### PR TITLE
SCUMM: Properly stop Wendy's music in MM NES

### DIFF
--- a/engines/scumm/detection_tables.h
+++ b/engines/scumm/detection_tables.h
@@ -158,7 +158,7 @@ static const GameSettings gameVariantsTable[] = {
 	{"maniac", "C64 Demo",   0, GID_MANIAC, 0, 0, MDT_C64, GF_DEMO, Common::kPlatformC64, GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI) },
 	{"maniac", "V1",      "v1", GID_MANIAC, 1, 0, MDT_PCSPK | MDT_PCJR, 0, Common::kPlatformDOS, GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI)},
 	{"maniac", "V1 Demo", "v1", GID_MANIAC, 1, 0, MDT_PCSPK | MDT_PCJR, GF_DEMO, Common::kPlatformDOS, GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI)},
-	{"maniac", "NES",        0, GID_MANIAC, 1, 0, MDT_NONE,  0, Common::kPlatformNES, GUIO3(GUIO_NOSPEECH, GUIO_NOMIDI, GUIO_NOASPECT)},
+	{"maniac", "NES",        0, GID_MANIAC, 1, 0, MDT_NONE,  0, Common::kPlatformNES, GUIO4(GUIO_NOSPEECH, GUIO_NOMIDI, GUIO_NOASPECT, GUIO_ENHANCEMENTS)},
 	{"maniac", "V2",      "v2", GID_MANIAC, 2, 0, MDT_PCSPK | MDT_PCJR, 0, UNK, GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI)},
 	{"maniac", "V2 Demo", "v2", GID_MANIAC, 2, 0, MDT_PCSPK | MDT_PCJR, GF_DEMO, Common::kPlatformDOS, GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI)},
 

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2401,6 +2401,14 @@ void ScummEngine_v5::o5_stopSound() {
 		return;
 	}
 
+	// WORKAROUND: In MM NES, Wendy's CD player script forgets to update the
+	// music status variable when you stop it. Wendy's music would then
+	// resume when leaving some rooms (such as room 3 with the chandelier),
+	// even though her CD player was off.
+	if (_game.id == GID_MANIAC && _game.platform == Common::kPlatformNES && sound == 75 && vm.slot[_currentScript].number == 50 && VAR(VAR_EGO) == 6 && VAR(224) == sound && _enableEnhancements) {
+		VAR(224) = 0;
+	}
+
 	_sound->stopSound(sound);
 }
 


### PR DESCRIPTION
In the NES version of Maniac Mansion, each kid has their own CD player playing a different background music by default.

Each CD player script does something like this when you turn it off:

```
...
(2F) if (!getState04(46)) {
(D8)   printEgo("It's already off.");
(18) } else {
(67)   clearState04(46);
(1A)   Var[224] = 0;  # <==
(3C)   stopSound(71);
(**) }
...
```

but Wendy's CD player script is missing the `Var[224] = 0` line (all the other CD player scripts have it), so although her music was stopped, the game scripts weren't properly aware of this, and so her music could suddenly resume, such as when entering and leaving room 3 with her character. (This would also happen with Nestopia.)

Indeed, here's `exit-3.dmp`:

```
(3C) stopSound(25);
(3C) stopSound(20);
(3C) stopSound(29);
(3C) stopSound(44);
(3C) stopSound(50);
(3C) stopSound(70);
(FC) VAR_RESULT = isSoundRunning(Var[224]);
(28) if (!VAR_RESULT) {
(9C)   startSound(Var[224]);
(**) }
(00) stopObjectCode();
END
```

so when you leave that room, `Var[224]` is still 75 (= her track number) and so her music starts again, even though her CD player really is off. 

So the following PR just tries to catch this missing line, by targeting this script, and checking if `Var[224]` is still set to Wendy's track when the `stopSound(75)` line is triggered. It shouldn't be, so we set it back to 0 in that case.

## How to reproduce

1. Start a new Maniac Mansion NES game
2. Pick Wendy as a character
3. Turn off her CD player
4. Pick up the key under the door mat, open the door with it and enter the mansion
5. Go to the room on the right (the one with the chandelier), and then exit that room.

Since you've turned off the music, it shouldn't resume (as happens for every other player).