### PR TITLE
KEYMAPPER: Allow multiple inputs bound to a keymap action as defaults

### DIFF
--- a/backends/keymapper/keymap.cpp
+++ b/backends/keymapper/keymap.cpp
@@ -256,19 +256,13 @@ StringArray Keymap::getActionDefaultMappings(Action *action) {
 	if (_backendDefaultBindings) {
 		KeymapperDefaultBindings::const_iterator it = _backendDefaultBindings->findDefaultBinding(_id, action->id);
 		if (it != _backendDefaultBindings->end()) {
-			if (it->_value.empty()) {
-				return StringArray();
-			}
-			return StringArray(1, it->_value);
+			return it->_value;
 		}
 
 		// If no keymap-specific default mapping was found, look for a standard action binding
 		it = _backendDefaultBindings->findDefaultBinding(kStandardActionsKeymapName, action->id);
 		if (it != _backendDefaultBindings->end()) {
-			if (it->_value.empty()) {
-				return StringArray();
-			}
-			return StringArray(1, it->_value);
+			return it->_value;
 		}
 	}
 

--- a/backends/keymapper/keymapper-defaults.h
+++ b/backends/keymapper/keymapper-defaults.h
@@ -29,7 +29,7 @@
 
 namespace Common {
 
-class KeymapperDefaultBindings : public HashMap<String, String> {
+class KeymapperDefaultBindings : public HashMap<String, StringArray> {
 public:
 	/**
 	 * This sets a default hwInput for a given Keymap Action
@@ -37,12 +37,42 @@ public:
 	 * @param actionId String representing Action id (Action.id)
 	 * @param hwInputId String representing the HardwareInput id (HardwareInput.id)
 	 */
-	void setDefaultBinding(String keymapId, String actionId, String hwInputId) { setVal(keymapId + "_" + actionId, hwInputId); }
+	void setDefaultBinding(String keymapId, String actionId, String hwInputId) {
+		setVal(keymapId + "_" + actionId, hwInputId.empty() ? StringArray() : StringArray(1, hwInputId));
+	}
+
+	/**
+	* This adds a default hwInput for a given Keymap Action
+	* @param keymapId String representing Keymap id (Keymap.name)
+	* @param actionId String representing Action id (Action.id)
+	* @param hwInputId String representing the HardwareInput id (HardwareInput.id)
+	*/
+	void addDefaultBinding(String keymapId, String actionId, String hwInputId) {
+		// NOTE: addDefaultBinding() cannot be used to remove bindings;
+		// use setDefaultBinding() with a nullptr or empty string as hwInputId instead.
+		if (hwInputId.empty()) {
+			return;
+		}
+
+		KeymapperDefaultBindings::iterator it = findDefaultBinding(keymapId, actionId);
+		if (it != end()) {
+			// Don't allow an input to map to the same action multiple times
+			StringArray& itv = it->_value;
+
+			Array<String>::const_iterator found = Common::find(itv.begin(), itv.end(), hwInputId);
+			if (found == itv.end()) {
+				itv.push_back(hwInputId);
+			}
+		} else {
+			setDefaultBinding(keymapId, actionId, hwInputId);
+		}
+	}
+
 	/**
 	 * This retrieves the assigned default hwKey for a given Keymap Action
 	 * @param keymapId String representing Keymap id (Keymap.name)
 	 * @param actionId String representing Action id (Action.id)
-	 * @return String representing the HardwareInput id (HardwareInput.id)
+	 * @return StringArray representing the list of HardwareInput ids (HardwareInput.id) that are mapped to Keymap Action
 	 */
 	const_iterator findDefaultBinding(String keymapId, String actionId) const {
 		return find(keymapId + "_" + actionId);

--- a/backends/keymapper/keymapper-defaults.h
+++ b/backends/keymapper/keymapper-defaults.h
@@ -57,7 +57,7 @@ public:
 		KeymapperDefaultBindings::iterator it = findDefaultBinding(keymapId, actionId);
 		if (it != end()) {
 			// Don't allow an input to map to the same action multiple times
-			StringArray& itv = it->_value;
+			StringArray &itv = it->_value;
 
 			Array<String>::const_iterator found = Common::find(itv.begin(), itv.end(), hwInputId);
 			if (found == itv.end()) {


### PR DESCRIPTION
This allows backeds to override a keymap action mapping with lists of mapped hardware inputs instead of just one hardware input id

However, it will still be an overridding, so it will require all hardware input ids for a given keymap action to be added. In other words, if a backend uses addDefaultBinding() for a given action, it will not ADD to any existing mappings of the action, other than the ones that the backend itself has added (with addDefaultBinding())

Pros: Extended functionality, resolves an issue with Android controller devices (virtual mouse movement needing to be mapped to DPAD directional keys and (left) joystick movements).

Cons: Adds complexity to the implementation, and does not keep any mappings to an action that are set elsewhere -- it still overrides the mappings with new ones added using addDefaultBinding().

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
