### PR TITLE
MACOSX: Tiger/Leopard CoreAudio and NSUInteger cleanup

### DIFF
--- a/backends/platform/sdl/macosx/appmenu_osx.mm
+++ b/backends/platform/sdl/macosx/appmenu_osx.mm
@@ -40,7 +40,12 @@
 #endif
 
 #if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_5
+// https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Cocoa64BitGuide/64BitChangesCocoa/64BitChangesCocoa.html
+#if __LP64__ || NS_BUILD_32_LIKE_64
 typedef unsigned long NSUInteger;
+#else
+typedef unsigned int NSUInteger;
+#endif
 
 // Those are not defined in the 10.4 SDK, but they are defined when targeting
 // Mac OS X 10.4 or above in the 10.5 SDK, and they do work with 10.4.
@@ -140,7 +145,7 @@ static void openFromBundle(NSString *file) {
 		NSArray *dirContents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:bundlePath error:nil];
 		NSEnumerator *dirEnum = [dirContents objectEnumerator];
 		NSString *file;
-		while (file = [dirEnum nextObject]) {
+		while ((file = [dirEnum nextObject])) {
 			if ([file hasPrefix:@"ScummVM Manual"] && [file hasSuffix:@".pdf"]) {
 				[[NSWorkspace sharedWorkspace] openFile:[bundlePath stringByAppendingPathComponent:file]];
 				return;

--- a/backends/platform/sdl/macosx/macosx_wrapper.mm
+++ b/backends/platform/sdl/macosx/macosx_wrapper.mm
@@ -37,7 +37,12 @@
 #endif
 
 #if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_5
+// https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Cocoa64BitGuide/64BitChangesCocoa/64BitChangesCocoa.html
+#if __LP64__ || NS_BUILD_32_LIKE_64
 typedef unsigned long NSUInteger;
+#else
+typedef unsigned int NSUInteger;
+#endif
 
 // Those are not defined in the 10.4 SDK, but they are defined when targeting
 // Mac OS X 10.4 or above in the 10.5 SDK, and they do work with 10.4.


### PR DESCRIPTION
The first part is just a simplification of the checks done to build with the older CoreAudio API, which is required for macOS 10.4 support. Instead of checking for PowerPC CPUs to determine that we're (likely) targeting macOS 10.4, I just reuse the `MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_5` preprocessor checks we do in other places, which simplifies things and should make it possible to build for x86 10.4 again (if someone really wants to…).

I'm also fixing the `ComponentDescription`/`AudioComponentDescription` check: this change was done in macOS 10.6, not 10.5.

The other change is for `NSUInteger`. We only redefine it when targeting macOS 10.4, but it should be an `unsigned int` and not an `unsigned long`, on 32-bit architectures. The preprocessor checks come from Apple documentation and their SDK; since this is only used in a macOS backend file, and in a preprocessor define which only targets macOS 10.4 (which I've tested) I think we can just reuse it as-is.

(`unsigned long` and `unsigned int` have the same width on 32-bit x86/PPC, but it's probably better to just copy what the 10.5 SDK did.)

All of this has been tested on:

* macOS 10.4 with the 10.4 SDK (uses the older CoreAudio API)
* macOS 10.5 with the 10.5 SDK (uses the newer CoreAudio API)
* macOS 10.5 while forcing the 10.4 SDK and using ` -mmin-macosx-version=10.4` (uses the older CoreAudio API)
* macOS 12.6 (uses the newer CoreAudio API).

while testing the CoreAudio, taskbar and copy-and-paste features. I also made some checks with `nm -g` to be sure that it's still building with the proper symbols when targeting 10.4 vs. 10.5.

@criezy: Does this look good to you? Thanks!