### PR TITLE
SAGA2: Fix Wrong spellID crash when using spells from inventory!

### DIFF
--- a/engines/saga2/magic.cpp
+++ b/engines/saga2/magic.cpp
@@ -93,8 +93,15 @@ GameObject *GetOwner(GameObject *go) {
 // This call looks up a spells object prototype. It can accept either
 //   an object ID or a spell ID
 SkillProto *skillProtoFromID(int16 spellOrObjectID) {
+	SkillProto *sProto = (SkillProto *)GameObject::protoAddress(spellOrObjectID);
 	if (spellOrObjectID > MAX_SPELLS)
-		return (SkillProto *)GameObject::protoAddress(spellOrObjectID);
+		return sProto;
+
+	// Can be spellId, check if this the prototype returned by spellOrObjectID refers to a spell
+	int16 manaColor = spellBook[sProto->getSpellID()].getManaType();
+	int16 manaCost  = spellBook[sProto->getSpellID()].getManaAmt();
+	if (manaColor >= ksManaIDRed &&  manaColor <= ksManaIDViolet &&  manaCost > 0) // A spell
+		return sProto;
 
 	if (spellOrObjectID >= kTotalSpellBookPages)
 		error("Wrong spellID: %d > %d", spellOrObjectID, kTotalSpellBookPages);


### PR DESCRIPTION
In function [skillProtoFromID, magic.cpp](https://github.com/scummvm/scummvm/blob/8fea0be1bdd2bb613e76e481e693fbb14131794c/engines/saga2/magic.cpp#L95) the logic to get skill is simple, If the id given is greater than maximum spells then it simply returns game object from address, whereas if not then it will return spell from the spell book! This is based upon the assumption that _Spell objects will have IDs > the number of spells_, however, it sometimes happens that spell object get Id between this safe range, thus the error of **Wrong spellID**.

The patch fixes this by fetching the game object from the address and checking if it is a spell, If it is, then it simply returns the address, else checks for range.
```
int16 manaColor = spellBook[sProto->getSpellID()].getManaType();
int16 manaCost  = spellBook[sProto->getSpellID()].getManaAmt();
if (manaColor >= ksManaIDRed &&  manaColor <= ksManaIDViolet &&  manaCost > 0) // A spell
return sProto;
```