### PR TITLE
BASE: SDL: Show SDL version in --version output

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -61,6 +61,10 @@ static const char USAGE_STRING[] =
 	"Try '%s --help' for more options.\n"
 ;
 
+#ifdef SDL_BACKEND
+#include "backends/platform/sdl/sdl-sys.h"
+#endif
+
 // DONT FIXME: DO NOT ORDER ALPHABETICALLY, THIS IS ORDERED BY IMPORTANCE/CATEGORY! :)
 static const char HELP_STRING1[] =
 	"ScummVM - Graphical Adventure Game Interpreter\n"
@@ -1766,6 +1770,15 @@ bool processSettings(Common::String &command, Common::StringMap &settings, Commo
 		return true;
 	} else if (command == "version") {
 		printf("%s\n", gScummVMFullVersion);
+#ifdef SDL_BACKEND
+#ifdef USE_SDL2
+		SDL_version sdlLinkedVersion;
+		SDL_GetVersion(&sdlLinkedVersion);
+		printf("Using SDL backend with SDL %d.%d.%d\n", sdlLinkedVersion.major, sdlLinkedVersion.minor, sdlLinkedVersion.patch);
+#else
+		printf("Using SDL backend with SDL1.2\n")
+#endif
+#endif
 		printf("Features compiled in: %s\n", gScummVMFeatures);
 		return true;
 	} else if (command == "help") {

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -1776,7 +1776,7 @@ bool processSettings(Common::String &command, Common::StringMap &settings, Commo
 		SDL_GetVersion(&sdlLinkedVersion);
 		printf("Using SDL backend with SDL %d.%d.%d\n", sdlLinkedVersion.major, sdlLinkedVersion.minor, sdlLinkedVersion.patch);
 #else
-		printf("Using SDL backend with SDL1.2\n");
+		printf("Using SDL backend with SDL %d.%d.%d\n", SDL_Linked_Version()->major, SDL_Linked_Version()->minor, SDL_Linked_Version()->patch);
 #endif
 #endif
 		printf("Features compiled in: %s\n", gScummVMFeatures);

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -1776,7 +1776,7 @@ bool processSettings(Common::String &command, Common::StringMap &settings, Commo
 		SDL_GetVersion(&sdlLinkedVersion);
 		printf("Using SDL backend with SDL %d.%d.%d\n", sdlLinkedVersion.major, sdlLinkedVersion.minor, sdlLinkedVersion.patch);
 #else
-		printf("Using SDL backend with SDL1.2\n")
+		printf("Using SDL backend with SDL1.2\n");
 #endif
 #endif
 		printf("Features compiled in: %s\n", gScummVMFeatures);


### PR DESCRIPTION
Inspired by @raziel-'s comment at https://github.com/scummvm/scummvm/pull/4788#issuecomment-1461469285, this patch shows the currently running SDL2 version when using the `--version` command:

```
ScummVM 2.8.0git2438-g4b14cdd8fed (Mar  9 2023 08:31:57)
Using SDL backend with SDL 2.26.3
Features compiled in: Vorbis FLAC MP3 RGB zLib MPEG2 FluidSynth Theora VPX AAC A/52 FreeType2 FriBiDi JPEG PNG GIF taskbar TTS cloud (servers, local) ENet TinyGL OpenGL (with shaders)
```

Unfortunately, `SDL_GetVersion` is only available in SDL2+, so we can't exactly determine the version when using SDL1.