### PR TITLE
Support AppleDouble inside __MACOSX directory

### DIFF
--- a/common/macresman.h
+++ b/common/macresman.h
@@ -318,6 +318,8 @@ private:
 	static Path constructAppleDoubleName(Path name);
 	static Path disassembleAppleDoubleName(Path name, bool *isAppleDouble);
 
+	static SeekableReadStream *openAppleDoubleWithAppleOrOSXNaming(Archive& archive, const Path &fileName);
+
 	/**
 	 * Do a sanity check whether the given stream is a raw resource fork.
 	 *

--- a/common/path.cpp
+++ b/common/path.cpp
@@ -276,6 +276,20 @@ Path Path::punycodeDecode() const {
 	return ret;
 }
 
+Path Path::joinComponents(const StringArray& c) {
+	String res;
+
+	for (uint i = 0; i < c.size(); i++) {
+		res += c[i];
+		if (i + 1 < c.size())
+			res += DIR_SEPARATOR;
+	}
+
+	Path ret;
+	ret._str = res;
+	return ret;
+}
+
 // See getIdentifierString() for more details.
 // This does the same but for a single path component and is used by
 // getIdentifierString().

--- a/common/path.h
+++ b/common/path.h
@@ -215,6 +215,12 @@ public:
 	 * 2 separots follow each other
 	 */
 	StringArray splitComponents() const;
+
+
+	/**
+	 * Opposite of splitComponents
+	 */
+	static Path joinComponents(const StringArray& c);
 };
 
 /** @} */


### PR DESCRIPTION
This is common if HFS(+) directory was compressed in a zip or copied to a FAT or (more rarely) UFS