### PR TITLE
DIRECTOR: LINGO: Implement clearGlobals Lingo command

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1655,9 +1655,7 @@ void LB::b_alert(int nargs) {
 }
 
 void LB::b_clearGlobals(int nargs) {
-	g_lingo->printSTUBWithArglist("b_clearGlobals", nargs);
-
-	g_lingo->dropStack(nargs);
+	g_lingo->_globalvars.clear();
 }
 
 void LB::b_cursor(int nargs) {


### PR DESCRIPTION
This change implements the stubbed function `LB::b_clearGlobals()`. Functionality is implemented as described in the Lingo Dictionary for D4 and has been tested using the `clearGlobals` workshop movie. Behaviour in ScummVM matches movie's behaviour in BasiliskII