### PR TITLE
KEYMAPPER: Allow repeated keypresses for standard actions

### DIFF
--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -77,53 +77,63 @@ Common::KeymapArray MetaEngine::initKeymaps(const char *target) const {
 	act = new Action(kStandardActionPause, _("Pause"));
 	act->setKeyEvent(KeyState(KEYCODE_SPACE, ' '));
 	act->addDefaultInputMapping("SPACE");
+	act->allowKbdRepeats();
 	engineKeyMap->addAction(act);
 
 	act = new Action(kStandardActionOpenMainMenu, _("Game menu"));
 	act->setKeyEvent(KeyState(KEYCODE_F5, ASCII_F5));
 	act->addDefaultInputMapping("F5");
 	act->addDefaultInputMapping("JOY_LEFT_SHOULDER");
+	act->allowKbdRepeats();
 	engineKeyMap->addAction(act);
 
 	act = new Action(kStandardActionSkip, _("Skip"));
 	act->setKeyEvent(KeyState(KEYCODE_ESCAPE, ASCII_ESCAPE));
 	act->addDefaultInputMapping("ESCAPE");
 	act->addDefaultInputMapping("JOY_Y");
+	act->allowKbdRepeats();
 	engineKeyMap->addAction(act);
 
 	act = new Action("SKLI", _("Skip line"));
 	act->setKeyEvent(KeyState(KEYCODE_PERIOD, '.'));
 	act->addDefaultInputMapping("PERIOD");
 	act->addDefaultInputMapping("JOY_X");
+	act->allowKbdRepeats();
 	engineKeyMap->addAction(act);
 
 	act = new Action("PIND", _("Predictive input dialog"));
 	act->setEvent(EVENT_PREDICTIVE_DIALOG);
+	act->allowKbdRepeats();
 	engineKeyMap->addAction(act);
 
 	act = new Action("RETURN", _("Confirm"));
 	act->setKeyEvent(KeyState(KEYCODE_RETURN, ASCII_RETURN));
 	act->addDefaultInputMapping("RETURN");
+	act->allowKbdRepeats();
 	engineKeyMap->addAction(act);
 
 	act = new Action(kStandardActionMoveUp, _("Up"));
 	act->setKeyEvent(KEYCODE_KP8);
 	act->addDefaultInputMapping("JOY_UP");
+	act->allowKbdRepeats();
 	engineKeyMap->addAction(act);
 
 	act = new Action(kStandardActionMoveDown, _("Down"));
 	act->setKeyEvent(KEYCODE_KP2);
 	act->addDefaultInputMapping("JOY_DOWN");
+	act->allowKbdRepeats();
 	engineKeyMap->addAction(act);
 
 	act = new Action(kStandardActionMoveLeft, _("Left"));
 	act->setKeyEvent(KEYCODE_KP4);
 	act->addDefaultInputMapping("JOY_LEFT");
+	act->allowKbdRepeats();
 	engineKeyMap->addAction(act);
 
 	act = new Action(kStandardActionMoveRight, _("Right"));
 	act->setKeyEvent(KEYCODE_KP6);
 	act->addDefaultInputMapping("JOY_RIGHT");
+	act->allowKbdRepeats();
 	engineKeyMap->addAction(act);
 
 	return Keymap::arrayOf(engineKeyMap);


### PR DESCRIPTION
I recently got notice of the fact that we lost the capability of repeated keypresses for the standard actions mapped in the keymapper. Although this is a very small fix, I wanted to get some opinions on this, to see if it could potentially break anything (but AFAIK the keymapper just routes its data onto each engine input handling routines, so if it wasn't broken before it _shouldn't_ be broken now).