### PR TITLE
SLUDGE: Fix camera getting reset after loading saved game

### DIFF
--- a/engines/sludge/backdrop.cpp
+++ b/engines/sludge/backdrop.cpp
@@ -477,17 +477,22 @@ void GraphicsManager::saveBackdrop(Common::WriteStream *stream) {
 }
 
 void GraphicsManager::loadBackdrop(int ssgVersion, Common::SeekableReadStream *stream) {
-	_cameraX = stream->readUint16BE();
-	_cameraY = stream->readUint16BE();
+	int cameraX = stream->readUint16BE();
+	int cameraY = stream->readUint16BE();
+	float cameraZoom;
 	if (ssgVersion >= VERSION(2, 0)) {
-		_cameraZoom = stream->readFloatLE();
+		cameraZoom = stream->readFloatLE();
 	} else {
-		_cameraZoom = 1.0;
+		cameraZoom = 1.0;
 	}
 
 	_brightnessLevel = stream->readByte();
 
 	loadHSI(-1, stream, 0, 0, true);
+
+	_cameraX = cameraX;
+	_cameraY = cameraY;
+	_cameraZoom = cameraZoom;
 }
 
 bool GraphicsManager::getRGBIntoStack(uint x, uint y, StackHandler *sH) {


### PR DESCRIPTION
loadHSI calls reserveBackdrop, which resets camera values. Apply camera position and zoom in loadBackdrop after calling loadHSI, so the stored camera state gets preserved.