### PR TITLE
DIRECTOR: LINGO: Add warnings for b_open Lingo function

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1115,6 +1115,13 @@ void LB::b_open(int nargs) {
 	if (nargs == 2)
 		g_lingo->pop();
 	warning("LB::b_open(): Unsupported command open encountered -> The movie tried to open %s", d.asString().c_str());
+
+	if (!debugChannelSet(-1, kDebugFewFramesOnly) &&
+		!(g_director->getGameGID() == GID_TEST || g_director->getGameGID() == GID_TESTALL)) {
+		Common::U32String message = Common::String::format("Unsupported command open encountered -> The movie tried to execute open %s!", d.asString().c_str());
+		GUI::MessageDialog dialog(message, _("Ok"));
+		dialog.runModal();
+	}
 }
 
 void LB::b_openDA(int nargs) {

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1111,9 +1111,10 @@ void LB::b_getNthFileNameInFolder(int nargs) {
 }
 
 void LB::b_open(int nargs) {
-	g_lingo->printSTUBWithArglist("b_open", nargs);
-
-	g_lingo->dropStack(nargs);
+	Datum d = g_lingo->pop();
+	if (nargs == 2)
+		g_lingo->pop();
+	warning("LB::b_open(): Unsupported command open encountered -> The movie tried to open %s", d.asString().c_str());
 }
 
 void LB::b_openDA(int nargs) {


### PR DESCRIPTION
This change implements a warning for unsupported open Lingo command in `LB::b_open()`