### PR TITLE
ANDROID: Map gamepad inputs to joystick events

### DIFF
--- a/backends/platform/android/android.h
+++ b/backends/platform/android/android.h
@@ -160,6 +160,8 @@ private:
 	int _trackball_scale;
 	int _dpad_scale;
 	int _joystick_scale;
+	int _axisPosX;
+	int _axisPosY;
 //	int _fingersDown;
 	int _firstPointerId;
 	int _secondPointerId;

--- a/backends/platform/android/android.h
+++ b/backends/platform/android/android.h
@@ -160,8 +160,6 @@ private:
 	int _trackball_scale;
 	int _dpad_scale;
 	int _joystick_scale;
-	int _axisPosX;
-	int _axisPosY;
 //	int _fingersDown;
 	int _firstPointerId;
 	int _secondPointerId;

--- a/backends/platform/android/events.cpp
+++ b/backends/platform/android/events.cpp
@@ -1106,10 +1106,10 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 	case JE_GAMEPAD:
 		switch (arg1) {
 		case AKEY_EVENT_ACTION_DOWN:
-			e.type = Common::EVENT_KEYDOWN;
+			e.type = Common::EVENT_JOYBUTTON_DOWN;
 			break;
 		case AKEY_EVENT_ACTION_UP:
-			e.type = Common::EVENT_KEYUP;
+			e.type = Common::EVENT_JOYBUTTON_UP;
 			break;
 		default:
 			LOGE("unhandled jaction on gamepad key: %d", arg1);
@@ -1117,32 +1117,48 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 		}
 
 		switch (arg2) {
+		case AKEYCODE_BUTTON_START:
+			e.joystick.button = Common::JOYSTICK_BUTTON_START;
+			break;
+
+		case AKEYCODE_BUTTON_SELECT:
+			e.joystick.button = Common::JOYSTICK_BUTTON_BACK;
+			break;
+
+		case AKEYCODE_BUTTON_MODE:
+			e.joystick.button = Common::JOYSTICK_BUTTON_GUIDE;
+			break;
+
 		case AKEYCODE_BUTTON_A:
+			e.joystick.button = Common::JOYSTICK_BUTTON_A;
+			break;
+
 		case AKEYCODE_BUTTON_B:
-			switch (arg1) {
-			case AKEY_EVENT_ACTION_DOWN:
-				e.type = (arg2 == AKEYCODE_BUTTON_A?
-					  Common::EVENT_LBUTTONDOWN :
-					  Common::EVENT_RBUTTONDOWN);
-				break;
-			case AKEY_EVENT_ACTION_UP:
-				e.type = (arg2 == AKEYCODE_BUTTON_A?
-					  Common::EVENT_LBUTTONUP :
-					  Common::EVENT_RBUTTONUP);
-				break;
-			}
-
-			e.mouse = dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
-
+			e.joystick.button = Common::JOYSTICK_BUTTON_B;
 			break;
 
 		case AKEYCODE_BUTTON_X:
-			e.kbd.keycode = Common::KEYCODE_ESCAPE;
-			e.kbd.ascii = Common::ASCII_ESCAPE;
+			e.joystick.button = Common::JOYSTICK_BUTTON_X;
 			break;
 
 		case AKEYCODE_BUTTON_Y:
-			e.type = Common::EVENT_MAINMENU;
+			e.joystick.button = Common::JOYSTICK_BUTTON_Y;
+			break;
+
+		case AKEYCODE_BUTTON_L1:
+			e.joystick.button = Common::JOYSTICK_BUTTON_LEFT_SHOULDER;
+			break;
+
+		case AKEYCODE_BUTTON_R1:
+			e.joystick.button = Common::JOYSTICK_BUTTON_RIGHT_SHOULDER;
+			break;
+
+		case AKEYCODE_BUTTON_THUMBL:
+			e.joystick.button = Common::JOYSTICK_BUTTON_LEFT_STICK;
+			break;
+
+		case AKEYCODE_BUTTON_THUMBR:
+			e.joystick.button = Common::JOYSTICK_BUTTON_RIGHT_STICK;
 			break;
 
 		default:

--- a/backends/platform/android/events.cpp
+++ b/backends/platform/android/events.cpp
@@ -1175,18 +1175,14 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 		switch (arg1) {
 		// AMOTION_EVENT_ACTION_MOVE is 2 in NDK (https://developer.android.com/ndk/reference/group/input)
 		case AMOTION_EVENT_ACTION_MOVE:
-			// already multiplied by 100
-			_axisPosX = (int32)arg2 * Common::JOYAXIS_MAX / _eventScaleX;
-			_axisPosY = (int32)arg3 * Common::JOYAXIS_MAX / _eventScaleY;
-
 			e.type = Common::EVENT_JOYAXIS_MOTION;
 
 			e.joystick.axis = Common::JOYSTICK_AXIS_LEFT_STICK_X;
-			e.joystick.position = CLIP<int32>(_axisPosX, Common::JOYAXIS_MIN, Common::JOYAXIS_MAX);
+			e.joystick.position = CLIP<int32>(arg2, Common::JOYAXIS_MIN, Common::JOYAXIS_MAX);
 			pushEvent(e);
 
 			e.joystick.axis = Common::JOYSTICK_AXIS_LEFT_STICK_Y;
-			e.joystick.position = CLIP<int32>(_axisPosY, Common::JOYAXIS_MIN, Common::JOYAXIS_MAX);
+			e.joystick.position = CLIP<int32>(arg3, Common::JOYAXIS_MIN, Common::JOYAXIS_MAX);
 			pushEvent(e);
 
 			break;

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMEventsBase.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMEventsBase.java
@@ -60,6 +60,9 @@ public class ScummVMEventsBase implements
 	public static final int TOUCH_MODE_GAMEPAD = 2;
 	public static final int TOUCH_MODE_MAX = 3;
 
+	public static final int JOYSTICK_AXIS_MAX = 32767;
+	public static final float JOYSTICK_AXIS_HAT_SCALE = 0.33f;
+
 	final protected Context _context;
 	final protected ScummVM _scummvm;
 	final protected GestureDetector _gd;

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMEventsModern.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMEventsModern.java
@@ -112,6 +112,8 @@ public class ScummVMEventsModern extends ScummVMEventsBase {
 	}
 
 	private void processJoystickInput(MotionEvent event, int historyPos) {
+		// TODO: make left stick, right stick, and d-pad distinguishable
+		// from each other. Also, handle analog triggers.
 
 		InputDevice inputDevice = event.getDevice();
 
@@ -121,7 +123,9 @@ public class ScummVMEventsModern extends ScummVMEventsBase {
 		float x = getCenteredAxis(event, inputDevice, MotionEvent.AXIS_X, historyPos);
 		//Log.d(ScummVM.LOG_TAG, "JOYSTICK - LEFT: x= " +x);
 		if (x == 0) {
-			x = getCenteredAxis(event, inputDevice, MotionEvent.AXIS_HAT_X, historyPos);
+			// reducing to 1/3 since hat axis is non-analog, and 100% of axis max
+			// is way too fast when used for cursor movement
+			x = getCenteredAxis(event, inputDevice, MotionEvent.AXIS_HAT_X, historyPos) * 0.33f;
 			//Log.d(ScummVM.LOG_TAG, "JOYSTICK - HAT: x= " +x);
 		}
 		if (x == 0) {
@@ -135,7 +139,7 @@ public class ScummVMEventsModern extends ScummVMEventsBase {
 		float y = getCenteredAxis(event, inputDevice, MotionEvent.AXIS_Y, historyPos);
 		//Log.d(ScummVM.LOG_TAG, "JOYSTICK - LEFT: y= " +y);
 		if (y == 0) {
-			y = getCenteredAxis(event, inputDevice, MotionEvent.AXIS_HAT_Y, historyPos);
+			y = getCenteredAxis(event, inputDevice, MotionEvent.AXIS_HAT_Y, historyPos) * 0.33f;
 			//Log.d(ScummVM.LOG_TAG, "JOYSTICK - HAT: y= " +y);
 		}
 		if (y == 0) {
@@ -149,10 +153,11 @@ public class ScummVMEventsModern extends ScummVMEventsBase {
 		if (Math.abs(x * 100) < 20.0f && Math.abs(y * 100) < 20.0f) {
 			//Log.d(ScummVM.LOG_TAG, "JOYSTICK - pushEvent(): STOPPED: " + (int)(x * 100) + " y= " + (int)(y * 100));
 			removeMessages();
-			// do the move anyway, just don't repeat
+			// do the move, then signal the joystick has returned to center pos
 			repeatMove();
 			repeatingX = 0.0f;
 			repeatingY = 0.0f;
+			repeatMove();
 		} else {
 			//Log.d(ScummVM.LOG_TAG, "JOYSTICK - pushEvent(): x= " + (int)(x * 100) + " y= " + (int)(y * 100));
 			if (repeatingX != 0.0f || repeatingY != 0.0f) {

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMEventsModern.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMEventsModern.java
@@ -105,8 +105,8 @@ public class ScummVMEventsModern extends ScummVMEventsBase {
 
 	private boolean repeatMove() {
 		_scummvm.pushEvent(JE_JOYSTICK, MotionEvent.ACTION_MOVE,
-			(int) (repeatingX * 100),
-			(int) (repeatingY * 100),
+			(int) (repeatingX * JOYSTICK_AXIS_MAX),
+			(int) (repeatingY * JOYSTICK_AXIS_MAX),
 			0, 0, 0);
 		return true;
 	}
@@ -125,7 +125,7 @@ public class ScummVMEventsModern extends ScummVMEventsBase {
 		if (x == 0) {
 			// reducing to 1/3 since hat axis is non-analog, and 100% of axis max
 			// is way too fast when used for cursor movement
-			x = getCenteredAxis(event, inputDevice, MotionEvent.AXIS_HAT_X, historyPos) * 0.33f;
+			x = getCenteredAxis(event, inputDevice, MotionEvent.AXIS_HAT_X, historyPos) * JOYSTICK_AXIS_HAT_SCALE;
 			//Log.d(ScummVM.LOG_TAG, "JOYSTICK - HAT: x= " +x);
 		}
 		if (x == 0) {
@@ -139,7 +139,7 @@ public class ScummVMEventsModern extends ScummVMEventsBase {
 		float y = getCenteredAxis(event, inputDevice, MotionEvent.AXIS_Y, historyPos);
 		//Log.d(ScummVM.LOG_TAG, "JOYSTICK - LEFT: y= " +y);
 		if (y == 0) {
-			y = getCenteredAxis(event, inputDevice, MotionEvent.AXIS_HAT_Y, historyPos) * 0.33f;
+			y = getCenteredAxis(event, inputDevice, MotionEvent.AXIS_HAT_Y, historyPos) * JOYSTICK_AXIS_HAT_SCALE;
 			//Log.d(ScummVM.LOG_TAG, "JOYSTICK - HAT: y= " +y);
 		}
 		if (y == 0) {
@@ -150,7 +150,7 @@ public class ScummVMEventsModern extends ScummVMEventsBase {
 		// extra filter to stop repetition in order to avoid cases when android does not send onGenericMotionEvent()
 		// for small x or y (while abs is still larger than range.getflat())
 		// In such case we would end up with a slow moving "mouse" cursor - so we need this extra filter
-		if (Math.abs(x * 100) < 20.0f && Math.abs(y * 100) < 20.0f) {
+		if (Math.abs(x) < 0.2f && Math.abs(y) < 0.2f) {
 			//Log.d(ScummVM.LOG_TAG, "JOYSTICK - pushEvent(): STOPPED: " + (int)(x * 100) + " y= " + (int)(y * 100));
 			removeMessages();
 			// do the move, then signal the joystick has returned to center pos


### PR DESCRIPTION
This is an attempt to address [ticket #13909](https://bugs.scummvm.org/ticket/13909).

Previously A and B buttons were sending to left and right click events, X was sending an ESC key event, and Y was opening the system menu. This commit changes those and wires up additional gamepad buttons to the associated Joystick events instead so that more gamepad buttons can be used.