### PR TITLE
AUDIO: Use fixed-point arithmetic in the CMS emulator

### DIFF
--- a/audio/softsynth/cms.h
+++ b/audio/softsynth/cms.h
@@ -34,16 +34,16 @@ struct saa1099_channel {
 	int envelope[2];			/* envelope (0x00..0x0f or 0x10 == off) */
 
 	/* vars to simulate the square wave */
-	double counter;
-	double freq;
+	int32 counter;
+	int32 freq;
 	int level;
 };
 
 /* this structure defines a noise channel */
 struct saa1099_noise {
 	/* vars to simulate the noise generator output */
-	double counter;
-	double freq;
+	int32 counter;
+	int32 freq;
 	int level;				/* noise polynomal shifter */
 };
 


### PR DESCRIPTION
It would be nice to get rid of the integer division as well, but for now this improves performance in the DS port quite a bit.

This includes the changes from PR #4447.