### PR TITLE
BACKENDS: OPENGL: Rework libretro pipeline

### DIFF
--- a/backends/graphics/android/android-graphics.cpp
+++ b/backends/graphics/android/android-graphics.cpp
@@ -206,8 +206,10 @@ void AndroidGraphicsManager::refreshScreen() {
 
 void AndroidGraphicsManager::touchControlDraw(int16 x, int16 y, int16 w, int16 h, const Common::Rect &clip) {
 	_backBuffer.enableBlend(OpenGL::Framebuffer::kBlendModeTraditionalTransparency);
-	OpenGL::Pipeline::getActivePipeline()->drawTexture(_touchcontrols->getGLTexture(),
-	                                                   x, y, w, h, clip);
+	OpenGL::Pipeline *pipeline = getPipeline();
+	pipeline->activate();
+	pipeline->drawTexture(_touchcontrols->getGLTexture(),
+	                      x, y, w, h, clip);
 }
 
 void AndroidGraphicsManager::touchControlNotifyChanged() {

--- a/backends/graphics/opengl/framebuffer.cpp
+++ b/backends/graphics/opengl/framebuffer.cpp
@@ -20,19 +20,20 @@
  */
 
 #include "backends/graphics/opengl/framebuffer.h"
-#include "backends/graphics/opengl/texture.h"
 #include "backends/graphics/opengl/pipelines/pipeline.h"
+#include "backends/graphics/opengl/texture.h"
 #include "graphics/opengl/debug.h"
 
 namespace OpenGL {
 
 Framebuffer::Framebuffer()
-	: _viewport(), _projectionMatrix(), _isActive(false), _clearColor(),
+	: _viewport(), _projectionMatrix(), _pipeline(nullptr), _clearColor(),
 	  _blendState(kBlendModeDisabled), _scissorTestState(false), _scissorBox() {
 }
 
-void Framebuffer::activate() {
-	_isActive = true;
+void Framebuffer::activate(Pipeline *pipeline) {
+	assert(pipeline);
+	_pipeline = pipeline;
 
 	applyViewport();
 	applyProjectionMatrix();
@@ -45,9 +46,9 @@ void Framebuffer::activate() {
 }
 
 void Framebuffer::deactivate() {
-	_isActive = false;
-
 	deactivateInternal();
+
+	_pipeline = nullptr;
 }
 
 void Framebuffer::setClearColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) {
@@ -97,7 +98,8 @@ void Framebuffer::applyViewport() {
 }
 
 void Framebuffer::applyProjectionMatrix() {
-	Pipeline::getActivePipeline()->setProjectionMatrix(_projectionMatrix);
+	assert(_pipeline);
+	_pipeline->setProjectionMatrix(_projectionMatrix);
 }
 
 void Framebuffer::applyClearColor() {

--- a/backends/graphics/opengl/framebuffer.cpp
+++ b/backends/graphics/opengl/framebuffer.cpp
@@ -136,6 +136,28 @@ void Framebuffer::applyScissorBox() {
 	GL_CALL(glScissor(_scissorBox[0], _scissorBox[1], _scissorBox[2], _scissorBox[3]));
 }
 
+void Framebuffer::copyRenderStateFrom(const Framebuffer &other, uint copyMask) {
+	if (copyMask & kCopyMaskClearColor) {
+		memcpy(_clearColor, other._clearColor, sizeof(_clearColor));
+	}
+	if (copyMask & kCopyMaskBlendState) {
+		_blendState = other._blendState;
+	}
+	if (copyMask & kCopyMaskScissorState) {
+		_scissorTestState = other._scissorTestState;
+	}
+	if (copyMask & kCopyMaskScissorBox) {
+		memcpy(_scissorBox, other._scissorBox, sizeof(_scissorBox));
+	}
+
+	if (isActive()) {
+		applyClearColor();
+		applyBlendState();
+		applyScissorTestState();
+		applyScissorBox();
+	}
+}
+
 //
 // Backbuffer implementation
 //

--- a/backends/graphics/opengl/framebuffer.cpp
+++ b/backends/graphics/opengl/framebuffer.cpp
@@ -154,25 +154,25 @@ void Backbuffer::setDimensions(uint width, uint height) {
 	_viewport[3] = height;
 
 	// Setup orthogonal projection matrix.
-	_projectionMatrix[ 0] =  2.0f / width;
-	_projectionMatrix[ 1] =  0.0f;
-	_projectionMatrix[ 2] =  0.0f;
-	_projectionMatrix[ 3] =  0.0f;
+	_projectionMatrix(0, 0) =  2.0f / width;
+	_projectionMatrix(0, 1) =  0.0f;
+	_projectionMatrix(0, 2) =  0.0f;
+	_projectionMatrix(0, 3) =  0.0f;
 
-	_projectionMatrix[ 4] =  0.0f;
-	_projectionMatrix[ 5] = -2.0f / height;
-	_projectionMatrix[ 6] =  0.0f;
-	_projectionMatrix[ 7] =  0.0f;
+	_projectionMatrix(1, 0) =  0.0f;
+	_projectionMatrix(1, 1) = -2.0f / height;
+	_projectionMatrix(1, 2) =  0.0f;
+	_projectionMatrix(1, 3) =  0.0f;
 
-	_projectionMatrix[ 8] =  0.0f;
-	_projectionMatrix[ 9] =  0.0f;
-	_projectionMatrix[10] =  0.0f;
-	_projectionMatrix[11] =  0.0f;
+	_projectionMatrix(2, 0) =  0.0f;
+	_projectionMatrix(2, 1) =  0.0f;
+	_projectionMatrix(2, 2) =  0.0f;
+	_projectionMatrix(2, 3) =  0.0f;
 
-	_projectionMatrix[12] = -1.0f;
-	_projectionMatrix[13] =  1.0f;
-	_projectionMatrix[14] =  0.0f;
-	_projectionMatrix[15] =  1.0f;
+	_projectionMatrix(3, 0) = -1.0f;
+	_projectionMatrix(3, 1) =  1.0f;
+	_projectionMatrix(3, 2) =  0.0f;
+	_projectionMatrix(3, 3) =  1.0f;
 
 	// Directly apply changes when we are active.
 	if (isActive()) {
@@ -240,25 +240,25 @@ bool TextureTarget::setSize(uint width, uint height) {
 	_viewport[3] = texHeight;
 
 	// Setup orthogonal projection matrix.
-	_projectionMatrix[ 0] =  2.0f / texWidth;
-	_projectionMatrix[ 1] =  0.0f;
-	_projectionMatrix[ 2] =  0.0f;
-	_projectionMatrix[ 3] =  0.0f;
+	_projectionMatrix(0, 0) =  2.0f / texWidth;
+	_projectionMatrix(0, 1) =  0.0f;
+	_projectionMatrix(0, 2) =  0.0f;
+	_projectionMatrix(0, 3) =  0.0f;
 
-	_projectionMatrix[ 4] =  0.0f;
-	_projectionMatrix[ 5] =  2.0f / texHeight;
-	_projectionMatrix[ 6] =  0.0f;
-	_projectionMatrix[ 7] =  0.0f;
+	_projectionMatrix(1, 0) =  0.0f;
+	_projectionMatrix(1, 1) =  2.0f / texHeight;
+	_projectionMatrix(1, 2) =  0.0f;
+	_projectionMatrix(1, 3) =  0.0f;
 
-	_projectionMatrix[ 8] =  0.0f;
-	_projectionMatrix[ 9] =  0.0f;
-	_projectionMatrix[10] =  0.0f;
-	_projectionMatrix[11] =  0.0f;
+	_projectionMatrix(2, 0) =  0.0f;
+	_projectionMatrix(2, 1) =  0.0f;
+	_projectionMatrix(2, 2) =  0.0f;
+	_projectionMatrix(2, 3) =  0.0f;
 
-	_projectionMatrix[12] = -1.0f;
-	_projectionMatrix[13] = -1.0f;
-	_projectionMatrix[14] =  0.0f;
-	_projectionMatrix[15] =  1.0f;
+	_projectionMatrix(3, 0) = -1.0f;
+	_projectionMatrix(3, 1) = -1.0f;
+	_projectionMatrix(3, 2) =  0.0f;
+	_projectionMatrix(3, 3) =  1.0f;
 
 	// Directly apply changes when we are active.
 	if (isActive()) {

--- a/backends/graphics/opengl/framebuffer.h
+++ b/backends/graphics/opengl/framebuffer.h
@@ -86,6 +86,22 @@ public:
 	 * Obtain projection matrix of the framebuffer.
 	 */
 	const Math::Matrix4 &getProjectionMatrix() const { return _projectionMatrix; }
+
+	enum CopyMask {
+		kCopyMaskClearColor   = (1 << 0),
+		kCopyMaskBlendState   = (1 << 1),
+		kCopyMaskScissorState = (1 << 2),
+		kCopyMaskScissorBox   = (1 << 4),
+
+		kCopyMaskAll          = kCopyMaskClearColor | kCopyMaskBlendState |
+		                        kCopyMaskScissorState | kCopyMaskScissorBox,
+	};
+
+	/**
+	 * Copy rendering state from another framebuffer
+	 */
+	void copyRenderStateFrom(const Framebuffer &other, uint copyMask);
+
 protected:
 	bool isActive() const { return _pipeline != nullptr; }
 

--- a/backends/graphics/opengl/framebuffer.h
+++ b/backends/graphics/opengl/framebuffer.h
@@ -28,11 +28,12 @@
 
 namespace OpenGL {
 
+class Pipeline;
+
 /**
  * Object describing a framebuffer OpenGL can render to.
  */
 class Framebuffer {
-	friend class Pipeline;
 public:
 	Framebuffer();
 	virtual ~Framebuffer() {};
@@ -86,7 +87,7 @@ public:
 	 */
 	const Math::Matrix4 &getProjectionMatrix() const { return _projectionMatrix; }
 protected:
-	bool isActive() const { return _isActive; }
+	bool isActive() const { return _pipeline != nullptr; }
 
 	GLint _viewport[4];
 	void applyViewport();
@@ -109,11 +110,11 @@ protected:
 	 */
 	virtual void deactivateInternal() {}
 
-private:
+public:
 	/**
 	 * Accessor to activate framebuffer for pipeline.
 	 */
-	void activate();
+	void activate(Pipeline *pipeline);
 
 	/**
 	 * Accessor to deactivate framebuffer from pipeline.
@@ -121,7 +122,7 @@ private:
 	void deactivate();
 
 private:
-	bool _isActive;
+	Pipeline *_pipeline;
 
 	GLfloat _clearColor[4];
 	void applyClearColor();

--- a/backends/graphics/opengl/framebuffer.h
+++ b/backends/graphics/opengl/framebuffer.h
@@ -148,7 +148,7 @@ public:
 	void setDimensions(uint width, uint height);
 
 protected:
-	virtual void activateInternal();
+	void activateInternal() override;
 };
 
 #if !USE_FORCED_GLES
@@ -163,7 +163,7 @@ class GLTexture;
 class TextureTarget : public Framebuffer {
 public:
 	TextureTarget();
-	virtual ~TextureTarget();
+	~TextureTarget() override;
 
 	/**
 	 * Notify that the GL context is about to be destroyed.
@@ -186,7 +186,7 @@ public:
 	GLTexture *getTexture() const { return _texture; }
 
 protected:
-	virtual void activateInternal();
+	void activateInternal() override;
 
 private:
 	GLTexture *_texture;

--- a/backends/graphics/opengl/framebuffer.h
+++ b/backends/graphics/opengl/framebuffer.h
@@ -24,6 +24,8 @@
 
 #include "graphics/opengl/system_headers.h"
 
+#include "math/matrix4.h"
+
 namespace OpenGL {
 
 /**
@@ -82,14 +84,14 @@ public:
 	/**
 	 * Obtain projection matrix of the framebuffer.
 	 */
-	const GLfloat *getProjectionMatrix() const { return _projectionMatrix; }
+	const Math::Matrix4 &getProjectionMatrix() const { return _projectionMatrix; }
 protected:
 	bool isActive() const { return _isActive; }
 
 	GLint _viewport[4];
 	void applyViewport();
 
-	GLfloat _projectionMatrix[4*4];
+	Math::Matrix4 _projectionMatrix;
 	void applyProjectionMatrix();
 
 	/**

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -355,6 +355,8 @@ bool OpenGLGraphicsManager::loadShader(const Common::String &fileName) {
 			warning("Failed to load shader %s", fileName.c_str());
 			return false;
 		}
+	} else {
+		_libretroPipeline->close();
 	}
 #endif
 

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -351,14 +351,6 @@ protected:
 	 */
 	byte _gamePalette[3 * 256];
 
-#if !USE_FORCED_GLES
-	/**
-	 * The render target for the virtual game screen. Used when
-	 * LibRetro shaders are enabled.
-	 */
-	TextureTarget *_gameScreenTarget;
-#endif
-
 	//
 	// Overlay
 	//

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -324,6 +324,8 @@ protected:
 
 	void updateLinearFiltering();
 
+	Pipeline *getPipeline() const { return _pipeline; }
+
 	/**
 	 * The default pixel format of the backend.
 	 */

--- a/backends/graphics/opengl/pipelines/clut8.cpp
+++ b/backends/graphics/opengl/pipelines/clut8.cpp
@@ -31,7 +31,7 @@ CLUT8LookUpPipeline::CLUT8LookUpPipeline()
 	: ShaderPipeline(ShaderMan.query(ShaderManager::kCLUT8LookUp)), _paletteTexture(nullptr) {
 }
 
-void CLUT8LookUpPipeline::drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) {
+void CLUT8LookUpPipeline::drawTextureInternal(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) {
 	// Set the palette texture.
 	GL_CALL(glActiveTexture(GL_TEXTURE1));
 	if (_paletteTexture) {
@@ -39,7 +39,7 @@ void CLUT8LookUpPipeline::drawTexture(const GLTexture &texture, const GLfloat *c
 	}
 
 	GL_CALL(glActiveTexture(GL_TEXTURE0));
-	ShaderPipeline::drawTexture(texture, coordinates, texcoords);
+	ShaderPipeline::drawTextureInternal(texture, coordinates, texcoords);
 }
 #endif // !USE_FORCED_GLES
 

--- a/backends/graphics/opengl/pipelines/clut8.cpp
+++ b/backends/graphics/opengl/pipelines/clut8.cpp
@@ -32,6 +32,8 @@ CLUT8LookUpPipeline::CLUT8LookUpPipeline()
 }
 
 void CLUT8LookUpPipeline::drawTextureInternal(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) {
+	assert(isActive());
+
 	// Set the palette texture.
 	GL_CALL(glActiveTexture(GL_TEXTURE1));
 	if (_paletteTexture) {

--- a/backends/graphics/opengl/pipelines/clut8.h
+++ b/backends/graphics/opengl/pipelines/clut8.h
@@ -33,7 +33,7 @@ public:
 
 	void setPaletteTexture(const GLTexture *paletteTexture) { _paletteTexture = paletteTexture; }
 
-	virtual void drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords);
+	void drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) override;
 
 private:
 	const GLTexture *_paletteTexture;

--- a/backends/graphics/opengl/pipelines/clut8.h
+++ b/backends/graphics/opengl/pipelines/clut8.h
@@ -33,7 +33,8 @@ public:
 
 	void setPaletteTexture(const GLTexture *paletteTexture) { _paletteTexture = paletteTexture; }
 
-	void drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) override;
+protected:
+	void drawTextureInternal(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) override;
 
 private:
 	const GLTexture *_paletteTexture;

--- a/backends/graphics/opengl/pipelines/fixed.cpp
+++ b/backends/graphics/opengl/pipelines/fixed.cpp
@@ -40,13 +40,23 @@ void FixedPipeline::activateInternal() {
 	}
 #endif
 	GL_CALL(glEnable(GL_TEXTURE_2D));
+	GL_CALL(glColor4f(_r, _g, _b, _a));
 }
 
 void FixedPipeline::setColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) {
-	GL_CALL(glColor4f(r, g, b, a));
+	_r = r;
+	_g = g;
+	_b = b;
+	_a = a;
+
+	if (isActive()) {
+		GL_CALL(glColor4f(r, g, b, a));
+	}
 }
 
 void FixedPipeline::drawTextureInternal(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) {
+	assert(isActive());
+
 	texture.bind();
 
 	GL_CALL(glTexCoordPointer(2, GL_FLOAT, 0, texcoords));
@@ -55,9 +65,7 @@ void FixedPipeline::drawTextureInternal(const GLTexture &texture, const GLfloat 
 }
 
 void FixedPipeline::setProjectionMatrix(const Math::Matrix4 &projectionMatrix) {
-	if (!isActive()) {
-		return;
-	}
+	assert(isActive());
 
 	GL_CALL(glMatrixMode(GL_PROJECTION));
 	GL_CALL(glLoadMatrixf(projectionMatrix.getData()));

--- a/backends/graphics/opengl/pipelines/fixed.cpp
+++ b/backends/graphics/opengl/pipelines/fixed.cpp
@@ -46,7 +46,7 @@ void FixedPipeline::setColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) {
 	GL_CALL(glColor4f(r, g, b, a));
 }
 
-void FixedPipeline::drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) {
+void FixedPipeline::drawTextureInternal(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) {
 	texture.bind();
 
 	GL_CALL(glTexCoordPointer(2, GL_FLOAT, 0, texcoords));

--- a/backends/graphics/opengl/pipelines/fixed.cpp
+++ b/backends/graphics/opengl/pipelines/fixed.cpp
@@ -26,6 +26,8 @@ namespace OpenGL {
 
 #if !USE_FORCED_GLES2
 void FixedPipeline::activateInternal() {
+	Pipeline::activateInternal();
+
 	GL_CALL(glDisable(GL_LIGHTING));
 	GL_CALL(glDisable(GL_FOG));
 	GL_CALL(glShadeModel(GL_FLAT));

--- a/backends/graphics/opengl/pipelines/fixed.cpp
+++ b/backends/graphics/opengl/pipelines/fixed.cpp
@@ -54,13 +54,13 @@ void FixedPipeline::drawTexture(const GLTexture &texture, const GLfloat *coordin
 	GL_CALL(glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));
 }
 
-void FixedPipeline::setProjectionMatrix(const GLfloat *projectionMatrix) {
+void FixedPipeline::setProjectionMatrix(const Math::Matrix4 &projectionMatrix) {
 	if (!isActive()) {
 		return;
 	}
 
 	GL_CALL(glMatrixMode(GL_PROJECTION));
-	GL_CALL(glLoadMatrixf(projectionMatrix));
+	GL_CALL(glLoadMatrixf(projectionMatrix.getData()));
 
 	GL_CALL(glMatrixMode(GL_MODELVIEW));
 	GL_CALL(glLoadIdentity());

--- a/backends/graphics/opengl/pipelines/fixed.h
+++ b/backends/graphics/opengl/pipelines/fixed.h
@@ -29,6 +29,8 @@ namespace OpenGL {
 #if !USE_FORCED_GLES2
 class FixedPipeline : public Pipeline {
 public:
+	FixedPipeline() : _r(0.f), _g(0.f), _b(0.f), _a(0.f) {}
+
 	void setColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) override;
 
 	void setProjectionMatrix(const Math::Matrix4 &projectionMatrix) override;
@@ -36,6 +38,8 @@ public:
 protected:
 	void activateInternal() override;
 	void drawTextureInternal(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) override;
+
+	GLfloat _r, _g, _b, _a;
 };
 #endif // !USE_FORCED_GLES2
 

--- a/backends/graphics/opengl/pipelines/fixed.h
+++ b/backends/graphics/opengl/pipelines/fixed.h
@@ -31,12 +31,11 @@ class FixedPipeline : public Pipeline {
 public:
 	void setColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) override;
 
-	void drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) override;
-
 	void setProjectionMatrix(const Math::Matrix4 &projectionMatrix) override;
 
 protected:
 	void activateInternal() override;
+	void drawTextureInternal(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) override;
 };
 #endif // !USE_FORCED_GLES2
 

--- a/backends/graphics/opengl/pipelines/fixed.h
+++ b/backends/graphics/opengl/pipelines/fixed.h
@@ -29,14 +29,14 @@ namespace OpenGL {
 #if !USE_FORCED_GLES2
 class FixedPipeline : public Pipeline {
 public:
-	virtual void setColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a);
+	void setColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) override;
 
-	virtual void drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords);
+	void drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) override;
 
-	virtual void setProjectionMatrix(const Math::Matrix4 &projectionMatrix);
+	void setProjectionMatrix(const Math::Matrix4 &projectionMatrix) override;
 
 protected:
-	virtual void activateInternal();
+	void activateInternal() override;
 };
 #endif // !USE_FORCED_GLES2
 

--- a/backends/graphics/opengl/pipelines/fixed.h
+++ b/backends/graphics/opengl/pipelines/fixed.h
@@ -33,7 +33,7 @@ public:
 
 	virtual void drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords);
 
-	virtual void setProjectionMatrix(const GLfloat *projectionMatrix);
+	virtual void setProjectionMatrix(const Math::Matrix4 &projectionMatrix);
 
 protected:
 	virtual void activateInternal();

--- a/backends/graphics/opengl/pipelines/libretro.cpp
+++ b/backends/graphics/opengl/pipelines/libretro.cpp
@@ -337,6 +337,8 @@ void LibRetroPipeline::deactivateInternal() {
 }
 
 bool LibRetroPipeline::open(const Common::FSNode &shaderPreset) {
+	close();
+
 	_shaderPreset = LibRetro::parsePreset(shaderPreset);
 	if (!_shaderPreset)
 		return false;

--- a/backends/graphics/opengl/pipelines/libretro.cpp
+++ b/backends/graphics/opengl/pipelines/libretro.cpp
@@ -228,6 +228,8 @@ void LibRetroPipeline::close() {
 
 	delete _shaderPreset;
 	_shaderPreset = nullptr;
+
+	_isAnimated = false;
 }
 
 static Common::FSNode getChildRecursive(const Common::FSNode &basePath, const Common::String &fileName) {

--- a/backends/graphics/opengl/pipelines/libretro.cpp
+++ b/backends/graphics/opengl/pipelines/libretro.cpp
@@ -180,7 +180,7 @@ void LibRetroPipeline::drawTexture(const GLTexture &texture, const GLfloat *coor
 	_frameCount++;
 }
 
-void LibRetroPipeline::setProjectionMatrix(const GLfloat *projectionMatrix) {
+void LibRetroPipeline::setProjectionMatrix(const Math::Matrix4 &projectionMatrix) {
 	if (_applyProjectionChanges) {
 		ShaderPipeline::setProjectionMatrix(projectionMatrix);
 	}
@@ -489,9 +489,7 @@ bool LibRetroPipeline::setupFBOs() {
 		pass.vertexCoord[7] = (uint)sourceH;
 
 		// Set projection matrix in passes's shader.
-		Math::Matrix4 m4;
-		m4.setData(pass.target->getProjectionMatrix());
-		pass.shader->setUniform("MVPMatrix", m4);
+		pass.shader->setUniform("MVPMatrix", pass.target->getProjectionMatrix());
 	}
 	return true;
 }

--- a/backends/graphics/opengl/pipelines/libretro.cpp
+++ b/backends/graphics/opengl/pipelines/libretro.cpp
@@ -279,6 +279,11 @@ static void stripShaderParameters(char *source, UniformsMap &uniforms) {
 }
 
 bool LibRetroPipeline::loadPasses() {
+	// Error out if there are no passes
+	if (!_shaderPreset->passes.size()) {
+		return false;
+	}
+
 	// First of all, build the aliases list
 	Common::String aliasesDefines;
 	Common::StringArray aliases;

--- a/backends/graphics/opengl/pipelines/libretro.cpp
+++ b/backends/graphics/opengl/pipelines/libretro.cpp
@@ -142,17 +142,21 @@ void LibRetroPipeline::drawTexture(const GLTexture &texture, const GLfloat *coor
 
 	// Get back screen size from texture coordinates.
 	// FIXME: We assume a fixed set of triangle strip
-	GLfloat w, h;
-	w = coordinates[6] - coordinates[0];
-	h = coordinates[7] - coordinates[1];
-	setOutputSize(w, h);
+	GLfloat outputWidth, outputHeight;
+	outputWidth = coordinates[6] - coordinates[0];
+	outputHeight = coordinates[7] - coordinates[1];
+
+	bool outputSizeChanged = (_outputWidth != outputWidth || _outputHeight != outputHeight);
+	// Save output dimensions.
+	_outputWidth  = outputWidth;
+	_outputHeight = outputHeight;
+
 
 	// In case texture dimensions or viewport dimensions changed, we need to
 	// update the pipeline's state.
 	if (   texture.getLogicalWidth() != _inputWidth
 		|| texture.getLogicalHeight() != _inputHeight
-		|| _outputSizeChanged) {
-		_outputSizeChanged = false;
+		|| outputSizeChanged) {
 		_inputWidth  = texture.getLogicalWidth();
 		_inputHeight = texture.getLogicalHeight();
 
@@ -186,14 +190,6 @@ void LibRetroPipeline::activateInternal() {
 }
 
 void LibRetroPipeline::deactivateInternal() {
-}
-
-void LibRetroPipeline::setOutputSize(uint outputWidth, uint outputHeight) {
-	_outputSizeChanged = (_outputWidth != outputWidth || _outputHeight != outputHeight);
-
-	// Save output dimensions.
-	_outputWidth  = outputWidth;
-	_outputHeight = outputHeight;
 }
 
 bool LibRetroPipeline::open(const Common::FSNode &shaderPreset) {
@@ -425,11 +421,6 @@ bool LibRetroPipeline::loadPasses() {
 
 
 	// Now try to setup FBOs with some dummy size to make sure it could work
-	uint bakInputWidth = _inputWidth;
-	uint bakInputHeight = _inputHeight;
-	uint bakOutputWidth = _outputWidth;
-	uint bakOutputHeight = _outputHeight;
-
 	_inputWidth = 320;
 	_inputHeight = 200;
 	_outputWidth = 640;
@@ -437,12 +428,10 @@ bool LibRetroPipeline::loadPasses() {
 
 	bool ret = setupFBOs();
 
-	_inputWidth = bakInputWidth;
-	_inputHeight = bakInputHeight;
-	_outputWidth = bakOutputWidth;
-	_outputHeight = bakOutputHeight;
-	// Force to reset everything at next draw
-	_outputSizeChanged = true;
+	_inputWidth = 0;
+	_inputHeight = 0;
+	_outputWidth = 0;
+	_outputHeight = 0;
 
 	if (!ret) {
 		return false;

--- a/backends/graphics/opengl/pipelines/libretro.cpp
+++ b/backends/graphics/opengl/pipelines/libretro.cpp
@@ -187,9 +187,11 @@ void LibRetroPipeline::setProjectionMatrix(const Math::Matrix4 &projectionMatrix
 }
 
 void LibRetroPipeline::activateInternal() {
+	// Don't call anything, we call ShaderPipeline::activateInternal in due time
 }
 
 void LibRetroPipeline::deactivateInternal() {
+	// Don't call anything, we call ShaderPipeline::deactivateInternal in due time
 }
 
 bool LibRetroPipeline::open(const Common::FSNode &shaderPreset) {

--- a/backends/graphics/opengl/pipelines/libretro.cpp
+++ b/backends/graphics/opengl/pipelines/libretro.cpp
@@ -134,7 +134,7 @@ LibRetroPipeline::~LibRetroPipeline() {
 	close();
 }
 
-void LibRetroPipeline::drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) {
+void LibRetroPipeline::drawTextureInternal(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) {
 	Framebuffer *const targetBuffer = _activeFramebuffer;
 
 	// Set input texture for 1st pass to texture to draw.
@@ -174,7 +174,7 @@ void LibRetroPipeline::drawTexture(const GLTexture &texture, const GLfloat *coor
 	_applyProjectionChanges = false;
 
 	ShaderPipeline::activateInternal();
-	ShaderPipeline::drawTexture(*_passes[_passes.size() - 1].target->getTexture(), coordinates, texcoords);
+	ShaderPipeline::drawTextureInternal(*_passes[_passes.size() - 1].target->getTexture(), coordinates, texcoords);
 	ShaderPipeline::deactivateInternal();
 
 	_frameCount++;

--- a/backends/graphics/opengl/pipelines/libretro.h
+++ b/backends/graphics/opengl/pipelines/libretro.h
@@ -52,8 +52,6 @@ public:
 	LibRetroPipeline(const Common::FSNode &shaderPreset);
 	~LibRetroPipeline() override;
 
-	void drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) override;
-
 	void setProjectionMatrix(const Math::Matrix4 &projectionMatrix) override;
 
 	bool open(const Common::FSNode &shaderPreset);
@@ -70,6 +68,7 @@ public:
 private:
 	void activateInternal() override;
 	void deactivateInternal() override;
+	void drawTextureInternal(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) override;
 
 	bool loadTextures();
 	bool loadPasses();

--- a/backends/graphics/opengl/pipelines/libretro.h
+++ b/backends/graphics/opengl/pipelines/libretro.h
@@ -50,11 +50,11 @@ class LibRetroPipeline : public ShaderPipeline {
 public:
 	LibRetroPipeline();
 	LibRetroPipeline(const Common::FSNode &shaderPreset);
-	virtual ~LibRetroPipeline();
+	~LibRetroPipeline() override;
 
-	virtual void drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords);
+	void drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) override;
 
-	virtual void setProjectionMatrix(const Math::Matrix4 &projectionMatrix);
+	void setProjectionMatrix(const Math::Matrix4 &projectionMatrix) override;
 
 	bool open(const Common::FSNode &shaderPreset);
 	void close();
@@ -68,8 +68,8 @@ public:
 			&& OpenGLContext.framebufferObjectSupported;
 	}
 private:
-	virtual void activateInternal();
-	virtual void deactivateInternal();
+	void activateInternal() override;
+	void deactivateInternal() override;
 
 	bool loadTextures();
 	bool loadPasses();

--- a/backends/graphics/opengl/pipelines/libretro.h
+++ b/backends/graphics/opengl/pipelines/libretro.h
@@ -56,8 +56,6 @@ public:
 
 	virtual void setProjectionMatrix(const GLfloat *projectionMatrix);
 
-	void setOutputSize(uint outputWidth, uint outputHeight);
-
 	bool open(const Common::FSNode &shaderPreset);
 	void close();
 
@@ -88,7 +86,6 @@ private:
 	uint _inputWidth;
 	uint _inputHeight;
 
-	bool _outputSizeChanged;
 	uint _outputWidth;
 	uint _outputHeight;
 

--- a/backends/graphics/opengl/pipelines/libretro.h
+++ b/backends/graphics/opengl/pipelines/libretro.h
@@ -54,7 +54,7 @@ public:
 
 	virtual void drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords);
 
-	virtual void setProjectionMatrix(const GLfloat *projectionMatrix);
+	virtual void setProjectionMatrix(const Math::Matrix4 &projectionMatrix);
 
 	bool open(const Common::FSNode &shaderPreset);
 	void close();

--- a/backends/graphics/opengl/pipelines/libretro.h
+++ b/backends/graphics/opengl/pipelines/libretro.h
@@ -107,7 +107,8 @@ private:
 	bool _isAnimated;
 	uint _frameCount;
 
-	LibRetroTextureTarget *_inputTarget;
+	Common::Array<LibRetroTextureTarget> _inputTargets;
+	uint _currentTarget;
 
 	struct Texture {
 		Texture() : textureData(nullptr), glTexture(nullptr) {}
@@ -124,11 +125,11 @@ private:
 
 	struct Pass {
 		Pass()
-			: shaderPass(nullptr), shader(nullptr), target(nullptr),
-			  texCoords(), texSamplers(), inputTexture(nullptr), vertexCoord(), hasFrameCount(false) {}
+			: shaderPass(nullptr), shader(nullptr), target(nullptr), texCoords(), texSamplers(),
+			inputTexture(nullptr), vertexCoord(), hasFrameCount(false), prevCount(0) {}
 		Pass(const LibRetro::ShaderPass *sP, Shader *s, TextureTarget *t)
-			: shaderPass(sP), shader(s), target(t), texCoords(),
-			  texSamplers(), inputTexture(nullptr), vertexCoord(), hasFrameCount(false) {}
+			: shaderPass(sP), shader(s), target(t), texCoords(), texSamplers(),
+			inputTexture(nullptr), vertexCoord(), hasFrameCount(false), prevCount(0) {}
 
 		const LibRetro::ShaderPass *shaderPass;
 		Shader *shader;
@@ -237,7 +238,7 @@ private:
 		 */
 		void buildTexSamplers(const uint id, const TextureArray &textures, const Common::StringArray &aliases);
 
-		void addTexSampler(const Common::String &name, uint *unit, const TextureSampler::Type type, const uint index, const bool prefixIsId = false);
+		bool addTexSampler(const Common::String &name, uint *unit, const TextureSampler::Type type, const uint index, const bool prefixIsId = false);
 
 		/**
 		 * Input texture of the pass.
@@ -254,6 +255,11 @@ private:
 		 * Allows to speed up if it is not here
 		 */
 		bool hasFrameCount;
+
+		/**
+		 * The number of previous frames this pass needs
+		 */
+		uint prevCount;
 	};
 
 	typedef Common::Array<Pass> PassArray;

--- a/backends/graphics/opengl/pipelines/pipeline.cpp
+++ b/backends/graphics/opengl/pipelines/pipeline.cpp
@@ -27,11 +27,19 @@ namespace OpenGL {
 Pipeline *Pipeline::activePipeline = nullptr;
 
 Pipeline::Pipeline()
-	: _activeFramebuffer(nullptr), _isActive(false) {
+	: _activeFramebuffer(nullptr) {
 }
 
 void Pipeline::activate() {
-	_isActive = true;
+	if (activePipeline == this) {
+		return;
+	}
+
+	if (activePipeline) {
+		activePipeline->deactivate();
+	}
+
+	activePipeline = this;
 
 	if (_activeFramebuffer) {
 		_activeFramebuffer->activate(this);
@@ -41,41 +49,29 @@ void Pipeline::activate() {
 }
 
 void Pipeline::deactivate() {
+	assert(isActive());
+
 	deactivateInternal();
 
 	if (_activeFramebuffer) {
 		_activeFramebuffer->deactivate();
 	}
 
-	_isActive = false;
+	activePipeline = nullptr;
 }
 
 Framebuffer *Pipeline::setFramebuffer(Framebuffer *framebuffer) {
 	Framebuffer *oldFramebuffer = _activeFramebuffer;
-	if (_isActive && oldFramebuffer) {
+	if (isActive() && oldFramebuffer) {
 		oldFramebuffer->deactivate();
 	}
 
 	_activeFramebuffer = framebuffer;
-	if (_isActive && _activeFramebuffer) {
+	if (isActive() && _activeFramebuffer) {
 		_activeFramebuffer->activate(this);
 	}
 
 	return oldFramebuffer;
-}
-
-Pipeline *Pipeline::setPipeline(Pipeline *pipeline) {
-	Pipeline *oldPipeline = activePipeline;
-	if (oldPipeline) {
-		oldPipeline->deactivate();
-	}
-
-	activePipeline = pipeline;
-	if (activePipeline) {
-		activePipeline->activate();
-	}
-
-	return oldPipeline;
 }
 
 } // End of namespace OpenGL

--- a/backends/graphics/opengl/pipelines/pipeline.cpp
+++ b/backends/graphics/opengl/pipelines/pipeline.cpp
@@ -41,11 +41,13 @@ void Pipeline::activate() {
 
 	activePipeline = this;
 
+	activateInternal();
+}
+
+void Pipeline::activateInternal() {
 	if (_activeFramebuffer) {
 		_activeFramebuffer->activate(this);
 	}
-
-	activateInternal();
 }
 
 void Pipeline::deactivate() {
@@ -53,11 +55,13 @@ void Pipeline::deactivate() {
 
 	deactivateInternal();
 
+	activePipeline = nullptr;
+}
+
+void Pipeline::deactivateInternal() {
 	if (_activeFramebuffer) {
 		_activeFramebuffer->deactivate();
 	}
-
-	activePipeline = nullptr;
 }
 
 Framebuffer *Pipeline::setFramebuffer(Framebuffer *framebuffer) {

--- a/backends/graphics/opengl/pipelines/pipeline.cpp
+++ b/backends/graphics/opengl/pipelines/pipeline.cpp
@@ -34,7 +34,7 @@ void Pipeline::activate() {
 	_isActive = true;
 
 	if (_activeFramebuffer) {
-		_activeFramebuffer->activate();
+		_activeFramebuffer->activate(this);
 	}
 
 	activateInternal();
@@ -58,7 +58,7 @@ Framebuffer *Pipeline::setFramebuffer(Framebuffer *framebuffer) {
 
 	_activeFramebuffer = framebuffer;
 	if (_isActive && _activeFramebuffer) {
-		_activeFramebuffer->activate();
+		_activeFramebuffer->activate(this);
 	}
 
 	return oldFramebuffer;

--- a/backends/graphics/opengl/pipelines/pipeline.h
+++ b/backends/graphics/opengl/pipelines/pipeline.h
@@ -141,12 +141,12 @@ protected:
 	 * This sets the OpenGL state to make use of drawing with the given
 	 * OpenGL pipeline.
 	 */
-	virtual void activateInternal() = 0;
+	virtual void activateInternal();
 
 	/**
 	 * Deactivate the pipeline.
 	 */
-	virtual void deactivateInternal() {}
+	virtual void deactivateInternal();
 
 	virtual void drawTextureInternal(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) = 0;
 

--- a/backends/graphics/opengl/pipelines/pipeline.h
+++ b/backends/graphics/opengl/pipelines/pipeline.h
@@ -83,23 +83,25 @@ public:
 	 * @param texture     Texture to use for drawing.
 	 * @param coordinates x1, y1, x2, y2 coordinates where to draw the texture.
 	 */
-	virtual void drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) = 0;
-
-	void drawTexture(const GLTexture &texture, const GLfloat *coordinates) {
-		drawTexture(texture, coordinates, texture.getTexCoords());
+	inline void drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) {
+		drawTextureInternal(texture, coordinates, texcoords);
 	}
 
-	void drawTexture(const GLTexture &texture, GLfloat x, GLfloat y, GLfloat w, GLfloat h) {
+	inline void drawTexture(const GLTexture &texture, const GLfloat *coordinates) {
+		drawTextureInternal(texture, coordinates, texture.getTexCoords());
+	}
+
+	inline void drawTexture(const GLTexture &texture, GLfloat x, GLfloat y, GLfloat w, GLfloat h) {
 		const GLfloat coordinates[4*2] = {
 			x,     y,
 			x + w, y,
 			x,     y + h,
 			x + w, y + h
 		};
-		drawTexture(texture, coordinates, texture.getTexCoords());
+		drawTextureInternal(texture, coordinates, texture.getTexCoords());
 	}
 
-	void drawTexture(const GLTexture &texture, GLfloat x, GLfloat y, GLfloat w, GLfloat h, const Common::Rect &clip) {
+	inline void drawTexture(const GLTexture &texture, GLfloat x, GLfloat y, GLfloat w, GLfloat h, const Common::Rect &clip) {
 		const GLfloat coordinates[4*2] = {
 			x,     y,
 			x + w, y,
@@ -122,7 +124,7 @@ public:
 			(float)clip.right / tw, (float)clip.bottom / th
 		};
 
-		drawTexture(texture, coordinates, texcoords);
+		drawTextureInternal(texture, coordinates, texcoords);
 	}
 
 	/**
@@ -145,6 +147,8 @@ protected:
 	 * Deactivate the pipeline.
 	 */
 	virtual void deactivateInternal() {}
+
+	virtual void drawTextureInternal(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) = 0;
 
 	bool isActive() const { return _isActive; }
 

--- a/backends/graphics/opengl/pipelines/pipeline.h
+++ b/backends/graphics/opengl/pipelines/pipeline.h
@@ -26,6 +26,8 @@
 
 #include "backends/graphics/opengl/texture.h"
 
+#include "math/matrix4.h"
+
 namespace OpenGL {
 
 class Framebuffer;
@@ -127,7 +129,7 @@ public:
 	 *
 	 * This is intended to be only ever be used by Framebuffer subclasses.
 	 */
-	virtual void setProjectionMatrix(const GLfloat *projectionMatrix) = 0;
+	virtual void setProjectionMatrix(const Math::Matrix4 &projectionMatrix) = 0;
 
 protected:
 	/**

--- a/backends/graphics/opengl/pipelines/pipeline.h
+++ b/backends/graphics/opengl/pipelines/pipeline.h
@@ -42,7 +42,7 @@ class Framebuffer;
 class Pipeline {
 public:
 	Pipeline();
-	virtual ~Pipeline() {}
+	virtual ~Pipeline() { if (isActive()) deactivate(); }
 
 	/**
 	 * Activate the pipeline.
@@ -150,31 +150,13 @@ protected:
 
 	virtual void drawTextureInternal(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) = 0;
 
-	bool isActive() const { return _isActive; }
+	bool isActive() const { return activePipeline == this; }
 
 	Framebuffer *_activeFramebuffer;
 
 private:
-	bool _isActive;
-
 	/** Currently active rendering pipeline. */
 	static Pipeline *activePipeline;
-
-public:
-	/**
-	 * Set new pipeline.
-	 *
-	 * Client is responsible for any memory management related to pipelines.
-	 *
-	 * @param pipeline Pipeline to activate.
-	 * @return Formerly active pipeline.
-	 */
-	static Pipeline *setPipeline(Pipeline *pipeline);
-
-	/**
-	 * Query the currently active rendering pipeline.
-	 */
-	static Pipeline *getActivePipeline() { return activePipeline; }
 };
 
 } // End of namespace OpenGL

--- a/backends/graphics/opengl/pipelines/pipeline.h
+++ b/backends/graphics/opengl/pipelines/pipeline.h
@@ -24,6 +24,7 @@
 
 #include "graphics/opengl/system_headers.h"
 
+#include "backends/graphics/opengl/framebuffer.h"
 #include "backends/graphics/opengl/texture.h"
 
 #include "math/matrix4.h"

--- a/backends/graphics/opengl/pipelines/shader.cpp
+++ b/backends/graphics/opengl/pipelines/shader.cpp
@@ -76,6 +76,8 @@ void ShaderPipeline::setColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) {
 }
 
 void ShaderPipeline::drawTextureInternal(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) {
+	assert(isActive());
+
 	texture.bind();
 
 	GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, _coordsVBO));
@@ -88,6 +90,8 @@ void ShaderPipeline::drawTextureInternal(const GLTexture &texture, const GLfloat
 }
 
 void ShaderPipeline::setProjectionMatrix(const Math::Matrix4 &projectionMatrix) {
+	assert(isActive());
+
 	_activeShader->setUniform("projection", projectionMatrix);
 }
 #endif // !USE_FORCED_GLES

--- a/backends/graphics/opengl/pipelines/shader.cpp
+++ b/backends/graphics/opengl/pipelines/shader.cpp
@@ -75,7 +75,7 @@ void ShaderPipeline::setColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) {
 	}
 }
 
-void ShaderPipeline::drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) {
+void ShaderPipeline::drawTextureInternal(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) {
 	texture.bind();
 
 	GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, _coordsVBO));

--- a/backends/graphics/opengl/pipelines/shader.cpp
+++ b/backends/graphics/opengl/pipelines/shader.cpp
@@ -87,10 +87,8 @@ void ShaderPipeline::drawTexture(const GLTexture &texture, const GLfloat *coordi
 	GL_CALL(glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));
 }
 
-void ShaderPipeline::setProjectionMatrix(const GLfloat *projectionMatrix) {
-	Math::Matrix4 m4;
-	m4.setData(projectionMatrix);
-	_activeShader->setUniform("projection", m4);
+void ShaderPipeline::setProjectionMatrix(const Math::Matrix4 &projectionMatrix) {
+	_activeShader->setUniform("projection", projectionMatrix);
 }
 #endif // !USE_FORCED_GLES
 

--- a/backends/graphics/opengl/pipelines/shader.cpp
+++ b/backends/graphics/opengl/pipelines/shader.cpp
@@ -50,6 +50,8 @@ ShaderPipeline::~ShaderPipeline() {
 }
 
 void ShaderPipeline::activateInternal() {
+	Pipeline::activateInternal();
+
 	if (OpenGLContext.multitextureSupported) {
 		GL_CALL(glActiveTexture(GL_TEXTURE0));
 	}
@@ -63,6 +65,8 @@ void ShaderPipeline::activateInternal() {
 
 void ShaderPipeline::deactivateInternal() {
 	_activeShader->unbind();
+
+	Pipeline::deactivateInternal();
 }
 
 void ShaderPipeline::setColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) {

--- a/backends/graphics/opengl/pipelines/shader.h
+++ b/backends/graphics/opengl/pipelines/shader.h
@@ -36,13 +36,12 @@ public:
 
 	void setColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) override;
 
-	void drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) override;
-
 	void setProjectionMatrix(const Math::Matrix4 &projectionMatrix) override;
 
 protected:
 	void activateInternal() override;
 	void deactivateInternal() override;
+	void drawTextureInternal(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) override;
 
 	GLuint _coordsVBO;
 	GLuint _texcoordsVBO;

--- a/backends/graphics/opengl/pipelines/shader.h
+++ b/backends/graphics/opengl/pipelines/shader.h
@@ -32,17 +32,17 @@ class Shader;
 class ShaderPipeline : public Pipeline {
 public:
 	ShaderPipeline(Shader *shader);
-	~ShaderPipeline();
+	~ShaderPipeline() override;
 
-	virtual void setColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a);
+	void setColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) override;
 
-	virtual void drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords);
+	void drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords) override;
 
-	virtual void setProjectionMatrix(const Math::Matrix4 &projectionMatrix);
+	void setProjectionMatrix(const Math::Matrix4 &projectionMatrix) override;
 
 protected:
-	virtual void activateInternal();
-	virtual void deactivateInternal();
+	void activateInternal() override;
+	void deactivateInternal() override;
 
 	GLuint _coordsVBO;
 	GLuint _texcoordsVBO;

--- a/backends/graphics/opengl/pipelines/shader.h
+++ b/backends/graphics/opengl/pipelines/shader.h
@@ -38,7 +38,7 @@ public:
 
 	virtual void drawTexture(const GLTexture &texture, const GLfloat *coordinates, const GLfloat *texcoords);
 
-	virtual void setProjectionMatrix(const GLfloat *projectionMatrix);
+	virtual void setProjectionMatrix(const Math::Matrix4 &projectionMatrix);
 
 protected:
 	virtual void activateInternal();

--- a/backends/graphics/opengl/texture.cpp
+++ b/backends/graphics/opengl/texture.cpp
@@ -99,6 +99,7 @@ void GLTexture::setWrapMode(WrapMode wrapMode) {
 #endif
 		// fall through
 		case kWrapModeRepeat:
+		default:
 			glwrapMode = GL_REPEAT;
 	}
 

--- a/backends/graphics/opengl/texture.cpp
+++ b/backends/graphics/opengl/texture.cpp
@@ -796,13 +796,12 @@ void TextureCLUT8GPU::updateGLTexture() {
 
 void TextureCLUT8GPU::lookUpColors() {
 	// Setup pipeline to do color look up.
-	Pipeline *oldPipeline = Pipeline::setPipeline(_clut8Pipeline);
+	_clut8Pipeline->activate();
 
 	// Do color look up.
-	Pipeline::getActivePipeline()->drawTexture(_clut8Texture, _clut8Vertices);
+	_clut8Pipeline->drawTexture(_clut8Texture, _clut8Vertices);
 
-	// Restore old state.
-	Pipeline::setPipeline(oldPipeline);
+	_clut8Pipeline->deactivate();
 }
 #endif // !USE_FORCED_GLES
 

--- a/backends/graphics/opengl/texture.h
+++ b/backends/graphics/opengl/texture.h
@@ -279,29 +279,29 @@ public:
 	 * @param format      The format used for the texture input.
 	 */
 	Texture(GLenum glIntFormat, GLenum glFormat, GLenum glType, const Graphics::PixelFormat &format);
-	virtual ~Texture();
+	~Texture() override;
 
-	virtual void destroy();
+	void destroy() override;
 
-	virtual void recreate();
+	void recreate() override;
 
-	virtual void enableLinearFiltering(bool enable);
+	void enableLinearFiltering(bool enable) override;
 
-	virtual void allocate(uint width, uint height);
+	void allocate(uint width, uint height) override;
 
-	virtual uint getWidth() const { return _userPixelData.w; }
-	virtual uint getHeight() const { return _userPixelData.h; }
+	uint getWidth() const override { return _userPixelData.w; }
+	uint getHeight() const override { return _userPixelData.h; }
 
 	/**
 	 * @return The logical format of the texture data.
 	 */
-	virtual Graphics::PixelFormat getFormat() const { return _format; }
+	Graphics::PixelFormat getFormat() const override { return _format; }
 
-	virtual Graphics::Surface *getSurface() { return &_userPixelData; }
-	virtual const Graphics::Surface *getSurface() const { return &_userPixelData; }
+	Graphics::Surface *getSurface() override { return &_userPixelData; }
+	const Graphics::Surface *getSurface() const override { return &_userPixelData; }
 
-	virtual void updateGLTexture();
-	virtual const GLTexture &getGLTexture() const { return _glTexture; }
+	void updateGLTexture() override;
+	const GLTexture &getGLTexture() const override { return _glTexture; }
 protected:
 	const Graphics::PixelFormat _format;
 
@@ -317,21 +317,21 @@ private:
 class FakeTexture : public Texture {
 public:
 	FakeTexture(GLenum glIntFormat, GLenum glFormat, GLenum glType, const Graphics::PixelFormat &format, const Graphics::PixelFormat &fakeFormat);
-	virtual ~FakeTexture();
+	~FakeTexture() override;
 
-	virtual void allocate(uint width, uint height);
+	void allocate(uint width, uint height) override;
 
-	virtual Graphics::PixelFormat getFormat() const { return _fakeFormat; }
+	Graphics::PixelFormat getFormat() const override { return _fakeFormat; }
 
-	virtual bool hasPalette() const { return (_palette != nullptr); }
+	bool hasPalette() const override { return (_palette != nullptr); }
 
-	virtual void setColorKey(uint colorKey);
-	virtual void setPalette(uint start, uint colors, const byte *palData);
+	void setColorKey(uint colorKey) override;
+	void setPalette(uint start, uint colors, const byte *palData) override;
 
-	virtual Graphics::Surface *getSurface() { return &_rgbData; }
-	virtual const Graphics::Surface *getSurface() const { return &_rgbData; }
+	Graphics::Surface *getSurface() override { return &_rgbData; }
+	const Graphics::Surface *getSurface() const override { return &_rgbData; }
 
-	virtual void updateGLTexture();
+	void updateGLTexture() override;
 protected:
 	Graphics::Surface _rgbData;
 	Graphics::PixelFormat _fakeFormat;
@@ -341,39 +341,39 @@ protected:
 class TextureRGB555 : public FakeTexture {
 public:
 	TextureRGB555();
-	virtual ~TextureRGB555() {};
+	~TextureRGB555() override {}
 
-	virtual void updateGLTexture();
+	void updateGLTexture() override;
 };
 
 class TextureRGBA8888Swap : public FakeTexture {
 public:
 	TextureRGBA8888Swap();
-	virtual ~TextureRGBA8888Swap() {};
+	~TextureRGBA8888Swap() override {}
 
-	virtual void updateGLTexture();
+	void updateGLTexture() override;
 };
 
 #ifdef USE_SCALERS
 class ScaledTexture : public FakeTexture {
 public:
 	ScaledTexture(GLenum glIntFormat, GLenum glFormat, GLenum glType, const Graphics::PixelFormat &format, const Graphics::PixelFormat &fakeFormat);
-	virtual ~ScaledTexture();
+	~ScaledTexture() override;
 
-	virtual void allocate(uint width, uint height);
+	void allocate(uint width, uint height) override;
 
-	virtual uint getWidth() const { return _rgbData.w; }
-	virtual uint getHeight() const { return _rgbData.h; }
-	virtual Graphics::PixelFormat getFormat() const { return _fakeFormat; }
+	uint getWidth() const override { return _rgbData.w; }
+	uint getHeight() const override { return _rgbData.h; }
+	Graphics::PixelFormat getFormat() const override { return _fakeFormat; }
 
-	virtual bool hasPalette() const { return (_palette != nullptr); }
+	bool hasPalette() const override { return (_palette != nullptr); }
 
-	virtual Graphics::Surface *getSurface() { return &_rgbData; }
-	virtual const Graphics::Surface *getSurface() const { return &_rgbData; }
+	Graphics::Surface *getSurface() override { return &_rgbData; }
+	const Graphics::Surface *getSurface() const override { return &_rgbData; }
 
-	virtual void updateGLTexture();
+	void updateGLTexture() override;
 
-	virtual void setScaler(uint scalerIndex, int scaleFactor);
+	void setScaler(uint scalerIndex, int scaleFactor) override;
 protected:
 	Graphics::Surface *_convData;
 	Scaler *_scaler;
@@ -390,33 +390,33 @@ class CLUT8LookUpPipeline;
 class TextureCLUT8GPU : public Surface {
 public:
 	TextureCLUT8GPU();
-	virtual ~TextureCLUT8GPU();
+	~TextureCLUT8GPU() override;
 
-	virtual void destroy();
+	void destroy() override;
 
-	virtual void recreate();
+	void recreate() override;
 
-	virtual void enableLinearFiltering(bool enable);
+	void enableLinearFiltering(bool enable) override;
 
-	virtual void allocate(uint width, uint height);
+	void allocate(uint width, uint height) override;
 
-	virtual bool isDirty() const { return _paletteDirty || Surface::isDirty(); }
+	bool isDirty() const override { return _paletteDirty || Surface::isDirty(); }
 
-	virtual uint getWidth() const { return _userPixelData.w; }
-	virtual uint getHeight() const { return _userPixelData.h; }
+	uint getWidth() const override { return _userPixelData.w; }
+	uint getHeight() const override { return _userPixelData.h; }
 
-	virtual Graphics::PixelFormat getFormat() const;
+	Graphics::PixelFormat getFormat() const override;
 
-	virtual bool hasPalette() const { return true; }
+	bool hasPalette() const override { return true; }
 
-	virtual void setColorKey(uint colorKey);
-	virtual void setPalette(uint start, uint colors, const byte *palData);
+	void setColorKey(uint colorKey) override;
+	void setPalette(uint start, uint colors, const byte *palData) override;
 
-	virtual Graphics::Surface *getSurface() { return &_userPixelData; }
-	virtual const Graphics::Surface *getSurface() const { return &_userPixelData; }
+	Graphics::Surface *getSurface() override { return &_userPixelData; }
+	const Graphics::Surface *getSurface() const override { return &_userPixelData; }
 
-	virtual void updateGLTexture();
-	virtual const GLTexture &getGLTexture() const;
+	void updateGLTexture() override;
+	const GLTexture &getGLTexture() const override;
 
 	static bool isSupportedByContext() {
 		return OpenGLContext.shadersSupported

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -393,15 +393,22 @@ void GuiManager::redraw() {
 			// This case is an optimization to avoid redrawing the whole dialog
 			// stack when opening a new dialog.
 
-			_theme->drawToBackbuffer();
+			if (_displayTopDialogOnly) {
+				// When displaying only the top dialog clear the screen
+				if (_redrawStatus == kRedrawOpenDialog) {
+					_theme->clearAll();
+					_theme->drawToBackbuffer();
+				}
+			} else {
+				_theme->drawToBackbuffer();
 
-			if (_redrawStatus == kRedrawOpenDialog && _dialogStack.size() > 1) {
-				Dialog *previousDialog = _dialogStack[_dialogStack.size() - 2];
-				previousDialog->drawDialog(kDrawLayerForeground);
-			}
+				if (_redrawStatus == kRedrawOpenDialog && _dialogStack.size() > 1) {
+					Dialog *previousDialog = _dialogStack[_dialogStack.size() - 2];
+					previousDialog->drawDialog(kDrawLayerForeground);
+				}
 
-			if (!_displayTopDialogOnly)
 				_theme->applyScreenShading(shading);
+			}
 
 			_dialogStack.top()->drawDialog(kDrawLayerBackground);
 


### PR DESCRIPTION
This PR makes several changes to the OpenGL backend.
Majority of changes are quite straightforward but some are less.

The rationale behind all these changes was to allow the LibretroPipeline to own two ShaderPipelines.
This allows to hide all the play with these pipelines inside LibretroPipeline and let OpenGLGraphicsManager play with only one Pipeline and no framebuffer.
The _libretroPipeline object is still here to handle the calls specific to it as having a scaling shader is still something not possible with the base Pipeline model (and we don't necessarily want that).

In the end this let us support the Prev textures (previous frames) in an elegant way.
A clean fix, needed for metacrt shader, is also applied thanks to this rework (the image was up and down).

Finally, there are serval small bugfixes which were discovered when trying the code on Android where notifyContextCreate is almost never called unlinke on SDL where it is called at every mode change (this hides some bugs).

WIth this, I believe all GLSL shaders from RetroArch should work flawlessly.