### PR TITLE
BURIED: Clear _controlDown flag on GUI windows opening

### DIFF
--- a/engines/buried/buried.cpp
+++ b/engines/buried/buried.cpp
@@ -504,6 +504,10 @@ void BuriedEngine::pollForEvents() {
 			window->postMessage(new RButtonUpMessage(window->convertPointToLocal(event.mouse), 0));
 			break;
 		}
+		case Common::EVENT_MAINMENU: {
+			((FrameWindow *)_mainWindow)->_controlDown = false;
+			break;
+		}
 		default:
 			break;
 		}

--- a/engines/buried/gameui.cpp
+++ b/engines/buried/gameui.cpp
@@ -311,6 +311,7 @@ void GameUIWindow::onKeyUp(const Common::KeyState &key, uint flags) {
 	case Common::KEYCODE_s:
 		if ((key.flags & Common::KBD_CTRL) && cloakingDisabled && !interfaceMenuActive) {
 			_vm->handleSaveDialog();
+			((FrameWindow *)_vm->_mainWindow)->_controlDown = false;
 		} else if (_sceneViewWindow)
 			_sceneViewWindow->sendMessage(new KeyUpMessage(key, flags));
 		break;
@@ -318,13 +319,15 @@ void GameUIWindow::onKeyUp(const Common::KeyState &key, uint flags) {
 	case Common::KEYCODE_l:
 		if ((key.flags & Common::KBD_CTRL) && cloakingDisabled && !interfaceMenuActive) {
 			_vm->handleRestoreDialog();
+			((FrameWindow *)_vm->_mainWindow)->_controlDown = false;
 		} else if (_sceneViewWindow)
 			_sceneViewWindow->sendMessage(new KeyUpMessage(key, flags));
 		break;
 	case Common::KEYCODE_p:
-		if ((key.flags & Common::KBD_CTRL) && cloakingDisabled && !interfaceMenuActive)
+		if ((key.flags & Common::KBD_CTRL) && cloakingDisabled && !interfaceMenuActive) {
 			_vm->pauseGame();
-		else if (_sceneViewWindow)
+			((FrameWindow *)_vm->_mainWindow)->_controlDown = false;
+		} else if (_sceneViewWindow)
 			_sceneViewWindow->sendMessage(new KeyUpMessage(key, flags));
 		break;
 	default:

--- a/engines/buried/scene_view.cpp
+++ b/engines/buried/scene_view.cpp
@@ -2296,6 +2296,7 @@ void SceneViewWindow::onKeyUp(const Common::KeyState &key, uint flags) {
 			// Return to main menu
 			if (_vm->runQuitDialog())
 				((FrameWindow *)_vm->_mainWindow)->showMainMenu();
+			((FrameWindow *)_vm->_mainWindow)->_controlDown = false;
 			return;
 		}
 		break;
@@ -2304,6 +2305,7 @@ void SceneViewWindow::onKeyUp(const Common::KeyState &key, uint flags) {
 			// Current points (ScummVM enhancement - Agent evaluation
 			// from death screens)
 			_vm->showPoints();
+			((FrameWindow *)_vm->_mainWindow)->_controlDown = false;
 			return;
 		}
 		break;


### PR DESCRIPTION
The controlDown boolean is used to check if the CTRL key is pressed, thus
enabling "fast mode". But the status is only updated on key release, meaning
that combinations using CTRL that open GUI windows (GMM and others specific to the engine)
leave the game in this state (unless the player presses another key).
The PR clears the flag when opening these windows and on MAINMENU event.

NOTE: There is a borderline not-working case when the player attempts to quit using CTRL-Z
and exit confirmation is enabled.

fixes TRAC #13584

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
