### PR TITLE
DIRECTOR: LINGO: Implement setting of timeOutLapsed property

### DIFF
--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -121,6 +121,7 @@ DirectorEngine::DirectorEngine(OSystem *syst, const DirectorGameDescription *gam
 	_centerStage = true;
 
 	_surface = nullptr;
+	_tickBaseline = 0;
 }
 
 DirectorEngine::~DirectorEngine() {

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -245,6 +245,9 @@ private:
 	Graphics::ManagedSurface *_surface;
 
 	StartOptions _options;
+
+public:
+	int _tickBaseline;
 };
 
 // An extension of MacPlotData for interfacing with inks and patterns without

--- a/engines/director/events.cpp
+++ b/engines/director/events.cpp
@@ -40,7 +40,7 @@
 
 namespace Director {
 
-uint32 DirectorEngine::getMacTicks() { return g_system->getMillis() * 60 / 1000.; }
+uint32 DirectorEngine::getMacTicks() { return (g_system->getMillis() * 60 / 1000.) - _tickBaseline; }
 
 bool DirectorEngine::processEvents(bool captureClick) {
 	debugC(3, kDebugEvents, "\n@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -1105,7 +1105,12 @@ void Lingo::setTheEntity(int entity, Datum &id, int field, Datum &d) {
 		break;
 	case kTheTimeoutLapsed:
 		// timeOutLapsed can be set in D4, but can't in D3. see D3.1 interactivity manual p312 and D4 dictionary p296.
-		setTheEntitySTUB(kTheTimeoutLapsed);
+		if (g_director->getVersion() >= 400 && d.type == INT) {
+			g_director->_tickBaseline = g_director->getMacTicks() - d.asInt();
+		}
+		if (d.type != INT) {
+			warning("Lingo::setTheEntity() : Wrong DatumType %d for setting of Lingo Property timeOutLapsed", d.type);
+		}
 		break;
 	case kTheTimeoutLength:
 		g_director->getCurrentMovie()->_timeOutLength = d.asInt();


### PR DESCRIPTION
This change adds a baseline which is subtracted from the timer to give the modified lapsed time. The baseline is set to 0 by default so the modified lapsed time won't show up unless it has been set. The changes have NOT been tested as there weren't any workshop movies testing for the same. I will update it after making a movie and testing it