### PR TITLE
AGOS: enable dedicated detection of Simon 1 for the 25th Anniversary edition with full English subtitles

### DIFF
--- a/engines/agos/agos.cpp
+++ b/engines/agos/agos.cpp
@@ -691,8 +691,14 @@ Common::Error AGOSEngine::init() {
 		_subtitles = ConfMan.getBool("subtitles");
 
 		if (getGameType() == GType_SIMON1) {
+			const Common::FSNode gameDataDir(ConfMan.get("path"));
+			Common::FSNode subDir = gameDataDir.getChild("En_sub");
+
+			// 25th Anniversary edition features full English subtitles
+			if (_language == Common::EN_ANY && subDir.exists())
+				_subtitles = true;
 			// English and German versions don't have full subtitles
-			if (_language == Common::EN_ANY || _language == Common::DE_DEU)
+			else if (_language == Common::EN_ANY || _language == Common::DE_DEU)
 				_subtitles = false;
 			// Other versions require speech to be enabled
 			else

--- a/engines/agos/detection_tables.h
+++ b/engines/agos/detection_tables.h
@@ -2010,12 +2010,39 @@ static const AGOSGameDescription gameDescriptions[] = {
 				{ "simon.gme",		GAME_GMEFILE,	"b1b18d0731b64c0738c5cc4a2ee792fc", 7030377},
 				{ "stripped.txt",	GAME_STRFILE,	"a27e87a9ba21212d769804b3df47bfb2", 252},
 				{ "tbllist",		GAME_TBLFILE,	"d198a80de2c59e4a0cd24b98814849e8", 711},
+				{ "simon.wav",		0,				"312c6a2733c0769526ebc45854d1232a", 170374592},
 				AD_LISTEND
 			},
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_CD,
 			GUIO3(GUIO_NOSUBTITLES, GAMEOPTION_WINDOWS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
+		},
+
+		GType_SIMON1,
+		GID_SIMON1,
+		GF_TALKIE
+	},
+
+	// Simon the Sorcerer 1 - 25th Anniversary
+	{
+		{
+			"simon1",
+			"25thAniversary",
+
+			{
+				{ "gamepc",			GAME_BASEFILE,	"c7c12fea7f6d0bfd22af5cdbc8166862", 36152},
+				{ "icon.dat",		GAME_ICONFILE,	"22107c24dfb31b66ac503c28a6e20b19", 14361},
+				{ "simon.gme",		GAME_GMEFILE,	"b1b18d0731b64c0738c5cc4a2ee792fc", 7030377},
+				{ "stripped.txt",	GAME_STRFILE,	"a27e87a9ba21212d769804b3df47bfb2", 252},
+				{ "tbllist",		GAME_TBLFILE,	"d198a80de2c59e4a0cd24b98814849e8", 711},
+				{ "simon.mp3",		0,				"91c5d0e332e0013e6869e03e49833885", 36341696},
+				AD_LISTEND
+			},
+			Common::EN_ANY,
+			Common::kPlatformWindows,
+			ADGF_CD,
+			GUIO2(GAMEOPTION_WINDOWS_TEMPOS, GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},
 
 		GType_SIMON1,


### PR DESCRIPTION
I drafted this PR to get comments and feedback. It allows to play the 25th Anniversary edition with full English subtitles and speech. I want to know if this is the right path, and if I should add support for german subtitles as well (which also seem to be included in that release).