### PR TITLE
AMIGAOS: Revert use of -ldl to satisfy buildbot

### DIFF
--- a/configure
+++ b/configure
@@ -4051,7 +4051,6 @@ PLUGIN_LDFLAGS		+= -Wl,-T$(srcdir)/backends/plugins/3ds/plugin.ld -march=armv6k 
 		_plugin_suffix=".plugin"
 		append_var CXXFLAGS "-fPIC"
 		append_var LIBS "-use-dynld"
-		append_var LIBS "-ldl"
 		append_var LIBS "-lauto"
 		append_var _strip "-x"
 _mak_plugins='


### PR DESCRIPTION
@lephilousophe mentioned in #3886 that -ldl is not used in SDL backends.

To satisfy buildbot and thanks to him for showing me the wrongs in my ways, this is now reverted.

Did a fresh complete build and quickly tested some engines, together with a few starts and quits, no bad things happened so far.

...sorry for breaking buildbot :-/

I could always use more of those pointers :-D