### PR TITLE
Improve usage of Advanced detector for Mac case

### DIFF
--- a/engines/composer/composer.cpp
+++ b/engines/composer/composer.cpp
@@ -93,6 +93,17 @@ Common::Error ComposerEngine::run() {
 		_directoriesToStrip = 0;
 	}
 
+	if (getPlatform() == Common::kPlatformMacintosh) {
+		const Common::FSNode gameDataDir(ConfMan.get("path"));
+		if (gameId == "sleepingcub")
+			SearchMan.addSubDirectoryMatching(gameDataDir, "sleepcub");
+		if (gameId == "princess")
+			SearchMan.addSubDirectoryMatching(gameDataDir, "princess");
+		if (gameId == "liam")
+			SearchMan.addSubDirectoryMatching(gameDataDir, "liam");
+
+	}
+
 	uint width = 640;
 	if (_bookIni.hasKey("Width", "Common"))
 		width = atoi(getStringFromConfig("Common", "Width").c_str());

--- a/engines/composer/detection_tables.h
+++ b/engines/composer/detection_tables.h
@@ -45,8 +45,8 @@ static const ComposerGameDescription gameDescriptions[] = {
 			"babayaga",
 			0,
 			{
-				{"book.mac", GAME_CONFIGFILE, "d82143cbc4a36093250c7d6f80af1147", -1},
-  				{"Baba Yaga", GAME_EXECUTABLE, "ae3a4445f42fe10253da7ee4ea0d37d6", 44321},
+				{"book.mac", GAME_CONFIGFILE, "d:d82143cbc4a36093250c7d6f80af1147", 1877},
+				{"Baba Yaga", GAME_EXECUTABLE, "d:ae3a4445f42fe10253da7ee4ea0d37d6", 44321},
 				AD_LISTEND
 			},
 			Common::EN_ANY,
@@ -148,12 +148,12 @@ static const ComposerGameDescription gameDescriptions[] = {
 			"imoking",
 			0,
 			{
-				{"book.mac", GAME_CONFIGFILE, "d09a628d147506be1dee854bc9f66664", 102},
+				{"book.mac", GAME_CONFIGFILE, "d:4896a22874bb660f5ba26a0af111f9c0", 1868},
 				AD_LISTEND
 			},
 			Common::HE_ISR,
 			Common::kPlatformMacintosh,
-			ADGF_MACRESFORK,
+			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOASPECT, GUIO_NOMIDI)
 		},
 		GType_ComposerV1
@@ -199,12 +199,12 @@ static const ComposerGameDescription gameDescriptions[] = {
 			"babayaga",
 			"Magic Tales: Baba Yaga and the Magic Geese Demo",
 			{
-				{"book.mac", GAME_CONFIGFILE, "a4a125f0d000ad4ea8f33a10b1dbab2a", 76},
+				{"book.mac", GAME_CONFIGFILE, "d:ed4a902df3b26d58e9c013f814a30ee8", 134},
 				AD_LISTEND
 			},
 			Common::EN_ANY,
 			Common::kPlatformMacintosh,
-			ADGF_USEEXTRAASTITLE | ADGF_MACRESFORK | ADGF_DEMO,
+			ADGF_USEEXTRAASTITLE | ADGF_DEMO,
 			GUIO2(GUIO_NOASPECT, GUIO_NOMIDI)
 		},
 		GType_ComposerV1
@@ -216,12 +216,12 @@ static const ComposerGameDescription gameDescriptions[] = {
 			"littlesamurai",
 			"Magic Tales: The Little Samurai Demo",
 			{
-				{"book.mac", GAME_CONFIGFILE, "1593836491edb4a5d68354c072bf729d", 76},
+				{"book.mac", GAME_CONFIGFILE, "d:57a82d563800001ed88b2742c3650a2d", 136},
 				AD_LISTEND
 			},
 			Common::EN_ANY,
 			Common::kPlatformMacintosh,
-			ADGF_USEEXTRAASTITLE | ADGF_MACRESFORK | ADGF_DEMO,
+			ADGF_USEEXTRAASTITLE | ADGF_DEMO,
 			GUIO2(GUIO_NOASPECT, GUIO_NOMIDI)
 		},
 		GType_ComposerV1
@@ -233,8 +233,8 @@ static const ComposerGameDescription gameDescriptions[] = {
 			"imoking",
 			0,
 			{
-				{"book.mac", GAME_CONFIGFILE, "190158751630f69c2b6cf146aa2f1efc", -1},
-				{"imo and the king", GAME_EXECUTABLE, "b0277885fec943b5f19409f35b33964c", -1},
+				{"book.mac", GAME_CONFIGFILE, "d:190158751630f69c2b6cf146aa2f1efc", 1874},
+				{"imo and the king", GAME_EXECUTABLE, "d:b0277885fec943b5f19409f35b33964c", 44242},
 				AD_LISTEND
 			},
 			Common::EN_ANY,
@@ -320,8 +320,8 @@ static const ComposerGameDescription gameDescriptions[] = {
 			"littlesamurai",
 			0,
 			{
-				{"book.mac", GAME_CONFIGFILE, "190158751630f69c2b6cf146aa2f1efc", -1},
-				{"The Little Samurai", GAME_EXECUTABLE, "38121dd649c24e8676aa108cf35d44b5", -1},
+				{"book.mac", GAME_CONFIGFILE, "d:190158751630f69c2b6cf146aa2f1efc", 1874},
+				{"The Little Samurai", GAME_EXECUTABLE, "d:38121dd649c24e8676aa108cf35d44b5", 44128},
 				AD_LISTEND
 			},
 			Common::EN_ANY,
@@ -355,12 +355,12 @@ static const ComposerGameDescription gameDescriptions[] = {
 			"littlesamurai",
 			0,
 			{
-				{"book.mac", GAME_CONFIGFILE, "542f47cac09a903d34ac7f3e62400a64", 76},
+				{"book.mac", GAME_CONFIGFILE, "d:190158751630f69c2b6cf146aa2f1efc", 1874},
 				AD_LISTEND
 			},
 			Common::HE_ISR,
 			Common::kPlatformMacintosh,
-			ADGF_MACRESFORK,
+			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOASPECT, GUIO_NOMIDI)
 		},
 		GType_ComposerV1
@@ -406,12 +406,12 @@ static const ComposerGameDescription gameDescriptions[] = {
 			"magictales",
 			"Magic Tales Demo: Baba Yaga, Samurai, Imo",
 			{
-				{"demo.mac", GAME_CONFIGFILE, "240fc2fbbc2a1a915e0adabde98b4a12", 404},
+				{"demo.mac", GAME_CONFIGFILE, "d:6e775cda6539102d1ddee852bebf32c1", 488},
 				AD_LISTEND
 			},
 			Common::HE_ISR,
 			Common::kPlatformMacintosh,
-			ADGF_USEEXTRAASTITLE | ADGF_MACRESFORK | ADGF_DEMO,
+			ADGF_USEEXTRAASTITLE | ADGF_DEMO,
 			GUIO2(GUIO_NOASPECT, GUIO_NOMIDI)
 		},
 		GType_ComposerV1
@@ -439,8 +439,8 @@ static const ComposerGameDescription gameDescriptions[] = {
 			"liam",
 			0,
 			{
-				{"liam finds a story.ini", GAME_CONFIGFILE, "85a1ca6002ded8572920bbdb73d35b0a", -1},
-				{"page99.rsc", GAME_SCRIPTFILE, "11b0a19c6b6d73c39e2bd289a457c1dc", -1},
+				{"liam finds a story.ini", GAME_CONFIGFILE, "d:85a1ca6002ded8572920bbdb73d35b0a", 747},
+				{"page99.rsc", GAME_SCRIPTFILE, "d:11b0a19c6b6d73c39e2bd289a457c1dc", 355159},
 				AD_LISTEND
 			},
 			Common::EN_ANY,
@@ -490,7 +490,7 @@ static const ComposerGameDescription gameDescriptions[] = {
 			"darby",
 			0,
 			{
-				{"Darby the Dragon.ini", GAME_CONFIGFILE, "d81f9214936fa70d42fc578908d4bb3d", -1},
+				{"Darby the Dragon.ini", GAME_CONFIGFILE, "d:d81f9214936fa70d42fc578908d4bb3d", 2950},
 				AD_LISTEND
 			},
 			Common::EN_ANY,
@@ -589,7 +589,7 @@ static const ComposerGameDescription gameDescriptions[] = {
 			"gregory",
 			0,
 			{
-				{"Gregory.ini", GAME_CONFIGFILE, "fa82f14731f28c7379c5a106df07a0d6", -1},
+				{"Gregory.ini", GAME_CONFIGFILE, "d:fa82f14731f28c7379c5a106df07a0d6", 2753},
 				AD_LISTEND
 			},
 			Common::EN_ANY,
@@ -656,8 +656,8 @@ static const ComposerGameDescription gameDescriptions[] = {
 			"princess",
 			0,
 			{
-				{"the princess and the crab.ini", GAME_CONFIGFILE, "f6b551a7304643004bd5e4df7ac1e76e", -1},
-				{"page99.rsc", GAME_SCRIPTFILE, "fd5ebd3b5e36c4651c50241619525355", -1},
+				{"the princess and the crab.ini", GAME_CONFIGFILE, "d:f6b551a7304643004bd5e4df7ac1e76e", 877},
+				{"page99.rsc", GAME_SCRIPTFILE, "d:fd5ebd3b5e36c4651c50241619525355", 45418},
 				AD_LISTEND
 			},
 			Common::EN_ANY,
@@ -691,8 +691,8 @@ static const ComposerGameDescription gameDescriptions[] = {
 			"sleepingcub",
 			0,
 			{
-				{"sleeping cub.ini", GAME_CONFIGFILE, "39642a4036cb51443f5e90052c3ad0b2", -1},
-				{"page99.rsc", GAME_SCRIPTFILE, "219fbd9bd2ff87c7023814405d753145", -1},
+				{"sleeping cub.ini", GAME_CONFIGFILE, "d:39642a4036cb51443f5e90052c3ad0b2", 877},
+				{"page99.rsc", GAME_SCRIPTFILE, "d:219fbd9bd2ff87c7023814405d753145", 46916},
 				AD_LISTEND
 			},
 			Common::EN_ANY,

--- a/engines/composer/detection_tables.h
+++ b/engines/composer/detection_tables.h
@@ -506,7 +506,8 @@ static const ComposerGameDescription gameDescriptions[] = {
 			"darby",
 			0,
 			{
-				{"page99.rsc", GAME_SCRIPTFILE, "ca350397f0c009649afc0cb6145921f0", 1286480},
+				{"page99.rsc", GAME_SCRIPTFILE, "d:ca350397f0c009649afc0cb6145921f0", 1286480},
+				{"Dragor le dragon.ini", GAME_CONFIGFILE, "d:b0ccebb50cf8377486d86cb65ee7215d", 2240},
 				AD_LISTEND
 			},
 			Common::FR_FRA,

--- a/engines/composer/detection_tables.h
+++ b/engines/composer/detection_tables.h
@@ -245,6 +245,24 @@ static const ComposerGameDescription gameDescriptions[] = {
 		GType_ComposerV1
 	},
 
+	// Magic Tales: Imo and the King Mac Demo from Baba Yaga CD
+	{
+		{
+			"imoking",
+			"Magic Tales: Imo and the King Demo",
+			{
+				{"book.mac", GAME_CONFIGFILE, "d:b3456692eab14e9bdac64db6dad27be9", 136},
+				{"imo and the king", GAME_EXECUTABLE, "d:764e0feea86cc201471f2b443161023b", 44321},
+				AD_LISTEND
+			},
+			Common::EN_ANY,
+			Common::kPlatformMacintosh,
+			ADGF_USEEXTRAASTITLE | ADGF_DEMO,
+			GUIO2(GUIO_NOASPECT, GUIO_NOMIDI)
+		},
+		GType_ComposerV1
+	},
+
 	// Magic Tales: Imo and the King German - from bug #10199
 	{
 		{

--- a/engines/composer/resource.cpp
+++ b/engines/composer/resource.cpp
@@ -26,6 +26,7 @@
 #include "common/substream.h"
 #include "common/util.h"
 #include "common/textconsole.h"
+#include "common/macresman.h"
 
 namespace Composer {
 
@@ -41,10 +42,10 @@ Archive::~Archive() {
 }
 
 bool Archive::openFile(const Common::String &fileName) {
-	Common::File *file = new Common::File();
+	Common::SeekableReadStream *file
+		= Common::MacResManager::openFileOrDataFork(fileName);
 
-	if (!file->open(fileName)) {
-		delete file;
+	if (!file) {
 		return false;
 	}
 

--- a/engines/composer/scripting.cpp
+++ b/engines/composer/scripting.cpp
@@ -24,6 +24,7 @@
 #include "composer/composer.h"
 #include "composer/graphics.h"
 #include "composer/resource.h"
+#include "common/macresman.h"
 
 namespace Composer {
 
@@ -616,8 +617,9 @@ int16 ComposerEngine::scriptFuncCall(uint16 id, int16 param1, int16 param2, int1
 			if (!_bookIni.hasKey(Common::String::format("%d", param1), "Data"))
 				return 0;
 			filename = getFilename("Data", param1);
-			Common::File *file = new Common::File();
-			if (!file->open(filename))
+			Common::SeekableReadStream *file =
+				Common::MacResManager::openFileOrDataFork(filename);
+			if (!file)
 				error("couldn't open '%s' to get vars id '%d'", filename.c_str(), param1);
 			stream = file;
 		}

--- a/engines/game.cpp
+++ b/engines/game.cpp
@@ -258,16 +258,20 @@ Common::U32String generateUnknownGameReport(const DetectedGames &detectedGames, 
 	Common::sort(filenames.begin(), filenames.end());
 	for (uint i = 0; i < filenames.size(); ++i) {
 		const FileProperties &file = matchedFiles[filenames[i]];
-		Common::String addon;
+		Common::String md5Prefix;
 
 		if (file.md5prop & kMD5MacResFork)
-			addon += ", ADGF_MACRESFORK";
+			md5Prefix += "r";
+		if (file.md5prop & kMD5MacDataFork)
+			md5Prefix += "d";
 		if (file.md5prop & kMD5Tail)
-			addon += ", ADGF_TAILMD5";
+			md5Prefix += "t";
+		if (!md5Prefix.empty())
+			md5Prefix += ":";
 
-		report += Common::String::format("  {\"%s\", 0, \"%s\", %lld}%s,\n",
-			Common::punycode_encodefilename(Common::U32String(&filenames[i].c_str()[2])).c_str(), // Skip the md5 prefix
-			file.md5.c_str(), (long long)file.size, addon.c_str());
+		report += Common::String::format("  {\"%s\", 0, \"%s%s\", %lld},\n",
+			Common::punycode_encodefilename(Common::U32String(strchr(filenames[i].c_str(), ':') + 1)).c_str(), // Skip the md5 prefix
+			md5Prefix.c_str(), file.md5.c_str(), (long long)file.size);
 	}
 
 	report += Common::U32String("\n");

--- a/engines/hadesch/detection_tables.h
+++ b/engines/hadesch/detection_tables.h
@@ -47,14 +47,14 @@ static const ADGameDescription gameDescriptions[] = {
 		"hadesch",
 		0,
 		{
-			{"Hades Challenge PPC", 0, "0a1dd550e5efe7f36370e689811fac73", 28945},
-			{"WD.POD", 0, "be7030fc4229e69e719ee2c756eb6ba1", 7479768},
-			{"ol.pod", 0, "7cabba8d1d4f1239e312e045ef4e9735", 5621074},
+			{"Hades Challenge PPC", 0, "r:0a1dd550e5efe7f36370e689811fac73", 28945},
+			{"WD.POD", 0, "d:be7030fc4229e69e719ee2c756eb6ba1", 7479768},
+			{"ol.pod", 0, "d:7cabba8d1d4f1239e312e045ef4e9735", 5621074},
 			AD_LISTEND
 		},
 		Common::EN_ANY,
 		Common::kPlatformMacintosh,
-		ADGF_DROPPLATFORM | ADGF_MACRESFORK,
+		ADGF_DROPPLATFORM,
 		GUIO1(GUIO_NOMIDI)
 
 	},

--- a/engines/kyra/detection_tables.h
+++ b/engines/kyra/detection_tables.h
@@ -316,10 +316,10 @@ const KYRAGameDescription adGameDescs[] = {
 		{
 			"kyra1",
 			"StuffIt multi-floppy",
-			AD_ENTRY1s("xn--Legend of Kyrandia Installer-o11r", "83d0f8e8c44a0aaa92b06081c40cd3c2", 69726),
+			AD_ENTRY1s("xn--Legend of Kyrandia Installer-o11r", "d:23ae9506979d844c29cccb40774e471e", 1363968),
 			Common::EN_ANY,
 			Common::kPlatformMacintosh,
-			ADGF_MACRESFORK,
+			ADGF_NO_FLAGS,
 			GUIO3(GUIO_NOSPEECH, GUIO_MIDIGM, GUIO_RENDERVGA)
 		},
 				KYRA1_FLOPPY_CMP_FLAGS
@@ -329,23 +329,10 @@ const KYRAGameDescription adGameDescs[] = {
 		{
 			"kyra1",
 			"StuffIt",
-			AD_ENTRY1s("xn--Install Legend of Kyrandia-jf8p", "1d763e991c787431cac3786afbbdae72", 53899),
+			AD_ENTRY1s("xn--Install Legend of Kyrandia-jf8p", "d:e279c397f46b0913abb5595e2cdce2ed", 10276153),
 			Common::EN_ANY,
 			Common::kPlatformMacintosh,
-			ADGF_MACRESFORK,
-			GUIO3(GUIO_NOSPEECH, GUIO_MIDIGM, GUIO_RENDERVGA)
-		},
-				KYRA1_FLOPPY_CMP_FLAGS
-	},
-
-	{
-		{
-			"kyra1",
-			"StuffIt",
-			AD_ENTRY1s("xn--Install Legend of Kyrandia-jf8p", "e279c397f46b0913abb5595e2cdce2ed", 10276153),
-			Common::EN_ANY,
-			Common::kPlatformMacintosh,
-			ADGF_MACRESFORK,
+			ADGF_NO_FLAGS,
 			GUIO3(GUIO_NOSPEECH, GUIO_MIDIGM, GUIO_RENDERVGA)
 		},
 		KYRA1_FLOPPY_CMP_FLAGS

--- a/engines/saga/detection_tables.h
+++ b/engines/saga/detection_tables.h
@@ -305,16 +305,16 @@ static const SAGAGameDescription gameDescriptions[] = {
 			"ite",
 			"CD",
 			{
-				{"ite resources",	GAME_RESOURCEFILE | GAME_MACBINARY,	"ee65f8e713127cf7f2d56371d2b8e63d", 2264},
-				{"ite scripts",		GAME_SCRIPTFILE | GAME_MACBINARY,	"ee65f8e713127cf7f2d56371d2b8e63d", 2264},
-				{"ite sounds",		GAME_SOUNDFILE | GAME_MACBINARY,	"ee65f8e713127cf7f2d56371d2b8e63d", 2264},
-				{"ite music",		GAME_MUSICFILE_GM | GAME_MACBINARY,	"b0d66d7ae48f35c5c9a3444343b86f85", 3135053},
+				{"ite resources",	GAME_RESOURCEFILE | GAME_MACBINARY,	"d:4f7fa11c5175980ed593392838523060", 8862102},
+				{"ite scripts",		GAME_SCRIPTFILE | GAME_MACBINARY,	"d:adf1f46c1d0589083996a7060c798ad0", 336006},
+				{"ite sounds",		GAME_SOUNDFILE | GAME_MACBINARY,	"d:8ee4d9ee27688785608d09faaa4a974c", 3680672},
+				{"ite music",		GAME_MUSICFILE_GM | GAME_MACBINARY,	"r:b0d66d7ae48f35c5c9a3444343b86f85", 3135053},
 				// {"ite voices",		GAME_VOICEFILE | GAME_MACBINARY,	"ee65f8e713127cf7f2d56371d2b8e63d", 2264},
 				AD_LISTEND
 			},
 			Common::EN_ANY,
 			Common::kPlatformMacintosh,
-			ADGF_CD | ADGF_MACRESFORK,
+			ADGF_CD,
 			GUIO0()
 		},
 		GID_ITE,

--- a/engines/zvision/detection_tables.h
+++ b/engines/zvision/detection_tables.h
@@ -122,34 +122,12 @@ static const ZVisionGameDescription gameDescriptions[] = {
 	{
 		// Zork Nemesis English Mac version
 		// Bugreport #11755
-		// These are proper checksums, but it is not working with AD so far
-		// (see comment at the start of getFileProperties()
 		{
 			"znemesis",
 			_s("Missing game code"), // Reason for being unsupported
 			{
-				{ "CSCR.ZFS", 0, "ce26cbb17bfbaa774742b3187262a7c0", 2597635 },
-				{ "ASCR.ZFS", 0, "5ee98db1bf73983eb8148da231342085", 929931 },
-				AD_LISTEND
-			},
-			Common::EN_ANY,
-			Common::kPlatformMacintosh,
-			ADGF_UNSUPPORTED | ADGF_MACRESFORK,
-			GUIO4(GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_DOUBLE_FPS, GAMEOPTION_ENABLE_VENUS, GAMEOPTION_DISABLE_ANIM_WHILE_TURNING)
-		},
-		GID_NEMESIS
-	},
-
-	{
-		// Zork Nemesis English Mac version
-		// These are improper checksums for MacBinary files
-		// Added to avoid further bugreports.
-		{
-			"znemesis",
-			_s("Missing game code"), // Reason for being unsupported
-			{
-				{ "CSCR.ZFS", 0, "afcf3b38c210db13988fe7b22d5b2288", 2597888 },
-				{ "ASCR.ZFS", 0, "75e07b46ef60967c9ea66a19e4916b0f", 930176 },
+				{ "CSCR.ZFS", 0, "d:ce26cbb17bfbaa774742b3187262a7c0", 2597635 },
+				{ "ASCR.ZFS", 0, "d:5ee98db1bf73983eb8148da231342085", 929931 },
 				AD_LISTEND
 			},
 			Common::EN_ANY,


### PR DESCRIPTION
Some of the abuse and suboptimal use stems from past limitations of AD:
* Usage of data fork with ADGF_MACRESFORK
* Checksumming of resource fork when we  don't use it otherwise. Remaining case in MADE engine

This doesn't cover following problems:
* Checksumming macbinary
* Checksumming file when checksum of data fork is intended