### PR TITLE
SCUMM: GUI: Implement MI1 SegaCD menu

### DIFF
--- a/engines/scumm/dialogs.cpp
+++ b/engines/scumm/dialogs.cpp
@@ -455,7 +455,9 @@ const char *InfoDialog::getPlainEngineString(int stringno, bool forceHardcodedSt
 			}
 		}
 	} else if (_vm->_game.version >= 3) {
-		if (!forceHardcodedString)
+		if (_vm->_game.platform == Common::kPlatformSegaCD)
+			result = (const char *)_vm->getStringAddress(stringno);
+		else if (!forceHardcodedString)
 			result = (const char *)_vm->getStringAddress(getStaticResString(_vm->_language, stringno - 1).num);
 
 		if (!result) {

--- a/engines/scumm/gfx_gui.cpp
+++ b/engines/scumm/gfx_gui.cpp
@@ -2025,7 +2025,6 @@ bool ScummEngine::executeMainMenuOperationSegaCD(int op, int mouseX, int mouseY,
 
 			// First time...
 			int args[16];
-			int32 prevCode = _scummVars[63];
 			memset(args, 0, sizeof(args));
 			args[0] = _bootParam;
 
@@ -2107,7 +2106,7 @@ bool ScummEngine::executeMainMenuOperationSegaCD(int op, int mouseX, int mouseY,
 	case GUI_CTRL_NUMPAD_BACK:
 	{
 		int inputNum = op == GUI_CTRL_NUMPAD_0 ? 0 : op;
-		int curIdx;
+		uint curIdx;
 		for (curIdx = 0; curIdx < sizeof(_mainMenuSegaCDPasscode); curIdx++) {
 			if (_mainMenuSegaCDPasscode[curIdx] == '\0')
 				break;
@@ -3429,7 +3428,7 @@ void ScummEngine::drawMainMenuControlsSegaCD() {
 	drawGUIText(buf, nullptr, 184, yConstant - 34, stringColor, false);
 
 	if (_menuPage != GUI_PAGE_CODE_CONFIRM && _menuPage != GUI_PAGE_LOAD) {
-		for (int i = 0; i < sizeof(_mainMenuSegaCDPasscode); i++) {
+		for (uint i = 0; i < sizeof(_mainMenuSegaCDPasscode); i++) {
 			_mainMenuSegaCDPasscode[i] = '\0';
 		}
 	}

--- a/engines/scumm/gfx_gui.cpp
+++ b/engines/scumm/gfx_gui.cpp
@@ -2106,11 +2106,7 @@ bool ScummEngine::executeMainMenuOperationSegaCD(int op, int mouseX, int mouseY,
 	case GUI_CTRL_NUMPAD_BACK:
 	{
 		int inputNum = (op == GUI_CTRL_NUMPAD_0) ? 0 : op;
-		uint curIdx;
-		for (curIdx = 0; curIdx < sizeof(_mainMenuSegaCDPasscode); curIdx++) {
-			if (_mainMenuSegaCDPasscode[curIdx] == '\0')
-				break;
-		}
+		uint curIdx = strnlen(_mainMenuSegaCDPasscode, sizeof(_mainMenuSegaCDPasscode));
 
 		if (op == GUI_CTRL_NUMPAD_BACK) {
 			if (curIdx > 0) {

--- a/engines/scumm/gfx_gui.cpp
+++ b/engines/scumm/gfx_gui.cpp
@@ -2898,7 +2898,7 @@ void ScummEngine::setUpMainMenuControlsSegaCD() {
 								yConstant + 43,
 								getGUIString(gsCancel), 1, 1);
 	} else if (_menuPage == GUI_PAGE_LOAD) {
-		Common::String numbers[] = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
+		const char numbers[10][2] = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
 
 		setUpInternalGUIControl(GUI_CTRL_NUMPAD_0,
 								getBannerColor(4),
@@ -2913,7 +2913,7 @@ void ScummEngine::setUpMainMenuControlsSegaCD() {
 								yConstant + 43,
 								211,
 								yConstant + 57,
-								numbers[0].c_str(), 1, 1);
+								numbers[0], 1, 1);
 
 		setUpInternalGUIControl(GUI_CTRL_NUMPAD_BACK,
 								getBannerColor(4),
@@ -2945,7 +2945,7 @@ void ScummEngine::setUpMainMenuControlsSegaCD() {
 										yConstant + 29 - row * 14,
 										211 + col * 14,
 										yConstant + 43 - row * 14,
-										numbers[row * 3 + (col + 1)].c_str(), 1, 1);
+										numbers[row * 3 + (col + 1)], 1, 1);
 			}
 		}
 	}

--- a/engines/scumm/gfx_gui.cpp
+++ b/engines/scumm/gfx_gui.cpp
@@ -2105,7 +2105,7 @@ bool ScummEngine::executeMainMenuOperationSegaCD(int op, int mouseX, int mouseY,
 	case GUI_CTRL_NUMPAD_9:
 	case GUI_CTRL_NUMPAD_BACK:
 	{
-		int inputNum = op == GUI_CTRL_NUMPAD_0 ? 0 : op;
+		int inputNum = (op == GUI_CTRL_NUMPAD_0) ? 0 : op;
 		uint curIdx;
 		for (curIdx = 0; curIdx < sizeof(_mainMenuSegaCDPasscode); curIdx++) {
 			if (_mainMenuSegaCDPasscode[curIdx] == '\0')
@@ -2122,7 +2122,7 @@ bool ScummEngine::executeMainMenuOperationSegaCD(int op, int mouseX, int mouseY,
 
 			if (curIdx >= 3) { // Last digit
 				updateMainMenuControls();
-				ScummEngine::drawDirtyScreenParts();
+				drawDirtyScreenParts();
 
 				waitForTimer(120);
 
@@ -2869,9 +2869,7 @@ void ScummEngine::setUpMainMenuControlsSegaCD() {
 								235,
 								yConstant + 34,
 								_uncheckedBox, 1, 1);
-	}
-
-	if (_menuPage == GUI_PAGE_RESTART || _menuPage == GUI_PAGE_CODE_CONFIRM) {
+	} else if (_menuPage == GUI_PAGE_RESTART || _menuPage == GUI_PAGE_CODE_CONFIRM) {
 		// OK button
 		setUpInternalGUIControl(GUI_CTRL_OK_BUTTON,
 								getBannerColor(4),
@@ -2903,9 +2901,7 @@ void ScummEngine::setUpMainMenuControlsSegaCD() {
 								isJap ? 291 : 257,
 								yConstant + 43,
 								getGUIString(gsCancel), 1, 1);
-	}
-
-	if (_menuPage == GUI_PAGE_LOAD) {
+	} else if (_menuPage == GUI_PAGE_LOAD) {
 		Common::String numbers[] = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
 
 		setUpInternalGUIControl(GUI_CTRL_NUMPAD_0,
@@ -3616,13 +3612,14 @@ void ScummEngine::updateMainMenuControls() {
 void ScummEngine::updateMainMenuControlsSegaCD() {
 	char msg[256];
 	int yConstant = _virtscr[kMainVirtScreen].topline + (_virtscr[kMainVirtScreen].h / 2);
-	bool isJap = _language == Common::JA_JPN;
+	bool isJap = (_language == Common::JA_JPN);
 
 	if (_menuPage == GUI_PAGE_MAIN) {
+		// Fill the slider string of symbols shaped like a "=" character
 		strncpy(_mainMenuTextSpeedSlider, "\x3a\x3a\x3a\x3a\x3a\x3a\x3a\x3a\x3a\x3a", sizeof(_mainMenuTextSpeedSlider));
 
 		if (VAR_CHARINC != 0xFF)
-			_mainMenuTextSpeedSlider[9 - VAR(VAR_CHARINC)] = '\x3b';
+			_mainMenuTextSpeedSlider[9 - VAR(VAR_CHARINC)] = '\x3b'; // The cursor of the slider
 
 		_internalGUIControls[GUI_CTRL_TEXT_SPEED_SLIDER].label = _mainMenuTextSpeedSlider;
 

--- a/engines/scumm/input.cpp
+++ b/engines/scumm/input.cpp
@@ -932,9 +932,12 @@ void ScummEngine::processKeyboard(Common::KeyState lastKeyHit) {
 		restartKeyPressed |= ((_game.version < 3 || _game.version > 6) &&
 			lastKeyHit.keycode == Common::KEYCODE_F8 && lastKeyHit.hasFlags(0));
 
-		// ...or if this is a v3 FM-Towns game, restart on F8 (the original accepted a key value of 0xFFFF8008)
+		// ...or if this is a v3 FM-Towns game, restart on F8 (the original accepted a key value of 0xFFFF8008)...
 		restartKeyPressed |= _game.platform == Common::kPlatformFMTowns && _game.version == 3 &&
 			lastKeyHit.keycode == Common::KEYCODE_F8 && lastKeyHit.hasFlags(0);
+
+		// ...but do not allow the restart banner to appear at all, if this is MI1 SegaCD.
+		restartKeyPressed &= _game.platform != Common::kPlatformSegaCD;
 
 		if (restartKeyPressed) {
 			queryRestart();

--- a/engines/scumm/input.cpp
+++ b/engines/scumm/input.cpp
@@ -898,7 +898,7 @@ void ScummEngine::processKeyboard(Common::KeyState lastKeyHit) {
 		char sliderString[256];
 		PauseToken pt;
 
-		if (((VAR_PAUSE_KEY != 0xFF && (lastKeyHit.ascii == VAR(VAR_PAUSE_KEY))) ||
+		if ((VAR_PAUSE_KEY != 0xFF && (lastKeyHit.ascii == VAR(VAR_PAUSE_KEY)) ||
 			(lastKeyHit.keycode == Common::KEYCODE_SPACE && _game.features & GF_DEMO))) {
 			if (isSegaCD) {
 				if (VAR(VAR_MAINMENU_KEY) != 0)

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -3167,8 +3167,7 @@ bool ScummEngine::isUsingOriginalGUI() {
 
 	if (_game.platform == Common::kPlatformNES ||
 		_game.platform == Common::kPlatformPCEngine ||
-		(_game.platform == Common::kPlatformAtariST && _game.version == 2) ||
-		(_game.platform == Common::kPlatformSegaCD && _language == Common::JA_JPN))
+		(_game.platform == Common::kPlatformAtariST && _game.version == 2))
 		return false;
 
 	if (_game.heversion != 0)
@@ -3198,10 +3197,14 @@ void ScummEngine::runBootscript() {
 	}
 
 	args[0] = _bootParam;
+
 	if (_game.id == GID_MANIAC && (_game.features & GF_DEMO) && (_game.platform != Common::kPlatformC64))
 		runScript(9, 0, 0, args);
 	else
 		runScript(1, 0, 0, args);
+
+	if (_game.platform == Common::kPlatformSegaCD)
+		_scummVars[411] = _bootParam;
 }
 
 #ifdef ENABLE_HE

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -3202,9 +3202,6 @@ void ScummEngine::runBootscript() {
 		runScript(9, 0, 0, args);
 	else
 		runScript(1, 0, 0, args);
-
-	if (_game.platform == Common::kPlatformSegaCD)
-		_scummVars[411] = _bootParam;
 }
 
 #ifdef ENABLE_HE

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -468,7 +468,7 @@ enum GUIString {
 	gsConfirmPasscode = 58,
 	gsInvalidPasscode = 59,
 	gsSlowFast = 60,
-	gsRestartGame = 61
+	gsRestartGame = 61,
 };
 
 struct InternalGUIControl {

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -364,9 +364,12 @@ class ResourceManager;
  * GUI defines and enums.
  */
 
-#define GUI_PAGE_MAIN 0
-#define GUI_PAGE_SAVE 1
-#define GUI_PAGE_LOAD 2
+#define GUI_PAGE_MAIN         0
+#define GUI_PAGE_SAVE         1
+#define GUI_PAGE_LOAD         2
+#define GUI_PAGE_RESTART      3 // Sega CD
+#define GUI_PAGE_CODE_CONFIRM 4 // Sega CD
+#define GUI_PAGE_INVALID_CODE 5 // Sega CD
 
 #define GUI_CTRL_FIRST_SG               1
 #define GUI_CTRL_LAST_SG                9
@@ -388,6 +391,21 @@ class ResourceManager;
 #define GUI_CTRL_OUTER_BOX              26
 #define GUI_CTRL_INNER_BOX              27
 
+// Sega CD
+#define GUI_CTRL_NUMPAD_1           1
+#define GUI_CTRL_NUMPAD_2           2
+#define GUI_CTRL_NUMPAD_3           3
+#define GUI_CTRL_NUMPAD_4           4
+#define GUI_CTRL_NUMPAD_5           5
+#define GUI_CTRL_NUMPAD_6           6
+#define GUI_CTRL_NUMPAD_7           7
+#define GUI_CTRL_NUMPAD_8           8
+#define GUI_CTRL_NUMPAD_9           9
+#define GUI_CTRL_NUMPAD_0           10
+#define GUI_CTRL_RESTART_BUTTON     13
+#define GUI_CTRL_ARROW_LEFT_BUTTON  16
+#define GUI_CTRL_ARROW_RIGHT_BUTTON 17
+#define GUI_CTRL_NUMPAD_BACK        23
 
 enum GUIString {
 	gsPause = 0,
@@ -444,7 +462,13 @@ enum GUIString {
 	gsEGAMode = 52,
 	gsCGAMode = 53,
 	gsHerculesMode = 54,
-	gsTandyMode = 55
+	gsTandyMode = 55,
+	gsCurrentPasscode = 56,
+	gsEnterPasscode = 57,
+	gsConfirmPasscode = 58,
+	gsInvalidPasscode = 59,
+	gsSlowFast = 60,
+	gsRestartGame = 61
 };
 
 struct InternalGUIControl {
@@ -637,6 +661,8 @@ protected:
 	const char _checkedBox[2] = {'x', '\0'};
 	const char _arrowUp[2] = {'\x18', '\0'};
 	const char _arrowDown[2] = {'\x19', '\0'};
+	const char _arrowLeft[2] = {'\x3c', '\0'};
+	const char _arrowRight[2] = {'\x3d', '\0'};
 
 	Common::StringArray _savegameNames;
 	int _menuPage = 0;
@@ -649,6 +675,7 @@ protected:
 	char _mainMenuSpeechSlider[17];
 	char _mainMenuSfxSlider[17];
 	char _mainMenuTextSpeedSlider[17];
+	char _mainMenuSegaCDPasscode[5];
 	int _spooledMusicIsToBeEnabled = 1;
 	int _saveScriptParam = 0;
 	int _guiCursorAnimCounter = 0;
@@ -715,10 +742,14 @@ protected:
 
 	void showMainMenu();
 	virtual void setUpMainMenuControls();
+	void setUpMainMenuControlsSegaCD();
 	void drawMainMenuControls();
+	void drawMainMenuControlsSegaCD();
 	void updateMainMenuControls();
+	void updateMainMenuControlsSegaCD();
 	void drawMainMenuTitle(const char *title);
 	bool executeMainMenuOperation(int op, int mouseX, int mouseY, bool &hasLoadedState);
+	bool executeMainMenuOperationSegaCD(int op, int mouseX, int mouseY, bool &hasLoadedState);
 	bool shouldHighlightLabelAndWait(int clickedControl);
 	void fillSavegameLabels();
 	bool canWriteGame(int slotId);


### PR DESCRIPTION
Thanks to @einstein95, I've been able to fully implement the menu for the Sega CD version of The Secret Of Monkey Island.

F5 will open the GMM, while the SPACE key, acting as our pause button, opens the menu just like on the original.
The SegaCD apparently has no banners (I haven't been able to trigger those...), so those are disabled here as well.

The passcode saving/loading system is fully functional, but please give it some further testing if you can 🙂 

Here are the usual screenshots:

![image](https://user-images.githubusercontent.com/11290886/206788098-7c36a9ec-469b-4ba9-b1d8-651e23a09414.png)
![image](https://user-images.githubusercontent.com/11290886/206788141-ae67859a-c788-4973-a9be-a286e8e70d6a.png)
![image](https://user-images.githubusercontent.com/11290886/206788175-57d7b303-a864-45ec-b2de-b190b9cc355d.png)
![image](https://user-images.githubusercontent.com/11290886/206788269-c4c1bcd3-d774-4be7-9600-5bdf1f5247b7.png)
![image](https://user-images.githubusercontent.com/11290886/206788320-f3f92d30-d2f4-4f01-8c21-d13c35cd7632.png)
