### PR TITLE
CONFIGURE: Some OpenBSD tweaks + let the endianness check build if there's no __attribute__

### DIFF
--- a/configure
+++ b/configure
@@ -2336,6 +2336,9 @@ fi
 #
 echo_n "Checking endianness... "
 cat > tmp_endianness_check.cpp << EOF
+#ifndef __GNUC__
+#define __attribute__(x)
+#endif
 __attribute__ ((used)) unsigned short ascii_mm[] = { 0x4249, 0x4765, 0x6E44, 0x6961, 0x6E53, 0x7953, 0 };
 __attribute__ ((used)) unsigned short ascii_ii[] = { 0x694C, 0x5454, 0x656C, 0x6E45, 0x6944, 0x6E61, 0 };
 const char * _ascii() { char* s = (char*) ascii_mm; s = (char*) ascii_ii; return s; }
@@ -4359,7 +4362,7 @@ EOF
 			cc_check -lspeechd && _tts=yes
 			;;
 		darwin*)
-			# Check the API is available. The most recent API we need is for the NSSpeechSynthesizerDelegate protocole
+			# Check the API is available. The most recent API we need is for the NSSpeechSynthesizerDelegate protocol
 			cat > $TMPC << EOF
 #include <AppKit/NSSpeechSynthesizer.h>
 @interface SpeechDelegate : NSObject<NSSpeechSynthesizerDelegate> {

--- a/configure
+++ b/configure
@@ -2148,6 +2148,9 @@ if test "$have_gcc" = yes ; then
 	amigaos* | dreamcast | ds | mingw* | mint* | morphos | n64 | ps3 | psp2)
 		std_variant=gnu++
 		;;
+	openbsd*)
+		pedantic=no
+		;;
 	*)
 		;;
 	esac

--- a/configure
+++ b/configure
@@ -2900,7 +2900,7 @@ EOF
 			_optimization_level=-O2
 		fi
 	;;
-	freebsd* | openbsd*)
+	freebsd*)
 		append_var LDFLAGS "-L/usr/local/lib"
 		append_var CXXFLAGS "-I/usr/local/include"
 		;;
@@ -2995,6 +2995,11 @@ EOF
 		add_line_to_config_mk 'N64 = 1'
 		_detection_features_full=no
 		_nuked_opl=no
+		;;
+	openbsd*)
+		append_var LDFLAGS "-L/usr/local/lib"
+		append_var CXXFLAGS "-I/usr/local/include"
+		_seq_midi=no
 		;;
 	ps3)
 		# Force use of SDL and freetype from the ps3 toolchain


### PR DESCRIPTION
The commits are unrelated but they're small changes to the same file.

## OpenBSD

Contrary to FreeBSD, OpenBSD completely removed its `/dev/sequencer` support back in 2013, since sndio is its replacement (for which we already have a MIDI backend):
https://marc.info/?l=openbsd-cvs&m=136333866832000&w=2

So the first commit moves OpenBSD to its own section and always disables SEQ MIDI there, as was recently done for macOS in commit 1aabe9087e815efa56c9692c5b856b9e199528d6.

The other OpenBSD commit just disables `-pedantic` there, because some system headers make the build noisy, otherwise. (It builds fine with `-std=c++11`, though.)

(Basically, this is a backport of what the official OpenBSD port has been doing for some years; I'm trying to reduce the number of patches which are applied in the ports tree.)

## `__attribute__`

The other commit is related to the endianness test in `configure`: it has some `__attribute((used))` lines coming [from Fedora](https://src.fedoraproject.org/rpms/scummvm/blob/f33/f/gcc-lto-2.2.0.patch) since they use LTO by default (well, the check itself could maybe be rewritten so that it will never trigger any dead-code elimination, and remove EBCDIC support ;) but `__attribute__` is used unconditionally so it could fail compiling with some non-GCC-compatible compilers.  In practice, `configure` implicitly targets GCC-compatible compilers I believe, but…