### PR TITLE
PS3: Properly init the fullscreen and aspect_ratio config keys

### DIFF
--- a/backends/platform/sdl/ps3/ps3.cpp
+++ b/backends/platform/sdl/ps3/ps3.cpp
@@ -88,6 +88,10 @@ void OSystem_PS3::initBackend() {
 	ConfMan.registerDefault("fullscreen", true);
 	ConfMan.registerDefault("aspect_ratio", true);
 
+	ConfMan.setBool("fullscreen", true);
+	if (!ConfMan.hasKey("aspect_ratio"))
+		ConfMan.setBool("aspect_ratio", true);
+
 	// Create the savefile manager
 	if (_savefileManager == 0)
 		_savefileManager = new DefaultSaveFileManager(PREFIX "/saves");


### PR DESCRIPTION
The PS3 backend had that weird behavior where you'd need to check the "Aspect Ratio" option in order to disable it, by default. [Trac#11743](https://bugs.scummvm.org/ticket/11743) reported a similar problem on Android.

Looking at the various `backends/platform/` backends, this appears to come from the fact that only `ConfMan.registerDefault()` is called in the PS3 backend but that's not enough; so I've copied what the PSP2, Android and Switch do. The Android backend gives the most [explanations](https://github.com/scummvm/scummvm/blob/97a138ae2e51e357d93e2eb689ad797338fae4fb/backends/platform/android/android.cpp#L370) about this.

Tested with the PS3 toolchain and the (very nice) `devtools/docker.sh` build script.