### PR TITLE
DIRECTOR: Set 'the result' for calls, Normalise xlib calls for mac delimiters (:, @:), Working Saves for TD!

### DIFF
--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -191,10 +191,15 @@ void Lingo::push(Datum d) {
 	_stack.push_back(d);
 }
 
-void Lingo::pushVoid() {
+Datum Lingo::getVoid() {
 	Datum d;
 	d.u.s = nullptr;
 	d.type = VOID;
+	return d;
+}
+
+void Lingo::pushVoid() {
+	Datum d = getVoid();
 	push(d);
 }
 
@@ -1650,11 +1655,20 @@ void LC::call(const Symbol &funcSym, int nargs, bool allowRetVal) {
 
 		if (funcSym.u.bltin != LB::b_return && funcSym.u.bltin != LB::b_value) {
 			if (stackSize == stackSizeBefore + 1) {
+				// Set "the result" to return value!, when a method
+				// this is for handling result after execution!
+				Datum top = g_lingo->peek(0);
+				if (top.type == INT)
+					g_lingo->_theResult = top;
+
 				if (!allowRetVal) {
 					Datum extra = g_lingo->pop();
 					warning("Builtin '%s' dropping return value: %s", funcSym.name->c_str(), extra.asString(true).c_str());
 				}
 			} else if (stackSize == stackSizeBefore) {
+				// No value, hence "the result" is VOID
+				g_lingo->_theResult = g_lingo->getVoid();
+
 				if (allowRetVal)
 					error("Builtin '%s' did not return value", funcSym.name->c_str());
 			} else if (stackSize > stackSizeBefore) {

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -45,6 +45,7 @@
 #include "director/lingo/xlibs/cdromxobj.h"
 #include "director/lingo/xlibs/darkenscreen.h"
 #include "director/lingo/xlibs/developerStack.h"
+#include "director/lingo/xlibs/dialogs.h"
 #include "director/lingo/xlibs/dpwavi.h"
 #include "director/lingo/xlibs/dpwqtw.h"
 #include "director/lingo/xlibs/draw.h"
@@ -165,6 +166,7 @@ static struct XLibProto {
 	{ CDROMXObj::fileNames,				CDROMXObj::open,			CDROMXObj::close,			kXObj,					200 },	// D2
 	{ DarkenScreen::fileNames,			DarkenScreen::open,			DarkenScreen::close,		kXObj,					300 },	// D3
 	{ DeveloperStack::fileNames,		DeveloperStack::open,		DeveloperStack::close,		kXObj,					300 },	// D3
+	{ DialogsXObj::fileNames,			DialogsXObj::open,			DialogsXObj::close,			kXObj,					400 },	// D4
 	{ DPwAVI::fileNames,				DPwAVI::open,				DPwAVI::close,				kXObj,					400 },	// D4
 	{ DPwQTw::fileNames,				DPwQTw::open,				DPwQTw::close,				kXObj,					400 },	// D4
 	{ DrawXObj::fileNames,				DrawXObj::open,				DrawXObj::close,			kXObj,					400 },	// D4

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -244,6 +244,9 @@ Common::String Lingo::normalizeXLibName(Common::String name) {
 
 	name.trim();
 
+	// Normalize to remove machintosh path delimiters (':', '@:')
+	name = convertPath(name);
+
 	return name;
 }
 

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -403,6 +403,7 @@ public:
 	char *readString() { char *s = getString(_state->pc); _state->pc += calcStringAlignment(s); return s; }
 	char *getString(uint pc) { return (char *)(&((*_state->script)[_state->pc])); }
 
+	Datum getVoid();
 	void pushVoid();
 
 	void printSTUBWithArglist(const char *funcname, int nargs, const char *prefix = "STUB:");

--- a/engines/director/lingo/xlibs/dialogs.cpp
+++ b/engines/director/lingo/xlibs/dialogs.cpp
@@ -1,0 +1,141 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*************************************
+*
+* USED IN:
+* Total Distortion
+*
+*************************************/
+/*
+ * -- Dialogs XObject. Written by Scott Kildall. Copyright (c) Red Eye  Software, December 11th, 1994.
+ * Compuserve:72703,451 AOL:KILDALL  APPLELINK:S.KILDALL
+ * Internet:72703.451@compuserve.com
+ * Licensed for the MediaBook CD for Director
+ * Published by gray matter design (415) 243-0394
+ *
+ * Dialogs
+ * X        mNew          --Creates a new instance of the XObject
+ * SSSS     mPutFile, Dialog Title, Default Name, Default Extension       --Displays a save dialog box
+ * SSSS     mGetFile, Dialog Title, Default Name, Default Extension       --Displays an open dialog box
+ *
+ * -- How it is called:
+ * set GameFileFULLPATH to gDialogsObj(mPutFile, "Save your Total Distortion Game File!", "TDGame", "TDG")
+ * set GameFileFULLPATH to gDialogsObj(mGetFile, "Find your Total Distortion Game File!", "*.TDG", "TDG")
+*/
+
+#include "gui/filebrowser-dialog.h"
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/xlibs/dialogs.h"
+
+namespace Director {
+
+const char *DialogsXObj::xlibNames[] = {
+	"DialogS",
+	nullptr
+};
+
+const char *DialogsXObj::fileNames[] = {
+	"DialogS",
+	"shaREQUE", // TD loads this up using openXLib("@:shaREQUE.DLL")
+	nullptr
+};
+
+static MethodProto xlibMethods[] = {
+	{ "new",               DialogsXObj::m_new,              0, 0,  400 },  // D4
+	{ "GetFile",           DialogsXObj::m_getFile,          3, 3,  400 },  // D4
+	{ "PutFile",           DialogsXObj::m_putFile,          3, 3,  400 },  // D4
+	{ nullptr, nullptr, 0, 0, 0 }
+};
+
+void DialogsXObj::open(int type) {
+	if (type == kXObj) {
+		DialogsXObject::initMethods(xlibMethods);
+		DialogsXObject *xobj = new DialogsXObject(kXObj);
+		for (uint i = 0; xlibNames[i]; i++) {
+			g_lingo->exposeXObject(xlibNames[i], xobj);
+		}
+	}
+}
+
+void DialogsXObj::close(int type) {
+	if (type == kXObj) {
+		DialogsXObject::cleanupMethods();
+		for (uint i = 0; xlibNames[i]; i++) {
+			g_lingo->_globalvars[xlibNames[i]] = Datum();
+		}
+	}
+}
+
+DialogsXObject::DialogsXObject(ObjectType ObjectType) : Object<DialogsXObject>("DialogS") {
+	_objType = ObjectType;
+}
+
+void DialogsXObj::m_new(int nargs) {
+	g_lingo->push(g_lingo->_state->me);
+}
+
+void DialogsXObj::m_putFile(int nargs) {
+	Common::String title = g_lingo->pop().asString();
+	Common::String name = g_lingo->pop().asString();
+	Common::String extn = g_lingo->pop().asString();
+
+	Common::String prefix = g_director->getTargetName() + '-';
+	Common::String mask = prefix + "*." + extn + ".txt";
+	Common::String filename = name;
+
+	GUI::FileBrowserDialog browser(title.c_str(), "txt", GUI::kFBModeSave, mask.c_str());
+	if (browser.runModal() > 0) {
+		filename = browser.getResult();
+		if (!filename.matchString(mask)) // If user choose to create new file (rather than overwriting existing one)
+			filename = Common::String::format("C:\\%s%s", prefix.c_str(), filename.c_str());
+		else {
+			// Here user chose existing save file to be overwritten, so format it before sending! (To prevent duplicate extensions)
+			const Common::String suffx = "." + extn;
+			Common::replace(filename, suffx, "");
+		}
+	}
+	warning("DialogsXObj::m_putFile return filename: %s", filename.c_str());
+	g_lingo->push(Datum(filename));
+}
+
+void DialogsXObj::m_getFile(int nargs) {
+	Common::String title = g_lingo->pop().asString();
+	Common::String name = g_lingo->pop().asString();
+	Common::String extn = g_lingo->pop().asString();
+
+	Common::String prefix = g_director->getTargetName() + '-';
+	Common::String mask = prefix + "*." + extn + ".txt";
+	Common::String fileName = name;
+
+	GUI::FileBrowserDialog browser(title.c_str(), "txt", GUI::kFBModeLoad, mask.c_str());
+	if (browser.runModal() > 0) {
+		Common::String path = browser.getResult();
+		fileName = Common::String::format("C:\\%s", path.c_str()); // Create fullpath from this name, as: C:\filename.TDG.txt!
+	}
+	warning("DialogsXObj::m_getFile return filename: %s", fileName.c_str());
+	g_lingo->push(Datum(fileName));
+}
+
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/dialogs.h
+++ b/engines/director/lingo/xlibs/dialogs.h
@@ -1,0 +1,47 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XLIBS_DIALOGSXOBJ_H
+#define DIRECTOR_LINGO_XLIBS_DIALOGSXOBJ_H
+
+namespace Director {
+class DialogsXObject : public Object<DialogsXObject> {
+public:
+	DialogsXObject(ObjectType objType);
+};
+
+namespace DialogsXObj {
+
+extern const char *xlibNames[];
+extern const char *fileNames[];
+
+void open(int type);
+void close(int type);
+
+void m_new(int nargs);
+void m_putFile(int nargs);
+void m_getFile(int nargs);
+
+} // End of namespace DialogsXObj
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/lingo/xlibs/fileio.cpp
+++ b/engines/director/lingo/xlibs/fileio.cpp
@@ -95,6 +95,7 @@ namespace Director {
 const char *FileIO::xlibName = "FileIO";
 const char *FileIO::fileNames[] = {
 	"FileIO",
+	"shFILEIO", // TD loads this up using openXLib("@:shFILEIO.DLL")
 	nullptr
 };
 

--- a/engines/director/lingo/xlibs/fileio.cpp
+++ b/engines/director/lingo/xlibs/fileio.cpp
@@ -204,12 +204,14 @@ void FileIO::m_new(int nargs) {
 	Common::String option = d1.asString();
 	Common::String path = d2.asString();
 	Common::String origpath = path;
+	char dirSeparator = g_director->_dirSeparator;
 
 	Common::String prefix = g_director->getTargetName() + '-';
 
 	if (option.hasPrefix("?")) {
 		option = option.substr(1);
 		Common::String mask = prefix + "*.txt";
+		dirSeparator = '/';
 
 		GUI::FileBrowserDialog browser(nullptr, "txt", option.equalsIgnoreCase("write") ? GUI::kFBModeSave : GUI::kFBModeLoad, mask.c_str());
 		if (browser.runModal() <= 0) {
@@ -222,8 +224,8 @@ void FileIO::m_new(int nargs) {
 	}
 
 	// Enforce target to the created files so they do not mix up
-	Common::String filename = lastPathComponent(path, '/');
-	Common::String dir = firstPathComponents(path, '/');
+	Common::String filename = lastPathComponent(path, dirSeparator);
+	Common::String dir = firstPathComponents(path, dirSeparator);
 
 	if (!filename.hasPrefixIgnoreCase(prefix))
 		filename = dir + prefix + filename;

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -50,6 +50,7 @@ MODULE_OBJS = \
 	lingo/xlibs/cdromxobj.o \
 	lingo/xlibs/darkenscreen.o \
 	lingo/xlibs/developerStack.o \
+	lingo/xlibs/dialogs.o \
 	lingo/xlibs/dpwavi.o \
 	lingo/xlibs/dpwqtw.o \
 	lingo/xlibs/draw.o \


### PR DESCRIPTION
Pull request is fragmented into three atomic commits for each of these, please review!

1. Set 'the result' for calls - Before this, the value of the result was not being set in XObject/Factory calls, this patch fixes it and thus the result will now be set after each caller! (eg. used for FileIO, for verifying status of operation after executing handler)
2. Normalise xlib calls for mac delimiters - Before patch, delimiters such as : and @: were not removed from openXLib calls, this patch fixes it and removes them.
3. Fully working Saves for total distortion! - Load/Save games are fully working, also the same goes for loading/saving video files under total distortion!