### PR TITLE
GRAPHICS: Fix alpha blend on 16-bit target regression

### DIFF
--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -388,6 +388,7 @@ void ManagedSurface::blitFromInner(const Surface &src, const Common::Rect &srcRe
 					// Partially transparent, so calculate new pixel colors
 					if (destFormat.bytesPerPixel == 2) {
 						uint32 destColor = *reinterpret_cast<uint16 *>(destVal);
+						destFormat.colorToARGB(destColor, aDest, rDest, gDest, bDest);
 					} else if (format.bytesPerPixel == 4) {
 						uint32 destColor = *reinterpret_cast<uint32 *>(destVal);
 						destFormat.colorToARGB(destColor, aDest, rDest, gDest, bDest);


### PR DESCRIPTION
Fixes regression noted from pull request https://github.com/scummvm/scummvm/pull/3951

Destination pixel colors were not being properly fetched when doing alpha blends on a 16-bit target.