### PR TITLE
GUI: TTS: strip GUI formatting before reading list item

### DIFF
--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -285,7 +285,7 @@ void ListWidget::handleMouseMoved(int x, int y, int button) {
 
 	if (item != -1) {
 		if(_lastRead != item) {
-			read(_list[item]);
+			read(stripGUIformatting(_list[item]));
 			_lastRead = item;
 		}
 	}


### PR DESCRIPTION
Fixes the GUI formatting being read when using TTS