### PR TITLE
TINSEL: Fix DW2 subtitle color on big-endian systems

### DIFF
--- a/engines/tinsel/actors.cpp
+++ b/engines/tinsel/actors.cpp
@@ -1036,9 +1036,9 @@ void Actor::SetActorRGB(int ano, COLORREF color) {
 	assert(ano >= 0 && ano <= _numActors);
 
 	if (ano)
-		_actorInfo[ano - 1].textColor = TO_32(color);
+		_actorInfo[ano - 1].textColor = color;
 	else
-		_defaultColor = TO_32(color);
+		_defaultColor = color;
 }
 
 /**


### PR DESCRIPTION
On big-endian PowerPC, several Discworld 2 (DOS) characters have very hard to read black subtitles:

(when the narrator reacts after looking at the accelerator for the first time in the High Energy Facility)

![scummvm-dw2-gb-00000](https://user-images.githubusercontent.com/9024526/204151134-bfafcadd-0d7f-4a10-b705-0b51476b7c8e.png)

(when talking to the Suffrajester in the cemetery)

![scummvm-dw2-gb-00001](https://user-images.githubusercontent.com/9024526/204151136-c13c8f7a-cc58-462b-99c0-2b86283ae212.png)

Those should be red, instead.

It appears that the color given to `SetActorRGB()` is already in native endianness, so there's no need to call `TO_32()` which would do a double conversion on big-endian hosts (but act as a no-op on little-endian hosts).

Looking at `tinlib.cpp:CallLibraryRoutine()` comments, `SetActorRGB()` is apparently only used by DW2 and Discworld Noir. But the `TO_32()` macro was apparently added there in commit b05fa7f20414d6a7571a9ba52f542e527f598c62 for DW1 Mac — maybe just as a small oversight?

I don't have Discworld Noir, though, and I don't have any PS1/Saturn DW1 or DW2 release. So I can't check them for any possible regression.

So, submitting this as a PR so that people with more Tinsel expertise can confirm if this is OK. Thanks!