### PR TITLE
BACKENDS: Fix GCC warning

### DIFF
--- a/backends/graphics/opengl/pipelines/libretro/parser.cpp
+++ b/backends/graphics/opengl/pipelines/libretro/parser.cpp
@@ -196,7 +196,7 @@ bool PresetParser::lookUpValue(const Common::String &key, uint *value) {
 		const long uintVal = strtol(iter->_value.c_str(), &endptr, 0);
 		// Original libretro is quite laxist with int values and only checks errno
 		// This means that as long as there is some number at start, parsing won't fail
-		if (endptr == iter->_value.c_str() || uintVal >= UINT_MAX || uintVal < 0) {
+		if (endptr == iter->_value.c_str() || (long long)uintVal >= UINT_MAX || uintVal < 0) {
 			_errorDesc = "Invalid unsigned integer value for key '" + key + "': '" + iter->_value + '\'';
 			return false;
 		} else {


### PR DESCRIPTION
```
parser.cpp:199:63: warning: comparison of integer expressions of different signedness: 'const long int' and 'unsigned int' [-Wsign-compare]
  199 |                 if (endptr == iter->_value.c_str() || uintVal >= UINT_MAX || uintVal < 0) {
      |
```
