### PR TITLE
Declare custom help support

### DIFF
--- a/engines/dialogs.cpp
+++ b/engines/dialogs.cpp
@@ -81,6 +81,8 @@ MainMenuDialog::MainMenuDialog(Engine *engine)
 	// To enable "Help", an engine needs to use a subclass of MainMenuDialog
 	// (at least for now, we might change how this works in the future).
 	_helpButton = new GUI::ButtonWidget(this, "GlobalMenu.Help", _("~H~elp"), Common::U32String(), kHelpCmd);
+	_helpButton->setVisible(_engine->hasFeature(Engine::kSupportsHelp));
+	_helpButton->setEnabled(_engine->hasFeature(Engine::kSupportsHelp));
 
 	new GUI::ButtonWidget(this, "GlobalMenu.About", _("~A~bout"), Common::U32String(), kAboutCmd);
 

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -286,7 +286,14 @@ public:
 		 * The engine will need to read the actual resolution used by the
 		 * backend using OSystem::getWidth and OSystem::getHeight.
 		 */
-		kSupportsArbitraryResolutions
+		kSupportsArbitraryResolutions,
+
+		/**
+		 * The game provides custom help.
+		 *
+		 * This enables the help button in the main menu.
+		 */
+		 kSupportsHelp
 	};
 
 

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -237,6 +237,7 @@ bool ScummEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsLoadingDuringRuntime) ||
 		(f == kSupportsSavingDuringRuntime) ||
 		(f == kSupportsSubtitleOptions) ||
+		(f == kSupportsHelp) ||
 		(
 			f == kSupportsChangingOptionsDuringRuntime &&
 			Common::String(_game.guioptions).contains(GUIO_AUDIO_OVERRIDE)


### PR DESCRIPTION
It's a distraction to have a button that doesn't do anything useful in all but one engine. So hide it when not supported.