### PR TITLE
SLUDGE: Fix transitionFader 

### DIFF
--- a/engines/sludge/transition.cpp
+++ b/engines/sludge/transition.cpp
@@ -37,7 +37,7 @@ void GraphicsManager::setBrightnessLevel(int brightnessLevel) {
 unsigned lastFrom, lastTo;
 
 void GraphicsManager::transitionFader() {
-	blendColor(&_renderSurface, TS_ARGB(_brightnessLevel, 255, 255, 255), Graphics::BLEND_MULTIPLY);
+	blendColor(&_renderSurface, TS_ARGB(255 - _brightnessLevel, 0, 0, 0), Graphics::BLEND_NORMAL);
 }
 
 void GraphicsManager::transitionCrossFader() {


### PR DESCRIPTION
Instead of manipulating alpha with BLEND_MULTIPLY, simply blend in normal mode with translucent black. This fixes transitions with low brightness levels (close to 0), which previously would effectively act as if the level was set to 255.