### PR TITLE
SCUMM: HE: fix costume loop regression

### DIFF
--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -3084,7 +3084,7 @@ void ScummEngine::stopTalk() {
 				// Delay unsetting _heTalking to next sound frame. fixes bug #3533.
 				_actorShouldStopTalking = true;
 			} else {
-				((ActorHE *)a)->_heTalking = true;
+				((ActorHE *)a)->_heTalking = false;
 			}
 		}
 	}


### PR DESCRIPTION
This fixes a regression caused by #4225
In Pajama Sam 2 when Sam hides under the sofa the game is stuck on a loop without advancing to the next lines.
seeing the diff, seems I have accidently negated the boolean value, sorry about that 😅 

Thanks