### PR TITLE
DOCS: Fixing the hyperlink on FAQ 1.1.5

### DIFF
--- a/doc/docportal/help/faq.rst
+++ b/doc/docportal/help/faq.rst
@@ -34,7 +34,7 @@ See the `Compiling ScummVM wiki page <https://wiki.scummvm.org/index.php?title=C
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Our project has a strict no-piracy policy. Hence, we do not provide any support when it becomes evident that you did not obtain your game copy legally.
 
-We outlined a more detailed response on `our Wiki <https://wiki.scummvm.org/index.php?title=Copyright_FAQ>`.
+We outlined a more detailed response on `our Wiki <https://wiki.scummvm.org/index.php?title=Copyright_FAQ>`_.
 
 And no, "abandonware" is not a proper legal concept in any country. Just like how it's not legal to copy a book under copyright because it is out-of-print, it is not legal to copy a game under copyright because the company is no longer selling it.
 


### PR DESCRIPTION
## Before

<img width="707" alt="image" src="https://user-images.githubusercontent.com/6200170/205521747-03f3d07a-0083-4472-842b-ba80da61c8d9.png">

## After

<img width="709" alt="image" src="https://user-images.githubusercontent.com/6200170/205521916-f75f07bf-a5e4-474a-b0c2-b5f666499e07.png">