### PR TITLE
GLK: SCOTT: Fix leak in disk_image.cpp

### DIFF
--- a/engines/glk/scott/disk_image.cpp
+++ b/engines/glk/scott/disk_image.cpp
@@ -744,18 +744,14 @@ RawDirEntry *findLargestFileEntry(DiskImage *di) {
 DiskImage *diCreateFromData(uint8_t *data, int length) {
 	DiskImage *di;
 
+    if (data == nullptr)
+        return nullptr;
+
 	if ((di = new DiskImage) == nullptr) {
 		return nullptr;
 	}
 
 	di->_size = length;
-
-	/* allocate buffer for image */
-	if ((di->_image = new byte[length]) == nullptr) {
-		delete di;
-		return nullptr;
-	}
-
 	di->_image = data;
 
 	di->_errinfo = nullptr;
@@ -798,7 +794,6 @@ DiskImage *diCreateFromData(uint8_t *data, int length) {
 		break;
 
 	default:
-		delete[] di->_image;
 		delete di;
 		return nullptr;
 	}


### PR DESCRIPTION
The method `diCreateFromData()` is set up as if it is going to copy the `data` supplied by the caller to the `_image` member, allocating memory for it, but then just assigns `data` to it instead (at line 759), leaking the allocated memory.

This also means that if the data supplied is not a valid disk image, it will delete the original data when it reaches the `default` switch case, potentially causing a double delete down the line if the caller does not anticipate it.

We fix this by just removing the allocation and the deletion. An alternative would have been to actually copy the data instead.

This is based on the updated [original C source](https://github.com/angstsmurf/garglk/blob/c0c4f6df352226b96b493d3ffca08ac4f115ca17/terps/c64diskimage/c64diskimage.c#L476-L541).