### PR TITLE
COMMON: Add SeekableReadStreamEndianWrapper

### DIFF
--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -427,6 +427,18 @@
 	#endif
 #endif
 
+#ifndef WARN_DEPRECATED
+	#if __cplusplus >= 201703L
+		#define WARN_DEPRECATED(msg) [[deprecated(msg)]]
+	#elif defined(__GNUC__)
+		#define WARN_DEPRECATED(msg) __attribute__((__deprecated__(msg)))
+	#elif defined(_MSC_VER)
+		#define WARN_DEPRECATED(msg) __declspec(deprecated(msg))
+	#else
+		#define WARN_DEPRECATED(msg)
+	#endif
+#endif
+
 #ifndef STRINGBUFLEN
 	#if defined(__N64__) || defined(__DS__) || defined(__3DS__)
 		#define STRINGBUFLEN 256

--- a/common/substream.h
+++ b/common/substream.h
@@ -96,6 +96,7 @@ public:
  */
 class SeekableSubReadStreamEndian :  virtual public SeekableSubReadStream, virtual public SeekableReadStreamEndian {
 public:
+	WARN_DEPRECATED("Use SeekableReadStreamEndianWrapper with SeekableSubReadStream instead")
 	SeekableSubReadStreamEndian(SeekableReadStream *parentStream, uint32 begin, uint32 end, bool bigEndian, DisposeAfterUse::Flag disposeParentStream = DisposeAfterUse::NO)
 		: SeekableSubReadStream(parentStream, begin, end, disposeParentStream),
 		  SeekableReadStreamEndian(bigEndian),

--- a/engines/director/archive.cpp
+++ b/engines/director/archive.cpp
@@ -349,7 +349,7 @@ Common::SeekableReadStreamEndian *MacArchive::getResource(uint32 tag, uint16 id)
 		error("MacArchive::getResource(): Archive does not contain '%s' %d", tag2str(tag), id);
 	}
 
-	return new Common::SeekableSubReadStreamEndian(stream, 0, stream->size(), true, DisposeAfterUse::YES);
+	return new Common::SeekableReadStreamEndianWrapper(stream, true, DisposeAfterUse::YES);
 }
 
 // RIFF Archive code
@@ -524,7 +524,7 @@ bool RIFXArchive::openStream(Common::SeekableReadStream *stream, uint32 startOff
 		return false;
 	}
 
-	Common::SeekableSubReadStreamEndian endianStream(stream, 0, stream->size(), _isBigEndian, DisposeAfterUse::NO);
+	Common::SeekableReadStreamEndianWrapper endianStream(stream, _isBigEndian, DisposeAfterUse::NO);
 	endianStream.seek(startOffset + moreOffset + 4);
 
 	uint32 sz = endianStream.readUint32(); // size

--- a/engines/gob/anifile.cpp
+++ b/engines/gob/anifile.cpp
@@ -58,7 +58,7 @@ ANIFile::ANIFile(GobEngine *vm, const Common::String &fileName,
 
 	Common::SeekableReadStream *ani = _vm->_dataIO->getFile(endianFileName);
 	if (ani) {
-		Common::SeekableSubReadStreamEndian sub(ani, 0, ani->size(), bigEndian, DisposeAfterUse::YES);
+		Common::SeekableReadStreamEndianWrapper sub(ani, bigEndian, DisposeAfterUse::YES);
 
 		// The big endian version pads a few fields to even size
 		_hasPadding = bigEndian;
@@ -75,7 +75,7 @@ ANIFile::~ANIFile() {
 		delete *l;
 }
 
-void ANIFile::load(Common::SeekableSubReadStreamEndian &ani, const Common::String &fileName) {
+void ANIFile::load(Common::SeekableReadStreamEndian &ani, const Common::String &fileName) {
 	ani.skip(2); // Unused
 
 	uint16 animationCount = ani.readUint16();
@@ -112,7 +112,7 @@ void ANIFile::load(Common::SeekableSubReadStreamEndian &ani, const Common::Strin
 }
 
 void ANIFile::loadAnimation(Animation &animation, FrameArray &frames,
-							Common::SeekableSubReadStreamEndian &ani) {
+							Common::SeekableReadStreamEndian &ani) {
 
 	// Animation properties
 
@@ -185,7 +185,7 @@ void ANIFile::loadAnimation(Animation &animation, FrameArray &frames,
 	}
 }
 
-void ANIFile::loadFrames(FrameArray &frames, Common::SeekableSubReadStreamEndian &ani) {
+void ANIFile::loadFrames(FrameArray &frames, Common::SeekableReadStreamEndian &ani) {
 	uint32 curFrame = 0;
 
 	bool end = false;
@@ -233,7 +233,7 @@ void ANIFile::loadFrames(FrameArray &frames, Common::SeekableSubReadStreamEndian
 	}
 }
 
-CMPFile *ANIFile::loadLayer(Common::SeekableSubReadStreamEndian &ani) {
+CMPFile *ANIFile::loadLayer(Common::SeekableReadStreamEndian &ani) {
 	Common::String file = Util::setExtension(Util::readString(ani, 13), "");
 	if (_hasPadding)
 		ani.skip(1);

--- a/engines/gob/anifile.h
+++ b/engines/gob/anifile.h
@@ -28,7 +28,7 @@
 #include "common/list.h"
 
 namespace Common {
-	class SeekableSubReadStreamEndian;
+	class SeekableReadStreamEndian;
 }
 
 namespace Gob {
@@ -129,13 +129,13 @@ private:
 
 	// Loading helpers
 
-	void load(Common::SeekableSubReadStreamEndian &ani, const Common::String &fileName);
+	void load(Common::SeekableReadStreamEndian &ani, const Common::String &fileName);
 
-	CMPFile *loadLayer(Common::SeekableSubReadStreamEndian &ani);
+	CMPFile *loadLayer(Common::SeekableReadStreamEndian &ani);
 
 	void loadAnimation(Animation &animation, FrameArray &frames,
-	                   Common::SeekableSubReadStreamEndian &ani);
-	void loadFrames(FrameArray &frames, Common::SeekableSubReadStreamEndian &ani);
+	                   Common::SeekableReadStreamEndian &ani);
+	void loadFrames(FrameArray &frames, Common::SeekableReadStreamEndian &ani);
 
 	// Drawing helpers
 

--- a/engines/gob/cmpfile.cpp
+++ b/engines/gob/cmpfile.cpp
@@ -150,7 +150,7 @@ void CMPFile::loadRXY(Common::SeekableReadStream &rxy) {
 	                 ((_vm->getEndiannessMethod() == kEndiannessMethodSystem) &&
 	                  (_vm->getEndianness() == kEndiannessBE));
 
-	Common::SeekableSubReadStreamEndian sub(&rxy, 0, rxy.size(), bigEndian, DisposeAfterUse::NO);
+	Common::SeekableReadStreamEndianWrapper sub(&rxy, bigEndian, DisposeAfterUse::NO);
 
 	_coordinates = new RXYFile(sub);
 

--- a/engines/gob/decfile.cpp
+++ b/engines/gob/decfile.cpp
@@ -59,7 +59,7 @@ DECFile::DECFile(GobEngine *vm, const Common::String &fileName,
 
 	Common::SeekableReadStream *ani = _vm->_dataIO->getFile(endianFileName);
 	if (ani) {
-		Common::SeekableSubReadStreamEndian sub(ani, 0, ani->size(), bigEndian, DisposeAfterUse::YES);
+		Common::SeekableReadStreamEndianWrapper sub(ani, bigEndian, DisposeAfterUse::YES);
 
 		// The big endian version pads a few fields to even size
 		_hasPadding = bigEndian;
@@ -78,7 +78,7 @@ DECFile::~DECFile() {
 		delete *l;
 }
 
-void DECFile::load(Common::SeekableSubReadStreamEndian &dec, const Common::String &fileName) {
+void DECFile::load(Common::SeekableReadStreamEndian &dec, const Common::String &fileName) {
 	dec.skip(2); // Unused
 
 	int16 backdropCount = dec.readUint16();
@@ -110,7 +110,7 @@ void DECFile::load(Common::SeekableSubReadStreamEndian &dec, const Common::Strin
 		loadParts(dec);
 }
 
-void DECFile::loadBackdrop(Common::SeekableSubReadStreamEndian &dec) {
+void DECFile::loadBackdrop(Common::SeekableReadStreamEndian &dec) {
 	// Interestingly, DEC files reference "FOO.LBM" instead of "FOO.CMP"
 	Common::String file = Util::setExtension(Util::readString(dec, 13), "");
 	if (_hasPadding)
@@ -119,7 +119,7 @@ void DECFile::loadBackdrop(Common::SeekableSubReadStreamEndian &dec) {
 	_backdrop = new CMPFile(_vm, file, _width, _height, _bpp);
 }
 
-CMPFile *DECFile::loadLayer(Common::SeekableSubReadStreamEndian &dec) {
+CMPFile *DECFile::loadLayer(Common::SeekableReadStreamEndian &dec) {
 	Common::String file = Util::setExtension(Util::readString(dec, 13), "");
 	if (_hasPadding)
 		dec.skip(1);
@@ -127,7 +127,7 @@ CMPFile *DECFile::loadLayer(Common::SeekableSubReadStreamEndian &dec) {
 	return new CMPFile(_vm, file, _width, _height, _bpp);
 }
 
-void DECFile::loadParts(Common::SeekableSubReadStreamEndian &dec) {
+void DECFile::loadParts(Common::SeekableReadStreamEndian &dec) {
 	dec.skip(13); // Name
 	if (_hasPadding)
 		dec.skip(1);
@@ -143,7 +143,7 @@ void DECFile::loadParts(Common::SeekableSubReadStreamEndian &dec) {
 		loadPart(*p, dec);
 }
 
-void DECFile::loadPart(Part &part, Common::SeekableSubReadStreamEndian &dec) {
+void DECFile::loadPart(Part &part, Common::SeekableReadStreamEndian &dec) {
 	part.layer = dec.readByte() - 1;
 	part.part  = dec.readByte();
 

--- a/engines/gob/decfile.h
+++ b/engines/gob/decfile.h
@@ -26,7 +26,7 @@
 
 namespace Common {
 	class String;
-	class SeekableSubReadStreamEndian;
+	class SeekableReadStreamEndian;
 }
 
 namespace Gob {
@@ -85,14 +85,14 @@ private:
 	PartArray  _parts;
 
 
-	void load(Common::SeekableSubReadStreamEndian &dec, const Common::String &fileName);
+	void load(Common::SeekableReadStreamEndian &dec, const Common::String &fileName);
 
-	void loadBackdrop(Common::SeekableSubReadStreamEndian &dec);
+	void loadBackdrop(Common::SeekableReadStreamEndian &dec);
 
-	CMPFile *loadLayer(Common::SeekableSubReadStreamEndian &dec);
+	CMPFile *loadLayer(Common::SeekableReadStreamEndian &dec);
 
-	void loadParts(Common::SeekableSubReadStreamEndian &dec);
-	void loadPart(Part &part, Common::SeekableSubReadStreamEndian &dec);
+	void loadParts(Common::SeekableReadStreamEndian &dec);
+	void loadPart(Part &part, Common::SeekableReadStreamEndian &dec);
 };
 
 } // End of namespace Gob

--- a/engines/gob/rxyfile.cpp
+++ b/engines/gob/rxyfile.cpp
@@ -27,12 +27,12 @@
 namespace Gob {
 
 RXYFile::RXYFile(Common::SeekableReadStream &rxy) : _width(0), _height(0) {
-	Common::SeekableSubReadStreamEndian sub(&rxy, 0, rxy.size(), false, DisposeAfterUse::NO);
+	Common::SeekableReadStreamEndianWrapper sub(&rxy, false, DisposeAfterUse::NO);
 
 	load(sub);
 }
 
-RXYFile::RXYFile(Common::SeekableSubReadStreamEndian &rxy) : _width(0), _height(0) {
+RXYFile::RXYFile(Common::SeekableReadStreamEndian &rxy) : _width(0), _height(0) {
 	load(rxy);
 }
 
@@ -70,7 +70,7 @@ const RXYFile::Coordinates &RXYFile::operator[](uint i) const {
 	return _coords[i];
 }
 
-void RXYFile::load(Common::SeekableSubReadStreamEndian &rxy) {
+void RXYFile::load(Common::SeekableReadStreamEndian &rxy) {
 	if (rxy.size() < 2)
 		return;
 

--- a/engines/gob/rxyfile.h
+++ b/engines/gob/rxyfile.h
@@ -27,7 +27,7 @@
 
 namespace Common {
 	class SeekableReadStream;
-	class SeekableSubReadStreamEndian;
+	class SeekableReadStreamEndian;
 }
 
 namespace Gob {
@@ -46,7 +46,7 @@ public:
 	};
 
 	RXYFile(Common::SeekableReadStream &rxy);
-	RXYFile(Common::SeekableSubReadStreamEndian &rxy);
+	RXYFile(Common::SeekableReadStreamEndian &rxy);
 	RXYFile(uint16 width, uint16 height);
 	~RXYFile();
 
@@ -72,7 +72,7 @@ private:
 	uint16 _height;
 
 
-	void load(Common::SeekableSubReadStreamEndian &rxy);
+	void load(Common::SeekableReadStreamEndian &rxy);
 };
 
 } // End of namespace Gob

--- a/engines/kyra/gui/saveload_eob.cpp
+++ b/engines/kyra/gui/saveload_eob.cpp
@@ -44,7 +44,7 @@ Common::Error EoBCoreEngine::loadGameState(int slot) {
 	if (!saveFile)
 		return Common::Error(Common::kReadingFailed);
 
-	Common::SeekableSubReadStreamEndian in(saveFile, saveFile->pos(), saveFile->size(), !header.originalSave, DisposeAfterUse::YES);
+	Common::SeekableReadStreamEndianWrapper in(saveFile, !header.originalSave, DisposeAfterUse::YES);
 	_loading = true;
 
 	if (slot != -1)
@@ -698,7 +698,7 @@ Common::String EoBCoreEngine::readOriginalSaveFile(Common::String &file) {
 	if (sourcePlatform == Common::kPlatformDOS && padding && (exp & 0xFF000000))
 		sourcePlatform = Common::kPlatformAmiga;
 
-	Common::SeekableSubReadStreamEndian in(fs, 0, fs->size(), sourcePlatform == Common::kPlatformAmiga, DisposeAfterUse::YES);
+	Common::SeekableReadStreamEndianWrapper in(fs, sourcePlatform == Common::kPlatformAmiga, DisposeAfterUse::YES);
 
 	if (_flags.gameID == GI_EOB1) {
 		// Nothing to read here for EOB 1. Original EOB 1 has

--- a/engines/kyra/gui/saveload_hof.cpp
+++ b/engines/kyra/gui/saveload_hof.cpp
@@ -147,7 +147,7 @@ Common::Error KyraEngine_HoF::loadGameState(int slot) {
 
 	int loadedZTable = _characterShapeFile;
 
-	Common::SeekableSubReadStreamEndian in(saveFile, saveFile->pos(), saveFile->size(), !header.originalSave, DisposeAfterUse::YES);
+	Common::SeekableReadStreamEndianWrapper in(saveFile, !header.originalSave, DisposeAfterUse::YES);
 
 	_screen->hideMouse();
 	_screen->fadeToBlack(10);

--- a/engines/kyra/gui/saveload_lol.cpp
+++ b/engines/kyra/gui/saveload_lol.cpp
@@ -52,7 +52,7 @@ Common::Error LoLEngine::loadGameState(int slot) {
 	_screen->fillRect(112, 0, 287, 119, 0, 0);
 	_screen->updateScreen();
 
-	Common::SeekableSubReadStreamEndian in(saveFile, saveFile->pos(), saveFile->size(), !header.originalSave, DisposeAfterUse::YES);
+	Common::SeekableReadStreamEndianWrapper in(saveFile, !header.originalSave, DisposeAfterUse::YES);
 
 	for (int i = 0; i < 4; i++) {
 		LoLCharacter *c = &_characters[i];

--- a/engines/kyra/gui/saveload_mr.cpp
+++ b/engines/kyra/gui/saveload_mr.cpp
@@ -147,7 +147,7 @@ Common::Error KyraEngine_MR::loadGameState(int slot) {
 
 	int curShapes = _characterShapeFile;
 
-	Common::SeekableSubReadStreamEndian in(saveFile, saveFile->pos(), saveFile->size(), !header.originalSave, DisposeAfterUse::YES);
+	Common::SeekableReadStreamEndianWrapper in(saveFile, !header.originalSave, DisposeAfterUse::YES);
 
 	_screen->hideMouse();
 

--- a/engines/kyra/resource/resource.cpp
+++ b/engines/kyra/resource/resource.cpp
@@ -353,7 +353,7 @@ Common::SeekableReadStream *Resource::createReadStream(const Common::String &fil
 
 Common::SeekableReadStreamEndian *Resource::createEndianAwareReadStream(const Common::String &file, int endianness) {
 	Common::SeekableReadStream *stream = _files.createReadStreamForMember(file);
-	return stream ? new EndianAwareStreamWrapper(stream, (endianness == kForceBE) ? true : (endianness == kForceLE ? false : _bigEndianPlatForm)) : nullptr;
+	return stream ? new Common::SeekableReadStreamEndianWrapper(stream, (endianness == kForceBE) ? true : (endianness == kForceLE ? false : _bigEndianPlatForm), DisposeAfterUse::YES) : nullptr;
 }
 
 Common::Archive *Resource::loadArchive(const Common::String &name, Common::ArchiveMemberPtr member) {

--- a/engines/kyra/resource/resource_intern.h
+++ b/engines/kyra/resource/resource_intern.h
@@ -147,28 +147,6 @@ public:
 	static Common::Archive *load(Resource *owner, const Common::String &filename, Common::MacResManager *macResMan);
 };
 
-class EndianAwareStreamWrapper : public Common::SeekableReadStreamEndian {
-public:
-	EndianAwareStreamWrapper(Common::SeekableReadStream *stream, bool bigEndian, bool disposeAfterUse = true) : Common::SeekableReadStreamEndian(bigEndian), Common::ReadStreamEndian(bigEndian), _stream(stream), _dispose(disposeAfterUse) {}
-	~EndianAwareStreamWrapper() override { if (_dispose) delete _stream; }
-
-	// Common::Stream interface
-	bool err() const override { return _stream->err(); }
-
-	// Common::ReadStream interface
-	bool eos() const override { return _stream->eos(); }
-	uint32 read(void *dataPtr, uint32 dataSize) override { return _stream->read(dataPtr, dataSize); }
-
-	// Common::SeekableReadStream interface
-	int64 pos() const override { return _stream->pos(); }
-	int64 size() const override { return _stream->size(); }
-	bool seek(int64 offset, int whence = SEEK_SET) override { return _stream->seek(offset, whence); }
-
-private:
-	Common::SeekableReadStream *_stream;
-	bool _dispose;
-};
-
 } // End of namespace Kyra
 
 #endif

--- a/engines/kyra/resource/resource_segacd.cpp
+++ b/engines/kyra/resource/resource_segacd.cpp
@@ -108,7 +108,7 @@ Common::SeekableReadStreamEndian *SegaCDResource::resStreamEndian(int resID) {
 	if (!str)
 		return 0;
 
-	return new EndianAwareStreamWrapper(str, _str->isBE(), true);
+	return new Common::SeekableReadStreamEndianWrapper(str, _str->isBE(), DisposeAfterUse::YES);
 }
 
 Common::SeekableReadStream *SegaCDResource::resStream(int resID) {

--- a/engines/kyra/script/script_eob.cpp
+++ b/engines/kyra/script/script_eob.cpp
@@ -212,7 +212,7 @@ bool EoBInfProcessor::preventRest() const {
 	return _preventRest ? true : false;
 }
 
-void EoBInfProcessor::loadState(Common::SeekableSubReadStreamEndian &in, bool origFile) {
+void EoBInfProcessor::loadState(Common::SeekableReadStreamEndian &in, bool origFile) {
 	_preventRest = (_vm->game() == GI_EOB1 && origFile) ? 0 : in.readByte();
 	int numFlags = (_vm->game() == GI_EOB1 && origFile) ? 12 : 18;
 	for (int i = 0; i < numFlags; i++)

--- a/engines/kyra/script/script_eob.h
+++ b/engines/kyra/script/script_eob.h
@@ -45,7 +45,7 @@ public:
 	bool checkFlags(uint32 flags) const;
 	bool preventRest() const;
 
-	void loadState(Common::SeekableSubReadStreamEndian &in, bool origFile = false);
+	void loadState(Common::SeekableReadStreamEndian &in, bool origFile = false);
 	void saveState(Common::OutSaveFile *out, bool origFile = false);
 	void reset();
 

--- a/engines/mohawk/livingbooks.cpp
+++ b/engines/mohawk/livingbooks.cpp
@@ -804,7 +804,7 @@ uint16 LBPage::getResourceVersion() {
 }
 
 void LBPage::loadBITL(uint16 resourceId) {
-	Common::SeekableSubReadStreamEndian *bitlStream = _vm->wrapStreamEndian(ID_BITL, resourceId);
+	Common::SeekableReadStreamEndian *bitlStream = _vm->wrapStreamEndian(ID_BITL, resourceId);
 
 	while (true) {
 		Common::Rect rect = _vm->readRect(bitlStream);
@@ -857,9 +857,9 @@ void LBPage::loadBITL(uint16 resourceId) {
 	delete bitlStream;
 }
 
-Common::SeekableSubReadStreamEndian *MohawkEngine_LivingBooks::wrapStreamEndian(uint32 tag, uint16 id) {
+Common::SeekableReadStreamEndian *MohawkEngine_LivingBooks::wrapStreamEndian(uint32 tag, uint16 id) {
 	Common::SeekableReadStream *dataStream = getResource(tag, id);
-	return new Common::SeekableSubReadStreamEndian(dataStream, 0, dataStream->size(), isBigEndian(), DisposeAfterUse::YES);
+	return new Common::SeekableReadStreamEndianWrapper(dataStream, isBigEndian(), DisposeAfterUse::YES);
 }
 
 Common::String MohawkEngine_LivingBooks::getStringFromConfig(const Common::String &section, const Common::String &key) {
@@ -1470,7 +1470,7 @@ LBAnimationNode::~LBAnimationNode() {
 }
 
 void LBAnimationNode::loadScript(uint16 resourceId) {
-	Common::SeekableSubReadStreamEndian *scriptStream = _vm->wrapStreamEndian(ID_SCRP, resourceId);
+	Common::SeekableReadStreamEndian *scriptStream = _vm->wrapStreamEndian(ID_SCRP, resourceId);
 
 	reset();
 
@@ -1726,7 +1726,7 @@ bool LBAnimationNode::transparentAt(int x, int y) {
 }
 
 LBAnimation::LBAnimation(MohawkEngine_LivingBooks *vm, LBAnimationItem *parent, uint16 resourceId) : _vm(vm), _parent(parent) {
-	Common::SeekableSubReadStreamEndian *aniStream = _vm->wrapStreamEndian(ID_ANI, resourceId);
+	Common::SeekableReadStreamEndian *aniStream = _vm->wrapStreamEndian(ID_ANI, resourceId);
 
 	// ANI records in the Wanderful sampler are 32 bytes, extra bytes are just NULs
 	if (aniStream->size() != 30 && aniStream->size() != 32)
@@ -1759,7 +1759,7 @@ LBAnimation::LBAnimation(MohawkEngine_LivingBooks *vm, LBAnimationItem *parent, 
 	if (sprResourceOffset)
 		error("Cannot handle non-zero ANI offset yet");
 
-	Common::SeekableSubReadStreamEndian *sprStream = _vm->wrapStreamEndian(ID_SPR, sprResourceId);
+	Common::SeekableReadStreamEndian *sprStream = _vm->wrapStreamEndian(ID_SPR, sprResourceId);
 
 	uint16 numBackNodes = sprStream->readUint16();
 	uint16 numFrontNodes = sprStream->readUint16();
@@ -1818,7 +1818,7 @@ void LBAnimation::loadShape(uint16 resourceId) {
 	if (resourceId == 0)
 		return;
 
-	Common::SeekableSubReadStreamEndian *shapeStream = _vm->wrapStreamEndian(ID_SHP, resourceId);
+	Common::SeekableReadStreamEndian *shapeStream = _vm->wrapStreamEndian(ID_SHP, resourceId);
 
 	if (_vm->isPreMohawk()) {
 		if (shapeStream->size() < 6)
@@ -2071,7 +2071,7 @@ LBItem::~LBItem() {
 		delete _scriptEntries[i];
 }
 
-void LBItem::readFrom(Common::SeekableSubReadStreamEndian *stream) {
+void LBItem::readFrom(Common::SeekableReadStreamEndian *stream) {
 	_resourceId = stream->readUint16();
 	_itemId = stream->readUint16();
 	uint16 size = stream->readUint16();

--- a/engines/mohawk/livingbooks.h
+++ b/engines/mohawk/livingbooks.h
@@ -36,7 +36,7 @@
 #include "livingbooks_code.h"
 
 namespace Common {
-	class SeekableSubReadStreamEndian;
+	class SeekableReadStreamEndian;
 	class MemoryReadStreamEndian;
 }
 
@@ -385,7 +385,7 @@ public:
 	LBItem(MohawkEngine_LivingBooks *vm, LBPage *page, Common::Rect rect);
 	virtual ~LBItem();
 
-	void readFrom(Common::SeekableSubReadStreamEndian *stream);
+	void readFrom(Common::SeekableReadStreamEndian *stream);
 	void readData(uint16 type, uint16 size, byte *data);
 	virtual void readData(uint16 type, uint16 size, Common::MemoryReadStreamEndian *stream);
 
@@ -721,7 +721,7 @@ public:
 
 	void addNotifyEvent(NotifyEvent event);
 
-	Common::SeekableSubReadStreamEndian *wrapStreamEndian(uint32 tag, uint16 id);
+	Common::SeekableReadStreamEndian *wrapStreamEndian(uint32 tag, uint16 id);
 	Common::String readString(Common::ReadStream *stream);
 	Common::Rect readRect(Common::ReadStreamEndian *stream);
 

--- a/engines/mohawk/livingbooks_code.cpp
+++ b/engines/mohawk/livingbooks_code.cpp
@@ -180,7 +180,7 @@ LBCode::LBCode(MohawkEngine_LivingBooks *vm, uint16 baseId) : _vm(vm) {
 		return;
 	}
 
-	Common::SeekableSubReadStreamEndian *bcodStream = _vm->wrapStreamEndian(ID_BCOD, baseId);
+	Common::SeekableReadStreamEndian *bcodStream = _vm->wrapStreamEndian(ID_BCOD, baseId);
 
 	uint32 totalSize = bcodStream->readUint32();
 	if (totalSize != (uint32)bcodStream->size())

--- a/engines/mohawk/livingbooks_graphics.cpp
+++ b/engines/mohawk/livingbooks_graphics.cpp
@@ -85,7 +85,7 @@ void LBGraphics::setPalette(uint16 id) {
 	// Old Living Books games use the old CTBL-style palette format while newer
 	// games use the better tPAL format which can store partial palettes.
 	if (_vm->isPreMohawk()) {
-		Common::SeekableSubReadStreamEndian *ctblStream = _vm->wrapStreamEndian(ID_CTBL, id);
+		Common::SeekableReadStreamEndian *ctblStream = _vm->wrapStreamEndian(ID_CTBL, id);
 		uint16 colorCount = ctblStream->readUint16();
 		byte *palette = new byte[colorCount * 3];
 

--- a/engines/sci/video/robot_decoder.cpp
+++ b/engines/sci/video/robot_decoder.cpp
@@ -27,8 +27,7 @@
 #include "common/platform.h"         // for Platform::kPlatformMacintosh
 #include "common/rational.h"         // for operator*, Rational
 #include "common/str.h"              // for String
-#include "common/stream.h"           // for SeekableReadStream
-#include "common/substream.h"        // for SeekableSubReadStreamEndian
+#include "common/stream.h"           // for SeekableReadStream, SeekableReadStreamEndianWrapper
 #include "common/textconsole.h"      // for error, warning
 #include "common/types.h"            // for Flag::NO, Flag::YES
 #include "sci/engine/seg_manager.h"  // for SegManager
@@ -385,7 +384,7 @@ void RobotDecoder::initStream(const GuiResourceId robotId) {
 	const uint16 version = stream->readUint16BE();
 	const bool bigEndian = (0 < version && version <= 0x00ff);
 
-	_stream = new Common::SeekableSubReadStreamEndian(stream, 0, stream->size(), bigEndian, DisposeAfterUse::YES);
+	_stream = new Common::SeekableReadStreamEndianWrapper(stream, bigEndian, DisposeAfterUse::YES);
 	_stream->seek(2, SEEK_SET);
 	if (_stream->readUint32BE() != MKTAG('S', 'O', 'L', 0)) {
 		error("Resource %s is not Robot type!", fileName.c_str());

--- a/engines/sci/video/robot_decoder.h
+++ b/engines/sci/video/robot_decoder.h
@@ -32,7 +32,7 @@
 #include "sci/graphics/helpers.h"        // for GuiResourceId
 #include "sci/graphics/screen_item32.h"  // for ScaleInfo, ScreenItem (ptr o...
 
-namespace Common { class SeekableSubReadStreamEndian; }
+namespace Common { class SeekableReadStreamEndian; }
 namespace Sci {
 class Plane;
 class SegManager;
@@ -644,7 +644,7 @@ private:
 	/**
 	 * The read stream containing raw robot data.
 	 */
-	Common::SeekableSubReadStreamEndian *_stream;
+	Common::SeekableReadStreamEndian *_stream;
 
 	/**
 	 * The current status of the player.

--- a/engines/trecision/resource.cpp
+++ b/engines/trecision/resource.cpp
@@ -42,7 +42,7 @@
 namespace Trecision {
 
 Common::SeekableReadStreamEndian *TrecisionEngine::readEndian(Common::SeekableReadStream *stream, DisposeAfterUse::Flag dispose) {
-	return new Common::SeekableSubReadStreamEndian(stream, 0, stream->size(), isAmiga(), dispose);
+	return new Common::SeekableReadStreamEndianWrapper(stream, isAmiga(), dispose);
 }
 
 void TrecisionEngine::loadAll() {


### PR DESCRIPTION
This is intended as a replacement for `Common::SeekableSubReadStreamEndian` - since most engines using it don't actually need a partial substream, the new class is simpler and avoids unpredictability when directly accessing the parent stream.

There are a few places in the Director, Kyra and mTropolis that do need a substream, however since adapting those cases is a bit more involved, I've simply marked the old class as deprecated for now.