### PR TITLE
PINK: Use the actual target when searching for saves

### DIFF
--- a/engines/pink/gui.cpp
+++ b/engines/pink/gui.cpp
@@ -146,9 +146,9 @@ struct SaveStateDescriptorTimeComparator {
 	}
 };
 
-static SaveStateList listSaves(bool isPeril) {
+SaveStateList PinkEngine::listSaves() const {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
-	Common::String pattern = isPeril ? "peril.s##" : "pokus.s##";
+	Common::String pattern = getMetaEngine()->getSavegameFile(kSavegameFilePattern, _targetName.c_str());
 	Common::StringArray filenames = saveFileMan->listSavefiles(pattern);
 
 	SaveStateList saveList;
@@ -179,7 +179,7 @@ void PinkEngine::initMenu() {
 
 	Graphics::MacMenuSubMenu *subMenu = _menu->getSubmenu(nullptr, 0);
 	if (subMenu) {
-		SaveStateList saves = listSaves(isPeril());
+		SaveStateList saves = listSaves();
 		if (!saves.empty()) {
 			_menu->removeMenuItem(subMenu, kRecentSaveId);
 			int maxSaves = saves.size() > kMaxSaves ? kMaxSaves : saves.size();

--- a/engines/pink/pink.h
+++ b/engines/pink/pink.h
@@ -105,6 +105,7 @@ public:
 	Common::String getSaveStateName(int slot) const override {
 		return Common::String::format("%s.s%02d", _targetName.c_str(), slot);
 	}
+	SaveStateList listSaves() const;
 
 	friend class Console;
 


### PR DESCRIPTION
This ensures consistent behavior between listing and loading of saves.

I was getting strange results with my localized version, seems like i have saves using both the `peril` and `peril-se` prefixes. With this change both listing and loading uses the new `peril-se` prefix.