### PR TITLE
DIRECTOR: LINGO: Implement scriptNum of sprite STUB in lingo-the.cpp

### DIFF
--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -1368,7 +1368,8 @@ Datum Lingo::getTheSprite(Datum &id1, int field) {
 		warning("STUB: Lingo::getTheSprite(): Unprocessed getting field \"%s\" of sprite", field2str(field));
 		break;
 	case kTheScriptNum:
-		warning("STUB: Lingo::getTheSprite(): Unprocessed getting field \"%s\" of sprite", field2str(field));
+		d.type = INT;
+		d.u.i = sprite->_scriptId.member;
 		break;
 	case kTheStartTime:
 		d.u.i = channel->_startTime;


### PR DESCRIPTION
This change implements scriptNum of sprite property in `Lingo::getTheSprit()` and makes `scriptNum of sprite` workshop movie work as intended.