### PR TITLE
DIRECTOR: Add support for "set picture of cast" and "get picture of cast"

### DIFF
--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -706,12 +706,11 @@ void Cast::loadBitmapData(int key, BitmapCastMember *bitmapCast) {
 				delete file;
 
 				if (res) {
-					bitmapCast->_img = decoder;
+					bitmapCast->setPicture(*decoder, decoder->hasPalette());
 					bitmapCast->_external = true;
 
 					const Graphics::Surface *surf = decoder->getSurface();
 					if (decoder->hasPalette()) {
-						bitmapCast->_size = surf->pitch * surf->h + decoder->getPaletteColorCount() * 3;
 						// For BMPs this sometimes gets set to 16 in the cast record,
 						// we should go with what the target image has.
 						bitmapCast->_bitsPerPixel = 8;
@@ -781,10 +780,9 @@ void Cast::loadBitmapData(int key, BitmapCastMember *bitmapCast) {
 		return;
 	}
 
-	bitmapCast->_img = img;
-	const Graphics::Surface *surf = img->getSurface();
-	bitmapCast->_size = surf->pitch * surf->h + img->getPaletteColorCount() * 3;
+	bitmapCast->setPicture(*img, true);
 
+	delete img;
 	delete pic;
 
 	debugC(5, kDebugImages, "Cast::loadBitmapData(): Bitmap: id: %d, w: %d, h: %d, flags1: %x, flags2: %x bytes: %x, bpp: %d clut: %x", imgId, w, h, bitmapCast->_flags1, bitmapCast->_flags2, bitmapCast->_bytes, bitmapCast->_bitsPerPixel, bitmapCast->_clut);

--- a/engines/director/castmember.cpp
+++ b/engines/director/castmember.cpp
@@ -550,6 +550,30 @@ Common::String BitmapCastMember::formatInfo() {
 	);
 }
 
+PictureReference *BitmapCastMember::getPicture() const {
+	auto picture = new PictureReference;
+
+	// Not sure if we can make the assumption that the owning
+	// BitmapCastMember will live as long as any reference,
+	// so we'll make a copy of the Picture.
+	picture->_picture = new Picture(*_picture);
+
+	return picture;
+}
+
+void BitmapCastMember::setPicture(PictureReference &picture) {
+	delete _picture;
+	_picture = new Picture(*picture._picture);
+
+	// Force redither
+	delete _ditheredImg;
+	_ditheredImg = nullptr;
+
+	// Make sure we get redrawn
+	setModified(true);
+	// TODO: Should size be adjusted?
+}
+
 void BitmapCastMember::setPicture(Image::ImageDecoder &image, bool adjustSize) {
 	delete _picture;
 	_picture = new Picture(image);

--- a/engines/director/castmember.h
+++ b/engines/director/castmember.h
@@ -137,6 +137,8 @@ public:
 
 	Common::String formatInfo() override;
 
+	PictureReference *getPicture() const;
+	void setPicture(PictureReference &picture);
 	void setPicture(Image::ImageDecoder &image, bool adjustSize);
 
 	Picture *_picture = nullptr;

--- a/engines/director/castmember.h
+++ b/engines/director/castmember.h
@@ -57,6 +57,7 @@ namespace Director {
 class AudioDecoder;
 struct CastMemberInfo;
 class Channel;
+struct Picture;
 struct Resource;
 class Sprite;
 class Stxt;
@@ -136,7 +137,9 @@ public:
 
 	Common::String formatInfo() override;
 
-	Image::ImageDecoder *_img;
+	void setPicture(Image::ImageDecoder &image, bool adjustSize);
+
+	Picture *_picture = nullptr;
 	Graphics::Surface *_ditheredImg;
 	Graphics::FloodFill *_matte;
 

--- a/engines/director/cursor.cpp
+++ b/engines/director/cursor.cpp
@@ -27,6 +27,7 @@
 #include "director/cursor.h"
 #include "director/movie.h"
 #include "director/castmember.h"
+#include "director/picture.h"
 
 namespace Director {
 
@@ -92,15 +93,15 @@ void Cursor::readFromCast(Datum cursorCasts) {
 	for (int y = 0; y < 16; y++) {
 		const byte *cursor = nullptr, *mask = nullptr;
 
-		if (y < cursorBitmap->_img->getSurface()->h &&
-				y < maskBitmap->_img->getSurface()->h) {
-			cursor = (const byte *)cursorBitmap->_img->getSurface()->getBasePtr(0, y);
-			mask = (const byte *)maskBitmap->_img->getSurface()->getBasePtr(0, y);
+		if (y < cursorBitmap->_picture->_surface.h &&
+				y < maskBitmap->_picture->_surface.h) {
+			cursor = (const byte *)cursorBitmap->_picture->_surface.getBasePtr(0, y);
+			mask = (const byte *)maskBitmap->_picture->_surface.getBasePtr(0, y);
 		}
 
 		for (int x = 0; x < 16; x++) {
-			if (x >= cursorBitmap->_img->getSurface()->w ||
-					x >= maskBitmap->_img->getSurface()->w) {
+			if (x >= cursorBitmap->_picture->_surface.w ||
+					x >= maskBitmap->_picture->_surface.w) {
 				cursor = mask = nullptr;
 			}
 

--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -33,6 +33,7 @@
 #include "director/archive.h"
 #include "director/cast.h"
 #include "director/movie.h"
+#include "director/picture.h"
 #include "director/score.h"
 #include "director/sound.h"
 #include "director/window.h"
@@ -359,6 +360,10 @@ Common::String DirectorEngine::getStartupPath() const {
 
 bool DirectorEngine::desktopEnabled() {
 	return !(_wmMode & Graphics::kWMModeNoDesktop);
+}
+
+PatternTile::~PatternTile() {
+	delete img;
 }
 
 } // End of namespace Director

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -128,20 +128,17 @@ struct MacShape {
 	int lineSize;
 	uint pattern;
 
-	Image::ImageDecoder *tile;
+	Picture *tile;
 	const Common::Rect *tileRect;
 
 	Graphics::MacPlotData *pd;
 };
 
 struct PatternTile {
-	Image::ImageDecoder *img = 0;
+	Picture *img = nullptr;
 	Common::Rect rect;
 
-	~PatternTile() {
-		if (img)
-			delete img;
-	}
+	~PatternTile();
 };
 
 const int SCALE_THRESHOLD = 0x100;
@@ -199,7 +196,7 @@ public:
 	uint16 getPaletteColorCount() const { return _currentPaletteLength; }
 
 	void loadPatterns();
-	Image::ImageDecoder *getTile(int num);
+	Picture *getTile(int num);
 	const Common::Rect &getTileRect(int num);
 	uint32 transformColor(uint32 color);
 	Graphics::MacPatterns &getPatterns();

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1767,9 +1767,9 @@ void LB::b_objectp(int nargs) {
 }
 
 void LB::b_pictureP(int nargs) {
-	g_lingo->pop();
-	warning("STUB: b_pictureP");
-	g_lingo->push(Datum(0));
+	Datum d = g_lingo->pop();
+	Datum res((d.type == PICTUREREF) ? 1 : 0);
+	g_lingo->push(res);
 }
 
 void LB::b_stringp(int nargs) {

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -963,7 +963,8 @@ Datum BitmapCastMember::getField(int field) {
 		d = _clut;
 		break;
 	case kThePicture:
-		warning("STUB: BitmapCastMember::getField(): Unprocessed getting field \"%s\" of cast %d", g_lingo->field2str(field), _castId);
+		d.type = PICTUREREF;
+		d.u.picture = getPicture();
 		break;
 	default:
 		d = CastMember::getField(field);
@@ -993,7 +994,12 @@ bool BitmapCastMember::setField(int field, const Datum &d) {
 		_clut = d.asInt();
 		return true;
 	case kThePicture:
-		warning("STUB: BitmapCastMember::setField(): Unprocessed setting field \"%s\" of cast %d", g_lingo->field2str(field), _castId);
+		if (d.type == PICTUREREF && d.u.picture != nullptr) {
+			setPicture(*d.u.picture);
+			return true;
+		} else {
+			warning("BitmapCastMember::setField(): Wrong Datum type %d for kThePicture (or nullptr)", d.type);
+		}
 		return false;
 	default:
 		break;

--- a/engines/director/lingo/lingo.cpp
+++ b/engines/director/lingo/lingo.cpp
@@ -938,6 +938,9 @@ void Datum::reset() {
 		case MENUREF:
 			delete u.menu;
 			break;
+		case PICTUREREF:
+			delete u.picture;
+			break;
 		default:
 			warning("Datum::reset(): Unprocessed REF type %d", type);
 			break;
@@ -1163,6 +1166,9 @@ Common::String Datum::asString(bool printonly) const {
 	case MENUREF:
 		s = Common::String::format("menu(%d, %d)", u.menu->menuIdNum, u.menu->menuItemIdNum);
 		break;
+	case PICTUREREF:
+		s = Common::String::format("picture: %p", (void*)u.picture->_picture);
+		break;
 	default:
 		warning("Incorrect operation asString() for type: %s", type2str());
 	}
@@ -1228,6 +1234,8 @@ const char *Datum::type2str(bool ilk) const {
 		return ilk ? "object" : "OBJECT";
 	case PARRAY:
 		return ilk ? "proplist" : "PARRAY";
+	case PICTUREREF:
+		return ilk ? "picture" :  "PICTUREREF";
 	case POINT:
 		return ilk ? "point" : "POINT";
 	case PROPREF:
@@ -1267,6 +1275,8 @@ int Datum::equalTo(Datum &d, bool ignoreCase) const {
 		return u.obj == d.u.obj;
 	case CASTREF:
 		return *u.cast == *d.u.cast;
+	case PICTUREREF:
+		return 0; // Original always returns 0 on picture reference comparison
 	default:
 		break;
 	}

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -47,6 +47,7 @@ struct LingoArchive;
 struct LingoV4Bytecode;
 struct LingoV4TheEntity;
 struct Node;
+struct Picture;
 class AbstractObject;
 class Cast;
 class ScriptContext;

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -41,6 +41,7 @@ namespace Director {
 
 struct ChunkReference;
 struct MenuReference;
+struct PictureReference;
 struct TheEntity;
 struct TheEntityField;
 struct LingoArchive;
@@ -144,6 +145,7 @@ struct Datum {	/* interpreter stack type */
 		ChunkReference *cref; /* CHUNKREF */
 		CastMemberID *cast;	/* CASTREF, FIELDREF */
 		MenuReference *menu; /* MENUREF	*/
+		PictureReference *picture; /* PICTUREREF */
 	} u;
 
 	int *refCount;
@@ -207,6 +209,13 @@ struct MenuReference {
 	Common::String *menuItemIdStr;
 
 	MenuReference();
+};
+
+struct PictureReference {
+	Picture *_picture = nullptr;
+	~PictureReference() {
+		delete _picture;
+	}
 };
 
 struct PCell {

--- a/engines/director/lingo/tests/equality.lingo
+++ b/engines/director/lingo/tests/equality.lingo
@@ -19,3 +19,8 @@ scummvmAssert("<Object:#FileIO" > 0)
 
 -- Invalid comparisons should return FALSE
 scummvmAssert(not (#test <= 0))
+
+-- Picture comparisons are always false, even between the exact same cast.
+set a to the picture of cast 1
+scummvmAssert(a <> a)
+scummvmAssert(a <> the picture of cast 1)   -- always false

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -16,6 +16,7 @@ MODULE_OBJS = \
 	images.o \
 	metaengine.o \
 	movie.o \
+	picture.o \
 	resource.o \
 	score.o \
 	sound.o \

--- a/engines/director/picture.cpp
+++ b/engines/director/picture.cpp
@@ -1,0 +1,49 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "image/image_decoder.h"
+#include "director/picture.h"
+
+namespace Director {
+
+Picture::Picture(Image::ImageDecoder &img) {
+	_surface.copyFrom(*img.getSurface());
+	copyPalette(img.getPalette(), img.getPaletteColorCount());
+}
+
+Picture::Picture(Picture &picture) {
+	_surface.copyFrom(picture._surface);
+	copyPalette(picture._palette, picture._paletteColors);
+}
+
+Picture::~Picture() {
+	_surface.free();
+	delete[] _palette;
+}
+
+void Picture::copyPalette(const byte *src, int numColors) {
+	delete[] _palette;
+	_paletteColors = numColors;
+	_palette = new byte[getPaletteSize()]();
+	memcpy(_palette, src, getPaletteSize());
+}
+
+} // End of namespace Director

--- a/engines/director/picture.h
+++ b/engines/director/picture.h
@@ -1,0 +1,51 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_PICTURE_H
+#define DIRECTOR_PICTURE_H
+
+#include "graphics/surface.h"
+
+namespace Image {
+class ImageDecoder;
+}
+
+namespace Director {
+
+struct Picture {
+	Graphics::Surface _surface;
+	byte *_palette = nullptr;
+	int _paletteColors = 0;
+
+	int getPaletteSize() const {
+		return _paletteColors * 3;
+	}
+
+	Picture(Image::ImageDecoder &img);
+	Picture(Picture &picture);
+	~Picture();
+private:
+	void copyPalette(const byte *src, int numColors);
+};
+
+} // End of namespace Director
+
+#endif // DIRECTOR_PICTURE_H

--- a/engines/director/tests.cpp
+++ b/engines/director/tests.cpp
@@ -35,6 +35,7 @@
 #include "director/director.h"
 #include "director/archive.h"
 #include "director/movie.h"
+#include "director/picture.h"
 #include "director/window.h"
 #include "director/lingo/lingo.h"
 
@@ -103,10 +104,10 @@ void Window::testFontScaling() {
 
 	x = 10;
 	for (int i = 0; i < kNumBuiltinTiles; i++) {
-		Image::ImageDecoder *tile = g_director->getTile(i);
-		surface.blitFrom(tile->getSurface(), Common::Point(x, 250));
+		Picture *tile = g_director->getTile(i);
+		surface.blitFrom(tile->_surface, Common::Point(x, 250));
 
-		x += tile->getSurface()->w + 10;
+		x += tile->_surface.w + 10;
 	}
 
 	Common::String path = pathMakeRelative("blend2.pic");

--- a/engines/director/types.h
+++ b/engines/director/types.h
@@ -357,6 +357,7 @@ enum DatumType {
 	MENUREF,
 	OBJECT,
 	PARRAY,
+	PICTUREREF,
 	POINT,
 	PROPREF,
 	RECT,


### PR DESCRIPTION
This does a refactor of how BitmapCastMember deals with it's picture, so that we can get/set the picture. In particular we now pass around copies, so that we can ensure that if we set a global to the picture of some cast member, the picture survives the cast member from which it came.