### PR TITLE
GUI: Preserve the enabled state of _soundFontClearButton when reflowing the window

### DIFF
--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -3271,10 +3271,12 @@ void GlobalOptionsDialog::reflowLayout() {
 	if (_midiTabId != -1) {
 		_tabWidget->setActiveTab(_midiTabId);
 
+		bool enabled = _soundFontClearButton->isEnabled();
 		_tabWidget->removeWidget(_soundFontClearButton);
 		_soundFontClearButton->setNext(nullptr);
 		delete _soundFontClearButton;
 		_soundFontClearButton = addClearButton(_tabWidget, "GlobalOptions_MIDI.mcFontClearButton", kClearSoundFontCmd);
+		_soundFontClearButton->setEnabled(enabled);
 	}
 
 	if (_pathsTabId != -1) {


### PR DESCRIPTION
Normally, the clear button is supposed to be greyed out when no soundfont is selected, however recreating the button during a layout change caused the button to be re-enabled.