### PR TITLE
DOCS: Update for iOS 15 and iOS 16 new security settings

### DIFF
--- a/doc/docportal/other_platforms/ios.rst
+++ b/doc/docportal/other_platforms/ios.rst
@@ -123,9 +123,22 @@ Next to **General**, click on **Signing & Capabilities**. Under **Signing**, tic
 
 If you have not added your developer account to Xcode, do this now. Click **Add an Account** in the dropdown menu.
 
-In the upper left-hand corner, press the play button to build ScummVM. When the build is finished, it launches on your connected device.
+In the upper left-hand corner, press the play button to build ScummVM.
 
-If ScummVM does not launch and you get an error message advising that the app failed to launch due to an invalid code signature, inadequate entitlements or because its profile has not been explicitly trusted by the user, you need to trust the apps that you have built. On your iOS device, go to **Settings > General > Device Management > Developer App > Trust "Apple Development:yourAppleIDhere" > Trust**.
+.. note::
+
+  Starting with iOS 16, you may get an error message here if you haven't `enabled Developer Mode <https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device>`_ on your iOS device. This can be done with the **Settings > Privacy & Security > Developer Mode** switch, which will restart your device and reduce its security level.
+
+  If you can't see this option, unplug and plug your device again, and make sure that it's visible to Xcode.
+
+When the build is finished, ScummVM launches on your connected device.
+
+.. note::
+
+  If ScummVM does not launch and you get an error message advising that the app failed to launch due to an invalid code signature, inadequate entitlements or because its profile has not been explicitly trusted by the user, you need to trust the apps that you have built. On your iOS device, go to:
+  
+  - **Settings > General > Device Management > Developer App > Trust "Apple Development:yourAppleIDhere" > Trust**
+  - or **Settings > General > VPN & Device Management** (iOS 15+)
 
 
 Devices with custom firmware


### PR DESCRIPTION
With iOS 15, the setting for trusting your own developer certificate has moved to a new location, and on iOS 16, building your own version of ScummVM becomes even more of a burden, because you need to enable Developer Mode (and keep it enabled for the app to continue working… for 7 days).

Since iOS users tend to be quite up-to-date generally, this is probably important.