### PR TITLE
MACOSX: Prefer openURL/openURLs over openFile on macOS 10.15+

### DIFF
--- a/backends/platform/sdl/macosx/macosx-compat.h
+++ b/backends/platform/sdl/macosx/macosx-compat.h
@@ -44,4 +44,8 @@
 #define MAC_OS_X_VERSION_10_12 101200
 #endif
 
+#ifndef MAC_OS_X_VERSION_10_15
+#define MAC_OS_X_VERSION_10_15 101500
+#endif
+
 #endif


### PR DESCRIPTION
They're the recommended APIs now, and `openFile` is deprecated starting with macOS 11.0. `openURLs:withApplicationAtURL` (for TextEdit usage) requires macOS 10.15+, so we need different code paths.

~~Please don't merge yet, I'd like to test this on macOS 10.4 too.~~ EDIT: done.