### PR TITLE
DIRECTOR: LINGO: Implement offset rect Lingo builtin

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -2706,11 +2706,27 @@ void LB::b_map(int nargs) {
 }
 
 void LB::b_offsetRect(int nargs) {
-	g_lingo->printSTUBWithArglist("b_offsetRect", nargs);
+	Datum vert = g_lingo->pop();
+	Datum hori = g_lingo->pop();
+	Datum rect = g_lingo->pop();
 
-	g_lingo->dropStack(nargs);
+	if (vert.type != INT ||
+		hori.type != INT ||
+		!(rect.type == RECT || (rect.type == ARRAY && rect.u.farr->arr.size() >= 4))) {
+		warning(" LB::b_offsetRect(): Invalid DatumType of inputs");
+		g_lingo->push(rect);
+	}
 
-	g_lingo->push(Datum(0));
+	//When vert is positive, rect moves higher
+	//When hori is positive, rect moves towards right
+
+	rect.u.farr->arr[0].u.i += hori.u.i;
+	rect.u.farr->arr[2].u.i += hori.u.i;
+	rect.u.farr->arr[1].u.i -= vert.u.i;
+	rect.u.farr->arr[3].u.i -= vert.u.i;
+	
+
+	g_lingo->push(rect);
 }
 
 void LB::b_union(int nargs) {

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -1649,6 +1649,15 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 			sprite->_moveable = false;
 		}
 		break;
+	case kTheRect:
+		if (d.type == RECT || (d.type == ARRAY && d.u.farr->arr.size() >= 4)) {
+			score->renderSprites(score->getCurrentFrame(), kRenderForceUpdate);
+			channel->_currentPoint = Common::Point(d.u.farr->arr[0].u.i, d.u.farr->arr[1].u.i);
+			sprite->_width = d.u.farr->arr[2].u.i - d.u.farr->arr[0].u.i;
+			sprite->_height = d.u.farr->arr[3].u.i - d.u.farr->arr[1].u.i;
+			channel->_dirty = true;
+		}
+		break;
 	case kTheStartTime:
 		channel->_startTime = d.asInt();
 		if (sprite->_cast->_type == kCastDigitalVideo)


### PR DESCRIPTION
This change implements the offset rect function. It also introduces the case of kTheRect in `Lingo::setTheSprite()` which the console was complaining of being nonexistent. The changes have been tested by the `offset rect` workshop movie