### PR TITLE
HYPNO: Optimize rendering routines

### DIFF
--- a/engines/hypno/hypno.cpp
+++ b/engines/hypno/hypno.cpp
@@ -450,6 +450,7 @@ void HypnoEngine::updateVideo(MVideo &video) {
 void HypnoEngine::updateScreen(MVideo &video) {
 	const Graphics::Surface *frame = video.decoder->decodeNextFrame();
 	bool dirtyPalette = video.decoder->hasDirtyPalette();
+	bool isFullscreen = (frame->w == _screenW && frame->h == _screenH);
 
 	if (frame->h == 0 || frame->w == 0 || video.decoder->getPalette() == nullptr)
 		return;
@@ -461,7 +462,7 @@ void HypnoEngine::updateScreen(MVideo &video) {
 		g_system->getPaletteManager()->setPalette(videoPalette, 0, 256);
 	}
 
-	if (video.scaled) {
+	if (video.scaled && !isFullscreen) {
 		Graphics::Surface *sframe = frame->scale(_screenW, _screenH);
 		Common::Rect srcRect(sframe->w, sframe->h);
 		Common::Rect dstRect = srcRect;

--- a/engines/hypno/hypno.h
+++ b/engines/hypno/hypno.h
@@ -31,7 +31,7 @@
 #include "engines/engine.h"
 #include "graphics/font.h"
 #include "graphics/fontman.h"
-#include "graphics/managed_surface.h"
+#include "graphics/surface.h"
 #include "graphics/palette.h"
 
 #include "hypno/grammar.h"
@@ -39,10 +39,6 @@
 
 namespace Image {
 class ImageDecoder;
-}
-
-namespace Graphics {
-class ManagedSurface;
 }
 
 struct ADGameDescription;
@@ -202,7 +198,7 @@ public:
 	int _screenW, _screenH;
 	Graphics::PixelFormat _pixelFormat;
 	void changeScreenMode(const Common::String &mode);
-	Graphics::ManagedSurface *_compositeSurface;
+	Graphics::Surface *_compositeSurface;
 	uint32 _transparentColor;
 	Common::Rect screenRect;
 	void updateScreen(MVideo &video);


### PR DESCRIPTION
`Graphics::Surface::scale()` is slow, and can be avoided if the original surface is already the requested dimensions. In addition, using  more specialised routines for copying and colour key blitting instead of the more generic `blitFrom` and `transBlitFrom` from `Graphics::ManagedSurface` also provides a performance boost on slower systems.

This includes the changes from PR #3956.
