### PR TITLE
SCUMM: MONKEY2: align library cards to the right

### DIFF
--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -541,6 +541,8 @@ bool ScummEngine::newLine() {
 	} else if (_isRTL) {
 		if (_game.id == GID_MANIAC || ((_game.id == GID_MONKEY || _game.id == GID_MONKEY2) && _charset->getCurID() == 4)) {
 			_nextLeft = _screenWidth - _charset->getStringWidth(0, _charsetBuffer + _charsetBufPos) - _nextLeft;
+		} else if (_game.id == GID_MONKEY2 && _charset->getCurID() == 5) {
+			_nextLeft += _screenWidth - 210 - _charset->getStringWidth(0, _charsetBuffer + _charsetBufPos);
 		}
 	}
 	if (_game.version == 0) {
@@ -797,6 +799,8 @@ void ScummEngine::CHARSET_1() {
 	} else if (_isRTL) {
 		if (_game.id == GID_MANIAC || ((_game.id == GID_MONKEY || _game.id == GID_MONKEY2) && _charset->getCurID() == 4)) {
 			_nextLeft = _screenWidth - _charset->getStringWidth(0, _charsetBuffer + _charsetBufPos) - _nextLeft;
+		} else if (_game.id == GID_MONKEY2 && _charset->getCurID() == 5) {
+			_nextLeft += _screenWidth - 210 - _charset->getStringWidth(0, _charsetBuffer + _charsetBufPos);
 		}
 	}
 


### PR DESCRIPTION
This aligns the library cards in Monkey Island 2 to the right

comparison (based on #4189)

Before:
![libskull3](https://user-images.githubusercontent.com/10459948/184551522-36d94343-ee34-4a7a-8abe-22a27d6cc31c.png)

After:
![libskull4](https://user-images.githubusercontent.com/10459948/184551526-39748e5d-e7a6-429a-8700-66cdbe31c20c.png)

CC @orgads 
Thanks
