### PR TITLE
GUI: Add a portrait version of the launcher

### DIFF
--- a/gui/ThemeParser.cpp
+++ b/gui/ThemeParser.cpp
@@ -813,6 +813,11 @@ bool ThemeParser::parserCallback_import(ParserNode *node) {
 }
 
 bool ThemeParser::parserCallback_layout(ParserNode *node) {
+	if (resolutionCheck(node->values["resolution"]) == false) {
+		node->ignore = true;
+		return true;
+	}
+
 	int spacing = -1;
 
 	if (node->values.contains("spacing")) {

--- a/gui/ThemeParser.cpp
+++ b/gui/ThemeParser.cpp
@@ -1091,6 +1091,10 @@ bool ThemeParser::resolutionCheck(const Common::String &resolution) {
 			// theme by default
 			token = 375;
 #endif
+		} else if (cur[offset] == 'x') {
+			token = _baseWidth;
+		} else if (cur[offset] == 'y') {
+			token = _baseHeight;
 		} else {
 			token = atoi(cur.c_str() + offset);
 		}

--- a/gui/ThemeParser.h
+++ b/gui/ThemeParser.h
@@ -204,6 +204,7 @@ protected:
 					XML_PROP(align, false)
 					XML_PROP(padding, false)
 					XML_PROP(spacing, false)
+					XML_PROP(resolution, false)
 
 					XML_KEY(import)
 						XML_PROP(layout, true)

--- a/gui/themes/common/highres_layout.stx
+++ b/gui/themes/common/highres_layout.stx
@@ -150,7 +150,7 @@
 		/>
 	</globals>
 
-	<dialog name = 'Launcher' overlays = 'screen'>
+	<dialog name = 'Launcher' overlays = 'screen' resolution = 'y<=x'>
 		<layout type = 'vertical' align = 'center' padding = '23, 23, 8, 40'>
 			<widget name = 'Logo'
 					width = '287'
@@ -223,6 +223,90 @@
 							type = 'Button'
 					/>
 				</layout>
+			</layout>
+			<layout type = 'horizontal' padding = '0, 0, 6, 0' spacing = '2'>
+				<widget name = 'ListSwitch'
+						height = 'Globals.Button.Height'
+						width = 'Globals.Button.Height'
+				/>
+				<widget name = 'GridSwitch'
+						height = 'Globals.Button.Height'
+						width = 'Globals.Button.Height'
+				/>
+				<space />
+			</layout>
+		</layout>
+	</dialog>
+
+	<dialog name = 'Launcher' overlays = 'screen' resolution = 'y>x'>
+		<layout type = 'vertical' align = 'center' padding = '23, 23, 8, 92'>
+			<widget name = 'Logo'
+					width = '287'
+					height = '80'
+					rtl = 'no'
+			/>
+			<layout type = 'horizontal'  spacing = '5' padding = '10, 0, 0, 0'>
+				<widget name = 'SearchPic'
+						width = '16'
+						height = '17'
+						rtl = 'no'
+				/>
+				<widget name = 'Search'
+						width = '120'
+						height = 'Globals.Line.Height'
+				/>
+				<widget name = 'SearchClearButton'
+						height = 'Globals.Line.Height'
+						width = 'Globals.Line.Height'
+				/>
+				<space size = '5' />
+				<widget name = 'GroupPic'
+						width = '17'
+						height = '17'
+						rtl = 'no'
+				/>
+				<widget name = 'laGroupPopup'
+						width = '100'
+						type = 'PopUp'
+				/>
+				<space />
+				<widget name = 'Version'
+						width = '310'
+						height = 'Globals.Line.Height'
+						textalign = 'center'
+				/>
+				<space />
+			</layout>
+			<layout type = 'horizontal' padding = '0, 0, 2, 0' spacing = '2'>
+				<widget name = 'GameList'/>
+			</layout>
+			<layout type = 'horizontal' padding = '0, 0, 2, 0' spacing = '2'>
+				<widget name = 'LoadGameButton'
+						height = 'Globals.Button.Height'
+				/>
+				<widget name = 'AddGameButton'
+						height = 'Globals.Button.Height'
+				/>
+				<widget name = 'EditGameButton'
+						height = 'Globals.Button.Height'
+				/>
+				<widget name = 'RemoveGameButton'
+						height = 'Globals.Button.Height'
+				/>
+			</layout>
+			<layout type = 'horizontal' padding = '0, 0, 0, 0' spacing = '2'>
+				<widget name = 'QuitButton'
+						height = 'Globals.Button.Height'
+				/>
+				<widget name = 'AboutButton'
+						height = 'Globals.Button.Height'
+				/>
+				<widget name = 'OptionsButton'
+						height = 'Globals.Button.Height'
+				/>
+				<widget name = 'StartButton'
+						height = 'Globals.Button.Height'
+				/>
 			</layout>
 			<layout type = 'horizontal' padding = '0, 0, 6, 0' spacing = '2'>
 				<widget name = 'ListSwitch'


### PR DESCRIPTION
In portrait mode, the buttons are moved to the bottom of the screen instead of next to the game list, so that there's more room for the game description to be displayed.