### PR TITLE
DIRECTOR: handle go with multiple int arguments

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1328,10 +1328,16 @@ void LB::b_go(int nargs) {
 			Datum movie;
 			Datum frame;
 
-			if (nargs > 0) {
+			if (nargs > 0 && firstArg.type == STRING) {
 				movie = firstArg;
 				TYPECHECK(movie, STRING);
 
+				frame = g_lingo->pop();
+				nargs -= 1;
+			// Even if there's more than one argument, if the first
+			// arg is an int, Director discards the remainder and
+			// treats it as the frame.
+			} else if (nargs > 0 && firstArg.type == INT) {
 				frame = g_lingo->pop();
 				nargs -= 1;
 			} else {


### PR DESCRIPTION
While `go` is intended to be called with either one int arugment or one string and one int argument, Director accepts multiple int args. In this case, it treats the first argument as an integer and silently discards the rest. Before this branch, ScummVM would always treat two arguments as being the movie + frame case and throw a typecheck error for the first argument. This fixes it by checking the type of the first arg and discarding the rest, matching Director's behaviour.

This was seen on the title screen of Wallobee Jack: The Thai Sun Adventure, which calls it like so: `go (the frame) 0`