### PR TITLE
SCUMM: FREDDI4: workaround lipsync issues in final scene

### DIFF
--- a/engines/scumm/akos.cpp
+++ b/engines/scumm/akos.cpp
@@ -1463,6 +1463,13 @@ bool ScummEngine_v6::akos_increaseAnim(Actor *a, int chan, const byte *aksq, con
 			case AKC_C0A0:
 			case AKC_C0A1:
 			case AKC_C0A2:
+				// WORKAROUND bug #3533 luther does not moves his lips on subsequent sentences (only the first one).
+				// we skip the opcode instruction until all lines are said.
+				if (_game.id == GID_FREDDI4 && _currentRoom == 43 && a->_costume == 809 && code == AKC_C0A1 && a->getAnimVar(23) > 0) {
+					a->setAnimVar(23, a->getAnimVar(23) - 1);
+					((ActorHE *)a)->_heTalking = true;
+					break;
+				}
 				curpos += 4;
 				break;
 			case AKC_ComplexChan2:
@@ -1528,6 +1535,15 @@ bool ScummEngine_v6::akos_increaseAnim(Actor *a, int chan, const byte *aksq, con
 		case AKC_JumpL:
 		case AKC_JumpNE:
 		case AKC_JumpE:
+			// WORKAROUND bug #3533 when freddi talks in multiple sentences, she moves her lips on the first sequence.
+			// then luther moves his lips on the second and the rest are disembodied.
+			// we force the comparison (loop to start of freddi's lips) until all lines are said.
+			if (_game.id == GID_FREDDI4 && _currentRoom == 43 && a->_costume == 809 && a->getAnimVar(25) > 0) {
+				a->setAnimVar(25, a->getAnimVar(25) - 1);
+				curpos = GUW(2);
+				break;
+			}
+
 			if (akos_compare(a->getAnimVar(GB(4)), GW(5), code - AKC_JumpStart) != 0) {
 				curpos = GUW(2);
 				break;

--- a/engines/scumm/he/script_v72he.cpp
+++ b/engines/scumm/he/script_v72he.cpp
@@ -793,6 +793,12 @@ void ScummEngine_v72he::o72_actorOps() {
 		k = getStackList(args, ARRAYSIZE(args));
 		for (i = 0; i < k; ++i) {
 			a->setUserCondition(args[i] & 0x7F, args[i] & 0x80);
+			// WORKAROUND bug #3533 luther does not moves his lips on subsequent sentences (only the first one).
+			// we skip the opcode instruction until all lines are said.
+			// The animation var is set to the number of lines minus 1.
+			if (_game.id == GID_FREDDI4 && _game.heversion == 98 && _currentRoom == 43 && args[i] == 130  && vm.slot[_currentScript].offs != 84203) {
+				a->setAnimVar(23, vm.slot[_currentScript].offs == 79584 ? 2 : 1);
+			}
 		}
 		break;
 	case 24: 		// SO_TALK_CONDITION (HE 80+)
@@ -831,6 +837,13 @@ void ScummEngine_v72he::o72_actorOps() {
 		break;
 	case 76:		// SO_COSTUME
 		a->setActorCostume(pop());
+		// WORKAROUND bug #3533 when freddi talks in multiple sentences, she moves her lips on the first sequence.
+		// then luther moves his lips on the second and the rest are disembodied.
+		// we force the comparison (loop to start of freddi's lips) until all lines are said.
+		// The animation var is set to the number of lines minus 1.
+		if (_game.id == GID_FREDDI4 && _currentRoom == 43 && a->_costume == 809) {
+			a->setAnimVar(25, vm.slot[_currentScript].offs == 105213 ? 3 : 1);
+		}
 		break;
 	case 77:		// SO_STEP_DIST
 		j = pop();


### PR DESCRIPTION
This workarounds https://bugs.scummvm.org/ticket/3533

In general, there seems to be some opcodes in the costume scripts that should be skipped by some unknown condition...
The animation frames in the same costume (809) seems to be 2 sequences:
- freddi talks
- luther talks

So the genral flow of this costume is
- when freddi finishes moving her lips, it's luther turns
- when luther finishes moving his lips, voice become disembodied

for now, this is somewhat hacky solution to loop when the sequence ends prematurely by the counting the amount of lines to be said.

NOTE: This bug does not occur in the original interperter, so there should be some other method, that should solve it from the root cause.