### PR TITLE
STARK: Add a method for drawing filled rectangles

### DIFF
--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -1041,6 +1041,8 @@ XcodeProvider::ValueList& XcodeProvider::getResourceFiles(const BuildSetup &setu
 			files.push_back("engines/stark/shaders/stark_prop.vertex");
 			files.push_back("engines/stark/shaders/stark_surface.fragment");
 			files.push_back("engines/stark/shaders/stark_surface.vertex");
+			files.push_back("engines/stark/shaders/stark_surface_fill.fragment");
+			files.push_back("engines/stark/shaders/stark_surface_fill.vertex");
 			files.push_back("engines/stark/shaders/stark_fade.fragment");
 			files.push_back("engines/stark/shaders/stark_fade.vertex");
 			files.push_back("engines/stark/shaders/stark_shadow.fragment");

--- a/dists/scummvm.rc
+++ b/dists/scummvm.rc
@@ -164,6 +164,8 @@ shaders/stark_prop.fragment          FILE    "engines/stark/shaders/stark_prop.f
 shaders/stark_prop.vertex            FILE    "engines/stark/shaders/stark_prop.vertex"
 shaders/stark_surface.fragment       FILE    "engines/stark/shaders/stark_surface.fragment"
 shaders/stark_surface.vertex         FILE    "engines/stark/shaders/stark_surface.vertex"
+shaders/stark_surface_fill.fragment  FILE    "engines/stark/shaders/stark_surface_fill.fragment"
+shaders/stark_surface_fill.vertex    FILE    "engines/stark/shaders/stark_surface_fill.vertex"
 shaders/stark_fade.fragment          FILE    "engines/stark/shaders/stark_fade.fragment"
 shaders/stark_fade.vertex            FILE    "engines/stark/shaders/stark_fade.vertex"
 shaders/stark_shadow.fragment        FILE    "engines/stark/shaders/stark_shadow.fragment"

--- a/engines/stark/gfx/color.h
+++ b/engines/stark/gfx/color.h
@@ -19,39 +19,32 @@
  *
  */
 
-#ifndef STARK_UI_MENU_DIARY_INDEX_H
-#define STARK_UI_MENU_DIARY_INDEX_H
+#ifndef STARK_GFX_COLOR_H
+#define STARK_GFX_COLOR_H
 
-#include "engines/stark/ui/menu/locationscreen.h"
+#include "common/scummsys.h"
 
 namespace Stark {
+namespace Gfx {
 
-/**
- * The diary index is the in-game menu
- */
-class DiaryIndexScreen : public StaticLocationScreen {
-public:
-	DiaryIndexScreen(Gfx::Driver *gfx, Cursor *cursor);
-	virtual ~DiaryIndexScreen();
+struct Color {
+	uint8 r;
+	uint8 g;
+	uint8 b;
+	uint8 a;
 
-	// StaticLocationScreen API
-	void open() override;
+	Color(uint8 red, uint8 green, uint8 blue, uint8 alpha = 0xFF) :
+			r(red), g(green), b(blue), a(alpha) {}
 
-private:
-	void widgetTextColorHandler(StaticLocationWidget &widget, const Common::Point &mousePos);
-	void backHandler();
-	void settingsHandler();
-	void fmvHandler();
-	void loadHandler();
-	void saveHandler();
-	void diaryHandler();
-	void dialogHandler();
-	void quitHandler();
-
-	const Gfx::Color _textColorHovered = Gfx::Color(0x1E, 0x1E, 0x96);
-	const Gfx::Color _textColorDefault = Gfx::Color(0x00, 0x00, 0x00);
+	bool operator==(const Color &color) const {
+		return r == color.r &&
+		       g == color.g &&
+		       b == color.b &&
+		       a == color.a;
+	}
 };
 
+} // End of namespace Gfx
 } // End of namespace Stark
 
- #endif // STARK_UI_MENU_DIARY_INDEX_H
+#endif // STARK_GFX_COLOR_H

--- a/engines/stark/gfx/opengls.cpp
+++ b/engines/stark/gfx/opengls.cpp
@@ -58,6 +58,7 @@ static const GLfloat fadeVertices[] = {
 
 OpenGLSDriver::OpenGLSDriver() :
 	_surfaceShader(nullptr),
+	_surfaceFillShader(nullptr),
 	_actorShader(nullptr),
 	_fadeShader(nullptr),
 	_shadowShader(nullptr),
@@ -68,6 +69,7 @@ OpenGLSDriver::OpenGLSDriver() :
 OpenGLSDriver::~OpenGLSDriver() {
 	OpenGL::Shader::freeBuffer(_surfaceVBO);
 	OpenGL::Shader::freeBuffer(_fadeVBO);
+	delete _surfaceFillShader;
 	delete _surfaceShader;
 	delete _actorShader;
 	delete _fadeShader;
@@ -82,6 +84,10 @@ void OpenGLSDriver::init() {
 	_surfaceVBO = OpenGL::Shader::createBuffer(GL_ARRAY_BUFFER, sizeof(surfaceVertices), surfaceVertices);
 	_surfaceShader->enableVertexAttribute("position", _surfaceVBO, 2, GL_FLOAT, GL_TRUE, 2 * sizeof(float), 0);
 	_surfaceShader->enableVertexAttribute("texcoord", _surfaceVBO, 2, GL_FLOAT, GL_TRUE, 2 * sizeof(float), 0);
+
+	static const char* fillAttributes[] = { "position", nullptr };
+	_surfaceFillShader = OpenGL::Shader::fromFiles("stark_surface_fill", fillAttributes);
+	_surfaceFillShader->enableVertexAttribute("position", _surfaceVBO, 2, GL_FLOAT, GL_TRUE, 2 * sizeof(float), 0);
 
 	static const char* actorAttributes[] = { "position1", "position2", "bone1", "bone2", "boneWeight", "normal", "texcoord", nullptr };
 	_actorShader = OpenGL::Shader::fromFiles("stark_actor", actorAttributes);
@@ -212,6 +218,10 @@ OpenGL::Shader *OpenGLSDriver::createActorShaderInstance() {
 
 OpenGL::Shader *OpenGLSDriver::createSurfaceShaderInstance() {
 	return _surfaceShader->clone();
+}
+
+OpenGL::Shader *OpenGLSDriver::createSurfaceFillShaderInstance() {
+	return _surfaceFillShader->clone();
 }
 
 OpenGL::Shader *OpenGLSDriver::createFadeShaderInstance() {

--- a/engines/stark/gfx/opengls.h
+++ b/engines/stark/gfx/opengls.h
@@ -59,6 +59,7 @@ public:
 
 	OpenGL::Shader *createActorShaderInstance();
 	OpenGL::Shader *createSurfaceShaderInstance();
+	OpenGL::Shader *createSurfaceFillShaderInstance();
 	OpenGL::Shader *createFadeShaderInstance();
 	OpenGL::Shader *createShadowShaderInstance();
 
@@ -77,6 +78,7 @@ private:
 	Common::Rect _unscaledViewport;
 
 	OpenGL::Shader *_surfaceShader;
+	OpenGL::Shader *_surfaceFillShader;
 	OpenGL::Shader *_actorShader;
 	OpenGL::Shader *_fadeShader;
 	OpenGL::Shader *_shadowShader;

--- a/engines/stark/gfx/openglssurface.h
+++ b/engines/stark/gfx/openglssurface.h
@@ -49,6 +49,7 @@ public:
 	// SurfaceRenderer API
 	void render(const Bitmap *bitmap, const Common::Point &dest) override;
 	void render(const Bitmap *bitmap, const Common::Point &dest, uint width, uint height) override;
+	void fill(const Color &color, const Common::Point &dest, uint width, uint height) override;
 
 private:
 	Math::Vector2d normalizeOriginalCoordinates(int x, int y) const;
@@ -56,6 +57,7 @@ private:
 
 	OpenGLSDriver *_gfx;
 	OpenGL::Shader *_shader;
+	OpenGL::Shader *_shaderFill;
 };
 
 } // End of namespace Gfx

--- a/engines/stark/gfx/openglsurface.h
+++ b/engines/stark/gfx/openglsurface.h
@@ -35,12 +35,6 @@ namespace Gfx {
 class OpenGLDriver;
 class Bitmap;
 
-struct _SurfaceVertex {
-	float x;
-	float y;
-};
-typedef _SurfaceVertex SurfaceVertex;
-
 /**
  * An programmable pipeline OpenGL surface renderer
  */
@@ -52,10 +46,17 @@ public:
 	// SurfaceRenderer API
 	void render(const Bitmap *bitmap, const Common::Point &dest) override;
 	void render(const Bitmap *bitmap, const Common::Point &dest, uint width, uint height) override;
+	void fill(const Color &color, const Common::Point &dest, uint width, uint height) override;
 
 private:
+	struct SurfaceVertex {
+		float x;
+		float y;
+	};
+
 	Math::Vector2d normalizeOriginalCoordinates(int x, int y) const;
 	Math::Vector2d normalizeCurrentCoordinates(int x, int y) const;
+	void convertToVertices(SurfaceVertex *vertices, const Common::Point &dest, uint width, uint height) const;
 
 	OpenGLDriver *_gfx;
 };

--- a/engines/stark/gfx/surfacerenderer.h
+++ b/engines/stark/gfx/surfacerenderer.h
@@ -28,6 +28,7 @@ namespace Stark {
 namespace Gfx {
 
 class Bitmap;
+struct Color;
 
 /**
  * A renderer to draw textures as two dimensional surfaces to the current viewport
@@ -46,6 +47,11 @@ public:
 	 * Draw a 2D surface from the specified bitmap with given width and height
 	 */
 	virtual void render(const Bitmap *bitmap, const Common::Point &dest, uint width, uint height) = 0;
+
+	/**
+	 * Draw a filled 2D rectangle using the specified color
+	 */
+	virtual void fill(const Color &color, const Common::Point &dest, uint width, uint height) = 0;
 
 	/**
 	 * When this is set to true, the texture size is expected to be in current

--- a/engines/stark/gfx/tinyglbitmap.cpp
+++ b/engines/stark/gfx/tinyglbitmap.cpp
@@ -28,8 +28,7 @@ namespace Stark {
 namespace Gfx {
 
 TinyGlBitmap::TinyGlBitmap() :
-		Bitmap(),
-		 _1x1Color(0) {
+		Bitmap() {
 	_blitImage = tglGenBlitImage();
 }
 
@@ -51,11 +50,6 @@ void TinyGlBitmap::update(const Graphics::Surface *surface, const byte *palette)
 		convertedSurface->free();
 		delete convertedSurface;
 	} else {
-		// W/A for 1x1 size bitmap
-		// store pixel color used later fo creating scalled bitmap
-		if (_width == 1 && _height == 1) {
-			_1x1Color = surface->getPixel(0, 0);
-		}
 		tglUploadBlitImage(_blitImage, *surface, 0, false);
 	}
 }

--- a/engines/stark/gfx/tinyglbitmap.h
+++ b/engines/stark/gfx/tinyglbitmap.h
@@ -42,11 +42,9 @@ public:
 	TinyGL::BlitImage *getBlitImage() const;
 	void update(const Graphics::Surface *surface, const byte *palette = nullptr) override;
 	void setSamplingFilter(SamplingFilter filter) override;
-	uint32 get1x1Color() { return _1x1Color; }
 
 protected:
 	TinyGL::BlitImage *_blitImage;
-	uint32 _1x1Color;
 };
 
 } // End of namespace Gfx

--- a/engines/stark/gfx/tinyglsurface.h
+++ b/engines/stark/gfx/tinyglsurface.h
@@ -46,10 +46,17 @@ public:
 	// SurfaceRenderer API
 	void render(const Bitmap *bitmap, const Common::Point &dest) override;
 	void render(const Bitmap *bitmap, const Common::Point &dest, uint width, uint height) override;
+	void fill(const Color &color, const Common::Point &dest, uint width, uint height) override;
 
 private:
+	struct SurfaceVertex {
+		float x;
+		float y;
+	};
+
 	Math::Vector2d normalizeOriginalCoordinates(int x, int y) const;
 	Math::Vector2d normalizeCurrentCoordinates(int x, int y) const;
+	void convertToVertices(SurfaceVertex *vertices, const Common::Point &dest, uint width, uint height) const;
 
 	TinyGLDriver *_gfx;
 };

--- a/engines/stark/resources/image.cpp
+++ b/engines/stark/resources/image.cpp
@@ -262,7 +262,7 @@ void ImageStill::printData() {
 
 ImageText::ImageText(Object *parent, byte subType, uint16 index, const Common::String &name) :
 		Image(parent, subType, index, name),
-		_color(Color(0, 0, 0)),
+		_color(Gfx::Color(0, 0, 0)),
 		_font(0) {
 }
 

--- a/engines/stark/resources/image.h
+++ b/engines/stark/resources/image.h
@@ -26,12 +26,13 @@
 #include "common/str.h"
 
 #include "engines/stark/resources/object.h"
-#include "engines/stark/visual/text.h"
+#include "engines/stark/gfx/color.h"
 
 namespace Stark {
 
 class Visual;
 class VisualImageXMG;
+class VisualText;
 namespace Formats {
 class XRCReadStream;
 }
@@ -140,7 +141,7 @@ protected:
 
 	Common::Point _size;
 	Common::String _text;
-	Color _color;
+	Gfx::Color _color;
 	uint32 _font;
 };
 

--- a/engines/stark/shaders/stark_surface_fill.fragment
+++ b/engines/stark/shaders/stark_surface_fill.fragment
@@ -1,0 +1,9 @@
+
+OUTPUT
+
+uniform float fadeLevel;
+uniform vec4 color;
+
+void main() {
+	outColor = color + vec4(fadeLevel, fadeLevel, fadeLevel, 0) * color.a;
+}

--- a/engines/stark/shaders/stark_surface_fill.vertex
+++ b/engines/stark/shaders/stark_surface_fill.vertex
@@ -1,0 +1,23 @@
+in vec2 position;
+
+uniform vec2 verOffsetXY;
+uniform vec2 verSizeWH;
+uniform vec2 viewport;
+uniform UBOOL snapToGrid;
+
+void main() {
+	// Coordinates are [0.0; 1.0], transform to [-1.0; 1.0]
+	vec2 pos = verOffsetXY + position * verSizeWH;
+
+	if (UBOOL_TEST(snapToGrid)) {
+		// Align vertex coordinates to the native pixel grid
+		// This ensures text does not get garbled by nearest neighbors scaling
+		pos.x = floor(pos.x * viewport.x + 0.5) / viewport.x;
+		pos.y = floor(pos.y * viewport.y + 0.5) / viewport.y;
+	}
+
+	pos.x = pos.x * 2.0 - 1.0;
+	pos.y = -1.0 * (pos.y * 2.0 - 1.0);
+
+	gl_Position = vec4(pos, 0.0, 1.0);
+}

--- a/engines/stark/ui/cursor.cpp
+++ b/engines/stark/ui/cursor.cpp
@@ -165,8 +165,8 @@ void Cursor::setMouseHint(const Common::String &hint) {
 		if (!hint.empty()) {
 			_mouseText = new VisualText(_gfx);
 			_mouseText->setText(hint);
-			_mouseText->setColor(Color(0xFF, 0xFF, 0xFF));
-			_mouseText->setBackgroundColor(Color(0x00, 0x00, 0x00, 0x80));
+			_mouseText->setColor(Gfx::Color(0xFF, 0xFF, 0xFF));
+			_mouseText->setBackgroundColor(Gfx::Color(0x00, 0x00, 0x00, 0x80));
 			_mouseText->setFont(FontProvider::kSmallFont);
 			_mouseText->setTargetWidth(96);
 		} else {

--- a/engines/stark/ui/dialogbox.h
+++ b/engines/stark/ui/dialogbox.h
@@ -24,7 +24,7 @@
 
 #include "engines/stark/stark.h"
 #include "engines/stark/ui/window.h"
-#include "engines/stark/visual/text.h"
+#include "engines/stark/gfx/color.h"
 
 #include "common/keyboard.h"
 #include "common/scummsys.h"
@@ -90,7 +90,7 @@ private:
 	Common::Rect _cancelButtonRect;
 	Common::Rect _messageRect;
 
-	const Color _textColor = Color(0xFF, 0xFF, 0xFF);
+	const Gfx::Color _textColor = Gfx::Color(0xFF, 0xFF, 0xFF);
 
 	ConfirmCallback *_confirmCallback;
 };

--- a/engines/stark/ui/dialogbox.h
+++ b/engines/stark/ui/dialogbox.h
@@ -69,7 +69,7 @@ protected:
 	void onClick(const Common::Point &pos) override;
 
 private:
-	Graphics::Surface *loadBackground();
+	Gfx::Bitmap *loadBackground(Gfx::Driver *gfx);
 	static void drawBevel(Graphics::Surface *surface, const Common::Rect &rect);
 	static Common::Rect centerRect(const Common::Rect &container, const Common::Rect &size);
 
@@ -91,6 +91,7 @@ private:
 	Common::Rect _messageRect;
 
 	const Gfx::Color _textColor = Gfx::Color(0xFF, 0xFF, 0xFF);
+	const Gfx::Color _backgroundColor = Gfx::Color(26, 28, 57);
 
 	ConfirmCallback *_confirmCallback;
 };

--- a/engines/stark/ui/menu/dialogmenu.cpp
+++ b/engines/stark/ui/menu/dialogmenu.cpp
@@ -328,7 +328,7 @@ DialogLineText::DialogLineText(Gfx::Driver *gfx, uint logIndex, uint lineIndex, 
 	Common::String name = StarkGlobal->getCharacterName(logLine.characterId);
 	name.toUppercase();
 
-	Color color = logLine.characterId == StarkGlobal->getApril()->getCharacterIndex() ? _textColorApril : _textColorNormal;
+	Gfx::Color color = logLine.characterId == StarkGlobal->getApril()->getCharacterIndex() ? _textColorApril : _textColorNormal;
 
 	_nameText.setText(name);
 	_nameText.setColor(color);

--- a/engines/stark/ui/menu/dialogmenu.h
+++ b/engines/stark/ui/menu/dialogmenu.h
@@ -99,7 +99,7 @@ public:
 	void onScreenChanged() { _text.reset(); }
 
 private:
-	const Color _color = Color(0x68, 0x05, 0x04);
+	const Gfx::Color _color = Gfx::Color(0x68, 0x05, 0x04);
 
 	Common::Point _pos;
 	VisualText _text;
@@ -127,8 +127,8 @@ public:
 	}
 
 private:
-	const Color _textColorApril = Color(0x68, 0x05, 0x04);
-	const Color _textColorNormal = Color(0x1E, 0x1E, 0x96);
+	const Gfx::Color _textColorApril = Gfx::Color(0x68, 0x05, 0x04);
+	const Gfx::Color _textColorNormal = Gfx::Color(0x1E, 0x1E, 0x96);
 
 	Common::Point _namePos, _linePos;
 	VisualText _nameText, _lineText;
@@ -158,8 +158,8 @@ public:
 	void onScreenChanged() override;
 
 private:
-	const Color _textColorHovered = Color(0x1E, 0x1E, 0x96);
-	const Color _textColorDefault = Color(0x00, 0x00, 0x00);
+	const Gfx::Color _textColorHovered = Gfx::Color(0x1E, 0x1E, 0x96);
+	const Gfx::Color _textColorDefault = Gfx::Color(0x00, 0x00, 0x00);
 
 	uint _logIndex, _chapter;
 	int _width, _height;

--- a/engines/stark/ui/menu/diaryindex.cpp
+++ b/engines/stark/ui/menu/diaryindex.cpp
@@ -104,7 +104,7 @@ void DiaryIndexScreen::open() {
 
 void DiaryIndexScreen::widgetTextColorHandler(StaticLocationWidget &widget, const Common::Point &mousePos) {
 	if (widget.isVisible()) {
-		Color textColor = widget.isMouseInside(mousePos) ? _textColorHovered : _textColorDefault;
+		Gfx::Color textColor = widget.isMouseInside(mousePos) ? _textColorHovered : _textColorDefault;
 		widget.setTextColor(textColor);
 	}
 }

--- a/engines/stark/ui/menu/fmvmenu.h
+++ b/engines/stark/ui/menu/fmvmenu.h
@@ -90,13 +90,13 @@ public:
 
 	void onClick();
 
-	void setTextColor(const Color &color) { _title.setColor(color); }
+	void setTextColor(const Gfx::Color &color) { _title.setColor(color); }
 
 	void onScreenChanged() { _title.reset(); }
 
 private:
-	const Color _textColorHovered = Color(0x1E, 0x1E, 0x96);
-	const Color _textColorDefault = Color(0x00, 0x00, 0x00);
+	const Gfx::Color _textColorHovered = Gfx::Color(0x1E, 0x1E, 0x96);
+	const Gfx::Color _textColorDefault = Gfx::Color(0x00, 0x00, 0x00);
 
 	Common::Point _formatRectPos;
 	int _fontHeight;

--- a/engines/stark/ui/menu/locationscreen.cpp
+++ b/engines/stark/ui/menu/locationscreen.cpp
@@ -228,7 +228,7 @@ void StaticLocationWidget::setupSounds(int16 enterSound, int16 clickSound) {
 	}
 }
 
-void StaticLocationWidget::setTextColor(const Color &textColor) {
+void StaticLocationWidget::setTextColor(const Gfx::Color &textColor) {
 	if (!_renderEntry) return;
 
 	VisualText *text = _renderEntry->getText();

--- a/engines/stark/ui/menu/locationscreen.h
+++ b/engines/stark/ui/menu/locationscreen.h
@@ -24,7 +24,7 @@
 
 #include "engines/stark/ui/screen.h"
 #include "engines/stark/ui/window.h"
-#include "engines/stark/visual/text.h"
+#include "engines/stark/gfx/color.h"
 
 namespace Stark {
 
@@ -121,7 +121,7 @@ public:
 	 *
 	 * Only applies for widget referring to a RenderEntry for a text visual
 	 */
-	void setTextColor(const Color &textColor);
+	void setTextColor(const Gfx::Color &textColor);
 
 	/** Widgets must be visible to be rendered and interactive */
 	bool isVisible() const;

--- a/engines/stark/ui/menu/saveloadmenu.cpp
+++ b/engines/stark/ui/menu/saveloadmenu.cpp
@@ -93,7 +93,7 @@ void SaveLoadMenuScreen::open() {
 			CLICK_HANDLER(SaveLoadMenuScreen, prevPageHandler),
 			nullptr));
 	_widgets.back()->setupSounds(0, 1);
-	_widgets.back()->setTextColor(Color(0, 0, 0));
+	_widgets.back()->setTextColor(Gfx::Color(0, 0, 0));
 	_widgets.back()->setVisible(_page > 0);
 
 	_widgets.push_back(new StaticLocationWidget(
@@ -101,7 +101,7 @@ void SaveLoadMenuScreen::open() {
 			CLICK_HANDLER(SaveLoadMenuScreen, nextPageHandler),
 			nullptr));
 	_widgets.back()->setupSounds(0, 1);
-	_widgets.back()->setTextColor(Color(0, 0, 0));
+	_widgets.back()->setTextColor(Gfx::Color(0, 0, 0));
 	_widgets.back()->setVisible(_page < _maxPage);
 
 	loadSaveData(_page);

--- a/engines/stark/ui/menu/saveloadmenu.h
+++ b/engines/stark/ui/menu/saveloadmenu.h
@@ -156,8 +156,8 @@ public:
 	bool hasSave() { return _hasSave; }
 
 private:
-	const Color _outlineColor = Color(0x1E, 0x1E, 0x96);
-	const Color _textColor = Color(0x5C, 0x48, 0x3D);
+	const Gfx::Color _outlineColor = Gfx::Color(0x1E, 0x1E, 0x96);
+	const Gfx::Color _textColor = Gfx::Color(0x5C, 0x48, 0x3D);
 
 	int _slot;
 	SaveLoadMenuScreen *_screen;

--- a/engines/stark/ui/menu/settingsmenu.h
+++ b/engines/stark/ui/menu/settingsmenu.h
@@ -105,8 +105,8 @@ private:
 	void backHandler();
 
 private:
-	const Color _textColorHovered = Color(0x1E, 0x1E, 0x96);
-	const Color _textColorDefault = Color(0x00, 0x00, 0x00);
+	const Gfx::Color _textColorHovered = Gfx::Color(0x1E, 0x1E, 0x96);
+	const Gfx::Color _textColorDefault = Gfx::Color(0x00, 0x00, 0x00);
 
 	TestSoundManager _soundManager;
 };
@@ -155,7 +155,7 @@ public:
 	void onMouseUp() override;
 
 private:
-	const Color _textColorBgHovered = Color(0xFF, 0xFF, 0xFF);
+	const Gfx::Color _textColorBgHovered = Gfx::Color(0xFF, 0xFF, 0xFF);
 	static const int _maxVolume = 256;
 
 	VisualImageXMG *_sliderImage;

--- a/engines/stark/ui/world/actionmenu.cpp
+++ b/engines/stark/ui/world/actionmenu.cpp
@@ -57,8 +57,8 @@ ActionMenu::ActionMenu(Gfx::Driver *gfx, Cursor *cursor) :
 	_background = StarkStaticProvider->getUIElement(StaticProvider::kActionMenuBg);
 
 	_itemDescription = new VisualText(gfx);
-	_itemDescription->setColor(Color(0xFF, 0xFF, 0xFF));
-	_itemDescription->setBackgroundColor(Color(0x00, 0x00, 0x00, 0x80));
+	_itemDescription->setColor(Gfx::Color(0xFF, 0xFF, 0xFF));
+	_itemDescription->setBackgroundColor(Gfx::Color(0x00, 0x00, 0x00, 0x80));
 	_itemDescription->setFont(FontProvider::kSmallFont);
 	_itemDescription->setTargetWidth(96);
 

--- a/engines/stark/ui/world/button.cpp
+++ b/engines/stark/ui/world/button.cpp
@@ -84,7 +84,7 @@ void Button::showButtonHint() {
 	if (!_mouseText) {
 		_mouseText = new VisualText(StarkGfx);
 		_mouseText->setText(_text);
-		_mouseText->setColor(Color(0xFF, 0xFF, 0xFF));
+		_mouseText->setColor(Gfx::Color(0xFF, 0xFF, 0xFF));
 		_mouseText->setFont(FontProvider::kSmallFont);
 		_mouseText->setTargetWidth(96);
 	}

--- a/engines/stark/ui/world/clicktext.cpp
+++ b/engines/stark/ui/world/clicktext.cpp
@@ -25,7 +25,7 @@
 
 namespace Stark {
 
-ClickText::ClickText(const Common::String &text, const Color &color) :
+ClickText::ClickText(const Common::String &text, const Gfx::Color &color) :
 		_text(text),
 		_color(color) {
 	_visualPassive = new VisualText(StarkGfx);
@@ -36,7 +36,7 @@ ClickText::ClickText(const Common::String &text, const Color &color) :
 
 	_visualActive = new VisualText(StarkGfx);
 	_visualActive->setText(_text);
-	_visualActive->setColor(Color(0x00, 0x00, 0x00));
+	_visualActive->setColor(Gfx::Color(0x00, 0x00, 0x00));
 	_visualActive->setBackgroundColor(_color);
 	_visualActive->setFont(FontProvider::kBigFont);
 	_visualActive->setTargetWidth(600);

--- a/engines/stark/ui/world/clicktext.h
+++ b/engines/stark/ui/world/clicktext.h
@@ -22,7 +22,7 @@
 #ifndef STARK_UI_CLICK_TEXT_H
 #define STARK_UI_CLICK_TEXT_H
 
-#include "engines/stark/visual/text.h"
+#include "engines/stark/gfx/color.h"
 
 #include "common/scummsys.h"
 #include "common/rect.h"
@@ -34,7 +34,7 @@ class VisualText;
 
 class ClickText {
 public:
-	ClickText(const Common::String &text, const Color &color);
+	ClickText(const Common::String &text, const Gfx::Color &color);
 	~ClickText();
 
 	void setPosition(const Common::Point &pos) { _position = pos; }
@@ -52,7 +52,7 @@ private:
 	Common::Point _position;
 	Common::String _text;
 	Common::Rect _bbox;
-	Color _color;
+	Gfx::Color _color;
 };
 
 } // End of namespace Stark

--- a/engines/stark/ui/world/dialogpanel.cpp
+++ b/engines/stark/ui/world/dialogpanel.cpp
@@ -159,7 +159,7 @@ void DialogPanel::onRender() {
 void DialogPanel::updateSubtitleVisual() {
 	clearSubtitleVisual();
 
-	Color color = _otherColor;
+	Gfx::Color color = _otherColor;
 	if (_currentSpeech->characterIsApril())
 		color = _aprilColor;
 

--- a/engines/stark/ui/world/dialogpanel.h
+++ b/engines/stark/ui/world/dialogpanel.h
@@ -23,7 +23,7 @@
 #define STARK_UI_DIALOG_PANEL_H
 
 #include "engines/stark/ui/window.h"
-#include "engines/stark/visual/text.h"
+#include "engines/stark/gfx/color.h"
 
 #include "common/scummsys.h"
 #include "common/str.h"
@@ -34,6 +34,7 @@
 namespace Stark {
 
 class VisualImageXMG;
+class VisualText;
 class ClickText;
 
 namespace Resources {
@@ -103,8 +104,8 @@ private:
 	Common::Array<ClickText*> _options;
 	bool _acceptIdleMousePos;
 
-	Color _aprilColor = Color(0xFF, 0xC0, 0x00);
-	Color _otherColor = Color(0xFF, 0x40, 0x40);
+	const Gfx::Color _aprilColor = Gfx::Color(0xFF, 0xC0, 0x00);
+	const Gfx::Color _otherColor = Gfx::Color(0xFF, 0x40, 0x40);
 	static const uint32 _optionsTop = 4;
 	static const uint32 _optionsLeft = 30;
 	static const uint32 _optionsHeight = 80;

--- a/engines/stark/visual/text.cpp
+++ b/engines/stark/visual/text.cpp
@@ -296,29 +296,11 @@ void VisualText::createBitmap() {
 	_bitmap->setSamplingFilter(Gfx::Bitmap::kNearest);
 
 	surface.free();
-
-	// If we have a background color, generate a 1x1px bitmap of that color
-	if (_backgroundColor.a != 0) {
-		surface.create(1, 1, Gfx::Driver::getRGBAPixelFormat());
-
-		uint32 bgColor = surface.format.ARGBToColor(
-		            _backgroundColor.a, _backgroundColor.r, _backgroundColor.g, _backgroundColor.b
-		            );
-
-		surface.fillRect(Common::Rect(surface.w, surface.h), bgColor);
-		multiplyColorWithAlpha(&surface);
-
-		_bgBitmap = _gfx->createBitmap(&surface);
-
-		surface.free();
-	}
 }
 
 void VisualText::freeBitmap() {
 	delete _bitmap;
 	_bitmap = nullptr;
-	delete _bgBitmap;
-	_bgBitmap = nullptr;
 }
 
 void VisualText::render(const Common::Point &position) {
@@ -326,8 +308,8 @@ void VisualText::render(const Common::Point &position) {
 		createBitmap();
 	}
 
-	if (_bgBitmap) {
-		_surfaceRenderer->render(_bgBitmap, position, _bitmap->width(), _bitmap->height());
+	if (_backgroundColor.a != 0) {
+		_surfaceRenderer->fill(_backgroundColor, position, _bitmap->width(), _bitmap->height());
 	}
 
 	_surfaceRenderer->render(_bitmap, position);

--- a/engines/stark/visual/text.cpp
+++ b/engines/stark/visual/text.cpp
@@ -41,9 +41,8 @@ VisualText::VisualText(Gfx::Driver *gfx) :
 		Visual(TYPE),
 		_gfx(gfx),
 		_bitmap(nullptr),
-		_bgBitmap(nullptr),
-		_color(Color(0, 0, 0)),
-		_backgroundColor(Color(0, 0, 0, 0)),
+		_color(Gfx::Color(0, 0, 0)),
+		_backgroundColor(Gfx::Color(0, 0, 0, 0)),
 		_align(Graphics::kTextAlignLeft),
 		_targetWidth(600),
 		_targetHeight(600),
@@ -73,7 +72,7 @@ void VisualText::setText(const Common::String &text) {
 	}
 }
 
-void VisualText::setColor(const Color &color) {
+void VisualText::setColor(const Gfx::Color &color) {
 	if (_color == color) {
 		return;
 	}
@@ -82,7 +81,7 @@ void VisualText::setColor(const Color &color) {
 	_color = color;
 }
 
-void VisualText::setBackgroundColor(const Color &color) {
+void VisualText::setBackgroundColor(const Gfx::Color &color) {
 	if (color == _backgroundColor) {
 		return;
 	}
@@ -198,7 +197,7 @@ static void multiplyColorWithAlpha(Graphics::Surface *source) {
  *
  * Color space aware version.
  */
-static void blendWithColor(Graphics::Surface *source, const Color &color) {
+static void blendWithColor(Graphics::Surface *source, const Gfx::Color &color) {
 	assert(source->format == Gfx::Driver::getRGBAPixelFormat());
 
 	float sRL = srgbToLinear(color.r / 255.f);

--- a/engines/stark/visual/text.h
+++ b/engines/stark/visual/text.h
@@ -74,7 +74,6 @@ private:
 	Gfx::Driver *_gfx;
 	Gfx::SurfaceRenderer *_surfaceRenderer;
 	Gfx::Bitmap *_bitmap;
-	Gfx::Bitmap *_bgBitmap;
 
 	Common::String _text;
 	Gfx::Color _color;

--- a/engines/stark/visual/text.h
+++ b/engines/stark/visual/text.h
@@ -25,6 +25,7 @@
 #include "engines/stark/visual/visual.h"
 
 #include "engines/stark/services/fontprovider.h"
+#include "engines/stark/gfx/color.h"
 
 #include "common/rect.h"
 #include "graphics/font.h"
@@ -36,23 +37,6 @@ class Driver;
 class SurfaceRenderer;
 class Bitmap;
 }
-
-struct Color {
-	uint8 r;
-	uint8 g;
-	uint8 b;
-	uint8 a;
-
-	Color(uint8 red, uint8 green, uint8 blue, uint8 alpha = 0xFF) :
-			r(red), g(green), b(blue), a(alpha) {}
-
-	bool operator==(const Color &color) const {
-		return r == color.r &&
-		       g == color.g &&
-		       b == color.b &&
-		       a == color.a;
-	}
-};
 
 /**
  * Text renderer
@@ -67,8 +51,8 @@ public:
 	Common::Rect getRect();
 
 	void setText(const Common::String &text);
-	void setColor(const Color &color);
-	void setBackgroundColor(const Color &color);
+	void setColor(const Gfx::Color &color);
+	void setBackgroundColor(const Gfx::Color &color);
 	void setAlign(Graphics::TextAlign align);
 	void setTargetWidth(uint32 width);
 	void setTargetHeight(uint32 height);
@@ -93,8 +77,8 @@ private:
 	Gfx::Bitmap *_bgBitmap;
 
 	Common::String _text;
-	Color _color;
-	Color _backgroundColor;
+	Gfx::Color _color;
+	Gfx::Color _backgroundColor;
 	Graphics::TextAlign _align;
 	uint32 _targetWidth;
 	uint32 _targetHeight;


### PR DESCRIPTION
This allows removing a workaround in the TinyGL renderer, and avoids needing to allocate large textures just to draw a solid colour.