### PR TITLE
SCI: (SCI1+) - improve channel sound flag handling

### DIFF
--- a/engines/sci/sound/music.h
+++ b/engines/sci/sound/music.h
@@ -280,6 +280,10 @@ protected:
 	ChannelRemapping *determineChannelMap();
 	void resetDeviceChannel(int devChannel, bool mainThread);
 
+public:
+	// The parsers need to know this for the dontMap channels...
+	bool isDeviceChannelMapped(int devChannel) const;
+
 private:
 	MusicList _playList;
 	bool _soundOn;


### PR DESCRIPTION
This is a followup to
https://github.com/scummvm/scummvm/pull/3934

It cleans up some things I noticed when I implemented the mute flag handling. In particular, it properly implements handling of flag 1 and removes the hack  that always set flag 2 on channel 9. I haven't encountered any actual bugs that would be noticeable (apparently, the hack works), so there is no hurry to merge this.

The only game where I actually encountered flag 1 usage is KQ5 (both floppy and CD).