### PR TITLE
DIRECTOR: Bunch of stuff

### DIFF
--- a/engines/director/detection_paths.h
+++ b/engines/director/detection_paths.h
@@ -71,7 +71,6 @@ const char *directoryGlobs[] = {
 	"xn--Musejagd mit Ton-vnb",		// GGMD German
 	"music",
 	"solos",
-	"sounds",
 	"duthelp",
 	"dutvideo",
 	"endsound",

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -73,7 +73,6 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "barbpauper",			"Barbie as the Princess and the Pauper" },
 	{ "barbrapunzel",		"Barbie as Rapunzel: A Creative Adventure" },
 	{ "barbswanlake",		"Barbie of Swan Lake: The Enchanted Forest" },
-	{ "basilbaker",			"Venice Under Glass: A Basil Baker Mystery Adventure" },
 	{ "bbbighelpers",		"Little Bears Make Big Helpers: Life's Little Lessons with the Berenstain Bears" },
 	{ "bearfamily",			"A Bear Family Adventure" },
 	{ "beautyorbeast",		"Beauty or the Beast" },
@@ -432,9 +431,11 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "vcop",				"Virtual Cop" },
 	{ "vcop1",				"Virtual Cop: Episode One: Good Cop / Bad Cop" },
 	{ "vcop2",				"Virtual Cop: Episode Two: The Angel Returns" },
-	{ "veniceglass",		"Venice Under Glass" },
+	{ "veniceglass",		"Venice Under Glass: A Basil Baker Mystery Adventure" },
+	{ "videocasino",		"Video Casino" },
 	{ "vjg",				"Vegas Jackpot Gold" },
 	{ "vnc",				"Virtual Nightclub" },
+	{ "voodoolounge",		"The Rolling Stones: Voodoo Lounge" },
 	{ "vp2",				"Virtual Physics: The Eggs of Time" },
 	{ "vvcyber",			"Victor Vector & Yondo: The Cyberplasm Formula" },
 	{ "vvdinosaur",			"Victor Vector & Yondo: The Last Dinosaur Egg" },
@@ -534,7 +535,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "heuther",			"Understanding Pathophysiology, 3rd Edition" },
 	{ "hikaruhana",			"Shining Flower: Hikaruhana" },					// 光る花
 	{ "hirezaudio",			"Hi Rez Audio" },
-	{ "hunchback",			"The Secret of the Hunchback" },
+	{ "hunchback",			"Interactive Storybook: The Secret of the Hunchback" },
 	{ "ibmcdextra",			"Sony Music CD Extra Sampler" },  // AKA IBM CD-Extra (CPDP 000350)
 	{ "iptr",				"I Photograph to Remember" },
 	{ "isscommerce",		"International Space Station: Space Commercialization" },
@@ -554,15 +555,14 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "makers",				"Makers of the 20th Century" },
 	{ "mediabook",			"The MediaBook CD for Director" },
 	{ "moag",				"The Museum of Anything Goes" },
-	{ "ms500nations",		"Microsoft 500 Nations" },
 	{ "msa2001",			"Middle School Advantage 2001" },
+	{ "ms500nations",		"Microsoft 500 Nations" },
 	{ "msdinosaurs",		"Microsoft Dinosaurs" },
 	{ "msoceans",			"Microsoft Oceans" },
 	{ "mswine",				"Microsoft Wine Guide" },
 	{ "mysteriousegypt",	"Mysterious Egypt" }, // aka Voyage in Egypt
 	{ "newslinks",			"ABC NewsLinks" },
 	{ "nia4",				"News in Action 4" },
-	{ "nightsky",			"Night Sky" },
 	{ "nixon",				"Nixon: Watergate" },
 	{ "nmm",				"Nine Month Miracle" },
 	{ "nobel100",			"The Nobel Prize: 100 Years of Creativity and Innovation" },
@@ -570,6 +570,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "paris",				"Paris: History and Splendour" },
 	{ "parisvt",			"Virtual Tourism Paris" },
 	{ "parliament",			"People & Parliament: A Stranger's Guide to Westminster" },
+	{ "paperplanes",		"WordPerfect Main Street presents Paper Planes" },
 	{ "picasso",			"Picasso: the man, his works, the legend" },
 	{ "pixar",				"Pixar Projector" },
 	{ "planetstrass",		"Pl@net" },
@@ -607,6 +608,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "trekshipaddon",		"Star Trek: Starship Creator Add-on Pack"},
 	{ "trektech",			"Star Trek: The Next Generation Interactive Technical Manual" },
 	{ "truthsfictions",		"Truths & Fictions: A Journey from Documentary to Digital Photography" },
+	{ "ugtmk",				"The Ultimate Guide to Mortal Kombat" },
 	{ "universe",			"Invisible Universe" },
 	{ "unwrap",				"Unwrap the Magic: Holiday 2000 Interactive CD-ROM" }, // J.C.Penney
 	{ "ushistory",			"The History of the United States for Young People" },
@@ -626,6 +628,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "worldnet",			"AT&T WorldNet Service E-Guide" },
 	{ "wwanimals",			"Wide World of Animals" },
 	{ "xfua",				"The X-Files Unrestricted Access" },
+	{ "xmen-burgerking",	"X-Men Evolution Burger King mini CD" },
 
 	// Productivity software
 	{ "expbooktoolkit2",	"Expanded Book Toolkit II" },
@@ -639,6 +642,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "antsafire",			"Ants Afire!" },
 	{ "aolstarwars",		"Star Wars: Episode III: Game, Videos & More!" },
 	{ "arad",				"Animaniacs River Adventure" },
+	{ "astroblast",			"AstroBlast" },
 	{ "belcher",			"The Belcher" },
 	{ "bigsound",			"BigSound VW Player" },
 	{ "bigtimemovie",		"Big Time Movie Studios" },
@@ -649,37 +653,54 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "childishgambino",	"Capturing Donald Glover's Motion" },
 	{ "chuckaduck",			"Chuck-A-Duck" },
 	{ "colormind",			"ColorMind" },
+	{ "courtneyfilter",		"The Courtney Filter" },
 	{ "crybaby",			"Crying, Screaming Baby" },
+	{ "deedeedanger",		"Dexter's Laboratory: Dee Dee Duplication Danger" },
 	{ "dfireworks",			"The Digital Fireworks Stand" },
+	{ "digihbd",			"Digital Happy Birthday Card" },
 	{ "dreidel",			"DreidelLand: An Electronic Hanukah Treat" },
 	{ "emigre",				"Emigre Signs of Type: Big Cheese" },
+	{ "flingshot",			"The Rugrats Movie: Baby Food Flingshot" },
 	{ "fortuneteller",		"The Fortune Teller" },
+	{ "headhunter",			"HeadHunter" },
+	{ "hurlman",			"Hurlman" },
+	{ "illusions",			"Illusions" },
 	{ "imision369",			"ImIsion 369" },
 	{ "kfk",				"Kung Fu Kim" },
 	{ "letterrally",		"Letter Rally" },
 	{ "limit0",				"Limit 0" },
+	{ "lovinghenry",		"Loving Henry" },
 	{ "makeamug",			"Make-A-Mug" },
 	{ "makingmusic",		"Morton Subotnick's Making Music" },
+	{ "marathonsecrets",	"Marathon Secrets" },
 	{ "mathtest",			"Math Test" },
 	{ "missileattack",		"Missile Attack" },
+	{ "myfavburps",			"My Favorite Burps" },
 	{ "namegame",			"Name that Game" },
+	{ "netmaze",			"Netmaze" },
+	{ "nickmemory",			"Nicktoons Memory Challenge" },
 	{ "njdevils2001",		"2001 New Jersey Devils Interactive CD ROM" },
 	{ "nomis",				"Nomis" },
 	{ "nyknicks2000",		"NY Knicks 2000" },
 	{ "nykshuffle",			"NYK Shuffle" },
 	{ "nyyankeesyb",		"New York Yankees Interactive Yearbook" },
 	{ "pfarrypuzzle",		"Paul Farry Puzzle" },
+	{ "popapenguin",		"Pop-a-Penguin" },
 	{ "prangers1",			"PowerRangers Part 1" },
 	{ "prangers2",			"PowerRangers Part 2" },
 	{ "psych",				"Psych: An Interactive Stress Buster!" },
 	{ "revdemo",			"Macromedia Director 4.0 Revolution" },  // from CD-ROM Now issue #7 '94
+	{ "rooked",				"Rooked" },
 	{ "saspurs2001",		"San Antonio Spurs 2001 Broadcast Screensaver" }, // Not a screensaver
 	{ "saspurs2005",		"San Antonio Spurs Internet Hot-links" }, // Not a screensaver
 	{ "scanmon",			"ScanMon" },
 	{ "seinfeldondvd",		"Seinfeld on DVD" },
 	{ "sensei",				"Sensei" },
 	{ "simpsontrivia",		"The Simpsons Trivia" },
+	{ "smile",				"SMILE! The Splattering" },
 	{ "sorgato",			"Sylvain Sorgato's Drawings in variable color" },
+	{ "spitwad",			"High School High Spitwad Game" },
+	{ "springhead",			"Springhead" },
 	{ "ssmorphclock",		"Morph Clock Screensaver" },
 	{ "summertime",			"Summertime" },
 	{ "thematrix",			"The Matrix: Cinemas Everywhere June 11" },
@@ -695,6 +716,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "bobmambo5",			"Bob the Builder: Mambo No. 5" },
 	{ "chaquico1000",		"Craig Chaquico: A Thousand Pictures" },
 	{ "concentration",		"Solitudes: Natural Concentration" },
+	{ "doorswindows",		"The Cranberries: Doors and Windows" },
 	{ "freakshowost",		"The Residents: Freak Show: Multimedia Bonus Track" },
 	{ "gingerbreadman",		"The Residents: Gingerbread Man" },
 	{ "girlsaloudbox",		"Girls Aloud: The Singles Box Set" },
@@ -817,6 +839,9 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "zwergnase",			"Zwerg Nase: Ein interaktives Märchen" },
 
 	// Italian titles
+	{ "fuzzyfloppy2",		"Fuzzy e Floppy: Il Furto Della Rotonda" },
+	{ "fuzzyfloppy3",		"Fuzzy e Floppy: Il Raggio Magico" },
+	{ "tesorovenezia",		"Il tesoro di Venezia" },
 	{ "ironmask",			"The Iron Mask" },
 	{ "lunes",				"I Lunes e la sfera di Lasifer" },					// Lunes & the sphere of Lasifer
 	{ "magicanti",			"I Magicanti e i 3 elementi" },						// The Magicanti & the 3 elements
@@ -888,7 +913,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "henachoco11",		"スロプロウエスタン" }, // Slowpro Western
 	{ "henachococd",		"ギャラクレヤン'75 オレニモインゼイクレヤン" }, // Galakureyan'75 Inzeikureyan
 	{ "henachocoexpo",		"イタチョコの野望" }, // Itachoco's Ambition
-	{ "hidoiyo",			"ひどいよ / ひどいよくん" },
+	{ "hidoiyokun",			"ひどいよくん" }, // Hidoiyo-kun
 	{ "himejijo",			"A.MAZING姫路城" },									// A.MAZING Himejijo (the HIMEJI Castle)
 	{ "horrortour2",		"Zeddas: Horror Tour 2" },
 	{ "horrortour3",		"ラビラーント" },									// Labyrinthe
@@ -917,7 +942,6 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "mamauta1",			"ママうたおう! 第一巻みんなともだち" }, // Mama Utaou: Daiikkan Minna Tomodachi
 	{ "maria",				"MA-RI-A 人形館の呪い" },
 	{ "marinefantasy",		"大方洋二の海中写真館 Marine Fantasy" },
-	{ "mazebrew",			"MazeBrew" },
 	{ "mecadrill",			"Mecadrill" },
 	{ "mipeterwolf",		"～Music Island Vol.1～　\"ピーターと狼\"" },
 	{ "missihb",			"MISS Interactive Hard Boiled" },
@@ -989,7 +1013,6 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "ukiuki2",			"ウキウキ釣り天国2 ～波止の五目釣り～" },		// Ukiuki Tsuri Tengoku 2: Namitome no Gomokuzuri
 	{ "ukiuki3",			"ウキウキ釣り天国3 ～人魚島のボート釣り～" },		// Ukiuki Tsuri Tengoku 3: Ningyo-tou no Boutozuri
 	{ "ukiukiitsudemo",		"ウキウキ釣り天国 ～いつでもどこでも海釣り三昧～" },		// Ukiuki Tsuri Tengoku: Itsudemo Dokodemo Umitsuri Zanmai
-
 	{ "ukiukistamp",		"うきうきスタンプ" },
 	{ "ukyo1",				"うきょー1" },
 	{ "ursaminorblue",		"銀河の魚 URSA minor BLUE" },				// Galaxy Fish: Ursa Minor Blue
@@ -1110,6 +1133,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "sculpt4d",			"Sculpt 4D" },
 	{ "shinshofukei",		"心象風景" }, // Psychological Landscape
 	{ "spawncollection",	"Spawn Figure Collection for Windows 95" },
+	{ "srdsunrise",			"スーパーロボット伝説 東北新社・サンライズロボット編" },  // Super Robot Densetsu: Touhokushinsha Sunrise Robot-hen
 	{ "ssheidi1",			"Heidi スクリーンセーバー 1" },
 	{ "ssheidi2",			"Heidi スクリーンセーバー 2" },
 	{ "sskero",				"ケロ Screen Saver" },
@@ -1174,7 +1198,6 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "strata",				"Strata Studio Pro" },
 	{ "toeic",				"PowerTOEIC" },
 	{ "toonet11",			"TooNet11" },
-	{ "trans2",				"Trans'2　～僕とあたしと恋人と～" }, // Trans' 2: Boku to Atashi to Koibito to
 	{ "transland",			"トランスランド" },
 	{ "wonderompm",			"アルダスページメーカー4.5J速習用CD-ROM" },		// CD-ROM for Quick Study of Aldus PageMaker 4.5J
 	{ "wonderomcw",			"WONDEROM クラリスワークス" },					// WONDEROM ClarisWorks ver.2
@@ -1260,6 +1283,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "freeallangels",		"Ash: Free All Angels Video Mixer" },
 	{ "klingonlab",			"Klingon Language Lab" },
 	{ "lbfamfun",			"Little Bear Family Fun" },
+	{ "mousepractice",		"Mouse Practice" },	// from At Ease, disk 2
 	{ "picarddossier",		"Mini-Omnipedia: Picard Dossier" },
 	{ "poliq",				"Political IQ Test" },
 	{ "pqmakingof",			"The Making of Police Quest" },
@@ -1283,6 +1307,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "famdoc3",			"The Family Doctor, 3rd Edition" },
 	{ "macworldexpo92",		"Macworld Expo CD Boston 1992" },
 	{ "manhole",			"The Manhole" },
+	{ "mazebrew",			"MazeBrew" },
 	{ "mazewars",			"Maze Wars+" },
 	{ "mmmozart",			"Multimedia Mozart: The Dissonant Quartet" },
 	{ "mmschubert",			"Multimedia Schubert: The \"Trout\" Quintet" },
@@ -1300,7 +1325,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "insidemacgames",		"Inside Mac Games" },
 	{ "interactivemagic",   "MacUser Mac Interactive Magic" },
 	{ "iwave",				"Interactive Wave" },
-	{ "maccubed7",			"MacCubed Disc 7: Internet & Utilities" },
+	{ "maccubed",			"MacCubed³" },
 	{ "macsca",				"Mac S.C.A. Magazine" },
 	{ "macweekvideo",		"MacWEEK Guide to Desktop Video" },
 	{ "mieuxmieux",			"Le CD-ROM Mac Mieux-Mieux" },
@@ -1317,6 +1342,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "applestore",			"Apple Company Store" },
 	{ "aptesampler",		"APTE Product Sampler" },
 	{ "arcmedia",			"Arc Media Demos" },
+	{ "aromeinteractive",	"Arome Interactive Sampler" },
 	{ "bestservice",		"Best Service Soundware Company Presentation" },  // from CD-ROM Now issue #7 '94
 	{ "blaster",			"Blaster Series Demo" },
 	{ "bpmc",				"Byron Preiss Multimedia Catalog" },
@@ -1325,6 +1351,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "coreltour",			"Corel Product Tour" },
 	{ "davidsonpp",			"Davidson Product Previews" },
 	{ "davidsonps",			"Davidson Product Sampler" },
+	{ "dewarswl",			"DeWar's \"White Label\"" },
 	{ "disneyint",			"Disney Interactive presents Learning & Creativity Sampler Volume I" },
 	{ "disneylearning",		"Disney Interactive Learning Sampler" },
 	{ "dkmm2",				"Dorling Kindersley Multimedia Sampler Disc 2" },
@@ -1337,7 +1364,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "gusbuds",			"Gus and the CyberBuds Learning Adventure Series" },
 	{ "headbone",			"Headbone CD-ROM Sampler" },
 	{ "hoffman",			"H+a Collection" },
-	{ "housejam",			"HouseJam - An excerpt from Meet MediaBand" },  // from CD-ROM Now issue #7 '94
+	{ "housejam",			"HouseJam - An excerpt from Meet MediaBand" },
 	{ "ilearn",				"iLearn" },
 	{ "imagineers",			"The Imagineers" },
 	{ "imaginopolis",		"Microsoft Imaginopolis" },
@@ -1352,11 +1379,13 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "mcdonaldland",		"Mission to McDonaldland" },    // Promo game distributed by McDonald's fastfood chain (AU/NZ only)
 	{ "msgfromapple",		"Message from Apple" },
 	{ "newton",				"World of Newton" },
+	{ "optimumrsrc",		"Optimum Resource Sampler" },
 	{ "origin",				"Origin Systems Product Catalog" },
 	{ "playskool",			"Playskool Software Experience CD-ROM Sampler" },
 	{ "poohlearn",			"Disney Learning Winnie the Pooh Demos" },
 	{ "rh",					"Rescue Heroes Demo" },
 	{ "sfk",				"Science for Kids Product Demos" },
+	{ "sonywalkman",		"Sony Walkman PRD-155SB / PRD-150" },
 	{ "tlc",				"The Learning Company Sampler" },
 	{ "ubt",				"Under the Big Top" },
 	{ "vygrpresents",		"Voyager Presents" },
@@ -1373,6 +1402,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "baseballhits",		"Baseball's Greatest Hits"},
 	{ "bcsinkfloat",		"Blue's Clues: Sink and Float" },
 	{ "blockbuster2",		"Blockbuster Guide to Movies & Videos, 2nd Edition" },
+	{ "blownaway",			"Blown Away" },
 	{ "bobteam",			"Bob the Builder: Teamwork" },
 	{ "bookshelf94",		"Microsoft Bookshelf '94" },
 	{ "bookshelf95",		"Microsoft Bookshelf '95" },
@@ -1387,11 +1417,14 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "cpu",				"Connectix PowerBook Utilities" },
 	{ "cricketdraw",		"CA Cricket Draw III" },
 	{ "d",					"D" },
+	{ "defendinghuman",		"Donald A. Norman: Defending Human Attributes in the Age of the Machine" },
 	{ "dinosafari",			"Dinosaur Safari" },
 	{ "dotsafe",			"Dotsafe" },
 	{ "earthwormjim",		"Earthworm Jim" },
+	{ "ephemeralfilms",		"Ephemeral Films: 1931-1961" },
 	{ "exos",				"Exos PowerStick" },
 	{ "explorapedia",		"Microsoft Explorapedia" },
+	{ "eyewitnessscience",	"Eyewitness Encyclopedia of Science" },
 	{ "famalbum",			"Family Album Creator" },
 	{ "famdoc4",			"The Family Doctor, 4th Edition" },
 	{ "freehand",			"Aldus FreeHand 2.0" },
@@ -1403,12 +1436,14 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "ideacomm",			"IDEAcomm Mac" },
 	{ "iliad",				"Iliad" },
 	{ "illustrator",		"Adobe Illustrator" },
+	{ "it1d",				"In the First Degree" },
 	{ "landdesigner",		"Sierra Land Designer" },
 	{ "lbt8",				"The Land Before Time: The Big Freeze" },
 	{ "leopardspots",		"How the Leopard Got His Spots" },
 	{ "lion",				"Lion" },
 	{ "lotus123",			"Lotus 1-2-3" },
 	{ "macbasics",			"Macintosh Basics" },
+	{ "macbeth",			"Macbeth" },
 	{ "macos8",				"Mac OS 8" },
 	{ "macportable",		"Your Apple Tour of the Macintosh Portable" },
 	{ "mathblasterjr",		"Math Blaster Jr." },
@@ -1425,9 +1460,8 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "msbaseball",			"Microsoft Complete Baseball" },
 	{ "msbasketball",		"Microsoft Complete Basketball" },
 	{ "msbob",				"Microsoft Bob" },
-	{ "msbhumanbody",		"Scholastic's The Magic School Bus Explores the Human Body" },
-	{ "msbsolarsystem",		"Scholastic's The Magic School Bus Explores the Solar System" },
 	{ "mscomposers",		"Microsoft Illustrated Interactive Composer Series" },
+	{ "msdangerous",		"Microsoft Dangerous Creatures" },
 	{ "msdogs",				"Microsoft Dogs" },
 	{ "msexcel",			"Microsoft Excel" },
 	{ "msflight",			"Microsoft Flight Simulator" },
@@ -1446,15 +1480,21 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "mspublishd",			"Microsoft Publisher Design Packs" },
 	{ "msschedule",			"Microsoft Schedule+" },
 	{ "mssndbits",			"Microsoft SoundBits" },
+	{ "msspaceflight",		"Microsoft Space Simulator & Microsoft Flight Simulator" },
 	{ "msword",				"Microsoft Word" },
 	{ "msworks",			"Microsoft Works" },
-	{ "muppets",			"Muppet Treasure Island" },
+	{ "msbhumanbody",		"Scholastic's The Magic School Bus Explores the Human Body" },
+	{ "msbsolarsystem",		"Scholastic's The Magic School Bus Explores the Solar System" },
+	{ "mti",				"Muppet Treasure Island" },
 	{ "musiccentral96",		"Microsoft Music Central 96" },
 	{ "musicpublisher",		"Graphic Notes Music Publisher" },
 	{ "netmarket",			"CUC netMarket Demo" },
+	{ "nightsky",			"Night Sky Interactive" },
 	{ "ofoto",				"Light Source Ofoto" },
+	{ "onevolution",		"Stephen Jay Gould: On Evolution" },
 	{ "orly",				"Orly's Draw-A-Story" },
 	{ "pagemaker",			"Aldus PageMaker" },
+	{ "panicpark",			"Panic in the Park" },
 	{ "pitfall",			"Pitfall: The Mayan Adventure" },
 	{ "powerchess",			"Power Chess" },
 	{ "princeint",			"Prince Interactive" },
@@ -1468,8 +1508,11 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "shanghai",			"Shanghai: Great Moments" },
 	{ "smashsounds1",		"Smash Sounds Volume 1" },
 	{ "spycraft",			"Spycraft: The Great Game" },
+	{ "statusmac",			"STATUS*Mac" },
 	{ "system7smash",		"System 7 is a SMASH!" },
+	{ "texturescape",		"Specular TextureScape" },
 	{ "thetowerxmas",		"TOWER/CD ~Christmas Disc~" },
+	{ "thisisspinaltap",	"This Is Spinal Tap" },
 	{ "timelapse",			"Timelapse" },
 	{ "trekfinalunity",		"Star Trek: The Next Generation - \"A Final Unity\"" },
 	{ "ultrobot",			"Isaac Asimov's The Ultimate Robot" },
@@ -1485,6 +1528,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "zoombini",			"Logical Journey of the Zoombinis" },
 
 	// Screen Savers
+	{ "aslss",				"ASL ScreenSaver" },
 	{ "barbssbubbles",		"Barbie Screen Styler: Bubbles" },
 	{ "barbsskisses",		"Barbie Screen Styler: Kisses" },
 	{ "barbssshoes",		"Barbie Screen Styler: Shoes" },
@@ -1522,13 +1566,14 @@ static const PlainGameDescriptor directorGames[] = {
 	// Press kits with Director content
 	{ "bvi1997",			"Buena Vista International 1997 Promotional Interactive CD-ROM" },
 	{ "bluesbros2000",		"Blues Brothers 2000 Full Promotion" },
-	{ "easports2000",		"EA Sports_2000 (E3 1999)" },
+	{ "easports2000",		"EA Sports 2000 (E3 1999)" },
 	{ "hoaddams2",			"Hollywood Online: Addams Family Values" },
 	{ "hoangus",			"Hollywood Online: Angus" },
 	{ "hodolores",			"Hollywood Online: Dolores Claiborne" },
 	{ "horobroy",			"Hollywood Online: Rob Roy: Legend of the Mist" },
 	{ "hostargate",			"Hollywood Online: Stargate" },
 	{ "hothenet",			"Hollywood Online: The Net" },
+	{ "hotrekgens",			"Hollywood Online: Star Trek Generations"},
 	{ "leepipes",			"Lee Pipes Press Kit" },
 	{ "mulanpresskit",		"Mulan Multimedia Press Kit" },
 	{ "stalker",			"S.T.A.L.K.E.R.: Shadow of Chernobyl" },
@@ -1536,50 +1581,10 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "vug2005",			"Vivendi Universal Games 2005 E3 DPK" },
 	{ "westwood",			"Westwood Studios Digital Press Kit 2000" },
 
-	// Not supported
-	{ "busty3",				"Busty Babes Volume III" },
-	{ "busty4",				"Busty Babes Volume IV" },
-	{ "csa",				"Cyber Sex Angel" },
-	{ "cyberphoto",			"CyberPhotographer" },
-	{ "dancinggals",		"Dancing Gals Power" },
-	{ "digerotica",			"Digital Erotica" },
-	{ "digitalogue",		"Digitalogue Home Museum Series" },
-	{ "dmj5",				"DMJ5: The Game!" },			// Devil in Miss Jones
-	{ "dmpgallery",			"Digital Magazine for Photography: Gallery" },
-	{ "dream1",				"The Dream Machine: The Virtual Sexual Experience" },
-	{ "dream2",				"The Dream Machine 2" },
-	{ "eros",				"Fischer's Erotic Encyclopedia" },
-	{ "gilgameshnite",		"ギルガメッシュ Night Super Deluxe CD-ROM" },		// Gilgamesh
-	{ "historiapoca",		"A História Não Contada de Pocahontas" }, // The Untold Story of Pocahontas
-	{ "houseparty",			"House Party: The Game" },
-	{ "immorale",			"Immorale" },
-	{ "isswim98",			"Inside Sports 1998 Swimsuit Issue" },
-	{ "labyrinth",			"Labyrinth" },
-	{ "legs",				"Legs" },
-	{ "macplaymate1",		"MacPlaymate" },
-	{ "macplaymate2",		"MacPlaymate II" },
-	{ "neurodancer",		"NeuroDancer" },
-	{ "nightnurses",		"Nightshift Nurses: The Game" },
-	{ "pbvv",				"Playboy's Voluptuous Vixens" },
-	{ "playmate1999",		"1999 Playboy Playmate Calendar" },
-	{ "sadowar",			"RSP" },
-	{ "scop",				"Scop" },
-	{ "shock",				"Shock: The Game" },
-	{ "sororitystwrdss",	"Sorority Stewardesses" },
-	{ "thebody",			"The Body: Five doors plus" },
-	{ "thelegs",			"The Legs ～Get a LEG up～" },
-	{ "timewarp",			"Time Warp" },
-	{ "venus",				"Venus Photo CD-ROM" },
-	{ "vpeepshow",			"Virtual Peep Show" },
-	{ "vsex1",				"Virtual Sex" },
-	{ "vsex2",				"Virtual Sex II" },
-	{ "vsexasia",			"Virtual Sex with Asia"},
-	{ "vvalerie1",			"Virtual Valerie" },
-	{ "vvalerie2",			"Virtual Valerie 2" },
-	{ "vvaleriedc",			"Virtual Valerie: Director's Cut" },
-	{ "vveronika",			"Virtual Veronika" },
-	{ "vvs1",				"Supermodels: Virtual Video Shoot" },
-
+	// Unknown (to sort)
+	{ "planetearth",		"Planet Earth: The Story of Environmental Awareness" },
+	{ "acaciarevise",		"Acacia's Revise Series" },
+	{ "multimediastudio",	"The Multimedia Cartoon Studio" },
 	{ 0, 0 }
 };
 
@@ -1755,6 +1760,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 //////////////////////////////////////////////////
 
 	MACGAME1_l("alice", "", "Alice", "e54ec74aeb4355b0acd46320327c1bed", 271740, Common::JA_JPN, 200),
+	// CD serial TONP-1506, uses CD-Audio
 	MACGAME1_l("alice", "Digipak", "Alice", "e54ec74aeb4355b0acd46320327c1bed", 274018, Common::JA_JPN, 200),
 
 	// Many separate apps on a single disk
@@ -1787,6 +1793,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	// Movies called from HyperCard with external MacroMind Player 2.0
 	MACGAME1("spelunx", "v1.2", "Spelunx", "3eb3598b7f6bb09de4dd31aca3683d8f", 371154, 200),
+
+	// Original file name is STATUS*Mac 2.0 Demo
+	MACDEMO1("statusmac", "2.0 Demo", "xn--STATUSMac 2.0 Demo-za43f", "cfa68a1bc49251497ebde18e5fc9c217", 742048, 200),
 
 	MACGAME2("system7smash", "", "Double Click", "e54ec74aeb4355b0acd46320327c1bed", 225921,
 								 "Smash", "7c11c3c07b87188cdf6260f922bb9e3c", 9031, 201),
@@ -1836,8 +1845,12 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	MACGAME1("alice2ocean", "", "From Alice to Ocean", "1ae45c23586b41997ba52e2e7c771c4c", 375210, 310),
 
-	MACGAME1("amandastories", "3.0 B&W", "AmandaStories", "fdbf26d3796068ee4ae1a9b6cd052c4e", 195988, 300),
-	MACGAME1("amandastories", "3.0 Color", "AmandaStories", "1687f456d7f2bcf98e84fec6d3a03c17", 353729, 300),
+	// v3.0 is the 1991 Mac-only release, v4.0 is the 1993 Win/Mac hybrid release
+	// In the Mac-only release, only the 'AmandaStories Color' version is Director, 'AmandaStories B & W' is HyperCard; also uses a single audio track
+	// Original Mac filename of the 1993 version is AmandaStories®
+	MACGAME1("amandastories", "v3.0", "AmandaStories", "1687f456d7f2bcf98e84fec6d3a03c17", 353729, 300),
+	MACGAME1("amandastories", "v4.0", "xn--AmandaStories-1sa", "88e2dc106dd1e5da5aebf9ed36944a7f", 360905, 300),
+	WINGAME1t("amandastories", "", "AMANDA.EXE", "9c44f3e450184e5db441bccbaf4a830a", 373139, 310),
 	MACDEMO1("amandastories", "Sampler", "AmandaStories Sampler", "60cc4ccbab898f1f444088fb5aad90c4", 1783259, 311),
 
 	// Uses audio tracks
@@ -1933,7 +1946,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// English Mac filename is The C.H.A.O.S. Continuum™
 	// Japanese Mac demo filename is CHAOS デモ and another file is called CHAOS Demo
 	// English Mac demo from The Family Doctor, 3rd Edition
-	MACGAME1("chaos", "", "xn--The C.H.A.O.S. Continuum-3r4o", "2ce360c9ea2da80a2c6d1040b0ad92dd", 384225, 300),
+	MACGAME1("chaos", "", "xn--The C.H.A.O.S. Continuum-3r4o", "2ce360c9ea2da80a2c6d1040b0ad92dd", 384225, 313),
 	WINGAME2t("chaos", "", "CHAOS.EXE",    "5d1d9e1ff9a43e4d5b28441ce6d642fd", 375294,
 						   "ANTEROOM.MMM", "6004a72285c7757e12ea214374e6fc5d", 15160, 310),
 	MACDEMO1_l("chaos", "Demo", "Start CHAOS Demo", "f5277c53bacd27936158dd3867e587e2", 394683, Common::JA_JPN, 311),
@@ -1981,9 +1994,6 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Original filename is キューティ１０デモ
 	MACDEMO1_l("cutie10", "Demo", "Cutie 10 demo", "f5277c53bacd27936158dd3867e587e2", 390059, Common::JA_JPN, 311),
 
-	// From the Police Quest Collection
-	WINGAME1("darylfgates", "", "INTERVEW.EXE", "351c9f2cf2c205eea7a9ce50e73974ee", 1059729, 311),
-
 	MACGAME1_l("delphinokioku", "", "DELPHOI", "957b631d36a03be6c4671981a0b81681", 309951, Common::JA_JPN, 310),
 
 	MACGAME1("digby", "", "Start Digby's Adventures!", "7f443f2e63fd497a9ad85b10dc880a91", 383758, 313),
@@ -2018,13 +2028,12 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// 1994 demo for Millie's Math House, Thinkin' Things, Kid Desk
 	MACGAME1_l("edmark", "", "EDMARK", "276bee761e48a6fd709df77d5c2f60dd", 392437, Common::JA_JPN, 313),
 
-	// Demo contains Apparelizer 1.0 minigame; full game is D4
-	// Found on Disc Inferno from APC magazine (Australia), Dec 1999
-	WINDEMO1("elroycostume", "Demo", "elroy.exe", "9d18c6a224dd0e5be4ad03a05c74254b", 854349, 311),
-
 	MACDEMO1("emigre", "Demo", "play cheese", "7c80091b84d4d5d48f7c773b30b10598", 990413, 310),
 
 	MACGAME1("encarta94", "", "Installer Files/Encarta Projector", "7f443f2e63fd497a9ad85b10dc880a91", 385727, 313),
+	// From CD Loisirs Nº6
+	WINDEMO2t("encarta94", "", "ENCARTA.EXE", "15556b44638f59a1b55b050843562dfe", 370013,
+							   "ENCADEMO.MMM", "17d992f65d52a070f1e7c15300031c79", 1321638, 300),
 
 	MACGAME1("encarta95", "", "Installer Files/Encarta Projector", "7f443f2e63fd497a9ad85b10dc880a91", 385729, 313),
 	WINDEMO1("encarta95", "Demo", "ENDEM95.EXE", "61d63911d437806fd473ffc31ddfc53d", 12109799, 311),
@@ -2092,7 +2101,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 	FMTGAME2_l("gadget", "Room(306)", "GADGET/ROOM306.EXE",	"7d0657bab79bc396a0c5b2271fbfeb16", 369009,
 									  "DATA/GA00.MMM",		"72ffa3d703affdf146ba19cb80e6bdbd", 324390, Common::JA_JPN, 310),
 	// Warning text at the end is in both Japanese and English
-	MACDEMO1("gadget", "Demo", "GADGET",	 "f5277c53bacd27936158dd3867e587e2", 390109, 311),
+	MACDEMO1("gadget", "Demo", "GADGET",	  "f5277c53bacd27936158dd3867e587e2", 390109, 311),
 	WINDEMO2t("gadget", "Demo", "GADGET.EXE",		 "52a854cc16777395d05aa87859e6be5a", 684203,
 								"DATA/01_HOTEL.DIR", "3287761cea8b676110a197e0c2ec7d31", 9403586, 311),
 
@@ -2150,14 +2159,20 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	MACDEMO1("hirezaudio", "Vol. 1 Demo", "Hi Rez Demo Projector", "1ae45c23586b41997ba52e2e7c771c4c", 1562852, 310),
 
-	MACGAME1("hoaddams2", "",  "AddamsFamilyInt",				"7f443f2e63fd497a9ad85b10dc880a91", 1381040, 313),
-	MACGAME1("hoangus", "",	   "Angus IPK",						"2ce360c9ea2da80a2c6d1040b0ad92dd", 2029855, 313),
-	MACGAME1("hodolores", "",  "Dolores Claiborne Interactive", "7f443f2e63fd497a9ad85b10dc880a91", 1475936, 313),
-	MACGAME1("hostargate", "", "Stargate Interactive",			"7f443f2e63fd497a9ad85b10dc880a91", 1394354, 313),
-	MACGAME1("hothenet", "",   "The Net Interactive Kit",		"7f443f2e63fd497a9ad85b10dc880a91", 2027385, 313),
-	WINGAME1("hoangus", "",	   "ANGUS.EXE",  "7c8230a804abf9353b05627a675b5ffb", 2383326, 313),
-	WINGAME1("hodolores", "",  "DOLRES.EXE", "65d06b5fef155a2473434571aff5bc29", 1671516, 313),
-	WINGAME1("hothenet", "",   "NET.EXE",	 "65d06b5fef155a2473434571aff5bc29", 2357523, 313),
+	MACGAME1("hoaddams2", "", "AddamsFamilyInt", "7f443f2e63fd497a9ad85b10dc880a91", 1381040, 313),
+
+	MACGAME1("hoangus", "", "Angus IPK", "2ce360c9ea2da80a2c6d1040b0ad92dd", 2029855, 313),
+	WINGAME1("hoangus", "", "ANGUS.EXE", "7c8230a804abf9353b05627a675b5ffb", 2383326, 313),
+
+	MACGAME1("hodolores", "", "Dolores Claiborne Interactive", "7f443f2e63fd497a9ad85b10dc880a91", 1475936, 313),
+	WINGAME1("hodolores", "", "DOLRES.EXE", "65d06b5fef155a2473434571aff5bc29", 1671516, 313),
+
+	MACGAME1("hostargate", "", "Stargate Interactive", "7f443f2e63fd497a9ad85b10dc880a91", 1394354, 313),
+
+	MACGAME1("hothenet", "", "The Net Interactive Kit", "7f443f2e63fd497a9ad85b10dc880a91", 2027385, 313),
+	WINGAME1("hothenet", "", "NET.EXE", "65d06b5fef155a2473434571aff5bc29", 2357523, 313),
+
+	WINGAME1t("hotrekgens", "", "TREK.EXE", "dbf91fa10fef580c7f8e2962c4151d30", 1861869, 310),
 
 	// Movies are played from HyperCard. Each of the 10 lessons and 3 practice examples are Director.
 	MACDEMO1_l("hypercardlessons", "Demo", "Lesson1movie", "8ac6b58b68561d6227921cbfef30a02d", 62177, Common::JA_JPN, 300),
@@ -2287,14 +2302,17 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1_l("lvi", "Nº1", "LVI.EXE", "65d06b5fef155a2473434571aff5bc29", 634203, Common::FR_FRA, 310),
 
 	MACDEMO1_l("lotus123", "Tour", "Tour of 1-2-3.v3", "1ed38b71d8d0f075483117f7fa559e7c", 367077, Common::JA_JPN, 302),
+	WINDEMO1t("lotus123", "Release 4 Tour", "123TOUR.EXE", "3192b417bdc7a11b266ceed5b6476ee2", 353568, 300),
 
 #undef SUPPORT_STATUS
 #define SUPPORT_STATUS ADGF_NO_FLAGS
 
-	MACGAME1("lzone",  "",   "L-ZONE",		"f5277c53bacd27936158dd3867e587e2", 392484, 300),
-	MACGAME1("lzone",  "v2", "L-ZONE",		"276bee761e48a6fd709df77d5c2f60dd", 395088, 310),
-	GENGAME1_("lzone", "",   "L-ZONE",		"9f0bb7ec7720e4f680ee3aa3d22c1c9d", 384968, Common::EN_ANY, Common::kPlatformMacintoshII, ADGF_MACRESFORK, 300),
-	WINGAME1t("lzone", "",   "L_ZONE/L_ZONE.EXE",	"079429bfc54a1df8e7b4d379aefa0b59", 370009, 300),
+	MACGAME1("lzone",  "",	"L-ZONE", "f5277c53bacd27936158dd3867e587e2", 392228, 311),
+	// MACGAME1("lzone", "Readme", "Read Me First", "f5277c53bacd27936158dd3867e587e2", 392224, 311),
+	MACGAME1("lzone", "v2",	"L-ZONE", "276bee761e48a6fd709df77d5c2f60dd", 395088, 313),
+	// MACGAME1("lzone", "Readme",	"Read Me First", "276bee761e48a6fd709df77d5c2f60dd", 394664, 313),
+	GENGAME1_("lzone", "",	"L-ZONE", "9f0bb7ec7720e4f680ee3aa3d22c1c9d", 384712, Common::EN_ANY, Common::kPlatformMacintoshII, ADGF_MACRESFORK, 300),
+	WINGAME1t("lzone", "",	"L_ZONE/L_ZONE.EXE", "079429bfc54a1df8e7b4d379aefa0b59", 370009, 300),
 
 #undef SUPPORT_STATUS
 #define SUPPORT_STATUS ADGF_UNSTABLE
@@ -2324,9 +2342,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 									"MSI C-S",   "224006f035e5f5fc0dd0133fbc5c6b89", 142729, Common::JA_JPN, 311),
 
 	// Original Mac filename is Maniac Sports™
-	MACGAME1("maniacsports", "", "xn--maniac sports-8q9g", "2ce360c9ea2da80a2c6d1040b0ad92dd", 420962, 311),
-	WINGAME2("maniacsports", "", "MANIAC.EXE", "65d06b5fef155a2473434571aff5bc29", 371274,
-								 "SUPPORT/MSWORLD.MMM", "e9cdd7f30fb3386e7b67c6769147f60a", 218378, 311),
+	MACGAME1("maniacsports", "", "xn--Maniac Sports-8q9g", "2ce360c9ea2da80a2c6d1040b0ad92dd", 420962, 311),
+	WINGAME2t("maniacsports", "", "MANIAC.EXE", "06c073b9e084e7f41c814f00229e3cde", 371274,
+								  "SUPPORT/MSINTRO.MMM", "02bfadbf255139d60a0b9dd1382936d1", 377340, 311),
 
 	MACDEMO1_l("marinefantasy", "Demo", "MarineFantasy", "276bee761e48a6fd709df77d5c2f60dd", 394970, Common::JA_JPN, 313),
 
@@ -2338,7 +2356,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	// aka Bit-Bot's Math Voyage; A Viagem na Matemática do Bit Bot (PT-BR)
 	// Developed by Magic Quest, Inc.
-	// Floppy version of Bit-Bot's Math Voyage (aka v2.0.4) requires installation, InstallShield v3
+	// Floppy version of Bit-Bot's Math Voyage (v2.0.4) requires installation, InstallShield v3
 	//   {"BBMV1.Z", "4d8576b627d6dcc79d0a57237261a0ef", 264550}
 	//   {"BBMV2.1", "e8c7538d7e2942a91412375873188177", 710280}
 	//   {"BBMV2.2", "8a1c7a1a1088713b27bb3dc2aadee46b", 1430074}
@@ -2359,8 +2377,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Original filename is 付録
 	MACGAME1_l("mazebox", "Vol.1", "xn--bnq597n", "f5277c53bacd27936158dd3867e587e2", 419531, Common::JA_JPN, 311),
 
-	// Demo runs from Aldus SuperCard with Director movies
-	MACDEMO1_l("mazebrew", "Demo", "MBW", "3350d8c895d47d217d2dfa58aa95496d", 558, Common::JA_JPN, 311),
+	// Game runs from Aldus SuperCard with Director launcher and movies
+	// This demo detection entry is for the movie launched from "MazeBox Works Vol.1", do not use
+	// MACDEMO1_l("mazebrew", "Demo", "MBW", "3350d8c895d47d217d2dfa58aa95496d", 558, Common::JA_JPN, 311),
 	MACGAME1_l("mazebrew", "v2.0", "MazeBrew  v.2.0", "f5277c53bacd27936158dd3867e587e2", 491957, Common::JA_JPN, 311),
 
 	MACDEMO1("meetingmaker", "Demo", "Meeting Maker Demo", "19fe54e0b5c60405c7a88d9e4e032965", 721720, 300),
@@ -2379,6 +2398,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	MACDEMO1_l("moderntimes", "Demo", "ModernTimes", "f5277c53bacd27936158dd3867e587e2", 391357, Common::JA_JPN, 311),
 	MACDEMO1_l("moderntimes", "Demo", "ModernTimes", "f5277c53bacd27936158dd3867e587e2", 391334, Common::JA_JPN, 311),
+
+	MACGAME1("mousepractice", "", " Mouse Practice", "9f0bb7ec7720e4f680ee3aa3d22c1c9d", 349937, 300),
 
 	// Demos from The Computer Buyer Collection Volume 1 - Sep 1995
 	WINDEMO2t("msarcade",	   "Demo",		"ARCADE.EXE",   "a7f83e35541a2952cd4848becee98c1d", 1843614,
@@ -2415,12 +2436,22 @@ static const DirectorGameDescription gameDescriptions[] = {
 									"BASEB1.MMM",	"6cd090073aa3e159490d4a0458adaf7e", 1251222, 300),
 
 	MACGAME1("msdinosaurs", "Overview Movie", "Overview Movie", "479541070b3cbab6fd8473ce6267fb98", 792604, 310),
+	// From CD Loisirs Nº6
+	WINDEMO2t("msdinosaurs", "Demo", "DINOSAUR.EXE", "593f33ddf837f0b9c737712351ff6faa", 370013,
+									 "DINODEMO.MMM", "78863a9c384aea75affff8bb61294751", 2959664, 300),
+
+	// From CD Loisirs Nº6
+	WINDEMO2t("msdangerous", "Demo", "DANGER.EXE", "04af79d00b4492d86baff5fe3601f534", 370004,
+									 "DANG1.MMM", "57b3823b36c60a065bb6f8a11d49dccb", 4872194, 300),
+	WINDEMO2t("msspaceflight", "Demo", "SPACE.EXE", "66eeaad4eb9d8ed1ad9c445ed4eacb14", 370004,
+									   "FLIG1.MMM", "fcdf7ed5bf3da589ef3d516db2b97af1", 4097580, 300),
 
 	MACDEMO1("msproject", "Demo", "MS Project demo", "9f0bb7ec7720e4f680ee3aa3d22c1c9d", 1059914, 300),
 
 	// "Message from Apple" found on Nikkei Mac CD-ROM (1994-2-17)
-	MACGAME1_l("msgfromapple", "", "Message", "4c7fddccfe5ab2e9c6398efa5dbe37c1", 395526, Common::JA_JPN, 313),
+	// "from Apple/Message" found on Macintosh Demo Software Zenshuu CD-ROM '94, disc 1
 	MACGAME1_l("msgfromapple", "", "Message from Apple", "4c7fddccfe5ab2e9c6398efa5dbe37c1", 395566, Common::JA_JPN, 313),
+	MACGAME1_l("msgfromapple", "", "from Apple/Message", "4c7fddccfe5ab2e9c6398efa5dbe37c1", 395526, Common::JA_JPN, 313),
 
 	// French version is D5
 	MACGAME1("murderbrett", "", "The Environmental Surfer", "2ce360c9ea2da80a2c6d1040b0ad92dd", 384213, 300),
@@ -2564,11 +2595,11 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1("satodesign", "Gift Disk", "Animation", "a03ae8a9bf211bcb26388b6b6da17c2b", 388853, 311),
 	MACGAME1("satohomosexual", "", "SATO&NAKAZAWA", "a03ae8a9bf211bcb26388b6b6da17c2b", 736276, 311),
 
-	MACGAME1_l("schoolworld", "Capture", "CAPTURE",			 "f5277c53bacd27936158dd3867e587e2", 1652208, Common::JA_JPN, 311),
 	MACGAME1_l("schoolworld", "Breed",	 "BREED",			 "f5277c53bacd27936158dd3867e587e2", 545024, Common::JA_JPN, 311),
+	WINGAME1t_l("schoolworld", "Breed",	  "BREED.EXE",		  "4dcee516cdda1661c2c62852d8c1350f", 375277, Common::JA_JPN, 310),
+	MACGAME1_l("schoolworld", "Capture", "CAPTURE",			 "f5277c53bacd27936158dd3867e587e2", 1652208, Common::JA_JPN, 311),
+	WINGAME1t_l("schoolworld", "Capture", "CAPTURE.EXE",	  "f0bfae0867a86735affd5d0e07e857e7", 375279, Common::JA_JPN, 310),
 	MACDEMO1_l("schoolworld", "Demo",	 "SchoolWorld-DEMO", "f5277c53bacd27936158dd3867e587e2", 4046527, Common::JA_JPN, 311),
-	WINGAME1_l("schoolworld", "Capture", "CAPTURE.EXE",		 "7c8230a804abf9353b05627a675b5ffb", 375279, Common::JA_JPN, 310),
-	WINGAME1_l("schoolworld", "Breed",	 "BREED.EXE",		 "7c8230a804abf9353b05627a675b5ffb", 375277, Common::JA_JPN, 310),
 
 	// Manual only. Full game is made in VB3 and contains unsupported content
 	WINGAME1("scissorsnstones", "", "MANUAL.EXE", "7c8230a804abf9353b05627a675b5ffb", 2494292, 310),
@@ -2598,6 +2629,11 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1("sialmanac94", "", "SPORTSI.EXE", "990caf82b2406e3342fb93ddb7222bf5", 461040, 310),
 
 	WINDEMO1("sk8board", "Demo", "RIDE.EXE", "65d06b5fef155a2473434571aff5bc29", 370013, 310),
+
+	// Demo from Blender 1.5
+	// Version 1.2 onwards are D4
+	MACGAME1("smile", "v1.1", "SMILE! The Splattering", "249f5b6c2a2b050af6ebd533203c5e32", 2479330, 310),
+	MACDEMO1("smile", "v1.1", "Smile!", "1ae45c23586b41997ba52e2e7c771c4c", 1462136, 310),
 
 	MACGAME1("smithamerica", "", "Smithsonian's America", "b2df07bdfe2a843e8f355a77a1cca47e", 384223, 313),
 	WINGAME1t("smithamerica", "", "AMERICA.EXE", "762716cefb27adf3156d5978ce62c0d8", 370010, 310),
@@ -2691,6 +2727,10 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1("verttice", "v1.0", "xn--DreamLight Verttice 1.0-35a3288r", "b57fff2bb16ad91d6e807ceeab357271", 1082993, 311),
 	MACGAME1("verttice", "v1.1", "xn--DreamLight Verttice 1.1-35a3288r", "1ae45c23586b41997ba52e2e7c771c4c", 1086927, 311),
 	MACGAME1("verttice", "v1.1 PowerMac", "xn--DreamLight Verttice 1.1-35a3288r", "1ae45c23586b41997ba52e2e7c771c4c", 1089191, 311),
+
+	// System 7 + Power Mac versions are D4
+	MACGAME1("videocasino", "", "xn--Video Casino Sys. 6-co0l", "96936d0dbef06314515f134ccbbc35e1", 1488811, 310),
+	MACDEMO1("videocasino", "Demo", "VC.Demo.14.Start", "1ae45c23586b41997ba52e2e7c771c4c", 877609, 310),
 
 	MACGAME2("vvcyber", "", "Start Game", "7f443f2e63fd497a9ad85b10dc880a91", 384846,
 							"START0",	  "6d6781e7183df66d8995285e4e3f1a50", 807, 300),
@@ -2907,15 +2947,19 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINDEMO1t("adamtis", "Demo",	  "ADAMDEMO.EXE",		   "451a5ea3f5a47874dbad22d1715d2635", 7342649, 404),
 	WINDEMO1("adamtis", "Skull Demo", "PUZZLE.EXE",			   "d2dcc8b55382fc1807e357af5108f7ba", 1057997,	404),
 
+	// CD serial SYHB-002
 	MACGAME1("alice", "", "Alice", "3b61149c922f0fd815ca29686e4f554a", 304458, 400),
-	WINGAME1("alice", "", "ALICE.EXE", "c67ece9b657ee80355520ac37a25fe55", 684733, 400),
+	WINGAME1t("alice", "", "ALICE_W/ALICE.EXE", "da6b3cb75f548d5c79ef831320b97035", 684733, 400),
+	// CD serial TORT-3001
+	MACGAME1_l("alice", "Hybrid", "Alice", "3b61149c922f0fd815ca29686e4f554a", 304486, Common::JA_JPN, 400),
+	WINGAME1t_l("alice", "Hybrid", "ALICE_W/ALICE.EXE", "da6b3cb75f548d5c79ef831320b97035", 684733, Common::JA_JPN, 400),
 
 	// Developed by Collabo Software and NOVUM, distributed by XING Inc.
 	// Mac projector does indeed end in .EXE
 	// Win has projectors for 8-bit and 16-bit color
-	MACGAME1_l("alius", "",             "ALIUS_FAT.EXE", "df355a56c186f3d6a64d99e96600f48c", 499193, Common::JA_JPN, 404),
-	WINGAME1_l("alius", "8-bit Color",  "ALIUS_8.EXE",   "9db857a65199db5251a33b2121ec5984", 2426433, Common::JA_JPN, 404),
-	WINGAME1_l("alius", "16-bit Color", "ALIUS_16.EXE",  "98ac4e872421263dbbde1636b1e9d0e1", 2635737, Common::JA_JPN, 404),
+	MACGAME1_l("alius", "",				"ALIUS_FAT.EXE", "df355a56c186f3d6a64d99e96600f48c", 499193, Common::JA_JPN, 404),
+	WINGAME1_l("alius", "8-bit Color",	"ALIUS_8.EXE",   "9db857a65199db5251a33b2121ec5984", 2426433, Common::JA_JPN, 404),
+	WINGAME1_l("alius", "16-bit Color",	"ALIUS_16.EXE",  "98ac4e872421263dbbde1636b1e9d0e1", 2635737, Common::JA_JPN, 404),
 
 	MACGAME1("alphabet", "", "Alpha.ppc", "71287376e445ab9c98f0d150bb0ed175", 59444, 404),
 	WINGAME1("alphabet", "", "ALPHA.EXE", "c89c8301db7ef0ebffedf435863b3ffc", 749092, 404),
@@ -2951,8 +2995,10 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Original filename is Ants Afire!™ 1.2
 	// Original Pro demo filename is Ants Afire! Pro™ PM
 	// Demo is from Inside Mac Games #25 - Mar 25 1995
+	// 2nd demo from MacCubed³ #1
 	MACGAME1("antsafire", "v1.2", "xn--Ants Afire! 1.2-ke3i", "1682231de376e5465240f6e4a7952072", 291960, 403),
 	MACDEMO1("antsafire", "Pro 1.2.7 Demo", "xn--Ants Afire! Pro PM-qu3k", "71287376e445ab9c98f0d150bb0ed175", 60096, 404), // 1.2 on title screen
+	MACDEMO1("antsafire", "Pro 1.2.7 Demo", "Ants Afire! Pro Demo 1.2.7", "ea646eccc9a53f44ce082459d4809a06", 483490, 400),
 
 	MACDEMO1("aol", "v2.6 Demo", "America Online Easy", "67f572196550aedb1f9523d782022be0", 482582, 404),
 	WINDEMO1t("aol", "Demo", "AOL.EXE", "b91b98671625a60252dba2cc7d052e7d", 1426687, 404),
@@ -2971,6 +3017,11 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1("arcofdoom", "", "ARC.EXE", "fd3e9ad004597b01656b28c348a2ae7f", 687973, 400),
 	MACDEMO1("arcofdoom", "Demo", "ArcDemo", "cdb27c916044ae4dceb4b7326063fa03", 301669, 400),
 
+	// English and German selectable from main menu
+	// The Four Seasons of Gourmet French Cuisine
+	// The Art of Making Great Pastries
+	MACGAME1("aromeinteractive", "", "Demo", "77f4098988d5386794d1530065f514cd", 301669, 400),
+
 	WINDEMO2("artofmagic", "Demo", "MAGIC.EXE", "57347ee90d930c1bb222c5652c4b3a50", 690969,
 								   "WINWORLD.DIR", "0cf86a011d48ef31790514f13f92484d", 19977904, 404),
 
@@ -2985,6 +3036,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	MACGAME1("atbat", "2.0", "At Bat", "ea553e3f3fa123ad38fa5249621e8c8b", 292906, 403),
 	WINGAME1t("atbat", "2.0", "ATBAT.EXE", "de8a2b4f91c1e7a22e36f394a3a64af5", 842033, 400),
+	WINDEMO1t("atbat", "", "ATBATDMO.EXE", "2000eefeb4bf68749dad55e101cbd318", 3266657, 400),
 
 	MACGAME1("athletics", "", "ATHLETICS", "17efee018a660458fae80de4364021ac", 482866, 404),
 	WINGAME1("athletics", "", "PROJECT.EXE", "b804f1e4bf84c31979502329ee0f8c28", 696839, 404),
@@ -3000,13 +3052,13 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Russian version appears to be identical with only assets replaced
 	// Original Japanese Mac filename is バッドデイ(Power PC)
 	MACGAME1("badday", "",	 "BadDay (Universal)", "b7e69c37b7355022d400c14aa97c5d54", 483781, 404),
-	MACGAME1_l("badday", "", "BadDay (Power PC)",  "c5f8c31feb5c3d4596b63455c520fc46", 60352, Common::JA_JPN, 404),
+	MACGAME1_l("badday", "", "xn--(Power PC)-jx4ilmwb1a7h", "c5f8c31feb5c3d4596b63455c520fc46", 60096, Common::JA_JPN, 404),
 	WINGAME2("badday", "",   "BAD_DAY.EXE", "4ad339db5379a860b33cbb0fa64f18e2", 742342,
 							 "BADDAY.DXR",	"b4b6fa644f64555f9f7af51454c40909", 288810, 404),
 	WINGAME2_l("badday", "", "BAD_DAY.EXE",	"4ad339db5379a860b33cbb0fa64f18e2", 742342,
 							 "BADDAY.DXR",	"b4b6fa644f64555f9f7af51454c40909", 397994, Common::RU_RUS, 404),
-	WINGAME2_l("badday", "", "BAD_DAY.EXE",	"7589f11c6411e59c0e82ec129090460f", 768773,
-							 "BADDAY.DXR",	"26c3b03b18e7aa098216be73d96289b0", 549108, Common::JA_JPN, 404),
+	WINGAME2t_l("badday", "", "BDM/BAD_DAY.EXE",   "3023f944e8d494393bf08c0cb7a61ba0", 768773,
+							  "BADDAY/BADDAY.DXR", "1e28a7f03ff2441eb8a5ac07204222dd", 549108, Common::JA_JPN, 404),
 
 	// Original filename is みんなであそぼ　デモ
 	// Kidsoft US packaging says A Bear Family Adventure featuring Playtime in the Park by Erica Dale
@@ -3064,16 +3116,24 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	WINGAME1("blaster", "", "DEMO.EXE", "617725437da4d66c176a9e7011977097", 24300731, 400),
 
-	MACGAME2("blender", "Volume 2.1", "BLENDME (POWERMAC)", "9d10bbbf1b8d527e203c6be2eac3518c", 58058,
-									  "FILES/OPENING.DIR",	"f5d3c1e813ec276de53d5ff13a6bf337", 2888054, 404),
-	MACGAME2("blender", "Volume 2.2", "BLENDME (POWERMAC)", "9d10bbbf1b8d527e203c6be2eac3518c", 58058,
-									  "FILES/OPENING.DIR",	"9984fd46227b54b7e48a76cec2cec06b", 1991202, 404),
-	WINGAME2t("blender", "Volume 2.1", "BLENDME.EXE",		"ce776239b21820b1a8030cffa190ab37", 728849,
-									   "FILES/OPENING.DIR",	"b4fdf4b19e4a425a241624855617802a", 2887926, 404),
-	WINGAME2t("blender", "Volume 2.2", "BLENDME.EXE",		"ce776239b21820b1a8030cffa190ab37", 728849,
-									   "FILES/OPENING.DIR",	"3dd81344b84bc717bee11e878afe4339", 1991074, 404),
-	WINDEMO2t("blender", "Volume 2.3", "BLENDME.EXE",		"ce776239b21820b1a8030cffa190ab37", 728849,
-									   "OPENING.DIR",		"cf1e8a8c8e8ee15fddda07490ded4b0e", 6989498, 404),
+	MACGAME1("blender",  "Volume 1.5", "Blender 1.5",		 "bcd3c718db258701496b3c5bcb827ef2", 483518, 404),
+	WINGAME2t("blender", "Volume 1.5", "BLENDER.EXE",		 "f280c3cee63594aca2687ce96dbe0dde", 776767,
+									   "FILES/OPENING.DIR",	 "08164bbffad6fc8bf45e81f0b47acfbb", 2986544, 404),
+	MACGAME2("blender",  "Volume 2.1", "BLENDME (POWERMAC)", "9d10bbbf1b8d527e203c6be2eac3518c", 58058,
+									   "FILES/OPENING.DIR",	 "f5d3c1e813ec276de53d5ff13a6bf337", 2888054, 404),
+	WINGAME2t("blender", "Volume 2.1", "BLENDME.EXE",		 "ce776239b21820b1a8030cffa190ab37", 728849,
+									   "FILES/OPENING.DIR",	 "b4fdf4b19e4a425a241624855617802a", 2887926, 404),
+	MACGAME2("blender",  "Volume 2.2", "BLENDME (POWERMAC)", "9d10bbbf1b8d527e203c6be2eac3518c", 58058,
+									   "FILES/OPENING.DIR",	 "9984fd46227b54b7e48a76cec2cec06b", 1991202, 404),
+	WINGAME2t("blender", "Volume 2.2", "BLENDME.EXE",		 "ce776239b21820b1a8030cffa190ab37", 728849,
+									   "FILES/OPENING.DIR",	 "3dd81344b84bc717bee11e878afe4339", 1991074, 404),
+	// from CD-ROM Magazine #8
+	WINDEMO2t("blender", "Volume 1.2", "BLENDER.EXE",		 "7ea9c92fdbd88f397b0e559e451cea0a", 776073,
+									   "OPENING2.DIR",		 "3b7612dc2ed897b59f2063b82b8cc49c", 1849464, 404),
+	WINDEMO2t("blender", "Volume 1.4", "BLENDER.EXE",		 "a2d1e9d51c277082fe7911f6bb4613ed", 704513,
+									   "OPENING.DIR",		 "fa5a476ae30b10113541098d7dd11168", 12138642, 404),
+	WINDEMO2t("blender", "Volume 2.3", "BLENDME.EXE",		 "ce776239b21820b1a8030cffa190ab37", 728849,
+									   "OPENING.DIR",		 "cf1e8a8c8e8ee15fddda07490ded4b0e", 6989498, 404),
 
 	MACGAME1("blenderbest", "", "PPC LAUNCHER", "9d10bbbf1b8d527e203c6be2eac3518c", 58058, 404),
 	WINGAME1("blenderbest", "", "BLENDPC.EXE", "408fdb0f6806d93a9af0412f3704481e", 728849, 404),
@@ -3081,15 +3141,29 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1t("blinddate", "", "BLINDATE.EXE", "200eb58f092b3714e66596d9c435c301", 685837, 400),
 	MACGAME1("blinddate", "", "Blind Date", "5323b298a375507307a2db7de1681a64", 310661, 403),
 
-	// Dutch title is Blinky Bill 1 en het verhaal van de Griezel-Grot
-	// Portuguese title is A Caverna do Fantasma de Blinky Bill
-	WINGAME1("blinkybill1", "",		   "BLINKY.EXE",   "0d374b4a559e505c0db63cabc2219380", 712501, 404),
-	WINGAME1("blinkybill1", "Softkey", "BLINKY95.EXE", "f236295291fe54b8ca13534442ee1a8c", 713061, 404),
-	WINGAME2_l("blinkybill1", "",	   "start.exe",	   "be1e65196a1d1c810d84c0084a5c1033", 717299,
-									   "ghost0.dxr",   "5d79d1d50d7abc7bc7b6d72b3b4b831d", 112048, Common::NL_NLD, 404),
-	WINGAME1_l("blinkybill1", "",	   "BLINKY95.EXE", "3ee51e3c9f0f7f069580ef5361fd4e3d", 717025, Common::PT_BRA, 404),
+	// Original release is Win/Mac hybrid, Softkey release is Windows only
+	// aka La Caverna dei Fantasmi (IT); Blinky Bill 1 en het verhaal van de Griezel-Grot (NL); A Caverna do Fantasma de Blinky Bill (PT)
+	// Mac demo from MacFormat #44, Win demo from CD-ROM Today v2n10
+	// French and Dutch demos from Transposia 98
+	WINGAME1t(	"blinkybill1", "Softkey", "BLINKY95.EXE", "d63bdcee971abdccd26a7f9ad1faa39e", 713061, 404),
+	MACGAME2_l(	"blinkybill1", "", "BB/16M", "17efee018a660458fae80de4364021ac", 481254,
+								   "La Caverna dei Fantasmi", "cbf7119d62a3528d490cd517b4451061", 5967, Common::IT_ITA, 404),
+	WINGAME1t_l("blinkybill1", "", "BLINKY95.EXE", "e711b3a14fe5664380c58f3e366e0b5c", 727459, Common::IT_ITA, 404),
+	WINGAME2_l(	"blinkybill1", "", "start.exe",	   "be1e65196a1d1c810d84c0084a5c1033", 717299,
+								   "ghost0.dxr",   "5d79d1d50d7abc7bc7b6d72b3b4b831d", 112048, Common::NL_NLD, 404),
+	WINGAME1t_l("blinkybill1", "", "BLINKY95.EXE", "146512cdebe499a48872cc9e8710d738", 717025, Common::PT_BRA, 404),
+	MACGAME2_l(	"blinkybill1", "", "BB/16M", "17efee018a660458fae80de4364021ac", 481254,
+								   "A Caverna do Fantasma", "cbf7119d62a3528d490cd517b4451061", 5965, Common::IT_ITA, 404),
+	MACDEMO2(	"blinkybill1", "Demo", "BB/16M", "17efee018a660458fae80de4364021ac", 481254,
+									   "Ghost Cave Demo 16Mb", "5b8b1a76b4724565b8b3f184a753b79a", 2502, 404),
+	WINDEMO1t(	"blinkybill1", "Demo", "BLINKY.EXE", "6641493b9033e5c39e0f0fa1870b1081", 712501, 404),
+	WINDEMO1t_l("blinkybill1", "Demo", "BBDEMO95.EXE", "cfb7565e3f99adf6fed6cefab3cd8f2d", 716797, Common::FR_FRA, 404),
+	WINDEMO1t_l("blinkybill1", "Demo", "BBDEMO95.EXE", "14e7a58d39b94b3374277382bf8effff", 715635, Common::NL_NLD, 404),
 
 	WINDEMO1("blockbuster2", "Demo", "BB2.EXE", "132e49c93beae46c2803db11584e6315", 8447185, 404),
+
+	WINDEMO2t_l("blownaway", "Demo", "DEMO.EXE", "db13582be83388b285f634b4165068ce", 745999,
+									 "DEMO2.DXR", "39242284ad536ac5285fc6dfd239138f", 1694128, Common::DE_DEU, 404),
 
 	WINDEMO1("bookshelf95", "Demo", "BS95DEMO.EXE", "9493e1f5e92c89de805f07e1529243d4", 2593543, 404),
 
@@ -3106,8 +3180,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Retail CD release from BeachWare, Inc.
 	// Windows version also has CASINO2.EXE (Casino! Basic) for low performance PCs
 	// Director-based AUTORUN.EXE launcher chooses between these options on Win9X
-	MACGAME1("casino", "", "Casino! for PowerPC", "5bb6f4e7f9f026e2b5cf758796db3cd2", 57984, 400),
-	WINGAME1("casino", "", "CASINO.EXE", "7bb58472256eb84983a7d86843c81042", 692873, 404),
+	MACGAME1("casino", "", "Casino! for PowerPC", "5bb6f4e7f9f026e2b5cf758796db3cd2", 57728, 400),
+	WINGAME1t("casino", "", "CASINO.EXE", "fdae6bb9b74fabe7e5eab6df294b02f5", 692873, 404),
 	MACDEMO1("casino", "Sampler", "Casino! Sampler", "cbce20666bfe47a9533331c6be1e6039", 285255, 404),
 	WINDEMO1t("casino", "Sampler", "CASINO.EXE", "9957a5c3d67e857b5fd9cb084f7f8726", 1801785, 404),
 
@@ -3177,21 +3251,25 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	MACDEMO1("cinemac", "Sample Projector", "Sample Projector with BackDrop", "2c27791a84756be6201d281bad54f7bb", 286214, 404),
 
-	MACGAME1("circus", "", "Circus!", "dc5a87dda7a0daf46604515f7d2cca66", 319863, 400),
+	MACGAME1("circus", "v1.0.6", "Circus!", "dc5a87dda7a0daf46604515f7d2cca66", 319863, 400),
 	WINGAME1("circus", "", "CIRCUS.EXE", "50d81af709047f5d1310468a3cd5a248", 1503187, 400),
-	PIPGAME1_l("circus", "", "Circus!", "0d69b9bb731fba3d861a5f18e1810aa5", 61739, Common::JA_JPN, 404),
+	PIPGAME1_l("circus", "", "Circus!", "0d69b9bb731fba3d861a5f18e1810aa5", 61483, Common::JA_JPN, 404),
 	MACDEMO2("circus", "Demo", "Demo",		  "dc5a87dda7a0daf46604515f7d2cca66", 308286,
-							   "DemoLoop",	  "dc5a87dda7a0daf46604515f7d2cca66", 308286, 403),
-	WINDEMO2("circus", "Demo", "DEMO.EXE",	  "360f8621637354b9231059470c71fc43", 685645,
-							   "PREVIEW.EXE", "d98e36d5e525e8369458509b46587d8d", 686139, 400),
+							   "PREVIEW.MOV", "7d33c9b1fa93092499e29305f9b3a414", 5698025, 403),
+	WINDEMO2t("circus", "Demo", "DEMO.EXE",	   "f4c553260761cbc7b070515d514b44ad", 685645,
+								"PREVIEW.MOV", "2975f81df0e3540567f6e9460ba831f1", 5698025, 400),
+	MACDEMO2("circus", "Looping Demo", "DemoLoop", "dc5a87dda7a0daf46604515f7d2cca66", 308286,
+									   "PREVIEW.MOV", "7d33c9b1fa93092499e29305f9b3a414", 5698025, 403),
+	WINDEMO2t("circus", "Looping Demo", "PREVIEW.EXE", "edeb117e306c77f1496631ff9d6f1cbb", 686139,
+										"PREVIEW.MOV", "2975f81df0e3540567f6e9460ba831f1", 5698025, 400),
 
 	// Product catalog - does not correspond to any single game
+	// Mac version found on Blockbuster Video Guide to Movies & Videos
 	// Win version found on the Billboard Music Guide CD (1995 and 1997)
 	// The icon is the only additional file that could be used for detection
+	MACGAME1("cmc", "", "Creative Multimedia Catalog", "0c7bbb4b24823e5ab871cb4c1d6f3710", 483490, 404),
 	WINGAME2("cmc", "", "CATALOG.EXE", "11029bddba243a6be861367d45be5db9", 3896961,
 						"CMC.ICO",	   "cecbfb6ffa9bd2b1fe27e2d571809c7f", 766, 404),
-	// Mac version found on Blockbuster Video Guide to Movies & Videos
-	MACGAME1("cmc", "", "Creative Multimedia Catalog", "0c7bbb4b24823e5ab871cb4c1d6f3710", 483490, 404),
 
 	// Original filename is CityNetLine デモ版
 	MACDEMO1_l("cnl", "Demo", "CityNetLine Demo Version", "f5033f237ad1b1639fc46d01a82ac380", 286396, Common::JA_JPN, 404),
@@ -3208,6 +3286,10 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	MACGAME1_l("cookieginger", "", "COOKIE", "17efee018a660458fae80de4364021ac", 484181, Common::JA_JPN, 404),
 	WINGAME1t_l("cookieginger", "", "COOKIE.EXE", "03f2a878ff04b2e1ad7549fc6895da56", 766213, Common::JA_JPN, 404),
+
+	// From Blender 1.5
+	// Original filename is 'the courtney filter™'
+	MACGAME1("courtneyfilter", "", "xn--the courtney filter-jo0l", "bcd3c718db258701496b3c5bcb827ef2", 482582, 404),
 
 	// Mac version's executable is inside an installer
 	MACGAME1_l("crouton", "", "CROUTON F/CROUTON", "18f6634ce655067ddfaa413d3313515d", 484370, Common::JA_JPN, 404),
@@ -3256,6 +3338,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1("darkeye", "", "The Dark Eye (Universal)", "67f572196550aedb1f9523d782022be0", 486334, 400),
 	WINGAME1t("darkeye", "", "DARKEYE.EXE", "67ba8428573dba0c8e12e7f02e4ef1bc", 742326, 400),
 
+	// From the Police Quest Collection
+	WINGAME1t("darylfgates", "", "INTERVEW.EXE", "8262bbad22daa2cdd9cf13ebba1b84ea", 1059729, 400),
+
 	WINGAME1("davidsonpp", "1995", "DPP.EXE", "36c28cd89054df395c17c024a6ad6197", 112839901, 404),
 
 	// Original Pippin filename is ダズロイド
@@ -3274,6 +3359,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 							  "00INTRO.DIR",		   "3621850ac727f9cf116c41143482c16c", 4044830, Common::ZH_CHN, 404),
 	WINGAME1("dcanyoncd", "", "DINO_CD.EXE",		   "5fe054ed623541a92c04f1572ecb6c5d", 3160272, 404),
 
+	// From CD Loisirs Nº6
+	MACDEMO1("defendinghuman", "Demo", "Donald A Norman", "77f4098988d5386794d1530065f514cd", 301669, 400),
+
 	// Mac executable is Derrat Sorcerum™ v1.0.3
 	MACGAME1("derratsorcerum", "", "Derrat Sorcerum v1.0.3", "a546ef2b921a9b48fd93928f1a505f22", 483762, 400),
 	MACDEMO1("derratsorcerum", "Demo", "Derrat Sorcerum Demo v1.0.3", "a546ef2b921a9b48fd93928f1a505f22", 483762, 400),
@@ -3281,6 +3369,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Both Mac and Win versions require installation to extract executable
 	MACGAME1("devo", "", "Smart Patrol", "01be45e7241194dad07938e7059b88e3", 478506, 400),
 	WINGAME1("devo", "", "SMRTPTRL.EXE", "6030100dbff520b8763f6e98d15389d7", 741904, 400),
+
+	// From Blender 1.5
+	WINGAME1t("dewarswl", "", "dewars.exe", "b7e96f0dadee0f5a0f732e380bd7b5ea", 698341, 404),
 
 	MACGAME1_l("digby", "", "Start Digby's Adventures", "a8e65a2268226bd59f12ebdc58a221f3", 481482, Common::ZH_CHN, 404),
 	WINGAME1_l("digby", "", "DIGBY.EXE", "adc126fbc4387e5d8e84dcd5abd33653", 684269, Common::ZH_CHN, 400),
@@ -3307,6 +3398,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	MACGAME1("dkmm2", "", "DKSDMac", "8554afe42cffb4add44bf37e48e1d954", 322917, 400),
 	WINGAME1t("dkmm2", "", "DKSD2PC.EXE", "d43fd79cc7ec54a1b2b55562f4634b49", 862849, 400),
+
+	MACGAME1("doorswindows", "", "doors and windows-start", "01be45e7241194dad07938e7059b88e3", 483490, 404),
+	WINGAME1t("doorswindows", "", "doorwin.EXE", "af8680b093a154b6ece67b16569260a7", 2400203, 404),
 
 	WINGAME1t_l("doshifunspecial", "", "DOSHIFUN.EXE", "7bf89e4d7175aef9f5ea532774cf2d4e", 4854695, Common::JA_JPN, 404),
 
@@ -3362,8 +3456,10 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINDEMO1("elroybug", "Demo", "ELRYDEMO.EXE", "cb2d86ea52d81d12d1fe8eadfb4a118c", 2438763, 404),
 
 	// Developed and published by Headbone Interactive, Seattle
+	// Demo contains Apparelizer 1.0 minigame; Found on Disc Inferno from APC magazine (Australia), Dec 1999
 	MACGAME1("elroycostume", "", "Elroy's Costume Closet", "0c7bbb4b24823e5ab871cb4c1d6f3710", 483746, 404),
 	WINGAME1("elroycostume", "", "ECCLOSET.EXE", "f2fb9b1c60d3d1ee2b664165f4199391", 1327420, 404),
+	WINDEMO1("elroycostume", "Demo", "elroy.exe", "9d18c6a224dd0e5be4ad03a05c74254b", 854349, 400),
 
 	MACGAME1("elroypave", "", "Elroy Hits the Pavement", "17efee018a660458fae80de4364021ac", 525840, 404),
 	WINGAME1("elroypave", "", "PAVEMENT.EXE", "7937f42747788b558bc32cced3d8f66b", 758491, 404),
@@ -3378,6 +3474,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	WINDEMO1("encarta95", "1995 Demo", "ENCARTA.EXE", "54a60641ccd62a49891aaa8329c97f46", 12015231, 404),
 
+	// From CD Loisirs Nº6
+	MACDEMO1("ephemeralfilms", "Demo", "Ephemeral Films", "77f4098988d5386794d1530065f514cd", 301669, 400),
+
 	WINDEMO1("exos", "Demo", "EXOSDEMO.EXE", "e26dc25e9f03c4343375e84521dc0c7d", 4001759, 404),
 
 	MACDEMO1_l("expbooktoolkit2", "1.5 Demo", "T2v1.5 DEMO", "0c7bbb4b24823e5ab871cb4c1d6f3710", 502657, Common::JA_JPN, 404),
@@ -3390,6 +3489,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME2_l("explorers", "", "XPLRNW.EXE",	"907c28b272eb40fad1b5f42ec841b010", 696741,
 								"STARTEXP.DIR", "3c3ab943769c548856d7cd84a8f808ec", 11198, Common::PT_BRA, 404),
 
+	// From MacFormat #42
+	MACDEMO1("eyewitnessscience", "", "SCIENCE", "ec8ef0209ab8e43a803b5c283c3ce8fb", 310482, 403),
+
 	WINDEMO1t("famalbum", "Tour", "TOUR.EXE", "73b4edd8e627dc50d8107913d9386c9a", 1962659, 404),
 
 	WINDEMO1("famdoc4", "1995 Demo", "BUBBA.EXE", "40e115073d00b7b763ff63b49e0ff798", 9322307, 404),
@@ -3399,15 +3501,16 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Decomposed variant of the above
 	MACGAME1_l("fantasystudio", "", "xn--2bkaw2bxdbn9bd8s8lyd", "da0da5d543b237051975ad70bec129f4", 484743, Common::JA_JPN, 404),
 
+	// Full game is D3
 	MACDEMO1_l("fantazion", "Demo", "Demo-16M", "77f4098988d5386794d1530065f514cd", 303309, Common::JA_JPN, 400),
 
 	// Mac version requires installation, Felix Cartoon Toolbox Installer, uses Smaller Installer by Cyclos
-	MACGAME1("fct",		  "", " Felix Cartoon Toolbox", "7446214d1f3b0309e51bc477b03096c9", 295690, 404),
-	WINGAME1("fct",		  "", "FELIX.EXE",	  "6475efb8f19537e6753ba898daaf8c8d", 694477, 400),
+	MACGAME1("fct",		  "", " Felix Cartoon Toolbox",	  "7446214d1f3b0309e51bc477b03096c9", 295690, 404),
+	WINGAME1("fct",		  "", "FELIX.EXE",				  "6475efb8f19537e6753ba898daaf8c8d", 694477, 400),
 	MACGAME1("fctplayer", "", "Mac Felix Cartoon Player", "7446214d1f3b0309e51bc477b03096c9", 295667, 404),
-	WINGAME1("fctplayer", "", "PLAYER.EXE",	  "194c9d45a603a1a131c39ac43b54d8aa", 834551, 404),
-	WINGAME1("fctexport", "", "TRANSFMR.EXE", "ca58379b982a714d975358421fe4be50", 1542693, 400),
-	MACDEMO1("fct",		  "Demo", "BIG TOP DEMO", "ea646eccc9a53f44ce082459d4809a06", 486703, 404),
+	WINGAME1("fctplayer", "", "PLAYER.EXE",				  "194c9d45a603a1a131c39ac43b54d8aa", 834551, 404),
+	WINGAME1("fctexport", "", "TRANSFMR.EXE",			  "ca58379b982a714d975358421fe4be50", 1542693, 400),
+	MACDEMO1("fct",	  "Demo", "BIG TOP DEMO",			  "ea646eccc9a53f44ce082459d4809a06", 486703, 404),
 
 	WINGAME1("flw", "", "FLW.EXE", "7d02787f74f2adfc0c66f34646380c0e", 720683, 400),
 
@@ -3455,8 +3558,10 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINDEMO2("frankrw", "Demo", "TITLE.EXE", "8879c4196154261cba4cba13fd8e6497", 696855,
 								"TITLE.DXR", "e2b2e3bdf7d87ecd98e9bb768b7ed555", 2371220, 404),
 
+	// Mac demo from CD Loisirs Nº6
 	MACGAME1("freakshow", "D4", "FreakShow Projector", "dc5a87dda7a0daf46604515f7d2cca66", 300644, 400),
 	WINGAME1t("freakshow", "", "INSTALL/FREAKS.EXE", "e36cf1ec95f220eb165f38b0e7b572a5", 695893, 400),
+	MACDEMO1("freakshow", "Demo", "Freak Show", "77f4098988d5386794d1530065f514cd", 301669, 400),
 
 	// http://discogs.com/release/2052805
 	// Remastered album released by Euro Ralph, Hamburg (1994)
@@ -3479,13 +3584,17 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1("futurepromotion", "", "FUTURE",  "2885d9aacbeaecf4a27a7978a6b55c9b", 290474, 400),
 	WINGAME1t("futurepromotion", "", "FUTURE.EXE",  "a8e1020f952480d98920b1c7cc08644d", 6099243, 400),
 
-	// Developed by De Agostini Multimedia, Novara, Piedmont, Italy (1995)
+	// Developed by DeAgostini Multimedia, Novara, Piedmont, Italy (1995)
 	// Original Italian title is Fuzzy e Floppy: Il mistero dell'ape d'oro
+	// Spanish title: Fuzzy & Floppy: Las Aventuras de La Abeja de Oro
+	// German title: Fuzzy & Floppy auf der Jagd nach der goldenen Biene
 	// English version by Macmillan Interactive Publishing (MIP), London
 	MACGAME1("fuzzyfloppy1", "", "Fuzzy & Floppy (PPC)", "25e6bf9372fb9350b0873a2c1c66e312", 60068, 404),
 	WINGAME1t("fuzzyfloppy1", "", "BEE.EXE", "f60a44f4c3fe602685f972e16746040d", 696827, 404),
 	WINGAME1_l("fuzzyfloppy1", "", "APEDORO.EXE", "317dfcb883a6dd59129606adcd3ffdcb", 696827, Common::IT_ITA, 404),
 	WINDEMO1t("fuzzyfloppy1", "Demo", "APE.EXE", "f60a44f4c3fe602685f972e16746040d", 696827, 404),
+
+	WINGAME1t_l("fuzzyfloppy2", "", "ROTONDA.EXE", "99b7160243ac5807dc1e39c603284620", 701131, Common::IT_ITA, 404),
 
 	// Original filename 'がんばれ！いぬちゃん'
 	MACGAME1_l("ganbareinuchan", "", "xn--n8jp8dzbs1jpcwcg96593c", "411051c134236a9ead0d0d1837aafb5e", 290426, Common::JA_JPN, 402),
@@ -3566,8 +3675,13 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACDEMO1("goldilocks", "Sampler", "Goldilocks Gamebook Sampler", "cbce20666bfe47a9533331c6be1e6039", 285267, 403),
 	// from http://web.archive.org/web/20051126063716id_/http://www.beachware.com/download/goldsea.exe (self-extracting ZIP)
 	WINDEMO1t("goldilocks", "Sampler", "GOLDILKS.EXE", "a59533f9043f9e642fc17d39c843d55b", 1894363, 404),
+	WINDEMO1t("goldilocks", "Sampler", "GOLDILKS.EXE", "a59533f9043f9e642fc17d39c843d55b", 1894348, 404),	// if extracted using 7zip
 
-	WINGAME1("gordak", "", "GordakCD.exe", "d3dcd15712e8ac16cb88d86af9cd64bf", 737262, 404),
+	// Both versions require installation
+	// Mac: "Gord@k Mac Installer", VISE 3.5 installer
+	// Win: SETUP32.EXE, InstallShield v3
+	MACGAME1( "gordak", "", "GORDAK",		"5f48d38b0c9b9c8790796d1eb1525713", 486726, 404),
+	WINGAME1t("gordak", "", "GordakCD.exe", "0d9d03bf2462f22aed3cd3e7d49018df", 737262, 404),
 
 	MACDEMO2_l("greetingstudio", "Demo", "Click Me",   "17efee018a660458fae80de4364021ac", 484351,
 										 "MAIN.DIR",   "f5f8e6c76bb0659fc80fa2c1c263afa9", 3016176, Common::JA_JPN, 404),
@@ -3680,9 +3794,10 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1_l("hibino", "", "INTERACTIVE EXHIBITION ppc", "422270206b9bd6aff43bbe95047f6ce9", 59757, Common::JA_JPN, 404),
 	WINGAME1t_l("hibino", "", "HIBINO.EXE", "58bc10d8a9cf443e9451dd2c0325e23e", 747203, Common::JA_JPN, 404),
 
-	MACGAME1_l("hidoiyo", "Dai-ichi-wa", "xn--n8jwd0a9fz90pnw8c3lwa", 	   "35707ed8fa1cb9a3cb643b51681cd0a9", 290398, Common::JA_JPN, 402),
-	MACGAME1_l("hidoiyo", "Dai-ni-wa ",  "xn--n8jwa0f9a2hxc9690agv6dhz2a", "35707ed8fa1cb9a3cb643b51681cd0a9", 290398, Common::JA_JPN, 402),
-	MACGAME1_l("hidoiyo", "Dai-san-wa",  "xn--n8jwa0f9a2hxcs640aeqxehz2a", "35707ed8fa1cb9a3cb643b51681cd0a9", 290398, Common::JA_JPN, 402),
+	// Original Mac filenames are "ひどいよ第一話", "ひどいよくん第二話", "ひどいよくん第三話"
+	MACGAME1_l("hidoiyokun", "Dai-ichi-wa", "xn--n8jwd0a9fz90pnw8c3lwa", "35707ed8fa1cb9a3cb643b51681cd0a9", 290398, Common::JA_JPN, 402),
+	MACGAME1_l("hidoiyokun", "Dai-ni-wa ", "xn--n8jwa0f9a2hxc9690agv6dhz2a", "35707ed8fa1cb9a3cb643b51681cd0a9", 290398, Common::JA_JPN, 402),
+	MACGAME1_l("hidoiyokun", "Dai-san-wa", "xn--n8jwa0f9a2hxcs640aeqxehz2a", "35707ed8fa1cb9a3cb643b51681cd0a9", 290398, Common::JA_JPN, 402),
 
 	// Found on Uki Uki 3 CD
 	// Original movie filename is デモ
@@ -3704,10 +3819,16 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1_l("horrortour2", "", "ZEDDAS PowerPC", "da7d3f1d85bdb99518b586c40d2a673e", 60013, Common::JA_JPN, 400),
 	WINGAME1_l("horrortour2", "", "HT2.EXE", "499d8545ee2325b18d3f09fb2c0fc26e", 698029, Common::JA_JPN, 400),
 
+	// Developed by Michael Eleftheriades
+	// Mac version from The Mac CD-ROM 6
+	// Windows version from CD-ROM Now issue #7 '94
+	MACGAME1("housejam", "", "HOUSEJAM", "6ba1e12a35baf58a0d61f537e7489010", 283046, 404),
 	WINGAME1t("housejam", "", "HOUSEJAM.EXE", "f00912d1c03213bb002d3062cbd1d123", 12034983, 404),
 
 	// Full game is supported in SCI engine
 	WINDEMO1t("hoyle5", "Demo", "HOYLE5.EXE", "499760334d09425e80c69e9a1b178ec5", 6287863, 404),
+
+	MACGAME1("hurlman", "", "Hurlman", "6385f77fa00b44ccbb04258b864eeae6", 338931, 400),
 
 	// full game is not Director
 	WINDEMO1("hyperblade", "Demo", "HYPER.EXE", "4a8fd0d74faef305bc935e1aac94d3e8", 712817, 400),
@@ -3720,6 +3841,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1t("hotwheelswiener", "", "WIENER.EXE", "6d0228018fb293aa6e48b2a51e273e4d", 1391592, 404),
 
 	MACGAME1("hunchback", "", "Hunchback", "17efee018a660458fae80de4364021ac", 481226, 404),
+	WINGAME1t("hunchback", "", "HUNCH.EXE", "27d1a388006a4b2d63b1810248a55b14", 25837061, 404),
 
 	WINGAME1("id4p1", "iD4 Mission Disk 1 - Alien Supreme Commander", "SUPREME.EXE", "629eb9a5d991a2dbe380804e8c37043a", 1664965, 400),
 	WINGAME1("id4p2", "iD4 Mission Disk 2 - Alien Science Officer", "SCIENCE.EXE", "812a4b81b70e61e547c14dbbd507b402", 1766499, 400),
@@ -3733,9 +3855,11 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1("id4p10", "iD4 Mission Disk 10 - Alien Bomber", "BOMBER.EXE", "17758a9f425f7f3e7a926951e6c770f4", 1844189, 400),
 	WINGAME1("id4p11", "iD4 Mission Disk 11 - Area 51", "AREA51.EXE", "78be40f9c7e8e1770c388cc16a522aaf", 1776077, 400),
 
+	// From More MacCube, disc 3
+	MACGAME1("illusions", "", "ILLUSIONS", "7fd44b6dffa0ea0402eaed4c3769b39b", 285282, 404),
+
 	MACGAME1_l("illustratorsamerica", "", "IIA.PPC", "da7d3f1d85bdb99518b586c40d2a673e", 63845, Common::JA_JPN, 403),
 	WINGAME1t_l("illustratorsamerica", "", "IIA.EXE", "77a83014d697fbb3f908739b03e8341a", 771599, Common::JA_JPN, 404),
-
 
 	MACDEMO1("imagineers", "Portfolio", "The Imagineers Demo", "f00c61f30719f8ed5f64ddff2e3c7268", 482302, 404),
 
@@ -3802,6 +3926,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACDEMO1("iona", "'96", "IONA DEMO", "547fefcd6bda748214be2068a7bcdead", 292216, 404),
 	WINDEMO2("iona", "'96", "DEMO.EXE", "95a3aeb1017546da820a8d3c95d3c4e4", 1946711,
 							"MAIN.DIR", "71eacbde48a94043390d7dab58b8bb52", 1812168, 404),
+	// Iona + Edmark catalog
+	WINDEMO2t("iona", "'96+Edmark", "DEMO.EXE",		"103e0c6cce7f5f1f61580dc6913f273c", 1060457,
+									"EDMOVIES/BBH", "3ada3c95704cafcbee5c96e7d2216c4c", 3051912, 404),
 
 	WINGAME1_l("ios", "",	 "IOS.EXE", "2b8edd5af0f79d84542c57754b7fbf61", 1004833, Common::JA_JPN, 404),
 	WINGAME1_l("ioshow", "", "HOW.EXE", "a526a724f26e266b17815b4f7f7ae079", 1863309, Common::JA_JPN, 404),
@@ -3815,6 +3942,10 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1("isis", "", "ISIS.EXE", "59c1cb960199dd3f041262ab5271bb23", 14747213, 400),
 	MACGAME1_l("isis", "", "ISIS", "dedfabf9ee7bf5aab003bdab4137bca6", 780610, Common::DE_DEU, 400),
 	WINGAME1_l("isis", "", "ISIS.EXE", "d7f7e89495ac22c75b3fc04c09675b6e", 16750643, Common::DE_DEU, 400),
+
+	WINDEMO1t("it1d", "Demo", "INTHE1ST.EXE", "b6c6fd5d3cdb941f63128e13716c2f68", 2597207, 400),
+	// found on PC Format CD-ROM Collection 19
+	WINDEMO1t("it1d", "Demo", "INTHE1ST.EXE", "685717457c3219012eda7403579f94c9", 2576067, 400),
 
 	MACGAME1("iwave", "Issue 1", "!", "ae7178ba5dd9dcd15fb7a27cd99089b2", 484389, 400),
 	WINGAME1("iwave", "Issue 1", "IWAVE.EXE", "67aa1f75dc23e071e5325be04e9738a6", 690955, 400),
@@ -3958,12 +4089,18 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1("louvre", "", "Louvre 5 Mo", "a685f1809706f42bff5f3ee94f606065", 483774, 404),
 	WINGAME1("louvre", "", "LOUVRE.EXE", "f575ed4b37c05ab4249f9d6d3c3d7e17", 698829, 404),
 
+	// From MacFormat #44
+	MACGAME1("lovinghenry", "", "Loving Henry", "041f913ae9bfaebe53a238c14a7281e0", 291052, 403),
+
 	// Win/Mac versions are D3
 	PIPGAME1_l("lzone", "", "L-ZONE", "07c3095bd36e5aed00ba12f17f761070", 60096, Common::JA_JPN, 400),
 
 	// Pre-rendered CG animated adventure based on the popular comedy manga
 	// Developed by Future Pirates, published by Toshiba EMI
 	MACGAME1_l("macaroni", "", "Macaroni.PowerMac", "be7faef1b5c713e2d13a693eb6e1f5c9", 180281, Common::JA_JPN, 404),
+
+	// From CD Loisirs Nº6
+	MACDEMO1("macbeth", "Demo", "Macbeth", "77f4098988d5386794d1530065f514cd", 301669, 400),
 
 	MACDEMO1("macos8", "Tour", "Mac OS 8 Tour", "2332900b20b0d33e0617e5e7505923e8", 776072, 404),
 
@@ -4000,6 +4137,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	MACDEMO1_l("manhole", "Masterpiece Edition Demo", "The Manhole DEMO", "583a2d78dfcc184f2fbabfd3187322c1", 301861, Common::JA_JPN, 400),
 	MACDEMO1_l("manhole", "Masterpiece Edition Demo", "The Manhole DEMO", "583a2d78dfcc184f2fbabfd3187322c1", 301669, Common::JA_JPN, 400),
+
+	MACGAME1("marathonsecrets", "v1.0", "Marathon Secrets 1.0", "cdb27c916044ae4dceb4b7326063fa03", 301669, 400),
 
 	// Windows version on same disc is D3
 	MACGAME1("mask", "", "The Mask", "32a48ccef630fd453ac3501f72474545", 291308, 403),
@@ -4049,14 +4188,13 @@ static const DirectorGameDescription gameDescriptions[] = {
 								  "HOMECRE.DIR", "c01c5736dd1a49f52169c01e8d39a998", 1313276, 404),
 
 	WINGAME1("mckenzie", "", "MCKFRAME.EXE", "581608fa7224b0b62e11e397d2aa76c1", 3217950, 404),
-	WINDEMO1("mckenzie", "November 16", "MCKDEMO.EXE", "f2bc8c75f8df853780619583ba216beb", 8634631, 404),
-	WINDEMO1t("mckenzie", "30 Megs", "MCKDEMO.EXE", "7f524fed018d3455c0a9358b34543123", 7212177, 404),
+	WINDEMO1("mckenzie", "November 16 Demo", "MCKDEMO.EXE", "f2bc8c75f8df853780619583ba216beb", 8634631, 404),
+	WINDEMO1t("mckenzie", "30 Megs Demo", "MCKDEMO.EXE", "7f524fed018d3455c0a9358b34543123", 7212177, 404),
 
 	WINGAME1("mckenziemf", "", "MCKFRAME.EXE", "49c04e880f314a4965d21273df4f2dee", 4038355, 404),
 
-	WINGAME2t("mcluhan", "", "mcluhan/mcluhan.exe", "317d00bfea3c27688462f01bdd6ac2aa", 3587645,
-							 "fg/sunmorn.mov", "baee2df57be48984fabb721ce996b224", 1331857, 404),
-	MACGAME1("mcluhan", "", "McLuhan Folder/McLuhan.dxr", "ce91eb31b2fcebc26451e0cc1632a964", 44371496, 404),
+	WINGAME1t("mcluhan", "", "MCLUHAN/MCLUHAN.EXE", "317d00bfea3c27688462f01bdd6ac2aa", 3587645, 404),
+	MACGAME1("mcluhan", "", "McLuhan Folder/Understanding McLuhan", "f18e1cf6fb9fea099aae580c2057e551", 308558, 404),
 
 	WINDEMO1t("mcmillennium", "Demo", "MILLDEMO.EXE", "028a149906ca490f8634e30c6b3c3957", 3630918, 404),
 
@@ -4168,8 +4306,10 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1("mummy", "", "MUMMY", "01be45e7241194dad07938e7059b88e3", 503560, 400),
 	WINGAME1("mummy", "", "MUMMY.EXE", "2ebe3a4ef8c128db46794333d4b61c36", 2939630, 404),
 
-	// Full game is not Director
-	WINDEMO1("muppets", "Demo", "MUPPETS.EXE", "4a8fd0d74faef305bc935e1aac94d3e8", 712817, 400),
+	// Demo for a game that is detected in mTropolis engine
+	WINDEMO1("mti", "Demo", "MUPPETS/MUPPETS.EXE", "4a8fd0d74faef305bc935e1aac94d3e8", 712817, 400),
+
+	MACDEMO1("multimediastudio", "Demo", "Cartoon Studio", "9414302660bf6b78d3866199d3476128", 288891, 403),
 
 	// English version is D3
 	MACGAME1_l("murdertaylor", "", "Taylor French", "dc839fb9e2f8e6bfc4f4f995c57df495", 291683, Common::DE_DEU, 400),
@@ -4210,6 +4350,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACDEMO1_l("nendo", "Demo Movie", "xn--Nendo -8v4emd6eta10ab", "bcd3c718db258701496b3c5bcb827ef2", 481803, Common::JA_JPN, 404),
 	// decomposed version of the filename above
 	MACDEMO1_l("nendo", "Demo Movie", "xn--Nendo -1m4ea71b5dvgxa35ac", "bcd3c718db258701496b3c5bcb827ef2", 481803, Common::JA_JPN, 404),
+
+	MACGAME1("netmaze", "v1.1", "Netmaze 1.1", "ea646eccc9a53f44ce082459d4809a06", 483518, 404),
 
 	WINDEMO1("newslinks", "Demo", "NEWS.EXE", "22900fa6922d71b1f880aa3cc0bbad1a", 16526563, 404),
 
@@ -4267,6 +4409,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	WINDEMO1("nyack", "Demo", "NYACKDEM.EXE", "8902ed0bcaf2d78151f819ba41eaf124", 720431, 404),
 
+	// From CD Loisirs Nº6
+	MACDEMO1("onevolution", "Demo", "Stephen Jay Gould", "77f4098988d5386794d1530065f514cd", 301669, 400),
+
 	WINGAME1("operafatal", "",	 "OPERA.EXE",		 "2b9da5566698a1f4b453e1a27e00ad29", 697739, 400),
 	MACGAME2("operafatal", "",	 "OPERA FATAL",		 "f5033f237ad1b1639fc46d01a82ac380", 285310,
 								 "Opera/SPRINT.Dxr", "3e86f01eeac5fa3349c5177378997a7f", 694912, 400),
@@ -4305,9 +4450,23 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1("painters", "", "PAINTERS.EXE", "3cba94b585493ef5f22d0d650b6eb7fd", 895727, 404),
 	MACGAME1("painters", "", "Painters Painting", "0a81aee4106eec4ffc0cc564a7c15a23", 288774, 404),
 
+	// Full version isn't Director
+	// Found on Electronic Entertainment CD-ROM Sampler Disc (December 1995)
+	WINDEMO1t("panicpark", "Demo", "PANIC!.EXE", "171360aac3ee8ebbb1eee36cebe703f2", 2013371, 404),
+	// Found on The Best of Select: Games Special 4, batch file is the only other file in the folder
+	WINDEMO2t("panicpark", "Demo", "PANIC.EXE", "9d0fe435d9becfcc67f7c25ad1f88102", 2370615,
+								   "GOWIN.BAT", "206e3ef43a49e92cda0727a3ba870dc5", 10, 404),
+
 	// Developed by Museworthy
 	MACGAME1("paparazzi", "", "MUSEWTHY/Paparazzi!", "0c7bbb4b24823e5ab871cb4c1d6f3710", 482610, 404),
 	WINGAME1t("paparazzi", "", "PPRAZZI.EXE", "2b0ea9256d85425a2a31e4bdf0ba3aa9", 5331351, 400),
+
+	// Windows version isn't Director
+	// Demo from CD Loisirs Nº6
+	MACGAME2("paperplanes", "", "Paper Planes", "cdb27c916044ae4dceb4b7326063fa03", 303933,
+								"Demo", "e704dc2489f81643aa7717105004bc9d", 1777750, 400),
+	MACDEMO2("paperplanes", "Demo", "Paper Planes", "cdb27c916044ae4dceb4b7326063fa03", 303933,
+									"Demo", "edceb9d0a3b4726dca10f8a825e20fee", 1895406, 400),
 
 	// Full version is bilingual. Demo is French only.
 	// Demo found on EMME Keys to Knowledge sampler CD
@@ -4338,6 +4497,18 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	MACGAME1_l("peepeebonbon", "", "PPBB.MAC", "33f733b2809b94c3301096902f642b6e", 289518, Common::JA_JPN, 402),
 	WINGAME1t_l("peepeebonbon", "", "PPBB.EXE", "ccfe8e10528261b78f4a8c9657a54ff8", 746983, Common::JA_JPN, 404),
+
+	// Original filename is 'ペペロン村の四季'
+	MACGAME1_l("pepperon", "", "xn--u9j2la0f4a9404c9vg8wz", "8b138db44d4421cc7294a9dc792ccf1b", 521283, Common::JA_JPN, 404),
+	// Decomposed variant of the above
+	MACGAME1_l("pepperon", "", "xn--u9jtea0wb1ktbx480dksir53a", "8b138db44d4421cc7294a9dc792ccf1b", 521283, Common::JA_JPN, 404),
+	WINGAME1t_l("pepperon", "", "PEPPERON/START95.EXE", "b7fd4c43d44291a15ef1829e96652a5b", 1094585, Common::JA_JPN, 404),
+	// French version titled "Valmaison au fil des saisons"
+	MACGAME1_l("pepperon", "", "Valmaison", "8b138db44d4421cc7294a9dc792ccf1b", 502569, Common::FR_FRA, 404),
+	WINGAME1_l("pepperon", "", "PEPPERON/START95.EXE", "4086df04abc18956581cee17b48e81c1", 1805439, Common::FR_FRA, 404),
+	// Dutch version titled "Op avontuur in kabouterstad"
+	WINGAME2t_l("pepperon", "", "START95.EXE", "7dbb1621a27aea372c06a156197de57f", 1088309,
+								"OPENN.DIR", "2effe5cc59f2262fcf204a479c027de3", 1807124, Common::NL_NLD, 404),
 
 	MACGAME1_l("planetdob", "", "Planet Dob", "01be45e7241194dad07938e7059b88e3", 484095, Common::JA_JPN, 404),
 
@@ -4420,6 +4591,11 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1("planetarizona", "", "Planet Arizona", "0c7bbb4b24823e5ab871cb4c1d6f3710", 488433, 400),
 	WINGAME1("planetarizona", "", "ARIZONA.EXE", "a23462ec87eff973d2cdb2ddfd4a59fa", 698651, 400),
 
+	// Mac demo from MacFormat #44
+	// Win demo from Computer Buyer v17n68 (January 1997)
+	MACDEMO1("planetearth", "Demo", "Planet Earth", "a546ef2b921a9b48fd93928f1a505f22", 483490, 404),
+	WINDEMO1t("planetearth", "", "PLANETE.EXE", "1ab2d4f204eb42c9a8ff5257f7cef149", 690069, 404),
+
 	// Found on the Play-Doh Creations CD
 	MACGAME1("playskool", "",  "goHIGmem PPC", "a6043fbba9186296faf8a2b82e5e4182", 64250, 404),
 	WINGAME2t("playskool", "", "SAMPLER.EXE",  "4de224099dd6f16d5c9892f94c975f2a", 696951,
@@ -4427,6 +4603,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	// Distributed with Vote America demo
 	WINGAME1t("poliq", "", "POLIQ.EXE", "08ea6f2f9af69af4d70967870fd92f81", 1376591, 404),
+
+	MACGAME1("popapenguin", "", "pwrmacp", "ccf864a8dc6e9d0d26eb73b4683e634b", 61012, 404),
 
 	MACGAME1_l("popup", "", "POP UP COMPUTER", "c1c73a286e7fdb439c8d49c79a2d9997", 318305, Common::JA_JPN, 400),
 	WINGAME1_l("popup", "", "POPUP.EXE", "f47f7663a75120eca6c9e91025d51786", 65216494, Common::JA_JPN, 400),
@@ -4562,8 +4740,16 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	WINDEMO1("smashsounds1", "Demo", "SMASH.EXE", "cc9f6f623ef61d2ac364eb41f65957ed", 2076581, 404),
 
+	// Previous versions are D3
+	// Demo from Software of the Month Club (May 1996)
+	WINDEMO1t("smile", "v1.2", "smiledmo.exe", "72fefa3c49aa47731e6ab0bb076ccca7", 1872801, 400),
+
 	// German version of Silly Noisy House (1999)
 	WINGAME1_l("snh", "", "DBBBH.EXE", "9e13813fd39da5e27627ee28894d6ec0", 738336, Common::DE_DEU, 404),
+
+	// From Blender 1.5
+	MACGAME1("sonywalkman", "", "SONY AD LAUNCHER", "0c7bbb4b24823e5ab871cb4c1d6f3710", 481254, 404),
+	WINGAME1t("sonywalkman", "", "SONY.EXE", "9858a13454c751dc1eb7527cff4ba0c8", 710099, 404),
 
 	MACGAME1("sorgato", "", "SORGATO'S VARIABLE COLOR", "4011dd51c0eed1b5cf1fbf55360a7f60", 304189, 400),
 
@@ -4576,8 +4762,16 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	MACGAME1("spacestationalpha", "", "The Encounter 16+MB", "e019f541a05887922e2ee19bcff5bb25", 483774, 404),
 
+	MACGAME1("spitwad", "", "HSH", "f5033f237ad1b1639fc46d01a82ac380", 283018, 404),
+
+	MACGAME1("springhead", "", "Springhead", "e6833f1ce3b022f0128e4c80a55bcd46", 288490, 404),
+
 	// Full game is not Director
 	WINDEMO1("spycraft", "Demo", "SPYCRAFT.EXE", "4a8fd0d74faef305bc935e1aac94d3e8", 712817, 400),
+
+	// Original filename is 東北新社･ｻﾝﾗｲｽﾞﾛﾎﾞｯﾄ編
+	MACGAME1_l("srdsunrise", "", "xn--djrs64bpib449aukfxo2t9baxa4fva2f2f0eoc0atc", "1c2e5371b835680e7c1ca8bcea008bef", 502589, Common::JA_JPN, 404),
+	WINGAME1t_l("srdsunrise", "", "SRR_2.EXE", "3da1ce225f70e341500d0995e575f0e6", 747123, Common::JA_JPN, 404),
 
 	MACGAME1("sscocacola", "", "Coca-Cola Animations", "6e86a061950bc3987ce2ddf531bfde34", 295426, 403),
 	MACGAME1("ssdietcoke", "", "DietCoke Animations", "6e86a061950bc3987ce2ddf531bfde34", 295426, 403),
@@ -4618,6 +4812,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1("teamxtreme1", "", "XTREME.EXE", "45ab80997efedec388ff5200722e673c", 690123, 400),
 	WINGAME1("teamxtreme2", "", "TX2.EXE", "50c80bd2add25e574494838772973beb", 2585471, 400),
 
+	// From MacFormat #42
+	MACDEMO1("texturescape", "", "TextureScape Show", "77f4098988d5386794d1530065f514cd", 303961, 400),
+
 	// Mac full executable name is ハイ！鉄マンです
 	// Mac demo executable name is デモ
 	MACGAME1_l("tetsuman", "",	   "Tetsuman",		"bcd3c718db258701496b3c5bcb827ef2", 484323, Common::JA_JPN, 404),
@@ -4649,6 +4846,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	// Mac version is not Director
 	WINGAME1("thinkinthingsdp", "", "PARENTS.EXE", "4e82061a925caa16320c52b38aeb68c5", 1160899, 400),
+
+	// From CD Loisirs Nº6
+	MACDEMO1("thisisspinaltap", "Demo", "Spinal Tap", "79f66d95f0089330fa2d3d12a3cc0b2e", 291972, 403),
 
 	// Korean Windows version is named 'Time Girl'
 	WINGAME1_l("timegal", "", "TIMEGIRL.EXE", "0e5a7734bdc74198a62171ea4d51a364", 687457, Common::KO_KOR, 400),
@@ -4706,6 +4906,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Spanish title is Verdades y Ficciones
 	MACGAME1("truthsfictions", "", "Truths & Fictions", "4577dd3eadc467a986ab172d90871b22", 534968, 404),
 
+	WINGAME1t("ugtmk", "", "TUG2MK.EXE", "3612d22c5c2f6bda8449828eaf338173", 692411, 404),
+
 	// Original filenames are 合わせ月の夜 (disc 1), フェンネル (disc 2), いにしえびと (disc 3)
 	MACGAME1_l("twistynight1", "", "Moonlit Night", "8ea9e9a699c61edddffd79ddd0c994d7", 290682, Common::JA_JPN, 402),
 	MACGAME1_l("twistynight2", "", "Fennel", "8ea9e9a699c61edddffd79ddd0c994d7", 290682, Common::JA_JPN, 402),
@@ -4760,17 +4962,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	WINGAME1t("ushistory", "", "HISTORY.EXE", "5660e6a7b772b5bf8867627ab0d7a58b", 703629, 404),
 
-	// Original filename is 'ペペロン村の四季'
-	MACGAME1_l("pepperon", "", "xn--u9j2la0f4a9404c9vg8wz", "8b138db44d4421cc7294a9dc792ccf1b", 521283, Common::JA_JPN, 404),
-	// Decomposed variant of the above
-	MACGAME1_l("pepperon", "", "xn--u9jtea0wb1ktbx480dksir53a", "8b138db44d4421cc7294a9dc792ccf1b", 521283, Common::JA_JPN, 404),
-	WINGAME1t_l("pepperon", "", "PEPPERON/START95.EXE", "b7fd4c43d44291a15ef1829e96652a5b", 1094585, Common::JA_JPN, 404),
-
-	// French version titled "Valmaison au fil des saisons"
-	MACGAME1_l("pepperon", "", "Valmaison", "8b138db44d4421cc7294a9dc792ccf1b", 502569, Common::FR_FRA, 404),
-	WINGAME1_l("pepperon", "", "PEPPERON/START95.EXE", "4086df04abc18956581cee17b48e81c1", 1805439, Common::FR_FRA, 404),
-	// Dutch version titled "Op avontuur in kabouterstad"
-	WINGAME1_l("pepperon", "", "START95.EXE", "e67abd6a890060fa8c41b7b363013254", 1088309, Common::NL_NLD, 404),
+	// System 6 version is D3
+	MACGAME1("videocasino", "", "xn--Video Casino PowerMac-pb4m", "ccf864a8dc6e9d0d26eb73b4683e634b", 60068, 404),
+	MACDEMO1("videocasino", "Demo", "VC.Demo.14.7.Start", "17efee018a660458fae80de4364021ac", 483490, 404),
 
 	// Demo covering various Voyager Japan discs
 	// Original filename is 'キッズ CD-ROM'
@@ -4798,8 +4992,19 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1("vnc", "", "VNC.EXE", "40ba00213a10164eb6e01847108f9b21", 1086869, 404),
 	WINGAME1("vnc", "Beta", "VNC.EXE", "e6f284971c09f19e3277aa8ebcf58cbd", 726643, 404),
 
+	// Mac version requires installation, 'Install Voodoo Lounge', StuffIt
+	MACGAME1("voodoolounge",  "",	   "Voodoo Lounge", "b7e69c37b7355022d400c14aa97c5d54", 502080, 404),
+	WINGAME2t("voodoolounge", "",	   "VOODOO.EXE", "09553ceec915a1eeb9a990245bfd189b", 866187,
+									   "VLMOVIES/16_VIPLG.DXR", "9ca1989d17bf1946b6349027eb8b681b", 3344100, 404),
+	MACGAME1("voodoolounge",  "Raver", "Voodoo Raver", "b7e69c37b7355022d400c14aa97c5d54", 499816, 404),
+	WINGAME1t("voodoolounge", "Raver", "SCRNRAVE.EXE", "0b6366628443168328b40c0660741ed8", 696751, 404),
+	WINDEMO2t("voodoolounge", "Demo",  "VOODOO.EXE", "0122b7c0fb828771d6dc589bba448e01", 1119265,
+									   "VLMOVIES/16_VIPLG.DXR", "53e5b7f4aad56a651d9e00ed7b7bd70d", 6901738, 404),
+
 	// English Windows version also contains this application
-	// "The PC version is launched from a very simple projector called "GOPREV.EXE", which lives in the "SUPPL" folder. The installer copies this executable to a directory on the hard drive, and creates a lingo.ini file that puts the drive letter of the CD-ROM drive into a global called CDPath. This projector calls the movie CDPath&"PREVIEW.DIR"."
+	// "The PC version is launched from a very simple projector called "GOPREV.EXE", which lives in the "SUPPL" folder.
+	// The installer copies this executable to a directory on the hard drive, and creates a lingo.ini file that puts the
+	// drive letter of the CD-ROM drive into a global called CDPath. This projector calls the movie CDPath&"PREVIEW.DIR"."
 	// WINGAME1t("vygrpresents", "Installed", "GOPREV.EXE", "d6cbe5df16170418dee965c5bc1d5e87", 712453, 400),
 	// Japanese version is Mac-only
 	MACGAME1("vygrpresents", "", "Voyager Preview", "4efba92cbb95eff273c40e57d0f0f535", 296494, 403),
@@ -4967,6 +5172,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// GT Publishing, New York, ABCD-ROM series (1997)
 	WINGAME1("abclunch", "", "ABC95.EXE", "1a7acbba10a7246ba58c1d53fc7203f5", 1421779, 501),
 
+	// From Computer Buyer v17n68 (January 1997)
+	WINDEMO1t("acaciarevise", "", "PCDEMO.EXE", "203616f3f18a0f2a1a326ac1f6944028", 943091, 501),
+
 	WINGAME1t_l("acneattack", "", "Acne.exe", "9ec3d648c42e41cc2263d3c643d7ad1e", 1905311, Common::SE_SWE, 501),
 
 	// Installers for both platforms also use Director
@@ -5001,7 +5209,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Available here: http://web.archive.org/web/20080412010505/http://www.beachware.com/download/
 	// Each shareware title plays 1 of 2 arcade games until unlocked with registration code
 	// All games are also available and unlocked on the retail BeachWare Classic Arcade CD
-	MACGAME1("arcadeboing", "",	"Classic Arcade Boing!", "231d3041df162be4a0ddd36a74eb03b6", 719261, 501),
+	MACGAME1("arcadeboing", "",	"Classic Arcade Boing!", "231d3041df162be4a0ddd36a74eb03b6", 719005, 501),
 	WINGAME2("arcadeairattack", "", "shware32.exe", "1a7acbba10a7246ba58c1d53fc7203f5", 1410427,
 									"Bomber.Dxr",	"e2409782f6bfa16862fba0437c9cdf3d", 3443518, 501),
 	WINGAME2("arcadeboing", "",		"shware32.exe", "1a7acbba10a7246ba58c1d53fc7203f5", 1410427,
@@ -5029,6 +5237,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	WINDEMO1t("backpackerjr", "Demo", "BPJDEMO.EXE", "8320e90992dffe88d21d39743ed7b89e", 1418643, 501),
 	WINDEMO1t("backpackerjr", "Demo", "BPJDEMO.EXE", "8320e90992dffe88d21d39743ed7b89e", 1418681, 501),
+
 
 	// Requires installation, installer is also Director
 	WINGAME1_l("backpacker2", "", "BP2NEW.EXE", "842014a812b454620f64b860fd7211f0", 940821, Common::NB_NOR, 501),
@@ -5142,9 +5351,10 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1_l("clocksakura", "", "Sakura Tokei", "65063397536553c4f6ff2a6c07194bf7", 1602709, Common::JA_JPN, 500), // さくら時計
 	MACGAME1_l("clocktomoyo", "", "Tomoyo Tokei", "65063397536553c4f6ff2a6c07194bf7", 1602707, Common::JA_JPN, 500), // 知世時計
 
-	// Installer uses Director and Authorware
-	// Developed by Arome, distributed by Global Star Software
-	WINGAME1("cocktailhour", "", "COCKT32.EXE", "1a7acbba10a7246ba58c1d53fc7203f5", 1411465, 501),
+	// Launcher uses Director 6 and Authorware
+	// Developed by Arome Interactive, distributed by Global Star Software
+	// Requires installation, DATA.Z, InstallShield v3
+	WINGAME1t("cocktailhour", "", "COCKT32.EXE", "f594dd4e50ea175e8d3453b3cd16b536", 1411465, 501),
 
 	MACGAME1("colormind", "v1.5", "ColorMind 1.5", "37faaf693259d7a4fa031f4a2edf3098", 126087, 501),
 
@@ -5183,6 +5393,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Mini-game from Star Warped can also be launched separately
 	MACGAME1("deathstar", "Minigame", "Death Star Destructo", "11aea1c6868839f53cc6312df724364f", 107835, 501),
 	WINGAME1t("deathstar", "Minigame", "DSD32.EXE", "9e3c304fdd669c79b5670057557cd1fb", 2758841, 501),
+
+	// From MacFormat #42
+	MACGAME1("digihbd", "", "Digital Happy Birthday Card", "61f3e061ae6236d8f72312ae9de83f46", 703153, 500),
 
 	// Windows executables for Win 3.1 and 95; Mac executables for 68k, PPC, and Fat binary
 	MACGAME1("dimensionq", "", "Dimension Q", "c148f66ae3511fb88733102aa27efe7e", 719313, 501),
@@ -5266,40 +5479,30 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINDEMO1_l("ernie", "Demo", "ERNIE.EXE", "1a7acbba10a7246ba58c1d53fc7203f5", 1417371, Common::SE_SWE, 500),
 
 	// "Explore Space" 5 CD Bundle
-	MACGAME2("explorespace1", "", "Solar", 				  "231d3041df162be4a0ddd36a74eb03b6", 719005,
-								  "PROGRAM/456MAIN.Dxr",  "c6ce20cd8a95fd88aee9fabe8987aee6", 375330, 501),
-	WINGAME2("explorespace1", 	  "Win 95", "WIN95.EXE",  "1a7acbba10a7246ba58c1d53fc7203f5", 1411387,
-								  "PROGRAM/456MAIN.DXR",  "c6ce20cd8a95fd88aee9fabe8987aee6", 375330, 501),
-	WINGAME2("explorespace1", 	  "Win 3.1", "WIN31.EXE", "842014a812b454620f64b860fd7211f0", 933175,
-								  "PROGRAM/456MAIN.DXR",  "c6ce20cd8a95fd88aee9fabe8987aee6", 375330, 501),
+	MACGAME2("explorespace1", "", "Solar",				 "231d3041df162be4a0ddd36a74eb03b6", 719005,
+								  "PROGRAM/456MAIN.Dxr", "c6ce20cd8a95fd88aee9fabe8987aee6", 375330, 501),
+	WINGAME2("explorespace1", "", "WIN95.EXE",			 "1a7acbba10a7246ba58c1d53fc7203f5", 1411387,
+								  "PROGRAM/456MAIN.DXR", "c6ce20cd8a95fd88aee9fabe8987aee6", 375330, 501),
 
-	MACGAME2("explorespace2", "", "Mars", 				  "231d3041df162be4a0ddd36a74eb03b6", 719005,
-								  "PROGRAM/457MAIN.Dxr",  "9bb4f9407e4658f50ae970fc0a5133a6", 435968, 501),
-	WINGAME2("explorespace2", 	  "Win 95", "WIN95.EXE",  "1a7acbba10a7246ba58c1d53fc7203f5", 1411387,
-								  "PROGRAM/457MAIN.DXR",  "9bb4f9407e4658f50ae970fc0a5133a6", 435968, 501),
-	WINGAME2("explorespace2",     "Win 3.1", "WIN31.EXE", "842014a812b454620f64b860fd7211f0", 933175,
-								  "PROGRAM/457MAIN.DXR",  "9bb4f9407e4658f50ae970fc0a5133a6", 435968, 501),
+	MACGAME2("explorespace2", "", "Mars",				 "231d3041df162be4a0ddd36a74eb03b6", 719005,
+								  "PROGRAM/457MAIN.Dxr", "9bb4f9407e4658f50ae970fc0a5133a6", 435968, 501),
+	WINGAME2("explorespace2", "", "WIN95.EXE",			 "1a7acbba10a7246ba58c1d53fc7203f5", 1411387,
+								  "PROGRAM/457MAIN.DXR", "9bb4f9407e4658f50ae970fc0a5133a6", 435968, 501),
 
-	MACGAME2("explorespace3", "", "Sun_Moon", 			  "231d3041df162be4a0ddd36a74eb03b6", 719005,
-								  "PROGRAM/458MAIN.Dxr",  "78244a687f279eda8655ac9fd7ce5531", 531620, 501),
-	WINGAME2("explorespace3",     "Win 95", "WIN95.EXE",  "1a7acbba10a7246ba58c1d53fc7203f5", 1411387,
-							      "PROGRAM/458MAIN.DXR",  "78244a687f279eda8655ac9fd7ce5531", 531620, 501),
-	WINGAME2("explorespace3",     "Win 3.1", "WIN31.EXE", "842014a812b454620f64b860fd7211f0", 933175,
-								  "PROGRAM/458MAIN.DXR",  "78244a687f279eda8655ac9fd7ce5531", 531620, 501),
+	MACGAME2("explorespace3", "", "Sun_Moon",			 "231d3041df162be4a0ddd36a74eb03b6", 719005,
+								  "PROGRAM/458MAIN.Dxr", "78244a687f279eda8655ac9fd7ce5531", 531620, 501),
+	WINGAME2("explorespace3", "", "WIN95.EXE",			 "1a7acbba10a7246ba58c1d53fc7203f5", 1411387,
+								  "PROGRAM/458MAIN.DXR", "78244a687f279eda8655ac9fd7ce5531", 531620, 501),
 
-	MACGAME2("explorespace4", "", "Galaxy",			      "231d3041df162be4a0ddd36a74eb03b6", 719005,
-								  "PROGRAM/460MAIN.Dxr",  "4212a73dc3482104192ad4f0937446cf", 275180, 501),
-	WINGAME2("explorespace4",     "Win 95", "WIN95.EXE",  "1a7acbba10a7246ba58c1d53fc7203f5", 1411387,
-								  "PROGRAM/460MAIN.DXR",  "4212a73dc3482104192ad4f0937446cf", 275180, 501),
-	WINGAME2("explorespace4",     "Win 3.1", "WIN31.EXE", "842014a812b454620f64b860fd7211f0", 933175,
-								  "PROGRAM/460MAIN.DXR",  "4212a73dc3482104192ad4f0937446cf", 275180, 501),
+	MACGAME2("explorespace4", "", "Galaxy",				 "231d3041df162be4a0ddd36a74eb03b6", 719005,
+								  "PROGRAM/460MAIN.Dxr", "4212a73dc3482104192ad4f0937446cf", 275180, 501),
+	WINGAME2("explorespace4", "", "WIN95.EXE",			 "1a7acbba10a7246ba58c1d53fc7203f5", 1411387,
+								  "PROGRAM/460MAIN.DXR", "4212a73dc3482104192ad4f0937446cf", 275180, 501),
 
-	MACGAME2("explorespace5", "", "Space",				  "231d3041df162be4a0ddd36a74eb03b6", 719005,
-								  "PROGRAM/459MAIN.Dxr",  "3868e98be38c2fbff814e2b8f1663fc9", 376868, 501),
-	WINGAME2("explorespace5", 	  "Win 95", "WIN95.EXE",  "1a7acbba10a7246ba58c1d53fc7203f5", 1411387,
-								  "PROGRAM/459MAIN.DXR",  "3868e98be38c2fbff814e2b8f1663fc9", 376868, 501),
-	WINGAME2("explorespace5",     "Win 3.1", "WIN31.EXE", "842014a812b454620f64b860fd7211f0", 933175,
-								  "PROGRAM/459MAIN.DXR",  "3868e98be38c2fbff814e2b8f1663fc9", 376868, 501),
+	MACGAME2("explorespace5", "", "Space",				 "231d3041df162be4a0ddd36a74eb03b6", 719005,
+								  "PROGRAM/459MAIN.Dxr", "3868e98be38c2fbff814e2b8f1663fc9", 376868, 501),
+	WINGAME2("explorespace5", "", "WIN95.EXE",			 "1a7acbba10a7246ba58c1d53fc7203f5", 1411387,
+								  "PROGRAM/459MAIN.DXR", "3868e98be38c2fbff814e2b8f1663fc9", 376868, 501),
 
 	// Developed by Brilliant Interactive Ideas, published by Brainstorm
 	MACGAME1("flipper", "", "Flipper!",	  "6e7e31d05709e1d38d63f4df6a59eec0", 718381, 501),
@@ -5391,6 +5594,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME2("headbone", "Sampler 2", "SAMPLER.EXE", "c3c38bd3907ca7e13220b74bd0317a6c", 1019877,
 									  "DEMOS.DXR",	 "d8c086a6879d092b409110f9bf5b93de", 3016920, 500),
 
+	// From MacFormat #42, original file name 'HeadHunter™'
+	MACGAME1("headhunter", "", "xn--HeadHunter-398e", "315c637cac0a4b735dc6e3f7cb1842f7", 721143, 500),
+
 	// Hoffman + Associates previews. Found on Nikolai in Outer Space.
 	WINGAME1("hoffman", "", "HARUNNER.EXE", "3460ad87d2ba57104e2810a77b53c220", 1458773, 500),
 
@@ -5417,10 +5623,12 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	// Australian Broadcasting Corporation (ABC) has made this available for free download
 	// https://www.abc.net.au/science/ingenious/patch.htm
-	MACGAME1("ingenious", "",   "Ingenious",   "f5d1590da086b496507871f12382e973", 754833, 501),
-	WINGAME1("ingenious", "",   "INGW95.EXE",  "3460ad87d2ba57104e2810a77b53c220", 1398293, 500),
-	MACGAME1("ingenioused", "", "EdRes",       "f5d1590da086b496507871f12382e973", 754807, 501),
-	WINGAME1("ingenioused", "", "EDRES95.EXE", "1a7acbba10a7246ba58c1d53fc7203f5", 1417113, 501),
+	MACGAME1("ingenious", "",	 "Ingenious",	"f5d1590da086b496507871f12382e973", 754577,	 501),
+	WINGAME1t("ingenious", "",	 "INGW95.EXE",	"706038517a38b3b61f04ee783bcbfe78", 1398293, 501),
+	MACGAME1("ingenioused", "",	 "EdRes",		"f5d1590da086b496507871f12382e973", 754551,	 501),
+	WINGAME1t("ingenioused", "", "EdRes95.exe",	"ed161f0dbe88c909dac7f10535c340ad", 1417113, 501),
+	// from "Patch for Windows 2000 and Windows XP"
+	WINGAME1t("ingenious", "",	 "IngW95.exe",	"2c210cc563d5562741b34fb6156e37c3", 1414789, 501),
 
 	// Later releases are titled "I Spy School Days"
 	// Bilingual Spanish/English release by Star E-Media of Orange County, California
@@ -5474,7 +5682,13 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1t("kidsbox", "Normal", "KIDS_N.EXE", "7abed0fbe806404b5e4045927b293950", 1443095, 500),
 	WINGAME1t("kidsbox", "Slow", "KIDS_O.EXE", "7abed0fbe806404b5e4045927b293950", 1443093, 500),
 
-	MACGAME1("maccubed7", "", "Let's Go! Internet & Utilities", "5b3a7fa45ec7655c5f9b7fe39ae37a11", 705613, 500),
+	MACGAME1("maccubed", "Disc 1", "Let's Go! Arcade", "5b3a7fa45ec7655c5f9b7fe39ae37a11", 705357, 500),
+	MACGAME1("maccubed", "Disc 2", "Let's Go! Games", "5b3a7fa45ec7655c5f9b7fe39ae37a11", 705357, 500),
+	MACGAME1("maccubed", "Disc 3", "Let's Go! Kids, Board &Card", "5b3a7fa45ec7655c5f9b7fe39ae37a11", 705357, 500),
+	MACGAME1("maccubed", "Disc 4", "Let's Go! Education", "5b3a7fa45ec7655c5f9b7fe39ae37a11", 705357, 500),
+	MACGAME1("maccubed", "Disc 5", "Let's Go! Home and Office", "5b3a7fa45ec7655c5f9b7fe39ae37a11", 705357, 500),
+	MACGAME1("maccubed", "Disc 6", "Let's Go! Multimedia", "5b3a7fa45ec7655c5f9b7fe39ae37a11", 705357, 500),
+	MACGAME1("maccubed", "Disc 7", "Let's Go! Internet & Utilities", "5b3a7fa45ec7655c5f9b7fe39ae37a11", 705357, 500),
 
 	// Original Mac Pre-K filename contains non-printable character
 	// Full games do not use Director except for Progress Report utilities
@@ -5541,6 +5755,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1("musicforliving",  "", "ASL", "4f2c70510b4cbedf758cf9958d218e6e", 705445,  505),
 	WINGAME1t("musicforliving", "", "ASL.EXE",	   "b7853a82d4edff6be38b545143e95940", 1411198, 501),
 
+	// From MacFormat #44
+	MACGAME1("myfavburps", "", "My Favorite Burps", "7b0837f93c5de519acdf1feea2a4ccf2", 703153, 500),
+
 	// Original filename is 'ねぎ3世'
 	MACGAME1_l("negi3", "", "xn--3-l8t6do49k", "e2acdaafa16d8dbecbeca418d7e44899", 719636, Common::JA_JPN, 500),
 	// Decomposed variant
@@ -5591,6 +5808,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Found on PC World (Czechia) Sept 2003
 	WINGAME2_l("nemcina", "", "START_32.EXE", "3460ad87d2ba57104e2810a77b53c220", 1710313,
 							  "CVIC.DXR",     "8f12d20e12dddc2fc3207e1f4e571d17", 23223862, Common::CS_CZE, 500),
+
+	MACGAME1("nickmemory", "", "Memory Challenge", "cb5fe0ca2ddb43abe9996ef569918a53", 703153, 500),
 
 	// All original Mac filenames end with ™
 	// Nikolai in Outer Space did not get a Mac release
@@ -5939,10 +6158,10 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	// ein Fall für TKKG: Katjas Geheimnis (bilingual DE/EN)
 	MACGAME2("tkkg1", "", "TKKG start", "6e7e31d05709e1d38d63f4df6a59eec0", 719005,
-							"SCORE.DXR",  "9ffb87ff9d3110435da99a052279fb4c", 10434, 501),
+						  "SCORE.DXR",  "9ffb87ff9d3110435da99a052279fb4c", 10434, 501),
 	WINGAME1t("tkkg1", "", "TKKG1_95.EX_", "a6284109fe843164812af767fb9f41c8", 1411299, 501),
 
-	MACGAME1("trekchair", "", "Star Trek Captain's Chair™/Captain's Chair Player", "d8bad538d97edf5990c451699e429db3", 764476, 501),
+	MACGAME1("trekchair", "", "xn--Star Trek Captain's Chair-tl1p/Captain's Chair Player", "d8bad538d97edf5990c451699e429db3", 764476, 501),
 	WINGAME1t("trekchair", "", "CAP_WIN.EXE", "6c3c66dd2a5a91257fd2691e3888d47d", 1399089, 500),
 
 	MACGAME1("troubleshoot101", "Basic", "Troubleshooting 101 IA", "62e979424add2428daa835610fb83864", 719261, 501),
@@ -5972,6 +6191,10 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	MACGAME1("venetiandeer", "", "Venetian Deer", "1a352eb1a1c0b1e1b6ac041d58c50cbc", 716741, 501),
 	WINGAME1t("venetiandeer", "", "DEER.EXE", "5098878e6a7813b0a2a480d36cd352bc", 952215, 501),
+
+	// Developed by DeAgostini Multimedia
+	// Should also have a Mac version from the same disc
+	WINGAME1t_l("tesorovenezia", "", "VEN95.EXE", "d28edd9d3e3474feec760c942c410993", 1393935, Common::IT_ITA, 501),
 
 	MACGAME1("vp2", "", "VPhys2", "cb91232ecece0045461d236d5914c03d", 719261, 500),
 	MACDEMO1("vp2", "Demo", "VP2Demo", "cb91232ecece0045461d236d5914c03d", 719261, 500),
@@ -6077,6 +6300,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1_l("anony", "", "Anony", "65063397536553c4f6ff2a6c07194bf7", 1845815, Common::JA_JPN, 602),
 	WINGAME1t_l("anony", "", "ANONY.EXE", "83a8b0577877f3ca90ef2df6e6e287ae", 2029722, Common::JA_JPN, 602),
 
+	MACGAME1_l("aslss", "", "ASL", "aa9d5cab48b17f563110dc271c6663b4", 1133578, Common::JA_JPN, 601),
+
 	// Fun Pack is on the Party Time CD
 	WINGAME1("bananaspack", "", "_Fun_Pack.exe", "a593079aecf5bd938ce75264cac24b2d", 1508656, 600),
 	WINGAME1("bananasparty", "", "_Party_Time.exe", "a593079aecf5bd938ce75264cac24b2d", 1508811, 600),
@@ -6098,7 +6323,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	// Japanese release, "Zlurp", is part of the Digitalogue Future Artist Series
 	MACGAME1_l("boitearire", "", "Zlurp", "e402b347a9cf682d2154c70cfefdbf26", 115776, Common::JA_JPN, 601),
-	WINGAME1t_l("boitearire", "", "ZLURP.EXE", "cf81c34b261e9bc9e4af4dffa9298b5f", 1710871, Common::JA_JPN, 601),
+	WINGAME1t_l("boitearire", "", "ZLURP.EXE", "cf81c34b261e9bc9e4af4dffa9298b5f", 1710871, Common::JA_JPN, 600),
 
 	WINGAME1t_l("brspel", "", "START.EXE", "8d1bfc4ea72c1892412f2ecabb96c990", 3465523, Common::DA_DNK, 650),
 
@@ -6172,6 +6397,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1_l("ddoa", "Vol.3", "xn--mckta2dwiub0759and2ei6b", "fd87b233709108cc1fb001523ce772f5", 1033199, Common::JA_JPN, 601),
 	MACGAME1_l("ddoa", "Vol.4", "xn--dckj9k8cad7ij0189hun1b", "fd87b233709108cc1fb001523ce772f5", 1033199, Common::JA_JPN, 601),
 
+	MACGAME1("deedeedanger", "", "Dee Dee Danger", "f4e6bb84a18322cc5077c336eeec4549", 115739, 650),
+
 	WINGAME1("delphi4tutor", "", "Del4Tutor.exe", "ece1c7a090010965890840102978e693", 3125198, 601),
 
 	WINGAME1("dfireworks", "Ver.98", "Firewk32.exe", "ece1c7a090010965890840102978e693", 1513130, 601),
@@ -6200,6 +6427,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Mini-game from Microshaft Winblows that can also be launched separately
 	MACGAME1("exploder", "", "Winblows Exploder", "089658f6d7d68f07eece8a68e5fdc35e", 115391, 600),
 	WINGAME1t("exploder", "", "EXPLODER.EXE", "ae488c615d7ecb621c96c59b98eccf9b", 4712625, 600),
+
+	MACGAME1("flingshot", "", "FlingShot", "769cbb727ae2dda3f8ab6682d65ab439", 1031461, 650),
 
 	WINGAME1("forestia", "", "FORESTIA.EXE", "9ba84c313bc116ffa08029aad52cd2e8", 1859350, 601),
 	WINGAME1_l("forestia", "", "Forestia.exe", "5e123b0ddb0f1193e1f840c50f24e382", 1521194, Common::FI_FIN, 650),
@@ -6317,7 +6546,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1t_l("gasbook5", "Ichiro Tanida", "ICHIRO_TANIDA.exe", "e405783a91d8ffa261d4c792eeb5bed4", 1910437, Common::JA_JPN, 602),
 	MACGAME1_l("gasbook5", "Fontrom Volume 2", "FONTROM2", "078483b4b9b3a88bcf2c322529e88bfb", 1035296, Common::JA_JPN, 602),
 	WINGAME1t_l("gasbook5", "Fontrom Volume 2", "FONTROM2.exe", "690b272f3251feb2e65c2efa40000461", 1710689, Common::JA_JPN, 602),
-	// Original filename is a series of spaces and tabs
+	// Original filename is a series of spaces and tabs (<tab><tab><tab><tab><tab><space><tab><tab><tab>)
 	MACGAME1_l("gasbook5", "patterns for modernities", "xn-- -caaaaabaa6ebbbbcbb", "2bcd01161eb741dcf9506dc7432d1d7c", 1032968, Common::JA_JPN, 602),
 	WINGAME1t_l("gasbook5", "patterns for modernities", "pfm.exe", "229bf06d879da191478b26c447ef2b46", 1910453, Common::JA_JPN, 602),
 	MACGAME1_l("gasbook5", "volumeone", "volumeone", "2bcd01161eb741dcf9506dc7432d1d7c", 1034324, Common::JA_JPN, 602),
@@ -6825,9 +7054,6 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1("badmilk", "", "badmilk", "0944b962ebb00f4b5d5149d220f8449b", 111478, 702),
 	WINGAME1("badmilk", "", "badmilk.exe", "7c18c9a6af2694156bf09ed195c1ab09", 2682776, 702),
 
-	WINDEMO2("basilbaker", "Preview", "Start.exe",	  "c1a2e8b7e41fa204009324a9c7db1030", 2615108,
-									  "Mission1.dxr", "ddf7a5d922d1d99c9debc72f7ab3f247", 1979501, 700),
-
 	WINGAME1("bbbighelpers", "", "BigHelpers.exe", "7c18c9a6af2694156bf09ed195c1ab09", 2843894, 702),
 
 	// Later releases are D8
@@ -6906,6 +7132,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	// Found on デスクトップマスコット ファービー (Desktop Mascot Furby)
 	WINGAME1_l("furbydentaku", "", "xn--.exe-fk4colma72ab4209fos3h", "1799677b9d869c8dc577d931e229ee3b", 3002842, Common::JA_JPN, 702),
+
+	WINGAME1t_l("fuzzyfloppy3", "", "ff3.exe", "7b602367611d4b0422c6c86c2832c4b6", 1815664, Common::IT_ITA, 700),
 
 	// Miel Monteur - Miel Bouwt Auto's!
 	WINGAME2_l("garygadget1", "", "Start.exe", "c1a2e8b7e41fa204009324a9c7db1030", 2933829,
@@ -7088,7 +7316,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1("sshercules", "", "Herc Screen Saver.exe", "7c18c9a6af2694156bf09ed195c1ab09", 47066937, 702),
 
 	// http://web.archive.org/web/20080412010505/http://www.beachware.com/download/
-	MACGAME1("ssmorphclock", "", "MorphClock", "fa52f0136cde568a46249ce74f01a324", 189234, 700),
+	MACGAME1("ssmorphclock", "v1.5", "MorphClock", "fa52f0136cde568a46249ce74f01a324", 188978, 700),
 	WINGAME1("ssmorphclock", "", "Morph Clock.exe", "c1a2e8b7e41fa204009324a9c7db1030", 3800619, 700),
 
 	// Screen Saver found on Solitudes Natural Relaxation ECD
@@ -7112,8 +7340,13 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1_l("tomlisaindiens", "", "TOM ET LISA.EXE", "7c18c9a6af2694156bf09ed195c1ab09", 783498, Common::NL_NLD, 702),
 
 	// Full game was never released
+	WINDEMO2("veniceglass", "Preview", "Start.exe",	  "c1a2e8b7e41fa204009324a9c7db1030", 2615108,
+									  "Mission1.dxr", "ddf7a5d922d1d99c9debc72f7ab3f247", 1979501, 700),
 	WINDEMO2t("veniceglass", "Demo", "Start.exe", "6c1f4b9fddf094e240f759596b335479", 2615108,
 									 "Book1.dxr", "f9a656b9f31f44f195161e932ada634b", 16795693, 700),
+	// Found on a promotional screensaver CD for the game
+	WINDEMO2t("veniceglass", "Demo", "Start.exe", "6c1f4b9fddf094e240f759596b335479", 2615108,
+									 "Book1.dxr", "5af1a02fe8fb811e2a5a638011435108", 16796595, 700),
 
 	// Original filename is DreamLight® Verttice™ 3.0
 	MACGAME1("verttice", "v3.0", "DreamLight Verttice 3.0", "0944b962ebb00f4b5d5149d220f8449b", 123353, 702),
@@ -7214,7 +7447,10 @@ static const DirectorGameDescription gameDescriptions[] = {
 							   "DATA/intro.dxr", "a8fe1c32a4c4d40ed00393d8602b979e", 997164, 800),
 
 	// From bugreport #13438
+	// Mac version is D10
 	WINGAME1t("artmarcopatrito", "", "The_Art.exe", "5b1dc5ceba980c61ff9f6c82f187f106", 2158556, 851),
+
+	MACGAME1("astroblast", "v1.1", "AstroBlast", "b669b6ace5f203cf7dbdee5277d0c908", 218617, 800),
 
 	MACGAME2("avrilletgo", "ECD", "Projector",	   "4ea5fc09f79eee6dded94dc40f303779", 194863,
 								  "movie.dxr",	   "6d0c0712fdd32cf1de489b4c152b2460", 50908119, 800),
@@ -7432,6 +7668,12 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	MACGAME1_l("operafatal", "Classic OS", "Opera Classic", "78e78f91a6e42ece5a585c3a3dc81de3", 172200, Common::DE_DEU, 800),
 
+	// Mac version requires installation, Install Sampler, Installer VISE 3.5 LITE installer
+	MACGAME2("optimumrsrc", "", "SAMPLER", "64cc6d7654b62973f8b72099eb0ea934", 196851,
+								"esl_bil.dxr", "70e5dd0d083af6f150eec9f2587c91ec", 9763420, 800),
+	WINGAME2t("optimumrsrc", "", "sampler.exe", "1269bfae9866db2000a012ad4107efe4", 2323650,
+								 "esl_bil.dxr", "fa0a09ae0b5ecb47148708a30f28fd66", 9763420, 800),
+
 	WINGAME1t_l("janoschpanama", "", "panama.exe", "25d1a9fb6c8067953888719e07dc29bd", 2384444, Common::DE_DEU, 800),
 	WINGAME1t_l("janoschverkehr", "", "verkehr.exe", "fa749c7798f69f4aa615d35b2b991348", 2294886, Common::DE_DEU, 851),
 
@@ -7622,6 +7864,40 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1("westwood", "", "WW DPK", "4ea5fc09f79eee6dded94dc40f303779", 194863, 800),
 	WINGAME1("westwood", "", "WW_DPK.exe", "e24d4bab978b1a5c2326d2c56cf4d781", 2351418, 800),
 
+	// These only differ by the included wallpaper and comic
+	MACGAME2("xmen-burgerking", "Cyclops", "XMEN", "4ea5fc09f79eee6dded94dc40f303779", 196871,
+										   "Comic/issues/cyclops.swf", "cbf9e69d550e4eea19697e8259ff9bfc", 1528559, 800),
+	WINGAME2t("xmen-burgerking", "Cyclops", "xmen.exe", "c9a4619a36fd555966cb3d903ae8887f", 2250798,
+											"Comic/issues/cyclops.swf", "f79f4cb0ce3bf3f65f14936449be2005", 1528559, 800),
+	MACGAME2("xmen-burgerking", "Magneto", "XMEN", "4ea5fc09f79eee6dded94dc40f303779", 196871,
+										   "Comic/issues/magneto.swf", "18eaad40c806b052b188c225582749f5", 1663916, 800),
+	WINGAME2t("xmen-burgerking", "Magneto", "xmen.exe", "c9a4619a36fd555966cb3d903ae8887f", 2250798,
+											"Comic/issues/magneto.swf", "2eb262c96caa6c5d3228633914c0188b", 1663916, 800),
+	MACGAME2("xmen-burgerking", "Mystique", "XMEN", "4ea5fc09f79eee6dded94dc40f303779", 196871,
+											"Comic/issues/mystique.swf", "5001426be4d06d8f41ba9b568b4106e0", 1408296, 800),
+	WINGAME2t("xmen-burgerking", "Mystique", "xmen.exe", "c9a4619a36fd555966cb3d903ae8887f", 2250798,
+											 "Comic/issues/mystique.swf", "661fcb999537ac12cfc9d5021c3e7ef8", 1408296, 800),
+	MACGAME2("xmen-burgerking", "Nightcrawler", "XMEN", "4ea5fc09f79eee6dded94dc40f303779", 196871,
+												"Comic/issues/nightcrawler.swf", "0a88f3394ece9ae256533ebc0153e6a6", 3260798, 800),
+	WINGAME2t("xmen-burgerking", "Nightcrawler", "xmen.exe", "c9a4619a36fd555966cb3d903ae8887f", 2250798,
+												 "Comic/issues/nightcrawler.swf", "ad17845d6e684bf698b5dc47266489e8", 3260798, 800),
+	MACGAME2("xmen-burgerking", "Quicksilver", "XMEN", "4ea5fc09f79eee6dded94dc40f303779", 196871,
+											   "Comic/issues/quicksilver.swf", "b2e591d0b0b201e118f5dae8158fd9d2", 2204025, 800),
+	WINGAME2t("xmen-burgerking", "Quicksilver", "xmen.exe", "c9a4619a36fd555966cb3d903ae8887f", 2250798,
+												"Comic/issues/quicksilver.swf", "e7eb73b13f585f18a4a145680c5b02ac", 2204025, 800),
+	MACGAME2("xmen-burgerking", "Rogue", "XMEN", "4ea5fc09f79eee6dded94dc40f303779", 196871,
+										 "Comic/issues/rogue.swf", "2f53877359763c3c1df76038778ee729", 1330923, 800),
+	WINGAME2t("xmen-burgerking", "Rogue", "xmen.exe", "c9a4619a36fd555966cb3d903ae8887f", 2250798,
+										  "Comic/issues/rogue.swf", "2faca8b96e595be822d4d893092a06a8", 1330923, 800),
+	MACGAME2("xmen-burgerking", "Toad", "XMEN", "4ea5fc09f79eee6dded94dc40f303779", 196871,
+										"Comic/issues/toad.swf", "b48563852c989803d96467ce7fed4109", 1429068, 800),
+	WINGAME2t("xmen-burgerking", "Toad", "xmen.exe", "c9a4619a36fd555966cb3d903ae8887f", 2250798,
+										 "Comic/issues/toad.swf", "dcc3a9eec85460e29a146c3a14bf6c38", 1429068, 800),
+	MACGAME2("xmen-burgerking", "Wolverine", "XMEN", "4ea5fc09f79eee6dded94dc40f303779", 196871,
+											 "Comic/issues/wolverine.swf", "dbc67fe22aab4ce9a59ca220c2287588", 1282980, 800),
+	WINGAME2t("xmen-burgerking", "Wolverine", "xmen.exe", "c9a4619a36fd555966cb3d903ae8887f", 2250798,
+											  "Comic/issues/wolverine.swf", "61220a36d2e79f62c4e7350cf9b25659", 1282980, 800),
+
 	// Original Mac filename is 妖精妖怪図鑑
 	MACGAME1_l("yokaizukan", "", "xn--lcs34da058ddt2bxt3a", "dd3c8aeb1d2847c77db701ad49ad8186", 163060, Common::JA_JPN, 850),
 	WINGAME1_l("yokaizukan", "", "xn--.exe-ul4gs3la685khv6dnj8b", "b541b4e21a7284bef5180907f72d5702", 2118234, Common::JA_JPN, 850),
@@ -7758,6 +8034,10 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Game description is based on desktop shortcut after installation
 	WINGAME1("aolstarwars", "", "STARWARS.EXE", "bcf64185ce848b7b70858d62945f48a8", 25472412, 1010),
 
+	// Windows version is D8.5
+	// External movies in the 'ME' folder are aliased to ':Cassic OS:ME' (sic)
+	MACGAME1("artmarcopatrito", "", "The Art.osx", "2dbd6c69e359896c0291101c93b0dc03", 303895, 1000),
+
 	MACGAME1("babarcoins", "", "Mac.osx",		"a171b7a952d1ac68ae3cd419d6dfc674", 309249, 1010),
 	WINGAME2("babarcoins", "", "Start.exe",		"b198e9bf56c679747e4fd0972d5ba7b7", 2659300,
 							   "ba-01_A01.dxr", "cb38821091082aeb097e88551b791e05", 9946435, 1010),
@@ -7890,170 +8170,6 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1_l("pixelineskolevik", "", "Pixeline - Vikingerne.exe",	"b162d633891f0ab2e2fc6ba6164df337", 5909524, Common::DA_DNK, 1100),
 	// Win executable on Mac partition
 	WINGAME1t_l("pixelineskolevik", "", "Pixeline - Vikingerne.exe", "52d593de1aae5db1f2ef1c503af20833", 7568472, Common::DA_DNK, 1100),
-
-
-//////////////////////////////////////////////////
-//
-// Not supported
-//
-//////////////////////////////////////////////////
-
-// MacroMind VideoWorks Player 1.00 (pre-director)
-	// Touring Engine Ver 1.00. Original filename is MacPlaymate™
-	MACGAME1("macplaymate1", "", "MacPlaymate", "4bdad2173d739dcaca1241afe88c7aef", 33851, 0),
-
-// MacroMind Director v2
-	MACGAME1("macplaymate2", "", "MacPlaymate II", "cfa68a1bc49251497ebde18e5fc9c217", 822229, 200),
-
-// MacroMind / Macromedia Director v3
-	MACGAME1_l("dancinggals", "", "DANCING GALS", "f5277c53bacd27936158dd3867e587e2", 392229, Common::JA_JPN, 311),
-	WINGAME1t_l("dancinggals", "", "DANCING.EXE", "3d061123bdcb50637ee792fd5322ad8e", 375294, Common::JA_JPN, 300),
-
-	// Found on NeuroDancer, #3 is D4
-	WINGAME1t("digerotica", "#2", "CATALOG.EXE", "3efa3f7d66cc81dd7170354305c24726", 2576067, 300),
-
-	MACDEMO2_l("digitalogue", "Preview", "PREVIEW",   "f5277c53bacd27936158dd3867e587e2", 392506,
-										 "preview-1", "71f28684bafe3195685cf8b7a6c674d9", 1294330, Common::JA_JPN, 311),
-
-	MACGAME1_l("dmpgallery",  "Vol.1",   "Gallery vol.1",		   "a03ae8a9bf211bcb26388b6b6da17c2b", 7522802, Common::JA_JPN, 311),
-	MACGAME1_l("dmpgallery",  "Vol.2",   "Gallery vol.2",		   "f5277c53bacd27936158dd3867e587e2", 1941814, Common::JA_JPN, 311),
-	MACGAME1_l("dmpgallery",  "Vol.3",   "Gallery vol.3",		   "f5277c53bacd27936158dd3867e587e2", 2913247, Common::JA_JPN, 311),
-
-	MACGAME1("dream1", "", "xn--DREAM.13-ra44a", "2ce360c9ea2da80a2c6d1040b0ad92dd", 580694, 310),
-	WINGAME1("dream1", "", "PLAYER.EXE", "2e5713cd0e39c6bb9dc9292e552f88be", 58000, 310),
-
-	// Original filename is ギルガメSDガイ
-	MACDEMO1_l("gilgameshnite", "Demo", "Gilgamesh SD Guide", "f5277c53bacd27936158dd3867e587e2", 1173668, Common::JA_JPN, 311),
-
-	// Original filename is ﾍﾙﾑﾄ･ﾆｭｰﾄﾝ & 石田えり
-	MACDEMO1_l("immorale", "Demo", "Helmut Newton & Eri Ishida", "f5277c53bacd27936158dd3867e587e2", 390241, Common::JA_JPN, 311),
-
-	MACGAME1("isswim98", "", "Inside Sports Swimsuit 98", "4577dd3eadc467a986ab172d90871b22", 304156, 404),
-	WINGAME1("isswim98", "", "ISSWIM98.EXE",			  "24de9da2e30d07ba98d2fd6259afd16c", 753801, 404),
-
-	// Photography disc published by The One Corporation
-	MACDEMO1_l("labyrinth", "Demonstration Version", "Labyrinth_Demo", "276bee761e48a6fd709df77d5c2f60dd", 395949, Common::JA_JPN, 313),
-
-	MACDEMO1_l("legs", "Demo", "LEGS Vol.1", "f5277c53bacd27936158dd3867e587e2", 547761, Common::JA_JPN, 311),
-	MACDEMO1_l("legs", "Demo", "LEGS Vol.1", "f5277c53bacd27936158dd3867e587e2", 547752, Common::JA_JPN, 311),
-
-	// Mac also has an 8-bit color binary. Win is limited to 8-bit color in D3.
-	// Original filename is NeuroDancer™ 16-bit
-	MACGAME1("neurodancer",  "",			  "xn--NeuroDancer 16-bit-mu3k", "2ce360c9ea2da80a2c6d1040b0ad92dd", 1793375, 300),
-	WINGAME1t("neurodancer", "",			  "ND.EXE",						 "151008e1188f77c69f336a92b8cc59aa", 457981,  300),
-	MACGAME1("neurodancer",  "Online Manual", "NeuroDancer Online Manual",	 "2ce360c9ea2da80a2c6d1040b0ad92dd", 1237129, 300),
-	WINGAME1t("neurodancer", "Online Manual", "NDMAN.EXE",					 "58fdb03893ba8daa2f45789122c954ef", 1450997,  300),
-
-	// SPR-304  SPICE Vol.4
-	// MACGAME1_l("scop", "", "SCOP.SYSTEM/PROJ.SCOP", "276bee761e48a6fd709df77d5c2f60dd", 392502, Common::JA_JPN, 313),
-	MACGAME1_l("scop", "", "SCOP.SYSTEM/MAIN", "d315ad4319994f24cbbb251b44074270", 546587, Common::JA_JPN, 313),
-
-	// Original filename is ビーナスの美女のデモ
-	MACDEMO1("venus", "Demo", "Venus no Bijo Demo", "1ae45c23586b41997ba52e2e7c771c4c", 3333366, 310),
-
-	MACGAME1("vvalerie1", "", "VV", "d830c8fa306d1bd501fbedf1cf9dd57a", 707189, 310),
-
-	MACDEMO1("vpeepshow", "Demo", "Virtual PeepShow", "f5277c53bacd27936158dd3867e587e2", 425489, 311),
-
-// Macromedia Director v4
-	MACGAME1("busty3", "", "Busty III Slide Viewer", "1682231de376e5465240f6e4a7952072", 289980, 400),
-	WINGAME1("busty3", "", "BUSTY3.EXE",			   "07c20a266c2fd9d35960a7ce413cfedf", 4293647, 400),
-
-	MACGAME1("busty4", "", "Busty 4",				   "d35d3bb2e79e008e6bd9af62d099344f", 483746, 404),
-	WINGAME1("busty4", "", "BUSTY4.EXE",			   "09d32c60f12c76c6d1d0f3d2d5593e44", 1569431, 404),
-
-	// Found on NeuroDancer, also available as its own disc
-	MACGAME1("digerotica", "#3", "SAMPLER 3",	  "77f4098988d5386794d1530065f514cd", 303912,  404),
-	WINGAME1t("digerotica", "#3", "SAMPLER3.EXE", "401f999fc67e9728cc857afc1badef8f", 8467883, 404),
-
-	// Original Mac filename is Fischer's Erotic Encyclopœdia
-	MACGAME1("eros", "", "Fischer's Erotic Encyclopedia", "0c7bbb4b24823e5ab871cb4c1d6f3710", 486982, 404),
-	WINGAME1("eros", "", "EROS.EXE",					  "714d53f8cfbb6a8bb22e535978af6278", 690595, 404),
-
-	MACGAME1("isswim98", "", "Inside Sports Swimsuit 98", "4577dd3eadc467a986ab172d90871b22", 304156, 404),
-	WINGAME1("isswim98", "", "ISSWIM98.EXE",			  "24de9da2e30d07ba98d2fd6259afd16c", 753801, 404),
-
-	WINGAME1t_l("historiapoca", "", "POCA.EXE", "ec6b23cf02a45199f6b5287fcff935fb", 13881713, Common::PT_BRA, 400),
-
-	MACGAME1("sororitystwrdss", "", "SORORITY STEWARDESSES", "0c7bbb4b24823e5ab871cb4c1d6f3710", 483490, 404),
-	WINGAME1t("sororitystwrdss", "", "SORORITY.EXE", "0aa0c9e9ba383fa1e6825d4561c238b1", 1646273, 404),
-
-	MACDEMO2_l("thebody", "Demo", "DEMO",	   "bcd3c718db258701496b3c5bcb827ef2", 484323,
-								  "START.DIR", "beeb32cacc5108838a8b5c6850275b86", 7342, Common::JA_JPN, 404),
-	WINDEMO2_l("thebody", "Demo", "DEMO.EXE",  "763f360a098cf3bec7cbdc5685b1e4a3", 1193483,
-								  "START.DIR", "dd60f73a3c0590754b07e0cee4ec2921", 7206, Common::JA_JPN, 404),
-
-	MACGAME1_l("vvaleriedc", "", "Valerie", "9e3f05103eeb6b4b356e3c7c1e9b6802", 288134, Common::JA_JPN, 402),
-
-	MACGAME1("vvalerie2", "", "VV2",		  "98229e39001a22ec1cfeb8f124c28483", 307427, 400),
-	WINGAME1("vvalerie2", "", "VALERIE2.EXE", "e11ef9aad93815eaacfad6fa6a427c6b", 686367, 400),
-
-	MACGAME1("vsex1", "", "Virtual Sex Power Mac", "db9b7f11aea52a294d2986a94a184000", 60096, 404),
-	WINGAME1t("vsex1", "", "VIRTUAL.EXE", "2bb142d53403c61438affdb5d954b3ae", 10350653, 404),
-
-	MACGAME1("vsex2", "", "Virtual Sex II", "a8e65a2268226bd59f12ebdc58a221f3", 483518, 404),
-	WINGAME1("vsex2", "", "VIRTUAL.EXE", "cf056a922edc435507f1a223cbf1cb3b", 12084517, 404),
-
-// Macromedia Director v5
-	MACGAME1("cyberphoto", "", "Cyber Photographer", "9fbd2e99a6a23933083ba0934e4a7d01", 705313, 500),
-	MACGAME1("cyberphoto", "CyberPrintshop", "Cyber Printshop", "9fbd2e99a6a23933083ba0934e4a7d01", 705313, 500),
-	WINGAME1t("cyberphoto", "", "CYBER.EXE", "ebd865feed5683e65c6fa47b5fcd3a0b", 2172413, 500),
-	WINGAME1t("cyberphoto", "CyberPrintshop", "CYBERP.EXE", "ebd865feed5683e65c6fa47b5fcd3a0b", 2172571, 500),
-
-	WINGAME1t("dmj5", "", "dmj32.exe", "14faa2408e90bef3aa5cfde2f44d5781", 1448701, 501),
-	MACGAME2("dmj5", "", "PowerPC", "6710977cfafc46ebe050897e01719f89", 107863,
-						 "pc/intros.dxr", "8c00de08fb4e67d41fe8cf7460c4bf61", 498546, 501),
-
-	WINGAME1("dream2", "", "Dm2win95.exe", "2e62abdad839e42068afdcd0644d7dcf", 6213931, 500),
-
-	MACGAME2("houseparty", "", "PPC Mac", "6710977cfafc46ebe050897e01719f89", 106955,
-							   "Pc/intro.Dxr", "7baf18aedf9b59a44cd9f1ceed435dd9", 3789638, 501),
-	WINGAME1t("houseparty", "", "HP32.EXE", "2791eaf410352fbc2ab7030c83c35161", 1393989, 500),
-
-	MACGAME2("nightnurses", "", "PPC Mac", "6710977cfafc46ebe050897e01719f89", 107863,
-								"pc/nurses.Dxr", "00ec56fe938980c739a661b3f723b3b1", 91178, 501),
-	WINGAME2t("nightnurses", "", "32bits.exe", "e043dc8ad875ea72fee9664922574d88", 1849567,
-								 "nurses.Dxr", "a9285ccae77711201d1f2b389a06dd07", 91178, 501),
-
-	WINGAME1t("sadowar", "v1.1", "RSP.EXE", "bc4b1010bb4f05d2d4789f6eb3e13b04", 1393989, 500),
-
-	MACGAME1("shock", "", "PPC SHOCK", "6710977cfafc46ebe050897e01719f89", 106955, 501),
-	WINGAME2t("shock", "", "32BIT.EXE", "2791eaf410352fbc2ab7030c83c35161", 1393989,
-						   "SHOCK.DXR", "c6509da8399739df5966d2933da0b33e", 163310, 501),
-
-	WINDEMO2_l("thelegs", "8-bit Color Demo",  "S.EXE",		  "c3c38bd3907ca7e13220b74bd0317a6c", 1013279,
-											   "START8.DIR",  "ed4bfebf096a195ae68db0fe7ba999cc", 4812, Common::JA_JPN, 500),
-	WINDEMO2_l("thelegs", "16-bit Color Demo", "S.EXE",		  "1c654e09938e5a27f694e694aca13833", 1387193,
-											   "START16.DIR", "1b42803d81028c827022eb08e00616b0", 4942, Common::JA_JPN, 500),
-
-	MACGAME1_l("timewarp", "",  "Time Warp", "80d51128cda4f75986e2e00e110b26f3", 705445, Common::DE_DEU, 500),
-	WINGAME2t_l("timewarp", "", "START32.EXE", "13fa7fd5d46ec8f5a44fecef77e27962", 1855247,
-								"TIMEWARP/INTRO.DXR", "18e309348235ac467f103d80dcea13ee", 2498042, Common::DE_DEU, 501),
-
-	// Mac version also includes Classic binaries
-	// Mac and Windows demos from http://www.catear.info/pr/trans2/download/
-	MACDEMO1("trans2", "Demo", "Trans2.osx", "91824f7788a1a8c129637dcadaff32df", 284863, 1010),
-	// Name configuration tool is also Director, and a separate executable
-	MACDEMO1("trans2", "Name configuration (demo)", "name_config.osx", "91824f7788a1a8c129637dcadaff32df", 284863, 1010),
-	WINDEMO1t_l("trans2", "Demo", "Trans2.exe", "1345daaccfb2e922bce7a1ec76bd229a", 2680954, Common::JA_JPN, 1010),
-	WINDEMO1t_l("trans2", "Name configuration (demo)", "name_config.exe", "cef71307ff7456353f06b03cf79d60d3", 4896694, Common::JA_JPN, 1010),
-
-	MACGAME1("vsexasia", "", "Virtual Sex with Asia", "f3817a8eca9efb143a23b76525dedfa9", 744578, 501),
-	WINGAME1t("vsexasia", "", "ASIA32.EXE", "686e9ceb9d2bceae861eac37d0f67653", 1397213, 501),
-
-	MACGAME1("vveronika", "", "Veronika", "43e89a8298b7dc638e2d6939fadc5234", 94329, 500),
-
-// Macromedia Director v6
-	WINGAME1t("csa", "", "csa.exe", "6f7adaaba3ad2302987d5cf3299f94bb", 5512394, 600),
-
-	MACGAME1("pbvv", "", "Playboy",	   "f26885badb07dcf3a79defda517d4ddb", 1032662, 602),
-	WINGAME1("pbvv", "", "PBVV95.EXE", "a593079aecf5bd938ce75264cac24b2d", 1700279, 600),
-
-	MACGAME1("playmate1999", "", "Playboy PowerPC", "63e8b9f6744efefbb8a004a2b76e2b1d", 116023,  650),
-	WINGAME1("playmate1999", "", "PB95.exe",		"d62438566e44826960fc16c5c23dbe43", 1710252, 650),
-
-	MACGAME1("vvs1", "", "Virtual Video Shoot 1", "8a8b55e649fca6581ba2e3ffdedba2ed", 1069321, 600),
-	WINGAME1t("vvs1", "", "VVS32.EXE", "abeb994f4b952385ef2ba063bf0cf81a", 1515517, 600),
 
 	{ AD_TABLE_END_MARKER, GID_GENERIC, 0 }
 

--- a/engines/director/game-quirks.cpp
+++ b/engines/director/game-quirks.cpp
@@ -71,6 +71,10 @@ struct CachedFile {
 		"WOLFGANG.dat",	// It needs an empty file
 			(const byte *)"", 0
 	},
+	{ "mcluhan", Common::kPlatformWindows,
+		"prefs/Markers/List.Txt",	// It needs an empty file
+			(const byte *)"", 0
+	},
 	{ nullptr, Common::kPlatformUnknown, nullptr, nullptr, 0 }
 };
 
@@ -93,7 +97,7 @@ static void quirkLzone() {
 
 static void quirkMcLuhan() {
 	// TODO. Read fonts from MCLUHAN/SYSTEM directory
-	g_director->_extraSearchPath.push_back("mcluhan\\");
+	g_director->_extraSearchPath.push_back("mcluhan");
 	Graphics::MacFontManager *fontMan = g_director->_wm->_fontMan;
 	fontMan->loadWindowsFont("MCLUHAN/SYSTEM/MCBOLD13.FON");
 	fontMan->loadWindowsFont("MCLUHAN/SYSTEM/MCLURG__.FON");

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1200,6 +1200,7 @@ void LB::b_openXlib(int nargs) {
 				g_director->_allOpenResFiles.setVal(resPath, resFile);
 				uint32 XCOD = MKTAG('X', 'C', 'O', 'D');
 				uint32 XCMD = MKTAG('X', 'C', 'M', 'D');
+				uint32 XFCN = MKTAG('X', 'F', 'C', 'N');
 
 				Common::Array<uint16> rsrcList = resFile->getResourceIDList(XCOD);
 
@@ -1211,6 +1212,12 @@ void LB::b_openXlib(int nargs) {
 				rsrcList = resFile->getResourceIDList(XCMD);
 				for (uint i = 0; i < rsrcList.size(); i++) {
 					xlibName = resFile->getResourceDetail(XCMD, rsrcList[i]).name.c_str();
+					g_lingo->openXLib(xlibName, kXObj);
+				}
+
+				rsrcList = resFile->getResourceIDList(XFCN);
+				for (uint i = 0; i < rsrcList.size(); i++) {
+					xlibName = resFile->getResourceDetail(XFCN, rsrcList[i]).name.c_str();
 					g_lingo->openXLib(xlibName, kXObj);
 				}
 				return;
@@ -1432,8 +1439,8 @@ void LB::b_preLoad(int nargs) {
 
 	g_lingo->_theResult = g_lingo->pop();
 
-	if (nargs == 2)
-		g_lingo->pop();
+	if (nargs > 1)
+		g_lingo->dropStack(nargs - 1);
 }
 
 void LB::b_preLoadCast(int nargs) {
@@ -1715,7 +1722,7 @@ void LB::b_alert(int nargs) {
 
 	if (!debugChannelSet(-1, kDebugFewFramesOnly)) {
 		g_director->_wm->clearHandlingWidgets();
-		GUI::MessageDialog dialog(alert.c_str(), _("OK"));
+		GUI::MessageDialog dialog(g_director->getCurrentMovie()->getCast()->decodeString(alert), _("OK"));
 		dialog.runModal();
 	}
 }

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -43,7 +43,9 @@
 #include "director/lingo/xlibs/cdromxobj.h"
 #include "director/lingo/xlibs/darkenscreen.h"
 #include "director/lingo/xlibs/ednox.h"
+#include "director/lingo/xlibs/fileexists.h"
 #include "director/lingo/xlibs/fileio.h"
+#include "director/lingo/xlibs/findfolder.h"
 #include "director/lingo/xlibs/flushxobj.h"
 #include "director/lingo/xlibs/fplayxobj.h"
 #include "director/lingo/xlibs/gpid.h"
@@ -64,9 +66,11 @@
 #include "director/lingo/xlibs/soundjam.h"
 #include "director/lingo/xlibs/spacemgr.h"
 #include "director/lingo/xlibs/videodiscxobj.h"
+#include "director/lingo/xlibs/volumelist.h"
 #include "director/lingo/xlibs/widgetxobj.h"
 #include "director/lingo/xlibs/winxobj.h"
 #include "director/lingo/xlibs/xplayanim.h"
+#include "director/lingo/xlibs/yasix.h"
 
 namespace Director {
 
@@ -144,7 +148,9 @@ static struct XLibProto {
 	{ CDROMXObj::fileNames,				CDROMXObj::open,			CDROMXObj::close,			kXObj,					200 },	// D2
 	{ DarkenScreen::fileNames,			DarkenScreen::open,			DarkenScreen::close,		kXObj,					300 },	// D3
 	{ Ednox::fileNames,					Ednox::open,				Ednox::close,				kXObj,					300 },	// D3
+	{ FileExists::fileNames,			FileExists::open,			FileExists::close,			kXObj,					300 },	// D3
 	{ FileIO::fileNames,				FileIO::open,				FileIO::close,				kXObj | kXtraObj,		200 },	// D2
+	{ FindFolder::fileNames,			FindFolder::open,			FindFolder::close,			kXObj,					300 },	// D3
 	{ FlushXObj::fileNames,				FlushXObj::open,			FlushXObj::close,			kXObj,					300 },	// D3
 	{ FPlayXObj::fileNames,				FPlayXObj::open,			FPlayXObj::close,			kXObj,					200 },	// D2
 	{ GpidXObj::fileNames,				GpidXObj::open,				GpidXObj::close,			kXObj,					400 },	// D4
@@ -165,9 +171,11 @@ static struct XLibProto {
 	{ SerialPortXObj::fileNames,		SerialPortXObj::open,		SerialPortXObj::close,		kXObj,					200 },	// D2
 	{ SoundJam::fileNames,				SoundJam::open,				SoundJam::close,			kXObj,					400 },	// D4
 	{ SpaceMgr::fileNames,				SpaceMgr::open,				SpaceMgr::close,			kXObj,					400 },	// D4
+	{ VolumeList::fileNames,			VolumeList::open,			VolumeList::close,			kXObj,					300 },	// D3
 	{ WidgetXObj::fileNames,			WidgetXObj::open,			WidgetXObj::close, 			kXObj,					400 },  // D4
 	{ VideodiscXObj::fileNames,			VideodiscXObj::open,		VideodiscXObj::close,		kXObj,					200 },	// D2
 	{ XPlayAnim::fileNames,				XPlayAnim::open,			XPlayAnim::close,			kXObj,					300 },	// D3
+	{ Yasix::fileNames,					Yasix::open,				Yasix::close,				kXObj,					300 },	// D3
 	{ nullptr, nullptr, nullptr, 0, 0 }
 };
 

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -41,11 +41,14 @@
 #include "director/lingo/xlibs/askuser.h"
 #include "director/lingo/xlibs/barakeobj.h"
 #include "director/lingo/xlibs/cdromxobj.h"
+#include "director/lingo/xlibs/darkenscreen.h"
+#include "director/lingo/xlibs/ednox.h"
 #include "director/lingo/xlibs/fileio.h"
 #include "director/lingo/xlibs/flushxobj.h"
 #include "director/lingo/xlibs/fplayxobj.h"
 #include "director/lingo/xlibs/gpid.h"
 #include "director/lingo/xlibs/jwxini.h"
+#include "director/lingo/xlibs/iscd.h"
 #include "director/lingo/xlibs/jitdraw3.h"
 #include "director/lingo/xlibs/labeldrvxobj.h"
 #include "director/lingo/xlibs/memoryxobj.h"
@@ -139,10 +142,13 @@ static struct XLibProto {
 	{ AskUser::fileNames,				AskUser::open,				AskUser::close,				kXObj,					400 },	// D4
 	{ BarakeObj::fileNames,				BarakeObj::open,			BarakeObj::close,			kXObj,					400 },	// D4
 	{ CDROMXObj::fileNames,				CDROMXObj::open,			CDROMXObj::close,			kXObj,					200 },	// D2
+	{ DarkenScreen::fileNames,			DarkenScreen::open,			DarkenScreen::close,		kXObj,					300 },	// D3
+	{ Ednox::fileNames,					Ednox::open,				Ednox::close,				kXObj,					300 },	// D3
 	{ FileIO::fileNames,				FileIO::open,				FileIO::close,				kXObj | kXtraObj,		200 },	// D2
 	{ FlushXObj::fileNames,				FlushXObj::open,			FlushXObj::close,			kXObj,					300 },	// D3
 	{ FPlayXObj::fileNames,				FPlayXObj::open,			FPlayXObj::close,			kXObj,					200 },	// D2
 	{ GpidXObj::fileNames,				GpidXObj::open,				GpidXObj::close,			kXObj,					400 },	// D4
+	{ IsCD::fileNames,					IsCD::open,					IsCD::close,				kXObj,					300 },	// D3
 	{ JITDraw3XObj::fileNames,			JITDraw3XObj::open,			JITDraw3XObj::close,		kXObj,					400 },	// D4
 	{ JourneyWareXINIXObj::fileNames,	JourneyWareXINIXObj::open,	JourneyWareXINIXObj::close,	kXObj,					400 },	// D4
 	{ LabelDrvXObj::fileNames,			LabelDrvXObj::open,			LabelDrvXObj::close,		kXObj,					400 },	// D4

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -51,6 +51,7 @@
 #include "director/lingo/xlibs/gpid.h"
 #include "director/lingo/xlibs/jwxini.h"
 #include "director/lingo/xlibs/iscd.h"
+#include "director/lingo/xlibs/ispippin.h"
 #include "director/lingo/xlibs/jitdraw3.h"
 #include "director/lingo/xlibs/labeldrvxobj.h"
 #include "director/lingo/xlibs/memoryxobj.h"
@@ -61,6 +62,7 @@
 #include "director/lingo/xlibs/orthoplayxobj.h"
 #include "director/lingo/xlibs/palxobj.h"
 #include "director/lingo/xlibs/popupmenuxobj.h"
+#include "director/lingo/xlibs/qtmovie.h"
 #include "director/lingo/xlibs/registercomponent.h"
 #include "director/lingo/xlibs/serialportxobj.h"
 #include "director/lingo/xlibs/soundjam.h"
@@ -155,6 +157,7 @@ static struct XLibProto {
 	{ FPlayXObj::fileNames,				FPlayXObj::open,			FPlayXObj::close,			kXObj,					200 },	// D2
 	{ GpidXObj::fileNames,				GpidXObj::open,				GpidXObj::close,			kXObj,					400 },	// D4
 	{ IsCD::fileNames,					IsCD::open,					IsCD::close,				kXObj,					300 },	// D3
+	{ IsPippin::fileNames,				IsPippin::open,				IsPippin::close,			kXObj,					400 },	// D4
 	{ JITDraw3XObj::fileNames,			JITDraw3XObj::open,			JITDraw3XObj::close,		kXObj,					400 },	// D4
 	{ JourneyWareXINIXObj::fileNames,	JourneyWareXINIXObj::open,	JourneyWareXINIXObj::close,	kXObj,					400 },	// D4
 	{ LabelDrvXObj::fileNames,			LabelDrvXObj::open,			LabelDrvXObj::close,		kXObj,					400 },	// D4
@@ -166,6 +169,7 @@ static struct XLibProto {
 	{ OrthoPlayXObj::fileNames,			OrthoPlayXObj::open,		OrthoPlayXObj::close,		kXObj,					400 },	// D4
 	{ PalXObj::fileNames,				PalXObj::open,				PalXObj::close,				kXObj,					400 },	// D4
 	{ PopUpMenuXObj::fileNames,			PopUpMenuXObj::open,		PopUpMenuXObj::close,		kXObj,					200 },	// D2
+	{ QTMovie::fileNames,				QTMovie::open,				QTMovie::close,				kXObj,					400 },	// D4
 	{ RearWindowXObj::fileNames,		RearWindowXObj::open,		RearWindowXObj::close,		kXObj,					400 },	// D4
 	{ RegisterComponent::fileNames,		RegisterComponent::open,	RegisterComponent::close,	kXObj,					400 },	// D4
 	{ SerialPortXObj::fileNames,		SerialPortXObj::open,		SerialPortXObj::close,		kXObj,					200 },	// D2

--- a/engines/director/lingo/lingo-patcher.cpp
+++ b/engines/director/lingo/lingo-patcher.cpp
@@ -122,8 +122,7 @@ struct ScriptPatch {
 
 	// Non-existent menu cast reference
 	{"warlock", nullptr, kPlatformWindows, "STARBIRD:ABOUT", kScoreScript, 4, 0,
-			1, "installmenu A13",
-				""},
+			1, "installmenu A13", ""},
 
 
 	// Patching dead loop which was fixed in v2
@@ -145,9 +144,11 @@ struct ScriptPatch {
 			1, "GO \"SPACE\" OF MOVIE \"L-ZONE:DATA:R-G:ST-A2\",\"242,197\"",
 			   "GO \"SPACE\" OF MOVIE \"L-ZONE:DATA:R-G:ST-A2\""},
 
+
 	{"lingoexpo", "", kPlatformMacintosh, "Lingo Expo:Navigator", kMovieScript, 9, 0,
 			97, "  append(codeExampleList,\"6,301,302,303,304,305,306\")  - KIOSK SCRIPTS",
 				"  append(codeExampleList,\"6,301,302,303,304,305,306\")"},
+
 
 	{"jman", "", kPlatformWindows, "mmm:Mars Space Game 05", kMovieScript, 10, 0,
 			68, "set DamageParameter = (gProcessorSpeed/2) + 7)",
@@ -166,12 +167,14 @@ struct ScriptPatch {
 	{"jman", "", kPlatformWindows, "MMM:Shared Cast B&W", kMovieScript, 323, 0,
 			192, "updateStage", "set the trails of sprite 19 to 0"},
 
+
 	{"snh", "Hybrid release", kPlatformWindows, "SNHstart", kMovieScript, 0, 0,
 			3, "changedrive", ""}, // HACK: This macro inserts \x01 after the first character in myCD/myHD
 	{"snh", "Hybrid release", kPlatformWindows, "SNHstart", kMovieScript, 0, 0,
 			6, "set mytest2 = FileIO(mnew, \"read\" mymovie)", "set mytest2 = FileIO(mnew, \"read\", mymovie)"},
 	{"snh", "Hybrid release", kPlatformWindows, "SNHstart", kMovieScript, 0, 0,
 			14, "set mytest3 = FileIO(mnew, \"read\" mymovie)", "set mytest3 = FileIO(mnew, \"read\", mymovie)"},
+
 
 	// Ambiguous syntax that's parsed differently between D3 and later versions
 	{"henachoco03", "", kPlatformMacintosh, "xn--oj7cxalkre7cjz1d2agc0e8b1cm", kMovieScript, 0, 0,
@@ -188,10 +191,12 @@ struct ScriptPatch {
 			123, "locaobject(mLHizikaraHand (rhenka + 1),dotti)", "locaobject(mLHizikaraHand,(rhenka + 1),dotti)"},
 	{"henachoco03", "Demo", kPlatformMacintosh, "Muzukashiihon", kMovieScript, 0, 0,
 			136, "locaobject(mRHizikaraHand (rhenka + 1),dotti)", "locaobject(mRHizikaraHand,(rhenka + 1),dotti)"},
-	
+
+
 	// C.H.A.O.S
 	{"chaos", "", kPlatformWindows, "Intro", kCastScript, 10, 0,
 			9, "rHyperPACo \"blank\", 498, 350 gGenPathWay", "rHyperPACo \"blank\", 498, 350, gGenPathWay"},
+
 
 	{nullptr, nullptr, kPlatformUnknown, nullptr, kNoneScript, 0, 0, 0, nullptr, nullptr}
 };

--- a/engines/director/lingo/lingo-patcher.cpp
+++ b/engines/director/lingo/lingo-patcher.cpp
@@ -198,6 +198,24 @@ struct ScriptPatch {
 			9, "rHyperPACo \"blank\", 498, 350 gGenPathWay", "rHyperPACo \"blank\", 498, 350, gGenPathWay"},
 
 
+	{"smile", "v1.1", kPlatformMacintosh, "SMILE! The Splattering", kScoreScript, 24, 0,
+			1, "go to frame \"Info b\"If you have not paid   ", "go to frame \"Info b\""},
+
+
+	{"amandastories", "", kPlatformWindows, "Shared Cast", kMovieScript, 512, 0,
+			55, "    set mytest1 = FileIO(mnew, \"read\" mymovie)", "    set mytest1 = FileIO(mnew, \"read\", mymovie)"},
+	{"amandastories", "", kPlatformWindows, "Shared Cast", kMovieScript, 512, 0,
+			63, "      set mytest2 = FileIO(mnew, \"read\" mymovie)", "      set mytest2 = FileIO(mnew, \"read\", mymovie)"},
+	{"amandastories", "", kPlatformWindows, "Shared Cast", kMovieScript, 512, 0,
+			70, "          set mytest3 = FileIO(mnew, \"read\" mymovie)", "          set mytest3 = FileIO(mnew, \"read\", mymovie)"},
+	{"amandastories", "", kPlatformWindows, "ASstart", kMovieScript, 0, 0,
+			5, "  set mytest = FileIO(mnew, \"read\" mymovie)", "  set mytest = FileIO(mnew, \"read\", mymovie)"},
+	{"amandastories", "", kPlatformWindows, "ASstart", kMovieScript, 0, 0,
+			11, "    set mytest2 = FileIO(mnew, \"read\" mymovie)", "    set mytest2 = FileIO(mnew, \"read\", mymovie)"},
+	{"amandastories", "", kPlatformWindows, "ASstart", kMovieScript, 0, 0,
+			19, "      set mytest3 = FileIO(mnew, \"read\" mymovie)", "      set mytest3 = FileIO(mnew, \"read\", mymovie)"},
+
+
 	{nullptr, nullptr, kPlatformUnknown, nullptr, kNoneScript, 0, 0, 0, nullptr, nullptr}
 };
 

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -544,8 +544,8 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 		// 22 - PowerBook 100			D3
 		// 23 - PowerBook 140			D3
 		// 24 - Macintosh Quadra 950	D4
-		// 25 - Macintosh LCIII			D4
-		// 27 - PowerBook Duo 210		D4
+		// 25 - PowerBook Duo 210		D4
+		// 27 - Macintosh LCIII			D4
 		// 28 - Macintosh Centris 650	D4
 		// 30 - PowerBook Duo 230		D4
 		// 31 - PowerBook 180			D4

--- a/engines/director/lingo/xlibs/cdromxobj.cpp
+++ b/engines/director/lingo/xlibs/cdromxobj.cpp
@@ -20,87 +20,138 @@
  */
 
 /*
- * mNew	 creates a new object instance for a single
- *     CD-ROM player. if the Apple Audio CD Player is not
- *     mounted the instance will not be created.
- *
- * mDispose  disposes of the current instance.
- *     This should always be called when you are finished
- *     using the XObject.
- *
- * mName  returns the name of the XObj.
- *
- * mPlay  plays the  current track from the beginning.
- *
- * mPlayTrack, trackNum  plays the specified track number
- *     from its beginning.
- *
- * mPlayName, trackName  plays the specified track name.
- *     (Note: volume name is ignored.)
- *
- * mPlayAbsTime, minute, second, frame  plays starting at
- *     the specified absolute time on current CD-ROM.
- *
- * mPlaySegment, startMin, startSec, startFrm, stopMin, stopSec, stopFrm  plays starting at the specified absolute
- *     time, and stops at the specified stopping point.
- *
- * mAskPlay, leftDialogPosition, topDialogPosition  opens
- *     a standard file dialog for the user to select a track.
- *
- * mStepFwd  steps forward one track and plays.
- *
- * mStepBwd  steps back one track and plays.
- *
- * mPause  pauses the player. When this method is called a
- *     second time, the player will continue the mode prior to
- *     first call; just like calling mContinue.
- *
- * mContinue  continues the mode prior to calling mPause.
- *
- * mStop  stops playing.
- *
- * mStopTrack, trackNum  stops when specified track
- *     finishes playing.
- *
- * mStopAbsTime, minute, second, frame  stops play at
- *     absolute time position.
- *
- * mRemoveStop  removes the conditions which are set
- *     with: mPlaySegment, mStopTrack and mStopAbsTime.
- *
- * mEject  ejects the CD from the drive.
- *
- * mStatus  returns the status of the CD player. See the
- *     mDescribe for a list of messages which are returned.
- *
- * mPlayMode  returns the play mode from an audio track.
- *     The play mode describes how to play the audio track.
- *     See the mDescribe for a list of messages.
- *
- * mCurrentFormat  returns the format of the current track
- *     See the mDescribe for a list of messages.
- *
- * mCurrentTrack  returns the current track.
- *
- * mCurrentTime  returns the current time (min:sec:frame).
- *
- * mFirstTrack  returns the first track number on current CD
- *
- * mLastTrack  returns the last track number on current CD
- *
- * mTotalTime  returns the total time on current CD in
- *     minutes:seconds:frames.
- *
- * mScanFwd min, sec, frm, monitorP  scans forward.
- * mScanBwd min, sec, frm, monitorP  scans backwards.
- *   min, sec, and frm are the absolute time to start scan.
- *   monitorP — if true, will stop scan when mouse is
- *   released, and continue playing at current position.
- *   However, this will inhibit all other events.
- *   Otherwise use the mStopScan method.
- *
- * mStopScan  stops scan and continues playing at current
- *     position.
+  --AppleAudioCD, CDAudio, 1.0, 4/3/90
+  --
+  --© 1989, 1990 MacroMind, Inc.
+  -- by Jeff Tanner
+  --
+  ------------------------------------------------------
+  ------------------------------------------------------
+  --  An Apple CD SC Player must be mounted
+  --      in order for this XObject to operate properly.
+  --      The easiest way to check for mounting is to
+  --      check the desktop for the CD icon.
+  ------------------------------------------------------
+  ------------------------------------------------------
+  -- This XObject recognizes only the first player in the SCSI chain .
+  ------------------------------------------------------
+  ------------------------------------------------------
+  --=METHODS=--
+  X   mNew --Creates a new instance of the XObject.
+  X   mDispose --Disposes of the instance.
+  S   mName --Returns name of the XObject.
+  ------------------------------------------------------
+  ------------------------------------------------------
+  -- PLAY CD METHODS:
+  S   mPlay --Plays current track from the beginning.
+  SI mPlayTrack, trackNum --Plays the specified track from the beginning.
+  SS   mPlayName, trackName --Plays by track name.
+  --      Note: The full pathname is unnecessary.
+  --      The track names for tracks 1 - 9 are
+  --          "TRACK<space><space>trackNum" and for tracks 10 to 99 are
+  --          "TRACK<space>trackNum".
+  SIII mPlayAbsTime, minute, second, frame --Starts play at absolute time position on current CD-ROM.
+  --
+  SIIIIII mPlaySegment, startMin, startSec, startFrm, stopMin, stopSec, stopFrm
+  --          < startMin, startSec, startFrm > - Start time
+  --          < stopMin, stopSec, stopFrm > - Stop time
+  SII  mAskPlay, leftDialog, topDialog        --With a file dialog box,
+  --                                  selects an Audio track to play.
+  --          < leftDialog, topDialog > - Where to place the file dialog box
+  ------------------------------------------------------
+  S   mStepFwd --Steps forward one track and Plays.
+  S   mStepBwd --Steps back one track and Plays.
+  --
+  S    mPause --Pauses the player.
+  --      When this method is called a second time,
+  --      the player will continue in normal play mode.
+  S    mContinue --Continues the mode prior to calling mPause.
+  --
+  S    mStop                              --Stops play.
+  SI   mStopTrack, trackNum               --Stops when the selected track finishes playing.
+  SIII mStopAbsTime, minute, second, frame --Stops play at a specified absolute time position.
+  S    mRemoveStop -- Removes stop conditions.
+  --          Stop conditions are set with these methods:
+  --                  mPlaySegment
+  --                  mStopTrack
+  --                  mStopAbsTime
+  --
+  S    mEject --Ejects CD-ROM from drive.
+  --
+  ------------------------------------------------------
+  ------------------------------------------------------
+  -- STATUS METHODS:
+  S    mStatus --Returns status of Audio CD player.
+  --      Returns message strings:
+  --          Audio play in progress
+  --          Audio pause in operation
+  --          Audio muting on
+  --          Audio play operation completed
+  --          Error occurred during audio play
+  --          Not currently playing
+  --
+  S    mPlayMode      --Returns a play mode from audio track.
+  --      The play mode describes how to play the audio track.
+  --      Returns message strings:
+  --          Muting on (no audio)
+  --          Right channel through right channel only
+  --          Left channel through right channel only
+  --          Left and right channels through right channel only
+  --          Right channel through left channel only
+  --          Right channel through left and right channel
+  --          Right channel through left channel,
+  --              Left channel through right channel
+  --          Right channel through left channel,
+  --              Left and right channels through right channel
+  --          Left channel through left channel only
+  --          Left channel through left channel,
+  --              Right channel through right channel (Stereo)
+  --          Left channel through left and right channel
+  --          Left channel through left channel,
+  --              Left and right channels through right channel
+  --          Left and right channels through left channel only
+  --          Left and right channels through left channel,
+  --              Right channel through right channel
+  --          Left and right channels through left channel,
+  --              Left channel through right channel
+  --          Left and right channels through
+  --              both left channel and right channel (Mono)
+  --
+  S    mCurrentFormat         --Returns the format of the current track.
+  --      Returns message strings:
+  --          2 audio channels without preemphasis
+  --          2 audio channels with preemphasis
+  --          4 audio channels without preemphasis
+  --          4 audio channels with preemphasis
+  --          Data track
+  --
+  ------------------------------------------------------
+  ------------------------------------------------------
+  --
+  I    mCurrentTrack --Returns number of the current track.
+  S    mCurrentTime  --Returns the current absolute time (min:sec:frm).
+  --
+  I    mFirstTrack  -- Returns first track number on current CD-ROM.
+  I    mLastTrack  -- Returns last track number on current CD-ROM.
+  S    mTotalTime -- Returns total time on current CD-ROM (min:sec:frm)
+  ------------------------------------------------------
+  ------------------------------------------------------
+  -- SCANNING METHODS:
+  -- Starting at a specific time:
+  --   min, sec, and frm parameters are to indicate
+  --      the absolute time to start scan.
+  --   monitorP - if true, it will stop scan moment mouse
+  --      is released, and continue playing at current position.
+  --      However, this will inhibit all other events.
+  --      Otherwise use mStopScan method.
+  SIIII mScanFwd min, sec, frm, monitorP -- Fast forward scan
+  SIIII mScanBwd min, sec, frm, monitorP -- Fast reverse scan
+  --
+  S   mStopScan --Stops scan and continues playing at current position.
+  --
+  --  End description of AppleAudioCD XObject methods.
+  ------------------------------------------------------
+  ------------------------------------------------------
  */
 
 #include "backends/audiocd/audiocd.h"

--- a/engines/director/lingo/xlibs/darkenscreen.cpp
+++ b/engines/director/lingo/xlibs/darkenscreen.cpp
@@ -1,0 +1,64 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*************************************
+ *
+ * USED IN:
+ * Secrets of the Pyramids (Mac)
+ * Mindscape's Wonder Land (Mac)
+ * Grackon's Curse (Mac)
+ * Return to Jurassic (Mac)
+ * Ednovation demos (Mac)
+ *
+ *************************************/
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/xlibs/darkenscreen.h"
+
+
+namespace Director {
+
+const char *DarkenScreen::xlibName = "darkenScreen";
+const char *DarkenScreen::fileNames[] = {
+	"darkenScreen",
+	0
+};
+
+static BuiltinProto builtins[] = {
+	{ "darkenScreen", DarkenScreen::m_darkenscreen, 0, 0, 300, HBLTIN },
+	{ nullptr, nullptr, 0, 0, 0, VOIDSYM }
+};
+
+void DarkenScreen::open(int type) {
+	g_lingo->initBuiltIns(builtins);
+}
+
+void DarkenScreen::close(int type) {
+	g_lingo->cleanupBuiltIns(builtins);
+}
+
+void DarkenScreen::m_darkenscreen(int nargs) {
+    g_lingo->printSTUBWithArglist("DarkenScreen::m_darkenscreen", nargs);
+}
+
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/darkenscreen.h
+++ b/engines/director/lingo/xlibs/darkenscreen.h
@@ -1,0 +1,41 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XLIBS_DARKENSCREEN_H
+#define DIRECTOR_LINGO_XLIBS_DARKENSCREEN_H
+
+namespace Director {
+
+namespace DarkenScreen {
+
+extern const char *xlibName;
+extern const char *fileNames[];
+
+void open(int type);
+void close(int type);
+
+void m_darkenscreen(int nargs);
+
+} // End of namespace DarkenScreen
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/lingo/xlibs/ednox.cpp
+++ b/engines/director/lingo/xlibs/ednox.cpp
@@ -1,0 +1,236 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*************************************
+ *
+ * USED IN:
+ * Secrets of the Pyramids (Win)
+ * Mindscape's Wonder Land (Win)
+ * Grackon's Curse (Win)
+ * Return to Jurassic (Win)
+ *
+ *************************************/
+/*
+-- Ednox External Factory. 22Nov93 PTM
+ednox
+I      mNew                --Creates a new instance of the XObject
+X      mDispose            --Disposes of XObject instance
+S      mName               --Returns the XObject name (Widget)
+I      mStatus             --Returns an integer status code
+SI     mError, code        --Returns an error string
+S      mLastError          --Returns last error string
+SSI    playSoundX       --Play an external sound, return status string
+S      clearSoundX      --Stop an external sound, return status string
+S      checkSoundX      --check an external sound,see if it is still playing
+SS      drawBkgndX,hBkgnd   --draw background image, from resource bitmap
+SS     SaveX, hStrIn    --Save string into a file(file name will be prompted
+SSSI    GetPathX,hSection,hStrIn,mMacMode, Retrieve the installed path name from the win.ini and return
+S      RestoreX     --Restore string from a file(file name will be prompted
+SS      SetDriveX,hStrIn    --Set the current path name
+SSS    IsCDX,hDrive,hStrIn --Check for the correct CD
+S      EnableTaskSwitch    --enable task switch
+S      DisableTaskSwitch   --Disable task switch
+SSS    getDocumentName,hdir,hext --Get strings of file in specific directory
+SSS    getDocumentFile,hDir,hFile --Get string from a file
+SSSS   saveDocumentFile,hDir,hFile,hStrIn --save string into a file
+SSS    deleteDocumentFile,hDir,hFile  -- delete a file from the directory
+*/
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/xlibs/ednox.h"
+
+
+namespace Director {
+
+const char *Ednox::xlibName = "Ednox";
+const char *Ednox::fileNames[] = {
+	"Ednox",
+	0
+};
+
+static MethodProto xlibMethods[] = {
+	{ "mNew",				Ednox::m_new,					0,	0,	300 },	// d3
+	{ "mDispose",			Ednox::m_dispose,				0,	0,	300 },	// d3
+	{ "mName",				Ednox::m_name,					0,	0,	300 },	// d3
+	{ "mStatus",			Ednox::m_status,				0,	0,	300 },	// d3
+	{ "mError",				Ednox::m_error,					1,	1,	300 },	// d3
+	{ "mLastError",			Ednox::m_lasterror,				0,	0,	300 },	// d3
+	{ "playSoundX",			Ednox::m_playsoundx,			2,	2,	300 },	// d3
+	{ "clearSoundX",		Ednox::m_clearsoundx,			0,	0,	300 },	// d3
+	{ "checkSoundX",		Ednox::m_checksoundx,			0,	0,	300 },	// d3
+	{ "drawBkgndX",			Ednox::m_drawbkgndx,			1,	1,	300 },	// d3
+	{ "SaveX",				Ednox::m_savex,					1,	1,	300 },	// d3
+	{ "GetPathX",			Ednox::m_getpathx,				3,	3,	300 },	// d3
+	{ "RestoreX",			Ednox::m_restorex,				0,	0,	300 },	// d3
+	{ "SetDriveX",			Ednox::m_setdrivex,				1,	1,	300 },	// d3
+	{ "IsCDX",				Ednox::m_iscdx,					2,	2,	300 },	// d3
+	{ "EnableTaskSwitch",	Ednox::m_enabletaskswitch,		0,	0,	300 },	// d3
+	{ "DisableTaskSwitch",	Ednox::m_disabletaskswitch,		0,	0,	300 },	// d3
+	{ "getDocumentName",	Ednox::m_getdocumentname,		2,	2,	300 },	// d3
+	{ "getDocumentFile",	Ednox::m_getdocumentfile,		2,	2,	300 },	// d3
+	{ "saveDocumentFile",	Ednox::m_savedocumentfile,		3,	3,	300 },	// d3
+	{ "deleteDocumentFile",	Ednox::m_deletedocumentfile,	2,	2,	300 },	// d3
+	{ nullptr, nullptr, 0, 0, 0 }
+};
+
+void Ednox::open(int type) {
+	if (type == kXObj) {
+		EdnoxObject::initMethods(xlibMethods);
+		EdnoxObject *xobj = new EdnoxObject(kXObj);
+		g_lingo->exposeXObject(xlibName, xobj);
+	}
+}
+
+void Ednox::close(int type) {
+	if (type == kXObj) {
+		EdnoxObject::cleanupMethods();
+		g_lingo->_globalvars[xlibName] = Datum();
+	}
+}
+
+
+EdnoxObject::EdnoxObject(ObjectType ObjectType) :Object<EdnoxObject>("Ednox") {
+	_objType = ObjectType;
+}
+
+void Ednox::m_new(int nargs) {
+	g_lingo->push(g_lingo->_currentMe);
+}
+
+void Ednox::m_dispose(int nargs) {
+	g_lingo->printSTUBWithArglist("Ednox::m_dispose", nargs);
+}
+
+void Ednox::m_getdocumentfile(int nargs) {
+	// Common::U32String hFile = g_lingo->pop().asString();
+	// Common::U32String hDir = g_lingo->pop().asString();
+	g_lingo->printSTUBWithArglist("Ednox::m_getdocumentfile", nargs);
+	g_lingo->dropStack(nargs);
+}
+
+void Ednox::m_getpathx(int nargs) {
+	/* int mMacMode = */ g_lingo->pop().asInt();
+	Common::U32String hStrIn = g_lingo->pop().asString();
+	/* Common::U32String hSection = */ g_lingo->pop().asString();
+	hStrIn.toLowercase();
+	if (hStrIn == "cdpath"){
+		g_lingo->push(Datum("d:\\"));
+	} else {
+		g_lingo->push(Datum(""));
+	}
+}
+
+void Ednox::m_iscdx(int nargs) {
+	/* Common::U32String hStrIn = */ g_lingo->pop().asString();
+	Common::U32String hDrive = g_lingo->pop().asString();
+	// g_lingo->printSTUBWithArglist("Ednox::m_iscdx", nargs);
+	if (hDrive == "d:\\"){
+		g_lingo->push(Datum(0));
+	} else {
+		g_lingo->push(Datum(-1));
+	}
+}
+
+void Ednox::m_savedocumentfile(int nargs) {
+	// Common::U32String hStrIn = g_lingo->pop().asString();
+	// Common::U32String hFile = g_lingo->pop().asString();
+	// Common::U32String hDir = g_lingo->pop().asString();
+	g_lingo->printSTUBWithArglist("Ednox::m_savedocumentfile", nargs);
+	g_lingo->dropStack(nargs);
+}
+
+void Ednox::m_setdrivex(int nargs) {
+	// Common::U32String hStrIn = g_lingo->pop().asString();
+	g_lingo->printSTUBWithArglist("Ednox::m_setdrivex", nargs);
+	g_lingo->dropStack(nargs);
+	g_lingo->push(Datum(0));
+}
+
+void Ednox::m_checksoundx(int nargs) {
+	g_lingo->printSTUBWithArglist("Ednox::m_checksoundx", nargs);
+}
+
+void Ednox::m_clearsoundx(int nargs) {
+	g_lingo->printSTUBWithArglist("Ednox::m_clearsoundx", nargs);
+}
+
+void Ednox::m_deletedocumentfile(int nargs) {
+	// Common::U32String hFile = g_lingo->pop().asString();
+	// Common::U32String hDir = g_lingo->pop().asString();
+	g_lingo->printSTUBWithArglist("Ednox::m_deletedocumentfile", nargs);
+	g_lingo->dropStack(nargs);
+}
+
+void Ednox::m_disabletaskswitch(int nargs) {
+	g_lingo->printSTUBWithArglist("Ednox::m_disabletaskswitch", nargs);
+}
+
+void Ednox::m_drawbkgndx(int nargs) {
+	// Common::U32String hBkgnd = g_lingo->pop().asString();
+	g_lingo->printSTUBWithArglist("Ednox::m_drawbkgndx", nargs);
+}
+
+void Ednox::m_enabletaskswitch(int nargs) {
+	g_lingo->printSTUBWithArglist("Ednox::m_enabletaskswitch", nargs);
+}
+
+void Ednox::m_getdocumentname(int nargs) {
+	// Common::U32String hExt = g_lingo->pop().asString();
+	// Common::U32String hDir = g_lingo->pop().asString();
+	g_lingo->printSTUBWithArglist("Ednox::m_getdocumentname", nargs);
+	g_lingo->dropStack(nargs);
+}
+
+void Ednox::m_error(int nargs) {
+	// int code = g_lingo->pop().asInt();
+	g_lingo->printSTUBWithArglist("Ednox::m_error", nargs);
+	g_lingo->dropStack(nargs);
+}
+
+void Ednox::m_lasterror(int nargs) {
+	g_lingo->printSTUBWithArglist("Ednox::m_lasterror", nargs);
+}
+
+void Ednox::m_name(int nargs) {
+	g_lingo->push(Datum("ednox"));
+}
+
+void Ednox::m_status(int nargs) {
+	g_lingo->printSTUBWithArglist("Ednox::m_status", nargs);
+}
+
+void Ednox::m_playsoundx(int nargs) {
+	g_lingo->printSTUBWithArglist("Ednox::m_playsoundx", nargs);
+}
+
+void Ednox::m_restorex(int nargs) {
+	g_lingo->printSTUBWithArglist("Ednox::m_restorex", nargs);
+}
+
+void Ednox::m_savex(int nargs) {
+	// Common::U32String hStrIn = g_lingo->pop().asString();
+	g_lingo->printSTUBWithArglist("Ednox::m_savex", nargs);
+	g_lingo->dropStack(nargs);
+}
+
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/ednox.h
+++ b/engines/director/lingo/xlibs/ednox.h
@@ -1,0 +1,66 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XLIBS_EDNOX_H
+#define DIRECTOR_LINGO_XLIBS_EDNOX_H
+
+namespace Director {
+
+class EdnoxObject : public Object<EdnoxObject> {
+public:
+    EdnoxObject(ObjectType objType);
+};
+
+namespace Ednox {
+
+extern const char *xlibName;
+extern const char *fileNames[];
+
+void open(int type);
+void close(int type);
+
+void m_new(int nargs);
+void m_dispose(int nargs);
+void m_name(int nargs);
+void m_status(int nargs);
+void m_error(int nargs);
+void m_lasterror(int nargs);
+void m_playsoundx(int nargs);
+void m_clearsoundx(int nargs);
+void m_checksoundx(int nargs);
+void m_drawbkgndx(int nargs);
+void m_savex(int nargs);
+void m_getpathx(int nargs);
+void m_restorex(int nargs);
+void m_setdrivex(int nargs);
+void m_iscdx(int nargs);
+void m_enabletaskswitch(int nargs);
+void m_disabletaskswitch(int nargs);
+void m_getdocumentname(int nargs);
+void m_getdocumentfile(int nargs);
+void m_savedocumentfile(int nargs);
+void m_deletedocumentfile(int nargs);
+
+} // End of namespace Ednox
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/lingo/xlibs/fileexists.cpp
+++ b/engines/director/lingo/xlibs/fileexists.cpp
@@ -1,0 +1,82 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*************************************
+ *
+ * USED IN:
+ * Yearn2Learn: The Flintstones Coloring Book
+ *
+ *************************************/
+/*
+ * © 1989,1990 Apple Computer, Inc., v.1.1, by Anup Murarka
+ * FileExists(pathname «, “noDialog”:errGlobal»)
+*/
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/xlibs/fileexists.h"
+#include "common/savefile.h"
+
+
+namespace Director {
+
+const char *FileExists::xlibName = "FileExists";
+const char *FileExists::fileNames[] = {
+	"FileExists",
+	0
+};
+
+static BuiltinProto builtins[] = {
+	{ "FileExists", FileExists::m_fileexists, 1, 1, 300, HBLTIN },
+	{ nullptr, nullptr, 0, 0, 0, VOIDSYM }
+};
+
+void FileExists::open(int type) {
+	g_lingo->initBuiltIns(builtins);
+}
+
+void FileExists::close(int type) {
+	g_lingo->cleanupBuiltIns(builtins);
+}
+
+void FileExists::m_fileexists(int nargs) {
+	// This is mostly copied from FileIO::m_new
+	Common::SaveFileManager *saves = g_system->getSavefileManager();
+	Common::String path = g_lingo->pop().asString();
+	Common::String origpath = path;
+
+	if (!path.hasSuffixIgnoreCase(".txt")) {
+		path += ".txt";
+	}
+	Common::String filename = lastPathComponent(path, g_director->_dirSeparator);
+	if (!(saves->exists(filename))) {
+		Common::File *f = new Common::File;
+
+		if (!f->open(Common::Path(pathMakeRelative(origpath), g_director->_dirSeparator))) {
+			g_lingo->push(Datum(false));
+			return;
+		}
+		g_lingo->push(Datum(true));
+	}
+}
+
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/fileexists.h
+++ b/engines/director/lingo/xlibs/fileexists.h
@@ -1,0 +1,41 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XLIBS_FILEEXISTS_H
+#define DIRECTOR_LINGO_XLIBS_FILEEXISTS_H
+
+namespace Director {
+
+namespace FileExists {
+
+extern const char *xlibName;
+extern const char *fileNames[];
+
+void open(int type);
+void close(int type);
+
+void m_fileexists(int nargs);
+
+} // End of namespace FileExists
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/lingo/xlibs/fileio.cpp
+++ b/engines/director/lingo/xlibs/fileio.cpp
@@ -19,6 +19,67 @@
  *
  */
 
+/*
+  --FileIO, Tool, 1.5.0 , 31mar92
+  --© 1989-1992 MacroMind, Inc.
+  --by John Thompson and Al McNeil
+  ---------------------------------------------------------------------
+  ---------------------------------------------------------------------
+  --=METHODS=--
+  --
+  ISS mNew, mode, fileNameOrType  --Creates a new instance of the XObject.
+  --  Mode can be :
+  --    "read"  - Read "fileName"
+  --    "?read"   - Select and Read "fileType"
+  --    "write"   - Write "fileName"
+  --    "?write"  - Select and Write "fileName"
+  --    "append"  - Append "fileName"
+  --    "?append" - Select and Append "fileName"
+  --  FileType for ?read can be :
+  --    "TEXT" - standard file type
+  --    "trak" - cd track type
+  --    etc... - Any four character combination.
+  --
+  X mDispose  --Disposes of XObject instance.
+  S mName --Returns the name of the XObject.
+  /IXX  mWrite, countPtr, bufferPtr --Writes out a set of chars. Returns error code.
+  II  mWriteChar, charNum --Writes a single character. Returns error code.
+  IS  mWriteString, string  --Writes out a string of chars. Returns error code.
+  /IXX  mRead, countPtr, bufferPtr  --Reads into buffer. Returns error code.
+  I mReadChar   --Returns a single character.
+  S mReadWord   --Returns the next word of an input file.
+  S mReadLine --Returns the next line of an input file.
+  S mReadFile --Returns the remainder of the file.
+  --
+  SSS mReadToken, breakString, skipString
+  --      --breakstring designates character (or token) that signals to stop reading.
+  --      --skipstring designates what characters (or tokens) not to read.
+  I mGetPosition  --Returns the file position.
+  II  mSetPosition, newPos  --Sets the file position. Returns error code.
+  I mGetLength  --Returns the number of chars in the file.
+  ISS mSetFinderInfo, typeString, creatorString --Sets the finder info. Returns error code.
+  S mGetFinderInfo  --Gets the finder info.
+  S mFileName --Returns the name of the file.
+  S mNativeFileName --Returns the name of the file.
+  I mDelete   --Delete the file and dispose of me.
+  I     mStatus  --Returns result code of the last file io activity
+  --
+  SI  +mError, errorCode  --Returns error message string.
+  -- Possible error codes:
+  --  -33 :: File directory full
+  --  -34 :: Volume full
+  --  -35 :: Volume not found
+  --  -36 :: I/O Error
+  --  -37 :: Bad file name
+  --  -38 :: File not open
+  --  -42 :: Too many files open
+  --  -43 :: File not found
+  --  -56 :: No such drive
+  --  -65 :: No disk in drive
+  --  -120 :: Directory not found
+  V     mReadPICT
+*/
+
 #include "gui/filebrowser-dialog.h"
 
 #include "common/memstream.h"

--- a/engines/director/lingo/xlibs/fileio.cpp
+++ b/engines/director/lingo/xlibs/fileio.cpp
@@ -110,7 +110,7 @@ static MethodProto xlibMethods[] = {
 	{ "readFile",				FileIO::m_readFile,			 0, 0,	200 },	// D2
 	{ "readLine",				FileIO::m_readLine,			 0, 0,	200 },	// D2
 	{ "readToken",				FileIO::m_readToken,		 2, 2,	200 },	// D2
-	{ "readPict",				FileIO::m_readPict,			 0,	0,	300 },  // D3
+	{ "readPict",				FileIO::m_readPict,			 0, 0,	300 },	// D3
 	{ "readWord",				FileIO::m_readWord,			 0, 0,	200 },	// D2
 	{ "setFinderInfo",			FileIO::m_setFinderInfo,	 2, 2,	200 },	// D2
 	{ "setPosition",			FileIO::m_setPosition,		 1, 1,	200 },	// D2

--- a/engines/director/lingo/xlibs/findfolder.cpp
+++ b/engines/director/lingo/xlibs/findfolder.cpp
@@ -1,0 +1,116 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*************************************
+ *
+ * USED IN:
+ * Yearn2Learn: The Flintstones Coloring Book
+ *
+ *************************************/
+/*
+                                             FindFolder 1.1
+
+                                        by Frédéric RINALDI
+
+
+DESCRIPTION
+------------
+  FindFolder returns the full pathname of the active System folder or any of its reserved folders (System 7.0).
+
+
+SYNTAX
+-------
+                        FindFolder([<folder descriptor>[,<create it>]])
+
+PARAMETERS
+------------
+   <folder descriptor> is a string describing the folder. It must be one of these values (only first char is checked) :
+          A[pple menu]
+          C[ontrol Panel]
+          D[esktop]
+          E[xtensions]
+          F[onts] (System 7.1 only)
+          P[references]
+          M[onitor printing]
+          N[etwork trash]
+          T[rash]
+          I[tems startup]
+          S[ystem]
+          Y : TemporarY items
+
+   Default value is "S".
+
+   <create it> is a boolean telling if the XFCN must create the folder if not found (only with System 7.0). Default is FALSE.
+
+   Both parameters are optional. Using "!", "?" or "=" as first parameter will return an online help (resp. copyright,  syntax and output).
+
+USING
+-----
+  The XFCN returns the full pathname of the requested folder, ending with colon.
+   Under System 6.0, only current System folder can be returned.
+
+ERRORS
+-------
+If an error occurs, the XFCN can return :
+     "Error : Empty parameter"
+     "Error : Second param must be boolean"
+     "Error : Folder not found"
+     "Error : Found file instead of folder"
+
+HISTORY
+-------
+1.1 :                                                                                          04/21/92
+• Added "font" param for System 7.1
+*/
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/xlibs/findfolder.h"
+
+
+namespace Director {
+
+const char *FindFolder::xlibName = "FindFolder";
+const char *FindFolder::fileNames[] = {
+	"FindFolder",
+	0
+};
+
+static BuiltinProto builtins[] = {
+	{ "FindFolder", FindFolder::m_findfolder, 0, 2, 300, HBLTIN },
+	{ nullptr, nullptr, 0, 0, 0, VOIDSYM }
+};
+
+void FindFolder::open(int type) {
+	g_lingo->initBuiltIns(builtins);
+}
+
+void FindFolder::close(int type) {
+	g_lingo->cleanupBuiltIns(builtins);
+}
+
+void FindFolder::m_findfolder(int nargs) {
+	g_lingo->dropStack(nargs);
+	g_lingo->push(Datum(""));
+}
+
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/findfolder.h
+++ b/engines/director/lingo/xlibs/findfolder.h
@@ -1,0 +1,41 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XLIBS_FINDFOLDER_H
+#define DIRECTOR_LINGO_XLIBS_FINDFOLDER_H
+
+namespace Director {
+
+namespace FindFolder {
+
+extern const char *xlibName;
+extern const char *fileNames[];
+
+void open(int type);
+void close(int type);
+
+void m_findfolder(int nargs);
+
+} // End of namespace FindFolder
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/lingo/xlibs/iscd.cpp
+++ b/engines/director/lingo/xlibs/iscd.cpp
@@ -1,0 +1,66 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*************************************
+ *
+ * USED IN:
+ * Secrets of the Pyramids (Mac)
+ *
+ *************************************/
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/xlibs/iscd.h"
+
+
+namespace Director {
+
+const char *IsCD::xlibName = "isCD";
+const char *IsCD::fileNames[] = {
+	"isCD",
+	0
+};
+
+static BuiltinProto builtins[] = {
+	{ "isCD", IsCD::m_iscd, 1, 1, 300, HBLTIN },
+	{ nullptr, nullptr, 0, 0, 0, VOIDSYM }
+};
+
+void IsCD::open(int type) {
+	g_lingo->initBuiltIns(builtins);
+}
+
+void IsCD::close(int type) {
+	g_lingo->cleanupBuiltIns(builtins);
+}
+
+void IsCD::m_iscd(int nargs) {
+	// -1: running from hard drive
+	//  0: running on CD
+	//  1: no CD
+	//  2: disk name with the label
+	//  3: multiple CDs with the label
+	Common::String disk_label = g_lingo->pop().asString();
+	g_lingo->push(Datum(0));
+}
+
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/iscd.h
+++ b/engines/director/lingo/xlibs/iscd.h
@@ -1,0 +1,41 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XLIBS_ISCD_H
+#define DIRECTOR_LINGO_XLIBS_ISCD_H
+
+namespace Director {
+
+namespace IsCD {
+
+extern const char *xlibName;
+extern const char *fileNames[];
+
+void open(int type);
+void close(int type);
+
+void m_iscd(int nargs);
+
+} // End of namespace IsCD
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/lingo/xlibs/ispippin.cpp
+++ b/engines/director/lingo/xlibs/ispippin.cpp
@@ -1,0 +1,61 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*************************************
+ *
+ * USED IN:
+ * Circus! (Pippin)
+ *
+ *************************************/
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/xlibs/ispippin.h"
+
+
+namespace Director {
+
+const char *IsPippin::xlibName = "IsPippin";
+const char *IsPippin::fileNames[] = {
+	"IsPippin",
+	0
+};
+
+static BuiltinProto builtins[] = {
+	{ "IsPippin", IsPippin::m_ispippin, 0, 0, 400, HBLTIN },
+	{ nullptr, nullptr, 0, 0, 0, VOIDSYM }
+};
+
+void IsPippin::open(int type) {
+	g_lingo->initBuiltIns(builtins);
+}
+
+void IsPippin::close(int type) {
+	g_lingo->cleanupBuiltIns(builtins);
+}
+
+void IsPippin::m_ispippin(int nargs) {
+	// Simply returns "true" or "false"
+	g_lingo->push(Datum(g_director->getPlatform() == Common::kPlatformPippin ? "true" : "false"));
+}
+
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/ispippin.h
+++ b/engines/director/lingo/xlibs/ispippin.h
@@ -1,0 +1,41 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XLIBS_ISPIPPIN_H
+#define DIRECTOR_LINGO_XLIBS_ISPIPPIN_H
+
+namespace Director {
+
+namespace IsPippin {
+
+extern const char *xlibName;
+extern const char *fileNames[];
+
+void open(int type);
+void close(int type);
+
+void m_ispippin(int nargs);
+
+} // End of namespace IsPippin
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/lingo/xlibs/jitdraw3.cpp
+++ b/engines/director/lingo/xlibs/jitdraw3.cpp
@@ -81,11 +81,11 @@ static MethodProto xlibMethods[] = {
 	{ "Dispose",			JITDraw3XObj::m_dispose,		  0, 0,	400 },	// D4
 	{ "CheckIfCDROM",		JITDraw3XObj::m_checkifcdrom,	  0, 0,	400 },	// D4
 	{ "MsgOkCancel",		JITDraw3XObj::m_msgokcancel,	  2, 2,	400 },	// D4
-	{ "MsgOk",				JITDraw3XObj::m_msgok,			  2, 2,  400 },	// D4
-	{ "MsgYesNo",			JITDraw3XObj::m_msgyesno,		  2, 2,  400 },	// D4
-	{ "GotoDraw",			JITDraw3XObj::m_gotodraw,		  0, 0,  400 },	// D4
-	{ "AddDrawButton",		JITDraw3XObj::m_adddrawbutton,	  0, 0,  400 },	// D4
-	{ "RemoveDrawButton",	JITDraw3XObj::m_removedrawbutton, 0, 0,  400 },	// D4
+	{ "MsgOk",				JITDraw3XObj::m_msgok,			  2, 2,	400 },	// D4
+	{ "MsgYesNo",			JITDraw3XObj::m_msgyesno,		  2, 2,	400 },	// D4
+	{ "GotoDraw",			JITDraw3XObj::m_gotodraw,		  0, 0,	400 },	// D4
+	{ "AddDrawButton",		JITDraw3XObj::m_adddrawbutton,	  0, 0,	400 },	// D4
+	{ "RemoveDrawButton",	JITDraw3XObj::m_removedrawbutton, 0, 0,	400 },	// D4
 	{ nullptr, nullptr, 0, 0, 0 }
 };
 

--- a/engines/director/lingo/xlibs/miscx.cpp
+++ b/engines/director/lingo/xlibs/miscx.cpp
@@ -77,7 +77,7 @@ static MethodProto xlibMethods[] = {
 	{ "BootName",				MiscX::m_bootName,		0,	0,	400 },	// D4
 	{ "InsureFolder",			MiscX::m_insureFolder,	1,	1,	400 },	// D4
 	{ "PrefsFolder",			MiscX::m_prefsFolder,	0,	0,	400 },	// D4
-    { nullptr, nullptr, 0, 0, 0 }
+	{ nullptr, nullptr, 0, 0, 0 }
 };
 
 void MiscX::open(int type) {

--- a/engines/director/lingo/xlibs/moovxobj.cpp
+++ b/engines/director/lingo/xlibs/moovxobj.cpp
@@ -21,30 +21,28 @@
 
 /*************************************
  *
- * Xobject to play Quicktime Videos
- *
  * USED IN:
- * C.H.A.O.S. Continuum
+ * The C.H.A.O.S. Continuum (Windows)
  *
  *************************************/
 
 /*
---moovXobj 10.22.93 <<gzr>>
-moovXobj
-I		mNew							--Creates a new instance of the XObject.
-X		mDispose						--Disposes of XObject instance.
-S		mName							--Returns the XObject name (moovobj).
-I		mMovieInit						--Initialize QTW.
-I		mMovieKill						--Dispose of QTW.
-I		mFondler						--Movie idle task.
-ISII	mPlayMovie name,left,top		--Play movie at designated location.
-I		mPauseMovie						--Pause active movie.
-II		mSoundMovie						--Turn movie sound on or off.
-I		mStopMovie						--Stops active movie.
-I		mMovieDone						--Returns true if movie done.
+  moovXobj: Creative Multimedia, 1993 <<gzr>>
+  --moovXobj 10.22.93 <<gzr>>
+  moovXobj
+  I       mNew                            --Creates a new instance of the XObject.
+  X       mDispose                        --Disposes of XObject instance.
+  S       mName                           --Returns the XObject name (moovobj).
+  I       mMovieInit                      --Initialize QTW.
+  I       mMovieKill                      --Dispose of QTW.
+  I       mFondler                        --Movie idle task.
+  ISII    mPlayMovie name,left,top        --Play movie at designated location.
+  I       mPauseMovie                     --Pause active movie.
+  II      mSoundMovie                     --Turn movie sound on or off.
+  I       mStopMovie                      --Stops active movie.
+  I       mMovieDone                      --Returns true if movie done.
 
-ScummVM Note: mMovieDone returns true when the movie is _not_ done.
-
+  ScummVM Note: mMovieDone returns true when the movie is _not_ done.
  */
 
 #include "video/qt_decoder.h"
@@ -75,7 +73,6 @@ static MethodProto xlibMethods[] = {
 	{ "SoundMovie",				MoovXObj::m_soundMovie,	    	0,	0,	300 },	// D4
 	{ "StopMovie",				MoovXObj::m_stopMovie,	    	0,	0,	300 },	// D4
 	{ "MovieDone",				MoovXObj::m_movieDone,		    0,	0,	300 },	// D4
-
 	{ nullptr, nullptr, 0, 0, 0 }
 };
 
@@ -197,5 +194,4 @@ void MoovXObj::m_movieDone(int nargs) {
 	g_lingo->push(result);
 }
 
-}
-// End of namespace Director
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/moovxobj.cpp
+++ b/engines/director/lingo/xlibs/moovxobj.cpp
@@ -70,7 +70,7 @@ static MethodProto xlibMethods[] = {
 	{ "Fondler",				MoovXObj::m_fondler,	    	0,	0,	300 },	// D4
 	{ "PlayMovie",				MoovXObj::m_playMovie,		    3,	3,	300 },	// D4
 	{ "PauseMovie",				MoovXObj::m_pauseMovie,	    	0,	0,	300 },	// D4
-	{ "SoundMovie",				MoovXObj::m_soundMovie,	    	0,	0,	300 },	// D4
+	{ "SoundMovie",				MoovXObj::m_soundMovie,	    	1,	1,	300 },	// D4
 	{ "StopMovie",				MoovXObj::m_stopMovie,	    	0,	0,	300 },	// D4
 	{ "MovieDone",				MoovXObj::m_movieDone,		    0,	0,	300 },	// D4
 	{ nullptr, nullptr, 0, 0, 0 }
@@ -180,6 +180,7 @@ void MoovXObj::m_pauseMovie(int nargs) {
 void MoovXObj::m_soundMovie(int nargs) {
 	// unused in C.H.A.O.S.
 	g_lingo->printSTUBWithArglist("MoovXObj::m_soundMovie", nargs);
+	g_lingo->dropStack(nargs);
 }
 
 void MoovXObj::m_stopMovie(int nargs) {

--- a/engines/director/lingo/xlibs/popupmenuxobj.cpp
+++ b/engines/director/lingo/xlibs/popupmenuxobj.cpp
@@ -20,24 +20,79 @@
  */
 
 /*
- * mAppendMenu, menuList  adds items to menuList
- * mDisableItem, itemNum  disables item in pop up menu
- * mEnableItem, itemNum  enables item in pop up menu
- * mGetItem, itemNum  returns item in pop up menu
- * mGetMenuID  returns assigned menuID number
- * mPopNum, Left, Top, itemNum  returns selected
- *     item’s number
- * mPopText, Left, Top, itemNum  returns selected
- *     item’s text
- * mSetItem, itemNum, newItemText  sets changes to an
- *     item in pop up menu
- * mSetItemMark, markNum  sets marker for pop up menu,
- *     default is check
- * mSmart, TrueOrFalse  remembers last selection if itemNum
- *    is 0 (there was no item selected by user)
- * mSetItemIcon, itemNum, iconID  attaches an icon to
- *    menu item; icons should have IDs from 257 to 511
- */
+  --PopMenu, Tool, 1.0, 4/1/90
+  --© 1989, 1990 MacroMind, Inc.
+  -- by Jeff Tanner
+  ------------------------------------------------
+  ------------------------------------------------
+  --  IMPORTANT NOTE:  In Lingo, build PopMenus after using
+  --    the command installMenu.  On the Mac, Pop-up menus are
+  --    extensions of the menu bar.  When the command installMenu
+  --    is called, this will remove all menus currently on
+  --    the menubar (including pop-up menus) and only install those
+  --    menus defined in the text window referenced by the
+  --    castNum parameter.  If installMenu is used after
+  --    creating PopMenus, these PopMenus must be disposed of
+  --    and then recreated.
+  ------------------------------------------------
+  --  MENULIST NOTE: In Lingo, there are several ways
+  --      to build the menu list for a PopUp menu.
+  --
+  --      - a menulist can be a continuous string
+  --          with items seperated by semicolons.
+  --          example: "item1;item2;item3"
+  --
+  --      - a menulist can be a set of strings, each
+  --          representing an item, separated by
+  --          &return& and ending with &return
+  --          example: "item1"&return&"item2"&return
+  --
+  --      - a menulist could come from a cast member with
+  --          each menu item separated by a carrage return.
+  --          example: set menulist to the text of cast A31
+  ------------------------------------------------
+  --  MENUITEM NOTE: Use only alphanumeric characters,
+  --      0 - 9 and A - Z.  Avoid dashes.  Indicate
+  --      style by "item1;item2<B;item3<U"
+  --      To change an item's style, add < followed by a
+  --      character at the end of the menu item text:
+  --          <B  Bold
+  --          <U  Underlined
+  --          <I  Italics
+  --          <S  Shadowed
+  --          <O  Outlined
+  ------------------------------------------------
+  ------------------------------------------------
+  --=METHODS=--
+  XSI     mNew, menuList, menuID --Creates a new instance of the XObject.
+  --   menuItemList - "item1;item2<B;item3<U"
+  --      Separate all items with semicolons.
+  --      Maximum character length of menulist is 256.
+  --   menuID - to avoid resourse conflict with Director,
+  --      use a menu ID between 100 and 1000.
+  --
+  X   mDispose --Disposes of the XObject instance.
+  S   mName --Returns the name of the XObject.
+  ------------------------------------------------
+  ------------------------------------------------
+  XS  mAppendMenu, menuList --Adds items to menuList.
+  XI  mDisableItem, itemNum --Disables item in pop up menu.
+  XI  mEnableItem, itemNum --Enables item in pop up menu.
+  SI  mGetItem, itemNum --Returns item in pop up menu.
+  I   mGetMenuID --Returns the assigned Menu ID number.
+  ------------------------------------------------
+  ------------------------------------------------
+  IIII    mPopNum, Left, Top, itemNum --Returns selected item's number.
+  SIII    mPopText, Left, Top, itemNum --Returns selected item's text.
+  ------------------------------------------------
+  ------------------------------------------------
+  XIS mSetItem, itemNum, newItemText --Sets changes to an item in pop up menu
+  XI  mSetItemMark, markNum --Sets marker for pop up menu: default is check.
+  XI  mSmart, TrueOrFalse --Remembers last selection if itemNum is 0
+  XII mSetItemIcon, itemNum, iconID --Attaches an icon to menu item, id# 257 - 511
+  ------------------------------------------------
+  ------------------------------------------------
+*/
 
 #include "director/director.h"
 #include "director/lingo/lingo.h"

--- a/engines/director/lingo/xlibs/qtmovie.cpp
+++ b/engines/director/lingo/xlibs/qtmovie.cpp
@@ -1,0 +1,64 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*************************************
+ *
+ * USED IN:
+ * L-Zone (Mac II)
+ *
+ *************************************/
+/*
+  QTMovie OpenMovie, windowType, fileName, location, options...
+*/
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/xlibs/qtmovie.h"
+
+
+namespace Director {
+
+const char *QTMovie::xlibName = "QTMovie";
+const char *QTMovie::fileNames[] = {
+	"QTMovie",
+	nullptr
+};
+
+static BuiltinProto builtins[] = {
+	{ "QTMovie", QTMovie::m_qtmovie, 3, 6, 300, HBLTIN },
+	{ nullptr, nullptr, 0, 0, 0, VOIDSYM }
+};
+
+void QTMovie::open(int type) {
+	g_lingo->initBuiltIns(builtins);
+}
+
+void QTMovie::close(int type) {
+	g_lingo->cleanupBuiltIns(builtins);
+}
+
+void QTMovie::m_qtmovie(int nargs) {
+	g_lingo->printSTUBWithArglist("QTMovie::m_qtmovie", nargs);
+	g_lingo->dropStack(nargs);
+}
+
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/qtmovie.h
+++ b/engines/director/lingo/xlibs/qtmovie.h
@@ -1,0 +1,41 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XLIBS_QTMOVIE_H
+#define DIRECTOR_LINGO_XLIBS_QTMOVIE_H
+
+namespace Director {
+
+namespace QTMovie {
+
+extern const char *xlibName;
+extern const char *fileNames[];
+
+void open(int type);
+void close(int type);
+
+void m_qtmovie(int nargs);
+
+} // End of namespace QTMovie
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/lingo/xlibs/volumelist.cpp
+++ b/engines/director/lingo/xlibs/volumelist.cpp
@@ -1,0 +1,66 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*************************************
+ *
+ * USED IN:
+ * Yearn2Learn: The Flintstones Coloring Book
+ *
+ *************************************/
+/*
+ * v1.0, ©1989, 1990 Eric Carlson, Apple Computer, Inc.
+ * VolumeList(«“nodialog:ErrMsg”»)
+*/
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/xlibs/volumelist.h"
+
+
+namespace Director {
+
+const char *VolumeList::xlibName = "VolumeList";
+const char *VolumeList::fileNames[] = {
+	"VolumeList",
+	0
+};
+
+static BuiltinProto builtins[] = {
+	{ "VolumeList", VolumeList::m_volumelist, 0, 0, 300, HBLTIN },
+	{ nullptr, nullptr, 0, 0, 0, VOIDSYM }
+};
+
+void VolumeList::open(int type) {
+	g_lingo->initBuiltIns(builtins);
+}
+
+void VolumeList::close(int type) {
+	g_lingo->cleanupBuiltIns(builtins);
+}
+
+void VolumeList::m_volumelist(int nargs) {
+	// Would presumably give a list of volumes attached,
+	// with the first being the boot disk
+	g_lingo->push(Datum(""));
+}
+
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/volumelist.h
+++ b/engines/director/lingo/xlibs/volumelist.h
@@ -1,0 +1,41 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XLIBS_VOLUMELIST_H
+#define DIRECTOR_LINGO_XLIBS_VOLUMELIST_H
+
+namespace Director {
+
+namespace VolumeList {
+
+extern const char *xlibName;
+extern const char *fileNames[];
+
+void open(int type);
+void close(int type);
+
+void m_volumelist(int nargs);
+
+} // End of namespace VolumeList
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/lingo/xlibs/yasix.cpp
+++ b/engines/director/lingo/xlibs/yasix.cpp
@@ -1,0 +1,69 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*************************************
+ *
+ * USED IN:
+ * Yearn2Learn: The Flintstones Coloring Book
+ *
+ *************************************/
+/* v0.2, ©1992 Clark Brady, 317/839-0442 - YASIX - Yet Another System Information XFCN */
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/xlibs/yasix.h"
+
+
+namespace Director {
+
+const char *Yasix::xlibName = "YASIX";
+const char *Yasix::fileNames[] = {
+	"YASIX",
+	0
+};
+
+static BuiltinProto builtins[] = {
+	{ "YASIX", Yasix::m_yasix, 0, 0, 300, HBLTIN },
+	{ nullptr, nullptr, 0, 0, 0, VOIDSYM }
+};
+
+void Yasix::open(int type) {
+	g_lingo->initBuiltIns(builtins);
+}
+
+void Yasix::close(int type) {
+	g_lingo->cleanupBuiltIns(builtins);
+}
+
+void Yasix::m_yasix(int nargs) {
+	g_lingo->push(Datum("Machine_Type   Macintosh\r\n\
+Keyboard_Type ExtISOADBKbd\r\n\
+Processor_Type 68030\r\n\
+MMU_Type NoMMU\r\n\
+FPU_Type NoFPU\r\n\
+Physical_RAM 16 Meg\r\n\
+System_Version 7.6.1\r\n\
+Screen_0 0,0,640,480 Color 32 bit\r\n\
+Volume_1 ScummVM 500M 500M"));
+}
+
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/yasix.h
+++ b/engines/director/lingo/xlibs/yasix.h
@@ -1,0 +1,41 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XLIBS_YASIX_H
+#define DIRECTOR_LINGO_XLIBS_YASIX_H
+
+namespace Director {
+
+namespace Yasix {
+
+extern const char *xlibName;
+extern const char *fileNames[];
+
+void open(int type);
+void close(int type);
+
+void m_yasix(int nargs);
+
+} // End of namespace Yasix
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -44,10 +44,13 @@ MODULE_OBJS = \
 	lingo/xlibs/askuser.o \
 	lingo/xlibs/barakeobj.o \
 	lingo/xlibs/cdromxobj.o \
+	lingo/xlibs/darkenscreen.o \
+	lingo/xlibs/ednox.o \
 	lingo/xlibs/fileio.o \
 	lingo/xlibs/flushxobj.o \
 	lingo/xlibs/fplayxobj.o \
 	lingo/xlibs/gpid.o \
+	lingo/xlibs/iscd.o \
 	lingo/xlibs/jitdraw3.o \
 	lingo/xlibs/jwxini.o \
 	lingo/xlibs/labeldrvxobj.o \

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -46,7 +46,9 @@ MODULE_OBJS = \
 	lingo/xlibs/cdromxobj.o \
 	lingo/xlibs/darkenscreen.o \
 	lingo/xlibs/ednox.o \
+	lingo/xlibs/fileexists.o \
 	lingo/xlibs/fileio.o \
+	lingo/xlibs/findfolder.o \
 	lingo/xlibs/flushxobj.o \
 	lingo/xlibs/fplayxobj.o \
 	lingo/xlibs/gpid.o \
@@ -67,9 +69,11 @@ MODULE_OBJS = \
 	lingo/xlibs/soundjam.o \
 	lingo/xlibs/spacemgr.o \
 	lingo/xlibs/videodiscxobj.o \
+	lingo/xlibs/volumelist.o \
 	lingo/xlibs/widgetxobj.o \
 	lingo/xlibs/winxobj.o \
-	lingo/xlibs/xplayanim.o
+	lingo/xlibs/xplayanim.o \
+	lingo/xlibs/yasix.o
 
 # HACK: Skip this when including the file for detection objects.
 ifeq "$(USE_RULES)" "1"

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -53,6 +53,7 @@ MODULE_OBJS = \
 	lingo/xlibs/fplayxobj.o \
 	lingo/xlibs/gpid.o \
 	lingo/xlibs/iscd.o \
+	lingo/xlibs/ispippin.o \
 	lingo/xlibs/jitdraw3.o \
 	lingo/xlibs/jwxini.o \
 	lingo/xlibs/labeldrvxobj.o \
@@ -64,6 +65,7 @@ MODULE_OBJS = \
 	lingo/xlibs/orthoplayxobj.o \
 	lingo/xlibs/palxobj.o \
 	lingo/xlibs/popupmenuxobj.o \
+	lingo/xlibs/qtmovie.o \
 	lingo/xlibs/registercomponent.o \
 	lingo/xlibs/serialportxobj.o \
 	lingo/xlibs/soundjam.o \

--- a/engines/director/resource.cpp
+++ b/engines/director/resource.cpp
@@ -155,6 +155,7 @@ void Window::probeMacBinary(MacArchive *archive) {
 				delete _currentMovie;
 				_currentMovie = nullptr;
 
+				probeProjector(moviePath);
 			} else {
 				warning("Couldn't find score with name: %s", sname.c_str());
 			}
@@ -177,6 +178,14 @@ void Window::probeMacBinary(MacArchive *archive) {
 		for (Common::Array<uint16>::iterator iterator = xcmd.begin(); iterator != xcmd.end(); ++iterator) {
 			Resource res = archive->getResourceDetail(MKTAG('X', 'C', 'M', 'D'), *iterator);
 			debug(0, "Detected XCMD '%s'", res.name.c_str());
+			g_lingo->openXLib(res.name, kXObj);
+		}
+	}
+	if (archive->hasResource(MKTAG('X', 'F', 'C', 'N'), -1)) {
+		Common::Array<uint16> xfcn = archive->getResourceIDList(MKTAG('X', 'F', 'C', 'N'));
+		for (Common::Array<uint16>::iterator iterator = xfcn.begin(); iterator != xfcn.end(); ++iterator) {
+			Resource res = archive->getResourceDetail(MKTAG('X', 'F', 'C', 'N'), *iterator);
+			debug(0, "Detected XFCN '%s'", res.name.c_str());
 			g_lingo->openXLib(res.name, kXObj);
 		}
 	}

--- a/engines/director/sound.cpp
+++ b/engines/director/sound.cpp
@@ -780,7 +780,7 @@ Audio::AudioStream *SNDDecoder::getAudioStream(bool looping, bool forPuppet, Dis
 }
 
 bool SNDDecoder::hasLoopBounds() {
-	return _loopStart != 0 || _loopEnd != 0;
+	return _loopStart != 0 && _loopEnd != 0;
 }
 
 AudioFileDecoder::AudioFileDecoder(Common::String &path)

--- a/engines/director/util.cpp
+++ b/engines/director/util.cpp
@@ -434,7 +434,7 @@ bool testPath(Common::String &path, bool directory) {
 		bool exists = false;
 		for (Common::FSList::iterator i = fslist.begin(); i != fslist.end(); ++i) {
 			// for each element in the path, choose the first FSNode
-			// with a case-insensitive matcing name
+			// with a case-insensitive matching name
 			if (i->getName().equalsIgnoreCase(token)) {
 				// If this the final path component, check if we're allowed to match with a directory
 				node = Common::FSNode(*i);
@@ -529,7 +529,7 @@ Common::String wrappedPathMakeRelative(Common::String path, bool recursive, bool
 		debug(9, "wrappedPathMakeRelative(): s3 try %s", convPath.c_str());
 
 		if (!testPath(convPath, directory)) {
-			// If we were supplied with parh with subdirectories,
+			// If we were supplied a path with subdirectories,
 			// attempt to combine it with the current movie path at every iteration
 			Common::String locPath = Common::normalizePath(g_director->getCurrentPath() + convPath, g_director->_dirSeparator);
 			debug(9, "wrappedPathMakeRelative(): s3.1 try %s", locPath.c_str());


### PR DESCRIPTION
There is a ton of stuff in here that spans from my last Director PR to now, including:
* try to get XFCNs started
* Fix finding files in punycoded foldernames
* Correctly decode non-ASCII alerts
* fileio: I have no idea if this fixes or breaks things
* testExtensions: Try the non-converted filename as well
* Add XFCNs for Flintstones Coloring Book
* Add full readme for PopUpMenuXObj
* hack: fix bug where _loopEnd can be 0 with _loopStart > 0
* Start adding XFCNs/Xlibs used by Ednovation games
* Add D4 hybrid release of Alice (serial: TORT-3001)
* Fix loading Xlibs from non-parent movies
* Add detection for amandastories v4.0; patches for Windows version
* Add IsPippin XCMD for Circus! (Pippin)
* Fix m_put not returning item
* Blender 1.5 demos and detection fixes
* Add Voodoo Lounge