### PR TITLE
SCUMM: Fix RTL display for verbs with indirection on MI2

### DIFF
--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -567,7 +567,7 @@ void ScummEngine::fakeBidiString(byte *ltext, bool ignoreVerb) const {
 	// Reverses texts on each line marked by control characters (considering different control characters used in verbs panel)
 	// While preserving original order of numbers (also negative numbers and comma separated)
 	int32 ll = 0;
-	if (_game.id == GID_INDY4 && ltext[ll] == 0x7F) {
+	if ((_game.id == GID_INDY4 && ltext[ll] == 0x7F) || (_game.id == GID_MONKEY2 && ltext[ll] == 0x07)) {
 		ll++;
 	}
 	while (ltext[ll] == 0xFF) {
@@ -648,9 +648,15 @@ void ScummEngine::fakeBidiString(byte *ltext, bool ignoreVerb) const {
 		}
 		break;
 	}
-	if (!ignoreVerb && _game.id == GID_INDY4 && ltext[0] == 0x7F) {
-		ltext[start + ipos + ll] = 0x80;
-		ltext[start + ipos + ll + 1] = 0;
+	if (!ignoreVerb) {
+		if (_game.id == GID_INDY4 && ltext[0] == 0x7F) {
+			ltext[start + ipos + ll] = 0x80;
+			ltext[start + ipos + ll + 1] = 0;
+		} else if (_game.id == GID_MONKEY2 && ltext[0] == 0x07) {
+			ltext[0] = ' ';
+			ltext[start + ipos + ll] = 0x07;
+			ltext[start + ipos + ll + 1] = 0;
+		}
 	}
 
 	free(buff);


### PR DESCRIPTION
For example: 07 FF 07 21 00

The first 07 is the skull, then ff 07 21 appends the verb referenced in
variable 33. If this verb contains control characters, the result is
something like "07 FF 0A 0F 29 ... Some text".

Now, the bidi algorithm *doesn't* skip all the initial control characters
(they are skipped later in the loop), and it only reverses the text, but
the 07 remains in the beginning. The result is 07 FF 0A 0F 29 ... txet emoS

Use a similar technique like was done for INDY4 - Skip the initial 07
character, then append it in the end, and replace the original one with a
space. This gives 32 FF 0A 0F 29 ... txet emoS 07.