### PR TITLE
DIRECTOR: LINGO: Implement traceLogFile Lingo Property

### DIFF
--- a/engines/director/debugger.cpp
+++ b/engines/director/debugger.cpp
@@ -61,4 +61,17 @@ bool Debugger::lingoCommandProcessor(const char *inputOrig) {
 	return true;
 }
 
+void Debugger::debugLogFile(Common::String logs) {
+	debugPrintf("%s", logs.c_str());
+	if (!g_director->_traceLogFile.empty()) {
+		const Common::String filename = g_director->_traceLogFile;
+		if (out.open(filename, true)) {
+			out.seek(out.size());
+			out.write(logs.c_str(), logs.size());
+			out.flush();
+			out.close();
+		}
+	}
+}
+
 } // End of namespace Director

--- a/engines/director/debugger.h
+++ b/engines/director/debugger.h
@@ -30,11 +30,14 @@ namespace Director {
 class Debugger : public GUI::Debugger {
 public:
 	Debugger();
+	void debugLogFile(Common::String logs);
 
 private:
 	bool cmd_lingo(int argc, const char **argv);
 
 	bool lingoCommandProcessor(const char *inputOrig);
+
+	Common::DumpFile out;
 };
 
 

--- a/engines/director/debugger.h
+++ b/engines/director/debugger.h
@@ -30,14 +30,16 @@ namespace Director {
 class Debugger : public GUI::Debugger {
 public:
 	Debugger();
-	void debugLogFile(Common::String logs);
+	~Debugger();
+	void debugLogFile(Common::String logs, bool prompt);
 
 private:
 	bool cmd_lingo(int argc, const char **argv);
 
 	bool lingoCommandProcessor(const char *inputOrig);
 
-	Common::DumpFile out;
+	Common::DumpFile _out;
+	Common::String _outName;
 };
 
 

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -259,6 +259,7 @@ private:
 
 public:
 	int _tickBaseline;
+	Common::String _traceLogFile;
 };
 
 // An extension of MacPlotData for interfacing with inks and patterns without

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1191,13 +1191,21 @@ void LB::b_setCallBack(int nargs) {
 }
 
 void LB::b_showResFile(int nargs) {
-	g_lingo->dropStack(nargs);
-	warning("LB: b_showResFile: showResFile is not supported by ScummVM");
+	if (nargs)
+		g_lingo->pop();
+	Common::String out;
+	for (auto it = g_director->_openResFiles.begin(); it != g_director->_openResFiles.end(); it++)
+		out += it->_key + "\n";
+	g_debugger->debugLogFile(out, false);
 }
 
 void LB::b_showXlib(int nargs) {
-	g_lingo->dropStack(nargs);
-	warning("LB: b_showXlib: showXlib is not supported by ScummVM");
+	if (nargs)
+		g_lingo->pop();
+	Common::String out;
+	for (auto it = g_lingo->_openXLibs.begin(); it != g_lingo->_openXLibs.end(); it++)
+		out += it->_key + "\n";
+	g_debugger->debugLogFile(out, false);
 }
 
 void LB::b_xFactoryList(int nargs) {

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1679,7 +1679,7 @@ void LB::b_put(int nargs) {
 			output += " ";
 	}
 	if (g_debugger->isActive()) {
-		g_debugger->debugPrintf("-- %s\n", output.c_str());
+		g_debugger->debugLogFile(output, true);
 	} else {
 		debug("-- %s", output.c_str());
 	}
@@ -1698,7 +1698,7 @@ void LB::b_showGlobals(int nargs) {
 			}
 		}
 	}
-	g_debugger->debugPrintf("%s", global_out.c_str());
+	g_debugger->debugLogFile(global_out, false);
 }
 
 void LB::b_showLocals(int nargs) {
@@ -1708,7 +1708,7 @@ void LB::b_showLocals(int nargs) {
 			local_out += it->_key + " = " + it->_value.asString() + "\n";
 		}
 	}
-	g_debugger->debugPrintf("%s", local_out.c_str());
+	g_debugger->debugLogFile(local_out, false);
 }
 
 ///////////////////

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -1241,7 +1241,10 @@ void Lingo::setTheEntity(int entity, Datum &id, int field, Datum &d) {
 	{
 		if (d.asString().size()) {
 			Common::String logPath = ConfMan.get("path") + "/" + d.asString();
-			if (Common::FSNode(logPath).isWritable())
+			Common::FSNode out(logPath);
+			if (!out.exists())
+				out.createWriteStream();
+			if (out.isWritable())
 				g_director->_traceLogFile = logPath;
 		} else {
 			g_director->_traceLogFile.clear();

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -19,6 +19,8 @@
  *
  */
 
+#include "common/config-manager.h"
+#include "common/fs.h"
 #include "graphics/macgui/macbutton.h"
 #include "graphics/macgui/macmenu.h"
 
@@ -949,7 +951,8 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 		d.u.i = g_lingo->_traceLoad;
 		break;
 	case kTheTraceLogFile:
-		getTheEntitySTUB(kTheTraceLogFile);
+		d.type = STRING;
+		d.u.s = new Common::String(g_director->_traceLogFile);
 		break;
 	case kTheUpdateMovieEnabled:
 		d.type = INT;
@@ -1235,7 +1238,15 @@ void Lingo::setTheEntity(int entity, Datum &id, int field, Datum &d) {
 		g_lingo->_traceLoad = d.asInt();
 		break;
 	case kTheTraceLogFile:
-		setTheEntitySTUB(kTheTraceLogFile);
+	{
+		if (d.asString().size()) {
+			Common::String logPath = ConfMan.get("path") + "/" + d.asString();
+			if (Common::FSNode(logPath).isWritable())
+				g_director->_traceLogFile = logPath;
+		} else {
+			g_director->_traceLogFile.clear();
+		}
+	}
 		break;
 	case kTheUpdateMovieEnabled:
 		g_lingo->_updateMovieEnabled = bool(d.asInt());


### PR DESCRIPTION
This change implements traceLogFile and the required function in g_debugger. There is a new wrapper of debugPrintf which will log the stdout and stderr output in the log file specified. Functionality has been tested and us found consistent to that of the original