### PR TITLE
DIRECTOR: LINGO: Remove all occurences of _loadedCast outside of the Cast namespace

### DIFF
--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -170,6 +170,10 @@ const Stxt *Cast::getStxt(int castId) {
 	return result;
 }
 
+int Cast::getCastSize() {
+	return _loadedCast->size();
+}
+
 Common::Rect Cast::getCastMemberInitialRect(int castId) {
 	CastMember *cast = _loadedCast->getVal(castId);
 
@@ -199,6 +203,15 @@ CastMember *Cast::setCastMember(CastMemberID castId, CastMember *cast) {
 
 	_loadedCast->setVal(castId.member, cast);
 	return cast;
+}
+
+bool Cast::eraseCastMember(CastMemberID castId) {
+	if (_loadedCast->contains(castId.member)) {
+		_loadedCast->erase(castId.member);
+		return true;
+	}
+
+	return false;
 }
 
 void Cast::setArchive(Archive *archive) {

--- a/engines/director/cast.h
+++ b/engines/director/cast.h
@@ -95,9 +95,11 @@ public:
 	void loadSoundCasts();
 
 	void copyCastStxts();
+	int getCastSize();
 	Common::Rect getCastMemberInitialRect(int castId);
 	void setCastMemberModified(int castId);
 	CastMember *setCastMember(CastMemberID castId, CastMember *cast);
+	bool eraseCastMember(CastMemberID castId);
 	CastMember *getCastMember(int castId);
 	CastMember *getCastMemberByName(const Common::String &name);
 	CastMember *getCastMemberByScriptId(int scriptId);

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1781,7 +1781,7 @@ void LB::b_duplicate(int nargs) {
 	auto channels = g_director->getCurrentMovie()->getScore()->_channels;
 
 	castMember->setModified(true);
-	g_director->getCurrentMovie()->getCast()->_loadedCast->setVal(to.u.i, castMember);
+	g_director->getCurrentMovie()->createOrReplaceCastMember(to.asMemberID(), castMember);
 
 	for (uint16 i = 0; i < currentFrame->_sprites.size(); i++) {
 		if (currentFrame->_sprites[i]->_castId == to.asMemberID())
@@ -1846,9 +1846,9 @@ void LB::b_erase(int nargs) {
 
 void LB::b_findEmpty(int nargs) {
 	Datum d = g_lingo->pop();
-	uint16  c_start = g_director->getCurrentMovie()->getCast()->_castArrayStart;
-	uint16  c_end = g_director->getCurrentMovie()->getCast()->_castArrayEnd;
-	Common::HashMap<int, CastMember *> *cast = g_director->getCurrentMovie()->getCast()->_loadedCast;
+	Cast *cast = g_director->getCurrentMovie()->getCast();
+	uint16 c_start = cast->_castArrayStart;
+	uint16 c_end = cast->_castArrayEnd;
 
 	if (d.type != CASTREF) {
 		warning("Incorrect argument type for findEmpty");
@@ -1866,7 +1866,7 @@ void LB::b_findEmpty(int nargs) {
 	}
 
 	for (uint16 i = c_start; i <= c_end; i++) {
-		if (!cast->contains((int) i) || cast->getVal((int) i)->_type == kCastTypeNull) {
+		if (!(cast->getCastMember(i) && cast->getCastMember(i)->_type != kCastTypeNull)) {
 			d.u.i = i;
 			d.type = INT;
 			g_lingo->push(d);
@@ -2097,7 +2097,7 @@ void LB::b_move(int nargs) {
 		return;
 	}
 
-	if (!g_director->getCurrentMovie()->getCast()->_loadedCast->contains(src.u.cast->member)) {
+	if (!g_director->getCurrentMovie()->getCastMember(*src.u.cast)) {
 		warning("b_move: Source CastMember doesn't exist");
 		return;
 	}
@@ -2106,11 +2106,36 @@ void LB::b_move(int nargs) {
 		warning("b_move: wrong castLib '%d' in src CastMemberID", src.u.cast->castLib);
 	}
 
-	CastMember *toMove = g_director->getCurrentMovie()->getCast()->_loadedCast->getVal(src.u.cast->member);
+	g_lingo->push(dest);
+	b_erase(1);
+
+	Movie *movie = g_director->getCurrentMovie();
+	uint16 frame = movie->getScore()->getCurrentFrame();
+	Frame *currentFrame = movie->getScore()->_frames[frame];
+	auto channels = g_director->getCurrentMovie()->getScore()->_channels;
+	
+
+	movie->getScore()->renderFrame(frame, kRenderForceUpdate);
+
+	CastMember *toMove = g_director->getCurrentMovie()->getCastMember(src.asMemberID());
 	CastMember *toReplace = new CastMember(*toMove);
 	toReplace->_type = kCastTypeNull;
-	g_director->getCurrentMovie()->getCast()->_loadedCast->setVal(dest.u.cast->member, toMove);
-	g_director->getCurrentMovie()->getCast()->_loadedCast->setVal(src.u.cast->member, toReplace);
+	g_director->getCurrentMovie()->createOrReplaceCastMember(dest.asMemberID(), toMove);
+	g_director->getCurrentMovie()->createOrReplaceCastMember(src.asMemberID(), toReplace);
+
+	for (uint16 i = 0; i < currentFrame->_sprites.size(); i++) {
+		if (currentFrame->_sprites[i]->_castId == dest.asMemberID())
+			currentFrame->_sprites[i]->setCast(dest.asMemberID());
+	}
+
+	for (uint i = 0; i < channels.size(); i++) {
+		if (channels[i]->_sprite->_castId == dest.asMemberID()) {
+			channels[i]->_sprite->setCast(CastMemberID(1, 0));
+			channels[i]->_dirty = true;
+		}
+	}
+
+	movie->getScore()->renderFrame(frame, kRenderForceUpdate);
 }
 
 void LB::b_moveableSprite(int nargs) {
@@ -2143,7 +2168,7 @@ void LB::b_pasteClipBoardInto(int nargs) {
 	auto channels = movie->getScore()->_channels;
 
 	castMember->setModified(true);
-	movie->getCast()->_loadedCast->setVal(to.u.cast->member, castMember);
+	movie->createOrReplaceCastMember(*to.u.cast, castMember);
 
 	for (uint16 i = 0; i < currentFrame->_sprites.size(); i++) {
 		if (currentFrame->_sprites[i]->_castId == to.asMemberID())

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -392,7 +392,7 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 		break;
 	case kTheCastMembers:
 		d.type = INT;
-		d.u.i = movie->getCast()->_loadedCast->size() + (movie->_sharedCast ? movie->_sharedCast->_loadedCast->size() : 0);
+		d.u.i = movie->getCast()->getCastSize() + (movie->_sharedCast ? movie->_sharedCast->getCastSize() : 0);
 		break;
 	case kTheCenterStage:
 		d.type = INT;

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -95,7 +95,6 @@ Movie::Movie(Window *window) {
 Movie::~Movie() {
 	// _movieArchive is shared with the cast, so the cast will free it
 	delete _cast;
-
 	delete _sharedCast;
 	delete _score;
 }
@@ -331,6 +330,14 @@ CastMember* Movie::createOrReplaceCastMember(CastMemberID memberID, CastMember* 
 	}
 
 	return result;
+}
+
+bool Movie::eraseCastMember(CastMemberID memberID) {
+	if (_casts.contains(memberID.castLib)) {
+		return _casts.getVal(memberID.castLib)->eraseCastMember(memberID);
+	}
+
+	return false;
 }
 
 CastMember *Movie::getCastMemberByName(const Common::String &name, int castLib) {

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -72,6 +72,7 @@ Movie::Movie(Window *window) {
 	_movieArchive = nullptr;
 
 	_cast = new Cast(this, 0);
+	_casts.setVal(_cast->_castLibID, _cast);
 	_sharedCast = nullptr;
 	_score = new Score(this);
 
@@ -311,8 +312,8 @@ void Movie::loadSharedCastsFrom(Common::String filename) {
 
 CastMember *Movie::getCastMember(CastMemberID memberID) {
 	CastMember *result = nullptr;
-	if (memberID.castLib == 0) {
-		result = _cast->getCastMember(memberID.member);
+	if (_casts.contains(memberID.castLib)) {
+		result = _casts.getVal(memberID.castLib)->getCastMember(memberID.member);
 		if (result == nullptr && _sharedCast) {
 			result = _sharedCast->getCastMember(memberID.member);
 		}
@@ -325,10 +326,8 @@ CastMember *Movie::getCastMember(CastMemberID memberID) {
 CastMember* Movie::createOrReplaceCastMember(CastMemberID memberID, CastMember* cast) {
 	CastMember *result = nullptr;
 
-	if (memberID.castLib == 0) {
-		result = _cast->setCastMember(memberID, cast);
-	} else if (memberID.castLib == 1) {
-		result = _sharedCast->setCastMember(memberID, cast);
+	if (_casts.contains(memberID.castLib)) {
+		_casts.getVal(memberID.castLib)->setCastMember(memberID, cast);
 	}
 
 	return result;
@@ -336,8 +335,8 @@ CastMember* Movie::createOrReplaceCastMember(CastMemberID memberID, CastMember* 
 
 CastMember *Movie::getCastMemberByName(const Common::String &name, int castLib) {
 	CastMember *result = nullptr;
-	if (castLib == 0) {
-		result = _cast->getCastMemberByName(name);
+	if (_casts.contains(castLib)) {
+		result = _casts.getVal(castLib)->getCastMemberByName(name);
 		if (result == nullptr && _sharedCast) {
 			result = _sharedCast->getCastMemberByName(name);
 		}
@@ -349,8 +348,8 @@ CastMember *Movie::getCastMemberByName(const Common::String &name, int castLib) 
 
 CastMemberInfo *Movie::getCastMemberInfo(CastMemberID memberID) {
 	CastMemberInfo *result = nullptr;
-	if (memberID.castLib == 0) {
-		result = _cast->getCastMemberInfo(memberID.member);
+	if (_casts.contains(memberID.castLib)) {
+		result = _casts.getVal(memberID.castLib)->getCastMemberInfo(memberID.member);
 		if (result == nullptr && _sharedCast) {
 			result = _sharedCast->getCastMemberInfo(memberID.member);
 		}
@@ -362,8 +361,8 @@ CastMemberInfo *Movie::getCastMemberInfo(CastMemberID memberID) {
 
 const Stxt *Movie::getStxt(CastMemberID memberID) {
 	const Stxt *result = nullptr;
-	if (memberID.castLib == 0) {
-		result = _cast->getStxt(memberID.member);
+	if (_casts.contains(memberID.castLib)) {
+		result = _casts.getVal(memberID.castLib)->getStxt(memberID.member);
 		if (result == nullptr && _sharedCast) {
 			result = _sharedCast->getStxt(memberID.member);
 		}
@@ -374,7 +373,7 @@ const Stxt *Movie::getStxt(CastMemberID memberID) {
 }
 
 LingoArchive *Movie::getMainLingoArch() {
-	return _cast->_lingoArchive;
+	return _casts.getVal(0)->_lingoArchive;
 }
 
 LingoArchive *Movie::getSharedLingoArch() {
@@ -383,8 +382,8 @@ LingoArchive *Movie::getSharedLingoArch() {
 
 ScriptContext *Movie::getScriptContext(ScriptType type, CastMemberID id) {
 	ScriptContext *result = nullptr;
-	if (id.castLib == 0) {
-		result = _cast->_lingoArchive->getScriptContext(type, id.member);
+	if (_casts.contains(id.castLib)) {
+		result = _casts.getVal(id.castLib)->_lingoArchive->getScriptContext(type, id.member);
 		if (result == nullptr && _sharedCast) {
 			result = _sharedCast->_lingoArchive->getScriptContext(type, id.member);
 		}

--- a/engines/director/movie.h
+++ b/engines/director/movie.h
@@ -94,7 +94,7 @@ public:
 	Common::String getMacName() const { return _macName; }
 	Window *getWindow() const { return _window; }
 	DirectorEngine *getVM() const { return _vm; }
-	Cast *getCast() const { return _cast; }
+	Cast *getCast() const { return _casts.getValOrDefault(0, nullptr); }
 	Cast *getSharedCast() const { return _sharedCast; }
 	Score *getScore() const { return _score; }
 
@@ -103,6 +103,7 @@ public:
 
 	CastMember *getCastMember(CastMemberID memberID);
 	CastMember *createOrReplaceCastMember(CastMemberID memberID, CastMember *cast);
+	bool eraseCastMember(CastMemberID memberID);
 	CastMember *getCastMemberByName(const Common::String &name, int castLib);
 	CastMemberInfo *getCastMemberInfo(CastMemberID memberID);
 	const Stxt *getStxt(CastMemberID memberID);

--- a/engines/director/movie.h
+++ b/engines/director/movie.h
@@ -176,6 +176,7 @@ private:
 	DirectorEngine *_vm;
 	Lingo *_lingo;
 	Cast *_cast;
+	Common::HashMap<int, Cast *> _casts;
 	Score *_score;
 
 	uint32 _flags;

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -562,14 +562,8 @@ void Score::renderSprites(uint16 frameId, RenderMode mode) {
 				_window->addDirtyRect(channel->getBbox());
 
 			if (currentSprite->_cast && currentSprite->_cast->_erase) {
-				auto cast = currentSprite->_cast->getCast()->_loadedCast;
-				for (auto it = cast->begin(); it != cast->end(); ++it) {
-					if (it->_value == currentSprite->_cast) {
-						cast->erase(it);
-						currentSprite->_cast->_erase = false;
-						break;
-					}
-				}
+				_movie->eraseCastMember(currentSprite->_castId);
+				currentSprite->_cast->_erase = false;
 
 				currentSprite->setCast(currentSprite->_castId);
 				nextSprite->setCast(nextSprite->_castId);


### PR DESCRIPTION
These changes remove unnecessary occurrences of _loadedCast outside of the Cast namespaces and also implement multiple casts, something which will be used in D5.