### PR TITLE
ENGINES: Fix warning about passing a non-trivial class to va_start.

### DIFF
--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -464,12 +464,12 @@ void GUIErrorMessageFormat(const char *fmt, ...) {
 	GUIErrorMessage(msg);
 }
 
-void GUIErrorMessageFormat(Common::U32String fmt, ...) {
+void GUIErrorMessageFormatU32StringPtr(const Common::U32String *fmt, ...) {
 	Common::U32String msg("");
 
 	va_list va;
 	va_start(va, fmt);
-	Common::U32String::vformat(fmt.begin(), fmt.end(), msg, va);
+	Common::U32String::vformat(fmt->begin(), fmt->end(), msg, va);
 	va_end(va);
 
 	GUIErrorMessage(msg);

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -78,7 +78,14 @@ void GUIErrorMessageWithURL(const Common::String &msg, const char *url);
 /**
  * Initialize graphics and show an error message.
  */
-void GUIErrorMessageFormat(Common::U32String fmt, ...);
+void GUIErrorMessageFormatU32StringPtr(const Common::U32String *fmt, ...);
+/**
+ * Initialize graphics and show an error message.
+ */
+template<class... TParam>
+inline void GUIErrorMessageFormat(const Common::U32String &fmt, TParam... param) {
+	GUIErrorMessageFormatU32StringPtr(&fmt, Common::forward<TParam>(param)...);
+}
 /**
  * Initialize graphics and show an error message.
  */


### PR DESCRIPTION
Similar to the fix already done in 55d31b02601591c8b126b2115d91d3ad6fabc9c5 for strings.  Fixes a warning in Visual Studio:

`G:\src2\scummvm\engines\engine.cpp(482,2): warning C4840: non-portable use of class 'Common::U32String' as an argument to a variadic function`
`G:\src2\scummvm\engines\engine.cpp(482,2): note: 'Common::U32String::U32String' is non-trivial`
`G:\src2\scummvm\engines\engine.cpp(482,2): note: the constructor and destructor will not be called; a bitwise copy of the class will be passed as the argument`
