### PR TITLE
NUVIE: Fix Ultima 6 actor doll and gump colors

### DIFF
--- a/engines/ultima/nuvie/files/nuvie_bmp_file.cpp
+++ b/engines/ultima/nuvie/files/nuvie_bmp_file.cpp
@@ -282,7 +282,7 @@ Graphics::ManagedSurface *NuvieBmpFile::getSdlSurface32() {
 
 	Graphics::ManagedSurface *surface = new Graphics::ManagedSurface(
 		infoHeader.width, infoHeader.height,
-		Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0)
+		Graphics::PixelFormat(4, 8, 8, 8, 0, 0, 8, 16, 24)
 	);
 
 	unsigned char *src_buf = data;


### PR DESCRIPTION
Set the pixel format of actor doll and various gump ManagedSurfaces to match the format loaded into their buffers.

This corrects colors in:

with style set to "new style" (in video options):

- Actor dolls (the small figure showing equipped items)

- The spellbook gump (opened when casting a spell)

- The sun / moon ribbon to the top right

with style set to "original" and "use new actor dolls" on:

- Actor dolls

Fixes [#13513](https://bugs.scummvm.org/ticket/13513)