### PR TITLE
GUI: Only use a transparent colour for BMP images

### DIFF
--- a/engines/dialogs.cpp
+++ b/engines/dialogs.cpp
@@ -51,8 +51,7 @@ MainMenuDialog::MainMenuDialog(Engine *engine)
 	_logo = 0;
 	if (g_gui.xmlEval()->getVar("Globals.ShowGlobalMenuLogo", 0) == 1 && g_gui.theme()->supportsImages()) {
 		_logo = new GUI::GraphicsWidget(this, "GlobalMenu.Logo");
-		_logo->useThemeTransparency(true);
-		_logo->setGfx(g_gui.theme()->getImageSurface(GUI::ThemeEngine::kImageLogoSmall));
+		_logo->setGfxFromTheme(GUI::ThemeEngine::kImageLogoSmall);
 	} else {
 		GUI::StaticTextWidget *title = new GUI::StaticTextWidget(this, "GlobalMenu.Title", Common::U32String("ScummVM"));
 		title->setAlign(Graphics::kTextAlignCenter);
@@ -171,8 +170,7 @@ void MainMenuDialog::reflowLayout() {
 	if (g_gui.xmlEval()->getVar("Globals.ShowGlobalMenuLogo", 0) == 1 && g_gui.theme()->supportsImages()) {
 		if (!_logo)
 			_logo = new GUI::GraphicsWidget(this, "GlobalMenu.Logo");
-		_logo->useThemeTransparency(true);
-		_logo->setGfx(g_gui.theme()->getImageSurface(GUI::ThemeEngine::kImageLogoSmall));
+		_logo->setGfxFromTheme(GUI::ThemeEngine::kImageLogoSmall);
 
 		GUI::StaticTextWidget *title = (GUI::StaticTextWidget *)findWidget("GlobalMenu.Title");
 		if (title) {

--- a/graphics/VectorRenderer.h
+++ b/graphics/VectorRenderer.h
@@ -457,7 +457,7 @@ public:
 	void drawCallback_BITMAP(const Common::Rect &area, const DrawStep &step) {
 		uint16 x, y, w, h;
 		stepGetPositions(step, area, x, y, w, h);
-		blitKeyBitmap(step.blitSrc, Common::Point(x, y), true);
+		blitManagedSurface(step.blitSrc, Common::Point(x, y));
 	}
 
 	void drawCallback_CROSS(const Common::Rect &area, const DrawStep &step) {
@@ -508,7 +508,7 @@ public:
 	 */
 	virtual void blitSurface(const Graphics::ManagedSurface *source, const Common::Rect &r) = 0;
 
-	virtual void blitKeyBitmap(const Graphics::ManagedSurface *source, const Common::Point &p, bool themeTrans) = 0;
+	virtual void blitManagedSurface(const Graphics::ManagedSurface *source, const Common::Point &p) = 0;
 
 	/**
 	 * Draws a string into the screen. Wrapper for the Graphics::Font string drawing

--- a/graphics/VectorRendererSpec.cpp
+++ b/graphics/VectorRendererSpec.cpp
@@ -591,7 +591,6 @@ VectorRendererSpec(PixelFormat format) :
 	_blueMask((0xFF >> format.bLoss) << format.bShift),
 	_alphaMask((0xFF >> format.aLoss) << format.aShift) {
 
-	_bitmapAlphaColor = _format.RGBToColor(255, 0, 255);
 	_clippingArea = Common::Rect(0, 0, 32767, 32767);
 
 	_fgColor = _bgColor = _bevelColor = 0;
@@ -811,7 +810,7 @@ blitSurface(const Graphics::ManagedSurface *source, const Common::Rect &r) {
 
 template<typename PixelType>
 void VectorRendererSpec<PixelType>::
-blitKeyBitmap(const Graphics::ManagedSurface *source, const Common::Point &p, bool themeTrans) {
+blitManagedSurface(const Graphics::ManagedSurface *source, const Common::Point &p) {
 	Common::Rect drawRect(p.x, p.y, p.x + source->w, p.y + source->h);
 	drawRect.clip(_clippingArea);
 	drawRect.translate(-p.x, -p.y);
@@ -829,10 +828,7 @@ blitKeyBitmap(const Graphics::ManagedSurface *source, const Common::Point &p, bo
 		np = p;
 	}
 
-	if (themeTrans)
-		_activeSurface->transBlitFrom(*source, drawRect, np, _bitmapAlphaColor);
-	else
-		_activeSurface->blitFrom(*source, drawRect, np);
+	_activeSurface->blitFrom(*source, drawRect, np);
 }
 
 template<typename PixelType>

--- a/graphics/VectorRendererSpec.h
+++ b/graphics/VectorRendererSpec.h
@@ -88,7 +88,7 @@ public:
 
 	void fillSurface() override;
 	void blitSurface(const Graphics::ManagedSurface *source, const Common::Rect &r) override;
-	void blitKeyBitmap(const Graphics::ManagedSurface *source, const Common::Point &p, bool themeTrans) override;
+	void blitManagedSurface(const Graphics::ManagedSurface *source, const Common::Point &p) override;
 
 	void applyScreenShading(GUI::ThemeEngine::ShadingStyle shadingStyle) override;
 
@@ -321,7 +321,6 @@ protected:
 	Common::Array<int> _gradIndexes;
 
 	PixelType _bevelColor;
-	PixelType _bitmapAlphaColor;
 };
 
 

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -712,15 +712,23 @@ bool ThemeEngine::addBitmap(const Common::String &filename, const Common::String
 
 		if (srcSurface && srcSurface->format.bytesPerPixel != 1)
 			surf = new Graphics::ManagedSurface(srcSurface->convertTo(_overlayFormat));
+
+		if (surf)
+			surf->setTransparentColor(surf->format.RGBToColor(0xFF, 0x00, 0xFF));
 	}
 
 	if (_scaleFactor != 1.0 && surf) {
 		Graphics::Surface *tmp2 = surf->rawSurface().scale(surf->w * _scaleFactor, surf->h * _scaleFactor, false);
 
+		Graphics::ManagedSurface *surf2 = new Graphics::ManagedSurface(tmp2);
+
+		if (surf->hasTransparentColor())
+			surf2->setTransparentColor(surf->getTransparentColor());
+
 		surf->free();
 		delete surf;
 
-		surf = new Graphics::ManagedSurface(tmp2);
+		surf = surf2;
 	}
 	// Store the surface into our hashmap (attention, may store NULL entries!)
 	_bitmaps[filename] = surf;
@@ -1231,7 +1239,7 @@ void ThemeEngine::drawPopUpWidget(const Common::Rect &r, const Common::U32String
 	}
 }
 
-void ThemeEngine::drawSurface(const Common::Point &p, const Graphics::ManagedSurface &surface, bool themeTrans) {
+void ThemeEngine::drawManagedSurface(const Common::Point &p, const Graphics::ManagedSurface &surface) {
 	if (!ready())
 		return;
 
@@ -1239,7 +1247,7 @@ void ThemeEngine::drawSurface(const Common::Point &p, const Graphics::ManagedSur
 		return;
 
 	_vectorRenderer->setClippingRect(_clip);
-	_vectorRenderer->blitKeyBitmap(&surface, p, themeTrans);
+	_vectorRenderer->blitManagedSurface(&surface, p);
 
 	Common::Rect dirtyRect = Common::Rect(p.x, p.y, p.x + surface.w, p.y + surface.h);
 	dirtyRect.clip(_clip);

--- a/gui/ThemeEngine.h
+++ b/gui/ThemeEngine.h
@@ -466,7 +466,7 @@ public:
 	void drawDropDownButton(const Common::Rect &r, uint32 dropdownWidth, const Common::U32String &str,
 	                        WidgetStateInfo buttonState, bool inButton, bool inDropdown, bool rtl = false);
 
-	void drawSurface(const Common::Point &p, const Graphics::ManagedSurface &surface, bool themeTrans = false);
+	void drawManagedSurface(const Common::Point &p, const Graphics::ManagedSurface &surface);
 
 	void drawSlider(const Common::Rect &r, int width, WidgetStateInfo state = kStateEnabled, bool rtl = false);
 

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -211,7 +211,6 @@ void LauncherDialog::build() {
 		_grpChooserDesc = nullptr;
 		_groupPic = new GraphicsWidget(this, _title + ".GroupPic", _("Select Group by"));
 		_groupPic->setGfxFromTheme(ThemeEngine::kImageGroup);
-		_groupPic->useThemeTransparency(true);
 	} else
 #endif
 		_grpChooserDesc = new StaticTextWidget(this, Common::String(_title + ".laGroupPopupDesc"), _("Group:"));
@@ -236,7 +235,6 @@ void LauncherDialog::build() {
 
 	if (g_gui.xmlEval()->getVar("Globals.ShowLauncherLogo") == 1 && g_gui.theme()->supportsImages()) {
 		_logo = new GraphicsWidget(this, _title + ".Logo");
-		_logo->useThemeTransparency(true);
 		_logo->setGfxFromTheme(ThemeEngine::kImageLogo);
 
 		new StaticTextWidget(this, _title + ".Version", Common::U32String(gScummVMVersionDate));
@@ -755,7 +753,6 @@ void LauncherDialog::reflowLayout() {
 
 		if (!_logo)
 			_logo = new GraphicsWidget(this, _title + ".Logo");
-		_logo->useThemeTransparency(true);
 		_logo->setGfxFromTheme(ThemeEngine::kImageLogo);
 	} else {
 		StaticTextWidget *ver = (StaticTextWidget *)findWidget(Common::String(_title + ".Version").c_str());
@@ -785,7 +782,6 @@ void LauncherDialog::reflowLayout() {
 		if (!_groupPic)
 			_groupPic = new GraphicsWidget(this, _title + ".GroupPic");
 		_groupPic->setGfxFromTheme(ThemeEngine::kImageGroup);
-		_groupPic->useThemeTransparency(true);
 
 		if (_grpChooserDesc) {
 			removeWidget(_grpChooserDesc);
@@ -854,8 +850,7 @@ ButtonWidget *LauncherDialog::createSwitchButton(const Common::String &name, con
 #ifndef DISABLE_FANCY_THEMES
 	if (g_gui.xmlEval()->getVar("Globals.ShowChooserPics") == 1 && g_gui.theme()->supportsImages()) {
 		button = new PicButtonWidget(this, name, tooltip, cmd);
-		((PicButtonWidget *)button)->useThemeTransparency(true);
-		((PicButtonWidget *)button)->setGfx(g_gui.theme()->getImageSurface(image), kPicButtonStateEnabled, false);
+		((PicButtonWidget *)button)->setGfxFromTheme(image, kPicButtonStateEnabled, false);
 	} else
 #endif
 		button = new ButtonWidget(this, name, desc, tooltip, cmd);

--- a/gui/onscreendialog.cpp
+++ b/gui/onscreendialog.cpp
@@ -62,36 +62,31 @@ OnScreenDialog::OnScreenDialog(bool isRecord) : Dialog("OnScreenDialog") {
 #ifndef DISABLE_FANCY_THEMES
 	if (g_gui.xmlEval()->getVar("Globals.OnScreenDialog.ShowPics") == 1 && g_gui.theme()->supportsImages()) {
 		GUI::PicButtonWidget *button;
-		button = new PicButtonWidget(this, "OnScreenDialog.StopButton", Common::U32String(), kStopCmd, 0);
-		button->useThemeTransparency(true);
 
+		button = new PicButtonWidget(this, "OnScreenDialog.StopButton", Common::U32String(), kStopCmd, 0);
 		if (g_system->getOverlayWidth() > 320)
-			button->setGfx(g_gui.theme()->getImageSurface(ThemeEngine::kImageStopButton));
+			button->setGfxFromTheme(ThemeEngine::kImageStopButton);
 		else
-			button->setGfx(g_gui.theme()->getImageSurface(ThemeEngine::kImageStopSmallButton));
+			button->setGfxFromTheme(ThemeEngine::kImageStopSmallButton);
 
 		if (isRecord) {
 			button = new PicButtonWidget(this, "OnScreenDialog.EditButton", Common::U32String(), kEditCmd, 0);
-			button->useThemeTransparency(true);
-
 			if (g_system->getOverlayWidth() > 320)
-				button->setGfx(g_gui.theme()->getImageSurface(ThemeEngine::kImageEditButton));
+				button->setGfxFromTheme(ThemeEngine::kImageEditButton);
 			else
-				button->setGfx(g_gui.theme()->getImageSurface(ThemeEngine::kImageEditSmallButton));
+				button->setGfxFromTheme(ThemeEngine::kImageEditSmallButton);
 		} else {
 			button = new PicButtonWidget(this, "OnScreenDialog.SwitchModeButton", Common::U32String(), kSwitchModeCmd, 0);
-			button->useThemeTransparency(true);
 			if (g_system->getOverlayWidth() > 320)
-				button->setGfx(g_gui.theme()->getImageSurface(ThemeEngine::kImageSwitchModeButton));
+				button->setGfxFromTheme(ThemeEngine::kImageSwitchModeButton);
 			else
-				button->setGfx(g_gui.theme()->getImageSurface(ThemeEngine::kImageSwitchModeSmallButton));
+				button->setGfxFromTheme(ThemeEngine::kImageSwitchModeSmallButton);
 
 			button = new PicButtonWidget(this, "OnScreenDialog.FastReplayButton", Common::U32String(), kFastModeCmd, 0);
-			button->useThemeTransparency(true);
 			if (g_system->getOverlayWidth() > 320)
-				button->setGfx(g_gui.theme()->getImageSurface(ThemeEngine::kImageFastReplayButton));
+				button->setGfxFromTheme(ThemeEngine::kImageFastReplayButton);
 			else
-				button->setGfx(g_gui.theme()->getImageSurface(ThemeEngine::kImageFastReplaySmallButton));
+				button->setGfxFromTheme(ThemeEngine::kImageFastReplaySmallButton);
 		}
 	} else
 #endif

--- a/gui/predictivedialog.cpp
+++ b/gui/predictivedialog.cpp
@@ -105,8 +105,7 @@ PredictiveDialog::PredictiveDialog() : Dialog("Predictive") {
 #ifndef DISABLE_FANCY_THEMES
 	if (g_gui.xmlEval()->getVar("Globals.Predictive.ShowDeletePic") == 1 && g_gui.theme()->supportsImages()) {
 		_button[kDelAct] = new PicButtonWidget(this, "Predictive.Delete", _("Delete char"), kDelCmd);
-		((PicButtonWidget *)_button[kDelAct])->useThemeTransparency(true);
-		((PicButtonWidget *)_button[kDelAct])->setGfx(g_gui.theme()->getImageSurface(ThemeEngine::kImageDelButton));
+		((PicButtonWidget *)_button[kDelAct])->setGfxFromTheme(ThemeEngine::kImageDelButton);
 	} else
 #endif
 		_button[kDelAct] = new ButtonWidget(this, "Predictive.Delete" , _("<") , Common::U32String(), kDelCmd);
@@ -182,8 +181,7 @@ void PredictiveDialog::reflowLayout() {
 
 	if (g_gui.xmlEval()->getVar("Globals.Predictive.ShowDeletePic") == 1 && g_gui.theme()->supportsImages()) {
 		_button[kDelAct] = new PicButtonWidget(this, "Predictive.Delete", _("Delete char"), kDelCmd);
-		((PicButtonWidget *)_button[kDelAct])->useThemeTransparency(true);
-		((PicButtonWidget *)_button[kDelAct])->setGfx(g_gui.theme()->getImageSurface(ThemeEngine::kImageDelButton));
+		((PicButtonWidget *)_button[kDelAct])->setGfxFromTheme(ThemeEngine::kImageDelButton);
 	} else {
 		_button[kDelAct] = new ButtonWidget(this, "Predictive.Delete" , _("<") , Common::U32String(), kDelCmd);
 	}

--- a/gui/recorderdialog.cpp
+++ b/gui/recorderdialog.cpp
@@ -81,7 +81,6 @@ RecorderDialog::RecorderDialog() : Dialog("RecorderDialog"), _list(nullptr), _cu
 	_playbackButton->setEnabled(false);
 
 	_gfxWidget = new GUI::GraphicsWidget(this, 0, 0, 10, 10);
-	_gfxWidget->useThemeTransparency(false);
 
 	addThumbnailContainerButtonsAndText();
 }

--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -392,8 +392,7 @@ ButtonWidget *SaveLoadChooserDialog::createSwitchButton(const Common::String &na
 #ifndef DISABLE_FANCY_THEMES
 	if (g_gui.xmlEval()->getVar("Globals.ShowChooserPics") == 1 && g_gui.theme()->supportsImages()) {
 		button = new PicButtonWidget(this, name, tooltip, cmd);
-		((PicButtonWidget *)button)->useThemeTransparency(true);
-		((PicButtonWidget *)button)->setGfx(g_gui.theme()->getImageSurface(image), kPicButtonStateEnabled, false);
+		((PicButtonWidget *)button)->setGfxFromTheme(image, kPicButtonStateEnabled, false);
 	} else
 #endif
 		button = new ButtonWidget(this, name, desc, tooltip, cmd);
@@ -447,7 +446,6 @@ SaveLoadChooserSimple::SaveLoadChooserSimple(const Common::U32String &title, con
 	_list->setEditable(saveMode);
 
 	_gfxWidget = new GraphicsWidget(this, 0, 0, 10, 10);
-	_gfxWidget->useThemeTransparency(false);
 
 	_date = new StaticTextWidget(this, 0, 0, 10, 10, _("No date saved"), Graphics::kTextAlignCenter);
 	_time = new StaticTextWidget(this, 0, 0, 10, 10, _("No time saved"), Graphics::kTextAlignCenter);
@@ -1052,7 +1050,6 @@ void SaveLoadChooserGrid::reflowLayout() {
 			}
 
 			PicButtonWidget *button = new PicButtonWidget(container, dstX, dstY, buttonWidth, buttonHeight, Common::U32String(), buttonCmd);
-			button->useThemeTransparency(false);
 			dstY += buttonHeight;
 
 			StaticTextWidget *description = new StaticTextWidget(container, dstX, dstY, buttonWidth, kLineHeight, Common::String(), Graphics::kTextAlignStart);

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -448,7 +448,6 @@ ButtonWidget *addClearButton(GuiObject *boss, const Common::String &name, uint32
 			button = new PicButtonWidget(boss, name, _("Clear value"), cmd);
 		else
 			button = new PicButtonWidget(boss, x, y, w, h, scale, _("Clear value"), cmd);
-		((PicButtonWidget *)button)->useThemeTransparency(true);
 		((PicButtonWidget *)button)->setGfxFromTheme(ThemeEngine::kImageEraser, kPicButtonStateEnabled, false);
 	} else
 #endif
@@ -611,7 +610,7 @@ const Graphics::ManagedSurface *scaleGfx(const Graphics::ManagedSurface *gfx, in
 
 PicButtonWidget::PicButtonWidget(GuiObject *boss, int x, int y, int w, int h, bool scale, const Common::U32String &tooltip, uint32 cmd, uint8 hotkey)
 	: ButtonWidget(boss, x, y, w, h, scale, Common::U32String(), tooltip, cmd, hotkey),
-	  _alpha(255), _transparency(false), _showButton(true) {
+	  _showButton(true) {
 
 	setFlags(WIDGET_ENABLED/* | WIDGET_BORDER*/ | WIDGET_CLEARBG);
 	_type = kButtonWidget;
@@ -623,7 +622,7 @@ PicButtonWidget::PicButtonWidget(GuiObject *boss, int x, int y, int w, int h, co
 
 PicButtonWidget::PicButtonWidget(GuiObject *boss, const Common::String &name, const Common::U32String &tooltip, uint32 cmd, uint8 hotkey)
 	: ButtonWidget(boss, name, Common::U32String(), tooltip, cmd, hotkey),
-	  _alpha(255), _transparency(false), _showButton(true) {
+	  _showButton(true) {
 	setFlags(WIDGET_ENABLED/* | WIDGET_BORDER*/ | WIDGET_CLEARBG);
 	_type = kButtonWidget;
 }
@@ -711,7 +710,7 @@ void PicButtonWidget::drawWidget() {
 		const int x = _x + (_w - gfx->w) / 2;
 		const int y = _y + (_h - gfx->h) / 2;
 
-		g_gui.theme()->drawSurface(Common::Point(x, y), *gfx, _transparency);
+		g_gui.theme()->drawManagedSurface(Common::Point(x, y), *gfx);
 	}
 }
 
@@ -929,7 +928,7 @@ int SliderWidget::posToValue(int pos) {
 #pragma mark -
 
 GraphicsWidget::GraphicsWidget(GuiObject *boss, int x, int y, int w, int h, bool scale, const Common::U32String &tooltip)
-	: Widget(boss, x, y, w, h, scale, tooltip), _gfx(), _alpha(255), _transparency(false) {
+	: Widget(boss, x, y, w, h, scale, tooltip), _gfx() {
 	setFlags(WIDGET_ENABLED | WIDGET_CLEARBG);
 	_type = kGraphicsWidget;
 }
@@ -939,7 +938,7 @@ GraphicsWidget::GraphicsWidget(GuiObject *boss, int x, int y, int w, int h, cons
 }
 
 GraphicsWidget::GraphicsWidget(GuiObject *boss, const Common::String &name, const Common::U32String &tooltip)
-	: Widget(boss, name, tooltip), _gfx(), _alpha(255), _transparency(false) {
+	: Widget(boss, name, tooltip), _gfx() {
 	setFlags(WIDGET_ENABLED | WIDGET_CLEARBG);
 	_type = kGraphicsWidget;
 }
@@ -1015,7 +1014,7 @@ void GraphicsWidget::drawWidget() {
 		const int x = _x + (_w - _gfx.w) / 2;
 		const int y = _y + (_h - _gfx.h) / 2;
 
-		g_gui.theme()->drawSurface(Common::Point(x, y), _gfx, _transparency);
+		g_gui.theme()->drawManagedSurface(Common::Point(x, y), _gfx);
 	}
 }
 

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -309,16 +309,12 @@ public:
 	void setGfxFromTheme(const char *name, int statenum = kPicButtonStateEnabled, bool scale = true);
 	void setGfx(int w, int h, int r, int g, int b, int statenum = kPicButtonStateEnabled);
 
-	void useAlpha(int alpha) { _alpha = alpha; }
-	void useThemeTransparency(bool enable) { _transparency = enable; }
 	void setButtonDisplay(bool enable) {_showButton = enable; }
 
 protected:
 	void drawWidget() override;
 
 	Graphics::ManagedSurface _gfx[kPicButtonStateMax + 1];
-	int _alpha;
-	bool _transparency;
 	bool _showButton;
 };
 
@@ -450,15 +446,10 @@ public:
 	void setGfx(int w, int h, int r, int g, int b);
 	void setGfxFromTheme(const char *name);
 
-	void useAlpha(int alpha) { _alpha = alpha; }
-	void useThemeTransparency(bool enable) { _transparency = enable; }
-
 protected:
 	void drawWidget() override;
 
 	Graphics::ManagedSurface _gfx;
-	int _alpha;
-	bool _transparency;
 };
 
 /* ContainerWidget */

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -119,14 +119,14 @@ void GridItemWidget::drawWidget() {
 			r.translate(0, kLineHeight);
 		}
 	} else {
-		g_gui.theme()->drawSurface(Common::Point(_x, _y), _thumbGfx, true);
+		g_gui.theme()->drawManagedSurface(Common::Point(_x, _y), _thumbGfx);
 	}
 
 	// Draw Platform Icon
 	const Graphics::ManagedSurface *platGfx = _grid->platformToSurface(_activeEntry->platform);
 	if (platGfx) {
 		Common::Point p(_x + thumbWidth - platGfx->w, _y + thumbHeight - platGfx->h);
-		g_gui.theme()->drawSurface(p, *platGfx, true);
+		g_gui.theme()->drawManagedSurface(p, *platGfx);
 	}
 
 	// Draw Flag
@@ -135,14 +135,14 @@ void GridItemWidget::drawWidget() {
 		// SVG and PNG can resize differently so it's better to use thumbWidth as reference to
 		// ensure all flags are aligned
 		Common::Point p(_x + thumbWidth - (thumbWidth / 5), _y + 5);
-		g_gui.theme()->drawSurface(p, *flagGfx, true);
+		g_gui.theme()->drawManagedSurface(p, *flagGfx);
 	}
 
 	// Draw Demo Overlay
 	const Graphics::ManagedSurface *demoGfx = _grid->demoToSurface(_activeEntry->extra);
 	if (demoGfx) {
 		Common::Point p(_x, _y);
-		g_gui.theme()->drawSurface(p, *demoGfx, true);
+		g_gui.theme()->drawManagedSurface(p, *demoGfx);
 	}
 
 	bool validEntry = _activeEntry->validEntry;
@@ -152,7 +152,7 @@ void GridItemWidget::drawWidget() {
 		const Graphics::ManagedSurface *darkenGfx = _grid->disabledThumbnail();
 		if (darkenGfx) {
 			Common::Point p(_x, _y);
-			g_gui.theme()->drawSurface(p, *darkenGfx, true);
+			g_gui.theme()->drawManagedSurface(p, *darkenGfx);
 		}
 	}
 
@@ -246,10 +246,6 @@ GridItemTray::GridItemTray(GuiObject *boss, int x, int y, int w, int h, int entr
 	_editButton = new PicButtonWidget(this, trayPaddingX + buttonWidth + buttonSpacingX, trayPaddingY + buttonHeight + buttonSpacingY,
 									  buttonWidth, buttonHeight,
 									  _("Edit"), kEditButtonCmd);
-
-	_playButton->useThemeTransparency(true);
-	_loadButton->useThemeTransparency(true);
-	_editButton->useThemeTransparency(true);
 }
 
 void GridItemTray::reflowLayout() {


### PR DESCRIPTION
By doing this, we can assume that colour keys and alpha channels are mutually exclusive, which allows for future optimisation.