### PR TITLE
OPENDINGUX: restore the scaler for the rs90/rg99 ports and use 320x200 for the RG99

### DIFF
--- a/backends/graphics/opendingux/opendingux-graphics.cpp
+++ b/backends/graphics/opendingux/opendingux-graphics.cpp
@@ -51,7 +51,8 @@ void OpenDinguxGraphicsManager::getDefaultResolution(uint &w, uint &h) {
 	SDL_Rect const* const*availableModes = SDL_ListModes(&p, SDL_FULLSCREEN|SDL_HWSURFACE);
 	w = availableModes[0]->w;
 	h = availableModes[0]->h;
-	if (h > w) h /= 2; // RG99 has a 320x480 screen, gui should render at 320x240 to look correct
+	// Request 320x200 for the RG99, to let the software aspect correction kick in
+	if ( w == 320 && h == 480 ) h = 200;
 #else
 	w = 320;
 	h = 200;

--- a/configure
+++ b/configure
@@ -3647,9 +3647,7 @@ if test -n "$_host"; then
 					_16bit=no
 					_highres=no
 					# Scaling is handled by IPU
-					_build_aspect=no
 					_build_scalers=no
-					_host=opendingux-rs90
 					;;
 				*)
 					echo "WARNING: Unknown OpenDingux target"


### PR DESCRIPTION
By requesting a videomode of 320x200, we can let the software upscaler kick in, which is very sharp
compared to IPU upscaling