### PR TITLE
TOON: Add vielogom.smk to German demo detection

### DIFF
--- a/engines/toon/detection.cpp
+++ b/engines/toon/detection.cpp
@@ -103,6 +103,7 @@ static const ADGameDescription gameDescriptions[] = {
 			{"local.pak", 0, "bf5da4c03f78ffbd643f12122319366e", 3250841},
 			{"wacexdbl.emc", 0, "cfbc2156a31b294b038204888407ebc8", 6974},
 			{"generic.svl", 0, "5eb99850ada22f0b8cf6392262d4dd07", 9404599},
+			{"vielogom.smk", 0, "4ca9f87dab70a9956431fddd40e43471", 3077708},
 			AD_LISTEND
 		},
 		Common::DE_DEU, Common::kPlatformDOS, ADGF_DEMO, GUIO1(GUIO_NOMIDI)


### PR DESCRIPTION
If you install the demo, this file isn't copied. Additionally ScummVM will segfault.
