### PR TITLE
GUI: Move keymap descriptions to the left if there isn't enough room

### DIFF
--- a/backends/keymapper/remap-widget.cpp
+++ b/backends/keymapper/remap-widget.cpp
@@ -104,7 +104,7 @@ void RemapWidget::reflowActionWidgets() {
 	int spacing = g_gui.xmlEval()->getVar("Globals.KeyMapper.Spacing");
 	int keyButtonWidth = g_gui.xmlEval()->getVar("Globals.KeyMapper.ButtonWidth");
 	int resetButtonWidth = g_gui.xmlEval()->getVar("Globals.KeyMapper.ResetWidth");
-	int labelWidth = getWidth() - (spacing + keyButtonWidth + spacing);
+	int labelWidth = widgetsBoss()->getWidth() - (spacing + keyButtonWidth + spacing);
 	labelWidth = MAX(0, labelWidth);
 
 	uint textYOff = (buttonHeight - kLineHeight) / 2;
@@ -121,7 +121,7 @@ void RemapWidget::reflowActionWidgets() {
 
 			// Insert a keymap separator
 			uint descriptionX = 2 * spacing + keyButtonWidth;
-			uint resetX = getWidth() - spacing - resetButtonWidth;
+			uint resetX = widgetsBoss()->getWidth() - spacing - resetButtonWidth;
 
 			KeymapTitleRow keymapTitle = _keymapSeparators[row.keymap];
 			if (keymapTitle.descriptionText) {

--- a/backends/keymapper/remap-widget.cpp
+++ b/backends/keymapper/remap-widget.cpp
@@ -114,29 +114,35 @@ void RemapWidget::reflowActionWidgets() {
 	Keymap *previousKeymap = nullptr;
 
 	for (uint i = 0; i < _actions.size(); i++) {
-		uint x;
-
 		ActionRow &row = _actions[i];
 
 		if (previousKeymap != row.keymap) {
 			previousKeymap = row.keymap;
 
 			// Insert a keymap separator
-			x = 2 * spacing + keyButtonWidth;
+			uint descriptionX = 2 * spacing + keyButtonWidth;
+			uint resetX = getWidth() - spacing - resetButtonWidth;
 
 			KeymapTitleRow keymapTitle = _keymapSeparators[row.keymap];
 			if (keymapTitle.descriptionText) {
-				int descriptionWidth = getWidth() - x - spacing - resetButtonWidth - spacing;
-				descriptionWidth = MAX(0, descriptionWidth);
+				int descriptionWidth = resetX - descriptionX - spacing;
+				int descriptionFullWidth = g_gui.getStringWidth(keymapTitle.descriptionText->getLabel());
 
-				keymapTitle.descriptionText->resize(x, y + textYOff, descriptionWidth, kLineHeight, false);
-				keymapTitle.resetButton->resize(x + descriptionWidth, y, resetButtonWidth, buttonHeight, false);
+				if (descriptionWidth < descriptionFullWidth) {
+					descriptionX -= (descriptionFullWidth - descriptionWidth);
+					descriptionWidth = descriptionFullWidth;
+				} else if (descriptionWidth < 0) {
+					descriptionWidth = 0;
+				}
+
+				keymapTitle.descriptionText->resize(descriptionX, y + textYOff, descriptionWidth, kLineHeight, false);
+				keymapTitle.resetButton->resize(resetX, y, resetButtonWidth, buttonHeight, false);
 			}
 
 			y += buttonHeight + spacing;
 		}
 
-		x = spacing;
+		uint x = spacing;
 
 		row.keyButton->resize(x, y, keyButtonWidth, buttonHeight, false);
 


### PR DESCRIPTION
Before:
![scummvm-sky-00000](https://user-images.githubusercontent.com/19293424/209376640-a1d8c8d6-3b26-4df9-8746-4f09562050b2.png)

After:
![scummvm-sky-00002](https://user-images.githubusercontent.com/19293424/209397101-32577c8b-0c20-43fe-b93c-56ddef917ac0.png)
