### PR TITLE
SCUMM: HE: dump costume script

### DIFF
--- a/engines/scumm/akos.cpp
+++ b/engines/scumm/akos.cpp
@@ -52,71 +52,6 @@ struct AkosOffset {
 #include "common/pack-end.h"	// END STRUCT PACKING
 
 
-enum AkosOpcodes {
-	AKC_Return = 0xC001,
-	AKC_SetVar = 0xC010,
-	AKC_CmdQue3 = 0xC015,
-	AKC_C016 = 0xC016,
-	AKC_C017 = 0xC017,
-	AKC_C018 = 0xC018,
-	AKC_C019 = 0xC019,
-	AKC_ComplexChan = 0xC020,
-	AKC_C021 = 0xC021,
-	AKC_C022 = 0xC022,
-	AKC_ComplexChan2 = 0xC025,
-	AKC_Jump = 0xC030,
-	AKC_JumpIfSet = 0xC031,
-	AKC_AddVar = 0xC040,
-	AKC_C042 = 0xC042,
-	AKC_C044 = 0xC044,
-	AKC_C045 = 0xC045,
-	AKC_C046 = 0xC046,
-	AKC_C047 = 0xC047,
-	AKC_C048 = 0xC048,
-	AKC_Ignore = 0xC050,
-	AKC_IncVar = 0xC060,
-	AKC_CmdQue3Quick = 0xC061,
-	AKC_JumpStart = 0xC070,
-	AKC_JumpE = 0xC070,
-	AKC_JumpNE = 0xC071,
-	AKC_JumpL = 0xC072,
-	AKC_JumpLE = 0xC073,
-	AKC_JumpG = 0xC074,
-	AKC_JumpGE = 0xC075,
-	AKC_StartAnim = 0xC080,
-	AKC_StartVarAnim = 0xC081,
-	AKC_Random = 0xC082,
-	AKC_SetActorClip = 0xC083,
-	AKC_StartAnimInActor = 0xC084,
-	AKC_SetVarInActor = 0xC085,
-	AKC_HideActor = 0xC086,
-	AKC_SetDrawOffs = 0xC087,
-	AKC_JumpTable = 0xC088,
-	AKC_SoundStuff = 0xC089,
-	AKC_Flip = 0xC08A,
-	AKC_Cmd3 = 0xC08B,
-	AKC_Ignore3 = 0xC08C,
-	AKC_Ignore2 = 0xC08D,
-	AKC_C08E = 0xC08E,
-	AKC_SkipStart = 0xC090,
-	AKC_SkipE = 0xC090,
-	AKC_SkipNE = 0xC091,
-	AKC_SkipL = 0xC092,
-	AKC_SkipLE = 0xC093,
-	AKC_SkipG = 0xC094,
-	AKC_SkipGE = 0xC095,
-	AKC_ClearFlag = 0xC09F,
-	AKC_C0A0 = 0xC0A0,
-	AKC_C0A1 = 0xC0A1,
-	AKC_C0A2 = 0xC0A2,
-	AKC_C0A3 = 0xC0A3,
-	AKC_C0A4 = 0xC0A4,
-	AKC_C0A5 = 0xC0A5,
-	AKC_C0A6 = 0xC0A6,
-	AKC_C0A7 = 0xC0A7,
-	AKC_EndSeq = 0xC0FF
-};
-
 static bool akos_compare(int a, int b, byte cmd) {
 	switch (cmd) {
 	case 0:
@@ -1372,10 +1307,6 @@ bool ScummEngine_v6::akos_increaseAnims(const byte *akos, Actor *a) {
 	}
 	return result;
 }
-
-#define GW(o) ((int16)READ_LE_UINT16(aksq+curpos+(o)))
-#define GUW(o) READ_LE_UINT16(aksq+curpos+(o))
-#define GB(o) aksq[curpos+(o)]
 
 bool ScummEngine_v6::akos_increaseAnim(Actor *a, int chan, const byte *aksq, const uint16 *akfo, int numakfo) {
 	byte active;

--- a/engines/scumm/akos.h
+++ b/engines/scumm/akos.h
@@ -123,6 +123,75 @@ protected:
 	void markRectAsDirty(Common::Rect rect);
 };
 
+enum AkosOpcodes {
+	AKC_Return = 0xC001,
+	AKC_SetVar = 0xC010,
+	AKC_CmdQue3 = 0xC015,
+	AKC_C016 = 0xC016,
+	AKC_C017 = 0xC017,
+	AKC_C018 = 0xC018,
+	AKC_C019 = 0xC019,
+	AKC_ComplexChan = 0xC020,
+	AKC_C021 = 0xC021,
+	AKC_C022 = 0xC022,
+	AKC_ComplexChan2 = 0xC025,
+	AKC_Jump = 0xC030,
+	AKC_JumpIfSet = 0xC031,
+	AKC_AddVar = 0xC040,
+	AKC_C042 = 0xC042,
+	AKC_C044 = 0xC044,
+	AKC_C045 = 0xC045,
+	AKC_C046 = 0xC046,
+	AKC_C047 = 0xC047,
+	AKC_C048 = 0xC048,
+	AKC_Ignore = 0xC050,
+	AKC_IncVar = 0xC060,
+	AKC_CmdQue3Quick = 0xC061,
+	AKC_JumpStart = 0xC070,
+	AKC_JumpE = 0xC070,
+	AKC_JumpNE = 0xC071,
+	AKC_JumpL = 0xC072,
+	AKC_JumpLE = 0xC073,
+	AKC_JumpG = 0xC074,
+	AKC_JumpGE = 0xC075,
+	AKC_StartAnim = 0xC080,
+	AKC_StartVarAnim = 0xC081,
+	AKC_Random = 0xC082,
+	AKC_SetActorClip = 0xC083,
+	AKC_StartAnimInActor = 0xC084,
+	AKC_SetVarInActor = 0xC085,
+	AKC_HideActor = 0xC086,
+	AKC_SetDrawOffs = 0xC087,
+	AKC_JumpTable = 0xC088,
+	AKC_SoundStuff = 0xC089,
+	AKC_Flip = 0xC08A,
+	AKC_Cmd3 = 0xC08B,
+	AKC_Ignore3 = 0xC08C,
+	AKC_Ignore2 = 0xC08D,
+	AKC_C08E = 0xC08E,
+	AKC_SkipStart = 0xC090,
+	AKC_SkipE = 0xC090,
+	AKC_SkipNE = 0xC091,
+	AKC_SkipL = 0xC092,
+	AKC_SkipLE = 0xC093,
+	AKC_SkipG = 0xC094,
+	AKC_SkipGE = 0xC095,
+	AKC_ClearFlag = 0xC09F,
+	AKC_C0A0 = 0xC0A0,
+	AKC_C0A1 = 0xC0A1,
+	AKC_C0A2 = 0xC0A2,
+	AKC_C0A3 = 0xC0A3,
+	AKC_C0A4 = 0xC0A4,
+	AKC_C0A5 = 0xC0A5,
+	AKC_C0A6 = 0xC0A6,
+	AKC_C0A7 = 0xC0A7,
+	AKC_EndSeq = 0xC0FF
+};
+
+#define GW(o) ((int16)READ_LE_UINT16(aksq+curpos+(o)))
+#define GUW(o) READ_LE_UINT16(aksq+curpos+(o))
+#define GB(o) aksq[curpos+(o)]
+
 } // End of namespace Scumm
 
 #endif

--- a/engines/scumm/debugger.cpp
+++ b/engines/scumm/debugger.cpp
@@ -35,6 +35,8 @@
 #include "scumm/scumm.h"
 #include "scumm/sound.h"
 
+#include "scumm/akos.h"
+
 namespace Scumm {
 
 void debugC(int channel, const char *s, ...) {
@@ -77,6 +79,7 @@ ScummDebugger::ScummDebugger(ScummEngine *s)
 	registerCmd("object",    WRAP_METHOD(ScummDebugger, Cmd_Object));
 	registerCmd("script",    WRAP_METHOD(ScummDebugger, Cmd_Script));
 	registerCmd("scr",       WRAP_METHOD(ScummDebugger, Cmd_Script));
+	registerCmd("cosdump",   WRAP_METHOD(ScummDebugger, Cmd_Cosdump));
 	registerCmd("scripts",   WRAP_METHOD(ScummDebugger, Cmd_PrintScript));
 	registerCmd("importres", WRAP_METHOD(ScummDebugger, Cmd_ImportRes));
 
@@ -521,6 +524,329 @@ bool ScummDebugger::Cmd_PrintScript(int argc, const char **argv) {
 		}
 	}
 	debugPrintf("+-----------------------------------+\n");
+
+	return true;
+}
+
+bool ScummDebugger::Cmd_Cosdump(int argc, const char **argv) {
+	const byte *akos;
+	const byte *aksq;
+	uint32 curpos;
+	uint32 code;
+	uint32 aend;
+	int costume;
+	int count;
+	int i;
+
+	if (argc < 2) {
+		debugPrintf("Syntax: cosdump <num>\n");
+		return true;
+	}
+
+	costume = atoi(argv[1]);
+	if (costume >= _vm->_numCostumes) {
+		debugPrintf("Costume %d is out of range (range: 1 - %d)\n", costume, _vm->_numCostumes);
+		return true;
+	}
+
+	akos = _vm->getResourceAddress(rtCostume, costume);
+
+	curpos = 0;
+	aksq = _vm->findResourceData(MKTAG('A','K','S','Q'), akos);
+	if (aksq == nullptr) {
+		debugPrintf("Costume %d does not have AKSQ block\n", costume);
+		return true;
+	}
+	aend = READ_BE_UINT32(aksq - 4) - 8;
+	debugPrintf("DUMP COSTUME SCRIPT %d (size %d)\n", costume, aend);
+	while (curpos < aend) {
+		code = GB(0);
+		if (code & 0x80)
+			code = READ_BE_UINT16(aksq + curpos);
+		debugPrintf("[%04x] (%04x) ", curpos, code);
+		switch (code) {
+		case AKC_Return:
+			debugPrintf("RETURN\n");
+			curpos += 2;
+			break;
+		case AKC_SetVar:
+			debugPrintf("VAR[%d] = %d\n", GB(4), GW(2));
+			curpos += 5;
+			break;
+		case AKC_CmdQue3:
+			debugPrintf("START SOUND %d\n", GB(2));
+			curpos += 3;
+			break;
+		case AKC_C016:
+			debugPrintf("IF SOUND RUNNING VAR[%d] GOTO [%04x]\n", GB(4), GUW(2));
+			curpos += 5;
+			break;
+		case AKC_C017:
+			debugPrintf("IF NOT SOUND RUNNING VAR[%d] GOTO [%04x]\n", GB(4), GUW(2));
+			curpos += 5;
+			break;
+		case AKC_C018:
+			debugPrintf("IF SOUND RUNNING %d GOTO [%04x]\n", GB(4), GUW(2));
+			curpos += 5;
+			break;
+		case AKC_C019:
+			debugPrintf("IF NOT SOUND RUNNING %d GOTO [%04x]\n", GB(4), GUW(2));
+			curpos += 5;
+			break;
+		case AKC_ComplexChan:
+			debugPrintf("DRAW:\n");
+			curpos += 2;
+			count = GB(0);
+			curpos++;
+			for (i = 0; i < count; i++) {
+				code = GB(4);
+				if (code & 0x80) {
+					code = READ_BE_UINT16(aksq + curpos + 4);
+					debugPrintf("\tEXTENDED OFFSET %d POS %d,%d\n", code, GW(0), GW(2));
+					curpos++;
+				} else {
+					debugPrintf("\tOFFSET %d POS %d,%d\n", code, GW(0), GW(2));
+				}
+				curpos += 5;
+			}
+			break;
+		case AKC_C021:
+			debugPrintf("CONDITION MASK DRAW [%04x] [", curpos + GB(2));
+			count = GB(3);
+			for (i = 0; i < count; i++) {
+				if (i)
+					debugPrintf(", ");
+				debugPrintf("%d", GB(4));
+				curpos++;
+			}
+			debugPrintf("]\n");
+			curpos += 4;
+			count = GB(0);
+			curpos++;
+			for (i = 0; i < count; i++) {
+				code = GB(4);
+				if (code & 0x80) {
+					code = READ_BE_UINT16(aksq + curpos + 4);
+					debugPrintf("\tEXTENDED OFFSET %d POS %d,%d\n", code, GW(0), GW(2));
+					curpos++;
+				} else {
+					debugPrintf("\tOFFSET %d POS %d,%d\n", code, GW(0), GW(2));
+				}
+				curpos += 5;
+			}
+			break;
+		case AKC_C022:
+			debugPrintf("CONDITION MASK DRAW [%04x] [", curpos + GB(2));
+			count = GB(3);
+			for (i = 0; i < count; i++) {
+				if (i)
+					debugPrintf(", ");
+				debugPrintf("%d", GB(4));
+				curpos++;
+			}
+			debugPrintf("] AT OFFSET %d, %d:\n", GW(2), GW(4));
+			curpos += 6;
+			count = GB(0);
+			curpos++;
+			for (i = 0; i < count; i++) {
+				code = GB(4);
+				if (code & 0x80) {
+					code = READ_BE_UINT16(aksq + curpos + 4);
+					debugPrintf("\tEXTENDED OFFSET %d POS %d,%d\n", code, GW(0), GW(2));
+					curpos++;
+				} else {
+					debugPrintf("\tOFFSET %d POS %d,%d\n", code, GW(0), GW(2));
+				}
+				curpos += 5;
+			}
+			break;
+		case AKC_ComplexChan2:
+			debugPrintf("DRAW AT OFFSET %d, %d:\n", GW(2), GW(4));
+			curpos += 6;
+			count = GB(0);
+			curpos++;
+			for (i = 0; i < count; i++) {
+				code = GB(4);
+				if (code & 0x80) {
+					code = READ_BE_UINT16(aksq + curpos + 4);
+					debugPrintf("\tEXTENDED OFFSET %d POS %d,%d\n", code, GW(0), GW(2));
+					curpos++;
+				} else {
+					debugPrintf("\tOFFSET %d POS %d,%d\n", code, GW(0), GW(2));
+				}
+				curpos += 5;
+			}
+			break;
+		case AKC_Jump:
+			debugPrintf("GOTO [%04x]\n", GUW(2));
+			curpos += 4;
+			break;
+		case AKC_JumpIfSet:
+			debugPrintf("IF VAR[%d] GOTO [%04x]\n", GB(4), GUW(2));
+			curpos += 5;
+			break;
+		case AKC_AddVar:
+			debugPrintf("VAR[%d] += %d\n", GB(4), GW(2));
+			curpos += 5;
+			break;
+		case AKC_C042:
+			debugPrintf("START SOUND %d SOFT\n", GB(2));
+			curpos += 3;
+			break;
+		case AKC_C044:
+			debugPrintf("START SOUND VAR[%d] SOFT\n", GB(2));
+			curpos += 3;
+			break;
+		case AKC_C045:
+			debugPrintf("USER CONDITION %d = VAR[%d] GOTO [%04x] \n", GB(3), GB(4), GB(2));
+			curpos += 5;
+			break;
+		case AKC_C046:
+			debugPrintf("VAR[%d] = USER CONDITION %d GOTO [%04x] \n", GB(4), GB(3), GB(2));
+			curpos += 5;
+			break;
+		case AKC_C047:
+			debugPrintf("TALK CONDITION %d SET GOTO [%04x] \n", GB(3), GB(2));
+			curpos += 4;
+			break;
+		case AKC_C048:
+			debugPrintf("VAR[%d] = TALK CONDITION %d GOTO [%04x] \n", GB(4), GB(3), GB(2));
+			curpos += 5;
+			break;
+		case AKC_Ignore:
+			debugPrintf("IGNORE %d\n", GB(2));
+			curpos += 3;
+			break;
+		case AKC_IncVar:
+			debugPrintf("VAR[0]++\n");
+			curpos += 2;
+			break;
+		case AKC_CmdQue3Quick:
+			debugPrintf("START SOUND QUICK\n");
+			curpos += 2;
+			break;
+		case AKC_JumpE:
+			debugPrintf("IF VAR[%d] == %d GOTO [%04x]\n", GB(4), GW(5), GUW(2));
+			curpos += 7;
+			break;
+		case AKC_JumpNE:
+			debugPrintf("IF VAR[%d] != %d GOTO [%04x]\n", GB(4), GW(5), GUW(2));
+			curpos += 7;
+			break;
+		case AKC_JumpL:
+			debugPrintf("IF VAR[%d] < %d GOTO [%04x]\n", GB(4), GW(5), GUW(2));
+			curpos += 7;
+			break;
+		case AKC_JumpLE:
+			debugPrintf("IF VAR[%d] <= %d GOTO [%04x]\n", GB(4), GW(5), GUW(2));
+			curpos += 7;
+			break;
+		case AKC_JumpG:
+			debugPrintf("IF VAR[%d] > %d GOTO [%04x]\n", GB(4), GW(5), GUW(2));
+			curpos += 7;
+			break;
+		case AKC_JumpGE:
+			debugPrintf("IF VAR[%d] >= %d GOTO [%04x]\n", GB(4), GW(5), GUW(2));
+			curpos += 7;
+			break;
+		case AKC_StartAnim:
+			debugPrintf("START ANIMATION %d\n", GB(2));
+			curpos += 3;
+			break;
+		case AKC_StartVarAnim:
+			debugPrintf("START ANIMATION VAR[%d]\n", GB(2));
+			curpos += 3;
+			break;
+		case AKC_Random:
+			debugPrintf("VAR[%d] = RANDOM BETWEEN %d AND %d\n", GB(6), GW(2), GW(4));
+			curpos += 7;
+			break;
+		case AKC_SetActorClip:
+			debugPrintf("ZCLIP %d\n", GB(2));
+			curpos += 3;
+			break;
+		case AKC_StartAnimInActor:
+			debugPrintf("START ANIMATION ACTOR VAR[%d] VAR[%d]\n", GB(2), GB(3));
+			curpos += 4;
+			break;
+		case AKC_SetVarInActor:
+			debugPrintf("ACTOR VAR[%d] VAR[%d] = %d\n", GB(2), GB(3), GW(4));
+			curpos += 6;
+			break;
+		case AKC_HideActor:
+			debugPrintf("DESTROY ACTOR\n");
+			curpos += 2;
+			break;
+		case AKC_SetDrawOffs:
+			debugPrintf("SET DRAW OFFSETS %d %d\n", GW(2), GW(4));
+			curpos += 6;
+			break;
+		case AKC_JumpTable:
+			debugPrintf("GOTO OFFSET AT VAR[%d]\n", GB(2));
+			curpos += 3;
+			break;
+		// case AKC_SoundStuff:
+		// 	break;
+		// case AKC_Flip:
+		// 	break;
+		// case AKC_Cmd3:
+		// 	break;
+		// case AKC_Ignore3:
+		// 	break;
+		case AKC_Ignore2:
+			debugPrintf("START SOUND VAR[%d]\n", GB(2));
+			curpos += 3;
+			break;
+		// case AKC_C08E:
+		// 	break;
+		// case AKC_SkipE:
+		// 	break;
+		// case AKC_SkipNE:
+		// 	break;
+		// case AKC_SkipL:
+		// 	break;
+		// case AKC_SkipLE:
+		// 	break;
+		// case AKC_SkipG:
+		// 	break;
+		// case AKC_SkipGE:
+		// 	break;
+		// case AKC_ClearFlag:
+		// 	break;
+		case AKC_C0A0:
+			debugPrintf("START TALK %d {%d}\n", GB(2), GB(3));
+			curpos += 4;
+			break;
+		case AKC_C0A1:
+			debugPrintf("IF ACTOR TALKING GOTO [%04x]\n", GUW(2));
+			curpos += 4;
+			break;
+		case AKC_C0A2:
+			debugPrintf("IF NOT ACTOR TALKING GOTO [%04x]\n", GUW(2));
+			curpos += 4;
+			break;
+		case AKC_C0A3:
+			debugPrintf("START TALK VAR[%d]\n", GB(2));
+			curpos += 3;
+			break;
+		// case AKC_C0A4:
+		// 	break;
+		// case AKC_C0A5:
+		// 	break;
+		// case AKC_C0A6:
+		// 	break;
+		// case AKC_C0A7:
+		// 	break;
+		case AKC_EndSeq:
+			debugPrintf("STOP\n");
+			curpos += 2;
+			break;
+		default:
+			warning("DEFAULT OP, breaking...\n");
+			return true;
+			break;
+		}
+	}
 
 	return true;
 }

--- a/engines/scumm/debugger.h
+++ b/engines/scumm/debugger.h
@@ -65,6 +65,7 @@ private:
 	bool Cmd_Show(int argc, const char **argv);
 	bool Cmd_Hide(int argc, const char **argv);
 
+	bool Cmd_Cosdump(int argc, const char **argv);
 	bool Cmd_IMuse(int argc, const char **argv);
 	bool Cmd_DiMuse(int argc, const char **argv);
 


### PR DESCRIPTION
This adds debug utility to dump the AKOS script sequence.
It was tested on all costumes from Freddi Fish 4 and some sampled from Freddi Fish 3.

to use:
activate the debugger and type:
```
cosdump <num>
```
hope it will be useful someday