### PR TITLE
BACKENDS: Disable curl deprecation warnings

### DIFF
--- a/backends/networking/curl/networkreadstream.cpp
+++ b/backends/networking/curl/networkreadstream.cpp
@@ -20,6 +20,7 @@
  */
 
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
+#define CURL_DISABLE_DEPRECATION
 
 #include <curl/curl.h>
 #include "backends/networking/curl/networkreadstream.h"


### PR DESCRIPTION
We still need to support older versions, so mute the warnings as long as the old APIs can still be used.
