### PR TITLE
SCI: fix sound pausing when loading via kRestoreGame

### DIFF
--- a/engines/sci/engine/kfile.cpp
+++ b/engines/sci/engine/kfile.cpp
@@ -1238,10 +1238,11 @@ reg_t kRestoreGame(EngineState *s, int argc, reg_t *argv) {
 		s->r_acc = TRUE_REG; // signals failure
 	}
 
-	if (!s->r_acc.isNull()) {
-		// no success?
-		if (pausedMusic)
+	if (pausedMusic) {
+		if (!s->r_acc.isNull()) // no success?
 			g_sci->_soundCmd->pauseAll(false); // unpause music
+		else
+			g_sci->_soundCmd->resetGlobalPauseCounter(); // reset music global pause counter without affecting the individual sounds
 	}
 
 	return s->r_acc;

--- a/engines/sci/sound/music.cpp
+++ b/engines/sci/sound/music.cpp
@@ -294,6 +294,28 @@ void SciMusic::pauseAll(bool pause) {
 	}
 }
 
+void SciMusic::resetGlobalPauseCounter() {
+	// This is an adjustment for our savegame loading process,
+	// ONLY when done from kRestoreGame().
+	// The enginge will call SciMusic::pauseAll() before loading.
+	// So the _globalPause will be increased and the individual
+	// sounds will be paused, too. However, the sounds will
+	// then be restored to the playing status that is stored in
+	// the savegame. The _globalPause stays, however. There may
+	// be no unpausing after the loading, since the playing status
+	// in the savegames is the correct one. So, the essence is:
+	// the _globalPause counter needs to go down without anything
+	// else happening.
+	// The loading from GMM has been implemented differently. It
+	// will remove the paused state before loading (and doesn't
+	// do anything unpleasant afterwards, either). So this is not
+	// needed there.
+	// I have added an assert, since it is such a special case,
+	// people need to know what they're doing if they call this...
+	assert(_globalPause == 1);
+	_globalPause = 0;
+}
+
 void SciMusic::stopAll() {
 	const MusicList::iterator end = _playList.end();
 	for (MusicList::iterator i = _playList.begin(); i != end; ++i) {

--- a/engines/sci/sound/music.h
+++ b/engines/sci/sound/music.h
@@ -193,6 +193,7 @@ private:
 public:
 	void clearPlayList();
 	void pauseAll(bool pause);
+	void resetGlobalPauseCounter();
 	void stopAll();
 	void stopAllSamples();
 

--- a/engines/sci/sound/soundcmd.cpp
+++ b/engines/sci/sound/soundcmd.cpp
@@ -918,6 +918,10 @@ void SoundCommandParser::pauseAll(bool pause) {
 	_music->pauseAll(pause);
 }
 
+void SoundCommandParser::resetGlobalPauseCounter() {
+	_music->resetGlobalPauseCounter();
+}
+
 MusicType SoundCommandParser::getMusicType() const {
 	assert(_music);
 	return _music->soundGetMusicType();

--- a/engines/sci/sound/soundcmd.h
+++ b/engines/sci/sound/soundcmd.h
@@ -55,6 +55,7 @@ public:
 	// Functions used for the ScummVM menus
 	void setMasterVolume(int vol);
 	void pauseAll(bool pause);
+	void resetGlobalPauseCounter();
 #ifdef ENABLE_SCI32
 	void setVolume(const reg_t obj, const int vol);
 #endif


### PR DESCRIPTION
This is similar to what we recently fixed for the saving. It does concern only the loading from the SCI menu and from the SCI death dialog (that's how it got my attention).

I have written a long comment in SciMusic::resetGlobalPauseCounter()  which explains it.

I have decided to make this very obvious (you could say: more ugly), so it won't cause confusion in the future. 