### PR TITLE
GLK: SCOTT: Fix inverted conditional statement

### DIFF
--- a/engines/glk/scott/load_game.cpp
+++ b/engines/glk/scott/load_game.cpp
@@ -252,7 +252,7 @@ void loadGameFile(Common::SeekableReadStream *f) {
 		break;
 	}
 
-	if (!(_G(_game)->_subType & (C64 | MYSTERIOUS))) {
+	if ((_G(_game)->_subType & (C64 | MYSTERIOUS)) == (MYSTERIOUS | C64)) {
 		mysterious64Sysmess();
 	}
 


### PR DESCRIPTION
Line 255, `if (!(_G(_game)->_subType & (C64 | MYSTERIOUS)))`, is supposed to check whether the current game is a Commodore 64 version of one of the eleven Mysterious Adventures by Brian Howarth, and if so set the appropriate system messages. Currently it does the opposite.

~~A one-character change that may also fix~~ Fixes https://bugs.scummvm.org/ticket/14255.

EDIT:  Now it is properly fixed.

EDIT 2: The [lines 139-263](https://github.com/scummvm/scummvm/blob/6cf8b64c270895d1dce5ea07f693969c2188acae/engines/glk/scott/load_game.cpp#L139-L263) in `load_game.cpp` set the entries of the Common::StringArray `_sys` to the right string from `_systemMessages`, which contains strings read from the original game data.

All Scott Adams format games have roughly the same system messages, but to save memory they may omit the unused ones, so that a game without treasures might skip all treasure-related messages such as "You have stored X treasures", for example. Therefore, the strings read from the game data (into `_systemMessages`) have to be rearranged so that `_sys` has the expected messages in the expected order.

Conveniently, all the Commodore 64 Mysterious Adventures have the same messages in the same order in their game data, so they get their own function, `mysterious64Sysmess()`.

*Questprobe featuring the Hulk*, however, is a little different, and has a completely blank array of `_systemMessages`.  This is because unlike the other games, it does not has it system messages neatly ordered as a table at a single place in the data, but they are individually dispersed throughout the code. It was decided that it was too much work to extract them all. Instead it uses [the boilerplate built-in fallback messages](https://github.com/scummvm/scummvm/blob/6cf8b64c270895d1dce5ea07f693969c2188acae/engines/glk/scott/game_info.cpp#L226-L279) listed in `game_info.cpp`.

So what happens currently is that, because the conditional statement at line 255 is inverted, every game *not* a Commodore 64 game or a "Mysterious Adventure" gets its system messages set by `mysterious64Sysmess()`. And in *The Hulk*'s case, this means that it gets a lot of empty strings as system messages, resulting in [ticket 14255](https://bugs.scummvm.org/ticket/14255).