### PR TITLE
ICB: Fix an off-by-one in InitWeather()

### DIFF
--- a/engines/icb/set_pc.cpp
+++ b/engines/icb/set_pc.cpp
@@ -1338,7 +1338,7 @@ void _set::InitWeather(int32 type, int32 particleQty, int32 lightning, int32 win
 	if (m_wParticleQty > WEATHER_MAX_PARTICLES)
 		m_wParticleQty = WEATHER_MAX_PARTICLES;
 
-	for (int32 i = WEATHER_MAX_PARTICLES; i >= 0; i--) {
+	for (int32 i = WEATHER_MAX_PARTICLES - 1; i >= 0; i--) {
 		m_wParticleX[i] = (int16)((g_icb->getRandomSource()->getRandomNumber(WEATHER_SCREEN_WIDTH - 1)) - WEATHER_HALF_SCREEN_WIDTH);
 		m_wParticleY[i] = (int16)((g_icb->getRandomSource()->getRandomNumber(WEATHER_SCREEN_HEIGHT - 1)) - WEATHER_HALF_SCREEN_HEIGHT);
 		m_wParticleZ[i] = (int16)((g_icb->getRandomSource()->getRandomNumber(WEATHER_SCREEN_DEPTH - 1)) - WEATHER_HALF_SCREEN_DEPTH);


### PR DESCRIPTION
From UBSan (clang++ 14.0) during *In Cold Blood* initialization:

```
engines/icb/set_pc.cpp:1342:3: runtime error: index 256 out of bounds for type 'int16[256]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior engines/icb/set_pc.cpp:1342:3 in 
engines/icb/set_pc.cpp:1343:3: runtime error: index 256 out of bounds for type 'int16[256]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior engines/icb/set_pc.cpp:1343:3 in 
engines/icb/set_pc.cpp:1344:3: runtime error: index 256 out of bounds for type 'int16[256]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior engines/icb/set_pc.cpp:1344:3 in 
```

The arrays have `WEATHER_MAX_PARTICLES` elements, so this just looks like a small off-by-one.

ok?