### PR TITLE
SCUMM: Add delay to "Turbo Technologies" PC Engine Loom loading screen

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -730,15 +730,16 @@ void ScummEngine_v5::o5_animateActor() {
 }
 
 void ScummEngine_v5::o5_breakHere() {
-	// WORKAROUND: The PC Engine shows a Turbo Technologies loading screen.
-	// In the Mednafen emulator it's shown for about 10 seconds while the
-	// game is loading resources. ScummVM does that in the blink of an eye.
+	// WORKAROUND: The English PC Engine version of Loom shows a Turbo
+	// Technologies loading screen. In the Mednafen emulator it's shown for
+	// about 10 seconds while the game is loading resources. ScummVM does
+	// that in the blink of an eye.
 	//
 	// Injecting the delay into the breakHere instruction seems like the
 	// least intrusive way of adding the delay. The script calls it a number
 	// of times, but only once from room 69.
 
-	if (_game.id == GID_LOOM && _game.platform == Common::kPlatformPCEngine && vm.slot[_currentScript].number == 44 && _currentRoom == 69) {
+  if (_game.id == GID_LOOM && _game.platform == Common::kPlatformPCEngine && _language == Common::EN_ANY && vm.slot[_currentScript].number == 44 && _currentRoom == 69) {
 		vm.slot[_currentScript].delay = 120;
 		vm.slot[_currentScript].status = ssPaused;
 	}

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -730,6 +730,19 @@ void ScummEngine_v5::o5_animateActor() {
 }
 
 void ScummEngine_v5::o5_breakHere() {
+	// WORKAROUND: The PC Engine shows a Turbo Technologies loading screen.
+	// In the Mednafen emulator it's shown for about 10 seconds while the
+	// game is loading resources. ScummVM does that in the blink of an eye.
+	//
+	// Injecting the delay into the breakHere instruction seems like the
+	// least intrusive way of adding the delay. The script calls it a number
+	// of times, but only once from room 69.
+
+	if (_game.id == GID_LOOM && _game.platform == Common::kPlatformPCEngine && vm.slot[_currentScript].number == 44 && _currentRoom == 69) {
+		vm.slot[_currentScript].delay = 120;
+		vm.slot[_currentScript].status = ssPaused;
+	}
+
 	updateScriptPtr();
 	_currentScript = 0xFF;
 }


### PR DESCRIPTION
This adds an artificial delay to the "Turbo Technologies" loading screen in the PC Engine version of Loom. The original gets its delay - about 10 seconds, judging by the emulator I tried - by loading resources. ScummVM does that in the blink of an eye. Of course, we don't want the full delay. Just a tasteful one to give the player a chance to read it.

I have only tested this with the English version of the game. It would be great if someone could test the Japanese one as well.

This is the script. Attaching the delay to the breakHere opcode was the best way I could think of.

[script-44.dmp.txt](https://github.com/scummvm/scummvm/files/9056378/script-44.dmp.txt)
