### PR TITLE
DIRECTOR: LINGO: Implement Number of Castmembers STUB in Lingo::getTheEntity()

### DIFF
--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -387,7 +387,11 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 		d = getTheCast(id, field);
 		break;
 	case kTheCastMembers:
-		warning("STUB: Lingo::getTheEntity(): Unprocessed getting field %s of entity %s", field2str(field), entity2str(entity));
+		{
+			d.type = INT;
+			Movie *movie = g_director->getCurrentMovie();
+			d.u.i = movie->getCast()->_loadedCast->size() + movie->_sharedCast->_loadedCast->size();
+		}
 		break;
 	case kTheCenterStage:
 		d.type = INT;


### PR DESCRIPTION
This change implements the getting of number of castMembers. THe changes have been tested using the `number of castMembers` workshop movie which shows identical behaviour to as observed in BasiliskII