### PR TITLE
DIRECTOR: fix palette regression

### DIFF
--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -169,7 +169,7 @@ void Frame::readChannels(Common::ReadStreamEndian *stream, uint16 version) {
 		} else {
 			stream->read(unk, 3);
 
-			_palette.paletteId = stream->readUint16();
+			_palette.paletteId = stream->readSint16();
 			_palette.firstColor = stream->readByte(); // for cycles. note: these start at 0x80 (for pal entry 0)!
 			_palette.lastColor = stream->readByte();
 			_palette.flags = stream->readByte();


### PR DESCRIPTION
#3979 introduced a fix for fetching the palette. However, it misinterpreted the number as an unsigned int instead of a signed int, leading to incorrect palettes on certain other games.

@einstein95 suggested this. I confirmed that via reading as a signed int, Japan Art Today 07 is fixed while The Seven Colours retains the correct palette from #3979.

Fixes https://bugs.scummvm.org/ticket/13615.