### PR TITLE
DIRECTOR: Fix a couple memory leaks in Window::loadEXE

### DIFF
--- a/engines/director/resource.cpp
+++ b/engines/director/resource.cpp
@@ -302,6 +302,9 @@ Archive *Window::loadEXE(const Common::String movie) {
 
 	if (result)
 		result->setPathName(movie);
+	else
+		delete exeStream;
+
 	return result;
 }
 

--- a/engines/director/resource.cpp
+++ b/engines/director/resource.cpp
@@ -296,6 +296,7 @@ Archive *Window::loadEXE(const Common::String movie) {
 			result = loadEXEv3(exeStream);
 		} else {
 			warning("Window::loadEXE(): Unhandled Windows EXE version %d", g_director->getVersion());
+			delete exeStream;
 			return nullptr;
 		}
 	}


### PR DESCRIPTION
Before returning a nullptr result (i.e. loading the EXE failed), we should first delete the existing exeStream