### PR TITLE
GRAPHICS: Add a mechanism to get the game and overlay display rects

### DIFF
--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -81,6 +81,7 @@ public:
 
 	virtual int16 getHeight() const = 0;
 	virtual int16 getWidth() const = 0;
+	virtual Common::Rect getScreenRect() const = 0;
 	virtual void setPalette(const byte *colors, uint start, uint num) = 0;
 	virtual void grabPalette(byte *colors, uint start, uint num) const = 0;
 	virtual void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) = 0;
@@ -101,6 +102,7 @@ public:
 	virtual void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) = 0;
 	virtual int16 getOverlayHeight() const = 0;
 	virtual int16 getOverlayWidth() const = 0;
+	virtual Common::Rect getOverlayRect() const = 0;
 	virtual float getHiDPIScreenFactor() const { return 1.0f; }
 
 	virtual bool showMouse(bool visible) = 0;

--- a/backends/graphics/null/null-graphics.h
+++ b/backends/graphics/null/null-graphics.h
@@ -60,6 +60,7 @@ public:
 
 	int16 getHeight() const override { return _height; }
 	int16 getWidth() const override { return _width; }
+	Common::Rect getScreenRect() const override { return Common::Rect(0, 0, _width, _height); }
 	void setPalette(const byte *colors, uint start, uint num) override {}
 	void grabPalette(byte *colors, uint start, uint num) const override {}
 	void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) override {}
@@ -80,6 +81,7 @@ public:
 	void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) override {}
 	int16 getOverlayHeight() const override { return _height; }
 	int16 getOverlayWidth() const override { return _width; }
+	Common::Rect getOverlayRect() const override { return Common::Rect(0, 0, _width, _height); }
 
 	bool showMouse(bool visible) override { return !visible; }
 	void warpMouse(int x, int y) override {}

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -53,6 +53,14 @@ public:
 		_cursorNeedsRedraw(false),
 		_cursorLastInActiveArea(true) {}
 
+	Common::Rect getScreenRect() const override {
+		return _gameDrawRect;
+	}
+
+	Common::Rect getOverlayRect() const override {
+		return _overlayDrawRect;
+	}
+
 	void showOverlay() override {
 		if (_overlayVisible)
 			return;


### PR DESCRIPTION
This adds methods to retrieve the game and overlay rects so I can scale and position subtitles in the overlay in a consistent way relative to the game screen.