### PR TITLE
GUI: Rework launcher grouping

### DIFF
--- a/gui/MetadataParser.cpp
+++ b/gui/MetadataParser.cpp
@@ -69,9 +69,10 @@ bool MetadataParser::parserCallback_company(ParserNode *node) {
 
 bool MetadataParser::closedKeyCallback(ParserNode *node) {
 	if (node->name == "game")
-		_gameInfo[node->values["id"]] = MetadataGame(node->values["id"], node->values["name"], node->values["engine_id"],
-										node->values["company_id"],	node->values["moby_id"], node->values["datafiles"],
-										node->values["series_id"]);
+		_gameInfo[Common::String::format("%s:%s",
+			node->values["engine_id"].c_str(), node->values["id"].c_str())] = MetadataGame(
+			node->values["id"], node->values["name"], node->values["engine_id"], node->values["company_id"],
+			node->values["moby_id"], node->values["datafiles"], node->values["series_id"]);
 	if (node->name == "engine")
 		_engineInfo[node->values["id"]] = MetadataEngine(node->values["id"], node->values["name"], node->values["alt_name"],
 											true);

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -1150,8 +1150,9 @@ void LauncherSimple::groupEntries(const Common::Array<const Common::ConfigManage
 	}
 	case kGroupByCompany: {
 		for (uint i = 0; i < metadata.size(); ++i) {
-			Common::U32String gameid = metadata[i]->getVal(Common::String("gameid"));
-			attrs.push_back(_metadataParser._gameInfo[gameid].company_id);
+			Common::String gameid = metadata[i]->getVal("gameid");
+			Common::String engineid = metadata[i]->getVal("engineid");
+			attrs.push_back(_metadataParser._gameInfo[buildQualifiedGameName(engineid, gameid)].company_id);
 		}
 		_list->setGroupHeaderFormat(Common::U32String(""), Common::U32String(""));
 		// I18N: List grouping when no pubisher is specified
@@ -1168,8 +1169,9 @@ void LauncherSimple::groupEntries(const Common::Array<const Common::ConfigManage
 	}
 	case kGroupBySeries: {
 		for (uint i = 0; i < metadata.size(); ++i) {
-			Common::U32String gameid = metadata[i]->getVal(Common::String("gameid"));
-			attrs.push_back(_metadataParser._gameInfo[gameid].series_id);
+			Common::String gameid = metadata[i]->getVal("gameid");
+			Common::String engineid = metadata[i]->getVal("engineid");
+			attrs.push_back(_metadataParser._gameInfo[buildQualifiedGameName(engineid, gameid)].series_id);
 		}
 		_list->setGroupHeaderFormat(Common::U32String(""), Common::U32String(""));
 		// I18N: List group when no game series is specified
@@ -1345,8 +1347,9 @@ void LauncherGrid::groupEntries(const Common::Array<const Common::ConfigManager:
 	}
 	case kGroupBySeries: {
 		for (uint i = 0; i < metadata.size(); ++i) {
-			Common::U32String gameid = metadata[i]->getVal(Common::String("gameid"));
-			attrs.push_back(_metadataParser._gameInfo[gameid].series_id);
+			Common::String gameid = metadata[i]->getVal("gameid");
+			Common::String engineid = metadata[i]->getVal("engineid");
+			attrs.push_back(_metadataParser._gameInfo[buildQualifiedGameName(engineid, gameid)].series_id);
 		}
 		_grid->setGroupHeaderFormat(Common::U32String(""), Common::U32String(""));
 		// I18N: List grouping when no game series is specified
@@ -1359,8 +1362,9 @@ void LauncherGrid::groupEntries(const Common::Array<const Common::ConfigManager:
 	}
 	case kGroupByCompany: {
 		for (uint i = 0; i < metadata.size(); ++i) {
-			Common::U32String gameid = metadata[i]->getVal(Common::String("gameid"));
-			attrs.push_back(_metadataParser._gameInfo[gameid].company_id);
+			Common::String gameid = metadata[i]->getVal("gameid");
+			Common::String engineid = metadata[i]->getVal("engineid");
+			attrs.push_back(_metadataParser._gameInfo[buildQualifiedGameName(engineid, gameid)].company_id);
 		}
 		_grid->setGroupHeaderFormat(Common::U32String(""), Common::U32String(""));
 		// I18N: List group when no publisher is specified

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -1336,7 +1336,7 @@ void LauncherGrid::groupEntries(const Common::Array<LauncherEntry> &metadata) {
 	switch (_groupBy) {
 	case kGroupByFirstLetter: {
 		for (Common::Array<LauncherEntry>::const_iterator iter = metadata.begin(); iter != metadata.end(); ++iter) {
-			attrs.push_back(iter->description.substr(0, 1));
+			attrs.push_back(iter->title.substr(0, 1));
 		}
 		_grid->setGroupHeaderFormat(Common::U32String(""), Common::U32String("..."));
 		break;

--- a/gui/launcher.h
+++ b/gui/launcher.h
@@ -204,7 +204,7 @@ public:
 	int runModal();
 	void selectLauncher();
 
-	Common::StringMap *getGameList() { return &_games; }
+	const Common::StringMap &getGameList() { return _games; }
 
 private:
 	void genGameList();


### PR DESCRIPTION
This PR adds fields to LauncherEntry structure and makes the building process of the entries list common to both launchers.
It also make sure that when metadata is queried the engined ID is used to match games and not only the game ID as this prevent miscategorization of games because of game ID clashes.
Finally, in grid mode, when grouping by first letter, the title is used as it's what is displayed on the screen.
