### PR TITLE
OPENGL: Fix VS integer cast to pointer of larger size warning

### DIFF
--- a/graphics/opengl/shader.cpp
+++ b/graphics/opengl/shader.cpp
@@ -363,7 +363,7 @@ void Shader::enableVertexAttribute(const char *attrib, GLuint vbo, GLint size, G
 	va._type = type;
 	va._normalized = normalized;
 	va._stride = stride;
-	va._pointer = (const void *)(long)offset;
+	va._pointer = reinterpret_cast<const void *>(static_cast<uintptr>(offset));
 }
 
 void Shader::disableVertexAttribute(const char *attrib, int size, const float *data) {


### PR DESCRIPTION
Proper fix for 8ee4251f41d4b44091fa1a6168dd578f3e17a943

long is 32-bit on Windows.