### PR TITLE
SCI32: Make RTL BiDi conversion direction hard coded

### DIFF
--- a/engines/sci/graphics/text32.cpp
+++ b/engines/sci/graphics/text32.cpp
@@ -392,7 +392,7 @@ void GfxText32::drawText(const uint index, uint length) {
 	} else {
 		const char *textOrig = _text.c_str() + index;
 		Common::String textLogical = Common::String(textOrig, (uint32)length);
-		textString = Common::convertBiDiString(textLogical, g_sci->getLanguage());
+		textString = Common::convertBiDiString(textLogical, g_sci->getLanguage(), Common::BiDiParagraph::BIDI_PAR_RTL);
 		text = textString.c_str();
 	}
 


### PR DESCRIPTION
The default behaviour for `Common::convertBiDiString` is to use
`BIDI_PAR_ON` for direction, which means that it tries to guess to
paragraph language, and choose the direction according to it.

However, in SQ6 many (all?) texts begin with control characters,
which make that function to think that these are English texts,
and therefore it chooses LTR direction, and punctuations are wrongly
placed.

Since the call to the function is under `if` clause for RTL,
it's safe to hard code that direction.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
