### PR TITLE
Fix building plugins with address sanitizer enabled

### DIFF
--- a/configure
+++ b/configure
@@ -46,6 +46,7 @@ SAVED_WINDRESFLAGS=$WINDRESFLAGS
 
 # Use environment vars if set
 CXXFLAGS="$CXXFLAGS $CPPFLAGS"
+PLUGIN_LDFLAGS=$LDFLAGS
 
 # Backslashes into forward slashes:
 # The following OS/2 specific code is performed to deal with handling of backslashes by ksh.
@@ -977,7 +978,7 @@ Optional Libraries:
 
   --with-ieee1284-prefix=DIR prefix where libieee1284 is installed (optional)
   --enable-opl2lpt         enable OPL2LPT support
-  
+
   --with-retrowave-prefix=DIR prefix where libretrowave is installed (optional)
   --enable-retrowave       enable RetroWave OPL3 support
 
@@ -4207,7 +4208,7 @@ POST_OBJS_FLAGS := -Wl,-no-whole-archive
 		append_var DEFINES "-DUNCACHED_PLUGINS"
 _mak_plugins='
 LDFLAGS				+= -Wl,-T$(srcdir)/backends/plugins/psp/main_prog.ld  -Wl,-zmax-page-size=128
-PLUGIN_LDFLAGS		+= -Wl,-T$(srcdir)/backends/plugins/psp/plugin.ld -Wl,-zmax-page-size=128 -lstdc++ 
+PLUGIN_LDFLAGS		+= -Wl,-T$(srcdir)/backends/plugins/psp/plugin.ld -Wl,-zmax-page-size=128 -lstdc++
 '
 		;;
 	*)
@@ -5994,6 +5995,7 @@ if test "$_enable_asan" = yes ; then
 	else
 		append_var CXXFLAGS "-fsanitize=address -fno-omit-frame-pointer"
 		append_var LDFLAGS "-fsanitize=address -fno-omit-frame-pointer"
+		append_var PLUGIN_LDFLAGS "-fsanitize=address -fno-omit-frame-pointer"
 	fi
 fi
 echo "$_enable_asan"
@@ -6003,6 +6005,7 @@ echo_n "Enabling Thread Sanitizer... "
 if test "$_enable_tsan" = yes ; then
 	append_var CXXFLAGS "-fsanitize=thread"
 	append_var LDFLAGS "-fsanitize=thread"
+	append_var PLUGIN_LDFLAGS "-fsanitize=thread"
 fi
 echo "$_enable_tsan"
 
@@ -6011,6 +6014,7 @@ echo_n "Enabling Undefined Behavior Sanitizer... "
 if test "$_enable_ubsan" = yes ; then
 	append_var CXXFLAGS "-fsanitize=undefined"
 	append_var LDFLAGS "-fsanitize=undefined"
+	append_var PLUGIN_LDFLAGS "-fsanitize=undefined"
 fi
 echo "$_enable_ubsan"
 
@@ -6320,6 +6324,7 @@ OBJS += $OBJS
 DEFINES += $DEFINES
 LDFLAGS += $LDFLAGS
 
+PLUGIN_LDFLAGS += $PLUGIN_LDFLAGS
 $_mak_plugins
 
 port_mk = $_port_mk

--- a/rules.mk
+++ b/rules.mk
@@ -48,7 +48,7 @@ ifdef PLUGIN
 PLUGIN-$(MODULE) := plugins/$(PLUGIN_PREFIX)$(notdir $(MODULE))$(PLUGIN_SUFFIX)
 $(PLUGIN-$(MODULE)): $(MODULE_OBJS-$(MODULE)) $(PLUGIN_EXTRA_DEPS)
 	$(QUIET)$(MKDIR) plugins
-	+$(QUIET_PLUGIN)$(LD) $(SAVED_LDFLAGS) $(filter-out $(PLUGIN_EXTRA_DEPS),$+) $(PLUGIN_LDFLAGS) -o $@
+	+$(QUIET_PLUGIN)$(LD) $(filter-out $(PLUGIN_EXTRA_DEPS),$+) $(PLUGIN_LDFLAGS) -o $@
 
 # Reset PLUGIN var
 PLUGIN:=


### PR DESCRIPTION
The issues was introduced with commit 0974f168b204b26f620d2a7e1a55021e66309e64. Before that commit the `$LDFLAGS` were used for the link command on the plugins, and this includes the sanitizer flags. After that commit it uses the `$SAVED_LDFLAGS` instead and that results in link errors (undefined symbols) when address sanitizer is enabled (and probably also for than and ubsan, although I have not checked).

Reverting the commit fixes the issue for me on macOS. However it is probably not a good fix, and is meant to open a discussion on the best way to fix the issue. Which is why I marked it as draft.

The commit was added in PR #2082 by @besser82 . From the discussion there I understand that it fixes link errors on some platforms (see https://github.com/scummvm/scummvm/pull/2077#issuecomment-589943413). So I am guessing reverting it would reintroduce those errors. However those are no longer visible on buildbot so I am not sure what the issues were.

If I understood that correctly and the change from this PR is not good, my suggestion would be to introduce a  `PLUGIN_LDFLAGS` initially set to `SAVED_LDFLAGS` but to which we add the asan, tsan, and ubsan flags (and maybe others?) depending on the configure options used. Does anybody have a better suggestion?
