### PR TITLE
DIRECTOR: LINGO: Implement b_showGlobals builtin command

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1682,7 +1682,16 @@ void LB::b_put(int nargs) {
 }
 
 void LB::b_showGlobals(int nargs) {
-	warning("STUB: b_showGlobals");
+	b_version(0);
+	Datum ver = g_lingo->pop();
+	Common::String global_out = "-- Global Variables --\nversion = ";
+	global_out += ver.asString() + "\n";
+	if (g_lingo->_globalvars.size()) {
+		for (auto it = g_lingo->_globalvars.begin(); it != g_lingo->_globalvars.end(); it++) {
+			global_out += it->_key + " = " + it->_value.asString() + "\n";
+		}
+	}
+	g_debugger->debugPrintf("%s", global_out.c_str());
 }
 
 void LB::b_showLocals(int nargs) {


### PR DESCRIPTION
This change implements the showGlobals command, which outputs the globals and their values in stdout. This can be used in the lingo debugging mode `lingo on`. Changes tested using the showGlobals workshop movie. It deviates in 2 ways:
* The version also shows the patch of Director in ScummVM but not in BasiliskII
* A SerialPort XObject is also in the output in ScummVM but not in BasiliskII

According to the Lingo Dictionary for D4, open XObjects should also be shown by the showGlobals command. I am not quite sure why SerialPort doesn't show up in BasiliskII