### PR TITLE
CREATE_PROJECT: Set Xcode MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -1389,6 +1389,7 @@ void XcodeProvider::setupBuildConfiguration(const BuildSetup &setup) {
 	scummvmOSX_LibPaths.push_back("\"$(inherited)\"");
 	scummvmOSX_LibPaths.push_back("\"\\\"$(SRCROOT)/lib\\\"\"");
 	ADD_SETTING_LIST(scummvmOSX_Debug, "LIBRARY_SEARCH_PATHS", scummvmOSX_LibPaths, kSettingsNoQuote | kSettingsAsList, 5);
+	ADD_SETTING_QUOTE(scummvmOSX_Debug, "MACOSX_DEPLOYMENT_TARGET", "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)");
 	ADD_SETTING_QUOTE(scummvmOSX_Debug, "OTHER_CFLAGS", "");
 	ADD_SETTING(scummvmOSX_Debug, "PRODUCT_NAME", PROJECT_NAME);
 


### PR DESCRIPTION
Mac xcode builds are currently broken when using the latest xcode on anything less than the latest macos version.

We have not been setting `MACOSX_DEPLOYMENT_TARGET` in the project file. This was okay before xcode 14, because xcode would use a reasonable default value. Xcode 14 changed this. Now when this property isn't set, xcode defaults to the maximum os version it's aware of. If the current os is less than this then the build fails.

Xcode 14 introduced `RECOMMENDED_MACOSX_DEPLOYMENT_TARGET` for this purpose, so now we use that. This shouldn't change behavior for earlier xcode versions, but I'm not in a position to test that.