### PR TITLE
GRAPHICS: Fix segmentation fault for thumbnail from incomplete fill

### DIFF
--- a/graphics/thumbnail.cpp
+++ b/graphics/thumbnail.cpp
@@ -279,7 +279,7 @@ int *scaleLine(int size, int srcSize) {
 	int scale = 100 * size / srcSize;
 	assert(scale > 0);
 	int *v = new int[size];
-	Common::fill(v, &v[size - 1], 0);
+	Common::fill(v, v + size, 0);
 
 	int distCtr = 0;
 	int *destP = v;


### PR DESCRIPTION
Common::fill() fills up to but not including the address of the last item

Previously the last item of array v was not filled with 0, so if the rest of the code in the scaleLine() method did not update it, it would have a random int value which could cause segmentation fault when using the scale() method.

I had this issue while doing some test recording with the event recorder.
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
