### PR TITLE
MADE: Add detection for FM-Towns version of The Manhole

### DIFF
--- a/engines/made/detection_tables.h
+++ b/engines/made/detection_tables.h
@@ -505,6 +505,23 @@ static const MadeGameDescription gameDescriptions[] = {
 	},
 
 	{
+		// The Manhole
+		{
+			"manhole",
+			"",
+			AD_ENTRY1s("manhole.dat", "2f14b5d87a862aad25701514dc282475", 119667),
+			Common::JA_JPN,
+			Common::kPlatformFMTowns,
+			ADGF_CD | ADGF_UNSTABLE,
+			GUIO1(GUIO_NOSPEECH)
+		},
+		GID_MANHOLE,
+		0,
+		GF_CD,
+		3,
+	},
+
+	{
 		// Leather Goddesses of Phobos 2 (English)
 		{
 			"lgop2",


### PR DESCRIPTION
Marked as ADGF_UNSTABLE due to lacking MUSIC.BLK (entirely CD-Audio). Commenting out the check for this file gives another error later on: `Failed to find picture 10`

CD contents:
```
 187 Jun 22  1990 AUTOEXEC.BAT
  84 Jun 22  1990 CONFIG.SYS
 33K Jun 22  1990 CONTROL.EXE
 863 Jun 22  1990 DICUTY.COM
128K Jun 22  1990 DRIVE_R.IMG
 76K Jun 22  1990 IO.SYS
117K Sep  7  1990 MANHOLE.DAT
112K Sep  7  1990 MH.EXP
6.0K Jun 22  1990 OAK2USR.DIC
4.3M Sep  7  1990 PICS.BLK
 73K Jul 17  1990 RUN386.EXE
 59K Sep  7  1990 SNDS.BLK
 80K Jun 22  1990 TBIOS.BIN
 387 Jun 22  1990 TBIOS.SYS
238K Jun 22  1990 TMENU.EXP
 32K Jul 17  1990 TMENU.ICN
 128 Jul 17  1990 TMENU.INF
112K Jun 22  1990 T_OAK2.EXE
```