### PR TITLE
GUI: In grid view show invalid entries in grey text and darken the thumbnail

### DIFF
--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -1520,11 +1520,14 @@ void LauncherGrid::updateListing() {
 		Common::String language = "XX";
 		Common::String platform;
 		Common::String extra;
+		Common::String path;
+		bool valid_path = false;
 		iter->domain->tryGetVal("engineid", engineid);
 		iter->domain->tryGetVal("language", language);
 		iter->domain->tryGetVal("platform", platform);
 		iter->domain->tryGetVal("extra", extra);
-		gridList.push_back(GridItemInfo(k++, engineid, gameid, iter->title, iter->description, extra, Common::parseLanguage(language), Common::parsePlatform(platform)));
+		valid_path = (!iter->domain->tryGetVal("path", path) || !Common::FSNode(path).isDirectory()) ? false : true;
+		gridList.push_back(GridItemInfo(k++, engineid, gameid, iter->title, iter->description, extra, Common::parseLanguage(language), Common::parsePlatform(platform), valid_path));
 		_domains.push_back(iter->key);
 	}
 

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -154,9 +154,13 @@ void GridItemWidget::drawWidget() {
 				titleLines[1].deleteLastChar();
 			titleLines[1] += Common::U32String("...");
 		}
+		// Display text in alternate color if the path is unreachable
+		// Should be ok using kStateDisabled, but the list widget uses FontColorAlternate so let's stick to that
+		GUI::ThemeEngine::FontColor color = _activeEntry->validEntry ? GUI::ThemeEngine::kFontColorNormal : GUI::ThemeEngine::kFontColorAlternate;
 		Common::Rect r(_x, _y + thumbHeight, _x + thumbWidth, _y + thumbHeight + kLineHeight);
 		for (uint k = 0; k < MIN(2U, titleLines.size()); ++k) {
-			g_gui.theme()->drawText(r, titleLines[k], GUI::ThemeEngine::kStateEnabled, Graphics::kTextAlignCenter);
+			g_gui.theme()->drawText(r, titleLines[k], GUI::ThemeEngine::kStateEnabled, Graphics::kTextAlignCenter, GUI::ThemeEngine::kTextInversionNone,
+									0, true, ThemeEngine::kFontStyleBold, color);
 			r.translate(0, kLineHeight);
 		}
 	}

--- a/gui/widgets/grid.h
+++ b/gui/widgets/grid.h
@@ -101,7 +101,7 @@ protected:
 	Common::HashMap<int, const Graphics::ManagedSurface *> _platformIcons;
 	Common::HashMap<int, const Graphics::ManagedSurface *> _languageIcons;
 	Common::HashMap<int, const Graphics::ManagedSurface *> _extraIcons;
-
+	Graphics::ManagedSurface *_disabledIconOverlay;
 	// Images are mapped by filename -> surface.
 	Common::HashMap<Common::String, const Graphics::ManagedSurface *> _loadedSurfaces;
 
@@ -174,6 +174,7 @@ public:
 	const Graphics::ManagedSurface *languageToSurface(Common::Language languageCode);
 	const Graphics::ManagedSurface *platformToSurface(Common::Platform platformCode);
 	const Graphics::ManagedSurface *demoToSurface(const Common::String extraString);
+	const Graphics::ManagedSurface *disabledThumbnail();
 
 	/// Update _visibleEntries from _allEntries and returns true if reload is required.
 	bool calcVisibleEntries();

--- a/gui/widgets/grid.h
+++ b/gui/widgets/grid.h
@@ -48,7 +48,7 @@ enum {
 
 /* GridItemInfo */
 struct GridItemInfo {
-	bool		isHeader;
+	bool		isHeader, validEntry;
 	int 		entryID;
 	Common::String 		engineid;
 	Common::String 		gameid;
@@ -64,13 +64,13 @@ struct GridItemInfo {
 	int32				x, y, w, h;
 
 	GridItemInfo(int id, const Common::String &eid, const Common::String &gid, const Common::String &t,
-		const Common::String &d, const Common::String &e, Common::Language l, Common::Platform p)
-		: entryID(id), gameid(gid), engineid(eid), title(t), description(d), extra(e), language(l), platform(p), isHeader(false) {
+		const Common::String &d, const Common::String &e, Common::Language l, Common::Platform p, bool v)
+		: entryID(id), gameid(gid), engineid(eid), title(t), description(d), extra(e), language(l), platform(p), validEntry(v), isHeader(false) {
 		thumbPath = Common::String::format("icons/%s-%s.png", engineid.c_str(), gameid.c_str());
 	}
 
 	GridItemInfo(const Common::String &groupHeader, int groupID) : title(groupHeader), description(groupHeader),
-		isHeader(true), entryID(groupID), language(Common::UNK_LANG), platform(Common::kPlatformUnknown) {
+		isHeader(true), validEntry(true), entryID(groupID), language(Common::UNK_LANG), platform(Common::kPlatformUnknown) {
 		thumbPath = Common::String("");
 	}
 };


### PR DESCRIPTION
Unlike the list view, currently the invalid entries are not indicated in any way.
This PR:
* Changes the color of the invalid entries to KFontColorAlternate (like the listview)
* Adds a simple svg overlay (which is just a 60% dark square) to darken the icon so that it looks "inactive"

The .svg is placed in /icons/extra/ but maybe another location would be better suited (suggestions welcome)

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
