### PR TITLE
SCUMM HE: Fix loading playbooks in Football 2002.

### DIFF
--- a/engines/scumm/he/logic/football.cpp
+++ b/engines/scumm/he/logic/football.cpp
@@ -473,7 +473,6 @@ int LogicHEfootball2002::getPlaybookFiles(int32 *args) {
 	// Now store the result in an array
 	int array = _vm->setupStringArray(output.size());
 	Common::strlcpy((char *)_vm->getStringAddress(array), output.c_str(), output.size() + 1);
-	_vm->getResourceSize(rtString, array);
 
 	// And store the array index in variable 108
 	writeScummVar(108, array);


### PR DESCRIPTION
This fixes a crash that occurs when trying to load and save a custom playbook file in Backyard Football 2002.  That line was randomly added in commit 3d39d206eeb7156562534fad5ba499781e5b79bd, and will always result in an assertion error.  That call wasn't here previously, and I do not see any reasoning behind it, so might as well get rid of it.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
