### PR TITLE
NUVIE: Fix Ultima 6 crash on opening spellbook

### DIFF
--- a/engines/ultima/nuvie/views/spell_view.h
+++ b/engines/ultima/nuvie/views/spell_view.h
@@ -60,7 +60,7 @@ public:
 	SpellView(Configuration *cfg);
 	~SpellView() override;
 
-	bool init(Screen *tmp_screen, void *view_manager, uint16 x, uint16 y, Font *f, Party *p, TileManager *tm, ObjManager *om);
+	virtual bool init(Screen *tmp_screen, void *view_manager, uint16 x, uint16 y, Font *f, Party *p, TileManager *tm, ObjManager *om);
 
 	void set_spell_caster(Actor *actor, Obj *s_container, bool eventMode);
 	sint16 get_selected_spell() {

--- a/engines/ultima/nuvie/views/spell_view_gump.h
+++ b/engines/ultima/nuvie/views/spell_view_gump.h
@@ -49,7 +49,7 @@ public:
 	SpellViewGump(Configuration *cfg);
 	~SpellViewGump() override;
 
-	bool init(Screen *tmp_screen, void *view_manager, uint16 x, uint16 y, Font *f, Party *p, TileManager *tm, ObjManager *om);
+	bool init(Screen *tmp_screen, void *view_manager, uint16 x, uint16 y, Font *f, Party *p, TileManager *tm, ObjManager *om) override;
 
 	void Display(bool full_redraw) override;
 


### PR DESCRIPTION
Fix a NULL pointer dereference when opening the "new style" spellbook gump.

In an attempt to initialize a new SpellViewGump the code erroneously called the init() method of the parent class (SpellView). This left the "font" member variable set to NULL.

To reproduce the bug:

1. Enable "new style" in the video options (requires a restart)

2. Get a spellbook (e.g. from the Avatars room SW of the throne room)

3. Open the inventory by pressing TAB and click the spellbook to ready it

4. Press c to open the spellbook gump

Fixes [#12536](https://bugs.scummvm.org/ticket/12536)


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
