### PR TITLE
CI: Update various GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: ilammy/setup-nasm@v1
         if: ${{ matrix.useNasm }} == 'true'
       - name: Install vcpkg and packages
@@ -46,7 +46,7 @@ jobs:
           vcpkgTriplet: '${{ matrix.triplet }}'
           vcpkgArguments: '${{ matrix.vcpkgPackages }}'
 #      - name: Upload libs
-#        uses: actions/upload-artifact@v2
+#        uses: actions/upload-artifact@v3
 #        with:
 #          name: libs-${{ matrix.triplet }}
 #          path: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}
@@ -68,29 +68,29 @@ jobs:
           echo "SCUMMVM_LIBS=${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}\\debug" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Copy-Item "${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}\\include" -Destination "${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}\\debug" -Recurse
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.1.3
       - name: Build scummvm
         run: |
           cd build-scummvm
           ls
           msbuild scummvm.sln /m /p:BuildInParallel=true /p:Configuration=${{ env.CONFIGURATION }} /p:PreferredToolArchitecture=x64 /p:Platform=${{ matrix.platform }}
 #      - name: Upload scummvm
-#        uses: actions/upload-artifact@v2
+#        uses: actions/upload-artifact@v3
 #        with:
 #          name: scummvm-${{ matrix.arch }}
 #          path: build-scummvm/${{ env.CONFIGURATION }}${{ matrix.arch }}/*.exe
 #      - name: Upload scummvm libs
-#        uses: actions/upload-artifact@v2
+#        uses: actions/upload-artifact@v3
 #        with:
 #          name: scummvm-${{ matrix.arch }}
 #          path: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}\\bin\\*.dll
 #      - name: Upload scummvm symbols
-#        uses: actions/upload-artifact@v2
+#        uses: actions/upload-artifact@v3
 #        with:
 #          name: symbols-${{ matrix.arch }}
 #          path: build-scummvm/${{ env.CONFIGURATION }}${{ matrix.arch }}/*.pdb
 #      - name: Upload scummvm libs symbols
-#        uses: actions/upload-artifact@v2
+#        uses: actions/upload-artifact@v3
 #        with:
 #          name: symbols-${{ matrix.arch }}
 #          path: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}\\bin\\*.pdb
@@ -118,7 +118,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install packages
         if: ${{ matrix.brewPackages }}
         run: brew install ${{ matrix.brewPackages }}
@@ -139,7 +139,7 @@ jobs:
           ./devtools/create_project/xcode/build/Release/create_project . --xcode --enable-all-engines ${{ matrix.configflags }}
           ls
       - name: Build cache
-        uses: mikehardy/buildcache-action@v1
+        uses: mikehardy/buildcache-action@v2
         with:
           cache_key: ${{ matrix.platform }}
       - name: Build scummvm
@@ -169,7 +169,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Add Ubuntu Xenial package sources
         if: matrix.platform == 'ubuntu-20.04'
         run: |
@@ -180,7 +180,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install ${{ matrix.aptPackages }}
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ matrix.platform }}
           max-size: 1G


### PR DESCRIPTION
This updates several GitHub Actions components that we use.

Most of them deal with the current Node.js 12 and set-output deprecation warnings:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: `actions/checkout@v2`, `mikehardy/buildcache-action@v1`
> 
> GitHub Actions: Deprecating save-state and set-output commands: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
