### PR TITLE
TETRAEDGE: Do not call quitGame() when receiving a QUIT or RTL event

### DIFF
--- a/engines/tetraedge/te/te_input_mgr.cpp
+++ b/engines/tetraedge/te/te_input_mgr.cpp
@@ -59,10 +59,6 @@ void TeInputMgr::handleEvent(const Common::Event &e) {
 		case Common::EVENT_MAINMENU:
 			g_engine->getGame()->_returnToMainMenu = true;
 			break;
-		case Common::EVENT_RETURN_TO_LAUNCHER:
-		case Common::EVENT_QUIT:
-			g_engine->quitGame();
-			break;
 		default:
 			break;
 	}

--- a/engines/tetraedge/tetraedge.h
+++ b/engines/tetraedge/tetraedge.h
@@ -98,7 +98,8 @@ public:
 			(f == kSupportsLoadingDuringRuntime) ||
 			(f == kSupportsSavingDuringRuntime) ||
 			(f == kSupportsReturnToLauncher) ||
-			(f == kSupportsChangingOptionsDuringRuntime);
+			(f == kSupportsChangingOptionsDuringRuntime) ||
+			(f == kSupportsQuitDialogOverride);
 	};
 
 	bool canLoadGameStateCurrently() override;


### PR DESCRIPTION
The only thing that quitGame() does is to send a new QUIT event, but  we already have one. So this is unnecessary. Furthermore this causes  an infinite loop in the case of a RTL event if the option to return to the launcher on quit is on. Indeed  DefaultEventManager::pushEvent() has a check in the case of a EVENT_QUIT to ignore it if it already received one, which avoids the infinite loop, unless the EVENT_QUIT are converted to RTL events.

This fixes bug [#14328](https://bugs.scummvm.org/ticket/14328) and [#14329](https://bugs.scummvm.org/ticket/14329).

I checked that the games still quits properly with all known way to quit a game:
 - The in-game menu.
 - Using CMD+Q (on macOS).
 - Using the `Quit ScummVM` menu item in the ScummVM menu (on macOS).
 - Using the close button in the Window title bar.
 - Using the GMM.

This pull request also includes a separate commit to not show the ScummVM quit confirmation dialog if `Ask for confirmation on exit` is on in the ScummVM options. Indeed that option does not work with at least Syberia and Syberia 2 (and furthermore Syberia has its own confirmation dialog).