### PR TITLE
HUGO: Use slot 99 for the "restart" fallback save instead of slot 0

### DIFF
--- a/engines/hugo/hugo.cpp
+++ b/engines/hugo/hugo.cpp
@@ -298,7 +298,7 @@ Common::Error HugoEngine::run() {
 			_status._skipIntroFl = true;
 			_file->restoreGame(loadSlot);
 		} else {
-			_file->saveGame(0, "New Game");
+			_file->saveGame(99, "New Game [reserved]");
 		}
 	}
 

--- a/engines/hugo/metaengine.cpp
+++ b/engines/hugo/metaengine.cpp
@@ -147,6 +147,12 @@ SaveStateDescriptor HugoMetaEngine::querySaveMetaInfos(const char *target, int s
 
 		SaveStateDescriptor desc(this, slot, saveName);
 
+		// Protect slot 99 (used for 'restart game')
+		if (slot == 99) {
+			desc.setDeletableFlag(false);
+			desc.setWriteProtectedFlag(true);
+		}
+
 		Graphics::Surface *thumbnail;
 		if (!Graphics::loadThumbnail(*file, thumbnail)) {
 			warning("Missing or broken savegame thumbnail");
@@ -172,7 +178,13 @@ SaveStateDescriptor HugoMetaEngine::querySaveMetaInfos(const char *target, int s
 		delete file;
 		return desc;
 	}
-	return SaveStateDescriptor();
+
+	SaveStateDescriptor desc(this, slot, Common::String());
+	// Protect slot 99 (used for 'restart game')
+	if (slot == 99)
+		desc.setWriteProtectedFlag(true);
+
+	return desc;
 }
 
 void HugoMetaEngine::removeSaveState(const char *target, int slot) const {

--- a/engines/hugo/parser.cpp
+++ b/engines/hugo/parser.cpp
@@ -290,7 +290,7 @@ void Parser::keyHandler(Common::Event event) {
 			break;
 		case Common::KEYCODE_n:
 			if (Utils::yesNoBox("Are you sure you want to start a new game?"))
-				_vm->_file->restoreGame(0);
+				_vm->_file->restoreGame(99);
 			break;
 		case Common::KEYCODE_s:
 			if (gameStatus._viewState == kViewPlay) {


### PR DESCRIPTION
The Hugo games keep a save slot which  is used when restarting the game using CTRL-N.
This PR uses slot 99 (the last available) instead of slot 0, which is normally used for autosaves.
Also fixes TRAC 11559

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
