### PR TITLE
MTROPOLIS: Two fixes for SPQR

### DIFF
--- a/engines/mtropolis/elements.cpp
+++ b/engines/mtropolis/elements.cpp
@@ -1558,7 +1558,6 @@ MiniscriptInstructionOutcome MToonElement::scriptSetRange(MiniscriptThread *thre
 	if (value.getType() == DynamicValueTypes::kPoint)
 		return scriptSetRangeTyped(thread, value.getPoint());
 
-	return scriptSetRangeTyped(thread, value.getIntRange());
 	thread->error("Invalid type for mToon range");
 	return kMiniscriptInstructionOutcomeFailed;
 }

--- a/engines/mtropolis/elements.cpp
+++ b/engines/mtropolis/elements.cpp
@@ -1553,12 +1553,14 @@ MiniscriptInstructionOutcome MToonElement::scriptSetCel(MiniscriptThread *thread
 }
 
 MiniscriptInstructionOutcome MToonElement::scriptSetRange(MiniscriptThread *thread, const DynamicValue &value) {
-	if (value.getType() != DynamicValueTypes::kIntegerRange) {
-		thread->error("Invalid type for mToon range");
-		return kMiniscriptInstructionOutcomeFailed;
-	}
+	if (value.getType() == DynamicValueTypes::kIntegerRange)
+		return scriptSetRangeTyped(thread, value.getIntRange());
+	if (value.getType() == DynamicValueTypes::kPoint)
+		return scriptSetRangeTyped(thread, value.getPoint());
 
 	return scriptSetRangeTyped(thread, value.getIntRange());
+	thread->error("Invalid type for mToon range");
+	return kMiniscriptInstructionOutcomeFailed;
 }
 
 MiniscriptInstructionOutcome MToonElement::scriptSetRangeStart(MiniscriptThread *thread, const DynamicValue &value) {
@@ -1634,6 +1636,11 @@ MiniscriptInstructionOutcome MToonElement::scriptSetRangeTyped(MiniscriptThread 
 	}
 
 	return kMiniscriptInstructionOutcomeContinue;
+}
+
+MiniscriptInstructionOutcome MToonElement::scriptSetRangeTyped(MiniscriptThread *thread, const Common::Point &pointRef) {
+	IntRange intRange(pointRef.x, pointRef.y);
+	return scriptSetRangeTyped(thread, intRange);
 }
 
 void MToonElement::onPauseStateChanged() {

--- a/engines/mtropolis/elements.h
+++ b/engines/mtropolis/elements.h
@@ -272,6 +272,7 @@ private:
 
 	MiniscriptInstructionOutcome scriptRangeWriteRefAttribute(MiniscriptThread *thread, DynamicValueWriteProxy &result, const Common::String &attrib);
 	MiniscriptInstructionOutcome scriptSetRangeTyped(MiniscriptThread *thread, const IntRange &value);
+	MiniscriptInstructionOutcome scriptSetRangeTyped(MiniscriptThread *thread, const Common::Point &value);
 
 	void onPauseStateChanged() override;
 

--- a/engines/mtropolis/runtime.cpp
+++ b/engines/mtropolis/runtime.cpp
@@ -2674,6 +2674,9 @@ bool WorldManagerInterface::readAttribute(MiniscriptThread *thread, DynamicValue
 	} else if (attrib == "combineredraws") {
 		result.setBool(_combineRedraws);
 		return true;
+	} else if (attrib == "postponeredraws") {
+		result.setBool(_postponeRedraws);
+		return true;
 	}
 
 	return RuntimeObject::readAttribute(thread, result, attrib);
@@ -2697,6 +2700,9 @@ MiniscriptInstructionOutcome WorldManagerInterface::writeRefAttribute(Miniscript
 		return kMiniscriptInstructionOutcomeContinue;
 	} else if (attrib == "combineredraws") {
 		DynamicValueWriteBoolHelper::create(&_combineRedraws, result);
+		return kMiniscriptInstructionOutcomeContinue;
+	} else if (attrib == "postponeredraws") {
+		DynamicValueWriteBoolHelper::create(&_postponeRedraws, result);
 		return kMiniscriptInstructionOutcomeContinue;
 	} else if (attrib == "qtpalettehack") {
 		DynamicValueWriteDiscardHelper::create(result);

--- a/engines/mtropolis/runtime.cpp
+++ b/engines/mtropolis/runtime.cpp
@@ -2650,7 +2650,7 @@ void MessageProperties::setValue(const DynamicValue &value) {
 		_value = value;
 }
 
-WorldManagerInterface::WorldManagerInterface() : _gameMode(false), _combineRedraws(true), _opInt(0) {
+WorldManagerInterface::WorldManagerInterface() : _gameMode(false), _combineRedraws(true), _postponeRedraws(false), _opInt(0) {
 }
 
 bool WorldManagerInterface::readAttribute(MiniscriptThread *thread, DynamicValue &result, const Common::String &attrib) {

--- a/engines/mtropolis/runtime.h
+++ b/engines/mtropolis/runtime.h
@@ -2044,6 +2044,7 @@ private:
 	int32 _opInt;
 	bool _gameMode;
 	bool _combineRedraws;
+	bool _postponeRedraws;
 };
 
 class AssetManagerInterface : public RuntimeObject {


### PR DESCRIPTION
This PR makes two changes so SPQR's second puzzle works:

- It adds the `postponeredraws` attribute to the worldmanager.
- It allows setting the animation range of an mToon to a floating-point range. SPQR does this and it used to crash. Note: I have not RE'd the original interpreter so I cannot be sure this behavior is correct, but it works fine for SPQR.