### PR TITLE
GUI: Attempt loading of .png flags if .svg version is not available

### DIFF
--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -132,7 +132,9 @@ void GridItemWidget::drawWidget() {
 	// Draw Flag
 	const Graphics::ManagedSurface *flagGfx = _grid->languageToSurface(_activeEntry->language);
 	if (flagGfx) {
-		Common::Point p(_x + thumbWidth - flagGfx->w - 5, _y + 5);
+		// SVG and PNG can resize differently so it's better to use thumbWidth as reference to
+		// ensure all flags are aligned
+		Common::Point p(_x + thumbWidth - (thumbWidth / 5), _y + 5);
 		g_gui.theme()->drawSurface(p, *flagGfx, true);
 	}
 

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -675,7 +675,7 @@ void GridWidget::loadFlagIcons() {
 		if (gfx) {
 			_languageIcons[l->id] = gfx;
 			continue;
-		} // if no .svg, try .png
+		} // if no .svg flag is available, search for a .png
 		path = Common::String::format("icons/flags/%s.png", l->code);
 		gfx = loadSurfaceFromFile(path);
 		if (gfx) {
@@ -686,7 +686,7 @@ void GridWidget::loadFlagIcons() {
 				delete gfx;
 			}
 		} else {
-			_languageIcons[l->id] = nullptr; // nothing found, set no nullptr
+			_languageIcons[l->id] = nullptr; // nothing found, set to nullptr
 		}
 	}
 }

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -672,8 +672,19 @@ void GridWidget::loadFlagIcons() {
 		Graphics::ManagedSurface *gfx = loadSurfaceFromFile(path, _flagIconWidth, _flagIconHeight);
 		if (gfx) {
 			_languageIcons[l->id] = gfx;
+			continue;
+		} // if no .svg, try .png
+		path = Common::String::format("icons/flags/%s.png", l->code);
+		gfx = loadSurfaceFromFile(path);
+		if (gfx) {
+			const Graphics::ManagedSurface *scGfx = scaleGfx(gfx, _flagIconWidth, _flagIconHeight, true);
+			_languageIcons[l->id] = scGfx;
+			if (gfx != scGfx) {
+				gfx->free();
+				delete gfx;
+			}
 		} else {
-			_languageIcons[l->id] = nullptr;
+			_languageIcons[l->id] = nullptr; // nothing found, set no nullptr
 		}
 	}
 }


### PR DESCRIPTION
The current GUI has problems rendering complex SVGs, e.g. the Brazilian flag, Croatia, and in general any flag
containing detailed emblems.
Since using simpler flags is unacceptable for various reasons, a possibile approach is to use .png for these flags.

This PR simply updates the loadFlagIcon routine to look for a .png if the .svg file is not available.
Also slightly changes the positioning to preserve alignment.

NOTE!!!
For this PR to work the relative PR in scummvm-icons must be merged:
https://github.com/scummvm/scummvm-icons/pull/88

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
