### PR TITLE
ENGINES: Fix punycode encoding of directory separator in unknown game report

### DIFF
--- a/engines/game.cpp
+++ b/engines/game.cpp
@@ -269,8 +269,9 @@ Common::U32String generateUnknownGameReport(const DetectedGames &detectedGames, 
 		if (!md5Prefix.empty())
 			md5Prefix += ":";
 
+		Common::Path filepath(strchr(filenames[i].c_str(), ':') + 1);
 		report += Common::String::format("  {\"%s\", 0, \"%s%s\", %lld},\n",
-			Common::punycode_encodefilename(Common::U32String(strchr(filenames[i].c_str(), ':') + 1)).c_str(), // Skip the md5 prefix
+			filepath.punycodeEncode().toString().c_str(), // Skip the md5 prefix
 			md5Prefix.c_str(), file.md5.c_str(), (long long)file.size);
 	}
 


### PR DESCRIPTION
The unknown game report punycode encode the file path of detected file. Currently it treats those as file name. This is an issue for engines that use the `kADFlagMatchFullPaths` flag, as they can have directory separator as part of this path , causing it to be encoded.

For example with Broken Sword unknown variants:
```
  {"xn--clustersscripts.clm-2a08g", 0, "6b6d9a32668e6f0285318dbe33f167fe", 1088468},
  {"xn--clustersswordres.rif-3a62h", 0, "6b579d7cd94756f5c1e362a9b61f94a3", 59788},
  {"xn--smackshicredits.smk-2a08g", 0, "9cea2fbd374c7723f59cfa0ed077df7a", 12467196},
  {"xn--smackshiintro.smk-0a88f", 0, "d602a28f5f5c583bf9870a23a94a9bc5", 13525168},
```

This PR delegates the punycode encoding to the `Common::Path` class, to properly handle splitting the path into its components, and encoding each component separately. This gives the expected result:
```
  {"clusters/scripts.clm", 0, "6b6d9a32668e6f0285318dbe33f167fe", 1088468},
  {"clusters/swordres.rif", 0, "6b579d7cd94756f5c1e362a9b61f94a3", 59788},
  {"smackshi/credits.smk", 0, "9cea2fbd374c7723f59cfa0ed077df7a", 12467196},
  {"smackshi/intro.smk", 0, "d602a28f5f5c583bf9870a23a94a9bc5", 13525168},
```

This is a very simple change. However I am not completely sure that it does not introduce regressions, which is why I am opening a pull request for it. For safety we may want to limit the change to the case where the unknown variant comes from an AdvancedGameDetector instances that use the `kADFlagMatchFullPaths` flag. But at this point in the code that information has been long lost. So doing so would require deeper changes to pass the information all the way to this point.

But before I do that, I wanted to check if that is even needed. Is there any engine that use '/' as part of file names in detection table? Would the change here cause a regression for those? I guess it could but only if the file names on the disk are not already punycode encoded. Are there are systems out there that still support using `/` as part of file name and could have the file on disk with the name not already encoded? Or is there other cases I am missing where the change could cause a regression?