### PR TITLE
COMMON: Add function to flatten QuickTime edit lists

### DIFF
--- a/common/quicktime.cpp
+++ b/common/quicktime.cpp
@@ -807,6 +807,34 @@ void QuickTimeParser::close() {
 	_fd = nullptr;
 }
 
+void QuickTimeParser::flattenEditLists() {
+	// This flattens the movie edit list, collapsing everything into a single edit.
+	// This is necessary to work around sound popping in Obsidian on certain movies:
+	//
+	// For some reason, numerous movies have audio tracks with edit lists consisting
+	// off numerous 0.5-second duration chunks, which is 22050 audio examples at the
+	// 44100Hz media rate, but the edit media times are spaced out 22080 apart.
+	//
+	// The QuickTime File Format reference seems to suggest that this means the audio
+	// would skip ahead 30 samples every half-second, which is what the playback code
+	// currently does, and that causes audible popping in some movies (such as the
+	// cube maze greeter vidbot when she says "Take take take, that's all you ever do!"
+	// after repeatedly visiting her.)
+	//
+	// Other players seem to just play the audio track chunks consecutively without the
+	// 30-sample skips, which produces the correct results, not sure why.
+
+	for (Track *track : _tracks) {
+		if (track->editList.size()) {
+			EditListEntry &lastEntry = track->editList.back();
+			EditListEntry &firstEntry = track->editList.front();
+			firstEntry.trackDuration = (lastEntry.timeOffset + lastEntry.trackDuration);
+
+			track->editList.resize(1);
+		}
+	}
+}
+
 QuickTimeParser::SampleDesc::SampleDesc(Track *parentTrack, uint32 codecTag) {
 	_parentTrack = parentTrack;
 	_codecTag = codecTag;

--- a/common/quicktime.h
+++ b/common/quicktime.h
@@ -78,6 +78,12 @@ public:
 	void close();
 
 	/**
+	 * Flattens edit lists to a single edit containing the first edit contiguously through the last edit.
+	 * Used to work around bad edit offsets.
+	 */
+	void flattenEditLists();
+
+	/**
 	 * Set the beginning offset of the video so we can modify the offsets in the stco
 	 * atom of videos inside the Mohawk/mTropolis archives
 	 * @param offset the beginning offset of the video


### PR DESCRIPTION
Adds a function to flatten the edit lists of a movie, reducing it to a single edit.

Needed to fix this bug in Obsidian: https://github.com/elasota/scummvm/issues/136

For some reason, some vidbot movies have edit lists of exactly-half-second edits, but the audio media time offsets are spaced 22080 apart, causing it to skip ahead 30 audio samples every half-second.  I can't find anything that would explain why this doesn't cause problems elsewhere except that other players might be ignoring edit lists or not handling them accurately.

So, this adds a function that allows the engine to ignore the edit lists, effectively treating the movie as only contiguous tracks.