### PR TITLE
SLUDGE: Reimplement builtin launch for webpages

### DIFF
--- a/engines/sludge/builtin.cpp
+++ b/engines/sludge/builtin.cpp
@@ -47,8 +47,6 @@
 
 namespace Sludge {
 
-Variable *launchResult = NULL;
-
 extern bool allowAnyFilename;
 extern VariableStack *noStack;
 extern int numBIFNames, numUserFunc;
@@ -879,20 +877,23 @@ builtIn(launch) {
 		(newTextA[4] == ':' || (newTextA[4] == 's' && newTextA[5] == ':'))) {
 
 		// IT'S A WEBSITE!
-		g_sludge->launchMe.clear();
-		g_sludge->launchMe = newTextA;
-	} else {
-		Common::String gameDir = g_sludge->gamePath;
-		gameDir += "/";
-		g_sludge->launchMe.clear();
-		g_sludge->launchMe = gameDir + newText;
-		if (g_sludge->launchMe.empty())
-			return BR_ERROR;
+		bool success = g_sludge->_system->openUrl(newText);
+		fun->reg.setVariable(SVT_INT, success);
+		return BR_CONTINUE;
 	}
-	fun->reg.setVariable(SVT_INT, 1);
-	launchResult = &fun->reg;
 
-	return BR_KEEP_AND_PAUSE;
+	Common::String gameDir = ConfMan.get("path");
+	newText = gameDir + newText;
+
+	// local webpage?
+	if (newText.hasSuffixIgnoreCase(".htm") || newText.hasSuffixIgnoreCase(".html")) {
+		bool success = g_sludge->_system->openUrl("file:///" + newText);
+		fun->reg.setVariable(SVT_INT, success);
+	} else {
+		fun->reg.setVariable(SVT_INT, 0);
+	}
+
+	return BR_CONTINUE;
 }
 
 builtIn(pause) {

--- a/engines/sludge/event.cpp
+++ b/engines/sludge/event.cpp
@@ -34,7 +34,6 @@
 
 namespace Sludge {
 
-extern Variable *launchResult;
 extern VariableStack *noStack;
 
 EventManager::EventManager(SludgeEngine *vm) {
@@ -147,23 +146,6 @@ void EventManager::checkInput() {
 }
 
 bool EventManager::handleInput() {
-	static int l = 0;
-
-	if (!_vm->launchMe.empty()) {
-		if (l) {
-			// Still paused because of spawned thingy...
-		} else {
-			l = 1;
-
-			launchResult->setVariable(SVT_INT, 0/*launch(launchMe) > 31*/); //TODO:false value
-			_vm->launchMe.clear();
-			launchResult = nullptr;
-		}
-		return true;
-	} else {
-		l = 0;
-	}
-
 	if (!_vm->_regionMan->getOverRegion())
 		_vm->_regionMan->updateOverRegion();
 

--- a/engines/sludge/sludge.cpp
+++ b/engines/sludge/sludge.cpp
@@ -64,7 +64,6 @@ SludgeEngine::SludgeEngine(OSystem *syst, const SludgeGameDescription *gameDesc)
 	_pixelFormat = new Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
 
 	// Init Strings
-	launchMe = "";
 	launchNext = "";
 	loadNow = "";
 	gamePath = "";

--- a/engines/sludge/sludge.h
+++ b/engines/sludge/sludge.h
@@ -72,7 +72,6 @@ protected:
 
 public:
 	// global String variables
-	Common::String launchMe;
 	Common::String launchNext;
 	Common::String loadNow;
 	Common::String gamePath;

--- a/engines/sludge/sludger.cpp
+++ b/engines/sludge/sludger.cpp
@@ -59,7 +59,6 @@ FILETIME fileTime;
 
 int numGlobals = 0;
 
-extern Variable *launchResult;
 extern Variable *globalVars;
 extern VariableStack *noStack;
 
@@ -137,7 +136,6 @@ void initSludge() {
 
 	// global variables
 	numGlobals = 0;
-	launchResult = nullptr;
 
 	allowAnyFilename = true;
 	noStack = nullptr;


### PR DESCRIPTION
This allows opening webpages from inside games. E.g. the help option in out of order.

As a bonus it gets rid of a few global variables.