### PR TITLE
KYRA: Fix pointless NULL validation

### DIFF
--- a/engines/kyra/script/script_hof.cpp
+++ b/engines/kyra/script/script_hof.cpp
@@ -872,8 +872,7 @@ int KyraEngine_HoF::o2_defineSceneAnim(EMCState *script) {
 	anim.height = stackPos(7);
 	anim.specialSize = stackPos(9);
 	anim.shapeIndex = stackPos(11);
-	if (stackPosString(12) != nullptr)
-		strcpy(anim.filename, stackPosString(12));
+	strcpy(anim.filename, stackPosString(12));
 
 	if (anim.flags & 0x40) {
 		if (!_sceneAnimMovie[animId]->open(anim.filename, 1, nullptr))


### PR DESCRIPTION
Reported by GCC 12:
```
../scummvm/engines/kyra/script/script_hof.cpp: In member function 'int Kyra::KyraEngine_HoF::o2_defineSceneAnim(Kyra::EMCState*)':
../scummvm/engines/kyra/script/script_hof.cpp:875:32: warning: comparing the result of pointer addition '(((const char*)script->Kyra::EMCState::dataPtr->Kyra::EMCData::text) + ((sizetype)READ_BE_UINT16((((const void*)script->Kyra::EMCState::dataPtr->Kyra::EMCData::text) + ((sizetype)(((int)((Kyra::KyraEngine_HoF*)this)->Kyra::KyraEngine_HoF::<anonymous>.Kyra::KyraEngine_v2::<anonymous>.Kyra::KyraEngine_v1::emcSafeReadStack(script, 12, 875, ((const char*)"../scummvm/engines/kyra/script/script_hof.cpp"))) << 1))))))' and NULL [-Waddress]
  875 |         if (stackPosString(12) != nullptr)
```
