### PR TITLE
GLK: Fix bad indentation

### DIFF
--- a/engines/glk/zcode/processor.cpp
+++ b/engines/glk/zcode/processor.cpp
@@ -349,7 +349,7 @@ void Processor::call(zword routine, int argc, zword *args, int ct) {
 		if (h_version <= V4)		// V1 to V4 games provide default
 			CODE_WORD(value);		// values for all local variables
 
-			*--_sp = (zword)((argc-- > 0) ? args[i] : value);
+		*--_sp = (zword)((argc-- > 0) ? args[i] : value);
 	}
 
 	// Start main loop for direct calls


### PR DESCRIPTION
Reported by GCC 12:
```
../scummvm/engines/glk/zcode/processor.cpp: In member function 'void Glk::ZCode::Processor::call(Glk::ZCode::zword, int, Glk::ZCode::zword*, int)':
../scummvm/engines/glk/zcode/processor.cpp:349:17: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
  349 |                 if (h_version <= V4)            // V1 to V4 games provide default
      |                 ^~
../scummvm/engines/glk/zcode/processor.cpp:352:25: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
  352 |                         *--_sp = (zword)((argc-- > 0) ? args[i] : value);
      |                         ^
```