### PR TITLE
AGI: French Translation support

### DIFF
--- a/engines/agi/detection.h
+++ b/engines/agi/detection.h
@@ -67,7 +67,8 @@ enum AgiGameFeatures {
 	GF_AGI256      = (1 << 2), // marks fanmade AGI-256 games
 	GF_FANMADE     = (1 << 3), // marks fanmade games
 	GF_OLDAMIGAV20 = (1 << 4),
-	GF_2GSOLDSOUND = (1 << 5)
+	GF_2GSOLDSOUND = (1 << 5),
+	GF_EXTCHAR = (1 << 6) // use WORDS.TOK.EXTENDED
 };
 
 enum BooterDisks {

--- a/engines/agi/detection_tables.h
+++ b/engines/agi/detection_tables.h
@@ -717,7 +717,7 @@ static const AGIGameDescription gameDescriptions[] = {
 	GAME("pq1", "2.0G 1987-12-03", "d194e5d88363095f55d5096b8e32fbbb", 0x2917, GID_PQ1),
 
 	// Police Quest 1 (PC) 2.0G 12/3/87; with Hebrew translation
-	GAME_LVFPN("pq1", "2.0G 1987-12-03", "PQ1.WAG", "59e1b2fb6d025968b8ed7388f107c7b5", -1, Common::HE_ISR, 0x2917, 0, GID_PQ1, Common::kPlatformDOS, GType_V2, GAMEOPTIONS_DEFAULT),
+	GAME_LVFPN("pq1", "2.0G 1987-12-03", "PQ1.WAG", "59e1b2fb6d025968b8ed7388f107c7b5", -1, Common::HE_ISR, 0x2917, GF_EXTCHAR, GID_PQ1, Common::kPlatformDOS, GType_V2, GAMEOPTIONS_DEFAULT),
 
 	// Police Quest 1 (CoCo3 360k) [AGI 2.023]
 	GAME_PS("pq1", "", "28a077041f75aab78f66804800940085", 375, 0x2440, GID_PQ1, Common::kPlatformCoCo3),
@@ -756,6 +756,9 @@ static const AGIGameDescription gameDescriptions[] = {
 
 	// Space Quest 1 (PC 5.25"/3.5") 2.2 [AGI 2.426/2.917]
 	GAME("sq1", "2.2 1987-05-07 5.25\"/3.5\"", "5d67630aba008ec5f7f9a6d0a00582f4", 0x2440, GID_SQ1),
+
+	// Space Quest 1 (PC 5.25"/3.5") 2.2 [AGI 2.917]; French Translation
+	GAME_LVFPN("sq1", "2.2 1987-05-07 5.25\"/3.5\"", "words.tok.extended", "3f1730f3c9d4622a986f735af0f8734a", 12665, Common::FR_FRA, 0x2917, GF_EXTCHAR, GID_SQ1, Common::kPlatformDOS, GType_V2, GAMEOPTIONS_DEFAULT),
 
 	// Space Quest 1 (CoCo3 360k) [AGI 2.072]
 	GAME_PS("sq1", "", "5d67630aba008ec5f7f9a6d0a00582f4", 372, 0x2440, GID_SQ1, Common::kPlatformCoCo3),

--- a/engines/agi/keyboard.cpp
+++ b/engines/agi/keyboard.cpp
@@ -155,6 +155,56 @@ void AgiEngine::processScummVMEvents() {
 				}
 			}
 
+			if (_game._vm->getLanguage() == Common::FR_FRA) {
+				// Convert to CP858
+				if (key >= 0x80 && key <= 0xff) {
+					switch (key) {
+					case 0xe9:
+						key = 0x82;
+						break;
+					case 0xe8:
+						key = 0x8a;
+						break;
+					case 0xe7:
+						key = 0x87;
+						break;
+					case 0xe0:
+						key = 0x85;
+						break;
+					case 0xf9:
+						key = 0x97;
+						break;
+					case 0xf4:
+						key = 0x93;
+						break;
+					case 0xee:
+						key = 0x8c;
+						break;
+					case 0xef:
+						key = 0x8b;
+						break;
+					case 0xea:
+						key = 0x88;
+						break;
+					case 0xeb:
+						key = 0x89;
+						break;
+					case 0xe2:
+						key = 0x83;
+						break;
+					case 0xe4:
+						key = 0x84;
+						break;
+					case 0xfb:
+						key = 0x96;
+						break;
+					case 0xfc:
+						key = 0x81;
+						break;
+					}
+				}
+			}
+
 			if ((key) && (key <= 0xFF)) {
 				// No special key, directly accept it
 				// Is ISO-8859-1, we need lower 128 characters only, which is plain ASCII, so no mapping required

--- a/engines/agi/loader_v2.cpp
+++ b/engines/agi/loader_v2.cpp
@@ -275,10 +275,11 @@ int AgiLoader_v2::loadObjects(const char *fname) {
 }
 
 int AgiLoader_v2::loadWords(const char *fname) {
-	if (_vm->getLanguage() != Common::HE_ISR)
-		return _vm->_words->loadDictionary(fname);
-	else
+	if (_vm->getFeatures() & GF_EXTCHAR) {
 		return _vm->_words->loadExtendedDictionary(fname);
+	} else {
+		return _vm->_words->loadDictionary(fname);
+	}
 }
 
 } // End of namespace Agi

--- a/engines/agi/text.cpp
+++ b/engines/agi/text.cpp
@@ -714,6 +714,10 @@ void TextMgr::promptKeyPress(uint16 newKey) {
 		if ((newKey >= 0x20) && (newKey <= 0xff))
 			acceptableInput = true;
 		break;
+	case Common::FR_FRA:
+		if ((newKey >= 0x20) && (newKey != 0x5e) && (newKey <= 0xff))
+			acceptableInput = true;
+		break;
 	default:
 		if ((newKey >= 0x20) && (newKey <= 0x7f))
 			acceptableInput = true;
@@ -1026,6 +1030,10 @@ void TextMgr::stringKeyPress(uint16 newKey) {
 			case Common::RU_RUS:
 			case Common::HE_ISR:
 				if ((newKey >= 0x20) && (newKey <= 0xff))
+					acceptableInput = true;
+				break;
+			case Common::FR_FRA:
+				if ((newKey >= 0x20) && (newKey != 0x5e) && (newKey <= 0xff))
 					acceptableInput = true;
 				break;
 			default:

--- a/engines/agi/text.cpp
+++ b/engines/agi/text.cpp
@@ -711,7 +711,7 @@ void TextMgr::promptKeyPress(uint16 newKey) {
 	switch (_vm->getLanguage()) {
 	case Common::RU_RUS:
 	case Common::HE_ISR:
-		if (newKey >= 0x20)
+		if ((newKey >= 0x20) && (newKey <= 0xff))
 			acceptableInput = true;
 		break;
 	default:
@@ -1025,7 +1025,7 @@ void TextMgr::stringKeyPress(uint16 newKey) {
 			switch (_vm->getLanguage()) {
 			case Common::RU_RUS:
 			case Common::HE_ISR:
-				if (newKey >= 0x20)
+				if ((newKey >= 0x20) && (newKey <= 0xff))
 					acceptableInput = true;
 				break;
 			default:

--- a/engines/agi/words.cpp
+++ b/engines/agi/words.cpp
@@ -251,7 +251,7 @@ int16 Words::findWordInDictionary(const Common::String &userInputLowcased, uint1
 
 	foundWordLen = 0;
 
-	const byte lastCharInAbc = _vm->getLanguage() == Common::HE_ISR ? 0xfa : 'z';
+	const byte lastCharInAbc = _vm->getFeatures() & GF_EXTCHAR ? 0xff : 'z';
 
 	if ((firstChar >= 'a') && (firstChar <= lastCharInAbc)) {
 		// word has to start with a letter


### PR DESCRIPTION
Full support for extended characters in French translations, detection for SQ1 FR.

AGI bug fix: Prevents right-click and mouse scroll wheel from adding unwanted keypresses to the player input line when language is HE_ISR or RU_RUS for AGI games.
