### PR TITLE
MOHAWK: Add detection for the Williams-Sonoma Guide to Good Cooking

### DIFF
--- a/engines/mohawk/detection.cpp
+++ b/engines/mohawk/detection.cpp
@@ -63,6 +63,7 @@ static const PlainGameDescriptor mohawkGames[] = {
 	{"stellaluna", "Stellaluna"},
 	{"sheila", "Sheila Rae, the Brave"},
 	{"rugratsps", "Rugrats Print Shop" },
+	{"wsg", "Williams-Sonoma Guide to Good Cooking" },
 	{nullptr, nullptr}
 };
 

--- a/engines/mohawk/detection_tables.h
+++ b/engines/mohawk/detection_tables.h
@@ -3169,6 +3169,21 @@ static const MohawkGameDescription gameDescriptions[] = {
 		0,
 	},
 
+	{
+		{
+			"wsg",
+			_s("Missing game code"), // Reason for being unsupported
+			AD_ENTRY1s("WSKL.CFG", "0d0d1156387ad51bf2b0c6bdc380f751", 1269),
+			Common::EN_ANY,
+			Common::kPlatformWindows,
+			ADGF_UNSUPPORTED,
+			GUIO1(GUIO_NOASPECT)
+		},
+		GType_LIVINGBOOKSV3,
+		0,
+		0,
+	},
+
 	{ AD_TABLE_END_MARKER, 0, 0, 0 }
 };
 


### PR DESCRIPTION
`WSKL.CFG` uses an identical format to Living Books, but uses 16bpp images and a database. Attempting to force the current code to draw the first image (9000) in `Credits.MHK` gives the following log output:
```
Decoding Mohawk Bitmap (640x480, 16bpp, Raw Packing + Unknown Drawing)
Unhandled bpp 16!
```