### PR TITLE
ALL: Fix various MSVC C4309 enum sign warnings

### DIFF
--- a/common/span.h
+++ b/common/span.h
@@ -42,7 +42,7 @@ namespace Common {
 	typedef typename super_type::reference reference; \
 	typedef typename super_type::const_reference const_reference;
 
-enum {
+enum : uint {
 	kSpanMaxSize = 0xFFFFFFFF,
 	kSpanKeepOffset = 0xFFFFFFFF
 };

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -89,7 +89,7 @@ struct ADGameFileDescription {
  *
  * Note that the lowest 16 bits are currently reserved for use by the client code.
  */
-enum ADGameFlags {
+enum ADGameFlags : uint {
 	ADGF_NO_FLAGS        =  0u,        ///< No flags.
 	ADGF_TAILMD5         = (1u << 16), ///< Calculate the MD5 for this entry from the end of the file.
 	ADGF_AUTOGENTARGET   = (1u << 17), ///< Automatically generate gameid from @ref ADGameDescription::extra.

--- a/engines/dragons/dragons.h
+++ b/engines/dragons/dragons.h
@@ -45,7 +45,7 @@ enum kReadSaveHeaderError {
 	kRSHEIoError = 3
 };
 
-enum Flags {
+enum Flags : uint {
 	ENGINE_FLAG_1 = 1,
 	ENGINE_FLAG_2 = 2,
 	ENGINE_FLAG_4 = 4,

--- a/engines/glk/events.h
+++ b/engines/glk/events.h
@@ -55,7 +55,7 @@ enum EvType {
 /**
  * Keycodes
  */
-enum Keycode {
+enum Keycode : uint {
 	keycode_Unknown  = 0xffffffffU,
 	keycode_Left     = 0xfffffffeU,
 	keycode_Right    = 0xfffffffdU,

--- a/engines/lastexpress/shared.h
+++ b/engines/lastexpress/shared.h
@@ -99,7 +99,7 @@ enum SoundTag {
     processes the sound as a payment for portability, so we can afford
     to just mix the silence without special processing of muted entries.
 */
-enum SoundFlag {
+enum SoundFlag : uint {
 	kSoundVolumeEntityDefault = 0xFFFFFFFF, // special value for SoundManager::playSound; choose volume based on distance to the entity
 
 	kVolumeNone               = 0x0,
@@ -172,7 +172,7 @@ enum AmbientSoundState {
 // Time is measured in ticks, with 15 ticks per second. One minute is 900
 // ticks, one hour is 54,000 ticks, and one day is 1,296,000 ticks.
 
-enum TimeValue {
+enum TimeValue : uint {
 	kTimeNone                 = 0,
 	kTime5933                 = 5933,
 
@@ -478,7 +478,7 @@ enum ChapterIndex {
 //////////////////////////////////////////////////////////////////////////
 // Index of scenes
 //////////////////////////////////////////////////////////////////////////
-enum SceneIndex {
+enum SceneIndex : uint {
 	kSceneNone                    = 0,
 	kSceneMenu                    = 1,
 

--- a/engines/mohawk/view.h
+++ b/engines/mohawk/view.h
@@ -32,7 +32,7 @@ class GraphicsManager;
 class Feature;
 class View;
 
-enum {
+enum : uint {
 	kFeatureObjectMask = 0xff, // both (sort of)
 	kFeatureOldSortForeground = 0x1000, // old
 	kFeatureOldDropSpot = 0x2000, // old

--- a/engines/mtropolis/data.h
+++ b/engines/mtropolis/data.h
@@ -76,7 +76,7 @@ enum TextAlignmentCode {
 
 namespace DataObjectTypes {
 
-enum DataObjectType {
+enum DataObjectType : uint {
 	kUnknown								= 0,
 
 	kProjectLabelMap						= 0x22,
@@ -425,7 +425,7 @@ struct ProjectLabelMap : public DataObject {
 		LabelTree();
 		~LabelTree();
 
-		enum {
+		enum : uint {
 			kExpandedInEditor = 0x80000000,
 		};
 
@@ -719,7 +719,7 @@ protected:
 };
 
 struct SoundElement : public StructuralDef {
-	enum SoundFlags {
+	enum SoundFlags : uint {
 		kPaused = 0x40000000,
 		kLoop = 0x80000000,
 	};
@@ -1010,7 +1010,7 @@ protected:
 	DataReadErrorCode load(DataReader &reader) override;
 };
 
-enum MessageFlags {
+enum MessageFlags : uint {
 	kMessageFlagNoRelay = 0x20000000,
 	kMessageFlagNoCascade = 0x40000000,
 	kMessageFlagNoImmediate = 0x80000000,
@@ -1085,7 +1085,7 @@ protected:
 };
 
 struct ChangeSceneModifier : public DataObject {
-	enum ChangeSceneFlags {
+	enum ChangeSceneFlags : uint {
 		kChangeSceneFlagNextScene			= 0x80000000,
 		kChangeSceneFlagPrevScene			= 0x40000000,
 		kChangeSceneFlagSpecificScene		= 0x20000000,

--- a/engines/mutationofjb/widgets/widget.h
+++ b/engines/mutationofjb/widgets/widget.h
@@ -39,7 +39,7 @@ class GuiScreen;
 
 class Widget {
 public:
-	enum {
+	enum : uint {
 		DIRTY_NONE = 0,
 		DIRTY_ALL = 0xFFFFFFFF
 	};

--- a/engines/neverhood/gamevars.h
+++ b/engines/neverhood/gamevars.h
@@ -28,7 +28,7 @@
 
 namespace Neverhood {
 
-enum {
+enum : uint {
 	// Misc
 	V_MODULE_NAME				= 0x91080831,			// Currently active module name hash
 	V_CURRENT_SCENE				= 0x108A4870,			// Current scene in the current module

--- a/engines/parallaction/objects.h
+++ b/engines/parallaction/objects.h
@@ -92,7 +92,7 @@ enum ZoneFlags {
 };
 
 
-enum CommandFlags {
+enum CommandFlags : uint {
 	kFlagsAll			= 0xFFFFFFFFU,
 
 	kFlagsVisited		= 1,

--- a/engines/sci/engine/script.h
+++ b/engines/sci/engine/script.h
@@ -55,7 +55,7 @@ enum ScriptOffsetEntryTypes {
 	SCI_SCR_OFFSET_TYPE_SAID
 };
 
-enum {
+enum : uint {
 	kNoRelocation = 0xFFFFFFFF
 };
 

--- a/engines/scumm/he/wiz_he.h
+++ b/engines/scumm/he/wiz_he.h
@@ -203,7 +203,7 @@ enum WizCompositeFlags {
 	kWCFSubConditionBits = 0x20
 };
 
-enum WizSpcConditionTypes {
+enum WizSpcConditionTypes : uint {
 	kWSPCCTBits = 0xc0000000,
 	kWSPCCTOr   = 0x00000000,
 	kWSPCCTAnd  = 0x40000000,

--- a/engines/scumm/resource.h
+++ b/engines/scumm/resource.h
@@ -44,7 +44,7 @@ public:
 	const byte *findNext(uint32 tag);
 };
 
-enum {
+enum : uint {
 	RES_INVALID_OFFSET = 0xFFFFFFFF
 };
 

--- a/graphics/colormasks.h
+++ b/graphics/colormasks.h
@@ -65,7 +65,7 @@ The meaning of these is masks is the following:
 
 template<>
 struct ColorMasks<565> {
-	enum {
+	enum : uint {
 		kHighBitsMask    = 0xF7DEF7DE,
 		kLowBitsMask     = 0x08210821,
 		qhighBits   = 0xE79CE79C,


### PR DESCRIPTION
MSVC shows quite a lot of `warning C4309: 'initializing' : truncation of constant value` when an enum contains an unsigned value.

With C++11, it seems that making those enums do an `: unsigned int` is just a reasonable way of silencing any warning, while making it more explicit that having an unsigned value there is intended.

Not a C++ language lawyer, though, so I hope that's the right approach…

