### PR TITLE
SCUMM: Fix Sophia speaking with Indy's voice when looking at him

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -3276,6 +3276,24 @@ void ScummEngine_v5::decodeParseString() {
 					} else {
 						printString(textSlot, _scriptPointer);
 					}
+				} else if (_game.id == GID_INDY4 && vm.slot[_currentScript].number == 161 && _actorToPrintStrFor == 2 &&
+						_game.platform != Common::kPlatformAmiga && strcmp(_game.variant, "Floppy") != 0 &&
+						_enableEnhancements) {
+					// WORKAROUND: In Indy 4, if one plays as Sophia and looks at Indy, then
+					// her "There's nothing to look at." reaction line will be said with
+					// Indy's voice, because script 68-161 doesn't check for Sophia in this
+					// case. Script 68-4 has a "There's nothing to look at." line for Sophia,
+					// though, so we reuse this if the current line contains the expected
+					// audio offset.
+					if (memcmp(_scriptPointer, "\xFF\x0A\x5D\x8E\xFF\x0A\x63\x08\xFF\x0A\x0E\x00\xFF\x0A\x00\x00", 16) == 0) {
+						byte *tmpBuf = new byte[len];
+						memcpy(tmpBuf, "\xFF\x0A\xCE\x3B\xFF\x0A\x01\x05\xFF\x0A\x0E\x00\xFF\x0A\x00\x00", 16);
+						memcpy(tmpBuf + 16, _scriptPointer + 16, len - 16);
+						printString(textSlot, tmpBuf);
+						delete[] tmpBuf;
+					} else {
+						printString(textSlot, _scriptPointer);
+					}
 				} else if (_game.id == GID_MONKEY_EGA && _roomResource == 30 && vm.slot[_currentScript].number == 411 &&
 							strstr((const char *)_scriptPointer, "NCREDIT-NOTE-AMOUNT")) {
 					// WORKAROUND for bug #4886 (MI1EGA German: Credit text incorrect)


### PR DESCRIPTION
## Context

In Indy 4, you can play as Sophia in some scenes (for example, in the Azores).

But if you look at Indy with her, she'll speak with Indy's voice, in the Talkie version.

The culprit seems to be script 68-161:

```
(48) if (Var[181] == 2) {
(42)   chainScript(162,[]);
(48) } else if (Var[181] == 11) {
(48)   if (VAR_EGO == 2) {
(D8)     printEgo([Text(sound(0x865362C, 0xA) + "No thanks.")]);
(18)   } else {
(D8)     printEgo([Text(sound(0x8638E5D, 0xE) + "There's nothing to look at.")]);
(**)   }
(18) } else {
       # Here:
(D8)   printEgo([Text(sound(0x8638E5D, 0xE) + "There's nothing to look at.")]);
(**) }
(A0) stopObjectCode();
END
```

I'm not sure what `Var[181]` is, but when using the "Look at" verb, we reach the last `else` block. But this default case uses the same sample for Indy and Sophia, hence the wrong voice when playing with Sophia…

## Proposed workaround

Fortunately, script 68-4 has a dub for the exact same line, with Sophia's voice.

So I just reuse its audio content if `_actorToPrintStrFor` is `2` (= playing as Sophia) in this scene, and if the current dialogue line points to the audio offset that we expect. I'm not changing the text itself.

AFAIK, there's only a single, identical MONSTER.SOU file for all talkie ports of this game (DOS, Macintosh, FM-TOWNS), but checking the audio offset is still safer, especially for fan translations or any eventual fandub or unknown version of the game. 

## How to test

1. Play any talkie version, start the game with boot param `6005`, use Esc to skip the fake intro
2. Talk to Sophia, ask her to take the lead (opt. 2)
3. As Sophia, use the "Look at" verb on Indy
4. She should now speak with her own voice

(I've tested the DOS/English version from GOG, my old Macintosh/English CD, and a French fan translation)