### PR TITLE
CI: emscripten deployment to Github pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,14 +179,3 @@ jobs:
       - name: Build devtools
         run: |
           make devtools
-      - name: Build emscripten
-        if: ${{ env.SDL_CONFIG == 'sdl2-config' }}
-        run: |
-          make clean
-          ./dists/emscripten/build.sh build --verbose  --enable-plugins --disable-tinygl --default-dynamic --enable-all-engines --bundle-games=testbed,twine,warlock,sky/BASS-Floppy-1.3.zip,feeble,queen/FOTAQ_Floppy.zip,ft,grim/grim-win-demo2-en.zip,lsl7,lure,myst,phantasmagoria,hires1,tlj,sword2,sinistersix,"https://downloads.scummvm.org/frs/demos/hypno/wetlands-dos-demo1-en.zip","https://downloads.scummvm.org/frs/demos/private/private-eye-win-demo-us.zip",jman,wrath,chuckaduck
-      - name: Deploy emscripten port
-        uses: JamesIves/github-pages-deploy-action@v4.2.5
-        if: ${{ env.SDL_CONFIG == 'sdl2-config' }}
-        with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: build-emscripten # The folder the action should deploy.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
         if: ${{ env.SDL_CONFIG == 'sdl2-config' }}
         run: |
           make clean
-          ./dists/emscripten/build.sh build --verbose  --enable-plugins --disable-tinygl --default-dynamic --enable-all-engines --bundle-games=testbed,comi/comi-win-large-demo-en.zip,warlock,sky/BASS-Floppy-1.3.zip,drascula/drascula-audio-mp3-2.0.zip,monkey4,feeble,queen/FOTAQ_Floppy.zip,ft,grim/grim-win-demo2-en.zip,lsl7,lure,myst,phantasmagoria,riven,hires1,tlj,sword2,"https://archive.org/download/Last_Express_demo/Last_Express_demo.zip",sinistersix,"https://downloads.scummvm.org/frs/demos/hypno/wetlands-dos-demo1-en.zip",jman,wrath,chuckaduck
+          ./dists/emscripten/build.sh build --verbose  --enable-plugins --disable-tinygl --default-dynamic --enable-all-engines --bundle-games=testbed,twine,warlock,sky/BASS-Floppy-1.3.zip,feeble,queen/FOTAQ_Floppy.zip,ft,grim/grim-win-demo2-en.zip,lsl7,lure,myst,phantasmagoria,hires1,tlj,sword2,sinistersix,"https://downloads.scummvm.org/frs/demos/hypno/wetlands-dos-demo1-en.zip","https://downloads.scummvm.org/frs/demos/private/private-eye-win-demo-us.zip",jman,wrath,chuckaduck
       - name: Deploy emscripten port
         uses: JamesIves/github-pages-deploy-action@v4.2.5
         if: ${{ env.SDL_CONFIG == 'sdl2-config' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,7 @@ jobs:
       - name: Build emscripten
         if: ${{ matrix.sdlConfig }} == 'sdl2-config'
         run: |
+          make clean
           ./dists/emscripten/build.sh build --verbose  --enable-plugins --disable-tinygl --default-dynamic --enable-all-engines --bundle-games=testbed,comi/comi-win-large-demo-en.zip,warlock,sky/BASS-Floppy-1.3.zip,drascula/drascula-audio-mp3-2.0.zip,monkey4,feeble,queen/FOTAQ_Floppy.zip,ft,grim/grim-win-demo2-en.zip,lsl7,lure,myst,phantasmagoria,riven,hires1,tlj,sword2,"https://archive.org/download/Last_Express_demo/Last_Express_demo.zip",sinistersix,"https://downloads.scummvm.org/frs/demos/hypno/wetlands-dos-demo1-en.zip",jman,wrath,chuckaduck
       - name: Deploy emscripten port
         uses: JamesIves/github-pages-deploy-action@v4.2.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
         run: |
           make devtools
       - name: Build emscripten
+        if: ${{ matrix.sdlConfig }} == 'sdl2-config'
         run: |
           ./dists/emscripten/build.sh build --verbose  --enable-plugins --disable-tinygl --default-dynamic --enable-all-engines --bundle-games=testbed,comi/comi-win-large-demo-en.zip,warlock,sky/BASS-Floppy-1.3.zip,drascula/drascula-audio-mp3-2.0.zip,monkey4,feeble,queen/FOTAQ_Floppy.zip,ft,grim/grim-win-demo2-en.zip,lsl7,lure,myst,phantasmagoria,riven,hires1,tlj,sword2,"https://archive.org/download/Last_Express_demo/Last_Express_demo.zip",sinistersix,"https://downloads.scummvm.org/frs/demos/hypno/wetlands-dos-demo1-en.zip",jman,wrath,chuckaduck
       - name: Deploy emscripten port

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,3 +179,11 @@ jobs:
       - name: Build devtools
         run: |
           make devtools
+      - name: Build emscripten
+        run: |
+          ./dists/emscripten/build.sh build --verbose  --enable-plugins --disable-tinygl --default-dynamic --enable-all-engines --bundle-games=testbed,comi/comi-win-large-demo-en.zip,warlock,sky/BASS-Floppy-1.3.zip,drascula/drascula-audio-mp3-2.0.zip,monkey4,feeble,queen/FOTAQ_Floppy.zip,ft,grim/grim-win-demo2-en.zip,lsl7,lure,myst,phantasmagoria,riven,hires1,tlj,sword2,"https://archive.org/download/Last_Express_demo/Last_Express_demo.zip",sinistersix,"https://downloads.scummvm.org/frs/demos/hypno/wetlands-dos-demo1-en.zip",jman,wrath,chuckaduck
+      - name: Deploy emscripten port
+        uses: JamesIves/github-pages-deploy-action@v4.2.5
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: scummvm/build-emscripten # The folder the action should deploy.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,12 +180,13 @@ jobs:
         run: |
           make devtools
       - name: Build emscripten
-        if: ${{ matrix.sdlConfig }} == 'sdl2-config'
+        if: ${{ env.SDL_CONFIG == 'sdl2-config' }}
         run: |
           make clean
           ./dists/emscripten/build.sh build --verbose  --enable-plugins --disable-tinygl --default-dynamic --enable-all-engines --bundle-games=testbed,comi/comi-win-large-demo-en.zip,warlock,sky/BASS-Floppy-1.3.zip,drascula/drascula-audio-mp3-2.0.zip,monkey4,feeble,queen/FOTAQ_Floppy.zip,ft,grim/grim-win-demo2-en.zip,lsl7,lure,myst,phantasmagoria,riven,hires1,tlj,sword2,"https://archive.org/download/Last_Express_demo/Last_Express_demo.zip",sinistersix,"https://downloads.scummvm.org/frs/demos/hypno/wetlands-dos-demo1-en.zip",jman,wrath,chuckaduck
       - name: Deploy emscripten port
         uses: JamesIves/github-pages-deploy-action@v4.2.5
+        if: ${{ env.SDL_CONFIG == 'sdl2-config' }}
         with:
           branch: gh-pages # The branch the action should deploy to.
-          folder: scummvm/build-emscripten # The folder the action should deploy.
+          folder: build-emscripten # The folder the action should deploy.

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -1,0 +1,33 @@
+name: CI
+on:
+  schedule:
+    - cron: '0 0 * * *' // at the end of every day
+jobs:
+  ubuntu:
+    name: Ubuntu
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ubuntu-latest
+            sdlConfig: sdl2-config
+            aptPackages: 'libsdl2-dev libsdl2-net-dev liba52-dev libjpeg-turbo8-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev libfribidi-dev libcurl4-openssl-dev libgtk-3-dev libspeechd-dev libsndio-dev libunity-dev'
+    env:
+      SDL_CONFIG: ${{ matrix.sdlConfig }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install ${{ matrix.aptPackages }}
+      - name: Build emscripten port
+        run: |
+          make clean
+          ./dists/emscripten/build.sh build --verbose  --enable-plugins --disable-tinygl --default-dynamic --enable-all-engines --bundle-games=testbed,warlock,sky/BASS-Floppy-1.3.zip,feeble,queen/FOTAQ_Floppy.zip,ft,grim/grim-win-demo2-en.zip,lsl7,lure,myst,phantasmagoria,hires1,tlj,sword2,sinistersix,"https://downloads.scummvm.org/frs/demos/hypno/wetlands-dos-demo1-en.zip","https://downloads.scummvm.org/frs/demos/private/private-eye-win-demo-us.zip",jman,wrath,chuckaduck
+      - name: Deploy artifacts
+        uses: JamesIves/github-pages-deploy-action@v4.2.5
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: build-emscripten # The folder the action should deploy.

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -1,8 +1,7 @@
 name: Emscripten deployment
-on:
-  schedule:
-    - cron: '0 0 * * *'
-  workflow_dispatch:
+on: [push, pull_request]
+#  schedule:
+#    - cron: '0 0 * * *'
 jobs:
   ubuntu:
     name: Ubuntu

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -1,7 +1,7 @@
-name: CI
+name: Emscripten deployment
 on:
   schedule:
-    - cron: '0 0 * * *' // at the end of every day
+    - cron: '0 0 * * *'
 jobs:
   ubuntu:
     name: Ubuntu

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -2,6 +2,7 @@ name: Emscripten deployment
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 jobs:
   ubuntu:
     name: Ubuntu

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -24,7 +24,6 @@ jobs:
           sudo apt-get install ${{ matrix.aptPackages }}
       - name: Build emscripten port
         run: |
-          make clean
           ./dists/emscripten/build.sh build --verbose  --enable-plugins --disable-tinygl --default-dynamic --enable-all-engines --bundle-games=testbed,warlock,sky/BASS-Floppy-1.3.zip,feeble,queen/FOTAQ_Floppy.zip,ft,grim/grim-win-demo2-en.zip,lsl7,lure,myst,phantasmagoria,hires1,tlj,sword2,sinistersix,"https://downloads.scummvm.org/frs/demos/hypno/wetlands-dos-demo1-en.zip","https://downloads.scummvm.org/frs/demos/private/private-eye-win-demo-us.zip",jman,wrath,chuckaduck
       - name: Deploy artifacts
         uses: JamesIves/github-pages-deploy-action@v4.2.5


### PR DESCRIPTION
This small PR deploys to Github pages using the Github action that we already use for CI tests. This code is based on @chkuendig demo deployment (https://github.com/chkuendig/scummvm-demo/).

Before merging, there a few important points to discuss: 
* As expected, it will require to enable the Github pages for the main scummvm (I don't have permissions to do it). The deployment should be available at: http://scummvm.github.io/scummvm.html 
* The Github action runs at every commit and this is too often to redeploy. I think it could be once per day as we have the nightly builds.
* The selection of demos is arbitrary, we should try to prioritize the ones from the games that should be tested for the upcoming releases. 