### PR TITLE
GUI: Multiple fixes to grid widget

### DIFF
--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -1509,8 +1509,18 @@ void LauncherGrid::updateListing() {
 		gridList.push_back(GridItemInfo(k++, engineid, gameid, iter->title, iter->description, Common::parseLanguage(language), Common::parsePlatform(platform)));
 	}
 
+	const int oldSel = _grid->getSelected();
+
 	_grid->setEntryList(&gridList);
 	groupEntries(attrs);
+
+	if (oldSel < (int)gridList.size() && oldSel >= 0)
+		_grid->setSelected(oldSel);	// Restore the old selection
+	else if (oldSel != -1)
+		// Select the last entry if the list has been reduced
+		_grid->setSelected(gridList.size() - 1);
+	updateButtons();
+
 	// And fill out our structures
 	for (Common::Array<LauncherEntry>::const_iterator iter = domainList.begin(); iter != domainList.end(); ++iter) {
 		_domains.push_back(iter->key);
@@ -1525,7 +1535,19 @@ void LauncherGrid::updateButtons() {
 	}
 }
 
-void LauncherGrid::selectTarget(const Common::String &target) {}
+void LauncherGrid::selectTarget(const Common::String &target) {
+	if (!target.empty()) {
+		int itemToSelect = 0;
+		Common::StringArray::const_iterator iter;
+		for (iter = _domains.begin(); iter != _domains.end(); ++iter, ++itemToSelect) {
+			if (target == *iter) {
+				_grid->setSelected(itemToSelect);
+				break;
+			}
+		}
+	}
+}
+
 int LauncherGrid::getSelected() { return _grid->getSelected(); }
 
 void LauncherGrid::build() {

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -891,9 +891,6 @@ void GridWidget::reflowLayout() {
 	calcEntrySizes();
 	calcInnerHeight();
 
-	_scrollBar->checkBounds(_scrollBar->_currentPos);
-	_scrollPos = _scrollBar->_currentPos;
-
 	_scrollBar->resize(_scrollWindowWidth - _scrollBarWidth, 0, _scrollBarWidth, _scrollWindowHeight, false);
 
 	if (calcVisibleEntries()) {
@@ -901,6 +898,9 @@ void GridWidget::reflowLayout() {
 	}
 
 	assignEntriesToItems();
+	if (_selectedEntry) {
+		scrollToEntry(_selectedEntry->entryID, false);
+	}
 	scrollBarRecalc();
 	markAsDirty();
 }

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -947,4 +947,14 @@ void GridWidget::setFilter(const Common::U32String &filter) {
 	sortGroups();
 }
 
+void GridWidget::setSelected(int id) {
+	for (uint i = 0; i < _sortedEntryList.size(); ++i) {
+		if ((!_sortedEntryList[i]->isHeader) && (_sortedEntryList[i]->entryID == id)) {
+			_selectedEntry = _sortedEntryList[i];
+			scrollToEntry(id, false);
+			break;
+		}
+	}
+}
+
 } // End of namespace GUI

--- a/gui/widgets/grid.h
+++ b/gui/widgets/grid.h
@@ -209,6 +209,7 @@ public:
 	void openTrayAtSelected();
 	void scrollBarRecalc();
 
+	void setSelected(int id);
 	void setFilter(const Common::U32String &filter);
 };
 

--- a/gui/widgets/grid.h
+++ b/gui/widgets/grid.h
@@ -103,7 +103,8 @@ protected:
 	Common::HashMap<Common::String, const Graphics::ManagedSurface *> _loadedSurfaces;
 
 	Common::Array<GridItemInfo>			_dataEntryList;
-	Common::Array<GridItemInfo>			_sortedEntryList;
+	Common::Array<GridItemInfo>			_headerEntryList;
+	Common::Array<GridItemInfo *>		_sortedEntryList;
 	Common::Array<GridItemInfo *>		_visibleEntryList;
 
 	Common::String							_groupingAttribute;


### PR DESCRIPTION
This PR fixes [#13499](https://bugs.scummvm.org/ticket/13499).
In addition, before this, filter became inconsistent when we changed the grouping option.
Additionally, the selected game is now preserved when switching between grid and list and restored at startup.
Finally a small memory optimization is done by not storing the grid items twice but only storing pointers to original list.