### PR TITLE
CREATE_PROJECT: Disable Xcode GCC_WARN_64_TO_32_BIT_CONVERSION on macOS

### DIFF
--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -1077,6 +1077,7 @@ void XcodeProvider::setupBuildConfiguration(const BuildSetup &setup) {
 	ADD_SETTING(scummvm_Debug, "GCC_INPUT_FILETYPE", "automatic");
 	ADD_SETTING(scummvm_Debug, "GCC_NO_COMMON_BLOCKS", "YES");
 	ADD_SETTING(scummvm_Debug, "GCC_OPTIMIZATION_LEVEL", "0");
+	ADD_SETTING(scummvm_Debug, "GCC_WARN_64_TO_32_BIT_CONVERSION", "NO");
 	ADD_SETTING(scummvm_Debug, "GCC_WARN_SIGN_COMPARE", "YES");
 	ADD_SETTING(scummvm_Debug, "GCC_WARN_UNDECLARED_SELECTOR", "YES");
 	ADD_SETTING(scummvm_Debug, "GCC_WARN_UNINITIALIZED_AUTOS", "YES");
@@ -1149,7 +1150,6 @@ void XcodeProvider::setupBuildConfiguration(const BuildSetup &setup) {
 	ADD_SETTING(iPhone_Debug, "GCC_ENABLE_CPP_EXCEPTIONS", "NO");
 	ADD_SETTING(iPhone_Debug, "GCC_OPTIMIZATION_LEVEL", "0");
 	ADD_SETTING(iPhone_Debug, "GCC_PRECOMPILE_PREFIX_HEADER", "NO");
-	ADD_SETTING(iPhone_Debug, "GCC_WARN_64_TO_32_BIT_CONVERSION", "NO");
 	ADD_SETTING_QUOTE(iPhone_Debug, "GCC_PREFIX_HEADER", "");
 	ADD_SETTING(iPhone_Debug, "GCC_UNROLL_LOOPS", "YES");
 	ValueList iPhone_HeaderSearchPaths;


### PR DESCRIPTION
Building for macOS [with Xcode](https://wiki.scummvm.org/index.php/Compiling_ScummVM/macOS#Compiling_ScummVM_via_the_Xcode_GUI) currently outputs hundreds of warnings that we normally choose to ignore with ` -Wno-shorten-64-to-32` in the main Makefile.

Xcode has a `GCC_WARN_64_TO_32_BIT_CONVERSION` setting to trigger this option, but it's currently only set for iOS builds. This PR moves this setting to be common to iOS *and* macOS builds. 

End result is much less warning noise in Xcode build console.

Any objection?