### PR TITLE
SCUMM: GUI: Make quit confirmation dialogs visible only if "confirm_exit" is true

### DIFF
--- a/backends/events/default/default-events.cpp
+++ b/backends/events/default/default-events.cpp
@@ -180,7 +180,7 @@ bool DefaultEventManager::pollEvent(Common::Event &event) {
 		break;
 
 	case Common::EVENT_RETURN_TO_LAUNCHER:
-		if (ConfMan.getBool("confirm_exit")) {
+		if (g_engine && !g_engine->hasFeature(Engine::kSupportsQuitDialogOverride) && ConfMan.getBool("confirm_exit")) {
 			if (_confirmExitDialogActive) {
 				forwardEvent = false;
 				break;
@@ -204,7 +204,7 @@ bool DefaultEventManager::pollEvent(Common::Event &event) {
 		break;
 
 	case Common::EVENT_QUIT:
-		if (g_engine && ConfMan.getBool("confirm_exit")) {
+		if (g_engine && !g_engine->hasFeature(Engine::kSupportsQuitDialogOverride) && ConfMan.getBool("confirm_exit")) {
 			if (_confirmExitDialogActive) {
 				forwardEvent = false;
 				break;

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -300,7 +300,12 @@ public:
 		 *
 		 * This enables the help button in the main menu.
 		 */
-		 kSupportsHelp
+		 kSupportsHelp,
+
+		/**
+		 * The engine provides overrides to the quit and exit to launcher dialogs.
+		 */
+		kSupportsQuitDialogOverride,
 	};
 
 

--- a/engines/scumm/dialogs.cpp
+++ b/engines/scumm/dialogs.cpp
@@ -1048,7 +1048,10 @@ GUI::CheckboxWidget *ScummOptionsContainerWidget::createEnhancementsCheckbox(Gui
 }
 
 GUI::CheckboxWidget *ScummOptionsContainerWidget::createOriginalGUICheckbox(GuiObject *boss, const Common::String &name) {
-	return new GUI::CheckboxWidget(boss, name, _("Enable the original GUI and Menu"), _("Allow the game to use the in-engine graphical interface and the original save/load menu."));
+	return new GUI::CheckboxWidget(boss, name,
+		_("Enable the original GUI and Menu"),
+		_("Allow the game to use the in-engine graphical interface and the original save/load menu. Use it together with the \"Ask for confirmation on exit\" for a more complete experience.")
+	);
 }
 
 void ScummOptionsContainerWidget::updateAdjustmentSlider(GUI::SliderWidget *slider, GUI::StaticTextWidget *value) {

--- a/engines/scumm/gfx_gui.cpp
+++ b/engines/scumm/gfx_gui.cpp
@@ -813,7 +813,9 @@ int ScummEngine::getInternalGUIControlFromCoordinates(int x, int y) {
 #ifdef ENABLE_SCUMM_7_8
 void ScummEngine_v7::queryQuit(bool returnToLauncher) {
 	if (isUsingOriginalGUI()) {
-		if (_game.version == 8 && !(_game.features & GF_DEMO)) {
+		if (_game.version == 8 && !(_game.features & GF_DEMO) &&
+			(ConfMan.hasKey("confirm_exit") && ConfMan.getBool("confirm_exit"))) {
+
 			int boxWidth, strWidth;
 			int ctrlId;
 			char yesLabelPtr[512];
@@ -1507,19 +1509,23 @@ void ScummEngine::queryQuit(bool returnToLauncher) {
 		localizedYesKey = msgLabelPtr[Common::strnlen(msgLabelPtr, sizeof(msgLabelPtr)) - 1];
 		msgLabelPtr[Common::strnlen(msgLabelPtr, sizeof(msgLabelPtr)) - 1] = '\0';
 
-		_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, true);
-
 		// "Are you sure you want to quit?  (Y/N)"
 		Common::KeyState ks;
-		if (_game.version > 4) {
-			ks = showBannerAndPause(0, -1, msgLabelPtr);
-		} else if (_game.version < 3) {
-			ks = printMessageAndPause(msgLabelPtr, 0, -1, true);
-		} else {
-			ks = showOldStyleBannerAndPause(msgLabelPtr, 12, -1);
-		}
+		if (ConfMan.hasKey("confirm_exit") && ConfMan.getBool("confirm_exit")) {
+			_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, true);
 
-		_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, false);
+			if (_game.version > 4) {
+				ks = showBannerAndPause(0, -1, msgLabelPtr);
+			} else if (_game.version < 3) {
+				ks = printMessageAndPause(msgLabelPtr, 0, -1, true);
+			} else {
+				ks = showOldStyleBannerAndPause(msgLabelPtr, 12, -1);
+			}
+
+			_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, false);
+		} else {
+			ks = Common::KeyCode(localizedYesKey);
+		}
 
 		if (tolower(localizedYesKey) == ks.ascii || toupper(localizedYesKey) == ks.ascii ||
 			(ks.keycode == Common::KEYCODE_c && ks.hasFlags(Common::KBD_CTRL)) ||

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -241,7 +241,8 @@ bool ScummEngine::hasFeature(EngineFeature f) const {
 		(
 			f == kSupportsChangingOptionsDuringRuntime &&
 			Common::String(_game.guioptions).contains(GUIO_AUDIO_OVERRIDE)
-		);
+		) ||
+		(f == kSupportsQuitDialogOverride && _useOriginalGUI);
 }
 
 

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -664,7 +664,8 @@ static const ExtraGuiOption audioOverride {
 
 static const ExtraGuiOption enableOriginalGUI = {
 	_s("Enable the original GUI and Menu"),
-	_s("Allow the game to use the in-engine graphical interface and the original save/load menu."),
+	_s("Allow the game to use the in-engine graphical interface and the original save/load menu. \
+		Use it together with the \"Ask for confirmation on exit\" for a more complete experience."),
 	"original_gui",
 	true,
 	0,


### PR DESCRIPTION
This fixes an issue in which keyboard-less platforms would have to always use the virtual keyboard to exit any SCUMM game using the original GUI. Sorry :-)

Now we expose a `Engine::kSupportsQuitDialogOverride` feature from the `Engine`, so that any engine implementing its own GUI (and specifically, dialogs which would overlap with the ScummVM event generated ones, like the quit dialogs) can override the ScummVM ones.

Now, the SCUMM confirmation banners for exiting the game will only appear if the "Ask for confirmation on exit" toggle is active, and when they do, they won't overlap with the ones from the outside world.

Shamelessly requesting a review from anyone who participated in the relevant debate about it 😝 