### PR TITLE
JANITORIAL: Fix "the the" and similar typos

### DIFF
--- a/audio/softsynth/mt32/TVA.cpp
+++ b/audio/softsynth/mt32/TVA.cpp
@@ -229,7 +229,7 @@ void TVA::recalcSustain() {
 	// Real hardware units ignore this possibility and rely on the assumption that the target is the current amp.
 	// This is OK in most situations but when the ramp that is currently in progress needs to change direction
 	// due to a volume/expression update, this leads to a jump in the amp that is audible as an unpleasant click.
-	// To avoid that, we compare the newTarget with the the actual current ramp value and correct the direction if necessary.
+	// To avoid that, we compare the newTarget with the actual current ramp value and correct the direction if necessary.
 	int targetDelta = newTarget - target;
 
 	// Calculate an increment to get to the new amp value in a short, more or less consistent amount of time

--- a/audio/softsynth/opl/dbopl.cpp
+++ b/audio/softsynth/opl/dbopl.cpp
@@ -907,7 +907,7 @@ Channel* Channel::BlockTemplate( Chip* chip, Bit32u samples, Bit32s* output ) {
 	default:
 		break;
 	}
-	//Init the operators with the the current vibrato and tremolo values
+	//Init the operators with the current vibrato and tremolo values
 	Op( 0 )->Prepare( chip );
 	Op( 1 )->Prepare( chip );
 	if ( mode > sm4Start ) {
@@ -1066,7 +1066,7 @@ INLINE Bit32u Chip::ForwardLFO( Bit32u samples ) {
 		lfoCounter &= (LFO_MAX - 1);
 		//Maximum of 7 vibrato value * 4
 		vibratoIndex = ( vibratoIndex + 1 ) & 31;
-		//Clip tremolo to the the table size
+		//Clip tremolo to the table size
 		if ( tremoloIndex + 1 < TREMOLO_TABLE  )
 			++tremoloIndex;
 		else

--- a/audio/soundfont/synthfile.cpp
+++ b/audio/soundfont/synthfile.cpp
@@ -30,7 +30,7 @@
 using namespace std;
 
 //  **********************************************************************************
-//  SynthFile - An intermediate class to lay out all of the the data necessary for Coll conversion
+//  SynthFile - An intermediate class to lay out all of the data necessary for Coll conversion
 //				to DLS or SF2 formats.  Currently, the structure is identical to
 //DLS.
 //  **********************************************************************************

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
@@ -2496,7 +2496,7 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 		}
 
 		// Important note: We cannot assume that anything sent here is a relative path on top of the *ONLY* SAF "root" path
-		//                 since the the user could select another SD Card (from multiple inserted or replaces the current one and inserts another)
+		//                 since the user could select another SD Card (from multiple inserted or replaces the current one and inserts another)
 		// TODO Can we translate our path string "/storage/XXXX-XXXXX/folder/doc.ext' a content URI? or a document URI?
 		String[] parts = relPath.split("\\/");
 		for (int i = 0; i < parts.length; i++) {

--- a/common/lua/double_serialization.cpp
+++ b/common/lua/double_serialization.cpp
@@ -31,7 +31,7 @@ SerializedDouble encodeDouble(double value) {
 	int exponent;
 	double significand = frexp(value, &exponent);
 
-	// Shift the the first part of the significand into the integer range
+	// Shift the first part of the significand into the integer range
 	double shiftedsignificandPart = ldexp(fabs(significand), 32);
 	uint32 significandOne = uint32(floor(shiftedsignificandPart));
 

--- a/common/unzip.cpp
+++ b/common/unzip.cpp
@@ -528,7 +528,7 @@ unzFile unzOpen(Common::SeekableReadStream *stream) {
 
 	uLong number_disk;          /* number of the current dist, used for
 								   spaning ZIP, unsupported, always 0*/
-	uLong number_disk_with_CD;  /* number the the disk with central dir, used
+	uLong number_disk_with_CD;  /* number the disk with central dir, used
 								   for spaning ZIP, unsupported, always 0*/
 	uLong number_entry_CD;      /* total number of entries in
 	                               the central dir

--- a/doc/docportal/advanced_topics/understand_audio.rst
+++ b/doc/docportal/advanced_topics/understand_audio.rst
@@ -212,7 +212,7 @@ ScummVM has to resample all sounds to the selected output frequency. It is recom
 Audio buffer size
 ==========================
 
-There is no option to control audio buffer size through the GUI, but the default value can be overridden in the the :doc:`configuration file <../advanced_topics/configuration_file>` with the *audio_buffer_size* configuration keyword. The default value is calculated based on output sampling frequency to keep audio latency below 45ms.
+There is no option to control audio buffer size through the GUI, but the default value can be overridden in the :doc:`configuration file <../advanced_topics/configuration_file>` with the *audio_buffer_size* configuration keyword. The default value is calculated based on output sampling frequency to keep audio latency below 45ms.
 
 Appropriate values are normally between 512 and 8192, but the value must be one of: 256, 512, 1024, 2048, 4096, 8192, 16384, or 32768.
 

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -493,7 +493,7 @@ public:
 	/**
 	 * Return the name of the engine plugin based on the engineID.
 	 *
-	 * The the engineID must match the one from MetaEngine.
+	 * The engineID must match the one from MetaEngine.
 	 *
 	 * @see MetaEngine::getName().
 	 */

--- a/engines/agi/sprite.cpp
+++ b/engines/agi/sprite.cpp
@@ -444,7 +444,7 @@ void SpritesMgr::showObject(int16 viewNr) {
  * @param x     x coordinate to place the view
  * @param y     y coordinate to place the view
  * @param pri   priority to use
- * @param mar   if < 4, create a margin around the the base of the cel
+ * @param mar   if < 4, create a margin around the base of the cel
  */
 void SpritesMgr::addToPic(int16 viewNr, int16 loopNr, int16 celNr, int16 xPos, int16 yPos, int16 priority, int16 border) {
 	debugC(3, kDebugLevelSprites, "addToPic(view=%d, loop=%d, cel=%d, x=%d, y=%d, pri=%d, border=%d)", viewNr, loopNr, celNr, xPos, yPos, priority, border);

--- a/engines/ags/engine/script/cc_instance.cpp
+++ b/engines/ags/engine/script/cc_instance.cpp
@@ -560,7 +560,7 @@ int ccInstance::Run(int32_t curpc) {
 				_G(new_line_hook)(this, _G(currentline));
 			break;
 		case SCMD_ADD:
-			// If the the register is SREG_SP, we are allocating new variable on the stack
+			// If the register is SREG_SP, we are allocating new variable on the stack
 			if (arg1.IValue == SREG_SP) {
 				// Only allocate new data if current stack entry is invalid;
 				// in some cases this may be advancing over value that was written by MEMWRITE*

--- a/engines/buried/frame_window.cpp
+++ b/engines/buried/frame_window.cpp
@@ -213,7 +213,7 @@ bool FrameWindow::showClosingScreen() {
 	_mainChildWindow->showWindow(kWindowShow);
 	_mainChildWindow->setFocus();
 
-	// Start the the title sequence
+	// Start the title sequence
 	((TitleSequenceWindow *)_mainChildWindow)->playTitleSequence();
 
 	// Empty the input queue

--- a/engines/chewy/rooms/room89.cpp
+++ b/engines/chewy/rooms/room89.cpp
@@ -111,7 +111,7 @@ void Room89::entry() {
 		// Unsquish out thanks for playing screen
 		_G(out)->setPointer(_G(workptr));
 		_G(out)->cls();
-		// Those strings are also displayed in the the German version
+		// Those strings are also displayed in the German version
 		_G(out)->printxy(70, 80, 15, 0, 0, "Thank you for playing");
 		_G(out)->printxy(70, 100, 15, 0, 0, "  CHEWY Esc from F5");
 		_G(out)->spriteSave(_G(tempArea), 0, 0, 320, 200);

--- a/engines/cine/various.cpp
+++ b/engines/cine/various.cpp
@@ -1442,7 +1442,7 @@ void removeMessages() {
 			// NOTE: These are really removeOverlay calls that have been deferred.
 			// In Operation Stealth's disassembly elements are removed from the
 			// overlay list right in the drawOverlays function (And actually in
-			// some other places too) and that's where incrementing a the overlay's
+			// some other places too) and that's where incrementing the overlay's
 			// last parameter by one if it's negative and testing it for positivity
 			// comes from too.
 			remove = it->type == 3 || (it->type == 2 && (it->color >= 0 || ++(it->color) >= 0));

--- a/engines/director/lingo/xlibs/winxobj.cpp
+++ b/engines/director/lingo/xlibs/winxobj.cpp
@@ -19,7 +19,7 @@
  *
  */
 
-/* RearWindow is a Mac only XObject. It's purpose is to cover the screen
+/* RearWindow is a Mac only XObject. Its purpose is to cover the screen
  * with either a 1-bit pattern, indexed color, direct(RGB) color, bitmappedCastMember
  * or PICT file picture.
  *
@@ -56,7 +56,7 @@ const char *RearWindowXObj::fileNames[] = {
 --   © 1989-93 by Macromedia Inc.
 --
 -- Purpose of the XObject:
---   Covers the the Finder desktop (behind the Director Stage) with a window
+--   Covers the Finder desktop (behind the Director Stage) with a window
 --   containing either a 1-bit pattern, indexed color, direct (RGB) color,
 --   bitmapped castMember, or PICT file picture.
 --
@@ -104,7 +104,7 @@ S   mGetAppName -- returns name of current application, so you can test for eith
 --
 I  mGetMemoryNeeded  -- Returns number of Bytes needed to create a RearWindow
 --  for all screen devices. Compare this with the Lingo function 'the freeBlock'.
---  If the the mNew method specified "Single" monitor configuration, then
+--  If the mNew method specified "Single" monitor configuration, then
 --  this refers to the number of Bytes for only one monitor. See the
 --  RearWindow Example Movie for how to use this with Lingo
 --

--- a/engines/dm/gfx.h
+++ b/engines/dm/gfx.h
@@ -731,7 +731,7 @@ public:
 
 
 	/* srcHeight and destHeight are not necessary for blitting, only error checking, thus they are defaulted for existing code which
-	does not pass anything, newly imported calls do pass srcHeght and srcWidth, so this is a ceonvenience change so the the parameters
+	does not pass anything, newly imported calls do pass srcHeght and srcWidth, so this is a convenience change so the parameters
 	match the original exactly, if need arises for heights then we'll have to retrospectively add them in old function calls*/
 	/* Expects inclusive boundaries in box */
 	void blitToBitmap(byte *srcBitmap, byte *destBitmap, const Box &box, uint16 srcX, uint16 srcY, uint16 srcByteWidth,

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -176,7 +176,7 @@ Engine::Engine(OSystem *syst)
 	//
 	// If an engine only used CursorMan.replaceCursor and no cursor has
 	// been setup before, then replaceCursor just uses pushCursor. This
-	// means that that the engine's cursor is never again removed from
+	// means that the engine's cursor is never again removed from
 	// CursorMan. Hence we setup a fake cursor here and remove it again
 	// in the destructor.
 	CursorMan.pushCursor(NULL, 0, 0, 0, 0, 0);

--- a/engines/glk/agt/config.h
+++ b/engines/glk/agt/config.h
@@ -39,7 +39,7 @@ namespace AGT {
 
    Ideally, a port to a new platform should only need to modify this
 	file, the makefile, os_<whatever>.c, and possibly filename.c.  (In
-	practice, you may also need to tweak the the high-level I/O code
+	practice, you may also need to tweak the high-level I/O code
 	in interface.c or the memory-allocation code in util.c.  If you
 	find yourself needing to do more than that, get in touch with me.)  */
 

--- a/engines/glk/agt/os_glk.cpp
+++ b/engines/glk/agt/os_glk.cpp
@@ -30,7 +30,7 @@ namespace AGT {
  * Glk interface for AGiliTy 1.1.1.1
  * -------------------------------
  *
- * This module contains the the Glk porting layer for AGiliTy.  It
+ * This module contains the Glk porting layer for AGiliTy.  It
  * defines the Glk arguments list structure, the entry points for the
  * Glk library framework to use, and all platform-abstracted I/O to
  * link to Glk's I/O.

--- a/engines/glk/alan2/main.cpp
+++ b/engines/glk/alan2/main.cpp
@@ -164,7 +164,7 @@ void error(CONTEXT, MsgKind msgno) {
 
   statusline()
 
-  Print the the status line on the top of the screen.
+  Print the status line on the top of the screen.
 
   */
 void statusline() {

--- a/engines/glk/magnetic/magnetic_types.h
+++ b/engines/glk/magnetic/magnetic_types.h
@@ -80,7 +80,7 @@ struct picture {
  * between calls is about 100 milliseconds.
  * Each call to ms_animate() will fill in the arguments with the address
  * and size of an array of ms_position structures (see below), each of
- * which holds an an animation frame number and x and y co-ordinates. To
+ * which holds an animation frame number and x and y co-ordinates. To
  * display the animation, decode all the animation frames (discussed below)
  * from a single call to ms_animate() and display each one over the main picture.
  * If your port does not support animations, define NO_ANIMATION.

--- a/engines/gnap/fontdata.h
+++ b/engines/gnap/fontdata.h
@@ -26,7 +26,7 @@ namespace Gnap {
 
 struct FONT_CHAR_INFO {
   const byte _width;              // width, in bits (or pixels), of the character
-  const uint16 _offset;           // offset of the character's bitmap, in bytes, into the the FONT_INFO's data array
+  const uint16 _offset;           // offset of the character's bitmap, in bytes, into the FONT_INFO's data array
 
   FONT_CHAR_INFO(byte width, uint16 offset) : _width(width), _offset(offset) {}
 };

--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -1837,7 +1837,7 @@ bool Actor::shouldDrawShadow(int shadowId) {
 		return false;
 
 	// Don't draw a shadow if the shadow caster and the actor are on different sides
-	// of the the shadow plane.
+	// of the shadow plane.
 
 	if (shadow->planeList.size() == 0)
 		return false;

--- a/engines/icb/gfx/rap_api.h
+++ b/engines/icb/gfx/rap_api.h
@@ -37,7 +37,7 @@ namespace ICB {
 
 // A bone-bone link
 // tx, ty, tz : is translation
-// parent : is the the parent bone ID
+// parent : is the parent bone ID
 // = nBones means no linkage
 typedef struct BoneLink {
 	int16 tx, ty, tz;
@@ -83,9 +83,9 @@ typedef struct WeightedVertexLink {
 // tsb = weird PSX flag, giving the VRAM texture page to use
 // pad = padding !
 //
-// n0, v0 = index into the the normal and vertex pool for normal/vertex 0
-// n1, v1 = index into the the normal and vertex pool for normal/vertex 1
-// n2, v2 = index into the the normal and vertex pool for normal/vertex 2
+// n0, v0 = index into the normal and vertex pool for normal/vertex 0
+// n1, v1 = index into the normal and vertex pool for normal/vertex 1
+// n2, v2 = index into the normal and vertex pool for normal/vertex 2
 //
 // The .rap file format
 //

--- a/engines/icb/options_manager_pc.cpp
+++ b/engines/icb/options_manager_pc.cpp
@@ -4840,7 +4840,7 @@ void OptionsManager::AnimateSlotsPaging() {
 				DrawMovieSlots(m_movieOffset - M_NUMBER_OF_VISIBLE_MOVIE_SLOTS, m_mySlotSurface1ID);
 			}
 
-			// Blit this surface the the screen with animating offsets and transparency
+			// Blit this surface the screen with animating offsets and transparency
 			surface_manager->Blit_surface_to_surface(m_mySlotSurface1ID, working_buffer_id, &m_pageOn_from, &m_pageOn_dest, DDBLT_KEYSRC);
 		}
 
@@ -4863,7 +4863,7 @@ void OptionsManager::AnimateSlotsPaging() {
 				DrawMovieSlots(m_movieOffset, m_mySlotSurface1ID);
 			}
 
-			// Blit this surface the the screen with animating offsets and transparency
+			// Blit this surface the screen with animating offsets and transparency
 			surface_manager->Blit_surface_to_surface(m_mySlotSurface1ID, working_buffer_id, &m_pageOff_from, &m_pageOff_dest, DDBLT_KEYSRC);
 		}
 
@@ -4924,7 +4924,7 @@ void OptionsManager::AnimateSlotsPaging() {
 				DrawMovieSlots(m_movieOffset + M_NUMBER_OF_VISIBLE_MOVIE_SLOTS, m_mySlotSurface1ID);
 			}
 
-			// Blit this surface the the screen with animating offsets and transparency
+			// Blit this surface the screen with animating offsets and transparency
 			surface_manager->Blit_surface_to_surface(m_mySlotSurface1ID, working_buffer_id, &m_pageOn_from, &m_pageOn_dest, DDBLT_KEYSRC);
 		}
 
@@ -4946,7 +4946,7 @@ void OptionsManager::AnimateSlotsPaging() {
 				DrawMovieSlots(m_movieOffset, m_mySlotSurface1ID);
 			}
 
-			// Blit this surface the the screen with animating offsets and transparency
+			// Blit this surface the screen with animating offsets and transparency
 			surface_manager->Blit_surface_to_surface(m_mySlotSurface1ID, working_buffer_id, &m_pageOff_from, &m_pageOff_dest, DDBLT_KEYSRC);
 		}
 

--- a/engines/icb/remora_pc.cpp
+++ b/engines/icb/remora_pc.cpp
@@ -289,7 +289,7 @@ void _remora::SetUpRemora() {
 	// Prepare the Remora casing.
 	SetUpSurfaceForBitmap(REMORA_BITMAP_REMORA, m_sCasingSourceRectangle, m_sCasingTargetRectangle, m_nCasingSurfaceID);
 
-	// Draw the the casing.
+	// Draw the casing.
 	surface_manager->Blit_surface_to_surface(m_nCasingSurfaceID, m_nRemoraSurfaceID, &m_sCasingSourceRectangle, &m_sCasingTargetRectangle);
 
 	// Set up the sprites that flash when text goes off the top or botttom of the screen.

--- a/engines/icb/res_man.cpp
+++ b/engines/icb/res_man.cpp
@@ -737,7 +737,7 @@ uint8 *res_man::LoadFile(int32 &cluster_search, RMParams *params) {
 	}
 
 	// align to 8 byte boundary in length so that next resource will adjoin legally
-	// so, the the file was 5 bytes int32 it would end up being 8 bytes int32
+	// so, the file was 5 bytes int32 it would end up being 8 bytes int32
 	adj_len = (params->len + 7) & ~7;
 
 	if (adj_len >= total_pool)

--- a/engines/lure/disk.cpp
+++ b/engines/lure/disk.cpp
@@ -83,7 +83,7 @@ void Disk::openFile(uint8 fileNum) {
 	if (_fileNum != 0xff) delete _fileHandle;
 	_fileNum = fileNum;
 
-	// Open up the the new file
+	// Open up the new file
 	_fileHandle = new Common::File();
 
 	char sFilename[10];

--- a/engines/mads/nebular/globals_nebular.h
+++ b/engines/mads/nebular/globals_nebular.h
@@ -271,7 +271,7 @@ enum {
 };
 
 /* Section #7 */
-// Status of the the bottle
+// Status of the bottle
 enum {
 	BOTTLE_EMPTY = 0, BOTTLE_ONE_QUARTER_FULL = 1, BOTTLE_HALF_FULL = 2,
 	BOTTLE_THREE_QUARTERS_FULL = 3, BOTTLE_FULL = 4

--- a/engines/mohawk/console.cpp
+++ b/engines/mohawk/console.cpp
@@ -580,7 +580,7 @@ bool RivenConsole::Cmd_DumpScript(int argc, const char **argv) {
 	// Get CARD/HSPT data and dump their scripts
 	if (!scumm_stricmp(argv[2], "CARD")) {
 		// Use debugN to print these because the scripts can get very large and would
-		// really be useless if the the text console is not used. A DumpFile could also
+		// really be useless if the text console is not used. A DumpFile could also
 		// theoretically be used, but I (clone2727) typically use this dynamically and
 		// don't want countless files laying around without game context. If one would
 		// want a file of a script they could just redirect stdout to a file or use

--- a/engines/mohawk/riven.cpp
+++ b/engines/mohawk/riven.cpp
@@ -538,7 +538,7 @@ void MohawkEngine_Riven::loadLanguageDatafile(char prefix, uint16 stackId) {
 		if (stackId == kStackOspit && getLanguage() != Common::EN_ANY && getLanguage() != Common::RU_RUS) {
 			// WORKAROUND: The international CD versions were repacked for the 25th anniversary release
 			// so they share the same resources as the English DVD version. The resource IDs for the DVD
-			// version resources have a delta of 1 in their numbering when compared the the CD version
+			// version resources have a delta of 1 in their numbering when compared the CD version
 			// resources for Gehn's office. Unfortunately this delta was not compensated when repacking
 			// the archives. We need to do it here at run time...
 			mhk->offsetResourceIDs(ID_TBMP, 196, 1);

--- a/engines/saga2/player.h
+++ b/engines/saga2/player.h
@@ -273,7 +273,7 @@ bool actorIDToPlayerID(ObjectID id, PlayerActorID &result);
 void handlePlayerActorDeath(PlayerActorID id);
 
 //  Transport the center actor and the banded brothers who have a path
-//  the the center actor
+//  the center actor
 void transportCenterBand(const Location &loc);
 
 void handlePlayerActorAttacked(PlayerActorID id);

--- a/engines/sci/engine/workarounds.cpp
+++ b/engines/sci/engine/workarounds.cpp
@@ -1291,7 +1291,7 @@ static const SciMessageWorkaroundEntry messageWorkarounds[] = {
 	{ GID_GK1,           SCI_MEDIA_FLOPPY, K_LANG_NONE,     -1,  420,   4,   8,   3,  1, { MSG_WORKAROUND_REMAP,    420,   4,   8,   7,  1,  0,   0,   0, nullptr } },
 	// Clicking money on Loreli when sitting or dancing in room 420 - bug #10819
 	//  The script transposes sitting vs dancing responses, passes an invalid cond for one of them, and the
-	//  audio36 for the the other has the wrong tuple, which we fix in the audio36 workarounds.
+	//  audio36 for the other has the wrong tuple, which we fix in the audio36 workarounds.
 	{ GID_GK1,           SCI_MEDIA_ALL,    K_LANG_NONE,     -1,  420,   2,  32,   3,  1, { MSG_WORKAROUND_REMAP,    420,   2,  32,   0,  1,  0,   0,   0, nullptr } },
 	{ GID_GK1,           SCI_MEDIA_ALL,    K_LANG_NONE,     -1,  420,   2,  32,   0,  1, { MSG_WORKAROUND_REMAP,    420,   2,  32,   2,  1,  0,   0,   0, nullptr } },
 	// Clicking one of Gabriel's letters on Gerde in room 120 after getting his address in some versions

--- a/engines/scumm/imuse_digi/dimuse_codecs.cpp
+++ b/engines/scumm/imuse_digi/dimuse_codecs.cpp
@@ -180,7 +180,7 @@ static int32 compDecode(byte *src, byte *dst) {
 int32 decompressADPCM(byte *compInput, byte *compOutput, int channels) {
 	byte *src;
 
-	// Decoder for the the IMA ADPCM variants used in COMI.
+	// Decoder for the IMA ADPCM variants used in COMI.
 	// Contrary to regular IMA ADPCM, this codec uses a variable
 	// bitsize for the encoded data.
 

--- a/engines/scumm/object.cpp
+++ b/engines/scumm/object.cpp
@@ -172,7 +172,7 @@ void ScummEngine::clearOwnerOf(int obj) {
 	// Stop the associated object script code (else crashes might occurs)
 	stopObjectScript(obj);
 
-	// If the object is "owned" by a the current room, we scan the
+	// If the object is "owned" by the current room, we scan the
 	// object list and (only if it's a floating object) nuke it.
 	if (getOwner(obj) == OF_OWNER_ROOM) {
 		for (i = 0; i < _numLocalObjects; i++)  {

--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -688,8 +688,8 @@ void ScummEngine::writeVar(uint var, int value) {
 
 		// Unlike the PC version, the Macintosh version of Loom appears
 		// to hard-code the drawing of the practice mode box. This is
-		// handled by script 27 in both versions, but wherease the PC
-		// version draws the notes, the the Mac version this just sets
+		// handled by script 27 in both versions, but whereas the PC
+		// version draws the notes, the Mac version just sets
 		// variables 50 and 54.
 		//
 		// In this script, the variables are set to the same value but

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -1349,8 +1349,8 @@ void ScummEngine_v5::o5_isScriptRunning() {
 	// expected to give something to the cannibals, but instead look at certain
 	// items like the compass or kidnap note. Those inventory items contain little
 	// cutscenes and are abrubtly stopped by the endcutscene in script 204 at 0x0060.
-	// This patch changes the the result of isScriptRunning(164) to also wait for
-	// any inventory scripts that are in a cutscene state, preventing the crash.
+	// This patch changes the result of isScriptRunning(164) to also wait for any
+	// inventory scripts that are in a cutscene state, preventing the crash.
 	if (_game.id == GID_MONKEY && vm.slot[_currentScript].number == 204 && _currentRoom == 25) {
 		ScriptSlot *ss = vm.slot;
 		for (int i = 0; i < NUM_SCRIPT_SLOT; i++, ss++) {

--- a/engines/scumm/verbs.cpp
+++ b/engines/scumm/verbs.cpp
@@ -575,7 +575,7 @@ void ScummEngine::checkExecVerbs() {
 		if ((_game.id == GID_INDY4 || _game.id == GID_PASS) && _mouseAndKeyboardStat >= '0' && _mouseAndKeyboardStat <= '9') {
 			// To support keyboard fighting in FOA, we need to remap the number keys.
 			// FOA apparently expects PC scancode values (see script 46 if you want
-			// to know where I got these numbers from). Oddly enough, the The Indy 3
+			// to know where I got these numbers from). Oddly enough, the Indy 3
 			// part of the "Passport to Adventure" demo expects the same keyboard
 			// mapping, even though the full game doesn't.
 			static const int numpad[10] = {

--- a/engines/sherlock/objects.cpp
+++ b/engines/sherlock/objects.cpp
@@ -714,7 +714,7 @@ void Sprite::checkSprite() {
 
 		if (objBounds.contains(pt)) {
 			if (objBounds.contains(spritePt)) {
-				// Current point is already inside the the bounds, so impact occurred
+				// Current point is already inside the bounds, so impact occurred
 				// on a previous call. So simply do nothing until we're clear of the box
 				switch (obj._aType) {
 				case TALK_MOVE:

--- a/engines/sherlock/objects.h
+++ b/engines/sherlock/objects.h
@@ -247,7 +247,7 @@ public:
 	static void setVm(SherlockEngine *vm);
 
 	/**
-	 * Returns true if the the object has an Allow Talk Code in the sequence that it's
+	 * Returns true if the object has an Allow Talk Code in the sequence that it's
 	 * currently running, specified by the _talkSeq field of the object. If it's 0,
 	 * then it's a regular sequence. If it's not 0 but below 128, then it's a Talk Sequence.
 	 * If it's above 128, then it's one of the Listen sequences.

--- a/engines/sherlock/scene.h
+++ b/engines/sherlock/scene.h
@@ -268,7 +268,7 @@ public:
 	int checkForZones(const Common::Point &pt, int zoneType);
 
 	/**
-	 * Check which zone the the given position is located in.
+	 * Check which zone the given position is located in.
 	 */
 	int whichZone(const Common::Point &pt);
 

--- a/engines/sherlock/tattoo/tattoo_user_interface.cpp
+++ b/engines/sherlock/tattoo/tattoo_user_interface.cpp
@@ -225,7 +225,7 @@ void TattooUserInterface::doJournal() {
 	_windowOpen = false;
 	_key = -1;
 
-	// Restore the the old screen palette and greyscale lookup table
+	// Restore the old screen palette and greyscale lookup table
 	screen.clear();
 	screen.setPalette(screen._cMap);
 	Common::copy(&lookupTable[0], &lookupTable[PALETTE_COUNT], &_lookupTable[0]);

--- a/engines/sherlock/tattoo/widget_files.cpp
+++ b/engines/sherlock/tattoo/widget_files.cpp
@@ -210,7 +210,7 @@ void WidgetFiles::handleEvents() {
 		}
 	}
 
-	// Only redraw the window if the the scrollbar position has changed
+	// Only redraw the window if the scrollbar position has changed
 	if (ui._scrollHighlight != oldHighlight || oldScrollIndex != _savegameIndex || _selector != _oldSelector)
 		render(RENDER_NAMES_AND_SCROLLBAR);
 	_oldSelector = _selector;

--- a/engines/sherlock/tattoo/widget_talk.cpp
+++ b/engines/sherlock/tattoo/widget_talk.cpp
@@ -125,7 +125,7 @@ void WidgetTalk::handleEvents() {
 	int oldScrollIndex = _talkScrollIndex;
 	handleScrolling(_talkScrollIndex, NUM_VISIBLE_TALK_LINES, _statementLines.size());
 
-	// Only redraw the window if the the scrollbar position has changed
+	// Only redraw the window if the scrollbar position has changed
 	if (ui._scrollHighlight != oldHighlight || oldScrollIndex != _talkScrollIndex)
 		render(HL_NO_HIGHLIGHTING);
 

--- a/engines/stark/scene.h
+++ b/engines/stark/scene.h
@@ -79,7 +79,7 @@ public:
 	void setSwayAngle(const Math::Angle &angle);
 	Math::Angle getSwayAngle() const;
 
-	/** Get the axis for the the sway actor rotation, in world coordinates */
+	/** Get the axis for the sway actor rotation, in world coordinates */
 	Math::Vector3d getSwayDirection() const;
 
 	/** Access the float up / down current Z offset for the actors */

--- a/engines/sword1/router.cpp
+++ b/engines/sword1/router.cpp
@@ -290,7 +290,7 @@ int32 Router::getRoute() {
 // THE SLIDY PATH ROUTINES
 
 int32 Router::smoothestPath() {
-	// This is the second big part of the route finder and the the only
+	// This is the second big part of the route finder and the only
 	// bit that tries to be clever (the other bits are clever).
 	//
 	// This part of the autorouter creates a list of modules from a set of

--- a/engines/sword2/router.cpp
+++ b/engines/sword2/router.cpp
@@ -349,7 +349,7 @@ int32 Router::getRoute() {
 // THE SLIDY PATH ROUTINES
 
 int32 Router::smoothestPath() {
-	// This is the second big part of the route finder and the the only
+	// This is the second big part of the route finder and the only
 	// bit that tries to be clever (the other bits are clever).
 	//
 	// This part of the autorouter creates a list of modules from a set of

--- a/engines/sword25/gfx/graphicengine.h
+++ b/engines/sword25/gfx/graphicengine.h
@@ -121,7 +121,7 @@ public:
 
 	/**
 	 * Creates a thumbnail with the dimensions of 200x125. This will not include the top and bottom of the screen..
-	 * the interface boards the the image as a 16th of it's original size.
+	 * the interface boards the image as a 16th of it's original size.
 	 * Notes: This method should only be called after a call to EndFrame(), and before the next call to StartFrame().
 	 * The frame buffer must have a resolution of 800x600.
 	 * @param Filename  The filename for the screenshot

--- a/engines/sword25/gfx/image/image.h
+++ b/engines/sword25/gfx/image/image.h
@@ -77,7 +77,7 @@ public:
 	                The default value is 0.
 	    @param PosY the position on the Y-axis in the target image in pixels where the image is supposed to be rendered.<br>
 	                The default value is 0.
-	    @param Flipping how the the image should be flipped.<br>
+	    @param Flipping how the image should be flipped.<br>
 	                    The default value is Graphics::FLIP_NONE (no flipping)
 	    @param pSrcPartRect Pointer on Common::Rect which specifies the section to be rendered. If the whole image has to be rendered the Pointer is NULL.<br>
 	                        This referes to the unflipped and unscaled image.<br>

--- a/engines/titanic/true_talk/tt_parser.cpp
+++ b/engines/titanic/true_talk/tt_parser.cpp
@@ -378,7 +378,7 @@ int TTparser::searchAndReplace(TTstring &line, int startIndex, const StringArray
 		const CString &replacementStr = strings[idx + 1];
 
 		if (!strncmp(line.c_str() + startIndex, origStr.c_str(), strings[idx].size())) {
-			// Ensure that that a space follows the match, or the end of string,
+			// Ensure that a space follows the match, or the end of string,
 			// so the end of the string doesn't match on parts of larger words
 			char c = line[startIndex + strings[idx].size()];
 			if (c == ' ' || c == '\0') {

--- a/engines/tsage/graphics.cpp
+++ b/engines/tsage/graphics.cpp
@@ -1475,7 +1475,7 @@ void GfxFont::writeString(const char *s, int numChars) {
 }
 
 /**
- * Writes the the specified string at the current text position
+ * Writes the specified string at the current text position
  *
  * @s String to display
  */

--- a/engines/ultima/nuvie/screen/scale.inl
+++ b/engines/ultima/nuvie/screen/scale.inl
@@ -983,7 +983,7 @@ static void Scale_Scale2x
 typedef unsigned int COMPONENT;
 
 
-// fill `row' with the the disassembled color components from the original
+// fill `row' with the disassembled color components from the original
 // pixel values in `from'; if we run out of source pixels, just keep copying
 // the last one we got
 static inline void fill_rgb_row

--- a/engines/ultima/nuvie/script/script.cpp
+++ b/engines/ultima/nuvie/script/script.cpp
@@ -2587,7 +2587,7 @@ static int nscript_player_set_karma(lua_State *L) {
 /***
 Decrement the player's alcohol counter (U6)
 
-If value is greater than the counter the the counter is left at zero.
+If value is greater than the counter the counter is left at zero.
 @function player_dec_alcohol
 @param value number to decrement counter by
 @within player

--- a/engines/ultima/ultima4/game/game.cpp
+++ b/engines/ultima/ultima4/game/game.cpp
@@ -492,7 +492,7 @@ Std::vector<Coords> gameGetDirectionalActionPath(int dirmask, int validDirection
 
 	/*
 	 * try every tile in the given direction, up to the given range.
-	 * Stop when the the range is exceeded, or the action is blocked.
+	 * Stop when the range is exceeded, or the action is blocked.
 	 */
 
 	MapCoords t_c(origin);

--- a/engines/ultima/ultima4/map/dungeon.h
+++ b/engines/ultima/ultima4/map/dungeon.h
@@ -86,7 +86,7 @@ struct DngRoom {
 	 * tile when entering the dungeon room.
 	 *
 	 * Also, one dungeon room is apparently supposed to be connected
-	 * to another, although the the connection does not exist in the
+	 * to another, although the connection does not exist in the
 	 * DOS U4 dungeon data file.  This was fixed by removing a few
 	 * wall tiles, and relocating a chest and the few monsters around
 	 * it to the center of the room.

--- a/engines/ultima/ultima8/world/world.h
+++ b/engines/ultima/ultima8/world/world.h
@@ -108,7 +108,7 @@ public:
 		_ethereal.push_front(objid);
 	}
 
-	//! check if the the ethereal void is empty
+	//! check if the ethereal void is empty
 	bool etherealEmpty() const {
 		return _ethereal.empty();
 	}

--- a/engines/xeen/patcher.cpp
+++ b/engines/xeen/patcher.cpp
@@ -57,7 +57,7 @@ static const ScriptEntry SCRIPT_PATCHES[] = {
 	{ GType_DarkSide, 62, DS_MAP62_PIT2 }	// Fix fall position for pit
 };
 
-// List of objects that that need to be removed. Most of these are for copies of objects that appear in
+// List of objects that need to be removed. Most of these are for copies of objects that appear in
 // the distance on the edge of other maps, so they don't simply pop into existance when the map changes.
 // When the main object is removed, the original didn't properly also removie the object copies
 #define REMOVE_OBJECTS_COUNT 6

--- a/engines/xeen/worldofxeen/clouds_cutscenes.h
+++ b/engines/xeen/worldofxeen/clouds_cutscenes.h
@@ -50,7 +50,7 @@ private:
 	bool showCloudsTitle();
 
 	/**
-	 * Inner implementation of the the Clouds of Xeen intro sequence
+	 * Inner implementation of the Clouds of Xeen intro sequence
 	 */
 	bool showCloudsIntroInner();
 

--- a/graphics/VectorRendererSpec.cpp
+++ b/graphics/VectorRendererSpec.cpp
@@ -43,7 +43,7 @@ inline frac_t fp_sqroot(uint32 x) {
 	return doubleToFrac(sqrt((double)x));
 #else
 	// The code below wants to use a lot of registers, which is not good on
-	// x86 processors. By taking advantage of the fact the the input value is
+	// x86 processors. By taking advantage of the fact the input value is
 	// an integer, it might be possible to improve this. Furthermore, we could
 	// take advantage of the fact that we call this function several times on
 	// decreasing values. By feeding it the sqrt of the previous old x, as well

--- a/graphics/transparent_surface.h
+++ b/graphics/transparent_surface.h
@@ -97,7 +97,7 @@ struct TransparentSurface : public Graphics::Surface {
 	 The default value is 0.
 	 @param posY the position on the Y-axis in the target image in pixels where the image is supposed to be rendered.<br>
 	 The default value is 0.
-	 @param flipping how the the image should be flipped.<br>
+	 @param flipping how the image should be flipped.<br>
 	 The default value is Graphics::FLIP_NONE (no flipping)
 	 @param pPartRect Pointer on Common::Rect which specifies the section to be rendered. If the whole image has to be rendered the Pointer is NULL.<br>
 	 This referes to the unflipped and unscaled image.<br>

--- a/graphics/yuv_to_rgb.cpp
+++ b/graphics/yuv_to_rgb.cpp
@@ -409,7 +409,7 @@ void convertYUV410ToRGB(byte *dstPtr, int dstPitch, const YUVToRGBLookup *lookup
 
 	for (int y = 0; y < yHeight; y++) {
 		for (int x = 0; x < quarterWidth; x++) {
-			// Perform bilinear interpolation on the the chroma values
+			// Perform bilinear interpolation on the chroma values
 			// Based on the algorithm found here: http://tech-algorithm.com/articles/bilinear-image-scaling/
 			// Feel free to optimize further
 			int targetY = y >> 2;

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -648,7 +648,7 @@ bool LauncherDialog::doGameDetection(const Common::String &path) {
 			selectTarget(editDialog.getDomain());
 			g_gui.scheduleTopDialogRedraw();
 		} else {
-			// User aborted, remove the the new domain again
+			// User aborted, remove the new domain again
 			ConfMan.removeGameDomain(domain);
 		}
 


### PR DESCRIPTION
This removes some cases of "the the", "an an" or "that that" in the comments (except when it looked correct in its context).

(Maybe there's some vendored code where changing this doesn't make any sense, though?)