### PR TITLE
AUDIO: Backport changes from DOSBox to the CMS emulator 

### DIFF
--- a/audio/softsynth/cms.cpp
+++ b/audio/softsynth/cms.cpp
@@ -30,6 +30,8 @@
 
 #define LEFT	0x00
 #define RIGHT	0x01
+/*#define MASTER_CLOCK 14318180/2 */
+#define MASTER_CLOCK 7159090
 
 static const byte envelope[8][64] = {
 	/* zero amplitude */
@@ -164,9 +166,9 @@ void CMSEmulator::update(int chip, int16 *buffer, int length) {
 
 	for (ch = 0; ch < 2; ch++) {
 		switch (saa->noise_params[ch]) {
-		case 0: saa->noise[ch].freq = 31250.0 * 2; break;
-		case 1: saa->noise[ch].freq = 15625.0 * 2; break;
-		case 2: saa->noise[ch].freq =  7812.5 * 2; break;
+		case 0: saa->noise[ch].freq = MASTER_CLOCK/256  * 2; break;
+		case 1: saa->noise[ch].freq = MASTER_CLOCK/512  * 2; break;
+		case 2: saa->noise[ch].freq = MASTER_CLOCK/1024 * 2; break;
 		case 3: saa->noise[ch].freq = saa->channels[ch * 3].freq; break;
 		default: break;
 		}
@@ -179,14 +181,14 @@ void CMSEmulator::update(int chip, int16 *buffer, int length) {
 		/* for each channel */
 		for (ch = 0; ch < 6; ch++) {
 			if (saa->channels[ch].freq == 0.0)
-				saa->channels[ch].freq = (double)((2 * 15625) << saa->channels[ch].octave) /
-				(511.0 - (double)saa->channels[ch].frequency);
+				saa->channels[ch].freq = (double)((2 * MASTER_CLOCK/512) << saa->channels[ch].octave) /
+					(511.0 - (double)saa->channels[ch].frequency);
 
 			/* check the actual position in the square wave */
 			saa->channels[ch].counter -= saa->channels[ch].freq;
 			while (saa->channels[ch].counter < 0) {
 				/* calculate new frequency now after the half wave is updated */
-				saa->channels[ch].freq = (double)((2 * 15625) << saa->channels[ch].octave) /
+				saa->channels[ch].freq = (double)((2 * MASTER_CLOCK/512) << saa->channels[ch].octave) /
 					(511.0 - (double)saa->channels[ch].frequency);
 
 				saa->channels[ch].counter += _sampleRate;

--- a/audio/softsynth/cms.cpp
+++ b/audio/softsynth/cms.cpp
@@ -82,35 +82,21 @@ static const int amplitude_lookup[16] = {
 };
 
 void CMSEmulator::portWrite(int port, int val) {
-	switch (port) {
-	case 0x220:
+	switch (port-_basePort) {
+	case 0:
+		portWriteIntern(0, 0, val);
+		break;
+
+	case 1:
 		portWriteIntern(0, 1, val);
 		break;
 
-	case 0x221:
-		_saa1099[0].selected_reg = val & 0x1f;
-		if (_saa1099[0].selected_reg == 0x18 || _saa1099[0].selected_reg == 0x19) {
-			/* clock the envelope channels */
-			if (_saa1099[0].env_clock[0])
-				envelope(0, 0);
-			if (_saa1099[0].env_clock[1])
-				envelope(0, 1);
-		}
+	case 2:
+		portWriteIntern(1, 0, val);
 		break;
 
-	case 0x222:
+	case 3:
 		portWriteIntern(1, 1, val);
-		break;
-
-	case 0x223:
-		_saa1099[1].selected_reg = val & 0x1f;
-		if (_saa1099[1].selected_reg == 0x18 || _saa1099[1].selected_reg == 0x19) {
-			/* clock the envelope channels */
-			if (_saa1099[1].env_clock[0])
-				envelope(1, 0);
-			if (_saa1099[1].env_clock[1])
-				envelope(1, 1);
-		}
 		break;
 
 	default:
@@ -252,6 +238,18 @@ void CMSEmulator::update(int chip, int16 *buffer, int length) {
 
 void CMSEmulator::portWriteIntern(int chip, int offset, int data) {
 	SAA1099 *saa = &_saa1099[chip];
+	if(offset == 1) {
+		// address port
+		saa->selected_reg = data & 0x1f;
+		if (saa->selected_reg == 0x18 || saa->selected_reg == 0x19) {
+			/* clock the envelope channels */
+			if (saa->env_clock[0])
+				envelope(chip,0);
+			if (saa->env_clock[1])
+				envelope(chip,1);
+		}
+		return;
+	}
 	int reg = saa->selected_reg;
 	int ch;
 

--- a/audio/softsynth/cms.h
+++ b/audio/softsynth/cms.h
@@ -66,11 +66,12 @@ struct SAA1099 {
 
 class CMSEmulator {
 public:
-	CMSEmulator(uint32 sampleRate) {
+	CMSEmulator(uint32 sampleRate, uint32 basePort = 0x220) {
 		// In PCs the chips run at 7.15909 MHz instead of 8 MHz.
 		// Adjust sampling rate upwards to bring pitch down.
 		_sampleRate = (sampleRate * 352) / 315;
 		memset(_saa1099, 0, sizeof(SAA1099)*2);
+		_basePort = basePort;
 	}
 
 	~CMSEmulator() { }
@@ -81,6 +82,7 @@ public:
 
 private:
 	uint32 _sampleRate;
+	uint32 _basePort;
 
 	SAA1099 _saa1099[2];
 

--- a/audio/softsynth/cms.h
+++ b/audio/softsynth/cms.h
@@ -67,9 +67,7 @@ struct SAA1099 {
 class CMSEmulator {
 public:
 	CMSEmulator(uint32 sampleRate, uint32 basePort = 0x220) {
-		// In PCs the chips run at 7.15909 MHz instead of 8 MHz.
-		// Adjust sampling rate upwards to bring pitch down.
-		_sampleRate = (sampleRate * 352) / 315;
+		_sampleRate = sampleRate;
 		memset(_saa1099, 0, sizeof(SAA1099)*2);
 		_basePort = basePort;
 	}


### PR DESCRIPTION
The DOSBox CMS emulator was removed in 2018 and replaced with MAME's SAA1099 emulator, but there are still a couple of potentially useful changes that were made since it was imported into ScummVM.