### PR TITLE
ENGINES: Change the MetaEngineDetection interface to match MetaEngine

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -962,10 +962,10 @@ static void listGames(const Common::String &engineID) {
 			continue;
 		}
 
-		if (all || (p->getEngineId() == engineID)) {
+		if (all || (p->getName() == engineID)) {
 			PlainGameList list = p->get<MetaEngineDetection>().getSupportedGames();
 			for (PlainGameList::const_iterator v = list.begin(); v != list.end(); ++v) {
-				printf("%-30s %s\n", buildQualifiedGameName(p->get<MetaEngineDetection>().getEngineId(), v->gameId).c_str(), v->description);
+				printf("%-30s %s\n", buildQualifiedGameName(p->get<MetaEngineDetection>().getName(), v->gameId).c_str(), v->description);
 			}
 		}
 	}
@@ -982,10 +982,10 @@ static void listAllGames(const Common::String &engineID) {
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
 		const MetaEngineDetection &metaEngine = (*iter)->get<MetaEngineDetection>();
 
-		if (any || (metaEngine.getEngineId() == engineID)) {
+		if (any || (metaEngine.getName() == engineID)) {
 			PlainGameList list = metaEngine.getSupportedGames();
 			for (PlainGameList::const_iterator v = list.begin(); v != list.end(); ++v) {
-				printf("%-30s %s\n", buildQualifiedGameName(metaEngine.getEngineId(), v->gameId).c_str(), v->description);
+				printf("%-30s %s\n", buildQualifiedGameName(metaEngine.getName(), v->gameId).c_str(), v->description);
 			}
 		}
 	}
@@ -1004,7 +1004,7 @@ static void listEngines() {
 			continue;
 		}
 
-		printf("%-15s %s\n", p->get<MetaEngineDetection>().getEngineId(), p->get<MetaEngineDetection>().getName());
+		printf("%-15s %s\n", p->get<MetaEngineDetection>().getName(), p->get<MetaEngineDetection>().getEngineName());
 	}
 }
 
@@ -1016,7 +1016,7 @@ static void listAllEngines() {
 	const PluginList &plugins = EngineMan.getPlugins();
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
 		const MetaEngineDetection &metaEngine = (*iter)->get<MetaEngineDetection>();
-		printf("%-15s %s\n", metaEngine.getEngineId(), metaEngine.getName());
+		printf("%-15s %s\n", metaEngine.getName(), metaEngine.getEngineName());
 	}
 }
 
@@ -1070,10 +1070,10 @@ static void listDebugFlags(const Common::String &engineID) {
 		const PluginList &plugins = EngineMan.getPlugins();
 		for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
 			const MetaEngineDetection &metaEngine = (*iter)->get<MetaEngineDetection>();
-			if (metaEngine.getEngineId() == engineID) {
+			if (metaEngine.getName() == engineID) {
 				printf("Flag name       Flag description                                           \n");
 				printf("--------------- ------------------------------------------------------\n");
-				printf("ID=%-12s Name=%s\n", metaEngine.getEngineId(), metaEngine.getName());
+				printf("ID=%-12s Name=%s\n", metaEngine.getName(), metaEngine.getEngineName());
 				printDebugFlags(metaEngine.getDebugChannels());
 				return;
 			}
@@ -1090,7 +1090,7 @@ static void listAllEngineDebugFlags() {
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
 		const MetaEngineDetection &metaEngine = (*iter)->get<MetaEngineDetection>();
 		printf("--------------- ------------------------------------------------------\n");
-		printf("ID=%-12s Name=%s\n", metaEngine.getEngineId(), metaEngine.getName());
+		printf("ID=%-12s Name=%s\n", metaEngine.getName(), metaEngine.getEngineName());
 		printDebugFlags(metaEngine.getDebugChannels());
 	}
 }

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -132,8 +132,8 @@ static const Plugin *detectPlugin() {
 	}
 
 	// Query the plugin for the game descriptor
-	printf("   Looking for a plugin supporting this target... %s\n", plugin->getName());
 	const MetaEngineDetection &metaEngine = plugin->get<MetaEngineDetection>();
+	printf("   Looking for a plugin supporting this target... %s\n", metaEngine.getEngineName());
 	DebugMan.addAllDebugChannels(metaEngine.getDebugChannels());
 	PlainGameDescriptor game = metaEngine.findGame(gameId.c_str());
 	if (!game.gameId) {
@@ -224,7 +224,7 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 		// Print a warning; note that scummvm_main will also
 		// display an error dialog, so we don't have to do this here.
 		warning("%s failed to instantiate engine: %s (target '%s', path '%s')",
-			plugin->getName(),
+			metaEngineDetection.getEngineName(),
 			err.getDesc().c_str(),
 			target.c_str(),
 			dir.getPath().c_str()

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -55,14 +55,6 @@ const char *Plugin::getName() const {
 	return _pluginObject->getName();
 }
 
-const char *Plugin::getEngineId() const {
-	if (_type == PLUGIN_TYPE_ENGINE_DETECTION) {
-		return get<MetaEngineDetection>().getEngineId();
-	}
-
-	return nullptr;
-}
-
 StaticPlugin::StaticPlugin(PluginObject *pluginobject, PluginType type) {
 	assert(pluginobject);
 	assert(type < PLUGIN_TYPE_MAX);
@@ -297,16 +289,16 @@ const Plugin *PluginManager::getEngineFromMetaEngine(const Plugin *plugin) {
 	const Plugin *enginePlugin = nullptr;
 
 	// Use the engineID from MetaEngine for comparison.
-	Common::String metaEnginePluginName = plugin->getEngineId();
+	Common::String metaEnginePluginName = plugin->getName();
 
 	enginePlugin = PluginMan.findEnginePlugin(metaEnginePluginName);
 
 	if (enginePlugin) {
-		debug(9, "MetaEngine: %s \t matched to \t Engine: %s", plugin->getName(), enginePlugin->getFileName());
+		debug(9, "MetaEngine: %s \t matched to \t Engine: %s", plugin->get<MetaEngineDetection>().getEngineName(), enginePlugin->getFileName());
 		return enginePlugin;
 	}
 
-	debug(9, "MetaEngine: %s couldn't find a match for an engine plugin.", plugin->getName());
+	debug(9, "MetaEngine: %s couldn't find a match for an engine plugin.", plugin->get<MetaEngineDetection>().getEngineName());
 	return nullptr;
 }
 
@@ -322,7 +314,7 @@ const Plugin *PluginManager::getMetaEngineFromEngine(const Plugin *plugin) {
 	Common::String enginePluginName(plugin->getName());
 
 	for (PluginList::const_iterator itr = pl.begin(); itr != pl.end(); itr++) {
-		Common::String metaEngineName = (*itr)->getEngineId();
+		Common::String metaEngineName = (*itr)->getName();
 
 		if (metaEngineName.equalsIgnoreCase(enginePluginName)) {
 			metaEngine = (*itr);
@@ -331,7 +323,7 @@ const Plugin *PluginManager::getMetaEngineFromEngine(const Plugin *plugin) {
 	}
 
 	if (metaEngine) {
-		debug(9, "Engine: %s matched to MetaEngine: %s", plugin->getFileName(), metaEngine->getName());
+		debug(9, "Engine: %s matched to MetaEngine: %s", plugin->getFileName(), metaEngine->get<MetaEngineDetection>().getEngineName());
 		return metaEngine;
 	}
 
@@ -683,7 +675,7 @@ QualifiedGameList EngineManager::findGamesMatching(const Common::String &engineI
 
 			PlainGameDescriptor pluginResult = engine.findGame(gameId.c_str());
 			if (pluginResult.gameId) {
-				results.push_back(QualifiedGameDescriptor(engine.getEngineId(), pluginResult));
+				results.push_back(QualifiedGameDescriptor(engine.getName(), pluginResult));
 			}
 		}
 	} else {
@@ -713,7 +705,7 @@ QualifiedGameList EngineManager::findGameInLoadedPlugins(const Common::String &g
 		PlainGameDescriptor pluginResult = engine.findGame(gameId.c_str());
 
 		if (pluginResult.gameId) {
-			results.push_back(QualifiedGameDescriptor(engine.getEngineId(), pluginResult));
+			results.push_back(QualifiedGameDescriptor(engine.getName(), pluginResult));
 		}
 	}
 
@@ -815,7 +807,7 @@ const Plugin *EngineManager::findPlugin(const Common::String &engineId) const {
 	const PluginList &plugins = getPlugins();
 
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); iter++)
-		if (engineId == (*iter)->get<MetaEngineDetection>().getEngineId())
+		if (engineId == (*iter)->get<MetaEngineDetection>().getName())
 			return *iter;
 
 	return nullptr;
@@ -887,7 +879,7 @@ QualifiedGameDescriptor EngineManager::findTarget(const Common::String &target, 
 	if (plugin)
 		*plugin = foundPlugin;
 
-	return QualifiedGameDescriptor(engine.getEngineId(), desc);
+	return QualifiedGameDescriptor(engine.getName(), desc);
 }
 
 void EngineManager::upgradeTargetIfNecessary(const Common::String &target) const {
@@ -951,7 +943,7 @@ void EngineManager::upgradeTargetForEngineId(const Common::String &target) const
 		DetectedGames candidates = metaEngine.detectGames(files);
 		if (candidates.empty()) {
 			warning("No games supported by the engine '%s' were found in path '%s' when upgrading target '%s'",
-			        metaEngine.getEngineId(), path.c_str(), target.c_str());
+			        metaEngine.getName(), path.c_str(), target.c_str());
 			return;
 		}
 

--- a/base/plugins.h
+++ b/base/plugins.h
@@ -163,7 +163,6 @@ public:
 	 **/
 	PluginType getType() const;
 	const char *getName() const;
-	const char *getEngineId() const;
 
 	template <class T>
 	T &get() const {

--- a/devtools/create_engine/files/detection.h
+++ b/devtools/create_engine/files/detection.h
@@ -47,11 +47,11 @@ public:
 	XyzzyMetaEngineDetection();
 	~XyzzyMetaEngineDetection() override {}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "xyzzy";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Xyzzy";
 	}
 

--- a/engines/access/detection.cpp
+++ b/engines/access/detection.cpp
@@ -46,11 +46,11 @@ public:
 		_maxScanDepth = 3;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "access";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Access";
 	}
 

--- a/engines/adl/detection.cpp
+++ b/engines/adl/detection.cpp
@@ -472,11 +472,11 @@ class AdlMetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
 	AdlMetaEngineDetection() : AdvancedMetaEngineDetection(gameFileDescriptions, sizeof(AdlGameDescription), adlGames, optionsList) { }
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "ADL";
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "adl";
 	}
 

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -186,7 +186,7 @@ DetectedGame AdvancedMetaEngineDetection::toDetectedGame(const ADDetectedGame &a
 			title = extraInfo->gameName.c_str();
 	}
 
-	DetectedGame game(getEngineId(), desc->gameId, title, desc->language, desc->platform, extra, ((desc->flags & (ADGF_UNSUPPORTED | ADGF_WARNING)) != 0));
+	DetectedGame game(getName(), desc->gameId, title, desc->language, desc->platform, extra, ((desc->flags & (ADGF_UNSUPPORTED | ADGF_WARNING)) != 0));
 	game.hasUnknownFiles = adGame.hasUnknownFiles;
 	game.matchedFiles = adGame.matchedFiles;
 
@@ -581,7 +581,7 @@ ADDetectedGames AdvancedMetaEngineDetection::detectGame(const Common::FSNode &pa
 	const ADGameDescription *g;
 	const byte *descPtr;
 
-	debugC(3, kDebugGlobalDetection, "Starting detection for engine '%s' in dir '%s'", getEngineId(), parent.getPath().c_str());
+	debugC(3, kDebugGlobalDetection, "Starting detection for engine '%s' in dir '%s'", getName(), parent.getPath().c_str());
 
 	preprocessDescriptions();
 
@@ -840,7 +840,7 @@ void AdvancedMetaEngineDetection::preprocessDescriptions() {
 			if (strchr(fileDesc->fileName, '/')) {
 				if (!(_flags & kADFlagMatchFullPaths))
 					warning("Path component detected in entry for '%s' in engine '%s' but no kADFlagMatchFullPaths is set",
-						g->gameId, getEngineId());
+						g->gameId, getName());
 
 				Common::StringTokenizer tok(fileDesc->fileName, "/");
 
@@ -858,7 +858,7 @@ void AdvancedMetaEngineDetection::preprocessDescriptions() {
 		// Check if the detection entry have only files from the blacklist
 		if (isEntryGrayListed(g)) {
 			debug(0, "WARNING: Detection entry for '%s' in engine '%s' contains only blacklisted names. Add more files to the entry (%s)",
-				g->gameId, getEngineId(), g->filesDescriptions[0].md5);
+				g->gameId, getName(), g->filesDescriptions[0].md5);
 		}
 	}
 }

--- a/engines/agi/detection.cpp
+++ b/engines/agi/detection.cpp
@@ -168,11 +168,11 @@ public:
 		_flags = kADFlagMatchFullPaths;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "agi";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "AGI preAGI + v2 + v3";
 	}
 

--- a/engines/agos/detection.cpp
+++ b/engines/agos/detection.cpp
@@ -148,11 +148,11 @@ public:
 		return Engines::findGameID(gameId, _gameIds, obsoleteGameIDsTable);
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "agos";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "AGOS";
 	}
 

--- a/engines/ags/detection.h
+++ b/engines/ags/detection.h
@@ -70,11 +70,11 @@ public:
 	AGSMetaEngineDetection();
 	~AGSMetaEngineDetection() override {}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "ags";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Adventure Game Studio";
 	}
 

--- a/engines/asylum/detection.cpp
+++ b/engines/asylum/detection.cpp
@@ -55,11 +55,11 @@ public:
 		return detectGameFilebased(allFiles, Asylum::fileBasedFallback);
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "asylum";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Sanitarium";
 	}
 

--- a/engines/avalanche/detection.cpp
+++ b/engines/avalanche/detection.cpp
@@ -57,11 +57,11 @@ public:
 	AvalancheMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, sizeof(AvalancheGameDescription), avalancheGames) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "avalanche";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Avalanche";
 	}
 

--- a/engines/bbvs/detection.cpp
+++ b/engines/bbvs/detection.cpp
@@ -99,11 +99,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "bbvs";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "MTV's Beavis and Butt-head in Virtual Stupidity";
 	}
 

--- a/engines/bladerunner/detection.cpp
+++ b/engines/bladerunner/detection.cpp
@@ -122,8 +122,8 @@ class BladeRunnerMetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
 	BladeRunnerMetaEngineDetection();
 
-	const char *getEngineId() const override;
 	const char *getName() const override;
+	const char *getEngineName() const override;
 	const char *getOriginalCopyright() const override;
 	const DebugChannelDef *getDebugChannels() const override;
 };
@@ -145,11 +145,11 @@ BladeRunnerMetaEngineDetection::BladeRunnerMetaEngineDetection()
 		_flags = kADFlagUseExtraAsHint;
 }
 
-const char *BladeRunnerMetaEngineDetection::getEngineId() const {
+const char *BladeRunnerMetaEngineDetection::getName() const {
 	return "bladerunner";
 }
 
-const char *BladeRunnerMetaEngineDetection::getName() const {
+const char *BladeRunnerMetaEngineDetection::getEngineName() const {
 	return "Blade Runner";
 }
 

--- a/engines/buried/detection.cpp
+++ b/engines/buried/detection.cpp
@@ -75,11 +75,11 @@ public:
 		_directoryGlobs = Buried::directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "buried";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "The Journeyman Project 2: Buried in Time";
 	}
 

--- a/engines/cge/detection.cpp
+++ b/engines/cge/detection.cpp
@@ -141,11 +141,11 @@ public:
 	CGEMetaEngineDetection() : AdvancedMetaEngineDetection(CGE::gameDescriptions, sizeof(ADGameDescription), CGEGames, optionsList) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "cge";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "CGE";
 	}
 

--- a/engines/cge2/detection.cpp
+++ b/engines/cge2/detection.cpp
@@ -145,11 +145,11 @@ public:
 	CGE2MetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, sizeof(ADGameDescription), CGE2Games, optionsList) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "cge2";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "CGE2";
 	}
 

--- a/engines/chewy/detection.cpp
+++ b/engines/chewy/detection.cpp
@@ -129,11 +129,11 @@ public:
 		_flags = kADFlagMatchFullPaths;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "chewy";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Chewy: Esc from F5";
 	}
 

--- a/engines/cine/detection.cpp
+++ b/engines/cine/detection.cpp
@@ -77,11 +77,11 @@ public:
 		_guiOptions = GUIO3(GUIO_NOSPEECH, GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_TRANSPARENT_DIALOG_BOXES);
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "cine";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Cinematique evo 1";
 	}
 

--- a/engines/composer/detection.cpp
+++ b/engines/composer/detection.cpp
@@ -58,11 +58,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "composer";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Magic Composer";
 	}
 

--- a/engines/cruise/detection.cpp
+++ b/engines/cruise/detection.cpp
@@ -204,11 +204,11 @@ public:
 		_guiOptions = GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI);
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "cruise";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Cinematique evo 2";
 	}
 

--- a/engines/cryo/detection.cpp
+++ b/engines/cryo/detection.cpp
@@ -123,11 +123,11 @@ public:
 	CryoMetaEngineDetection() : AdvancedMetaEngineDetection(Cryo::gameDescriptions, sizeof(ADGameDescription), cryoGames) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "cryo";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Cryo";
 	}
 

--- a/engines/cryomni3d/detection.cpp
+++ b/engines/cryomni3d/detection.cpp
@@ -67,11 +67,11 @@ public:
 		return detectGameFilebased(allFiles, fileBased);
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "cryomni3d";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Cryo Omni3D";
 	}
 

--- a/engines/director/detection.cpp
+++ b/engines/director/detection.cpp
@@ -84,11 +84,11 @@ public:
 			_customTarget[customTargetList[i].name] = true;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "director";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Macromedia Director";
 	}
 

--- a/engines/dm/detection.cpp
+++ b/engines/dm/detection.cpp
@@ -98,11 +98,11 @@ public:
 	DMMetaEngineDetection() : AdvancedMetaEngineDetection(DM::gameDescriptions, sizeof(DMADGameDescription), DMGames, optionsList) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "dm";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Dungeon Master";
 	}
 

--- a/engines/draci/detection.cpp
+++ b/engines/draci/detection.cpp
@@ -95,11 +95,11 @@ public:
 	DraciMetaEngineDetection() : AdvancedMetaEngineDetection(Draci::gameDescriptions, sizeof(ADGameDescription), draciGames) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "draci";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Draci Historie";
 	}
 

--- a/engines/dragons/detection.cpp
+++ b/engines/dragons/detection.cpp
@@ -126,11 +126,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "dragons";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Blazing Dragons";
 	}
 

--- a/engines/drascula/detection.cpp
+++ b/engines/drascula/detection.cpp
@@ -317,11 +317,11 @@ public:
 		_guiOptions = GUIO2(GUIO_NOMIDI, GAMEOPTION_ORIGINAL_SAVELOAD);
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "drascula";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Drascula: The Vampire Strikes Back";
 	}
 

--- a/engines/dreamweb/detection.cpp
+++ b/engines/dreamweb/detection.cpp
@@ -110,11 +110,11 @@ public:
 		_guiOptions = GUIO1(GUIO_NOMIDI);
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "dreamweb";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "DreamWeb";
 	}
 

--- a/engines/glk/detection.h
+++ b/engines/glk/detection.h
@@ -32,11 +32,11 @@ class GlkMetaEngineDetection : public MetaEngineDetection {
 public:
 	GlkMetaEngineDetection() : MetaEngineDetection() {}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Glk";
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "glk";
 	}
 

--- a/engines/gnap/detection.cpp
+++ b/engines/gnap/detection.cpp
@@ -83,11 +83,11 @@ public:
 		_maxScanDepth = 3;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "gnap";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Gnap";
 	}
 

--- a/engines/gob/detection/detection.cpp
+++ b/engines/gob/detection/detection.cpp
@@ -47,11 +47,11 @@ class GobMetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
 	GobMetaEngineDetection();
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "gob";
 	}
 
-	const char *getName() const override;
+	const char *getEngineName() const override;
 	const char *getOriginalCopyright() const override;
 
 	const DebugChannelDef *getDebugChannels() const override {
@@ -168,7 +168,7 @@ const Gob::GOBGameDescription *GobMetaEngineDetection::detectOnceUponATime(const
 	return &Gob::fallbackOnceUpon[gameType][platform];
 }
 
-const char *GobMetaEngineDetection::getName() const {
+const char *GobMetaEngineDetection::getEngineName() const {
 	return "Gob";
 }
 

--- a/engines/griffon/detection.cpp
+++ b/engines/griffon/detection.cpp
@@ -82,11 +82,11 @@ public:
 			) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "griffon";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Griffon Engine";
 	}
 

--- a/engines/grim/detection.cpp
+++ b/engines/grim/detection.cpp
@@ -641,11 +641,11 @@ public:
 		return Engines::findGameID(gameid, _gameIds, obsoleteGameIDsTable);
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Grim";
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "grim";
 	}
 

--- a/engines/groovie/detection.cpp
+++ b/engines/groovie/detection.cpp
@@ -340,11 +340,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "groovie";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Groovie";
 	}
 

--- a/engines/hadesch/detection.cpp
+++ b/engines/hadesch/detection.cpp
@@ -74,11 +74,11 @@ public:
 		_directoryGlobs = Hadesch::directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "hadesch";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Hades Challenge";
 	}
 

--- a/engines/hdb/detection.cpp
+++ b/engines/hdb/detection.cpp
@@ -137,11 +137,11 @@ public:
 	HDBMetaEngineDetection() : AdvancedMetaEngineDetection(HDB::gameDescriptions, sizeof(ADGameDescription), hdbGames, optionsList) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "hdb";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Hyperspace Delivery Boy!";
 	}
 

--- a/engines/hopkins/detection.cpp
+++ b/engines/hopkins/detection.cpp
@@ -80,11 +80,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "hopkins";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Hopkins FBI";
 	}
 

--- a/engines/hugo/detection.cpp
+++ b/engines/hugo/detection.cpp
@@ -132,11 +132,11 @@ public:
 	HugoMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, sizeof(HugoGameDescription), hugoGames) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "hugo";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Hugo";
 	}
 

--- a/engines/hypno/detection.cpp
+++ b/engines/hypno/detection.cpp
@@ -324,11 +324,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "hypno";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Hypno";
 	}
 

--- a/engines/icb/detection.cpp
+++ b/engines/icb/detection.cpp
@@ -83,9 +83,9 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getName() const override { return "In Cold Blood Engine"; }
+	const char *getEngineName() const override { return "In Cold Blood Engine"; }
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "icb";
 	}
 

--- a/engines/illusions/detection.cpp
+++ b/engines/illusions/detection.cpp
@@ -116,11 +116,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "illusions";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Illusions";
 	}
 

--- a/engines/kingdom/detection.cpp
+++ b/engines/kingdom/detection.cpp
@@ -83,11 +83,11 @@ public:
 	KingdomMetaEngineDetection() : AdvancedMetaEngineDetection(Kingdom::gameDescriptions, sizeof(ADGameDescription), kingdomGames) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "kingdom";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Kingdom: The Far Reaches' Engine";
 	}
 

--- a/engines/kyra/detection.cpp
+++ b/engines/kyra/detection.cpp
@@ -179,11 +179,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "kyra";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Kyra";
 	}
 

--- a/engines/lab/detection.cpp
+++ b/engines/lab/detection.cpp
@@ -102,11 +102,11 @@ public:
 		_flags = kADFlagUseExtraAsHint;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "lab";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Labyrinth of Time";
 	}
 

--- a/engines/lastexpress/detection.cpp
+++ b/engines/lastexpress/detection.cpp
@@ -229,11 +229,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "lastexpress";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "The Last Express";
 	}
 

--- a/engines/lilliput/detection.cpp
+++ b/engines/lilliput/detection.cpp
@@ -119,11 +119,11 @@ public:
 	LilliputMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, sizeof(LilliputGameDescription), lilliputGames) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "lilliput";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Lilliput";
 	}
 

--- a/engines/lure/detection.cpp
+++ b/engines/lure/detection.cpp
@@ -279,11 +279,11 @@ public:
 		_guiOptions = GUIO1(GUIO_NOSPEECH);
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "lure";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Lure of the Temptress";
 	}
 

--- a/engines/macventure/detection.cpp
+++ b/engines/macventure/detection.cpp
@@ -71,11 +71,11 @@ public:
 		_md5Bytes = 5000000; // TODO: Upper limit, adjust it once all games are added
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "macventure";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "MacVenture";
 	}
 

--- a/engines/made/detection.cpp
+++ b/engines/made/detection.cpp
@@ -60,11 +60,11 @@ public:
 	MadeMetaEngineDetection() : AdvancedMetaEngineDetection(Made::gameDescriptions, sizeof(Made::MadeGameDescription), madeGames, Made::optionsList) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "made";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "MADE";
 	}
 

--- a/engines/mads/detection.cpp
+++ b/engines/mads/detection.cpp
@@ -139,11 +139,11 @@ public:
 		_maxScanDepth = 3;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "mads";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "MADS";
 	}
 

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -141,7 +141,10 @@ public:
 	virtual ~MetaEngineDetection() {}
 
 	/** Get the engine ID. */
-	virtual const char *getEngineId() const = 0;
+	virtual const char *getName() const = 0;
+
+	/** Get the engine name. */
+	virtual const char *getEngineName() const = 0;
 
 	/** Return some copyright information about the original engine. */
 	virtual const char *getOriginalCopyright() const = 0;

--- a/engines/mohawk/detection.cpp
+++ b/engines/mohawk/detection.cpp
@@ -89,11 +89,11 @@ public:
 		return detectGameFilebased(allFiles, Mohawk::fileBased);
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "mohawk";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Mohawk";
 	}
 

--- a/engines/mortevielle/detection.cpp
+++ b/engines/mortevielle/detection.cpp
@@ -48,11 +48,11 @@ public:
 		_flags = kADFlagUseExtraAsHint;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "mortevielle";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Mortville Manor";
 	}
 

--- a/engines/mtropolis/detection.cpp
+++ b/engines/mtropolis/detection.cpp
@@ -112,11 +112,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "mtropolis";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "mTropolis";
 	}
 

--- a/engines/mutationofjb/detection.cpp
+++ b/engines/mutationofjb/detection.cpp
@@ -103,11 +103,11 @@ public:
 		_directoryGlobs = mutationofjbDirectoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "mutationofjb";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Mutation of J.B.";
 	}
 

--- a/engines/myst3/detection.cpp
+++ b/engines/myst3/detection.cpp
@@ -229,11 +229,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Myst III";
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "myst3";
 	}
 

--- a/engines/nancy/detection.cpp
+++ b/engines/nancy/detection.cpp
@@ -230,11 +230,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "nancy";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Nancy Drew";
 	}
 

--- a/engines/neverhood/detection.cpp
+++ b/engines/neverhood/detection.cpp
@@ -178,11 +178,11 @@ public:
 		_guiOptions = GUIO5(GUIO_NOSUBTITLES, GUIO_NOMIDI, GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_SKIP_HALL_OF_RECORDS, GAMEOPTION_SCALE_MAKING_OF_VIDEOS);
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "neverhood";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "The Neverhood Chronicles";
 	}
 

--- a/engines/ngi/detection.cpp
+++ b/engines/ngi/detection.cpp
@@ -190,11 +190,11 @@ public:
 	NGIMetaEngineDetection() : AdvancedMetaEngineDetection(NGI::gameDescriptions, sizeof(NGI::NGIGameDescription), ngiGames) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "ngi";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Nikita Game Interface";
 	}
 

--- a/engines/parallaction/detection.cpp
+++ b/engines/parallaction/detection.cpp
@@ -206,11 +206,11 @@ public:
 		_guiOptions = GUIO1(GUIO_NOLAUNCHLOAD);
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "parallaction";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Parallaction";
 	}
 

--- a/engines/pegasus/detection.cpp
+++ b/engines/pegasus/detection.cpp
@@ -149,11 +149,11 @@ public:
 	PegasusMetaEngineDetection() : AdvancedMetaEngineDetection(Pegasus::gameDescriptions, sizeof(Pegasus::PegasusGameDescription), pegasusGames) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "pegasus";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "The Journeyman Project: Pegasus Prime";
 	}
 

--- a/engines/petka/detection.cpp
+++ b/engines/petka/detection.cpp
@@ -49,11 +49,11 @@ public:
 		_maxScanDepth = 2;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "petka";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Red Comrades";
 	}
 

--- a/engines/pink/detection.cpp
+++ b/engines/pink/detection.cpp
@@ -56,11 +56,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "pink";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Pink Panther";
 	}
 

--- a/engines/playground3d/detection.cpp
+++ b/engines/playground3d/detection.cpp
@@ -48,11 +48,11 @@ public:
 		_md5Bytes = 512;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "playground3d";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Playground 3d: the testing and playground environment for 3d renderers";
 	}
 

--- a/engines/plumbers/detection.cpp
+++ b/engines/plumbers/detection.cpp
@@ -71,11 +71,11 @@ public:
 	PlumbersMetaEngineDetection() : AdvancedMetaEngineDetection(Plumbers::gameDescriptions, sizeof(ADGameDescription), plumbersGames) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "plumbers";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Plumbers Don't Wear Ties";
 	}
 

--- a/engines/prince/detection.cpp
+++ b/engines/prince/detection.cpp
@@ -168,11 +168,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "prince";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "The Prince and the Coward";
 	}
 

--- a/engines/private/detection.cpp
+++ b/engines/private/detection.cpp
@@ -233,11 +233,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "private";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Private Eye";
 	}
 

--- a/engines/queen/detection.cpp
+++ b/engines/queen/detection.cpp
@@ -485,11 +485,11 @@ public:
 	QueenMetaEngineDetection() : AdvancedMetaEngineDetection(Queen::gameDescriptions, sizeof(Queen::QueenGameDescription), queenGames, optionsList) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "queen";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Flight of the Amazon Queen";
 	}
 

--- a/engines/saga/detection.cpp
+++ b/engines/saga/detection.cpp
@@ -42,11 +42,11 @@ public:
 		_directoryGlobs = DIRECTORY_GLOBS;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "saga";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "SAGA ["
 
 #if defined(ENABLE_IHNM)

--- a/engines/saga2/detection.cpp
+++ b/engines/saga2/detection.cpp
@@ -134,11 +134,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "saga2";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "SAGA2";
 	}
 

--- a/engines/sci/detection.cpp
+++ b/engines/sci/detection.cpp
@@ -192,11 +192,11 @@ public:
 		return debugFlagList;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "sci";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "SCI ["
 #ifdef ENABLE_SCI32
 			"all games"
@@ -226,7 +226,7 @@ ADDetectedGame SciMetaEngineDetection::fallbackDetect(const FileMap &allFiles, c
 		}
 	}
 
-	const Plugin *metaEnginePlugin = EngineMan.findPlugin(getEngineId());
+	const Plugin *metaEnginePlugin = EngineMan.findPlugin(getName());
 
 	if (metaEnginePlugin) {
 		const Plugin *enginePlugin = PluginMan.getEngineFromMetaEngine(metaEnginePlugin);

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -69,7 +69,7 @@ using namespace Scumm;
 
 class ScummMetaEngineDetection : public MetaEngineDetection {
 public:
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "scumm";
 	}
 
@@ -77,7 +77,7 @@ public:
 		return debugFlagList;
 	}
 
-	const char *getName() const override;
+	const char *getEngineName() const override;
 	const char *getOriginalCopyright() const override;
 
 	PlainGameList getSupportedGames() const override;
@@ -131,7 +131,7 @@ DetectedGames ScummMetaEngineDetection::detectGames(const Common::FSList &fslist
 		const PlainGameDescriptor *g = findPlainGameDescriptor(x->game.gameid, gameDescriptions);
 		assert(g);
 
-		DetectedGame game = DetectedGame(getEngineId(), x->game.gameid, g->description, x->language, x->game.platform, x->extra);
+		DetectedGame game = DetectedGame(getName(), x->game.gameid, g->description, x->language, x->game.platform, x->extra);
 
 		// Compute and set the preferred target name for this game.
 		// Based on generateComplexID() in advancedDetector.cpp.
@@ -146,7 +146,7 @@ DetectedGames ScummMetaEngineDetection::detectGames(const Common::FSList &fslist
 	return detectedGames;
 }
 
-const char *ScummMetaEngineDetection::getName() const {
+const char *ScummMetaEngineDetection::getEngineName() const {
 	return "SCUMM ["
 
 #if defined(ENABLE_SCUMM_7_8) && defined(ENABLE_HE)

--- a/engines/sherlock/detection.cpp
+++ b/engines/sherlock/detection.cpp
@@ -148,11 +148,11 @@ public:
 	SherlockMetaEngineDetection() : AdvancedMetaEngineDetection(Sherlock::gameDescriptions, sizeof(Sherlock::SherlockGameDescription),
 		sherlockGames, optionsList) {}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "sherlock";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Sherlock";
 	}
 

--- a/engines/sky/detection.cpp
+++ b/engines/sky/detection.cpp
@@ -66,10 +66,10 @@ static const SkyVersion skyVersions[] = {
 
 class SkyMetaEngineDetection : public MetaEngineDetection {
 public:
-	const char *getName() const override;
+	const char *getEngineName() const override;
 	const char *getOriginalCopyright() const override;
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "sky";
 	}
 
@@ -79,7 +79,7 @@ public:
 	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/, bool /*skipIncomplete*/) override;
 };
 
-const char *SkyMetaEngineDetection::getName() const {
+const char *SkyMetaEngineDetection::getEngineName() const {
 	return "Beneath a Steel Sky";
 }
 
@@ -162,12 +162,12 @@ DetectedGames SkyMetaEngineDetection::detectGames(const Common::FSList &fslist, 
 		if (sv->dinnerTableEntries) {
 			Common::String extra = Common::String::format("v0.0%d %s", sv->version, sv->extraDesc);
 
-			DetectedGame game = DetectedGame(getEngineId(), skySetting.gameId, skySetting.description, Common::UNK_LANG, Common::kPlatformUnknown, extra);
+			DetectedGame game = DetectedGame(getName(), skySetting.gameId, skySetting.description, Common::UNK_LANG, Common::kPlatformUnknown, extra);
 			game.setGUIOptions(sv->guioptions);
 
 			detectedGames.push_back(game);
 		} else {
-			detectedGames.push_back(DetectedGame(getEngineId(), skySetting.gameId, skySetting.description));
+			detectedGames.push_back(DetectedGame(getName(), skySetting.gameId, skySetting.description));
 		}
 	}
 

--- a/engines/sludge/detection.cpp
+++ b/engines/sludge/detection.cpp
@@ -80,11 +80,11 @@ public:
 		_maxScanDepth = 1;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "sludge";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Sludge";
 	}
 

--- a/engines/stark/detection.cpp
+++ b/engines/stark/detection.cpp
@@ -424,11 +424,11 @@ public:
 		_guiOptions = GUIO4(GUIO_NOMIDI, GAMEOPTION_ASSETS_MOD, GAMEOPTION_LINEAR_FILTERING, GAMEOPTION_FONT_ANTIALIASING);
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Stark";
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "stark";
 	}
 

--- a/engines/startrek/detection.cpp
+++ b/engines/startrek/detection.cpp
@@ -361,11 +361,11 @@ public:
 		return debugFlagList;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "startrek";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Star Trek";
 	}
 

--- a/engines/supernova/detection.cpp
+++ b/engines/supernova/detection.cpp
@@ -126,11 +126,11 @@ public:
 	SupernovaMetaEngineDetection() : AdvancedMetaEngineDetection(Supernova::gameDescriptions, sizeof(ADGameDescription), supernovaGames, optionsList) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "supernova";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Mission Supernova";
 	}
 

--- a/engines/sword1/detection.cpp
+++ b/engines/sword1/detection.cpp
@@ -72,11 +72,11 @@ static const char *const g_filesToCheck[NUM_FILES_TO_CHECK] = { // these files h
 
 class SwordMetaEngineDetection : public MetaEngineDetection {
 public:
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "sword1";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Broken Sword: The Shadow of the Templars";
 	}
 	const char *getOriginalCopyright() const override {
@@ -187,17 +187,17 @@ DetectedGames SwordMetaEngineDetection::detectGames(const Common::FSList &fslist
 
 	DetectedGame game;
 	if (mainFilesFound && pcFilesFound && demoFilesFound)
-		game = DetectedGame(getEngineId(), sword1DemoSettings);
+		game = DetectedGame(getName(), sword1DemoSettings);
 	else if (mainFilesFound && pcFilesFound && psxFilesFound)
-		game = DetectedGame(getEngineId(), sword1PSXSettings);
+		game = DetectedGame(getName(), sword1PSXSettings);
 	else if (mainFilesFound && pcFilesFound && psxDemoFilesFound)
-		game = DetectedGame(getEngineId(), sword1PSXDemoSettings);
+		game = DetectedGame(getName(), sword1PSXDemoSettings);
 	else if (mainFilesFound && pcFilesFound && !psxFilesFound)
-		game = DetectedGame(getEngineId(), sword1FullSettings);
+		game = DetectedGame(getName(), sword1FullSettings);
 	else if (mainFilesFound && macFilesFound)
-		game = DetectedGame(getEngineId(), sword1MacFullSettings);
+		game = DetectedGame(getName(), sword1MacFullSettings);
 	else if (mainFilesFound && macDemoFilesFound)
-		game = DetectedGame(getEngineId(), sword1MacDemoSettings);
+		game = DetectedGame(getName(), sword1MacDemoSettings);
 	else
 		return detectedGames;
 

--- a/engines/sword2/detection.cpp
+++ b/engines/sword2/detection.cpp
@@ -39,11 +39,11 @@ static const ExtraGuiOption sword2ExtraGuiOption = {
 
 class Sword2MetaEngineDetection : public MetaEngineDetection {
 public:
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "sword2";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Broken Sword II: The Smoking Mirror";
 	}
 	const char *getOriginalCopyright() const override {

--- a/engines/sword25/detection.cpp
+++ b/engines/sword25/detection.cpp
@@ -66,11 +66,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "sword25";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Broken Sword 2.5";
 	}
 

--- a/engines/teenagent/detection.cpp
+++ b/engines/teenagent/detection.cpp
@@ -207,11 +207,11 @@ public:
 	TeenAgentMetaEngineDetection() : AdvancedMetaEngineDetection(teenAgentGameDescriptions, sizeof(ADGameDescription), teenAgentGames) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "teenagent";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "TeenAgent";
 	}
 

--- a/engines/testbed/detection.cpp
+++ b/engines/testbed/detection.cpp
@@ -54,11 +54,11 @@ public:
 		_md5Bytes = 512;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "testbed";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "TestBed: The Backend Testing Framework";
 	}
 

--- a/engines/tinsel/detection.cpp
+++ b/engines/tinsel/detection.cpp
@@ -50,11 +50,11 @@ public:
 	TinselMetaEngineDetection() : AdvancedMetaEngineDetection(Tinsel::gameDescriptions, sizeof(Tinsel::TinselGameDescription), tinselGames) {
 	}
 
-	const char *getEngineId() const  override{
+	const char *getName() const  override{
 		return "tinsel";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Tinsel";
 	}
 

--- a/engines/titanic/detection.cpp
+++ b/engines/titanic/detection.cpp
@@ -48,11 +48,11 @@ public:
 		_maxScanDepth = 3;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "titanic";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Starship Titanic";
 	}
 

--- a/engines/toltecs/detection.cpp
+++ b/engines/toltecs/detection.cpp
@@ -243,11 +243,11 @@ public:
 	ToltecsMetaEngineDetection() : AdvancedMetaEngineDetection(Toltecs::gameDescriptions, sizeof(Toltecs::ToltecsGameDescription), toltecsGames, Toltecs::optionsList) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "toltecs";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "3 Skulls of the Toltecs";
 	}
 

--- a/engines/tony/detection.cpp
+++ b/engines/tony/detection.cpp
@@ -54,11 +54,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "tony";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Tony Tough and the Night of Roasted Moths";
 	}
 

--- a/engines/toon/detection.cpp
+++ b/engines/toon/detection.cpp
@@ -158,11 +158,11 @@ public:
 		return detectGameFilebased(allFiles, Toon::fileBasedFallback);
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "toon";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Toonstruck";
 	}
 

--- a/engines/touche/detection.cpp
+++ b/engines/touche/detection.cpp
@@ -141,11 +141,11 @@ public:
 		return detectGameFilebased(allFiles, Touche::fileBasedFallback);
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "touche";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Touche: The Adventures of the Fifth Musketeer";
 	}
 

--- a/engines/trecision/detection.cpp
+++ b/engines/trecision/detection.cpp
@@ -243,11 +243,11 @@ public:
 		_guiOptions = GUIO2(GUIO_NOMIDI, GAMEOPTION_ORIGINAL_SAVELOAD);
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "trecision";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Trecision Adventure Module";
 	}
 

--- a/engines/tsage/detection.cpp
+++ b/engines/tsage/detection.cpp
@@ -46,11 +46,11 @@ public:
 	TSageMetaEngineDetection() : AdvancedMetaEngineDetection(TsAGE::gameDescriptions, sizeof(TsAGE::tSageGameDescription), tSageGameTitles) {
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "tsage";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "TsAGE";
 	}
 

--- a/engines/tucker/detection.cpp
+++ b/engines/tucker/detection.cpp
@@ -121,11 +121,11 @@ public:
 		_md5Bytes = 512;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "tucker";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Bud Tucker in Double Trouble";
 	}
 

--- a/engines/twine/detection.cpp
+++ b/engines/twine/detection.cpp
@@ -1152,11 +1152,11 @@ public:
 		_guiOptions = GUIO12(GAMEOPTION_WALL_COLLISION, GAMEOPTION_DISABLE_SAVE_MENU,  GAMEOPTION_DEBUG, GAMEOPTION_AUDIO_CD, GAMEOPTION_SOUND, GAMEOPTION_VOICES, GAMEOPTION_TEXT, GAMEOPTION_MOVIES, GAMEOPTION_MOUSE, GAMEOPTION_USA_VERSION, GAMEOPTION_HIGH_RESOLUTION, GAMEOPTION_TEXT_TO_SPEECH);
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "twine";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Little Big Adventure";
 	}
 

--- a/engines/ultima/detection.h
+++ b/engines/ultima/detection.h
@@ -75,11 +75,11 @@ public:
 	UltimaMetaEngineDetection();
 	~UltimaMetaEngineDetection() override {}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "ultima";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Ultima";
 	}
 

--- a/engines/voyeur/detection.cpp
+++ b/engines/voyeur/detection.cpp
@@ -45,11 +45,11 @@ public:
 		_maxScanDepth = 3;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "voyeur";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Voyeur";
 	}
 

--- a/engines/wage/detection.cpp
+++ b/engines/wage/detection.cpp
@@ -46,11 +46,11 @@ public:
 		_guiOptions = GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI);
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "wage";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "World Adventure Game Engine";
 	}
 

--- a/engines/wintermute/detection.cpp
+++ b/engines/wintermute/detection.cpp
@@ -109,11 +109,11 @@ public:
 		_directoryGlobs = directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "wintermute";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Wintermute";
 	}
 
@@ -138,7 +138,7 @@ public:
 			}
 		}
 
-		const Plugin *metaEnginePlugin = EngineMan.findPlugin(getEngineId());
+		const Plugin *metaEnginePlugin = EngineMan.findPlugin(getName());
 
 		if (metaEnginePlugin) {
 			const Plugin *enginePlugin = PluginMan.getEngineFromMetaEngine(metaEnginePlugin);

--- a/engines/xeen/detection.cpp
+++ b/engines/xeen/detection.cpp
@@ -83,11 +83,11 @@ public:
 		_maxScanDepth = 3;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "xeen";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Xeen";
 	}
 

--- a/engines/zvision/detection.cpp
+++ b/engines/zvision/detection.cpp
@@ -38,11 +38,11 @@ public:
 		_directoryGlobs = ZVision::directoryGlobs;
 	}
 
-	const char *getEngineId() const override {
+	const char *getName() const override {
 		return "zvision";
 	}
 
-	const char *getName() const override {
+	const char *getEngineName() const override {
 		return "Z-Vision";
 	}
 

--- a/gui/about.cpp
+++ b/gui/about.cpp
@@ -132,7 +132,7 @@ AboutDialog::AboutDialog()
 		}
 
 		str = "C0";
-		str += p->get<MetaEngineDetection>().getName();
+		str += p->get<MetaEngineDetection>().getEngineName();
 		addLine(str);
 		str = "C2";
 		str += p->get<MetaEngineDetection>().getOriginalCopyright();

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -875,7 +875,7 @@ void LauncherChooser::genGameList() {
 
 		PlainGameList list = metaEngine.getSupportedGames();
 		for (auto v = list.begin(); v != list.end(); ++v) {
-			_games[buildQualifiedGameName(metaEngine.getEngineId(), v->gameId)] = v->description;
+			_games[buildQualifiedGameName(metaEngine.getName(), v->gameId)] = v->description;
 		}
 	}
 }


### PR DESCRIPTION
With this PR, `MetaEngineDetection::getName()` returns the engine ID, which should match the value of `MetaEngine::getName()`, and `MetaEngineDetection::getEngineName()` returns the full name of the engine that's used in the about dialog and command line interface.

This includes the changes from PR #3646.