### PR TITLE
COMMON: Check CRC16 in Stuffit

### DIFF
--- a/common/compression/stuffit.cpp
+++ b/common/compression/stuffit.cpp
@@ -182,7 +182,7 @@ bool StuffItArchive::open(Common::SeekableReadStream *stream) {
 		uint16 actualHeaderCRC = crc.crcFast(header, sizeof(header) - 2);
 
 		if (actualHeaderCRC != headerCRC)
-			error ("Header CRC mismatch: %04x vs %04x", actualHeaderCRC, headerCRC);
+			error ("StuffItArchive::open(): Header CRC mismatch: %04x vs %04x", actualHeaderCRC, headerCRC);
 
 		// Ignore directories for now
 		if (dataForkCompression == 32 || dataForkCompression == 33)
@@ -291,7 +291,7 @@ Common::SharedArchiveContents StuffItArchive::readContentsForPath(const Common::
 	uint16 actualCRC = Common::CRC16().crcFast(uncompressedBlock, entry.uncompressedSize);
 
 	if (actualCRC != entry.crc) {
-		error("CRC mismatch: %04x vs %04x", actualCRC, entry.crc);
+		error("StuffItArchive::readContentsForPath(): CRC mismatch: %04x vs %04x for file %s", actualCRC, entry.crc, name.c_str());
 	}
 
 	return Common::SharedArchiveContents(uncompressedBlock, entry.uncompressedSize);


### PR DESCRIPTION
This improves file corruption checking but due to its breakage potential I propose to shunt it to the next version. Opening PR so it doesn't get lost