### PR TITLE
DIRECTOR: do not try to open dirs as files

### DIFF
--- a/engines/director/util.cpp
+++ b/engines/director/util.cpp
@@ -393,6 +393,7 @@ Common::String getPath(Common::String path, Common::String cwd) {
 
 bool testPath(Common::String &path, bool directory) {
 	Common::FSNode d = Common::FSNode(*g_director->getGameDataDir());
+	Common::FSNode node;
 
 	// Test if we have it right in the SearchMan
 	if (SearchMan.hasFile(Common::Path(path, g_director->_dirSeparator)))
@@ -426,12 +427,18 @@ bool testPath(Common::String &path, bool directory) {
 			// for each element in the path, choose the first FSNode
 			// with a case-insensitive matcing name
 			if (i->getName().equalsIgnoreCase(token)) {
+				// If this is a directory, it's not a valid candidate
+				node = Common::FSNode(*i);
+				if (node.isDirectory()) {
+					continue;
+				}
+
 				exists = true;
 				newPath += i->getName();
 				if (!directory_list.empty())
 					newPath += (g_director->_dirSeparator);
 
-				d = Common::FSNode(*i);
+				d = node;
 				break;
 			}
 		}


### PR DESCRIPTION
This fixes a bug introduced by 1823539136a680e40153108542db4b8f3481e6ca. That commit made it possible to look into directories when loading files in Util's `testPath`. However, this introduced a bug: if a movie existed in the same path as a directory of the same basename, `testPath` will now find the directory first before the movie. It will return that as the file to open, which will then fail further down the stack when `File::open` fails on it. This adds a check first if the file is a directory before accepting it as the path.

Affected games include Ganbare Inuchan 2 and the Windows version of Spaceship Warlock. I've confirmed this fixes Inuchan 2.

Fixes https://bugs.scummvm.org/ticket/13733.

cc @sev- 