### PR TITLE
TOON: Menu fixes, and settings synchronization with ScummVM config

### DIFF
--- a/engines/toon/audio.cpp
+++ b/engines/toon/audio.cpp
@@ -127,6 +127,7 @@ int AudioManager::playMusic(const Common::String &dir, const Common::String &mus
 	_channels[_currentMusicChannel] = new AudioStreamInstance(this, _mixer, srs, true, true);
 	_channels[_currentMusicChannel]->setVolume(_musicMuted ? 0 : 255);
 	_channels[_currentMusicChannel]->play(true, Audio::Mixer::kMusicSoundType);
+
 	return _currentMusicChannel;
 }
 
@@ -212,7 +213,7 @@ bool AudioManager::loadAudioPack(int32 id, const Common::String &indexFile, cons
 	return _audioPacks[id]->loadAudioPackage(indexFile, packFile);
 }
 
-void AudioManager::setMusicVolume(int32 volume) {
+void AudioManager::setMusicVolume(uint8 volume) {
 	debugC(1, kDebugAudio, "setMusicVolume(%d)", volume);
 	if (_channels[0])
 		_channels[0]->setVolume(volume);

--- a/engines/toon/audio.h
+++ b/engines/toon/audio.h
@@ -130,13 +130,14 @@ public:
 
 	bool voiceStillPlaying();
 
-	void playMusic(const Common::String &dir, const Common::String &music);
+	int playMusic(const Common::String &dir, const Common::String &music);
 	void playVoice(int32 id, bool genericVoice);
 	int32 playSFX(int32 id, int volume, bool genericSFX);
 	void stopCurrentVoice();
 	void stopAllSfxs();
 	void setMusicVolume(int32 volume);
-	void stopMusic();
+	void stopMusicChannel(int channelId, bool fade);
+	void stopMusic(bool fade = true);
 	void muteVoice(bool mute);
 	void muteMusic(bool mute);
 	void muteSfx(bool mute);
@@ -154,14 +155,15 @@ public:
 	bool loadAudioPack(int32 id, const Common::String &indexFile, const Common::String &packFile);
 
 	AudioStreamInstance *_channels[16];  // 0-1 : music
-	// 2 : voice
-	// 3-16 : SFX
+	                                     // 2 : voice
+	                                     // 3-16 : SFX
 
 	AudioStreamPackage *_audioPacks[4];  // 0 : generic streams
-	// 1 : local streams
-	// 2 : generic SFX
-	// 3 : local SFX
-	uint32 _currentMusicChannel;
+	                                     // 1 : local streams
+	                                     // 2 : generic SFX
+	                                     // 3 : local SFX
+
+	int _currentMusicChannel;
 	Common::String _currentMusicName;
 	ToonEngine *_vm;
 	Audio::Mixer *_mixer;

--- a/engines/toon/audio.h
+++ b/engines/toon/audio.h
@@ -156,7 +156,7 @@ public:
 
 	AudioStreamInstance *_channels[16];  // 0-1 : music
 	                                     // 2 : voice
-	                                     // 3-16 : SFX
+	                                     // 3-15 : SFX
 
 	AudioStreamPackage *_audioPacks[4];  // 0 : generic streams
 	                                     // 1 : local streams

--- a/engines/toon/audio.h
+++ b/engines/toon/audio.h
@@ -135,15 +135,15 @@ public:
 	int32 playSFX(int32 id, int volume, bool genericSFX);
 	void stopCurrentVoice();
 	void stopAllSfxs();
-	void setMusicVolume(int32 volume);
+	void setMusicVolume(uint8 volume);
 	void stopMusicChannel(int channelId, bool fade);
 	void stopMusic(bool fade = true);
 	void muteVoice(bool mute);
 	void muteMusic(bool mute);
 	void muteSfx(bool mute);
-	bool isVoiceMuted() { return _voiceMuted; }
-	bool isMusicMuted() { return _musicMuted; }
-	bool isSfxMuted() { return _sfxMuted; }
+	bool isVoiceMuted() const { return _voiceMuted; }
+	bool isMusicMuted() const { return _musicMuted; }
+	bool isSfxMuted() const { return _sfxMuted; }
 
 	void startAmbientSFX(int32 id, int32 delay, int32 mode, int32 volume);
 	void killAmbientSFX(int32 id);

--- a/engines/toon/subtitles.cpp
+++ b/engines/toon/subtitles.cpp
@@ -37,7 +37,7 @@ SubtitleRenderer::~SubtitleRenderer() {
 
 
 void SubtitleRenderer::render(const Graphics::Surface &frame, uint32 frameNumber, byte color) {
-	if (!_hasSubtitles || _tw.empty()) {
+	if (!_hasSubtitles || _tw.empty() || !_vm->showConversationText()) {
 		return;
 	}
 

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -1290,9 +1290,8 @@ bool ToonEngine::showMainmenu(bool &loadedGame) {
 	bool doExitMenu = false;
 	bool exitGame = false;
 	int menuMask = MAINMENUMASK_BASE;
-	Common::SeekableReadStream *mainmenuMusicFile = NULL;
-	AudioStreamInstance *mainmenuMusic = NULL;
 	bool musicPlaying = false;
+	int musicPlayingChannel = -1;
 	int32 oldMouseButton = _mouseButton;
 
 	_gameState->_inMenu = true;
@@ -1305,14 +1304,8 @@ bool ToonEngine::showMainmenu(bool &loadedGame) {
 
 		while (!clickRelease) {
 			if (!musicPlaying) {
-				mainmenuMusicFile = resources()->openFile("BR091013.MUS");
-				if (mainmenuMusicFile) {
-					mainmenuMusic = new AudioStreamInstance(_audioManager, _mixer, mainmenuMusicFile, true);
-					mainmenuMusic->play(false);
-					musicPlaying = true;
-				} else {
-					musicPlaying = false;
-				}
+				musicPlayingChannel = _audioManager->playMusic("", "BR091013");
+				musicPlaying = musicPlayingChannel >= 0;
 			}
 
 			if (_dirtyAll) {
@@ -1422,6 +1415,7 @@ bool ToonEngine::showMainmenu(bool &loadedGame) {
 							break;
 
 						case MAINMENUHOTSPOT_LOADGAME:
+
 							doExitMenu = loadGame(-1);
 							loadedGame = doExitMenu;
 							if (loadedGame) {
@@ -1438,8 +1432,7 @@ bool ToonEngine::showMainmenu(bool &loadedGame) {
 						case MAINMENUHOTSPOT_CREDITS:
 							if (musicPlaying) {
 								//stop music
-								mainmenuMusic->stop(false);
-								delete mainmenuMusicFile;
+								_audioManager->stopMusicChannel(musicPlayingChannel, false);
 								musicPlaying = false;
 							}
 							if (clickingOn == MAINMENUHOTSPOT_INTRO) {
@@ -1475,8 +1468,7 @@ bool ToonEngine::showMainmenu(bool &loadedGame) {
 
 		if (musicPlaying && doExitMenu) {
 			//stop music
-			mainmenuMusic->stop(false);
-			delete mainmenuMusicFile;
+			_audioManager->stopMusicChannel(musicPlayingChannel, false);
 			musicPlaying = false;
 		}
 	}

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -918,18 +918,17 @@ bool ToonEngine::showOptions() {
 			oldMouseY = _mouseY;
 			oldMouseButton = _mouseButton;
 
-			// update mouse clicking state and handle hotkeys
-			parseInput();
-
-			// NOTE Placing the code here seems to mitigate the issue
-			//      of clicking Play to resume playing and Drew moving to
-			//      that spot in-game.
-			//      It still happens if mouse button is held down.
 			if (_shouldQuit || doExitMenu) {
 				clickingOn = OPTIONMENUHOTSPOT_NONE;
 				clickRelease = true;
 				doExitMenu = true;
+				// Prevent holding left mouse button down to be detected
+				// as a new click when returning from menu
+				_lastMouseButton = _mouseButton;
 			} else {
+				// update mouse clicking state and handle hotkeys
+				parseInput();
+
 				copyToVirtualScreen(true);
 				if (_firstFrame) {
 					_firstFrame = false;
@@ -1340,13 +1339,17 @@ bool ToonEngine::showMainmenu(bool &loadedGame) {
 
 			oldMouseButton = _mouseButton;
 
-			parseInput();
-
 			if (_shouldQuit || doExitMenu) {
 				clickingOn = MAINMENUHOTSPOT_NONE;
 				clickRelease = true;
 				doExitMenu = true;
+				// Prevent holding left mouse button down to be detected
+				// as a new click when returning from menu
+				_lastMouseButton = _mouseButton;
 			} else {
+				// update mouse clicking state and handle hotkeys
+				parseInput();
+
 				copyToVirtualScreen(true);
 				_system->delayMillis(17);
 
@@ -2255,6 +2258,7 @@ void ToonEngine::clickEvent() {
 
 		if (_pathFinding->findClosestWalkingPoint(_mouseX + _gameState->_currentScrollValue , _mouseY, &xx, &yy))
 			_drew->walkTo(xx, yy);
+
 		return;
 	}
 

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -3699,6 +3699,10 @@ void ToonEngine::drawCustomText(int16 x, int16 y, const char *line, Graphics::Su
 	}
 }
 
+bool ToonEngine::showConversationText() const {
+	return _showConversationText;
+}
+
 void ToonEngine::pauseEngineIntern(bool pause) {
 
 	Engine::pauseEngineIntern(pause);

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -152,6 +152,8 @@ void ToonEngine::init() {
 	_audioManager->loadAudioPack(0, "GENERIC.SVI", "GENERIC.SVL");
 	_audioManager->loadAudioPack(2, "GENERIC.SEI", "GENERIC.SEL");
 
+	adjustMovieVolume();
+
 	_lastMouseButton = 0;
 	_mouseButton = 0;
 	_lastRenderTime = _system->getMillis();
@@ -207,15 +209,18 @@ void ToonEngine::parseInput() {
 			}
 			if (event.kbd.keycode == Common::KEYCODE_m && !hasModifier) {
 				_audioManager->muteMusic(!_audioManager->isMusicMuted());
+				adjustMovieVolume();
 			}
 			if (event.kbd.keycode == Common::KEYCODE_d && !hasModifier) {
 				_audioManager->muteVoice(!_audioManager->isVoiceMuted());
+				adjustMovieVolume();
 				if (!_showConversationText && _audioManager->isVoiceMuted()) {
 					turnOnText(true, false);
 				}
 			}
 			if (event.kbd.keycode == Common::KEYCODE_s && !hasModifier) {
 				_audioManager->muteSfx(!_audioManager->isSfxMuted());
+				adjustMovieVolume();
 			}
 			if (event.kbd.keycode == Common::KEYCODE_F1 && !hasModifier) {
 				if (_gameState->_inMenu) {
@@ -1061,6 +1066,7 @@ bool ToonEngine::showOptions() {
 							chosenSoundType = Audio::Mixer::kSFXSoundType;
 						}
 						_mixer->setVolumeForSoundType(chosenSoundType, targetVol);
+						adjustMovieVolume();
 
 						if (_mixer->getVolumeForSoundType(Audio::Mixer::kSpeechSoundType) == 0
 						    && !_showConversationText) {
@@ -1133,6 +1139,7 @@ bool ToonEngine::showOptions() {
 								} else
 									_audioManager->muteSfx(true);
 							}
+							adjustMovieVolume();
 							if (!_isEnglishDemo)
 								playSFX(-7, 128);
 							break;
@@ -1498,6 +1505,13 @@ bool ToonEngine::showQuitConfirmationDialogue() {
 	// text variant of the yes/no option).
 	GUI::MessageDialog dialog(_("Are you sure you want to exit?"), _("Yes"), _("No"));
 	return (dialog.runModal() == GUI::kMessageOK);
+}
+
+void ToonEngine::adjustMovieVolume() {
+	int movieVol = MAX<int>((_audioManager->isMusicMuted() ? 0 : _mixer->getVolumeForSoundType(Audio::Mixer::kMusicSoundType)),
+	                        (_audioManager->isVoiceMuted() ? 0 : _mixer->getVolumeForSoundType(Audio::Mixer::kSpeechSoundType)));
+	movieVol = MAX<int>(movieVol,(_audioManager->isSfxMuted() ? 0 : _mixer->getVolumeForSoundType(Audio::Mixer::kSFXSoundType)));
+	_mixer->setVolumeForSoundType(Audio::Mixer::kPlainSoundType, movieVol);
 }
 
 Common::Error ToonEngine::run() {

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -569,20 +569,20 @@ enum MainMenuMasks {
 };
 
 enum OptionMenuSelections {
-	OPTIONMENUHOTSPOT_NONE					= 0,
-	OPTIONMENUHOTSPOT_PLAY					= 1,
-	OPTIONMENUHOTSPOT_QUIT					= 2,
-	OPTIONMENUHOTSPOT_TEXT					= 3,
-	OPTIONMENUHOTSPOT_TEXTSPEED				= 4,
-	OPTIONMENUHOTSPOT_VOLUMESFX				= 5,
-	OPTIONMENUHOTSPOT_VOLUMESFXSLIDER		= 6,
-	OPTIONMENUHOTSPOT_VOLUMEMUSIC			= 7,
-	OPTIONMENUHOTSPOT_VOLUMEMUSICSLIDER		= 8,
-	OPTIONMENUHOTSPOT_VOLUMEVOICE			= 9,
-	OPTIONMENUHOTSPOT_VOLUMEVOICESLIDER		= 10,
-	OPTIONMENUHOTSPOT_SPEAKERBUTTON			= 11,
-	OPTIONMENUHOTSPOT_SPEAKERLEVER			= 12,
-	OPTIONMENUHOTSPOT_VIDEO_MODE			= 13
+	OPTIONMENUHOTSPOT_NONE                  = 0,
+	OPTIONMENUHOTSPOT_PLAY                  = 1,
+	OPTIONMENUHOTSPOT_QUIT                  = 2,
+	OPTIONMENUHOTSPOT_TEXT                  = 3,
+	OPTIONMENUHOTSPOT_TEXTSPEED             = 4,
+	OPTIONMENUHOTSPOT_VOLUMESFX             = 5,
+	OPTIONMENUHOTSPOT_VOLUMESFXSLIDER       = 6,
+	OPTIONMENUHOTSPOT_VOLUMEMUSIC           = 7,
+	OPTIONMENUHOTSPOT_VOLUMEMUSICSLIDER     = 8,
+	OPTIONMENUHOTSPOT_VOLUMEVOICE           = 9,
+	OPTIONMENUHOTSPOT_VOLUMEVOICESLIDER     = 10,
+	OPTIONMENUHOTSPOT_SPEAKERBUTTON         = 11,
+	OPTIONMENUHOTSPOT_SPEAKERLEVER          = 12,
+	OPTIONMENUHOTSPOT_VIDEO_MODE            = 13
 };
 
 enum OptionMenuMasks {
@@ -620,7 +620,7 @@ static const MenuFile optionMenuFiles[] = {
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_QUIT,					"QUITBUTN.CAF",	0 },	// "Quit" button
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_VIDEO_MODE,			"VIDMODE.CAF",	0 },	// "Video mode" slider
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_TEXTSPEED,			"TXTSPEED.CAF",	0 },	// "Text speed" slider
-	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_TEXT,					"TEXTDIAL.CAF",	0},		// "Text" button
+	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_TEXT,					"TEXTDIAL.CAF",	0 },	// "Text" button
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_VOLUMESFX,			"SFXBUTN.CAF",	0 },	// "SFX" button
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_VOLUMESFXSLIDER,		"SFXSLDR.CAF",	0 },	// "SFX volume" slider
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_VOLUMEVOICE,			"VOICEBTN.CAF",	0 },	// "Voice" button
@@ -628,7 +628,7 @@ static const MenuFile optionMenuFiles[] = {
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_VOLUMEMUSIC,			"MUSICBTN.CAF",	0 },	// "Music" button
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_VOLUMEMUSICSLIDER,	"MUSICSLD.CAF",	0 },	// "Music volume" button
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_SPEAKERBUTTON,		"XTRABUTN.CAF",	0 },	// Right speaker button
-	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_SPEAKERLEVER,			"XTRALEVR.CAF",	0},		// Left speaker switch
+	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_SPEAKERLEVER,			"XTRALEVR.CAF",	0 },	// Left speaker switch
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_NONE,					"ANTENNAL.CAF",	6 },	// Decorative animation
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_NONE,					"ANTENNAR.CAF",	6 },	// Decorative animation
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_NONE,					"BIGREDL.CAF",	6 },	// Decorative animation
@@ -653,7 +653,7 @@ static const MenuFile optionMenuFilesEnglishDemo[] = {
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_QUIT,					"QUITBUTN.CAF",	0 },	// "Quit" button
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_VIDEO_MODE,			"VIDMODE.CAF",	0 },	// "Video mode" slider
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_TEXTSPEED,			"TXTSPEED.CAF",	0 },	// "Text speed" slider
-	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_TEXT,					"TEXTDIAL.CAF",	0},		// "Text" button
+	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_TEXT,					"TEXTDIAL.CAF",	0 },	// "Text" button
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_VOLUMESFX,			"SFXBUTN.CAF",	0 },	// "SFX" button
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_VOLUMESFXSLIDER,		"SFXSLDR.CAF",	0 },	// "SFX volume" slider
 	{ OPTIONMENUMASK_EVERYWHERE,	OPTIONMENUHOTSPOT_VOLUMEVOICE,			"VOICEBTN.CAF",	0 },	// "Voice" button
@@ -671,11 +671,12 @@ struct MenuEntry {
 	int animateOnFrame;
 	int animateCurFrame;
 	int activeFrame;
+	int targetFrame;
 	bool playOnce;
+	bool handled;
 };
 
 bool ToonEngine::showOptions() {
-
 	storePalette();
 	fadeOut(5);
 	Picture* optionPicture = new Picture(this);
@@ -690,30 +691,55 @@ bool ToonEngine::showOptions() {
 	_gameState->_mouseHidden = false;
 
 	// English demo options menu has less animations and no SFX
-	int optionMenuEntryCount = _isEnglishDemo ? OPTIONMENU_ENTRYCOUNT_ENGLISH_DEMO : OPTIONMENU_ENTRYCOUNT;
+	const int optionMenuEntryCount = _isEnglishDemo ? OPTIONMENU_ENTRYCOUNT_ENGLISH_DEMO : OPTIONMENU_ENTRYCOUNT;
+
 	const MenuFile *optionMenuFilesPtr = _isEnglishDemo ? optionMenuFilesEnglishDemo : optionMenuFiles;
 	MenuEntry *entries = new MenuEntry[optionMenuEntryCount];
 
-	for (int entryNr = 0; entryNr < optionMenuEntryCount; entryNr++) {
+	for (int entryNr = 0; entryNr < optionMenuEntryCount; ++entryNr) {
 		entries[entryNr].menuMask = optionMenuFilesPtr[entryNr].menuMask;
 		entries[entryNr].id = optionMenuFilesPtr[entryNr].id;
 		entries[entryNr].animation = new Animation(this);
 		entries[entryNr].animation->loadAnimation(optionMenuFilesPtr[entryNr].animationFile);
-		if (entries[entryNr].id != OPTIONMENUHOTSPOT_NONE)
+		if (entries[entryNr].id != OPTIONMENUHOTSPOT_NONE) {
 			entries[entryNr].rect = entries[entryNr].animation->getRect();
+			// Bug fix for short hotspot rectangle for the text speed slider
+			// This bug is an original game bug.
+			// NOTE If low resolution mode is supported in the future,
+			//      this height increment should be adjusted accordingly
+			if (entries[entryNr].id == OPTIONMENUHOTSPOT_TEXTSPEED)
+				entries[entryNr].rect.bottom += 10;
+
+			if (entries[entryNr].id == OPTIONMENUHOTSPOT_TEXT && !_isEnglishDemo) {
+				// For the game proper we need to extend the rectangle for the TEXT hotspot
+				// above and to the left and right, so that we can detect clicking on
+				// each of the labels around the dial.
+				// NOTE If low resolution mode is supported in the future,
+				//      these rectangle dimensions should be adjusted accordingly
+				entries[entryNr].rect.top -= 20;
+				entries[entryNr].rect.left -= 65;
+				entries[entryNr].rect.right += 65;
+			}
+		}
 		entries[entryNr].animateOnFrame = optionMenuFilesPtr[entryNr].animateOnFrame;
 		entries[entryNr].animateCurFrame = 0;
 		entries[entryNr].activeFrame = 0;
+		entries[entryNr].targetFrame = -1;
 		entries[entryNr].playOnce = false;
+		entries[entryNr].handled = false;
 	}
 
-	entries[10].activeFrame = _audioManager->_mixer->getVolumeForSoundType(Audio::Mixer::kMusicSoundType) * (entries[10].animation->_numFrames - 1) / 256;
-	entries[8].activeFrame = _audioManager->_mixer->getVolumeForSoundType(Audio::Mixer::kSpeechSoundType) * (entries[8].animation->_numFrames - 1) / 256;
-	entries[6].activeFrame = _audioManager->_mixer->getVolumeForSoundType(Audio::Mixer::kSFXSoundType) * (entries[6].animation->_numFrames - 1) / 256;
+	// Setting dial / option value in the game options menu
+	entries[10].activeFrame = _mixer->getVolumeForSoundType(Audio::Mixer::kMusicSoundType) * (entries[10].animation->_numFrames - 1) / Audio::Mixer::kMaxMixerVolume;
+	entries[8].activeFrame = _mixer->getVolumeForSoundType(Audio::Mixer::kSpeechSoundType) * (entries[8].animation->_numFrames - 1) / Audio::Mixer::kMaxMixerVolume;
+	entries[6].activeFrame = _mixer->getVolumeForSoundType(Audio::Mixer::kSFXSoundType) * (entries[6].animation->_numFrames - 1) / Audio::Mixer::kMaxMixerVolume;
 
 	entries[9].activeFrame = _audioManager->isMusicMuted() ? 0 : 3;
 	entries[7].activeFrame = _audioManager->isVoiceMuted() ? 0 : 3;
 	entries[5].activeFrame = _audioManager->isSfxMuted() ? 0 : 3;
+
+	// TODO retrieve stored textSpeed value and set the needle indicator accordingly
+	entries[3].activeFrame = 0;
 
 	entries[2].activeFrame = entries[2].animation->_numFrames - 1;
 
@@ -734,17 +760,25 @@ bool ToonEngine::showOptions() {
 
 	int menuMask = OPTIONMENUMASK_EVERYWHERE;
 	int ratioX = 0;
-	bool doExit = false;
+	int ratioY = 0;
+	bool doExitMenu = false;
 	bool exitGame = false;
+	bool targetFrameExceeded = false;
 	_gameState->_inMenu = true;
 	dirtyAllScreen();
 	_firstFrame = true;
 
-	while (!doExit) {
+	int32 oldMouseX = _mouseX;
+	int32 oldMouseY = _mouseY;
+	int32 oldMouseButton = _mouseButton;
+	int targetVol;
+	Audio::Mixer::SoundType chosenSoundType;
+
+	while (!doExitMenu) {
 
 		int clickingOn = OPTIONMENUHOTSPOT_NONE;
 		int clickingOnSprite = 0;
-		int clickRelease = false;
+		bool clickRelease = false;
 
 		while (!clickRelease) {
 
@@ -756,7 +790,8 @@ bool ToonEngine::showOptions() {
 			}
 			clearDirtyRects();
 
-			for (int entryNr = 0; entryNr < optionMenuEntryCount; entryNr++) {
+			// Handle animations
+			for (int entryNr = 0; entryNr < optionMenuEntryCount; ++entryNr) {
 				if (entries[entryNr].menuMask & menuMask) {
 					int animPosX = 0;
 					int animPosY = 0;
@@ -765,7 +800,7 @@ bool ToonEngine::showOptions() {
 						if (sparkleDelay > 0) {
 							// Don't show the next sparkle until the delay has
 							// counted down.
-							sparkleDelay--;
+							--sparkleDelay;
 							continue;
 						} else if (entries[entryNr].animateCurFrame == 0 && entries[entryNr].activeFrame == 0) {
 							// Start of a new sparkle animation. Generate a
@@ -776,202 +811,299 @@ bool ToonEngine::showOptions() {
 						animPosX = sparklePosX;
 						animPosY = sparklePosY;
 					}
-					if (entries[entryNr].animateOnFrame) {
-						entries[entryNr].animateCurFrame++;
+					if (entries[entryNr].animateOnFrame) { // animateOnFrame is used to slow down an animation
+						++entries[entryNr].animateCurFrame; // counter towards animateOnFrame
 						if (entries[entryNr].animateOnFrame <= entries[entryNr].animateCurFrame) {
-							entries[entryNr].activeFrame++;
-							if (entries[entryNr].activeFrame >= entries[entryNr].animation->_numFrames) {
-								entries[entryNr].activeFrame = 0;
-								if (entries[entryNr].playOnce) {
+
+							if (entries[entryNr].targetFrame >= 0) {
+								if (entries[entryNr].targetFrame >= entries[entryNr].animation->_numFrames) {
+									entries[entryNr].targetFrame = entries[entryNr].animation->_numFrames - 1;
+								}
+								targetFrameExceeded = false;
+								if (entries[entryNr].activeFrame <= entries[entryNr].targetFrame) {
+									++entries[entryNr].activeFrame;
+									if (entries[entryNr].activeFrame > entries[entryNr].targetFrame)
+										targetFrameExceeded = true;
+								} else if (entries[entryNr].activeFrame >= entries[entryNr].targetFrame) {
+									--entries[entryNr].activeFrame;
+									if (entries[entryNr].activeFrame < entries[entryNr].targetFrame)
+										targetFrameExceeded = true;
+								}
+
+								if (targetFrameExceeded) {
 									entries[entryNr].animateOnFrame = 0;
-									entries[entryNr].playOnce = false;
+									entries[entryNr].activeFrame = entries[entryNr].targetFrame;
+									entries[entryNr].targetFrame = -1;
+
+									if (entries[entryNr].id == OPTIONMENUHOTSPOT_PLAY) { // PLAY BUTTON
+										exitGame = false;
+										doExitMenu = true;
+									}
+
+									if (entries[entryNr].id == OPTIONMENUHOTSPOT_QUIT) { // QUIT BUTTON
+										exitGame = showQuitConfirmationDialogue();
+										if (exitGame)  {
+											doExitMenu = true;
+										} else {
+											entries[entryNr].activeFrame = 0;
+										}
+									}
 								}
-								if (entryNr == 20 && entries[entryNr].animateOnFrame > 0) {
-									playSFX(-3, 128);
+							} else {
+								++entries[entryNr].activeFrame;
+								if (!_isEnglishDemo && entries[entryNr].activeFrame == 3) {
+									if (entryNr == 19)  {
+										// The left (SPEECH test) horn has 7 frames.
+										// Frame 3 works best to play the Burp Speech sound
+										_audioManager->playVoice(316, true);
+									} else if (entryNr == 20) {
+										// The right (SFX test) horn has 7 frames.
+										// Frame 3 works best to play the Bell SFX sound
+										playSFX(-3, 128);
+									}
 								}
-								if (_isEnglishDemo && entryNr == 11)
-									// Sparkle animation has finished. Generate
-									// a random delay until the next sparkle.
-									sparkleDelay = randRange(0, 100);
+								if (entries[entryNr].activeFrame >= entries[entryNr].animation->_numFrames) {
+									entries[entryNr].activeFrame = 0;
+									if (_isEnglishDemo && entryNr == 11) {
+										// Sparkle animation has finished. Generate
+										// a random delay until the next sparkle.
+										sparkleDelay = randRange(0, 100);
+									}
+									if (entries[entryNr].playOnce) {
+										entries[entryNr].animateOnFrame = 0;
+										entries[entryNr].playOnce = false;
+									}
+								}
 							}
 							entries[entryNr].animateCurFrame = 0;
 						}
 					}
-					int32 frameNr = entries[entryNr].activeFrame;
-					entries[entryNr].animation->drawFrame(*_mainSurface, frameNr, animPosX, animPosY);
+					entries[entryNr].animation->drawFrame(*_mainSurface, entries[entryNr].activeFrame, animPosX, animPosY);
 				}
 			}
 
+			oldMouseX = _mouseX;
+			oldMouseY = _mouseY;
+			oldMouseButton = _mouseButton;
+
+			// update mouse clicking state
 			parseInput();
 
-			copyToVirtualScreen(true);
-			if (_firstFrame) {
-				_firstFrame = false;
-				fadeIn(5);
-			}
-			_system->delayMillis(17);
-
-			if (_mouseButton & 1) {
-				// left mouse button pushed down
+			// NOTE Placing the code here seems to mitigate the issue
+			//      of clicking Play to resume playing and Drew moving to
+			//      that spot in-game.
+			//      It still happens if mouse button is held down.
+			if (_shouldQuit || doExitMenu) {
 				clickingOn = OPTIONMENUHOTSPOT_NONE;
-				for (int entryNr = 0; entryNr < optionMenuEntryCount; entryNr++) {
-					if (entries[entryNr].menuMask & menuMask) {
-						if (entries[entryNr].id != OPTIONMENUHOTSPOT_NONE) {
-							if (entries[entryNr].rect.contains(_mouseX, _mouseY)) {
+				clickRelease = true;
+				doExitMenu = true;
+			} else {
+				copyToVirtualScreen(true);
+				if (_firstFrame) {
+					_firstFrame = false;
+					fadeIn(5);
+				}
+				_system->delayMillis(17);
+
+				// Avoid unnecessary checks and actions if mouse has not moved or changed status
+				if (oldMouseButton != _mouseButton
+				    || ((_mouseButton & 1)
+				        && (oldMouseX != _mouseX || oldMouseY != _mouseY))) {
+					if (_mouseButton & 1) {
+						// left mouse button pressed
+						for (int entryNr = 0; entryNr < optionMenuEntryCount; ++entryNr) {
+							if (entries[entryNr].menuMask & menuMask
+							    && entries[entryNr].id != OPTIONMENUHOTSPOT_NONE
+							    && entries[entryNr].rect.contains(_mouseX, _mouseY)
+							    && ((clickingOn == OPTIONMENUHOTSPOT_NONE && !(oldMouseButton & 1))
+							        || (clickingOn == entries[entryNr].id && !entries[entryNr].handled))) {
 								clickingOn = entries[entryNr].id;
 								clickingOnSprite = entryNr;
+								// Note, due to how rect.contains() is implemented,
+								// the difference (_mouseX - entries[entryNr].rect.left)
+								// will always be lower than entries[entryNr].rect.width()
+								// and thus ratioX will always be lower than 256.
+								// This is intentional.
 								ratioX = (_mouseX - entries[entryNr].rect.left) * 256 / entries[entryNr].rect.width();
+								ratioY = (_mouseY - entries[entryNr].rect.top) * 256 / entries[entryNr].rect.height();
+								break;
 							}
+						}
+					} else if (clickingOn != OPTIONMENUHOTSPOT_NONE) {
+						// left mouse button released/not pushed down
+						clickRelease = true;
+						clickingOn = OPTIONMENUHOTSPOT_NONE;
+						entries[clickingOnSprite].handled = false;
+					}
+
+					// handle sliders
+					switch (clickingOn) {
+					case OPTIONMENUHOTSPOT_VOLUMEMUSICSLIDER:
+						// fall through
+					case OPTIONMENUHOTSPOT_VOLUMEVOICESLIDER:
+						// fall through
+					case OPTIONMENUHOTSPOT_VOLUMESFXSLIDER:
+						entries[clickingOnSprite].targetFrame = ratioX * (entries[clickingOnSprite].animation->_numFrames) / 256;
+						entries[clickingOnSprite].animateOnFrame = 1;
+						entries[clickingOnSprite].playOnce = true;
+
+						targetVol = entries[clickingOnSprite].targetFrame * Audio::Mixer::kMaxMixerVolume / (entries[clickingOnSprite].animation->_numFrames - 1);
+						if (clickingOn == OPTIONMENUHOTSPOT_VOLUMEMUSICSLIDER)
+							chosenSoundType = Audio::Mixer::kMusicSoundType;
+						else if (clickingOn == OPTIONMENUHOTSPOT_VOLUMEVOICESLIDER)
+							chosenSoundType = Audio::Mixer::kSpeechSoundType;
+						else
+							chosenSoundType = Audio::Mixer::kSFXSoundType;
+						_mixer->setVolumeForSoundType(chosenSoundType, targetVol);
+						break;
+
+					case OPTIONMENUHOTSPOT_TEXTSPEED:
+						entries[clickingOnSprite].targetFrame = ratioX * (entries[clickingOnSprite].animation->_numFrames) / 256;
+						entries[clickingOnSprite].animateOnFrame = 1;
+						entries[clickingOnSprite].playOnce = true;
+						// TODO store textSpeed
+						break;
+
+					default:
+						break;
+					}
+
+					// handle buttons
+					if (clickingOn != OPTIONMENUHOTSPOT_NONE && !entries[clickingOnSprite].handled) {
+						switch (clickingOn) {
+						case OPTIONMENUHOTSPOT_PLAY:
+							// fall through
+						case OPTIONMENUHOTSPOT_QUIT:
+							entries[clickingOnSprite].handled = true;
+							entries[clickingOnSprite].targetFrame = entries[clickingOnSprite].animation->_numFrames - 1;
+							entries[clickingOnSprite].animateOnFrame = 1;
+							entries[clickingOnSprite].playOnce = true;
+							if (!_isEnglishDemo) {
+								if (clickingOn == OPTIONMENUHOTSPOT_PLAY)
+									playSFX(-7, 128);
+								else
+									playSFX(-8, 128);
+							}
+							break;
+
+						case OPTIONMENUHOTSPOT_VOLUMEMUSIC:
+							// fall through
+						case OPTIONMENUHOTSPOT_VOLUMEVOICE:
+							// fall through
+						case OPTIONMENUHOTSPOT_VOLUMESFX:
+							entries[clickingOnSprite].handled = true;
+							if (entries[clickingOnSprite].activeFrame == 0) {
+								entries[clickingOnSprite].targetFrame = entries[clickingOnSprite].animation->_numFrames - 1;
+								entries[clickingOnSprite].animateOnFrame = 1;
+								entries[clickingOnSprite].playOnce = true;
+								if (clickingOn == OPTIONMENUHOTSPOT_VOLUMEMUSIC)
+									_audioManager->muteMusic(false);
+								else if (clickingOn == OPTIONMENUHOTSPOT_VOLUMEVOICE)
+									_audioManager->muteVoice(false);
+								else
+									_audioManager->muteSfx(false);
+							} else {
+								entries[clickingOnSprite].targetFrame = 0;
+								entries[clickingOnSprite].animateOnFrame = 1;
+								entries[clickingOnSprite].playOnce = true;
+								if (clickingOn == OPTIONMENUHOTSPOT_VOLUMEMUSIC)
+									_audioManager->muteMusic(true);
+								else if (clickingOn == OPTIONMENUHOTSPOT_VOLUMEVOICE)
+									_audioManager->muteVoice(true);
+								else
+									_audioManager->muteSfx(true);
+							}
+							if (!_isEnglishDemo)
+								playSFX(-7, 128);
+							break;
+
+						case OPTIONMENUHOTSPOT_SPEAKERBUTTON:
+							entries[clickingOnSprite].handled = true;
+							entries[clickingOnSprite].animateOnFrame = 4;
+							entries[clickingOnSprite].playOnce = true;
+
+							entries[19].animateOnFrame = 4;
+							entries[19].playOnce = true;
+
+							if (!_isEnglishDemo)
+								playSFX(-10, 128);
+							break;
+
+						case OPTIONMENUHOTSPOT_SPEAKERLEVER:
+							entries[clickingOnSprite].handled = true;
+							// Speaker lever animation has 2 frames (on and off position).
+							// Set the activeFrame to the other position than the current one.
+							entries[clickingOnSprite].activeFrame = entries[clickingOnSprite].activeFrame ? 0 : 1;
+							if (entries[clickingOnSprite].activeFrame == 1) {
+								entries[20].animateOnFrame = 4;
+								entries[20].playOnce = false;
+							} else {
+								entries[20].playOnce = true;
+							}
+							if (!_isEnglishDemo)
+								playSFX(-10, 128);
+							break;
+
+						case OPTIONMENUHOTSPOT_TEXT:
+							entries[clickingOnSprite].handled = true;
+							if (!_isEnglishDemo) {
+								if ((ratioY <= 151 && ratioX >= 88 && ratioX <= 169)
+								    || (ratioY > 151 && ratioX >= 122 && ratioX <= 145) ) {
+									_showConversationText = false;
+									entries[clickingOnSprite].targetFrame = 4;
+									entries[clickingOnSprite].animateOnFrame = 1;
+									entries[clickingOnSprite].playOnce = true;
+								} else if (ratioY > 151 && ratioX > 145) {
+									_showConversationText = true;
+									setFont(true);
+									entries[clickingOnSprite].targetFrame = 8;
+									entries[clickingOnSprite].animateOnFrame = 1;
+									entries[clickingOnSprite].playOnce = true;
+								} else if (ratioY > 151 && ratioX < 122) {
+									_showConversationText = true;
+									setFont(false);
+									entries[clickingOnSprite].targetFrame = 0;
+									entries[clickingOnSprite].animateOnFrame = 1;
+									entries[clickingOnSprite].playOnce = true;
+								}
+								playSFX(-9, 128);
+							} else {
+								// In the demo, the behavior is different:
+								// Clicking anywhere in the Text Dial hotspot
+								// toggles between "Text Off" and "Text On"
+								switch (entries[clickingOnSprite].activeFrame) {
+								case 0:
+									_showConversationText = true;
+									entries[clickingOnSprite].targetFrame = 8;
+									entries[clickingOnSprite].animateOnFrame = 1;
+									entries[clickingOnSprite].playOnce = true;
+									break;
+
+								case 8:
+									_showConversationText = false;
+									entries[clickingOnSprite].targetFrame = 0;
+									entries[clickingOnSprite].animateOnFrame = 1;
+									entries[clickingOnSprite].playOnce = true;
+									break;
+
+								default:
+									break;
+								}
+							}
+							break;
+
+						// don't allow change to video mode
+						case OPTIONMENUHOTSPOT_VIDEO_MODE:
+							entries[clickingOnSprite].handled = true;
+							playSoundWrong();
+							break;
+
+						default:
+							break;
 						}
 					}
 				}
-			} else {
-				// left mouse button released/not pushed down
-				if (clickingOn != OPTIONMENUHOTSPOT_NONE)
-					clickRelease = true;
 			}
-
-			// handle sliders
-			if (clickingOn == OPTIONMENUHOTSPOT_VOLUMEMUSICSLIDER) {
-				entries[clickingOnSprite].activeFrame = ratioX * (entries[clickingOnSprite].animation->_numFrames) / 256;
-				int vol = entries[clickingOnSprite].activeFrame * 256 / entries[clickingOnSprite].animation->_numFrames;
-				_audioManager->_mixer->setVolumeForSoundType(Audio::Mixer::kMusicSoundType, vol);
-			}
-
-			if (clickingOn == OPTIONMENUHOTSPOT_VOLUMEVOICESLIDER) {
-				entries[clickingOnSprite].activeFrame = ratioX * (entries[clickingOnSprite].animation->_numFrames) / 256;
-				int vol = entries[clickingOnSprite].activeFrame * 256 / entries[clickingOnSprite].animation->_numFrames;
-				_audioManager->_mixer->setVolumeForSoundType(Audio::Mixer::kSpeechSoundType, vol);
-			}
-
-			if (clickingOn == OPTIONMENUHOTSPOT_VOLUMESFXSLIDER) {
-				entries[clickingOnSprite].activeFrame = ratioX * (entries[clickingOnSprite].animation->_numFrames) / 256;
-				int vol = entries[clickingOnSprite].activeFrame * 256 / entries[clickingOnSprite].animation->_numFrames;
-				_audioManager->_mixer->setVolumeForSoundType(Audio::Mixer::kSFXSoundType, vol);
-			}
-
-			if (clickingOn == OPTIONMENUHOTSPOT_TEXTSPEED) {
-				entries[clickingOnSprite].activeFrame = ratioX * (entries[clickingOnSprite].animation->_numFrames) / 256;
-			}
-
-			if (clickingOn == OPTIONMENUHOTSPOT_PLAY) {
-				entries[0].activeFrame = entries[0].animation->_numFrames - 1;
-			} else {
-				entries[0].activeFrame = 0;
-			}
-
-			if (clickingOn == OPTIONMENUHOTSPOT_QUIT) {
-				entries[1].activeFrame = entries[1].animation->_numFrames - 1;
-			} else {
-				entries[1].activeFrame = 0;
-			}
-
-			if (_shouldQuit) {
-				clickingOn = OPTIONMENUHOTSPOT_NONE;
-				clickRelease = true;
-				doExit = true;
-			}
-		}
-
-		if (clickingOn == OPTIONMENUHOTSPOT_VOLUMEMUSIC) {
-			if (entries[9].activeFrame == 0) {
-				entries[9].activeFrame = 3;
-				_audioManager->muteMusic(false);
-			} else {
-				entries[9].activeFrame = 0;
-				_audioManager->muteMusic(true);
-			}
-			if (!_isEnglishDemo)
-				playSFX(-7, 128);
-		}
-
-		if (clickingOn == OPTIONMENUHOTSPOT_VOLUMEVOICE) {
-			if (entries[7].activeFrame == 0) {
-				entries[7].activeFrame = 3;
-				_audioManager->muteVoice(false);
-			} else {
-				entries[7].activeFrame = 0;
-				_audioManager->muteVoice(true);
-			}
-			if (!_isEnglishDemo)
-				playSFX(-7, 128);
-		}
-
-		if (clickingOn == OPTIONMENUHOTSPOT_VOLUMESFX) {
-			if (entries[5].activeFrame == 0) {
-				entries[5].activeFrame = 3;
-				_audioManager->muteSfx(false);
-			} else {
-				entries[5].activeFrame = 0;
-				_audioManager->muteSfx(true);
-			}
-			if (!_isEnglishDemo)
-				playSFX(-7, 128);
-		}
-
-		if (clickingOn == OPTIONMENUHOTSPOT_SPEAKERBUTTON) {
-			entries[11].animateOnFrame = 4;
-			entries[11].playOnce = true;
-
-			entries[19].animateOnFrame = 4;
-			entries[19].playOnce = true;
-
-			playSFX(-10, 128);
-			if (!_isEnglishDemo)
-				_audioManager->playVoice(316, true);
-		}
-
-		if (clickingOn == OPTIONMENUHOTSPOT_SPEAKERLEVER) {
-
-			entries[12].activeFrame = 1 - entries[12].activeFrame;
-			if(entries[12].activeFrame == 1) {
-				entries[20].animateOnFrame = 4;
-				entries[20].playOnce = false;
-				playSFX(-3, 128);
-			} else {
-				entries[20].playOnce = true;
-			}
-			if (!_isEnglishDemo)
-				playSFX(-9, 128);
-		}
-
-		if (clickingOn == OPTIONMENUHOTSPOT_TEXT) {
-
-			if (entries[4].activeFrame == 0) {
-				_showConversationText = false;
-				entries[4].activeFrame = 4;
-			} else if (entries[4].activeFrame == 4) {
-				_showConversationText = true;
-				setFont(true);
-				entries[4].activeFrame = 8;
-			} else if(entries[4].activeFrame == 8) {
-				_showConversationText = true;
-				setFont(false);
-				entries[4].activeFrame = 0;
-			}
-
-			if (!_isEnglishDemo)
-				playSFX(-9, 128);
-		}
-
-		// don't allow change to video mode
-		if (clickingOn == OPTIONMENUHOTSPOT_VIDEO_MODE) {
-			playSoundWrong();
-		}
-
-		if (clickingOn == OPTIONMENUHOTSPOT_PLAY) {
-			doExit = true;
-			exitGame = false;
-			if (!_isEnglishDemo)
-				_audioManager->playSFX(10, 128, true);
-		}
-
-		if (clickingOn == OPTIONMENUHOTSPOT_QUIT) {
-			doExit = true;
-			exitGame = true;
-			_shouldQuit = true;
-			if (!_isEnglishDemo)
-				_audioManager->playSFX(10, 128, true);
 		}
 	}
 
@@ -984,9 +1116,15 @@ bool ToonEngine::showOptions() {
 	restorePalette();
 	dirtyAllScreen();
 
+	for (int entryNr = 0; entryNr < optionMenuEntryCount; ++entryNr)
+		delete entries[entryNr].animation;
 	delete[] entries;
+
 	delete optionPicture;
 
+	if (!_shouldQuit && exitGame) {
+		_shouldQuit = exitGame;
+	}
 	return exitGame;
 }
 
@@ -998,47 +1136,57 @@ bool ToonEngine::showMainmenu(bool &loadedGame) {
 
 	MenuEntry entries[MAINMENU_ENTRYCOUNT];
 
-	for (int entryNr = 0; entryNr < MAINMENU_ENTRYCOUNT; entryNr++) {
+	for (int entryNr = 0; entryNr < MAINMENU_ENTRYCOUNT; ++entryNr) {
 		entries[entryNr].menuMask = mainMenuFiles[entryNr].menuMask;
 		entries[entryNr].id = mainMenuFiles[entryNr].id;
 		entries[entryNr].animation = new Animation(this);
 		entries[entryNr].animation->loadAnimation(mainMenuFiles[entryNr].animationFile);
-		if (entries[entryNr].id != MAINMENUHOTSPOT_NONE)
+		if (entries[entryNr].id != MAINMENUHOTSPOT_NONE) {
 			entries[entryNr].rect = entries[entryNr].animation->getRect();
+			if (entries[entryNr].id == MAINMENUHOTSPOT_HOTKEYSCLOSE) {
+				// In the original game, clicking anywhere on the
+				// hotspots' screen will return the user to the main menu
+				entries[entryNr].rect.top = 0;
+				entries[entryNr].rect.left = 0;
+				entries[entryNr].rect.right = TOON_SCREEN_WIDTH;
+				entries[entryNr].rect.bottom = TOON_SCREEN_HEIGHT;
+			}
+		}
 		entries[entryNr].animateOnFrame = mainMenuFiles[entryNr].animateOnFrame;
 		entries[entryNr].animateCurFrame = 0;
 		entries[entryNr].activeFrame = 0;
+		entries[entryNr].handled = false;
 	}
 
 	setCursor(0);
 
-	bool doExit = false;
+	bool doExitMenu = false;
 	bool exitGame = false;
 	int menuMask = MAINMENUMASK_BASE;
 	Common::SeekableReadStream *mainmenuMusicFile = NULL;
 	AudioStreamInstance *mainmenuMusic = NULL;
 	bool musicPlaying = false;
+	int32 oldMouseButton = _mouseButton;
 
 	_gameState->_inMenu = true;
 	dirtyAllScreen();
 
-	while (!doExit) {
+	while (!doExitMenu) {
 		int clickingOn = MAINMENUHOTSPOT_NONE;
-		int clickRelease = false;
-
-		if (!musicPlaying) {
-			mainmenuMusicFile = resources()->openFile("BR091013.MUS");
-			if (mainmenuMusicFile) {
-				mainmenuMusic = new AudioStreamInstance(_audioManager, _mixer, mainmenuMusicFile, true);
-				mainmenuMusic->play(false);
-				musicPlaying = true;
-			}
-			else {
-				musicPlaying = false;
-			}
-		}
+		int clickingOnSprite = 0;
+		bool clickRelease = false;
 
 		while (!clickRelease) {
+			if (!musicPlaying) {
+				mainmenuMusicFile = resources()->openFile("BR091013.MUS");
+				if (mainmenuMusicFile) {
+					mainmenuMusic = new AudioStreamInstance(_audioManager, _mixer, mainmenuMusicFile, true);
+					mainmenuMusic->play(false);
+					musicPlaying = true;
+				} else {
+					musicPlaying = false;
+				}
+			}
 
 			if (_dirtyAll) {
 				mainmenuPicture->draw(*_mainSurface, 0, 0, 0, 0);
@@ -1049,21 +1197,19 @@ bool ToonEngine::showMainmenu(bool &loadedGame) {
 
 			clearDirtyRects();
 
-			for (int entryNr = 0; entryNr < MAINMENU_ENTRYCOUNT; entryNr++) {
+			// Handle animations
+			for (int entryNr = 0; entryNr < MAINMENU_ENTRYCOUNT; ++entryNr) {
 				if (entries[entryNr].menuMask & menuMask) {
 					if (entries[entryNr].animateOnFrame) {
-						entries[entryNr].animateCurFrame++;
+						++entries[entryNr].animateCurFrame;
 						if (entries[entryNr].animateOnFrame <= entries[entryNr].animateCurFrame) {
-							entries[entryNr].activeFrame++;
+							++entries[entryNr].activeFrame;
 							if (entries[entryNr].activeFrame >= entries[entryNr].animation->_numFrames)
 								entries[entryNr].activeFrame = 0;
 							entries[entryNr].animateCurFrame = 0;
 						}
 					}
-					int32 frameNr = entries[entryNr].activeFrame;
-					if ((entries[entryNr].id == clickingOn) && (clickingOn != MAINMENUHOTSPOT_NONE))
-						frameNr = 1;
-					entries[entryNr].animation->drawFrame(*_mainSurface, frameNr, 0, 0);
+					entries[entryNr].animation->drawFrame(*_mainSurface, entries[entryNr].activeFrame, 0, 0);
 				}
 			}
 
@@ -1072,93 +1218,167 @@ bool ToonEngine::showMainmenu(bool &loadedGame) {
 				_needPaletteFlush = false;
 			}
 
-			parseInput();
-			copyToVirtualScreen(true);
-			_system->delayMillis(17);
+			oldMouseButton = _mouseButton;
 
-			if (_mouseButton & 1) {
-				// left mouse button pushed down
+			parseInput();
+
+			if (_shouldQuit || doExitMenu) {
 				clickingOn = MAINMENUHOTSPOT_NONE;
-				for (int entryNr = 0; entryNr < MAINMENU_ENTRYCOUNT; entryNr++) {
-					if (entries[entryNr].menuMask & menuMask) {
-						if (entries[entryNr].id != MAINMENUHOTSPOT_NONE) {
-							if (entries[entryNr].rect.contains(_mouseX, _mouseY))
-								clickingOn = entries[entryNr].id;
+				clickRelease = true;
+				doExitMenu = true;
+			} else {
+				copyToVirtualScreen(true);
+				_system->delayMillis(17);
+
+				if (_mouseButton & 1) {
+					// left mouse button pushed down
+					for (int entryNr = 0; entryNr < MAINMENU_ENTRYCOUNT; ++entryNr) {
+						if (entries[entryNr].menuMask & menuMask
+						    && entries[entryNr].id != MAINMENUHOTSPOT_NONE
+						    && entries[entryNr].rect.contains(_mouseX, _mouseY)
+						    && (clickingOn == MAINMENUHOTSPOT_NONE && !(oldMouseButton & 1))) {
+							clickingOn = entries[entryNr].id;
+							clickingOnSprite = entryNr;
+							break;
+						}
+					}
+				} else if (clickingOn != MAINMENUHOTSPOT_NONE) {
+					// left mouse button released/not pushed down
+					clickRelease = true;
+					clickingOn = MAINMENUHOTSPOT_NONE;
+					entries[clickingOnSprite].handled = false;
+				}
+
+				// handle buttons
+				if (clickingOn != MAINMENUHOTSPOT_NONE && !entries[clickingOnSprite].handled) {
+					// NOTE "MAINMENUHOTSPOT_HOTKEYSCLOSE" does not have two frames
+					if (entries[clickingOnSprite].animation->_numFrames > 1 && entries[clickingOnSprite].activeFrame == 0) {
+						// First show the button as clicked
+						entries[clickingOnSprite].activeFrame = 1;
+
+						// Use click sfx sound only for:
+						// Start game, Load Game and Hotkeys menu (but not going back from it)
+						// Use special sfx sound for quit
+						switch (clickingOn) {
+						case MAINMENUHOTSPOT_HOTKEYS:
+							// fall through
+						case MAINMENUHOTSPOT_START:
+							// fall through
+						case MAINMENUHOTSPOT_LOADGAME:
+							// fall through
+							playSFX(-9, 128);
+							break;
+
+						case MAINMENUHOTSPOT_QUIT:
+							playSFX(-8, 128);
+							break;
+
+						default:
+							break;
+						}
+					} else {
+						entries[clickingOnSprite].handled = true;
+						switch (entries[clickingOnSprite].id) {
+						case MAINMENUHOTSPOT_HOTKEYS:
+							// fall through
+						case MAINMENUHOTSPOT_HOTKEYSCLOSE:
+							menuMask = clickingOn == MAINMENUHOTSPOT_HOTKEYS? MAINMENUMASK_HOTKEYS : MAINMENUMASK_BASE;
+							entries[clickingOnSprite].activeFrame = 0;
+							break;
+
+						case MAINMENUHOTSPOT_START:
+							// Start game (actually exit main menu)
+							clickingOn = MAINMENUHOTSPOT_NONE;
+							clickRelease = true;
+							loadedGame = false;
+							doExitMenu = true;
+							break;
+
+						case MAINMENUHOTSPOT_LOADGAME:
+							doExitMenu = loadGame(-1);
+							loadedGame = doExitMenu;
+							if (loadedGame) {
+								clickingOn = MAINMENUHOTSPOT_NONE;
+								clickRelease = true;
+							} else {
+								entries[clickingOnSprite].activeFrame = 0;
+							}
+							exitGame = false;
+							break;
+
+						case MAINMENUHOTSPOT_INTRO:
+							// fall through
+						case MAINMENUHOTSPOT_CREDITS:
+							if (musicPlaying) {
+								//stop music
+								mainmenuMusic->stop(false);
+								delete mainmenuMusicFile;
+								musicPlaying = false;
+							}
+							if (clickingOn == MAINMENUHOTSPOT_INTRO) {
+								// Play intro movies
+								getMoviePlayer()->play("209_1M.SMK", 0x10);
+								getMoviePlayer()->play("209_2M.SMK", 0x10);
+								getMoviePlayer()->play("209_3M.SMK", 0x10);
+							} else {
+								// Play credits movie
+								getMoviePlayer()->play("CREDITS.SMK", 0x0);
+							}
+							entries[clickingOnSprite].activeFrame = 0;
+							break;
+
+						case MAINMENUHOTSPOT_QUIT:
+							exitGame = showQuitConfirmationDialogue();
+							if (exitGame)  {
+								clickingOn = MAINMENUHOTSPOT_NONE;
+								clickRelease = true;
+								doExitMenu = true;
+							} else {
+								entries[clickingOnSprite].activeFrame = 0;
+							}
+							break;
+
+						default:
+							break;
 						}
 					}
 				}
-			} else {
-				// left mouse button released/not pushed down
-				if (clickingOn != MAINMENUHOTSPOT_NONE)
-					clickRelease = true;
-			}
-			if (_shouldQuit) {
-				clickingOn = MAINMENUHOTSPOT_NONE;
-				clickRelease = true;
-				doExit = true;
 			}
 		}
 
-		if (clickingOn != MAINMENUHOTSPOT_NONE) {
-			_audioManager->playSFX(10, 128, true);
-		}
-
-		switch (clickingOn) {
-		case MAINMENUHOTSPOT_HOTKEYS:
-			menuMask = MAINMENUMASK_HOTKEYS;
-			continue;
-		case MAINMENUHOTSPOT_HOTKEYSCLOSE:
-			menuMask = MAINMENUMASK_BASE;
-			continue;
-		default:
-			break;
-		}
-
-		if (musicPlaying) {
+		if (musicPlaying && doExitMenu) {
 			//stop music
 			mainmenuMusic->stop(false);
 			delete mainmenuMusicFile;
 			musicPlaying = false;
 		}
-
-		switch (clickingOn) {
-		case MAINMENUHOTSPOT_START:
-			// Start game (actually exit main menu)
-			loadedGame = false;
-			doExit = true;
-			break;
-		case MAINMENUHOTSPOT_INTRO:
-			// Play intro movies
-			getMoviePlayer()->play("209_1M.SMK", 0x10);
-			getMoviePlayer()->play("209_2M.SMK", 0x10);
-			getMoviePlayer()->play("209_3M.SMK", 0x10);
-			break;
-		case MAINMENUHOTSPOT_LOADGAME:
-			doExit = loadGame(-1);
-			loadedGame = doExit;
-			exitGame = false;
-			break;
-		case MAINMENUHOTSPOT_CREDITS:
-			// Play credits movie
-			getMoviePlayer()->play("CREDITS.SMK", 0x0);
-			break;
-		case MAINMENUHOTSPOT_QUIT:
-			exitGame = true;
-			doExit = true;
-			break;
-		default:
-			break;
-		}
 	}
 
 	_gameState->_inMenu = false;
 
-	//delete mainmenuMusic;
-	for (int entryNr = 0; entryNr < MAINMENU_ENTRYCOUNT; entryNr++)
+	for (int entryNr = 0; entryNr < MAINMENU_ENTRYCOUNT; ++entryNr)
 		delete entries[entryNr].animation;
 	delete mainmenuPicture;
 
+	if (!_shouldQuit && exitGame) {
+		 _shouldQuit = exitGame;
+	}
 	return !exitGame;
+}
+
+bool ToonEngine::showQuitConfirmationDialogue() {
+	// In the original game this dialogue prompt was:
+	// "Are you sure you want to exit? (Y/N)"
+	// See: devtools\create_toon\staticdata.h
+	// We could allow create_toon to include this text
+	// and all its variations for the game's localizations in toon.dat,
+	// especially if we implement a native game dialogue prompt.
+	// But using ScummVM's Message Dialogue works just as well,
+	// and it requires a mouse click for yes/no selection
+	// instead of a keyboard key-press (which would also be dependent on the
+	// text variant of the yes/no option).
+	GUI::MessageDialog dialog(_("Are you sure you want to exit?"), _("Yes"), _("No"));
+	return (dialog.runModal() == GUI::kMessageOK);
 }
 
 Common::Error ToonEngine::run() {

--- a/engines/toon/toon.h
+++ b/engines/toon/toon.h
@@ -111,6 +111,7 @@ public:
 	Common::Error run() override;
 	bool showMainmenu(bool &loadedGame);
 	bool showOptions();
+	bool showQuitConfirmationDialogue();
 	void init();
 	bool loadToonDat();
 	char **loadTextsVariants(Common::File &in);

--- a/engines/toon/toon.h
+++ b/engines/toon/toon.h
@@ -441,6 +441,7 @@ protected:
 	bool _isDemo;
 	bool _isEnglishDemo;
 	bool _showConversationText;
+	int  _textSpeed;
 	bool _useAlternativeFont;
 	bool _needPaletteFlush;
 };

--- a/engines/toon/toon.h
+++ b/engines/toon/toon.h
@@ -112,7 +112,6 @@ public:
 	bool showMainmenu(bool &loadedGame);
 	bool showOptions();
 	bool showQuitConfirmationDialogue();
-	void adjustMovieVolume();
 	void init();
 	bool loadToonDat();
 	char **loadTextsVariants(Common::File &in);
@@ -215,7 +214,7 @@ public:
 	bool canSaveGameStateCurrently() override;
 	bool canLoadGameStateCurrently() override;
 	void pauseEngineIntern(bool pause) override;
-	void turnOnText(bool enable, bool useAlternativeFont = false);
+	void syncSoundSettings() override;
 
 	Resources *resources() {
 		return _resources;
@@ -333,6 +332,7 @@ public:
 
 	bool hasFeature(EngineFeature f) const override {
 		return
+			(f == kSupportsSubtitleOptions) ||
 			(f == kSupportsReturnToLauncher) ||
 			(f == kSupportsLoadingDuringRuntime) ||
 			(f == kSupportsSavingDuringRuntime);
@@ -445,6 +445,7 @@ protected:
 	int  _textSpeed;
 	bool _useAlternativeFont;
 	bool _needPaletteFlush;
+	bool _noMusicDriver; // If "Music Device" is set to "No Music" from Audio tab
 };
 
 } // End of namespace Toon

--- a/engines/toon/toon.h
+++ b/engines/toon/toon.h
@@ -214,6 +214,7 @@ public:
 	bool canSaveGameStateCurrently() override;
 	bool canLoadGameStateCurrently() override;
 	void pauseEngineIntern(bool pause) override;
+	void turnOnText(bool enable, bool useAlternativeFont = false);
 
 	Resources *resources() {
 		return _resources;

--- a/engines/toon/toon.h
+++ b/engines/toon/toon.h
@@ -112,6 +112,7 @@ public:
 	bool showMainmenu(bool &loadedGame);
 	bool showOptions();
 	bool showQuitConfirmationDialogue();
+	void adjustMovieVolume();
 	void init();
 	bool loadToonDat();
 	char **loadTextsVariants(Common::File &in);

--- a/engines/toon/toon.h
+++ b/engines/toon/toon.h
@@ -211,6 +211,7 @@ public:
 	void waitForScriptStep();
 	void doMagnifierEffect();
 	void drawCustomText(int16 x, int16 y, const char *line, Graphics::Surface *frame, byte color);
+	bool showConversationText() const;
 	bool canSaveGameStateCurrently() override;
 	bool canLoadGameStateCurrently() override;
 	void pauseEngineIntern(bool pause) override;


### PR DESCRIPTION
These commits update the menu to bring its behavior closer to the original game. 

I've tested with the full game (GOG version) and the English and German Demo versions. 

Changes include:
- Proper sounds to buttons
- Button click is effected at mouse down, not mouse up
- Moving the mouse around while holding the mouse button down activates / affects only one control (not every control that the mouse passed over)
- Button and slider animations in Options Menu
- Reduce frequency of checking and updating a control's state
- DEMO: don't allow middle Text option which does not exist in Demo
- Text options dial moves to area clicked. If Text Off mode conflicts with mute speech or speech volume or "mute all" setting, then dial will select Text On and the proper Font type.
- Sync music / sfx and speech volume and music status with ScummVM config (via options menu and hotkeys)
- Sync font type selection with ScummVM config
- Sync text speed with ScummVM config
- Do not allow both speech muted and no subtitles (even via hotkeys -- which is an original bug)
- Video volume is set to the max of the non-muted sound types (music, speech and sfx). As far as I can tell by testing, this is how the original game must handle it too.
- When text is OFF (or equivalently if ScummVM audio config is set to "Speech") then subtitles won't be displayed on video cutscenes. Tested with subtitles provided by rzil/BLooperZ in the PR that added the support for such subtitles. https://github.com/scummvm/scummvm/pull/1887

These changes should address bug tickets https://bugs.scummvm.org/ticket/11329 and https://bugs.scummvm.org/ticket/7806

The PR includes a translatable String (the one shown in the Quit confirmation dialogue). 

~~A current known issue that I'll try to fix ASAP:~~
~~If from Options Menu, the player clicks on Play and keeps the mouse button down, Drew will move to the spot when the cursor was in-game.~~ **Edit**: This issue has now been fixed in this PR.

Some pending tasks **but not for this PR**:
- Text speed is now persisted but it does not affect the subtitles speed in game. Maybe someone with better knowledge of the engine can tackle this (~~if it was working in the original game and~~ if it's worth implementing anyway). **Edit**: From just testing, it seems that how this worked in the original was that lower value meant more delay keeping the subtitle on-screen, higher value meant quicker removal of the quote -- I think the dealy counts after the speech has finished (even if speech is muted). It is not related to whether the speech sound is muted or not. The delay seems however to be related to the size (or word count maybe? or the duration of the corresponding speech) of the quote, since there is noticeable difference between small quotes and larger ones.
- In English Demo, arrow keys can also control the mouse cursor. Also LSHIFT and RSHIFT act as click (both as left click I think?).
- In English Demo, in Options Menu the mouse cursor turns into an animated pointing hand or an animated grabbing hand (over the video mode lever) or the non-animated arrow cursor. It is laggy though and not worth the trouble to implement in my opinion.

I have not restored all of the original behavior. Certain parts of that behavior are even counter intuitive and in my opinion not worth reproducing. Like for example in the original setting the volume of a sound type to 0, would set that sound type also as muted, but the mute button will only be popped in the Options Menu after you have exited and re-entered the Options Menu). That also might be confusing since "mute" status is not supposed to be connected to volume level. Similarily, in the English demo, the slider needle could only be moved if the player clicked on the needled and moved it while holding it -- the new behavior is more user friendly and follows the approach of the full game and German Demo.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
