### PR TITLE
BACKENDS: Make StdioStream use a 64-bit fseeko/ftello on more platforms

### DIFF
--- a/backends/fs/posix/posix-iostream.cpp
+++ b/backends/fs/posix/posix-iostream.cpp
@@ -32,7 +32,11 @@
 
 
 PosixIoStream *PosixIoStream::makeFromPath(const Common::String &path, bool writeMode) {
+#if defined(HAS_FSEEKO64)
+	FILE *handle = fopen64(path.c_str(), writeMode ? "wb" : "rb");
+#else
 	FILE *handle = fopen(path.c_str(), writeMode ? "wb" : "rb");
+#endif
 
 	if (handle)
 		return new PosixIoStream(handle);

--- a/backends/fs/stdiostream.cpp
+++ b/backends/fs/stdiostream.cpp
@@ -56,8 +56,10 @@ bool StdioStream::eos() const {
 int64 StdioStream::pos() const {
 #if defined(WIN32)
 	return _ftelli64((FILE *)_handle);
-#elif defined(__linux__) || defined(__APPLE__)
+#elif defined(HAS_FSEEKO_OFFT_64)
 	return ftello((FILE *)_handle);
+#elif defined(HAS_FSEEKO64)
+	return ftello64((FILE *)_handle);
 #else
 	return ftell((FILE *)_handle);
 #endif
@@ -69,11 +71,16 @@ int64 StdioStream::size() const {
 	_fseeki64((FILE *)_handle, 0, SEEK_END);
 	int64 length = _ftelli64((FILE *)_handle);
 	_fseeki64((FILE *)_handle, oldPos, SEEK_SET);
-#elif defined(__linux__) || defined(__APPLE__)
+#elif defined(HAS_FSEEKO_OFFT_64)
 	int64 oldPos = ftello((FILE *)_handle);
 	fseeko((FILE *)_handle, 0, SEEK_END);
 	int64 length = ftello((FILE *)_handle);
 	fseeko((FILE *)_handle, oldPos, SEEK_SET);
+#elif defined(HAS_FSEEKO64)
+	int64 oldPos = ftello64((FILE *)_handle);
+	fseeko64((FILE *)_handle, 0, SEEK_END);
+	int64 length = ftello64((FILE *)_handle);
+	fseeko64((FILE *)_handle, oldPos, SEEK_SET);
 #else
 	int64 oldPos = ftell((FILE *)_handle);
 	fseek((FILE *)_handle, 0, SEEK_END);
@@ -87,8 +94,10 @@ int64 StdioStream::size() const {
 bool StdioStream::seek(int64 offs, int whence) {
 #if defined(WIN32)
 	return _fseeki64((FILE *)_handle, offs, whence) == 0;
-#elif defined(__linux__) || defined(__APPLE__)
+#elif defined(HAS_FSEEKO_OFFT_64)
 	return fseeko((FILE *)_handle, offs, whence) == 0;
+#elif defined(HAS_FSEEKO64)
+	return fseeko64((FILE *)_handle, offs, whence) == 0;
 #else
 	return fseek((FILE *)_handle, offs, whence) == 0;
 #endif
@@ -119,6 +128,8 @@ StdioStream *StdioStream::makeFromPath(const Common::String &path, bool writeMod
 	wchar_t *wPath = Win32::stringToTchar(path);
 	FILE *handle = _wfopen(wPath, writeMode ? L"wb" : L"rb");
 	free(wPath);
+#elif defined(HAS_FSEEKO64)
+	FILE *handle = fopen64(path.c_str(), writeMode ? "wb" : "rb");
 #else
 	FILE *handle = fopen(path.c_str(), writeMode ? "wb" : "rb");
 #endif

--- a/configure
+++ b/configure
@@ -4090,7 +4090,7 @@ EOF
 			# Otherwise, when not cross-compiling, try with LFS_CFLAGS
 			if test -z "$_host"; then
 				TMPFLAGS=`getconf LFS_CFLAGS 2>/dev/null`
-				if ! test -z "$TMPFLAGS" ; then
+				if test $? -eq 0 && test ! -z "$TMPFLAGS" && test "$TMPFLAGS" != undefined ; then
 					cc_check_no_clean $TMPFLAGS && _has_fseeko_offt_64=yes
 					if test "$_has_fseeko_offt_64" = yes ; then
 						echo "yes (adding $TMPFLAGS)"

--- a/configure
+++ b/configure
@@ -256,6 +256,8 @@ _detection_features_full=yes
 # be modified otherwise. Consider them read-only.
 _posix=no
 _has_posix_spawn=no
+_has_fseeko_offt_64=no
+_has_fseeko64=no
 _endian=unknown
 _need_memalign=yes
 _have_x86=no
@@ -2983,11 +2985,6 @@ EOF
 		_ranlib=:
 		;;
 	linux* | uclinux*)
-		# When not cross-compiling, enable large file support, but don't
-		# care if getconf doesn't exist or doesn't recognize LFS_CFLAGS.
-		if test -z "$_host"; then
-			append_var CXXFLAGS "`getconf LFS_CFLAGS 2>/dev/null`"
-		fi
 		;;
 	mingw*)
 		append_var DEFINES "-DWIN32"
@@ -4060,6 +4057,84 @@ EOF
 		append_var DEFINES "-DHAS_POSIX_SPAWN"
 	fi
 fi
+
+#
+# Check for 64-bit file offset compatibility
+#
+# This is currently only used by StdioStream. If nothing is found,
+# you'll be limited to <2GB files, which still covers the vast majority
+# of supported games.
+#
+case $_host_os in
+	mingw*)
+		# StdioStream just uses _ftelli64
+		;;
+	*)
+		echo_n "Checking if fseeko with 64-bit off_t is supported... "
+		cat > $TMPC << EOF
+#include <stdio.h>
+#include <sys/types.h> /* off_t on legacy systems */
+int main() {
+	static int test_array[1 - 2 * !(sizeof(off_t) >= 8)];
+	fseeko(stdin, 0, SEEK_SET);
+	test_array[0] = 0;
+	return 0;
+}
+EOF
+		cc_check_no_clean && _has_fseeko_offt_64=yes
+		# Good, there's fseeko with a 64-bit off_t by default
+		if test "$_has_fseeko_offt_64" = yes ; then
+			echo yes
+			append_var DEFINES "-DHAS_FSEEKO_OFFT_64"
+		else
+			# Otherwise, when not cross-compiling, try with LFS_CFLAGS
+			if test -z "$_host"; then
+				TMPFLAGS=`getconf LFS_CFLAGS 2>/dev/null`
+				if ! test -z "$TMPFLAGS" ; then
+					cc_check_no_clean $TMPFLAGS && _has_fseeko_offt_64=yes
+					if test "$_has_fseeko_offt_64" = yes ; then
+						echo "yes (adding $TMPFLAGS)"
+						append_var DEFINES "-DHAS_FSEEKO_OFFT_64"
+						append_var CXXFLAGS "$TMPFLAGS"
+					fi
+				fi
+			fi
+
+			# Otherwise, try the usual magical suspects
+			if test "$_has_fseeko_offt_64" = no ; then
+				# note: -D__LARGE64_FILES is another option, but it may be broken on
+				# some platforms, so add it to your platform defines instead, if it
+				# requires it and you've checked that the result works.
+				for largeflag in "-D_FILE_OFFSET_BITS=64" "-D_LARGE_FILES" "-D_LARGEFILE_SOURCE" ; do
+					cc_check_no_clean $largeflag && _has_fseeko_offt_64=yes
+					if test "$_has_fseeko_offt_64" = yes ; then
+						echo "yes (adding $largeflag)"
+						append_var DEFINES "-DHAS_FSEEKO_OFFT_64"
+						append_var CXXFLAGS "$largeflag"
+						break
+					fi
+				done
+			fi
+
+			# Otherwise, fseeko64 is your last chance
+			if test "$_has_fseeko_offt_64" = no ; then
+				echo no
+				echo_n "Checking if fseeko64 is supported... "
+				cat > $TMPC << EOF
+#include <stdio.h>
+int main() { fseeko64(stdin, 0, SEEK_SET); return 0; }
+EOF
+				cc_check_no_clean -D_LARGEFILE64_SOURCE && _has_fseeko64=yes
+				echo $_has_fseeko64
+				if test "$_has_fseeko64" = yes ; then
+					append_var DEFINES "-DHAS_FSEEKO64"
+					append_var CXXFLAGS "-D_LARGEFILE64_SOURCE"
+				fi
+			fi
+		fi
+		cc_check_clean
+		;;
+esac
 
 #
 # Check whether to enable a verbose build

--- a/devtools/create_project/cmake.cpp
+++ b/devtools/create_project/cmake.cpp
@@ -341,6 +341,9 @@ void CMakeProvider::writeDefines(const BuildSetup &setup, std::ofstream &output)
 	output << "\tadd_definitions(-DWIN32)\n";
 	output << "else()\n";
 	output << "\tadd_definitions(-DPOSIX)\n";
+	output << "\t# Hope for the best regarding fseeko and 64-bit off_t\n";
+	output << "\tadd_definitions(-D_FILE_OFFSET_BITS=64)\n";
+	output << "\tadd_definitions(-DHAS_FSEEKO_OFFT_64)\n";
 	output << "endif()\n";
 
 	output << "add_definitions(-DSDL_BACKEND)\n";

--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -1343,6 +1343,7 @@ void XcodeProvider::setupDefines(const BuildSetup &setup) {
 	REMOVE_DEFINE(_defines, "SDL_BACKEND");
 	ADD_DEFINE(_defines, "CONFIG_H");
 	ADD_DEFINE(_defines, "UNIX");
+	ADD_DEFINE(_defines, "HAS_FSEEKO_OFFT_64");
 	ADD_DEFINE(_defines, "SCUMMVM");
 }
 


### PR DESCRIPTION
This tries to be a next step in the 64-bit file offset journey started by PR #3133.

## Context

StdioStream currently does this on non-Windows systems (that one already uses `_ftelli64()`): 

```c++
	// ...
#elif defined(__linux__) || defined(__APPLE__)
	int64 oldPos = ftello((FILE *)_handle);
	fseeko((FILE *)_handle, 0, SEEK_END);
	int64 length = ftello((FILE *)_handle);
	fseeko((FILE *)_handle, oldPos, SEEK_SET);
	// ...
```

but several platforms are missing (e.g. BSDs), and having `fseeko()`/`ftello()` doesn't mean that its `off_t` is always 64-bit capable, unfortunately :(

## Approach

So the following PR tries to improve on this with some new `configure` checks. I'm mostly following the build logic used in most GNU tools:

* test for fseeko() and check whether its `off_t` is >= 8 bytes
* (if fseeko() is there, just infer that ftello() will be there, too)
* if that doesn't work, and we're not cross-compiling, retry with `getconf LFS_CFLAGS` (recommended on Solaris for example)
* if that doesn't work, try with `-D_FILE_OFFSET_BITS=64` and similar magical incantations
* if that doesn't work, look for `fseeko64` (it looks like AmigaOS4 has this, for example)
* if that doesn't work, well, you're probably stuck with <2GB files, but that still covers the vast majority of games supported by ScummVM, for now. And for some very old and constrained platforms, I'm not sure it's really meaningful to try loading very big resources anyway.

And then, I'm adjusting StdioStream for those changes. `configure` will also print its findings, which may help having a quick glance at ports having theoretical 64-bit file offset support.

(For `create_project`, I'm just using a simpler hardcoded approach, since that tool is only used for a handful of "more reasonable" platforms. If you want the most portable environment, you already need to use `configure` anyway.)

I've tested the build part on several platforms, thanks to `devtools/docker.sh`. I'll put a summary table below.

## Considerations

⚠️ **HOWEVER**, from some experience with several systems, unlocking 64-bit file offsets may actually cause issues on some platforms where it's not the default and where upstream never really tested it. We may need to exclude them (by explicitly opting out of 64-bit fseeko for them), then, but I think we won't be able to find them until doing some regression tests there (such as making sure that loading a "small" game still works and doesn't become much slower, at least). We may also need to watch out the buildbot…

Some platforms also look very particular (I'm thinking of the RISC OS port for example) so I hope that turning this on there won't cause any major issue.

Since we're not close to the deadline of a next major release (AFAIK), I think we probably have the time to properly test this and/or wait for people to report any issue. But if you think that a different approach should be taken, there's no problem of course.