### PR TITLE
SCUMM: Disable MT-32 support for MONKEY1-VGA-FR

### DIFF
--- a/devtools/scumm-md5.txt
+++ b/devtools/scumm-md5.txt
@@ -216,7 +216,7 @@ monkey	The Secret of Monkey Island
 	d0b531227a27c6662018d2bd05aac52a	8357	de	DOS	VGA	VGA	4 disk v1.1, 14.Feb.91	Fingolfin
 	66fd5ff9a810dfeb6d6bdada18221140	-1	it	DOS	VGA	VGA	4 disk	Andrea Petrucci
 	45152f7cf2ba8f43cf8a8ea2e740ae09	8357	es	DOS	VGA	VGA	4 disk	Fingolfin
-	a01fab4a64d47b96e2e58e6b0f825cc7	8347	fr	DOS	VGA	VGA	8 disk v1.0, 6/4/91 II	Sebast26
+	a01fab4a64d47b96e2e58e6b0f825cc7	8347	fr	DOS	VGA	VGA	8 disk v1.0, 6/4/91 II (incomplete MT-32)	Sebast26
 
 	8776caed014c321272af407c1502a2df	8955	en	Mac	Mac	-	Mac v2.4	Petr Maruska (#3295)
 

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -1921,6 +1921,20 @@ void ScummEngine::setupMusic(int midi, const Common::String &macInstrumentFile) 
 		}
 	}
 
+	// WORKAROUND: MT-32 support is broken in the French VGA floppy version
+	// of MI1 (the index references an invalid DISK00.LEC file, and the
+	// 'roland' room appears to be completely missing). We can't do much about
+	// this; revert to Adlib so that users don't get confused by the error.
+	if (_game.id == GID_MONKEY_VGA && _language == Common::FR_FRA && _sound->_musicType == MDT_MIDI &&
+		memcmp(_gameMD5, "\xa0\x1f\xab\x4a\x64\xd4\x7b\x96\xe2\xe5\x8e\x6b\x0f\x82\x5c\xc7", 16) == 0) {
+		GUI::MessageDialog dialog(
+			_("This particular version of Monkey Island 1 is known to miss some\n"
+			"required resources for MT-32. Using AdLib instead."),
+			_("OK"));
+		dialog.runModal();
+		_sound->_musicType = MDT_ADLIB;
+	}
+
 	if (_game.platform == Common::kPlatformMacintosh && (_game.id == GID_MONKEY2 || _game.id == GID_INDY4)) {
 		// While the Mac versions do have ADL resources, the Mac player
 		// doesn't handle them. So if a song is missing a MAC resource,


### PR DESCRIPTION
The French VGA floppy version of Monkey Island 1 (and, apparently, this version alone) is missing the usual `'roland'` room, and the index references an invalid `DISK00.LEC` file, although the game scripts didn't disable the MT-32 feature itself. This causes a fatal error when trying to run this game with MT-32 support, even with the original interpreter (while it does work with the English and Spanish VGA floppy versions).

(This is not related to the "Roland Upgrade": this one was meant for the EGA version only; the VGA floppy version had MT-32 support included by default, AFAIK.)

We can't do much about this, since many resources appear to be missing, but we can detect this version (since we have the MD5 sum of the `00.LFL` index referencing that invalid `DISK00.LEC` disk) and warn the user before going back to Adlib mode. Otherwise, some users can be confused by the fatal error about the `DISK00.LEC` file (e.g. https://forums.scummvm.org/viewtopic.php?p=97555, https://www.vogons.org/viewtopic.php?t=4066).

OK?