### PR TITLE
SCUMM: Work around typo in Syd's biography in DOS Maniac Mansion (v1)

### DIFF
--- a/engines/scumm/script_v2.cpp
+++ b/engines/scumm/script_v2.cpp
@@ -414,6 +414,20 @@ void ScummEngine_v2::decodeParseString() {
 		*ptr = 0;
 	}
 
+	// WORKAROUND: There is a typo in Syd's biography ("tring" instead of
+	// "trying") in the English DOS version of Maniac Mansion (v1). As far
+	// as I know, this is the only version with the typo.
+	else if (_game.id == GID_MANIAC && _game.version == 1
+		&& _game.platform == Common::kPlatformDOS
+		&& !(_game.features & GF_DEMO) && _language == Common::EN_ANY
+		&& vm.slot[_currentScript].number == 260 && _enableEnhancements
+		&& strncmp((char *)buffer + 26, " tring ", 7) == 0) {
+		for (byte *p = ptr; p >= buffer + 29; p--)
+			*(p + 1) = *p;
+
+		buffer[29] = 'y';
+	}
+
 	int textSlot = 0;
 	_string[textSlot].xpos = 0;
 	_string[textSlot].ypos = 0;


### PR DESCRIPTION
I forget where I saw it, but it was pointed out that the English version of Maniac Mansion (v1) has a typo in Syd's biography, where it says he's "tring" to start his own new-wave band.

Edit: Found it: https://forums.thimbleweedpark.com/t/maniac-mansion-released-on-steam/2162/59

![scummvm-maniac-v1-00006](https://user-images.githubusercontent.com/601765/186076171-c678d8d5-cd0b-41a9-83f9-0b3835d9120d.png)

This was fixed in the enhanced version, and at least judging by YouTube videos of the C64 version the typo isn't there either. The NES version apparently rewrites the biography so that the word "trying" is no longer in it.

This pull request fixes the typo, if enhancements are enabled:

![scummvm-maniac-v1-00007](https://user-images.githubusercontent.com/601765/186077058-893fad7e-646d-44ce-ae04-497203b77310.png)

(I know I could have used memmove to adjust the string, but I thought a loop made it much clearer exactly what was being moved.)
