### PR TITLE
COMMON: Add ability to disable warning for valueless lines in INI files

### DIFF
--- a/common/formats/ini-file.cpp
+++ b/common/formats/ini-file.cpp
@@ -52,6 +52,7 @@ bool INIFile::isValidName(const String &name) const {
 
 INIFile::INIFile() {
 	_allowNonEnglishCharacters = false;
+	_suppressValuelessLineWarning = false;
 }
 
 void INIFile::clear() {
@@ -172,7 +173,8 @@ bool INIFile::loadFromStream(SeekableReadStream &stream) {
 			// Split string at '=' into 'key' and 'value'. First, find the "=" delimeter.
 			const char *p = strchr(t, '=');
 			if (!p) {
-				warning("Config file buggy: Junk found in line %d: '%s'", lineno, t);
+				if (!_suppressValuelessLineWarning)
+					warning("Config file buggy: Junk found in line %d: '%s'", lineno, t);
 				kv.key = String(t);
 				kv.value.clear();
 			}  else {
@@ -474,6 +476,10 @@ void INIFile::Section::removeKey(const String &key) {
 
 void INIFile::allowNonEnglishCharacters() {
 	_allowNonEnglishCharacters = true;
+}
+
+void INIFile::suppressValuelessLineWarning() {
+	_suppressValuelessLineWarning = true;
 }
 
 } // End of namespace Common

--- a/common/formats/ini-file.h
+++ b/common/formats/ini-file.h
@@ -131,11 +131,13 @@ public:
 	void listKeyValues(StringMap &kv); /*!< Get a list of all key/value pairs in this INI file. */
 
 	void allowNonEnglishCharacters(); /*!< Allow non-English characters in this INI file. */
+	void suppressValuelessLineWarning(); /*!< Disable warnings for lines that contain only keys. */
 
 private:
 	String		_defaultSectionName;
 	SectionList _sections;
 	bool _allowNonEnglishCharacters;
+	bool _suppressValuelessLineWarning;
 
 	Section *getSection(const String &section);
 	const Section *getSection(const String &section) const;

--- a/engines/vcruise/runtime.cpp
+++ b/engines/vcruise/runtime.cpp
@@ -159,6 +159,8 @@ void SfxData::load(Common::SeekableReadStream &stream, Audio::Mixer *mixer) {
 	Common::INIFile iniFile;
 
 	iniFile.allowNonEnglishCharacters();
+	iniFile.suppressValuelessLineWarning();
+
 	if (!iniFile.loadFromStream(stream))
 		warning("SfxData::load failed to parse INI file");
 


### PR DESCRIPTION
V-Cruise uses an INI-like format for sfx files, where values under the "playlists" section are only simple strings and not formatted as key-value pairs.  The INI parser is capable of parsing them, but throws an extreme amount of warnings as there are usually hundreds of lines per animation file in this format.

This adds a function to disable the warning.