### PR TITLE
DIRECTOR: LINGO: Implement the beepOn property and remove their respective STUBs

### DIFF
--- a/engines/director/events.cpp
+++ b/engines/director/events.cpp
@@ -190,6 +190,10 @@ bool Movie::processEvent(Common::Event &event) {
 			// Even in D4, `the clickOn` uses the old "active" sprite instead of mouse sprite.
 			_currentClickOnSpriteId = sc->getActiveSpriteIDFromPos(pos);
 
+			if (!spriteId && _isBeepOn) {
+				g_lingo->func_beep(1);
+			}
+
 			if (spriteId > 0 && sc->_channels[spriteId]->_sprite->shouldHilite()) {
 				_currentHiliteChannelId = spriteId;
 				g_director->_wm->_hilitingWidget = true;

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -377,7 +377,8 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 		d = g_lingo->_actorList;
 		break;
 	case kTheBeepOn:
-		getTheEntitySTUB(kTheBeepOn);
+		d.type = INT;
+		d.u.i = (int)g_director->getCurrentMovie()->_isBeepOn;
 		break;
 	case kTheButtonStyle:
 		d.type = INT;
@@ -936,7 +937,7 @@ void Lingo::setTheEntity(int entity, Datum &id, int field, Datum &d) {
 		g_lingo->_actorList = d;
 		break;
 	case kTheBeepOn:
-		setTheEntitySTUB(kTheBeepOn);
+		g_director->getCurrentMovie()->_isBeepOn = (bool)d.u.i;
 		break;
 	case kTheButtonStyle:
 		if (d.asInt())

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -87,6 +87,8 @@ Movie::Movie(Window *window) {
 	_timeOutKeyDown = true;
 	_timeOutMouse = true;
 	_timeOutPlay = false;
+
+	_isBeepOn = false;
 }
 
 Movie::~Movie() {

--- a/engines/director/movie.h
+++ b/engines/director/movie.h
@@ -168,6 +168,8 @@ public:
 	bool _timeOutMouse;
 	bool _timeOutPlay;
 
+	bool _isBeepOn;
+
 private:
 	Window *_window;
 	DirectorEngine *_vm;


### PR DESCRIPTION
Implements the beepOn property by creating a bool `_isBeepOn` for the movie and emitting a beep at every mouse down event which meets these conditions:
* beepOn is true
* castMember being clicked is not active
Tested using `beepOn` workshop movie and shows identical behaviour as in BasiliskII