### PR TITLE
DEVTOOLS: Fix create_engine compilation with mingw-w64

### DIFF
--- a/devtools/create_engine/create_engine.cpp
+++ b/devtools/create_engine/create_engine.cpp
@@ -25,7 +25,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <sys/stat.h>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <windows.h>
 #else
 #include <unistd.h>
@@ -50,7 +50,7 @@ static const char *const FILENAMES[] = {
 const char *const ENGINES = "create_project ..\\.. --use-canonical-lib-names --msvc\n";
 
 bool fileExists(const char *name) {
-#ifdef _MSC_VER
+#ifdef _WIN32
 	return (GetFileAttributesA(name) != INVALID_FILE_ATTRIBUTES);
 #else
 	return (!access(name, F_OK));
@@ -58,7 +58,7 @@ bool fileExists(const char *name) {
 }
 
 bool createDirectory(const char *name) {
-#ifdef _MSC_VER
+#ifdef _WIN32
 	return CreateDirectoryA(name, nullptr);
 #else
 	return (!mkdir(name, 0755));


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->

Prior to the change, when create_engine was compiled using mingw-w64, it would fail building due to `error: too many arguments to function 'int mkdir(const char*)'`. Replacing the `_MSC_VER` with `_WIN32` fixes the issue as windows.h gets included and `CreateDirectoryA` is used instead of `mkdir`.
