### PR TITLE
BLADERUNNER: optimize math calculations.

### DIFF
--- a/engines/bladerunner/slice_renderer.cpp
+++ b/engines/bladerunner/slice_renderer.cpp
@@ -612,10 +612,13 @@ void SliceRenderer::drawShadowInWorld(int transparency, Graphics::Surface &surfa
 		0.0f, 1.0f, 0.0f, _position.y,
 		0.0f, 0.0f, 1.0f, _position.z);
 
+	float s = sin(_facing);
+	float c = cos(_facing);
+
 	Matrix4x3 mRotation(
-		cos(_facing), -sin(_facing), 0.0f, 0.0f,
-		sin(_facing),  cos(_facing), 0.0f, 0.0f,
-		        0.0f,          0.0f, 1.0f, 0.0f);
+		   c,   -s, 0.0f, 0.0f,
+		   s,    c, 0.0f, 0.0f,
+		0.0f, 0.0f, 1.0f, 0.0f);
 
 	Matrix4x3 mScale(
 		_frameScale.x,          0.0f,              0.0f, 0.0f,


### PR DESCRIPTION
This patch just moves the calls to `sin()` and `cos()` outside the declaration of the rotation matrix, so that those values are calculated only one time, as it has been already done in other parts of this source code.
