### PR TITLE
ALL: Fix strncpy usages

### DIFF
--- a/engines/agi/text.cpp
+++ b/engines/agi/text.cpp
@@ -889,7 +889,7 @@ void TextMgr::promptCommandWindow(bool recallLastCommand, uint16 newKey) {
 	if (_systemUI->askForCommand(commandText)) {
 		if (commandText.size()) {
 			// Something actually was entered?
-			strncpy((char *)&_prompt, commandText.c_str(), sizeof(_prompt));
+			Common::strcpy_s((char *)_prompt, sizeof(_prompt), commandText.c_str());
 			promptRememberForAutoComplete(true);
 			memcpy(&_promptPrevious, &_prompt, sizeof(_prompt));
 			// parse text

--- a/engines/glk/jacl/parser.cpp
+++ b/engines/glk/jacl/parser.cpp
@@ -385,10 +385,10 @@ void call_functions(const char *base_name) {
 	 * PASS. IF THE COMMAND FAILS, 'TIME' WILL BE SET TO FALSE */
 	TIME->value = TRUE;
 
-	strncpy(base_function, base_name + 1, 80);
+	Common::strlcpy(base_function, base_name + 1, 81);
 	Common::strcat_s(base_function, "_");
 
-	strncpy(override_, base_function, 80);
+	Common::strlcpy(override_, base_function, 81);
 
 	Common::strcpy_s(before_function, "+before_");
 	Common::strcat_s(before_function, base_name + 1);

--- a/engines/glk/level9/os_glk.cpp
+++ b/engines/glk/level9/os_glk.cpp
@@ -1289,8 +1289,8 @@ static void gln_graphics_locate_bitmaps(const char *gamefile) {
 	basename = gamefile;
 
 	/* Take a copy of the directory part of the filename. */
-	dirname = (char *)gln_malloc(basename - gamefile + 1);
-	strncpy(dirname, gamefile, basename - gamefile);
+	dirname = (char *)gln_malloc(/*basename - gamefile +*/ 1);
+	//strncpy(dirname, gamefile, basename - gamefile);
 	dirname[basename - gamefile] = '\0';
 
 	/*

--- a/engines/glk/tads/tads2/vocabulary_parser.cpp
+++ b/engines/glk/tads/tads2/vocabulary_parser.cpp
@@ -4753,8 +4753,7 @@ static void voc_get_spec_str(voccxdef *ctx, char vocw_id,
 	/* if we didn't find it, use the default */
 	if (!found)
 	{
-		strncpy(buf, default_name, (size_t)buflen);
-		buf[buflen - 1] = '\0';
+		Common::strlcpy(buf, default_name, (size_t)buflen);
 	}
 }
 

--- a/engines/mutationofjb/commands/changecommand.cpp
+++ b/engines/mutationofjb/commands/changecommand.cpp
@@ -70,7 +70,7 @@ bool ChangeCommandParser::parseValueString(const Common::String &valueString, bo
 	if (valueString.hasPrefix("NM")) {
 		reg = ChangeCommand::NM;
 		op = ChangeCommand::SetValue;
-		strncpy(ccv._strVal, val, MAX_ENTITY_NAME_LENGTH);
+		Common::strlcpy(ccv._strVal, val, MAX_ENTITY_NAME_LENGTH + 1);
 	} else if (valueString.hasPrefix("LT")) {
 		reg = ChangeCommand::LT;
 		ccv._byteVal = parseInteger(val, op);
@@ -354,7 +354,7 @@ Command::ExecuteResult ChangeDoorCommand::execute(ScriptExecutionContext &script
 
 	switch (_register) {
 	case NM:
-		strncpy(door->_name, _value._strVal, MAX_ENTITY_NAME_LENGTH);
+		Common::strlcpy(door->_name, _value._strVal, MAX_ENTITY_NAME_LENGTH + 1);
 		break;
 	case LT:
 		door->_destSceneId = _value._byteVal;
@@ -477,7 +477,7 @@ Command::ExecuteResult ChangeStaticCommand::execute(ScriptExecutionContext &scri
 		stat->_active = _value._byteVal;
 		break;
 	case NM:
-		strncpy(stat->_name, _value._strVal, MAX_ENTITY_NAME_LENGTH);
+		Common::strlcpy(stat->_name, _value._strVal, MAX_ENTITY_NAME_LENGTH + 1);
 		break;
 	case XX:
 		stat->_x = _value._wordVal;

--- a/engines/saga/actor.cpp
+++ b/engines/saga/actor.cpp
@@ -1107,9 +1107,9 @@ void Actor::drawSpeech() {
 	outputString.resize(stringLength + 1);
 
 	if (_activeSpeech.speechFlags & kSpeakSlow)
-		strncpy(&outputString.front(), _activeSpeech.strings[0], _activeSpeech.slowModeCharIndex + 1);
+		Common::strlcpy(&outputString.front(), _activeSpeech.strings[0], _activeSpeech.slowModeCharIndex + 2);
 	else
-		strncpy(&outputString.front(), _activeSpeech.strings[0], stringLength);
+		Common::strlcpy(&outputString.front(), _activeSpeech.strings[0], stringLength + 1);
 
 	if (_activeSpeech.actorsCount > 1) {
 		height = _vm->_font->getHeight(kKnownFontScript);

--- a/engines/saga/interface.cpp
+++ b/engines/saga/interface.cpp
@@ -1203,10 +1203,10 @@ bool Interface::processTextInput(Common::KeyState keystate) {
 	case Common::KEYCODE_DELETE:
 		if (_textInputPos <= _textInputStringLength) {
 			if (_textInputPos != 1) {
-				strncpy(tempString, _textInputString, _textInputPos - 1);
+				Common::strlcpy(tempString, _textInputString, _textInputPos);
 			}
 			if (_textInputPos != _textInputStringLength) {
-				strncat(tempString, &_textInputString[_textInputPos], _textInputStringLength - _textInputPos);
+				Common::strlcat(tempString, &_textInputString[_textInputPos], _textInputStringLength + 1);
 			}
 			Common::strcpy_s(_textInputString, tempString);
 			_textInputStringLength = strlen(_textInputString);
@@ -1243,14 +1243,14 @@ bool Interface::processTextInput(Common::KeyState keystate) {
 					break;
 				}
 				if (_textInputPos != 1) {
-					strncpy(tempString, _textInputString, _textInputPos - 1);
+					Common::strlcpy(tempString, _textInputString, _textInputPos);
 					Common::strcat_s(tempString, ch);
 				}
 				if ((_textInputStringLength == 0) || (_textInputPos == 1)) {
 					Common::strcpy_s(tempString, ch);
 				}
 				if ((_textInputStringLength != 0) && (_textInputPos != _textInputStringLength)) {
-					strncat(tempString, &_textInputString[_textInputPos - 1], _textInputStringLength - _textInputPos + 1);
+					Common::strlcat(tempString, &_textInputString[_textInputPos - 1], _textInputStringLength + 1);
 				}
 
 				Common::strcpy_s(_textInputString, tempString);
@@ -2496,7 +2496,7 @@ bool Interface::converseAddText(const char *text, int strId, int replyId, byte r
 		}
 
 		_converseText[_converseTextCount].text.resize(i + 1);
-		strncpy(&_converseText[_converseTextCount].text.front(), _converseWorkString, i);
+		Common::strlcpy(&_converseText[_converseTextCount].text.front(), _converseWorkString, i + 1);
 
 		_converseText[_converseTextCount].strId = strId;
 		_converseText[_converseTextCount].text[i] = 0;
@@ -2512,7 +2512,7 @@ bool Interface::converseAddText(const char *text, int strId, int replyId, byte r
 		if (len == i)
 			break;
 
-		strncpy(_converseWorkString, &_converseWorkString[i + 1], len - i);
+		Common::strlcpy(_converseWorkString, &_converseWorkString[i + 1], CONVERSE_MAX_WORK_STRING);
 	}
 
 	_converseStrCount++;

--- a/gui/predictivedialog.cpp
+++ b/gui/predictivedialog.cpp
@@ -509,8 +509,7 @@ void PredictiveDialog::processButton(ButtonId button) {
 			if (_mode == kModePre && _unitedDict.dictActLine && _numMatchingWords > 1 && _wordNumber != 0)
 				bringWordtoTop(_unitedDict.dictActLine, _wordNumber);
 
-			strncpy(_temp, _currentWord.c_str(), _currentCode.size());
-			_temp[_currentCode.size()] = 0;
+			Common::strcpy_s(_temp, _currentWord.c_str());
 			_prefix += _temp;
 			_prefix += " ";
 			_currentCode.clear();
@@ -564,8 +563,7 @@ void PredictiveDialog::processButton(ButtonId button) {
 				if (_unitedDict.dictActLine && _numMatchingWords > 1) {
 					_wordNumber = (_wordNumber + 1) % _numMatchingWords;
 					char tmp[kMaxLineLen];
-					strncpy(tmp, _unitedDict.dictActLine, kMaxLineLen);
-					tmp[kMaxLineLen - 1] = 0;
+					Common::strlcpy(tmp, _unitedDict.dictActLine, kMaxLineLen);
 					char *tok = strtok(tmp, " ");
 					for (uint8 i = 0; i <= _wordNumber; i++)
 						tok = strtok(nullptr, " ");
@@ -697,8 +695,7 @@ void PredictiveDialog::bringWordtoTop(char *str, int wordnum) {
 
 	if (!str)
 		return;
-	strncpy(buf, str, kMaxLineLen);
-	buf[kMaxLineLen - 1] = 0;
+	Common::strlcpy(buf, str, kMaxLineLen);
 	char *word = strtok(buf, " ");
 	if (!word) {
 		debug(5, "Predictive Dialog: Invalid dictionary line");
@@ -771,8 +768,7 @@ bool PredictiveDialog::matchWord() {
 	_wordNumber = 0;
 	if (0 == strncmp(_unitedDict.dictLine[line], _currentCode.c_str(), _currentCode.size())) {
 		char tmp[kMaxLineLen];
-		strncpy(tmp, _unitedDict.dictLine[line], kMaxLineLen);
-		tmp[kMaxLineLen - 1] = 0;
+		Common::strlcpy(tmp, _unitedDict.dictLine[line], kMaxLineLen);
 		char *tok;
 		strtok(tmp, " ");
 		tok = strtok(nullptr, " ");
@@ -821,10 +817,10 @@ void PredictiveDialog::addWord(Dict &dict, const Common::String &word, const Com
 			newLine = (char *)malloc(newLineSize + 1);
 
 			char *ptr = newLine;
-			strncpy(ptr, dict.dictLine[line], oldLineSize);
+			Common::strcpy_s(ptr, newLineSize + 1, dict.dictLine[line]);
 			ptr += oldLineSize;
-			Common::String tmp = ' ' + word + '\0';
-			strncpy(ptr, tmp.c_str(), tmp.size());
+			Common::String tmp = ' ' + word;
+			Common::strcpy_s(ptr, newLineSize + 1 - oldLineSize, tmp.c_str());
 
 			dict.dictLine[line] = newLine;
 			_memoryList[_numMemory++] = newLine;
@@ -846,7 +842,7 @@ void PredictiveDialog::addWord(Dict &dict, const Common::String &word, const Com
 					int len = (predictLine == _predictiveDict.dictLineCount - 1) ? &_predictiveDict.dictText[_predictiveDict.dictTextSize] - _predictiveDict.dictLine[predictLine] :
 					          _predictiveDict.dictLine[predictLine + 1] - _predictiveDict.dictLine[predictLine];
 					newLine = (char *)malloc(len);
-					strncpy(newLine, _predictiveDict.dictLine[predictLine], len);
+					Common::strlcpy(newLine, _predictiveDict.dictLine[predictLine], len);
 				} else {
 					// if there is no word in predictive dictionary, we need to copy to
 					// user dictionary mathed line + new word.
@@ -854,27 +850,26 @@ void PredictiveDialog::addWord(Dict &dict, const Common::String &word, const Com
 					          _predictiveDict.dictLine[predictLine + 1] - _predictiveDict.dictLine[predictLine];
 					newLine = (char *)malloc(len + word.size() + 1);
 					char *ptr = newLine;
-					strncpy(ptr, _predictiveDict.dictLine[predictLine], len);
+					Common::strlcpy(ptr, _predictiveDict.dictLine[predictLine], len);
 					ptr[len - 1] = ' ';
 					ptr += len;
-					strncpy(ptr, word.c_str(), word.size());
-					ptr[len + word.size()] = '\0';
+					Common::strlcpy(ptr, word.c_str(), word.size() + 1);
 				}
 			} else {
 				// if we didnt find line in predictive dialog, we should copy to user dictionary
 				// code + word
 				Common::String tmp;
-				tmp = tmpCode + word + '\0';
-				newLine = (char *)malloc(tmp.size());
-				strncpy(newLine, tmp.c_str(), tmp.size());
+				tmp = tmpCode + word;
+				newLine = (char *)malloc(tmp.size() + 1);
+				Common::strcpy_s(newLine, tmp.size() + 1, tmp.c_str());
 			}
 		} else {
 			// if want to insert line to different from user dictionary, we should copy to this
 			// dictionary code + word
 			Common::String tmp;
-			tmp = tmpCode + word + '\0';
-			newLine = (char *)malloc(tmp.size());
-			strncpy(newLine, tmp.c_str(), tmp.size());
+			tmp = tmpCode + word;
+			newLine = (char *)malloc(tmp.size() + 1);
+			Common::strcpy_s(newLine, tmp.size() + 1, tmp.c_str());
 		}
 	}
 


### PR DESCRIPTION
This fixes several warnings in buildbot.

strcpy_s is used when strncpy would have the ability to overflow the destination buffer.
In other cases, strlcpy is used. This ensures the string is always zero terminated.