### PR TITLE
SCI: Macintosh Fonts

### DIFF
--- a/engines/director/tests.cpp
+++ b/engines/director/tests.cpp
@@ -154,7 +154,7 @@ void Window::testFonts() {
 
 			debug("Font: %s", name.c_str());
 
-			Graphics::MacFontFamily font;
+			Graphics::MacFontFamily font(name);
 			font.load(*stream);
 		}
 	}

--- a/engines/sci/detection_tables.h
+++ b/engines/sci/detection_tables.h
@@ -28,6 +28,7 @@ namespace Sci {
 #define GUIO_STD16_SPEECH GUIO4(GAMEOPTION_PREFER_DIGITAL_SFX, GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_MIDI_MODE, GAMEOPTION_RGB_RENDERING)
 #define GUIO_STD16_SPEECH_GM GUIO5(GUIO_MIDIGM, GAMEOPTION_PREFER_DIGITAL_SFX, GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_MIDI_MODE, GAMEOPTION_RGB_RENDERING)
 #define GUIO_STD16_MAC GUIO5(GUIO_NOSPEECH, GAMEOPTION_PREFER_DIGITAL_SFX, GAMEOPTION_MIDI_MODE, GAMEOPTION_RGB_RENDERING, GAMEOPTION_TTS)
+#define GUIO_STD16_MAC_HIRESFONTS GUIO6(GUIO_NOSPEECH, GAMEOPTION_PREFER_DIGITAL_SFX, GAMEOPTION_MIDI_MODE, GAMEOPTION_HIGH_RESOLUTION_GRAPHICS, GAMEOPTION_RGB_RENDERING, GAMEOPTION_TTS)
 #define GUIO_STD16_MAC_UNDITHER GUIO6(GUIO_NOSPEECH, GAMEOPTION_EGA_UNDITHER, GAMEOPTION_PREFER_DIGITAL_SFX, GAMEOPTION_MIDI_MODE, GAMEOPTION_RGB_RENDERING, GAMEOPTION_TTS)
 #define GUIO_STD16_MAC_PALETTEMODS GUIO7(GUIO_NOSPEECH, GAMEOPTION_EGA_UNDITHER, GAMEOPTION_PREFER_DIGITAL_SFX, GAMEOPTION_MIDI_MODE, GAMEOPTION_RGB_RENDERING, GAMEOPTION_PALETTE_MODS, GAMEOPTION_TTS)
 #define GUIO_STD16_MAC_SPEECH GUIO3(GAMEOPTION_PREFER_DIGITAL_SFX, GAMEOPTION_MIDI_MODE, GAMEOPTION_RGB_RENDERING)
@@ -84,7 +85,7 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		{"resource.002", 0, "e1a6b6f1060f60be9dcb6d28ad7a2a20", 1168310},
 		{"resource.003", 0, "6c3d1bb26ad532c94046bc9ac49b5ff4", 891295},
 		AD_LISTEND},
-		Common::EN_ANY, Common::kPlatformMacintosh, 0, GUIO_STD16_MAC },
+		Common::EN_ANY, Common::kPlatformMacintosh, 0, GUIO_STD16_MAC_HIRESFONTS },
 
 	// Castle of Dr. Brain - English DOS Non-Interactive Demo
 	// SCI interpreter version 1.000.005
@@ -817,7 +818,7 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		{"Data1", 0, "ef7cbd62727989818f1cfae69c9fd61d", 3038236},
 		{"Data2", 0, "2424b418f7d52c385cea4701f529c69a", 4721476},
 		AD_LISTEND},
-		Common::EN_ANY, Common::kPlatformMacintosh, ADGF_MACRESFORK, GUIO_STD16_MAC },
+		Common::EN_ANY, Common::kPlatformMacintosh, ADGF_MACRESFORK, GUIO_STD16_MAC_HIRESFONTS },
 
 	// Fun Seeker's Guide - English DOS
 	// SCI interpreter version 0.000.506
@@ -2298,7 +2299,7 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		{"Data1", 0, "a183fc0c22fcbd9be4c8800d974b5599", 3891868},
 		{"Data2", 0, "b3722460dfd3097a1fbaf99a21ad8ea5", 15031016},
 		AD_LISTEND},
-		Common::EN_ANY, Common::kPlatformMacintosh, ADGF_MACRESFORK, GUIO_STD16_MAC },
+		Common::EN_ANY, Common::kPlatformMacintosh, ADGF_MACRESFORK, GUIO_STD16_MAC_HIRESFONTS },
 
 #undef GUIO_KQ6_DEMO
 #undef GUIO_KQ6_CD
@@ -2866,7 +2867,7 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		{"resource.001", 0, "aa6f153f70f1e32d1bde465fff08eecf", 1137418},
 		{"resource.002", 0, "b22c616aa789ebef990290c7ffd86548", 1097477},
 		AD_LISTEND},
-		Common::EN_ANY, Common::kPlatformMacintosh, 0, GUIO_STD16_MAC },
+		Common::EN_ANY, Common::kPlatformMacintosh, 0, GUIO_STD16_MAC_HIRESFONTS },
 
 	// Larry 1 VGA Remake - English DOS Non-Interactive Demo
 	// SCI interpreter version 1.000.084
@@ -3286,7 +3287,7 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		{"resource.006", 0, "dda27ce00682aa76198dac124bbbe334", 1110043},
 		{"resource.007", 0, "ac443fae1285fb359bf2b2bc6a7301ae", 989801},
 		AD_LISTEND},
-		Common::EN_ANY, Common::kPlatformMacintosh, 0, GUIO_STD16_MAC },
+		Common::EN_ANY, Common::kPlatformMacintosh, 0, GUIO_STD16_MAC_HIRESFONTS },
 
 	// Larry 5 - German DOS (from Tobis87)
 	// SCI interpreter version T.A00.196
@@ -3431,7 +3432,7 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		{"Data1", 0, "482e6bcdda3a89390d5c4bcbfb5896b4", 2754651},
 		{"Data2", 0, "ba0799a45076780dfbceb8fce4c549c9", 5846089},
 		AD_LISTEND},
-		Common::EN_ANY, Common::kPlatformMacintosh, ADGF_MACRESFORK | ADGF_UNSTABLE, GUIO_STD16_MAC },
+		Common::EN_ANY, Common::kPlatformMacintosh, ADGF_MACRESFORK | ADGF_UNSTABLE, GUIO_STD16_MAC_HIRESFONTS },
 
 	// Crazy Nick's Software Picks: Leisure Suit Larry's Casino - English DOS (from the Leisure Suit Larry Collection)
 	// Executable scanning reports "1.001.029", VERSION file reports "1.000"
@@ -4729,7 +4730,7 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		{"Data1", 0, "106527ff8756e4e1a795d63d23e8b833", 1752102},
 		{"Data2", 0, "5cdd92033231159c6e9c71d43e9f194d", 6574490},
 		AD_LISTEND},
-		Common::EN_ANY, Common::kPlatformMacintosh, ADGF_MACRESFORK, GUIO_STD16_MAC },
+		Common::EN_ANY, Common::kPlatformMacintosh, ADGF_MACRESFORK, GUIO_STD16_MAC_HIRESFONTS },
 
 	// Quest for Glory 2 - English Amiga
 	// Game version 1.109
@@ -5319,7 +5320,7 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		{"resource.003", 0, "ae46e195e66df5a131917f0aa80b5669", 1242794},
 		{"resource.004", 0, "91d58a9eb2187c38424990afe4c12bc6", 1250949},
 		AD_LISTEND},
-		Common::EN_ANY, Common::kPlatformMacintosh, 0, GUIO_STD16_MAC },
+		Common::EN_ANY, Common::kPlatformMacintosh, 0, GUIO_STD16_MAC_HIRESFONTS },
 
 	// Space Quest 1 VGA Remake - English Non-Interactive Demo (from FRG)
 	// SCI interpreter version 1.000.181

--- a/engines/sci/engine/kernel.cpp
+++ b/engines/sci/engine/kernel.cpp
@@ -770,7 +770,8 @@ void Kernel::loadKernelNames(GameFeatures *features) {
 			// In the Windows version of KQ6 CD, the empty kSetSynonyms
 			// function has been replaced with kPortrait. In KQ6 Mac,
 			// kPlayBack has been replaced by kShowMovie.
-			if ((g_sci->getPlatform() == Common::kPlatformWindows) || (g_sci->forceHiresGraphics()))
+			if ((g_sci->getPlatform() == Common::kPlatformWindows) || 
+				(g_sci->getPlatform() == Common::kPlatformDOS && g_sci->forceHiresGraphics()))
 				_kernelNames[0x26] = "Portrait";
 			else if (g_sci->getPlatform() == Common::kPlatformMacintosh)
 				_kernelNames[0x84] = "ShowMovie";

--- a/engines/sci/engine/kmisc.cpp
+++ b/engines/sci/engine/kmisc.cpp
@@ -761,8 +761,6 @@ reg_t kPlatform(EngineState *s, int argc, reg_t *argv) {
 		kPlatformWin311OrHigher = 7
 	};
 
-	bool isWindows = g_sci->getPlatform() == Common::kPlatformWindows;
-
 	if (argc == 0) {
 		// This is called in KQ5CD with no parameters, where it seems to do some
 		// graphics driver check. This kernel function didn't have subfunctions
@@ -772,10 +770,9 @@ reg_t kPlatform(EngineState *s, int argc, reg_t *argv) {
 		return NULL_REG;
 	}
 
-	if (g_sci->forceHiresGraphics()) {
-		// force Windows platform, so that hires-graphics are enabled
-		isWindows = true;
-	}
+	// treat DOS with hires graphics as Windows so that hires graphics are enabled
+	bool isWindows = (g_sci->getPlatform() == Common::kPlatformWindows) ||
+		             (g_sci->getPlatform() == Common::kPlatformDOS && g_sci->forceHiresGraphics());
 
 	uint16 operation = (argc == 0) ? 0 : argv[0].toUint16();
 

--- a/engines/sci/engine/kvideo.cpp
+++ b/engines/sci/engine/kvideo.cpp
@@ -136,10 +136,18 @@ reg_t kShowMovie(EngineState *s, int argc, reg_t *argv) {
 			// Mac QuickTime
 			// The only argument is the string for the video
 
-			// HACK: Switch to 16bpp graphics for Cinepak.
+			// Switch to 16bpp graphics for Cinepak
 			if (g_system->getScreenFormat().bytesPerPixel == 1) {
-				initGraphics(screenWidth, screenHeight, nullptr);
-				switchedGraphicsMode = true;
+				const Common::List<Graphics::PixelFormat> supportedFormats = g_system->getSupportedFormats();
+				Common::List<Graphics::PixelFormat>::const_iterator it;
+				for (it = supportedFormats.begin(); it != supportedFormats.end(); ++it) {
+					if (it->bytesPerPixel == 2) {
+						const Graphics::PixelFormat format = *it;
+						initGraphics(screenWidth, screenHeight, &format);
+						switchedGraphicsMode = true;
+						break;
+					}
+				}
 			}
 
 			if (g_system->getScreenFormat().bytesPerPixel == 1) {

--- a/engines/sci/graphics/controls16.cpp
+++ b/engines/sci/graphics/controls16.cpp
@@ -328,7 +328,11 @@ void GfxControls16::kernelDrawButton(Common::Rect rect, reg_t obj, const char *t
 		_paint16->frameRect(rect);
 		rect.grow(-2);
 		_ports->textGreyedOutput(!(style & SCI_CONTROLS_STYLE_ENABLED));
-		_text16->Box(text, languageSplitter, false, rect, SCI_TEXT16_ALIGNMENT_CENTER, fontId);
+		if (!g_sci->hasMacFonts()) {
+			_text16->Box(text, languageSplitter, false, rect, SCI_TEXT16_ALIGNMENT_CENTER, fontId);
+		} else {
+			_text16->macDraw(text, rect, SCI_TEXT16_ALIGNMENT_CENTER, fontId, _text16->GetFontId(), 0);
+		}
 		_ports->textGreyedOutput(false);
 		rect.grow(1);
 		if (style & SCI_CONTROLS_STYLE_SELECTED)
@@ -347,6 +351,15 @@ void GfxControls16::kernelDrawButton(Common::Rect rect, reg_t obj, const char *t
 			_paint16->invertRectViaXOR(rect);
 		else
 			_paint16->invertRect(rect);
+		if (g_sci->hasMacFonts()) {
+			// Mac scripts set a flag to tell the interpreter to draw white text when inverted.
+			// Note that KQ6 does not do this because it includes the PC version of the script,
+			// causing button text to disappear when clicked in the original.
+			uint16 textColor = (style & SCI_CONTROLS_STYLE_MAC_INVERTED) ? 255 : 0;
+			rect.grow(-1);
+			_text16->macDraw(text, rect, SCI_TEXT16_ALIGNMENT_CENTER, fontId, _text16->GetFontId(), textColor);
+			rect.grow(1);
+		}
 		_paint16->bitsShow(rect);
 	}
 }
@@ -358,7 +371,11 @@ void GfxControls16::kernelDrawText(Common::Rect rect, reg_t obj, const char *tex
 		rect.grow(1);
 		_paint16->eraseRect(rect);
 		rect.grow(-1);
-		_text16->Box(text, languageSplitter, false, rect, alignment, fontId);
+		if (!g_sci->hasMacFonts()) {
+			_text16->Box(text, languageSplitter, false, rect, alignment, fontId);
+		} else {
+			_text16->macDraw(text, rect, alignment, fontId, _text16->GetFontId(), 0);
+		}
 		if (style & SCI_CONTROLS_STYLE_SELECTED) {
 			_paint16->frameRect(rect);
 		}

--- a/engines/sci/graphics/controls16.h
+++ b/engines/sci/graphics/controls16.h
@@ -25,9 +25,10 @@
 namespace Sci {
 
 enum controlStateFlags {
-	SCI_CONTROLS_STYLE_ENABLED  = 0x0001,  ///< 0001 - enabled buttons
-	SCI_CONTROLS_STYLE_DISABLED = 0x0004,  ///< 0010 - grayed out buttons
-	SCI_CONTROLS_STYLE_SELECTED = 0x0008   ///< 1000 - widgets surrounded by a frame
+	SCI_CONTROLS_STYLE_ENABLED      = 0x0001,  ///< enabled buttons
+	SCI_CONTROLS_STYLE_DISABLED     = 0x0004,  ///< grayed out buttons
+	SCI_CONTROLS_STYLE_SELECTED     = 0x0008,  ///< widgets surrounded by a frame
+	SCI_CONTROLS_STYLE_MAC_INVERTED = 0x0040   ///< control is inverted (mac-only for hi-res fonts)
 };
 
 // Control types and flags

--- a/engines/sci/graphics/macfont.cpp
+++ b/engines/sci/graphics/macfont.cpp
@@ -1,0 +1,161 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/macresman.h"
+#include "graphics/fontman.h"
+#include "graphics/fonts/macfont.h"
+#include "graphics/macgui/macfontmanager.h"
+#include "graphics/macgui/macwindowmanager.h"
+#include "sci/graphics/macfont.h"
+
+namespace Sci {
+
+GfxMacFontManager::GfxMacFontManager(Common::MacResManager *macExecutable) :
+	_defaultFont(nullptr) {
+
+	if (macExecutable != nullptr) {
+		// Load fonts from mac executable.
+		// Use kWMModeForceBuiltinFonts to prevent MacFontManager from attempting
+		// to load fonts from classicmacfonts.dat, as we don't use them and it
+		// will produce a warning() when it's not present.
+		_usesSystemFonts = false;
+		uint32 mode = Graphics::MacGUIConstants::kWMModeForceBuiltinFonts;
+		_macFontManager = new Graphics::MacFontManager(mode, Common::Language::UNK_LANG);
+		_macFontManager->loadFonts(macExecutable);
+
+		// Register each font family that was loaded from the executable so that
+		// their Graphics::Font can be retrieved through FontManager::getFontByName().
+		const Common::Array<Graphics::MacFontFamily *> &fontFamilies = _macFontManager->getFontFamilies();
+		for (uint i = 0; i < fontFamilies.size(); ++i) {
+			_macFontManager->registerFontName(fontFamilies[i]->getName(), fontFamilies[i]->getFontFamilyId());
+		}
+
+		if (!initFromFontTable(macExecutable)) {
+			_macFonts.clear(true);
+			_defaultFont = nullptr;
+		}
+	} else {
+		// Load fonts from classicmacfonts.dat. This logs a warning if it can't be found.
+		_usesSystemFonts = true;
+		_macFontManager = new Graphics::MacFontManager(0, Common::Language::UNK_LANG);
+
+		// Load Palatino. These values were hard-coded in the interpreter in SciToMacFont.
+		const Graphics::Font *palatinoSmall = getMacFont(Graphics::kMacFontPalatino, 10);
+		const Graphics::Font *palatinoLarge = getMacFont(Graphics::kMacFontPalatino, 18);
+		if (palatinoSmall == nullptr || palatinoLarge == nullptr) {
+			return;
+		}
+
+		// Map all fonts to Palatino.
+		_defaultFont = new MacFontItem { palatinoSmall, palatinoLarge };
+		_macFonts.setVal(0, _defaultFont);
+	}
+}
+
+GfxMacFontManager::~GfxMacFontManager() {
+	for (Common::HashMap<GuiResourceId, MacFontItem *>::iterator it = _macFonts.begin(); it != _macFonts.end(); ++it) {
+		delete it->_value;
+	}
+	delete _macFontManager;
+}
+
+// The font mapping table is a small binary resource with id 128 and type `ftbl`
+bool GfxMacFontManager::initFromFontTable(Common::MacResManager *macExecutable) {
+	Common::SeekableReadStream *table = macExecutable->getResource(MKTAG('f', 't', 'b', 'l'), 128);
+	if (table == nullptr) {
+		warning("Mac font table not found in \"%s\"", macExecutable->getBaseFileName().rawString().c_str());
+		return false;
+	}
+
+	// Table header is 4 bytes followed by entries of 10 bytes each
+	uint16 defaultFontIndex = table->readUint16BE();
+	uint16 numberOfFonts = table->readUint16BE();
+	if (table->eos() || table->size() < 4 + numberOfFonts * 10) {
+		warning("Invalid mac font table in \"%s\"", macExecutable->getBaseFileName().rawString().c_str());
+		return false;
+	}
+
+	for (uint16 i = 0; i < numberOfFonts; ++i) {
+		uint16 sciFontId = table->readUint16BE();
+		if (_macFonts.contains(sciFontId)) {
+			warning("Duplicate Mac font table entry for %d in \"%s\"", sciFontId, macExecutable->getBaseFileName().rawString().c_str());
+			return false;
+		}
+		uint16 macFontId = table->readUint16BE();
+		uint16 smallFontSize = table->readUint16BE();
+		uint16 mediumFontSize = table->readUint16BE(); // large in KQ5 (not supported yet)
+		uint16 largeFontSize = table->readUint16BE();
+
+		const Graphics::Font *smallFont = getMacFont(macFontId, smallFontSize);
+		const Graphics::Font *largeFont = getMacFont(macFontId, MAX(mediumFontSize, largeFontSize));
+		if (smallFont == nullptr || largeFont == nullptr) {
+			warning("Mac font %d not found in \"%s\"", macFontId, macExecutable->getBaseFileName().rawString().c_str());
+			return false;
+		}
+
+		MacFontItem *font = new MacFontItem { smallFont, largeFont };
+		_macFonts.setVal(sciFontId, font);
+
+		if (i == defaultFontIndex) {
+			_defaultFont = font;
+		}
+	}
+
+	return true;
+}
+
+const Graphics::Font *GfxMacFontManager::getMacFont(int macFontId, int size) {
+	// Is this font in MacFontManager? This logs a warning if it isn't.
+	if (_macFontManager->getFontName(macFontId).empty()) {
+		return nullptr;
+	}
+
+	// Build a MacFont to get the full font name for this size and style (regular)
+	Graphics::MacFont macFont(macFontId, size, 0);
+	Common::String fontName = _macFontManager->getFontName(macFont);
+
+	// Get the font through the regular FontManager through which MacFontManager
+	// registered it when loading fonts. MacFontManager::getFont() does lots of
+	// extra stuff and fallback handling which we're not interested in.
+	// We just want the font if it's there and nullptr if it isn't. Our fallback
+	// behavior if we can't get the mac fonts is to use SCI fonts.
+	return FontMan.getFontByName(fontName);
+}
+
+bool GfxMacFontManager::hasFonts() {
+	return _defaultFont != nullptr;
+}
+
+bool GfxMacFontManager::usesSystemFonts() {
+	return _usesSystemFonts;
+}
+
+const Graphics::Font *GfxMacFontManager::getSmallFont(GuiResourceId sciFontId) {
+	MacFontItem *item = _macFonts.getValOrDefault(sciFontId, _defaultFont);
+	return item->smallFont;
+}
+
+const Graphics::Font *GfxMacFontManager::getLargeFont(GuiResourceId sciFontId) {
+	MacFontItem *item = _macFonts.getValOrDefault(sciFontId, _defaultFont);
+	return item->largeFont;
+}
+
+} // End of namespace Sci

--- a/engines/sci/graphics/macfont.h
+++ b/engines/sci/graphics/macfont.h
@@ -1,0 +1,104 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SCI_GRAPHICS_MACFONT_H
+#define SCI_GRAPHICS_MACFONT_H
+
+#include "common/hashmap.h"
+#include "sci/graphics/helpers.h"   // for GuiResourceId
+
+namespace Common {
+class MacResManager;
+}
+namespace Graphics {
+class MacFontManager;
+class Font;
+}
+
+namespace Sci {
+
+/**
+ * GfxMacFontManager handles loading Mac fonts and mapping them to SCI fonts.
+ *
+ * Most Mac SCI1/1.1 games use native Mac fonts to draw their controls.
+ * This was done by altering the kernel functions used by the control scripts
+ * such as kDrawControl and kTextSize. All dialog text and buttons use these
+ * functions so this affects most text in SCI games. Scripts that draw text with
+ * kDisplay are unaffected and continue to use SCI fonts.
+ *
+ * The Mac game window could be set to three sizes: 100% (small), 150% (medium),
+ * or 200% (large). These percentages were relative to the internal resolution
+ * of the game; usually 320x200. The game's screen was stretched to the window
+ * and the Mac fonts were drawn directly to the window using Mac's Toolbox API.
+ * The Mac interpreter chose the font size based on the window size. At 200% the
+ * text was relatively high-resolution and looked quite crisp and distinct.
+ *
+ * The Mac fonts were originally included in the resource fork of the game's
+ * executable. The resource fork also contained a small table that specified
+ * the mapping of SCI font ids to Mac font ids, along with a default Mac font,
+ * and the Mac font sizes to use for the small, medium, and large window.
+ *
+ * Sierra switched to using the Palatino system font in QFG1VGA and LSL6.
+ * The font mapping table still existed, but the interpreter was hard-coded to
+ * always use Palatino values instead.
+ *
+ * GfxMacFontManager handles both cases by accepting the loaded Mac executable
+ * of games that include their own fonts. If no executable is provided then it
+ * attempts to use Palatino from classicmacfonts.dat along with the hard-coded
+ * values from Sierra's interpreter.
+ *
+ * GfxMacFontManager only exposes the small and large fonts. When Mac fonts are
+ * present, the game is upscaled to 200% and the large font is used for drawing.
+ * The small font is used for text calculations that determine the size of
+ * the text area, regardless of which font size is drawn on it.
+ *
+ * TODO: Add KQ5 support. It did things differently and it only had two window
+ * sizes. The mapping table changed and it appears to have its own sizing logic.
+ * Unfortunately, KQ5's interpreter doesn't include function names.
+ */
+class GfxMacFontManager {
+public:
+	GfxMacFontManager(Common::MacResManager *macExecutable = nullptr);
+	~GfxMacFontManager();
+
+	bool hasFonts();
+	bool usesSystemFonts();
+	const Graphics::Font *getSmallFont(GuiResourceId sciFontId);
+	const Graphics::Font *getLargeFont(GuiResourceId sciFontId);
+
+private:
+	bool initFromFontTable(Common::MacResManager *macExecutable);
+	const Graphics::Font *getMacFont(int macFontId, int size);
+
+	struct MacFontItem {
+		const Graphics::Font *smallFont;
+		const Graphics::Font *largeFont;
+	};
+
+	bool _usesSystemFonts;
+	Graphics::MacFontManager *_macFontManager;
+	Common::HashMap<GuiResourceId, MacFontItem *> _macFonts;
+	MacFontItem *_defaultFont;
+};
+
+} // End of namespace Sci
+
+#endif

--- a/engines/sci/graphics/macfont.h
+++ b/engines/sci/graphics/macfont.h
@@ -66,9 +66,10 @@ namespace Sci {
  * values from Sierra's interpreter.
  *
  * GfxMacFontManager only exposes the small and large fonts. When Mac fonts are
- * present, the game is upscaled to 200% and the large font is used for drawing.
- * The small font is used for text calculations that determine the size of
- * the text area, regardless of which font size is drawn on it.
+ * present and high resolution graphics are enabled, the game is upscaled to
+ * 200% and the large font is used. If high resolution graphics are disabled
+ * then the small font is used with no upscaling. Either way, the small font is
+ * always used for the calculations that determine the size of the text area.
  *
  * TODO: Add KQ5 support. It did things differently and it only had two window
  * sizes. The mapping table changed and it appears to have its own sizing logic.

--- a/engines/sci/graphics/maciconbar.h
+++ b/engines/sci/graphics/maciconbar.h
@@ -54,10 +54,12 @@ private:
 	};
 
 	Common::Array<IconBarItem> _iconBarItems;
-	uint32 _lastX;
 	uint16 _inventoryIndex;
 	Graphics::Surface *_inventoryIcon;
 	bool _allDisabled;
+
+	bool _isUpscaled;
+	Common::SpanOwner<SciSpan<byte> > _upscaleBuffer;
 
 	Graphics::Surface *loadPict(ResourceId id);
 	Graphics::Surface *createImage(uint32 iconIndex, bool isSelected);
@@ -68,8 +70,8 @@ private:
 	void drawIcon(uint16 index, bool selected);
 	void drawSelectedImage(uint16 index);
 	bool isIconEnabled(uint16 index) const;
-	void drawEnabledImage(Graphics::Surface *surface, const Common::Rect &rect);
-	void drawDisabledImage(Graphics::Surface *surface, const Common::Rect &rect);
+	void drawDisabledPattern(Graphics::Surface &surface, const Common::Rect &rect);
+	void drawImage(Graphics::Surface *surface, const Common::Rect &rect, bool enabled);
 	bool pointOnIcon(uint32 iconIndex, Common::Point point);
 };
 

--- a/engines/sci/graphics/scifont.h
+++ b/engines/sci/graphics/scifont.h
@@ -22,6 +22,7 @@
 #ifndef SCI_GRAPHICS_SCIFONT_H
 #define SCI_GRAPHICS_SCIFONT_H
 
+#include "sci/resource/resource.h"
 #include "sci/graphics/helpers.h"
 #include "sci/util.h"
 

--- a/engines/sci/graphics/screen.cpp
+++ b/engines/sci/graphics/screen.cpp
@@ -67,12 +67,17 @@ GfxScreen::GfxScreen(ResourceManager *resMan) : _resMan(resMan) {
 	if ((g_sci->getLanguage() == Common::JA_JPN) && (getSciVersion() <= SCI_VERSION_1_1))
 		_upscaledHires = GFX_SCREEN_UPSCALED_640x400;
 
-	// Macintosh SCI0 games used 480x300, while the scripts were running at 320x200
 	if (g_sci->getPlatform() == Common::kPlatformMacintosh) {
 		if (getSciVersion() <= SCI_VERSION_01) {
+			// Macintosh SCI0 games used 480x300, while the scripts were running at 320x200
 			_upscaledHires = GFX_SCREEN_UPSCALED_480x300;
 			_width = 480;
 			_height = 300; // regular visual, priority and control map are 480x300 (this is different than other upscaled SCI games)
+		} else {
+			// Macintosh SCI1/1.1 games use hi-res native fonts
+			if (g_sci->hasMacFonts()) {
+				_upscaledHires = GFX_SCREEN_UPSCALED_640x400;
+			}
 		}
 
 		// Some Mac SCI1/1.1 games only take up 190 rows and do not
@@ -112,8 +117,10 @@ GfxScreen::GfxScreen(ResourceManager *resMan) : _resMan(resMan) {
 		break;
 	case GFX_SCREEN_UPSCALED_640x400:
 		// Police Quest 2 and Quest For Glory on PC9801 (Japanese)
-		_displayWidth = 640;
-		_displayHeight = 400;
+		// Mac SCI1/1.1 with hi-res Mac fonts
+		// Korean fan translations
+		_displayWidth = _scriptWidth * 2;
+		_displayHeight = _scriptHeight * 2;
 		for (int i = 0; i <= _scriptHeight; i++)
 			_upscaledHeightMapping[i] = i * 2;
 		for (int i = 0; i <= _scriptWidth; i++)
@@ -145,6 +152,11 @@ GfxScreen::GfxScreen(ResourceManager *resMan) : _resMan(resMan) {
 	_priorityScreen = (byte *)calloc(_pixels, 1);
 	_controlScreen = (byte *)calloc(_pixels, 1);
 	_displayScreen = (byte *)calloc(_displayPixels, 1);
+	
+	// Create a Surface for _displayPixels so that we can draw to it from interfaces
+	// that only draw to Surfaces. Currently that's just Graphics::Font.
+	Graphics::PixelFormat format8 = Graphics::PixelFormat::createFormatCLUT8();
+	_displayScreenSurface.init(_displayWidth, _displayHeight, _displayWidth, _displayScreen, format8);
 
 	memset(&_ditheredPicColors, 0, sizeof(_ditheredPicColors));
 
@@ -177,22 +189,32 @@ GfxScreen::GfxScreen(ResourceManager *resMan) : _resMan(resMan) {
 	}
 
 	// Initialize the actual screen
-	Graphics::PixelFormat format8 = Graphics::PixelFormat::createFormatCLUT8();
 	const Graphics::PixelFormat *format = &format8;
 	if (ConfMan.getBool("rgb_rendering"))
 		format = nullptr; // Backend's preferred mode; RGB if available
 
 	if (g_sci->hasMacIconBar()) {
 		// For SCI1.1 Mac games with the custom icon bar, we need to expand the screen
-		// to accommodate for the icon bar. Of course, both KQ6 and QFG1 VGA differ in size.
+		// to accommodate for the icon bar. Of course, both KQ6 and Freddy Pharkas differ in size.
 		// We add 2 to the height of the icon bar to add a buffer between the screen and the
 		// icon bar (as did the original interpreter).
-		if (g_sci->getGameId() == GID_KQ6)
-			initGraphics(_displayWidth, _displayHeight + 26 + 2, format);
-		else if (g_sci->getGameId() == GID_FREDDYPHARKAS)
-			initGraphics(_displayWidth, _displayHeight + 28 + 2, format);
-		else
+		int macIconBarBuffer = 0;
+		switch (g_sci->getGameId()) {
+		case GID_KQ6: 
+			macIconBarBuffer = 26 + 2;
+			break;
+		case GID_FREDDYPHARKAS:
+			macIconBarBuffer = 28 + 2;
+			break;
+		default:
 			error("Unknown SCI1.1 Mac game");
+		}
+
+		if (_upscaledHires == GFX_SCREEN_UPSCALED_640x400) {
+			macIconBarBuffer *= 2;
+		}
+
+		initGraphics(_displayWidth, _displayHeight + macIconBarBuffer, format);
 	} else
 		initGraphics(_displayWidth, _displayHeight, format);
 
@@ -616,6 +638,12 @@ void GfxScreen::drawLine(Common::Point startPoint, Common::Point endPoint, byte 
 			vectorPutLinePixel(left, top, drawMask, color, priority, control);
 		}
 	}
+}
+
+// We put hi-res native Mac fonts onto an upscaled background.
+// The incoming coordinates are already hi-res.
+void GfxScreen::putHiresChar(const Graphics::Font *commonFont, int16 x, int16 y, uint16 chr, byte color) {
+	commonFont->drawChar(&_displayScreenSurface, chr, x, y, color);
 }
 
 // We put hires hangul chars onto upscaled background, so we need to adjust

--- a/engines/sci/graphics/screen.cpp
+++ b/engines/sci/graphics/screen.cpp
@@ -55,9 +55,11 @@ GfxScreen::GfxScreen(ResourceManager *resMan) : _resMan(resMan) {
 
 	// King's Quest 6 has hires content in the Windows version which we also
 	// allow to be optionally enabled in the DOS version.
-	if ((g_sci->getPlatform() == Common::kPlatformWindows) || (g_sci->forceHiresGraphics())) {
-		if (g_sci->getGameId() == GID_KQ6)
+	if (g_sci->getGameId() == GID_KQ6) {
+		if ((g_sci->getPlatform() == Common::kPlatformWindows) ||
+			(g_sci->getPlatform() == Common::kPlatformDOS && g_sci->forceHiresGraphics())) {
 			_upscaledHires = GFX_SCREEN_UPSCALED_640x440;
+		}
 	}
 
 	// Korean versions of games use hi-res font on upscaled version of the game.
@@ -74,8 +76,8 @@ GfxScreen::GfxScreen(ResourceManager *resMan) : _resMan(resMan) {
 			_width = 480;
 			_height = 300; // regular visual, priority and control map are 480x300 (this is different than other upscaled SCI games)
 		} else {
-			// Macintosh SCI1/1.1 games use hi-res native fonts
-			if (g_sci->hasMacFonts()) {
+			// Macintosh SCI1/1.1 games use hi-res native fonts if hi-res graphics are enabled
+			if (g_sci->hasMacFonts() && g_sci->forceHiresGraphics()) {
 				_upscaledHires = GFX_SCREEN_UPSCALED_640x400;
 			}
 		}
@@ -640,9 +642,10 @@ void GfxScreen::drawLine(Common::Point startPoint, Common::Point endPoint, byte 
 	}
 }
 
-// We put hi-res native Mac fonts onto an upscaled background.
-// The incoming coordinates are already hi-res.
-void GfxScreen::putHiresChar(const Graphics::Font *commonFont, int16 x, int16 y, uint16 chr, byte color) {
+// We put native Mac fonts onto an upscaled background if they are hires,
+// otherwise lores Mac fonts are used with no upscaling. The caller handles
+// all of this so there are no scaling adjustments to make here.
+void GfxScreen::putMacChar(const Graphics::Font *commonFont, int16 x, int16 y, uint16 chr, byte color) {
 	commonFont->drawChar(&_displayScreenSurface, chr, x, y, color);
 }
 

--- a/engines/sci/graphics/screen.h
+++ b/engines/sci/graphics/screen.h
@@ -118,7 +118,7 @@ public:
 	}
 	void enableUndithering(bool flag);
 
-	void putHiresChar(const Graphics::Font *commonFont, int16 x, int16 y, uint16 chr, byte color);
+	void putMacChar(const Graphics::Font *commonFont, int16 x, int16 y, uint16 chr, byte color);
 	void putKanjiChar(Graphics::FontSJIS *commonFont, int16 x, int16 y, uint16 chr, byte color);
 	void putHangulChar(Graphics::FontKorean *commonFont, int16 x, int16 y, uint16 chr, byte color);
 

--- a/engines/sci/graphics/screen.h
+++ b/engines/sci/graphics/screen.h
@@ -26,6 +26,7 @@
 #include "sci/graphics/helpers.h"
 #include "sci/graphics/view.h"
 
+#include "graphics/font.h"
 #include "graphics/sjis.h"
 #include "graphics/korfont.h"
 #include "graphics/pixelformat.h"
@@ -117,6 +118,7 @@ public:
 	}
 	void enableUndithering(bool flag);
 
+	void putHiresChar(const Graphics::Font *commonFont, int16 x, int16 y, uint16 chr, byte color);
 	void putKanjiChar(Graphics::FontSJIS *commonFont, int16 x, int16 y, uint16 chr, byte color);
 	void putHangulChar(Graphics::FontKorean *commonFont, int16 x, int16 y, uint16 chr, byte color);
 
@@ -196,6 +198,7 @@ private:
 	 * Only read from this buffer for Save/ShowBits usage.
 	 */
 	byte *_displayScreen;
+	Graphics::Surface _displayScreenSurface;
 
 	// Screens for RGB mode support
 	byte *_displayedScreen;

--- a/engines/sci/graphics/text16.h
+++ b/engines/sci/graphics/text16.h
@@ -22,6 +22,10 @@
 #ifndef SCI_GRAPHICS_TEXT16_H
 #define SCI_GRAPHICS_TEXT16_H
 
+namespace Graphics {
+class Font;
+}
+
 namespace Sci {
 
 #define SCI_TEXT16_ALIGNMENT_RIGHT -1
@@ -34,12 +38,13 @@ class GfxPorts;
 class GfxPaint16;
 class GfxScreen;
 class GfxFont;
+class GfxMacFontManager;
 /**
  * Text16 class, handles text calculation and displaying of text for SCI0->SCI1.1 games
  */
 class GfxText16 {
 public:
-	GfxText16(GfxCache *fonts, GfxPorts *ports, GfxPaint16 *paint16, GfxScreen *screen);
+	GfxText16(GfxCache *fonts, GfxPorts *ports, GfxPaint16 *paint16, GfxScreen *screen, GfxMacFontManager *macFontManager);
 	~GfxText16();
 
 	GuiResourceId GetFontId();
@@ -75,16 +80,20 @@ public:
 	void kernelTextFonts(int argc, reg_t *argv);
 	void kernelTextColors(int argc, reg_t *argv);
 
+	void macTextSize(const Common::String &text, GuiResourceId sciFontId, GuiResourceId origSciFontId, int16 maxWidth, int16 *textWidth, int16 *textHeight);
+	void macDraw(const Common::String &text, Common::Rect rect, TextAlignment alignment, GuiResourceId sciFontId, GuiResourceId origSciFontId, int16 color);
 private:
 	void init();
 	bool SwitchToFont1001OnKorean(const char *text, uint16 languageSplitter);
 	bool SwitchToFont900OnSjis(const char *text, uint16 languageSplitter);
 	static bool isJapaneseNewLine(int16 curChar, int16 nextChar);
+	int16 macGetLongest(const Common::String &text, uint start, const Graphics::Font *font, int16 maxWidth, int16 *lineWidth);
 
 	GfxCache *_cache;
 	GfxPorts *_ports;
 	GfxPaint16 *_paint16;
 	GfxScreen *_screen;
+	GfxMacFontManager *_macFontManager; // null when not applicable
 
 	int _codeFontsCount;
 	GuiResourceId *_codeFonts;

--- a/engines/sci/module.mk
+++ b/engines/sci/module.mk
@@ -47,8 +47,9 @@ MODULE_OBJS := \
 	graphics/controls16.o \
 	graphics/coordadjuster.o \
 	graphics/cursor.o \
-	graphics/fontsjis.o \
 	graphics/fontkorean.o \
+	graphics/fontsjis.o \
+	graphics/macfont.o \
 	graphics/maciconbar.o \
 	graphics/menu.o \
 	graphics/paint16.o \

--- a/engines/sci/resource/resource.cpp
+++ b/engines/sci/resource/resource.cpp
@@ -3122,6 +3122,28 @@ Common::String ResourceManager::findSierraGameId(const bool isBE) {
 	return heap->getStringAt(offset);
 }
 
+// Mac executables are currently used for icon bars and native fonts.
+// Eventually they should be used for native menus and possibly even splash screens.
+// For example, LSL6 can't function without native menus. (bug #11356)
+// Executables that we currently don't use are commented out.
+Common::String ResourceManager::getMacExecutableName() const {
+	switch (g_sci->getGameId()) {
+	case GID_CASTLEBRAIN: return "Castle of Dr. Brain"; // fonts, splash screen
+	case GID_FREDDYPHARKAS: return "Freddy Pharkas"; // fonts, icon bar, menu, splash screen
+	//case GID_HOYLE4: return "Hoyle"; // menu, splash screen
+	//case GID_KQ5: return "King's Quest V"; // fonts (not supported yet), splash screen
+	case GID_KQ6: return "King's Quest VI"; // fonts, icon bar, menu, splash screen
+	case GID_LSL1: return "Leisure Suit Larry 1"; // fonts, splash screen
+	case GID_LSL5: return "Leisure Suit Larry 5"; // fonts, splash screen
+	//case GID_LSL6: return "Leisure Suit Larry 6"; // menu, splash screen
+	//case GID_QFG1VGA: return "Quest for Glory"; // menu, splash screen
+	case GID_SQ1: return "Space Quest 1"; // fonts, splash screen
+	//case GID_SQ3: return "SQ3"; // menu, splash screen
+	//case GID_SQ4: return "Space Quest IV"; // splash screen
+	default: return "";
+	}
+}
+
 bool ResourceManager::isKoreanMessageMap(ResourceSource *source) {
 	return source->getLocationName() == "message.map" && g_sci && g_sci->getLanguage() == Common::KO_KOR;
 }

--- a/engines/sci/resource/resource.h
+++ b/engines/sci/resource/resource.h
@@ -644,6 +644,8 @@ protected:
 	void detectSciVersion();
 
 public:
+	/** Returns the file name of the game's Mac executable. */
+	Common::String getMacExecutableName() const;
 	bool isKoreanMessageMap(ResourceSource *source);
 
 private:

--- a/engines/sci/sci.cpp
+++ b/engines/sci/sci.cpp
@@ -289,12 +289,19 @@ Common::Error SciEngine::run() {
 	_scriptPatcher = new ScriptPatcher();
 	SegManager *segMan = new SegManager(_resMan, _scriptPatcher);
 
+	// Load the Mac executable and fonts if available
+	if (getSciVersion() < SCI_VERSION_2 && getPlatform() == Common::kPlatformMacintosh) {
+		loadMacExecutable();
+		loadMacFonts();
+	}
+
 	// Read user option for forcing hires graphics
 	// Only show/selectable for:
 	//  - King's Quest 6 CD
 	//  - King's Quest 6 CD demo
 	//  - Gabriel Knight 1 CD
 	//  - Police Quest 4 CD
+	//  - SCI1/1.1 Mac games with hires fonts
 	//
 	// Gabriel Knight 1 on Mac is hi-res only, so it should NOT get this option.
 	// Confirmed by [md5] and originally by clone2727.
@@ -304,16 +311,12 @@ Common::Error SciEngine::run() {
 		// We need to do this, because the option's default is "true", but we don't want "true"
 		// for any game that does not have this option.
 		_forceHiresGraphics = ConfMan.getBool("enable_high_resolution_graphics");
+	} else if (hasMacFonts()) {
+		// Default to using hires Mac fonts if GUI option isn't present, as it was added later.
+		_forceHiresGraphics = true;
 	}
 
 	if (getSciVersion() < SCI_VERSION_2) {
-		// Load the Mac executable and fonts if available.
-		// If fonts are found then GfxScreen will enable upscaling.
-		if (getPlatform() == Common::kPlatformMacintosh) {
-			loadMacExecutable();
-			loadMacFonts();
-		}
-		
 		// Initialize the game screen
 		_gfxScreen = new GfxScreen(_resMan);
 		_gfxScreen->enableUndithering(ConfMan.getBool("disable_dithering"));

--- a/engines/sci/sci.h
+++ b/engines/sci/sci.h
@@ -66,6 +66,7 @@ class GfxControls16;
 class GfxControls32;
 class GfxCoordAdjuster16;
 class GfxCursor;
+class GfxMacFontManager;
 class GfxMacIconBar;
 class GfxMenu;
 class GfxPaint16;
@@ -193,7 +194,18 @@ public:
 	bool isBE() const;
 
 	bool hasParser() const;
+
+	/** Returns true if the game supports native Mac fonts and the fonts are available. */
+	bool hasMacFonts() const;
+	
+	/** Returns true if the game is a Mac version with an icon bar on the bottom. */
 	bool hasMacIconBar() const;
+
+	/**
+	 * Returns true if the game is a Mac version that used native Mac file dialogs
+	 * for saving and restoring. These versions do not include resources for the
+	 * normal save and restore screens, so the ScummVM UI must always be used.
+	 */
 	bool hasMacSaveRestoreDialogs() const;
 
 	inline ResourceManager *getResMan() const { return _resMan; }
@@ -283,6 +295,7 @@ public:
 	GfxText16 *_gfxText16;
 	GfxTransitions *_gfxTransitions; // transitions between screens for 16-bit gfx
 	GfxMacIconBar *_gfxMacIconBar; // Mac Icon Bar manager
+	GfxMacFontManager *_gfxMacFontManager; // null when not applicable
 	SciTTS *_tts;
 
 #ifdef ENABLE_SCI32
@@ -339,9 +352,21 @@ private:
 	void exitGame();
 
 	/**
-	 * Loads the Mac executable for SCI1 games
+	 * Loads the Mac executable for SCI1/1.1 games.
+	 * This function should only be called on Mac games.
+	 * If the executable isn't used, or is missing but optional,
+	 * then this function does nothing.
 	 */
 	void loadMacExecutable();
+
+	/**
+	 * Loads Mac native fonts for SCI1/1.1 games that support them.
+	 * This function should only be called on Mac games after loadMacExecutable()
+	 * has been called. Depending on the game, fonts are loaded from either the
+	 * executable or from classicmacfonts.dat. If fonts are not present, then a
+	 * warning is logged and SCI fonts are used instead.
+	 */
+	void loadMacFonts();
 
 	void initStackBaseWithSelector(Selector selector);
 

--- a/engines/scumm/charset.cpp
+++ b/engines/scumm/charset.cpp
@@ -1551,7 +1551,7 @@ CharsetRendererMac::CharsetRendererMac(ScummEngine *vm, const Common::String &fo
 	if (!fond)
 		return;
 
-	Graphics::MacFontFamily fontFamily;
+	Graphics::MacFontFamily fontFamily(fontFamilyName);
 	if (!fontFamily.load(*fond)) {
 		delete fond;
 		return;

--- a/graphics/font.cpp
+++ b/graphics/font.cpp
@@ -31,6 +31,14 @@ int Font::getFontAscent() const {
 	return -1;
 }
 
+int Font::getFontDescent() const {
+	return -1;
+}
+
+int Font::getFontLeading() const {
+	return -1;
+}
+
 int Font::getKerningOffset(uint32 left, uint32 right) const {
 	return 0;
 }

--- a/graphics/font.h
+++ b/graphics/font.h
@@ -105,6 +105,24 @@ public:
 	virtual int getFontAscent() const;
 
 	/**
+	 * Return the descent of the font.
+	 *
+	 * @return Font descent in pixels. If it is unknown
+	 * a value of -1 is returned.
+	 */
+	virtual int getFontDescent() const;
+
+	/**
+	 * Return the leading of the font.
+	 * This is the distance between the descent line
+	 * and the ascent line below it.
+	 *
+	 * @return Font leading in pixels. If it is unknown
+	 * a value of -1 is returned.
+	 */
+	virtual int getFontLeading() const;
+
+	/**
 	 * Return the maximum width of the font.
 	 *
 	 * @return Maximum font width in pixels.

--- a/graphics/fonts/macfont.cpp
+++ b/graphics/fonts/macfont.cpp
@@ -64,7 +64,9 @@ static int getDepth(uint16 _fontType) {
 	return 1 << ((_fontType >> 2) & 3);
 }
 
-MacFontFamily::MacFontFamily() {
+MacFontFamily::MacFontFamily(const Common::String &name) {
+	_name = name;
+
 	_ffFlags = 0;
 	_ffFamID = 0;
 	_ffFirstChar = 0;

--- a/graphics/fonts/macfont.h
+++ b/graphics/fonts/macfont.h
@@ -33,7 +33,7 @@ namespace Graphics {
 
 class MacFontFamily {
 public:
-	MacFontFamily();
+	MacFontFamily(const Common::String &name);
 	~MacFontFamily();
 
 	bool load(Common::SeekableReadStream &stream);
@@ -46,9 +46,13 @@ public:
 		uint16 _fontID;
 	};
 
+	const Common::String &getName() { return _name; }
+	uint16 getFontFamilyId() { return _ffFamID; }
 	Common::Array<AsscEntry> *getAssocTable() { return &_ffAssocEntries; }
 
 private:
+	Common::String _name;
+
 	// FOND
 	uint16 _ffFlags;
 	uint16 _ffFamID;

--- a/graphics/fonts/macfont.h
+++ b/graphics/fonts/macfont.h
@@ -170,6 +170,8 @@ public:
 
 	virtual int getFontHeight() const { return _data._fRectHeight; }
 	virtual int getFontAscent() const { return _data._ascent; }
+	virtual int getFontDescent() const { return _data._descent; }
+	virtual int getFontLeading() const { return _data._leading; }
 	virtual int getMaxCharWidth() const { return _data._maxWidth; }
 	virtual int getCharWidth(uint32 chr) const;
 	virtual void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const;

--- a/graphics/macgui/macfontmanager.cpp
+++ b/graphics/macgui/macfontmanager.cpp
@@ -367,7 +367,7 @@ void MacFontManager::loadFonts(Common::MacResManager *fontFile) {
 				familyName = cleanFontName(familyName);
 			}
 
-			Graphics::MacFontFamily *fontFamily = new MacFontFamily();
+			Graphics::MacFontFamily *fontFamily = new MacFontFamily(familyName);
 			fontFamily->load(*fond);
 
 			Common::Array<Graphics::MacFontFamily::AsscEntry> *assoc = fontFamily->getAssocTable();

--- a/graphics/macgui/macfontmanager.h
+++ b/graphics/macgui/macfontmanager.h
@@ -170,6 +170,8 @@ public:
 	void forceBuiltinFonts() { _builtInFonts = true; }
 	int parseSlantFromName(const Common::String &name);
 
+	const Common::Array<MacFontFamily *> &getFontFamilies() { return _fontFamilies; }
+
 private:
 	void loadFontsBDF();
 	void loadFonts();


### PR DESCRIPTION
High-resolution native Macintosh fonts are now supported in the following games when the game's executable is present:

- Castle of Dr. Brain
- Freddy Pharkas
- King's Quest 6
- Leisure Suit Larry 1
- Leisure Suit Larry 5
- Space Quest 1

And on these games when classicmacfonts.dat is present:

- Leisure Suit Larry 6 (floppy)
- Quest for Glory 1

If you're interested in the SCI details about this, engines/sci/graphics/macfont.h starts with a large explanation. If the Mac fonts aren't present then we fall back to SCI fonts like we do now. KQ6 and Freddy Pharkas should always use Mac fonts since we require the game executable for their icon bars.

I modded a few of the games to display internal text wrapping/sizing metrics and I'm happy to say that I can no longer locate discrepancies between the games in a Mac emulator running System 7.5.5. I'm sure we'll find some edge cases eventually, but I've suddenly run out of excuses to not finish this. =)

I'm most interested in feedback about how I'm using the MacGUI MacFontManager and the minor changes I made to it and the Font/MacFONTFont classes to expose necessary info. *Huge* thanks to @djsrv and @rvanlaar for helping me navigate MacFontManager and not break it. This feature wouldn't have happened without MacGUI, it's been a TODO for a decade!

I did not use MacGUI widgets/windows/etc for drawing text; I know that sounds good on paper but it's overkill for this and I think it's currently incompatible with this simple use case of drawing text with a transparent background to an unmanaged surface and calculating text wrapping results without drawing. I was interested if the text wrapping would save me work in replicating what classic Mac did, but the first comment in splitString is `// TODO::code is not elegant, we need to figure out a way which include all situations` and it handles way more things than SCI needs. Plus it only took a little code to get the correct results and incorporate SCI's own tweaks, so that's the route I went. I'll be happy to review a PR someday that "upgrades" it! ;)

https://bugs.scummvm.org/ticket/7043

![kq6](https://user-images.githubusercontent.com/22204938/200094913-f47e718e-f16b-4a63-ad04-5c90a3c67b2b.png)
![qfg1vga](https://user-images.githubusercontent.com/22204938/200094918-8ca1bbb6-814e-4695-b0ca-6fe1f5461a02.png)

(And yes, those first few pixels in "T" getting cut off is how it looks on a Mac too)
