### PR TITLE
GUI: Fix AGI/SCI Fanmade title in gridview

### DIFF
--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -1516,7 +1516,6 @@ void LauncherGrid::updateListing() {
 		Common::String engineid;
 		engineid = iter->_value.getValOrDefault("engineid");
 
-		// Strip platform language from the title.
 		Common::String key = buildQualifiedGameName(engineid, gameid);
 
 		if (_launcherChooser->getGameList()->contains(key)) {
@@ -1529,6 +1528,18 @@ void LauncherGrid::updateListing() {
 
 		if (description.empty())
 			description = Common::String::format("Unknown (target %s, gameid %s)", iter->_key.c_str(), gameid.c_str());
+
+		// Fallback for fanmade AGI/SCI games that have an identical title
+		if (title.contains("Fanmade AGI") || title.contains("Fanmade SCI")) {
+			title = description;
+
+			// Strip platform language from the title.
+			if (title.contains("(")) {
+				size_t extraPos = description.find("(");
+				if (extraPos != Common::String::npos)
+					title = Common::String(description.c_str(), extraPos);
+			}
+		}
 
 		if (title.empty())
 			title = description;


### PR DESCRIPTION
GUI: Fix title in gridview for AGI/SCI fanmade games

In gridview the title for AGI/SCI fanmade was identical for all fanmade games, checked the previous version before this behavior was introduced to come up with a fix for these edge cases. Since it specifically checks for those type of games, others should be unaffected. Ticket 13719