### PR TITLE
TWINE: Add detection for DotEmu Android version of LBA1

### DIFF
--- a/common/platform.cpp
+++ b/common/platform.cpp
@@ -55,6 +55,7 @@ const PlatformDescription g_platforms[] = {
 	{ "xbox", "xbox", "xbox", "Microsoft Xbox", kPlatformXbox },
 	{ "cdi", "cdi", "cdi", "Philips CD-i", kPlatformCDi },
 	{ "ios", "ios", "ios", "Apple iOS", kPlatformIOS },
+	{ "android", "android", "android", "Android", kPlatformAndroid },
 	{ "os2", "os2", "os2", "OS/2", kPlatformOS2 },
 	{ "beos", "beos", "beos", "BeOS", kPlatformBeOS },
 	{ "ppc", "ppc", "ppc", "PocketPC", kPlatformPocketPC },

--- a/common/platform.h
+++ b/common/platform.h
@@ -68,6 +68,7 @@ enum Platform {
 	kPlatformXbox,
 	kPlatformCDi,
 	kPlatformIOS,
+	kPlatformAndroid,
 	kPlatformOS2,
 	kPlatformBeOS,
 	kPlatformPocketPC,

--- a/engines/twine/audio/music.cpp
+++ b/engines/twine/audio/music.cpp
@@ -266,7 +266,7 @@ bool Music::playMidiMusic(int32 midiIdx, int32 loop) {
 }
 
 void Music::stopMidiMusic() {
-	if (_engine->_gameFlags & TF_DOTEMU_ENHANCED) {
+	if (_engine->isDotEmuEnhanced()) {
 		_engine->_system->getMixer()->stopHandle(_midiHandle);
 	}
 

--- a/engines/twine/audio/sound.h
+++ b/engines/twine/audio/sound.h
@@ -22,6 +22,7 @@
 #ifndef TWINE_SOUND_H
 #define TWINE_SOUND_H
 
+#include "audio/audiostream.h"
 #include "audio/mixer.h"
 #include "common/scummsys.h"
 #include "common/types.h"
@@ -62,7 +63,7 @@ private:
 	/** Samples playing at a actors position */
 	int32 samplesPlayingActors[NUM_CHANNELS]{0};
 
-	bool playSample(int channelIdx, int index, uint8 *sampPtr, int32 sampSize, int32 loop, const char *name, Audio::Mixer::SoundType soundType = Audio::Mixer::kPlainSoundType, DisposeAfterUse::Flag disposeFlag = DisposeAfterUse::YES);
+	bool playSample(int channelIdx, int index, Audio::SeekableAudioStream *audioStream, int32 loop, const char *name, Audio::Mixer::SoundType soundType = Audio::Mixer::kPlainSoundType);
 
 	bool isChannelPlaying(int32 channel);
 

--- a/engines/twine/detection.cpp
+++ b/engines/twine/detection.cpp
@@ -443,7 +443,7 @@ static const ADGameDescription twineGameDescriptions[] = {
 		AD_ENTRY1s("text.hqr", "a374c93450dd2bb874b7167a63974e8d", 377224),
 		Common::EN_ANY,
 		Common::kPlatformAndroid,
-		ADGF_UNSTABLE | TwinE::TF_DOTEMU_ENHANCED,
+		TwinE::TF_DOTEMU_ENHANCED,
 		GUIO1(GUIO_NONE)
 	},
 	{
@@ -452,7 +452,7 @@ static const ADGameDescription twineGameDescriptions[] = {
 		AD_ENTRY1s("text.hqr", "a374c93450dd2bb874b7167a63974e8d", 377224),
 		Common::FR_FRA,
 		Common::kPlatformAndroid,
-		ADGF_UNSTABLE | TwinE::TF_DOTEMU_ENHANCED,
+		TwinE::TF_DOTEMU_ENHANCED,
 		GUIO1(GUIO_NONE)
 	},
 	{
@@ -461,7 +461,7 @@ static const ADGameDescription twineGameDescriptions[] = {
 		AD_ENTRY1s("text.hqr", "a374c93450dd2bb874b7167a63974e8d", 377224),
 		Common::DE_DEU,
 		Common::kPlatformAndroid,
-		ADGF_UNSTABLE | TwinE::TF_DOTEMU_ENHANCED,
+		TwinE::TF_DOTEMU_ENHANCED,
 		GUIO1(GUIO_NONE)
 	},
 

--- a/engines/twine/detection.cpp
+++ b/engines/twine/detection.cpp
@@ -434,6 +434,37 @@ static const ADGameDescription twineGameDescriptions[] = {
 		GUIO1(GUIO_NONE)
 	},
 
+	// Little Big Adventure - DotEmu Enhanced Version (Android)
+	// liblba.so
+	// 8 Sep 2014 at 15:56
+	{
+		"lba",
+		"DotEmu",
+		AD_ENTRY1s("text.hqr", "a374c93450dd2bb874b7167a63974e8d", 377224),
+		Common::EN_ANY,
+		Common::kPlatformAndroid,
+		ADGF_UNSTABLE | TwinE::TF_DOTEMU_ENHANCED,
+		GUIO1(GUIO_NONE)
+	},
+	{
+		"lba",
+		"DotEmu",
+		AD_ENTRY1s("text.hqr", "a374c93450dd2bb874b7167a63974e8d", 377224),
+		Common::FR_FRA,
+		Common::kPlatformAndroid,
+		ADGF_UNSTABLE | TwinE::TF_DOTEMU_ENHANCED,
+		GUIO1(GUIO_NONE)
+	},
+	{
+		"lba",
+		"DotEmu",
+		AD_ENTRY1s("text.hqr", "a374c93450dd2bb874b7167a63974e8d", 377224),
+		Common::DE_DEU,
+		Common::kPlatformAndroid,
+		ADGF_UNSTABLE | TwinE::TF_DOTEMU_ENHANCED,
+		GUIO1(GUIO_NONE)
+	},
+
 	// Little Big Adventure - GOG Version
 	// LBA.GOG
 	// 11 October 2011 at 17:30

--- a/engines/twine/metaengine.cpp
+++ b/engines/twine/metaengine.cpp
@@ -57,7 +57,7 @@ public:
 		} else if (gameId == "lbashow") {
 			gameType = TwineGameType::GType_LBASHOW;
 		}
-		*engine = new TwinE::TwinEEngine(syst, desc->language, desc->flags, gameType);
+		*engine = new TwinE::TwinEEngine(syst, desc->language, desc->flags, desc->platform, gameType);
 		return Common::kNoError;
 	}
 

--- a/engines/twine/text.cpp
+++ b/engines/twine/text.cpp
@@ -78,7 +78,7 @@ void Text::initVoxBank(TextBankId bankIdx) {
 	}
 	// get the correct vox hqr file
 	_currentVoxBankFile = Common::String::format("%s%s" VOX_EXT, LanguageTypes[_engine->_cfgfile.LanguageId].id, LanguageSuffixTypes[(int)bankIdx]);
-	_currentOggBaseFile = Common::String::format("%s_%s_", LanguageTypes[_engine->_cfgfile.LanguageId].id, LanguageSuffixTypes[(int)bankIdx]);
+	_currentOggBaseFile = Common::String::format("%s%s_", LanguageTypes[_engine->_cfgfile.LanguageId].id, LanguageSuffixTypes[(int)bankIdx]);
 	// TODO: loop through other languages and take the scummvm settings regarding voices into account...
 
 	// TODO check the rest to reverse

--- a/engines/twine/text.cpp
+++ b/engines/twine/text.cpp
@@ -78,6 +78,7 @@ void Text::initVoxBank(TextBankId bankIdx) {
 	}
 	// get the correct vox hqr file
 	_currentVoxBankFile = Common::String::format("%s%s" VOX_EXT, LanguageTypes[_engine->_cfgfile.LanguageId].id, LanguageSuffixTypes[(int)bankIdx]);
+	_currentOggBaseFile = Common::String::format("%s_%s_", LanguageTypes[_engine->_cfgfile.LanguageId].id, LanguageSuffixTypes[(int)bankIdx]);
 	// TODO: loop through other languages and take the scummvm settings regarding voices into account...
 
 	// TODO check the rest to reverse

--- a/engines/twine/text.h
+++ b/engines/twine/text.h
@@ -153,6 +153,8 @@ public:
 
 	const TextEntry *_currDialTextEntry = nullptr; // ordered entry
 	Common::String _currentVoxBankFile;
+	// used for the android version (dotemu)
+	Common::String _currentOggBaseFile;
 
 	bool _showDialogueBubble = true;
 

--- a/engines/twine/twine.cpp
+++ b/engines/twine/twine.cpp
@@ -123,8 +123,8 @@ void TwineScreen::update() {
 	Super::update();
 }
 
-TwinEEngine::TwinEEngine(OSystem *system, Common::Language language, uint32 flags, TwineGameType gameType)
-	: Engine(system), _gameType(gameType), _gameLang(language), _frontVideoBuffer(this), _gameFlags(flags), _rnd("twine") {
+TwinEEngine::TwinEEngine(OSystem *system, Common::Language language, uint32 flags, Common::Platform platform, TwineGameType gameType)
+	: Engine(system), _gameType(gameType), _gameLang(language), _frontVideoBuffer(this), _gameFlags(flags), _platform(platform), _rnd("twine") {
 	// Add default file directories
 	const Common::FSNode gameDataDir(ConfMan.get("path"));
 	SearchMan.addSubDirectoryMatching(gameDataDir, "fla");

--- a/engines/twine/twine.h
+++ b/engines/twine/twine.h
@@ -23,6 +23,7 @@
 #define TWINE_TWINE_H
 
 #include "backends/keymapper/keymap.h"
+#include "common/platform.h"
 #include "common/random.h"
 #include "common/rect.h"
 #include "engines/advancedDetector.h"
@@ -227,7 +228,7 @@ private:
 	 */
 	bool runGameEngine();
 public:
-	TwinEEngine(OSystem *system, Common::Language language, uint32 flagsTwineGameType, TwineGameType gameType);
+	TwinEEngine(OSystem *system, Common::Language language, uint32 flagsTwineGameType, Common::Platform platform, TwineGameType gameType);
 	~TwinEEngine() override;
 
 	Common::Error run() override;
@@ -252,6 +253,7 @@ public:
 	bool isMod() const { return (_gameFlags & TwinE::TF_MOD) != 0; }
 	bool isDotEmuEnhanced() const { return (_gameFlags & TwinE::TF_DOTEMU_ENHANCED) != 0; }
 	bool isDemo() const { return (_gameFlags & ADGF_DEMO) != 0; };
+	bool isAndroid() const { return _platform == Common::Platform::kPlatformAndroid; };
 	const char *getGameId() const;
 	Common::Language getGameLang() const;
 
@@ -293,6 +295,7 @@ public:
 	int32 _loopInventoryItem = 0;
 	int32 _loopActorStep = 0;
 	uint32 _gameFlags;
+	Common::Platform _platform;
 
 	/** Disable screen recenter */
 	bool _disableScreenRecenter = false;


### PR DESCRIPTION
This was available in 2014 via Humble Bundle and is notable as it doesn't use VOX files, instead having split ogg files for the sound effects. I'm marking this as a draft for @mgerhardy. This also adds `kPlatformAndroid` as required.

I'm not sure as to the proper format for the build date, the ARMv7a .so has `LBA/Relentless (Sep  8 2014 / 15:55:03)` while the x86 .so has `LBA/Relentless (Sep  8 2014 / 15:56:52)`. I used the date/time from the x86 version converted into the same format the other entries use.