### PR TITLE
TINYGL: Make use of ColorMask templates for NearestTexelBuffer

### DIFF
--- a/graphics/tinygl/colormasks.h
+++ b/graphics/tinygl/colormasks.h
@@ -1,0 +1,146 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef GRAPHICS_TINYGL_COLORMASKS_H
+#define GRAPHICS_TINYGL_COLORMASKS_H
+
+#include "graphics/tinygl/gl.h"
+
+namespace TinyGL {
+
+template<uint Format, uint Type>
+struct ColorMasks {
+};
+
+template<>
+struct ColorMasks<TGL_RGB, TGL_UNSIGNED_SHORT_5_6_5> {
+	enum : uint {
+		kBytesPerPixel = 2,
+
+		kAlphaBits  = 0,
+		kRedBits    = 5,
+		kGreenBits  = 6,
+		kBlueBits   = 5,
+
+		kAlphaShift = 0,
+		kRedShift   = kGreenBits+kBlueBits,
+		kGreenShift = kBlueBits,
+		kBlueShift  = 0,
+
+		kAlphaMask  = ((1 << kAlphaBits) - 1) << kAlphaShift,
+		kRedMask    = ((1 << kRedBits) - 1) << kRedShift,
+		kGreenMask  = ((1 << kGreenBits) - 1) << kGreenShift,
+		kBlueMask   = ((1 << kBlueBits) - 1) << kBlueShift,
+
+		kRedBlueMask = kRedMask | kBlueMask,
+	};
+
+	typedef uint16 PixelType;
+};
+
+template<>
+struct ColorMasks<TGL_RGBA, TGL_UNSIGNED_SHORT_5_5_5_1> {
+	enum {
+		kBytesPerPixel = 2,
+
+		kAlphaBits  = 1,
+		kRedBits    = 5,
+		kGreenBits  = 5,
+		kBlueBits   = 5,
+
+		kAlphaShift = 0,
+		kRedShift   = kGreenBits+kBlueBits+kAlphaBits,
+		kGreenShift = kBlueBits+kAlphaBits,
+		kBlueShift  = kAlphaBits,
+
+		kAlphaMask = ((1 << kAlphaBits) - 1) << kAlphaShift,
+		kRedMask   = ((1 << kRedBits) - 1) << kRedShift,
+		kGreenMask = ((1 << kGreenBits) - 1) << kGreenShift,
+		kBlueMask  = ((1 << kBlueBits) - 1) << kBlueShift,
+
+		kRedBlueMask = kRedMask | kBlueMask
+	};
+
+	typedef uint16 PixelType;
+};
+
+template<>
+struct ColorMasks<TGL_RGBA, TGL_UNSIGNED_SHORT_4_4_4_4> {
+	enum {
+		kBytesPerPixel = 2,
+
+		kAlphaBits  = 4,
+		kRedBits    = 4,
+		kGreenBits  = 4,
+		kBlueBits   = 4,
+
+		kAlphaShift = 0,
+		kRedShift   = kGreenBits+kBlueBits+kAlphaBits,
+		kGreenShift = kBlueBits+kAlphaBits,
+		kBlueShift  = kAlphaBits,
+
+		kAlphaMask = ((1 << kAlphaBits) - 1) << kAlphaShift,
+		kRedMask   = ((1 << kRedBits) - 1) << kRedShift,
+		kGreenMask = ((1 << kGreenBits) - 1) << kGreenShift,
+		kBlueMask  = ((1 << kBlueBits) - 1) << kBlueShift,
+
+		kRedBlueMask = kRedMask | kBlueMask
+	};
+
+	typedef uint16 PixelType;
+};
+
+template<>
+struct ColorMasks<TGL_RGBA, TGL_UNSIGNED_BYTE> {
+	enum {
+		kBytesPerPixel = 4,
+
+		kAlphaBits  = 8,
+		kRedBits    = 8,
+		kGreenBits  = 8,
+		kBlueBits   = 8,
+
+#if defined(SCUMM_LITTLE_ENDIAN)
+		kAlphaShift = kRedBits+kGreenBits+kBlueBits,
+		kRedShift   = 0,
+		kGreenShift = kRedBits,
+		kBlueShift  = kRedBits+kGreenBits,
+#else
+		kAlphaShift = 0,
+		kRedShift   = kGreenBits+kBlueBits+kAlphaBits,
+		kGreenShift = kBlueBits+kAlphaBits,
+		kBlueShift  = kAlphaBits,
+#endif
+
+		kAlphaMask = ((1 << kAlphaBits) - 1) << kAlphaShift,
+		kRedMask   = ((1 << kRedBits) - 1) << kRedShift,
+		kGreenMask = ((1 << kGreenBits) - 1) << kGreenShift,
+		kBlueMask  = ((1 << kBlueBits) - 1) << kBlueShift,
+
+		kRedBlueMask = kRedMask | kBlueMask,
+	};
+
+	typedef uint32 PixelType;
+};
+
+} // End of namespace Graphics
+
+#endif

--- a/graphics/tinygl/texelbuffer.cpp
+++ b/graphics/tinygl/texelbuffer.cpp
@@ -91,12 +91,12 @@ protected:
 
 BaseNearestTexelBuffer::BaseNearestTexelBuffer(const byte *buf, const Graphics::PixelFormat &format, uint width, uint height, uint textureSize) : TexelBuffer(width, height, textureSize), _format(format) {
 	uint count = _width * _height * _format.bytesPerPixel;
-	_buf = new byte[count];
+	_buf = (byte *)gl_malloc(count);
 	memcpy(_buf, buf, count);
 }
 
 BaseNearestTexelBuffer::~BaseNearestTexelBuffer() {
-	delete[] _buf;
+	gl_free(_buf);
 }
 
 template<uint Format, uint Type>
@@ -214,7 +214,7 @@ BilinearTexelBuffer::BilinearTexelBuffer(byte *buf, const Graphics::PixelFormat 
 	uint8 *texel8;
 	uint32 *texel32;
 
-	texel32 = _texels = new uint32[_width * _height << PIXEL_PER_TEXEL_SHIFT];
+	texel32 = _texels = (uint32 *)gl_malloc((_width * _height << PIXEL_PER_TEXEL_SHIFT) * sizeof(uint32));
 	for (uint y = 0; y < _height; y++) {
 		for (uint x = 0; x < _width; x++) {
 			texel8 = (uint8 *)texel32;
@@ -264,7 +264,7 @@ BilinearTexelBuffer::BilinearTexelBuffer(byte *buf, const Graphics::PixelFormat 
 }
 
 BilinearTexelBuffer::~BilinearTexelBuffer() {
-	delete[] _texels;
+	gl_free(_texels);
 }
 
 static inline int interpolate(int v00, int v01, int v10, int xf, int yf) {

--- a/graphics/tinygl/texelbuffer.h
+++ b/graphics/tinygl/texelbuffer.h
@@ -23,7 +23,6 @@
 #define GRAPHICS_TEXELBUFFER_H
 
 #include "graphics/pixelformat.h"
-#include "graphics/tinygl/colormasks.h"
 
 namespace TinyGL {
 
@@ -48,71 +47,8 @@ protected:
 	float _widthRatio, _heightRatio;
 };
 
-class BaseNearestTexelBuffer : public TexelBuffer {
-public:
-	BaseNearestTexelBuffer(const byte *buf, const Graphics::PixelFormat &format, uint width, uint height, uint textureSize);
-	~BaseNearestTexelBuffer();
-
-protected:
-	byte *_buf;
-	Graphics::PixelFormat _format;
-};
-
-template<uint Format, uint Type>
-class NearestTexelBuffer final : public BaseNearestTexelBuffer {
-public:
-	NearestTexelBuffer(const byte *buf, const Graphics::PixelFormat &format, uint width, uint height, uint textureSize)
-	  : BaseNearestTexelBuffer(buf, format, width, height, textureSize) {}
-
-protected:
-	void getARGBAt(
-		uint pixel,
-		uint, uint,
-		uint8 &a, uint8 &r, uint8 &g, uint8 &b
-	) const override {
-		Pixel col = *(((const Pixel *)_buf) + pixel);
-		_format.colorToARGBT<ColorMask>(col, a, r, g, b);
-	}
-
-	typedef ColorMasks<Format, Type> ColorMask;
-	typedef typename ColorMask::PixelType Pixel;
-};
-
-template<>
-class NearestTexelBuffer<TGL_RGB, TGL_UNSIGNED_BYTE> final : public BaseNearestTexelBuffer {
-public:
-	NearestTexelBuffer(const byte *buf, const Graphics::PixelFormat &format, uint width, uint height, uint textureSize)
-	  : BaseNearestTexelBuffer(buf, format, width, height, textureSize) {}
-
-protected:
-	void getARGBAt(
-		uint pixel,
-		uint, uint,
-		uint8 &a, uint8 &r, uint8 &g, uint8 &b
-	) const override {
-		byte *col = _buf + (pixel * 3);
-		a = 0xff;
-		r = col[0];
-		g = col[1];
-		b = col[2];
-	}
-};
-
-class BilinearTexelBuffer : public TexelBuffer {
-public:
-	BilinearTexelBuffer(byte *buf, const Graphics::PixelFormat &format, uint width, uint height, uint textureSize);
-	~BilinearTexelBuffer();
-
-protected:
-	void getARGBAt(
-		uint pixel,
-		uint ds, uint dt,
-		uint8 &a, uint8 &r, uint8 &g, uint8 &b
-	) const override;
-
-private:
-	uint32 *_texels;
-};
+TexelBuffer *createNearestTexelBuffer(const byte *buf, const Graphics::PixelFormat &pf, uint format, uint type, uint width, uint height, uint textureSize);
+TexelBuffer *createBilinearTexelBuffer(byte *buf, const Graphics::PixelFormat &pf, uint format, uint type, uint width, uint height, uint textureSize);
 
 } // end of namespace TinyGL
 

--- a/graphics/tinygl/texture.cpp
+++ b/graphics/tinygl/texture.cpp
@@ -164,46 +164,20 @@ void GLContext::glopTexImage2D(GLParam *p) {
 		case TGL_LINEAR_MIPMAP_NEAREST:
 		case TGL_LINEAR_MIPMAP_LINEAR:
 		case TGL_LINEAR:
-			im->pixmap = new BilinearTexelBuffer(
+			im->pixmap = createBilinearTexelBuffer(
 				pixels, pf,
+				format, type,
 				width, height,
 				_textureSize
 			);
 			break;
 		default:
-			if (format == TGL_RGBA && type == TGL_UNSIGNED_BYTE) {
-				im->pixmap = new NearestTexelBuffer<TGL_RGBA, TGL_UNSIGNED_BYTE>(
-					pixels, pf,
-					width, height,
-					_textureSize
-				);
-			} else if (format == TGL_RGB && type == TGL_UNSIGNED_BYTE) {
-				im->pixmap = new NearestTexelBuffer<TGL_RGB,  TGL_UNSIGNED_BYTE>(
-					pixels, pf,
-					width, height,
-					_textureSize
-				);
-			} else if (format == TGL_RGB && type == TGL_UNSIGNED_SHORT_5_6_5) {
-				im->pixmap = new NearestTexelBuffer<TGL_RGB,  TGL_UNSIGNED_SHORT_5_6_5>(
-					pixels, pf,
-					width, height,
-					_textureSize
-				);
-			} else if (format == TGL_RGBA && type == TGL_UNSIGNED_SHORT_5_5_5_1) {
-				im->pixmap = new NearestTexelBuffer<TGL_RGBA, TGL_UNSIGNED_SHORT_5_5_5_1>(
-					pixels, pf,
-					width, height,
-					_textureSize
-				);
-			} else if (format == TGL_RGBA && type == TGL_UNSIGNED_SHORT_4_4_4_4) {
-				im->pixmap = new NearestTexelBuffer<TGL_RGBA, TGL_UNSIGNED_SHORT_4_4_4_4>(
-					pixels, pf,
-					width, height,
-					_textureSize
-				);
-			} else {
-				error("TinyGL texture: format 0x%04x and type 0x%04x combination not supported", format, type);
-			}
+			im->pixmap = createNearestTexelBuffer(
+				pixels, pf,
+				format, type,
+				width, height,
+				_textureSize
+			);
 			break;
 		}
 	}


### PR DESCRIPTION
This reduces the amount of memory required for textures with packed pixels, and should hopefully offer some performance improvements as well.