### PR TITLE
AGS: More commits from upstream

### DIFF
--- a/engines/ags/engine/ac/character.cpp
+++ b/engines/ags/engine/ac/character.cpp
@@ -83,7 +83,7 @@ void Character_AddInventory(CharacterInfo *chaa, ScriptInvItem *invi, int addInd
 	int ee;
 
 	if (invi == nullptr)
-		quit("!AddInventoryToCharacter: invalid invnetory number");
+		quit("!AddInventoryToCharacter: invalid inventory number");
 
 	int inum = invi->id;
 
@@ -641,7 +641,7 @@ void Character_LockViewOffsetEx(CharacterInfo *chap, int vii, int xoffs, int yof
 void Character_LoseInventory(CharacterInfo *chap, ScriptInvItem *invi) {
 
 	if (invi == nullptr)
-		quit("!LoseInventoryFromCharacter: invalid invnetory number");
+		quit("!LoseInventoryFromCharacter: invalid inventory number");
 
 	int inum = invi->id;
 

--- a/engines/ags/engine/ac/display.cpp
+++ b/engines/ags/engine/ac/display.cpp
@@ -84,16 +84,10 @@ Bitmap *create_textual_image(const char *text, int asspch, int isThought,
 	else if (use_thought_gui)
 		usingGui = _GP(game).options[OPT_THOUGHTGUI];
 
-	int padding = get_textwindow_padding(usingGui);
+	const int padding = get_textwindow_padding(usingGui);
 	const int paddingScaled = get_fixed_pixel_size(padding);
  	// Just in case screen size is not neatly divisible by 320x200
 	const int paddingDoubledScaled = get_fixed_pixel_size(padding * 2);
-
-	// FIXME: Fixes the display of the F1 help dialog in La Croix Pan,
-	// since it was previously incorrectly wrapping on the 's' at the end
-	// of the 'Cursors' word. May be due to minor differences in width calcs
-	if (padding == 3 && ConfMan.get("gameid") == "lacroixpan")
-		padding = 0;
 
 	// WORKAROUND: Guard Duty specifies a wii of 100,000, which is larger
 	// than can be supported by ScummVM's surface classes

--- a/engines/ags/engine/ac/display.h
+++ b/engines/ags/engine/ac/display.h
@@ -38,6 +38,9 @@ using AGS::Shared::GUIMain;
 // also accepts explicit overlay ID >= OVER_CUSTOM
 
 struct ScreenOverlay;
+Shared::Bitmap *create_textual_image(const char *text, int asspch, int isThought,
+									 int &xx, int &yy, int &adjustedXX, int &adjustedYY, int wii, int usingfont, int allowShrink,
+									 bool &alphaChannel);
 // Creates a textual overlay using the given parameters;
 // Pass yy = -1 to find Y co-ord automatically
 // allowShrink = 0 for none, 1 for leftwards, 2 for rightwards

--- a/engines/ags/engine/ac/game_state.cpp
+++ b/engines/ags/engine/ac/game_state.cpp
@@ -268,8 +268,7 @@ ScriptViewport *GameState::RegisterRoomViewport(int index, int32_t handle) {
 }
 
 void GameState::DeleteRoomViewport(int index) {
-	// NOTE: viewport 0 can not be deleted
-	if (index <= 0 || (size_t)index >= _roomViewports.size())
+	if (index < 0 || (size_t)index >= _roomViewports.size())
 		return;
 	auto handle = _scViewportHandles[index];
 	auto scobj = const_cast<ScriptViewport*>((const ScriptViewport*)ccGetObjectAddressFromHandle(handle));
@@ -328,8 +327,7 @@ ScriptCamera *GameState::RegisterRoomCamera(int index, int32_t handle) {
 }
 
 void GameState::DeleteRoomCamera(int index) {
-	// NOTE: camera 0 can not be deleted
-	if (index <= 0 || (size_t)index >= _roomCameras.size())
+	if (index < 0 || (size_t)index >= _roomCameras.size())
 		return;
 	auto handle = _scCameraHandles[index];
 	auto scobj = const_cast<ScriptCamera*>((const ScriptCamera*)ccGetObjectAddressFromHandle(handle));

--- a/engines/ags/engine/ac/global_inventory_item.cpp
+++ b/engines/ags/engine/ac/global_inventory_item.cpp
@@ -108,7 +108,7 @@ void RunInventoryInteraction(int iit, int modd) {
 		run_event_block_inv(iit, 3);
 	} else if (modd == MODE_TALK)
 		run_event_block_inv(iit, 2);
-	else // other click on invnetory
+	else // other click on inventory
 		run_event_block_inv(iit, 4);
 }
 

--- a/engines/ags/engine/ac/global_overlay.cpp
+++ b/engines/ags/engine/ac/global_overlay.cpp
@@ -57,7 +57,8 @@ int CreateTextOverlay(int xx, int yy, int wii, int fontid, int text_color, const
 void SetTextOverlay(int ovrid, int xx, int yy, int wii, int fontid, int text_color, const char *text) {
 	RemoveOverlay(ovrid);
 	const int disp_type = ovrid;
-	if (CreateTextOverlay(xx, yy, wii, fontid, text_color, text, disp_type) != ovrid)
+	int new_ovrid = CreateTextOverlay(xx, yy, wii, fontid, text_color, text, disp_type);
+	if (new_ovrid != ovrid)
 		quit("SetTextOverlay internal error: inconsistent type ids");
 }
 

--- a/engines/ags/engine/ac/global_overlay.cpp
+++ b/engines/ags/engine/ac/global_overlay.cpp
@@ -46,6 +46,7 @@ int CreateTextOverlay(int xx, int yy, int wii, int fontid, int text_color, const
 
 	if (xx != OVR_AUTOPLACE) {
 		data_to_game_coords(&xx, &yy);
+		// NOTE: this is ugly, but OVR_AUTOPLACE here suggests that width is already in game coords
 		wii = data_to_game_coord(wii);
 	} else  // allow DisplaySpeechBackground to be shrunk
 		allowShrink = 1;

--- a/engines/ags/engine/ac/overlay.cpp
+++ b/engines/ags/engine/ac/overlay.cpp
@@ -81,12 +81,8 @@ void Overlay_SetText(ScriptOverlay *scover, int width, int fontid, int text_colo
 										 width, fontid, allow_shrink, has_alpha);
 
 	// Update overlay properties
-	over.SetImage(image);
+	over.SetImage(image, adj_x - dummy_x, adj_y - dummy_y);
 	over.SetAlphaChannel(has_alpha);
-	over.x = x;
-	over.y = y;
-	over.offsetX = adj_x - dummy_x;
-	over.offsetY = adj_y - dummy_y;
 	over.ddb = nullptr; // is generated during first draw pass
 }
 
@@ -390,17 +386,15 @@ size_t add_screen_overlay_impl(bool roomlayer, int x, int y, int type, int sprnu
 	}
 	ScreenOverlay over;
 	if (piccy) {
-		over.SetImage(piccy);
+		over.SetImage(piccy, pic_offx, pic_offy);
 		over.SetAlphaChannel(has_alpha);
 	} else {
-		over.SetSpriteNum(sprnum);
+		over.SetSpriteNum(sprnum, pic_offx, pic_offy);
 		over.SetAlphaChannel((_GP(game).SpriteInfos[sprnum].Flags & SPF_ALPHACHANNEL) != 0);
 	}
 	over.ddb = nullptr; // is generated during first draw pass
 	over.x = x;
 	over.y = y;
-	over.offsetX = pic_offx;
-	over.offsetY = pic_offy;
 	// by default draw speech and portraits over GUI, and the rest under GUI
 	over.zorder = (roomlayer || type == OVER_TEXTMSG || type == OVER_PICTURE || type == OVER_TEXTSPEECH) ?
 		INT_MAX : INT_MIN;

--- a/engines/ags/engine/ac/overlay.cpp
+++ b/engines/ags/engine/ac/overlay.cpp
@@ -60,11 +60,18 @@ void Overlay_SetText(ScriptOverlay *scover, int wii, int fontid, int text_color,
 	int xx = game_to_data_coord(_GP(screenover)[ovri].x);
 	int yy = game_to_data_coord(_GP(screenover)[ovri].y);
 
-	RemoveOverlay(scover->overlayId);
+	// FIXME: a refactor needed!
+	// these calls to RemoveOverlay and CreateOverlay below are potentially dangerous,
+	// because they may allocate new script objects too under certain conditions.
+	// This did not happen because users only had access to custom overlay pointers before,
+	// but now they also may access internal overlays (such as Say text and portrait).
 	const int disp_type = scover->overlayId;
+	RemoveOverlay(scover->overlayId);
 
-	if (CreateTextOverlay(xx, yy, wii, fontid, text_color, get_translation(text), disp_type) != scover->overlayId)
+	int new_ovrid = CreateTextOverlay(xx, yy, wii, fontid, text_color, get_translation(text), disp_type);
+	if (new_ovrid != disp_type)
 		quit("SetTextOverlay internal error: inconsistent type ids");
+	scover->overlayId = new_ovrid;
 }
 
 int Overlay_GetX(ScriptOverlay *scover) {

--- a/engines/ags/engine/ac/screen_overlay.cpp
+++ b/engines/ags/engine/ac/screen_overlay.cpp
@@ -35,11 +35,12 @@ Bitmap *ScreenOverlay::GetImage() const {
 		_pic.get();
 }
 
-void ScreenOverlay::SetImage(Shared::Bitmap *pic) {
+void ScreenOverlay::SetImage(Shared::Bitmap *pic, int offx, int offy) {
 	_flags &= ~kOver_SpriteReference;
 	_pic.reset(pic);
 	_sprnum = -1;
-	offsetX = offsetY = 0;
+	offsetX = offx;
+	offsetY = offy;
 	scaleWidth = scaleHeight = 0;
 	const auto *img = GetImage();
 	if (img) {
@@ -49,11 +50,12 @@ void ScreenOverlay::SetImage(Shared::Bitmap *pic) {
 	MarkChanged();
 }
 
-void ScreenOverlay::SetSpriteNum(int sprnum) {
+void ScreenOverlay::SetSpriteNum(int sprnum, int offx, int offy) {
 	_flags |= kOver_SpriteReference;
 	_pic.reset();
 	_sprnum = sprnum;
-	offsetX = offsetY = 0;
+	offsetX = offx;
+	offsetY = offy;
 	scaleWidth = scaleHeight = 0;
 	const auto *img = GetImage();
 	if (img) {

--- a/engines/ags/engine/ac/screen_overlay.h
+++ b/engines/ags/engine/ac/screen_overlay.h
@@ -99,8 +99,8 @@ struct ScreenOverlay {
 	int GetSpriteNum() const {
 		return _sprnum;
 	}
-	void SetImage(Shared::Bitmap *pic);
-	void SetSpriteNum(int sprnum);
+	void SetImage(Shared::Bitmap *pic, int offx = 0, int offy = 0);
+	void SetSpriteNum(int sprnum, int offx = 0, int offy = 0);
 	// Tells if Overlay has graphically changed recently
 	bool HasChanged() const {
 		return _hasChanged;

--- a/engines/ags/engine/ac/speech.cpp
+++ b/engines/ags/engine/ac/speech.cpp
@@ -94,12 +94,12 @@ SkipSpeechStyle internal_skip_speech_to_user(int internal_val) {
 bool init_voicepak(const String &name) {
 	if (_GP(usetup).no_speech_pack) return false; // voice-over disabled
 
-	_GP(play).voice_avail = false;
 	String speech_file = name.IsEmpty() ? "speech.vox" : String::FromFormat("sp_%s.vox", name.GetCStr());
 	if (_GP(ResPaths).SpeechPak.Name.CompareNoCase(speech_file) == 0)
 		return true; // same pak already assigned
 
 	// First remove existing voice packs
+	_GP(play).voice_avail = false;
 	_GP(AssetMgr)->RemoveLibrary(_GP(ResPaths).SpeechPak.Path);
 	_GP(AssetMgr)->RemoveLibrary(_GP(ResPaths).VoiceDirSub);
 

--- a/engines/ags/engine/device/mouse_w32.cpp
+++ b/engines/ags/engine/device/mouse_w32.cpp
@@ -72,8 +72,8 @@ void mgetgraphpos() {
 		_G(real_mouse_y) = CLIP(_G(real_mouse_y) + rel_y, _GP(mouse).ControlRect.Top, _GP(mouse).ControlRect.Bottom);
 	} else {
 		// Save real cursor coordinates provided by system
-		_G(real_mouse_x) = _G(sys_mouse_x);
-		_G(real_mouse_y) = _G(sys_mouse_y);
+		_G(real_mouse_x) = CLIP((int)_G(sys_mouse_x), _GP(mouse).ControlRect.Left, _GP(mouse).ControlRect.Right);
+		_G(real_mouse_y) = CLIP((int)_G(sys_mouse_y), _GP(mouse).ControlRect.Top, _GP(mouse).ControlRect.Bottom);
 	}
 
 	// Set new in-game cursor position

--- a/engines/ags/engine/game/savegame_components.cpp
+++ b/engines/ags/engine/game/savegame_components.cpp
@@ -773,7 +773,7 @@ HSaveError ReadOverlays(Stream *in, int32_t cmp_ver, const PreservedParams & /*p
 		bool has_bitmap;
 		over.ReadFromFile(in, has_bitmap, cmp_ver);
 		if (has_bitmap)
-			over.SetImage(read_serialized_bitmap(in));
+			over.SetImage(read_serialized_bitmap(in), over.offsetX, over.offsetY);
 		if (over.scaleWidth <= 0 || over.scaleHeight <= 0) {
 			over.scaleWidth = over.GetImage()->GetWidth();
 			over.scaleHeight = over.GetImage()->GetHeight();

--- a/engines/ags/engine/game/savegame_v321.cpp
+++ b/engines/ags/engine/game/savegame_v321.cpp
@@ -286,7 +286,7 @@ static void restore_game_overlays(Stream *in) {
 	ReadOverlays_Aligned(in, has_bitmap, num_overs);
 	for (size_t i = 0; i < num_overs; ++i) {
 		if (has_bitmap[i])
-			_GP(screenover)[i].SetImage(read_serialized_bitmap(in));
+			_GP(screenover)[i].SetImage(read_serialized_bitmap(in), _GP(screenover)[i].offsetX, _GP(screenover)[i].offsetY);
 	}
 }
 

--- a/engines/ags/shared/core/def_version.h
+++ b/engines/ags/shared/core/def_version.h
@@ -22,9 +22,9 @@
 #ifndef AGS_SHARED_CORE_DEFVERSION_H
 #define AGS_SHARED_CORE_DEFVERSION_H
 
-#define ACI_VERSION_STR      "3.6.0.35"
+#define ACI_VERSION_STR      "3.6.0.36"
 #if defined (RC_INVOKED) // for MSVC resource compiler
-#define ACI_VERSION_MSRC_DEF  3.6.0.35
+#define ACI_VERSION_MSRC_DEF  3.6.0.36
 #endif
 
 #define SPECIAL_VERSION ""

--- a/engines/ags/shared/game/main_game_file.cpp
+++ b/engines/ags/shared/game/main_game_file.cpp
@@ -756,6 +756,7 @@ HGameFileError ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVersio
 	}
 
 	Debug::Printf(kDbgMsg_Info, "Game title: '%s'", game.gamename);
+	Debug::Printf(kDbgMsg_Info, "Game guid: '%s'", game.guid);
 
 	if (game.GetGameRes().IsNull())
 		return new MainGameFileError(kMGFErr_InvalidNativeResolution);

--- a/engines/ags/shared/game/main_game_file.cpp
+++ b/engines/ags/shared/game/main_game_file.cpp
@@ -756,6 +756,7 @@ HGameFileError ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVersio
 	}
 
 	Debug::Printf(kDbgMsg_Info, "Game title: '%s'", game.gamename);
+	Debug::Printf(kDbgMsg_Info, "Game uid (old format): `%d`", game.uniqueid);
 	Debug::Printf(kDbgMsg_Info, "Game guid: '%s'", game.guid);
 
 	if (game.GetGameRes().IsNull())

--- a/engines/ags/shared/util/multi_file_lib.cpp
+++ b/engines/ags/shared/util/multi_file_lib.cpp
@@ -401,11 +401,7 @@ int8_t MFLUtil::ReadEncInt8(Stream *in, int &rand_val) {
 int32_t MFLUtil::ReadEncInt32(Stream *in, int &rand_val) {
 	int val;
 	ReadEncArray(&val, sizeof(int32_t), 1, in, rand_val);
-#if AGS_PLATFORM_ENDIAN_BIG
-	return AGS::Shared::BitByteOperations::SwapBytesInt32(val);
-#else
-	return val;
-#endif
+	return BBOp::Int32FromLE(val);
 }
 
 void MFLUtil::ReadEncString(char *buffer, size_t max_len, Stream *in, int &rand_val) {


### PR DESCRIPTION
This PR continues the task to incorporate AGS upstream commits

from
https://github.com/adventuregamestudio/ags/commit/0f5c6178ac07b96f0703b35334d77f83977d43fd (not included)
up to
https://github.com/adventuregamestudio/ags/commit/17503d7bd066e8bd4a5af490c9ab053a47e4468f

Includes fix for trac [13882](https://bugs.scummvm.org/ticket/13882)

SKIPPED COMMITS:

All the commits related to the "touch-to-mouse emulation", since we still need to decide if it's needed
0f5c6178ac07b96f0703b35334d77f83977d43fd
571d1ccfbb560e31998088e5efe00b415dd572d3
1d59972ba2e4560dbc2c327f7ffdfada9815f938
f9a5ee81a34acfcd63137703df10d199e2eb0013
7d33416a9c96137ec5bc0c738751de0434394d04
14f34b60067679064208096538010702192560b7
5f5acede172c0162e5a721bc740f32d5be1b589f
cc3f2a45f56db9d305e21c82ce4589c76968c944

Engine: fix agsblend plugin stub missing DrawSprite
f3970d07138cd71172070aeca7ad6c326e389d17
Not needed

Engine: in OpenAlSource::GetPositionMs return prediction if no buffers 
084f3f281359560a94ed819ff649edbf8bf9c4a0
Scummvm has its own sound code

Common: fixed ReadEncInt32() on big-endian systems
5e29a339fc83bf5c06a3a9a3b1c65a2fc4b4e72c
already merged

Common: small fix to 5e29a33
427752da015fd93549deef1a31d5e533e5c9319e
already merged

Engine: fix gfx sw driver presented offset twice
6fc888e04c4130fb4f58bc2608438c4057cb0701
Blitting code is different, should be fixed already

Engine: support alternate name for stub/builtin spritefont plugin
1f258dec6875910b385ed1ef46b7be7c4b9ed928
Already in scummvm

SpriteFont: add "The Excavation at Hob's Barrow" to Clifftop detection
fe218e52b99b73819e9ff3ba4e6b999b42642b3d
Different implementation, already in scummvm

SpriteFont: fixed a typecast warning
a016cd18794c0baba1763f2a43586ed472ea3550
Not needed

SpriteFont: support explicit choice between variants using cflags
9f5244ad6c3c07b4e1a6c3623d2f508ec93b45f6
Different implementation

Engine: fix freebsd comment
259a376bcae031ed099cc881b5a2892487f9f090
Not present

OSX: enable RMB simulation with Ctrl+LMB (in SDL2)
3fd5531f79044f58c261d9af0c7401ab1edf4ca7
PENDING: is this needed?

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
