### PR TITLE
GUI: Show user-provided names in grid widget

### DIFF
--- a/gui/widgets/grid.h
+++ b/gui/widgets/grid.h
@@ -66,6 +66,8 @@ struct GridItemInfo {
 		const Common::String &d, Common::Language l, Common::Platform p)
 		: entryID(id), gameid(gid), engineid(eid), title(t), description(d), language(l), platform(p), isHeader(false) {
 		thumbPath = Common::String::format("icons/%s-%s.png", engineid.c_str(), gameid.c_str());
+		if (!description.matchString(title + " (*"))
+			title = description;
 	}
 
 	GridItemInfo(const Common::String &groupHeader, int groupID) : title(groupHeader), description(groupHeader),


### PR DESCRIPTION
If the description is Some Game (DOS/English), then show the original title
(Some Game), since the DOS/English is expressed using icons. But in case it
has been changed by the user, show it as it is.
