### PR TITLE
DIRECTOR: Let Cast class manage registering the archive

### DIFF
--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -93,6 +93,9 @@ Cast::~Cast() {
 
 	if (_castArchive) {
 		_castArchive->close();
+
+		g_director->_openResFiles.erase(_castArchive->getPathName());
+
 		delete _castArchive;
 		_castArchive = nullptr;
 	}
@@ -197,6 +200,9 @@ void Cast::setArchive(Archive *archive) {
 	} else {
 		_macName = archive->getFileName();
 	}
+
+	// Register the resfile so that Cursor::readFromResource can find it
+	g_director->_openResFiles.setVal(archive->getPathName(), archive);
 }
 
 void Cast::loadArchive() {

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -95,9 +95,6 @@ Movie::~Movie() {
 	// _movieArchive is shared with the cast, so the cast will free it
 	delete _cast;
 
-	if (_sharedCast)
-		g_director->_openResFiles.erase(_sharedCast->getArchive()->getPathName());
-
 	delete _sharedCast;
 	delete _score;
 }
@@ -284,8 +281,6 @@ void Movie::clearSharedCast() {
 	if (!_sharedCast)
 		return;
 
-	g_director->_openResFiles.erase(_sharedCast->getArchive()->getPathName());
-
 	delete _sharedCast;
 
 	_sharedCast = nullptr;
@@ -312,9 +307,6 @@ void Movie::loadSharedCastsFrom(Common::String filename) {
 	_sharedCast = new Cast(this, 0, true);
 	_sharedCast->setArchive(sharedCast);
 	_sharedCast->loadArchive();
-
-	// Register the resfile so that Cursor::readFromResource can find it
-	g_director->_openResFiles.setVal(sharedCast->getPathName(), sharedCast);
 }
 
 CastMember *Movie::getCastMember(CastMemberID memberID) {


### PR DESCRIPTION
This fixes a null pointer crash and potential issues when switching between movies.

Examples: Let's play dressup with Bert (exit), Learn the art of magic (instant)
