### PR TITLE
COMMON: Allow games to use overlay for something else than GUI

### DIFF
--- a/backends/graphics/android/android-graphics.h
+++ b/backends/graphics/android/android-graphics.h
@@ -90,7 +90,7 @@ public:
 protected:
 	void setSystemMousePosition(const int x, const int y) override {}
 
-	void showOverlay() override;
+	void showOverlay(bool inGUI) override;
 	void hideOverlay() override;
 
 

--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -86,7 +86,7 @@ public:
 	virtual void setFocusRectangle(const Common::Rect& rect) = 0;
 	virtual void clearFocusRectangle() = 0;
 
-	virtual void showOverlay() = 0;
+	virtual void showOverlay(bool inGUI) = 0;
 	virtual void hideOverlay() = 0;
 	virtual bool isOverlayVisible() const = 0;
 	virtual Graphics::PixelFormat getOverlayFormat() const = 0;

--- a/backends/graphics/null/null-graphics.h
+++ b/backends/graphics/null/null-graphics.h
@@ -71,7 +71,7 @@ public:
 	void setFocusRectangle(const Common::Rect& rect) override {}
 	void clearFocusRectangle() override {}
 
-	void showOverlay() override { _overlayVisible = true; }
+	void showOverlay(bool inGUI) override { _overlayVisible = true; }
 	void hideOverlay() override { _overlayVisible = false; }
 	bool isOverlayVisible() const override { return _overlayVisible; }
 	Graphics::PixelFormat getOverlayFormat() const override { return Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0); }

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -403,7 +403,7 @@ protected:
 	Common::Rect _focusRect;
 #endif
 
-	virtual void addDirtyRect(int x, int y, int w, int h, bool realCoordinates = false);
+	virtual void addDirtyRect(int x, int y, int w, int h, bool inOverlay, bool realCoordinates = false);
 
 	virtual void drawMouse();
 	virtual void undrawMouse();

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -44,6 +44,7 @@ public:
 		_windowWidth(0),
 		_windowHeight(0),
 		_overlayVisible(false),
+		_overlayInGUI(false),
 		_gameScreenShakeXOffset(0),
 		_gameScreenShakeYOffset(0),
 		_forceRedraw(false),
@@ -53,13 +54,22 @@ public:
 		_cursorNeedsRedraw(false),
 		_cursorLastInActiveArea(true) {}
 
-	void showOverlay() override {
+	void showOverlay(bool inGUI) override {
+		_overlayInGUI = inGUI;
+
+		if (inGUI) {
+			_activeArea.drawRect = _overlayDrawRect;
+			_activeArea.width = getOverlayWidth();
+			_activeArea.height = getOverlayHeight();
+		} else {
+			_activeArea.drawRect = _gameDrawRect;
+			_activeArea.width = getWidth();
+			_activeArea.height = getHeight();
+		}
+
 		if (_overlayVisible)
 			return;
 
-		_activeArea.drawRect = _overlayDrawRect;
-		_activeArea.width = getOverlayWidth();
-		_activeArea.height = getOverlayHeight();
 		_overlayVisible = true;
 		_forceRedraw = true;
 		notifyActiveAreaChanged();
@@ -68,6 +78,8 @@ public:
 	void hideOverlay() override {
 		if (!_overlayVisible)
 			return;
+
+		_overlayInGUI = true;
 
 		_activeArea.drawRect = _gameDrawRect;
 		_activeArea.width = getWidth();
@@ -203,7 +215,7 @@ protected:
 			populateDisplayAreaDrawRect(overlayAspect, getOverlayWidth(), getOverlayHeight(), _overlayDrawRect);
 		}
 
-		if (_overlayVisible) {
+		if (_overlayInGUI) {
 			_activeArea.drawRect = _overlayDrawRect;
 			_activeArea.width = getOverlayWidth();
 			_activeArea.height = getOverlayHeight();
@@ -295,6 +307,11 @@ protected:
 	 * is visible or not.
 	 */
 	bool _overlayVisible;
+
+	/**
+	 * Whether when overlay is shown, mouse coordinates depend on window or game screen size
+	 */
+	bool _overlayInGUI;
 
 	/**
 	 * The offset by which the screen is moved horizontally.

--- a/backends/graphics3d/android/android-graphics3d.h
+++ b/backends/graphics3d/android/android-graphics3d.h
@@ -70,7 +70,7 @@ public:
 	virtual void setFeatureState(OSystem::Feature f, bool enable) override;
 	virtual bool getFeatureState(OSystem::Feature f) const override;
 
-	virtual void showOverlay() override;
+	virtual void showOverlay(bool inGUI) override;
 	virtual void hideOverlay() override;
 	virtual void clearOverlay() override;
 	virtual void grabOverlay(Graphics::Surface &surface) const override;
@@ -172,6 +172,7 @@ private:
 	GLESTexture *_overlay_background;
 	GLESTexture *_overlay_texture;
 	bool _show_overlay;
+	bool _overlay_in_gui;
 
 	// Mouse layer
 	GLESBaseTexture *_mouse_texture;

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -649,7 +649,8 @@ void OpenGLSdlGraphics3dManager::updateScreen() {
 	if (_overlayVisible) {
 		_overlayScreen->update();
 
-		if (_overlayBackground) {
+		// If the overlay is in game we expect the game to continue calling OpenGL
+		if (_overlayBackground && _overlayInGUI) {
 			_overlayBackground->update();
 		}
 
@@ -685,11 +686,12 @@ int16 OpenGLSdlGraphics3dManager::getWidth() const {
 #pragma mark --- Overlays ---
 #pragma mark -
 
-void OpenGLSdlGraphics3dManager::showOverlay() {
-	if (_overlayVisible) {
+void OpenGLSdlGraphics3dManager::showOverlay(bool inGUI) {
+	if (_overlayVisible && _overlayInGUI == inGUI) {
 		return;
 	}
-	WindowedGraphicsManager::showOverlay();
+
+	WindowedGraphicsManager::showOverlay(inGUI);
 
 	delete _overlayBackground;
 	_overlayBackground = nullptr;

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
@@ -92,7 +92,7 @@ public:
 	void clearFocusRectangle() override {}
 
 	// GraphicsManager API - Overlay
-	void showOverlay() override;
+	void showOverlay(bool inGUI) override;
 	void hideOverlay() override;
 	Graphics::PixelFormat getOverlayFormat() const override { return _overlayFormat; }
 	void clearOverlay() override;

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -198,8 +198,8 @@ void ModularGraphicsBackend::clearFocusRectangle() {
 	_graphicsManager->clearFocusRectangle();
 }
 
-void ModularGraphicsBackend::showOverlay() {
-	_graphicsManager->showOverlay();
+void ModularGraphicsBackend::showOverlay(bool inGUI) {
+	_graphicsManager->showOverlay(inGUI);
 }
 
 void ModularGraphicsBackend::hideOverlay() {

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -101,7 +101,7 @@ public:
 	void setFocusRectangle(const Common::Rect& rect) override final;
 	void clearFocusRectangle() override final;
 
-	void showOverlay() override final;
+	void showOverlay(bool inGUI) override final;
 	void hideOverlay() override final;
 	bool isOverlayVisible() const override final;
 	Graphics::PixelFormat getOverlayFormat() const override final;

--- a/backends/platform/3ds/osystem-events.cpp
+++ b/backends/platform/3ds/osystem-events.cpp
@@ -277,7 +277,7 @@ void OSystem_3DS::destroyEvents() {
 }
 
 void OSystem_3DS::transformPoint(touchPosition &point) {
-	if (!_overlayVisible) {
+	if (!_overlayInGUI) {
 		point.px = static_cast<float>(point.px) / _gameBottomTexture.getScaleX() - _gameBottomTexture.getPosX();
 		point.py = static_cast<float>(point.py) / _gameBottomTexture.getScaleY() - _gameBottomTexture.getPosY();
 	}
@@ -286,7 +286,7 @@ void OSystem_3DS::transformPoint(touchPosition &point) {
 }
 
 void OSystem_3DS::clipPoint(touchPosition &point) {
-	if (_overlayVisible) {
+	if (_overlayInGUI) {
 		point.px = CLIP<uint16>(point.px, 0, getOverlayWidth()  - 1);
 		point.py = CLIP<uint16>(point.py, 0, getOverlayHeight() - 1);
 	} else {

--- a/backends/platform/3ds/osystem-graphics.cpp
+++ b/backends/platform/3ds/osystem-graphics.cpp
@@ -263,7 +263,7 @@ void OSystem_3DS::updateSize() {
 	_gameBottomTexture.setPosition(_gameBottomX, _gameBottomY);
 	_gameTopTexture.setOffset(0, 0);
 	_gameBottomTexture.setOffset(0, 0);
-	if (_overlayVisible) {
+	if (_overlayInGUI) {
 		_cursorTexture.setScale(1.f, 1.f);
 	} else if (config.screen == kScreenTop) {
 		_cursorTexture.setScale(_gameTopTexture.getScaleX(), _gameTopTexture.getScaleY());
@@ -329,7 +329,7 @@ OSystem::TransactionError OSystem_3DS::endGFXTransaction() {
 }
 
 float OSystem_3DS::getScaleRatio() const {
-	if (_overlayVisible) {
+	if (_overlayInGUI) {
 		return 1.0;
 	} else if (config.screen == kScreenTop) {
 		return _gameTopTexture.getScaleX();
@@ -457,7 +457,7 @@ void OSystem_3DS::updateScreen() {
 			}
 			if (_cursorVisible && config.showCursor && config.screen == kScreenTop) {
 				C3D_FVUnifMtx4x4(GPU_VERTEX_SHADER, _modelviewLocation, _cursorTexture.getMatrix());
-				_cursorTexture.setFilteringMode(!_overlayVisible && _filteringEnabled);
+				_cursorTexture.setFilteringMode(!_overlayInGUI && _filteringEnabled);
 				_cursorTexture.render();
 			}
 		}
@@ -486,7 +486,7 @@ void OSystem_3DS::updateScreen() {
 			}
 			if (_cursorVisible && config.showCursor) {
 				C3D_FVUnifMtx4x4(GPU_VERTEX_SHADER, _modelviewLocation, _cursorTexture.getMatrix());
-				_cursorTexture.setFilteringMode(!_overlayVisible && _filteringEnabled);
+				_cursorTexture.setFilteringMode(!_overlayInGUI && _filteringEnabled);
 				_cursorTexture.render();
 			}
 		}
@@ -609,13 +609,15 @@ void OSystem_3DS::updateMagnify() {
 	}
 }
 
-void OSystem_3DS::showOverlay() {
+void OSystem_3DS::showOverlay(bool inGUI) {
+	_overlayInGUI = inGUI;
 	_overlayVisible = true;
 	updateSize();
 }
 
 void OSystem_3DS::hideOverlay() {
 	_overlayVisible = false;
+	_overlayInGUI = false;
 	updateSize();
 }
 

--- a/backends/platform/3ds/osystem.cpp
+++ b/backends/platform/3ds/osystem.cpp
@@ -81,6 +81,7 @@ OSystem_3DS::OSystem_3DS():
 	_gameTextureDirty(false),
 	_filteringEnabled(true),
 	_overlayVisible(false),
+	_overlayInGUI(false),
 	_screenChangeId(0),
 	_magnifyMode(MODE_MAGOFF),
 	exiting(false),

--- a/backends/platform/3ds/osystem.h
+++ b/backends/platform/3ds/osystem.h
@@ -153,7 +153,7 @@ public:
 	void setShakePos(int shakeXOffset, int shakeYOffset);
 	void setFocusRectangle(const Common::Rect &rect);
 	void clearFocusRectangle();
-	void showOverlay();
+	void showOverlay(bool inGUI);
 	void hideOverlay();
 	bool isOverlayVisible() const { return _overlayVisible; }
 	Graphics::PixelFormat getOverlayFormat() const;
@@ -241,6 +241,7 @@ private:
 	int _screenShakeXOffset;
 	int _screenShakeYOffset;
 	bool _overlayVisible;
+	bool _overlayInGUI;
 	int _screenChangeId;
 
 	DVLB_s *_dvlb;

--- a/backends/platform/dc/dc.h
+++ b/backends/platform/dc/dc.h
@@ -154,7 +154,7 @@ public:
   int16 getOverlayHeight();
   int16 getOverlayWidth();
   bool isOverlayVisible() const { return _overlay_visible; }
-  void showOverlay();
+  void showOverlay(bool inGUI);
   void hideOverlay();
   void clearOverlay();
   void grabOverlay(Graphics::Surface &surface);
@@ -193,6 +193,7 @@ public:
   bool _overlay_visible, _overlay_dirty, _screen_dirty;
   int _screen_buffer, _overlay_buffer, _mouse_buffer;
   bool _aspect_stretch, _softkbd_on, _enable_cursor_palette;
+  bool _overlay_in_gui;
   float _overlay_fade, _xscale, _yscale, _top_offset;
   int _softkbd_motion;
 

--- a/backends/platform/dc/dcmain.cpp
+++ b/backends/platform/dc/dcmain.cpp
@@ -45,7 +45,7 @@ OSystem_Dreamcast::OSystem_Dreamcast()
   : _devpoll(0), screen(NULL), mouse(NULL), overlay(NULL), _softkbd(this),
 	_ms_buf(NULL), _mixer(NULL),
 	_current_shake_x_pos(0), _current_shake_y_pos(0), _aspect_stretch(false), _softkbd_on(false),
-	_softkbd_motion(0), _enable_cursor_palette(false), _screenFormat(0)
+	_softkbd_motion(0), _enable_cursor_palette(false), _overlay_in_gui(false), _screenFormat(0)
 {
   memset(screen_tx, 0, sizeof(screen_tx));
   memset(mouse_tx, 0, sizeof(mouse_tx));

--- a/backends/platform/dc/display.cpp
+++ b/backends/platform/dc/display.cpp
@@ -634,14 +634,16 @@ void OSystem_Dreamcast::mouseToSoftKbd(int x, int y, int &rx, int &ry) const
 }
 
 
-void OSystem_Dreamcast::showOverlay()
+void OSystem_Dreamcast::showOverlay(bool inGUI)
 {
+  _overlay_in_gui = inGUI;
   _overlay_visible = true;
   clearOverlay();
 }
 
 void OSystem_Dreamcast::hideOverlay()
 {
+  _overlay_in_gui = false;
   _overlay_visible = false;
 }
 

--- a/backends/platform/dc/input.cpp
+++ b/backends/platform/dc/input.cpp
@@ -215,7 +215,7 @@ bool OSystem_Dreamcast::pollEvent(Common::Event &event)
   if (_ms_cur_y>=_screen_h) _ms_cur_y=_screen_h-1;
   event.mouse.x = _ms_cur_x;
   event.mouse.y = _ms_cur_y;
-  if (_overlay_visible) {
+  if (_overlay_in_gui) {
 	event.mouse.x -= _overlay_x;
 	event.mouse.y -= _overlay_y;
   }

--- a/backends/platform/ds/ds-graphics.cpp
+++ b/backends/platform/ds/ds-graphics.cpp
@@ -408,7 +408,9 @@ void OSystem_DS::updateScreen() {
 
 	if (_overlay.isVisible()) {
 		_overlay.update();
-	} else {
+	}
+
+	if (_framebuffer.isVisible()) {
 		if (_paletteDirty) {
 			dmaCopyHalfWords(3, _palette, BG_PALETTE, 256 * 2);
 #ifdef DISABLE_TEXT_CONSOLE
@@ -430,12 +432,14 @@ void OSystem_DS::setShakePos(int shakeXOffset, int shakeYOffset) {
 	DS::setShakePos(shakeXOffset, shakeYOffset);
 }
 
-void OSystem_DS::showOverlay() {
+void OSystem_DS::showOverlay(bool inGUI) {
+	_overlayInGUI = inGUI;
 	_overlay.reset();
 	_overlay.show();
 }
 
 void OSystem_DS::hideOverlay() {
+	_overlayInGUI = false;
 	_overlay.hide();
 }
 
@@ -471,7 +475,7 @@ Graphics::PixelFormat OSystem_DS::getOverlayFormat() const {
 }
 
 Common::Point OSystem_DS::transformPoint(int16 x, int16 y) {
-	if (_overlay.isVisible())
+	if (_overlayInGUI)
 		return Common::Point(x, y);
 	else
 		return _framebuffer.realToScaled(x, y);
@@ -484,7 +488,7 @@ bool OSystem_DS::showMouse(bool visible) {
 }
 
 void OSystem_DS::warpMouse(int x, int y) {
-	if (_overlay.isVisible())
+	if (_overlayInGUI)
 		_cursorPos = Common::Point(x, y);
 	else
 		_cursorPos = _framebuffer.scaledToReal(x, y);

--- a/backends/platform/ds/osystem_ds.cpp
+++ b/backends/platform/ds/osystem_ds.cpp
@@ -46,7 +46,7 @@ OSystem_DS *OSystem_DS::_instance = NULL;
 OSystem_DS::OSystem_DS()
 	: _eventSource(NULL), _disableCursorPalette(true),
 	_graphicsMode(GFX_HWSCALE), _stretchMode(100),
-	_paletteDirty(false), _cursorDirty(false),
+	_paletteDirty(false), _cursorDirty(false), _overlayInGUI(false),
 	_pfCLUT8(Graphics::PixelFormat::createFormatCLUT8()),
 	_pfABGR1555(Graphics::PixelFormat(2, 5, 5, 5, 1, 0, 5, 10, 15)),
 	_callbackTimer(10), _currentTimeMillis(0), _subScreenActive(true)

--- a/backends/platform/ds/osystem_ds.h
+++ b/backends/platform/ds/osystem_ds.h
@@ -59,6 +59,7 @@ protected:
 	int _cursorHotY;
 	uint32 _cursorKey;
 	bool _cursorVisible;
+	bool _overlayInGUI;
 
 	DSEventSource *_eventSource;
 	DS::Keyboard *_keyboard;
@@ -107,7 +108,7 @@ public:
 	virtual void updateScreen();
 	virtual void setShakePos(int shakeXOffset, int shakeYOffset);
 
-	virtual void showOverlay();
+	virtual void showOverlay(bool inGUI);
 	virtual void hideOverlay();
 	virtual bool isOverlayVisible() const;
 	virtual void clearOverlay();

--- a/backends/platform/ios7/ios7_common.h
+++ b/backends/platform/ios7/ios7_common.h
@@ -69,7 +69,7 @@ enum UIViewTapDescription {
 
 struct VideoContext {
 	VideoContext() : asprectRatioCorrection(), screenWidth(), screenHeight(), overlayVisible(false),
-	                 overlayWidth(), overlayHeight(), mouseX(), mouseY(),
+	                 overlayInGUI(false), overlayWidth(), overlayHeight(), mouseX(), mouseY(),
 	                 mouseHotspotX(), mouseHotspotY(), mouseWidth(), mouseHeight(),
 	                 mouseIsVisible(), filtering(false), shakeXOffset(), shakeYOffset() {
 	}
@@ -81,6 +81,7 @@ struct VideoContext {
 
 	// Overlay state
 	bool overlayVisible;
+	bool overlayInGUI;
 	uint overlayWidth, overlayHeight;
 	Graphics::Surface overlayTexture;
 

--- a/backends/platform/ios7/ios7_osys_events.cpp
+++ b/backends/platform/ios7/ios7_osys_events.cpp
@@ -230,7 +230,7 @@ bool OSystem_iOS7::handleEvent_secondMouseUp(Common::Event &event, int x, int y)
 
 	if (curTime - _lastSecondaryDown < 400) {
 		//printf("Right tap!\n");
-		if (curTime - _lastSecondaryTap < 400 && !_videoContext->overlayVisible) {
+		if (curTime - _lastSecondaryTap < 400 && !_videoContext->overlayInGUI) {
 			//printf("Right escape!\n");
 			event.type = Common::EVENT_KEYDOWN;
 			_queuedInputEvent.type = Common::EVENT_KEYUP;
@@ -283,8 +283,8 @@ bool OSystem_iOS7::handleEvent_mouseDragged(Common::Event &event, int x, int y) 
 		mouseNewPosX = (int)(_videoContext->mouseX - deltaX / 0.5f);
 		mouseNewPosY = (int)(_videoContext->mouseY - deltaY / 0.5f);
 
-		int widthCap = _videoContext->overlayVisible ? _videoContext->overlayWidth : _videoContext->screenWidth;
-		int heightCap = _videoContext->overlayVisible ? _videoContext->overlayHeight : _videoContext->screenHeight;
+		int widthCap = _videoContext->overlayInGUI ? _videoContext->overlayWidth : _videoContext->screenWidth;
+		int heightCap = _videoContext->overlayInGUI ? _videoContext->overlayHeight : _videoContext->screenHeight;
 
 		if (mouseNewPosX < 0)
 			mouseNewPosX = 0;

--- a/backends/platform/ios7/ios7_osys_main.h
+++ b/backends/platform/ios7/ios7_osys_main.h
@@ -164,7 +164,7 @@ public:
 	void unlockScreen() override;
 	void setShakePos(int shakeXOffset, int shakeYOffset) override;
 
-	void showOverlay() override;
+	void showOverlay(bool inGUI) override;
 	void hideOverlay() override;
 	bool isOverlayVisible() const override { return _videoContext->overlayVisible; }
 	void clearOverlay() override;

--- a/backends/platform/ios7/ios7_osys_video.mm
+++ b/backends/platform/ios7/ios7_osys_video.mm
@@ -355,9 +355,10 @@ void OSystem_iOS7::setShakePos(int shakeXOffset, int shakeYOffset) {
 	_mouseDirty = true;
 }
 
-void OSystem_iOS7::showOverlay() {
+void OSystem_iOS7::showOverlay(bool inGUI) {
 	//printf("showOverlay()\n");
 	_videoContext->overlayVisible = true;
+	_videoContext->overlayInGUI = inGUI;
 	dirtyFullOverlayScreen();
 	updateScreen();
 	execute_on_main_thread(^ {
@@ -369,6 +370,7 @@ void OSystem_iOS7::showOverlay() {
 void OSystem_iOS7::hideOverlay() {
 	//printf("hideOverlay()\n");
 	_videoContext->overlayVisible = false;
+	_videoContext->overlayInGUI = false;
 	_dirtyOverlayRects.clear();
 	dirtyFullScreen();
 	execute_on_main_thread(^ {

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -522,7 +522,7 @@ uint getSizeNextPOT(uint size) {
 	CGRect *rect;
 	int maxWidth, maxHeight;
 
-	if (!_videoContext.overlayVisible) {
+	if (!_videoContext.overlayInGUI) {
 		rect = &_gameScreenRect;
 		maxWidth = _videoContext.screenWidth;
 		maxHeight = _videoContext.screenHeight;
@@ -533,7 +533,7 @@ uint getSizeNextPOT(uint size) {
 	}
 
 	if (!maxWidth || !maxHeight) {
-		printf("WARNING: updateMouseCursorScaling called when screen was not ready (%d)!\n", _videoContext.overlayVisible);
+		printf("WARNING: updateMouseCursorScaling called when screen was not ready (%d)!\n", _videoContext.overlayInGUI);
 		return;
 	}
 
@@ -787,7 +787,7 @@ uint getSizeNextPOT(uint size) {
 
 	CGRect *area;
 	int width, height, offsetX, offsetY;
-	if (_videoContext.overlayVisible) {
+	if (_videoContext.overlayInGUI) {
 		area = &_overlayRect;
 		width = _videoContext.overlayWidth;
 		height = _videoContext.overlayHeight;

--- a/backends/platform/iphone/iphone_common.h
+++ b/backends/platform/iphone/iphone_common.h
@@ -53,7 +53,7 @@ enum UIViewSwipeDirection {
 
 struct VideoContext {
 	VideoContext() : asprectRatioCorrection(), screenWidth(), screenHeight(), overlayVisible(false),
-	                 overlayWidth(), overlayHeight(), mouseX(), mouseY(),
+	                 overlayInGUI(false), overlayWidth(), overlayHeight(), mouseX(), mouseY(),
 	                 mouseHotspotX(), mouseHotspotY(), mouseWidth(), mouseHeight(),
 	                 mouseIsVisible(), filtering(false),
 	                 shakeXOffset(), shakeYOffset() {
@@ -66,6 +66,7 @@ struct VideoContext {
 
 	// Overlay state
 	bool overlayVisible;
+	bool overlayInGUI;
 	uint overlayWidth, overlayHeight;
 	Graphics::Surface overlayTexture;
 

--- a/backends/platform/iphone/iphone_video.mm
+++ b/backends/platform/iphone/iphone_video.mm
@@ -318,7 +318,7 @@ const char *iPhone_getDocumentsDir() {
 	CGRect *rect;
 	int maxWidth, maxHeight;
 
-	if (!_videoContext.overlayVisible) {
+	if (!_videoContext.overlayInGUI) {
 		rect = &_gameScreenRect;
 		maxWidth = _videoContext.screenWidth;
 		maxHeight = _videoContext.screenHeight;
@@ -329,7 +329,7 @@ const char *iPhone_getDocumentsDir() {
 	}
 
 	if (!maxWidth || !maxHeight) {
-		printf("WARNING: updateMouseCursorScaling called when screen was not ready (%d)!\n", _videoContext.overlayVisible);
+		printf("WARNING: updateMouseCursorScaling called when screen was not ready (%d)!\n", _videoContext.overlayInGUI);
 		return;
 	}
 
@@ -626,7 +626,7 @@ const char *iPhone_getDocumentsDir() {
 
 	CGRect *area;
 	int width, height, offsetX, offsetY;
-	if (_videoContext.overlayVisible) {
+	if (_videoContext.overlayInGUI) {
 		area = &_overlayRect;
 		width = _videoContext.overlayWidth;
 		height = _videoContext.overlayHeight;

--- a/backends/platform/iphone/osys_events.cpp
+++ b/backends/platform/iphone/osys_events.cpp
@@ -182,7 +182,7 @@ bool OSystem_IPHONE::handleEvent_secondMouseUp(Common::Event &event, int x, int 
 
 	if (curTime - _lastSecondaryDown < 400) {
 		//printf("Right tap!\n");
-		if (curTime - _lastSecondaryTap < 400 && !_videoContext->overlayVisible) {
+		if (curTime - _lastSecondaryTap < 400 && !_videoContext->overlayInGUI) {
 			//printf("Right escape!\n");
 			event.type = Common::EVENT_KEYDOWN;
 			_queuedInputEvent.type = Common::EVENT_KEYUP;
@@ -235,8 +235,8 @@ bool OSystem_IPHONE::handleEvent_mouseDragged(Common::Event &event, int x, int y
 		mouseNewPosX = (int)(_videoContext->mouseX - deltaX / 0.5f);
 		mouseNewPosY = (int)(_videoContext->mouseY - deltaY / 0.5f);
 
-		int widthCap = _videoContext->overlayVisible ? _videoContext->overlayWidth : _videoContext->screenWidth;
-		int heightCap = _videoContext->overlayVisible ? _videoContext->overlayHeight : _videoContext->screenHeight;
+		int widthCap = _videoContext->overlayInGUI ? _videoContext->overlayWidth : _videoContext->screenWidth;
+		int heightCap = _videoContext->overlayInGUI ? _videoContext->overlayHeight : _videoContext->screenHeight;
 
 		if (mouseNewPosX < 0)
 			mouseNewPosX = 0;

--- a/backends/platform/iphone/osys_main.h
+++ b/backends/platform/iphone/osys_main.h
@@ -145,7 +145,7 @@ public:
 	virtual void unlockScreen();
 	virtual void setShakePos(int shakeXOffset, int shakeYOffset);
 
-	virtual void showOverlay();
+	virtual void showOverlay(bool inGUI);
 	virtual void hideOverlay();
 	virtual bool isOverlayVisible() const { return _videoContext->overlayVisible; }
 	virtual void clearOverlay();

--- a/backends/platform/iphone/osys_video.mm
+++ b/backends/platform/iphone/osys_video.mm
@@ -279,9 +279,10 @@ void OSystem_IPHONE::setShakePos(int shakeXOffset, int shakeYOffset) {
 	_mouseDirty = true;
 }
 
-void OSystem_IPHONE::showOverlay() {
+void OSystem_IPHONE::showOverlay(bool inGUI) {
 	//printf("showOverlay()\n");
 	_videoContext->overlayVisible = true;
+	_videoContext->overlayInGUI = inGUI;
 	dirtyFullOverlayScreen();
 	updateScreen();
 	[g_iPhoneViewInstance performSelectorOnMainThread:@selector(updateMouseCursorScaling) withObject:nil waitUntilDone: YES];
@@ -291,6 +292,7 @@ void OSystem_IPHONE::showOverlay() {
 void OSystem_IPHONE::hideOverlay() {
 	//printf("hideOverlay()\n");
 	_videoContext->overlayVisible = false;
+	_videoContext->overlayInGUI = false;
 	_dirtyOverlayRects.clear();
 	dirtyFullScreen();
 	[g_iPhoneViewInstance performSelectorOnMainThread:@selector(updateMouseCursorScaling) withObject:nil waitUntilDone: YES];

--- a/backends/platform/n64/osys_n64.h
+++ b/backends/platform/n64/osys_n64.h
@@ -109,6 +109,7 @@ protected:
 
 	uint16	_overlayHeight, _overlayWidth;
 	bool	_overlayVisible;
+	bool	_overlayInGUI;
 
 	bool	_disableFpsLimit; // When this is enabled, the system doesn't limit screen updates
 
@@ -164,7 +165,7 @@ public:
 	virtual void unlockScreen();
 	virtual void setShakePos(int shakeXOffset, int shakeYOffset);
 
-	virtual void showOverlay();
+	virtual void showOverlay(bool inGUI);
 	virtual void hideOverlay();
 	virtual bool isOverlayVisible() const { return _overlayVisible; }
 	virtual void clearOverlay();

--- a/backends/platform/n64/osys_n64_base.cpp
+++ b/backends/platform/n64/osys_n64_base.cpp
@@ -90,6 +90,7 @@ OSystem_N64::OSystem_N64() {
 	_disableFpsLimit = false;
 
 	_overlayVisible = false;
+	_overlayInGUI = false;
 
 	_shakeXOffset = 0;
 	_shakeYOffset = 0;
@@ -613,27 +614,34 @@ void OSystem_N64::setShakePos(int shakeXOffset, int shakeYOffset) {
 	return;
 }
 
-void OSystem_N64::showOverlay() {
-	// Change min/max mouse coords
-	_mouseMaxX = _overlayWidth;
-	_mouseMaxY = _overlayHeight;
+void OSystem_N64::showOverlay(bool inGUI) {
+	_overlayInGUI = inGUI;
 
-	// Relocate the mouse cursor given the new limitations
-	warpMouse(_mouseX, _mouseY);
+	if (inGUI) {
+		// Change min/max mouse coords
+		_mouseMaxX = _overlayWidth;
+		_mouseMaxY = _overlayHeight;
+
+		// Relocate the mouse cursor given the new limitations
+		warpMouse(_mouseX, _mouseY);
+	}
 
 	_overlayVisible = true;
 	_dirtyOffscreen = true;
 }
 
 void OSystem_N64::hideOverlay() {
-	// Change min/max mouse coords
-	_mouseMaxX = _gameWidth;
-	_mouseMaxY = _gameHeight;
+	if (_overlayInGUI) {
+		// Change min/max mouse coords
+		_mouseMaxX = _gameWidth;
+		_mouseMaxY = _gameHeight;
 
-	// Relocate the mouse cursor given the new limitations
-	warpMouse(_mouseX, _mouseY);
+		// Relocate the mouse cursor given the new limitations
+		warpMouse(_mouseX, _mouseY);
+	}
 
 	_overlayVisible = false;
+	_overlayInGUI = false;
 
 	// Clear double buffered display
 	clearAllVideoBuffers();

--- a/backends/platform/psp/osys_psp.cpp
+++ b/backends/platform/psp/osys_psp.cpp
@@ -229,12 +229,14 @@ void OSystem_PSP::setShakePos(int shakeXOffset, int shakeYOffset) {
 	_screen.setShakePos(shakeXOffset, shakeYOffset);
 }
 
-void OSystem_PSP::showOverlay() {
+void OSystem_PSP::showOverlay(bool inGUI) {
 	DEBUG_ENTER_FUNC();
 	_pendingUpdate = false;
 	_overlay.setVisible(true);
-	_cursor.setLimits(_overlay.getWidth(), _overlay.getHeight());
-	_cursor.useGlobalScaler(false);	// mouse with overlay is 1:1
+	if (inGUI) {
+		_cursor.setLimits(_overlay.getWidth(), _overlay.getHeight());
+		_cursor.useGlobalScaler(false);	// mouse with overlay is 1:1
+	}
 }
 
 void OSystem_PSP::hideOverlay() {

--- a/backends/platform/psp/osys_psp.h
+++ b/backends/platform/psp/osys_psp.h
@@ -101,7 +101,7 @@ public:
 	void setShakePos(int shakeXOffset, int shakeYOffset);
 
 	// Overlay related
-	void showOverlay();
+	void showOverlay(bool inGUI);
 	void hideOverlay();
 	bool isOverlayVisible() const;
 	void clearOverlay();

--- a/backends/platform/wii/osystem.cpp
+++ b/backends/platform/wii/osystem.cpp
@@ -39,6 +39,7 @@
 OSystem_Wii::OSystem_Wii() :
 	_startup_time(0),
 
+	_overlayInGUI(false),
 	_cursorDontScale(true),
 	_cursorPaletteDisabled(true),
 	_cursorPalette(NULL),

--- a/backends/platform/wii/osystem.h
+++ b/backends/platform/wii/osystem.h
@@ -75,6 +75,7 @@ private:
 	gfx_screen_coords_t _coordsOverlay;
 	gfx_tex_t _texOverlay;
 	bool _overlayDirty;
+	bool _overlayInGUI;
 
 	u32 _lastScreenUpdate;
 	u16 _currentWidth, _currentHeight;
@@ -173,7 +174,7 @@ public:
 	void unlockScreen() override;
 	void setShakePos(int shakeXOffset, int shakeYOffset) override;
 
-	void showOverlay() override;
+	void showOverlay(bool inGUI) override;
 	void hideOverlay() override;
 	bool isOverlayVisible() const override { return _overlayVisible; }
 	void clearOverlay() override;

--- a/backends/platform/wii/osystem_gfx.cpp
+++ b/backends/platform/wii/osystem_gfx.cpp
@@ -113,7 +113,7 @@ void OSystem_Wii::deinitGfx() {
 }
 
 void OSystem_Wii::updateScreenResolution() {
-	if (_overlayVisible) {
+	if (_overlayInGUI) {
 		_currentWidth = _overlayWidth;
 		_currentHeight = _overlayHeight;
 	} else {
@@ -554,17 +554,23 @@ void OSystem_Wii::setShakePos(int shakeXOffset, int shakeYOffset) {
 	_coordsGame.y -= f32(shakeYOffset) * _currentYScale;
 }
 
-void OSystem_Wii::showOverlay() {
-	_mouseX = _overlayWidth / 2;
-	_mouseY = _overlayHeight / 2;
+void OSystem_Wii::showOverlay(bool inGUI) {
+	if (inGUI) {
+		_mouseX = _overlayWidth / 2;
+		_mouseY = _overlayHeight / 2;
+	}
+	_overlayInGUI = inGUI;
 	_overlayVisible = true;
 	updateScreenResolution();
 	gfx_tex_set_bilinear_filter(&_texMouse, true);
 }
 
 void OSystem_Wii::hideOverlay() {
-	_mouseX = _gameWidth / 2;
-	_mouseY = _gameHeight / 2;
+	if (_overlayInGUI) {
+		_mouseX = _gameWidth / 2;
+		_mouseY = _gameHeight / 2;
+	}
+	_overlayInGUI = false;
 	_overlayVisible = false;
 	updateScreenResolution();
 	gfx_tex_set_bilinear_filter(&_texMouse, _bilinearFilter);

--- a/common/system.h
+++ b/common/system.h
@@ -1181,10 +1181,13 @@ public:
 	 * and then manually compose whatever graphics we want to show in the overlay.
 	 * This works because we assume the game to be "paused" whenever an overlay
 	 * is active.
+	 *
+	 * @param inGame Whether the overlay is used to display GUI or in game images
+	 *
 	 */
 
 	/** Activate the overlay mode. */
-	virtual void showOverlay() = 0;
+	virtual void showOverlay(bool inGUI = true) = 0;
 
 	/** Deactivate the overlay mode. */
 	virtual void hideOverlay() = 0;

--- a/engines/agos/animation.cpp
+++ b/engines/agos/animation.cpp
@@ -469,7 +469,7 @@ void MoviePlayerSMK::playVideo() {
 	while (!endOfVideo() && !_skipMovie && !_vm->shouldQuit()) {
 		_subtitles.drawSubtitle(getTime(), true);
 		handleNextFrame();
-		g_system->showOverlay();
+		g_system->showOverlay(false);
 		g_system->clearOverlay();
 	}
 }

--- a/engines/groovie/video/player.cpp
+++ b/engines/groovie/video/player.cpp
@@ -124,7 +124,7 @@ void VideoPlayer::waitFrame() {
 		_lastFrameTime = currTime;
 		_frameTimeDrift = 0.0f;
 
-		g_system->showOverlay();
+		g_system->showOverlay(false);
 		g_system->clearOverlay();
 	} else {
 		uint32 millisDiff = currTime - _lastFrameTime;

--- a/engines/mohawk/video.cpp
+++ b/engines/mohawk/video.cpp
@@ -196,7 +196,7 @@ bool VideoManager::updateMovies() {
 	bool updateScreen = false;
 
 	for (VideoList::iterator it = _videos.begin(); it != _videos.end(); ) {
-		g_system->showOverlay();
+		g_system->showOverlay(false);
 		g_system->clearOverlay();
 
 		// Check of the video has reached the end


### PR DESCRIPTION
This is a try to tackle the mouse coordinates issue we now get with subtitles.

Subtitles use the overlay.
When it is shown, mouse coordinates change to cover (at least in OpenGL SDL) the whole screen and coordinates are not scaled to game screen.
This PR adds a new parameter to showOverlay allowing the game to keep its mouse coordinates while displaying something on the overlay.
The changes have only been tried on SDL (surface, OpenGL, OpenGL with libretro) and need a thorough review.

After this PR I also have some changes to subtitles to make them more efficient but it will come later.