### PR TITLE
COMMON: Simplify singleton instantiation

### DIFF
--- a/backends/cloud/cloudmanager.cpp
+++ b/backends/cloud/cloudmanager.cpp
@@ -31,12 +31,6 @@
 #include "backends/networking/sdl_net/localwebserver.h"
 #endif
 
-namespace Common {
-
-DECLARE_SINGLETON(Cloud::CloudManager);
-
-}
-
 namespace Cloud {
 
 const char *const CloudManager::kStoragePrefix = "storage_";

--- a/backends/fs/psp/psp-fs-factory.cpp
+++ b/backends/fs/psp/psp-fs-factory.cpp
@@ -43,10 +43,6 @@
 
 #include <unistd.h>
 
-namespace Common {
-DECLARE_SINGLETON(PSPFilesystemFactory);
-}
-
 AbstractFSNode *PSPFilesystemFactory::makeRootFileNode() const {
 	return new PSPFilesystemNode();
 }

--- a/backends/fs/wii/wii-fs-factory.cpp
+++ b/backends/fs/wii/wii-fs-factory.cpp
@@ -43,10 +43,6 @@
 #include <smb.h>
 #endif
 
-namespace Common {
-DECLARE_SINGLETON(WiiFilesystemFactory);
-}
-
 WiiFilesystemFactory::WiiFilesystemFactory() :
 	_dvdMounted(false),
 	_smbMounted(false),

--- a/backends/graphics/opengl/shader.cpp
+++ b/backends/graphics/opengl/shader.cpp
@@ -24,10 +24,6 @@
 
 #if !USE_FORCED_GLES
 
-namespace Common {
-DECLARE_SINGLETON(OpenGL::ShaderManager);
-}
-
 namespace OpenGL {
 
 namespace {

--- a/backends/networking/curl/connectionmanager.cpp
+++ b/backends/networking/curl/connectionmanager.cpp
@@ -29,12 +29,6 @@
 #include "common/system.h"
 #include "common/timer.h"
 
-namespace Common {
-
-DECLARE_SINGLETON(Networking::ConnectionManager);
-
-}
-
 namespace Networking {
 
 ConnectionManager::ConnectionManager(): _multi(nullptr), _timerStarted(false), _frame(0) {

--- a/backends/networking/sdl_net/localwebserver.cpp
+++ b/backends/networking/sdl_net/localwebserver.cpp
@@ -58,9 +58,6 @@
 
 namespace Common {
 class MemoryReadWriteStream;
-
-DECLARE_SINGLETON(Networking::LocalWebserver);
-
 }
 
 namespace Networking {

--- a/backends/platform/psp/display_manager.cpp
+++ b/backends/platform/psp/display_manager.cpp
@@ -63,10 +63,6 @@ const OSystem::GraphicsMode DisplayManager::_supportedModes[] = {
 
 // Class VramAllocator -----------------------------------
 
-namespace Common {
-DECLARE_SINGLETON(VramAllocator);
-}
-
 //#define __PSP_DEBUG_FUNCS__	/* For debugging the stack */
 //#define __PSP_DEBUG_PRINT__
 

--- a/backends/platform/psp/powerman.cpp
+++ b/backends/platform/psp/powerman.cpp
@@ -29,10 +29,6 @@
 //#define __PSP_DEBUG_PRINT__
 #include "backends/platform/psp/trace.h"
 
-namespace Common {
-DECLARE_SINGLETON(PowerManager);
-}
-
 // Function to debug the Power Manager (we have no output to screen)
 inline void PowerManager::debugPM() {
 	PSP_DEBUG_PRINT("PM status[%d]. Listcount[%d]. CriticalCount[%d]. ThreadId[%x]. Error[%d]\n",

--- a/backends/platform/psp/rtc.cpp
+++ b/backends/platform/psp/rtc.cpp
@@ -33,9 +33,6 @@
 
 
 // Class PspRtc ---------------------------------------------------------------
-namespace Common {
-DECLARE_SINGLETON(PspRtc);
-}
 
 void PspRtc::init() {						// init our starting ticks
 	uint32 ticks[2];

--- a/backends/plugins/elf/memory-manager.cpp
+++ b/backends/plugins/elf/memory-manager.cpp
@@ -28,10 +28,6 @@
 #include "common/util.h"
 #include <malloc.h>
 
-namespace Common {
-DECLARE_SINGLETON(ELFMemoryManager);
-}
-
 ELFMemoryManager::ELFMemoryManager() :
 	_heap(0), _heapSize(0), _heapAlign(0),
 	_trackAllocs(false), _measuredSize(0), _measuredAlign(0),

--- a/backends/plugins/elf/shorts-segment-manager.cpp
+++ b/backends/plugins/elf/shorts-segment-manager.cpp
@@ -32,10 +32,6 @@ extern char __plugin_hole_start;	// Indicates start of hole in program file for 
 extern char __plugin_hole_end;		// Indicates end of hole in program file
 extern char _gp[];					// Value of gp register
 
-namespace Common {
-DECLARE_SINGLETON(ShortSegmentManager);	// For singleton
-}
-
 ShortSegmentManager::ShortSegmentManager() {
 	_shortsStart = &__plugin_hole_start ;	//shorts segment begins at the plugin hole we made when linking
 	_shortsEnd = &__plugin_hole_end;		//and ends at the end of that hole.

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -654,10 +654,6 @@ void PluginManager::addToPluginsInMemList(Plugin *plugin) {
 
 #include "engines/metaengine.h"
 
-namespace Common {
-DECLARE_SINGLETON(EngineManager);
-}
-
 /**
  * This function works for both cached and uncached PluginManagers.
  * For the cached version, most of the logic here will short circuit.
@@ -987,10 +983,6 @@ void EngineManager::upgradeTargetForEngineId(const Common::String &target) const
 
 #include "audio/musicplugin.h"
 
-namespace Common {
-DECLARE_SINGLETON(MusicManager);
-}
-
 const PluginList &MusicManager::getPlugins() const {
 	return PluginManager::instance().getPlugins(PLUGIN_TYPE_MUSIC);
 }
@@ -998,10 +990,6 @@ const PluginList &MusicManager::getPlugins() const {
 // Scaler plugins
 
 #include "graphics/scalerplugin.h"
-
-namespace Common {
-DECLARE_SINGLETON(ScalerManager);
-}
 
 const PluginList &ScalerManager::getPlugins() const {
 	return PluginManager::instance().getPlugins(PLUGIN_TYPE_SCALER);

--- a/common/achievements.cpp
+++ b/common/achievements.cpp
@@ -29,9 +29,6 @@
 
 namespace Common {
 
-DECLARE_SINGLETON(AchievementsManager);
-
-
 AchievementsManager::AchievementsManager() {
 	_iniFile = nullptr;
 	unsetActiveDomain();

--- a/common/archive.cpp
+++ b/common/archive.cpp
@@ -287,6 +287,4 @@ void SearchManager::clear() {
 #endif
 }
 
-DECLARE_SINGLETON(SearchManager);
-
 } // namespace Common

--- a/common/config-manager.cpp
+++ b/common/config-manager.cpp
@@ -35,7 +35,7 @@ static bool isValidDomainName(const Common::String &domName) {
 
 namespace Common {
 
-DECLARE_SINGLETON(ConfigManager);
+DEFINE_SINGLETON(ConfigManager);
 
 char const *const ConfigManager::kApplicationDomain = "scummvm";
 char const *const ConfigManager::kTransientDomain = "__TRANSIENT";

--- a/common/config-manager.h
+++ b/common/config-manager.h
@@ -51,7 +51,7 @@ class SeekableReadStream;
  *       which sends out notifications to interested parties whenever the value
  *       of some specific (or any) configuration key changes.
  */
-class ConfigManager : public Singleton<ConfigManager> {
+class ConfigManager : public OptionalSingleton<ConfigManager> {
 
 public:
 
@@ -219,7 +219,7 @@ public:
 	void                     copyFrom(ConfigManager &source); /*!< Copy from a ConfigManager instance. */
 	/** @} */
 private:
-	friend class Singleton<SingletonBaseType>;
+	friend class OptionalSingleton<SingletonBaseType>;
 	ConfigManager();
 
 	void			loadFromStream(SeekableReadStream &stream);
@@ -250,6 +250,8 @@ private:
 };
 
 /** @} */
+
+DECLARE_SINGLETON(ConfigManager);
 
 } // End of namespace Common
 

--- a/common/coroutines.cpp
+++ b/common/coroutines.cpp
@@ -32,8 +32,6 @@ namespace Common {
 /** Helper null context instance */
 CoroContext nullContext = nullptr;
 
-DECLARE_SINGLETON(CoroutineScheduler);
-
 #ifdef COROUTINE_DEBUG
 namespace {
 /** Count of active coroutines */

--- a/common/debug.cpp
+++ b/common/debug.cpp
@@ -38,8 +38,6 @@ const DebugChannelDef gDebugChannels[] = {
 };
 namespace Common {
 
-DECLARE_SINGLETON(DebugManager);
-
 namespace {
 
 struct DebugLevelComperator {

--- a/common/osd_message_queue.cpp
+++ b/common/osd_message_queue.cpp
@@ -24,8 +24,6 @@
 
 namespace Common {
 
-DECLARE_SINGLETON(OSDMessageQueue);
-
 OSDMessageQueue::OSDMessageQueue() : _lastUpdate(0) {
 }
 

--- a/common/translation.cpp
+++ b/common/translation.cpp
@@ -38,8 +38,6 @@
 
 namespace Common {
 
-DECLARE_SINGLETON(MainTranslationManager);
-
 bool operator<(const TLanguage &l, const TLanguage &r) {
 	return l.name < r.name;
 }

--- a/configure
+++ b/configure
@@ -2292,14 +2292,6 @@ EOF
 
 set_flag_if_supported -Wglobal-constructors
 
-# If the compiler supports the -Wundefined-var-template flag, silence that warning.
-# We get this warning a lot with regard to the Singleton class as we explicitly
-# instantiate each specialisation. An alternate way to deal with it would be to
-# change the way we instantiate the singleton classes as done in PR #967.
-# Note: we check the -Wundefined-var-template as gcc does not error out on unknown
-# -Wno-xxx flags.
-set_flag_if_supported -Wno-undefined-var-template
-
 # Vanilla clang 6 enables the new -Wpragma-pack which warns when leaving an
 # included file which changes the current alignment.
 # As our common/pack-{start,end}.h trigger this we disable this warning.

--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -1083,7 +1083,6 @@ void XcodeProvider::setupBuildConfiguration(const BuildSetup &setup) {
 	ADD_SETTING(scummvm_Debug, "GCC_WARN_UNUSED_FUNCTION", "YES");
 	ValueList scummvm_WarningCFlags;
 	scummvm_WarningCFlags.push_back("-Wno-multichar");
-	scummvm_WarningCFlags.push_back("-Wno-undefined-var-template");
 	scummvm_WarningCFlags.push_back("-Wno-pragma-pack");
 	scummvm_WarningCFlags.push_back("-Wc++11-extensions");
 	ADD_SETTING_LIST(scummvm_Debug, "WARNING_CFLAGS", scummvm_WarningCFlags, kSettingsQuoteVariable | kSettingsAsList, 5);

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -498,12 +498,6 @@ void AdvancedMetaEngineDetection::composeFileHashMap(FileMap &allFiles, const Co
 	}
 }
 
-/* Singleton Cache Storage for MD5 */
-
-namespace Common {
-	DECLARE_SINGLETON(MD5CacheManager);
-}
-
 // Sync with engines/game.cpp
 static char flagsToMD5Prefix(uint32 flags) {
 	if (flags & ADGF_MACRESFORK) {

--- a/engines/asylum/system/config.cpp
+++ b/engines/asylum/system/config.cpp
@@ -23,10 +23,6 @@
 
 #include "asylum/system/sound.h"
 
-namespace Common {
-DECLARE_SINGLETON(Asylum::ConfigurationManager);
-}
-
 namespace Asylum {
 
 static bool g_config_initialized = false;

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -129,10 +129,6 @@ bool ChainedGamesManager::pop(Common::String &target, int &slot) {
 	return true;
 }
 
-namespace Common {
-DECLARE_SINGLETON(ChainedGamesManager);
-}
-
 Engine::Engine(OSystem *syst)
 	: _system(syst),
 		_mixer(_system->getMixer()),

--- a/engines/lure/sound.cpp
+++ b/engines/lure/sound.cpp
@@ -33,10 +33,6 @@
 #include "audio/adlib_ms.h"
 #include "audio/midiparser.h"
 
-namespace Common {
-DECLARE_SINGLETON(Lure::SoundManager);
-}
-
 namespace Lure {
 
 //#define SOUND_CROP_CHANNELS

--- a/engines/nancy/state/credits.cpp
+++ b/engines/nancy/state/credits.cpp
@@ -29,10 +29,6 @@
 
 #include "engines/nancy/state/credits.h"
 
-namespace Common {
-DECLARE_SINGLETON(Nancy::State::Credits);
-}
-
 namespace Nancy {
 namespace State {
 

--- a/engines/nancy/state/help.cpp
+++ b/engines/nancy/state/help.cpp
@@ -29,10 +29,6 @@
 
 #include "engines/nancy/ui/button.h"
 
-namespace Common {
-DECLARE_SINGLETON(Nancy::State::Help);
-}
-
 namespace Nancy {
 namespace State {
 

--- a/engines/nancy/state/logo.cpp
+++ b/engines/nancy/state/logo.cpp
@@ -28,10 +28,6 @@
 
 #include "engines/nancy/state/logo.h"
 
-namespace Common {
-DECLARE_SINGLETON(Nancy::State::Logo);
-}
-
 namespace Nancy {
 namespace State {
 

--- a/engines/nancy/state/mainmenu.cpp
+++ b/engines/nancy/state/mainmenu.cpp
@@ -28,10 +28,6 @@
 #include "engines/nancy/state/mainmenu.h"
 #include "engines/nancy/state/scene.h"
 
-namespace Common {
-DECLARE_SINGLETON(Nancy::State::MainMenu);
-}
-
 namespace Nancy {
 namespace State {
 

--- a/engines/nancy/state/map.cpp
+++ b/engines/nancy/state/map.cpp
@@ -31,10 +31,6 @@
 
 #include "engines/nancy/ui/button.h"
 
-namespace Common {
-DECLARE_SINGLETON(Nancy::State::Map);
-}
-
 namespace Nancy {
 namespace State {
 

--- a/engines/nancy/state/scene.cpp
+++ b/engines/nancy/state/scene.cpp
@@ -35,9 +35,7 @@
 
 #include "engines/nancy/ui/button.h"
 
-namespace Common {
-DECLARE_SINGLETON(Nancy::State::Scene);
-}
+DEFINE_SINGLETON(Nancy::State::Scene);
 
 namespace Nancy {
 namespace State {

--- a/engines/nancy/state/scene.h
+++ b/engines/nancy/state/scene.h
@@ -66,7 +66,7 @@ struct SceneInfo {
 };
 
 // The game state that handles all of the gameplay
-class Scene : public State, public Common::Singleton<Scene> {
+class Scene : public State, public Common::OptionalSingleton<Scene> {
 	friend class Nancy::Action::ActionRecord;
 	friend class Nancy::Action::ActionManager;
 	friend class Nancy::Action::SliderPuzzle;
@@ -265,5 +265,7 @@ private:
 
 } // End of namespace State
 } // End of namespace Nancy
+
+DECLARE_SINGLETON(Nancy::State::Scene);
 
 #endif // NANCY_STATE_SCENE_H

--- a/engines/pegasus/gamestate.cpp
+++ b/engines/pegasus/gamestate.cpp
@@ -29,10 +29,6 @@
 #include "pegasus/gamestate.h"
 #include "pegasus/scoring.h"
 
-namespace Common {
-DECLARE_SINGLETON(Pegasus::GameStateManager);
-}
-
 namespace Pegasus {
 
 Common::Error GameStateManager::writeGameState(Common::WriteStream *stream) {

--- a/engines/pegasus/input.cpp
+++ b/engines/pegasus/input.cpp
@@ -31,10 +31,6 @@
 #include "pegasus/input.h"
 #include "pegasus/pegasus.h"
 
-namespace Common {
-DECLARE_SINGLETON(Pegasus::InputDeviceManager);
-}
-
 namespace Pegasus {
 
 InputDeviceManager::InputDeviceManager() {

--- a/engines/pegasus/items/biochips/arthurchip.cpp
+++ b/engines/pegasus/items/biochips/arthurchip.cpp
@@ -26,10 +26,6 @@
 #include "pegasus/ai/ai_area.h"
 #include "pegasus/items/biochips/arthurchip.h"
 
-namespace Common {
-DECLARE_SINGLETON(Pegasus::ArthurManager);
-}
-
 namespace Pegasus {
 
 static const char *kArthurWisdomMovies[] = {

--- a/engines/sludge/newfatal.cpp
+++ b/engines/sludge/newfatal.cpp
@@ -27,10 +27,6 @@
 #include "sludge/sludge.h"
 #include "sludge/sound.h"
 
-namespace Common {
-DECLARE_SINGLETON(Sludge::FatalMsgManager);
-}
-
 namespace Sludge {
 
 int inFatal(const Common::String &str) {

--- a/engines/stark/services/services.cpp
+++ b/engines/stark/services/services.cpp
@@ -21,10 +21,6 @@
 
 #include "engines/stark/services/services.h"
 
-namespace Common {
-DECLARE_SINGLETON(Stark::StarkServices);
-}
-
 namespace Stark {
 
 } // End of namespace Stark

--- a/engines/sword25/gfx/animationtemplateregistry.cpp
+++ b/engines/sword25/gfx/animationtemplateregistry.cpp
@@ -33,10 +33,6 @@
 #include "sword25/gfx/animationtemplateregistry.h"
 #include "sword25/gfx/animationtemplate.h"
 
-namespace Common {
-DECLARE_SINGLETON(Sword25::AnimationTemplateRegistry);
-}
-
 namespace Sword25 {
 
 bool AnimationTemplateRegistry::persist(OutputPersistenceBlock &writer) {

--- a/engines/sword25/math/regionregistry.cpp
+++ b/engines/sword25/math/regionregistry.cpp
@@ -33,10 +33,6 @@
 #include "sword25/math/regionregistry.h"
 #include "sword25/math/region.h"
 
-namespace Common {
-DECLARE_SINGLETON(Sword25::RegionRegistry);
-}
-
 namespace Sword25 {
 
 bool RegionRegistry::persist(OutputPersistenceBlock &writer) {

--- a/engines/sword25/sword25.cpp
+++ b/engines/sword25/sword25.cpp
@@ -49,9 +49,7 @@
 
 #include "sword25/gfx/animationtemplateregistry.h"	// Needed so we can destroy the singleton
 #include "sword25/gfx/renderobjectregistry.h"		// Needed so we can destroy the singleton
-namespace Common {
-DECLARE_SINGLETON(Sword25::RenderObjectRegistry);
-}
+
 #include "sword25/math/regionregistry.h"			// Needed so we can destroy the singleton
 
 namespace Sword25 {

--- a/engines/testbed/config-params.cpp
+++ b/engines/testbed/config-params.cpp
@@ -24,10 +24,6 @@
 
 #include "testbed/config-params.h"
 
-namespace Common {
-DECLARE_SINGLETON(Testbed::ConfigParams);
-}
-
 namespace Testbed {
 
 ConfigParams::ConfigParams() {

--- a/engines/wintermute/base/base_engine.cpp
+++ b/engines/wintermute/base/base_engine.cpp
@@ -31,9 +31,6 @@
 #include "engines/wintermute/wintermute.h"
 #include "engines/wintermute/system/sys_class_registry.h"
 #include "common/system.h"
-namespace Common {
-DECLARE_SINGLETON(Wintermute::BaseEngine);
-}
 
 namespace Wintermute {
 

--- a/graphics/cursorman.cpp
+++ b/graphics/cursorman.cpp
@@ -24,10 +24,6 @@
 #include "common/system.h"
 #include "common/stack.h"
 
-namespace Common {
-DECLARE_SINGLETON(Graphics::CursorManager);
-}
-
 namespace Graphics {
 
 CursorManager::~CursorManager() {

--- a/graphics/fontman.cpp
+++ b/graphics/fontman.cpp
@@ -25,10 +25,6 @@
 
 #include "common/translation.h"
 
-namespace Common {
-DECLARE_SINGLETON(Graphics::FontManager);
-}
-
 namespace Graphics {
 
 FORWARD_DECLARE_FONT(g_sysfont);

--- a/graphics/fonts/ttf.cpp
+++ b/graphics/fonts/ttf.cpp
@@ -1079,8 +1079,4 @@ Font *findTTFace(const Common::Array<Common::String> &files, const Common::U32St
 
 } // End of namespace Graphics
 
-namespace Common {
-DECLARE_SINGLETON(Graphics::TTFLibrary);
-} // End of namespace Common
-
 #endif

--- a/graphics/opengl/context.cpp
+++ b/graphics/opengl/context.cpp
@@ -39,10 +39,6 @@ static GLADapiproc loadFunc(const char *name) {
 }
 #endif
 
-namespace Common {
-DECLARE_SINGLETON(OpenGL::Context);
-}
-
 namespace OpenGL {
 
 Context::Context() {

--- a/graphics/yuv_to_rgb.cpp
+++ b/graphics/yuv_to_rgb.cpp
@@ -85,10 +85,6 @@
 #include "graphics/surface.h"
 #include "graphics/yuv_to_rgb.h"
 
-namespace Common {
-DECLARE_SINGLETON(Graphics::YUVToRGBManager);
-}
-
 namespace Graphics {
 
 class YUVToRGBLookup {

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -24,10 +24,6 @@
 
 #ifdef ENABLE_EVENTRECORDER
 
-namespace Common {
-DECLARE_SINGLETON(GUI::EventRecorder);
-}
-
 #include "common/debug-channels.h"
 #include "backends/timer/sdl/sdl-timer.h"
 #include "backends/mixer/mixer.h"

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -45,9 +45,7 @@
 
 #include "graphics/cursorman.h"
 
-namespace Common {
-DECLARE_SINGLETON(GUI::GuiManager);
-}
+DEFINE_SINGLETON(GUI::GuiManager);
 
 namespace GUI {
 

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -69,9 +69,9 @@ typedef Common::FixedStack<Dialog *> DialogStack;
 /**
  * GUI manager singleton.
  */
-class GuiManager : public Common::Singleton<GuiManager>, public CommandSender {
+class GuiManager : public Common::OptionalSingleton<GuiManager>, public CommandSender {
 	friend class Dialog;
-	friend class Common::Singleton<SingletonBaseType>;
+	friend class Common::OptionalSingleton<SingletonBaseType>;
 	GuiManager();
 	~GuiManager() override;
 public:
@@ -227,5 +227,7 @@ protected:
 };
 
 } // End of namespace GUI
+
+DECLARE_SINGLETON(GUI::GuiManager);
 
 #endif


### PR DESCRIPTION
Another take for eefa72afa1978a9dea10f5b1833fcc8f58a3468e.

With C++11, static variables in functions are guaranteed to be thread-safe[1], and it also solves the undefined-var-template warning.

For classes that require hasInstance() or need to reinstantiate the singleton, there's a new OptionalSingleton class that satisfies these needs.

[1] https://iamroman.org/blog/2017/04/cpp11-static-init/
