### PR TITLE
TOLTECS: Fix unaligned access causing SIGBUS in Screen::addAnimatedSprite()

### DIFF
--- a/engines/toltecs/screen.cpp
+++ b/engines/toltecs/screen.cpp
@@ -209,13 +209,13 @@ void Screen::addAnimatedSprite(int16 x, int16 y, int16 fragmentId, byte *data, i
 		drawRequest.scaling = 0;
 	}
 
-	int16 count = FROM_LE_16(spriteArray[0]);
+	int16 count = READ_LE_UINT16(&spriteArray[0]);
 
 	//debug(0, "count = %d", count);
 
 	for (int16 index = 1; index <= count; index++) {
 
-		byte *spriteItem = data + FROM_LE_16(spriteArray[index]);
+		byte *spriteItem = data + READ_LE_UINT16(&spriteArray[index]);
 
 		uint16 loopNum = READ_LE_UINT16(spriteItem + 0) & 0x7FFF;
 		uint16 loopCount = READ_LE_UINT16(spriteItem + 2);


### PR DESCRIPTION
The `toltecs-demo.zip` demo would SIGBUS in `Screen::addAnimatedSprite()` when playing it on OpenBSD/loongson, which has a mips64el CPU with strict-alignment constraints. This is the same setup as for my older PR #2241.

Changing the `FROM_LE_16()` calls there to `READ_LE_UINT16()` calls fixes the issue. Looking a bit at `common/endian.h`, it appears that only the latter properly deals with unaligned memory accesses. Commit 30e3a8161857260e75c84e4a54cf0849afa10dfd was a similar change.

This possibly fixes the game on other strict-alignment ports such as Dreamcast, PSP or some old ARM devices.

On x86-64 and Apple M1, `screen.o` remains identical before and after this change, as expected. I think it's safe to cherry-pick this for the 2.6.0 release, but you're the judges :)