### PR TITLE
SCUMM: INSANE: Fix one of the counters when Ben uses the goggles

### DIFF
--- a/engines/scumm/insane/insane_scenes.cpp
+++ b/engines/scumm/insane/insane_scenes.cpp
@@ -1065,7 +1065,7 @@ void Insane::postCase16(byte *renderBitmap, int32 codecparam, int32 setupsan12,
 	Common::sprintf_s(buf, "^f01%04d", tmp);
 	smlayer_showStatusMsg(-1, renderBitmap, codecparam, 202, 168, 1, 2, 0, "%s", buf);
 
-	Common::sprintf_s(buf, "^f01%02o", curFrame & 0xff);
+	Common::sprintf_s(buf, "^f01%02x", curFrame & 0xff);
 	smlayer_showStatusMsg(-1, renderBitmap, codecparam, 240, 168, 1, 2, 0, "%s", buf);
 	smlayer_showStatusMsg(-1, renderBitmap, codecparam, 170, 43, 1, 2, 0, "%s", buf);
 


### PR DESCRIPTION
In Full Throttle, when Ben uses the goggles to find the secret area in the old mine road, the first and last number being displayed on that view should be formatted in hexadecimal in the original game (yeah), not octal.

Here it is in DREAMM (notice the two `FC` counters):

![ft-hex-dreamm](https://user-images.githubusercontent.com/9024526/201216051-c75ebb26-2722-4e34-bc89-edccad66df18.png)

in the 2002 Windows interpreter by Aaron Giles:

![ft-hex-aaron-giles](https://user-images.githubusercontent.com/9024526/201216177-f12dac48-fc43-4459-b07a-12b28478c542.png)

and in ScummVM before this change (notice the `164` counters):

![ft-hex-scummvm](https://user-images.githubusercontent.com/9024526/201216278-cd238221-9725-479c-8c47-4268ad751023.png)

Checked against the DOS version in DREAMM, the 2002 Windows interpreter from Aaron Giles, and the 2017 remaster (all in French though...). I also have the Macintosh release, but I think you'll forgive me if I stop there :)

AFAICS, the 4 counters have the following maximum values, when I visually compare the results while playing with the various interpreters:

```
FF+
78+ 1300- FF+
```

(`+` means that it increments, `-` means that it decrements.)

So yeah, the other values seem fine.

## How to test

1. Start the game with boot param `551`
2. Left-click for the old mine road
3. Once you're there, right-click to put on the goggles
4. Watch out for the first and last counter values on that view

(If Ben is suddenly stuck in a loop where he puts and removes his goggles forever, then you've fallen into the other issue I'm trying to investigate. Restart from step 1 for now.)
