### PR TITLE
ULTIMA8: Remove most dependencies on shared code

### DIFF
--- a/engines/ultima/nuvie/nuvie.h
+++ b/engines/ultima/nuvie/nuvie.h
@@ -22,6 +22,7 @@
 #ifndef NUVIE_NUVIE_H
 #define NUVIE_NUVIE_H
 
+#include "ultima/shared/engine/events.h"
 #include "ultima/shared/engine/ultima.h"
 #include "ultima/shared/std/string.h"
 #include "ultima/nuvie/conf/configuration.h"
@@ -39,7 +40,7 @@ class Screen;
 class Script;
 class SoundManager;
 
-class NuvieEngine : public Ultima::Shared::UltimaEngine {
+class NuvieEngine : public Ultima::Shared::UltimaEngine, public Ultima::Shared::EventsCallback {
 private:
 	Configuration *_config;
 	Screen *_screen;
@@ -48,6 +49,7 @@ private:
 	SaveGame *_savegame;
 
 	SoundManager *_soundManager;
+	Ultima::Shared::EventsManager *_events;
 private:
 	void initConfig();
 	void assignGameConfigValues(uint8 game_type);

--- a/engines/ultima/shared/early/ultima_early.h
+++ b/engines/ultima/shared/early/ultima_early.h
@@ -34,6 +34,7 @@
 #include "engines/engine.h"
 #include "ultima/detection.h"
 
+#include "ultima/shared/engine/events.h"
 #include "ultima/shared/engine/ultima.h"
 
 namespace Ultima {
@@ -65,7 +66,7 @@ namespace Gfx {
 class Screen;
 }
 
-class UltimaEarlyEngine : public UltimaEngine {
+class UltimaEarlyEngine : public UltimaEngine, public EventsCallback {
 private:
 	/**
 	 * Initialize the engine
@@ -86,6 +87,7 @@ public:
 	GameBase *_game;
 	MouseCursor *_mouseCursor;
 	Gfx::Screen *_screen;
+	EventsManager *_events;
 public:
 	UltimaEarlyEngine(OSystem *syst, const UltimaGameDescription *gameDesc);
 	~UltimaEarlyEngine() override;

--- a/engines/ultima/shared/engine/ultima.cpp
+++ b/engines/ultima/shared/engine/ultima.cpp
@@ -36,7 +36,7 @@ UltimaEngine * g_ultima;
 
 UltimaEngine::UltimaEngine(OSystem *syst, const Ultima::UltimaGameDescription *gameDesc) :
 		Engine(syst), _gameDescription(gameDesc), _randomSource("Ultima"),
-		_dataArchive(nullptr), _events(nullptr) {
+		_dataArchive(nullptr) {
 	g_ultima = this;
 }
 

--- a/engines/ultima/shared/engine/ultima.h
+++ b/engines/ultima/shared/engine/ultima.h
@@ -23,8 +23,6 @@
 #define ULTIMA_SHARED_ENGINE_ULTIMA_H
 
 #include "ultima/detection.h"
-#include "ultima/shared/engine/debugger.h"
-#include "ultima/shared/engine/events.h"
 #include "common/archive.h"
 #include "common/random.h"
 #include "engines/engine.h"
@@ -32,7 +30,7 @@
 namespace Ultima {
 namespace Shared {
 
-class UltimaEngine : public Engine, public EventsCallback {
+class UltimaEngine : public Engine {
 private:
 	Common::RandomSource _randomSource;
 protected:
@@ -56,8 +54,6 @@ protected:
 		return false;
 	}
 
-public:
-	EventsManager *_events;
 public:
 	UltimaEngine(OSystem *syst, const Ultima::UltimaGameDescription *gameDesc);
 	~UltimaEngine() override;

--- a/engines/ultima/ultima8/gumps/container_gump.cpp
+++ b/engines/ultima/ultima8/gumps/container_gump.cpp
@@ -302,14 +302,14 @@ Gump *ContainerGump::onMouseDown(int button, int32 mx, int32 my) {
 	if (handled) return handled;
 
 	// only interested in left clicks
-	if (button == Shared::BUTTON_LEFT)
+	if (button == Mouse::BUTTON_LEFT)
 		return this;
 
 	return nullptr;
 }
 
 void ContainerGump::onMouseClick(int button, int32 mx, int32 my) {
-	if (button == Shared::BUTTON_LEFT) {
+	if (button == Mouse::BUTTON_LEFT) {
 		uint16 objID = TraceObjId(mx, my);
 
 		Item *item = getItem(objID);
@@ -326,7 +326,7 @@ void ContainerGump::onMouseClick(int button, int32 mx, int32 my) {
 }
 
 void ContainerGump::onMouseDouble(int button, int32 mx, int32 my) {
-	if (button == Shared::BUTTON_LEFT) {
+	if (button == Mouse::BUTTON_LEFT) {
 		uint16 objID = TraceObjId(mx, my);
 
 		if (objID == getObjId()) {

--- a/engines/ultima/ultima8/gumps/credits_gump.cpp
+++ b/engines/ultima/ultima8/gumps/credits_gump.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "common/config-manager.h"
+#include "common/events.h"
 
 #include "ultima/ultima8/gumps/credits_gump.h"
 

--- a/engines/ultima/ultima8/gumps/difficulty_gump.cpp
+++ b/engines/ultima/ultima8/gumps/difficulty_gump.cpp
@@ -141,7 +141,7 @@ void DifficultyGump::PaintThis(RenderSurface *surf, int32 lerp_factor, bool scal
 }
 
 void DifficultyGump::onMouseClick(int button, int32 mx, int32 my) {
-	if (button == Shared::BUTTON_LEFT) {
+	if (button == Mouse::BUTTON_LEFT) {
 		Gump *gump = FindGump(mx, my);
 		if (gump && gump->GetIndex() > 0) {
 			int idx = gump->GetIndex();

--- a/engines/ultima/ultima8/gumps/game_map_gump.cpp
+++ b/engines/ultima/ultima8/gumps/game_map_gump.cpp
@@ -271,12 +271,12 @@ Gump *GameMapGump::onMouseDown(int button, int32 mx, int32 my) {
 	GumpToScreenSpace(sx, sy);
 
 	AvatarMoverProcess *amp = Ultima8Engine::get_instance()->getAvatarMoverProcess();
-	if (button == Shared::BUTTON_RIGHT || button == Shared::BUTTON_LEFT) {
+	if (button == Mouse::BUTTON_RIGHT || button == Mouse::BUTTON_LEFT) {
 		amp->onMouseDown(button, sx, sy);
 	}
 
-	if (button == Shared::BUTTON_LEFT || button == Shared::BUTTON_RIGHT ||
-	        button == Shared::BUTTON_MIDDLE) {
+	if (button == Mouse::BUTTON_LEFT || button == Mouse::BUTTON_RIGHT ||
+	        button == Mouse::BUTTON_MIDDLE) {
 		// we take all clicks
 		return this;
 	}
@@ -286,7 +286,7 @@ Gump *GameMapGump::onMouseDown(int button, int32 mx, int32 my) {
 
 void GameMapGump::onMouseUp(int button, int32 mx, int32 my) {
 	AvatarMoverProcess *amp = Ultima8Engine::get_instance()->getAvatarMoverProcess();
-	if (button == Shared::BUTTON_RIGHT || button == Shared::BUTTON_LEFT) {
+	if (button == Mouse::BUTTON_RIGHT || button == Mouse::BUTTON_LEFT) {
 		amp->onMouseUp(button);
 	}
 }
@@ -294,10 +294,10 @@ void GameMapGump::onMouseUp(int button, int32 mx, int32 my) {
 void GameMapGump::onMouseClick(int button, int32 mx, int32 my) {
 	MainActor *avatar = getMainActor();
 	switch (button) {
-	case Shared::BUTTON_LEFT: {
+	case Mouse::BUTTON_LEFT: {
 		if (avatar->isInCombat()) break;
 
-		if (Mouse::get_instance()->isMouseDownEvent(Shared::BUTTON_RIGHT)) break;
+		if (Mouse::get_instance()->isMouseDownEvent(Mouse::BUTTON_RIGHT)) break;
 
 		uint16 objID = TraceObjId(mx, my);
 		Item *item = getItem(objID);
@@ -314,7 +314,7 @@ void GameMapGump::onMouseClick(int button, int32 mx, int32 my) {
 		}
 		break;
 	}
-	case Shared::BUTTON_MIDDLE: {
+	case Mouse::BUTTON_MIDDLE: {
 		uint16 objID = TraceObjId(mx, my);
 		Item *item = getItem(objID);
 		if (item) {
@@ -359,10 +359,10 @@ void GameMapGump::onMouseClick(int button, int32 mx, int32 my) {
 void GameMapGump::onMouseDouble(int button, int32 mx, int32 my) {
 	MainActor *avatar = getMainActor();
 	switch (button) {
-	case Shared::BUTTON_LEFT: {
+	case Mouse::BUTTON_LEFT: {
 		if (avatar->isInCombat()) break;
 
-		if (Mouse::get_instance()->isMouseDownEvent(Shared::BUTTON_RIGHT)) break;
+		if (Mouse::get_instance()->isMouseDownEvent(Mouse::BUTTON_RIGHT)) break;
 
 		uint16 objID = TraceObjId(mx, my);
 		Item *item = getItem(objID);

--- a/engines/ultima/ultima8/gumps/keypad_gump.cpp
+++ b/engines/ultima/ultima8/gumps/keypad_gump.cpp
@@ -19,6 +19,8 @@
  *
  */
 
+#include "common/events.h"
+
 #include "ultima/ultima8/audio/audio_process.h"
 #include "ultima/ultima8/gumps/keypad_gump.h"
 #include "ultima/ultima8/games/game_data.h"

--- a/engines/ultima/ultima8/gumps/mini_stats_gump.cpp
+++ b/engines/ultima/ultima8/gumps/mini_stats_gump.cpp
@@ -102,7 +102,7 @@ uint16 MiniStatsGump::TraceObjId(int32 mx, int32 my) {
 }
 
 Gump *MiniStatsGump::onMouseDown(int button, int32 mx, int32 my) {
-	if (button == Shared::BUTTON_LEFT)
+	if (button == Mouse::BUTTON_LEFT)
 		return this;
 
 	return nullptr;

--- a/engines/ultima/ultima8/gumps/minimap_gump.cpp
+++ b/engines/ultima/ultima8/gumps/minimap_gump.cpp
@@ -177,14 +177,14 @@ Gump *MiniMapGump::onMouseDown(int button, int32 mx, int32 my) {
 		return handled;
 
 	// only interested in left clicks
-	if (button == Shared::BUTTON_LEFT)
+	if (button == Mouse::BUTTON_LEFT)
 		return this;
 
 	return nullptr;
 }
 
 void MiniMapGump::onMouseDouble(int button, int32 mx, int32 my) {
-	if (button == Shared::BUTTON_LEFT) {
+	if (button == Mouse::BUTTON_LEFT) {
 		HideGump();
 	}
 }

--- a/engines/ultima/ultima8/gumps/paged_gump.cpp
+++ b/engines/ultima/ultima8/gumps/paged_gump.cpp
@@ -19,6 +19,8 @@
  *
  */
 
+#include "common/events.h"
+
 #include "ultima/ultima8/gumps/paged_gump.h"
 #include "ultima/ultima8/games/game_data.h"
 #include "ultima/ultima8/graphics/gump_shape_archive.h"

--- a/engines/ultima/ultima8/gumps/u8_save_gump.cpp
+++ b/engines/ultima/ultima8/gumps/u8_save_gump.cpp
@@ -312,7 +312,7 @@ Gump *U8SaveGump::showLoadSaveGump(Gump *parent, bool save) {
 		return nullptr;
 	}
 
-	if (save && !Ultima8Engine::get_instance()->canSaveGameStateCurrently(false)) {
+	if (save && !Ultima8Engine::get_instance()->canSaveGameStateCurrently()) {
 		return nullptr;
 	}
 

--- a/engines/ultima/ultima8/gumps/u8_save_gump.cpp
+++ b/engines/ultima/ultima8/gumps/u8_save_gump.cpp
@@ -171,7 +171,7 @@ Gump *U8SaveGump::onMouseDown(int button, int32 mx, int32 my) {
 
 
 void U8SaveGump::onMouseClick(int button, int32 mx, int32 my) {
-	if (button != Shared::BUTTON_LEFT) return;
+	if (button != Mouse::BUTTON_LEFT) return;
 
 	ParentToGump(mx, my);
 

--- a/engines/ultima/ultima8/gumps/widgets/button_widget.cpp
+++ b/engines/ultima/ultima8/gumps/widgets/button_widget.cpp
@@ -110,7 +110,7 @@ Gump *ButtonWidget::onMouseDown(int button, int32 mx, int32 my) {
 	Gump *ret = Gump::onMouseDown(button, mx, my);
 	if (ret)
 		return ret;
-	if (button == Shared::BUTTON_LEFT) {
+	if (button == Mouse::BUTTON_LEFT) {
 		// CHECKME: change dimensions or not?
 		if (!_mouseOver) {
 			_shape = _shapeDown;
@@ -130,7 +130,7 @@ uint16 ButtonWidget::TraceObjId(int32 mx, int32 my) {
 
 
 void ButtonWidget::onMouseUp(int button, int32 mx, int32 my) {
-	if (button == Shared::BUTTON_LEFT) {
+	if (button == Mouse::BUTTON_LEFT) {
 		if (!_mouseOver) {
 			_shape = _shapeUp;
 			_frameNum = _frameNumUp;

--- a/engines/ultima/ultima8/kernel/mouse.cpp
+++ b/engines/ultima/ultima8/kernel/mouse.cpp
@@ -52,8 +52,8 @@ Mouse::~Mouse() {
 	_instance = nullptr;
 }
 
-bool Mouse::buttonDown(Shared::MouseButton button) {
-	assert(button != Shared::MOUSE_LAST);
+bool Mouse::buttonDown(MouseButton button) {
+	assert(button != MOUSE_LAST);
 	bool handled = false;
 	uint32 now = g_system->getMillis();
 
@@ -91,8 +91,8 @@ bool Mouse::buttonDown(Shared::MouseButton button) {
 	return handled;
 }
 
-bool Mouse::buttonUp(Shared::MouseButton button) {
-	assert(button != Shared::MOUSE_LAST);
+bool Mouse::buttonUp(MouseButton button) {
+	assert(button != MOUSE_LAST);
 	bool handled = false;
 
 	_mouseButton[button].clearState(MBS_DOWN);
@@ -112,7 +112,7 @@ bool Mouse::buttonUp(Shared::MouseButton button) {
 		handled = true;
 	}
 
-	if (button == Shared::BUTTON_LEFT && _dragging != Mouse::DRAG_NOT) {
+	if (button == BUTTON_LEFT && _dragging != Mouse::DRAG_NOT) {
 		stopDragging(_mousePos.x, _mousePos.y);
 		handled = true;
 	}
@@ -126,7 +126,7 @@ void Mouse::popAllCursors() {
 	update();
 }
 
-bool Mouse::isMouseDownEvent(Shared::MouseButton button) const {
+bool Mouse::isMouseDownEvent(MouseButton button) const {
 	return _mouseButton[button].isState(MBS_DOWN);
 }
 
@@ -329,9 +329,9 @@ void Mouse::setMouseCoords(int mx, int my) {
 	}
 
 	if (_dragging == DRAG_NOT) {
-		if (_mouseButton[Shared::BUTTON_LEFT].isState(MBS_DOWN)) {
-			int startx = _mouseButton[Shared::BUTTON_LEFT]._downPoint.x;
-			int starty = _mouseButton[Shared::BUTTON_LEFT]._downPoint.y;
+		if (_mouseButton[BUTTON_LEFT].isState(MBS_DOWN)) {
+			int startx = _mouseButton[BUTTON_LEFT]._downPoint.x;
+			int starty = _mouseButton[BUTTON_LEFT]._downPoint.y;
 			if (ABS(startx - mx) > 2 ||
 				ABS(starty - my) > 2) {
 				startDragging(startx, starty);
@@ -417,7 +417,7 @@ void Mouse::startDragging(int startx, int starty) {
 	// pause the kernel
 	Kernel::get_instance()->pause();
 
-	_mouseButton[Shared::BUTTON_LEFT].setState(MBS_HANDLED);
+	_mouseButton[BUTTON_LEFT].setState(MBS_HANDLED);
 
 	if (_dragging == DRAG_INVALID) {
 		setMouseCursor(MOUSE_CROSS);
@@ -518,7 +518,7 @@ void Mouse::stopDragging(int mx, int my) {
 }
 
 void Mouse::handleDelayedEvents() {
-	for (int button = 0; button < Shared::MOUSE_LAST; ++button) {
+	for (int button = 0; button < MOUSE_LAST; ++button) {
 		if (!(_mouseButton[button]._state & (MBS_HANDLED | MBS_DOWN)) &&
 			!_mouseButton[button].lastWithinDblClkTimeout()) {
 			Gump *gump = getGump(_mouseButton[button]._downGump);

--- a/engines/ultima/ultima8/kernel/mouse.h
+++ b/engines/ultima/ultima8/kernel/mouse.h
@@ -24,7 +24,6 @@
 
 #include "common/system.h"
 #include "common/rect.h"
-#include "ultima/shared/engine/events.h"
 #include "ultima/ultima8/misc/common_types.h"
 #include "ultima/ultima8/misc/direction.h"
 
@@ -81,6 +80,14 @@ class Gump;
 
 class Mouse {
 public:
+	enum MouseButton {
+		BUTTON_NONE = 0,
+		BUTTON_LEFT = 1,
+		BUTTON_RIGHT = 2,
+		BUTTON_MIDDLE = 3,
+		MOUSE_LAST
+	};
+
 	enum MouseCursor {
 		MOUSE_NORMAL = 0,
 		MOUSE_NONE = 1,
@@ -109,7 +116,7 @@ private:
 	uint32 _flashingCursorTime;
 
 	// mouse input state
-	MButton _mouseButton[Shared::MOUSE_LAST];
+	MButton _mouseButton[MOUSE_LAST];
 
 	uint16 _mouseOverGump;
 	Common::Point _mousePos;
@@ -134,12 +141,12 @@ public:
 	/**
 	 * Called when a mouse button is pressed down
 	 */
-	bool buttonDown(Shared::MouseButton button);
+	bool buttonDown(MouseButton button);
 
 	/**
 	 * Called when a mouse ubtton is released
 	 */
-	bool buttonUp(Shared::MouseButton button);
+	bool buttonUp(MouseButton button);
 
 	//! get mouse cursor length. 0 = short, 1 = medium, 2 = long
 	int getMouseLength(int mx, int my) const;
@@ -174,7 +181,7 @@ public:
 	//! set current mouse cursor location
 	void setMouseCoords(int mx, int my);
 
-	bool isMouseDownEvent(Shared::MouseButton button) const;
+	bool isMouseDownEvent(MouseButton button) const;
 
 	//! remove all existing cursors
 	void popAllCursors();

--- a/engines/ultima/ultima8/misc/debugger.cpp
+++ b/engines/ultima/ultima8/misc/debugger.cpp
@@ -63,7 +63,7 @@ namespace Ultima8 {
 
 Debugger *g_debugger;
 
-Debugger::Debugger() : Shared::Debugger() {
+Debugger::Debugger() : GUI::Debugger() {
 	g_debugger = this;
 
 	// WARNING: Not only can the methods below be executed directly in the debugger,

--- a/engines/ultima/ultima8/misc/debugger.h
+++ b/engines/ultima/ultima8/misc/debugger.h
@@ -23,10 +23,10 @@
 #define ULTIMA_ULTIMA8_ENGINE_DEBUGGER_H
 
 #include "ultima/ultima8/misc/common_types.h"
-#include "ultima/shared/engine/debugger.h"
 #include "ultima/shared/std/containers.h"
 #include "common/debug.h"
 #include "common/stream.h"
+#include "gui/debugger.h"
 
 namespace Ultima {
 namespace Ultima8 {
@@ -34,7 +34,7 @@ namespace Ultima8 {
 /**
  * Debugger base class
  */
-class Debugger : public Shared::Debugger {
+class Debugger : public GUI::Debugger {
 private:
 	const char *strBool(bool flag) {
 		return flag ? "true" : "false";

--- a/engines/ultima/ultima8/ultima8.h
+++ b/engines/ultima/ultima8/ultima8.h
@@ -23,7 +23,9 @@
 #ifndef ULTIMA8_ULTIMA8
 #define ULTIMA8_ULTIMA8
 
+#include "common/events.h"
 #include "common/stream.h"
+#include "graphics/screen.h"
 #include "ultima/shared/std/containers.h"
 #include "ultima/shared/engine/ultima.h"
 #include "ultima/ultima8/usecode/intrinsics.h"
@@ -104,6 +106,7 @@ private:
 	// Timing stuff
 	int32 _lerpFactor;       //!< Interpolation factor for this frame (0-256)
 	bool _inBetweenFrame;    //!< Set true if we are doing an inbetween frame
+	uint32 _priorFrameCounterTime;
 
 	bool _highRes;			 //!< Set to true to enable larger screen size
 	bool _frameSkip;         //!< Set to true to enable frame skipping (default false)
@@ -165,6 +168,7 @@ private:
 	//! \return true if detected all the fields, false if detection failed
 	bool getGameInfo(const istring &game, GameInfo *gameinfo);
 
+	bool pollEvent(Common::Event &event);
 protected:
 	// Engine APIs
 	Common::Error run() override;
@@ -206,7 +210,7 @@ public:
 		return _screen;
 	}
 
-	Graphics::Screen *getScreen() const override;
+	Graphics::Screen *getScreen() const;
 
 	Common::Error runGame();
 	virtual void handleEvent(const Common::Event &event);

--- a/engines/ultima/ultima8/ultima8.h
+++ b/engines/ultima/ultima8/ultima8.h
@@ -24,10 +24,10 @@
 #define ULTIMA8_ULTIMA8
 
 #include "common/events.h"
+#include "common/random.h"
 #include "common/stream.h"
 #include "graphics/screen.h"
 #include "ultima/shared/std/containers.h"
-#include "ultima/shared/engine/ultima.h"
 #include "ultima/ultima8/usecode/intrinsics.h"
 #include "ultima/ultima8/misc/common_types.h"
 #include "ultima/ultima8/games/game_info.h"
@@ -65,11 +65,14 @@ struct GameInfo;
 #define GAME_IS_CRUSADER (GAME_IS_REMORSE || GAME_IS_REGRET)
 #define GAME_IS_DEMO (Ultima8Engine::get_instance()->getGameInfo()->_ucOffVariant == GameInfo::GAME_UC_DEMO)
 
-class Ultima8Engine : public Shared::UltimaEngine {
+class Ultima8Engine : public Engine {
 	friend class Debugger;
 private:
+	Common::RandomSource _randomSource;
+
 	bool _isRunning;
 	GameInfo *_gameInfo;
+	const UltimaGameDescription *_gameDescription;
 
 	// minimal system
 	FileSystem *_fileSystem;
@@ -131,7 +134,7 @@ private:
 	/**
 	 * Does engine deinitialization
 	 */
-	void deinitialize() override;
+	void deinitialize();
 
 	/**
 	 * Shows the Pentagram splash screen
@@ -173,14 +176,14 @@ protected:
 	// Engine APIs
 	Common::Error run() override;
 
-	bool initialize() override;
+	bool initialize();
 
 	void pauseEngineIntern(bool pause) override;
 
 	/**
 	 * Returns the data archive folder and version that's required
 	 */
-	bool isDataRequired(Common::String &folder, int &majorVersion, int &minorVersion) override;
+	bool isDataRequired(Common::String &folder, int &majorVersion, int &minorVersion);
 
 public:
 	Ultima8Engine(OSystem *syst, const Ultima::UltimaGameDescription *gameDesc);
@@ -191,6 +194,8 @@ public:
 	}
 
 	bool hasFeature(EngineFeature f) const override;
+
+	Common::Language getLanguage() const;
 
 	Common::Error startup();
 	void shutdown();
@@ -301,6 +306,11 @@ public:
 	}
 
 	/**
+	 * Get a random number
+	 */
+	uint getRandomNumber(uint maxVal) { return _randomSource.getRandomNumber(maxVal); }
+
+	/**
 	 * Notifies the engine that the sound settings may have changed
 	 */
 	void syncSoundSettings() override;
@@ -318,12 +328,12 @@ public:
 	/**
 	 * Returns true if a savegame can be loaded
 	 */
-	bool canLoadGameStateCurrently(bool isAutosave = false) override { return true; }
+	bool canLoadGameStateCurrently() override { return true; }
 
 	/**
 	 * Returns true if the game can be saved
 	 */
-	bool canSaveGameStateCurrently(bool isAutosave = false) override;
+	bool canSaveGameStateCurrently() override;
 
 	/**
 	 * Load a game

--- a/engines/ultima/ultima8/world/actors/avatar_gravity_process.cpp
+++ b/engines/ultima/ultima8/world/actors/avatar_gravity_process.cpp
@@ -41,7 +41,7 @@ AvatarGravityProcess::AvatarGravityProcess(MainActor *avatar, int gravity)
 }
 
 void AvatarGravityProcess::run() {
-	if (!Mouse::get_instance()->isMouseDownEvent(Shared::BUTTON_RIGHT)) {
+	if (!Mouse::get_instance()->isMouseDownEvent(Mouse::BUTTON_RIGHT)) {
 		// right mouse button not down, so fall normally
 
 		GravityProcess::run();

--- a/engines/ultima/ultima8/world/actors/avatar_mover_process.cpp
+++ b/engines/ultima/ultima8/world/actors/avatar_mover_process.cpp
@@ -182,11 +182,11 @@ void AvatarMoverProcess::onMouseDown(int button, int32 mx, int32 my) {
 	int bid = 0;
 
 	switch (button) {
-	case Shared::BUTTON_LEFT: {
+	case Mouse::BUTTON_LEFT: {
 		bid = 0;
 		break;
 	}
-	case Shared::BUTTON_RIGHT: {
+	case Mouse::BUTTON_RIGHT: {
 		bid = 1;
 		break;
 	}
@@ -204,9 +204,9 @@ void AvatarMoverProcess::onMouseDown(int button, int32 mx, int32 my) {
 void AvatarMoverProcess::onMouseUp(int button) {
 	int bid = 0;
 
-	if (button == Shared::BUTTON_LEFT) {
+	if (button == Mouse::BUTTON_LEFT) {
 		bid = 0;
-	} else if (button == Shared::BUTTON_RIGHT) {
+	} else if (button == Mouse::BUTTON_RIGHT) {
 		bid = 1;
 	} else {
 		CANT_HAPPEN_MSG("invalid MouseUp passed to AvatarMoverProcess");


### PR DESCRIPTION
As discussed on Discord, I'd like to split the Ultima engine into multiple separate engines to reduce requirements on lower-end devices. This PR removes most of the dependencies on shared code from the Ultima 8 subengine, so it can be cleanly separated from the rest of the engine.

Two exceptions remain for now:
- `UltimaDataArchive` is still used for reading from `ultima.dat`. I plan to split the archive in a separate PR.
- The classes in the `Ultima::Std` namespace are still used throughout the engine, but can easily be duplicated if necessary.
