### PR TITLE
STARK: Fix memory leak

### DIFF
--- a/engines/stark/stark.cpp
+++ b/engines/stark/stark.cpp
@@ -75,7 +75,6 @@ StarkEngine::~StarkEngine() {
 	delete StarkServices::instance().dialogPlayer;
 	delete StarkServices::instance().randomSource;
 	delete StarkServices::instance().scene;
-	delete StarkServices::instance().gfx;
 	delete StarkServices::instance().staticProvider;
 	delete StarkServices::instance().resourceProvider;
 	delete StarkServices::instance().global;
@@ -86,6 +85,7 @@ StarkEngine::~StarkEngine() {
 	delete StarkServices::instance().settings;
 	delete StarkServices::instance().gameChapter;
 	delete StarkServices::instance().gameMessage;
+	delete StarkServices::instance().gfx;
 
 	StarkServices::destroy();
 


### PR DESCRIPTION
When using TinyGL, bitmaps need to be deleted before the context is destroyed, otherwise the memory used won't actually be freed.