### PR TITLE
ALL: Forbid system strnlen and rename our implementation to scumm_strnlen

### DIFF
--- a/common/forbidden.h
+++ b/common/forbidden.h
@@ -551,31 +551,31 @@
 #define sprintf(a,b,...)	FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
 #endif
 
-// Use Common:scumm_stricmp in common/str.h
+// Use scumm_stricmp in common/str.h
 #ifndef FORBIDDEN_SYMBOL_EXCEPTION_stricmp
 #undef stricmp
 #define stricmp(a,b)	FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
 #endif
 
-// Use Common:scumm_strnicmp in common/str.h
+// Use scumm_strnicmp in common/str.h
 #ifndef FORBIDDEN_SYMBOL_EXCEPTION_strnicmp
 #undef strnicmp
 #define strnicmp(a,b,c)	FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
 #endif
 
-// Use Common:scumm_stricmp in common/str.h
+// Use scumm_stricmp in common/str.h
 #ifndef FORBIDDEN_SYMBOL_EXCEPTION_strcasecmp
 #undef strcasecmp
 #define strcasecmp(a,b)	FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
 #endif
 
-// Use Common:scumm_strnicmp in common/str.h
+// Use scumm_strnicmp in common/str.h
 #ifndef FORBIDDEN_SYMBOL_EXCEPTION_strncasecmp
 #undef strncasecmp
 #define strncasecmp(a,b,c)	FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
 #endif
 
-// Use Common::scumm_strdup in common/str.h
+// Use scumm_strdup in common/str.h
 #ifndef FORBIDDEN_SYMBOL_EXCEPTION_strdup
 #undef strdup
 #define strdup(a)	FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*

--- a/common/forbidden.h
+++ b/common/forbidden.h
@@ -581,6 +581,12 @@
 #define strdup(a)	FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
 #endif
 
+// Use scumm_strnlen in common/str.h
+#ifndef FORBIDDEN_SYMBOL_EXCEPTION_strnlen
+#undef strnlen
+#define strnlen(a,b)	FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
+#endif
+
 /*
  * We also would like to disable the following symbols;
  * however, these are also frequently used in regular code,

--- a/common/span.h
+++ b/common/span.h
@@ -393,7 +393,7 @@ public:
 		const char *string = (const char *)impl().data() + index;
 
 		if (numEntries == kSpanMaxSize) {
-			numEntries = strnlen(string, impl().size() - index);
+			numEntries = scumm_strnlen(string, impl().size() - index);
 		}
 
 		impl().validate(index, numEntries);

--- a/common/str.cpp
+++ b/common/str.cpp
@@ -944,13 +944,6 @@ size_t strlcat(char *dst, const char *src, size_t size) {
 	return dstLength + (src - srcStart);
 }
 
-size_t strnlen(const char *src, size_t maxSize) {
-	size_t counter = 0;
-	while (counter != maxSize && *src++)
-		++counter;
-	return counter;
-}
-
 String toPrintable(const String &in, bool keepNewLines) {
 	Common::String res;
 
@@ -1068,4 +1061,12 @@ const char *scumm_strcasestr(const char *s, const char *find) {
 		s--;
 	}
 	return s;
+}
+
+//  Portable implementation of strnlen.
+size_t scumm_strnlen(const char *src, size_t maxSize) {
+	size_t counter = 0;
+	while (counter != maxSize && *src++)
+		++counter;
+	return counter;
 }

--- a/common/str.h
+++ b/common/str.h
@@ -518,17 +518,6 @@ size_t strlcpy(char *dst, const char *src, size_t size);
 size_t strlcat(char *dst, const char *src, size_t size);
 
 /**
- * Determine the length of a string up to a maximum of `maxSize` characters.
- * This should be used instead of `strlen` when reading the length of a C string
- * from potentially unsafe or corrupt sources, like game assets.
- *
- * @param src The source string.
- * @param maxSize The maximum size of the string.
- * @return The length of the string.
- */
-size_t strnlen(const char *src, size_t maxSize);
-
-/**
  * Convenience wrapper for tag2string which "returns" a C string.
  * Note: It is *NOT* safe to do anything with the return value other than directly
  * copying or printing it.
@@ -564,5 +553,16 @@ extern int scumm_compareDictionary(const char *s1, const char *s2);
 extern const char *scumm_skipArticle(const char *s1);
 
 extern const char *scumm_strcasestr(const char *s, const char *find);
+
+/**
+ * Determine the length of a string up to a maximum of `maxSize` characters.
+ * This should be used instead of `strlen` when reading the length of a C string
+ * from potentially unsafe or corrupt sources, like game assets.
+ *
+ * @param src The source string.
+ * @param maxSize The maximum size of the string.
+ * @return The length of the string.
+ */
+extern size_t scumm_strnlen(const char *src, size_t maxSize);
 
 #endif

--- a/engines/agi/inv.cpp
+++ b/engines/agi/inv.cpp
@@ -67,13 +67,13 @@ void InventoryMgr::getPlayerInventory() {
 			if (!_vm->isLanguageRTL()) {
 				if (inventoryEntry.column > 1) {
 					// right side, adjust column accordingly
-					inventoryEntry.column -= Common::strnlen(inventoryEntry.name, FONT_COLUMN_CHARACTERS);
+					inventoryEntry.column -= scumm_strnlen(inventoryEntry.name, FONT_COLUMN_CHARACTERS);
 				}
 			} else {
 				// mirror the sides
 				if (inventoryEntry.column == 1) {
 					// right side, adjust column accordingly
-					inventoryEntry.column = FONT_COLUMN_CHARACTERS - 1 - Common::strnlen(inventoryEntry.name, FONT_COLUMN_CHARACTERS);
+					inventoryEntry.column = FONT_COLUMN_CHARACTERS - 1 - scumm_strnlen(inventoryEntry.name, FONT_COLUMN_CHARACTERS);
 				} else {
 					// left side, adjust column accordingly
 					inventoryEntry.column = 1;

--- a/engines/agi/text.cpp
+++ b/engines/agi/text.cpp
@@ -587,7 +587,7 @@ void TextMgr::statusDraw() {
 		if (!_vm->isLanguageRTL())
 			charPos_Set(_statusRow, 1);
 		else
-			charPos_Set(_statusRow, FONT_COLUMN_CHARACTERS - Common::strnlen(statusTextPtr, FONT_COLUMN_CHARACTERS) - 1);
+			charPos_Set(_statusRow, FONT_COLUMN_CHARACTERS - scumm_strnlen(statusTextPtr, FONT_COLUMN_CHARACTERS) - 1);
 		displayText(statusTextPtr);
 
 		if (!_vm->isLanguageRTL())
@@ -850,7 +850,7 @@ void TextMgr::promptRedraw() {
 			displayText((char *)&_prompt);
 			inputEditOff();
 		} else {
-			charPos_Set(_promptRow, FONT_COLUMN_CHARACTERS - 2 - Common::strnlen((const char *)_prompt, FONT_COLUMN_CHARACTERS));
+			charPos_Set(_promptRow, FONT_COLUMN_CHARACTERS - 2 - scumm_strnlen((const char *)_prompt, FONT_COLUMN_CHARACTERS));
 			inputEditOff();
 			displayText((char *)&_prompt);
 			displayText(textPtr);

--- a/engines/glk/agt/agility.h
+++ b/engines/glk/agt/agility.h
@@ -1052,12 +1052,12 @@ rbool match_str(const char **pstr, const char *match);
 
 #ifdef NEED_STR_CMP
 #undef strcasecmp
-//define strcasecmp Common::scumm_strcasecmp
+//define strcasecmp scumm_strcasecmp
 extern int strcasecmp(const char *s1, const char *s2);
 #endif
 #ifdef NEED_STRN_CMP
 #undef strncasecmp
-//define strncasecmp Common::scumm_strnicmp
+//define strncasecmp scumm_strnicmp
 extern int strncasecmp(const char *s1, const char *s2, size_t len);
 #endif
 

--- a/engines/kyra/gui/gui_lol.cpp
+++ b/engines/kyra/gui/gui_lol.cpp
@@ -2527,7 +2527,7 @@ void GUI_LoL::setupSaveMenuSlots(Menu &menu, int num) {
 			// Trim long GMM save descriptions to fit our save slots
 			int fC = _screen->getTextWidth(s);
 			while (s[0] && fC >= saveSlotMaxLen) {
-				s[Common::strnlen(s, buffLeft) - 1]  = 0;
+				s[scumm_strnlen(s, buffLeft) - 1]  = 0;
 				fC = _screen->getTextWidth(s);
 			}
 
@@ -2540,7 +2540,7 @@ void GUI_LoL::setupSaveMenuSlots(Menu &menu, int num) {
 			}
 
 			menu.item[i].itemString = s;
-			int slotLen = Common::strnlen(s, buffLeft) + 1;
+			int slotLen = scumm_strnlen(s, buffLeft) + 1;
 			s += slotLen;
 			buffLeft -= slotLen;
 			menu.item[i].saveSlot = _saveSlots[i + _savegameOffset - slotOffs];

--- a/engines/kyra/sequence/sequences_hof.cpp
+++ b/engines/kyra/sequence/sequences_hof.cpp
@@ -420,14 +420,14 @@ SeqPlayer_HOF::SeqPlayer_HOF(KyraEngine_v1 *vm, Screen_v2 *screen, OSystem *syst
 	char **tmpSndLst = new char *[_sequenceSoundListSize];
 
 	for (int i = 0; i < _sequenceSoundListSize; i++) {
-		const int len = Common::strnlen(seqSoundList[i], 8);
+		const int len = scumm_strnlen(seqSoundList[i], 8);
 
 		tmpSndLst[i] = new char[len + 1];
 		tmpSndLst[i][0] = 0;
 
 		if (tlkfiles && len > 1) {
 			for (int ii = 0; ii < tempSize; ii++) {
-				if (Common::strnlen(tlkfiles[ii], 8) > 1 && !scumm_stricmp(&seqSoundList[i][1], &tlkfiles[ii][1]))
+				if (scumm_strnlen(tlkfiles[ii], 8) > 1 && !scumm_stricmp(&seqSoundList[i][1], &tlkfiles[ii][1]))
 					Common::strlcpy(tmpSndLst[i], tlkfiles[ii], len + 1);
 			}
 		}

--- a/engines/kyra/text/text_lol.cpp
+++ b/engines/kyra/text/text_lol.cpp
@@ -163,7 +163,7 @@ void TextDisplayer_LoL::printDialogueText2(int dim, const char *str, EMCState *s
 	Screen::FontId of = _screen->setFont(_pc98TextMode ? Screen::FID_SJIS_TEXTMODE_FNT : Screen::FID_9_FNT);
 
 	preprocessString(str, script, paramList, paramIndex);
-	_numCharsTotal = Common::strnlen(_dialogueBuffer, 2559);
+	_numCharsTotal = scumm_strnlen(_dialogueBuffer, 2559);
 	displayText(_dialogueBuffer);
 
 	_screen->setScreenDim(oldDim);
@@ -304,13 +304,13 @@ void TextDisplayer_LoL::preprocessString(const char *str, EMCState *script, cons
 		switch (para) {
 		case 'a':
 			Common::strlcpy(dst, Common::String::format("%d", _scriptTextParameter).c_str(), 2560 - (dst - _dialogueBuffer));
-			dst += Common::strnlen(dst, 2559 - (dst - _dialogueBuffer));
+			dst += scumm_strnlen(dst, 2559 - (dst - _dialogueBuffer));
 			break;
 
 		case 'n':
 			if (script || paramList) {
 				Common::strlcpy(dst, _vm->_characters[script ? script->stack[script->sp + paramIndex] : paramList[paramIndex]].name, 2560 - (dst - _dialogueBuffer));
-				dst += Common::strnlen(dst, 2559 - (dst - _dialogueBuffer));
+				dst += scumm_strnlen(dst, 2559 - (dst - _dialogueBuffer));
 			} else {
 				warning("TextDisplayer_LoL::preprocessString(): Missing replacement data for placeholder '%%%c'", para);
 			}
@@ -319,7 +319,7 @@ void TextDisplayer_LoL::preprocessString(const char *str, EMCState *script, cons
 		case 's':
 			if (script || paramList) {
 				Common::strlcpy(dst, _vm->getLangString(script ? script->stack[script->sp + paramIndex] : paramList[paramIndex]), 2560 - (dst - _dialogueBuffer));
-				dst += Common::strnlen(dst, 2559 - (dst - _dialogueBuffer));
+				dst += scumm_strnlen(dst, 2559 - (dst - _dialogueBuffer));
 			} else {
 				warning("TextDisplayer_LoL::preprocessString(): Missing replacement data for placeholder '%%%c'", para);
 			}
@@ -331,7 +331,7 @@ void TextDisplayer_LoL::preprocessString(const char *str, EMCState *script, cons
 		case 'x':
 			if (script || paramList) {
 				Common::strlcpy(dst, Common::String::format("%d", script ? script->stack[script->sp + paramIndex] : paramList[paramIndex]).c_str(), 2560 - (dst - _dialogueBuffer));
-				dst += Common::strnlen(dst, 2559 - (dst - _dialogueBuffer));
+				dst += scumm_strnlen(dst, 2559 - (dst - _dialogueBuffer));
 			} else {
 				warning("TextDisplayer_LoL::preprocessString(): Missing replacement data for placeholder '%%%c'", para);
 			}

--- a/engines/kyra/text/text_mr.cpp
+++ b/engines/kyra/text/text_mr.cpp
@@ -46,7 +46,7 @@ char *TextDisplayer_MR::preprocessString(const char *str) {
 
 	if (_vm->_lang == 3) {
 		Screen::FontId curFont = _screen->setFont(Screen::FID_CHINESE_FNT);
-		int textLen = Common::strnlen(p, sizeof(_talkBuffer));
+		int textLen = scumm_strnlen(p, sizeof(_talkBuffer));
 
 		if (textLen > 68) {
 			int maxTextWidth = ((textLen + 3) / 3) & ~1;

--- a/engines/kyra/text/text_rpg.cpp
+++ b/engines/kyra/text/text_rpg.cpp
@@ -557,7 +557,7 @@ void TextDisplayer_rpg::printDialogueText(int stringId, const char *pageBreakStr
 }
 
 void TextDisplayer_rpg::printDialogueText(const char *str, bool wait) {
-	assert(Common::strnlen(str, kEoBTextBufferSize) < kEoBTextBufferSize);
+	assert(scumm_strnlen(str, kEoBTextBufferSize) < kEoBTextBufferSize);
 	Common::strlcpy(_dialogueBuffer, str, kEoBTextBufferSize);
 
 	displayText(_dialogueBuffer);

--- a/engines/sci/console.cpp
+++ b/engines/sci/console.cpp
@@ -1424,7 +1424,7 @@ bool Console::cmdMapInstrument(int argc, const char **argv) {
 			char *instrumentName = new char[11];
 			Common::strlcpy(instrumentName, argv[1], 11);
 
-			for (uint16 i = 0; i < Common::strnlen(instrumentName, 11); i++)
+			for (uint16 i = 0; i < scumm_strnlen(instrumentName, 11); i++)
 				if (instrumentName[i] == '_')
 					instrumentName[i] = ' ';
 

--- a/engines/sci/engine/file.cpp
+++ b/engines/sci/engine/file.cpp
@@ -282,7 +282,7 @@ int fgets_wrapper(EngineState *s, char *dest, int maxsize, int handle) {
 	int readBytes = 0;
 	if (maxsize > 1) {
 		f->_in->readLine(dest, maxsize);
-		readBytes = Common::strnlen(dest, maxsize); // FIXME: sierra sci returned byte count and didn't react on NUL characters
+		readBytes = scumm_strnlen(dest, maxsize); // FIXME: sierra sci returned byte count and didn't react on NUL characters
 		// The returned string must not have an ending LF
 		if (readBytes > 0) {
 			if (dest[readBytes - 1] == 0x0A)

--- a/engines/sci/engine/kfile.cpp
+++ b/engines/sci/engine/kfile.cpp
@@ -367,7 +367,7 @@ reg_t kFileIOOpen(EngineState *s, int argc, reg_t *argv) {
 				score = Common::String::format("%u%03u", save.highScore, save.lowScore);
 			}
 
-			const uint nameLength = Common::strnlen(save.name, kMaxSaveNameLength);
+			const uint nameLength = scumm_strnlen(save.name, kMaxSaveNameLength);
 			const uint size = nameLength + /* \r\n */ 2 + score.size();
 			byte *buffer = (byte *)malloc(size);
 			memcpy(buffer, save.name, nameLength);
@@ -412,7 +412,7 @@ reg_t kFileIOOpen(EngineState *s, int argc, reg_t *argv) {
 			}
 
 			const Common::String avatarId = Common::String::format("%02d", save.avatarId);
-			const uint nameLength = Common::strnlen(save.name, kMaxSaveNameLength);
+			const uint nameLength = scumm_strnlen(save.name, kMaxSaveNameLength);
 			const uint size = nameLength + /* \r\n */ 2 + avatarId.size() + 1;
 			char *buffer = (char *)malloc(size);
 			memcpy(buffer, save.name, nameLength);

--- a/engines/sci/engine/message.cpp
+++ b/engines/sci/engine/message.cpp
@@ -82,7 +82,7 @@ public:
 				const uint16 stringOffset = recordPtr.getUint16LEAt(2);
 				const uint32 maxSize = _data.size() - stringOffset;
 				record.string = (const char *)_data.getUnsafeDataAt(stringOffset, maxSize);
-				record.length = Common::strnlen(record.string, maxSize);
+				record.length = scumm_strnlen(record.string, maxSize);
 				if (record.length == maxSize) {
 					warning("Message %s from %s appears truncated at %d", tuple.toString().c_str(), _data.name().c_str(), recordPtr - _data);
 				}
@@ -110,7 +110,7 @@ public:
 				const uint16 stringOffset = recordPtr.getUint16LEAt(5);
 				const uint32 maxSize = _data.size() - stringOffset;
 				record.string = (const char *)_data.getUnsafeDataAt(stringOffset, maxSize);
-				record.length = Common::strnlen(record.string, maxSize);
+				record.length = scumm_strnlen(record.string, maxSize);
 				if (record.length == maxSize) {
 					warning("Message %s from %s appears truncated at %d", tuple.toString().c_str(), _data.name().c_str(), recordPtr - _data);
 				}
@@ -138,7 +138,7 @@ public:
 				const uint16 stringOffset = recordPtr.getUint16SEAt(5);
 				const uint32 maxSize = _data.size() - stringOffset;
 				record.string = (const char *)_data.getUnsafeDataAt(stringOffset, maxSize);
-				record.length = Common::strnlen(record.string, maxSize);
+				record.length = scumm_strnlen(record.string, maxSize);
 				if (record.length == maxSize) {
 					warning("Message %s from %s appears truncated at %d", tuple.toString().c_str(), _data.name().c_str(), recordPtr - _data);
 				}
@@ -169,7 +169,7 @@ public:
 				const uint16 stringOffset = recordPtr.getUint16BEAt(6);
 				const uint32 maxSize = _data.size() - stringOffset;
 				record.string = (const char *)_data.getUnsafeDataAt(stringOffset, maxSize);
-				record.length = Common::strnlen(record.string, maxSize);
+				record.length = scumm_strnlen(record.string, maxSize);
 				if (record.length == maxSize) {
 					warning("Message %s from %s appears truncated at %d", tuple.toString().c_str(), _data.name().c_str(), recordPtr - _data);
 				}

--- a/engines/sci/engine/seg_manager.cpp
+++ b/engines/sci/engine/seg_manager.cpp
@@ -855,7 +855,7 @@ size_t SegManager::strlen(reg_t str) {
 		// There is no guarantee that raw strings are zero-terminated; for
 		// example, Phant1 reads "\r\n" from a pointer of size 2 during the
 		// chase
-		return Common::strnlen((const char *)str_r.raw, str_r.maxSize);
+		return scumm_strnlen((const char *)str_r.raw, str_r.maxSize);
 	} else {
 		int i = 0;
 		while (getChar(str_r, i))
@@ -880,7 +880,7 @@ Common::String SegManager::getString(reg_t pointer) {
 		// There is no guarantee that raw strings are zero-terminated; for
 		// example, Phant1 reads "\r\n" from a pointer of size 2 during the
 		// chase
-		const uint size = Common::strnlen((const char *)src_r.raw, src_r.maxSize);
+		const uint size = scumm_strnlen((const char *)src_r.raw, src_r.maxSize);
 		ret = Common::String((const char *)src_r.raw, size);
 	} else {
 		uint i = 0;

--- a/engines/sci/engine/segment.h
+++ b/engines/sci/engine/segment.h
@@ -807,11 +807,11 @@ public:
 			while (source < end && *source != '\0' && *source != showChar && *source <= kWhitespaceBoundary) {
 				++source;
 			}
-			memmove(target, source, Common::strnlen((char *)source, _size - 1) + 1);
+			memmove(target, source, scumm_strnlen((char *)source, _size - 1) + 1);
 		}
 
 		if (flags & kArrayTrimRight) {
-			source = data + Common::strnlen((char *)data, _size) - 1;
+			source = data + scumm_strnlen((char *)data, _size) - 1;
 			while (source > data && *source != showChar && *source <= kWhitespaceBoundary) {
 				*source = '\0';
 				--source;
@@ -847,7 +847,7 @@ public:
 					}
 					++source;
 
-					memmove(target, source, Common::strnlen((char *)source, _size - 1) + 1);
+					memmove(target, source, scumm_strnlen((char *)source, _size - 1) + 1);
 				}
 			}
 		}

--- a/engines/sci/parser/vocabulary.cpp
+++ b/engines/sci/parser/vocabulary.cpp
@@ -219,7 +219,7 @@ bool Vocabulary::loadSuffixes() {
 
 		int maxSize = resource->size() - seeker;
 		suffix.alt_suffix = (const char *)resource->getUnsafeDataAt(seeker, maxSize);
-		suffix.alt_suffix_length = Common::strnlen(suffix.alt_suffix, maxSize);
+		suffix.alt_suffix_length = scumm_strnlen(suffix.alt_suffix, maxSize);
 		if (suffix.alt_suffix_length == maxSize) {
 			error("Vocabulary alt from %s appears truncated for suffix %d at %u", resource->name().c_str(), _parserSuffixes.size(), seeker);
 		}
@@ -239,7 +239,7 @@ bool Vocabulary::loadSuffixes() {
 
 		maxSize = resource->size() - seeker;
 		suffix.word_suffix = (const char *)resource->getUnsafeDataAt(seeker, maxSize);
-		suffix.word_suffix_length = Common::strnlen(suffix.word_suffix, maxSize);
+		suffix.word_suffix_length = scumm_strnlen(suffix.word_suffix, maxSize);
 		if (suffix.word_suffix_length == maxSize) {
 			error("Vocabulary word from %s appears truncated for suffix %d at %u", resource->name().c_str(), _parserSuffixes.size(), seeker);
 		}
@@ -314,7 +314,7 @@ bool Vocabulary::loadAltInputs() {
 		t._input = (const char *)&*it;
 
 		uint32 maxSize = end - it;
-		uint32 l = Common::strnlen(t._input, maxSize);
+		uint32 l = scumm_strnlen(t._input, maxSize);
 		if (l == maxSize) {
 			error("Alt input from %s appears truncated at %d", resource->name().c_str(), it - resource->cbegin());
 		}
@@ -323,7 +323,7 @@ bool Vocabulary::loadAltInputs() {
 
 		t._replacement = (const char *)&*it;
 		maxSize = end - it;
-		l = Common::strnlen(t._replacement, maxSize);
+		l = scumm_strnlen(t._replacement, maxSize);
 		if (l == maxSize) {
 			error("Alt input replacement from %s appears truncated at %d", resource->name().c_str(), it - resource->cbegin());
 		}
@@ -380,9 +380,9 @@ bool Vocabulary::checkAltInput(Common::String &text, uint16 &cursorPos) {
 					// replace
 					const uint32 maxSize = text.size() - cursorPos;
 					if (cursorPos > p + i->_inputLength) {
-						cursorPos += Common::strnlen(i->_replacement, maxSize) - i->_inputLength;
+						cursorPos += scumm_strnlen(i->_replacement, maxSize) - i->_inputLength;
 					} else if (cursorPos > p) {
-						cursorPos = p + Common::strnlen(i->_replacement, maxSize);
+						cursorPos = p + scumm_strnlen(i->_replacement, maxSize);
 					}
 
 					for (uint32 j = 0; j < i->_inputLength; ++j)

--- a/engines/scumm/gfx_gui.cpp
+++ b/engines/scumm/gfx_gui.cpp
@@ -1483,8 +1483,8 @@ void ScummEngine::queryQuit(bool returnToLauncher) {
 
 	convertMessageToString((const byte *)getGUIString(gsQuitPrompt), (byte *)msgLabelPtr, sizeof(msgLabelPtr));
 	if (msgLabelPtr[0] != '\0') {
-		localizedYesKey = msgLabelPtr[Common::strnlen(msgLabelPtr, sizeof(msgLabelPtr)) - 1];
-		msgLabelPtr[Common::strnlen(msgLabelPtr, sizeof(msgLabelPtr)) - 1] = '\0';
+		localizedYesKey = msgLabelPtr[scumm_strnlen(msgLabelPtr, sizeof(msgLabelPtr)) - 1];
+		msgLabelPtr[scumm_strnlen(msgLabelPtr, sizeof(msgLabelPtr)) - 1] = '\0';
 
 		_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, true);
 
@@ -1521,8 +1521,8 @@ void ScummEngine::queryRestart() {
 
 	convertMessageToString((const byte *)getGUIString(gsRestart), (byte *)msgLabelPtr, sizeof(msgLabelPtr));
 	if (msgLabelPtr[0] != '\0') {
-		localizedYesKey = msgLabelPtr[Common::strnlen(msgLabelPtr, sizeof(msgLabelPtr)) - 1];
-		msgLabelPtr[Common::strnlen(msgLabelPtr, sizeof(msgLabelPtr)) - 1] = '\0';
+		localizedYesKey = msgLabelPtr[scumm_strnlen(msgLabelPtr, sizeof(msgLabelPtr)) - 1];
+		msgLabelPtr[scumm_strnlen(msgLabelPtr, sizeof(msgLabelPtr)) - 1] = '\0';
 
 		_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, true);
 
@@ -1614,8 +1614,8 @@ bool ScummEngine::canWriteGame(int slotId) {
 			Common::strlcpy(msgLabelPtr, "Do you want to replace this saved game?  (Y/N)Y", sizeof(msgLabelPtr));
 		}
 
-		localizedYesKey = msgLabelPtr[Common::strnlen(msgLabelPtr, sizeof(msgLabelPtr)) - 1];
-		msgLabelPtr[Common::strnlen(msgLabelPtr, sizeof(msgLabelPtr)) - 1] = '\0';
+		localizedYesKey = msgLabelPtr[scumm_strnlen(msgLabelPtr, sizeof(msgLabelPtr)) - 1];
+		msgLabelPtr[scumm_strnlen(msgLabelPtr, sizeof(msgLabelPtr)) - 1] = '\0';
 
 		_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, true);
 
@@ -2106,7 +2106,7 @@ bool ScummEngine::executeMainMenuOperationSegaCD(int op, int mouseX, int mouseY,
 	case GUI_CTRL_NUMPAD_BACK:
 	{
 		int inputNum = (op == GUI_CTRL_NUMPAD_0) ? 0 : op;
-		uint curIdx = Common::strnlen(_mainMenuSegaCDPasscode, sizeof(_mainMenuSegaCDPasscode));
+		uint curIdx = scumm_strnlen(_mainMenuSegaCDPasscode, sizeof(_mainMenuSegaCDPasscode));
 
 		if (op == GUI_CTRL_NUMPAD_BACK) {
 			if (curIdx > 0) {

--- a/engines/supernova/supernova.cpp
+++ b/engines/supernova/supernova.cpp
@@ -262,7 +262,7 @@ void SupernovaEngine::renderRoom(Room &room) {
 }
 
 void SupernovaEngine::renderMessage(const char *text, MessagePosition position) {
-	_gm->_messageDuration = (Common::strnlen(text, 512) + 20) * _textSpeed / 10;
+	_gm->_messageDuration = (scumm_strnlen(text, 512) + 20) * _textSpeed / 10;
 	_screen->renderMessage(text, position);
 }
 

--- a/engines/supernova/supernova1/rooms.cpp
+++ b/engines/supernova/supernova1/rooms.cpp
@@ -4166,7 +4166,7 @@ void Outro::animate(int filenumber, int section1, int section2, int duration) {
 void Outro::animate(int filenumber, int section1, int section2, int duration,
 					MessagePosition position, const char *text) {
 	_vm->renderMessage(text, position);
-	int delay = (Common::strnlen(text, 512) + 20) * (10 - duration) * _vm->_textSpeed / 400;
+	int delay = (scumm_strnlen(text, 512) + 20) * (10 - duration) * _vm->_textSpeed / 400;
 	_vm->setCurrentImage(filenumber);
 	while (delay) {
 		if (section1)
@@ -4184,7 +4184,7 @@ void Outro::animate(int filenumber, int section1, int section2, int section3, in
 					int duration, MessagePosition position, const char *text) {
 	_vm->renderMessage(text, position);
 	if (duration == 0)
-		duration = (Common::strnlen(text, 512) + 20) * _vm->_textSpeed / 40;
+		duration = (scumm_strnlen(text, 512) + 20) * _vm->_textSpeed / 40;
 
 	_vm->setCurrentImage(filenumber);
 	while(duration) {

--- a/engines/ultima/nuvie/misc/u6_misc.cpp
+++ b/engines/ultima/nuvie/misc/u6_misc.cpp
@@ -135,7 +135,7 @@ bool find_path(Std::string path, Std::string &dir_str) {
 
 	for (item = readdir(dir); item != NULL; item = readdir(dir)) {
 		debug("trying %s, want %s", item->d_name, dir_str.c_str());
-		if (strlen(item->d_name) == dir_str.length() && Common::scumm_stricmp(item->d_name, dir_str.c_str()) == 0) {
+		if (strlen(item->d_name) == dir_str.length() && scumm_stricmp(item->d_name, dir_str.c_str()) == 0) {
 			dir_str = item->d_name;
 			return true;
 		}

--- a/test/common/str.h
+++ b/test/common/str.h
@@ -434,27 +434,27 @@ class StringTestSuite : public CxxTest::TestSuite
 		TS_ASSERT_EQUALS(strcmp(test4, resultString), 0);
 	}
 
-	void test_strnlen() {
+	void test_scumm_strnlen() {
 		static const char * const testString = "123";
-		TS_ASSERT_EQUALS(Common::strnlen(testString, 0), 0u);
-		TS_ASSERT_EQUALS(Common::strnlen(testString, 1), 1u);
-		TS_ASSERT_EQUALS(Common::strnlen(testString, 2), 2u);
-		TS_ASSERT_EQUALS(Common::strnlen(testString, 3), 3u);
-		TS_ASSERT_EQUALS(Common::strnlen(testString, 4), 3u);
+		TS_ASSERT_EQUALS(scumm_strnlen(testString, 0), 0u);
+		TS_ASSERT_EQUALS(scumm_strnlen(testString, 1), 1u);
+		TS_ASSERT_EQUALS(scumm_strnlen(testString, 2), 2u);
+		TS_ASSERT_EQUALS(scumm_strnlen(testString, 3), 3u);
+		TS_ASSERT_EQUALS(scumm_strnlen(testString, 4), 3u);
 
 		const char testArray[4] = { '1', '2', '3', '4' };
-		TS_ASSERT_EQUALS(Common::strnlen(testArray, 0), 0u);
-		TS_ASSERT_EQUALS(Common::strnlen(testArray, 1), 1u);
-		TS_ASSERT_EQUALS(Common::strnlen(testArray, 2), 2u);
-		TS_ASSERT_EQUALS(Common::strnlen(testArray, 3), 3u);
-		TS_ASSERT_EQUALS(Common::strnlen(testArray, 4), 4u);
+		TS_ASSERT_EQUALS(scumm_strnlen(testArray, 0), 0u);
+		TS_ASSERT_EQUALS(scumm_strnlen(testArray, 1), 1u);
+		TS_ASSERT_EQUALS(scumm_strnlen(testArray, 2), 2u);
+		TS_ASSERT_EQUALS(scumm_strnlen(testArray, 3), 3u);
+		TS_ASSERT_EQUALS(scumm_strnlen(testArray, 4), 4u);
 
 		const char testArray2[4] = { '1', '\0', '3', '4' };
-		TS_ASSERT_EQUALS(Common::strnlen(testArray2, 0), 0u);
-		TS_ASSERT_EQUALS(Common::strnlen(testArray2, 1), 1u);
-		TS_ASSERT_EQUALS(Common::strnlen(testArray2, 2), 1u);
-		TS_ASSERT_EQUALS(Common::strnlen(testArray2, 3), 1u);
-		TS_ASSERT_EQUALS(Common::strnlen(testArray2, 4), 1u);
+		TS_ASSERT_EQUALS(scumm_strnlen(testArray2, 0), 0u);
+		TS_ASSERT_EQUALS(scumm_strnlen(testArray2, 1), 1u);
+		TS_ASSERT_EQUALS(scumm_strnlen(testArray2, 2), 1u);
+		TS_ASSERT_EQUALS(scumm_strnlen(testArray2, 3), 1u);
+		TS_ASSERT_EQUALS(scumm_strnlen(testArray2, 4), 1u);
 	}
 
 	void test_scumm_stricmp() {


### PR DESCRIPTION
`strnlen` is a non-portable POSIX.1-2008 function: we already have a wrapper for it in `common/str.h`, but there's no `common/forbidden.h` "poison" for the libc symbol, so it sometimes sneaks in (see commits 818194e8cf03a0115faa0b028080ffb2a474d11e, a029ea203e54eb29e40b9d3c65516b6311e97686) and causes build errors on the OSX 10.4/10.5 port that I maintain.

Having an early check for it should help making sure that we always use our own implementation, but the `forbidden.h` trick means that it must be renamed to `scumm_strnlen` and moved out of the `Common` namespace (as done for the other `scumm_str*` reimplementations).

(This also fixes some lines/comments mentioning that those `scumm_str*` wrappers are part of the Common namespace, which is not true for them.)

Any objection?