### PR TITLE
SLUDGE: Fix detection of nsc

### DIFF
--- a/engines/sludge/detection_tables.h
+++ b/engines/sludge/detection_tables.h
@@ -390,7 +390,7 @@ static const SludgeGameDescription gameDescriptions[] = {
 		{
 			"nsc",
 			"v1.03",
-			AD_ENTRY1s("gamedata", "57f318cc09e93a1e0685b790a956ebdc", 12733871),
+			AD_ENTRY1s("gamedata.slg", "57f318cc09e93a1e0685b790a956ebdc", 12733871),
 			Common::EN_ANY,
 			Common::kPlatformUnknown,
 			ADGF_UNSTABLE,


### PR DESCRIPTION
The filename in the detection was wrong, so it wasn't correctly detected.