### PR TITLE
BUILD: Disable -Wshadow and -Wmissing-field-initializers before GCC 5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ifeq "$(HAVE_GCC)" "1"
 	CXXFLAGS+= -Wno-long-long -Wno-multichar -Wno-unknown-pragmas -Wno-reorder
 	# Enable even more warnings...
 	CXXFLAGS+= -Wpointer-arith -Wcast-qual
-	CXXFLAGS+= -Wshadow -Wnon-virtual-dtor -Wwrite-strings
+	CXXFLAGS+= -Wnon-virtual-dtor -Wwrite-strings
 
 	# Currently we disable this gcc flag, since it will also warn in cases,
 	# where using GCC_PRINTF (means: __attribute__((format(printf, x, y))))

--- a/configure
+++ b/configure
@@ -2201,8 +2201,17 @@ if test "$have_gcc" = yes; then
 		cxx_version=`gcc_get_define __clang_version__`
 		cxx_version="`echo "${cxx_version}" | sed -e 's/"\([^ ]*\) .*/\1/'`"
 		cxx_version="clang $cxx_version, ok"
+
+		append_var CXXFLAGS "-Wshadow"
 	else
 		cxx_version="GCC $cxx_version, ok"
+
+		# Way too many false positives before GCC 5
+		if test $_cxx_major -ge 5; then
+			append_var CXXFLAGS "-Wshadow"
+		else
+			append_var CXXFLAGS "-Wno-missing-field-initializers"
+		fi
 	fi
 elif test "$have_icc" = yes; then
 	cxx_version="`( $CXX -dumpversion ) 2>/dev/null`"


### PR DESCRIPTION
The `-Wshadow` and `-Wmissing-field-initializers` GCC flags gave many false positives before GCC 5, and this creates a lot of irrelevant noise in the build logs. See the Ubuntu 20.04 g++ 4.8 CI for an example, or the Dreamcast or RISC OS buildbots. Even Linus complained about the old `-Wshadow` at the time.

The flags are now only enabled on Clang builds and GCC >= 5 builds.