### PR TITLE
WINTERMUTE: Add initial detection for Lost Bride

### DIFF
--- a/engines/wintermute/base/scriptables/script_ext_directory.cpp
+++ b/engines/wintermute/base/scriptables/script_ext_directory.cpp
@@ -25,10 +25,12 @@
  * Copyright (c) 2011 Jan Nedoma
  */
 
+#include "engines/wintermute/base/base_engine.h"
+#include "engines/wintermute/base/base_file_manager.h"
+#include "engines/wintermute/base/scriptables/script_ext_array.h"
 #include "engines/wintermute/base/scriptables/script_ext_directory.h"
 #include "engines/wintermute/base/scriptables/script_stack.h"
 #include "engines/wintermute/base/scriptables/script_value.h"
-#include "engines/wintermute/base/base_engine.h"
 #include "engines/wintermute/persistent.h"
 
 namespace Wintermute {
@@ -66,7 +68,7 @@ bool SXDirectory::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisSt
 		const char *dirName = stack->pop()->getString();
 
 		if (strcmp(dirName, "saves") == 0) {
-			// Known games that do this: alphapolaris, hamlet, papasdaughters1, papasdaughters2, polechudes
+			// Known games that do this: alphapolaris, hamlet, lostbride, papasdaughters1, papasdaughters2, polechudes, etc
 			// No need to actually create anything, files will be stored at SavefileManager
 			stack->pushBool(true);
 		} else {
@@ -103,13 +105,28 @@ bool SXDirectory::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisSt
 		stack->pushInt(0);
 		BaseScriptable *array = makeSXArray(_gameRef, stack);
 
-		// used in secret scene of "Art of Murder 1: FBI Confidential"
-		if (strcmp(dirName, "X:\\FBI\\data\\scenes\\17-magic\\") == 0 && strcmp(name, "GetDirectories") == 0) {
+		if (strcmp(dirName, "saves") == 0 && strcmp(name, "GetFiles") == 0) {
+			// used in "Tale of The Lost Bride and A Hidden Treasure"
+			// returns list of saves, removing "lostbride-win-ru.saves_" prefix
+
+			Common::StringArray fnames;
+			BaseFileManager::getEngineInstance()->listMatchingFiles(fnames, "*");
+			for (uint32 i = 0; i < fnames.size(); i++) {
+				stack->pushString(fnames[i].c_str());
+				((SXArray *)array)->push(stack->pop());
+			}
+
+		} else if (strcmp(dirName, "X:\\FBI\\data\\scenes\\17-magic\\") == 0 && strcmp(name, "GetDirectories") == 0) {
+			// used in secret scene of "Art of Murder 1: FBI Confidential"
 			// TODO: return list of "scenes\17-magic" subfolders from data.dcp
+
 			warning("FBI\\scenes\\17-magic Directory.%s is not implemented! Returning empty array...", name);
+
 		} else {
 			// No currently known games need this
+
 			warning("Directory.%s is not implemented! Returning empty array...", name);
+
 		}
 
  		stack->pushNative(array, false);

--- a/engines/wintermute/detection_tables.h
+++ b/engines/wintermute/detection_tables.h
@@ -112,6 +112,7 @@ static const PlainGameDescriptor wintermuteGames[] = {
 	{"juliastars",      "J.U.L.I.A.: Among the Stars"},
 	{"juliauntold",     "J.U.L.I.A.: Untold"},
 	{"lotl",            "Limbo of the Lost"},
+	{"lostbride",       "Tale of The Lost Bride and A Hidden Treasure"},
 	{"machumayu",       "Machu Mayu"},
 	{"mentalrepairs",   "Mental Repairs Inc"},
 	{"mirage",          "Mirage"},
@@ -1731,6 +1732,10 @@ static const WMEGameDescription gameDescriptions[] = {
 	// Limbo of the Lost (Russian)
 	WME_WINENTRY("lotl", "",
 		WME_ENTRY1s("data.dcp", "2042ea14f2d7c52a139d768e962040c1", 354370575), Common::RU_RUS, ADGF_UNSTABLE | GF_3D, WME_1_7_2),
+
+    // Tale of The Lost Bride and A Hidden Treasure (Russian)
+    WME_WINENTRY("lostbride", "",
+		WME_ENTRY1s("data.dcp", "cb45b579c6d5767341a9b07bc807df5f", 106683613), Common::RU_RUS, ADGF_UNSTABLE, WME_1_9_1),
 
 	// Machu Mayu (Demo)
 	WME_WINENTRY("machumayu", "Demo",

--- a/engines/wintermute/ext/plugins.h
+++ b/engines/wintermute/ext/plugins.h
@@ -39,6 +39,7 @@ BaseScriptable *makeSXSteamAPI(BaseGame *inGame, ScStack *stack);
 BaseScriptable *makeSXWMEGalaxyAPI(BaseGame *inGame, ScStack *stack);
 BaseScriptable *makeSX3fStatistics(BaseGame *inGame, ScStack *stack);
 BaseScriptable *makeSXCommandLineHelper(BaseGame *inGame, ScStack *stack);
+BaseScriptable *makeSXSample(BaseGame *inGame, ScStack *stack);
 
 bool EmulatePluginCall(BaseGame *inGame, ScStack *stack, ScStack *thisStack, char *name) {
 	ScValue *thisObj;
@@ -86,6 +87,18 @@ bool EmulatePluginCall(BaseGame *inGame, ScStack *stack, ScStack *thisStack, cha
 		thisObj = thisStack->getTop();
 
 		thisObj->setNative(makeSXCommandLineHelper(inGame, stack));
+
+		stack->pushNULL();
+		return STATUS_OK;
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Window mode changer (from wme_windowmode.dll of "lostbride" game)
+	//////////////////////////////////////////////////////////////////////////
+	else if (strcmp(name, "Sample") == 0) {
+		thisObj = thisStack->getTop();
+
+		thisObj->setNative(makeSXSample(inGame, stack));
 
 		stack->pushNULL();
 		return STATUS_OK;

--- a/engines/wintermute/ext/wme_windowmode.cpp
+++ b/engines/wintermute/ext/wme_windowmode.cpp
@@ -1,0 +1,89 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ * This file is based on WME Lite.
+ * http://dead-code.org/redir.php?target=wmelite
+ * Copyright (c) 2011 Jan Nedoma
+ */
+
+#include "engines/metaengine.h"
+#include "engines/wintermute/wintermute.h"
+#include "engines/wintermute/base/base_game.h"
+#include "engines/wintermute/base/base_engine.h"
+#include "engines/wintermute/base/gfx/base_renderer.h"
+#include "engines/wintermute/base/scriptables/script_stack.h"
+#include "engines/wintermute/base/scriptables/script_value.h"
+#include "engines/wintermute/ext/wme_windowmode.h"
+
+namespace Wintermute {
+
+IMPLEMENT_PERSISTENT(SXSample, false)
+
+BaseScriptable *makeSXSample(BaseGame *inGame, ScStack *stack) {
+	return new SXSample(inGame,  stack);
+}
+
+//////////////////////////////////////////////////////////////////////////
+SXSample::SXSample(BaseGame *inGame, ScStack *stack) : BaseScriptable(inGame) {
+	stack->correctParams(1);
+
+	int value = stack->pop()->getInt();
+
+	inGame->_renderer->setWindowed(value);
+}
+
+//////////////////////////////////////////////////////////////////////////
+SXSample::~SXSample() {
+}
+
+//////////////////////////////////////////////////////////////////////////
+const char *SXSample::scToString() {
+	return "[sample object]";
+}
+
+
+//////////////////////////////////////////////////////////////////////////
+bool SXSample::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack, const char *name) {
+	return STATUS_FAILED;
+}
+
+
+//////////////////////////////////////////////////////////////////////////
+ScValue *SXSample::scGetProperty(const Common::String &name) {
+	_scValue->setNULL();
+	return _scValue;
+}
+
+
+//////////////////////////////////////////////////////////////////////////
+bool SXSample::scSetProperty(const char *name, ScValue *value) {
+	return STATUS_FAILED;
+}
+
+
+//////////////////////////////////////////////////////////////////////////
+bool SXSample::persist(BasePersistenceManager *persistMgr) {
+	BaseScriptable::persist(persistMgr);
+	return STATUS_OK;
+}
+
+} // End of namespace Wintermute

--- a/engines/wintermute/ext/wme_windowmode.h
+++ b/engines/wintermute/ext/wme_windowmode.h
@@ -1,0 +1,49 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ * This file is based on WME Lite.
+ * http://dead-code.org/redir.php?target=wmelite
+ * Copyright (c) 2011 Jan Nedoma
+ */
+
+#ifndef WINTERMUTE_WINDOWMODE_H
+#define WINTERMUTE_WINDOWMODE_H
+
+#include "common/str.h"
+#include "engines/wintermute/base/base_scriptable.h"
+
+namespace Wintermute {
+
+class SXSample : public BaseScriptable {
+public:
+	DECLARE_PERSISTENT(SXSample, BaseScriptable)
+	ScValue *scGetProperty(const Common::String &name) override;
+	bool scSetProperty(const char *name, ScValue *value) override;
+	bool scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack, const char *name) override;
+	const char *scToString() override;
+	SXSample(BaseGame *inGame, ScStack *stack);
+	~SXSample() override;
+};
+
+} // End of namespace Wintermute
+
+#endif

--- a/engines/wintermute/keymapper_tables.h
+++ b/engines/wintermute/keymapper_tables.h
@@ -1334,6 +1334,55 @@ inline Common::KeymapArray getWintermuteKeymaps(const char *target, const Common
 		act->addDefaultInputMapping("PAGEDOWN"); // extra keyboard
 		act->addDefaultInputMapping("JOY_DOWN"); // extra joy
 		gameKeyMap->addAction(act);
+	} else if (gameId == "lostbride") {
+		act = new Action("HELP", _("Show help"));
+		act->setKeyEvent(KEYCODE_F1);
+		act->addDefaultInputMapping("F1"); // original keyboard
+		act->addDefaultInputMapping("JOY_Y"); // extra joy
+		act->addDefaultInputMapping("MOUSE_MIDDLE"); // extra mouse
+		gameKeyMap->addAction(act);
+
+		act = new Action(kStandardActionMoveUp, _("Up"));
+		act->setKeyEvent(KEYCODE_UP);
+		act->addDefaultInputMapping("UP"); // original keyboard
+		act->addDefaultInputMapping("JOY_UP"); // extra joy
+		gameKeyMap->addAction(act);
+
+		act = new Action(kStandardActionMoveDown, _("Down"));
+		act->setKeyEvent(KEYCODE_DOWN);
+		act->addDefaultInputMapping("DOWN"); // original keyboard
+		act->addDefaultInputMapping("JOY_DOWN"); // extra joy
+		gameKeyMap->addAction(act);
+
+		act = new Action(kStandardActionMoveLeft, _("Left"));
+		act->setKeyEvent(KEYCODE_LEFT);
+		act->addDefaultInputMapping("LEFT"); // original keyboard
+		act->addDefaultInputMapping("JOY_LEFT"); // extra joy
+		gameKeyMap->addAction(act);
+
+		act = new Action(kStandardActionMoveRight, _("Right"));
+		act->setKeyEvent(KEYCODE_RIGHT);
+		act->addDefaultInputMapping("RIGHT"); // original keyboard
+		act->addDefaultInputMapping("JOY_RIGHT"); // extra joy
+		gameKeyMap->addAction(act);
+
+		act = new Action(kStandardActionEE, _("???"));
+		act->setKeyEvent(KeyState(KEYCODE_SLASH, 0, KBD_SHIFT));
+		act->addDefaultInputMapping("S+SLASH"); // original keyboard
+		//TODO: extra joy control, e.g. "JOY_R+JOY_A+JOY_B"
+		gameKeyMap->addAction(act);
+
+		act = new Action("HINT", _("???"));
+		act->setKeyEvent(KeyState(KEYCODE_s, 's'));
+		act->addDefaultInputMapping("s"); // original keyboard
+		//TODO: extra joy control, e.g. "JOY_R+JOY_A"
+		gameKeyMap->addAction(act);
+
+		act = new Action("NOHINT", _("Hide hints"));
+		act->setKeyEvent(KeyState(KEYCODE_h, 'h'));
+		act->addDefaultInputMapping("h"); // original keyboard
+		//TODO: extra joy control, e.g. "JOY_R+JOY_B"
+		gameKeyMap->addAction(act);
 	} else if (gameId == "mentalrepairs") {
 		act = new Action("HINT", _("Show hints"));
 		act->setKeyEvent(KeyState(KEYCODE_SPACE, ASCII_SPACE));

--- a/engines/wintermute/module.mk
+++ b/engines/wintermute/module.mk
@@ -105,6 +105,7 @@ MODULE_OBJS := \
 	ext/wme_commandlinehelper.o \
 	ext/wme_galaxy.o \
 	ext/wme_steam.o \
+	ext/wme_windowmode.o \
 	debugger/breakpoint.o \
 	debugger/debugger_controller.o \
 	debugger/error.o \

--- a/engines/wintermute/wintermute.cpp
+++ b/engines/wintermute/wintermute.cpp
@@ -439,10 +439,8 @@ bool WintermuteEngine::getGameInfo(const Common::FSList &fslist, Common::String 
 					}
 					caption = value;
 
-					for (uint i = 0; i< value.size(); i++)
-					{
-						if ( int(value[i]) < 16 || int(value[i]) >= 127 )
-						{
+					for (uint i = 0; i< value.size(); i++) {
+						if ( int(value[i]) < 16 || int(value[i]) >= 127 ) {
 							caption = "(invalid)";
 						}
 					}

--- a/engines/wintermute/wintermute.cpp
+++ b/engines/wintermute/wintermute.cpp
@@ -438,6 +438,14 @@ bool WintermuteEngine::getGameInfo(const Common::FSList &fslist, Common::String 
 						}
 					}
 					caption = value;
+
+					for (uint i = 0; i< value.size(); i++)
+					{
+						if ( int(value[i]) < 16 || int(value[i]) >= 127 )
+						{
+							caption = "(invalid)";
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR provides very basic parts of support for https://questzone.ru/enzi/game/2156

The game is detected and starts, keys works and can be remapped, the internal savefiles are created and seems to be managed correctly, screenmode can be changed.

2 known issues:
* Once you beat any level, the game hangs inside some WME scripts calling Sleep(100) in a loop. Need debugging.
* Sometimes level starts incorrectly, showing static screen instead of interactive playing field. Need debugging.