### PR TITLE
GRAPHICS: Add support for cursor masks and cursor inverted pixels

### DIFF
--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -99,7 +99,7 @@ public:
 
 	virtual bool showMouse(bool visible) = 0;
 	virtual void warpMouse(int x, int y) = 0;
-	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL) = 0;
+	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = nullptr, const byte *mask = nullptr) = 0;
 	virtual void setCursorPalette(const byte *colors, uint start, uint num) = 0;
 
 	virtual void displayMessageOnOSD(const Common::U32String &msg) {}

--- a/backends/graphics/null/null-graphics.h
+++ b/backends/graphics/null/null-graphics.h
@@ -83,7 +83,7 @@ public:
 
 	bool showMouse(bool visible) override { return !visible; }
 	void warpMouse(int x, int y) override {}
-	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL) override {}
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override {}
 	void setCursorPalette(const byte *colors, uint start, uint num) override {}
 
 private:

--- a/backends/graphics/opengl/framebuffer.cpp
+++ b/backends/graphics/opengl/framebuffer.cpp
@@ -119,6 +119,14 @@ void Framebuffer::applyBlendState() {
 			GL_CALL(glEnable(GL_BLEND));
 			GL_CALL(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
 			break;
+		case kBlendModeAdditive:
+			GL_CALL(glEnable(GL_BLEND));
+			GL_CALL(glBlendFunc(GL_ONE, GL_ONE));
+			break;
+		case kBlendModeMaskAlphaAndInvertByColor:
+			GL_CALL(glEnable(GL_BLEND));
+			GL_CALL(glBlendFunc(GL_ONE_MINUS_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA));
+			break;
 		default:
 			break;
 	}

--- a/backends/graphics/opengl/framebuffer.h
+++ b/backends/graphics/opengl/framebuffer.h
@@ -59,7 +59,18 @@ public:
 		 * Requires the image data being drawn to have its color values pre-multipled
 		 * with the alpha value.
 		 */
-		kBlendModePremultipliedTransparency
+		kBlendModePremultipliedTransparency,
+
+		/**
+		 * Newly drawn pixels add to the destination value.
+		 */
+		kBlendModeAdditive,
+
+		/**
+		 * Newly drawn pixels mask out existing pixels based on the alpha value and
+		 * add inversions of the pixels based on the color.
+		 */
+		kBlendModeMaskAlphaAndInvertByColor,
 	};
 
 	/**

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -119,7 +119,7 @@ public:
 	void clearOverlay() override;
 	void grabOverlay(Graphics::Surface &surface) const override;
 
-	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format) override;
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) override;
 	void setCursorPalette(const byte *colors, uint start, uint num) override;
 
 	void displayMessageOnOSD(const Common::U32String &msg) override;
@@ -130,6 +130,8 @@ public:
 	void grabPalette(byte *colors, uint start, uint num) const override;
 
 protected:
+	void renderCursor();
+
 	/**
 	 * Whether an GLES or GLES2 context is active.
 	 */
@@ -168,7 +170,7 @@ protected:
 	 * @param wantScaler Whether or not a software scaler should be used.
 	 * @return A pointer to the surface or nullptr on failure.
 	 */
-	Surface *createSurface(const Graphics::PixelFormat &format, bool wantAlpha = false, bool wantScaler = false);
+	Surface *createSurface(const Graphics::PixelFormat &format, bool wantAlpha = false, bool wantScaler = false, bool wantMask = false);
 
 	//
 	// Transaction support
@@ -375,6 +377,11 @@ protected:
 	Surface *_cursor;
 
 	/**
+	 * The rendering surface for the opacity and inversion mask (if any)
+	 */
+	Surface *_cursorMask;
+
+	/**
 	 * The X offset for the cursor hotspot in unscaled game coordinates.
 	 */
 	int _cursorHotspotX;
@@ -416,6 +423,11 @@ protected:
 	 * The key color.
 	 */
 	uint32 _cursorKeyColor;
+
+	/**
+	 * If true, use key color.
+	 */
+	bool _cursorUseKey;
 
 	/**
 	 * Whether no cursor scaling should be applied.

--- a/backends/graphics/opengl/texture.h
+++ b/backends/graphics/opengl/texture.h
@@ -194,6 +194,13 @@ public:
 	virtual void allocate(uint width, uint height) = 0;
 
 	/**
+	 * Assign a mask to the surface, where a byte value of 0 is black with 0 alpha and 1 is the normal color.
+	 *
+	 * @param mask   The mask data.
+	 */
+	virtual void setMask(const byte *mask) {}
+
+	/**
 	 * Copy image data to the surface.
 	 *
 	 * The format of the input data needs to match the format returned by
@@ -320,6 +327,7 @@ public:
 	~FakeTexture() override;
 
 	void allocate(uint width, uint height) override;
+	void setMask(const byte *mask) override;
 
 	Graphics::PixelFormat getFormat() const override { return _fakeFormat; }
 
@@ -336,6 +344,7 @@ protected:
 	Graphics::Surface _rgbData;
 	Graphics::PixelFormat _fakeFormat;
 	uint32 *_palette;
+	uint8 *_mask;
 };
 
 class TextureRGB555 : public FakeTexture {

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -1954,8 +1954,11 @@ void SurfaceSdlGraphicsManager::copyRectToOverlay(const void *buf, int pitch, in
 #pragma mark --- Mouse ---
 #pragma mark -
 
-void SurfaceSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keyColor, bool dontScale, const Graphics::PixelFormat *format) {
+void SurfaceSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keyColor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
 	bool formatChanged = false;
+
+	if (mask)
+		warning("SurfaceSdlGraphicsManager::setMouseCursor: Masks are not supported");
 
 	if (format) {
 #ifndef USE_RGB_COLOR

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -124,7 +124,7 @@ public:
 	int16 getOverlayHeight() const override { return _videoMode.overlayHeight; }
 	int16 getOverlayWidth() const override { return _videoMode.overlayWidth; }
 
-	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL) override;
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override;
 	void setCursorPalette(const byte *colors, uint start, uint num) override;
 
 #ifdef USE_OSD

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -759,9 +759,12 @@ void AndroidGraphics3dManager::updateCursorScaling() {
 void AndroidGraphics3dManager::setMouseCursor(const void *buf, uint w, uint h,
         int hotspotX, int hotspotY,
         uint32 keycolor, bool dontScale,
-        const Graphics::PixelFormat *format) {
+        const Graphics::PixelFormat *format, const byte *mask) {
 	ENTER("%p, %u, %u, %d, %d, %u, %d, %p", buf, w, h, hotspotX, hotspotY,
 	      keycolor, dontScale, format);
+
+	if (mask)
+		warning("AndroidGraphics3dManager::setMouseCursor: Masks are not supported");
 
 	GLTHREADCHECK;
 

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -760,8 +760,8 @@ void AndroidGraphics3dManager::setMouseCursor(const void *buf, uint w, uint h,
         int hotspotX, int hotspotY,
         uint32 keycolor, bool dontScale,
         const Graphics::PixelFormat *format, const byte *mask) {
-	ENTER("%p, %u, %u, %d, %d, %u, %d, %p", buf, w, h, hotspotX, hotspotY,
-	      keycolor, dontScale, format);
+	ENTER("%p, %u, %u, %d, %d, %u, %d, %p, %p", buf, w, h, hotspotX, hotspotY,
+	      keycolor, dontScale, format, mask);
 
 	if (mask)
 		warning("AndroidGraphics3dManager::setMouseCursor: Masks are not supported");

--- a/backends/graphics3d/android/android-graphics3d.h
+++ b/backends/graphics3d/android/android-graphics3d.h
@@ -109,7 +109,7 @@ public:
 	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX,
 	                            int hotspotY, uint32 keycolor,
 	                            bool dontScale,
-	                            const Graphics::PixelFormat *format) override;
+	                            const Graphics::PixelFormat *format, const byte *mask) override;
 	virtual void setCursorPalette(const byte *colors, uint start, uint num) override;
 
 	float getHiDPIScreenFactor() const override;

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
@@ -103,7 +103,7 @@ public:
 
 	// GraphicsManager API - Mouse
 	bool showMouse(bool visible) override;
-	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL) override {}
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override {}
 	void setCursorPalette(const byte *colors, uint start, uint num) override {}
 
 	// SdlGraphicsManager API

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -260,8 +260,8 @@ void ModularGraphicsBackend::warpMouse(int x, int y) {
 	_graphicsManager->warpMouse(x, y);
 }
 
-void ModularGraphicsBackend::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format) {
-	_graphicsManager->setMouseCursor(buf, w, h, hotspotX, hotspotY, keycolor, dontScale, format);
+void ModularGraphicsBackend::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
+	_graphicsManager->setMouseCursor(buf, w, h, hotspotX, hotspotY, keycolor, dontScale, format, mask);
 }
 
 void ModularGraphicsBackend::setCursorPalette(const byte *colors, uint start, uint num) {

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -115,7 +115,7 @@ public:
 
 	bool showMouse(bool visible) override final;
 	void warpMouse(int x, int y) override final;
-	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL) override final;
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override final;
 	void setCursorPalette(const byte *colors, uint start, uint num) override final;
 	bool lockMouse(bool lock) override final;
 

--- a/backends/platform/3ds/osystem-graphics.cpp
+++ b/backends/platform/3ds/osystem-graphics.cpp
@@ -767,12 +767,15 @@ void OSystem_3DS::setCursorDelta(float deltaX, float deltaY) {
 void OSystem_3DS::setMouseCursor(const void *buf, uint w, uint h,
 								 int hotspotX, int hotspotY,
 								 uint32 keycolor, bool dontScale,
-								 const Graphics::PixelFormat *format) {
+								 const Graphics::PixelFormat *format, const byte *mask) {
 	_cursorScalable = !dontScale;
 	_cursorHotspotX = hotspotX;
 	_cursorHotspotY = hotspotY;
 	_cursorKeyColor = keycolor;
 	_pfCursor = !format ? Graphics::PixelFormat::createFormatCLUT8() : *format;
+
+	if (mask)
+		warning("OSystem_3DS::setMouseCursor: Masks are not supported");
 
 	if (w != (uint)_cursor.w || h != (uint)_cursor.h || _cursor.format != _pfCursor) {
 		_cursor.create(w, h, _pfCursor);

--- a/backends/platform/3ds/osystem.h
+++ b/backends/platform/3ds/osystem.h
@@ -170,7 +170,7 @@ public:
 	void warpMouse(int x, int y);
 	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX,
 	                    int hotspotY, uint32 keycolor, bool dontScale = false,
-	                    const Graphics::PixelFormat *format = NULL);
+	                    const Graphics::PixelFormat *format = NULL, const byte *mask = NULL);
 	void setCursorPalette(const byte *colors, uint start, uint num);
 
 	// Transform point from touchscreen coords into gamescreen coords

--- a/backends/platform/dc/dc.h
+++ b/backends/platform/dc/dc.h
@@ -126,7 +126,7 @@ public:
   void warpMouse(int x, int y);
 
   // Set the bitmap that's used when drawing the cursor.
-  void setMouseCursor(const void *buf, uint w, uint h, int hotspot_x, int hotspot_y, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format);
+  void setMouseCursor(const void *buf, uint w, uint h, int hotspot_x, int hotspot_y, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask);
 
   // Replace the specified range of cursor the palette with new colors.
   void setCursorPalette(const byte *colors, uint start, uint num);

--- a/backends/platform/dc/display.cpp
+++ b/backends/platform/dc/display.cpp
@@ -295,8 +295,10 @@ void OSystem_Dreamcast::warpMouse(int x, int y)
 
 void OSystem_Dreamcast::setMouseCursor(const void *buf, uint w, uint h,
 				       int hotspot_x, int hotspot_y,
-				       uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format)
-{
+				       uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
+	if (mask)
+		warning("OSystem_Dreamcast::setMouseCursor: Masks are not supported");
+
   _ms_cur_w = w;
   _ms_cur_h = h;
 

--- a/backends/platform/ds/ds-graphics.cpp
+++ b/backends/platform/ds/ds-graphics.cpp
@@ -549,9 +549,12 @@ void OSystem_DS::warpMouse(int x, int y) {
 		_cursorPos = _screen->scaledToReal(x, y);
 }
 
-void OSystem_DS::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, u32 keycolor, bool dontScale, const Graphics::PixelFormat *format) {
+void OSystem_DS::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, u32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
 	if (!buf || w == 0 || h == 0)
 		return;
+
+	if (mask)
+		warning("OSystem_DS::setMouseCursor: Masks are not supported");
 
 	Graphics::PixelFormat actualFormat = format ? *format : _pfCLUT8;
 	if (_cursor.w != (int16)w || _cursor.h != (int16)h || _cursor.format != actualFormat)

--- a/backends/platform/ds/osystem_ds.h
+++ b/backends/platform/ds/osystem_ds.h
@@ -126,7 +126,7 @@ public:
 	virtual bool showMouse(bool visible);
 
 	virtual void warpMouse(int x, int y);
-	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, u32 keycolor, bool dontScale, const Graphics::PixelFormat *format);
+	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, u32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask);
 
 	virtual void addSysArchivesToSearchSet(Common::SearchSet &s, int priority);
 

--- a/backends/platform/ios7/ios7_osys_main.h
+++ b/backends/platform/ios7/ios7_osys_main.h
@@ -177,7 +177,7 @@ public:
 	bool showMouse(bool visible) override;
 
 	void warpMouse(int x, int y) override;
-	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor = 255, bool dontScale = false, const Graphics::PixelFormat *format = NULL) override;
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor = 255, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override;
 	void setCursorPalette(const byte *colors, uint start, uint num) override;
 
 	bool pollEvent(Common::Event &event) override;

--- a/backends/platform/ios7/ios7_osys_video.mm
+++ b/backends/platform/ios7/ios7_osys_video.mm
@@ -505,8 +505,8 @@ void OSystem_iOS7::dirtyFullOverlayScreen() {
 void OSystem_iOS7::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
 	//printf("setMouseCursor(%p, %u, %u, %i, %i, %u, %d, %p)\n", (const void *)buf, w, h, hotspotX, hotspotY, keycolor, dontScale, (const void *)format);
 
-	//if (mask)
-	//	printf("OSystem_iOS7::setMouseCursor: Masks are not supported");
+	if (mask)
+		printf("OSystem_iOS7::setMouseCursor: Masks are not supported");
 
 	const Graphics::PixelFormat pixelFormat = format ? *format : Graphics::PixelFormat::createFormatCLUT8();
 #if 0

--- a/backends/platform/ios7/ios7_osys_video.mm
+++ b/backends/platform/ios7/ios7_osys_video.mm
@@ -502,8 +502,11 @@ void OSystem_iOS7::dirtyFullOverlayScreen() {
 	}
 }
 
-void OSystem_iOS7::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format) {
+void OSystem_iOS7::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
 	//printf("setMouseCursor(%p, %u, %u, %i, %i, %u, %d, %p)\n", (const void *)buf, w, h, hotspotX, hotspotY, keycolor, dontScale, (const void *)format);
+
+	//if (mask)
+	//	printf("OSystem_iOS7::setMouseCursor: Masks are not supported");
 
 	const Graphics::PixelFormat pixelFormat = format ? *format : Graphics::PixelFormat::createFormatCLUT8();
 #if 0

--- a/backends/platform/iphone/osys_main.h
+++ b/backends/platform/iphone/osys_main.h
@@ -158,7 +158,7 @@ public:
 	virtual bool showMouse(bool visible);
 
 	virtual void warpMouse(int x, int y);
-	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor = 255, bool dontScale = false, const Graphics::PixelFormat *format = NULL);
+	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor = 255, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL);
 	virtual void setCursorPalette(const byte *colors, uint start, uint num);
 
 	virtual bool pollEvent(Common::Event &event);

--- a/backends/platform/iphone/osys_video.mm
+++ b/backends/platform/iphone/osys_video.mm
@@ -400,7 +400,7 @@ void OSystem_IPHONE::dirtyFullOverlayScreen() {
 	}
 }
 
-void OSystem_IPHONE::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format) {
+void OSystem_IPHONE::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
 	//printf("setMouseCursor(%p, %u, %u, %i, %i, %u, %d, %p)\n", (const void *)buf, w, h, hotspotX, hotspotY, keycolor, dontScale, (const void *)format);
 
 	const Graphics::PixelFormat pixelFormat = format ? *format : Graphics::PixelFormat::createFormatCLUT8();

--- a/backends/platform/n64/osys_n64.h
+++ b/backends/platform/n64/osys_n64.h
@@ -180,7 +180,7 @@ public:
 	virtual bool showMouse(bool visible);
 
 	virtual void warpMouse(int x, int y);
-	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format);
+	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask);
 	virtual void setCursorPalette(const byte *colors, uint start, uint num);
 
 	virtual bool pollEvent(Common::Event &event);

--- a/backends/platform/n64/osys_n64_base.cpp
+++ b/backends/platform/n64/osys_n64_base.cpp
@@ -766,8 +766,11 @@ void OSystem_N64::warpMouse(int x, int y) {
 	_dirtyOffscreen = true;
 }
 
-void OSystem_N64::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format) {
+void OSystem_N64::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
 	if (!w || !h) return;
+
+	if (mask)
+		warning("OSystem_DS::setMouseCursor: Masks are not supported");
 
 	_mouseHotspotX = hotspotX;
 	_mouseHotspotY = hotspotY;

--- a/backends/platform/n64/osys_n64_base.cpp
+++ b/backends/platform/n64/osys_n64_base.cpp
@@ -770,7 +770,7 @@ void OSystem_N64::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, 
 	if (!w || !h) return;
 
 	if (mask)
-		warning("OSystem_DS::setMouseCursor: Masks are not supported");
+		warning("OSystem_N64::setMouseCursor: Masks are not supported");
 
 	_mouseHotspotX = hotspotX;
 	_mouseHotspotY = hotspotY;

--- a/backends/platform/psp/osys_psp.cpp
+++ b/backends/platform/psp/osys_psp.cpp
@@ -305,8 +305,12 @@ void OSystem_PSP::warpMouse(int x, int y) {
 	_cursor.setXY(x, y);
 }
 
-void OSystem_PSP::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format) {
+void OSystem_PSP::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
 	DEBUG_ENTER_FUNC();
+
+	if (mask)
+		PSP_DEBUG_PRINT("OSystem_PSP::setMouseCursor: Masks are not supported");
+
 	_displayManager.waitUntilRenderFinished();
 	_pendingUpdate = false;
 

--- a/backends/platform/psp/osys_psp.h
+++ b/backends/platform/psp/osys_psp.h
@@ -114,7 +114,7 @@ public:
 	// Mouse related
 	bool showMouse(bool visible);
 	void warpMouse(int x, int y);
-	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format);
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask);
 
 	// Events and input
 	bool pollEvent(Common::Event &event);

--- a/backends/platform/wii/osystem.h
+++ b/backends/platform/wii/osystem.h
@@ -191,7 +191,7 @@ public:
 	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX,
 								int hotspotY, uint32 keycolor,
 								bool dontScale,
-								const Graphics::PixelFormat *format) override;
+								const Graphics::PixelFormat *format, const byte *mask) override;
 
 	bool pollEvent(Common::Event &event) override;
 	uint32 getMillis(bool skipRecord = false) override;

--- a/backends/platform/wii/osystem_gfx.cpp
+++ b/backends/platform/wii/osystem_gfx.cpp
@@ -657,7 +657,11 @@ void OSystem_Wii::warpMouse(int x, int y) {
 void OSystem_Wii::setMouseCursor(const void *buf, uint w, uint h, int hotspotX,
 									int hotspotY, uint32 keycolor,
 									bool dontScale,
-									const Graphics::PixelFormat *format) {
+									const Graphics::PixelFormat *format, const byte *mask) {
+
+	if (mask)
+		printf("OSystem_Wii::setMouseCursor: Masks are not supported\n");
+
 	gfx_tex_format_t tex_format = GFX_TF_PALETTE_RGB5A3;
 	uint tw, th;
 	uint32 oldKeycolor = _mouseKeyColor;

--- a/common/system.h
+++ b/common/system.h
@@ -121,6 +121,25 @@ enum Type {
 } // End of namespace LogMessageType
 
 /**
+* Pixel mask modes for cursor graphics.
+*/
+enum CursorMaskValue {
+	// Overlapped pixel is unchanged
+	kCursorMaskTransparent = 0,
+
+	// Overlapped pixel is replaced with the cursor pixel.
+	kCursorMaskOpaque = 1,
+
+	/** Fully inverts the overlapped pixel regardless of the cursor color data.
+	 *  Backend must support kFeatureCursorMaskInvert for this mode. */
+	kCursorMaskInvert = 2,
+
+	/** Inverts the overlapped pixel based on the cursor's color value.
+	  * Backend must support kFeatureCursorMaskInvertUsingColor for this mode. */
+	kCursorMaskInvertUsingColor = 3,
+};
+
+/**
  * Interface for ScummVM backends.
  *
  * If you want to port ScummVM to a system that is not currently
@@ -385,6 +404,24 @@ public:
 		 * The GUI also relies on this feature for mouse cursors.
 		 */
 		kFeatureCursorPalette,
+
+		/**
+		 * Backends supporting this feature allow specifying a mask for a
+		 * cursor instead of a key color.
+		 */
+		kFeatureCursorMask,
+
+		/**
+		 * Backends supporting this feature allow cursor masks to use mode kCursorMaskInvert in mask values,
+		 * which inverts the destination pixel.
+		 */
+		kFeatureCursorMaskInvert,
+
+		/**
+		 * Backends supporting this feature allow cursor masks to use mode kCursorMaskInvertUsingColor in the mask values,
+		 * which inverts the destination pixel based on the color value of the cursor.
+		 */
+		kFeatureCursorMaskInvertUsingColor,
 
 		/**
 		 * A backend has this feature if its overlay pixel format has an alpha
@@ -1312,11 +1349,13 @@ public:
 	 * @param keycolor  Transparency color value. This should not exceed the maximum color value of the specified format.
 	 *                  In case it does, the behavior is undefined. The backend might just error out or simply ignore the
 	 *                  value. (The SDL backend will just assert to prevent abuse of this).
+	 *                  This parameter does nothing if a mask is provided.
 	 * @param dontScale Whether the cursor should never be scaled. An exception is high ppi displays, where the cursor
 	 *                  might be too small to notice otherwise, these are allowed to scale the cursor anyway.
 	 * @param format    Pointer to the pixel format that the cursor graphic uses (0 means CLUT8).
+	 * @param mask      A mask containing values from the CursorMaskValue enum for each cursor pixel.
 	 */
-	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = nullptr) = 0;
+	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = nullptr, const byte *mask = nullptr) = 0;
 
 	/**
 	 * Replace the specified range of cursor palette with new colors.

--- a/common/system.h
+++ b/common/system.h
@@ -134,9 +134,8 @@ enum CursorMaskValue {
 	 *  Backend must support kFeatureCursorMaskInvert for this mode. */
 	kCursorMaskInvert = 2,
 
-	/** Inverts the overlapped pixel based on the cursor's color value.
-	  * Backend must support kFeatureCursorMaskInvertUsingColor for this mode. */
-	kCursorMaskInvertUsingColor = 3,
+	/** kFeatureCursorMaskInvertUsingColor for this mode. */
+	kCursorMaskPaletteXorColorXnor = 3,
 };
 
 /**
@@ -418,10 +417,11 @@ public:
 		kFeatureCursorMaskInvert,
 
 		/**
-		 * Backends supporting this feature allow cursor masks to use mode kCursorMaskInvertUsingColor in the mask values,
-		 * which inverts the destination pixel based on the color value of the cursor.
+		 * Backends supporting this feature allow cursor masks to use mode kCursorMaskPaletteXorColorXnor in the mask values,
+		 * which uses (Color XOR Destination) for CLUT8 blending and (Color XNOR Destination) for RGB blending.  This is
+		 * equivalent to Classic MacOS behavior for pixel colors other than black and white.
 		 */
-		kFeatureCursorMaskInvertUsingColor,
+		kFeatureCursorMaskPaletteXorColorXnor,
 
 		/**
 		 * A backend has this feature if its overlay pixel format has an alpha

--- a/common/system.h
+++ b/common/system.h
@@ -124,17 +124,20 @@ enum Type {
 * Pixel mask modes for cursor graphics.
 */
 enum CursorMaskValue {
-	// Overlapped pixel is unchanged
+	/** Overlapped pixel is unchanged */
 	kCursorMaskTransparent = 0,
 
-	// Overlapped pixel is replaced with the cursor pixel.
+	/** Overlapped pixel is replaced with the cursor pixel. */
 	kCursorMaskOpaque = 1,
 
 	/** Fully inverts the overlapped pixel regardless of the cursor color data.
 	 *  Backend must support kFeatureCursorMaskInvert for this mode. */
 	kCursorMaskInvert = 2,
 
-	/** kFeatureCursorMaskInvertUsingColor for this mode. */
+	/** Blends with mode (Destination AND Mask) XOR Color in palette modes, or
+	 *  (Destination AND Mask) XOR (NOT Color) in RGB modes, which is equivalent to
+	 *  Classic MacOS behavior for pixel colors other than black and white.
+	 *  Backend must support kFeatureCursorMaskPaletteXorColorXnor for this mode. */
 	kCursorMaskPaletteXorColorXnor = 3,
 };
 

--- a/engines/testbed/graphics.cpp
+++ b/engines/testbed/graphics.cpp
@@ -798,7 +798,7 @@ TestExitStatus GFXtests::maskedCursors() {
 		}
 
 		bool haveInverted = g_system->hasFeature(OSystem::kFeatureCursorMaskInvert);
-		bool haveInvertedColor = g_system->hasFeature(OSystem::kFeatureCursorMaskInvertUsingColor);
+		bool haveColorXorBlend = g_system->hasFeature(OSystem::kFeatureCursorMaskPaletteXorColorXnor);
 
 		// Fill middle column
 		for (int y = 0; y < 16; y++) {
@@ -812,7 +812,7 @@ TestExitStatus GFXtests::maskedCursors() {
 				maskData[(y + 0) * 16 + x + 11] = kCursorMaskTransparent;
 				maskData[(y + 4) * 16 + x + 11] = kCursorMaskOpaque;
 				maskData[(y + 8) * 16 + x + 11] = kCursorMaskInvert;
-				maskData[(y + 12) * 16 + x + 11] = kCursorMaskInvertUsingColor;
+				maskData[(y + 12) * 16 + x + 11] = kCursorMaskPaletteXorColorXnor;
 			}
 		}
 
@@ -823,7 +823,7 @@ TestExitStatus GFXtests::maskedCursors() {
 					maskData[y * 16 + x] = kCursorMaskTransparent;
 		}
 
-		if (!haveInvertedColor) {
+		if (!haveColorXorBlend) {
 			for (int y = 12; y < 16; y++)
 				for (int x = 0; x < 16; x++)
 					maskData[y * 16 + x] = kCursorMaskTransparent;
@@ -868,7 +868,7 @@ TestExitStatus GFXtests::maskedCursors() {
 			}
 		}
 
-		if (!haveInvertedColor) {
+		if (!haveColorXorBlend) {
 			if (!Testsuite::handleInteractiveInput("Was the part of the cursor to the right of the 'C' inverted according to the color to the left of it?", "Yes", "No", kOptionLeft)) {
 				return kTestFailed;
 			}
@@ -921,7 +921,7 @@ TestExitStatus GFXtests::maskedCursors() {
 				}
 			}
 
-			if (!haveInvertedColor) {
+			if (!haveColorXorBlend) {
 				if (!Testsuite::handleInteractiveInput("Was the part of the cursor to the right of the 'C' inverted according to the color to the left of it?", "Yes", "No", kOptionLeft)) {
 					return kTestFailed;
 				}

--- a/engines/testbed/graphics.cpp
+++ b/engines/testbed/graphics.cpp
@@ -740,6 +740,7 @@ TestExitStatus GFXtests::maskedCursors() {
 
 	TestExitStatus passed = kTestPassed;
 	bool isFeaturePresent = g_system->hasFeature(OSystem::kFeatureCursorMask);
+	bool haveCursorPalettes = g_system->hasFeature(OSystem::kFeatureCursorPalette);
 
 	g_system->delayMillis(1000);
 
@@ -836,6 +837,9 @@ TestExitStatus GFXtests::maskedCursors() {
 		
 		g_system->getPaletteManager()->setPalette(newPalette, 0, 4);
 
+		if (haveCursorPalettes)
+			g_system->setCursorPalette(newPalette, 0, 4);
+
 		CursorMan.replaceCursor(cursorData, 16, 16, 1, 1, 0, false, nullptr, maskData);
 		CursorMan.showMouse(true);
 		
@@ -862,13 +866,13 @@ TestExitStatus GFXtests::maskedCursors() {
 			return kTestFailed;
 		}
 
-		if (!haveInverted) {
+		if (haveInverted) {
 			if (!Testsuite::handleInteractiveInput("Was the part of the cursor to the right of the 'I' inverted?", "Yes", "No", kOptionLeft)) {
 				return kTestFailed;
 			}
 		}
 
-		if (!haveColorXorBlend) {
+		if (haveColorXorBlend) {
 			if (!Testsuite::handleInteractiveInput("Was the part of the cursor to the right of the 'C' inverted according to the color to the left of it?", "Yes", "No", kOptionLeft)) {
 				return kTestFailed;
 			}
@@ -915,13 +919,13 @@ TestExitStatus GFXtests::maskedCursors() {
 				return kTestFailed;
 			}
 
-			if (!haveInverted) {
+			if (haveInverted) {
 				if (!Testsuite::handleInteractiveInput("Was the part of the cursor to the right of the 'I' inverted?", "Yes", "No", kOptionLeft)) {
 					return kTestFailed;
 				}
 			}
 
-			if (!haveColorXorBlend) {
+			if (haveColorXorBlend) {
 				if (!Testsuite::handleInteractiveInput("Was the part of the cursor to the right of the 'C' inverted according to the color to the left of it?", "Yes", "No", kOptionLeft)) {
 					return kTestFailed;
 				}

--- a/engines/testbed/graphics.h
+++ b/engines/testbed/graphics.h
@@ -45,6 +45,7 @@ TestExitStatus fullScreenMode();
 TestExitStatus filteringMode();
 TestExitStatus aspectRatio();
 TestExitStatus palettizedCursors();
+TestExitStatus maskedCursors();
 TestExitStatus mouseMovements();
 TestExitStatus copyRectToScreen();
 TestExitStatus iconifyWindow();

--- a/graphics/cursor.h
+++ b/graphics/cursor.h
@@ -58,6 +58,9 @@ public:
 	/** Return the cursor's surface. */
 	virtual const byte *getSurface() const = 0;
 
+	/** Return the cursor's mask, if it has one. */
+	virtual const byte *getMask() const { return nullptr; }
+
 	/** Return the cursor's palette in RGB format. */
 	virtual const byte *getPalette() const = 0;
 	/** Return the starting index of the palette. */

--- a/graphics/cursorman.h
+++ b/graphics/cursorman.h
@@ -68,22 +68,25 @@ public:
 	 * can be safely freed afterwards.
 	 *
 	 * @param buf		New cursor data.
+	 * @param mask		New cursor data.
 	 * @param w			Width.
 	 * @param h			Height.
 	 * @param hotspotX	Hotspot X coordinate.
 	 * @param hotspotY	Hotspot Y coordinate.
 	 * @param keycolor	Color value for the transparent color. This cannot exceed
 	 *                  the maximum color value as defined by format.
+	 *                  Does nothing if mask is set.
 	 * @param dontScale	Whether the cursor should never be scaled. An exception are high PPI displays, where the cursor
 	 *                  would be too small to notice otherwise. These are allowed to scale the cursor anyway.
 	 * @param format	Pointer to the pixel format that the cursor graphic uses.
 	 *					CLUT8 will be used if this is null or not specified.
+	 * @param mask      Optional pointer to cursor mask containing values from the CursorMaskValue enum.
 	 *
 	 * @note It is acceptable for the buffer to be a null pointer. It is sometimes
 	 *       useful to push a "dummy" cursor and modify it later. The
 	 *       cursor will be added to the stack, but not to the backend.
 	 */
-	void pushCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL);
+	void pushCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL);
 
 	/**
 	 * Pop a cursor from the stack, and restore the previous one to the
@@ -100,18 +103,21 @@ public:
 	 * more optimized way of popping the old cursor before pushing the new one.
 	 *
 	 * @param buf		New cursor data.
+	 * @param mask		New cursor mask data.
 	 * @param w			Width.
 	 * @param h			Height.
 	 * @param hotspotX	Hotspot X coordinate.
 	 * @param hotspotY	Hotspot Y coordinate.
 	 * @param keycolor	Color value for the transparent color. This cannot exceed
 	 *                  the maximum color value as defined by format.
+	 *                  Does nothing if mask is set.
 	 * @param dontScale	Whether the cursor should never be scaled. An exception are high PPI displays, where the cursor
 	 *                  would be too small to notice otherwise. These are allowed to scale the cursor anyway.
 	 * @param format	Pointer to the pixel format that the cursor graphic uses,
 	 *					CLUT8 will be used if this is null or not specified.
+	 * @param mask      Optional pointer to cursor mask containing values from the CursorMaskValue enum.
 	 */
-	void replaceCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL);
+	void replaceCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = nullptr, const byte *mask = nullptr);
 
 	/**
 	 * Replace the current cursor on the stack.
@@ -211,6 +217,7 @@ private:
 
 	struct Cursor {
 		byte *_data;
+		byte *_mask;
 		bool _visible;
 		uint _width;
 		uint _height;
@@ -223,9 +230,9 @@ private:
 		uint _size;
 
 		// _format set to default by Graphics::PixelFormat default constructor
-		Cursor() : _data(0), _visible(false), _width(0), _height(0), _hotspotX(0), _hotspotY(0), _keycolor(0), _dontScale(false), _size(0) {}
+		Cursor() : _data(0), _mask(0), _visible(false), _width(0), _height(0), _hotspotX(0), _hotspotY(0), _keycolor(0), _dontScale(false), _size(0) {}
 
-		Cursor(const void *data, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL);
+		Cursor(const void *data, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask);
 		~Cursor();
 	};
 

--- a/graphics/cursorman.h
+++ b/graphics/cursorman.h
@@ -68,7 +68,6 @@ public:
 	 * can be safely freed afterwards.
 	 *
 	 * @param buf		New cursor data.
-	 * @param mask		New cursor data.
 	 * @param w			Width.
 	 * @param h			Height.
 	 * @param hotspotX	Hotspot X coordinate.


### PR DESCRIPTION
This adds support for explicit cursor masks instead of key color as well as inverted pixel masks.  The third mode (color XOR) is not currently supported by anything, it can in theory be implemented via glLogicOp in OpenGL 2.0 and GLES 2.0 but due to some tough problems with filtering, it's only really possible with either unscaled cursors or by rendering into the framebuffer instead of as an overlay with subpixel precision.

I'm not sure if any games actually use color XOR, it's definitely supported by classic MacOS and in theory could be supported on Windows but based on WDDM documentation, any invert color other than white may be undefined behavior on Windows.  So, I'm stubbing it out for completeness and so cursor loading code can try to handle it with a bit more elegance, but that's it.