### PR TITLE
DIRECTOR: Force a widget refresh for bitmaps with custom palettes

### DIFF
--- a/engines/director/castmember.h
+++ b/engines/director/castmember.h
@@ -125,6 +125,7 @@ public:
 	~BitmapCastMember();
 	Graphics::MacWidget *createWidget(Common::Rect &bbox, Channel *channel, SpriteType spriteType) override;
 
+	bool isModified() override;
 	void createMatte(Common::Rect &bbox);
 	Graphics::Surface *getMatte(Common::Rect &bbox);
 	void copyStretchImg(Graphics::Surface *surface, const Common::Rect &bbox, const byte *pal = 0);
@@ -145,6 +146,7 @@ public:
 	uint16 _flags2;
 	uint16 _bytes;
 	int _clut;
+	int _ditheredTargetClut;
 
 	uint16 _bitsPerPixel;
 


### PR DESCRIPTION
If a bitmap cast member has a custom palette, createWidget() has a routine to dither the image to the current score palette. However, this needs to be done every time there is a change in palette, as the dithering might not match, or not be necessary due to a matching score palette.

Fixes the menu screen in the Mac version of Majestic Part 1.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
