### PR TITLE
COMMON: Uninitialized field cleanup

### DIFF
--- a/common/quicktime.cpp
+++ b/common/quicktime.cpp
@@ -49,6 +49,7 @@ QuickTimeParser::QuickTimeParser() {
 	_scaleFactorY = 1;
 	_resFork = new MacResManager();
 	_disposeFileHandle = DisposeAfterUse::YES;
+	_timeScale = 1;
 
 	initParseTable();
 }

--- a/common/winexe.h
+++ b/common/winexe.h
@@ -66,7 +66,7 @@ enum WinResourceType {
 
 class WinResourceID {
 public:
-	WinResourceID() { _idType = kIDTypeNull; }
+	WinResourceID() { _idType = kIDTypeNull; _id = 0; }
 	WinResourceID(String x) { _idType = kIDTypeString; _name = x; }
 	WinResourceID(uint32 x) { _idType = kIDTypeNumerical; _id = x; }
 


### PR DESCRIPTION
Fixes Coverity defect 1490111 and some VS code analysis warnings.