### PR TITLE
GUI: Make text selectable in input boxes

### DIFF
--- a/gui/widgets/editable.cpp
+++ b/gui/widgets/editable.cpp
@@ -30,11 +30,13 @@ namespace GUI {
 
 EditableWidget::EditableWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &tooltip, uint32 cmd)
 	: Widget(boss, x, y, w, h, tooltip), CommandSender(boss), _cmd(cmd) {
+	setFlags(WIDGET_TRACK_MOUSE);
 	init();
 }
 
 EditableWidget::EditableWidget(GuiObject *boss, const Common::String &name, const Common::U32String &tooltip, uint32 cmd)
 	: Widget(boss, name, tooltip), CommandSender(boss), _cmd(cmd) {
+	setFlags(WIDGET_TRACK_MOUSE);
 	init();
 }
 
@@ -46,6 +48,11 @@ void EditableWidget::init() {
 	_caretInverse = false;
 
 	_editScrollOffset = 0;
+
+	_selCaretPos = -1;
+	_selOffset = 0;
+
+	_shiftPressed = _isDragging = false;
 
 	_align = g_gui.useRTL() ? Graphics::kTextAlignRight : Graphics::kTextAlignLeft;
 	_drawAlign = _align;
@@ -104,6 +111,92 @@ void EditableWidget::handleTickle() {
 	}
 }
 
+void EditableWidget::handleMouseDown(int x, int y, int button, int clickCount) {
+	if (!isEnabled())
+		return;
+	
+	_isDragging = true;
+	// Select all text incase of double press
+	if (clickCount > 1) {
+		_selCaretPos = 0;
+		setCaretPos(caretVisualPos(_editString.size()));
+		setSelectionOffset(_editString.size() - _selCaretPos);
+		markAsDirty();
+		return;
+	}
+	
+	// Clear any selection
+	if (_selOffset != 0 && !_shiftPressed)
+		clearSelection();
+	else if (_shiftPressed && _selCaretPos < 0)
+		_selCaretPos = _caretPos;
+
+	if (g_gui.useRTL()) {
+		x = _w - x;
+	}
+
+	x += _editScrollOffset;
+	int width = 0;
+	if (_drawAlign == Graphics::kTextAlignRight)
+		width = _editScrollOffset + getEditRect().width() - g_gui.getStringWidth(_editString, _font);
+
+	uint i, last = 0;
+	for (i = 0; i < _editString.size(); ++i) {
+		const uint cur = _editString[i];
+		width += g_gui.getCharWidth(cur, _font) + g_gui.getKerningOffset(last, cur, _font);
+		if (width >= x && width > _editScrollOffset)
+			break;
+		last = cur;
+	}
+	setCaretPos(i);
+	if(_selCaretPos >= 0) setSelectionOffset(i - _selCaretPos);
+	markAsDirty();
+}
+
+void EditableWidget::handleMouseUp(int x, int y, int button, int clickCount) {
+	if(isEnabled())
+		_isDragging = false;
+}
+
+void EditableWidget::handleMouseMoved(int x, int y, int button) {
+	if(_isDragging && isEnabled()) {
+		if(_selCaretPos < 0)
+			_selCaretPos = _caretPos;
+
+		if (g_gui.useRTL()) {
+			x = _w - x;
+		}
+
+		if (x < 0 && _editScrollOffset > 0) {
+			_editScrollOffset += x;
+			if(_editScrollOffset < 0)
+				_editScrollOffset = 0;
+		}
+
+		x += _editScrollOffset;
+		int width = 0;
+		if (_drawAlign == Graphics::kTextAlignRight)
+			width = _editScrollOffset + getEditRect().width() - g_gui.getStringWidth(_editString, _font);
+		uint i, last = 0;
+		for (i = 0; i < _editString.size(); ++i) {
+			const uint cur = _editString[i];
+			width += g_gui.getCharWidth(cur, _font) + g_gui.getKerningOffset(last, cur, _font);
+			if (width >= x && width > _editScrollOffset)
+				break;
+			last = cur;
+		}
+
+		setCaretPos(i);
+		if(_selCaretPos >= 0) setSelectionOffset(i - _selCaretPos);
+		markAsDirty();
+	}
+}
+
+bool EditableWidget::handleKeyUp(Common::KeyState state) {
+	_shiftPressed = state.hasFlags(Common::KBD_SHIFT);
+	return false;
+}
+
 bool EditableWidget::handleKeyDown(Common::KeyState state) {
 	bool handled = true;
 	bool dirty = false;
@@ -116,6 +209,8 @@ bool EditableWidget::handleKeyDown(Common::KeyState state) {
 	// First remove caret
 	if (_caretVisible)
 		drawCaret(true);
+
+	_shiftPressed = state.hasFlags(Common::KBD_SHIFT);
 
 	// Remap numeric keypad if NUM lock is *not* active.
 	// This code relies on the fact that the various KEYCODE_KP* values are
@@ -154,10 +249,22 @@ bool EditableWidget::handleKeyDown(Common::KeyState state) {
 
 	case Common::KEYCODE_BACKSPACE:
 		deleteIndex = caretLogicalPos();
-		if (deleteIndex > 0) {
+		if (deleteIndex > 0 && _selOffset == 0) {
 			deleteIndex--;
 			_editString.deleteChar(deleteIndex);
 			setCaretPos(caretVisualPos(deleteIndex));
+			dirty = true;
+
+			sendCommand(_cmd, 0);
+		} else if (deleteIndex >= 0 && _selOffset != 0) {
+			int selBegin = _selCaretPos;
+			int selEnd = _selCaretPos + _selOffset;
+			if (selBegin > selEnd) 
+				SWAP(selBegin, selEnd);
+			_editString.erase(selBegin, selEnd - selBegin);
+			setCaretPos(caretVisualPos(selBegin));
+			_selCaretPos = -1;
+			_selOffset = 0;
 			dirty = true;
 
 			sendCommand(_cmd, 0);
@@ -181,11 +288,23 @@ bool EditableWidget::handleKeyDown(Common::KeyState state) {
 	case Common::KEYCODE_END:
 		// Move caret to end
 		setCaretPos(caretVisualPos(_editString.size()));
+		if (state.flags & Common::KBD_SHIFT)
+			setSelectionOffset(_editString.size() - _selCaretPos);
+		else
+			clearSelection();
 		forcecaret = true;
 		dirty = true;
 		break;
 
 	case Common::KEYCODE_LEFT:
+		if(state.hasFlags(Common::KBD_SHIFT)) {
+			if(_selCaretPos < 0)
+				_selCaretPos = _caretPos;
+			if(_caretPos > 0)
+			_selOffset--;
+		} else {
+			clearSelection();
+		}
 		// Move caret one left (if possible)
 		if (_caretPos > 0) {
 			dirty = setCaretPos(_caretPos - 1);
@@ -195,6 +314,14 @@ bool EditableWidget::handleKeyDown(Common::KeyState state) {
 		break;
 
 	case Common::KEYCODE_RIGHT:
+		if(state.hasFlags(Common::KBD_SHIFT)) {
+			if(_selCaretPos < 0)
+				_selCaretPos = _caretPos;
+			if(_selOffset + _selCaretPos < (int)_editString.size())
+			_selOffset++;
+		} else {
+			clearSelection();
+		}
 		// Move caret one right (if possible)
 		if (_caretPos < (int)_editString.size()) {
 			dirty = setCaretPos(_caretPos + 1);
@@ -207,6 +334,10 @@ bool EditableWidget::handleKeyDown(Common::KeyState state) {
 	case Common::KEYCODE_HOME:
 		// Move caret to start
 		setCaretPos(caretVisualPos(0));
+		if (state.flags & Common::KBD_SHIFT)
+			setSelectionOffset(0 - _selCaretPos);
+		else
+			clearSelection();
 		forcecaret = true;
 		dirty = true;
 		break;
@@ -229,8 +360,14 @@ bool EditableWidget::handleKeyDown(Common::KeyState state) {
 
 	case Common::KEYCODE_c:
 		if (state.flags & Common::KBD_CTRL) {
-			if (!getEditString().empty())
-				g_system->setTextInClipboard(getEditString());
+			if (!getEditString().empty()) {
+				int selBegin = _selCaretPos;
+				int selEnd = _selCaretPos + _selOffset;
+				if (selBegin > selEnd)
+					SWAP(selBegin, selEnd);
+				const Common::U32String selected(getEditString().begin() + selBegin, getEditString().begin() + selEnd);
+				g_system->setTextInClipboard(selected);
+			}
 		} else {
 			defaultKeyDownHandler(state, dirty, forcecaret, handled);
 		}
@@ -262,6 +399,7 @@ bool EditableWidget::handleKeyDown(Common::KeyState state) {
 				dirty = setCaretPos(_editString.size());
 				forcecaret = true;
 			}
+			clearSelection();
 			break;
 		}
 #endif
@@ -280,12 +418,27 @@ bool EditableWidget::handleKeyDown(Common::KeyState state) {
 }
 
 void EditableWidget::defaultKeyDownHandler(Common::KeyState &state, bool &dirty, bool &forcecaret, bool &handled) {
-	const int logicalPosition = caretLogicalPos();
-	if (tryInsertChar(state.ascii, logicalPosition)) {
-		setCaretPos(caretVisualPos(logicalPosition + 1));
+	if (isCharAllowed(state.ascii)) {
+		// Incase of a selection, replace the selection with the character
+		if (_selCaretPos >= 0) {
+			int selBegin = _selCaretPos;
+			int selEnd = _selCaretPos + _selOffset;
+			if (selBegin > selEnd) 
+				SWAP(selBegin, selEnd);
+			_editString.replace(selBegin, selEnd - selBegin, Common::U32String(state.ascii));
+			if(_editString.size() > 0)
+				selBegin++;
+			setCaretPos(caretVisualPos(selBegin));
+			_selCaretPos = -1;
+			_selOffset = 0;
+		} else {
+			// Insert char normally at caretPos
+			const int logicalPosition = caretLogicalPos();
+			_editString.insertChar(state.ascii, logicalPosition);
+			setCaretPos(caretVisualPos(logicalPosition + 1));
+		}
 		dirty = true;
 		forcecaret = true;
-
 		sendCommand(_cmd, 0);
 	} else {
 		handled = false;
@@ -295,6 +448,12 @@ void EditableWidget::defaultKeyDownHandler(Common::KeyState &state, bool &dirty,
 int EditableWidget::getCaretOffset() const {
 	Common::UnicodeBiDiText utxt(_editString);
 	Common::U32String substr(utxt.visual.begin(), utxt.visual.begin() + _caretPos);
+	return g_gui.getStringWidth(substr, _font) - _editScrollOffset;
+}
+
+int EditableWidget::getSelectionCarretOffset() const {
+	Common::UnicodeBiDiText utxt(_editString);
+	Common::U32String substr(utxt.visual.begin(), utxt.visual.begin() + _selCaretPos);
 	return g_gui.getStringWidth(substr, _font) - _editScrollOffset;
 }
 
@@ -359,6 +518,10 @@ void EditableWidget::drawCaret(bool erase) {
 		// EditTextWidget uses that but not ListWidget. Thus, one should check
 		// whether we can unify the drawing in the text area first to avoid
 		// possible glitches due to different methods used.
+		if (_selOffset < 0) 
+			_inversion = ThemeEngine::kTextInversionFocus;
+		else 
+			_inversion = ThemeEngine::kTextInversionNone;
 		width = MIN(editRect.width() - caretOffset, width);
 		if (width > 0) {
 			g_gui.theme()->drawText(Common::Rect(x, y, x + width, y + editRect.height()), character,
@@ -408,6 +571,16 @@ void EditableWidget::makeCaretVisible() {
 	_caretTime = g_system->getMillis() + kCaretBlinkTime;
 	_caretVisible = true;
 	drawCaret(false);
+}
+
+void EditableWidget::clearSelection() {
+	_selCaretPos = -1;
+	_selOffset = 0;
+	markAsDirty();
+}
+
+void EditableWidget::setSelectionOffset(int newOffset) {
+	_selOffset = newOffset;
 }
 
 } // End of namespace GUI

--- a/gui/widgets/editable.h
+++ b/gui/widgets/editable.h
@@ -52,6 +52,12 @@ protected:
 
 	int			_editScrollOffset;
 
+	int			_selCaretPos;
+	int			_selOffset;
+	bool		_shiftPressed;
+	bool		_isDragging;
+	bool		_disableSelection;
+
 	Graphics::TextAlign _align;
 	Graphics::TextAlign _drawAlign;
 
@@ -70,10 +76,15 @@ public:
 	virtual const Common::U32String &getEditString() const	{ return _editString; }
 
 	void handleTickle() override;
+	void handleMouseDown(int x, int y, int button, int clickCount) override;
+	void handleMouseUp(int x, int y, int button, int clickCount) override;
+	void handleMouseMoved(int x, int y, int button) override;
 	bool handleKeyDown(Common::KeyState state) override;
+	bool handleKeyUp(Common::KeyState state) override;
 	void reflowLayout() override;
 
 	bool setCaretPos(int newPos);
+	void setSelectionOffset(int newOffset);
 
 protected:
 	virtual void startEditMode() = 0;
@@ -86,6 +97,7 @@ protected:
 	 */
 	virtual Common::Rect getEditRect() const = 0;
 	virtual int getCaretOffset() const;
+	virtual int getSelectionCarretOffset() const;
 	void drawCaret(bool erase);
 	bool adjustOffset();
 	void makeCaretVisible();
@@ -99,6 +111,8 @@ protected:
 
 	int caretVisualPos(int logicalPos);
 	int caretLogicalPos() const;
+
+	void clearSelection();
 };
 
 } // End of namespace GUI

--- a/gui/widgets/edittext.h
+++ b/gui/widgets/edittext.h
@@ -42,8 +42,6 @@ public:
 
 	void setEditString(const Common::U32String &str) override;
 
-	void handleMouseDown(int x, int y, int button, int clickCount) override;
-
 	bool wantsFocus() override { return true; }
 
 	void reflowLayout() override;


### PR DESCRIPTION
This adds the ability to select text in a EditTextWidget. 
The following list of behaviour is implemented:- 

- Double Click: Selects all the text
- SHIFT + L/R: Increments/Decrements selection.
- SHIFT + Left Click: Selects text between caret position and the mouse click.
- SHIFT + Home/End : Selects Text between the caretPosition and starting of the string/the end of the string.
- Dragging the mouse over the string will select that part of the string.
- Pressing backspace while a selection has been made will delete that selection.
- Pressing CTRL+C while a selection has been made will copy the selection to clipboard.
- Pressing CTRL+V while a selection has been made will replace the selected text with the text from clipboard.

Many thanks to @sev- for answering my questions and writing the rendering code!
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
