### PR TITLE
SCUMM: Remove old MI2 getDist() workaround for Trac#420

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -1417,11 +1417,6 @@ void ScummEngine_v5::o5_getDist() {
 	else
 		r = getObjActToObjActDist(o1, o2);
 
-	// FIXME: MI2 race workaround, see bug #420. We never quite figured out
-	// what the real cause of this, or if it maybe occurs in the original, too...
-	if (_game.id == GID_MONKEY2 && vm.slot[_currentScript].number == 40 && r < 60)
-		r = 60;
-
 	setResult(r);
 }
 


### PR DESCRIPTION
@AndywinXp says I should go submitting this one 😛 

A workaround for [Trac#420](https://bugs.scummvm.org/ticket/420) was added more than 20 years ago, but I can't reproduce the issue anymore with the DOS, Macintosh, or Amiga versions, and back in 2008 @eriktorbjorn said he couldn't reproduce this old issue anymore either.

I couldn't reproduce any lock-up with the original DOS version in DOSBox either.

(I'll submit a second PR for the other getDist() workaround that's just below this one, as all my tests aren't done for that one yet)