### PR TITLE
GLK: SCOTT: Fix out-of-bounds write

### DIFF
--- a/engines/glk/scott/resource.cpp
+++ b/engines/glk/scott/resource.cpp
@@ -105,12 +105,9 @@ uint8_t *readDictionary(GameInfo info, uint8_t **pointer, int loud) {
 	int nv = info._numberOfVerbs;
 	int nn = info._numberOfNouns;
 
-	for (int i = 0; i <= MAX(nv, nw) - nv; i++) {
-		_G(_verbs)[nv + i] = ".\0";
-	}
-
-	for (int i = 0; i <= MAX(nn, nw) - nn; i++) {
-		_G(_nouns)[nn + i] = ".\0";
+	for (int i = 0; i < nw + 2; i++) {
+		_G(_verbs)[i] = ".";
+		_G(_nouns)[i] = ".";
 	}
 
 	do {


### PR DESCRIPTION
If `nv` or `nn` (number of verbs or number of nouns) is equal to or larger than `nw` (number of words) + 2, these loops will try to write out of bounds and assert. This happens for example in the C64 version of *The Golden Baton*.

To fix this, it is really enough to change the `>=` operator to `>`, but I took the opportunity to simplify the code a bit.

This is based on the updated C source at https://github.com/angstsmurf/garglk/blob/c0c4f6df352226b96b493d3ffca08ac4f115ca17/terps/scott/detectgame.c#L120-L137
