### PR TITLE
BLADERUNNER: avoid writing two times XYZ waypoints

### DIFF
--- a/engines/bladerunner/waypoints.cpp
+++ b/engines/bladerunner/waypoints.cpp
@@ -32,17 +32,15 @@ Waypoints::Waypoints(BladeRunnerEngine *vm, int count) {
 }
 
 void Waypoints::getXYZ(int waypointId, float *x, float *y, float *z) const {
-	*x = 0;
-	*y = 0;
-	*z = 0;
-
 	if (waypointId < 0 || waypointId >= _count || !_waypoints[waypointId].present) {
-		return;
+		*x = 0;
+		*y = 0;
+		*z = 0;
+	} else {
+		*x = _waypoints[waypointId].position.x;
+		*y = _waypoints[waypointId].position.y;
+		*z = _waypoints[waypointId].position.z;
 	}
-
-	*x = _waypoints[waypointId].position.x;
-	*y = _waypoints[waypointId].position.y;
-	*z = _waypoints[waypointId].position.z;
 }
 
 int Waypoints::getSetId(int waypointId) const {


### PR DESCRIPTION
In my opinion, there is no need to write values into X/Y/Z pointers two times, it can be more efficient to write only once the value that we need.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
