### PR TITLE
JANITORIAL/DEVTOOLS: Upgrade some warnings to errors in MSVC and fix them.

### DIFF
--- a/common/math.h
+++ b/common/math.h
@@ -52,11 +52,11 @@
 #endif
 
 #ifndef FLT_MIN
-	#define FLT_MIN 1E-37
+	#define FLT_MIN 1E-37f
 #endif
 
 #ifndef FLT_MAX
-	#define FLT_MAX 1E+37
+	#define FLT_MAX 1E+37f
 #endif
 
 namespace Common {

--- a/common/ptr.h
+++ b/common/ptr.h
@@ -734,6 +734,82 @@ private:
 	bool                  _isvalid;
 };
 
+
+/**
+ * UnalignedPtr: Allows pointers to and access of memory addresses where the underlying data
+ * doesn't have proper alignment.
+ */
+
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM) || defined(_M_ARM64))
+
+template<class T>
+class UnalignedPtr {
+public:
+	UnalignedPtr();
+	UnalignedPtr(__unaligned T *ptr);
+
+	T load() const;
+	void store(const T &value) const;
+
+private:
+	__unaligned T *_ptr;
+};
+
+template<class T>
+UnalignedPtr<T>::UnalignedPtr() : _ptr(nullptr) {
+}
+
+template<class T>
+UnalignedPtr<T>::UnalignedPtr(__unaligned T *ptr) : _ptr(ptr) {
+}
+
+template<class T>
+T UnalignedPtr<T>::load() const {
+	return *_ptr;
+}
+
+template<class T>
+void UnalignedPtr<T>::store(const T &value) const {
+	*_ptr = value;
+}
+
+#else
+
+template<class T>
+class UnalignedPtr {
+public:
+	UnalignedPtr();
+	UnalignedPtr(T *ptr);
+
+	T load() const;
+	void store(const T &value) const;
+
+private:
+	T *_ptr;
+};
+
+template<class T>
+UnalignedPtr<T>::UnalignedPtr() : _ptr(nullptr) {
+}
+
+template<class T>
+UnalignedPtr<T>::UnalignedPtr(T *ptr) : _ptr(ptr) {
+}
+
+template<class T>
+T UnalignedPtr<T>::load() const {
+	T result;
+	memcpy(&result, _ptr, sizeof(T));
+	return result;
+}
+
+template<class T>
+void UnalignedPtr<T>::store(const T &value) const {
+	memcpy(_ptr, &value, sizeof(T));
+}
+
+#endif
+
 /** @} */
 
 } // End of namespace Common

--- a/devtools/create_project/cmake.cpp
+++ b/devtools/create_project/cmake.cpp
@@ -29,8 +29,8 @@
 
 namespace CreateProjectTool {
 
-CMakeProvider::CMakeProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version)
-	: ProjectProvider(global_warnings, project_warnings, version) {
+CMakeProvider::CMakeProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, StringList &global_errors, const int version)
+	: ProjectProvider(global_warnings, project_warnings, global_errors, version) {
 }
 
 const CMakeProvider::Library *CMakeProvider::getLibraryFromFeature(const char *feature, bool useSDL2) const {

--- a/devtools/create_project/cmake.h
+++ b/devtools/create_project/cmake.h
@@ -34,7 +34,7 @@ namespace CreateProjectTool {
  */
 class CMakeProvider final : public ProjectProvider {
 public:
-	CMakeProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version = 0);
+	CMakeProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, StringList &global_errors, const int version = 0);
 
 protected:
 

--- a/devtools/create_project/codeblocks.cpp
+++ b/devtools/create_project/codeblocks.cpp
@@ -27,8 +27,8 @@
 
 namespace CreateProjectTool {
 
-CodeBlocksProvider::CodeBlocksProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version)
-	: ProjectProvider(global_warnings, project_warnings, version) {
+CodeBlocksProvider::CodeBlocksProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, StringList &global_errors, const int version)
+	: ProjectProvider(global_warnings, project_warnings, global_errors, version) {
 }
 
 void CodeBlocksProvider::createWorkspace(const BuildSetup &setup) {

--- a/devtools/create_project/codeblocks.h
+++ b/devtools/create_project/codeblocks.h
@@ -28,7 +28,7 @@ namespace CreateProjectTool {
 
 class CodeBlocksProvider final : public ProjectProvider {
 public:
-	CodeBlocksProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version = 0);
+	CodeBlocksProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, StringList &global_errors, const int version = 0);
 
 protected:
 

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -489,7 +489,7 @@ public:
 	 * @param project_warnings List of project-specific warnings
 	 * @param version Target project version.
 	 */
-	ProjectProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version = 0);
+	ProjectProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, StringList &global_errors, const int version = 0);
 	virtual ~ProjectProvider() {}
 
 	/**
@@ -509,7 +509,8 @@ public:
 
 protected:
 	const int _version;                                  ///< Target project version
-	StringList &_globalWarnings;                         ///< Global warnings
+	StringList &_globalWarnings;                         ///< Global (ignored) warnings
+	StringList &_globalErrors;                           ///< Global errors (promoted from warnings)
 	std::map<std::string, StringList> &_projectWarnings; ///< Per-project warnings
 
 	UUIDMap _engineUuidMap; ///< List of (project name, UUID) pairs

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -31,8 +31,8 @@ namespace CreateProjectTool {
 // MSBuild Provider (Visual Studio 2010 and later)
 //////////////////////////////////////////////////////////////////////////
 
-MSBuildProvider::MSBuildProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version, const MSVCVersion &msvc)
-	: MSVCProvider(global_warnings, project_warnings, version, msvc) {
+MSBuildProvider::MSBuildProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, StringList &global_errors, const int version, const MSVCVersion &msvc)
+	: MSVCProvider(global_warnings, project_warnings, global_errors, version, msvc) {
 
 	_archs.push_back(ARCH_X86);
 	_archs.push_back(ARCH_AMD64);
@@ -349,6 +349,10 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 	for (StringList::const_iterator i = _globalWarnings.begin(); i != _globalWarnings.end(); ++i)
 		warnings += *i + ';';
 
+	std::string warningsAsErrors;
+	for (StringList::const_iterator i = _globalErrors.begin(); i != _globalErrors.end(); ++i)
+		warningsAsErrors += "/we\"" + (*i) + "\" ";
+
 	std::string definesList;
 	for (StringList::const_iterator i = defines.begin(); i != defines.end(); ++i)
 		definesList += *i + ';';
@@ -395,7 +399,7 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 	           << "\t\t\t<MultiProcessorCompilation>true</MultiProcessorCompilation>\n"
 	           << "\t\t\t<ConformanceMode>true</ConformanceMode>\n"
 	           << "\t\t\t<ObjectFileName>$(IntDir)dists\\msvc\\%(RelativeDir)</ObjectFileName>\n"
-	           << "\t\t\t<AdditionalOptions>/utf-8 " << (_msvcVersion.version >= 15 ? "/Zc:__cplusplus " : "") << "%(AdditionalOptions)</AdditionalOptions>\n"
+			   << "\t\t\t<AdditionalOptions>/utf-8 " << (_msvcVersion.version >= 15 ? "/Zc:__cplusplus " : "") << warningsAsErrors << "%(AdditionalOptions)</AdditionalOptions>\n"
 	           << "\t\t</ClCompile>\n"
 	           << "\t\t<Link>\n"
 	           << "\t\t\t<IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>\n";

--- a/devtools/create_project/msbuild.h
+++ b/devtools/create_project/msbuild.h
@@ -28,7 +28,7 @@ namespace CreateProjectTool {
 
 class MSBuildProvider final : public MSVCProvider {
 public:
-	MSBuildProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version, const MSVCVersion &msvc);
+	MSBuildProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, StringList &global_errors, const int version, const MSVCVersion &msvc);
 
 protected:
 	void createProjectFile(const std::string &name, const std::string &uuid, const BuildSetup &setup, const std::string &moduleDir,

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -31,8 +31,8 @@ namespace CreateProjectTool {
 //////////////////////////////////////////////////////////////////////////
 // MSVC Provider (Base class)
 //////////////////////////////////////////////////////////////////////////
-MSVCProvider::MSVCProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version, const MSVCVersion &msvc)
-	: ProjectProvider(global_warnings, project_warnings, version), _msvcVersion(msvc) {
+MSVCProvider::MSVCProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, StringList &global_errors, const int version, const MSVCVersion &msvc)
+	: ProjectProvider(global_warnings, project_warnings, global_errors, version), _msvcVersion(msvc) {
 
 	_enableLanguageExtensions = tokenize(ENABLE_LANGUAGE_EXTENSIONS, ',');
 	_disableEditAndContinue = tokenize(DISABLE_EDIT_AND_CONTINUE, ',');

--- a/devtools/create_project/msvc.h
+++ b/devtools/create_project/msvc.h
@@ -28,7 +28,7 @@ namespace CreateProjectTool {
 
 class MSVCProvider : public ProjectProvider {
 public:
-	MSVCProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version, const MSVCVersion &msvcVersion);
+	MSVCProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, StringList &global_errors, const int version, const MSVCVersion &msvcVersion);
 
 protected:
 	const MSVCVersion _msvcVersion;

--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -271,8 +271,8 @@ void XcodeProvider::addBuildFile(const std::string &id, const std::string &name,
 	_buildFile._flags = kSettingsSingleItem;
 }
 
-XcodeProvider::XcodeProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version)
-	: ProjectProvider(global_warnings, project_warnings, version) {
+XcodeProvider::XcodeProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, StringList &global_errors, const int version)
+	: ProjectProvider(global_warnings, project_warnings, global_errors, version) {
 	_rootSourceGroup = nullptr;
 }
 

--- a/devtools/create_project/xcode.h
+++ b/devtools/create_project/xcode.h
@@ -31,7 +31,7 @@ namespace CreateProjectTool {
 
 class XcodeProvider final : public ProjectProvider {
 public:
-	XcodeProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, const int version = 0);
+	XcodeProvider(StringList &global_warnings, std::map<std::string, StringList> &project_warnings, StringList &global_errors, const int version = 0);
 
 protected:
 

--- a/engines/buried/environ/agent3_lair.cpp
+++ b/engines/buried/environ/agent3_lair.cpp
@@ -80,7 +80,7 @@ int LairEntry::postEnterRoom(Window *viewWindow, const Location &priorLocation) 
 
 	if (((SceneViewWindow *)viewWindow)->getGlobalFlags().alRestoreSkipAgent3Initial == 1) {
 		// Start new secondary ambient
-		_vm->_sound->setSecondaryAmbientSound(_vm->getFilePath(_staticData.location.timeZone, _staticData.location.environment, 14), 64);
+		_vm->_sound->setSecondaryAmbientSound(_vm->getFilePath(_staticData.location.timeZone, _staticData.location.environment, 14), true, 64);
 
 		_staticData.cycleStartFrame = 0;
 		_staticData.cycleFrameCount = 54;
@@ -180,7 +180,7 @@ int LairEntry::postEnterRoom(Window *viewWindow, const Location &priorLocation) 
 	_currentSoundID = _vm->_sound->playSoundEffect(_vm->getFilePath(IDS_AGENT3_VIRUS_SOUND_BASE + 6), 128, false, true);
 
 	// Start new secondary ambient
-	_vm->_sound->setSecondaryAmbientSound(_vm->getFilePath(_staticData.location.timeZone, _staticData.location.environment, 14), 64);
+	_vm->_sound->setSecondaryAmbientSound(_vm->getFilePath(_staticData.location.timeZone, _staticData.location.environment, 14), true, 64);
 
 	_passwordIndex = 0;
 	_stepDelay = 0;

--- a/engines/director/resource.cpp
+++ b/engines/director/resource.cpp
@@ -285,7 +285,7 @@ void Window::loadEXE(const Common::String movie) {
 }
 
 void Window::loadEXEv3(Common::SeekableReadStream *stream) {
-	uint32 mmmSize;
+	uint32 mmmSize = 0;
 	Common::String mmmFileName;
 	Common::String directoryName;
 

--- a/engines/freescape/language/instruction.cpp
+++ b/engines/freescape/language/instruction.cpp
@@ -215,9 +215,11 @@ void FreescapeEngine::executeSPFX(FCLInstruction &instruction) {
 		if (src == 0 && dst >= 2 && dst <= 5) {
 			_currentArea->remapColor(dst, 1);
 			return;
-		} if (src == 0) {
+		}
+
+		if (src == 0) {
 			color = dst;
-		} else if (src > 0) {
+		} else {
 
 			switch (src) {
 			case 1:
@@ -268,7 +270,7 @@ bool FreescapeEngine::executeEndIfVisibilityIsEqual(FCLInstruction &instruction)
 		}
 	}
 
-	return (obj->isInvisible() == value);
+	return (obj->isInvisible() == (value != 0));
 }
 
 bool FreescapeEngine::executeEndIfNotEqual(FCLInstruction &instruction) {

--- a/engines/glk/archetype/archetype.cpp
+++ b/engines/glk/archetype/archetype.cpp
@@ -131,10 +131,10 @@ void Archetype::interpret() {
 	cleanup(result);
 }
 
-void Archetype::write(const String fmt, ...) {
+void Archetype::write_internal(const String *fmt, ...) {
 	va_list ap;
 	va_start(ap, fmt);
-	Common::String s = Common::String::vformat(fmt.c_str(), ap);
+	Common::String s = Common::String::vformat(fmt->c_str(), ap);
 	va_end(ap);
 
 	_lastOutputText = s;
@@ -143,10 +143,10 @@ void Archetype::write(const String fmt, ...) {
 		glk_put_buffer(s.c_str(), s.size());
 }
 
-void Archetype::writeln(const String fmt, ...) {
+void Archetype::writeln_internal(const String *fmt, ...) {
 	va_list ap;
 	va_start(ap, fmt);
-	Common::String s = Common::String::vformat(fmt.c_str(), ap);
+	Common::String s = Common::String::vformat(fmt->c_str(), ap);
 	va_end(ap);
 
 	s += '\n';

--- a/engines/glk/archetype/archetype.h
+++ b/engines/glk/archetype/archetype.h
@@ -177,12 +177,14 @@ public:
 	/**
 	 * Write some text to the screen
 	 */
-	void write(const String fmt, ...);
+	template<class... TParam>
+	void write(const String &fmt, TParam... args);
 
 	/**
 	 * Write a line to the screen
 	 */
-	void writeln(const String fmt, ...);
+	template<class... TParam>
+	void writeln(const String &fmt, TParam... args);
 	void writeln() { writeln(""); }
 
 	/**
@@ -194,7 +196,21 @@ public:
 	 * Read in a single key
 	 */
 	char readKey();
+
+private:
+	void write_internal(const String *fmt, ...);
+	void writeln_internal(const String *fmt, ...);
 };
+
+template<class... TParam>
+inline void Archetype::write(const String &format, TParam... param) {
+	return write_internal(&format, Common::forward<TParam>(param)...);
+}
+
+template<class... TParam>
+inline void Archetype::writeln(const String &format, TParam... param) {
+	return writeln_internal(&format, Common::forward<TParam>(param)...);
+}
 
 extern Archetype *g_vm;
 

--- a/engines/glk/comprehend/comprehend.cpp
+++ b/engines/glk/comprehend/comprehend.cpp
@@ -132,12 +132,12 @@ void Comprehend::print(const char *fmt, ...) {
 	glk_put_string_stream(glk_window_get_stream(_bottomWindow), msg.c_str());
 }
 
-void Comprehend::print(const Common::U32String fmt, ...) {
+void Comprehend::print_u32_internal(const Common::U32String *fmt, ...) {
 	Common::U32String outputMsg;
 
 	va_list argp;
 	va_start(argp, fmt);
-	Common::U32String::vformat(fmt.begin(), fmt.end(), outputMsg, argp);
+	Common::U32String::vformat(fmt->begin(), fmt->end(), outputMsg, argp);
 	va_end(argp);
 
 	glk_put_string_stream_uni(glk_window_get_stream(_bottomWindow), outputMsg.u32_str());

--- a/engines/glk/comprehend/comprehend.h
+++ b/engines/glk/comprehend/comprehend.h
@@ -133,7 +133,8 @@ public:
 	/**
 	 * Print unicode-string to the buffer window
 	 */
-	void print(const Common::U32String fmt, ...);
+	template<class... TParam>
+	void print(const Common::U32String &fmt, TParam... param);
 
 	/**
 	 * Prints the room description in the room description window
@@ -216,7 +217,15 @@ public:
 	 * Returns true if an input line is currently active
 	 */
 	bool isInputLineActive() const;
+
+private:
+	void print_u32_internal(const Common::U32String *fmt, ...);
 };
+
+template<class... TParam>
+void Comprehend::print(const Common::U32String &fmt, TParam... param) {
+	print_u32_internal(&fmt, Common::forward<TParam>(param)...);
+}
 
 extern Comprehend *g_comprehend;
 

--- a/engines/glk/scott/scott.cpp
+++ b/engines/glk/scott/scott.cpp
@@ -240,13 +240,13 @@ void Scott::display(winid_t w, const char *fmt, ...) {
 		glk_put_string_stream(_G(_transcript), msg.c_str());
 }
 
-void Scott::display(winid_t w, const Common::U32String fmt, ...) {
+void Scott::display_u32_internal(winid_t w, const Common::U32String *fmt, ...) {
 	Common::U32String msg;
 
 	va_list ap;
 
 	va_start(ap, fmt);
-	Common::U32String::vformat(fmt.begin(), fmt.end(), msg, ap);
+	Common::U32String::vformat(fmt->begin(), fmt->end(), msg, ap);
 	va_end(ap);
 
 	glk_put_string_stream_uni(glk_window_get_stream(w), msg.u32_str());

--- a/engines/glk/scott/scott.h
+++ b/engines/glk/scott/scott.h
@@ -198,7 +198,7 @@ public:
 	void output(const Common::U32String &a);
 	void outputNumber(int a);
 	void display(winid_t w, const char *fmt, ...);
-	void display(winid_t w, const Common::U32String fmt, ...);
+	template<class... TParam> void display(winid_t w, const Common::U32String &fmt, TParam... param);
 	void fatal(const char *x);
 	void hitEnter();
 	void updates(event_t ev);
@@ -251,7 +251,15 @@ public:
 	 * in the Quetzal save file that will be created
 	 */
 	Common::Error writeGameData(Common::WriteStream *ws) override;
+
+private:
+	void display_u32_internal(winid_t w, const Common::U32String *fmt, ...);
 };
+
+template<class... TParam>
+inline void Scott::display(winid_t w, const Common::U32String &fmt, TParam... param) {
+	display_u32_internal(w, &fmt, Common::forward<TParam>(param)...);
+}
 
 extern Scott *g_scott;
 

--- a/engines/grim/lua/lstx.cpp
+++ b/engines/grim/lua/lstx.cpp
@@ -980,6 +980,9 @@ int yyparse() {
 	/* Push a new state, which is found in  yystate  .  */
 	/* In all cases, when you get here, the value and location stacks
 	have just been pushed. so pushing a state here evens the stacks.  */
+
+	memset(&yylval, 0, sizeof(yylval));
+
 yynewstate:
 
 	*++yyssp = yystate;

--- a/engines/hpl1/engine/graphics/Material_BaseLight.cpp
+++ b/engines/hpl1/engine/graphics/Material_BaseLight.cpp
@@ -162,8 +162,10 @@ iGpuProgram *iMaterial_BaseLight::getGpuProgram(const eMaterialRenderType aType,
 				program = eBaseLightProgram_Point1;
 			else if (apLight->GetLightType() == eLight3DType_Spot)
 				program = eBaseLightProgram_Spot1;
-			else
+			else {
 				assert(false);
+				program = static_cast<eBaseLightProgram>(0);
+			}
 		}
 		return _shaders[program];
 	} else if (aType == eMaterialRenderType_Diffuse) {

--- a/engines/hpl1/engine/graphics/Material_Fallback01_BaseLight.cpp
+++ b/engines/hpl1/engine/graphics/Material_Fallback01_BaseLight.cpp
@@ -111,7 +111,7 @@ iMaterial_Fallback01_BaseLight::~iMaterial_Fallback01_BaseLight() {
 //-----------------------------------------------------------------------
 
 iGpuProgram *iMaterial_Fallback01_BaseLight::getGpuProgram(const eMaterialRenderType aType, const int alPass, iLight3D *apLight) {
-	eBaseLightProgram program;
+	eBaseLightProgram program = eBaseLightProgram_Point1;
 	if (apLight) {
 		if (apLight->GetLightType() == eLight3DType_Point)
 			program = eBaseLightProgram_Point1;

--- a/engines/hpl1/engine/graphics/Material_Fallback02_BaseLight.cpp
+++ b/engines/hpl1/engine/graphics/Material_Fallback02_BaseLight.cpp
@@ -103,7 +103,7 @@ iMaterial_Fallback02_BaseLight::~iMaterial_Fallback02_BaseLight() {
 //-----------------------------------------------------------------------
 
 iGpuProgram *iMaterial_Fallback02_BaseLight::getGpuProgram(const eMaterialRenderType aType, const int alPass, iLight3D *apLight) {
-	eBaseLightProgram program;
+	eBaseLightProgram program = eBaseLightProgram_Point1;
 	if (apLight) {
 		if (apLight->GetLightType() == eLight3DType_Point)
 			program = eBaseLightProgram_Point1;

--- a/engines/hpl1/engine/libraries/newton/core/dgDelaunayTetrahedralization.cpp
+++ b/engines/hpl1/engine/libraries/newton/core/dgDelaunayTetrahedralization.cpp
@@ -144,8 +144,8 @@ void dgDelaunayTetrahedralization::SortVertexArray() {
 			dgInt32 index = face.m_otherVertex;
 			face.m_otherVertex = points[index].m_index;
 			for (dgInt32 j = 0; j < 3; j++) {
-				dgInt32 index = face.m_index[j];
-				face.m_index[j] = points[index].m_index;
+				dgInt32 ptindex = face.m_index[j];
+				face.m_index[j] = points[ptindex].m_index;
 			}
 		}
 	}

--- a/engines/hpl1/engine/libraries/newton/core/dgQuaternion.cpp
+++ b/engines/hpl1/engine/libraries/newton/core/dgQuaternion.cpp
@@ -71,8 +71,8 @@ dgQuaternion::dgQuaternion(const dgMatrix &matrix) {
 #ifdef _DEBUG
 	dgMatrix tmp(*this, matrix.m_posit);
 	dgMatrix unitMatrix(tmp * matrix.Inverse());
-	for (dgInt32 i = 0; i < 4; i++) {
-		dgFloat32 err = dgAbsf(unitMatrix[i][i] - dgFloat32(1.0f));
+	for (dgInt32 di = 0; di < 4; di++) {
+		dgFloat32 err = dgAbsf(unitMatrix[di][di] - dgFloat32(1.0f));
 		NEWTON_ASSERT(err < dgFloat32(1.0e-2f));
 	}
 

--- a/engines/hpl1/engine/libraries/newton/physics/dgCollisionConvex.cpp
+++ b/engines/hpl1/engine/libraries/newton/physics/dgCollisionConvex.cpp
@@ -1515,8 +1515,8 @@ dgInt32 dgCollisionConvex::CalculatePlaneIntersection(const dgVector &normal,
 			for (dgInt32 i = 0; i < m_edgeCount; i++) {
 				ptr = &m_simplex[i];
 				side0 = plane.Evalue(m_vertex[ptr->m_vertex]);
-				dgFloat32 side1 = plane.Evalue(m_vertex[ptr->m_twin->m_vertex]);
-				if ((side1 < dgFloat32(0.0f)) && (side0 > dgFloat32(0.0f))) {
+				dgFloat32 dside1 = plane.Evalue(m_vertex[ptr->m_twin->m_vertex]);
+				if ((dside1 < dgFloat32(0.0f)) && (side0 > dgFloat32(0.0f))) {
 					NEWTON_ASSERT(0);
 					firstEdge = ptr;
 					break;

--- a/engines/hpl1/engine/libraries/newton/physics/dgCollisionConvexHull.cpp
+++ b/engines/hpl1/engine/libraries/newton/physics/dgCollisionConvexHull.cpp
@@ -210,12 +210,12 @@ dgBigVector dgCollisionConvexHull::FaceNormal(const dgEdge *face,
 	dgBigVector e0(
 	    pool[edge->m_incidentVertex] - pool[edge->m_prev->m_incidentVertex]);
 	do {
-		dgBigVector e1(
+		dgBigVector de1(
 		    pool[edge->m_next->m_incidentVertex] - pool[edge->m_incidentVertex]);
-		dgBigVector n1(e0 * e1);
+		dgBigVector n1(e0 * de1);
 		dgFloat64 x = normal % n1;
 		NEWTON_ASSERT(x > -dgFloat64(0.01f));
-		e0 = e1;
+		e0 = de1;
 		edge = edge->m_next;
 	} while (edge != face);
 #endif

--- a/engines/hpl1/engine/libraries/newton/physics/dgMeshEffect.cpp
+++ b/engines/hpl1/engine/libraries/newton/physics/dgMeshEffect.cpp
@@ -3962,21 +3962,21 @@ void dgMeshEffect::ClipMesh(const dgMeshEffectSolidTree *const clipper,
 					for (dgList<dgMeshTreeCSGFace *>::dgListNode *node1 =
 					            faceList.GetFirst();
 					        node1; node1 = node1->GetNext()) {
-						dgMeshTreeCSGFace *const face = node1->GetInfo();
+						dgMeshTreeCSGFace *const dface = node1->GetInfo();
 						NEWTON_ASSERT(
-						    clipper->GetFaceSide(face) == dgMeshEffectSolidTree::m_empty);
+						    clipper->GetFaceSide(dface) == dgMeshEffectSolidTree::m_empty);
 					}
 #endif
 					frontMesh->AddPolygon(count, &facePoints[0].m_vertex.m_x,
 					                      sizeof(dgVertexAtribute), dgFastInt(facePoints[0].m_material));
 				} else {
 #ifdef _DEBUG
-					for (dgList<dgMeshTreeCSGFace *>::dgListNode *node1 =
+					for (dgList<dgMeshTreeCSGFace *>::dgListNode *dnode1 =
 					            faceList.GetFirst();
-					        node1; node1 = node1->GetNext()) {
-						dgMeshTreeCSGFace *const face = node1->GetInfo();
+					        dnode1; dnode1 = dnode1->GetNext()) {
+						dgMeshTreeCSGFace *const dface = dnode1->GetInfo();
 						NEWTON_ASSERT(
-						    clipper->GetFaceSide(face) == dgMeshEffectSolidTree::m_solid);
+						    clipper->GetFaceSide(dface) == dgMeshEffectSolidTree::m_solid);
 					}
 #endif
 					backMesh->AddPolygon(count, &facePoints[0].m_vertex.m_x,

--- a/engines/hpl1/engine/scene/Light3D.cpp
+++ b/engines/hpl1/engine/scene/Light3D.cpp
@@ -668,7 +668,7 @@ void iLight3D::RenderShadow(iRenderable *apObject, cRenderSettings *apRenderSett
 		const cTriEdge &Edge = pEdges[edge];
 
 		const cTriangleData *pTri1 = &pTriangles[Edge.tri1];
-		const cTriangleData *pTri2;
+		const cTriangleData *pTri2 = nullptr;
 		if (Edge.invert_tri2 == false)
 			pTri2 = &pTriangles[Edge.tri2];
 

--- a/engines/hpl1/engine/scene/World2D.cpp
+++ b/engines/hpl1/engine/scene/World2D.cpp
@@ -757,7 +757,7 @@ int cWorld2D::LoadTileData(cTile *apTile, tString *asData, int alStart) {
 	int lCount = alStart;
 	int lStart = lCount;
 	int lValType = 0;
-	int lSet;
+	int lSet = 0;
 	int lNum;
 
 	while (true) {

--- a/engines/hpl1/opengl.h
+++ b/engines/hpl1/opengl.h
@@ -44,7 +44,7 @@ Common::ScopedPtr<Graphics::Surface> createGLViewportScreenshot();
 }
 
 #define GL_CHECK(x) {x; ::Hpl1::checkOGLErrors(__func__, __LINE__);}
-#define GL_CHECK_FN() GL_CHECK()
+#define GL_CHECK_FN() {::Hpl1::checkOGLErrors(__func__, __LINE__);}
 
 #endif // USE_OPENGL
 #endif // HPL1_OPENGL_H

--- a/engines/hpl1/penumbra-overture/GameMusicHandler.cpp
+++ b/engines/hpl1/penumbra-overture/GameMusicHandler.cpp
@@ -125,7 +125,7 @@ void cGameMusicHandler::Update(float afTimeStep) {
 		}
 		// Music playing
 		else {
-			bool bFound;
+			bool bFound = false;
 			tGameEnemyIterator enemyIt = mpInit->mpMapHandler->GetGameEnemyIterator();
 			while (enemyIt.HasNext()) {
 				iGameEnemy *pEnemy = enemyIt.Next();

--- a/engines/hypno/spider/talk.cpp
+++ b/engines/hypno/spider/talk.cpp
@@ -81,7 +81,7 @@ void SpiderEngine::showConversation() {
 	for (Actions::const_iterator itt = _conversation.begin(); itt != _conversation.end(); ++itt) {
 		Talk *a = (Talk *)*itt;
 		if (a->active && !skipRepeated) {
-			uint32 frame;
+			uint32 frame = 0;
 			Common::String path;
 			for (TalkCommands::const_iterator it = a->commands.begin(); it != a->commands.end(); ++it) {
 				if (it->command == "F") {

--- a/engines/icb/protocol.h
+++ b/engines/icb/protocol.h
@@ -71,6 +71,8 @@ typedef struct {
 	uint16 blend;
 } _animHeader;
 
+#pragma pack(pop)
+
 _frameHeader *FetchFrameHeader(uint8 *animFile, uint16 frameNo); // (25sep96JEL)
 
 } // End of namespace ICB

--- a/engines/icb/stagedraw_pc_poly.cpp
+++ b/engines/icb/stagedraw_pc_poly.cpp
@@ -523,7 +523,7 @@ void drawObjects(SDactor &act, PSXLampList &lamplist, PSXrgb *pAmbient, PSXShade
 int32 drawSpecialObjects(SDactor &actor, MATRIXPC *local2screen, int32 brightness, SVECTOR *minBBox, SVECTOR *maxBBox) {
 	// Shooting ?
 	int32 mflash = 0;
-	SVECTOR mpos;
+	SVECTOR mpos = {0, 0, 0, 0};
 
 	_mega *&mega = actor.log->mega;
 	_vox_image *&vox = actor.log->voxel_info;

--- a/engines/mads/mps_installer.cpp
+++ b/engines/mads/mps_installer.cpp
@@ -131,18 +131,22 @@ Common::SharedArchiveContents MpsInstaller::readContentsForPath(const Common::St
 		uncompressedSize = desc._compressedSize;
 		compressedBuf = nullptr;
 		break;
-	case 1:
-		Common::MemoryReadStream compressedReadStream(compressedBuf, desc._compressedSize);
-		uncompressedBuf = new byte[uncompressedSize];
-		if (!Common::decompressDCL(&compressedReadStream, uncompressedBuf, desc._compressedSize, uncompressedSize)) {
+	case 1: {
+			Common::MemoryReadStream compressedReadStream(compressedBuf, desc._compressedSize);
+			uncompressedBuf = new byte[uncompressedSize];
+			if (!Common::decompressDCL(&compressedReadStream, uncompressedBuf, desc._compressedSize, uncompressedSize)) {
+				delete[] compressedBuf;
+				delete[] uncompressedBuf;
+				error("Unable to decompress %s", desc._fileName.c_str());
+				return Common::SharedArchiveContents();
+			}
 			delete[] compressedBuf;
-			delete[] uncompressedBuf;
-			error("Unable to decompress %s", desc._fileName.c_str());
-			return Common::SharedArchiveContents();
-		}
-		delete[] compressedBuf;
-		compressedBuf = nullptr;
+			compressedBuf = nullptr;
 
+		} break;
+	default:
+		error("Unsupported compression algorithm");
+		uncompressedBuf = nullptr;
 		break;
 	}
 

--- a/engines/myst3/puzzles.cpp
+++ b/engines/myst3/puzzles.cpp
@@ -228,7 +228,7 @@ void Puzzles::leversBall(int16 var) {
 
 	const NewPosition *position = nullptr;
 	for (uint i = 0; i < ARRAYSIZE(move->p); i++)
-		if (move->p[i].newLeft == newLeverLeft && move->p[i].newRight == newLeverRight) {
+		if (move->p[i].newLeft == (newLeverLeft != 0) && move->p[i].newRight == (newLeverRight != 0)) {
 			position = &move->p[i];
 			break;
 		}

--- a/engines/playground3d/gfx_opengl.cpp
+++ b/engines/playground3d/gfx_opengl.cpp
@@ -269,11 +269,11 @@ void OpenGLRenderer::drawInViewport() {
 	glDisableClientState(GL_VERTEX_ARRAY);
 
 	glPushMatrix();
-	_pos.x() += 0.01;
-	_pos.y() += 0.01;
+	_pos.x() += 0.01f;
+	_pos.y() += 0.01f;
 	if (_pos.x() >= 1.0f) {
-		_pos.x() = -1.0;
-		_pos.y() = -1.0;
+		_pos.x() = -1.0f;
+		_pos.y() = -1.0f;
 	}
 	glTranslatef(_pos.x(), _pos.y(), 0);
 
@@ -314,7 +314,7 @@ void OpenGLRenderer::drawRgbaTexture() {
 	glEnableClientState(GL_VERTEX_ARRAY);
 	glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
-	glTranslatef(-0.8, 0.8, 0);
+	glTranslatef(-0.8f, 0.8f, 0);
 
 	glVertexPointer(2, GL_FLOAT, 2 * sizeof(GLfloat), bitmapVertices);
 	glTexCoordPointer(2, GL_FLOAT, 2 * sizeof(GLfloat), textCords);

--- a/engines/playground3d/gfx_opengl_shaders.cpp
+++ b/engines/playground3d/gfx_opengl_shaders.cpp
@@ -216,32 +216,32 @@ void ShaderRenderer::drawRgbaTexture() {
 
 	_bitmapShader->use();
 
-	offset.setX(-0.8);
-	offset.setY(0.8);
+	offset.setX(-0.8f);
+	offset.setY(0.8f);
 	_bitmapShader->setUniform("offsetXY", offset);
 	glBindTexture(GL_TEXTURE_2D, _textureRgbaId[0]);
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
-	offset.setX(-0.3);
-	offset.setY(0.8);
+	offset.setX(-0.3f);
+	offset.setY(0.8f);
 	_bitmapShader->setUniform("offsetXY", offset);
 	glBindTexture(GL_TEXTURE_2D, _textureRgbId[0]);
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
-	offset.setX(0.2);
-	offset.setY(0.8);
+	offset.setX(0.2f);
+	offset.setY(0.8f);
 	_bitmapShader->setUniform("offsetXY", offset);
 	glBindTexture(GL_TEXTURE_2D, _textureRgb565Id[0]);
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
-	offset.setX(0.7);
-	offset.setY(0.8);
+	offset.setX(0.7f);
+	offset.setY(0.8f);
 	_bitmapShader->setUniform("offsetXY", offset);
 	glBindTexture(GL_TEXTURE_2D, _textureRgba5551Id[0]);
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
-	offset.setX(-0.8);
-	offset.setY(0.2);
+	offset.setX(-0.8f);
+	offset.setY(0.2f);
 	_bitmapShader->setUniform("offsetXY", offset);
 	glBindTexture(GL_TEXTURE_2D, _textureRgba4444Id[0]);
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);

--- a/engines/playground3d/gfx_tinygl.cpp
+++ b/engines/playground3d/gfx_tinygl.cpp
@@ -313,8 +313,8 @@ void TinyGLRenderer::drawInViewport() {
 	tglDisableClientState(TGL_VERTEX_ARRAY);
 
 	tglPushMatrix();
-	_pos.x() += 0.01;
-	_pos.y() += 0.01;
+	_pos.x() += 0.01f;
+	_pos.y() += 0.01f;
 	if (_pos.x() >= 1.0f) {
 		_pos.x() = -1.0;
 		_pos.y() = -1.0;
@@ -358,7 +358,7 @@ void TinyGLRenderer::drawRgbaTexture() {
 	tglEnableClientState(TGL_VERTEX_ARRAY);
 	tglEnableClientState(TGL_TEXTURE_COORD_ARRAY);
 
-	tglTranslatef(-0.799f, 0.8, 0);
+	tglTranslatef(-0.799f, 0.8f, 0);
 	//tglTranslatef(-0.8, 0.8, 0); // some gfx issue
 
 	tglVertexPointer(2, TGL_FLOAT, 2 * sizeof(TGLfloat), bitmapVertices);
@@ -373,7 +373,7 @@ void TinyGLRenderer::drawRgbaTexture() {
 	tglBindTexture(TGL_TEXTURE_2D, _textureRgbId[0]);
 	tglDrawArrays(TGL_TRIANGLE_STRIP, 0, 4);
 
-	tglTranslatef(0.501, 0, 0);
+	tglTranslatef(0.501f, 0, 0);
 	//tglTranslatef(0.5, 0, 0); // some gfx issue
 
 	tglVertexPointer(2, TGL_FLOAT, 2 * sizeof(TGLfloat), bitmapVertices);

--- a/engines/playground3d/playground3d.cpp
+++ b/engines/playground3d/playground3d.cpp
@@ -175,9 +175,9 @@ Graphics::Surface *Playground3dEngine::generateRgbaTexture(int width, int height
 void Playground3dEngine::drawAndRotateCube() {
 	Math::Vector3d pos = Math::Vector3d(0.0f, 0.0f, 6.0f);
 	_gfx->drawCube(pos, Math::Vector3d(_rotateAngleX, _rotateAngleY, _rotateAngleZ));
-	_rotateAngleX += 0.25;
-	_rotateAngleY += 0.50;
-	_rotateAngleZ += 0.10;
+	_rotateAngleX += 0.25f;
+	_rotateAngleY += 0.50f;
+	_rotateAngleZ += 0.10f;
 	if (_rotateAngleX >= 360)
 		_rotateAngleX = 0;
 	if (_rotateAngleY >= 360)
@@ -189,7 +189,7 @@ void Playground3dEngine::drawAndRotateCube() {
 void Playground3dEngine::drawPolyOffsetTest() {
 	Math::Vector3d pos = Math::Vector3d(0.0f, 0.0f, 6.0f);
 	_gfx->drawPolyOffsetTest(pos, Math::Vector3d(0, _rotateAngleY, 0));
-	_rotateAngleY += 0.10;
+	_rotateAngleY += 0.10f;
 	if (_rotateAngleY >= 360)
 		_rotateAngleY = 0;
 }

--- a/engines/saga/animation.cpp
+++ b/engines/saga/animation.cpp
@@ -699,8 +699,8 @@ void Anim::decodeFrame(AnimationData *anim, size_t frameOffset, byte *buf, size_
 
 	if (_vm->isAGA() || _vm->isECS()) {
 		int curY = 0, curX = 0;
-		unsigned realY;
-		unsigned outbit;
+		unsigned realY = 0;
+		unsigned outbit = 0;
 		// TODO: Check if we want to use tempaltes instead to optimize AGA case
 		unsigned int pixelSize = _vm->isAGA() ? 8 : 5;
 		while (1) {

--- a/engines/saga2/actor.cpp
+++ b/engines/saga2/actor.cpp
@@ -3112,7 +3112,7 @@ uint8 Actor::evaluateFollowerNeeds(Actor *follower) {
 
 //  Returns 0 if not moving, 1 if path being calculated,
 //  2 if path being followed.
-bool Actor::pathFindState() {
+int Actor::pathFindState() {
 	if (_moveTask == nullptr)
 		return 0;
 	if (_moveTask->_pathFindTask)

--- a/engines/saga2/actor.h
+++ b/engines/saga2/actor.h
@@ -946,7 +946,7 @@ public:
 
 	//  Returns 0 if not moving, 1 if path being calculated,
 	//  2 if path being followed.
-	bool pathFindState();
+	int pathFindState();
 
 	//  High level actor behavior functions
 private:

--- a/engines/saga2/effects.cpp
+++ b/engines/saga2/effects.cpp
@@ -249,7 +249,7 @@ void ProtoTAGEffect::implement(GameObject *cst, SpellTarget *trg, int8) {
 	assert(tag);
 	if (_affectBit == kSettagLocked) {
 		//if ( tag->builtInBehavior()==ActiveItem::kBuiltInDoor )
-		if (tag->isLocked() != _onOff)
+		if (tag->isLocked() != (_onOff != 0))
 			tag->acceptLockToggle(cst->thisID(), tag->lockType());
 	} else if (_affectBit == kSettagOpen) {
 		tag->trigger(cst->thisID(), _onOff);

--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -795,6 +795,7 @@ void Actor::startWalkActor(int destX, int destY, int dir) {
 	if (_vm->_game.version <= 4) {
 		abr.x = destX;
 		abr.y = destY;
+		abr.box = kInvalidBox;
 	} else {
 		abr = adjustXYToBeInBox(destX, destY);
 	}

--- a/engines/stark/gfx/renderentry.cpp
+++ b/engines/stark/gfx/renderentry.cpp
@@ -122,7 +122,7 @@ bool RenderEntry::compare(const RenderEntry *x, const RenderEntry *y) {
 		// This should ensure the items remain in the same order if they have the same sort key
 		return x->_owner->getIndex() < y->_owner->getIndex();
 	} else {
-		return -1;
+		return (x->_owner < y->_owner);
 	}
 }
 

--- a/engines/tony/mpal/expr.cpp
+++ b/engines/tony/mpal/expr.cpp
@@ -182,7 +182,7 @@ static int evaluateAndFreeExpression(byte *expr) {
  * will point to the area of memory containing the parsed expression
  * @returns		Pointer to the buffer immediately after the expression, or NULL if error.
  */
-const byte *parseExpression(const byte *lpBuf, MpalHandle *h) {
+const byte *parseExpression(const byte *lpBuf, const Common::UnalignedPtr<MpalHandle> &h) {
 	byte *start;
 
 	uint32 num = *lpBuf;
@@ -191,11 +191,11 @@ const byte *parseExpression(const byte *lpBuf, MpalHandle *h) {
 	if (num == 0)
 		return NULL;
 
-	*h = globalAllocate(GMEM_MOVEABLE | GMEM_ZEROINIT, num * sizeof(Expression) + 1);
-	if (*h == NULL)
+	h.store(globalAllocate(GMEM_MOVEABLE | GMEM_ZEROINIT, num * sizeof(Expression) + 1));
+	if (h.load() == NULL)
 		return NULL;
 
-	start = (byte *)globalLock(*h);
+	start = (byte *)globalLock(h.load());
 	*start = (byte)num;
 
 	LpExpression cur = (LpExpression)(start + 1);

--- a/engines/tony/mpal/expr.h
+++ b/engines/tony/mpal/expr.h
@@ -106,7 +106,7 @@ enum ExprListTypes {
  * will point to the area of memory containing the parsed expression
  * @returns		Pointer to the buffer immediately after the expression, or NULL if error.
  */
-const byte *parseExpression(const byte *lpBuf, MpalHandle *h);
+const byte *parseExpression(const byte *lpBuf, const Common::UnalignedPtr<MpalHandle> &h);
 
 /**
  * Calculate the value of a mathamatical expression

--- a/engines/ultima/nuvie/gui/widgets/msg_scroll.cpp
+++ b/engines/ultima/nuvie/gui/widgets/msg_scroll.cpp
@@ -287,7 +287,7 @@ void MsgScroll::set_scroll_dimensions(uint16 w, uint16 h) {
 	display_pos = 0;
 }
 
-int MsgScroll::print(Std::string format, ...) {
+int MsgScroll::print_internal(const Std::string *format, ...) {
 
 	va_list ap;
 	int printed = 0;
@@ -311,7 +311,7 @@ int MsgScroll::print(Std::string format, ...) {
 
 		/* try formatting */
 		va_start(ap, format);
-		printed = vsnprintf(buffer, bufsize, format.c_str(), ap);
+		printed = vsnprintf(buffer, bufsize, format->c_str(), ap);
 		va_end(ap);
 
 		if (printed < 0) {

--- a/engines/ultima/nuvie/gui/widgets/msg_scroll.h
+++ b/engines/ultima/nuvie/gui/widgets/msg_scroll.h
@@ -233,7 +233,8 @@ public:
 	virtual void set_font(uint8 font_type);
 	virtual bool is_garg_font();
 
-	int print(const Std::string format, ...);
+	template<class... TParam>
+	int print(const Std::string &format, TParam... param);
 
 	virtual void display_string(Std::string s, Font *f, bool include_on_map_window);
 	void display_string(Std::string s, Font *f, uint8 color, bool include_on_map_window);
@@ -324,8 +325,14 @@ protected:
 		return font_color;
 	}
 
-
+private:
+	int print_internal(const Std::string *format, ...);
 };
+
+template<class... TParam>
+inline int MsgScroll::print(const Std::string &format, TParam... param) {
+	return print_internal(&format, Common::forward<TParam>(param)...);
+}
 
 } // End of namespace Nuvie
 } // End of namespace Ultima

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
@@ -485,7 +485,7 @@ bool BaseRenderOpenGL3D::setup3D(Camera3D *camera, bool force) {
 		glEnable(GL_BLEND);
 		// wme uses 8 as a reference value and Direct3D expects it to be in the range [0, 255]
 		// 8 / 255 ~ 0.0313
-		glAlphaFunc(GL_GEQUAL, 0.0313);
+		glAlphaFunc(GL_GEQUAL, 0.0313f);
 
 		setAmbientLight();
 

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
@@ -179,7 +179,7 @@ bool BaseRenderOpenGL3DShader::enableShadows() {
 
 		float nearPlane = 1.0f;
 		float farPlane = 10000.0f;
-		float fovy = M_PI / 4.0f;
+		float fovy = static_cast<float>(M_PI / 4.0f);
 
 		float top = nearPlane *  tanf(fovy * 0.5f);
 		float bottom = -top;

--- a/engines/wintermute/wintermute.cpp
+++ b/engines/wintermute/wintermute.cpp
@@ -196,7 +196,7 @@ int WintermuteEngine::init() {
 	#ifdef ENABLE_WME3D
 	Common::ArchiveMemberList actors3d;
 	_game->_playing3DGame = instance.getFlags() & GF_3D;
-	_game->_playing3DGame |= BaseEngine::instance().getFileManager()->listMatchingPackageMembers(actors3d, "*.act3d");
+	_game->_playing3DGame |= (BaseEngine::instance().getFileManager()->listMatchingPackageMembers(actors3d, "*.act3d") != 0);
 	#endif
 	instance.setGameRef(_game);
 	BasePlatform::initialize(this, _game, 0, nullptr);


### PR DESCRIPTION
This upgrades several VS warnings to errors in Visual Studio and fixes their occurrences.  Most of these are either non-compliant language extensions or things that cause undefined behavior, all of them should be low-risk and straightforward to fix.

The only one that's not straightforward to fix is C4315 but that usually happens when a #pragma pack(1) isn't terminated, which is a dangerous error that can cause miscompiled functions to be ODR'd into other engines, which is really bad!

C4701: potential use of uninitialized local variable
C4703: potential use of uninitialized local pointer
C4456: declaration hides previous local declaration
C4003: not enough arguments for function-like macro invocation
C4840: use of non-trivial class as an argument to a variadic function
C4805: unsafe mix of bool and int in a numeric operation or comparison
C4305: truncation of double to float or int to bool
C4366: address taken of unaligned field and used as an aligned pointer
C4315: object constructed into an unaligned field with a constructor that expects it to be aligned