### PR TITLE
ENGINES: Fix autosave overwriting regular save without warning

### DIFF
--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -36,15 +36,15 @@ SaveStateDescriptor::SaveStateDescriptor()
 
 SaveStateDescriptor::SaveStateDescriptor(const MetaEngine *metaEngine, int slot, const Common::U32String &d)
 	: _slot(slot), _description(d), _isLocked(false), _playTimeMSecs(0), _saveType(kSaveTypeUndetermined) {
-	initSaveType(metaEngine);
+	initSaveSlot(metaEngine);
 }
 
 SaveStateDescriptor::SaveStateDescriptor(const MetaEngine *metaEngine, int slot, const Common::String &d)
 	: _slot(slot), _description(Common::U32String(d)), _isLocked(false), _playTimeMSecs(0), _saveType(kSaveTypeUndetermined) {
-	initSaveType(metaEngine);
+	initSaveSlot(metaEngine);
 }
 
-void SaveStateDescriptor::initSaveType(const MetaEngine *metaEngine) {
+void SaveStateDescriptor::initSaveSlot(const MetaEngine *metaEngine) {
 	// Do not allow auto-save slot to be deleted or overwritten.
 	if (!metaEngine && g_engine)
 		metaEngine = g_engine->getMetaEngine();

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -35,12 +35,12 @@ SaveStateDescriptor::SaveStateDescriptor()
 }
 
 SaveStateDescriptor::SaveStateDescriptor(const MetaEngine *metaEngine, int slot, const Common::U32String &d)
-	: _slot(slot), _description(d), _isLocked(false), _playTimeMSecs(0) {
+	: _slot(slot), _description(d), _isLocked(false), _playTimeMSecs(0), _saveType(kSaveTypeUndetermined) {
 	initSaveType(metaEngine);
 }
 
 SaveStateDescriptor::SaveStateDescriptor(const MetaEngine *metaEngine, int slot, const Common::String &d)
-	: _slot(slot), _description(Common::U32String(d)), _isLocked(false), _playTimeMSecs(0) {
+	: _slot(slot), _description(Common::U32String(d)), _isLocked(false), _playTimeMSecs(0), _saveType(kSaveTypeUndetermined) {
 	initSaveType(metaEngine);
 }
 
@@ -51,7 +51,6 @@ void SaveStateDescriptor::initSaveType(const MetaEngine *metaEngine) {
 	const bool autosave =
 			metaEngine && ConfMan.getInt("autosave_period") && _slot == metaEngine->getAutosaveSlot();
 	_isWriteProtected = autosave;
-	_saveType = autosave ? kSaveTypeAutosave : kSaveTypeRegular;
 	_isDeletable = !autosave;
 }
 

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -86,10 +86,10 @@ void SaveStateDescriptor::setAutosave(bool autosave) {
 }
 
 bool SaveStateDescriptor::isAutosave() const {
-	if (_saveType != kSaveTypeUndetermined) {
-		return _saveType == kSaveTypeAutosave;
+	if (hasAutosaveName()) {
+		return true;
 	} else {
-		return hasAutosaveName();
+		return _saveType == kSaveTypeAutosave;
 	}
 }
 

--- a/engines/savestate.h
+++ b/engines/savestate.h
@@ -61,7 +61,7 @@ private:
 		kSaveTypeAutosave
 	};
 
-	void initSaveType(const MetaEngine *metaEngine);
+	void initSaveSlot(const MetaEngine *metaEngine);
 public:
 	SaveStateDescriptor();
 	SaveStateDescriptor(const MetaEngine *metaEngine, int slot, const Common::U32String &d);

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -2673,7 +2673,7 @@ bool GlobalOptionsDialog::updateAutosavePeriod(int newValue) {
 				if (autoSaveSlot < 0)
 					continue;
 				SaveStateDescriptor desc = metaEngine.querySaveMetaInfos(target.c_str(), autoSaveSlot);
-				if (desc.getSaveSlot() != -1 && !desc.getDescription().empty() && !desc.hasAutosaveName()) {
+				if (desc.getSaveSlot() != -1 && !desc.getDescription().empty() && !desc.isAutosave()) {
 					if (saveList.size() >= maxListSize) {
 						hasMore = true;
 						break;


### PR DESCRIPTION
Currently, the saveType property is being set under two completely different contexts, one that's set when the save is created or overwritten (based on the autosave flag, which identifies the save type), the other when an instance of the SaveStateDescriptor is created (based on the slot type, which identifies where the save is stored), neither value being mutually exclusive. 

How the value is applied depends on where isAutosave() is called. If it's called when an autosave is pending, as intended, then it's used to identify the save type of any file in the autosave slot. If it's called when building a save list (in listSaves()), it's used to test if the slot is empty. Having two different meanings for the same value, calculated using unrelated methods, will produce conflicts in both instances.

The saveType property is intended to identify the type of save stored in the autosave slot. Setting the saveType property based on slot type identifies any type of save stored in the autosave slot as an autosave.  It's therefore inappropriate for identifying the actual type of save in the slot (refer [#Trac13841](https://bugs.scummvm.org/ticket/13841) for details).

Reverting this method prevents an autosave from overwriting a regular save without warning.

This is the first step in resolving this conflict of purposes when using isAutosave(). The second is to revert the use of isAutosave() in listSaves(), which I will address in a follow up PR.

This complements #4350, which addresses issues with false positives affecting the autoave file (i.e. an autosave identified as a regular save).