### PR TITLE
DIRECTOR: fix sound loop in The Seven Colours

### DIFF
--- a/engines/director/sound.cpp
+++ b/engines/director/sound.cpp
@@ -790,7 +790,7 @@ Audio::AudioStream *SNDDecoder::getAudioStream(bool looping, bool forPuppet, Dis
 }
 
 bool SNDDecoder::hasLoopBounds() {
-	return _loopStart != 0 && _loopEnd != 0;
+	return _loopStart != 0 || _loopEnd != 0;
 }
 
 AudioFileDecoder::AudioFileDecoder(Common::String &path)

--- a/engines/director/sound.cpp
+++ b/engines/director/sound.cpp
@@ -135,7 +135,9 @@ void DirectorSound::playCastMember(CastMemberID memberID, uint8 soundChannel, bo
 		//   4. maybe more?
 		if (shouldStopOnZero(soundChannel)) {
 			stopSound(soundChannel);
-		} else {
+		// Director 4 will stop after the current loop iteration, but
+		// Director 3 will continue looping until the sound is replaced.
+		} else if (g_director->getVersion() >= 400) {
 			// If there is a loopable stream specified, set the loop to expire by itself
 			if (_channels[soundChannel - 1].loopPtr) {
 				debugC(5, kDebugSound, "DirectorSound::playCastMember(): telling loop in channel %d to stop", soundChannel);


### PR DESCRIPTION
This fixes two separate issues that kept the looping sound in the bedroom from working in The Seven Colours:

* The heuristic to determine if a sound could loop in D3 didn't consider that the start sample could be `0`.
* D3 and D4 seem to have different behaviour for looping sounds, and the conditional that stops loop from the next iteration was stopping sounds that should keep going under D3.

I need to double-check the behaviour for that second one in the editor, but it definitely fixes The Seven Colours.