### PR TITLE
GUI: Show the entire length of descriptions in Achievements tab

### DIFF
--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -1418,16 +1418,25 @@ void OptionsDialog::addAchievementsControls(GuiObject *boss, const Common::Strin
 	uint16 ySmallStep = yStep / 3;
 	uint16 yPos = lineHeight + yStep * 3;
 
-	uint16 commentDelta = g_system->getOverlayWidth() <= 320 ? 25 : 30; // textline left tabbing
-	uint16 progressBarWidth = 240;
+	uint16 width;
+	uint16 textline_numchars;  // max number of chars in textline
+	uint16 progressBarWidth;
+	uint16 commentDelta = g_system->getOverlayWidth() <= 320 ? 20 : 30; // textline left tabbing
 	float scale_factor = g_gui.getScaleFactor();
 
-	uint16 width = 440 + 800 * (scale_factor - 1);
-	uint16 textline_numchars = 70 + 80 * (scale_factor - 1);
-	commentDelta *= scale_factor;
-
-	if (g_system->getOverlayWidth() - width < 100)
-		width = g_system->getOverlayWidth() - 100 * scale_factor; // clamp width to at least 100px smaller than overlay to prevent glitchy scrollbars
+	if (g_system->getOverlayWidth() > 320) { // hires
+		width = 440 + 800 * (scale_factor - 1);
+		textline_numchars = 70 + 80 * (scale_factor - 1);
+		progressBarWidth = 240;
+		commentDelta *= scale_factor;
+		if (g_system->getOverlayWidth() - width < 100) {
+			width = g_system->getOverlayWidth() - 100 * scale_factor; // clamp width to at least 100px smaller than overlay to prevent glitchy scrollbars
+		}
+	} else { // lores
+		width = 250 + 480 * (scale_factor - 1);
+		textline_numchars = 40 + 60 * (scale_factor - 1);
+		progressBarWidth = 130;
+	}
 
 	for (int16 viewAchieved = 1; viewAchieved >= 0; viewAchieved--) {
 		// run this twice, first view all achieved, then view all non-hidden & non-achieved
@@ -1459,8 +1468,7 @@ void OptionsDialog::addAchievementsControls(GuiObject *boss, const Common::Strin
 				uint16 str_chars = descr->comment.size(), printed_chars = 0, i = 0;
 				Common::U32String comment_line(descr->comment);
 				while ((str_chars - printed_chars) > textline_numchars) { // check if string needs to go on multiple lines
-					for (i = (printed_chars + textline_numchars - 1); comment_line[i] != ' ' && i > 0; i--)
-						; // find a space to avoid breaking words
+					for (i = (printed_chars + textline_numchars - 1); comment_line[i] != ' ' && i > 0; i--) {}; // find a space to avoid breaking words
 					new StaticTextWidget(scrollContainer, lineHeight + commentDelta, yPos, width - commentDelta, yStep, Common::U32String(comment_line.begin() + (!printed_chars ? 0 : (printed_chars + 1)), comment_line.begin() + i), Graphics::kTextAlignStart, Common::U32String(), ThemeEngine::kFontStyleNormal);
 					yPos += yStep;
 					printed_chars = i;

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -1413,14 +1413,21 @@ void OptionsDialog::addAchievementsControls(GuiObject *boss, const Common::Strin
 	uint16 nAchieved = 0;
 	uint16 nHidden = 0;
 	uint16 nMax = AchMan.getAchievementCount();
-
 	uint16 lineHeight = g_gui.xmlEval()->getVar("Globals.Line.Height");
 	uint16 yStep = lineHeight;
 	uint16 ySmallStep = yStep / 3;
 	uint16 yPos = lineHeight + yStep * 3;
+
+	uint16 commentDelta = g_system->getOverlayWidth() <= 320 ? 25 : 30; // textline left tabbing
 	uint16 progressBarWidth = 240;
-	uint16 width = g_system->getOverlayWidth() <= 320 ? 240 : 410;
-	uint16 commentDelta = g_system->getOverlayWidth() <= 320 ? 25 : 30;
+	float scale_factor = g_gui.getScaleFactor();
+
+	uint16 width = 440 + 800 * (scale_factor - 1);
+	uint16 textline_numchars = 70 + 80 * (scale_factor - 1);
+	commentDelta *= scale_factor;
+
+	if (g_system->getOverlayWidth() - width < 100)
+		width = g_system->getOverlayWidth() - 100 * scale_factor; // clamp width to at least 100px smaller than overlay to prevent glitchy scrollbars
 
 	for (int16 viewAchieved = 1; viewAchieved >= 0; viewAchieved--) {
 		// run this twice, first view all achieved, then view all non-hidden & non-achieved
@@ -1448,11 +1455,20 @@ void OptionsDialog::addAchievementsControls(GuiObject *boss, const Common::Strin
 			checkBox->setState(isAchieved);
 			yPos += yStep;
 
-	        if (!descr->comment.empty()) {
-				new StaticTextWidget(scrollContainer, lineHeight + commentDelta, yPos, width - commentDelta, yStep, Common::U32String(descr->comment), Graphics::kTextAlignStart, Common::U32String(), ThemeEngine::kFontStyleNormal);
+			if (!descr->comment.empty()) {
+				uint16 str_chars = descr->comment.size(), printed_chars = 0, i = 0;
+				Common::U32String comment_line(descr->comment);
+				while ((str_chars - printed_chars) > textline_numchars) { // check if string needs to go on multiple lines
+					for (i = (printed_chars + textline_numchars - 1); comment_line[i] != ' ' && i > 0; i--)
+						; // find a space to avoid breaking words
+					new StaticTextWidget(scrollContainer, lineHeight + commentDelta, yPos, width - commentDelta, yStep, Common::U32String(comment_line.begin() + (!printed_chars ? 0 : (printed_chars + 1)), comment_line.begin() + i), Graphics::kTextAlignStart, Common::U32String(), ThemeEngine::kFontStyleNormal);
+					yPos += yStep;
+					printed_chars = i;
+					i++; // to skip trailing space when leaving the loop
+				}
+				new StaticTextWidget(scrollContainer, lineHeight + commentDelta, yPos, width - commentDelta, yStep, Common::U32String(comment_line.begin() + i, comment_line.end()), Graphics::kTextAlignStart, Common::U32String(), ThemeEngine::kFontStyleNormal);
 				yPos += yStep;
 			}
-
 			yPos += ySmallStep;
 		}
 	}


### PR DESCRIPTION
This PR improves the display of the achievements descriptions in the achievements tab, taking gui scale
into account and splitting the string into two or more lines if needed.

Reported in TRAC [12946](https://bugs.scummvm.org/ticket/12946)

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
