### PR TITLE
DIRECTOR: LINGO: Implement kTheModified field in CastMember::getField()

### DIFF
--- a/engines/director/castmember.cpp
+++ b/engines/director/castmember.cpp
@@ -48,6 +48,7 @@ CastMember::CastMember(Cast *cast, uint16 castId, Common::SeekableReadStreamEndi
 	_flags1 = 0;
 
 	_modified = true;
+	_isChanged = false;
 
 	_objType = kCastMemberObj;
 
@@ -57,6 +58,12 @@ CastMember::CastMember(Cast *cast, uint16 castId, Common::SeekableReadStreamEndi
 
 CastMemberInfo *CastMember::getInfo() {
 	return _cast->getCastMemberInfo(_castId);
+}
+
+void CastMember::setModified(bool modified) {
+	_modified = modified;
+	if (modified)
+		_isChanged = true;
 }
 
 

--- a/engines/director/castmember.h
+++ b/engines/director/castmember.h
@@ -73,7 +73,7 @@ public:
 	virtual bool isEditable() { return false; }
 	virtual void setEditable(bool editable) {}
 	virtual bool isModified() { return _modified; }
-	virtual void setModified(bool modified) { _modified = modified; }
+	void setModified(bool modified);
 	virtual Graphics::MacWidget *createWidget(Common::Rect &bbox, Channel *channel, SpriteType spriteType) { return nullptr; }
 	virtual void updateWidget(Graphics::MacWidget *widget, Channel *channel) {}
 	virtual void updateFromWidget(Graphics::MacWidget *widget) {}
@@ -110,6 +110,7 @@ protected:
 	// a link to the widget we created, we may use it later
 	Graphics::MacWidget *_widget;
 	bool _modified;
+	bool _isChanged;
 };
 
 class BitmapCastMember : public CastMember {

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -661,7 +661,7 @@ Datum CastMember::getField(int field) {
 		d = 1; // Not loaded handled in Lingo::getTheCast
 		break;
 	case kTheModified:
-		warning("STUB: CastMember::getField():: Unprocessed getting field \"%s\" of cast %d", g_lingo->field2str(field), _castId);
+		d = (int)_isChanged;
 		break;
 	case kTheName:
 		if (castInfo)


### PR DESCRIPTION
This is a quick fix to implement the STUB for the `Modified` property of CastMember