### PR TITLE
DEVTOOLS: dumper-companion.py: better handle removing null bytes from partition type

### DIFF
--- a/devtools/dumper-companion.py
+++ b/devtools/dumper-companion.py
@@ -318,7 +318,7 @@ def extract_volume(args: argparse.Namespace) -> int:
                     ">III", f.read(12)
                 )
                 f.seek(32, 1)
-                partition_type = f.read(32).decode("ascii").strip("\0")
+                partition_type = f.read(32).decode("ascii").split("\0")[0]
                 if partition_num <= num_partitions and partition_type != "Apple_HFS":
                     # Move onto the next partition
                     partition_num += 1


### PR DESCRIPTION
Handles an edge case of a disc which had a partition table overwritten with another, making
```
00000430: 4170 706c 655f 4846 5300 6974 696f 6e5f  Apple_HFS.ition_
00000440: 6d61 7000 0000 0000 0000 0000 0000 0000  map.............
```