### PR TITLE
SCI: fix bug no. 10183 (QFG1EGA: Baba Yaga's hut sound bug)

### DIFF
--- a/engines/sci/sound/music.cpp
+++ b/engines/sci/sound/music.cpp
@@ -699,7 +699,7 @@ void SciMusic::soundStop(MusicEntry *pSnd) {
 	pSnd->fadeStep = 0; // end fading, if fading was in progress
 
 	// SSCI0 resumes the next available sound from the (priority ordered) list with a paused status.
-	if (_soundVersion <= SCI_VERSION_0_LATE && (pSnd = getFirstSlotWithStatus(kSoundPaused)))
+	if (_soundVersion <= SCI_VERSION_0_LATE && previousStatus == kSoundPlaying && (pSnd = getFirstSlotWithStatus(kSoundPaused)))
 		soundResume(pSnd);
 }
 

--- a/engines/sci/sound/soundcmd.cpp
+++ b/engines/sci/sound/soundcmd.cpp
@@ -137,8 +137,12 @@ void SoundCommandParser::processInitSound(reg_t obj) {
 
 	// Check if a track with the same sound object is already playing
 	MusicEntry *oldSound = _music->getSlot(obj);
-	if (oldSound)
-		processDisposeSound(obj);
+	if (oldSound) {
+		if (_soundVersion <= SCI_VERSION_0_LATE)
+			_music->soundKill(oldSound);
+		else
+			processDisposeSound(obj);
+	}
 
 	MusicEntry *newSound = new MusicEntry();
 	newSound->resourceId = resourceId;


### PR DESCRIPTION
These are two different bugs in that one scene.

I have fixed the one in processInitSound() without making more changes than necessary.  The relevant part is that there may not be any call to processStopSound() which would happen when calling processDisposeSound().
The original works a bit different than what we do: If there is an existing node for a sound, it will not remove and delete it. It will just use that node and not create a new one. A new node will only be created when there isn't already one for that sound.
To stay in line with our current code I just remove the existing node with soundKill, since it doesn't really matter which way round you do this (use the old node or remove it and make a new one). The relevant part is really just avoiding processDisposeSound() and processStopSound(). 
Disclaimer: I have not checked if the call to processDisposeSound() is actually right for SCI1. I just left this as it was...

The other bug is completely separate from that. The game tries to stop a sound that isn't actually playing. In that case the behaviour of the original interpreter is that none of the paused sounds waiting in the playlist get activated. I fixed it accordingly.