### PR TITLE
KYRA: Support hebrew fan translation of MR

### DIFF
--- a/devtools/create_kyradat/create_kyradat.cpp
+++ b/devtools/create_kyradat/create_kyradat.cpp
@@ -38,7 +38,7 @@
 
 
 enum {
-	kKyraDatVersion = 117
+	kKyraDatVersion = 118
 };
 
 const ExtractFilename extractFilenames[] = {

--- a/devtools/create_kyradat/games.cpp
+++ b/devtools/create_kyradat/games.cpp
@@ -103,6 +103,7 @@ const Game kyra3Games[] = {
 	{ kKyra3, kPlatformDOS, kTalkieVersion, IT_ITA },
 	{ kKyra3, kPlatformDOS, kTalkieVersion, ES_ESP },
 	{ kKyra3, kPlatformDOS, kTalkieVersion, RU_RUS },
+	{ kKyra3, kPlatformDOS, kTalkieVersion, HE_ISR },
 	{ kKyra3, kPlatformDOS, kTalkieVersion, ZH_CHN },
 	{ kKyra3, kPlatformDOS, kTalkieVersion, ZH_TWN },
 

--- a/devtools/create_kyradat/resources.cpp
+++ b/devtools/create_kyradat/resources.cpp
@@ -104,6 +104,7 @@
 #include "resources/mr_dos_cd_italian.h"
 #include "resources/mr_dos_cd_spanish.h"
 #include "resources/mr_dos_cd_russian.h"
+#include "resources/mr_dos_cd_hebrew.h"
 #include "resources/mr_dos_cd_chinese_simplified.h"
 #include "resources/mr_dos_cd_chinese_trad.h"
 
@@ -1173,6 +1174,7 @@ static const ResourceProvider resourceProviders[] = {
 	{ k3MainMenuStrings, kKyra3, kPlatformDOS, kTalkieVersion, IT_ITA, &k3MainMenuStringsDOSCDItalianProvider },
 	{ k3MainMenuStrings, kKyra3, kPlatformDOS, kTalkieVersion, ES_ESP, &k3MainMenuStringsDOSCDSpanishProvider },
 	{ k3MainMenuStrings, kKyra3, kPlatformDOS, kTalkieVersion, RU_RUS, &k3MainMenuStringsDOSCDRussianProvider },
+	{ k3MainMenuStrings, kKyra3, kPlatformDOS, kTalkieVersion, HE_ISR, &k3MainMenuStringsDOSCDHebrewProvider },
 	{ k3MainMenuStrings, kKyra3, kPlatformDOS, kTalkieVersion, ZH_CHN, &k3MainMenuStringsDOSCDChineseSmplProvider },
 	{ k3MainMenuStrings, kKyra3, kPlatformDOS, kTalkieVersion, ZH_TWN, &k3MainMenuStringsDOSCDChineseTradProvider },
 	{ k3MusicFiles, kKyra3, kPlatformDOS, kTalkieVersion, UNK_LANG, &k3MusicFilesDOSCDProvider },
@@ -1188,6 +1190,7 @@ static const ResourceProvider resourceProviders[] = {
 	{ k2FontData, kKyra3, kPlatformDOS, kTalkieVersion, IT_ITA, &k3DummyDataDOSCDProvider },
 	{ k2FontData, kKyra3, kPlatformDOS, kTalkieVersion, ES_ESP, &k3DummyDataDOSCDProvider },
 	{ k2FontData, kKyra3, kPlatformDOS, kTalkieVersion, RU_RUS, &k3DummyDataDOSCDProvider },
+	{ k2FontData, kKyra3, kPlatformDOS, kTalkieVersion, HE_ISR, &k3DummyDataDOSCDProvider },
 	{ k2FontData, kKyra3, kPlatformDOS, kTalkieVersion, ZH_CHN, &k3FontDataDOSCDChineseSmplProvider },
 	{ k2FontData, kKyra3, kPlatformDOS, kTalkieVersion, ZH_TWN, &k3FontDataDOSCDChineseTradProvider },
 	{ k3VqaSubtitlesIntro, kKyra3, kPlatformDOS, kTalkieVersion, EN_ANY, &k3VqaSubtitlesIntroDOSCDEnglishProvider },
@@ -1196,6 +1199,7 @@ static const ResourceProvider resourceProviders[] = {
 	{ k3VqaSubtitlesIntro, kKyra3, kPlatformDOS, kTalkieVersion, IT_ITA, &k3VqaSubtitlesIntroDOSCDItalianProvider },
 	{ k3VqaSubtitlesIntro, kKyra3, kPlatformDOS, kTalkieVersion, ES_ESP, &k3VqaSubtitlesIntroDOSCDSpanishProvider },
 	{ k3VqaSubtitlesIntro, kKyra3, kPlatformDOS, kTalkieVersion, RU_RUS, &k3VqaSubtitlesIntroDOSCDRussianProvider },
+	{ k3VqaSubtitlesIntro, kKyra3, kPlatformDOS, kTalkieVersion, HE_ISR, &k3VqaSubtitlesIntroDOSCDHebrewProvider },
 	{ k3VqaSubtitlesIntro, kKyra3, kPlatformDOS, kTalkieVersion, ZH_CHN, &k3VqaSubtitlesIntroDOSCDChineseSmplProvider },
 	{ k3VqaSubtitlesIntro, kKyra3, kPlatformDOS, kTalkieVersion, ZH_TWN, &k3VqaSubtitlesIntroDOSCDChineseTradProvider },
 	{ k3VqaSubtitlesBoat, kKyra3, kPlatformDOS, kTalkieVersion, EN_ANY, &k3VqaSubtitlesBoatDOSCDEnglishProvider },
@@ -1204,6 +1208,7 @@ static const ResourceProvider resourceProviders[] = {
 	{ k3VqaSubtitlesBoat, kKyra3, kPlatformDOS, kTalkieVersion, IT_ITA, &k3VqaSubtitlesBoatDOSCDItalianProvider },
 	{ k3VqaSubtitlesBoat, kKyra3, kPlatformDOS, kTalkieVersion, ES_ESP, &k3VqaSubtitlesBoatDOSCDSpanishProvider },
 	{ k3VqaSubtitlesBoat, kKyra3, kPlatformDOS, kTalkieVersion, RU_RUS, &k3VqaSubtitlesBoatDOSCDRussianProvider },
+	{ k3VqaSubtitlesBoat, kKyra3, kPlatformDOS, kTalkieVersion, HE_ISR, &k3VqaSubtitlesBoatDOSCDHebrewProvider },
 	{ k3VqaSubtitlesBoat, kKyra3, kPlatformDOS, kTalkieVersion, ZH_CHN, &k3VqaSubtitlesBoatDOSCDChineseSmplProvider },
 	{ k3VqaSubtitlesBoat, kKyra3, kPlatformDOS, kTalkieVersion, ZH_TWN, &k3VqaSubtitlesBoatDOSCDChineseTradProvider },
 	{ kEoBBaseNpcPresetsNames, kEoB1, kPlatformDOS, kNoSpecial, EN_ANY, &kEoB1NpcPresetsNamesDOSEnglishProvider },

--- a/devtools/create_kyradat/resources/mr_dos_cd_hebrew.h
+++ b/devtools/create_kyradat/resources/mr_dos_cd_hebrew.h
@@ -1,0 +1,20 @@
+static const char *const k3MainMenuStringsDOSCDHebrew[4] = {
+	"\xE4\xFA\xE7\xEC\xFA \xEE\xF9\xE7\xF7 \xE7\xE3\xF9",
+	"\xE4\xF7\xE3\xEE\xE4",
+	"\xE8\xF2\xE9\xF0\xFA \xEE\xF9\xE7\xF7",
+	"\xE9\xF6\xE9\xE0\xE4 \xEE\xE4\xEE\xF9\xE7\xF7"
+};
+
+static const StringListProvider k3MainMenuStringsDOSCDHebrewProvider = { ARRAYSIZE(k3MainMenuStringsDOSCDHebrew), k3MainMenuStringsDOSCDHebrew };
+
+static const char *const k3VqaSubtitlesIntroDOSCDHebrew[] = {
+	""// TODO
+};
+
+static const StringListProvider k3VqaSubtitlesIntroDOSCDHebrewProvider = { ARRAYSIZE(k3VqaSubtitlesIntroDOSCDHebrew), k3VqaSubtitlesIntroDOSCDHebrew };
+
+static const char *const k3VqaSubtitlesBoatDOSCDHebrew[] = {
+	""// TODO
+};
+
+static const StringListProvider k3VqaSubtitlesBoatDOSCDHebrewProvider = { ARRAYSIZE(k3VqaSubtitlesBoatDOSCDHebrew), k3VqaSubtitlesBoatDOSCDHebrew };

--- a/engines/kyra/detection_tables.h
+++ b/engines/kyra/detection_tables.h
@@ -50,6 +50,7 @@ namespace {
 #define KYRA3_CD_4LANG_FLAGS FLAGS(false, false, true, false, false, false, false, true, true, true, Kyra::GI_KYRA3)
 #define KYRA3_CD_INS_4LANG_FLAGS FLAGS(false, false, true, false, false, false, false, true, false, true, Kyra::GI_KYRA3)
 #define KYRA3_CD_FAN_FLAGS(x, y) FLAGS_FAN(x, y, false, false, true, false, false, false, false, true, false, false, Kyra::GI_KYRA3)
+#define KYRA3_CD_INS_FAN_FLAGS(x, y) FLAGS_FAN(x, y, false, false, true, false, false, false, false, true, true, false, Kyra::GI_KYRA3)
 
 #define LOL_CD_FLAGS FLAGS(false, false, true, false, false, false, false, false, false, false, Kyra::GI_LOL)
 #define LOL_CD_FAN_FLAGS(x, y) FLAGS_FAN(x, y, false, false, true, false, false, false, false, false, false, false, Kyra::GI_LOL)
@@ -1015,6 +1016,20 @@ const KYRAGameDescription adGameDescs[] = {
 			GUIO5(GUIO_NOMIDI, GUIO_RENDERVGA, GAMEOPTION_KYRA3_AUDIENCE, GAMEOPTION_KYRA3_SKIP, GAMEOPTION_KYRA3_HELIUM)
 		},
 		KYRA3_CD_FLAGS
+	},
+
+	{ // Hebrew fan translation
+		{
+			"kyra3",
+			0,
+			AD_ENTRY2s("ONETIME.PAK", "3833ff312757b8e6147f464cca0a6587", -1,
+					   "8FAT.FNT", "12424362a537e1335b10323c4013bb1d", -1),
+			Common::HE_ISR,
+			Common::kPlatformDOS,
+			ADGF_DROPLANGUAGE,
+			GUIO5(GUIO_NOMIDI, GUIO_RENDERVGA, GAMEOPTION_KYRA3_AUDIENCE, GAMEOPTION_KYRA3_SKIP, GAMEOPTION_KYRA3_HELIUM)
+		},
+		KYRA3_CD_INS_FAN_FLAGS(Common::HE_ISR, Common::EN_ANY)
 	},
 
 	// installed version

--- a/engines/kyra/gui/gui_mr.cpp
+++ b/engines/kyra/gui/gui_mr.cpp
@@ -140,19 +140,26 @@ void KyraEngine_MR::updateItemCommand(Item item, int str, uint8 c0) {
 	char buffer[100];
 	char *src = (char *)getTableEntry(_itemFile, item);
 
-	if (_lang != 3) {
-		while (*src != ' ')
+	if (_flags.lang != Common::HE_ISR) {
+		if (_lang != 3) {
+			while (*src != ' ')
+				++src;
 			++src;
-		++src;
-		*src = toupper(*src);
-	}
+			*src = toupper(*src);
+		}
 
-	strcpy(buffer, src);
+		strcpy(buffer, src);
 
-	if (_lang != 3)
+		if (_lang != 3)
+			strcat(buffer, " ");
+
+		strcat(buffer, (const char *)getTableEntry(_cCodeFile, str));
+	} else {
+		strcpy(buffer, (const char *)getTableEntry(_cCodeFile, str));
 		strcat(buffer, " ");
-
-	strcat(buffer, (const char *)getTableEntry(_cCodeFile, str));
+		strcat(buffer, src);
+		strcat(buffer, ".");
+	}
 
 	showMessage(buffer, c0, 0xF0);
 }
@@ -445,6 +452,8 @@ int KyraEngine_MR::getScoreX(const char *str) {
 
 	int width = _screen->getTextWidth(str);
 	int x = 160 + (width / 2) - 32;
+	if (_flags.lang == Common::HE_ISR)
+		x = 140 - 32;
 
 	_screen->setFont(oldFont);
 	_screen->_charSpacing = 0;
@@ -618,16 +627,28 @@ int KyraEngine_MR::buttonShowScore(Button *button) {
 	while (*buffer != '%')
 		++buffer;
 
-	buffer[0] = (_score / 100) + '0';
-	buffer[1] = ((_score % 100) / 10) + '0';
-	buffer[2] = (_score % 10) + '0';
+	if (_flags.lang != Common::HE_ISR) {
+		buffer[0] = (_score / 100) + '0';
+		buffer[1] = ((_score % 100) / 10) + '0';
+		buffer[2] = (_score % 10) + '0';
+	} else {
+		buffer[0] = (_score % 10) + '0';
+		buffer[1] = ((_score % 100) / 10) + '0';
+		buffer[2] = (_score / 100) + '0';
+	}
 
 	while (*buffer != '%')
 		++buffer;
 
-	buffer[0] = (_scoreMax / 100) + '0';
-	buffer[1] = ((_scoreMax % 100) / 10) + '0';
-	buffer[2] = (_scoreMax % 10) + '0';
+	if (_flags.lang != Common::HE_ISR) {
+		buffer[0] = (_scoreMax / 100) + '0';
+		buffer[1] = ((_scoreMax % 100) / 10) + '0';
+		buffer[2] = (_scoreMax % 10) + '0';
+	} else {
+		buffer[0] = (_scoreMax % 10) + '0';
+		buffer[1] = ((_scoreMax % 100) / 10) + '0';
+		buffer[2] = (_scoreMax / 100) + '0';
+	}
 
 	showMessage(_stringBuffer, 0xFF, 0xF0);
 	return 0;
@@ -802,6 +823,16 @@ void KyraEngine_MR::printAlbumText(int page, const char *str, int x, int y, uint
 	if (_lang == 3) {
 		_screen->setFont(Screen::FID_CHINESE_FNT);
 		_screen->setFontStyles(_screen->_currentFont, Font::kStyleNone);
+	}
+
+	Common::String strr((const char *)str);
+	Common::String revBuffer;
+	if (_flags.lang == Common::HE_ISR) {
+		for (int i = strr.size() - 1; i >= 0; --i)
+			revBuffer += str[i];
+		str = revBuffer.c_str();
+
+		x += 120 - _screen->getTextWidth(str);
 	}
 
 	_screen->printText(str, x, y, c0, 0);

--- a/engines/kyra/resource/staticres.cpp
+++ b/engines/kyra/resource/staticres.cpp
@@ -38,7 +38,7 @@
 
 namespace Kyra {
 
-#define RESFILE_VERSION 117
+#define RESFILE_VERSION 118
 
 namespace {
 bool checkKyraDat(Common::SeekableReadStream *file) {

--- a/engines/kyra/text/text_mr.cpp
+++ b/engines/kyra/text/text_mr.cpp
@@ -161,7 +161,16 @@ void TextDisplayer_MR::printText(const Common::String &str, int x, int y, uint8 
 	colorMap[3] = c1;
 	_screen->setTextColor(colorMap, 0, 3);
 	_screen->_charSpacing = -2;
-	_screen->printText(str.c_str(), x, y, c0, c2);
+
+	Common::String revBuffer;
+	const char *cstr = str.c_str();
+	if (_vm->gameFlags().lang == Common::HE_ISR) {
+		for (int i = str.size() - 1; i >= 0; --i)
+			revBuffer += str[i];
+		cstr = revBuffer.c_str();
+	}
+
+	_screen->printText(cstr, x, y, c0, c2);
 	_screen->_charSpacing = 0;
 }
 


### PR DESCRIPTION
Following #2683 and #3277


this PR adds support for hebrew fan translation of Legend of Kyrandia 3: Malcolm's Revenge
changes:
Add kyra3 hebrew fan translation detection entry*
Add kyra3 hebrew strings to KYRA.DAT (+Bump KYRA.DAT version)
Reverse strings in the family album and align to the right
Adjust ordering of object action strings
Adjust scores display

Thank you

(*)A new macro `KYRA3_CD_INS_FAN_FLAGS` was introduced to allow the translation patch to work with GOG version (in which the westwood installer is not unpacked**).
(**)IMHO, it might better to move this logic away from detection (merge duplicated installer/installed entries in detections), and just try to load the installer file if it exists, but it is out of scope for this PR😅. (If this suggestion seems OK I will open another PR with it)