### PR TITLE
DIRECTOR: failure to fetch from archive may not be fatal

### DIFF
--- a/engines/director/cursor.cpp
+++ b/engines/director/cursor.cpp
@@ -176,11 +176,14 @@ void Cursor::readFromResource(Datum resourceId) {
 		bool readSuccessful = false;
 
 		for (Common::HashMap<Common::String, Archive *, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo>::iterator it = g_director->_openResFiles.begin(); it != g_director->_openResFiles.end(); ++it) {
-			Common::SeekableReadStreamEndian *cursorStream;
+			Common::SeekableReadStreamEndian *cursorStream = nullptr;
+			MacArchive *arch = (MacArchive *)it->_value;
 
-			cursorStream = ((MacArchive *)it->_value)->getResource(MKTAG('C', 'U', 'R', 'S'), resourceId.asInt());
-			if (!cursorStream)
-				cursorStream = ((MacArchive *)it->_value)->getResource(MKTAG('C', 'R', 'S', 'R'), resourceId.asInt());
+			if (arch->hasResource(MKTAG('C', 'U', 'R', 'S'), resourceId.asInt()))
+				cursorStream = arch->getResource(MKTAG('C', 'U', 'R', 'S'), resourceId.asInt());
+
+			if (!cursorStream && arch->hasResource(MKTAG('C', 'R', 'S', 'R'), resourceId.asInt()))
+				cursorStream = arch->getResource(MKTAG('C', 'R', 'S', 'R'), resourceId.asInt());
 
 			if (cursorStream && readFromStream(*((Common::SeekableReadStream *)cursorStream), false, 0)) {
 				_usePalette = true;


### PR DESCRIPTION
Starting with 1ac3cb27ac53b1c3e6b9160e611e6e8ea1cd8fac, Bandai Previews Vol. 3 crashes on startup with a failure to load a cursor (`RIFXArchive::getResource(): Archive does not contain 'CURS' 280!`). That commit just registers a new archive to search, so I was confused at first why it would cause it to fail to find the cursor, until I checked the backtrace.

The cursor fetching happens in a loop, here in `Cursor::readFromResource`: https://github.com/scummvm/scummvm/blob/abea37c9bbd92e2f864fb9c7cc1453b56c144572/engines/director/cursor.cpp#L181 It walks through every archive looking for the cursor, and breaks once it's found it. However, inside the archive code, if it fails to find the requested resource, it simply calls `error` instead of returning a `nullptr` so the caller can act on it: https://github.com/scummvm/scummvm/blob/2d30fcb84fdaec1afa9c757f1b9a60485c32fb66/engines/director/archive.cpp#L913

The reason Bandai Previews worked before is because it only had one archive open at the time, and the archive containing the cursor was the first one it accessed. Now that we've inserted a second archive into the resources, it's landing on the archive that *doesn't* contain the cursor and getting the error. I couldn't find it in the documentation, but it seems like `error()` is for unrecoverable errors, is that right? If so, it seems like the right solution here is to switch from `error()` to logging and returning `nullptr` so the caller can choose what to do.

cc @sev- - this is based on our discussion in Discord.