### PR TITLE
ALL: Force CRLF line-endings for Windows .bat files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,8 @@ insert_final_newline = true
 vc_generate_documentation_comments = doxygen_slash_star
 end_of_line = lf
 
+[*.bat]
+end_of_line = crlf
+
 [*.lingo]
 charset = macroman

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 /po/*.po encoding=utf-8
 *.lingo	encoding=MacRoman
 /engines.awk eol=lf
+*.bat text eol=crlf
 *.cpp text eol=lf
 *.h text eol=lf
 *.hpp text eol=lf


### PR DESCRIPTION
Subtle parsing problems with labels can happen if Windows batch files are checked out with Unix LF line-endings.

See:

* https://stackoverflow.com/questions/232651/why-the-system-cannot-find-the-batch-label-specified-is-thrown-even-if-label-e
* https://www.dostips.com/forum/viewtopic.php?t=8988
* https://github.com/coq/coq/issues/8610

Submitting this as PR in case someone sees an issue with this, since Windows is not my main development environment.