### PR TITLE
ENGINES: Changing Touche to Touché in game & engine name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2633,7 +2633,7 @@ For a more comprehensive changelog of the latest experimental code, see:
 
  New Games:
    - Added Cinematique evo 1 engine. Currently only Future Wars is supported.
-   - Added Touche: The Adventures of the Fifth Musketeer engine.
+   - Added Touché: The Adventures of the Fifth Musketeer engine.
    - Added support for Gobliins 2.
    - Added support for Simon the Sorcerer's Puzzle Pack.
    - Added support for Ween: The Prophecy.

--- a/audio/midiplayer.h
+++ b/audio/midiplayer.h
@@ -105,7 +105,7 @@ public:
 	 *
 	 * @todo This method currently does not do anything if the new volume
 	 *       matches the old volume. But some engines always update the
-	 *       volume (Parallaction, Tinsel, Touché, ...). This is why
+	 *       volume (Parallaction, Tinsel, Touche, ...). This is why
 	 *       this method is currently virtual. We really should figure
 	 *       which way to do it, and then make this the default, and make
 	 *       this method non-virtual again.

--- a/audio/midiplayer.h
+++ b/audio/midiplayer.h
@@ -105,7 +105,7 @@ public:
 	 *
 	 * @todo This method currently does not do anything if the new volume
 	 *       matches the old volume. But some engines always update the
-	 *       volume (Parallaction, Tinsel, Touche, ...). This is why
+	 *       volume (Parallaction, Tinsel, Touché, ...). This is why
 	 *       this method is currently virtual. We really should figure
 	 *       which way to do it, and then make this the default, and make
 	 *       this method non-virtual again.

--- a/doc/cz/PrectiMe
+++ b/doc/cz/PrectiMe
@@ -334,7 +334,7 @@ Další hry:
      TeenAgent                                   [teenagent]
      Toonstruck                                  [toon]
      Tony Tough and the Night of Roasted Moths   [tony]
-     Touche: The Adventures of the Fifth
+     Touché: The Adventures of the Fifth
          Musketeer                               [touche]
      U.F.O.s / Gnap: Der Schurke aus dem All     [gnap]
      Voyeur                                      [voyeur]
@@ -1311,7 +1311,7 @@ ScummVM podporuje různé zkratky ve hře. Liší se mezi různými hrami SCUMM 
   TeenAgent
     F5                     - Zobrazí Globální Menu
 
-  Touche: The Adventures of the Fifth Musketeer:
+  Touché: The Adventures of the Fifth Musketeer:
     Ctrl-f                 - Zapnout rychlý režim
     F5                     - Zobrazit možnosti
     F9                     - Zapnout režim rychlé chůze

--- a/doc/se/LasMig
+++ b/doc/se/LasMig
@@ -226,7 +226,7 @@ MADE-spel från Activision:
      The Legend of Kyrandia                      [kyra1]
      The Legend of Kyrandia: The Hand of Fate    [kyra2]
      The Legend of Kyrandia: Malcolm's Revenge   [kyra3]
-     Touche: The Adventures of the Fifth
+     Touché: The Adventures of the Fifth
          Musketeer                               [touche]
 
 SCUMM-spel från Humongous Entertainment:
@@ -1010,7 +1010,7 @@ ScummVM stöder ett antal kortkommandon medan du spelar. De är olika för SCUMM
   TeenAgent
     F5                     - Visar den globala menyn
 
-  Touche: The Adventures of the Fifth Musketeer:
+  Touché: The Adventures of the Fifth Musketeer:
     Ctrl-f                 - Aktivera snabbläge
     F5                     - Visa inställningar
     F9                     - Snabbt gångläge på

--- a/engines/touche/configure.engine
+++ b/engines/touche/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine touche "Touche: The Adventures of the Fifth Musketeer" yes "" "" "highres"
+add_engine touche "Touché: The Adventures of the Fifth Musketeer" yes "" "" "highres"

--- a/engines/touche/detection.cpp
+++ b/engines/touche/detection.cpp
@@ -25,7 +25,7 @@
 #include "touche/touche.h"
 
 static const PlainGameDescriptor toucheGames[] = {
-	{ "touche", "Touche: The Adventures of the Fifth Musketeer" },
+	{ "touche", "Touché: The Adventures of the Fifth Musketeer" },
 	{ 0, 0 }
 };
 
@@ -146,11 +146,11 @@ public:
 	}
 
 	const char *getEngineName() const override {
-		return "Touche: The Adventures of the Fifth Musketeer";
+		return "Touché: The Adventures of the Fifth Musketeer";
 	}
 
 	const char *getOriginalCopyright() const override {
-		return "Touche: The Adventures of the Fifth Musketeer (C) Clipper Software";
+		return "Touché: The Adventures of the Fifth Musketeer (C) Clipper Software";
 	}
 
 	const DebugChannelDef *getDebugChannels() const override {

--- a/engines/touche/midi.cpp
+++ b/engines/touche/midi.cpp
@@ -85,7 +85,7 @@ void MidiPlayer::setVolume(int volume) {
 	// transmit the volume change, even if the current _masterVolume
 	// equals the new master volume. This *could* make a difference in
 	// some situations.
-	// So, we should determine whether Touche requires this behavioral
+	// So, we should determine whether Touché requires this behavioral
 	// difference; and maybe also if other engines could benefit from it
 	// (as hypothetically, it might fix some subtle bugs?)
 	_masterVolume = CLIP(volume, 0, 255);

--- a/engines/touche/midi.cpp
+++ b/engines/touche/midi.cpp
@@ -85,7 +85,7 @@ void MidiPlayer::setVolume(int volume) {
 	// transmit the volume change, even if the current _masterVolume
 	// equals the new master volume. This *could* make a difference in
 	// some situations.
-	// So, we should determine whether Touché requires this behavioral
+	// So, we should determine whether the engine requires this behavioral
 	// difference; and maybe also if other engines could benefit from it
 	// (as hypothetically, it might fix some subtle bugs?)
 	_masterVolume = CLIP(volume, 0, 255);

--- a/engines/touche/touche.h
+++ b/engines/touche/touche.h
@@ -36,12 +36,12 @@
 #include "touche/console.h"
 
 /**
- * This is the namespace of the Touche engine.
+ * This is the namespace of the Touché engine.
  *
  * Status of this engine: ???
  *
  * Games using this engine:
- * - Touche: The Adventures of the Fifth Musketeer
+ * - Touché: The Adventures of the Fifth Musketeer
  */
 namespace Touche {
 

--- a/engines/touche/touche.h
+++ b/engines/touche/touche.h
@@ -36,7 +36,7 @@
 #include "touche/console.h"
 
 /**
- * This is the namespace of the Touché engine.
+ * This is the namespace of the Touche engine.
  *
  * Status of this engine: ???
  *


### PR DESCRIPTION
The full title is *Touché: The Adventures of the Fifth Musketeer* (with the accented é) as shown on the [Wikipedia page](https://en.wikipedia.org/wiki/Touché:_The_Adventures_of_the_Fifth_Musketeer).

The engine name and game id are still `touche`.

## Before
<img width="638" alt="image" src="https://user-images.githubusercontent.com/6200170/196014210-a11691ae-4560-4363-a8dc-ab7dedaa8801.png">

## After
<img width="630" alt="image" src="https://user-images.githubusercontent.com/6200170/196014207-4bcc9e45-55b9-4f72-81be-0a4f0e4ac701.png">
