### PR TITLE
ENGINES: Allow AdvancedDetector to match on data fork and to specify type on per-file basis

### DIFF
--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -520,8 +520,7 @@ static MD5Properties gameFlagsToDefaultMD5Props(uint32 flags) {
 
 static bool getFilePropertiesIntern(uint md5Bytes, const AdvancedMetaEngine::FileMap &allFiles, MD5Properties md5prop, const Common::String &fname, FileProperties &fileProps);
 
-bool AdvancedMetaEngineDetection::getFileProperties(const FileMap &allFiles, const ADGameDescription &game, const Common::String &fname, FileProperties &fileProps) const {
-	MD5Properties md5prop = gameFlagsToDefaultMD5Props(game.flags);
+bool AdvancedMetaEngineDetection::getFileProperties(const FileMap &allFiles, MD5Properties md5prop, const Common::String &fname, FileProperties &fileProps) const {
 	Common::String hashname = Common::String::format("%c:%s:%d", md5PropToCacheChar(md5prop), fname.c_str(), _md5Bytes);
 
 	if (MD5Man.contains(hashname)) {
@@ -540,8 +539,7 @@ bool AdvancedMetaEngineDetection::getFileProperties(const FileMap &allFiles, con
 	return res;
 }
 
-bool AdvancedMetaEngine::getFilePropertiesExtern(uint md5Bytes, const FileMap &allFiles, const ADGameDescription &game, const Common::String &fname, FileProperties &fileProps) const {
-	MD5Properties md5prop = gameFlagsToDefaultMD5Props(game.flags);
+bool AdvancedMetaEngine::getFilePropertiesExtern(uint md5Bytes, const FileMap &allFiles, MD5Properties md5prop, const Common::String &fname, FileProperties &fileProps) const {
 	return getFilePropertiesIntern(md5Bytes, allFiles, md5prop, fname, fileProps);
 }
 
@@ -627,7 +625,7 @@ ADDetectedGames AdvancedMetaEngineDetection::detectGame(const Common::FSNode &pa
 				continue;
 
 			FileProperties tmp;
-			if (getFileProperties(allFiles, *g, fname, tmp)) {
+			if (getFileProperties(allFiles, md5prop, fname, tmp)) {
 				debugC(3, kDebugGlobalDetection, "> '%s': '%s' %ld", key.c_str(), tmp.md5.c_str(), long(tmp.size));
 			}
 
@@ -772,6 +770,7 @@ ADDetectedGame AdvancedMetaEngineDetection::detectGameFilebased(const FileMap &a
 			debugC(4, kDebugGlobalDetection, "Matched: %s", agdesc->gameId);
 
 			if (numMatchedFiles > maxNumMatchedFiles) {
+				MD5Properties md5prop = gameFlagsToDefaultMD5Props(agdesc->flags);
 				maxNumMatchedFiles = numMatchedFiles;
 
 				debugC(4, kDebugGlobalDetection, "and overridden");
@@ -782,7 +781,7 @@ ADDetectedGame AdvancedMetaEngineDetection::detectGameFilebased(const FileMap &a
 				for (filenames = ptr->filenames; *filenames; ++filenames) {
 					FileProperties tmp;
 
-					if (getFileProperties(allFiles, *agdesc, *filenames, tmp))
+					if (getFileProperties(allFiles, md5prop, *filenames, tmp))
 						game.matchedFiles[*filenames] = tmp;
 				}
 

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -537,7 +537,7 @@ static MD5Properties gameFileToMD5Props(const ADGameFileDescription *fileEntry, 
 static bool getFilePropertiesIntern(uint md5Bytes, const AdvancedMetaEngine::FileMap &allFiles, MD5Properties md5prop, const Common::String &fname, FileProperties &fileProps);
 
 bool AdvancedMetaEngineDetection::getFileProperties(const FileMap &allFiles, MD5Properties md5prop, const Common::String &fname, FileProperties &fileProps) const {
-	Common::String hashname = Common::String::format("%c:%s:%d", md5PropToCacheChar(md5prop), fname.c_str(), _md5Bytes);
+	Common::String hashname = Common::String::format("%s:%s:%d", md5PropToCachePrefix(md5prop), fname.c_str(), _md5Bytes);
 
 	if (MD5Man.contains(hashname)) {
 		fileProps.md5 = MD5Man.getMD5(hashname);
@@ -635,7 +635,7 @@ ADDetectedGames AdvancedMetaEngineDetection::detectGame(const Common::FSNode &pa
 		for (fileDesc = g->filesDescriptions; fileDesc->fileName; fileDesc++) {
 			MD5Properties md5prop = gameFileToMD5Props(fileDesc, g->flags);
 			Common::String fname = fileDesc->fileName;
-			Common::String key = Common::String::format("%c:%s", md5PropToCacheChar(md5prop), fname.c_str());
+			Common::String key = Common::String::format("%s:%s", md5PropToCachePrefix(md5prop), fname.c_str());
 
 			if (filesProps.contains(key))
 				continue;
@@ -683,7 +683,7 @@ ADDetectedGames AdvancedMetaEngineDetection::detectGame(const Common::FSNode &pa
 		for (fileDesc = game.desc->filesDescriptions; fileDesc->fileName; fileDesc++) {
 			Common::String tstr = fileDesc->fileName;
 			MD5Properties md5prop = gameFileToMD5Props(fileDesc, g->flags);
-			Common::String key = Common::String::format("%c:%s", md5PropToCacheChar(md5prop), tstr.c_str());
+			Common::String key = Common::String::format("%s:%s", md5PropToCachePrefix(md5prop), tstr.c_str());
 
 			if (!filesProps.contains(key) || filesProps[key].size == -1) {
 				allFilesPresent = false;

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -440,7 +440,7 @@ protected:
 	void composeFileHashMap(FileMap &allFiles, const Common::FSList &fslist, int depth, const Common::String &parentName = Common::String()) const;
 
 	/** Get the properties (size and MD5) of this file. */
-	bool getFileProperties(const FileMap &allFiles, const ADGameDescription &game, const Common::String &fname, FileProperties &fileProps) const;
+	bool getFileProperties(const FileMap &allFiles, MD5Properties md5prop, const Common::String &fname, FileProperties &fileProps) const;
 
 	/** Convert an AD game description into the shared game description format. */
 	virtual DetectedGame toDetectedGame(const ADDetectedGame &adGame, ADDetectedGameExtraInfo *extraInfo = nullptr) const;
@@ -509,7 +509,7 @@ public:
 	 *
 	 * Based on @ref MetaEngine::getFileProperties.
 	 */
-	bool getFilePropertiesExtern(uint md5Bytes, const FileMap &allFiles, const ADGameDescription &game, const Common::String &fname, FileProperties &fileProps) const;
+	bool getFilePropertiesExtern(uint md5Bytes, const FileMap &allFiles, MD5Properties md5prop, const Common::String &fname, FileProperties &fileProps) const;
 
 protected:
 	/**

--- a/engines/director/detection.cpp
+++ b/engines/director/detection.cpp
@@ -287,7 +287,7 @@ ADDetectedGame DirectorMetaEngineDetection::fallbackDetect(const FileMap &allFil
 		ADDetectedGame game(&desc->desc);
 
 		FileProperties tmp;
-		if (getFileProperties(allFiles, desc->desc, file->getName(), tmp)) {
+		if (getFileProperties(allFiles, kMD5Tail, file->getName(), tmp)) {
 			game.hasUnknownFiles = true;
 			game.matchedFiles[file->getName()] = tmp;
 		}

--- a/engines/game.cpp
+++ b/engines/game.cpp
@@ -165,8 +165,7 @@ Common::U32String DetectionResults::generateUnknownGameReport(bool translate, ui
 	return ::generateUnknownGameReport(_detectedGames, translate, false, wordwrapAt);
 }
 
-// Sync with engines/advancedDetector.cpp
-static char flagsToMD5Prefix(uint32 flags) {
+char md5PropToCacheChar(MD5Properties flags) {
 	if (flags & kMD5MacResFork) {
 		if (flags & kMD5Tail)
 			return 'e';
@@ -224,7 +223,7 @@ Common::U32String generateUnknownGameReport(const DetectedGames &detectedGames, 
 
 		// Consolidate matched files across all engines and detection entries
 		for (FilePropertiesMap::const_iterator it = game.matchedFiles.begin(); it != game.matchedFiles.end(); it++) {
-			Common::String key = Common::String::format("%c:%s", flagsToMD5Prefix(it->_value.md5prop), it->_key.c_str());
+			Common::String key = Common::String::format("%c:%s", md5PropToCacheChar(it->_value.md5prop), it->_key.c_str());
 			matchedFiles.setVal(key, it->_value);
 		}
 	}

--- a/engines/game.cpp
+++ b/engines/game.cpp
@@ -166,15 +166,32 @@ Common::U32String DetectionResults::generateUnknownGameReport(bool translate, ui
 }
 
 char md5PropToCacheChar(MD5Properties flags) {
-	if (flags & kMD5MacResFork) {
+	switch (flags & kMD5MacMask) {
+	case kMD5MacDataFork: {
+		if (flags & kMD5Tail)
+			return 'd';
+		return 'z';
+	}
+
+	case kMD5MacResOrDataFork: {
 		if (flags & kMD5Tail)
 			return 'e';
 		return 'm';
 	}
-	if (flags & kMD5Tail)
-		return 't';
 
-	return 'f';
+	case kMD5MacResFork: {
+		if (flags & kMD5Tail)
+			return 'x';
+		return 'r';
+	}
+
+	default: {
+		if (flags & kMD5Tail)
+			return 't';
+
+		return 'f';
+	}
+	}
 }
 
 Common::U32String generateUnknownGameReport(const DetectedGames &detectedGames, bool translate, bool fullPath, uint32 wordwrapAt) {

--- a/engines/game.cpp
+++ b/engines/game.cpp
@@ -165,31 +165,31 @@ Common::U32String DetectionResults::generateUnknownGameReport(bool translate, ui
 	return ::generateUnknownGameReport(_detectedGames, translate, false, wordwrapAt);
 }
 
-char md5PropToCacheChar(MD5Properties flags) {
+const char *md5PropToCachePrefix(MD5Properties flags) {
 	switch (flags & kMD5MacMask) {
 	case kMD5MacDataFork: {
 		if (flags & kMD5Tail)
-			return 'd';
-		return 'z';
+			return "dt";
+		return "d";
 	}
 
 	case kMD5MacResOrDataFork: {
 		if (flags & kMD5Tail)
-			return 'e';
-		return 'm';
+			return "mt";
+		return "m";
 	}
 
 	case kMD5MacResFork: {
 		if (flags & kMD5Tail)
-			return 'x';
-		return 'r';
+			return "rt";
+		return "r";
 	}
 
 	default: {
 		if (flags & kMD5Tail)
-			return 't';
+			return "ft";
 
-		return 'f';
+		return "f";
 	}
 	}
 }
@@ -240,7 +240,7 @@ Common::U32String generateUnknownGameReport(const DetectedGames &detectedGames, 
 
 		// Consolidate matched files across all engines and detection entries
 		for (FilePropertiesMap::const_iterator it = game.matchedFiles.begin(); it != game.matchedFiles.end(); it++) {
-			Common::String key = Common::String::format("%c:%s", md5PropToCacheChar(it->_value.md5prop), it->_key.c_str());
+			Common::String key = Common::String::format("%s:%s", md5PropToCachePrefix(it->_value.md5prop), it->_key.c_str());
 			matchedFiles.setVal(key, it->_value);
 		}
 	}

--- a/engines/game.h
+++ b/engines/game.h
@@ -103,9 +103,12 @@ enum GameSupportLevel {
  */
 
 enum MD5Properties {
-	kMD5Head		= 0 << 1,	// the MD5 is calculated from the head, default
-	kMD5Tail		= 1 << 1,	// the MD5 is calculated from the tail
-	kMD5MacResFork	= 1 << 2	// the MD5 is calculated from the Mac Resource fork (head or tail)
+	kMD5Head		 = 0 << 1,	// the MD5 is calculated from the head, default
+	kMD5Tail		 = 1 << 1,	// the MD5 is calculated from the tail
+	kMD5MacResFork           = 1 << 2,	// the MD5 is calculated from the Mac Resource fork (no fall back) (head or tail)
+	kMD5MacDataFork	         = 1 << 3,	// the MD5 is calculated from the Mac Data fork (head or tail)
+	kMD5MacResOrDataFork     = kMD5MacResFork | kMD5MacDataFork,	// the MD5 is calculated from the Mac Resource fork falling back to data fork (head or tail). Deprecated.
+	kMD5MacMask              = kMD5MacResFork | kMD5MacDataFork,    // Mask for mac type
 };
 
 char md5PropToCacheChar(MD5Properties val);

--- a/engines/game.h
+++ b/engines/game.h
@@ -108,6 +108,8 @@ enum MD5Properties {
 	kMD5MacResFork	= 1 << 2	// the MD5 is calculated from the Mac Resource fork (head or tail)
 };
 
+char md5PropToCacheChar(MD5Properties val);
+
 /**
  * A record describing the properties of a file. Used on the existing
  * files while detecting a game.

--- a/engines/game.h
+++ b/engines/game.h
@@ -111,7 +111,7 @@ enum MD5Properties {
 	kMD5MacMask              = kMD5MacResFork | kMD5MacDataFork,    // Mask for mac type
 };
 
-char md5PropToCacheChar(MD5Properties val);
+const char *md5PropToCachePrefix(MD5Properties val);
 
 /**
  * A record describing the properties of a file. Used on the existing

--- a/engines/sludge/detection.cpp
+++ b/engines/sludge/detection.cpp
@@ -148,7 +148,7 @@ ADDetectedGame SludgeMetaEngineDetection::fallbackDetect(const FileMap &allFiles
 		game.desc = &s_fallbackDesc.desc;
 
 		FileProperties tmp;
-		if (getFileProperties(allFiles, s_fallbackDesc.desc, fileName, tmp)) {
+		if (getFileProperties(allFiles, kMD5Head, fileName, tmp)) {
 			game.hasUnknownFiles = true;
 			game.matchedFiles[fileName] = tmp;
 		}

--- a/engines/wintermute/metaengine.cpp
+++ b/engines/wintermute/metaengine.cpp
@@ -226,7 +226,7 @@ public:
 			if (!file->getName().hasSuffixIgnoreCase(".dcp")) continue;
 
 			FileProperties tmp;
-			if (AdvancedMetaEngine::getFilePropertiesExtern(md5Bytes, allFiles, s_fallbackDesc, file->getName(), tmp)) {
+			if (AdvancedMetaEngine::getFilePropertiesExtern(md5Bytes, allFiles, kMD5Head, file->getName(), tmp)) {
 				game.hasUnknownFiles = true;
 				game.matchedFiles[file->getName()] = tmp;
 			}


### PR DESCRIPTION
This is a second attempton https://github.com/scummvm/scummvm/pull/4377 with 3 changes:
1) Modify as little code as possible
2) Keep ADGF_MACRESFORK semantics unchanged (falling back to datafork)
3) Warning for incorrect dump is moved to next PR