### PR TITLE
SCUMM: Correctly reposition mouse on loading savegames when using render mode with its own scaling

### DIFF
--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -1162,8 +1162,23 @@ void ScummEngine::saveLoadWithSerializer(Common::Serializer &s) {
 
 	// When loading, move the mouse to the saved mouse position.
 	if (s.isLoading() && s.getVersion() >= VER(20)) {
+		int x = _mouse.x;
+		int y = _mouse.y;
+
+		// Convert the mouse position, which uses game coordinates, to
+		// screen coordinates for the rendering modes that need it.
+
+		if (_renderMode == Common::kRenderHercA || _renderMode == Common::kRenderHercG) {
+			x *= 2;
+			x += (kHercWidth - _screenWidth * 2) / 2;
+			y = y * 7 / 4;
+		} else if (_macScreen || (_useCJKMode && _textSurfaceMultiplier == 2)) {
+			x *= 2;
+			y *= 2;
+		}
+
 		updateCursor();
-		_system->warpMouse(_mouse.x, _mouse.y);
+		_system->warpMouse(x, y);
 	}
 
 	// Before V61, we re-used the _haveMsg flag to handle "alternative" speech


### PR DESCRIPTION
Since the saved mouse position uses game coordinates, any rendering mode that causes the graphics to be rescaled will have to convert them to screen coordinates before warping the mouse there. (The rendering mode scalers are separate from the backend scalers.)

Note that I have only tested this with Mac Indy3 and Loom, and a little bit with the Hercules rendering mode. It would be good if someone else could help me test, particularly the "(_useCJKMode && _textSurfaceMultiplier == 2)" thing.