### PR TITLE
SCUMM: Work around a small glitch with Largo's door in Monkey2

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2446,8 +2446,21 @@ void ScummEngine_v5::o5_setOwnerOf() {
 
 void ScummEngine_v5::o5_setState() {
 	int obj, state;
+
 	obj = getVarOrDirectWord(PARAM_1);
 	state = getVarOrDirectByte(PARAM_2);
+
+	// WORKAROUND: The door will glitch if one closes it before using the voodoo
+	// doll on Largo. Script 13-213 triggers the same action without any glitch,
+	// though, since it properly resets the state of the (invisible) laundry claim
+	// ticket part of the door, so we just reuse its setState and setClass calls.
+	if (_game.id == GID_MONKEY2 && _currentRoom == 13 && vm.slot[_currentScript].number == 200 &&
+		obj == 108 && state == 1 && getState(100) != 1 && getState(111) != 2 && _enableEnhancements) {
+		putState(111, 2);
+		markObjectRectAsDirty(111);
+		putClass(111, 160, true);
+	}
+
 	putState(obj, state);
 	markObjectRectAsDirty(obj);
 	if (_bgNeedsRedraw)


### PR DESCRIPTION
This is a very small issue, since I don't think a lot of players would do the following action… so if you think it's not worth it, that's fine ;)

## Description

At the end of Part I, if you close the door just before using the pins with the voodoo doll near Largo, the door will "glitch" this way when he opens it again:

![largo-door-glitch](https://user-images.githubusercontent.com/9024526/184676302-ab126b36-2bbb-48a2-840f-f44f8542e1d7.png)

It looks like this is because the door is made of several layers, one of them dealing with the presence/absence of the laundry claim ticket. When Guybrush opens the door, script 13-213 is called and properly clears this, but when Largo escapes from the room, the state of this layer isn't properly updated.

## Fix

Here's how script 13-200 deals with this action when Largo opens the door:

```
...
[0391] (36) walkActorToObject(6,108);
[0395] (0F) VAR_RESULT = getObjectState(100);
[039A] (08) if (VAR_RESULT != 1) {
[03A1] (AE)   WaitForActor(6);
[03A4] (11)   animateCostume(6,10);
[03A7] (2E)   delay(10);
[03AB] (07)   setState(108,1); # <==
[03AF] (07)   setState(100,1);
[03B3] (2E)   delay(10);
[03B7] (11)   animateCostume(6,3);
[03BA] (**) }
[03BA] (30) setBoxFlags(5,1);
[03BE] (30) setBoxFlags(6,1);
[03C2] (91) animateCostume(VAR_EGO,10);
...
```

When Guybrush does the same action, it's done a bit differently, by script 13-213 (with `Local[0] == 2` and `Local[2] == VAR_EGO`):

```
Script# 213
[0000] (40) cutscene([2]);
[0005] (A8) if (Local[1]) {
[000A] (C8)   if (Local[1] == VAR_EGO) {
[0011] (91)     animateCostume(VAR_EGO,10);
[0015] (2E)     delay(20);
[0019] (**)   }
[0019] (**) }
[0019] (48) if (Local[0] == 2) {
[0020] (40)   cutscene([2]);
[0025] (07)   setState(111,2);     # <==
[0029] (5D)   setClass(111,[160]); # <==
[0030] (07)   setState(108,1);
[0034] (07)   setState(100,1);
[0038] (1C)   startSound(2);
[003A] (C0)   endCutscene();
[003B] (A8)   if (Local[1]) {
[0040] (C8)     if (Local[1] == VAR_EGO) {
[0047] (2E)       delay(20);
[004B] (91)       animateCostume(VAR_EGO,3);
[004F] (**)     }
[004F] (**)   }
[004F] (18) }
...
```

i.e., for Guybrush `setState(111,2)` and `setClass(111,[160)]` are called and this properly clears this part of the door.

So the following PR just replicates this for Largo.

## How to test

1. Start the game with boot param `498` 
2. Open and enter Largo's room on the left
3. Immediately close the door once you see Largo
4. Quickly use the pins with the voodoo doll
5. When Largo opens the door again to quit the room, the door should be completely open without any glitch.

Tested with the DOS/English, DOS/French, Amiga/English, Macintosh/English and Ultimate Talkie releases.

It also happens with the original interpreter and in the Ultimate Talkie Edition.