### PR TITLE
NUVIE: Fix Ultima 6 crash on loading save

### DIFF
--- a/engines/ultima/nuvie/menus/game_menu_dialog.cpp
+++ b/engines/ultima/nuvie/menus/game_menu_dialog.cpp
@@ -148,8 +148,8 @@ GUI_status GameMenuDialog::callback(uint16 msg, GUI_CallBack *caller, void *data
 		close_dialog();
 		g_engine->saveGameDialog();
 	} else if (caller == load_button) {
-		close_dialog();
 		g_engine->loadGameDialog();
+		close_dialog();
 	} else if (caller == video_button) {
 		GUI_Widget *video_dialog;
 		video_dialog = (GUI_Widget *) new VideoDialog(this);


### PR DESCRIPTION
Fix a use-after-free bug. The chain of events causing it is as follows:

In-game the user changes the current view (e.g. by pressing TAB to go to inventory view). The user next presses ESC to open the GameMenuDialog and then clicks the "Load Game" button. A save slot is selected and then loaded.

The resulting call chain is:

```
GUI_Button::Activate_button()
  GameMenuDialog::callback()
    GameMenuDialog::close_dialog() <-- This marks GameMenuDialog
                                       for deletion by the GUI
    g_engine->loadGameDialog()
      GUI::AddWidget() <-------------- This deletes GameMenuDialog
                                       and its children, including
                                       the "Load Game" button
```

Control then returns to GUI_Button::Activate_button() with "this" containing the address of the freed button.

An attempt to call Redraw() finally dereferences the invalid pointer.

This is fixed by calling loadGameDialog() before close_dialog().


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
