### PR TITLE
GRAPHICS: Optimize and fix subtitles

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -636,7 +636,7 @@ void OpenGLGraphicsManager::updateScreen() {
 	// Clear the screen buffer.
 	GL_CALL(glClear(GL_COLOR_BUFFER_BIT));
 
-	if (!_overlayInGUI) {
+	if (!_overlayVisible) {
 		// The scissor test is enabled to:
 		// - Clip the cursor to the game screen
 		// - Clip the game screen when the shake offset is non-zero
@@ -694,7 +694,7 @@ void OpenGLGraphicsManager::updateScreen() {
 		                         _cursorWidthScaled, _cursorHeightScaled);
 	}
 
-	if (!_overlayInGUI) {
+	if (!_overlayVisible) {
 		_backBuffer.enableScissorTest(false);
 	}
 

--- a/engines/agos/animation.cpp
+++ b/engines/agos/animation.cpp
@@ -438,7 +438,7 @@ bool MoviePlayerSMK::load() {
 	CursorMan.showMouse(false);
 
 	Common::String subtitlesName = Common::String::format("%s.srt", baseName);
-	loadSubtitles(subtitlesName.c_str());
+	_subtitles.loadSRTFile(subtitlesName.c_str());
 
 	return true;
 }
@@ -466,16 +466,19 @@ void MoviePlayerSMK::copyFrameToBuffer(byte *dst, uint x, uint y, uint pitch) {
 }
 
 void MoviePlayerSMK::playVideo() {
-	while (!endOfVideo() && !_skipMovie && !_vm->shouldQuit()) {
-		_subtitles.drawSubtitle(getTime(), true);
-		handleNextFrame();
-		g_system->showOverlay(false);
+	if (_subtitles.isLoaded()) {
 		g_system->clearOverlay();
+		g_system->showOverlay(false);
+	}
+	while (!endOfVideo() && !_skipMovie && !_vm->shouldQuit()) {
+		handleNextFrame();
 	}
 }
 
 void MoviePlayerSMK::stopVideo() {
-	g_system->hideOverlay();
+	if (_subtitles.isLoaded()) {
+		g_system->hideOverlay();
+	}
 	close();
 }
 
@@ -518,6 +521,8 @@ bool MoviePlayerSMK::processFrame() {
 		warning("dropped frame %i", getCurFrame());
 		return false;
 	}
+
+	_subtitles.drawSubtitle(getTime(), false);
 
 	_vm->_system->updateScreen();
 

--- a/engines/agos/animation.h
+++ b/engines/agos/animation.h
@@ -62,7 +62,6 @@ public:
 	virtual void playVideo() = 0;
 	virtual void nextFrame() = 0;
 	virtual void stopVideo() = 0;
-	void loadSubtitles(const char *fname) { _subtitles.loadSRTFile(fname); }
 
 protected:
 	virtual void handleNextFrame();

--- a/engines/groovie/script.cpp
+++ b/engines/groovie/script.cpp
@@ -987,6 +987,8 @@ bool Script::playvideofromref(uint32 fileref, bool loopUntilAudioDone) {
 
 			_bitflags = 0;
 
+			_vm->_videoPlayer->unloadSubtitles();
+
 			// End the playback
 			return true;
 		}

--- a/engines/groovie/script.cpp
+++ b/engines/groovie/script.cpp
@@ -959,8 +959,8 @@ bool Script::playvideofromref(uint32 fileref, bool loopUntilAudioDone) {
 			Common::String subtitleName = _vm->_resMan->getGjdName(info);
 			subtitleName = subtitleName.substr(0, subtitleName.size() - 4);
 			subtitleName.toUppercase();
-			// add the filename without the extension, then add the .txt extension
-			subtitleName += "-" + info.filename.substr(0, info.filename.size() - 3) + "txt";
+			// add the filename without the extension, then add the srt extension
+			subtitleName += "-" + info.filename.substr(0, info.filename.size() - 3) + "srt";
 
 			_vm->_videoPlayer->loadSubtitles(subtitleName.c_str());
 		} else {

--- a/engines/groovie/video/player.cpp
+++ b/engines/groovie/video/player.cpp
@@ -107,13 +107,17 @@ bool VideoPlayer::playFrame() {
 			}
 		}
 
-		if (_subtitles.isLoaded()) {
-			_subtitles.close();
-			g_system->hideOverlay();
-		}
+		unloadSubtitles();
 	}
 
 	return end;
+}
+
+void VideoPlayer::unloadSubtitles() {
+	if (_subtitles.isLoaded()) {
+		_subtitles.close();
+		g_system->hideOverlay();
+	}
 }
 
 void VideoPlayer::waitFrame() {

--- a/engines/groovie/video/player.cpp
+++ b/engines/groovie/video/player.cpp
@@ -87,10 +87,9 @@ bool VideoPlayer::playFrame() {
 	// Process the next frame while the file is open
 	if (_file) {
 		end = playFrameInternal();
-	}
 
-	uint32 currTime = _syst->getMillis();
-	_subtitles.drawSubtitle(currTime - _startTime);
+		_subtitles.drawSubtitle(_lastFrameTime - _startTime);
+	}
 
 	// The file has been completely processed
 	if (end) {
@@ -108,7 +107,10 @@ bool VideoPlayer::playFrame() {
 			}
 		}
 
-		g_system->hideOverlay();
+		if (_subtitles.isLoaded()) {
+			_subtitles.close();
+			g_system->hideOverlay();
+		}
 	}
 
 	return end;
@@ -124,8 +126,10 @@ void VideoPlayer::waitFrame() {
 		_lastFrameTime = currTime;
 		_frameTimeDrift = 0.0f;
 
-		g_system->showOverlay(false);
-		g_system->clearOverlay();
+		if (_subtitles.isLoaded()) {
+			g_system->showOverlay(false);
+			g_system->clearOverlay();
+		}
 	} else {
 		uint32 millisDiff = currTime - _lastFrameTime;
 		float fMillis = _millisBetweenFrames + _frameTimeDrift;

--- a/engines/groovie/video/player.h
+++ b/engines/groovie/video/player.h
@@ -50,6 +50,7 @@ public:
 	void setOverrideSpeed(bool isOverride);
 
 	void loadSubtitles(const char *fname) { _subtitles.loadSRTFile(fname); }
+	void unloadSubtitles();
 
 protected:
 	// To be implemented by subclasses

--- a/engines/mohawk/video.h
+++ b/engines/mohawk/video.h
@@ -219,6 +219,10 @@ public:
 	 */
 	void setVolume(int volume);
 
+	/**
+	 * Load the subtitles
+	 */
+	void loadSubtitles(const char *fname) { _subtitles.loadSRTFile(fname); }
 private:
 	// Non-changing variables
 	Video::VideoDecoder *_video;
@@ -231,6 +235,8 @@ private:
 	bool _loop;
 	bool _enabled;
 	Audio::Timestamp _start;
+
+	Video::Subtitles _subtitles;
 };
 
 typedef Common::SharedPtr<VideoEntry> VideoEntryPtr;
@@ -254,7 +260,6 @@ public:
 	VideoEntryPtr findVideo(const Common::String &fileName);
 	void drawVideoFrame(const VideoEntryPtr &video, const Audio::Timestamp &time);
 	void removeEntry(const VideoEntryPtr &video);
-	void loadSubtitles(const char *fname) { _subtitles.loadSRTFile(fname); }
 
 protected:
 	MohawkEngine *_vm;
@@ -274,8 +279,6 @@ protected:
 	// Dithering control
 	bool _enableDither;
 	void checkEnableDither(VideoEntryPtr &entry);
-
-	Video::Subtitles _subtitles;
 };
 
 } // End of namespace Mohawk

--- a/video/subtitles.h
+++ b/video/subtitles.h
@@ -85,8 +85,10 @@ private:
 
 	Graphics::Surface *_surface;
 
-	Common::Rect _bbox;
 	Common::Rect _drawRect;
+	Common::Rect _requestedBBox;
+	Common::Rect _realBBox;
+	int16 _lastOverlayWidth, _lastOverlayHeight;
 
 	Common::String _fname;
 	Common::String _subtitle;

--- a/video/subtitles.h
+++ b/video/subtitles.h
@@ -68,12 +68,16 @@ public:
 	void setBBox(const Common::Rect bbox);
 	void setColor(byte r, byte g, byte b);
 	void setPadding(uint16 horizontal, uint16 vertical);
-	void drawSubtitle(uint32 timestamp, bool force = false);
+	bool drawSubtitle(uint32 timestamp, bool force = false);
+	bool isLoaded() const { return _loaded || _subtitleDev; }
 
 private:
+	void renderSubtitle();
+
 	SRTParser _srtParser;
 	bool _loaded;
 	bool _subtitleDev;
+	bool _overlayHasAlpha;
 
 	const Graphics::Font *_font;
 	int _fontHeight;
@@ -81,9 +85,9 @@ private:
 	Graphics::Surface *_surface;
 
 	Common::Rect _bbox;
-	Common::Rect _dirtyRect;
+	Common::Rect _drawRect;
 
-	Common::String _prevSubtitle;
+	Common::String _subtitle;
 	uint32 _color;
 	uint32 _blackColor;
 	uint32 _transparentColor;

--- a/video/subtitles.h
+++ b/video/subtitles.h
@@ -64,6 +64,7 @@ public:
 	~Subtitles();
 
 	void loadSRTFile(const char *fname);
+	void close() { _loaded = false; _srtParser.cleanup(); }
 	void setFont(const char *fontname, int height = 18);
 	void setBBox(const Common::Rect bbox);
 	void setColor(byte r, byte g, byte b);

--- a/video/subtitles.h
+++ b/video/subtitles.h
@@ -64,7 +64,7 @@ public:
 	~Subtitles();
 
 	void loadSRTFile(const char *fname);
-	void close() { _loaded = false; _srtParser.cleanup(); }
+	void close() { _loaded = false; _subtitle.clear(); _fname.clear(); _srtParser.cleanup(); }
 	void setFont(const char *fontname, int height = 18);
 	void setBBox(const Common::Rect bbox);
 	void setColor(byte r, byte g, byte b);
@@ -88,6 +88,7 @@ private:
 	Common::Rect _bbox;
 	Common::Rect _drawRect;
 
+	Common::String _fname;
 	Common::String _subtitle;
 	uint32 _color;
 	uint32 _blackColor;


### PR DESCRIPTION
This is the follow up of #4417.

This PR:
- avoids clearing the overlay when it supports alpha,
- avoids updating screen when the engine will do it afterwards,
- reorders calls to draw subtitles in engines to have them displayed at the proper frame
- avoids calling `showOverlay` repeatedly,
- prevents messing with overlay when there is no subtitles,
- applies cosmetic changes to developer mode.

In the mean time it fixes some display bugs and properly handles pauses in MOHAWK (it has only been tested on the intro scene).
It has not been tested in GROOVIE and AGOS.