### PR TITLE
DIRECTOR: LINGO: Implement showLocals lingo command

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1686,7 +1686,13 @@ void LB::b_showGlobals(int nargs) {
 }
 
 void LB::b_showLocals(int nargs) {
-	warning("STUB: b_showLocals");
+	Common::String local_out = "-- Local Variables --\n";
+	if (g_lingo->_localvars) {
+		for (auto it = g_lingo->_localvars->begin(); it != g_lingo->_localvars->end(); it++) {
+			local_out += it->_key + " = " + it->_value.asString() + "\n";
+		}
+	}
+	g_debugger->debugPrintf("%s", local_out.c_str());
 }
 
 ///////////////////


### PR DESCRIPTION
This change implements the `showLocals` lingo command and removes the STUB from lingo-builtins.cpp. The changes have been tested using `showLocals` workshop movie, and the behaviour in ScummVM is identical to behaviour of the said movie in BasiliskII. This command would output the localVars to the stdout and can be used in the debugging mode with `lingo on`