### PR TITLE
COMMON: reduce mass add detection output by skipping certain ADGF flags and skipping incomplete file/md5/size matches

### DIFF
--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -717,7 +717,7 @@ QualifiedGameList EngineManager::findGameInLoadedPlugins(const Common::String &g
 	return results;
 }
 
-DetectionResults EngineManager::detectGames(const Common::FSList &fslist, uint32 skipADFlags) {
+DetectionResults EngineManager::detectGames(const Common::FSList &fslist, uint32 skipADFlags, bool skipIncomplete) {
 	DetectedGames candidates;
 	PluginList plugins;
 	PluginList::const_iterator iter;
@@ -735,7 +735,7 @@ DetectionResults EngineManager::detectGames(const Common::FSList &fslist, uint32
 		MetaEngineDetection &metaEngine = (*iter)->get<MetaEngineDetection>();
 		// set the debug flags
 		DebugMan.addAllDebugChannels(metaEngine.getDebugChannels());
-		DetectedGames engineCandidates = metaEngine.detectGames(fslist, skipADFlags);
+		DetectedGames engineCandidates = metaEngine.detectGames(fslist, skipADFlags, skipIncomplete);
 
 		for (uint i = 0; i < engineCandidates.size(); i++) {
 			engineCandidates[i].path = fslist.begin()->getParent().getPath();

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -717,7 +717,7 @@ QualifiedGameList EngineManager::findGameInLoadedPlugins(const Common::String &g
 	return results;
 }
 
-DetectionResults EngineManager::detectGames(const Common::FSList &fslist) {
+DetectionResults EngineManager::detectGames(const Common::FSList &fslist, uint32 skipADFlags) {
 	DetectedGames candidates;
 	PluginList plugins;
 	PluginList::const_iterator iter;
@@ -735,7 +735,7 @@ DetectionResults EngineManager::detectGames(const Common::FSList &fslist) {
 		MetaEngineDetection &metaEngine = (*iter)->get<MetaEngineDetection>();
 		// set the debug flags
 		DebugMan.addAllDebugChannels(metaEngine.getDebugChannels());
-		DetectedGames engineCandidates = metaEngine.detectGames(fslist);
+		DetectedGames engineCandidates = metaEngine.detectGames(fslist, skipADFlags);
 
 		for (uint i = 0; i < engineCandidates.size(); i++) {
 			engineCandidates[i].path = fslist.begin()->getParent().getPath();

--- a/engines/adl/detection.cpp
+++ b/engines/adl/detection.cpp
@@ -488,7 +488,7 @@ public:
 		return debugFlagList;
 	}
 
-	ADDetectedGames detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra, uint32 skipADFlags) override;
+	ADDetectedGames detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra, uint32 skipADFlags, bool skipIncomplete) override;
 
 	bool addFileProps(const FileMap &allFiles, Common::String fname, FilePropertiesMap &filePropsMap) const;
 };
@@ -512,9 +512,9 @@ bool AdlMetaEngineDetection::addFileProps(const FileMap &allFiles, Common::Strin
 }
 
 // Based on AdvancedMetaEngine::detectGame
-ADDetectedGames AdlMetaEngineDetection::detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra, uint32 skipADFlags) {
+ADDetectedGames AdlMetaEngineDetection::detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra, uint32 skipADFlags, bool skipIncomplete) {
 	// We run the file-based detector first, if it finds a match we do not search for disk images
-	ADDetectedGames matched = AdvancedMetaEngineDetection::detectGame(parent, allFiles, language, platform, extra, skipADFlags);
+	ADDetectedGames matched = AdvancedMetaEngineDetection::detectGame(parent, allFiles, language, platform, extra, skipADFlags, skipIncomplete);
 
 	if (!matched.empty())
 		return matched;

--- a/engines/adl/detection.cpp
+++ b/engines/adl/detection.cpp
@@ -488,7 +488,7 @@ public:
 		return debugFlagList;
 	}
 
-	ADDetectedGames detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra) override;
+	ADDetectedGames detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra, uint32 skipADFlags) override;
 
 	bool addFileProps(const FileMap &allFiles, Common::String fname, FilePropertiesMap &filePropsMap) const;
 };
@@ -512,9 +512,9 @@ bool AdlMetaEngineDetection::addFileProps(const FileMap &allFiles, Common::Strin
 }
 
 // Based on AdvancedMetaEngine::detectGame
-ADDetectedGames AdlMetaEngineDetection::detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra) {
+ADDetectedGames AdlMetaEngineDetection::detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra, uint32 skipADFlags) {
 	// We run the file-based detector first, if it finds a match we do not search for disk images
-	ADDetectedGames matched = AdvancedMetaEngineDetection::detectGame(parent, allFiles, language, platform, extra);
+	ADDetectedGames matched = AdvancedMetaEngineDetection::detectGame(parent, allFiles, language, platform, extra, skipADFlags);
 
 	if (!matched.empty())
 		return matched;

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -358,7 +358,7 @@ public:
 	 * (possibly empty) list of games supported by the engine that were
 	 * found among the given files.
 	 */
-	DetectedGames detectGames(const Common::FSList &fslist) override;
+	DetectedGames detectGames(const Common::FSList &fslist, uint32 skipADFlags) override;
 
 	/**
 	 * A generic createInstance.
@@ -419,15 +419,16 @@ protected:
 	 * Parameters @p language and @p platform are used to pass the values
 	 * specified by the user. This is used to restrict search scope.
 	 *
-	 * @param parent    Parent node of this file node.
-	 * @param allFiles  List of all present files, as computed by the @ref composeFileHashMap.
-	 * @param language  Restrict results to the specified language.
-	 * @param platform  Restrict results to the specified platform.
-	 * @param extra     Restrict results to the specified @c extra string (only if @ref kADFlagUseExtraAsHint is set).
+	 * @param parent		Parent node of this file node.
+	 * @param allFiles		List of all present files, as computed by the @ref composeFileHashMap.
+	 * @param language		Restrict results to the specified language.
+	 * @param platform		Restrict results to the specified platform.
+	 * @param extra			Restrict results to the specified @c extra string (only if @ref kADFlagUseExtraAsHint is set).
+	 * @param skipADFlags	Specify bitmask of ADGF flags to be ignored (for mass add).
 	 *
 	 * @return A list of @ref ADGameDescription pointers corresponding to the matched games.
 	 */
-	virtual ADDetectedGames detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra);
+	virtual ADDetectedGames detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra, uint32 skipADFlags = 0);
 
 	/**
 	 * @return True if variant of a game with unknown files can be played with the engine and false otherwise.

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -358,7 +358,7 @@ public:
 	 * (possibly empty) list of games supported by the engine that were
 	 * found among the given files.
 	 */
-	DetectedGames detectGames(const Common::FSList &fslist, uint32 skipADFlags) override;
+	DetectedGames detectGames(const Common::FSList &fslist, uint32 skipADFlags, bool skipIncomplete) override;
 
 	/**
 	 * A generic createInstance.
@@ -419,16 +419,17 @@ protected:
 	 * Parameters @p language and @p platform are used to pass the values
 	 * specified by the user. This is used to restrict search scope.
 	 *
-	 * @param parent		Parent node of this file node.
-	 * @param allFiles		List of all present files, as computed by the @ref composeFileHashMap.
-	 * @param language		Restrict results to the specified language.
-	 * @param platform		Restrict results to the specified platform.
-	 * @param extra			Restrict results to the specified @c extra string (only if @ref kADFlagUseExtraAsHint is set).
-	 * @param skipADFlags	Specify bitmask of ADGF flags to be ignored (for mass add).
+	 * @param parent		  Parent node of this file node.
+	 * @param allFiles		  List of all present files, as computed by the @ref composeFileHashMap.
+	 * @param language		  Restrict results to the specified language.
+	 * @param platform		  Restrict results to the specified platform.
+	 * @param extra			  Restrict results to the specified @c extra string (only if @ref kADFlagUseExtraAsHint is set).
+	 * @param skipADFlags	  Specify bitmask of ADGF flags to be ignored (for mass add).
+	 * @param skipIncomplete  Ignore results with incomplete file/md5/size matches (for mass add).
 	 *
 	 * @return A list of @ref ADGameDescription pointers corresponding to the matched games.
 	 */
-	virtual ADDetectedGames detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra, uint32 skipADFlags = 0);
+	virtual ADDetectedGames detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra, uint32 skipADFlags = 0, bool skipIncomplete = false);
 
 	/**
 	 * @return True if variant of a game with unknown files can be played with the engine and false otherwise.

--- a/engines/ags/detection.cpp
+++ b/engines/ags/detection.cpp
@@ -74,7 +74,7 @@ AGSMetaEngineDetection::AGSMetaEngineDetection() : AdvancedMetaEngineDetection(A
 	        sizeof(AGS::AGSGameDescription), AGS::GAME_NAMES) {
 }
 
-DetectedGames AGSMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 skipADFlags) {
+DetectedGames AGSMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 skipADFlags, bool skipIncomplete) {
 	FileMap allFiles;
 
 	if (fslist.empty())
@@ -84,7 +84,7 @@ DetectedGames AGSMetaEngineDetection::detectGames(const Common::FSList &fslist, 
 	composeFileHashMap(allFiles, fslist, (_maxScanDepth == 0 ? 1 : _maxScanDepth));
 
 	// Run the detector on this
-	ADDetectedGames matches = detectGame(fslist.begin()->getParent(), allFiles, Common::UNK_LANG, Common::kPlatformUnknown, "", skipADFlags);
+	ADDetectedGames matches = detectGame(fslist.begin()->getParent(), allFiles, Common::UNK_LANG, Common::kPlatformUnknown, "", skipADFlags, skipIncomplete);
 
 	cleanupPirated(matches);
 

--- a/engines/ags/detection.cpp
+++ b/engines/ags/detection.cpp
@@ -74,7 +74,7 @@ AGSMetaEngineDetection::AGSMetaEngineDetection() : AdvancedMetaEngineDetection(A
 	        sizeof(AGS::AGSGameDescription), AGS::GAME_NAMES) {
 }
 
-DetectedGames AGSMetaEngineDetection::detectGames(const Common::FSList &fslist) {
+DetectedGames AGSMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 skipADFlags) {
 	FileMap allFiles;
 
 	if (fslist.empty())
@@ -84,7 +84,7 @@ DetectedGames AGSMetaEngineDetection::detectGames(const Common::FSList &fslist) 
 	composeFileHashMap(allFiles, fslist, (_maxScanDepth == 0 ? 1 : _maxScanDepth));
 
 	// Run the detector on this
-	ADDetectedGames matches = detectGame(fslist.begin()->getParent(), allFiles, Common::UNK_LANG, Common::kPlatformUnknown, "");
+	ADDetectedGames matches = detectGame(fslist.begin()->getParent(), allFiles, Common::UNK_LANG, Common::kPlatformUnknown, "", skipADFlags);
 
 	cleanupPirated(matches);
 

--- a/engines/ags/detection.h
+++ b/engines/ags/detection.h
@@ -86,7 +86,7 @@ public:
 		return debugFlagList;
 	}
 
-	DetectedGames detectGames(const Common::FSList &fslist, uint32 skipADFlags) override;
+	DetectedGames detectGames(const Common::FSList &fslist, uint32 skipADFlags, bool skipIncomplete) override;
 
 	ADDetectedGame fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist, ADDetectedGameExtraInfo **extra = nullptr) const override;
 

--- a/engines/ags/detection.h
+++ b/engines/ags/detection.h
@@ -86,7 +86,7 @@ public:
 		return debugFlagList;
 	}
 
-	DetectedGames detectGames(const Common::FSList &fslist) override;
+	DetectedGames detectGames(const Common::FSList &fslist, uint32 skipADFlags) override;
 
 	ADDetectedGame fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist, ADDetectedGameExtraInfo **extra = nullptr) const override;
 

--- a/engines/glk/detection.cpp
+++ b/engines/glk/detection.cpp
@@ -180,7 +180,7 @@ PlainGameDescriptor GlkMetaEngineDetection::findGame(const char *gameId) const {
 
 #undef FIND_GAME
 
-DetectedGames GlkMetaEngineDetection::detectGames(const Common::FSList &fslist) {
+DetectedGames GlkMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) {
 #ifndef RELEASE_BUILD
 	// This is as good a place as any to detect multiple sub-engines using the same Ids
 	detectClashes();

--- a/engines/glk/detection.cpp
+++ b/engines/glk/detection.cpp
@@ -180,7 +180,7 @@ PlainGameDescriptor GlkMetaEngineDetection::findGame(const char *gameId) const {
 
 #undef FIND_GAME
 
-DetectedGames GlkMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) {
+DetectedGames GlkMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/, bool /*skipIncomplete*/) {
 #ifndef RELEASE_BUILD
 	// This is as good a place as any to detect multiple sub-engines using the same Ids
 	detectClashes();

--- a/engines/glk/detection.h
+++ b/engines/glk/detection.h
@@ -56,7 +56,7 @@ public:
 	 * (possibly empty) list of games supported by the engine which it was able
 	 * to detect amongst the given files.
 	 */
-	DetectedGames detectGames(const Common::FSList &fslist) override;
+	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) override;
 
 	/**
 	 * Query the engine for a PlainGameDescriptor for the specified gameid, if any.

--- a/engines/glk/detection.h
+++ b/engines/glk/detection.h
@@ -56,7 +56,7 @@ public:
 	 * (possibly empty) list of games supported by the engine which it was able
 	 * to detect amongst the given files.
 	 */
-	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) override;
+	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipUnsupported*/, bool /*skipIncomplete*/) override;
 
 	/**
 	 * Query the engine for a PlainGameDescriptor for the specified gameid, if any.

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -157,7 +157,7 @@ public:
 	 * (possibly empty) list of games supported by the engine that were
 	 * found among the given files.
 	 */
-	virtual DetectedGames detectGames(const Common::FSList &fslist) = 0;
+	virtual DetectedGames detectGames(const Common::FSList &fslist, uint32 skipADFlags = 0) = 0;
 
 	/**
 	 * Return a list of extra GUI options for the specified target.
@@ -574,10 +574,10 @@ class EngineManager : public Common::Singleton<EngineManager> {
 public:
 	/**
 	 * Given a list of FSNodes in a given directory, detect a set of games contained within.
-	 *
+	 * @ param skipADFlags		Ignore results which are flagged with the ADGF flags specified here (for mass add)
 	 * Returns an empty list if none are found.
 	 */
-	DetectionResults detectGames(const Common::FSList &fslist);
+	DetectionResults detectGames(const Common::FSList &fslist, uint32 skipADFlags = 0);
 
 	/** Find a plugin by its engine ID. */
 	const Plugin *findPlugin(const Common::String &engineId) const;

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -157,7 +157,7 @@ public:
 	 * (possibly empty) list of games supported by the engine that were
 	 * found among the given files.
 	 */
-	virtual DetectedGames detectGames(const Common::FSList &fslist, uint32 skipADFlags = 0) = 0;
+	virtual DetectedGames detectGames(const Common::FSList &fslist, uint32 skipADFlags = 0, bool skipIncomplete = false) = 0;
 
 	/**
 	 * Return a list of extra GUI options for the specified target.
@@ -575,9 +575,10 @@ public:
 	/**
 	 * Given a list of FSNodes in a given directory, detect a set of games contained within.
 	 * @ param skipADFlags		Ignore results which are flagged with the ADGF flags specified here (for mass add)
+	 * @ param skipIncomplete	Ignore incomplete file/md5/size matches (for mass add)
 	 * Returns an empty list if none are found.
 	 */
-	DetectionResults detectGames(const Common::FSList &fslist, uint32 skipADFlags = 0);
+	DetectionResults detectGames(const Common::FSList &fslist, uint32 skipADFlags = 0, bool skipIncomplete = false);
 
 	/** Find a plugin by its engine ID. */
 	const Plugin *findPlugin(const Common::String &engineId) const;

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -82,7 +82,7 @@ public:
 
 	PlainGameList getSupportedGames() const override;
 	PlainGameDescriptor findGame(const char *gameid) const override;
-	DetectedGames detectGames(const Common::FSList &fslist) override;
+	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) override;
 
 	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
 };
@@ -121,7 +121,7 @@ static Common::String generatePreferredTarget(const DetectorResult &x) {
 	return res;
 }
 
-DetectedGames ScummMetaEngineDetection::detectGames(const Common::FSList &fslist) {
+DetectedGames ScummMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) {
 	DetectedGames detectedGames;
 	Common::List<DetectorResult> results;
 	::detectGames(fslist, results, nullptr);

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -82,7 +82,7 @@ public:
 
 	PlainGameList getSupportedGames() const override;
 	PlainGameDescriptor findGame(const char *gameid) const override;
-	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) override;
+	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/, bool /*skipIncomplete*/) override;
 
 	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
 };
@@ -121,7 +121,7 @@ static Common::String generatePreferredTarget(const DetectorResult &x) {
 	return res;
 }
 
-DetectedGames ScummMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) {
+DetectedGames ScummMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/, bool /*skipIncomplete*/) {
 	DetectedGames detectedGames;
 	Common::List<DetectorResult> results;
 	::detectGames(fslist, results, nullptr);

--- a/engines/sky/detection.cpp
+++ b/engines/sky/detection.cpp
@@ -76,7 +76,7 @@ public:
 	PlainGameList getSupportedGames() const override;
 	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
 	PlainGameDescriptor findGame(const char *gameid) const override;
-	DetectedGames detectGames(const Common::FSList &fslist) override;
+	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) override;
 };
 
 const char *SkyMetaEngineDetection::getName() const {
@@ -118,7 +118,7 @@ PlainGameDescriptor SkyMetaEngineDetection::findGame(const char *gameid) const {
 	return PlainGameDescriptor::empty();
 }
 
-DetectedGames SkyMetaEngineDetection::detectGames(const Common::FSList &fslist) {
+DetectedGames SkyMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) {
 	DetectedGames detectedGames;
 	bool hasSkyDsk = false;
 	bool hasSkyDnr = false;

--- a/engines/sky/detection.cpp
+++ b/engines/sky/detection.cpp
@@ -76,7 +76,7 @@ public:
 	PlainGameList getSupportedGames() const override;
 	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
 	PlainGameDescriptor findGame(const char *gameid) const override;
-	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) override;
+	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/, bool /*skipIncomplete*/) override;
 };
 
 const char *SkyMetaEngineDetection::getName() const {
@@ -118,7 +118,7 @@ PlainGameDescriptor SkyMetaEngineDetection::findGame(const char *gameid) const {
 	return PlainGameDescriptor::empty();
 }
 
-DetectedGames SkyMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) {
+DetectedGames SkyMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/, bool /*skipIncomplete*/) {
 	DetectedGames detectedGames;
 	bool hasSkyDsk = false;
 	bool hasSkyDnr = false;

--- a/engines/sword1/detection.cpp
+++ b/engines/sword1/detection.cpp
@@ -85,7 +85,7 @@ public:
 
 	PlainGameList getSupportedGames() const override;
 	PlainGameDescriptor findGame(const char *gameId) const override;
-	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) override;
+	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/, bool /*skipIncomplete*/) override;
 };
 
 PlainGameList SwordMetaEngineDetection::getSupportedGames() const {
@@ -132,7 +132,7 @@ void Sword1CheckDirectory(const Common::FSList &fslist, bool *filesFound) {
 	}
 }
 
-DetectedGames SwordMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) {
+DetectedGames SwordMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/, bool /*skipIncomplete*/) {
 	int i, j;
 	DetectedGames detectedGames;
 	bool filesFound[NUM_FILES_TO_CHECK];

--- a/engines/sword1/detection.cpp
+++ b/engines/sword1/detection.cpp
@@ -85,7 +85,7 @@ public:
 
 	PlainGameList getSupportedGames() const override;
 	PlainGameDescriptor findGame(const char *gameId) const override;
-	DetectedGames detectGames(const Common::FSList &fslist) override;
+	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) override;
 };
 
 PlainGameList SwordMetaEngineDetection::getSupportedGames() const {
@@ -132,7 +132,7 @@ void Sword1CheckDirectory(const Common::FSList &fslist, bool *filesFound) {
 	}
 }
 
-DetectedGames SwordMetaEngineDetection::detectGames(const Common::FSList &fslist) {
+DetectedGames SwordMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) {
 	int i, j;
 	DetectedGames detectedGames;
 	bool filesFound[NUM_FILES_TO_CHECK];

--- a/engines/sword2/detection.cpp
+++ b/engines/sword2/detection.cpp
@@ -53,7 +53,7 @@ public:
 	PlainGameList getSupportedGames() const override;
 	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
 	PlainGameDescriptor findGame(const char *gameid) const override;
-	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) override;
+	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/, bool /*skipIncomplete*/) override;
 };
 
 PlainGameList Sword2MetaEngineDetection::getSupportedGames() const {
@@ -82,7 +82,7 @@ PlainGameDescriptor Sword2MetaEngineDetection::findGame(const char *gameid) cons
 	return PlainGameDescriptor::of(g->gameid, g->description);
 }
 
-DetectedGames Sword2MetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) {
+DetectedGames Sword2MetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/, bool /*skipIncomplete*/) {
 	// The required game data files can be located in the game directory, or in
 	// a subdirectory called "clusters". In the latter case, we don't want to
 	// detect the game in that subdirectory, as this will detect the game twice

--- a/engines/sword2/detection.cpp
+++ b/engines/sword2/detection.cpp
@@ -53,7 +53,7 @@ public:
 	PlainGameList getSupportedGames() const override;
 	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
 	PlainGameDescriptor findGame(const char *gameid) const override;
-	DetectedGames detectGames(const Common::FSList &fslist) override;
+	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) override;
 };
 
 PlainGameList Sword2MetaEngineDetection::getSupportedGames() const {
@@ -82,7 +82,7 @@ PlainGameDescriptor Sword2MetaEngineDetection::findGame(const char *gameid) cons
 	return PlainGameDescriptor::of(g->gameid, g->description);
 }
 
-DetectedGames Sword2MetaEngineDetection::detectGames(const Common::FSList &fslist) {
+DetectedGames Sword2MetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/) {
 	// The required game data files can be located in the game directory, or in
 	// a subdirectory called "clusters". In the latter case, we don't want to
 	// detect the game in that subdirectory, as this will detect the game twice

--- a/gui/massadd.cpp
+++ b/gui/massadd.cpp
@@ -176,7 +176,7 @@ void MassAddDialog::handleTickle() {
 		}
 
 		// Run the detector on the dir
-		DetectionResults detectionResults = EngineMan.detectGames(files, (ADGF_WARNING | ADGF_UNSUPPORTED));
+		DetectionResults detectionResults = EngineMan.detectGames(files, (ADGF_WARNING | ADGF_UNSUPPORTED), true);
 
 		if (detectionResults.foundUnknownGames()) {
 			Common::U32String report = detectionResults.generateUnknownGameReport(false, 80);

--- a/gui/massadd.cpp
+++ b/gui/massadd.cpp
@@ -27,6 +27,8 @@
 #include "common/taskbar.h"
 #include "common/translation.h"
 
+#include "engines/advancedDetector.h"
+
 #include "gui/massadd.h"
 
 #ifndef DISABLE_MASS_ADD
@@ -174,7 +176,7 @@ void MassAddDialog::handleTickle() {
 		}
 
 		// Run the detector on the dir
-		DetectionResults detectionResults = EngineMan.detectGames(files);
+		DetectionResults detectionResults = EngineMan.detectGames(files, (ADGF_WARNING | ADGF_UNSUPPORTED));
 
 		if (detectionResults.foundUnknownGames()) {
 			Common::U32String report = detectionResults.generateUnknownGameReport(false, 80);


### PR DESCRIPTION
Skip over targets with ADGF_WARNING and ADGF_UNSUPPORTED flags when using "mass add".

The alternative would/could be to just invent a new flag like ADGF_NOMASSADD

For me, this is mostly about fixing bug no. 13282.
https://bugs.scummvm.org/ticket/13282

We sometimes have bogus entries which only have the purpose of presenting the error message (reasons for being unsupported) contained in the extra field of the detection entry.

This PR certainly does not attend to all issues that the "mass add" option currently has, but it does clean it up a bit...