### PR TITLE
IMAGE: Fix MSRLEDecoder if pitch > width

### DIFF
--- a/image/codecs/msrle.cpp
+++ b/image/codecs/msrle.cpp
@@ -55,9 +55,10 @@ void MSRLEDecoder::decode8(Common::SeekableReadStream &stream) {
 	byte *data = (byte *) _surface->getPixels();
 	uint16 width  = _surface->w;
 	uint16 height = _surface->h;
+	uint16 pitch = _surface->pitch;
 
-	byte *output     = data + ((height - 1) * width);
-	byte *output_end = data + ((height)     * width);
+	byte *output     = data + ((height - 1) * pitch);
+	byte *output_end = data + ((height)     * pitch) - (pitch - width);
 
 	while (!stream.eos()) {
 		byte count = stream.readByte();
@@ -69,7 +70,7 @@ void MSRLEDecoder::decode8(Common::SeekableReadStream &stream) {
 
 				x = 0;
 				y--;
-				output = data + (y * width);
+				output = data + (y * pitch);
 
 			} else if (value == 1) {
 				// End of image
@@ -89,7 +90,7 @@ void MSRLEDecoder::decode8(Common::SeekableReadStream &stream) {
 					return;
 				}
 
-				output = data + ((y * width) + x);
+				output = data + ((y * pitch) + x);
 
 			} else {
 				// Copy data


### PR DESCRIPTION
Fixes [14356](https://bugs.scummvm.org/ticket/14356).

It's possible that there's more bugs like this but I can't test it as this was the first occasion where I saw something corrupted.

For instance `MSRLE4Decoder::decode4` uses a slightly inefficient but safe `getBasePtr(x, y)` (which implicitly uses surface pitch) but I think this line:

`byte *output_end = (byte *)_surface->getBasePtr(_surface->w, y);`

is wrong -- technically speaking, nothing will be written past the allocated memory but the algorithm is writing past `width` pixels in the unused surface area. 