### PR TITLE
IMAGE: Fix cinepak conversion to 8bpp for some Myst (1994) videos

### DIFF
--- a/image/codecs/cinepak.cpp
+++ b/image/codecs/cinepak.cpp
@@ -426,6 +426,11 @@ const Graphics::Surface *CinepakDecoder::decodeFrame(Common::SeekableReadStream 
 	if (!_curFrame.surface) {
 		_curFrame.surface = new Graphics::Surface();
 		_curFrame.surface->create(_curFrame.width, _curFrame.height, _pixelFormat);
+	} else if (_ditherPalette && _pixelFormat.bytesPerPixel != _curFrame.surface->format.bytesPerPixel) {
+		_curFrame.surface->free();
+		delete _curFrame.surface;
+		_curFrame.surface = new Graphics::Surface();
+		_curFrame.surface->create(_curFrame.width, _curFrame.height, _pixelFormat);
 	}
 
 	_y = 0;


### PR DESCRIPTION
This addresses bug ticket #13479

The fix should not have side-effects, but someone more familiar with the code for the cinepak decoder should review this.

I can see some black artifacts at the start of the videos so maybe something else is needed as well, or a different approach altogether. Relevant short discord discussion starts here: https://discord.com/channels/581224060529148060/581224061091446795/975812864721956924


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
