### PR TITLE
DIRECTOR: add quirk for henachoco05

### DIFF
--- a/engines/director/game-quirks.cpp
+++ b/engines/director/game-quirks.cpp
@@ -79,14 +79,8 @@ struct CachedFile {
 };
 
 
-static void quirkKidsBox() {
-    // Kids Box opens with a 320x150 splash screen before switching to
-    // a full screen 640x480 game window. If desktop mode is off, ScummVM
-    // will pick a game window that fits the splash screen and then try
-    // to squish the full size game window into it.
+static void quirk640x480Desktop() {
     g_director->_wmMode &= ~Graphics::kWMModeNoDesktop;
-    // Game runs in 640x480; clipping it to this size ensures the main
-    // game window takes up the full screen, and only the splash is windowed.
     g_director->_wmWidth = 640;
     g_director->_wmHeight = 480;
 }
@@ -109,7 +103,18 @@ struct Quirk {
 	Common::Platform platform;
 	void (*quirk)();
 } quirks[] = {
-    { "kidsbox", Common::kPlatformMacintosh, &quirkKidsBox },
+	// Rodem expects to be able to track the mouse cursor outside the
+	// window, which is impossible in ScummVM. Giving it a virtual
+	// desktop allows it to work like it would ahve on the original OS.
+	{ "henachoco05", Common::kPlatformMacintosh, &quirk640x480Desktop },
+	{ "henachoco05", Common::kPlatformWindows, &quirk640x480Desktop },
+    // Kids Box opens with a 320x150 splash screen before switching to
+    // a full screen 640x480 game window. If desktop mode is off, ScummVM
+    // will pick a game window that fits the splash screen and then try
+    // to squish the full size game window into it.
+    // It runs in 640x480; clipping it to this size ensures the main
+    // game window takes up the full screen, and only the splash is windowed.
+    { "kidsbox", Common::kPlatformMacintosh, &quirk640x480Desktop },
 	{ "lzone", Common::kPlatformWindows, &quirkLzone },
 	{ "mcluhan", Common::kPlatformWindows, &quirkMcLuhan },
 	{ nullptr, Common::kPlatformUnknown, nullptr }


### PR DESCRIPTION
Rodem tracks mouse movement outside the game window. It's not possible to trigger Rodem's movement to the next screen to the left or right just by moving the mouse cursor to the edge of the screen; it has to be tracked outside the screen altogether.

This can be fixed by enabling ScummVM's desktop emulation. I've confirmed this makes both the Mac and Windows versions playable. Since an existing quirk already implemented this behaviour, I've renamed the existing function and given it a more generic name.

Requires @moralrecordings's branch https://github.com/moralrecordings/scummvm/tree/yakenrodem_compat to be able to test gameplay; otherwise the game doesn't get past the loading screen.