### PR TITLE
SDL: Clip DPI scaling factor to ensure we get a reasonable value

### DIFF
--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -24,6 +24,7 @@
 #include "backends/platform/sdl/sdl-window.h"
 
 #include "common/textconsole.h"
+#include "common/util.h"
 
 #include "icons/scummvm.xpm"
 
@@ -292,7 +293,9 @@ float SdlWindow::getDpiScalingFactor() const {
 	getDisplayDpi(&dpi, &defaultDpi);
 	debug(4, "dpi: %g default: %g", dpi, defaultDpi);
 	float ratio = dpi / defaultDpi;
-	return ratio;
+	// Getting the DPI can be unreliable, so clamp the scaling factor to make sure
+	// we do not return unreasonable values.
+	return CLIP(ratio, 1.0f, 4.0f);
 }
 
 float SdlWindow::getSdlDpiScalingFactor() const {


### PR DESCRIPTION
As shown by bug https://bugs.scummvm.org/ticket/14132, getting the DPI can be unreliable on some system, causing abnormal DPI scaling factor to be used. So I am proposing to clip the DPI scaling factor to a reasonable range. This should fix that bug since it will now return a factor of 1 instead of 0.289459 (I don't see any case where returning a value below 1 would make sense).

The change is simple, but I am creating a pull request in case I overlooked a possible issue with it.