### PR TITLE
NEVERHOOD: Reload BOBBY puzzle when changing languages with NHC.

### DIFF
--- a/engines/neverhood/gamemodule.cpp
+++ b/engines/neverhood/gamemodule.cpp
@@ -292,6 +292,24 @@ void GameModule::initCubeSymbolsPuzzle() {
 	}
 }
 
+byte GameModule::parseCrystalColor(char colorLetter) {
+	switch (colorLetter) {
+	case 'B':
+		return 4;
+	case 'G':
+		return 3;
+	case 'O':
+		return 1;
+	case 'R':
+		return 0;
+	case 'V':
+		return 5;
+	case 'Y':
+		return 2;
+	default:
+		return 0;
+	}
+}
 void GameModule::initCrystalColorsPuzzle() {
 	if (!getGlobalVar(V_CRYSTAL_COLORS_INIT)) {
 		TextResource textResource(_vm);
@@ -300,29 +318,7 @@ void GameModule::initCrystalColorsPuzzle() {
 		textStart = textResource.getString(0, textEnd);
 		for (uint index = 0; index < 5; index++) {
 			char colorLetter = (byte)textStart[index];
-			byte correctColorNum = 0, misalignedColorNum;
-			switch (colorLetter) {
-			case 'B':
-				correctColorNum = 4;
-				break;
-			case 'G':
-				correctColorNum = 3;
-				break;
-			case 'O':
-				correctColorNum = 1;
-				break;
-			case 'R':
-				correctColorNum = 0;
-				break;
-			case 'V':
-				correctColorNum = 5;
-				break;
-			case 'Y':
-				correctColorNum = 2;
-				break;
-			default:
-				break;
-			}
+			byte correctColorNum = parseCrystalColor(colorLetter), misalignedColorNum;
 			do {
 				misalignedColorNum = _vm->_rnd->getRandomNumber(6 - 1);
 			} while (misalignedColorNum == correctColorNum);

--- a/engines/neverhood/gamemodule.h
+++ b/engines/neverhood/gamemodule.h
@@ -60,6 +60,7 @@ public:
 	int getPreviousModuleNum() { return _moduleNum; }
 
 	void createModule(int moduleNum, int which);
+	static byte parseCrystalColor(char colorLetter);
 protected:
 	int _moduleNum;
 	Entity *_prevChildObject;


### PR DESCRIPTION
This has slightly different logic that original NHC override library. Original library attempts to rotate the solution and current state by the same amount. We do the following:

1. If correct solution didn't change, load as usual
2. If correct solution changed and puzzle was already solved, set both current and correct solution to the new correct solution
3. If correct solution changed and puzzle was not already solved, reinit the puzzle


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
