### PR TITLE
NETWORKING: fixed mixed malloc/delete/delete[]

### DIFF
--- a/backends/networking/curl/curlrequest.cpp
+++ b/backends/networking/curl/curlrequest.cpp
@@ -35,7 +35,7 @@ CurlRequest::CurlRequest(DataCallback cb, ErrorCallback ecb, Common::String url)
 
 CurlRequest::~CurlRequest() {
 	delete _stream;
-	delete _bytesBuffer;
+	delete[] _bytesBuffer;
 }
 
 NetworkReadStream *CurlRequest::makeStream() {
@@ -126,7 +126,7 @@ void CurlRequest::setBuffer(byte *buffer, uint32 size) {
 		warning("CurlRequest: added POST fields would be ignored, because buffer added");
 
 	if (_bytesBuffer)
-		delete _bytesBuffer;
+		delete[] _bytesBuffer;
 
 	_bytesBuffer = buffer;
 	_bytesBufferSize = size;

--- a/engines/scumm/he/moonbase/net_main.cpp
+++ b/engines/scumm/he/moonbase/net_main.cpp
@@ -85,7 +85,7 @@ int Net::addUser(char *shortName, char *longName) {
 		new Common::Callback<Net, Common::JSONValue *>(this, &Net::addUserCallback),
 		new Common::Callback<Net, Networking::ErrorResponse>(this, &Net::addUserErrorCallback));
 
-	char *buf = (char *)malloc(MAX_PACKET_SIZE);
+	char *buf = new char[MAX_PACKET_SIZE];
 	snprintf(buf, MAX_PACKET_SIZE, "{\"shortname\":\"%s\",\"longname\":\"%s\",\"sessionid\":%d}", shortName, longName, _sessionid);
 	rq.setPostData((byte *)buf, strlen(buf));
 	rq.setContentType("application/json");
@@ -145,7 +145,7 @@ int Net::createSession(char *name) {
 		new Common::Callback<Net, Common::JSONValue *>(this, &Net::createSessionCallback),
 		new Common::Callback<Net, Networking::ErrorResponse>(this, &Net::createSessionErrorCallback));
 
-	char *buf = (char *)malloc(MAX_PACKET_SIZE);
+	char *buf = new char[MAX_PACKET_SIZE];
 	snprintf(buf, MAX_PACKET_SIZE, "{\"name\":\"%s\"}", name);
 	rq.setPostData((byte *)buf, strlen(buf));
 	rq.setContentType("application/json");
@@ -207,7 +207,7 @@ int Net::endSession() {
 		new Common::Callback<Net, Common::JSONValue *>(this, &Net::endSessionCallback),
 		new Common::Callback<Net, Networking::ErrorResponse>(this, &Net::endSessionErrorCallback));
 
-	char *buf = (char *)malloc(MAX_PACKET_SIZE);
+	char *buf = new char[MAX_PACKET_SIZE];
 	snprintf(buf, MAX_PACKET_SIZE, "{\"sessionid\":%d, \"userid\":%d}", _sessionid, _myUserId);
 	rq.setPostData((byte *)buf, strlen(buf));
 	rq.setContentType("application/json");
@@ -239,7 +239,7 @@ void Net::disableSessionJoining() {
 		nullptr,
 		new Common::Callback<Net, Networking::ErrorResponse>(this, &Net::disableSessionJoiningErrorCallback));
 
-	char *buf = (char *)malloc(MAX_PACKET_SIZE);
+	char *buf = new char[MAX_PACKET_SIZE];
 	snprintf(buf, MAX_PACKET_SIZE, "{\"sessionid\":%d}", _sessionid);
 	rq->setPostData((byte *)buf, strlen(buf));
 	rq->setContentType("application/json");
@@ -292,7 +292,7 @@ bool Net::destroyPlayer(int32 playerDPID) {
 		nullptr,
 		new Common::Callback<Net, Networking::ErrorResponse>(this, &Net::destroyPlayerErrorCallback));
 
-	char *buf = (char *)malloc(MAX_PACKET_SIZE);
+	char *buf = new char[MAX_PACKET_SIZE];
 	snprintf(buf, MAX_PACKET_SIZE, "{\"sessionid\":%d, \"userid\":%d}", _sessionid, playerDPID);
 	rq->setPostData((byte *)buf, strlen(buf));
 	rq->setContentType("application/json");
@@ -593,7 +593,7 @@ bool Net::remoteReceiveData() {
 		new Common::Callback<Net, Common::JSONValue *>(this, &Net::remoteReceiveDataCallback),
 		new Common::Callback<Net, Networking::ErrorResponse>(this, &Net::remoteReceiveDataErrorCallback));
 
-	char *buf = (char *)malloc(MAX_PACKET_SIZE);
+	char *buf = new char[MAX_PACKET_SIZE];
 	snprintf(buf, MAX_PACKET_SIZE, "{\"sessionid\":%d, \"playerid\":%d}", _sessionid, _myUserId);
 	rq.setPostData((byte *)buf, strlen(buf));
 	rq.setContentType("application/json");


### PR DESCRIPTION
```
==84284== Mismatched free() / delete / delete []
==84284==    at 0x484371B: operator delete(void*) (vg_replace_malloc.c:923)
==84284==    by 0x5BFBBF: Networking::CurlRequest::~CurlRequest() (curlrequest.cpp:38)
==84284==    by 0x5C0963: Networking::CurlJsonRequest::~CurlJsonRequest() (curljsonrequest.cpp:40)
==84284==    by 0x5ACF0B: Cloud::GoogleDrive::GoogleDriveTokenRefresher::~GoogleDriveTokenRefresher() (googledrivetokenrefresher.cpp:37)
==84284==    by 0x5ACF27: Cloud::GoogleDrive::GoogleDriveTokenRefresher::~GoogleDriveTokenRefresher() (googledrivetokenrefresher.cpp:37)
==84284==    by 0x5BC2FC: Networking::ConnectionManager::interateRequests() (connectionmanager.cpp:189)
==84284==    by 0x5BC0FA: Networking::ConnectionManager::handle() (connectionmanager.cpp:158)
==84284==    by 0x5BBF45: Networking::connectionsThread(void*) (connectionmanager.cpp:127)
==84284==    by 0x5E6932: DefaultTimerManager::handler() (default-timer.cpp:110)
==84284==    by 0x5D7F04: timer_handler(unsigned int, void*) (sdl-timer.cpp:32)
==84284==    by 0x49283D3: ??? (in /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0.2600.1)
==84284==    by 0x4927F64: ??? (in /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0.2600.1)
```