### PR TITLE
Use MSVC_PRINTF when GCC_PRINTF is used

### DIFF
--- a/engines/agos/agos.h
+++ b/engines/agos/agos.h
@@ -728,7 +728,7 @@ protected:
 	void uncompressText(byte *ptr);
 	byte *uncompressToken(byte a, byte *ptr);
 
-	void showMessageFormat(const char *s, ...) GCC_PRINTF(2, 3);
+	void showMessageFormat(MSVC_PRINTF const char *s, ...) GCC_PRINTF(2, 3);
 	const byte *getStringPtrByID(uint16 stringId, bool upperCase = false);
 	const byte *getLocalStringByID(uint16 stringId);
 	uint getNextStringID();
@@ -2083,7 +2083,7 @@ protected:
 	void printScreenText(uint vgaSpriteId, uint color, const char *stringPtr, int16 x, int16 y, int16 width) override;
 
 	void printInteractText(uint16 num, const char *string);
-	void sendInteractText(uint16 num, const char *fmt, ...) GCC_PRINTF(3, 4);
+	void sendInteractText(uint16 num, MSVC_PRINTF const char *fmt, ...) GCC_PRINTF(3, 4);
 
 	void checkLinkBox();
 	void hyperLinkOn(uint16 x);

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -82,7 +82,7 @@ void GUIErrorMessageFormat(Common::U32String fmt, ...);
 /**
  * Initialize graphics and show an error message.
  */
-void GUIErrorMessageFormat(const char *fmt, ...) GCC_PRINTF(1, 2);
+void GUIErrorMessageFormat(MSVC_PRINTF const char *fmt, ...) GCC_PRINTF(1, 2);
 
 
 class Engine;

--- a/engines/glk/adrift/scprotos.h
+++ b/engines/glk/adrift/scprotos.h
@@ -63,9 +63,9 @@ typedef void (*sc_write_callbackref_t)(void *, const sc_byte *, sc_int);
 /*
  * Small utility and wrapper functions.
  */
-extern void sc_trace(const sc_char *format, ...) GCC_PRINTF(1, 2);
-extern void sc_error(const sc_char *format, ...) GCC_PRINTF(1, 2);
-extern void sc_fatal(const sc_char *format, ...) GCC_PRINTF(1, 2);
+extern void sc_trace(MSVC_PRINTF const sc_char *format, ...) GCC_PRINTF(1, 2);
+extern void sc_error(MSVC_PRINTF const sc_char *format, ...) GCC_PRINTF(1, 2);
+extern void sc_fatal(MSVC_PRINTF const sc_char *format, ...) GCC_PRINTF(1, 2);
 extern void *sc_malloc(size_t size);
 extern void *sc_realloc(void *pointer, size_t size);
 extern void sc_free(void *pointer);

--- a/engines/glk/adrift/sxprotos.h
+++ b/engines/glk/adrift/sxprotos.h
@@ -49,9 +49,9 @@ typedef struct sx_test_descriptor_s {
 /*
  * Small utility and wrapper functions.
  */
-extern void sx_trace(const sc_char *format, ...) GCC_PRINTF(1, 2);
-extern void sx_error(const sc_char *format, ...) GCC_PRINTF(1, 2);
-extern void sx_fatal(const sc_char *format, ...) GCC_PRINTF(1, 2);
+extern void sx_trace(MSVC_PRINTF const sc_char *format, ...) GCC_PRINTF(1, 2);
+extern void sx_error(MSVC_PRINTF const sc_char *format, ...) GCC_PRINTF(1, 2);
+extern void sx_fatal(MSVC_PRINTF const sc_char *format, ...) GCC_PRINTF(1, 2);
 extern void *sx_malloc(size_t size);
 extern void *sx_realloc(void *pointer, size_t size);
 extern void sx_free(void *pointer);

--- a/engines/glk/archetype/string.h
+++ b/engines/glk/archetype/string.h
@@ -61,7 +61,7 @@ public:
 		return *this;
 	}
 
-	static String format(const char *fmt, ...) GCC_PRINTF(1, 2);
+	static String format(MSVC_PRINTF const char *fmt, ...) GCC_PRINTF(1, 2);
 
 	static String vformat(const char *fmt, va_list args);
 

--- a/engines/icb/common/px_string.h
+++ b/engines/icb/common/px_string.h
@@ -95,7 +95,7 @@ inline pxString::~pxString() {
 		delete[] s;
 }
 
-const char *pxVString(const char *format, ...) GCC_PRINTF(1, 2);
+const char *pxVString(MSVC_PRINTF const char *format, ...) GCC_PRINTF(1, 2);
 
 class pxFlexiCharBuffer {
 	char *m_buffer; // The buffer itself

--- a/engines/kyra/text/text_lol.h
+++ b/engines/kyra/text/text_lol.h
@@ -44,7 +44,7 @@ public:
 	void expandField();
 
 	void printDialogueText2(int dim, const char *str, EMCState *script, const uint16 *paramList, int16 paramIndex);
-	void printMessage(uint16 type, const char *str, ...) GCC_PRINTF(3, 4);
+	void printMessage(uint16 type, MSVC_PRINTF const char *str, ...) GCC_PRINTF(3, 4);
 
 	int16 _scriptTextParameter;
 

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -111,7 +111,7 @@ enum {
 };
 
 /* SCUMM Debug Channels */
-void debugC(int level, const char *s, ...) GCC_PRINTF(2, 3);
+void debugC(int level, MSVC_PRINTF const char *s, ...) GCC_PRINTF(2, 3);
 
 enum {
 	DEBUG_GENERAL	=	1 << 0,		// General debug
@@ -702,7 +702,7 @@ protected:
 	void restoreSurfacesPostGUI();
 
 public:
-	char displayMessage(const char *altButton, const char *message, ...) GCC_PRINTF(3, 4);
+	char displayMessage(const char *altButton, MSVC_PRINTF const char *message, ...) GCC_PRINTF(3, 4);
 
 protected:
 	byte _fastMode = 0;

--- a/engines/sherlock/screen.h
+++ b/engines/sherlock/screen.h
@@ -105,12 +105,12 @@ public:
 	 * Prints the text passed onto the back buffer at the given position and color.
 	 * The string is then blitted to the screen
 	 */
-	void print(const Common::Point &pt, uint color, const char *formatStr, ...) GCC_PRINTF(4, 5);
+	void print(const Common::Point &pt, uint color, MSVC_PRINTF const char *formatStr, ...) GCC_PRINTF(4, 5);
 
 	/**
 	 * Print a strings onto the back buffer without blitting it to the screen
 	 */
-	void gPrint(const Common::Point &pt, uint color, const char *formatStr, ...) GCC_PRINTF(4, 5);
+	void gPrint(const Common::Point &pt, uint color, MSVC_PRINTF const char *formatStr, ...) GCC_PRINTF(4, 5);
 
 	/**
 	 * Copies a section of the second back buffer into the main back buffer

--- a/engines/sherlock/tattoo/tattoo_user_interface.h
+++ b/engines/sherlock/tattoo/tattoo_user_interface.h
@@ -172,7 +172,7 @@ public:
 	/**
 	 * This will display a text message in a dialog at the bottom of the screen
 	 */
-	void putMessage(const char *formatStr, ...) GCC_PRINTF(2, 3);
+	void putMessage(MSVC_PRINTF const char *formatStr, ...) GCC_PRINTF(2, 3);
 
 	/**
 	 * Makes a greyscale translation table for each palette entry in the table

--- a/engines/sky/control.h
+++ b/engines/sky/control.h
@@ -198,7 +198,7 @@ public:
 	void saveDescriptions(const Common::StringArray &list);
 
 private:
-	int displayMessage(const char *altButton, const char *message, ...) GCC_PRINTF(3, 4);
+	int displayMessage(const char *altButton, MSVC_PRINTF const char *message, ...) GCC_PRINTF(3, 4);
 
 	void initPanel();
 	void removePanel();

--- a/engines/sword1/control.h
+++ b/engines/sword1/control.h
@@ -99,7 +99,7 @@ public:
 	}
 
 private:
-	int displayMessage(const char *altButton, const char *message, ...) GCC_PRINTF(3, 4);
+	int displayMessage(const char *altButton, MSVC_PRINTF const char *message, ...) GCC_PRINTF(3, 4);
 
 	bool convertSaveGame(uint8 slot, char *desc);
 	void showSavegameNames();

--- a/engines/testbed/testsuite.h
+++ b/engines/testbed/testsuite.h
@@ -148,8 +148,8 @@ public:
 	virtual const char *getName() const = 0;
 	virtual const char *getDescription() const = 0;
 
-	static void logPrintf(const char *s, ...) GCC_PRINTF(1, 2);
-	static void logDetailedPrintf(const char *s, ...) GCC_PRINTF(1, 2);
+	static void logPrintf(MSVC_PRINTF const char *s, ...) GCC_PRINTF(1, 2);
+	static void logDetailedPrintf(MSVC_PRINTF const char *s, ...) GCC_PRINTF(1, 2);
 
 	// Progress bar (Information Display) related methods.
 	/**

--- a/gui/console.h
+++ b/gui/console.h
@@ -143,7 +143,7 @@ public:
 	void handleKeyDown(Common::KeyState state) override;
 	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data) override;
 
-	int printFormat(int dummy, const char *format, ...) GCC_PRINTF(3, 4);
+	int printFormat(int dummy, MSVC_PRINTF const char *format, ...) GCC_PRINTF(3, 4);
 	int vprintFormat(int dummy, const char *format, va_list argptr);
 
 	void printChar(int c);

--- a/gui/debugger.h
+++ b/gui/debugger.h
@@ -45,7 +45,7 @@ public:
 
 	int getCharsPerLine();
 
-	int debugPrintf(const char *format, ...) GCC_PRINTF(2, 3);
+	int debugPrintf(MSVC_PRINTF const char *format, ...) GCC_PRINTF(2, 3);
 
 	void debugPrintColumns(const Common::StringArray &list);
 


### PR DESCRIPTION
This adds `MSVC_PRINTF` in several cases where only `GCC_PRINTF` was used until now.

`MSVC_PRINTF` isn't as useful as `GCC_PRINTF` because (AFAIK, just a very casual MSVC user) it's only going to be checked if you enable `/analyze`, but using it shouldn't hurt.

Submitting this as a PR so that I can check the CI part (I've tested some cases myself in Visual Code 2022 but it looks like the whole thing would take a couple of hours…) and in case any MSVC user has an objection.