### PR TITLE
MOHAWK: Add detection entry for Hebrew release of Just Grandma and Me

### DIFF
--- a/engines/mohawk/detection_tables.h
+++ b/engines/mohawk/detection_tables.h
@@ -1528,6 +1528,23 @@ static const MohawkGameDescription gameDescriptions[] = {
 		0
 	},
 
+	// Just Grandma and Me 2.0
+	// Hebrew CD
+	{
+		{
+			"grandma",
+			"v2.0",
+			AD_ENTRY1("LBPLAY32.LB", "28f6d88dae354a3c17ea0e59c771bff7"),
+			Common::HE_ISR,
+			Common::kPlatformWindows,
+			ADGF_UNSTABLE,
+			GUIO1(GUIO_NOASPECT)
+		},
+		GType_LIVINGBOOKSV3,
+		0,
+		0
+	},
+
 	// Just Grandma and Me
 	// From bug Trac #6745
 	{


### PR DESCRIPTION
This adds detection entry for the unsupported* Hebrew CD release of "Just Grandma and Me"

(*)Game has graphical glitches when played

I assumed it v2 beacuse outline filename extension is LB, as v2 examples in wiki

+ checking the EXE in hex viewer it says "Living Books Player v2"