### PR TITLE
AMIGAOS: Debug builds with all debug information

### DIFF
--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -50,7 +50,7 @@ ifdef DYNAMIC_MODULES
 	makedir all $(AMIGAOSPATH)/plugins
 	# Preserve all debug information on debug builds
 ifdef DEBUG_BUILD
-		cp $(PLUGINS) $(AMIGAOSPATH)/$(plugin)
+		cp $(PLUGINS) $(AMIGAOSPATH)/plugins/$(plugin)
 else
 		$(foreach plugin, $(PLUGINS), $(STRIP) $(plugin) -o $(AMIGAOSPATH)/$(plugin);)
 endif

--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -48,7 +48,12 @@ ifneq ($(DIST_FILES_SHADERS),)
 endif
 ifdef DYNAMIC_MODULES
 	makedir all $(AMIGAOSPATH)/plugins
-	$(foreach plugin, $(PLUGINS), $(STRIP) $(plugin) -o $(AMIGAOSPATH)/$(plugin);)
+	# Preserve all debug information on debug builds
+ifdef DEBUG_BUILD
+		cp $(PLUGINS) $(AMIGAOSPATH)/$(plugin)
+else
+		$(foreach plugin, $(PLUGINS), $(STRIP) $(plugin) -o $(AMIGAOSPATH)/$(plugin);)
+endif
 	makedir all $(AMIGAOSPATH)/sobjs
 	# AmigaOS installations, especially vanilla ones, won't have every
 	# mandatory shared library in place, let alone the correct versions.
@@ -57,5 +62,9 @@ ifdef DYNAMIC_MODULES
 	rx Ext_Inst_so.rexx $(EXECUTABLE) $(AMIGAOSPATH)
 	rm -f Ext_Inst_so.rexx
 endif
+# Preserve all debug information on debug builds
+ifdef DEBUG_BUILD
+	cp $(EXECUTABLE) $(AMIGAOSPATH)/$(EXECUTABLE)
+else
 	$(STRIP) $(EXECUTABLE) -o $(AMIGAOSPATH)/$(EXECUTABLE)
-
+endif

--- a/configure
+++ b/configure
@@ -2576,6 +2576,7 @@ case $_host_os in
 			_optimization_level=-O0
 			append_var CXXFLAGS "-fno-omit-frame-pointer"
 			append_var CXXFLAGS "-fno-strict-aliasing"
+			define_in_config_if_yes "$_debug_build" 'DEBUG_BUILD'
 		fi
 		# When building dynamic, add everything possible as plugin
 		if test "$_dynamic_modules" = yes ; then


### PR DESCRIPTION
This only touches AmigaOS

- adds a DEBUG_BUILD define to the build environment
- makes use of the define to not strip any information from debug builds

Sorry for the wrong indentation in amigaos.mk, but my shell still doesn´t like indented ifdefs