### PR TITLE
SCUMM HE: BYB '01 online mod: allow forced runner turnaround

### DIFF
--- a/engines/scumm/he/script_v72he.cpp
+++ b/engines/scumm/he/script_v72he.cpp
@@ -173,6 +173,23 @@ int ScummEngine_v72he::readArray(int array, int idx2, int idx1) {
 			  FROM_LE_32(ah->dim2start), FROM_LE_32(ah->dim2end));
 	}
 
+#if defined(USE_ENET) && defined(USE_LIBCURL)
+	if (ConfMan.getBool("enable_competitive_mods")) {
+		// Mod for Backyard Baseball 2001 online competitive play: allow baserunners to be
+		// turned around while they're jogging to the next base on a pop-up.
+		// The game checks if the runner is forced to the next base (i.e. there's a runner on the base behind them),
+		// and if they are then basepath clicks to turn them around have no effect.
+		// Here we return 0 (false) no matter what, so these clicks now have the desired effect.
+		if (_game.id == GID_BASEBALL2001 &&
+			_currentRoom == 3 && vm.slot[_currentScript].number == 2076 &&  // This is the script that handles basepath clicks
+			readVar(399) == 1 &&  // This checks that we're playing online
+			// This is the array of baserunner status info, and the value in position 8 specifies whether the runner is forced
+			array == 295 && idx1 == 8) {
+			return 0;
+		}
+	}
+#endif
+
 	const int offset = (FROM_LE_32(ah->dim1end) - FROM_LE_32(ah->dim1start) + 1) *
 		(idx2 - FROM_LE_32(ah->dim2start)) + (idx1 - FROM_LE_32(ah->dim1start));
 

--- a/engines/scumm/he/script_v72he.cpp
+++ b/engines/scumm/he/script_v72he.cpp
@@ -179,10 +179,13 @@ int ScummEngine_v72he::readArray(int array, int idx2, int idx1) {
 		// turned around while they're jogging to the next base on a pop-up.
 		// The game checks if the runner is forced to the next base (i.e. there's a runner on the base behind them),
 		// and if they are then basepath clicks to turn them around have no effect.
-		// Here we return 0 (false) no matter what, so these clicks now have the desired effect.
+		// Here we return 0 (false) under certain conditions, so these clicks now have the desired effect.
 		if (_game.id == GID_BASEBALL2001 &&
 			_currentRoom == 3 && vm.slot[_currentScript].number == 2076 &&  // This is the script that handles basepath clicks
 			readVar(399) == 1 &&  // This checks that we're playing online
+			readVar(0x8000 + 11) == 1 &&  // The ball is a pop-up
+			readVar(291) < 2 &&  // Less than two outs
+			readVar(300) == 0 &&  // Ball hasn't bounced
 			// This is the array of baserunner status info, and the value in position 8 specifies whether the runner is forced
 			array == 295 && idx1 == 8) {
 			return 0;


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
This is probably the first of a few PRs that will add small mods for competitive online play for Backyard Baseball 2001. They'll all be behind `if (ConfMan.getBool("enable_competitive_mods")) {` and other checks so that they apply only when the user is playing online and has the competitive play mods option enabled.

This mod is somewhat of a quality-of-life change, as it eliminates a frustrating in-game experience. The most common case of this is: a weak pop-up is hit with a runner on first base. The game automatically "jogs" this baserunner towards second base at half speed. The user cannot return the runner to first base, because they're technically [forced](https://en.wikipedia.org/wiki/Force_play) and the game's logic doesn't allow this (dictated in room 3 script 2076). The ball is then caught and thrown to first base for a double play before the runner can return. [This video](https://streamable.com/ds7s9p) shows this case, where I'm clicking to try to turn the runner around to no avail.

With this change, these runners can be turned around in this specific situation.