### PR TITLE
VIDEO: Add setOutputPixelFormat() to the VideoDecoder interface

### DIFF
--- a/engines/asylum/views/video.cpp
+++ b/engines/asylum/views/video.cpp
@@ -189,13 +189,15 @@ void VideoPlayer::play(const Common::String &filename, bool showSubtitles) {
 	int32 frameEnd = 0;
 	int32 currentSubtitle = 0;
 
-	_decoder->start();
-
 	if (_vm->checkGameVersion("Steam") || _vm->isAltDemo()) {
-		Graphics::PixelFormat decoderFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-		_decoder->setDefaultHighColorFormat(decoderFormat);
+		Graphics::PixelFormat bestFormat = g_system->getSupportedFormats().front();
+		_decoder->setOutputPixelFormat(bestFormat);
+
+		Graphics::PixelFormat decoderFormat = _decoder->getPixelFormat();
 		initGraphics(640, 480, &decoderFormat);
 	}
+
+	_decoder->start();
 
 	while (!_done && !Engine::shouldQuit() && !_decoder->endOfVideo()) {
 		_vm->handleEvents();

--- a/engines/grim/movie/bink.cpp
+++ b/engines/grim/movie/bink.cpp
@@ -44,7 +44,6 @@ MoviePlayer *CreateBinkPlayer(bool demo) {
 
 BinkPlayer::BinkPlayer(bool demo) : MoviePlayer(), _demo(demo) {
 	_videoDecoder = new Video::BinkDecoder();
-	_videoDecoder->setDefaultHighColorFormat(Graphics::PixelFormat(4, 8, 8, 8, 0, 8, 16, 24, 0));
 	_subtitleIndex = _subtitles.begin();
 }
 
@@ -205,7 +204,10 @@ bool BinkPlayer::loadFile(const Common::String &filename) {
 
 	Common::SeekableReadStream *bink = nullptr;
 	bink = new Common::SeekableSubReadStream(stream, startBinkPos, stream->size(), DisposeAfterUse::YES);
-	return _videoDecoder->loadStream(bink);
+	if (!_videoDecoder->loadStream(bink))
+		return false;
+	_videoDecoder->setOutputPixelFormat(Graphics::PixelFormat(4, 8, 8, 8, 0, 8, 16, 24, 0));
+	return true;
 }
 
 } // end of namespace Grim

--- a/engines/grim/movie/mpeg.cpp
+++ b/engines/grim/movie/mpeg.cpp
@@ -45,8 +45,8 @@ bool MpegPlayer::loadFile(const Common::String &filename) {
 	if (!stream)
 		return false;
 
-	_videoDecoder->setDefaultHighColorFormat(Graphics::PixelFormat(4, 8, 8, 8, 0, 8, 16, 24, 0));
 	_videoDecoder->loadStream(stream);
+	_videoDecoder->setOutputPixelFormat(Graphics::PixelFormat(4, 8, 8, 8, 0, 8, 16, 24, 0));
 	_videoDecoder->start();
 
 	return true;

--- a/engines/icb/movie_pc.cpp
+++ b/engines/icb/movie_pc.cpp
@@ -65,7 +65,6 @@ bool MovieManager::registerMovie(const char *fileName, bool8 fade, bool8 loop) {
 		g_theMusicManager->StopMusic();
 
 	_binkDecoder = new Video::BinkDecoder();
-	_binkDecoder->setDefaultHighColorFormat(Graphics::PixelFormat(4, 8, 8, 8, 0, 16, 8, 0, 24));
 
 	Common::SeekableReadStream *stream = openDiskFileForBinaryStreamRead(fileName);
 	if (!stream) {
@@ -74,6 +73,9 @@ bool MovieManager::registerMovie(const char *fileName, bool8 fade, bool8 loop) {
 	if (!_binkDecoder->loadStream(stream)) {
 		return false;
 	}
+
+	_binkDecoder->setOutputPixelFormat(Graphics::PixelFormat(4, 8, 8, 8, 0, 16, 8, 0, 24));
+
 	if (_binkDecoder->getWidth() != SCREEN_WIDTH) {
 		_x = (SCREEN_WIDTH / 2) - (_binkDecoder->getWidth() / 2);
 	}

--- a/engines/icb/options_manager_pc.cpp
+++ b/engines/icb/options_manager_pc.cpp
@@ -6182,8 +6182,6 @@ void OptionsManager::DrawSlideShow() {
 
 		// This slide is bink compressed
 		Video::BinkDecoder *binkDecoder = new Video::BinkDecoder();
-		binkDecoder->setDefaultHighColorFormat(Graphics::PixelFormat(4, 8, 8, 8, 0, 16, 8, 0, 24));
-
 		Common::MemoryReadStream *stream = new Common::MemoryReadStream((byte *)slideptr, slideLen);
 		if (!stream) {
 			Fatal_error("Failed open bink file");
@@ -6191,6 +6189,8 @@ void OptionsManager::DrawSlideShow() {
 		if (!binkDecoder->loadStream(stream)) {
 			Fatal_error("Failed open bink file");
 		}
+
+		binkDecoder->setOutputPixelFormat(Graphics::PixelFormat(4, 8, 8, 8, 0, 16, 8, 0, 24));
 
 		// Verify image dimensions
 		if (binkDecoder->getWidth() > SCREEN_WIDTH || binkDecoder->getHeight() > SCREEN_DEPTH)

--- a/engines/myst3/inventory.cpp
+++ b/engines/myst3/inventory.cpp
@@ -338,8 +338,8 @@ DragItem::DragItem(Myst3Engine *vm, uint id):
 
 	// Load the movie
 	_movieStream = movieDesc.getData();
-	_bink.setDefaultHighColorFormat(Texture::getRGBAPixelFormat());
 	_bink.loadStream(_movieStream);
+	_bink.setOutputPixelFormat(Texture::getRGBAPixelFormat());
 	_bink.start();
 
 	const Graphics::Surface *frame = _bink.decodeNextFrame();

--- a/engines/myst3/menu.cpp
+++ b/engines/myst3/menu.cpp
@@ -57,8 +57,8 @@ Dialog::Dialog(Myst3Engine *vm, uint id):
 
 	// Load the movie
 	Common::SeekableReadStream *movieStream = movieDesc.getData();
-	_bink.setDefaultHighColorFormat(Texture::getRGBAPixelFormat());
 	_bink.loadStream(movieStream);
+	_bink.setOutputPixelFormat(Texture::getRGBAPixelFormat());
 	_bink.start();
 
 	const Graphics::Surface *frame = _bink.decodeNextFrame();

--- a/engines/myst3/movie.cpp
+++ b/engines/myst3/movie.cpp
@@ -73,9 +73,9 @@ Movie::Movie(Myst3Engine *vm, uint16 id) :
 	loadPosition(binkDesc.getVideoData());
 
 	Common::SeekableReadStream *binkStream = binkDesc.getData();
-	_bink.setDefaultHighColorFormat(Texture::getRGBAPixelFormat());
 	_bink.setSoundType(Audio::Mixer::kSFXSoundType);
 	_bink.loadStream(binkStream);
+	_bink.setOutputPixelFormat(Texture::getRGBAPixelFormat());
 
 	if (binkDesc.getType() == Archive::kMultitrackMovie || binkDesc.getType() == Archive::kDialogMovie) {
 		uint language = ConfMan.getInt("audio_language");

--- a/engines/myst3/puzzles.cpp
+++ b/engines/myst3/puzzles.cpp
@@ -1527,8 +1527,8 @@ void Puzzles::projectorLoadBitmap(uint16 bitmap) {
 	// Rebuild the complete background image from the frames of the bink movie
 	Common::SeekableReadStream *movieStream = movieDesc.getData();
 	Video::BinkDecoder bink;
-	bink.setDefaultHighColorFormat(Texture::getRGBAPixelFormat());
 	bink.loadStream(movieStream);
+	bink.setOutputPixelFormat(Texture::getRGBAPixelFormat());
 	bink.start();
 
 	for (uint i = 0; i < 1024; i += 256) {
@@ -1554,8 +1554,8 @@ void Puzzles::projectorAddSpotItem(uint16 bitmap, uint16 x, uint16 y) {
 	// Rebuild the complete background image from the frames of the bink movie
 	Common::SeekableReadStream *movieStream = movieDesc.getData();
 	Video::BinkDecoder bink;
-	bink.setDefaultHighColorFormat(Texture::getRGBAPixelFormat());
 	bink.loadStream(movieStream);
+	bink.setOutputPixelFormat(Texture::getRGBAPixelFormat());
 	bink.start();
 
 	const Graphics::Surface *frame = bink.decodeNextFrame();

--- a/engines/myst3/subtitles.cpp
+++ b/engines/myst3/subtitles.cpp
@@ -360,8 +360,8 @@ bool MovieSubtitles::loadSubtitles(int32 id) {
 
 	// Load the movie
 	Common::SeekableReadStream *movieStream = movie.getData();
-	_bink.setDefaultHighColorFormat(Texture::getRGBAPixelFormat());
 	_bink.loadStream(movieStream);
+	_bink.setOutputPixelFormat(Texture::getRGBAPixelFormat());
 	_bink.start();
 
 	return true;

--- a/engines/scumm/he/animation_he.cpp
+++ b/engines/scumm/he/animation_he.cpp
@@ -65,13 +65,13 @@ int MoviePlayer::load(const Common::String &filename, int flags, int image) {
 	if (_video->isVideoLoaded())
 		_video->close();
 
-	// Ensure that Bink will use our PixelFormat
-	_video->setDefaultHighColorFormat(g_system->getScreenFormat());
-
 	if (!_video->loadFile(filename)) {
 		warning("Failed to load video file %s", filename.c_str());
 		return -1;
 	}
+
+	// Ensure that Bink will use our PixelFormat
+	_video->setOutputPixelFormat(g_system->getScreenFormat());
 
 	_video->start();
 

--- a/engines/stark/ui/world/fmvscreen.cpp
+++ b/engines/stark/ui/world/fmvscreen.cpp
@@ -41,7 +41,6 @@ FMVScreen::FMVScreen(Gfx::Driver *gfx, Cursor *cursor) :
 	_bitmap->setSamplingFilter(StarkSettings->getImageSamplingFilter());
 
 	_decoder = new Video::BinkDecoder();
-	_decoder->setDefaultHighColorFormat(_bitmap->getBestPixelFormat());
 	_decoder->setSoundType(Audio::Mixer::kSFXSoundType);
 
 	_surfaceRenderer = _gfx->createSurfaceRenderer();
@@ -82,6 +81,7 @@ void FMVScreen::play(const Common::String &name) {
 	if (!_decoder->isVideoLoaded()) {
 		error("Could not open %s", name.c_str());
 	}
+	_decoder->setOutputPixelFormat(_bitmap->getBestPixelFormat());
 	_decoder->start();
 }
 

--- a/engines/stark/visual/smacker.cpp
+++ b/engines/stark/visual/smacker.cpp
@@ -72,9 +72,9 @@ void VisualSmacker::loadBink(Common::SeekableReadStream *stream) {
 
 	_decoder = new Video::BinkDecoder();
 	_decoder->setSoundType(Audio::Mixer::kSFXSoundType);
-	// We need a format with alpha transparency, so we can't use _bitmap->getBestPixelFormat() here.
-	_decoder->setDefaultHighColorFormat(Gfx::Driver::getRGBAPixelFormat());
 	_decoder->loadStream(stream);
+	// We need a format with alpha transparency, so we can't use _bitmap->getBestPixelFormat() here.
+	_decoder->setOutputPixelFormat(Gfx::Driver::getRGBAPixelFormat());
 
 	init();
 }

--- a/image/codecs/cinepak.cpp
+++ b/image/codecs/cinepak.cpp
@@ -624,6 +624,14 @@ void CinepakDecoder::decodeVectors(Common::SeekableReadStream &stream, uint16 st
 	}
 }
 
+bool CinepakDecoder::setOutputPixelFormat(const Graphics::PixelFormat &format) {
+	if (_bitsPerPixel == 8)
+		return false;
+
+	_pixelFormat = format;
+	return true;
+}
+
 bool CinepakDecoder::canDither(DitherType type) const {
 	return (type == kDitherTypeVFW || type == kDitherTypeQT) && _bitsPerPixel == 24;
 }

--- a/image/codecs/cinepak.h
+++ b/image/codecs/cinepak.h
@@ -74,6 +74,7 @@ public:
 
 	const Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream) override;
 	Graphics::PixelFormat getPixelFormat() const override { return _pixelFormat; }
+	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override;
 
 	bool containsPalette() const override { return _ditherPalette != 0; }
 	const byte *getPalette() override { _dirtyPalette = false; return _ditherPalette; }

--- a/image/codecs/codec.h
+++ b/image/codecs/codec.h
@@ -86,6 +86,12 @@ public:
 	virtual Graphics::PixelFormat getPixelFormat() const = 0;
 
 	/**
+	 * Select the preferred format to use, for codecs where this is faster than converting
+	 * the image afterwards. Returns true if supported, and false otherwise.
+	 */
+	virtual bool setOutputPixelFormat(const Graphics::PixelFormat &format) { return false; }
+
+	/**
 	 * Can this codec's frames contain a palette?
 	 */
 	virtual bool containsPalette() const { return false; }

--- a/image/codecs/indeo/indeo.cpp
+++ b/image/codecs/indeo/indeo.cpp
@@ -469,25 +469,9 @@ IndeoDecoderBase::IndeoDecoderBase(uint16 width, uint16 height, uint bitsPerPixe
 	_bitsPerPixel = bitsPerPixel;
 	_pixelFormat = g_system->getScreenFormat();
 
-	if (_pixelFormat.bytesPerPixel == 1) {
-		switch (bitsPerPixel) {
-		case 15:
-			_pixelFormat = Graphics::PixelFormat(2, 5, 5, 5, 0, 0, 5, 10, 0);
-			break;
-		case 16:
-			_pixelFormat = Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0);
-			break;
-		case 24:
-			_pixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 0, 16, 8, 0, 0);
-			break;
-		case 32:
-			_pixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-			break;
-		default:
-			error("Invalid color depth");
-			break;
-		}
-	}
+	// Default to a 32bpp format, if in 8bpp mode
+	if (_pixelFormat.bytesPerPixel == 1)
+		_pixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0);
 
 	_ctx._bRefBuf = 3; // buffer 2 is used for scalability mode
 }

--- a/image/codecs/indeo/indeo.h
+++ b/image/codecs/indeo/indeo.h
@@ -537,6 +537,12 @@ protected:
 	Graphics::PixelFormat getPixelFormat() const override { return _pixelFormat; }
 
 	/**
+	 * Select the preferred format to use, for codecs where this is faster than converting
+	 * the image afterwards. Returns true if supported, and false otherwise.
+	 */
+	bool setOutputPixelFormat(const Graphics::PixelFormat &format) { _pixelFormat = format; return true; }
+
+	/**
 	 * Decode the Indeo picture header.
 	 * @returns		0 = Ok, negative number = error
 	 */

--- a/image/codecs/indeo/indeo.h
+++ b/image/codecs/indeo/indeo.h
@@ -518,8 +518,11 @@ private:
 		int blkSize);
 protected:
 	IVI45DecContext _ctx;
+	uint16 _width;
+	uint16 _height;
+	uint _bitsPerPixel;
 	Graphics::PixelFormat _pixelFormat;
-	Graphics::Surface _surface;
+	Graphics::Surface *_surface;
 
 	/**
 	 *  Scan patterns shared between indeo4 and indeo5

--- a/image/codecs/indeo3.cpp
+++ b/image/codecs/indeo3.cpp
@@ -47,25 +47,9 @@ Indeo3Decoder::Indeo3Decoder(uint16 width, uint16 height, uint bitsPerPixel) : _
 	_height = height;
 	_pixelFormat = g_system->getScreenFormat();
 
-	if (_pixelFormat.bytesPerPixel == 1) {
-		switch (bitsPerPixel) {
-		case 15:
-			_pixelFormat = Graphics::PixelFormat(2, 5, 5, 5, 0, 0, 5, 10, 0);
-			break;
-		case 16:
-			_pixelFormat = Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0);
-			break;
-		case 24:
-			_pixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 0, 16, 8, 0, 0);
-			break;
-		case 32:
-			_pixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-			break;
-		default:
-			error("Invalid color depth");
-			break;
-		}
-	}
+	// Default to a 32bpp format, if in 8bpp mode
+	if (_pixelFormat.bytesPerPixel == 1)
+		_pixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0);
 
 	buildModPred();
 	allocFrames();

--- a/image/codecs/indeo3.cpp
+++ b/image/codecs/indeo3.cpp
@@ -39,10 +39,12 @@
 
 namespace Image {
 
-Indeo3Decoder::Indeo3Decoder(uint16 width, uint16 height, uint bitsPerPixel) : _ModPred(0), _corrector_type(0) {
+Indeo3Decoder::Indeo3Decoder(uint16 width, uint16 height, uint bitsPerPixel) : _surface(nullptr), _ModPred(0), _corrector_type(0) {
 	_iv_frame[0].the_buf = 0;
 	_iv_frame[1].the_buf = 0;
 
+	_width = width;
+	_height = height;
 	_pixelFormat = g_system->getScreenFormat();
 
 	if (_pixelFormat.bytesPerPixel == 1) {
@@ -65,16 +67,16 @@ Indeo3Decoder::Indeo3Decoder(uint16 width, uint16 height, uint bitsPerPixel) : _
 		}
 	}
 
-	_surface = new Graphics::Surface;
-	_surface->create(width, height, _pixelFormat);
-
 	buildModPred();
 	allocFrames();
 }
 
 Indeo3Decoder::~Indeo3Decoder() {
-	_surface->free();
-	delete _surface;
+	if (_surface) {
+		_surface->free();
+		delete _surface;
+		_surface = nullptr;
+	}
 
 	delete[] _iv_frame[0].the_buf;
 	delete[] _ModPred;
@@ -134,8 +136,8 @@ void Indeo3Decoder::buildModPred() {
 }
 
 void Indeo3Decoder::allocFrames() {
-	int32 luma_width   = (_surface->w + 3) & (~3);
-	int32 luma_height  = (_surface->h + 3) & (~3);
+	int32 luma_width   = (_width + 3) & (~3);
+	int32 luma_height  = (_height + 3) & (~3);
 
 	int32 chroma_width  = ((luma_width  >> 2) + 3) & (~3);
 	int32 chroma_height = ((luma_height >> 2) + 3) & (~3);
@@ -209,6 +211,11 @@ const Graphics::Surface *Indeo3Decoder::decodeFrame(Common::SeekableReadStream &
 	} else {
 		_cur_frame = _iv_frame;
 		_ref_frame = _iv_frame + 1;
+	}
+
+	if (!_surface) {
+		_surface = new Graphics::Surface;
+		_surface->create(_width, _height, _pixelFormat);
 	}
 
 	if (flags3 == 0x80)

--- a/image/codecs/indeo3.h
+++ b/image/codecs/indeo3.h
@@ -56,6 +56,8 @@ public:
 private:
 	Graphics::Surface *_surface;
 
+	uint16 _width;
+	uint16 _height;
 	Graphics::PixelFormat _pixelFormat;
 
 	static const int _corrector_type_0[24];

--- a/image/codecs/indeo3.h
+++ b/image/codecs/indeo3.h
@@ -50,6 +50,7 @@ public:
 
 	const Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream) override;
 	Graphics::PixelFormat getPixelFormat() const override;
+	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override { _pixelFormat = format; return true; }
 
 	static bool isIndeo3(Common::SeekableReadStream &stream);
 

--- a/image/codecs/indeo4.cpp
+++ b/image/codecs/indeo4.cpp
@@ -88,7 +88,7 @@ const Graphics::Surface *Indeo4Decoder::decodeFrame(Common::SeekableReadStream &
 	_ctx._frameData = nullptr;
 	_ctx._frameSize = 0;
 
-	return (err < 0) ? nullptr : &_surface;
+	return (err < 0) ? nullptr : _surface;
 }
 
 int Indeo4Decoder::decodePictureHeader() {
@@ -111,11 +111,11 @@ int Indeo4Decoder::decodePictureHeader() {
 		_ctx._hasBFrames = true;
 
 	_ctx._hasTransp = _ctx._gb->getBit();
-	if (_ctx._hasTransp && _surface.format.aBits() == 0) {
+	if (_ctx._hasTransp && _surface->format.aBits() == 0) {
 		// Surface is 4 bytes per pixel, but only RGB. So promote the
 		// surface to full RGBA, and convert all the existing pixels
 		_pixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-		_surface.convertToInPlace(_pixelFormat);
+		_surface->convertToInPlace(_pixelFormat);
 	}
 
 	// unknown bit: Mac decoder ignores this bit, XANIM returns error
@@ -610,16 +610,16 @@ int Indeo4Decoder::decodeRLETransparency(VLC_TYPE (*table)[2]) {
 	bool runIsOpaque = _ctx._gb->getBit();
 	bool nextRunIsOpaque = !runIsOpaque;
 
-	uint32 *pixel = (uint32 *)_surface.getPixels();
-	const int surfacePixelPitch = _surface.pitch / _surface.format.bytesPerPixel;
-	const int surfacePadding = surfacePixelPitch - _surface.w;
-	const uint32 *endOfVisibleRow = pixel + _surface.w;
-	const uint32 *endOfVisibleArea = pixel + surfacePixelPitch * _surface.h - surfacePadding;
+	uint32 *pixel = (uint32 *)_surface->getPixels();
+	const int surfacePixelPitch = _surface->pitch / _surface->format.bytesPerPixel;
+	const int surfacePadding = surfacePixelPitch - _surface->w;
+	const uint32 *endOfVisibleRow = pixel + _surface->w;
+	const uint32 *endOfVisibleArea = pixel + surfacePixelPitch * _surface->h - surfacePadding;
 
-	const int codecAlignedWidth = (_surface.w + 31) & ~31;
-	const int codecPaddingSize = codecAlignedWidth - _surface.w;
+	const int codecAlignedWidth = (_surface->w + 31) & ~31;
+	const int codecPaddingSize = codecAlignedWidth - _surface->w;
 
-	int numPixelsToRead = codecAlignedWidth * _surface.h;
+	int numPixelsToRead = codecAlignedWidth * _surface->h;
 	int numPixelsToSkip = 0;
 	while (numPixelsToRead > 0) {
 		int value = _ctx._gb->getVLC2<1, IVI_VLC_BITS>(table);
@@ -716,7 +716,7 @@ int Indeo4Decoder::decodeTransparency() {
 
 	if (_ctx._gb->getBit()) { /* @350 */
 		/* @358 */
-		_ctx._transKeyColor = _surface.format.ARGBToColor(0, _ctx._gb->getBits<8>(), _ctx._gb->getBits<8>(), _ctx._gb->getBits<8>());
+		_ctx._transKeyColor = _surface->format.ARGBToColor(0, _ctx._gb->getBits<8>(), _ctx._gb->getBits<8>(), _ctx._gb->getBits<8>());
 		debug(4, "Indeo4: Key color is %08x", _ctx._transKeyColor);
 		/* @477 */
 	}
@@ -767,8 +767,8 @@ int Indeo4Decoder::decodeTransparency() {
 	// necessary for correct decoding of game videos.
 	assert(!_ctx._usesTiling);
 
-	assert(_surface.format.bytesPerPixel == 4);
-	assert((_surface.pitch % 4) == 0);
+	assert(_surface->format.bytesPerPixel == 4);
+	assert((_surface->pitch % 4) == 0);
 
 	const uint32 startByte = _ctx._gb->pos() / 8;
 
@@ -781,7 +781,7 @@ int Indeo4Decoder::decodeTransparency() {
 			// It should only be necessary to draw transparency here since the
 			// data from the YUV planes gets drawn to the output surface on each
 			// frame, which resets the surface pixels to be fully opaque
-			_surface.fillRect(Common::Rect(_surface.w, _surface.h), _ctx._transKeyColor);
+			_surface->fillRect(Common::Rect(_surface->w, _surface->h), _ctx._transKeyColor);
 		}
 
 		// No alignment here

--- a/image/codecs/indeo5.cpp
+++ b/image/codecs/indeo5.cpp
@@ -96,7 +96,7 @@ const Graphics::Surface *Indeo5Decoder::decodeFrame(Common::SeekableReadStream &
 	_ctx._frameData = nullptr;
 	_ctx._frameSize = 0;
 
-	return (err < 0) ? nullptr : &_surface;
+	return (err < 0) ? nullptr : _surface;
 }
 
 int Indeo5Decoder::decodePictureHeader() {

--- a/image/codecs/mjpeg.cpp
+++ b/image/codecs/mjpeg.cpp
@@ -40,6 +40,11 @@ namespace Image {
 
 MJPEGDecoder::MJPEGDecoder() : Codec() {
 	_pixelFormat = g_system->getScreenFormat();
+
+	// Default to a 32bpp format, if in 8bpp mode
+	if (_pixelFormat.bytesPerPixel == 1)
+		_pixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0);
+
 	_surface = 0;
 }
 

--- a/image/codecs/mjpeg.h
+++ b/image/codecs/mjpeg.h
@@ -47,6 +47,7 @@ public:
 
 	const Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream) override;
 	Graphics::PixelFormat getPixelFormat() const override { return _pixelFormat; }
+	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override { _pixelFormat = format; return true; }
 
 private:
 	Graphics::PixelFormat _pixelFormat;

--- a/image/codecs/mpeg.cpp
+++ b/image/codecs/mpeg.cpp
@@ -37,6 +37,11 @@ namespace Image {
 
 MPEGDecoder::MPEGDecoder() : Codec() {
 	_pixelFormat = g_system->getScreenFormat();
+
+	// Default to a 32bpp format, if in 8bpp mode
+	if (_pixelFormat.bytesPerPixel == 1)
+		_pixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0);
+
 	_surface = 0;
 
 	_mpegDecoder = mpeg2_init();

--- a/image/codecs/mpeg.h
+++ b/image/codecs/mpeg.h
@@ -53,6 +53,7 @@ public:
 	// Codec interface
 	const Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream) override;
 	Graphics::PixelFormat getPixelFormat() const override { return _pixelFormat; }
+	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override { _pixelFormat = format; return true; }
 
 	// MPEGPSDecoder call
 	bool decodePacket(Common::SeekableReadStream &packet, uint32 &framePeriod, Graphics::Surface *dst = 0);

--- a/image/codecs/svq1.cpp
+++ b/image/codecs/svq1.cpp
@@ -47,6 +47,12 @@ SVQ1Decoder::SVQ1Decoder(uint16 width, uint16 height) {
 	debug(1, "SVQ1Decoder::SVQ1Decoder(width:%d, height:%d)", width, height);
 	_width = width;
 	_height = height;
+	_pixelFormat = g_system->getScreenFormat();
+
+	// Default to a 32bpp format, if in 8bpp mode
+	if (_pixelFormat.bytesPerPixel == 1)
+		_pixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0);
+
 	_frameWidth = _frameHeight = 0;
 	_surface = 0;
 
@@ -251,7 +257,7 @@ const Graphics::Surface *SVQ1Decoder::decodeFrame(Common::SeekableReadStream &st
 	// Now we'll create the surface
 	if (!_surface) {
 		_surface = new Graphics::Surface();
-		_surface->create(yWidth, yHeight, g_system->getScreenFormat());
+		_surface->create(yWidth, yHeight, _pixelFormat);
 		_surface->w = _width;
 		_surface->h = _height;
 	}

--- a/image/codecs/svq1.h
+++ b/image/codecs/svq1.h
@@ -44,9 +44,11 @@ public:
 	~SVQ1Decoder() override;
 
 	const Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream) override;
-	Graphics::PixelFormat getPixelFormat() const override { return _surface->format; }
+	Graphics::PixelFormat getPixelFormat() const override { return _pixelFormat; }
+	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override { _pixelFormat = format; return true; }
 
 private:
+	Graphics::PixelFormat _pixelFormat;
 	Graphics::Surface *_surface;
 	uint16 _width, _height;
 	uint16 _frameWidth, _frameHeight;

--- a/image/codecs/xan.h
+++ b/image/codecs/xan.h
@@ -47,6 +47,7 @@ public:
 
 	const Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream) override;
 	Graphics::PixelFormat getPixelFormat() const override { return _pixelFormat; }
+	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override { _pixelFormat = format; return true; }
 
 private:
 	void decodeFrameType0(Common::SeekableReadStream &stream);

--- a/image/jpeg.h
+++ b/image/jpeg.h
@@ -59,6 +59,7 @@ public:
 	// Codec API
 	const Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream) override;
 	Graphics::PixelFormat getPixelFormat() const override;
+	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override { _requestedPixelFormat = format; return true; }
 
 	// Special API for JPEG
 	enum ColorSpace {
@@ -94,13 +95,6 @@ public:
 	 * @param outSpace The color space to output.
 	 */
 	void setOutputColorSpace(ColorSpace outSpace) { _colorSpace = outSpace; }
-
-	/**
-	 * Request the output pixel format. The JPEG decoder provides high performance
-	 * color conversion routines for some pixel formats. This setting allows to use
-	 * them and avoid costly subsequent color conversion.
-	 */
-	void setOutputPixelFormat(const Graphics::PixelFormat &format) { _requestedPixelFormat = format; }
 
 private:
 	Graphics::Surface _surface;

--- a/video/3do_decoder.cpp
+++ b/video/3do_decoder.cpp
@@ -396,6 +396,10 @@ Graphics::PixelFormat ThreeDOMovieDecoder::StreamVideoTrack::getPixelFormat() co
 	return _codec->getPixelFormat();
 }
 
+bool ThreeDOMovieDecoder::StreamVideoTrack::setOutputPixelFormat(const Graphics::PixelFormat &format) {
+	return _codec->setOutputPixelFormat(format);
+}
+
 void ThreeDOMovieDecoder::StreamVideoTrack::decodeFrame(Common::SeekableReadStream *stream, uint32 videoTimeStamp) {
 	_surface = _codec->decodeFrame(*stream);
 	_curFrame++;

--- a/video/3do_decoder.h
+++ b/video/3do_decoder.h
@@ -75,6 +75,7 @@ private:
 		uint16 getWidth() const override { return _width; }
 		uint16 getHeight() const override { return _height; }
 		Graphics::PixelFormat getPixelFormat() const override;
+		bool setOutputPixelFormat(const Graphics::PixelFormat &format);
 		int getCurFrame() const override { return _curFrame; }
 		int getFrameCount() const override { return _frameCount; }
 		void setNextFrameStartTime(uint32 nextFrameStartTime) { _nextFrameStartTime = nextFrameStartTime; }

--- a/video/avi_decoder.cpp
+++ b/video/avi_decoder.cpp
@@ -985,6 +985,13 @@ Graphics::PixelFormat AVIDecoder::AVIVideoTrack::getPixelFormat() const {
 	return Graphics::PixelFormat();
 }
 
+bool AVIDecoder::AVIVideoTrack::setOutputPixelFormat(const Graphics::PixelFormat &format) {
+	if (_videoCodec)
+		return _videoCodec->setOutputPixelFormat(format);
+
+	return false;
+}
+
 void AVIDecoder::AVIVideoTrack::loadPaletteFromChunkRaw(Common::SeekableReadStream *chunk, int firstEntry, int numEntries) {
 	assert(chunk);
 	assert(firstEntry >= 0);

--- a/video/avi_decoder.h
+++ b/video/avi_decoder.h
@@ -212,6 +212,7 @@ protected:
 		uint16 getHeight() const { return _bmInfo.height; }
 		uint16 getBitCount() const { return _bmInfo.bitCount; }
 		Graphics::PixelFormat getPixelFormat() const;
+		bool setOutputPixelFormat(const Graphics::PixelFormat &format);
 		int getCurFrame() const { return _curFrame; }
 		int getFrameCount() const { return _frameCount; }
 		Common::String &getName() { return _vidsHeader.name; }

--- a/video/bink_decoder.h
+++ b/video/bink_decoder.h
@@ -147,15 +147,16 @@ private:
 
 	class BinkVideoTrack : public FixedRateVideoTrack {
 	public:
-		BinkVideoTrack(uint32 width, uint32 height, const Graphics::PixelFormat &format, uint32 frameCount, const Common::Rational &frameRate, bool swapPlanes, bool hasAlpha, uint32 id);
+		BinkVideoTrack(uint32 width, uint32 height, uint32 frameCount, const Common::Rational &frameRate, bool swapPlanes, bool hasAlpha, uint32 id);
 		~BinkVideoTrack();
 
-		uint16 getWidth() const override { return _surface.w; }
-		uint16 getHeight() const  override{ return _surface.h; }
-		Graphics::PixelFormat getPixelFormat() const override { return _surface.format; }
+		uint16 getWidth() const override { return _width; }
+		uint16 getHeight() const  override{ return _height; }
+		Graphics::PixelFormat getPixelFormat() const override { return _pixelFormat; }
+		bool setOutputPixelFormat(const Graphics::PixelFormat &format) { _pixelFormat = format; return true; }
 		int getCurFrame() const override { return _curFrame; }
 		int getFrameCount() const override { return _frameCount; }
-		const Graphics::Surface *decodeNextFrame() override { return &_surface; }
+		const Graphics::Surface *decodeNextFrame() override { return _surface; }
 		bool isSeekable() const  override{ return true; }
 		bool seek(const Audio::Timestamp &time) override { return true; }
 		bool rewind() override;
@@ -243,7 +244,10 @@ private:
 		int _curFrame;
 		int _frameCount;
 
-		Graphics::Surface _surface;
+		Graphics::Surface *_surface;
+		Graphics::PixelFormat _pixelFormat;
+		uint16 _width;
+		uint16 _height;
 		int _surfaceWidth; ///< The actual surface width
 		int _surfaceHeight; ///< The actual surface height
 

--- a/video/hnm_decoder.cpp
+++ b/video/hnm_decoder.cpp
@@ -1064,6 +1064,10 @@ Graphics::PixelFormat HNMDecoder::HNM6VideoTrack::getPixelFormat() const {
 	return _decoder->getPixelFormat();
 }
 
+bool HNMDecoder::HNM6VideoTrack::setOutputPixelFormat(const Graphics::PixelFormat &format) {
+	return _decoder->setOutputPixelFormat(format);
+}
+
 void HNMDecoder::HNM6VideoTrack::decodeChunk(byte *data, uint32 size,
         uint16 chunkType, uint16 flags) {
 	if (chunkType == MKTAG16('I', 'X') ||

--- a/video/hnm_decoder.h
+++ b/video/hnm_decoder.h
@@ -162,6 +162,7 @@ private:
 		uint16 getWidth() const override;
 		uint16 getHeight() const override;
 		Graphics::PixelFormat getPixelFormat() const override;
+		bool setOutputPixelFormat(const Graphics::PixelFormat &format) override;
 		const Graphics::Surface *decodeNextFrame() override { return _surface; }
 
 		virtual void newFrame(uint32 frameDelay) override;

--- a/video/mkv_decoder.h
+++ b/video/mkv_decoder.h
@@ -88,13 +88,14 @@ protected:
 private:
 	class VPXVideoTrack : public VideoTrack {
 	public:
-		VPXVideoTrack(const Graphics::PixelFormat &format, const mkvparser::Track *const pTrack);
+		VPXVideoTrack(const mkvparser::Track *const pTrack);
 		~VPXVideoTrack();
 
 		bool endOfTrack() const;
-		uint16 getWidth() const { return _displaySurface.w; }
-		uint16 getHeight() const { return _displaySurface.h; }
-		Graphics::PixelFormat getPixelFormat() const { return _displaySurface.format; }
+		uint16 getWidth() const { return _width; }
+		uint16 getHeight() const { return _height; }
+		Graphics::PixelFormat getPixelFormat() const { return _pixelFormat; }
+		bool setOutputPixelFormat(const Graphics::PixelFormat &format) { _pixelFormat = format; return true; }
 		int getCurFrame() const { return _curFrame; }
 		uint32 getNextFrameStartTime() const { return (uint32)(_nextFrameStartTime * 1000); }
 		const Graphics::Surface *decodeNextFrame();
@@ -106,8 +107,11 @@ private:
 		bool _endOfVideo;
 		double _nextFrameStartTime;
 
+		uint16 _width;
+		uint16 _height;
+		Graphics::PixelFormat _pixelFormat;
+
 		Graphics::Surface _surface;
-		Graphics::Surface _displaySurface;
 		Common::Queue<Graphics::Surface> _displayQueue;
 
 		vpx_codec_ctx_t *_codec = nullptr;

--- a/video/mpegps_decoder.h
+++ b/video/mpegps_decoder.h
@@ -113,13 +113,14 @@ private:
 	// An MPEG 1/2 video track
 	class MPEGVideoTrack : public VideoTrack, public MPEGStream {
 	public:
-		MPEGVideoTrack(Common::SeekableReadStream *firstPacket, const Graphics::PixelFormat &format);
+		MPEGVideoTrack(Common::SeekableReadStream *firstPacket);
 		~MPEGVideoTrack();
 
 		bool endOfTrack() const { return _endOfTrack; }
 		uint16 getWidth() const;
 		uint16 getHeight() const;
 		Graphics::PixelFormat getPixelFormat() const;
+		bool setOutputPixelFormat(const Graphics::PixelFormat &format);
 		int getCurFrame() const { return _curFrame; }
 		uint32 getNextFrameStartTime() const { return _nextFrameStartTime.msecs(); }
 		const Graphics::Surface *decodeNextFrame();
@@ -136,7 +137,11 @@ private:
 		Audio::Timestamp _nextFrameStartTime;
 		Graphics::Surface *_surface;
 
-		void findDimensions(Common::SeekableReadStream *firstPacket, const Graphics::PixelFormat &format);
+		uint16 _width;
+		uint16 _height;
+		Graphics::PixelFormat _pixelFormat;
+
+		void findDimensions(Common::SeekableReadStream *firstPacket);
 
 #ifdef USE_MPEG2
 		Image::MPEGDecoder *_mpegDecoder;

--- a/video/psx_decoder.cpp
+++ b/video/psx_decoder.cpp
@@ -340,17 +340,21 @@ Audio::AudioStream *PSXStreamDecoder::PSXAudioTrack::getAudioStream() const {
 }
 
 
-PSXStreamDecoder::PSXVideoTrack::PSXVideoTrack(Common::SeekableReadStream *firstSector, CDSpeed speed, int frameCount) : _nextFrameStartTime(0, speed), _frameCount(frameCount) {
+PSXStreamDecoder::PSXVideoTrack::PSXVideoTrack(Common::SeekableReadStream *firstSector, CDSpeed speed, int frameCount) : _nextFrameStartTime(0, speed), _frameCount(frameCount), _surface(nullptr) {
 	assert(firstSector);
 
 	firstSector->seek(40);
-	uint16 width = firstSector->readUint16LE();
-	uint16 height = firstSector->readUint16LE();
-	_surface = new Graphics::Surface();
-	_surface->create(width, height, g_system->getScreenFormat());
+	_width = firstSector->readUint16LE();
+	_height = firstSector->readUint16LE();
 
-	_macroBlocksW = (width + 15) / 16;
-	_macroBlocksH = (height + 15) / 16;
+	_pixelFormat = g_system->getScreenFormat();
+
+	// Default to a 32bpp format, if in 8bpp mode
+	if (_pixelFormat.bytesPerPixel == 1)
+		_pixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0);
+
+	_macroBlocksW = (_width + 15) / 16;
+	_macroBlocksH = (_height + 15) / 16;
 	_yBuffer = new byte[_macroBlocksW * _macroBlocksH * 16 * 16];
 	_cbBuffer = new byte[_macroBlocksW * _macroBlocksH * 8 * 8];
 	_crBuffer = new byte[_macroBlocksW * _macroBlocksH * 8 * 8];
@@ -363,8 +367,10 @@ PSXStreamDecoder::PSXVideoTrack::PSXVideoTrack(Common::SeekableReadStream *first
 }
 
 PSXStreamDecoder::PSXVideoTrack::~PSXVideoTrack() {
-	_surface->free();
-	delete _surface;
+	if (_surface) {
+		_surface->free();
+		delete _surface;
+	}
 
 	delete[] _yBuffer;
 	delete[] _cbBuffer;
@@ -383,6 +389,11 @@ const Graphics::Surface *PSXStreamDecoder::PSXVideoTrack::decodeNextFrame() {
 }
 
 void PSXStreamDecoder::PSXVideoTrack::decodeFrame(Common::BitStreamMemoryStream *frame, uint sectorCount) {
+	if (!_surface) {
+		_surface = new Graphics::Surface();
+		_surface->create(_width, _height, _pixelFormat);
+	}
+
 	// A frame is essentially an MPEG-1 intra frame
 
 	Common::BitStreamMemory16LEMSB bits(frame);

--- a/video/psx_decoder.h
+++ b/video/psx_decoder.h
@@ -80,9 +80,10 @@ private:
 		PSXVideoTrack(Common::SeekableReadStream *firstSector, CDSpeed speed, int frameCount);
 		~PSXVideoTrack();
 
-		uint16 getWidth() const { return _surface->w; }
-		uint16 getHeight() const { return _surface->h; }
-		Graphics::PixelFormat getPixelFormat() const { return _surface->format; }
+		uint16 getWidth() const { return _width; }
+		uint16 getHeight() const { return _height; }
+		Graphics::PixelFormat getPixelFormat() const { return _pixelFormat; }
+		bool setOutputPixelFormat(const Graphics::PixelFormat &format) { _pixelFormat = format; return true; }
 		bool endOfTrack() const { return _endOfTrack; }
 		int getCurFrame() const { return _curFrame; }
 		int getFrameCount() const { return _frameCount; }
@@ -94,6 +95,9 @@ private:
 
 	private:
 		Graphics::Surface *_surface;
+		Graphics::PixelFormat _pixelFormat;
+		uint16 _width;
+		uint16 _height;
 		uint32 _frameCount;
 		Audio::Timestamp _nextFrameStartTime;
 		bool _endOfTrack;

--- a/video/qt_decoder.cpp
+++ b/video/qt_decoder.cpp
@@ -461,6 +461,13 @@ Graphics::PixelFormat QuickTimeDecoder::VideoTrackHandler::getPixelFormat() cons
 	return ((VideoSampleDesc *)_parent->sampleDescs[0])->_videoCodec->getPixelFormat();
 }
 
+bool QuickTimeDecoder::VideoTrackHandler::setOutputPixelFormat(const Graphics::PixelFormat &format) {
+	if (_forcedDitherPalette)
+		return false;
+
+	return ((VideoSampleDesc *)_parent->sampleDescs[0])->_videoCodec->setOutputPixelFormat(format);
+}
+
 int QuickTimeDecoder::VideoTrackHandler::getFrameCount() const {
 	return _parent->frameCount;
 }

--- a/video/qt_decoder.h
+++ b/video/qt_decoder.h
@@ -135,6 +135,7 @@ private:
 		uint16 getWidth() const;
 		uint16 getHeight() const;
 		Graphics::PixelFormat getPixelFormat() const;
+		bool setOutputPixelFormat(const Graphics::PixelFormat &format);
 		int getCurFrame() const { return _curFrame; }
 		int getFrameCount() const;
 		uint32 getNextFrameStartTime() const; // milliseconds

--- a/video/theora_decoder.h
+++ b/video/theora_decoder.h
@@ -79,17 +79,18 @@ protected:
 private:
 	class TheoraVideoTrack : public VideoTrack {
 	public:
-		TheoraVideoTrack(const Graphics::PixelFormat &format, th_info &theoraInfo, th_setup_info *theoraSetup);
+		TheoraVideoTrack(th_info &theoraInfo, th_setup_info *theoraSetup);
 		~TheoraVideoTrack();
 
 		bool endOfTrack() const { return _endOfVideo; }
-		uint16 getWidth() const { return _displaySurface.w; }
-		uint16 getHeight() const { return _displaySurface.h; }
-		Graphics::PixelFormat getPixelFormat() const { return _displaySurface.format; }
+		uint16 getWidth() const { return _width; }
+		uint16 getHeight() const { return _height; }
+		Graphics::PixelFormat getPixelFormat() const { return _pixelFormat; }
+		bool setOutputPixelFormat(const Graphics::PixelFormat &format) { _pixelFormat = format; return true; }
 		int getCurFrame() const { return _curFrame; }
 		const Common::Rational &getFrameRate() const { return _frameRate; }
 		uint32 getNextFrameStartTime() const { return (uint32)(_nextFrameStartTime * 1000); }
-		const Graphics::Surface *decodeNextFrame() { return &_displaySurface; }
+		const Graphics::Surface *decodeNextFrame() { return _displaySurface; }
 
 		bool decodePacket(ogg_packet &oggPacket);
 		void setEndOfVideo() { _endOfVideo = true; }
@@ -100,8 +101,15 @@ private:
 		Common::Rational _frameRate;
 		double _nextFrameStartTime;
 
-		Graphics::Surface _surface;
-		Graphics::Surface _displaySurface;
+		Graphics::Surface *_surface;
+		Graphics::Surface *_displaySurface;
+		Graphics::PixelFormat _pixelFormat;
+		int _x;
+		int _y;
+		uint16 _width;
+		uint16 _height;
+		uint16 _surfaceWidth;
+		uint16 _surfaceHeight;
 
 		th_dec_ctx *_theoraDecode;
 

--- a/video/video_decoder.cpp
+++ b/video/video_decoder.cpp
@@ -48,6 +48,7 @@ VideoDecoder::VideoDecoder() {
 	_nextVideoTrack = 0;
 	_mainAudioTrack = 0;
 	_canSetDither = true;
+	_canSetDefaultFormat = true;
 
 	// Find the best format for output
 	_defaultHighColorFormat = g_system->getScreenFormat();
@@ -79,6 +80,7 @@ void VideoDecoder::close() {
 	_nextVideoTrack = 0;
 	_mainAudioTrack = 0;
 	_canSetDither = true;
+	_canSetDefaultFormat = true;
 }
 
 bool VideoDecoder::loadFile(const Common::Path &filename) {
@@ -208,6 +210,7 @@ Graphics::PixelFormat VideoDecoder::getPixelFormat() const {
 const Graphics::Surface *VideoDecoder::decodeNextFrame() {
 	_needsUpdate = false;
 	_canSetDither = false;
+	_canSetDefaultFormat = false;
 
 	readNextPacket();
 
@@ -541,6 +544,23 @@ bool VideoDecoder::setDitheringPalette(const byte *palette) {
 		if ((*it)->getTrackType() == Track::kTrackTypeVideo && ((VideoTrack *)*it)->canDither()) {
 			((VideoTrack *)*it)->setDither(palette);
 			result = true;
+		}
+	}
+
+	return result;
+}
+
+bool VideoDecoder::setOutputPixelFormat(const Graphics::PixelFormat &format) {
+	// If a frame was already decoded, we can't set it now.
+	if (!_canSetDefaultFormat)
+		return false;
+
+	bool result = false;
+
+	for (TrackList::iterator it = _tracks.begin(); it != _tracks.end(); it++) {
+		if ((*it)->getTrackType() == Track::kTrackTypeVideo) {
+			if (((VideoTrack *)*it)->setOutputPixelFormat(format))
+				result = true;
 		}
 	}
 

--- a/video/video_decoder.cpp
+++ b/video/video_decoder.cpp
@@ -49,12 +49,6 @@ VideoDecoder::VideoDecoder() {
 	_mainAudioTrack = 0;
 	_canSetDither = true;
 	_canSetDefaultFormat = true;
-
-	// Find the best format for output
-	_defaultHighColorFormat = g_system->getScreenFormat();
-
-	if (_defaultHighColorFormat.bytesPerPixel == 1)
-		_defaultHighColorFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0);
 }
 
 void VideoDecoder::close() {

--- a/video/video_decoder.h
+++ b/video/video_decoder.h
@@ -397,6 +397,17 @@ public:
 	 */
 	bool setDitheringPalette(const byte *palette);
 
+	/**
+	 * Set the default high color format for videos that convert from YUV.
+	 *
+	 * This should be called after loadStream(), but before a decodeNextFrame()
+	 * call. This is enforced.
+	 *
+	 * @param format The preferred output pixel format
+	 * @return true on success, false otherwise
+	 */
+	bool setOutputPixelFormat(const Graphics::PixelFormat &format);
+
 	/////////////////////////////////////////
 	// Audio Control
 	/////////////////////////////////////////
@@ -576,6 +587,11 @@ protected:
 		 * Get the pixel format of this track
 		 */
 		virtual Graphics::PixelFormat getPixelFormat() const = 0;
+
+		/**
+		 * Set the default high color format for videos that convert from YUV.
+		 */
+		virtual bool setOutputPixelFormat(const Graphics::PixelFormat &format) { return false; }
 
 		/**
 		 * Get the current frame of this track
@@ -954,8 +970,9 @@ private:
 	mutable bool _dirtyPalette;
 	const byte *_palette;
 
-	// Enforcement of not being able to set dither
+	// Enforcement of not being able to set dither or set the default format
 	bool _canSetDither;
+	bool _canSetDefaultFormat;
 
 	// Default PixelFormat settings
 	Graphics::PixelFormat _defaultHighColorFormat;

--- a/video/video_decoder.h
+++ b/video/video_decoder.h
@@ -357,16 +357,6 @@ public:
 	virtual const Graphics::Surface *decodeNextFrame();
 
 	/**
-	 * Set the default high color format for videos that convert from YUV.
-	 *
-	 * By default, VideoDecoder will attempt to use the screen format
-	 * if it's >8bpp and use a 32bpp format when not.
-	 *
-	 * This must be set before calling loadStream().
-	 */
-	void setDefaultHighColorFormat(const Graphics::PixelFormat &format) { _defaultHighColorFormat = format; }
-
-	/**
 	 * Set the video to decode frames in reverse.
 	 *
 	 * By default, VideoDecoder will decode forward.
@@ -382,7 +372,7 @@ public:
 	 * Tell the video to dither to a palette.
 	 *
 	 * By default, VideoDecoder will return surfaces in native, or in the case
-	 * of YUV-based videos, the format set by setDefaultHighColorFormat().
+	 * of YUV-based videos, the format set by setOutputPixelFormat().
 	 * For video formats or codecs that support it, this will start outputting
 	 * its surfaces in 8bpp with this palette.
 	 *
@@ -893,11 +883,6 @@ protected:
 	bool endOfVideoTracks() const;
 
 	/**
-	 * Get the default high color format
-	 */
-	Graphics::PixelFormat getDefaultHighColorFormat() const { return _defaultHighColorFormat; }
-
-	/**
 	 * Set _nextVideoTrack to the video track with the lowest start time for the next frame.
 	 *
 	 * @return _nextVideoTrack
@@ -973,9 +958,6 @@ private:
 	// Enforcement of not being able to set dither or set the default format
 	bool _canSetDither;
 	bool _canSetDefaultFormat;
-
-	// Default PixelFormat settings
-	Graphics::PixelFormat _defaultHighColorFormat;
 
 protected:
 	// Internal helper functions


### PR DESCRIPTION
This new API is intended to replace `setDefaultHighColorFormat()`, and allows the preferred format to be set after calling `loadStream()`. This way, it's possible to read the required pixel format for codecs that don't support arbitrary formats and use it when setting the screen mode. The video player in the Testbed engine has been adapted to demonstrate this.

TODO:
- Decoders:
- [x] Bink
- [x] MKV
- [x] PSX
- [x] Theora
- [ ] VMD
- Codecs:
- [ ] HNM
- [x] XAN
- Engines:
- [x] Asylum
- [x] Grim
- [x] ICB
- [x] Myst III
- [x] SCUMM
- [x] Stark