### PR TITLE
BASE: Show SDL1.2/SDL2 in the About dialog

### DIFF
--- a/backends/platform/sdl/sdl-sys.h
+++ b/backends/platform/sdl/sdl-sys.h
@@ -173,9 +173,8 @@
 // In SDL 2.0, intrin.h is now included in SDL_cpuinfo.h, which includes
 // setjmp.h. SDL_cpuinfo.h is included from SDL.h and SDL_syswm.h.
 // Thus, we remove the exceptions for setjmp and longjmp before these two
-// includes. Unfortunately, we can't use SDL_VERSION_ATLEAST here, as SDL.h
-// hasn't been included yet at this point.
-#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && defined(_MSC_VER)
+// includes.
+#if !defined(FORBIDDEN_SYMBOL_ALLOW_ALL) && defined(_MSC_VER) && defined(USE_SDL2)
 // We unset any fake definitions of setjmp/longjmp here
 
 #ifndef FORBIDDEN_SYMBOL_EXCEPTION_setjmp

--- a/base/version.cpp
+++ b/base/version.cpp
@@ -208,6 +208,13 @@ const char gScummVMFeatures[] = ""
 #ifdef USE_LIBCURL
 	"libcurl "
 #endif
+#ifdef SDL_BACKEND
+#ifdef USE_SDL2
+	"SDL2 "
+#else
+	"SDL1.2 "
+#endif
+#endif
 #ifdef USE_SDL_NET
 	"SDL_net "
 #endif

--- a/configure
+++ b/configure
@@ -4129,6 +4129,7 @@ if test "$_sdl" = yes ; then
 	append_var LIBS "$SDL_LIBS"
 	case $_sdlversion in
 		2.*.*)
+			append_var DEFINES "-DUSE_SDL2"
 			add_line_to_config_mk "USE_SDL2 = 1"
 			_sdlMajorVersionNumber=2
 			;;

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -431,9 +431,6 @@ int main(int argc, char *argv[]) {
 		cout << "\nBuilding against SDL 1.2\n\n";
 	} else {
 		cout << "\nBuilding against SDL 2.0\n\n";
-		// TODO: This also defines USE_SDL2 in the preprocessor, we don't do
-		// this in our configure/make based build system. Adapt create_project
-		// to replicate this behavior.
 		setup.defines.push_back("USE_SDL2");
 	}
 


### PR DESCRIPTION
This tweaks the build system a bit, so that the About dialog will now show whether SDL1.2 or SDL2 (or later) is used.

The idea is to have a quick way of figuring out when an official port still uses SDL1.2, just after starting it. Knowing it from memory or from the build logs is not always convenient.