### PR TITLE
OPENGL: Allow shaders to be used with OpenGL 1.5

### DIFF
--- a/graphics/opengl/context.cpp
+++ b/graphics/opengl/context.cpp
@@ -321,11 +321,6 @@ int Context::getGLSLVersion() const {
 		return 0;
 	}
 
-	// No shader support in OpenGL 1.x
-	if (type == kContextGL && !isGLVersionOrHigher(2, 0)) {
-		return 0;
-	}
-
 	const char *glslVersionString = (const char *)glGetString(GL_SHADING_LANGUAGE_VERSION);
 	if (!glslVersionString) {
 		warning("Could not get GLSL version");


### PR DESCRIPTION
This was tested on Windows 98 SE with the official Nvidia GeForce 2 drivers (which provides OpenGL 1.5 and GLSL 1.10).