### PR TITLE
SCUMM: Fix missing Dr. Fred line when he receives a new diamond

### DIFF
--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -2393,7 +2393,7 @@ void ScummEngine_v6::o6_printEgo() {
 void ScummEngine_v6::o6_talkActor() {
 	int offset = _scriptPointer - _scriptOrgPointer;
 
-	// WORKAROUND for bug #1452: see below for detailed description
+	// WORKAROUND for missing waitForMessage() calls; see below
 	if (_forcedWaitForMessage) {
 		if (VAR(VAR_HAVE_MSG)) {
 			_scriptPointer--;
@@ -2421,6 +2421,20 @@ void ScummEngine_v6::o6_talkActor() {
 
 	_string[0].loadDefault();
 	actorTalk(_scriptPointer);
+
+	// WORKAROUND: Dr Fred's first reaction line about Hoagie's and Laverne's
+	// units after receiving a new diamond is unused because of missing
+	// wait.waitForMessage() calls. We always simulate this opcode when
+	// triggering Dr Fred's lines in this part of the script, since there is
+	// no stable offset for all the floppy, CD and translated versions, and
+	// no easy way to only target the impacted lines.
+	if (_game.id == GID_TENTACLE && vm.slot[_currentScript].number == 9
+		&& vm.localvar[_currentScript][0] == 216 && _actorToPrintStrFor == 4 && _enableEnhancements) {
+		_forcedWaitForMessage = true;
+		_scriptPointer--;
+
+		return;
+	}
 
 	// WORKAROUND for bug #1452: "DIG: Missing subtitles when talking to Brink"
 	// Original script does not have wait.waitForMessage() after several messages:


### PR DESCRIPTION
Thanks to NeoDement on Tcrf for spotting this:
https://tcrf.net/Maniac_Mansion:_Day_of_the_Tentacle/Unused_Scripts#Chron-O-John_Status_Check

## Context

When Dr. Fred receives a new diamond, he's supposed to report the status of Hoagie's and Laverne's units, but the `talkActor()` lines for that don't have any associated `wait.waitForMessage()`, so they were unseen and unheard in
the game until now. The Remastered version didn't fix this…

Global script 9 (stored in room 7):

```
...
[0170] (5D) } else if (dup[1] == 216) {
[017B] (5D)   if (bitvar9) {
[0182] (5D)     if (bitvar10) {
[0188] (5E)       startScript(0,30,[])
[0192] (7C)       stopScript(0)
[0196] (**)     }
[0196] (**)   }
[0196] (68)   beginCutscene([2])
[019D] (43)   bitvar40 = 1
[01A3] (95)   beginOverride()
[01A4] (73)   jump 4d2
[01A7] (BA)   talkActor(sound(0x4034F2, 0xA) + "Can we bring back my friends now?",1)
[01DD] (A9)   wait.waitForMessage()
[01DF] (5D)   if (bitvar9) {
[01E5] (BA)     talkActor(sound(0x491E26, 0xA) + "According to my instruments, your lively friend in the future hasn't yet powered her unit.",4)
[0254] (5D)   } else if (bitvar10) {
[025D] (BA)     talkActor(sound(0x4B1202, 0xE) + "According to my instruments, your rotund friend in the past hasn't yet powered his unit.",4)
[02CA] (73)   } else {
[02CD] (BA)     talkActor(sound(0x4D2429, 0xE) + "According to my instruments, your friends have not yet powered their units.",4)
[032D] (**)   }
     # ==> missing wait.waitForMessage() for the talkActor() lines above <==
[032D] (BA)   talkActor(sound(0x4ED66E, 0x12) + "We've repaired the primary device^" + wait() + "^but before we can do anything, BOTH time pods must be energized as well." + wait() + "Then we can bring back what's-his-name and who's-her-face!",4)
[03EB] (A9)   wait.waitForMessage()
...
```

I couldn't find a way of only targeting the impacted lines (I can't use the offsets since they change between the CD, floppy and translated releases), so this is applied to every line from Dr. Fred there (only targeting the `if (dup[1] == 216)` part of this script). It doesn't seem to cause any problem, though. This reuses the logic for the Dig workaround just below that.

## How to test

I couldn't find a boot param which properly covers this part of the script (in boot param `969`, Hoagie and Laverne already plugged their units so this part of the script isn't triggered), so here's a savegame for the English PC talkie version:

Download [`tentacle.s10.zip`](https://github.com/scummvm/scummvm/files/8893575/tentacle.s10.zip), extract it and put its content inside your savegame folder.

1. Load this savegame
2. Make Bernard use the phone: in the cutscene, Dr. Fred should now say `"According to my instruments, your friends have not yet powered their units."`
3. OR make Hoagie plug his unit, and then use the phone; Dr. Fred should now say `"According to my instruments, your lively friend in the future hasn't yet powered her unit."`
4. OR make Laverne plug her unit, and then use the phone; Dr. Fred should now say `"According to my instruments, your rotund friend in the past hasn't yet powered his unit."`

and everything else in this cutscene should also remain OK.

Tested with the English and French talkie versions, with the original and [reMONSTERed](https://github.com/BLooperZ/remonstered) audio. It should probably work with the Macintosh and floppy versions, too, but I don't have them.