### PR TITLE
SCUMM: Add Explore the Farm Mac version to detection

### DIFF
--- a/engines/scumm/detection_tables.h
+++ b/engines/scumm/detection_tables.h
@@ -614,7 +614,8 @@ static const GameFilenamePattern gameFilenamesTable[] = {
 	{ "dog", "Springparadijs", kGenHEMac, Common::NL_NLD, Common::kPlatformMacintosh, 0 },
 
 	{ "farm", "farm", kGenHEPC, UNK_LANG, UNK, 0 },
-	{ "farm", "farm", kGenHEMac, UNK_LANG, Common::kPlatformMacintosh, 0 },
+	{ "farm", "The Farm", kGenHEMac, UNK_LANG, Common::kPlatformMacintosh, 0 },
+	{ "farm", "farm", kGenHEMac, Common::NL_NLD, Common::kPlatformMacintosh, 0 },
 	{ "farm", "farmdemo", kGenHEPC, UNK_LANG, UNK, 0 },
 	{ "farm", "Farm Demo", kGenHEMac, UNK_LANG, Common::kPlatformMacintosh, 0 },
 

--- a/engines/scumm/detection_tables.h
+++ b/engines/scumm/detection_tables.h
@@ -615,7 +615,6 @@ static const GameFilenamePattern gameFilenamesTable[] = {
 
 	{ "farm", "farm", kGenHEPC, UNK_LANG, UNK, 0 },
 	{ "farm", "The Farm", kGenHEMac, UNK_LANG, Common::kPlatformMacintosh, 0 },
-	{ "farm", "farm", kGenHEMac, Common::NL_NLD, Common::kPlatformMacintosh, 0 },
 	{ "farm", "farmdemo", kGenHEPC, UNK_LANG, UNK, 0 },
 	{ "farm", "Farm Demo", kGenHEMac, UNK_LANG, Common::kPlatformMacintosh, 0 },
 


### PR DESCRIPTION
The new entry uses the "The Farm" pattern, the existing entry uses "farm"

The existing entry was also updated to refer to the Dutch version, for which it was added
(https://github.com/scummvm/scummvm/commit/2e497bb9f83d0435e88bcd283b636c4e2c9043e3).
This commit fixes the issue reported in https://bugs.scummvm.org/ticket/13483
Related forum thread is here: https://forums.scummvm.org/viewtopic.php?t=16585
and Discord discussion here: https://discord.com/channels/581224060529148060/581224061091446795/975285829696102410


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
