### PR TITLE
SCUMM: FREDDI4: fix lipsync issues

### DIFF
--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -3064,14 +3064,20 @@ void ScummEngine::stopTalk() {
 		}
 		if (_game.version <= 7 && _game.heversion == 0)
 			setTalkingActor(0xFF);
-		if (_game.heversion != 0)
-			((ActorHE *)a)->_heTalking = false;
+		if (_game.heversion != 0) {
+			if (_game.heversion == 98 && _game.id == GID_FREDDI4) {
+				// Delay unsetting _heTalking to next sound frame. fixes bug #3533.
+				_actorShouldStopTalking = true;
+			} else {
+				((ActorHE *)a)->_heTalking = true;
+			}
+		}
 	}
 
 	if ((_game.id == GID_DIG && !(_game.features & GF_DEMO)) || _game.id == GID_CMI) {
 		setTalkingActor(0);
 		VAR(VAR_HAVE_MSG) = 0;
-	} else if (_game.heversion >= 60) {
+	} else if (_game.heversion >= 60 && !_actorShouldStopTalking) {
 		setTalkingActor(0);
 	}
 

--- a/engines/scumm/akos.cpp
+++ b/engines/scumm/akos.cpp
@@ -1813,6 +1813,13 @@ void ScummEngine_v6::akos_processQueue() {
 			error("akos_queCommand(%d,%d,%d,%d)", cmd, a->_number, param_1, param_2);
 		}
 	}
+
+	if (_game.heversion == 98 && _game.id == GID_FREDDI4 && _actorShouldStopTalking) {
+		Actor *a = derefActor(getTalkingActor(), "ScummEngine_v6::akos_processQueue()");
+		((ActorHE *)a)->_heTalking = false;
+		setTalkingActor(0);
+		_actorShouldStopTalking = false;
+	}
 }
 
 #ifdef ENABLE_SCUMM_7_8

--- a/engines/scumm/akos.cpp
+++ b/engines/scumm/akos.cpp
@@ -1463,13 +1463,6 @@ bool ScummEngine_v6::akos_increaseAnim(Actor *a, int chan, const byte *aksq, con
 			case AKC_C0A0:
 			case AKC_C0A1:
 			case AKC_C0A2:
-				// WORKAROUND bug #3533 luther does not moves his lips on subsequent sentences (only the first one).
-				// we skip the opcode instruction until all lines are said.
-				if (_game.id == GID_FREDDI4 && _currentRoom == 43 && a->_costume == 809 && code == AKC_C0A1 && a->getAnimVar(23) > 0) {
-					a->setAnimVar(23, a->getAnimVar(23) - 1);
-					((ActorHE *)a)->_heTalking = true;
-					break;
-				}
 				curpos += 4;
 				break;
 			case AKC_ComplexChan2:
@@ -1535,15 +1528,6 @@ bool ScummEngine_v6::akos_increaseAnim(Actor *a, int chan, const byte *aksq, con
 		case AKC_JumpL:
 		case AKC_JumpNE:
 		case AKC_JumpE:
-			// WORKAROUND bug #3533 when freddi talks in multiple sentences, she moves her lips on the first sequence.
-			// then luther moves his lips on the second and the rest are disembodied.
-			// we force the comparison (loop to start of freddi's lips) until all lines are said.
-			if (_game.id == GID_FREDDI4 && _currentRoom == 43 && a->_costume == 809 && a->getAnimVar(25) > 0) {
-				a->setAnimVar(25, a->getAnimVar(25) - 1);
-				curpos = GUW(2);
-				break;
-			}
-
 			if (akos_compare(a->getAnimVar(GB(4)), GW(5), code - AKC_JumpStart) != 0) {
 				curpos = GUW(2);
 				break;

--- a/engines/scumm/he/script_v72he.cpp
+++ b/engines/scumm/he/script_v72he.cpp
@@ -793,12 +793,6 @@ void ScummEngine_v72he::o72_actorOps() {
 		k = getStackList(args, ARRAYSIZE(args));
 		for (i = 0; i < k; ++i) {
 			a->setUserCondition(args[i] & 0x7F, args[i] & 0x80);
-			// WORKAROUND bug #3533 luther does not moves his lips on subsequent sentences (only the first one).
-			// we skip the opcode instruction until all lines are said.
-			// The animation var is set to the number of lines minus 1.
-			if (_game.id == GID_FREDDI4 && _game.heversion == 98 && _currentRoom == 43 && args[i] == 130  && vm.slot[_currentScript].offs != 84203) {
-				a->setAnimVar(23, vm.slot[_currentScript].offs == 79584 ? 2 : 1);
-			}
 		}
 		break;
 	case 24: 		// SO_TALK_CONDITION (HE 80+)
@@ -837,13 +831,6 @@ void ScummEngine_v72he::o72_actorOps() {
 		break;
 	case 76:		// SO_COSTUME
 		a->setActorCostume(pop());
-		// WORKAROUND bug #3533 when freddi talks in multiple sentences, she moves her lips on the first sequence.
-		// then luther moves his lips on the second and the rest are disembodied.
-		// we force the comparison (loop to start of freddi's lips) until all lines are said.
-		// The animation var is set to the number of lines minus 1.
-		if (_game.id == GID_FREDDI4 && _currentRoom == 43 && a->_costume == 809) {
-			a->setAnimVar(25, vm.slot[_currentScript].offs == 105213 ? 3 : 1);
-		}
 		break;
 	case 77:		// SO_STEP_DIST
 		j = pop();

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -1257,6 +1257,7 @@ protected:
 	byte _charsetBuffer[512];
 
 	bool _keepText = false;
+	bool _actorShouldStopTalking = false;
 	byte _msgCount = 0;
 
 	int _nextLeft = 0, _nextTop = 0;


### PR DESCRIPTION
Fixes https://bugs.scummvm.org/ticket/3533
by simulating a delay of one frame to unsetting _heTalkie flag.
It seems to match the behaviour in the original interperter.

The workarounds in #4138 are reverted as well as they are no longer needed

Notes:
- Should the revert commit be squashed/rephrased?
- It seems to be potentialy a big change so I limited this behaviour to this game only. perhaps should be reused if other games have lipsync issues.
- ~~I am not sure that sound.cpp is appropriate place for this fix, but for some reason it didn't work when put in actor processing loop.~~
- I didn't notice issues when testing this, but if some are found, some more checks can be added to the test condition.