### PR TITLE
SLUDGE: Use unescaped value when calling openUrl in launch

### DIFF
--- a/engines/sludge/builtin.cpp
+++ b/engines/sludge/builtin.cpp
@@ -877,7 +877,7 @@ builtIn(launch) {
 		(newTextA[4] == ':' || (newTextA[4] == 's' && newTextA[5] == ':'))) {
 
 		// IT'S A WEBSITE!
-		bool success = g_sludge->_system->openUrl(newText);
+		bool success = g_sludge->_system->openUrl(newTextA);
 		fun->reg.setVariable(SVT_INT, success);
 		return BR_CONTINUE;
 	}


### PR DESCRIPTION
newText is an escaped filename, which escapes characters like : and /, which are essential for URLs. Use unescaped version like original OpenSLUDGE does, as otherwise URLs get mangled and become unusable.