### PR TITLE
GUI: Support unicode and BiDi in editable widget

### DIFF
--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -1665,11 +1665,11 @@ int ThemeEngine::getStringWidth(const Common::U32String &str, FontStyle font) co
 	return ready() ? _texts[fontStyleToData(font)]->_fontPtr->getStringWidth(str) : 0;
 }
 
-int ThemeEngine::getCharWidth(byte c, FontStyle font) const {
+int ThemeEngine::getCharWidth(uint32 c, FontStyle font) const {
 	return ready() ? _texts[fontStyleToData(font)]->_fontPtr->getCharWidth(c) : 0;
 }
 
-int ThemeEngine::getKerningOffset(byte left, byte right, FontStyle font) const {
+int ThemeEngine::getKerningOffset(uint32 left, uint32 right, FontStyle font) const {
 	return ready() ? _texts[fontStyleToData(font)]->_fontPtr->getKerningOffset(left, right) : 0;
 }
 

--- a/gui/ThemeEngine.h
+++ b/gui/ThemeEngine.h
@@ -432,9 +432,9 @@ public:
 
 	int getStringWidth(const Common::U32String &str, FontStyle font = kFontStyleBold) const;
 
-	int getCharWidth(byte c, FontStyle font = kFontStyleBold) const;
+	int getCharWidth(uint32 c, FontStyle font = kFontStyleBold) const;
 
-	int getKerningOffset(byte left, byte right, FontStyle font = kFontStyleBold) const;
+	int getKerningOffset(uint32 left, uint32 right, FontStyle font = kFontStyleBold) const;
 
 	//@}
 

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -92,7 +92,7 @@ public:
 		: EditTextWidget(boss, name, text, tooltip) {}
 
 protected:
-	bool tryInsertChar(byte c, int pos) override {
+	bool tryInsertChar(Common::u32char_type_t c, int pos) override {
 		if (Common::isAlnum(c) || c == '-' || c == '_') {
 			_editString.insertChar(c, pos);
 			return true;

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -115,8 +115,8 @@ public:
 	int getFontHeight(ThemeEngine::FontStyle style = ThemeEngine::kFontStyleBold) const { return _theme->getFontHeight(style); }
 	int getStringWidth(const Common::String &str, ThemeEngine::FontStyle style = ThemeEngine::kFontStyleBold) const { return _theme->getStringWidth(str, style); }
 	int getStringWidth(const Common::U32String &str, ThemeEngine::FontStyle style = ThemeEngine::kFontStyleBold) const { return _theme->getStringWidth(str, style); }
-	int getCharWidth(byte c, ThemeEngine::FontStyle style = ThemeEngine::kFontStyleBold) const { return _theme->getCharWidth(c, style); }
-	int getKerningOffset(byte left, byte right, ThemeEngine::FontStyle font = ThemeEngine::kFontStyleBold) const { return _theme->getKerningOffset(left, right, font); }
+	int getCharWidth(uint32 c, ThemeEngine::FontStyle style = ThemeEngine::kFontStyleBold) const { return _theme->getCharWidth(c, style); }
+	int getKerningOffset(uint32 left, uint32 right, ThemeEngine::FontStyle font = ThemeEngine::kFontStyleBold) const { return _theme->getKerningOffset(left, right, font); }
 
 	/**
 	 * Tell the GuiManager to check whether the screen resolution has changed.

--- a/gui/widgets/editable.h
+++ b/gui/widgets/editable.h
@@ -94,7 +94,10 @@ protected:
 
 	void setFontStyle(ThemeEngine::FontStyle font) { _font = font; }
 
-	virtual bool tryInsertChar(byte c, int pos);
+	virtual bool tryInsertChar(Common::u32char_type_t c, int pos);
+
+	int caretVisualPos(int logicalPos);
+	int caretLogicalPos() const;
 };
 
 } // End of namespace GUI


### PR DESCRIPTION
This allow writing unicode to editable text input, including BiDi support (write RTL and LTR languages together).
The neat trick here is appending single space to calculate the caret position which changes according to last character direction.
