### PR TITLE
COMMON: fix String::rfind for default value of pos (max value of size_t)

### DIFF
--- a/common/str.cpp
+++ b/common/str.cpp
@@ -325,9 +325,15 @@ size_t String::rfind(const char *s) const {
 }
 
 size_t String::rfind(char c, size_t pos) const {
-	for (int idx = MIN((int)_size - 1, (int)pos); idx >= 0; --idx) {
-		if ((*this)[idx] == c)
-			return idx;
+	if (pos == npos || pos > _size)
+		pos = _size;
+	else
+		++pos;
+
+	while (pos > 0) {
+		--pos;
+		if ((*this)[pos] == c)
+			return pos;
 	}
 
 	return npos;

--- a/test/common/str.h
+++ b/test/common/str.h
@@ -561,6 +561,22 @@ class StringTestSuite : public CxxTest::TestSuite
 		TS_ASSERT_EQUALS(s4, "TestTestTestTestTestTestTestTestTestTestTest");
 	}
 
+	void test_find() {
+		Common::String a("0123012"), b;
+
+		TS_ASSERT_EQUALS(a.find('1'), 1u);
+		TS_ASSERT_EQUALS(a.find('3'), 3u);
+		TS_ASSERT_EQUALS(a.find('1', 3), 5u);
+		TS_ASSERT_EQUALS(b.find('*'), Common::String::npos);
+		TS_ASSERT_EQUALS(b.find('*', 1), Common::String::npos);
+
+		TS_ASSERT_EQUALS(a.rfind('1'), 5u);
+		TS_ASSERT_EQUALS(a.rfind('3'), 3u);
+		TS_ASSERT_EQUALS(a.rfind('1', 3), 1u);
+		TS_ASSERT_EQUALS(b.rfind('*'), Common::String::npos);
+		TS_ASSERT_EQUALS(b.rfind('*', 1), Common::String::npos);
+	}
+
 	void test_setChar() {
 		Common::String testString("123456");
 		testString.setChar('2', 0);


### PR DESCRIPTION
Default value for pos is npos:
`size_t rfind(char c, size_t pos = npos) const;`

So if default value was used, after its cast to int a very big negative value appeared in the right part of MIN((int)_size - 1, (int)pos). Additional check was added to handle this case.