### PR TITLE
BLADERUNNER: pre-calculate some math constants

### DIFF
--- a/engines/bladerunner/fog.cpp
+++ b/engines/bladerunner/fog.cpp
@@ -115,7 +115,8 @@ void Fog::setupFrame(int frame) {
 void FogSphere::read(Common::ReadStream *stream, int frameCount) {
 	_frameCount = frameCount;
 	int size = readCommon(stream);
-	_radius = stream->readFloatLE();
+	float radius = stream->readFloatLE();
+	_radius_sq = radius * radius;
 	readAnimationData(stream, size - 52);
 }
 
@@ -135,12 +136,14 @@ void FogSphere::calculateCoeficient(Vector3 position, Vector3 viewPosition, floa
 	Vector3 rayDirection = (rayDestination - rayOrigin).normalize();
 
 	float b = Vector3::dot(rayDirection, rayOrigin);
-	float c = Vector3::dot(rayOrigin, rayOrigin) - (_radius * _radius);
+	float c = Vector3::dot(rayOrigin, rayOrigin) - _radius_sq;
 	float d = b * b - c;
 
 	if (d >= 0.0f) { // there is an interstection between ray and the sphere
-		Vector3 intersection1 = rayOrigin + (-b - sqrt(d)) * rayDirection;
-		Vector3 intersection2 = rayOrigin + (-b + sqrt(d)) * rayDirection;
+		float sqrt_d = sqrt(d);
+
+		Vector3 intersection1 = rayOrigin + (-b - sqrt_d) * rayDirection;
+		Vector3 intersection2 = rayOrigin + (-b + sqrt_d) * rayDirection;
 
 		Vector3 intersection1World = _inverted * intersection1;
 		Vector3 intersection2World = _inverted * intersection2;
@@ -165,7 +168,12 @@ void FogSphere::calculateCoeficient(Vector3 position, Vector3 viewPosition, floa
 void FogCone::read(Common::ReadStream *stream, int frameCount) {
 	_frameCount = frameCount;
 	int size = readCommon(stream);
-	_coneAngle = stream->readFloatLE();
+	float coneAngle = stream->readFloatLE();
+	float tan_coneAngle = tan(coneAngle);
+
+	_cos_coneAngle = cos(coneAngle);
+	_tan_coneAngle_sq = tan_coneAngle * tan_coneAngle;
+
 	readAnimationData(stream, size - 52);
 }
 
@@ -190,14 +198,14 @@ void FogCone::calculateCoeficient(Vector3 position, Vector3 viewPosition, float 
 
 		float cosTheta = sqrt(1.0f - Vector3::dot(planeNormal, v) * Vector3::dot(planeNormal, v));
 
-		if (cosTheta > cos(_coneAngle)) {
+		if (cosTheta > _cos_coneAngle) {
 			Vector3 u = Vector3::cross(v, planeNormal).normalize();
 			Vector3 w = Vector3::cross(u, v).normalize();
 
 			float tanTheta = sqrt(1.0f - cosTheta * cosTheta) / cosTheta;
 
 			Vector3 temp1 = tanTheta * w;
-			Vector3 temp2 = sqrt(tan(_coneAngle) * tan(_coneAngle) - tanTheta * tanTheta) * u;
+			Vector3 temp2 = sqrt(_tan_coneAngle_sq - tanTheta * tanTheta) * u;
 
 			Vector3 delta1 = v + temp1 - temp2;
 			Vector3 delta2 = v + temp1 + temp2;

--- a/engines/bladerunner/fog.h
+++ b/engines/bladerunner/fog.h
@@ -80,10 +80,10 @@ protected:
 
 class FogSphere : public Fog {
 private:
-	float _radius;
+	float _radius_sq;
 
 public:
-	FogSphere():_radius(0.0f) {};
+	FogSphere():_radius_sq(0.0f) {};
 
 	void read(Common::ReadStream *stream, int frameCount) override;
 	void calculateCoeficient(Vector3 position, Vector3 viewPosition, float *coeficient) override;
@@ -91,10 +91,11 @@ public:
 
 class FogCone : public Fog {
 private:
-	float _coneAngle;
+	float _tan_coneAngle_sq;
+	float _cos_coneAngle;
 
 public:
-	FogCone():_coneAngle(0.0f) {};
+	FogCone():_tan_coneAngle_sq(0.0f), _cos_coneAngle(1.0f) {};
 
 	void read(Common::ReadStream *stream, int frameCount) override;
 	void calculateCoeficient(Vector3 position, Vector3 viewPosition, float *coeficient) override;


### PR DESCRIPTION
There are some values that are read from stream and never changed by the calculations. Since they are used as parameter on expensive math functions like cos() and tan(), it would be worth to pre-calculate their values and use them when needed.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
