### PR TITLE
AGOS: FEEBLE: Add subtitles support for SMK videos

### DIFF
--- a/engines/agos/animation.cpp
+++ b/engines/agos/animation.cpp
@@ -416,6 +416,12 @@ MoviePlayerSMK::MoviePlayerSMK(AGOSEngine_Feeble *vm, const char *name)
 
 	memset(baseName, 0, sizeof(baseName));
 	memcpy(baseName, name, strlen(name));
+
+	int16 h = g_system->getOverlayHeight();
+
+	_subtitles.setBBox(Common::Rect(20, h - 120, g_system->getOverlayWidth() - 20, h - 20));
+	_subtitles.setColor(0xff, 0xff, 0xff);
+	_subtitles.setFont("FreeSans.ttf");
 }
 
 bool MoviePlayerSMK::load() {
@@ -430,6 +436,9 @@ bool MoviePlayerSMK::load() {
 	debug(0, "Playing video %s", videoName.c_str());
 
 	CursorMan.showMouse(false);
+
+	Common::String subtitlesName = Common::String::format("%s.srt", baseName);
+	loadSubtitles(subtitlesName.c_str());
 
 	return true;
 }
@@ -457,11 +466,16 @@ void MoviePlayerSMK::copyFrameToBuffer(byte *dst, uint x, uint y, uint pitch) {
 }
 
 void MoviePlayerSMK::playVideo() {
-	while (!endOfVideo() && !_skipMovie && !_vm->shouldQuit())
+	while (!endOfVideo() && !_skipMovie && !_vm->shouldQuit()) {
+		_subtitles.drawSubtitle(getTime(), true);
 		handleNextFrame();
+		g_system->showOverlay();
+		g_system->clearOverlay();
+	}
 }
 
 void MoviePlayerSMK::stopVideo() {
+	g_system->hideOverlay();
 	close();
 }
 

--- a/engines/agos/animation.h
+++ b/engines/agos/animation.h
@@ -26,6 +26,7 @@
 
 #include "video/dxa_decoder.h"
 #include "video/smk_decoder.h"
+#include "video/subtitles.h"
 #include "audio/mixer.h"
 
 namespace AGOS {
@@ -61,11 +62,13 @@ public:
 	virtual void playVideo() = 0;
 	virtual void nextFrame() = 0;
 	virtual void stopVideo() = 0;
+	void loadSubtitles(const char *fname) { _subtitles.loadSRTFile(fname); }
 
 protected:
 	virtual void handleNextFrame();
 	virtual bool processFrame() = 0;
 	virtual void startSound() {}
+	Video::Subtitles _subtitles;
 };
 
 class MoviePlayerDXA : public MoviePlayer, Video::DXADecoder {


### PR DESCRIPTION
This adds subtitles support for The Feeble Files.
based on #4186 

NOTES:
- Only implemented for SMK video. the same method could work for DXA, but couldn't convert with the recent RADTools release to test.
- There is black background when using SDL Surface, which is transparent in OpenGL.

Thanks