### PR TITLE
AGS: Fix mousepress not being tracked

### DIFF
--- a/engines/ags/engine/ac/sys_events.cpp
+++ b/engines/ags/engine/ac/sys_events.cpp
@@ -166,6 +166,7 @@ static eAGSMouseButton mgetbutton() {
 	if ((butis > 0) & (_G(butwas) > 0))
 		return kMouseNone;  // don't allow holding button down
 
+	_G(butwas) = butis;
 	if (butis & MouseBitLeft)
 		return kMouseLeft;
 	else if (butis & MouseBitRight)


### PR DESCRIPTION
When incorporating commits from upstream, it seems this line was left out (not on purpose, I think).
This causes the "repeated mouseclicks" and lines skipping reported in bugs [13894](https://bugs.scummvm.org/ticket/13894), [13988](https://bugs.scummvm.org/ticket/13988), [13994](https://bugs.scummvm.org/ticket/13994)

The related commit is (https://github.com/scummvm/scummvm/commit/5987bc5e6e01c22ee2bd1c1d86fa32e28230de78)
from upstream (https://github.com/adventuregamestudio/ags/commit/471098d239b076c494beb2d554572ccb69372667)

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
