### PR TITLE
JANITORIAL: Fix various "an" typos

### DIFF
--- a/audio/decoders/adpcm.h
+++ b/audio/decoders/adpcm.h
@@ -64,7 +64,7 @@ enum ADPCMType {
 
 /**
  * Takes an input stream containing ADPCM compressed sound data and creates
- * an RewindableAudioStream from that.
+ * a RewindableAudioStream from that.
  *
  * @param stream            the SeekableReadStream from which to read the ADPCM data
  * @param disposeAfterUse   whether to delete the stream after use

--- a/audio/decoders/raw.cpp
+++ b/audio/decoders/raw.cpp
@@ -64,7 +64,7 @@ public:
 	bool seek(const Timestamp &where) override;
 private:
 	const int _rate;                                           ///< Sample rate of stream
-	const bool _isStereo;                                      ///< Whether this is an stereo stream
+	const bool _isStereo;                                      ///< Whether this is a stereo stream
 	Timestamp _playtime;                                       ///< Calculated total play time
 	Common::DisposablePtr<Common::SeekableReadStream> _stream; ///< Stream to read data from
 	bool _endOfData;                                           ///< Whether the stream end has been reached

--- a/audio/decoders/xa.h
+++ b/audio/decoders/xa.h
@@ -42,7 +42,7 @@ class RewindableAudioStream;
 
 /**
  * Takes an input stream containing XA ADPCM sound data and creates
- * an RewindableAudioStream from that.
+ * a RewindableAudioStream from that.
  *
  * @param stream            the SeekableReadStream from which to read the XA ADPCM data
  * @param rate              the sampling rate

--- a/backends/fs/morphos/morphos-fs.h
+++ b/backends/fs/morphos/morphos-fs.h
@@ -68,19 +68,19 @@ protected:
 
 public:
 	/**
-	 * Creates an MorphOSFilesystemNode with the root node as path.
+	 * Creates a MorphOSFilesystemNode with the root node as path.
 	 */
 	MorphOSFilesystemNode();
 
 	/**
-	 * Creates an MorphOSFilesystemNode for a given path.
+	 * Creates a MorphOSFilesystemNode for a given path.
 	 *
 	 * @param path Common::String with the path the new node should point to.
 	 */
 	MorphOSFilesystemNode(const Common::String &p);
 
 	/**
-	 * Creates an MorphOSFilesystemNode given its lock and display name.
+	 * Creates a MorphOSFilesystemNode given its lock and display name.
 	 *
 	 * @param pLock BPTR to the lock.
 	 * @param pDisplayName name to be used for display, in case not supplied the FilePart() of the filename will be used.

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -133,7 +133,7 @@ protected:
 	void renderCursor();
 
 	/**
-	 * Whether an GLES or GLES2 context is active.
+	 * Whether a GLES or GLES2 context is active.
 	 */
 	bool isGLESContext() const { return OpenGLContext.type == kContextGLES || OpenGLContext.type == kContextGLES2; }
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -1843,7 +1843,7 @@ void SurfaceSdlGraphicsManager::setFocusRectangle(const Common::Rect &rect) {
 	// thus we need to clip the rect here...
 	_focusRect.clip(_videoMode.screenWidth, _videoMode.screenHeight);
 
-	// We just fake this as a dirty rect for now, to easily force an screen update whenever
+	// We just fake this as a dirty rect for now, to easily force a screen update whenever
 	// the rect changes.
 	addDirtyRect(_focusRect.left, _focusRect.top, _focusRect.width(), _focusRect.height(), _overlayVisible);
 #endif
@@ -1857,7 +1857,7 @@ void SurfaceSdlGraphicsManager::clearFocusRectangle() {
 
 	_enableFocusRect = false;
 
-	// We just fake this as a dirty rect for now, to easily force an screen update whenever
+	// We just fake this as a dirty rect for now, to easily force a screen update whenever
 	// the rect changes.
 	addDirtyRect(_focusRect.left, _focusRect.top, _focusRect.width(), _focusRect.height(), _overlayVisible);
 #endif

--- a/backends/keymapper/input-watcher.h
+++ b/backends/keymapper/input-watcher.h
@@ -36,7 +36,7 @@ struct HardwareInput;
  *
  * When the watch mode is enabled, the watcher disables the Keymapper
  * and sets itself as an event observer. Once an event corresponding
- * to an hardware input is received, it is saved for later retrieval.
+ * to a hardware input is received, it is saved for later retrieval.
  *
  * Used by the remap dialog to capture input.
  */

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -242,7 +242,7 @@ void OSystem_SDL::initBackend() {
 	if (_graphicsManager == nullptr) {
 #ifdef USE_OPENGL
 		// Setup a list with both SDL and OpenGL graphics modes. We only do
-		// this whenever the subclass did not already set up an graphics
+		// this whenever the subclass did not already set up a graphics
 		// manager yet. This is because we don't know the type of the graphics
 		// manager of the subclass, thus we cannot easily switch between the
 		// OpenGL one and the set up one. It also is to be expected that the

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -329,7 +329,7 @@ const Plugin *PluginManager::getMetaEngineFromEngine(const Plugin *plugin) {
 		return metaEngine;
 	}
 
-	debug(9, "Engine: %s couldn't find a match for an MetaEngine plugin.", plugin->getFileName());
+	debug(9, "Engine: %s couldn't find a match for a MetaEngine plugin.", plugin->getFileName());
 	return nullptr;
 }
 

--- a/common/func.h
+++ b/common/func.h
@@ -158,7 +158,7 @@ inline PointerToUnaryFunc<Arg, Result> ptr_fun(Result (*func)(Arg)) {
 }
 
 /**
- * Creates an binary function object from a function pointer.
+ * Creates a binary function object from a function pointer.
  */
 template<class Arg1, class Arg2, class Result>
 inline PointerToBinaryFunc<Arg1, Arg2, Result> ptr_fun(Result (*func)(Arg1, Arg2)) {
@@ -429,7 +429,7 @@ private:
  * else
  *     warning("Unimplemented opcode %d", opcodeNum);
  *
- * If you want to see an real world example check the kyra engine.
+ * If you want to see a real-world example, check the kyra engine.
  * Files: engines/kyra/script.cpp and .h and engines/kyra/script_*.cpp
  * are interesting for that matter.
  */

--- a/common/system.h
+++ b/common/system.h
@@ -802,7 +802,7 @@ public:
 	 * OpenGL context does not support the function.
 	 *
 	 * @param name The name of the OpenGL function.
-	 * @return An function pointer for the requested OpenGL function or
+	 * @return A function pointer for the requested OpenGL function or
 	 *         nullptr in case of failure.
 	 */
 	virtual void *getOpenGLProcAddress(const char *name) const { return nullptr; }

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -198,7 +198,7 @@ StringList getFeatureDefines(const FeatureList &features);
 
 /**
  * Sets the state of a given feature. This can be used to
- * either include or exclude an feature.
+ * either include or exclude a feature.
  *
  * @param name Name of the feature.
  * @param features List of features to operate on.

--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -117,7 +117,7 @@ bool shouldSkipFileForTarget(const std::string &fileID, const std::string &targe
 	// - if the parent directory is "backends/platform/ios7", the file belongs to the iOS target.
 	// - if the parent directory is "/sdl", the file belongs to the macOS target.
 	// - if the file has a suffix, like "_osx", or "_ios", the file belongs to one of the target.
-	// - if the file is an macOS icon file (icns), it belongs to the macOS target.
+	// - if the file is a macOS icon file (icns), it belongs to the macOS target.
 	std::string name, ext;
 	splitFilename(fileName, name, ext);
 

--- a/devtools/create_titanic/hashmap.h
+++ b/devtools/create_titanic/hashmap.h
@@ -70,7 +70,7 @@ template<class T> class IteratorImpl;
  * that returns true if its two arguments are to be considered
  * equal. Also, we assume that "=" works on Val objects for assignment.
  *
- * If aa is an HashMap<Key,Val>, then space is allocated each time aa[key] is
+ * If aa is a HashMap<Key,Val>, then space is allocated each time aa[key] is
  * referenced, for a new key. If the object is const, then an assertion is
  * triggered instead. Hence if you are not sure whether a key is contained in
  * the map, use contains() first to check for its presence.

--- a/engines/agos/drivers/simon1/adlib.cpp
+++ b/engines/agos/drivers/simon1/adlib.cpp
@@ -249,7 +249,7 @@ uint8 MidiDriver_Simon1_AdLib::allocateOplChannel(uint8 channel, uint8 source, u
 			// Found an inactive channel - use this.
 			allocatedChannel = inactiveChannel;
 		} else {
-			// An channel already playing a note must be "stolen".
+			// A channel already playing a note must be "stolen".
 
 			// The original had some logic for a priority based reuse of
 			// channels. However, the priority value is always 0, which causes

--- a/engines/asylum/console.cpp
+++ b/engines/asylum/console.cpp
@@ -339,7 +339,7 @@ bool Console::cmdHelp(int, const char **) {
 	debugPrintf(" scene       - change the scene\n");
 	debugPrintf(" show_script - show script commands\n");
 	debugPrintf(" kill_script - terminate a script\n");
-	debugPrintf(" puzzle      - run an puzzle\n");
+	debugPrintf(" puzzle      - run a puzzle\n");
 	debugPrintf(" insertdisc  - show Insert Disc screen\n");
 	debugPrintf("\n");
 	debugPrintf(" get_status  - get actor's status\n");

--- a/engines/bladerunner/debugger.cpp
+++ b/engines/bladerunner/debugger.cpp
@@ -1585,7 +1585,7 @@ bool Debugger::cmdObject(int argc, const char **argv) {
 					bbox.getXYZ(&a.x, &a.y, &a.z, &b.x, &b.y, &b.z);
 					Vector3 pos = _vm->_view->calculateScreenPosition(0.5 * (a + b));
 					// Intentional? When loading a game, in the loaded Scene:
-					// an object can be an non-obstacle as a sceneObject but an obstacle as a Set object.
+					// an object can be a non-obstacle as a sceneObject but an obstacle as a Set object.
 					// and this seems to be considered as a non-obstacle by the game in that Scene.
 					// These are objects that the Unobstacle_Object() is called for when a scene is loaded (SceneLoaded())
 					// So the sceneObject property overrides the Set object property in these cases

--- a/engines/cge/snail.cpp
+++ b/engines/cge/snail.cpp
@@ -1230,7 +1230,7 @@ void CGEEngine::snLight(bool in) {
 }
 
 /**
- * Set an horizontal boundary
+ * Set a horizontal boundary
  * @param scene			Scene number
  * @param barX			Horizontal boundary value
  */

--- a/engines/glk/adrift/os_glk.cpp
+++ b/engines/glk/adrift/os_glk.cpp
@@ -539,7 +539,7 @@ static void gsc_set_locale(const sc_char *name) {
  * having to write transcripts as ascii.
  */
 static void gsc_put_char_uni(glui32 unicode, const char *ascii) {
-	/* If there is an transcript stream, temporarily disconnect it. */
+	/* If there is a transcript stream, temporarily disconnect it. */
 	if (gsc_transcript_stream)
 		g_vm->glk_window_set_echo_stream(gsc_main_window, nullptr);
 

--- a/engines/glk/tads/os_banners.h
+++ b/engines/glk/tads/os_banners.h
@@ -209,7 +209,7 @@ void *os_banner_create(void *parent, int where, void *other, int wintype,
 #define OS_BANNER_TYPE_TEXT       1
 
 /*
- *   "Text grid" window.  This type of window is similar to an normal text
+ *   "Text grid" window.  This type of window is similar to a normal text
  *   window (OS_BANNER_TYPE_TEXT), but is guaranteed to arrange its text in
  *   a regular grid of character cells, all of the same size.  This means
  *   that the output position can be moved to an arbitrary point within the

--- a/engines/grim/emi/sound/codecs/scx.h
+++ b/engines/grim/emi/sound/codecs/scx.h
@@ -55,7 +55,7 @@ private:
 
 /**
  * Takes an input stream containing SCX sound data and creates
- * an RewindableAudioStream from that.
+ * a RewindableAudioStream from that.
  *
  * @param stream            the SeekableReadStream from which to read the SCX data
  * @param disposeAfterUse   whether to delete the stream after use

--- a/engines/groovie/script.cpp
+++ b/engines/groovie/script.cpp
@@ -1849,7 +1849,7 @@ void Script::o_hotspot_slot() {
 
 	debugC(1, kDebugScript, "Groovie::Script: HOTSPOT-SLOT %d (%d,%d,%d,%d) @0x%04X cursor=%d (TODO)", slot, left, top, right, bottom, address, cursor);
 
-	// Set rectangle according to the used engine. To remove the previously written text an the screen.
+	// Set rectangle according to the used engine. To remove the previously written text on the screen.
 	Common::Rect removeText;
 	if (_version == kGroovieT7G) {
 		removeText.left = 0;

--- a/engines/kingdom/constants.cpp
+++ b/engines/kingdom/constants.cpp
@@ -572,7 +572,7 @@ const uint8 _emlTable[] = {
 };
 
 const uint8 _zoomTable[81][9][2] = {
-	// The first array is a dummy one used to fix an stupid trick on the index in the original
+	// The first array is a dummy one used to fix a stupid trick on the index in the original
 	{{   0, 0x0A}, {   0, 0x0A}, {   0, 0x0A}, {   0, 0x0A}, {   0, 0x0A}, {   0, 0x0A}, {   0, 0x0A}, {   0, 0x0A}, {   0, 0x0A}},
 	{{   0, 0x0A}, {   0, 0x0A}, {   0, 0x0A}, {   0, 0x0A}, {   8, 0x0A}, {   4, 0x0A}, {   2, 0x0A}, {   1, 0x0A}, {   0, 0x0A}},
 	{{   0, 0x0A}, {   0, 0x0A}, {   0, 0x0A}, {   0, 0x0A}, {   8, 0x0A}, {   4, 0x0A}, {   2, 0x0A}, {   1, 0x0A}, {   0, 0x0A}},

--- a/engines/kyra/gui/saveload_lok.cpp
+++ b/engines/kyra/gui/saveload_lok.cpp
@@ -201,7 +201,7 @@ Common::Error KyraEngine_LoK::loadGameState(int slot) {
 	_brandonPosY = _currentCharacter->y2 = _currentCharacter->y1;
 
 	// We need to reset the "_noDrawShapesFlag" flag of Animator_LoK
-	// over here. Else in certain cases restoring an savegame might
+	// over here. Else in certain cases restoring a savegame might
 	// result in no shapes being drawn at all. See bug report
 	// #4625 "KYRA1: Invisible Brandon" for an example of this.
 	_animator->_noDrawShapesFlag = 0;

--- a/engines/kyra/sequence/sequences_lok.cpp
+++ b/engines/kyra/sequence/sequences_lok.cpp
@@ -246,7 +246,7 @@ bool KyraEngine_LoK::seq_introStory() {
 	_screen->clearPage(3);
 	_screen->clearPage(0);
 
-	// HACK: The Italian fan translation uses an special text screen here
+	// HACK: The Italian fan translation uses a special text screen here
 	// so we show it even when text is disabled
 	if (!textEnabled() && speechEnabled() && _flags.lang != Common::IT_ITA)
 		return false;

--- a/engines/lastexpress/game/action.cpp
+++ b/engines/lastexpress/game/action.cpp
@@ -1465,7 +1465,7 @@ IMPLEMENT_ACTION(playMusicChapterSetupTrain)
 //////////////////////////////////////////////////////////////////////////
 // // Action 43
 IMPLEMENT_ACTION(switchChapter)
-	// Nothing to do here as an hotspot action
+	// Nothing to do here as a hotspot action
 	return kSceneInvalid;
 }
 

--- a/engines/lastexpress/game/logic.cpp
+++ b/engines/lastexpress/game/logic.cpp
@@ -264,7 +264,7 @@ void Logic::eventMouse(const Common::Event &ev) {
 		return;
 	}
 
-	// Found an hotspot: update the cursor and perform the action if the user clicked the mouse
+	// Found a hotspot: update the cursor and perform the action if the user clicked the mouse
 	_engine->getCursor()->setStyle(getAction()->getCursor(*hotspot));
 
 	if (ev.type != Common::EVENT_LBUTTONUP || _flagActionPerformed)

--- a/engines/mm/shared/xeen/sound_driver.h
+++ b/engines/mm/shared/xeen/sound_driver.h
@@ -173,7 +173,7 @@ public:
 	virtual ~SoundDriver();
 
 	/**
-	 * Starts an special effect playing
+	 * Starts a special effect playing
 	 */
 	virtual void playFX(uint effectId, const byte *data);
 

--- a/engines/mm/shared/xeen/sound_driver_adlib.h
+++ b/engines/mm/shared/xeen/sound_driver_adlib.h
@@ -148,7 +148,7 @@ public:
 	~SoundDriverAdlib() override;
 
 	/**
-	 * Starts an special effect playing
+	 * Starts a special effect playing
 	 */
 	void playFX(uint effectId, const byte *data) override;
 

--- a/engines/mohawk/resource.cpp
+++ b/engines/mohawk/resource.cpp
@@ -237,7 +237,7 @@ bool MohawkArchive::openStream(Common::SeekableReadStream *stream) {
 		debug(4, "File[%02x]: Offset = %08x  Size = %07x  Flags = %02x  Unknown = %04x", i, fileTable[i].offset, fileTable[i].size, fileTable[i].flags, fileTable[i].unknown);
 	}
 
-	// Now go in an read in each of the types
+	// Now go in and read in each of the types
 	stream->seek(absOffset);
 	uint16 stringTableOffset = stream->readUint16BE();
 	uint16 typeCount = stream->readUint16BE();

--- a/engines/mohawk/riven_card.cpp
+++ b/engines/mohawk/riven_card.cpp
@@ -850,7 +850,7 @@ RivenHotspot *RivenCard::getHotspotByName(const Common::String &name, bool optio
 	if (optional) {
 		return nullptr;
 	} else {
-		error("Card %d does not have an hotspot named %s", _id, name.c_str());
+		error("Card %d does not have a hotspot named %s", _id, name.c_str());
 	}
 }
 

--- a/engines/parallaction/graphics.cpp
+++ b/engines/parallaction/graphics.cpp
@@ -818,7 +818,7 @@ void Gfx::freeDialogueObjects() {
 
 void Gfx::setBackground(uint type, BackgroundInfo *info) {
 	if (!info) {
-		warning("Gfx::setBackground() called with an null BackgroundInfo");
+		warning("Gfx::setBackground() called with a null BackgroundInfo");
 		return;
 	}
 

--- a/engines/prince/debugger.cpp
+++ b/engines/prince/debugger.cpp
@@ -92,7 +92,7 @@ bool Debugger::Cmd_SetFlag(int argc, const char **argv) {
  * This command gets the value of a flag
  */
 bool Debugger::Cmd_GetFlag(int argc, const char **argv) {
-	// Check for an flag to display
+	// Check for a flag to display
 	if (argc != 2) {
 		debugPrintf("Usage: %s <flag number>\n", argv[0]);
 		return true;

--- a/engines/prince/prince.h
+++ b/engines/prince/prince.h
@@ -206,7 +206,7 @@ enum AnimType {
 // Nak (PL - Nakladka)
 struct Mask {
 	uint16 _state; // visible / invisible
-	int16 _flags; // turning on / turning off of an mask
+	int16 _flags; // turning on / turning off of a mask
 	int16 _x1;
 	int16 _y1;
 	int16 _x2;

--- a/engines/saga2/contain.cpp
+++ b/engines/saga2/contain.cpp
@@ -927,7 +927,7 @@ void ReadyContainerView::drawClipped(
 	int16           originX = _extent.x - offset.x + _iconOrigin.x,
 	                originY = _extent.y - offset.y + _iconOrigin.y;
 
-	//  Row an column number of the inventory slot.
+	//  Row and column number of the inventory slot.
 	int16           col,
 	                row;
 

--- a/engines/saga2/sensor.cpp
+++ b/engines/saga2/sensor.cpp
@@ -43,7 +43,7 @@ void newSensorList(SensorList *s) {
 }
 
 //----------------------------------------------------------------------
-//	Deallocate an SensorList
+//	Deallocate a SensorList
 
 void deleteSensorList(SensorList *s) {
 	g_vm->_sensorListList.remove(s);

--- a/engines/saga2/sensor.h
+++ b/engines/saga2/sensor.h
@@ -58,7 +58,7 @@ struct GameEvent;
 
 //  Allocate a new SensorList
 void newSensorList(SensorList *s);
-//  Deallocate an SensorList
+//  Deallocate a SensorList
 void deleteSensorList(SensorList *p);
 
 //  Fetch a specified object's SensorList

--- a/engines/sci/resource/resource_patcher.h
+++ b/engines/sci/resource/resource_patcher.h
@@ -152,7 +152,7 @@ private:
 	PatchSizes calculatePatchSizes(const byte *patchData) const;
 
 	/**
-	 * Reads an block size from the patch data, validates it, and advances the
+	 * Reads a block size from the patch data, validates it, and advances the
 	 * patch data pointer.
 	 */
 	int32 readBlockSize(const byte * &patchData) const;

--- a/engines/scumm/dialogs.cpp
+++ b/engines/scumm/dialogs.cpp
@@ -635,7 +635,7 @@ const ResString &InfoDialog::getStaticResString(Common::Language lang, int strin
 
 	// Added in SCUMM4. Only the numbers are used, so there
 	// is no need to provide language specific strings; there are
-	// some exceptions for which there's only an hardcoded English
+	// some exceptions for which there's only a hardcoded English
 	// string.
 	static const ResString strMap2[] = {
 		{7, ("Save")},

--- a/engines/scumm/he/net/net_main.h
+++ b/engines/scumm/he/net/net_main.h
@@ -127,7 +127,7 @@ public:
 	int whoAmI();
 
 	/**
-	 * @brief Creates and host an network game session.
+	 * @brief Creates and host a network game session.
 	 *
 	 * @param name Session name
 	 * @retval 1 on success.
@@ -357,8 +357,8 @@ private:
 	/**
 	 * Attempt to connect to a game session with its address and port.
 	 *
-	 * @param address Address of an session to connect to.
-	 * @param port Port number of an session to connect to.
+	 * @param address Address of a session to connect to.
+	 * @param port Port number of a session to connect to.
 	 * @retval true on success
 	 * @retval false on failure.
 	 *

--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -621,7 +621,7 @@ void ScummEngine_v6::o6_gt() {
 	int a = pop();
 	int b = pop();
 
-	// WORKAROUND: In Football 2002, when hosting an Network game, it would eventually timeout,
+	// WORKAROUND: In Football 2002, when hosting a Network game, it would eventually timeout,
 	// which causes the game to stop hosting and query for sessions again.
 	//
 	// [016C] (39)     localvar8++

--- a/engines/scumm/util.cpp
+++ b/engines/scumm/util.cpp
@@ -49,7 +49,7 @@ int newDirToOldDir(int dir) {
 }
 
 /**
- * Convert an new style (angle) direction to an old style one.
+ * Convert a new style (angle) direction to an old style one.
  */
 int oldDirToNewDir(int dir) {
 	assert(0 <= dir && dir <= 3);

--- a/engines/sherlock/talk.cpp
+++ b/engines/sherlock/talk.cpp
@@ -615,7 +615,7 @@ void Talk::stripVoiceCommands() {
 	for (uint sIdx = 0; sIdx < _statements.size(); ++sIdx) {
 		Statement &statement = _statements[sIdx];
 
-		// Scan for an sound effect byte, which indicates to play a sound
+		// Scan for a sound effect byte, which indicates to play a sound
 		for (uint idx = 0; idx < statement._reply.size(); ++idx) {
 			if (statement._reply[idx] == (char)_opcodes[OP_SFX_COMMAND]) {
 				// Replace instruction character with a space, and delete the

--- a/engines/sludge/sludger.cpp
+++ b/engines/sludge/sludger.cpp
@@ -250,8 +250,8 @@ bool initSludge(const Common::String &filename) {
 	}
 
 	if (customIconLogo & 2) {
-		// There is an logo - read it!
-		debugC(2, kSludgeDebugDataLoad, "There is an logo - read it!");
+		// There is a logo - read it!
+		debugC(2, kSludgeDebugDataLoad, "There is a logo - read it!");
 
 		// read game logo
 		Graphics::Surface gameLogo;

--- a/engines/stark/gfx/openglfade.h
+++ b/engines/stark/gfx/openglfade.h
@@ -34,7 +34,7 @@ namespace Gfx {
 class OpenGLDriver;
 
 /**
- * An programmable pipeline OpenGL fade screen renderer
+ * A programmable pipeline OpenGL fade screen renderer
  */
 class OpenGLFadeRenderer : public FadeRenderer {
 public:

--- a/engines/stark/gfx/openglsfade.h
+++ b/engines/stark/gfx/openglsfade.h
@@ -38,7 +38,7 @@ namespace Gfx {
 class OpenGLSDriver;
 
 /**
- * An programmable pipeline OpenGL fade screen renderer
+ * A programmable pipeline OpenGL fade screen renderer
  */
 class OpenGLSFadeRenderer : public FadeRenderer {
 public:

--- a/engines/stark/gfx/openglssurface.h
+++ b/engines/stark/gfx/openglssurface.h
@@ -39,7 +39,7 @@ class OpenGLSDriver;
 class Bitmap;
 
 /**
- * An programmable pipeline OpenGL surface renderer
+ * A programmable pipeline OpenGL surface renderer
  */
 class OpenGLSSurfaceRenderer : public SurfaceRenderer {
 public:

--- a/engines/stark/gfx/openglsurface.h
+++ b/engines/stark/gfx/openglsurface.h
@@ -36,7 +36,7 @@ class OpenGLDriver;
 class Bitmap;
 
 /**
- * An programmable pipeline OpenGL surface renderer
+ * A programmable pipeline OpenGL surface renderer
  */
 class OpenGLSurfaceRenderer : public SurfaceRenderer {
 public:

--- a/engines/stark/gfx/tinyglbitmap.h
+++ b/engines/stark/gfx/tinyglbitmap.h
@@ -30,7 +30,7 @@ namespace Stark {
 namespace Gfx {
 
 /**
- * An TinyGL bitmap wrapper
+ * A TinyGL bitmap wrapper
  */
 class TinyGlBitmap : public Bitmap {
 public:

--- a/engines/stark/gfx/tinyglfade.h
+++ b/engines/stark/gfx/tinyglfade.h
@@ -32,7 +32,7 @@ namespace Gfx {
 class TinyGLDriver;
 
 /**
- * An programmable pipeline TinyGL fade screen renderer
+ * A programmable pipeline TinyGL fade screen renderer
  */
 class TinyGLFadeRenderer : public FadeRenderer {
 public:

--- a/engines/stark/gfx/tinyglsurface.h
+++ b/engines/stark/gfx/tinyglsurface.h
@@ -36,7 +36,7 @@ class TinyGLDriver;
 class Bitmap;
 
 /**
- * An programmable pipeline TinyGL surface renderer
+ * A programmable pipeline TinyGL surface renderer
  */
 class TinyGLSurfaceRenderer : public SurfaceRenderer {
 public:

--- a/engines/stark/gfx/tinygltexture.h
+++ b/engines/stark/gfx/tinygltexture.h
@@ -30,7 +30,7 @@ namespace Stark {
 namespace Gfx {
 
 /**
- * An TinyGL texture wrapper
+ * A TinyGL texture wrapper
  */
 class TinyGlTexture : public Texture {
 public:

--- a/engines/sword25/gfx/image/image.h
+++ b/engines/sword25/gfx/image/image.h
@@ -155,7 +155,7 @@ public:
 
 	/**
 	    @brief Checks, if the BS_Image can be a target image for a Blit call.
-	    @return Returns false, if a Blit() call with this object as an target is not allowed.
+	    @return Returns false, if a Blit() call with this object as a target is not allowed.
 	*/
 	virtual bool isBlitTarget() const = 0;
 

--- a/engines/tsage/debugger.cpp
+++ b/engines/tsage/debugger.cpp
@@ -249,7 +249,7 @@ bool Debugger::Cmd_SetFlag(int argc, const char **argv) {
  * This command gets the value of a flag
  */
 bool Debugger::Cmd_GetFlag(int argc, const char **argv) {
-	// Check for an flag to display
+	// Check for a flag to display
 	if (argc != 2) {
 		debugPrintf("Usage: %s <flag number>\n", argv[0]);
 		return true;

--- a/engines/tsage/ringworld2/ringworld2_outpost.cpp
+++ b/engines/tsage/ringworld2/ringworld2_outpost.cpp
@@ -2431,7 +2431,7 @@ void Scene1337::dispatch() {
 }
 
 void Scene1337::actionDisplay(int resNum, int lineNum, int x, int y, int keepOnScreen, int width, int textMode, int fontNum, int colFG, int colBGExt, int colFGExt) {
-	// TODO: Check if it's normal that arg5 is unused and replaced by an hardcoded 0 value
+	// TODO: Check if it's normal that arg5 is unused and replaced by a hardcoded 0 value
 	// May hide an original bug
 
 	SceneItem::display(resNum, lineNum, SET_X, x, SET_Y, y, SET_KEEP_ONSCREEN, 0,

--- a/engines/tsage/ringworld2/ringworld2_outpost.h
+++ b/engines/tsage/ringworld2/ringworld2_outpost.h
@@ -160,7 +160,7 @@ public:
 	bool _displayHelpFl;
 	bool _instructionsDisplayedFl;
 
-	// Discarded cards are put in the available cards pile, with an higher index so there no conflict
+	// Discarded cards are put in the available cards pile, with a higher index so there's no conflict
 	int _currentDiscardIndex;
 	int _availableCardsPile[100];
 	int _cardsAvailableNumb;

--- a/engines/twine/scene/extra.cpp
+++ b/engines/twine/scene/extra.cpp
@@ -213,7 +213,7 @@ int Extra::getBonusSprite(BonusParameter bonusParameter) const {
 	assert(bonusIndex >= 0);
 	assert(bonusIndex < numBonus);
 	int8 bonusSprite = bonusSprites[bonusIndex];
-	// if bonus is magic an no magic level yet, then give life points
+	// if bonus is magic and no magic level yet, then give life points
 	if (!_engine->_gameState->_magicLevelIdx && bonusSprite == SPRITEHQR_MAGICPOINTS) {
 		bonusSprite = SPRITEHQR_LIFEPOINTS;
 	}

--- a/engines/twine/script/script_move.cpp
+++ b/engines/twine/script/script_move.cpp
@@ -595,7 +595,7 @@ int32 ScriptMove::mFACE_HERO(TwinEEngine *engine, MoveScriptContext &ctx) {
 }
 
 /**
- * Generate an random angle for the current actor
+ * Generate a random angle for the current actor
  * @note Opcode @c 0x22
  */
 int32 ScriptMove::mANGLE_RND(TwinEEngine *engine, MoveScriptContext &ctx) {

--- a/engines/ultima/nuvie/script/script.cpp
+++ b/engines/ultima/nuvie/script/script.cpp
@@ -2933,7 +2933,7 @@ static int nscript_map_remove_obj(lua_State *L) {
 Can you put an actor at a given map location
 @function map_can_put
 @tparam MapCoord|x,y,z location
-@treturn boolean true if actor an be placed at location otherwise false
+@treturn boolean true if actor can be placed at location otherwise false
 @within map
  */
 static int nscript_map_can_put_actor(lua_State *L) {
@@ -2953,7 +2953,7 @@ static int nscript_map_can_put_actor(lua_State *L) {
 Can you put an object at a given map location
 @function map_can_put_obj
 @tparam MapCoord|x,y,z location
-@treturn bool true if an object an be placed at location otherwise false
+@treturn bool true if an object can be placed at location otherwise false
 @within map
  */
 static int nscript_map_can_put_obj(lua_State *L) {

--- a/engines/ultima/nuvie/sound/decoder/random_collection_audio_stream.h
+++ b/engines/ultima/nuvie/sound/decoder/random_collection_audio_stream.h
@@ -40,7 +40,7 @@ public:
 };
 
 /**
- * Factory function for an QueuingAudioStream.
+ * Factory function for a QueuingAudioStream.
  */
 RandomCollectionAudioStream *makeRandomCollectionAudioStream(int rate, bool stereo, Std::vector<Audio::RewindableAudioStream *>streams, DisposeAfterUse::Flag disposeAfterUse);
 

--- a/engines/ultima/ultima1/maps/map_city_castle.h
+++ b/engines/ultima/ultima1/maps/map_city_castle.h
@@ -155,7 +155,7 @@ public:
 	void dropCoins(uint coins) override;
 
 	/**
-	 * Do an get action
+	 * Do a get action
 	 */
 	void get() override;
 
@@ -201,7 +201,7 @@ public:
 	void dropCoins(uint coins) override;
 
 	/**
-	 * Do an get action
+	 * Do a get action
 	 */
 	void get() override;
 

--- a/engines/ultima/ultima8/filesys/savegame.h
+++ b/engines/ultima/ultima8/filesys/savegame.h
@@ -81,7 +81,7 @@ public:
 	//! \param size (in bytes) of data
 	bool writeFile(const Std::string &name, const uint8 *data, uint32 size);
 
-	//! write a file to the savegame from an memory stream
+	//! write a file to the savegame from a memory stream
 	//! \param name name of the file
 	//! \param buf the MemoryWriteStreamDynamic to save
 	bool writeFile(const Std::string &name, Common::MemoryWriteStreamDynamic *buf);

--- a/engines/ultima/ultima8/graphics/soft_render_surface.h
+++ b/engines/ultima/ultima8/graphics/soft_render_surface.h
@@ -64,7 +64,7 @@ public:
 	// Paint a Shape
 	void Paint(const Shape *s, uint32 frame, int32 x, int32 y, bool untformed_pal = false) override;
 
-	// Paint an Shape without clipping
+	// Paint a Shape without clipping
 	void PaintNoClip(const Shape *s, uint32 frame, int32 x, int32 y, bool untformed_pal = false) override;
 
 	// Paint a Translucent Shape.

--- a/engines/ultima/ultima8/kernel/object_manager.cpp
+++ b/engines/ultima/ultima8/kernel/object_manager.cpp
@@ -261,7 +261,7 @@ bool ObjectManager::load(Common::ReadStream *rs, uint32 version) {
 	// _objIDs (up to 511 is reserved by U8Game, 666 is reserved for Guardian
 	// barks).
 	// FIXME: Properly fix this objID leak and increment the savegame number.
-	//        This check can then be turned into an savegame corruption check
+	//        This check can then be turned into a savegame corruption check
 	//        for saves with the new savegame version.
 	// We also fail loading when we're out of _objIDs since this could
 	// have caused serious issues when critical _objects haven't been created.

--- a/engines/ultima/ultima8/world/item.cpp
+++ b/engines/ultima/ultima8/world/item.cpp
@@ -1961,7 +1961,7 @@ void Item::leaveFastArea() {
 		if (c) c->destroyContents();
 
 		destroy();
-		// NB: destroy() creates an DestroyItemProcess to actually
+		// NB: destroy() creates a DestroyItemProcess to actually
 		// delete the item in this case.
 	}
 	// If we have a gravity process, move us to the ground

--- a/graphics/cursorman.h
+++ b/graphics/cursorman.h
@@ -140,7 +140,7 @@ public:
 	/**
 	 * Test whether cursor palettes are supported.
 	 *
-	 * This is just an convenience wrapper for checking whether
+	 * This is just a convenience wrapper for checking whether
 	 * OSystem::kFeatureCursorPalette is supported by OSystem.
 	 *
 	 * @see OSystem::kFeatureCursorPalette

--- a/graphics/macgui/macwindowborder.h
+++ b/graphics/macgui/macwindowborder.h
@@ -77,7 +77,7 @@ public:
 
 	/**
 	 * Add the given surface as the display of the border in the state that is instructed by flag.
-	 * Will fail if there is already an border.
+	 * Will fail if there is already a border.
 	 * @param The surface that will be displayed.
 	 * @param The border type indicated by flag
 	 * @param The title position of bmp image

--- a/graphics/scaler/scale2x.cpp
+++ b/graphics/scaler/scale2x.cpp
@@ -22,7 +22,7 @@
 /*
  * This file contains a C and MMX implementation of the Scale2x effect.
  *
- * You can find an high level description of the effect at :
+ * You can find a high-level description of the effect at:
  *
  * https://www.scale2x.it
  *

--- a/graphics/scaler/scale3x.cpp
+++ b/graphics/scaler/scale3x.cpp
@@ -22,7 +22,7 @@
 /*
  * This file contains a C and MMX implementation of the Scale2x effect.
  *
- * You can find an high level description of the effect at :
+ * You can find a high-level description of the effect at:
  *
  * https://www.scale2x.it
  *

--- a/graphics/scaler/scalebit.cpp
+++ b/graphics/scaler/scalebit.cpp
@@ -21,9 +21,9 @@
 
 /*
  * This file contains an example implementation of the Scale effect
- * applyed to a generic bitmap.
+ * applied to a generic bitmap.
  *
- * You can find an high level description of the effect at :
+ * You can find a high-level description of the effect at:
  *
  * https://www.scale2x.it
  *
@@ -166,7 +166,7 @@ static void scale3x(void* void_dst, unsigned dst_slice, const void* void_src, un
  * The destination bitmap must be manually allocated before calling the function,
  * note that the resulting size is exactly 4x4 times the size of the source bitmap.
  * \note This function requires also a small buffer bitmap used internally to store
- * intermediate results. This bitmap must have at least an horizontal size in bytes of 2*width*pixel,
+ * intermediate results. This bitmap must have at least a horizontal size in bytes of 2*width*pixel,
  * and a vertical size of 6 rows. The memory of this buffer must not be allocated
  * in video memory because it's also read and not only written. Generally
  * a heap (malloc) or a stack (alloca) buffer is the best choices.

--- a/graphics/scaler/scalebit.h
+++ b/graphics/scaler/scalebit.h
@@ -21,9 +21,9 @@
 
 /*
  * This file contains an example implementation of the Scale effect
- * applyed to a generic bitmap.
+ * applied to a generic bitmap.
  *
- * You can find an high level description of the effect at :
+ * You can find a high-level description of the effect at:
  *
  * https://www.scale2x.it
  *

--- a/graphics/tinygl/zgl.h
+++ b/graphics/tinygl/zgl.h
@@ -159,7 +159,7 @@ struct GLParamBuffer {
 
 struct GLList {
 	GLParamBuffer *first_op_buffer;
-	// TODO: extensions for an hash table or a better allocating scheme
+	// TODO: extensions for a hash table or a better allocating scheme
 };
 
 struct GLVertex {

--- a/gui/browser.cpp
+++ b/gui/browser.cpp
@@ -166,7 +166,7 @@ void BrowserDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data
 	case kListSelectionChangedCmd:
 		// We do not allow selecting directories in directory
 		// browser mode, thus we will invalidate the selection
-		// when the user selects an directory over here.
+		// when the user selects a directory over here.
 		if (data != (uint32)-1 && _isDirBrowser && !_nodeContent[data].isDirectory())
 			_fileList->setSelected(-1);
 		break;

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -442,8 +442,8 @@ void GuiManager::runLoop() {
 			// We will need to check whether the screen changed while polling
 			// for an event here. While we do send EVENT_SCREEN_CHANGED
 			// whenever this happens we still cannot be sure that we get such
-			// an event immediately. For example, we might have an mouse move
-			// event queued before an screen changed event. In some rare cases
+			// an event immediately. For example, we might have a mouse move
+			// event queued before a screen changed event. In some rare cases
 			// this would make the GUI redraw (with the code a few lines
 			// below) when it is not yet updated for new overlay dimensions.
 			// As a result ScummVM would crash because it tries to copy data

--- a/video/video_decoder.h
+++ b/video/video_decoder.h
@@ -193,8 +193,8 @@ public:
 	 * variables can be updated appropriately.
 	 *
 	 * This is a convenience method which automatically keeps track on how
-	 * often the video has been paused, ensuring that after pausing an video
-	 * e.g. twice, it has to be unpaused twice before actuallying resuming.
+	 * often the video has been paused, ensuring that after pausing a video
+	 * e.g. twice, it has to be unpaused twice before actually resuming.
 	 *
 	 * @param pause		true to pause the video, false to resume it
 	 */


### PR DESCRIPTION
This just fixes some `an` typos in comments. I've used separate commits when the change was outside a comment, but in that case they are just debug messages.