### PR TITLE
SCUMM: I18N: More explicit description of the Shift+V Full Throttle shortcut

### DIFF
--- a/engines/scumm/help.cpp
+++ b/engines/scumm/help.cpp
@@ -233,8 +233,12 @@ void ScummHelp::updateStrings(byte gameId, byte version, Common::Platform platfo
 			ADD_BIND("p", _("Punch"));
 			ADD_BIND("k", _("Kick"));
 			ADD_LINE;
-			// I18N: A shortcut to skip the bike fight and derby sequences in Full Throttle
-			ADD_BIND(_("Shift") + U32String(" v"), _("Fight cheat"));
+			ADD_BIND(
+				// I18N: The name of the 'Shift' key on a PC keyboard
+				_("Shift") + U32String(" v"),
+				// I18N: Lets one skip the bike/car fight sequences in Full Throttle
+				_("Fight cheat")
+			);
 			break;
 		case GID_DIG:
 			ADD_BIND("e", _("Examine"));


### PR DESCRIPTION
Previous `// I18N` description of mine was confusing, especially since it got applied to `_("Shift")` and not `_("Fight cheat")`. Let's be explicit about both lines.

(Mainly making a PR to make sure that no compiler complains about the I18N comments inside the the macro, **DON'T MERGE** before CI is done)