### PR TITLE
HYPNO: Add a missing argument in function call

### DIFF
--- a/engines/hypno/cursors.cpp
+++ b/engines/hypno/cursors.cpp
@@ -143,7 +143,7 @@ void HypnoEngine::changeCursor(const Common::String &cursor, uint32 n, bool cent
 	Graphics::Surface *entry = decodeFrame(cursor, n, &palette);
 	uint32 hotspotX = centerCursor ? entry->w / 2 : 0;
 	uint32 hotspotY = centerCursor ? entry->h / 2 : 0;
-	CursorMan.replaceCursor(entry->getPixels(), entry->w, entry->h, hotspotX, hotspotY, 0, &_pixelFormat);
+	CursorMan.replaceCursor(entry->getPixels(), entry->w, entry->h, hotspotX, hotspotY, 0, false, &_pixelFormat);
 	CursorMan.replaceCursorPalette(palette, 0, 256);
 	entry->free();
 	delete entry;
@@ -153,7 +153,7 @@ void HypnoEngine::changeCursor(const Common::String &cursor, uint32 n, bool cent
 void HypnoEngine::changeCursor(const Graphics::Surface &entry, byte *palette, bool centerCursor) {
 	uint32 hotspotX = centerCursor ? entry.w / 2 : 0;
 	uint32 hotspotY = centerCursor ? entry.h / 2 : 0;
-	CursorMan.replaceCursor(entry.getPixels(), entry.w, entry.h, hotspotX, hotspotY, 0, &_pixelFormat);
+	CursorMan.replaceCursor(entry.getPixels(), entry.w, entry.h, hotspotX, hotspotY, 0, false, &_pixelFormat);
 	CursorMan.replaceCursorPalette(palette, 0, 256);
 	CursorMan.showMouse(true);
 }


### PR DESCRIPTION
Reported by GCC 12:

```
../scummvm/engines/hypno/cursors.cpp:146:96: warning: the address of 'Hypno::HypnoEngine::_pixelFormat' will never be NULL [-Waddress]
  146 |         CursorMan.replaceCursor(entry->getPixels(), entry->w, entry->h, hotspotX, hotspotY, 0, &_pixelFormat);
      |                                                                                                ^~~~~~~~~~~~~
```