### PR TITLE
GUI: Fix browsing in presence of files with \1 in names

### DIFF
--- a/gui/browser.cpp
+++ b/gui/browser.cpp
@@ -242,9 +242,9 @@ void BrowserDialog::updateListing() {
 		}
 
 		if (i->isDirectory())
-			list.push_back(color + Common::U32String(i->getName() + "/"));
+			list.push_back(color + ListWidget::escapeString(Common::U32String(i->getName()) + "/"));
 		else
-			list.push_back(color + Common::U32String(i->getName()));
+			list.push_back(color + ListWidget::escapeString(Common::U32String(i->getName())));
 	}
 
 	_fileList->setList(list);

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -860,6 +860,19 @@ Common::U32String ListWidget::stripGUIformatting(const Common::U32String &str) {
 	return stripped;
 }
 
+Common::U32String ListWidget::escapeString(const Common::U32String &str) {
+	Common::U32String escaped;
+	const uint32 *s = str.u32_str();
+
+	while (*s) {
+		if (*s == '\001')
+			escaped += '\001';
+		escaped += *s++;
+	}
+
+	return escaped;
+}
+
 void ListWidget::drawFormattedText(const Common::Rect &r, const Common::U32String &str, ThemeEngine::WidgetStateInfo state,
 				Graphics::TextAlign align, ThemeEngine::TextInversionState inverted, int deltax, bool useEllipsis,
 				ThemeEngine::FontColor color) {

--- a/gui/widgets/list.h
+++ b/gui/widgets/list.h
@@ -154,6 +154,7 @@ public:
 	static Common::U32String getThemeColor(ThemeEngine::FontColor color);
 	static ThemeEngine::FontColor getThemeColor(const Common::U32String &color);
 	static Common::U32String stripGUIformatting(const Common::U32String &str);
+	static Common::U32String escapeString(const Common::U32String &str);
 
 protected:
 	void drawWidget() override;


### PR DESCRIPTION
Currently file containing \1 in its name causes erroring out with "Wrong string format".

Hades Challenge Mac partiton has such files in the root. So if they are copied then it's impossible to select folder with Hades Challenge. Many tools skip (as they are hidden) or rename them while saving original name in AppleDouble or MacBinary. dumper-companion also renames them but scummvm transparently decodes punycode back.

