### PR TITLE
ANDROID: Stop annoying touch mode change

### DIFF
--- a/backends/graphics/android/android-graphics.cpp
+++ b/backends/graphics/android/android-graphics.cpp
@@ -66,8 +66,7 @@ static void loadBuiltinTexture(JNI::BitmapResources resource, OpenGL::Surface *s
 // AndroidGraphicsManager
 //
 AndroidGraphicsManager::AndroidGraphicsManager() :
-	_touchcontrols(nullptr),
-	_old_touch_mode(OSystem_Android::TOUCH_MODE_TOUCHPAD) {
+	_touchcontrols(nullptr) {
 	ENTER();
 
 	// Initialize our OpenGL ES context.
@@ -157,8 +156,6 @@ void AndroidGraphicsManager::displayMessageOnOSD(const Common::U32String &msg) {
 void AndroidGraphicsManager::showOverlay() {
 	if (_overlayVisible)
 		return;
-
-	_old_touch_mode = JNI::getTouchMode();
 
 	OpenGL::OpenGLGraphicsManager::showOverlay();
 }

--- a/backends/graphics/android/android-graphics.cpp
+++ b/backends/graphics/android/android-graphics.cpp
@@ -159,8 +159,6 @@ void AndroidGraphicsManager::showOverlay() {
 		return;
 
 	_old_touch_mode = JNI::getTouchMode();
-	// not in 3D, in overlay
-	dynamic_cast<OSystem_Android *>(g_system)->applyTouchSettings(false, true);
 
 	OpenGL::OpenGLGraphicsManager::showOverlay();
 }
@@ -168,9 +166,6 @@ void AndroidGraphicsManager::showOverlay() {
 void AndroidGraphicsManager::hideOverlay() {
 	if (!_overlayVisible)
 		return;
-
-	// Restore touch mode active before overlay was shown
-	JNI::setTouchMode(_old_touch_mode);
 
 	OpenGL::OpenGLGraphicsManager::hideOverlay();
 }

--- a/backends/graphics/android/android-graphics.h
+++ b/backends/graphics/android/android-graphics.h
@@ -100,7 +100,6 @@ protected:
 
 private:
 	OpenGL::Surface *_touchcontrols;
-	int _old_touch_mode;
 };
 
 #endif

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -499,8 +499,6 @@ void AndroidGraphics3dManager::showOverlay() {
 	}
 
 	_old_touch_mode = JNI::getTouchMode();
-	// in 3D, in overlay
-	dynamic_cast<OSystem_Android *>(g_system)->applyTouchSettings(true, true);
 
 	_show_overlay = true;
 	_force_redraw = true;
@@ -545,9 +543,6 @@ void AndroidGraphics3dManager::hideOverlay() {
 	_show_overlay = false;
 
 	_overlay_background->release();
-
-	// Restore touch mode active before overlay was shown
-	JNI::setTouchMode(_old_touch_mode);
 
 	warpMouse(_game_texture->width() / 2, _game_texture->height() / 2);
 

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -92,8 +92,7 @@ AndroidGraphics3dManager::AndroidGraphics3dManager() :
 	_mouse_hotspot(),
 	_mouse_dont_scale(false),
 	_show_mouse(false),
-	_touchcontrols_texture(nullptr),
-	_old_touch_mode(OSystem_Android::TOUCH_MODE_TOUCHPAD) {
+	_touchcontrols_texture(nullptr) {
 
 	if (JNI::egl_bits_per_pixel == 16) {
 		// We default to RGB565 and RGBA5551 which is closest to what we setup in Java side
@@ -497,8 +496,6 @@ void AndroidGraphics3dManager::showOverlay() {
 	if (_show_overlay) {
 		return;
 	}
-
-	_old_touch_mode = JNI::getTouchMode();
 
 	_show_overlay = true;
 	_force_redraw = true;

--- a/backends/graphics3d/android/android-graphics3d.h
+++ b/backends/graphics3d/android/android-graphics3d.h
@@ -185,7 +185,6 @@ private:
 
 	// Touch controls layer
 	GLESTexture *_touchcontrols_texture;
-	int _old_touch_mode;
 };
 
 #endif


### PR DESCRIPTION
It is very annoying when you go to menu for saving and your control mode is changed (from touch to mouse) as well as after menu was closed (when it goes back to old mode value). By default for touch screen device touch mode is better choise in case of this type of design (when you got mouse cursor). Btw after start now you get mouse instead of touch mode - it is also not convenient (with this fix - touch mode will be on start).
P.S. I'm always fighting with this control changes during menu pop up etc... spent time to understand what happened, where is cursor and change mode... very annoying! In case of this patch _old_touch_mode can be deleted from implementation of android-graphics.* and android-graphics3d.* due to useless (it is only used for this feature).
