### PR TITLE
CI: Use a fork of vcpkg (temporarily)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,11 @@ jobs:
         uses: lukka/run-vcpkg@v7
         id: runvcpkg
         with:
-          vcpkgGitCommitId: fd766eba2b4cf59c7123d46189be373e2cee959d
+          # temporary hack until create_project / vcpkg incompatibility is resolved.
+          # use a fork of vcpkg with the previous working setup from March 2022
+          # with the the January 2023 fix for msys-libtool's url cherry-picked.
+          vcpkgGitURL: 'https://github.com/sluicebox/vcpkg.git'
+          vcpkgGitCommitId: f28c1edaffcb027da40b120112c89033d4303dcc
           vcpkgTriplet: '${{ matrix.triplet }}'
           vcpkgArguments: '${{ matrix.vcpkgPackages }}'
 #      - name: Upload libs


### PR DESCRIPTION
This is a temporary fix for the failing Windows builds in Github CI.

I've forked vcpkg and made a branch at the previous working commit from March 2022 and cherry picked the recent commit that fixes the broken msys-libtool url. This avoids the other incompatibilties that have arisen since March. Specifically, the SDL2_net library file name has changed again. (And maybe there are more problems?)

I know that @SupSuper is working on a proper fix in `create_project`. Until then, I think it would be nice to get our green checkmarks back. =)

Previous working vcpkg commit: https://github.com/microsoft/vcpkg/commit/be5c4ef68b51142ba705f0678b45d284977de677
Recent vcpkg commit that fixes msys-libtool download: https://github.com/microsoft/vcpkg/commit/fd766eba2b4cf59c7123d46189be373e2cee959d