### PR TITLE
COMMON: Fix undefined-var-template warning with CLang

### DIFF
--- a/audio/musicplugin.h
+++ b/audio/musicplugin.h
@@ -130,6 +130,10 @@ public:
 	const PluginList &getPlugins() const;
 };
 
+namespace Common {
+DECLARE_SINGLETON(MusicManager);
+}
+
 /** Convenience shortcut for accessing the Music manager. */
 #define MusicMan MusicManager::instance()
 /** @} */

--- a/backends/cloud/cloudmanager.cpp
+++ b/backends/cloud/cloudmanager.cpp
@@ -33,7 +33,7 @@
 
 namespace Common {
 
-DECLARE_SINGLETON(Cloud::CloudManager);
+DEFINE_SINGLETON(Cloud::CloudManager);
 
 }
 

--- a/backends/cloud/cloudmanager.h
+++ b/backends/cloud/cloudmanager.h
@@ -304,4 +304,8 @@ public:
 
 } // End of namespace Cloud
 
+namespace Common {
+DECLARE_SINGLETON(Cloud::CloudManager);
+}
+
 #endif

--- a/backends/fs/psp/psp-fs-factory.cpp
+++ b/backends/fs/psp/psp-fs-factory.cpp
@@ -44,7 +44,7 @@
 #include <unistd.h>
 
 namespace Common {
-DECLARE_SINGLETON(PSPFilesystemFactory);
+DEFINE_SINGLETON(PSPFilesystemFactory);
 }
 
 AbstractFSNode *PSPFilesystemFactory::makeRootFileNode() const {

--- a/backends/fs/psp/psp-fs-factory.h
+++ b/backends/fs/psp/psp-fs-factory.h
@@ -43,4 +43,8 @@ private:
 	friend class Common::Singleton<SingletonBaseType>;
 };
 
+namespace Common {
+DECLARE_SINGLETON(PSPFilesystemFactory);
+}
+
 #endif /*PSP_FILESYSTEM_FACTORY_H*/

--- a/backends/fs/wii/wii-fs-factory.cpp
+++ b/backends/fs/wii/wii-fs-factory.cpp
@@ -44,7 +44,7 @@
 #endif
 
 namespace Common {
-DECLARE_SINGLETON(WiiFilesystemFactory);
+DEFINE_SINGLETON(WiiFilesystemFactory);
 }
 
 WiiFilesystemFactory::WiiFilesystemFactory() :

--- a/backends/fs/wii/wii-fs-factory.h
+++ b/backends/fs/wii/wii-fs-factory.h
@@ -83,4 +83,8 @@ private:
 #endif
 };
 
+namespace Common {
+DECLARE_SINGLETON(WiiFilesystemFactory);
+}
+
 #endif /*Wii_FILESYSTEM_FACTORY_H*/

--- a/backends/graphics/opengl/shader.cpp
+++ b/backends/graphics/opengl/shader.cpp
@@ -25,7 +25,7 @@
 #if !USE_FORCED_GLES
 
 namespace Common {
-DECLARE_SINGLETON(OpenGL::ShaderManager);
+DEFINE_SINGLETON(OpenGL::ShaderManager);
 }
 
 namespace OpenGL {

--- a/backends/graphics/opengl/shader.h
+++ b/backends/graphics/opengl/shader.h
@@ -71,6 +71,10 @@ private:
 
 } // End of namespace OpenGL
 
+namespace Common {
+DECLARE_SINGLETON(OpenGL::ShaderManager);
+}
+
 /** Shortcut for accessing the font manager. */
 #define ShaderMan (OpenGL::ShaderManager::instance())
 

--- a/backends/networking/curl/connectionmanager.cpp
+++ b/backends/networking/curl/connectionmanager.cpp
@@ -31,7 +31,7 @@
 
 namespace Common {
 
-DECLARE_SINGLETON(Networking::ConnectionManager);
+DEFINE_SINGLETON(Networking::ConnectionManager);
 
 }
 

--- a/backends/networking/curl/connectionmanager.h
+++ b/backends/networking/curl/connectionmanager.h
@@ -127,4 +127,8 @@ public:
 
 } // End of namespace Networking
 
+namespace Common {
+DECLARE_SINGLETON(Networking::ConnectionManager);
+}
+
 #endif

--- a/backends/networking/sdl_net/localwebserver.cpp
+++ b/backends/networking/sdl_net/localwebserver.cpp
@@ -59,7 +59,7 @@
 namespace Common {
 class MemoryReadWriteStream;
 
-DECLARE_SINGLETON(Networking::LocalWebserver);
+DEFINE_SINGLETON(Networking::LocalWebserver);
 
 }
 

--- a/backends/networking/sdl_net/localwebserver.h
+++ b/backends/networking/sdl_net/localwebserver.h
@@ -111,4 +111,8 @@ public:
 
 } // End of namespace Networking
 
+namespace Common {
+DECLARE_SINGLETON(Networking::LocalWebserver);
+}
+
 #endif

--- a/backends/platform/psp/display_manager.cpp
+++ b/backends/platform/psp/display_manager.cpp
@@ -64,7 +64,7 @@ const OSystem::GraphicsMode DisplayManager::_supportedModes[] = {
 // Class VramAllocator -----------------------------------
 
 namespace Common {
-DECLARE_SINGLETON(VramAllocator);
+DEFINE_SINGLETON(VramAllocator);
 }
 
 //#define __PSP_DEBUG_FUNCS__	/* For debugging the stack */

--- a/backends/platform/psp/display_manager.h
+++ b/backends/platform/psp/display_manager.h
@@ -65,6 +65,9 @@ private:
 	uint32 _bytesAllocated;
 };
 
+namespace Common {
+DECLARE_SINGLETON(VramAllocator);
+}
 
 /**
  *	Class used only by DisplayManager to start/stop GU rendering

--- a/backends/platform/psp/powerman.cpp
+++ b/backends/platform/psp/powerman.cpp
@@ -30,7 +30,7 @@
 #include "backends/platform/psp/trace.h"
 
 namespace Common {
-DECLARE_SINGLETON(PowerManager);
+DEFINE_SINGLETON(PowerManager);
 }
 
 // Function to debug the Power Manager (we have no output to screen)

--- a/backends/platform/psp/powerman.h
+++ b/backends/platform/psp/powerman.h
@@ -128,6 +128,10 @@ public:
 
 };
 
+namespace Common {
+DECLARE_SINGLETON(PowerManager);
+}
+
 // For easy access
 #define PowerMan	PowerManager::instance()
 

--- a/backends/platform/psp/rtc.cpp
+++ b/backends/platform/psp/rtc.cpp
@@ -34,7 +34,7 @@
 
 // Class PspRtc ---------------------------------------------------------------
 namespace Common {
-DECLARE_SINGLETON(PspRtc);
+DEFINE_SINGLETON(PspRtc);
 }
 
 void PspRtc::init() {						// init our starting ticks

--- a/backends/platform/psp/rtc.h
+++ b/backends/platform/psp/rtc.h
@@ -43,4 +43,8 @@ public:
 	uint32 getMicros();
 };
 
+namespace Common {
+DECLARE_SINGLETON(PspRtc);
+}
+
 #endif

--- a/backends/plugins/elf/memory-manager.cpp
+++ b/backends/plugins/elf/memory-manager.cpp
@@ -29,7 +29,7 @@
 #include <malloc.h>
 
 namespace Common {
-DECLARE_SINGLETON(ELFMemoryManager);
+DEFINE_SINGLETON(ELFMemoryManager);
 }
 
 ELFMemoryManager::ELFMemoryManager() :

--- a/backends/plugins/elf/memory-manager.h
+++ b/backends/plugins/elf/memory-manager.h
@@ -80,6 +80,10 @@ private:
 	uint32 _bytesAllocated;
 };
 
+namespace Common {
+DECLARE_SINGLETON(ELFMemoryManager);
+}
+
 #endif /* defined(DYNAMIC_MODULES) && defined(USE_ELF_LOADER) */
 
 #endif /* ELF_MEMORY_MANAGER_H */

--- a/backends/plugins/elf/shorts-segment-manager.cpp
+++ b/backends/plugins/elf/shorts-segment-manager.cpp
@@ -33,7 +33,7 @@ extern char __plugin_hole_end;		// Indicates end of hole in program file
 extern char _gp[];					// Value of gp register
 
 namespace Common {
-DECLARE_SINGLETON(ShortSegmentManager);	// For singleton
+DEFINE_SINGLETON(ShortSegmentManager);	// For singleton
 }
 
 ShortSegmentManager::ShortSegmentManager() {

--- a/backends/plugins/elf/shorts-segment-manager.h
+++ b/backends/plugins/elf/shorts-segment-manager.h
@@ -107,6 +107,10 @@ private:
 	char *_highestAddress;
 };
 
+namespace Common {
+DECLARE_SINGLETON(ShortSegmentManager);
+}
+
 #endif // defined(DYNAMIC_MODULES) && defined(USE_ELF_LOADER) && defined(MIPS_TARGET)
 
 #endif /* SHORTS_SEGMENT_MANAGER_H */

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -655,7 +655,7 @@ void PluginManager::addToPluginsInMemList(Plugin *plugin) {
 #include "engines/metaengine.h"
 
 namespace Common {
-DECLARE_SINGLETON(EngineManager);
+DEFINE_SINGLETON(EngineManager);
 }
 
 /**
@@ -988,7 +988,7 @@ void EngineManager::upgradeTargetForEngineId(const Common::String &target) const
 #include "audio/musicplugin.h"
 
 namespace Common {
-DECLARE_SINGLETON(MusicManager);
+DEFINE_SINGLETON(MusicManager);
 }
 
 const PluginList &MusicManager::getPlugins() const {
@@ -1000,7 +1000,7 @@ const PluginList &MusicManager::getPlugins() const {
 #include "graphics/scalerplugin.h"
 
 namespace Common {
-DECLARE_SINGLETON(ScalerManager);
+DEFINE_SINGLETON(ScalerManager);
 }
 
 const PluginList &ScalerManager::getPlugins() const {

--- a/common/archive.cpp
+++ b/common/archive.cpp
@@ -301,6 +301,6 @@ void SearchManager::clear() {
 #endif
 }
 
-DECLARE_SINGLETON(SearchManager);
+DEFINE_SINGLETON(SearchManager);
 
 } // namespace Common

--- a/common/archive.h
+++ b/common/archive.h
@@ -320,6 +320,8 @@ private:
 	SearchManager();
 };
 
+DECLARE_SINGLETON(SearchManager);
+
 /** Shortcut for accessing the Search Manager. */
 #define SearchMan		Common::SearchManager::instance()
 

--- a/common/config-manager.cpp
+++ b/common/config-manager.cpp
@@ -35,7 +35,7 @@ static bool isValidDomainName(const Common::String &domName) {
 
 namespace Common {
 
-DECLARE_SINGLETON(ConfigManager);
+DEFINE_SINGLETON(ConfigManager);
 
 char const *const ConfigManager::kApplicationDomain = "scummvm";
 char const *const ConfigManager::kTransientDomain = "__TRANSIENT";

--- a/common/config-manager.h
+++ b/common/config-manager.h
@@ -251,6 +251,8 @@ private:
 
 /** @} */
 
+DECLARE_SINGLETON(ConfigManager);
+
 } // End of namespace Common
 
 /** Shortcut for accessing the configuration manager. */

--- a/common/coroutines.cpp
+++ b/common/coroutines.cpp
@@ -32,7 +32,7 @@ namespace Common {
 /** Helper null context instance */
 CoroContext nullContext = nullptr;
 
-DECLARE_SINGLETON(CoroutineScheduler);
+DEFINE_SINGLETON(CoroutineScheduler);
 
 #ifdef COROUTINE_DEBUG
 namespace {

--- a/common/coroutines.h
+++ b/common/coroutines.h
@@ -560,6 +560,8 @@ public:
 
 /** @} */
 
+DECLARE_SINGLETON(CoroutineScheduler);
+
 } // end of namespace Common
 
 #endif // COMMON_COROUTINES_H

--- a/common/debug-channels.h
+++ b/common/debug-channels.h
@@ -168,6 +168,8 @@ private:
 	void addDebugChannels(const DebugChannelDef *channels);
 };
 
+DECLARE_SINGLETON(DebugManager);
+
 /** Shortcut for accessing the Debug Manager. */
 #define DebugMan		Common::DebugManager::instance()
 

--- a/common/debug.cpp
+++ b/common/debug.cpp
@@ -38,7 +38,7 @@ const DebugChannelDef gDebugChannels[] = {
 };
 namespace Common {
 
-DECLARE_SINGLETON(DebugManager);
+DEFINE_SINGLETON(DebugManager);
 
 namespace {
 

--- a/common/osd_message_queue.cpp
+++ b/common/osd_message_queue.cpp
@@ -24,7 +24,7 @@
 
 namespace Common {
 
-DECLARE_SINGLETON(OSDMessageQueue);
+DEFINE_SINGLETON(OSDMessageQueue);
 
 OSDMessageQueue::OSDMessageQueue() : _lastUpdate(0) {
 }

--- a/common/osd_message_queue.h
+++ b/common/osd_message_queue.h
@@ -77,6 +77,8 @@ private:
 
 /** @} */
 
+DECLARE_SINGLETON(OSDMessageQueue);
+
 } // End of namespace Common
 
 #endif

--- a/common/singleton.h
+++ b/common/singleton.h
@@ -102,7 +102,7 @@ protected:
  * This is because C++ requires initial explicit specialization
  * to be placed in the same namespace as the template.
  */
-#define DECLARE_SINGLETON(T) \
+#define DEFINE_SINGLETON(T) \
 	template<> T *Singleton<T>::_singleton = 0
 
 /** @} */

--- a/common/singleton.h
+++ b/common/singleton.h
@@ -97,6 +97,13 @@ protected:
 };
 
 /**
+ * This macro must be used in Common namespace everytime
+ * a Singleton class is declared.
+ */
+#define DECLARE_SINGLETON(T) \
+	template<> T *Singleton<T>::_singleton
+
+/**
  * Note that you need to use this macro from the Common namespace.
  *
  * This is because C++ requires initial explicit specialization

--- a/common/translation.cpp
+++ b/common/translation.cpp
@@ -38,7 +38,7 @@
 
 namespace Common {
 
-DECLARE_SINGLETON(MainTranslationManager);
+DEFINE_SINGLETON(MainTranslationManager);
 
 bool operator<(const TLanguage &l, const TLanguage &r) {
 	return l.name < r.name;

--- a/common/translation.h
+++ b/common/translation.h
@@ -254,6 +254,7 @@ public:
 	MainTranslationManager() : TranslationManager("translations.dat") {}
 	~MainTranslationManager() {}
 };
+DECLARE_SINGLETON(MainTranslationManager);
 
 /** @} */
 

--- a/configure
+++ b/configure
@@ -2307,14 +2307,6 @@ EOF
 
 set_flag_if_supported -Wglobal-constructors
 
-# If the compiler supports the -Wundefined-var-template flag, silence that warning.
-# We get this warning a lot with regard to the Singleton class as we explicitly
-# instantiate each specialisation. An alternate way to deal with it would be to
-# change the way we instantiate the singleton classes as done in PR #967.
-# Note: we check the -Wundefined-var-template as gcc does not error out on unknown
-# -Wno-xxx flags.
-set_flag_if_supported -Wno-undefined-var-template
-
 # Vanilla clang 6 enables the new -Wpragma-pack which warns when leaving an
 # included file which changes the current alignment.
 # As our common/pack-{start,end}.h trigger this we disable this warning.

--- a/engines/achievements.cpp
+++ b/engines/achievements.cpp
@@ -30,7 +30,7 @@
 
 namespace Common {
 
-DECLARE_SINGLETON(AchievementsManager);
+DEFINE_SINGLETON(AchievementsManager);
 
 
 AchievementsManager::AchievementsManager() {

--- a/engines/achievements.h
+++ b/engines/achievements.h
@@ -274,6 +274,8 @@ private:
 	Common::HashMap<String, Common::Array<AchievementDescription> > _achievements;
 };
 
+DECLARE_SINGLETON(AchievementsManager);
+
 /** Shortcut for accessing the Achievements Manager. */
 #define AchMan Common::AchievementsManager::instance()
 

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -502,7 +502,7 @@ void AdvancedMetaEngineDetection::composeFileHashMap(FileMap &allFiles, const Co
 /* Singleton Cache Storage for MD5 */
 
 namespace Common {
-	DECLARE_SINGLETON(MD5CacheManager);
+DEFINE_SINGLETON(MD5CacheManager);
 }
 
 // Sync with engines/game.cpp

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -583,6 +583,10 @@ private:
 	SizeHashMap sizeHashMap;
 };
 
+namespace Common {
+DECLARE_SINGLETON(MD5CacheManager);
+}
+
 /** Convenience shortcut for accessing the MD5CacheManager. */
 #define MD5Man MD5CacheManager::instance()
 /** @} */

--- a/engines/asylum/system/config.cpp
+++ b/engines/asylum/system/config.cpp
@@ -24,7 +24,7 @@
 #include "asylum/system/sound.h"
 
 namespace Common {
-DECLARE_SINGLETON(Asylum::ConfigurationManager);
+DEFINE_SINGLETON(Asylum::ConfigurationManager);
 }
 
 namespace Asylum {

--- a/engines/asylum/system/config.h
+++ b/engines/asylum/system/config.h
@@ -105,4 +105,8 @@ private:
 
 } // end of namespace Asylum
 
+namespace Common {
+DECLARE_SINGLETON(Asylum::ConfigurationManager);
+}
+
 #endif // ASYLUM_SYSTEM_CONFIG_H

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -130,7 +130,7 @@ bool ChainedGamesManager::pop(Common::String &target, int &slot) {
 }
 
 namespace Common {
-DECLARE_SINGLETON(ChainedGamesManager);
+DEFINE_SINGLETON(ChainedGamesManager);
 }
 
 Engine::Engine(OSystem *syst)

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -685,6 +685,11 @@ public:
 	bool pop(Common::String &target, int &slot);
 };
 
+namespace Common {
+DECLARE_SINGLETON(ChainedGamesManager);
+}
+
+
 /** Convenience shortcut for accessing the chained games manager. */
 #define ChainedGamesMan ChainedGamesManager::instance()
 /** @} */

--- a/engines/lure/sound.cpp
+++ b/engines/lure/sound.cpp
@@ -34,7 +34,7 @@
 #include "audio/midiparser.h"
 
 namespace Common {
-DECLARE_SINGLETON(Lure::SoundManager);
+DEFINE_SINGLETON(Lure::SoundManager);
 }
 
 namespace Lure {

--- a/engines/lure/sound.h
+++ b/engines/lure/sound.h
@@ -195,6 +195,10 @@ protected:
 
 } // End of namespace Lure
 
+namespace Common {
+DECLARE_SINGLETON(Lure::SoundManager);
+}
+
 #define Sound (::Lure::SoundManager::instance())
 
 #endif

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -618,6 +618,10 @@ private:
 	void upgradeTargetForEngineId(const Common::String &target) const;
 };
 
+namespace Common {
+DECLARE_SINGLETON(EngineManager);
+}
+
 /** Convenience shortcut for accessing the engine manager. */
 #define EngineMan EngineManager::instance()
 /** @} */

--- a/engines/nancy/state/credits.cpp
+++ b/engines/nancy/state/credits.cpp
@@ -30,7 +30,7 @@
 #include "engines/nancy/state/credits.h"
 
 namespace Common {
-DECLARE_SINGLETON(Nancy::State::Credits);
+DEFINE_SINGLETON(Nancy::State::Credits);
 }
 
 namespace Nancy {

--- a/engines/nancy/state/credits.h
+++ b/engines/nancy/state/credits.h
@@ -71,4 +71,8 @@ protected:
 } // End of namespace State
 } // End of namespace Nancy
 
+namespace Common {
+DECLARE_SINGLETON(Nancy::State::Credits);
+}
+
 #endif // NANCY_STATE_CREDITS_H

--- a/engines/nancy/state/help.cpp
+++ b/engines/nancy/state/help.cpp
@@ -30,7 +30,7 @@
 #include "engines/nancy/ui/button.h"
 
 namespace Common {
-DECLARE_SINGLETON(Nancy::State::Help);
+DEFINE_SINGLETON(Nancy::State::Help);
 }
 
 namespace Nancy {

--- a/engines/nancy/state/help.h
+++ b/engines/nancy/state/help.h
@@ -64,4 +64,8 @@ private:
 } // End of namespace State
 } // End of namespace Nancy
 
+namespace Common {
+DECLARE_SINGLETON(Nancy::State::Help);
+}
+
 #endif // NANCY_STATE_HELP_H

--- a/engines/nancy/state/logo.cpp
+++ b/engines/nancy/state/logo.cpp
@@ -29,7 +29,7 @@
 #include "engines/nancy/state/logo.h"
 
 namespace Common {
-DECLARE_SINGLETON(Nancy::State::Logo);
+DEFINE_SINGLETON(Nancy::State::Logo);
 }
 
 namespace Nancy {

--- a/engines/nancy/state/logo.h
+++ b/engines/nancy/state/logo.h
@@ -66,4 +66,8 @@ private:
 } // end of namespace State
 } // End of namespace Nancy
 
+namespace Common {
+DECLARE_SINGLETON(Nancy::State::Logo);
+}
+
 #endif // NANCY_STATE_LOGO_H

--- a/engines/nancy/state/mainmenu.cpp
+++ b/engines/nancy/state/mainmenu.cpp
@@ -29,7 +29,7 @@
 #include "engines/nancy/state/scene.h"
 
 namespace Common {
-DECLARE_SINGLETON(Nancy::State::MainMenu);
+DEFINE_SINGLETON(Nancy::State::MainMenu);
 }
 
 namespace Nancy {

--- a/engines/nancy/state/mainmenu.h
+++ b/engines/nancy/state/mainmenu.h
@@ -60,4 +60,8 @@ private:
 } // End of namespace State
 } // End of namespace Nancy
 
+namespace Common {
+DECLARE_SINGLETON(Nancy::State::MainMenu);
+}
+
 #endif // NANCY_STATE_MAINMENU_H

--- a/engines/nancy/state/map.cpp
+++ b/engines/nancy/state/map.cpp
@@ -32,7 +32,7 @@
 #include "engines/nancy/ui/button.h"
 
 namespace Common {
-DECLARE_SINGLETON(Nancy::State::Map);
+DEFINE_SINGLETON(Nancy::State::Map);
 }
 
 namespace Nancy {

--- a/engines/nancy/state/map.h
+++ b/engines/nancy/state/map.h
@@ -93,4 +93,8 @@ private:
 } // End of namespace State
 } // End of namespace Nancy
 
+namespace Common {
+DECLARE_SINGLETON(Nancy::State::Map);
+}
+
 #endif // NANCY_STATE_MAP_H

--- a/engines/nancy/state/scene.cpp
+++ b/engines/nancy/state/scene.cpp
@@ -36,7 +36,7 @@
 #include "engines/nancy/ui/button.h"
 
 namespace Common {
-DECLARE_SINGLETON(Nancy::State::Scene);
+DEFINE_SINGLETON(Nancy::State::Scene);
 }
 
 namespace Nancy {

--- a/engines/nancy/state/scene.h
+++ b/engines/nancy/state/scene.h
@@ -266,4 +266,8 @@ private:
 } // End of namespace State
 } // End of namespace Nancy
 
+namespace Common {
+DECLARE_SINGLETON(Nancy::State::Scene);
+}
+
 #endif // NANCY_STATE_SCENE_H

--- a/engines/pegasus/gamestate.cpp
+++ b/engines/pegasus/gamestate.cpp
@@ -30,7 +30,7 @@
 #include "pegasus/scoring.h"
 
 namespace Common {
-DECLARE_SINGLETON(Pegasus::GameStateManager);
+DEFINE_SINGLETON(Pegasus::GameStateManager);
 }
 
 namespace Pegasus {

--- a/engines/pegasus/gamestate.h
+++ b/engines/pegasus/gamestate.h
@@ -880,6 +880,10 @@ private:
 
 } // End of namespace Pegasus
 
+namespace Common {
+DECLARE_SINGLETON(Pegasus::GameStateManager);
+}
+
 #define GameState (::Pegasus::GameStateManager::instance())
 
 #endif

--- a/engines/pegasus/input.cpp
+++ b/engines/pegasus/input.cpp
@@ -32,7 +32,7 @@
 #include "pegasus/pegasus.h"
 
 namespace Common {
-DECLARE_SINGLETON(Pegasus::InputDeviceManager);
+DEFINE_SINGLETON(Pegasus::InputDeviceManager);
 }
 
 namespace Pegasus {

--- a/engines/pegasus/input.h
+++ b/engines/pegasus/input.h
@@ -511,6 +511,10 @@ public:
 
 } // End of namespace Pegasus
 
+namespace Common {
+DECLARE_SINGLETON(Pegasus::InputDeviceManager);
+}
+
 #define InputDevice (::Pegasus::InputDeviceManager::instance())
 
 #endif

--- a/engines/pegasus/items/biochips/arthurchip.cpp
+++ b/engines/pegasus/items/biochips/arthurchip.cpp
@@ -27,7 +27,7 @@
 #include "pegasus/items/biochips/arthurchip.h"
 
 namespace Common {
-DECLARE_SINGLETON(Pegasus::ArthurManager);
+DEFINE_SINGLETON(Pegasus::ArthurManager);
 }
 
 namespace Pegasus {

--- a/engines/pegasus/items/biochips/arthurchip.h
+++ b/engines/pegasus/items/biochips/arthurchip.h
@@ -216,6 +216,10 @@ extern ArthurChip *g_arthurChip;
 
 } // End of namespace Pegasus
 
+namespace Common {
+DECLARE_SINGLETON(Pegasus::ArthurManager);
+}
+
 #define Arthur (::Pegasus::ArthurManager::instance())
 
 #endif

--- a/engines/sludge/newfatal.cpp
+++ b/engines/sludge/newfatal.cpp
@@ -28,7 +28,7 @@
 #include "sludge/sound.h"
 
 namespace Common {
-DECLARE_SINGLETON(Sludge::FatalMsgManager);
+DEFINE_SINGLETON(Sludge::FatalMsgManager);
 }
 
 namespace Sludge {

--- a/engines/sludge/newfatal.h
+++ b/engines/sludge/newfatal.h
@@ -66,4 +66,8 @@ int fatal(const Common::String &str1, const Common::String &str2);
 
 } // End of namespace Sludge
 
+namespace Common {
+DECLARE_SINGLETON(Sludge::FatalMsgManager);
+}
+
 #endif

--- a/engines/stark/services/services.cpp
+++ b/engines/stark/services/services.cpp
@@ -22,7 +22,7 @@
 #include "engines/stark/services/services.h"
 
 namespace Common {
-DECLARE_SINGLETON(Stark::StarkServices);
+DEFINE_SINGLETON(Stark::StarkServices);
 }
 
 namespace Stark {

--- a/engines/stark/services/services.h
+++ b/engines/stark/services/services.h
@@ -112,4 +112,8 @@ public:
 
 } // End of namespace Stark
 
+namespace Common {
+DECLARE_SINGLETON(Stark::StarkServices);
+}
+
 #endif // STARK_SERVICES_SERVICES_H

--- a/engines/sword25/gfx/animationtemplateregistry.cpp
+++ b/engines/sword25/gfx/animationtemplateregistry.cpp
@@ -34,7 +34,7 @@
 #include "sword25/gfx/animationtemplate.h"
 
 namespace Common {
-DECLARE_SINGLETON(Sword25::AnimationTemplateRegistry);
+DEFINE_SINGLETON(Sword25::AnimationTemplateRegistry);
 }
 
 namespace Sword25 {

--- a/engines/sword25/gfx/animationtemplateregistry.h
+++ b/engines/sword25/gfx/animationtemplateregistry.h
@@ -53,4 +53,8 @@ public:
 
 } // End of namespace Sword25
 
+namespace Common {
+DECLARE_SINGLETON(Sword25::AnimationTemplateRegistry);
+}
+
 #endif

--- a/engines/sword25/gfx/renderobjectregistry.h
+++ b/engines/sword25/gfx/renderobjectregistry.h
@@ -47,4 +47,8 @@ class RenderObjectRegistry :
 
 } // End of namespace Sword25
 
+namespace Common {
+DECLARE_SINGLETON(Sword25::RenderObjectRegistry);
+}
+
 #endif

--- a/engines/sword25/math/regionregistry.cpp
+++ b/engines/sword25/math/regionregistry.cpp
@@ -34,7 +34,7 @@
 #include "sword25/math/region.h"
 
 namespace Common {
-DECLARE_SINGLETON(Sword25::RegionRegistry);
+DEFINE_SINGLETON(Sword25::RegionRegistry);
 }
 
 namespace Sword25 {

--- a/engines/sword25/math/regionregistry.h
+++ b/engines/sword25/math/regionregistry.h
@@ -52,4 +52,8 @@ public:
 
 } // End of namespace Sword25
 
+namespace Common {
+DECLARE_SINGLETON(Sword25::RegionRegistry);
+}
+
 #endif

--- a/engines/sword25/sword25.cpp
+++ b/engines/sword25/sword25.cpp
@@ -50,7 +50,7 @@
 #include "sword25/gfx/animationtemplateregistry.h"	// Needed so we can destroy the singleton
 #include "sword25/gfx/renderobjectregistry.h"		// Needed so we can destroy the singleton
 namespace Common {
-DECLARE_SINGLETON(Sword25::RenderObjectRegistry);
+DEFINE_SINGLETON(Sword25::RenderObjectRegistry);
 }
 #include "sword25/math/regionregistry.h"			// Needed so we can destroy the singleton
 

--- a/engines/testbed/config-params.cpp
+++ b/engines/testbed/config-params.cpp
@@ -25,7 +25,7 @@
 #include "testbed/config-params.h"
 
 namespace Common {
-DECLARE_SINGLETON(Testbed::ConfigParams);
+DEFINE_SINGLETON(Testbed::ConfigParams);
 }
 
 namespace Testbed {

--- a/engines/testbed/config-params.h
+++ b/engines/testbed/config-params.h
@@ -105,4 +105,8 @@ public:
 
 } // End of Namespace Testbed
 
+namespace Common {
+DECLARE_SINGLETON(Testbed::ConfigParams);
+}
+
 #endif

--- a/engines/wintermute/base/base_engine.cpp
+++ b/engines/wintermute/base/base_engine.cpp
@@ -32,7 +32,7 @@
 #include "engines/wintermute/system/sys_class_registry.h"
 #include "common/system.h"
 namespace Common {
-DECLARE_SINGLETON(Wintermute::BaseEngine);
+DEFINE_SINGLETON(Wintermute::BaseEngine);
 }
 
 namespace Wintermute {

--- a/engines/wintermute/base/base_engine.h
+++ b/engines/wintermute/base/base_engine.h
@@ -92,4 +92,8 @@ public:
 
 } // End of namespace Wintermute
 
+namespace Common {
+DECLARE_SINGLETON(Wintermute::BaseEngine);
+}
+
 #endif

--- a/graphics/cursorman.cpp
+++ b/graphics/cursorman.cpp
@@ -25,7 +25,7 @@
 #include "common/stack.h"
 
 namespace Common {
-DECLARE_SINGLETON(Graphics::CursorManager);
+DEFINE_SINGLETON(Graphics::CursorManager);
 }
 
 namespace Graphics {

--- a/graphics/cursorman.h
+++ b/graphics/cursorman.h
@@ -247,7 +247,12 @@ private:
 	bool _locked;
 };
 /** @} */
+
 } // End of namespace Graphics
+
+namespace Common {
+DECLARE_SINGLETON(Graphics::CursorManager);
+}
 
 #define CursorMan	(::Graphics::CursorManager::instance())
 

--- a/graphics/fontman.cpp
+++ b/graphics/fontman.cpp
@@ -26,7 +26,7 @@
 #include "common/translation.h"
 
 namespace Common {
-DECLARE_SINGLETON(Graphics::FontManager);
+DEFINE_SINGLETON(Graphics::FontManager);
 }
 
 namespace Graphics {

--- a/graphics/fontman.h
+++ b/graphics/fontman.h
@@ -119,6 +119,10 @@ private:
 /** @} */
 } // End of namespace Graphics
 
+namespace Common {
+DECLARE_SINGLETON(Graphics::FontManager);
+}
+
 /** @addtogroup graphics_fontman
  *  @{
  */

--- a/graphics/fonts/ttf.cpp
+++ b/graphics/fonts/ttf.cpp
@@ -1080,7 +1080,7 @@ Font *findTTFace(const Common::Array<Common::String> &files, const Common::U32St
 } // End of namespace Graphics
 
 namespace Common {
-DECLARE_SINGLETON(Graphics::TTFLibrary);
+DEFINE_SINGLETON(Graphics::TTFLibrary);
 } // End of namespace Common
 
 #endif

--- a/graphics/opengl/context.cpp
+++ b/graphics/opengl/context.cpp
@@ -40,7 +40,7 @@ static GLADapiproc loadFunc(const char *name) {
 #endif
 
 namespace Common {
-DECLARE_SINGLETON(OpenGL::Context);
+DEFINE_SINGLETON(OpenGL::Context);
 }
 
 namespace OpenGL {

--- a/graphics/opengl/context.h
+++ b/graphics/opengl/context.h
@@ -127,6 +127,10 @@ private:
 
 } // End of namespace OpenGL
 
+namespace Common {
+DECLARE_SINGLETON(OpenGL::Context);
+}
+
 /** Shortcut for accessing the active OpenGL context. */
 #define OpenGLContext OpenGL::Context::instance()
 

--- a/graphics/scalerplugin.h
+++ b/graphics/scalerplugin.h
@@ -236,6 +236,10 @@ public:
 	void updateOldSettings();
 };
 
+namespace Common {
+DECLARE_SINGLETON(ScalerManager);
+}
+
 /** Convenience shortcut for accessing singleton */
 #define ScalerMan ScalerManager::instance()
 

--- a/graphics/yuv_to_rgb.cpp
+++ b/graphics/yuv_to_rgb.cpp
@@ -86,7 +86,7 @@
 #include "graphics/yuv_to_rgb.h"
 
 namespace Common {
-DECLARE_SINGLETON(Graphics::YUVToRGBManager);
+DEFINE_SINGLETON(Graphics::YUVToRGBManager);
 }
 
 namespace Graphics {

--- a/graphics/yuv_to_rgb.h
+++ b/graphics/yuv_to_rgb.h
@@ -134,6 +134,10 @@ private:
  /** @} */
 } // End of namespace Graphics
 
+namespace Common {
+DECLARE_SINGLETON(Graphics::YUVToRGBManager);
+}
+
 #define YUVToRGBMan (::Graphics::YUVToRGBManager::instance())
 
 #endif

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -25,7 +25,7 @@
 #ifdef ENABLE_EVENTRECORDER
 
 namespace Common {
-DECLARE_SINGLETON(GUI::EventRecorder);
+DEFINE_SINGLETON(GUI::EventRecorder);
 }
 
 #include "common/debug-channels.h"

--- a/gui/EventRecorder.h
+++ b/gui/EventRecorder.h
@@ -253,6 +253,10 @@ private:
 
 } // End of namespace GUI
 
+namespace Common {
+DECLARE_SINGLETON(GUI::EventRecorder);
+}
+
 #endif // ENABLE_EVENTRECORDER
 
 #endif

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -46,7 +46,7 @@
 #include "graphics/cursorman.h"
 
 namespace Common {
-DECLARE_SINGLETON(GUI::GuiManager);
+DEFINE_SINGLETON(GUI::GuiManager);
 }
 
 namespace GUI {

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -228,4 +228,8 @@ protected:
 
 } // End of namespace GUI
 
+namespace Common {
+DECLARE_SINGLETON(GUI::GuiManager);
+}
+
 #endif


### PR DESCRIPTION
Another take after #4383.
This has the advantage to be a one line fix which seem to silence the warnings.
Let's see what Github CI think about it.