### PR TITLE
MOHAWK: hide overlay when movie is skipped

### DIFF
--- a/engines/mohawk/video.cpp
+++ b/engines/mohawk/video.cpp
@@ -51,6 +51,7 @@ VideoEntry::~VideoEntry() {
 }
 
 void VideoEntry::close() {
+	g_system->hideOverlay();
 	delete _video;
 	_video = nullptr;
 }
@@ -194,13 +195,12 @@ VideoEntryPtr VideoManager::playMovie(uint16 id) {
 bool VideoManager::updateMovies() {
 	bool updateScreen = false;
 
-	g_system->showOverlay();
-	g_system->clearOverlay();
-
 	for (VideoList::iterator it = _videos.begin(); it != _videos.end(); ) {
+		g_system->showOverlay();
+		g_system->clearOverlay();
+
 		// Check of the video has reached the end
 		if ((*it)->endOfVideo()) {
-			g_system->hideOverlay();
 			if ((*it)->isLooping()) {
 				// Seek back if looping
 				(*it)->seek((*it)->getStart());


### PR DESCRIPTION
Fixes https://bugs.scummvm.org/ticket/13874
Which was caused by #4285 , sorry.

The issue was caused when using OpenGL graphics, if the opening logo movie is skipped (so the end was not reached according to `VideoManager`)
also fixed that overlay will not be shown if there are no movies to play.
