### PR TITLE
SCUMM: Add a `grail` command to the debugger

### DIFF
--- a/engines/scumm/debugger.cpp
+++ b/engines/scumm/debugger.cpp
@@ -82,7 +82,8 @@ ScummDebugger::ScummDebugger(ScummEngine *s)
 
 	if (_vm->_game.id == GID_LOOM)
 		registerCmd("drafts",  WRAP_METHOD(ScummDebugger, Cmd_PrintDraft));
-
+	if (_vm->_game.id == GID_INDY3)
+		registerCmd("grail",  WRAP_METHOD(ScummDebugger, Cmd_PrintGrail));
 	if (_vm->_game.id == GID_MONKEY && _vm->_game.platform == Common::kPlatformSegaCD)
 		registerCmd("passcode",  WRAP_METHOD(ScummDebugger, Cmd_Passcode));
 
@@ -1000,6 +1001,28 @@ bool ScummDebugger::Cmd_PrintDraft(int argc, const char **argv) {
 			(draft & 0x2000) ? 'K' : ' ',
 			(draft & 0x4000) ? 'U' : ' ');
 	}
+
+	return true;
+}
+
+bool ScummDebugger::Cmd_PrintGrail(int argc, const char **argv) {
+	if (_vm->_game.id != GID_INDY3) {
+		debugPrintf("Command only works with Indy3\n");
+		return true;
+	}
+
+	if (_vm->_currentRoom != 86) {
+		debugPrintf("Command only works in room 86\n");
+		return true;
+	}
+
+	const int grailNumber = _vm->_scummVars[253];
+	if (grailNumber < 1 || grailNumber > 10) {
+		debugPrintf("Couldn't find the Grail number\n");
+		return true;
+	}
+
+	debugPrintf("Real Grail is Grail #%d\n", grailNumber);
 
 	return true;
 }

--- a/engines/scumm/debugger.h
+++ b/engines/scumm/debugger.h
@@ -57,6 +57,7 @@ private:
 	bool Cmd_ImportRes(int argc, const char **argv);
 
 	bool Cmd_PrintDraft(int argc, const char **argv);
+	bool Cmd_PrintGrail(int argc, const char **argv);
 	bool Cmd_Passcode(int argc, const char **argv);
 
 	bool Cmd_Debug(int argc, const char **argv);


### PR DESCRIPTION
## Context

At the end of Indy3, you must find the real Grail among 10 grails in front of the old knight.

![Choosing wisely](https://scientificgamer.com/blog/wp-content/uploads/2020/11/last_crusade_grails.png)

For this you need to:

* think of taking notes when visiting the catacombs and the painting in Castle Brunwald, and not lose them until the end of the game.
* and own and read all the related hints in the original manual, but it's quite long, in English only (at least on GOG 😞), there's a lot of cursive content, and so on.
* or have some luck (10% probability).

If you get it wrong:

* you die,
* and you need to restart the 3 trials again.
* (the original game would event prevent you from using your saves).

I don't think the debugger is meant to contain the solution for every puzzle, but finding the real Grail is not just a cheap 1/2 chance and I'm not sure all modern players are as meticulous as you could be for an adventure game in 1990. Especially since your probability of winning is quite low if you don't have the manual. So, since there's already a `drafts` command for Loom, this adds a `grail` command for Indy3.

Using `scummVars[253]` comes from my interpretation of script 0086-0122:

```
[00DA] (AC)       Exprmode Var[53] = ((Var[253] + 888) - 1);
[00E9] (C8)       if (Local[1] == Var[53]) {
[00F0] (1A)         Bit[1504] = 1;
[00F5] (18)       } else {
[00F8] (1A)         Bit[1504] = 0;
[00FD] (**)       }
[00FD] (5C)       oldRoomEffect-set(128);
[0101] (72)       loadRoom(87);
[0103] (80)       breakHere();
[0104] (A8)       unless (Var[57]) goto 0103;
[0109] (52)       actorFollowCamera(1);
[010B] (5C)       oldRoomEffect-set(257);
[010F] (28)       if (!Bit[1504]) {
                        // "He chose poorly." ......
```

It seems to always work here (VGA PC), but tests on EGA/Macintosh/FM-TOWNS are welcome :)

## How to test

1. Type `room 86` in the debugger (that's the room where you need to make the choice)
2. Once the knight is done talking, type `grail` in the debugger
3. Note the number you're given, pick up the related grail (e.g. if it says `7`, pick up the 7th grail from the left).
4. Use it with the water on the right, and confirm that Indy chose wisely.

Note: there are some non-clickable grails being displayed (which is odd but well…). You need to count the *clickable* grails (and the count starts from 1, not 0).