### PR TITLE
ANDROID: Fix touchscreen stylus check

### DIFF
--- a/backends/platform/android/org/scummvm/scummvm/MouseHelper.java
+++ b/backends/platform/android/org/scummvm/scummvm/MouseHelper.java
@@ -9,8 +9,6 @@ import android.view.MotionEvent;
 //import android.view.SurfaceView;
 import android.view.View;
 
-import static android.view.MotionEvent.TOOL_TYPE_STYLUS;
-
 /**
  * Contains helper methods for mouse/hover events that were introduced in Android 4.0.
  */
@@ -101,16 +99,6 @@ public class MouseHelper implements View.OnHoverListener {
 
 	}
 
-	public static boolean isStylus(MotionEvent e){
-		if (e == null) {
-			return false;
-		}
-
-		int toolType = e.getToolType(0);
-
-		return (toolType == TOOL_TYPE_STYLUS);
-	}
-
 	public static boolean isMouse(KeyEvent e) {
 		if (e == null) {
 			return false;
@@ -144,7 +132,7 @@ public class MouseHelper implements View.OnHoverListener {
 		// SOURCE_MOUSE_RELATIVE is sent when mouse is detected as trackball
 		// TODO: why does this happen? Do we need to also check for SOURCE_TRACKBALL here?
 		return ((sources & InputDevice.SOURCE_MOUSE) == InputDevice.SOURCE_MOUSE)
-		       ||  isStylus(e)
+		       || (e.getToolType(0) == MotionEvent.TOOL_TYPE_STYLUS)
 		       || ((sources & InputDevice.SOURCE_TOUCHPAD) == InputDevice.SOURCE_TOUCHPAD)
 		       ||  isTrackball(e);
 	}

--- a/backends/platform/android/org/scummvm/scummvm/MouseHelper.java
+++ b/backends/platform/android/org/scummvm/scummvm/MouseHelper.java
@@ -99,6 +99,23 @@ public class MouseHelper implements View.OnHoverListener {
 
 	}
 
+	// "Checking against SOURCE_STYLUS only indicates "an input device is capable of obtaining input
+	// from a stylus. To determine whether a given touch event was produced by a stylus, examine
+	// the tool type returned by MotionEvent#getToolType(int) for each individual pointer."
+	// https://developer.android.com/reference/android/view/InputDevice#SOURCE_STYLUS
+	public static boolean isStylus(MotionEvent e){
+		if (e == null) {
+			return false;
+		}
+
+		for(int idx = 0; idx < e.getPointerCount(); idx++) {
+			if (e.getToolType(idx) == MotionEvent.TOOL_TYPE_STYLUS)
+				return true;
+		}
+
+		return false;
+	}
+
 	public static boolean isMouse(KeyEvent e) {
 		if (e == null) {
 			return false;
@@ -131,9 +148,10 @@ public class MouseHelper implements View.OnHoverListener {
 
 		// SOURCE_MOUSE_RELATIVE is sent when mouse is detected as trackball
 		// TODO: why does this happen? Do we need to also check for SOURCE_TRACKBALL here?
+		// TODO: should these all be checks against TOOL_TYPEs instead of SOURCEs?
 		return ((sources & InputDevice.SOURCE_MOUSE) == InputDevice.SOURCE_MOUSE)
-		       || (e.getToolType(0) == MotionEvent.TOOL_TYPE_STYLUS)
 		       || ((sources & InputDevice.SOURCE_TOUCHPAD) == InputDevice.SOURCE_TOUCHPAD)
+		       ||  isStylus(e)
 		       ||  isTrackball(e);
 	}
 

--- a/backends/platform/android/org/scummvm/scummvm/MouseHelper.java
+++ b/backends/platform/android/org/scummvm/scummvm/MouseHelper.java
@@ -9,6 +9,8 @@ import android.view.MotionEvent;
 //import android.view.SurfaceView;
 import android.view.View;
 
+import static android.view.MotionEvent.TOOL_TYPE_STYLUS;
+
 /**
  * Contains helper methods for mouse/hover events that were introduced in Android 4.0.
  */
@@ -99,6 +101,16 @@ public class MouseHelper implements View.OnHoverListener {
 
 	}
 
+	public static boolean isStylus(MotionEvent e){
+		if (e == null) {
+			return false;
+		}
+
+		int toolType = e.getToolType(0);
+
+		return (toolType == TOOL_TYPE_STYLUS);
+	}
+
 	public static boolean isMouse(KeyEvent e) {
 		if (e == null) {
 			return false;
@@ -132,7 +144,7 @@ public class MouseHelper implements View.OnHoverListener {
 		// SOURCE_MOUSE_RELATIVE is sent when mouse is detected as trackball
 		// TODO: why does this happen? Do we need to also check for SOURCE_TRACKBALL here?
 		return ((sources & InputDevice.SOURCE_MOUSE) == InputDevice.SOURCE_MOUSE)
-		       || ((sources & InputDevice.SOURCE_STYLUS) == InputDevice.SOURCE_STYLUS)
+		       ||  isStylus(e)
 		       || ((sources & InputDevice.SOURCE_TOUCHPAD) == InputDevice.SOURCE_TOUCHPAD)
 		       ||  isTrackball(e);
 	}


### PR DESCRIPTION
ANDROID: Fix touchscreen stylus check

Fix issue where all touch input on some tablets was being treated
as mouse input.  Check the tool type used instead of the input device
because SOURCE_STYLUS only indicates a device is capable of obtaining
input from a stylus.  This should fix Ticket #11711.  
