### PR TITLE
TONY: Remove hack in sound.cpp (AmigaOS4)

### DIFF
--- a/engines/tony/sound.cpp
+++ b/engines/tony/sound.cpp
@@ -578,32 +578,6 @@ bool FPStream::loadFile(const Common::String &fileName, int bufSize) {
 	// Save the size of the stream
 	_size = _file.size();
 
-#ifdef __amigaos4__
-	// HACK: AmigaOS 4 has weird performance problems with reading in the audio thread,
-	// so we read the whole stream into memory.
-	switch (codec) {
-	case FPCODEC_ADPCM:
-		_rewindableStream = Audio::makeADPCMStream(_file.readStream(_size), DisposeAfterUse::YES, 0, Audio::kADPCMDVI, 44100, 2);
-		break;
-	case FPCODEC_MP3:
-#ifdef USE_MAD
-		_rewindableStream = Audio::makeMP3Stream(&_file, DisposeAfterUse::YES);
-#endif
-		break;
-	case FPCODEC_OGG:
-#ifdef USE_VORBIS
-		_rewindableStream = Audio::makeVorbisStream(&_file, DisposeAfterUse::YES);
-#endif
-		break;
-	case FPCODEC_FLAC:
-#ifdef USE_FLAC
-		_rewindableStream = Audio::makeFLACStream(&_file, DisposeAfterUse::YES);
-#endif
-		break;
-	default:
-		break;
-	}
-#else
 	switch (codec) {
 	case FPCODEC_ADPCM:
 		_rewindableStream = Audio::makeADPCMStream(&_file, DisposeAfterUse::NO, 0, Audio::kADPCMDVI, 44100, 2);
@@ -626,7 +600,6 @@ bool FPStream::loadFile(const Common::String &fileName, int bufSize) {
 	default:
 		break;
 	}
-#endif
 
 	// All done
 	_fileLoaded = true;


### PR DESCRIPTION
This was fixed in one of the OS updates.

Tested locally, no more weird slowdowns.

Please review if I have broken something

Thank you