### PR TITLE
CONFIGURE: Enable SCUMM_NEED_ALIGNMENT when using --enable-ubsan

### DIFF
--- a/configure
+++ b/configure
@@ -2490,6 +2490,10 @@ case $_host_cpu in
 		_need_memalign=yes
 		;;
 esac
+if test "$_enable_ubsan" = yes ; then
+	# UBSan implies -fsanitize=alignment, so avoid false positives.
+	_need_memalign=yes
+fi
 echo "$_need_memalign"
 
 define_in_config_h_if_yes $_need_memalign 'SCUMM_NEED_ALIGNMENT'


### PR DESCRIPTION
`-fsanitize=undefined` implies `-fsanitize=alignment` ([source](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#available-checks)), so we need to define `SCUMM_NEED_ALIGNMENT` for UBSan builds, otherwise many false positives will be reported, such as for `engines/scumm/smush/codec47.cpp`.

That's also a good way of having more tests for the `SCUMM_NEED_ALIGNMENT` code paths during development :)