### PR TITLE
WIN32: implement isConnectionLimited

### DIFF
--- a/backends/platform/sdl/win32/win32.h
+++ b/backends/platform/sdl/win32/win32.h
@@ -52,6 +52,8 @@ public:
 	Common::String getDefaultIconsPath() override;
 	Common::String getScreenshotsPath() override;
 
+	bool isConnectionLimited() override;
+
 protected:
 	Common::String getDefaultConfigFileName() override;
 	Common::String getDefaultLogFileName() override;


### PR DESCRIPTION
This implements the isConnectionLimited member function of OSystem on windows.

Since it use a relatively new function it's dynamically linked and failure is gracefully handled.
