### PR TITLE
DREAMWEB: fix thumbnails when using original save/load screens

### DIFF
--- a/engines/dreamweb/dreamweb.cpp
+++ b/engines/dreamweb/dreamweb.cpp
@@ -270,6 +270,8 @@ DreamWebEngine::DreamWebEngine(OSystem *syst, const DreamWebGameDescription *gam
 
 DreamWebEngine::~DreamWebEngine() {
 	delete _sound;
+	if (_thumbnail.getPixels())
+		_thumbnail.free();
 }
 
 void DreamWebEngine::pauseEngineIntern(bool pause) {

--- a/engines/dreamweb/dreamweb.h
+++ b/engines/dreamweb/dreamweb.h
@@ -31,6 +31,8 @@
 
 #include "engines/engine.h"
 
+#include "graphics/surface.h"
+
 #include "dreamweb/console.h"
 
 #include "dreamweb/structs.h"
@@ -157,6 +159,7 @@ private:
 	void setSpeed(uint speed);
 
 	const DreamWebGameDescription	*_gameDescription;
+	Graphics::Surface				_thumbnail;
 	Common::RandomSource			_rnd;
 	Common::String _datafilePrefix;
 	Common::String _speechDirName;

--- a/engines/dreamweb/saveload.cpp
+++ b/engines/dreamweb/saveload.cpp
@@ -307,6 +307,8 @@ void DreamWebEngine::oldToNames() {
 }
 
 void DreamWebEngine::saveLoad() {
+	if (ConfMan.getBool("originalsaveload"))
+		createThumbnail(_thumbnail);
 	if (_vars._watchingTime || (_pointerMode == 2)) {
 		blank();
 		return;
@@ -563,7 +565,11 @@ void DreamWebEngine::savePosition(unsigned int slot, const char *descbuf) {
 	outSaveFile->writeUint32LE(saveDate);
 	outSaveFile->writeUint32LE(saveTime);
 	outSaveFile->writeUint32LE(playTime);
-	Graphics::saveThumbnail(*outSaveFile);
+
+	if (ConfMan.getBool("originalsaveload"))
+		Graphics::saveThumbnail(*outSaveFile, _thumbnail);
+	else
+		Graphics::saveThumbnail(*outSaveFile);
 
 	outSaveFile->finalize();
 	if (outSaveFile->err()) {


### PR DESCRIPTION
When the 'Use original save/load screens' option is checked, thumbnails contain the save screen contents instead of the actual map
