### PR TITLE
GOB: ADIBOU2: Add couple detection entries and a fix to get one in-game

### DIFF
--- a/engines/gob/detection/tables_adibou.h
+++ b/engines/gob/detection/tables_adibou.h
@@ -44,7 +44,6 @@
 	{
 		"adibou1",
 		"ADIBOU 1 Environnement 4-7 ans",
-
 		AD_ENTRY1s("intro.stk", "904a93f46687617bb34e672020fc17a4", 248724),
 		FR_FRA,
 		kPlatformDOS,
@@ -203,9 +202,25 @@
 {
 	{
 		"adibou2",
-		"ADIBù 2",
+		"ADIBÙ 2",
 		AD_ENTRY1s("intro.stk", "092707829555f27706920e4cacf1fada", 8737958),
 		IT_ITA,
+		kPlatformDOS,
+		ADGF_TESTING,
+		GUIO0()
+	},
+	kGameTypeAdibou2,
+	kFeaturesNone,
+	0, 0, 0
+},
+
+// -- Spanish: Adibù --
+{
+	{
+		"adibou2",
+		"ADIBÙ 2",
+		AD_ENTRY1s("intro.stk", "0b996fcd8929245fecddc4d9169843d0", 956682),
+		ES_ESP,
 		kPlatformDOS,
 		ADGF_TESTING,
 		GUIO0()
@@ -241,6 +256,21 @@
 		kPlatformDOS,
 		ADGF_DEMO | ADGF_TESTING,
 		GUIO0()
+	},
+	kGameTypeAdibou2,
+	kFeatures640x480,
+	0, 0, 0
+},
+{
+	// Titlescreen says "ADIBOO: Limited version!", Sierra setup says "Adiboo 2 Demo"
+	{
+		"adibou2",
+		"ADIBOO 2 Demo",
+		AD_ENTRY1s("intro.stk", "ea6c2d25f33135db763c1175979d904a", 528108),
+		EN_GRB,
+		kPlatformDOS,
+		ADGF_DEMO | ADGF_TESTING,
+		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeAdibou2,
 	kFeatures640x480,

--- a/engines/gob/inter_v1.cpp
+++ b/engines/gob/inter_v1.cpp
@@ -1835,7 +1835,7 @@ void Inter_v1::o1_manageDataFile(OpFuncParams &params) {
 	Common::String file = _vm->_game->_script->evalString();
 
 	if (!file.empty()) {
-		_vm->_dataIO->openArchive(file, true);
+		_vm->_dataIO->openArchive(Common::Path(file, '\\').rawString(), true);
 	} else {
 		_vm->_dataIO->closeArchive(true);
 


### PR DESCRIPTION
The demo tries to load `ADIBODEM\INTROENV.STK`, which on Mac/Linux will fail. Unsure if any other GOB game uses subfolders or how they do it.

[adibou2-demo-en.zip](https://github.com/scummvm/scummvm/files/10204769/adibou2-demo-en.zip)
