### PR TITLE
SCUMM: GUI: remove forced alignment

### DIFF
--- a/engines/scumm/string_v7.cpp
+++ b/engines/scumm/string_v7.cpp
@@ -449,12 +449,6 @@ void ScummEngine_v7::drawTextImmediately(const byte *text, Common::Rect *clipRec
 
 	_charset->setCurID(charset);
 
-	// If a Hebrew String comes up that is still marked as kStyleAlignLeft we fix it here...
-	if (_language == Common::HE_ISR && !(flags & (kStyleAlignCenter | kStyleAlignRight))) {
-		effFlags = (TextStyleFlags)(flags | kStyleAlignRight);
-		effX = _screenWidth - 1 - effX;
-	}
-
 	_textV7->drawString((const char *)msg, (byte *)vs->getPixels(0, _screenTop), rect, effX, y, vs->pitch, color, effFlags);
 
 	rect.top += _screenTop;
@@ -469,12 +463,6 @@ void ScummEngine_v7::drawBlastTexts() {
 		BlastText &bt = _blastTextQueue[i];
 
 		_charset->setCurID(_blastTextQueue[i].charset);
-
-		// If a Hebrew String comes up that is still marked as kStyleAlignLeft we fix it here...
-		if (_language == Common::HE_ISR && !(bt.flags & (kStyleAlignCenter | kStyleAlignRight))) {
-			bt.flags = (TextStyleFlags)(bt.flags | kStyleAlignRight);
-			bt.xpos = _screenWidth - 1 - bt.xpos;
-		}
 
 		if (bt.flags & kStyleWordWrap) {
 			bt.rect = _wrappedTextClipRect;


### PR DESCRIPTION
Following the wonderful work of @AndywinXp and @athrxx for implementing original GUI [1] and perfecting string rendering

The removed block of code is no longer needed, and seems to cause problems on original GUI display on Hebrew (which the block is scoped to).

Thanks

[1] https://github.com/scummvm/scummvm/pull/4206
