### PR TITLE
NUVIE: Fix Ultima 6 projectile collision

### DIFF
--- a/engines/ultima/nuvie/core/map.h
+++ b/engines/ultima/nuvie/core/map.h
@@ -187,7 +187,7 @@ public:
 	const char *look(uint16 x, uint16 y, uint8 level);
 
 	bool lineTest(int start_x, int start_y, int end_x, int end_y, uint8 level,
-	              uint8 flags, LineTestResult &Result, uint32 skip = 0, Obj *excluded_obj = NULL); // excluded_obj only works for LT_HitUnpassable
+	              uint8 flags, LineTestResult &Result, uint32 skip = 0, Obj *excluded_obj = NULL, bool want_screen_space = false); // excluded_obj only works for LT_HitUnpassable
 
 	bool testIntersection(int x, int y, uint8 level, uint8 flags, LineTestResult &Result, Obj *excluded_obj = NULL); // excluded_obj only works for LT_HitUnpassable
 

--- a/engines/ultima/nuvie/script/script.cpp
+++ b/engines/ultima/nuvie/script/script.cpp
@@ -3168,7 +3168,7 @@ static int nscript_map_line_hit_check(lua_State *L) {
 	uint8 level = (uint8) luaL_checkinteger(L, 5);
 
 	//FIXME world wrapping for MD
-	if (map->lineTest(x, y, x1, y1, level, LT_HitMissileBoundary, result)) {
+	if (map->lineTest(x, y, x1, y1, level, LT_HitMissileBoundary, result, 0, NULL, true)) {
 		lua_pushinteger(L, result.hit_x);
 		lua_pushinteger(L, result.hit_y);
 	} else {


### PR DESCRIPTION
Make the line drawing algorithm used in projectile collision detection operate in screen space to match the original game.

Before this change the calculation was done in tile space, which caused incorrect results.

Note that the modified method Map::lineTest() is also used in other parts of the code unrelated to projectiles. Regressions are possible. If it breaks anything projectiles might need to be handled separately.

To reproduce the incorrect behavior :
1. Get a ranged weapon (e.g. Iolos crossbow)
2. Stand directly left of the SW pillar S of the throne room
3. Attack tiles/targets to the NE

In the original game the pillar will block the shots.