### PR TITLE
SCUMM: Let Max finish his comment on capitalism at Snuckey's (WORKAROUND)

### DIFF
--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -2377,6 +2377,24 @@ void ScummEngine_v6::o6_talkActor() {
 		return;
 	}
 
+	// WORKAROUND: If Sam tries to buy an object at Snuckey's without having
+	// any money, Max's comment on capitalism may be cut too early because the
+	// employee reacts immediately after Max without any prior waitForMessage().
+	// The magic values below come from scripts 11-67 and 11-205.
+	//
+	// This call can't just be inserted after Max's line; it needs to be done
+	// just before the employee's line, otherwise the timing with Sam's moves
+	// will feel off -- so we can't use the _forcedWaitForMessage trick.
+	if (_game.id == GID_SAMNMAX && _roomResource == 11 && vm.slot[_currentScript].number == 67
+		&& getOwner(70) != 2 && !readVar(0x8000 + 67) && !readVar(0x8000 + 39) && readVar(0x8000 + 12) == 1
+		&& !getClass(126, 6) && _enableEnhancements) {
+		if (VAR(VAR_HAVE_MSG)) {
+			_scriptPointer--;
+			o6_breakHere();
+			return;
+		}
+	}
+
 	_actorToPrintStrFor = pop();
 
 	// WORKAROUND for bug #3803: "DOTT: Bernard impersonating LaVerne"


### PR DESCRIPTION
## Description

In Sam & Max, if one tries to buy an object at Snuckey's without having the money for it, the employee will tell you to put it back where you've picked it up. As usual, Max has a funny comment for this, but his line will be very quickly cut by the "Anything else?" question from the employee.

This PR makes sure that Max will be able to finish his sentence.

This small oversight also happens in the original DOS interpreter (run through DREAMM) and with the 2002 interpreter from Aaron Giles.

## Technical details

As already done in `o6_talkActor()`, I'm just emulating the missing `waitForMessage()`.

I'm reusing some checks from scripts 11-67 and 11-205 in order to only target the impacted line.

We can't reuse the `_forcedWaitForMessage` trick, since we want to add the missing `waitForMessage()` *immediately before* the employee's line, and not just right after Max's line. Otherwise, Sam will wait for too long near the counter and this feels odd.

## Testing

1. Start a new Sam & Max game. **Don't** pick up the money at your office.
2. Take your car and go at Snuckey's (any hamburger icon on the map).
3. Pick up the pecan-flavored candies on the top of the leftmost display.
4. Talk to the employee, ask about it.
5. Max's reaction about capitalism should be heard/seen in full, whether you're playing in subtitles/speech/both mode.

Optionally, pick up one of the Sam & Max games on the right too (so that Sam has to put back several objects). You can also test the case where Max goes away, by asking for the bathroom key, etc.

Tested with the CD/English, CD/French, CD/German, Floppy/French DOS releases.

Tests on the Macintosh version would be nice, although I'm pretty confident it will work there too.