### PR TITLE
DIRECTOR: Fix Palette loading wrong Palette index

### DIFF
--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -167,9 +167,9 @@ void Frame::readChannels(Common::ReadStreamEndian *stream, uint16 version) {
 
 			stream->read(unk, 6);
 		} else {
-			stream->read(unk, 4);
+			stream->read(unk, 3);
 
-			_palette.paletteId = stream->readByte();
+			_palette.paletteId = stream->readUint16();
 			_palette.firstColor = stream->readByte(); // for cycles. note: these start at 0x80 (for pal entry 0)!
 			_palette.lastColor = stream->readByte();
 			_palette.flags = stream->readByte();

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -256,7 +256,7 @@ void Score::startPlay() {
 	_playState = kPlayStarted;
 	_nextFrameTime = 0;
 
-	_lastPalette = _movie->getCast()->_defaultPalette;
+	_lastPalette = _frames[_currentFrame]->_palette.paletteId;
 	_vm->setPalette(resolvePaletteId(_lastPalette));
 
 	if (_frames.size() <= 1) {	// We added one empty sprite


### PR DESCRIPTION
This fix corrects custom palettes for D3 movies. They were very much implemented but the index being fetched was incorrect. This fix also enables `The Seven Colors : Legend of Psys City` to work with the correct palette in scummvm