### PR TITLE
SCUMM: Fix the navigator head text color in MI1 CD (WORKAROUND)

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -3409,6 +3409,19 @@ void ScummEngine_v5::decodeParseStringTextString(int textSlot) {
 		// "I heard that!" offscreen.
 		_string[textSlot].color = 0xF9;
 		printString(textSlot, _scriptPointer);
+	} else if (_game.id == GID_MONKEY && _game.platform != Common::kPlatformSegaCD &&
+			(vm.slot[_currentScript].number == 140 || vm.slot[_currentScript].number == 294) &&
+			_actorToPrintStrFor == 255 && _string[textSlot].color == 0x06 &&
+			strcmp(_game.variant, "SE Talkie") != 0 && _enableEnhancements) {
+		// WORKAROUND: In MI1 CD, the colors when the navigator head speaks are
+		// not the intended ones (dark purple instead of brown), because the
+		// original `Color(6)` parameter was kept without adjusting it for the
+		// v5 palette changes (a common oversight in that version). The verb
+		// options may also look wrong in that scene, but we don't fix that, as
+		// this font in displayed in green, white or purple between the
+		// different releases and scenes, so we don't know the original intent.
+		_string[textSlot].color = 0xEA;
+		printString(textSlot, _scriptPointer);
 	} else if (_game.id == GID_MONKEY && _roomResource == 25 && vm.slot[_currentScript].number == 205) {
 		printPatchedMI1CannibalString(textSlot, _scriptPointer);
 	} else {


### PR DESCRIPTION
Once more, the v5 release of Monkey Island 1 (likely) didn't use the intended color in some places. This is similar to what was found in PR #4266 or #4168. The root cause appears to be identical: the palette was reordered between the v4 and v5 VGA releases, but some color parameters weren't updated (except in the official SegaCD release, and in the fan-made Ultimate Talkie Edition).

## Description

When the navigator head speaks, the v4 VGA floppy release properly kept its text brown, but the v5 VGA release forgot to adjust the `Color(6)` parameters for the v5 palette changes, meaning that the text was in dark purple.

Here's the behavior in the VGA floppy release:
https://www.youtube.com/watch?v=UAvuZsflglw&t=12326s

and here's what happens in the VGA CD release:
https://www.youtube.com/watch?v=u8JGiyPuZ6A&t=12080s

This PR just puts the brown color back again, since that's what used in every other version.

*(The dialogue options may look a bit wrong, too, but we have no consensus on what could have been the original intent for it — see below. So I'm just fixing the navigator head subtitle color.)

## Test

1. Start a v5 release of Monkey Island 1 (different from the SegaCD and Ultimate Talkie Edition, since they already fix this)
2. Run it with boot param `999` (boot params `1212`, `4313` and `6342` can also be used, but don't allow as many interactions)
3. Try using the necklace in your inventory: look at the color of the navigator head's reaction
4. Talk to the navigator head: look at the color of his subtitles

The navigator's lines should be brown (as in every other release), and not dark purple anymore.

Tested with the CD/DOS/English and CD/DOS/French releases. Macintosh and FM-TOWNS tests very welcome!