### PR TITLE
CONFIGURE: Allow to enable all subengines of an engine

### DIFF
--- a/configure
+++ b/configure
@@ -3699,7 +3699,7 @@ case $_backend in
 		append_var LIBS "-framework QuartzCore -framework CoreFoundation -framework Foundation"
 		append_var LIBS "-framework AudioToolbox -framework CoreAudio -framework SystemConfiguration "
 		append_var LIBS "-framework GameController"
-		if [ $_host_cpu = 'aarch64' ]; then
+		if test "$_host_cpu" = 'aarch64' ; then
 			append_var LDFLAGS "-miphoneos-version-min=7.1 -arch arm64"
 			append_var CFLAGS "-miphoneos-version-min=7.1 -arch arm64"
 			append_var CXXFLAGS "-miphoneos-version-min=7.1 -arch arm64"

--- a/configure
+++ b/configure
@@ -692,15 +692,30 @@ engine_enable() {
 		fi
 	fi
 
-	if test "$opt" = "static" -o "$opt" = "dynamic" -o "$opt" = "yes" ; then
-		if test "`get_engine_name ${engine}`" != "" ; then
-			set_var _engine_${engine}_build "$opt"
-		else
-			engine_option_error ${engine}
-		fi
-	else
+	if test "$opt" != "static" -a "$opt" != "dynamic" -a "$opt" != "yes" ; then
 		option_error
+		return
 	fi
+
+	subengines=
+	if test "${engine%_all}" != "${engine}" ; then
+		engine="${engine%_all}"
+		subengines=$(get_engine_subengines ${engine})
+		if test "$subengines" = "" ; then
+			engine_option_error "${engine}*"
+			return
+		fi
+	fi
+
+	if test "`get_engine_name ${engine}`" = "" ; then
+		engine_option_error ${engine}
+		return
+	fi
+
+	set_var _engine_${engine}_build "$opt"
+	for subengine in $subengines ; do
+		set_var _engine_${subengine}_build "$opt"
+	done
 }
 
 # Disable the given engine


### PR DESCRIPTION
By specifying a `*` at the end of the engine in `--enable-engine`, all of its subengines get enabled too.
The `*` character could be changed to something else (like `+`) to avoid globbing in shell.

The code is slightly refactored to be more readable by avoiding nested blocks.
Use of return is superfluous as the error functions make use of exit but it was already done like that above.

In addition I changed a `[` to `test` for consistency.