### PR TITLE
ANDROID: Show SAF info popup after launcher constructor

### DIFF
--- a/base/main.cpp
+++ b/base/main.cpp
@@ -110,6 +110,71 @@ static bool launcherDialog() {
 	GUI::LauncherChooser dlg;
 	dlg.selectLauncher();
 #endif
+
+#ifdef __ANDROID__
+	// This early popup message for Android, informing the users about important
+	// changes to file access, needs to be after language for the GUI has been selected
+	if (AndroidFilesystemFactory::instance().hasSAF()
+		&& !ConfMan.hasKey("android_saf_dialog_shown")) {
+
+		bool cancelled = false;
+
+		if (!ConfMan.getGameDomains().empty()) {
+			GUI::MessageDialog alert(_(
+				// I18N: <Add a new folder> must match the translation done in backends/fs/android/android-saf-fs.h
+				"In this new version of ScummVM Android, significant changes were made to "
+				"the file access system to allow support for modern versions of the Android "
+				"Operating System.\n"
+				"If you find that your existing added games or custom paths no longer work, "
+				"please edit those paths and this time use the SAF system to browse to the "
+				"desired locations.\n"
+				"To do that:\n"
+				"\n"
+				"  1. For each game whose data is not found, go to the \"Paths\" tab in "
+				"the \"Game Options\" and change the \"Game path\"\n"
+				"  2. Inside the ScummVM file browser, use \"Go Up\" until you reach "
+				"the \"root\" folder where you will see the \"<Add a new folder>\" option.\n"
+				"  3. Choose that, then browse and select the \"parent\" folder for your "
+				"games subfolders, e.g. \"SD Card > myGames\". Click on \"Use this folder\".\n"
+				"  4. Then, a new folder \"myGames\" will appear on the \"root\" folder "
+				"of the ScummVM browser.\n"
+				"  5. Browse through this folder to your game data.\n"
+				"\n"
+				"Steps 2 and 3 need to be done only once for all of your games."
+				), _("Ok"),
+				// I18N: A button caption to dismiss amessage and read it later
+				_("Read Later"), Graphics::kTextAlignLeft);
+
+			if (alert.runModal() != GUI::kMessageOK)
+				cancelled = true;
+		} else {
+			GUI::MessageDialog alert(_(
+				// I18N: <Add a new folder> must match the translation done in backends/fs/android/android-saf-fs.h
+				"In this new version of ScummVM Android, significant changes were made to "
+				"the file access system to allow support for modern versions of the Android "
+				"Operating System.\n"
+				"Thus, you need to set up SAF in order to be able to add the games.\n"
+				"\n"
+				"  1. Inside the ScummVM file browser, use \"Go Up\" until you reach "
+				"the \"root\" folder where you will see the \"<Add a new folder>\" option.\n"
+				"  2. Choose that, then browse and select the \"parent\" folder for your "
+				"games subfolders, e.g. \"SD Card > myGames\". Click on \"Use this folder\".\n"
+				"  3. Then, a new folder \"myGames\" will appear on the \"root\" folder "
+				"of the ScummVM browser.\n"
+				"  4. Browse through this folder to your game data."
+				), _("Ok"),
+				// I18N: A button caption to dismiss a message and read it later
+				_("Read Later"), Graphics::kTextAlignLeft);
+
+			if (alert.runModal() != GUI::kMessageOK)
+				cancelled = true;
+		}
+
+		if (!cancelled)
+			ConfMan.setBool("android_saf_dialog_shown", true);
+	}
+#endif
+
 	return (dlg.runModal() != -1);
 }
 

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -735,68 +735,6 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 	}
 #endif
 
-#ifdef __ANDROID__
-	if (AndroidFilesystemFactory::instance().hasSAF()
-		&& !ConfMan.hasKey("android_saf_dialog_shown")) {
-
-		bool cancelled = false;
-
-		if (!ConfMan.getGameDomains().empty()) {
-			GUI::MessageDialog alert(_(
-				// I18N: <Add a new folder> must match the translation done in backends/fs/android/android-saf-fs.h
-				"In this new version of ScummVM Android, significant changes were made to "
-				"the file access system to allow support for modern versions of the Android "
-				"Operating System.\n"
-				"If you find that your existing added games or custom paths no longer work, "
-				"please edit those paths and this time use the SAF system to browse to the "
-				"desired locations.\n"
-				"To do that:\n"
-				"\n"
-				"  1. For each game whose data is not found, go to the \"Paths\" tab in "
-				"the \"Game Options\" and change the \"Game path\"\n"
-				"  2. Inside the ScummVM file browser, use \"Go Up\" until you reach "
-				"the \"root\" folder where you will see the \"<Add a new folder>\" option.\n"
-				"  3. Choose that, then browse and select the \"parent\" folder for your "
-				"games subfolders, e.g. \"SD Card > myGames\". Click on \"Use this folder\".\n"
-				"  4. Then, a new folder \"myGames\" will appear on the \"root\" folder "
-				"of the ScummVM browser.\n"
-				"  5. Browse through this folder to your game data.\n"
-				"\n"
-				"Steps 2 and 3 need to be done only once for all of your games."
-				), _("Ok"),
-				// I18N: A button caption to dismiss amessage and read it later
-				_("Read Later"), Graphics::kTextAlignLeft);
-
-			if (alert.runModal() != GUI::kMessageOK)
-				cancelled = true;
-		} else {
-			GUI::MessageDialog alert(_(
-				// I18N: <Add a new folder> must match the translation done in backends/fs/android/android-saf-fs.h
-				"In this new version of ScummVM Android, significant changes were made to "
-				"the file access system to allow support for modern versions of the Android "
-				"Operating System.\n"
-				"Thus, you need to set up SAF in order to be able to add the games.\n"
-				"\n"
-				"  1. Inside the ScummVM file browser, use \"Go Up\" until you reach "
-				"the \"root\" folder where you will see the \"<Add a new folder>\" option.\n"
-				"  2. Choose that, then browse and select the \"parent\" folder for your "
-				"games subfolders, e.g. \"SD Card > myGames\". Click on \"Use this folder\".\n"
-				"  3. Then, a new folder \"myGames\" will appear on the \"root\" folder "
-				"of the ScummVM browser.\n"
-				"  4. Browse through this folder to your game data."
-				), _("Ok"),
-				// I18N: A button caption to dismiss a message and read it later
-				_("Read Later"), Graphics::kTextAlignLeft);
-
-			if (alert.runModal() != GUI::kMessageOK)
-				cancelled = true;
-		}
-
-		if (!cancelled)
-			ConfMan.setBool("android_saf_dialog_shown", true);
-	}
-#endif
-
 #if defined(USE_CLOUD) && defined(USE_LIBCURL)
 	CloudMan.init();
 	CloudMan.syncSaves();


### PR DESCRIPTION
Fixes the issue of not using the GUI language to display this warning dialogue.

However, it has the disadvantage that if the user selects to read the message later, the message will show up when reloading the launcher, even if it was after playing the game and returning back to the launcher (so not only when launching ScummVM).

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
