### PR TITLE
AMIGAOS: Revert dynamic detection features

### DIFF
--- a/configure
+++ b/configure
@@ -2585,8 +2585,9 @@ case $_host_os in
 			define_in_config_if_yes "$_debug_build" 'DEBUG_BUILD'
 		fi
 		# When building dynamic, add everything possible as plugin
+		# except detection_features (see bug #13603)
 		if test "$_dynamic_modules" = yes ; then
-			_detection_features_static=no
+			_detection_features_static=yes
 			_plugins_default=dynamic
 		fi
 		# Use 'long' for ScummVM's 4 byte typedef, because AmigaOS


### PR DESCRIPTION
see bug #13603 and advice from @dwatteau.(thank you)

The detection code (not the engines themselves) should only be moved to a dynamic plugin when the backend or memory is extremely limited (e.g. the Nintendo DS and Dreamcast ports, which have very limited RAM on board).

I could live with not backporting, I'll do a manual change for the release build then.

Thank you