### PR TITLE
HDB: A few menu fixes for Hyperspace Delivery Boy!

### DIFF
--- a/engines/hdb/ai-funcs.cpp
+++ b/engines/hdb/ai-funcs.cpp
@@ -19,6 +19,8 @@
  *
  */
 
+#include "common/config-manager.h"
+
 #include "hdb/hdb.h"
 #include "hdb/ai.h"
 #include "hdb/ai-player.h"
@@ -825,7 +827,7 @@ void AI::killPlayer(Death method) {
 	}
 
 	// sound.StopMusic();
-	if (!g_hdb->_sound->getMusicVolume())
+	if (ConfMan.getInt(CONFIG_MUSICVOL) == 0)
 		g_hdb->_sound->playSound(SND_TRY_AGAIN);
 }
 

--- a/engines/hdb/hdb.cpp
+++ b/engines/hdb/hdb.cpp
@@ -180,8 +180,7 @@ bool HDBGame::init() {
 	_menu->init();
 
 	// Query the selected music device (defaults to MT_AUTO device).
-	Common::String selDevStr = ConfMan.hasKey("music_driver") ? ConfMan.get("music_driver") : Common::String("auto");
-	MidiDriver::DeviceHandle dev = MidiDriver::getDeviceHandle(selDevStr.empty() ? Common::String("auto") : selDevStr);
+	MidiDriver::DeviceHandle dev = MidiDriver::getDeviceHandle(ConfMan.hasKey("music_driver") ? ConfMan.get("music_driver") : Common::String("auto"));
 	_noMusicDriver = (MidiDriver::getMusicType(dev) == MT_NULL || MidiDriver::getMusicType(dev) == MT_INVALID);
 	syncSoundSettings();
 

--- a/engines/hdb/hdb.cpp
+++ b/engines/hdb/hdb.cpp
@@ -36,6 +36,8 @@
 #include "hdb/mpc.h"
 #include "hdb/window.h"
 
+#include "audio/mididrv.h"
+
 #define CHEAT_PATCHES 0
 
 namespace HDB {
@@ -110,7 +112,7 @@ HDBGame::HDBGame(OSystem *syst, const ADGameDescription *gameDesc) : Engine(syst
 	_loadInfo.active = false;
 	_loadInfo.slot = 0;
 
-	syncSoundSettings();
+	_noMusicDriver = false;
 }
 
 HDBGame::~HDBGame() {
@@ -140,6 +142,16 @@ HDBGame::~HDBGame() {
 }
 
 bool HDBGame::init() {
+	// Assign default values to the ScummVM configuration manager, in case settings are missing
+	ConfMan.registerDefault(CONFIG_MUSICVOL, 192);
+	ConfMan.registerDefault(CONFIG_SFXVOL, 192);
+	ConfMan.registerDefault(CONFIG_SPEECHVOL, 192);
+	ConfMan.registerDefault(CONFIG_MUTEALL, "false");
+	ConfMan.registerDefault(CONFIG_NOSPEECH, "false");
+	ConfMan.registerDefault(CONFIG_CHEAT, "false");
+	// Menu::readConfig() takes care of the default values for:
+	// CONFIG_MSTONE7, CONFIG_MSTONE14, CONFIG_MSTONE21
+
 	/*
 		Game Subsystem Initializations
 	*/
@@ -166,6 +178,12 @@ bool HDBGame::init() {
 	_input->init();
 	_lua->init();
 	_menu->init();
+
+	// Query the selected music device (defaults to MT_AUTO device).
+	Common::String selDevStr = ConfMan.hasKey("music_driver") ? ConfMan.get("music_driver") : Common::String("auto");
+	MidiDriver::DeviceHandle dev = MidiDriver::getDeviceHandle(selDevStr.empty() ? Common::String("auto") : selDevStr);
+	_noMusicDriver = (MidiDriver::getMusicType(dev) == MT_NULL || MidiDriver::getMusicType(dev) == MT_INVALID);
+	syncSoundSettings();
 
 	_debugLogo = _gfx->loadIcon("icon_debug_logo");
 	_progressGfx = _gfx->loadPic(PIC_LOADBAR);
@@ -1075,6 +1093,37 @@ Common::Error HDBGame::run() {
 	}
 
 	return Common::kNoError;
+}
+
+void HDBGame::syncSoundSettings() {
+	Engine::syncSoundSettings();
+
+	_mixer->setVolumeForSoundType(_mixer->kMusicSoundType, ConfMan.getInt(CONFIG_MUSICVOL));
+	_mixer->setVolumeForSoundType(_mixer->kSFXSoundType, ConfMan.getInt(CONFIG_SFXVOL));
+	_mixer->setVolumeForSoundType(_mixer->kSpeechSoundType, ConfMan.getInt(CONFIG_SPEECHVOL));
+
+	if (_noMusicDriver) {
+		// This affects *only* the music muting.
+		_mixer->muteSoundType(_mixer->kMusicSoundType, true);
+	}
+
+	bool allSoundIsMuted = false;
+	if (ConfMan.hasKey(CONFIG_MUTEALL)) {
+		allSoundIsMuted = ConfMan.getBool(CONFIG_MUTEALL);
+		if (!_noMusicDriver) {
+			_mixer->muteSoundType(_mixer->kMusicSoundType, allSoundIsMuted);
+		}
+		_mixer->muteSoundType(_mixer->kSFXSoundType, allSoundIsMuted);
+		_mixer->muteSoundType(_mixer->kSpeechSoundType, allSoundIsMuted);
+	}
+
+	if (ConfMan.hasKey(CONFIG_NOSPEECH) && !allSoundIsMuted) {
+		_mixer->muteSoundType(_mixer->kSpeechSoundType, ConfMan.getBool(CONFIG_NOSPEECH));
+		_sound->setVoiceStatus(!ConfMan.getBool(CONFIG_NOSPEECH));
+	}
+
+	// write-back to ini file for persistence
+	ConfMan.flushToDisk();
 }
 
 } // End of namespace HDB

--- a/engines/hdb/hdb.h
+++ b/engines/hdb/hdb.h
@@ -47,6 +47,18 @@ class Picture;
 class Sound;
 class Window;
 
+#define	CONFIG_MUSICVOL     "music_volume"
+#define	CONFIG_SFXVOL       "sfx_volume"
+#define	CONFIG_SPEECHVOL    "speech_volume"
+#define	CONFIG_MSTONE7      "hdb_memory_heap"
+#define	CONFIG_MSTONE14     "lua_stack_offset"
+#define	CONFIG_MSTONE21     "fmod_mix_timer"
+#define	CONFIG_SOUNDCACHE   "sound_cache_max" // Unused
+#define	CONFIG_GFXCACHE     "gfx_cache_max"   // Unused
+#define	CONFIG_CHEAT        "hypercheat"
+#define	CONFIG_NOSPEECH     "speech_mute"
+#define	CONFIG_MUTEALL      "mute"
+
 enum {
 	kTileWidth = 32,
 	kTileHeight = 32,
@@ -143,6 +155,7 @@ public:
 	void initializePath(const Common::FSNode &gamePath) override;
 
 	Common::Error run() override;
+	void syncSoundSettings() override;
 
 	// Detection related members;
 	const ADGameDescription *_gameDescription;
@@ -370,6 +383,7 @@ private:
 		int  slot;
 	} _saveInfo, _loadInfo;
 
+	bool  _noMusicDriver; // If "Music Device" is set to "No Music" from Audio tab
 };
 
 extern HDBGame *g_hdb;

--- a/engines/hdb/menu.cpp
+++ b/engines/hdb/menu.cpp
@@ -346,7 +346,7 @@ void Menu::readConfig() {
 		needFlush = true;
 	}
 
-	if (ConfMan.hasKey(CONFIG_CHEAT)) {
+	if (ConfMan.hasKey(CONFIG_CHEAT) && ConfMan.getBool(CONFIG_CHEAT)) {
 		g_hdb->setCheatingOn();
 		debug("Cheating enabled");
 	}
@@ -366,7 +366,7 @@ void Menu::writeConfig() {
 	ConfMan.setInt(CONFIG_MSTONE21, value);
 
 	if (g_hdb->getCheatingOn())
-		ConfMan.set(CONFIG_CHEAT, "1");
+		ConfMan.setBool(CONFIG_CHEAT, true);
 
 	ConfMan.flushToDisk();
 }

--- a/engines/hdb/menu.cpp
+++ b/engines/hdb/menu.cpp
@@ -1698,20 +1698,20 @@ void Menu::drawRocketAndSelections() {
 
 	// exhaust
 	if (_rocketEx < 5) {
-		_rocketEx1->drawMasked(_mRocketX + _mRocketEXHX, _rocketY + _mRocketYBottom);
+		_rocketEx1->drawMasked(_rocketX + _mRocketEXHX, _rocketY + _mRocketYBottom);
 		if (!g_hdb->isPPC()) {
-			_rocketEx2->drawMasked(_mRocketX + _mRocketEXHX2, _rocketY + _mRocketYBottom);
+			_rocketEx2->drawMasked(_rocketX + _mRocketEXHX2, _rocketY + _mRocketYBottom);
 		}
 	} else if (_rocketEx >= 5 && _rocketEx < 10) {
-		_rocketEx2->drawMasked(_mRocketX + _mRocketEXHX, _rocketY + _mRocketYBottom);
+		_rocketEx2->drawMasked(_rocketX + _mRocketEXHX, _rocketY + _mRocketYBottom);
 		if (!g_hdb->isPPC()) {
-			_rocketEx1->drawMasked(_mRocketX + _mRocketEXHX2, _rocketY + _mRocketYBottom);
+			_rocketEx1->drawMasked(_rocketX + _mRocketEXHX2, _rocketY + _mRocketYBottom);
 		}
 	} else {
 		_rocketEx = 0;
-		_rocketEx1->drawMasked(_mRocketX + _mRocketEXHX, _rocketY + _mRocketYBottom);
+		_rocketEx1->drawMasked(_rocketX + _mRocketEXHX, _rocketY + _mRocketYBottom);
 		if (!g_hdb->isPPC()) {
-			_rocketEx2->drawMasked(_mRocketX + _mRocketEXHX2, _rocketY + _mRocketYBottom);
+			_rocketEx2->drawMasked(_rocketX + _mRocketEXHX2, _rocketY + _mRocketYBottom);
 		}
 	}
 	_rocketEx++;

--- a/engines/hdb/menu.cpp
+++ b/engines/hdb/menu.cpp
@@ -646,7 +646,7 @@ void Menu::drawMenu() {
 
 			// title logo
 			_titleLogo->drawMasked(centerPic(_titleLogo), _rocketY + _mTitleY);
-			_menuBackoutGfx->drawMasked(_backoutX, g_hdb->_menu->_backoutY);
+			_menuBackoutGfx->drawMasked(_backoutX, _backoutY);
 		}
 	} else if (_optionsActive) {
 		//-------------------------------------------------------------------
@@ -711,7 +711,7 @@ void Menu::drawMenu() {
 
 			// title logo
 			_titleLogo->drawMasked(centerPic(_titleLogo), _rocketY + _mTitleY);
-			_menuBackoutGfx->drawMasked(_backoutX, g_hdb->_menu->_backoutY);
+			_menuBackoutGfx->drawMasked(_backoutX, _backoutY);
 
 			// Ignore Controls Screen Button
 			//_controlButtonGfx->drawMasked(centerPic(_controlButtonGfx), _mControlsY);
@@ -756,7 +756,7 @@ void Menu::drawMenu() {
 			_titleLogo->drawMasked(centerPic(_titleLogo), _rocketY + _mTitleY);
 			// CHOOSE SLOT screen
 			_modeLoadGfx->drawMasked(centerPic(_modeLoadGfx), _oBannerY);
-			_menuBackoutGfx->drawMasked(_backoutX, g_hdb->_menu->_backoutY);
+			_menuBackoutGfx->drawMasked(_backoutX, _backoutY);
 
 			if (!g_hdb->isPPC()) {
 				if (_saveGames[kAutoSaveSlot].seconds)
@@ -802,7 +802,7 @@ void Menu::drawMenu() {
 		drawWarpScreen();
 		// title logo
 		_titleLogo->drawMasked(centerPic(_titleLogo), _rocketY + _mTitleY);
-		_menuBackoutGfx->drawMasked(_warpBackoutX, g_hdb->_menu->_warpBackoutY);
+		_menuBackoutGfx->drawMasked(_warpBackoutX, _warpBackoutY);
 
 		Common::String textString;
 		for (int i = 0; i < 10; i++) {
@@ -1373,7 +1373,7 @@ void Menu::processInput(int x, int y) {
 		if (!g_hdb->getCheatingOn())
 			open = (x >= _nebulaX && x < _nebulaX + 16 && y >= _nebulaY && y < _nebulaY + 16);
 		else
-			open = (y > g_hdb->_menu->_menuExitY && x < _menuExitXLeft);
+			open = (y > _menuExitY && x < _menuExitXLeft);
 
 		if (open) {
 
@@ -1389,7 +1389,7 @@ void Menu::processInput(int x, int y) {
 		//-------------------------------------------------------------------
 		int	xit = getMenuKey();
 
-		if (y >= g_hdb->_menu->_menuExitY || y < _menuExitYTop || xit) {
+		if (y >= _menuExitY || y < _menuExitYTop || xit) {
 			_optionsScrolling = true;
 			_optionsXV = -5;
 			g_hdb->_sound->playSound(SND_MENU_BACKOUT);
@@ -1402,7 +1402,7 @@ void Menu::processInput(int x, int y) {
 			_newgameActive = false;
 			g_hdb->changeGameState();
 			// that's it!  the Game Loop takes over from here...
-		} else if (y >= _modeActionY - 10 && y <= g_hdb->_menu->_menuExitY) {
+		} else if (y >= _modeActionY - 10 && y <= _menuExitY) {
 			// ACTION MODE area
 			g_hdb->setActionMode(1);
 			g_hdb->_sound->playSound(SND_MENU_ACCEPT);
@@ -1458,7 +1458,7 @@ void Menu::processInput(int x, int y) {
 				g_hdb->_sound->setVoiceStatus(value);
 				g_hdb->_sound->playSound(SND_GUI_INPUT);
 			}
-		} else if (y >= g_hdb->_menu->_menuExitY || y < _menuExitYTop || xit) {
+		} else if (y >= _menuExitY || y < _menuExitYTop || xit) {
 			g_hdb->_sound->playSound(SND_MENU_BACKOUT);
 			_optionsScrolling = true;
 			_optionsXV = -5;
@@ -1477,7 +1477,7 @@ void Menu::processInput(int x, int y) {
 		//-------------------------------------------------------------------
 		int	xit = getMenuKey();
 
-		if (y >= g_hdb->_menu->_menuExitY + 15 || y < _menuExitYTop || xit) {
+		if (y >= _menuExitY + 15 || y < _menuExitYTop || xit) {
 			_optionsScrolling = true;
 			_optionsXV = -5;
 			g_hdb->_sound->playSound(SND_MENU_BACKOUT);
@@ -1533,7 +1533,7 @@ void Menu::processInput(int x, int y) {
 		//-------------------------------------------------------------------
 		int	xit = getMenuKey();
 
-		if ((y >= g_hdb->_menu->_menuExitY && x < _menuExitXLeft) || xit) {
+		if ((y >= _menuExitY && x < _menuExitXLeft) || xit) {
 			_menuActive = true;
 			_warpActive = false;
 			g_hdb->_sound->playSound(SND_MENU_BACKOUT);

--- a/engines/hdb/menu.cpp
+++ b/engines/hdb/menu.cpp
@@ -251,8 +251,6 @@ Menu::Menu() {
 	_versionGfx = nullptr;
 	_warpGfx = nullptr;
 
-	_warpBackoutX = 0;
-	_warpBackoutY = 0;
 	_titleCycle = 0;
 	_titleDelay = 0;
 	_resumeSong = SONG_NONE;

--- a/engines/hdb/menu.cpp
+++ b/engines/hdb/menu.cpp
@@ -174,7 +174,7 @@ Menu::Menu() {
 	_titleActive = false;
 	_menuActive = false;
 	_optionsActive = false;
-	_optionsScreenId = 0;
+	_optionsScreenId = kOptionsScreenMain;
 	_gamefilesActive = false;
 	_newgameActive = false;
 	_warpActive = false;
@@ -185,7 +185,7 @@ Menu::Menu() {
 	_sayHDB = false;
 	_menuKey = 0;
 
-	_nextScreen = 0;
+	_nextScreen = kMenuOptions;
 
 	_nebulaY = 0;		// Used as a flag
 	_fStars[0].y = 0;	// Used as a flag
@@ -541,14 +541,14 @@ void Menu::drawMenu() {
 			_optionsXV += 3;
 			if (_optionsScrollX > g_hdb->_screenWidth + 10) {
 				switch (_nextScreen) {
-				case 0:
+				case kMenuOptions:
 					_optionsActive = true;
-					_optionsScreenId = 1;
+					_optionsScreenId = kOptionsScreenMain;
 					break;
-				case 1:
+				case kMenuLoadGame:
 					_gamefilesActive = true;
 					break;
-				case 2:
+				case kMenuNewGame:
 					_newgameActive = true;
 					break;
 				default:
@@ -674,12 +674,11 @@ void Menu::drawMenu() {
 				_oBannerY = -48;
 				_optionsScrolling = false;
 				_optionsActive = false;
-				_optionsScreenId = 0;
 				_menuActive = true;
 			}
 
 			drawRocketAndSelections();
-		} else if (_optionsScreenId == 1) {
+		} else if (_optionsScreenId == kOptionsScreenMain) {
 			//
 			// Options menu content
 			//
@@ -721,8 +720,8 @@ void Menu::drawMenu() {
 			_menuBackoutGfx->drawMasked(_backoutX, _backoutY);
 
 			// Ignore Controls Screen Button
-			//_controlButtonGfx->drawMasked(centerPic(_controlButtonGfx), _mControlsY);
-		} else if (_optionsScreenId == 2) {
+			_controlButtonGfx->drawMasked(centerPic(_controlButtonGfx), _mControlsY);
+		} else if (_optionsScreenId == kOptionsScreenModifyControls) {
 			//
 			// Draw CONTROLS screen
 			//
@@ -1306,14 +1305,14 @@ void Menu::processInput(int x, int y) {
 			_optionsXV = 5;
 			g_hdb->_sound->playSound(SND_MENU_ACCEPT);
 			g_hdb->_sound->freeSound(SND_HDB);
-			_nextScreen = 2;
+			_nextScreen = kMenuNewGame;
 		} else if (x >= _menuX && x < _menuX + _menuItemWidth &&
 			y >= _menuY + _mLoadY && y < _menuY + _mLoadY + _menuItemHeight) {
 			// game files?
-				_optionsScrolling = true;
-				_optionsXV = 5;
-				g_hdb->_sound->playSound(SND_MENU_ACCEPT);
-				_nextScreen = 1;
+			_optionsScrolling = true;
+			_optionsXV = 5;
+			g_hdb->_sound->playSound(SND_MENU_ACCEPT);
+			_nextScreen = kMenuLoadGame;
 		} else if (x >= _menuX && x < _menuX + _menuItemWidth &&
 			y >= _menuY + _mOptionsY && y < _menuY + _mOptionsY + _menuItemHeight) {
 			// options?
@@ -1323,7 +1322,7 @@ void Menu::processInput(int x, int y) {
 				_resumeSong = temp;
 			_optionsScrolling = true;
 			_optionsXV = 5;
-			_nextScreen = 0;
+			_nextScreen = kMenuOptions;
 			g_hdb->_sound->playSound(SND_MENU_ACCEPT);
 		} else if (((x >= _menuX && x < _menuX + _menuItemWidth &&
 			y >= _menuY + _mResumeY && y < _menuY + _mResumeY + _menuItemHeight) || resume) &&
@@ -1347,7 +1346,6 @@ void Menu::processInput(int x, int y) {
 				y >= kStarRedY && y <= kStarRedY + _starRedGfx[0]->_height &&
 				g_hdb->getStarsMonkeystone7() == STARS_MONKEYSTONE_7) {
 				_optionsActive = false;
-				_optionsScreenId = 0;
 				g_hdb->setGameState(GAME_PLAY);
 				if (scumm_strnicmp(g_hdb->currentMapName(), "map30", 5))	// don't save if we're already on 30!
 					g_hdb->saveGameState(kAutoSaveSlot, "FIXME"); // Add here date/level name // TODO
@@ -1358,7 +1356,6 @@ void Menu::processInput(int x, int y) {
 				y >= kStarGreenY && y <= kStarGreenY + _starGreenGfx[0]->_height &&
 				g_hdb->getStarsMonkeystone14() == STARS_MONKEYSTONE_14) {
 				_optionsActive = false;
-				_optionsScreenId = 0;
 				g_hdb->setGameState(GAME_PLAY);
 				if (scumm_strnicmp(g_hdb->currentMapName(), "map30", 5))	// don't save if we're already on 30!
 					g_hdb->saveGameState(kAutoSaveSlot, "FIXME"); // Add here date/level name // TODO
@@ -1370,7 +1367,6 @@ void Menu::processInput(int x, int y) {
 				y >= kStarBlueY && y <= kStarBlueY + _starBlueGfx[0]->_height &&
 				g_hdb->getStarsMonkeystone21() == STARS_MONKEYSTONE_21) {
 				_optionsActive = false;
-				_optionsScreenId = 0;
 				g_hdb->setGameState(GAME_PLAY);
 				if (scumm_strnicmp(g_hdb->currentMapName(), "map30", 5))	// don't save if we're already on 30!
 					g_hdb->saveGameState(kAutoSaveSlot, "FIXME"); // Add here date/level name // TODO
@@ -1430,7 +1426,7 @@ void Menu::processInput(int x, int y) {
 		//
 		// Controls screen
 		//
-		if (_optionsScreenId == 2) {
+		if (_optionsScreenId == kOptionsScreenModifyControls) {
 			controlsInput(x, y);
 			return;
 		}
@@ -1483,7 +1479,7 @@ void Menu::processInput(int x, int y) {
 			// CONTROLS BUTTON!
 
 			// Ignore Controls Button
-			//_optionsScreenId = 2;
+			//_optionsScreenId = kOptionsScreenModifyControls;
 			//_clickDelay = 20;
 			//g_hdb->_sound->playSound(SND_POP);
 		}
@@ -1675,13 +1671,13 @@ void Menu::drawRocketAndSelections() {
 
 	// top-down/up scrolling stuff
 	switch (_nextScreen) {
-	case 0:
+	case kMenuOptions:
 		_optionsGfx->drawMasked(centerPic(_optionsGfx), _oBannerY);
 		break;
-	case 1:
+	case kMenuLoadGame:
 		_modeLoadGfx->drawMasked(centerPic(_modeLoadGfx), _oBannerY);
 		break;
-	case 2:
+	case kMenuNewGame:
 		_newGfx->drawMasked(centerPic(_newGfx), _oBannerY);
 		break;
 	default:

--- a/engines/hdb/menu.h
+++ b/engines/hdb/menu.h
@@ -197,8 +197,8 @@ public:
 	Picture	*_starRedGfx[2], *_starGreenGfx[2], *_starBlueGfx[2], *_versionGfx;
 	Picture *_screenshots1gfx, *_screenshots1agfx, *_screenshots2gfx, *_demoPlaqueGfx, *_handangoGfx;
 
-	bool _menuActive, _optionsScrolling, _newgameActive, _sayHDB;
-	int	_gamefilesActive, _clickDelay, _saveSlot, _optionsActive, _quitActive, _warpActive;
+	bool _menuActive, _optionsScrolling, _newgameActive, _sayHDB, _warpActive, _gamefilesActive, _optionsActive, _quitActive;
+	int	_clickDelay, _saveSlot, _optionsScreenId, _quitCounter, _warpMapId;
 	int	_optionsScrollX, _optionsXV, _oBannerY;
 	int	_nextScreen;
 

--- a/engines/hdb/menu.h
+++ b/engines/hdb/menu.h
@@ -28,16 +28,6 @@
 
 namespace HDB {
 
-#define	CONFIG_MUSICVOL		"music_volume"
-#define	CONFIG_SOUNDVOL		"sound_volume"
-#define	CONFIG_MSTONE7		"hdb_memory_heap"
-#define	CONFIG_MSTONE14		"lua_stack_offset"
-#define	CONFIG_MSTONE21		"fmod_mix_timer"
-#define	CONFIG_SOUNDCACHE	"sound_cache_max"
-#define	CONFIG_GFXCACHE		"gfx_cache_max"
-#define	CONFIG_CHEAT		"hypercheat"
-#define	CONFIG_VOICES		"voices"
-
 #define	TITLE_DELAY1		2				// time to wait before OOH OOH
 #define	TITLE_DELAY2		0.5				// time to spend doing OOH OOH
 #define	TITLE_DELAY3		1				// time to wait before ending title

--- a/engines/hdb/menu.h
+++ b/engines/hdb/menu.h
@@ -50,6 +50,17 @@ enum {
 	kMaxStars = 10
 };
 
+enum OptionsScreens {
+	kOptionsScreenMain = 1,          // The main Options screen; Sound Settings and Modify Controls button
+	kOptionsScreenModifyControls = 2 // The controls screen, for viewing and remapping controls (currently not implemented)
+};
+
+enum MenuScreens {
+	kMenuOptions  = 0,
+	kMenuLoadGame = 1,
+	kMenuNewGame  = 2
+};
+
 struct Star {
 	int x, y, speed, anim, delay;
 

--- a/engines/hdb/sound.cpp
+++ b/engines/hdb/sound.cpp
@@ -1678,16 +1678,6 @@ void Sound::playVoice(int index, int actor) {
 	return;
 }
 
-//void Sound::setMusicVolume(int volume) {
-//	_musicVolume = volume;
-//	if (_song1.isPlaying()) {
-//		_song1.setVolume(volume);
-//	}
-//	if (_song2.isPlaying()) {
-//		_song2.setVolume(volume);
-//	}
-//}
-
 void Sound::startMusic(SoundType song) {
 	g_hdb->_menu->saveSong(song);
 

--- a/engines/hdb/sound.h
+++ b/engines/hdb/sound.h
@@ -1468,9 +1468,9 @@ public:
 	bool isPlaying() const;
 	SoundType getSong() const;
 
-	void setVolume(int volume);
-
-	void update();
+	// The update() method is to be used for cross fading, fade-in and fade-out of music
+	// However, it's currently unused and only partially implemented.
+//	void update();
 
 private:
 	static Common::String getFileName(SoundType song);
@@ -1501,16 +1501,6 @@ public:
 	void init();
 	void save(Common::OutSaveFile *out);
 	void loadSaveFile(Common::InSaveFile *in);
-	void setMusicVolume(int value);
-	int getMusicVolume() {
-		return _musicVolume;
-	}
-	void setSFXVolume(int value) {
-		_sfxVolume = value;
-	}
-	int getSFXVolume() {
-		return _sfxVolume;
-	}
 	void setVoiceStatus(bool value) {
 		_voicesOn = value;
 	}
@@ -1518,7 +1508,7 @@ public:
 		return _voicesOn;
 	}
 	void clearPersistent() {
-		memset(&_voicePlayed[0], 0, sizeof(_voicePlayed));
+		memset(_voicePlayed, 0, NUM_VOICES * sizeof(byte));
 	}
 
 	void playSound(int index);
@@ -1539,7 +1529,9 @@ public:
 	void fadeOutMusic(int ramp);
 	void stopMusic();
 	void beginMusic(SoundType song, bool fadeIn, int ramp);
-	void updateMusic();
+	// The updateMusic() method is to be used for cross fading, fade-in and fade-out of music
+	// However, it's currently unused and only partially implemented.
+//	void updateMusic();
 	bool songPlaying(SoundType song);
 	void stopChannel(int channel);
 	int registerSound(const char *name);
@@ -1570,13 +1562,11 @@ public:
 	// Music System Variables
 
 	Song _song1, _song2;
-	int _musicVolume;
 
 	// Sound Caching System Variables
 
 	SoundCache _soundCache[kMaxSounds];
 	int _numSounds;
-	int _sfxVolume;
 	Audio::SoundHandle _handles[kMaxSNDChannels];
 
 };


### PR DESCRIPTION
I've tested HDB Linux for a while, looked into the code and came up with a few quick fixes.
1. Retrieve the "cheats enabled" value properly from ScummVm configuration. Previously, the game would always begin in cheat mode.
2. Set the "back" button for the warp screen in the proper position (where the code sets the hotspot for it). Hopefully this does not break the PPC support, but the code removed for this seemed to be something left over. 
3. Remove the need to access some menu members via _gdb->_menu, which also seemed like leftover code.
4. Separate some members to boolean and integer, since the code previously would use booleans as ids or counters as well, assuming values 0 and 1 for true, false, but also increasing them beyond these values. This should improve readability with minimal cost.
5. Volume synchronization between GMM (ScummVM configuration manager) and the game's volume and volume controls.

Pending known issues (not for this PR): 
- The hotspots for buttons (eg "back button", map selection from warp screen) are a lot broader than they should be. Maybe this is intentional or done like this to support PPC version too, which as far as I can tell has a different layout, without much code branching(?)
- Config is written back only when quitting the game by the quit button. In all other cases (returning via ScummVM's GMM to launcher, closing the window directly), the config for the game is not written back. Edit: This now only refers to settings written in menu.cpp in writeConfig() and readConfig(); the volume related settings which are synched in this PR do not have this issue. 
- Music songs cross fading is effectively disabled. There seems to be some work towards supporting this, but the code is incomplete, and most of it is methods that are never called, or commented out, or methods that use "temporary" code which calls existing methods skipping any fade in or fade out process.
- ~~Sounds volume is not synched between game and GMM / ScummVM configuration for the game. GMM volume settings does not affect the game's sounds volume at all~~ (this is now implemented and part of this PR).
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
