### PR TITLE
GLK: SCOTT: Add fallback entry and avoid reporting any C64 rom as a possible variant

### DIFF
--- a/engines/glk/scott/detection.cpp
+++ b/engines/glk/scott/detection.cpp
@@ -93,7 +93,10 @@ bool ScottMetaEngine::detectGames(const Common::FSList &fslist, DetectedGames &g
 			++p;
 
 		if (!p->_gameId) {
-			if (!isBlorb && filename.hasSuffixIgnoreCase(".dat"))
+
+			// ignore possible variants for common extensions to prevent flooding in mass-add
+			if (!isBlorb && (filename.hasSuffixIgnoreCase(".z80") || filename.hasSuffixIgnoreCase(".dat") ||
+				filename.hasSuffixIgnoreCase(".d64") || filename.hasSuffixIgnoreCase(".t64")))
 				continue;
 
 			const PlainGameDescriptor &desc = SCOTT_GAME_LIST[0];

--- a/engines/glk/scott/detection_tables.h
+++ b/engines/glk/scott/detection_tables.h
@@ -38,6 +38,8 @@ namespace Glk {
 namespace Scott {
 
 const PlainGameDescriptor SCOTT_GAME_LIST[] = {
+	{ "scottadams",			"Scott Adams IF Game" },
+
 	// Scott Adams games
 	{ "adventureland",		"Adventureland" },
 	{ "pirateadventure",	"Pirate Adventure" },


### PR DESCRIPTION
Currently the glk/scott detector reports any file with extension .d64 or .t64 as a possible variant of a scott game.
This is not ideal and can lead to a huge number of useless detections if a user picks a folder filled with commodore roms.
This PR simply filters out z80/dat/d64/t64 files. Files with extension .saga and .fiad are not excluded as these extensions
are quite unusual.

The PR also adds the missing fallback entry "Scott Adams IF Game" (previously, all unknown games were reported as
possible Adventureland variants)
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
