### PR TITLE
OPENGLSDL: Redraw screen when receiving an expose event

### DIFF
--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -278,6 +278,7 @@ void OpenGLSdlGraphicsManager::updateScreen() {
 }
 
 void OpenGLSdlGraphicsManager::notifyVideoExpose() {
+	_forceRedraw = true;
 }
 
 void OpenGLSdlGraphicsManager::notifyResize(const int width, const int height) {


### PR DESCRIPTION
Without this, the window is not refreshed when it is recovered or minimized and restored.

I use a PR for this because I want to be sure it doesn't cause troubles in other platforms.
The same is done in SurfaceSDL backend.

In OpenGL 3D backend it has not to be done because there is no optimization on drawing.