### PR TITLE
HPL1: Fix compile failure in VS2022.

### DIFF
--- a/engines/hpl1/engine/libraries/newton/core/dgVector.h
+++ b/engines/hpl1/engine/libraries/newton/core/dgVector.h
@@ -297,7 +297,6 @@ DG_INLINE dgVector::dgVector(const simd_type &val) {
 
 constexpr DG_INLINE dgVector::dgVector(dgFloat32 x, dgFloat32 y, dgFloat32 z, dgFloat32 w)
 	: dgTemplateVector<dgFloat32>(x, y, z, w) {
-	_ASSERTE(dgCheckVector((*this)));
 }
 
 DG_INLINE dgFloat32 dgVector::DotProductSimd(const dgVector &A) const {


### PR DESCRIPTION
Removes an assert from a constexpr constructor.  The assert attempts to call a bunch of non-constexpr functions, which is not allowed.