### PR TITLE
GUI: Fix thumbnails for event recorder dialogue

### DIFF
--- a/common/recorderfile.cpp
+++ b/common/recorderfile.cpp
@@ -696,7 +696,7 @@ Graphics::Surface *PlaybackFile::getScreenShot(int number) {
 		if (screenCount == number) {
 			screenCount++;
 			_readStream->seek(-4, SEEK_CUR);
-			Graphics::Surface *thumbnail;
+			Graphics::Surface *thumbnail = nullptr;
 			return Graphics::loadThumbnail(*_readStream, thumbnail) ? thumbnail : NULL;
 		} else {
 			uint32 size = _readStream->readUint32BE();

--- a/gui/recorderdialog.h
+++ b/gui/recorderdialog.h
@@ -53,11 +53,14 @@ private:
 	GUI::ButtonWidget *_editButton;
 	GUI::ButtonWidget *_deleteButton;
 	GUI::ButtonWidget *_playbackButton;
+	GUI::ButtonWidget *_nextScreenshotBtn;
+	GUI::ButtonWidget *_prevScreenshotBtn;
 
 	void updateList();
 	void updateScreenShotsText();
 	void updateSelection(bool redraw);
 	void updateScreenshot();
+	void addThumbnailContainerButtonsAndText();
 public:
 	Common::U32String _author;
 	Common::String    _name;


### PR DESCRIPTION
Also prevent segmentation fault cases related to low-res or switching from low-res to hi-res

And fix memory leak related to loading and scaling of the thumbnail image

A lot of the updated logic is borrowed from the saveload-dialog.cpp for the simple list view (with the thumbnail to the right of the list).


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
