### PR TITLE
DIRECTOR: Prevent changing of spriteType for QDShapes

### DIFF
--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -459,7 +459,8 @@ void Sprite::setCast(CastMemberID memberID) {
 
 	_castId = memberID;
 	_cast = _movie->getCastMember(_castId);
-	if (g_director->getVersion() >= 400)
+	//As QDShapes don't have an associated cast, we must not change their _SpriteType.
+	if (g_director->getVersion() >= 400 && !isQDShape())
 		_spriteType = kCastMemberSprite;
 
 	if (_cast) {


### PR DESCRIPTION
This change renders the QDShape sprites correctly. QDShape in D4 don't have a CastMember associated with the sprite in the score, while setCast() changed the _spriteType, which didn't render them correctly in D4. This change prevents this erroneous change of _spriteType in setCast() for QDShapes