### PR TITLE
AGOS: Fix wrong condition in adlib implementation

### DIFF
--- a/engines/agos/drivers/accolade/adlib.cpp
+++ b/engines/agos/drivers/accolade/adlib.cpp
@@ -147,7 +147,7 @@ void MidiDriver_Accolade_AdLib::deinitSource(uint8 source) {
 		if (_oplType != OPL::Config::kOpl3) {
 			// For OPL2, get the current music instrument for this OPL channel.
 			program = _controlData[0][channel].program;
-			if (_instrumentRemapping)
+			if (_instrumentRemapping[program])
 				// Apply instrument remapping (if specified) to instrument channels.
 				program = _instrumentRemapping[program];
 		}


### PR DESCRIPTION
Reported by GCC 12:

```
../scummvm/engines/agos/drivers/accolade/adlib.cpp: In member function 'virtual void AGOS::MidiDriver_Accolade_AdLib::deinitSource(uint8)':
../scummvm/engines/agos/drivers/accolade/adlib.cpp:150:29: warning: the address of 'AGOS::MidiDriver_Accolade_AdLib::_instrumentRemapping' will never be NULL [-Waddress]
  150 |                         if (_instrumentRemapping)
      |                             ^~~~~~~~~~~~~~~~~~~~
In file included from ../scummvm/engines/agos/drivers/accolade/adlib.cpp:22:
../scummvm/engines/agos/drivers/accolade/adlib.h:86:14: note: 'AGOS::MidiDriver_Accolade_AdLib::_instrumentRemapping' declared here
   86 |         byte _instrumentRemapping[128];
      |              ^~~~~~~~~~~~~~~~~~~~
```
