### PR TITLE
CI: Explicitly use the Bash shell on macOS and Linux for proper `pipefail`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
     env:
       BUILDCACHE_MAX_CACHE_SIZE: 2000000000
       BUILDCACHE_HARD_LINKS: true
+    defaults:
+      run:
+        # Must be explicit for proper pipefail support
+        shell: bash
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -140,7 +144,7 @@ jobs:
           cache_key: ${{ matrix.platform }}
       - name: Build scummvm
         run: |
-          set -o pipefail && xcodebuild CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ build -project scummvm.xcodeproj ${{ matrix.buildFlags }} | awk '$1 !~ /^(export|cd|clang++)/'
+          xcodebuild CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ build -project scummvm.xcodeproj ${{ matrix.buildFlags }} | awk '$1 !~ /^(export|cd|clang++)/'
           ls
   ubuntu:
     name: Ubuntu
@@ -159,6 +163,10 @@ jobs:
             aptPackages: 'g++-4.8 libsdl1.2-dev libsdl-net1.2-dev liba52-dev libjpeg-turbo8-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev libfribidi-dev libcurl4-openssl-dev libgtk-3-dev libspeechd-dev libsndio-dev libunity-dev'
     env:
       SDL_CONFIG: ${{ matrix.sdlConfig }}
+    defaults:
+      run:
+        # Must be explicit for proper pipefail support
+        shell: bash
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This is a follow-up to commit 5fe99667ce48699c7b8053440f1d0235b52c5826.

According to <https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell>, if the Bash shell is used as an implicit configuration instead of an explicit configuration, it won't be run with the `set -o pipefail` option, on Linux and macOS runners.

I think it's probably just better to always enable `pipefail` in the main shell of a CI environment, but maybe someone sees a reason why we should keep things the way they are? Hence the PR.