### PR TITLE
DIRECTOR: permit setting the desktop resolution

### DIFF
--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -86,6 +86,8 @@ DirectorEngine::DirectorEngine(OSystem *syst, const DirectorGameDescription *gam
 	_fixStageSize = false;
 	_fixStageRect = Common::Rect();
 	_wmMode = debugChannelSet(-1, kDebugDesktop) ? wmModeDesktop : wmModeFullscreen;
+	_wmWidth = 1024;
+	_wmHeight = 768;
 
 	_wm = nullptr;
 

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -242,6 +242,8 @@ public:
 	Common::FSNode _gameDataDir;
 	CastMemberID *_clipBoard;
 	uint32 _wmMode;
+	uint16 _wmWidth;
+	uint16 _wmHeight;
 
 private:
 	byte *_currentPalette;

--- a/engines/director/game-quirks.cpp
+++ b/engines/director/game-quirks.cpp
@@ -29,6 +29,10 @@ static void quirkKidsBox() {
     // will pick a game window that fits the splash screen and then try
     // to squish the full size game window into it.
     g_director->_wmMode = Director::wmModeDesktop;
+    // Game runs in 640x480; clipping it to this size ensures the main
+    // game window takes up the full screen, and only the splash is windowed.
+    g_director->_wmWidth = 640;
+    g_director->_wmHeight = 480;
 }
 
 static void quirkLzone() {

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -150,8 +150,8 @@ bool Movie::loadArchive() {
 
 	// TODO: Add more options for desktop dimensions
 	if (_window == _vm->getStage()) {
-		uint16 windowWidth = g_director->desktopEnabled() ? 1024 : _movieRect.width();
-		uint16 windowHeight = g_director->desktopEnabled() ? 768 : _movieRect.height();
+		uint16 windowWidth = g_director->desktopEnabled() ? g_director->_wmWidth : _movieRect.width();
+		uint16 windowHeight = g_director->desktopEnabled() ? g_director->_wmHeight : _movieRect.height();
 		if (_vm->_wm->_screenDims.width() != windowWidth || _vm->_wm->_screenDims.height() != windowHeight) {
 			_vm->_wm->resizeScreen(windowWidth, windowHeight);
 			recenter = true;


### PR DESCRIPTION
Currently, the resolution set by the debug desktop mode is hardcoded to 1024x768. This isn't always that convenient, especially given that many Director games target 640x480 screens.

Currently, the only place this is used is the Kids Box quirk. I've set the window to 640x480 so that the main game is fullscreen, and only the opening splash screen is displayed as a window within the desktop. It could potentially be exposed in other ways too.