### PR TITLE
OPENGL: Check if GL_TEXTURE_MAX_LEVEL is supported before using it

### DIFF
--- a/engines/stark/gfx/opengltexture.cpp
+++ b/engines/stark/gfx/opengltexture.cpp
@@ -75,17 +75,15 @@ void OpenGlTexture::setLevelCount(uint32 count) {
 	_levelCount = count;
 
 	if (count >= 1) {
-#if !USE_FORCED_GLES2
-		// GLES2 does not allow setting the max provided mipmap level.
+		// GLES1 and GLES2 do not allow setting the max provided mipmap level.
 		// It expects all the levels to be provided, which is not the case in TLJ.
-		// FIXME: Enable mipmapping on GLES2
-		if (OpenGLContext.type != OpenGL::kContextGLES2) {
+		// FIXME: Enable mipmapping on GLES without this extension
+		if (OpenGLContext.textureMaxLevelSupported) {
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, count - 1);
 
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_NEAREST);
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 		}
-#endif
 
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_MIRRORED_REPEAT);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_MIRRORED_REPEAT);
@@ -95,7 +93,7 @@ void OpenGlTexture::setLevelCount(uint32 count) {
 void OpenGlTexture::addLevel(uint32 level, const Graphics::Surface *surface, const byte *palette) {
 	assert(level < _levelCount);
 
-	if (level == 0 || OpenGLContext.type != OpenGL::kContextGLES2) {
+	if (level == 0 || OpenGLContext.textureMaxLevelSupported) {
 		updateLevel(level, surface, palette);
 	}
 }

--- a/graphics/opengl/context.cpp
+++ b/graphics/opengl/context.cpp
@@ -71,6 +71,7 @@ void Context::reset() {
 	textureEdgeClampSupported = false;
 	textureBorderClampSupported = false;
 	textureMirrorRepeatSupported = false;
+	textureMaxLevelSupported = false;
 }
 
 void Context::initialize(ContextType contextType) {
@@ -186,6 +187,8 @@ void Context::initialize(ContextType contextType) {
 			textureBorderClampSupported = true;
 		} else if (token == "GL_ARB_texture_mirrored_repeat") {
 			textureMirrorRepeatSupported = true;
+		} else if (token == "GL_SGIS_texture_lod" || token == "GL_APPLE_texture_max_level") {
+			textureMaxLevelSupported = true;
 		}
 	}
 
@@ -219,6 +222,7 @@ void Context::initialize(ContextType contextType) {
 		textureEdgeClampSupported = true;
 		// No border clamping in GLES2
 		textureMirrorRepeatSupported = true;
+		// TODO: textureMaxLevelSupported with GLES3
 		debug(5, "OpenGL: GLES2 context initialized");
 	} else if (type == kContextGLES) {
 		// GLES doesn't support shaders natively
@@ -264,10 +268,11 @@ void Context::initialize(ContextType contextType) {
 			glGetIntegerv(GL_MAX_SAMPLES, (GLint *)&multisampleMaxSamples);
 		}
 
-		// OpenGL 1.2 and later always has packed pixels and texture edge clamp support
+		// OpenGL 1.2 and later always has packed pixels, texture edge clamp and texture max level support
 		if (isGLVersionOrHigher(1, 2)) {
 			packedPixelsSupported = true;
 			textureEdgeClampSupported = true;
+			textureMaxLevelSupported = true;
 		}
 		// OpenGL 1.3 adds texture border clamp support
 		if (isGLVersionOrHigher(1, 3)) {
@@ -302,6 +307,7 @@ void Context::initialize(ContextType contextType) {
 	debug(5, "OpenGL: Unpack subimage support: %d", unpackSubImageSupported);
 	debug(5, "OpenGL: OpenGL ES depth 24 support: %d", OESDepth24);
 	debug(5, "OpenGL: Texture edge clamping support: %d", textureEdgeClampSupported);
+	debug(5, "OpenGL: Texture max level support: %d", textureMaxLevelSupported);
 }
 
 int Context::getGLSLVersion() const {

--- a/graphics/opengl/context.h
+++ b/graphics/opengl/context.h
@@ -117,6 +117,9 @@ public:
 	/** Whether texture coordinate mirrored repeat is available or not. */
 	bool textureMirrorRepeatSupported;
 
+	/** Whether texture max level is available or not. */
+	bool textureMaxLevelSupported;
+
 private:
 	/**
 	 * Returns the native GLSL version supported by the driver.

--- a/graphics/opengl/system_headers.h
+++ b/graphics/opengl/system_headers.h
@@ -99,4 +99,8 @@
 #endif
 #endif
 
+#if !defined(GL_TEXTURE_MAX_LEVEL) && defined(GL_TEXTURE_MAX_LEVEL_APPLE)
+	#define GL_TEXTURE_MAX_LEVEL GL_TEXTURE_MAX_LEVEL_APPLE
+#endif
+
 #endif


### PR DESCRIPTION
This is split out from PR #4633, and may be useful with OpenGL 1.1 as well.