### PR TITLE
GRAPHICS: Additional changes for RGB332 overlays

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -1486,11 +1486,30 @@ bool SurfaceSdlGraphicsManager::saveScreenshot(const Common::String &filename) c
 	Graphics::PixelFormat format = convertSDLPixelFormat(_hwScreen->format);
 	Graphics::Surface data;
 	data.init(_hwScreen->w, _hwScreen->h, _hwScreen->pitch, _hwScreen->pixels, format);
+
+	bool success;
+
+	SDL_Palette *sdlPalette = _hwScreen->format->palette;
+	if (sdlPalette) {
+		byte palette[256 * 3];
+		for (int i = 0; i < sdlPalette->ncolors; i++) {
+			palette[(i * 3) + 0] = sdlPalette->colors[i].r;
+			palette[(i * 3) + 1] = sdlPalette->colors[i].g;
+			palette[(i * 3) + 2] = sdlPalette->colors[i].b;
+		}
+
 #ifdef USE_PNG
-	const bool success = Image::writePNG(out, data);
+		success = Image::writePNG(out, data, palette);
 #else
-	const bool success = Image::writeBMP(out, data);
+		success = Image::writeBMP(out, data, palette);
 #endif
+	} else {
+#ifdef USE_PNG
+		success = Image::writePNG(out, data);
+#else
+		success = Image::writeBMP(out, data);
+#endif
+	}
 
 	SDL_UnlockSurface(_hwScreen);
 

--- a/graphics/fonts/ttf.cpp
+++ b/graphics/fonts/ttf.cpp
@@ -721,7 +721,7 @@ void TTFFont::drawChar(Surface * dst, uint32 chr, int x, int y, uint32 color,
 
 	uint8 *dstPos = (uint8 *)dst->getBasePtr(x, y);
 
-	if (dst->format.bytesPerPixel == 1) {
+	if (dst->format.isCLUT8()) {
 		for (int cy = 0; cy < h; ++cy) {
 			uint8 *rDst = dstPos;
 			const uint8 *src = srcPos;
@@ -739,6 +739,8 @@ void TTFFont::drawChar(Surface * dst, uint32 chr, int x, int y, uint32 color,
 			dstPos += dst->pitch;
 			srcPos += glyph.image.pitch;
 		}
+	} else if (dst->format.bytesPerPixel == 1) {
+		renderGlyph<uint8>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format, transparentColor);
 	} else if (dst->format.bytesPerPixel == 2) {
 		renderGlyph<uint16>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format, transparentColor);
 	} else if (dst->format.bytesPerPixel == 4) {

--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -290,15 +290,17 @@ void ManagedSurface::blitFromInner(const Surface &src, const Common::Rect &srcRe
 
 	bool isSameFormat = (destFormat == srcFormat);
 	if (!isSameFormat) {
-		// When the pixel format differs, the destination must be non-paletted
-		assert(destFormat.bytesPerPixel == 2 || destFormat.bytesPerPixel == 3 || destFormat.bytesPerPixel == 4);
-		assert(srcFormat.bytesPerPixel == 2 || srcFormat.bytesPerPixel == 3 || srcFormat.bytesPerPixel == 4
-			|| (srcFormat.bytesPerPixel == 1 && srcPalette));
+		assert(destFormat.bytesPerPixel == 1 || destFormat.bytesPerPixel == 2 || destFormat.bytesPerPixel == 3 || destFormat.bytesPerPixel == 4);
+		assert(srcFormat.bytesPerPixel == 1 || srcFormat.bytesPerPixel == 2 || srcFormat.bytesPerPixel == 3 || srcFormat.bytesPerPixel == 4);
+		if (srcFormat.bytesPerPixel == 1) {
+			// When the pixel format differs, the destination must be non-paletted
+			assert(!destFormat.isCLUT8() || srcPalette);
+		}
 	}
 
 
 	uint32 alphaMask = 0;
-	if (srcFormat.bytesPerPixel == 1) {
+	if (srcFormat.isCLUT8()) {
 		alphaMask = 0xff000000u;
 	} else {
 		if (srcFormat.aBits() > 0)
@@ -314,7 +316,7 @@ void ManagedSurface::blitFromInner(const Surface &src, const Common::Rect &srcRe
 
 		// For paletted format, assume the palette is the same and there is no transparency.
 		// We can thus do a straight copy of the pixels.
-		if (destFormat.bytesPerPixel == 1 && noScale) {
+		if (destFormat.isCLUT8() && noScale) {
 			int width = srcRect.width();
 			if (destRect.left + width > w)
 				width = w - destRect.left;
@@ -335,19 +337,21 @@ void ManagedSurface::blitFromInner(const Surface &src, const Common::Rect &srcRe
 
 			const byte *srcVal = &srcP[scaleXCtr / SCALE_THRESHOLD * srcFormat.bytesPerPixel];
 			byte *destVal = &destP[xCtr * destFormat.bytesPerPixel];
-			if (destFormat.bytesPerPixel == 1) {
+			if (destFormat.isCLUT8()) {
 				*destVal = *srcVal;
 				continue;
 			}
 
 			uint32 col = 0;
-			if (srcFormat.bytesPerPixel == 1) {
+			if (srcFormat.isCLUT8()) {
 				assert(srcPalette != nullptr);	// Catch the cases when palette is missing
 				// Get the palette color
 				col = srcPalette[*srcVal];
 			} else {
 				// Use the src's pixel format to split up the source pixel
-				if (srcFormat.bytesPerPixel == 2)
+				if (srcFormat.bytesPerPixel == 1)
+					col = *reinterpret_cast<const uint8 *>(srcVal);
+				else if (srcFormat.bytesPerPixel == 2)
 					col = *reinterpret_cast<const uint16 *>(srcVal);
 				else if (srcFormat.bytesPerPixel == 4)
 					col = *reinterpret_cast<const uint32 *>(srcVal);
@@ -371,7 +375,7 @@ void ManagedSurface::blitFromInner(const Surface &src, const Common::Rect &srcRe
 				byte aDest = 0, rDest = 0, gDest = 0, bDest = 0;
 
 				// Different format or partially transparent
-				if (srcFormat.bytesPerPixel == 1) {
+				if (srcFormat.isCLUT8()) {
 					rSrc = col & 0xff;
 					gSrc = (col >> 8) & 0xff;
 					bSrc = (col >> 16) & 0xff;
@@ -388,7 +392,9 @@ void ManagedSurface::blitFromInner(const Surface &src, const Common::Rect &srcRe
 				} else {
 					// Partially transparent, so calculate new pixel colors
 					uint32 destColor;
-					if (destFormat.bytesPerPixel == 2)
+					if (destFormat.bytesPerPixel == 1)
+						destColor = *reinterpret_cast<uint8 *>(destVal);
+					else if (destFormat.bytesPerPixel == 2)
 						destColor = *reinterpret_cast<uint16 *>(destVal);
 					else if (destFormat.bytesPerPixel == 4)
 						destColor = *reinterpret_cast<uint32 *>(destVal);
@@ -417,7 +423,9 @@ void ManagedSurface::blitFromInner(const Surface &src, const Common::Rect &srcRe
 				destPixel = destFormat.ARGBToColor(aDest, rDest, gDest, bDest);
 			}
 
-			if (destFormat.bytesPerPixel == 2)
+			if (destFormat.bytesPerPixel == 1)
+				*(uint8 *)destVal = destPixel;
+			else if (destFormat.bytesPerPixel == 2)
 				*(uint16 *)destVal = destPixel;
 			else if (destFormat.bytesPerPixel == 4)
 				*(uint32 *)destVal = destPixel;
@@ -546,7 +554,7 @@ void transBlitPixel(TSRC srcVal, TDEST &destVal, const Graphics::PixelFormat &sr
 		uint32 overrideColor, uint32 srcAlpha, const uint32 *srcPalette, const byte *lookup) {
 	// Decode and re-encode each pixel
 	byte aSrc, rSrc, gSrc, bSrc;
-	if (srcFormat.bytesPerPixel == 1) {
+	if (srcFormat.isCLUT8()) {
 		assert(srcPalette != nullptr);	// Catch the cases when palette is missing
 
 		// Get the palette color
@@ -705,13 +713,15 @@ void ManagedSurface::transBlitFromInner(const Surface &src, const Common::Rect &
 			error("Surface::transBlitFrom: mask dimensions do not match src");
 	}
 
-	HANDLE_BLIT(1, 1, byte, byte)
-	HANDLE_BLIT(1, 2, byte, uint16)
-	HANDLE_BLIT(1, 4, byte, uint32)
+	HANDLE_BLIT(1, 1, uint8,  uint8)
+	HANDLE_BLIT(1, 2, uint8,  uint16)
+	HANDLE_BLIT(1, 4, uint8,  uint32)
+	HANDLE_BLIT(2, 1, uint16, uint8)
 	HANDLE_BLIT(2, 2, uint16, uint16)
-	HANDLE_BLIT(4, 4, uint32, uint32)
 	HANDLE_BLIT(2, 4, uint16, uint32)
+	HANDLE_BLIT(4, 1, uint32, uint8)
 	HANDLE_BLIT(4, 2, uint32, uint16)
+	HANDLE_BLIT(4, 4, uint32, uint32)
 	error("Surface::transBlitFrom: bytesPerPixel must be 1, 2, or 4");
 
 	// Mark the affected area

--- a/image/bmp.cpp
+++ b/image/bmp.cpp
@@ -153,7 +153,7 @@ bool BitmapDecoder::loadStream(Common::SeekableReadStream &stream) {
 	return true;
 }
 
-bool writeBMP(Common::WriteStream &out, const Graphics::Surface &input) {
+bool writeBMP(Common::WriteStream &out, const Graphics::Surface &input, const byte *palette) {
 #ifdef SCUMM_LITTLE_ENDIAN
 	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 16, 8, 0, 0);
 #else
@@ -166,7 +166,7 @@ bool writeBMP(Common::WriteStream &out, const Graphics::Surface &input) {
 	if (input.format == requiredFormat_3byte) {
 		surface = &input;
 	} else {
-		surface = tmp = input.convertTo(requiredFormat_3byte);
+		surface = tmp = input.convertTo(requiredFormat_3byte, palette);
 	}
 
 	int dstPitch = surface->w * 3;

--- a/image/bmp.h
+++ b/image/bmp.h
@@ -86,7 +86,7 @@ private:
 /**
  * Outputs an uncompressed BMP stream of the given input surface.
  */
-bool writeBMP(Common::WriteStream &out, const Graphics::Surface &input);
+bool writeBMP(Common::WriteStream &out, const Graphics::Surface &input, const byte *palette = nullptr);
 /** @} */
 } // End of namespace Image
 


### PR DESCRIPTION
This fixes some crashes and visual issues when using hardware palettes in non-RS90 builds, although there are still some issues with the mouse and OSD, as well as when opening the GMM in-game.