### PR TITLE
 SCI: fix bug no. 13496 (LSL6 music plays all instruments / tracks at …

### DIFF
--- a/engines/sci/sound/midiparser_sci.h
+++ b/engines/sci/sound/midiparser_sci.h
@@ -114,7 +114,6 @@ protected:
 
 	bool _channelUsed[16];
 	int16 _channelRemap[16];
-	bool _channelMuted[16];
 	byte _channelVolume[16];
 
 	struct ChannelState {

--- a/engines/sci/sound/music.cpp
+++ b/engines/sci/sound/music.cpp
@@ -504,6 +504,7 @@ void SciMusic::soundInitSnd(MusicEntry *pSnd) {
 				pSnd->_chan[chan.number]._dontRemap = (chan.flags & 2);
 				pSnd->_chan[chan.number]._prio = chan.prio;
 				pSnd->_chan[chan.number]._voices = chan.poly;
+				pSnd->_chan[chan.number]._mute = (chan.flags & 4) ? 1 : 0;
 
 				// CHECKME: Some SCI versions use chan.flags & 1 for this:
 				pSnd->_chan[chan.number]._dontMap = false;

--- a/engines/sci/sound/music.h
+++ b/engines/sci/sound/music.h
@@ -65,7 +65,7 @@ struct MusicEntryChannel {
 	int8 _voices;
 	bool _dontRemap;
 	bool _dontMap;
-	bool _mute;
+	uint8 _mute;
 };
 
 


### PR DESCRIPTION
…once)

I am not sure if this bug ticket is about just one or about several bugs. This is at least something I could reproduce. The reason is that there can be channels that should start up muted. We didn't support that. I also fixed a couple of other things about the mute state that I noticed.

This should get some testing before it gets merged. 

