### PR TITLE
COMMON: Add numeric limits

### DIFF
--- a/common/numeric-limits.h
+++ b/common/numeric-limits.h
@@ -1,0 +1,81 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef COMMON_NUMERIC_LIMITS_H
+#define COMMON_NUMERIC_LIMITS_H
+
+#include "common/scummsys.h"
+#include "common/type-traits.h"
+
+namespace Common {
+
+template <typename T, bool TIsIntegral, bool TIsUnsigned>
+struct IntegralNumericLimitsImpl {
+};
+
+template<typename T>
+struct IntegralNumericLimitsImpl<T, true, false> {
+	static const T kMaxValue = ((T(1) << (sizeof(T) * 8 - 2)) - 1) * 2 + 1;
+	static const T kMinValue = -kMaxValue - 1;
+};
+
+template<typename T>
+struct IntegralNumericLimitsImpl<T, true, true> {
+	static const T kMaxValue = ((T(1) << (sizeof(T) * 8 - 1)) - 1) * 2 + 1;
+	static const T kMinValue = 0;
+};
+
+template<typename T>
+struct IntegralNumericLimits : public IntegralNumericLimitsImpl<T, IsIntegral<T>::value, IsUnsigned<T>::value> {
+};
+
+template<>
+struct IntegralNumericLimits<bool> {
+	static const bool kMaxValue = true;
+	static const bool kMinValue = false;
+};
+
+template<typename T>
+struct NumericLimits {
+	static inline T min() { return IntegralNumericLimits<T>::kMinValue; }
+	static inline T max() { return IntegralNumericLimits<T>::kMaxValue; }
+	static inline T lowest() { return IntegralNumericLimits<T>::kMinValue; }
+};
+
+template<>
+struct NumericLimits<float> {
+	static inline float max() { return 3.402823466e+38f; }			// Maximum normal value
+	static inline float min() { return 1.175494351e-38f; }			// Minimum normal positive value
+	static inline float denorm_min() { return 1.401298464e-45f; }	// Minimum positive value
+	static inline float lowest() { return -max(); }
+};
+
+template<>
+struct NumericLimits<double> {
+	static inline double max() { return 1.7976931348623158e+308; }			// Maximum normal value
+	static inline double min() { return 2.2250738585072014e-308; }			// Minimum normal positive value
+	static inline double denorm_min() { return 4.9406564584124654e-324; }	// Minimum positive value
+	static inline double lowest() { return -max(); }
+};
+
+} // namespace Common
+
+#endif

--- a/common/type-traits.h
+++ b/common/type-traits.h
@@ -28,6 +28,28 @@ namespace Common {
 	template <typename T> struct RemoveConst { typedef T type; };
 	template <typename T> struct RemoveConst<const T> { typedef T type; };
 	template <typename T> struct AddConst { typedef const T type; };
+	template <typename T> struct IsUnsigned { static const bool value = ((T(0) < T(-1))); };
+
+	template <typename T> struct IsIntegral { static const bool value = false; };
+	template<> struct IsIntegral<bool> { static const bool value = true; };
+	template<> struct IsIntegral<char> { static const bool value = true; };
+	template<> struct IsIntegral<signed char> { static const bool value = true; };
+	template<> struct IsIntegral<unsigned char> { static const bool value = true; };
+	template<> struct IsIntegral<wchar_t> { static const bool value = true; };
+	template<> struct IsIntegral<short> { static const bool value = true; };
+	template<> struct IsIntegral<unsigned short> { static const bool value = true; };
+	template<> struct IsIntegral<int> { static const bool value = true; };
+	template<> struct IsIntegral<unsigned int> { static const bool value = true; };
+	template<> struct IsIntegral<long> { static const bool value = true; };
+	template<> struct IsIntegral<unsigned long> { static const bool value = true; };
+	template<> struct IsIntegral<long long> { static const bool value = true; };
+	template<> struct IsIntegral<unsigned long long> { static const bool value = true; };
+	
+	template <typename T> struct IsFloatingPoint { static const bool value = false; };
+	template<> struct IsFloatingPoint<float> { static const bool value = true; };
+	template<> struct IsFloatingPoint<double> { static const bool value = true; };
+	
+	template <typename T> struct IsArithmetic { static const bool value = IsIntegral<T>::value || IsFloatingPoint<T>::value; };
 } // End of namespace Common
 
 #endif


### PR DESCRIPTION
There are multiple engines using their own min/max definitions because Common doesn't define them.  In some cases they might even be buggy (i.e. wintermute.h defines UINT_MAX_VALUE as a signed constant so it's actually -1?)

This adds them to Common.