### PR TITLE
DISTS: Fix project_license in AppStream metadata

### DIFF
--- a/dists/scummvm.appdata.xml
+++ b/dists/scummvm.appdata.xml
@@ -3,7 +3,7 @@
 <component type="desktop">
   <id>scummvm.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-2.0+</project_license>
+  <project_license>GPL-3.0-or-later</project_license>
   <name>ScummVM</name>
   <summary>Interpreter for numerous adventure games and role-playing games</summary>
   <summary xml:lang="de">Interpreter für zahlreiche Adventure-Spiele und RPGs</summary>


### PR DESCRIPTION
This changes license in the project_license tag to a correct one as suggested by @lotharsm in https://github.com/flathub/org.scummvm.ScummVM/pull/28#pullrequestreview-1297508199.

This should ideally be merged not only into master, but also into the upcoming 2.7 branches (if possible) and ideally before ScummVM 2.7.0 gets released.