### PR TITLE
SCUMM: Convert if/else if in o4_saveLoadGame to switch; fix typos

### DIFF
--- a/engines/scumm/input.cpp
+++ b/engines/scumm/input.cpp
@@ -797,10 +797,10 @@ void ScummEngine_v6::processKeyboard(Common::KeyState lastKeyHit) {
 }
 
 void ScummEngine_v2::processKeyboard(Common::KeyState lastKeyHit) {
-	// RETURN is used to skip cutscenes in the Commodote 64 version of Zak McKracken
+	// RETURN is used to skip cutscenes in the Commodore 64 version of Zak McKracken
 	if (_game.id == GID_ZAK &&_game.platform == Common::kPlatformC64 && lastKeyHit.keycode == Common::KEYCODE_RETURN && lastKeyHit.hasFlags(0)) {
 		lastKeyHit = Common::KeyState(Common::KEYCODE_ESCAPE);
-	// F7 is used to skip cutscenes in the Commodote 64 version of Maniac Mansion
+	// F7 is used to skip cutscenes in the Commodore 64 version of Maniac Mansion
 	} else if (_game.id == GID_MANIAC &&_game.platform == Common::kPlatformC64) {
 		// Demo always F7 to be pressed to restart
 		if (_game.features & GF_DEMO) {

--- a/engines/scumm/script_v4.cpp
+++ b/engines/scumm/script_v4.cpp
@@ -374,10 +374,16 @@ void ScummEngine_v4::o4_saveLoadGame() {
 		// 1 Load
 		// 2 Save
 		slot = 1;
-		if (a == 1)
+		switch (a) {
+		case 1:
 			_opcode = 0x40;
-		else if ((a == 2) || (_game.platform == Common::kPlatformNES))
+			break;
+		case 2:
 			_opcode = 0x80;
+			break;
+		default:
+			error("o4_saveLoadGame: unknown param %d", a);
+		}
 	} else {
 		slot = a & 0x1F;
 		// Slot numbers in older games start with 0, in newer games with 1


### PR DESCRIPTION
The `(a == 2) || (_game.platform == Common::kPlatformNES)` doesn't make sense as the NES version only does `saveLoadGame(1)` / `saveLoadGame(2)`, so it's already covered by the first check.