### PR TITLE
HADESCH: Support playing HFS partition fully extracted as macbinary

### DIFF
--- a/common/macresman.cpp
+++ b/common/macresman.cpp
@@ -90,7 +90,7 @@ bool MacResManager::hasDataFork() const {
 }
 
 bool MacResManager::hasResFork() const {
-	return !_baseFileName.empty() && _mode != kResForkNone;
+	return !_baseFileName.empty() && _mode != kResForkNone && _resForkSize != 0;
 }
 
 uint32 MacResManager::getResForkDataSize() const {
@@ -403,13 +403,15 @@ bool MacResManager::loadFromMacBinary(SeekableReadStream *stream) {
 			_resForkOffset = MBI_INFOHDR + dataSizePad;
 			_resForkSize = rsrcSize;
 		}
+
+		if (_resForkOffset < 0)
+			return false;
+
+		_mode = kResForkMacBinary;
+		return load(stream);
 	}
 
-	if (_resForkOffset < 0)
-		return false;
-
-	_mode = kResForkMacBinary;
-	return load(stream);
+	return false;
 }
 
 bool MacResManager::loadFromRawFork(SeekableReadStream *stream) {
@@ -428,6 +430,11 @@ bool MacResManager::load(SeekableReadStream *stream) {
 
 	if (_mode == kResForkNone)
 		return false;
+
+	if (_resForkSize == 0) {
+		_stream = stream;
+		return true;
+	}
 
 	stream->seek(_resForkOffset);
 

--- a/common/macresman.h
+++ b/common/macresman.h
@@ -87,6 +87,13 @@ public:
 	bool open(const Path &fileName, Archive &archive);
 
 	/**
+	 * Opens file named fileName or data fork extracted as macbin
+	 * @return The stream if found, 0 otherwise
+	 */
+	static SeekableReadStream *openFileOrDataFork(const Path &fileName, Archive &archive);
+	static SeekableReadStream *openFileOrDataFork(const Path &fileName);
+
+	/**
 	 * See if a Mac data/resource fork pair exists.
 	 * @param fileName The base file name of the file
 	 * @return True if either a data fork or resource fork with this name exists

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -557,6 +557,15 @@ static bool getFilePropertiesIntern(uint md5Bytes, const AdvancedMetaEngine::Fil
 
 		if (fileProps.size != 0)
 			return true;
+
+		Common::SeekableReadStream *dataFork = macResMan.getDataFork();
+		if (dataFork && dataFork->size()) {
+			fileProps.size = dataFork->size();
+			fileProps.md5 = Common::computeStreamMD5AsString(*dataFork, md5Bytes);
+			delete dataFork;
+			return true;
+		}
+		delete dataFork;
 	}
 
 	if (!allFiles.contains(fname))

--- a/engines/hadesch/hadesch.cpp
+++ b/engines/hadesch/hadesch.cpp
@@ -495,10 +495,10 @@ Common::Error HadeschEngine::run() {
 		};
 		debug("HadeschEngine: loading wd.pod");
 		for (uint i = 0; i < ARRAYSIZE(wdpodpaths); ++i) {
-			Common::SharedPtr<Common::File> file(new Common::File());
-			if (file->open(wdpodpaths[i])) {
+			Common::SharedPtr<Common::SeekableReadStream> stream(Common::MacResManager::openFileOrDataFork(wdpodpaths[i]));
+			if (stream) {
 				_wdPodFile = Common::SharedPtr<PodFile>(new PodFile("WD.POD"));
-				_wdPodFile->openStore(file);
+				_wdPodFile->openStore(stream);
 				break;
 			}
 		}
@@ -516,8 +516,8 @@ Common::Error HadeschEngine::run() {
 	// on cdScenePath
 	const char *const scenepaths[] = {"CDAssets/", "Scenes/"};
 	for (uint i = 0; i < ARRAYSIZE(scenepaths); ++i) {
-		Common::ScopedPtr<Common::File> file(new Common::File());
-		if (file->open(Common::String(scenepaths[i]) + "OLYMPUS/OL.POD")) {
+		Common::ScopedPtr<Common::SeekableReadStream> stream(Common::MacResManager::openFileOrDataFork(Common::String(scenepaths[i]) + "OLYMPUS/OL.POD"));
+		if (stream) {
 			_cdScenesPath = scenepaths[i];
 			break;
 		}

--- a/engines/hadesch/pod_file.cpp
+++ b/engines/hadesch/pod_file.cpp
@@ -22,6 +22,7 @@
  */
 #include "common/debug.h"
 #include "common/file.h"
+#include "common/macresman.h"
 #include "common/memstream.h"
 
 #include "hadesch/hadesch.h"
@@ -75,12 +76,16 @@ bool PodFile::openStore(const Common::SharedPtr<Common::SeekableReadStream> &par
 }
 
 bool PodFile::openStore(const Common::String &name) {
-	Common::SharedPtr<Common::File> file(new Common::File());
-	if (name.empty() || !file->open(name)) {
+  	if (name.empty()) {
 		return false;
 	}
 
-	return openStore(file);
+	Common::SharedPtr<Common::SeekableReadStream> stream(Common::MacResManager::openFileOrDataFork(name));
+	if (!stream) {
+		return false;
+	}
+
+	return openStore(stream);
 }
 
 // It's tempting to use substream but substream is not thread safe

--- a/engines/hadesch/video.cpp
+++ b/engines/hadesch/video.cpp
@@ -32,6 +32,7 @@
 #include "hadesch/pod_file.h"
 #include "hadesch/baptr.h"
 #include "common/translation.h"
+#include "common/macresman.h"
 
 static const int kVideoMaxW = 1280;
 static const int kVideoMaxH = 480;
@@ -758,12 +759,13 @@ void VideoRoom::playVideo(const Common::String &name, int zValue,
 	Common::SharedPtr<Video::SmackerDecoder> decoder
 	  = Common::SharedPtr<Video::SmackerDecoder>(new Video::SmackerDecoder());
 
-	Common::File *file = new Common::File;
 	Common::String mappedName = _assetMap.get(name, 1);
 	if (mappedName == "") {
 		mappedName = name;
 	}
-	if (!file->open(_smkPath + "/" + mappedName + ".SMK") || !decoder->loadStream(file)) {
+	Common::SeekableReadStream *stream = Common::MacResManager::openFileOrDataFork(_smkPath + "/" + mappedName + ".SMK");
+
+	if (!stream || !decoder->loadStream(stream)) {
 		debug("Video file %s can't be opened", name.c_str());
 		g_vm->handleEvent(callbackEvent);
 		return;


### PR DESCRIPTION
Currently HFS+ partition is supported in following formats:
* On Mac OS X natively
* Apple Double
* Detached .rsrc
* Executable as MacBinary and rest as plain

The last one is used by e.g. dumper-companion.py and automode of hfsutils hcopy but other tools support e.g. hfsutils hcopy 
 in macbinary mode copies everything as macbinary and this is a better mode for data preservation as it keeps i.a. file types and finder data. This PR add support for full macbinary copy while keeping other possibilities