### PR TITLE
[RFC] SCUMM: COMI: Add option to enable "A Pirate I Was Meant To Be" for non-ENG versions

### DIFF
--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -686,6 +686,16 @@ static const ExtraGuiOption enableLowLatencyAudio = {
 	0
 };
 
+static const ExtraGuiOption enableCOMISong = {
+	_s("Enable the \"A Pirate I Was Meant To Be\" song"),
+	_s("Enable the song at the beginning of Part 3 of the game, \"A Pirate I Was Meant To Be\", \
+		which was cut in international releases. Beware though: subtitles may not be fully translated."),
+	"enable_song",
+	false,
+	0,
+	0
+};
+
 const ExtraGuiOptions ScummMetaEngine::getExtraGuiOptions(const Common::String &target) const {
 	ExtraGuiOptions options;
 	// Query the GUI options
@@ -694,6 +704,7 @@ const ExtraGuiOptions ScummMetaEngine::getExtraGuiOptions(const Common::String &
 	const Common::String extra = ConfMan.get("extra", target);
 	const Common::String guiOptions = parseGameGUIOptions(guiOptionsString);
 	const Common::Platform platform = Common::parsePlatform(ConfMan.get("platform", target));
+	const Common::String language = ConfMan.get("language", target);
 
 	if (target.empty() || guiOptions.contains(GUIO_ORIGINALGUI)) {
 		options.push_back(enableOriginalGUI);
@@ -709,6 +720,10 @@ const ExtraGuiOptions ScummMetaEngine::getExtraGuiOptions(const Common::String &
 	}
 	if (target.empty() || gameid == "comi") {
 		options.push_back(comiObjectLabelsOption);
+
+		if (!language.equals("en")) {
+			options.push_back(enableCOMISong);
+		}
 	}
 	if (target.empty() || platform == Common::kPlatformNES) {
 		options.push_back(mmnesObjectLabelsOption);

--- a/engines/scumm/script_v8.cpp
+++ b/engines/scumm/script_v8.cpp
@@ -262,6 +262,13 @@ int ScummEngine_v8::fetchScriptWordSigned() {
 int ScummEngine_v8::readVar(uint var) {
 	debugC(DEBUG_VARS, "readvar(%d)", var);
 
+	// The following action re-enables the song at the beginning of Part 3,
+	// which was disabled for international releases, if the user decides so.
+	if (_enableCOMISong &&
+		VAR_LANGUAGE != 0xFF && var == VAR_LANGUAGE &&
+		vm.slot[_currentScript].number == 319 && _currentRoom == 52)
+		return 0;
+
 	if (!(var & 0xF0000000)) {
 		assertRange(0, var, _numVariables - 1, "variable");
 		return _scummVars[var];

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -1409,6 +1409,13 @@ void ScummEngine::setupScumm(const Common::String &macResourceFile) {
 		_bootParam = -1;
 	}
 
+	if (_game.version == 8 && (_language != Common::EN_ANY && _language != Common::EN_GRB && _language != Common::EN_USA)) {
+		ConfMan.registerDefault("enable_song", true);
+		if (ConfMan.hasKey("enable_song", _targetName)) {
+			_enableCOMISong = ConfMan.getBool("enable_song");
+		}
+	}
+
 #ifndef ATARI
 	int maxHeapThreshold = -1;
 

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -547,6 +547,7 @@ public:
 	bool _enableEnhancements = false;
 	bool _useOriginalGUI = true;
 	bool _enableAudioOverride = false;
+	bool _enableCOMISong = false;
 
 	Common::Keymap *_insaneKeymap;
 


### PR DESCRIPTION
As asked by @lotharsm about 7 years ago ([#7887](https://bugs.scummvm.org/ticket/7887)), here's this little nice addition. 😄

The check does not appear in the options if the user is using the ENG version of the game, of course.