### PR TITLE
NEVERHOOD: Show Japanese overwrite prompt if running Japanese version

### DIFF
--- a/engines/neverhood/menumodule.h
+++ b/engines/neverhood/menumodule.h
@@ -259,6 +259,7 @@ public:
 protected:
 	void update();
 	uint32 handleMessage(int messageNum, const MessageParam &param, Entity *sender);
+	void displayOverwriteStrings(const Common::String &description);
 };
 
 } // End of namespace Neverhood


### PR DESCRIPTION
My big question with it: can I have UTF-8 strings in the source code or should I encode them somehow?