### PR TITLE
SCUMM: Don't print unprintable chars in warnings and errors

### DIFF
--- a/engines/scumm/charset.cpp
+++ b/engines/scumm/charset.cpp
@@ -841,7 +841,7 @@ void CharsetRendererV3::printChar(int chr, bool ignoreCharsetMask) {
 	assertRange(0, _curId, _vm->_numCharsets - 1, "charset");
 
 	if ((vs = _vm->findVirtScreen(_top)) == nullptr) {
-		warning("findVirtScreen(%d) failed, therefore printChar cannot print '%c'", _top, chr);
+		warning("findVirtScreen(%d) failed, therefore printChar cannot print '\\x%X'", _top, chr);
 		return;
 	}
 
@@ -1695,7 +1695,7 @@ void CharsetRendererMac::printChar(int chr, bool ignoreCharsetMask) {
 	VirtScreen *vs;
 
 	if ((vs = _vm->findVirtScreen(_top)) == nullptr) {
-		warning("findVirtScreen(%d) failed, therefore printChar cannot print '%c'", _top, chr);
+		warning("findVirtScreen(%d) failed, therefore printChar cannot print '\\x%X'", _top, chr);
 		return;
 	}
 

--- a/engines/scumm/imuse/imuse.cpp
+++ b/engines/scumm/imuse/imuse.cpp
@@ -185,7 +185,7 @@ bool IMuseInternal::isMT32(int sound) {
 	if (ptr[4] == 'S' && ptr[5] == 'O')
 		return false;
 
-	error("Unknown music type: '%c%c%c%c'", (char)tag >> 24, (char)tag >> 16, (char)tag >> 8, (char)tag);
+	error("Unknown music type: '%s'", tag2str(tag));
 
 	return false;
 }
@@ -227,7 +227,7 @@ bool IMuseInternal::isMIDI(int sound) {
 	if (ptr[4] == 'S' && ptr[5] == 'O')
 		return true;
 
-	error("Unknown music type: '%c%c%c%c'", (char)tag >> 24, (char)tag >> 16, (char)tag >> 8, (char)tag);
+	error("Unknown music type: '%s'", tag2str(tag));
 
 	return false;
 }
@@ -271,7 +271,7 @@ bool IMuseInternal::supportsPercussion(int sound) {
 	if (ptr[4] == 'S' && ptr[5] == 'O')
 		return true;
 
-	error("Unknown music type: '%c%c%c%c'", (char)tag >> 24, (char)tag >> 16, (char)tag >> 8, (char)tag);
+	error("Unknown music type: '%s'", tag2str(tag));
 
 	return false;
 }


### PR DESCRIPTION
Some `warning()` and `error()` routines in the SCUMM engine will print some raw chars on the terminal, but there's no guarantee that they're printable characters, especially if you've hit a decoding issue and encounter some random bytes.

* For the `charset.cpp` change, an example comes from the fan-made German translation of Zak FM-TOWNS (see [Trac#10530](https://bugs.scummvm.org/ticket/10530#comment:6)) which embeds some erroneous `\r` characters and prints `'!RNING: findVirtScreen(200) failed, therefore printChar cannot print '` (sic) because of this.
* For `imuse.cpp`, the existing code didn't handle non-printable characters either, and it was actually wrong. Just use `tag2str()` (which knows how to deal with unprintable chars), like we do in some other places in that engine.
 
Any objection?