### PR TITLE
SCUMM: Reuse bomp decoder for SMUSH RLE codec

### DIFF
--- a/engines/scumm/bomp.cpp
+++ b/engines/scumm/bomp.cpp
@@ -50,7 +50,7 @@ void decompressBomp(byte *dst, const byte *src, int w, int h) {
 	} while (--h);
 }
 
-void bompDecodeLine(byte *dst, const byte *src, int len) {
+void bompDecodeLine(byte *dst, const byte *src, int len, bool setZero) {
 	assert(len > 0);
 
 	int num;
@@ -64,12 +64,17 @@ void bompDecodeLine(byte *dst, const byte *src, int len) {
 		len -= num;
 		if (code & 1) {
 			color = *src++;
-			memset(dst, color, num);
+			if (setZero || color)
+				memset(dst, color, num);
+			dst += num;
 		} else {
-			memcpy(dst, src, num);
-			src += num;
+			while (num--) {
+				color = *src++;
+				if (setZero || color)
+					*dst = color;
+				dst++;
+			}
 		}
-		dst += num;
 	}
 }
 

--- a/engines/scumm/bomp.cpp
+++ b/engines/scumm/bomp.cpp
@@ -68,11 +68,18 @@ void bompDecodeLine(byte *dst, const byte *src, int len, bool setZero) {
 				memset(dst, color, num);
 			dst += num;
 		} else {
-			while (num--) {
-				color = *src++;
-				if (setZero || color)
-					*dst = color;
-				dst++;
+			if (setZero) {
+				// Copy optimization when transparency is not needed
+				memcpy(dst, src, num);
+				src += num;
+				dst += num;
+			} else {
+				while (num--) {
+					color = *src++;
+					if (color)
+						*dst = color;
+					dst++;
+				}
 			}
 		}
 	}

--- a/engines/scumm/bomp.h
+++ b/engines/scumm/bomp.h
@@ -31,7 +31,7 @@ void bompApplyMask(byte *line_buffer, byte *mask, byte maskbit, int32 size, byte
 void bompApplyShadow(int shadowMode, const byte *shadowPalette, const byte *line_buffer, byte *dst, int32 size, byte transparency, bool HE7Check = false);
 
 void decompressBomp(byte *dst, const byte *src, int w, int h);
-void bompDecodeLine(byte *dst, const byte *src, int size);
+void bompDecodeLine(byte *dst, const byte *src, int size, bool setZero = true);
 void bompDecodeLineReverse(byte *dst, const byte *src, int size);
 
 

--- a/engines/scumm/smush/codec1.cpp
+++ b/engines/scumm/smush/codec1.cpp
@@ -22,40 +22,18 @@
 
 #include "common/endian.h"
 
+#include "scumm/bomp.h"
+
 namespace Scumm {
 
 void smushDecodeRLE(byte *dst, const byte *src, int left, int top, int width, int height, int pitch) {
-	byte val, code;
-	int32 length;
-	int h = height, lineSize;
-
 	dst += top * pitch;
-	for (h = 0; h < height; h++) {
-		lineSize = READ_LE_UINT16(src);
-		src += 2;
+	do {
 		dst += left;
-		while (lineSize > 0) {
-			code = *src++;
-			lineSize--;
-			length = (code >> 1) + 1;
-			if (code & 1) {
-				val = *src++;
-				lineSize--;
-				if (val)
-					memset(dst, val, length);
-				dst += length;
-			} else {
-				lineSize -= length;
-				while (length--) {
-					val = *src++;
-					if (val)
-						*dst = val;
-					dst++;
-				}
-			}
-		}
-		dst += pitch - left - width;
-	}
+		bompDecodeLine(dst, src + 2, width, false);
+		src += READ_LE_UINT16(src) + 2;
+		dst += pitch - left;
+	} while (--height);
 }
 
 } // End of namespace Scumm


### PR DESCRIPTION
This refactors SMUSH RLE codec (previously codec1) to use BOMP decoder (which is the same algorithm)
Added a flag to BOMP decoder to support transparency (another option was to zero-out the buffer before decoding).

There was a slight difference in the old implementation, of using the source length instead of the given width,
I haven't seen any difference when batch decoding all graphics from FT/DIG/COMI/Mortimer back when I implemented it in python.
anyway, judging by the last line in old implementation* (`dst += pitch - left - width;`), it could potentially cause graphic glitches if for some reason the source line stopped prematurely. (might be a good idea to verify this on disasm, and if needed add both conditions)

I have verified FT's mineroad looks ok.

* the `- width` is apparently needed to cancel the increments to `dst` along the way, which potentially might not match.