### PR TITLE
SLUDGE: Make sure initial backdrop gets its alpha channel stored

### DIFF
--- a/engines/sludge/backdrop.cpp
+++ b/engines/sludge/backdrop.cpp
@@ -430,6 +430,9 @@ bool GraphicsManager::loadHSI(int num, Common::SeekableReadStream *stream, int x
 		return false;
 	}
 
+	if (!_backdropExists)
+		_backdropSurface.fillRect(Common::Rect(x, y, x + tmp.w, y + tmp.h), _renderSurface.format.ARGBToColor(0, 0, 0, 0));
+
 	// copy surface loaded to backdrop
 	Graphics::TransparentSurface tmp_trans(tmp, false);
 	tmp_trans.blit(_backdropSurface, x, y);


### PR DESCRIPTION
OpenSLUDGE draws the first backdrop image with alpha channel intact. Afterwards, next images are blended with previous backdrop contents.

So far ScummVM always did the later part, but never the former, which caused parallax to not work as it relies on alpha channel being propagated into backdrop (which gets initiallly filled with opaque black, so it had no chance to ever be transparent).

Fix that by clearing the area the first backdrop image is about to get blitted into with full transparency.