### PR TITLE
DIRECTOR: Fix missing text in buttons in 32bpp mode

### DIFF
--- a/engines/director/castmember.cpp
+++ b/engines/director/castmember.cpp
@@ -1427,7 +1427,7 @@ Graphics::MacWidget *TextCastMember::createWidget(Common::Rect &bbox, Channel *c
 	case kCastButton:
 		// note that we use _initialRect for the dimensions of the button;
 		// the values provided in the sprite bounding box are ignored
-		widget = new Graphics::MacButton(Graphics::MacButtonType(buttonType), getAlignment(), g_director->getCurrentWindow(), bbox.left, bbox.top, _initialRect.width(), _initialRect.height(), g_director->_wm, _ftext, macFont, getForeColor(), 0xff);
+		widget = new Graphics::MacButton(Graphics::MacButtonType(buttonType), getAlignment(), g_director->getCurrentWindow(), bbox.left, bbox.top, _initialRect.width(), _initialRect.height(), g_director->_wm, _ftext, macFont, getForeColor(), g_director->_wm->_colorWhite);
 		widget->_focusable = true;
 
 		((Graphics::MacButton *)widget)->setHilite(_hilite);

--- a/engines/director/graphics.cpp
+++ b/engines/director/graphics.cpp
@@ -241,8 +241,8 @@ void inkDrawPixel(int x, int y, int src, void *data) {
 		byte rSrc, gSrc, bSrc;
 		byte rDst, gDst, bDst;
 
-		wm->decomposeColor(src, rSrc, gSrc, bSrc);
-		wm->decomposeColor(*dst, rDst, gDst, bDst);
+		wm->decomposeColor<T>(src, rSrc, gSrc, bSrc);
+		wm->decomposeColor<T>(*dst, rDst, gDst, bDst);
 
 		double alpha = (double)p->alpha / 100.0;
 		rDst = static_cast<byte>((rSrc * alpha) + (rDst * (1.0 - alpha)));
@@ -272,10 +272,10 @@ void inkDrawPixel(int x, int y, int src, void *data) {
 				byte rFor, gFor, bFor;
 				byte rBak, gBak, bBak;
 
-				wm->decomposeColor(src, rSrc, gSrc, bSrc);
-				wm->decomposeColor(*dst, rDst, gDst, bDst);
-				wm->decomposeColor(p->foreColor, rFor, gFor, bFor);
-				wm->decomposeColor(p->backColor, rBak, gBak, bBak);
+				wm->decomposeColor<T>(src, rSrc, gSrc, bSrc);
+				wm->decomposeColor<T>(*dst, rDst, gDst, bDst);
+				wm->decomposeColor<T>(p->foreColor, rFor, gFor, bFor);
+				wm->decomposeColor<T>(p->backColor, rBak, gBak, bBak);
 
 				*dst = wm->findBestColor((rSrc | rFor) & (~rSrc | rBak),
 										(gSrc | gFor) & (~gSrc | gBak),
@@ -297,10 +297,10 @@ void inkDrawPixel(int x, int y, int src, void *data) {
 				byte rFor, gFor, bFor;
 				byte rBak, gBak, bBak;
 
-				wm->decomposeColor(src, rSrc, gSrc, bSrc);
-				wm->decomposeColor(*dst, rDst, gDst, bDst);
-				wm->decomposeColor(p->foreColor, rFor, gFor, bFor);
-				wm->decomposeColor(p->backColor, rBak, gBak, bBak);
+				wm->decomposeColor<T>(src, rSrc, gSrc, bSrc);
+				wm->decomposeColor<T>(*dst, rDst, gDst, bDst);
+				wm->decomposeColor<T>(p->foreColor, rFor, gFor, bFor);
+				wm->decomposeColor<T>(p->backColor, rBak, gBak, bBak);
 
 				*dst = wm->findBestColor((~rSrc | rFor) & (rSrc | rBak),
 										(~gSrc | gFor) & (gSrc | gBak),
@@ -333,8 +333,8 @@ void inkDrawPixel(int x, int y, int src, void *data) {
 		byte rSrc, gSrc, bSrc;
 		byte rDst, gDst, bDst;
 
-		wm->decomposeColor(src, rSrc, gSrc, bSrc);
-		wm->decomposeColor(*dst, rDst, gDst, bDst);
+		wm->decomposeColor<T>(src, rSrc, gSrc, bSrc);
+		wm->decomposeColor<T>(*dst, rDst, gDst, bDst);
 
 		switch (p->ink) {
 		case kInkTypeBlend:

--- a/graphics/macgui/macwidget.cpp
+++ b/graphics/macgui/macwidget.cpp
@@ -26,7 +26,7 @@
 
 namespace Graphics {
 
-MacWidget::MacWidget(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, bool focusable, uint16 border, uint16 gutter, uint16 shadow, uint fgcolor, uint bgcolor) :
+MacWidget::MacWidget(MacWidget *parent, int x, int y, int w, int h, MacWindowManager *wm, bool focusable, uint16 border, uint16 gutter, uint16 shadow, uint32 fgcolor, uint32 bgcolor) :
 	_focusable(focusable), _parent(parent), _border(border), _gutter(gutter), _shadow(shadow), _wm(wm) {
 	_contentIsDirty = true;
 	_priority = 0;

--- a/graphics/macgui/macwindowmanager.h
+++ b/graphics/macgui/macwindowmanager.h
@@ -323,15 +323,15 @@ public:
 	void setEngineRedrawCallback(void *engine, void (*redrawCallback)(void *engine));
 
 	void passPalette(const byte *palette, uint size);
-	uint32 findBestColor(byte cr, byte cg, byte cb);
+	template <typename T> void decomposeColor(uint32 color, byte &r, byte &g, byte &b);
+	uint findBestColor(byte cr, byte cg, byte cb);
 	uint32 findBestColor(uint32 color);
-	void decomposeColor(uint32 color, byte &r, byte &g, byte &b);
 	void setDesktopColor(byte, byte, byte);
 
-	uint inverter(uint src);
+	byte inverter(byte src);
 
 	const byte *getPalette() { return _palette; }
-	uint getPaletteSize() { return _paletteSize; }
+	byte getPaletteSize() { return _paletteSize; }
 
 	void renderZoomBox(bool redraw = false);
 	void addZoomBox(ZoomBox *box);

--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -431,14 +431,14 @@ void ManagedSurface::blitFromInner(const Surface &src, const Common::Rect &srcRe
 	addDirtyRect(Common::Rect(0, 0, this->w, this->h));
 }
 
-void ManagedSurface::transBlitFrom(const Surface &src, uint transColor, bool flipped,
-		uint overrideColor, uint srcAlpha) {
+void ManagedSurface::transBlitFrom(const Surface &src, uint32 transColor, bool flipped,
+		uint32 overrideColor, uint32 srcAlpha) {
 	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(0, 0, this->w, this->h),
 		transColor, flipped, overrideColor, srcAlpha);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Point &destPos,
-		uint transColor, bool flipped, uint overrideColor, uint srcAlpha) {
+		uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha) {
 	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(destPos.x, destPos.y,
 		destPos.x + src.w, destPos.y + src.h), transColor, flipped, overrideColor, srcAlpha);
 }
@@ -456,26 +456,26 @@ void ManagedSurface::transBlitFrom(const Surface &src, const Common::Point &dest
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Rect &srcRect,
-		const Common::Point &destPos, uint transColor, bool flipped, uint overrideColor, uint srcAlpha) {
+		const Common::Point &destPos, uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha) {
 	transBlitFrom(src, srcRect, Common::Rect(destPos.x, destPos.y,
 		destPos.x + srcRect.width(), destPos.y + srcRect.height()), transColor, flipped, overrideColor, srcAlpha);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Rect &srcRect,
-		const Common::Rect &destRect, uint transColor, bool flipped, uint overrideColor, uint srcAlpha,
+		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha,
 		const Surface *mask, bool maskOnly) {
 	transBlitFromInner(src, srcRect, destRect, transColor, flipped, overrideColor, srcAlpha,
 		nullptr, nullptr, mask, maskOnly);
 }
 
-void ManagedSurface::transBlitFrom(const ManagedSurface &src, uint transColor, bool flipped,
-		uint overrideColor, uint srcAlpha) {
+void ManagedSurface::transBlitFrom(const ManagedSurface &src, uint32 transColor, bool flipped,
+		uint32 overrideColor, uint32 srcAlpha) {
 	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(0, 0, this->w, this->h),
 		transColor, flipped, overrideColor, srcAlpha);
 }
 
 void ManagedSurface::transBlitFrom(const ManagedSurface &src, const Common::Point &destPos,
-		uint transColor, bool flipped, uint overrideColor, uint srcAlpha) {
+		uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha) {
 	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(destPos.x, destPos.y,
 		destPos.x + src.w, destPos.y + src.h), transColor, flipped, overrideColor, srcAlpha);
 }
@@ -487,17 +487,17 @@ void ManagedSurface::transBlitFrom(const ManagedSurface &src, const Common::Poin
 }
 
 void ManagedSurface::transBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect,
-		const Common::Point &destPos, uint transColor, bool flipped, uint overrideColor, uint srcAlpha) {
-	uint tColor = !transColor && src._transparentColorSet ? src._transparentColor : transColor;
+		const Common::Point &destPos, uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha) {
+	uint32 tColor = !transColor && src._transparentColorSet ? src._transparentColor : transColor;
 
 	transBlitFrom(src, srcRect, Common::Rect(destPos.x, destPos.y, destPos.x + srcRect.width(),
 		destPos.y + srcRect.height()), tColor, flipped, overrideColor, srcAlpha);
 }
 
 void ManagedSurface::transBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect,
-		const Common::Rect &destRect, uint transColor, bool flipped, uint overrideColor, uint srcAlpha,
+		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha,
 		const Surface *mask, bool maskOnly) {
-	if (transColor == (uint)-1 && src._transparentColorSet)
+	if (transColor == (uint32)-1 && src._transparentColorSet)
 		transColor = src._transparentColor;
 	const uint32 *srcPalette = src._paletteSet ? src._palette : nullptr;
 	const uint32 *dstPalette = _paletteSet ? _palette : nullptr;
@@ -545,7 +545,7 @@ static byte *createPaletteLookup(const uint32 *srcPalette, const uint32 *dstPale
 
 template<typename TSRC, typename TDEST>
 void transBlitPixel(TSRC srcVal, TDEST &destVal, const Graphics::PixelFormat &srcFormat, const Graphics::PixelFormat &destFormat,
-		uint overrideColor, uint srcAlpha, const uint32 *srcPalette, const byte *lookup) {
+		uint32 overrideColor, uint32 srcAlpha, const uint32 *srcPalette, const byte *lookup) {
 	// Decode and re-encode each pixel
 	byte aSrc, rSrc, gSrc, bSrc;
 	if (srcFormat.bytesPerPixel == 1) {
@@ -592,7 +592,7 @@ void transBlitPixel(TSRC srcVal, TDEST &destVal, const Graphics::PixelFormat &sr
 
 template<>
 void transBlitPixel<byte, byte>(byte srcVal, byte &destVal, const Graphics::PixelFormat &srcFormat, const Graphics::PixelFormat &destFormat,
-		uint overrideColor, uint srcAlpha, const uint32 *srcPalette, const byte *lookup) {
+		uint32 overrideColor, uint32 srcAlpha, const uint32 *srcPalette, const byte *lookup) {
 	if (srcAlpha == 0) {
 		// Completely transparent, so skip
 		return;
@@ -606,7 +606,7 @@ void transBlitPixel<byte, byte>(byte srcVal, byte &destVal, const Graphics::Pixe
 
 template<typename TSRC, typename TDEST>
 void transBlit(const Surface &src, const Common::Rect &srcRect, ManagedSurface &dest, const Common::Rect &destRect,
-		TSRC transColor, bool flipped, uint overrideColor, uint srcAlpha, const uint32 *srcPalette,
+		TSRC transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha, const uint32 *srcPalette,
 		const uint32 *dstPalette, const Surface *mask, bool maskOnly) {
 	int scaleX = SCALE_THRESHOLD * srcRect.width() / destRect.width();
 	int scaleY = SCALE_THRESHOLD * srcRect.height() / destRect.height();
@@ -697,8 +697,8 @@ void transBlit(const Surface &src, const Common::Rect &srcRect, ManagedSurface &
 	else
 
 void ManagedSurface::transBlitFromInner(const Surface &src, const Common::Rect &srcRect,
-		const Common::Rect &destRect, uint transColor, bool flipped, uint overrideColor,
-		uint srcAlpha, const uint32 *srcPalette, const uint32 *dstPalette, const Surface *mask, bool maskOnly) {
+		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 overrideColor,
+		uint32 srcAlpha, const uint32 *srcPalette, const uint32 *dstPalette, const Surface *mask, bool maskOnly) {
 	if (src.w == 0 || src.h == 0 || destRect.width() == 0 || destRect.height() == 0)
 		return;
 
@@ -735,7 +735,7 @@ void ManagedSurface::addDirtyRect(const Common::Rect &r) {
 	}
 }
 
-void ManagedSurface::clear(uint color) {
+void ManagedSurface::clear(uint32 color) {
 	if (!empty())
 		fillRect(getBounds(), color);
 }

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -90,8 +90,8 @@ protected:
 	 * Inner method for copying another surface into this one at a given destination position.
 	 */
 	void transBlitFromInner(const Surface &src, const Common::Rect &srcRect,
-		const Common::Rect &destRect, uint transColor, bool flipped, uint overrideColor,
-		uint srcAlpha, const uint32 *srcPalette, const uint32 *dstPalette, const Surface *mask, bool maskOnly);
+		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 overrideColor,
+		uint32 srcAlpha, const uint32 *srcPalette, const uint32 *dstPalette, const Surface *mask, bool maskOnly);
 public:
 	/**
 	 * Clip the given source bounds so the passed destBounds will be entirely on-screen.
@@ -354,8 +354,8 @@ public:
 	 *						the source surface.
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
 	 */
-	void transBlitFrom(const Surface &src, uint transColor = 0, bool flipped = false,
-		uint overrideColor = 0, uint srcAlpha = 0xff);
+	void transBlitFrom(const Surface &src, uint32 transColor = 0, bool flipped = false,
+		uint32 overrideColor = 0, uint32 srcAlpha = 0xff);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -369,7 +369,7 @@ public:
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
 	 */
 	void transBlitFrom(const Surface &src, const Common::Point &destPos,
-		uint transColor = 0, bool flipped = false, uint overrideColor = 0, uint srcAlpha = 0xff);
+		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -404,7 +404,7 @@ public:
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
 	 */
 	void transBlitFrom(const Surface &src, const Common::Rect &srcRect, const Common::Point &destPos,
-		uint transColor = 0, bool flipped = false, uint overrideColor = 0, uint srcAlpha = 0xff);
+		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -422,7 +422,7 @@ public:
 	 * @param maskOnly		Optional parameter for using mask over @p transColor.
 	 */
 	void transBlitFrom(const Surface &src, const Common::Rect &srcRect, const Common::Rect &destRect,
-		uint transColor = 0, bool flipped = false, uint overrideColor = 0, uint srcAlpha = 0xff,
+		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff,
 		const Surface *mask = nullptr, bool maskOnly = false);
 
 	/**
@@ -435,8 +435,8 @@ public:
 	 *						the source surface.
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
 	 */
-	void transBlitFrom(const ManagedSurface &src, uint transColor = 0, bool flipped = false,
-		uint overrideColor = 0, uint srcAlpha = 0xff);
+	void transBlitFrom(const ManagedSurface &src, uint32 transColor = 0, bool flipped = false,
+		uint32 overrideColor = 0, uint32 srcAlpha = 0xff);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -450,7 +450,7 @@ public:
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
 	 */
 	void transBlitFrom(const ManagedSurface &src, const Common::Point &destPos,
-		uint transColor = 0, bool flipped = false, uint overrideColor = 0, uint srcAlpha = 0xff);
+		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -475,7 +475,7 @@ public:
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
 	 */
 	void transBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect, const Common::Point &destPos,
-		uint transColor = 0, bool flipped = false, uint overrideColor = 0, uint srcAlpha = 0xff);
+		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -493,7 +493,7 @@ public:
 	 * @param maskOnly		Optional parameter for using mask over @p transColor.
 	 */
 	void transBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect, const Common::Rect &destRect,
-		uint transColor = 0, bool flipped = false, uint overrideColor = 0, uint srcAlpha = 0xff,
+		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff,
 		const Surface *mask = nullptr, bool maskOnly = false);
 
 	/**
@@ -508,7 +508,7 @@ public:
 	/**
 	 * Clear the entire surface.
 	 */
-	void clear(uint color = 0);
+	void clear(uint32 color = 0);
 
 	/**
 	 * Mark the entire surface as dirty.
@@ -642,7 +642,7 @@ public:
 	/**
 	 * Set the transparent color.
 	 */
-	void setTransparentColor(uint color) {
+	void setTransparentColor(uint32 color) {
 		_transparentColor = color;
 		_transparentColorSet = true;
 	}

--- a/graphics/primitives.cpp
+++ b/graphics/primitives.cpp
@@ -25,7 +25,7 @@
 
 namespace Graphics {
 
-void drawLine(int x0, int y0, int x1, int y1, int color, void (*plotProc)(int, int, int, void *), void *data) {
+void drawLine(int x0, int y0, int x1, int y1, uint32 color, void (*plotProc)(int, int, int, void *), void *data) {
 	// Bresenham's line algorithm, as described by Wikipedia
 	const bool steep = ABS(y1 - y0) > ABS(x1 - x0);
 
@@ -63,7 +63,7 @@ void drawLine(int x0, int y0, int x1, int y1, int color, void (*plotProc)(int, i
 	}
 }
 
-void drawHLine(int x1, int x2, int y, int color, void (*plotProc)(int, int, int, void *), void *data) {
+void drawHLine(int x1, int x2, int y, uint32 color, void (*plotProc)(int, int, int, void *), void *data) {
 	if (x1 > x2)
 		SWAP(x1, x2);
 
@@ -71,7 +71,7 @@ void drawHLine(int x1, int x2, int y, int color, void (*plotProc)(int, int, int,
 		(*plotProc)(x, y, color, data);
 }
 
-void drawVLine(int x, int y1, int y2, int color, void (*plotProc)(int, int, int, void *), void *data) {
+void drawVLine(int x, int y1, int y2, uint32 color, void (*plotProc)(int, int, int, void *), void *data) {
 	if (y1 > y2)
 		SWAP(y1, y2);
 
@@ -79,7 +79,7 @@ void drawVLine(int x, int y1, int y2, int color, void (*plotProc)(int, int, int,
 		(*plotProc)(x, y, color, data);
 }
 
-void drawThickLine(int x0, int y0, int x1, int y1, int penX, int penY, int color, void (*plotProc)(int, int, int, void *), void *data) {
+void drawThickLine(int x0, int y0, int x1, int y1, int penX, int penY, uint32 color, void (*plotProc)(int, int, int, void *), void *data) {
 	assert(penX > 0 && penY > 0);
 
 	// Shortcut
@@ -98,7 +98,7 @@ void drawThickLine(int x0, int y0, int x1, int y1, int penX, int penY, int color
 
 /* Bresenham as presented in Foley & Van Dam */
 /* Code is based on GD lib http://libgd.github.io/ */
-void drawThickLine2(int x1, int y1, int x2, int y2, int thick, int color, void (*plotProc)(int, int, int, void *), void *data) {
+void drawThickLine2(int x1, int y1, int x2, int y2, int thick, uint32 color, void (*plotProc)(int, int, int, void *), void *data) {
 	int incr1, incr2, d, x, y, xend, yend, xdirflag, ydirflag;
 	int wid;
 	int w, wstart;
@@ -238,7 +238,7 @@ void drawThickLine2(int x1, int y1, int x2, int y2, int thick, int color, void (
 	}
 }
 
-void drawFilledRect(Common::Rect &rect, int color, void (*plotProc)(int, int, int, void *), void *data) {
+void drawFilledRect(Common::Rect &rect, uint32 color, void (*plotProc)(int, int, int, void *), void *data) {
 	for (int y = rect.top; y < rect.bottom; y++)
 		drawHLine(rect.left, rect.right - 1, y, color, plotProc, data);
 }
@@ -246,12 +246,12 @@ void drawFilledRect(Common::Rect &rect, int color, void (*plotProc)(int, int, in
 /**
  * @brief Draws filled rectangle _with_ right and bottom edges
  */
-void drawFilledRect1(Common::Rect &rect, int color, void (*plotProc)(int, int, int, void *), void *data) {
+void drawFilledRect1(Common::Rect &rect, uint32 color, void (*plotProc)(int, int, int, void *), void *data) {
 	for (int y = rect.top; y <= rect.bottom; y++)
 		drawHLine(rect.left, rect.right, y, color, plotProc, data);
 }
 
-void drawRect(Common::Rect &rect, int color, void (*plotProc)(int, int, int, void *), void *data) {
+void drawRect(Common::Rect &rect, uint32 color, void (*plotProc)(int, int, int, void *), void *data) {
 	drawHLine(rect.left, rect.right - 1, rect.top, color, plotProc, data);
 	drawHLine(rect.left, rect.right - 1, rect.bottom - 1, color, plotProc, data);
 	drawVLine(rect.left, rect.top, rect.bottom - 1, color, plotProc, data);
@@ -261,21 +261,21 @@ void drawRect(Common::Rect &rect, int color, void (*plotProc)(int, int, int, voi
 /**
  * @brief Draws rectangle outline _with_ right and bottom edges
  */
-void drawRect1(Common::Rect &rect, int color, void (*plotProc)(int, int, int, void *), void *data) {
+void drawRect1(Common::Rect &rect, uint32 color, void (*plotProc)(int, int, int, void *), void *data) {
 	drawHLine(rect.left, rect.right, rect.top, color, plotProc, data);
 	drawHLine(rect.left, rect.right, rect.bottom, color, plotProc, data);
 	drawVLine(rect.left, rect.top, rect.bottom, color, plotProc, data);
 	drawVLine(rect.right, rect.top, rect.bottom, color, plotProc, data);
 }
 
-void drawRoundRect(Common::Rect &rect, int arc, int color, bool filled, void (*plotProc)(int, int, int, void *), void *data) {
+void drawRoundRect(Common::Rect &rect, int arc, uint32 color, bool filled, void (*plotProc)(int, int, int, void *), void *data) {
 	Common::Rect r(rect.left, rect.top, rect.right - 1, rect.bottom - 1);
 
 	drawRoundRect1(r, arc, color, filled, plotProc, data);
 }
 
 // http://members.chello.at/easyfilter/bresenham.html
-void drawRoundRect1(Common::Rect &rect, int arc, int color, bool filled, void (*plotProc)(int, int, int, void *), void *data) {
+void drawRoundRect1(Common::Rect &rect, int arc, uint32 color, bool filled, void (*plotProc)(int, int, int, void *), void *data) {
 	if (rect.height() < rect.width()) {
 		int x = -arc, y = 0, err = 2-2*arc; /* II. Quadrant */
 		int dy = rect.height() - arc * 2;
@@ -371,7 +371,7 @@ void drawRoundRect1(Common::Rect &rect, int arc, int color, bool filled, void (*
 
 // Based on public-domain code by Darel Rex Finley, 2007
 // http://alienryderflex.com/polygon_fill/
-void drawPolygonScan(int *polyX, int *polyY, int npoints, Common::Rect &bbox, int color, void (*plotProc)(int, int, int, void *), void *data) {
+void drawPolygonScan(int *polyX, int *polyY, int npoints, Common::Rect &bbox, uint32 color, void (*plotProc)(int, int, int, void *), void *data) {
 	int *nodeX = (int *)calloc(npoints, sizeof(int));
 	int i, j;
 
@@ -409,7 +409,7 @@ void drawPolygonScan(int *polyX, int *polyY, int npoints, Common::Rect &bbox, in
 }
 
 // http://members.chello.at/easyfilter/bresenham.html
-void drawEllipse(int x0, int y0, int x1, int y1, int color, bool filled, void (*plotProc)(int, int, int, void *), void *data) {
+void drawEllipse(int x0, int y0, int x1, int y1, uint32 color, bool filled, void (*plotProc)(int, int, int, void *), void *data) {
 	int a = abs(x1 - x0), b = abs(y1 - y0), b1 = b & 1; /* values of diameter */
 	long dx = 4 * (1 - a) * b * b, dy = 4 * (b1 + 1) * a * a; /* error increment */
 	long err = dx + dy + b1 * a * a, e2; /* error of 1.step */

--- a/graphics/primitives.h
+++ b/graphics/primitives.h
@@ -26,21 +26,21 @@
 
 namespace Graphics {
 
-void drawLine(int x0, int y0, int x1, int y1, int color, void (*plotProc)(int, int, int, void *), void *data);
-void drawHLine(int x1, int x2, int y, int color, void (*plotProc)(int, int, int, void *), void *data);
-void drawVLine(int x, int y1, int y2, int color, void (*plotProc)(int, int, int, void *), void *data);
-void drawThickLine(int x0, int y0, int x1, int y1, int penX, int penY, int color, void (*plotProc)(int, int, int, void *), void *data);
-void drawThickLine2(int x1, int y1, int x2, int y2, int thick, int color,
+void drawLine(int x0, int y0, int x1, int y1, uint32 color, void (*plotProc)(int, int, int, void *), void *data);
+void drawHLine(int x1, int x2, int y, uint32 color, void (*plotProc)(int, int, int, void *), void *data);
+void drawVLine(int x, int y1, int y2, uint32 color, void (*plotProc)(int, int, int, void *), void *data);
+void drawThickLine(int x0, int y0, int x1, int y1, int penX, int penY, uint32 color, void (*plotProc)(int, int, int, void *), void *data);
+void drawThickLine2(int x1, int y1, int x2, int y2, int thick, uint32 color,
 								void (*plotProc)(int, int, int, void *), void *data);
-void drawFilledRect(Common::Rect &rect, int color, void (*plotProc)(int, int, int, void *), void *data);
-void drawFilledRect1(Common::Rect &rect, int color, void (*plotProc)(int, int, int, void *), void *data);
-void drawRect(Common::Rect &rect, int color, void (*plotProc)(int, int, int, void *), void *data);
-void drawRect1(Common::Rect &rect, int color, void (*plotProc)(int, int, int, void *), void *data);
-void drawRoundRect(Common::Rect &rect, int arc, int color, bool filled, void (*plotProc)(int, int, int, void *), void *data);
-void drawRoundRect1(Common::Rect &rect, int arc, int color, bool filled, void (*plotProc)(int, int, int, void *), void *data);
-void drawPolygonScan(int *polyX, int *polyY, int npoints, Common::Rect &bbox, int color,
+void drawFilledRect(Common::Rect &rect, uint32 color, void (*plotProc)(int, int, int, void *), void *data);
+void drawFilledRect1(Common::Rect &rect, uint32 color, void (*plotProc)(int, int, int, void *), void *data);
+void drawRect(Common::Rect &rect, uint32 color, void (*plotProc)(int, int, int, void *), void *data);
+void drawRect1(Common::Rect &rect, uint32 color, void (*plotProc)(int, int, int, void *), void *data);
+void drawRoundRect(Common::Rect &rect, int arc, uint32 color, bool filled, void (*plotProc)(int, int, int, void *), void *data);
+void drawRoundRect1(Common::Rect &rect, int arc, uint32 color, bool filled, void (*plotProc)(int, int, int, void *), void *data);
+void drawPolygonScan(int *polyX, int *polyY, int npoints, Common::Rect &bbox, uint32 color,
 								void (*plotProc)(int, int, int, void *), void *data);
-void drawEllipse(int x0, int y0, int x1, int y1, int color, bool filled, void (*plotProc)(int, int, int, void *), void *data);
+void drawEllipse(int x0, int y0, int x1, int y1, uint32 color, bool filled, void (*plotProc)(int, int, int, void *), void *data);
 
 } // End of namespace Graphics
 


### PR DESCRIPTION
These changes reimplement decomposeColor in macwindowmanager to fix missing text in buttons in 32bpp mode