### PR TITLE
SCUMM: Add adjustment sliders for VGA Loom (CD) and MI1 (CD) audio

### DIFF
--- a/engines/scumm/dialogs.cpp
+++ b/engines/scumm/dialogs.cpp
@@ -896,29 +896,20 @@ MI1CdGameOptionsWidget::MI1CdGameOptionsWidget(GuiObject *boss, const Common::St
 
 	_introAdjustmentValue->setFlags(GUI::WIDGET_CLEARBG);
 
-	// The unofficial talkie version has a separate track for the outlook
-	// music, and does its own enhancements through script patching.
+	text = new GUI::StaticTextWidget(widgetsBoss(), "MI1CdGameOptionsDialog.OutlookAdjustmentLabel", _("Outlook Adjust:"));
 
-	if (!extra.contains("SE Talkie")) {
-		text = new GUI::StaticTextWidget(widgetsBoss(), "MI1CdGameOptionsDialog.OutlookAdjustmentLabel", _("Outlook Adjust:"));
+	text->setAlign(Graphics::TextAlign::kTextAlignEnd);
 
-		text->setAlign(Graphics::TextAlign::kTextAlignEnd);
+	_outlookAdjustmentSlider = new GUI::SliderWidget(widgetsBoss(), "MI1CdGameOptionsDialog.OutlookAdjustment", _("The outlook music is part of the intro track. Adjust the position in the track at which it starts playing. Use this if the music is cut off, or if you hear part of the previous music."), kOutlookAdjustmentChanged);
 
-		_outlookAdjustmentSlider = new GUI::SliderWidget(widgetsBoss(), "MI1CdGameOptionsDialog.OutlookAdjustment", _("The outlook music is part of the intro track. Adjust the position in the track at which it starts playing. Use this if the music is cut off, or if you hear part of the previous music."), kOutlookAdjustmentChanged);
+	_outlookAdjustmentSlider->setMinValue(-200);
+	_outlookAdjustmentSlider->setMaxValue(200);
 
-		_outlookAdjustmentSlider->setMinValue(-200);
-		_outlookAdjustmentSlider->setMaxValue(200);
+	_outlookAdjustmentValue = new GUI::StaticTextWidget(widgetsBoss(), "MI1CdGameOptionsDialog.OutlookAdjustmentValue", Common::U32String());
 
-		_outlookAdjustmentValue = new GUI::StaticTextWidget(widgetsBoss(), "MI1CdGameOptionsDialog.OutlookAdjustmentValue", Common::U32String());
+	_outlookAdjustmentValue->setFlags(GUI::WIDGET_CLEARBG);
 
-		_outlookAdjustmentValue->setFlags(GUI::WIDGET_CLEARBG);
-
-		_enableEnhancementsCheckbox = createEnhancementsCheckbox(widgetsBoss(), "MI1CdGameOptionsDialog.EnableEnhancements");
-	} else {
-		_outlookAdjustmentSlider = nullptr;
-		_outlookAdjustmentValue = nullptr;
-		_enableEnhancementsCheckbox = nullptr;
-	}
+	_enableEnhancementsCheckbox = createEnhancementsCheckbox(widgetsBoss(), "MI1CdGameOptionsDialog.EnableEnhancements");
 }
 
 void MI1CdGameOptionsWidget::load() {
@@ -930,27 +921,19 @@ void MI1CdGameOptionsWidget::load() {
 	_introAdjustmentSlider->setValue(introAdjustment);
 	updateIntroAdjustmentValue();
 
-	if (_outlookAdjustmentSlider) {
-		if (ConfMan.hasKey("mi1_outlook_adjustment", _domain))
-			outlookAdjustment = ConfMan.getInt("mi1_outlook_adjustment", _domain);
+	if (ConfMan.hasKey("mi1_outlook_adjustment", _domain))
+		outlookAdjustment = ConfMan.getInt("mi1_outlook_adjustment", _domain);
 
-		_outlookAdjustmentSlider->setValue(outlookAdjustment);
-		updateOutlookAdjustmentValue();
-	}
+	_outlookAdjustmentSlider->setValue(outlookAdjustment);
+	updateOutlookAdjustmentValue();
 
-	if (_enableEnhancementsCheckbox)
-		_enableEnhancementsCheckbox->setState(ConfMan.getBool("enable_enhancements", _domain));
+	_enableEnhancementsCheckbox->setState(ConfMan.getBool("enable_enhancements", _domain));
 }
 
 bool MI1CdGameOptionsWidget::save() {
 	ConfMan.setInt("mi1_intro_adjustment", _introAdjustmentSlider->getValue(), _domain);
-
-	if (_outlookAdjustmentSlider)
-		ConfMan.setInt("mi1_outlook_adjustment", _outlookAdjustmentSlider->getValue(), _domain);
-
-	if (_enableEnhancementsCheckbox)
-		ConfMan.setBool("enable_enhancements", _enableEnhancementsCheckbox->getState(), _domain);
-
+	ConfMan.setInt("mi1_outlook_adjustment", _outlookAdjustmentSlider->getValue(), _domain);
+	ConfMan.setBool("enable_enhancements", _enableEnhancementsCheckbox->getState(), _domain);
 	return true;
 }
 
@@ -963,21 +946,16 @@ void MI1CdGameOptionsWidget::defineLayout(GUI::ThemeEval &layouts, const Common:
 				.addWidget("IntroAdjustmentLabel", "OptionsLabel")
 				.addWidget("IntroAdjustment", "WideSlider")
 				.addWidget("IntroAdjustmentValue", "ShortOptionsLabel")
-			.closeLayout();
-
-	if (_outlookAdjustmentSlider) {
-		layouts.addLayout(GUI::ThemeLayout::kLayoutHorizontal, 12)
-			.addPadding(0, 0, 0, 0)
-			.addWidget("OutlookAdjustmentLabel", "OptionsLabel")
-			.addWidget("OutlookAdjustment", "WideSlider")
-			.addWidget("OutlookAdjustmentValue", "ShortOptionsLabel")
-		.closeLayout();
-	}
-
-	if (_enableEnhancementsCheckbox)
-		layouts.addWidget("EnableEnhancements", "Checkbox");
-
-	layouts.closeLayout().closeDialog();
+			.closeLayout()
+			.addLayout(GUI::ThemeLayout::kLayoutHorizontal, 12)
+				.addPadding(0, 0, 0, 0)
+				.addWidget("OutlookAdjustmentLabel", "OptionsLabel")
+				.addWidget("OutlookAdjustment", "WideSlider")
+				.addWidget("OutlookAdjustmentValue", "ShortOptionsLabel")
+			.closeLayout()
+			.addWidget("EnableEnhancements", "Checkbox")
+		.closeLayout()
+	.closeDialog();
 }
 
 void MI1CdGameOptionsWidget::handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) {

--- a/engines/scumm/dialogs.h
+++ b/engines/scumm/dialogs.h
@@ -210,9 +210,22 @@ private:
 };
 
 /**
+ * Common options widget stuff.
+ */
+class ScummOptionsContainerWidget : public GUI::OptionsContainerWidget {
+public:
+	ScummOptionsContainerWidget(GuiObject *boss, const Common::String &name, const Common::String &dialogLayout, const Common::String &domain) :
+		OptionsContainerWidget(boss, name, dialogLayout, false, domain) {
+	}
+
+	GUI::CheckboxWidget *createEnhancementsCheckbox(GuiObject *boss, const Common::String &name);
+	void updateAdjustmentSlider(GUI::SliderWidget *slider, GUI::StaticTextWidget *value);
+};
+
+/**
  * Options widget for EGA Loom.
  */
-class LoomEgaGameOptionsWidget : public GUI::OptionsContainerWidget {
+class LoomEgaGameOptionsWidget : public ScummOptionsContainerWidget {
 public:
 	LoomEgaGameOptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain);
 	~LoomEgaGameOptionsWidget() override {};
@@ -228,11 +241,67 @@ private:
 	void defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const override;
 	void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) override;
 
-	GUI::CheckboxWidget *_enableEnhancements;
+	GUI::CheckboxWidget *_enableEnhancementsCheckbox;
 	GUI::SliderWidget *_overtureTicksSlider;
 	GUI::StaticTextWidget *_overtureTicksValue;
 
 	void updateOvertureTicksValue();
+};
+
+/**
+ * Options widget for VGA Loom (DOS CD).
+ */
+class LoomVgaGameOptionsWidget : public ScummOptionsContainerWidget {
+public:
+	LoomVgaGameOptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain);
+	~LoomVgaGameOptionsWidget() override {};
+
+	void load() override;
+	bool save() override;
+
+private:
+	enum {
+		kPlaybackAdjustmentChanged = 'PBAC'
+	};
+
+	void defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const override;
+	void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) override;
+
+	GUI::CheckboxWidget *_enableEnhancementsCheckbox;
+	GUI::SliderWidget *_playbackAdjustmentSlider;
+	GUI::StaticTextWidget *_playbackAdjustmentValue;
+
+	void updatePlaybackAdjustmentValue();
+};
+
+/**
+ * Options widget for CD Monkey Island 1.
+ */
+class MI1CdGameOptionsWidget : public ScummOptionsContainerWidget {
+public:
+	MI1CdGameOptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain);
+	~MI1CdGameOptionsWidget() override {};
+
+	void load() override;
+	bool save() override;
+
+private:
+	enum {
+		kIntroAdjustmentChanged = 'IACH',
+		kOutlookAdjustmentChanged = 'OACH'
+	};
+
+	void defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const override;
+	void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) override;
+
+	GUI::CheckboxWidget *_enableEnhancementsCheckbox;
+	GUI::SliderWidget *_introAdjustmentSlider;
+	GUI::StaticTextWidget *_introAdjustmentValue;
+	GUI::SliderWidget *_outlookAdjustmentSlider;
+	GUI::StaticTextWidget *_outlookAdjustmentValue;
+
+	void updateIntroAdjustmentValue();
+	void updateOutlookAdjustmentValue();
 };
 
 } // End of namespace Scumm

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -553,7 +553,7 @@ GUI::OptionsContainerWidget *ScummMetaEngine::buildEngineOptionsWidgetDynamic(GU
 
 		return new Scumm::LoomEgaGameOptionsWidget(boss, name, target);
 	} else if (gameid == "monkey") {
-		if (extra != "CD" && extra != "FM-TOWNS" && extra != "SEGA" && !extra.contains("SE Talkie"))
+		if (extra != "CD" && extra != "FM-TOWNS" && extra != "SEGA")
 			return nullptr;
 
 		return new Scumm::MI1CdGameOptionsWidget(boss, name, target);

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -530,22 +530,36 @@ SaveStateDescriptor ScummMetaEngine::querySaveMetaInfos(const char *target, int 
 }
 
 GUI::OptionsContainerWidget *ScummMetaEngine::buildEngineOptionsWidgetDynamic(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const {
-	if (ConfMan.get("gameid", target) != "loom")
-		return nullptr;
-
-	// These Loom settings are only relevant for the EGA version, since
-	// that is the only one that has an overture.
-
-	Common::Platform platform = Common::parsePlatform(ConfMan.get("platform", target));
-	if (platform != Common::kPlatformUnknown && platform != Common::kPlatformDOS)
-		return nullptr;
-
+	Common::String gameid = ConfMan.get("gameid", target);
 	Common::String extra = ConfMan.get("extra", target);
 
-	if (extra == "Steam" || extra == "VGA")
-		return nullptr;
+	if (gameid == "loom") {
+		Common::Platform platform = Common::parsePlatform(ConfMan.get("platform", target));
+		if (platform != Common::kPlatformUnknown && platform != Common::kPlatformDOS)
+			return nullptr;
 
-	return new Scumm::LoomEgaGameOptionsWidget(boss, name, target);
+		// The VGA Loom settings are only relevant for the DOS CD
+		// version, not the Steam version (which is assumed to be well
+		// timed already).
+
+		if (extra == "VGA")
+			return new Scumm::LoomVgaGameOptionsWidget(boss, name, target);
+
+		if (extra == "Steam")
+			return nullptr;
+
+		// These EGA Loom settings are only relevant for the EGA
+		// version, since that is the only one that has an overture.
+
+		return new Scumm::LoomEgaGameOptionsWidget(boss, name, target);
+	} else if (gameid == "monkey") {
+		if (extra != "CD" && extra != "FM-TOWNS" && extra != "SEGA" && !extra.contains("SE Talkie"))
+			return nullptr;
+
+		return new Scumm::MI1CdGameOptionsWidget(boss, name, target);
+	}
+
+	return nullptr;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(SCUMM)

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -3065,11 +3065,19 @@ void ScummEngine_v5::decodeParseString() {
 						// I.e. in total 22650 frames.
 						offset = (int)(offset * 7.5 - 22500 - 2*75);
 
+						// Add the user-specified adjustment.
+						if (ConfMan.hasKey("loom_playback_adjustment")) {
+							int adjustment = ConfMan.getInt("loom_playback_adjustment");
+							offset += ((75 * adjustment) / 100);
+							if (offset < 0)
+								offset = 0;
+						}
+
 						// Slightly increase the delay (5 frames = 1/25 of a second).
 						// This noticably improves the experience in Loom CD.
 						delay = (int)(delay * 7.5 + 5);
 
-						_sound->playCDTrack(1, 0, offset, delay);
+						_sound->playCDTrack(1, 1, offset, delay);
 					}
 				} else {
 					error("ScummEngine_v5::decodeParseString: Unhandled case 8");

--- a/engines/scumm/sound.cpp
+++ b/engines/scumm/sound.cpp
@@ -519,6 +519,13 @@ void Sound::playSound(int soundID) {
 			int start = (ptr[2] * 60 + ptr[3]) * 75 + ptr[4];
 			int end = (ptr[5] * 60 + ptr[6]) * 75 + ptr[7];
 
+			// Add the user-specified adjustments.
+			if (_vm->_game.id == GID_MONKEY && track == 17) {
+				int adjustment = ConfMan.getInt(start == 0 ? "mi1_intro_adjustment" : "mi1_outlook_adjustment");
+
+				start += ((75 * adjustment) / 100);
+			}
+
 			playCDTrack(track, loops == 0xff ? -1 : loops, start, end <= start ? 0 : end - start);
 			_currentCDSound = soundID;
 		} else {


### PR DESCRIPTION
When ripping the audio tracks from CD, you may not get quite what the game expects, e.g. my copy of Loom has less silence at the start of the track than the CDDA.SOU file from the Steam version, causing numerous sound glitches. And the MI1 intro appears to be timed with the assumption that there is no silence at all at the start of that track.

This pull request adds game-specific settings to help compensate for this without having the edit the audio files. ("Why settings?" you may ask. Well, I'm told that all CD rippers/CD drives don't produce quite identical results, so hard-coding the adjustments seems risky. And for MI1, I can easily see a situation where someone may want to replace the audio tracks, e.g. from the Special Edition.)

There are three settings:

- For VGA talkie Loom, "Playback Adjust" adjusts the offset to start playing from by anything from -2 to +2 seconds. I set this to -0.34 to match CDDA.SOU.
- For MI1 CD (DOS, SEGA, FM Towns, SE Talkie), "Intro Adjust" adjusts the offset to start playing the opening music from by anything from 0 to 2 seconds. I set this to +1.14 to get the music to sync up better with the animation, and not get cut off at the end.
- For MI1 CD (DOS, SEGA, FM Towns), "Outlook Adjust" adjusts the offset to start playing the outlook part of the intro music from by anything from -2 to 2 seconds. I set this to +0.40 to avoid hearing the fade-out of the intro music. This option is not available for the SE Talkie since it uses a separate track for the outlook music.

Actually, it seems to be of limited use for the SE Talkie since both the "CD" soundtracks it built appear to be well timed. So maybe the setting should be removed completely from that version to keep things simple?

The names of the settings are also open to debate.

I don't own the SEGA and FM Towns versions, so I can't test with them. It's possible that timing differences make the settings less useful there.