### PR TITLE
CI: Make msbuild less verbose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           cd build-scummvm
           ls
-          msbuild scummvm.sln /m /p:BuildInParallel=true /p:Configuration=${{ env.CONFIGURATION }} /p:PreferredToolArchitecture=x64 /p:Platform=${{ matrix.platform }}
+          msbuild scummvm.sln /m /p:BuildInParallel=true /p:Configuration=${{ env.CONFIGURATION }} /p:PreferredToolArchitecture=x64 /p:Platform=${{ matrix.platform }} /v:minimal
 #      - name: Upload scummvm
 #        uses: actions/upload-artifact@v2
 #        with:


### PR DESCRIPTION
This PR makes the msbuild CI task use [`/v:minimal`](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022) in order to have an output that's comparable to the Xcode and Linux build output (i.e. not excessively verbose).

Rough estimate:

* before: 20 000 lines, 3.8 MB log ooutput
* after: 7 000 lines, 630 KB log output

(Otherwise, I think most people tend not to read this output, because it's so gigantic it takes forever to load, and it's very hard to notice any warning in it.)

Any objection?