### PR TITLE
AUDIO: Add flag to preserve MIDI Type 1 source track information

### DIFF
--- a/audio/midiparser_smf.cpp
+++ b/audio/midiparser_smf.cpp
@@ -29,6 +29,11 @@
 static const byte commandLengths[8] = { 3, 3, 3, 3, 2, 2, 3, 0 };
 static const byte specialLengths[16] = { 0, 2, 3, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
 
+MidiParser_SMF::MidiParser_SMF(int8 source) : MidiParser(source), _buffer(nullptr) {
+	for (int i = 0; i < ARRAYSIZE(_noteChannelToTrack); i++)
+		_noteChannelToTrack[i] = -1;
+}
+
 MidiParser_SMF::~MidiParser_SMF() {
 	free(_buffer);
 }
@@ -295,6 +300,8 @@ uint32 MidiParser_SMF::compressToType0(byte *tracks[], byte numTracks, byte *buf
 
 		if (commandLengths[(event >> 4) - 8] > 0) {
 			copyBytes = commandLengths[(event >> 4) - 8];
+			if ((event & 0xf0) == MidiDriver_BASE::MIDI_COMMAND_NOTE_ON)
+				_noteChannelToTrack[event & 0x0f] = bestTrack;
 		} else if (specialLengths[(event & 0x0F)] > 0) {
 			copyBytes = specialLengths[(event & 0x0F)];
 		} else if (event == 0xF0) {

--- a/audio/midiparser_smf.h
+++ b/audio/midiparser_smf.h
@@ -30,6 +30,7 @@
 class MidiParser_SMF : public MidiParser {
 protected:
 	byte *_buffer;
+	int8 _noteChannelToTrack[16];
 
 protected:
 	/**
@@ -47,7 +48,7 @@ protected:
 	void parseNextEvent(EventInfo &info) override;
 
 public:
-	MidiParser_SMF(int8 source = -1) : MidiParser(source), _buffer(nullptr) {}
+	MidiParser_SMF(int8 source = -1);
 	~MidiParser_SMF();
 
 	bool loadMusic(byte *data, uint32 size) override;


### PR DESCRIPTION
Not sure this is the greatest way to do this.

Obsidian uses type 1 SMF, and two parts of the game conditionally mute MIDI tracks (the Church puzzle unmutes tracks the further you get through it, and the canvas puzzle mutes the piano track if you solve or are attempting to solve the puzzle).

Unfortunately, it does this by muting track numbers, not channels, but MidiParser currently wipes out the track information from type 1 when it converts it to type 0.

This adds a flag to keep the tracking information as metadata so it can be recovered, and passes the track number with MidiParser events.