### PR TITLE
CI: Enable libvpx and giflib in most runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,11 +160,11 @@ jobs:
           - platform: ubuntu-latest
             sdlConfig: sdl2-config
             cxx: ccache g++
-            aptPackages: 'libsdl2-dev libsdl2-net-dev liba52-dev libjpeg-turbo8-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev libfribidi-dev libcurl4-openssl-dev libgtk-3-dev libspeechd-dev libsndio-dev libunity-dev'
+            aptPackages: 'libsdl2-dev libsdl2-net-dev liba52-dev libjpeg-turbo8-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev libfribidi-dev libcurl4-openssl-dev libgtk-3-dev libspeechd-dev libsndio-dev libunity-dev libgif-dev'
           - platform: ubuntu-20.04
             sdlConfig: sdl-config
             cxx: ccache g++-4.8
-            aptPackages: 'g++-4.8 libsdl1.2-dev libsdl-net1.2-dev liba52-dev libjpeg-turbo8-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev libfribidi-dev libcurl4-openssl-dev libgtk-3-dev libspeechd-dev libsndio-dev libunity-dev'
+            aptPackages: 'g++-4.8 libsdl1.2-dev libsdl-net1.2-dev liba52-dev libjpeg-turbo8-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev libfribidi-dev libcurl4-openssl-dev libgtk-3-dev libspeechd-dev libsndio-dev libunity-dev libgif-dev'
     env:
       SDL_CONFIG: ${{ matrix.sdlConfig }}
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,21 +15,21 @@ jobs:
           - platform: win32
             triplet: x86-windows
             arch: x86
-            configFlags: --enable-faad --enable-mpeg2 --enable-discord
-            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib giflib fribidi'
+            configFlags: --enable-discord --enable-faad --enable-gif --enable-mpeg2
+            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype fribidi giflib libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib'
             useNasm: 'true'
           - platform: x64
             arch: x64
             triplet: x64-windows
-            configFlags: --enable-faad --enable-mpeg2 --enable-discord
-            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib giflib fribidi'
+            configFlags: --enable-discord --enable-faad --enable-gif --enable-mpeg2
+            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype fribidi giflib libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib'
           - platform: arm64
             arch: arm64
             triplet: arm64-windows
             # fribidi is disabled due to https://github.com/microsoft/vcpkg/issues/11248 [fribidi] Fribidi doesn't cross-compile on x86-64 to target arm/arm64
             # Note that fribidi is also disabled on arm64 in devtools/create_project/msvc.cpp
-            configFlags: --enable-faad --enable-mpeg2 --enable-discord --disable-fribidi --disable-opengl
-            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib giflib'
+            configFlags: --enable-discord --enable-faad --enable-gif --enable-mpeg2 --disable-fribidi --disable-opengl
+            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype giflib libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib'
     env:
       CONFIGURATION: Debug
       PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,11 +160,11 @@ jobs:
           - platform: ubuntu-latest
             sdlConfig: sdl2-config
             cxx: ccache g++
-            aptPackages: 'libsdl2-dev libsdl2-net-dev liba52-dev libjpeg-turbo8-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev libfribidi-dev libcurl4-openssl-dev libgtk-3-dev libspeechd-dev libsndio-dev libunity-dev libgif-dev'
+            aptPackages: 'libsdl2-dev libsdl2-net-dev liba52-dev libjpeg-turbo8-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev libfribidi-dev libcurl4-openssl-dev libgtk-3-dev libspeechd-dev libsndio-dev libunity-dev libgif-dev libvpx-dev'
           - platform: ubuntu-20.04
             sdlConfig: sdl-config
             cxx: ccache g++-4.8
-            aptPackages: 'g++-4.8 libsdl1.2-dev libsdl-net1.2-dev liba52-dev libjpeg-turbo8-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev libfribidi-dev libcurl4-openssl-dev libgtk-3-dev libspeechd-dev libsndio-dev libunity-dev libgif-dev'
+            aptPackages: 'g++-4.8 libsdl1.2-dev libsdl-net1.2-dev liba52-dev libjpeg-turbo8-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev libfribidi-dev libcurl4-openssl-dev libgtk-3-dev libspeechd-dev libsndio-dev libunity-dev libgif-dev libvpx-dev'
     env:
       SDL_CONFIG: ${{ matrix.sdlConfig }}
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,8 @@ jobs:
         include:
           - platform: macosx
             buildFlags: -scheme ScummVM-macOS
-            configFlags: --disable-nasm --enable-faad --enable-mpeg2
-            brewPackages: a52dec faad2 flac fluid-synth freetype fribidi jpeg mad libmpeg2 libogg libpng libvorbis sdl2 sdl2_net theora giflib
+            configFlags: --disable-nasm --enable-faad --enable-gif --enable-mpeg2 --enable-vpx
+            brewPackages: a52dec faad2 flac fluid-synth freetype fribidi giflib jpeg mad libmpeg2 libogg libpng libvorbis libvpx sdl2 sdl2_net theora
           - platform: ios7
             buildFlags: -scheme ScummVM-iOS CODE_SIGN_IDENTITY="" CODE_SIGNING_ALLOWED=NO
             configFlags: --disable-nasm --disable-opengl --disable-theoradec --disable-mpeg2 --disable-taskbar --disable-tts --disable-fribidi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,11 +160,11 @@ jobs:
           - platform: ubuntu-latest
             sdlConfig: sdl2-config
             cxx: ccache g++
-            aptPackages: 'libsdl2-dev libsdl2-net-dev liba52-dev libjpeg-turbo8-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev libfribidi-dev libcurl4-openssl-dev libgtk-3-dev libspeechd-dev libsndio-dev libunity-dev libgif-dev libvpx-dev'
+            aptPackages: 'liba52-dev libcurl4-openssl-dev libfaad-dev libflac-dev libfluidsynth-dev libfreetype6-dev libfribidi-dev libgif-dev libgtk-3-dev libjpeg-turbo8-dev libmad0-dev libmpeg2-4-dev libogg-dev libpng-dev libsdl2-dev libsdl2-net-dev libsndio-dev libspeechd-dev libtheora-dev libunity-dev libvorbis-dev libvpx-dev zlib1g-dev'
           - platform: ubuntu-20.04
             sdlConfig: sdl-config
             cxx: ccache g++-4.8
-            aptPackages: 'g++-4.8 libsdl1.2-dev libsdl-net1.2-dev liba52-dev libjpeg-turbo8-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev libfribidi-dev libcurl4-openssl-dev libgtk-3-dev libspeechd-dev libsndio-dev libunity-dev libgif-dev libvpx-dev'
+            aptPackages: 'g++-4.8 liba52-dev libcurl4-openssl-dev libfaad-dev libflac-dev libfluidsynth-dev libfreetype6-dev libfribidi-dev libgif-dev libgtk-3-dev libjpeg-turbo8-dev libmad0-dev libmpeg2-4-dev libogg-dev libpng-dev libsdl-net1.2-dev libsdl1.2-dev libsndio-dev libspeechd-dev libtheora-dev libunity-dev libvorbis-dev libvpx-dev zlib1g-dev'
     env:
       SDL_CONFIG: ${{ matrix.sdlConfig }}
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,21 +15,21 @@ jobs:
           - platform: win32
             triplet: x86-windows
             arch: x86
-            configFlags: --enable-discord --enable-faad --enable-gif --enable-mpeg2
-            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype fribidi giflib libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib'
+            configFlags: --enable-discord --enable-faad --enable-gif --enable-mpeg2 --enable-vpx
+            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype fribidi giflib libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis libvpx sdl2 sdl2-net zlib'
             useNasm: 'true'
           - platform: x64
             arch: x64
             triplet: x64-windows
-            configFlags: --enable-discord --enable-faad --enable-gif --enable-mpeg2
-            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype fribidi giflib libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib'
+            configFlags: --enable-discord --enable-faad --enable-gif --enable-mpeg2 --enable-vpx
+            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype fribidi giflib libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis libvpx sdl2 sdl2-net zlib'
           - platform: arm64
             arch: arm64
             triplet: arm64-windows
             # fribidi is disabled due to https://github.com/microsoft/vcpkg/issues/11248 [fribidi] Fribidi doesn't cross-compile on x86-64 to target arm/arm64
             # Note that fribidi is also disabled on arm64 in devtools/create_project/msvc.cpp
-            configFlags: --enable-discord --enable-faad --enable-gif --enable-mpeg2 --disable-fribidi --disable-opengl
-            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype giflib libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis sdl2 sdl2-net zlib'
+            configFlags: --enable-discord --enable-faad --enable-gif --enable-mpeg2 --enable-vpx --disable-fribidi --disable-opengl
+            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype giflib libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis libvpx sdl2 sdl2-net zlib'
     env:
       CONFIGURATION: Debug
       PLATFORM: ${{ matrix.platform }}

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -67,6 +67,7 @@ std::string MSVCProvider::getLibraryFromFeature(const char *feature, const Build
 		{      "faad", "faad.lib",                  nullptr,         nullptr,                                           "libfaad.lib" },
 		{     "mpeg2", "mpeg2.lib",                 nullptr,         nullptr,                                           "libmpeg2.lib" },
 		{ "theoradec", "theora.lib",                nullptr,         nullptr,                                           "libtheora_static.lib" },
+		{       "vpx", "vpx.lib",                   nullptr,         nullptr,                                           nullptr },
 		{ "freetype2", "freetype.lib",              "freetyped.lib", nullptr,                                           nullptr },
 		{      "jpeg", "jpeg.lib",                  nullptr,         nullptr,                                           "jpeg-static.lib" },
 		{"fluidsynth", "fluidsynth.lib",            nullptr,         nullptr,                                           "libfluidsynth.lib" },


### PR DESCRIPTION
This adds libvpx and giflib support to most Github Actions runners, so that the `sludge` (where libvpx support was recently added) and `hpl1` (giflib is required to build it) engines have better CI coverage.

This PR also completes libvpx support in `create_project` for MSVC. 