### PR TITLE
ENGINES: Use ADExtraGuiOptionsMap for the options in engines using AdvancedMetaEngineDetection

### DIFF
--- a/common/gui_options.h
+++ b/common/gui_options.h
@@ -111,6 +111,9 @@
 #define GUIO7(a,b,c,d,e,f,g) (a b c d e f g)
 #define GUIO8(a,b,c,d,e,f,g,h) (a b c d e f g h)
 #define GUIO9(a,b,c,d,e,f,g,h,i) (a b c d e f g h i)
+#define GUIO10(a,b,c,d,e,f,g,h,i,j) (a b c d e f g h i j)
+#define GUIO11(a,b,c,d,e,f,g,h,i,j,k) (a b c d e f g h i j k)
+#define GUIO12(a,b,c,d,e,f,g,h,i,j,k,l) (a b c d e f g h i j k l)
 
 namespace Common {
 

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -382,7 +382,7 @@ public:
 	 *
 	 * @return A list of extra GUI options for an engine plugin and target.
 	 */
-	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
+	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override final;
 
 	static Common::StringArray getPathsFromEntry(const ADGameDescription *g);
 

--- a/engines/agos/detection.cpp
+++ b/engines/agos/detection.cpp
@@ -73,45 +73,72 @@ static const char *const directoryGlobs[] = {
 
 using namespace AGOS;
 
-static const ExtraGuiOption opl3Mode = {
-	_s("AdLib OPL3 mode"),
-	_s("When AdLib is selected, OPL3 features will be used. Depending on the game, this will prevent cut-off notes, add extra notes or instruments and/or add stereo."),
-	"opl3_mode",
-	false,
-	0,
-	0
+namespace AGOS {
+
+static const ADExtraGuiOptionsMap optionsList[] = {
+	{
+		GAMEOPTION_OPL3_MODE,
+		{
+			_s("AdLib OPL3 mode"),
+			_s("When AdLib is selected, OPL3 features will be used. Depending on the game, this will prevent cut-off notes, add extra notes or instruments and/or add stereo."),
+			"opl3_mode",
+			false,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_DOS_TEMPOS,
+		{
+			_s("Use DOS version music tempos"),
+			_s("Selecting this option will play the music using the tempos used by the DOS version of the game. Otherwise, the faster tempos of the Windows version will be used."),
+			"dos_music_tempos",
+			true,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_WINDOWS_TEMPOS,
+		{
+			_s("Use DOS version music tempos"),
+			_s("Selecting this option will play the music using the tempos used by the DOS version of the game. Otherwise, the faster tempos of the Windows version will be used."),
+			"dos_music_tempos",
+			false,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_PREFER_DIGITAL_SFX,
+		{
+			_s("Prefer digital sound effects"),
+			_s("Prefer digital sound effects instead of synthesized ones"),
+			"prefer_digitalsfx",
+			true,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_DISABLE_FADE_EFFECTS,
+		{
+			_s("Disable fade-out effects"),
+			_s("Don't fade every screen to black when leaving a room."),
+			"disable_fade_effects",
+			false,
+			0,
+			0
+		}
+	},
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-static const ExtraGuiOption useDosTempos = {
-	_s("Use DOS version music tempos"),
-	_s("Selecting this option will play the music using the tempos used by the DOS version of the game. Otherwise, the faster tempos of the Windows version will be used."),
-	"dos_music_tempos",
-	false,
-	0,
-	0
-};
-
-static const ExtraGuiOption preferDigitalSfx = {
-	_s("Prefer digital sound effects"),
-	_s("Prefer digital sound effects instead of synthesized ones"),
-	"prefer_digitalsfx",
-	true,
-	0,
-	0
-};
-
-static const ExtraGuiOption disableFadeEffects = {
-	_s("Disable fade-out effects"),
-	_s("Don't fade every screen to black when leaving a room."),
-	"disable_fade_effects",
-	false,
-	0,
-	0
-};
+} // End of namespace AGOS
 
 class AgosMetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
-	AgosMetaEngineDetection() : AdvancedMetaEngineDetection(AGOS::gameDescriptions, sizeof(AGOS::AGOSGameDescription), agosGames) {
+	AgosMetaEngineDetection() : AdvancedMetaEngineDetection(AGOS::gameDescriptions, sizeof(AGOS::AGOSGameDescription), agosGames, AGOS::optionsList) {
 		_guiOptions = GUIO1(GUIO_NOLAUNCHLOAD);
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
@@ -135,38 +162,6 @@ public:
 
 	const DebugChannelDef *getDebugChannels() const override {
 		return debugFlagList;
-	}
-
-	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override {
-		const Common::String gameid = ConfMan.get("gameid", target);
-		const Common::String platform = ConfMan.get("platform", target);
-		const Common::String extra = ConfMan.get("extra", target);
-
-		ExtraGuiOptions options;
-		if (target.empty() || ((gameid == "elvira1" || gameid == "elvira2" || gameid == "waxworks" || gameid == "simon1") && platform == "pc")) {
-			// DOS versions of Elvira 1 and 2, Waxworks and Simon 1 can
-			// optionally make use of AdLib OPL3 features.
-			options.push_back(opl3Mode);
-		}
-		if (target.empty() || (gameid == "simon1" && ((platform == "pc" && extra != "Floppy Demo") || platform == "windows" ||
-				(platform == "acorn" && extra.contains("CD"))))) {
-			// Simon 1 DOS (except the floppy demo), Windows and Acorn CD can
-			// choose between the DOS or Windows music tempos.
-			ExtraGuiOption dosTemposOption = useDosTempos;
-			// DOS tempos are default for the DOS versions; other versions use
-			// the Windows tempos by default.
-			dosTemposOption.defaultState = platform == "pc";
-			options.push_back(dosTemposOption);
-		}
-		if (target.empty() || ((gameid == "elvira2" || gameid == "waxworks") && platform == "pc")) {
-			// DOS versions of Elvira 2 and Waxworks can use either Adlib or
-			// digital SFX.
-			options.push_back(preferDigitalSfx);
-		}
-		if (target.empty() || gameid == "simon1" || gameid == "simon2") {
-			options.push_back(disableFadeEffects);
-		}
-		return options;
 	}
 };
 

--- a/engines/agos/detection_tables.h
+++ b/engines/agos/detection_tables.h
@@ -19,6 +19,12 @@
  *
  */
 
+#define GAMEOPTION_OPL3_MODE            GUIO_GAMEOPTIONS1
+#define GAMEOPTION_DOS_TEMPOS           GUIO_GAMEOPTIONS2
+#define GAMEOPTION_WINDOWS_TEMPOS       GUIO_GAMEOPTIONS3
+#define GAMEOPTION_PREFER_DIGITAL_SFX   GUIO_GAMEOPTIONS4
+#define GAMEOPTION_DISABLE_FADE_EFFECTS GUIO_GAMEOPTIONS5
+
 namespace AGOS {
 
 static const AGOSGameDescription gameDescriptions[] = {
@@ -284,7 +290,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_DEMO,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE)
 		},
 
 		GType_ELVIRA1,
@@ -307,7 +313,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE)
 		},
 
 		GType_ELVIRA1,
@@ -330,7 +336,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::CS_CZE,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE)
 		},
 
 		GType_ELVIRA1,
@@ -353,7 +359,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE)
 		},
 
 		GType_ELVIRA1,
@@ -376,7 +382,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE)
 		},
 
 		GType_ELVIRA1,
@@ -399,7 +405,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE)
 		},
 
 		GType_ELVIRA1,
@@ -630,7 +636,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO3(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_PREFER_DIGITAL_SFX)
 		},
 
 		GType_ELVIRA2,
@@ -656,7 +662,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO3(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_PREFER_DIGITAL_SFX)
 		},
 
 		GType_ELVIRA2,
@@ -682,7 +688,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO3(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_PREFER_DIGITAL_SFX)
 		},
 
 		GType_ELVIRA2,
@@ -708,7 +714,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::CS_CZE,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO3(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_PREFER_DIGITAL_SFX)
 		},
 
 		GType_ELVIRA2,
@@ -734,7 +740,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO3(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_PREFER_DIGITAL_SFX)
 		},
 
 		GType_ELVIRA2,
@@ -760,7 +766,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO3(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_PREFER_DIGITAL_SFX)
 		},
 
 		GType_ELVIRA2,
@@ -786,7 +792,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO3(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_PREFER_DIGITAL_SFX)
 		},
 
 		GType_ELVIRA2,
@@ -812,7 +818,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO3(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_PREFER_DIGITAL_SFX)
 		},
 
 		GType_ELVIRA2,
@@ -838,7 +844,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO3(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_PREFER_DIGITAL_SFX)
 		},
 
 		GType_ELVIRA2,
@@ -943,7 +949,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_DEMO,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO3(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_PREFER_DIGITAL_SFX)
 		},
 
 		GType_WW,
@@ -972,7 +978,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO3(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_PREFER_DIGITAL_SFX)
 		},
 
 		GType_WW,
@@ -1001,7 +1007,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO3(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_PREFER_DIGITAL_SFX)
 		},
 
 		GType_WW,
@@ -1030,7 +1036,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO3(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_PREFER_DIGITAL_SFX)
 		},
 
 		GType_WW,
@@ -1059,7 +1065,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO3(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_PREFER_DIGITAL_SFX)
 		},
 
 		GType_WW,
@@ -1083,7 +1089,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformAcorn,
 			ADGF_NO_FLAGS,
-			GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI)
+			GUIO3(GUIO_NOSPEECH, GUIO_NOMIDI, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1108,7 +1114,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformAcorn,
 			ADGF_DEMO,
-			GUIO1(GUIO_NOSUBTITLES)
+			GUIO3(GUIO_NOSUBTITLES, GAMEOPTION_WINDOWS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1133,7 +1139,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformAcorn,
 			ADGF_CD,
-			GUIO1(GUIO_NOSUBTITLES)
+			GUIO3(GUIO_NOSUBTITLES, GAMEOPTION_WINDOWS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1157,7 +1163,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformAmiga,
 			ADGF_NO_FLAGS,
-			GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI)
+			GUIO3(GUIO_NOSPEECH, GUIO_NOMIDI, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1181,7 +1187,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformAmiga,
 			ADGF_DEMO,
-			GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI)
+			GUIO3(GUIO_NOSPEECH, GUIO_NOMIDI, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1205,7 +1211,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformAmiga,
 			ADGF_NO_FLAGS,
-			GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI)
+			GUIO3(GUIO_NOSPEECH, GUIO_NOMIDI, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1229,7 +1235,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformAmiga,
 			ADGF_NO_FLAGS,
-			GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI)
+			GUIO3(GUIO_NOSPEECH, GUIO_NOMIDI, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1253,7 +1259,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformAmiga,
 			ADGF_NO_FLAGS,
-			GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI)
+			GUIO3(GUIO_NOSPEECH, GUIO_NOMIDI, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1277,7 +1283,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformAmiga,
 			ADGF_NO_FLAGS,
-			GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI)
+			GUIO3(GUIO_NOSPEECH, GUIO_NOMIDI, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1301,7 +1307,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformAmiga,
 			ADGF_NO_FLAGS,
-			GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI)
+			GUIO3(GUIO_NOSPEECH, GUIO_NOMIDI, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1326,7 +1332,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformAmiga,
 			ADGF_NO_FLAGS,
-			GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI)
+			GUIO3(GUIO_NOSPEECH, GUIO_NOMIDI, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1350,7 +1356,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformAmiga,
 			ADGF_CD,
-			GUIO2(GUIO_NOSUBTITLES, GUIO_NOMIDI)
+			GUIO3(GUIO_NOSUBTITLES, GUIO_NOMIDI, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1374,7 +1380,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformAmiga,
 			ADGF_CD,
-			GUIO2(GUIO_NOSUBTITLES, GUIO_NOMIDI)
+			GUIO3(GUIO_NOSUBTITLES, GUIO_NOMIDI, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1399,7 +1405,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformAmiga,
 			ADGF_CD | ADGF_DEMO,
-			GUIO2(GUIO_NOSUBTITLES, GUIO_NOMIDI)
+			GUIO3(GUIO_NOSUBTITLES, GUIO_NOMIDI, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1424,7 +1430,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_DEMO,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO3(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1448,7 +1454,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO4(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1472,7 +1478,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::CS_CZE,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO4(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1496,7 +1502,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::RU_RUS,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO4(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1520,7 +1526,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO4(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1544,7 +1550,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::CS_CZE,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO4(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1568,7 +1574,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::RU_RUS,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO4(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1592,7 +1598,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO4(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1616,7 +1622,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO4(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1640,7 +1646,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO4(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1664,7 +1670,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO4(GUIO_NOSPEECH, GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1689,7 +1695,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_DEMO,
-			GUIO1(GUIO_NOSUBTITLES)
+			GUIO4(GUIO_NOSUBTITLES, GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1715,7 +1721,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_DEMO,
-			GUIO1(GUIO_NOSUBTITLES)
+			GUIO4(GUIO_NOSUBTITLES, GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1740,7 +1746,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO1(GUIO_NOSUBTITLES)
+			GUIO4(GUIO_NOSUBTITLES, GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1765,7 +1771,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO1(GUIO_NOSUBTITLES)
+			GUIO4(GUIO_NOSUBTITLES, GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1790,7 +1796,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::RU_RUS,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO3(GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1815,7 +1821,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO3(GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1840,7 +1846,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSUBTITLES)
+			GUIO4(GUIO_NOSUBTITLES, GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1865,7 +1871,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::HE_ISR,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO3(GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1890,7 +1896,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::HE_ISR,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO3(GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1915,7 +1921,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO3(GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1941,7 +1947,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformWindows,
 			ADGF_CD,
-			GUIO0()
+			GUIO3(GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1966,7 +1972,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO3(GAMEOPTION_OPL3_MODE, GAMEOPTION_DOS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -1991,7 +1997,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_CD,
-			GUIO1(GUIO_NOSUBTITLES)
+			GUIO3(GUIO_NOSUBTITLES, GAMEOPTION_WINDOWS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -2016,7 +2022,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformWindows,
 			ADGF_CD,
-			GUIO1(GUIO_NOSUBTITLES)
+			GUIO3(GUIO_NOSUBTITLES, GAMEOPTION_WINDOWS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,
@@ -2041,7 +2047,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2066,7 +2072,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::RU_RUS,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2091,7 +2097,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2116,7 +2122,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2141,7 +2147,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2166,7 +2172,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_DEMO,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2191,7 +2197,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_DEMO,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2216,7 +2222,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_DEMO,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2241,7 +2247,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2266,7 +2272,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2291,7 +2297,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2316,7 +2322,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2341,7 +2347,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2366,7 +2372,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::HE_ISR,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2392,7 +2398,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformWindows,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2417,7 +2423,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2442,7 +2448,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::RU_RUS,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2467,7 +2473,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::CS_CZE,
 			Common::kPlatformWindows,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2492,7 +2498,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2517,7 +2523,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformWindows,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2542,7 +2548,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformWindows,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2567,7 +2573,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::PL_POL,
 			Common::kPlatformWindows,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2593,7 +2599,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::PL_POL,
 			Common::kPlatformWindows,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2619,7 +2625,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2644,7 +2650,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::RU_RUS,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2669,7 +2675,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::PL_POL,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2694,7 +2700,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::HE_ISR,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2719,7 +2725,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2744,7 +2750,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::CS_CZE,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,
@@ -2769,7 +2775,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON2,

--- a/engines/drascula/detection.cpp
+++ b/engines/drascula/detection.cpp
@@ -27,6 +27,8 @@
 
 #include "drascula/detection.h"
 
+#define GAMEOPTION_ORIGINAL_SAVELOAD      GUIO_GAMEOPTIONS1
+
 static const PlainGameDescriptor drasculaGames[] = {
 	{"drascula", "Drascula: The Vampire Strikes Back"},
 	{nullptr, nullptr}
@@ -294,19 +296,25 @@ static const DrasculaGameDescription gameDescriptions[] = {
 	{ AD_TABLE_END_MARKER }
 };
 
-static const ExtraGuiOption drasculaExtraGuiOption = {
-	_s("Use original save/load screens"),
-	_s("Use the original save/load screens instead of the ScummVM ones"),
-	"originalsaveload",
-	false,
-	0,
-	0
+static const ADExtraGuiOptionsMap optionsList[] = {
+	{
+		GAMEOPTION_ORIGINAL_SAVELOAD,
+		{
+			_s("Use original save/load screens"),
+			_s("Use the original save/load screens instead of the ScummVM ones"),
+			"originalsaveload",
+			false,
+			0,
+			0
+		}
+	},
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
 class DrasculaMetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
-	DrasculaMetaEngineDetection() : AdvancedMetaEngineDetection(Drascula::gameDescriptions, sizeof(Drascula::DrasculaGameDescription), drasculaGames) {
-		_guiOptions = GUIO1(GUIO_NOMIDI);
+	DrasculaMetaEngineDetection() : AdvancedMetaEngineDetection(Drascula::gameDescriptions, sizeof(Drascula::DrasculaGameDescription), drasculaGames, Drascula::optionsList) {
+		_guiOptions = GUIO2(GUIO_NOMIDI, GAMEOPTION_ORIGINAL_SAVELOAD);
 	}
 
 	const char *getEngineId() const override {
@@ -320,15 +328,7 @@ public:
 	const char *getOriginalCopyright() const override {
 		return "Drascula: The Vampire Strikes Back (C) 2000 Alcachofa Soft, (C) 1996 Digital Dreams Multimedia, (C) 1994 Emilio de Paz";
 	}
-
-	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
 };
-
-const ExtraGuiOptions DrasculaMetaEngineDetection::getExtraGuiOptions(const Common::String &target) const {
-	ExtraGuiOptions options;
-	options.push_back(drasculaExtraGuiOption);
-	return options;
-}
 
 } // End of namespace Drascula
 

--- a/engines/hypno/detection.cpp
+++ b/engines/hypno/detection.cpp
@@ -24,6 +24,12 @@
 #include "engines/advancedDetector.h"
 #include "hypno/hypno.h"
 
+#define GAMEOPTION_ORIGINAL_CHEATS   GUIO_GAMEOPTIONS1
+#define GAMEOPTION_INFINITE_HEALTH   GUIO_GAMEOPTIONS2
+#define GAMEOPTION_INFINITE_AMMO     GUIO_GAMEOPTIONS3
+#define GAMEOPTION_UNLOCK_ALL_LEVELS GUIO_GAMEOPTIONS4
+#define GAMEOPTION_RESTORED_CONTENT  GUIO_GAMEOPTIONS5
+
 static const DebugChannelDef debugFlagList[] = {
 	{Hypno::kHypnoDebugMedia, "media", "Media debug channel"},
 	{Hypno::kHypnoDebugParser, "parser", "Parser debug channel"},
@@ -234,6 +240,66 @@ static const ADGameDescription gameDescriptions[] = {
 	},
 	AD_TABLE_END_MARKER
 };
+
+static const ADExtraGuiOptionsMap optionsList[] = {
+	{
+		GAMEOPTION_ORIGINAL_CHEATS,
+		{
+			_s("Enable original cheats"),
+			_s("Allow cheats using the C key."),
+			"cheats",
+			true,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_INFINITE_HEALTH,
+		{
+			_s("Enable infinite health cheat"),
+			_s("Player health will never decrease (except for game over scenes)."),
+			"infiniteHealth",
+			false,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_INFINITE_AMMO,
+		{
+			_s("Enable infinite ammo cheat"),
+			_s("Player ammo will never decrease."),
+			"infiniteAmmo",
+			false,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_UNLOCK_ALL_LEVELS,
+		{
+			_s("Unlock all levels"),
+			_s("All levels will be available to play."),
+			"unlockAllLevels",
+			false,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_RESTORED_CONTENT,
+		{
+			_s("Enable restored content"),
+			_s("Add additional content that is not enabled the original implementation."),
+			"restored",
+			true,
+			0,
+			0
+		}
+	},
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR
+};
+
 } // End of namespace Hypno
 
 static const char *const directoryGlobs[] = {
@@ -250,55 +316,10 @@ static const char *const directoryGlobs[] = {
 	nullptr
 };
 
-static const ExtraGuiOption hypnoExtraGuiOptionOriginalCheats = {
-	_s("Enable original cheats"),
-	_s("Allow cheats using the C key."),
-	"cheats",
-	true,
-	0,
-	0
-};
-
-static const ExtraGuiOption hypnoExtraGuiOptionInfiniteHealthCheat = {
-	_s("Enable infinite health cheat"),
-	_s("Player health will never decrease (except for game over scenes)."),
-	"infiniteHealth",
-	false,
-	0,
-	0
-};
-
-static const ExtraGuiOption hypnoExtraGuiOptionInfiniteAmmoCheat = {
-	_s("Enable infinite ammo cheat"),
-	_s("Player ammo will never decrease."),
-	"infiniteAmmo",
-	false,
-	0,
-	0
-};
-
-static const ExtraGuiOption hypnoExtraGuiOptionUnlockAllLevels = {
-	_s("Unlock all levels"),
-	_s("All levels will be available to play."),
-	"unlockAllLevels",
-	false,
-	0,
-	0
-};
-
-static const ExtraGuiOption hypnoExtraGuiOptionRestoredContent = {
-	_s("Enable restored content"),
-	_s("Add additional content that is not enabled the original implementation."),
-	"restored",
-	true,
-	0,
-	0
-};
-
 class HypnoMetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
-	HypnoMetaEngineDetection() : AdvancedMetaEngineDetection(Hypno::gameDescriptions, sizeof(ADGameDescription), Hypno::hypnoGames) {
-		_guiOptions = GUIO1(GUIO_NOMIDI);
+	HypnoMetaEngineDetection() : AdvancedMetaEngineDetection(Hypno::gameDescriptions, sizeof(ADGameDescription), Hypno::hypnoGames, Hypno::optionsList) {
+		_guiOptions = GUIO6(GUIO_NOMIDI, GAMEOPTION_ORIGINAL_CHEATS, GAMEOPTION_INFINITE_HEALTH, GAMEOPTION_INFINITE_AMMO, GAMEOPTION_UNLOCK_ALL_LEVELS, GAMEOPTION_RESTORED_CONTENT);
 		_maxScanDepth = 3;
 		_directoryGlobs = directoryGlobs;
 	}
@@ -320,19 +341,7 @@ public:
 	const DebugChannelDef *getDebugChannels() const override {
 		return debugFlagList;
 	}
-
-	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
 };
-
-const ExtraGuiOptions HypnoMetaEngineDetection::getExtraGuiOptions(const Common::String &target) const {
-	ExtraGuiOptions options;
-	options.push_back(hypnoExtraGuiOptionOriginalCheats);
-	options.push_back(hypnoExtraGuiOptionInfiniteHealthCheat);
-	options.push_back(hypnoExtraGuiOptionInfiniteAmmoCheat);
-	options.push_back(hypnoExtraGuiOptionRestoredContent);
-	options.push_back(hypnoExtraGuiOptionUnlockAllLevels);
-	return options;
-}
 
 REGISTER_PLUGIN_STATIC(HYPNO_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, HypnoMetaEngineDetection);
 

--- a/engines/made/detection.cpp
+++ b/engines/made/detection.cpp
@@ -36,9 +36,28 @@ static const PlainGameDescriptor madeGames[] = {
 
 #include "made/detection_tables.h"
 
+namespace Made {
+
+static const ADExtraGuiOptionsMap optionsList[] = {
+	{
+		GAMEOPTION_INTRO_MUSIC_DIGITAL,
+		{
+			_s("Play a digital soundtrack during the opening movie"),
+			_s("If selected, the game will use a digital soundtrack during the introduction. Otherwise, it will play MIDI music."),
+			"intro_music_digital",
+			true,
+			0,
+			0
+		}
+	},
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR
+};
+
+} // End of namespace Made
+
 class MadeMetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
-	MadeMetaEngineDetection() : AdvancedMetaEngineDetection(Made::gameDescriptions, sizeof(Made::MadeGameDescription), madeGames) {
+	MadeMetaEngineDetection() : AdvancedMetaEngineDetection(Made::gameDescriptions, sizeof(Made::MadeGameDescription), madeGames, Made::optionsList) {
 	}
 
 	const char *getEngineId() const override {
@@ -53,30 +72,8 @@ public:
 		return "MADE Engine (C) Activision";
 	}
 
-	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
-
 	ADDetectedGame fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist, ADDetectedGameExtraInfo **extra) const override;
 };
-
-static const ExtraGuiOption introMusicDigital = {
-	_s("Play a digital soundtrack during the opening movie"),
-	_s("If selected, the game will use a digital soundtrack during the introduction. Otherwise, it will play MIDI music."),
-	"intro_music_digital",
-	true,
-	0,
-	0
-};
-
-const ExtraGuiOptions MadeMetaEngineDetection::getExtraGuiOptions(const Common::String &target) const {
-	const Common::String gameid = ConfMan.get("gameid", target);
-	const Common::String extra = ConfMan.get("extra", target);
-
-	ExtraGuiOptions options;
-	if (target.empty() || (gameid == "rtz" && extra.contains("CD"))) {
-		options.push_back(introMusicDigital);
-	}
-	return options;
-}
 
 ADDetectedGame MadeMetaEngineDetection::fallbackDetect(const FileMap &allFiles, const Common::FSList &fslist, ADDetectedGameExtraInfo **extra) const {
 	// Set the default values for the fallback descriptor's ADGameDescription part.

--- a/engines/made/detection_tables.h
+++ b/engines/made/detection_tables.h
@@ -25,6 +25,8 @@
 #include "engines/advancedDetector.h"
 #include "common/translation.h"
 
+#define GAMEOPTION_INTRO_MUSIC_DIGITAL GUIO_GAMEOPTIONS1
+
 namespace Made {
 
 static const MadeGameDescription gameDescriptions[] = {
@@ -43,7 +45,7 @@ static const MadeGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO0()
+			GUIO1(GAMEOPTION_INTRO_MUSIC_DIGITAL)
 		},
 		GID_RTZ,
 		0,
@@ -61,7 +63,7 @@ static const MadeGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_INTRO_MUSIC_DIGITAL)
 		},
 		GID_RTZ,
 		0,
@@ -78,7 +80,7 @@ static const MadeGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_INTRO_MUSIC_DIGITAL)
 		},
 		GID_RTZ,
 		0,
@@ -95,7 +97,7 @@ static const MadeGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_INTRO_MUSIC_DIGITAL)
 		},
 		GID_RTZ,
 		0,
@@ -112,7 +114,7 @@ static const MadeGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_INTRO_MUSIC_DIGITAL)
 		},
 		GID_RTZ,
 		0,
@@ -130,7 +132,7 @@ static const MadeGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_INTRO_MUSIC_DIGITAL)
 		},
 		GID_RTZ,
 		0,
@@ -151,7 +153,7 @@ static const MadeGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_INTRO_MUSIC_DIGITAL)
 		},
 		GID_RTZ,
 		0,
@@ -169,7 +171,7 @@ static const MadeGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_INTRO_MUSIC_DIGITAL)
 		},
 		GID_RTZ,
 		0,
@@ -187,7 +189,7 @@ static const MadeGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_INTRO_MUSIC_DIGITAL)
 		},
 		GID_RTZ,
 		0,
@@ -205,7 +207,7 @@ static const MadeGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_INTRO_MUSIC_DIGITAL)
 		},
 		GID_RTZ,
 		0,
@@ -223,7 +225,7 @@ static const MadeGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_INTRO_MUSIC_DIGITAL)
 		},
 		GID_RTZ,
 		0,
@@ -241,7 +243,7 @@ static const MadeGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_INTRO_MUSIC_DIGITAL)
 		},
 		GID_RTZ,
 		0,
@@ -259,7 +261,7 @@ static const MadeGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_INTRO_MUSIC_DIGITAL)
 		},
 		GID_RTZ,
 		0,
@@ -282,7 +284,7 @@ static const MadeGameDescription gameDescriptions[] = {
 			Common::KO_KOR,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_INTRO_MUSIC_DIGITAL)
 		},
 		GID_RTZ,
 		0,
@@ -333,7 +335,7 @@ static const MadeGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_DEMO | ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_INTRO_MUSIC_DIGITAL)
 		},
 		GID_RTZ,
 		0,
@@ -351,7 +353,7 @@ static const MadeGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_DEMO | ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_INTRO_MUSIC_DIGITAL)
 		},
 		GID_RTZ,
 		0,
@@ -370,7 +372,7 @@ static const MadeGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformMacintosh,
 			ADGF_DEMO | ADGF_CD | ADGF_MACRESFORK,
-			GUIO0()
+			GUIO1(GAMEOPTION_INTRO_MUSIC_DIGITAL)
 		},
 		GID_RTZ,
 		0,

--- a/engines/mtropolis/detection.cpp
+++ b/engines/mtropolis/detection.cpp
@@ -34,6 +34,58 @@ static const PlainGameDescriptor mTropolisGames[] = {
 
 #include "mtropolis/detection_tables.h"
 
+namespace MTropolis {
+
+static const ADExtraGuiOptionsMap optionsList[] = {
+	{
+		GAMEOPTION_WIDESCREEN_MOD,
+		{
+			_s("16:9 Widescreen Mod"),
+			_s("Removes letterboxing and moves some display elements, improving coverage on widescreen displays"),
+			"mtropolis_mod_obsidian_widescreen",
+			false,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_DYNAMIC_MIDI,
+		{
+			_s("Improved Music Mixing"),
+			_s("Enables dynamic MIDI mixer, improving quality, but behaving less like mTropolis Player."),
+			"mtropolis_mod_dynamic_midi",
+			true,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_LAUNCH_DEBUG,
+		{
+			_s("Start with debugger"),
+			_s("Starts with the debugger dashboard active"),
+			"mtropolis_debug_at_start",
+			false,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_LAUNCH_BREAK,
+		{
+			_s("Start debugging immediately"),
+			_s("Halts progress and stops at the debugger immediately"),
+			"mtropolis_pause_at_start",
+			false,
+			0,
+			0
+		}
+	},
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR
+};
+
+} // End of namespace MTropolis
+
 static const char *directoryGlobs[] = {
 	"Obsidian",
 	"RESOURCE",
@@ -43,7 +95,8 @@ static const char *directoryGlobs[] = {
 
 class MTropolisMetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
-	MTropolisMetaEngineDetection() : AdvancedMetaEngineDetection(MTropolis::gameDescriptions, sizeof(MTropolis::MTropolisGameDescription), mTropolisGames) {
+	MTropolisMetaEngineDetection() : AdvancedMetaEngineDetection(MTropolis::gameDescriptions, sizeof(MTropolis::MTropolisGameDescription), mTropolisGames, MTropolis::optionsList) {
+		_guiOptions = GUIO3(GAMEOPTION_DYNAMIC_MIDI, GAMEOPTION_LAUNCH_DEBUG, GAMEOPTION_LAUNCH_BREAK);
 		_maxScanDepth = 3;
 		_directoryGlobs = directoryGlobs;
 	}
@@ -59,57 +112,6 @@ public:
 	const char *getOriginalCopyright() const override {
 		return "mTropolis (C) mFactory/Quark";
 	}
-
-	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
 };
-
-const ExtraGuiOptions MTropolisMetaEngineDetection::getExtraGuiOptions(const Common::String &target) const {
-	ExtraGuiOptions options;
-
-	Common::String gameid = ConfMan.get("gameid", target);
-
-	if (gameid == "obsidian") {
-		static const ExtraGuiOption widescreenOption = {
-			_s("16:9 Widescreen Mod"),
-			_s("Removes letterboxing and moves some display elements, improving coverage on widescreen displays"),
-			"mtropolis_mod_obsidian_widescreen",
-			false,
-			0,
-			0};
-
-		options.push_back(widescreenOption);
-	}
-
-	static const ExtraGuiOption dynamicMIDIOption = {
-		_s("Improved Music Mixing"),
-		_s("Enables dynamic MIDI mixer, improving quality, but behaving less like mTropolis Player."),
-		"mtropolis_mod_dynamic_midi",
-		true,
-		0,
-		0};
-
-	static const ExtraGuiOption launchDebugOption = {
-		_s("Start with debugger"),
-		_s("Starts with the debugger dashboard active"),
-		"mtropolis_debug_at_start",
-		false,
-		0,
-		0
-	};
-	static const ExtraGuiOption launchBreakOption = {
-		_s("Start debugging immediately"),
-		_s("Halts progress and stops at the debugger immediately"),
-		"mtropolis_pause_at_start",
-		false,
-		0,
-		0
-	};
-
-	options.push_back(dynamicMIDIOption);
-	options.push_back(launchDebugOption);
-	options.push_back(launchBreakOption);
-
-	return options;
-}
 
 REGISTER_PLUGIN_STATIC(MTROPOLIS_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, MTropolisMetaEngineDetection);

--- a/engines/mtropolis/detection_tables.h
+++ b/engines/mtropolis/detection_tables.h
@@ -26,6 +26,11 @@
 
 #include "mtropolis/detection.h"
 
+#define GAMEOPTION_WIDESCREEN_MOD GUIO_GAMEOPTIONS1
+#define GAMEOPTION_DYNAMIC_MIDI   GUIO_GAMEOPTIONS2
+#define GAMEOPTION_LAUNCH_DEBUG   GUIO_GAMEOPTIONS3
+#define GAMEOPTION_LAUNCH_BREAK   GUIO_GAMEOPTIONS4
+
 namespace MTropolis {
 
 static const MTropolisGameDescription gameDescriptions[] = {
@@ -46,7 +51,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformMacintosh,
 			ADGF_UNSTABLE,
-			GUIO0()
+			GUIO1(GAMEOPTION_WIDESCREEN_MOD)
 		},
 		GID_OBSIDIAN,
 		0,
@@ -74,7 +79,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_UNSTABLE,
-			GUIO0()
+			GUIO1(GAMEOPTION_WIDESCREEN_MOD)
 		},
 		GID_OBSIDIAN,
 		0,
@@ -101,7 +106,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformWindows,
 			ADGF_UNSTABLE,
-			GUIO0()
+			GUIO1(GAMEOPTION_WIDESCREEN_MOD)
 		},
 		GID_OBSIDIAN,
 		0,
@@ -127,7 +132,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformMacintosh,
 			ADGF_DEMO | ADGF_UNSTABLE,
-			GUIO0()
+			GUIO1(GAMEOPTION_WIDESCREEN_MOD)
 		},
 		GID_OBSIDIAN,
 		0,
@@ -150,7 +155,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_DEMO | ADGF_UNSTABLE,
-			GUIO0()
+			GUIO1(GAMEOPTION_WIDESCREEN_MOD)
 		},
 		GID_OBSIDIAN,
 		0,
@@ -173,7 +178,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_DEMO | ADGF_UNSTABLE,
-			GUIO0()
+			GUIO1(GAMEOPTION_WIDESCREEN_MOD)
 		},
 		GID_OBSIDIAN,
 		0,
@@ -196,7 +201,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_DEMO | ADGF_UNSTABLE,
-			GUIO0()
+			GUIO1(GAMEOPTION_WIDESCREEN_MOD)
 		},
 		GID_OBSIDIAN,
 		0,
@@ -219,7 +224,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_DEMO | ADGF_UNSTABLE,
-			GUIO0()
+			GUIO1(GAMEOPTION_WIDESCREEN_MOD)
 		},
 		GID_OBSIDIAN,
 		0,

--- a/engines/neverhood/detection.cpp
+++ b/engines/neverhood/detection.cpp
@@ -27,6 +27,10 @@
 
 #include "neverhood/detection.h"
 
+#define GAMEOPTION_ORIGINAL_SAVELOAD      GUIO_GAMEOPTIONS1
+#define GAMEOPTION_SKIP_HALL_OF_RECORDS   GUIO_GAMEOPTIONS2
+#define GAMEOPTION_SCALE_MAKING_OF_VIDEOS GUIO_GAMEOPTIONS3
+
 static const PlainGameDescriptor neverhoodGames[] = {
 	{"neverhood", "The Neverhood Chronicles"},
 	{nullptr, nullptr}
@@ -128,40 +132,50 @@ static const ADGameDescription gameDescriptions[] = {
 	AD_TABLE_END_MARKER
 };
 
+static const ADExtraGuiOptionsMap optionsList[] = {
+	{
+		GAMEOPTION_ORIGINAL_SAVELOAD,
+		{
+			_s("Use original save/load screens"),
+			_s("Use the original save/load screens instead of the ScummVM ones"),
+			"originalsaveload",
+			false,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_SKIP_HALL_OF_RECORDS,
+		{
+			_s("Skip the Hall of Records storyboard scenes"),
+			_s("Allows the player to skip past the Hall of Records storyboard scenes"),
+			"skiphallofrecordsscenes",
+			false,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_SCALE_MAKING_OF_VIDEOS,
+		{
+			_s("Scale the making of videos to full screen"),
+			_s("Scale the making of videos, so that they use the whole screen"),
+			"scalemakingofvideos",
+			false,
+			0,
+			0
+		}
+	},
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR
+};
+
 } // End of namespace Neverhood
-
-static const ExtraGuiOption neverhoodExtraGuiOption1 = {
-	_s("Use original save/load screens"),
-	_s("Use the original save/load screens instead of the ScummVM ones"),
-	"originalsaveload",
-	false,
-	0,
-	0
-};
-
-static const ExtraGuiOption neverhoodExtraGuiOption2 = {
-	_s("Skip the Hall of Records storyboard scenes"),
-	_s("Allows the player to skip past the Hall of Records storyboard scenes"),
-	"skiphallofrecordsscenes",
-	false,
-	0,
-	0
-};
-
-static const ExtraGuiOption neverhoodExtraGuiOption3 = {
-	_s("Scale the making of videos to full screen"),
-	_s("Scale the making of videos, so that they use the whole screen"),
-	"scalemakingofvideos",
-	false,
-	0,
-	0
-};
 
 
 class NeverhoodMetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
-	NeverhoodMetaEngineDetection() : AdvancedMetaEngineDetection(Neverhood::gameDescriptions, sizeof(ADGameDescription), neverhoodGames) {
-		_guiOptions = GUIO2(GUIO_NOSUBTITLES, GUIO_NOMIDI);
+	NeverhoodMetaEngineDetection() : AdvancedMetaEngineDetection(Neverhood::gameDescriptions, sizeof(ADGameDescription), neverhoodGames, Neverhood::optionsList) {
+		_guiOptions = GUIO5(GUIO_NOSUBTITLES, GUIO_NOMIDI, GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_SKIP_HALL_OF_RECORDS, GAMEOPTION_SCALE_MAKING_OF_VIDEOS);
 	}
 
 	const char *getEngineId() const override {
@@ -175,16 +189,6 @@ public:
 	const char *getOriginalCopyright() const override {
 		return "The Neverhood Chronicles (C) The Neverhood, Inc.";
 	}
-
-	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
 };
-
-const ExtraGuiOptions NeverhoodMetaEngineDetection::getExtraGuiOptions(const Common::String &target) const {
-	ExtraGuiOptions options;
-	options.push_back(neverhoodExtraGuiOption1);
-	options.push_back(neverhoodExtraGuiOption2);
-	options.push_back(neverhoodExtraGuiOption3);
-	return options;
-}
 
 REGISTER_PLUGIN_STATIC(NEVERHOOD_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, NeverhoodMetaEngineDetection);

--- a/engines/sword25/detection.cpp
+++ b/engines/sword25/detection.cpp
@@ -43,19 +43,25 @@ static const char *directoryGlobs[] = {
 	0
 };
 
-static const ExtraGuiOption sword25ExtraGuiOption = {
-	_s("Use English speech"),
-	_s("Use English speech instead of German for every language other than German"),
-	"english_speech",
-	false,
-	0,
-	0
+static const ADExtraGuiOptionsMap optionsList[] = {
+	{
+		GAMEOPTION_ENGLISH_SPEECH,
+		{
+			_s("Use English speech"),
+			_s("Use English speech instead of German for every language other than German"),
+			"english_speech",
+			false,
+			0,
+			0
+		}
+	},
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
 class Sword25MetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
-	Sword25MetaEngineDetection() : AdvancedMetaEngineDetection(Sword25::gameDescriptions, sizeof(ADGameDescription), sword25Game) {
-		_guiOptions = GUIO1(GUIO_NOMIDI);
+	Sword25MetaEngineDetection() : AdvancedMetaEngineDetection(Sword25::gameDescriptions, sizeof(ADGameDescription), sword25Game, optionsList) {
+		_guiOptions = GUIO2(GUIO_NOMIDI, GAMEOPTION_ENGLISH_SPEECH);
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}
@@ -75,14 +81,6 @@ public:
 	const DebugChannelDef *getDebugChannels() const override {
 		return debugFlagList;
 	}
-
-	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
 };
-
-const ExtraGuiOptions Sword25MetaEngineDetection::getExtraGuiOptions(const Common::String &target) const {
-	ExtraGuiOptions options;
-	options.push_back(sword25ExtraGuiOption);
-	return options;
-}
 
 REGISTER_PLUGIN_STATIC(SWORD25_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, Sword25MetaEngineDetection);

--- a/engines/sword25/detection_tables.h
+++ b/engines/sword25/detection_tables.h
@@ -19,6 +19,8 @@
  *
  */
 
+#define GAMEOPTION_ENGLISH_SPEECH GUIO_GAMEOPTIONS1
+
 namespace Sword25 {
 
 static const ADGameDescription gameDescriptions[] = {

--- a/engines/toltecs/detection.cpp
+++ b/engines/toltecs/detection.cpp
@@ -32,6 +32,7 @@
 #include "toltecs/toltecs.h"
 #include "toltecs/detection.h"
 
+#define GAMEOPTION_ORIGINAL_SAVELOAD      GUIO_GAMEOPTIONS1
 
 static const PlainGameDescriptor toltecsGames[] = {
 	{"toltecs", "3 Skulls of the Toltecs"},
@@ -52,7 +53,7 @@ static const ToltecsGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NONE)
+			GUIO1(GAMEOPTION_ORIGINAL_SAVELOAD)
 		},
 	},
 
@@ -66,7 +67,7 @@ static const ToltecsGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NONE)
+			GUIO1(GAMEOPTION_ORIGINAL_SAVELOAD)
 		},
 	},
 
@@ -80,7 +81,7 @@ static const ToltecsGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_PIRATED,
-			GUIO1(GUIO_NONE)
+			GUIO1(GAMEOPTION_ORIGINAL_SAVELOAD)
 		},
 	},
 
@@ -93,7 +94,7 @@ static const ToltecsGameDescription gameDescriptions[] = {
 			Common::RU_RUS,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NONE)
+			GUIO1(GAMEOPTION_ORIGINAL_SAVELOAD)
 		},
 	},
 
@@ -106,7 +107,7 @@ static const ToltecsGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NONE)
+			GUIO1(GAMEOPTION_ORIGINAL_SAVELOAD)
 		},
 	},
 
@@ -120,7 +121,7 @@ static const ToltecsGameDescription gameDescriptions[] = {
 			Common::PL_POL,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NONE)
+			GUIO1(GAMEOPTION_ORIGINAL_SAVELOAD)
 		},
 	},
 
@@ -133,7 +134,7 @@ static const ToltecsGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NONE)
+			GUIO1(GAMEOPTION_ORIGINAL_SAVELOAD)
 		},
 	},
 
@@ -146,7 +147,7 @@ static const ToltecsGameDescription gameDescriptions[] = {
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NONE)
+			GUIO1(GAMEOPTION_ORIGINAL_SAVELOAD)
 		},
 	},
 
@@ -160,7 +161,7 @@ static const ToltecsGameDescription gameDescriptions[] = {
 			Common::HU_HUN,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NONE)
+			GUIO1(GAMEOPTION_ORIGINAL_SAVELOAD)
 		},
 	},
 
@@ -174,7 +175,7 @@ static const ToltecsGameDescription gameDescriptions[] = {
 			Common::CS_CZE,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NONE)
+			GUIO1(GAMEOPTION_ORIGINAL_SAVELOAD)
 		},
 	},
 
@@ -187,7 +188,7 @@ static const ToltecsGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_DEMO,
-			GUIO1(GUIO_NONE)
+			GUIO1(GAMEOPTION_ORIGINAL_SAVELOAD)
 		},
 	},
 
@@ -200,7 +201,7 @@ static const ToltecsGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_DEMO,
-			GUIO1(GUIO_NONE)
+			GUIO1(GAMEOPTION_ORIGINAL_SAVELOAD)
 		},
 	},
 
@@ -220,20 +221,26 @@ static const ToltecsGameDescription gameDescriptions[] = {
 	{ AD_TABLE_END_MARKER }
 };
 
-} // End of namespace Toltecs
-
-static const ExtraGuiOption toltecsExtraGuiOption = {
-	_s("Use original save/load screens"),
-	_s("Use the original save/load screens instead of the ScummVM ones"),
-	"originalsaveload",
-	false,
-	0,
-	0
+static const ADExtraGuiOptionsMap optionsList[] = {
+	{
+		GAMEOPTION_ORIGINAL_SAVELOAD,
+		{
+			_s("Use original save/load screens"),
+			_s("Use the original save/load screens instead of the ScummVM ones"),
+			"originalsaveload",
+			false,
+			0,
+			0
+		}
+	},
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
+
+} // End of namespace Toltecs
 
 class ToltecsMetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
-	ToltecsMetaEngineDetection() : AdvancedMetaEngineDetection(Toltecs::gameDescriptions, sizeof(Toltecs::ToltecsGameDescription), toltecsGames) {
+	ToltecsMetaEngineDetection() : AdvancedMetaEngineDetection(Toltecs::gameDescriptions, sizeof(Toltecs::ToltecsGameDescription), toltecsGames, Toltecs::optionsList) {
 	}
 
 	const char *getEngineId() const override {
@@ -247,17 +254,6 @@ public:
 	const char *getOriginalCopyright() const override {
 		return "3 Skulls of the Toltecs (C) Revistronic 1996";
 	}
-
-	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
 };
-
-const ExtraGuiOptions ToltecsMetaEngineDetection::getExtraGuiOptions(const Common::String &target) const {
-	ExtraGuiOptions options;
-
-	if (target.empty() || ConfMan.get("platform", target) != "windows")
-		options.push_back(toltecsExtraGuiOption);
-
-	return options;
-}
 
 REGISTER_PLUGIN_STATIC(TOLTECS_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, ToltecsMetaEngineDetection);

--- a/engines/twine/detection.cpp
+++ b/engines/twine/detection.cpp
@@ -27,6 +27,19 @@
 #include "twine/detection.h"
 #include "twine/shared.h"
 
+#define GAMEOPTION_WALL_COLLISION GUIO_GAMEOPTIONS1
+#define GAMEOPTION_DISABLE_SAVE_MENU GUIO_GAMEOPTIONS2
+#define GAMEOPTION_DEBUG GUIO_GAMEOPTIONS3
+#define GAMEOPTION_AUDIO_CD GUIO_GAMEOPTIONS4
+#define GAMEOPTION_SOUND GUIO_GAMEOPTIONS5
+#define GAMEOPTION_VOICES GUIO_GAMEOPTIONS6
+#define GAMEOPTION_TEXT GUIO_GAMEOPTIONS7
+#define GAMEOPTION_MOVIES GUIO_GAMEOPTIONS8
+#define GAMEOPTION_MOUSE GUIO_GAMEOPTIONS9
+#define GAMEOPTION_USA_VERSION GUIO_GAMEOPTIONS10
+#define GAMEOPTION_HIGH_RESOLUTION GUIO_GAMEOPTIONS11
+#define GAMEOPTION_TEXT_TO_SPEECH GUIO_GAMEOPTIONS12
+
 static const PlainGameDescriptor twineGames[] = {
 	{ "lba", "Little Big Adventure" },
 	{ "lbashow", "Little Big Adventure Freeware Slide Show" },
@@ -896,120 +909,149 @@ static const ADGameDescription twineGameDescriptions[] = {
 	AD_TABLE_END_MARKER
 };
 
-static const ExtraGuiOption OptWallCollision = {
-	_s("Enable wall collisions"),
-	_s("Enable the original wall collision damage"),
-	"wallcollision",
-	false,
-	0,
-	0
-};
-
-// this only changes the menu and doesn't change the autosave behaviour - as scummvm is handling this now
-static const ExtraGuiOption OptDisableSaveMenu = {
-	_s("Disable save menu"),
-	_s("The original only had autosaves. This allows you to save whenever you want."),
-	"useautosaving",
-	false,
-	0,
-	0
-};
-
-static const ExtraGuiOption OptDebug = {
-	_s("Enable debug mode"),
-	_s("Enable the debug mode"),
-	"debug",
-	false,
-	0,
-	0
-};
-
-static const ExtraGuiOption OptUseCD = {
-	_s("Enable audio CD"),
-	_s("Enable the original audio cd track"),
-	"usecd",
-	false,
-	0,
-	0
-};
-
-static const ExtraGuiOption OptSound = {
-	_s("Enable sound"),
-	_s("Enable the sound for the game"),
-	"sound",
-	true,
-	0,
-	0
-};
-
-static const ExtraGuiOption OptVoices = {
-	_s("Enable voices"),
-	_s("Enable the voices for the game"),
-	"voice",
-	true,
-	0,
-	0
-};
-
-static const ExtraGuiOption OptText = {
-	_s("Enable text"),
-	_s("Enable the text for the game"),
-	"displaytext",
-	true,
-	0,
-	0
-};
-
-static const ExtraGuiOption OptMovies = {
-	_s("Enable movies"),
-	_s("Enable the cutscenes for the game"),
-	"movie",
-	true,
-	0,
-	0
-};
-
-static const ExtraGuiOption OptMouse = {
-	_s("Enable mouse"),
-	_s("Enable the mouse for the UI"),
-	"mouse",
-	true,
-	0,
-	0
-};
-
-static const ExtraGuiOption OptUSAVersion = {
-	_s("Use the USA version"),
-	_s("Enable the USA specific version flags"),
-	"version",
-	false,
-	0,
-	0
-};
-
-static const ExtraGuiOption OptHighRes = {
-	_s("Enable high resolution"),
-	_s("Enable a higher resolution for the game"),
-	"usehighres",
-	false,
-	0,
-	0
-};
-
+static const ADExtraGuiOptionsMap twineOptionsList[] = {
+	{
+		GAMEOPTION_WALL_COLLISION,
+		{
+			_s("Enable wall collisions"),
+			_s("Enable the original wall collision damage"),
+			"wallcollision",
+			false,
+			0,
+			0
+		}
+	},
+	{
+		// this only changes the menu and doesn't change the autosave behaviour - as scummvm is handling this now
+		GAMEOPTION_DISABLE_SAVE_MENU,
+		{
+			_s("Disable save menu"),
+			_s("The original only had autosaves. This allows you to save whenever you want."),
+			"useautosaving",
+			false,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_DEBUG,
+		{
+			_s("Enable debug mode"),
+			_s("Enable the debug mode"),
+			"debug",
+			false,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_AUDIO_CD,
+		{
+			_s("Enable audio CD"),
+			_s("Enable the original audio cd track"),
+			"usecd",
+			false,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_SOUND,
+		{
+			_s("Enable sound"),
+			_s("Enable the sound for the game"),
+			"sound",
+			true,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_VOICES,
+		{
+			_s("Enable voices"),
+			_s("Enable the voices for the game"),
+			"voice",
+			true,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_TEXT,
+		{
+			_s("Enable text"),
+			_s("Enable the text for the game"),
+			"displaytext",
+			true,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_MOVIES,
+		{
+			_s("Enable movies"),
+			_s("Enable the cutscenes for the game"),
+			"movie",
+			true,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_MOUSE,
+		{
+			_s("Enable mouse"),
+			_s("Enable the mouse for the UI"),
+			"mouse",
+			true,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_USA_VERSION,
+		{
+			_s("Use the USA version"),
+			_s("Enable the USA specific version flags"),
+			"version",
+			false,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_HIGH_RESOLUTION,
+		{
+			_s("Enable high resolution"),
+			_s("Enable a higher resolution for the game"),
+			"usehighres",
+			false,
+			0,
+			0
+		}
+	},
 #ifdef USE_TTS
-static const ExtraGuiOption OptTextToSpeech = {
-	_s("TTS Narrator"),
-	_s("Use TTS to read the descriptions (if TTS is available)"),
-	"tts_narrator",
-	false,
-	0,
-	0
-};
+	{
+		GAMEOPTION_TEXT_TO_SPEECH,
+		{
+			_s("TTS Narrator"),
+			_s("Use TTS to read the descriptions (if TTS is available)"),
+			"tts_narrator",
+			false,
+			0,
+			0
+		}
+	},
 #endif
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR
+};
 
 class TwinEMetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
-	TwinEMetaEngineDetection() : AdvancedMetaEngineDetection(twineGameDescriptions, sizeof(ADGameDescription), twineGames) {
+	TwinEMetaEngineDetection() : AdvancedMetaEngineDetection(twineGameDescriptions, sizeof(ADGameDescription), twineGames, twineOptionsList) {
+		_guiOptions = GUIO12(GAMEOPTION_WALL_COLLISION, GAMEOPTION_DISABLE_SAVE_MENU,  GAMEOPTION_DEBUG, GAMEOPTION_AUDIO_CD, GAMEOPTION_SOUND, GAMEOPTION_VOICES, GAMEOPTION_TEXT, GAMEOPTION_MOVIES, GAMEOPTION_MOUSE, GAMEOPTION_USA_VERSION, GAMEOPTION_HIGH_RESOLUTION, GAMEOPTION_TEXT_TO_SPEECH);
 	}
 
 	const char *getEngineId() const override {
@@ -1027,27 +1069,6 @@ public:
 	const DebugChannelDef *getDebugChannels() const override {
 		return debugFlagList;
 	}
-
-	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
 };
-
-const ExtraGuiOptions TwinEMetaEngineDetection::getExtraGuiOptions(const Common::String &target) const {
-	ExtraGuiOptions options;
-	options.push_back(OptWallCollision);
-	options.push_back(OptDisableSaveMenu);
-	options.push_back(OptMouse);
-	options.push_back(OptHighRes);
-	options.push_back(OptSound);
-	options.push_back(OptUseCD);
-	options.push_back(OptMovies);
-	options.push_back(OptUSAVersion);
-	options.push_back(OptVoices);
-	options.push_back(OptText);
-	options.push_back(OptDebug);
-#ifdef USE_TTS
-	options.push_back(OptTextToSpeech);
-#endif
-	return options;
-}
 
 REGISTER_PLUGIN_STATIC(TWINE_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, TwinEMetaEngineDetection);


### PR DESCRIPTION
TODO:
- [x] agos
- [x] drascula
- [x] hypno
- [x] made
- [x] mtropolis
- [x] neverhood
- [x] sword25
- [x] toltecs
- [x] twine
