### PR TITLE
COMMON: Add (missing?) indentation to defines

### DIFF
--- a/common/keyboard.h
+++ b/common/keyboard.h
@@ -25,12 +25,12 @@
 #include "common/scummsys.h"
 
 #if defined(__amigaos4__) || defined(__MORPHOS__)
-// KEYCODE_LESS and KEYCODE_GREATER are already defined in AmigaOS, inside
-// include/include_h/intuition/intuition.h (bug #5532)
-#if defined(KEYCODE_LESS) && defined(KEYCODE_GREATER)
-#undef KEYCODE_LESS
-#undef KEYCODE_GREATER
-#endif
+	// KEYCODE_LESS and KEYCODE_GREATER are already defined in AmigaOS and MorphOS,
+	// inside "include/include_h/intuition/intuition.h" (fixes bug #5532)
+	#if defined(KEYCODE_LESS) && defined(KEYCODE_GREATER)
+		#undef KEYCODE_LESS
+		#undef KEYCODE_GREATER
+	#endif
 #endif
 
 namespace Common {


### PR DESCRIPTION
I´m not sure if this was intended, but it looks so wrong without indentation.

Feel free to reject if it was intended