### PR TITLE
GOB: Remove needless NULL validation

### DIFF
--- a/engines/gob/goblin.cpp
+++ b/engines/gob/goblin.cpp
@@ -107,10 +107,8 @@ Goblin::~Goblin() {
 		if (_goblins[i]) {
 			if (_goblins[i]->realStateMach) {
 				for (state = 0; state < (i == 3 ? 70 : 40); state++)
-					if (_goblins[i]->realStateMach[state])
-						for (col = 0; col < 6; col++)
-							if (_goblins[i]->realStateMach[state][col])
-								delete _goblins[i]->realStateMach[state][col];
+					for (col = 0; col < 6; col++)
+						delete _goblins[i]->realStateMach[state][col];
 				delete[] _goblins[i]->realStateMach;
 			}
 			delete _goblins[i];


### PR DESCRIPTION
Reported by GCC 12:

```
goblin.cpp: In destructor 'virtual Gob::Goblin::~Goblin()':
goblin.cpp:110:77: warning: comparing the result of pointer addition '(((Gob::Goblin*)this)->Gob::Goblin::_goblins[i]->Gob::Goblin::Gob_Object::realStateMach + ((sizetype)(((long long unsigned int)state) * 48)))' and NULL [-Waddress]
  110 |                                         if (_goblins[i]->realStateMach[state])
      |                                                                             ^
```
