### PR TITLE
DISTS: Fix AppData id

### DIFF
--- a/dists/scummvm.appdata.xml
+++ b/dists/scummvm.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2020-2022 The ScummVM Team -->
 <component type="desktop">
-  <id>org.scummvm.ScummVM.desktop</id>
+  <id>scummvm.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <name>ScummVM</name>


### PR DESCRIPTION
Commit 1f4e197 changed the AppData id to a rDNS one, however the actual appdata/desktop file names stayed non-rDNS. This broke the metadata since AppStream parsers cannot match the correct desktop file anymore. This PR reverts the change.

Another possible "solution" would be to add `<launchable type="desktop-id">scummvm.desktop</launchable>` tag (just the `<provides>` tag is not sufficient and useful in this case), however I consider that being a workaround, especially in this case when the appdata file name is also non-rDNS (_scummvm.appdata.xml_ instead of _org.scummvm.ScummVM.appdata.xml_).

True proper solution would be to rename [scummvm.desktop](https://github.com/scummvm/scummvm/blob/master/dists/scummvm.desktop) to `org.scummvm.ScummVM.desktop` and [scummvm.appdata.xml](https://github.com/scummvm/scummvm/blob/master/dists/scummvm.appdata.xml)(.cpp) to `org.scummvm.ScummVM.appdata.xml`(.cpp), but that would require much more work (and bring possible downstream packaging issues because of upstream file names changes) than just fixing the AppStream id.