### PR TITLE
AGOS: Add an option to disable the fade-out effects in Simon1/Simon2

### DIFF
--- a/doc/docportal/settings/engine.rst
+++ b/doc/docportal/settings/engine.rst
@@ -9,7 +9,7 @@ From the Launcher, highlight a game on the games list, select **Edit Game**, and
 To find out which engine powers your game, have a look at the ScummVM Supported Games `wiki page
 <https://wiki.scummvm.org/index.php?title=Category:Supported_Games>`_.
 
-Engines: ADL_ | AGI_ | BLADERUNNER_ | CGE_ | CINE_ | DRASCULA_ | DREAMWEB_ | HDB_ | HOPKINS_ | KYRA_ | LURE_ | MADS_ | NEVERHOOD_ | SCI_ | SCUMM_ | SHERLOCK_ | SKY_ | SUPERNOVA_ | TOLTECS_ | WINTERMUTE_ | XEEN_ |
+Engines: ADL_ | AGI_ | AGOS_ | BLADERUNNER_ | CGE_ | CINE_ | DRASCULA_ | DREAMWEB_ | HDB_ | HOPKINS_ | KYRA_ | LURE_ | MADS_ | NEVERHOOD_ | SCI_ | SCUMM_ | SHERLOCK_ | SKY_ | SUPERNOVA_ | TOLTECS_ | WINTERMUTE_ | XEEN_ |
 
 .. figure:: ../images/settings/engine.png
 
@@ -100,6 +100,20 @@ Add speed menu
 	Adds a game speed menu, similar to the PC version.
 
 	*apple2gs_speedmenu*
+
+,,,,,,
+
+.. _AGOS:
+
+AGOS
+******
+
+.. _fadeout:
+
+Disable fade-out effects
+	Don't fade every screen to black when leaving a room.
+
+	*disable_fade_effects*
 
 ,,,,,,
 

--- a/engines/agos/agos.cpp
+++ b/engines/agos/agos.cpp
@@ -371,7 +371,8 @@ AGOSEngine::AGOSEngine(OSystem *system, const AGOSGameDescription *gd)
 
 	_fastFadeCount = 0;
 	_fastFadeInFlag = 0;
-	_fastFadeOutFlag = 0;
+	_fastFadeOutFlag = false;
+	_neverFade = false;
 	_exitCutscene = 0;
 	_paletteFlag = 0;
 	_bottomPalette = false;
@@ -602,6 +603,9 @@ Common::Error AGOSEngine::init() {
 		_internalWidth <<= 1;
 		_internalHeight <<= 1;
 	}
+
+	if (ConfMan.hasKey("disable_fade_effects"))
+		_neverFade = ConfMan.getBool("disable_fade_effects");
 
 	initGraphics(_internalWidth, _internalHeight);
 

--- a/engines/agos/agos.h
+++ b/engines/agos/agos.h
@@ -454,6 +454,7 @@ protected:
 	bool _bottomPalette;
 	uint16 _fastFadeCount;
 	volatile uint16 _fastFadeInFlag;
+	bool _neverFade;
 
 	uint16 _screenWidth, _screenHeight;
 	uint16 _internalWidth, _internalHeight;

--- a/engines/agos/detection.cpp
+++ b/engines/agos/detection.cpp
@@ -100,6 +100,15 @@ static const ExtraGuiOption preferDigitalSfx = {
 	0
 };
 
+static const ExtraGuiOption disableFadeEffects = {
+	_s("Disable fade-out effects"),
+	_s("Don't fade every screen to black when leaving a room."),
+	"disable_fade_effects",
+	false,
+	0,
+	0
+};
+
 class AgosMetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
 	AgosMetaEngineDetection() : AdvancedMetaEngineDetection(AGOS::gameDescriptions, sizeof(AGOS::AGOSGameDescription), agosGames) {
@@ -153,6 +162,9 @@ public:
 			// DOS versions of Elvira 2 and Waxworks can use either Adlib or
 			// digital SFX.
 			options.push_back(preferDigitalSfx);
+		}
+		if (target.empty() || gameid == "simon1" || gameid == "simon2") {
+			options.push_back(disableFadeEffects);
 		}
 		return options;
 	}

--- a/engines/agos/vga_ww.cpp
+++ b/engines/agos/vga_ww.cpp
@@ -197,8 +197,8 @@ void AGOSEngine::vc61() {
 
 void AGOSEngine::vc62_fastFadeOut() {
 	vc29_stopAllSounds();
-	
-	if (!_fastFadeOutFlag) {
+
+	if (!_neverFade && !_fastFadeOutFlag) {
 		uint i, fadeSize, fadeCount;
 
 		_fastFadeCount = 256;


### PR DESCRIPTION
Simon the Sorcerer 1 & 2 play a fade-out to black effect when you leave a room.

The problem is that you're *very* frequently moving from one room to the next, and this effect is a bit slow (and on some devices where SDL doesn't have a lot of acceleration, it gets quite painful).

Moreover, Simon walks in a really… relaxed manner, so I know a lot of "modern" players who complain about the pace of the game being way too slow, in 2022. I've found that disabling the fade-out effect makes the experience a bit nicer: you feel less interrupted by a slow animation every 20 seconds.

So, this PR adds a new `disable_fade_effects` option (disabled by default, since the fade-out is part of the original game). I'm only applying it on the `simon1` and `simon2` targets, because they're the only AGOS games I have.

Tested with the English and French versions of Simon1/Simon2 from GOG.