### PR TITLE
DIRECTOR: openMainArchive may be opening an EXE

### DIFF
--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -91,7 +91,9 @@ Cast::~Cast() {
 		for (Common::HashMap<int, const Stxt *>::iterator it = _loadedStxts->begin(); it != _loadedStxts->end(); ++it)
 			delete it->_value;
 
-	if (_castArchive) {
+	// There may be another open reference to the same file, in which
+	// case attempting to free it now would be dangerous.
+	if (_castArchive && !g_director->_allOpenResFiles.contains(_castArchive->getPathName())) {
 		_castArchive->close();
 		delete _castArchive;
 		_castArchive = nullptr;

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -1071,6 +1071,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "fantasystudio",		"Fantasy Studio" }, // RPG Maker-style creation toolkit
 	{ "fototune",			"FotoTune Multimedia Show" },
 	{ "fukuda",				"Fukuda Shigeo Retrospective Collection" },
+	{ "fukuokagoround",		"Fukuoka Go-Round" },
 	{ "furbydentaku",		"ファービー電卓" },								// Furby Calculator
 	{ "futarinoryori",		"ふたりの料理物語" },								// A Tale of Two Chefs
 	{ "futurepromotion",	"Towa Tei: Future Promotion" },
@@ -3691,6 +3692,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Bilingual Japanese/English
 	MACGAME1("fukuda", "", "Mac/FUKUDA",  "0b55676d539ba5e29560e7c4da4fbad6", 483187, 404),
 	WINGAME1t("fukuda", "", "WIN/MAIN/FUKUDA.EXE",  "71eec68c19354b67badc7c82f159374b", 739951, 404),
+
+	MACGAME2_l("fukuokagoround", "", "Fukuoka Go-Round",  "0c7bbb4b24823e5ab871cb4c1d6f3710", 484167, "shared.dir", "b83bfaec3666b328ec743e074a94115f", 20900286, Common::JA_JPN, 404),
+	WINGAME2t_l("fukuokagoround", "", "FGR.EXE",  "dc2da038ba67c2bd2f5bb31b97261db9", 5293611, "SHARED.DIR", "6bf95a48f366bdf8af3a198c7b723c77", 16038266, Common::JA_JPN, 404),
 
 	// Original filename is ・ふたりの料理物語
 	MACDEMO1_l("futarinoryori", "Demo", "A Tale of Two Chefs", "22815cf659b911c4e07d0015cac5d98f", 301681, Common::JA_JPN, 400),

--- a/engines/director/resource.cpp
+++ b/engines/director/resource.cpp
@@ -199,7 +199,7 @@ Archive *Window::openMainArchive(const Common::String movie) {
 	// If the archive is already open, don't reopen it;
 	// just init from the existing archive. This prevents errors that
 	// can happen when trying to load the same archive more than once.
-	if (g_director->_allOpenResFiles.contains(movie)) {
+	if (g_director->_allOpenResFiles.contains(movie) && SearchMan.hasFile(movie)) {
 		_mainArchive = g_director->_allOpenResFiles.getVal(movie);
 
 		if (g_director->getPlatform() == Common::kPlatformWindows) {

--- a/engines/director/window.h
+++ b/engines/director/window.h
@@ -172,13 +172,13 @@ public:
 	void probeProjector(const Common::String &movie);
 	void probeMacBinary(MacArchive *archive);
 	Archive *openMainArchive(const Common::String movie);
-	void loadEXE(const Common::String movie);
+	Archive *loadEXE(const Common::String movie);
 	void loadEXEv3(Common::SeekableReadStream *stream);
 	void loadEXEv4(Common::SeekableReadStream *stream);
 	void loadEXEv5(Common::SeekableReadStream *stream);
 	void loadEXEv7(Common::SeekableReadStream *stream);
 	void loadEXERIFX(Common::SeekableReadStream *stream, uint32 offset);
-	void loadMac(const Common::String movie);
+	Archive *loadMac(const Common::String movie);
 	void loadStartMovieXLibs();
 
 	// lingo/lingo-object.cpp


### PR DESCRIPTION
This fixes Fukuoka-Go-Round, which ends up passing the main EXE as a movie to (re)open at runtime instead of a movie. Without this, clicking back to the main menu crashes the disc because it tries to open the EXE as RIFX.