### PR TITLE
AMIGAOS: Clean up amigaos-fs.cpp/amigaos-dialogs.cpp

### DIFF
--- a/backends/dialogs/amigaos/amigaos-dialogs.cpp
+++ b/backends/dialogs/amigaos/amigaos-dialogs.cpp
@@ -41,6 +41,7 @@ struct Library *AslBase;
 Common::DialogManager::DialogResult AmigaOSDialogManager::showFileBrowser(const Common::U32String &title, Common::FSNode &choice, bool isDirBrowser) {
 
 	char pathBuffer[MAXPATHLEN];
+	strcpy(pathBuffer, "SYS:");
 
 	Common::String newTitle = title.encode(Common::kISO8859_1);
 

--- a/backends/fs/amigaos/amigaos-fs.cpp
+++ b/backends/fs/amigaos/amigaos-fs.cpp
@@ -36,15 +36,15 @@ const char *lastPathComponent(const Common::String &str) {
 	int pathOffset = str.size();
 
 	if (pathOffset <= 0) {
-		debug(6, "lastPathComponent() failed -> Bad offset (Empty path received)!");
+		debug(0, "lastPathComponent() failed -> Bad offset (Empty path received)!");
 		return 0;
 	}
 
 	const char *p = str.c_str();
 
-	while (pathOffset > 0 && (p[pathOffset-1] == '/' || p[pathOffset-1] == ':'))
+	while (pathOffset > 0 && (p[pathOffset - 1] == '/' || p[pathOffset - 1] == ':'))
 		pathOffset--;
-	while (pathOffset > 0 && (p[pathOffset-1] != '/' && p[pathOffset-1] != ':'))
+	while (pathOffset > 0 && (p[pathOffset - 1] != '/' && p[pathOffset - 1] != ':'))
 		pathOffset--;
 	return p + pathOffset;
 }


### PR DESCRIPTION
amigaos-fs.cpp:
- Enhanced some of the debug output
- Renamed some variables for better readability
- Removed two debug outputs (if it works, don't bother me) :-)
- Removed lots of superfluous blank lines
- Removed two unneeded variables
- Tried to follow coding conventions

amigaos-dialogs.cpp:
- initialize pathBuffer

These only touch the AmigaOS4 platform, but i'd still be grateful for comments (especially about coding convention breaches)

Thank you