### PR TITLE
SCUMM: Use CP850 (or Windows-1252) in dialogs for some European languages

### DIFF
--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -2018,6 +2018,13 @@ Common::CodePage ScummEngine::getDialogCodePage() const {
 		default:
 			return Common::kWindows1255;
 		}
+	case Common::DE_DEU:
+	case Common::ES_ESP:
+	case Common::FR_FRA:
+	case Common::IT_ITA:
+	case Common::PT_BRA:
+	case Common::PT_PRT:
+		return (_game.version > 7) ? Common::kWindows1252 : Common::kDos850;
 	default:
 		return Common::kCodePageInvalid;
 	}


### PR DESCRIPTION
**German, Italian, Spanish, French, Portuguese, Brazilian testers wanted!**

This is not 100% correct, since LEC used an incomplete, tweaked and variable internal code page that's just *based* on CP850 (or Windows-1252 in COMI, it seems) for European releases, but it should still be an improvement other the existing behavior, when the ScummVM UI needs to print some non-ASCII characters when you press the Space or F8 keys.

For example, here's the current behavior with the CD/French version of Monkey1:

![scummvm-monkey-fr-00000](https://user-images.githubusercontent.com/9024526/185165745-60e1dee2-4f80-47cf-bcda-f8278b66108c.png)

and with this PR:

![scummvm-monkey-fr-00001](https://user-images.githubusercontent.com/9024526/185165815-9de1c743-e0b2-4344-95ea-37a3a246721d.png)

I'm just adding values for the Western European languages where I'm quite confident that this is going to be OK, since I also deal with them with ScummTR. When there was no official release from LucasArts for a language, it becomes a bit more difficult to guess the values; some fan-made translations just use their own very random codepages.

From my experience, the non-DOS European releases often used that CP850-like encoding, too.

I've tested my French SCUMM games, and a couple of German ones I have. I have almost no HE game.

The more tests the better :)