### PR TITLE
VCRUISE: Add V-Cruise engine

### DIFF
--- a/engines/vcruise/POTFILES
+++ b/engines/vcruise/POTFILES
@@ -1,0 +1,1 @@
+engines/vcruise/metaengine.cpp

--- a/engines/vcruise/audio_player.cpp
+++ b/engines/vcruise/audio_player.cpp
@@ -1,0 +1,75 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "vcruise/audio_player.h"
+
+namespace VCruise {
+
+AudioPlayer::AudioPlayer(Audio::Mixer *mixer, const Common::SharedPtr<Audio::AudioStream> &baseStream, byte volume, int8 balance)
+	: _exhausted(false), _mixer(nullptr), _baseStream(baseStream) {
+	_mixer = mixer;
+	mixer->playStream(Audio::Mixer::kPlainSoundType, &_handle, this, -1, volume, balance, DisposeAfterUse::NO);
+}
+
+AudioPlayer::~AudioPlayer() {
+	stop();
+}
+
+int AudioPlayer::readBuffer(int16 *buffer, const int numSamplesTimesChannelCount) {
+	Common::StackLock lock(_mutex);
+
+	int samplesRead = 0;
+	if (_exhausted)
+		return 0;
+
+	samplesRead = _baseStream->readBuffer(buffer, numSamplesTimesChannelCount);
+
+	if (samplesRead != numSamplesTimesChannelCount)
+		_exhausted = true;
+
+	return samplesRead;
+}
+
+bool AudioPlayer::isStereo() const {
+	return _baseStream->isStereo();
+}
+
+int AudioPlayer::getRate() const {
+	return _baseStream->getRate();
+}
+
+bool AudioPlayer::endOfData() const {
+	return _exhausted;
+}
+
+void AudioPlayer::sendToMixer(Audio::Mixer *mixer, byte volume, int8 balance) {
+	mixer->playStream(Audio::Mixer::kPlainSoundType, &_handle, this, -1, volume, balance, DisposeAfterUse::NO);
+}
+
+void AudioPlayer::stop() {
+	if (_mixer)
+		_mixer->stopHandle(_handle);
+
+	_exhausted = true;
+	_mixer = nullptr;
+}
+
+} // End of namespace VCruise

--- a/engines/vcruise/audio_player.h
+++ b/engines/vcruise/audio_player.h
@@ -1,0 +1,60 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef VCRUISE_AUDIO_PLAYER_H
+#define VCRUISE_AUDIO_PLAYER_H
+
+#include "common/mutex.h"
+
+#include "audio/audiostream.h"
+#include "audio/mixer.h"
+
+namespace VCruise {
+
+struct AudioMetadata;
+class CachedAudio;
+
+class AudioPlayer : public Audio::AudioStream {
+public:
+	AudioPlayer(Audio::Mixer *mixer, const Common::SharedPtr<Audio::AudioStream> &baseStream, byte volume, int8 balance);
+	~AudioPlayer();
+
+	int readBuffer(int16 *buffer, const int numSamples) override;
+	bool isStereo() const override;
+	int getRate() const override;
+	bool endOfData() const override;
+
+	void sendToMixer(Audio::Mixer *mixer, byte volume, int8 balance);
+	void stop();
+
+private:
+	Common::Mutex _mutex;
+
+	Audio::SoundHandle _handle;
+	bool _isLooping;
+	bool _exhausted;
+	Audio::Mixer *_mixer;
+	Common::SharedPtr<Audio::AudioStream> _baseStream;
+};
+
+} // End of namespace VCruise
+
+#endif

--- a/engines/vcruise/configure.engine
+++ b/engines/vcruise/configure.engine
@@ -1,0 +1,4 @@
+# This file is included from the main "configure" script
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+add_engine vcruise "V-Cruise" no "schizm" "" "16bit highres"
+add_engine schizm "Schizm" no "" "" "16bit highres jpeg"

--- a/engines/vcruise/configure.engine
+++ b/engines/vcruise/configure.engine
@@ -1,4 +1,4 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine vcruise "V-Cruise" no "schizm" "" "16bit highres"
-add_engine schizm "Schizm" no "" "" "16bit highres jpeg"
+add_engine vcruise "V-Cruise" no "schizm" "" "16bit highres mad"
+add_engine schizm "Schizm" no "" "" "16bit highres mad jpeg"

--- a/engines/vcruise/credits.pl
+++ b/engines/vcruise/credits.pl
@@ -1,0 +1,3 @@
+begin_section("V-Cruise");
+	add_person("Eric Lasota", "OneEightHundred", "");
+end_section();

--- a/engines/vcruise/detection.cpp
+++ b/engines/vcruise/detection.cpp
@@ -36,16 +36,12 @@ static const PlainGameDescriptor vCruiseGames[] = {
 
 #include "vcruise/detection_tables.h"
 
-static const char *directoryGlobs[] = {
-	nullptr
-};
-
 class VCruiseMetaEngineDetection : public AdvancedMetaEngineDetection {
 public:
 	VCruiseMetaEngineDetection() : AdvancedMetaEngineDetection(VCruise::gameDescriptions, sizeof(VCruise::VCruiseGameDescription), vCruiseGames) {
 		_guiOptions = GUIO1(GAMEOPTION_LAUNCH_DEBUG);
 		_maxScanDepth = 1;
-		_directoryGlobs = directoryGlobs;
+		_directoryGlobs = nullptr;
 		_flags = kADFlagCanPlayUnknownVariants;
 	}
 

--- a/engines/vcruise/detection.cpp
+++ b/engines/vcruise/detection.cpp
@@ -1,0 +1,105 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "base/plugins.h"
+
+#include "common/config-manager.h"
+#include "common/language.h"
+
+#include "engines/advancedDetector.h"
+
+#include "vcruise/detection.h"
+
+static const PlainGameDescriptor vCruiseGames[] = {
+	{"reah", "Reah: Face the Unknown"},
+	{"schizm", "Schizm: Mysterious Journey"},
+	{nullptr, nullptr}
+};
+
+#include "vcruise/detection_tables.h"
+
+static const char *directoryGlobs[] = {
+	nullptr
+};
+
+class VCruiseMetaEngineDetection : public AdvancedMetaEngineDetection {
+public:
+	VCruiseMetaEngineDetection() : AdvancedMetaEngineDetection(VCruise::gameDescriptions, sizeof(VCruise::VCruiseGameDescription), vCruiseGames) {
+		_guiOptions = GUIO1(GAMEOPTION_LAUNCH_DEBUG);
+		_maxScanDepth = 1;
+		_directoryGlobs = directoryGlobs;
+		_flags = kADFlagCanPlayUnknownVariants;
+	}
+
+	const char *getName() const override {
+		return "vcruise";
+	}
+
+	const char *getEngineName() const override {
+		return "V-Cruise";
+	}
+
+	const char *getOriginalCopyright() const override {
+		return "V-Cruise (C) LK Avalon";
+	}
+
+	DetectedGame toDetectedGame(const ADDetectedGame &adGame, ADDetectedGameExtraInfo *extraInfo) const override {
+		DetectedGame game = AdvancedMetaEngineDetection::toDetectedGame(adGame, extraInfo);
+
+		VCruise::VCruiseGameID gameID = reinterpret_cast<const VCruise::VCruiseGameDescription *>(adGame.desc)->gameID;
+
+		if (gameID == VCruise::GID_REAH) {
+			game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(Common::NL_NLD));
+			game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(Common::FR_FRA));
+			game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(Common::IT_ITA));
+			game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(Common::DE_DEU));
+			game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(Common::PL_POL));
+			game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(Common::ES_ESP));
+		} else if (gameID == VCruise::GID_SCHIZM) {
+			game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(Common::NL_NLD));
+			game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(Common::FR_FRA));
+			game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(Common::IT_ITA));
+			game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(Common::DE_DEU));
+			game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(Common::PL_POL));
+			game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(Common::ES_ESP));
+			game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(Common::EL_GRC));
+			game.appendGUIOptions(Common::getGameGUIOptionsDescriptionLanguage(Common::RU_RUS));
+		}
+
+		return game;
+	}
+
+	/*
+	Common::String parseAndCustomizeGuiOptions(const Common::String &optionsString, const Common::String &domain) const {
+		Common::String guiOptions = AdvancedMetaEngineDetection::parseAndCustomizeGuiOptions(optionsString, domain);
+
+		if (domain.hasPrefix("reah")) {
+			guiOptions += " lang_Dutch lang_French lang_Italian lang_German lang_Polish lang_Spanish";
+		} else if (domain.hasPrefix("schizm")) {
+			guiOptions += " lang_Dutch lang_French lang_Italian lang_German lang_Greek lang_Polish lang_Russian lang_Spanish";
+		}
+
+		return guiOptions;
+	}
+	*/
+};
+
+REGISTER_PLUGIN_STATIC(VCRUISE_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, VCruiseMetaEngineDetection);

--- a/engines/vcruise/detection.h
+++ b/engines/vcruise/detection.h
@@ -27,8 +27,10 @@
 namespace VCruise {
 
 enum VCruiseGameID {
-	GID_REAH	= 0,
-	GID_SCHIZM	= 1,
+	GID_UNKNOWN	= 0,
+
+	GID_REAH	= 1,
+	GID_SCHIZM	= 2,
 };
 
 struct VCruiseGameDescription {

--- a/engines/vcruise/detection.h
+++ b/engines/vcruise/detection.h
@@ -1,0 +1,46 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef VCRUISE_DETECTION_H
+#define VCRUISE_DETECTION_H
+
+#include "engines/advancedDetector.h"
+
+namespace VCruise {
+
+enum VCruiseGameID {
+	GID_REAH	= 0,
+	GID_SCHIZM	= 1,
+};
+
+struct VCruiseGameDescription {
+	ADGameDescription desc;
+
+	VCruiseGameID gameID;
+};
+
+
+#define GAMEOPTION_LAUNCH_DEBUG					GUIO_GAMEOPTIONS1
+
+
+} // End of namespace VCruise
+
+#endif // VCRUISE_DETECTION_H

--- a/engines/vcruise/detection_tables.h
+++ b/engines/vcruise/detection_tables.h
@@ -1,0 +1,53 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef VCRUISE_DETECTION_TABLES_H
+#define VCRUISE_DETECTION_TABLES_H
+
+#include "engines/advancedDetector.h"
+
+#include "vcruise/detection.h"
+
+namespace VCruise {
+
+static const VCruiseGameDescription gameDescriptions[] = {
+
+	{ // Reah: Face the Unknown, GOG downloadable version
+		{
+			"reah",
+			"GOG",
+			{
+				{"Reah.exe", 0, "60ec19c53f1323cc7f0314f98d396283", 304128},
+				AD_LISTEND
+			},
+			Common::EN_ANY,
+			Common::kPlatformWindows,
+			ADGF_UNSTABLE,
+			GUIO0()
+		},
+		GID_REAH,
+	},
+	{ AD_TABLE_END_MARKER }
+};
+
+} // End of namespace MTropolis
+
+#endif

--- a/engines/vcruise/detection_tables.h
+++ b/engines/vcruise/detection_tables.h
@@ -30,10 +30,10 @@ namespace VCruise {
 
 static const VCruiseGameDescription gameDescriptions[] = {
 
-	{ // Reah: Face the Unknown, GOG downloadable version
+	{ // Reah: Face the Unknown, DVD/digital version
 		{
 			"reah",
-			"GOG",
+			"DVD",
 			{
 				{"Reah.exe", 0, "60ec19c53f1323cc7f0314f98d396283", 304128},
 				AD_LISTEND

--- a/engines/vcruise/detection_tables.h
+++ b/engines/vcruise/detection_tables.h
@@ -45,6 +45,36 @@ static const VCruiseGameDescription gameDescriptions[] = {
 		},
 		GID_REAH,
 	},
+	{ // Reah: Face the Unknown, 6 CD Version
+		{
+			"reah",
+			"CD",
+			{
+				{"Reah.exe", 0, "77bc7f7819cdd443f52b193529138c87", 305664},
+				AD_LISTEND
+			},
+			Common::EN_ANY,
+			Common::kPlatformWindows,
+			ADGF_UNSTABLE,
+			GUIO0()
+		},
+		GID_REAH,
+	},
+	{ // Schizm, 5 CD Version
+		{
+			"schizm",
+			"CD",
+			{
+				{"Schizm.exe", 0, "296edd26d951c3bdc4d303c4c88b27cd", 364544},
+				AD_LISTEND
+			},
+			Common::EN_ANY,
+			Common::kPlatformWindows,
+			ADGF_UNSTABLE,
+			GUIO0()
+		},
+		GID_SCHIZM,
+	},
 	{ AD_TABLE_END_MARKER, GID_UNKNOWN }
 };
 

--- a/engines/vcruise/detection_tables.h
+++ b/engines/vcruise/detection_tables.h
@@ -34,10 +34,7 @@ static const VCruiseGameDescription gameDescriptions[] = {
 		{
 			"reah",
 			"DVD",
-			{
-				{"Reah.exe", 0, "60ec19c53f1323cc7f0314f98d396283", 304128},
-				AD_LISTEND
-			},
+			AD_ENTRY1s("Reah.exe", "60ec19c53f1323cc7f0314f98d396283", 304128),
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_UNSTABLE,
@@ -49,10 +46,7 @@ static const VCruiseGameDescription gameDescriptions[] = {
 		{
 			"reah",
 			"CD",
-			{
-				{"Reah.exe", 0, "77bc7f7819cdd443f52b193529138c87", 305664},
-				AD_LISTEND
-			},
+			AD_ENTRY1s("Reah.exe", "77bc7f7819cdd443f52b193529138c87", 305664),
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_UNSTABLE,
@@ -64,10 +58,7 @@ static const VCruiseGameDescription gameDescriptions[] = {
 		{
 			"schizm",
 			"CD",
-			{
-				{"Schizm.exe", 0, "296edd26d951c3bdc4d303c4c88b27cd", 364544},
-				AD_LISTEND
-			},
+			AD_ENTRY1s("Schizm.exe", "296edd26d951c3bdc4d303c4c88b27cd", 364544),
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_UNSTABLE,
@@ -78,6 +69,6 @@ static const VCruiseGameDescription gameDescriptions[] = {
 	{ AD_TABLE_END_MARKER, GID_UNKNOWN }
 };
 
-} // End of namespace MTropolis
+} // End of namespace VCruise
 
 #endif

--- a/engines/vcruise/detection_tables.h
+++ b/engines/vcruise/detection_tables.h
@@ -45,7 +45,7 @@ static const VCruiseGameDescription gameDescriptions[] = {
 		},
 		GID_REAH,
 	},
-	{ AD_TABLE_END_MARKER }
+	{ AD_TABLE_END_MARKER, GID_UNKNOWN }
 };
 
 } // End of namespace MTropolis

--- a/engines/vcruise/metaengine.cpp
+++ b/engines/vcruise/metaengine.cpp
@@ -33,14 +33,19 @@ struct Surface;
 namespace VCruise {
 
 static const ADExtraGuiOptionsMap optionsList[] = {
-	{GAMEOPTION_LAUNCH_DEBUG,
-	 {_s("Start with debugger"),
-	  _s("Starts with the debugger dashboard active."),
-	  "vcruise_debug",
-	  false,
-	  0,
-	  0}},
-	AD_EXTRA_GUI_OPTIONS_TERMINATOR};
+	{
+		GAMEOPTION_LAUNCH_DEBUG,
+		{
+			_s("Start with debugger"),
+			_s("Starts with the debugger dashboard active."),
+			"vcruise_debug",
+			false,
+			0,
+			0
+		}
+	},
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR
+};
 
 } // End of namespace VCruise
 

--- a/engines/vcruise/metaengine.cpp
+++ b/engines/vcruise/metaengine.cpp
@@ -1,0 +1,74 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/translation.h"
+
+#include "engines/advancedDetector.h"
+#include "vcruise/vcruise.h"
+
+namespace Graphics {
+
+struct Surface;
+
+} // End of namespace Graphics
+
+namespace VCruise {
+
+static const ADExtraGuiOptionsMap optionsList[] = {
+	{GAMEOPTION_LAUNCH_DEBUG,
+	 {_s("Start with debugger"),
+	  _s("Starts with the debugger dashboard active."),
+	  "vcruise_debug",
+	  false,
+	  0,
+	  0}},
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR};
+
+} // End of namespace VCruise
+
+class VCruiseMetaEngine : public AdvancedMetaEngine {
+public:
+	const char *getName() const override {
+		return "vcruise";
+	}
+
+	const ADExtraGuiOptionsMap *getAdvancedExtraGuiOptions() const override {
+		return VCruise::optionsList;
+	}
+
+	bool hasFeature(MetaEngineFeature f) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+};
+
+bool VCruiseMetaEngine::hasFeature(MetaEngineFeature f) const {
+	return checkExtendedSaves(f);
+}
+
+Common::Error VCruiseMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+	*engine = new VCruise::VCruiseEngine(syst, reinterpret_cast<const VCruise::VCruiseGameDescription *>(desc));
+	return Common::kNoError;
+}
+
+#if PLUGIN_ENABLED_DYNAMIC(VCRUISE)
+REGISTER_PLUGIN_DYNAMIC(VCRUISE, PLUGIN_TYPE_ENGINE, VCruiseMetaEngine);
+#else
+REGISTER_PLUGIN_STATIC(VCRUISE, PLUGIN_TYPE_ENGINE, VCruiseMetaEngine);
+#endif

--- a/engines/vcruise/module.mk
+++ b/engines/vcruise/module.mk
@@ -1,6 +1,7 @@
 MODULE := engines/vcruise
 
 MODULE_OBJS = \
+	audio_player.o \
 	metaengine.o \
 	runtime.o \
 	script.o \

--- a/engines/vcruise/module.mk
+++ b/engines/vcruise/module.mk
@@ -3,6 +3,8 @@ MODULE := engines/vcruise
 MODULE_OBJS = \
 	metaengine.o \
 	runtime.o \
+	script.o \
+	textparser.o \
 	vcruise.o
 
 

--- a/engines/vcruise/module.mk
+++ b/engines/vcruise/module.mk
@@ -1,0 +1,18 @@
+MODULE := engines/vcruise
+
+MODULE_OBJS = \
+	metaengine.o \
+	runtime.o \
+	vcruise.o
+
+
+# This module can be built as a plugin
+ifeq ($(ENABLE_VCRUISE), DYNAMIC_PLUGIN)
+PLUGIN := 1
+endif
+
+# Include common rules
+include $(srcdir)/rules.mk
+
+# Detection objects
+DETECT_OBJS += $(MODULE)/detection.o

--- a/engines/vcruise/runtime.cpp
+++ b/engines/vcruise/runtime.cpp
@@ -1,0 +1,106 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/formats/winexe.h"
+#include "common/ptr.h"
+#include "common/system.h"
+
+#include "graphics/cursorman.h"
+#include "graphics/wincursor.h"
+#include "graphics/managed_surface.h"
+
+#include "vcruise/runtime.h"
+
+
+
+namespace VCruise {
+
+Runtime::Runtime(OSystem *system) : _system(system), _roomNumber(1), _gameState(kGameStateBoot) {
+}
+
+Runtime::~Runtime() {
+}
+
+void Runtime::loadCursors(const char *exeName) {
+	Common::SharedPtr<Common::WinResources> winRes(Common::WinResources::createFromEXE(exeName));
+	if (!winRes)
+		error("Couldn't open executable file %s", exeName);
+
+	Common::Array<Common::WinResourceID> cursorGroupIDs = winRes->getIDList(Common::kWinGroupCursor);
+	for (Common::Array<Common::WinResourceID>::const_iterator it = cursorGroupIDs.begin(), itEnd = cursorGroupIDs.end(); it != itEnd; ++it) {
+		const Common::WinResourceID &id = *it;
+
+		Common::SharedPtr<Graphics::WinCursorGroup> cursorGroup(Graphics::WinCursorGroup::createCursorGroup(winRes.get(), *it));
+		if (!winRes) {
+			warning("Couldn't load cursor group");
+			continue;
+		}
+
+		Common::String nameStr = id.getString();
+		if (nameStr.size() == 8 && nameStr.substr(0, 7) == "CURSOR_") {
+			char c = nameStr[7];
+			if (c >= '0' && c <= '9') {
+				uint shortID = c - '0';
+				if (shortID >= _cursorsShort.size())
+					_cursorsShort.resize(shortID + 1);
+				_cursorsShort[shortID] = cursorGroup;
+			}
+		} else if (nameStr.size() == 13 && nameStr.substr(0, 11) == "CURSOR_CUR_") {
+			char c1 = nameStr[11];
+			char c2 = nameStr[12];
+			if (c1 >= '0' && c1 <= '9' && c2 >= '0' && c2 <= '9') {
+				uint longID = (c1 - '0') * 10 + (c2 - '0');
+				if (longID >= _cursors.size())
+					_cursors.resize(longID + 1);
+				_cursors[longID] = cursorGroup;
+			}
+		}
+	}
+}
+
+bool Runtime::runFrame() {
+	bool moreActions = true;
+	while (moreActions) {
+		moreActions = false;
+		switch (_gameState) {
+		case kGameStateBoot:
+			bootGame();
+			break;
+		case kGameStateQuit:
+			return false;
+		default:
+			error("Unknown game state");
+			return false;
+		}
+	}
+
+	return true;
+}
+
+void Runtime::bootGame() {
+}
+
+void Runtime::drawFrame() {
+
+	_system->updateScreen();
+}
+
+} // End of namespace VCruise

--- a/engines/vcruise/runtime.cpp
+++ b/engines/vcruise/runtime.cpp
@@ -28,6 +28,12 @@
 #include "graphics/wincursor.h"
 #include "graphics/managed_surface.h"
 
+#include "audio/decoders/wave.h"
+#include "audio/audiostream.h"
+
+#include "video/avi_decoder.h"
+
+#include "vcruise/audio_player.h"
 #include "vcruise/runtime.h"
 #include "vcruise/script.h"
 #include "vcruise/textparser.h"
@@ -59,8 +65,16 @@ const MapScreenDirectionDef *MapDef::getScreenDirection(uint screen, uint direct
 	return screenDirections[screen][direction].get();
 }
 
-Runtime::Runtime(OSystem *system, const Common::FSNode &rootFSNode, VCruiseGameID gameID)
-	: _system(system), _roomNumber(1), _screenNumber(0), _loadedRoomNumber(0), _activeScreenNumber(0), _gameState(kGameStateBoot), _gameID(gameID), _rootFSNode(rootFSNode), _havePendingScreenChange(false) {
+void Runtime::RenderSection::init(const Common::Rect &paramRect, const Graphics::PixelFormat &fmt) {
+	rect = paramRect;
+	surf.reset(new Graphics::ManagedSurface(paramRect.width(), paramRect.height(), fmt));
+	surf->fillRect(Common::Rect(0, 0, surf->w, surf->h), 0xffffffff);
+}
+
+Runtime::Runtime(OSystem *system, Audio::Mixer *mixer, const Common::FSNode &rootFSNode, VCruiseGameID gameID)
+	: _system(system), _mixer(mixer), _roomNumber(1), _screenNumber(0), _direction(0), _loadedRoomNumber(0), _activeScreenNumber(0),
+	  _gameState(kGameStateBoot), _gameID(gameID), _rootFSNode(rootFSNode), _havePendingScreenChange(false), _scriptNextInstruction(0),
+	  _escOn(false), _loadedAnimation(0), _animFrameNumber(0), _animLastFrame(0), _animDecoderState(kAnimDecoderStateStopped) {
 
 	_logDir = _rootFSNode.getChild("Log");
 	if (!_logDir.exists() || !_logDir.isDirectory())
@@ -69,9 +83,23 @@ Runtime::Runtime(OSystem *system, const Common::FSNode &rootFSNode, VCruiseGameI
 	_mapDir = _rootFSNode.getChild("Map");
 	if (!_mapDir.exists() || !_mapDir.isDirectory())
 		error("Couldn't resolve Map directory");
+
+	_sfxDir = _rootFSNode.getChild("Sfx");
+	if (!_sfxDir.exists() || !_sfxDir.isDirectory())
+		error("Couldn't resolve Sfx directory");
+
+	_animsDir = _rootFSNode.getChild("Anims");
+	if (!_animsDir.exists() || !_animsDir.isDirectory())
+		error("Couldn't resolve Anims directory");
 }
 
 Runtime::~Runtime() {
+}
+
+void Runtime::initSections(Common::Rect gameRect, Common::Rect menuRect, Common::Rect trayRect, const Graphics::PixelFormat &pixFmt) {
+	_gameSection.init(gameRect, pixFmt);
+	_menuSection.init(menuRect, pixFmt);
+	_traySection.init(trayRect, pixFmt);
 }
 
 void Runtime::loadCursors(const char *exeName) {
@@ -121,8 +149,14 @@ bool Runtime::runFrame() {
 			break;
 		case kGameStateQuit:
 			return false;
-		case kGameStateRunning:
-			moreActions = runGame();
+		case kGameStateIdle:
+			moreActions = runIdle();
+			break;
+		case kGameStateScript:
+			moreActions = runScript();
+			break;
+		case kGameStateWaitingForAnimation:
+			moreActions = runWaitForAnimation();
 			break;
 		default:
 			error("Unknown game state");
@@ -138,20 +172,18 @@ bool Runtime::bootGame() {
 	loadIndex();
 	debug(1, "Index loaded OK");
 
-	_gameState = kGameStateRunning;
+	_gameState = kGameStateIdle;
 
 	if (_gameID == GID_REAH) {
 		// TODO: Change to the logo instead (0xb1) instead when menus are implemented
-		_roomNumber = 1;
-		_screenNumber = 0xb0;
-		_havePendingScreenChange = true;
+		changeToScreen(1, 0xb0);
 	} else
 		error("Couldn't figure out what screen to start on");
 
 	return true;
 }
 
-bool Runtime::runGame() {
+bool Runtime::runIdle() {
 
 	if (_havePendingScreenChange) {
 		_havePendingScreenChange = false;
@@ -161,6 +193,175 @@ bool Runtime::runGame() {
 	}
 
 	return false;
+}
+
+bool Runtime::runWaitForAnimation() {
+	if (!_animDecoder) {
+		_gameState = kGameStateScript;
+		return true;
+	}
+
+	bool needsFirstFrame = false;
+	if (_animDecoderState == kAnimDecoderStatePaused) {
+		_animDecoder->pauseVideo(false);
+		_animDecoderState = kAnimDecoderStatePlaying;
+		needsFirstFrame = true;
+	} else if (_animDecoderState == kAnimDecoderStateStopped) {
+		_animDecoder->start();
+		_animDecoderState = kAnimDecoderStatePlaying;
+		needsFirstFrame = true;
+	}
+
+	for (;;) {
+		bool needNewFrame = needsFirstFrame || (_animDecoder->getTimeToNextFrame() == 0);
+		needsFirstFrame = false;
+
+		if (!needNewFrame)
+			break;
+
+		const Graphics::Surface *surface = _animDecoder->decodeNextFrame();
+		if (!surface) {
+			_gameState = kGameStateScript;
+			return true;
+		}
+
+		Common::Rect copyRect = Common::Rect(0, 0, surface->w, surface->h);
+
+		Common::Rect constraintRect = Common::Rect(0, 0, _gameSection.rect.width(), _gameSection.rect.height());
+
+		copyRect = copyRect.findIntersectingRect(constraintRect);
+
+		if (copyRect.isValidRect() || !copyRect.isEmpty()) {
+			_gameSection.surf->blitFrom(*surface, copyRect, copyRect);
+			_system->copyRectToScreen(_gameSection.surf->getBasePtr(copyRect.left, copyRect.top), _gameSection.surf->pitch, copyRect.left + _gameSection.rect.left, copyRect.top + _gameSection.rect.top, copyRect.width(), copyRect.height());
+		}
+
+		// The current frame will be the frame to be decoded on the next decode call,
+		// which means if it exceeds the last frame then it's time to stop
+		if (_animDecoder->getCurFrame() > static_cast<int>(_animLastFrame)) {
+			_animDecoder->pauseVideo(true);
+			_animDecoderState = kAnimDecoderStatePaused;
+
+			_gameState = kGameStateScript;
+			return true;
+		}
+	}
+
+	// Pump and handle events
+	return false;
+}
+
+#ifdef DISPATCH_OP
+#error "DISPATCH_OP already defined"
+#endif
+
+#define DISPATCH_OP(op) \
+	case ScriptOps::k##op: this->scriptOp##op(arg); break
+
+bool Runtime::runScript() {
+	while (_gameState == kGameStateScript) {
+		uint instrNum = _scriptNextInstruction;
+		if (!_activeScript || instrNum >= _activeScript->instrs.size()) {
+			terminateScript();
+			return true;
+		}
+
+		_scriptNextInstruction++;
+
+		const Instruction &instr = _activeScript->instrs[instrNum];
+		int32 arg = instr.arg;
+
+		switch (instr.op) {
+			DISPATCH_OP(Number);
+			DISPATCH_OP(Rotate);
+			DISPATCH_OP(Angle);
+			DISPATCH_OP(AngleGGet);
+			DISPATCH_OP(Speed);
+			DISPATCH_OP(SAnimL);
+			DISPATCH_OP(ChangeL);
+
+			DISPATCH_OP(AnimR);
+			DISPATCH_OP(AnimF);
+			DISPATCH_OP(AnimN);
+			DISPATCH_OP(AnimG);
+			DISPATCH_OP(AnimS);
+			DISPATCH_OP(Anim);
+
+			DISPATCH_OP(Static);
+			DISPATCH_OP(VarLoad);
+			DISPATCH_OP(VarStore);
+			DISPATCH_OP(SetCursor);
+			DISPATCH_OP(SetRoom);
+			DISPATCH_OP(LMB);
+			DISPATCH_OP(LMB1);
+			DISPATCH_OP(SoundS1);
+			DISPATCH_OP(SoundL2);
+
+			DISPATCH_OP(Music);
+			DISPATCH_OP(MusicUp);
+			DISPATCH_OP(Parm1);
+			DISPATCH_OP(Parm2);
+			DISPATCH_OP(Parm3);
+			DISPATCH_OP(ParmG);
+
+			DISPATCH_OP(VolumeDn4);
+			DISPATCH_OP(VolumeUp3);
+			DISPATCH_OP(Random);
+			DISPATCH_OP(Drop);
+			DISPATCH_OP(Dup);
+			DISPATCH_OP(Say3);
+			DISPATCH_OP(SetTimer);
+			DISPATCH_OP(LoSet);
+			DISPATCH_OP(LoGet);
+			DISPATCH_OP(HiSet);
+			DISPATCH_OP(HiGet);
+
+			DISPATCH_OP(Not);
+			DISPATCH_OP(And);
+			DISPATCH_OP(Or);
+			DISPATCH_OP(CmpEq);
+
+			DISPATCH_OP(BitLoad);
+			DISPATCH_OP(BitSet0);
+			DISPATCH_OP(BitSet1);
+
+			DISPATCH_OP(Disc1);
+			DISPATCH_OP(Disc2);
+			DISPATCH_OP(Disc3);
+
+			DISPATCH_OP(EscOn);
+			DISPATCH_OP(EscOff);
+			DISPATCH_OP(EscGet);
+			DISPATCH_OP(BackStart);
+
+			DISPATCH_OP(AnimName);
+			DISPATCH_OP(ValueName);
+			DISPATCH_OP(VarName);
+			DISPATCH_OP(SoundName);
+			DISPATCH_OP(CursorName);
+
+			DISPATCH_OP(CheckValue);
+			DISPATCH_OP(Jump);
+
+		default:
+			error("Unimplemented opcode %i", static_cast<int>(instr.op));
+		}
+	}
+
+	return true;
+}
+
+#undef DISPATCH_OP
+
+void Runtime::terminateScript() {
+	_activeScript.reset();
+	_scriptNextInstruction = 0;
+
+	if (_gameState == kGameStateScript)
+		_gameState = kGameStateIdle;
+
+	if (_havePendingScreenChange)
+		changeToScreen(_roomNumber, _screenNumber);
 }
 
 void Runtime::loadIndex() {
@@ -242,7 +443,16 @@ void Runtime::changeToScreen(uint roomNumber, uint screenNumber) {
 	bool changedRoom = (roomNumber != _loadedRoomNumber);
 	bool changedScreen = (screenNumber != _activeScreenNumber) || changedRoom;
 
+	_roomNumber = roomNumber;
+	_screenNumber = screenNumber;
+
+	_loadedRoomNumber = roomNumber;
+	_activeScreenNumber = screenNumber;
+
 	if (changedRoom) {
+		// Scripts are not allowed
+		assert(!_activeScript);
+
 		_scriptSet.reset();
 
 		Common::String logFileName = Common::String::format("Room%02i.log", static_cast<int>(roomNumber));
@@ -262,6 +472,21 @@ void Runtime::changeToScreen(uint roomNumber, uint screenNumber) {
 			if (Common::SeekableReadStream *mapFile = mapFileNode.createReadStream()) {
 				loadMap(mapFile);
 				delete mapFile;
+			}
+		}
+	}
+
+	if (changedScreen) {
+		if (_scriptSet) {
+			Common::HashMap<uint, Common::SharedPtr<RoomScriptSet> >::const_iterator roomScriptIt = _scriptSet->roomScripts.find(_roomNumber);
+			if (roomScriptIt != _scriptSet->roomScripts.end()) {
+				Common::HashMap<uint, Common::SharedPtr<ScreenScriptSet> > &screenScriptsMap = roomScriptIt->_value->screenScripts;
+				Common::HashMap<uint, Common::SharedPtr<ScreenScriptSet> >::const_iterator screenScriptIt = screenScriptsMap.find(_screenNumber);
+				if (screenScriptIt != screenScriptsMap.end()) {
+					const Common::SharedPtr<Script> &script = screenScriptIt->_value->entryScript;
+					if (script)
+						activateScript(script);
+				}
 			}
 		}
 	}
@@ -311,6 +536,79 @@ void Runtime::loadMap(Common::SeekableReadStream *stream) {
 			}
 		}
 	}
+}
+
+void Runtime::changeMusicTrack(int track) {
+	_musicPlayer.reset();
+
+	Common::String wavFileName = Common::String::format("Music-%02i.wav", static_cast<int>(track));
+	Common::FSNode wavFileNode = _sfxDir.getChild(wavFileName);
+	if (wavFileNode.exists()) {
+		if (Common::SeekableReadStream *wavFile = wavFileNode.createReadStream()) {
+			if (Audio::SeekableAudioStream *audioStream = Audio::makeWAVStream(wavFile, DisposeAfterUse::YES)) {
+				Common::SharedPtr<Audio::AudioStream> loopingStream(Audio::makeLoopingAudioStream(audioStream, 0));
+
+				_musicPlayer.reset(new AudioPlayer(_mixer, loopingStream, 255, 0));
+			}
+		}
+	}
+}
+
+void Runtime::changeAnimation(const AnimationDef &animDef) {
+	int animFile = animDef.animNum;
+	if (animFile < 0)
+		animFile = -animFile;
+
+	if (_loadedAnimation != static_cast<uint>(animFile)) {
+		_loadedAnimation = animFile;
+		_animDecoder.reset();
+		_animDecoderState = kAnimDecoderStateStopped;
+
+		Common::String aviFileName = Common::String::format("Anim%04i.avi", animFile);
+		Common::FSNode aviFileNode = _animsDir.getChild(aviFileName);
+		if (!aviFileNode.exists()) {
+			warning("Animation file %i is missing", animFile);
+			return;
+		}
+
+		if (Common::SeekableReadStream *aviFile = aviFileNode.createReadStream()) {
+			_animDecoder.reset(new Video::AVIDecoder());
+			if (!_animDecoder->loadStream(aviFile)) {
+				warning("Animation file %i could not be loaded", animFile);
+				return;
+			}
+		} else {
+			warning("Animation file %i is missing", animFile);
+			return;
+		}
+	}
+
+	if (_animDecoderState == kAnimDecoderStatePlaying) {
+		_animDecoder->pauseVideo(true);
+		_animDecoderState = kAnimDecoderStatePaused;
+	}
+
+	_animDecoder->seekToFrame(animDef.firstFrame);
+	_animFrameNumber = animDef.firstFrame;
+	_animLastFrame = animDef.lastFrame;
+}
+
+AnimationDef Runtime::stackArgsToAnimDef(const StackValue_t *args) const {
+	AnimationDef def;
+	def.animNum = args[0];
+	def.firstFrame = args[1];
+	def.lastFrame = args[2];
+
+	return def;
+}
+
+void Runtime::activateScript(const Common::SharedPtr<Script> &script) {
+	if (script->instrs.size() == 0)
+		return;
+
+	_activeScript = script;
+	_scriptNextInstruction = 0;
+	_gameState = kGameStateScript;
 }
 
 bool Runtime::parseIndexDef(TextParser &parser, IndexParseType parseType, uint roomNumber, const Common::String &blamePath) {
@@ -433,8 +731,183 @@ void Runtime::allocateRoomsUpTo(uint roomNumber) {
 	}
 }
 
-void Runtime::drawFrame() {
+#ifdef CHECK_STACK
+#error "CHECK_STACK is already defined"
+#endif
 
+#define PEEK_STACK(n)                                                                         \
+	if (this->_scriptStack.size() < (n)) {                                                      \
+		error("Script stack underflow");                                                      \
+		return;                                                                               \
+	}                                                                                         \
+	const ScriptArg_t *stackArgs = &this->_scriptStack[this->_scriptStack.size() - (n)]
+
+
+#define TAKE_STACK(n)                                                                         \
+	StackValue_t stackArgs[n];                                                                \
+	do {                                                                                      \
+		const uint stackSize = _scriptStack.size();                                           \
+		if (stackSize < (n)) {                                                                \
+			error("Script stack underflow");                                                  \
+			return;                                                                           \
+		}                                                                                     \
+		const StackValue_t *stackArgsPtr = &this->_scriptStack[stackSize - (n)];              \
+		for (uint i = 0; i < (n); i++)                                                        \
+			stackArgs[i] = stackArgsPtr[i];                                                   \
+		this->_scriptStack.resize(stackSize - (n));                                           \
+	} while (false)
+
+void Runtime::scriptOpNumber(ScriptArg_t arg) {
+	_scriptStack.push_back(arg);
+}
+
+void Runtime::scriptOpRotate(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpAngle(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpAngleGGet(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpSpeed(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpSAnimL(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpChangeL(ScriptArg_t arg) { error("Unimplemented opcode"); }
+
+void Runtime::scriptOpAnimR(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpAnimF(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpAnimN(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpAnimG(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpAnimS(ScriptArg_t arg) { error("Unimplemented opcode"); }
+
+void Runtime::scriptOpAnim(ScriptArg_t arg) {
+	TAKE_STACK(kAnimDefStackArgs + 2);
+
+	AnimationDef animDef = stackArgsToAnimDef(stackArgs + 0);
+	changeAnimation(animDef);
+
+	_gameState = kGameStateWaitingForAnimation;
+	_screenNumber = stackArgs[kAnimDefStackArgs + 0];
+	_direction = stackArgs[kAnimDefStackArgs + 1];
+}
+
+void Runtime::scriptOpStatic(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpVarLoad(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpVarStore(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpSetCursor(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpSetRoom(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpLMB(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpLMB1(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpSoundS1(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpSoundL2(ScriptArg_t arg) { error("Unimplemented opcode"); }
+
+void Runtime::scriptOpMusic(ScriptArg_t arg) {
+	TAKE_STACK(1);
+
+	changeMusicTrack(stackArgs[0]);
+}
+
+void Runtime::scriptOpMusicUp(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpParm1(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpParm2(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpParm3(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpParmG(ScriptArg_t arg) { error("Unimplemented opcode"); }
+
+void Runtime::scriptOpVolumeDn4(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpVolumeUp3(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpRandom(ScriptArg_t arg) { error("Unimplemented opcode"); }
+
+void Runtime::scriptOpDrop(ScriptArg_t arg) {
+	TAKE_STACK(1);
+}
+
+void Runtime::scriptOpDup(ScriptArg_t arg) {
+	TAKE_STACK(1);
+
+	_scriptStack.push_back(stackArgs[0]);
+	_scriptStack.push_back(stackArgs[0]);
+}
+
+void Runtime::scriptOpSay3(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpSetTimer(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpLoSet(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpLoGet(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpHiSet(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpHiGet(ScriptArg_t arg) { error("Unimplemented opcode"); }
+
+void Runtime::scriptOpNot(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpAnd(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpOr(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpCmpEq(ScriptArg_t arg) { error("Unimplemented opcode"); }
+
+void Runtime::scriptOpBitLoad(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpBitSet0(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpBitSet1(ScriptArg_t arg) { error("Unimplemented opcode"); }
+
+void Runtime::scriptOpDisc1(ScriptArg_t arg) {
+	// Always pass disc check
+	TAKE_STACK(1);
+	_scriptStack.push_back(1);
+}
+
+void Runtime::scriptOpDisc2(ScriptArg_t arg) {
+	// Always pass disc check
+	TAKE_STACK(2);
+	_scriptStack.push_back(1);
+}
+
+void Runtime::scriptOpDisc3(ScriptArg_t arg) {
+	// Always pass disc check
+	TAKE_STACK(3);
+	_scriptStack.push_back(1);
+}
+
+void Runtime::scriptOpEscOn(ScriptArg_t arg) {
+	TAKE_STACK(1);
+
+	_escOn = (stackArgs[0] != 0);
+}
+
+void Runtime::scriptOpEscOff(ScriptArg_t arg) {
+	_escOn = false;
+}
+
+void Runtime::scriptOpEscGet(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpBackStart(ScriptArg_t arg) { error("Unimplemented opcode"); }
+
+void Runtime::scriptOpAnimName(ScriptArg_t arg) {
+	// I doubt this is actually how it works internally but whatever
+	if (_roomNumber >= _roomDefs.size())
+		error("Can't resolve animation for room, room number was invalid");
+
+	Common::SharedPtr<RoomDef> roomDef = _roomDefs[_roomNumber];
+	if (!roomDef)
+		error("Can't resolve animation for room, room number was invalid");
+
+
+	Common::HashMap<Common::String, AnimationDef>::const_iterator it = roomDef->animations.find(_scriptSet->strings[arg]);
+	if (it == roomDef->animations.end())
+		error("Can't resolve animation for room, couldn't find animation '%s'", _scriptSet->strings[arg].c_str());
+
+	_scriptStack.push_back(it->_value.animNum);
+	_scriptStack.push_back(it->_value.firstFrame);
+	_scriptStack.push_back(it->_value.lastFrame);
+}
+
+
+void Runtime::scriptOpValueName(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpVarName(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpSoundName(ScriptArg_t arg) { error("Unimplemented opcode"); }
+void Runtime::scriptOpCursorName(ScriptArg_t arg) { error("Unimplemented opcode"); }
+
+void Runtime::scriptOpCheckValue(ScriptArg_t arg) {
+	PEEK_STACK(1);
+
+	if (arg == stackArgs[0])
+		_scriptStack.pop_back();
+	else
+		_scriptNextInstruction++;
+}
+
+void Runtime::scriptOpJump(ScriptArg_t arg) {
+	_scriptNextInstruction = arg;
+}
+
+void Runtime::drawFrame() {
 	_system->updateScreen();
 }
 

--- a/engines/vcruise/runtime.cpp
+++ b/engines/vcruise/runtime.cpp
@@ -239,9 +239,7 @@ bool Runtime::runWaitForAnimation() {
 			_system->copyRectToScreen(_gameSection.surf->getBasePtr(copyRect.left, copyRect.top), _gameSection.surf->pitch, copyRect.left + _gameSection.rect.left, copyRect.top + _gameSection.rect.top, copyRect.width(), copyRect.height());
 		}
 
-		// The current frame will be the frame to be decoded on the next decode call,
-		// which means if it exceeds the last frame then it's time to stop
-		if (_animDecoder->getCurFrame() > static_cast<int>(_animLastFrame)) {
+		if (_animDecoder->getCurFrame() >= static_cast<int>(_animLastFrame)) {
 			_animDecoder->pauseVideo(true);
 			_animDecoderState = kAnimDecoderStatePaused;
 

--- a/engines/vcruise/runtime.cpp
+++ b/engines/vcruise/runtime.cpp
@@ -1038,8 +1038,16 @@ void Runtime::onKeyDown(Common::KeyCode keyCode) {
 	queueOSEvent(evt);
 }
 
-#ifdef CHECK_STACK
-#error "CHECK_STACK is already defined"
+#ifdef PEEK_STACK
+#error "PEEK_STACK is already defined"
+#endif
+
+#ifdef TAKE_STACK
+#error "TAKE_STACK is already defined"
+#endif
+
+#ifdef OPCODE_STUB
+#error "OPCODE_STUB is already defined"
 #endif
 
 #define PEEK_STACK(n)                                                                         \
@@ -1064,6 +1072,11 @@ void Runtime::onKeyDown(Common::KeyCode keyCode) {
 		this->_scriptStack.resize(stackSize - (n));                                           \
 	} while (false)
 
+#define OPCODE_STUB(op)                           \
+	void Runtime::scriptOp##op(ScriptArg_t arg) { \
+		error("Unimplemented opcode '" #op "'");  \
+	}
+
 void Runtime::scriptOpNumber(ScriptArg_t arg) {
 	_scriptStack.push_back(arg);
 }
@@ -1076,9 +1089,9 @@ void Runtime::scriptOpRotate(ScriptArg_t arg) {
 	_havePanAnimations = true;
 }
 
-void Runtime::scriptOpAngle(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpAngleGGet(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpSpeed(ScriptArg_t arg) { error("Unimplemented opcode"); }
+OPCODE_STUB(Angle)
+OPCODE_STUB(AngleGGet)
+OPCODE_STUB(Speed)
 
 void Runtime::scriptOpSAnimL(ScriptArg_t arg) {
 	TAKE_STACK(kAnimDefStackArgs + 2);
@@ -1096,12 +1109,12 @@ void Runtime::scriptOpSAnimL(ScriptArg_t arg) {
 	_idleAnimations[direction] = animDef;
 }
 
-void Runtime::scriptOpChangeL(ScriptArg_t arg) { error("Unimplemented opcode"); }
+OPCODE_STUB(ChangeL)
 
-void Runtime::scriptOpAnimR(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpAnimF(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpAnimN(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpAnimG(ScriptArg_t arg) { error("Unimplemented opcode"); }
+OPCODE_STUB(AnimR)
+OPCODE_STUB(AnimF)
+OPCODE_STUB(AnimN)
+OPCODE_STUB(AnimG)
 
 void Runtime::scriptOpAnimS(ScriptArg_t arg) {
 	TAKE_STACK(kAnimDefStackArgs + 2);
@@ -1129,7 +1142,7 @@ void Runtime::scriptOpAnim(ScriptArg_t arg) {
 	_havePendingScreenChange = true;
 }
 
-void Runtime::scriptOpStatic(ScriptArg_t arg) { error("Unimplemented opcode"); }
+OPCODE_STUB(Static)
 
 void Runtime::scriptOpVarLoad(ScriptArg_t arg) {
 	TAKE_STACK(1);
@@ -1160,15 +1173,15 @@ void Runtime::scriptOpSetCursor(ScriptArg_t arg) {
 	changeToCursor(_cursors[stackArgs[0]]);
 }
 
-void Runtime::scriptOpSetRoom(ScriptArg_t arg) { error("Unimplemented opcode"); }
+OPCODE_STUB(SetRoom)
 
 void Runtime::scriptOpLMB(ScriptArg_t arg) {
 	if (!_scriptEnv.lmb)
 		terminateScript();
 }
 
-void Runtime::scriptOpLMB1(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpSoundS1(ScriptArg_t arg) { error("Unimplemented opcode"); }
+OPCODE_STUB(LMB1)
+OPCODE_STUB(SoundS1)
 
 void Runtime::scriptOpSoundL2(ScriptArg_t arg) {
 	TAKE_STACK(2);
@@ -1186,25 +1199,26 @@ void Runtime::scriptOpMusic(ScriptArg_t arg) {
 void Runtime::scriptOpMusicUp(ScriptArg_t arg) {
 	TAKE_STACK(2);
 
-	warning("Music volume changes are not implemented");
+	warning("Music volume ramp up is not implemented");
 	(void)stackArgs;
 }
 
 void Runtime::scriptOpMusicDn(ScriptArg_t arg) {
 	TAKE_STACK(2);
 
-	warning("Music volume changes are not implemented");
+	warning("Music volume ramp down is not implemented");
 	(void)stackArgs;
 }
 
-void Runtime::scriptOpParm1(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpParm2(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpParm3(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpParmG(ScriptArg_t arg) { error("Unimplemented opcode"); }
 
-void Runtime::scriptOpVolumeDn4(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpVolumeUp3(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpRandom(ScriptArg_t arg) { error("Unimplemented opcode"); }
+OPCODE_STUB(Parm1)
+OPCODE_STUB(Parm2)
+OPCODE_STUB(Parm3)
+OPCODE_STUB(ParmG)
+
+OPCODE_STUB(VolumeDn4)
+OPCODE_STUB(VolumeUp3)
+OPCODE_STUB(Random)
 
 void Runtime::scriptOpDrop(ScriptArg_t arg) {
 	TAKE_STACK(1);
@@ -1218,12 +1232,12 @@ void Runtime::scriptOpDup(ScriptArg_t arg) {
 	_scriptStack.push_back(stackArgs[0]);
 }
 
-void Runtime::scriptOpSay3(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpSetTimer(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpLoSet(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpLoGet(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpHiSet(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpHiGet(ScriptArg_t arg) { error("Unimplemented opcode"); }
+OPCODE_STUB(Say3)
+OPCODE_STUB(SetTimer)
+OPCODE_STUB(LoSet)
+OPCODE_STUB(LoGet)
+OPCODE_STUB(HiSet)
+OPCODE_STUB(HiGet)
 
 void Runtime::scriptOpNot(ScriptArg_t arg) {
 	TAKE_STACK(1);
@@ -1249,9 +1263,9 @@ void Runtime::scriptOpCmpEq(ScriptArg_t arg) {
 	_scriptStack.push_back((stackArgs[0] == stackArgs[1]) ? 1 : 0);
 }
 
-void Runtime::scriptOpBitLoad(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpBitSet0(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpBitSet1(ScriptArg_t arg) { error("Unimplemented opcode"); }
+OPCODE_STUB(BitLoad)
+OPCODE_STUB(BitSet0)
+OPCODE_STUB(BitSet1)
 
 void Runtime::scriptOpDisc1(ScriptArg_t arg) {
 	// Disc check, always pass
@@ -1284,8 +1298,8 @@ void Runtime::scriptOpEscOff(ScriptArg_t arg) {
 	_escOn = false;
 }
 
-void Runtime::scriptOpEscGet(ScriptArg_t arg) { error("Unimplemented opcode"); }
-void Runtime::scriptOpBackStart(ScriptArg_t arg) { error("Unimplemented opcode"); }
+OPCODE_STUB(EscGet)
+OPCODE_STUB(BackStart)
 
 void Runtime::scriptOpAnimName(ScriptArg_t arg) {
 	// I doubt this is actually how it works internally but whatever
@@ -1307,7 +1321,7 @@ void Runtime::scriptOpAnimName(ScriptArg_t arg) {
 }
 
 
-void Runtime::scriptOpValueName(ScriptArg_t arg) { error("Unimplemented opcode"); }
+OPCODE_STUB(ValueName)
 
 void Runtime::scriptOpVarName(ScriptArg_t arg) {
 	if (_roomNumber >= _roomDefs.size())
@@ -1362,6 +1376,11 @@ void Runtime::scriptOpCheckValue(ScriptArg_t arg) {
 void Runtime::scriptOpJump(ScriptArg_t arg) {
 	_scriptNextInstruction = arg;
 }
+
+#undef TAKE_STACK
+#undef PEEK_STACK
+#undef OPCODE_STUB
+
 
 void Runtime::drawFrame() {
 	_system->updateScreen();

--- a/engines/vcruise/runtime.cpp
+++ b/engines/vcruise/runtime.cpp
@@ -623,10 +623,10 @@ void Runtime::changeToScreen(uint roomNumber, uint screenNumber) {
 
 	if (changedScreen) {
 		if (_scriptSet) {
-			Common::HashMap<uint, Common::SharedPtr<RoomScriptSet> >::const_iterator roomScriptIt = _scriptSet->roomScripts.find(_roomNumber);
+			RoomScriptSetMap_t::const_iterator roomScriptIt = _scriptSet->roomScripts.find(_roomNumber);
 			if (roomScriptIt != _scriptSet->roomScripts.end()) {
-				Common::HashMap<uint, Common::SharedPtr<ScreenScriptSet> > &screenScriptsMap = roomScriptIt->_value->screenScripts;
-				Common::HashMap<uint, Common::SharedPtr<ScreenScriptSet> >::const_iterator screenScriptIt = screenScriptsMap.find(_screenNumber);
+				const ScreenScriptSetMap_t &screenScriptsMap = roomScriptIt->_value->screenScripts;
+				ScreenScriptSetMap_t::const_iterator screenScriptIt = screenScriptsMap.find(_screenNumber);
 				if (screenScriptIt != screenScriptsMap.end()) {
 					const Common::SharedPtr<Script> &script = screenScriptIt->_value->entryScript;
 					if (script)
@@ -976,16 +976,16 @@ void Runtime::drawDebugOverlay() {
 
 Common::SharedPtr<Script> Runtime::findScriptForInteraction(uint interactionID) const {
 	if (_scriptSet) {
-		Common::HashMap<uint, Common::SharedPtr<RoomScriptSet> >::const_iterator roomScriptIt = _scriptSet->roomScripts.find(_roomNumber);
+		RoomScriptSetMap_t::const_iterator roomScriptIt = _scriptSet->roomScripts.find(_roomNumber);
 
 		if (roomScriptIt != _scriptSet->roomScripts.end()) {
 			const RoomScriptSet &roomScriptSet = *roomScriptIt->_value;
 
-			Common::HashMap<uint, Common::SharedPtr<ScreenScriptSet> >::const_iterator screenScriptIt = roomScriptSet.screenScripts.find(_screenNumber);
+			ScreenScriptSetMap_t::const_iterator screenScriptIt = roomScriptSet.screenScripts.find(_screenNumber);
 			if (screenScriptIt != roomScriptSet.screenScripts.end()) {
 				const ScreenScriptSet &screenScriptSet = *screenScriptIt->_value;
 
-				Common::HashMap<uint, Common::SharedPtr<Script> >::const_iterator interactionScriptIt = screenScriptSet.interactionScripts.find(interactionID);
+				ScriptMap_t::const_iterator interactionScriptIt = screenScriptSet.interactionScripts.find(interactionID);
 				if (interactionScriptIt != screenScriptSet.interactionScripts.end())
 					return interactionScriptIt->_value;
 			}

--- a/engines/vcruise/runtime.cpp
+++ b/engines/vcruise/runtime.cpp
@@ -811,7 +811,7 @@ void Runtime::scriptOpSAnimL(ScriptArg_t arg) {
 	TAKE_STACK(kAnimDefStackArgs + 2);
 
 	if (stackArgs[kAnimDefStackArgs] != 0)
-		warning("sanimL second operand wasn't zero (what does that do??)");
+		warning("sanimL second operand wasn't zero (what does that do?)");
 
 	AnimationDef animDef = stackArgsToAnimDef(stackArgs + 0);
 	uint direction = stackArgs[kAnimDefStackArgs + 1];
@@ -888,6 +888,7 @@ void Runtime::scriptOpSoundL2(ScriptArg_t arg) {
 	TAKE_STACK(2);
 
 	warning("Sound loop not implemented yet");
+	(void)stackArgs;
 }
 
 void Runtime::scriptOpMusic(ScriptArg_t arg) {
@@ -900,12 +901,14 @@ void Runtime::scriptOpMusicUp(ScriptArg_t arg) {
 	TAKE_STACK(2);
 
 	warning("Music volume changes are not implemented");
+	(void)stackArgs;
 }
 
 void Runtime::scriptOpMusicDn(ScriptArg_t arg) {
 	TAKE_STACK(2);
 
 	warning("Music volume changes are not implemented");
+	(void)stackArgs;
 }
 
 void Runtime::scriptOpParm1(ScriptArg_t arg) { error("Unimplemented opcode"); }
@@ -919,6 +922,7 @@ void Runtime::scriptOpRandom(ScriptArg_t arg) { error("Unimplemented opcode"); }
 
 void Runtime::scriptOpDrop(ScriptArg_t arg) {
 	TAKE_STACK(1);
+	(void)stackArgs;
 }
 
 void Runtime::scriptOpDup(ScriptArg_t arg) {

--- a/engines/vcruise/runtime.cpp
+++ b/engines/vcruise/runtime.cpp
@@ -970,18 +970,21 @@ void Runtime::scriptOpBitSet1(ScriptArg_t arg) { error("Unimplemented opcode"); 
 void Runtime::scriptOpDisc1(ScriptArg_t arg) {
 	// Disc check, always pass
 	TAKE_STACK(1);
+	(void)stackArgs;
 	_scriptStack.push_back(1);
 }
 
 void Runtime::scriptOpDisc2(ScriptArg_t arg) {
 	// Disc check, always pass
 	TAKE_STACK(2);
+	(void)stackArgs;
 	_scriptStack.push_back(1);
 }
 
 void Runtime::scriptOpDisc3(ScriptArg_t arg) {
 	// Disc check, always pass
 	TAKE_STACK(3);
+	(void)stackArgs;
 	_scriptStack.push_back(1);
 }
 

--- a/engines/vcruise/runtime.cpp
+++ b/engines/vcruise/runtime.cpp
@@ -262,26 +262,26 @@ bool Runtime::runWaitForAnimation() {
 	if (animEnded) {
 		_gameState = kGameStateScript;
 		return true;
-	} else {
-		// Still waiting, check events
-		OSEvent evt;
-		while (popOSEvent(evt)) {
-			if (evt.type == kOSEventTypeKeyDown && evt.keyCode == Common::KEYCODE_ESCAPE) {
-				if (_escOn) {
-					// Terminate the animation
-					if (_animDecoderState == kAnimDecoderStatePlaying) {
-						_animDecoder->pauseVideo(true);
-						_animDecoderState = kAnimDecoderStatePaused;
-					}
-					_gameState = kGameStateScript;
-					return true;
+	}
+
+	// Still waiting, check events
+	OSEvent evt;
+	while (popOSEvent(evt)) {
+		if (evt.type == kOSEventTypeKeyDown && evt.keyCode == Common::KEYCODE_ESCAPE) {
+			if (_escOn) {
+				// Terminate the animation
+				if (_animDecoderState == kAnimDecoderStatePlaying) {
+					_animDecoder->pauseVideo(true);
+					_animDecoderState = kAnimDecoderStatePaused;
 				}
+				_gameState = kGameStateScript;
+				return true;
 			}
 		}
-
-		// Yield
-		return false;
 	}
+
+	// Yield
+	return false;
 }
 
 void Runtime::continuePlayingAnimation(bool loop, bool &outAnimationEnded) {
@@ -343,7 +343,7 @@ void Runtime::continuePlayingAnimation(bool loop, bool &outAnimationEnded) {
 		}
 
 		if (!loop) {
-			if (_animDisplayingFrame >= static_cast<int>(_animLastFrame)) {
+			if (_animDisplayingFrame >= _animLastFrame) {
 				_animDecoder->pauseVideo(true);
 				_animDecoderState = kAnimDecoderStatePaused;
 

--- a/engines/vcruise/runtime.h
+++ b/engines/vcruise/runtime.h
@@ -23,6 +23,7 @@
 #define VCRUISE_RUNTIME_H
 
 #include "common/hashmap.h"
+#include "common/keyboard.h"
 
 #include "vcruise/detection.h"
 
@@ -43,6 +44,8 @@ class AVIDecoder;
 } // End of namespace Video
 
 namespace VCruise {
+
+static const uint kNumDirections = 8;
 
 class AudioPlayer;
 class TextParser;
@@ -92,7 +95,6 @@ struct MapScreenDirectionDef {
 
 struct MapDef {
 	static const uint kNumScreens = 96;
-	static const uint kNumDirections = 8;
 	static const uint kFirstScreen = 0xa0;
 
 	Common::SharedPtr<MapScreenDirectionDef> screenDirections[kNumScreens][kNumDirections];
@@ -112,6 +114,11 @@ public:
 
 	bool runFrame();
 	void drawFrame();
+
+	void onLButtonDown(int16 x, int16 y);
+	void onLButtonUp(int16 x, int16 y);
+	void onMouseMove(int16 x, int16 y);
+	void onKeyDown(Common::KeyCode keyCode);
 
 private:
 	enum IndexParseType {
@@ -194,6 +201,7 @@ private:
 
 	void scriptOpMusic(ScriptArg_t arg);
 	void scriptOpMusicUp(ScriptArg_t arg);
+	void scriptOpMusicDn(ScriptArg_t arg);
 	void scriptOpParm1(ScriptArg_t arg);
 	void scriptOpParm2(ScriptArg_t arg);
 	void scriptOpParm3(ScriptArg_t arg);
@@ -245,6 +253,18 @@ private:
 	uint _roomNumber;	// Room number can be changed independently of the loaded room, the screen doesn't change until a command changes it
 	uint _screenNumber;
 	uint _direction;
+
+	AnimationDef _panLeftAnimationDef;
+	AnimationDef _panRightAnimationDef;
+	bool _havePanAnimations;
+
+	AnimationDef _idleAnimations[kNumDirections];
+	bool _haveIdleAnimations[kNumDirections];
+
+	Common::HashMap<uint32, int32> _variables;
+
+	static const uint kPanLeftInteraction = 1;
+	static const uint kPanRightInteraction = 3;
 
 	uint _loadedRoomNumber;
 	uint _activeScreenNumber;

--- a/engines/vcruise/runtime.h
+++ b/engines/vcruise/runtime.h
@@ -338,12 +338,6 @@ private:
 
 	VCruiseGameID _gameID;
 
-	Common::FSNode _rootFSNode;
-	Common::FSNode _logDir;
-	Common::FSNode _mapDir;
-	Common::FSNode _sfxDir;
-	Common::FSNode _animsDir;
-
 	Common::Array<Common::SharedPtr<RoomDef> > _roomDefs;
 	Common::SharedPtr<ScriptSet> _scriptSet;
 

--- a/engines/vcruise/runtime.h
+++ b/engines/vcruise/runtime.h
@@ -75,7 +75,6 @@ struct RoomDef {
 	Common::HashMap<Common::String, uint> vars;
 	Common::HashMap<Common::String, int> values;
 	Common::HashMap<Common::String, Common::String> texts;
-	Common::HashMap<Common::String, int> consts;
 	Common::HashMap<Common::String, int> sounds;
 
 	Common::String name;
@@ -214,7 +213,7 @@ private:
 
 	void activateScript(const Common::SharedPtr<Script> &script, const ScriptEnvironmentVars &envVars);
 
-	bool parseIndexDef(TextParser &parser, IndexParseType parseType, uint roomNumber, const Common::String &blamePath);
+	bool parseIndexDef(IndexParseType parseType, uint roomNumber, const Common::String &key, const Common::String &value);
 	void allocateRoomsUpTo(uint roomNumber);
 
 	void drawDebugOverlay();

--- a/engines/vcruise/runtime.h
+++ b/engines/vcruise/runtime.h
@@ -1,0 +1,64 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef VCRUISE_RUNTIME_H
+#define VCRUISE_RUNTIME_H
+
+class OSystem;
+
+namespace Graphics {
+
+struct WinCursorGroup;
+
+} // End of namespace Graphics
+
+namespace VCruise {
+
+enum GameState {
+	kGameStateBoot,
+	kGameStateCinematic,
+	kGameStateQuit,
+};
+
+class Runtime {
+public:
+	explicit Runtime(OSystem *system);
+	virtual ~Runtime();
+
+	void loadCursors(const char *exeName);
+
+	bool runFrame();
+	void drawFrame();
+
+private:
+	void bootGame();
+
+	Common::Array<Common::SharedPtr<Graphics::WinCursorGroup> > _cursors;		// Cursors indexed as CURSOR_CUR_##
+	Common::Array<Common::SharedPtr<Graphics::WinCursorGroup> > _cursorsShort;	// Cursors indexed as CURSOR_#
+
+	OSystem *_system;
+	uint _roomNumber;
+	GameState _gameState;
+};
+
+} // End of namespace VCruise
+
+#endif

--- a/engines/vcruise/runtime.h
+++ b/engines/vcruise/runtime.h
@@ -66,6 +66,29 @@ struct RoomDef {
 	Common::String name;
 };
 
+struct InteractionDef {
+	InteractionDef();
+
+	Common::Rect rect;
+	uint16 interactionID;
+	uint16 objectType;
+};
+
+struct MapScreenDirectionDef {
+	Common::Array<InteractionDef> interactions;
+};
+
+struct MapDef {
+	static const uint kNumScreens = 96;
+	static const uint kNumDirections = 8;
+	static const uint kFirstScreen = 0xa0;
+
+	Common::SharedPtr<MapScreenDirectionDef> screenDirections[kNumScreens][kNumDirections];
+
+	void clear();
+	const MapScreenDirectionDef *getScreenDirection(uint screen, uint direction);
+};
+
 class Runtime {
 public:
 	Runtime(OSystem *system, const Common::FSNode &rootFSNode, VCruiseGameID gameID);
@@ -82,6 +105,7 @@ private:
 
 	void loadIndex();
 	void changeToScreen(uint roomNumber, uint screenNumber);
+	void loadMap(Common::SeekableReadStream *stream);
 
 	Common::Array<Common::SharedPtr<Graphics::WinCursorGroup> > _cursors;		// Cursors indexed as CURSOR_CUR_##
 	Common::Array<Common::SharedPtr<Graphics::WinCursorGroup> > _cursorsShort;	// Cursors indexed as CURSOR_#
@@ -98,9 +122,12 @@ private:
 
 	Common::FSNode _rootFSNode;
 	Common::FSNode _logDir;
+	Common::FSNode _mapDir;
 
 	Common::Array<Common::SharedPtr<RoomDef> > _roomDefs;
 	Common::SharedPtr<ScriptSet> _scriptSet;
+
+	MapDef _map;
 
 	enum IndexParseType {
 		kIndexParseTypeNone,

--- a/engines/vcruise/script.cpp
+++ b/engines/vcruise/script.cpp
@@ -253,7 +253,6 @@ void ScriptCompiler::expectNumber(uint32 &outNumber) {
 
 void ScriptCompiler::compileRoomScriptSet(ScriptSet *ss) {
 	Common::SharedPtr<RoomScriptSet> roomScript;
-	uint roomID = 0;
 
 	TextParserState state;
 	Common::String token;

--- a/engines/vcruise/script.cpp
+++ b/engines/vcruise/script.cpp
@@ -202,17 +202,9 @@ bool ScriptCompiler::parseDecNumber(const Common::String &token, uint start, uin
 	if (start == token.size())
 		return false;
 
-	uint32 num = 0;
-	for (uint i = start; i < token.size(); i++) {
-		char c = token[i];
-		uint32 digit = 0;
-		if (c >= '0' && c <= '9')
-			digit = c - '0';
-		else
-			return false;
-
-		num = num * 10u + digit;
-	}
+	uint num = 0;
+	if (!sscanf(token.c_str() + start, "%u", &num))
+		return false;
 
 	outNumber = num;
 	return true;
@@ -222,19 +214,9 @@ bool ScriptCompiler::parseHexNumber(const Common::String &token, uint start, uin
 	if (start == token.size())
 		return false;
 
-	uint32 num = 0;
-	for (uint i = start; i < token.size(); i++) {
-		char c = token[i];
-		uint32 digit = 0;
-		if (c >= '0' && c <= '9')
-			digit = c - '0';
-		else if (c >= 'a' && c <= 'f')
-			digit = (c - 'a') + 0xa;
-		else
-			return false;
-
-		num = num * 16u + digit;
-	}
+	uint num = 0;
+	if (!sscanf(token.c_str() + start, "%x", &num))
+		return false;
 
 	outNumber = num;
 	return true;

--- a/engines/vcruise/script.cpp
+++ b/engines/vcruise/script.cpp
@@ -752,9 +752,6 @@ uint ScriptCompiler::indexString(const Common::String &str) {
 }
 
 Common::SharedPtr<ScriptSet> compileLogicFile(Common::ReadStream &stream, uint streamSize, const Common::String &blamePath) {
-
-	uint cipherOffset = 255u - (streamSize % 255u);
-
 	LogicUnscrambleStream unscrambleStream(&stream, streamSize);
 	TextParser parser(&unscrambleStream);
 

--- a/engines/vcruise/script.cpp
+++ b/engines/vcruise/script.cpp
@@ -320,6 +320,7 @@ void ScriptCompiler::compileScreenScriptSet(ScreenScriptSet *sss) {
 			codeGenScript(protoScript, *currentScript);
 
 			currentScript.reset(new Script());
+			protoScript.reset();
 
 			sss->interactionScripts[interactionNumber] = currentScript;
 		} else if (compileInstructionToken(protoScript, token)) {

--- a/engines/vcruise/script.cpp
+++ b/engines/vcruise/script.cpp
@@ -376,6 +376,7 @@ static ScriptNamedInstruction g_namedInstructions[] = {
 	{"soundL2", ProtoOp::kProtoOpScript, ScriptOps::kSoundL2},
 	{"music", ProtoOp::kProtoOpScript, ScriptOps::kMusic},
 	{"musicUp", ProtoOp::kProtoOpScript, ScriptOps::kMusicUp},
+	{"musicDn", ProtoOp::kProtoOpScript, ScriptOps::kMusicDn},
 
 	{"parm1", ProtoOp::kProtoOpScript, ScriptOps::kParm1},
 	{"parm2", ProtoOp::kProtoOpScript, ScriptOps::kParm2},

--- a/engines/vcruise/script.cpp
+++ b/engines/vcruise/script.cpp
@@ -412,7 +412,7 @@ bool ScriptCompiler::compileInstructionToken(ProtoScript &script, const Common::
 		return true;
 	}
 
-	if (token.size() >= 5 && token[0] == 'C' && token[1] == 'U' && token[2] == 'R' && token[3] == '_') {
+	if (token.hasPrefix("CUR_")) {
 		script.instrs.push_back(ProtoInstruction(ScriptOps::kCursorName, indexString(token)));
 		return true;
 	}

--- a/engines/vcruise/script.cpp
+++ b/engines/vcruise/script.cpp
@@ -1,0 +1,770 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/stream.h"
+#include "common/hash-str.h"
+
+#include "engines/vcruise/script.h"
+#include "engines/vcruise/textparser.h"
+
+
+namespace VCruise {
+
+class LogicUnscrambleStream : public Common::ReadStream {
+public:
+	LogicUnscrambleStream(Common::ReadStream *stream, uint streamSize);
+
+	bool eos() const override;
+	uint32 read(void *dataPtr, uint32 dataSize) override;
+
+private:
+	byte _cipher[255];
+	uint _cipherOffset;
+	Common::ReadStream *_stream;
+};
+
+LogicUnscrambleStream::LogicUnscrambleStream(Common::ReadStream *stream, uint streamSize) : _stream(stream) {
+	int key = 255;
+	for (int i = 0; i < 255; i++) {
+		int parityBit = ((key ^ (key >> 1) ^ (key >> 6) ^ (key >> 7))) & 1;
+		key = (key >> 1) | (parityBit << 7);
+		_cipher[254 - i] = key;
+	}
+
+	_cipherOffset = 255u - (streamSize % 255u);
+}
+
+bool LogicUnscrambleStream::eos() const {
+	return _stream->eos();
+}
+
+uint32 LogicUnscrambleStream::read(void *dataPtr, uint32 dataSize) {
+	uint32 numRead = _stream->read(dataPtr, dataSize);
+
+	byte *decipher = static_cast<byte *>(dataPtr);
+
+	uint cipherOffset = _cipherOffset;
+
+	uint32 remaining = numRead;
+	while (remaining) {
+		if (cipherOffset == 255)
+			cipherOffset = 0;
+
+		(*decipher++) ^= _cipher[cipherOffset++];
+		remaining--;
+	}
+
+	_cipherOffset = cipherOffset;
+	return numRead;
+}
+
+Instruction::Instruction() : op(ScriptOps::kInvalid), arg(0) {
+}
+
+Instruction::Instruction(ScriptOps::ScriptOp paramOp) : op(paramOp), arg(0) {
+}
+
+Instruction::Instruction(ScriptOps::ScriptOp paramOp, int32 paramArg) : op(paramOp), arg(paramArg) {
+}
+
+enum ProtoOp {
+	kProtoOpScript, // Use script opcode
+
+	kProtoOpJumpToLabel,
+	kProtoOpLabel,
+
+	kProtoOpIf,
+	kProtoOpElse,
+	kProtoOpEndIf,
+	kProtoOpSwitch,
+	kProtoOpCase,
+	kProtoOpEndSwitch,
+	kProtoOpDefault,
+	kProtoOpBreak,
+};
+
+struct ProtoInstruction {
+	ProtoInstruction();
+	explicit ProtoInstruction(ScriptOps::ScriptOp op);
+	ProtoInstruction(ScriptOps::ScriptOp paramOp, int32 paramArg);
+	ProtoInstruction(ProtoOp paramProtoOp, ScriptOps::ScriptOp paramOp, int32 paramArg);
+
+	ProtoOp protoOp;
+	ScriptOps::ScriptOp op;
+	int32 arg;
+};
+
+ProtoInstruction::ProtoInstruction() : protoOp(kProtoOpScript), op(ScriptOps::kInvalid), arg(0) {
+}
+
+ProtoInstruction::ProtoInstruction(ScriptOps::ScriptOp paramOp) : protoOp(kProtoOpScript), op(paramOp), arg(0) {
+}
+
+ProtoInstruction::ProtoInstruction(ScriptOps::ScriptOp paramOp, int32 paramArg) : protoOp(kProtoOpScript), op(paramOp), arg(paramArg) {
+}
+
+ProtoInstruction::ProtoInstruction(ProtoOp paramProtoOp, ScriptOps::ScriptOp paramOp, int32 paramArg) : protoOp(paramProtoOp), op(paramOp), arg(paramArg) {
+}
+
+struct ProtoScript {
+	Common::Array<ProtoInstruction> instrs;
+
+	void reset();
+};
+
+void ProtoScript::reset() {
+	instrs.clear();
+}
+
+struct ScriptNamedInstruction {
+	const char *str;
+	ProtoOp protoOp;
+	ScriptOps::ScriptOp op;
+};
+
+class ScriptCompiler {
+public:
+	ScriptCompiler(TextParser &parser, const Common::String &blamePath);
+
+	void compileRoomScriptSet(ScriptSet *ss);
+
+private:
+	bool parseNumber(const Common::String &token, uint32 &outNumber) const;
+	static bool parseDecNumber(const Common::String &token, uint start, uint32 &outNumber);
+	static bool parseHexNumber(const Common::String &token, uint start, uint32 &outNumber);
+	void expectNumber(uint32 &outNumber);
+
+	void compileRoomScriptSet(RoomScriptSet *rss);
+	void compileScreenScriptSet(ScreenScriptSet *sss);
+	bool compileInstructionToken(ProtoScript &script, const Common::String &token);
+
+	void codeGenScript(ProtoScript &protoScript, Script &script);
+
+	uint indexString(const Common::String &str);
+
+	enum NumberParsingMode {
+		kNumberParsingDec,
+		kNumberParsingHex,
+	};
+
+	TextParser &_parser;
+	NumberParsingMode _numberParsingMode;
+	const Common::String _blamePath;
+
+	Common::HashMap<Common::String, uint> _stringToIndex;
+	Common::Array<Common::String> _strings;
+};
+
+ScriptCompiler::ScriptCompiler(TextParser &parser, const Common::String &blamePath) : _numberParsingMode(kNumberParsingHex), _parser(parser), _blamePath(blamePath) {
+}
+
+bool ScriptCompiler::parseNumber(const Common::String &token, uint32 &outNumber) const {
+	if (token.size() == 0)
+		return false;
+
+	if (token[0] == 'd')
+		return parseDecNumber(token, 1, outNumber);
+
+	if (token[0] == '0') {
+		switch (_numberParsingMode) {
+		case kNumberParsingDec:
+			return parseDecNumber(token, 0, outNumber);
+		case kNumberParsingHex:
+			return parseHexNumber(token, 0, outNumber);
+		default:
+			error("Unknown number parsing mode");
+			return false;
+		}
+	}
+
+	return false;
+}
+
+bool ScriptCompiler::parseDecNumber(const Common::String &token, uint start, uint32 &outNumber) {
+	if (start == token.size())
+		return false;
+
+	uint32 num = 0;
+	for (uint i = start; i < token.size(); i++) {
+		char c = token[i];
+		uint32 digit = 0;
+		if (c >= '0' && c <= '9')
+			digit = c - '0';
+		else
+			return false;
+
+		num = num * 10u + digit;
+	}
+
+	outNumber = num;
+	return true;
+}
+
+bool ScriptCompiler::parseHexNumber(const Common::String &token, uint start, uint32 &outNumber) {
+	if (start == token.size())
+		return false;
+
+	uint32 num = 0;
+	for (uint i = start; i < token.size(); i++) {
+		char c = token[i];
+		uint32 digit = 0;
+		if (c >= '0' && c <= '9')
+			digit = c - '0';
+		else if (c >= 'a' && c <= 'f')
+			digit = (c - 'a') + 0xa;
+		else
+			return false;
+
+		num = num * 16u + digit;
+	}
+
+	outNumber = num;
+	return true;
+}
+
+void ScriptCompiler::expectNumber(uint32 &outNumber) {
+	TextParserState state;
+	Common::String token;
+	if (_parser.parseToken(token, state)) {
+		if (!parseNumber(token, outNumber))
+			error("Error compiling script at line %i col %i: Expected number but found '%s'", static_cast<int>(state._lineNum), static_cast<int>(state._col), token.c_str());
+	} else {
+		error("Error compiling script at line %i col %i: Expected number", static_cast<int>(state._lineNum), static_cast<int>(state._col));
+	}
+}
+
+void ScriptCompiler::compileRoomScriptSet(ScriptSet *ss) {
+	Common::SharedPtr<RoomScriptSet> roomScript;
+	uint roomID = 0;
+
+	TextParserState state;
+	Common::String token;
+	while (_parser.parseToken(token, state)) {
+		if (token == "~ROOM") {
+			if (roomScript)
+				error("Error compiling script at line %i col %i: Encountered ~ROOM without ~EROOM", static_cast<int>(state._lineNum), static_cast<int>(state._col));
+			roomScript.reset(new RoomScriptSet());
+
+			uint32 roomNumber = 0;
+			expectNumber(roomNumber);
+
+			ss->roomScripts[roomNumber] = roomScript;
+
+			compileRoomScriptSet(roomScript.get());
+		} else {
+			error("Error compiling script at line %i col %i: Expected ~ROOM and found '%s'", static_cast<int>(state._lineNum), static_cast<int>(state._col), token.c_str());
+		}
+	}
+
+	ss->strings = Common::move(_strings);
+}
+
+void ScriptCompiler::compileRoomScriptSet(RoomScriptSet *rss) {
+	TextParserState state;
+	Common::String token;
+	while (_parser.parseToken(token, state)) {
+		if (token == "~EROOM") {
+			return;
+		} else if (token == "~SCR") {
+			uint32 screenNumber = 0;
+			expectNumber(screenNumber);
+
+			Common::SharedPtr<ScreenScriptSet> sss(new ScreenScriptSet());
+			compileScreenScriptSet(sss.get());
+
+			rss->screenScripts[screenNumber] = sss;
+		} else {
+			error("Error compiling script at line %i col %i: Expected ~EROOM or ~SCR and found '%s'", static_cast<int>(state._lineNum), static_cast<int>(state._col), token.c_str());
+		}
+	}
+
+	error("Error compiling script: Room wasn't terminated");
+}
+
+void ScriptCompiler::compileScreenScriptSet(ScreenScriptSet *sss) {
+	TextParserState state;
+	Common::String token;
+
+	ProtoScript protoScript;
+	Common::SharedPtr<Script> currentScript(new Script());
+
+	sss->entryScript.reset(currentScript);
+
+	while (_parser.parseToken(token, state)) {
+		if (token == "~EROOM" || token == "~SCR") {
+			_parser.requeue(token, state);
+
+			codeGenScript(protoScript, *currentScript);
+			return;
+		} else if (token == "~*") {
+			uint32 interactionNumber = 0;
+			expectNumber(interactionNumber);
+
+			codeGenScript(protoScript, *currentScript);
+
+			currentScript.reset(new Script());
+
+			sss->interactionScripts[interactionNumber] = currentScript;
+		} else if (compileInstructionToken(protoScript, token)) {
+			// Nothing
+		} else {
+			error("Error compiling script at line %i col %i: Expected ~EROOM or ~SCR or ~* or instruction but found '%s'", static_cast<int>(state._lineNum), static_cast<int>(state._col), token.c_str());
+		}
+	}
+}
+
+static ScriptNamedInstruction g_namedInstructions[] = {
+	{"rotate", ProtoOp::kProtoOpScript, ScriptOps::kRotate},
+	{"angle", ProtoOp::kProtoOpScript, ScriptOps::kAngle},
+	{"angleG@", ProtoOp::kProtoOpScript, ScriptOps::kAngleGGet},
+	{"speed", ProtoOp::kProtoOpScript, ScriptOps::kSpeed},
+	{"sanimL", ProtoOp::kProtoOpScript, ScriptOps::kSAnimL},
+	{"changeL", ProtoOp::kProtoOpScript, ScriptOps::kChangeL},
+	{"animR", ProtoOp::kProtoOpScript, ScriptOps::kAnimR},
+	{"animF", ProtoOp::kProtoOpScript, ScriptOps::kAnimF},
+	{"animN", ProtoOp::kProtoOpScript, ScriptOps::kAnimN},
+	{"animG", ProtoOp::kProtoOpScript, ScriptOps::kAnimG},
+	{"animS", ProtoOp::kProtoOpScript, ScriptOps::kAnimS},
+	{"anim", ProtoOp::kProtoOpScript, ScriptOps::kAnim},
+	{"static", ProtoOp::kProtoOpScript, ScriptOps::kStatic},
+	{"yes@", ProtoOp::kProtoOpScript, ScriptOps::kVarLoad},
+	{"yes!", ProtoOp::kProtoOpScript, ScriptOps::kVarStore},
+	{"cursor!", ProtoOp::kProtoOpScript, ScriptOps::kSetCursor},
+	{"room!", ProtoOp::kProtoOpScript, ScriptOps::kSetRoom},
+	{"lmb", ProtoOp::kProtoOpScript, ScriptOps::kLMB},
+	{"lmb1", ProtoOp::kProtoOpScript, ScriptOps::kLMB1},
+	{"volumeDn4", ProtoOp::kProtoOpScript, ScriptOps::kVolumeDn4},
+	{"volumeUp3", ProtoOp::kProtoOpScript, ScriptOps::kVolumeUp3},
+	{"rnd", ProtoOp::kProtoOpScript, ScriptOps::kRandom},
+	{"drop", ProtoOp::kProtoOpScript, ScriptOps::kDrop},
+	{"dup", ProtoOp::kProtoOpScript, ScriptOps::kDup},
+	{"say3", ProtoOp::kProtoOpScript, ScriptOps::kSay3},
+	{"setTimer", ProtoOp::kProtoOpScript, ScriptOps::kSetTimer},
+	{"lo!", ProtoOp::kProtoOpScript, ScriptOps::kLoSet},
+	{"lo@", ProtoOp::kProtoOpScript, ScriptOps::kLoGet},
+	{"hi!", ProtoOp::kProtoOpScript, ScriptOps::kHiSet},
+	{"hi@", ProtoOp::kProtoOpScript, ScriptOps::kHiGet},
+
+	{"and", ProtoOp::kProtoOpScript, ScriptOps::kAnd},
+	{"or", ProtoOp::kProtoOpScript, ScriptOps::kOr},
+	{"not", ProtoOp::kProtoOpScript, ScriptOps::kNot},
+	{"=", ProtoOp::kProtoOpScript, ScriptOps::kCmpEq},
+
+	{"bit@", ProtoOp::kProtoOpScript, ScriptOps::kBitLoad},
+	{"bit0!", ProtoOp::kProtoOpScript, ScriptOps::kBitSet0},
+	{"bit1!", ProtoOp::kProtoOpScript, ScriptOps::kBitSet1},
+
+	{"soundS1", ProtoOp::kProtoOpScript, ScriptOps::kSoundS1},
+	{"soundL2", ProtoOp::kProtoOpScript, ScriptOps::kSoundL2},
+	{"music", ProtoOp::kProtoOpScript, ScriptOps::kMusic},
+	{"musicUp", ProtoOp::kProtoOpScript, ScriptOps::kMusicUp},
+
+	{"parm1", ProtoOp::kProtoOpScript, ScriptOps::kParm1},
+	{"parm2", ProtoOp::kProtoOpScript, ScriptOps::kParm2},
+	{"parm3", ProtoOp::kProtoOpScript, ScriptOps::kParm3},
+	{"parmG", ProtoOp::kProtoOpScript, ScriptOps::kParmG},
+
+	{"disc1", ProtoOp::kProtoOpScript, ScriptOps::kDisc1},
+	{"disc2", ProtoOp::kProtoOpScript, ScriptOps::kDisc2},
+	{"disc3", ProtoOp::kProtoOpScript, ScriptOps::kDisc3},
+
+	{"#if", ProtoOp::kProtoOpIf, ScriptOps::kInvalid},
+	{"#eif", ProtoOp::kProtoOpEndIf, ScriptOps::kInvalid},
+	{"#else", ProtoOp::kProtoOpElse, ScriptOps::kInvalid},
+
+	{"#switch:", ProtoOp::kProtoOpSwitch, ScriptOps::kInvalid},
+	{"#eswitch", ProtoOp::kProtoOpEndSwitch, ScriptOps::kInvalid},
+	{"break", ProtoOp::kProtoOpBreak, ScriptOps::kInvalid},
+	{"#default", ProtoOp::kProtoOpDefault, ScriptOps::kInvalid},
+
+	{"esc_on", ProtoOp::kProtoOpScript, ScriptOps::kEscOn},
+	{"esc_off", ProtoOp::kProtoOpScript, ScriptOps::kEscOff},
+	{"esc_get@", ProtoOp::kProtoOpScript, ScriptOps::kEscGet},
+	{"backStart", ProtoOp::kProtoOpScript, ScriptOps::kBackStart},
+};
+
+bool ScriptCompiler::compileInstructionToken(ProtoScript &script, const Common::String &token) {
+	uint32 number = 0;
+	if (parseNumber(token, number)) {
+		script.instrs.push_back(ProtoInstruction(ScriptOps::kNumber, number));
+		return true;
+	}
+
+	if (token.size() >= 1 && token[0] == ':') {
+		if (token.size() >= 3 && token[2] == ':') {
+			if (token[1] == 'Y') {
+				script.instrs.push_back(ProtoInstruction(ScriptOps::kVarName, indexString(token.substr(3))));
+				return true;
+			} else if (token[1] == 'V') {
+				script.instrs.push_back(ProtoInstruction(ScriptOps::kValueName, indexString(token.substr(3))));
+				return true;
+			} else
+				return false;
+		}
+
+		script.instrs.push_back(ProtoInstruction(ScriptOps::kAnimName, indexString(token.substr(1))));
+		return true;
+	}
+
+	if (token.size() >= 2 && token[0] == '_') {
+		script.instrs.push_back(ProtoInstruction(ScriptOps::kSoundName, indexString(token.substr(1))));
+		return true;
+	}
+
+	if (token.size() >= 5 && token[0] == 'C' && token[1] == 'U' && token[2] == 'R' && token[3] == '_') {
+		script.instrs.push_back(ProtoInstruction(ScriptOps::kCursorName, indexString(token)));
+		return true;
+	}
+
+	if (token == "#switch") {
+		_parser.expect(":", _blamePath);
+		script.instrs.push_back(ProtoInstruction(kProtoOpSwitch, ScriptOps::kInvalid, 0));
+		return true;
+	}
+
+	if (token == "#case") {
+		uint32 caseNumber = 0;
+		_parser.expect(":", _blamePath);
+		expectNumber(caseNumber);
+
+		script.instrs.push_back(ProtoInstruction(kProtoOpCase, ScriptOps::kInvalid, caseNumber));
+		return true;
+	}
+
+	if (token == "#case:") {
+		uint32 caseNumber = 0;
+		expectNumber(caseNumber);
+
+		script.instrs.push_back(ProtoInstruction(kProtoOpCase, ScriptOps::kInvalid, caseNumber));
+		return true;
+	}
+
+	for (const ScriptNamedInstruction &namedInstr : g_namedInstructions) {
+		if (token == namedInstr.str) {
+			script.instrs.push_back(ProtoInstruction(namedInstr.protoOp, namedInstr.op, 0));
+			return true;
+		}
+	}
+
+	return false;
+}
+
+enum CodeGenFlowControlBlockType {
+	kFlowControlInvalid,
+
+	kFlowControlIf,
+	kFlowControlSwitch,
+};
+
+struct CodeGenControlFlowBlock {
+	CodeGenControlFlowBlock();
+
+	CodeGenFlowControlBlockType type;
+	uint index;
+};
+
+CodeGenControlFlowBlock::CodeGenControlFlowBlock() : type(kFlowControlInvalid), index(0) {
+}
+
+struct CodeGenSwitchCase {
+	CodeGenSwitchCase();
+
+	int32 value;
+	uint label;
+};
+
+CodeGenSwitchCase::CodeGenSwitchCase() : value(0), label(0) {
+}
+
+struct CodeGenSwitch {
+	CodeGenSwitch();
+
+	Common::Array<CodeGenSwitchCase> cases;
+
+	uint endLabel;
+
+	uint defaultLabel;
+	bool hasDefault;
+};
+
+CodeGenSwitch::CodeGenSwitch() : defaultLabel(0), endLabel(0), hasDefault(false) {
+}
+
+struct CodeGenIf {
+	CodeGenIf();
+
+	uint endLabel;
+
+	uint elseLabel;
+	bool hasElse;
+};
+
+CodeGenIf::CodeGenIf() : endLabel(0), elseLabel(0), hasElse(false) {
+}
+
+
+void ScriptCompiler::codeGenScript(ProtoScript &protoScript, Script &script) {
+	Common::Array<ProtoInstruction> instrs;
+	Common::Array<CodeGenSwitch> switches;
+	Common::Array<CodeGenIf> ifs;
+	Common::Array<CodeGenControlFlowBlock> controlFlowStack;
+
+	int32 nextLabel = 0;
+
+	// Pass 1: Convert all flow control constructs into references to the flow control construct.
+	// This changes Switch, If, and Break proto-ops to point to the corresponding if or switch index
+	for (const ProtoInstruction &instr : protoScript.instrs) {
+		switch (instr.protoOp) {
+		case kProtoOpScript:
+			instrs.push_back(instr);
+			break;
+		case kProtoOpBreak: {
+			bool found = false;
+			for (uint ri = 0; ri < controlFlowStack.size(); ri++) {
+				const CodeGenControlFlowBlock &cf = controlFlowStack[controlFlowStack.size() - 1 - ri];
+				if (cf.type == kFlowControlSwitch) {
+					found = true;
+					instrs.push_back(ProtoInstruction(kProtoOpBreak, ScriptOps::kInvalid, cf.index));
+					break;
+				}
+			}
+
+			if (!found)
+				error("Error in codegen: break statement outside of a switch case");
+		} break;
+		case kProtoOpIf: {
+			CodeGenControlFlowBlock cf;
+			cf.type = kFlowControlIf;
+			cf.index = ifs.size();
+			controlFlowStack.push_back(cf);
+
+			CodeGenIf ifBlock;
+			ifBlock.endLabel = nextLabel++;
+			ifs.push_back(ifBlock);
+
+			instrs.push_back(ProtoInstruction(kProtoOpIf, ScriptOps::kInvalid, cf.index));
+		} break;
+		case kProtoOpElse: {
+			if (controlFlowStack.size() == 0)
+				error("Error in codegen: #else outside of control flow");
+
+			CodeGenControlFlowBlock &cf = controlFlowStack[controlFlowStack.size() - 1];
+
+			if (cf.type != kFlowControlIf)
+				error("Error in codegen: #else inside wrong control block type");
+
+			CodeGenIf &ifBlock = ifs[cf.index];
+
+			if (ifBlock.hasElse)
+				error("Error in codegen: #else already set for #if block");
+
+			ifBlock.hasElse = true;
+			ifBlock.elseLabel = nextLabel++;
+
+			instrs.push_back(ProtoInstruction(kProtoOpJumpToLabel, ScriptOps::kInvalid, ifBlock.endLabel));
+			instrs.push_back(ProtoInstruction(kProtoOpLabel, ScriptOps::kInvalid, ifBlock.elseLabel));
+		} break;
+		case kProtoOpEndIf: {
+			if (controlFlowStack.size() == 0)
+				error("Error in codegen: #eif outside of control flow");
+
+			CodeGenControlFlowBlock &cf = controlFlowStack[controlFlowStack.size() - 1];
+
+			if (cf.type != kFlowControlIf)
+				error("Error in codegen: #eif inside wrong control block type");
+
+			const CodeGenIf &ifBlock = ifs[cf.index];
+
+			instrs.push_back(ProtoInstruction(kProtoOpLabel, ScriptOps::kInvalid, ifBlock.endLabel));
+
+			controlFlowStack.pop_back();
+		} break;
+		case kProtoOpSwitch: {
+			CodeGenControlFlowBlock cf;
+			cf.type = kFlowControlSwitch;
+			cf.index = switches.size();
+			controlFlowStack.push_back(cf);
+
+			CodeGenSwitch switchBlock;
+			switchBlock.endLabel = nextLabel++;
+			switches.push_back(switchBlock);
+
+			instrs.push_back(ProtoInstruction(kProtoOpSwitch, ScriptOps::kInvalid, cf.index));
+		} break;
+		case kProtoOpCase: {
+			if (controlFlowStack.size() == 0)
+				error("Error in codegen: #case outside of control flow");
+
+			CodeGenControlFlowBlock &cf = controlFlowStack[controlFlowStack.size() - 1];
+
+			if (cf.type != kFlowControlSwitch)
+				error("Error in codegen: #case inside wrong control block type");
+
+			CodeGenSwitch &switchBlock = switches[cf.index];
+
+			CodeGenSwitchCase caseDef;
+			caseDef.label = nextLabel++;
+			caseDef.value = instr.arg;
+
+			switchBlock.cases.push_back(caseDef);
+
+			instrs.push_back(ProtoInstruction(kProtoOpLabel, ScriptOps::kInvalid, caseDef.label));
+		} break;
+		case kProtoOpDefault: {
+			if (controlFlowStack.size() == 0)
+				error("Error in codegen: #case outside of control flow");
+
+			CodeGenControlFlowBlock &cf = controlFlowStack[controlFlowStack.size() - 1];
+
+			if (cf.type != kFlowControlSwitch)
+				error("Error in codegen: #case inside wrong control block type");
+
+			CodeGenSwitch &switchBlock = switches[cf.index];
+
+			if (switchBlock.hasDefault)
+				error("Error in codegen: #switch already has a default");
+
+			switchBlock.hasDefault = true;
+			switchBlock.defaultLabel = nextLabel++;
+
+			instrs.push_back(ProtoInstruction(kProtoOpLabel, ScriptOps::kInvalid, switchBlock.defaultLabel));
+		} break;
+		case kProtoOpEndSwitch: {
+			if (controlFlowStack.size() == 0)
+				error("Error in codegen: #eswitch outside of control flow");
+
+			CodeGenControlFlowBlock &cf = controlFlowStack[controlFlowStack.size() - 1];
+
+			if (cf.type != kFlowControlSwitch)
+				error("Error in codegen: #eswitch inside wrong control block type");
+
+			const CodeGenSwitch &switchBlock = switches[cf.index];
+
+			instrs.push_back(ProtoInstruction(kProtoOpLabel, ScriptOps::kInvalid, switchBlock.endLabel));
+
+			controlFlowStack.pop_back();
+		} break;
+		default:
+			error("Internal error: Unhandled proto-op");
+			break;
+		}
+	}
+
+	if (controlFlowStack.size() > 0)
+		error("Error in codegen: Unterminated flow control construct");
+
+	Common::Array<ProtoInstruction> instrs2;
+
+	Common::HashMap<uint, uint> labelToInstr;
+
+	// Pass 2: Convert CF block references into label-targeting ops
+	// This eliminates If, Switch, and Break ops
+	for (const ProtoInstruction &instr : instrs) {
+		switch (instr.protoOp) {
+		case kProtoOpScript:
+		case kProtoOpJumpToLabel:
+			instrs2.push_back(instr);
+			break;
+		case kProtoOpIf: {
+			const CodeGenIf &ifBlock = ifs[instr.arg];
+
+			instrs2.push_back(ProtoInstruction(ScriptOps::kCheckValue, 0));
+			instrs2.push_back(ProtoInstruction(kProtoOpJumpToLabel, ScriptOps::kInvalid, ifBlock.hasElse ? ifBlock.elseLabel : ifBlock.endLabel));
+			instrs2.push_back(ProtoInstruction(ScriptOps::kDrop));
+		} break;
+		case kProtoOpSwitch: {
+			const CodeGenSwitch &switchBlock = switches[instr.arg];
+
+			for (const CodeGenSwitchCase &caseDef : switchBlock.cases) {
+				instrs2.push_back(ProtoInstruction(ScriptOps::kCheckValue, caseDef.value));
+				instrs2.push_back(ProtoInstruction(kProtoOpJumpToLabel, ScriptOps::kInvalid, caseDef.value));
+			}
+
+			instrs2.push_back(ProtoInstruction(ScriptOps::kDrop));
+			instrs2.push_back(ProtoInstruction(kProtoOpJumpToLabel, ScriptOps::kInvalid, switchBlock.hasDefault ? switchBlock.defaultLabel : switchBlock.endLabel));
+		} break;
+		case kProtoOpLabel:
+			labelToInstr[static_cast<uint>(instr.arg)] = instrs2.size();
+			break;
+		case kProtoOpBreak: {
+			const CodeGenSwitch &switchBlock = switches[instr.arg];
+
+			instrs2.push_back(ProtoInstruction(kProtoOpJumpToLabel, ScriptOps::kInvalid, switchBlock.endLabel));
+		} break;
+		default:
+			error("Internal error: Unhandled proto-op");
+			break;
+		}
+	}
+
+	instrs.clear();
+
+	// Pass 3: Resolve labels and write out finished instructions
+	script.instrs.reserve(instrs2.size());
+
+	for (const ProtoInstruction &instr : instrs2) {
+		switch (instr.protoOp) {
+		case kProtoOpScript:
+			script.instrs.push_back(Instruction(instr.op, instr.arg));
+			break;
+		case kProtoOpJumpToLabel: {
+			Common::HashMap<uint, uint>::const_iterator it = labelToInstr.find(static_cast<uint>(instr.arg));
+			if (it == labelToInstr.end())
+				error("Internal error: Unmatched label");
+
+			script.instrs.push_back(Instruction(ScriptOps::kJump, it->_value));
+		} break;
+		default:
+			error("Internal error: Unhandled proto-op");
+			break;
+		}
+	}
+}
+
+uint ScriptCompiler::indexString(const Common::String &str) {
+	Common::HashMap<Common::String, uint>::const_iterator it = _stringToIndex.find(str);
+	if (it == _stringToIndex.end()) {
+		uint index = _strings.size();
+		_stringToIndex[str] = index;
+		_strings.push_back(str);
+		return index;
+	}
+
+	return it->_value;
+}
+
+Common::SharedPtr<ScriptSet> compileLogicFile(Common::ReadStream &stream, uint streamSize, const Common::String &blamePath) {
+
+	uint cipherOffset = 255u - (streamSize % 255u);
+
+	LogicUnscrambleStream unscrambleStream(&stream, streamSize);
+	TextParser parser(&unscrambleStream);
+
+	Common::SharedPtr<ScriptSet> scriptSet(new ScriptSet());
+
+	ScriptCompiler compiler(parser, blamePath);
+
+	compiler.compileRoomScriptSet(scriptSet.get());
+
+	return scriptSet;
+}
+
+} // namespace VCruise

--- a/engines/vcruise/script.h
+++ b/engines/vcruise/script.h
@@ -1,0 +1,145 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef VCRUISE_SCRIPT_H
+#define VCRUISE_SCRIPT_H
+
+#include "common/array.h"
+#include "common/hashmap.h"
+#include "common/ptr.h"
+#include "common/types.h"
+
+namespace Common {
+
+class ReadStream;
+
+} // End of namespace Common
+
+namespace VCruise {
+
+namespace ScriptOps {
+
+enum ScriptOp {
+	kInvalid,
+
+	kNumber,
+
+	kRotate,
+	kAngle,
+	kAngleGGet,
+	kSpeed,
+	kSAnimL,
+	kChangeL,
+	kAnimR,
+	kAnimF,
+	kAnimN,
+	kAnimG,
+	kAnimS,
+	kAnim,
+	kStatic,
+	kVarLoad,
+	kVarStore,
+	kSetCursor,
+	kSetRoom,
+	kLMB,
+	kLMB1,
+	kSoundS1,
+	kSoundL2,
+	kMusic,
+	kMusicUp,
+	kParm1,
+	kParm2,
+	kParm3,
+	kParmG,
+	kVolumeDn4,
+	kVolumeUp3,
+	kRandom,
+	kDrop,
+	kDup,
+	kSay3,
+	kSetTimer,
+	kLoSet,
+	kLoGet,
+	kHiSet,
+	kHiGet,
+
+	kNot,
+	kAnd,
+	kOr,
+	kCmpEq,
+
+	kBitLoad,
+	kBitSet0,
+	kBitSet1,
+
+	kDisc1,
+	kDisc2,
+	kDisc3,
+
+	kEscOn,
+	kEscOff,
+	kEscGet,
+	kBackStart,
+
+	kAnimName,
+	kValueName,
+	kVarName,
+	kSoundName,
+	kCursorName,
+
+	kCheckValue,	// Check if stack top is equal to arg.  If it is, pop the argument, otherwise leave it on the stack and skip the next instruction.
+	kJump,			// Offset instruction index by arg.
+};
+
+} // End of namespace ScriptOps
+
+struct Instruction {
+	Instruction();
+	explicit Instruction(ScriptOps::ScriptOp paramOp);
+	Instruction(ScriptOps::ScriptOp paramOp, int32 paramArg);
+
+	ScriptOps::ScriptOp op;
+	int32 arg;
+};
+
+struct Script {
+	Common::Array<Instruction> instrs;
+};
+
+struct ScreenScriptSet {
+	Common::SharedPtr<Script> entryScript;
+	Common::HashMap<uint, Common::SharedPtr<Script> > interactionScripts;
+};
+
+struct RoomScriptSet {
+	Common::HashMap<uint, Common::SharedPtr<ScreenScriptSet> > screenScripts;
+};
+
+struct ScriptSet {
+	Common::HashMap<uint, Common::SharedPtr<RoomScriptSet> > roomScripts;
+	Common::Array<Common::String> strings;
+};
+
+Common::SharedPtr<ScriptSet> compileLogicFile(Common::ReadStream &stream, uint streamSize, const Common::String &blamePath);
+
+}
+
+#endif

--- a/engines/vcruise/script.h
+++ b/engines/vcruise/script.h
@@ -35,6 +35,10 @@ class ReadStream;
 
 namespace VCruise {
 
+struct ScreenScriptSet;
+struct RoomScriptSet;
+struct ScriptSet;
+
 namespace ScriptOps {
 
 enum ScriptOp {
@@ -127,17 +131,21 @@ struct Script {
 	Common::Array<Instruction> instrs;
 };
 
+typedef Common::HashMap<uint, Common::SharedPtr<Script> > ScriptMap_t;
+typedef Common::HashMap<uint, Common::SharedPtr<ScreenScriptSet> > ScreenScriptSetMap_t;
+typedef Common::HashMap<uint, Common::SharedPtr<RoomScriptSet> > RoomScriptSetMap_t;
+
 struct ScreenScriptSet {
 	Common::SharedPtr<Script> entryScript;
-	Common::HashMap<uint, Common::SharedPtr<Script> > interactionScripts;
+	ScriptMap_t interactionScripts;
 };
 
 struct RoomScriptSet {
-	Common::HashMap<uint, Common::SharedPtr<ScreenScriptSet> > screenScripts;
+	ScreenScriptSetMap_t screenScripts;
 };
 
 struct ScriptSet {
-	Common::HashMap<uint, Common::SharedPtr<RoomScriptSet> > roomScripts;
+	RoomScriptSetMap_t roomScripts;
 	Common::Array<Common::String> strings;
 };
 

--- a/engines/vcruise/script.h
+++ b/engines/vcruise/script.h
@@ -107,6 +107,8 @@ enum ScriptOp {
 
 	kCheckValue,	// Check if stack top is equal to arg.  If it is, pop the argument, otherwise leave it on the stack and skip the next instruction.
 	kJump,			// Offset instruction index by arg.
+
+	kNumOps,
 };
 
 } // End of namespace ScriptOps

--- a/engines/vcruise/script.h
+++ b/engines/vcruise/script.h
@@ -65,6 +65,7 @@ enum ScriptOp {
 	kSoundL2,
 	kMusic,
 	kMusicUp,
+	kMusicDn,
 	kParm1,
 	kParm2,
 	kParm3,

--- a/engines/vcruise/textparser.cpp
+++ b/engines/vcruise/textparser.cpp
@@ -133,43 +133,8 @@ void TextParser::expectInt(int &outInt, const Common::String &blamePath) {
 	TextParserState state;
 	expectTokenInternal(token, blamePath, state);
 
-	int result = 0;
-	bool isNegative = false;
-	uint startIndex = 0;
-	if (token[0] == '-') {
-		if (token.size() == 1)
-			error("Parsing error in '%s' at line %i col %i: Signed integer was malformed", blamePath.c_str(), static_cast<int>(state._lineNum), static_cast<int>(state._col));
-
-		isNegative = true;
-		startIndex = 1;
-	}
-
-	int base = 10;
-	bool isHex = (token.size() >= (startIndex) + 3 && token[startIndex] == '0' && token[startIndex + 1] == 'x');
-	if (isHex) {
-		startIndex += 2;
-		base = 16;
-	}
-
-	for (uint i = startIndex; i < token.size(); i++) {
-		char c = token[i];
-		int digit = 0;
-		if (c >= '0' && c <= '9')
-			digit = (c - '0');
-		else if (isHex && (c >= 'a' && c <= 'f'))
-			digit = (c - 'a') + 0xa;
-		else if (isHex && (c >= 'A' && c <= 'F'))
-			digit = (c - 'A') + 0xa;
-		else
-			error("Parsing error in '%s' at line %i col %i: Integer contained non-digits", blamePath.c_str(), static_cast<int>(state._lineNum), static_cast<int>(state._col));
-
-		if (isNegative)
-			digit = -digit;
-
-		result = result * base + digit;
-	}
-
-	outInt = result;
+	if (!sscanf(token.c_str(), "%i", &outInt))
+		error("Parsing error in '%s' at line %i col %i: Integer was malformed", blamePath.c_str(), static_cast<int>(state._lineNum), static_cast<int>(state._col));
 }
 
 void TextParser::expectUInt(uint &outUInt, const Common::String &blamePath) {
@@ -177,19 +142,8 @@ void TextParser::expectUInt(uint &outUInt, const Common::String &blamePath) {
 	TextParserState state;
 	expectTokenInternal(token, blamePath, state);
 
-	uint result = 0;
-
-	for (uint i = 0; i < token.size(); i++) {
-		char c = token[i];
-		if (c < '0' || c > '9')
-			error("Parsing error in '%s' at line %i col %i: Integer contained non-digits", blamePath.c_str(), static_cast<int>(state._lineNum), static_cast<int>(state._col));
-
-		uint additional = c - '0';
-
-		result = result * 10 + additional;
-	}
-
-	outUInt = result;
+	if (!sscanf(token.c_str(), "%u", &outUInt))
+		error("Parsing error in '%s' at line %i col %i: Unsigned integer was malformed", blamePath.c_str(), static_cast<int>(state._lineNum), static_cast<int>(state._col));
 }
 
 void TextParser::expectLine(Common::String &outToken, const Common::String &blamePath, bool continueToNextLine) {

--- a/engines/vcruise/textparser.cpp
+++ b/engines/vcruise/textparser.cpp
@@ -1,0 +1,322 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/stream.h"
+#include "common/textconsole.h"
+
+#include "vcruise/textparser.h"
+
+namespace VCruise {
+
+TextParserState::TextParserState() : _lineNum(1), _col(1), _prevWasCR(false), _isParsingComment(false) {
+}
+
+TextParser::TextParser(Common::ReadStream *stream) : _stream(stream), _readBufferPos(0), _readBufferEnd(0), _returnBufferPos(kReturnBufferSize) {
+	memset(_readBuffer, 0, kReadBufferSize);
+	memset(_returnedBuffer, 0, kReturnBufferSize);
+}
+
+bool TextParser::readOneChar(char &outC, TextParserState &outState) {
+	if (_returnBufferPos == kReturnBufferSize) {
+		if (_readBufferPos == _readBufferEnd) {
+			if (_stream->eos())
+				return false;
+
+			_readBufferPos = 0;
+			_readBufferEnd = _stream->read(_readBuffer, kReadBufferSize);
+			if (_readBufferEnd == 0)
+				return false;
+		}
+	}
+
+	char c = 0;
+
+	if (_returnBufferPos != kReturnBufferSize) {
+		c = _returnedBuffer[_returnBufferPos++];
+	} else {
+		c = _readBuffer[_readBufferPos++];
+	}
+
+	TextParserState prevState = _state;
+
+	if (c == '\r') {
+		_state._lineNum++;
+		_state._col = 1;
+		_state._isParsingComment = false;
+		_state._prevWasCR = true;
+	} else if (c == '\n') {
+		if (!_state._prevWasCR) {
+			_state._lineNum++;
+			_state._col = 1;
+		}
+		_state._prevWasCR = false;
+	} else {
+		_state._col++;
+		_state._prevWasCR = false;
+
+		if (c == ';')
+			_state._isParsingComment = true;
+	}
+
+
+	outC = c;
+	outState = prevState;
+
+	return true;
+}
+
+bool TextParser::skipWhitespaceAndComments(char &outC, TextParserState &outState) {
+	char c = 0;
+	TextParserState firstCharState;
+
+	while (readOneChar(c, firstCharState)) {
+		if (isWhitespace(c))
+			continue;
+
+		if (_state._isParsingComment)
+			continue;
+
+		outC = c;
+		outState = firstCharState;
+		return true;
+	}
+
+	return false;
+}
+
+bool TextParser::isDelimiter(char c) {
+	if (c == ',' || c == '=' || c == '[' || c == ']')
+		return true;
+
+	return false;
+}
+
+bool TextParser::isWhitespace(char c) {
+	return (c == ' ') || ((c & 0xe0) == 0);
+}
+
+void TextParser::requeue(const char *chars, uint numChars, const TextParserState &state) {
+	_state = state;
+	assert(_returnBufferPos >= numChars);
+	_returnBufferPos -= numChars;
+	memcpy(_returnedBuffer + _returnBufferPos, chars, numChars);
+}
+
+void TextParser::requeue(const Common::String &str, const TextParserState &state) {
+	requeue(str.c_str(), str.size(), state);
+}
+
+void TextParser::expectToken(Common::String &outToken, const Common::String &blamePath) {
+	TextParserState state;
+	expectTokenInternal(outToken, blamePath, state);
+}
+
+void TextParser::expectShort(int16 &outInt, const Common::String &blamePath) {
+	int i;
+	expectInt(i, blamePath);
+	outInt = static_cast<int16>(i);
+}
+
+void TextParser::expectInt(int &outInt, const Common::String &blamePath) {
+	Common::String token;
+	TextParserState state;
+	expectTokenInternal(token, blamePath, state);
+
+	int result = 0;
+	bool isNegative = false;
+	uint startIndex = 0;
+	if (token[0] == '-') {
+		if (token.size() == 1)
+			error("Parsing error in '%s' at line %i col %i: Signed integer was malformed", blamePath.c_str(), static_cast<int>(state._lineNum), static_cast<int>(state._col));
+
+		isNegative = true;
+		startIndex = 1;
+	}
+
+	int base = 10;
+	bool isHex = (token.size() >= (startIndex) + 3 && token[startIndex] == '0' && token[startIndex + 1] == 'x');
+	if (isHex) {
+		startIndex += 2;
+		base = 16;
+	}
+
+	for (uint i = startIndex; i < token.size(); i++) {
+		char c = token[i];
+		int digit = 0;
+		if (c >= '0' && c <= '9')
+			digit = (c - '0');
+		else if (isHex && (c >= 'a' && c <= 'f'))
+			digit = (c - 'a') + 0xa;
+		else if (isHex && (c >= 'A' && c <= 'F'))
+			digit = (c - 'A') + 0xa;
+		else
+			error("Parsing error in '%s' at line %i col %i: Integer contained non-digits", blamePath.c_str(), static_cast<int>(state._lineNum), static_cast<int>(state._col));
+
+		if (isNegative)
+			digit = -digit;
+
+		result = result * base + digit;
+	}
+
+	outInt = result;
+}
+
+void TextParser::expectUInt(uint &outUInt, const Common::String &blamePath) {
+	Common::String token;
+	TextParserState state;
+	expectTokenInternal(token, blamePath, state);
+
+	uint result = 0;
+
+	for (uint i = 0; i < token.size(); i++) {
+		char c = token[i];
+		if (c < '0' || c > '9')
+			error("Parsing error in '%s' at line %i col %i: Integer contained non-digits", blamePath.c_str(), static_cast<int>(state._lineNum), static_cast<int>(state._col));
+
+		uint additional = c - '0';
+
+		result = result * 10 + additional;
+	}
+
+	outUInt = result;
+}
+
+void TextParser::expectLine(Common::String &outToken, const Common::String &blamePath, bool continueToNextLine) {
+	outToken.clear();
+
+	char c = 0;
+	TextParserState state;
+
+	bool isSkippingWhitespace = true;
+	uint nonWhitespaceLength = 0;
+
+	while (readOneChar(c, state)) {
+		if (c == '\r' || c == '\n' || _state._isParsingComment) {
+			requeue(&c, 1, state);
+			if (continueToNextLine)
+				skipToEOL();
+			break;
+		}
+
+		bool cIsWhitespace = isWhitespace(c);
+		if (isSkippingWhitespace) {
+			if (cIsWhitespace)
+				continue;
+			isSkippingWhitespace = false;
+		}
+
+		outToken += c;
+		if (!cIsWhitespace)
+			nonWhitespaceLength = outToken.size();
+	}
+
+	if (nonWhitespaceLength != outToken.size())
+		outToken = outToken.substr(0, nonWhitespaceLength);
+}
+
+void TextParser::expect(const char *str, const Common::String &blamePath) {
+	Common::String token;
+	TextParserState state;
+	expectTokenInternal(token, blamePath, state);
+
+	if (token != str)
+		error("Parsing error in '%s' at line %i col %i: Expected token '%s' but found '%s'", blamePath.c_str(), static_cast<int>(state._lineNum), static_cast<int>(state._col), str, token.c_str());
+}
+
+void TextParser::skipToEOL() {
+	char c = 0;
+	TextParserState state;
+
+	while (readOneChar(c, state)) {
+		if (c == '\n')
+			return;
+
+		if (c == '\r') {
+			if (readOneChar(c, state)) {
+				if (c != '\n')
+					requeue(&c, 1, state);
+				return;
+			}
+		}
+	}
+}
+
+bool TextParser::checkEOL() {
+	char c = 0;
+	TextParserState state;
+
+	for (;;) {
+		if (!readOneChar(c, state))
+			return true;
+
+		if (_state._isParsingComment || c == '\n' || c == '\r') {
+			// EOL or comment
+			requeue(&c, 1, state);
+			return true;
+		}
+
+		if (!isWhitespace(c)) {
+			// Non-whitespace
+			requeue(&c, 1, state);
+			return false;
+		}
+	}
+}
+
+void TextParser::expectTokenInternal(Common::String &outToken, const Common::String &blamePath, TextParserState &outState) {
+	if (!parseToken(outToken, outState))
+		error("Parsing error in '%s' unexpected end of file", blamePath.c_str());
+}
+
+bool TextParser::parseToken(Common::String &outString, TextParserState &outState) {
+	outString.clear();
+
+	char c = 0;
+	TextParserState state;
+
+	if (!skipWhitespaceAndComments(c, state))
+		return false;
+
+	outState = state;
+
+	outString += c;
+
+	if (isDelimiter(c))
+		return true;
+
+	while (readOneChar(c, state)) {
+		if (isWhitespace(c) || _state._isParsingComment) {
+			requeue(&c, 1, state);
+			return true;
+		}
+
+		if (isDelimiter(c)) {
+			requeue(&c, 1, state);
+			return true;
+		}
+
+		outString += c;
+	}
+
+	return true;
+}
+
+} // End of namespace VCruise

--- a/engines/vcruise/textparser.h
+++ b/engines/vcruise/textparser.h
@@ -1,0 +1,91 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef VCRUISE_TEXTPARSER_H
+#define VCRUISE_TEXTPARSER_H
+
+#include "common/str.h"
+#include "common/memstream.h"
+
+namespace Common {
+
+class ReadStream;
+
+} // End of namespace Common
+
+namespace VCruise {
+
+struct TextParserState {
+	TextParserState();
+
+	uint _lineNum;
+	uint _col;
+	bool _prevWasCR;
+	bool _isParsingComment;
+};
+
+class TextParser {
+public:
+	explicit TextParser(Common::ReadStream *stream);
+
+	bool parseToken(Common::String &outString, TextParserState &outState);
+
+	bool readOneChar(char &outC, TextParserState &outState);
+	bool skipWhitespaceAndComments(char &outC, TextParserState &outState);
+
+	void requeue(const char *chars, uint numChars, const TextParserState &state);
+	void requeue(const Common::String &str, const TextParserState &state);
+
+	void expectToken(Common::String &outToken, const Common::String &blamePath);
+	void expectShort(int16 &outInt, const Common::String &blamePath);
+	void expectInt(int &outInt, const Common::String &blamePath);
+	void expectUInt(uint &outUInt, const Common::String &blamePath);
+	void expectLine(Common::String &outToken, const Common::String &blamePath, bool continueToNextLine);
+
+	void expect(const char *str, const Common::String &blamePath);
+
+	void skipToEOL();
+	bool checkEOL();
+
+private:
+	void expectTokenInternal(Common::String &outToken, const Common::String &blamePath, TextParserState &outState);
+
+	static bool isDelimiter(char c);
+	static bool isWhitespace(char c);
+
+	TextParserState _state;
+
+	Common::ReadStream *_stream;
+
+	static const uint kReadBufferSize = 4096;
+	static const uint kReturnBufferSize = 8;
+
+	char _returnedBuffer[kReturnBufferSize];
+	uint _returnBufferPos;
+
+	char _readBuffer[kReadBufferSize];
+	uint _readBufferPos;
+	uint _readBufferEnd;
+};
+
+} // End of namespace VCruise
+
+#endif

--- a/engines/vcruise/textparser.h
+++ b/engines/vcruise/textparser.h
@@ -75,15 +75,10 @@ private:
 
 	Common::ReadStream *_stream;
 
-	static const uint kReadBufferSize = 4096;
-	static const uint kReturnBufferSize = 8;
+	static const uint kReturnedBufferSize = 8;
 
-	char _returnedBuffer[kReturnBufferSize];
-	uint _returnBufferPos;
-
-	char _readBuffer[kReadBufferSize];
-	uint _readBufferPos;
-	uint _readBufferEnd;
+	char _returnedBuffer[kReturnedBufferSize];
+	uint _returnedBufferPos;
 };
 
 } // End of namespace VCruise

--- a/engines/vcruise/vcruise.cpp
+++ b/engines/vcruise/vcruise.cpp
@@ -1,0 +1,157 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "engines/util.h"
+
+#include "common/config-manager.h"
+#include "common/events.h"
+#include "common/system.h"
+#include "common/algorithm.h"
+
+#include "vcruise/runtime.h"
+#include "vcruise/vcruise.h"
+
+namespace VCruise {
+
+VCruiseEngine::VCruiseEngine(OSystem *syst, const VCruiseGameDescription *gameDesc) : Engine(syst), _gameDescription(gameDesc) {
+	const Common::FSNode gameDataDir(ConfMan.get("path"));
+}
+
+VCruiseEngine::~VCruiseEngine() {
+}
+
+void VCruiseEngine::handleEvents() {
+	Common::Event evt;
+	Common::EventManager *eventMan = _system->getEventManager();
+
+	while (eventMan->pollEvent(evt)) {
+		switch (evt.type) {
+		default:
+			break;
+		}
+	}
+}
+
+Common::Error VCruiseEngine::run() {
+	Common::List<Graphics::PixelFormat> pixelFormats = _system->getSupportedFormats();
+
+	const Graphics::PixelFormat *fmt16 = nullptr;
+	const Graphics::PixelFormat *fmt32 = nullptr;
+
+	for (const Graphics::PixelFormat &fmt : pixelFormats) {
+		if (fmt.rBits() == 8 && fmt.gBits() == 8 && fmt.bBits() == 8)
+			fmt32 = &fmt;
+		if ((fmt.rBits() + fmt.gBits() + fmt.bBits()) == 16)
+			fmt16 = &fmt;
+	}
+
+	// Figure out screen layout
+	Common::Point size;
+
+	Common::Point videoSize;
+	Common::Point traySize;
+	Common::Point menuBarSize;
+	const char *exeName = nullptr;
+
+	if (_gameDescription->gameID == GID_REAH) {
+		videoSize = Common::Point(608, 348);
+		menuBarSize = Common::Point(640, 44);
+		traySize = Common::Point(640, 88);
+		exeName = "Reah.exe";
+	} else if (_gameDescription->gameID == GID_SCHIZM) {
+		videoSize = Common::Point(640, 360);
+		menuBarSize = Common::Point(640, 32);
+		traySize = Common::Point(640, 88);
+		exeName = "Schizm.exe";
+	} else {
+		error("Unknown game");
+	}
+
+	size.x = videoSize.x;
+	if (menuBarSize.x > size.x)
+		size.x = menuBarSize.x;
+	if (traySize.x > size.x)
+		size.x = traySize.x;
+
+	size.y = videoSize.y + menuBarSize.y + traySize.y;
+
+	Common::Point menuTL = Common::Point((size.x - menuBarSize.x) / 2, 0);
+	Common::Point videoTL = Common::Point((size.x - videoSize.x) / 2, menuTL.y);
+	Common::Point trayTL = Common::Point((size.x - traySize.x) / 2, videoTL.y);
+
+	_menuBarRect = Common::Rect(menuTL.x, menuTL.y, menuTL.x + menuBarSize.x, menuTL.y + menuBarSize.y);
+	_videoRect = Common::Rect(videoTL.x, videoTL.y, videoTL.x + videoSize.x, videoTL.y + videoSize.y);
+	_trayRect = Common::Rect(trayTL.x, trayTL.y, trayTL.x + traySize.x, trayTL.y + traySize.y);
+
+	if (fmt32)
+		initGraphics(size.x, size.y, fmt32);
+	else if (fmt16)
+		initGraphics(size.x, size.y, fmt16);
+	else
+		error("Unable to find a suitable graphics format");
+
+	_runtime.reset(new Runtime(_system));
+
+	_runtime->loadCursors(exeName);
+
+	// Run the game
+	while (!shouldQuit()) {
+		handleEvents();
+
+		if (!_runtime->runFrame())
+			break;
+
+		_runtime->drawFrame();
+		_system->delayMillis(10);
+	}
+
+	_runtime.reset();
+
+	return Common::kNoError;
+}
+
+void VCruiseEngine::pauseEngineIntern(bool pause) {
+	Engine::pauseEngineIntern(pause);
+}
+
+bool VCruiseEngine::hasFeature(EngineFeature f) const {
+	switch (f) {
+	case kSupportsReturnToLauncher:
+	case kSupportsSavingDuringRuntime:
+		return true;
+	default:
+		return false;
+	};
+}
+
+Common::Error VCruiseEngine::saveGameStream(Common::WriteStream *stream, bool isAutosave) {
+	return Common::Error(Common::kUnknownError);
+}
+
+bool VCruiseEngine::canSaveAutosaveCurrently() {
+	return false;
+}
+
+bool VCruiseEngine::canSaveGameStateCurrently() {
+	return false;
+}
+
+} // End of namespace VCruise

--- a/engines/vcruise/vcruise.cpp
+++ b/engines/vcruise/vcruise.cpp
@@ -108,7 +108,7 @@ Common::Error VCruiseEngine::run() {
 	else
 		error("Unable to find a suitable graphics format");
 
-	_runtime.reset(new Runtime(_system));
+	_runtime.reset(new Runtime(_system, _rootFSNode, _gameDescription->gameID));
 
 	_runtime->loadCursors(exeName);
 
@@ -152,6 +152,12 @@ bool VCruiseEngine::canSaveAutosaveCurrently() {
 
 bool VCruiseEngine::canSaveGameStateCurrently() {
 	return false;
+}
+
+void VCruiseEngine::initializePath(const Common::FSNode &gamePath) {
+	Engine::initializePath(gamePath);
+
+	_rootFSNode = gamePath;
 }
 
 } // End of namespace VCruise

--- a/engines/vcruise/vcruise.cpp
+++ b/engines/vcruise/vcruise.cpp
@@ -65,14 +65,17 @@ void VCruiseEngine::handleEvents() {
 Common::Error VCruiseEngine::run() {
 	Common::List<Graphics::PixelFormat> pixelFormats = _system->getSupportedFormats();
 
-	const Graphics::PixelFormat *fmt16 = nullptr;
+	const Graphics::PixelFormat *fmt16_565 = nullptr;
+	const Graphics::PixelFormat *fmt16_555 = nullptr;
 	const Graphics::PixelFormat *fmt32 = nullptr;
 
 	for (const Graphics::PixelFormat &fmt : pixelFormats) {
-		if (fmt.rBits() == 8 && fmt.gBits() == 8 && fmt.bBits() == 8)
+		if (fmt32 == nullptr && fmt.bytesPerPixel == 4 && fmt.rBits() == 8 && fmt.gBits() == 8 && fmt.bBits() == 8)
 			fmt32 = &fmt;
-		if ((fmt.rBits() + fmt.gBits() + fmt.bBits()) == 16)
-			fmt16 = &fmt;
+		if (fmt16_555 == nullptr && fmt.rBits() == 5 && fmt.gBits() == 5 && fmt.bBits() == 5)
+			fmt16_555 = &fmt;
+		if (fmt16_565 == nullptr && fmt.rBits() == 5 && fmt.gBits() == 6 && fmt.bBits() == 5)
+			fmt16_565 = &fmt;
 	}
 
 	// Figure out screen layout
@@ -115,8 +118,10 @@ Common::Error VCruiseEngine::run() {
 
 	if (fmt32)
 		initGraphics(size.x, size.y, fmt32);
-	else if (fmt16)
-		initGraphics(size.x, size.y, fmt16);
+	else if (fmt16_565)
+		initGraphics(size.x, size.y, fmt16_565);
+	else if (fmt16_555)
+		initGraphics(size.x, size.y, fmt16_555);
 	else
 		error("Unable to find a suitable graphics format");
 

--- a/engines/vcruise/vcruise.cpp
+++ b/engines/vcruise/vcruise.cpp
@@ -34,7 +34,7 @@ namespace VCruise {
 VCruiseEngine::VCruiseEngine(OSystem *syst, const VCruiseGameDescription *gameDesc) : Engine(syst), _gameDescription(gameDesc) {
 	const Common::FSNode gameDataDir(ConfMan.get("path"));
 
-	SearchMan.addDirectory(gameDataDir.getPath(), gameDataDir);
+	SearchMan.addDirectory(gameDataDir.getPath(), gameDataDir, 0, 2);
 }
 
 VCruiseEngine::~VCruiseEngine() {

--- a/engines/vcruise/vcruise.cpp
+++ b/engines/vcruise/vcruise.cpp
@@ -94,8 +94,8 @@ Common::Error VCruiseEngine::run() {
 	size.y = videoSize.y + menuBarSize.y + traySize.y;
 
 	Common::Point menuTL = Common::Point((size.x - menuBarSize.x) / 2, 0);
-	Common::Point videoTL = Common::Point((size.x - videoSize.x) / 2, menuTL.y);
-	Common::Point trayTL = Common::Point((size.x - traySize.x) / 2, videoTL.y);
+	Common::Point videoTL = Common::Point((size.x - videoSize.x) / 2, menuTL.y + menuBarSize.y);
+	Common::Point trayTL = Common::Point((size.x - traySize.x) / 2, videoTL.y + videoSize.y);
 
 	_menuBarRect = Common::Rect(menuTL.x, menuTL.y, menuTL.x + menuBarSize.x, menuTL.y + menuBarSize.y);
 	_videoRect = Common::Rect(videoTL.x, videoTL.y, videoTL.x + videoSize.x, videoTL.y + videoSize.y);
@@ -108,7 +108,10 @@ Common::Error VCruiseEngine::run() {
 	else
 		error("Unable to find a suitable graphics format");
 
-	_runtime.reset(new Runtime(_system, _rootFSNode, _gameDescription->gameID));
+	_system->fillScreen(0);
+
+	_runtime.reset(new Runtime(_system, _mixer, _rootFSNode, _gameDescription->gameID));
+	_runtime->initSections(_videoRect, _menuBarRect, _trayRect, _system->getScreenFormat());
 
 	_runtime->loadCursors(exeName);
 

--- a/engines/vcruise/vcruise.cpp
+++ b/engines/vcruise/vcruise.cpp
@@ -44,6 +44,18 @@ void VCruiseEngine::handleEvents() {
 
 	while (eventMan->pollEvent(evt)) {
 		switch (evt.type) {
+		case Common::EVENT_LBUTTONDOWN:
+			_runtime->onLButtonDown(evt.mouse.x, evt.mouse.y);
+			break;
+		case Common::EVENT_LBUTTONUP:
+			_runtime->onLButtonUp(evt.mouse.x, evt.mouse.y);
+			break;
+		case Common::EVENT_MOUSEMOVE:
+			_runtime->onMouseMove(evt.mouse.x, evt.mouse.y);
+			break;
+		case Common::EVENT_KEYDOWN:
+			_runtime->onKeyDown(evt.kbd.keycode);
+			break;
 		default:
 			break;
 		}

--- a/engines/vcruise/vcruise.cpp
+++ b/engines/vcruise/vcruise.cpp
@@ -33,6 +33,8 @@ namespace VCruise {
 
 VCruiseEngine::VCruiseEngine(OSystem *syst, const VCruiseGameDescription *gameDesc) : Engine(syst), _gameDescription(gameDesc) {
 	const Common::FSNode gameDataDir(ConfMan.get("path"));
+
+	SearchMan.addDirectory(gameDataDir.getPath(), gameDataDir);
 }
 
 VCruiseEngine::~VCruiseEngine() {
@@ -84,18 +86,15 @@ Common::Error VCruiseEngine::run() {
 	Common::Point videoSize;
 	Common::Point traySize;
 	Common::Point menuBarSize;
-	const char *exeName = nullptr;
 
 	if (_gameDescription->gameID == GID_REAH) {
 		videoSize = Common::Point(608, 348);
 		menuBarSize = Common::Point(640, 44);
 		traySize = Common::Point(640, 88);
-		exeName = "Reah.exe";
 	} else if (_gameDescription->gameID == GID_SCHIZM) {
 		videoSize = Common::Point(640, 360);
 		menuBarSize = Common::Point(640, 32);
 		traySize = Common::Point(640, 88);
-		exeName = "Schizm.exe";
 	} else {
 		error("Unknown game");
 	}
@@ -130,6 +129,8 @@ Common::Error VCruiseEngine::run() {
 	_runtime.reset(new Runtime(_system, _mixer, _rootFSNode, _gameDescription->gameID));
 	_runtime->initSections(_videoRect, _menuBarRect, _trayRect, _system->getScreenFormat());
 
+	const char *exeName = _gameDescription->desc.filesDescriptions[0].fileName;
+
 	_runtime->loadCursors(exeName);
 
 	if (ConfMan.getBool("vcruise_debug")) {
@@ -159,7 +160,7 @@ void VCruiseEngine::pauseEngineIntern(bool pause) {
 bool VCruiseEngine::hasFeature(EngineFeature f) const {
 	switch (f) {
 	case kSupportsReturnToLauncher:
-	case kSupportsSavingDuringRuntime:
+	//case kSupportsSavingDuringRuntime:
 		return true;
 	default:
 		return false;

--- a/engines/vcruise/vcruise.cpp
+++ b/engines/vcruise/vcruise.cpp
@@ -132,6 +132,10 @@ Common::Error VCruiseEngine::run() {
 
 	_runtime->loadCursors(exeName);
 
+	if (ConfMan.getBool("vcruise_debug")) {
+		_runtime->setDebugMode(true);
+	}
+
 	// Run the game
 	while (!shouldQuit()) {
 		handleEvents();

--- a/engines/vcruise/vcruise.h
+++ b/engines/vcruise/vcruise.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef VCRUISE_VCRUISE_H
-#define VCRUISE_VCRUISE_H
+#ifndef VCRUISE_H
+#define VCRUISE_H
 
 #include "engines/engine.h"
 #include "common/rect.h"
@@ -76,4 +76,4 @@ private:
 
 } // End of namespace VCruise
 
-#endif /* VCRUISE_VCRUISE_H */
+#endif /* VCRUISE_H */

--- a/engines/vcruise/vcruise.h
+++ b/engines/vcruise/vcruise.h
@@ -1,0 +1,75 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef VCRUISE_VCRUISE_H
+#define VCRUISE_VCRUISE_H
+
+#include "engines/engine.h"
+#include "common/rect.h"
+
+#include "vcruise/runtime.h"
+#include "vcruise/detection.h"
+
+/**
+ * This is the namespace of the V-Cruise engine.
+ *
+ * Status of this engine: ???
+ *
+ * Games using this engine:
+ * - Reah: Face the Unknown
+ * - Schizm: Mysterious Journey
+ */
+namespace VCruise {
+
+class VCruiseEngine : public ::Engine {
+protected:
+	// Engine APIs
+	Common::Error run() override;
+
+public:
+	VCruiseEngine(OSystem *syst, const VCruiseGameDescription *gameDesc);
+	~VCruiseEngine() override;
+
+	bool hasFeature(EngineFeature f) const override;
+	//void syncSoundSettings() override;
+
+	const VCruiseGameDescription *_gameDescription;
+
+	Common::Error saveGameStream(Common::WriteStream *stream, bool isAutosave) override;
+	bool canSaveAutosaveCurrently() override;
+	bool canSaveGameStateCurrently() override;
+
+protected:
+	void pauseEngineIntern(bool pause) override;
+
+private:
+	void handleEvents();
+
+	Common::Rect _videoRect;
+	Common::Rect _menuBarRect;
+	Common::Rect _trayRect;
+
+	Common::SharedPtr<Runtime> _runtime;
+};
+
+} // End of namespace VCruise
+
+#endif /* VCRUISE_VCRUISE_H */

--- a/engines/vcruise/vcruise.h
+++ b/engines/vcruise/vcruise.h
@@ -57,6 +57,8 @@ public:
 	bool canSaveAutosaveCurrently() override;
 	bool canSaveGameStateCurrently() override;
 
+	void initializePath(const Common::FSNode &gamePath) override;
+
 protected:
 	void pauseEngineIntern(bool pause) override;
 
@@ -66,6 +68,8 @@ private:
 	Common::Rect _videoRect;
 	Common::Rect _menuBarRect;
 	Common::Rect _trayRect;
+
+	Common::FSNode _rootFSNode;
 
 	Common::SharedPtr<Runtime> _runtime;
 };

--- a/video/avi_decoder.cpp
+++ b/video/avi_decoder.cpp
@@ -383,8 +383,8 @@ void AVIDecoder::readStreamName(uint32 size) {
 		skipChunk(size);
 	} else {
 		// Get in the name
-		assert(size > 0 && size < 64);
-		char buffer[64];
+		assert(size > 0 && size < 128);
+		char buffer[128];
 		_fileStream->read(buffer, size);
 		if (size & 1)
 			_fileStream->skip(1);

--- a/video/avi_decoder.h
+++ b/video/avi_decoder.h
@@ -58,6 +58,7 @@ namespace Video {
  *  - sword1
  *  - sword2
  *  - titanic
+ *  - vcruise
  *  - zvision
  */
 class AVIDecoder : public VideoDecoder {


### PR DESCRIPTION
This adds initial support for the V-Cruise engine used by Reah: Face the Unknown and Schizm: Mysterious Journey and initial detection for Reah.  (I actually need to figure out the detection some more because the GOG version and DVD version only ship English VO.)

This is very preliminary right now, right now it boots Reah to the intro cinematic and then gets stuck at the opening screen, I'm working on getting navigation implemented.

Documentation of its formats (and a decoder/encoder for the scripts) currently resides at https://github.com/elasota/vcr, everything is documented except for yet-to-be-understood script ops and the "morph" format which was added in Schizm.

The biggest change to core is the addition of cursor masks.  Reah uses a magnifying glass cursor where the lens part is inverted, unfortunately ScummVM only supports color key cursors.  This tries to add the groundwork (i.e. mode values and feature flags) for fully supporting the Windows and classic MacOS cursor formats, although only total inversion is supported in OpenGL right now.