### PR TITLE
DIRECTOR: Implement STUB Lingo command move

### DIFF
--- a/engines/director/lingo/tests/builtin.lingo
+++ b/engines/director/lingo/tests/builtin.lingo
@@ -22,7 +22,8 @@ puppetTransition 2,4,20
 
 -- These are D4+
 move cast 1, cast 1
-move cast 1
+move cast 1, 3
+move cast 3, 1
 put findEmpty(cast 10)
 pasteClipBoardInto cast 2
 put the width of cast 1


### PR DESCRIPTION
This change implements the lingo command `move` which moves the given cast member to either the provided cast window or to the first empty cast window. This and changes done in https://github.com/scummvm/scummvm/pull/3903 together make the findEmpty workshop movie work as intended.
This also needed a change in the tests as one of the move tests was causing another test to fail