### PR TITLE
NEVERHOOD: Remove "Chronicles" from detection entry

### DIFF
--- a/engines/neverhood/detection.cpp
+++ b/engines/neverhood/detection.cpp
@@ -28,7 +28,7 @@
 #include "neverhood/detection.h"
 
 static const PlainGameDescriptor neverhoodGames[] = {
-	{"neverhood", "The Neverhood Chronicles"},
+	{"neverhood", "The Neverhood"},
 	{nullptr, nullptr}
 };
 
@@ -142,11 +142,11 @@ public:
 	}
 
 	const char *getEngineName() const override {
-		return "The Neverhood Chronicles";
+		return "The Neverhood";
 	}
 
 	const char *getOriginalCopyright() const override {
-		return "The Neverhood Chronicles (C) The Neverhood, Inc.";
+		return "The Neverhood (C) The Neverhood, Inc.";
 	}
 };
 


### PR DESCRIPTION
Opening a PR for this because I don't know if it's related to copyright or something else.
The game title screen is indeed "The Neverhood Chronicles", but that title is never used anywhere
(boxart, manual, mobygames...) so it seems appropriate to just use "The Neverhood" for the
detection entry.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
