### PR TITLE
SCUMM: Fix randomly unreachable fire in DOTT (WORKAROUND)

### DIFF
--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -735,6 +735,21 @@ void ScummEngine_v6::o6_startScript() {
 	script = pop();
 	flags = pop();
 
+	// WORKAROUND: In DOTT, when Jefferson builds the fire, `startScript(1,106,[91,5])`
+	// is called, which randomly changes the state of the fire object between 1 and 5,
+	// as long as Hoagie doesn't exit this room. This makes him randomly fail
+	// interacting with it, saying "I can't reach it." instead of the intended "No.
+	// Fire bad." line. It looks like the 1-5 states for the fire object are useless
+	// leftovers which can be safely ignored in order to make sure that Hoagie's
+	// comment is always available (maybe the fire was meant to be displayed
+	// differently when it's just been lit, but then the idea was dropped?).
+	// This also happens with the original interpreters and with the remaster.
+	if (_game.id == GID_TENTACLE && _roomResource == 13 &&
+		vm.slot[_currentScript].number == 21 && script == 106 &&
+		args[0] == 91 && _enableEnhancements) {
+		return;
+	}
+
 	// WORKAROUND for a bug also present in the original EXE: After greasing (or oiling?)
 	// the cannonballs in the Plunder Town Theater, during the juggling show, the game
 	// cuts from room 18 (backstage) to room 19 (stage).


### PR DESCRIPTION
This one was reported by NeoDement on Discord. Thanks!

## Context

In DOTT, script 13-21 calls `startScript(1,106,[91,5])` when Jefferson builds the fire, but this script continuously changes the state of the fire object to a random value between 1 and 5 (this stops when you exit his room), and so if Hoagie tries interacting with it, he'll say "I can't reach it." instead of the intended "No. Fire bad." line, most of the time.

![image-3](https://user-images.githubusercontent.com/9024526/212554442-7a975d5c-c7fe-4d1b-a1e1-dddeffd1b6ec.png)

This also happens with the original DOS interpreter, the 2002 Aaron Giles Windows interpreter, and the Remastered version.

Script 13-21 (once Jefferson is done building the fire):

```
....

(9C) roomOps.roomScroll(160,VAR_ROOM_WIDTH)
(70) setState(83,0)
(6E) setClass(83,[160])
(70) setState(88,1)
(6E) setClass(88,[32])
(6E) setClass(91,[32])
(5E) startScript(1,106,[91,5]) # <== here
     ^^^^^^^^^^^^^^^^^^^^^^^^^
(5F) startScriptQuick(200,[])
(82) animateActor(7,10)
(5E) startScript(1,202,[])
(5E) startScript(1,201,[])
(5E) startScript(1,206,[])
(5E) startScript(1,208,[])
(61) drawObject(89,1)
(67) endCutscene()
(66) stopObjectCodeB()
END
```

Script 61-106:

```
[0000] (43) localvar4 = VAR_ROOM
[0006] (5D) if (!localvar1) {
[000D] (43)   localvar1 = 3
[0013] (**) }
[0013] (43) var132 = (localvar1 - 1)
[001D] (43) localvar3 = (getRandomNumber(var132) + 1)
[0028] (5D) unless ((localvar3 != localvar2)) jump 13
[0032] (61) drawObject(localvar0,localvar3)
[0039] (43) localvar2 = localvar3
[003F] (6C) breakHere()
[0040] (5D) unless ((VAR_ROOM != localvar4)) jump 13
[004A] (66) stopObjectCodeB()
END
```

…which I believe is equivalent to the following C-like code:

```c++
object = scriptParam[0];
maxRandom = scriptParam[1];
if (!scriptParam[1])
	maxRandom = 3;

startRoom = VAR_ROOM;
prevRandom = -1;
// Stop doing the following actions once we've moved to a different room
do {
	// Get a random state between 1 and 5 inclusive, that's not the previous value
	do {
		randomState = getRandomNumber(maxRandom) + 1;
	} while (randomState != prevRandom);

	drawObject(object, randomState);
	prevRandom = random;

	breakHere();
} while (startRoom != VAR_ROOM);
```

Completely ignoring this script fixes this problem and it doesn't seem to cause any regression with the fire itself. My hypothesis is that the game designers wanted to have an "early fire" animation when the fire has just been lit by Jefferson, but then they dropped the idea and used the same unique fire animation but forgot to turn off this script.

(Even if this hypothesis is wrong, I can't see any visual or behavioral regression if I ignore this script… but tests are welcome.)

## Test

1. Start the game with boot param `555`
2. With Hoagie, give the exploding cigar to George Washington
3. Then, give him the trapped teeth: Jefferson will build a fire
4. Try "picking up" the fire (the fire, not the fireplace)
5. Make sure that Hoagie always reacts by saying "No. Fire bad." instead of a strange "I can't reach it."
6. Leave and enter this room, and start at step 4 again, just to be sure

