### PR TITLE
Fix commandLine.cpp build on 3DS and various cleanups

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -55,17 +55,15 @@ namespace Base {
 
 #ifndef DISABLE_COMMAND_LINE
 
-#if !defined(__DS__)
 static const char USAGE_STRING[] =
 	"%s: %s\n"
 	"Usage: %s [OPTIONS]... [GAME]\n"
 	"\n"
 	"Try '%s --help' for more options.\n"
 ;
-#endif
 
 // DONT FIXME: DO NOT ORDER ALPHABETICALLY, THIS IS ORDERED BY IMPORTANCE/CATEGORY! :)
-#if defined(__DS__) || defined(__3DS__)
+#if defined(__3DS__)
 static const char HELP_STRING1[] = "%s None"; // save more data segment space
 static const char HELP_STRING2[] = "None";
 static const char HELP_STRING3[] = "None";
@@ -258,9 +256,7 @@ static void usage(const char *s, ...) {
 	vsnprintf(buf, STRINGBUFLEN, s, va);
 	va_end(va);
 
-#if !defined(__DS__)
 	printf(USAGE_STRING, s_appName, buf, s_appName, s_appName);
-#endif
 	exit(1);
 }
 

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -65,7 +65,7 @@ static const char USAGE_STRING[] =
 #endif
 
 // DONT FIXME: DO NOT ORDER ALPHABETICALLY, THIS IS ORDERED BY IMPORTANCE/CATEGORY! :)
-#if defined(ANDROID) || defined(__DS__) || defined(__3DS__)
+#if defined(__DS__) || defined(__3DS__)
 static const char HELP_STRING1[] = "%s None"; // save more data segment space
 static const char HELP_STRING2[] = "None";
 static const char HELP_STRING3[] = "None";

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -55,6 +55,7 @@ namespace Base {
 
 #ifndef DISABLE_COMMAND_LINE
 
+#ifndef DISABLE_HELP_STRINGS
 static const char USAGE_STRING[] =
 	"%s: %s\n"
 	"Usage: %s [OPTIONS]... [GAME]\n"
@@ -63,12 +64,6 @@ static const char USAGE_STRING[] =
 ;
 
 // DONT FIXME: DO NOT ORDER ALPHABETICALLY, THIS IS ORDERED BY IMPORTANCE/CATEGORY! :)
-#if defined(__3DS__)
-static const char HELP_STRING1[] = "%s None"; // save more data segment space
-static const char HELP_STRING2[] = "None";
-static const char HELP_STRING3[] = "None";
-static const char HELP_STRING4[] = "None";
-#else
 static const char HELP_STRING1[] =
 	"ScummVM - Graphical Adventure Game Interpreter\n"
 	"Usage: %s [OPTIONS]... [GAME]\n"
@@ -249,6 +244,7 @@ static const char *s_appName = "scummvm";
 static void NORETURN_PRE usage(MSVC_PRINTF const char *s, ...) GCC_PRINTF(1, 2) NORETURN_POST;
 
 static void usage(const char *s, ...) {
+#ifndef DISABLE_HELP_STRINGS
 	char buf[STRINGBUFLEN];
 	va_list va;
 
@@ -257,6 +253,7 @@ static void usage(const char *s, ...) {
 	va_end(va);
 
 	printf(USAGE_STRING, s_appName, buf, s_appName, s_appName);
+#endif
 	exit(1);
 }
 
@@ -1743,6 +1740,7 @@ bool processSettings(Common::String &command, Common::StringMap &settings, Commo
 		printf("Features compiled in: %s\n", gScummVMFeatures);
 		return true;
 	} else if (command == "help") {
+#ifndef DISABLE_HELP_STRINGS
 		printf(HELP_STRING1, s_appName);
 
 		Common::String s = HELP_STRING2;
@@ -1779,7 +1777,7 @@ bool processSettings(Common::String &command, Common::StringMap &settings, Commo
 		printf("%s)\n", s.c_str());
 
 		printf(HELP_STRING4);
-
+#endif
 		return true;
 	} else if (command == "auto-detect") {
 		bool resursive = settings["recursive"] == "true";

--- a/configure
+++ b/configure
@@ -3165,6 +3165,7 @@ if test -n "$_host"; then
 	case "$_host" in
 		3ds)
 			append_var DEFINES "-DDISABLE_FANCY_THEMES"
+			append_var DEFINES "-DDISABLE_HELP_STRINGS"
 			append_var DEFINES "-DDISABLE_SID"
 			append_var DEFINES "-DDISABLE_NES_APU"
 			_backend="3ds"
@@ -3330,7 +3331,7 @@ if test -n "$_host"; then
 			if test "$_debug_build" != yes; then
 				append_var DEFINES "-DDISABLE_TEXT_CONSOLE"
 			fi
-			append_var DEFINES "-DDISABLE_COMMAND_LINE"
+			append_var DEFINES "-DDISABLE_HELP_STRINGS"
 			append_var DEFINES "-DDISABLE_DOSBOX_OPL"
 			append_var DEFINES "-DDISABLE_FANCY_THEMES"
 			append_var DEFINES "-DDISABLE_SID"


### PR DESCRIPTION
This PR fixes 3DS build and cleans up the file a little to remove outdated blocks.
@BallM4788 you may want to take a look at this.