### PR TITLE
SLUDGE: Save/restore region's direction as signed integer

### DIFF
--- a/engines/sludge/region.cpp
+++ b/engines/sludge/region.cpp
@@ -78,7 +78,7 @@ void RegionManager::saveRegions(Common::WriteStream *stream) {
 		stream->writeUint16BE((*it)->y2);
 		stream->writeUint16BE((*it)->sX);
 		stream->writeUint16BE((*it)->sY);
-		stream->writeUint16BE((*it)->di);
+		stream->writeSint16BE((*it)->di);
 		g_sludge->_objMan->saveObjectRef((*it)->thisType, stream);
 	}
 }
@@ -94,7 +94,7 @@ void RegionManager::loadRegions(Common::SeekableReadStream *stream) {
 		newRegion->y2 = stream->readUint16BE();
 		newRegion->sX = stream->readUint16BE();
 		newRegion->sY = stream->readUint16BE();
-		newRegion->di = stream->readUint16BE();
+		newRegion->di = stream->readSint16BE();
 		newRegion->thisType = g_sludge->_objMan->loadObjectRef(stream);
 	}
 }


### PR DESCRIPTION
The engine is using -1 as an undefined direction, so keep it that way after save & restore cycle. Otherwise persons will spin around for a while trying to rotate themselves to 65535 degrees when aligning to a region with undefined direction.


https://user-images.githubusercontent.com/126204/212193088-d8c9963c-0d42-4ed2-83f7-fd4b70774d8e.mp4

