### PR TITLE
SCUMM: Restrict the "I am Choas." Loom workaround to the English talkie

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -3254,7 +3254,9 @@ void ScummEngine_v5::decodeParseString() {
 		case 15:{	// SO_TEXTSTRING
 				const int len = resStrLen(_scriptPointer);
 
-				if (_game.id == GID_LOOM && vm.slot[_currentScript].number == 95 && _enableEnhancements && strcmp((const char *)_scriptPointer, "I am Choas.") == 0) {
+				if (_game.id == GID_LOOM && _game.version == 4 && _language == Common::EN_ANY &&
+						vm.slot[_currentScript].number == 95 && _enableEnhancements &&
+						strcmp((const char *)_scriptPointer, "I am Choas.") == 0) {
 					// WORKAROUND: This happens when Chaos introduces
 					// herself to bishop Mandible. Of all the places to put
 					// a typo...


### PR DESCRIPTION
As far as I know, the "I am Choas." typo in Loom was only part of the VGA talkie release (and even Brian Moriarty complained about it!).

So this diff just restricts the existing workaround to the v4 English game, mainly in order to follow the current practice of making the SCUMM workarounds as precise as possible when we can. (The code as it is today wouldn't cause any issue, though, since we `strcmp()`)

I could only test the EGA and talkie releases, though, because they're the only ones I have in English.

@eriktorbjorn: do you think that this is worth it and correct?