### PR TITLE
SCUMM: Prevent the storekeeper from using the Force in in MI1CD (WORKAROUND)

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -3119,6 +3119,24 @@ void ScummEngine_v5::o5_walkActorTo() {
 	a = derefActor(getVarOrDirectByte(PARAM_1), "o5_walkActorTo");
 	x = getVarOrDirectWord(PARAM_2);
 	y = getVarOrDirectWord(PARAM_3);
+
+	// WORKAROUND: In MI1 CD, when the storekeeper comes back from outside,
+	// he will close the door *after* going to his counter, which looks very
+	// strange, since he's then quite far away from the door. Force calling
+	// the script which closes the door *before* he starts walking away from
+	// it, as in the other releases. Another v5 bug fixed on SegaCD, though!
+	if (_game.id == GID_MONKEY && _game.platform != Common::kPlatformSegaCD && _currentRoom == 30 &&
+		vm.slot[_currentScript].number == 207 && a->_number == 11 && x == 232 && y == 141 &&
+		_enableEnhancements && strcmp(_game.variant, "SE Talkie") != 0) {
+		if (whereIsObject(387) == WIO_ROOM && getState(387) == 1 && getState(437) == 1) {
+			int args[NUM_SCRIPT_LOCAL];
+			memset(args, 0, sizeof(args));
+			args[0] = 387;
+			args[1] = 437;
+			runScript(26, 0, 0, args);
+		}
+	}
+
 	a->startWalkActor(x, y, -1);
 }
 


### PR DESCRIPTION
## Description

In the v5 releases of Monkey Island 1, the storekeeper on Mêlée Island closes the door *after* going to the counter, which looks very strange since he's far away from it, at this point. In the v4 releases, he just closes it *before* walking away from it, which is much more natural.

This also happens in the original interpreter, and in the Special Edition.

AFAIK the storekeeper isn't meant to have the same Jedi powers as the troll on the bridge, so that's probably yet another scripting oversight from the SCUMM v4 to v5 update.

Fix this by calling the related script (`startScript(26,[387,437])`) just before the storekeeper is going to move away from the door (`walkActorTo(11,232,141)`). That `26` script takes care of checking/updating the state of the `[387,437]` objects, so with the additional checks I'm doing, it should be safe. Object `387` is the door itself, actor `11` is the storekeeper.

(This was already fixed in the Ultimate Talkie edition.)

## Test

1. Start any v5 release of Monkey Island 1 with boot param `707`
2. Use the bell on the counter
3. The storekeeper will come back to his shop; make sure he closes the door *before* moving away from it, as intended and as in the other releases.
4. Try this with and without skipping this small cutscene.

Macintosh, FM-TOWNS and SegaCD tests welcome.

**EDIT:** So that's another v5 bug that the SegaCD release already fixed. Interesting 