### PR TITLE
STARK: Add initial OpenGL ES 1 support

### DIFF
--- a/backends/graphics3d/opengl/framebuffer.cpp
+++ b/backends/graphics3d/opengl/framebuffer.cpp
@@ -37,6 +37,8 @@
 
 namespace OpenGL {
 
+#if !USE_FORCED_GLES
+
 static bool usePackedBuffer() {
 	return OpenGLContext.packedDepthStencilSupported;
 }
@@ -183,6 +185,7 @@ void MultiSampleFrameBuffer::detach() {
 }
 
 #endif // !USE_FORCED_GLES2
+#endif // !USE_FORCED_GLES
 
 } // End of namespace OpenGL
 

--- a/backends/graphics3d/opengl/framebuffer.h
+++ b/backends/graphics3d/opengl/framebuffer.h
@@ -30,14 +30,21 @@
 
 namespace OpenGL {
 
-class FrameBuffer : public TextureGL {
+class BaseFrameBuffer : public TextureGL {
+public:
+	virtual void attach() = 0;
+	virtual void detach() = 0;
+};
+
+#if !USE_FORCED_GLES
+class FrameBuffer : public BaseFrameBuffer {
 public:
 	FrameBuffer(uint width, uint height);
 	FrameBuffer(GLuint texture_name, uint width, uint height, uint texture_width, uint texture_height);
 	virtual ~FrameBuffer();
 
-	virtual void attach();
-	virtual void detach();
+	void attach() override;
+	void detach() override;
 
 protected:
 	GLuint getFrameBufferName() const { return _frameBuffer; }
@@ -54,8 +61,8 @@ public:
 	MultiSampleFrameBuffer(uint width, uint height, int samples);
 	virtual ~MultiSampleFrameBuffer();
 
-	virtual void attach();
-	virtual void detach();
+	void attach() override;
+	void detach() override;
 
 private:
 	void init();
@@ -64,6 +71,7 @@ private:
 	GLuint _msDepthId;
 	GLuint _msSamples;
 };
+#endif
 #endif
 
 } // End of namespace OpenGL

--- a/backends/graphics3d/opengl/surfacerenderer.cpp
+++ b/backends/graphics3d/opengl/surfacerenderer.cpp
@@ -84,13 +84,13 @@ FixedSurfaceRenderer::~FixedSurfaceRenderer() {
 
 void FixedSurfaceRenderer::prepareState() {
 	// Save current state
-	glPushAttrib(GL_TRANSFORM_BIT | GL_VIEWPORT_BIT | GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_SCISSOR_BIT | GL_PIXEL_MODE_BIT | GL_TEXTURE_BIT);
+	// glPushAttrib(GL_TRANSFORM_BIT | GL_VIEWPORT_BIT | GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_SCISSOR_BIT | GL_PIXEL_MODE_BIT | GL_TEXTURE_BIT);
 
 	// prepare view
 	glMatrixMode(GL_PROJECTION);
 	glPushMatrix();
 	glLoadIdentity();
-	glOrtho(0, 1.0, 1.0, 0, 0, 1);
+	glOrthof(0, 1.0, 1.0, 0, 0, 1);
 
 	glMatrixMode(GL_MODELVIEW);
 	glPushMatrix();
@@ -128,13 +128,13 @@ void FixedSurfaceRenderer::render(const TextureGL *tex, const Math::Rect2d &dest
 	vertices[1].y = offsetY;
 	vertices[1].u = texcropX;
 	vertices[1].v = texTop;
-	vertices[2].x = offsetX + sizeX;
+	vertices[2].x = offsetX;
 	vertices[2].y = offsetY + sizeY;
-	vertices[2].u = texcropX;
+	vertices[2].u = 0.0f;
 	vertices[2].v = texBottom;
-	vertices[3].x = offsetX;
+	vertices[3].x = offsetX + sizeX;
 	vertices[3].y = offsetY + sizeY;
-	vertices[3].u = 0.0f;
+	vertices[3].u = texcropX;
 	vertices[3].v = texBottom;
 
 	glColor4f(1.0, 1.0, 1.0, 1.0);
@@ -147,7 +147,7 @@ void FixedSurfaceRenderer::render(const TextureGL *tex, const Math::Rect2d &dest
 	glVertexPointer(2, GL_FLOAT, sizeof(SurfaceVertex), &vertices[0].x);
 	glTexCoordPointer(2, GL_FLOAT, sizeof(SurfaceVertex), &vertices[0].u);
 
-	glDrawArrays(GL_QUADS, 0, 4);
+	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
 	glDisableClientState(GL_VERTEX_ARRAY);
 	glDisableClientState(GL_TEXTURE_COORD_ARRAY);
@@ -163,7 +163,7 @@ void FixedSurfaceRenderer::restorePreviousState() {
 	glMatrixMode(GL_TEXTURE);
 	glPopMatrix();
 
-	glPopAttrib();
+	// glPopAttrib();
 
 	_flipY = false;
 	_alphaBlending = false;

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -79,6 +79,9 @@ OpenGLSdlGraphics3dManager::OpenGLSdlGraphics3dManager(SdlEventSource *eventSour
 		DEFAULT_GL_MINOR = 3,
 #endif
 
+		DEFAULT_GLES_MAJOR = 1,
+		DEFAULT_GLES_MINOR = 1,
+
 		DEFAULT_GLES2_MAJOR = 2,
 		DEFAULT_GLES2_MINOR = 0
 	};
@@ -88,6 +91,11 @@ OpenGLSdlGraphics3dManager::OpenGLSdlGraphics3dManager(SdlEventSource *eventSour
 	_glContextProfileMask = SDL_GL_CONTEXT_PROFILE_ES;
 	_glContextMajor = DEFAULT_GLES2_MAJOR;
 	_glContextMinor = DEFAULT_GLES2_MINOR;
+#elif USE_FORCED_GLES
+	_glContextType = OpenGL::kContextGLES;
+	_glContextProfileMask = SDL_GL_CONTEXT_PROFILE_ES;
+	_glContextMajor = DEFAULT_GLES_MAJOR;
+	_glContextMinor = DEFAULT_GLES_MINOR;
 #else
 	bool noDefaults = false;
 
@@ -620,7 +628,8 @@ void OpenGLSdlGraphics3dManager::drawOverlay() {
 	_surfaceRenderer->restorePreviousState();
 }
 
-OpenGL::FrameBuffer *OpenGLSdlGraphics3dManager::createFramebuffer(uint width, uint height) {
+OpenGL::BaseFrameBuffer *OpenGLSdlGraphics3dManager::createFramebuffer(uint width, uint height) {
+#if !USE_FORCED_GLES
 #if !USE_FORCED_GLES2
 	if (_antialiasing && OpenGLContext.framebufferObjectMultisampleSupported) {
 		return new OpenGL::MultiSampleFrameBuffer(width, height, _antialiasing);
@@ -629,6 +638,9 @@ OpenGL::FrameBuffer *OpenGLSdlGraphics3dManager::createFramebuffer(uint width, u
 	{
 		return new OpenGL::FrameBuffer(width, height);
 	}
+#else
+	return nullptr;
+#endif
 }
 
 void OpenGLSdlGraphics3dManager::updateScreen() {

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
@@ -31,7 +31,7 @@
 #include "graphics/opengl/context.h"
 
 namespace OpenGL {
-	class FrameBuffer;
+	class BaseFrameBuffer;
 	class SurfaceRenderer;
 	class TextureGL;
 	class TiledSurface;
@@ -172,8 +172,8 @@ protected:
 	void drawOverlay();
 	void closeOverlay();
 
-	OpenGL::FrameBuffer *_frameBuffer;
-	OpenGL::FrameBuffer *createFramebuffer(uint width, uint height);
+	OpenGL::BaseFrameBuffer *_frameBuffer;
+	OpenGL::BaseFrameBuffer *createFramebuffer(uint width, uint height);
 	bool shouldRenderToFramebuffer() const;
 
 protected:

--- a/configure
+++ b/configure
@@ -6429,7 +6429,9 @@ echocheck "OpenGL for game"
 if test "$_opengl_can_compile" = "yes"; then
 	if test "$_opengl_mode" = "gles"; then
 		# GLES 1.x is not supported for 3D games
-		_opengl_game_classic=no
+		if test "$_opengl_game_classic" != "no"; then
+			_opengl_game_classic=yes
+		fi
 		_opengl_game_shaders=no
 	elif test "$_opengl_mode" = "gles2"; then
 		# GLES2 doesn't support GL classic

--- a/engines/stark/gfx/openglactor.cpp
+++ b/engines/stark/gfx/openglactor.cpp
@@ -105,7 +105,10 @@ void OpenGLActorRenderer::render(const Math::Vector3d &position, float direction
 	const Common::Array<BoneNode *> &bones = _model->getBones();
 
 	if (!_gfx->computeLightsEnabled()) {
-		glColorMaterial(GL_FRONT_AND_BACK, GL_DIFFUSE);
+#if !USE_FORCED_GLES
+		if (OpenGLContext.type != OpenGL::kContextGLES) {
+			glColorMaterial(GL_FRONT_AND_BACK, GL_DIFFUSE);
+#endif
 		glEnable(GL_COLOR_MATERIAL);
 	}
 
@@ -127,12 +130,12 @@ void OpenGLActorRenderer::render(const Math::Vector3d &position, float direction
 				if (_gfx->computeLightsEnabled())
 					color = Math::Vector3d(1.0f, 1.0f, 1.0f);
 				else
-					glColor3f(1.0f, 1.0f, 1.0f);
+					glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 			} else {
 				if (_gfx->computeLightsEnabled())
 					color = Math::Vector3d(material->r, material->g, material->b);
 				else
-					glColor3f(material->r, material->g, material->b);
+					glColor4f(material->r, material->g, material->b, 1.0f);
 			}
 			uint32 index = vertexIndices[i];
 			auto vertex = _faceVBO[index];
@@ -252,6 +255,7 @@ void OpenGLActorRenderer::render(const Math::Vector3d &position, float direction
 				vertex.r = color.x();
 				vertex.g = color.y();
 				vertex.b = color.z();
+				vertex.a = 0xff; /* needed for compatibility with OpenGL ES 1.x */
 			}
 
 			_faceVBO[index] = vertex;
@@ -269,7 +273,7 @@ void OpenGLActorRenderer::render(const Math::Vector3d &position, float direction
 			glTexCoordPointer(2, GL_FLOAT, sizeof(ActorVertex), &_faceVBO[0].texS);
 		glNormalPointer(GL_FLOAT, sizeof(ActorVertex), &_faceVBO[0].nx);
 		if (_gfx->computeLightsEnabled())
-			glColorPointer(3, GL_FLOAT, sizeof(ActorVertex), &_faceVBO[0].r);
+			glColorPointer(4, GL_FLOAT, sizeof(ActorVertex), &_faceVBO[0].r);
 
 		glDrawElements(GL_TRIANGLES, numVertexIndices, GL_UNSIGNED_INT, vertexIndices);
 

--- a/engines/stark/gfx/openglactor.h
+++ b/engines/stark/gfx/openglactor.h
@@ -65,6 +65,7 @@ struct _ActorVertex {
 	float r;
 	float g;
 	float b;
+	float a;
 };
 typedef _ActorVertex ActorVertex;
 

--- a/engines/stark/gfx/openglprop.cpp
+++ b/engines/stark/gfx/openglprop.cpp
@@ -94,12 +94,14 @@ void OpenGLPropRenderer::render(const Math::Vector3d &position, float direction,
 		}
 		auto vertexIndices = _faceEBO[face];
 		auto numVertexIndices = (face)->vertexIndices.size();
-		if (!_gfx->computeLightsEnabled()) {
+#if !USE_FORCED_GLES
+		if (!_gfx->computeLightsEnabled() && OpenGLContext.type != OpenGL::kContextGLES) {
 			if (material.doubleSided)
 				glColorMaterial(GL_FRONT_AND_BACK, GL_DIFFUSE);
 			else
 				glColorMaterial(GL_FRONT, GL_DIFFUSE);
 		}
+#endif
 		for (uint32 i = 0; i < numVertexIndices; i++) {
 			uint32 index = vertexIndices[i];
 			auto vertex = _faceVBO[index];
@@ -107,7 +109,7 @@ void OpenGLPropRenderer::render(const Math::Vector3d &position, float direction,
 				if (_gfx->computeLightsEnabled())
 					color = Math::Vector3d(1.0f, 1.0f, 1.0f);
 				else
-					glColor3f(1.0f, 1.0f, 1.0f);
+					glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 				if (material.doubleSided) {
 					vertex.texS = vertex.stexS;
 					vertex.texT = 1.0f - vertex.stexT;
@@ -119,7 +121,7 @@ void OpenGLPropRenderer::render(const Math::Vector3d &position, float direction,
 				if (_gfx->computeLightsEnabled())
 					color = Math::Vector3d(material.r, material.g, material.b);
 				else
-					glColor3f(material.r, material.g, material.b);
+					glColor4f(material.r, material.g, material.b, 1.0f);
 			}
 
 			if (_gfx->computeLightsEnabled()) {
@@ -183,6 +185,7 @@ void OpenGLPropRenderer::render(const Math::Vector3d &position, float direction,
 				vertex.r = color.x();
 				vertex.g = color.y();
 				vertex.b = color.z();
+				vertex.a = 0xff; /* needed for compatibility with OpenGL ES 1.x */
 			}
 			_faceVBO[index] = vertex;
 		}
@@ -199,7 +202,7 @@ void OpenGLPropRenderer::render(const Math::Vector3d &position, float direction,
 			glTexCoordPointer(2, GL_FLOAT, sizeof(PropVertex), &_faceVBO[0].texS);
 		glNormalPointer(GL_FLOAT, sizeof(PropVertex), &_faceVBO[0].nx);
 		if (_gfx->computeLightsEnabled())
-			glColorPointer(3, GL_FLOAT, sizeof(PropVertex), &_faceVBO[0].r);
+			glColorPointer(4, GL_FLOAT, sizeof(PropVertex), &_faceVBO[0].r);
 
 		glDrawElements(GL_TRIANGLES, face->vertexIndices.size(), GL_UNSIGNED_INT, vertexIndices);
 

--- a/engines/stark/gfx/openglprop.h
+++ b/engines/stark/gfx/openglprop.h
@@ -53,6 +53,7 @@ struct _PropVertex {
 	float r;
 	float g;
 	float b;
+	float a;
 };
 typedef _PropVertex PropVertex;
 

--- a/engines/stark/gfx/openglsurface.cpp
+++ b/engines/stark/gfx/openglsurface.cpp
@@ -72,7 +72,7 @@ void OpenGLSurfaceRenderer::render(const Bitmap *bitmap, const Common::Point &de
 
 	glVertexPointer(2, GL_FLOAT, sizeof(SurfaceVertex), &vertices[0].x);
 	glTexCoordPointer(2, GL_FLOAT, 2 * sizeof(float), textCords);
-	glColor3f(1.0f - _fadeLevel, 1.0f - _fadeLevel, 1.0f - _fadeLevel);
+	glColor4f(1.0f - _fadeLevel, 1.0f - _fadeLevel, 1.0f - _fadeLevel, 1.0f);
 
 	bitmap->bind();
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);

--- a/engines/stark/gfx/opengltexture.cpp
+++ b/engines/stark/gfx/opengltexture.cpp
@@ -83,8 +83,11 @@ void OpenGlTexture::setLevelCount(uint32 count) {
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 		}
 
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_MIRRORED_REPEAT);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_MIRRORED_REPEAT);
+		// TODO: Provide a fallback if this isn't available.
+		if (OpenGLContext.textureMirrorRepeatSupported) {
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_MIRRORED_REPEAT);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_MIRRORED_REPEAT);
+		}
 	}
 }
 

--- a/graphics/opengl/context.cpp
+++ b/graphics/opengl/context.cpp
@@ -187,9 +187,10 @@ void Context::initialize(ContextType contextType) {
 			OESDepth24 = true;
 		} else if (token == "GL_SGIS_texture_edge_clamp") {
 			textureEdgeClampSupported = true;
-		} else if (token == "GL_SGIS_texture_border_clamp") {
+		} else if (token == "GL_ARB_texture_border_clamp" || token == "GL_SGIS_texture_border_clamp" || token == "GL_OES_texture_border_clamp" ||
+		           token == "GL_EXT_texture_border_clamp" || token == "GL_NV_texture_border_clamp") {
 			textureBorderClampSupported = true;
-		} else if (token == "GL_ARB_texture_mirrored_repeat") {
+		} else if (token == "GL_ARB_texture_mirrored_repeat" || token == "GL_OES_texture_mirrored_repeat" || token == "GL_IBM_texture_mirrored_repeat") {
 			textureMirrorRepeatSupported = true;
 		} else if (token == "GL_SGIS_texture_lod" || token == "GL_APPLE_texture_max_level") {
 			textureMaxLevelSupported = true;
@@ -234,7 +235,9 @@ void Context::initialize(ContextType contextType) {
 		// So if we use GLAD we can check for ARB extensions and expect a GLSL of 1.00
 #ifdef USE_GLAD
 		shadersSupported = ARBShaderObjects && ARBShadingLanguage100 && ARBVertexShader && ARBFragmentShader;
-		glslVersion = 100;
+		if (shadersSupported) {
+			glslVersion = 100;
+		}
 #endif
 		// We don't expect GLES to support shaders recent enough for engines
 
@@ -291,7 +294,11 @@ void Context::initialize(ContextType contextType) {
 		warning("OpenGL: Unknown context initialized");
 	}
 
+#if !USE_FORCED_GLES
 	const char *glslVersionString = (const char *)glGetString(GL_SHADING_LANGUAGE_VERSION);
+#else
+	const char *glslVersionString = NULL;
+#endif
 
 	// Log features supported by GL context.
 	debug(5, "OpenGL version: %s", verString);

--- a/graphics/opengl/system_headers.h
+++ b/graphics/opengl/system_headers.h
@@ -70,20 +70,6 @@
 	#endif
 	#undef GL_GLEXT_PROTOTYPES
 
-	#ifndef GL_BGRA
-		#define GL_BGRA GL_BGRA_EXT
-	#endif
-
-	#if !defined(GL_UNPACK_ROW_LENGTH)
-		// The Android SDK does not declare GL_UNPACK_ROW_LENGTH_EXT
-		#define GL_UNPACK_ROW_LENGTH 0x0CF2
-	#endif
-
-	#if !defined(GL_MAX_SAMPLES)
-		// The Android SDK and SDL1 don't declare GL_MAX_SAMPLES
-		#define GL_MAX_SAMPLES 0x8D57
-	#endif
-
 #elif USE_FORCED_GLES
 
 	#define GL_GLEXT_PROTOTYPES
@@ -97,10 +83,34 @@
 	#undef GL_GLEXT_PROTOTYPES
 
 #endif
+
+#if !defined(GL_BGRA) && defined(GL_BGRA_EXT)
+	#define GL_BGRA GL_BGRA_EXT
+#endif
+
+#if !defined(GL_MIRRORED_REPEAT) && defined(GL_MIRRORED_REPEAT_OES)
+	#define GL_MIRRORED_REPEAT GL_MIRRORED_REPEAT_OES
 #endif
 
 #if !defined(GL_TEXTURE_MAX_LEVEL) && defined(GL_TEXTURE_MAX_LEVEL_APPLE)
 	#define GL_TEXTURE_MAX_LEVEL GL_TEXTURE_MAX_LEVEL_APPLE
+#endif
+
+#if !defined(GL_CLAMP_TO_BORDER)
+	// Multiple extensions provide this using the same value
+	#define GL_CLAMP_TO_BORDER 0x812D
+#endif
+
+#if !defined(GL_UNPACK_ROW_LENGTH)
+	// The Android SDK does not declare GL_UNPACK_ROW_LENGTH_EXT
+	#define GL_UNPACK_ROW_LENGTH 0x0CF2
+#endif
+
+#if !defined(GL_MAX_SAMPLES)
+	// The Android SDK and SDL1 don't declare GL_MAX_SAMPLES
+	#define GL_MAX_SAMPLES 0x8D57
+#endif
+
 #endif
 
 #endif


### PR DESCRIPTION
TODO:
- [ ] Split some of the standalone changes into separate PRs.
- [ ] Framebuffer support?
- [ ] Replace glPushAttrib and glPopAttrib
- [ ] Handle glOrtho vs glOrthof at runtime
- [ ] Detect OpenGL ES 1 at runtime
- [x] Fix crash when _computeLights is enabled
- [ ] Replace glColorMaterial
- [ ] Proper fallback when GL_OES_texture_border_clamp is missing?
- [ ] Ensure the other engines still build and run correctly.