### PR TITLE
GRIM: Move required data url into a variable String

### DIFF
--- a/engines/grim/md5check.cpp
+++ b/engines/grim/md5check.cpp
@@ -561,10 +561,12 @@ bool MD5Check::advanceCheck(int *pos, int *total) {
 			return false;
 		}
 	} else {
+		Common::String urlForRequiredDataFiles = Common::String::format("https://wiki.scummvm.org/index.php?title=%s#Required_data_files",
+		                                                                (g_grim->getGameType() == GType_GRIM)? "Grim_Fandango" : "Escape_from_Monkey_Island");
 		warning("Could not open %s for checking", sum.filename);
 		GUI::displayErrorDialog(Common::U32String::format(_("Could not open the file %s for checking.\nIt may be missing or "
-								"you may not have the rights to open it.\nGo to https://wiki.scummvm.org/index.php/Datafiles to see a list "
-								"of the needed files."), sum.filename));
+								"you may not have the rights to open it.\nGo to %s to see a list "
+								"of the needed files."), sum.filename, urlForRequiredDataFiles.c_str()));
 		return false;
 	}
 

--- a/engines/grim/md5check.cpp
+++ b/engines/grim/md5check.cpp
@@ -24,6 +24,7 @@
 #include "common/translation.h"
 
 #include "gui/error.h"
+#include "gui/message.h"
 
 #include "engines/grim/md5check.h"
 #include "engines/grim/grim.h"
@@ -564,9 +565,10 @@ bool MD5Check::advanceCheck(int *pos, int *total) {
 		Common::String urlForRequiredDataFiles = Common::String::format("https://wiki.scummvm.org/index.php?title=%s#Required_data_files",
 		                                                                (g_grim->getGameType() == GType_GRIM)? "Grim_Fandango" : "Escape_from_Monkey_Island");
 		warning("Could not open %s for checking", sum.filename);
-		GUI::displayErrorDialog(Common::U32String::format(_("Could not open the file %s for checking.\nIt may be missing or "
+		GUI::MessageDialogWithURL dialog(Common::U32String::format(_("Could not open the file %s for checking.\nIt may be missing or "
 								"you may not have the rights to open it.\nGo to %s to see a list "
-								"of the needed files."), sum.filename, urlForRequiredDataFiles.c_str()));
+								"of the needed files."), sum.filename, urlForRequiredDataFiles.c_str()), urlForRequiredDataFiles.c_str());
+		dialog.runModal();
 		return false;
 	}
 

--- a/engines/grim/md5check.cpp
+++ b/engines/grim/md5check.cpp
@@ -24,7 +24,6 @@
 #include "common/translation.h"
 
 #include "gui/error.h"
-#include "gui/message.h"
 
 #include "engines/grim/md5check.h"
 #include "engines/grim/grim.h"
@@ -565,10 +564,9 @@ bool MD5Check::advanceCheck(int *pos, int *total) {
 		Common::String urlForRequiredDataFiles = Common::String::format("https://wiki.scummvm.org/index.php?title=%s#Required_data_files",
 		                                                                (g_grim->getGameType() == GType_GRIM)? "Grim_Fandango" : "Escape_from_Monkey_Island");
 		warning("Could not open %s for checking", sum.filename);
-		GUI::MessageDialogWithURL dialog(Common::U32String::format(_("Could not open the file %s for checking.\nIt may be missing or "
-								"you may not have the rights to open it.\nGo to %s to see a list "
-								"of the needed files."), sum.filename, urlForRequiredDataFiles.c_str()), urlForRequiredDataFiles.c_str());
-		dialog.runModal();
+		GUIErrorMessageWithURL(Common::U32String::format(_("Could not open the file %s for checking.\nIt may be missing or "
+		                       "you may not have the rights to open it.\nGo to %s to see a list "
+		                       "of the needed files."), sum.filename, urlForRequiredDataFiles.c_str()), urlForRequiredDataFiles.c_str());
 		return false;
 	}
 


### PR DESCRIPTION
This allows to use correct url based on detected game

Related notes: Before this PR, for this translatable string: https://github.com/scummvm/scummvm/blob/master/engines/grim/md5check.cpp#L565
the French and Dutch translations still used the old (now defunct) url: https://wiki.residualvm.org/index.php/Datafiles. 

The newer translations do use a valid url but it's very generic with no immediate info about Grim Fandango or EMI: https://wiki.scummvm.org/index.php/Datafiles

This PR uses a variable string there, so that the correct url is used, based on the detected game. It will be one of these:
- https://wiki.scummvm.org/index.php?title=Grim_Fandango#Required_data_files 
- https://wiki.scummvm.org/index.php?title=Escape_from_Monkey_Island#Required_data_files

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
