### PR TITLE
CI: Make the Xcode builds around 90% less verbose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
           cache_key: ${{ matrix.platform }}
       - name: Build scummvm
         run: |
-          xcodebuild CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ build -project scummvm.xcodeproj ${{ matrix.buildFlags }}
+          xcodebuild CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ build -project scummvm.xcodeproj ${{ matrix.buildFlags }} | awk '$1 !~ /^(export|cd|clang++)/'
           ls
   ubuntu:
     name: Ubuntu


### PR DESCRIPTION
The Xcode CI builds are very noisy at the moment, especially if you compare them to the Ubuntu CI builds. It's so noisy that it's slow to load in Github UI, and it's hard to see and search for what's important.

xcodebuild has a `-quiet` flag, but it appears to remove a lot of stuff, so this `awk` call will just remove the noisiest lines.

OK?