### PR TITLE
SCUMM: Always build with Player_HE support

### DIFF
--- a/engines/scumm/players/player_he.cpp
+++ b/engines/scumm/players/player_he.cpp
@@ -19,8 +19,6 @@
  *
  */
 
-#ifdef ENABLE_HE
-
 #include "scumm/players/player_he.h"
 #include "scumm/scumm.h"
 #include "scumm/file.h"
@@ -236,5 +234,3 @@ void Player_HE::send(uint32 b) {
 }
 
 }
-
-#endif

--- a/engines/scumm/players/player_he.h
+++ b/engines/scumm/players/player_he.h
@@ -29,8 +29,6 @@
 
 class MidiParser;
 
-#ifdef ENABLE_HE
-
 namespace Scumm {
 class ScummEngine;
 
@@ -69,7 +67,5 @@ private:
 	void loadAdLibBank();
 };
 }
-
-#endif
 
 #endif

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2032,10 +2032,8 @@ void ScummEngine::setupMusic(int midi, const Common::String &macInstrumentFile) 
 		// support this with the Player_AD code at the moment. The reason here
 		// is that multi MIDI is supported internally by our iMuse output.
 		_musicEngine = new Player_AD(this, _mixer->mutex());
-#ifdef ENABLE_HE
 	} else if (_game.platform == Common::kPlatformDOS && _sound->_musicType == MDT_ADLIB && _game.heversion >= 60) {
 		_musicEngine = new Player_HE(this);
-#endif
 	} else if (_game.version >= 3 && _game.heversion <= 62) {
 		MidiDriver *nativeMidiDriver = nullptr;
 		MidiDriver *adlibMidiDriver = nullptr;


### PR DESCRIPTION
Previously this was disabled if the HE subengine is disabled, but that's intended to cover HE 7.1+ games, while `Player_HE` is mainly for older games.