### PR TITLE
SCI: (FPFP/Demo) - fix bug no. 12610

### DIFF
--- a/engines/sci/sound/music.cpp
+++ b/engines/sci/sound/music.cpp
@@ -1236,6 +1236,7 @@ void SciMusic::remapChannels(bool mainThread) {
 #ifdef DEBUG_REMAP
 			debug(" Mapping (dontRemap) song %d, channel %d to device channel %d", songIndex, _channelMap[i]._channel, i);
 #endif
+			resetDeviceChannel(i, mainThread);
 			if (mainThread) _channelMap[i]._song->pMidiParser->mainThreadBegin();
 			_channelMap[i]._song->pMidiParser->remapChannel(_channelMap[i]._channel, i);
 			if (mainThread) _channelMap[i]._song->pMidiParser->mainThreadEnd();


### PR DESCRIPTION
("hanging MIDI notes")

The original interpreter resets the channels more often than we do
in the remap function. The assumption apparently was that the
loop at the very end of the function would catch everything. But
it does not catch the dontRemap channels if they are not within
 the _driverFirstChannel/_driverLastChannel range.
If more bugs like this come up it might be necessary to add even
more resets, but I am very reluctant about unnecessary changes
to the remap function. And this code has been around for a long
time without any other bug reports of this sort. So I think we have
reason to be optimistic about it.
