### PR TITLE
AMIGAOS: Few additions and changes to AmigaOS target

### DIFF
--- a/configure
+++ b/configure
@@ -2569,25 +2569,32 @@ case $_host_os in
 		append_var LIBS "-lcitro3d"
 		;;
 	amigaos*)
-		# On building dynamic, everything (possible) should be built as plugin.
+		# Leave out resources by default to save binary size
+		_builtin_resources=no
+		# AmigaOS (PPC) target
+		_port_mk="backends/platform/sdl/amigaos/amigaos.mk"
+		add_line_to_config_mk 'AMIGAOS = 1'
+		append_var CXXFLAGS "-mlongcall"
+		# Enable optimizations for non-debug builds
+		if test "$_debug_build" = no; then
+			_optimization_level=-O2
+			append_var CXXFLAGS "-fomit-frame-pointer"
+			append_var CXXFLAGS "-fstrict-aliasing"
+		else
+			_optimization_level=-O0
+			append_var CXXFLAGS "-fno-omit-frame-pointer"
+			append_var CXXFLAGS "-fno-strict-aliasing"
+		fi
+		# When building dynamic, add everything possible as plugin
 		if test "$_dynamic_modules" = yes ; then
 			_detection_features_static=no
 			_plugins_default=dynamic
 		fi
-		# We have to use 'long' for our 4 byte typedef, because
-		# AmigaOS already typedefs (u)int32 as (unsigned) long.
+		# Use 'long' for ScummVM's 4 byte typedef, because
+		# AmigaOS already typedefs (u)int32 as (unsigned) long
 		type_4_byte='long'
-		# Supress format warnings, as the 'long' 4 byte causes noisy ones.
+		# Suppress format warnings as the 'long' 4 byte causes noisy ones
 		append_var CXXFLAGS "-Wno-format"
-		# Enable optimizations for non-debug builds.
-		if test "$_debug_build" = no; then
-			_optimization_level=-O2
-		fi
-		append_var LDFLAGS "-Wl,--export-dynamic"
-		add_line_to_config_mk 'AMIGAOS = 1'
-		_port_mk="backends/platform/sdl/amigaos/amigaos.mk"
-		# Leave out resources by default, save binary size.
-		_builtin_resources=no
 		;;
 	android)
 		case $_host in

--- a/configure
+++ b/configure
@@ -2578,8 +2578,6 @@ case $_host_os in
 		# Enable optimizations for non-debug builds
 		if test "$_debug_build" = no; then
 			_optimization_level=-O2
-			append_var CXXFLAGS "-fomit-frame-pointer"
-			append_var CXXFLAGS "-fstrict-aliasing"
 		else
 			_optimization_level=-O0
 			append_var CXXFLAGS "-fno-omit-frame-pointer"
@@ -2590,10 +2588,10 @@ case $_host_os in
 			_detection_features_static=no
 			_plugins_default=dynamic
 		fi
-		# Use 'long' for ScummVM's 4 byte typedef, because
-		# AmigaOS already typedefs (u)int32 as (unsigned) long
+		# Use 'long' for ScummVM's 4 byte typedef, because AmigaOS
+		# already typedefs (u)int32 as (unsigned) long and suppress
+		# those noisy format warnings caused by the 'long' 4 byte
 		type_4_byte='long'
-		# Suppress format warnings as the 'long' 4 byte causes noisy ones
 		append_var CXXFLAGS "-Wno-format"
 		;;
 	android)

--- a/configure
+++ b/configure
@@ -4048,10 +4048,12 @@ PLUGIN_LDFLAGS		+= -Wl,-T$(srcdir)/backends/plugins/3ds/plugin.ld -march=armv6k 
 '
 		;;
 	amigaos | morphos)
-		_plugin_prefix="lib"
-		_plugin_suffix=".so"
+		_plugin_prefix=""
+		_plugin_suffix=".plugin"
 		append_var CXXFLAGS "-fPIC"
 		append_var LIBS "-use-dynld"
+		append_var LIBS "-ldl -lauto"
+		append_var _strip "-x"
 _mak_plugins='
 PLUGIN_EXTRA_DEPS =
 PLUGIN_LDFLAGS  += -shared

--- a/configure
+++ b/configure
@@ -4047,12 +4047,13 @@ _mak_plugins='
 PLUGIN_LDFLAGS		+= -Wl,-T$(srcdir)/backends/plugins/3ds/plugin.ld -march=armv6k -mfloat-abi=hard
 '
 		;;
-	amigaos | morphos)
+	amigaos)
 		_plugin_prefix=""
 		_plugin_suffix=".plugin"
 		append_var CXXFLAGS "-fPIC"
 		append_var LIBS "-use-dynld"
-		append_var LIBS "-ldl -lauto"
+		append_var LIBS "-ldl"
+		append_var LIBS "-lauto"
 		append_var _strip "-x"
 _mak_plugins='
 PLUGIN_EXTRA_DEPS =
@@ -4188,6 +4189,18 @@ PLUGIN_EXTRA_DEPS	= $(EXECUTABLE)
 PLUGIN_LDFLAGS		:= -Wl,--enable-auto-import -shared ./libscummvm.a
 PRE_OBJS_FLAGS		:= -Wl,--whole-archive
 POST_OBJS_FLAGS		:= -Wl,--export-all-symbols -Wl,--no-whole-archive -Wl,--out-implib,./libscummvm.a
+'
+		;;
+	morphos)
+		_plugin_prefix="lib"
+		_plugin_suffix=".so"
+		append_var CXXFLAGS "-fPIC"
+		append_var LIBS "-use-dynld"
+_mak_plugins='
+PLUGIN_EXTRA_DEPS =
+PLUGIN_LDFLAGS  += -shared
+PRE_OBJS_FLAGS  := -Wl,-export-dynamic -Wl,-whole-archive
+POST_OBJS_FLAGS := -Wl,-no-whole-archive
 '
 		;;
 	psp)

--- a/configure
+++ b/configure
@@ -4040,18 +4040,6 @@ _mak_plugins=
 if test "$_dynamic_modules" = yes ; then
 	echo_n "Checking whether building plugins is supported... "
 	case $_host_os in
-	emscripten)
-		_plugin_prefix="lib"
-		_plugin_suffix=".wasm"
-		append_var CXXFLAGS "-fPIC"
-		append_var LIBS ""
-_mak_plugins='
-PLUGIN_EXTRA_DEPS =
-PLUGIN_LDFLAGS  += -s SIDE_MODULE=1 -s EXPORT_ALL=1
-PRE_OBJS_FLAGS  := -s MAIN_MODULE=1 -s EXPORT_ALL=1
-POST_OBJS_FLAGS :=
-'
-		;;
 	3ds)
 		_elf_loader=yes
 		append_var DEFINES "-DUNCACHED_PLUGINS"
@@ -4120,6 +4108,18 @@ POST_OBJS_FLAGS		:= -Wl,--no-whole-archive
 		append_var DEFINES "-DELF_NO_MEM_MANAGER"
 _mak_plugins='
 PLUGIN_LDFLAGS		+= -Wl,-T$(srcdir)/backends/plugins/ds/plugin.ld -mthumb -mthumb-interwork -mfloat-abi=soft
+'
+		;;
+	emscripten)
+		_plugin_prefix="lib"
+		_plugin_suffix=".wasm"
+		append_var CXXFLAGS "-fPIC"
+		append_var LIBS ""
+_mak_plugins='
+PLUGIN_EXTRA_DEPS =
+PLUGIN_LDFLAGS  += -s SIDE_MODULE=1 -s EXPORT_ALL=1
+PRE_OBJS_FLAGS  := -s MAIN_MODULE=1 -s EXPORT_ALL=1
+POST_OBJS_FLAGS :=
 '
 		;;
 	freebsd* | openbsd*)


### PR DESCRIPTION
Pending feedback from @BeWorld2018 and @theIDinside (emscripten author, though i didn`t touch the code itself)
Also still need to check with a full build (looks promising though)

Any other feedback (especially gcc gurus and dynamic stuff) welcome (looking at you @lephilousophe) :-D
Please ask, if you find something odd, so i can revise and maybe even rethink a change

configure, line 2572ff
- Streamlined target
- Added some gcc safeguard switches
- Fixed comments and a typo

configure, line 4036ff to 4113ff
- Sort emscripten dynamic target alphabetically


I'd like to get your confirmation on the next changes, since it also touches MorphOS.
Otherwise i'll have to split targets.

Conforming to many of the other platforms use of plugin naming
and to distinguish between ScummVM's engine plugins and the OS'
shared objects/libraries names.
configure, line 4051ff
- Changed plugin naming

configure, line 4055ff
- Added use of dl library for dynamic
 builds
- Added "x" flag to "strip" to preserve global symbols for dynamic builds
(honestly stolen from @dwatteau and his PR https://github.com/scummvm/scummvm/pull/3877) ;-)


I hope i did it correctly this time.
Probably cherry picking is possible too now?

Thank you