### PR TITLE
ENGINES: Correcting capitalization of bbvs full name

### DIFF
--- a/doc/cz/PrectiMe
+++ b/doc/cz/PrectiMe
@@ -289,7 +289,7 @@ Hry od Sierra Entertainment (SCI):
 Další hry:
      3 Skulls of the Toltecs                     [toltecs]
      Amazon: Guardians of Eden                   [access]
-     Beavis and Butt-head in Virtual Stupidity   [bbvs]
+     Beavis and Butt-Head in Virtual Stupidity   [bbvs]
      Blue Force                                  [blueforce]
      Broken Sword: The Return of the Templars    [sword25]
      Bud Tucker in Double Trouble                [tucker]

--- a/doc/de/LIESMICH
+++ b/doc/de/LIESMICH
@@ -394,7 +394,7 @@ Andere Spiele:
      Amazon: Guardians of Eden                   [access]
      Baphomets Fluch 2.5:
          Die Rückkehr der Tempelritter           [sword25]
-     Beavis and Butt-head in Virtual Stupidity   [bbvs]
+     Beavis and Butt-Head in Virtual Stupidity   [bbvs]
      Blade Runner                                [bladerunner]
      Blue Force                                  [blueforce]
      Bud Tucker in Double Trouble                [tucker]

--- a/engines/bbvs/detection.cpp
+++ b/engines/bbvs/detection.cpp
@@ -25,7 +25,7 @@
 #include "bbvs/detection.h"
 
 static const PlainGameDescriptor bbvsGames[] = {
-	{ "bbvs", "Beavis and Butt-head in Virtual Stupidity" },
+	{ "bbvs", "Beavis and Butt-Head in Virtual Stupidity" },
 	{ nullptr, nullptr }
 };
 
@@ -104,7 +104,7 @@ public:
 	}
 
 	const char *getEngineName() const override {
-		return "MTV's Beavis and Butt-head in Virtual Stupidity";
+		return "MTV's Beavis and Butt-Head in Virtual Stupidity";
 	}
 
 	const char *getOriginalCopyright() const override {


### PR DESCRIPTION
"Beavis and Butt-head in Virtual Stupidity" -> "Beavis and Butt-Head in Virtual Stupidity"

This matches how it [appears on Wikipedia](https://en.wikipedia.org/wiki/Beavis_and_Butt-Head_in_Virtual_Stupidity) as well as how it's capitalized in [the show itself](https://en.wikipedia.org/wiki/Beavis_and_Butt-Head).