### PR TITLE
DIRECTOR: LINGO: Implement searchCurrentFolder STUB in Lingo::getTheEntity()

### DIFF
--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -758,7 +758,9 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 		d.u.i = _vm->getVersion();
 		break;
 	case kTheSearchCurrentFolder:
-		getTheEntitySTUB(kTheSearchCurrentFolder);
+		//We always allow searching in current folder
+		warning("BUILDBOT: SearchCurrentFolder is queried");
+		d = Datum(1);
 		break;
 	case kTheSearchPath:
 		d = g_lingo->_searchPath;
@@ -1041,6 +1043,9 @@ void Lingo::setTheEntity(int entity, Datum &id, int field, Datum &d) {
 	case kTheScummvmVersion:
 		// Allow director version change: used for testing version differences via the lingo tests.
 		_vm->setVersion(d.asInt());
+		break;
+	case kTheSearchCurrentFolder:
+		warning("BUILDBOT: Trying to set SearchCurrentFolder lingo property");
 		break;
 	case kTheSelEnd:
 		g_director->getCurrentMovie()->_selEnd = d.asInt();


### PR DESCRIPTION
This change returns true for the property searchCurrentFolder as we won't be supporting the setting of this property to False