### PR TITLE
HYPNO: Remove unneeded feature dependencies

### DIFF
--- a/engines/hypno/configure.engine
+++ b/engines/hypno/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine hypno "Hypnotix Inc." yes "" "" "highres 16bit"
+add_engine hypno "Hypnotix Inc." yes "" "" ""


### PR DESCRIPTION
As far as I can tell, only Spider-Man: The Sinister Six requires high resolution support, and none of the games targeted by this engine require 16-bit graphics support.