### PR TITLE
GOB: Add another German variant of adibou2

### DIFF
--- a/engines/gob/detection/tables_adibou.h
+++ b/engines/gob/detection/tables_adibou.h
@@ -198,6 +198,22 @@
 	0, 0, 0
 },
 
+{
+	{
+		"adibou2",
+		"Adi Junior (Packard Bell OEM)",
+		AD_ENTRY1s("intro.stk", "80588ad3b5510bb44d3f40d6b07b81e7", 956328),
+		DE_DEU,
+		kPlatformWindows,
+		ADGF_TESTING,
+		GUIO0()
+	},
+	kGameTypeAdibou2,
+	kFeatures640x480,
+	0, 0, 0
+},
+
+
 // -- Italian: Adibù --
 {
 	{

--- a/engines/gob/detection/tables_adibou.h
+++ b/engines/gob/detection/tables_adibou.h
@@ -201,7 +201,7 @@
 {
 	{
 		"adibou2",
-		"Adi Junior (Packard Bell OEM)",
+		"ADI Jr. (Packard Bell OEM)",
 		AD_ENTRY1s("intro.stk", "80588ad3b5510bb44d3f40d6b07b81e7", 956328),
 		DE_DEU,
 		kPlatformWindows,


### PR DESCRIPTION
This patch adds a detection entry for the German version of Adibou 2 (dubbed "Adi Junior 2" here) I got with an Packard Bell PC, so it is a OEM bundled version.

And yes, this version is most likely the very first PC game I ever played - thank you @sdelamarre!

This version is playable, but in ScummVM, it is missing the intro sequence and starts straight with the character selection screen.

There are a bunch of warnings printed when starting the game:
```
WARNING: File "APPLIS.BOU" not found!
WARNING: File "ENVIR.BOU" not found!
WARNING: File "RESEAU.BOU" not found!
WARNING: File "RAM.BOU" not found!
WARNING: File "RAM16.BOU" not found!
WARNING: File "DEBUGA.BOU" not found!
WARNING: File "CHEAT.BOU" not found!
WARNING: Urban/Playtoons Stub: Unknown Video/Music command: -2, DEBUT!
WARNING: Urban/Playtoons Stub: Unknown Video/Music command: -2, DEBUT!
```

However, since the game itself works, I think adding makes sense at this point.