### PR TITLE
SCUMM: Bring the Jolly Roger fix from Monkey1 VGA to the other releases

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -439,14 +439,16 @@ void ScummEngine_v5::o5_actorOps() {
 
 	// WORKAROUND: There's a continuity error in Monkey 1, in that the Jolly Roger should
 	// only appear in the first scene showing the Sea Monkey in the middle of the sea,
-	// since Guybrush must have picked it for the two other cutscenes to happen.
+	// since Guybrush must have picked it for the two other ship cutscenes to happen.
 	//
-	// The VGA releases fixed this, but this has been lost in the v5 versions. We just
-	// check that the script describing that "the crew begins to plan their voyage" is
-	// running, as that release did.  The Ultimate Talkie fixed this, but differently.
-	if ((_game.id == GID_MONKEY_EGA || _game.id == GID_MONKEY) && _roomResource == 87 &&
-		vm.slot[_currentScript].number == 10002 && act == 9 && _enableEnhancements &&
-		strcmp(_game.variant, "SE Talkie") != 0) {
+	// Some official releases appear to have a fix for this (e.g. the English floppy VGA
+	// version), but most releases don't. The fixed release would check whether the
+	// script describing that "the crew begins to plan their voyage" is running in order
+	// to display the flag, so we just reuse this check. The Ultimate Talkie also fixed
+	// this, but in a different way which doesn't look as portable between releases.
+	if ((_game.id == GID_MONKEY_EGA || _game.id == GID_MONKEY_VGA || _game.id == GID_MONKEY) &&
+		_roomResource == 87 && vm.slot[_currentScript].number == 10002 && act == 9 &&
+		_enableEnhancements && strcmp(_game.variant, "SE Talkie") != 0) {
 		const int scriptNr = (_game.version == 5) ? 122 : 119;
 		if (!isScriptRunning(scriptNr)) {
 			a->putActor(0);

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -437,6 +437,24 @@ void ScummEngine_v5::o5_actorOps() {
 	Actor *a = derefActor(act, "o5_actorOps");
 	int i, j;
 
+	// WORKAROUND: There's a continuity error in Monkey 1, in that the Jolly Roger should
+	// only appear in the first scene showing the Sea Monkey in the middle of the sea,
+	// since Guybrush must have picked it for the two other cutscenes to happen.
+	//
+	// The VGA releases fixed this, but this has been lost in the v5 versions. We just
+	// check that the script describing that "the crew begins to plan their voyage" is
+	// running, as that release did.  The Ultimate Talkie fixed this, but differently.
+	if ((_game.id == GID_MONKEY_EGA || _game.id == GID_MONKEY) && _roomResource == 87 &&
+		vm.slot[_currentScript].number == 10002 && act == 9 && _enableEnhancements &&
+		strcmp(_game.variant, "SE Talkie") != 0) {
+		const int scriptNr = (_game.version == 5) ? 122 : 119;
+		if (!isScriptRunning(scriptNr)) {
+			a->putActor(0);
+			stopObjectCode();
+			return;
+		}
+	}
+
 	while ((_opcode = fetchScriptByte()) != 0xFF) {
 		if (_game.features & GF_SMALL_HEADER)
 			_opcode = (_opcode & 0xE0) | convertTable[(_opcode & 0x1F) - 1];
@@ -756,7 +774,7 @@ void ScummEngine_v5::o5_breakHere() {
 	// least intrusive way of adding the delay. The script calls it a number
 	// of times, but only once from room 69.
 
-  if (_game.id == GID_LOOM && _game.platform == Common::kPlatformPCEngine && _language == Common::EN_ANY && vm.slot[_currentScript].number == 44 && _currentRoom == 69) {
+	if (_game.id == GID_LOOM && _game.platform == Common::kPlatformPCEngine && _language == Common::EN_ANY && vm.slot[_currentScript].number == 44 && _currentRoom == 69) {
 		vm.slot[_currentScript].delay = 120;
 		vm.slot[_currentScript].status = ssPaused;
 	}


### PR DESCRIPTION
Monkey Island 1 has a small continuity error which was only fixed in the (quite rare) VGA floppy release.

## Explanation

At the start of Part 2, you see the Sea Monkey ship in the middle of the sea, with its Jolly Roger (pirate flag). You see this scene again when you complete the voodo recipe, and when Guybrush uses the cannon. But the Jolly Roger shouldn't be visible on the ship anymore at this point, since Guybrush must pick it in order to complete the recipe.

That's a small continuity error that the VGA v4 releases (**EDIT:** only *some* of them, see below) actually fixed. But that fix was lost when the game was ported to SCUMM v5. (The Special Edition has this error too. The Ultimate Talkie Edition fixed it.)

In that scene, the flag is drawn by the entry script of room 87. In the EGA release, it's done unconditionally:

```
[0000] (48) if (VAR_VIDEOMODE == 4) {
[0007] (33)   RoomColor(0,3)
[000D] (**) }
[000D] (0C) Resource.lockCostume(49);
[0010] (0C) Resource.loadCostume(49);
[0013] (13) ActorOps(9,[Init(),Costume(49),Palette(0,6)]);
[001C] (5D) setClass(9,[150,148]);
[0026] (11) animateCostume(9,248);
[0029] (13) ActorOps(9,[Elevation(-108)]);
[002F] (2D) putActorInRoom(9,87);
[0032] (01) putActor(9,156,0);
[0038] (11) animateCostume(9,9);
[003B] (00) stopObjectCode();
```

but some VGA v4 releases added a condition:

```
[0000] (48) if (VAR_VIDEOMODE == 4) {
[0007] (33)   RoomColor(0,3)
[000D] (**) }
[000D] (68) VAR_RESULT = isScriptRunning(119); # <==
[0011] (A8) if (VAR_RESULT) {
[0016] (13)   ActorOps(9,[Init(),Costume(49),Palette(0,6)]);
[001F] (5D)   setClass(9,[150,148]);
[0029] (11)   animateCostume(9,248);
[002C] (13)   ActorOps(9,[Elevation(-108)]);
[0032] (2D)   putActorInRoom(9,87);
[0035] (01)   putActor(9,156,0);
[003B] (11)   animateCostume(9,9);
[003E] (**) }
[003E] (00) stopObjectCode();
```

Script 119 (or 122 in v5 releases) is the script printing the narrative description during the very first scene of Part 2 ("The crew begins to plan their voyage"…). 

So this PR just tries to replicate this check.

⚠️ **HOWEVER** ⚠️ I'm calling `stopObjectCode()`, since I just want to skip all the (different) opcodes until the end of that script (there's no safe/easy value to increment `_scriptPointer` with, as there are so many variants of that game). I don't know enough about the SCUMM engine to know if it's safe to `stopObjectCode()` in the middle of `o5_actorOps()`, though! It seems to work, but if someone with enough SCUMM experience can tell whether this is OK…

## How to test

Ideally, play the whole Part 2, if you know it well (it's not very long). Unfortunately, the closest boot params appear to miss the very first scene of this chapter…

You could also:

* `room 14`
* for v4: `script 105 run`, or for v5: `script 108 run` (all of this in the debugger)
* make sure that there's no visible Jolly Roger in the next scene
* complete the cannon puzzle, and check again that there's no flag when Guybrush flies to Monkey Island.

but that shortcut is not the real thing (so the Ultimate Talkie test will fail, since it does a different kind of check), and you'll miss the first scene where the flag *should* appear.

I've tested the DOS/EGA, DOS/VGA, DOS/CD, Ultimate Talkie and Amiga releases. FM-TOWNS and Macintosh tests would be welcome, although v5+ games are usually almost identical on all ports.