### PR TITLE
COMMON: Add string encoding API with more informative error behavior

### DIFF
--- a/common/str-enc.h
+++ b/common/str-enc.h
@@ -57,6 +57,11 @@ enum CodePage {
 	kLastEncoding = kASCII
 };
 
+enum StringEncodingResult {
+	kStringEncodingResultSucceeded,
+	kStringEncodingResultHasErrors,
+};
+
 U32String convertUtf8ToUtf32(const String &str);
 String convertUtf32ToUtf8(const U32String &str);
 

--- a/common/str.h
+++ b/common/str.h
@@ -246,14 +246,14 @@ public:
 	U32String decode(CodePage page = kUtf8) const;
 
 protected:
-	void encodeUTF8(const U32String &src);
-	void encodeWindows932(const U32String &src);
-	void encodeWindows949(const U32String &src);
-	void encodeWindows950(const U32String &src, bool translit = true);
-	void encodeJohab(const U32String &src);
-	void encodeOneByte(const U32String &src, CodePage page, bool translit = true);
-	void encodeInternal(const U32String &src, CodePage page);
-	void translitChar(U32String::value_type point);
+	StringEncodingResult encodeUTF8(const U32String &src, char errorChar);
+	StringEncodingResult encodeWindows932(const U32String &src, char errorChar);
+	StringEncodingResult encodeWindows949(const U32String &src, char errorChar);
+	StringEncodingResult encodeWindows950(const U32String &src, bool translit, char errorChar);
+	StringEncodingResult encodeJohab(const U32String &src, char errorChar);
+	StringEncodingResult encodeOneByte(const U32String &src, CodePage page, bool translit, char errorChar);
+	StringEncodingResult encodeInternal(const U32String &src, CodePage page, char errorChar);
+	StringEncodingResult translitChar(U32String::value_type point, char errorChar);
 
 	friend class U32String;
 };

--- a/common/ustr.h
+++ b/common/ustr.h
@@ -127,6 +127,10 @@ public:
 	/** Convert the string to the given @p page encoding and return the result as a new String. */
 	String encode(CodePage page = kUtf8) const;
 
+	/** Convert the string to the given @p page encoding and output in string @p outString,
+		replacing invalid characters with @p errorChar. */
+	StringEncodingResult encode(String &outString, CodePage page, char errorChar) const;
+
 	/**
 	 * Print formatted data into a U32String object.
 	 *


### PR DESCRIPTION
This updates the string encode API to return a status code indicating whether the encoding completely succeeded, or if it contains errors.

Currently, unmappable characters are just silently encoded as "?" so there is no way to determine if a Unicode code point is valid on a particular code page other than seeing if it comes out as "?" when the input character wasn't "?" which is a pretty gnarly hack.

The mTropolis engine needs this to filter out keystrokes that don't map to a valid character.