### PR TITLE
TINYGL: Replace tglFrustum, tglOrtho and tglClearDepth with float versions

### DIFF
--- a/engines/freescape/gfx_tinygl.cpp
+++ b/engines/freescape/gfx_tinygl.cpp
@@ -104,7 +104,7 @@ void TinyGLRenderer::updateProjectionMatrix(float fov, float nearClipPlane, floa
 	float ymaxValue = xmaxValue / aspectRatio;
 	// debug("max values: %f %f", xmaxValue, ymaxValue);
 
-	tglFrustum(xmaxValue, -xmaxValue, -ymaxValue, ymaxValue, nearClipPlane, farClipPlane);
+	tglFrustumf(xmaxValue, -xmaxValue, -ymaxValue, ymaxValue, nearClipPlane, farClipPlane);
 	tglMatrixMode(TGL_MODELVIEW);
 	tglLoadIdentity();
 }
@@ -135,7 +135,7 @@ void TinyGLRenderer::renderPlayerShoot(byte color, const Common::Point position,
 
 	tglMatrixMode(TGL_PROJECTION);
 	tglLoadIdentity();
-	tglOrtho(0, _screenW, _screenH, 0, 0, 1);
+	tglOrthof(0, _screenW, _screenH, 0, 0, 1);
 	tglMatrixMode(TGL_MODELVIEW);
 	tglLoadIdentity();
 

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -113,7 +113,7 @@ void GfxTinyGL::setupCameraFrustum(float fov, float nclip, float fclip) {
 	tglLoadIdentity();
 
 	float right = nclip * tan(fov / 2 * ((float)M_PI / 180));
-	tglFrustum(-right, right, -right * 0.75, right * 0.75, nclip, fclip);
+	tglFrustumf(-right, right, -right * 0.75f, right * 0.75f, nclip, fclip);
 
 	tglMatrixMode(TGL_MODELVIEW);
 	tglLoadIdentity();
@@ -500,7 +500,7 @@ void GfxTinyGL::startActorDraw(const Actor *actor) {
 			float right = 1;
 			float top = right * 0.75;
 			float div = 6.0f;
-			tglFrustum(-right / div, right / div, -top / div, top / div, 1.0f / div, 3276.8f);
+			tglFrustumf(-right / div, right / div, -top / div, top / div, 1.0f / div, 3276.8f);
 			tglMatrixMode(TGL_MODELVIEW);
 			tglLoadIdentity();
 			tglScalef(1.0, 1.0, -1.0);
@@ -1292,7 +1292,7 @@ void GfxTinyGL::dimScreen() {
 void GfxTinyGL::dimRegion(int x, int y, int w, int h, float level) {
 	tglMatrixMode(TGL_PROJECTION);
 	tglLoadIdentity();
-	tglOrtho(0, _gameWidth, _gameHeight, 0, 0, 1);
+	tglOrthof(0, _gameWidth, _gameHeight, 0, 0, 1);
 	tglMatrixMode(TGL_MODELVIEW);
 	tglLoadIdentity();
 
@@ -1322,7 +1322,7 @@ void GfxTinyGL::dimRegion(int x, int y, int w, int h, float level) {
 void GfxTinyGL::irisAroundRegion(int x1, int y1, int x2, int y2) {
 	tglMatrixMode(TGL_PROJECTION);
 	tglLoadIdentity();
-	tglOrtho(0.0, _gameWidth, _gameHeight, 0.0, 0.0, 1.0);
+	tglOrthof(0, _gameWidth, _gameHeight, 0, 0, 1);
 	tglMatrixMode(TGL_MODELVIEW);
 	tglLoadIdentity();
 
@@ -1374,7 +1374,7 @@ void GfxTinyGL::drawRectangle(const PrimitiveObject *primitive) {
 
 	tglMatrixMode(TGL_PROJECTION);
 	tglLoadIdentity();
-	tglOrtho(0, _screenWidth, _screenHeight, 0, 0, 1);
+	tglOrthof(0, _screenWidth, _screenHeight, 0, 0, 1);
 	tglMatrixMode(TGL_MODELVIEW);
 	tglLoadIdentity();
 
@@ -1418,7 +1418,7 @@ void GfxTinyGL::drawLine(const PrimitiveObject *primitive) {
 
 	tglMatrixMode(TGL_PROJECTION);
 	tglLoadIdentity();
-	tglOrtho(0, _screenWidth, _screenHeight, 0, 0, 1);
+	tglOrthof(0, _screenWidth, _screenHeight, 0, 0, 1);
 	tglMatrixMode(TGL_MODELVIEW);
 	tglLoadIdentity();
 
@@ -1447,7 +1447,7 @@ void GfxTinyGL::drawDimPlane() {
 
 	tglMatrixMode(TGL_PROJECTION);
 	tglLoadIdentity();
-	tglOrtho(0, 1.0, 1.0, 0, 0, 1);
+	tglOrthof(0, 1, 1, 0, 0, 1);
 	tglMatrixMode(TGL_MODELVIEW);
 	tglLoadIdentity();
 
@@ -1489,7 +1489,7 @@ void GfxTinyGL::drawPolygon(const PrimitiveObject *primitive) {
 
 	tglMatrixMode(TGL_PROJECTION);
 	tglLoadIdentity();
-	tglOrtho(0, _screenWidth, _screenHeight, 0, 0, 1);
+	tglOrthof(0, _screenWidth, _screenHeight, 0, 0, 1);
 	tglMatrixMode(TGL_MODELVIEW);
 	tglLoadIdentity();
 

--- a/engines/hpl1/engine/impl/low_level_graphics_tgl.cpp
+++ b/engines/hpl1/engine/impl/low_level_graphics_tgl.cpp
@@ -393,7 +393,7 @@ void LowLevelGraphicsTGL::SetupGL() {
 	tglViewport(0, 0, mvScreenSize.x, mvScreenSize.y);
 
 	// Depth Test setup
-	tglClearDepth(1.0f);      // VAlues buffer is cleared with
+	tglClearDepthf(1.0f);      // VAlues buffer is cleared with
 	tglEnable(TGL_DEPTH_TEST); // enable depth testing
 	tglDepthFunc(TGL_LEQUAL);  // function to do depth test with
 	tglDisable(TGL_ALPHA_TEST);
@@ -660,7 +660,7 @@ void LowLevelGraphicsTGL::ScaleMatrix(eMatrix aMtxType, const cVector3f &avScale
 void LowLevelGraphicsTGL::SetOrthoProjection(const cVector2f &avSize, float afMin, float afMax) {
 	tglMatrixMode(TGL_PROJECTION);
 	tglLoadIdentity();
-	tglOrtho(0, avSize.x, avSize.y, 0, afMin, afMax);
+	tglOrthof(0, avSize.x, avSize.y, 0, afMin, afMax);
 }
 
 //-----------------------------------------------------------------------
@@ -855,7 +855,7 @@ void LowLevelGraphicsTGL::SetClearColor(const cColor &aCol) {
 	tglClearColor(aCol.r, aCol.g, aCol.b, aCol.a);
 }
 void LowLevelGraphicsTGL::SetClearDepth(float afDepth) {
-	tglClearDepth(afDepth);
+	tglClearDepthf(afDepth);
 }
 void LowLevelGraphicsTGL::SetClearStencil(int alVal) {
 	tglClearStencil(alVal);

--- a/engines/myst3/gfx_tinygl.cpp
+++ b/engines/myst3/gfx_tinygl.cpp
@@ -107,17 +107,17 @@ void TinyGLRenderer::selectTargetWindow(Window *window, bool is3D, bool scaled) 
 
 		if (!window) {
 			if (scaled) {
-				tglOrtho(0.0, kOriginalWidth, kOriginalHeight, 0.0, -1.0, 1.0);
+				tglOrthof(0, kOriginalWidth, kOriginalHeight, 0, -1, 1);
 			} else {
-				tglOrtho(0.0, _system->getWidth(), _system->getHeight(), 0.0, -1.0, 1.0);
+				tglOrthof(0, _system->getWidth(), _system->getHeight(), 0, -1, 1);
 			}
 		} else {
 			if (scaled) {
 				Common::Rect originalRect = window->getOriginalPosition();
-				tglOrtho(0.0, originalRect.width(), originalRect.height(), 0.0, -1.0, 1.0);
+				tglOrthof(0, originalRect.width(), originalRect.height(), 0, -1, 1);
 			} else {
 				Common::Rect vp = window->getPosition();
-				tglOrtho(0.0, vp.width(), vp.height(), 0.0, -1.0, 1.0);
+				tglOrthof(0, vp.width(), vp.height(), 0, -1, 1);
 			}
 		}
 

--- a/engines/tetraedge/te/te_renderer_tinygl.cpp
+++ b/engines/tetraedge/te/te_renderer_tinygl.cpp
@@ -113,7 +113,7 @@ void TeRendererTinyGL::init(uint width, uint height) {
 	tglDepthFunc(TGL_LEQUAL);
 	// Original does this, probably not needed?
 	//tglHint(TGL_PERSPECTIVE_CORRECTION_HINT, TGL_DONT_CARE);
-	tglClearDepth(1.0);
+	tglClearDepthf(1.0f);
 	//tglClearStencil(0);
 	_clearColor = TeColor(0, 0, 0, 255);
 	tglClearColor(0, 0, 0, 1.0);

--- a/graphics/tinygl/api.cpp
+++ b/graphics/tinygl/api.cpp
@@ -453,34 +453,42 @@ void tglViewport(TGLint x, TGLint y, TGLsizei width, TGLsizei height) {
 	c->gl_add_op(p);
 }
 
-void tglFrustum(TGLdouble left, TGLdouble right, TGLdouble bottom, TGLdouble top, TGLdouble nearv, TGLdouble farv) {
+void tglFrustumf(TGLfloat left, TGLfloat right, TGLfloat bottom, TGLfloat top, TGLfloat nearv, TGLfloat farv) {
 	TinyGL::GLContext *c = TinyGL::gl_get_context();
 	TinyGL::GLParam p[7];
 
 	p[0].op = TinyGL::OP_Frustum;
-	p[1].f = (float)left;
-	p[2].f = (float)right;
-	p[3].f = (float)bottom;
-	p[4].f = (float)top;
-	p[5].f = (float)nearv;
-	p[6].f = (float)farv;
+	p[1].f = left;
+	p[2].f = right;
+	p[3].f = bottom;
+	p[4].f = top;
+	p[5].f = nearv;
+	p[6].f = farv;
+
+	c->gl_add_op(p);
+}
+
+void tglFrustum(TGLdouble left, TGLdouble right, TGLdouble bottom, TGLdouble top, TGLdouble nearv, TGLdouble farv) {
+	tglFrustumf((TGLfloat)left, (TGLfloat)right, (TGLfloat)bottom, (TGLfloat)top, (TGLfloat)nearv, (TGLfloat)farv);
+}
+
+void tglOrthof(TGLfloat left, TGLfloat right, TGLfloat bottom, TGLfloat top, TGLfloat zNear, TGLfloat zFar) {
+	TinyGL::GLContext *c = TinyGL::gl_get_context();
+	TinyGL::GLParam p[7];
+
+	p[0].op = TinyGL::OP_Ortho;
+	p[1].f = left;
+	p[2].f = right;
+	p[3].f = bottom;
+	p[4].f = top;
+	p[5].f = zNear;
+	p[6].f = zFar;
 
 	c->gl_add_op(p);
 }
 
 void tglOrtho(TGLdouble left, TGLdouble right, TGLdouble bottom, TGLdouble top, TGLdouble zNear, TGLdouble zFar) {
-	TinyGL::GLContext *c = TinyGL::gl_get_context();
-	TinyGL::GLParam p[7];
-
-	p[0].op = TinyGL::OP_Ortho;
-	p[1].f = (float)left;
-	p[2].f = (float)right;
-	p[3].f = (float)bottom;
-	p[4].f = (float)top;
-	p[5].f = (float)zNear;
-	p[6].f = (float)zFar;
-
-	c->gl_add_op(p);
+	tglOrthof((TGLfloat)left, (TGLfloat)right, (TGLfloat)bottom, (TGLfloat)top, (TGLfloat)zNear, (TGLfloat)zFar);
 }
 
 // lightning
@@ -612,14 +620,18 @@ void tglClearColor(TGLfloat r, TGLfloat g, TGLfloat b, TGLfloat a) {
 	c->gl_add_op(p);
 }
 
-void tglClearDepth(TGLdouble depth) {
+void tglClearDepthf(TGLfloat depth) {
 	TinyGL::GLContext *c = TinyGL::gl_get_context();
 	TinyGL::GLParam p[2];
 
 	p[0].op = TinyGL::OP_ClearDepth;
-	p[1].f = (float)depth;
+	p[1].f = depth;
 
 	c->gl_add_op(p);
+}
+
+void tglClearDepth(TGLdouble depth) {
+	tglClearDepthf((TGLfloat)depth);
 }
 
 void tglClearStencil(TGLint s) {

--- a/graphics/tinygl/gl.h
+++ b/graphics/tinygl/gl.h
@@ -1167,4 +1167,23 @@ void tglTexSubImage3D(TGLenum target, TGLint level, TGLint xoffset, TGLint yoffs
 void tglCopyTexSubImage3D(TGLenum target, TGLint level, TGLint xoffset, TGLint yoffset,
                           TGLint zoffset, TGLint x, TGLint y, TGLsizei width, TGLsizei height);
 
+
+// --- GL ES 1.0 / GL_OES_single_precision ---
+
+// matrix
+void tglFrustumf(TGLfloat left, TGLfloat right, TGLfloat bottom, TGLfloat top,
+                 TGLfloat nearv, TGLfloat farv);
+void tglOrthof(TGLfloat left, TGLfloat right, TGLfloat bottom, TGLfloat top,
+               TGLfloat zNear, TGLfloat zFar);
+
+// clear
+void tglClearDepthf(TGLfloat depth);
+
+// gets
+void tglGetClipPlanef(TGLenum plane, TGLfloat *equation);
+
+// misc
+void tglDepthRangef(TGLclampf zNear, TGLclampf zFar);
+void tglClipPlanef(TGLenum plane, const TGLfloat *equation);
+
 #endif


### PR DESCRIPTION
This avoids needing to cast the parameters to doubles, only for the functions to cast them to floats.