### PR TITLE
NUVIE: Fix Ultima 6 item order

### DIFF
--- a/engines/ultima/nuvie/core/obj.cpp
+++ b/engines/ultima/nuvie/core/obj.cpp
@@ -192,21 +192,24 @@ Actor *Obj::get_actor_holding_obj() {
 }
 
 //Add child object into container, stacking if required
-void Obj::add(Obj *obj, bool stack) {
+void Obj::add(Obj *obj, bool stack, bool addAtTail) {
 	if (container == NULL)
 		make_container();
 
 	if (stack && Game::get_game()->get_obj_manager()->is_stackable(obj))
-		add_and_stack(obj);
+		add_and_stack(obj, addAtTail);
 	else
-		container->addAtPos(0, obj);
+		if (!addAtTail)
+			container->addAtPos(0, obj);
+		else
+			container->add(obj);
 
 	obj->set_in_container(this);
 
 	return;
 }
 
-void Obj::add_and_stack(Obj *obj) {
+void Obj::add_and_stack(Obj *obj, bool addAtTail) {
 	U6Link *link;
 	Obj *cont_obj;
 
@@ -224,7 +227,10 @@ void Obj::add_and_stack(Obj *obj) {
 		}
 	}
 
-	container->addAtPos(0, obj); // add the object as we couldn't find another object to stack with.
+	if (!addAtTail)
+		container->addAtPos(0, obj); // add the object as we couldn't find another object to stack with.
+	else
+		container->add(obj);
 
 	return;
 }

--- a/engines/ultima/nuvie/core/obj.h
+++ b/engines/ultima/nuvie/core/obj.h
@@ -173,7 +173,7 @@ public:
 	void set_in_script(bool flag);
 	void set_actor_obj(bool flag);
 
-	void add(Obj *obj, bool stack = false);
+	void add(Obj *obj, bool stack = false, bool addAtTail = false);
 
 	bool remove(Obj *obj);
 
@@ -183,7 +183,7 @@ public:
 
 protected:
 
-	void add_and_stack(Obj *obj);
+	void add_and_stack(Obj *obj, bool addAtTail = false);
 
 };
 

--- a/engines/ultima/nuvie/core/obj_manager.cpp
+++ b/engines/ultima/nuvie/core/obj_manager.cpp
@@ -1623,7 +1623,7 @@ bool ObjManager::addObjToContainer(U6LList *llist, Obj *obj) {
 		c_obj = (Obj *)link->data;
 
 	if (c_obj) { // we've found our container.
-		c_obj->add(obj);
+		c_obj->add(obj, false, true); //add at tail position
 
 		//DEBUG(0,LEVEL_DEBUGGING,"Cont: %s\n", tile_manager->lookAtTile(get_obj_tile_num(c_obj->obj_n)+c_obj->frame_n,0,false));
 		//DEBUG(0,LEVEL_DEBUGGING,"Add to container %s", tile_manager->lookAtTile(get_obj_tile_num(obj->obj_n)+obj->frame_n,0,false));

--- a/engines/ultima/nuvie/core/obj_manager.cpp
+++ b/engines/ultima/nuvie/core/obj_manager.cpp
@@ -382,7 +382,7 @@ bool ObjManager::save_obj(NuvieIO *save_buf, Obj *obj, uint16 parent_objblk_n) {
 	obj_save_count += 1;
 
 	if (obj->container) {
-		for (link = obj->container->end(); link != NULL; link = link->prev)
+		for (link = obj->container->start(); link != NULL; link = link->next)
 			save_obj(save_buf, (Obj *)link->data, objblk_n);
 	}
 

--- a/engines/ultima/nuvie/usecode/usecode.cpp
+++ b/engines/ultima/nuvie/usecode/usecode.cpp
@@ -163,11 +163,11 @@ bool UseCode::search_container(Obj *obj, bool show_string) {
 
 	/* Test whether this object has items inside it. */
 	if ((obj->container != NULL) &&
-	        ((obj_link = obj->container->end()) != NULL)) {
+	        ((obj_link = obj->container->start()) != NULL)) {
 		/* Add objects to obj_list. */
 		for (; obj_link != NULL;) {
 			temp_obj = (Obj *)obj_link->data;
-			obj_link = obj_link->prev;
+			obj_link = obj_link->next;
 			/*
 			obj_list->add(temp_obj);
 			temp_obj->status |= OBJ_STATUS_OK_TO_TAKE;
@@ -180,7 +180,7 @@ bool UseCode::search_container(Obj *obj, bool show_string) {
 			if (show_string) {
 				scroll->display_string(obj_manager->look_obj(temp_obj, true));
 				if (obj_link) // more objects left
-					scroll->display_string(obj_link->prev ? ", " : ", and ");
+					scroll->display_string(obj_link->next ? ", " : ", and ");
 			}
 		}
 		/* Remove objects from the container. */


### PR DESCRIPTION
Addresses the following problems:

1. UseCode::search_container() moves items to the map in the wrong order
2. When loading a chunk items are added to containers in the wrong order (e.g. Iolos starting bag and the chest in the Avatars room SW of the throne room)

This assumes the correct order is the one expected by the inventory GUI.

The items should be ordered as follows when starting a new game with these fixes:
Gargoyle corpse: weapons first, helmets/armor last
Iolos bag: knife first, grapes last
Avatar chest: torches first, chain coif last

Fixes [#13514](https://bugs.scummvm.org/ticket/13514)