### PR TITLE
DIRECTOR: LINGO: Prevent execution of cast script in presence of D3-sprite script

### DIFF
--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -127,12 +127,15 @@ void Movie::queueSpriteEvent(Common::Queue<LingoEvent> &queue, LEvent event, int
 	if (sprite->_scriptId.member) {
 		ScriptContext *script = getScriptContext(kScoreScript, sprite->_scriptId);
 		if (script) {
-			// In D3 the event lingo is not contained in a handler
-			// If sprite is immediate, its script is run on mouseDown, otherwise on mouseUp
-			if (((event == kEventMouseDown && sprite->_immediate) || (event == kEventMouseUp && !sprite->_immediate))
-					&& script->_eventHandlers.contains(kEventGeneric)) {
-				queue.push(LingoEvent(kEventGeneric, eventId, kScoreScript, sprite->_scriptId, false, spriteId));
+			if (script->_eventHandlers.contains(kEventGeneric)) {
+				// D3-style sprite script, not contained in a handler
+				// If sprite is immediate, its script is run on mouseDown, otherwise on mouseUp
+				if ((event == kEventMouseDown && sprite->_immediate) || (event == kEventMouseUp && !sprite->_immediate)) {
+					queue.push(LingoEvent(kEventGeneric, eventId, kScoreScript, sprite->_scriptId, false, spriteId));
+				}
+				return; // Do not execute the cast script if there is a D3-style sprite script
 			} else if (script->_eventHandlers.contains(event)) {
+				// D4-style event handler
 				queue.push(LingoEvent(event, eventId, kScoreScript, sprite->_scriptId, false, spriteId));
 			}
 		}


### PR DESCRIPTION
This change returns execution of spriteEvent script when there is a D3-sprite script on the sprite. This doesn't allow the castmember script to execute in such a case. This fixes https://trello.com/c/zeckOxrU/499-the-apartment-30-40-wrong-navigation