### PR TITLE
SCUMM: Fix missing voice when selling back the hub cap and pirate hat

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -1404,9 +1404,22 @@ void ScummEngine_v5::o5_isEqual() {
 	// are only played on type 5 soundcards. However, there is at least one
 	// other sound effect (the bartender spitting) which is only played on
 	// type 3 soundcards.
-
 	if (_game.id == GID_MONKEY2 && var == VAR_SOUNDCARD && b == 5)
 		b = a;
+
+	// WORKAROUND: The Ultimate Talkie edition of Monkey Island 2 doesn't
+	// check the proper objects when you sell back the hub cap and the
+	// pirate hat to the antique dealer on Booty Island, making Guybrush
+	// silent when he asks about these two particular objects.
+	//
+	// Not using `_enableEnhancements`, since this small oversight only
+	// exists in this fan-made edition which was made for enhancements.
+	if (_game.id == GID_MONKEY2 && _roomResource == 48 && vm.slot[_currentScript].number == 215 && a == vm.localvar[_currentScript][0] && strcmp(_game.variant, "SE Talkie") == 0) {
+		if (a == 550 && b == 530)
+			b = 550;
+		else if (a == 549 && b == 529)
+			b = 549;
+	}
 
 	// HACK: To allow demo script of Maniac Mansion V2
 	// The camera x position is only 100, instead of 180, after game title name scrolls.


### PR DESCRIPTION
This one was found by Threepwang while he was testing his own French translation.

## Context

This only happens with the Ultimate Talkie edition of Monkey Island 2, when you go to the Booty Boutique and try to buy/sell some objects.

Script 215 in room 48 (talkie edition 0.2) does this:

```
...
[0004] (48) if (Local[0] == 530) { # <===
[000B] (D8)   printEgo([Text(sound(0xACDDEDE, 0xA) + "Can I sell back this hub cap?")]);
[003B] (48) } else if (Local[0] == 529) { # <===
[0045] (D8)   printEgo([Text(sound(0xACE4833, 0xA) + "Can I sell back this pirate hat?")]);
[0078] (48) } else if (Local[0] == 534) {
[0082] (D8)   printEgo([Text(sound(0xACEC310, 0xA) + "Can I sell back this wreath?")]);
[00B1] (48) } else if (Local[0] == 547) {
[00BB] (D8)   printEgo([Text(sound(0xACF2463, 0xA) + "Can I sell back this rock and roll collector's plate?")]);
[0103] (18) } else {
[0106] (48)   if (Local[0] == 520) {
[010D] (18)     goto 00BB;
[0110] (**)   }
[0110] (48)   if (Local[0] == 537) {
[0117] (D8)     printEgo([Text(sound(0xACFCB35, 0xA) + "Can I sell back this feather pen?")]);
[014B] (18)   } else {
[014E] (48)     if (Local[0] == 548) {
[0155] (18)       goto 0082;
[0158] (**)     }
[0158] (48)     if (Local[0] == 551) {
[015F] (18)       goto 0117;
[0162] (**)     }
[0162] (9D)     if (classOfIs(Local[0],[137])) {
[016B] (D8)       printEgo([Text("Can I sell back these " + getName(Local[0]) + "?")]);
[0189] (18)     } else {
[018C] (D8)       printEgo([Text("Can I sell back this " + getName(Local[0]) + "?")]);
[01A9] (**)     }
[01A9] (**)   }
[01A9] (**) }
...
```

but for the hub cap and the pirate hat, the comparison is wrong, it should check for `550` and `549` since they must be in your inventory to be sold again.

So, the first two `if ()` would never match and you'd fall back to the voice-less `Can I sell back this XXX...`. Not game-breaking, but the audio sample is there, and the Ultimate Talkie edition was all about fixing and improving everything in the orignal game :)

As usual, I try to take many precautions in my checks (so if a future version of the Ultimate Edition appears, this shouldn't cause any problem). In this particular case, I don't check for `_enableEnhancements` since this fan-made edition *is* about enhancements in the first place (a similar reasoning is already applied to an existing workaround in this same file).

## How to test

1. You need the Ultimate Talkie edition of Monkey Island 2 to test this.
2. Start the game with the `-b 619` boot param.
3. Buy (= pick up) a hub cap (on the left) and a pirate hat (at the top).
4. Sell (= give) them back to the antique dealer.

With this fix, you should hear Guybrush's voice again when he asks about selling back these objects.