### PR TITLE
COMMON: Optimize some array ops.

### DIFF
--- a/common/array.h
+++ b/common/array.h
@@ -72,8 +72,11 @@ public:
 	 */
 	explicit Array(size_type count) : _size(count) {
 		allocCapacity(count);
+
+		T *storage = _storage;
+
 		for (size_type i = 0; i < count; ++i)
-			new ((void *)&_storage[i]) T();
+			new ((void *)&storage[i]) T();
 	}
 
 	/**
@@ -367,10 +370,14 @@ public:
 	/** Change the size of the array. */
 	void resize(size_type newSize) {
 		reserve(newSize);
+
+		T *storage = _storage;
+
 		for (size_type i = newSize; i < _size; ++i)
-			_storage[i].~T();
+			storage[i].~T();
 		for (size_type i = _size; i < newSize; ++i)
-			new ((void *)&_storage[i]) T();
+			new ((void *)&storage[i]) T();
+
 		_size = newSize;
 	}
 


### PR DESCRIPTION
Minor perf improvement: Copies the `_storage` value to a local before operating on the loop so the compiler doesn't have to assume that `_storage` might be modified by the loop (either due to `_storage` aliasing the array, or as a side-effect of calling the constructor/destructor).

This should speed up byte/char array resizes in particular by allowing the compiler to convert them to memsets.