### PR TITLE
[UNSURE] SCUMM: Prevent an OOB _extraBoxFlags access in Actor::remapDirection()

### DIFF
--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -1372,16 +1372,19 @@ int Actor::remapDirection(int dir, bool is_walking) {
 	// actor is in the current room anyway.
 
 	if (!_ignoreBoxes || _vm->_game.id == GID_LOOM) {
-		specdir = _vm->_extraBoxFlags[_walkbox];
-		if (specdir) {
-			if (specdir & 0x8000) {
-				dir = specdir & 0x3FFF;
-			} else {
-				specdir = specdir & 0x3FFF;
-				if (specdir - 90 < dir && dir < specdir + 90)
-					dir = specdir;
-				else
-					dir = specdir + 180;
+		if (_walkbox != kOldInvalidBox) {
+			assert(_walkbox < ARRAYSIZE(_vm->_extraBoxFlags));
+			specdir = _vm->_extraBoxFlags[_walkbox];
+			if (specdir) {
+				if (specdir & 0x8000) {
+					dir = specdir & 0x3FFF;
+				} else {
+					specdir = specdir & 0x3FFF;
+					if (specdir - 90 < dir && dir < specdir + 90)
+						dir = specdir;
+					else
+						dir = specdir + 180;
+				}
 			}
 		}
 

--- a/engines/scumm/actor.h
+++ b/engines/scumm/actor.h
@@ -76,7 +76,7 @@ struct AdjustBoxResult {	/* Result type of AdjustBox functions */
 };
 
 enum {
-	kOldInvalidBox = 255,	// For small header games
+	kOldInvalidBox = 255,	// For GF_SMALL_HEADER games
 	kNewInvalidBox = 0
 };
 

--- a/engines/scumm/boxes.cpp
+++ b/engines/scumm/boxes.cpp
@@ -165,7 +165,7 @@ static Common::Point closestPtOnLine(const Common::Point &lineStart, const Commo
 byte ScummEngine::getMaskFromBox(int box) {
 	// WORKAROUND for bug #791 and #897. This appears to have been a
 	// long standing bug in the original engine?
-	if (_game.version <= 3 && box == 255)
+	if (_game.version <= 3 && box == kOldInvalidBox)
 		return 1;
 
 	Box *ptr = getBoxBaseAddr(box);
@@ -453,7 +453,7 @@ byte ScummEngine::getNumBoxes() {
 
 Box *ScummEngine::getBoxBaseAddr(int box) {
 	byte *ptr = getResourceAddress(rtMatrix, 2);
-	if (!ptr || box == 255)
+	if (!ptr || box == kOldInvalidBox)
 		return nullptr;
 
 	// WORKAROUND: The NES version of Maniac Mansion attempts to set flags for boxes 2-4


### PR DESCRIPTION
⚠️ I'm submitting this one in good faith, but I'd need a review from someone with more experience in the SCUMM boxes code than me…

When building with `--enable-ubsan` (with clang++ 14.0 on macOS 12.6) and if I:

1. Start a new Loom Talkie game
2. Click on the leaf on the tree, and let it fall

then UBSan catches this:

```
engines/scumm/actor.cpp:1375:13: runtime error: index 255 out of bounds for type 'uint16[65]'
```

which comes from:

https://github.com/scummvm/scummvm/blob/9c7c48077a86eabde9e91a8eabf60b8cb4727863/engines/scumm/actor.cpp#L1375

`_walkbox` is equal to `kOldInvalidBox` (= 255) in that case, but this array only has 65 elements.

Reading nearby code, the top of `ScummEngine::getMaskFromBox()` and [Trac#791](https://bugs.scummvm.org/ticket/791), I wonder if this could be another case where we need to exclude `kOldInvalidBox` walkboxes, while the original interpreters forgot to do this and did an OOB access too.

But this is just a guess… so I'm putting this in Draft status for now.