### PR TITLE
TINSEL: Handle DW2 saves that had Noir-sized SysVars

### DIFF
--- a/engines/tinsel/savescn.h
+++ b/engines/tinsel/savescn.h
@@ -59,7 +59,7 @@ struct SAVED_DATA {
 	uint32		SavedTune[3];			// Music
 	bool		bTinselDim;
 	int			SavedScrollFocus;
-	int			SavedSystemVars[SV_TOPVALID];
+	int			SavedSystemVars[SV_TOPVALID_T3];
 	SOUNDREELS	SavedSoundReels[MAX_SOUNDREELS];
 };
 

--- a/engines/tinsel/sysvar.cpp
+++ b/engines/tinsel/sysvar.cpp
@@ -42,7 +42,7 @@ extern int NewestSavedGame();
 
 // These vars are reset upon engine destruction
 
-static int g_systemVars[SV_TOPVALID];
+static int g_systemVars[SV_TOPVALID_T3];
 static SCNHANDLE g_systemStrings[SS_MAX_VALID];
 
 //----------------- FUNCTIONS --------------------------------
@@ -57,7 +57,7 @@ void ResetVarsSysVar() {
  */
 
 void InitSysVars() {
-	int initialSystemVars[SV_TOPVALID] = {
+	int initialSystemVars[SV_TOPVALID_T3] = {
 	    INV_1, // Default inventory
 
 	    10,  // Y-offset of Conversation(TOP)

--- a/engines/tinsel/sysvar.h
+++ b/engines/tinsel/sysvar.h
@@ -83,6 +83,8 @@ typedef enum {	SV_DEFAULT_INV,
 		ISV_GHOST_BASE_T2 = 0x2B,
 		ISV_GHOST_COLOR_T2 = 0x2C,
 
+		SV_TOPVALID_T2 = 0x2D,
+
 		SV_SPRITER_SCENE_ID = 0x2F, // Noir, loaded scene
 		ISV_DIVERT_ACTOR_T3 = 0x32,
 		ISV_NO_BLOCKING_T3 = 0x33,
@@ -92,13 +94,14 @@ typedef enum {	SV_DEFAULT_INV,
 		SV_SPRITER_SCALE = 0x37, // Noir, scale used for 3D rendering
 		SV_SPRITER_OVERLAY = 0x38, // Noir, if additional model is loaded
 
-		SV_TOPVALID } SYSVARS;
+		SV_TOPVALID_T3 } SYSVARS;
 
 #define ISV_DIVERT_ACTOR ((TinselVersion == 3) ? ISV_DIVERT_ACTOR_T3 : ISV_DIVERT_ACTOR_T2)
 #define ISV_NO_BLOCKING ((TinselVersion == 3) ? ISV_NO_BLOCKING_T3 : ISV_NO_BLOCKING_T2)
 #define ISV_GHOST_ACTOR ((TinselVersion == 3) ? ISV_GHOST_ACTOR_T3 : ISV_GHOST_ACTOR_T2)
 #define ISV_GHOST_BASE ((TinselVersion == 3) ? ISV_GHOST_BASE_T3 : ISV_GHOST_BASE_T2)
 #define ISV_GHOST_COLOR ((TinselVersion == 3) ? ISV_GHOST_COLOR_T3 : ISV_GHOST_COLOR_T2)
+#define SV_TOPVALID ((TinselVersion == 3) ? SV_TOPVALID_T3 : SV_TOPVALID_T2)
 
 typedef enum {
 


### PR DESCRIPTION
With this change we now once again can read pre 2.6 savegames. Similarly savegames created after this fix will be readable by ScummVM < 2.6.0. We will also be able to load savegames created by ScummVM 2.6.x.

The only limitation is that since we now create the same kind of savegames as older versions again, ScummVM 2.6.x will be unable to load savegames created after this.

This fixes bug #13897