### PR TITLE
BASE: Add default extrapath and themepahth when running in tree

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -1965,6 +1965,20 @@ bool processSettings(Common::String &command, Common::StringMap &settings, Commo
 		ConfMan.set(key, value, useSessionDomain ? Common::ConfigManager::kSessionDomain : Common::ConfigManager::kTransientDomain);
 	}
 
+	// In non-release builds, if themepath and extrapath are not defined yet, add them to the session path so that it works out
+	// of the box when building and running in tree.
+#if !defined(RELEASE_BUILD) && !defined(WIN32)
+	#define ADD_DEFAULT_PATH(key, path) \
+		if (!ConfMan.hasKey(key)) { \
+			Common::FSNode node(path); \
+			if (node.exists() && node.isDirectory() && node.isReadable()) \
+				ConfMan.set(key, path, Common::ConfigManager::kSessionDomain); \
+		}
+
+	ADD_DEFAULT_PATH("themepath", "gui/themes/")
+	ADD_DEFAULT_PATH("extrapath", "dists/engine-data/")
+#endif
+
 	return false;
 }
 


### PR DESCRIPTION
This means building and running scummvm in tree works out of the box.

Unfortnatelly registering them as defaults would not work as ConfMan::hasKey() returns false when only defined as a default, and in most places this is checked before using those paths. So if we wanted to use defaults we would need to replace all those checks with a check that the path is not empty.

There is a drawback to using the session domain though: it takes priority over all other domains. So a custom extrapath defined for a game will be ignored. I tried to mitigate the issue by only adding those path if they exist(so that it does not break shadow builds for example). I am not sure if this is a big issue or not. I suspect it could be an issue for example when using munt for some games and a custom extrapath for those games to point to the MT32 rom files. There is a workaround that is to explicitly set an extrapath in the global settings so that it is not added to the session settings, but it is not obvious.

So I propose this as a pull request so that the benefit and drawbacks can be discussed and weighted.