### PR TITLE
COMMON: Adding iconspath parameter to the command line

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -151,6 +151,7 @@ static const char HELP_STRING[] =
 	"                           pce, segacd, wii, windows)\n"
 	"  --savepath=PATH          Path to where saved games are stored\n"
 	"  --extrapath=PATH         Extra path to additional game data\n"
+	"  --iconspath=PATH         Path to additional icons for the launcher grid view\n"
 	"  --soundfont=FILE         Select the SoundFont for MIDI playback (only\n"
 	"                           supported by some MIDI drivers)\n"
 	"  --multi-midi             Enable combination AdLib and native MIDI\n"
@@ -836,6 +837,15 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 				} else if (!path.isReadable()) {
 					usage("Non-readable extra path '%s'", option);
 				}
+			END_OPTION
+
+			DO_LONG_OPTION("iconspath")
+			Common::FSNode path(option);
+			if (!path.exists()) {
+				usage("Non-existent icons path '%s'", option);
+			} else if (!path.isReadable()) {
+				usage("Non-readable icons path '%s'", option);
+			}
 			END_OPTION
 
 			DO_LONG_OPTION("md5-path")
@@ -1847,6 +1857,7 @@ bool processSettings(Common::String &command, Common::StringMap &settings, Commo
 		"subtitles",
 		"savepath",
 		"extrapath",
+		"iconspath",
 		"screenshotpath",
 		"soundfont",
 		"multi-midi",

--- a/doc/docportal/advanced_topics/command_line.rst
+++ b/doc/docportal/advanced_topics/command_line.rst
@@ -129,6 +129,7 @@ Short options are listed where they are available.
         ``--dump-scripts``,``-u``,"Enables script dumping if a directory called 'dumps' exists in the current directory"
         ``--enable-gs``,,":ref:`Enables Roland GS mode for MIDI playback <gs>`"
         ``--extrapath=PATH``,,":ref:`Extra path to additional game data <extra>`"
+        ``--iconspath=PATH``,,":ref:`Path to additional icons for the launcher grid view <iconspath>`"
         ``--filtering``,,":ref:`Forces filtered graphics mode <filtering>`"
         ``--fullscreen``,``-f``,":ref:`Forces full-screen mode <fullscreen>`"
         ``--game=NAME``,,"In combination with ``--add`` or ``--detect`` only adds or attempts to detect the game with id NAME."

--- a/doc/docportal/advanced_topics/configuration_file.rst
+++ b/doc/docportal/advanced_topics/configuration_file.rst
@@ -163,6 +163,7 @@ There are many recognized configuration keys. In the table below, each key is ei
 		enable_unsupported_game_warning,boolean,true, Shows a warning when adding a game that is unsupported.
 		extra,string, ,"Shows additional information about a game, such as version"
 		":ref:`extrapath <extra>`",string,None,
+		":ref:`iconspath <iconspath>`",string,None,
 		":ref:`fade_style <fade>`",boolean,true,
 		":ref:`filtering <filtering>`",boolean,false,
 		":ref:`floating_cursors <floating>`",boolean,false,

--- a/doc/docportal/settings/paths.rst
+++ b/doc/docportal/settings/paths.rst
@@ -41,3 +41,9 @@ Extra Path
 
 	*extrapath*
 
+.. _iconspath:
+
+Icons Path
+	Sets the path to the folder in which ScummVM will look for additional icons for the launcher grid view.
+
+	*iconspath*

--- a/doc/se/LasMig
+++ b/doc/se/LasMig
@@ -705,6 +705,7 @@ Ordning: scummvm [INSTÄLLNINGAR]... [SPEL]
                            pce, segacd, windows)
   --savepath=PATH          Sökväg dit spardata lagras
   --extrapath=PATH         ”Extra”-sökväg för ytterligare speldata
+  --iconspath=PATH         <Path to additional icons for the launcher grid view>
   --soundfont=FILE         Välj SoundFont för MIDI-uppspelning (Stöds endast
                            av vissa MIDI-drivers)
   --multi-midi             Aktivera kombination av AdLib och Native MIDI


### PR DESCRIPTION
Just like `extrapath` and `themepath`, you can now add `iconspath` as a command line option (in addition to via the GUI).

This includes documentation updates as well.