### PR TITLE
DIRECTOR: Stub/Implement the XObjects used in Gahan Wilson's Haunted House.

### DIFF
--- a/audio/decoders/aiff.h
+++ b/audio/decoders/aiff.h
@@ -43,6 +43,24 @@ namespace Audio {
 
 class RewindableAudioStream;
 
+class AIFFHeader {
+public:
+	~AIFFHeader();
+	static AIFFHeader *readAIFFHeader(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse);
+	RewindableAudioStream *makeAIFFStream(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse);
+
+	uint32 getFrameCount() const { return _frameCount; }
+	uint32 getFrameRate() const { return _rate; }
+
+private:
+	uint16 _channels = 0;
+	uint32 _frameCount = 0;
+	uint16 _bitsPerSample = 0;
+	uint32 _rate = 0;
+	uint32 _codec = 0;
+	Common::SeekableReadStream *_dataStream = nullptr;
+};
+
 /**
  * Try to load an AIFF from the given seekable stream and create an AudioStream
  * from that data.

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -45,6 +45,7 @@
 #include "director/lingo/xlibs/labeldrvxobj.h"
 #include "director/lingo/xlibs/memoryxobj.h"
 #include "director/lingo/xlibs/movemousexobj.h"
+#include "director/lingo/xlibs/movutils.h"
 #include "director/lingo/xlibs/orthoplayxobj.h"
 #include "director/lingo/xlibs/palxobj.h"
 #include "director/lingo/xlibs/popupmenuxobj.h"
@@ -134,6 +135,7 @@ static struct XLibProto {
 	{ JourneyWareXINIXObj::fileNames,	JourneyWareXINIXObj::open,	JourneyWareXINIXObj::close,	kXObj,					400 }, 	// D4
 	{ PalXObj::fileNames,				PalXObj::open,				PalXObj::close,				kXObj,					400 }, 	// D4
 	{ MemoryXObj::fileNames,			MemoryXObj::open,			MemoryXObj::close,			kXObj,					400 }, 	// D4
+	{ MovUtilsXObj::fileNames,			MovUtilsXObj::open,			MovUtilsXObj::close,		kXObj,					400 }, 	// D4
 	{ PopUpMenuXObj::fileNames,			PopUpMenuXObj::open,		PopUpMenuXObj::close,		kXObj,					200 }, 	// D2
 	{ SerialPortXObj::fileNames,		SerialPortXObj::open,		SerialPortXObj::close,		kXObj,					200 },	// D2
 	{ SoundJam::fileNames,				SoundJam::open,				SoundJam::close,			kXObj,					400 },	// D4

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -40,6 +40,7 @@
 #include "director/lingo/xlibs/fileio.h"
 #include "director/lingo/xlibs/flushxobj.h"
 #include "director/lingo/xlibs/fplayxobj.h"
+#include "director/lingo/xlibs/jwxini.h"
 #include "director/lingo/xlibs/labeldrvxobj.h"
 #include "director/lingo/xlibs/memoryxobj.h"
 #include "director/lingo/xlibs/movemousexobj.h"
@@ -122,24 +123,24 @@ static struct XLibProto {
 	int type;
 	int version;
 } xlibs[] = {
-	{ CDROMXObj::fileNames,			CDROMXObj::open,		CDROMXObj::close,			kXObj,					200 },	// D2
-	{ FileIO::fileNames,			FileIO::open,			FileIO::close,				kXObj | kXtraObj,		200 },	// D2
-	{ FlushXObj::fileNames,			FlushXObj::open,		FlushXObj::close,			kXObj,					400 },	// D4
-	{ FPlayXObj::fileNames,			FPlayXObj::open,		FPlayXObj::close,			kXObj,					200 },	// D2
-	{ LabelDrvXObj::fileNames,		LabelDrvXObj::open,		LabelDrvXObj::close,		kXObj,					400 }, 	// D4
-	{ OrthoPlayXObj::fileNames,		OrthoPlayXObj::open,	OrthoPlayXObj::close,		kXObj,					400 }, 	// D4
-	{ PalXObj::fileNames,			PalXObj::open,			PalXObj::close,				kXObj,					400 }, 	// D4
-	{ MemoryXObj::fileNames,		MemoryXObj::open,		MemoryXObj::close,			kXObj,					400 }, 	// D4
-	{ PopUpMenuXObj::fileNames,		PopUpMenuXObj::open,	PopUpMenuXObj::close,		kXObj,					200 }, 	// D2
-	{ SerialPortXObj::fileNames,	SerialPortXObj::open,	SerialPortXObj::close,		kXObj,					200 },	// D2
-	{ SoundJam::fileNames,			SoundJam::open,			SoundJam::close,			kXObj,					400 },	// D4
-	{ RegisterComponent::fileNames,	RegisterComponent::open,RegisterComponent::close,	kXObj,					400 },	// D4
-	{ VideodiscXObj::fileNames,		VideodiscXObj::open,	VideodiscXObj::close,		kXObj,					200 }, 	// D2
-	{ RearWindowXObj::fileNames,	RearWindowXObj::open,	RearWindowXObj::close,		kXObj,					400 },	// D4
-	{ MoveMouseXObj::fileNames,		MoveMouseXObj::open,	MoveMouseXObj::close,		kXObj,					400 },	// D4
-	{ XPlayAnim::fileNames,			XPlayAnim::open,		XPlayAnim::close, 			kXObj,					300 },	// D3
+	{ CDROMXObj::fileNames,				CDROMXObj::open,			CDROMXObj::close,			kXObj,					200 },	// D2
+	{ FileIO::fileNames,				FileIO::open,				FileIO::close,				kXObj | kXtraObj,		200 },	// D2
+	{ FlushXObj::fileNames,				FlushXObj::open,			FlushXObj::close,			kXObj,					400 },	// D4
+	{ FPlayXObj::fileNames,				FPlayXObj::open,			FPlayXObj::close,			kXObj,					200 },	// D2
+	{ LabelDrvXObj::fileNames,			LabelDrvXObj::open,			LabelDrvXObj::close,		kXObj,					400 }, 	// D4
+	{ OrthoPlayXObj::fileNames,			OrthoPlayXObj::open,		OrthoPlayXObj::close,		kXObj,					400 }, 	// D4
+	{ JourneyWareXINIXObj::fileNames,	JourneyWareXINIXObj::open,	JourneyWareXINIXObj::close,	kXObj,					400 }, 	// D4
+	{ PalXObj::fileNames,				PalXObj::open,				PalXObj::close,				kXObj,					400 }, 	// D4
+	{ MemoryXObj::fileNames,			MemoryXObj::open,			MemoryXObj::close,			kXObj,					400 }, 	// D4
+	{ PopUpMenuXObj::fileNames,			PopUpMenuXObj::open,		PopUpMenuXObj::close,		kXObj,					200 }, 	// D2
+	{ SerialPortXObj::fileNames,		SerialPortXObj::open,		SerialPortXObj::close,		kXObj,					200 },	// D2
+	{ SoundJam::fileNames,				SoundJam::open,				SoundJam::close,			kXObj,					400 },	// D4
+	{ RegisterComponent::fileNames,		RegisterComponent::open,	RegisterComponent::close,	kXObj,					400 },	// D4
+	{ VideodiscXObj::fileNames,			VideodiscXObj::open,		VideodiscXObj::close,		kXObj,					200 }, 	// D2
+	{ RearWindowXObj::fileNames,		RearWindowXObj::open,		RearWindowXObj::close,		kXObj,					400 },	// D4
+	{ MoveMouseXObj::fileNames,			MoveMouseXObj::open,		MoveMouseXObj::close,		kXObj,					400 },	// D4
+	{ XPlayAnim::fileNames,				XPlayAnim::open,			XPlayAnim::close, 			kXObj,					300 },	// D3
 	{ nullptr, nullptr, nullptr, 0, 0 }
-
 };
 
 void Lingo::initXLibs() {

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -40,6 +40,7 @@
 #include "director/lingo/xlibs/fileio.h"
 #include "director/lingo/xlibs/flushxobj.h"
 #include "director/lingo/xlibs/fplayxobj.h"
+#include "director/lingo/xlibs/gpid.h"
 #include "director/lingo/xlibs/jwxini.h"
 #include "director/lingo/xlibs/labeldrvxobj.h"
 #include "director/lingo/xlibs/memoryxobj.h"
@@ -127,6 +128,7 @@ static struct XLibProto {
 	{ FileIO::fileNames,				FileIO::open,				FileIO::close,				kXObj | kXtraObj,		200 },	// D2
 	{ FlushXObj::fileNames,				FlushXObj::open,			FlushXObj::close,			kXObj,					400 },	// D4
 	{ FPlayXObj::fileNames,				FPlayXObj::open,			FPlayXObj::close,			kXObj,					200 },	// D2
+	{ GpidXObj::fileNames,				GpidXObj::open,				GpidXObj::close,			kXObj,					400 },	// D4
 	{ LabelDrvXObj::fileNames,			LabelDrvXObj::open,			LabelDrvXObj::close,		kXObj,					400 }, 	// D4
 	{ OrthoPlayXObj::fileNames,			OrthoPlayXObj::open,		OrthoPlayXObj::close,		kXObj,					400 }, 	// D4
 	{ JourneyWareXINIXObj::fileNames,	JourneyWareXINIXObj::open,	JourneyWareXINIXObj::close,	kXObj,					400 }, 	// D4

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -36,6 +36,7 @@
 #include "director/lingo/lingo-object.h"
 #include "director/lingo/lingo-the.h"
 
+#include "director/lingo/xlibs/aiff.h"
 #include "director/lingo/xlibs/cdromxobj.h"
 #include "director/lingo/xlibs/fileio.h"
 #include "director/lingo/xlibs/flushxobj.h"
@@ -125,6 +126,7 @@ static struct XLibProto {
 	int type;
 	int version;
 } xlibs[] = {
+	{ AiffXObj::fileNames,				AiffXObj::open,				AiffXObj::close,			kXObj,					400 },	// D4
 	{ CDROMXObj::fileNames,				CDROMXObj::open,			CDROMXObj::close,			kXObj,					200 },	// D2
 	{ FileIO::fileNames,				FileIO::open,				FileIO::close,				kXObj | kXtraObj,		200 },	// D2
 	{ FlushXObj::fileNames,				FlushXObj::open,			FlushXObj::close,			kXObj,					400 },	// D4

--- a/engines/director/lingo/xlibs/aiff.cpp
+++ b/engines/director/lingo/xlibs/aiff.cpp
@@ -1,0 +1,99 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*************************************
+ *
+ * USED IN:
+ * Gahan Wilson's Ultimate Haunted House
+ *
+ *************************************/
+
+/*
+ * -- copyright 1994 by Byron Priess Multimedia, authored by MayoSmith and Lee
+ * aiff
+ * I      mNew                --Read Docs to avoid Hard Drive failure
+ * X      mDispose            --Disposes of XObject instance
+ * S      mName               --Returns the XObject name (Widget)
+ * I      mStatus             --Returns an integer status code
+ * SI     mError, code        --Returns an error string
+ * S      mLastError          --Returns last error string
+ * III    mAdd, arg1, arg2    --Returns arg1+arg2
+ * SSI    mFirst, str, nchars --Return the first nchars of string str
+ * V      mMul, f1, f2        --Returns f1*f2 as floating point
+ * X      mGlobals            --Sample code to Read & Modify globals
+ * X      mSymbols            --Sample code to work with Symbols
+ * X      mSendPerform        --Sample code to show SendPerform call
+ * X      mFactory            --Sample code to find Factory objects
+ * IS     mDuration, str      --Read Docs to avoid Hard Drive failure
+ */
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/xlibs/aiff.h"
+
+
+namespace Director {
+
+const char *AiffXObj::xlibName = "aiff";
+const char *AiffXObj::fileNames[] = {
+	"AIFF",
+	nullptr
+};
+
+static MethodProto xlibMethods[] = {
+	{ "new",   		AiffXObj::m_new,					0,	0,	400 },	// D4
+	{ "Duration",   AiffXObj::m_duration,				1,	1,	400 },	// D4
+	{ nullptr, nullptr, 0, 0, 0 }
+};
+
+void AiffXObj::open(int type) {
+	if (type == kXObj) {
+		AiffXObject::initMethods(xlibMethods);
+		AiffXObject *xobj = new AiffXObject(kXObj);
+		g_lingo->_globalvars[xlibName] = xobj;
+	}
+}
+
+void AiffXObj::close(int type) {
+	if (type == kXObj) {
+		AiffXObject::cleanupMethods();
+		g_lingo->_globalvars[xlibName] = Datum();
+	}
+}
+
+
+AiffXObject::AiffXObject(ObjectType ObjectType) :Object<AiffXObject>("AiffXObj") {
+	_objType = ObjectType;
+}
+
+void AiffXObj::m_new(int nargs) {
+	g_lingo->printSTUBWithArglist("AiffXObj::new", nargs);
+	g_lingo->push(g_lingo->_currentMe);
+}
+
+void AiffXObj::m_duration(int nargs) {
+	g_lingo->printSTUBWithArglist("AiffXObj::m_duration", nargs);
+	g_lingo->dropStack(nargs);
+	g_lingo->push(Datum(0)); // TODO: Implement
+}
+
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/aiff.h
+++ b/engines/director/lingo/xlibs/aiff.h
@@ -1,0 +1,49 @@
+/* ScummVM - Graphic Adventure Engine
+*
+* ScummVM is the legal property of its developers, whose names
+* are too numerous to list here. Please refer to the COPYRIGHT
+* file distributed with this source distribution.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+ */
+
+
+#ifndef DIRECTOR_LINGO_XLIBS_AIFF_H
+#define DIRECTOR_LINGO_XLIBS_AIFF_H
+
+namespace Director {
+
+class AiffXObject : public Object<AiffXObject> {
+public:
+	AiffXObject(ObjectType objType);
+};
+
+namespace AiffXObj {
+
+extern const char *xlibName;
+extern const char *fileNames[];
+
+void open(int type);
+void close(int type);
+
+void m_new(int nargs);
+
+void m_duration(int nargs);
+
+} // End of namespace AiffXObj
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/lingo/xlibs/gpid.cpp
+++ b/engines/director/lingo/xlibs/gpid.cpp
@@ -1,0 +1,90 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*************************************
+ *
+ * USED IN:
+ * Gahan Wilson's Ultimate Haunted House
+ *
+ *************************************/
+
+/*
+ * Product Identification Number
+ * Gahan Wilson's Ultimate Haunted House
+ * Copyright 1994 Byron Preiss Multimedia Company, Inc.
+ * 'Copyright 1994, Byron Preiss Multimedia
+ * -- copyright 1994 by Byron Priess Multimedia, authored by MayoSmith
+ * gpid
+ * I      mNew                        --Read Docs to avoid Hard Drive failure
+ * X      mDispose                    --Disposes of XObject instance
+ * S      mName                       --Returns the XObject name (Widget)
+ * I      mStatus                     --Returns an integer status code
+ * SI     mError, code                --Returns an error string
+ * S      mLastError                  --Returns last error string
+ * I      mGetPid                     --Retrieves PID
+ *
+ */
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/xlibs/gpid.h"
+
+
+namespace Director {
+
+const char *GpidXObj::xlibName = "gpid";
+const char *GpidXObj::fileNames[] = {
+	"GPID",
+	nullptr
+};
+
+static MethodProto xlibMethods[] = {
+	{ "new",   GpidXObj::m_new,					0,	0,	400 },	// D4
+	{ nullptr, nullptr, 0, 0, 0 }
+};
+
+void GpidXObj::open(int type) {
+	if (type == kXObj) {
+		ProductIdXObject::initMethods(xlibMethods);
+		ProductIdXObject *xobj = new ProductIdXObject(kXObj);
+		g_lingo->_globalvars[xlibName] = xobj;
+	}
+}
+
+void GpidXObj::close(int type) {
+	if (type == kXObj) {
+		ProductIdXObject::cleanupMethods();
+		g_lingo->_globalvars[xlibName] = Datum();
+	}
+}
+
+
+ProductIdXObject::ProductIdXObject(ObjectType ObjectType) :Object<ProductIdXObject>("GpidXObj") {
+	_objType = ObjectType;
+}
+
+void GpidXObj::m_new(int nargs) {
+	g_lingo->printSTUBWithArglist("gpid::new", nargs);
+	g_lingo->push(g_lingo->_currentMe);
+}
+
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/gpid.h
+++ b/engines/director/lingo/xlibs/gpid.h
@@ -1,0 +1,47 @@
+/* ScummVM - Graphic Adventure Engine
+*
+* ScummVM is the legal property of its developers, whose names
+* are too numerous to list here. Please refer to the COPYRIGHT
+* file distributed with this source distribution.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+ */
+
+
+#ifndef DIRECTOR_LINGO_XLIBS_GPID_H
+#define DIRECTOR_LINGO_XLIBS_GPID_H
+
+namespace Director {
+
+class ProductIdXObject : public Object<ProductIdXObject> {
+public:
+	ProductIdXObject(ObjectType objType);
+};
+
+namespace GpidXObj {
+
+extern const char *xlibName;
+extern const char *fileNames[];
+
+void open(int type);
+void close(int type);
+
+void m_new(int nargs);
+
+} // End of namespace GpidXObj
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/lingo/xlibs/jwxini.cpp
+++ b/engines/director/lingo/xlibs/jwxini.cpp
@@ -1,0 +1,142 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*************************************
+ *
+ * USED IN:
+ * Gahan Wilson's Ultimate Haunted House
+ *
+ *************************************/
+
+/*
+ * +Access INI Files (c) JourneyWare Media 1994
+ * -- Access INI files
+ * X      mDispose                                                  --Dispose of the XObject
+ * ISSIS  mGetPrivateProfileInt, App, Key, Def, File                --GetPrivateProfileInt
+ * SSSSIS mGetPrivateProfileString, App, Key, Default, Size, File   --GetPrivateProfileString
+ * ISSI   mGetProfileInt, App, Key, Default                         --GetProfileInt
+ * SSSSI  mGetProfileString, App, Key, Def, Size                    --GetProfileString
+ * S      mName                                                     --Return XObject name
+ * I      mNew                                                      --Create a new instance
+ * ISSSS  mWritePrivateProfileString, App, Key, String, File        --WritePrivateProfileString
+ * ISSS   mWriteProfileString, App, Key, String                     --WriteProfileString
+ */
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/xlibs/jwxini.h"
+
+
+namespace Director {
+
+const char *JourneyWareXINIXObj::xlibName = "INI";
+const char *JourneyWareXINIXObj::fileNames[] = {
+   "JWXINI",
+   nullptr
+};
+
+static MethodProto xlibMethods[] = {
+    { "new",						JourneyWareXINIXObj::m_new,							0,	0,	400 },	// D4
+    { "GetPrivateProfileInt",		JourneyWareXINIXObj::m_GetPrivateProfileInt,		4,	4,	400 },	// D4
+    { "GetPrivateProfileString", 	JourneyWareXINIXObj::m_GetPrivateProfileString,		5,	5,	400 },	// D4
+    { "GetProfileInt",				JourneyWareXINIXObj::m_GetProfileInt,				3,	3,	400 },	// D4
+	{ "GetProfileString", 			JourneyWareXINIXObj::m_GetProfileString,			4,	4,	400 },	// D4
+	{ "WritePrivateProfileString", 	JourneyWareXINIXObj::m_WritePrivateProfileString,	4,	4,	400 },	// D4
+	{ "WriteProfileString", 		JourneyWareXINIXObj::m_WriteProfileString,			3,	3,	400 },	// D4
+    { nullptr, nullptr, 0, 0, 0 }
+};
+
+void JourneyWareXINIXObj::open(int type) {
+   if (type == kXObj) {
+	   JourneyWareXINIXObject::initMethods(xlibMethods);
+	   JourneyWareXINIXObject *xobj = new JourneyWareXINIXObject(kXObj);
+	   g_lingo->_globalvars[xlibName] = xobj;
+   }
+}
+
+void JourneyWareXINIXObj::close(int type) {
+   if (type == kXObj) {
+	   JourneyWareXINIXObject::cleanupMethods();
+	   g_lingo->_globalvars[xlibName] = Datum();
+   }
+}
+
+
+JourneyWareXINIXObject::JourneyWareXINIXObject(ObjectType ObjectType) :Object<JourneyWareXINIXObject>("JourneyWareXINIXObj") {
+   _objType = ObjectType;
+}
+
+void JourneyWareXINIXObj::m_new(int nargs) {
+   g_lingo->printSTUBWithArglist("JWXIni::new", nargs);
+   g_lingo->push(g_lingo->_currentMe);
+}
+
+void JourneyWareXINIXObj::m_GetPrivateProfileInt(int nargs) {
+	g_lingo->printSTUBWithArglist("JWXIni::GetPrivateProfileInt", nargs);
+	/*auto file= */g_lingo->pop().asString();
+	auto defaultValue = g_lingo->pop().asInt();
+	/*auto key = */g_lingo->pop().asString();
+	/*auto application = */g_lingo->pop().asString();
+	g_lingo->push(Datum(defaultValue)); // TODO: We only return the default for now
+}
+
+void JourneyWareXINIXObj::m_GetPrivateProfileString(int nargs) {
+	g_lingo->printSTUBWithArglist("JWXIni::GetPrivateProfileString", nargs);
+	/*auto file = */g_lingo->pop().asString();
+	/*auto size = */g_lingo->pop().asInt();
+	auto defaultValue = g_lingo->pop().asString();
+	/*auto key = */g_lingo->pop().asString();
+	/*auto application = */g_lingo->pop().asString();
+	g_lingo->push(Datum(defaultValue)); // TODO: We only return the default for now
+}
+
+void JourneyWareXINIXObj::m_GetProfileInt(int nargs) {
+	g_lingo->printSTUBWithArglist("JWXIni::GetProfileInt", nargs);
+	auto defaultValue = g_lingo->pop().asInt();
+	/*auto key = */g_lingo->pop().asString();
+	/*auto application = */g_lingo->pop().asString();
+	g_lingo->push(Datum(defaultValue)); // TODO: We only return the default for now
+}
+
+void JourneyWareXINIXObj::m_GetProfileString(int nargs) {
+	g_lingo->printSTUBWithArglist("JWXIni::GetProfileString", nargs);
+	/*auto size = */g_lingo->pop().asInt();
+	auto defaultValue = g_lingo->pop().asString();
+	/*auto key = */g_lingo->pop().asString();
+	/*auto application = */g_lingo->pop().asString();
+	g_lingo->push(Datum(defaultValue)); // TODO: We only return the default for now
+}
+
+void JourneyWareXINIXObj::m_WritePrivateProfileString(int nargs) {
+	g_lingo->printSTUBWithArglist("JWXIni::WritePrivateProfileString", nargs);
+	g_lingo->dropStack(nargs);
+	g_lingo->push(Datum(0)); // TODO
+}
+
+void JourneyWareXINIXObj::m_WriteProfileString(int nargs) {
+	g_lingo->printSTUBWithArglist("JWXIni::WriteProfileString", nargs);
+	g_lingo->dropStack(nargs);
+	g_lingo->push(Datum(0)); // TODO
+}
+
+
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/jwxini.h
+++ b/engines/director/lingo/xlibs/jwxini.h
@@ -1,0 +1,55 @@
+/* ScummVM - Graphic Adventure Engine
+*
+* ScummVM is the legal property of its developers, whose names
+* are too numerous to list here. Please refer to the COPYRIGHT
+* file distributed with this source distribution.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+
+#ifndef DIRECTOR_LINGO_XLIBS_JWXINI_H
+#define DIRECTOR_LINGO_XLIBS_JWXINI_H
+
+namespace Director {
+
+class JourneyWareXINIXObject : public Object<JourneyWareXINIXObject> {
+public:
+	JourneyWareXINIXObject(ObjectType objType);
+};
+
+namespace JourneyWareXINIXObj {
+
+extern const char *xlibName;
+extern const char *fileNames[];
+
+void open(int type);
+void close(int type);
+
+void m_new(int nargs);
+void m_clear(int nargs);
+
+void m_GetPrivateProfileInt(int nargs);
+void m_GetPrivateProfileString(int nargs);
+void m_GetProfileInt(int nargs);
+void m_GetProfileString(int nargs);
+void m_WritePrivateProfileString(int nargs);
+void m_WriteProfileString(int nargs);
+
+} // End of namespace JourneyWareXINIXObj
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/lingo/xlibs/movutils.cpp
+++ b/engines/director/lingo/xlibs/movutils.cpp
@@ -1,0 +1,137 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*************************************
+ *
+ * USED IN:
+ * Gahan Wilson's Ultimate Haunted House
+ *
+ *************************************/
+
+/*
+ * -- MovieUtilities External Factory, v. 1.0.7  by David Jackson Shields
+ * MovUtils
+ * I      mNew                  --Create new XObject instance
+ * X      mDispose              --Dispose of XObject instance
+ * S      mName                 --Return the XObject name (MovUtils)
+ * SS     mGetVolName           --Return name of disk drive (volume) from path
+ * S      mGetSystemPath        --Return system directory path as a string
+ * S      mGetWindowsPath       --Return Windows directory path as a string
+ * IS     mSetDefaultPath       --Set current drive:irectory path
+ * SS     mGetChildWindowNames  --Return string of all Child window names,
+ * --                                     given a Parent window name
+ * IS     mGetNamedWindowHdl    --Return the ID handle to the named window
+ * --                                     (needed for MCI commands)
+ * XSLLII mDrawLine             --Draw line in the named window from point A
+ * --                                     to point B, at specified pen width and color
+ * ISLI   mDrawOval             --Draw filled oval (ellipse) in the named window,
+ * --                                     the bounds RECT, using specified fill color
+ * ISLI   mDrawRect             --Draw filled RECT in the named window, within the bounds
+ * --                                     RECT, using specified fill color
+ * ISLII  mDrawRoundRect        --Draw filled rounded RECT in the named window, within bounds
+ * --                                     RECT, with specified curvature and fill color
+ * ISLI   mDrawPoly             --Draw filled polygon in named window from a linear
+ * --                                     list of coordinates, using specified fill color
+ * ISLIII mDrawPie              --Draw filled arc in named window, within bounds RECT, from
+ * --                                     start angle to arc angle, using specified fill color
+ * I      mPrintLandscape       --Print the Stage in Landscape orientation using dithered grays
+ * SS     mNoPunct              --Remove all punctuation chars from text
+ * SS     mToUpperCase          --Convert text to all upperCase chars
+ * SS     mToLowerCase          --Convert text to all lowerCase chars
+ * SS     mTrimWhiteChars       --Remove leading and trailing 'white space' chars from text
+ * SS     mDollarFormat         --Convert number string to US currency format
+ * ISI    mGetWordStart         --Find number of chars to start of specified word
+ * ISI    mGetWordEnd           --Find number of chars to end   of specified word
+ * ISI    mGetLineStart         --Find number of chars to start of specified line
+ * ISI    mGetLineEnd           --Find number of chars to end   of specified line
+ * IS     mIsAlphaNum           --Return Boolean whether char is alphaNumeric
+ * IS     mIsAlpha              --Return Boolean whether char is alphabetic
+ * IS     mIsUpper              --Return Boolean whether char is upperCase alphabetic
+ * IS     mIsLower              --Return Boolean whether char is lowerCase alphabetic
+ * IS     mIsDigit              --Return Boolean whether char is a decimal digit
+ * IS     mIsPunctuation        --Return Boolean whether char is punctuation
+ * IS     mIsWhiteSpace         --Return Boolean whether char is a 'white space' char
+ * IS     mIsPrintable          --Return Boolean whether char is printable
+ * IS     mIsGraphic            --Return Boolean whether char is graphic
+ * IS     mIsControl            --Return Boolean whether char is a control char
+ * IS     mIsHex                --Return Boolean whether char is a hexadecimal digit
+ * III    mBitSet               --Set   specified bit within a long integer
+ * III    mBitTest              --Test  specified bit within a long integer
+ * III    mBitClear             --Clear specified bit within a long integer
+ * II     mBitShiftL            --Shift specified bit left  within a long integer
+ * II     mBitShiftR            --Shift specified bit right within a long integer
+ * III    mBitAnd               --Perform logical AND operation of two long integers
+ * III    mBitOr                --Perform logical OR  operation of two long integers
+ * III    mBitXOr               --Perform logical XOR operation of two long integers
+ * II     mBitNot               --Perform logical NOT operation on a long integer
+ * IS     mBitStringToNumber    --Translate string of '1's and '0's to a long integer
+ * PL     mStageToCast          --Returns a picture handle to the image in the Rect on Stage
+ * ISL    mStageToDIB           --Save, to a named bitmap file, the image in the Rect on Stage
+ * ISL    mStageToPICT          --Save, to a Mac PICT file, the image in the Rect on Stage
+ * SS     mCRtoCRLF             --Add a LineFeed to each Return char within Macintosh text
+ * SS     mCRLFtoCR             --Remove LineFeed from each end of line within Windows text
+ * III    mGetMessage           --Get mouse/key messages from the application message queue
+ */
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/xlibs/movutils.h"
+
+
+namespace Director {
+
+const char *MovUtilsXObj::xlibName = "movutils";
+const char *MovUtilsXObj::fileNames[] = {
+	"MOVUTILS",
+	nullptr
+};
+
+static MethodProto xlibMethods[] = {
+	{ "new",   MovUtilsXObj::m_new,					0,	0,	400 },	// D4
+	{ nullptr, nullptr, 0, 0, 0 }
+};
+
+void MovUtilsXObj::open(int type) {
+	if (type == kXObj) {
+		MovieUtilsXObject::initMethods(xlibMethods);
+		MovieUtilsXObject *xobj = new MovieUtilsXObject(kXObj);
+		g_lingo->_globalvars[xlibName] = xobj;
+	}
+}
+
+void MovUtilsXObj::close(int type) {
+	if (type == kXObj) {
+		MovieUtilsXObject::cleanupMethods();
+		g_lingo->_globalvars[xlibName] = Datum();
+	}
+}
+
+MovieUtilsXObject::MovieUtilsXObject(ObjectType ObjectType) :Object<MovieUtilsXObject>("MovUtilsXObj") {
+	_objType = ObjectType;
+}
+
+void MovUtilsXObj::m_new(int nargs) {
+	g_lingo->printSTUBWithArglist("MovUtilsXObj::new", nargs);
+	g_lingo->push(g_lingo->_currentMe);
+}
+
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/movutils.h
+++ b/engines/director/lingo/xlibs/movutils.h
@@ -1,0 +1,48 @@
+/* ScummVM - Graphic Adventure Engine
+*
+* ScummVM is the legal property of its developers, whose names
+* are too numerous to list here. Please refer to the COPYRIGHT
+* file distributed with this source distribution.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+ */
+
+
+#ifndef DIRECTOR_LINGO_XLIBS_MOVUTILS_H
+#define DIRECTOR_LINGO_XLIBS_MOVUTILS_H
+
+namespace Director {
+
+class MovieUtilsXObject : public Object<MovieUtilsXObject> {
+public:
+	MovieUtilsXObject(ObjectType objType);
+};
+
+namespace MovUtilsXObj {
+
+extern const char *xlibName;
+extern const char *fileNames[];
+
+void open(int type);
+void close(int type);
+
+void m_new(int nargs);
+void m_clear(int nargs);
+
+} // End of namespace MovUtilsXObj
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -39,6 +39,7 @@ MODULE_OBJS = \
 	lingo/lingo-preprocessor.o \
 	lingo/lingo-the.o \
 	lingo/lingo-utils.o \
+	lingo/xlibs/aiff.o \
 	lingo/xlibs/cdromxobj.o \
 	lingo/xlibs/fileio.o \
 	lingo/xlibs/flushxobj.o \

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -43,6 +43,7 @@ MODULE_OBJS = \
 	lingo/xlibs/fileio.o \
 	lingo/xlibs/flushxobj.o \
 	lingo/xlibs/fplayxobj.o \
+	lingo/xlibs/gpid.o \
 	lingo/xlibs/labeldrvxobj.o \
 	lingo/xlibs/jwxini.o \
 	lingo/xlibs/memoryxobj.o \

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -45,6 +45,7 @@ MODULE_OBJS = \
 	lingo/xlibs/fplayxobj.o \
 	lingo/xlibs/gpid.o \
 	lingo/xlibs/labeldrvxobj.o \
+	lingo/xlibs/movutils.o \
 	lingo/xlibs/jwxini.o \
 	lingo/xlibs/memoryxobj.o \
 	lingo/xlibs/movemousexobj.o \

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -44,6 +44,7 @@ MODULE_OBJS = \
 	lingo/xlibs/flushxobj.o \
 	lingo/xlibs/fplayxobj.o \
 	lingo/xlibs/labeldrvxobj.o \
+	lingo/xlibs/jwxini.o \
 	lingo/xlibs/memoryxobj.o \
 	lingo/xlibs/movemousexobj.o \
 	lingo/xlibs/orthoplayxobj.o \


### PR DESCRIPTION
This adds a minimal implementation of the various XObjects used in Gahan Wilson's Haunted House, of note is that this does some modifications to the common aiff-decoder to be able to implement the "Duration" query in the aiff-xobject.

The XObjects stubbed/implemented are:
* GPID - Product Identification Number
* JourneyWareXINI - Windows Registry queries
* MovUtils - MovieUtilities
* AIFF - Mainly support for querying the duration of AIFF-files.

This does make the intro to Gahan Wilson work a bit better, but sadly the game still doesn't progress beyond the Foyer yet.

Comments are very welcome.