### PR TITLE
ASYLUM: Support hebrew fan-translation

### DIFF
--- a/engines/asylum/detection_tables.h
+++ b/engines/asylum/detection_tables.h
@@ -281,6 +281,21 @@ static const ADGameDescription gameDescriptions[] = {
 		GUIO0()
 	},
 	{
+		// Hebrew fanmade translation (GOG version)
+		"asylum",
+		"Fanmade",
+		{
+			{"SNTRM.DAT", 0, "7cfcc457c1f579fbf9878ac175d29374", 8930},
+			{"RES.005",   0, "02c06cb1cb4038203c027b53a5d71c05", 18064925},
+			{"SCN.006",   0, "3a5b54da08198012dc0614114782d5fb", 2918330},
+			AD_LISTEND
+		},
+		Common::HE_ISR,
+		Common::kPlatformWindows,
+		ADGF_DROPPLATFORM,
+		GUIO0()
+	},
+	{
 		// English Demo
 		"asylum",
 		"Demo",

--- a/engines/asylum/system/text.cpp
+++ b/engines/asylum/system/text.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "common/rational.h"
+#include "common/unicode-bidi.h"
 
 #include "asylum/system/text.h"
 
@@ -138,6 +139,8 @@ void Text::draw(const char *text) {
 	if (!text)
 		return;
 
+	if (_vm->getLanguage() == Common::HE_ISR)
+		text = Common::convertBiDiString(text, Common::kWindows1255).c_str();
 	while (*text) {
 		drawChar(text[0]);
 		text++;
@@ -151,6 +154,8 @@ void Text::draw(const char *text, int16 length) {
 	if (!text)
 		return;
 
+	if (_vm->getLanguage() == Common::HE_ISR)
+		text = Common::convertBiDiString(Common::String(text, length), Common::kWindows1255).c_str();
 	for (int16 i = 0; i < length; i++)
 		drawChar(text[i]);
 }


### PR DESCRIPTION
This adds BiDi text rendering support for the upcoming Hebrew fan-translation of Sanitarium.

RES.005 is used for detection as it's less likely to change (RES.005 contains chapter 1 fonts, RES.000 contains texts)

Thanks