### PR TITLE
DIRECTOR: unify getResource behaviour

### DIFF
--- a/engines/director/archive.cpp
+++ b/engines/director/archive.cpp
@@ -343,8 +343,7 @@ Common::SeekableReadStreamEndian *MacArchive::getResource(uint32 tag, uint16 id)
 	Common::SeekableReadStream *stream = _resFork->getResource(tag, id);
 
 	if (stream == nullptr) {
-		warning("MacArchive::getResource('%s', %d): Resource doesn't exit", tag2str(tag), id);
-		return nullptr;
+		error("MacArchive::getResource(): Archive does not contain '%s' %d", tag2str(tag), id);
 	}
 
 	return new Common::SeekableSubReadStreamEndian(stream, 0, stream->size(), true, DisposeAfterUse::YES);
@@ -922,8 +921,7 @@ Common::SeekableReadStreamEndian *RIFXArchive::getResource(uint32 tag, uint16 id
 			unsigned long actualUncompLength = res.uncompSize;
 			Common::SeekableReadStreamEndian *stream = readZlibData(*_stream, res.size, &actualUncompLength, _isBigEndian);
 			if (!stream) {
-				warning("RIFXArchive::getResource(): Could not uncompress '%s' %d", tag2str(tag), id);
-				return nullptr;
+				error("RIFXArchive::getResource(): Could not uncompress '%s' %d", tag2str(tag), id);
 			}
 			if (res.uncompSize != actualUncompLength) {
 				warning("RIFXArchive::getResource(): For '%s' %d expected uncompressed length %d but got length %lu",


### PR DESCRIPTION
Almost every path returns an error if `getResource` is called but the resource can't be found. These two paths returned a `nullptr` instead. The `MacResource` side of this led to a runtime crash in Alice before 1ed15b789d0f623fc1fab520e8a5fca6ba003ac3. This PR unifies the behaviour so all versions behave identically.