### PR TITLE
SCUMM: Centralize RTL support condition

### DIFF
--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -312,6 +312,7 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 		_herculesBuf = (byte *)malloc(kHercWidth * kHercHeight);
 	}
 
+	_isRTL = (_game.version >= 4 && _game.version < 7 && _game.heversion == 0 && _language == Common::HE_ISR);
 #ifndef DISABLE_HELP
 	// Create custom GMM dialog providing a help subdialog
 	assert(!_mainMenuDialog);

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -1221,6 +1221,7 @@ private:
 	};
 
 	bool _existLanguageFile = false;
+	bool _isRTL = false;
 	byte *_languageBuffer = nullptr;
 	int _numTranslatedLines = 0;
 	TranslatedLine *_translatedLines = nullptr;

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -538,7 +538,7 @@ bool ScummEngine::newLine() {
 			// (FT/German, if you look at the sign on the container at game start). After counterchecking
 			// the original code it seems that setting _nextLeft to 0 is the right thing to do here.
 			_nextLeft = /*_game.version >= 6 ? _string[0].xpos :*/ 0;
-	} else if (_game.version >= 4 && _game.version < 7 && _game.heversion == 0 && _language == Common::HE_ISR) {
+	} else if (_isRTL) {
 		if (_game.id == GID_MONKEY && _charset->getCurID() == 4) {
 			_nextLeft = _screenWidth - _charset->getStringWidth(0, _charsetBuffer + _charsetBufPos) - _nextLeft;
 		}
@@ -785,7 +785,7 @@ void ScummEngine::CHARSET_1() {
 		_nextLeft -= _charset->getStringWidth(0, _charsetBuffer + _charsetBufPos) / 2;
 		if (_nextLeft < 0)
 			_nextLeft = _game.version >= 6 ? _string[0].xpos : 0;
-	} else if (_game.version >= 4 && _game.version < 7 && _game.heversion == 0 && _language == Common::HE_ISR) {
+	} else if (_isRTL) {
 		if (_game.id == GID_MONKEY && _charset->getCurID() == 4) {
 			_nextLeft = _screenWidth - _charset->getStringWidth(0, _charsetBuffer + _charsetBufPos) - _nextLeft;
 		}
@@ -795,9 +795,8 @@ void ScummEngine::CHARSET_1() {
 
 	int c = 0;
 
-	if (_game.version >= 4 && _game.version < 7 && _game.heversion == 0 && _language == Common::HE_ISR) {
+	if (_isRTL)
 		fakeBidiString(_charsetBuffer + _charsetBufPos, true);
-	}
 
 	bool createTextBox = (_macScreen && _game.id == GID_INDY3);
 	bool drawTextBox = false;
@@ -894,9 +893,8 @@ void ScummEngine::drawString(int a, const byte *msg) {
 
 	convertMessageToString(msg, buf, sizeof(buf));
 
-	if (_game.version >= 4 && _game.heversion == 0 && _language == Common::HE_ISR) {
+	if (_isRTL)
 		fakeBidiString(buf, false);
-	}
 
 	_charset->_top = _string[a].ypos + _screenTop;
 	_charset->_startLeft = _charset->_left = _string[a].xpos;
@@ -957,7 +955,7 @@ void ScummEngine::drawString(int a, const byte *msg) {
 
 	if (_charset->_center) {
 		_charset->_left -= _charset->getStringWidth(a, buf) / 2;
-	} else if (_game.version >= 4 && _game.version < 7 && _game.heversion == 0 && _game.id != GID_SAMNMAX && _language == Common::HE_ISR) {
+	} else if (_isRTL && _game.id != GID_SAMNMAX) {
 		// Ignore INDY4 verbs (but allow dialogue)
 		if (_game.id != GID_INDY4 || buf[0] == 127) {
 			if (_game.id == GID_INDY4)
@@ -1006,7 +1004,7 @@ void ScummEngine::drawString(int a, const byte *msg) {
 			case 8:
 				if (_charset->_center) {
 					_charset->_left = _charset->_startLeft - _charset->getStringWidth(a, buf + i);
-				} else if (_game.version >= 4 && _game.version < 7 && _game.heversion == 0 && _language == Common::HE_ISR) {
+				} else if (_isRTL) {
 					_charset->_left = _screenWidth - _charset->_startLeft - _charset->getStringWidth(1, buf + i);
 				} else {
 					_charset->_left = _charset->_startLeft;


### PR DESCRIPTION
Store it in a member instead of duplicating the condition.