### PR TITLE
Fix crash when clicking Hide while downloading icons

### DIFF
--- a/gui/downloadiconsdialog.cpp
+++ b/gui/downloadiconsdialog.cpp
@@ -304,7 +304,6 @@ void DownloadIconsDialog::handleCommand(CommandSender *sender, uint32 cmd, uint3
 		break;
 	case kDownloadEndedCmd:
 		setState(kDownloadComplete);
-		setResult(1); // Need tell the options to refresh launcher
 		break;
 	case kListDownloadFinishedCmd:
 		setState(kDownloadStateListDownloaded);

--- a/gui/downloadiconsdialog.h
+++ b/gui/downloadiconsdialog.h
@@ -73,18 +73,11 @@ public:
 	void handleTickle() override;
 	void reflowLayout() override;
 
-	void downloadListCallback(Networking::DataResponse response);
-	void downloadFileCallback(Networking::DataResponse response);
-	void errorCallback(Networking::ErrorResponse error);
-
 	void setError(Common::U32String &msg);
 
 private:
-	void downloadList();
 	void calculateList();
-	void proceedDownload();
 	void setState(IconProcessState state);
-	bool takeOneFile();
 };
 
 } // End of namespace GUI

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -114,6 +114,7 @@ struct ArchiveMemberListBackComparator {
 	}
 };
 void GuiManager::initIconsSet() {
+	Common::StackLock lock(_iconsMutex);
 	Common::Archive *dat;
 
 	_iconsSet.clear();

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -27,6 +27,7 @@
 #include "common/stack.h"
 #include "common/str.h"
 #include "common/list.h"
+#include "common/mutex.h"
 
 #include "gui/ThemeEngine.h"
 #include "gui/widget.h"
@@ -91,7 +92,10 @@ public:
 
 	ThemeEval *xmlEval() { return _theme->getEvaluator(); }
 
-	Common::SearchSet &getIconsSet() { return _iconsSet; }
+	Common::SearchSet &getIconsSet() {
+		Common::StackLock lock(_iconsMutex);
+		return _iconsSet;
+	}
 
 	int16 getGUIWidth() const { return _baseWidth; }
 	int16 getGUIHeight() const { return _baseHeight; }
@@ -162,6 +166,7 @@ protected:
 	int			_topDialogLeftPadding;
 	int			_topDialogRightPadding;
 
+	Common::Mutex _iconsMutex;
 	Common::SearchSet _iconsSet;
 
 	// position and time of last mouse click (used to detect double clicks)

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -96,10 +96,9 @@ public:
 
 	ThemeEval *xmlEval() { return _theme->getEvaluator(); }
 
-	Common::SearchSet &getIconsSet() {
-		Common::StackLock lock(_iconsMutex);
-		return _iconsSet;
-	}
+	void lockIconsSet() { _iconsMutex.lock(); }
+	void unlockIconsSet()  { _iconsMutex.unlock(); }
+	Common::SearchSet &getIconsSet() { return _iconsSet; }
 
 	int16 getGUIWidth() const { return _baseWidth; }
 	int16 getGUIHeight() const { return _baseHeight; }

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -45,6 +45,10 @@ namespace Common {
 
 namespace GUI {
 
+enum {
+	kIconsSetLoadedCmd  = 'icns'
+};
+
 class Dialog;
 class ThemeEval;
 class GuiObject;
@@ -65,7 +69,7 @@ typedef Common::FixedStack<Dialog *> DialogStack;
 /**
  * GUI manager singleton.
  */
-class GuiManager : public Common::Singleton<GuiManager> {
+class GuiManager : public Common::Singleton<GuiManager>, public CommandSender {
 	friend class Dialog;
 	friend class Common::Singleton<SingletonBaseType>;
 	GuiManager();
@@ -168,6 +172,7 @@ protected:
 
 	Common::Mutex _iconsMutex;
 	Common::SearchSet _iconsSet;
+	bool _iconsSetChanged;
 
 	// position and time of last mouse click (used to detect double clicks)
 	struct MousePos {

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -1477,6 +1477,9 @@ void LauncherGrid::handleCommand(CommandSender *sender, uint32 cmd, uint32 data)
 		ConfMan.flushToDisk();
 		reflowLayout();
 		break;
+	case kIconsSetLoadedCmd:
+		rebuild();
+		break;
 	default:
 		LauncherDialog::handleCommand(sender, cmd, data);
 	}

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -183,6 +183,7 @@ LauncherDialog::LauncherDialog(const Common::String &dialogName, LauncherChooser
 
 	Common::ArchiveMemberList mdFiles;
 
+	g_gui.lockIconsSet();
 	g_gui.getIconsSet().listMatchingMembers(mdFiles, "*.xml");
 	for (Common::ArchiveMemberList::iterator md = mdFiles.begin(); md != mdFiles.end(); ++md) {
 		if (_metadataParser.loadStream((*md)->createReadStream()) == false) {
@@ -194,6 +195,7 @@ LauncherDialog::LauncherDialog(const Common::String &dialogName, LauncherChooser
 		}
 		_metadataParser.close();
 	}
+	g_gui.unlockIconsSet();
 }
 
 LauncherDialog::~LauncherDialog() {

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -2991,12 +2991,7 @@ void GlobalOptionsDialog::handleCommand(CommandSender *sender, uint32 cmd, uint3
 #ifdef USE_LIBCURL
 	case kUpdateIconsCmd: {
 		DownloadIconsDialog dia;
-
-		if (dia.runModal() > 0) {
-			if (_launcher && _launcher->getType() == kLauncherDisplayGrid)
-				_launcher->rebuild();
-		}
-
+		dia.runModal();
 		break;
 	}
 #endif

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -292,9 +292,11 @@ Graphics::ManagedSurface *loadSurfaceFromFile(const Common::String &name, int re
 #ifdef USE_PNG
 		const Graphics::Surface *srcSurface = nullptr;
 		Image::PNGDecoder decoder;
+		g_gui.lockIconsSet();
 		if (g_gui.getIconsSet().hasFile(name)) {
 			Common::SeekableReadStream *stream = g_gui.getIconsSet().createReadStreamForMember(name);
 			if (!decoder.loadStream(*stream)) {
+				g_gui.unlockIconsSet();
 				warning("Error decoding PNG");
 				return surf;
 			}
@@ -309,10 +311,12 @@ Graphics::ManagedSurface *loadSurfaceFromFile(const Common::String &name, int re
 		} else {
 			debug(5, "GridWidget: Cannot read file '%s'", name.c_str());
 		}
+		g_gui.unlockIconsSet();
 #else
 		error("No PNG support compiled");
 #endif
 	} else if (name.hasSuffix(".svg")) {
+		g_gui.lockIconsSet();
 		if (g_gui.getIconsSet().hasFile(name)) {
 			Common::SeekableReadStream *stream = g_gui.getIconsSet().createReadStreamForMember(name);
 			Graphics::SVGBitmap *image = nullptr;
@@ -326,6 +330,7 @@ Graphics::ManagedSurface *loadSurfaceFromFile(const Common::String &name, int re
 		} else {
 			debug(5, "GridWidget: Cannot read file '%s'", name.c_str());
 		}
+		g_gui.unlockIconsSet();
 	}
 	return surf;
 }


### PR DESCRIPTION
The icons download calls callbacks in the `DownloadIconsDialog`. When we click Hide the dialog is closed, and the next attempt to access one of the callbacks causes a crash. To fix this issue, this pull request moves the callbacks for the icons download from the `DownloadIconsDialog` to the `DialogState`.

This first change then caused two other issues to become apparent:
* There was a race condition with the `GuiManager::_iconsSet` variable as the icon download is calling `GuiManager::initIconsSet` from one of the callback (when the download has finished), which runs in a separate thread. This was not an issue before fixing the crash, but now that we can close the download and options dialog while downloading the icons, the grid launcher can be accessing the `_iconSet` when the download finishes (that was a fun one to debug 😩 ).
* The grid launcher update was triggered by the download dialog after icons have been downloaded. But that means it was not happening if the dialog is closed while downloading the icons.

I made two additional commits to fix two two issues. I am not convinced by the last commit though. Is there a better way to do it?

This fixes [bug #13567](https://bugs.scummvm.org/ticket/13567).