### PR TITLE
AGS: Fix ReadEncInt32() on big-endian systems

### DIFF
--- a/engines/ags/shared/util/multi_file_lib.cpp
+++ b/engines/ags/shared/util/multi_file_lib.cpp
@@ -402,9 +402,10 @@ int32_t MFLUtil::ReadEncInt32(Stream *in, int &rand_val) {
 	int val;
 	ReadEncArray(&val, sizeof(int32_t), 1, in, rand_val);
 #if AGS_PLATFORM_ENDIAN_BIG
-	AGS::Shared::BitByteOperations::SwapBytesInt32(val);
-#endif
+	return AGS::Shared::BitByteOperations::SwapBytesInt32(val);
+#else
 	return val;
+#endif
 }
 
 void MFLUtil::ReadEncString(char *buffer, size_t max_len, Stream *in, int &rand_val) {


### PR DESCRIPTION
User Joseito reported on Discord that `kq1agdi` crashes on Wii, with `Common::vector` trying to allocate 1409286144 bytes (= 1.4 GB).

This is because `MFLUtil::ReadEncInt32()` didn't properly use the return value of `SwapBytesInt32()`, when building for a big-endian system. Then, huge values would be returned to `MFLUtil::ReadV21()`. The following diff just adds the missing intended `return` keyword, so that the value is properly swapped for big-endian.

This is a backport of my https://github.com/adventuregamestudio/ags/pull/1798 upstream PR, which has been merged.

OK to also backport this to `branch-2-6`?