### PR TITLE
WINTERMUTE: Fix crash on loaded games

### DIFF
--- a/engines/wintermute/base/base_object.cpp
+++ b/engines/wintermute/base/base_object.cpp
@@ -1118,6 +1118,9 @@ bool BaseObject::persist(BasePersistenceManager *persistMgr) {
 		persistMgr->transferFloat(TMEMBER(_scale3D));
 		persistMgr->transferVector3d(TMEMBER(_shadowLightPos));
 		persistMgr->transferBool(TMEMBER(_drawBackfaces));
+	} else {
+		_xmodel = nullptr;
+		_shadowModel = nullptr;
 	}
 #endif
 


### PR DESCRIPTION
Objects used by WME after loading are somehow casted from raw memory without calling constructors.
Thus, _xmodel may be uninstanciated, causing SEGFAULT on `delete _xmodel;` on scene change.

Test case:
1. Start James Peris 2, create a savegame
2. Exit ScummVM
3. Start ScummVM
4. Load game
5. Walk main character to any different location

Expected result: scene change
Actual result (e.g., on dayly Nindendo Switch build): SEGFAULT on  `delete _xmodel;`