### PR TITLE
CONFIGURE: Allow Cygwin as development platform.

### DIFF
--- a/configure
+++ b/configure
@@ -220,6 +220,7 @@ _nuked_opl=yes
 _builtin_resources=yes
 _windows_console=yes
 _windows_unicode=yes
+_cygwin_build=no
 # Default commands
 _ranlib=ranlib
 _strip=strip
@@ -1196,6 +1197,7 @@ for ac_option in $@; do
 	--enable-discord)             _discord=yes           ;;
 	--disable-discord)            _discord=no            ;;
 	--enable-verbose-build)      _verbose_build=yes      ;;
+	--enable-cygwin-build)       _cygwin_build=yes       ;;
 	--enable-plugins)            _dynamic_modules=yes    ;;
 	--default-dynamic)           _plugins_default=dynamic;;
 	--enable-mt32emu)            _mt32emu=yes            ;;
@@ -2689,8 +2691,15 @@ case $_host_os in
 		_seq_midi=no
 		;;
 	cygwin*)
-		echo ERROR: Cygwin building is not supported by ScummVM anymore. Consider using MinGW.
-		exit 1
+		if test "$_cygwin_build" = no; then
+			echo ERROR: Cygwin building is not supported by ScummVM anymore. Consider using MinGW.
+			exit 1
+		else
+			echo WARNING: Cygwin building is not supported by ScummVM anymore.
+			echo Cygwin should be used only for development purposes and testing POSIX code on Windows.
+			echo Consider using MinGW instead.
+			append_var DEFINES "-D_GNU_SOURCE"
+		fi
 		;;
 	darwin*)
 		case $_host_cpu in
@@ -4039,10 +4048,10 @@ esac
 #
 echo_n "Checking if host is POSIX compliant... "
 case $_host_os in
-	amigaos* | cygwin* | dreamcast | ds | gamecube | mingw* | morphos | n64 | ps3 | psp2 | psp | riscos | wii)
+	amigaos* | dreamcast | ds | gamecube | mingw* | morphos | n64 | ps3 | psp2 | psp | riscos | wii)
 		_posix=no
 		;;
-	3ds | android | beos* | bsd* | darwin* | dragonfly* | freebsd* | gnu* | gph-linux | haiku* | hpux* | iphone | ios7 | irix*| k*bsd*-gnu* | linux* | maemo | mint* | netbsd* | openbsd* | serenity* | solaris* | sunos* | switch | uclinux*)
+	3ds | android | beos* | bsd* | cygwin* | darwin* | dragonfly* | freebsd* | gnu* | gph-linux | haiku* | hpux* | iphone | ios7 | irix*| k*bsd*-gnu* | linux* | maemo | mint* | netbsd* | openbsd* | serenity* | solaris* | sunos* | switch | uclinux*)
 		_posix=yes
 		;;
 	os2-emx*)


### PR DESCRIPTION
I would like to suggest to allow the use of Cygwin as development platform.

This is not intended for providing builds for this environment (although SCUMMVM can be already built on it without problems), but for having an easy way for testing POSIX code on Windows. There could be some alternatives, like the (defunt) Microsoft POSIX subsystem, the (also defunct) Windows Services for UNIX or the WSL1 and WSL2, but they are all painful experiences, at least for me, especially when debugging graphical applications connected to an X server or working with physical devices (try to believe). Alternatively, it is also possible to make a full virtual machine by using emulators like QEMU, but it has not the same advantages of having the code running natively, especially when sharing the same files. And a minimum installation of a linux distribution with development tools requires not less than 20GB. So, this should be seen as a tool for developers, nothing more than that, because at the time of writing this seems to be the best and most comfortable way for debugging a change to the ports using POSIX code.

However, to avoid unintentional execution, the user must activate the support for Cygwin by providing `--enable-cygwin-build` at configure time, otherwise the process will halt again. Even when support for Cygwin is activated, a warning message is still shown to the user, for informing him on what he is doing.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
