### PR TITLE
COMMON: Add basic text node support to XMLParser

### DIFF
--- a/common/xmlparser.cpp
+++ b/common/xmlparser.cpp
@@ -340,8 +340,24 @@ bool XMLParser::parse() {
 		case kParserNeedHeader:
 		case kParserNeedKey:
 			if (_char != '<') {
-				parserError("Parser expecting key start.");
-				break;
+				if (_allowText) {
+					Common::String text;
+					do {
+						text += _char;
+						_char = _stream->readByte();
+					} while (_char != '<' && _char);
+					if (!_char) {
+						parserError("Unexpected end of file.");
+						break;
+					}
+					if (!textCallback(text)) {
+						parserError("Failed to process text segment.");
+						break;
+					}
+				} else {
+					parserError("Parser expecting key start.");
+					break;
+				}
 			}
 
 			if ((_char = _stream->readByte()) == 0) {

--- a/common/xmlparser.h
+++ b/common/xmlparser.h
@@ -100,7 +100,7 @@ public:
 	/**
 	 * Parser constructor.
 	 */
-	XMLParser() : _XMLkeys(nullptr), _stream(nullptr) {}
+	XMLParser() : _XMLkeys(nullptr), _stream(nullptr), _allowText(false), _char(0) {}
 
 	virtual ~XMLParser();
 
@@ -213,6 +213,17 @@ public:
 		return child->depth > 0 ? _activeKey[child->depth - 1] : 0;
 	}
 
+	/**
+	 * Allow text nodes (eg <tag>this is a text node</tag>) to appear in the
+	 * document.
+	 *
+	 * By default this parser does not allow text nodes and expects all data
+	 * to appear in attributes.
+	 */
+	void setAllowText() {
+		_allowText = true;
+	}
+
 protected:
 
 	/**
@@ -258,6 +269,15 @@ protected:
 	 * By default, all keys are properly closed.
 	 */
 	virtual bool closedKeyCallback(ParserNode *node) {
+		return true;
+	}
+
+	/**
+	 * Called when a text node is found.  This will only be called if
+	 * setAllowText() has been called, otherwise text nodes are considered
+	 * parse errors.
+	 */
+	virtual bool textCallback(const String &val) {
 		return true;
 	}
 
@@ -346,6 +366,7 @@ protected:
 
 private:
 	char _char;
+	bool _allowText; /** Allow text nodes in the doc (default false) */
 	SeekableReadStream *_stream;
 	String _fileName;
 


### PR DESCRIPTION
I'm working on an engine that needs basic text node support in the XML parser.

This is a simple implementation which I think works for my needs, but I'm open to other ideas - eg, should it provide the active element name, or some other structure with more information?