### PR TITLE
DREAMWEB: specify CLUT8 format for titles modes

### DIFF
--- a/engines/dreamweb/titles.cpp
+++ b/engines/dreamweb/titles.cpp
@@ -32,10 +32,10 @@ void initTitlesGfx() {
 	Graphics::ModeWithFormatList modes = {
 #ifdef USE_HIGHRES
 		// First try for a 640x480 mode
-		Graphics::ModeWithFormat(640, 480),
+		Graphics::ModeWithFormat(640, 480, Graphics::PixelFormat::createFormatCLUT8()),
 #endif
 		// System doesn't support it, so fall back on 320x240 mode
-		Graphics::ModeWithFormat(320, 240),
+		Graphics::ModeWithFormat(320, 240, Graphics::PixelFormat::createFormatCLUT8()),
 	};
 
 	initGraphicsAny(modes);


### PR DESCRIPTION
If not specified, format selection may fall back to `g_system->getSupportedFormats().front()`, which may provide a not appropriate format (e.g. `RGBA8888@4` will not display titles correcty).