### PR TITLE
ANDROID: Make SAF lookup faster

### DIFF
--- a/backends/platform/android/org/scummvm/scummvm/SAFFSTree.java
+++ b/backends/platform/android/org/scummvm/scummvm/SAFFSTree.java
@@ -123,7 +123,7 @@ public class SAFFSTree {
 	private static final SAFFSNode NOT_FOUND_NODE = new SAFFSNode();
 
 	private static class SAFCache extends LinkedHashMap<String, SAFFSNode> {
-		private static final int MAX_ENTRIES = 1000;
+		private static final int MAX_ENTRIES = 10000;
 
 		public SAFCache() {
 			super(16, 0.75f, true);


### PR DESCRIPTION
This fixes slowness at startup when there are many games.
The `getChild` was called once for each folder and while iterating over many entries, it only cached the result it was interested in.
`getChild` now calls `getChildren` when an entry is not in cache. This caches the whole folder and speeds up look ups for the same folder.
The cache is increased to take into account folder with more than 1000 elements (now 10000).
Currently, if a folder has more than 10000 items, elements could be seen as not found.