### PR TITLE
SCUMM: Fix a dead-end in Monkey Island 2 and restore a reaction from Dread

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -713,7 +713,7 @@ void ScummEngine_v5::o5_animateActor() {
 		return;
 	}
 
-	// WORKAROUND bug #1339: While on mars, going outside without your helmet
+	// WORKAROUND bug #1339: While on Mars, going outside without your helmet
 	// (or missing some other part of your "space suite" will cause your
 	// character to complain ("I can't breathe."). Unfortunately, this is
 	// coupled with an animate command, making it very difficult to return to
@@ -1489,7 +1489,40 @@ void ScummEngine_v5::o5_isNotEqual() {
 }
 
 void ScummEngine_v5::o5_notEqualZero() {
-	int a = getVar();
+	int a;
+
+	// WORKAROUND for a possible dead-end in Monkey Island 2. By luck, this
+	// only happens in the Ultimate Talkie Edition (because it fixes another
+	// script error which unveils this one).
+	//
+	// Once Bit[70] has been properly set by one of the configurations above,
+	// Captain Dread will have his intended reaction of forcing you to go back
+	// to Scabb Island, once you've got the four map pieces. But, unless you're
+	// playing in Lite mode, you'll need the lens from the model lighthouse,
+	// otherwise Wally won't be able to read the map, and you'll be completely
+	// stuck on Scabb Island with no way of going back to the Phatt Island
+	// Library, since Dread's ship is gone.
+	//
+	// Not using `_enableEnhancements`, since we always want to solve a dead-end
+	// in a Monkey Island game!
+	if (_game.id == GID_MONKEY2 && ((_roomResource == 22 && vm.slot[_currentScript].number == 202) || (_roomResource == 2 && vm.slot[_currentScript].number == 10002) || vm.slot[_currentScript].number == 97)) {
+		int var = fetchScriptWord();
+		a = readVar(var);
+
+		// If you've got the four map pieces and the script is checking this...
+		if (var == 0x8000 + 69 && a == 1 && readVar(0x8000 + 70) == 1 && readVar(0x8000 + 55) == 1 && readVar(0x8000 + 366) == 1) {
+			// ...but you don't have the lens and you never gave it to Wally...
+			// (and you're not playing the Lite mode, where this doesn't matter)
+			if (getOwner(295) != VAR(VAR_EGO) && readVar(0x8000 + 67) != 0 && readVar(0x8000 + 567) == 0) {
+				// ...then short-cirtcuit this condition, so that you can still go back
+				// to Phatt Island to pick up the lens, as in the original game.
+				a = 0;
+			}
+		}
+	} else {
+		a = getVar();
+	}
+
 	jumpRelative(a != 0);
 }
 

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -1493,7 +1493,8 @@ void ScummEngine_v5::o5_notEqualZero() {
 
 	// WORKAROUND for a possible dead-end in Monkey Island 2. By luck, this
 	// only happens in the Ultimate Talkie Edition (because it fixes another
-	// script error which unveils this one).
+	// script error which unveils this one), or if you enable the Enhancement
+	// option in one of the original releases (see o5_stopScript()).
 	//
 	// Once Bit[70] has been properly set by one of the configurations above,
 	// Captain Dread will have his intended reaction of forcing you to go back
@@ -1514,7 +1515,7 @@ void ScummEngine_v5::o5_notEqualZero() {
 			// ...but you don't have the lens and you never gave it to Wally...
 			// (and you're not playing the Lite mode, where this doesn't matter)
 			if (getOwner(295) != VAR(VAR_EGO) && readVar(0x8000 + 67) != 0 && readVar(0x8000 + 567) == 0) {
-				// ...then short-cirtcuit this condition, so that you can still go back
+				// ...then short-circuit this condition, so that you can still go back
 				// to Phatt Island to pick up the lens, as in the original game.
 				a = 0;
 			}
@@ -2670,6 +2671,21 @@ void ScummEngine_v5::o5_stopScript() {
 		stopObjectCode();
 	else
 		stopScript(script);
+
+	// WORKAROUND: When Guybrush buys a map piece from the antiques dealer,
+	// the script forgets to set Bit[70], which means that an intended
+	// reaction from Captain Dread forcing you to go back to Scabb when you
+	// get the full map was never triggered in the original game.
+	// The Ultimate Edition fixed this, so we're borrowing its script change.
+	//
+	// Note that fixing this unveils a second, much more problematic script
+	// oversight which could cause a dead-end if you didn't pick up the model
+	// lighthouse lens! See o5_notEqualZero().
+	if (_game.id == GID_MONKEY2 && script == 209 &&
+		_roomResource == 48 && vm.slot[_currentScript].number == 207 && _enableEnhancements &&
+		strcmp(_game.variant, "SE Talkie") != 0) {
+		writeVar(0x8000 + 70, 1);
+	}
 }
 
 void ScummEngine_v5::o5_stringOps() {

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -1493,8 +1493,8 @@ void ScummEngine_v5::o5_notEqualZero() {
 
 	// WORKAROUND for a possible dead-end in Monkey Island 2. By luck, this
 	// only happens in the Ultimate Talkie Edition (because it fixes another
-	// script error which unveils this one), or if you enable the Enhancement
-	// option in one of the original releases (see o5_stopScript()).
+	// script error which unveils this one), or when one enables the second
+	// workaround just below in one of the original releases.
 	//
 	// Once Bit[70] has been properly set by one of the configurations above,
 	// Captain Dread will have his intended reaction of forcing you to go back
@@ -1510,8 +1510,27 @@ void ScummEngine_v5::o5_notEqualZero() {
 		int var = fetchScriptWord();
 		a = readVar(var);
 
+		// WORKAROUND: When Guybrush buys a map piece from the antiques dealer,
+		// the script forgets to set Bit[70], which means that an intended
+		// reaction from Captain Dread forcing you to go back to Scabb when you
+		// get the full map was never triggered in the original game.
+		//
+		// The Ultimate Edition fixed this in script 48-207 (when you buy the
+		// map piece), but for the other versions we're fixing it on-the-fly
+		// at the last moment instead (by checking for the object in the
+		// inventory instead of Bit[70]), so that it will also work with older
+		// savegames, and so that you can uncheck the Enhancement option at any
+		// moment if you realize that you want the original behavior.
+		//
+		// Note that fixing this unveils the script error causing the possible
+		// dead-end described above.
+		if (var == 0x8000 + 70 && a == 0 && getOwner(519) == VAR(VAR_EGO) && strcmp(_game.variant, "SE Talkie") != 0 && _enableEnhancements) {
+			a = 1;
+		}
+
+		// [Back to the previous "dead-end" workaround.]
 		// If you've got the four map pieces and the script is checking this...
-		if (var == 0x8000 + 69 && a == 1 && readVar(0x8000 + 70) == 1 && readVar(0x8000 + 55) == 1 && readVar(0x8000 + 366) == 1) {
+		else if (var == 0x8000 + 69 && a == 1 && getOwner(519) == VAR(VAR_EGO) && readVar(0x8000 + 55) == 1 && readVar(0x8000 + 366) == 1) {
 			// ...but you don't have the lens and you never gave it to Wally...
 			// (and you're not playing the Lite mode, where this doesn't matter)
 			if (getOwner(295) != VAR(VAR_EGO) && readVar(0x8000 + 67) != 0 && readVar(0x8000 + 567) == 0) {
@@ -2671,21 +2690,6 @@ void ScummEngine_v5::o5_stopScript() {
 		stopObjectCode();
 	else
 		stopScript(script);
-
-	// WORKAROUND: When Guybrush buys a map piece from the antiques dealer,
-	// the script forgets to set Bit[70], which means that an intended
-	// reaction from Captain Dread forcing you to go back to Scabb when you
-	// get the full map was never triggered in the original game.
-	// The Ultimate Edition fixed this, so we're borrowing its script change.
-	//
-	// Note that fixing this unveils a second, much more problematic script
-	// oversight which could cause a dead-end if you didn't pick up the model
-	// lighthouse lens! See o5_notEqualZero().
-	if (_game.id == GID_MONKEY2 && script == 209 &&
-		_roomResource == 48 && vm.slot[_currentScript].number == 207 && _enableEnhancements &&
-		strcmp(_game.variant, "SE Talkie") != 0) {
-		writeVar(0x8000 + 70, 1);
-	}
 }
 
 void ScummEngine_v5::o5_stringOps() {


### PR DESCRIPTION
Yes, there is a dead-end in Monkey Island 2! But it only happens in the [Ultimate Talkie Edition](http://gratissaugen.de/ultimatetalkies/monkey2.html), because another bug in the original game prevented an intended scene from being triggered… so I'm fixing both issues in this PR (in separate commits).

Thanks to Ninou for discovering this dead-end, last summer. I also see that someone [recently reported this problem on Reddit](https://www.reddit.com/r/MonkeyIsland/comments/u7065m/monkey_island_2_glitch_help/). Spoilers ahead…

## Restoring an untriggered reaction from Captain Dread

Whenever you acquire one of of the four map pieces during Part 2, one SCUMM Bit is set so that the other scripts may know about this:

- `Bit[366]` (Rapp's)
- `Bit[55]` (Elaine's)
- `Bit[70]` (Antiques dealer's)
- `Bit[69]` (Rum Roger's)

Then, if you go back to Captain Dread's ship, the following check is done by script 22-202:

```
if (Bit[366]) {
  if (Bit[55]) {
    if (Bit[70]) {
      if (Bit[69]) {
        print(4,[Text("Mon, I gotta take you back to Scabb Island." + wait() + "I got goods I gotta deliver.")]);
        WaitForMessage();
        goto xxx;
      }
    }
  }
}
```

Yes, Captain Dread is supposed to bring you back to Scabb Island and leave you there, once you have the full map (probably so that the player knows where to focus in order to finish the second part of the game).

If you don't remember this, that's because… you've played the original game, which forgets to properly set `Bit[70]` when you get the map piece from the antiques dealer on Booty Island. The 2009 Special Edition dubbed the reaction line from Captain Dread, but yet it didn't fix setting `Bit[70]`, so you wouldn't hear it. Only the Ultimate Talkie Edition fixed this, so I'm borrowing this content restoration of theirs to the other versions.

That's not the way people remember playing the game, though, so this is marked as an Enhancement if you prefer disabling it in the game settings (I've written this workaround so that you can enable/disable just before you go back to Dread's ship). But it really looks like this scene was an original intent of the game authors, and only a small oversight prevented it from being triggered (a bit like the restored content in Grim Fandango and Blade Runner?).

But… restoring this content introduces a possible dead-end to the game!

## Preventing a possible dead-end in Monkey Island 2

Until now, this dead-end could only happen in the Ultimate Talkie Edition, because it's related to the restored reaction from Captain Dread. Since the Enhancement above restores it in all versions of the game, this dead-end must be fixed in all versions too.

If you:

- play Monkey Island 2 in Regular Mode (not in Lite Mode, where this dead-end is not possible AFAIK)
- play the Ultimate Talkie Edition, or any other version with the new enhancement above enabled
- get the four map pieces
- but forget to pick up the lens from the model lighthouse (in Phatt City Library)
- and then go to Captain Dread's ship

then, Dread will force you to go back to Scabb Island, leave you there and disappear. But then, since you stole Wally's monocle in Part 1, Wally won't be able to read the map, and you can't go back to Phatt Island to pick up the lens, since Dread is gone. Dead-end!

To fix this in ScummVM, I'm adding some checks when Dread's reaction is about to be triggered: if you're playing in Lite mode, but the model lighthouse lens isn't in your inventory, and the bit that's set when Wally receives a new monocle isn't set, then we detect a possible dead-end and we don't trigger Dread's reaction yet. You can still navigate between the 3 islands as in the original game.

This is intentionally *not* marked as an Enhancement; this fix is always applied, since you never want a dead-end in a Monkey Island game :)

## How to test

I couldn't find any useful boot param for this...

It's probably best to test the Ultimate Talkie Edition and an original game version, both with and without the Enhancement game setting.

1. Load a save where you've just found the last map piece on Phatt Island, but haven't picked up the model lighthouse lens yet. You can use [this save](https://github.com/scummvm/scummvm/files/9181286/monkey2.s12.zip) for the original DOS/English release of the game.
2. Go back to Captain Dread's ship
3. If you've enabled the Enhancement setting, Captain Dread should play his "I gotta take you back to Scabb Island" **only** when you have the model lighthouse lens (or if you already gave it to Wally).

(The change to `o5_notEqualZero()` is based on the workaround for `o5_equalZero()` just below.)

I've tested the original DOS English, DOS French, Macintosh English, and Amiga English releases, and then the Ultimate Talkie Edition.