### PR TITLE
SCUMM: Fix a continuity error with George Washington's teeth (DOTT)

### DIFF
--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -1815,7 +1815,16 @@ void ScummEngine_v6::o6_actorOps() {
 
 	switch (subOp) {
 	case 76:		// SO_COSTUME
-		a->setActorCostume(pop());
+		i = pop();
+		// WORKAROUND: There's a small continuity error in DOTT; the fire that
+		// makes Washington leave the room can only exist if he's wearing the
+		// chattering teeth, but yet when he comes back he's not wearing them
+		// during this cutscene.
+		if (_game.id == GID_TENTACLE && _currentRoom == 13 && vm.slot[_currentScript].number == 211 &&
+			a->_number == 8 && i == 53 && _enableEnhancements) {
+			i = 69;
+		}
+		a->setActorCostume(i);
 		break;
 	case 77:		// SO_STEP_DIST
 		j = pop();


### PR DESCRIPTION
In DOTT, you can't make George Washington leave the main hall without starting a fire, but this fire can't be started if George Washington is not wearing the chattering teeth.

So, when he comes back to that room, he should be wearing them, but this is not the case during the associated cutscene (he does wear them if you talk to him outside, or come back to this room again after this cutscene). The 2016 remaster didn't fix this either.

So this PR forces costume 69 (= chattering teeth) instead of costume 53 (= no chattering teeth) for George Washington in this script.

## How to test

1. Start the DOS/English CD release with the [following savegame](https://github.com/scummvm/scummvm/files/9226959/tentacle.s08.zip). Boot param `101` is also very close to this, if you know this part.
2. Pick up the gold-plated quill pen on the table, and exit the room by the left. A cutscene with George Washington will play: his teeth should move a lot (as already happens if you go seeing him outside without picking up the quill, or if come back to this room just after this cutscene).