### PR TITLE
DIRECTOR: Fix buildbot failure on null macmenu

### DIFF
--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -337,7 +337,7 @@ Common::Rect Channel::getBbox(bool unstretched) {
 						unstretched ? _sprite->_height : _height);
 	result.moveTo(getPosition());
 
-	if (_constraint) {
+	if (_constraint > 0 && _constraint <= g_director->getCurrentMovie()->getScore()->_channels.size()) {
 		Common::Rect constraintBbox = g_director->getCurrentMovie()->getScore()->_channels[_constraint]->getBbox();
 		if (result.top < constraintBbox.top)
 			_currentPoint.y = constraintBbox.top;

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -1269,6 +1269,11 @@ int Lingo::getMenuItemsNum(Datum &d) {
 
 	Graphics::MacMenuItem *menu = nullptr;
 
+	if (!g_director->_wm->getMenu()) {
+		warning("Lingo::getMenuItemsNum() : Menu does not exist!");
+		return 0;
+	}
+
 	if (d.u.menu->menuIdNum == -1) {
 		menu = g_director->_wm->getMenu()->getMenuItem(*d.u.menu->menuIdStr);
 	} else {

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -1073,6 +1073,11 @@ void Lingo::setTheEntity(int entity, Datum &id, int field, Datum &d) {
 		Graphics::MacMenuItem *menu, *menuItem;
 		menu = nullptr, menuItem = nullptr;
 
+		if (!g_director->_wm->getMenu()) {
+			warning("Lingo::setTheEntity() : Menu does not exist!");
+			break;
+		}
+
 		if (id.u.menu->menuIdNum == -1) {
 			menu = g_director->_wm->getMenu()->getMenuItem(*id.u.menu->menuIdStr);
 		} else {

--- a/graphics/macgui/macmenu.cpp
+++ b/graphics/macgui/macmenu.cpp
@@ -312,9 +312,6 @@ int MacMenu::numberOfMenus() {
 MacMenuItem *MacMenu::getMenuItem(const Common::String &menuId) {
 	MacMenuItem *menu = nullptr;
 
-	if (!this)
-		return menu;
-
 	for (uint i = 0; i < _items.size(); i++) {
 		// TODO: support unicode text menu
 		// didn't support unicode item finding yet

--- a/graphics/macgui/macmenu.cpp
+++ b/graphics/macgui/macmenu.cpp
@@ -312,6 +312,9 @@ int MacMenu::numberOfMenus() {
 MacMenuItem *MacMenu::getMenuItem(const Common::String &menuId) {
 	MacMenuItem *menu = nullptr;
 
+	if (!this)
+		return menu;
+
 	for (uint i = 0; i < _items.size(); i++) {
 		// TODO: support unicode text menu
 		// didn't support unicode item finding yet


### PR DESCRIPTION
This small change checks for a null macmenu before accessing its properties. This is a fix for some build steps for the director buildbot.