### PR TITLE
AGI: Write log() Function to File

### DIFF
--- a/engines/agi/agi.cpp
+++ b/engines/agi/agi.cpp
@@ -395,6 +395,7 @@ AgiEngine::AgiEngine(OSystem *syst, const AGIGameDescription *gameDesc) : AgiBas
 	_menu = nullptr;
 	_systemUI = nullptr;
 	_inventory = nullptr;
+	_logFile = nullptr;
 
 	_keyHoldMode = false;
 	_keyHoldModeLastKey = Common::KEYCODE_INVALID;
@@ -494,6 +495,11 @@ AgiEngine::~AgiEngine() {
 	if (_gfx) {
 		_gfx->deinitVideo();
 	}
+	if (_logFile) {
+		_logFile->finalize();
+		_logFile->close();
+	}
+	delete _logFile;
 	delete _inventory;
 	delete _systemUI;
 	delete _menu;

--- a/engines/agi/agi.h
+++ b/engines/agi/agi.h
@@ -847,6 +847,7 @@ public:
 	AgiLoader *_loader; // loader
 	GfxMenu *_menu;
 	SystemUI *_systemUI;
+	Common::DumpFile *_logFile; // File used for the log() agi command.
 
 	Common::Stack<ImageStackElement> _imageStack;
 
@@ -898,6 +899,8 @@ public:
 	void allowSynthetic(bool);
 	void processScummVMEvents();
 	void checkQuickLoad();
+
+	const Common::String getTargetName() const { return _targetName; }
 
 	// Objects
 public:


### PR DESCRIPTION
Now the log() function writes to a file, as
the AGI engine did.

It appears that ScummVM doesn't have any "append" functionality. As a result, I made this implementation create a new file each time ScummVM it started and a message is logged. The file name includes the game name and the current time, ensuring that logs won't be overwritten.

The format is: agi.\<gameid\>.\<currentime\>.log and will be logged to the working directory.

Last week I first implemented the log() function. In that commit I just had it log to the console. In this commit we start writing to a file.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
