### PR TITLE
RISCOS: Implement plugin provider

### DIFF
--- a/backends/module.mk
+++ b/backends/module.mk
@@ -275,7 +275,12 @@ MODULE_OBJS += \
 	events/riscossdl/riscossdl-events.o \
 	fs/riscos/riscos-fs.o \
 	fs/riscos/riscos-fs-factory.o \
+	plugins/riscos/riscos-provider.o
+ifndef SDL_BACKEND
+# This is needed for null backend but already included in SDL backend
+MODULE_OBJS += \
 	platform/sdl/riscos/riscos-utils.o
+endif
 endif
 
 ifdef PLAYSTATION3

--- a/backends/plugins/elf/arm-loader.cpp
+++ b/backends/plugins/elf/arm-loader.cpp
@@ -75,6 +75,10 @@ bool ARMDLObject::relocate(Elf32_Off offset, Elf32_Word size, byte *relSegment) 
 			}
 			break;
 
+		case R_ARM_PC24:
+//			debug(8, "elfloader: R_ARM_PC24: PC-relative jump, ld takes care of necessary relocation work for us.");
+			break;
+
 		case R_ARM_THM_CALL:
 //			debug(8, "elfloader: R_ARM_THM_CALL: PC-relative jump, ld takes care of necessary relocation work for us.");
 			break;

--- a/backends/plugins/elf/elf32.h
+++ b/backends/plugins/elf/elf32.h
@@ -227,6 +227,7 @@ typedef struct {
 
 // ARM relocation types
 #define R_ARM_NONE			0
+#define R_ARM_PC24			1
 #define R_ARM_ABS32			2
 #define R_ARM_THM_CALL		10
 #define R_ARM_CALL			28

--- a/backends/plugins/elf/plugin.syms
+++ b/backends/plugins/elf/plugin.syms
@@ -7,3 +7,4 @@ ___plugin_ctors
 ___plugin_ctors_end
 ___plugin_dtors
 ___plugin_dtors_end
+__dso_handle

--- a/backends/plugins/riscos/plugin.cpp
+++ b/backends/plugins/riscos/plugin.cpp
@@ -1,0 +1,54 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/scummsys.h"
+
+#ifdef USE_ELF_LOADER
+
+/**
+ * These functions are a hack to workaround a GCC limitation
+ * At every function entry, GCC adds a check on the stack size
+ * If the stack is too small, the functions _rt_stkovf_split_small or _rt_stkovf_split_big are called
+ * This call is done using a PC relative 24 bits address but we want to link back to main executable functions
+ * and this is not possible using this relocation type.
+ * So we create wrapper functions which will just jump to the main function using a 32 bits relocation.
+ * The wrapping is done by ld thanks to its --wrap argument
+ */
+
+__asm__ (
+	".global __wrap___rt_stkovf_split_small\n"
+	".type __wrap___rt_stkovf_split_small, %function\n"
+	"__wrap___rt_stkovf_split_small:\n"
+	"LDR	pc, .Lsmall\n"
+	".Lsmall:\n"
+	".word	__real___rt_stkovf_split_small\n"
+);
+
+__asm__ (
+	".global __wrap___rt_stkovf_split_big\n"
+	".type __wrap___rt_stkovf_split_big, %function\n"
+	"__wrap___rt_stkovf_split_big:\n"
+	"LDR	pc, .Lbig\n"
+	".Lbig:\n"
+	".word	__real___rt_stkovf_split_big\n"
+);
+
+#endif

--- a/backends/plugins/riscos/plugin.ld
+++ b/backends/plugins/riscos/plugin.ld
@@ -1,0 +1,221 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+OUTPUT_FORMAT("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+ENTRY(_start)
+
+PHDRS
+{
+	/* ScummVM's elf loader only allows a single segment, at the moment. */
+	plugin PT_LOAD FLAGS(7) /* Read | Write | Execute */;
+}
+
+SECTIONS
+{
+	/* =========== CODE section =========== */
+
+	/* Start the output high in memory so PC-relative jumps from the plugin
+	    to the main binary cannot reach, to force the linker to generate
+	    veneers converting the relative jumps to absolute jumps */
+	. = 0x8000000;
+
+	.text ALIGN(0x1000) :
+	{
+		/* .text */
+		*(.text.unlikely .text.*_unlikely .text.unlikely.*)
+		*(.text.exit .text.exit.*)
+		*(.text.startup .text.startup.*)
+		*(.text.hot .text.hot.*)
+		*(.text .stub .text.* .gnu.linkonce.t.*)
+		/* .gnu.warning sections are handled specially by elf32.em.  */
+		*(.gnu.warning)
+		*(.glue_7t) *(.glue_7) *(.riscos.libscl.chunkstub.start) *(SORT(.riscos.libscl.chunkstub.id*)) *(.riscos.libscl.chunkstub.end)
+	} : plugin
+
+	/* =========== RODATA section =========== */
+
+	. = ALIGN(0x1000);
+
+	.rodata :
+	{
+		*(.rodata)
+		*(.rodata.*)
+		*(.gnu.linkonce.r*)
+		*(.rodata1)
+		. = ALIGN(4);
+	} : plugin
+	.rodata1 :
+	{
+		*(.rodata1)
+		. = ALIGN(4);
+	} : plugin
+
+	.ARM.extab : { *(.ARM.extab* .gnu.linkonce.armextab.*) } : plugin
+	__exidx_start = .;
+	ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) } : plugin
+	__exidx_end = .;
+
+	/* =========== DATA section =========== */
+
+	. = ALIGN(0x1000);
+
+	.tdata ALIGN(4) :
+	{
+		*(.tdata)
+		*(.tdata.*)
+		*(.gnu.linkonce.td.*)
+		. = ALIGN(4);
+	} : plugin
+
+	.tbss ALIGN(4) :
+	{
+		*(.tbss)
+		*(.tbss.*)
+		*(.gnu.linkonce.tb.*)
+		*(.tcommon)
+		. = ALIGN(4);
+	} : plugin
+
+	.preinit_array ALIGN(4) :
+	{
+		PROVIDE (__preinit_array_start = .);
+		KEEP (*(.preinit_array))
+		PROVIDE (__preinit_array_end = .);
+	} : plugin
+
+	.init_array ALIGN(4) :
+	{
+		PROVIDE (__init_array_start = .);
+		KEEP (*(SORT(.init_array.*)))
+		KEEP (*(.init_array))
+		PROVIDE (__init_array_end = .);
+	} : plugin
+
+	.fini_array ALIGN(4) :
+	{
+		PROVIDE (__fini_array_start = .);
+		KEEP (*(.fini_array))
+		KEEP (*(SORT(.fini_array.*)))
+		PROVIDE (__fini_array_end = .);
+	} : plugin
+
+	.ctors ALIGN(4) :
+	{
+		___plugin_ctors = .;
+		KEEP (*(SORT(.ctors.*)))
+		KEEP (*(.ctors))
+		___plugin_ctors_end = .;
+	} : plugin
+
+	.dtors ALIGN(4) :
+	{
+		___plugin_dtors = .;
+		KEEP (*(SORT(.dtors.*)))
+		KEEP (*(.dtors))
+		___plugin_dtors_end = .;
+	} : plugin
+
+	.data :
+	{
+		*(.data)
+		*(.data.*)
+		*(.gnu.linkonce.d*)
+		CONSTRUCTORS
+		. = ALIGN(4);
+	} : plugin
+	.data1 :
+	{
+		*(.data1)
+		. = ALIGN(4);
+	} : plugin
+
+	__bss_start__ = .;
+	.bss ALIGN(4) :
+	{
+		*(.dynbss)
+		*(.bss)
+		*(SORT(.bss.*))
+		*(.gnu.linkonce.b*)
+		*(COMMON)
+		. = ALIGN(4);
+	} : plugin
+	__bss_end__ = .;
+
+	__end__ = ABSOLUTE(.) ;
+
+	/* ==================
+	   ==== Metadata ====
+	   ================== */
+
+	/* Discard sections that difficult post-processing */
+	/DISCARD/ : { *(.group .comment .note) }
+
+	/* Stabs debugging sections. */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0. */
+
+	/* DWARF 1 */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+
+	/* GNU DWARF 1 extensions */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+
+	/* DWARF 1.1 and DWARF 2 */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+
+	/* DWARF 2 */
+	.debug_info     0 : { *(.debug_info) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+
+	/* SGI/MIPS DWARF 2 extensions */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+
+	/* DWARF 3 */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+
+	/* DWARF Extension.  */
+	.debug_macro    0 : { *(.debug_macro) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+	.note.gnu.arm.ident 0 : { KEEP (*(.note.gnu.arm.ident)) }
+
+	/DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) }
+}

--- a/backends/plugins/riscos/riscos-provider.cpp
+++ b/backends/plugins/riscos/riscos-provider.cpp
@@ -32,6 +32,30 @@
 #include <kernel.h>
 #include <swis.h>
 
+// HACK: This is needed so that standard library functions that are only
+// used in plugins can be found in the main executable.
+void pluginHack() {
+	volatile float f = 0.0f;
+	volatile double d = 0.0;
+
+	byte *b = new (std::nothrow) byte[100];
+
+	f = tanhf(f);
+	f = logf(f);
+	f = lroundf(f);
+	f = frexpf(f, NULL);
+	f = ldexpf(f, 1);
+	f = fmaxf(f, f);
+	f = fminf(f, f);
+	f = truncf(f);
+
+	d = nearbyint(d);
+
+	rename("dummyA", "dummyB");
+
+	delete[] b;
+}
+
 class RiscOSDLObject : public ARMDLObject {
 protected:
 	void flushDataCache(void *ptr, uint32 len) const override {

--- a/backends/plugins/riscos/riscos-provider.cpp
+++ b/backends/plugins/riscos/riscos-provider.cpp
@@ -1,0 +1,71 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define FORBIDDEN_SYMBOL_ALLOW_ALL
+#include "common/scummsys.h"
+
+#if defined(DYNAMIC_MODULES) && defined(RISCOS)
+
+#include "backends/plugins/riscos/riscos-provider.h"
+#include "backends/plugins/elf/arm-loader.h"
+
+#include "common/debug.h"
+
+#include <kernel.h>
+#include <swis.h>
+
+typedef void (*Cache_CleanInvalidateRangePtr)(void *start, void *end);
+
+// This function enters in supervisor mode, call the ARMop and leaves the supervisor mode
+static void call_Cache_CleanInvalidateRange(void *start, void *end, Cache_CleanInvalidateRangePtr f) __asm__(".call_Cache_CleanInvalidateRange");
+__asm__(
+	".call_Cache_CleanInvalidateRange:\n"
+	"PUSH	{r4, lr}\n" // Backup r4 and lr
+	"MRS	r4, cpsr\n" // Backup CPSR in R4
+	"SWI    0x16\n" // OS_EnterOS
+	"MOV	lr, pc\n" //
+	"MOV	pc, r2\n" // Call 3rd argument (function pointer)
+	"MSR	cpsr_c, r4\n" // Restore CPSR (leave SVC mode)
+	"POP	{r4, pc}\n" // Restore R4 and return
+);
+
+
+class RiscOSDLObject : public ARMDLObject {
+protected:
+	void flushDataCache(void *ptr, uint32 len) const override {
+		Cache_CleanInvalidateRangePtr Cache_CleanInvalidateRange;
+
+		if (!_swix(OS_MMUControl, _IN(0)|_OUT(0), 2 | 21 << 8, &Cache_CleanInvalidateRange)) {
+			call_Cache_CleanInvalidateRange(ptr, (char *)ptr + len, Cache_CleanInvalidateRange);
+			return;
+		}
+
+		// OS_MMUControl 2 or Cache_CleanInvalidateRange are not supported: fallback to old inefficient OS_MMUControl 1
+		_swix(OS_MMUControl, _IN(0), 1 | 1 << 28 | 1 << 30 | 1 << 31);
+	}
+
+};
+
+Plugin *RiscOSPluginProvider::createPlugin(const Common::FSNode &node) const {
+	return new TemplatedELFPlugin<RiscOSDLObject>(node.getPath());
+}
+
+#endif // defined(DYNAMIC_MODULES) && defined(RISCOS)

--- a/backends/plugins/riscos/riscos-provider.h
+++ b/backends/plugins/riscos/riscos-provider.h
@@ -19,34 +19,18 @@
  *
  */
 
-#include "common/scummsys.h"
+#if defined(DYNAMIC_MODULES) && defined(RISCOS)
 
-#if defined(RISCOS)
+#ifndef BACKENDS_PLUGINS_RISCOS_PROVIDER_H
+#define BACKENDS_PLUGINS_RISCOS_PROVIDER_H
 
-#include "backends/platform/sdl/riscos/riscos.h"
-#include "backends/plugins/riscos/riscos-provider.h"
-#include "base/main.h"
+#include "backends/plugins/elf/elf-provider.h"
 
-int main(int argc, char *argv[]) {
+class RiscOSPluginProvider : public ELFPluginProvider {
+public:
+	Plugin *createPlugin(const Common::FSNode &node) const;
+};
 
-	// Create our OSystem instance
-	g_system = new OSystem_RISCOS();
-	assert(g_system);
+#endif // BACKENDS_PLUGINS_RISCOS_PROVIDER_H
 
-	// Pre initialize the backend
-	g_system->init();
-
-#ifdef DYNAMIC_MODULES
-	PluginManager::instance().addPluginProvider(new RiscOSPluginProvider());
-#endif
-
-	// Invoke the actual ScummVM main entry point
-	int res = scummvm_main(argc, argv);
-
-	// Free OSystem
-	g_system->destroy();
-
-	return res;
-}
-
-#endif
+#endif // defined(DYNAMIC_MODULES) && defined(RISCOS)

--- a/configure
+++ b/configure
@@ -5996,7 +5996,7 @@ case $_host_os in
 		;;
 esac
 
-case $_backend in
+case $_host in
 	3ds)
 		append_var DEFINES "-DPLUGIN_DIRECTORY=\\\"$datadir/plugins\\\""
 		;;

--- a/configure
+++ b/configure
@@ -4268,7 +4268,7 @@ if test "$_elf_loader" = yes; then
 	_plugin_suffix=".plg"
 	_mak_plugins='
 PLUGIN_EXTRA_DEPS	= $(EXECUTABLE)
-PLUGIN_LDFLAGS		= -nostartfiles backends/plugins/elf/version.o -Wl,-q,--just-symbols,$(EXECUTABLE),--retain-symbols-file,$(srcdir)/backends/plugins/elf/plugin.syms
+PLUGIN_LDFLAGS		= -nostartfiles backends/plugins/elf/version.o -Wl,-q,--retain-symbols-file,$(srcdir)/backends/plugins/elf/plugin.syms -Xlinker --just-symbols -Xlinker $(EXECUTABLE)
 PRE_OBJS_FLAGS		:= -Wl,--whole-archive
 POST_OBJS_FLAGS		:= -Wl,--no-whole-archive
 '"$_mak_plugins"

--- a/configure
+++ b/configure
@@ -4250,6 +4250,16 @@ LDFLAGS				+= -Wl,-T$(srcdir)/backends/plugins/psp/main_prog.ld  -Wl,-zmax-page-
 PLUGIN_LDFLAGS		+= -Wl,-T$(srcdir)/backends/plugins/psp/plugin.ld -Wl,-zmax-page-size=128 -lstdc++
 '
 		;;
+	riscos)
+		_elf_loader=yes
+		append_var DEFINES "-DELF_LOADER_CXA_ATEXIT"
+		append_var CXXFLAGS "-fuse-cxa-atexit"
+		append_var DEFINES "-DUNCACHED_PLUGINS"
+_mak_plugins='
+PLUGIN_EXTRA_DEPS	+= backends/plugins/riscos/plugin.o
+PLUGIN_LDFLAGS		+= -static -Wl,-T$(srcdir)/backends/plugins/riscos/plugin.ld backends/plugins/riscos/plugin.o -Wl,--wrap=__rt_stkovf_split_small -Wl,--wrap=__rt_stkovf_split_big
+'
+		;;
 	*)
 		_dynamic_modules=no
 		_mak_plugins=
@@ -6011,6 +6021,9 @@ case $_host in
 		# without a scummvm sub directory.
 		append_var DEFINES "-DPLUGIN_DIRECTORY=\\\"$libdir\\\""
 		;;
+	arm-*riscos)
+		append_var DEFINES "-DPLUGIN_DIRECTORY=\\\"\${datarootdir}/plugins\\\""
+		;;
 	*)
 		append_var DEFINES "-DPLUGIN_DIRECTORY=\\\"$libdir/scummvm\\\""
 		;;
@@ -6245,7 +6258,13 @@ case $_host_os in
 		fi
 		append_var CXXFLAGS "-ffunction-sections"
 		append_var CXXFLAGS "-fdata-sections"
-		append_var LDFLAGS "-Wl,--gc-sections"
+		if test "$_dynamic_modules" = no ; then
+			append_var LDFLAGS "-Wl,--gc-sections"
+		else
+			# toolchain asks for gc-sections
+			append_var LDFLAGS "-Wl,--no-gc-sections"
+			append_var CXXFLAGS "-mlong-calls"
+		fi
 		;;
 	n64)
 		# Move some libs down here, otherwise some symbols requires by libvorbis aren't found


### PR DESCRIPTION
This PR adds the ability for RiscOS to use plugin-based split builds.
This will let us overcome the size limitations we hit on the buildbot and provide a unique distribution with all engines bundled.

Some small changes are needed on the configure script to allow for RiscOS specifics: comma in file name and plugins directory different from other SDL ports.