### PR TITLE
SCUMM: Allow rendering v2 games in forced Amiga mode again

### DIFF
--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -283,7 +283,9 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 		break;
 
 	case Common::kRenderAmiga:
-		if (_game.platform != Common::kPlatformAmiga)
+		// Allow v2 games to be rendered in forced Amiga mode; this works, and
+		// doing this to avoid the "sunburn effect" in MM/Zak is popular.
+		if (_game.platform != Common::kPlatformAmiga && _game.version != 2)
 			_renderMode = Common::kRenderDefault;
 		break;
 


### PR DESCRIPTION
Commit 2fe65d95ef86433460c2c59eca9de022564c2926 limited render modes to suitable targets, but many users are used to render the DOS/V2 versions of Maniac Mansion and Zak in Amiga mode, to avoid the so-called "sunburn effect".  Playing the game with this setting doesn't cause any issue, as far as I know.

![scummvm-maniac-v2-00000](https://user-images.githubusercontent.com/9024526/190900395-45fe6181-e496-4200-be53-118994731325.png)
![scummvm-maniac-v2-00001](https://user-images.githubusercontent.com/9024526/190900396-70d7d410-3f00-4cf7-9cf5-17730feacd38.png)

This trick was known for years I believe, it was mentioned somewhere on our forums and PC Gaming Wiki even mentions it:

* https://www.pcgamingwiki.com/wiki/Maniac_Mansion#Higher_quality_graphics_in_V2_.22enhanced.22_version_.28ScummVM.29
* https://www.pcgamingwiki.com/wiki/Zak_McKracken_and_the_Alien_Mindbenders#Higher_quality_graphics_in_.22enhanced.22_EGA_version_.28ScummVM.29

Tested with my English and French V2/DOS versions of Maniac Mansion and Zak. I don't know if using the Amiga render mode on the Atari ST version works as well, though…

@athrxx: Do you see a problem with this change?