### PR TITLE
NOTFORMERGE: DETECTOR: Allow to specify md5-type per-file and message on missing resource

### DIFF
--- a/common/macresman.h
+++ b/common/macresman.h
@@ -221,7 +221,7 @@ public:
 	static MacVers *parseVers(SeekableReadStream *vvers);
 
 private:
-	SeekableReadStream *_stream;
+	SeekableReadStream *_stream, *_dataForkStream;
 	Path _baseFileName;
 
 	bool load(SeekableReadStream *stream);

--- a/engines/adl/detection.cpp
+++ b/engines/adl/detection.cpp
@@ -569,18 +569,18 @@ ADDetectedGames AdlMetaEngineDetection::detectGame(const Common::FSNode &parent,
 
 			game.matchedFiles[fileName] = filesProps[fileName];
 
-			if (game.hasUnknownFiles)
+			if (game.getHasUnknownFiles())
 				continue;
 
 			if (fDesc.md5 && fDesc.md5 != filesProps[fileName].md5) {
 				debugC(3, kDebugGlobalDetection, "MD5 Mismatch. Skipping (%s) (%s)", fDesc.md5, filesProps[fileName].md5.c_str());
-				game.hasUnknownFiles = true;
+				game.hasMismatchedFiles = true;
 				continue;
 			}
 
 			if (fDesc.fileSize != -1 && fDesc.fileSize != filesProps[fileName].size) {
 				debugC(3, kDebugGlobalDetection, "Size Mismatch. Skipping");
-				game.hasUnknownFiles = true;
+				game.hasMismatchedFiles = true;
 				continue;
 			}
 
@@ -589,7 +589,7 @@ ADDetectedGames AdlMetaEngineDetection::detectGame(const Common::FSNode &parent,
 
 		// This assumes that the detection table groups together games that have the same gameId and platform
 		if (allFilesPresent) {
-			if (!game.hasUnknownFiles) {
+			if (!game.getHasUnknownFiles()) {
 				debugC(2, kDebugGlobalDetection, "Found game: %s (%s/%s) (%d)", game.desc->gameId, getPlatformDescription(game.desc->platform), getLanguageDescription(game.desc->language), g);
 				// If we just added an unknown variant for this game and platform, remove it
 				if (!matched.empty() && strcmp(matched.back().desc->gameId, game.desc->gameId) == 0 && matched.back().desc->platform == game.desc->platform)

--- a/engines/ags/detection.cpp
+++ b/engines/ags/detection.cpp
@@ -184,7 +184,8 @@ ADDetectedGame AGSMetaEngineDetection::fallbackDetect(const FileMap &allFiles, c
 			game.matchedFiles[_filename].md5 = _md5;
 			game.matchedFiles[_filename].size = f.size();
 
-			game.hasUnknownFiles = hasUnknownFiles;
+			game.hasMismatchedFiles = hasUnknownFiles;
+			game.hasMissingResourceFork = false;
 			return game;
 		}
 	}

--- a/engines/director/detection.cpp
+++ b/engines/director/detection.cpp
@@ -287,8 +287,9 @@ ADDetectedGame DirectorMetaEngineDetection::fallbackDetect(const FileMap &allFil
 		ADDetectedGame game(&desc->desc);
 
 		FileProperties tmp;
-		if (getFileProperties(allFiles, desc->desc, file->getName(), tmp)) {
-			game.hasUnknownFiles = true;
+		if (getFileProperties(allFiles, kUseTail, file->getName(), tmp)) {
+			game.hasMismatchedFiles = true;
+			game.hasMissingResourceFork = false;
 			game.matchedFiles[file->getName()] = tmp;
 		}
 

--- a/engines/game.cpp
+++ b/engines/game.cpp
@@ -167,11 +167,6 @@ Common::U32String DetectionResults::generateUnknownGameReport(bool translate, ui
 
 // Sync with engines/advancedDetector.cpp
 static char flagsToMD5Prefix(uint32 flags) {
-	if (flags & kMD5MacResFork) {
-		if (flags & kMD5Tail)
-			return 'e';
-		return 'm';
-	}
 	if (flags & kMD5Tail)
 		return 't';
 
@@ -236,16 +231,19 @@ Common::U32String generateUnknownGameReport(const DetectedGames &detectedGames, 
 	report += Common::U32String("\n\n");
 
 	for (FilePropertiesMap::const_iterator file = matchedFiles.begin(); file != matchedFiles.end(); ++file) {
-		Common::String addon;
+		Common::String addon, md5;
 
-		if (file->_value.md5prop & kMD5MacResFork)
-			addon += ", ADGF_MACRESFORK";
 		if (file->_value.md5prop & kMD5Tail)
 			addon += ", ADGF_TAILMD5";
 
+		if (file->_value.md5prop & kMD5MatchedByMacResFork)
+			md5 = "r:" + file->_value.res_md5;
+		else
+			md5 = file->_value.md5;
+
 		report += Common::String::format("  {\"%s\", 0, \"%s\", %lld}%s,\n",
 			Common::punycode_encodefilename(Common::U32String(&file->_key.c_str()[2])).c_str(), // Skip the md5 prefix
-			file->_value.md5.c_str(), (long long)file->_value.size, addon.c_str());
+			md5.c_str(), (long long)file->_value.size, addon.c_str());
 	}
 
 	report += Common::U32String("\n");

--- a/engines/game.h
+++ b/engines/game.h
@@ -105,7 +105,7 @@ enum GameSupportLevel {
 enum MD5Properties {
 	kMD5Head		= 0 << 1,	// the MD5 is calculated from the head, default
 	kMD5Tail		= 1 << 1,	// the MD5 is calculated from the tail
-	kMD5MacResFork	= 1 << 2	// the MD5 is calculated from the Mac Resource fork (head or tail)
+	kMD5MatchedByMacResFork = 1 << 2        // the File was matched by MD5 from the Mac Resource fork (head or tail)
 };
 
 /**
@@ -113,11 +113,11 @@ enum MD5Properties {
  * files while detecting a game.
  */
 struct FileProperties {
-	int64 size;
-	Common::String md5;
+	int64 size, res_size;
+	Common::String md5, res_md5;
 	MD5Properties md5prop;
 
-	FileProperties() : size(-1), md5prop(kMD5Head) {}
+	FileProperties() : size(-1), res_size(-1), md5prop(kMD5Head) {}
 };
 
 /**

--- a/engines/hadesch/detection_tables.h
+++ b/engines/hadesch/detection_tables.h
@@ -47,14 +47,14 @@ static const ADGameDescription gameDescriptions[] = {
 		"hadesch",
 		0,
 		{
-			{"Hades Challenge PPC", 0, "0a1dd550e5efe7f36370e689811fac73", 28945},
-			{"WD.POD", 0, "be7030fc4229e69e719ee2c756eb6ba1", 7479768},
-			{"ol.pod", 0, "7cabba8d1d4f1239e312e045ef4e9735", 5621074},
+			{"Hades Challenge PPC", 0, "r:0a1dd550e5efe7f36370e689811fac73", 28945},
+			{"WD.POD", 0, "d:be7030fc4229e69e719ee2c756eb6ba1", 7479768},
+			{"ol.pod", 0, "d:7cabba8d1d4f1239e312e045ef4e9735", 5621074},
 			AD_LISTEND
 		},
 		Common::EN_ANY,
 		Common::kPlatformMacintosh,
-		ADGF_DROPPLATFORM | ADGF_MACRESFORK,
+		ADGF_DROPPLATFORM,
 		GUIO1(GUIO_NOMIDI)
 
 	},

--- a/engines/macventure/detection.cpp
+++ b/engines/macventure/detection.cpp
@@ -28,8 +28,8 @@ namespace MacVenture {
 
 #define ADGF_DEFAULT (ADGF_DROPLANGUAGE|ADGF_DROPPLATFORM|ADGF_MACRESFORK|ADGF_UNSTABLE)
 
-#define MACGAME(n, v, f, md5, s) {n, v, AD_ENTRY1s(f, md5, s), Common::EN_ANY, Common::kPlatformMacintosh, ADGF_DEFAULT, GUIO1(GUIO_NOMIDI)}
-#define MACDEMO(n, v, f, md5, s) {n, v, AD_ENTRY1s(f, md5, s), Common::EN_ANY, Common::kPlatformMacintosh, ADGF_DEFAULT|ADGF_DEMO, GUIO1(GUIO_NOMIDI)}
+#define MACGAME(n, v, f, md5, s) {n, v, AD_ENTRY1s(f, md5, s), Common::EN_ANY, Common::kPlatformMacintosh, ADGF_DEFAULT|ADGF_MACRESFORK, GUIO1(GUIO_NOMIDI)}
+#define MACDEMO(n, v, f, md5, s) {n, v, AD_ENTRY1s(f, md5, s), Common::EN_ANY, Common::kPlatformMacintosh, ADGF_DEFAULT|ADGF_MACRESFORK|ADGF_DEMO, GUIO1(GUIO_NOMIDI)}
 #define IIGSGAME(n, v, f, md5, s) {n, v, AD_ENTRY1s(f, md5, s), Common::EN_ANY, Common::kPlatformApple2GS, ADGF_DEFAULT, GUIO1(GUIO_NOMIDI)}
 
 static const ADGameDescription gameDescriptions[] = {

--- a/engines/sludge/detection.cpp
+++ b/engines/sludge/detection.cpp
@@ -148,8 +148,8 @@ ADDetectedGame SludgeMetaEngineDetection::fallbackDetect(const FileMap &allFiles
 		game.desc = &s_fallbackDesc.desc;
 
 		FileProperties tmp;
-		if (getFileProperties(allFiles, s_fallbackDesc.desc, fileName, tmp)) {
-			game.hasUnknownFiles = true;
+		if (getFileProperties(allFiles, kFilePropertiesNone, fileName, tmp)) {
+			game.hasMismatchedFiles = true;
 			game.matchedFiles[fileName] = tmp;
 		}
 

--- a/engines/wintermute/metaengine.cpp
+++ b/engines/wintermute/metaengine.cpp
@@ -178,8 +178,8 @@ public:
 			if (!file->getName().hasSuffixIgnoreCase(".dcp")) continue;
 
 			FileProperties tmp;
-			if (AdvancedMetaEngine::getFilePropertiesExtern(md5Bytes, allFiles, s_fallbackDesc, file->getName(), tmp)) {
-				game.hasUnknownFiles = true;
+			if (AdvancedMetaEngine::getFilePropertiesExtern(md5Bytes, allFiles, kFilePropertiesNone, file->getName(), tmp)) {
+				game.hasMismatchedFiles = true;
 				game.matchedFiles[file->getName()] = tmp;
 			}
 		}


### PR DESCRIPTION
   A common user error is to copy disk contents omitting resource forks.
    We should report it with a message instructing on how to dump properly.
    Unfortunately in current system we make no difference between hash of
    resource fork and hash of data fork, so we don't know when we expect a
    resource fork and when a plain file is good enough. Remove
    ADGF_MACRESFORK and instead use "r:" prefix to specify that it's a resource
    fork.

I would like to get it approved in general first before I go through checking bunch of games