### PR TITLE
MTROPOLIS: Add detection for Star Trek: The Game Show demo

### DIFF
--- a/engines/mtropolis/boot.cpp
+++ b/engines/mtropolis/boot.cpp
@@ -730,6 +730,21 @@ void SPQRGameDataHandler::unpackAdditionalFiles(Common::Array<Common::SharedPtr<
 	}
 }
 
+class STTGSGameDataHandler : public GameDataHandler {
+public:
+	STTGSGameDataHandler(const Game &game, const MTropolisGameDescription &gameDesc);
+
+	void addPlugIns(ProjectDescription &projectDesc, const Common::Array<FileIdentification> &files) override;
+};
+
+STTGSGameDataHandler::STTGSGameDataHandler(const Game &game, const MTropolisGameDescription &gameDesc) : GameDataHandler(game, gameDesc) {
+}
+
+void STTGSGameDataHandler::addPlugIns(ProjectDescription &projectDesc, const Common::Array<FileIdentification> &files) {
+	Common::SharedPtr<MTropolis::PlugIn> standardPlugIn = PlugIns::createStandard();
+	static_cast<Standard::StandardPlugIn *>(standardPlugIn.get())->getHacks().allowGarbledListModData = true;
+	projectDesc.addPlugIn(standardPlugIn);
+}
 
 static bool getMacTypesForMacBinary(const char *fileName, uint32 &outType, uint32 &outCreator) {
 	Common::SharedPtr<Common::SeekableReadStream> stream(SearchMan.createReadStreamForMember(fileName));
@@ -1107,6 +1122,12 @@ const char *spqrRetailMacDirectories[] = {
 	nullptr
 };
 
+const ManifestFile sttgsDemoWinFiles[] = {
+	{"MTPLAY95.EXE", MTFT_PLAYER},
+	{"Trektriv.mpl", MTFT_MAIN},
+	{nullptr, MTFT_AUTO}
+};
+
 const Game games[] = {
 	// Obsidian - Retail - Macintosh - English
 	{
@@ -1235,6 +1256,14 @@ const Game games[] = {
 		spqrRetailMacDirectories,
 		nullptr,
 		GameDataHandlerFactory<SPQRGameDataHandler>::create
+	},
+	// Star Trek: The Game Show - Demo - Windows
+	{
+		MTBOOT_STTGS_DEMO_WIN,
+		sttgsDemoWinFiles,
+		nullptr,
+		nullptr,
+		GameDataHandlerFactory<STTGSGameDataHandler>::create
 	},
 };
 

--- a/engines/mtropolis/detection.cpp
+++ b/engines/mtropolis/detection.cpp
@@ -31,6 +31,7 @@ static const PlainGameDescriptor mTropolisGames[] = {
 	{"obsidian", "Obsidian"},
 	{"mti", "Muppet Treasure Island"},
 	{"spqr", "SPQR: The Empire's Darkest Hour"},
+	{"sttgs", "Star Trek: The Game Show"},
 	{nullptr, nullptr}
 };
 

--- a/engines/mtropolis/detection.h
+++ b/engines/mtropolis/detection.h
@@ -29,8 +29,9 @@ namespace MTropolis {
 enum MTropolisGameID {
 	GID_OBSIDIAN			= 0,
 	GID_LEARNING_MTROPOLIS	= 1,
-	GID_MTI    				= 2,
-	GID_SPQR                = 3,
+	GID_MTI					= 2,
+	GID_SPQR				= 3,
+	GID_STTGS				= 4,
 };
 
 // Boot IDs - These can be shared across different variants if the file list and other properties are identical.
@@ -57,6 +58,8 @@ enum MTropolisGameBootID {
 
 	MTBOOT_SPQR_RETAIL_WIN,
 	MTBOOT_SPQR_RETAIL_MAC,
+
+	MTBOOT_STTGS_DEMO_WIN,
 };
 
 struct MTropolisGameDescription {

--- a/engines/mtropolis/detection_tables.h
+++ b/engines/mtropolis/detection_tables.h
@@ -488,6 +488,25 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		MTBOOT_SPQR_RETAIL_MAC,
 	},
 
+	{ // Star Trek: The Game Show demo
+		{
+			"sttgs",
+			"Demo",
+			{
+				// { "MTPLAY95.EXE", 0, "3ce9559e8c8047243fb7393a90d8b8f5", 756736 },
+				{ "Trektriv.mpl", 0, "2dfab3665f9d7a24473f7cd17a0615ba", 43003276 },
+				AD_LISTEND
+			},
+			Common::EN_ANY,
+			Common::kPlatformWindows,
+			ADGF_DEMO | ADGF_UNSTABLE,
+			GUIO0()
+		},
+		GID_STTGS,
+		0,
+		MTBOOT_STTGS_DEMO_WIN,
+	},
+
 	{ AD_TABLE_END_MARKER, 0, 0, MTBOOT_INVALID }
 };
 


### PR DESCRIPTION
Currently fails on `if (subObjectSize < lengthOfName * 256u)` in `PlugInModifier::load`