### PR TITLE
DEVTOOLS: Add precompiled header support to MSBuild/MSVC.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.dwp
 lib*.a
 .deps
+*_pch.cpp
 
 /config.log
 /scummvm

--- a/devtools/create_project/cmake.cpp
+++ b/devtools/create_project/cmake.cpp
@@ -270,7 +270,7 @@ static std::string filePrefix(const BuildSetup &setup, const std::string &module
 }
 
 void CMakeProvider::createProjectFile(const std::string &name, const std::string &, const BuildSetup &setup, const std::string &moduleDir,
-										   const StringList &includeList, const StringList &excludeList) {
+									  const StringList &includeList, const StringList &excludeList, const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude) {
 
 	const std::string projectFile = setup.outputDir + "/CMakeLists.txt";
 	std::ofstream project(projectFile.c_str(), std::ofstream::out | std::ofstream::app);
@@ -284,12 +284,12 @@ void CMakeProvider::createProjectFile(const std::string &name, const std::string
 		project << "add_library(" << name << "\n";
 	} else {
 		enginesStr << "add_engine(" << name << "\n";
-		addFilesToProject(moduleDir, enginesStr, includeList, excludeList, filePrefix(setup, moduleDir));
+		addFilesToProject(moduleDir, enginesStr, includeList, excludeList, pchIncludeRoot, pchDirs, pchExclude, filePrefix(setup, moduleDir));
 		enginesStr << ")\n\n";
 		return;
 	}
 
-	addFilesToProject(moduleDir, project, includeList, excludeList, filePrefix(setup, moduleDir));
+	addFilesToProject(moduleDir, project, includeList, excludeList, pchIncludeRoot, pchDirs, pchExclude, filePrefix(setup, moduleDir));
 
 	project << ")\n";
 	project << "\n";
@@ -356,12 +356,13 @@ void CMakeProvider::writeDefines(const BuildSetup &setup, std::ofstream &output)
 }
 
 void CMakeProvider::writeFileListToProject(const FileNode &dir, std::ostream &projectFile, const int indentation,
-												const std::string &objPrefix, const std::string &filePrefix) {
+										   const std::string &objPrefix, const std::string &filePrefix,
+										   const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude) {
 
 	std::string lastName;
 	for (const FileNode *node : dir.children) {
 		if (!node->children.empty()) {
-			writeFileListToProject(*node, projectFile, indentation + 1, objPrefix + node->name + '_', filePrefix + node->name + '/');
+			writeFileListToProject(*node, projectFile, indentation + 1, objPrefix + node->name + '_', filePrefix + node->name + '/', pchIncludeRoot, pchDirs, pchExclude);
 		} else {
 			std::string name, ext;
 			splitFilename(node->name, name, ext);

--- a/devtools/create_project/cmake.h
+++ b/devtools/create_project/cmake.h
@@ -45,10 +45,11 @@ protected:
 	void addResourceFiles(const BuildSetup &setup, StringList &includeList, StringList &excludeList) final {}
 
 	void createProjectFile(const std::string &name, const std::string &uuid, const BuildSetup &setup, const std::string &moduleDir,
-						   const StringList &includeList, const StringList &excludeList) final;
+						   const StringList &includeList, const StringList &excludeList, const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude) final;
 
 	void writeFileListToProject(const FileNode &dir, std::ostream &projectFile, const int indentation,
-								const std::string &objPrefix, const std::string &filePrefix) final;
+								const std::string &objPrefix, const std::string &filePrefix,
+								const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude) final;
 
 	const char *getProjectExtension() final;
 

--- a/devtools/create_project/codeblocks.cpp
+++ b/devtools/create_project/codeblocks.cpp
@@ -97,7 +97,7 @@ StringList getFeatureLibraries(const BuildSetup &setup) {
 }
 
 void CodeBlocksProvider::createProjectFile(const std::string &name, const std::string &, const BuildSetup &setup, const std::string &moduleDir,
-										   const StringList &includeList, const StringList &excludeList) {
+										   const StringList &includeList, const StringList &excludeList, const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude) {
 
 	const std::string projectFile = setup.outputDir + '/' + name + getProjectExtension();
 	std::ofstream project(projectFile.c_str());
@@ -210,9 +210,9 @@ void CodeBlocksProvider::createProjectFile(const std::string &name, const std::s
 	}
 
 	if (!modulePath.empty())
-		addFilesToProject(moduleDir, project, includeList, excludeList, setup.filePrefix + '/' + modulePath);
+		addFilesToProject(moduleDir, project, includeList, excludeList, pchIncludeRoot, pchDirs, pchExclude, setup.filePrefix + '/' + modulePath);
 	else
-		addFilesToProject(moduleDir, project, includeList, excludeList, setup.filePrefix);
+		addFilesToProject(moduleDir, project, includeList, excludeList, pchIncludeRoot, pchDirs, pchExclude, setup.filePrefix);
 
 
 	project << "\t\t<Extensions>\n"
@@ -249,13 +249,14 @@ void CodeBlocksProvider::writeDefines(const StringList &defines, std::ofstream &
 }
 
 void CodeBlocksProvider::writeFileListToProject(const FileNode &dir, std::ostream &projectFile, const int indentation,
-												const std::string &objPrefix, const std::string &filePrefix) {
+												const std::string &objPrefix, const std::string &filePrefix,
+												const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude) {
 
 	for (FileNode::NodeList::const_iterator i = dir.children.begin(); i != dir.children.end(); ++i) {
 		const FileNode *node = *i;
 
 		if (!node->children.empty()) {
-			writeFileListToProject(*node, projectFile, indentation + 1, objPrefix + node->name + '_', filePrefix + node->name + '/');
+			writeFileListToProject(*node, projectFile, indentation + 1, objPrefix + node->name + '_', filePrefix + node->name + '/', pchIncludeRoot, pchDirs, pchExclude);
 		} else {
 			std::string name, ext;
 			splitFilename(node->name, name, ext);

--- a/devtools/create_project/codeblocks.h
+++ b/devtools/create_project/codeblocks.h
@@ -39,10 +39,11 @@ protected:
 	void addResourceFiles(const BuildSetup &setup, StringList &includeList, StringList &excludeList) final;
 
 	void createProjectFile(const std::string &name, const std::string &uuid, const BuildSetup &setup, const std::string &moduleDir,
-						   const StringList &includeList, const StringList &excludeList) final;
+						   const StringList &includeList, const StringList &excludeList, const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude) final;
 
 	void writeFileListToProject(const FileNode &dir, std::ostream &projectFile, const int indentation,
-								const std::string &objPrefix, const std::string &filePrefix) final;
+								const std::string &objPrefix, const std::string &filePrefix,
+								const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude) final;
 
 	void writeReferences(const BuildSetup &setup, std::ofstream &output) final;
 

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -410,6 +410,21 @@ void splitFilename(const std::string &fileName, std::string &name, std::string &
 void splitPath(const std::string &path, std::string &dir, std::string &file);
 
 /**
+ * Calculates the include path and PCH file path (without the base directory).
+ *
+ * @param filePath Path to the source file.
+ * @param pchIncludeRoot Path to the PCH inclusion root directory (ending with separator).
+ * @param pchDirs List of PCH directories.
+ * @param pchExclude List of PCH exclusions.
+ * @param separator Path separator
+ * @param outPchIncludePath Output path to be used by #include directives.
+ * @param outPchFilePath Output file path.
+ * @param outPchFileName Output file name.
+ * @return True if the file path uses PCH, false if not.
+ */
+bool calculatePchPaths(const std::string &sourceFilePath, const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude, char separator, std::string &outPchIncludePath, std::string &outPchFilePath, std::string &outPchFileName);
+
+/**
  * Returns the basename of a path.
  * examples:
  *   a/b/c/d.ext -> d.ext
@@ -551,7 +566,7 @@ protected:
 	 * @param excludeList Files to exclude (must have "moduleDir" as prefix).
 	 */
 	virtual void createProjectFile(const std::string &name, const std::string &uuid, const BuildSetup &setup, const std::string &moduleDir,
-	                               const StringList &includeList, const StringList &excludeList) = 0;
+								   const StringList &includeList, const StringList &excludeList, const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude) = 0;
 
 	/**
 	 * Writes file entries for the specified directory node into
@@ -564,7 +579,8 @@ protected:
 	 * @param filePrefix Generic prefix to all files of the node.
 	 */
 	virtual void writeFileListToProject(const FileNode &dir, std::ostream &projectFile, const int indentation,
-	                                    const std::string &objPrefix, const std::string &filePrefix) = 0;
+										const std::string &objPrefix, const std::string &filePrefix,
+										const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude) = 0;
 
 	/**
 	 * Output a list of project references to the file stream
@@ -588,7 +604,8 @@ protected:
 	 * @param filePrefix Prefix to use for relative path arguments.
 	 */
 	void addFilesToProject(const std::string &dir, std::ostream &projectFile,
-	                       const StringList &includeList, const StringList &excludeList,
+						   const StringList &includeList, const StringList &excludeList,
+						   const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude,
 	                       const std::string &filePrefix);
 
 	/**
@@ -602,7 +619,7 @@ protected:
 	 * @param includeList Reference to a list, where included files should be added.
 	 * @param excludeList Reference to a list, where excluded files should be added.
 	 */
-	void createModuleList(const std::string &moduleDir, const StringList &defines, StringList &testDirs, StringList &includeList, StringList &excludeList, bool forDetection = false) const;
+	void createModuleList(const std::string &moduleDir, const StringList &defines, StringList &testDirs, StringList &includeList, StringList &excludeList, StringList &pchDirs, StringList &pchExclude, bool forDetection = false) const;
 
 	/**
 	 * Creates an UUID for every enabled engine of the

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -81,7 +81,7 @@ inline void outputProperties(const BuildSetup &setup, std::ostream &project, con
 } // End of anonymous namespace
 
 void MSBuildProvider::createProjectFile(const std::string &name, const std::string &uuid, const BuildSetup &setup, const std::string &moduleDir,
-										const StringList &includeList, const StringList &excludeList) {
+										const StringList &includeList, const StringList &excludeList, const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude) {
 	const std::string projectFile = setup.outputDir + '/' + name + getProjectExtension();
 	std::ofstream project(projectFile.c_str());
 	if (!project || !project.is_open()) {
@@ -156,9 +156,9 @@ void MSBuildProvider::createProjectFile(const std::string &name, const std::stri
 	}
 
 	if (!modulePath.empty())
-		addFilesToProject(moduleDir, project, includeList, excludeList, setup.filePrefix + '/' + modulePath);
+		addFilesToProject(moduleDir, project, includeList, excludeList, pchIncludeRoot, pchDirs, pchExclude, setup.filePrefix + '/' + modulePath);
 	else
-		addFilesToProject(moduleDir, project, includeList, excludeList, setup.filePrefix);
+		addFilesToProject(moduleDir, project, includeList, excludeList, pchIncludeRoot, pchDirs, pchExclude, setup.filePrefix);
 
 	// Output references for the main project
 	if (name == setup.projectName)
@@ -529,8 +529,52 @@ void MSBuildProvider::outputNasmCommand(std::ostream &projectFile, const std::st
 	}
 }
 
+void MSBuildProvider::insertPathIntoDirectory(FileNode &dir, const std::string &path) {
+	size_t separatorLoc = path.find('\\');
+	if (separatorLoc != std::string::npos) {
+		// Inside of a subdirectory
+
+		std::string subdirName = path.substr(0, separatorLoc);
+
+		FileNode::NodeList::iterator dirIt = dir.children.begin();
+		FileNode::NodeList::iterator dirItEnd = dir.children.end();
+		while (dirIt != dirItEnd) {
+			if ((*dirIt)->name == subdirName)
+				break;
+
+			++dirIt;
+		}
+
+		FileNode *dirNode = nullptr;
+		if (dirIt == dirItEnd) {
+			dirNode = new FileNode(subdirName);
+			dir.children.push_back(dirNode);
+		} else {
+			dirNode = *dirIt;
+		}
+
+		insertPathIntoDirectory(*dirNode, path.substr(separatorLoc + 1));
+	} else {
+		FileNode *fileNode = new FileNode(path);
+		dir.children.push_back(fileNode);
+	}
+}
+
+void MSBuildProvider::createFileNodesFromPCHList(FileNode &dir, const std::string &pathBase, const StringList &pchCompileFiles) {
+	for (StringList::const_iterator it = pchCompileFiles.begin(), itEnd = pchCompileFiles.end(); it != itEnd; ++it) {
+		const std::string &pchPath = *it;
+
+		if (pchPath.size() > pathBase.size() && pchPath.substr(0, pathBase.size()) == pathBase) {
+			std::string internalPath = pchPath.substr(pathBase.size());
+
+			insertPathIntoDirectory(dir, internalPath);
+		}
+	}
+}
+
 void MSBuildProvider::writeFileListToProject(const FileNode &dir, std::ostream &projectFile, const int,
-											 const std::string &objPrefix, const std::string &filePrefix) {
+											 const std::string &objPrefix, const std::string &filePrefix,
+											 const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude) {
 	// Reset lists
 	_filters.clear();
 	_compileFiles.clear();
@@ -544,11 +588,32 @@ void MSBuildProvider::writeFileListToProject(const FileNode &dir, std::ostream &
 	computeFileList(dir, objPrefix, filePrefix);
 	_filters.pop_back(); // remove last empty filter
 
+	StringList pchCompileFiles;
+
 	// Output compile, include, other and resource files
-	outputFiles(projectFile, _compileFiles, "ClCompile");
+	outputCompileFiles(projectFile, pchIncludeRoot, pchDirs, pchExclude, pchCompileFiles);
 	outputFiles(projectFile, _includeFiles, "ClInclude");
 	outputFiles(projectFile, _otherFiles, "None");
 	outputFiles(projectFile, _resourceFiles, "ResourceCompile");
+
+	if (pchCompileFiles.size() > 0) {
+		// Generate filters and additional compile files for PCH files
+		FileNode pchDir(dir.name);
+		createFileNodesFromPCHList(pchDir, convertPathToWin(dir.name) + '\\', pchCompileFiles);
+
+		StringList backupFilters = _filters;
+		_filters.clear();
+
+		_filters.push_back(""); // init filters
+		computeFileList(pchDir, objPrefix, filePrefix);
+		_filters.pop_back(); // remove last empty filter
+
+		// Combine lists, removing duplicates
+		for (StringList::const_iterator it = backupFilters.begin(), itEnd = backupFilters.end(); it != itEnd; ++it) {
+			if (std::find(_filters.begin(), _filters.end(), *it) != _filters.end())
+				_filters.push_back(*it);
+		}
+	}
 
 	// Output asm files
 	if (!_asmFiles.empty()) {
@@ -575,6 +640,126 @@ void MSBuildProvider::outputFiles(std::ostream &projectFile, const FileEntries &
 		for (FileEntries::const_iterator entry = files.begin(), end = files.end(); entry != end; ++entry) {
 			projectFile << "\t\t<" << action << " Include=\"" << (*entry).path << "\" />\n";
 		}
+		projectFile << "\t</ItemGroup>\n";
+	}
+}
+
+void MSBuildProvider::outputCompileFiles(std::ostream &projectFile, const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude, StringList &outPCHFiles) {
+	const FileEntries &files = _compileFiles;
+
+	const bool hasPCH = (pchDirs.size() > 0);
+
+	std::string pchIncludeRootWin;
+	StringList pchDirsWin;
+	StringList pchExcludeWin;
+
+	if (hasPCH) {
+		pchIncludeRootWin = convertPathToWin(pchIncludeRoot);
+
+		// Convert PCH paths to Win
+		for (StringList::const_iterator entry = pchDirs.begin(), end = pchDirs.end(); entry != end; ++entry) {
+			std::string convertedPath = convertPathToWin(*entry);
+			if (convertedPath.size() < pchIncludeRootWin.size() || convertedPath.substr(0, pchIncludeRootWin.size()) != pchIncludeRootWin) {
+				error("PCH path '" + convertedPath + "' wasn't located under PCH include root '" + pchIncludeRootWin + "'");
+			}
+
+			pchDirsWin.push_back(convertPathToWin(*entry));
+		}
+		for (StringList::const_iterator entry = pchExclude.begin(), end = pchExclude.end(); entry != end; ++entry) {
+			const std::string path = *entry;
+
+			if (path.size() >= 2 && path[path.size() - 1] == 'o' && path[path.size() - 2] == '.')
+				pchExcludeWin.push_back(convertPathToWin(path.substr(0, path.size() - 2)));
+		}
+	}
+
+	std::map<std::string, PCHInfo> pchMap;
+
+	if (!files.empty()) {
+		projectFile << "\t<ItemGroup>\n";
+		for (FileEntries::const_iterator entry = files.begin(), end = files.end(); entry != end; ++entry) {
+			std::string pchIncludePath, pchFilePath, pchFileName;
+
+			bool fileHasPCH = false;
+			if (hasPCH)
+				fileHasPCH = calculatePchPaths(entry->path, pchIncludeRootWin, pchDirsWin, pchExcludeWin, '\\', pchIncludePath, pchFilePath, pchFileName);
+
+			if (fileHasPCH) {
+				std::string pchOutputFileName = "$(IntDir)dists\\msvc\\%(RelativeDir)" + pchFileName.substr(0, pchFileName.size() - 2) + ".pch";
+
+				PCHInfo &pchInfo = pchMap[pchFilePath];
+				pchInfo.file = pchIncludePath;
+				pchInfo.outputFile = pchOutputFileName;
+
+				projectFile << "\t\t<ClCompile Include=\"" << (*entry).path << "\">\n";
+				projectFile << "\t\t\t<PrecompiledHeader>Use</PrecompiledHeader>\n";
+				projectFile << "\t\t\t<PrecompiledHeaderFile>" << pchIncludePath << "</PrecompiledHeaderFile>\n";
+				projectFile << "\t\t\t<PrecompiledHeaderOutputFile>" << pchOutputFileName << "</PrecompiledHeaderOutputFile>\n";
+				projectFile << "\t\t</ClCompile>\n";
+			} else {
+				projectFile << "\t\t<ClCompile Include=\"" << (*entry).path << "\" />\n";
+			}
+		}
+
+		// Flush PCH files
+		for (std::map<std::string, PCHInfo>::const_iterator pchIt = pchMap.begin(), pchItEnd = pchMap.end(); pchIt != pchItEnd; ++pchIt) {
+			const PCHInfo &pchInfo = pchIt->second;
+
+			const std::string &filePath = pchIt->first;
+			assert(filePath.size() >= 2 && filePath.substr(filePath.size() - 2) == ".h");
+
+			std::string cppFilePath = filePath.substr(0, filePath.size() - 2) + ".cpp";
+
+			std::string expectedContents = "/* This file is automatically generated by create_project */\n"
+										   "/* DO NOT EDIT MANUALLY */\n"
+										   "#include \"" + pchInfo.file + "\"\n";
+
+			// Try to avoid touching the generated .cpp if it's identical to the expected output.
+			// If we touch the file, then every file that includes PCH needs to be recompiled.
+			std::ifstream pchInputFile(cppFilePath.c_str());
+			bool needToEmit = true;
+			if (pchInputFile && pchInputFile.is_open()) {
+				std::string fileContents;
+				for (;;) {
+					char buffer[1024];
+					size_t numRead = sizeof(buffer) - 1;
+					pchInputFile.read(buffer, numRead);
+
+					buffer[pchInputFile.gcount()] = '\0';
+
+					fileContents += buffer;
+
+					if (pchInputFile.eof() || pchInputFile.fail())
+						break;
+
+					if (fileContents.size() > expectedContents.size())
+						break;
+				}
+
+				needToEmit = (fileContents != expectedContents);
+				pchInputFile.close();
+			}
+
+			if (needToEmit) {
+				std::ofstream pchOutputFile(cppFilePath.c_str());
+				if (!pchOutputFile || !pchOutputFile.is_open()) {
+					error("Could not open \"" + cppFilePath + "\" for writing");
+					return;
+				}
+
+				pchOutputFile << expectedContents;
+				pchOutputFile.close();
+			}
+
+			projectFile << "\t\t<ClCompile Include=\"" << cppFilePath << "\">\n";
+			projectFile << "\t\t\t<PrecompiledHeader>Create</PrecompiledHeader>\n";
+			projectFile << "\t\t\t<PrecompiledHeaderFile>" << pchInfo.file << "</PrecompiledHeaderFile>\n";
+			projectFile << "\t\t\t<PrecompiledHeaderOutputFile>" << pchInfo.outputFile << "</PrecompiledHeaderOutputFile>\n";
+			projectFile << "\t\t</ClCompile>\n";
+
+			outPCHFiles.push_back(cppFilePath);
+		}
+
 		projectFile << "\t</ItemGroup>\n";
 	}
 }

--- a/devtools/create_project/msbuild.h
+++ b/devtools/create_project/msbuild.h
@@ -32,12 +32,13 @@ public:
 
 protected:
 	void createProjectFile(const std::string &name, const std::string &uuid, const BuildSetup &setup, const std::string &moduleDir,
-	                       const StringList &includeList, const StringList &excludeList) override;
+						   const StringList &includeList, const StringList &excludeList, const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude) override;
 
 	void outputProjectSettings(std::ofstream &project, const std::string &name, const BuildSetup &setup, bool isRelease, MSVC_Architecture arch, const std::string &configuration);
 
 	void writeFileListToProject(const FileNode &dir, std::ostream &projectFile, const int indentation,
-	                            const std::string &objPrefix, const std::string &filePrefix) override;
+								const std::string &objPrefix, const std::string &filePrefix,
+								const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude) override;
 
 	void writeReferences(const BuildSetup &setup, std::ofstream &output) override;
 
@@ -61,6 +62,11 @@ private:
 	};
 	typedef std::list<FileEntry> FileEntries;
 
+	struct PCHInfo {
+		std::string file;
+		std::string outputFile;
+	};
+
 	std::list<std::string> _filters; // list of filters (we need to create a GUID for each filter id)
 	FileEntries _compileFiles;
 	FileEntries _includeFiles;
@@ -73,8 +79,12 @@ private:
 
 	void outputFilter(std::ostream &filters, const FileEntries &files, const std::string &action);
 	void outputFiles(std::ostream &projectFile, const FileEntries &files, const std::string &action);
+	void outputCompileFiles(std::ostream &projectFile, const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude, StringList &outPCHFiles);
 
 	void outputNasmCommand(std::ostream &projectFile, const std::string &config, const std::string &prefix);
+
+	static void createFileNodesFromPCHList(FileNode &dir, const std::string &pathBase, const StringList &pchCompileFiles);
+	static void insertPathIntoDirectory(FileNode &dir, const std::string &path);
 };
 
 } // namespace CreateProjectTool

--- a/devtools/create_project/xcode.h
+++ b/devtools/create_project/xcode.h
@@ -42,10 +42,12 @@ protected:
 	void addResourceFiles(const BuildSetup &setup, StringList &includeList, StringList &excludeList) final;
 
 	void createProjectFile(const std::string &name, const std::string &uuid, const BuildSetup &setup, const std::string &moduleDir,
-						   const StringList &includeList, const StringList &excludeList) final;
+						   const StringList &includeList, const StringList &excludeList, const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude) final;
 
 	void writeFileListToProject(const FileNode &dir, std::ostream &projectFile, const int indentation,
-								const std::string &objPrefix, const std::string &filePrefix) final;
+								const std::string &objPrefix, const std::string &filePrefix,
+								const std::string &pchIncludeRoot, const StringList &pchDirs, const StringList &pchExclude) final;
+
 private:
 	enum {
 		kSettingsAsList        = 0x01,


### PR DESCRIPTION
This adds support for precompiled headers to speed up build times.  It does this by looking for MODULE_PCH_DIRS and MODULE_PCH_EXCLUDE to indicate what files should use PCH.  This supports one PCH file per directory, but not subdirectories.  While subdirectory scan might be more efficient in some cases, I think the added efficiency is not worth the extra complications with large engines that include third-party libraries.  We'd need a directory exclusion mechanism for those and I think it's just not worth it.

Example of usage: Suppose I wanted to add PCH to mTropolis engine, which has a base directory and "plugin" directory, and I want to add PCH for both of them.  I would add to module.mk:
`MODULE_PCH_DIRS := . plugin`

Then I would have to add the files `engines/mtropolis/mtropolis_pch.h` and `engines/mtropolis/plugin/plugin_pch.h` and all files within those directories would need to include the respective PCH file before anything else.

Let's say I don't want the assets.cpp file using PCH.  I would add:
`MODULE_PCH_EXCLUDE := assets.o`

This PR adds support for MSBuild/MSVC only.  Other build systems can be added in the future, it's backward-compatible.