### PR TITLE
SCUMM: Fix some misattributed lines in Sam & Max (non-English)

### DIFF
--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -95,7 +95,7 @@ void ScummEngine::printString(int m, const byte *msg) {
 					if (a)
 						a->setAnimSpeed(2);
 					a = derefActorSafe(10, "printString");
-				if (a)
+					if (a)
 						a->setAnimSpeed(2);
 				}
 			}
@@ -1165,6 +1165,18 @@ int ScummEngine::convertMessageToString(const byte *msg, byte *dst, int dstSize)
 					*dst++ = chr;
 					*dst++ = src[num+0];
 					*dst++ = src[num+1];
+
+					// WORKAROUND: In some versions of Sam & Max, talking to Evelyn Morrison
+					// while wearing the bigfoot costume misattributes some lines to Max even
+					// though Sam is the one actually speaking. For example, the French and
+					// German releases use `startAnim(8)` while the English release correctly
+					// uses `startAnim(7)` for this.
+					if (_game.id == GID_SAMNMAX && _currentRoom == 52 && vm.slot[_currentScript].number == 102 &&
+						chr == 9 && readVar(0x8000 + 95) != 0 && (VAR(171) == 997 || VAR(171) == 998) &&
+						dst[-2] == 8 && _enableEnhancements) {
+						dst[-2] = 7;
+					}
+
 					if (_game.version == 8) {
 						*dst++ = src[num+2];
 						*dst++ = src[num+3];


### PR DESCRIPTION
The following PR fixes some misattributed lines when speaking to Evelyn Morrison near the end of the game, in Sam & Max. If you wear the bigfoot costume and talk to her, the lines are said with Sam's voice, but they're wrongly attached to Max (and so the subtitles and lip-syncing will not be applied to the intended actor).

As far as I can say, this doesn't happen in the CD/DOS/English version of the game, but maybe an earlier version or the Floppy/English has this bug. Anyway, this workaround fixes the script whenever it detects it's wrong.

## Explanation

Script 52-102 does this while talking to Evelyn Morrison while wearing the costume, in the non-English versions:

```
...
if (!bitvar95)
...
              # Clicking on the "!" icon
[155D] (5D)   if (dup[11] == 998) {
[1564] (BA)     talkActor(sound(0x58724A9, 0xA) + "Quel beau costume!" + startAnim(8),2) # <==
[1590] (CA)     delayFrames(11)
[1594] (A9)     wait.waitForMessage()
[1596] (82)     animateActor(4,249)
[159D] (6C)     breakHere()
[159E] (BA)     talkActor(sound(0x5878394, 0xA) + "Evelyn Morrison vous remercie.",4)
[15D1] (A9)     wait.waitForMessage()
[15D3] (82)     animateActor(4,250)
[15DA] (6C)     breakHere()
[15DB] (82)     animateActor(4,249)
[15E2] (6C)     breakHere()
[15E3] (73)     jump 152e
              # Clicking on the "?" icon
[15E6] (5D)   } else if (dup[11] == 997) {
[15F1] (BA)     talkActor(sound(0x5894692, 0xA) + "O\x97 avez-vous trouv\x82 ce regard \x82trange?" + startAnim(8),2) # <==
[1631] (A9)     wait.waitForMessage()
[1633] (CA)     delayFrames(11)
[1637] (82)     animateActor(4,250)
[163E] (BA)     talkActor(sound(0x58A127D, 0xA) + "Tournage 5, sc\x8Ane 36, garde-robe 14, en 1972. Plut\x93t efficace, vous ne trouvez pas?",4)
[16A6] (A9)     wait.waitForMessage()
[16A8] (82)     animateActor(4,249)
[16AF] (6C)     breakHere()
[16B0] (BA)     talkActor(sound(0x58CD40D, 0xA) + "Et c'est tellement naturel comme regard^" + startAnim(8),2) # <==
[16F1] (CA)     delayFrames(11)
[16F5] (A9)     wait.waitForMessage()
[16F7] (73)     jump 152e
...
```

Notice the usage of `startAnim(8)` for these lines, it looks like it's a way for the game to deal with the bigfoot costume being shared by two actors. `8` is Max, but these lines are clearly voiced by Sam.

The CD/DOS/English release (from GOG) fixed this:

```
...
[1391] (5D)   if (dup[11] == 998) {
[1398] (BA)     talkActor(sound(0x6185536, 0xA) + "Nice outfit." + startAnim(7),2)
[13BE] (CA)     delayFrames(11)
[13C2] (A9)     wait.waitForMessage()
[13C4] (82)     animateActor(4,249)
[13CB] (6C)     breakHere()
[13CC] (BA)     talkActor(sound(0x618AB61, 0xA) + "Evelyn Morrison thanks you.",4)
[13FC] (A9)     wait.waitForMessage()
[13FE] (82)     animateActor(4,250)
[1405] (6C)     breakHere()
[1406] (82)     animateActor(4,249)
[140D] (6C)     breakHere()
[140E] (73)     jump 1362
[1411] (5D)   } else if (dup[11] == 997) {
[141C] (BA)     talkActor(sound(0x61AFEF7, 0xA) + "So where'd you get that way-out look?" + startAnim(7),2)
[145B] (A9)     wait.waitForMessage()
[145D] (CA)     delayFrames(11)
[1461] (82)     animateActor(4,250)
[1468] (BA)     talkActor(sound(0x61B95A2, 0xA) + "Lot-5 set-36 wardrobe-14 back in '72.  It really works, don't you think?",4)
[14C5] (A9)     wait.waitForMessage()
[14C7] (82)     animateActor(4,249)
[14CE] (6C)     breakHere()
[14CF] (BA)     talkActor(sound(0x61D344D, 0xA) + "And it's such a natural look too." + startAnim(7),2)
[1509] (CA)     delayFrames(11)
[150D] (A9)     wait.waitForMessage()
[150F] (73)     jump 1362
...
```

i.e. it uses `startAnim(7)`, there, which is Sam, as intended.

So, this workaround:

* looks for this script
* looks for the startAnim op-code (`chr == 9` in `ScummEngine::convertMessageToString()`)
* looks for `if (!bitvar95)` to reach this particular part of the script (`readVar(0x8000 + 95) != 0`)
* looks for the "?" or "!" dialogue options (`VAR(171) == 997 || VAR(171) == 998`), because the startAnim() calls should be kept as-is in the other cases
* if `startAnim(8)` was used, it's overridden with `startAnim(7)` (`dst[-2] ...`)

This way, the lines are attached to Sam again.

## How to test

1. Start a non-English version of Sam & Max, such as the French or German release (they're available on GOG, and probably on Steam).
2. Load a save near the end of the game, when you wear your bigfoot costume but haven't met Bruno yet. [Here's a save](https://github.com/scummvm/scummvm/files/9181939/samnmax-fr.s18.zip) for the CD/DOS/French version.
3. Go back to Evelyn Morrison (go back to the room on the right, in the previous save) and talk to her.
4. When using the "?" and "!" icons, the remarks should be attached to Sam, not Max. (The "duck" and "hand" icons in this dialogue are OK.)
5. Try also to talk to Evelyn Morrison without wearing the costume (go back to the phone booth), etc.