### PR TITLE
DOCS: MAN: Various small improvements to the manual page

### DIFF
--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -1,4 +1,4 @@
-.Dd August 24, 2022
+.Dd August 29, 2022
 .Dt SCUMMVM 6
 .Os
 .Sh NAME
@@ -305,15 +305,10 @@ If
 is passed, fetch the MD5 length automatically, overriding
 .Fl -md5-length .
 .It Fl -md5mac
-Show MD5 hash for both the resource fork and data fork of the
-Macintosh file given by
-.Fl -md5-path= Ns Ar PATH .
-If
-.Fl -md5-length= Ns Ar NUM
-is passed, then show the MD5 hash of the first (if positive)
-or last (if negative)
-.Ar NUM
-bytes of each fork.
+Like
+.Fl -md5 ,
+but for old Macintosh files.
+Show MD5 hash for both the resource fork and data fork of the file.
 .It Fl -midi-gain= Ns Ar NUM
 Set the gain for MIDI playback, 0\(en1000 (default: 100).
 Only supported by some MIDI drivers.

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -99,7 +99,7 @@ Use alternate path for log file.
 .It Fl m | -music-volume= Ns Ar NUM
 Set the music volume, 0-255 (default: 192).
 .It Fl n | -subtitles
-Enable subtitles (use with games that have voice).
+Enable subtitles (for games that have voice).
 .It Fl p | -path= Ns Ar PATH
 Set the path to where the game is installed.
 .It Fl q | -language= Ns Ar LANG
@@ -180,9 +180,9 @@ Turkish
 Ukrainian
 .El
 .It Fl r | -speech-volume Ns Ar NUM
-Set the voice volume to, 0-255 (default: 192).
+Set the voice volume, 0-255 (default: 192).
 .It Fl s | -sfx-volume= Ns Ar NUM
-Set the sfx volume to, 0-255 (default: 192).
+Set the SFX volume, 0-255 (default: 192).
 .It Fl t | -list-targets
 Display list of user-configured game targets, and exit.
 .It Fl u | -dump-scripts
@@ -507,7 +507,7 @@ XDG environment variables take precedence, if defined.
 Configuration file on macOS.
 .El
 .Sh EXAMPLES
-Running the builtin game launcher:
+Running the built-in game launcher:
 .Pp
 .Dl $ scummvm
 .Pp

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -232,7 +232,8 @@ Use
 to specify a directory.
 .It Fl -dump-midi
 Dump MIDI events to
-.Pa dump.mid ,
+.Pa dump.mid
+(overwriting it),
 until quitting from game.
 .It Fl -enable-gs
 Enable patch mappings to emulate an MT-32 on a Roland GS device

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -446,7 +446,7 @@ Set music tempo (in percent, 50-200) for SCUMM games (default: 100).
 .It Fl -themepath= Ns Ar PATH
 Set the path to GUI themes.
 .It Fl -window-size= Ns Ar W,H
-Set the ScummVM window size to the specified dimensions (OpenGL only).
+Set the window size to the specified dimensions (OpenGL only).
 .El
 .Sh INGAME HOTKEYS
 .Bl -tag -width 13m

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -291,7 +291,8 @@ Show MD5 hash of the file given by
 .Fl -md5-path= Ns Ar PATH .
 If
 .Fl -md5-length= Ns Ar NUM
-is passed, then show the MD5 hash of the first or last
+is passed, then show the MD5 hash of the first (if positive)
+or last (if negative)
 .Ar NUM
 bytes of the file given by
 .Ar PATH .
@@ -305,7 +306,8 @@ Macintosh file given by
 .Fl -md5-path= Ns Ar PATH .
 If
 .Fl -md5-length= Ns Ar NUM
-is passed, then show the MD5 hash of the first or last
+is passed, then show the MD5 hash of the first (if positive)
+or last (if negative)
 .Ar NUM
 bytes of each fork.
 .It Fl -midi-gain= Ns Ar NUM

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -498,8 +498,9 @@ Override the default save path (POSIX systems).
 .El
 .Sh FILES
 .Bl -tag -width Ds
-.It Pa $HOME/.scummvmrc
-Configuration file on UNIX.
+.It Pa $HOME/.config/scummvm/scummvm.ini
+Configuration file on most Unix systems.
+XDG environment variables take precedence, if defined.
 .It Pa "$HOME/Library/Preferences/ScummVM Preferences"
 Configuration file on macOS.
 .El

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -41,7 +41,10 @@ is added.
 See also
 .Fl -detect .
 .It Fl b | -boot-param= Ns Ar NUM
-Pass number to the boot script (boot param).
+Pass number
+.Ar NUM
+to the boot script,
+for games supporting this feature.
 .It Fl c | -config= Ns Ar CONFIG
 Use alternate configuration file.
 .It Fl d | -debuglevel= Ns Ar NUM

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -20,10 +20,6 @@ For example,
 for Monkey Island.
 This can be either a built-in gameid, or a user configured target.
 .Sh OPTIONS
-More details for the following options can be
-found at
-.Lk https://docs.scummvm.org .
-.Pp
 The meaning of most long options (that is, those options starting with a
 double-dash) can be inverted by prefixing them with
 .Cm no- .
@@ -522,8 +518,7 @@ Running the Italian version of Maniac Mansion fullscreen:
 .Pp
 .Dl $ scummvm -q it -f scumm:maniac
 .Sh SEE ALSO
-.Lk https://docs.scummvm.org ,
-.Lk https://www.scummvm.org .
+.Lk https://docs.scummvm.org
 .Sh AUTHORS
 ScummVM was written by the ScummVM team.
 See

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -245,7 +245,8 @@ or
 .Fl -list-all-games ,
 only list games for this engine.
 .It Fl -engine-speed= Ns Ar NUM
-Set frame per second limit (0-100), 0 = no limit (default: 60).
+Set frame per second limit (0-100) for 3D games,
+0 = no limit (default: 60).
 .It Fl -extrapath= Ns Ar PATH
 Set the extra path to additional game and ScummVM data.
 .It Fl -filtering
@@ -427,7 +428,7 @@ Select graphics scaler
 .It Fl -screenshotpath= Ns Ar PATH
 Specify path where screenshot files are created.
 .It Fl -show-fps
-Display FPS in 3D games.
+Display FPS info in 3D games.
 .It Fl -soundfont= Ns Ar FILE
 Select the SoundFont for MIDI playback (only supported by some MIDI drivers).
 .It Fl -start-movie= Ns Ar NAME Ns Ar @NUM

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -27,6 +27,7 @@ For example,
 .Fl -no-aspect-ratio
 will turn aspect ratio correction off.
 This is useful if you want to override a setting in the configuration file.
+.\" Note: sorted alphabetically, since that's the mdoc convention
 .Bl -tag -width Ds
 .It Fl a | -add
 Add all games from current or specified (with
@@ -108,7 +109,7 @@ Set the path to where the game is installed.
 .It Fl q | -language= Ns Ar LANG
 Select game's language:
 .Bl -tag -width auto -compact
-.\" Sorted by English name of language
+.\" From common/language.cpp, sorted by English name of language
 .It Ar ar
 Arabic (Modern Standard)
 .It Ar ca
@@ -332,6 +333,7 @@ Select AdLib (OPL) emulator
 Set output sample rate in Hz (e.g. 22050).
 .It Fl -platform= Ns Ar PLATFORM
 Specify platform of game
+.\" From common/platform.cpp
 .Po
 .Ar 2gs ,
 .Ar 3do ,
@@ -378,6 +380,7 @@ or
 recurse down all subdirectories.
 .It Fl -render-mode= Ns Ar MODE
 Enable additional render modes
+.\" From common/gui_options.cpp
 .Po
 .Ar 2gs ,
 .Ar amiga ,
@@ -431,6 +434,7 @@ Start movie at frame for Director.
 Either argument can be specified without the other.
 .It Fl -stretch-mode= Ns Ar MODE
 Select stretch mode
+.\" From backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
 .Po
 .Ar center ,
 .Ar even-pixels ,

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -69,7 +69,9 @@ Internal PCjr emulation.
 .It Ar pcspk
 Internal PC Speaker emulation.
 .It Ar seq
-Use /dev/sequencer for MIDI, *nix users.
+Use
+.Pa /dev/sequencer
+for MIDI (some Unix systems).
 .It Ar sndio
 Use sndio MIDI.
 .It Ar timidity

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -183,7 +183,7 @@ Turkish
 .It Ar uk
 Ukrainian
 .El
-.It Fl r | -speech-volume Ns Ar NUM
+.It Fl r | -speech-volume= Ns Ar NUM
 Set the voice volume, 0\(en255 (default: 192).
 .It Fl s | -sfx-volume= Ns Ar NUM
 Set the SFX volume, 0\(en255 (default: 192).

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -476,7 +476,8 @@ Toggle full screen/windowed
 .It Alt-s
 Make a screenshot (SDL backend only)
 .It Ctrl-F7
-Open virtual keyboard (if enabled). This can also be triggered by a long press
+Open virtual keyboard (if available).
+This can also be triggered by a long press
 of the middle mouse button or wheel.
 .El
 .Pp

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -29,17 +29,17 @@ will turn aspect ratio correction off.
 This is useful if you want to override a setting in the configuration file.
 .Bl -tag -width Ds
 .It Fl a | -add
-Add all games from current or specified directory.
+Add all games from current or specified (with
+.Fl -path= Ns Ar PATH )
+directory.
 If
 .Fl -game= Ns Ar ID
 is passed, only the game with id
 .Ar ID
 is added.
+.Pp
 See also
 .Fl -detect .
-Use
-.Fl -path= Ns Ar PATH
-to specify a directory.
 .It Fl b | -boot-param= Ns Ar NUM
 Pass number to the boot script (boot param).
 .It Fl c | -config= Ns Ar CONFIG

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -15,10 +15,10 @@ role-playing games based on a variety of game engines.
 .Pp
 .Ar GAME
 is a short name of game to load.
-For example,
-.Em scumm:monkey
-for Monkey Island.
-This can be either a built-in gameid, or a user configured target.
+This can be either a built-in gameid (as given by
+.Fl -list-games ) ,
+or a user-configured target (as given by
+.Fl -list-targets ) .
 .Sh OPTIONS
 The meaning of most long options (that is, those options starting with a
 double-dash) can be inverted by prefixing them with

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -453,6 +453,7 @@ Set the path to GUI themes.
 Set the window size to the specified dimensions (OpenGL only).
 .El
 .Sh INGAME HOTKEYS
+.\" From doc/docportal/use_scummvm/keyboard_shortcuts.rst
 .Bl -tag -width 13m
 .It Ctrl-F5
 Display the Global Menu
@@ -477,13 +478,15 @@ Toggle graphics filtering
 .It Ctrl-Alt s
 Cycle through scaling modes
 .It Alt-Enter
-Toggle full screen/windowed
+Toggle full screen/windowed mode
 .It Alt-s
 Take a screenshot
 .It Ctrl-F7
 Open virtual keyboard (if available).
 This can also be triggered by a long press
-of the middle mouse button or wheel.
+of the middle mouse button or wheel
+.It Ctrl-Alt d
+Open the ScummVM debugger
 .El
 .Pp
 There are many more game-specific hotkeys.

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -206,8 +206,10 @@ one.
 Use
 .Fl -path= Ns Ar PATH
 to specify a directory.
-.It Fl -cdrom= Ns Ar NUM
-CD drive to play CD audio from (default: 0 = first drive).
+.It Fl -cdrom= Ns Ar DRIVE
+Set the drive to play CD audio from; can either be
+a drive, path, or numeric index
+(default: 0 = best choice drive).
 .It Fl -copy-protection
 Enable copy protection in games, when ScummVM disables it by default.
 .It Fl -dirtyrects

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -184,7 +184,7 @@ Set the voice volume to, 0-255 (default: 192).
 .It Fl s | -sfx-volume= Ns Ar NUM
 Set the sfx volume to, 0-255 (default: 192).
 .It Fl t | -list-targets
-Display list of configured targets and exit.
+Display list of user-configured game targets, and exit.
 .It Fl u | -dump-scripts
 Enable script dumping if a directory called
 .Pa dumps
@@ -220,7 +220,7 @@ Enable engine specific debug flags (separated by commas).
 Start demo mode of Maniac Mansion or The 7th Guest.
 .It Fl -detect
 Display a list of games with their ID from current or specified directory
-without adding it to the config.
+without adding it to the configuration file.
 Use
 .Fl -path= Ns Ar PATH
 to specify a directory.
@@ -301,7 +301,7 @@ is passed, fetch the MD5 length automatically, overriding
 .Fl -md5-length .
 .It Fl -md5mac
 Show MD5 hash for both the resource fork and data fork of the
-mac file given by
+Macintosh file given by
 .Fl -md5-path= Ns Ar PATH .
 If
 .Fl -md5-length= Ns Ar NUM
@@ -427,7 +427,7 @@ Display FPS in 3D games.
 Select the SoundFont for MIDI playback (only supported by some MIDI drivers).
 .It Fl -start-movie= Ns Ar NAME Ns Ar @NUM
 Start movie at frame for Director.
-Either can be specified without the other.
+Either argument can be specified without the other.
 .It Fl -stretch-mode= Ns Ar MODE
 Select stretch mode
 .Po

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -517,11 +517,15 @@ Running Day of the Tentacle specifying the path:
 .Pp
 .Dl $ scummvm -p /usr/local/share/games/tentacle scumm:tentacle
 .Pp
-Running The Dig with advmame2x filter with subtitles:
+Running The Dig with advmame2x filter and subtitles
+(with the
+.Ar dig-steam
+target already defined in the configuration file):
 .Pp
-.Dl $ scummvm --scaler=advmame --scale-factor=2 -n scumm:dig
+.Dl $ scummvm --scaler=advmame --scale-factor=2 -n dig-steam
 .Pp
-Running the Italian version of Maniac Mansion fullscreen:
+Running the Italian version of Maniac Mansion fullscreen,
+from the content of the current directory:
 .Pp
 .Dl $ scummvm -q it -f scumm:maniac
 .Sh SEE ALSO

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -402,9 +402,9 @@ Enable additional render modes
 .It Fl -renderer= Ns Ar RENDERER
 Select 3D renderer
 .Po
-.Ar software ,
 .Ar opengl ,
-.Ar opengl_shaders
+.Ar opengl_shaders ,
+.Ar software
 .Pc .
 .It Fl -savepath= Ns Ar PATH
 Specify where saved games are stored.

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -54,9 +54,9 @@ Internal AdLib emulation.
 .It Ar alsa
 Output using ALSA sequencer device.
 .It Ar core
-CoreAudio sound, for macOS users.
+CoreAudio sound (macOS).
 .It Ar coremidi
-CoreMIDI sound, for macOS users.
+CoreMIDI sound (macOS).
 .It Ar fluidsynth
 FluidSynth MIDI emulation.
 .It Ar mt32
@@ -80,7 +80,7 @@ Connect to TiMidity++ MIDI server.
 Internal FM-TOWNS YM2612 emulation (only usable in SCUMM FM-TOWNS games).
 Use only if you have a hardware MIDI synthesizer.
 .It Ar windows
-Windows built in MIDI sequencer for Windows users.
+Windows built-in MIDI sequencer (Windows).
 .El
 .It Fl F | -no-fullscreen
 Force windowed mode.

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -266,13 +266,13 @@ Display list of all detection engines and exit.
 Display list of all detected games and exit.
 .It Fl -list-audio-devices
 List all available audio devices.
-.It Fl -list-debugflags= Ns Ar engine
-Display list of engine specified debugflags.
-if
-.Ar engine= Ns global
-or
-.Ar engine
-is not specified, then it will list global debugflags.
+.It Fl -list-debugflags= Ns Ar ENGINE
+Display list of engine specified debugflags, and exit.
+If the
+.Ar ENGINE
+argument is
+.Dq global ,
+or if it is not specified, list global debugflags.
 .It Fl -list-engines
 Display list of supported engines and exit.
 .It Fl -list-saves

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -234,7 +234,8 @@ Dump MIDI events to
 .Pa dump.mid ,
 until quitting from game.
 .It Fl -enable-gs
-Enable Roland GS mode for MIDI playback.
+Enable patch mappings to emulate an MT-32 on a Roland GS device
+for MIDI playback.
 .It Fl -engine= Ns Ar ID
 In combination with
 .Fl -list-games

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -445,7 +445,7 @@ Select stretch mode
 .Ar stretch
 .Pc .
 .It Fl -talkspeed= Ns Ar NUM
-Set talk delay for SCUMM games, or talk speed for other games (default: 60).
+Set talk delay for SCUMM games, or talk speed for other games.
 .It Fl -tempo= Ns Ar NUM
 Set music tempo (in percent, 50-200) for SCUMM games (default: 100).
 .It Fl -themepath= Ns Ar PATH

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -259,13 +259,13 @@ Enable joystick input (default: 0 = first joystick).
 .It Fl -iconspath= Ns Ar PATH
 Set the path to additional icons for the launcher grid view.
 .It Fl -list-all-debugflags
-Display list of all engine specified debugflags.
+Display list of all engine debugflags, and exit.
 .It Fl -list-all-engines
 Display list of all detection engines, and exit.
 .It Fl -list-all-games
 Display list of all detected games, and exit.
 .It Fl -list-audio-devices
-List all available audio devices.
+List all available audio devices, and exit.
 .It Fl -list-debugflags= Ns Ar ENGINE
 Display list of engine specified debugflags, and exit.
 If the
@@ -278,7 +278,7 @@ Display list of supported engines, and exit.
 .It Fl -list-saves
 Display a list of saved games for the target specified with
 .Fl -game= Ns Ar TARGET ,
-or all targets if none is specified.
+or all targets if none is specified, and exit.
 .It Fl -list-themes
 Display list of all usable GUI themes, and exit.
 .It Fl -md5

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -473,7 +473,7 @@ Cycle through scaling modes
 .It Alt-Enter
 Toggle full screen/windowed
 .It Alt-s
-Make a screenshot (SDL backend only)
+Take a screenshot
 .It Ctrl-F7
 Open virtual keyboard (if available).
 This can also be triggered by a long press

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -1,17 +1,17 @@
-.Dd July 20, 2022
+.Dd August 24, 2022
 .Dt SCUMMVM 6
 .Os
 .Sh NAME
 .Nm scummvm
-.Nd graphic adventure game interpreter
+.Nd adventure and role-playing game interpreter
 .Sh SYNOPSIS
 .Nm scummvm
 .Op Ar OPTIONS
 .Op Ar GAME
 .Sh DESCRIPTION
 .Nm
-is an interpreter that will play graphic adventure games
-based on a variety of game engines.
+is an interpreter that will play numerous adventure and
+role-playing games based on a variety of game engines.
 .Pp
 .Ar GAME
 is a short name of game to load.

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -77,7 +77,7 @@ Use sndio MIDI.
 .It Ar timidity
 Connect to TiMidity++ MIDI server.
 .It Ar towns
-Internal FM-TOWNS YM2612 emulation (only usable in SCUMM FM-TOWNS games)
+Internal FM-TOWNS YM2612 emulation (only usable in SCUMM FM-TOWNS games).
 Use only if you have a hardware MIDI synthesizer.
 .It Ar windows
 Windows built in MIDI sequencer for Windows users.
@@ -87,11 +87,11 @@ Force windowed mode.
 .It Fl f | -fullscreen
 Force full-screen mode.
 .It Fl g | -gfx-mode= Ns Ar MODE
-Select graphics mode:
+Select graphics mode
 .Po
 .Ar opengl ,
 .Ar surfacesdl
-.Pc
+.Pc .
 .It Fl h | -help
 Display a brief help text and exit.
 .It Fl l | -logfile= Ns Ar PATH
@@ -237,7 +237,7 @@ or
 .Fl -list-all-games
 only lists games for this engine.
 .It Fl -engine-speed= Ns Ar NUM
-Set frame per second limit (0 - 100), 0 = no limit (default: 60).
+Set frame per second limit (0-100), 0 = no limit (default: 60).
 .It Fl -extrapath= Ns Ar PATH
 Extra path to additional game data.
 .It Fl -filtering
@@ -310,8 +310,7 @@ is passed, then show the MD5 hash of the first or last
 bytes of each fork.
 .It Fl -midi-gain= Ns Ar NUM
 Set the gain for MIDI playback, 0-1000 (default: 100).
-.br
-(only supported by some MIDI drivers)
+Only supported by some MIDI drivers.
 .It Fl -multi-midi
 Enable combination of AdLib and native MIDI.
 .It Fl -native-mt32

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -32,7 +32,7 @@ This is useful if you want to override a setting in the configuration file.
 Add all games from current or specified directory.
 If
 .Fl -game= Ns Ar ID
-is passed only the game with id
+is passed, only the game with id
 .Ar ID
 is added.
 See also
@@ -93,7 +93,7 @@ Select graphics mode
 .Ar surfacesdl
 .Pc .
 .It Fl h | -help
-Display a brief help text and exit.
+Display a brief help text, and exit.
 .It Fl l | -logfile= Ns Ar PATH
 Use alternate path for log file.
 .It Fl m | -music-volume= Ns Ar NUM
@@ -190,19 +190,19 @@ Enable script dumping if a directory called
 .Pa dumps
 exists in the current directory.
 .It Fl v | -version
-Display ScummVM version information and exit.
+Display ScummVM version information, and exit.
 .It Fl x | -save-slot= Ns Ar [SLOT]
 Set the saved game slot to load (default: autosave).
 .It Fl z | -list-games
-Display list of supported games and exit.
+Display list of supported games, and exit.
 .It Fl -alt-intro
 Use alternative intro for CD versions of Beneath a Steel Sky and Flight of the
 Amazon Queen.
 .It Fl -aspect-ratio
 Enable aspect ratio correction.
 .It Fl -auto-detect
-Display a list of games from current or specified directory and start the first
-one.
+Display a list of games from current or specified directory,
+and start the first one.
 Use
 .Fl -path= Ns Ar PATH
 to specify a directory.
@@ -236,8 +236,8 @@ Enable Roland GS mode for MIDI playback.
 In combination with
 .Fl -list-games
 or
-.Fl -list-all-games
-only lists games for this engine.
+.Fl -list-all-games ,
+only list games for this engine.
 .It Fl -engine-speed= Ns Ar NUM
 Set frame per second limit (0-100), 0 = no limit (default: 60).
 .It Fl -extrapath= Ns Ar PATH
@@ -248,8 +248,8 @@ Force filtered graphics mode.
 In combination with
 .Fl -add
 or
-.Fl -detect
-only adds or attempts to detect the game with id
+.Fl -detect ,
+only add or attempt to detect the game with id
 .Ar ID .
 .It Fl -gui-theme= Ns Ar THEME
 Select a GUI theme, as given by
@@ -261,9 +261,9 @@ Set the path to additional icons for the launcher grid view.
 .It Fl -list-all-debugflags
 Display list of all engine specified debugflags.
 .It Fl -list-all-engines
-Display list of all detection engines and exit.
+Display list of all detection engines, and exit.
 .It Fl -list-all-games
-Display list of all detected games and exit.
+Display list of all detected games, and exit.
 .It Fl -list-audio-devices
 List all available audio devices.
 .It Fl -list-debugflags= Ns Ar ENGINE
@@ -274,13 +274,13 @@ argument is
 .Dq global ,
 or if it is not specified, list global debugflags.
 .It Fl -list-engines
-Display list of supported engines and exit.
+Display list of supported engines, and exit.
 .It Fl -list-saves
 Display a list of saved games for the target specified with
-.Fl -game= Ns Ar TARGET
+.Fl -game= Ns Ar TARGET ,
 or all targets if none is specified.
 .It Fl -list-themes
-Display list of all usable GUI themes and exit.
+Display list of all usable GUI themes, and exit.
 .It Fl -md5
 Show MD5 hash of the file given by
 .Fl -md5-path= Ns Ar PATH .
@@ -370,7 +370,7 @@ Specify platform of game
 In combination with
 .Fl -add
 or
-.Fl -detect
+.Fl -detect ,
 recurse down all subdirectories.
 .It Fl -render-mode= Ns Ar MODE
 Enable additional render modes
@@ -511,7 +511,7 @@ Running the builtin game launcher:
 .Pp
 .Dl $ scummvm
 .Pp
-Running Day of the Tentacle specifying the path:
+Running Day of the Tentacle, specifying the path:
 .Pp
 .Dl $ scummvm -p /usr/local/share/games/tentacle scumm:tentacle
 .Pp

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -279,13 +279,6 @@ Display list of supported engines and exit.
 Display a list of saved games for the target specified with
 .Fl -game= Ns Ar TARGET
 or all targets if none is specified.
-.Fl -game= Ns Ar ID
-In combination with
-.Fl -add
-or
-.Fl -detect
-only adds or attempts to detect the game with id
-.Ar ID .
 .It Fl -list-themes
 Display list of all usable GUI themes and exit.
 .It Fl -md5

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -102,7 +102,7 @@ Display a brief help text, and exit.
 Use alternate path for log file.
 .It Fl m | -music-volume= Ns Ar NUM
 Set the music volume, 0\(en255 (default: 192).
-.It Fl n | -subtitles
+.It Fl n | - Ns Oo Cm no- Oc Ns Cm subtitles
 Enable subtitles (for games that have voice).
 .It Fl p | -path= Ns Ar PATH
 Set the path to where the game is installed.
@@ -199,11 +199,11 @@ Display ScummVM version information, and exit.
 Set the saved game slot to load (default: autosave).
 .It Fl z | -list-games
 Display list of supported games, and exit.
-.It Fl -alt-intro
-Use alternative intro for CD versions of Beneath a Steel Sky and Flight of the
-Amazon Queen.
-.It Fl -aspect-ratio
-Enable aspect ratio correction.
+.It Fl - Ns Oo Cm no- Oc Ns Cm alt-intro
+Toggle alternative intro for CD versions of Beneath a Steel Sky and
+Flight of the Amazon Queen (default: disabled).
+.It Fl - Ns Oo Cm no- Oc Ns Cm aspect-ratio
+Toggle aspect ratio correction.
 .It Fl -auto-detect
 Display a list of games from current or specified directory,
 and start the first one.
@@ -214,16 +214,16 @@ to specify a directory.
 Set the drive to play CD audio from; can either be
 a drive, path, or numeric index
 (default: 0 = best choice drive).
-.It Fl -copy-protection
+.It Fl - Ns Oo Cm no- Oc Ns Cm copy-protection
 Enable copy protection in games, when ScummVM disables it by default.
-.It Fl -dirtyrects
-Enable dirty rectangles optimisation in software renderer (default: enabled).
+.It Fl - Ns Oo Cm no- Oc Ns Cm dirtyrects
+Toggle dirty rectangles optimisation in software renderer (default: enabled).
 .It Fl -debug-channels-only
 Show only the specified debug channels.
 .It Fl -debugflags= Ns Ar FLAGS
 Enable engine specific debug flags (separated by commas).
-.It Fl -demo-mode
-Start demo mode of Maniac Mansion or The 7th Guest.
+.It Fl - Ns Oo Cm no- Oc Ns Cm demo-mode
+Toggle demo mode of Maniac Mansion or The 7th Guest (default: disabled).
 .It Fl -detect
 Display a list of games with their ID from current or specified directory
 without adding it to the configuration file.
@@ -249,8 +249,8 @@ Set frame per second limit (0\(en100) for 3D games,
 0 = no limit (default: 60).
 .It Fl -extrapath= Ns Ar PATH
 Set the extra path to additional game and ScummVM data.
-.It Fl -filtering
-Force filtered graphics mode.
+.It Fl - Ns Oo Cm no- Oc Ns Cm filtering
+Force filtered/unfiltered graphics mode.
 .It Fl -game= Ns Ar ID
 In combination with
 .Fl -add
@@ -320,8 +320,6 @@ Enable combination of AdLib and native MIDI.
 .It Fl -native-mt32
 Tell ScummVM that the MIDI device is an actual Roland MT-32 or compatible device.
 This disables any GM emulation.
-.It Fl -no-filtering
-Force unfiltered graphics mode.
 .It Fl -opl-driver= Ns Ar DRIVER
 Select AdLib (OPL) emulator
 .Po
@@ -374,12 +372,12 @@ Specify platform of game
 .Ar xbox ,
 .Ar zx
 .Pc .
-.It Fl -recursive
+.It Fl - Ns Oo Cm no- Oc Ns Cm recursive
 In combination with
 .Fl -add
 or
 .Fl -detect ,
-recurse down all subdirectories.
+recurse down all subdirectories (default: disabled).
 .It Fl -render-mode= Ns Ar MODE
 Enable additional render modes
 .\" From common/gui_options.cpp
@@ -427,8 +425,8 @@ Select graphics scaler
 .Pc .
 .It Fl -screenshotpath= Ns Ar PATH
 Specify path where screenshot files are created.
-.It Fl -show-fps
-Display FPS info in 3D games.
+.It Fl - Ns Oo Cm no- Oc Ns Cm show-fps
+Toggle FPS info in 3D games.
 .It Fl -soundfont= Ns Ar FILE
 Select the SoundFont for MIDI playback (only supported by some MIDI drivers).
 .It Fl -start-movie= Ns Ar NAME Ns Ar @NUM

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -487,8 +487,8 @@ of the middle mouse button or wheel.
 .El
 .Pp
 There are many more game-specific hotkeys.
-See
-.Lk https://wiki.scummvm.org/index.php?title=Category:Supported_Games .
+See:
+.Lk https://wiki.scummvm.org/index.php?title=Category:Supported_Games
 .Sh ENVIRONMENT
 .Bl -tag -width SCUMMVM
 .It Ev SCUMMVM_MIDI

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -101,7 +101,7 @@ Set the music volume, 0-255 (default: 192).
 .It Fl n | -subtitles
 Enable subtitles (use with games that have voice).
 .It Fl p | -path= Ns Ar PATH
-Path to where the game is installed.
+Set the path to where the game is installed.
 .It Fl q | -language= Ns Ar LANG
 Select game's language:
 .Bl -tag -width auto -compact
@@ -192,7 +192,7 @@ exists in the current directory.
 .It Fl v | -version
 Display ScummVM version information and exit.
 .It Fl x | -save-slot= Ns Ar [SLOT]
-Saved game slot to load (default: autosave).
+Set the saved game slot to load (default: autosave).
 .It Fl z | -list-games
 Display list of supported games and exit.
 .It Fl -alt-intro
@@ -241,7 +241,7 @@ only lists games for this engine.
 .It Fl -engine-speed= Ns Ar NUM
 Set frame per second limit (0-100), 0 = no limit (default: 60).
 .It Fl -extrapath= Ns Ar PATH
-Extra path to additional game data.
+Set the extra path to additional game and ScummVM data.
 .It Fl -filtering
 Force filtered graphics mode.
 .It Fl -game= Ns Ar ID
@@ -257,7 +257,7 @@ Select a GUI theme, as given by
 .It Fl -joystick= Ns Ar NUM
 Enable joystick input (default: 0 = first joystick).
 .It Fl -iconspath= Ns Ar PATH
-Path to additional icons for the launcher grid view.
+Set the path to additional icons for the launcher grid view.
 .It Fl -list-all-debugflags
 Display list of all engine specified debugflags.
 .It Fl -list-all-engines
@@ -311,7 +311,8 @@ Only supported by some MIDI drivers.
 .It Fl -multi-midi
 Enable combination of AdLib and native MIDI.
 .It Fl -native-mt32
-True Roland MT-32 MIDI (disable GM emulation).
+Tell ScummVM that the MIDI device is an actual Roland MT-32 or compatible device.
+This disables any GM emulation.
 .It Fl -no-filtering
 Force unfiltered graphics mode.
 .It Fl -opl-driver= Ns Ar DRIVER
@@ -398,9 +399,9 @@ Select 3D renderer
 .Ar opengl_shaders
 .Pc .
 .It Fl -savepath= Ns Ar PATH
-Path to where saved games are stored.
+Specify where saved games are stored.
 .It Fl -scale-factor= Ns Ar FACTOR
-Factor to scale the graphics by.
+Set the factor to scale the graphics by.
 .It Fl -scaler= Ns Ar MODE
 Select graphics scaler
 .Po
@@ -439,7 +440,7 @@ Set talk delay for SCUMM games, or talk speed for other games (default: 60).
 .It Fl -tempo= Ns Ar NUM
 Set music tempo (in percent, 50-200) for SCUMM games (default: 100).
 .It Fl -themepath= Ns Ar PATH
-Path to where GUI themes are stored.
+Set the path to GUI themes.
 .It Fl -window-size= Ns Ar W,H
 Set the ScummVM window size to the specified dimensions (OpenGL only).
 .El

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -48,8 +48,8 @@ to the boot script,
 for games supporting this feature.
 .It Fl c | -config= Ns Ar CONFIG
 Use alternate configuration file.
-.It Fl d | -debuglevel= Ns Ar NUM
-Set debug verbosity level.
+.It Fl d | -debuglevel Ns Op = Ns Ar NUM
+Enable and set debug verbosity level (default: 0).
 .It Fl e | -music-driver= Ns Ar MODE
 Select music driver:
 .Bl -tag -width 10m
@@ -195,8 +195,8 @@ Enable script dumping if a directory called
 exists in the current directory.
 .It Fl v | -version
 Display ScummVM version information, and exit.
-.It Fl x | -save-slot= Ns Ar [SLOT]
-Set the saved game slot to load (default: autosave).
+.It Fl x | -save-slot Ns Op = Ns Ar SLOT
+Set the saved game slot to load (default: 0 = autosave).
 .It Fl z | -list-games
 Display list of supported games, and exit.
 .It Fl - Ns Oo Cm no- Oc Ns Cm alt-intro
@@ -263,7 +263,7 @@ only add or attempt to detect the game with id
 .It Fl -gui-theme= Ns Ar THEME
 Select a GUI theme, as given by
 .Fl -list-themes .
-.It Fl -joystick= Ns Ar NUM
+.It Fl -joystick Ns Op = Ns Ar NUM
 Enable joystick input (default: 0 = first joystick).
 .It Fl -iconspath= Ns Ar PATH
 Set the path to additional icons for the launcher grid view.
@@ -275,7 +275,7 @@ Display list of all detection engines, and exit.
 Display list of all detected games, and exit.
 .It Fl -list-audio-devices
 List all available audio devices, and exit.
-.It Fl -list-debugflags= Ns Ar ENGINE
+.It Fl -list-debugflags Ns Op = Ns Ar ENGINE
 Display list of engine specified debugflags, and exit.
 If the
 .Ar ENGINE

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -430,8 +430,10 @@ Either can be specified without the other.
 Select stretch mode
 .Po
 .Ar center ,
-.Ar integral ,
+.Ar even-pixels ,
 .Ar fit ,
+.Ar fit_force_aspect ,
+.Ar pixel-perfect ,
 .Ar stretch
 .Pc .
 .It Fl -talkspeed= Ns Ar NUM

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -326,7 +326,7 @@ Select AdLib (OPL) emulator
 .Pc .
 .It Fl -output-rate= Ns Ar RATE
 Set output sample rate in Hz (e.g. 22050).
-.It Fl -platform= Ns Ar WORD
+.It Fl -platform= Ns Ar PLATFORM
 Specify platform of game
 .Po
 .Ar 2gs ,

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -251,6 +251,8 @@ Set frame per second limit (0\(en100) for 3D games,
 Set the extra path to additional game and ScummVM data.
 .It Fl - Ns Oo Cm no- Oc Ns Cm filtering
 Force filtered/unfiltered graphics mode.
+Filtered graphics mode uses bilinear interpolation
+while unfiltered graphics mode uses nearest neighbor.
 .It Fl -game= Ns Ar ID
 In combination with
 .Fl -add

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -493,6 +493,8 @@ MIDI driver.
 The ALSA port to open for output when using the
 .Ql alsa
 MIDI driver.
+.It Ev SCUMMVM_SAVEPATH
+Override the default save path (POSIX systems).
 .El
 .Sh FILES
 .Bl -tag -width Ds

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -101,7 +101,7 @@ Display a brief help text, and exit.
 .It Fl l | -logfile= Ns Ar PATH
 Use alternate path for log file.
 .It Fl m | -music-volume= Ns Ar NUM
-Set the music volume, 0-255 (default: 192).
+Set the music volume, 0\(en255 (default: 192).
 .It Fl n | -subtitles
 Enable subtitles (for games that have voice).
 .It Fl p | -path= Ns Ar PATH
@@ -184,9 +184,9 @@ Turkish
 Ukrainian
 .El
 .It Fl r | -speech-volume Ns Ar NUM
-Set the voice volume, 0-255 (default: 192).
+Set the voice volume, 0\(en255 (default: 192).
 .It Fl s | -sfx-volume= Ns Ar NUM
-Set the SFX volume, 0-255 (default: 192).
+Set the SFX volume, 0\(en255 (default: 192).
 .It Fl t | -list-targets
 Display list of user-configured game targets, and exit.
 .It Fl u | -dump-scripts
@@ -245,7 +245,7 @@ or
 .Fl -list-all-games ,
 only list games for this engine.
 .It Fl -engine-speed= Ns Ar NUM
-Set frame per second limit (0-100) for 3D games,
+Set frame per second limit (0\(en100) for 3D games,
 0 = no limit (default: 60).
 .It Fl -extrapath= Ns Ar PATH
 Set the extra path to additional game and ScummVM data.
@@ -313,7 +313,7 @@ or last (if negative)
 .Ar NUM
 bytes of each fork.
 .It Fl -midi-gain= Ns Ar NUM
-Set the gain for MIDI playback, 0-1000 (default: 100).
+Set the gain for MIDI playback, 0\(en1000 (default: 100).
 Only supported by some MIDI drivers.
 .It Fl -multi-midi
 Enable combination of AdLib and native MIDI.
@@ -448,7 +448,7 @@ Select stretch mode
 .It Fl -talkspeed= Ns Ar NUM
 Set talk delay for SCUMM games, or talk speed for other games.
 .It Fl -tempo= Ns Ar NUM
-Set music tempo (in percent, 50-200) for SCUMM games (default: 100).
+Set music tempo (in percent, 50\(en200) for SCUMM games (default: 100).
 .It Fl -themepath= Ns Ar PATH
 Set the path to GUI themes.
 .It Fl -window-size= Ns Ar W,H


### PR DESCRIPTION
This is a follow-up to PR #4121, regarding the manual page.

I tried to expand/update some descriptions, and improve the formatting a bit. This has been split into many smaller commits for easier (?) review.

I also plan to submit a similar update for `base/commandLine.cpp`, but probably in a distinct PR to avoid reviewing too many commits at once.