### PR TITLE
SCUMM: Replicate the original clock tower behavior (COMI)

### DIFF
--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -763,24 +763,6 @@ void ScummEngine_v6::o6_startScript() {
 		o6_breakHere();
 	}
 
-	// WORKAROUND bug #1493: In Puerto Pollo, if you have Guybrush examine
-	// the church clock, he'll read out the current time. Nice touch, only that
-	// it sounds crap in the german version (and maybe others, too). It seems
-	// the original engine of the german version played just a simple fixed
-	// text in this spot, for the above reason. Since the data files are
-	// unchanged, it must have been an engine hack job. No idea how they did
-	// it exactly, but this here is how we do it :-)
-	if (_game.id == GID_CMI && script == 204 &&
-		_currentRoom == 15 && vm.slot[_currentScript].number == 421 &&
-		_language == Common::DE_DEU) {
-
-		_actorToPrintStrFor = 1;
-		_string[0].loadDefault();
-		actorTalk((const byte *)"/VDSO325/Whoa! Look at the time. Gotta scoot.");
-
-		return;
-	}
-
 	runScript(script, (flags & 1) != 0, (flags & 2) != 0, args);
 }
 


### PR DESCRIPTION
**EDIT:** This PR was improved a bit later on. Please see below.

## (original PR; obsolete)

In Monkey Island 3, if Guybrush reads the clock in Puerto Pollo, he'll imitate a [speaking clock](https://en.wikipedia.org/wiki/Speaking_clock). ScummVM disables this for the German release though, since the result was poor for that language, and because it was disabled in that original release (see [Trac#1493](https://bugs.scummvm.org/ticket/1493)).

I see that the official French release did the same thing, back then (tested with my French CDs in a Windows 98 VM, and on Windows 10 running the original interpreter and then using DREAMM).

Indeed, the result isn't really good in French, either. For example, Guybrush will say *"sept-oh-un et trente-un secondes"* while our speaking clock would say *"dix-neuf heures, une minute, trente-et-une secondes"*.

(Dedicated to the French speaking clock, which was closed just a few weeks ago.)

### How to test

1. Have the French version of COMI (I believe it's on Steam and GOG).
2. Start the game with boot param `226`.
3. Go to Puerto Pollo (= the first city), look at the clock tower.
4. Guybrush should now say `"Whoa! Il se fait tard. Je dois m'en aller."` (French for "Look at the time, gotta scoot!") instead of reading the clock. This should be the same behavior as the original French interpreter.