### PR TITLE
GUI: Account for the scroll bar size in ScrollContainerWidget objects

### DIFF
--- a/backends/keymapper/remap-widget.cpp
+++ b/backends/keymapper/remap-widget.cpp
@@ -104,7 +104,7 @@ void RemapWidget::reflowActionWidgets() {
 	int spacing = g_gui.xmlEval()->getVar("Globals.KeyMapper.Spacing");
 	int keyButtonWidth = g_gui.xmlEval()->getVar("Globals.KeyMapper.ButtonWidth");
 	int resetButtonWidth = g_gui.xmlEval()->getVar("Globals.KeyMapper.ResetWidth");
-	int labelWidth = widgetsBoss()->getWidth() - (spacing + keyButtonWidth + spacing);
+	int labelWidth = getWidth() - (spacing + keyButtonWidth + spacing);
 	labelWidth = MAX(0, labelWidth);
 
 	uint textYOff = (buttonHeight - kLineHeight) / 2;
@@ -121,7 +121,7 @@ void RemapWidget::reflowActionWidgets() {
 
 			// Insert a keymap separator
 			uint descriptionX = 2 * spacing + keyButtonWidth;
-			uint resetX = widgetsBoss()->getWidth() - spacing - resetButtonWidth;
+			uint resetX = getWidth() - spacing - resetButtonWidth;
 
 			KeymapTitleRow keymapTitle = _keymapSeparators[row.keymap];
 			if (keymapTitle.descriptionText) {

--- a/gui/ThemeEval.cpp
+++ b/gui/ThemeEval.cpp
@@ -103,6 +103,12 @@ ThemeEval &ThemeEval::addWidget(const Common::String &name, const Common::String
 									typeH == -1 ? h : typeH,
 									typeAlign == Graphics::kTextAlignInvalid ? align : typeAlign,
 									getVar("Globals.TabWidget.Tab.Height", 0));
+	else if (type == "ScrollContainerWidget")
+		widget = new ThemeLayoutScrollContainerWidget(_curLayout.top(), name,
+									typeW == -1 ? w : typeW,
+									typeH == -1 ? h : typeH,
+									typeAlign == Graphics::kTextAlignInvalid ? align : typeAlign,
+									getVar("Globals.Scrollbar.Width", 0));
 	else
 		widget = new ThemeLayoutWidget(_curLayout.top(), name,
 									typeW == -1 ? w : typeW,

--- a/gui/ThemeLayout.h
+++ b/gui/ThemeLayout.h
@@ -50,6 +50,7 @@ public:
 		kLayoutHorizontal,
 		kLayoutWidget,
 		kLayoutTabWidget,
+		kLayoutScrollContainerWidget,
 		kLayoutSpace
 	};
 
@@ -280,6 +281,40 @@ protected:
 
 	ThemeLayout *makeClone(ThemeLayout *newParent) override {
 		ThemeLayoutTabWidget *n = new ThemeLayoutTabWidget(*this);
+		n->_parent = newParent;
+		return n;
+	}
+};
+
+class ThemeLayoutScrollContainerWidget : public ThemeLayoutWidget {
+	int _scrollWidth;
+
+public:
+	ThemeLayoutScrollContainerWidget(ThemeLayout *p, const Common::String &name, int16 w, int16 h, Graphics::TextAlign align, int scrollWidth):
+		ThemeLayoutWidget(p, name, w, h, align, p->getUseRTL()) {
+		_scrollWidth = scrollWidth;
+	}
+
+	void reflowLayout(Widget *widgetChain) override {
+		for (uint i = 0; i < _children.size(); ++i) {
+			_children[i]->reflowLayout(widgetChain);
+		}
+	}
+
+	bool getWidgetData(const Common::String &name, int16 &x, int16 &y, int16 &w, int16 &h, bool &useRTL) override {
+		if (ThemeLayoutWidget::getWidgetData(name, x, y, w, h, useRTL)) {
+			w -= _scrollWidth;
+			return true;
+		}
+
+		return false;
+	}
+
+protected:
+	LayoutType getLayoutType() const override { return kLayoutScrollContainerWidget; }
+
+	ThemeLayout *makeClone(ThemeLayout *newParent) override {
+		ThemeLayoutScrollContainerWidget *n = new ThemeLayoutScrollContainerWidget(*this);
 		n->_parent = newParent;
 		return n;
 	}

--- a/gui/themes/common/highres_layout.stx
+++ b/gui/themes/common/highres_layout.stx
@@ -459,7 +459,9 @@
 
 	<dialog name = 'GlobalOptions_Graphics' overlays = 'Dialog.GlobalOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 	<dialog name = 'GlobalOptions_Graphics_Container' overlays = 'GlobalOptions_Graphics.Container'>
@@ -778,7 +780,9 @@
 
 	<dialog name = 'GlobalOptions_Misc' overlays = 'Dialog.GlobalOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 
@@ -868,7 +872,9 @@
 
 	<dialog name = 'GlobalOptions_Cloud' overlays = 'Dialog.GlobalOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 
@@ -1275,13 +1281,17 @@
 
 	<dialog name = 'GameOptions_Achievements' overlays = 'Dialog.GameOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 
 	<dialog name = 'GameOptions_Graphics' overlays = 'Dialog.GameOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 	<dialog name = 'GameOptions_Graphics_Container' overlays = 'GameOptions_Graphics.Container'>
@@ -1569,7 +1579,9 @@
 
 	<dialog name = 'GlobalConfig_Achievements' overlays = 'Dialog.GlobalConfig.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 
@@ -2118,6 +2130,7 @@
 	<dialog name = 'UnknownGameDialog' overlays = 'Dialog.Launcher.GameList' shading = 'dim'>
 		<layout type = 'vertical' padding = '8, 8, 8, 0'>
 			<widget name = 'TextContainer'
+					type = 'ScrollContainerWidget'
 			/>
 			<layout type = 'horizontal' padding = '0, 0, 16, 16'>
 				<space/>

--- a/gui/themes/common/lowres_layout.stx
+++ b/gui/themes/common/lowres_layout.stx
@@ -398,7 +398,9 @@
 
 	<dialog name = 'GlobalOptions_Graphics' overlays = 'Dialog.GlobalOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 	<dialog name = 'GlobalOptions_Graphics_Container' overlays = 'GlobalOptions_Graphics.Container'>
@@ -716,7 +718,9 @@
 
 	<dialog name = 'GlobalOptions_Misc' overlays = 'Dialog.GlobalOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 
@@ -816,7 +820,9 @@
 
 	<dialog name = 'GlobalOptions_Cloud' overlays = 'Dialog.GlobalOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 
@@ -1206,13 +1212,17 @@
 
 	<dialog name = 'GameOptions_Achievements' overlays = 'Dialog.GameOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 
 	<dialog name = 'GameOptions_Graphics' overlays = 'Dialog.GameOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 	<dialog name = 'GameOptions_Graphics_Container' overlays = 'GameOptions_Graphics.Container'>
@@ -1509,7 +1519,9 @@
 
 	<dialog name = 'GlobalConfig_Achievements' overlays = 'Dialog.GlobalConfig.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 
@@ -2037,6 +2049,7 @@
 	<dialog name = 'UnknownGameDialog' overlays = 'screen' inset = '8' shading = 'dim'>
 		<layout type = 'vertical' padding = '8, 8, 8, 0'>
 			<widget name = 'TextContainer'
+					type = 'ScrollContainerWidget'
 			/>
 			<layout type = 'horizontal' padding = '0, 0, 8, 8'>
 				<space/>

--- a/gui/themes/scummclassic/classic_layout.stx
+++ b/gui/themes/scummclassic/classic_layout.stx
@@ -311,7 +311,9 @@
 
 	<dialog name = 'GlobalOptions_Graphics' overlays = 'Dialog.GlobalOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 	<dialog name = 'GlobalOptions_Graphics_Container' overlays = 'GlobalOptions_Graphics.Container'>
@@ -630,7 +632,9 @@
 
 	<dialog name = 'GlobalOptions_Misc' overlays = 'Dialog.GlobalOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 
@@ -720,7 +724,9 @@
 
 	<dialog name = 'GlobalOptions_Cloud' overlays = 'Dialog.GlobalOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 
@@ -1112,13 +1118,17 @@
 
 	<dialog name = 'GameOptions_Achievements' overlays = 'Dialog.GameOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 
 	<dialog name = 'GameOptions_Graphics' overlays = 'Dialog.GameOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 	<dialog name = 'GameOptions_Graphics_Container' overlays = 'GameOptions_Graphics.Container'>
@@ -1406,7 +1416,9 @@
 
 	<dialog name = 'GlobalConfig_Achievements' overlays = 'Dialog.GlobalConfig.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 
@@ -1953,6 +1965,7 @@
 	<dialog name = 'UnknownGameDialog' overlays = 'Dialog.Launcher.GameList' shading = 'dim'>
 		<layout type = 'vertical' padding = '8, 8, 8, 0'>
 			<widget name = 'TextContainer'
+					type = 'ScrollContainerWidget'
 			/>
 			<layout type = 'horizontal' padding = '0, 0, 16, 16'>
 				<space/>

--- a/gui/themes/scummclassic/classic_layout_lowres.stx
+++ b/gui/themes/scummclassic/classic_layout_lowres.stx
@@ -320,7 +320,9 @@
 
 	<dialog name = 'GlobalOptions_Graphics' overlays = 'Dialog.GlobalOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 	<dialog name = 'GlobalOptions_Graphics_Container' overlays = 'GlobalOptions_Graphics.Container'>
@@ -638,7 +640,9 @@
 
 	<dialog name = 'GlobalOptions_Misc' overlays = 'Dialog.GlobalOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 
@@ -738,7 +742,9 @@
 
 	<dialog name = 'GlobalOptions_Cloud' overlays = 'Dialog.GlobalOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 
@@ -1127,13 +1133,17 @@
 
 	<dialog name = 'GameOptions_Achievements' overlays = 'Dialog.GameOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 
 	<dialog name = 'GameOptions_Graphics' overlays = 'Dialog.GameOptions.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 	<dialog name = 'GameOptions_Graphics_Container' overlays = 'GameOptions_Graphics.Container'>
@@ -1429,7 +1439,9 @@
 
 	<dialog name = 'GlobalConfig_Achievements' overlays = 'Dialog.GlobalConfig.TabWidget'>
 		<layout type = 'vertical' padding = '0, 0, 0, 0'>
-			<widget name = 'Container'/>
+			<widget name = 'Container'
+					type = 'ScrollContainerWidget'
+			/>
 		</layout>
 	</dialog>
 
@@ -1936,6 +1948,7 @@
 	<dialog name = 'UnknownGameDialog' overlays = 'screen' inset = '8' shading = 'dim'>
 		<layout type = 'vertical' padding = '8, 8, 8, 0'>
 			<widget name = 'TextContainer'
+					type = 'ScrollContainerWidget'
 			/>
 			<layout type = 'horizontal' padding = '0, 0, 8, 8'>
 				<space/>

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -163,7 +163,7 @@ void Widget::draw() {
 Widget *Widget::findWidgetInChain(Widget *w, int x, int y) {
 	while (w) {
 		// Stop as soon as we find a widget that contains the point (x,y)
-		if (x >= w->_x && x < w->_x + w->_w && y >= w->_y && y < w->_y + w->getHeight())
+		if (x >= w->_x && x < w->_x + w->getWidth() && y >= w->_y && y < w->_y + w->getHeight())
 			break;
 		w = w->_next;
 	}

--- a/gui/widgets/scrollcontainer.h
+++ b/gui/widgets/scrollcontainer.h
@@ -31,6 +31,7 @@ namespace GUI {
 class ScrollContainerWidget: public Widget, public CommandSender {
 	ScrollBarWidget *_verticalScroll;
 	int16 _scrolledX, _scrolledY;
+	int _scrollbarWidth;
 	uint16 _limitH;
 	uint32 _reflowCmd;
 	ThemeEngine::WidgetBackground _backgroundType;
@@ -49,8 +50,6 @@ public:
 
 	bool containsWidget(Widget *) const override;
 
-	Common::Rect getClipRect() const override;
-
 	void setBackgroundType(ThemeEngine::WidgetBackground backgroundType);
 
 	void handleMouseWheel(int x, int y, int direction) override;
@@ -61,6 +60,9 @@ public:
 	int16	getChildY() const override;
 	uint16	getWidth() const override;
 	uint16	getHeight() const override;
+
+	void draw() override;
+	void markAsDirty() override;
 
 protected:
 	void drawWidget() override;


### PR DESCRIPTION
This currently works for `ScrollContainerWidget`s created using XML layouts, but not ones created using `TabWidget::addTab()` or `OptionsContainerWidget`.

Before:
![scummvm-00003](https://user-images.githubusercontent.com/19293424/209485276-5d0b122a-bf56-4ab0-a37d-7aa02e190be7.png)

After:
![scummvm-00001](https://user-images.githubusercontent.com/19293424/209485190-067a9acf-72e1-43fe-9a7c-134cb4f2b2fd.png)
