### PR TITLE
TOLTECS: Detect the (currently unsupported) 2019 remaster of 3 Skulls of the Toltecs

### DIFF
--- a/engines/toltecs/detection.cpp
+++ b/engines/toltecs/detection.cpp
@@ -23,6 +23,7 @@
 
 #include "engines/advancedDetector.h"
 
+#include "common/config-manager.h"
 #include "common/translation.h"
 #include "common/savefile.h"
 #include "common/str-array.h"
@@ -203,6 +204,19 @@ static const ToltecsGameDescription gameDescriptions[] = {
 		},
 	},
 
+	{
+		// Fenimore Fillmore: 3 Skulls of the Toltecs, 2019 Casual Brothers remaster (GOG, Steam)
+		{
+			"toltecs",
+			_s("Missing game code"), // Reason for being unsupported
+			AD_ENTRY1s("RData.lzma", "e0adae53ab5e821595a64032a4c2d5bc", 653477695),
+			Common::UNK_LANG,
+			Common::kPlatformWindows,
+			ADGF_REMASTERED | ADGF_UNSUPPORTED,
+			GUIO1(GUIO_NONE)
+		}
+	},
+
 	{ AD_TABLE_END_MARKER }
 };
 
@@ -239,7 +253,10 @@ public:
 
 const ExtraGuiOptions ToltecsMetaEngineDetection::getExtraGuiOptions(const Common::String &target) const {
 	ExtraGuiOptions options;
-	options.push_back(toltecsExtraGuiOption);
+
+	if (target.empty() || ConfMan.get("platform", target) != "windows")
+		options.push_back(toltecsExtraGuiOption);
+
 	return options;
 }
 


### PR DESCRIPTION
I've just discovered a couple of days ago that there's been a 2019 remaster of 3 Skulls of the Toltecs (which is currently on sale on GOG and Steam) made by Casual Brothers for Windows.

It features improved graphics from the original drawings (except in some scenes) so there's much less aliasing going on, the subtitles are much more readable, and the audio has been denoised a bit, it seems.

This PR just detects it and marks it as unsupported for now (since the resources are different).

(I'll probably update the wiki page too, if you're OK with this PR.)

Tested with the GOG and Steam versions.