### PR TITLE
SCI: avoid deadlocks by using only one mutex

### DIFF
--- a/engines/sci/sound/music.cpp
+++ b/engines/sci/sound/music.cpp
@@ -39,7 +39,7 @@
 namespace Sci {
 
 SciMusic::SciMusic(SciVersion soundVersion, bool useDigitalSFX)
-	: _soundVersion(soundVersion), _soundOn(true), _masterVolume(15), _globalReverb(0), _useDigitalSFX(useDigitalSFX), _needsResume(soundVersion > SCI_VERSION_0_LATE), _globalPause(0) {
+	: _mutex(g_system->getMixer()->mutex()), _soundVersion(soundVersion), _soundOn(true), _masterVolume(15), _globalReverb(0), _useDigitalSFX(useDigitalSFX), _needsResume(soundVersion > SCI_VERSION_0_LATE), _globalPause(0) {
 
 	// Reserve some space in the playlist, to avoid expensive insertion
 	// operations

--- a/engines/sci/sound/music.h
+++ b/engines/sci/sound/music.h
@@ -257,9 +257,9 @@ public:
 	void saveLoadWithSerializer(Common::Serializer &ser) override;
 
 	// Mutex for music code. Used to guard access to the song playlist, to the
-	// MIDI parser and to the MIDI driver/player. Note that guarded code must NOT
-	// include references to the mixer, otherwise there will probably be situations
-	// where a deadlock can occur
+	// MIDI parser and to the MIDI driver/player. We use a reference to
+	// the mixer's internal mutex to avoid deadlocks which sometimes occur when
+	// different threads lock each other up in different mutexes.
 	Common::Mutex &_mutex;
 
 protected:

--- a/engines/sci/sound/music.h
+++ b/engines/sci/sound/music.h
@@ -260,7 +260,7 @@ public:
 	// MIDI parser and to the MIDI driver/player. Note that guarded code must NOT
 	// include references to the mixer, otherwise there will probably be situations
 	// where a deadlock can occur
-	Common::Mutex _mutex;
+	Common::Mutex &_mutex;
 
 protected:
 	void sortPlayList();


### PR DESCRIPTION
Make use of the mixer's mutex instead of creating a new one. Otherwise there can still be lock-ups when the main thread and the mixer thread lock each other up in different mutexes (causing a deadlock/freeze). I just noticed this with KQ5 FM-Towns.

We had the same issue in AGOS, it was fixed by allowing access to the mixer's mutex. We can use the same thing here...
