### PR TITLE
RISCOS: Use dynamic areas for data and application space for plugins

### DIFF
--- a/backends/plugins/riscos/riscos-provider.cpp
+++ b/backends/plugins/riscos/riscos-provider.cpp
@@ -32,6 +32,18 @@
 #include <kernel.h>
 #include <swis.h>
 
+// By declaring this variable we force libunixlib to always use dynamic areas for data allocations
+// This frees up space for plugins and allows to have plenty of space for data
+const char *const __dynamic_da_name = "ScummVM Heap";
+
+// HACK: These two function are part of private API in libunixlib
+// They let allocate and free data in the application space where the stack is placed below 64MB
+// When using malloc with big chunks we end up in memory mapped areas above 64MB
+extern "C" {
+extern void *__stackalloc (size_t __size);
+extern void __stackfree (void *__ptr);
+}
+
 // HACK: This is needed so that standard library functions that are only
 // used in plugins can be found in the main executable.
 void pluginHack() {
@@ -75,8 +87,48 @@ protected:
 
 };
 
+/**
+ * On 26-bit RISC OS, plugins need to be allocated in the first 64 MB
+ * of RAM so that it can be executed. This may not be the case when using
+ * the default allocators, which use dynamic areas for large allocations.
+ */
+class RiscOSDLObject_AS : public RiscOSDLObject {
+protected:
+	void *allocateMemory(uint32 align, uint32 size) override {
+		// Allocate with worst case alignment in application space
+		void *p = __stackalloc(size + sizeof(uintptr) + align - 1);
+		void *np = (void *)(((uintptr)p + align - 1) & (-align));
+
+		*(uintptr *)((byte *)np + size) = (uintptr)p;
+
+		debug(8, "Allocated %p while alignment was %d: using %p", p, align, np);
+
+		return np;
+	}
+
+	void deallocateMemory(void *ptr, uint32 size) override {
+		void *p = (void *)*(uintptr *)((byte *)ptr + size);
+		debug(8, "Freeing %p which was allocated at %p", ptr, p);
+		__stackfree(p);
+	}
+};
+
+RiscOSPluginProvider::RiscOSPluginProvider() : _is32bit(false) {
+	__asm__ volatile (
+		"SUBS	%[is32bit], r0, r0\n\t" /* Set at least one status flag and set is32bits to 0 */
+		"TEQ	pc, pc\n\t"				/* First operand never contains flags while second one contains them in 26-bits only */
+		"MOVEQ	%[is32bit], #1\n\t"		/* Set to 1 only if EQ flag is set */
+		: [is32bit] "=r" (_is32bit)
+		: /* no inputs */
+		: "cc");
+}
+
 Plugin *RiscOSPluginProvider::createPlugin(const Common::FSNode &node) const {
-	return new TemplatedELFPlugin<RiscOSDLObject>(node.getPath());
+	if (_is32bit) {
+		return new TemplatedELFPlugin<RiscOSDLObject>(node.getPath());
+	} else {
+		return new TemplatedELFPlugin<RiscOSDLObject_AS>(node.getPath());
+	}
 }
 
 #endif // defined(DYNAMIC_MODULES) && defined(RISCOS)

--- a/backends/plugins/riscos/riscos-provider.h
+++ b/backends/plugins/riscos/riscos-provider.h
@@ -28,7 +28,11 @@
 
 class RiscOSPluginProvider : public ELFPluginProvider {
 public:
+	RiscOSPluginProvider();
 	Plugin *createPlugin(const Common::FSNode &node) const;
+
+private:
+	bool _is32bit;
 };
 
 #endif // BACKENDS_PLUGINS_RISCOS_PROVIDER_H

--- a/configure
+++ b/configure
@@ -3198,11 +3198,9 @@ EOF
 		# RiscOS has no OpenGL support at all even though it's SDL based
 		_opengl_mode=none
 		if test "$_dynamic_modules" = yes ; then
-			_detection_features_static=no
 			_plugins_default=dynamic
-		else
-			_detection_features_full=no
 		fi
+		_detection_features_full=no
 		;;
 	solaris*)
 		append_var DEFINES "-DSOLARIS"


### PR DESCRIPTION
This picks up from where https://github.com/lephilousophe/scummvm/tree/riscos37 left off, and allows builds with dynamic plugins enabled to run on 26-bit versions of RISC OS. Compared to that branch, the RMA fallback has been dropped for simplicity, and dynamic detection has been disabled since it's currently not possible to unload it while engines are running.

Thanks to @lephilousophe for doing the initial work on this.