### PR TITLE
SCUMM: Fix past-buffer read on fakeBidiString

### DIFF
--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -588,7 +588,7 @@ void ScummEngine::fakeBidiString(byte *ltext, bool ignoreVerb) const {
 		if (*current == 0x0D || *current == 0 || *current == 0xFF || *current == 0xFE) {
 
 			// ignore the line break for verbs texts
-			if (ignoreVerb && (*(current + 1) ==  8)) {
+			if (ignoreVerb && *current && (*(current + 1) ==  8)) {
 				*(current + 1) = *current;
 				*current = 0x08;
 				ipos += 2;


### PR DESCRIPTION
fakeBidiString accepts an argument named ignoreVerb. When it is set, we do
not reverse the current section at this point (only these 2 characters are
swapped, so that they'll be swapped back when reversing everything at once
afterwards).

But the condition above covers also end of string *current == 0 along with
the control characters, so on this case, the function still looked for the
newline character past the string buffer. On some cases, a previous string
that was written on the same buffer (the buffer is reused for every string
in the engine), can have newline exactly at this point, and we applied the
same logic, and swapped the newline with 0, which eventually resulted with
some garbled text from the previous buffer.

Fix by excluding end of buffer for this condition.
