### PR TITLE
JANITORIAL: SCUMM: Make the MD5/filesize script more portable

### DIFF
--- a/devtools/scumm-md5.txt
+++ b/devtools/scumm-md5.txt
@@ -39,16 +39,11 @@
 # of detect files, automatically inserting the values in here:
 #
 # #!/bin/sh
-# set -f
-# OIFS=$IFS
-# IFS="
-# "
-# for i in $(find . \( -name '00.*' -o -name '000.*' -o -name '*.??0' -o -name '*Data*' \) -type f); do
+# find . \( -name '00.*' -o -name '000.*' -o -name '*.??0' -o -name '*Data*' \) -type f | while read -r i; do
 #	m=$(dd if="$i" bs=1024k count=1 2>/dev/null | openssl dgst -md5 | awk '{print $NF}')
 #	s=$(wc -c < "$i" | awk '{print $1}')
 #	sed -i -e "s/$m\t-1/$m\t$s/" /PATH/TO/scumm-md5.txt
 # done
-# IFS=$OIFS
 #
 maniac	Maniac Mansion
 	2d624d1b214f7faf0094daea65c6d1a6	1188	en	2gs	Apple II	-	-

--- a/devtools/scumm-md5.txt
+++ b/devtools/scumm-md5.txt
@@ -4,8 +4,8 @@
 # GAMEID <TAB> DESCRIPTION
 # After this follows an arbitrary number of lines start with a tab. Each line
 # describes one specific variant of the game. It contains tab separated data:
-#  - MD5
-#  - file size (or -1 if unknown)
+#  - MD5 (first 1,048,576 bytes)
+#  - file size (or -1 if unknown, but only in last resort)
 #  - Language (two letter code)
 #  - Platform
 #  - Variant id
@@ -39,13 +39,14 @@
 # of detect files, automatically inserting the values in here:
 #
 # #!/bin/sh
+# set -f
 # OIFS=$IFS
 # IFS="
 # "
-# for i in `find -name 00.*` `find -name 000.*` `find -name *.??0` `find -name *Data*` ; do
-#	m=`head -c 1048576 "$i" | md5sum | cut -f1 -d' '` ;
-#	s=`du -b "$i" | cut -f1` ;
-#	sed -i -e "s/$m\t-1/$m\t$s/" /PATH/TO/scumm-md5.txt ;
+# for i in $(find . \( -name '00.*' -o -name '000.*' -o -name '*.??0' -o -name '*Data*' \) -type f); do
+#	m=$(dd if="$i" bs=1024k count=1 2>/dev/null | openssl dgst -md5 | awk '{print $NF}')
+#	s=$(wc -c < "$i" | awk '{print $1}')
+#	sed -i -e "s/$m\t-1/$m\t$s/" /PATH/TO/scumm-md5.txt
 # done
 # IFS=$OIFS
 #


### PR DESCRIPTION
`scumm-md5.txt` includes a small script example when one wants to update the file size field if it's still set to `-1`. But this script relies on GNU tools, so it won't work out of the box on macOS, for example.

**Changes:**

* `find` without a path is not portable, so I'm using `find .`
* `head -c` is not portable, so this uses `dd`, instead
* `md5sum` is not portable (it's `md5` on BSD systems), but people usually have OpenSSL so I use that instead
* `du -b` is not portable either, but `wc -c` does the job (POSIX imposes counting bytes and handling binary files)
* `sed -i` is not 100% portable, but in practice it's almost always there on modern systems, and working around this becomes quite inconvenient. So I'm just leaving it as-is
* I'm also using a single call to `find`, only checking for files and handling globbing patterns in a safer way (escaping them and using `set -f` so that it can be safely fed to the `for` loop)

Tested on macOS 12 (LibreSSL), OpenBSD 7.1 (LibreSSL), Debian 11 (OpenSSL).