### PR TITLE
HPL1: Fix spammy warning in AngelScript

### DIFF
--- a/engines/hpl1/engine/libraries/angelscript/angelscript.h
+++ b/engines/hpl1/engine/libraries/angelscript/angelscript.h
@@ -162,7 +162,7 @@ enum asECallConvTypes {
 };
 
 // Object type flags
-enum asEObjTypeFlags {
+enum asEObjTypeFlags : unsigned int {
 	asOBJ_NULL                       = 0,
 	asOBJ_REF                        = (1 << 0),
 	asOBJ_VALUE                      = (1 << 1),
@@ -192,7 +192,7 @@ enum asEObjTypeFlags {
 	asOBJ_APP_CLASS_A                = (asOBJ_APP_CLASS + asOBJ_APP_CLASS_ASSIGNMENT),
 	asOBJ_APP_CLASS_AK               = (asOBJ_APP_CLASS + asOBJ_APP_CLASS_ASSIGNMENT + asOBJ_APP_CLASS_COPY_CONSTRUCTOR),
 	asOBJ_APP_CLASS_K                = (asOBJ_APP_CLASS + asOBJ_APP_CLASS_COPY_CONSTRUCTOR),
-	asOBJ_APP_CLASS_MORE_CONSTRUCTORS = (1 << 31),
+	asOBJ_APP_CLASS_MORE_CONSTRUCTORS = (1u << 31),
 	asOBJ_APP_PRIMITIVE              = (1 << 13),
 	asOBJ_APP_FLOAT                  = (1 << 14),
 	asOBJ_APP_ARRAY                  = (1 << 15),
@@ -201,7 +201,7 @@ enum asEObjTypeFlags {
 	asOBJ_NOCOUNT                    = (1 << 18),
 	asOBJ_APP_CLASS_ALIGN8           = (1 << 19),
 	asOBJ_IMPLICIT_HANDLE            = (1 << 20),
-	asOBJ_MASK_VALID_FLAGS           = 0x801FFFFF,
+	asOBJ_MASK_VALID_FLAGS           = 0x801FFFFFu,
 	// Internal flags
 	asOBJ_SCRIPT_OBJECT              = (1 << 21),
 	asOBJ_SHARED                     = (1 << 22),


### PR DESCRIPTION
Changes `asEObjTypeFlags` to unsigned to fix constant truncation warnings that are spamming the VS build logs.  As far as I can tell, it's always operated on with asDWORD which is also unsigned so this should be more correct anyway.