### PR TITLE
GRAPHICS: Fix broken overload of transBlitFrom() in ManagedSurface

### DIFF
--- a/engines/titanic/support/direct_draw_surface.cpp
+++ b/engines/titanic/support/direct_draw_surface.cpp
@@ -90,7 +90,7 @@ void DirectDrawSurface::fillRect(Rect *rect, byte r, byte g, byte b) {
 void DirectDrawSurface::blit(const Rect &destRect, DirectDrawSurface *srcSurface, Rect &srcRect) {
 	assert(srcSurface);
 	if (!destRect.isEmpty())
-		_surface->transBlitFrom(*srcSurface->_surface, srcRect, destRect, (uint)-1);
+		_surface->transBlitFrom(*srcSurface->_surface, srcRect, destRect);
 }
 
 void DirectDrawSurface::blit(const Point &destPos, DirectDrawSurface *srcSurface, Rect *bounds) {

--- a/engines/ultima/nuvie/misc/sdl_compat.cpp
+++ b/engines/ultima/nuvie/misc/sdl_compat.cpp
@@ -53,7 +53,7 @@ int SDL_BlitSurface(const Graphics::ManagedSurface *src, const Common::Rect *src
 	Common::Rect srcRect = srcrect ? *srcrect : Common::Rect(0, 0, src->w, src->h);
 	Common::Point destPos = dstrect ? Common::Point(dstrect->left, dstrect->top) : Common::Point();
 
-	dst->transBlitFrom(*src, srcRect, destPos, (uint)-1);
+	dst->transBlitFrom(*src, srcRect, destPos);
 
 	if (dstrect) {
 		dstrect->setWidth(srcRect.width());

--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -503,7 +503,7 @@ void ManagedSurface::transBlitFrom(const ManagedSurface &src, const Common::Rect
 void ManagedSurface::transBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect,
 		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha,
 		const Surface *mask, bool maskOnly) {
-	if (transColor == (uint32)-1 && src._transparentColorSet)
+	if (!transColor && src._transparentColorSet)
 		transColor = src._transparentColor;
 	const uint32 *srcPalette = src._paletteSet ? src._palette : nullptr;
 	const uint32 *dstPalette = _paletteSet ? _palette : nullptr;
@@ -625,7 +625,7 @@ void transBlit(const Surface &src, const Common::Rect &srcRect, ManagedSurface &
 
 	// If we're dealing with a 32-bit source surface, we need to split up the RGB,
 	// since we'll want to find matching RGB pixels irrespective of the alpha
-	bool isSrcTrans32 = src.format.aBits() != 0 && transColor != (uint32)-1 && transColor > 0;
+	bool isSrcTrans32 = src.format.aBits() != 0 && transColor != 0;
 	if (isSrcTrans32) {
 		src.format.colorToRGB(transColor, rst, gst, bst);
 	}


### PR DESCRIPTION
This PR fixes an issue in one of the transBlitFrom() overloads in
ManagedSurface, where the function checks for a default argument
of -1, but the declaration in the header file sets the default to 0.
This breaks transparency when calling the blitFrom() overload
that takes a destRect argument.

I've found and corrected two cases where this change would break
transparency (one in Titanic and one in Nuvie), but since this bug
has been present for over three years, other engines are most likely
also affected.

Below is a list of places that I think might be affected by this change.
I can't test them myself since I don't have the needed games,
so I'd really appreciate some help.

- /engines/access/asurface.cpp, lines 160 & 164
- /engines/glk/zcode/bitmap_font.cpp, line 47
- /engines/mtropolis/elements.cpp, line 1948
- /engines/sherlock/surface.cpp, line 69 (3DO version)
- /engines/titanic/support/avi_surface.cpp, line 527
- /engines/twine/movies.cpp, line 423
- /engines/twine/menu/menu.cpp, line 262
- /engines/twine/renderer/redraw.cpp, line 920
- /engines/ultima/ultima8/ultima8.cpp, line 1646
- /graphics/macgui/macwindow.cpp, line 177