### PR TITLE
GRAPHICS: Fix cursor mask regressions

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -1393,6 +1393,10 @@ void OpenGLGraphicsManager::notifyContextCreate(ContextType type,
 		_cursor->recreate();
 	}
 
+	if (_cursorMask) {
+		_cursorMask->recreate();
+	}
+
 #ifdef USE_OSD
 	if (_osdMessageSurface) {
 		_osdMessageSurface->recreate();
@@ -1415,6 +1419,10 @@ void OpenGLGraphicsManager::notifyContextDestroy() {
 
 	if (_cursor) {
 		_cursor->destroy();
+	}
+
+	if (_cursorMask) {
+		_cursorMask->destroy();
 	}
 
 #ifdef USE_OSD

--- a/backends/graphics/opengl/texture.h
+++ b/backends/graphics/opengl/texture.h
@@ -341,6 +341,8 @@ public:
 
 	void updateGLTexture() override;
 protected:
+	void applyPaletteAndMask(byte *dst, const byte *src, uint dstPitch, uint srcPitch, uint srcWidth, const Common::Rect &dirtyArea, const Graphics::PixelFormat &dstFormat, const Graphics::PixelFormat &srcFormat) const;
+
 	Graphics::Surface _rgbData;
 	Graphics::PixelFormat _fakeFormat;
 	uint32 *_palette;


### PR DESCRIPTION
Fixes two regressions from PR #4713 

First, cursor transparency was breaking when toggling fullscreen mode on Windows (alt+enter) and possibly other platforms because the cursor texture was still mapped to an ID from the destroyed GL context.

Second, cursor mask transparency wasn't being applied when using scalers that can scale cursors (Normal and AdvMame), which was causing a border to appear around them in some games due to it being filled with the key color, despite the key color not actually being keyed out.