### PR TITLE
ENGINES: Prevent autosave overwriting regular save without warning

### DIFF
--- a/engines/cine/metaengine.cpp
+++ b/engines/cine/metaengine.cpp
@@ -129,14 +129,14 @@ SaveStateList CineMetaEngine::listSaves(const char *target) const {
 				SaveStateDescriptor saveStateDesc(this, slotNum, saveDesc);
 
 				if (saveStateDesc.getDescription().empty()) {
-					if (saveStateDesc.isAutosave()) {
+					if (slotNum == getAutosaveSlot()) {
 						saveStateDesc.setDescription(_("Unnamed autosave"));
 					} else {
 						saveStateDesc.setDescription(_("Unnamed savegame"));
 					}
 				}
 
-				if (saveStateDesc.isAutosave()) {
+				if (slotNum == getAutosaveSlot()) {
 					foundAutosave = true;
 				}
 
@@ -212,7 +212,9 @@ SaveStateDescriptor CineMetaEngine::querySaveMetaInfos(const char *target, int s
 
 	// No saving on empty autosave slot
 	if (slot == getAutosaveSlot()) {
-		return SaveStateDescriptor(this, slot, _("Empty autosave"));
+		SaveStateDescriptor desc(this, slot, _("Empty autosave"));
+		desc.setAutosave(true);
+		return desc;
 	}
 
 	return SaveStateDescriptor();

--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -364,7 +364,7 @@ SaveStateList MetaEngine::listSaves(const char *target) const {
 
 SaveStateList MetaEngine::listSaves(const char *target, bool saveMode) const {
 	SaveStateList saveList = listSaves(target);
-	int autosaveSlot = ConfMan.getInt("autosave_period") ? getAutosaveSlot() : -1;
+	int autosaveSlot = getAutosaveSlot();
 	if (!saveMode || autosaveSlot == -1)
 		return saveList;
 
@@ -379,7 +379,11 @@ SaveStateList MetaEngine::listSaves(const char *target, bool saveMode) const {
 
 	// No autosave yet. We want to add a dummy one in so that it can be marked as
 	// write protected, and thus be prevented from being saved in
-	SaveStateDescriptor desc(this, autosaveSlot, _("Autosave"));
+	const Common::U32String &dummyAutosave = ConfMan.getInt("autosave_period”) ? _(“Autosave on”) : _(“Autosave off”);
+	SaveStateDescriptor desc(this, autosaveSlot, dummyAutosave);
+	desc.setWriteProtectedFlag(true);
+	desc.setDeletableFlag(false);
+	
 	saveList.push_back(desc);
 	Common::sort(saveList.begin(), saveList.end(), SaveStateDescriptorSlotComparator());
 

--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -370,9 +370,11 @@ SaveStateList MetaEngine::listSaves(const char *target, bool saveMode) const {
 
 	// Check to see if an autosave is present
 	for (SaveStateList::iterator it = saveList.begin(); it != saveList.end(); ++it) {
-		// It has an autosave
-		if (it->isAutosave())
+		int slot = it->getSaveSlot();
+		if (slot == autosaveSlot) {
+			// It has an autosave
 			return saveList;
+		}
 	}
 
 	// No autosave yet. We want to add a dummy one in so that it can be marked as
@@ -428,6 +430,7 @@ SaveStateDescriptor MetaEngine::querySaveMetaInfos(const char *target, int slot)
 		SaveStateDescriptor desc(this, slot, Common::U32String());
 		parseSavegameHeader(&header, &desc);
 		desc.setThumbnail(header.thumbnail);
+		desc.setAutosave(header.isAutosave);
 		return desc;
 	}
 

--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -379,7 +379,7 @@ SaveStateList MetaEngine::listSaves(const char *target, bool saveMode) const {
 
 	// No autosave yet. We want to add a dummy one in so that it can be marked as
 	// write protected, and thus be prevented from being saved in
-	const Common::U32String &dummyAutosave = ConfMan.getInt("autosave_period”) ? _(“Autosave on”) : _(“Autosave off”);
+	const Common::U32String &dummyAutosave = (ConfMan.getInt("autosave_period") ? _("Autosave on") : _("Autosave off"));
 	SaveStateDescriptor desc(this, autosaveSlot, dummyAutosave);
 	desc.setWriteProtectedFlag(true);
 	desc.setDeletableFlag(false);

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -51,9 +51,10 @@ void SaveStateDescriptor::initSaveSlot(const MetaEngine *metaEngine) {
 	
 	if (autosaveSlot >= 0 && _slot == autosaveSlot) {
 		const bool autosaveEnabled = ConfMan.getInt("autosave_period");
-		// If autosaving enabled, do not allow autosave slot to be deleted or overwritten
-		_isWriteProtected = autosaveEnabled;
-		_isDeletable = !autosaveEnabled;	
+		// When autosaving enabled, add user support for managing autosave file.
+		// If autosaving disabled, do not allow autosave slot to be deleted or overwritten (no changes unless autosave tests are active).
+		_isWriteProtected = !autosaveEnabled;
+		_isDeletable = autosaveEnabled;	
 	} else {
 		_isWriteProtected = false;
 		_isDeletable = true;		

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -45,13 +45,19 @@ SaveStateDescriptor::SaveStateDescriptor(const MetaEngine *metaEngine, int slot,
 }
 
 void SaveStateDescriptor::initSaveSlot(const MetaEngine *metaEngine) {
-	// Do not allow auto-save slot to be deleted or overwritten.
 	if (!metaEngine && g_engine)
 		metaEngine = g_engine->getMetaEngine();
-	const bool autosave =
-			metaEngine && ConfMan.getInt("autosave_period") && _slot == metaEngine->getAutosaveSlot();
-	_isWriteProtected = autosave;
-	_isDeletable = !autosave;
+	int autosaveSlot = metaEngine ? metaEngine->getAutosaveSlot() : -1;
+	
+	if (autosaveSlot >= 0 && _slot == autosaveSlot) {
+		const bool autosaveEnabled = ConfMan.getInt("autosave_period");
+		// If autosaving enabled, do not allow autosave slot to be deleted or overwritten
+		_isWriteProtected = autosaveEnabled;
+		_isDeletable = !autosaveEnabled;	
+	} else {
+		_isWriteProtected = false;
+		_isDeletable = true;		
+	}
 }
 
 void SaveStateDescriptor::setThumbnail(Graphics::Surface *t) {

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -50,11 +50,9 @@ void SaveStateDescriptor::initSaveSlot(const MetaEngine *metaEngine) {
 	int autosaveSlot = metaEngine ? metaEngine->getAutosaveSlot() : -1;
 	
 	if (autosaveSlot >= 0 && _slot == autosaveSlot) {
-		const bool autosaveEnabled = ConfMan.getInt("autosave_period");
-		// When autosaving enabled, add user support for managing autosave file.
-		// If autosaving disabled, do not allow autosave slot to be deleted or overwritten (no changes unless autosave tests are active).
-		_isWriteProtected = !autosaveEnabled;
-		_isDeletable = autosaveEnabled;	
+		// Do not allow autosave slot to be deleted or overwritten
+		_isWriteProtected = true;
+		_isDeletable = false;	
 	} else {
 		_isWriteProtected = false;
 		_isDeletable = true;		

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -36,15 +36,15 @@ SaveStateDescriptor::SaveStateDescriptor()
 
 SaveStateDescriptor::SaveStateDescriptor(const MetaEngine *metaEngine, int slot, const Common::U32String &d)
 	: _slot(slot), _description(d), _isLocked(false), _playTimeMSecs(0), _saveType(kSaveTypeUndetermined) {
-	initSaveType(metaEngine);
+	initSaveSlot(metaEngine);
 }
 
 SaveStateDescriptor::SaveStateDescriptor(const MetaEngine *metaEngine, int slot, const Common::String &d)
 	: _slot(slot), _description(Common::U32String(d)), _isLocked(false), _playTimeMSecs(0), _saveType(kSaveTypeUndetermined) {
-	initSaveType(metaEngine);
+	initSaveSlot(metaEngine);
 }
 
-void SaveStateDescriptor::initSaveType(const MetaEngine *metaEngine) {
+void SaveStateDescriptor::initSaveSlot(const MetaEngine *metaEngine) {
 	// Do not allow auto-save slot to be deleted or overwritten.
 	if (!metaEngine && g_engine)
 		metaEngine = g_engine->getMetaEngine();

--- a/engines/savestate.cpp
+++ b/engines/savestate.cpp
@@ -35,12 +35,12 @@ SaveStateDescriptor::SaveStateDescriptor()
 }
 
 SaveStateDescriptor::SaveStateDescriptor(const MetaEngine *metaEngine, int slot, const Common::U32String &d)
-	: _slot(slot), _description(d), _isLocked(false), _playTimeMSecs(0) {
+	: _slot(slot), _description(d), _isLocked(false), _playTimeMSecs(0), _saveType(kSaveTypeUndetermined) {
 	initSaveType(metaEngine);
 }
 
 SaveStateDescriptor::SaveStateDescriptor(const MetaEngine *metaEngine, int slot, const Common::String &d)
-	: _slot(slot), _description(Common::U32String(d)), _isLocked(false), _playTimeMSecs(0) {
+	: _slot(slot), _description(Common::U32String(d)), _isLocked(false), _playTimeMSecs(0), _saveType(kSaveTypeUndetermined) {
 	initSaveType(metaEngine);
 }
 
@@ -51,7 +51,6 @@ void SaveStateDescriptor::initSaveType(const MetaEngine *metaEngine) {
 	const bool autosave =
 			metaEngine && ConfMan.getInt("autosave_period") && _slot == metaEngine->getAutosaveSlot();
 	_isWriteProtected = autosave;
-	_saveType = autosave ? kSaveTypeAutosave : kSaveTypeRegular;
 	_isDeletable = !autosave;
 }
 

--- a/engines/savestate.h
+++ b/engines/savestate.h
@@ -61,7 +61,7 @@ private:
 		kSaveTypeAutosave
 	};
 
-	void initSaveType(const MetaEngine *metaEngine);
+	void initSaveSlot(const MetaEngine *metaEngine);
 public:
 	SaveStateDescriptor();
 	SaveStateDescriptor(const MetaEngine *metaEngine, int slot, const Common::U32String &d);

--- a/engines/sci/metaengine.cpp
+++ b/engines/sci/metaengine.cpp
@@ -354,7 +354,8 @@ SaveStateList SciMetaEngine::listSaves(const char *target) const {
 				}
 				SaveStateDescriptor descriptor(this, slotNr, meta.name);
 
-				if (descriptor.isAutosave()) {
+				if (slotNr == 0) {
+					// ScummVM auto-save slot (note however, that autosave support is currently revoked)
 					hasAutosave = true;
 				}
 


### PR DESCRIPTION
Due to very slow connection speeds, I've opted to close, rather than attempt to rebase, #4358, and reopen with this appropriately named PR, and the commits relevant to the issue.

This replaces the content of #4355 & #4358, which contained previously merged commits from #4350. 

For an overview of the proposed changes in 73f48d3c010fe3a3a1e56ce69e30fae6cc8f1151 & ae1c1dbde56c16307448da160de3ba745b8d9c42, please refer to the description in #4355.

For an overview of the proposed changes in 52ceabeca519dfd01e95fecfb95470136365085f, 4f304bdc745f28feef06d44799c26af455a8688c & 0c7ea96fb382aab808a5cdd5c7aea1cab071873e, please refer to the description in #4358.

For a preliminary discussion regarding the resolution of this issue, please refer to #4358.

In summary, the issue is that a saveType initialization based on slot type is currently overriding the original method of setting the saveType value based on the isAutosave flag, that's set whenever a save is performed. As a result, affected engines are identifying any save stored in the autosave slot as an autosave, regardless of its true type.

The effect is that any user's regular save which happens to be stored in the autosave slot is now automatically overwritten by the autosave, instead of generating the in-game warning dialog, denying the user the opportunity to recover their save file.

The key is that this saveType-based-on-slot-type initialization is NOT required for the actual autosave process, originally being introduced only to determine if the autosave slot was empty, for the sole purpose of generating a dummy autosave if required. At the time of its introduction, the saveType property was NOT being used for autosave testing.

The risk was always that someday the saveType would again be restored to its intended purpose of identifying the type of save stored in the autosave slot, and this occurred with 9b05c206993d3107f98ac5b437801e33ba3c79b7, revealing the previously hidden consequences of coercing the use of saveType for something other than its intended purpose.

This PR resolves this issue by removing this unnecessary saveType initialization, restoring the previous default initialization to the SaveStateDescriptor methods, and removes the usage of the saveType in determining if the autosave slot is indeed empty, by replacing calls to isAutosave() in varous listSaves() methods with their original "slot == autosaveSlot" type calls.
 