### PR TITLE
COMMON: Create common archive caching and switch several archives to it

### DIFF
--- a/common/clickteam.h
+++ b/common/clickteam.h
@@ -29,7 +29,7 @@
 #include "common/hash-str.h"
 
 namespace Common {
-class ClickteamInstaller : public Archive {
+class ClickteamInstaller : public MemcachingCaseInsensitiveArchive {
 public:
 	enum class ClickteamTagId : uint16 {
 		BANNER_IMAGE = 0x1235,
@@ -56,7 +56,7 @@ public:
 	bool hasFile(const Path &path) const override;
 	int listMembers(Common::ArchiveMemberList&) const override;
 	const ArchiveMemberPtr getMember(const Path &path) const override;
-	SeekableReadStream *createReadStreamForMember(const Path &path) const override;
+	Common::SharedArchiveContents readContentsForPath(const Common::String& translated) const override;
 
 	ClickteamTag* getTag(ClickteamTagId tagId) const;
 
@@ -91,7 +91,6 @@ private:
 	Common::HashMap<Common::String, ClickteamFileDescriptor, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> _files;
 	Common::HashMap<uint16, Common::SharedPtr<ClickteamTag>> _tags;
 	Common::DisposablePtr<Common::SeekableReadStream> _stream;
-	mutable Common::HashMap<Common::String, Common::ScopedPtr<byte, Common::ArrayDeleter<byte>>, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> _cache;
 	uint32 _crcXor, _block3Offset/*, _block3Size*/;
 };
 }

--- a/common/ptr.h
+++ b/common/ptr.h
@@ -658,7 +658,7 @@ public:
 
 	explicit DisposablePtr(PointerType o, DisposeAfterUse::Flag dispose) : _pointer(o), _dispose(dispose), _shared() {}
 	explicit DisposablePtr(SharedPtr<T> o) : _pointer(o.get()), _dispose(DisposeAfterUse::NO), _shared(o) {}
-	DisposablePtr(DisposablePtr<T>&& o) : _pointer(o._pointer), _dispose(o._dispose), _shared(o._shared) {
+	DisposablePtr(DisposablePtr<T, DL>&& o) : _pointer(o._pointer), _dispose(o._dispose), _shared(o._shared) {
 		o._pointer = nullptr;
 		o._dispose = DisposeAfterUse::NO;
 		o._shared.reset();

--- a/common/stream.cpp
+++ b/common/stream.cpp
@@ -119,7 +119,7 @@ bool MemoryReadStream::seek(int64 offs, int whence) {
 	case SEEK_SET:
 		// Fall through
 	default:
-		_ptr = _ptrOrig + offs;
+		_ptr = _ptrOrig.get() + offs;
 		_pos = offs;
 		break;
 

--- a/engines/lilliput/stream.h
+++ b/engines/lilliput/stream.h
@@ -30,6 +30,9 @@ class ScriptStream : public Common::MemoryReadStream {
 private:
 	byte *_orgPtr;
 public:
+	ScriptStream(ScriptStream &&other) : Common::MemoryReadStream(Common::move(other)), _orgPtr(other._orgPtr) {
+		other._orgPtr = nullptr;
+	}
 	ScriptStream(byte *buf, int bufSize);
 	~ScriptStream() override;
 

--- a/engines/mads/mps_installer.cpp
+++ b/engines/mads/mps_installer.cpp
@@ -63,13 +63,8 @@ MpsInstaller* MpsInstaller::open(const Common::Path& baseName) {
 	return new MpsInstaller(_files, baseName);
 }
 
-// Use of \\ as path separator is a guess. Never seen an archive with subfolders
-static Common::String translateName(const Common::Path &path) {
-	return Common::normalizePath(path.toString('\\'), '\\');
-}
-
 bool MpsInstaller::hasFile(const Common::Path &path) const {
-	return _files.contains(translateName(path));
+	return _files.contains(translatePath(path));
 }
 
 int MpsInstaller::listMembers(Common::ArchiveMemberList &list) const {
@@ -81,26 +76,21 @@ int MpsInstaller::listMembers(Common::ArchiveMemberList &list) const {
 }
 
 const Common::ArchiveMemberPtr MpsInstaller::getMember(const Common::Path &path) const {
-	Common::String translated = translateName(path);
+	Common::String translated = translatePath(path);
 	if (!_files.contains(translated))
 		return nullptr;
 
 	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(_files.getVal(translated)._fileName, this));
 }
 
-// TODO: Make streams stay valid after destruction of archive
-Common::SeekableReadStream *MpsInstaller::createReadStreamForMember(const Common::Path &path) const {
-	Common::String translated = translateName(path);
+Common::SharedArchiveContents MpsInstaller::readContentsForPath(const Common::String& translated) const {
 	if (!_files.contains(translated))
-		return nullptr;
+		return Common::SharedArchiveContents();
 	FileDescriptor desc = _files.getVal(translated);
-	if (_cache.contains(desc._fileName)) {
-		return new Common::MemoryReadStream(_cache[desc._fileName].get(), desc._uncompressedSize, DisposeAfterUse::NO);
-	}
 
 	if (desc._compressionAlgo != 0 && desc._compressionAlgo != 1) {
 		debug ("Unsupported compression algorithm %d for %s", desc._compressionAlgo, desc._fileName.c_str());
-		return nullptr;
+		return Common::SharedArchiveContents();
 	}
 
 
@@ -115,14 +105,14 @@ Common::SeekableReadStream *MpsInstaller::createReadStreamForMember(const Common
 		if (!fvol.open(volumePath)) {
 			error("Failed to open volume %s.%03d", volumePath.toString().c_str(), vol);
 			delete[] compressedBuf;
-			return nullptr;
+			return Common::SharedArchiveContents();
 		}
 		fvol.seek(off);
 		int32 actual = fvol.read(outptr, rem);
 		if (actual <= 0) {
 			warning("Read failure in volume %s.%03d", volumePath.toString().c_str(), vol);
 			delete[] compressedBuf;
-			return nullptr;
+			return Common::SharedArchiveContents();
 		}
 
 		rem -= actual;
@@ -148,7 +138,7 @@ Common::SeekableReadStream *MpsInstaller::createReadStreamForMember(const Common
 			delete[] compressedBuf;
 			delete[] uncompressedBuf;
 			error("Unable to decompress %s", desc._fileName.c_str());
-			return nullptr;
+			return Common::SharedArchiveContents();
 		}
 		delete[] compressedBuf;
 		compressedBuf = nullptr;
@@ -156,8 +146,7 @@ Common::SeekableReadStream *MpsInstaller::createReadStreamForMember(const Common
 		break;
 	}
 
-	_cache[desc._fileName].reset(uncompressedBuf);
 	// TODO: Make it configurable to read directly from disk, at least in the uncompressed case
-	return new Common::MemoryReadStream(uncompressedBuf, desc._uncompressedSize, DisposeAfterUse::NO);
+	return Common::SharedArchiveContents(uncompressedBuf, desc._uncompressedSize);
 }
 }

--- a/engines/mads/mps_installer.h
+++ b/engines/mads/mps_installer.h
@@ -30,12 +30,12 @@
 
 namespace MADS {
 
-class MpsInstaller : public Common::Archive {
+class MpsInstaller : public Common::MemcachingCaseInsensitiveArchive {
 public:
 	bool hasFile(const Common::Path &path) const override;
 	int listMembers(Common::ArchiveMemberList&) const override;
 	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
-	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
+	Common::SharedArchiveContents readContentsForPath(const Common::String& translatedPath) const override;
 
 	static MpsInstaller* open(const Common::Path& baseName);
 
@@ -79,7 +79,6 @@ private:
 		     const Common::Path& baseName) : _files(files), _baseName(baseName) {}
 
 	FileMap _files;
-	mutable Common::HashMap<Common::String, Common::ScopedPtr<byte, Common::ArrayDeleter<byte>>, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> _cache;
 	Common::Path _baseName;
 };
 }


### PR DESCRIPTION
With this new caching the streams survive the destruction of the archive. In the same time different streams for the same file share the same backing memory but independent pointers. Opening failure is also cached