### PR TITLE
SURFACESDL: Initial support for 32-bit screen output

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -324,7 +324,7 @@ protected:
 
 	const PluginList &_scalerPlugins;
 	ScalerPluginObject *_scalerPlugin;
-	Scaler *_scaler;
+	Scaler *_scaler, *_mouseScaler;
 	uint _maxExtraPixels;
 	uint _extraPixels;
 
@@ -363,7 +363,6 @@ protected:
 			{ }
 	};
 
-	byte *_mouseData;
 	SDL_Rect _mouseBackup;
 	MousePos _mouseCurState;
 #ifdef USE_RGB_COLOR
@@ -375,9 +374,6 @@ protected:
 	bool _cursorPaletteDisabled;
 	SDL_Surface *_mouseOrigSurface;
 	SDL_Surface *_mouseSurface;
-	enum {
-		kMouseColorKey = 1
-	};
 
 	// Shake mode
 	// This is always set to 0 when building with SDL2.

--- a/graphics/VectorRendererSpec.cpp
+++ b/graphics/VectorRendererSpec.cpp
@@ -939,6 +939,8 @@ darkenFill(PixelType *ptr, PixelType *end) {
 	if (!g_system->hasFeature(OSystem::kFeatureOverlaySupportsAlpha)) {
 		// !kFeatureOverlaySupportsAlpha (but might have alpha bits)
 
+		mask |= _alphaMask;
+
 		while (ptr != end) {
 			*ptr = ((*ptr & ~mask) >> 2) | _alphaMask;
 			++ptr;
@@ -966,6 +968,8 @@ darkenFillClip(PixelType *ptr, PixelType *end, int x, int y) {
 
 	if (!g_system->hasFeature(OSystem::kFeatureOverlaySupportsAlpha)) {
 		// !kFeatureOverlaySupportsAlpha (but might have alpha bits)
+
+		mask |= _alphaMask;
 
 		while (ptr != end) {
 			if (IS_IN_CLIP(x, y)) *ptr = ((*ptr & ~mask) >> 2) | _alphaMask;

--- a/graphics/colormasks.h
+++ b/graphics/colormasks.h
@@ -286,6 +286,42 @@ struct ColorMasks<8888> {
 	typedef uint32 PixelType;
 };
 
+template<>
+struct ColorMasks<-8888> {
+	enum {
+		kBytesPerPixel = 4,
+
+		kAlphaBits  = 8,
+		kRedBits    = 8,
+		kGreenBits  = 8,
+		kBlueBits   = 8,
+
+		kAlphaShift = 0,
+		kRedShift   = kAlphaBits,
+		kGreenShift = kRedBits+kAlphaBits,
+		kBlueShift  = kGreenBits+kRedBits+kAlphaBits,
+
+		kAlphaMask = ((1u << kAlphaBits) - 1) << kAlphaShift,
+		kRedMask   = ((1u << kRedBits) - 1) << kRedShift,
+		kGreenMask = ((1u << kGreenBits) - 1) << kGreenShift,
+		kBlueMask  = ((1u << kBlueBits) - 1) << kBlueShift,
+
+		kRedBlueMask = kRedMask | kBlueMask,
+
+		kLowBits    = (1 << kRedShift) | (1 << kGreenShift) | (1 << kBlueShift) | (1 << kAlphaShift),
+		kLow2Bits   = (3 << kRedShift) | (3 << kGreenShift) | (3 << kBlueShift) | (3 << kAlphaShift),
+		kLow3Bits   = (7 << kRedShift) | (7 << kGreenShift) | (7 << kBlueShift) | (7 << kAlphaShift),
+		kLow4Bits   = (15 << kRedShift) | (15 << kGreenShift) | (15 << kBlueShift) | (15 << kAlphaShift),
+
+		kLowBitsMask = kLowBits,
+		kHighBitsMask = ~kLowBits,
+		qlowBits = kLow2Bits,
+		qhighBits = ~kLow2Bits
+	};
+
+	typedef uint32 PixelType;
+};
+
 } // End of namespace Graphics
 
 #endif

--- a/graphics/scaler/hq.cpp
+++ b/graphics/scaler/hq.cpp
@@ -5003,6 +5003,38 @@ void HQScaler::HQ3x16(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint3
 }
 #endif
 
+void HQScaler::HQ2x32(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 dstPitch, int width, int height) {
+	if (_format.aLoss == 0) {
+		if (_format.aShift == 0) {
+			HQ2x_implementation<Graphics::ColorMasks<-8888> >(srcPtr, srcPitch, dstPtr,
+					dstPitch, width, height, _RGBtoYUV);
+		} else {
+			HQ2x_implementation<Graphics::ColorMasks<8888> >(srcPtr, srcPitch, dstPtr,
+					dstPitch, width, height, _RGBtoYUV);
+		}
+	} else {
+		assert((_format.rMax() | _format.gMax() | _format.bMax()) <= 0xffffff);
+		HQ2x_implementation<Graphics::ColorMasks<888> >(srcPtr, srcPitch, dstPtr,
+				dstPitch, width, height, _RGBtoYUV);
+	}
+}
+
+void HQScaler::HQ3x32(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 dstPitch, int width, int height) {
+	if (_format.aLoss == 0) {
+		if (_format.aShift == 0) {
+			HQ3x_implementation<Graphics::ColorMasks<-8888> >(srcPtr, srcPitch, dstPtr,
+					dstPitch, width, height, _RGBtoYUV);
+		} else {
+			HQ3x_implementation<Graphics::ColorMasks<8888> >(srcPtr, srcPitch, dstPtr,
+					dstPitch, width, height, _RGBtoYUV);
+		}
+	} else {
+		assert((_format.rMax() | _format.gMax() | _format.bMax()) <= 0xffffff);
+		HQ3x_implementation<Graphics::ColorMasks<888> >(srcPtr, srcPitch, dstPtr,
+				dstPitch, width, height, _RGBtoYUV);
+	}
+}
+
 void HQScaler::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 							uint8 *dstPtr, uint32 dstPitch, int width, int height, int x, int y) {
 	if (_format.bytesPerPixel == 2) {
@@ -5017,20 +5049,10 @@ void HQScaler::scaleIntern(const uint8 *srcPtr, uint32 srcPitch,
 	} else {
 		switch (_factor) {
 		case 2:
-			if (_format.aLoss == 0)
-				HQ2x_implementation<Graphics::ColorMasks<8888> >(srcPtr, srcPitch, dstPtr,
-						dstPitch, width, height, _RGBtoYUV);
-			else
-				HQ2x_implementation<Graphics::ColorMasks<888> >(srcPtr, srcPitch, dstPtr,
-						dstPitch, width, height, _RGBtoYUV);
+			HQ2x32(srcPtr, srcPitch, dstPtr, dstPitch, width, height);
 			break;
 		case 3:
-			if (_format.aLoss == 0)
-				HQ3x_implementation<Graphics::ColorMasks<8888> >(srcPtr, srcPitch, dstPtr,
-						dstPitch, width, height, _RGBtoYUV);
-			else
-				HQ3x_implementation<Graphics::ColorMasks<888> >(srcPtr, srcPitch, dstPtr,
-						dstPitch, width, height, _RGBtoYUV);
+			HQ3x32(srcPtr, srcPitch, dstPtr, dstPitch, width, height);
 			break;
 		}
 	}

--- a/graphics/scaler/hq.h
+++ b/graphics/scaler/hq.h
@@ -40,6 +40,8 @@ protected:
 	void initLUT(Graphics::PixelFormat format);
 	inline void HQ2x16(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 dstPitch, int width, int height);
 	inline void HQ3x16(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 dstPitch, int width, int height);
+	inline void HQ2x32(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 dstPitch, int width, int height);
+	inline void HQ3x32(const uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 dstPitch, int width, int height);
 
 	uint32 *_RGBtoYUV;
 #ifdef USE_NASM


### PR DESCRIPTION
TODO:
- Both SDL1 and SDL2 always request a 16-bit format for now.
- The dirty rectangle for the cursor isn't always correct and causes graphical issues when moving the mouse large distances.
- Not all scalers support all pixel formats.
