### PR TITLE
AMIGAOS: Fix target installation

### DIFF
--- a/backends/platform/sdl/amigaos/amigaos.mk
+++ b/backends/platform/sdl/amigaos/amigaos.mk
@@ -13,16 +13,16 @@ amigaosdist: $(EXECUTABLE) $(PLUGINS)
 	# Releases should always be completely fresh installs.
 	rm -rf $(AMIGAOSPATH)
 	makedir all $(AMIGAOSPATH)
-	cp ${srcdir}/dists/amigaos/scummvm_drawer.info $(patsubst %/,%,$(AMIGAOSPATH)).info
-	cp ${srcdir}/dists/amigaos/scummvm.info $(AMIGAOSPATH)/$(EXECUTABLE).info
+	$(CP) ${srcdir}/dists/amigaos/scummvm_drawer.info $(patsubst %/,%,$(AMIGAOSPATH)).info
+	$(CP) ${srcdir}/dists/amigaos/scummvm.info $(AMIGAOSPATH)/$(EXECUTABLE).info
 ifdef DIST_FILES_DOCS
 	makedir all $(AMIGAOSPATH)/doc
-	cp $(DIST_FILES_DOCS) $(AMIGAOSPATH)/doc
-	$(foreach lang, $(DIST_FILES_DOCS_languages), makedir all $(AMIGAOSPATH)/doc/$(lang); cp $(DIST_FILES_DOCS_$(lang)) $(AMIGAOSPATH)/doc/$(lang);)
+	$(CP) $(DIST_FILES_DOCS) $(AMIGAOSPATH)/doc
+	$(foreach lang, $(DIST_FILES_DOCS_languages), makedir all $(AMIGAOSPATH)/doc/$(lang); $(CP) $(DIST_FILES_DOCS_$(lang)) $(AMIGAOSPATH)/doc/$(lang);)
 	# README.md and corresponding scripts must be in cwd
 	# when building out of tree.
-	cp ${srcdir}/README.md README.tmp
-	cp ${srcdir}/dists/amigaos/md2ag.rexx .
+	$(CP) ${srcdir}/README.md README.tmp
+	$(CP) ${srcdir}/dists/amigaos/md2ag.rexx .
 	# (buildbot) LC_ALL is here to work around Debian bug #973647
 	LC_ALL=C rx md2ag.rexx README.tmp $(AMIGAOSPATH)/doc/
 	rm -f md2ag.rexx README.tmp
@@ -30,41 +30,45 @@ endif
 	# Copy mandatory installation files.
 	makedir all $(AMIGAOSPATH)/extras
 ifdef DIST_FILES_ENGINEDATA
-	cp $(DIST_FILES_ENGINEDATA) $(AMIGAOSPATH)/extras
+	$(CP) $(DIST_FILES_ENGINEDATA) $(AMIGAOSPATH)/extras
 endif
 ifdef DIST_FILES_NETWORKING
-	cp $(DIST_FILES_NETWORKING) $(AMIGAOSPATH)/extras
+	$(CP) $(DIST_FILES_NETWORKING) $(AMIGAOSPATH)/extras
 endif
 ifdef DIST_FILES_VKEYBD
-	cp $(DIST_FILES_VKEYBD) $(AMIGAOSPATH)/extras
+	$(CP) $(DIST_FILES_VKEYBD) $(AMIGAOSPATH)/extras
 endif
 ifdef DIST_FILES_THEMES
 	makedir all $(AMIGAOSPATH)/themes
-	cp $(DIST_FILES_THEMES) $(AMIGAOSPATH)/themes
+	$(CP) $(DIST_FILES_THEMES) $(AMIGAOSPATH)/themes
 endif
 ifneq ($(DIST_FILES_SHADERS),)
 	makedir all $(AMIGAOSPATH)/extras/shaders
-	cp $(DIST_FILES_SHADERS) $(AMIGAOSPATH)/extras/shaders
+	$(CP) $(DIST_FILES_SHADERS) $(AMIGAOSPATH)/extras/shaders
 endif
 ifdef DYNAMIC_MODULES
 	makedir all $(AMIGAOSPATH)/plugins
-	# Preserve all debug information on debug builds
+	# Catch edge-case when no engines/plugins are compiled
+	# otherwise cp/strip will error out due to missing source files.
+ifneq ($(PLUGINS),)
 ifdef DEBUG_BUILD
-		cp $(PLUGINS) $(AMIGAOSPATH)/plugins/$(plugin)
+		# Preserve all debug information on debug builds
+		$(CP) $(PLUGINS) $(AMIGAOSPATH)/plugins/$(plugin)
 else
 		$(foreach plugin, $(PLUGINS), $(STRIP) $(plugin) -o $(AMIGAOSPATH)/$(plugin);)
+endif
 endif
 	makedir all $(AMIGAOSPATH)/sobjs
 	# AmigaOS installations, especially vanilla ones, won't have every
 	# mandatory shared library in place, let alone the correct versions.
 	# Extract and install compiled-in shared libraries to their own subdir.
-	cp ${srcdir}/dists/amigaos/Ext_Inst_so.rexx .
+	$(CP) ${srcdir}/dists/amigaos/Ext_Inst_so.rexx .
 	rx Ext_Inst_so.rexx $(EXECUTABLE) $(AMIGAOSPATH)
 	rm -f Ext_Inst_so.rexx
 endif
-# Preserve all debug information on debug builds
 ifdef DEBUG_BUILD
-	cp $(EXECUTABLE) $(AMIGAOSPATH)/$(EXECUTABLE)
+	# Preserve all debug information on debug builds
+	$(CP) $(EXECUTABLE) $(AMIGAOSPATH)/$(EXECUTABLE)
 else
 	$(STRIP) $(EXECUTABLE) -o $(AMIGAOSPATH)/$(EXECUTABLE)
 endif


### PR DESCRIPTION
- Fix an edge-case error during target installation
- Change hardcoded "cp" to it's envvar equivalent

Using
--disable-engine-all
together with plugins will lead to an empty plugins directory/list.
In turn, at least on my platform, both "cp" and "strip" will error out due to missing source files, breaking the rest of the installation.

This fix checks if there are plugins available before attempting to install them, otherwise plugins installation is simply skipped.

It works here locally with and without plugins compiled.

NB: A quick peek at the other targets show that
- opendingux and
- riscos
might be affected aswell?
But due to me knowing nothing about those platforms or how "cp" will react there on missing source files, I'll leave them be.
Also, this is such an edge-case it's probably not worth the hassle?

But maybe someone still wants to alert the porters?

If this is the wrong approach, please shout.

Thank you