### PR TITLE
AMIGAOS: Fix FLAC being skipped in configure

### DIFF
--- a/configure
+++ b/configure
@@ -2616,6 +2616,8 @@ case $_host_os in
 		_port_mk="backends/platform/sdl/amigaos/amigaos.mk"
 		add_line_to_config_mk 'AMIGAOS = 1'
 		append_var CXXFLAGS "-mlongcall"
+		# Dependencies might also be compiled with stack protection
+		append_var LDFLAGS "-fstack-protector"
 		# Enable full optimizations for non-debug builds
 		if test "$_debug_build" = no; then
 			_optimization_level=-O3


### PR DESCRIPTION
This fixes undefined references while the FLAC check is performed during configuring.
My local FLAC dependency was compiled with stack protection, leading to it not being picked up at all, due to a missing -lssp flag.
Forcing -lssp globally in the AmigaOS build now, which hopefully will catch all future dependies that might be compiled with stack protection as well.

Similar fix is in the tools PR.

Thank you very much @sev- and @lephilousophe 

Please review