### PR TITLE
DIRECTOR: LINGO: Implement setting of kTheRect field in CastMember::setField()

### DIFF
--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -726,7 +726,7 @@ bool CastMember::setField(int field, const Datum &d) {
 		castInfo->name = d.asString();
 		return true;
 	case kTheRect:
-		warning("STUB: CastMember::setField(): Unprocessed setting field \"%s\" of cast %d", g_lingo->field2str(field), _castId);
+		warning("CastMember::setField(): Attempt to set read-only field \"%s\" of cast %d", g_lingo->field2str(field), _castId);
 		return false;
 	case kThePurgePriority:
 		_purgePriority = CLIP<int>(d.asInt(), 0, 3);


### PR DESCRIPTION
This change prevents setting of `_initialRect` of the CastMember from the setField() function and implements the STUB