### PR TITLE
GUI: Fix mouse wheel on grid item tray causing ScummVM to exit abruptly

### DIFF
--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -270,7 +270,6 @@ void GridItemTray::handleMouseDown(int x, int y, int button, int clickCount) {
 }
 
 void GridItemTray::handleMouseWheel(int x, int y, int direction) {
-	Dialog::handleMouseWheel(x, y, direction);
 	close();
 }
 


### PR DESCRIPTION
When using the mouse wheel (scroll up/down) in the Grid view, item tray for a selected game, ScummVM would exit.

To replicate the buggy behavior, from the ScummVM launcher, go to Grid view, select a game and then use mouse-wheel to scroll over any of the buttons of the highlighted game's small popup (ie. the buttons for Play, Edit and Saves).

I didn't notice any side-effects from the fix, but someone more familiar with the code should confirm.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
