### PR TITLE
MTROPOLIS: Implement the Return Modifier and tentative opint handling

### DIFF
--- a/engines/mtropolis/modifiers.cpp
+++ b/engines/mtropolis/modifiers.cpp
@@ -2314,7 +2314,7 @@ bool ReturnModifier::respondsToEvent(const Event &evt) const {
 }
 
 VThreadState ReturnModifier::consumeMessage(Runtime *runtime, const Common::SharedPtr<MessageProperties> &msg) {
-	warning("Return modifier not implemented");
+	runtime->addSceneStateTransition(HighLevelSceneTransition(nullptr, HighLevelSceneTransition::kTypeReturn, false, false));
 	return kVThreadReturn;
 }
 

--- a/engines/mtropolis/runtime.cpp
+++ b/engines/mtropolis/runtime.cpp
@@ -2766,7 +2766,8 @@ MiniscriptInstructionOutcome WorldManagerInterface::setCurrentScene(MiniscriptTh
 		return kMiniscriptInstructionOutcomeFailed;
 	}
 
-	thread->getRuntime()->addSceneStateTransition(HighLevelSceneTransition(scene->getSelfReference().lock().staticCast<Structural>(), HighLevelSceneTransition::kTypeChangeToScene, false, false));
+	bool addToReturnList = _opInt & 0x01 != 0;
+	thread->getRuntime()->addSceneStateTransition(HighLevelSceneTransition(scene->getSelfReference().lock().staticCast<Structural>(), HighLevelSceneTransition::kTypeChangeToScene, false, addToReturnList));
 
 	return kMiniscriptInstructionOutcomeContinue;
 }


### PR DESCRIPTION
When SPQR opens a dialog box it wants to return from, it sets `worldmanager.opint` to 7 before switching `worldmanager.currentscene`  to the dialog box scene. (Other values encountered in SPQR are 2 and 4, which seem to be used for scene transitions that do not go to dialogs.) It therefore seems logical that 7 is used to indicate that the add-to-return-list flag should be set. This PR tentatively assumes that the least significant bit of `opint` is the add-to-return-list flag and sets this flag accordingly when handling writes to `currentscene`.

Together with a (very simple) implementation of the Return Modifier, this PR makes SPQR's dialog handling work (i.e., dialogs can be closed with the exit button now).

Please note that I have not reverse-engineered anything here (as I have no real idea how to achieve that). This PR is based simply on observing SPQR's behavior, so what's implemented here may not match what mTropolis does. For games that do not use `opint`, this change _should_ not break anything, as the add-to-return-list flag was already set to `false` anyway.