### PR TITLE
ULTIMA8: Switch to CursorManager for mouse cursor

### DIFF
--- a/engines/ultima/ultima8/kernel/mouse.h
+++ b/engines/ultima/ultima8/kernel/mouse.h
@@ -131,11 +131,6 @@ public:
 	~Mouse();
 
 	/**
-	 * Setup the mouse cursors
-	 */
-	void setup();
-
-	/**
 	 * Called when a mouse button is pressed down
 	 */
 	bool buttonDown(Shared::MouseButton button);
@@ -214,7 +209,7 @@ public:
 	Gump *getMouseOverGump() const;
 	void resetMouseOverGump() { _mouseOverGump = 0; }
 
-	void paint();
+	void update();
 };
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/ultima8.cpp
+++ b/engines/ultima/ultima8/ultima8.cpp
@@ -638,8 +638,8 @@ void Ultima8Engine::paint() {
 	}
 #endif
 
-	// Draw the mouse
-	_mouse->paint();
+	// Update the mouse
+	_mouse->update();
 
 	// End _painting
 	_screen->EndPainting();
@@ -695,10 +695,6 @@ void Ultima8Engine::GraphicSysInit() {
 		paint();
 		return;
 	}
-
-	// setup normal mouse cursor
-	debugN(MM_INFO, "Loading Default Mouse Cursor...\n");
-	_mouse->setup();
 
 	_desktopGump = new DesktopGump(0, 0, width, height);
 	_desktopGump->InitGump(0);
@@ -1246,9 +1242,9 @@ Common::Error Ultima8Engine::loadGameStream(Common::SeekableReadStream *stream) 
 	}
 
 	_mouse->pushMouseCursor(Mouse::MOUSE_WAIT);
-	_screen->BeginPainting();
-	_mouse->paint();
-	_screen->EndPainting();
+
+	// Redraw to indicate busy
+	paint();
 
 	Common::SeekableReadStream *ds;
 	GameInfo saveinfo;


### PR DESCRIPTION
Switching the mouse cursor from an in-engine paint to use of the CursorManager. This makes use of the keycolor now available on the mouse shape frames - tested in Ultima 8 & Crusader: No Remorse. The cursors still needs to update on every frame as the red cross (not-allowed) cursor flashes on a timer. 
