### PR TITLE
MOHAWK: A couple of hacks to get some games partially working

### DIFF
--- a/engines/mohawk/detection_tables.h
+++ b/engines/mohawk/detection_tables.h
@@ -3085,7 +3085,7 @@ static const MohawkGameDescription gameDescriptions[] = {
 			ADGF_NO_FLAGS,
 			GUIO1(GUIO_NOASPECT)
 		},
-		GType_LIVINGBOOKSV2,
+		GType_LIVINGBOOKSV3,
 		0,
 		0,
 	},
@@ -3148,7 +3148,7 @@ static const MohawkGameDescription gameDescriptions[] = {
 			ADGF_DEMO,
 			GUIO1(GUIO_NOASPECT)
 		},
-		GType_LIVINGBOOKSV2,
+		GType_LIVINGBOOKSV3,
 		0,
 		0,
 	},

--- a/engines/mohawk/livingbooks.cpp
+++ b/engines/mohawk/livingbooks.cpp
@@ -1415,7 +1415,7 @@ void MohawkEngine_LivingBooks::handleNotify(NotifyEvent &event) {
 		debug(2, "kLBNotifyChangeMode: v2 type %d", event.param);
 		switch (event.param) {
 		case 1:
-			debug(2, "kLBNotifyChangeMode:, mode %d, page %d.%d",
+			debug(2, "kLBNotifyChangeMode: mode %d, page %d.%d",
 				event.newMode, event.newPage, event.newSubpage);
 			// TODO: what is entry.newUnknown?
 			if (!event.newMode)
@@ -1728,7 +1728,8 @@ bool LBAnimationNode::transparentAt(int x, int y) {
 LBAnimation::LBAnimation(MohawkEngine_LivingBooks *vm, LBAnimationItem *parent, uint16 resourceId) : _vm(vm), _parent(parent) {
 	Common::SeekableSubReadStreamEndian *aniStream = _vm->wrapStreamEndian(ID_ANI, resourceId);
 
-	if (aniStream->size() != 30)
+	// ANI records in the Wanderful sampler are 32 bytes, extra bytes are just NULs
+	if (aniStream->size() != 30 && aniStream->size() != 32)
 		warning("ANI Record size mismatch");
 
 	uint16 version = aniStream->readUint16();
@@ -1746,6 +1747,9 @@ LBAnimation::LBAnimation(MohawkEngine_LivingBooks *vm, LBAnimationItem *parent, 
 	debug(5, "ANI clip: (%d, %d), (%d, %d)", _clip.left, _clip.top, _clip.right, _clip.bottom);
 	debug(5, "ANI color id: %d", colorId);
 	debug(5, "ANI SPRResourceId: %d, offset %d", sprResourceId, sprResourceOffset);
+	if (aniStream->size() == 32) {
+		debug(5, "ANI extra bytes: (%d)", aniStream->readUint16());
+	}
 
 	if (aniStream->pos() != aniStream->size())
 		error("Still %d bytes at the end of anim stream", (int)(aniStream->size() - aniStream->pos()));

--- a/engines/mohawk/livingbooks_code.cpp
+++ b/engines/mohawk/livingbooks_code.cpp
@@ -1957,7 +1957,7 @@ uint LBCode::parseCode(const Common::String &source) {
 				Common::String tempString;
 				tempString += token;
 				while (pos < source.size()) {
-					if (!Common::isAlpha(source[pos]) && !Common::isDigit(source[pos]))
+					if (!Common::isAlpha(source[pos]) && !Common::isDigit(source[pos]) && source[pos] != '_') // Wanderful sampler uses _ in variables
 						break;
 					tempString += source[pos++];
 				}


### PR DESCRIPTION
Marking the Mac versions of the Daniel in the Lions' Den demo and The Story of Creation working is due to d096b78acaa510e02cb9be9a2e2dc17e53f80e3e adding in a check to use LBv1 if the game is marked as LBv2 and kPlatformMacintosh. Ideally it should be changed, but I don't have all the Mac versions to check if it's the case for just that one game or all other Mac games.

The Wanderful version of the sampler uses a 32 byte ANI, the extra bytes being nuls. The `&& source[pos] != 95` part is due to some variables using `_` in the names, which the engine was previously failing on parsing.