### PR TITLE
CLOUD: Fix #11244 crash; do minor changes to GUI

### DIFF
--- a/backends/cloud/cloudmanager.cpp
+++ b/backends/cloud/cloudmanager.cpp
@@ -421,18 +421,10 @@ double CloudManager::getSyncDownloadingProgress() const {
 	return 1;
 }
 
-uint64 CloudManager::getSyncDownloadBytesNumber() const {
+void CloudManager::getSyncDownloadingInfo(Storage::SyncDownloadingInfo &info) const {
 	Storage *storage = getCurrentStorage();
 	if (storage)
-		return storage->getSyncDownloadBytesNumber();
-	return 0;
-}
-
-uint64 CloudManager::getSyncDownloadTotalBytesNumber() const {
-	Storage *storage = getCurrentStorage();
-	if (storage)
-		return storage->getSyncDownloadTotalBytesNumber();
-	return 0;
+		storage->getSyncDownloadingInfo(info);
 }
 
 double CloudManager::getSyncProgress() const {

--- a/backends/cloud/cloudmanager.cpp
+++ b/backends/cloud/cloudmanager.cpp
@@ -421,6 +421,20 @@ double CloudManager::getSyncDownloadingProgress() const {
 	return 1;
 }
 
+uint64 CloudManager::getSyncDownloadBytesNumber() const {
+	Storage *storage = getCurrentStorage();
+	if (storage)
+		return storage->getSyncDownloadBytesNumber();
+	return 0;
+}
+
+uint64 CloudManager::getSyncDownloadTotalBytesNumber() const {
+	Storage *storage = getCurrentStorage();
+	if (storage)
+		return storage->getSyncDownloadTotalBytesNumber();
+	return 0;
+}
+
 double CloudManager::getSyncProgress() const {
 	Storage *storage = getCurrentStorage();
 	if (storage)

--- a/backends/cloud/cloudmanager.cpp
+++ b/backends/cloud/cloudmanager.cpp
@@ -441,12 +441,6 @@ void CloudManager::cancelSync() const {
 		storage->cancelSync();
 }
 
-void CloudManager::setSyncTarget(GUI::CommandReceiver *target) const {
-	Storage *storage = getCurrentStorage();
-	if (storage)
-		storage->setSyncTarget(target);
-}
-
 void CloudManager::showCloudDisabledIcon() {
 	_icon.show(CloudIcon::kDisabled, 3000);
 }

--- a/backends/cloud/cloudmanager.h
+++ b/backends/cloud/cloudmanager.h
@@ -251,6 +251,12 @@ public:
 	/** Returns a number in [0, 1] range which represents current sync downloading progress (1 = complete). */
 	double getSyncDownloadingProgress() const;
 
+	/** Returns a number of bytes that is downloaded in current sync downloading progress. */
+	uint64 getSyncDownloadBytesNumber() const;
+
+	/** Returns a total number of bytes to be downloaded in current sync downloading progress. */
+	uint64 getSyncDownloadTotalBytesNumber() const;
+
 	/** Returns a number in [0, 1] range which represents current sync progress (1 = complete). */
 	double getSyncProgress() const;
 

--- a/backends/cloud/cloudmanager.h
+++ b/backends/cloud/cloudmanager.h
@@ -251,11 +251,8 @@ public:
 	/** Returns a number in [0, 1] range which represents current sync downloading progress (1 = complete). */
 	double getSyncDownloadingProgress() const;
 
-	/** Returns a number of bytes that is downloaded in current sync downloading progress. */
-	uint64 getSyncDownloadBytesNumber() const;
-
-	/** Returns a total number of bytes to be downloaded in current sync downloading progress. */
-	uint64 getSyncDownloadTotalBytesNumber() const;
+	/** Fills a struct with numbers about current sync downloading progress. */
+	void getSyncDownloadingInfo(Storage::SyncDownloadingInfo &info) const;
 
 	/** Returns a number in [0, 1] range which represents current sync progress (1 = complete). */
 	double getSyncProgress() const;

--- a/backends/cloud/cloudmanager.h
+++ b/backends/cloud/cloudmanager.h
@@ -260,9 +260,6 @@ public:
 	/** Cancels running sync. */
 	void cancelSync() const;
 
-	/** Sets SavesSyncRequest's target to given CommandReceiver. */
-	void setSyncTarget(GUI::CommandReceiver *target) const;
-
 	/** Shows a "cloud disabled" icon for three seconds. */
 	void showCloudDisabledIcon();
 

--- a/backends/cloud/savessyncrequest.cpp
+++ b/backends/cloud/savessyncrequest.cpp
@@ -34,7 +34,7 @@
 namespace Cloud {
 
 SavesSyncRequest::SavesSyncRequest(Storage *storage, Storage::BoolCallback callback, Networking::ErrorCallback ecb):
-	Request(nullptr, ecb), CommandSender(nullptr), _storage(storage), _boolCallback(callback),
+	Request(nullptr, ecb), _storage(storage), _boolCallback(callback),
 	_workingRequest(nullptr), _ignoreCallback(false) {
 	start();
 }
@@ -269,15 +269,12 @@ void SavesSyncRequest::directoryCreatedErrorCallback(Networking::ErrorResponse e
 void SavesSyncRequest::downloadNextFile() {
 	if (_filesToDownload.empty()) {
 		_currentDownloadingFile = StorageFile("", 0, 0, false); //so getFilesToDownload() would return an empty array
-		sendCommand(GUI::kSavesSyncEndedCmd, 0);
 		uploadNextFile();
 		return;
 	}
 
 	_currentDownloadingFile = _filesToDownload.back();
 	_filesToDownload.pop_back();
-
-	sendCommand(GUI::kSavesSyncProgressCmd, (int)(getDownloadingProgress() * 100));
 
 	debug(9, "\nSavesSyncRequest: downloading %s (%d %%)", _currentDownloadingFile.name().c_str(), (int)(getProgress() * 100));
 	_workingRequest = _storage->downloadById(

--- a/backends/cloud/savessyncrequest.cpp
+++ b/backends/cloud/savessyncrequest.cpp
@@ -301,7 +301,6 @@ void SavesSyncRequest::fileDownloadedCallback(Storage::BoolResponse response) {
 	}
 
 	//update local timestamp for downloaded file
-	_localFilesTimestamps = DefaultSaveFileManager::loadTimestamps();
 	_localFilesTimestamps[_currentDownloadingFile.name()] = _currentDownloadingFile.timestamp();
 	DefaultSaveFileManager::saveTimestamps(_localFilesTimestamps);
 
@@ -352,7 +351,6 @@ void SavesSyncRequest::fileUploadedCallback(Storage::UploadResponse response) {
 		return;
 
 	//update local timestamp for the uploaded file
-	_localFilesTimestamps = DefaultSaveFileManager::loadTimestamps();
 	_localFilesTimestamps[_currentUploadingFile] = response.value.timestamp();
 	DefaultSaveFileManager::saveTimestamps(_localFilesTimestamps);
 

--- a/backends/cloud/savessyncrequest.cpp
+++ b/backends/cloud/savessyncrequest.cpp
@@ -394,7 +394,23 @@ double SavesSyncRequest::getDownloadingProgress() const {
 
 	uint32 totalFilesToDownload = _totalFilesToHandle - _filesToUpload.size();
 	uint32 filesLeftToDownload = _filesToDownload.size() + (_currentDownloadingFile.name() != "" ? 1 : 0);
+	if (filesLeftToDownload > totalFilesToDownload)
+		filesLeftToDownload = totalFilesToDownload;
 	return (double)(totalFilesToDownload - filesLeftToDownload) / (double)(totalFilesToDownload);
+}
+
+void SavesSyncRequest::getDownloadingInfo(Storage::SyncDownloadingInfo &info) const {
+	info.bytesDownloaded = getDownloadedBytes();
+	info.bytesToDownload = getBytesToDownload();
+
+	uint32 totalFilesToDownload = _totalFilesToHandle - _filesToUpload.size();
+	uint32 filesLeftToDownload = _filesToDownload.size() + (_currentDownloadingFile.name() != "" ? 1 : 0);
+	if (filesLeftToDownload > totalFilesToDownload)
+		filesLeftToDownload = totalFilesToDownload;
+	info.filesDownloaded = totalFilesToDownload - filesLeftToDownload;
+	info.filesToDownload = totalFilesToDownload;
+
+	info.inProgress = (totalFilesToDownload > 0 && filesLeftToDownload > 0);
 }
 
 double SavesSyncRequest::getProgress() const {

--- a/backends/cloud/savessyncrequest.h
+++ b/backends/cloud/savessyncrequest.h
@@ -26,11 +26,10 @@
 #include "backends/cloud/storage.h"
 #include "common/hashmap.h"
 #include "common/hash-str.h"
-#include "gui/object.h"
 
 namespace Cloud {
 
-class SavesSyncRequest: public Networking::Request, public GUI::CommandSender {
+class SavesSyncRequest: public Networking::Request {
 	Storage *_storage;
 	Storage::BoolCallback _boolCallback;
 	Common::HashMap<Common::String, uint32> _localFilesTimestamps;

--- a/backends/cloud/savessyncrequest.h
+++ b/backends/cloud/savessyncrequest.h
@@ -41,6 +41,7 @@ class SavesSyncRequest: public Networking::Request {
 	bool _ignoreCallback;
 	uint32 _totalFilesToHandle;
 	Common::String _date;
+	uint32 _bytesToDownload, _bytesDownloaded;
 
 	void start();
 	void directoryListedCallback(Storage::ListDirectoryResponse response);
@@ -71,6 +72,9 @@ public:
 
 	/** Returns an array of saves names which are not downloaded yet. */
 	Common::Array<Common::String> getFilesToDownload();
+
+	uint32 getDownloadedBytes() const;
+	uint32 getBytesToDownload() const;
 };
 
 } // End of namespace Cloud

--- a/backends/cloud/savessyncrequest.h
+++ b/backends/cloud/savessyncrequest.h
@@ -57,6 +57,9 @@ class SavesSyncRequest: public Networking::Request {
 	virtual void finishError(Networking::ErrorResponse error, Networking::RequestState state = Networking::FINISHED);
 	void finishSync(bool success);
 
+	uint32 getDownloadedBytes() const;
+	uint32 getBytesToDownload() const;
+
 public:
 	SavesSyncRequest(Storage *storage, Storage::BoolCallback callback, Networking::ErrorCallback ecb);
 	virtual ~SavesSyncRequest();
@@ -67,14 +70,14 @@ public:
 	/** Returns a number in range [0, 1], where 1 is "complete". */
 	double getDownloadingProgress() const;
 
+	/** Fills a struct with numbers about current sync downloading progress. */
+	void getDownloadingInfo(Storage::SyncDownloadingInfo &info) const;
+
 	/** Returns a number in range [0, 1], where 1 is "complete". */
 	double getProgress() const;
 
 	/** Returns an array of saves names which are not downloaded yet. */
 	Common::Array<Common::String> getFilesToDownload();
-
-	uint32 getDownloadedBytes() const;
-	uint32 getBytesToDownload() const;
 };
 
 } // End of namespace Cloud

--- a/backends/cloud/storage.cpp
+++ b/backends/cloud/storage.cpp
@@ -189,22 +189,12 @@ double Storage::getSyncDownloadingProgress() {
 	return result;
 }
 
-uint64 Storage::getSyncDownloadBytesNumber() {
-	uint64 result = 0;
+void Storage::getSyncDownloadingInfo(SyncDownloadingInfo& info) {
 	_runningRequestsMutex.lock();
-	if (_savesSyncRequest)
-		result = _savesSyncRequest->getDownloadedBytes();
+	if (_savesSyncRequest) {
+		_savesSyncRequest->getDownloadingInfo(info);
+	}
 	_runningRequestsMutex.unlock();
-	return result;
-}
-
-uint64 Storage::getSyncDownloadTotalBytesNumber() {
-	uint64 result = 0;
-	_runningRequestsMutex.lock();
-	if (_savesSyncRequest)
-		result = _savesSyncRequest->getBytesToDownload();
-	_runningRequestsMutex.unlock();
-	return result;
 }
 
 double Storage::getSyncProgress() {

--- a/backends/cloud/storage.cpp
+++ b/backends/cloud/storage.cpp
@@ -189,6 +189,24 @@ double Storage::getSyncDownloadingProgress() {
 	return result;
 }
 
+uint64 Storage::getSyncDownloadBytesNumber() {
+	uint64 result = 0;
+	_runningRequestsMutex.lock();
+	if (_savesSyncRequest)
+		result = _savesSyncRequest->getDownloadedBytes();
+	_runningRequestsMutex.unlock();
+	return result;
+}
+
+uint64 Storage::getSyncDownloadTotalBytesNumber() {
+	uint64 result = 0;
+	_runningRequestsMutex.lock();
+	if (_savesSyncRequest)
+		result = _savesSyncRequest->getBytesToDownload();
+	_runningRequestsMutex.unlock();
+	return result;
+}
+
 double Storage::getSyncProgress() {
 	double result = 1;
 	_runningRequestsMutex.lock();

--- a/backends/cloud/storage.cpp
+++ b/backends/cloud/storage.cpp
@@ -214,13 +214,6 @@ void Storage::cancelSync() {
 	_runningRequestsMutex.unlock();
 }
 
-void Storage::setSyncTarget(GUI::CommandReceiver *target) {
-	_runningRequestsMutex.lock();
-	if (_savesSyncRequest)
-		_savesSyncRequest->setTarget(target);
-	_runningRequestsMutex.unlock();
-}
-
 void Storage::savesSyncDefaultCallback(BoolResponse response) {
 	_runningRequestsMutex.lock();
 	_savesSyncRequest = nullptr;

--- a/backends/cloud/storage.h
+++ b/backends/cloud/storage.h
@@ -194,9 +194,6 @@ public:
 	/** Cancels running sync. */
 	virtual void cancelSync();
 
-	/** Sets SavesSyncRequest's target to given CommandReceiver. */
-	virtual void setSyncTarget(GUI::CommandReceiver *target);
-
 protected:
 	/** Finishes the sync. Shows an OSD message. */
 	virtual void savesSyncDefaultCallback(BoolResponse response);

--- a/backends/cloud/storage.h
+++ b/backends/cloud/storage.h
@@ -182,8 +182,14 @@ public:
 	/** Returns whether there is a SavesSyncRequest running. */
 	virtual bool isSyncing();
 
-	/** Returns a number in [0, 1] range which represents current sync progress (1 = complete). */
+	/** Returns a number in [0, 1] range which represents current sync downloading progress (1 = complete). */
 	virtual double getSyncDownloadingProgress();
+
+	/** Returns a number of bytes that is downloaded in current sync downloading progress. */
+	virtual uint64 getSyncDownloadBytesNumber();
+
+	/** Returns a total number of bytes to be downloaded in current sync download progress. */
+	virtual uint64 getSyncDownloadTotalBytesNumber();
 
 	/** Returns a number in [0, 1] range which represents current sync progress (1 = complete). */
 	virtual double getSyncProgress();

--- a/backends/cloud/storage.h
+++ b/backends/cloud/storage.h
@@ -185,11 +185,14 @@ public:
 	/** Returns a number in [0, 1] range which represents current sync downloading progress (1 = complete). */
 	virtual double getSyncDownloadingProgress();
 
-	/** Returns a number of bytes that is downloaded in current sync downloading progress. */
-	virtual uint64 getSyncDownloadBytesNumber();
+	struct SyncDownloadingInfo {
+		uint64 bytesDownloaded = 0, bytesToDownload = 0;
+		uint64 filesDownloaded = 0, filesToDownload = 0;
+		bool inProgress = false;
+	};
 
-	/** Returns a total number of bytes to be downloaded in current sync download progress. */
-	virtual uint64 getSyncDownloadTotalBytesNumber();
+	/** Fills a struct with numbers about current sync downloading progress. */
+	virtual void getSyncDownloadingInfo(SyncDownloadingInfo &info);
 
 	/** Returns a number in [0, 1] range which represents current sync progress (1 = complete). */
 	virtual double getSyncProgress();

--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -100,7 +100,8 @@ void SaveLoadCloudSyncProgressDialog::handleTickle() {
 
 void SaveLoadCloudSyncProgressDialog::pollCloudMan() {
 	_pollFrame = (_pollFrame + 1) % 60;
-	if (_pollFrame != 1) return;
+	if (_pollFrame != 1)
+		return;
 
 	const bool syncing = CloudMan.isSyncing();
 	const uint32 progress = (uint32)(100 * CloudMan.getSyncDownloadingProgress());
@@ -109,11 +110,26 @@ void SaveLoadCloudSyncProgressDialog::pollCloudMan() {
 		_close = true;
 	}
 
-	Common::String downloaded, downloadedUnits, total, totalUnits;
-	downloaded = getHumanReadableBytes(CloudMan.getSyncDownloadBytesNumber(), downloadedUnits);
-	total = getHumanReadableBytes(CloudMan.getSyncDownloadTotalBytesNumber(), totalUnits);
+	Cloud::Storage::SyncDownloadingInfo info;
+	CloudMan.getSyncDownloadingInfo(info);
 
-	_percentLabel->setLabel(Common::String::format("%u %% (%s %S / %s %S)", progress, downloaded.c_str(), _(downloadedUnits).c_str(), total.c_str(), _(totalUnits).c_str()));
+	Common::String downloaded, downloadedUnits, total, totalUnits;
+	downloaded = getHumanReadableBytes(info.bytesDownloaded, downloadedUnits);
+	total = getHumanReadableBytes(info.bytesToDownload, totalUnits);
+
+	Common::String progressPercent = Common::String::format("%u %%", progress);
+	Common::String filesDownloaded = Common::String::format("%llu", info.filesDownloaded);
+	Common::String filesToDownload = Common::String::format("%llu", info.filesToDownload);
+
+	_percentLabel->setLabel(
+		Common::U32String::format(
+			_("%s (%s %S / %s %S, %s / %s files)"),
+			progressPercent.c_str(),
+			downloaded.c_str(), _(downloadedUnits).c_str(),
+			total.c_str(), _(totalUnits).c_str(),
+			filesDownloaded.c_str(), filesToDownload.c_str()
+		)
+	);
 	_progressBar->setValue(progress);
 	_progressBar->markAsDirty();
 
@@ -389,7 +405,8 @@ ButtonWidget *SaveLoadChooserDialog::createSwitchButton(const Common::String &na
 #if defined(USE_CLOUD) && defined(USE_LIBCURL)
 void SaveLoadChooserDialog::pollCloudMan() {
 	_pollFrame = (_pollFrame + 1) % 60;
-	if (_pollFrame != 1) return;
+	if (_pollFrame != 1)
+		return;
 
 	const bool syncing = CloudMan.isSyncing();
 	const uint32 progress = (uint32)(100 * CloudMan.getSyncDownloadingProgress());
@@ -405,7 +422,8 @@ void SaveLoadChooserDialog::pollCloudMan() {
 		}
 	}
 
-	if (update) updateSaveList();
+	if (update)
+		updateSaveList();
 }
 #endif
 

--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -109,7 +109,11 @@ void SaveLoadCloudSyncProgressDialog::pollCloudMan() {
 		_close = true;
 	}
 
-	_percentLabel->setLabel(Common::String::format("%u %%", progress));
+	Common::String downloaded, downloadedUnits, total, totalUnits;
+	downloaded = getHumanReadableBytes(CloudMan.getSyncDownloadBytesNumber(), downloadedUnits);
+	total = getHumanReadableBytes(CloudMan.getSyncDownloadTotalBytesNumber(), totalUnits);
+
+	_percentLabel->setLabel(Common::String::format("%u %% (%s %S / %s %S)", progress, downloaded.c_str(), _(downloadedUnits).c_str(), total.c_str(), _(totalUnits).c_str()));
 	_progressBar->setValue(progress);
 	_progressBar->markAsDirty();
 

--- a/gui/saveload-dialog.h
+++ b/gui/saveload-dialog.h
@@ -30,21 +30,21 @@
 namespace GUI {
 
 #if defined(USE_CLOUD) && defined(USE_LIBCURL)
-enum SaveLoadCloudSyncProgress {
-	kSavesSyncProgressCmd = 'SSPR',
-	kSavesSyncEndedCmd = 'SSEN'
-};
-
 class SaveLoadCloudSyncProgressDialog : public Dialog { //protected?
 	StaticTextWidget *_label, *_percentLabel;
 	SliderWidget *_progressBar;
 	bool _close;
+	int _pollFrame;
+
 public:
 	SaveLoadCloudSyncProgressDialog(bool canRunInBackground);
 	~SaveLoadCloudSyncProgressDialog() override;
 
 	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data) override;
 	void handleTickle() override;
+
+private:
+	void pollCloudMan();
 };
 #endif
 
@@ -130,6 +130,14 @@ protected:
 	void addChooserButtons();
 	ButtonWidget *createSwitchButton(const Common::String &name, const Common::U32String &desc, const Common::U32String &tooltip, const char *image, uint32 cmd = 0);
 #endif // !DISABLE_SAVELOADCHOOSER_GRID
+
+#if defined(USE_CLOUD) && defined(USE_LIBCURL)
+	int _pollFrame;
+	bool _didUpdateAfterSync;
+
+	/** If CloudMan is syncing, this will refresh the list of saves. */
+	void pollCloudMan();
+#endif
 };
 
 class SaveLoadChooserSimple : public SaveLoadChooserDialog {

--- a/gui/saveload-dialog.h
+++ b/gui/saveload-dialog.h
@@ -30,14 +30,17 @@
 namespace GUI {
 
 #if defined(USE_CLOUD) && defined(USE_LIBCURL)
+class SaveLoadChooserDialog;
+
 class SaveLoadCloudSyncProgressDialog : public Dialog { //protected?
 	StaticTextWidget *_label, *_percentLabel;
 	SliderWidget *_progressBar;
+	SaveLoadChooserDialog *_parent;
 	bool _close;
 	int _pollFrame;
 
 public:
-	SaveLoadCloudSyncProgressDialog(bool canRunInBackground);
+	SaveLoadCloudSyncProgressDialog(bool canRunInBackground, SaveLoadChooserDialog *parent);
 	~SaveLoadCloudSyncProgressDialog() override;
 
 	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data) override;
@@ -137,6 +140,8 @@ protected:
 
 	/** If CloudMan is syncing, this will refresh the list of saves. */
 	void pollCloudMan();
+
+	friend class SaveLoadCloudSyncProgressDialog;
 #endif
 };
 


### PR DESCRIPTION
Changed SaveLoadCloudSyncProgressDialog and SaveLoadChooserDialog to poll CloudMan instead of being updated from another thread -- in order to fix [#11244](https://bugs.scummvm.org/ticket/11244).

Additionally, some minor GUI changes so SaveLoadChooserDialog is redrawn while SaveLoadCloudSyncProgressDialog is modal, and progress is displayed in bytes (more precise than files count).

![changed progress](https://user-images.githubusercontent.com/1948111/182033654-aee51c29-995c-4552-89bf-48f75f34f47c.png)

Also, removed `loadTimestamps()` in sync request, because it was not only re-reading the file (which seems excessful), but also invalidating save file manager's cache. I've encountered a segfault or a freeze a few times in `MemoryPool::freeUnusedPages()` while testing the other changes, which seems to happen when `DefaultSaveFileManager::assureCached()` clears a hashmap, so this was an attempt to make it much less frequent.