### PR TITLE
GROOVIE: stop fast video playback capability

### DIFF
--- a/engines/groovie/detection.cpp
+++ b/engines/groovie/detection.cpp
@@ -34,6 +34,7 @@ namespace Groovie {
 #define GAMEOPTION_ORIGINAL_SAVELOAD GUIO_GAMEOPTIONS2
 #define GAMEOPTION_EASIER_AI GUIO_GAMEOPTIONS3
 #define GAMEOPTION_FINAL_HOUR GUIO_GAMEOPTIONS4
+#define GAMEOPTION_SPEEDRUN GUIO_GAMEOPTIONS5
 
 static const DebugChannelDef debugFlagList[] = {
 	{Groovie::kDebugVideo, "Video", "Debug video and audio playback"},
@@ -74,34 +75,34 @@ const int BASE_FLAGS = ADGF_NO_FLAGS;
 
 
 #define T7GENTRY(extra, f1, x1, s1, f2, x2, s2, language, platform, flags) \
-	GROOVIEGAME("t7g", extra, f1, x1, s1, f2, x2, s2, language, platform, flags, GUIO8(GUIO_MIDIADLIB, GUIO_MIDIMT32, GUIO_MIDIGM, GUIO_NOASPECT, GUIO_NOSFX, GAMEOPTION_T7G_FAST_MOVIE_SPEED, GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_EASIER_AI), kGroovieT7G)
+	GROOVIEGAME("t7g", extra, f1, x1, s1, f2, x2, s2, language, platform, flags, GUIO9(GUIO_MIDIADLIB, GUIO_MIDIMT32, GUIO_MIDIGM, GUIO_NOASPECT, GUIO_NOSFX, GAMEOPTION_T7G_FAST_MOVIE_SPEED, GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_EASIER_AI, GAMEOPTION_SPEEDRUN), kGroovieT7G)
 
 #define T7GNOMIDIENTRY(extra, f1, x1, s1, f2, x2, s2, language, platform, flags, guiOptions) \
-	GROOVIEGAME("t7g", extra, f1, x1, s1, f2, x2, s2, language, platform, flags, (GUIO_NOMIDI GUIO_NOASPECT GUIO_NOSFX GAMEOPTION_T7G_FAST_MOVIE_SPEED guiOptions), kGroovieT7G)
+	GROOVIEGAME("t7g", extra, f1, x1, s1, f2, x2, s2, language, platform, flags, (GUIO_NOMIDI GUIO_NOASPECT GUIO_NOSFX GAMEOPTION_T7G_FAST_MOVIE_SPEED GAMEOPTION_SPEEDRUN guiOptions), kGroovieT7G)
 
 #define T11HENTRY(extra, f1, x1, s1, f2, x2, s2, language, platform, flags) \
-	GROOVIEGAME("11h", extra, f1, x1, s1, f2, x2, s2, language, platform, flags, GUIO6(GUIO_MIDIADLIB, GUIO_MIDIMT32, GUIO_MIDIGM GUIO_NOASPECT, GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_EASIER_AI, GAMEOPTION_FINAL_HOUR), kGroovieT11H)
+	GROOVIEGAME("11h", extra, f1, x1, s1, f2, x2, s2, language, platform, flags, GUIO7(GUIO_MIDIADLIB, GUIO_MIDIMT32, GUIO_MIDIGM GUIO_NOASPECT, GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_EASIER_AI, GAMEOPTION_FINAL_HOUR, GAMEOPTION_SPEEDRUN), kGroovieT11H)
 
 #define T11HDEMOENTRY(extra, f1, x1, s1, f2, x2, s2, language, platform, flags) \
-	GROOVIEGAME("11h", extra, f1, x1, s1, f2, x2, s2, language, platform, flags | ADGF_DEMO, GUIO5(GUIO_NOLAUNCHLOAD, GUIO_MIDIADLIB, GUIO_MIDIMT32, GUIO_MIDIGM, GUIO_NOASPECT), kGroovieT11H)
+	GROOVIEGAME("11h", extra, f1, x1, s1, f2, x2, s2, language, platform, flags | ADGF_DEMO, GUIO6(GUIO_NOLAUNCHLOAD, GUIO_MIDIADLIB, GUIO_MIDIMT32, GUIO_MIDIGM, GUIO_NOASPECT, GAMEOPTION_SPEEDRUN), kGroovieT11H)
 
 #define T11HMAKINGOFENTRY(f1, x1, s1, f2, x2, s2, language, platform) \
-	GROOVIEGAME("making11h", "", f1, x1, s1, f2, x2, s2, language, platform, ADGF_NO_FLAGS, GUIO4(GUIO_MIDIADLIB, GUIO_MIDIMT32, GUIO_MIDIGM, GUIO_NOASPECT), kGroovieT11H)
+	GROOVIEGAME("making11h", "", f1, x1, s1, f2, x2, s2, language, platform, ADGF_NO_FLAGS, GUIO5(GUIO_MIDIADLIB, GUIO_MIDIMT32, GUIO_MIDIGM, GUIO_NOASPECT, GAMEOPTION_SPEEDRUN), kGroovieT11H)
 
 #define CLANENTRY(extra, f1, x1, s1, f2, x2, s2, language, platform, flags) \
-	GROOVIEGAME("clandestiny", extra, f1, x1, s1, f2, x2, s2, language, platform, flags, GUIO4(GUIO_NOMIDI, GUIO_NOASPECT, GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_EASIER_AI), kGroovieCDY)
+	GROOVIEGAME("clandestiny", extra, f1, x1, s1, f2, x2, s2, language, platform, flags, GUIO5(GUIO_NOMIDI, GUIO_NOASPECT, GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_EASIER_AI, GAMEOPTION_SPEEDRUN), kGroovieCDY)
 
 #define CLANDEMOENTRY(extra, f1, x1, s1, f2, x2, s2, language, platform, flags) \
-	GROOVIEGAME("clandestiny", extra, f1, x1, s1, f2, x2, s2, language, platform, flags | ADGF_DEMO, GUIO3(GUIO_NOMIDI, GUIO_NOLAUNCHLOAD, GUIO_NOASPECT), kGroovieCDY)
+	GROOVIEGAME("clandestiny", extra, f1, x1, s1, f2, x2, s2, language, platform, flags | ADGF_DEMO, GUIO4(GUIO_NOMIDI, GUIO_NOLAUNCHLOAD, GUIO_NOASPECT, GAMEOPTION_SPEEDRUN), kGroovieCDY)
 
 #define UHPENTRY(extra, f1, x1, s1, f2, x2, s2, language, platform, flags) \
-	GROOVIEGAME("unclehenry", extra, f1, x1, s1, f2, x2, s2, language, platform, flags, GUIO3(GUIO_NOMIDI, GUIO_NOASPECT, GAMEOPTION_EASIER_AI), kGroovieUHP)
+	GROOVIEGAME("unclehenry", extra, f1, x1, s1, f2, x2, s2, language, platform, flags, GUIO4(GUIO_NOMIDI, GUIO_NOASPECT, GAMEOPTION_EASIER_AI, GAMEOPTION_SPEEDRUN), kGroovieUHP)
 
 #define TLCENTRY(extra, f1, x1, s1, f2, x2, s2, language, platform, flags) \
-	GROOVIEGAME("tlc", extra, f1, x1, s1, f2, x2, s2, language, platform, flags | ADGF_CD, GUIO2(GUIO_NOMIDI, GUIO_NOASPECT), kGroovieTLC)
+	GROOVIEGAME("tlc", extra, f1, x1, s1, f2, x2, s2, language, platform, flags | ADGF_CD, GUIO3(GUIO_NOMIDI, GUIO_NOASPECT, GAMEOPTION_SPEEDRUN), kGroovieTLC)
 
 #define TLCDVDENTRY(f1, x1, s1, f2, x2, s2, language, platform) \
-	GROOVIEGAME("tlc", _s("Missing game code"), f1, x1, s1, f2, x2, s2, language, platform, ADGF_UNSUPPORTED | ADGF_DVD, GUIO2(GUIO_NOMIDI, GUIO_NOASPECT), kGroovieTLC)
+	GROOVIEGAME("tlc", _s("Missing game code"), f1, x1, s1, f2, x2, s2, language, platform, ADGF_UNSUPPORTED | ADGF_DVD, GUIO3(GUIO_NOMIDI, GUIO_NOASPECT, GAMEOPTION_SPEEDRUN), kGroovieTLC)
 
 // clang-format off
 static const GroovieGameDescription gameDescriptions[] = {
@@ -311,6 +312,18 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 			_s("Updated Credits Music"),
 			_s("Play the song The Final Hour during the credits instead of reusing MIDI songs"),
 			"credits_music",
+			false,
+			0,
+			0
+		}
+	},
+
+	{
+		GAMEOPTION_SPEEDRUN,
+		{
+			_s("Speedrun Mode"),
+			_s("Affects the controls for fast forwarding the game"),
+			"speedrun_mode",
 			false,
 			0,
 			0

--- a/engines/groovie/script.cpp
+++ b/engines/groovie/script.cpp
@@ -973,9 +973,10 @@ bool Script::playvideofromref(uint32 fileref, bool loopUntilAudioDone) {
 			// End the playback
 			return true;
 		}
-		if (_fastForwarding == true) {
+		if (_fastForwarding) {
 			resetFastForward();
-			_vm->_videoPlayer->setOverrideSpeed(false);
+			if (!_fastForwarding)
+				_vm->_videoPlayer->setOverrideSpeed(false);
 		} else {
 			_vm->_videoPlayer->fastForward();
 			_fastForwarding = true;

--- a/engines/groovie/script.cpp
+++ b/engines/groovie/script.cpp
@@ -973,8 +973,13 @@ bool Script::playvideofromref(uint32 fileref, bool loopUntilAudioDone) {
 			// End the playback
 			return true;
 		}
-		_vm->_videoPlayer->fastForward();
-		_fastForwarding = true;
+		if (_fastForwarding == true) {
+			resetFastForward();
+			_vm->_videoPlayer->setOverrideSpeed(false);
+		} else {
+			_vm->_videoPlayer->fastForward();
+			_fastForwarding = true;
+		}
 	} else if (_fastForwarding) {
 		_vm->_videoPlayer->fastForward();
 	}

--- a/engines/groovie/script.cpp
+++ b/engines/groovie/script.cpp
@@ -904,6 +904,10 @@ bool Script::playvideofromref(uint32 fileref, bool loopUntilAudioDone) {
 	// It isn't the current video, open it
 	if (fileref != _videoRef) {
 
+		if (_fastForwarding && !ConfMan.getBool("speedrun_mode")) {
+			resetFastForward();
+		}
+
 		// Debug bitflags
 		debugCN(1, kDebugScript, "Groovie::Script: Play video 0x%04X (bitflags:", fileref);
 		for (int i = 15; i >= 0; i--) {
@@ -973,7 +977,7 @@ bool Script::playvideofromref(uint32 fileref, bool loopUntilAudioDone) {
 			// End the playback
 			return true;
 		}
-		if (_fastForwarding) {
+		if (_fastForwarding && !ConfMan.getBool("speedrun_mode")) {
 			resetFastForward();
 			if (!_fastForwarding)
 				_vm->_videoPlayer->setOverrideSpeed(false);

--- a/engines/groovie/video/player.h
+++ b/engines/groovie/video/player.h
@@ -46,13 +46,13 @@ public:
 	bool isFastForwarding();
 	virtual void drawString(Graphics::Surface *surface, const Common::String text, int posx, int posy, uint32 color, bool blackBackground) {}
 	virtual void copyfgtobg(uint8 arg) {}
+	void setOverrideSpeed(bool isOverride);
 
 protected:
 	// To be implemented by subclasses
 	virtual uint16 loadInternal() = 0;
 	virtual bool playFrameInternal() = 0;
 
-	void setOverrideSpeed(bool isOverride);
 	bool getOverrideSpeed() const { return _overrideSpeed; }
 
 	GroovieEngine *_vm;


### PR DESCRIPTION
cancelation of fast playback video by right mouse click and proceed watching video with normal speed and sound. It is needed to prevent skipping ghost scenes after speed up slow movement in game.