### PR TITLE
GLK: SCOTT: Update UNP64

### DIFF
--- a/engines/glk/scott/c64_checksums.cpp
+++ b/engines/glk/scott/c64_checksums.cpp
@@ -471,26 +471,14 @@ int decrunchC64(uint8_t **sf, size_t *extent, C64Rec record) {
 
 	uncompressed = new uint8_t[0xffff];
 
-	char *switches[3];
-	int numSwitches = 0;
-
-	if (record._switches != nullptr) {
-		char string[100];
-		Common::strcpy_s(string, record._switches);
-		switches[numSwitches] = strtok(string, " ");
-
-		while (switches[numSwitches] != nullptr)
-			switches[++numSwitches] = strtok(nullptr, " ");
-	}
-
 	size_t result = 0;
 
 	for (int i = 1; i <= record._decompressIterations; i++) {
 		/* We only send switches on the iteration specified by parameter */
 		if (i == record._parameter && record._switches != nullptr) {
-			result = unp64(_G(_entireFile), _G(_fileLength), uncompressed, &decompressedLength, switches, numSwitches);
+			result = unp64(_G(_entireFile), _G(_fileLength), uncompressed, &decompressedLength, record._switches);
 		} else
-			result = unp64(_G(_entireFile), _G(_fileLength), uncompressed, &decompressedLength, nullptr, 0);
+			result = unp64(_G(_entireFile), _G(_fileLength), uncompressed, &decompressedLength, nullptr);
 		if (result) {
 			if (_G(_entireFile) != nullptr)
 				delete[] _G(_entireFile);

--- a/engines/glk/scott/unp64/6502_emu.cpp
+++ b/engines/glk/scott/unp64/6502_emu.cpp
@@ -188,7 +188,7 @@ static int mode_indy(CpuCtx *r, InstArg *arg) {
 }
 
 static int mode_rel(CpuCtx *r, InstArg *arg) {
-	arg->_rel._value = r->_mem[r->_pc + 1];
+	arg->_rel._value = (int8_t)r->_mem[r->_pc + 1];
 	r->_pc += 2;
 	return MODE_RELATIVE;
 }

--- a/engines/glk/scott/unp64/exo_util.cpp
+++ b/engines/glk/scott/unp64/exo_util.cpp
@@ -125,7 +125,7 @@ int findSys(const byte *buf, int target) {
 
 static void loadPrgData(byte mem[65536], uint8_t *data, size_t dataLength, LoadInfo *info) {
 	int len = MIN(65536 - info->_start, static_cast<int>(dataLength));
-	memcpy(mem + info->_start, data, len);
+	memcpy(mem + info->_start, data, (size_t)len);
 
 	info->_end = info->_start + len;
 	info->_basicVarStart = -1;
@@ -178,6 +178,57 @@ int strToInt(const char *str, int *value) {
 	} while (0);
 
 	return status;
+}
+
+bool u32eq(const unsigned char *addr, uint32_t val)
+{
+	return addr[3] == (val >> 24) &&
+	addr[2] == ((val >> 16) & 0xff) &&
+	addr[1] == ((val >>	 8) & 0xff) &&
+	addr[0] == (val & 0xff);
+}
+
+bool u32eqmasked(const unsigned char *addr, uint32_t mask, uint32_t val)
+{
+	uint32_t val1 = addr[0] | (addr[1] << 8) | (addr[2] << 16) | (addr[3] << 24);
+	return (val1 & mask) == val;
+}
+
+bool u32eqxored(const unsigned char *addr, uint32_t xormask, uint32_t val)
+{
+	uint32_t val1 = addr[0] | (addr[1] << 8) | (addr[2] << 16) | (addr[3] << 24);
+	return (val1 ^ xormask) == val;
+}
+
+bool u16eqmasked(const unsigned char *addr, uint16_t mask, uint16_t val)
+{
+	uint16_t val1 = addr[0] | (addr[1] << 8);
+	return (val1 & mask) == val;
+}
+
+
+bool u16eq(const unsigned char *addr, uint16_t val)
+{
+	return addr[1] == (val >> 8) &&
+	addr[0] == (val & 0xff);
+}
+
+bool u16noteq(const unsigned char *addr, uint16_t val)
+{
+	return addr[1] != (val >> 8) ||
+	addr[0] != (val & 0xff);
+}
+
+bool u16gteq(const unsigned char *addr, uint16_t val)
+{
+	uint16_t val2 = addr[0] | (addr[1] << 8);
+	return val2 >= val;
+}
+
+bool u16lteq(const unsigned char *addr, uint16_t val)
+{
+	uint16_t val2 = addr[0] | (addr[1] << 8);
+	return val2 <= val;
 }
 
 } // End of namespace Scott

--- a/engines/glk/scott/unp64/exo_util.h
+++ b/engines/glk/scott/unp64/exo_util.h
@@ -63,6 +63,15 @@ void loadData(uint8_t *data, size_t dataLength, byte mem[65536], LoadInfo *info)
 
 int strToInt(const char *str, int *value);
 
+bool u32eq(const unsigned char *addr, uint32_t val);
+bool u16eq(const unsigned char *addr, uint16_t val);
+bool u16gteq(const unsigned char *addr, uint16_t val);
+bool u16lteq(const unsigned char *addr, uint16_t val);
+bool u16noteq(const unsigned char *addr, uint16_t val);
+bool u32eqmasked(const unsigned char *addr, uint32_t mask, uint32_t val);
+bool u32eqxored(const unsigned char *addr, uint32_t ormask, uint32_t val);
+bool u16eqmasked(const unsigned char *addr, uint16_t mask, uint16_t val);
+
 } // End of namespace Scott
 } // End of namespace Glk
 

--- a/engines/glk/scott/unp64/scanners/action_packer.cpp
+++ b/engines/glk/scott/unp64/scanners/action_packer.cpp
@@ -22,6 +22,7 @@
 #include "common/endian.h"
 #include "glk/scott/types.h"
 #include "glk/scott/unp64/unp64.h"
+#include "glk/scott/unp64/exo_util.h"
 
 namespace Glk {
 namespace Scott {
@@ -33,10 +34,10 @@ void scnActionPacker(UnpStr *unp) {
 		return;
 	mem = unp->_mem;
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x811) == 0x018538A9) &&
-			(*(unsigned int *)(mem + 0x81d) == 0xCEF7D0E8) &&
-			(*(unsigned int *)(mem + 0x82d) == 0x0F9D0837) &&
-			(*(unsigned int *)(mem + 0x84b) == 0x03D00120)) {
+		if (u32eq(mem + 0x811, 0x018538A9) &&
+			u32eq(mem + 0x81d, 0xCEF7D0E8) &&
+			u32eq(mem + 0x82d, 0x0F9D0837) &&
+			u32eq(mem + 0x84b, 0x03D00120)) {
 			unp->_depAdr = 0x110;
 			unp->_forced = 0x811;
 			unp->_strMem = READ_LE_UINT16(&mem[0x848]);

--- a/engines/glk/scott/unp64/scanners/byte_boiler.cpp
+++ b/engines/glk/scott/unp64/scanners/byte_boiler.cpp
@@ -22,6 +22,7 @@
 #include "common/endian.h"
 #include "glk/scott/types.h"
 #include "glk/scott/unp64/unp64.h"
+#include "glk/scott/unp64/exo_util.h"
 
 namespace Glk {
 namespace Scott {
@@ -33,10 +34,10 @@ void scnByteBoiler(UnpStr *unp) {
 		return;
 	mem = unp->_mem;
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x813) == 0xE800F09D) &&
-			(*(unsigned int *)(mem + 0x818) == 0x014E4CF7)) {
+		if (u32eq(mem + 0x813, 0xE800F09D) &&
+			u32eq(mem + 0x818, 0x014E4CF7)) {
 			p = READ_LE_UINT16(&mem[0x811]);
-			if (*(unsigned int *)(mem + p + 1) == 0x02D0FAA5) {
+			if (u32eq(mem + p + 1, 0x02D0FAA5)) {
 				unp->_depAdr = 0x14e;
 				unp->_forced = 0x80b;
 				unp->_retAdr = READ_LE_UINT16(&mem[p + 0x5c]);
@@ -50,17 +51,17 @@ void scnByteBoiler(UnpStr *unp) {
 	}
 	/* CPX hack */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x80b) == 0xA97800A2) &&
-			(*(unsigned int *)(mem + 0x815) == 0x4C01E6D0)) {
+		if (u32eq(mem + 0x80b, 0xA97800A2) &&
+			u32eq(mem + 0x815, 0x4C01E6D0)) {
 			q = READ_LE_UINT16(&mem[0x819]);
-			if ((*(unsigned int *)(mem + q + 3) == 0xE800F09D) &&
-				(*(unsigned int *)(mem + q + 8) == 0x014E4CF7)) {
+			if (u32eq(mem + q + 3, 0xE800F09D) &&
+				u32eq(mem + q + 8, 0x014E4CF7)) {
 				p = READ_LE_UINT16(&mem[q + 1]);
-				if (*(unsigned int *)(mem + p + 1) == 0x02D0FAA5) {
+				if (u32eq(mem + p + 1, 0x02D0FAA5)) {
 					unp->_depAdr = 0x14e;
 					unp->_forced = 0x80b;
-					unp->_retAdr = READ_LE_UINT16(&mem[p + 0x5c]); 
-					unp->_endAdr = READ_LE_UINT16(&mem[p + 0x0e]); 
+					unp->_retAdr = READ_LE_UINT16(&mem[p + 0x5c]);
+					unp->_endAdr = READ_LE_UINT16(&mem[p + 0x0e]);
 					unp->_endAdr++;
 					unp->_fStrAf = 0xfe;
 					unp->_idFlag = 1;
@@ -71,15 +72,15 @@ void scnByteBoiler(UnpStr *unp) {
 	}
 	/* SCS hack */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x813) == 0xE800F09D) &&
-			(*(unsigned int *)(mem + 0x818) == 0x01bf4CF7)) {
-			p = READ_LE_UINT16(&mem[0x811]); 
-			if ((*(unsigned int *)(mem + p + 1) == 0x02D0FAA5) &&
-				(*(unsigned int *)(mem + p + 0xdd) == 0x014e4c01)) {
+		if (u32eq(mem + 0x813, 0xE800F09D) &&
+			u32eq(mem + 0x818, 0x01bf4CF7)) {
+			p = READ_LE_UINT16(&mem[0x811]);
+			if (u32eq(mem + p + 1, 0x02D0FAA5) &&
+				u32eq(mem + p + 0xdd, 0x014e4c01)) {
 				unp->_depAdr = 0x14e;
 				unp->_forced = 0x80b;
-				unp->_retAdr = READ_LE_UINT16(&mem[p + 0x5c]); 
-				unp->_endAdr = READ_LE_UINT16(&mem[p + 0x0e]); 
+				unp->_retAdr = READ_LE_UINT16(&mem[p + 0x5c]);
+				unp->_endAdr = READ_LE_UINT16(&mem[p + 0x0e]);
 				unp->_endAdr++;
 				unp->_fStrAf = 0xfe;
 				unp->_idFlag = 1;

--- a/engines/glk/scott/unp64/scanners/caution.cpp
+++ b/engines/glk/scott/unp64/scanners/caution.cpp
@@ -22,6 +22,7 @@
 #include "common/endian.h"
 #include "glk/scott/types.h"
 #include "glk/scott/unp64/unp64.h"
+#include "glk/scott/unp64/exo_util.h"
 
 namespace Glk {
 namespace Scott {
@@ -34,10 +35,10 @@ void scnCaution(UnpStr *unp) {
 	mem = unp->_mem;
 	/* quickpacker 1.0 sysless */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x801) == 0xE67800A2) &&
-			(*(unsigned int *)(mem + 0x805) == 0x07EDBD01) &&
-			(*(unsigned int *)(mem + 0x80d) == 0x00284CF8) &&
-			(*(unsigned int *)(mem + 0x844) == 0xAC00334C)) {
+		if (u32eq(mem + 0x801, 0xE67800A2) &&
+			u32eq(mem + 0x805, 0x07EDBD01) &&
+			u32eq(mem + 0x80d, 0x00284CF8) &&
+			u32eq(mem + 0x844, 0xAC00334C)) {
 			unp->_forced = 0x801;
 			unp->_depAdr = 0x28;
 			unp->_retAdr = READ_LE_UINT16(&mem[0x86b]);
@@ -50,11 +51,11 @@ void scnCaution(UnpStr *unp) {
 	}
 	/* quickpacker 2.x + sys */
 	if (unp->_depAdr == 0) {
-		if (((*(unsigned int *)(mem + 0x80b) & 0xf0ffffff) == 0x60A200A0) &&
-			 (*(unsigned int *)(mem + 0x80f) == 0x0801BD78) &&
-			 (*(unsigned int *)(mem + 0x813) == 0xD0CA0095) &&
-			 (*(unsigned int *)(mem + 0x81e) == 0xD0C80291) &&
-			 (*(unsigned int *)(mem + 0x817) == 0x001A4CF8)) {
+		if (u32eqmasked(mem + 0x80b, 0xf0ffffff, 0x60A200A0) &&
+			u32eq(mem + 0x80f, 0x0801BD78) &&
+			u32eq(mem + 0x813, 0xD0CA0095) &&
+			u32eq(mem + 0x81e, 0xD0C80291) &&
+			u32eq(mem + 0x817, 0x001A4CF8)) {
 			unp->_forced = 0x80b;
 			unp->_depAdr = 0x01a;
 			if (mem[0x80e] == 0x69) {
@@ -77,11 +78,11 @@ void scnCaution(UnpStr *unp) {
 	}
 	/* strangely enough, sysless v2.0 depacker is at $0002 */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x83d) == 0xAA004A20) &&
-			(*(unsigned int *)(mem + 0x801) == 0xA27800A0) &&
-			(*(unsigned int *)(mem + 0x805) == 0x080FBD55) &&
-			(*(unsigned int *)(mem + 0x809) == 0xD0CA0095) &&
-			(*(unsigned int *)(mem + 0x80d) == 0x00024CF8)) {
+		if (u32eq(mem + 0x83d, 0xAA004A20) &&
+			u32eq(mem + 0x801, 0xA27800A0) &&
+			u32eq(mem + 0x805, 0x080FBD55) &&
+			u32eq(mem + 0x809, 0xD0CA0095) &&
+			u32eq(mem + 0x80d, 0x00024CF8)) {
 			unp->_forced = 0x801;
 			unp->_depAdr = 0x2;
 			unp->_retAdr = READ_LE_UINT16(&mem[0x83b]);
@@ -95,14 +96,14 @@ void scnCaution(UnpStr *unp) {
 	}
 	/* same goes for v2.5 sysless, seems almost another packer */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x83b) == 0xAA005520) &&
-			(*(unsigned int *)(mem + 0x801) == 0x60A200A0) &&
-			(*(unsigned int *)(mem + 0x805) == 0x0801BD78) &&
-			(*(unsigned int *)(mem + 0x809) == 0xD0CA0095) &&
-			(*(unsigned int *)(mem + 0x80d) == 0x00104CF8)) {
+		if (u32eq(mem + 0x83b, 0xAA005520) &&
+			u32eq(mem + 0x801, 0x60A200A0) &&
+			u32eq(mem + 0x805, 0x0801BD78) &&
+			u32eq(mem + 0x809, 0xD0CA0095) &&
+			u32eq(mem + 0x80d, 0x00104CF8)) {
 			unp->_forced = 0x801;
 			unp->_depAdr = 0x10;
-			unp->_retAdr = READ_LE_UINT16(&mem[0x839]); 
+			unp->_retAdr = READ_LE_UINT16(&mem[0x839]);
 			unp->_endAdr = READ_LE_UINT16(&mem[0x847]);
 			unp->_endAdr += 0x100;
 			unp->_fStrAf = 0x46;
@@ -113,11 +114,11 @@ void scnCaution(UnpStr *unp) {
 	}
 	/* hardpacker */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x80d) == 0x8534A978) &&
-			(*(unsigned int *)(mem + 0x811) == 0xB9B3A001) &&
-			(*(unsigned int *)(mem + 0x815) == 0x4C99081F) &&
-			(*(unsigned int *)(mem + 0x819) == 0xF7D08803) &&
-			(*(unsigned int *)(mem + 0x81d) == 0xB9034D4C)) {
+		if (u32eq(mem + 0x80d, 0x8534A978) &&
+			u32eq(mem + 0x811, 0xB9B3A001) &&
+			u32eq(mem + 0x815, 0x4C99081F) &&
+			u32eq(mem + 0x819, 0xF7D08803) &&
+			u32eq(mem + 0x81d, 0xB9034D4C)) {
 			unp->_forced = 0x80d;
 			unp->_depAdr = 0x34d;
 			unp->_retAdr = READ_LE_UINT16(&mem[0x87f]);

--- a/engines/glk/scott/unp64/scanners/ccs.cpp
+++ b/engines/glk/scott/unp64/scanners/ccs.cpp
@@ -34,10 +34,10 @@ void scnCCS(UnpStr *unp) {
 		return;
 	mem = unp->_mem;
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x817) == 0xB901E678) &&
-			(*(unsigned int *)(mem + 0x81b) == 0xFD990831) &&
-			(*(unsigned int *)(mem + 0x8ff) == 0xFEE60290) &&
-			(*(unsigned int *)(mem + 0x90f) == 0x02903985)) {
+		if (u32eq(mem + 0x817, 0xB901E678) &&
+			u32eq(mem + 0x81b, 0xFD990831) &&
+			u32eq(mem + 0x8ff, 0xFEE60290) &&
+			u32eq(mem + 0x90f, 0x02903985)) {
 			if (unp->_info->_run == -1)
 				unp->_forced = 0x817;
 			unp->_depAdr = 0x0ff;
@@ -54,10 +54,10 @@ void scnCCS(UnpStr *unp) {
 	}
 	/* derived from supercomp/eqseq */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x80b) == 0x8C7800A0) &&
-			(*(unsigned int *)(mem + 0x812) == 0x0099082F) &&
-			(*(unsigned int *)(mem + 0x846) == 0x0DADF2D0) &&
-			(*(unsigned int *)(mem + 0x8c0) == 0xF001124C)) {
+		if (u32eq(mem + 0x80b, 0x8C7800A0) &&
+			u32eq(mem + 0x812, 0x0099082F) &&
+			u32eq(mem + 0x846, 0x0DADF2D0) &&
+			u32eq(mem + 0x8c0, 0xF001124C)) {
 			if (unp->_info->_run == -1)
 				unp->_forced = 0x80b;
 			unp->_depAdr = 0x100;
@@ -72,10 +72,10 @@ void scnCCS(UnpStr *unp) {
 		}
 	}
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x814) == 0xB901E678) &&
-			(*(unsigned int *)(mem + 0x818) == 0xFD990829) &&
-			(*(unsigned int *)(mem + 0x8a1) == 0xFDA6FDB1) &&
-			(*(unsigned int *)(mem + 0x8a5) == 0xFEC602D0)) {
+		if (u32eq(mem + 0x814, 0xB901E678) &&
+			u32eq(mem + 0x818, 0xFD990829) &&
+			u32eq(mem + 0x8a1, 0xFDA6FDB1) &&
+			u32eq(mem + 0x8a5, 0xFEC602D0)) {
 			if (unp->_info->_run == -1)
 				unp->_forced = 0x814;
 			unp->_depAdr = 0x0ff;
@@ -85,10 +85,10 @@ void scnCCS(UnpStr *unp) {
 		}
 	}
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x818) == 0x2CB901E6) &&
-			(*(unsigned int *)(mem + 0x81c) == 0x00FB9908) &&
-			(*(unsigned int *)(mem + 0x850) == 0xFBB1C84A) &&
-			(*(unsigned int *)(mem + 0x854) == 0xB1C81185)) {
+		if (u32eq(mem + 0x818, 0x2CB901E6) &&
+			u32eq(mem + 0x81c, 0x00FB9908) &&
+			u32eq(mem + 0x850, 0xFBB1C84A) &&
+			u32eq(mem + 0x854, 0xB1C81185)) {
 			if (unp->_info->_run == -1)
 				unp->_forced = 0x812;
 			unp->_depAdr = 0x0ff;
@@ -98,10 +98,10 @@ void scnCCS(UnpStr *unp) {
 		}
 	}
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x818) == 0x2CB901E6) &&
-			(*(unsigned int *)(mem + 0x81c) == 0x00FB9908) &&
-			(*(unsigned int *)(mem + 0x851) == 0xFBB1C812) &&
-			(*(unsigned int *)(mem + 0x855) == 0xB1C81185)) {
+		if (u32eq(mem + 0x818, 0x2CB901E6) &&
+			u32eq(mem + 0x81c, 0x00FB9908) &&
+			u32eq(mem + 0x851, 0xFBB1C812) &&
+			u32eq(mem + 0x855, 0xB1C81185)) {
 			if (unp->_info->_run == -1)
 				unp->_forced = 0x812;
 			unp->_depAdr = 0x0ff;
@@ -111,10 +111,10 @@ void scnCCS(UnpStr *unp) {
 		}
 	}
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x82c) == 0x018538A9) &&
-			(*(unsigned int *)(mem + 0x831) == 0xFD990842) &&
-			(*(unsigned int *)(mem + 0x83e) == 0x00FF4CF1) &&
-			(*(unsigned int *)(mem + 0x8a5) == 0x50C651C6)) {
+		if (u32eq(mem + 0x82c, 0x018538A9) &&
+			u32eq(mem + 0x831, 0xFD990842) &&
+			u32eq(mem + 0x83e, 0x00FF4CF1) &&
+			u32eq(mem + 0x8a5, 0x50C651C6)) {
 			if (unp->_info->_run == -1)
 				unp->_forced = 0x822;
 			unp->_depAdr = 0x0ff;
@@ -125,11 +125,11 @@ void scnCCS(UnpStr *unp) {
 		}
 	}
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned short int *)(mem + 0x81a) == 0x00A0) &&
-			((*(unsigned int *)(mem + 0x820) == 0xFB990837) ||
-			 (*(unsigned int *)(mem + 0x824) == 0xFB990837)) &&
-			(*(unsigned int *)(mem + 0x83b) == 0xFD91FBB1) &&
-			(*(unsigned int *)(mem + 0x8bc) == 0xEE00FC99)) {
+		if (u16eq(mem + 0x81a, 0x00A0) &&
+			(u32eq(mem + 0x820, 0xFB990837) ||
+			 u32eq(mem + 0x824, 0xFB990837)) &&
+			u32eq(mem + 0x83b, 0xFD91FBB1) &&
+			u32eq(mem + 0x8bc, 0xEE00FC99)) {
 			if (unp->_info->_run == -1)
 				unp->_forced = 0x81a;
 			unp->_depAdr = 0x0ff;
@@ -141,11 +141,11 @@ void scnCCS(UnpStr *unp) {
 		}
 	}
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x812) == 0xE67800A0) &&
-			(*(unsigned int *)(mem + 0x816) == 0x0823B901) &&
-			(*(unsigned int *)(mem + 0x81a) == 0xC800FD99) &&
-			(*(unsigned int *)(mem + 0x81e) == 0xFF4CF7D0) &&
-			(*(unsigned int *)(mem + 0x885) == 0xFDA6FDB1)) {
+		if (u32eq(mem + 0x812, 0xE67800A0) &&
+			u32eq(mem + 0x816, 0x0823B901) &&
+			u32eq(mem + 0x81a, 0xC800FD99) &&
+			u32eq(mem + 0x81e, 0xFF4CF7D0) &&
+			u32eq(mem + 0x885, 0xFDA6FDB1)) {
 			if (unp->_info->_run == -1)
 				unp->_forced = 0x812;
 			unp->_depAdr = 0x0ff;
@@ -155,7 +155,7 @@ void scnCCS(UnpStr *unp) {
 			// unp->_fEndAf=0x2d;
 			unp->_endAdr = READ_LE_UINT16(&mem[0x803]);
 			unp->_endAdr++;
-			if (*(unsigned int *)(mem + 0x87f) == 0x4CA65920)
+			if (u32eq(mem + 0x87f, 0x4CA65920))
 				mem[0x87f] = 0x2c;
 			unp->_retAdr = READ_LE_UINT16(&mem[0x883]);
 			unp->_idFlag = 1;
@@ -163,10 +163,10 @@ void scnCCS(UnpStr *unp) {
 		}
 	}
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x812) == 0xE67800A0) &&
-			(*(unsigned int *)(mem + 0x816) == 0x084CB901) &&
-			(*(unsigned int *)(mem + 0x81a) == 0xA900FB99) &&
-			(*(unsigned int *)(mem + 0x848) == 0x00FF4CE2)) {
+		if (u32eq(mem + 0x812, 0xE67800A0) &&
+			u32eq(mem + 0x816, 0x084CB901) &&
+			u32eq(mem + 0x81a, 0xA900FB99) &&
+			u32eq(mem + 0x848, 0x00FF4CE2)) {
 			if (unp->_info->_run == -1)
 				unp->_forced = 0x812;
 			unp->_depAdr = 0x0ff;
@@ -178,10 +178,10 @@ void scnCCS(UnpStr *unp) {
 	}
 	/* Triad Hack */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x838) == 0xB9080099) &&
-			(*(unsigned int *)(mem + 0x83f) == 0xD0880816) &&
-			(*(unsigned int *)(mem + 0x8ff) == 0xFEE60290) &&
-			(*(unsigned int *)(mem + 0x90f) == 0x02903985)) {
+		if (u32eq(mem + 0x838, 0xB9080099) &&
+			u32eq(mem + 0x83f, 0xD0880816) &&
+			u32eq(mem + 0x8ff, 0xFEE60290) &&
+			u32eq(mem + 0x90f, 0x02903985)) {
 			if (unp->_info->_run == -1) {
 				for (p = 0x80b; p < 0x820; p++) {
 					if ((mem[p] & 0xa0) == 0xa0) {

--- a/engines/glk/scott/unp64/scanners/cruel.cpp
+++ b/engines/glk/scott/unp64/scanners/cruel.cpp
@@ -36,10 +36,10 @@ void scnCruel(UnpStr *unp) {
 	if (unp->_depAdr == 0) {
 		if (mem[0x810] == 0xb9 &&
 			((*(unsigned int *)(mem + 0x813) & 0xfffffeff) == 0xC800FA99) &&
-			(*(unsigned short int *)(mem + 0x818) == 0x4CF7)) {
+			u16eq(mem + 0x818, 0x4CF7)) {
 			if (mem[0x814] == 0xFA) {
 				p = READ_LE_UINT16(&mem[0x811]); // mem[0x811] | mem[0x812] << 8;
-				if (*(unsigned int *)(mem + p + 9) == 0xC8071C99) {
+				if (u32eq(mem + p + 9, 0xC8071C99)) {
 					unp->_endAdr = READ_LE_UINT16(&mem[p + 2]); // mem[p + 2] | mem[p + 3] << 8;
 					unp->_depAdr = 0x100;
 					if (unp->_info->_run == -1)
@@ -96,7 +96,7 @@ void scnCruel(UnpStr *unp) {
 				   v1.5 is infact more common
 				*/
 				p = READ_LE_UINT16(&mem[0x811]); // mem[0x811] | mem[0x812] << 8;
-				if (*(unsigned int *)(mem + p + 7) == 0xC8071C99) {
+				if (u32eq(mem + p + 7, 0xC8071C99)) {
 					unp->_endAdr = READ_LE_UINT16(&mem[p + 3]); // mem[p + 3] | mem[p + 4] << 8;
 					unp->_depAdr = 0x100;
 					unp->_forced = 0x80b;
@@ -107,7 +107,7 @@ void scnCruel(UnpStr *unp) {
 						unp->_retAdr = READ_LE_UINT16(&mem[p + 0x95]); // mem[p + 0x95] | mem[p + 0x96] << 8;
 					} else if ((mem[p + 0x20] == 0x4c) && (mem[p + 0x28] == 0x4c)) {
 						unp->_retAdr = READ_LE_UINT16(&mem[p + 0x29]); // mem[p + 0x29] | mem[p + 0x2a] << 8;
-					} 
+					}
 				}
 			}
 		}
@@ -119,12 +119,12 @@ void scnCruel(UnpStr *unp) {
 	/* MSCRUNCH 1.5 hack by Anubis */
 	if (unp->_depAdr == 0) {
 		if (mem[0x819] == 0x4c) {
-			p = READ_LE_UINT16(&mem[0x81a]);//mem[0x81a] | mem[0x81b] << 8;
+			p = READ_LE_UINT16(&mem[0x81a]); //mem[0x81a] | mem[0x81b] << 8;
 			if ((mem[p] == 0xa9) && (mem[p + 0x0f] == 0x30) &&
-				(*(unsigned int *)(mem + p + 0x13) == 0xCA04009D) &&
-				(*(unsigned int *)(mem + p + 0x38) == 0x01084C01)) {
+				u32eq(mem + p + 0x13, 0xCA04009D) &&
+				u32eq(mem + p + 0x38, 0x01084C01)) {
 				q = READ_LE_UINT16(&mem[p + 0x1f]); // mem[p + 0x1f] | mem[p + 0x20] << 8;
-				if (*(unsigned int *)(mem + q + 7) == 0xC8071C99) {
+				if (u32eq(mem + q + 7, 0xC8071C99)) {
 					unp->_endAdr = READ_LE_UINT16(&mem[q + 3]); // mem[q + 3] | mem[q + 4] << 8;
 					unp->_depAdr = 0x100;
 					if (unp->_info->_run == -1)
@@ -137,15 +137,15 @@ void scnCruel(UnpStr *unp) {
 	}
 	/* fast cruel 4.x */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x80b) == 0xE67800A0) &&
-			(*(unsigned int *)(mem + 0x813) == 0xC8034099) &&
-			((*(unsigned int *)(mem + 0x818) == 0x03404cF7) ||
-			 (*(unsigned int *)(mem + 0x818) == 0x03b34cF7) ||
-			 (*(unsigned int *)(mem + 0x818) == 0x03db4cF7))) {
+		if (u32eq(mem + 0x80b, 0xE67800A0) &&
+			u32eq(mem + 0x813, 0xC8034099) &&
+			(u32eq(mem + 0x818, 0x03404cF7) ||
+			 u32eq(mem + 0x818, 0x03b34cF7) ||
+			 u32eq(mem + 0x818, 0x03db4cF7))) {
 			p = READ_LE_UINT16(&mem[0x811]); // mem[0x811] | mem[0x812] << 8;
-			if (*(unsigned int *)(mem + p) == 0xa75801c6) {
+			if (u32eq(mem + p, 0xa75801c6)) {
 				p += 0x45;
-				q = READ_LE_UINT16(&mem[p]);            // mem[p] | mem[p + 1] << 8;
+				q = READ_LE_UINT16(&mem[p]);                // mem[p] | mem[p + 1] << 8;
 				unp->_endAdr = READ_LE_UINT16(&mem[q + 2]); // mem[q + 2] | mem[q + 3] << 8;
 				unp->_depAdr = 0x340;
 				unp->_forced = 0x80b;
@@ -157,9 +157,9 @@ void scnCruel(UnpStr *unp) {
 	}
 	/* Cruel 2.0 / (BB) packer header */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x837) == 0x9D0845BD) &&
-			(*(unsigned int *)(mem + 0x84f) == 0xE808039D) &&
-			(*(unsigned int *)(mem + 0x83b) == 0xC9E803B7)) {
+		if (u32eq(mem + 0x837, 0x9D0845BD) &&
+			u32eq(mem + 0x84f, 0xE808039D) &&
+			u32eq(mem + 0x83b, 0xC9E803B7)) {
 			unp->_depAdr = READ_LE_UINT16(&mem[0x843]); // mem[0x843] | mem[0x844] << 8;
 			if (unp->_info->_run == -1)
 				unp->_forced = 0x80d;
@@ -169,9 +169,9 @@ void scnCruel(UnpStr *unp) {
 			unp->_idFlag = 1;
 			return;
 		}
-		if ((*(unsigned int *)(mem + 0x845) == 0x03E04CF2) &&
-			(*(unsigned int *)(mem + 0x852) == 0x9D0893BD) &&
-			(*(unsigned int *)(mem + 0x856) == 0xD0E80803)) {
+		if (u32eq(mem + 0x845, 0x03E04CF2) &&
+			u32eq(mem + 0x852, 0x9D0893BD) &&
+			u32eq(mem + 0x856, 0xD0E80803)) {
 			unp->_depAdr = READ_LE_UINT16(&mem[0x847]); // mem[0x847] | mem[0x848] << 8;
 			if (unp->_info->_run == -1)
 				unp->_forced = 0x80d;
@@ -181,9 +181,9 @@ void scnCruel(UnpStr *unp) {
 			unp->_idFlag = 1;
 			return;
 		}
-		if ((*(unsigned int *)(mem + 0x841) == 0x03B74CF5) &&
-			(*(unsigned int *)(mem + 0x84c) == 0x9D089BBD) &&
-			(*(unsigned int *)(mem + 0x850) == 0xD0E8080B)) {
+		if (u32eq(mem + 0x841, 0x03B74CF5) &&
+			u32eq(mem + 0x84c, 0x9D089BBD) &&
+			u32eq(mem + 0x850, 0xD0E8080B)) {
 			unp->_depAdr = READ_LE_UINT16(&mem[0x843]); // mem[0x843] | mem[0x844] << 8;
 			if (unp->_info->_run == -1) {
 				unp->_forced = 0x811;
@@ -198,9 +198,9 @@ void scnCruel(UnpStr *unp) {
 			return;
 		}
 		/* this is a totally useless header, cheers TCOM! */
-		if ((*(unsigned int *)(mem + 0x80b) == 0x1BB900A0) &&
-			(*(unsigned int *)(mem + 0x80f) == 0x03B79908) &&
-			(*(unsigned int *)(mem + 0x823) == 0x039D0840)) {
+		if (u32eq(mem + 0x80b, 0x1BB900A0) &&
+			u32eq(mem + 0x80f, 0x03B79908) &&
+			u32eq(mem + 0x823, 0x039D0840)) {
 			unp->_depAdr = READ_LE_UINT16(&mem[0x819]); // mem[0x819] | mem[0x81a] << 8;
 			if (unp->_info->_run == -1)
 				unp->_forced = 0x80b;
@@ -213,24 +213,24 @@ void scnCruel(UnpStr *unp) {
 	}
 	/* Cruel 2.0 / (BB) packer sysless */
 	if (unp->_depAdr == 0) {
-		if ((((*(unsigned int *)(mem + 0x80b)) & 0x0000ffff) == 0x000000A0) &&
-			(*(unsigned int *)(mem + 0x817) == 0xC800CB99) &&
-			(*(unsigned int *)(mem + 0x81b) == 0x004CF7D0) && mem[0x81f] == 1) {
+		if (u32eqmasked(mem + 0x80b, 0x0000ffff, 0x000000A0) &&
+			u32eq(mem + 0x817, 0xC800CB99) &&
+			u32eq(mem + 0x81b, 0x004CF7D0) && mem[0x81f] == 1) {
 			p = READ_LE_UINT16(&mem[0x815]); // mem[0x815] | mem[0x816] << 8;
 			p += 0x31;
 			if ((mem[p + 4] == 0xb9) &&
-				(*(unsigned int *)(mem + p + 7) == 0xC8072099)) {
+				u32eq(mem + p + 7, 0xC8072099)) {
 				unp->_forced = 0x80b;
 				unp->_depAdr = 0x100;
 				unp->_endAdr = READ_LE_UINT16(&mem[p]); // mem[p] | mem[p + 1] << 8;
 				unp->_fStrAf = 0xfc;
 				/* patch: some version contain a zp cleaner sub at $01a2 */
-				if ((*(unsigned int *)(mem + p + 0xa6) == 0x00A9CBA2) &&
-					(*(unsigned int *)(mem + p + 0xaa) == 0xD0E80095)) {
+				if (u32eq(mem + p + 0xa6, 0x00A9CBA2) &&
+					u32eq(mem + p + 0xaa, 0xD0E80095)) {
 					mem[p + 0xa6] = 0x60;
 				}
 				/* patch: some version expects $01==#$34 already set from the header */
-				if (*(unsigned int *)(mem + 0x811) == 0xb9eaeaea) {
+				if (u32eq(mem + 0x811, 0xb9eaeaea)) {
 					mem[0x811] = 0xe6;
 					mem[0x812] = 0x01;
 				}
@@ -245,12 +245,12 @@ void scnCruel(UnpStr *unp) {
 	}
 	/* Cruel 2.1 / STA */
 	if (unp->_depAdr == 0) {
-		if (mem[0x80b] == 0xa0 && (*(unsigned int *)(mem + 0x817) == 0xC800CB99) &&
-			(*(unsigned int *)(mem + 0x81b) == 0x004CF7D0) && mem[0x81f] == 1) {
+		if (mem[0x80b] == 0xa0 && u32eq(mem + 0x817, 0xC800CB99) &&
+			u32eq(mem + 0x81b, 0x004CF7D0) && mem[0x81f] == 1) {
 			p = READ_LE_UINT16(&mem[0x815]); // mem[0x815] | mem[0x816] << 8;
 			p += 0x31;
-			if ((mem[p + 6] == 0xb9) &&
-				(*(unsigned int *)(mem + p + 9) == 0xC8072099)) {
+			if (mem[p + 6] == 0xb9 &&
+				u32eq(mem + p + 9, 0xC8072099)) {
 				unp->_forced = 0x80b;
 				unp->_depAdr = 0x100;
 				unp->_endAdr = READ_LE_UINT16(&mem[p]); // mem[p] | mem[p + 1] << 8;
@@ -266,12 +266,12 @@ void scnCruel(UnpStr *unp) {
 	}
 	/* unknown cruel, jmp $00e9, found in Illusion/Random warez */
 	if (unp->_depAdr == 0) {
-		if (mem[0x810] == 0xb9 && (*(unsigned int *)(mem + 0x813) == 0xC800e999) &&
-			(*(unsigned int *)(mem + 0x818) == 0x00e94CF7)) {
+		if (mem[0x810] == 0xb9 && u32eq(mem + 0x813, 0xC800e999) &&
+			u32eq(mem + 0x818, 0x00e94CF7)) {
 			p = READ_LE_UINT16(&mem[0x811]); // mem[0x811] | mem[0x812] << 8;
 			q = p - 0xed;
-			if ((*(unsigned int *)(mem + p) == 0x13F01284) &&
-				(*(unsigned int *)(mem + q) == 0xA9C8C8C8)) {
+			if (u32eq(mem + p, 0x13F01284) &&
+				u32eq(mem + q, 0xA9C8C8C8)) {
 				unp->_depAdr = 0xe9;
 				unp->_endAdr = READ_LE_UINT16(&mem[p + 0x13]); // mem[p + 0x13] | mem[p + 0x14] << 8;
 				unp->_retAdr = READ_LE_UINT16(&mem[q + 0x38]); // mem[q + 0x38] | mem[q + 0x39] << 8;
@@ -284,12 +284,12 @@ void scnCruel(UnpStr *unp) {
 		}
 	}
 	if (unp->_depAdr == 0) {
-		if (mem[0x810] == 0xb9 && (*(unsigned int *)(mem + 0x813) == 0xC800ed99) &&
-			(*(unsigned int *)(mem + 0x818) == 0x01004CF7)) {
+		if (mem[0x810] == 0xb9 && u32eq(mem + 0x813, 0xC800ed99) &&
+			u32eq(mem + 0x818, 0x01004CF7)) {
 			p = READ_LE_UINT16(&mem[0x811]); // mem[0x811] | mem[0x812] << 8;
 			q = p - 0xed;
-			if ((*(unsigned int *)(mem + p) == 0x01C60888) &&
-				(*(unsigned int *)(mem + q) == 0xA9C8C8C8)) {
+			if (u32eq(mem + p, 0x01C60888) &&
+				u32eq(mem + q, 0xA9C8C8C8)) {
 				unp->_depAdr = 0x100;
 				unp->_endAdr = READ_LE_UINT16(&mem[p + 0x0f]); // mem[p + 0x0f] | mem[p + 0x10] << 8;
 				unp->_retAdr = READ_LE_UINT16(&mem[q + 0x38]); // mem[q + 0x38] | mem[q + 0x39] << 8;
@@ -303,11 +303,11 @@ void scnCruel(UnpStr *unp) {
 	}
 	/* cruel 1.2 / unknown 2059 */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x80b) == 0xE67800A0) &&
-			(*(unsigned int *)(mem + 0x80f) == 0x0803B901) &&
-			(*(unsigned int *)(mem + 0x813) == 0xC800E399) &&
-			(*(unsigned int *)(mem + 0x817) == 0x004CF7D0) &&
-			(*(unsigned int *)(mem + 0x90b) == 0xC068FEC6)) {
+		if (u32eq(mem + 0x80b, 0xE67800A0) &&
+			u32eq(mem + 0x80f, 0x0803B901) &&
+			u32eq(mem + 0x813, 0xC800E399) &&
+			u32eq(mem + 0x817, 0x004CF7D0) &&
+			u32eq(mem + 0x90b, 0xC068FEC6)) {
 			unp->_depAdr = 0x100;
 			unp->_forced = 0x80b;
 			unp->_retAdr = READ_LE_UINT16(&mem[0x91c]); // mem[0x91c] | mem[0x91d] << 8;
@@ -319,11 +319,11 @@ void scnCruel(UnpStr *unp) {
 		/* this was found in Agile and S451 cracks, Galleon's "Cruel+Search"
 		   it's actually the real v1.0
 		*/
-		if ((*(unsigned int *)(mem + 0x80b) == 0xE67800A0) &&
-			(*(unsigned int *)(mem + 0x80f) == 0x0803B901) &&
-			(*(unsigned int *)(mem + 0x813) == 0xC800E399) &&
-			(*(unsigned int *)(mem + 0x8c5) == 0x011D4C04) &&
-			(*(unsigned int *)(mem + 0x90b) == 0xB1486018)) {
+		if (u32eq(mem + 0x80b, 0xE67800A0) &&
+			u32eq(mem + 0x80f, 0x0803B901) &&
+			u32eq(mem + 0x813, 0xC800E399) &&
+			u32eq(mem + 0x8c5, 0x011D4C04) &&
+			u32eq(mem + 0x90b, 0xB1486018)) {
 			unp->_depAdr = 0x100;
 			unp->_forced = 0x80b;
 			unp->_retAdr = READ_LE_UINT16(&mem[0x92d]); // mem[0x92d] | mem[0x92e] << 8;
@@ -332,11 +332,11 @@ void scnCruel(UnpStr *unp) {
 			unp->_idFlag = 1;
 			return;
 		}
-		if ((*(unsigned int *)(mem + 0x80b) == 0xE67800A0) &&
-			(*(unsigned int *)(mem + 0x80f) == 0x0803B901) &&
-			(*(unsigned int *)(mem + 0x813) == 0xC800E399) &&
-			(*(unsigned int *)(mem + 0x8b7) == 0x011D4C04) &&
-			(*(unsigned int *)(mem + 0x8fc) == 0xB1486018)) {
+		if (u32eq(mem + 0x80b, 0xE67800A0) &&
+			u32eq(mem + 0x80f, 0x0803B901) &&
+			u32eq(mem + 0x813, 0xC800E399) &&
+			u32eq(mem + 0x8b7, 0x011D4C04) &&
+			u32eq(mem + 0x8fc, 0xB1486018)) {
 			unp->_depAdr = 0x100;
 			unp->_forced = 0x80b;
 			unp->_retAdr = READ_LE_UINT16(&mem[0x91e]); // mem[0x91e] | mem[0x91f] << 8;
@@ -349,14 +349,14 @@ void scnCruel(UnpStr *unp) {
 
 	/* TKC "proggy crueler 2.3" (and 2.5) */
 	if (unp->_depAdr == 0) {
-		if ((mem[0x810] == 0xb9) && (mem[0x819] == 0xa9) &&
-			(*(unsigned int *)(mem + 0x813) == 0xC800fa99) &&
-			(*(unsigned int *)(mem + 0x822) == 0x4CAF86AE)) {
+		if (mem[0x810] == 0xb9 && mem[0x819] == 0xa9 &&
+			u32eq(mem + 0x813, 0xC800fa99) &&
+			u32eq(mem + 0x822, 0x4CAF86AE)) {
 			p = READ_LE_UINT16(&mem[0x811]); // mem[0x811] | mem[0x812] << 8;
 			q = p - 0x100;
 
-			if ((*(unsigned int *)(mem + p + 0x0c) == 0x20F7D0C8) &&
-				(*(unsigned int *)(mem + q) == 0xA9C8C8C8)) {
+			if (u32eq(mem + p + 0x0c, 0x20F7D0C8) &&
+				u32eq(mem + q, 0xA9C8C8C8)) {
 				unp->_depAdr = 0x100;
 				unp->_endAdr = READ_LE_UINT16(&mem[p + 0x02]); // mem[p + 0x02] | mem[p + 0x03] << 8;
 				unp->_retAdr = READ_LE_UINT16(&mem[q + 0x3f]); // mem[q + 0x3f] | mem[q + 0x40] << 8;

--- a/engines/glk/scott/unp64/scanners/eca.cpp
+++ b/engines/glk/scott/unp64/scanners/eca.cpp
@@ -22,6 +22,7 @@
 #include "common/endian.h"
 #include "glk/scott/types.h"
 #include "glk/scott/unp64/unp64.h"
+#include "glk/scott/unp64/exo_util.h"
 
 namespace Glk {
 namespace Scott {
@@ -35,26 +36,26 @@ void scnECA(UnpStr *unp) {
 	if (unp->_depAdr == 0) {
 		// for(p=0x810;p<0x830;p+=0x4)
 		for (p = 0x80d; p < 0x830; p += 0x1) {
-			if ((*(unsigned int *)(mem + p + 0x08) == (unsigned int)0x2D9D0032 + p) &&
-				(*(unsigned int *)(mem + p + 0x3a) == 0x2a2a2a2a) &&
-				(*(unsigned int *)(mem + p + 0x0c) == 0xF710CA00)) {
+			if (u32eq(mem + p + 0x08, (unsigned int)(0x2D9D0032 + p)) &&
+				u32eq(mem + p + 0x3a, 0x2a2a2a2a) &&
+				u32eq(mem + p + 0x0c, 0xF710CA00)) {
 				if (((*(unsigned int *)(mem + p + 0x00) & 0xf4fff000) == 0x8434A000) &&
-					(*(unsigned int *)(mem + p + 0x04) == 0xBD05A201)) {
+					u32eq(mem + p + 0x04, 0xBD05A201)) {
 					unp->_forced = p + 1;
 				} else if (((*(unsigned int *)(mem + p + 0x00) & 0xffffff00) == 0x04A27800) &&
-						   (*(unsigned int *)(mem + p + 0x04) == 0xBDE80186)) {
+						   u32eq(mem + p + 0x04, 0xBDE80186)) {
 					unp->_forced = p + 1;
 				} else if (((*(unsigned int *)(mem + p - 0x03) & 0xffffff00) == 0x04A27800) &&
-						   (*(unsigned int *)(mem + p + 0x04) == 0xBDE80186)) {
+                        u32eq(mem + p + 0x04, 0xBDE80186)) {
 					unp->_forced = p - 2;
-				} else if (*(unsigned int *)(mem + p - 0x03) == 0x8D00a978) {
+				} else if (u32eq(mem + p - 0x03, 0x8D00a978)) {
 					unp->_forced = p - 2;
 				}
 			}
 			if (!unp->_forced) {
-				if ((*(unsigned int *)(mem + p + 0x3a) == 0x2a2a2a2a) &&
-					(*(unsigned int *)(mem + p + 0x02) == 0x8534A978) &&
-					(mem[p - 3] == 0xa0)) {
+				if (u32eq(mem + p + 0x3a, 0x2a2a2a2a) &&
+					u32eq(mem + p + 0x02, 0x8534A978) &&
+					mem[p - 3] == 0xa0) {
 					unp->_forced = p - 3;
 					if (mem[p + 0x0d6] == 0x20 && mem[p + 0x0d7] == 0xe0 &&
 						mem[p + 0x0d8] == 0x03 && mem[p + 0x1da] == 0x5b &&
@@ -67,28 +68,28 @@ void scnECA(UnpStr *unp) {
 				}
 			}
 			if (!unp->_forced) { /* FDT */
-				if ((*(unsigned int *)(mem + p + 0x3a) == 0x2a2a2a2a) &&
-					(*(unsigned int *)(mem + p + 0x03) == 0x8604A278) &&
-					(*(unsigned int *)(mem + p + 0x0a) == 0x2D950842)) {
+				if (u32eq(mem + p + 0x3a, 0x2a2a2a2a) &&
+					u32eq(mem + p + 0x03, 0x8604A278) &&
+					u32eq(mem + p + 0x0a, 0x2D950842)) {
 					unp->_forced = p + 3;
 				}
 			}
 			if (!unp->_forced) {
 				/* decibel hacks */
-				if ((*(unsigned int *)(mem + p + 0x3a) == 0x2a2a2a2a) &&
-					(*(unsigned int *)(mem + p + 0x00) == 0x9D085EBD) &&
-					(*(unsigned int *)(mem + p - 0x06) == 0x018534A9)) {
+				if (u32eq(mem + p + 0x3a, 0x2a2a2a2a) &&
+					u32eq(mem + p + 0x00, 0x9D085EBD) &&
+					u32eq(mem + p - 0x06, 0x018534A9)) {
 					unp->_forced = p - 0x6;
 				}
 			}
 			if (unp->_forced) {
 				for (q = 0xd6; q < 0xde; q++) {
 					if (mem[p + q] == 0x20) {
-						if ((*(unsigned short int *)(mem + p + q + 1) == 0xa659) ||
-							(*(unsigned short int *)(mem + p + q + 1) == 0xff81) ||
-							(*(unsigned short int *)(mem + p + q + 1) == 0xe3bf) ||
-							(*(unsigned short int *)(mem + p + q + 1) == 0xe5a0) ||
-							(*(unsigned short int *)(mem + p + q + 1) == 0xe518)) {
+						if (u16eq(mem + p + q + 1, 0xa659) ||
+							u16eq(mem + p + q + 1, 0xff81) ||
+							u16eq(mem + p + q + 1, 0xe3bf) ||
+							u16eq(mem + p + q + 1, 0xe5a0) ||
+							u16eq(mem + p + q + 1, 0xe518)) {
 							mem[p + q] = 0x2c;
 							q += 2;
 							continue;
@@ -105,7 +106,7 @@ void scnECA(UnpStr *unp) {
 				unp->_depAdr = READ_LE_UINT16(&mem[p + 0x30]); // mem[p + 0x30] | mem[p + 0x31] << 8;
 				// some use $2d, some $ae
 				for (q = 0xed; q < 0x108; q++) {
-					if (*(unsigned int *)(mem + p + q) == 0xA518F7D0) {
+					if (u32eq(mem + p + q, 0xA518F7D0)) {
 						unp->_endAdr = mem[p + q + 4];
 						// if(unp->_DebugP)
 						// printf("EndAdr from $%02x\n",unp->_endAdr);
@@ -137,11 +138,11 @@ void scnECA(UnpStr *unp) {
 				*/
 				unp->_strMem = READ_LE_UINT16(&mem[p + 0x32]); // mem[p + 0x32] | mem[p + 0x33] << 8;
 				for (q = 0xcd; q < 0xd0; q++) {
-					if ((*(unsigned int *)(mem + p + q) & 0xffff00ff) == 0xa9010020) {
+					if (u32eqmasked(mem + p + q, 0xffff00ff, 0xa9010020)) {
 						unp->_ecaFlg = READ_LE_UINT16(&mem[p + q + 1]); // mem[p + q + 1] | mem[p + q + 2] << 8;
 						for (q = 0x110; q < 0x11f; q++) {
-							if ((*(unsigned int *)(mem + p + q) == 0x99EF00B9) &&
-								(mem[p + q + 0x12] == 0xc9)) {
+							if (u32eq(mem + p + q, 0x99EF00B9) &&
+								mem[p + q + 0x12] == 0xc9) {
 								unp->_ecaFlg |= (mem[p + q + 0x13] - 0xf) << 24;
 								break;
 							}
@@ -165,10 +166,10 @@ void scnECA(UnpStr *unp) {
 	}
 	/* old packer, many old 1985 warez used this */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x81b) == 0x018534A9) &&
-			(*(unsigned int *)(mem + 0x822) == 0xAFC600A0) &&
-			(*(unsigned int *)(mem + 0x826) == 0xB1082DCE) &&
-			(*(unsigned int *)(mem + 0x85b) == 0x2A2A2A2A)) {
+		if (u32eq(mem + 0x81b, 0x018534A9) &&
+			u32eq(mem + 0x822, 0xAFC600A0) &&
+			u32eq(mem + 0x826, 0xB1082DCE) &&
+			u32eq(mem + 0x85b, 0x2A2A2A2A)) {
 			unp->_forced = 0x81b;
 			unp->_depAdr = 0x100;
 			unp->_strMem = READ_LE_UINT16(&mem[0x853]); // mem[0x853] | mem[0x854] << 8;

--- a/engines/glk/scott/unp64/scanners/exomizer.cpp
+++ b/engines/glk/scott/unp64/scanners/exomizer.cpp
@@ -35,9 +35,9 @@ void scnExomizer(UnpStr *unp) {
 	mem = unp->_mem;
 	/* exomizer 3.x */
 	if (unp->_depAdr == 0) {
-		for (p = unp->_info->_end; p > unp->_info->_start; p--) {
-			if ((*(unsigned int *)(mem + p) == 0x100A8069) &&
-				(*(unsigned int *)(mem + p + 4) == 0xD0FD060F) &&
+		for (p = unp->_info->_end - 4; p > unp->_info->_start; p--) {
+			if (u32eq(mem + p, 0x100A8069) &&
+				u32eq(mem + p + 4, 0xD0FD060F) &&
 				mem[p - 6] == 0x4c && mem[p - 4] == 0x01) {
 				p -= 5;
 				q = 2;
@@ -59,7 +59,7 @@ void scnExomizer(UnpStr *unp) {
 		if (unp->_exoFnd) {
 			unp->_depAdr = 0x100 | mem[p];
 			for (; p < unp->_info->_end; p++) {
-				if (*(unsigned int *)(mem + p) == 0x7d010020)
+				if (u32eq(mem + p, 0x7d010020))
 					break;
 			}
 			for (; p < unp->_info->_end; p++) {
@@ -95,27 +95,27 @@ void scnExomizer(UnpStr *unp) {
 	}
 	/* exomizer 1.x/2.x */
 	if (unp->_depAdr == 0) {
-		for (p = unp->_info->_end; p > unp->_info->_start; p--) {
-			if ((((*(unsigned int *)(mem + p) == 0x4CF7D088) &&
-				  (*(unsigned int *)(mem + p - 0x0d) == 0xD034C0C8)) ||
-				 ((*(unsigned int *)(mem + p) == 0x4CA7A438) &&
-				  (*(unsigned int *)(mem + p - 0x0c) == 0x799FA5AE)) ||
-				 ((*(unsigned int *)(mem + p) == 0x4CECD08A) &&
-				  (*(unsigned int *)(mem + p - 0x13) == 0xCECA0EB0)) ||
-				 ((*(unsigned int *)(mem + p) == 0x4C00A0D3) &&
-				  (*(unsigned int *)(mem + p - 0x04) == 0xD034C0C8)) ||
-				 ((*(unsigned int *)(mem + p) == 0x4C00A0D2) &&
-				  (*(unsigned int *)(mem + p - 0x04) == 0xD034C0C8))) &&
+		for (p = unp->_info->_end - 4; p > unp->_info->_start; p--) {
+			if (((u32eq(mem + p, 0x4CF7D088) &&
+				  u32eq(mem + p - 0x0d, 0xD034C0C8)) ||
+				 (u32eq(mem + p, 0x4CA7A438) &&
+				  u32eq(mem + p - 0x0c, 0x799FA5AE)) ||
+				 (u32eq(mem + p, 0x4CECD08A) &&
+				  u32eq(mem + p - 0x13, 0xCECA0EB0)) ||
+				 (u32eq(mem + p, 0x4C00A0D3) &&
+				  u32eq(mem + p - 0x04, 0xD034C0C8)) ||
+				 (u32eq(mem + p, 0x4C00A0D2) &&
+				  u32eq(mem + p - 0x04, 0xD034C0C8))) &&
 				mem[p + 5] == 1) {
 				p += 4;
 				unp->_exoFnd = 1;
 				break;
-			} else if ((((*(unsigned int *)(mem + p) == 0x8C00A0d2) &&
-						 (*(unsigned int *)(mem + p - 0x04) == 0xD034C0C8)) ||
-						((*(unsigned int *)(mem + p) == 0x8C00A0d3) &&
-						 (*(unsigned int *)(mem + p - 0x04) == 0xD034C0C8)) ||
-						((*(unsigned int *)(mem + p) == 0x8C00A0cf) &&
-						 (*(unsigned int *)(mem + p - 0x04) == 0xD034C0C8))) &&
+			} else if (((u32eq(mem + p, 0x8C00A0d2) &&
+						 u32eq(mem + p - 0x04, 0xD034C0C8)) ||
+						(u32eq(mem + p, 0x8C00A0d3) &&
+						 u32eq(mem + p - 0x04, 0xD034C0C8)) ||
+						(u32eq(mem + p, 0x8C00A0cf) &&
+						 u32eq(mem + p - 0x04, 0xD034C0C8))) &&
 					   mem[p + 6] == 0x4c && mem[p + 8] == 1) {
 				p += 7;
 				unp->_exoFnd = 1;
@@ -127,7 +127,7 @@ void scnExomizer(UnpStr *unp) {
 			if (unp->_depAdr >= 0x134 && unp->_depAdr <= 0x14a /*0x13e*/) {
 				for (p = unp->_info->_end - 4; p > unp->_info->_start;
 					 p--) { /* 02 04 04 30 20 10 80 00 */
-					if (*(unsigned int *)(mem + p) == 0x30040402)
+					if (u32eq(mem + p, 0x30040402))
 						break;
 				}
 			} else {

--- a/engines/glk/scott/unp64/scanners/expert.cpp
+++ b/engines/glk/scott/unp64/scanners/expert.cpp
@@ -35,12 +35,12 @@ void scnExpert(UnpStr *unp) {
 	mem = unp->_mem;
 	if (unp->_depAdr == 0) {
 		for (q = 0x81b; q < 0x81d; q++) {
-			if ((*(unsigned int *)(mem + q + 0x00) == 0x852FA978) &&
-				(*(unsigned int *)(mem + q + 0x04) == 0x8534A900) &&
-				(*(unsigned int *)(mem + q + 0x14) == 0x03860286)) {
+			if (u32eq(mem + q + 0x00, 0x852FA978) &&
+				u32eq(mem + q + 0x04, 0x8534A900) &&
+				u32eq(mem + q + 0x14, 0x03860286)) {
 				for (p = 0x900; p < 0xfff0; p++) {
-					if ((*(unsigned int *)(mem + p + 1) == 0x00084C9A) &&
-						(*(unsigned int *)(mem + p - 4) == 0xA2058604)) {
+					if (u32eq(mem + p + 1, 0x00084C9A) &&
+						u32eq(mem + p - 4, 0xA2058604)) {
 						if (unp->_info->_run == -1) {
 							unp->_forced = q;
 							unp->_info->_run = q;
@@ -56,15 +56,15 @@ void scnExpert(UnpStr *unp) {
 		}
 		if (unp->_depAdr) {
 			unp->_rtiFrc = 1;
-			if (*(unsigned int *)(mem + 0x835) == 0x6E8D48A9) {
+			if (u32eq(mem + 0x835, 0x6E8D48A9)) {
 				p = 0;
-				if (*(unsigned int *)(mem + 0x92c) == 0x4902B100) {
+				if (u32eq(mem + 0x92c, 0x4902B100)) {
 					if (!unp->_idOnly) {
 						p = 0x876;
 						mem[p] = 0x00; /* 1st anti hack */
 						p = mem[0x930];
 					}
-				} else if (*(unsigned int *)(mem + 0x92f) == 0x4902B100) {
+				} else if (u32eq(mem + 0x92f, 0x4902B100)) {
 					if (!unp->_idOnly) {
 						p = 0x873;
 						mem[p] = 0xa9; /* 1st anti hack */
@@ -77,7 +77,7 @@ void scnExpert(UnpStr *unp) {
 					for (q = 0x980; q < 0xfff0; q++) {
 						if (((mem[q] ^ (p & 0xff)) == 0xac) &&
 							((mem[q + 3] ^ (p & 0xff)) == 0xc0) &&
-							(((*(unsigned int *)(mem + q + 7)) ^ p) == 0xC001F2AC)) {
+							u32eqxored(mem + q + 7, (unsigned int)p, 0xC001F2AC)) {
 							mem[q + 0x06] = (p & 0xff); /* 2nd anti hack */
 							mem[q + 0x0d] = (p & 0xff);
 							break;
@@ -88,11 +88,11 @@ void scnExpert(UnpStr *unp) {
 		}
 	}
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x81b) == 0x2FA9D878) &&
-			(*(unsigned int *)(mem + 0x82d) == 0x0873BDB0)) {
+		if (u32eq(mem + 0x81b, 0x2FA9D878) &&
+			u32eq(mem + 0x82d, 0x0873BDB0)) {
 			for (p = 0x900; p < 0xfff0; p++) {
-				if ((*(unsigned int *)(mem + p) == 0xA2F3D0CA) &&
-					(mem[p + 0x05] == 0x4c)) {
+				if (u32eq(mem + p, 0xA2F3D0CA) &&
+					mem[p + 0x05] == 0x4c) {
 					q = READ_LE_UINT16(&mem[p + 0x06]); // mem[p + 0x06] | mem[p + 0x07] << 8;
 					if (q != 0x100) {
 						unp->_depAdr = q;
@@ -110,13 +110,13 @@ void scnExpert(UnpStr *unp) {
 	   BloodMoney/HTL & SWIV/Inceria
 	*/
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x81b) == 0x8C00A078) &&
-			(*(unsigned int *)(mem + 0x831) == 0x05860485) &&
-			(*(unsigned int *)(mem + 0x998) == 0x00084C9A)) {
+		if (u32eq(mem + 0x81b, 0x8C00A078) &&
+			u32eq(mem + 0x831, 0x05860485) &&
+			u32eq(mem + 0x998, 0x00084C9A)) {
 			p = mem[0x919];
 			q = p << 24 | p << 16 | p << 8 | p;
 			for (p = 0x900; p < 0xfff0; p++) {
-				if (((*(unsigned int *)(mem + p) ^ q) == 0xA2F3D0CA) &&
+				if (((*(unsigned int *)(mem + p) ^ (unsigned int)q) == 0xA2F3D0CA) &&
 					((mem[p + 0x05] ^ (q & 0xff)) == 0x4c)) {
 					q = (mem[p + 0x06] ^ (q & 0xff)) | (mem[p + 0x07] ^ (q & 0xff)) << 8;
 					if (q != 0x100) {
@@ -133,13 +133,13 @@ void scnExpert(UnpStr *unp) {
 	}
 	/* sys2070 A.S.S. */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x817) == 0x00852FA9) &&
-			(*(unsigned int *)(mem + 0x823) == 0x05860485) &&
-			(*(unsigned int *)(mem + 0x9a0) == 0x00084C9A)) {
+		if (u32eq(mem + 0x817, 0x00852FA9) &&
+			u32eq(mem + 0x823, 0x05860485) &&
+			u32eq(mem + 0x9a0, 0x00084C9A)) {
 			p = mem[0x923];
 			q = p << 24 | p << 16 | p << 8 | p;
 			for (p = 0x900; p < 0xfff0; p++) {
-				if (((*(unsigned int *)(mem + p) ^ q) == 0xA2F3D0CA) &&
+				if (((*(unsigned int *)(mem + p) ^ (unsigned int)q) == 0xA2F3D0CA) &&
 					((mem[p + 0x05] ^ (q & 0xff)) == 0x4c)) {
 					q = (mem[p + 0x06] ^ (q & 0xff)) | (mem[p + 0x07] ^ (q & 0xff)) << 8;
 					if (q != 0x100) {
@@ -155,12 +155,12 @@ void scnExpert(UnpStr *unp) {
 		}
 	}
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x81b) == 0x7FA978D8) ||
-			(*(unsigned int *)(mem + 0x81b) == 0x7FA9D878) ||
-			(*(unsigned int *)(mem + 0x816) == 0x7FA978D8)) {
+		if (u32eq(mem + 0x81b, 0x7FA978D8) ||
+			u32eq(mem + 0x81b, 0x7FA9D878) ||
+			u32eq(mem + 0x816, 0x7FA978D8)) {
 			for (p = 0x900; p < 0xfff0; p++) {
-				if ((*(unsigned int *)(mem + p) == 0xA2F3D0CA) &&
-					(mem[p + 0x05] == 0x4c)) {
+				if (u32eq(mem + p, 0xA2F3D0CA) &&
+					mem[p + 0x05] == 0x4c) {
 					q = READ_LE_UINT16(&mem[p + 0x06]); // mem[p + 0x06] | mem[p + 0x07] << 8;
 					if (q != 0x100) {
 						unp->_depAdr = q;
@@ -170,13 +170,13 @@ void scnExpert(UnpStr *unp) {
 			}
 			if (unp->_depAdr) {
 				unp->_rtiFrc = 1;
-				if (*(unsigned int *)(mem + 0x816) == 0x7FA978D8) {
+				if (u32eq(mem + 0x816, 0x7FA978D8)) {
 					q = 0x816;
 					if (!unp->_idOnly) {
 						for (p = 0x900; p < 0xfff0; p++) {
-							if ((*(unsigned int *)(mem + p) == 0xE0A9F0A2) &&
-								(*(unsigned int *)(mem + p + 4) == 0xE807135D) &&
-								(mem[p + 0x8] == 0xd0)) {
+							if (u32eq(mem + p, 0xE0A9F0A2) &&
+								u32eq(mem + p + 4, 0xE807135D) &&
+								mem[p + 0x8] == 0xd0) {
 								mem[p + 0x1] = 0x00;
 								mem[p + 0x3] = 0x98;
 								memset(mem + p + 4, 0xea, 6);
@@ -188,9 +188,9 @@ void scnExpert(UnpStr *unp) {
 					q = 0x81b;
 					if (!unp->_idOnly) {
 						for (p = 0x900; p < 0xfff0; p++) {
-							if ((*(unsigned int *)(mem + p) == 0xCA08015D) &&
-								(*(unsigned int *)(mem + p + 4) == 0xF8D003E0) &&
-								(mem[p + 0xa] == 0xd0)) {
+							if (u32eq(mem + p, 0xCA08015D) &&
+								u32eq(mem + p + 4, 0xF8D003E0) &&
+								mem[p + 0xa] == 0xd0) {
 								p += 0xa;
 								mem[p] = 0x24;
 								break;
@@ -207,11 +207,11 @@ void scnExpert(UnpStr *unp) {
 	}
 	if (unp->_depAdr == 0) {
 		q = 0x81b;
-		if ((*(unsigned int *)(mem + q + 0x00) == 0x852FA978) &&
-			(*(unsigned int *)(mem + q + 0x04) == 0x8534A900) &&
-			(*(unsigned int *)(mem + q + 0x14) == 0x03860286) &&
-			(*(unsigned int *)(mem + q + 0x4f) == 0xA200594C) &&
-			(*(unsigned int *)(mem + q + 0xad) == 0x2000124C)) {
+		if (u32eq(mem + q + 0x00, 0x852FA978) &&
+			u32eq(mem + q + 0x04, 0x8534A900) &&
+			u32eq(mem + q + 0x14, 0x03860286) &&
+			u32eq(mem + q + 0x4f, 0xA200594C) &&
+			u32eq(mem + q + 0xad, 0x2000124C)) {
 			unp->_forced = q;
 			unp->_info->_run = q;
 			unp->_depAdr = 0x12;
@@ -221,11 +221,11 @@ void scnExpert(UnpStr *unp) {
 	/* expert 2.11 (sys2074) & unknown sys2061 */
 	if (unp->_depAdr == 0) {
 		for (q = 0x80d; q < 0x820; q++) {
-			if ((*(unsigned int *)(mem + q + 0x00) == 0x852FA978) &&
-				(*(unsigned int *)(mem + q + 0x04) == 0x8534A900) &&
-				(*(unsigned int *)(mem + q + 0x13) == 0x03840284) &&
-				(*(unsigned int *)(mem + q + 0x4f) == 0x084C003A) &&
-				(*(unsigned int *)(mem + q + 0xad) == 0x00AA2048)) {
+			if (u32eq(mem + q + 0x00, 0x852FA978) &&
+				u32eq(mem + q + 0x04, 0x8534A900) &&
+				u32eq(mem + q + 0x13, 0x03840284) &&
+				u32eq(mem + q + 0x4f, 0x084C003A) &&
+				u32eq(mem + q + 0xad, 0x00AA2048)) {
 				unp->_forced = q;
 				unp->_info->_run = q;
 				unp->_depAdr = 0x100 + mem[q + 0x17a] + 1;

--- a/engines/glk/scott/unp64/scanners/master_compressor.cpp
+++ b/engines/glk/scott/unp64/scanners/master_compressor.cpp
@@ -22,6 +22,7 @@
 #include "common/endian.h"
 #include "glk/scott/types.h"
 #include "glk/scott/unp64/unp64.h"
+#include "glk/scott/unp64/exo_util.h"
 
 namespace Glk {
 namespace Scott {
@@ -34,25 +35,25 @@ void scnMasterCompressor(UnpStr *unp) {
 	mem = unp->_mem;
 	if (unp->_depAdr == 0) {
 		for (p = 0x80d; p < 0x880; p++) {
-			if (((*(unsigned int *)(mem + p + 0x005) & 0x00ffffff) == 0x00BDD2A2) &&
-				 (*(unsigned int *)(mem + p + 0x00a) == 0xE000F99D) &&
-				 (*(unsigned int *)(mem + p + 0x017) == 0xCAEDD0CA) &&
-				 (*(unsigned int *)(mem + p + 0x031) == 0x84C82E86) &&
-				 ((*(unsigned int *)(mem + p + 0x035) & 0x0000ffff) == 0x00004C2D) &&
-				 (*(unsigned int *)(mem + p + 0x134) == 0xDBD0FFE6)) {
+			if (u32eqmasked(mem + p + 0x005, 0x00ffffff, 0x00BDD2A2) &&
+				u32eq(mem + p + 0x00a, 0xE000F99D) &&
+				u32eq(mem + p + 0x017, 0xCAEDD0CA) &&
+				u32eq(mem + p + 0x031, 0x84C82E86) &&
+				u32eqmasked(mem + p + 0x035, 0x0000ffff, 0x00004C2D) &&
+				u32eq(mem + p + 0x134, 0xDBD0FFE6)) {
 				if (/*mem[p]==0x78&&*/ mem[p + 1] == 0xa9 &&
-					(*(unsigned int *)(mem + p + 0x003) == 0xD2A20185)) {
-					unp->_depAdr = READ_LE_UINT16(&mem[p + 0x37]); // mem[p + 0x37] | mem[p + 0x38] << 8;
+					u32eq(mem + p + 0x003, 0xD2A20185)) {
+					unp->_depAdr = READ_LE_UINT16(&mem[p + 0x37]);
 					unp->_forced = p + 1;
 					if (mem[p + 0x12b] == 0x020) // jsr $0400, unuseful fx
 						mem[p + 0x12b] = 0x2c;
-				} else if (*(unsigned int *)(mem + p) == 0xD024E0E8) {
+				} else if (u32eq(mem + p, 0xD024E0E8)) {
 					/* HTL version */
-					unp->_depAdr = READ_LE_UINT16(&mem[p + 0x37]); // mem[p + 0x37] | mem[p + 0x38] << 8;
+					unp->_depAdr = READ_LE_UINT16(&mem[p + 0x37]);
 					unp->_forced = 0x840;
 				}
 				if (unp->_depAdr) {
-					unp->_retAdr = READ_LE_UINT16(&mem[p + 0x13e]); // mem[p + 0x13e] | mem[p + 0x13f] << 8;
+					unp->_retAdr = READ_LE_UINT16(&mem[p + 0x13e]);
 					unp->_endAdr = 0x2d;
 					unp->_fStrBf = unp->_endAdr;
 					unp->_idFlag = 1;
@@ -63,22 +64,22 @@ void scnMasterCompressor(UnpStr *unp) {
 	}
 	if (unp->_depAdr == 0) {
 		for (p = 0x80d; p < 0x880; p++) {
-			if (((*(unsigned int *)(mem + p + 0x005) & 0x00ffffff) == 0x00BDD2A2) &&
-				 (*(unsigned int *)(mem + p + 0x00a) == 0xE000F99D) &&
-				 (*(unsigned int *)(mem + p + 0x017) == 0xCAEDD0CA) &&
-				 (*(unsigned int *)(mem + p + 0x031) == 0x84C82E86) &&
-				 ((*(unsigned int *)(mem + p + 0x035) & 0x0000ffff) == 0x00004C2D) &&
-				 (*(unsigned int *)(mem + p + 0x12d) == 0xe2D0FFE6)) {
+			if (u32eqmasked(mem + p + 0x005, 0x00ffffff, 0x00BDD2A2) &&
+				u32eq(mem + p + 0x00a, 0xE000F99D) &&
+				u32eq(mem + p + 0x017, 0xCAEDD0CA) &&
+				u32eq(mem + p + 0x031, 0x84C82E86) &&
+				u32eqmasked(mem + p + 0x035, 0x0000ffff, 0x00004C2D) &&
+				u32eq(mem + p + 0x12d, 0xe2D0FFE6)) {
 				if (mem[p + 1] == 0xa9 &&
-					(*(unsigned int *)(mem + p + 0x003) == 0xD2A20185)) {
-					unp->_depAdr = READ_LE_UINT16(&mem[p + 0x37]); // mem[p + 0x37] | mem[p + 0x38] << 8;
+					u32eq(mem + p + 0x003, 0xD2A20185)) {
+					unp->_depAdr = READ_LE_UINT16(&mem[p + 0x37]);
 					unp->_forced = p + 1;
 				}
 				if (unp->_depAdr) {
 					if (mem[p + 0x136] == 0x4c)
-						unp->_retAdr = READ_LE_UINT16(&mem[p + 0x137]); // mem[p + 0x137] | mem[p + 0x138] << 8;
+						unp->_retAdr = READ_LE_UINT16(&mem[p + 0x137]);
 					else if (mem[p + 0x13d] == 0x4c)
-						unp->_retAdr = READ_LE_UINT16(&mem[p + 0x13e]); // mem[p + 0x13e] | mem[p + 0x13f] << 8;
+						unp->_retAdr = READ_LE_UINT16(&mem[p + 0x13e]);
 					unp->_endAdr = 0x2d;
 					unp->_fStrBf = unp->_endAdr;
 					unp->_idFlag = 1;
@@ -89,10 +90,10 @@ void scnMasterCompressor(UnpStr *unp) {
 	}
 	if (unp->_depAdr == 0) {
 		p = 0x812;
-		if ((*(unsigned int *)(mem + p + 0x000) == 0xE67800A0) &&
-			(*(unsigned int *)(mem + p + 0x004) == 0x0841B901) &&
-			(*(unsigned int *)(mem + p + 0x008) == 0xB900FA99) &&
-			(*(unsigned int *)(mem + p + 0x00c) == 0x34990910)) {
+		if (u32eq(mem + p + 0x000, 0xE67800A0) &&
+			u32eq(mem + p + 0x004, 0x0841B901) &&
+			u32eq(mem + p + 0x008, 0xB900FA99) &&
+			u32eq(mem + p + 0x00c, 0x34990910)) {
 			unp->_depAdr = 0x100;
 			unp->_forced = p;
 			unp->_retAdr = READ_LE_UINT16(&mem[0x943]); // mem[0x943] | mem[0x944] << 8;
@@ -104,10 +105,10 @@ void scnMasterCompressor(UnpStr *unp) {
 	}
 	/* Fred/Channel4 hack */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x811) == 0xA9A98078) &&
-			(*(unsigned int *)(mem + 0x815) == 0x85EE8034) &&
-			(*(unsigned int *)(mem + 0x819) == 0x802DA201) &&
-			(*(unsigned int *)(mem + 0x882) == 0x01004C2D)) {
+		if (u32eq(mem + 0x811, 0xA9A98078) &&
+			u32eq(mem + 0x815, 0x85EE8034) &&
+			u32eq(mem + 0x819, 0x802DA201) &&
+			u32eq(mem + 0x882, 0x01004C2D)) {
 			unp->_depAdr = 0x100;
 			unp->_forced = 0x811;
 			unp->_retAdr = READ_LE_UINT16(&mem[0x98b]); // mem[0x98b] | mem[0x98c] << 8;

--- a/engines/glk/scott/unp64/scanners/megabyte.cpp
+++ b/engines/glk/scott/unp64/scanners/megabyte.cpp
@@ -37,14 +37,14 @@ void scnMegabyte(UnpStr *unp) {
 		p = 0;
 		if (mem[0x816] == 0x4c)
 			p = READ_LE_UINT16(&mem[0x817]); // mem[0x817] | mem[0x818] << 8;
-		else if ((unp->_info->_run == 0x810) && (mem[0x814] == 0x4c) &&
-				 ((*(unsigned int *)(mem + 0x810) & 0xffff00ff) == 0x018500A9))
+		else if (unp->_info->_run == 0x810 && mem[0x814] == 0x4c &&
+				 u32eqmasked(mem + 0x810, 0xffff00ff, 0x018500A9))
 			p = READ_LE_UINT16(&mem[0x815]); // mem[0x815] | mem[0x816] << 8;
 		if (p) {
-			if ((mem[p + 0] == 0x78) && (mem[p + 1] == 0xa2) &&
-				(mem[p + 3] == 0xa0) &&
-				(*(unsigned int *)(mem + p + 0x05) == 0x15841486) &&
-				(*(unsigned int *)(mem + p + 0x1d) == 0x03804CF7)) {
+			if (mem[p + 0] == 0x78 && mem[p + 1] == 0xa2 &&
+				mem[p + 3] == 0xa0 &&
+				u32eq(mem + p + 0x05, 0x15841486) &&
+				u32eq(mem + p + 0x1d, 0x03804CF7)) {
 				unp->_depAdr = 0x380;
 				unp->_endAdr = READ_LE_UINT16(&mem[p + 0x55]); // mem[p + 0x55] | mem[p + 0x56] << 8;
 				unp->_endAdr++;
@@ -57,14 +57,14 @@ void scnMegabyte(UnpStr *unp) {
 	}
 	if (unp->_depAdr == 0) {
 		p = 0;
-		if ((mem[0x81a] == 0x4c) &&
-			((*(unsigned int *)(mem + 0x816) & 0xffff00ff) == 0x018500A9))
+		if (mem[0x81a] == 0x4c &&
+			u32eqmasked(mem + 0x816, 0xffff00ff, 0x018500A9))
 			p = READ_LE_UINT16(&mem[0x81b]); // mem[0x81b] | mem[0x81c] << 8;
 		if (p) {
-			if ((mem[p + 0] == 0x78) && (mem[p + 1] == 0xa2) &&
-				(mem[p + 3] == 0xa0) &&
-				(*(unsigned int *)(mem + p + 0x05) == 0x15841486) &&
-				(*(unsigned int *)(mem + p + 0x1d) == 0x03844CF7)) {
+			if (mem[p + 0] == 0x78 && mem[p + 1] == 0xa2 &&
+				mem[p + 3] == 0xa0 &&
+				u32eq(mem + p + 0x05, 0x15841486) &&
+				u32eq(mem + p + 0x1d, 0x03844CF7)) {
 				unp->_depAdr = 0x384;
 				unp->_forced = 0x816;
 				unp->_endAdr = READ_LE_UINT16(&mem[p + 0x59]); // mem[p + 0x59] | mem[p + 0x5a] << 8;

--- a/engines/glk/scott/unp64/scanners/pu_crunch.cpp
+++ b/engines/glk/scott/unp64/scanners/pu_crunch.cpp
@@ -34,52 +34,52 @@ void scnPuCrunch(UnpStr *unp) {
 		return;
 	mem = unp->_mem;
 	if (unp->_depAdr == 0) {
-		if ((mem[0x80d] == 0x78) &&
-			(*(unsigned int *)(mem + 0x813) == 0x34A20185) &&
-			(*(unsigned int *)(mem + 0x817) == 0x9D0842BD) &&
-			(*(unsigned int *)(mem + 0x81b) == 0xD0CA01FF) &&
-			(*(unsigned int *)(mem + 0x83d) == 0x4CEDD088)) {
+		if (mem[0x80d] == 0x78 &&
+			u32eq(mem + 0x813, 0x34A20185) &&
+			u32eq(mem + 0x817, 0x9D0842BD) &&
+			u32eq(mem + 0x81b, 0xD0CA01FF) &&
+			u32eq(mem + 0x83d, 0x4CEDD088)) {
 			for (p = 0x912; p < 0x938; p++) {
-				if ((*(unsigned int *)(mem + p) == 0x2D85FAA5) &&
-					(*(unsigned int *)(mem + p + 4) == 0x2E85FBA5)) {
+				if (u32eq(mem + p, 0x2D85FAA5) &&
+					u32eq(mem + p + 4, 0x2E85FBA5)) {
 					unp->_endAdr = 0xfa;
-					unp->_strMem = READ_LE_UINT16(&mem[0x879]); // mem[0x879] | mem[0x87a] << 8;
-					unp->_depAdr = READ_LE_UINT16(&mem[0x841]); // mem[0x841] | mem[0x842] << 8;
+					unp->_strMem = READ_LE_UINT16(&mem[0x879]);   // mem[0x879] | mem[0x87a] << 8;
+					unp->_depAdr = READ_LE_UINT16(&mem[0x841]);   // mem[0x841] | mem[0x842] << 8;
 					unp->_retAdr = READ_LE_UINT16(&mem[p + 0xa]); // mem[p + 0xa] | mem[p + 0xb] << 8;
 					unp->_forced = 0x80d;
 					break;
 				}
 			}
-		} else if ((mem[0x80d] == 0x78) &&
-				   (*(unsigned int *)(mem + 0x81a) == 0x10CA4B95) &&
-				   (*(unsigned int *)(mem + 0x81e) == 0xBD3BA2F8) &&
-				   (*(unsigned int *)(mem + 0x847) == 0x4CEDD088)) {
+		} else if (mem[0x80d] == 0x78 &&
+				   u32eq(mem + 0x81a, 0x10CA4B95) &&
+				   u32eq(mem + 0x81e, 0xBD3BA2F8) &&
+				   u32eq(mem + 0x847, 0x4CEDD088)) {
 			for (p = 0x912; p < 0x938; p++) {
-				if ((*(unsigned int *)(mem + p) == 0x2D85FAA5) &&
-					(*(unsigned int *)(mem + p + 4) == 0x2E85FBA5)) {
+				if (u32eq(mem + p, 0x2D85FAA5) &&
+					u32eq(mem + p + 4, 0x2E85FBA5)) {
 					unp->_endAdr = 0xfa;
 					unp->_strMem = READ_LE_UINT16(&mem[p + 0x88a]); // mem[0x88a] | mem[0x88b] << 8;
 					unp->_depAdr = READ_LE_UINT16(&mem[p + 0x84b]); // mem[0x84b] | mem[0x84c] << 8;
-					unp->_retAdr = READ_LE_UINT16(&mem[p + 0xa]); // mem[p + 0xa] | mem[p + 0xb] << 8;
+					unp->_retAdr = READ_LE_UINT16(&mem[p + 0xa]);   // mem[p + 0xa] | mem[p + 0xb] << 8;
 					unp->_forced = 0x80d;
 					break;
 				}
 			}
-		} else if ((mem[0x80d] == 0x78) &&
-				   (*(unsigned int *)(mem + 0x811) == 0x85AAA901) &&
-				   (*(unsigned int *)(mem + 0x81d) == 0xF69D083C) &&
-				   (*(unsigned int *)(mem + 0x861) == 0xC501C320) &&
-				   (*(unsigned int *)(mem + 0x839) == 0x01164CED)) {
+		} else if (mem[0x80d] == 0x78 &&
+				   u32eq(mem + 0x811, 0x85AAA901) &&
+				   u32eq(mem + 0x81d, 0xF69D083C) &&
+				   u32eq(mem + 0x861, 0xC501C320) &&
+				   u32eq(mem + 0x839, 0x01164CED)) {
 			unp->_endAdr = 0xfa;
 			unp->_strMem = READ_LE_UINT16(&mem[0x840]); // mem[0x840] | mem[0x841] << 8;
 			unp->_depAdr = 0x116;
 			unp->_retAdr = READ_LE_UINT16(&mem[0x8df]); // mem[0x8df] | mem[0x8e0] << 8;
 			unp->_forced = 0x80d;
-		} else if ((mem[0x80d] == 0x78) &&
-				   (*(unsigned int *)(mem + 0x811) == 0x85AAA901) &&
-				   (*(unsigned int *)(mem + 0x81d) == 0xF69D083C) &&
-				   (*(unsigned int *)(mem + 0x861) == 0xC501C820) &&
-				   (*(unsigned int *)(mem + 0x839) == 0x01164CED)) {
+		} else if (mem[0x80d] == 0x78 &&
+				   u32eq(mem + 0x811, 0x85AAA901) &&
+				   u32eq(mem + 0x81d, 0xF69D083C) &&
+				   u32eq(mem + 0x861, 0xC501C820) &&
+				   u32eq(mem + 0x839, 0x01164CED)) {
 			unp->_endAdr = 0xfa;
 			unp->_strMem = READ_LE_UINT16(&mem[0x840]); // mem[0x840] | mem[0x841] << 8;
 			unp->_depAdr = 0x116;
@@ -100,11 +100,11 @@ void scnPuCrunch(UnpStr *unp) {
 				if (mem[p] == 0x78) {
 					q = p;
 					for (; p < 0x824; p++) {
-						if (((*(unsigned int *)(mem + p) & 0xf0ffffff) == 0xF0BD53A2) &&
-							(*(unsigned int *)(mem + p + 4) == 0x01FF9D08) &&
-							(*(unsigned int *)(mem + p + 8) == 0xA2F7D0CA)) {
+						if (u32eqmasked(mem + p, 0xf0ffffff, 0xF0BD53A2) &&
+							u32eq(mem + p + 4, 0x01FF9D08) &&
+							u32eq(mem + p + 8, 0xA2F7D0CA)) {
 							unp->_forced = q;
-							q = mem[p + 3] & 0xf; /* can be $f0 or $f2, q&0x0f as offset */
+							q = mem[p + 3] & 0xf;              /* can be $f0 or $f2, q&0x0f as offset */
 							p = READ_LE_UINT16(&mem[p + 0xe]); // mem[p + 0xe] | mem[p + 0xf] << 8;
 							if (mem[p - 2] == 0x4c && mem[p + 0xa0 + q] == 0x85) {
 								unp->_depAdr = READ_LE_UINT16(&mem[p - 1]); // mem[p - 1] | mem[p] << 8;
@@ -113,8 +113,8 @@ void scnPuCrunch(UnpStr *unp) {
 								p += 0xa2;
 								q = p + 8;
 								for (; p < q; p++) {
-									if ((*(unsigned int *)(mem + p) == 0x2D85FAA5) &&
-										(mem[p + 9] == 0x4c)) {
+									if (u32eq(mem + p, 0x2D85FAA5) &&
+										mem[p + 9] == 0x4c) {
 										unp->_retAdr = READ_LE_UINT16(&mem[p + 0xa]); // mem[p + 0xa] | mem[p + 0xb] << 8;
 										break;
 									}
@@ -135,12 +135,12 @@ void scnPuCrunch(UnpStr *unp) {
 		if (unp->_depAdr == 0) {
 			unp->_idFlag = 0;
 			for (q = 0x70; q < 0xff; q++) {
-				if (((*(unsigned int *)(mem + 0x801 + q) & 0xFFFF00FF) == 0x20C80090) &&
-					((*(unsigned int *)(mem + 0x801 + q + 8) & 0xFFFF0FFF) ==
+				if (u32eqmasked(mem + 0x801 + q, 0xFFFF00FF, 0x20C80090) &&
+					u32eqmasked(mem + 0x801 + q + 8, 0xFFFF0FFF,
 					 0x0B9000C9) &&
-					((*(unsigned int *)(mem + 0x801 + q + 12) & 0x00FFF0FF) ==
+					u32eqmasked(mem + 0x801 + q + 12, 0x00FFF0FF,
 					 0x002000A2) &&
-					((*(unsigned int *)(mem + 0x801 + q + 30) & 0xF0FFFFFf) ==
+					u32eqmasked(mem + 0x801 + q + 30, 0xF0FFFFFf,
 					 0x009020E0)) {
 					unp->_idFlag = 385;
 					break;
@@ -148,10 +148,10 @@ void scnPuCrunch(UnpStr *unp) {
 			}
 			if (unp->_idFlag) {
 				for (p = 0x801 + q + 34; p < 0x9ff; p++) {
-					if (*(unsigned int *)(mem + p) == 0x00F920E8) {
+					if (u32eq(mem + p, 0x00F920E8)) {
 						for (; p < 0x9ff; p++) {
 							if (mem[p] == 0x4c) {
-								unp->_retAdr = mem[p + 1] | mem[p + 2] << 8;
+								unp->_retAdr = READ_LE_UINT16(&mem[p + 1]);
 								if (unp->_retAdr > 0x257)
 									break;
 							}
@@ -167,14 +167,14 @@ void scnPuCrunch(UnpStr *unp) {
 								unp->_info->_run = unp->_forced;
 							}
 						}
-					if ((*(unsigned int *)(mem + 0x801 + p) == 0xCA00F69D) &&
-						(mem[0x801 + p + 0x1b] == 0x4c)) {
+					if (u32eq(mem + 0x801 + p, 0xCA00F69D) &&
+						mem[0x801 + p + 0x1b] == 0x4c) {
 						q = 0x801 + p + 0x1c;
-						unp->_depAdr = mem[q] | mem[q + 1] << 8;
+						unp->_depAdr = READ_LE_UINT16(&mem[q]);
 						q = 0x801 + p - 2;
-						p = mem[q] | mem[q + 1] << 8;
+						p = READ_LE_UINT16(&mem[q]);
 						if ((mem[p + 3] == 0x8d) && (mem[p + 6] == 0xe6)) {
-							unp->_strMem = mem[p + 4] | mem[p + 5] << 8;
+							unp->_strMem = READ_LE_UINT16(&mem[p + 4]);
 						}
 						break;
 					}

--- a/engines/glk/scott/unp64/scanners/section8.cpp
+++ b/engines/glk/scott/unp64/scanners/section8.cpp
@@ -32,14 +32,14 @@ void scnSection8(UnpStr *unp) {
 	int p;
 	if (unp->_idFlag)
 		return;
-	mem =unp->_mem;
+	mem = unp->_mem;
 	if (unp->_depAdr == 0) {
 		for (p = 0x810; p <= 0x828; p++) {
-			if ((*(unsigned int *)(mem + p) == (unsigned int)(0x00BD00A2 + (((p & 0xff) + 0x11) << 24))) &&
-				(*(unsigned int *)(mem + p + 0x04) == 0x01009D08) &&
-				(*(unsigned int *)(mem + p + 0x10) == 0x34A97801) &&
-				(*(unsigned int *)(mem + p + 0x6a) == 0xB1017820) &&
-				(*(unsigned int *)(mem + p + 0x78) == 0x017F20AE)) {
+			if (u32eq(mem + p, (unsigned int)(0x00BD00A2 + (((p & 0xff) + 0x11) << 24))) &&
+				u32eq(mem + p + 0x04, 0x01009D08) &&
+				u32eq(mem + p + 0x10, 0x34A97801) &&
+				u32eq(mem + p + 0x6a, 0xB1017820) &&
+				u32eq(mem + p + 0x78, 0x017F20AE)) {
 				unp->_depAdr = 0x100;
 				break;
 			}
@@ -47,7 +47,7 @@ void scnSection8(UnpStr *unp) {
 		if (unp->_depAdr) {
 			if (unp->_info->_run == -1)
 				unp->_forced = p;
-			unp->_strMem = READ_LE_UINT16(&mem[p + 0x47]); // mem[p + 0x47] | mem[p + 0x4b] << 8;
+			unp->_strMem = mem[p + 0x47] | mem[p + 0x4b] << 8;
 			unp->_retAdr = READ_LE_UINT16(&mem[p + 0x87]); // mem[p + 0x87] | mem[p + 0x88] << 8;
 			if (unp->_retAdr == 0xf7) {
 				unp->_retAdr = 0xa7ae;
@@ -61,16 +61,16 @@ void scnSection8(UnpStr *unp) {
 	}
 	/* Crackman variant? */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x827) == 0x38BD00A2) &&
-			(*(unsigned int *)(mem + 0x82b) == 0x01009D08) &&
-			(*(unsigned int *)(mem + 0x837) == 0x34A97801) &&
-			(*(unsigned int *)(mem + 0x891) == 0xB1018420) &&
-			(*(unsigned int *)(mem + 0x89f) == 0x018b20AE)) {
+		if (u32eq(mem + 0x827, 0x38BD00A2) &&
+			u32eq(mem + 0x82b, 0x01009D08) &&
+			u32eq(mem + 0x837, 0x34A97801) &&
+			u32eq(mem + 0x891, 0xB1018420) &&
+			u32eq(mem + 0x89f, 0x018b20AE)) {
 			unp->_depAdr = 0x100;
 			if (unp->_info->_run == -1)
 				unp->_forced = 0x827;
-			unp->_strMem = READ_LE_UINT16(&mem[0x86e]); // mem[0x86e] | mem[0x872] << 8;
-			if (*(unsigned short int *)(mem + 0x8b7) == 0xff5b) {
+			unp->_strMem = mem[0x86e] | mem[0x872] << 8;
+			if (u16eq(mem + 0x8b7, 0xff5b)) {
 				mem[0x8b6] = 0x2c;
 				unp->_retAdr = READ_LE_UINT16(&mem[0x8ba]); // mem[0x8ba] | mem[0x8bb] << 8;
 			} else {
@@ -83,14 +83,14 @@ void scnSection8(UnpStr *unp) {
 	}
 	/* PET||SLAN variant? */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x812) == 0x20BD00A2) &&
-			(*(unsigned int *)(mem + 0x816) == 0x033c9D08) &&
-			(*(unsigned int *)(mem + 0x863) == 0xB103B420) &&
-			(*(unsigned int *)(mem + 0x86c) == 0x03BB20AE)) {
+		if (u32eq(mem + 0x812, 0x20BD00A2) &&
+			u32eq(mem + 0x816, 0x033c9D08) &&
+			u32eq(mem + 0x863, 0xB103B420) &&
+			u32eq(mem + 0x86c, 0x03BB20AE)) {
 			unp->_depAdr = 0x33c;
 			if (unp->_info->_run == -1)
 				unp->_forced = 0x812;
-			unp->_strMem = READ_LE_UINT16(&mem[0x856]); // mem[0x856] | mem[0x85a] << 8;
+			unp->_strMem = mem[0x856] | mem[0x85a] << 8;
 			unp->_retAdr = READ_LE_UINT16(&mem[0x896]); // mem[0x896] | mem[0x897] << 8;
 			unp->_endAdr = 0xae;
 			unp->_idFlag = 1;

--- a/engines/glk/scott/unp64/scanners/tbc_multicomp.cpp
+++ b/engines/glk/scott/unp64/scanners/tbc_multicomp.cpp
@@ -34,17 +34,17 @@ void scnTBCMultiComp(UnpStr *unp) {
 		return;
 	mem = unp->_mem;
 	if (unp->_depAdr == 0) {
-		if (((*(unsigned int *)(mem + 0x82c) & 0xfffffffd) == 0x9ACA0184) &&
-			 (*(unsigned int *)(mem + 0x830) == 0xA001004C) &&
-			 (*(unsigned int *)(mem + 0x834) == 0x84FD8400) &&
-			 (*(unsigned int *)(mem + 0x8a2) == 0x01494C01)) {
+		if (u32eqmasked(mem + 0x82c, 0xfffffffd, 0x9ACA0184) &&
+			u32eq(mem + 0x830, 0xA001004C) &&
+			u32eq(mem + 0x834, 0x84FD8400) &&
+			u32eq(mem + 0x8a2, 0x01494C01)) {
 			/*normal 2080*/
 			if (mem[0x84a] == 0x81) {
-				if (*(unsigned int *)(mem + 0x820) == 0x32BDE9A2) {
+				if (u32eq(mem + 0x820, 0x32BDE9A2)) {
 					unp->_forced = 0x820;
 					unp->_retAdr = READ_LE_UINT16(&mem[0x8b2]); // mem[0x8b2] | mem[0x8b3] << 8;
 					if (unp->_retAdr == 0x1e1) {
-						if (*(unsigned int *)(mem + 0x916) == 0x4CA87120) {
+						if (u32eq(mem + 0x916, 0x4CA87120)) {
 							p = *(unsigned short int *)(mem + 0x91a);
 							if (p == 0xa7ae) {
 								unp->_retAdr = p;
@@ -71,7 +71,7 @@ void scnTBCMultiComp(UnpStr *unp) {
 			}
 			/*firelord 2076*/
 			else if (mem[0x84a] == 0x7b) {
-				if (*(unsigned int *)(mem + 0x81d) == 0x32BDE9A2) {
+				if (u32eq(mem + 0x81d, 0x32BDE9A2)) {
 					unp->_forced = 0x81d;
 					unp->_retAdr = READ_LE_UINT16(&mem[0x8ac]); // mem[0x8ac] | mem[0x8ad] << 8;
 					p = 0x8eb;
@@ -97,11 +97,11 @@ void scnTBCMultiComp(UnpStr *unp) {
 	}
 	/* TBC Multicompactor ?  very similar but larger code */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x822) == 0x9D083DBD) &&
-			(*(unsigned int *)(mem + 0x826) == 0xD0CA0333) &&
-			(*(unsigned int *)(mem + 0x832) == 0xF7D0CA00) &&
-			(*(unsigned int *)(mem + 0x836) == 0xCA018678) &&
-			(*(unsigned int *)(mem + 0x946) == 0xADC5AFA5)) {
+		if (u32eq(mem + 0x822, 0x9D083DBD) &&
+			u32eq(mem + 0x826, 0xD0CA0333) &&
+			u32eq(mem + 0x832, 0xF7D0CA00) &&
+			u32eq(mem + 0x836, 0xCA018678) &&
+			u32eq(mem + 0x946, 0xADC5AFA5)) {
 			if (unp->_info->_run == -1) {
 				for (p = 0x81e; p < 0x821; p++) {
 					if (mem[p] == 0xa2) {
@@ -130,10 +130,10 @@ void scnTBCMultiComp(UnpStr *unp) {
 	}
 	/*"AUTOMATIC BREAK SYSTEM" found in Manowar Cracks*/
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x835) == 0x9D0845BD) &&
-			(*(unsigned int *)(mem + 0x839) == 0xD0CA00ff) &&
-			(*(unsigned int *)(mem + 0x83e) == 0xCA018678) &&
-			(*(unsigned int *)(mem + 0x8e1) == 0xADC5AFA5)) {
+		if (u32eq(mem + 0x835, 0x9D0845BD) &&
+			u32eq(mem + 0x839, 0xD0CA00ff) &&
+			u32eq(mem + 0x83e, 0xCA018678) &&
+			u32eq(mem + 0x8e1, 0xADC5AFA5)) {
 			if (unp->_info->_run == -1) {
 				for (p = 0x830; p < 0x834; p++) {
 					if (mem[p] == 0xa2) {

--- a/engines/glk/scott/unp64/scanners/tcs_crunch.cpp
+++ b/engines/glk/scott/unp64/scanners/tcs_crunch.cpp
@@ -22,6 +22,7 @@
 #include "common/endian.h"
 #include "glk/scott/types.h"
 #include "glk/scott/unp64/unp64.h"
+#include "glk/scott/unp64/exo_util.h"
 
 namespace Glk {
 namespace Scott {
@@ -33,23 +34,22 @@ void scnTCScrunch(UnpStr *unp) {
 		return;
 	mem = unp->_mem;
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x819) == 0x018536A9) && mem[0x81d] == 0x4c) {
+		if (u32eq(mem + 0x819, 0x018536A9) && mem[0x81d] == 0x4c) {
 			p = READ_LE_UINT16(&mem[0x81e]); // mem[0x81e] | mem[0x81f] << 8;
 			if (mem[p] == 0xa2 && mem[p + 2] == 0xbd &&
-				(*(unsigned int *)(mem + p + 0x05) == 0xE801109D) &&
-				((*(unsigned int *)(mem + p + 0x38) == 0x01524CFB) ||
-				((*(unsigned int *)(mem + p + 0x38) == 0x8DE1A9FB) &&
-				(*(unsigned int *)(mem + p + 0x3c) == 0x524C0328)))) {
+				u32eq(mem + p + 0x05, 0xE801109D) &&
+				(u32eq(mem + p + 0x38, 0x01524CFB) ||
+				 (u32eq(mem + p + 0x38, 0x8DE1A9FB) &&
+				  u32eq(mem + p + 0x3c, 0x524C0328)))) {
 				unp->_depAdr = 0x334;
 				unp->_forced = 0x819;
 				unp->_endAdr = 0x2d;
 			}
-		}
-		else if ((*(unsigned int *)(mem + 0x819) == 0x018534A9) && mem[0x81d] == 0x4c) {
+		} else if (u32eq(mem + 0x819, 0x018534A9) && mem[0x81d] == 0x4c) {
 			p = READ_LE_UINT16(&mem[0x81e]); // mem[0x81e] | mem[0x81f] << 8;
 			if (mem[p] == 0xa2 && mem[p + 2] == 0xbd &&
-				(*(unsigned int *)(mem + p + 0x05) == 0xE801109D) &&
-				(*(unsigned int *)(mem + p + 0x38) == 0x01304CFB)) {
+				u32eq(mem + p + 0x05, 0xE801109D) &&
+				u32eq(mem + p + 0x38, 0x01304CFB)) {
 				unp->_depAdr = 0x334;
 				unp->_forced = 0x818;
 				if (mem[unp->_forced] != 0x78)
@@ -59,9 +59,9 @@ void scnTCScrunch(UnpStr *unp) {
 				p += 0xc8;
 				q = p + 6;
 				for (; p < q; p += 3) {
-					if ((mem[p] == 0x20) &&
-						(*(unsigned short int *)(mem + p + 1) >= 0xa000) &&
-						(*(unsigned short int *)(mem + p + 1) <= 0xbfff)) {
+					if (mem[p] == 0x20 &&
+						u16gteq(mem + p + 1, 0xa000) &&
+						u16lteq(mem + p + 1, 0xbfff)) {
 						mem[p] = 0x2c;
 					}
 				}

--- a/engines/glk/scott/unp64/scanners/xtc.cpp
+++ b/engines/glk/scott/unp64/scanners/xtc.cpp
@@ -22,6 +22,7 @@
 #include "common/endian.h"
 #include "glk/scott/types.h"
 #include "glk/scott/unp64/unp64.h"
+#include "glk/scott/unp64/exo_util.h"
 
 namespace Glk {
 namespace Scott {
@@ -33,10 +34,10 @@ void scnXTC(UnpStr *unp) {
 		return;
 	mem = unp->_mem;
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned short int *)(mem + 0x80d) == 0xE678) &&
-			(*(unsigned int *)(mem + 0x811) == 0x1BCE0818) &&
-			(*(unsigned int *)(mem + 0x819) == 0xC8000099) &&
-			(*(unsigned int *)(mem + 0x82c) == 0x4CF7D0CA) &&
+		if (u16eq(mem + 0x80d, 0xE678) &&
+			u32eq(mem + 0x811, 0x1BCE0818) &&
+			u32eq(mem + 0x819, 0xC8000099) &&
+			u32eq(mem + 0x82c, 0x4CF7D0CA) &&
 			mem[0x85c] == 0x99) {
 			unp->_retAdr = READ_LE_UINT16(&mem[0x872]); // mem[0x872] | mem[0x873] << 8;
 			unp->_depAdr = 0x100;
@@ -51,10 +52,10 @@ void scnXTC(UnpStr *unp) {
 	/* XTC packer 1.0 & 2.2/2.4 */
 	if (unp->_depAdr == 0) {
 		for (p = 0x801; p < 0x80c; p += 0x0a) {
-			if ((*(unsigned short int *)(mem + p + 0x02) == 0xE678) &&
-				(*(unsigned int *)(mem + p + 0x07) == (unsigned int)(0xce08 | ((p + 0x10) << 16))) &&
-				(*(unsigned int *)(mem + p + 0x0e) == 0xC8000099) &&
-				(*(unsigned int *)(mem + p + 0x23) == 0x4CF7D0CA)) {
+			if (u16eq(mem + p + 0x02, 0xE678) &&
+				u32eq(mem + p + 0x07, (unsigned int)(0xce08 | ((p + 0x10) << 16))) &&
+				u32eq(mem + p + 0x0e, 0xC8000099) &&
+				u32eq(mem + p + 0x23, 0x4CF7D0CA)) {
 				/* has variable codebytes so addresses varies */
 				for (q = p + 0x37; q < p + 0x60; q += 4) {
 					if (mem[q] == 0xc9)
@@ -70,7 +71,7 @@ void scnXTC(UnpStr *unp) {
 		}
 		if (unp->_depAdr) {
 			unp->_retAdr = READ_LE_UINT16(&mem[q + 0x16]); // mem[q + 0x16] | mem[q + 0x17] << 8;
-			if (*(unsigned short int *)(mem + p) != 0x00a0)
+			if (u16noteq(mem + p, 0x00a0))
 				unp->_forced = p + 2; /* the ldy #$00 can be missing, skipped */
 			else
 				unp->_forced = p;
@@ -79,10 +80,10 @@ void scnXTC(UnpStr *unp) {
 			unp->_fEndAf--;
 			unp->_endAdC = 0xffff | EA_USE_Y;
 			unp->_strMem = READ_LE_UINT16(&mem[q + 1]); // mem[q + 1] | mem[q + 2] << 8;
-			if (*(unsigned int *)(mem + q + 0x1f) == 0xDDD00285) {
-			} else if (*(unsigned int *)(mem + q + 0x1f) == 0xF620DFD0) {
+			if (u32eq(mem + q + 0x1f, 0xDDD00285)) {
+			} else if (u32eq(mem + q + 0x1f, 0xF620DFD0)) {
 				/* rockstar's 2.2+ & shade/light's 2.4 are all the same */
-			} else { /* actually found to be Visiomizer 6.2/Zagon */
+			} else {                                           /* actually found to be Visiomizer 6.2/Zagon */
 				unp->_depAdr = READ_LE_UINT16(&mem[p + 0x27]); // mem[p + 0x27] | mem[p + 0x28] << 8;
 			}
 			unp->_idFlag = 1;
@@ -91,10 +92,10 @@ void scnXTC(UnpStr *unp) {
 	}
 	/* XTC 2.3 / 6codezipper */
 	if (unp->_depAdr == 0) {
-		if ((*(unsigned int *)(mem + 0x803) == 0xB9018478) &&
-			(*(unsigned int *)(mem + 0x80b) == 0xF7D0C8FF) &&
-			(*(unsigned int *)(mem + 0x81b) == 0x00FC9D08) &&
-			(*(unsigned int *)(mem + 0x85b) == 0xD0D0FFE4)) {
+		if (u32eq(mem + 0x803, 0xB9018478) &&
+			u32eq(mem + 0x80b, 0xF7D0C8FF) &&
+			u32eq(mem + 0x81b, 0x00FC9D08) &&
+			u32eq(mem + 0x85b, 0xD0D0FFE4)) {
 			unp->_depAdr = READ_LE_UINT16(&mem[0x823]); // mem[0x823] | mem[0x824] << 8;
 			unp->_forced = 0x803;
 			unp->_retAdr = READ_LE_UINT16(&mem[0x865]); // mem[0x865] | mem[0x866] << 8;
@@ -107,11 +108,11 @@ void scnXTC(UnpStr *unp) {
 	}
 	/* XTC 2.3 / G*P, probably by Rockstar */
 	if (unp->_depAdr == 0) {
-		if (((*(unsigned int *)(mem + 0x803) == 0xB901e678) ||
-			 (*(unsigned int *)(mem + 0x803) == 0xB9018478)) &&
-			 (*(unsigned int *)(mem + 0x80b) == 0xF7D0C8FF) &&
-			 (*(unsigned int *)(mem + 0x81b) == 0x00F59D08) &&
-			 (*(unsigned int *)(mem + 0x85b) == 0xD0D0F8E4)) {
+		if ((u32eq(mem + 0x803, 0xB901e678) ||
+			 u32eq(mem + 0x803, 0xB9018478)) &&
+			u32eq(mem + 0x80b, 0xF7D0C8FF) &&
+			u32eq(mem + 0x81b, 0x00F59D08) &&
+			u32eq(mem + 0x85b, 0xD0D0F8E4)) {
 			unp->_depAdr = READ_LE_UINT16(&mem[0x823]); // mem[0x823] | mem[0x824] << 8;
 			unp->_forced = 0x803;
 			unp->_retAdr = READ_LE_UINT16(&mem[0x865]); // mem[0x865] | mem[0x866] << 8;
@@ -127,10 +128,10 @@ void scnXTC(UnpStr *unp) {
 	*/
 	if (unp->_depAdr == 0) {
 		for (p = 0x801; p < 0x80c; p += 0x0a) {
-			if (((*(unsigned int *)(mem + p + 0x00) & 0xffff0000) == 0xE6780000) &&
-				((*(unsigned int *)(mem + p + 0x05) & 0xffff00ff) == 0xB90800CE) &&
-				(*(unsigned int *)(mem + p + 0x0b) == 0xC8000099) &&
-				(*(unsigned int *)(mem + p + 0x1e) == 0x4CF7D0CA)) {
+			if (u32eqmasked(mem + p + 0x00, 0xffff0000, 0xE6780000) &&
+				u32eqmasked(mem + p + 0x05, 0xffff00ff, 0xB90800CE) &&
+				u32eq(mem + p + 0x0b, 0xC8000099) &&
+				u32eq(mem + p + 0x1e, 0x4CF7D0CA)) {
 				/* has variable codebytes so addresses varies */
 				for (q = p + 0x36; q < p + 0x60; q += 4) {
 					if (mem[q] == 0xc9)

--- a/engines/glk/scott/unp64/unp64.cpp
+++ b/engines/glk/scott/unp64/unp64.cpp
@@ -97,7 +97,25 @@ int isBasicRun2(int pc) {
 		return 0;
 }
 
-int unp64(uint8_t *compressed, size_t length, uint8_t *destinationBuffer, size_t *finalLength, char *settings[], int numSettings) {
+int unp64(byte *compressed, size_t length, byte *destinationBuffer, size_t *finalLength, const char *switches) {
+
+	char settings[4][64];
+	int numSettings = 0;
+
+	if (switches != NULL) {
+		char string[100];
+		size_t string_length = strlen(switches);
+		if (string_length > 0 && string_length < 100) {
+			snprintf(string, sizeof string, "%s", switches);
+			char *setting = strtok(string, " ");
+			while (setting != NULL && numSettings < 4) {
+				snprintf(settings[numSettings], sizeof settings[numSettings], "%s", setting);
+				numSettings++;
+				setting = strtok(NULL, " ");
+			}
+		}
+	}
+
 	CpuCtx r[1];
 	LoadInfo info[1];
 	char name[260] = {0}, forcedname[260] = {0};
@@ -135,7 +153,6 @@ int unp64(uint8_t *compressed, size_t length, uint8_t *destinationBuffer, size_t
 						 0xA7, 0xA7, 0x79, 0xA6, 0x9C, 0xE3};
 
 	int iterMax = ITERMAX;
-	//int copyRoms[2][2] = {{0xa000, 0}, {0xe000, 0}};
 	int p;
 
 	memset(&_G(_unp), 0, sizeof(_G(_unp)));
@@ -173,7 +190,7 @@ int unp64(uint8_t *compressed, size_t length, uint8_t *destinationBuffer, size_t
 
 	if ((_G(_unp)._recurs == 0) && (numSettings > 0)) {
 		while (p < numSettings) {
-			if (settings && settings[p][0] == '-') {
+			if (settings[p][0] == '-') {
 				switch (settings[p][1]) {
 				case '-':
 					p = numSettings;
@@ -446,7 +463,7 @@ int unp64(uint8_t *compressed, size_t length, uint8_t *destinationBuffer, size_t
 				if (_G(_unp)._mon1st == 0) {
 					_G(_unp)._strMem = p;
 				}
-				_G(_unp)._mon1st = _G(_unp)._strMem;
+				_G(_unp)._mon1st = (unsigned int)_G(_unp)._strMem;
 				_G(_unp)._strMem = (p < _G(_unp)._strMem ? p : _G(_unp)._strMem);
 			}
 		}
@@ -461,8 +478,6 @@ int unp64(uint8_t *compressed, size_t length, uint8_t *destinationBuffer, size_t
 			return 0;
 
 		if ((mem[r->_pc] == 0x40) && (_G(_unp)._rtiFrc == 1)) {
-			if (nextInst(r) == 1)
-				return 0;
 			_G(_unp)._retAdr = r->_pc;
 			_G(_unp)._rtAFrc = 1;
 			if (_G(_unp)._retAdr < _G(_unp)._strMem)
@@ -509,9 +524,9 @@ int unp64(uint8_t *compressed, size_t length, uint8_t *destinationBuffer, size_t
 	}
 
 	if (_G(_unp)._fEndAf && _G(_unp)._monEnd) {
-		_G(_unp)._endAdC = mem[_G(_unp)._fEndAf] | mem[_G(_unp)._fEndAf + 1] << 8;
+		_G(_unp)._endAdC = (unsigned int)(mem[_G(_unp)._fEndAf] | mem[_G(_unp)._fEndAf + 1] << 8);
 		if ((int)_G(_unp)._endAdC > _G(_unp)._endAdr)
-			_G(_unp)._endAdr = _G(_unp)._endAdC;
+			_G(_unp)._endAdr = (int)_G(_unp)._endAdC;
 
 		_G(_unp)._endAdC = 0;
 		_G(_unp)._fEndAf = 0;
@@ -582,7 +597,7 @@ int unp64(uint8_t *compressed, size_t length, uint8_t *destinationBuffer, size_t
 	}
 
 	if (*forcedname) {
-		Common::strcpy_s(name, forcedname);
+		Common::sprintf_s(name, sizeof name, "%s", forcedname);
 	} else {
 		size_t ln = strlen(name);
 		if (ln > 248) {/* dirty hack in case name is REALLY long */
@@ -704,8 +719,8 @@ int unp64(uint8_t *compressed, size_t length, uint8_t *destinationBuffer, size_t
 	mem[_G(_unp)._strMem - 2] = _G(_unp)._strMem & 0xff;
 	mem[_G(_unp)._strMem - 1] = _G(_unp)._strMem >> 8;
 
-	memcpy(destinationBuffer, mem + (_G(_unp)._strMem - 2), _G(_unp)._endAdr - _G(_unp)._strMem + 2);
-	*finalLength = _G(_unp)._endAdr - _G(_unp)._strMem + 2;
+	memcpy(destinationBuffer, mem + (_G(_unp)._strMem - 2), (size_t)(_G(_unp)._endAdr - _G(_unp)._strMem + 2));
+	*finalLength = (size_t)(_G(_unp)._endAdr - _G(_unp)._strMem + 2);
 
 	if (_G(_unp)._recurs) {
 		if (++_G(_unp)._recurs > RECUMAX)

--- a/engines/glk/scott/unp64/unp64_interface.h
+++ b/engines/glk/scott/unp64/unp64_interface.h
@@ -27,7 +27,7 @@
 namespace Glk {
 namespace Scott {
 
-int unp64(uint8_t *compressed, size_t length, uint8_t *destinationBuffer, size_t *finalLength, char *settings[], int numSettings);
+int unp64(uint8_t *compressed, size_t length, uint8_t *destinationBuffer, size_t *finalLength, const char *settings);
 
 } // End of namespace Scott
 } // End of namespace Glk


### PR DESCRIPTION
This updates UNP64, the library used by the ScottFree engine to decompress Commodore
64 files.

The UNP64 code was not endian safe, contained many unaligned and a couple of
out-of-bounds reads and errors made in the translation to C++.

This fixes that, mainly by adding a number of helper functions to `exo_util.cpp` and
replacing the unsafe code with calls to them.

Some of the helper functions might replicate functionality that already exists in
`common/endian.h`, I haven't really looked into this.

It also changes the  interface called by the ScottFree engine, removing one
parameter and moving the parsing of "switches" out of  `c64_checksums.cpp` 
in Scott into `unp64.cpp`.

There is a small number of other minor fixes and cleanups of the UNP64 code.

I have tested this with all the relevant games I have. No regressions noted.
