### PR TITLE
SCUMM: MONKEY2: fix BiDi in multi-line dialogue interpolation

### DIFF
--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -573,6 +573,13 @@ void ScummEngine::fakeBidiString(byte *ltext, bool ignoreVerb) const {
 	while (ltext[ll] == 0xFF) {
 		ll += 4;
 	}
+
+	if (_game.id == GID_MONKEY2 && ltext[0] == 0x07) {
+		for (int i = 1; i < ll; i++)
+			ltext[i - 1] = ltext[i];
+		ltext[--ll] = 0x07;
+	}
+
 	int32 ipos = 0;
 	int32 start = 0;
 	byte *text = ltext + ll;
@@ -652,9 +659,9 @@ void ScummEngine::fakeBidiString(byte *ltext, bool ignoreVerb) const {
 		if (_game.id == GID_INDY4 && ltext[0] == 0x7F) {
 			ltext[start + ipos + ll] = 0x80;
 			ltext[start + ipos + ll + 1] = 0;
-		} else if (_game.id == GID_MONKEY2 && ltext[0] == 0x07) {
-			ltext[0] = ' ';
-			ltext[start + ipos + ll] = 0x07;
+		} else if (_game.id == GID_MONKEY2) {
+			// add non-printable character to end to avoid space trimming
+			ltext[start + ipos + ll] = '@';
 			ltext[start + ipos + ll + 1] = 0;
 		}
 	}


### PR DESCRIPTION
This fixes the skull marker appearing on the wrong line in Monkey Island 2.
specifically when the dialogue has multi-line interpolation (library catalog)
Before:
![libskull](https://user-images.githubusercontent.com/10459948/184549383-fc903057-13e3-429a-862b-2db9ede7275c.png)

After:
![libskull3](https://user-images.githubusercontent.com/10459948/184549446-5f2739a9-7152-4bbc-9115-9f9e1ce837f9.png)

CC @orgads 

Thanks
