### PR TITLE
GRAPHICS: Remove false positive warning from Win cursor group parser

### DIFF
--- a/graphics/wincursor.cpp
+++ b/graphics/wincursor.cpp
@@ -263,13 +263,8 @@ WinCursorGroup *WinCursorGroup::createCursorGroup(Common::WinResources *exe, con
 	for (uint32 i = 0; i < cursorCount; i++) {
 		stream->readUint16LE(); // width
 		stream->readUint16LE(); // height
-
-		// Plane count
-		if (stream->readUint16LE() != 1) {
-			warning("PlaneCount is not 1.");
-		}
-
-		stream->readUint16LE(); // bits per pixel
+		stream->readUint16LE(); // x hotspot
+		stream->readUint16LE(); // y hotspot
 		stream->readUint32LE(); // data size
 		uint32 cursorId = stream->readUint16LE();
 


### PR DESCRIPTION
Hard to prove this is correct because the Microsoft docs for the cursor group format is garbled and has CURSORDIR listed as many of the field types when they're actually WORD or DWORD for some reason:
https://docs.microsoft.com/en-us/windows/win32/menurc/resdir

... but right now this code is spamming a bunch of false-positive warnings when loading cursors from Obsidian because the "planes" field is usually 32 or 64.  I think what's going on is that the Planes/BitCount fields are actually xHotSpot/yHotSpot for cursors, corresponding with the difference between ICO and CUR format.

Either way, in-the-wild data is coming up with other numbers that appear to be valid, so this removes the check.