### PR TITLE
COMMON: Simplify API for getHumanReadableBytes()

### DIFF
--- a/common/util.cpp
+++ b/common/util.cpp
@@ -177,33 +177,33 @@ bool isBlank(int c) {
 #pragma mark -
 
 
-Common::U32String getHumanReadableBytes(uint64 bytes, Common::String &unitsOut) {
+Common::String getHumanReadableBytes(uint64 bytes, const char *&unitsOut) {
 	if (bytes < 1024) {
 		// I18N: Abbreviation for 'bytes' as data size
-		unitsOut = _("B");
+		unitsOut = _s("B");
 		return Common::String::format("%lu", (unsigned long int)bytes);
 	}
 
 	double floating = bytes / 1024.0;
-		// I18N: Abbreviation for 'kilobytes' as data size
-	unitsOut = _("KB");
+	// I18N: Abbreviation for 'kilobytes' as data size
+	unitsOut = _s("KB");
 
 	if (floating >= 1024) {
 		floating /= 1024.0;
 		// I18N: Abbreviation for 'megabytes' as data size
-		unitsOut = _("MB");
+		unitsOut = _s("MB");
 	}
 
 	if (floating >= 1024) {
 		floating /= 1024.0;
 		// I18N: Abbreviation for 'gigabytes' as data size
-		unitsOut = _("GB");
+		unitsOut = _s("GB");
 	}
 
 	if (floating >= 1024) { // woah
 		floating /= 1024.0;
 		// I18N: Abbreviation for 'terabytes' as data size
-		unitsOut = _("TB");
+		unitsOut = _s("TB");
 	}
 
 	// print one digit after floating point

--- a/common/util.h
+++ b/common/util.h
@@ -413,7 +413,7 @@ bool isBlank(int c);
  *
  * @return String with a floating point number representing the given size.
  */
-Common::U32String getHumanReadableBytes(uint64 bytes, Common::String &unitsOut);
+Common::String getHumanReadableBytes(uint64 bytes, const char *&unitsOut);
 
 /** @} */
 

--- a/gui/downloaddialog.cpp
+++ b/gui/downloaddialog.cpp
@@ -208,17 +208,16 @@ void DownloadDialog::reflowLayout() {
 }
 
 Common::U32String DownloadDialog::getSizeLabelText() {
-	Common::String downloaded, downloadedUnits, total, totalUnits;
-	downloaded = getHumanReadableBytes(CloudMan.getDownloadBytesNumber(), downloadedUnits);
-	total = getHumanReadableBytes(CloudMan.getDownloadTotalBytesNumber(), totalUnits);
+	const char *downloadedUnits, *totalUnits;
+	Common::String downloaded = Common::getHumanReadableBytes(CloudMan.getDownloadBytesNumber(), downloadedUnits);
+	Common::String total = Common::getHumanReadableBytes(CloudMan.getDownloadTotalBytesNumber(), totalUnits);
 	return Common::U32String::format(_("Downloaded %s %S / %s %S"), downloaded.c_str(), _(downloadedUnits).c_str(), total.c_str(), _(totalUnits).c_str());
 }
 
 Common::U32String DownloadDialog::getSpeedLabelText() {
-	Common::String speed, speedUnits;
-	speed = getHumanReadableBytes(CloudMan.getDownloadSpeed(), speedUnits);
-	speedUnits += "/s";
-	return Common::U32String::format(_("Download speed: %s %S"), speed.c_str(), _(speedUnits).c_str());
+	const char *speedUnits;
+	Common::String speed = Common::getHumanReadableBytes(CloudMan.getDownloadSpeed(), speedUnits);
+	return Common::U32String::format(_("Download speed: %s %S/s"), speed.c_str(), _(speedUnits).c_str());
 }
 
 void DownloadDialog::refreshWidgets() {

--- a/gui/downloadpacksdialog.cpp
+++ b/gui/downloadpacksdialog.cpp
@@ -255,8 +255,8 @@ void DownloadPacksDialog::setState(IconProcessState state) {
 		break;
 
 	case kDownloadStateListCalculated: {
-			Common::String size, sizeUnits;
-			size = getHumanReadableBytes(g_state->totalSize, sizeUnits);
+			const char *sizeUnits;
+			Common::String size = Common::getHumanReadableBytes(g_state->totalSize, sizeUnits);
 
 			_statusText->setLabel(Common::U32String::format(_("Detected %d new packs, %s %S"), g_state->fileHash.size(), size.c_str(), _(sizeUnits).c_str()));
 
@@ -282,8 +282,8 @@ void DownloadPacksDialog::setState(IconProcessState state) {
 		break;
 
 	case kDownloadComplete: {
-			Common::String size, sizeUnits;
-			size = getHumanReadableBytes(g_state->totalSize, sizeUnits);
+			const char *sizeUnits;
+			Common::String size = Common::getHumanReadableBytes(g_state->totalSize, sizeUnits);
 			_statusText->setLabel(Common::U32String::format(_("Download complete, downloaded %d packs, %s %S"), g_state->totalFiles, size.c_str(), _(sizeUnits).c_str()));
 			_cancelButton->setVisible(false);
 			_cancelButton->setLabel(_("Cancel download"));
@@ -358,17 +358,16 @@ void DownloadPacksDialog::reflowLayout() {
 }
 
 Common::U32String DownloadPacksDialog::getSizeLabelText() {
-	Common::String downloaded, downloadedUnits, total, totalUnits;
-	downloaded = getHumanReadableBytes(g_state->downloadedSize, downloadedUnits);
-	total = getHumanReadableBytes(g_state->totalSize, totalUnits);
+	const char *downloadedUnits, *totalUnits;
+	Common::String downloaded = Common::getHumanReadableBytes(g_state->downloadedSize, downloadedUnits);
+	Common::String total = Common::getHumanReadableBytes(g_state->totalSize, totalUnits);
 	return Common::U32String::format(_("Downloaded %s %S / %s %S"), downloaded.c_str(), _(downloadedUnits).c_str(), total.c_str(), _(totalUnits).c_str());
 }
 
 Common::U32String DownloadPacksDialog::getSpeedLabelText() {
-	Common::String speed, speedUnits;
-	speed = getHumanReadableBytes(getDownloadSpeed(), speedUnits);
-	speedUnits += "/s";
-	return Common::U32String::format(_("Download speed: %s %S"), speed.c_str(), _(speedUnits).c_str());
+	const char *speedUnits;
+	Common::String speed = Common::getHumanReadableBytes(getDownloadSpeed(), speedUnits);
+	return Common::U32String::format(_("Download speed: %s %S/s"), speed.c_str(), _(speedUnits).c_str());
 }
 
 void DownloadPacksDialog::refreshWidgets() {
@@ -457,10 +456,10 @@ void DownloadPacksDialog::clearCache() {
 		totalSize += size;
 	}
 
-	Common::String sizeUnits;
-	Common::String size = getHumanReadableBytes(totalSize, sizeUnits);
+	const char *sizeUnits;
+	Common::String size = Common::getHumanReadableBytes(totalSize, sizeUnits);
 
-	GUI::MessageDialog dialog(Common::U32String::format(_("You are about to remove %s %s of data, deleting all previously downloaded %S. Do you want to proceed?"), size.c_str(), sizeUnits.c_str(), _packname.c_str()), _("Proceed"), _("Cancel"));
+	GUI::MessageDialog dialog(Common::U32String::format(_("You are about to remove %s %S of data, deleting all previously downloaded %S. Do you want to proceed?"), size.c_str(), _(sizeUnits).c_str(), _packname.c_str()), _("Proceed"), _("Cancel"));
 	if (dialog.runModal() == ::GUI::kMessageOK) {
 
 		// Build list of previously downloaded icon files

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -3541,8 +3541,8 @@ void GlobalOptionsDialog::setupCloudTab() {
 	if (_storageUsedSpaceDesc) _storageUsedSpaceDesc->setVisible(shownConnectedInfo);
 	if (_storageUsedSpace) {
 		uint64 usedSpace = CloudMan.getStorageUsedSpace(_selectedStorageIndex);
-		Common::String usedSpaceNumber, usedSpaceUnits;
-		usedSpaceNumber = Common::getHumanReadableBytes(usedSpace, usedSpaceUnits);
+		const char *usedSpaceUnits;
+		Common::String usedSpaceNumber = Common::getHumanReadableBytes(usedSpace, usedSpaceUnits);
 		_storageUsedSpace->setLabel(Common::U32String::format("%s %S", usedSpaceNumber.c_str(), _(usedSpaceUnits).c_str()));
 		_storageUsedSpace->setVisible(shownConnectedInfo);
 	}

--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -113,9 +113,9 @@ void SaveLoadCloudSyncProgressDialog::pollCloudMan() {
 	Cloud::Storage::SyncDownloadingInfo info;
 	CloudMan.getSyncDownloadingInfo(info);
 
-	Common::String downloaded, downloadedUnits, total, totalUnits;
-	downloaded = getHumanReadableBytes(info.bytesDownloaded, downloadedUnits);
-	total = getHumanReadableBytes(info.bytesToDownload, totalUnits);
+	const char *downloadedUnits, *totalUnits;
+	Common::String downloaded = Common::getHumanReadableBytes(info.bytesDownloaded, downloadedUnits);
+	Common::String total = Common::getHumanReadableBytes(info.bytesToDownload, totalUnits);
 
 	Common::String progressPercent = Common::String::format("%u %%", progress);
 	Common::String filesDownloaded = Common::String::format("%llu", (unsigned long long)info.filesDownloaded);


### PR DESCRIPTION
This makes it easier to use in debug commands, avoids unnecessary string conversions and fixes a few cases where the units weren't being translated correctly.