### PR TITLE
GRAPHICS: Make rawBlitFrom take a ManagedSurface

### DIFF
--- a/engines/ags/shared/gfx/image.cpp
+++ b/engines/ags/shared/gfx/image.cpp
@@ -153,14 +153,14 @@ int save_bitmap(Common::WriteStream &out, BITMAP *bmp, const RGB *pal) {
 		}
 
 		surface.rawBlitFrom(temp, Common::Rect(0, 0, src.w, src.h),
-			Common::Point(0, 0), temp.getPalette());
+			Common::Point(0, 0));
 	} else {
 		// Copy from the source surface without alpha transparency
 		Graphics::ManagedSurface temp = src;
 		temp.format.aLoss = 8;
 
 		surface.rawBlitFrom(temp, Common::Rect(0, 0, src.w, src.h),
-			Common::Point(0, 0), nullptr);
+			Common::Point(0, 0));
 	}
 
 	// Write out the bitmap

--- a/engines/mtropolis/debug.cpp
+++ b/engines/mtropolis/debug.cpp
@@ -293,7 +293,7 @@ void DebugToolWindowBase::render() {
 				return;
 
 			getSurface()->fillRect(Common::Rect(0, kTopBarHeight, renderWidth, getHeight()), getSurface()->format.RGBToColor(255, 255, 255));
-			getSurface()->rawBlitFrom(*_toolSurface.get(), Common::Rect(srcLeft, srcTop, srcRight, srcBottom), Common::Point(destLeft, destTop + kTopBarHeight), nullptr);
+			getSurface()->rawBlitFrom(*_toolSurface.get(), Common::Rect(srcLeft, srcTop, srcRight, srcBottom), Common::Point(destLeft, destTop + kTopBarHeight));
 		} else {
 			_haveScrollBar = false;
 			cancelScrolling();

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -499,10 +499,10 @@ public:
 	/**
 	 * Does a blitFrom ignoring any transparency settings
 	 */
-	void rawBlitFrom(const Surface &src, const Common::Rect &srcRect,
-			const Common::Point &destPos, const uint32 *palette) {
-		blitFromInner(src, srcRect, Common::Rect(destPos.x, destPos.y,
-			destPos.x + srcRect.width(), destPos.y + srcRect.height()), palette);
+	void rawBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect,
+			const Common::Point &destPos) {
+		blitFromInner(src._innerSurface, srcRect, Common::Rect(destPos.x, destPos.y, destPos.x + srcRect.width(),
+			destPos.y + srcRect.height()), src._paletteSet ? src._palette : nullptr);
 	}
 
 	/**
@@ -679,14 +679,6 @@ public:
 	 * Grab the palette using RGB tuples.
 	 */
 	void grabPalette(byte *colors, uint start, uint num) const;
-
-	/**
-	 * Get the palette array.
-	 */
-	WARN_DEPRECATED("Use grabPalette instead")
-	const uint32 *getPalette() const {
-		return _palette;
-	}
 
 	/**
 	 * Set the palette using RGB tuples.


### PR DESCRIPTION
This allows to remove the palette argument and removes the need for getPalette.
