### PR TITLE
SCUMM: Drop subtitle workaround for Trac#2215 in Indy4

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2812,20 +2812,9 @@ void ScummEngine_v5::o5_stopObjectScript() {
 }
 
 void ScummEngine_v5::o5_stopScript() {
-	const byte *oldaddr = _scriptPointer - 1;
 	int script;
 
 	script = getVarOrDirectByte(PARAM_1);
-
-	if (_game.id == GID_INDY4 && script == 164 &&
-		_roomResource == 50 && vm.slot[_currentScript].number == 213 && VAR(VAR_HAVE_MSG)) {
-		// WORKAROUND bug #2215: Due to a script bug, a line of text is skipped
-		// which Indy is supposed to speak when he finds Orichalcum in some old
-		// bones in the caves below Crete.
-		_scriptPointer = oldaddr;
-		o5_breakHere();
-		return;
-	}
 
 	if (!script)
 		stopObjectCode();


### PR DESCRIPTION
This is one is about *removing* an old workaround!

## Description

See [Trac#2215](https://bugs.scummvm.org/ticket/2215) for the original  issue.

We have a "missing `waitForActor()`" workaround for a script in Indy4 (when Indy finds some orichalcum beads in some bones in Crete), but actually the subtitle just shows fine in both the original interpreter (running DOSBox and DREAMM) and modern ScummVM, for me.

Here's what script 50-213 does:

```
...
[00B1] (48)     if (Local[0] == 621) {
[00B8] (48)       if (VAR_ROOM == 160) {
[00BF] (1D)         if (classOfIs(621,[154])) {
[00C8] (D8)           printEgo([Text(sound(0x682BB53, 0xE) + "Another poor soul who couldn't find his way\x10out.")]);
[010B] (18)         } else {
[010E] (40)           cutscene([2]);
[0113] (11)           animateCostume(1,12);
[0116] (2A)           startScript(164,[5,92,134,100,255,1],F);
[012B] (80)           breakHere();
[012C] (80)           breakHere();
[012D] (80)           breakHere();
[012E] (D8)  # ===>   printEgo([Text(sound(0x6833013, 0x12) + "There are two orichalcum beads in these\x10bones!")]);
[016F] (80)           breakHere();
[0170] (80)           breakHere();
[0171] (80)           breakHere();
[0172] (62)           stopScript(164);
[0174] (2D)           putActorInRoom(5,0);
[0177] (37)           startObject(933,250,[2]);
[017F] (5D)           setClass(621,[146,154]);
[0189] (11)           animateCostume(1,3);
[018C] (C0)           endCutscene();
[018D] (**)         }
[018D] (18)       } else {
[0190] (D8)         printEgo([Text(sound(0x683AD0A, 0x12) + "Bones of previous explorers, no\x10doubt.")]);
[01C9] (**)       }
...
```

Since there's no bug in the original interpreter, I guess our implementation of the SCUMM engine improved since 2006, and now we don't see this issue either. So I don't see any reason to keep this workaround.

This effectively reverts commit 549eb83986a9991b963a6330fc51f7d563b3dc72.

## Test

1. Start any release of Indy4
2. Either load one of the old savegames in the Trac issue above, or use `room 160` (`shinymetal` > Ctrl-Shift-D > Ctrl-G > `160` in the original interpreters)
3. Look at the bones on the floor
4. Make sure that the `"There are two orichalcum beads in these bones!"` line is properly said/printer, and not interrupted.

Tested with the DOS/Floppy/French, DOS/Talkie/English and Macintosh/Talkie/English releases.