### PR TITLE
SCUMM: DIMUSE: Implement adaptive buffer underrun correction

### DIFF
--- a/engines/scumm/imuse_digi/dimuse_engine.h
+++ b/engines/scumm/imuse_digi/dimuse_engine.h
@@ -84,6 +84,8 @@ private:
 
 	bool _isEarlyDiMUSE;
 	bool _isEngineDisabled;
+	bool _checkForUnderrun;
+	int _underrunCooldown;
 
 	// These three are manipulated in the waveOut functions
 	uint8 *_outputAudioBuffer;
@@ -405,6 +407,7 @@ public:
 	int clampTuning(int value, int minValue, int maxValue);
 	int checkHookId(int &trackHookId, int sampleHookId);
 	int roundRobinSetBufferCount();
+	void adaptBufferCount();
 
 	// CMDs
 	int cmdsHandleCmd(int cmd, uint8 *ptr = nullptr,


### PR DESCRIPTION
Posting this as a PR since I'm touching the AUDIO subsystem 🙂 

After a long and painful history of me manually setting the "optimal" value for the number of stream buffers in the queue for DiMUSE games, and after getting a new Android phone which showed me that I still could get audio stutters 🙂, I decided to implement a routine for an adaptive buffer underrun correction. 

This was tested on Windows 10 and Ubuntu 21.10, but testers for different platforms are very welcome! (e.g. other Android devices, AmigaOS, MacOS, etc.)