### PR TITLE
SCUMM: Keep the security door closed by default in Maniac Mansion NES

### DIFF
--- a/engines/scumm/object.cpp
+++ b/engines/scumm/object.cpp
@@ -307,7 +307,7 @@ int ScummEngine::getState(int obj) {
 		// it. Fortunately this does not prevent frustrated players from
 		// blowing up the mansion, should they feel the urge to.
 
-		if (_game.id == GID_MANIAC && _game.version != 0 && (obj == 182 || obj == 193))
+		if (_game.id == GID_MANIAC && _game.version != 0 && _game.platform != Common::kPlatformNES && (obj == 182 || obj == 193))
 			_objectStateTable[obj] |= kObjectState_08;
 	}
 


### PR DESCRIPTION
We shouldn't bypass the security door in the NES version of Maniac Mansion: there was no copy protection there (since the game was on a cartridge), so the player is meant to open this door just like a regular door. That, and the associated sound effect, add to the dramatic effect when exploring the mansion.

Original interpreter here:
https://www.youtube.com/watch?v=9EU0Ml28keg&t=301

Plus, our bypass would prevent from closing that door again: nothing would happen at all.