### PR TITLE
BACKENDS: Restore original Cabal license header when quoting it

### DIFF
--- a/backends/audiocd/audiocd-stream.cpp
+++ b/backends/audiocd/audiocd-stream.cpp
@@ -27,7 +27,7 @@
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
+ * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,

--- a/backends/audiocd/audiocd-stream.h
+++ b/backends/audiocd/audiocd-stream.h
@@ -27,7 +27,7 @@
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
+ * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,

--- a/backends/audiocd/linux/linux-audiocd.cpp
+++ b/backends/audiocd/linux/linux-audiocd.cpp
@@ -27,7 +27,7 @@
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
+ * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,

--- a/backends/audiocd/linux/linux-audiocd.h
+++ b/backends/audiocd/linux/linux-audiocd.h
@@ -27,7 +27,7 @@
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
+ * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,

--- a/backends/audiocd/macosx/macosx-audiocd.cpp
+++ b/backends/audiocd/macosx/macosx-audiocd.cpp
@@ -27,7 +27,7 @@
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
+ * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,

--- a/backends/audiocd/macosx/macosx-audiocd.h
+++ b/backends/audiocd/macosx/macosx-audiocd.h
@@ -27,7 +27,7 @@
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
+ * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,

--- a/backends/audiocd/win32/win32-audiocd.cpp
+++ b/backends/audiocd/win32/win32-audiocd.cpp
@@ -27,7 +27,7 @@
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
+ * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,

--- a/backends/audiocd/win32/win32-audiocd.h
+++ b/backends/audiocd/win32/win32-audiocd.h
@@ -27,7 +27,7 @@
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
+ * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,


### PR DESCRIPTION
This **doesn't** ⚠️  revert these files to GPLv2+. Read their complete headers to be sure to understand what I'm fixing.

The `backends/audiocd/` files are derivative works of the Cabal project, which was GPLv2+. We have the right to put our derivate work under GPLv3+ (since the "+" in GPLv2+ explicitly allows this), but yet when we're quoting the `Original license header:` we shouldn't change the fact that Cabal is a GPLv2+ project.

So this change just keeps our GPLv3+ license header, while mentioning that the original was GPLv2+. (I think this just snuck in during the search/replace that took place in commit abea37c9bbd92e2f864fb9c7cc1453b56c144572).

@sev-: do you agree with this?