### PR TITLE
DIRECTOR: add Kids Box quirk to run in desktop mode

### DIFF
--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -96,8 +96,6 @@ DirectorEngine::DirectorEngine(OSystem *syst, const DirectorGameDescription *gam
 		SearchMan.addSubDirectoryMatching(_gameDataDir, directoryGlob);
 	}
 
-	gameQuirks(_gameDescription->desc.gameId, _gameDescription->desc.platform);
-
 	if (debugChannelSet(-1, kDebug32bpp))
 		_colorDepth = 32;
 	else
@@ -124,6 +122,8 @@ DirectorEngine::DirectorEngine(OSystem *syst, const DirectorGameDescription *gam
 
 	_surface = nullptr;
 	_tickBaseline = 0;
+
+	gameQuirks(_gameDescription->desc.gameId, _gameDescription->desc.platform);
 }
 
 DirectorEngine::~DirectorEngine() {

--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -187,7 +187,7 @@ Common::Error DirectorEngine::run() {
 	_stage = new Window(_wm->getNextId(), false, false, false, _wm, this, true);
 	*_stage->_refCount += 1;
 
-	if (!debugChannelSet(-1, kDebugDesktop))
+	if (!desktopEnabled())
 		_stage->disableBorder();
 
 	_surface = new Graphics::ManagedSurface(1, 1);
@@ -317,6 +317,10 @@ StartMovie DirectorEngine::getStartMovie() const {
 
 Common::String DirectorEngine::getStartupPath() const {
 	return _options.startupPath;
+}
+
+bool DirectorEngine::desktopEnabled() {
+	return !(_wmMode & Graphics::kWMModeNoDesktop);
 }
 
 } // End of namespace Director

--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -49,11 +49,6 @@
 
 namespace Director {
 
-const uint32 wmModeDesktop = Graphics::kWMModalMenuMode | Graphics::kWMModeManualDrawWidgets;
-const uint32 wmModeFullscreen = Graphics::kWMModalMenuMode | Graphics::kWMModeNoDesktop
-	| Graphics::kWMModeManualDrawWidgets | Graphics::kWMModeFullscreen;
-uint32 wmMode = 0;
-
 DirectorEngine *g_director;
 
 DirectorEngine::DirectorEngine(OSystem *syst, const DirectorGameDescription *gameDesc) : Engine(syst), _gameDescription(gameDesc) {
@@ -90,6 +85,7 @@ DirectorEngine::DirectorEngine(OSystem *syst, const DirectorGameDescription *gam
 	_version = getDescriptionVersion();
 	_fixStageSize = false;
 	_fixStageRect = Common::Rect();
+	_wmMode = debugChannelSet(-1, kDebugDesktop) ? wmModeDesktop : wmModeFullscreen;
 
 	_wm = nullptr;
 
@@ -178,12 +174,10 @@ Common::Error DirectorEngine::run() {
 
 	_currentPalette = nullptr;
 
-	wmMode = debugChannelSet(-1, kDebugDesktop) ? wmModeDesktop : wmModeFullscreen;
-
 	if (debugChannelSet(-1, kDebug32bpp))
-		wmMode |= Graphics::kWMMode32bpp;
+		_wmMode |= Graphics::kWMMode32bpp;
 
-	_wm = new Graphics::MacWindowManager(wmMode, &_director3QuickDrawPatterns, getLanguage());
+	_wm = new Graphics::MacWindowManager(_wmMode, &_director3QuickDrawPatterns, getLanguage());
 	_wm->setEngine(this);
 
 	_pixelformat = _wm->_pixelformat;

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -204,6 +204,8 @@ public:
 
 	Archive *createArchive();
 
+	bool desktopEnabled();
+
 	// events.cpp
 	bool processEvents(bool captureClick = false);
 	void processEventQUIT();

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -55,6 +55,10 @@ class ManagedSurface;
 
 namespace Director {
 
+const uint32 wmModeDesktop = Graphics::kWMModalMenuMode | Graphics::kWMModeManualDrawWidgets;
+const uint32 wmModeFullscreen = Graphics::kWMModalMenuMode | Graphics::kWMModeNoDesktop
+	| Graphics::kWMModeManualDrawWidgets | Graphics::kWMModeFullscreen;
+
 class Archive;
 class Cast;
 class DirectorSound;
@@ -235,6 +239,7 @@ public:
 	const DirectorGameDescription *_gameDescription;
 	Common::FSNode _gameDataDir;
 	CastMemberID *_clipBoard;
+	uint32 _wmMode;
 
 private:
 	byte *_currentPalette;
@@ -323,7 +328,6 @@ struct DirectorPlotData {
 
 extern DirectorEngine *g_director;
 extern Debugger *g_debugger;
-extern uint32 wmMode;
 
 } // End of namespace Director
 

--- a/engines/director/game-quirks.cpp
+++ b/engines/director/game-quirks.cpp
@@ -23,6 +23,14 @@
 
 namespace Director {
 
+static void quirkKidsBox() {
+    // Kids Box opens with a 320x150 splash screen before switching to
+    // a full screen 640x480 game window. If desktop mode is off, ScummVM
+    // will pick a game window that fits the splash screen and then try
+    // to squish the full size game window into it.
+    g_director->_wmMode = Director::wmModeDesktop;
+}
+
 static void quirkLzone() {
 	SearchMan.addSubDirectoryMatching(g_director->_gameDataDir, "win_data", 0, 2);
 }
@@ -47,6 +55,7 @@ struct Quirk {
 	Common::Platform platform;
 	void (*quirk)();
 } quirks[] = {
+    { "kidsbox", Common::kPlatformMacintosh, &quirkKidsBox },
 	{ "lzone", Common::kPlatformWindows, &quirkLzone },
 	{ "mediaband", Common::kPlatformUnknown, &quirkMediaband },
 	{ "warlock", Common::kPlatformUnknown, &quirkWarlock },

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -999,9 +999,9 @@ void Lingo::setTheEntity(int entity, Datum &id, int field, Datum &d) {
 		break;
 	case kTheButtonStyle:
 		if (d.asInt())
-			g_director->_wm->_mode = Director::wmMode | Graphics::kWMModeButtonDialogStyle;
+			g_director->_wm->_mode = g_director->_wmMode | Graphics::kWMModeButtonDialogStyle;
 		else
-			g_director->_wm->_mode = Director::wmMode;
+			g_director->_wm->_mode = g_director->_wmMode;
 		break;
 	case kTheCast:
 		setTheCast(id, field, d);

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -150,8 +150,8 @@ bool Movie::loadArchive() {
 
 	// TODO: Add more options for desktop dimensions
 	if (_window == _vm->getStage()) {
-		uint16 windowWidth = debugChannelSet(-1, kDebugDesktop) ? 1024 : _movieRect.width();
-		uint16 windowHeight = debugChannelSet(-1, kDebugDesktop) ? 768 : _movieRect.height();
+		uint16 windowWidth = g_director->desktopEnabled() ? 1024 : _movieRect.width();
+		uint16 windowHeight = g_director->desktopEnabled() ? 768 : _movieRect.height();
 		if (_vm->_wm->_screenDims.width() != windowWidth || _vm->_wm->_screenDims.height() != windowHeight) {
 			_vm->_wm->resizeScreen(windowWidth, windowHeight);
 			recenter = true;
@@ -160,7 +160,7 @@ bool Movie::loadArchive() {
 		}
 	}
 
-	if (recenter && debugChannelSet(-1, kDebugDesktop))
+	if (recenter && g_director->desktopEnabled())
 		_window->center(g_director->_centerStage);
 
 	_window->setStageColor(_stageColor, true);


### PR DESCRIPTION
Kids Box boots to a 320x150 splash screen, then switches to 640x480 for the main content. This causes ScummVM to pick an awkward window size: it selects a screen based around the splash screen, then squashes the main game down into that. See the sample images below.

![scummvm-kidsbox-demo-mac-ja-00002](https://user-images.githubusercontent.com/780485/177015763-2330e083-01ae-415b-a2df-54c0e0e01911.png)
<img width="752" alt="Screen Shot 2022-07-01 at 17 21 50" src="https://user-images.githubusercontent.com/780485/177015786-f4f628c1-1fd6-4b61-851f-11a1c58e854b.png">

@sev suggested implementing a quirk which sets the screen to desktop mode, which I confirmed works well when using the desktop mode. This is the start of that work, but it doesn't quite work yet. I've moved `wmMode` to an instance variable on `DirectorEngine` so it's accessible on `g_director`. I've confirmed that the quirk is evaluated before `_wm` is instantiated, but perhaps I'm scoping this incorrectly and it's assigning to the wrong value.