### PR TITLE
VIDEO: Fix playing HNM videos without sound

### DIFF
--- a/video/hnm_decoder.cpp
+++ b/video/hnm_decoder.cpp
@@ -214,6 +214,7 @@ void HNMDecoder::HNMVideoTrack::newFrame(uint32 frameDelay) {
 	// We can't rely on a detection in the header as some soundless HNM indicate they have
 	if (frameDelay == uint32(-1)) {
 		_nextFrameStartTime = _nextFrameStartTime.addMsecs(_regularFrameDelayMs);
+		return;
 	}
 
 	// HNM decoders use sound double buffering to pace the frames


### PR DESCRIPTION
Previously, videos without sound would cause -1 frames to be added to the next frame start time on top of the regular frame delay. This fixes transitions in Lost Eden on some platforms.