### PR TITLE
GRAPHICS: Fix darkened fills on overlays with alpha bits but no blending

### DIFF
--- a/graphics/VectorRendererSpec.cpp
+++ b/graphics/VectorRendererSpec.cpp
@@ -939,6 +939,8 @@ darkenFill(PixelType *ptr, PixelType *end) {
 	if (!g_system->hasFeature(OSystem::kFeatureOverlaySupportsAlpha)) {
 		// !kFeatureOverlaySupportsAlpha (but might have alpha bits)
 
+		mask |= _alphaMask;
+
 		while (ptr != end) {
 			*ptr = ((*ptr & ~mask) >> 2) | _alphaMask;
 			++ptr;
@@ -966,6 +968,8 @@ darkenFillClip(PixelType *ptr, PixelType *end, int x, int y) {
 
 	if (!g_system->hasFeature(OSystem::kFeatureOverlaySupportsAlpha)) {
 		// !kFeatureOverlaySupportsAlpha (but might have alpha bits)
+
+		mask |= _alphaMask;
 
 		while (ptr != end) {
 			if (IS_IN_CLIP(x, y)) *ptr = ((*ptr & ~mask) >> 2) | _alphaMask;


### PR DESCRIPTION
This fixes visual issues with the classic theme on some platforms.