### PR TITLE
SCUMM: improve savegame loading for SCUMM1-3

### DIFF
--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -579,19 +579,6 @@ bool ScummEngine::loadState(int slot, bool compat, Common::String &filename) {
 
 	_sound->pauseSounds(false);
 
-	// WORKAROUND: Original save/load script ran this script
-	// after game load, and o2_loadRoomWithEgo() does as well
-	// this script starts character-dependent music
-	//
-	// Fixes bug #3362: MANIACNES: Music Doesn't Start On Load Game
-	if (_game.platform == Common::kPlatformNES) {
-		runScript(5, 0, 0, nullptr);
-
-		if (VAR(224)) {
-			_sound->addSoundToQueue(VAR(224));
-		}
-	}
-
 	_sound->restoreAfterLoad();
 
 	return true;

--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -396,6 +396,10 @@ bool ScummEngine::loadState(int slot, bool compat, Common::String &filename) {
 	hdr.name[sizeof(hdr.name)-1] = 0;
 	_saveLoadDescription = hdr.name;
 
+	// Set to 0 during load to minimize stuttering
+	if (_musicEngine)
+		_musicEngine->setMusicVolume(0);
+
 	// Unless specifically requested with _saveSound, we do not save the iMUSE
 	// state for temporary state saves - such as certain cutscenes in DOTT,
 	// FOA, Sam and Max, etc.
@@ -449,12 +453,6 @@ bool ScummEngine::loadState(int slot, bool compat, Common::String &filename) {
 	ser.setVersion(hdr.ver);
 	saveLoadWithSerializer(ser);
 	delete in;
-
-	// Update volume settings
-	syncSoundSettings();
-
-	if (_townsPlayer && (hdr.ver >= VER(81)))
-		_townsPlayer->restoreAfterLoad();
 
 	// Init NES costume data
 	if (_game.platform == Common::kPlatformNES) {
@@ -1490,7 +1488,8 @@ void ScummEngine::saveLoadWithSerializer(Common::Serializer &s) {
 		// If we are loading, and the music being loaded was supposed to loop
 		// forever, then resume playing it. This helps a lot when the audio CD
 		// is used to provide ambient music (see bug #1150).
-		if (s.isLoading() && info.playing && info.numLoops < 0)
+		// FM-Towns versions handle this in Player_Towns_v1::restoreAfterLoad().
+		if (s.isLoading() && info.playing && info.numLoops < 0 && _game.platform != Common::kPlatformFMTowns)
 			_sound->playCDTrackInternal(info.track, info.numLoops, info.start, info.duration);
 	}
 

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2326,6 +2326,30 @@ load_game:
 			for (int i = 0; i < _numVerbs; i++)
 				drawVerb(i, 0);
 		} else {
+			if (_game.platform != Common::kPlatformNES && _game.platform != Common::kPlatformC64 && _game.platform != Common::kPlatformMacintosh) {
+				// MM and ZAK (v1/2)
+				int saveLoadRoom = 50;
+				int saveLoadVar = 21;
+				int saveLoadEnable = 1;
+
+				if (_game.id == GID_INDY3) {
+					saveLoadRoom = 14;
+					saveLoadVar = 58;
+				} else if (_game.platform == Common::kPlatformFMTowns) {
+					// ZAK FM-Towns
+					saveLoadVar = 115;
+				}
+
+				// Only execute this if the original would even allow saving in that situation
+				if (VAR(saveLoadVar) == saveLoadEnable && _userPut > 0 && !(VAR_VERB_SCRIPT != 0xFF && isScriptRunning(VAR(VAR_VERB_SCRIPT)))) {
+					int args[NUM_SCRIPT_LOCAL];
+					memset(args, 0, sizeof(args));
+					beginCutscene(args);
+					startScene(saveLoadRoom, nullptr, 0);
+					endCutscene();
+				}
+			}
+
 			redrawVerbs();
 		}
 

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2458,8 +2458,7 @@ void ScummEngine::scummLoop_handleSaveLoad() {
 
 			if (!_saveTemporaryState)
 				_lastSaveTime = _system->getMillis();
-		}
-		else {
+		} else {
 			success = loadState(_saveLoadSlot, _saveTemporaryState, filename);
 			if (!success)
 				errMsg = _("Failed to load saved game from file:\n\n%s");
@@ -2473,9 +2472,8 @@ void ScummEngine::scummLoop_handleSaveLoad() {
 
 			GUI::MessageDialog dialog(buf);
 			runDialog(dialog);
-		}
-		else if (_saveLoadFlag == 1 && _saveLoadSlot != 0 && !_saveTemporaryState) {
-		 // Display "Save successful" message, except for auto saves
+		} else if (_saveLoadFlag == 1 && _saveLoadSlot != 0 && !_saveTemporaryState) {
+			// Display "Save successful" message, except for auto saves
 			Common::U32String buf = Common::U32String::format(_("Successfully saved game in file:\n\n%s"), filename.c_str());
 
 			GUI::TimedMessageDialog dialog(buf, 1500);

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2275,102 +2275,17 @@ load_game:
 	if (_completeScreenRedraw) {
 		clearCharsetMask();
 		_charset->_hasMask = false;
-		bool restoreFMTownsSounds = (_townsPlayer != nullptr);
 
-		if (_game.id == GID_LOOM) {
-			// HACK as in game save stuff isn't supported exactly as in the original interpreter when using the
-			// ScummVM save/load dialog. The original save/load screen uses a special script (which we cannot
-			// call without displaying that screen) which will also makes some necessary follow-up operations. We
-			// simply try to achieve that manually. It fixes bugs #6011 and #13369.
-			// We just have to kind of pretend that we've gone through the save/load "room" (with all the right
-			// variables in place), so that all the operations get triggered properly.
-			// The glitch with the flask (#6011) seems to be present only in the DOS EGA, Amiga, Atari ST and
-			// FM-Towns versions. Mac, DOS Talkie and PC-Engine don't have that bug. We can rely on our old hack
-			// there, since it wouldn't work otherwise, anyway.
-			int args[NUM_SCRIPT_LOCAL];
-			memset(args, 0, sizeof(args));
+		if (_game.version > 3) {
+			if (_townsPlayer)
+				_townsPlayer->restoreAfterLoad();
 
-			uint saveLoadVar = 100;
-			if (_game.platform == Common::kPlatformMacintosh)
-				saveLoadVar = 105;
-			else if (_game.platform == Common::kPlatformPCEngine || _game.version == 4)
-				saveLoadVar = 150;
-
-			// Run this hack only under conditions where the original save script could actually be executed.
-			// Otherwise this would cause all sorts of glitches. Also exclude Mac, PC-Engine and DOS Talkie...
-			if (saveLoadVar == 100 && _userPut > 0 && !isScriptRunning(VAR(VAR_VERB_SCRIPT))) {
-				uint16 prevFlag = VAR(214) & 0x6000;
-				beginCutscene(args);
-				uint16 blockVerbsFlag = VAR(214) & (0x6000 ^ prevFlag);
-				if (Actor *a = derefActor(VAR(VAR_EGO))) {
-					// This is used to restore the correct camera position.
-					VAR(171) = a->_walkbox;
-					VAR(172) = a->getRealPos().x;
-					VAR(173) = a->getRealPos().y;
-				}
-				startScene(70, nullptr, 0);
-				VAR(saveLoadVar) = 0;
-				VAR(214) &= ~blockVerbsFlag;
-				endCutscene();
-
-				if (_game.platform == Common::kPlatformFMTowns && VAR(163)) {
-					// Sound restore script. Unlike other versions which handle this
-					// inside the usual entry scripts, FM-Towns calls this from the save script.
-					memset(args, 0, sizeof(args));
-					args[0] = VAR(163);
-					runScript(38, false, false, args);
-				}
-
-				restoreFMTownsSounds = false;
-
-			} else if (VAR(saveLoadVar) == 2) {
-				// This is our old hack. If verbs should be shown restore them.
-				byte restoreScript = (_game.platform == Common::kPlatformFMTowns) ? 17 : 18;
-				args[0] = 2;
-				runScript(restoreScript, 0, 0, args);
-				// Reset two variables, similar to what the save script would do, to avoid minor glitches
-				// of the verb image on the right of the distaff (image remaining blank when moving the
-				// mouse cursor over an object, bug #13369).
-				VAR(saveLoadVar + 2) = VAR(saveLoadVar + 3) = 0;
-			}
-
-		} else if (_game.version > 3) {
 			for (int i = 0; i < _numVerbs; i++)
 				drawVerb(i, 0);
-
-		} else {
-			if (_game.platform != Common::kPlatformNES && _game.platform != Common::kPlatformC64 && _game.platform != Common::kPlatformMacintosh) {
-				// MM and ZAK (v1/2)
-				int saveLoadRoom = 50;
-				int saveLoadVar = 21;
-				int saveLoadEnable = 1;
-
-				if (_game.id == GID_INDY3) {
-					saveLoadRoom = 14;
-					saveLoadVar = 58;
-				} else if (_game.platform == Common::kPlatformFMTowns) {
-					// ZAK FM-Towns
-					saveLoadVar = 115;
-				}
-
-				// Only execute this if the original would even allow saving in that situation
-				if (VAR(saveLoadVar) == saveLoadEnable && _userPut > 0 && !(VAR_VERB_SCRIPT != 0xFF && isScriptRunning(VAR(VAR_VERB_SCRIPT)))) {
-					int args[NUM_SCRIPT_LOCAL];
-					memset(args, 0, sizeof(args));
-					beginCutscene(args);
-					startScene(saveLoadRoom, nullptr, 0);
-					endCutscene();
-					restoreFMTownsSounds = false;
-				}
-			}
-			redrawVerbs();
 		}
 
 		// Update volume settings
 		syncSoundSettings();
-
-		if (restoreFMTownsSounds)
-			_townsPlayer->restoreAfterLoad();
 
 		handleMouseOver(false);
 
@@ -2561,19 +2476,123 @@ void ScummEngine::scummLoop_handleSaveLoad() {
 	}
 }
 
-void ScummEngine_v4::scummLoop_handleSaveLoad() {
+void ScummEngine_v3::scummLoop_handleSaveLoad() {
 	// copy saveLoadFlag as handleSaveLoad() resets it
 	byte saveLoad = _saveLoadFlag;
 
-	ScummEngine_v5::scummLoop_handleSaveLoad();
+	ScummEngine::scummLoop_handleSaveLoad();
 
-	// update IQ points after loading
-	if (saveLoad == 2) {
-		if (_game.id == GID_INDY3)
-			updateIQPoints();
+	if (_completeScreenRedraw) {
+		clearCharsetMask();
+		_charset->_hasMask = false;
+		bool restoreFMTownsSounds = (_townsPlayer != nullptr);
+
+		if (_game.id == GID_LOOM) {
+			// HACK as in game save stuff isn't supported exactly as in the original interpreter when using the
+			// ScummVM save/load dialog. The original save/load screen uses a special script (which we cannot
+			// call without displaying that screen) which will also makes some necessary follow-up operations. We
+			// simply try to achieve that manually. It fixes bugs #6011 and #13369.
+			// We just have to kind of pretend that we've gone through the save/load "room" (with all the right
+			// variables in place), so that all the operations get triggered properly.
+			// The Mac, DOS Talkie and PC-Engine don't have the bugs. We can rely on our old hack there, since
+			// it wouldn't work otherwise, anyway.
+			int args[NUM_SCRIPT_LOCAL];
+			memset(args, 0, sizeof(args));
+
+			uint saveLoadVar = 100;
+			if (_game.platform == Common::kPlatformMacintosh)
+				saveLoadVar = 105;
+			else if (_game.platform == Common::kPlatformPCEngine || _game.version == 4)
+				saveLoadVar = 150;
+
+			// Run this hack only under conditions where the original save script could actually be executed.
+			// Otherwise this would cause all sorts of glitches. Also exclude Mac, PC-Engine and DOS Talkie...
+			if (saveLoadVar == 100 && _userPut > 0 && !isScriptRunning(VAR(VAR_VERB_SCRIPT))) {
+				uint16 prevFlag = VAR(214) & 0x6000;
+				beginCutscene(args);
+				uint16 blockVerbsFlag = VAR(214) & (0x6000 ^ prevFlag);
+				if (Actor *a = derefActor(VAR(VAR_EGO))) {
+					// This is used to restore the correct camera position.
+					VAR(171) = a->_walkbox;
+					VAR(172) = a->getRealPos().x;
+					VAR(173) = a->getRealPos().y;
+				}
+				startScene(70, nullptr, 0);
+				VAR(saveLoadVar) = 0;
+				VAR(214) &= ~blockVerbsFlag;
+				endCutscene();
+
+				if (_game.platform == Common::kPlatformFMTowns && VAR(163)) {
+					// Sound restore script. Unlike other versions which handle this
+					// inside the usual entry scripts, FM-Towns calls this from the save script.
+					memset(args, 0, sizeof(args));
+					args[0] = VAR(163);
+					runScript(38, false, false, args);
+				}
+
+				restoreFMTownsSounds = false;
+
+			} else if (VAR(saveLoadVar) == 2) {
+				// This is our old hack. If verbs should be shown restore them.
+				byte restoreScript = (_game.platform == Common::kPlatformFMTowns) ? 17 : 18;
+				args[0] = 2;
+				runScript(restoreScript, 0, 0, args);
+				// Reset two variables, similiar to what the save script would do, to avoid minor glitches
+				// of the verb image on the right of the distaff (image remainung blank when moving the
+				// mouse cursor over an object, bug #13369).
+				VAR(saveLoadVar + 2) = VAR(saveLoadVar + 3) = 0;
+			}
+
+		} else {
+			if (_game.platform == Common::kPlatformNES) {
+				// WORKAROUND: Original save/load script ran this script
+				// after game load, and o2_loadRoomWithEgo() does as well
+				// this script starts character-dependent music
+				// Fixes bug #3362: MANIACNES: Music Doesn't Start On Load Game
+				if (_game.platform == Common::kPlatformNES) {
+					runScript(5, 0, 0, nullptr);
+					if (VAR(224))
+						_sound->addSoundToQueue(VAR(224));
+				}
+
+			} else if (_game.platform != Common::kPlatformC64 && _game.platform != Common::kPlatformMacintosh) {
+				// MM and ZAK (v1/2)
+				int saveLoadRoom = 50;
+				int saveLoadVar = 21;
+				int saveLoadEnable = 1;
+
+				if (_game.id == GID_INDY3) {
+					saveLoadRoom = 14;
+					saveLoadVar = 58;
+				} else if (_game.platform == Common::kPlatformFMTowns) {
+					// ZAK FM-Towns
+					saveLoadVar = 115;
+				}
+
+				// Only execute this if the original would even allow saving in that situation
+				if (VAR(saveLoadVar) == saveLoadEnable && _userPut > 0 && !(VAR_VERB_SCRIPT != 0xFF && isScriptRunning(VAR(VAR_VERB_SCRIPT)))) {
+					int args[NUM_SCRIPT_LOCAL];
+					memset(args, 0, sizeof(args));
+					beginCutscene(args);
+					startScene(saveLoadRoom, nullptr, 0);
+					endCutscene();
+					restoreFMTownsSounds = false;
+				}
+			}
+
+			// update IQ points after loading
+			if (saveLoad == 2) {
+				if (_game.id == GID_INDY3)
+					updateIQPoints();
+			}
+
+			redrawVerbs();
+		}
+
+		if (restoreFMTownsSounds)
+			_townsPlayer->restoreAfterLoad();
 	}
 }
-
 void ScummEngine_v5::scummLoop_handleSaveLoad() {
 	// copy saveLoadFlag as handleSaveLoad() resets it
 	byte saveLoad = _saveLoadFlag;

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2275,6 +2275,7 @@ load_game:
 	if (_completeScreenRedraw) {
 		clearCharsetMask();
 		_charset->_hasMask = false;
+		bool restoreFMTownsSounds = (_townsPlayer != nullptr);
 
 		if (_game.id == GID_LOOM) {
 			// HACK as in game save stuff isn't supported exactly as in the original interpreter when using the
@@ -2311,6 +2312,17 @@ load_game:
 				VAR(saveLoadVar) = 0;
 				VAR(214) &= ~blockVerbsFlag;
 				endCutscene();
+
+				if (_game.platform == Common::kPlatformFMTowns && VAR(163)) {
+					// Sound restore script. Unlike other versions which handle this
+					// inside the usual entry scripts, FM-Towns calls this from the save script.
+					memset(args, 0, sizeof(args));
+					args[0] = VAR(163);
+					runScript(38, false, false, args);
+				}
+
+				restoreFMTownsSounds = false;
+
 			} else if (VAR(saveLoadVar) == 2) {
 				// This is our old hack. If verbs should be shown restore them.
 				byte restoreScript = (_game.platform == Common::kPlatformFMTowns) ? 17 : 18;
@@ -2325,6 +2337,7 @@ load_game:
 		} else if (_game.version > 3) {
 			for (int i = 0; i < _numVerbs; i++)
 				drawVerb(i, 0);
+
 		} else {
 			if (_game.platform != Common::kPlatformNES && _game.platform != Common::kPlatformC64 && _game.platform != Common::kPlatformMacintosh) {
 				// MM and ZAK (v1/2)
@@ -2347,11 +2360,17 @@ load_game:
 					beginCutscene(args);
 					startScene(saveLoadRoom, nullptr, 0);
 					endCutscene();
+					restoreFMTownsSounds = false;
 				}
 			}
-
 			redrawVerbs();
 		}
+
+		// Update volume settings
+		syncSoundSettings();
+
+		if (restoreFMTownsSounds)
+			_townsPlayer->restoreAfterLoad();
 
 		handleMouseOver(false);
 

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -141,7 +141,16 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 		_gameMD5[i] = (byte)tmpVal;
 	}
 
+	_fileHandle = nullptr;
+
 	// Init all vars
+	_imuse = nullptr;
+	_imuseDigital = nullptr;
+	_musicEngine = nullptr;
+	_townsPlayer = nullptr;
+	_verbs = nullptr;
+	_objs = nullptr;
+	_sound = nullptr;
 	memset(&vm, 0, sizeof(vm));
 	memset(_localScriptOffsets, 0, sizeof(_localScriptOffsets));
 	vm.numNestedScripts = 0;
@@ -2088,6 +2097,7 @@ Common::Error ScummEngine::go() {
 		_saveLoadFlag = 0;
 		runBootscript();
 	} else {
+		_loadFromLauncher = true; // The only purpose of this is triggering the IQ points update for INDY3/4
 		_saveLoadFlag = 0;
 	}
 
@@ -2448,7 +2458,8 @@ void ScummEngine::scummLoop_handleSaveLoad() {
 
 			if (!_saveTemporaryState)
 				_lastSaveTime = _system->getMillis();
-		} else {
+		}
+		else {
 			success = loadState(_saveLoadSlot, _saveTemporaryState, filename);
 			if (!success)
 				errMsg = _("Failed to load saved game from file:\n\n%s");
@@ -2462,8 +2473,9 @@ void ScummEngine::scummLoop_handleSaveLoad() {
 
 			GUI::MessageDialog dialog(buf);
 			runDialog(dialog);
-		} else if (_saveLoadFlag == 1 && _saveLoadSlot != 0 && !_saveTemporaryState) {
-			// Display "Save successful" message, except for auto saves
+		}
+		else if (_saveLoadFlag == 1 && _saveLoadSlot != 0 && !_saveTemporaryState) {
+		 // Display "Save successful" message, except for auto saves
 			Common::U32String buf = Common::U32String::format(_("Successfully saved game in file:\n\n%s"), filename.c_str());
 
 			GUI::TimedMessageDialog dialog(buf, 1500);
@@ -2477,8 +2489,8 @@ void ScummEngine::scummLoop_handleSaveLoad() {
 }
 
 void ScummEngine_v3::scummLoop_handleSaveLoad() {
-	// copy saveLoadFlag as handleSaveLoad() resets it
-	byte saveLoad = _saveLoadFlag;
+	bool processIQPoints = (_game.id == GID_INDY3) && (_saveLoadFlag == 2 || _loadFromLauncher);
+	_loadFromLauncher = false;
 
 	ScummEngine::scummLoop_handleSaveLoad();
 
@@ -2581,10 +2593,8 @@ void ScummEngine_v3::scummLoop_handleSaveLoad() {
 			}
 
 			// update IQ points after loading
-			if (saveLoad == 2) {
-				if (_game.id == GID_INDY3)
-					updateIQPoints();
-			}
+			if (processIQPoints)
+				updateIQPoints();
 
 			redrawVerbs();
 		}
@@ -2594,16 +2604,14 @@ void ScummEngine_v3::scummLoop_handleSaveLoad() {
 	}
 }
 void ScummEngine_v5::scummLoop_handleSaveLoad() {
-	// copy saveLoadFlag as handleSaveLoad() resets it
-	byte saveLoad = _saveLoadFlag;
+	bool processIQPoints = (_game.id == GID_INDY4) && (_saveLoadFlag == 2 || _loadFromLauncher);
+	_loadFromLauncher = false;
 
 	ScummEngine::scummLoop_handleSaveLoad();
 
 	// update IQ points after loading
-	if (saveLoad == 2) {
-		if (_game.id == GID_INDY4)
-			runScript(145, 0, 0, nullptr);
-	}
+	if (processIQPoints)
+		runScript(145, 0, 0, nullptr);
 }
 
 #ifdef ENABLE_SCUMM_7_8

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -521,6 +521,7 @@ protected:
 	byte _saveLoadFlag = 0, _saveLoadSlot = 0;
 	uint32 _lastSaveTime = 0;
 	bool _saveTemporaryState = false;
+	bool _loadFromLauncher = false;
 	Common::String _saveLoadFileName;
 	Common::String _saveLoadDescription;
 

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -635,8 +635,8 @@ protected:
 	virtual void resetSentence() {}
 
 protected:
-	void beginCutscene(int *args);
-	void endCutscene();
+	virtual void beginCutscene(int *args);
+	virtual void endCutscene();
 	void abortCutscene();
 	void beginOverride();
 	void endOverride();

--- a/engines/scumm/scumm_v2.h
+++ b/engines/scumm/scumm_v2.h
@@ -91,6 +91,9 @@ protected:
 	void resetSentence() override;
 	void setUserState(byte state);
 
+	void beginCutscene(int *args) override { o2_cutscene(); }
+	void endCutscene() override { o2_endCutscene(); }
+
 	void handleMouseOver(bool updateInventory) override;
 	void checkExecVerbs() override;
 	void initV2MouseOver();

--- a/engines/scumm/scumm_v3.h
+++ b/engines/scumm/scumm_v3.h
@@ -39,6 +39,8 @@ public:
 protected:
 	void setupOpcodes() override;
 
+	void scummLoop_handleSaveLoad() override;
+
 	void readRoomsOffsets() override;
 	void loadCharset(int no) override;
 

--- a/engines/scumm/scumm_v4.h
+++ b/engines/scumm/scumm_v4.h
@@ -53,8 +53,6 @@ public:
 protected:
 	void setupOpcodes() override;
 
-	void scummLoop_handleSaveLoad() override;
-
 	int readResTypeList(ResType type) override;
 	void readIndexFile() override;
 	void loadCharset(int no) override;


### PR DESCRIPTION
This is a followup to
https://github.com/scummvm/scummvm/pull/3792
which improved the post-loading process for LOOM.

This will now be done for all v1-3 games by running the scripts that the games would expect. Which means that e. g. the music is restarted properly in ZAK and MM after loading (can be tested in ZAK v1/2, at the airport, you wouldn't have music after loading, because the script that starts it isn't run).

It won't do anything for Mac versions. These need separate analysis/testing, since the save/load process has been modified a bit  for these versions (no save/load "room", instead using Mac style menus and modified scripts).

This is limited to situations where the original games allow loading and saving, because games might glitch otherwise. E. g. in INDY3 I have a savegame AFTER choosing the grail which is very practical for me, because I don't have to remember my choice. But the original does not allow to save there (or at all, in that temple). If you load this AND run the original loading procedure it will be messed up (I don't have the grail in my inventory and the games pretends that I have just entered the room).

As a bonus, the PR fixes INDY3/4 iq points update when loading from the launcher...

Like the other PR, this should be left open for testing for a reasonable amount of time...