### PR TITLE
NEVERHOOD: Allow loading NHC from extrapath

### DIFF
--- a/engines/neverhood/dialogs.cpp
+++ b/engines/neverhood/dialogs.cpp
@@ -63,13 +63,20 @@ NeverhoodOptionsWidget::NeverhoodOptionsWidget(GuiObject *boss, const Common::St
 		"NeverhoodGameOptionsDialog.RepeatWillieHint", _("Repeat useful Willie's hint"),
 		_("Repeat actual useful hint by Willie"));
 
-	Common::String path = ConfMan.get("path", _domain);
-	Common::FSDirectory dir(path);
-	Common::FSDirectory *langdir = dir.getSubDirectory("language");
+	Common::FSDirectory dir(ConfMan.get("path", _domain));
+	Common::String extraPath(ConfMan.get("extrapath", _domain));
+	Common::FSDirectory extraDir(extraPath);
+	Common::Array<Common::FSDirectory *> langdirs = { &dir, dir.getSubDirectory("language") };
+	if (!extraPath.empty()) {
+		langdirs.push_back(&extraDir);
+		langdirs.push_back(extraDir.getSubDirectory("language"));
+	}
 	_nhcFiles.push_back("");
-	if (langdir) {
+	for (Common::Array<Common::FSDirectory *>::const_iterator langdir = langdirs.begin(); langdir != langdirs.end(); langdir++) {
 		Common::ArchiveMemberList nhcFileList;
-		langdir->listMatchingMembers(nhcFileList, "*.nhc");
+		if (!(*langdir))
+			continue;
+		(*langdir)->listMatchingMembers(nhcFileList, "*.nhc");
 
 		for (Common::ArchiveMemberList::iterator iter = nhcFileList.begin(); iter != nhcFileList.end(); ++iter) {
 			Common::String nhcFileName = (*iter)->getName();

--- a/engines/neverhood/neverhood.cpp
+++ b/engines/neverhood/neverhood.cpp
@@ -70,6 +70,7 @@ Common::Error NeverhoodEngine::run() {
 	const Common::FSNode gameDataDir(ConfMan.get("path"));
 
 	SearchMan.addSubDirectoryMatching(gameDataDir, "data");
+	SearchMan.addSubDirectoryMatching(gameDataDir, "language");
 
 	_isSaveAllowed = false;
 
@@ -101,7 +102,7 @@ Common::Error NeverhoodEngine::run() {
 	}
 
 	Common::String nhcFile = ConfMan.get("nhc_file");
-	if (!nhcFile.empty() && _res->addNhcArchive("language/" + nhcFile + ".nhc")) {
+	if (!nhcFile.empty() && _res->addNhcArchive(nhcFile + ".nhc")) {
 		uint32 fontSpecHash = calcHash("asRecFont");
 		if (_res->nhcExists(fontSpecHash, kResTypeData)) {
 			DataResource fontData(this);


### PR DESCRIPTION
We can't use SearchMan directly in dialogs.cpp as the engine may not be running when dialogs.cpp is called

This has a quirk that you need to reopen settings after changing the extra path. Is there any way to avoid this quirk?