### PR TITLE
SWORD25: set new md5 and size of heb patch

### DIFF
--- a/engines/sword25/detection_tables.h
+++ b/engines/sword25/detection_tables.h
@@ -106,13 +106,13 @@ static const ADGameDescription gameDescriptions[] = {
 		GUIO1(GUIO_NOASPECT)
 	},
 	{
-			"sword25",
-			"",
-			AD_ENTRY1s("lang_he.b25c", "7b0e58798793e0dd87023ef112a11d0f", 461034),
-			Common::HE_ISR,
-			Common::kPlatformUnknown,
-			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOASPECT)
+		"sword25",
+		"",
+		AD_ENTRY1s("lang_he.b25c","993604772b9c7d9d54219d6993ab9c6c", 1214843),
+		Common::HE_ISR,
+		Common::kPlatformUnknown,
+		ADGF_NO_FLAGS,
+		GUIO1(GUIO_NOASPECT)
 	},
 	// Hungarian "psylog" version.
 	// Submitted by goodoldgeorg in bug report #5888.


### PR DESCRIPTION
heb patch changes:

- translation of two letters in the game
- improvment of some of the fonts and the menu graphichs