### PR TITLE
[DONTMERGE] SCUMM: Fix COMI lip-syncing on big-endian hosts

### DIFF
--- a/engines/scumm/imuse_digi/dimuse_dispatch.cpp
+++ b/engines/scumm/imuse_digi/dimuse_dispatch.cpp
@@ -936,24 +936,37 @@ int IMuseDigital::dispatchNavigateMap(IMuseDigiDispatch *dispatchPtr) {
 			// within the interpreter, so I'm not going to argue with it
 
 			if (!dispatchPtr->trackPtr->syncPtr_0) {
-				dispatchPtr->trackPtr->syncPtr_0 = (byte *)malloc(READ_UINT32(mapCurEvent + 4));
-				memcpy(dispatchPtr->trackPtr->syncPtr_0, mapCurEvent + 3 * 4, READ_UINT32(mapCurEvent + 4));
-				dispatchPtr->trackPtr->syncSize_0 = READ_UINT32(mapCurEvent + 4);
+				const int32 size = READ_UINT32(mapCurEvent + 4);
+				assert(size % 4 == 0);
+				dispatchPtr->trackPtr->syncSize_0 = size;
+				dispatchPtr->trackPtr->syncPtr_0 = (byte *)malloc(size);
+				for (int32 i = 0; i < size / 4; i++)
+					WRITE_LE_UINT32(&(dispatchPtr->trackPtr->syncPtr_0[i * 4]), READ_UINT32(mapCurEvent + (3 * 4) + (i * 4)));
 
 			} else if (!dispatchPtr->trackPtr->syncPtr_1) {
-				dispatchPtr->trackPtr->syncPtr_1 = (byte *)malloc(READ_UINT32(mapCurEvent + 4));
-				memcpy(dispatchPtr->trackPtr->syncPtr_1, mapCurEvent + 3 * 4, READ_UINT32(mapCurEvent + 4));
-				dispatchPtr->trackPtr->syncSize_1 = READ_UINT32(mapCurEvent + 4);
+				const int32 size = READ_UINT32(mapCurEvent + 4);
+				assert(size % 4 == 0);
+				dispatchPtr->trackPtr->syncSize_1 = size;
+				dispatchPtr->trackPtr->syncPtr_1 = (byte *)malloc(size);
+				for (int32 i = 0; i < size / 4; i++)
+					WRITE_LE_UINT32(&(dispatchPtr->trackPtr->syncPtr_1[i * 4]), READ_UINT32(mapCurEvent + (3 * 4) + (i * 4)));
 
 			} else if (!dispatchPtr->trackPtr->syncPtr_2) {
-				dispatchPtr->trackPtr->syncPtr_2 = (byte *)malloc(READ_UINT32(mapCurEvent + 4));
-				memcpy(dispatchPtr->trackPtr->syncPtr_2, mapCurEvent + 3 * 4, READ_UINT32(mapCurEvent + 4));
-				dispatchPtr->trackPtr->syncSize_2 = READ_UINT32(mapCurEvent + 4);
+				const int32 size = READ_UINT32(mapCurEvent + 4);
+				assert(size % 4 == 0);
+				dispatchPtr->trackPtr->syncSize_2 = size;
+				dispatchPtr->trackPtr->syncPtr_2 = (byte *)malloc(size);
+				for (int32 i = 0; i < size / 4; i++)
+					WRITE_LE_UINT32(&(dispatchPtr->trackPtr->syncPtr_2[i * 4]), READ_UINT32(mapCurEvent + (3 * 4) + (i * 4)));
 
 			} else if (!dispatchPtr->trackPtr->syncPtr_3) {
-				dispatchPtr->trackPtr->syncPtr_3 = (byte *)malloc(READ_UINT32(mapCurEvent + 4));
-				memcpy(dispatchPtr->trackPtr->syncPtr_3, mapCurEvent + 3 * 4, READ_UINT32(mapCurEvent + 4));
-				dispatchPtr->trackPtr->syncSize_3 = READ_UINT32(mapCurEvent + 4);
+				const int32 size = READ_UINT32(mapCurEvent + 4);
+				assert(size % 4 == 0);
+				dispatchPtr->trackPtr->syncSize_3 = size;
+				dispatchPtr->trackPtr->syncPtr_3 = (byte *)malloc(size);
+				for (int32 i = 0; i < size / 4; i++)
+					WRITE_LE_UINT32(&(dispatchPtr->trackPtr->syncPtr_3[i * 4]), READ_UINT32(mapCurEvent + (3 * 4) + (i * 4)));
+
 			}
 
 			continue;


### PR DESCRIPTION
⚠️ **WIP work, don't merge!**

User Im_Percynator [reported on the forums](https://forums.scummvm.org/viewtopic.php?t=16666) that the 2.6.0 release on vWii has broken lip-syncing in COMI. I can reproduce this on a PowerBook G4 (with GDB and all that).

@AndywinXp helped me debugging this; we know that there's at least a problem with the `SYNC` chunks. 

The first commit in this PR restores part of the lip-syncing feature, by making sure that what's put inside `dispatchPtr->trackPtr->syncPtr` is treated as a series of little-endian uint32.

See this video (little-endian on the left, big-endian on the right) for the current status:  
https://youtu.be/aofWrNOjnHc

Notice that Murray "lip" syncing is still off during his second reaction, even with this fix.