### PR TITLE
SCUMM HE: Disable save compression for Moonbase.

### DIFF
--- a/engines/scumm/he/intern_he.h
+++ b/engines/scumm/he/intern_he.h
@@ -31,7 +31,7 @@
 
 namespace Common {
 class SeekableReadStream;
-class WriteStream;
+class SeekableWriteStream;
 }
 
 namespace Scumm {
@@ -50,7 +50,7 @@ protected:
 
 public:
 	Common::SeekableReadStream *_hInFileTable[17];
-	Common::WriteStream *_hOutFileTable[17];
+	Common::SeekableWriteStream *_hOutFileTable[17];
 
 	Common::Rect _actorClipOverride;	// HE specific
 
@@ -91,14 +91,14 @@ protected:
 
 	Common::SeekableReadStream *openFileForReading(const byte *fileName);
 	Common::SeekableReadStream *openSaveFileForReading(const byte *fileName);
-	Common::WriteStream *openSaveFileForWriting(const byte *fileName);
-	Common::WriteStream *openSaveFileForAppending(const byte *fileName);
+	Common::SeekableWriteStream *openSaveFileForWriting(const byte *fileName);
+	Common::SeekableWriteStream *openSaveFileForAppending(const byte *fileName);
 	void deleteSaveFile(const byte *fileName);
 	void renameSaveFile(const byte *from, const byte *to);
 	void pauseEngineIntern(bool pause) override;
 
 	Common::SeekableReadStream *openSaveFileForReading(int slot, bool compat, Common::String &fileName) override;
-	Common::WriteStream *openSaveFileForWriting(int slot, bool compat, Common::String &fileName) override;
+	Common::SeekableWriteStream *openSaveFileForWriting(int slot, bool compat, Common::String &fileName) override;
 
 	/* HE version 60 script opcodes */
 	void o60_setState();

--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -538,7 +538,7 @@ Common::SeekableReadStream *ScummEngine::openSaveFileForReading(int slot, bool c
 	return _saveFileMan->openForLoading(fileName);
 }
 
-Common::WriteStream *ScummEngine::openSaveFileForWriting(int slot, bool compat, Common::String &fileName) {
+Common::SeekableWriteStream *ScummEngine::openSaveFileForWriting(int slot, bool compat, Common::String &fileName) {
 	fileName = makeSavegameName(slot, compat);
 	return _saveFileMan->openForSaving(fileName);
 }

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -63,6 +63,7 @@ using GUI::Dialog;
 namespace Common {
 class SeekableReadStream;
 class WriteStream;
+class SeekableWriteStream;
 }
 namespace Graphics {
 class FontSJIS;
@@ -889,7 +890,7 @@ protected:
 	void copyHeapSaveGameToFile(int slot, const char *saveName);
 	bool changeSavegameName(int slot, char *newName);
 	virtual Common::SeekableReadStream *openSaveFileForReading(int slot, bool compat, Common::String &fileName);
-	virtual Common::WriteStream *openSaveFileForWriting(int slot, bool compat, Common::String &fileName);
+	virtual Common::SeekableWriteStream *openSaveFileForWriting(int slot, bool compat, Common::String &fileName);
 
 	Common::String makeSavegameName(int slot, bool temporary) const {
 		return makeSavegameName(_targetName, slot, temporary);


### PR DESCRIPTION
This PR makes the save out file table seekable for HE games, and since compressed save files cannot be seeked, it has been disabled when playing Moonbase Commander.  This allows custom maps to be saved properly.  It has been tested with other games, and it does not break saving/loading in those games.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
