### PR TITLE
HPL1: Fix build with Clang on x64 platforms

### DIFF
--- a/engines/hpl1/engine/libraries/newton/core/dgPolyhedra.cpp
+++ b/engines/hpl1/engine/libraries/newton/core/dgPolyhedra.cpp
@@ -2714,7 +2714,7 @@ void dgPolyhedra::Optimize(const dgFloat64 *const array, dgInt32 strideInBytes,
 							if (handle) {
 								handle->m_edge = NULL;
 							}
-							ptr->m_userData = (dgUnsigned32)(size_t)(NULL);
+							ptr->m_userData = PointerToInt(NULL);
 
 						}
 
@@ -2753,7 +2753,7 @@ void dgPolyhedra::Optimize(const dgFloat64 *const array, dgInt32 strideInBytes,
 									if (handle) {
 										handle->m_edge = NULL;
 									}
-									ptr1->m_userData = (dgUnsigned32)(size_t)(NULL);
+									ptr1->m_userData = PointerToInt(NULL);
 
 								}
 							}
@@ -2780,7 +2780,7 @@ void dgPolyhedra::Optimize(const dgFloat64 *const array, dgInt32 strideInBytes,
 									if (handle) {
 										handle->m_edge = NULL;
 									}
-									ptr1->m_twin->m_userData = (dgUnsigned32)(size_t)(NULL);
+									ptr1->m_twin->m_userData = PointerToInt(NULL);
 
 								}
 							}

--- a/engines/hpl1/engine/libraries/newton/core/dgPolyhedra.cpp
+++ b/engines/hpl1/engine/libraries/newton/core/dgPolyhedra.cpp
@@ -2714,7 +2714,7 @@ void dgPolyhedra::Optimize(const dgFloat64 *const array, dgInt32 strideInBytes,
 							if (handle) {
 								handle->m_edge = NULL;
 							}
-							ptr->m_userData = dgUnsigned32(NULL);
+							ptr->m_userData = (dgUnsigned32)(size_t)(NULL);
 
 						}
 
@@ -2753,7 +2753,7 @@ void dgPolyhedra::Optimize(const dgFloat64 *const array, dgInt32 strideInBytes,
 									if (handle) {
 										handle->m_edge = NULL;
 									}
-									ptr1->m_userData = dgUnsigned32(NULL);
+									ptr1->m_userData = (dgUnsigned32)(size_t)(NULL);
 
 								}
 							}
@@ -2780,7 +2780,7 @@ void dgPolyhedra::Optimize(const dgFloat64 *const array, dgInt32 strideInBytes,
 									if (handle) {
 										handle->m_edge = NULL;
 									}
-									ptr1->m_twin->m_userData = dgUnsigned32(NULL);
+									ptr1->m_twin->m_userData = (dgUnsigned32)(size_t)(NULL);
 
 								}
 							}


### PR DESCRIPTION
The HPL1 engine seems to be still under heavy development so this is rather a workaround to fix the build on x64 platforms with Clang which is very strict regarding pointer conversions to smaller types.