### PR TITLE
DINGUX: Only evaluate the toupper() macro argument once

### DIFF
--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -309,7 +309,7 @@
 	// Very BAD hack following, used to avoid triggering an assert in uClibc dingux library
 	// "toupper" when pressing keyboard function keys.
 	#undef toupper
-	#define toupper(c) (((c & 0xFF) >= 97) && ((c & 0xFF) <= 122) ? ((c & 0xFF) - 32) : (c & 0xFF))
+	#define toupper(c) __extension__ ({ auto _x = ((c) & 0xFF); (_x >= 97 && _x <= 122) ? (_x - 32) : _x; })
 
 #elif defined(__PSP__)
 


### PR DESCRIPTION
There are currently some `tolower()` or `toupper()` calls where its argument has some side effects:

```sh
git grep '\btolower(' | egrep -e 'tolower\((.*)\+\+(.*)\)' -e 'tolower\((.*)\((.*)\)'
git grep '\btoupper(' | egrep -e 'toupper\((.*)\+\+(.*)\)' -e 'toupper\((.*)\((.*)\)'
```

The Dingux/OpenDingux port currently defines its own `toupper()` macro "to avoid triggering an assert in uClibc dingux library", but it currently does so this way:

```c
#define toupper(c) (((c & 0xFF) >= 97) && ((c & 0xFF) <= 122) ? ((c & 0xFF) - 32) : (c & 0xFF))
```

and so if `(c)` has side effects, they're going to happen more times than intended on this platform.

Fixing the toupper()/tolower() callers is a solution, but sometimes the error comes back, so making a safer macro shouldn't hurt.

The following PR does so with a [GCC statement expression](https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html). That's a GCC-ism by definition (clang also accepts it), but AFAICS this port is only ever built with GCC anyway, and we're already in the middle of a hack in a `DINGUX` ifdef. `__extension__` should make `-pedantic` happy.

I don't have any device to test this, though. I see that there was some OpenDingux port activity in 2021.