### PR TITLE
COMMON: Change Common::Language and Common::Platform to use a smaller type

### DIFF
--- a/common/language.h
+++ b/common/language.h
@@ -42,7 +42,7 @@ class String;
 /**
  * List of game language.
  */
-enum Language {
+enum Language : int8 {
 	AR_ARB,
 	CA_ESP,
 	CS_CZE,

--- a/common/platform.h
+++ b/common/platform.h
@@ -43,7 +43,7 @@ class String;
  * This may be optional or required, depending on the game engine and the
  * game in question.
  */
-enum Platform {
+enum Platform : int8 {
 	kPlatformDOS,
 	kPlatformAmiga,
 	kPlatformAtari8Bit,


### PR DESCRIPTION
This reduces the size of the detection plugin on x86_64 Linux by about 100kb.