### PR TITLE
DIRECTOR: LINGO: Implement STUB kTheStageColor in Lingo::getTheEntity()

### DIFF
--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -826,7 +826,8 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 		d.u.i = _vm->getCurrentWindow()->getSurface()->h;
 		break;
 	case kTheStageColor:
-		getTheEntitySTUB(kTheStageColor);
+		d.type = INT;
+		d.u.i = g_director->getCurrentWindow()->getStageColor();
 		break;
 	case kTheStageLeft:
 		d.type = INT;


### PR DESCRIPTION
This change implements the getting STUB of `kTheStageColor`, returning an 8 bit integer for the stage color. 