### PR TITLE
ENGINES: Update autosave time before adjusting interval

### DIFF
--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -637,9 +637,9 @@ void Engine::saveAutosaveIfEnabled() {
 		saveFlag = false;
 	}
 
-	if (saveFlag) {
-		_lastAutosaveTime = _system->getMillis();
-	} else {
+	_lastAutosaveTime = _system->getMillis();
+	
+	if (!saveFlag) {
 		// Set the next autosave interval to be in 5 minutes, rather than whatever
 		// full autosave interval the user has selected
 		_lastAutosaveTime += ((5 * 60 - _autosaveInterval) * 1000);


### PR DESCRIPTION
When an autosave fails, or is skipped by the user, the next autosave attempt is scheduled for 5 minutes, regardless of the user's selected autosave interval.

Fixes an issue where the adjusted next autosave interval is incorrectly applied to the expired _lastAutosaveTime value, resulting in the next autosave being called immediately, and repeatedly, until the autosave is able to proceed.

Fixes the 'Skip autosave' button and Escape key being unable to dismiss the in-game warning dialog from the screen.