### PR TITLE
VIDEO: Set decoder frame rate when loading Theora video.

### DIFF
--- a/video/theora_decoder.cpp
+++ b/video/theora_decoder.cpp
@@ -169,6 +169,7 @@ bool TheoraDecoder::loadStream(Common::SeekableReadStream *stream) {
 	if (_hasVideo) {
 		_videoTrack = new TheoraVideoTrack(getDefaultHighColorFormat(), theoraInfo, theoraSetup);
 		addTrack(_videoTrack);
+		setRate(_videoTrack->getFrameRate());
 	}
 
 	th_info_clear(&theoraInfo);

--- a/video/theora_decoder.h
+++ b/video/theora_decoder.h
@@ -84,6 +84,7 @@ private:
 		uint16 getHeight() const { return _displaySurface.h; }
 		Graphics::PixelFormat getPixelFormat() const { return _displaySurface.format; }
 		int getCurFrame() const { return _curFrame; }
+		const Common::Rational &getFrameRate() const { return _frameRate; }
 		uint32 getNextFrameStartTime() const { return (uint32)(_nextFrameStartTime * 1000); }
 		const Graphics::Surface *decodeNextFrame() { return &_displaySurface; }
 


### PR DESCRIPTION
Previously the frame rate returned by `TheoraDecoder` was always 0 as it was never set anywhere.

Change it to set the decoder's frame rate to the video frame rate when a video track is loaded.  Possibly not always exactly correct (eg, if there are multiple video tracks), but will be right for most situations.