### PR TITLE
SCUMM: Fix hanging Maniac Mansion cutscene with the French version

### DIFF
--- a/engines/scumm/script_v2.cpp
+++ b/engines/scumm/script_v2.cpp
@@ -396,6 +396,24 @@ void ScummEngine_v2::decodeParseString() {
 	}
 	*ptr = 0;
 
+	// WORKAROUND bug #13473: in the French version of Maniac Mansion, the cutscene
+	// where Purple Tentacle is bullying Sandy hangs once Dr Fred is done talking,
+	// because his reaction line in shorter in this translation (which is unusual for
+	// French which tends to be more verbose) and the `unless (VAR_CHARCOUNT > 90)`
+	// loop in script #155 hasn't been ajusted for this shorter length.
+	//
+	// So we add some extra spaces at the end of the string if it's too short; this
+	// unblocks the cutscene and also lets Sandy react as intended.
+	//
+	// (Not using `_enableEnhancements` because some users could be really confused
+	// by the game hanging and they may not know about the Esc key.)
+	if (_game.id == GID_MANIAC && _game.platform != Common::kPlatformNES && _language == Common::FR_FRA && vm.slot[_currentScript].number == 155 && _roomResource == 31 && _actorToPrintStrFor == 9) {
+		while (ptr - buffer < 100) {
+			*ptr++ = ' ';
+		}
+		*ptr = 0;
+	}
+
 	int textSlot = 0;
 	_string[textSlot].xpos = 0;
 	_string[textSlot].ypos = 0;


### PR DESCRIPTION
This is related to [Trac issue #13473](https://bugs.scummvm.org/ticket/13473).

The official French version of Maniac Mansion hangs in the cutscene where Purple Tentacle is bullying Sandy in the lab.

Once Dr Fred is done talking, he should quit the room laughing, and Sandy should have a strong reaction, but with the original bug, the game just gets stuck and the characters indefinitely look at each other until your press Esc.

Here's an example where it hangs: <https://www.youtube.com/watch?v=MwKuK8RI5X0&t=5194s> (with what looks like an original Atari interpreter). It'd hang in DOSbox, too.

## Proposed fix

With some help from athrxx in the issue above (thanks!), we found that script no. 155 seems to be responsible for this:

```
...
[0064] (14) print(23,"Bas les pattes!");
[0074] (3B) waitForActor(13);
[0076] (1E) walkActorTo(13,21,50);
[007A] (3B) waitForActor(23);
[007C] (1E) walkActorTo(9,30,50);
[0080] (3B) waitForActor(9);
[0082] (11) animateActor(9,248);
[0085] (14) print(9,"TENTACULE MAUVE!!\x03Arr]te de tourmenter mes cobayes.\x03Am\\ne-la, la machine est pr]te.\x03Ha ha ha.");
[00DA] (80) breakHere();
[00DB] (44) unless (VAR_CHARCOUNT > 90) goto 00DA; # <==  gets stuck here
[00E1] (1E) walkActorTo(9,60,50);
[00E5] (AE) waitForMessage();
[00E6] (11) animateActor(23,250);
[00E9] (14) print(23,"AAAAAAAA!!!!");
...
```

It appears to be stuck in the `unless (VAR_CHARCOUNT > 90)` loop, potentially because the length check is the same in English and French versions, but here Dr Fred's line is shorter in French than in English (which is a bit unusual for French).

My interpretation is that the translation team forgot to adjust this `VAR_CHARCOUNT` check for the shorter string.

So, this PR just pads this string with extra spaces at the end, if we find that it's too short for the default `VAR_CHARCOUNT` check.

I tried to make it safe: this fix is only applied to the French version (we know that the English and German versions are OK; I don't know about the Spanish, Italian or Russian versions here). And we just add harmless spaces, so even if a French translation used a longer string or fixed the `VAR_CHARCOUNT` check, it should still work.

## Testing

You need the French version of Maniac Mansion (not NES) in order to see the original issue and test this fix. I thought GOG sold it, but actually it looks like they're only selling the (badly cracked) English version. The DOTT Remaster doesn't provide a French Maniac Mansion either… Old French DOTT CDs have it, though…

1. Start a new game with the French version.
2. Choose all your players.
3. Open the ScummVM debugger and type `script 155 run` to trigger this cutscene.