### PR TITLE
ENGINES: Properly identify the autosave file

### DIFF
--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -86,10 +86,10 @@ void SaveStateDescriptor::setAutosave(bool autosave) {
 }
 
 bool SaveStateDescriptor::isAutosave() const {
-	if (_saveType != kSaveTypeUndetermined) {
-		return _saveType == kSaveTypeAutosave;
+	if (hasAutosaveName()) {
+		return true;
 	} else {
-		return hasAutosaveName();
+		return _saveType == kSaveTypeAutosave;
 	}
 }
 

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -86,11 +86,7 @@ void SaveStateDescriptor::setAutosave(bool autosave) {
 }
 
 bool SaveStateDescriptor::isAutosave() const {
-	if (hasAutosaveName()) {
-		return true;
-	} else {
-		return _saveType == kSaveTypeAutosave;
-	}
+	return hasAutoSaveName() || _saveType == kSaveTypeAutosave;
 }
 
 bool SaveStateDescriptor::hasAutosaveName() const

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -2673,7 +2673,7 @@ bool GlobalOptionsDialog::updateAutosavePeriod(int newValue) {
 				if (autoSaveSlot < 0)
 					continue;
 				SaveStateDescriptor desc = metaEngine.querySaveMetaInfos(target.c_str(), autoSaveSlot);
-				if (desc.getSaveSlot() != -1 && !desc.getDescription().empty() && !desc.hasAutosaveName()) {
+				if (desc.getSaveSlot() != -1 && !desc.getDescription().empty() && !desc.isAutosave()) {
 					if (saveList.size() >= maxListSize) {
 						hasMore = true;
 						break;


### PR DESCRIPTION


Restructure isAutosave() function:

-  Prioritise name test
-  Access saveType test only if name test fails

Performs both tests when required, resolving false positives unique to each test, and ensures that only saves which fail both tests appear in autosave warning dialogs.

Change Global Options autosave test to isAutosave().

Properly fixes #12363, refers #13842
#