### PR TITLE
DIRECTOR: LINGO: Implement copyToClipBoard and pasteClipBoardInto STU…

### DIFF
--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -86,6 +86,7 @@ DirectorEngine::DirectorEngine(OSystem *syst, const DirectorGameDescription *gam
 	_currentWindow = nullptr;
 	_cursorWindow = nullptr;
 	_lingo = nullptr;
+	_clipBoard = nullptr;
 	_version = getDescriptionVersion();
 
 	_wm = nullptr;

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -281,6 +281,7 @@ protected:
 public:
 	const DirectorGameDescription *_gameDescription;
 	Common::FSNode _gameDataDir;
+	CastMemberID *_clipBoard;
 
 private:
 	byte *_currentPalette;

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1732,9 +1732,8 @@ void LB::b_constrainV(int nargs) {
 }
 
 void LB::b_copyToClipBoard(int nargs) {
-	g_lingo->printSTUBWithArglist("b_copyToClipBoard", nargs);
-
-	g_lingo->dropStack(nargs);
+	Datum d = g_lingo->pop();
+	g_director->_clipBoard = new CastMemberID(d.asMemberID());
 }
 
 void LB::b_duplicate(int nargs) {
@@ -2055,9 +2054,32 @@ void LB::b_moveableSprite(int nargs) {
 }
 
 void LB::b_pasteClipBoardInto(int nargs) {
-	g_lingo->printSTUBWithArglist("b_pasteClipBoardInto", nargs);
+	Datum to = g_lingo->pop();
+	if (!g_director->_clipBoard) {
+		warning("LB::b_pasteClipBoardInto(): Nothing to paste from clipboard, skipping paste..");
+		return;
+	}
 
-	g_lingo->dropStack(nargs);
+	Movie *movie = g_director->getCurrentMovie();
+	uint16 frame = movie->getScore()->getCurrentFrame(); 
+	Frame *currentFrame = movie->getScore()->_frames[frame];
+	CastMember *castMember = movie->getCastMember(*g_director->_clipBoard);
+	auto channels = movie->getScore()->_channels;
+
+	castMember->setModified(true);
+	movie->getCast()->_loadedCast->setVal(to.u.cast->member, castMember);
+
+	for (uint16 i = 0; i < currentFrame->_sprites.size(); i++) {
+		if (currentFrame->_sprites[i]->_castId == to.asMemberID())
+			currentFrame->_sprites[i]->setCast(to.asMemberID());
+	}
+
+	for (uint i = 0; i < channels.size(); i++) {
+		if (channels[i]->_sprite->_castId == to.asMemberID()) {
+			channels[i]->_sprite->setCast(to.asMemberID());
+			channels[i]->_dirty = true;
+		}
+	}
 }
 
 void LB::b_puppetPalette(int nargs) {


### PR DESCRIPTION
Implements the clipboard as a pointer to CastMemberID (as usage in Lingo would mean copying from existing CastMembers). This CastMemberID can then be used to load the CastMember and paste it at the given location. These changes have been tested using the `copyToClipBoard cast` workshop movie