### PR TITLE
ILLUSIONS: Fix an off-by-one in ScreenPalette::updateFaderPalette()

### DIFF
--- a/engines/illusions/screen.cpp
+++ b/engines/illusions/screen.cpp
@@ -301,7 +301,7 @@ void ScreenPalette::updatePalette() {
 void ScreenPalette::updateFaderPalette() {
 	if (_newFaderValue >= 255) {
 		_newFaderValue -= 256;
-		for (int i = _firstFaderIndex; i <= _lastFaderIndex; ++i) {
+		for (int i = _firstFaderIndex; i < _lastFaderIndex; ++i) {
 			byte r = _mainPalette[i * 3 + 0];
 			byte g = _mainPalette[i * 3 + 1];
 			byte b = _mainPalette[i * 3 + 2];
@@ -310,7 +310,7 @@ void ScreenPalette::updateFaderPalette() {
 			_faderPalette[i * 3 + 2] = b - (((_newFaderValue * (255 - b)) >> 8) & 0xFF);
 		}
 	} else {
-		for (int i = _firstFaderIndex; i <= _lastFaderIndex; ++i) {
+		for (int i = _firstFaderIndex; i < _lastFaderIndex; ++i) {
 			byte r = _mainPalette[i * 3 + 0];
 			byte g = _mainPalette[i * 3 + 1];
 			byte b = _mainPalette[i * 3 + 2];


### PR DESCRIPTION
Found by UBSAN/ASAN:

```
engines/illusions/screen.cpp:314:13: runtime error: index 768 out of bounds for type 'byte[768]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior engines/illusions/screen.cpp:314:13 in 
engines/illusions/screen.cpp:315:13: runtime error: index 769 out of bounds for type 'byte[768]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior engines/illusions/screen.cpp:315:13 in 
```

while starting the demo of Duckman, right after clicking on the very first intro screen of the game.

`_lastFaderIndex` is 256, _mainPalette is 3*256, so if you do something like `_mainPalette[i * 3 + 2]` you don't want the `i ==  _lastFaderIndex` case.