### PR TITLE
DRACI: Find max speech file using iterator

### DIFF
--- a/engines/draci/sound.cpp
+++ b/engines/draci/sound.cpp
@@ -203,6 +203,16 @@ void ZipSoundArchive::openArchive(const char *path, const char *extension, Sound
 		Common::ArchiveMemberList files;
 		_archive->listMembers(files);
 		_sampleCount = files.size();
+
+		// The sample files are in the form ####.mp3 but not all numbers are used so we need to
+		// iterate the archive and find the last file
+		for (Common::ArchiveMemberList::iterator iter = files.begin(); iter != files.end(); iter++) {
+			Common::String filename = (*iter)->getName();
+			filename.erase(filename.size() - 4);  // remove .mp3 extension
+			uint file_number = atoi(filename.c_str());
+			if(file_number > _sampleCount)		// finds the last file (numerically)
+				_sampleCount = file_number;
+		}
 		debugC(1, kDraciArchiverDebugLevel, "Capacity %d", _sampleCount);
 	} else {
 		debugC(1, kDraciArchiverDebugLevel, "Failed");


### PR DESCRIPTION
Draci Historie uses a single zipped file for the voices, which are simply numbered .mp3 files.
However, not all "numbers" are present in the filenames, so the total number of files in the archive is lower than the
identifiers; as a result, all the identifiers that are above the filetotal are considered out-of-bounds and ignored.
The bug does not occur when using the original uncompressed file because the maximum value is calculated when unpacking the resources.
The PR simply checks all files and finds the "highest" one, to be used as a limit.

Tested with Czech version, Polish version, English version with czech dub.
NOTE: The Polish dub is missing some lines, but that's unrelated to this bug.

Solves TRAC 6646

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
