### PR TITLE
MOHAWK: RIVEN: Fix autosave on exit during cutscene

### DIFF
--- a/engines/mohawk/riven.cpp
+++ b/engines/mohawk/riven.cpp
@@ -201,9 +201,6 @@ Common::Error MohawkEngine_Riven::run() {
 	while (!hasGameEnded())
 		doFrame();
 
-	// Attempt to autosave before exiting from the GMM / when closing the window
-	saveAutosaveIfEnabled();
-
 	return Common::kNoError;
 }
 
@@ -218,6 +215,11 @@ void MohawkEngine_Riven::doFrame() {
 	}
 
 	processInput();
+	
+	if (hasGameEnded()) {
+		// Attempt to autosave before exiting
+		saveAutosaveIfEnabled();
+	}
 
 	_stack->onFrame();
 

--- a/engines/mohawk/riven.cpp
+++ b/engines/mohawk/riven.cpp
@@ -215,7 +215,7 @@ void MohawkEngine_Riven::doFrame() {
 	}
 
 	processInput();
-	
+
 	_stack->onFrame();
 
 	if (!_scriptMan->runningQueuedScripts()) {

--- a/engines/mohawk/riven.cpp
+++ b/engines/mohawk/riven.cpp
@@ -216,11 +216,6 @@ void MohawkEngine_Riven::doFrame() {
 
 	processInput();
 	
-	if (hasGameEnded()) {
-		// Attempt to autosave before exiting
-		saveAutosaveIfEnabled();
-	}
-
 	_stack->onFrame();
 
 	if (!_scriptMan->runningQueuedScripts()) {
@@ -285,6 +280,11 @@ void MohawkEngine_Riven::processInput() {
 				} else if (!isGameVariant(GF_25TH)) {
 					openMainMenuDialog();
 				}
+					
+				if (!isGameVariant(GF_DEMO) && hasGameEnded()) {
+					// Attempt to autosave before exiting
+					saveAutosaveIfEnabled();
+				}	
 				break;
 			case kRivenActionPlayIntroVideos:
 				// Play the intro videos in the demo
@@ -308,6 +308,11 @@ void MohawkEngine_Riven::processInput() {
 				_stack->onAction((RivenAction)event.customType);
 				break;
 			}
+			break;
+		case Common::EVENT_QUIT:
+		case Common::EVENT_RETURN_TO_LAUNCHER:
+			// Attempt to autosave before exiting
+			saveAutosaveIfEnabled();
 			break;
 		default:
 			break;


### PR DESCRIPTION
An issue exists where an autosave is performed when exiting the game during a cutscene, even though normal saving is disabled at this time.

When exiting the game during a cutscene, the game skips ahead to the first interactive frame outside the cutscene, then completes the exit.

Currently, the autosave is called after this change to the game state, creating the opportunity to complete an unexpected save that skips the unseen portion of the cutscene.

Fixed by repositioning the saveAutosaveIfEnabled() call to a position before the game state is changed, ensuring the autosave is always attempted based on the game state, and save condition, existing at the time the exit call is initiated.

In this example, the autosave fails to complete, as expected.

Fixes bug [11440](https://bugs.scummvm.org/ticket/11440).