### PR TITLE
SCUMM: Fix the stairs in room 32 for the earliest Loom EGA releases

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -582,7 +582,7 @@ void ScummEngine_v5::o5_actorOps() {
 			if (_game.id == GID_LOOM && _game.platform == Common::kPlatformPCEngine && i == 0 && j == 0) {
 				for (int k = 0; k < 32; k++)
 					a->setPalette(k, 0xFF);
-			} else {	
+			} else {
 				a->setPalette(i, j);
 			}
 			break;
@@ -1062,6 +1062,21 @@ void ScummEngine_v5::o5_drawObject() {
 				putState(_objs[i].obj_nr, 0);
 		} while (--i);
 		return;
+	}
+
+	// WORKAROUND: In some of the earliest 16-color releases of Loom, the
+	// staircase at the right of room 32 will glitch if Bobbin uses it to exit
+	// the room, if he entered it via the other stairs in the ground. This has
+	// been officially fixed in some '1.2' releases (e.g. French DOS/EGA) and
+	// all later versions; this smaller workaround appears to be enough.
+	if (_game.id == GID_LOOM && _game.version == 3 && !(_game.features & GF_OLD256) && _roomResource == 32 &&
+		vm.slot[_currentScript].number == 10002 && obj == 540 && state == 1 && xpos == 255 && ypos == 255 &&
+		_enableEnhancements) {
+		if (getState(541) == 1) {
+			putState(obj, state);
+			obj = 541;
+			state = 0;
+		}
 	}
 
 	idx = getObjectIndex(obj);


### PR DESCRIPTION
This was found by @einstein95 on Discord while comparing the scripts of the 1.0/1.1/1.2 EGA releases of Loom.

![scummvm-loom-ega-fr-00000](https://user-images.githubusercontent.com/9024526/188734692-8e739517-135e-4f08-be15-06d7f5e9a55f.png)

In the earliest 16-color releases of Loom (English only, it seems), Bobbin will walk *through* the stairs (literally) if you exit one of the rooms in the dragon's cave by using the staircase on the right, after entering the room with the stairs in the middle of the ground. The 16-color 1.2 releases (and probably all later versions) fixed this, but it seems that the original 16-color English release is always 1.0/1.1 and so it always has this bug.

(**EDIT:** this problem also happens with the original DOS interpreter, if using a 1.0/1.1 version.)

## Explanations

It appears that the staircase is drawn with two objects, no. 540 and 541. Their states should change in some conditions (I can't say why it has to do that, though).

The 1.2 DOS/EGA French release appears to have fixed is this way:

```diff
LFv3_0032/ROv3/OCv3_0537:
=========================

@@ -5,6 +5,7 @@ Events:
 (30) setBoxFlags(0,0);
 (30) setBoxFlags(1,0);
 (30) setBoxFlags(2,0);
+(07) setState(541,0);
 (05) drawObject(540,255,255);
 (5D) setClass(1,[0,146]);
 (1E) walkActorTo(1,430,80);

LFv3_0032/SCv3_0079:
====================

@@ -13,6 +13,7 @@
 (30) setBoxFlags(2,0);
 (0A) startScript(18,[2]);
 (80) breakHere();
+(07) setState(541,0);
 (05) drawObject(540,255,255);
 (2D) putActorInRoom(1,32);
 (01) putActor(1,480,80);
@@ -27,6 +28,7 @@
 (30) setBoxFlags(2,128);
 (5D) setClass(1,[0]);
 (01) putActor(1,442,72);
+(07) setState(540,0);
 (05) drawObject(541,255,255);
 (80) breakHere();
 (C0) endCutscene();
```

The entry script for that room also has some differences, but it looks like `descumm` has trouble properly decoding it. Fortunately, the excellent [NUTCracker](https://github.com/BLooperZ/nutcracker) now has support for decoding v3 scripts, too.

So here's the difference for the entry script of room 32, with windex syntax:

```diff
@@ -116,9 +119,11 @@ room room_32 {
        set-box 1 to 128
        set-box 2 to 128
        if !(V.112 is 30) jump not_v112
+       state-of 541 is 0
        draw-object 540 at 255,255
        jump done
not_v112:
+       state-of 540 is 0
        draw-object 541 at 255,255
done:
        load-costume 98
@@ -128,6 +133,13 @@ done:
        put-actor 2 in-room 32
        put-actor 2 at 53,30
        do-animation 2 7
+       break-here
+       break-here
+       complex-temp = actor-x 1
+       if !(complex-temp <= 380) jump nope
+       state-of 540 is 0
+       draw-object 541 at 255,255
+nope:
        end-object
}
```

This one is looking at Bobbin's coordinates on the screen, `380` looking close to the base of the staircase…

I couldn't find a nice, simple way of replicating all these changes (especially the entry script ones) but it looks like I've found a smaller workaround which has the same effect. I'm not really sure of what I'm doing here, but it's a very simple room and I can't find any issue with this workaround. Tests welcome, though!

## How to test

1. Start any 16-color release of Loom (**Macintosh, Amiga and Atari tests welcome!** especially the Macintosh one, since it's quite different!)
2. In the ScummVM debugger, run `room 32`. Exit the room with the stairs in the ground, and then walk back to room 32 (otherwise you won't see the bug).
3. Walk to the top of the staircase on the right. In the 1.0/1.1 releases (type Ctrl-V in-game), Bobbin will glitch through the stairs in this case, unless you use this enhancement. In the 1.2 release, the bug should already be fixed, but this workaround shouldn't cause any regression either.
4. Also try walking the other stairs, walking to the left of the room… there should be no regression.

Tested with the DOS/EGA English release (had the bug), and the DOS/EGA French release (didn't have the bug).