### PR TITLE
GUI: Remove visible check in theme

### DIFF
--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -214,9 +214,6 @@ void Widget::setVisible(bool e) {
 }
 
 bool Widget::isVisible() const {
-	if (g_gui.xmlEval()->getVar("Dialog." + _name + ".Visible", 1) == 0)
-		return false;
-
 	return !(_flags & WIDGET_INVISIBLE);
 }
 


### PR DESCRIPTION
This check has been added in commit 1eff73cb412c6c403be82cde77ee61b9944f805e in 2006 and modified in commit 21989844a9800fe76af93c6b2d70ffd76bf73546 in 2008.
Since then I believe the visible flag couldn't be used and hasn't missed to anyone.

This isVisible function is really time critical because it is called many times at each draw iteration in runLoop.
Checking the theme implies composing a string, hashing it, and looking it up and running the GUI under a profiler (callgrind) makes it pop as time consuming.
