### PR TITLE
GUI: temporarily revert dialogue notification

### DIFF
--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -89,6 +89,7 @@ GuiManager::GuiManager() : CommandSender(nullptr), _redrawStatus(kRedrawDisabled
 
 	initTextToSpeech();
 	initIconsSet();
+	_iconsSetChanged = false;
 
 	ConfMan.registerDefault("gui_theme", "scummremastered");
 	Common::String themefile(ConfMan.get("gui_theme"));


### PR DESCRIPTION
8cda1fe870e76efd7b13514ab304af64a8187377 introduces a bug where launching a game via the CLI, bypassing the game selection GUI, fails if the game is marked as unsupported. This affects Director games in particular, since almost all of them are marked as unsupported.

To reproduce, try to launch a Director demo directly via the commandline. ScummVM should pop up a "The game you are about to start is not yet fully supported" warning. In `master`, the dialogue is immediately cancelled because of the `secondCommand()` call. Before 8cda1fe870e76efd7b13514ab304af64a8187377, and without this patch, the player is given the chance to choose "start anyway" or "cancel". 

This isn't a permanent fix, but I'm suggesting this partial revert for now to fix the regression.

cc @criezy 