### PR TITLE
GUI: Fix caret position in list widget

### DIFF
--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -624,6 +624,12 @@ Common::Rect ListWidget::getEditRect() const {
 	return r;
 }
 
+int ListWidget::getCaretOffset() const {
+	Common::U32String substr(_editString.begin(), _editString.begin() + _caretPos);
+	Common::U32String stripped = stripGUIformatting(substr);
+	return g_gui.getStringWidth(stripped, _font) - _editScrollOffset;
+}
+
 void ListWidget::checkBounds() {
 	if (_currentPos < 0 || _entriesPerPage > (int)_list.size())
 		_currentPos = 0;

--- a/gui/widgets/list.h
+++ b/gui/widgets/list.h
@@ -165,6 +165,7 @@ protected:
 	void abortEditMode() override;
 
 	Common::Rect getEditRect() const override;
+	int getCaretOffset() const override;
 
 	void copyListData(const Common::U32StringArray &list);
 


### PR DESCRIPTION
Strip formatting from the list widget string before taking the length of it to calculate the caret position. This can be seen e.g. in the save dialog when not using the icon view.

Otherwise, you'll end up with something like this:

![image](https://user-images.githubusercontent.com/601765/172301319-ccc51301-9426-45fa-bb12-a0f55b9b43d0.png)

(It was a bit tricky to get a screenshot, because the keypress to save screenshots in ScummVM will apparently cause the caret to be hidden.)