### PR TITLE
DIRECTOR: LINGO: IMplement kTheScoreColor STUB in Lingo::getTheEntity()

### DIFF
--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -1365,7 +1365,8 @@ Datum Lingo::getTheSprite(Datum &id1, int field) {
 		d.u.i = channel->getBbox().right;
 		break;
 	case kTheScoreColor:
-		warning("STUB: Lingo::getTheSprite(): Unprocessed getting field \"%s\" of sprite", field2str(field));
+		//Check the last 3 bits of the _colorcode byte as value lies in 0 to 5
+		d.u.i = (int)(sprite->_colorcode & 0x7);
 		break;
 	case kTheScriptNum:
 		warning("STUB: Lingo::getTheSprite(): Unprocessed getting field \"%s\" of sprite", field2str(field));


### PR DESCRIPTION
This change implements scoreColor of sprite property in the director engine. It looks for the last 3 bits of _colorcode byte of a sprite (As its overall value can mean more than one thing, like setting sprite editable and movable)
Change has been tested with `scoreColor of sprite` workshop movie and it shows identical results as to the original