### PR TITLE
MOHAWK: Fix wrong language for French lilmonster

### DIFF
--- a/engines/mohawk/detection_tables.h
+++ b/engines/mohawk/detection_tables.h
@@ -2413,7 +2413,7 @@ static const MohawkGameDescription gameDescriptions[] = {
 			"lilmonster",
 			"",
 			AD_ENTRY1("lmasf.lb", "8c22e79c97a86827d56b4c596066dcea"),
-			Common::EN_ANY,
+			Common::FR_FRA,
 			Common::kPlatformWindows,
 			ADGF_NO_FLAGS,
 			GUIO1(GUIO_NOASPECT)


### PR DESCRIPTION
See the original ticket (https://bugs.scummvm.org/ticket/5724) for confirmation: The French version was accidentally added as English. This can also be confirmed by looking at the filename (lmas**f**.lb), or simply by starting the game.