### PR TITLE
SCUMM: replace strcpy calls with Common::strlcpy

### DIFF
--- a/engines/scumm/dialogs.cpp
+++ b/engines/scumm/dialogs.cpp
@@ -493,14 +493,14 @@ const Common::U32String InfoDialog::queryResString(int stringno) {
 		result = (const byte *)getStaticResString(_vm->_language, stringno - 1).string;
 
 	if (result && *result == '/') {
-		_vm->translateText(result, buf);
+		_vm->translateText(result, buf, sizeof(buf));
 		result = buf;
 	}
 
 	if (!result || *result == '\0') // Gracelessly degrade to english :)
 		result = (const byte *)getStaticResString(_vm->_language, stringno - 1).string;
 
-	if (_vm->reverseIfNeeded(result, reverseBuf))
+	if (_vm->reverseIfNeeded(result, reverseBuf, sizeof(reverseBuf)))
 		result = reverseBuf;
 	// Convert to a proper string (take care of FF codes)
 	byte chr;

--- a/engines/scumm/he/logic/football.cpp
+++ b/engines/scumm/he/logic/football.cpp
@@ -472,7 +472,8 @@ int LogicHEfootball2002::getPlaybookFiles(int32 *args) {
 
 	// Now store the result in an array
 	int array = _vm->setupStringArray(output.size());
-	strcpy((char *)_vm->getStringAddress(array), output.c_str());
+	Common::strlcpy((char *)_vm->getStringAddress(array), output.c_str(), output.size() + 1);
+	_vm->getResourceSize(rtString, array);
 
 	// And store the array index in variable 108
 	writeScummVar(108, array);

--- a/engines/scumm/he/moonbase/ai_types.cpp
+++ b/engines/scumm/he/moonbase/ai_types.cpp
@@ -32,7 +32,7 @@ AIEntity::AIEntity(int id) {
 		debugC(DEBUG_MOONBASE_AI, "BRUTAKAS");
 		_id = id;
 		_nameString = new char[64];
-		strcpy(_nameString, "BRUTAKAS");
+		Common::strlcpy(_nameString, "BRUTAKAS", 64);
 		_behaviorVariation = AI_VAR_SMALL;
 		_targetVariation = AI_VAR_SMALL;
 		_angleVariation = AI_VAR_SMALL;
@@ -43,7 +43,7 @@ AIEntity::AIEntity(int id) {
 		debugC(DEBUG_MOONBASE_AI, "Agi");
 		_id = id;
 		_nameString = new char[64];
-		strcpy(_nameString, "Agi");
+		Common::strlcpy(_nameString, "Agi", 64);
 		_behaviorVariation = AI_VAR_SMALL;
 		_targetVariation = AI_VAR_MEDIUM;
 		_angleVariation = AI_VAR_MEDIUM;
@@ -54,7 +54,7 @@ AIEntity::AIEntity(int id) {
 		debugC(DEBUG_MOONBASE_AI, "El Gato de la Noche");
 		_id = id;
 		_nameString = new char[64];
-		strcpy(_nameString, "El Gato de la Noche");
+		Common::strlcpy(_nameString, "El Gato de la Noche", 64);
 		_behaviorVariation = AI_VAR_SMALL;
 		_targetVariation = AI_VAR_SMALL;
 		_angleVariation = AI_VAR_SMALL;
@@ -65,7 +65,7 @@ AIEntity::AIEntity(int id) {
 		debugC(DEBUG_MOONBASE_AI, "Pixelaht");
 		_id = id;
 		_nameString = new char[64];
-		strcpy(_nameString, "Pixelaht");
+		Common::strlcpy(_nameString, "Pixelaht", 64);
 		_behaviorVariation = AI_VAR_SMALL;
 		_targetVariation = AI_VAR_LARGE;
 		_angleVariation = AI_VAR_MEDIUM;
@@ -76,7 +76,7 @@ AIEntity::AIEntity(int id) {
 		debugC(DEBUG_MOONBASE_AI, "cYbaLL");
 		_id = id;
 		_nameString = new char[64];
-		strcpy(_nameString, "cYbaLL");
+		Common::strlcpy(_nameString, "cYbaLL", 64);
 		_behaviorVariation = AI_VAR_LARGE;
 		_targetVariation = AI_VAR_LARGE;
 		_angleVariation = AI_VAR_SMALL;
@@ -87,7 +87,7 @@ AIEntity::AIEntity(int id) {
 		debugC(DEBUG_MOONBASE_AI, "Neep! Neep!");
 		_id = id;
 		_nameString = new char[64];
-		strcpy(_nameString, "Neep! Neep!");
+		Common::strlcpy(_nameString, "Neep! Neep!", 64);
 		_behaviorVariation = AI_VAR_MEDIUM;
 		_targetVariation = AI_VAR_SMALL;
 		_angleVariation = AI_VAR_SMALL;
@@ -98,7 +98,7 @@ AIEntity::AIEntity(int id) {
 		debugC(DEBUG_MOONBASE_AI, "WARcupine");
 		_id = id;
 		_nameString = new char[64];
-		strcpy(_nameString, "WARcupine");
+		Common::strlcpy(_nameString, "WARcupine", 64);
 		_behaviorVariation = AI_VAR_SMALL;
 		_targetVariation = AI_VAR_SMALL;
 		_angleVariation = AI_VAR_LARGE;
@@ -109,7 +109,7 @@ AIEntity::AIEntity(int id) {
 		debugC(DEBUG_MOONBASE_AI, "aone");
 		_id = id;
 		_nameString = new char[64];
-		strcpy(_nameString, "aone");
+		Common::strlcpy(_nameString, "aone", 64);
 		_behaviorVariation = AI_VAR_MEDIUM;
 		_targetVariation = AI_VAR_MEDIUM;
 		_angleVariation = AI_VAR_MEDIUM;
@@ -120,7 +120,7 @@ AIEntity::AIEntity(int id) {
 		debugC(DEBUG_MOONBASE_AI, "S p a n d o");
 		_id = id;
 		_nameString = new char[64];
-		strcpy(_nameString, "S p a n d o");
+		Common::strlcpy(_nameString, "S p a n d o", 64);
 		_behaviorVariation = AI_VAR_LARGE;
 		_targetVariation = AI_VAR_LARGE;
 		_angleVariation = AI_VAR_SMALL;
@@ -131,7 +131,7 @@ AIEntity::AIEntity(int id) {
 		debugC(DEBUG_MOONBASE_AI, "Bonur J Lunatek");
 		_id = id;
 		_nameString = new char[64];
-		strcpy(_nameString, "Bonur J Lunatek");
+		Common::strlcpy(_nameString, "Bonur J Lunatek", 64);
 		_behaviorVariation = AI_VAR_HUGE;
 		_targetVariation = AI_VAR_HUGE;
 		_angleVariation = AI_VAR_HUGE;
@@ -142,7 +142,7 @@ AIEntity::AIEntity(int id) {
 		debugC(DEBUG_MOONBASE_AI, "Le Chuckre des Crawlres");
 		_id = id;
 		_nameString = new char[64];
-		strcpy(_nameString, "Le Chuckre des Crawlres");
+		Common::strlcpy(_nameString, "Le Chuckre des Crawlres", 64);
 		_behaviorVariation = AI_VAR_SMALL;
 		_targetVariation = AI_VAR_MEDIUM;
 		_angleVariation = AI_VAR_MEDIUM;
@@ -153,7 +153,7 @@ AIEntity::AIEntity(int id) {
 		debugC(DEBUG_MOONBASE_AI, "Energy Hog");
 		_id = id;
 		_nameString = new char[64];
-		strcpy(_nameString, "Energy Hog\n");
+		Common::strlcpy(_nameString, "Energy Hog\n", 64);
 		_behaviorVariation = AI_VAR_SMALL;
 		_targetVariation = AI_VAR_SMALL;
 		_angleVariation = AI_VAR_SMALL;
@@ -164,7 +164,7 @@ AIEntity::AIEntity(int id) {
 		debugC(DEBUG_MOONBASE_AI, "Ranger");
 		_id = id;
 		_nameString = new char[64];
-		strcpy(_nameString, "Ranger\n");
+		Common::strlcpy(_nameString, "Ranger\n", 64);
 		_behaviorVariation = AI_VAR_SMALL;
 		_targetVariation = AI_VAR_SMALL;
 		_angleVariation = AI_VAR_SMALL;

--- a/engines/scumm/imuse_digi/dimuse_bndmgr.cpp
+++ b/engines/scumm/imuse_digi/dimuse_bndmgr.cpp
@@ -94,7 +94,7 @@ int BundleDirCache::matchFile(const char *filename) {
 			_budleDirCache[freeSlot].isCompressed = true;
 		offset = file.readUint32BE();
 
-		strcpy(_budleDirCache[freeSlot].fileName, filename);
+		Common::strlcpy(_budleDirCache[freeSlot].fileName, filename, sizeof(_budleDirCache[freeSlot].fileName));
 		_budleDirCache[freeSlot].numFiles = file.readUint32BE();
 		_budleDirCache[freeSlot].bundleTable = (AudioTable *)malloc(_budleDirCache[freeSlot].numFiles * sizeof(AudioTable));
 		assert(_budleDirCache[freeSlot].bundleTable);
@@ -122,12 +122,11 @@ int BundleDirCache::matchFile(const char *filename) {
 						name[z++] = c;
 
 				name[z] = '\0';
-				strcpy(_budleDirCache[freeSlot].bundleTable[i].filename, name);
+				Common::strlcpy(_budleDirCache[freeSlot].bundleTable[i].filename, name, sizeof(_budleDirCache[freeSlot].bundleTable[i].filename));
 			}
 			_budleDirCache[freeSlot].bundleTable[i].offset = file.readUint32BE();
 			_budleDirCache[freeSlot].bundleTable[i].size = file.readUint32BE();
-			strcpy(_budleDirCache[freeSlot].indexTable[i].filename,
-					_budleDirCache[freeSlot].bundleTable[i].filename);
+			Common::strlcpy(_budleDirCache[freeSlot].indexTable[i].filename, _budleDirCache[freeSlot].bundleTable[i].filename, sizeof(_budleDirCache[freeSlot].indexTable[i].filename));
 			_budleDirCache[freeSlot].indexTable[i].index = i;
 		}
 		qsort(_budleDirCache[freeSlot].indexTable, _budleDirCache[freeSlot].numFiles,
@@ -158,7 +157,7 @@ BundleMgr::~BundleMgr() {
 
 Common::SeekableReadStream *BundleMgr::getFile(const char *filename, int32 &offset, int32 &size) {
 	BundleDirCache::IndexNode target;
-	strcpy(target.filename, filename);
+	Common::strlcpy(target.filename, filename, sizeof(target.filename));
 	BundleDirCache::IndexNode *found = (BundleDirCache::IndexNode *)bsearch(&target, _indexTable, _numFiles,
 			sizeof(BundleDirCache::IndexNode), (int (*)(const void *, const void *))scumm_stricmp);
 	if (found) {

--- a/engines/scumm/imuse_digi/dimuse_sndmgr.cpp
+++ b/engines/scumm/imuse_digi/dimuse_sndmgr.cpp
@@ -192,7 +192,7 @@ ImuseDigiSndMgr::SoundDesc *ImuseDigiSndMgr::openSound(int32 soundId, const char
 		error("ImuseDigiSndMgr::openSound() Unknown soundType %d (trying to load sound %d)", soundType, soundId);
 	}
 
-	strcpy(sound->name, soundName);
+	Common::strlcpy(sound->name, soundName, sizeof(sound->name));
 	sound->soundId = soundId;
 
 	if (soundType == IMUSE_BUNDLE) {

--- a/engines/scumm/resource.cpp
+++ b/engines/scumm/resource.cpp
@@ -1127,7 +1127,7 @@ void ScummEngine::loadPtrToResource(ResType type, ResId idx, const byte *source)
 			refreshScriptPointer();
 			source = _scriptPointer;
 		}
-		translateText(source, translateBuffer);
+		translateText(source, translateBuffer, sizeof(translateBuffer));
 
 		source = translateBuffer;
 		len = resStrLen(source) + 1;

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -3289,9 +3289,9 @@ void ScummEngine_v5::decodeParseString() {
 					byte tmpBuf[25];
 					memcpy(tmpBuf, _scriptPointer, 25);
 					if (tmpBuf[22] == '8')
-						strcpy((char *)tmpBuf+16, "^18^");
+						Common::strlcpy((char *)tmpBuf+16, "^18^", sizeof(tmpBuf) - 16);
 					else
-						strcpy((char *)tmpBuf+16, "^19^");
+						Common::strlcpy((char *)tmpBuf+16, "^19^", sizeof(tmpBuf) - 16);
 					printString(textSlot, tmpBuf);
 				} else if (_game.id == GID_INDY4 && _language == Common::EN_ANY && _roomResource == 10 &&
 						vm.slot[_currentScript].number == 209 && _actorToPrintStrFor == 4 && len == 81 &&
@@ -3337,8 +3337,8 @@ void ScummEngine_v5::decodeParseString() {
 					char tmpBuf[256];
 					const int diff = tmp - (const char *)_scriptPointer;
 					memcpy(tmpBuf, _scriptPointer, diff);
-					strcpy(tmpBuf + diff, "5000");
-					strcpy(tmpBuf + diff + 4, tmp + sizeof("NCREDIT-NOTE-AMOUNT") - 1);
+					Common::strlcpy(tmpBuf + diff, "5000", sizeof(tmpBuf) - diff);
+					Common::strlcpy(tmpBuf + diff + 4, tmp + sizeof("NCREDIT-NOTE-AMOUNT") - 1, sizeof(tmpBuf) - diff - 4);
 					printString(textSlot, (byte *)tmpBuf);
 				} else if (_game.id == GID_MONKEY && _roomResource == 25 && vm.slot[_currentScript].number == 205) {
 					printPatchedMI1CannibalString(textSlot, _scriptPointer);

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -1289,9 +1289,9 @@ public:
 	Common::Language _language;	// Accessed by a hack in NutRenderer::loadFont
 
 	// Used by class ScummDialog:
-	virtual void translateText(const byte *text, byte *trans_buff);
+	virtual void translateText(const byte *text, byte *trans_buff, int transBufferSize);
 	// Old Hebrew games require reversing the dialog text.
-	bool reverseIfNeeded(const byte *text, byte *reverseBuf) const;
+	bool reverseIfNeeded(const byte *text, byte *reverseBuf, int reverseBufSize) const;
 	// Returns codepage that matches the game for languages that require it.
 	Common::CodePage getDialogCodePage() const;
 

--- a/engines/scumm/scumm_v7.h
+++ b/engines/scumm/scumm_v7.h
@@ -161,7 +161,7 @@ protected:
 	void showMessageDialog(const byte *msg) override;
 
 	void actorTalk(const byte *msg) override;
-	void translateText(const byte *text, byte *trans_buff) override;
+	void translateText(const byte *text, byte *trans_buff, int transBufferSize) override;
 	void loadLanguageBundle() override;
 	void playSpeech(const byte *ptr);
 

--- a/engines/scumm/smush/smush_player.cpp
+++ b/engines/scumm/smush/smush_player.cpp
@@ -583,7 +583,7 @@ void SmushPlayer::handleTextResource(uint32 subType, int32 subSize, Common::Seek
 
 	byte transBuf[512];
 	if (_vm->_game.id == GID_CMI) {
-		_vm->translateText((const byte *)str - 1, transBuf);
+		_vm->translateText((const byte *)str - 1, transBuf, sizeof(transBuf));
 		while (*str++ != '/')
 			;
 		string2 = (char *)transBuf;
@@ -678,8 +678,8 @@ bool SmushPlayer::readString(const char *file) {
 		error("invalid filename : %s", file);
 	}
 	char fname[260];
-	memcpy(fname, file, i - file);
-	strcpy(fname + (i - file), ".trs");
+	memcpy(fname, file, MIN<int>(sizeof(fname), i - file));
+	Common::strlcpy(fname + (i - file), ".trs", sizeof(fname) - (i - file));
 	if ((_strings = getStrings(_vm, fname, false)) != 0) {
 		return true;
 	}
@@ -1126,8 +1126,8 @@ void SmushPlayer::tryCmpFile(const char *filename) {
 	// FIXME: How about using AudioStream::openStreamFile instead of the code below?
 
 #ifdef USE_VORBIS
-	memcpy(fname, filename, i - filename);
-	strcpy(fname + (i - filename), ".ogg");
+	memcpy(fname, filename, MIN<int>(i - filename, sizeof(fname)));
+	Common::strlcpy(fname + (i - filename), ".ogg", sizeof(fname) - (i - filename));
 	if (file->open(fname)) {
 		_compressedFileMode = true;
 		_vm->_mixer->playStream(Audio::Mixer::kSFXSoundType, _compressedFileSoundHandle, Audio::makeVorbisStream(file, DisposeAfterUse::YES));
@@ -1135,8 +1135,8 @@ void SmushPlayer::tryCmpFile(const char *filename) {
 	}
 #endif
 #ifdef USE_MAD
-	memcpy(fname, filename, i - filename);
-	strcpy(fname + (i - filename), ".mp3");
+	memcpy(fname, filename, MIN<int>(i - filename, sizeof(fname)));
+	Common::strlcpy(fname + (i - filename), ".mp3", sizeof(fname) - (i - filename));
 	if (file->open(fname)) {
 		_compressedFileMode = true;
 		_vm->_mixer->playStream(Audio::Mixer::kSFXSoundType, _compressedFileSoundHandle, Audio::makeMP3Stream(file, DisposeAfterUse::YES));

--- a/engines/scumm/sound.cpp
+++ b/engines/scumm/sound.cpp
@@ -728,21 +728,21 @@ void Sound::startTalkSound(uint32 offset, uint32 b, int mode, Audio::SoundHandle
 		char roomname[10];
 
 		if (offset == 1)
-			strcpy(roomname, "logo");
+			Common::strlcpy(roomname, "logo", sizeof(roomname));
 		else if (offset == 15)
-			strcpy(roomname, "canyon");
+			Common::strlcpy(roomname, "canyon", sizeof(roomname));
 		else if (offset == 17)
-			strcpy(roomname, "pig");
+			Common::strlcpy(roomname, "pig", sizeof(roomname));
 		else if (offset == 18)
-			strcpy(roomname, "derelict");
+			Common::strlcpy(roomname, "derelict", sizeof(roomname));
 		else if (offset == 19)
-			strcpy(roomname, "wreck");
+			Common::strlcpy(roomname, "wreck", sizeof(roomname));
 		else if (offset == 20)
-			strcpy(roomname, "grave");
+			Common::strlcpy(roomname, "grave", sizeof(roomname));
 		else if (offset == 23)
-			strcpy(roomname, "nexus");
+			Common::strlcpy(roomname, "nexus", sizeof(roomname));
 		else if (offset == 79)
-			strcpy(roomname, "newton");
+			Common::strlcpy(roomname, "newton", sizeof(roomname));
 		else {
 			warning("startTalkSound: dig demo: unknown room number: %d", offset);
 			return;
@@ -1748,7 +1748,7 @@ int ScummEngine::readSoundResource(ResId idx) {
 		// files seem to be 11 chars (8.3)
 		char *p = (char *)memchr(buffer, '.', 12);
 		if (!p) p = &buffer[8];
-		strcpy(p, ".dmu");
+		Common::strlcpy(p, ".dmu", sizeof(buffer) - (p - buffer));
 		debugC(DEBUG_SOUND, "FMUS file %s", buffer);
 
 		if (!dmuFile.open(buffer)) {


### PR DESCRIPTION
This replaces every single strcpy call in the engine with
Common::strlcpy.

Some of these cases might seem a bit pointless, but it is
supposed to discourage future use of strcpy. If people don't
see a single occasion of it they might think twice before they
use it...

I have turned it into a PR so whoever is interested can
check whether he/she sees anything suspicious.