### PR TITLE
DIRECTOR: full release of Through the Window

### DIFF
--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -2546,7 +2546,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	WINDEMO1("trekfinalunity", "Demo", "PLAYDEMO.EXE", "65d06b5fef155a2473434571aff5bc29", 370018, 310),
 
-	MACDEMO1_l("ttw", "Demo", "T.T.W.Demo", "51e8b81db434a6dcae723f6b7724143d", 691332, Common::JA_JPN, 302),
+	MACDEMO1_l("ttw", "Demo", "T.T.W.Demo", "51e8b81db434a6dcae723f6b7724143d", 691076, Common::JA_JPN, 302),
+	MACGAME1_l("ttw", "", "whales", "e184bbb4cc78e49733829ea7e2dc728a", 67777, Common::JA_JPN, 302),
 
 	// Full version is D4
 	MACDEMO2_l("ukiuki1", "Demo", "DEMO",	   "f5277c53bacd27936158dd3867e587e2", 392508,


### PR DESCRIPTION
This adds the full version of Through the Window; the demo was previously supported. Unlike the demo, the full version is some sort of HyperCard/Director hybrid. The main entry point is a `STAK`, not a Director movie, but it includes a full MacroMind Player and significant chunks of the game are Director.  Setting the entry point to the main executable or the player causes it to not boot, with the error `WARNING: Movie::loadArchive(): Wrong movie format. VWSC resource missing!`. I've set it instead to the first Director movie the game plays, `whales`.

I've also corrected the filesize of the demo, which was added before the Mac file size bug was fixed.