### PR TITLE
DIRECTOR: LINGO: Replace printSTUBWithArglist with macro printWithArglist

### DIFF
--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -422,7 +422,7 @@ void LC::cb_localcall() {
 	if ((nargs.type == ARGC) || (nargs.type == ARGCNORET)) {
 		Common::String name = g_lingo->_currentScriptContext->_functionNames[functionId];
 		if (debugChannelSet(3, kDebugLingoExec))
-			g_lingo->printSTUBWithArglist(name.c_str(), nargs.u.i, "localcall:");
+			printWithArgList(name.c_str(), nargs.u.i, "localcall:");
 
 		LC::call(name, nargs.u.i, nargs.type == ARGC);
 

--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -1468,7 +1468,7 @@ void LC::c_callfunc() {
 
 void LC::call(const Common::String &name, int nargs, bool allowRetVal) {
 	if (debugChannelSet(3, kDebugLingoExec))
-		g_lingo->printSTUBWithArglist(name.c_str(), nargs, "call:");
+		printWithArgList(name.c_str(), nargs, "call:");
 
 	Symbol funcSym;
 

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -56,6 +56,7 @@ class LingoCompiler;
 typedef void (*inst)(void);
 #define	STOP (inst)0
 #define ENTITY_INDEX(t,id) ((t) * 100000 + (id))
+#define printWithArgList g_lingo->printSTUBWithArglist
 
 int calcStringAlignment(const char *s);
 int calcCodeAlignment(int l);


### PR DESCRIPTION
Instead of using the STUB keyword to log `LC::cb_localcall` and `LC::call`, this change moves it to a macro and uses the macro for this purpose. This won't confuse these functions as "STUBbed" or missing something