### PR TITLE
SCI: fix regression from c2975276 (fix music handling during auto-save)

### DIFF
--- a/engines/sci/sound/music.h
+++ b/engines/sci/sound/music.h
@@ -193,6 +193,7 @@ private:
 public:
 	void clearPlayList();
 	void pauseAll(bool pause);
+	bool isAllPaused() const { return (_globalPause > 0); }
 	void resetGlobalPauseCounter();
 	void stopAll();
 	void stopAllSamples();

--- a/engines/sci/sound/soundcmd.cpp
+++ b/engines/sci/sound/soundcmd.cpp
@@ -369,7 +369,11 @@ reg_t SoundCommandParser::kDoSoundPause(EngineState *s, int argc, reg_t *argv) {
 		(_soundVersion < SCI_VERSION_2 && !obj.getSegment()) ||
 		(_soundVersion >= SCI_VERSION_2 && obj.isNull())
 	) {
-		_music->pauseAll(shouldPause);
+		// Don't unpause here, if the sound is already unpaused. The negative global pause counter
+		// that we introduced to accomodate our special needs during GMM save/load and autosave
+		// operations is not meant to be used here and will cause glitches.
+		if (_music->isAllPaused() || shouldPause)
+			_music->pauseAll(shouldPause);
 #ifdef ENABLE_SCI32
 		if (_soundVersion >= SCI_VERSION_2_1_EARLY) {
 			if (shouldPause) {


### PR DESCRIPTION
This is really a necessary fix, so recommended for merging before the release.

The negative global pause counter (that I really added only for the GMM/autosave situation) may not be used from within kDoSoundPause. It causes issues, the counter will go out of the expected range (also, the "Music also seems to randomly disappear when saving / restoring games" mentioned in ticket no. 13496 might be related to this).

I didn't see this, since we were focussed on SCI0. But it can be easily tested with e. g. LSL1 VGA. Just save right at the start and restore the game, it will call kDoSoundPause and trigger the issue (the counter will go out of range more and more, for me it just triggered the assert in resetGlobalPauseCounter()).
