### PR TITLE
MORPHOS: logMessage override

### DIFF
--- a/backends/platform/sdl/morphos/morphos.cpp
+++ b/backends/platform/sdl/morphos/morphos.cpp
@@ -19,6 +19,7 @@
  *
  */
 
+#define FORBIDDEN_SYMBOL_EXCEPTION_printf
 #include "common/scummsys.h"
 
 #ifdef __MORPHOS__
@@ -51,4 +52,9 @@ bool OSystem_MorphOS::hasFeature(Feature f) {
 	return OSystem_SDL::hasFeature(f);
 }
 
+void OSystem_MorphOS::logMessage(LogMessageType::Type type, const char * message) {
+#ifdef DEBUG_BUILD
+	printf("%s\n", message);
+#endif
+}
 #endif

--- a/backends/platform/sdl/morphos/morphos.h
+++ b/backends/platform/sdl/morphos/morphos.h
@@ -28,6 +28,7 @@ class OSystem_MorphOS : public OSystem_SDL {
 public:
 	void init() override;
 	virtual bool hasFeature(Feature f);
+	void logMessage(LogMessageType::Type type, const char *message) override;
 };
 
 #endif


### PR DESCRIPTION
Use printf if DEBUG_BUILD only.
This removes a lot of console messages.