### PR TITLE
GUI: Allow scaling dialog and widget sizes in constructors

### DIFF
--- a/engines/testbed/config.cpp
+++ b/engines/testbed/config.cpp
@@ -175,8 +175,7 @@ void TestbedInteractionDialog::addText(uint w, uint h, const Common::String text
 		xOffset = _xOffset;
 	}
 	_yOffset += yPadding;
-	GUI::StaticTextWidget *widget = new GUI::StaticTextWidget(this, xOffset, _yOffset, w, h, text, textAlign);
-	widget->resize(xOffset, _yOffset, w, h);
+	new GUI::StaticTextWidget(this, xOffset, _yOffset, w, h, true, text, textAlign);
 	_yOffset += h;
 }
 
@@ -185,24 +184,21 @@ void TestbedInteractionDialog::addButton(uint w, uint h, const Common::String na
 		xOffset = _xOffset;
 	}
 	_yOffset += yPadding;
-	_buttonArray.push_back(new GUI::ButtonWidget(this, xOffset, _yOffset, w, h, name, Common::U32String(), cmd));
-	_buttonArray.back()->resize(xOffset, _yOffset, w, h);
+	_buttonArray.push_back(new GUI::ButtonWidget(this, xOffset, _yOffset, w, h, true, name, Common::U32String(), cmd));
 	_yOffset += h;
 }
 
 void TestbedInteractionDialog::addList(uint x, uint y, uint w, uint h, const Common::Array<Common::U32String> &strArray, uint yPadding) {
 	_yOffset += yPadding;
-	GUI::ListWidget *list = new GUI::ListWidget(this, x, y, w, h);
-	list->resize(x, y, w, h);
+	GUI::ListWidget *list = new GUI::ListWidget(this, x, y, w, h, true);
 	list->setEditable(false);
 	list->setNumberingMode(GUI::kListNumberingOff);
 	list->setList(strArray);
 	_yOffset += h;
 }
 
-void TestbedInteractionDialog::addButtonXY(uint x, uint y, uint w, uint h, const Common::String name, uint32 cmd) {
-	_buttonArray.push_back(new GUI::ButtonWidget(this, x, _yOffset, w, h, name, Common::U32String(), cmd));
-	_buttonArray.back()->resize(x, y, w, h);
+void TestbedInteractionDialog::addButtonXY(uint x, uint /*y*/, uint w, uint h, const Common::String name, uint32 cmd) {
+	_buttonArray.push_back(new GUI::ButtonWidget(this, x, _yOffset, w, h, true, name, Common::U32String(), cmd));
 }
 
 void TestbedInteractionDialog::handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) {

--- a/engines/testbed/config.h
+++ b/engines/testbed/config.h
@@ -89,7 +89,7 @@ private:
 
 class TestbedInteractionDialog : public GUI::Dialog {
 public:
-	TestbedInteractionDialog(uint x, uint y, uint w, uint h) : GUI::Dialog(x, y, w, h), _xOffset(0), _yOffset(0) {}
+	TestbedInteractionDialog(uint x, uint y, uint w, uint h) : GUI::Dialog(x, y, w, h, true), _xOffset(0), _yOffset(0) {}
 	~TestbedInteractionDialog() override {}
 	void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) override;
 	void addButton(uint w, uint h, const Common::String name, uint32 cmd, uint xOffset = 0, uint yPadding = 8);

--- a/gui/dialog.cpp
+++ b/gui/dialog.cpp
@@ -37,8 +37,8 @@ namespace GUI {
  * ...
  */
 
-Dialog::Dialog(int x, int y, int w, int h)
-	: GuiObject(x, y, w, h),
+Dialog::Dialog(int x, int y, int w, int h, bool scale)
+	: GuiObject(x, y, w, h, scale),
 	  _mouseWidget(nullptr), _focusedWidget(nullptr), _dragWidget(nullptr), _tickleWidget(nullptr), _visible(false),
 	_backgroundType(GUI::ThemeEngine::kDialogBackgroundDefault) {
 	// Some dialogs like LauncherDialog use internally a fixed size, even though

--- a/gui/dialog.h
+++ b/gui/dialog.h
@@ -68,7 +68,7 @@ private:
 	int		_result;
 
 public:
-	Dialog(int x, int y, int w, int h);
+	Dialog(int x, int y, int w, int h, bool scale = false);
 	Dialog(const Common::String &name);
 
 	virtual int runModal();

--- a/gui/object.cpp
+++ b/gui/object.cpp
@@ -30,11 +30,18 @@ namespace GUI {
 
 #define SCALEVALUE(val) (val > 0 ? val * g_gui.getScaleFactor() : val)
 
-GuiObject::GuiObject(int x, int y, int w, int h) : _useRTL(true), _firstWidget(nullptr) {
-	_x = x;
-	_y = y;
-	_w = w;
-	_h = h;
+GuiObject::GuiObject(int x, int y, int w, int h, bool scale) : _useRTL(true), _firstWidget(nullptr) {
+	if (scale) {
+		_x = SCALEVALUE(x);
+		_y = SCALEVALUE(y);
+		_w = SCALEVALUE(w);
+		_h = SCALEVALUE(h);
+	} else {
+		_x = x;
+		_y = y;
+		_w = w;
+		_h = h;
+	}
 }
 
 GuiObject::GuiObject(const Common::String &name)

--- a/gui/object.h
+++ b/gui/object.h
@@ -70,7 +70,7 @@ protected:
 	Widget		*_firstWidget;
 
 public:
-	GuiObject(int x, int y, int w, int h);
+	GuiObject(int x, int y, int w, int h, bool scale = false);
 	GuiObject(const Common::String &name);
 	~GuiObject() override;
 

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -114,6 +114,7 @@ public:
 	static bool containsWidgetInChain(Widget *start, Widget *search);
 
 public:
+	Widget(GuiObject *boss, int x, int y, int w, int h, bool scale, const Common::U32String &tooltip = Common::U32String());
 	Widget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &tooltip = Common::U32String());
 	Widget(GuiObject *boss, const Common::String &name, const Common::U32String &tooltip = Common::U32String());
 	~Widget() override;
@@ -205,6 +206,7 @@ protected:
 	bool _useEllipsis;
 
 public:
+	StaticTextWidget(GuiObject *boss, int x, int y, int w, int h, bool scale, const Common::U32String &text, Graphics::TextAlign align, const Common::U32String &tooltip = Common::U32String(), ThemeEngine::FontStyle font = ThemeEngine::kFontStyleBold, Common::Language lang = Common::UNK_LANG, bool useEllipsis = true);
 	StaticTextWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &text, Graphics::TextAlign align, const Common::U32String &tooltip = Common::U32String(), ThemeEngine::FontStyle font = ThemeEngine::kFontStyleBold, Common::Language lang = Common::UNK_LANG, bool useEllipsis = true);
 	StaticTextWidget(GuiObject *boss, const Common::String &name, const Common::U32String &text, const Common::U32String &tooltip = Common::U32String(), ThemeEngine::FontStyle font = ThemeEngine::kFontStyleBold, Common::Language lang = Common::UNK_LANG, bool useEllipsis = true);
 	void setValue(int value);
@@ -231,6 +233,7 @@ protected:
 	uint8	_lowresHotkey;
 	Common::U32String _lowresLabel;
 public:
+	ButtonWidget(GuiObject *boss, int x, int y, int w, int h, bool scale, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0, const Common::U32String &lowresLabel = Common::U32String());
 	ButtonWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0, const Common::U32String &lowresLabel = Common::U32String());
 	ButtonWidget(GuiObject *boss, const Common::String &name, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0, const Common::U32String &lowresLabel = Common::U32String());
 
@@ -260,6 +263,7 @@ protected:
 /* DropdownButtonWidget */
 class DropdownButtonWidget : public ButtonWidget {
 public:
+	DropdownButtonWidget(GuiObject *boss, int x, int y, int w, int h, bool scale, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0, const Common::U32String &lowresLabel = Common::U32String());
 	DropdownButtonWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0, const Common::U32String &lowresLabel = Common::U32String());
 	DropdownButtonWidget(GuiObject *boss, const Common::String &name, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0, const Common::U32String &lowresLabel = Common::U32String());
 
@@ -295,6 +299,7 @@ protected:
 /* PicButtonWidget */
 class PicButtonWidget : public ButtonWidget {
 public:
+	PicButtonWidget(GuiObject *boss, int x, int y, int w, int h, bool scale, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0);
 	PicButtonWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0);
 	PicButtonWidget(GuiObject *boss, const Common::String &name, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0);
 	~PicButtonWidget() override;
@@ -324,6 +329,7 @@ protected:
 	bool _overrideText; 
 	int _spacing;
 public:
+	CheckboxWidget(GuiObject *boss, int x, int y, int w, int h, bool scale, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0);
 	CheckboxWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0);
 	CheckboxWidget(GuiObject *boss, const Common::String &name, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint8 hotkey = 0);
 
@@ -373,6 +379,7 @@ protected:
 	int _value;
 
 public:
+	RadiobuttonWidget(GuiObject *boss, int x, int y, int w, int h, bool scale, RadiobuttonGroup *group, int value, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint8 hotkey = 0);
 	RadiobuttonWidget(GuiObject *boss, int x, int y, int w, int h, RadiobuttonGroup *group, int value, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint8 hotkey = 0);
 	RadiobuttonWidget(GuiObject *boss, const Common::String &name, RadiobuttonGroup *group, int value, const Common::U32String &label, const Common::U32String &tooltip = Common::U32String(), uint8 hotkey = 0);
 
@@ -400,6 +407,7 @@ protected:
 	bool	_isDragging;
 	uint	_labelWidth;
 public:
+	SliderWidget(GuiObject *boss, int x, int y, int w, int h, bool scale, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0);
 	SliderWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0);
 	SliderWidget(GuiObject *boss, const Common::String &name, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0);
 
@@ -432,6 +440,7 @@ protected:
 /* GraphicsWidget */
 class GraphicsWidget : public Widget {
 public:
+	GraphicsWidget(GuiObject *boss, int x, int y, int w, int h, bool scale, const Common::U32String &tooltip = Common::U32String());
 	GraphicsWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &tooltip = Common::U32String());
 	GraphicsWidget(GuiObject *boss, const Common::String &name, const Common::U32String &tooltip = Common::U32String());
 	~GraphicsWidget() override;
@@ -455,7 +464,7 @@ protected:
 /* ContainerWidget */
 class ContainerWidget : public Widget {
 public:
-	ContainerWidget(GuiObject *boss, int x, int y, int w, int h);
+	ContainerWidget(GuiObject *boss, int x, int y, int w, int h, bool scale = false);
 	ContainerWidget(GuiObject *boss, const Common::String &name);
 	~ContainerWidget() override;
 
@@ -538,7 +547,7 @@ private:
 	ScrollContainerWidget *_scrollContainer;
 };
 
-ButtonWidget *addClearButton(GuiObject *boss, const Common::String &name, uint32 cmd, int x=0, int y=0, int w=0, int h=0);
+ButtonWidget *addClearButton(GuiObject *boss, const Common::String &name, uint32 cmd, int x=0, int y=0, int w=0, int h=0, bool scale = false);
 const Graphics::ManagedSurface *scaleGfx(const Graphics::ManagedSurface *gfx, int w, int h, bool filtering = false);
 
 } // End of namespace GUI

--- a/gui/widgets/editable.cpp
+++ b/gui/widgets/editable.cpp
@@ -28,10 +28,14 @@
 
 namespace GUI {
 
-EditableWidget::EditableWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &tooltip, uint32 cmd)
-	: Widget(boss, x, y, w, h, tooltip), CommandSender(boss), _cmd(cmd) {
+EditableWidget::EditableWidget(GuiObject *boss, int x, int y, int w, int h, bool scale, const Common::U32String &tooltip, uint32 cmd)
+	: Widget(boss, x, y, w, h, scale, tooltip), CommandSender(boss), _cmd(cmd) {
 	setFlags(WIDGET_TRACK_MOUSE);
 	init();
+}
+
+EditableWidget::EditableWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &tooltip, uint32 cmd)
+	: EditableWidget(boss, x, y, w, h, false, tooltip, cmd) {
 }
 
 EditableWidget::EditableWidget(GuiObject *boss, const Common::String &name, const Common::U32String &tooltip, uint32 cmd)

--- a/gui/widgets/editable.h
+++ b/gui/widgets/editable.h
@@ -66,6 +66,7 @@ protected:
 	ThemeEngine::TextInversionState  _inversion;
 
 public:
+	EditableWidget(GuiObject *boss, int x, int y, int w, int h, bool scale, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0);
 	EditableWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0);
 	EditableWidget(GuiObject *boss, const Common::String &name, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0);
 	~EditableWidget() override;

--- a/gui/widgets/edittext.cpp
+++ b/gui/widgets/edittext.cpp
@@ -28,8 +28,8 @@
 
 namespace GUI {
 
-EditTextWidget::EditTextWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &text, const Common::U32String &tooltip, uint32 cmd, uint32 finishCmd, ThemeEngine::FontStyle font)
-	: EditableWidget(boss, x, y - 1, w, h + 2, tooltip, cmd) {
+EditTextWidget::EditTextWidget(GuiObject *boss, int x, int y, int w, int h, bool scale, const Common::U32String &text, const Common::U32String &tooltip, uint32 cmd, uint32 finishCmd, ThemeEngine::FontStyle font)
+	: EditableWidget(boss, x, y - 1, w, h + 2, scale, tooltip, cmd) {
 	setFlags(WIDGET_ENABLED | WIDGET_CLEARBG | WIDGET_RETAIN_FOCUS | WIDGET_WANT_TICKLE);
 	_type = kEditTextWidget;
 	_finishCmd = finishCmd;
@@ -38,6 +38,10 @@ EditTextWidget::EditTextWidget(GuiObject *boss, int x, int y, int w, int h, cons
 
 	setEditString(text);
 	setFontStyle(font);
+}
+
+EditTextWidget::EditTextWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &text, const Common::U32String &tooltip, uint32 cmd, uint32 finishCmd, ThemeEngine::FontStyle font)
+	: EditTextWidget(boss, x, y, w, h, false, text, tooltip, cmd, finishCmd, font) {
 }
 
 EditTextWidget::EditTextWidget(GuiObject *boss, const Common::String &name, const Common::U32String &text, const Common::U32String &tooltip, uint32 cmd, uint32 finishCmd, ThemeEngine::FontStyle font)

--- a/gui/widgets/edittext.h
+++ b/gui/widgets/edittext.h
@@ -37,6 +37,7 @@ protected:
 	int				_rightPadding;
 
 public:
+	EditTextWidget(GuiObject *boss, int x, int y, int w, int h, bool scale, const Common::U32String &text, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint32 finishCmd = 0, ThemeEngine::FontStyle font = ThemeEngine::kFontStyleNormal);
 	EditTextWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &text, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint32 finishCmd = 0, ThemeEngine::FontStyle font = ThemeEngine::kFontStyleNormal);
 	EditTextWidget(GuiObject *boss, const Common::String &name, const Common::U32String &text, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0, uint32 finishCmd = 0, ThemeEngine::FontStyle font = ThemeEngine::kFontStyleNormal);
 

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -75,8 +75,8 @@ ListWidget::ListWidget(Dialog *boss, const Common::String &name, const Common::U
 	_topPadding = _bottomPadding = 0;
 }
 
-ListWidget::ListWidget(Dialog *boss, int x, int y, int w, int h, const Common::U32String &tooltip, uint32 cmd)
-	: EditableWidget(boss, x, y, w, h, tooltip), _cmd(cmd) {
+ListWidget::ListWidget(Dialog *boss, int x, int y, int w, int h, bool scale, const Common::U32String &tooltip, uint32 cmd)
+	: EditableWidget(boss, x, y, w, h, scale, tooltip), _cmd(cmd) {
 
 	_entriesPerPage = 0;
 	_scrollBarWidth = 0;
@@ -114,6 +114,10 @@ ListWidget::ListWidget(Dialog *boss, int x, int y, int w, int h, const Common::U
 	_topPadding = _bottomPadding = 0;
 
 	_scrollBarWidth = 0;
+}
+
+ListWidget::ListWidget(Dialog *boss, int x, int y, int w, int h, const Common::U32String &tooltip, uint32 cmd)
+	: ListWidget(boss, x, y, w, h, false, tooltip, cmd) {
 }
 
 void ListWidget::copyListData(const Common::U32StringArray &list) {

--- a/gui/widgets/list.h
+++ b/gui/widgets/list.h
@@ -99,6 +99,7 @@ protected:
 
 public:
 	ListWidget(Dialog *boss, const Common::String &name, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0);
+	ListWidget(Dialog *boss, int x, int y, int w, int h, bool scale, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0);
 	ListWidget(Dialog *boss, int x, int y, int w, int h, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0);
 
 	bool containsWidget(Widget *) const override;


### PR DESCRIPTION
The `GUIObject::resize()` function has a flag indicating that the given values need to be scaled with the HiDPI scaling factor. The constructor however does not have this flag, and does not do the scaling. This causes:
 - Code where a widget is created with some dimensions, and then resize() is called immediately afterward with the same dimensions to fix the size on HiDPI displays. This is a bit weird.
https://github.com/scummvm/scummvm/blob/3c7b7b4a724271a539dae794513d41a06fdb517b/engines/testbed/config.cpp#L178-L179
 - Some dialogs to have an incorrect size has it is not scaled.
![image](https://user-images.githubusercontent.com/552105/227388226-830d7eba-001a-4db7-ba51-c589c11bb59b.png)


In this pull request a `scale` is added to constructors of the dialog, and many widgets. Using it means we no longer have to call resize() to get the correct size. Also this makes more explicit that by default the sizes may not be scaled.
However the default value for this new flag is `false` (while it is `true` by default in `resize()`). The main reason for this is to avoid breaking all the existing code. Also in many cases the dimensions come from the `ThemeEngine` and it provides already scaled values. So the flag is mostly useful when we hardcode some values, as is done in the testbed engine code.

This pull request also fixes the size of some dialogs in testbed, and simplifies some code, to demonstrate the usefulness of the GUI changes.

![image](https://user-images.githubusercontent.com/552105/227388431-2f5d3c68-dfa2-4b0e-8d88-d93931db5e1b.png)

A note on the implementation: for consistency I decided to add the flag just after the size parameters in all the constructors. Also it makes it easier in code that want to pass a flag to do it than if the flag had been added as the last argument, after several other arguments that have default values. And to avoid having to update a lot of existing code, I did not modify the existing constructors but added new ones instead. Fortunately the constructor delegation possible in C++11 limits the code duplication.
