### PR TITLE
AGI: Initial Implemention of AGI's log() Function

### DIFF
--- a/engines/agi/op_cmd.cpp
+++ b/engines/agi/op_cmd.cpp
@@ -784,7 +784,49 @@ void cmdLoadGame(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
 void cmdInitDisk(AgiGame *state, AgiEngine *vm, uint8 *parameter) {             // do nothing
 }
 
-void cmdLog(AgiGame *state, AgiEngine *vm, uint8 *parameter) {              // do nothing
+// The log command adds an entry to the game's log file. The log format is:
+//
+// Room <#>
+// Input line : <text>
+// <message>
+//
+// Note: If AGI encounters any file errors while trying to open or write to
+// the logfile, it just ignores the errors, and does not write the log file entry.
+//
+// This is not yet a complete implementation of log(). There
+// are two follow-up items which are planned to be addressed.
+//
+// 1. No Log Formatting
+// We just log the message literally without
+// processing. According to the docs, you can use variables in the message, like:
+//
+// log("Unknown word: %w1"); [ This should log the first word the user typed.
+//
+// Other format codes include:
+// %g<number>: the text of the message with this number from message field of logic 0 is inserted at this place.
+// %m<number>: the text of the message with the given number(in this same logic) is inserted at this place.
+// %o<number>: the name of the inventory item that has an index number equal to the value of the variable given by <number> is inserted at this place.
+// %s<number>: the text of the string with the given number is inserted at this place.
+// %v<number>: at this place the output will include a decimal value of variable with the given number.
+// %w<number>: the text of the player - entered word with the given index number is inserted at this place. (The index is 'one based'; i.e.first word is % w1, second is % w2, etc.)
+//
+// 2. Logs not written to a file.
+// At the moment we are just logging to the console. To see
+// the logs, use the following arguments to scummvm:
+//
+// --debugflags=Scripts -d 1
+//
+void cmdLog(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
+	uint16 textNr = parameter[0];
+	if (state->_curLogic->texts != nullptr && (textNr - 1) <= state->_curLogic->numTexts) {
+		byte currentRoom = vm->getVar(VM_VAR_CURRENT_ROOM);
+		const char *inputLine = (char *)vm->_text->_promptPrevious;
+		const char *message = state->_curLogic->texts[textNr - 1];
+
+		debugC(1, kDebugLevelScripts, "Room %hhu", currentRoom);
+		debugC(1, kDebugLevelScripts, "Input line : %s", inputLine);
+		debugC(1, kDebugLevelScripts, "%s", message);
+	}
 }
 
 void cmdTraceOn(AgiGame *state, AgiEngine *vm, uint8 *parameter) {              // do nothing


### PR DESCRIPTION
This log() function was previously unimplemented in ScummVM. Its purpose is to write log messages and some metadata about the game state to a file.

This functionality does not affect game play. Presumably Sierra used this to beta test their games. They would log the words that their testers used but the game did not understand. The testers would then submit the log file back to Sierra. Sierra would add the missing words or descriptions to their games before release.

This is the first diff of a couple which will incrementally add this functionality. In this diff, we just collect the information we need to generate a log message close to what AGI actually did.

There are two notable differences which will be fixed in future diffs: (See the comments in the code for more details.)
1. No message formatting.
2. We log to the console only.

For context, I'm currently writing an AGI game and would like to collect this output from my friends and family, which is why I'm implementing this functionality today.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
