### PR TITLE
SCUMM: DEBUGGER: Add OBIM and OBCD offsets to `objects` command

### DIFF
--- a/engines/scumm/debugger.cpp
+++ b/engines/scumm/debugger.cpp
@@ -947,9 +947,9 @@ bool ScummDebugger::Cmd_PrintObjects(int argc, const char **argv) {
 	int i;
 	ObjectData *o;
 	debugPrintf("Objects in current room\n");
-	debugPrintf("+-----------------------------------------------------------+\n");
-	debugPrintf("|num |    name    |  x |  y |width|height|state|fl|   cls   |\n");
-	debugPrintf("+----+------------+----+----+-----+------+-----+--+---------+\n");
+	debugPrintf("+-------------------------------------------------------------------------------+\n");
+	debugPrintf("|num |    name    |  x |  y |width|height|state|fl|   cls   | obimoff | obcdoff |\n");
+	debugPrintf("+----+------------+----+----+-----+------+-----+--+---------+---------+---------+\n");
 
 	for (i = 1; i < _vm->_numLocalObjects; i++) {
 		o = &(_vm->_objs[i]);
@@ -959,9 +959,9 @@ bool ScummDebugger::Cmd_PrintObjects(int argc, const char **argv) {
 		const byte *name = _vm->getObjOrActorName(o->obj_nr);
 		if (!name)
 			name = (const byte *)"(null)";
-		debugPrintf("|%4d|%-12.12s|%4d|%4d|%5d|%6d|%5d|%2d|$%08x|\n",
+		debugPrintf("|%4d|%-12.12s|%4d|%4d|%5d|%6d|%5d|%2d|$%08x|$%08x|$%08x|\n",
 				o->obj_nr, name, o->x_pos, o->y_pos, o->width, o->height, o->state,
-				o->fl_object_index, classData);
+				o->fl_object_index, classData, o->OBIMoffset, o->OBCDoffset);
 	}
 	debugPrintf("\n");
 


### PR DESCRIPTION
This adds the `OBIMoffset` and `OBCDoffset` values to the `objects` table inside the SCUMM debugger. That was quite handy for me when working on PR #4293.

Any objection?

Tested with most of my LucasArts titles, and the handful of HE games I have.