### PR TITLE
SAGA: Move extra tables out of the detection plugin

### DIFF
--- a/engines/saga/detection.h
+++ b/engines/saga/detection.h
@@ -26,35 +26,6 @@
 
 namespace Saga {
 
-struct GameResourceDescription {
-	uint32 sceneLUTResourceId;
-	uint32 moduleLUTResourceId;
-	uint32 mainPanelResourceId;
-	uint32 conversePanelResourceId;
-	uint32 optionPanelResourceId;
-	uint32 mainSpritesResourceId;
-	uint32 mainPanelSpritesResourceId;
-	uint32 mainStringsResourceId;
-	// ITE specific resources
-	uint32 actorsStringsResourceId;
-	uint32 defaultPortraitsResourceId;
-	// IHNM specific resources
-	uint32 optionPanelSpritesResourceId;
-	uint32 warningPanelResourceId;
-	uint32 warningPanelSpritesResourceId;
-	uint32 psychicProfileResourceId;
-};
-
-struct GameFontDescription {
-	uint32 fontResourceId;
-};
-
-struct GamePatchDescription {
-	const char *fileName;
-	uint16 fileType;
-	uint32 resourceId;
-};
-
 enum GameIds {
 	GID_ITE = 0,
 	GID_IHNM = 1
@@ -88,7 +59,39 @@ enum GameFileTypes {
 	GAME_PATCHFILE        = 1 << 10    // IHNM patch file (patch.re_/patch.res)
 };
 
-// Make sure to update ITE_IntroLists if this enum is reordered.
+// Make sure to update ResourceLists in saga.c if this enum is reordered.
+enum GameResourceList : uint8 {
+	RESOURCELIST_NONE = 0,
+	RESOURCELIST_ITE,
+	RESOURCELIST_ITE_ENGLISH_ECS_CD,
+	RESOURCELIST_ITE_GERMAN_AGA_CD,
+	RESOURCELIST_ITE_GERMAN_ECS_CD,
+	RESOURCELIST_ITE_DEMO,
+	RESOURCELIST_IHNM,
+	RESOURCELIST_IHNM_DEMO,
+	RESOURCELIST_MAX
+};
+
+// Make sure to update FontLists in font.c if this enum is reordered.
+enum GameFontList : uint8 {
+	FONTLIST_NONE = 0,
+	FONTLIST_ITE,
+	FONTLIST_ITE_DEMO,
+	FONTLIST_ITE_WIN_DEMO,
+	FONTLIST_IHNM_DEMO,
+	FONTLIST_IHNM_CD,
+	FONTLIST_MAX
+};
+
+// Make sure to update PatchLists in resource.c if this enum is reordered.
+enum GamePatchList : uint8 {
+	PATCHLIST_NONE = 0,
+	PATCHLIST_ITE,
+	PATCHLIST_ITE_MAC,
+	PATCHLIST_MAX
+};
+
+// Make sure to update ITE_IntroLists in introproc_ite.c if this enum is reordered.
 enum GameIntroList : uint8 {
 	INTROLIST_NONE = 0,
 	INTROLIST_ITE_DEFAULT,
@@ -106,10 +109,9 @@ struct SAGAGameDescription {
 	int gameId;
 	uint32 features;
 	int startSceneNumber;
-	const GameResourceDescription *resourceDescription;
-	int fontsCount;
-	const GameFontDescription *fontDescriptions;
-	const GamePatchDescription *patchDescriptions;
+	GameResourceList resourceList;
+	GameFontList fontList;
+	GamePatchList patchList;
 	GameIntroList introList;
 };
 

--- a/engines/saga/detection.h
+++ b/engines/saga/detection.h
@@ -91,7 +91,7 @@ enum GamePatchList : uint8 {
 	PATCHLIST_MAX
 };
 
-// Make sure to update ITE_IntroLists in introproc_ite.c if this enum is reordered.
+// Make sure to update ITE_IntroLists in introproc_ite.cpp if this enum is reordered.
 enum GameIntroList : uint8 {
 	INTROLIST_NONE = 0,
 	INTROLIST_ITE_DEFAULT,

--- a/engines/saga/detection.h
+++ b/engines/saga/detection.h
@@ -59,7 +59,7 @@ enum GameFileTypes {
 	GAME_PATCHFILE        = 1 << 10    // IHNM patch file (patch.re_/patch.res)
 };
 
-// Make sure to update ResourceLists in saga.c if this enum is reordered.
+// Make sure to update ResourceLists in saga.cpp if this enum is reordered.
 enum GameResourceList : uint8 {
 	RESOURCELIST_NONE = 0,
 	RESOURCELIST_ITE,
@@ -72,7 +72,7 @@ enum GameResourceList : uint8 {
 	RESOURCELIST_MAX
 };
 
-// Make sure to update FontLists in font.c if this enum is reordered.
+// Make sure to update FontLists in font.cpp if this enum is reordered.
 enum GameFontList : uint8 {
 	FONTLIST_NONE = 0,
 	FONTLIST_ITE,
@@ -83,7 +83,7 @@ enum GameFontList : uint8 {
 	FONTLIST_MAX
 };
 
-// Make sure to update PatchLists in resource.c if this enum is reordered.
+// Make sure to update PatchLists in resource.cpp if this enum is reordered.
 enum GamePatchList : uint8 {
 	PATCHLIST_NONE = 0,
 	PATCHLIST_ITE,

--- a/engines/saga/detection_tables.h
+++ b/engines/saga/detection_tables.h
@@ -29,203 +29,6 @@
 
 namespace Saga {
 
-static const GameResourceDescription ITE_Resources_GermanAGACD = {
-	1810,	// Scene lookup table RN
-	216,	// Script lookup table RN
-	3,		// Main panel
-	4,		// Converse panel
-	5,		// Option panel
-	6,		// Main sprites
-	7,		// Main panel sprites
-	35,		// Main strings
-	// ITE specific resources
-	36,		// Actor names
-	125,	// Default portraits
-	// IHNM specific resources
-	0,		// Option panel sprites
-	0,		// Warning panel
-	0,		// Warning panel sprites
-	0		// Psychic profile background
-};
-
-static const GameResourceDescription ITE_Resources_GermanECSCD = {
-	1816,	// Scene lookup table RN
-	216,	// Script lookup table RN
-	3,		// Main panel
-	4,		// Converse panel
-	5,		// Option panel
-	6,		// Main sprites
-	7,		// Main panel sprites
-	35,		// Main strings
-	// ITE specific resources
-	36,		// Actor names
-	125,	// Default portraits
-	// IHNM specific resources
-	0,		// Option panel sprites
-	0,		// Warning panel
-	0,		// Warning panel sprites
-	0		// Psychic profile background
-};
-
-static const GameResourceDescription ITE_Resources = {
-	1806,	// Scene lookup table RN
-	216,	// Script lookup table RN
-	3,		// Main panel
-	4,		// Converse panel
-	5,		// Option panel
-	6,		// Main sprites
-	7,		// Main panel sprites
-	35,		// Main strings
-	// ITE specific resources
-	36,		// Actor names
-	125,	// Default portraits
-	// IHNM specific resources
-	0,		// Option panel sprites
-	0,		// Warning panel
-	0,		// Warning panel sprites
-	0		// Psychic profile background
-};
-
-static const GameResourceDescription ITE_Resources_EnglishECSCD = {
-	1812,	// Scene lookup table RN
-	216,	// Script lookup table RN
-	3,		// Main panel
-	4,		// Converse panel
-	5,		// Option panel
-	6,		// Main sprites
-	7,		// Main panel sprites
-	35,		// Main strings
-	// ITE specific resources
-	36,		// Actor names
-	125,	// Default portraits
-	// IHNM specific resources
-	0,		// Option panel sprites
-	0,		// Warning panel
-	0,		// Warning panel sprites
-	0		// Psychic profile background
-};
-
-// FIXME: Option panel should be 4 but it is an empty resource.
-// Proper fix would be to not load the options panel when the demo is running
-static const GameResourceDescription ITEDemo_Resources = {
-	318,	// Scene lookup table RN
-	146,	// Script lookup table RN
-	2,		// Main panel
-	3,		// Converse panel
-	3,		// Option panel
-	5,		// Main sprites
-	6,		// Main panel sprites
-	8,		// Main strings
-	// ITE specific resources
-	9,		// Actor names
-	80,		// Default portraits
-	// IHNM specific resources
-	0,		// Option panel sprites
-	0,		// Warning panel
-	0,		// Warning panel sprites
-	0		// Psychic profile background
-};
-
-static const GameResourceDescription IHNM_Resources = {
-	1272,	// Scene lookup table RN
-	29,		// Script lookup table RN
-	9,		// Main panel
-	10,		// Converse panel
-	15,		// Option panel
-	12,		// Main sprites
-	12,		// Main panel sprites
-	21,		// Main strings
-	// ITE specific resources
-	0,		// Actor names
-	0,		// Default portraits
-	// IHNM specific resources
-	16,		// Option panel sprites
-	17,		// Warning panel
-	18,		// Warning panel sprites
-	20		// Psychic profile background
-};
-
-static const GameResourceDescription IHNMDEMO_Resources = {
-	286,	// Scene lookup table RN
-	18,		// Script lookup table RN
-	5,		// Main panel
-	6,		// Converse panel
-	10,		// Option panel
-	7,		// Main sprites
-	7,		// Main panel sprites
-	16,		// Main strings
-	// ITE specific resources
-	0,		// Actor names
-	0,		// Default portraits
-	// IHNM specific resources
-	11,		// Option panel sprites
-	12,		// Warning panel
-	13,		// Warning panel sprites
-	15		// Psychic profile background
-};
-
-static const GameFontDescription ITEDEMO_GameFonts[]    = { {0}, {1} };
-static const GameFontDescription ITEWINDEMO_GameFonts[] = { {2}, {0} };
-static const GameFontDescription ITE_GameFonts[]        = { {2}, {0}, {1} };
-static const GameFontDescription IHNMDEMO_GameFonts[]   = { {2}, {3}, {4} };
-// Font 6 is kIHNMFont8, font 8 is kIHNMMainFont
-static const GameFontDescription IHNMCD_GameFonts[]     = { {2}, {3}, {4}, {5}, {6}, {7}, {8} };
-
-// Patch files. Files not found will be ignored
-static const GamePatchDescription ITEPatch_Files[] = {
-	{       "cave.mid", GAME_RESOURCEFILE,    9},
-	{      "intro.mid", GAME_RESOURCEFILE,   10},
-	{   "fvillage.mid", GAME_RESOURCEFILE,   11},
-	{    "elkhall.mid", GAME_RESOURCEFILE,   12},
-	{      "mouse.mid", GAME_RESOURCEFILE,   13},
-	{   "darkclaw.mid", GAME_RESOURCEFILE,   14},
-	{   "birdchrp.mid", GAME_RESOURCEFILE,   15},
-	{   "orbtempl.mid", GAME_RESOURCEFILE,   16},
-	{     "spooky.mid", GAME_RESOURCEFILE,   17},
-	{    "catfest.mid", GAME_RESOURCEFILE,   18},
-	{ "elkfanfare.mid", GAME_RESOURCEFILE,   19},
-	{     "bcexpl.mid", GAME_RESOURCEFILE,   20},
-	{   "boargtnt.mid", GAME_RESOURCEFILE,   21},
-	{   "boarking.mid", GAME_RESOURCEFILE,   22},
-	{   "explorea.mid", GAME_RESOURCEFILE,   23},
-	{   "exploreb.mid", GAME_RESOURCEFILE,   24},
-	{   "explorec.mid", GAME_RESOURCEFILE,   25},
-	{   "sunstatm.mid", GAME_RESOURCEFILE,   26},
-	{   "nitstrlm.mid", GAME_RESOURCEFILE,   27},
-	{   "humruinm.mid", GAME_RESOURCEFILE,   28},
-	{   "damexplm.mid", GAME_RESOURCEFILE,   29},
-	{     "tychom.mid", GAME_RESOURCEFILE,   30},
-	{     "kitten.mid", GAME_RESOURCEFILE,   31},
-	{      "sweet.mid", GAME_RESOURCEFILE,   32},
-	{   "brutalmt.mid", GAME_RESOURCEFILE,   33},
-	{     "shiala.mid", GAME_RESOURCEFILE,   34},
-
-	{       "wyrm.pak", GAME_RESOURCEFILE, 1529},
-	{      "wyrm1.dlt", GAME_RESOURCEFILE, 1530},
-	{      "wyrm2.dlt", GAME_RESOURCEFILE, 1531},
-	{      "wyrm3.dlt", GAME_RESOURCEFILE, 1532},
-	{      "wyrm4.dlt", GAME_RESOURCEFILE, 1533},
-	{   "credit3n.dlt", GAME_RESOURCEFILE, 1796}, // PC
-	{   "credit3m.dlt", GAME_RESOURCEFILE, 1796}, // Macintosh
-	{   "credit4n.dlt", GAME_RESOURCEFILE, 1797}, // PC
-	{   "credit4m.dlt", GAME_RESOURCEFILE, 1797}, // Macintosh
-	{       "p2_a.voc", GAME_VOICEFILE,       4},
-	{       "p2_a.iaf", GAME_VOICEFILE,       4},
-	{             NULL,              0,       0}
-};
-
-static const GamePatchDescription ITEMacPatch_Files[] = {
-	{       "wyrm.pak", GAME_RESOURCEFILE, 1529},
-	{      "wyrm1.dlt", GAME_RESOURCEFILE, 1530},
-	{      "wyrm2.dlt", GAME_RESOURCEFILE, 1531},
-	{      "wyrm3.dlt", GAME_RESOURCEFILE, 1532},
-	{      "wyrm4.dlt", GAME_RESOURCEFILE, 1533},
-	{   "credit3m.dlt", GAME_RESOURCEFILE, 1796},
-	{   "credit4m.dlt", GAME_RESOURCEFILE, 1797},
-	{       "p2_a.iaf", GAME_VOICEFILE,       4},
-	{             NULL,              0,       0}
-};
-
 static const SAGAGameDescription gameDescriptions[] = {
 	// ITE Section ////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -256,10 +59,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		GF_ITE_DOS_DEMO,
 		ITE_DEFAULT_SCENE,
-		&ITEDemo_Resources,
-		ARRAYSIZE(ITEDEMO_GameFonts),
-		ITEDEMO_GameFonts,
-		NULL,
+		RESOURCELIST_ITE_DEMO,
+		FONTLIST_ITE_DEMO,
+		PATCHLIST_NONE,
 		INTROLIST_ITE_DOS_DEMO,
 	},
 
@@ -281,10 +83,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITEWINDEMO_GameFonts),
-		ITEWINDEMO_GameFonts,
-		ITEMacPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE_WIN_DEMO,
+		PATCHLIST_ITE_MAC,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -308,10 +109,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITEWINDEMO_GameFonts),
-		ITEWINDEMO_GameFonts,
-		ITEMacPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE_WIN_DEMO,
+		PATCHLIST_ITE_MAC,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -335,10 +135,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITEWINDEMO_GameFonts),
-		ITEWINDEMO_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE_WIN_DEMO,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -362,10 +161,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		GF_8BIT_UNSIGNED_PCM,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITEWINDEMO_GameFonts),
-		ITEWINDEMO_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE_WIN_DEMO,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -396,10 +194,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		GF_8BIT_UNSIGNED_PCM,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITEWINDEMO_GameFonts),
-		ITEWINDEMO_GameFonts,
-		NULL,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE_WIN_DEMO,
+		PATCHLIST_NONE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -424,10 +221,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		GF_8BIT_UNSIGNED_PCM,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITEWINDEMO_GameFonts),
-		ITEWINDEMO_GameFonts,
-		NULL,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE_WIN_DEMO,
+		PATCHLIST_NONE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -449,10 +245,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITEWINDEMO_GameFonts),
-		ITEWINDEMO_GameFonts,
-		ITEMacPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE_WIN_DEMO,
+		PATCHLIST_ITE_MAC,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -474,10 +269,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		GF_SOME_MAC_RESOURCES,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		NULL,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_NONE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -507,10 +301,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		NULL,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_NONE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -535,10 +328,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		NULL,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_NONE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -567,10 +359,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		NULL,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_NONE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -594,10 +385,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		GF_EXTRA_ITE_CREDITS,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -621,10 +411,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		GF_EXTRA_ITE_CREDITS,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -647,10 +436,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		GF_EXTRA_ITE_CREDITS,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -673,10 +461,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -699,10 +486,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -724,10 +510,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -750,10 +535,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -776,10 +560,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -801,10 +584,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -826,10 +608,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -851,10 +632,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		NULL,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_NONE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -877,10 +657,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		NULL,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_NONE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -905,10 +684,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		NULL,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_NONE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -932,10 +710,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		NULL,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_NONE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -959,10 +736,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -984,10 +760,9 @@ static const SAGAGameDescription gameDescriptions[] = {
  		GID_ITE,
 		GF_ITE_FLOPPY,	// Even it that game version comes on a CD it behaves like a DOS floppy version
  		ITE_DEFAULT_SCENE,
- 		&ITE_Resources,
- 		ARRAYSIZE(ITE_GameFonts),
- 		ITE_GameFonts,
- 		NULL,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_NONE,
 		INTROLIST_ITE_DEFAULT,
  	},
 
@@ -1009,10 +784,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		0,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -1036,10 +810,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		GF_ITE_FLOPPY,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		NULL,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_NONE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -1061,10 +834,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		GF_ITE_FLOPPY,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -1086,10 +858,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		GF_ITE_FLOPPY,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -1111,10 +882,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		GF_ITE_FLOPPY,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -1136,10 +906,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		GF_ITE_FLOPPY,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_DEFAULT,
 	},
 
@@ -1162,10 +931,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		GF_EXTRA_ITE_CREDITS | GF_AGA_GRAPHICS,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources_GermanAGACD,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE_GERMAN_AGA_CD,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_AMIGA_GERMAN_AGA,
 	},
 	// This is on the same disk as previous but it's for ECS systems
@@ -1185,10 +953,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		GF_EXTRA_ITE_CREDITS | GF_ECS_GRAPHICS,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources_GermanECSCD,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE_GERMAN_ECS_CD,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_AMIGA_GERMAN_ECS,
 	},
 	// Amiga Future coverdisk/Wyrmkeep English edition
@@ -1208,10 +975,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		GF_EXTRA_ITE_CREDITS | GF_AGA_GRAPHICS,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_AMIGA_ENGLISH_AGA_CD,
 	},
 	// This is on the same disk as previous but it's for ECS systems
@@ -1231,10 +997,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_ITE,
 		GF_EXTRA_ITE_CREDITS | GF_ECS_GRAPHICS,
 		ITE_DEFAULT_SCENE,
-		&ITE_Resources_EnglishECSCD,
-		ARRAYSIZE(ITE_GameFonts),
-		ITE_GameFonts,
-		ITEPatch_Files,
+		RESOURCELIST_ITE_ENGLISH_ECS_CD,
+		FONTLIST_ITE,
+		PATCHLIST_ITE,
 		INTROLIST_ITE_AMIGA_ENGLISH_ECS_CD,
 	},
 
@@ -1262,10 +1027,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_IHNM,
 		0,
 		IHNMDEMO_DEFAULT_SCENE,
-		&IHNMDEMO_Resources,
-		ARRAYSIZE(IHNMDEMO_GameFonts),
-		IHNMDEMO_GameFonts,
-		NULL,
+		RESOURCELIST_IHNM_DEMO,
+		FONTLIST_IHNM_DEMO,
+		PATCHLIST_NONE,
 		INTROLIST_NONE,
 	},
 
@@ -1295,10 +1059,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_IHNM,
 		0,
 		IHNM_DEFAULT_SCENE,
-		&IHNM_Resources,
-		ARRAYSIZE(IHNMCD_GameFonts),
-		IHNMCD_GameFonts,
-		NULL,
+		RESOURCELIST_IHNM,
+		FONTLIST_IHNM_CD,
+		PATCHLIST_NONE,
 		INTROLIST_NONE,
 	},
 
@@ -1326,10 +1089,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_IHNM,
 		GF_IHNM_COLOR_FIX,
 		IHNM_DEFAULT_SCENE,
-		&IHNM_Resources,
-		ARRAYSIZE(IHNMCD_GameFonts),
-		IHNMCD_GameFonts,
-		NULL,
+		RESOURCELIST_IHNM,
+		FONTLIST_IHNM_CD,
+		PATCHLIST_NONE,
 		INTROLIST_NONE,
 	},
 
@@ -1357,10 +1119,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_IHNM,
 		0,
 		IHNM_DEFAULT_SCENE,
-		&IHNM_Resources,
-		ARRAYSIZE(IHNMCD_GameFonts),
-		IHNMCD_GameFonts,
-		NULL,
+		RESOURCELIST_IHNM,
+		FONTLIST_IHNM_CD,
+		PATCHLIST_NONE,
 		INTROLIST_NONE,
 	},
 
@@ -1388,10 +1149,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_IHNM,
 		0,
 		IHNM_DEFAULT_SCENE,
-		&IHNM_Resources,
-		ARRAYSIZE(IHNMCD_GameFonts),
-		IHNMCD_GameFonts,
-		NULL,
+		RESOURCELIST_IHNM,
+		FONTLIST_IHNM_CD,
+		PATCHLIST_NONE,
 		INTROLIST_NONE,
 	},
 
@@ -1417,10 +1177,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_IHNM,
 		GF_IHNM_COLOR_FIX,
 		IHNM_DEFAULT_SCENE,
-		&IHNM_Resources,
-		ARRAYSIZE(IHNMCD_GameFonts),
-		IHNMCD_GameFonts,
-		NULL,
+		RESOURCELIST_IHNM,
+		FONTLIST_IHNM_CD,
+		PATCHLIST_NONE,
 		INTROLIST_NONE,
 	},
 
@@ -1447,10 +1206,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_IHNM,
 		GF_IHNM_COLOR_FIX,
 		IHNM_DEFAULT_SCENE,
-		&IHNM_Resources,
-		ARRAYSIZE(IHNMCD_GameFonts),
-		IHNMCD_GameFonts,
-		NULL,
+		RESOURCELIST_IHNM,
+		FONTLIST_IHNM_CD,
+		PATCHLIST_NONE,
 		INTROLIST_NONE,
 	},
 
@@ -1477,10 +1235,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_IHNM,
 		GF_IHNM_COLOR_FIX,
 		IHNM_DEFAULT_SCENE,
-		&IHNM_Resources,
-		ARRAYSIZE(IHNMCD_GameFonts),
-		IHNMCD_GameFonts,
-		NULL,
+		RESOURCELIST_IHNM,
+		FONTLIST_IHNM_CD,
+		PATCHLIST_NONE,
 		INTROLIST_NONE,
 	},
 
@@ -1507,10 +1264,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_IHNM,
 		0,
 		IHNM_DEFAULT_SCENE,
-		&IHNM_Resources,
-		ARRAYSIZE(IHNMCD_GameFonts),
-		IHNMCD_GameFonts,
-		NULL,
+		RESOURCELIST_IHNM,
+		FONTLIST_IHNM_CD,
+		PATCHLIST_NONE,
 		INTROLIST_NONE,
 	},
 
@@ -1536,10 +1292,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_IHNM,
 		0,
 		IHNM_DEFAULT_SCENE,
-		&IHNM_Resources,
-		ARRAYSIZE(IHNMCD_GameFonts),
-		IHNMCD_GameFonts,
-		NULL,
+		RESOURCELIST_IHNM,
+		FONTLIST_IHNM_CD,
+		PATCHLIST_NONE,
 		INTROLIST_NONE,
 	},
 
@@ -1569,10 +1324,9 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_IHNM,
 		0,
 		IHNM_DEFAULT_SCENE,
-		&IHNM_Resources,
-		ARRAYSIZE(IHNMCD_GameFonts),
-		IHNMCD_GameFonts,
-		NULL,
+		RESOURCELIST_IHNM,
+		FONTLIST_IHNM_CD,
+		PATCHLIST_NONE,
 		INTROLIST_NONE,
 	},
 
@@ -1596,14 +1350,13 @@ static const SAGAGameDescription gameDescriptions[] = {
 		GID_IHNM,
 		0,
 		IHNM_DEFAULT_SCENE,
-		&IHNM_Resources,
-		ARRAYSIZE(IHNMCD_GameFonts),
-		IHNMCD_GameFonts,
-		NULL,
+		RESOURCELIST_IHNM,
+		FONTLIST_IHNM_CD,
+		PATCHLIST_NONE,
 		INTROLIST_NONE,
 	},
 
-	{ AD_TABLE_END_MARKER, 0, 0, 0, NULL, 0, NULL, NULL, INTROLIST_NONE }
+	{ AD_TABLE_END_MARKER, 0, 0, 0, RESOURCELIST_NONE, FONTLIST_MAX, PATCHLIST_MAX, INTROLIST_NONE }
 };
 
 } // End of namespace Saga

--- a/engines/saga/metaengine.cpp
+++ b/engines/saga/metaengine.cpp
@@ -43,13 +43,10 @@ namespace Saga {
 
 bool SagaEngine::isBigEndian() const { return (isMacResources() || (getPlatform() == Common::kPlatformAmiga)) && getGameId() == GID_ITE; }
 bool SagaEngine::isMacResources() const { return (getPlatform() == Common::kPlatformMacintosh); }
-const GameResourceDescription *SagaEngine::getResourceDescription() const { return _gameDescription->resourceDescription; }
 
-const GameFontDescription *SagaEngine::getFontDescription(int index) const {
-	assert(index < _gameDescription->fontsCount);
-	return &_gameDescription->fontDescriptions[index];
-}
-int SagaEngine::getFontsCount() const { return _gameDescription->fontsCount; }
+GameResourceList SagaEngine::getResourceList() const { return _gameDescription->resourceList; }
+GameFontList SagaEngine::getFontList() const { return _gameDescription->fontList; }
+GamePatchList SagaEngine::getPatchList() const { return _gameDescription->patchList; }
 
 int SagaEngine::getGameId() const { return _gameDescription->gameId; }
 
@@ -64,7 +61,6 @@ Common::Platform SagaEngine::getPlatform() const { return _gameDescription->desc
 int SagaEngine::getGameNumber() const { return _gameNumber; }
 int SagaEngine::getStartSceneNumber() const { return _gameDescription->startSceneNumber; }
 
-const GamePatchDescription *SagaEngine::getPatchDescriptions() const { return _gameDescription->patchDescriptions; }
 const ADGameFileDescription *SagaEngine::getFilesDescriptions() const { return _gameDescription->desc.filesDescriptions; }
 
 } // End of namespace Saga

--- a/engines/saga/resource.cpp
+++ b/engines/saga/resource.cpp
@@ -35,6 +35,67 @@
 
 namespace Saga {
 
+// Patch files. Files not found will be ignored
+static const GamePatchDescription ITEPatch_Files[] = {
+	{       "cave.mid", GAME_RESOURCEFILE,    9},
+	{      "intro.mid", GAME_RESOURCEFILE,   10},
+	{   "fvillage.mid", GAME_RESOURCEFILE,   11},
+	{    "elkhall.mid", GAME_RESOURCEFILE,   12},
+	{      "mouse.mid", GAME_RESOURCEFILE,   13},
+	{   "darkclaw.mid", GAME_RESOURCEFILE,   14},
+	{   "birdchrp.mid", GAME_RESOURCEFILE,   15},
+	{   "orbtempl.mid", GAME_RESOURCEFILE,   16},
+	{     "spooky.mid", GAME_RESOURCEFILE,   17},
+	{    "catfest.mid", GAME_RESOURCEFILE,   18},
+	{ "elkfanfare.mid", GAME_RESOURCEFILE,   19},
+	{     "bcexpl.mid", GAME_RESOURCEFILE,   20},
+	{   "boargtnt.mid", GAME_RESOURCEFILE,   21},
+	{   "boarking.mid", GAME_RESOURCEFILE,   22},
+	{   "explorea.mid", GAME_RESOURCEFILE,   23},
+	{   "exploreb.mid", GAME_RESOURCEFILE,   24},
+	{   "explorec.mid", GAME_RESOURCEFILE,   25},
+	{   "sunstatm.mid", GAME_RESOURCEFILE,   26},
+	{   "nitstrlm.mid", GAME_RESOURCEFILE,   27},
+	{   "humruinm.mid", GAME_RESOURCEFILE,   28},
+	{   "damexplm.mid", GAME_RESOURCEFILE,   29},
+	{     "tychom.mid", GAME_RESOURCEFILE,   30},
+	{     "kitten.mid", GAME_RESOURCEFILE,   31},
+	{      "sweet.mid", GAME_RESOURCEFILE,   32},
+	{   "brutalmt.mid", GAME_RESOURCEFILE,   33},
+	{     "shiala.mid", GAME_RESOURCEFILE,   34},
+
+	{       "wyrm.pak", GAME_RESOURCEFILE, 1529},
+	{      "wyrm1.dlt", GAME_RESOURCEFILE, 1530},
+	{      "wyrm2.dlt", GAME_RESOURCEFILE, 1531},
+	{      "wyrm3.dlt", GAME_RESOURCEFILE, 1532},
+	{      "wyrm4.dlt", GAME_RESOURCEFILE, 1533},
+	{   "credit3n.dlt", GAME_RESOURCEFILE, 1796}, // PC
+	{   "credit3m.dlt", GAME_RESOURCEFILE, 1796}, // Macintosh
+	{   "credit4n.dlt", GAME_RESOURCEFILE, 1797}, // PC
+	{   "credit4m.dlt", GAME_RESOURCEFILE, 1797}, // Macintosh
+	{       "p2_a.voc", GAME_VOICEFILE,       4},
+	{       "p2_a.iaf", GAME_VOICEFILE,       4},
+	{             NULL,              0,       0}
+};
+
+static const GamePatchDescription ITEMacPatch_Files[] = {
+	{       "wyrm.pak", GAME_RESOURCEFILE, 1529},
+	{      "wyrm1.dlt", GAME_RESOURCEFILE, 1530},
+	{      "wyrm2.dlt", GAME_RESOURCEFILE, 1531},
+	{      "wyrm3.dlt", GAME_RESOURCEFILE, 1532},
+	{      "wyrm4.dlt", GAME_RESOURCEFILE, 1533},
+	{   "credit3m.dlt", GAME_RESOURCEFILE, 1796},
+	{   "credit4m.dlt", GAME_RESOURCEFILE, 1797},
+	{       "p2_a.iaf", GAME_VOICEFILE,       4},
+	{             NULL,              0,       0}
+};
+
+static const GamePatchDescription *PatchLists[PATCHLIST_MAX] = {
+	/* PATCHLIST_NONE */    nullptr,
+	/* PATCHLIST_ITE */     ITEPatch_Files,
+	/* PATCHLIST_ITE_MAC */ ITEMacPatch_Files
+};
+
 bool ResourceContext::loadResIteAmiga(uint32 contextOffset, uint32 contextSize, int type) {
 	_file.seek(contextOffset);
 	uint16 resourceCount = _file.readUint16BE();
@@ -148,7 +209,9 @@ bool ResourceContext::load(SagaEngine *vm, Resource *resource) {
 	if (!loadRes(0, _fileSize, _fileType))
 		return false;
 
-	processPatches(resource, vm->getPatchDescriptions());
+	GamePatchList index = vm->getPatchList();
+	if (index < PATCHLIST_MAX && index > PATCHLIST_NONE)
+		processPatches(resource, PatchLists[index]);
 
 	// Close the file if it's part of a series of files.
 	// This prevents having all voice files open in IHNM for no reason, as each chapter uses

--- a/engines/saga/saga.cpp
+++ b/engines/saga/saga.cpp
@@ -52,6 +52,153 @@
 
 namespace Saga {
 
+static const GameResourceDescription ITE_Resources_GermanAGACD = {
+	1810,	// Scene lookup table RN
+	216,	// Script lookup table RN
+	3,		// Main panel
+	4,		// Converse panel
+	5,		// Option panel
+	6,		// Main sprites
+	7,		// Main panel sprites
+	35,		// Main strings
+	// ITE specific resources
+	36,		// Actor names
+	125,	// Default portraits
+	// IHNM specific resources
+	0,		// Option panel sprites
+	0,		// Warning panel
+	0,		// Warning panel sprites
+	0		// Psychic profile background
+};
+
+static const GameResourceDescription ITE_Resources_GermanECSCD = {
+	1816,	// Scene lookup table RN
+	216,	// Script lookup table RN
+	3,		// Main panel
+	4,		// Converse panel
+	5,		// Option panel
+	6,		// Main sprites
+	7,		// Main panel sprites
+	35,		// Main strings
+	// ITE specific resources
+	36,		// Actor names
+	125,	// Default portraits
+	// IHNM specific resources
+	0,		// Option panel sprites
+	0,		// Warning panel
+	0,		// Warning panel sprites
+	0		// Psychic profile background
+};
+
+static const GameResourceDescription ITE_Resources = {
+	1806,	// Scene lookup table RN
+	216,	// Script lookup table RN
+	3,		// Main panel
+	4,		// Converse panel
+	5,		// Option panel
+	6,		// Main sprites
+	7,		// Main panel sprites
+	35,		// Main strings
+	// ITE specific resources
+	36,		// Actor names
+	125,	// Default portraits
+	// IHNM specific resources
+	0,		// Option panel sprites
+	0,		// Warning panel
+	0,		// Warning panel sprites
+	0		// Psychic profile background
+};
+
+static const GameResourceDescription ITE_Resources_EnglishECSCD = {
+	1812,	// Scene lookup table RN
+	216,	// Script lookup table RN
+	3,		// Main panel
+	4,		// Converse panel
+	5,		// Option panel
+	6,		// Main sprites
+	7,		// Main panel sprites
+	35,		// Main strings
+	// ITE specific resources
+	36,		// Actor names
+	125,	// Default portraits
+	// IHNM specific resources
+	0,		// Option panel sprites
+	0,		// Warning panel
+	0,		// Warning panel sprites
+	0		// Psychic profile background
+};
+
+// FIXME: Option panel should be 4 but it is an empty resource.
+// Proper fix would be to not load the options panel when the demo is running
+static const GameResourceDescription ITEDemo_Resources = {
+	318,	// Scene lookup table RN
+	146,	// Script lookup table RN
+	2,		// Main panel
+	3,		// Converse panel
+	3,		// Option panel
+	5,		// Main sprites
+	6,		// Main panel sprites
+	8,		// Main strings
+	// ITE specific resources
+	9,		// Actor names
+	80,		// Default portraits
+	// IHNM specific resources
+	0,		// Option panel sprites
+	0,		// Warning panel
+	0,		// Warning panel sprites
+	0		// Psychic profile background
+};
+
+static const GameResourceDescription IHNM_Resources = {
+	1272,	// Scene lookup table RN
+	29,		// Script lookup table RN
+	9,		// Main panel
+	10,		// Converse panel
+	15,		// Option panel
+	12,		// Main sprites
+	12,		// Main panel sprites
+	21,		// Main strings
+	// ITE specific resources
+	0,		// Actor names
+	0,		// Default portraits
+	// IHNM specific resources
+	16,		// Option panel sprites
+	17,		// Warning panel
+	18,		// Warning panel sprites
+	20		// Psychic profile background
+};
+
+static const GameResourceDescription IHNMDEMO_Resources = {
+	286,	// Scene lookup table RN
+	18,		// Script lookup table RN
+	5,		// Main panel
+	6,		// Converse panel
+	10,		// Option panel
+	7,		// Main sprites
+	7,		// Main panel sprites
+	16,		// Main strings
+	// ITE specific resources
+	0,		// Actor names
+	0,		// Default portraits
+	// IHNM specific resources
+	11,		// Option panel sprites
+	12,		// Warning panel
+	13,		// Warning panel sprites
+	15		// Psychic profile background
+};
+
+static const GameResourceDescription *ResourceLists[RESOURCELIST_MAX] = {
+	/* RESOURCELIST_NONE */               nullptr,
+	/* RESOURCELIST_ITE */                &ITE_Resources,
+	/* RESOURCELIST_ITE_ENGLISH_ECS_CD */ &ITE_Resources_EnglishECSCD,
+	/* RESOURCELIST_ITE_GERMAN_AGA_CD */  &ITE_Resources_GermanAGACD,
+	/* RESOURCELIST_ITE_GERMAN_ECS_CD */  &ITE_Resources_GermanECSCD,
+	/* RESOURCELIST_ITE_DEMO */           &ITEDemo_Resources,
+	/* RESOURCELIST_IHNM */               &IHNM_Resources,
+	/* RESOURCELIST_IHNM_DEMO */          &IHNMDEMO_Resources
+};
+
+
 #define MAX_TIME_DELTA 100
 
 SagaEngine::SagaEngine(OSystem *syst, const SAGAGameDescription *gameDesc)
@@ -368,6 +515,12 @@ Common::Error SagaEngine::run() {
 	_music->close();
 
 	return Common::kNoError;
+}
+
+const GameResourceDescription *SagaEngine::getResourceDescription() const {
+	GameResourceList index = getResourceList();
+	assert(index < RESOURCELIST_MAX && index > RESOURCELIST_NONE);
+	return ResourceLists[index];
 }
 
 void SagaEngine::loadStrings(StringsTable &stringsTable, const ByteArray &stringsData, bool isBigEndian) {

--- a/engines/saga/saga.h
+++ b/engines/saga/saga.h
@@ -220,7 +220,36 @@ enum TextStringIds {
 	kTextLoadSavedGame
 };
 
+struct GameResourceDescription {
+	uint32 sceneLUTResourceId;
+	uint32 moduleLUTResourceId;
+	uint32 mainPanelResourceId;
+	uint32 conversePanelResourceId;
+	uint32 optionPanelResourceId;
+	uint32 mainSpritesResourceId;
+	uint32 mainPanelSpritesResourceId;
+	uint32 mainStringsResourceId;
+	// ITE specific resources
+	uint32 actorsStringsResourceId;
+	uint32 defaultPortraitsResourceId;
+	// IHNM specific resources
+	uint32 optionPanelSpritesResourceId;
+	uint32 warningPanelResourceId;
+	uint32 warningPanelSpritesResourceId;
+	uint32 psychicProfileResourceId;
+};
+
+struct GameFontDescription {
+	uint32 fontResourceId;
+};
+
 struct GameDisplayInfo;
+
+struct GamePatchDescription {
+	const char *fileName;
+	uint16 fileType;
+	uint32 resourceId;
+};
 
 enum GameObjectTypes {
 	kGameObjectNone = 0,
@@ -543,8 +572,9 @@ public:
 	bool isMacResources() const;
 	const GameResourceDescription *getResourceDescription() const;
 
-	const GameFontDescription *getFontDescription(int index) const;
-	int getFontsCount() const;
+	GameResourceList getResourceList() const;
+	GameFontList getFontList() const;
+	GamePatchList getPatchList() const;
 
 	int getGameId() const;
 	uint32 getFeatures() const;
@@ -552,8 +582,6 @@ public:
 	Common::Platform getPlatform() const;
 	int getGameNumber() const;
 	int getStartSceneNumber() const;
-
-	const GamePatchDescription *getPatchDescriptions() const;
 
 	const ADGameFileDescription *getFilesDescriptions() const;
 


### PR DESCRIPTION
This is a follow up to PR #4433.