### PR TITLE
GRAPHICS: IMAGE: clean up build warning

### DIFF
--- a/image/pict.h
+++ b/image/pict.h
@@ -63,7 +63,7 @@ public:
 	void destroy();
 	const Graphics::Surface *getSurface() const { return _outputSurface; }
 	const byte *getPalette() const { return _palette; }
-	const int getPaletteSize() const { return 256; }
+	int getPaletteSize() const { return 256; }
 	uint16 getPaletteColorCount() const { return _paletteColorCount; }
 
 	struct PixMap {


### PR DESCRIPTION
Clang flagged a warning here on build, which this PR cleans up: `warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]`