### PR TITLE
SCUMM: Properly document '.' and (Full Throttle) Shift-V shortcuts in help

### DIFF
--- a/engines/scumm/help.cpp
+++ b/engines/scumm/help.cpp
@@ -71,8 +71,7 @@ void ScummHelp::updateStrings(byte gameId, byte version, Common::Platform platfo
 	case 1:
 		title = _("Common keyboard commands:");
 		ADD_BIND("F5", _("Save / Load dialog"));
-		if (version >= 5)
-			ADD_BIND(".", _("Skip line of text"));
+		ADD_BIND(".", _("Skip line of text"));
 		ADD_BIND(_("Esc"), _("Skip cutscene"));
 		ADD_BIND(_("Space"), _("Pause game"));
 		ADD_BIND(_("Ctrl") + U32String(" 0-9"), _("Load saved game 1-10"));

--- a/engines/scumm/help.cpp
+++ b/engines/scumm/help.cpp
@@ -232,6 +232,9 @@ void ScummHelp::updateStrings(byte gameId, byte version, Common::Platform platfo
 			ADD_BIND("i", _("Inventory"));
 			ADD_BIND("p", _("Punch"));
 			ADD_BIND("k", _("Kick"));
+			ADD_LINE;
+			// I18N: A shortcut to skip the bike fight and derby sequences in Full Throttle
+			ADD_BIND(_("Shift") + U32String(" v"), _("Fight cheat"));
 			break;
 		case GID_DIG:
 			ADD_BIND("e", _("Examine"));


### PR DESCRIPTION
Two small suggestions for the about dialog in the SCUMM games. I've seen people on Twitch having a look at it, so it still has some use!

1. Always document the '`.`' shortcut to skip lines
    * It was restricted to v5+ [a long time ago](http://bugs.scummvm.org/ticket/942), but (fortunately) it looks like we now always implement it (tested while going back to Maniac Mansion v1).
2. Document the original Shift + V cheat shortcut to pass the bike fight / derby action sequences in Full Throttle
    * We're already documenting a similar cheat shortcut for Indy4 fights.
    * (I've added a small `ADD_LINE;` before it, since it's a cheat and not a regular control.)

OK?