### PR TITLE
SCUMM: Fix an original palette issue at Stan's in MONKEY1-CD (WORKAROUND)

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -642,6 +642,27 @@ void ScummEngine_v5::o5_setClass() {
 	while ((_opcode = fetchScriptByte()) != 0xFF) {
 		cls = getVarOrDirectWord(PARAM_1);
 
+		// WORKAROUND: In the CD versions of Monkey 1 with the full 256-color
+		// inventory, going at Stan's messes up the color of some objects, such
+		// as the "striking yellow color" of the flower from the forest, the
+		// rubber chicken, or Guybrush's trousers. The following palette fixes
+		// are taken from the Ultimate Talkie Edition.
+		if (_game.id == GID_MONKEY && _game.platform != Common::kPlatformFMTowns &&
+		    _game.platform != Common::kPlatformSegaCD && _roomResource == 59 &&
+		    vm.slot[_currentScript].number == 10002 && obj == 915 && cls == 6 &&
+		    _currentPalette[251 * 3] == 0 && _enableEnhancements &&
+		    strcmp(_game.variant, "SE Talkie") != 0) {
+			// True as long as Guybrush isn't done with the voodoo recipe on the
+			// Sea Monkey. The Ultimate Talkie Edition probably does this as a way
+			// to limit this palette override to Part One; just copy this behavior.
+			if (_scummVars[260] < 8) {
+				setPalColor(245,  68,  68, 68); // gray
+				setPalColor(247, 252, 244,  0); // yellow
+				setPalColor(249, 112, 212,  0); // lime
+			}
+			setPalColor(251, 32, 84, 0); // green
+		}
+
 		// WORKAROUND bug #3099: Due to a script bug, the wrong opcode is
 		// used to test and set the state of various objects (e.g. the inside
 		// door (object 465) of the of the Hostel on Mars), when opening the


### PR DESCRIPTION
In the versions of Monkey Island 1 with the full 256-color inventory, going at Stan's (when he's not there) will mess up the color of some objects, such as the "striking yellow color" of the flower from the forest suddenly being greenish in this room. 

This also happens with the original interpreter.

**Before this fix:**

![scummvm-monkey-00000](https://user-images.githubusercontent.com/9024526/189692225-ddbce69c-bc90-4982-855c-c659d16a153c.png)

**After this fix:**

![scummvm-monkey-00001](https://user-images.githubusercontent.com/9024526/189692232-63423af6-e29e-4efb-b998-a92ce10d3f39.png)

The yellow petals are yellow again, and Guybrush's trousers have their grayish gradient again. (This also fixes some other objects, such as the beak of the rubber chicken.)

The VGA floppy release doesn't appear to have the issue with Guybrush's trousers, so this bug is probably another oversight from the v5 release.

## Technical details

* I'm doing this in `o5_setClass()` because the entry script for room 59 has some `setClass(915,[6])` calls and that's the only reliable point I could find.
* This fix is not applied to the FM-TOWNS and Sega CD releases, since they use a smaller palette, so I think they should be fine (but note that I don't have them).
* The `setPalColor()` calls are taken from the Ultimate Talkie Edition.
* The ` _currentPalette[251 * 3] == 0` check is a quick way of making sure that nothing has changed this color yet. It's also a way of doing this fix only once, since `setClass(915,[6])` is called twice in this script.
* As explained in the comments, `_scummVars[260] < 8` is also taken from the Ultimate Talkie Edition fix. I think this is done so that some colors are only changed during Part One, but not in the last part where you fight against LeChuck.

## How to test

1. Start a v5 version of Monkey1 (i.e. a release with the new inventory icons, except for the SE Talkie version which already fixes this).
2. Use boot param `444` and then use `room 59` in the ScummVM debugger. (Or use any savegame where you have various objects in your inventory, during Part One but when Stan's not at his place).
3. Make sure that the gray, yellow and green colors look OK.
4. You can also try playing the end of the game again, to make sure that there's no regression there, since it reuses this room (boot param `8989` is near, but I'm not sure it properly sets `_scummVars[260]`).

Tested with my CD/DOS/English and CD/DOS/French versions.

Macintosh tests would be welcome (I believe it should also work there). SegaCD/FM-TOWNS would be a plus, but I'm excluding them from this workaround for now.