### PR TITLE
GLK: Remove pointless NULL validation

### DIFF
--- a/engines/glk/tads/tads2/debug.cpp
+++ b/engines/glk/tads/tads2/debug.cpp
@@ -155,7 +155,7 @@ int dbgnam(dbgcxdef *ctx, char *outbuf, int typ, int val)
 {
 	toksdef  sym;
 
-	if (!ctx->dbgcxtab || !ctx->dbgcxtab->tokthhsh)
+	if (!ctx->dbgcxtab)
 	{
 		memcpy(outbuf, "<NO SYMBOL TABLE>", (size_t)17);
 		return(17);


### PR DESCRIPTION
Reported by GCC 12:
```
../scummvm/engines/glk/tads/tads2/debug.cpp: In function 'int Glk::TADS::TADS2::dbgnam(dbgcxdef*, char*, int, int)':
../scummvm/engines/glk/tads/tads2/debug.cpp:158:47: warning: the address of 'Glk::TADS::TADS2::tokthdef::tokthhsh' will never be NULL [-Waddress]
  158 |         if (!ctx->dbgcxtab || !ctx->dbgcxtab->tokthhsh)
      |                                ~~~~~~~~~~~~~~~^~~~~~~~
In file included from ../scummvm/engines/glk/tads/tads2/run.h:42,
                 from ../scummvm/engines/glk/tads/tads2/debug.cpp:24:
../scummvm/engines/glk/tads/tads2/tokenizer.h:222:19: note: 'Glk::TADS::TADS2::tokthdef::tokthhsh' declared here
  222 |         tokthpdef tokthhsh[TOKHASHSIZE];                          /* hash table */
      |                   ^~~~~~~~
```
