### PR TITLE
GUI: Change SCUMM audio override label to "Load modded audio"

### DIFF
--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -235,8 +235,8 @@ static const ExtraGuiOption enableEnhancements {
 };
 
 static const ExtraGuiOption audioOverride {
-	_s("Use external audio"),
-	_s("Replace music, sound effects, and speech clips with external audio files if available"),
+	_s("Load modded audio"),
+	_s("Replace music, sound effects, and speech clips with modded audio files, if available."),
 	"audio_override",
 	true,
 	0,


### PR DESCRIPTION
This is to avoid ambiguity since "external audio" can mean speakers and such. Also, changing from "Use" to "Load" both to make it clearer what is happening and also to match the "Load modded assets" setting in the Stark engine.

## Before
<img width="409" alt="Before" src="https://user-images.githubusercontent.com/6200170/176979117-7dbe7dab-e279-441e-b69a-5a03db697804.png">

## After
<img width="409" alt="After" src="https://user-images.githubusercontent.com/6200170/176979022-dea2c286-0359-4549-b2ca-40b59a897c9b.png">