### PR TITLE
AGOS: Use proper filenames for the Acorn Floppy version of Simon 1

### DIFF
--- a/engines/agos/agos.cpp
+++ b/engines/agos/agos.cpp
@@ -571,6 +571,9 @@ AGOSEngine::AGOSEngine(OSystem *system, const AGOSGameDescription *gd)
 	// Add default file directories for Acorn version of
 	// Simon the Sorcerer 1
 	SearchMan.addSubDirectoryMatching(gameDataDir, "execute");
+	SearchMan.addSubDirectoryMatching(gameDataDir, "tables");
+	SearchMan.addSubDirectoryMatching(gameDataDir, "text");
+	SearchMan.addSubDirectoryMatching(gameDataDir, "tunes");
 
 	// Add default file directories for Amiga/Macintosh
 	// versions of Simon the Sorcerer 2

--- a/engines/agos/detection_tables.h
+++ b/engines/agos/detection_tables.h
@@ -1074,10 +1074,10 @@ static const AGOSGameDescription gameDescriptions[] = {
 			"Floppy",
 
 			{
-				{ "gamebase.dat",	GAME_BASEFILE,	"c392e494dcabed797b98cbcfc687b33a", 36980},
-				{ "icondata.dat",	GAME_ICONFILE,	"22107c24dfb31b66ac503c28a6e20b19", 14361},
-				{ "stripped.dat",	GAME_STRFILE,	"c95a0a1ee973e19c2a1c5d12026c139f", 252},
-				{ "tbllist.dat",	GAME_TBLFILE,	"d198a80de2c59e4a0cd24b98814849e8", 711},
+				{ "gamebase",	GAME_BASEFILE,	"c392e494dcabed797b98cbcfc687b33a", 36980},
+				{ "icondata",	GAME_ICONFILE,	"22107c24dfb31b66ac503c28a6e20b19", 14361},
+				{ "stripped",	GAME_STRFILE,	"c95a0a1ee973e19c2a1c5d12026c139f", 252},
+				{ "tbllist",	GAME_TBLFILE,	"d198a80de2c59e4a0cd24b98814849e8", 711},
 				AD_LISTEND
 			},
 			Common::EN_ANY,

--- a/engines/agos/detection_tables.h
+++ b/engines/agos/detection_tables.h
@@ -1067,6 +1067,30 @@ static const AGOSGameDescription gameDescriptions[] = {
 		GF_OLD_BUNDLE
 	},
 
+	// Simon the Sorcerer 1 - English Acorn Floppy Demo
+	{
+		{
+			"simon1",
+			"Floppy Demo",
+
+			{
+				{ "gamebase",	GAME_BASEFILE,	"a12b696170f14eca5ff75f1549829251", 24850},
+				{ "icondata",	GAME_ICONFILE,	"22107c24dfb31b66ac503c28a6e20b19", 14361},
+				{ "stripped",	GAME_STRFILE,	"8edde5b9498dc9f31da1093028da467c", 27},
+				{ "tbllist",	GAME_TBLFILE,	"1247e024e1f13ca54c1e354120c7519c", 105},
+				AD_LISTEND
+			},
+			Common::EN_ANY,
+			Common::kPlatformAcorn,
+			ADGF_DEMO,
+			GUIO3(GUIO_NOSPEECH, GUIO_NOMIDI, GAMEOPTION_DISABLE_FADE_EFFECTS)
+		},
+
+		GType_SIMON1,
+		GID_SIMON1,
+		GF_OLD_BUNDLE
+	},
+
 	// Simon the Sorcerer 1 - English Acorn Floppy
 	{
 		{

--- a/engines/agos/res.cpp
+++ b/engines/agos/res.cpp
@@ -780,6 +780,8 @@ void AGOSEngine::loadVGABeardFile(uint16 id) {
 				Common::sprintf_s(filename, "0%d.out", id);
 			else
 				Common::sprintf_s(filename, "0%d.pkd", id);
+		} else if (getPlatform() == Common::kPlatformAcorn) {
+			Common::sprintf_s(filename, "%.2d/0%d", id / 100, id);
 		} else {
 			Common::sprintf_s(filename, "0%d.VGA", id);
 		}
@@ -932,7 +934,7 @@ void AGOSEngine::loadVGAVideoFile(uint16 id, uint8 type, bool useError) {
 		decompressData(filename, dst, offs, srcSize, dstSize);
 	} else if (getFeatures() & GF_OLD_BUNDLE) {
 		if (getPlatform() == Common::kPlatformAcorn) {
-			Common::sprintf_s(filename, "%.3d%d.DAT", id, type);
+			Common::sprintf_s(filename, "%.2d/%.3d%d", id / 10, id, type);
 		} else if (getPlatform() == Common::kPlatformAmiga || getPlatform() == Common::kPlatformAtariST) {
 			if (getFeatures() & GF_TALKIE) {
 				Common::sprintf_s(filename, "%.3d%d.out", id, type);

--- a/engines/agos/res_snd.cpp
+++ b/engines/agos/res_snd.cpp
@@ -200,8 +200,6 @@ void AGOSEngine::playModule(uint16 music) {
 
 	if (getGameType() == GType_ELVIRA1 && getFeatures() & GF_DEMO)
 		Common::sprintf_s(filename, "elvira2");
-	else if (getPlatform() == Common::kPlatformAcorn)
-		Common::sprintf_s(filename, "%dtune.DAT", music);
 	else
 		Common::sprintf_s(filename, "%dtune", music);
 

--- a/engines/agos/string.cpp
+++ b/engines/agos/string.cpp
@@ -323,10 +323,6 @@ void AGOSEngine::loadTextIntoMem(uint16 stringId) {
 			filename += *p++;
 		p++;
 
-		if (getPlatform() == Common::kPlatformAcorn) {
-			filename += ".DAT";
-		}
-
 		baseMax = (p[0] * 256) | p[1];
 		p += 2;
 

--- a/engines/agos/subroutine.cpp
+++ b/engines/agos/subroutine.cpp
@@ -354,10 +354,6 @@ bool AGOSEngine_Waxworks::loadTablesIntoMem(uint16 subrId) {
 			filename += *p++;
 		p++;
 
-		if (getPlatform() == Common::kPlatformAcorn) {
-			filename += ".DAT";
-		}
-
 		for (;;) {
 			min_num = READ_BE_UINT16(p); p += 2;
 			if (min_num == 0)


### PR DESCRIPTION
It seems that ScummVM expected files copied from HostFS using RedSquirrel or VirtualAcorn, which attempt to map RISC OS file types to Windows file extensions, which isn't done by most other methods of copying data from RISC OS systems. Most of the subdirectories were also missing from the search path.

Detection for the demo version has also been added, which is what this has been tested with. While I haven't tried this with the full version, file names like "gamebase.dat" wouldn't fit in the 10 character limit that was prominent at the time, so it seems likely that this is needed there as well.