### PR TITLE
MADS: Add detection for Once Upon a Forest; fix segment loading for Rex Nebular, Dragonsphere and Phantom demos

### DIFF
--- a/engines/mads/audio.cpp
+++ b/engines/mads/audio.cpp
@@ -54,6 +54,7 @@ void AudioPlayer::setDefaultSoundGroup() {
 		setSoundGroup("rex009.dsr");
 		break;
 	case GType_Dragonsphere:
+	case GType_Forest:
 		setSoundGroup("drag009.dsr");
 		break;
 	case GType_Phantom:

--- a/engines/mads/detection.cpp
+++ b/engines/mads/detection.cpp
@@ -32,6 +32,7 @@ static const PlainGameDescriptor MADSGames[] = {
 	{"dragonsphere", "Dragonsphere"},
 	{"nebular", "Rex Nebular and the Cosmic Gender Bender"},
 	{"phantom", "Return of the Phantom"},
+	{"forest", "Once Upon a Forest"},
 	{nullptr, nullptr}
 };
 

--- a/engines/mads/detection.h
+++ b/engines/mads/detection.h
@@ -30,7 +30,8 @@ namespace MADS {
 enum {
 	GType_RexNebular = 0,
 	GType_Dragonsphere = 1,
-	GType_Phantom = 2
+	GType_Phantom = 2,
+	GType_Forest = 3
 };
 
 enum {

--- a/engines/mads/detection_tables.h
+++ b/engines/mads/detection_tables.h
@@ -152,6 +152,21 @@ static const MADSGameDescription gameDescriptions[] = {
 		0
 	},
 
+	{
+		// Once Upon a Forest DOS English
+		{
+			"forest",
+			"",
+			AD_ENTRY1s("section1.hag", "042518994daa7f96f9602e3b7e14a672", 816076),
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_UNSTABLE,
+			GUIO1(GAMEOPTION_EASY_MOUSE)
+		},
+		GType_Forest,
+		0
+	},
+
 #endif
 
 	{ AD_TABLE_END_MARKER, 0, 0 }

--- a/engines/mads/mads.h
+++ b/engines/mads/mads.h
@@ -113,6 +113,7 @@ public:
 	uint16 getVersion() const;
 	uint32 getGameID() const;
 	uint32 getGameFeatures() const;
+	bool isDemo() const;
 
 	int getRandomNumber(int maxNumber);
 	int getRandomNumber(int minNumber, int maxNumber);

--- a/engines/mads/metaengine.cpp
+++ b/engines/mads/metaengine.cpp
@@ -130,6 +130,10 @@ uint32 MADSEngine::getFeatures() const {
 	return _gameDescription->desc.flags;
 }
 
+bool MADSEngine::isDemo() const {
+	return (bool)(_gameDescription->desc.flags & ADGF_DEMO);
+}
+
 Common::Language MADSEngine::getLanguage() const {
 	return _gameDescription->desc.language;
 }

--- a/engines/mads/resources.cpp
+++ b/engines/mads/resources.cpp
@@ -156,14 +156,26 @@ void HagArchive::loadIndex(MADSEngine *vm) {
  		if (sectionIndex == 0 && !Common::File::exists("SECTION0.HAG"))
 			continue;
 
+		// Rex Nebular and Dragonsphere demos only have sections 1 and 9 - skip the rest
+		if ((vm->getGameID() == GType_RexNebular || vm->getGameID() == GType_Dragonsphere) && vm->isDemo())  {
+			if (sectionIndex != 1 && sectionIndex != 9)
+				continue;
+		}
+
+		// Phantom demo only has sections 1, 2 and 9 - skip the rest
+		if (vm->getGameID() == GType_Phantom && vm->isDemo())  {
+			if (sectionIndex != 1 && sectionIndex != 2 && sectionIndex != 9)
+				continue;
+		}
+
 		// Dragonsphere does not have some sections - skip them
 		if (vm->getGameID() == GType_Dragonsphere)  {
 			if (sectionIndex == 7 || sectionIndex == 8)
 				continue;
 		}
 
-		// Phantom does not have some sections - skip them
-		if (vm->getGameID() == GType_Phantom)  {
+		// Phantom and Forest don't have some sections - skip them
+		if (vm->getGameID() == GType_Phantom || vm->getGameID() == GType_Forest)  {
 			if (sectionIndex == 6 || sectionIndex == 7 || sectionIndex == 8)
 				continue;
 		}


### PR DESCRIPTION
Also yes, OUaF's EXE does reference `drag009.dsr` despite not containing that file. The demos still error out trying to load `FONTINTR.FF` that's apparently in `GLOBAL.HAG`.

After extracting the HAG files, the Rex Nebular demo doesn't use the FAB compression, instead using what's in ScummVM as `Common::GzioReadStream::deflateDecompress`.