### PR TITLE
GLK: Fix loading font colors for gStyles

### DIFF
--- a/engines/glk/conf.cpp
+++ b/engines/glk/conf.cpp
@@ -216,21 +216,21 @@ void Conf::synchronize() {
 
 	const char *const TG_COLOR[2] = { "tcolor_%d", "gcolor_%d" };
 	for (int tg = 0; tg < 2; ++tg) {
+		WindowStyle *pStyles = (tg == 0) ? _tStyles : _gStyles;
 		for (int style = 0; style <= 10; ++style) {
 			Common::String key = Common::String::format(TG_COLOR[tg], style);
-
 			if (_isLoading) {
 				if (exists(key)) {
 					Common::String line = ConfMan.get(key);
 					if (line.find(',') == 6) {
-						_tStyles[style].fg = parseColor(Common::String(line.c_str(), 6));
-						_tStyles[style].bg = parseColor(Common::String(line.c_str() + 7));
+						pStyles[style].fg = parseColor(Common::String(line.c_str(), 6));
+						pStyles[style].bg = parseColor(Common::String(line.c_str() + 7));
 					}
 				}
 			} else {
 				Common::String line = Common::String::format("%s,%s",
-					encodeColor(_tStyles[style].fg).c_str(),
-					encodeColor(_tStyles[style].bg).c_str()
+					encodeColor(pStyles[style].fg).c_str(),
+					encodeColor(pStyles[style].bg).c_str()
 				);
 				ConfMan.set(key, line);
 			}
@@ -239,19 +239,16 @@ void Conf::synchronize() {
 
 	const char *const TG_FONT[2] = { "tfont_%d", "gfont_%d" };
 	for (int tg = 0; tg < 2; ++tg) {
+		WindowStyle *pStyles = (tg == 0) ? _tStyles : _gStyles;
 		for (int style = 0; style <= 10; ++style) {
 			Common::String key = Common::String::format(TG_FONT[tg], style);
-
 			if (_isLoading) {
 				if (exists(key)) {
 					FACES font = Screen::getFontId(ConfMan.get(key));
-					if (tg == 0)
-						_tStyles[style].font = font;
-					else
-						_gStyles[style].font = font;
+					pStyles[style].font = font;
 				}
 			} else {
-				FACES font = (tg == 0) ? _tStyles[style].font : _gStyles[style].font;
+				FACES font = pStyles[style].font;
 				ConfMan.set(key, Screen::getFontName(font));
 			}
 		}


### PR DESCRIPTION
Previously setting a gcolor_x font color (eg. gcolor_0) value in scummvm.ini, it would overwrite the corresponding tcolor_x (here tcolor_0) value. 

The fix makes sense to me, since it now works as I would expect, but probably someone with deeper knowledge of the engine should okay this.
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
