### PR TITLE
GOB: Add detection for Adibou 2 French demo (interactive)

### DIFF
--- a/engines/gob/detection/tables_adibou.h
+++ b/engines/gob/detection/tables_adibou.h
@@ -235,6 +235,20 @@
 {
 	{
 		"adibou2",
+		"ADIBOU 2 Demo",
+		AD_ENTRY1s("intro.stk", "0f197c6b8f1cef3fb4aa37438a52e031", 954276),
+		FR_FRA,
+		kPlatformDOS,
+		ADGF_DEMO,
+		GUIO0()
+	},
+	kGameTypeAdibou2,
+	kFeatures640x480,
+	0, 0, 0
+},
+{
+	{
+		"adibou2",
 		"Non-Interactive Demo",
 		AD_ENTRY2s("demogb.scn", "9291455a908ac0e6aaaca686e532609b", 105,
 				   "demogb.vmd", "bc9c1db97db7bec8f566332444fa0090", 14320840),


### PR DESCRIPTION
Source is the double CD-ROM *Le kit rentrée scolaire de la Fnac* (August 1999) that was given for free at the Fnac French retail stores.

It appears to work ouf of the box (cc @sdelamarre). It's an interactive demo.

Should appear as `adibou2-dos-demo-fr.zip` on our demos page soon…