### PR TITLE
SCUMM: Fix Kerner's text mentioning the wrong person in New York

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -1294,13 +1294,13 @@ void ScummEngine_v5::o5_isScriptRunning() {
 	getResultPos();
 	setResult(isScriptRunning(getVarOrDirectByte(PARAM_1)));
 
-    // WORKAROUND bug #346 (also occurs in original): Object stopped with active cutscene
-    // In script 204 room 25 (Cannibal Village) a crash can occur when you are
-    // expected to give something to the cannibals, but instead look at certain
-    // items like the compass or kidnap note. Those inventory items contain little
-    // cutscenes and are abrubtly stopped by the endcutscene in script 204 at 0x0060.
-    // This patch changes the the result of isScriptRunning(164) to also wait for
-    // any inventory scripts that are in a cutscene state, preventing the crash.
+	// WORKAROUND bug #346 (also occurs in original): Object stopped with active cutscene
+	// In script 204 room 25 (Cannibal Village) a crash can occur when you are
+	// expected to give something to the cannibals, but instead look at certain
+	// items like the compass or kidnap note. Those inventory items contain little
+	// cutscenes and are abrubtly stopped by the endcutscene in script 204 at 0x0060.
+	// This patch changes the the result of isScriptRunning(164) to also wait for
+	// any inventory scripts that are in a cutscene state, preventing the crash.
 	if (_game.id == GID_MONKEY && vm.slot[_currentScript].number == 204 && _currentRoom == 25) {
 		ScriptSlot *ss = vm.slot;
 		for (int i = 0; i < NUM_SCRIPT_SLOT; i++, ss++) {
@@ -3128,6 +3128,24 @@ void ScummEngine_v5::decodeParseString() {
 					else
 						strcpy((char *)tmpBuf+16, "^19^");
 					printString(textSlot, tmpBuf);
+				} else if (_game.id == GID_INDY4 && _language == Common::EN_ANY && _roomResource == 10 &&
+						vm.slot[_currentScript].number == 209 && _actorToPrintStrFor == 4 && len == 81 &&
+						strcmp(_game.variant, "Floppy") != 0 && _enableEnhancements) {
+					// WORKAROUND: The English Talkie version of Indy4 changed Kerner's
+					// lines when he uses the phone booth in New York, but the text doesn't
+					// match the voice and it mentions the wrong person, in most releases.
+					// The fixed string is taken from the 1994 Macintosh release.
+					const char origText[] = "Fritz^ Fantastic\x10news!\xFF\x03I think we've found the treasure we\x10seek.";
+					const char newText[] = "Dr. Ubermann^ Fantastic\x10news!\xFF\x03We've found the treasure we\x10seek.";
+					if (strcmp((const char *)_scriptPointer + 16, origText) == 0) {
+						byte *tmpBuf = new byte[sizeof(newText) + 16];
+						memcpy(tmpBuf, _scriptPointer, 16);
+						memcpy(tmpBuf + 16, newText, sizeof(newText));
+						printString(textSlot, tmpBuf);
+						delete[] tmpBuf;
+					} else {
+						printString(textSlot, _scriptPointer);
+					}
 				} else if (_game.id == GID_MONKEY_EGA && _roomResource == 30 && vm.slot[_currentScript].number == 411 &&
 							strstr((const char *)_scriptPointer, "NCREDIT-NOTE-AMOUNT")) {
 					// WORKAROUND for bug #4886 (MI1EGA German: Credit text incorrect)


### PR DESCRIPTION
This comes from quickly diffing my Indy4 Talkie PC release with my Talkie Macintosh release, but [TCRF also mentions this](https://tcrf.net/Indiana_Jones_and_the_Fate_of_Atlantis#Revisional_Differences) among some other differences. The Macintosh releases often fixed some small issues in the original games… I think this one's worth "backporting".

## Context

In one of the first scenes, Kerner will use the phone booth in New York to report that he stole some interesting stuff. The talkie version changed these lines for some reason, but in the PC talkie release the new text doesn't match the new audio:

* Kerner says: `"Dr. Ubermann… Fantastic news! We've found the treasure we seek."`
* but the text prints: `"Fritz… Fantastic news! I think we've found the treasure we seek."`

the real problem is the wrong name, here. Here's a YouTube example: https://www.youtube.com/watch?v=LZZXJ3zCRDQ&t=1217s

The 1994 Macintosh release I have here fixed this line, fortunately (note that there are several Macintosh releases with different content). So this PR just replace the "Fritz" line with the "Dr. Ubermann" line if we find it in an English talkie version.

There was an official Japanese version with the English voices, but I don't have it and it shouldn't be as problematic there. AFAIK, every other translated talkie version is a fan-translation, which may or may not have fixed this on its own.

## How to test

1. Pick up any English talkie version of Indy4
2. Start the game with the `1112` boot param and wait for Kerner to use the phone booth outside
3. Kerner should start his conversation by saying "Dr Uberman…" and the audio and text should match

On the floppy releases, nothing should change. I don't know about the English FM-TOWNS version, but there are many checks so it shouldn't do anything bad.