### PR TITLE
CONFIGURE: fix build of dynamic modules under Cygwin

### DIFF
--- a/configure
+++ b/configure
@@ -4506,7 +4506,7 @@ PRE_OBJS_FLAGS  := -Wl,-export-dynamic -Wl,-whole-archive
 POST_OBJS_FLAGS := -Wl,-no-whole-archive
 '
 		;;
-	*mingw32* | mingw64)
+	*cygwin* | *mingw32* | mingw64)
 		_plugin_prefix=""
 		_plugin_suffix=".dll"
 _mak_plugins='


### PR DESCRIPTION
This tiny fix allows to build SCUMMVM with dynamic modules, when `--enable-cygwin-build` is also activated.