### PR TITLE
AGS: auto-detect Linux games based on executable

### DIFF
--- a/engines/ags/engine/main/config.cpp
+++ b/engines/ags/engine/main/config.cpp
@@ -354,8 +354,12 @@ void apply_config(const ConfigTree &cfg) {
 
 		// User's overrides and hacks
 		_GP(usetup).override_multitasking = CfgReadInt(cfg, "override", "multitasking", -1);
-		String override_os = CfgReadString(cfg, "override", "os");
 		_GP(usetup).override_script_os = -1;
+		// Looks for the existence of the Linux executable
+		if (File::IsFile(Path::ConcatPaths(_GP(usetup).startup_dir, "ags64"))) {
+			_GP(usetup).override_script_os = eOS_Linux;
+		}
+		String override_os = CfgReadString(cfg, "override", "os");
 		if (override_os.CompareNoCase("dos") == 0) {
 			_GP(usetup).override_script_os = eOS_DOS;
 		} else if (override_os.CompareNoCase("win") == 0) {


### PR DESCRIPTION
ags64 (and also ags32) are the name of the engine executable on Linux. These names seems to be exclusively used for that OS. Fix a bug in Zniw Adventure (GOG, Linux) due to translation path being different between Linux and Windows.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
