### PR TITLE
Fix Instances of Zero Sized Memory Allocations

### DIFF
--- a/engines/glk/quetzal.h
+++ b/engines/glk/quetzal.h
@@ -108,7 +108,7 @@ public:
 		Common::SeekableReadStream *getStream() {
 			_stream->seek(_chunks[_index]._offset);
 			return (_chunks[_index]._size == 0) ?
-				new Common::MemoryReadStream((byte *)malloc(0), 0, DisposeAfterUse::YES) :
+				new Common::MemoryReadStream(nullptr, 0, DisposeAfterUse::YES) :
 				_stream->readStream(_chunks[_index]._size);
 		}
 	};

--- a/engines/wintermute/base/gfx/x/modelx.cpp
+++ b/engines/wintermute/base/gfx/x/modelx.cpp
@@ -121,7 +121,7 @@ static byte *DecompressMsZipData(byte *buffer, uint32 inputSize, uint32 &decompr
 #endif
 	warning("DecompressMsZipData: Error decompressing data!");
 	decompressedSize = 0;
-	return new byte[0];
+	return nullptr;
 }
 
 static XFileLexer createXFileLexer(byte *&buffer, uint32 fileSize) {


### PR DESCRIPTION
Apart from generating warnings from GCC when -Walloc-zero is passed, the behaviour when
malloc or new is called with zero sized is implementation dependent and could result in
portability issues. See:
https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
````
-Walloc-zero

    Warn about calls to allocation functions decorated with attribute alloc_size that specify zero bytes, including those to the built-in forms of the functions aligned_alloc, alloca, calloc, malloc, and realloc. Because the behavior of these functions when called with a zero size differs among implementations (and in the case of realloc has been deprecated) relying on it may result in subtle portability bugs and should be avoided.
````

The GLK Queztal code has an instance of this calling malloc and the WINTERMUTE engine has an instance with C++ new operator for an array in a failure case.

This PR fixes these by replacing them with nullptr, but the engine developers should review to check if the code using this will test correctly in these cases.