### PR TITLE
SCUMM: Work around hard-to-read colors in MI1 VGA CD and Mac versions compared to the VGA floppy version

### DIFF
--- a/engines/scumm/gfx.cpp
+++ b/engines/scumm/gfx.cpp
@@ -2223,11 +2223,18 @@ bool Gdi::drawStrip(byte *dstPtr, VirtScreen *vs, int x, int y, const int width,
 	// makes the sign harder to read, so temporarily remap the color while
 	// drawing it. The text is also slightly different, but that is taken
 	// care of elsewhere.
+	//
+	// The SEGA CD version uses the old colors already, and the FM Towns
+	// version makes the text more readable by giving it a black outline.
 
-	else if (_vm->_game.id == GID_MONKEY && _vm->_currentRoom == 36
-			&& vs->number == kMainVirtScreen && y == 8 && x >= 7 && x <= 30
-			&& height == 88	&& strcmp(_vm->_game.variant, "SE Talkie") != 0
-			&& _vm->_enableEnhancements) {
+	else if (_vm->_game.id == GID_MONKEY &&
+			_vm->_game.platform != Common::kPlatformSegaCD &&
+			_vm->_game.platform != Common::kPlatformFMTowns &&
+			_vm->_currentRoom == 36 &&
+			vs->number == kMainVirtScreen &&
+			y == 8 && x >= 7 && x <= 30 && height == 88 &&
+			strcmp(_vm->_game.variant, "SE Talkie") != 0 &&
+			_vm->_enableEnhancements) {
 		_roomPalette[47] = 15;
 
 		byte result = decompressBitmap(dstPtr, vs->pitch, smap_ptr + offset, height);

--- a/engines/scumm/gfx.cpp
+++ b/engines/scumm/gfx.cpp
@@ -2218,6 +2218,21 @@ bool Gdi::drawStrip(byte *dstPtr, VirtScreen *vs, int x, int y, const int width,
 			_roomPalette[13] = 80;
 	}
 
+	// WORKAROUND: In the CD version of MI1, the sign about how the dogs
+	// are only sleeping has a dark blue background instead of white. This
+	// makes the sign harder to read, so temporarily remap the color while
+	// drawing it. The text is also slightly different, but that is taken
+	// care of elsewhere.
+
+	else if (_vm->_game.id == GID_MONKEY && _vm->_currentRoom == 36 && vs->number == kMainVirtScreen && y == 8 && x >= 7 && x <= 30 && height == 88 && _vm->_enableEnhancements) {
+		_roomPalette[47] = 15;
+
+		byte result = decompressBitmap(dstPtr, vs->pitch, smap_ptr + offset, height);
+
+		_roomPalette[47] = 47;
+		return result;
+	}
+
 	return decompressBitmap(dstPtr, vs->pitch, smap_ptr + offset, height);
 }
 

--- a/engines/scumm/gfx.cpp
+++ b/engines/scumm/gfx.cpp
@@ -2224,7 +2224,10 @@ bool Gdi::drawStrip(byte *dstPtr, VirtScreen *vs, int x, int y, const int width,
 	// drawing it. The text is also slightly different, but that is taken
 	// care of elsewhere.
 
-	else if (_vm->_game.id == GID_MONKEY && _vm->_currentRoom == 36 && vs->number == kMainVirtScreen && y == 8 && x >= 7 && x <= 30 && height == 88 && _vm->_enableEnhancements) {
+	else if (_vm->_game.id == GID_MONKEY && _vm->_currentRoom == 36
+			&& vs->number == kMainVirtScreen && y == 8 && x >= 7 && x <= 30
+			&& height == 88	&& strcmp(_vm->_game.variant, "SE Talkie") != 0
+			&& _vm->_enableEnhancements) {
 		_roomPalette[47] = 15;
 
 		byte result = decompressBitmap(dstPtr, vs->pitch, smap_ptr + offset, height);

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -3177,11 +3177,19 @@ void ScummEngine_v5::decodeParseString() {
 			// color. We can't find an exact match to what the
 			// floppy version used, but we pick on that's as close
 			// as we can get.
+			//
+			// The SEGA CD version uses the old colors already, and
+			// the FM Towns version makes the text more readable by
+			// giving it a black outline.
 
-			else if (_game.id == GID_MONKEY && _currentRoom == 36
-					&& vm.slot[_currentScript].number == 201 && color == 2
-					&& strcmp(_game.variant, "SE Talkie") != 0
-					&& _enableEnhancements) {
+			else if (_game.id == GID_MONKEY &&
+					_game.platform != Common::kPlatformSegaCD &&
+					_game.platform != Common::kPlatformFMTowns &&
+					_currentRoom == 36 &&
+					vm.slot[_currentScript].number == 201 &&
+					color == 2 &&
+					strcmp(_game.variant, "SE Talkie") != 0 &&
+					_enableEnhancements) {
 				color = findClosestPaletteColor(_currentPalette, 256, 0, 171, 0);
 			}
 

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -3178,7 +3178,10 @@ void ScummEngine_v5::decodeParseString() {
 			// floppy version used, but we pick on that's as close
 			// as we can get.
 
-			else if (_game.id == GID_MONKEY && _currentRoom == 36 && vm.slot[_currentScript].number == 201 && color == 2 && _enableEnhancements) {
+			else if (_game.id == GID_MONKEY && _currentRoom == 36
+					&& vm.slot[_currentScript].number == 201 && color == 2
+					&& strcmp(_game.variant, "SE Talkie") != 0
+					&& _enableEnhancements) {
 				color = findClosestPaletteColor(_currentPalette, 256, 0, 171, 0);
 			}
 

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -3172,6 +3172,16 @@ void ScummEngine_v5::decodeParseString() {
 			if (_game.id == GID_INDY3 && _game.platform == Common::kPlatformMacintosh && vm.slot[_currentScript].number == 134 && color == 0x8F)
 				color = 0x87;
 
+			// WORKAROUND: In the CD version of MI1, the text in
+			// the sign about the dogs only sleeping has the wrong
+			// color. We can't find an exact match to what the
+			// floppy version used, but we pick on that's as close
+			// as we can get.
+
+			else if (_game.id == GID_MONKEY && _currentRoom == 36 && vm.slot[_currentScript].number == 201 && color == 2 && _enableEnhancements) {
+				color = findClosestPaletteColor(_currentPalette, 256, 0, 171, 0);
+			}
+
 			_string[textSlot].color = color;
 			break;
 		case 2:		// SO_CLIPPED


### PR DESCRIPTION
This has been bugging me for years, but I'm a bit torn on whether or not ScummVM should work around it. When you drug the dogs in the VGA floppy version, the sign looks like this:

![scummvm-monkey-vga-00005](https://user-images.githubusercontent.com/601765/183303323-640ace80-ca6a-46cb-be11-42d3fc5c95bc.png)

Nice and easy to read. In the VGA CD version, it looks like this:

![scummvm-monkey-00004](https://user-images.githubusercontent.com/601765/183303341-f812030e-95ed-4089-a012-a0fdc2e6e9b5.png)

Which I personally find both ugly and hard to read. Maybe the people who made the Special Edition thought so too, because this is one case where the CD version's behavior wasn't carried over. (Image taken from YouTube playthrough.)

![mi1se-sign](https://user-images.githubusercontent.com/601765/183303455-21402543-0954-42a8-9d26-26588c97d94f.png)

In this pull request, I've tried my best at reproducing the floppy version's colors. The green text color isn't an exact match, but it's as close as I could get it.

![scummvm-monkey-00006](https://user-images.githubusercontent.com/601765/183303491-bb2ff137-41ed-4a18-8d6b-1086ea7ca2cb.png)

I hope the workaround is technically sound. I've tried it with the VGA CD version, and with my two Mac versions.

Come to think of it, I should probably make an exception for the Ultimate Talkie, because that has its own fix for it I believe? I'll look at that tomorrow.