### PR TITLE
LURE: Original VGA background color in popup menus

### DIFF
--- a/engines/lure/menu.cpp
+++ b/engines/lure/menu.cpp
@@ -479,9 +479,7 @@ uint16 PopupMenu::Show(int numEntries, const char *actions[]) {
 	Mouse &mouse = Mouse::getReference();
 	OSystem &system = *g_system;
 	Screen &screen = Screen::getReference();
-	Common::Rect r;
 	bool isEGA = LureEngine::getReference().isEGA();
-	byte bgColor = isEGA ? EGA_DIALOG_BG_COLOR : 0;
 	byte textColor = isEGA ? EGA_DIALOG_TEXT_COLOR : VGA_DIALOG_TEXT_COLOR;
 	byte whiteColor = isEGA ? EGA_DIALOG_WHITE_COLOR : VGA_DIALOG_WHITE_COLOR;
 
@@ -515,21 +513,17 @@ uint16 PopupMenu::Show(int numEntries, const char *actions[]) {
 	Common::Point size;
 	Surface::getDialogBounds(size, numCols, numLines, false);
 	Surface *s = new Surface(size.x, size.y);
-	s->createDialog(true);
+	s->createDialog();
 
 	int selectedIndex = 0;
 	bool refreshFlag = true;
-	r.left = Surface::textX();
-	r.right = s->width() - Surface::textX() + 1;
-	r.top = Surface::textY();
-	r.bottom = s->height() - Surface::textY() + 1;
 
 	bool bailOut = false;
 
 	while (!bailOut) {
 		if (refreshFlag) {
 			// Set up the contents of the menu
-			s->fillRect(r, bgColor);
+			s->refreshDialog();
 
 			for (int index = 0; index < numLines; ++index) {
 #ifndef LURE_CLICKABLE_MENUS

--- a/engines/lure/surface.cpp
+++ b/engines/lure/surface.cpp
@@ -207,9 +207,12 @@ void Surface::vgaRefreshDialog() {
 	// Skip dialog top
 	pSrc += ((VGA_DIALOG_EDGE_WIDTH - 2) + 1 + VGA_DIALOG_EDGE_WIDTH) * 9;
 	pDest += _width * 9;
+	// Skip dialog left border
+	pSrc += VGA_DIALOG_EDGE_WIDTH;
+	pDest += VGA_DIALOG_EDGE_WIDTH;
 
 	for (y = 0; y < yCenter; ++y) {
-		copyLine(pSrc, pDest, VGA_DIALOG_EDGE_WIDTH, xCenter, VGA_DIALOG_EDGE_WIDTH);
+		copyLine(pSrc, pDest, 0, xCenter, 0);
 		pDest += _width;
 	}
 }

--- a/engines/lure/surface.h
+++ b/engines/lure/surface.h
@@ -37,8 +37,10 @@ private:
 	MemoryBlock *_data;
 	uint16 _width, _height;
 
-	void egaCreateDialog(bool blackFlag);
-	void vgaCreateDialog(bool blackFlag);
+	void egaCreateDialog();
+	void vgaCreateDialog();
+	void egaRefreshDialog();
+	void vgaRefreshDialog();
 public:
 	Surface(MemoryBlock *src, uint16 width, uint16 height);
 	Surface(uint16 width, uint16 height);
@@ -71,7 +73,8 @@ public:
 	void copyFrom(MemoryBlock *src, uint32 destOffset);
 	void empty() { _data->empty(); }
 	void fillRect(const Common::Rect &r, uint8 color);
-	void createDialog(bool blackFlag = false);
+	void createDialog();
+	void refreshDialog();
 	void copyToScreen(uint16 x, uint16 y);
 	void centerOnScreen();
 


### PR DESCRIPTION
In the original VGA DOS game all GUI dialogs have a dark gray background
color. However in the ScummVM implementation the background color for
popup menus, which are the ones that appear when you right-click, is
black. The ScummVM EGA version works as intended.

Probably this issue was due to the difficulty of knowing at which index
the dark gray color was in all the different palettes. From my
understanding of the LURE engine and VGA, different graphic resources
could have different color palettes.

My solution was to copy the element side lines when the dialog needs to
be emptied, instead of filling a rectangle with solid black. In my
second commit there's even a more strict fix, in which I copy only the
element background, because there is no need to draw the wooden side
borders again.
