### PR TITLE
BACKENDS: CURL: Fix libcurl redefining ARRAYSIZE on Win32

### DIFF
--- a/backends/networking/curl/socket.cpp
+++ b/backends/networking/curl/socket.cpp
@@ -20,10 +20,10 @@
  */
 
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
+#include <curl/curl.h>
 #include "backends/networking/curl/socket.h"
 #include "common/debug.h"
 #include "common/system.h"
-#include <curl/curl.h>
 
 // Auxiliary function that waits on the socket.
 // From https://github.com/curl/curl/blob/master/docs/examples/sendrecv.c
@@ -115,8 +115,9 @@ bool CurlSocket::connect(Common::String url) {
 size_t CurlSocket::send(const char *data, int len) {
 	if (!_socket)
 		return -1;
-    size_t nsent_total = 0, left = len;
-    CURLcode res = CURLE_AGAIN;
+
+	size_t nsent_total = 0, left = len;
+	CURLcode res = CURLE_AGAIN;
 
 	// Keep looping until the whole thing is sent, errors,
 	// or times out.

--- a/backends/networking/curl/url.cpp
+++ b/backends/networking/curl/url.cpp
@@ -20,9 +20,9 @@
  */
 
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
+#include <curl/curl.h>
 #include "backends/networking/curl/url.h"
 #include "common/debug.h"
-#include <curl/curl.h>
 
 namespace Networking {
 


### PR DESCRIPTION
This is just meant to fix the following `ARRAYSIZE` macro redefinition warnings on Win32:

```
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\um\winnt.h(1375,1): warning C4005: 'ARRAYSIZE': macro redefinition (compiling source file ..\backends\networking\curl\socket.cpp) [D:\a\scummvm\scummvm\build-scummvm\scummvm.vcxproj]
D:\a\scummvm\scummvm\common\util.h(91,1): message : see previous definition of 'ARRAYSIZE' (compiling source file ..\backends\networking\curl\socket.cpp) [D:\a\scummvm\scummvm\build-scummvm\scummvm.vcxproj]

C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\um\winnt.h(1375,1): warning C4005: 'ARRAYSIZE': macro redefinition (compiling source file ..\backends\networking\curl\url.cpp) [D:\a\scummvm\scummvm\build-scummvm\scummvm.vcxproj]
D:\a\scummvm\scummvm\common\util.h(91,1): message : see previous definition of 'ARRAYSIZE' (compiling source file ..\backends\networking\curl\url.cpp) [D:\a\scummvm\scummvm\build-scummvm\scummvm.vcxproj]
```

as was done in commit 272d4105b274391427f92b25b80cbfe68c7997db for example.

As a PR for that quick CI test.