### PR TITLE
SCUMM: MI1 (CD DOS): Implement reloading CD Audio track when reloading game

### DIFF
--- a/engines/scumm/sound.h
+++ b/engines/scumm/sound.h
@@ -152,7 +152,7 @@ public:
 	void updateCD();
 	AudioCDManager::Status getCDStatus();
 	int getCurrentCDSound() const { return _currentCDSound; }
-
+	int getCDTrackIdFromSoundId(int soundId, int &loops, int &start);
 	bool isRolandLoom() const;
 	bool useReplacementAudioTracks() const { return _useReplacementAudioTracks; }
 	void updateMusicTimer();


### PR DESCRIPTION
Ciao! It seems that we didn't support this functionality at all, so I took advantage of the code eriktorbjorn already had in place for the Loom replacement tracks to implement this for MI1 CD (DOS version, FM-Towns is a totally different beast).

LOOM and any FM-Towns game are quite different: 
* In order for this to work for LOOM CD, I would have to store some new data in the savegames (the offset and the delay obtained in `ScummEngine_v5::decodeParseString()`, case 8;
* FM-Towns has its own CD Player class, which I'm currently not touching with a ten foot pole.

Both the two points above represent changes which are out of the scope with respect to this PR; rest assured though that the code I introduced is only reachable within MI1CD DOS.