### PR TITLE
DETECTOR: Fix punycode ambiguity

### DIFF
--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -469,7 +469,7 @@ void AdvancedMetaEngineDetection::composeFileHashMap(FileMap &allFiles, const Co
 		return;
 
 	for (Common::FSList::const_iterator file = fslist.begin(); file != fslist.end(); ++file) {
-		Common::String efname = Common::punycode_encodefilename(file->getName());
+		Common::String efname = file->getName();
 		Common::String tstr = ((_flags & kADFlagMatchFullPaths) && !parentName.empty() ? parentName + "/" : "") + efname;
 
 		if (file->isDirectory()) {
@@ -601,7 +601,7 @@ ADDetectedGames AdvancedMetaEngineDetection::detectGame(const Common::FSNode &pa
 				continue;
 
 			FileProperties tmp;
-			if (getFileProperties(allFiles, *g, fname, tmp)) {
+			if (getFileProperties(allFiles, *g, Common::punycode_decodefilename(fname), tmp)) {
 				debugC(3, kDebugGlobalDetection, "> '%s': '%s' %ld", key.c_str(), tmp.md5.c_str(), long(tmp.size));
 			}
 


### PR DESCRIPTION
For the same unicode string there are several possible valid punycode strings. E.g. "xn--Install\ Legend\ of\ Kyrandia-jf8p.bin" and "xn--Install Legend of Kyrandia.bin-9o5s" give the same unicode.

Former is the name for macbin as macresman looks for it and later is how fs layer sees it.

FS layer already decodes punycode filenames. So let's just decode punycodes coming from the code and meet them in UTF-32 land.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
