### PR TITLE
VIDEO: Fix VPX build for various platforms

### DIFF
--- a/configure
+++ b/configure
@@ -1337,6 +1337,7 @@ for ac_option in $@; do
 		arg=`echo $ac_option | cut -d '=' -f 2`
 		VPX_CFLAGS="-I$arg/include"
 		VPX_LIBS="-L$arg/lib"
+		VPX_STATIC_LIBS="-L$arg/lib"
 		;;
 	--with-faad-prefix=*)
 		arg=`echo $ac_option | cut -d '=' -f 2`
@@ -5328,6 +5329,7 @@ if test "$_vpx" = auto ; then
 
 	if test "$_pkg_config" = "yes" && $_pkgconfig --exists vpx; then
 		append_var VPX_LIBS "`$_pkgconfig --libs vpx`"
+		append_var VPX_STATIC_LIBS "`$_pkgconfig --static --libs vpx`"
 		append_var VPX_CFLAGS "`$_pkgconfig --cflags vpx`"
 	else
 		append_var VPX_LIBS "-lvpx"
@@ -5347,7 +5349,13 @@ int main(void) {
 	return 0;
 }
 EOF
-	cc_check $VPX_CFLAGS $VPX_LIBS && _vpx=yes
+	cc_check_no_clean $VPX_CFLAGS $VPX_LIBS && _vpx=yes
+	# If it fails, try with static libs, it may help
+	if test "$_vpx" != "yes"; then
+		VPX_LIBS="$VPX_STATIC_LIBS"
+		cc_check_no_clean $VPX_CFLAGS $VPX_LIBS && _vpx=yes
+	fi
+	cc_check_clean
 fi
 if test "$_vpx" = yes ; then
 	append_var LIBS "$VPX_LIBS -lvpx"

--- a/ports.mk
+++ b/ports.mk
@@ -520,6 +520,10 @@ ifdef USE_A52
 OSX_STATIC_LIBS += $(STATICLIBPATH)/lib/liba52.a
 endif
 
+ifdef USE_VPX
+OSX_STATIC_LIBS += $(STATICLIBPATH)/lib/libvpx.a
+endif
+
 ifdef USE_JPEG
 OSX_STATIC_LIBS += $(STATICLIBPATH)/lib/libjpeg.a
 endif


### PR DESCRIPTION
AppleTV and iOS need the libvpx.a file to be added to their build flags like other libraries.

MKV decoder needs proper support for Tremor. This is copied from Theora decoder.

libvpx can be built statically. In this case additional libraries may be needed (like pthread for multithreaded decoding).
Without this, it fails to build on platforms like Vita.

Finally, patch MKV parser to make it use our own objects instead of STL ones. This makes the code compile under MacOS i386 toolchain.
As the C++ headers are replaced by our own (which include C versions of them), `LLONG_MAX` needs to be redefined on some platforms (newlib based ones) and isnan can't be defined as a function as it may be a macro.

Without this PR, new toolchains which have libvpx can't be deployed.
