### PR TITLE
COMMON: Add ability to handle unknown xml keys

### DIFF
--- a/common/formats/xmlparser.cpp
+++ b/common/formats/xmlparser.cpp
@@ -190,7 +190,9 @@ bool XMLParser::parseActiveKey(bool closed) {
 		}
 
 	} else {
-		return parserError("Unexpected key in the active scope ('" + key->name + "').");
+		if (!handleUnknownKey(key))
+			return parserError("Unexpected key in the active scope ('" + key->name + "').");
+		ignore = true;
 	}
 
 	// check if any of the parents must be ignored.

--- a/common/formats/xmlparser.h
+++ b/common/formats/xmlparser.h
@@ -362,6 +362,15 @@ protected:
 	 */
 	virtual void cleanup() {}
 
+	/**
+	 * Overload if your parser wants to be notified of keys which haven't
+	 * been explicitly declared.
+	 *
+	 * The functions should return true if the key was handled and parsing should
+	 * continue, or false (default) to raise a parsing error.
+	 */
+	virtual bool handleUnknownKey(ParserNode *node) { return false; }
+
 	List<XMLKeyLayout *> _layoutList;
 
 private:


### PR DESCRIPTION
For Tetraedge version of Syberia 2 I have a need to parse an xml file which has many key names - the name of the key is used to create a mapping.

Rather than add dozens of functions, I added a simple way of customizing unknown key handling.  This should be completely backward-compatible as the default behaviour is still to raise a parsing error.