### PR TITLE
DIRECTOR: LINGO: Implement xFactoryList Lingo Function

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1199,8 +1199,12 @@ void LB::b_showXlib(int nargs) {
 
 void LB::b_xFactoryList(int nargs) {
 	Datum d = g_lingo->pop();
+	d.type = STRING;
+	d.u.s = new Common::String();
 
-	warning("STUB: b_xFactoryList(%s)", d.asString().c_str());
+	for (auto it = g_lingo->_openXLibs.begin(); it != g_lingo->_openXLibs.end(); it++)
+		*d.u.s += it->_key + "\n";
+	g_lingo->push(d);
 }
 
 ///////////////////


### PR DESCRIPTION
This change implements the xFactoryList builtin function in a modified way. While the original worked this way:
![image](https://user-images.githubusercontent.com/76248539/175939340-96503477-48e9-4af9-b171-8dfa7639032a.png)
This implementation will treat all inputs as "EMPTY"
This is because we don't currently save the filename from when an opened XObject is coming. Also some XObjects we load don't seem to have a filename (I used [this](https://github.com/scummvm/scummvm/blob/01d264569ca243552d6c65d9d2245ab3adb8bfb8/engines/director/lingo/lingo-builtins.cpp#L1149) but it didn't quite work)
So I am keeping it this way for now, as djsrv said that the usage of this function in target movies would be very very rare.
This change has been tested using ScummVM's debugger