### PR TITLE
SCUMM: prevent possible issues when range is reversed

### DIFF
--- a/engines/scumm/he/script_v100he.cpp
+++ b/engines/scumm/he/script_v100he.cpp
@@ -710,14 +710,14 @@ void ScummEngine_v100he::o100_arrayOps() {
 
 		offs = (b >= c) ? 1 : -1;
 		tmp2 = c;
-		tmp3 = c - b + 1;
+		tmp3 = ABS(c - b) + 1;
 		while (dim2start <= dim2end) {
 			tmp = dim1start;
 			while (tmp <= dim1end) {
 				writeArray(array, dim2start, tmp, tmp2);
 				if (--tmp3 == 0) {
 					tmp2 = c;
-					tmp3 = c - b + 1;
+					tmp3 = ABS(c - b) + 1;
 				} else {
 					tmp2 += offs;
 				}

--- a/engines/scumm/he/script_v72he.cpp
+++ b/engines/scumm/he/script_v72he.cpp
@@ -1174,14 +1174,14 @@ void ScummEngine_v72he::o72_arrayOps() {
 
 		offs = (b >= c) ? 1 : -1;
 		tmp2 = c;
-		tmp3 = c - b + 1;
+		tmp3 = ABS(c - b) + 1;
 		while (dim2start <= dim2end) {
 			tmp = dim1start;
 			while (tmp <= dim1end) {
 				writeArray(array, dim2start, tmp, tmp2);
 				if (--tmp3 == 0) {
 					tmp2 = c;
-					tmp3 = c - b + 1;
+					tmp3 = ABS(c - b) + 1;
 				} else {
 					tmp2 += offs;
 				}


### PR DESCRIPTION
This may prevent some possible issues when the scripts define array range assignment of reversed range.
Not sure if it's a good idea to have this fix, as I haven't find any game that used it yet, so I'm unable to test it.
