### PR TITLE
OPENGL: Disable FBO when targeting macOS Tiger or Leopard (HACK)

### DIFF
--- a/backends/graphics/opengl/context.cpp
+++ b/backends/graphics/opengl/context.cpp
@@ -30,6 +30,10 @@
 #include "common/tokenizer.h"
 #include "common/debug.h"
 
+#ifdef MACOSX
+#include <AvailabilityMacros.h>
+#endif
+
 namespace OpenGL {
 
 void Context::reset() {
@@ -202,6 +206,12 @@ void OpenGLGraphicsManager::initializeGLContext() {
 		g_context.packedPixelsSupported = true;
 		g_context.textureEdgeClampSupported = true;
 	}
+
+	// HACK FIXME: glBindFramebuffer(GL_FRAMEBUFFER, 0) crashes on Leopard if FBO
+	// has been enabled by the GL_EXT_framebuffer_object extension.
+#if defined(MACOSX) && __MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+	g_context.framebufferObjectSupported = false;
+#endif
 
 	// Log context type.
 	switch (g_context.type) {

--- a/graphics/opengl/context.cpp
+++ b/graphics/opengl/context.cpp
@@ -30,6 +30,10 @@
 
 #if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
+#ifdef MACOSX
+#include <AvailabilityMacros.h>
+#endif
+
 #ifdef USE_GLAD
 
 #ifdef SDL_BACKEND
@@ -179,6 +183,12 @@ void ContextGL::initialize(ContextOGLType contextType) {
 			glGetIntegerv(GL_MAX_SAMPLES, (GLint *)&multisampleMaxSamples);
 		}
 	}
+
+	// HACK FIXME: glBindFramebuffer(GL_FRAMEBUFFER, 0) crashes on Leopard if FBO
+	// has been enabled by the GL_EXT_framebuffer_object extension.
+#if defined(MACOSX) && __MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+	framebufferObjectSupported = false;
+#endif
 
 	// Log context type.
 	switch (type) {


### PR DESCRIPTION
That one I'm not a big fan of… it's a hack, but I can't find anything better.

While trying to resurrect the Mac PowerPC port (for Tiger and Leopard) I was having systematic crashes when OpenGL is initialized on my PowerBook G4. It looks like this problem appeared when switching from GLEW to GLAD, for some reason.

Any `glBindFramebuffer(GL_FRAMEBUFFER, 0)` call would crash with a null pointer on macOS Leopard if [FBO](https://www.khronos.org/opengl/wiki/Framebuffer_Object) remains enabled, even when the `GL_EXT_framebuffer_object` extension *really* is there. I can't see anything meaningful in gdb. SDL has no problem running with FBO, though…

I have no understanding of this part of the code, so always disabling FBO when targeting macOS Leopard or lower is the only option I could find at the moment :(

I have an iBook G4 where the ATI card has no FBO support, so the fix didn't change anything, there. Grim Fandango runs, but at a low framerate (around 12 FPS). The PowerBook G4 reports FBO support, but that's where I'm having my systematic crashes. Playing Grim Fandango on that Powerbook G4 is a good experience though, FPS is fine there even without FBO. I don't know what's the impact of disabling FBO on old cards, actually.

I'm open to any suggestion if you'd rather avoid this hack. Thanks.