### PR TITLE
OPENGL: Properly take extra pixels into account when using scalers

### DIFF
--- a/backends/graphics/opengl/texture.cpp
+++ b/backends/graphics/opengl/texture.cpp
@@ -573,6 +573,11 @@ void ScaledTexture::updateGLTexture() {
 
 	Common::Rect dirtyArea = getDirtyArea();
 
+	// Extend the dirty region for scalers
+	// that "smear" the screen, e.g. 2xSAI
+	dirtyArea.grow(_extraPixels);
+	dirtyArea.clip(Common::Rect(0, 0, _rgbData.w, _rgbData.h));
+
 	const byte *src = (const byte *)_rgbData.getBasePtr(dirtyArea.left, dirtyArea.top);
 	uint srcPitch = _rgbData.pitch;
 	byte *dst;


### PR DESCRIPTION
As in SurfaceSDL, the dirty rect must be grown.
The operation is done in [surfacesdl-graphics.cpp:1677](https://github.com/scummvm/scummvm/blob/08b79f77c3377a0a04df53f23d4d877ad0162476/backends/graphics/surfacesdl/surfacesdl-graphics.cpp#L1677)

This should fix [#14168](https://bugs.scummvm.org/ticket/14168).