### PR TITLE
SCUMM: Prevent Indy from being stuck in Crete (WORKAROUND)

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -3140,6 +3140,27 @@ void ScummEngine_v5::o5_walkActorTo() {
 		}
 	}
 
+	// WORKAROUND: In Indy4, in the Crete room where there's the gold box,
+	// Indy can get stuck if one clicks too quickly on the right and the
+	// "elevator" isn't there yet (also with the original interpreter).
+	// This is because the box matrix is initialized too late in the entry
+	// script for that room, so we have to do it a bit earlier.
+	//
+	// Intentionally not using `_enableEnhancements`, since you can get
+	// completely stuck.
+	if (_game.id == GID_INDY4 && vm.slot[_currentScript].number == 10002 &&
+		_currentRoom == (_game.platform == Common::kPlatformAmiga ? 58 : 60) &&
+		VAR(224) == 140 && a->_number == VAR(VAR_EGO) && x == 45 && y == 137) {
+		// If the elevator isn't on the current floor yet...
+		if (whereIsObject(829) == WIO_ROOM && getState(829) == 0 && getBoxFlags(7) != 128) {
+			// ...immediately set its box flags so that you can't walk on it
+			setBoxFlags(7, 128);
+			for (int i = 12; i <= 15; ++i)
+				setBoxFlags(i, 128);
+			createBoxMatrix();
+		}
+	}
+
 	a->startWalkActor(x, y, -1);
 }
 


### PR DESCRIPTION
I remember hitting that one with the original interpreter twenty years ago…

## Description

In Indy4, in the room in Crete with the "elevator" and where you pick up the gold box, quickly clicking on the right side of the room while Indy's entering it will make him make a "leap of faith" again. But that wasn't intended (since it's not Indy3), and more importantly you'll get completely stuck if you do that:

https://www.youtube.com/watch?v=aQpHjqJ7Zfg&t=19s

This is because the original entry script for room `60` initializes the walkbox matrix too late, so it's possible to move to the other side of the room before the walkbox restrictions kick in. This workaround just copy the original `setBoxFlags()` and `createBoxMatrix()` calls, but trigger them at an earlier stage.

Relevant output from that original script:

```
[0000] (1A) Var[164] = 88;
[0005] (30) setBoxFlags(7,0);
....
[0029] (48) } else if (Var[224] == 140) {
[0033] (9E)   walkActorTo(VAR_EGO,45,137);
[003A] (AE)   WaitForActor(VAR_EGO);
[003E] (0F)   VAR_RESULT = getObjectState(829);
[0043] (48)   if (VAR_RESULT == 0) {
[004A] (30)     setBoxFlags(7,128);
[004E] (30)     setBoxFlags(12,128);
[0052] (30)     setBoxFlags(13,128);
[0056] (30)     setBoxFlags(14,128);
[005A] (30)     setBoxFlags(15,128);
[005E] (**)   }
[005E] (48) }
...
[00B8] (30) createBoxMatrix();
...
```

This enhancement is always enforced, since you can get completely stuck, and some players can be totally confused by this problem. Erik saw someone mentioning this problem on Facebook last week.

(btw, a similar thing happens with the sentry room in the inner part of Atlantis, but you can't get stuck there and speedrunners like that one, so it's going to be a separate PR/enhancement)

## Test

1. Start any Indy4 release
2. `room 140`
3. Click on the door on the right, and very quickly click on the right part of the room while Indy starts walking in (as in the YouTube video above)
4. Try it several times after leaving/entering the room again, make sure you can't get past the hole anymore and that Indy doesn't get stuck.
5. (if you want to test the elevator puzzle in itself, you can pick up Sternhart's walking stick in `room 52`)

Tested with the DOS/English/Talkie, Macintosh/English/Talkie and DOS/French/Floppy releases.

Tests with the Floppy/Macintosh (done), FM-TOWNS (done) and Amiga (done) releases welcome :)