### PR TITLE
DOCS: fix talkspeed explanation

### DIFF
--- a/doc/docportal/settings/audio.rst
+++ b/doc/docportal/settings/audio.rst
@@ -63,7 +63,7 @@ Text and Speech
 .. _talkspeed:
 
 Subtitle speed
-	Adjusts the length of time that the subtitles are displayed on screen. The lower the speed is set, the longer the subtitles are displayed.
+	Adjusts the length of time that the subtitles are displayed on screen. The higher the value, the longer the subtitles are displayed.
 
 	*talkspeed*
 


### PR DESCRIPTION
Playing around with the "talkspeed" values, the name of this setting may be counter-intuitive:
Higher values do not mean higher speed. Instead they lead to higher (longer) display time.
In other words, talkspeed zero is fast, 255 is slow.
Related discussion (from 2008, though): https://forums.scummvm.org/viewtopic.php?t=6496
