### PR TITLE
CI: Add missing jpeg library for macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           - platform: macosx
             buildFlags: -scheme ScummVM-macOS
             configFlags: --disable-nasm --enable-faad --enable-mpeg2
-            brewPackages: a52dec faad2 flac fluid-synth freetype fribidi mad libmpeg2 libogg libpng libvorbis sdl2 sdl2_net theora giflib
+            brewPackages: a52dec faad2 flac fluid-synth freetype fribidi jpeg mad libmpeg2 libogg libpng libvorbis sdl2 sdl2_net theora giflib
           - platform: ios7
             buildFlags: -scheme ScummVM-iOS CODE_SIGN_IDENTITY="" CODE_SIGNING_ALLOWED=NO
             configFlags: --disable-nasm --disable-opengl --disable-theoradec --disable-mpeg2 --disable-taskbar --disable-tts --disable-fribidi


### PR DESCRIPTION
I'm seeing some `missing jpeglib.h` errors on the CI for macOS today, hopefully this fixes it?

Don't know what it'd suddenly cause an error, though. Maybe we were relying on an implicit dependency that Homebrew has just removed?

**EDIT:** In Homebrew, `jpeg` is the original IJG libjpeg, while `jpeg-turbo` is the libjpeg-turbo fork. Since the Linux builds already use libjpeg-turbo, I thought that using IJG libjpeg in the macOS runner would help cover both cases.