### PR TITLE
BACKENDS: Move isDataAndCDAudioReadFromSameCD() to AudioCDManager

### DIFF
--- a/backends/audiocd/audiocd.h
+++ b/backends/audiocd/audiocd.h
@@ -107,8 +107,15 @@ public:
 	/**
 	 * Checks whether the extracted audio cd tracks exists as files in
 	 * the search paths.
+	 * @return true if audio files of the expected naming scheme are found, and supported by ScummVM.
 	 */
 	virtual bool existExtractedCDAudioFiles(uint track) = 0;
+
+	/**
+	 * Checks if game data are read from the same CD drive which should also play game CD audio.
+	 * @return true, if this case is applicable, and the system doesn't allow it.
+	 */
+	virtual bool isDataAndCDAudioReadFromSameCD() = 0;
 };
 
 #endif

--- a/backends/audiocd/default/default-audiocd.h
+++ b/backends/audiocd/default/default-audiocd.h
@@ -48,6 +48,7 @@ public:
 	virtual void update();
 	virtual Status getStatus() const; // Subclasses should override for better status results
 	virtual bool existExtractedCDAudioFiles(uint track);
+	virtual bool isDataAndCDAudioReadFromSameCD() { return false; }
 
 private:
 	void fillPotentialTrackNames(Common::Array<Common::String> &trackNames, int track) const;

--- a/backends/audiocd/win32/win32-audiocd.cpp
+++ b/backends/audiocd/win32/win32-audiocd.cpp
@@ -151,6 +151,7 @@ public:
 	void close() override;
 	bool play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate,
 			Audio::Mixer::SoundType soundType) override;
+	bool isDataAndCDAudioReadFromSameCD() override;
 
 protected:
 	bool openCD(int drive) override;
@@ -383,6 +384,26 @@ bool Win32AudioCDManager::tryAddDrive(char drive, DriveList &drives) {
 	debug(2, "Detected drive %c:\\ as a CD drive", drive);
 	drives.push_back(drive);
 	return true;
+}
+
+bool Win32AudioCDManager::isDataAndCDAudioReadFromSameCD() {
+	// It is a known bug under Windows that games that play CD audio cause
+	// ScummVM to crash if the data files are read from the same CD.
+	char driveLetter;
+	const Common::FSNode gameDataDir(ConfMan.get("path"));
+	if (!gameDataDir.getPath().empty()) {
+		driveLetter = gameDataDir.getPath()[0];
+	} else {
+		// That's it! I give up!
+		Common::FSNode currentDir(".");
+		if (!currentDir.getPath().empty()) {
+			driveLetter = currentDir.getPath()[0];
+		} else {
+			return false;
+		}
+	}
+
+	return Win32::isDriveCD(driveLetter);
 }
 
 AudioCDManager *createWin32AudioCDManager() {

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -19,12 +19,6 @@
  *
  */
 
-#if defined(WIN32)
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include "backends/platform/sdl/win32/win32_wrapper.h"
-#endif
-
 #include "engines/engine.h"
 #include "engines/dialogs.h"
 #include "engines/util.h"
@@ -496,28 +490,13 @@ bool Engine::existExtractedCDAudioFiles(uint track) {
  * @return			true, if this case is applicable and the warning is displayed
  */
 bool Engine::isDataAndCDAudioReadFromSameCD() {
-#if defined(WIN32)
-	// It is a known bug under Windows that games that play CD audio cause
-	// ScummVM to crash if the data files are read from the same CD. Check
-	// if this appears to be the case and issue a warning.
-
 	// If we can find a compressed audio track, then it should be ok even
 	// if it's running from CD.
-	char driveLetter;
-	const Common::FSNode gameDataDir(ConfMan.get("path"));
-	if (!gameDataDir.getPath().empty()) {
-		driveLetter = gameDataDir.getPath()[0];
-	} else {
-		// That's it! I give up!
-		Common::FSNode currentDir(".");
-		if (!currentDir.getPath().empty()) {
-			driveLetter = currentDir.getPath()[0];
-		} else {
-			return false;
-		}
+	if (existExtractedCDAudioFiles()) {
+		return false;
 	}
 
-	if (Win32::isDriveCD(driveLetter)) {
+	if (g_system->getAudioCDManager()->isDataAndCDAudioReadFromSameCD()) {
 		GUI::MessageDialog dialog(
 			_("You appear to be playing this game directly\n"
 			"from the CD. This is known to cause problems,\n"
@@ -527,7 +506,6 @@ bool Engine::isDataAndCDAudioReadFromSameCD() {
 		dialog.runModal();
 		return true;
 	}
-#endif // defined(WIN32)
 	return false;
 }
 


### PR DESCRIPTION
This moves the platform-specific logic out of `engine.cpp` and into the backends where it belongs.