### PR TITLE
DIRECTOR: Really fix warning

### DIFF
--- a/engines/director/images.cpp
+++ b/engines/director/images.cpp
@@ -105,7 +105,7 @@ bool DIBDecoder::loadStream(Common::SeekableReadStream &stream) {
 			for (int x = 0; x < _surface->w; x++) {
 				// We're not su[pposed to modify the image that is coming from the decoder
 				// However, in this case, we know what we're doing.
-				*Common::remove_const<byte *>::type(_surface->getBasePtr(x, y)) = 255 - *(const byte *)_surface->getBasePtr(x, y);
+				*const_cast<byte *>((const byte *)_surface->getBasePtr(x, y)) = 255 - *(const byte *)_surface->getBasePtr(x, y);
 			}
 		}
 	}

--- a/engines/hpl1/engine/libraries/newton/core/dgHeap.h
+++ b/engines/hpl1/engine/libraries/newton/core/dgHeap.h
@@ -119,7 +119,7 @@ dgHeapBase<OBJECT, KEY>::dgHeapBase(const void *const buffer, dgInt32 sizeInByte
 //	NEWTON_ASSERT (0);
 //	m_allocated = false;
 	m_allocator = NULL;
-	m_pool = (RECORD *)Common::remove_const<void * const>::type(buffer);
+	m_pool = const_cast<RECORD *>((const RECORD *)buffer);
 	m_maxCount = dgInt32(sizeInBytes / sizeof(RECORD));
 	Flush();
 }

--- a/engines/hpl1/engine/libraries/newton/core/dgNode.h
+++ b/engines/hpl1/engine/libraries/newton/core/dgNode.h
@@ -173,7 +173,7 @@ dgNode<T>::~dgNode() {
 
 template<class T>
 dgRef *dgNode<T>::CreateClone() const {
-	return new T(*(T *)Common::remove_const<T *>::type(this));
+	return new T(*const_cast<T *>((const T *)this));
 }
 
 template<class T>

--- a/engines/hpl1/engine/libraries/newton/core/dgPolygonSoupDatabase.h
+++ b/engines/hpl1/engine/libraries/newton/core/dgPolygonSoupDatabase.h
@@ -94,7 +94,7 @@ inline dgUnsigned32 dgPolygonSoupDatabase::GetTagId(const dgInt32 *face) const {
 
 inline void dgPolygonSoupDatabase::SetTagId(const dgInt32 *facePtr, dgUnsigned32 newID) const {
 	dgUnsigned32 *face;
-	face = Common::remove_const<dgUnsigned32 *>::type(facePtr);
+	face = const_cast<dgUnsigned32 *>((const dgUnsigned32 *)facePtr);
 	face[-1] = newID;
 }
 


### PR DESCRIPTION
The purpose of `Common::remove_const` (and `std::remove_const` outside of ScummVM` is not to remove the const specifier from a variable, but to remove it from a type and define a non-const type in the process. It is typically use in template code, such as this example given by @lephilousophe on Discord (thanks, that saved me the trouble of creating one myself 😄 ):

```cpp
template<typename T>
class Test {
  Common::remove_const<T> mutable_item;
  T *array;
}
```

The previous commit to fix the warning thus did not fix anything as the code was still doing a C cast from a const type to a non-const one to remove the const specifier from the byte array. The proper way to fix that warning is to use a const_cast, as done in this pull request.

The main reason I am not committing this directly and opening a pull request is to give it more visibility, as I am sure more developers might be confused by the purpose of `Common::remove_const` and use it incorrectly .

