### PR TITLE
GRIM: Backport a Bison fix for uninitialized yyval (Trac#13784)

### DIFF
--- a/engines/grim/lua/lstx.cpp
+++ b/engines/grim/lua/lstx.cpp
@@ -1068,8 +1068,16 @@ yydefault:
 	/* Do a reduction.  yyn is the number of a rule to reduce with.  */
 yyreduce:
 	yylen = yyr2[yyn];
-	if (yylen > 0)
-		yyval = yyvsp[1 - yylen]; /* implement default value of the action */
+
+	/* If YYLEN is nonzero, implement the default value of the action:
+	   `$$ = $1'.
+
+	   Otherwise, the following line sets YYVAL to the semantic value of
+	   the lookahead token.  This behavior is undocumented and Bison
+	   users should not rely upon it.  Assigning to YYVAL
+	   unconditionally makes the parser a bit smaller, and it avoids a
+	   GCC warning that YYVAL may be used uninitialized.  */
+	yyval = yyvsp[1-yylen];
 
 	switch (yyn) {
 


### PR DESCRIPTION
See [Trac#13784](https://bugs.scummvm.org/ticket/13784): this fixes a runtime error whenever pressing a key in EMI in MSVC debug builds.

Upstream fix from GNU Bison 1.28c on 2000-10-02 (since this lstx.cpp file was intentionally built with the now ancient Bison 1.25)
https://git.savannah.gnu.org/cgit/bison.git/commit/?id=da9abf4366d824a23da3d2416856e9a482794eb1

`engines/director/lingo/lingo-gr.cpp`, `engines/hypno/grammar_arc.cpp`, `engines/hypno/grammar_mis.cpp` and `engines/private/grammar.cpp` (built with newer GNU Bison) have the same code.

Tested with MSVC 2022.

@aquadran: Does this look acceptable to you?