### PR TITLE
WIN32: Disable libjpeg-turbo SSE usage on Win95

### DIFF
--- a/backends/platform/sdl/win32/win32.h
+++ b/backends/platform/sdl/win32/win32.h
@@ -65,6 +65,10 @@ protected:
 private:
 	bool _isPortable;
 	bool detectPortableConfigFile();
+
+#if defined(USE_JPEG)
+	void initializeJpegLibraryForWin95();
+#endif
 };
 
 #endif


### PR DESCRIPTION
This should fix jpeg decoding crashing on Win95: https://bugs.scummvm.org/ticket/13643

@ccawley2011 and @lephilousophe figured this out, I just wrote it up in a Win95-compatible check. I haven't tested this code on Win95 as I'm not setup to do those builds, but I have tested the environment variable. When it's set, the Journeyman Project demo no longer crashes on Win95 in vmware.

![image](https://user-images.githubusercontent.com/22204938/214742106-b2555f94-83b6-466f-8c98-294f0ebfcdb7.png)
