### PR TITLE
AGS: Fix FileStream::EOS when used on a file opened for writing

### DIFF
--- a/engines/ags/shared/util/data_stream.cpp
+++ b/engines/ags/shared/util/data_stream.cpp
@@ -93,7 +93,7 @@ size_t DataStream::ReadAndConvertArrayOfInt64(int64_t *buffer, size_t count) {
 
 size_t DataStream::WriteAndConvertArrayOfInt16(const int16_t *buffer, size_t count) {
 	size_t elem;
-	for (elem = 0; elem < count && !EOS(); ++elem, ++buffer) {
+	for (elem = 0; elem < count; ++elem, ++buffer) {
 		int16_t val = *buffer;
 		ConvertInt16(val);
 		if (Write(&val, sizeof(int16_t)) < sizeof(int16_t)) {
@@ -105,7 +105,7 @@ size_t DataStream::WriteAndConvertArrayOfInt16(const int16_t *buffer, size_t cou
 
 size_t DataStream::WriteAndConvertArrayOfInt32(const int32_t *buffer, size_t count) {
 	size_t elem;
-	for (elem = 0; elem < count && !EOS(); ++elem, ++buffer) {
+	for (elem = 0; elem < count; ++elem, ++buffer) {
 		int32_t val = *buffer;
 		ConvertInt32(val);
 		if (Write(&val, sizeof(int32_t)) < sizeof(int32_t)) {
@@ -117,7 +117,7 @@ size_t DataStream::WriteAndConvertArrayOfInt32(const int32_t *buffer, size_t cou
 
 size_t DataStream::WriteAndConvertArrayOfInt64(const int64_t *buffer, size_t count) {
 	size_t elem;
-	for (elem = 0; elem < count && !EOS(); ++elem, ++buffer) {
+	for (elem = 0; elem < count; ++elem, ++buffer) {
 		int64_t val = *buffer;
 		ConvertInt64(val);
 		if (Write(&val, sizeof(int64_t)) < sizeof(int64_t)) {

--- a/engines/ags/shared/util/file_stream.cpp
+++ b/engines/ags/shared/util/file_stream.cpp
@@ -64,7 +64,7 @@ bool FileStream::IsValid() const {
 
 bool FileStream::EOS() const {
 	Common::ReadStream *rs = dynamic_cast<Common::ReadStream *>(_file);
-	return !rs || rs->eos();
+	return rs && rs->eos();
 }
 
 soff_t FileStream::GetLength() const {


### PR DESCRIPTION
EOS should always return false in this case.

This should fix [#13417](https://bugs.scummvm.org/ticket/13417).
If this works, this needs to be backported to 2.7