### PR TITLE
DIRECTOR: LINGO: Implement abort builtin command, issue warnings for unsupported commands showResFile, showXlib

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1186,15 +1186,13 @@ void LB::b_setCallBack(int nargs) {
 }
 
 void LB::b_showResFile(int nargs) {
-	Datum d = g_lingo->pop();
-
-	warning("STUB: b_showResFile(%s)", d.asString().c_str());
+	g_lingo->dropStack(nargs);
+	warning("LB: b_showResFile: showResFile is not supported by ScummVM");
 }
 
 void LB::b_showXlib(int nargs) {
-	Datum d = g_lingo->pop();
-
-	warning("STUB: b_showXlib(%s)", d.asString().c_str());
+	g_lingo->dropStack(nargs);
+	warning("LB: b_showXlib: showXlib is not supported by ScummVM");
 }
 
 void LB::b_xFactoryList(int nargs) {
@@ -1207,7 +1205,7 @@ void LB::b_xFactoryList(int nargs) {
 // Control
 ///////////////////
 void LB::b_abort(int nargs) {
-	warning("STUB: b_abort");
+	g_lingo->_abort = true;
 }
 
 void LB::b_continue(int nargs) {


### PR DESCRIPTION
This change implements the STUBbed builtin b_abort and adds warning messages for unsupported debugging commands showResFile, showXlib. Changes tested by the `abort` workshop movie