### PR TITLE
GRAPHICS: Remove or deprecate RGBA palette functions in ManagedSurface

### DIFF
--- a/engines/mtropolis/elements.cpp
+++ b/engines/mtropolis/elements.cpp
@@ -1094,11 +1094,10 @@ void ImageElement::render(Window *window) {
 		if (optimized->format.bytesPerPixel == 1) {
 			// FIXME: Pass palette to blit functions instead
 			if (_cachedImage->getOriginalColorDepth() == kColorDepthMode1Bit) {
-				const Graphics::PixelFormat &fmt = window->getPixelFormat();
-				uint32 blackColor = fmt.RGBToColor(0, 0, 0);
-				uint32 whiteColor = fmt.RGBToColor(255, 255, 255);
-
-				const uint32 bwPalette[2] = {whiteColor, blackColor};
+				const uint8 bwPalette[2 * 3] = {
+					255, 255, 255,
+					0, 0, 0
+				};
 				optimized->setPalette(bwPalette, 0, 2);
 			} else {
 				const Palette *palette = getPalette().get();
@@ -1921,8 +1920,10 @@ void TextLabelElement::render(Window *window) {
 
 	// TODO: Need to handle more modes
 	const ColorRGB8 &color = _renderProps.getForeColor();
-	const uint32 opaqueColor = target->format.RGBToColor(color.r, color.g, color.b);
-	const uint32 drawPalette[2] = {0, opaqueColor};
+	const uint8 drawPalette[2 * 3] = {
+		0, 0, 0,
+		color.r, color.g, color.b
+	};
 
 	if (_renderedText) {
 		_renderedText->setPalette(drawPalette, 0, 2);

--- a/engines/nancy/cursor.cpp
+++ b/engines/nancy/cursor.cpp
@@ -124,12 +124,9 @@ void CursorManager::setCursor(CursorType type, int16 itemID) {
 	// Convert the trans color from the original format to the screen format
 	uint transColor;
 	if (g_nancy->getGameType() == kGameTypeVampire) {
-		uint8 r, g, b;
-		uint32 input = surf->getPalette()[1];
-		r = input & 0xFF;
-		g = (input & 0xFF00) >> 8;
-		b = (input & 0xFF0000) >> 16;
-		transColor = temp.format.RGBToColor(r, g, b);
+		uint8 palette[1 * 3];
+		surf->grabPalette(palette, 1, 1);
+		transColor = temp.format.RGBToColor(palette[0], palette[1], palette[2]);
 	} else {
 		uint8 r, g, b;
 		surf->format.colorToRGB(g_nancy->_graphicsManager->getTransColor(), r, g, b);

--- a/engines/nancy/font.cpp
+++ b/engines/nancy/font.cpp
@@ -107,12 +107,9 @@ void Font::drawChar(Graphics::Surface *dst, uint32 chr, int x, int y, uint32 col
 				byte colorID = *(const byte *)_image.getBasePtr(srcRect.left + curX, srcRect.top +  curY);
 
 				if (colorID != _transColor) {
-					uint8 r, g, b;
-					uint curColor = _image.getPalette()[colorID];
-					r = curColor & 0xFF;
-					g = (curColor & 0xFF00) >> 8;
-					b = (curColor & 0xFF0000) >> 16;
-					*(uint16 *)dst->getBasePtr(x + curX, y + yOffset + curY) = dst->format.RGBToColor(r, g, b);
+					uint8 palette[1 * 3];
+					_image.grabPalette(palette, colorID, 1);
+					*(uint16 *)dst->getBasePtr(x + curX, y + yOffset + curY) = dst->format.RGBToColor(palette[0], palette[1], palette[2]);
 				}
 
 				break;

--- a/engines/nancy/graphics.cpp
+++ b/engines/nancy/graphics.cpp
@@ -141,13 +141,17 @@ void GraphicsManager::loadSurfacePalette(Graphics::ManagedSurface &inSurf, const
 
 void GraphicsManager::copyToManaged(const Graphics::Surface &src, Graphics::ManagedSurface &dst, bool verticalFlip, bool doubleSize) {
 	if (dst.w != (doubleSize ? src.w * 2 : src.w) || dst.h != (doubleSize ? src.h * 2 : src.h)) {
-		const uint32 *palette = dst.getPalette();
+		uint8 palette[256 * 3];
+		bool hasPalette = dst.hasPalette();
 		bool hasTransColor = dst.hasTransparentColor();
+
+		if (hasPalette && g_nancy->getGameType() == kGameTypeVampire) {
+			dst.grabPalette(palette, 0, 256);
+		}
+
 		dst.create(doubleSize ? src.w * 2 : src.w, doubleSize ? src.h * 2 : src.h, src.format);
 
-		if (palette && g_nancy->getGameType() == kGameTypeVampire) {
-			// free() clears the _hasPalette flag but doesn't clear the palette itself, so
-			// we just set it to itself; hopefully this doesn't cause any issues
+		if (hasPalette && g_nancy->getGameType() == kGameTypeVampire) {
 			dst.setPalette(palette, 0, 256);
 		}
 

--- a/engines/nancy/ui/inventorybox.cpp
+++ b/engines/nancy/ui/inventorybox.cpp
@@ -232,7 +232,9 @@ void InventoryBox::Curtains::init() {
 	_drawSurface.create(bounds.width(), bounds.height(), g_nancy->_graphicsManager->getInputPixelFormat());
 
 	if (g_nancy->getGameType() == kGameTypeVampire) {
-		_drawSurface.setPalette(g_nancy->_graphicsManager->_object0.getPalette(), 0, 256);
+		uint8 palette[256 * 3];
+		g_nancy->_graphicsManager->_object0.grabPalette(palette, 0, 256);
+		_drawSurface.setPalette(palette, 0, 256);
 	}
 
 	_screenPosition = _parent->getScreenPosition();

--- a/engines/nancy/ui/viewport.cpp
+++ b/engines/nancy/ui/viewport.cpp
@@ -198,7 +198,9 @@ void Viewport::loadVideo(const Common::String &filename, uint frameNr, uint vert
 
 	if (palette.size()) {
 		GraphicsManager::loadSurfacePalette(_drawSurface, palette);
-		_fullFrame.setPalette(_drawSurface.getPalette(), 0, 256);
+		uint8 pal[256 * 3];
+		_drawSurface.grabPalette(pal, 0, 256);
+		_fullFrame.setPalette(pal, 0, 256);
 	}
 
 	_movementLastFrame = 0;
@@ -208,13 +210,17 @@ void Viewport::loadVideo(const Common::String &filename, uint frameNr, uint vert
 
 void Viewport::setPalette(const Common::String &paletteName) {
 	GraphicsManager::loadSurfacePalette(_drawSurface, paletteName);
-	_fullFrame.setPalette(_drawSurface.getPalette(), 0, 256);
+	uint8 pal[256 * 3];
+	_drawSurface.grabPalette(pal, 0, 256);
+	_fullFrame.setPalette(pal, 0, 256);
 	_needsRedraw = true;
 }
 
 void Viewport::setPalette(const Common::String &paletteName, uint paletteStart, uint paletteSize) {
 	GraphicsManager::loadSurfacePalette(_drawSurface, paletteName, paletteStart, paletteSize);
-	_fullFrame.setPalette(_drawSurface.getPalette(), 0, 256);
+	uint8 pal[256 * 3];
+	_drawSurface.grabPalette(pal, 0, 256);
+	_fullFrame.setPalette(pal, 0, 256);
 	_needsRedraw = true;
 }
 

--- a/engines/private/private.cpp
+++ b/engines/private/private.cpp
@@ -1389,14 +1389,8 @@ void PrivateEngine::drawScreen() {
 		// No use of _compositeSurface, we write the frame directly to the screen in the expected position
 		g_system->copyRectToScreen(frame->getPixels(), frame->pitch, center.x, center.y, frame->w, frame->h);	
 	} else {
-		const byte *cPalette = (const byte *) _compositeSurface->getPalette();
-
-		byte newPalette[768];
-		for (int c = 0; c < 256; c++) { // This avoids any endianness issues
-			uint32 y = READ_UINT32(&cPalette[c * 4]) & 0x00FFFFFF;
-			WRITE_LE_UINT24(&newPalette[c * 3], y);
-		}
-
+		byte newPalette[256 * 3];
+		_compositeSurface->grabPalette(newPalette, 0, 256);
 		g_system->getPaletteManager()->setPalette(newPalette, 0, 256);
 
 		if (_mode == 1) {

--- a/engines/ultima/nuvie/gui/gui_font.cpp
+++ b/engines/ultima/nuvie/gui/gui_font.cpp
@@ -106,14 +106,20 @@ void GUI_Font::setTransparency(bool on) {
 
 /* determine foreground and background color values RGB*/
 void GUI_Font::setColoring(uint8 fr, uint8 fg, uint8 fb, uint8 br, uint8 bg, uint8 bb) {
-	const SDL_Color colors[2] = { MAKE_COLOR(br, bg, bb), MAKE_COLOR(fr, fg, fb) };
-	SDL_SetColors(_fontStore, colors, 0, 2);
+	const uint8 colors[2 * 3] = {
+		br, bg, bb,
+		fr, fg, fb
+	};
+	_fontStore->setPalette(colors, 0, 2);
 }
 
 void GUI_Font::setColoring(uint8 fr, uint8 fg, uint8 fb, uint8 fr1, uint8 fg1, uint8 fb1, uint8 br, uint8 bg, uint8 bb) {
-	const SDL_Color colors[3] = {
-		MAKE_COLOR(br, bg, bb), MAKE_COLOR(fr, fg, fb), MAKE_COLOR(fr1, fg1, fb1) };
-	SDL_SetColors(_fontStore, colors, 0, 3);
+	const uint8 colors[3 * 3] = {
+		br, bg, bb,
+		fr, fg, fb,
+		fr1, fg1, fb1
+	};
+	_fontStore->setPalette(colors, 0, 3);
 }
 
 /* put the text onto the given surface using the preset mode and colors */

--- a/engines/ultima/nuvie/misc/sdl_compat.cpp
+++ b/engines/ultima/nuvie/misc/sdl_compat.cpp
@@ -107,11 +107,6 @@ int SDL_SetColorKey(Graphics::ManagedSurface *surface, int flag, uint32 key) {
 	return 0;
 }
 
-int SDL_SetColors(Graphics::ManagedSurface *surface, const SDL_Color *colors, int firstcolor, int ncolors) {
-	surface->setPalette(colors, firstcolor, ncolors);
-	return 0;
-}
-
 int SDL_WaitEvent(Common::Event *event) {
 	while (!Events::get()->pollEvent(*event))
 		g_system->delayMillis(5);

--- a/engines/ultima/nuvie/misc/sdl_compat.h
+++ b/engines/ultima/nuvie/misc/sdl_compat.h
@@ -33,9 +33,6 @@ namespace Nuvie {
 
 #define SDL_SWSURFACE 0
 
-typedef uint32 SDL_Color;
-#define MAKE_COLOR(r, g, b) (((uint32)r) | (((uint32)g) << 8) | (((uint32)b) << 16) | (((uint32)0xff) << 24))
-
 extern uint32 SDL_GetTicks();
 extern void SDL_FreeSurface(Graphics::ManagedSurface *&s);
 extern void SDL_ShowCursor(bool show);
@@ -47,7 +44,6 @@ extern void SDL_UpdateRect(Graphics::ManagedSurface *surf, int x, int y, int w, 
 extern void SDL_UpdateRects(Graphics::ManagedSurface *surf, int count, Common::Rect *rects);
 extern Graphics::ManagedSurface *SDL_LoadBMP(const char *filename);
 extern int SDL_SetColorKey(Graphics::ManagedSurface *surface, int flag, uint32 key);
-extern int SDL_SetColors(Graphics::ManagedSurface *surface, const SDL_Color *colors, int firstcolor, int ncolors);
 extern int SDL_WaitEvent(Common::Event *event);
 extern int SDL_PollEvent(Common::Event *event);
 extern int SDL_LockSurface(Graphics::ManagedSurface *surface);

--- a/engines/ultima/nuvie/screen/screen.cpp
+++ b/engines/ultima/nuvie/screen/screen.cpp
@@ -135,7 +135,6 @@ bool Screen::set_palette(uint8 *p) {
 	if (_renderSurface == NULL || p == NULL)
 		return false;
 
-//SDL_SetColors(scaled_surface,palette,0,256);
 	for (int i = 0; i < 256; ++i) {
 		uint32  r = p[i * 3];
 		uint32  g = p[i * 3 + 1];

--- a/engines/ultima/ultima4/gfx/image.cpp
+++ b/engines/ultima/ultima4/gfx/image.cpp
@@ -108,7 +108,8 @@ void Image::setPalette(const RGBA *colors, unsigned n_colors) {
 void Image::setPaletteFromImage(const Image *src) {
 	assertMsg(_paletted && src->_paletted, "imageSetPaletteFromImage called on non-indexed image");
 
-	const uint32 *srcPal = src->_surface->getPalette();
+	uint8 srcPal[PALETTE_COUNT * 3];
+	src->_surface->grabPalette(srcPal, 0, PALETTE_COUNT);
 	_surface->setPalette(srcPal, 0, PALETTE_COUNT);
 }
 
@@ -116,30 +117,15 @@ RGBA Image::getPaletteColor(int index) {
 	RGBA color = RGBA(0, 0, 0, 0);
 
 	if (_paletted) {
-		uint32 pal = _surface->getPalette()[index];
-		color.r = (pal & 0xff);
-		color.g = (pal >> 8) & 0xff;
-		color.b = (pal >> 16) & 0xff;
+		uint8 pal[1 * 3];
+		_surface->grabPalette(pal, index, 1);
+		color.r = pal[0];
+		color.g = pal[1];
+		color.b = pal[2];
 		color.a = IM_OPAQUE;
 	}
 
 	return color;
-}
-
-int Image::getPaletteIndex(RGBA color) {
-	if (!_paletted)
-		return -1;
-
-	const uint32 *pal = _surface->getPalette();
-	uint32 color32 = color;
-
-	for (int i = 0; i < PALETTE_COUNT; ++i, ++pal) {
-		if (*pal == color32)
-			return i;
-	}
-
-	// return the proper palette index for the specified color
-	return -1;
 }
 
 RGBA Image::setColor(uint8 r, uint8 g, uint8 b, uint8 a) {
@@ -156,39 +142,39 @@ bool Image::setFontColor(ColorFG fg, ColorBG bg) {
 bool Image::setFontColorFG(ColorFG fg) {
 	switch (fg) {
 	case FG_GREY:
-		if (!setPaletteIndex(TEXT_FG_PRIMARY_INDEX,   setColor(153, 153, 153))) return false;
-		if (!setPaletteIndex(TEXT_FG_SECONDARY_INDEX, setColor(102, 102, 102))) return false;
-		if (!setPaletteIndex(TEXT_FG_SHADOW_INDEX,    setColor(51, 51, 51))) return false;
+		if (!setPaletteIndex(TEXT_FG_PRIMARY_INDEX,   153, 153, 153)) return false;
+		if (!setPaletteIndex(TEXT_FG_SECONDARY_INDEX, 102, 102, 102)) return false;
+		if (!setPaletteIndex(TEXT_FG_SHADOW_INDEX,    51, 51, 51)) return false;
 		break;
 	case FG_BLUE:
-		if (!setPaletteIndex(TEXT_FG_PRIMARY_INDEX,   setColor(102, 102, 255))) return false;
-		if (!setPaletteIndex(TEXT_FG_SECONDARY_INDEX, setColor(51, 51, 204))) return false;
-		if (!setPaletteIndex(TEXT_FG_SHADOW_INDEX,    setColor(51, 51, 51))) return false;
+		if (!setPaletteIndex(TEXT_FG_PRIMARY_INDEX,   102, 102, 255)) return false;
+		if (!setPaletteIndex(TEXT_FG_SECONDARY_INDEX, 51, 51, 204)) return false;
+		if (!setPaletteIndex(TEXT_FG_SHADOW_INDEX,    51, 51, 51)) return false;
 		break;
 	case FG_PURPLE:
-		if (!setPaletteIndex(TEXT_FG_PRIMARY_INDEX,   setColor(255, 102, 255))) return false;
-		if (!setPaletteIndex(TEXT_FG_SECONDARY_INDEX, setColor(204, 51, 204))) return false;
-		if (!setPaletteIndex(TEXT_FG_SHADOW_INDEX,    setColor(51, 51, 51))) return false;
+		if (!setPaletteIndex(TEXT_FG_PRIMARY_INDEX,   255, 102, 255)) return false;
+		if (!setPaletteIndex(TEXT_FG_SECONDARY_INDEX, 204, 51, 204)) return false;
+		if (!setPaletteIndex(TEXT_FG_SHADOW_INDEX,    51, 51, 51)) return false;
 		break;
 	case FG_GREEN:
-		if (!setPaletteIndex(TEXT_FG_PRIMARY_INDEX,   setColor(102, 255, 102))) return false;
-		if (!setPaletteIndex(TEXT_FG_SECONDARY_INDEX, setColor(0, 153, 0))) return false;
-		if (!setPaletteIndex(TEXT_FG_SHADOW_INDEX,    setColor(51, 51, 51))) return false;
+		if (!setPaletteIndex(TEXT_FG_PRIMARY_INDEX,   102, 255, 102)) return false;
+		if (!setPaletteIndex(TEXT_FG_SECONDARY_INDEX, 0, 153, 0)) return false;
+		if (!setPaletteIndex(TEXT_FG_SHADOW_INDEX,    51, 51, 51)) return false;
 		break;
 	case FG_RED:
-		if (!setPaletteIndex(TEXT_FG_PRIMARY_INDEX,   setColor(255, 102, 102))) return false;
-		if (!setPaletteIndex(TEXT_FG_SECONDARY_INDEX, setColor(204, 51, 51))) return false;
-		if (!setPaletteIndex(TEXT_FG_SHADOW_INDEX,    setColor(51, 51, 51))) return false;
+		if (!setPaletteIndex(TEXT_FG_PRIMARY_INDEX,   255, 102, 102)) return false;
+		if (!setPaletteIndex(TEXT_FG_SECONDARY_INDEX, 204, 51, 51)) return false;
+		if (!setPaletteIndex(TEXT_FG_SHADOW_INDEX,    51, 51, 51)) return false;
 		break;
 	case FG_YELLOW:
-		if (!setPaletteIndex(TEXT_FG_PRIMARY_INDEX,   setColor(255, 255, 51))) return false;
-		if (!setPaletteIndex(TEXT_FG_SECONDARY_INDEX, setColor(204, 153, 51))) return false;
-		if (!setPaletteIndex(TEXT_FG_SHADOW_INDEX,    setColor(51, 51, 51))) return false;
+		if (!setPaletteIndex(TEXT_FG_PRIMARY_INDEX,   255, 255, 51)) return false;
+		if (!setPaletteIndex(TEXT_FG_SECONDARY_INDEX, 204, 153, 51)) return false;
+		if (!setPaletteIndex(TEXT_FG_SHADOW_INDEX,    51, 51, 51)) return false;
 		break;
 	default:
-		if (!setPaletteIndex(TEXT_FG_PRIMARY_INDEX,   setColor(255, 255, 255))) return false;
-		if (!setPaletteIndex(TEXT_FG_SECONDARY_INDEX, setColor(204, 204, 204))) return false;
-		if (!setPaletteIndex(TEXT_FG_SHADOW_INDEX,    setColor(68, 68, 68))) return false;
+		if (!setPaletteIndex(TEXT_FG_PRIMARY_INDEX,   255, 255, 255)) return false;
+		if (!setPaletteIndex(TEXT_FG_SECONDARY_INDEX, 204, 204, 204)) return false;
+		if (!setPaletteIndex(TEXT_FG_SHADOW_INDEX,    68, 68, 68)) return false;
 	}
 	return true;
 }
@@ -196,22 +182,24 @@ bool Image::setFontColorFG(ColorFG fg) {
 bool Image::setFontColorBG(ColorBG bg) {
 	switch (bg) {
 	case BG_BRIGHT:
-		if (!setPaletteIndex(TEXT_BG_INDEX, setColor(0, 0, 102)))
+		if (!setPaletteIndex(TEXT_BG_INDEX, 0, 0, 102))
 			return false;
 		break;
 	default:
-		if (!setPaletteIndex(TEXT_BG_INDEX, setColor(0, 0, 0)))
+		if (!setPaletteIndex(TEXT_BG_INDEX, 0, 0, 0))
 			return false;
 	}
 	return true;
 }
 
-bool Image::setPaletteIndex(uint index, RGBA color) {
+bool Image::setPaletteIndex(uint index, uint8 r, uint8 g, uint8 b) {
 	if (!_paletted)
 		return false;
 
-	uint32 color32 = color;
-	_surface->setPalette(&color32, index, 1);
+	const uint8 palette[1 * 3] = {
+		r, g, b
+	};
+	_surface->setPalette(palette, index, 1);
 
 	// success
 	return true;
@@ -253,11 +241,12 @@ uint Image::getColor(byte r, byte g, byte b, byte a) {
 	uint color;
 
 	if (_surface->format.bytesPerPixel == 1) {
-		const uint32 *pal = _surface->getPalette();
-		for (color = 0; color <= 0xfe; ++color, ++pal) {
-			byte rv = *pal & 0xff;
-			byte gv = (*pal >> 8) & 0xff;
-			byte bv = (*pal >> 16) & 0xff;
+		uint8 pal[256 * 3];
+		_surface->grabPalette(pal, 0, 256);
+		for (color = 0; color <= 0xfe; ++color) {
+			byte rv = pal[(color * 3) + 0];
+			byte gv = pal[(color * 3) + 1] & 0xff;
+			byte bv = pal[(color * 3) + 2] & 0xff;
 			if (r == rv && g == gv && b == bv)
 				break;
 		}
@@ -379,11 +368,12 @@ void Image::getPixel(int x, int y, uint &r, uint &g, uint &b, uint &a) const {
 	getPixelIndex(x, y, index);
 
 	if (_surface->format.bytesPerPixel == 1) {
-		uint32 col = _surface->getPalette()[index];
-		r = col & 0xff;
-		g = (col >> 8) & 0xff;
-		b = (col >> 16) & 0xff;
-		a = (col >> 24) & 0xff;
+		uint8 pal[1 * 3];
+		_surface->grabPalette(pal, index, 1);
+		r = pal[0];
+		g = pal[1];
+		b = pal[2];
+		a = IM_OPAQUE;
 	} else {
 		_surface->format.colorToARGB(index, a1, r1, g1, b1);
 		r = r1;

--- a/engines/ultima/ultima4/gfx/image.h
+++ b/engines/ultima/ultima4/gfx/image.h
@@ -146,12 +146,8 @@ public:
 	/**
 	 * Sets the specified palette index to the specified RGB color
 	 */
-	bool setPaletteIndex(uint index, RGBA color);
+	bool setPaletteIndex(uint index, uint8 r, uint8 g, uint8 b);
 
-	/**
-	 * Returns the palette index of the specified RGB color
-	 */
-	int getPaletteIndex(RGBA color);
 	RGBA setColor(uint8 r, uint8 g, uint8 b, uint8 a = IM_OPAQUE);
 
 

--- a/engines/ultima/ultima4/gfx/imagemgr.cpp
+++ b/engines/ultima/ultima4/gfx/imagemgr.cpp
@@ -331,10 +331,10 @@ void ImageMgr::fixupIntro(Image *im, int prescale) {
 		im->setPaletteFromImage(borderInfo->_image);
 
 		// update the color of "and" and "present"
-		(void)im->setPaletteIndex(15, im->setColor(226, 226, 255));
+		(void)im->setPaletteIndex(15, 226, 226, 255);
 
 		// update the color of "Origin Systems, Inc."
-		(void)im->setPaletteIndex(9, im->setColor(129, 129, 255));
+		(void)im->setPaletteIndex(9, 129, 129, 255);
 
 #ifdef TODO
 		borderInfo->_image->save("border.png");

--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -764,13 +764,4 @@ void ManagedSurface::setPalette(const byte *colors, uint start, uint num) {
 		_owner->setPalette(colors, start, num);
 }
 
-void ManagedSurface::setPalette(const uint32 *colors, uint start, uint num) {
-	assert(start < 256 && (start + num) <= 256);
-	Common::copy(colors, colors + num, &_palette[start]);
-	_paletteSet = true;
-
-	if (_owner)
-		_owner->setPalette(colors, start, num);
-}
-
 } // End of namespace Graphics

--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -738,6 +738,18 @@ void ManagedSurface::clear(uint32 color) {
 		fillRect(getBounds(), color);
 }
 
+void ManagedSurface::grabPalette(byte *colors, uint start, uint num) const {
+	assert(start < 256 && (start + num) <= 256);
+	const uint32 *src = &_palette[start];
+
+	for (; num > 0; --num, colors += 3) {
+		uint32 p = *src++;
+		colors[0] =  p        & 0xff;
+		colors[1] = (p >> 8)  & 0xff;
+		colors[2] = (p >> 16) & 0xff;
+	}
+}
+
 void ManagedSurface::setPalette(const byte *colors, uint start, uint num) {
 	assert(start < 256 && (start + num) <= 256);
 	uint32 *dest = &_palette[start];

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -669,6 +669,18 @@ public:
 	}
 
 	/**
+	 * Return true if a palette has been set.
+	 */
+	bool hasPalette() const {
+		return _paletteSet;
+	}
+
+	/**
+	 * Grab the palette using RGB tuples.
+	 */
+	void grabPalette(byte *colors, uint start, uint num) const;
+
+	/**
 	 * Get the palette array.
 	 */
 	const uint32 *getPalette() const {

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -683,6 +683,7 @@ public:
 	/**
 	 * Get the palette array.
 	 */
+	WARN_DEPRECATED("Use grabPalette instead")
 	const uint32 *getPalette() const {
 		return _palette;
 	}
@@ -691,11 +692,6 @@ public:
 	 * Set the palette using RGB tuples.
 	 */
 	void setPalette(const byte *colors, uint start, uint num);
-
-	/**
-	 * Set the palette using RGBA values.
-	 */
-	void setPalette(const uint32 *colors, uint start, uint num);
 };
 /** @} */
 } // End of namespace Graphics

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -3643,14 +3643,7 @@ bool OptionsDialog::testGraphicsSettings() {
 	Graphics::ManagedSurface *pm5544 = Graphics::renderPM5544(xres, yres);
 
 	byte palette[768];
-	const uint32 *p = pm5544->getPalette();
-
-	for (int i = 0; i < 256; i++) {
-		palette[i * 3 + 0] =  p[i]        & 0xff;
-		palette[i * 3 + 1] = (p[i] >> 8)  & 0xff;
-		palette[i * 3 + 2] = (p[i] >> 16) & 0xff;
-	}
-
+	pm5544->grabPalette(palette, 0, 256);
 	g_system->getPaletteManager()->setPalette(palette, 0, 256);
 
 	g_system->copyRectToScreen(pm5544->surfacePtr()->getPixels(), pm5544->surfacePtr()->pitch, 0, 0, xres, yres);


### PR DESCRIPTION
Palettes with alpha transparency are not used by any engines, and using a different format for palettes compared to the rest of ScummVM prevents blitting code from being reused, in addition to some ambiguity for engines calling `setPalette` or `getPalette`.

This PR only changes the public interface, adapting `ManagedSurface` itself to use a standard palette format will be done in a follow-up PR.

This is currently a draft until proper testing can be done.