### PR TITLE
COMMON: Allow DisposablePtr to be backed by SharedPtr

### DIFF
--- a/audio/audiostream.h
+++ b/audio/audiostream.h
@@ -157,6 +157,20 @@ public:
 	 */
 	LoopingAudioStream(RewindableAudioStream *stream, uint loops, DisposeAfterUse::Flag disposeAfterUse = DisposeAfterUse::YES, bool rewind = true);
 
+	/**
+	 * Create a looping audio stream object.
+	 *
+	 * On creation of the LoopingAudioStream object, the underlying stream will be rewound.
+	 *
+	 * @see makeLoopingAudioStream
+	 *
+	 * @param stream  The stream to loop.
+	 * @param loops   How often to loop (0 = infinite).
+	 * @param disposeAfterUse  Destroy the stream after the LoopingAudioStream has finished playback.
+	 * @param rewind  If true, rewind the underlying stream.
+	 */
+	LoopingAudioStream(Common::DisposablePtr<RewindableAudioStream>&& stream, uint loops, bool rewind = true);
+
 	int readBuffer(int16 *buffer, const int numSamples);
 	bool endOfData() const;
 	bool endOfStream() const;

--- a/audio/mixer.cpp
+++ b/audio/mixer.cpp
@@ -635,11 +635,8 @@ Timestamp Channel::getElapsedTime() {
 void Channel::loop() {
 	assert(_stream);
 
-	Audio::RewindableAudioStream *rewindableStream = dynamic_cast<RewindableAudioStream *>(_stream.get());
-	if (rewindableStream) {
-		DisposeAfterUse::Flag dispose = _stream.getDispose();
-		_stream.disownPtr();
-		Audio::LoopingAudioStream *loopingStream = new Audio::LoopingAudioStream(rewindableStream, 0, dispose, false);
+	if (_stream.isDynamicallyCastable<RewindableAudioStream>()) {
+		Audio::LoopingAudioStream *loopingStream = new Audio::LoopingAudioStream(Common::move(_stream.moveAndDynamicCast<RewindableAudioStream>()), 0, false);
 		_stream.reset(loopingStream, DisposeAfterUse::YES);
 	}
 }

--- a/common/ptr.h
+++ b/common/ptr.h
@@ -709,24 +709,11 @@ public:
  	}
 
 	/**
-	 * Clears the pointer without destroying the old object.
-	 */
-	void disownPtr() {
-		_pointer = nullptr;
-		_dispose = DisposeAfterUse::NO;
-	}
-
-	/**
 	 * Returns the plain pointer value.
 	 *
 	 * @return the pointer the DisposablePtr manages
 	 */
 	PointerType get() const { return _pointer; }
-
-	/**
-	 * Returns the pointer's dispose flag.
-	 */
-	DisposeAfterUse::Flag getDispose() const { return _dispose; }
 
 	template <class T2, class DL2>
 	friend class DisposablePtr;

--- a/common/ptr.h
+++ b/common/ptr.h
@@ -657,6 +657,10 @@ public:
 	typedef T &ReferenceType;
 
 	explicit DisposablePtr(PointerType o, DisposeAfterUse::Flag dispose) : _pointer(o), _dispose(dispose) {}
+	DisposablePtr(DisposablePtr<T>&& o) : _pointer(o._pointer), _dispose(o._dispose) {
+		o._pointer = nullptr;
+		o._dispose = DisposeAfterUse::NO;
+	}
 
 	~DisposablePtr() {
 		if (_dispose) DL()(_pointer);

--- a/common/ptr.h
+++ b/common/ptr.h
@@ -691,6 +691,23 @@ public:
 		reset(nullptr, DisposeAfterUse::NO);
 	}
 
+	template <class T2>
+	bool isDynamicallyCastable() {
+		return dynamic_cast<T2 *>(_pointer) != nullptr;
+	}
+
+	/* Destroys the smart pointer while returning a pointer to
+	   assign to a new object.
+ 	 */
+	template <class T2, class DL2 = DefaultDeleter<T2> >
+	DisposablePtr<T2, DL2> moveAndDynamicCast() {
+		DisposablePtr<T2, DL2> ret(
+			dynamic_cast<T2 *>(_pointer), _dispose);
+ 		_pointer = nullptr;
+ 		_dispose = DisposeAfterUse::NO;
+		return ret;
+ 	}
+
 	/**
 	 * Clears the pointer without destroying the old object.
 	 */
@@ -710,6 +727,9 @@ public:
 	 * Returns the pointer's dispose flag.
 	 */
 	DisposeAfterUse::Flag getDispose() const { return _dispose; }
+
+	template <class T2, class DL2>
+	friend class DisposablePtr;
 
 private:
 	PointerType           _pointer;


### PR DESCRIPTION
Currently DisposablePtr Allows to transparently switch between raw
pointer and ScopedPtr semantics. Add a possibility to have SharedPtr
semantics as well.
    
Kill getDispose and disownPtr as they unnecessarily expose internal details
    
Their only user is Channel::loop together with its callee LoopingAudioStream,
switch them to a more modern and transparent Common::move semantics