### PR TITLE
[RFC] DREAMWEB: lower the music volume in the last scene

### DIFF
--- a/engines/dreamweb/stubs.cpp
+++ b/engines/dreamweb/stubs.cpp
@@ -41,7 +41,7 @@ const Room g_roomData[] = {
 	  255,255,255,0,
 	  7,2,255,255,255,255,6,255,255,255,1 },
 
-	// location 2: Louis' (?)
+	// location 2: Louis'
 	{ "DREAMWEB.R02",
 	  2,255,33,0,
 	  255,255,255,0,
@@ -113,7 +113,7 @@ const Room g_roomData[] = {
 	  255,255,255,0,
 	  1,4,255,255,255,255,255,255,255,255,13 },
 
-	// location 14
+	// location 14: subway station
 	{ "DREAMWEB.R14",
 	  14,255,44,20,
 	  255,255,255,0,
@@ -2227,19 +2227,26 @@ void DreamWebEngine::atmospheres() {
 			_sound->playChannel0(a->_sound, a->_repeat);
 
 			// NB: The asm here reads
-			//	cmp reallocation,2
+			//  cmp reallocation,2
 			//  cmp mapy,0
 			//  jz fullvol
 			//  jnz notlouisvol
-			//  I'm interpreting this as if the cmp reallocation is below the jz
+			// This should probably be interpreted like this:
+			//  cmp reallocation,2
+			//  jnz notlouisvol
+			//  cmp mapy,0
+			//  jz  fullvol
+			if (_realLocation == 2) {
+				if (_mapY == 0) {
+					_sound->volumeSet(0); // "fullvol"
+					return;
+				}
 
-			if (_mapY == 0) {
-				_sound->volumeSet(0); // "fullvol"
-				return;
+				if (_mapX == 22 && _mapY == 10) {
+					_sound->volumeSet(5); // "louisvol"
+					return;
+				}
 			}
-
-			if (_realLocation == 2 && _mapX == 22 && _mapY == 10)
-				_sound->volumeSet(5); // "louisvol"
 
 			if (hasSpeech() && _realLocation == 14) {
 				if (_mapX == 33) {


### PR DESCRIPTION
During Beckett's monologue (location 14), the music plays so loud that I can barely hear him.
This can be due to a bug in the original code preventing this case from being handled properly:

https://github.com/scummvm/scummvm/blob/2d33e5d318b6e43417dbfe94859075cafced0f17/devtools/tasmrecover/dreamweb/dreamweb.asm#L2231-L2239

There are two `cmp`'s in a row here, and I think it should look like this instead:
```assembly
cmp	reallocation,2
jnz	notlouisvol
cmp	mapy,0
jz	fullvol
```