### PR TITLE
DIRECTOR: LINGO: Implement map builtin STUB

### DIFF
--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -334,7 +334,20 @@ bool Channel::isVideoDirectToStage() {
 
 Common::Rect Channel::getBbox(bool unstretched) {
 	Common::Rect result(unstretched ? _sprite->_width : _width,
-											unstretched ? _sprite->_height : _height);
+						unstretched ? _sprite->_height : _height);
+	result.moveTo(getPosition());
+
+	if (_constraint) {
+		Common::Rect constraintBbox = g_director->getCurrentMovie()->getScore()->_channels[_constraint]->getBbox();
+		if (result.top < constraintBbox.top)
+			_currentPoint.y = constraintBbox.top;
+		if (result.left < constraintBbox.left)
+			_currentPoint.x = constraintBbox.left;
+		if (result.top > constraintBbox.bottom)
+			_currentPoint.y = constraintBbox.bottom;
+		if (result.left > constraintBbox.right)
+			_currentPoint.x = constraintBbox.right;
+	}
 	result.moveTo(getPosition());
 
 	return result;
@@ -663,14 +676,14 @@ void Channel::addDelta(Common::Point pos) {
 		if (!constraintBbox.contains(currentBbox)) {
 			if (currentBbox.top < constraintBbox.top) {
 				pos.y += constraintBbox.top - currentBbox.top;
-			} else if (currentBbox.bottom > constraintBbox.bottom) {
-				pos.y += constraintBbox.bottom - currentBbox.bottom;
+			} else if (currentBbox.top > constraintBbox.bottom) {
+				pos.y += constraintBbox.bottom;
 			}
 
 			if (currentBbox.left < constraintBbox.left) {
 				pos.x += constraintBbox.left - currentBbox.left;
-			} else if (currentBbox.right > constraintBbox.right) {
-				pos.x += constraintBbox.right - currentBbox.right;
+			} else if (currentBbox.left > constraintBbox.right) {
+				pos.x += constraintBbox.right;
 			}
 		}
 	}

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -2538,18 +2538,38 @@ void LB::b_inside(int nargs) {
 void LB::b_map(int nargs) {
 	Datum toRect = g_lingo->pop();
 	Datum fromRect = g_lingo->pop();
-	Datum srcPnt = g_lingo->pop();
+	Datum srcArr = g_lingo->pop();
+
+	if (!(toRect.type == RECT || (toRect.type == ARRAY && toRect.u.farr->arr.size() == 4)) ||
+		!(fromRect.type == RECT || (fromRect.type == ARRAY && fromRect.u.farr->arr.size() == 4))) {
+		warning("LB::b_map(): Invalid Datum Type of source and destination Rects");
+		return;
+	}
 
 	int toWidth = toRect.u.farr->arr[2].u.i - toRect.u.farr->arr[0].u.i;
 	int toHeight = toRect.u.farr->arr[3].u.i - toRect.u.farr->arr[1].u.i;
 	int fromWidth = fromRect.u.farr->arr[2].u.i - fromRect.u.farr->arr[0].u.i;
 	int fromHeight = fromRect.u.farr->arr[3].u.i - fromRect.u.farr->arr[1].u.i;
 
+	if (!(srcArr.type == POINT ||
+		srcArr.type == RECT ||
+		(srcArr.type == ARRAY && (srcArr.u.farr->arr.size() == 2 || srcArr.u.farr->arr.size() == 4)))) {
+		warning("LB::b_map(): Invalid Datum type of input Point / Rect");
+		return;
+	}
+
 	Datum d;
 	d.type = POINT;
 	d.u.farr = new FArray();
-	d.u.farr->arr.push_back(-((fromRect.u.farr->arr[2].u.i - srcPnt.u.farr->arr[0].u.i) * (toWidth / fromWidth)) + (fromRect.u.farr->arr[0].u.i) + toRect.u.farr->arr[0].u.i);
-	d.u.farr->arr.push_back(-((fromRect.u.farr->arr[3].u.i - srcPnt.u.farr->arr[1].u.i) * (toHeight / fromHeight)) + (fromRect.u.farr->arr[3].u.i));
+	d.u.farr->arr.push_back((srcArr.u.farr->arr[0].u.i - fromRect.u.farr->arr[0].u.i) * (toWidth / fromWidth) + toRect.u.farr->arr[0].u.i);
+	d.u.farr->arr.push_back((srcArr.u.farr->arr[1].u.i - fromRect.u.farr->arr[1].u.i) * (toHeight / fromHeight) + toRect.u.farr->arr[1].u.i);
+
+	if (srcArr.type == RECT ||
+		(srcArr.type == ARRAY && srcArr.u.farr->arr.size() == 4)) {
+		d.type = RECT;
+		d.u.farr->arr.push_back((srcArr.u.farr->arr[2].u.i - srcArr.u.farr->arr[0].u.i) * (toWidth / fromWidth) + d.u.farr->arr[0].u.i);
+		d.u.farr->arr.push_back((srcArr.u.farr->arr[3].u.i - srcArr.u.farr->arr[1].u.i) * (toWidth / fromWidth) + d.u.farr->arr[1].u.i);
+	}
 
 	g_lingo->push(d);
 }

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -2536,11 +2536,22 @@ void LB::b_inside(int nargs) {
 }
 
 void LB::b_map(int nargs) {
-	g_lingo->printSTUBWithArglist("b_map", nargs);
+	Datum toRect = g_lingo->pop();
+	Datum fromRect = g_lingo->pop();
+	Datum srcPnt = g_lingo->pop();
 
-	g_lingo->dropStack(nargs);
+	int toWidth = toRect.u.farr->arr[2].u.i - toRect.u.farr->arr[0].u.i;
+	int toHeight = toRect.u.farr->arr[3].u.i - toRect.u.farr->arr[1].u.i;
+	int fromWidth = fromRect.u.farr->arr[2].u.i - fromRect.u.farr->arr[0].u.i;
+	int fromHeight = fromRect.u.farr->arr[3].u.i - fromRect.u.farr->arr[1].u.i;
 
-	g_lingo->push(Datum(0));
+	Datum d;
+	d.type = POINT;
+	d.u.farr = new FArray();
+	d.u.farr->arr.push_back(-((fromRect.u.farr->arr[2].u.i - srcPnt.u.farr->arr[0].u.i) * (toWidth / fromWidth)) + (fromRect.u.farr->arr[0].u.i) + toRect.u.farr->arr[0].u.i);
+	d.u.farr->arr.push_back(-((fromRect.u.farr->arr[3].u.i - srcPnt.u.farr->arr[1].u.i) * (toHeight / fromHeight)) + (fromRect.u.farr->arr[3].u.i));
+
+	g_lingo->push(d);
 }
 
 void LB::b_offsetRect(int nargs) {

--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -343,6 +343,9 @@ bool Sprite::respondsToMouse() {
 }
 
 bool Sprite::isActive() {
+	if (_moveable)
+		return true;
+
 	if (_cast && _cast->_type == kCastButton)
 		return true;
 


### PR DESCRIPTION
This change implements the b_map builtin. It also introduces a change in how we handle constraints of sprites (by checking them each frame instead of just handling them during events) and classifies movable sprites as Active sprites too. Changes have been tested using the `map` workshop movie and also by plugging values in the Lingo Message window and ScummVM debugger.