### PR TITLE
COMMON: BUILD: Use 'long' for int32 in MSVC 32-bit builds

### DIFF
--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -475,8 +475,20 @@
 	typedef signed char int8;
 	typedef unsigned short uint16;
 	typedef signed short int16;
+	// HACK: Some ports, such as NDS and AmigaOS, are not frequently
+	// tested during development, but cause frequent buildbot failures
+	// because they need to use 'long' for int32. Windows 32-bit
+	// binaries have this nice property of being easy to build, having
+	// a 32-bit 'long' too, *and* being frequently tested (incl. Github
+	// Actions). We want to catch this case as early and frequently
+	// as possible, so Win32 is probably the best candidate for this...
+	#if defined(WIN32) && !defined(_WIN64)
+	typedef unsigned long uint32;
+	typedef signed long int32;
+	#else
 	typedef unsigned int uint32;
 	typedef signed int int32;
+	#endif
 	typedef unsigned int uint;
 	typedef signed long long int64;
 	typedef unsigned long long uint64;

--- a/engines/grim/lua_v1.cpp
+++ b/engines/grim/lua_v1.cpp
@@ -53,7 +53,7 @@ byte clamp_color(int c) {
 		return c;
 }
 
-int luaA_passresults();
+int32 luaA_passresults();
 
 void Lua_V1::new_dofile() {
 	const char *fname_str = luaL_check_string(1);

--- a/engines/ultima/nuvie/sound/adplug/opl_class.h
+++ b/engines/ultima/nuvie/sound/adplug/opl_class.h
@@ -68,7 +68,7 @@ typedef struct {
 	uint32  Cnt;        /* frequency counter            */
 	uint32  Incr;       /* frequency counter step       */
 	uint8   FB;         /* feedback shift value         */
-	int32   *connect1;  /* slot1 output pointer         */
+	signed int *connect1;  /* slot1 output pointer         */
 	int32   op1_out[2]; /* slot1 output for feedback    */
 	uint8   CON;        /* connection (algorithm) type  */
 

--- a/engines/ultima/nuvie/sound/adplug/opl_class.h
+++ b/engines/ultima/nuvie/sound/adplug/opl_class.h
@@ -39,17 +39,6 @@ namespace Nuvie {
 /* select output bits size of output : 8 or 16 */
 #define OPL_SAMPLE_BITS 16
 
-/* compiler dependence */
-#ifndef OSD_CPU_H
-#define OSD_CPU_H
-typedef unsigned char   uint8;   /* unsigned  8bit */
-typedef unsigned short  UINT16;  /* unsigned 16bit */
-typedef unsigned int    uint32;  /* unsigned 32bit */
-typedef signed char     int8;    /* signed  8bit   */
-typedef signed short    int16;   /* signed 16bit   */
-typedef signed int      int32;   /* signed 32bit   */
-#endif
-
 #if (OPL_SAMPLE_BITS==16)
 typedef int16 OPLSAMPLE;
 #endif


### PR DESCRIPTION
The AmigaOS, MorphOS and Nintendo DS ports hit frequent (several per months) buildbot errors because they use `long` to define `int32` for their own reasons, but `int != int32` is not something that's expected on the most common development environments, and the current CI doesn't catch this case (Github Actions is limited to Ubuntu, Windows and macOS "native" builds, although we could work around this with containers?).

So I was looking for a way to catch this in our current CI *and* on common daily development environments. The sooner we detect an int/int32 mismatch, the better.

On most 32-bit systems, `long` is a 32-bit value too, but building 32-bit binaries is becoming hard on the versions of macOS and Ubuntu supported by GitHub Actions (and they don't want to support any other Linux distribution). 32-bit support is still very easy to get out of the box on Windows, though, so you see where I'm heading to...

This PR changes the MSVC 32-bit builds to use `(u)long` for its `(u)int32` typedefs. Github Actions will catch the mismatches, and I think we also have some developers frequently using MSVC. So this should increase the chances of catching this issue *before* it hits the buildbot.

(I'm limiting this to 32-bit MSVC for minimal impact at the moment, especially since MSVC is used by Github Actions but unused for releases, AFAIK. I'm using `!defined(_WIN64)` because it's maybe better to keep both an `int` and a `long` int32 pipeline? This typedef change could also be applied to MinGW builds maybe, but then we'd need to use `-Wno-format` there because it causes noisy warnings, and I'm not sure it's a right thing to completely silence `-Wformat` on this "higher-tier" port.)

As a bonus, here are some other int/int32 discrepancies caught by MSVC with this setting,  but never caught by AmigaOS/NDS GCC until now.