### PR TITLE
BACKENDS: Add double-click time feature to support OS-configurable double-click intervals, implement it for Windows.

### DIFF
--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -89,9 +89,7 @@ OSystem_SDL::OSystem_SDL()
 	_logger(nullptr),
 	_eventSource(nullptr),
 	_eventSourceWrapper(nullptr),
-	_window(nullptr),
-	_haveDoubleClickTime(false),
-	_doubleClickTime(0)
+	_window(nullptr)
 {
 }
 
@@ -191,14 +189,6 @@ bool OSystem_SDL::hasFeature(Feature f) {
 	if (f == kFeatureOpenGLForGame) return true;
 	if (f == kFeatureShadersForGame) return _supportsShaders;
 #endif
-
-	if (f == kFeatureDoubleClickTime) {
-		bool haveDoubleClickTime = _haveDoubleClickTime;
-#ifdef ENABLE_EVENTRECORDER
-		g_eventRec.processHaveDoubleClickTime(haveDoubleClickTime);
-#endif
-		return haveDoubleClickTime;
-	}
 
 	return ModularGraphicsBackend::hasFeature(f);
 }
@@ -775,11 +765,10 @@ Common::SaveFileManager *OSystem_SDL::getSavefileManager() {
 }
 
 uint32 OSystem_SDL::getDoubleClickTime() const {
-	uint32 doubleClickTime = _doubleClickTime;
-#ifdef ENABLE_EVENTRECORDER
-	g_eventRec.processDoubleClickTime(doubleClickTime);
-#endif
-	return doubleClickTime;
+	if (ConfMan.hasKey("double_click_time"))
+		return ConfMan.getInt("double_click_time");
+
+	return getOSDoubleClickTime();
 }
 
 //Not specified in base class

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -89,7 +89,10 @@ OSystem_SDL::OSystem_SDL()
 	_logger(nullptr),
 	_eventSource(nullptr),
 	_eventSourceWrapper(nullptr),
-	_window(nullptr) {
+	_window(nullptr),
+	_haveDoubleClickTime(false),
+	_doubleClickTime(0)
+{
 }
 
 OSystem_SDL::~OSystem_SDL() {
@@ -188,6 +191,15 @@ bool OSystem_SDL::hasFeature(Feature f) {
 	if (f == kFeatureOpenGLForGame) return true;
 	if (f == kFeatureShadersForGame) return _supportsShaders;
 #endif
+
+	if (f == kFeatureDoubleClickTime) {
+		bool haveDoubleClickTime = _haveDoubleClickTime;
+#ifdef ENABLE_EVENTRECORDER
+		g_eventRec.processHaveDoubleClickTime(haveDoubleClickTime);
+#endif
+		return haveDoubleClickTime;
+	}
+
 	return ModularGraphicsBackend::hasFeature(f);
 }
 
@@ -760,6 +772,14 @@ Common::SaveFileManager *OSystem_SDL::getSavefileManager() {
 #else
 	return _savefileManager;
 #endif
+}
+
+uint32 OSystem_SDL::getDoubleClickTime() const {
+	uint32 doubleClickTime = _doubleClickTime;
+#ifdef ENABLE_EVENTRECORDER
+	g_eventRec.processDoubleClickTime(doubleClickTime);
+#endif
+	return _doubleClickTime;
 }
 
 //Not specified in base class

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -779,7 +779,7 @@ uint32 OSystem_SDL::getDoubleClickTime() const {
 #ifdef ENABLE_EVENTRECORDER
 	g_eventRec.processDoubleClickTime(doubleClickTime);
 #endif
-	return _doubleClickTime;
+	return doubleClickTime;
 }
 
 //Not specified in base class

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -89,8 +89,7 @@ OSystem_SDL::OSystem_SDL()
 	_logger(nullptr),
 	_eventSource(nullptr),
 	_eventSourceWrapper(nullptr),
-	_window(nullptr)
-{
+	_window(nullptr) {
 }
 
 OSystem_SDL::~OSystem_SDL() {
@@ -189,7 +188,6 @@ bool OSystem_SDL::hasFeature(Feature f) {
 	if (f == kFeatureOpenGLForGame) return true;
 	if (f == kFeatureShadersForGame) return _supportsShaders;
 #endif
-
 	return ModularGraphicsBackend::hasFeature(f);
 }
 

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -189,8 +189,7 @@ protected:
 	int getGraphicsMode() const override;
 #endif
 
-	bool _haveDoubleClickTime;
-	uint32 _doubleClickTime;
+	virtual uint32 getOSDoubleClickTime() const { return 0; }
 };
 
 #endif

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -89,6 +89,7 @@ public:
 	MixerManager *getMixerManager() override;
 	Common::TimerManager *getTimerManager() override;
 	Common::SaveFileManager *getSavefileManager() override;
+	uint32 getDoubleClickTime() const override;
 
 	// Default paths
 	virtual Common::String getDefaultIconsPath();
@@ -187,6 +188,9 @@ protected:
 	bool setGraphicsMode(int mode, uint flags) override;
 	int getGraphicsMode() const override;
 #endif
+
+	bool _haveDoubleClickTime;
+	uint32 _doubleClickTime;
 };
 
 #endif

--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -83,7 +83,6 @@ void OSystem_Win32::init() {
 #if defined(USE_JPEG)
 	initializeJpegLibraryForWin95();
 #endif
-
 	// Invoke parent implementation of this method
 	OSystem_SDL::init();
 }
@@ -503,6 +502,10 @@ void OSystem_Win32::addSysArchivesToSearchSet(Common::SearchSet &s, int priority
 
 AudioCDManager *OSystem_Win32::createAudioCDManager() {
 	return createWin32AudioCDManager();
+}
+
+uint32 OSystem_Win32::getOSDoubleClickTime() const {
+	return GetDoubleClickTime();
 }
 
 // libjpeg-turbo uses SSE instructions that error on at least some Win95 machines.

--- a/backends/platform/sdl/win32/win32.h
+++ b/backends/platform/sdl/win32/win32.h
@@ -62,6 +62,8 @@ protected:
 
 	HWND getHwnd() { return ((SdlWindow_Win32*)_window)->getHwnd(); }
 
+	uint32 getOSDoubleClickTime() const override;
+
 private:
 	bool _isPortable;
 	bool detectPortableConfigFile();

--- a/common/system.h
+++ b/common/system.h
@@ -548,7 +548,12 @@ public:
 		/**
 		* For platforms that should not have a Quit button.
 		*/
-		kFeatureNoQuit
+		kFeatureNoQuit,
+
+		/**
+		* Supports getDoubleClickTime call.
+		*/
+		kFeatureDoubleClickTime,
 	};
 
 	/**
@@ -1388,6 +1393,16 @@ public:
 	 * @see kFeatureCursorPalette
 	 */
 	virtual void setCursorPalette(const byte *colors, uint start, uint num) {}
+
+	
+
+	/** Get the system-configured double-click time interval.
+	 *
+	 * Backends which implement this should have the kFeatureDoubleClickTime flag set.
+	 *
+	 * @see kFeatureDoubleClickTime
+	 */
+	virtual uint32 getDoubleClickTime() const { return 0; }
 
 	/** @} */
 

--- a/common/system.h
+++ b/common/system.h
@@ -548,7 +548,7 @@ public:
 		/**
 		* For platforms that should not have a Quit button.
 		*/
-		kFeatureNoQuit,
+		kFeatureNoQuit
 	};
 
 	/**

--- a/common/system.h
+++ b/common/system.h
@@ -549,11 +549,6 @@ public:
 		* For platforms that should not have a Quit button.
 		*/
 		kFeatureNoQuit,
-
-		/**
-		* Supports getDoubleClickTime call.
-		*/
-		kFeatureDoubleClickTime,
 	};
 
 	/**
@@ -1396,11 +1391,9 @@ public:
 
 	
 
-	/** Get the system-configured double-click time interval.
-	 *
-	 * Backends which implement this should have the kFeatureDoubleClickTime flag set.
-	 *
-	 * @see kFeatureDoubleClickTime
+	/**
+	 * Get the system-configured double-click time interval.
+	 * If the system doesn't support configuring double-click time, returns 0.
 	 */
 	virtual uint32 getDoubleClickTime() const { return 0; }
 

--- a/engines/testbed/events.cpp
+++ b/engines/testbed/events.cpp
@@ -264,6 +264,48 @@ TestExitStatus EventTests::mouseEvents() {
 	return passed;
 }
 
+TestExitStatus EventTests::doubleClickTime() {
+	Testsuite::clearScreen();
+
+	uint32 dclickTime = g_system->getDoubleClickTime();
+
+	if (dclickTime == 0) {
+		if (Testsuite::handleInteractiveInput("Double-click time returned 0, meaning it isn't configurable on this operating system.\nIs that correct ?", "Yes", "No", kOptionLeft)) {
+			Testsuite::logDetailedPrintf("Unsupported double-click time check failed");
+			return kTestFailed;
+		}
+	}
+
+	Common::String info = "Testing double click time detection.\n "
+						  "This should report the correct double-click time for the system";
+
+	if (Testsuite::handleInteractiveInput(info, "OK", "Skip", kOptionRight)) {
+		Testsuite::logPrintf("Info! Skipping test : double click time\n");
+		return kTestSkipped;
+	}
+
+	info = Common::String::format("Double-click time was reported as: %u msec\nDoes this seem correct?", static_cast<unsigned int>(dclickTime));
+
+	if (Testsuite::handleInteractiveInput(info, "Yes", "No", kOptionRight)) {
+		Testsuite::logDetailedPrintf("Double-click time failed");
+		return kTestFailed;
+	}
+
+	if (Testsuite::handleInteractiveInput("Do you want to test for detecting configuration changes?\nIf so, change the OS double-click time now, then click 'Yes'", "Yes", "No", kOptionLeft)) {
+		dclickTime = g_system->getDoubleClickTime();
+
+		info = Common::String::format("Double-click time was reported as: %u msec\nDoes this seem correct?", static_cast<unsigned int>(dclickTime));
+
+		if (Testsuite::handleInteractiveInput(info, "Yes", "No", kOptionRight)) {
+			Testsuite::logDetailedPrintf("Double-click time reconfiguration failed");
+			return kTestFailed;
+		}
+	}
+
+
+	return kTestPassed;
+}
+
 TestExitStatus EventTests::kbdEvents() {
 
 	Testsuite::clearScreen();
@@ -330,6 +372,7 @@ TestExitStatus EventTests::showMainMenu() {
 
 EventTestSuite::EventTestSuite() {
 	addTest("MouseEvents", &EventTests::mouseEvents);
+	addTest("DoubleClickTime", &EventTests::doubleClickTime);
 	addTest("KeyboardEvents", &EventTests::kbdEvents);
 	addTest("MainmenuEvent", &EventTests::showMainMenu);
 }

--- a/engines/testbed/events.h
+++ b/engines/testbed/events.h
@@ -33,6 +33,7 @@ char keystrokeToChar();
 Common::Rect drawFinishZone();
 // will contain function declarations for Event tests
 TestExitStatus mouseEvents();
+TestExitStatus doubleClickTime();
 TestExitStatus kbdEvents();
 TestExitStatus showMainMenu();
 // add more here

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -512,6 +512,9 @@ void EventRecorder::getConfigFromDomain(const Common::ConfigManager::Domain *dom
 }
 
 void EventRecorder::getConfig() {
+	if (g_system->hasFeature(OSystem::kFeatureDoubleClickTime))
+		_recordFile->getHeader().settingsRecords["double_click_time"] = Common::String::format("%u", static_cast<unsigned int>(g_system->getDoubleClickTime()));
+
 	getConfigFromDomain(ConfMan.getDomain(ConfMan.kApplicationDomain));
 	getConfigFromDomain(ConfMan.getActiveDomain());
 	_recordFile->getHeader().settingsRecords["save_slot"] = ConfMan.get("save_slot");
@@ -684,6 +687,27 @@ Common::SeekableReadStream *EventRecorder::processSaveStream(const Common::Strin
 		return saveFile;
 	default:
 		return nullptr;
+	}
+}
+
+void EventRecorder::processHaveDoubleClickTime(bool &haveDoubleClickTime) {
+	if (_initialized && (_recordMode == kRecorderPlayback || _recordMode == kRecorderUpdate))
+		haveDoubleClickTime = _playbackFile->getHeader().settingsRecords.contains("double_click_time");
+}
+
+void EventRecorder::processDoubleClickTime(uint32 &doubleClickTime) {
+	if (_initialized && (_recordMode == kRecorderPlayback || _recordMode == kRecorderUpdate)) {
+		const Common::StringMap &settings = _playbackFile->getHeader().settingsRecords;
+		Common::StringMap::const_iterator it = settings.find("double_click_time");
+		if (it == settings.end())
+			doubleClickTime = 0;
+		else {
+			unsigned int temp = 0;
+			if (sscanf(it->_value.c_str(), "%u", &temp))
+				doubleClickTime = temp;
+			else
+				doubleClickTime = 0;
+		}
 	}
 }
 

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -512,8 +512,7 @@ void EventRecorder::getConfigFromDomain(const Common::ConfigManager::Domain *dom
 }
 
 void EventRecorder::getConfig() {
-	if (g_system->hasFeature(OSystem::kFeatureDoubleClickTime))
-		_recordFile->getHeader().settingsRecords["double_click_time"] = Common::String::format("%u", static_cast<unsigned int>(g_system->getDoubleClickTime()));
+	_recordFile->getHeader().settingsRecords["double_click_time"] = Common::String::format("%u", static_cast<unsigned int>(g_system->getDoubleClickTime()));
 
 	getConfigFromDomain(ConfMan.getDomain(ConfMan.kApplicationDomain));
 	getConfigFromDomain(ConfMan.getActiveDomain());
@@ -687,27 +686,6 @@ Common::SeekableReadStream *EventRecorder::processSaveStream(const Common::Strin
 		return saveFile;
 	default:
 		return nullptr;
-	}
-}
-
-void EventRecorder::processHaveDoubleClickTime(bool &haveDoubleClickTime) {
-	if (_initialized && (_recordMode == kRecorderPlayback || _recordMode == kRecorderUpdate))
-		haveDoubleClickTime = _playbackFile->getHeader().settingsRecords.contains("double_click_time");
-}
-
-void EventRecorder::processDoubleClickTime(uint32 &doubleClickTime) {
-	if (_initialized && (_recordMode == kRecorderPlayback || _recordMode == kRecorderUpdate)) {
-		const Common::StringMap &settings = _playbackFile->getHeader().settingsRecords;
-		Common::StringMap::const_iterator it = settings.find("double_click_time");
-		if (it == settings.end())
-			doubleClickTime = 0;
-		else {
-			unsigned int temp = 0;
-			if (sscanf(it->_value.c_str(), "%u", &temp))
-				doubleClickTime = temp;
-			else
-				doubleClickTime = 0;
-		}
 	}
 }
 

--- a/gui/EventRecorder.h
+++ b/gui/EventRecorder.h
@@ -87,6 +87,8 @@ public:
 	void processGameDescription(const ADGameDescription *desc);
 	bool processAutosave();
 	Common::SeekableReadStream *processSaveStream(const Common::String & fileName);
+	void processHaveDoubleClickTime(bool &haveDoubleClickTime);
+	void processDoubleClickTime(uint32 &doubleClickTime);
 
 	/** Hooks for intercepting into GUI processing, so required events could be shoot
 	 *  or filtered out */

--- a/gui/EventRecorder.h
+++ b/gui/EventRecorder.h
@@ -87,8 +87,6 @@ public:
 	void processGameDescription(const ADGameDescription *desc);
 	bool processAutosave();
 	Common::SeekableReadStream *processSaveStream(const Common::String & fileName);
-	void processHaveDoubleClickTime(bool &haveDoubleClickTime);
-	void processDoubleClickTime(uint32 &doubleClickTime);
 
 	/** Hooks for intercepting into GUI processing, so required events could be shoot
 	 *  or filtered out */


### PR DESCRIPTION
Definitely not sure the changes for the event recorder are in good places, open to suggestions.

This can be implemented on macOS as well with doubleClickInterval, see https://developer.apple.com/documentation/appkit/nsevent/1528384-doubleclickinterval