### PR TITLE
AVALANCHE: Bug fixes

### DIFF
--- a/engines/avalanche/animation.cpp
+++ b/engines/avalanche/animation.cpp
@@ -1053,7 +1053,7 @@ void Animation::faceAvvy(byte tripnum) {
 
 void Animation::arrowProcs(byte tripnum) {
 	AnimationType *tripSpr = _sprites[tripnum];
-	AnimationType *avvy = _sprites[tripnum];
+	AnimationType *avvy = _sprites[0];
 
 	if (tripSpr->_homing) {
 		// Arrow is still in flight.

--- a/engines/avalanche/avalot.cpp
+++ b/engines/avalanche/avalot.cpp
@@ -1079,30 +1079,39 @@ void AvalancheEngine::guideAvvy(Common::Point cursorPos) {
 	case 0:
 	default:
 		_animation->stopWalking();
+		_animation->setDirection(kDirStopped);
 		break; // Clicked on Avvy: no movement.
 	case 1:
 		_animation->setMoveSpeed(0, kDirLeft);
+		_animation->setDirection(kDirLeft);
 		break;
 	case 2:
 		_animation->setMoveSpeed(0, kDirRight);
+		_animation->setDirection(kDirRight);
 		break;
 	case 3:
 		_animation->setMoveSpeed(0, kDirUp);
+		_animation->setDirection(kDirUp);
 		break;
 	case 4:
 		_animation->setMoveSpeed(0, kDirUpLeft);
+		_animation->setDirection(kDirLeft);
 		break;
 	case 5:
 		_animation->setMoveSpeed(0, kDirUpRight);
+		_animation->setDirection(kDirUpRight);
 		break;
 	case 6:
 		_animation->setMoveSpeed(0, kDirDown);
+		_animation->setDirection(kDirDown);
 		break;
 	case 7:
 		_animation->setMoveSpeed(0, kDirDownLeft);
+		_animation->setDirection(kDirDownLeft);
 		break;
 	case 8:
 		_animation->setMoveSpeed(0, kDirDownRight);
+		_animation->setDirection(kDirDownRight);
 		break;
 	}    // No other values are possible.
 


### PR DESCRIPTION
Resolves 2 different bugs:

1) _The original game doesn't update the little icon which represents the direction Avalot is facing if you control him with the mouse by clicking on the background. At the moment, this bug is also present in the ScummVM version of the game._ 
from [the wiki page](https://wiki.scummvm.org/index.php/Avalanche).

2) Second commit fixes a bug where the arrow and main character are using the same sprite data which causes them to instantly collide and end the game during a scene.