### PR TITLE
JANITORIAL: Fix some lost or outdated URLs in comments

### DIFF
--- a/audio/decoders/aiff.cpp
+++ b/audio/decoders/aiff.cpp
@@ -21,7 +21,7 @@
 
 /*
  * The code in this file is based on information found at
- * http://www.borg.com/~jglatt/tech/aiff.htm
+ * https://www.co-bw.com/Audio_AIFF.htm
  *
  * Also partially based on libav's aiffdec.c
  */

--- a/audio/decoders/mac_snd.cpp
+++ b/audio/decoders/mac_snd.cpp
@@ -21,7 +21,7 @@
 
 /*
  * The code in this file is based on information found at
- * http://developer.apple.com/legacy/mac/library/documentation/mac/Sound/Sound-60.html#HEADING60-15
+ * https://developer.apple.com/library/archive/documentation/mac/Sound/Sound-60.html#HEADING60-15
  *
  * We implement both type 1 and type 2 snd resources, but only those that are sampled
  */

--- a/audio/decoders/quicktime.cpp
+++ b/audio/decoders/quicktime.cpp
@@ -562,7 +562,7 @@ uint32 QuickTimeAudioDecoder::QuickTimeAudioTrack::getAACSampleTime(uint32 total
 
 	// The first chunk of AAC contains "duration" samples that are used as a primer
 	// We need to subtract that number from the duration for the first chunk. See:
-	// http://developer.apple.com/library/mac/#documentation/QuickTime/QTFF/QTFFAppenG/QTFFAppenG.html#//apple_ref/doc/uid/TP40000939-CH2-SW1
+	// https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFAppenG/QTFFAppenG.html#//apple_ref/doc/uid/TP40000939-CH2-SW1
 	// The skipping of both the primer and the remainder are handled by the AAC code,
 	// whereas the timing of the remainder are handled by this time-to-sample chunk
 	// code already.

--- a/audio/miles_adlib.cpp
+++ b/audio/miles_adlib.cpp
@@ -437,7 +437,7 @@ void MidiDriver_Miles_AdLib::resetAdLibFMVoiceChannelRegisters(byte baseRegister
 	}
 }
 
-// MIDI messages can be found at http://www.midi.org/techspecs/midimessages.php
+// MIDI messages can be found at https://web.archive.org/web/20120128110425/http://www.midi.org/techspecs/midimessages.php
 void MidiDriver_Miles_AdLib::send(uint32 b) {
 	byte command = b & 0xf0;
 	byte channel = b & 0xf;

--- a/audio/miles_midi.cpp
+++ b/audio/miles_midi.cpp
@@ -170,7 +170,7 @@ void MidiDriver_Miles_Midi::initMidiDevice() {
 	}
 }
 
-// MIDI messages can be found at http://www.midi.org/techspecs/midimessages.php
+// MIDI messages can be found at https://web.archive.org/web/20120128110425/http://www.midi.org/techspecs/midimessages.php
 void MidiDriver_Miles_Midi::send(int8 source, uint32 b) {
 	assert(source < MAXIMUM_SOURCES);
 

--- a/audio/mt32gm.cpp
+++ b/audio/mt32gm.cpp
@@ -422,7 +422,7 @@ void MidiDriver_MT32GM::send(int8 source, uint32 b) {
 	processEvent(source, b, outputChannel, controlData);
 }
 
-// MIDI messages can be found at http://www.midi.org/techspecs/midimessages.php
+// MIDI messages can be found at https://web.archive.org/web/20120128110425/http://www.midi.org/techspecs/midimessages.php
 void MidiDriver_MT32GM::processEvent(int8 source, uint32 b, uint8 outputChannel, MidiChannelControlData &controlData, bool channelLockedByOtherSource) {
 	assert(source < MAXIMUM_SOURCES);
 

--- a/backends/dialogs/win32/win32-dialogs.cpp
+++ b/backends/dialogs/win32/win32-dialogs.cpp
@@ -48,7 +48,7 @@
 	// We use functionality introduced with Vista in this file.
 	// To assure that including the respective system headers gives us all
 	// required definitions we set Vista as minimum version we target.
-	// See: https://msdn.microsoft.com/en-us/library/windows/desktop/aa383745%28v=vs.85%29.aspx#macros_for_conditional_declarations
+	// See: https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers#macros-for-conditional-declarations
 #include <sdkddkver.h>
 #undef _WIN32_WINNT
 #define _WIN32_WINNT _WIN32_WINNT_VISTA

--- a/backends/midi/alsa.cpp
+++ b/backends/midi/alsa.cpp
@@ -107,7 +107,8 @@ int MidiDriver_ALSA::open() {
 	}
 	snd_seq_set_client_group(seq_handle, "input");
 
-	// According to http://www.alsa-project.org/~tiwai/alsa-subs.html
+	// According to
+	// https://web.archive.org/web/20120505164948/http://www.alsa-project.org/~tiwai/alsa-subs.html
 	// you can set read or write capabilities to allow other clients to
 	// read or write the port. I don't think we need that, unless maybe
 	// to be able to record the sound, but I can't get that to work even

--- a/backends/midi/coremidi.cpp
+++ b/backends/midi/coremidi.cpp
@@ -40,9 +40,9 @@
 /*
 For information on how to unify the CoreMidi and MusicDevice code:
 
-http://lists.apple.com/archives/Coreaudio-api/2005/Jun/msg00194.html
-http://lists.apple.com/archives/coreaudio-api/2003/Mar/msg00248.html
-http://lists.apple.com/archives/coreaudio-api/2003/Jul/msg00137.html
+https://lists.apple.com/archives/coreaudio-api/2005/Jun/msg00194.html
+https://lists.apple.com/archives/coreaudio-api/2003/Mar/msg00248.html
+https://lists.apple.com/archives/coreaudio-api/2003/Jul/msg00137.html
 
 */
 

--- a/backends/midi/seq.cpp
+++ b/backends/midi/seq.cpp
@@ -22,7 +22,7 @@
 /*
  * Raw output support by Michael Pearce
  * Alsa support by Nicolas Noble <nicolas@nobis-crew.org> copied from
- *    both the QuickTime support and (vkeybd http://www.alsa-project.org/~iwai/alsa.html)
+ * both the QuickTime support and (vkeybd https://web.archive.org/web/20070629122111/http://www.alsa-project.org/~iwai/alsa.html)
  */
 
 // Disable symbol overrides so that we can use system headers.

--- a/backends/networking/curl/networkreadstream.cpp
+++ b/backends/networking/curl/networkreadstream.cpp
@@ -296,7 +296,7 @@ Common::String NetworkReadStream::responseHeaders() const {
 }
 
 Common::HashMap<Common::String, Common::String> NetworkReadStream::responseHeadersMap() const {
-	// HTTP headers are described at RFC 2616: https://tools.ietf.org/html/rfc2616#section-4.2
+	// HTTP headers are described at RFC 2616: https://datatracker.ietf.org/doc/html/rfc2616#section-4.2
 	// this implementation tries to follow it, but for simplicity it does not support multi-line header values
 
 	Common::HashMap<Common::String, Common::String> headers;

--- a/backends/platform/maemo/maemo.cpp
+++ b/backends/platform/maemo/maemo.cpp
@@ -50,7 +50,7 @@ OSystem_SDL_Maemo::~OSystem_SDL_Maemo() {
 void OSystem_SDL_Maemo::init() {
 	// Use an iconless window for Maemo
 	// also N900 is hit by SDL_WM_SetIcon bug (window cannot receive input)
-	// http://bugzilla.libsdl.org/show_bug.cgi?id=586
+	// https://github.com/libsdl-org/SDL-1.2/issues/403
 	initSDL();
 	_window = new SdlIconlessWindow();
 

--- a/backends/platform/sdl/posix/posix.cpp
+++ b/backends/platform/sdl/posix/posix.cpp
@@ -136,7 +136,7 @@ Common::String OSystem_POSIX::getDefaultConfigFileName() {
 
 	// On POSIX systems we follow the XDG Base Directory Specification for
 	// where to store files. The version we based our code upon can be found
-	// over here: http://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
+	// over here: https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.8.html
 	envVar = getenv("XDG_CONFIG_HOME");
 	if (!envVar || !*envVar) {
 		envVar = getenv("HOME");
@@ -285,7 +285,7 @@ Common::String OSystem_POSIX::getDefaultLogFileName() {
 
 	// On POSIX systems we follow the XDG Base Directory Specification for
 	// where to store files. The version we based our code upon can be found
-	// over here: http://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
+	// over here: https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.8.html
 	const char *prefix = getenv("XDG_CACHE_HOME");
 	if (prefix == nullptr || !*prefix) {
 		prefix = getenv("HOME");

--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -426,7 +426,7 @@ bool SdlWindow::createOrUpdateWindow(int width, int height, uint32 flags) {
 	// macOS windows with the flag SDL_WINDOW_FULLSCREEN_DESKTOP exiting their fullscreen space
 	// ignore the size set by SDL_SetWindowSize while they were in fullscreen mode.
 	// Instead, they revert back to their previous windowed mode size.
-	// This is a bug in SDL2: https://bugzilla.libsdl.org/show_bug.cgi?id=3719.
+	// This is a bug in SDL2: https://github.com/libsdl-org/SDL/issues/2518.
 	// TODO: Remove the call to SDL_SetWindowSize below once the SDL bug is fixed.
 
 	// In some cases at this point there may be a pending SDL resize event with the old size.

--- a/backends/platform/sdl/win32/win32_wrapper.h
+++ b/backends/platform/sdl/win32/win32_wrapper.h
@@ -55,7 +55,7 @@ void getProcessDirectory(TCHAR *processDirectory, DWORD size);
 
 /**
  * Checks if the current running Windows version is greater or equal to the specified version.
- * See: https://docs.microsoft.com/en-us/windows/desktop/sysinfo/operating-system-version
+ * See: https://docs.microsoft.com/en-us/windows/win32/sysinfo/operating-system-version
  *
  * @param majorVersion The major version number (x.0)
  * @param minorVersion The minor version number (0.x)

--- a/backends/saves/posix/posix-saves.cpp
+++ b/backends/saves/posix/posix-saves.cpp
@@ -73,7 +73,7 @@ POSIXSaveFileManager::POSIXSaveFileManager() {
 
 		// On POSIX systems we follow the XDG Base Directory Specification for
 		// where to store files. The version we based our code upon can be found
-		// over here: http://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
+		// over here: https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.8.html
 		envVar = getenv("XDG_DATA_HOME");
 		if (!envVar || !*envVar) {
 			envVar = getenv("HOME");

--- a/backends/taskbar/win32/mingw-compat.h
+++ b/backends/taskbar/win32/mingw-compat.h
@@ -21,7 +21,7 @@
 
 // TODO: Remove header when the latest changes to the Windows SDK have been integrated into MingW
 //       For reference, the interface definitions here are imported the SDK headers and from the
-//       EcWin7 project (https://code.google.com/p/dukto/)
+//       EcWin7 project (https://github.com/colomboe/EcWin7)
 
 #ifndef BACKEND_WIN32_TASKBAR_MINGW_H
 #define BACKEND_WIN32_TASKBAR_MINGW_H

--- a/backends/taskbar/win32/win32-taskbar.cpp
+++ b/backends/taskbar/win32/win32-taskbar.cpp
@@ -48,7 +48,7 @@
 	// We use functionality introduced with Win7 in this file.
 	// To assure that including the respective system headers gives us all
 	// required definitions we set Win7 as minimum version we target.
-	// See: https://msdn.microsoft.com/en-us/library/windows/desktop/aa383745%28v=vs.85%29.aspx#macros_for_conditional_declarations
+	// See: https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers#macros-for-conditional-declarations
 	#include <sdkddkver.h>
 	#undef _WIN32_WINNT
 	#define _WIN32_WINNT _WIN32_WINNT_WIN7
@@ -67,7 +67,7 @@
 
 #include "common/textconsole.h"
 
-// System.Title property key, values taken from http://msdn.microsoft.com/en-us/library/bb787584.aspx
+// System.Title property key, values taken from https://docs.microsoft.com/en-us/windows/win32/properties/props-system-title
 const PROPERTYKEY PKEY_Title = { /* fmtid = */ { 0xF29F85E0, 0x4FF9, 0x1068, { 0xAB, 0x91, 0x08, 0x00, 0x2B, 0x27, 0xB3, 0xD9 } }, /* propID = */ 2 };
 
 Win32TaskbarManager::Win32TaskbarManager(SdlWindow_Win32 *window) : _window(window), _taskbar(nullptr), _count(0), _icon(nullptr) {

--- a/backends/updates/macosx/macosx-updates.mm
+++ b/backends/updates/macosx/macosx-updates.mm
@@ -40,11 +40,11 @@ SUUpdater *sparkleUpdater;
  * Sparkle is a software update framework for macOS which uses appcasts for
  * release information. Appcasts are RSS-like XML feeds which contain information
  * about the most current version at the time. If a new version is available, the
- * user is presented the release-notes/changes/fixes and is asked if he wants to
+ * user is presented the release-notes/changes/fixes and is asked if they want to
  * update, and if yes the Sparkle framework downloads a signed update package
  * from the server and automatically installs and restarts the software.
  * More detailed information is available at the following address:
- * http://sparkle.andymatuschak.org/
+ * https://sparkle-project.org/
  *
  */
 MacOSXUpdateManager::MacOSXUpdateManager() {

--- a/backends/updates/win32/win32-updates.cpp
+++ b/backends/updates/win32/win32-updates.cpp
@@ -37,11 +37,11 @@
  * Sparkle is a software update framework for macOS which uses appcasts for
  * release information. Appcasts are RSS-like XML feeds which contain information
  * about the most current version at the time. If a new version is available, the
- * user is presented the release-notes/changes/fixes and is asked if he wants to
+ * user is presented the release-notes/changes/fixes and is asked if they want to
  * update, and if yes the Sparkle framework downloads a signed update package
  * from the server and automatically installs and restarts the software.
  * More detailed information is available at the following address:
- * http://sparkle.andymatuschak.org/
+ * https://sparkle-project.org/
  *
  * WinSparkle is a heavily (to the point of being its almost-port) inspired by the
  * Sparkle framework originally by Andy Matuschak that became the de facto standard

--- a/common/json.cpp
+++ b/common/json.cpp
@@ -1086,7 +1086,7 @@ String JSONValue::stringifyImpl(size_t const indentDepth) const {
 
 /**
 * Creates a JSON encoded string with all required fields escaped
-* Works from http://www.ecma-internationl.org/publications/files/ECMA-ST/ECMA-262.pdf
+* Works from https://www.ecma-international.org/wp-content/uploads/ECMA-262_5.1_edition_june_2011.pdf
 * Section 15.12.3.
 *
 * @access private

--- a/common/lua/lmathlib.cpp
+++ b/common/lua/lmathlib.cpp
@@ -13,7 +13,7 @@
 // MSVC does not define M_PI, M_SQRT2 and other math defines by default.
 // _USE_MATH_DEFINES must be defined in order to have these defined, thus
 // we enable it here. For more information, check:
-// http://msdn.microsoft.com/en-us/library/4hwaceh6(v=VS.100).aspx
+// https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants
 #define _USE_MATH_DEFINES
 #include <math.h>
 

--- a/common/memorypool.h
+++ b/common/memorypool.h
@@ -158,7 +158,7 @@ public:
  * This *should* work with all C++ implementations, but may not.
  *
  * For details on using placement new for custom allocators, see e.g.
- * <http://www.parashift.com/c++-faq-lite/dtors.html#faq-11.14>
+ * <https://isocpp.org/wiki/faq/dtors#memory-pools>
  */
 inline void *operator new(size_t nbytes, Common::MemoryPool &pool) {
 	assert(nbytes <= pool.getChunkSize());

--- a/common/punycode.cpp
+++ b/common/punycode.cpp
@@ -48,7 +48,7 @@
 
 namespace Common {
 
-/* punycode parameters, see http://tools.ietf.org/html/rfc3492#section-5 */
+/* punycode parameters, see https://datatracker.ietf.org/doc/html/rfc3492#section-5 */
 #define BASE 36
 #define TMIN 1
 #define TMAX 26

--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -125,7 +125,7 @@
 	// MSVC does not define M_PI, M_SQRT2 and other math defines by default.
 	// _USE_MATH_DEFINES must be defined in order to have these defined, thus
 	// we enable it here. For more information, check:
-	// http://msdn.microsoft.com/en-us/library/4hwaceh6(v=VS.100).aspx
+	// https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants
 	#define _USE_MATH_DEFINES
 	#include <math.h>
 
@@ -452,7 +452,7 @@
 
 //
 // Determine 64 bitness
-// Reference: http://nadeausoftware.com/articles/2012/02/c_c_tip_how_detect_processor_type_using_compiler_predefined_macros
+// Reference: https://web.archive.org/web/20190413073704/http://nadeausoftware.com/articles/2012/02/c_c_tip_how_detect_processor_type_using_compiler_predefined_macros
 //
 #if !defined(HAVE_CONFIG_H)
 

--- a/common/str.h
+++ b/common/str.h
@@ -374,7 +374,7 @@ String tag2string(uint32 tag, bool nonPrintable = false);
  * string.
  *
  * @note This is modeled after OpenBSD's strlcpy. See the manpage here:
- *       http://www.openbsd.org/cgi-bin/man.cgi?query=strlcpy
+ *       https://man.openbsd.org/strlcpy
  *
  * @param dst The destination buffer.
  * @param src The source string.
@@ -392,7 +392,7 @@ size_t strlcpy(char *dst, const char *src, size_t size);
  * the dst string will not be changed and size + strlen(src) is returned.
  *
  * @note This is modeled after OpenBSD's strlcat. See the manpage here:
- *       http://www.openbsd.org/cgi-bin/man.cgi?query=strlcat
+ *       https://man.openbsd.org/strlcat
  *
  * @param dst The string the source string should be appended to.
  * @param src The source string.

--- a/common/stuffit.cpp
+++ b/common/stuffit.cpp
@@ -19,7 +19,7 @@
  *
  */
 
-// StuffIt parsing based on http://code.google.com/p/theunarchiver/wiki/StuffItFormat
+// StuffIt parsing based on https://github.com/mietek/theunarchiver/wiki/StuffItFormat
 // Compression 14 based on libxad (http://sourceforge.net/projects/libxad/)
 
 #include "common/stuffit.h"

--- a/devtools/create_titanic/memorypool.h
+++ b/devtools/create_titanic/memorypool.h
@@ -147,7 +147,7 @@ public:
  * This *should* work with all C++ implementations, but may not.
  *
  * For details on using placement new for custom allocators, see e.g.
- * <http://www.parashift.com/c++-faq-lite/dtors.html#faq-11.14>
+ * <https://isocpp.org/wiki/faq/dtors#memory-pools>
  */
 inline void *operator new(size_t nbytes, Common::MemoryPool &pool) {
 	assert(nbytes <= pool.getChunkSize());

--- a/devtools/create_xeen/memorypool.h
+++ b/devtools/create_xeen/memorypool.h
@@ -147,7 +147,7 @@ public:
  * This *should* work with all C++ implementations, but may not.
  *
  * For details on using placement new for custom allocators, see e.g.
- * <http://www.parashift.com/c++-faq-lite/dtors.html#faq-11.14>
+ * <https://isocpp.org/wiki/faq/dtors#memory-pools>
  */
 inline void *operator new(size_t nbytes, Common::MemoryPool &pool) {
 	assert(nbytes <= pool.getChunkSize());

--- a/devtools/create_xeen/str.h
+++ b/devtools/create_xeen/str.h
@@ -340,7 +340,7 @@ String tag2string(uint32 tag);
  * string.
  *
  * @note This is modeled after OpenBSD's strlcpy. See the manpage here:
- *       http://www.openbsd.org/cgi-bin/man.cgi?query=strlcpy
+ *       https://man.openbsd.org/strlcpy
  *
  * @param dst The destination buffer.
  * @param src The source string.
@@ -358,7 +358,7 @@ size_t strlcpy(char *dst, const char *src, size_t size);
  * the dst string will not be changed and size + strlen(src) is returned.
  *
  * @note This is modeled after OpenBSD's strlcat. See the manpage here:
- *       http://www.openbsd.org/cgi-bin/man.cgi?query=strlcat
+ *       https://man.openbsd.org/strlcat
  *
  * @param dst The string the source string should be appended to.
  * @param src The source string.

--- a/engines/ags/engine/ac/route_finder_jps.cpp
+++ b/engines/ags/engine/ac/route_finder_jps.cpp
@@ -243,7 +243,8 @@ bool Navigation::Reachable(int x0, int y0, int x1, int y1) const {
 }
 
 // A* using jump point search (JPS)
-// reference: http://users.cecs.anu.edu.au/~dharabor/data/papers/harabor-grastien-aaai11.pdf
+// reference: Online Graph Pruning for Pathfinding on Grid Maps
+// http://users.cecs.anu.edu.au/~dharabor/data/papers/harabor-grastien-aaai11.pdf
 void Navigation::AddPruned(int *buf, int &bcount, int x, int y) const {
 	assert(buf && bcount < 8);
 

--- a/engines/ags/shared/util/utf8.h
+++ b/engines/ags/shared/util/utf8.h
@@ -22,7 +22,7 @@
  //=============================================================================
  //
  // UTF-8 utilities.
- // Based on utf8 code from https://c9x.me/git/irc.git/tree/irc.c
+ // Based on utf8 code from https://c9x.me/irc/ (public domain)
  //
  //=============================================================================
 

--- a/engines/avalanche/enums.h
+++ b/engines/avalanche/enums.h
@@ -106,7 +106,7 @@ enum Magics {
 };
 
 // Constants to replace the command characters from Pascal.
-// For more information, see: https://github.com/urukgit/avalot/wiki/Scrolldrivers
+// For more information, see: https://github.com/marnanel/avalot/wiki/Scrolldrivers
 enum ControlCharacter {
 	kControlSpeechBubble = 2, // ^B
 	kControlCenter = 3, // ^C

--- a/engines/avalanche/graphics.h
+++ b/engines/avalanche/graphics.h
@@ -132,7 +132,7 @@ public:
 	byte getAlsoColor(int x1, int y1, int x2, int y2);
 	byte getScreenColor(Common::Point pos);
 
-	// Further information about this: http://www.shikadi.net/moddingwiki/Raw_EGA_data
+	// Further information about this: https://moddingwiki.shikadi.net/wiki/Raw_EGA_data
 	Graphics::Surface loadPictureRaw(Common::File &file, uint16 width, uint16 height);
 
 	void drawSprite(AnimationType *sprite, byte picnum, int16 x, int16 y);
@@ -172,7 +172,7 @@ private:
 	Graphics::Surface _backup;
 	Graphics::Surface _digits[10]; // digitsize and rwlitesize are defined in loadDigits() !!!
 	Graphics::Surface _directions[9]; // Maybe it will be needed to move them to the class itself instead.
-	Graphics::Surface _magics; // Lucerna::draw_also_lines() draws the "magical" lines here. Further information: https://github.com/urukgit/avalot/wiki/Also
+	Graphics::Surface _magics; // Lucerna::draw_also_lines() draws the "magical" lines here. Further information: https://github.com/marnanel/avalot/wiki/Also
 	Graphics::Surface _screen; // Only used in refreshScreen() to make it more optimized. (No recreation of it at every call of the function.)
 	Graphics::Surface _scrolls;
 	Graphics::Surface _surface;
@@ -192,7 +192,7 @@ private:
 
 	void skipDifference(int size, const Graphics::Surface &picture, Common::File &file);
 
-	// Further information about these two: http://www.shikadi.net/moddingwiki/Raw_EGA_data
+	// Further information about these two: https://moddingwiki.shikadi.net/wiki/Raw_EGA_data
 	Graphics::Surface loadPictureGraphic(Common::File &file); // Reads Graphic-planar EGA data.
 	Graphics::Surface loadPictureSign(Common::File &file, uint16 width, uint16 height); // Reads a tricky type of picture used for the "game over"/"about" scrolls and in the mini-game Nim.
 

--- a/engines/cine/sound.cpp
+++ b/engines/cine/sound.cpp
@@ -1564,7 +1564,7 @@ void PaulaSound::musicTimerCallback() {
 const int PaulaSound::_channelBalance[NUM_CHANNELS] = {
 	// L/R/R/L This is according to the Hardware Reference Manual.
 	// TODO: It seems the order is swapped for some Amiga models:
-	// http://www.amiga.org/forums/archive/index.php/t-7862.html
+	// https://forum.amiga.org/index.php?topic=7862.0
 	// Maybe we should consider using R/L/L/R to match Amiga 500?
 	// This also is a bit more drastic to what WineUAE defaults,
 	// which is only 70% of full panning.

--- a/engines/groovie/video/roq.cpp
+++ b/engines/groovie/video/roq.cpp
@@ -20,7 +20,7 @@
  */
 
 // ROQ video player based on this specification by Dr. Tim Ferguson:
-// http://www.csse.monash.edu.au/~timf/videocodec/idroq.txt
+// https://multimedia.cx/mirror/idroq.txt
 
 #include "groovie/video/roq.h"
 #include "groovie/graphics.h"

--- a/engines/made/made.cpp
+++ b/engines/made/made.cpp
@@ -192,7 +192,7 @@ void MadeEngine::handleEvents() {
 
 		case Common::EVENT_KEYDOWN:
 			// Handle any special keys here
-			// Supported keys taken from http://www.allgame.com/game.php?id=13542&tab=controls
+			// Supported keys taken from https://web.archive.org/web/20141114142447/http://www.allgame.com/game.php?id=13542&tab=controls
 
 			switch (event.kbd.keycode) {
 			case Common::KEYCODE_KP_PLUS:	// action (same as left mouse click)

--- a/engines/made/scriptfuncs.cpp
+++ b/engines/made/scriptfuncs.cpp
@@ -334,7 +334,7 @@ int16 ScriptFunctions::sfPlayNote(int16 argc, int16 *argv) {
 	// depending on which of the 3 keys on the right has been pressed.
 	// This value seems to be [12, 14] in NE and [1, 3] in EGA.
 
-	// Note frequencies based on http://www.phy.mtu.edu/~suits/notefreqs.html
+	// Note frequencies based on https://pages.mtu.edu/~suits/notefreqs.html
 	static const int freqTable[] = {
 		16, 17, 18, 19, 21, 22, 23, 24, 26, 28, 29,
 		30, 32, 35, 37, 39, 41, 44, 46, 49, 52, 55,

--- a/engines/saga2/shorten.cpp
+++ b/engines/saga2/shorten.cpp
@@ -27,7 +27,7 @@
 #include "saga2/shorten.h"
 
 // Based on etree's Shorten tool, version 3.6.1
-// http://etree.org/shnutils/shorten/
+// http://shnutils.freeshell.org/shorten/
 // and
 // https://github.com/soiaf/Java-Shorten-decoder
 

--- a/engines/sci/detection_tables.h
+++ b/engines/sci/detection_tables.h
@@ -993,7 +993,7 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		Common::EN_ANY, Common::kPlatformWindows, ADGF_DEMO, GUIO_GK2_DEMO },
 
 	// Gabriel Knight 2 - English DOS (GOG version) - ressci.* merged in ressci.000
-	// using Enrico Rolfi's HD/DVD installer: http://gkpatches.vogons.zetafleet.com/
+	// using Enrico Rolfi's HD/DVD installer: https://gkpatches.vogons.org/english.php
 	{"gk2", "", {
 		{"resmap.000", 0, "b996fa1e57389a1e179a00a0049de1f4", 8110},
 		{"ressci.000", 0, "a19fc3604c6e5407abcf03d59ee87217", 168522221},
@@ -1001,13 +1001,13 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		Common::EN_ANY, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_GK2 },
 	
 	// Gabriel Knight 2 - Korean DOS (GOG version) (from swkim01)
-    // using swkim01's SCI Message Editor: http://github.com/swkim01/scime/
-    {"gk2", "", {
-        {"resmap.000", 0, "b996fa1e57389a1e179a00a0049de1f4", 8110},
-        {"ressci.000", 0, "a19fc3604c6e5407abcf03d59ee87217", 168522221},
-        {"resource.msg", 0, "1c4439abcfda38be40090a37a91ad7d2", 331954},
-        AD_LISTEND},
-        Common::KO_KOR, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_GK2 },
+	// using swkim01's SCI Message Editor: http://github.com/swkim01/scime/
+	{"gk2", "", {
+		{"resmap.000", 0, "b996fa1e57389a1e179a00a0049de1f4", 8110},
+		{"ressci.000", 0, "a19fc3604c6e5407abcf03d59ee87217", 168522221},
+		{"resource.msg", 0, "1c4439abcfda38be40090a37a91ad7d2", 331954},
+		AD_LISTEND},
+		Common::KO_KOR, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_GK2 },
 
 	// Gabriel Knight 2 - English DOS (from jvprat)
 	// Executable scanning reports "2.100.002", VERSION file reports "1.1"

--- a/engines/sci/engine/kfile.cpp
+++ b/engines/sci/engine/kfile.cpp
@@ -117,7 +117,7 @@ reg_t kDeviceInfo(EngineState *s, int argc, reg_t *argv) {
 		return NULL_REG;
 	}
 	/* SCI uses these in a less-than-portable way to delete savegames.
-	** Read http://www-plan.cs.colorado.edu/creichen/freesci-logs/2005.10/log20051019.html
+	** Read https://web.archive.org/web/20060913122014/http://www-plan.cs.colorado.edu/creichen/freesci-logs/2005.10/log20051019.html
 	** for more information on our workaround for this.
 	*/
 	case K_DEVICE_INFO_GET_SAVECAT_NAME: {

--- a/engines/sci/engine/kmisc.cpp
+++ b/engines/sci/engine/kmisc.cpp
@@ -462,7 +462,7 @@ reg_t kGetConfig(EngineState *s, int argc, reg_t *argv) {
 }
 
 // Likely modelled after the Windows 3.1 function GetPrivateProfileInt:
-// http://msdn.microsoft.com/en-us/library/windows/desktop/ms724345%28v=vs.85%29.aspx
+// https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getprivateprofileint
 reg_t kGetSierraProfileInt(EngineState *s, int argc, reg_t *argv) {
 	if (g_sci->getPlatform() != Common::kPlatformWindows) {
 		return s->r_acc;

--- a/engines/sci/sound/drivers/adlib.cpp
+++ b/engines/sci/sound/drivers/adlib.cpp
@@ -277,7 +277,7 @@ void MidiDriver_AdLib::setVolume(byte volume) {
 	renewNotes(-1, true);
 }
 
-// MIDI messages can be found at http://www.midi.org/techspecs/midimessages.php
+// MIDI messages can be found at https://web.archive.org/web/20120128110425/http://www.midi.org/techspecs/midimessages.php
 void MidiDriver_AdLib::send(uint32 b) {
 	byte command = b & 0xf0;
 	byte channel = b & 0xf;

--- a/engines/sci/sound/drivers/fb01.cpp
+++ b/engines/sci/sound/drivers/fb01.cpp
@@ -575,7 +575,7 @@ int MidiPlayer_Fb01::open(ResourceManager *resMan) {
 		// Early SCI0 games have the sound bank embedded in the IMF driver.
 		// Note that these games didn't actually support the FB-01 as a device,
 		// but the IMF, which is the same device on an ISA card. Check:
-		// http://wiki.vintage-computer.com/index.php/IBM_Music_feature_card
+		// https://en.wikipedia.org/wiki/IBM_Music_Feature_Card
 
 		warning("FB-01 patch file not found, attempting to load sound bank from IMF.DRV");
 		// Try to load sound bank from IMF.DRV

--- a/engines/scumm/players/player_pce.cpp
+++ b/engines/scumm/players/player_pce.cpp
@@ -21,8 +21,8 @@
 
 /*
  * The PSG_HuC6280 class is based on the HuC6280 sound chip emulator
- * by Charles MacDonald (E-mail: cgfm2@hotmail.com, WWW: http://cgfm2.emuviews.com)
- * The implementation used here was taken from MESS (http://www.mess.org/)
+ * by Charles MacDonald (E-mail: cgfm2@hotmail.com, WWW: http://www.techno-junk.org)
+ * The implementation used here was taken from MESS (http://mess.redump.net)
  * the Multiple Emulator Super System (sound/c6280.c).
  * LFO and noise channel support have been removed (not used by Loom PCE).
  */

--- a/engines/scumm/players/player_sid.cpp
+++ b/engines/scumm/players/player_sid.cpp
@@ -42,7 +42,7 @@ namespace Scumm {
  * For more info on the SID chip see:
  * - http://www.dopeconnection.net/C64_SID.htm (German)
  * For more info on the VIC chip see:
- * - http://www.htu.tugraz.at/~herwig/c64/man-vic.php (German)
+ * - https://riff.2ix.at/c64/print.php?dok=man-vic (German)
  * - http://www.c64-wiki.de/index.php/VIC (German)
  */
 

--- a/engines/sherlock/scalpel/drivers/adlib.cpp
+++ b/engines/sherlock/scalpel/drivers/adlib.cpp
@@ -385,7 +385,7 @@ void MidiDriver_SH_AdLib::resetAdLibFMVoiceChannelRegisters(byte baseRegister, b
 	}
 }
 
-// MIDI messages can be found at http://www.midi.org/techspecs/midimessages.php
+// MIDI messages can be found at https://web.archive.org/web/20120128110425/http://www.midi.org/techspecs/midimessages.php
 void MidiDriver_SH_AdLib::send(uint32 b) {
 	byte command = b & 0xf0;
 	byte channel = b & 0xf;

--- a/engines/sherlock/scalpel/drivers/mt32.cpp
+++ b/engines/sherlock/scalpel/drivers/mt32.cpp
@@ -246,7 +246,7 @@ void MidiDriver_MT32::mt32SysEx(const byte *&dataPtr, int32 &bytesLeft) {
 	g_system->delayMillis(delay);
 }
 
-// MIDI messages can be found at http://www.midi.org/techspecs/midimessages.php
+// MIDI messages can be found at https://web.archive.org/web/20120128110425/http://www.midi.org/techspecs/midimessages.php
 void MidiDriver_MT32::send(uint32 b) {
 	byte command = b & 0xf0;
 	byte channel = b & 0xf;

--- a/engines/sword25/gfx/image/art.cpp
+++ b/engines/sword25/gfx/image/art.cpp
@@ -1051,7 +1051,7 @@ static bool art_pri_empty(ArtPriQ *pq) {
 }
 
 /* This heap implementation is based on Vasek Chvatal's course notes:
-   http://www.cs.rutgers.edu/~chvatal/notes/pq.html#heap */
+   https://users.encs.concordia.ca/~chvatal/notes/pq.html#heap */
 
 static void art_pri_bubble_up(ArtPriQ *pq, int vacant, ArtPriPoint *missing) {
 	ArtPriPoint **items = pq->items;

--- a/engines/tinsel/detection_tables.h
+++ b/engines/tinsel/detection_tables.h
@@ -36,7 +36,7 @@ static const TinselGameDescription gameDescriptions[] = {
 
 	// ==== Discworld 1 early (TinselV0) entries ==============================
 
-	{	// Floppy Demo V0 from http://www.adventure-treff.de/specials/dl_demos.php
+	{	// Floppy Demo V0 from https://web.archive.org/web/20100415160943/http://www.adventure-treff.de/specials/dl_demos.php
 		{
 			"dw",
 			"Floppy Demo",

--- a/engines/toon/picture.cpp
+++ b/engines/toon/picture.cpp
@@ -271,7 +271,7 @@ uint8 Picture::getData(int16 x, int16 y) {
 void Picture::floodFillNotWalkableOnMask(int16 x, int16 y) {
 	debugC(1, kDebugPicture, "floodFillNotWalkableOnMask(%d, %d)", x, y);
 	// Stack-based floodFill algorithm based on
-	// http://student.kuleuven.be/~m0216922/CG/files/floodfill.cpp
+	// https://web.archive.org/web/20100825020453/http://student.kuleuven.be/~m0216922/CG/files/floodfill.cpp
 	Common::Stack<Common::Point> stack;
 	stack.push(Common::Point(x, y));
 	while (!stack.empty()) {

--- a/engines/twine/resources/hqr.h
+++ b/engines/twine/resources/hqr.h
@@ -33,7 +33,7 @@ class TwinEEngine;
 /**
  * High Quality Resource
  *
- * http://lbafileinfo.kazekr.net/index.php?title=High_quality_resource
+ * https://web.archive.org/web/20181218233826/http://lbafileinfo.kazekr.net/index.php?title=High_quality_resource
  */
 namespace HQR {
 

--- a/engines/twine/scene/gamestate.cpp
+++ b/engines/twine/scene/gamestate.cpp
@@ -141,7 +141,7 @@ void GameState::initEngineVars() {
 	_engine->_actor->_previousHeroBehaviour = HeroBehaviourType::kNormal;
 }
 
-// http://lbafileinfo.kazekr.net/index.php?title=LBA1:Savegame
+// https://web.archive.org/web/*/http://lbafileinfo.kazekr.net/index.php?title=LBA1:Savegame
 bool GameState::loadGame(Common::SeekableReadStream *file) {
 	if (file == nullptr) {
 		return false;

--- a/engines/ultima/nuvie/files/u6_lzw.cpp
+++ b/engines/ultima/nuvie/files/u6_lzw.cpp
@@ -21,7 +21,7 @@
 
 //
 // This code is a modified version of the code from nodling's Ultima 6 website.
-// http://www.geocities.com/nodling/
+// https://web.archive.org/web/20091019144234/http://www.geocities.com/nodling/
 //
 
 // =============================================================

--- a/engines/ultima/nuvie/misc/u6_misc.cpp
+++ b/engines/ultima/nuvie/misc/u6_misc.cpp
@@ -719,7 +719,7 @@ void scaleLine8Bit(unsigned char *Target, unsigned char *Source, int SrcWidth, i
 	} /* while */
 }
 
-//Coarse 2D scaling from http://www.compuphase.com/graphic/scale.htm
+// Coarse 2D scaling from https://web.archive.org/web/20111011173251/http://www.compuphase.com/graphic/scale.htm
 void scale_rect_8bit(unsigned char *Source, unsigned char *Target, int SrcWidth, int SrcHeight,
 					 int TgtWidth, int TgtHeight) {
 	int NumPixels = TgtHeight;

--- a/engines/ultima/ultima4/core/lzw/lzw.cpp
+++ b/engines/ultima/ultima4/core/lzw/lzw.cpp
@@ -30,7 +30,8 @@
  * But since U4 uses a hash table in the decoder, this C version must do the same (or it won't be
  * able to decode the U4 files).
  * An article on LZW data (de)compression can be found here:
- * http://dogma.net/markn/articles/lzw/lzw.htm
+ * https://marknelson.us/posts/1989/10/01/lzw-data-compression.html
+ * https://marknelson.us/posts/2011/11/08/lzw-revisited.html
  */
 
 #include "ultima/ultima4/core/lzw/lzw.h"

--- a/engines/ultima/ultima4/core/utils.h
+++ b/engines/ultima/ultima4/core/utils.h
@@ -35,7 +35,7 @@ extern void assertMsg(bool exp, const char *desc, ...);
 /* The AdjustValue functions used to be #define'd macros, but these are
  * evil for several reasons, *especially* when they contain multiple
  * statements, and have if statements in them. The macros did both.
- * See http://www.parashift.com/c++-faq-lite/inline-functions.html#faq-9.5
+ * See https://isocpp.org/wiki/faq/inline-functions#inline-vs-macros
  * for more information.
  */
 inline void AdjustValueMax(int &v, int val, int max) {

--- a/engines/ultima/ultima4/gfx/screen.h
+++ b/engines/ultima/ultima4/gfx/screen.h
@@ -166,7 +166,7 @@ private:
 	 *   "Improvements to a Fast Algorithm for Calculating Shading
 	 *   and Visibility in a Two-Dimensional Field"
 	 *   -----
-	 *   http://www.fadden.com/techmisc/fast-los.html
+	 *   https://fadden.com/tech/fast-los.html
 	 *
 	 * This function uses a lookup table to get the correct shadowmap,
 	 * therefore, the table will need to be updated if the viewport

--- a/engines/ultima/ultima8/graphics/fonts/font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/font.cpp
@@ -59,7 +59,7 @@ bool Font::SJISTraits::canBreakAfter(Std::string::const_iterator &i) {
 	Std::string::const_iterator j = i;
 	uint32 u1 = unicode(j);
 
-	// See: http://www.wesnoth.org/wiki/JapaneseTranslation#Word-Wrapping
+	// See: https://wiki.wesnoth.org/index.php?title=JapaneseTranslation&oldid=23480#Word-Wrapping
 	// and: http://ja.wikipedia.org/wiki/%E7%A6%81%E5%89%87
 
 	switch (u1) {

--- a/engines/ultima/ultima8/usecode/uc_machine.cpp
+++ b/engines/ultima/ultima8/usecode/uc_machine.cpp
@@ -319,7 +319,7 @@ void UCMachine::execProcess(UCProcess *p) {
 
 			// REALLY MAJOR HACK:
 			// see docs/u8bugs.txt and
-			// http://sourceforge.net/tracker/index.php?func=detail&aid=2025145&group_id=53819&atid=471706
+			// https://sourceforge.net/p/pentagram/bugs/196/
 			if (GAME_IS_U8 && p->_classId == 0x7C) {
 				if (!strcmp(str, " Irgendetwas stimmt nicht!")) {
 					str[25] = '.'; // ! to .
@@ -412,7 +412,7 @@ void UCMachine::execProcess(UCProcess *p) {
 
 			// REALLY MAJOR HACK:
 			// see docs/u8bugs.txt and
-			// https://sourceforge.net/tracker/index.php?func=detail&aid=1018748&group_id=53819&atid=471709
+			// https://sourceforge.net/p/pentagram/feature-requests/6/
 			if (GAME_IS_U8 && p->_classId == 0x48B && func == 0xD0) {
 				// 0xD0 = setAvatarInStasis
 				_globals->setEntries(0, 1, 1);

--- a/engines/wintermute/detection_tables.h
+++ b/engines/wintermute/detection_tables.h
@@ -461,7 +461,7 @@ static const WMEGameDescription gameDescriptions[] = {
 	WME_WINENTRY("bickadoodle", "Version 1.2",
 		WME_ENTRY1s("data.dcp", "1796a48f3ed72dd785ce93334ab883cc", 35337760), Common::EN_ANY, ADGF_UNSTABLE, WME_1_9_1),
 
-	// Bickadoodle (download from http://aethericgames.com/games/bickadoodle/download-bickadoodle/)
+	// Bickadoodle (https://web.archive.org/web/20150516210632/http://aethericgames.com/games/bickadoodle/download-bickadoodle/)
 	WME_WINENTRY("bickadoodle", "",
 		WME_ENTRY1s("data.dcp", "1584d83577c32add0fce27fae91141a2", 35337728), Common::EN_ANY, ADGF_UNSTABLE, WME_1_9_1),
 

--- a/engines/wintermute/ext/dll_httpconnect.cpp
+++ b/engines/wintermute/ext/dll_httpconnect.cpp
@@ -21,7 +21,7 @@
 
 /*
  * This file is based on WME Lite.
- * http://dead-code.org/redir.php?target=wmelite
+ * http://res.dead-code.org/doku.php/wmelite:start
  * Copyright (c) 2011 Jan Nedoma
  */
 

--- a/engines/wintermute/ext/wme_steam.cpp
+++ b/engines/wintermute/ext/wme_steam.cpp
@@ -21,7 +21,7 @@
 
 /*
  * This file is based on WME Steam Plugin.
- * https://bitbucket.org/MnemonicWME/wme_steam_plugin
+ * https://archive.softwareheritage.org/browse/origin/directory/?origin_url=https://bitbucket.org/MnemonicWME/wme_steam_plugin
  * Copyright (c) 2013 Jan Nedoma
  */
 

--- a/graphics/fonts/macfont.cpp
+++ b/graphics/fonts/macfont.cpp
@@ -312,7 +312,7 @@ bool MacFONTFont::loadFont(Common::SeekableReadStream &stream, MacFontFamily *fa
 
 	// If positive, _nDescent holds the high bits of the offset to the
 	// width/offset table.
-	// http://mirror.informatimago.com/next/developer.apple.com/documentation/mac/Text/Text-252.html
+	// https://web.archive.org/web/20080724120946/developer.apple.com/documentation/mac/Text/Text-252.html
 	if (_data._nDescent > 0)
 		_data._owTLoc |= _data._nDescent << 16;
 

--- a/graphics/fonts/ttf.cpp
+++ b/graphics/fonts/ttf.cpp
@@ -465,7 +465,7 @@ Common::SeekableReadStream *TTFFont::readTTFTable(FT_ULong tag) const {
 int TTFFont::readPointSizeFromVDMXTable(int height) const {
 	// The Vertical Device Metrics table matches font heights with point sizes.
 	// FreeType does not expose it, we have to parse it ourselves.
-	// See https://www.microsoft.com/typography/otspec/vdmx.htm
+	// See https://docs.microsoft.com/en-us/typography/opentype/spec/vdmx
 
 	Common::ScopedPtr<Common::SeekableReadStream> vdmxBuf(readTTFTable(TTAG_VDMX));
 	if (!vdmxBuf) {

--- a/graphics/macgui/macfontmanager.cpp
+++ b/graphics/macgui/macfontmanager.cpp
@@ -32,7 +32,7 @@
 namespace Graphics {
 
 // Source: Apple IIGS Technical Note #41, "Font Family Numbers"
-// http://apple2.boldt.ca/?page=til/tn.iigs.041
+// https://www.1000bit.it/support/manuali/apple/technotes/iigs/tn.iigs.041.html
 static struct FontProto {
 	int id;
 	Common::Language lang;

--- a/graphics/scaler/hq.cpp
+++ b/graphics/scaler/hq.cpp
@@ -195,7 +195,7 @@ static inline uint32 ConvertYUV(uint32 x, const uint32 *RGBtoYUV) {
 
 /*
  * The HQ2x high quality 2x graphics filter.
- * Original author Maxim Stepin (see http://www.hiend3d.com/hq2x.html).
+ * Original author Maxim Stepin (https://web.archive.org/web/20090204033742/http://www.hiend3d.com/hq2x.html).
  * Adapted for ScummVM to 16 bit output and optimized by Max Horn.
  */
 template<typename ColorMask>
@@ -2112,7 +2112,7 @@ static void HQ2x_implementation(const uint8 *srcPtr, uint32 srcPitch, uint8 *dst
 
 /*
  * The HQ3x high quality 3x graphics filter.
- * Original author Maxim Stepin (see http://www.hiend3d.com/hq3x.html).
+ * Original author Maxim Stepin (https://web.archive.org/web/20090203211353/http://www.hiend3d.com/hq3x.html).
  * Adapted for ScummVM to 16 bit output and optimized by Max Horn.
  */
 template<typename ColorMask>

--- a/graphics/scaler/pm.cpp
+++ b/graphics/scaler/pm.cpp
@@ -23,7 +23,7 @@
 
 //
 // Code taken from Pablo Medina (aka "pm") (pjmedina3@yahoo.com)
-// You can find it here: http://2xpm.freeservers.com
+// You can find it here: https://web.archive.org/web/20051018114450/http://2xpm.freeservers.com/ 
 // Thanks for his great work
 // Implemented and fixed for ScummVM by Johannes Schickel (aka "LordHoto") (lordhoto [at] gmail [dot] com)
 //

--- a/graphics/scaler/scale2x.cpp
+++ b/graphics/scaler/scale2x.cpp
@@ -24,7 +24,7 @@
  *
  * You can find an high level description of the effect at :
  *
- * http://scale2x.sourceforge.net/
+ * https://www.scale2x.it
  *
  * Alternatively at the previous license terms, you are allowed to use this
  * code in your program with these conditions:

--- a/graphics/scaler/scale3x.cpp
+++ b/graphics/scaler/scale3x.cpp
@@ -24,7 +24,7 @@
  *
  * You can find an high level description of the effect at :
  *
- * http://scale2x.sourceforge.net/
+ * https://www.scale2x.it
  *
  * Alternatively at the previous license terms, you are allowed to use this
  * code in your program with these conditions:

--- a/graphics/scaler/scalebit.cpp
+++ b/graphics/scaler/scalebit.cpp
@@ -25,7 +25,7 @@
  *
  * You can find an high level description of the effect at :
  *
- * http://scale2x.sourceforge.net/
+ * https://www.scale2x.it
  *
  * Alternatively at the previous license terms, you are allowed to use this
  * code in your program with these conditions:

--- a/graphics/scaler/scalebit.h
+++ b/graphics/scaler/scalebit.h
@@ -25,7 +25,7 @@
  *
  * You can find an high level description of the effect at :
  *
- * http://scale2x.sourceforge.net/
+ * https://www.scale2x.it
  *
  * Alternatively at the previous license terms, you are allowed to use this
  * code in your program with these conditions:

--- a/image/pcx.cpp
+++ b/image/pcx.cpp
@@ -30,7 +30,7 @@
  * Based on the PCX specs:
  * http://www.fileformat.info/format/pcx/spec/a10e75307b3a4cc49c3bbe6db4c41fa2/view.htm
  * and the PCX decoder of FFmpeg (libavcodec/pcx.c):
- * http://git.videolan.org/?p=ffmpeg.git;a=blob;f=libavcodec/pcx.c
+ * https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/HEAD:/libavcodec/pcx.c
  */
 
 namespace Image {

--- a/image/pict.cpp
+++ b/image/pict.cpp
@@ -32,8 +32,8 @@
 namespace Image {
 
 // The PICT code is based off of the QuickDraw specs:
-// http://developer.apple.com/legacy/mac/library/documentation/mac/QuickDraw/QuickDraw-461.html
-// http://developer.apple.com/legacy/mac/library/documentation/mac/QuickDraw/QuickDraw-269.html
+// https://developer.apple.com/library/archive/documentation/mac/QuickDraw/QuickDraw-461.html
+// https://developer.apple.com/library/archive/documentation/mac/QuickDraw/QuickDraw-269.html
 
 PICTDecoder::PICTDecoder() {
 	_outputSurface = 0;
@@ -306,7 +306,7 @@ void PICTDecoder::unpackBitsRect(Common::SeekableReadStream &stream, bool withPa
 
 	// Read in the palette if there is one present
 	if (withPalette) {
-		// See http://developer.apple.com/legacy/mac/library/documentation/mac/QuickDraw/QuickDraw-267.html
+		// See https://developer.apple.com/library/archive/documentation/mac/QuickDraw/QuickDraw-267.html
 		stream.readUint32BE(); // seed
 		stream.readUint16BE(); // flags
 		_paletteColorCount = stream.readUint16BE() + 1;
@@ -537,8 +537,8 @@ void PICTDecoder::skipBitsRect(Common::SeekableReadStream &stream, bool withPale
 }
 
 // Compressed QuickTime details can be found here:
-// http://developer.apple.com/legacy/mac/library/#documentation/QuickTime/Rm/CompressDecompress/ImageComprMgr/B-Chapter/2TheImageCompression.html
-// http://developer.apple.com/legacy/mac/library/#documentation/QuickTime/Rm/CompressDecompress/ImageComprMgr/F-Chapter/6WorkingwiththeImage.html
+// https://developer.apple.com/library/archive/documentation/QuickTime/RM/CompressDecompress/ImageComprMgr/B-Chapter/2TheImageCompression.html
+// https://developer.apple.com/library/archive/documentation/QuickTime/RM/CompressDecompress/ImageComprMgr/F-Chapter/6WorkingwiththeImage.html
 void PICTDecoder::decodeCompressedQuickTime(Common::SeekableReadStream &stream) {
 	// First, read all the fields from the opcode
 	uint32 dataSize = stream.readUint32BE();

--- a/math/matrix3.cpp
+++ b/math/matrix3.cpp
@@ -43,7 +43,7 @@ void Matrix<3, 3>::transpose() {
 
 /**
  * Generates a lookat matrix. For reference, see
- * http://clb.demon.fi/MathGeoLib/docs/float3x3_LookAt.php
+ * http://clb.confined.space/MathGeoLib/nightly/docs/float3x3_LookAt.php
  */
 void Matrix<3, 3>::buildFromTargetDir(const Math::Vector3d &modelForward, const Math::Vector3d &targetDirection,
 									  const Math::Vector3d &modelUp, const Math::Vector3d &worldUp) {

--- a/math/matrix4.cpp
+++ b/math/matrix4.cpp
@@ -94,7 +94,7 @@ void Matrix<4, 4>::translate(const Vector3d &vec) {
 
 /**
  * Generates a lookat matrix. For reference, see
- * http://clb.demon.fi/MathGeoLib/docs/float3x3_LookAt.php
+ * http://clb.confined.space/MathGeoLib/nightly/docs/float3x3_LookAt.php
  */
 void Matrix<4, 4>::buildFromTargetDir(const Math::Vector3d &modelForward, const Math::Vector3d &targetDirection,
 									  const Math::Vector3d &modelUp, const Math::Vector3d &worldUp)

--- a/math/quat.cpp
+++ b/math/quat.cpp
@@ -31,7 +31,7 @@
  * This code (and our modifications) is made available here under the GPLv2 (or later).
  *
  * Additional changes written based on the math presented in
- * http://www.swarthmore.edu/NatSci/mzucker1/e27/diebel2006attitude.pdf
+ * https://web.archive.org/web/20120710204808/http://www.swarthmore.edu/NatSci/mzucker1/e27/diebel2006attitude.pdf
  *
  */
 

--- a/video/psx_decoder.cpp
+++ b/video/psx_decoder.cpp
@@ -20,7 +20,7 @@
  */
 
 // PlayStation Stream demuxer based on FFmpeg/libav
-// MDEC video emulation based on http://kenai.com/downloads/jpsxdec/Old/PlayStation1_STR_format1-00.txt
+// MDEC video emulation based on https://web.archive.org/web/20170411092531/https://kenai.com/downloads/jpsxdec/Old/PlayStation1_STR_format1-00.txt
 
 #include "audio/audiostream.h"
 #include "audio/decoders/adpcm.h"

--- a/video/smk_decoder.cpp
+++ b/video/smk_decoder.cpp
@@ -21,7 +21,7 @@
 
 // Based on http://wiki.multimedia.cx/index.php?title=Smacker
 // and the FFmpeg Smacker decoder (libavcodec/smacker.c), revision 16143
-// http://git.ffmpeg.org/?p=ffmpeg;a=blob;f=libavcodec/smacker.c;hb=b8437a00a2f14d4a437346455d624241d726128e
+// https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/40a19c443430de520d86bbd644033c8e2ca87e9b
 
 #include "video/smk_decoder.h"
 
@@ -713,7 +713,7 @@ void SmackerDecoder::SmackerVideoTrack::decodeFrame(Common::BitStreamMemory8LSB 
 						for (i = 0; i < 2; i++) {
 							// We first get p2 and then p1
 							// Check ffmpeg thread "[PATCH] Smacker video decoder bug fix"
-							// http://article.gmane.org/gmane.comp.video.ffmpeg.devel/78768
+							// https://ffmpeg.org/pipermail/ffmpeg-devel/2008-December/044246.html
 							p2 = _FullTree->getCode(bs);
 							p1 = _FullTree->getCode(bs);
 							for (j = 0; j < doubleY; ++j) {

--- a/video/smk_decoder.h
+++ b/video/smk_decoder.h
@@ -48,7 +48,7 @@ class BigHuffmanTree;
  *
  * Based on http://wiki.multimedia.cx/index.php?title=Smacker
  * and the FFmpeg Smacker decoder (libavcodec/smacker.c), revision 16143
- * http://svn.ffmpeg.org/ffmpeg/trunk/libavcodec/smacker.c?revision=16143&view=markup
+ * https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/40a19c443430de520d86bbd644033c8e2ca87e9b
  *
  * Video decoder used in engines:
  *  - agos


### PR DESCRIPTION
"Cool URIs don't change" until they do!

Some reference URLs are now gone (thanks to to the Wayback machine for bringing them back!) or have moved somewhere else. So this PR tries to keep as many available resources as possible. 

I didn't touch what was vendored more or less recently (e.g. nanosvg) so that it won't cause any unnecessary conflict if you need to sync it with upstream at some point, and there are also some very old comments (e.g. in the Symbian backend) for which I'm not sure it would have much sense to make this kind of change.