### PR TITLE
SCUMM: Fix regression in Actor::animateActor from 546fd42749d

### DIFF
--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -2669,7 +2669,7 @@ void Actor::animateActor(int anim) {
 		// fall through
 	default:
 		if (_vm->_game.version <= 2)
-			startAnimActor(chore);
+			startAnimActor(anim >> 2);
 		else
 			startAnimActor(anim);
 	}


### PR DESCRIPTION
This would cause the meteor explosion in the Maniac Mansion (V2) intro to not play. Bug reported in Discord by Vanfanel