### PR TITLE
MOHAWK: MYST: Show only existing subtitles

### DIFF
--- a/engines/mohawk/video.cpp
+++ b/engines/mohawk/video.cpp
@@ -177,7 +177,12 @@ VideoEntryPtr VideoManager::playMovie(const Common::String &fileName, Audio::Mix
 
 
 	Common::String subtitlesName = Common::String::format("%s.srt", fileName.substr(0, fileName.size() - 4).c_str());
-	loadSubtitles(subtitlesName.c_str());
+
+	if (Common::File::exists(subtitlesName)) {
+		loadSubtitles(subtitlesName.c_str());
+		g_system->showOverlay();
+		g_system->clearOverlay();
+	}
 
 	ptr->start();
 	return ptr;
@@ -196,8 +201,6 @@ bool VideoManager::updateMovies() {
 	bool updateScreen = false;
 
 	for (VideoList::iterator it = _videos.begin(); it != _videos.end(); ) {
-		g_system->showOverlay();
-		g_system->clearOverlay();
 
 		// Check of the video has reached the end
 		if ((*it)->endOfVideo()) {


### PR DESCRIPTION
An attempt to fix https://bugs.scummvm.org/ticket/13907
It seems showing the overlay messes up the interactive area size, limiting it to the top-left quarter of the screen.
And specifically happens on screens with seagull, which is shown by a video, which now always shows the overlay.

This limits the overlay to be shown only for videos that actually have subtitles file, assuming the seagull video will not have any.
As seen by above line, this solution is very limited. if any subtitles is made in interactive screen it will enable the same issue again.