### PR TITLE
SAGA: Move intro scene tables to intproc_ite.cpp

### DIFF
--- a/engines/saga/detection.h
+++ b/engines/saga/detection.h
@@ -23,6 +23,7 @@
 #define SAGA_DETECTION_H
 
 #include "engines/advancedDetector.h"
+#include "engines/saga/shared_detection_defines.h"
 
 namespace Saga {
 
@@ -99,10 +100,8 @@ struct SAGAGameDescription {
 	int fontsCount;
 	const GameFontDescription *fontDescriptions;
 	const GamePatchDescription *patchDescriptions;
-	const LoadSceneParams *introScenes;
+	const ITEIntroSceneDesc *introScenes;
 };
-
-extern LoadSceneParams ITE_IntroListDefault[];
 
 } // End of namespace Saga
 

--- a/engines/saga/detection_tables.h
+++ b/engines/saga/detection_tables.h
@@ -187,63 +187,63 @@ static const GameFontDescription IHNMCD_GameFonts[]     = { {2}, {3}, {4}, {5}, 
 #define RID_ITE_CAVE_SCENE_DOS_DEMO 302
 #define RID_ITE_VALLEY_SCENE_DOS_DEMO 310
 
-LoadSceneParams ITE_IntroListDefault[] = {
-	{RID_ITE_INTRO_ANIM_SCENE, kLoadByResourceId, SceneHandlers::SC_ITEIntroAnimProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{RID_ITE_CAVE_SCENE_1, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave1Proc, false, kTransitionFade, 0, NO_CHAPTER_CHANGE},
-	{RID_ITE_CAVE_SCENE_2, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave2Proc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{RID_ITE_CAVE_SCENE_3, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave3Proc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{RID_ITE_CAVE_SCENE_4, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave4Proc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{RID_ITE_VALLEY_SCENE, (Saga::SceneLoadFlags) (kLoadByResourceId | kLoadBgMaskIsImage), SceneHandlers::SC_ITEIntroValleyProc, false, kTransitionFade, 0, NO_CHAPTER_CHANGE},
-	{RID_ITE_TREEHOUSE_SCENE, kLoadByResourceId, SceneHandlers::SC_ITEIntroTreeHouseProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{RID_ITE_FAIREPATH_SCENE, kLoadByResourceId, SceneHandlers::SC_ITEIntroFairePathProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{RID_ITE_FAIRETENT_SCENE, kLoadByResourceId, SceneHandlers::SC_ITEIntroFaireTentProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{0, kLoadByResourceId, nullptr, false, kTransitionNoFade, 0, 0}
+static const ITEIntroSceneDesc ITE_IntroListDefault[] = {
+	{RID_ITE_INTRO_ANIM_SCENE, ITEIntroSceneDesc::kTypeIntroAnim},
+	{RID_ITE_CAVE_SCENE_1, ITEIntroSceneDesc::kTypeIntroCave1},
+	{RID_ITE_CAVE_SCENE_2, ITEIntroSceneDesc::kTypeIntroCave2},
+	{RID_ITE_CAVE_SCENE_3, ITEIntroSceneDesc::kTypeIntroCave3},
+	{RID_ITE_CAVE_SCENE_4, ITEIntroSceneDesc::kTypeIntroCave4},
+	{RID_ITE_VALLEY_SCENE, ITEIntroSceneDesc::kTypeIntroValley},
+	{RID_ITE_TREEHOUSE_SCENE, ITEIntroSceneDesc::kTypeIntroTreeHouse},
+	{RID_ITE_FAIREPATH_SCENE, ITEIntroSceneDesc::kTypeIntroFairePath},
+	{RID_ITE_FAIRETENT_SCENE, ITEIntroSceneDesc::kTypeIntroFaireTent},
+	{0, ITEIntroSceneDesc::kTypeEndMarker}
 };
 
-static const LoadSceneParams ITE_AmigaEnglishECSCD_IntroList[] = {
-//	{1544, kLoadByResourceId, SceneHandlers::SC_ITEIntroAnimProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE}, // Crashes, skip for now
-	{1548, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave1Proc, false, kTransitionFade, 0, NO_CHAPTER_CHANGE},
-	{1551, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave2Proc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{1554, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave3Proc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{1557, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave4Proc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{1562, (Saga::SceneLoadFlags) (kLoadByResourceId | kLoadBgMaskIsImage), SceneHandlers::SC_ITEIntroValleyProc, false, kTransitionFade, 0, NO_CHAPTER_CHANGE},
-	{1566, kLoadByResourceId, SceneHandlers::SC_ITEIntroTreeHouseProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{1570, kLoadByResourceId, SceneHandlers::SC_ITEIntroFairePathProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{1573, kLoadByResourceId, SceneHandlers::SC_ITEIntroFaireTentProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{0, kLoadByResourceId, nullptr, false, kTransitionNoFade, 0, 0}
+static const ITEIntroSceneDesc ITE_AmigaEnglishECSCD_IntroList[] = {
+//	{1544, ITEIntroSceneDesc::kTypeIntroAnim}, // Crashes, skip for now
+	{1548, ITEIntroSceneDesc::kTypeIntroCave1},
+	{1551, ITEIntroSceneDesc::kTypeIntroCave2},
+	{1554, ITEIntroSceneDesc::kTypeIntroCave3},
+	{1557, ITEIntroSceneDesc::kTypeIntroCave4},
+	{1562, ITEIntroSceneDesc::kTypeIntroValley},
+	{1566, ITEIntroSceneDesc::kTypeIntroTreeHouse},
+	{1570, ITEIntroSceneDesc::kTypeIntroFairePath},
+	{1573, ITEIntroSceneDesc::kTypeIntroFaireTent},
+	{0, ITEIntroSceneDesc::kTypeEndMarker}
 };
 
-static const LoadSceneParams ITE_AmigaGermanAGA_IntroList[] = {
-	{1538, kLoadByResourceId, SceneHandlers::SC_ITEIntroAnimProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{1543, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave1Proc, false, kTransitionFade, 0, NO_CHAPTER_CHANGE},
-	{1547, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave2Proc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{1551, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave3Proc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{1555, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave4Proc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{1560, (Saga::SceneLoadFlags) (kLoadByResourceId | kLoadBgMaskIsImage), SceneHandlers::SC_ITEIntroValleyProc, false, kTransitionFade, 0, NO_CHAPTER_CHANGE},
-	{1564, kLoadByResourceId, SceneHandlers::SC_ITEIntroTreeHouseProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{1568, kLoadByResourceId, SceneHandlers::SC_ITEIntroFairePathProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{1571, kLoadByResourceId, SceneHandlers::SC_ITEIntroFaireTentProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{0, kLoadByResourceId, nullptr, false, kTransitionNoFade, 0, 0}
+static const ITEIntroSceneDesc ITE_AmigaGermanAGA_IntroList[] = {
+	{1538, ITEIntroSceneDesc::kTypeIntroAnim},
+	{1543, ITEIntroSceneDesc::kTypeIntroCave1},
+	{1547, ITEIntroSceneDesc::kTypeIntroCave2},
+	{1551, ITEIntroSceneDesc::kTypeIntroCave3},
+	{1555, ITEIntroSceneDesc::kTypeIntroCave4},
+	{1560, ITEIntroSceneDesc::kTypeIntroValley},
+	{1564, ITEIntroSceneDesc::kTypeIntroTreeHouse},
+	{1568, ITEIntroSceneDesc::kTypeIntroFairePath},
+	{1571, ITEIntroSceneDesc::kTypeIntroFaireTent},
+	{0, ITEIntroSceneDesc::kTypeEndMarker}
 };
 
-static const LoadSceneParams ITE_AmigaGermanECS_IntroList[] = {
-	{1544, kLoadByResourceId, SceneHandlers::SC_ITEIntroAnimProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{1549, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave1Proc, false, kTransitionFade, 0, NO_CHAPTER_CHANGE},
-	{1553, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave2Proc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{1557, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave3Proc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{1561, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave4Proc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{1566, (Saga::SceneLoadFlags) (kLoadByResourceId | kLoadBgMaskIsImage), SceneHandlers::SC_ITEIntroValleyProc, false, kTransitionFade, 0, NO_CHAPTER_CHANGE},
-	{1570, kLoadByResourceId, SceneHandlers::SC_ITEIntroTreeHouseProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{1574, kLoadByResourceId, SceneHandlers::SC_ITEIntroFairePathProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{1577, kLoadByResourceId, SceneHandlers::SC_ITEIntroFaireTentProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{0, kLoadByResourceId, nullptr, false, kTransitionNoFade, 0, 0}
+static const ITEIntroSceneDesc ITE_AmigaGermanECS_IntroList[] = {
+	{1544, ITEIntroSceneDesc::kTypeIntroAnim},
+	{1549, ITEIntroSceneDesc::kTypeIntroCave1},
+	{1553, ITEIntroSceneDesc::kTypeIntroCave2},
+	{1557, ITEIntroSceneDesc::kTypeIntroCave3},
+	{1561, ITEIntroSceneDesc::kTypeIntroCave4},
+	{1566, ITEIntroSceneDesc::kTypeIntroValley},
+	{1570, ITEIntroSceneDesc::kTypeIntroTreeHouse},
+	{1574, ITEIntroSceneDesc::kTypeIntroFairePath},
+	{1577, ITEIntroSceneDesc::kTypeIntroFaireTent},
+	{0, ITEIntroSceneDesc::kTypeEndMarker}
 };
 
-static const LoadSceneParams ITE_DOS_Demo_IntroList[] = {
-	{RID_ITE_INTRO_ANIM_SCENE_DOS_DEMO, kLoadByResourceId, SceneHandlers::SC_ITEIntroAnimProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
-	{RID_ITE_CAVE_SCENE_DOS_DEMO, kLoadByResourceId, SceneHandlers::SC_ITEIntroCaveDemoProc, false, kTransitionFade, 0, NO_CHAPTER_CHANGE},
-	{RID_ITE_VALLEY_SCENE_DOS_DEMO, kLoadByResourceId, SceneHandlers::SC_ITEIntroValleyProc, false, kTransitionFade, 0, NO_CHAPTER_CHANGE},
-	{0, kLoadByResourceId, nullptr, false, kTransitionNoFade, 0, 0}
+static const ITEIntroSceneDesc ITE_DOS_Demo_IntroList[] = {
+	{RID_ITE_INTRO_ANIM_SCENE_DOS_DEMO, ITEIntroSceneDesc::kTypeIntroAnim},
+	{RID_ITE_CAVE_SCENE_DOS_DEMO, ITEIntroSceneDesc::kTypeIntroCaveDemo},
+	{RID_ITE_VALLEY_SCENE_DOS_DEMO, ITEIntroSceneDesc::kTypeIntroValley},
+	{0, ITEIntroSceneDesc::kTypeEndMarker}
 };
 
 // Patch files. Files not found will be ignored

--- a/engines/saga/introproc_ite.cpp
+++ b/engines/saga/introproc_ite.cpp
@@ -37,6 +37,20 @@
 
 namespace Saga {
 
+class SceneHandlers {
+public:
+	static int SC_ITEIntroAnimProc(int param, void *refCon);
+	static int SC_ITEIntroCave1Proc(int param, void *refCon);
+	static int SC_ITEIntroCave2Proc(int param, void *refCon);
+	static int SC_ITEIntroCave3Proc(int param, void *refCon);
+	static int SC_ITEIntroCave4Proc(int param, void *refCon);
+	static int SC_ITEIntroValleyProc(int param, void *refCon);
+	static int SC_ITEIntroTreeHouseProc(int param, void *refCon);
+	static int SC_ITEIntroFairePathProc(int param, void *refCon);
+	static int SC_ITEIntroFaireTentProc(int param, void *refCon);
+	static int SC_ITEIntroCaveDemoProc(int param, void *refCon);
+};
+
 #define INTRO_FRAMETIME 90
 #define INTRO_CAPTION_Y 170
 #define INTRO_DE_CAPTION_Y 160
@@ -53,16 +67,32 @@ namespace Saga {
 #define MUSIC_INTRO 9
 #define MUSIC_TITLE_THEME 10
 
+namespace {
+LoadSceneParams sceneParams[] = {
+	{0, kLoadByResourceId, nullptr, false, kTransitionNoFade, 0, 0},
+	{0, kLoadByResourceId, SceneHandlers::SC_ITEIntroAnimProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
+       	{0, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave1Proc, false, kTransitionFade, 0, NO_CHAPTER_CHANGE},
+	{0, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave2Proc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
+	{0, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave3Proc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
+	{0, kLoadByResourceId, SceneHandlers::SC_ITEIntroCave4Proc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
+	{0, (Saga::SceneLoadFlags) (kLoadByResourceId | kLoadBgMaskIsImage), SceneHandlers::SC_ITEIntroValleyProc, false, kTransitionFade, 0, NO_CHAPTER_CHANGE},
+	{0, kLoadByResourceId, SceneHandlers::SC_ITEIntroTreeHouseProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
+	{0, kLoadByResourceId, SceneHandlers::SC_ITEIntroFairePathProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
+	{0, kLoadByResourceId, SceneHandlers::SC_ITEIntroFaireTentProc, false, kTransitionNoFade, 0, NO_CHAPTER_CHANGE},
+	{0, kLoadByResourceId, SceneHandlers::SC_ITEIntroCaveDemoProc, false, kTransitionFade, 0, NO_CHAPTER_CHANGE},
+};
+}
+
 int Scene::ITEStartProc() {
 	LoadSceneParams firstScene;
 	LoadSceneParams tempScene;
-	const LoadSceneParams *scenes;
+	const ITEIntroSceneDesc *scenes;
 
 	scenes = _vm->getIntroScenes();
 
-	for (int i = 0; scenes[i].sceneDescriptor; i++) {
-		tempScene = scenes[i];
-		tempScene.sceneDescriptor = _vm->_resource->convertResourceId(tempScene.sceneDescriptor);
+	for (int i = 0; scenes[i].sceneType != ITEIntroSceneDesc::kTypeEndMarker; i++) {
+		tempScene = sceneParams[scenes[i].sceneType];
+		tempScene.sceneDescriptor = _vm->_resource->convertResourceId(scenes[i].sceneDescriptor);
 		_vm->_scene->queueScene(tempScene);
 	}
 

--- a/engines/saga/saga.h
+++ b/engines/saga/saga.h
@@ -424,7 +424,7 @@ public:
 	bool isAGA() const { return _gameDescription->features & GF_AGA_GRAPHICS; }
 	bool isECS() const { return _gameDescription->features & GF_ECS_GRAPHICS; }
 	unsigned getPalNumEntries() const { return isECS() ? 32 : 256; }
-	const LoadSceneParams *getIntroScenes() const { return _gameDescription->introScenes; }
+	const ITEIntroSceneDesc *getIntroScenes() const { return _gameDescription->introScenes; }
 
 	int16 _framesEsc;
 

--- a/engines/saga/scene.h
+++ b/engines/saga/scene.h
@@ -85,6 +85,32 @@ enum SAGAResourceTypes {
 	SAGA_PALETTE
 };
 
+typedef int (SceneProc) (int, void *);
+
+enum SceneTransitionType {
+	kTransitionNoFade,
+	kTransitionFade
+};
+
+enum SceneLoadFlags {
+	kLoadByResourceId = 0,
+	kLoadBySceneNumber = 1,
+	kLoadIdTypeMask = 1,
+	kLoadBgMaskIsImage = 1 << 16,
+};
+
+struct LoadSceneParams {
+	int32 sceneDescriptor;
+	SceneLoadFlags loadFlag;
+	SceneProc *sceneProc;
+	bool sceneSkipTarget;
+	SceneTransitionType transitionType;
+	int actorsEntrance;
+	int chapter;
+};
+
+#define NO_CHAPTER_CHANGE -2
+
 #define SAGA_RESLIST_ENTRY_LEN 4
 
 struct SceneResourceData {
@@ -146,6 +172,8 @@ typedef Common::List<LoadSceneParams> SceneQueueList;
 #define IHNM_TITLE_TIME_FM   19500
 
 #define CREDIT_DURATION1 4000
+
+class SceneHandlers;
 
 class Scene {
  public:

--- a/engines/saga/shared_detection_defines.h
+++ b/engines/saga/shared_detection_defines.h
@@ -19,6 +19,9 @@
  *
  */
 
+#ifndef SAGA_SHARED_DETECTION_DEFINES_H
+#define SAGA_SHARED_DETECTION_DEFINES_H
+
 // Default scenes
 #define ITE_DEFAULT_SCENE 32
 #define IHNM_DEFAULT_SCENE 151
@@ -26,43 +29,24 @@
 #define IHNMDEMO_DEFAULT_SCENE 144
 
 namespace Saga {
-typedef int (SceneProc) (int, void *);
 
-class SceneHandlers {
-public:
-	static int SC_ITEIntroAnimProc(int param, void *refCon);
-	static int SC_ITEIntroCave1Proc(int param, void *refCon);
-	static int SC_ITEIntroCave2Proc(int param, void *refCon);
-	static int SC_ITEIntroCave3Proc(int param, void *refCon);
-	static int SC_ITEIntroCave4Proc(int param, void *refCon);
-	static int SC_ITEIntroValleyProc(int param, void *refCon);
-	static int SC_ITEIntroTreeHouseProc(int param, void *refCon);
-	static int SC_ITEIntroFairePathProc(int param, void *refCon);
-	static int SC_ITEIntroFaireTentProc(int param, void *refCon);
-	static int SC_ITEIntroCaveDemoProc(int param, void *refCon);
+struct ITEIntroSceneDesc {
+	int sceneDescriptor;
+
+	enum LoadSceneType {
+		kTypeEndMarker,
+		kTypeIntroAnim,
+		kTypeIntroCave1,
+		kTypeIntroCave2,
+		kTypeIntroCave3,
+		kTypeIntroCave4,
+		kTypeIntroValley,
+		kTypeIntroTreeHouse,
+		kTypeIntroFairePath,
+		kTypeIntroFaireTent,
+		kTypeIntroCaveDemo,
+	} sceneType;
 };
-
-enum SceneTransitionType {
-	kTransitionNoFade,
-	kTransitionFade
-};
-
-enum SceneLoadFlags {
-	kLoadByResourceId = 0,
-	kLoadBySceneNumber = 1,
-	kLoadIdTypeMask = 1,
-	kLoadBgMaskIsImage = 1 << 16,
-};
-
-struct LoadSceneParams {
-	int32 sceneDescriptor;
-	SceneLoadFlags loadFlag;
-	SceneProc *sceneProc;
-	bool sceneSkipTarget;
-	SceneTransitionType transitionType;
-	int actorsEntrance;
-	int chapter;
-};
-
-#define NO_CHAPTER_CHANGE -2
 }
+
+#endif


### PR DESCRIPTION
Keep types and resource ids in detection_table.h. This allows to keep resource ids in detection_table.h while fixing build with saga detection but no saga itself

