### PR TITLE
BASE: Add C++11 char array initialized by a string literal test

### DIFF
--- a/base/test_new_standards.cpp
+++ b/base/test_new_standards.cpp
@@ -120,6 +120,16 @@ private:
 		// don't do anything with i
 	};
 
+#ifndef DONT_TEST_STRING_LITERAL_INIT
+	// ----------------------------------
+	// Char arrays initialized by a string literal
+	// * note - not properly implemented before GCC 5.1 (GCC Bug #43453)
+	// ----------------------------------
+	char _emptyMsg[1] = "";
+#else
+	char _emptyMsg[1] = { '\0' };
+#endif
+
 #ifndef DONT_TEST_FINAL_FUNCTION
 	// ----------------------------------
 	// Non-Overridable Member Functions (final)


### PR DESCRIPTION
C++11 char arrays initialized by a string literal were not properly implemented before GCC 5.1: <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=43453#c7>.

But we still have some ports using older GCC versions, such as the RISC OS, Dreamcast and OS X PPC ports.

Sometimes, some code wants to use this feature (see commit 6ac3994e3e582ec6a304c2a566bb1b0c69d507d2), so we've forced one of our runners to use an older GCC version to catch this: PR #4164. Otherwise, the build will fail with `error: array used as initializer`.

I thought that also adding it to our C++11 test suit made sense, then?

Tested on the OS X PPC environment (using `./configure --enable-test-c++11`), with G++ 4.8.5 and G++ 7.5.0, and then on macOS 12.6 with Clang++ 14.0. Also tested with MSVC 2022.