### PR TITLE
Inline some of the most called functions in SCI and SCUMM

### DIFF
--- a/engines/sci/console.cpp
+++ b/engines/sci/console.cpp
@@ -27,6 +27,7 @@
 #include "sci/debug.h"
 #include "sci/event.h"
 #include "sci/resource/resource.h"
+#include "sci/version.h"
 #include "sci/engine/state.h"
 #include "sci/engine/kernel.h"
 #include "sci/engine/selector.h"

--- a/engines/sci/engine/object.h
+++ b/engines/sci/engine/object.h
@@ -26,9 +26,9 @@
 #include "common/serializer.h"
 #include "common/textconsole.h"
 
-#include "sci/sci.h"			// for the SCI versions
 #include "sci/engine/vm_types.h"	// for reg_t
 #include "sci/util.h"
+#include "sci/version.h"
 
 namespace Sci {
 

--- a/engines/sci/engine/script.cpp
+++ b/engines/sci/engine/script.cpp
@@ -1290,10 +1290,6 @@ Common::Array<reg_t> Script::listObjectReferences() const {
 	return tmp;
 }
 
-bool Script::offsetIsObject(uint32 offset) const {
-	return _buf->getUint16SEAt(offset + SCRIPT_OBJECT_MAGIC_OFFSET) == SCRIPT_OBJECT_MAGIC_NUMBER;
-}
-
 void Script::applySaidWorkarounds() {
 	// WORKAROUND: SQ3 version 1.018 has a messy vocab problem.
 	// Sierra added the vocab entry "scout" to this version at group id 0x953

--- a/engines/sci/engine/script.h
+++ b/engines/sci/engine/script.h
@@ -125,7 +125,11 @@ public:
 	void syncLocalsBlock(SegManager *segMan);
 	ObjMap &getObjectMap() { return _objects; }
 	const ObjMap &getObjectMap() const { return _objects; }
-	bool offsetIsObject(uint32 offset) const;
+
+	// speed optimization: inline due to frequent calling
+	bool offsetIsObject(uint32 offset) const {
+		return _buf->getUint16SEAt(offset + SCRIPT_OBJECT_MAGIC_OFFSET) == SCRIPT_OBJECT_MAGIC_NUMBER;
+	}
 
 public:
 	Script();

--- a/engines/sci/engine/vm_types.cpp
+++ b/engines/sci/engine/vm_types.cpp
@@ -45,25 +45,6 @@ void reg_t::setSegment(SegmentId segment) {
 	}
 }
 
-uint32 reg_t::getOffset() const {
-	if (getSciVersion() < SCI_VERSION_3) {
-		return _offset;
-	} else {
-		// Return the lower 16 bits from the offset, and the 17th and 18th bits from the segment
-		return ((_segment & 0xC000) << 2) | _offset;
-	}
-}
-
-void reg_t::setOffset(uint32 offset) {
-	if (getSciVersion() < SCI_VERSION_3) {
-		_offset = offset;
-	} else {
-		// Store the lower 16 bits in the offset, and the 17th and 18th bits in the segment
-		_offset = offset & 0xFFFF;
-		_segment = ((offset & 0x30000) >> 2) | (_segment & 0x3FFF);
-	}
-}
-
 reg_t reg_t::lookForWorkaround(const reg_t right, const char *operation) const {
 	SciCallOrigin originReply;
 	SciWorkaroundSolution solution = trackOriginAndFindWorkaround(0, arithmeticWorkarounds, &originReply);

--- a/engines/sci/engine/vm_types.h
+++ b/engines/sci/engine/vm_types.h
@@ -23,6 +23,7 @@
 #define SCI_ENGINE_VM_TYPES_H
 
 #include "common/scummsys.h"
+#include "sci/version.h"
 
 namespace Sci {
 
@@ -42,8 +43,27 @@ struct reg_t {
 
 	SegmentId getSegment() const;
 	void setSegment(SegmentId segment);
-	uint32 getOffset() const;
-	void setOffset(uint32 offset);
+
+	// speed optimization: inline due to frequent calling
+	uint32 getOffset() const {
+		if (getSciVersion() < SCI_VERSION_3) {
+			return _offset;
+		} else {
+			// Return the lower 16 bits from the offset, and the 17th and 18th bits from the segment
+			return ((_segment & 0xC000) << 2) | _offset;
+		}
+	}
+
+	// speed optimization: inline due to frequent calling
+	void setOffset(uint32 offset) {
+		if (getSciVersion() < SCI_VERSION_3) {
+			_offset = offset;
+		} else {
+			// Store the lower 16 bits in the offset, and the 17th and 18th bits in the segment
+			_offset = offset & 0xFFFF;
+			_segment = ((offset & 0x30000) >> 2) | (_segment & 0x3FFF);
+		}
+	}
 
 	inline void incOffset(int32 offset) {
 		setOffset(getOffset() + offset);

--- a/engines/sci/resource/resource.cpp
+++ b/engines/sci/resource/resource.cpp
@@ -56,16 +56,11 @@ struct resource_index_t {
 
 //////////////////////////////////////////////////////////////////////
 
-static SciVersion s_sciVersion = SCI_VERSION_NONE;	// FIXME: Move this inside a suitable class, e.g. SciEngine
-
-SciVersion getSciVersion() {
-	assert(s_sciVersion != SCI_VERSION_NONE);
-	return s_sciVersion;
-}
+SciVersion g_sciVersion = SCI_VERSION_NONE;	// FIXME: Move this inside a suitable class, e.g. SciEngine
 
 SciVersion getSciVersionForDetection() {
 	assert(!g_sci);
-	return s_sciVersion;
+	return g_sciVersion;
 }
 
 const char *getSciVersionDesc(SciVersion version) {
@@ -2633,7 +2628,7 @@ bool ResourceManager::checkResourceForSignatures(ResourceType resourceType, uint
 void ResourceManager::detectSciVersion() {
 	// We use the view compression to set a preliminary s_sciVersion for the sake of getResourceInfo
 	// Pretend we have a SCI0 game
-	s_sciVersion = SCI_VERSION_0_EARLY;
+	g_sciVersion = SCI_VERSION_0_EARLY;
 	bool oldDecompressors = true;
 
 	ResourceCompression viewCompression;
@@ -2652,7 +2647,7 @@ void ResourceManager::detectSciVersion() {
 		// If it's a different compression type from kCompLZW, the game is probably
 		// SCI_VERSION_1_EGA_ONLY or later. If the views are uncompressed, it is
 		// likely not an early disk game.
-		s_sciVersion = SCI_VERSION_1_EGA_ONLY;
+		g_sciVersion = SCI_VERSION_1_EGA_ONLY;
 		oldDecompressors = false;
 	}
 
@@ -2691,15 +2686,15 @@ void ResourceManager::detectSciVersion() {
 		// versions of SCI3 PC games. That is, the Mac scripts are compiled as
 		// separate script and hunk resources instead of the SCI3 script format.
 		if (res) {
-			s_sciVersion = SCI_VERSION_2_1_EARLY; // we check for SCI2.1 specifics a bit later
+			g_sciVersion = SCI_VERSION_2_1_EARLY; // we check for SCI2.1 specifics a bit later
 		} else {
-			s_sciVersion = SCI_VERSION_1_1;
+			g_sciVersion = SCI_VERSION_1_1;
 			return;
 		}
 	}
 
 	// Handle SCI32 versions here
-	if (s_sciVersion != SCI_VERSION_2_1_EARLY) {
+	if (g_sciVersion != SCI_VERSION_2_1_EARLY) {
 		if (_volVersion >= kResVersionSci2) {
 			Common::List<ResourceId> heaps = listResources(kResourceTypeHeap);
 			bool hasHeapResources = !heaps.empty();
@@ -2708,18 +2703,18 @@ void ResourceManager::detectSciVersion() {
 			// SCI1 Late resource maps have the resource types or'd with
 			// 0x80. We differentiate between SCI2 and SCI2.1/3 based on that.
 			if (_mapVersion == kResVersionSci1Late) {
-				s_sciVersion = SCI_VERSION_2;
+				g_sciVersion = SCI_VERSION_2;
 				return;
 			} else if (hasHeapResources) {
-				s_sciVersion = SCI_VERSION_2_1_EARLY; // exact SCI2.1 version is checked a bit later
+				g_sciVersion = SCI_VERSION_2_1_EARLY; // exact SCI2.1 version is checked a bit later
 			} else {
-				s_sciVersion = SCI_VERSION_3;
+				g_sciVersion = SCI_VERSION_3;
 				return;
 			}
 		}
 	}
 
-	if (s_sciVersion == SCI_VERSION_2_1_EARLY) {
+	if (g_sciVersion == SCI_VERSION_2_1_EARLY) {
 		// we only know that it's SCI2.1, not which exact version it is
 
 		// check, if selector "wordFail" inside vocab 997 exists, if it does it's SCI2.1 Early
@@ -2728,11 +2723,11 @@ void ResourceManager::detectSciVersion() {
 			return;
 		}
 
-		s_sciVersion = SCI_VERSION_2_1_MIDDLE;
+		g_sciVersion = SCI_VERSION_2_1_MIDDLE;
 		if (checkResourceForSignatures(kResourceTypeScript, 64918, detectSci21NewStringSignature, nullptr)) {
 			// new kString call detected, it's SCI2.1 late
 			// TODO: this call seems to be different on Mac
-			s_sciVersion = SCI_VERSION_2_1_LATE;
+			g_sciVersion = SCI_VERSION_2_1_LATE;
 			return;
 		}
 		return;
@@ -2742,7 +2737,7 @@ void ResourceManager::detectSciVersion() {
 	// If the game has any heap file (here we check for heap file 0), then
 	// it definitely uses a SCI1.1 kernel
 	if (testResource(ResourceId(kResourceTypeHeap, 0))) {
-		s_sciVersion = SCI_VERSION_1_1;
+		g_sciVersion = SCI_VERSION_1_1;
 		return;
 	}
 
@@ -2750,18 +2745,18 @@ void ResourceManager::detectSciVersion() {
 	case kResVersionSci0Sci1Early:
 		if (_viewType == kViewVga) {
 			// VGA
-			s_sciVersion = SCI_VERSION_1_EARLY;
+			g_sciVersion = SCI_VERSION_1_EARLY;
 			return;
 		}
 
 		// EGA
 		if (hasOldScriptHeader()) {
-			s_sciVersion = SCI_VERSION_0_EARLY;
+			g_sciVersion = SCI_VERSION_0_EARLY;
 			return;
 		}
 
 		if (hasSci0Voc999()) {
-			s_sciVersion = SCI_VERSION_0_LATE;
+			g_sciVersion = SCI_VERSION_0_LATE;
 			return;
 		}
 
@@ -2770,17 +2765,17 @@ void ResourceManager::detectSciVersion() {
 
 			// We first check for SCI1 vocab.999
 			if (testResource(ResourceId(kResourceTypeVocab, 999))) {
-				s_sciVersion = SCI_VERSION_01;
+				g_sciVersion = SCI_VERSION_01;
 				return;
 			}
 
 			// If vocab.999 is missing, we try vocab.900
 			if (testResource(ResourceId(kResourceTypeVocab, 900))) {
 				if (hasSci1Voc900()) {
-					s_sciVersion = SCI_VERSION_01;
+					g_sciVersion = SCI_VERSION_01;
 					return;
 				} else {
-					s_sciVersion = SCI_VERSION_0_LATE;
+					g_sciVersion = SCI_VERSION_0_LATE;
 					return;
 				}
 			}
@@ -2790,35 +2785,35 @@ void ResourceManager::detectSciVersion() {
 
 		// New decompressors. It's either SCI_VERSION_1_EGA_ONLY or SCI_VERSION_1_EARLY.
 		if (hasSci1Voc900()) {
-			s_sciVersion = SCI_VERSION_1_EGA_ONLY;
+			g_sciVersion = SCI_VERSION_1_EGA_ONLY;
 			return;
 		}
 
 		// SCI_VERSION_1_EARLY EGA versions lack the parser vocab
-		s_sciVersion = SCI_VERSION_1_EARLY;
+		g_sciVersion = SCI_VERSION_1_EARLY;
 		return;
 	case kResVersionSci1Middle:
 	case kResVersionKQ5FMT:
-		s_sciVersion = SCI_VERSION_1_MIDDLE;
+		g_sciVersion = SCI_VERSION_1_MIDDLE;
 		// Amiga SCI1 middle games are actually SCI1 late
 		if (_viewType == kViewAmiga || _viewType == kViewAmiga64)
-			s_sciVersion = SCI_VERSION_1_LATE;
+			g_sciVersion = SCI_VERSION_1_LATE;
 		// Same goes for Mac SCI1 middle games
 		if (g_sci && g_sci->getPlatform() == Common::kPlatformMacintosh)
-			s_sciVersion = SCI_VERSION_1_LATE;
+			g_sciVersion = SCI_VERSION_1_LATE;
 		return;
 	case kResVersionSci1Late:
 		if (_volVersion == kResVersionSci11) {
-			s_sciVersion = SCI_VERSION_1_1;
+			g_sciVersion = SCI_VERSION_1_1;
 			return;
 		}
-		s_sciVersion = SCI_VERSION_1_LATE;
+		g_sciVersion = SCI_VERSION_1_LATE;
 		return;
 	case kResVersionSci11:
-		s_sciVersion = SCI_VERSION_1_1;
+		g_sciVersion = SCI_VERSION_1_1;
 		return;
 	default:
-		s_sciVersion = SCI_VERSION_NONE;
+		g_sciVersion = SCI_VERSION_NONE;
 		error("detectSciVersion(): Unable to detect the game's SCI version");
 	}
 }

--- a/engines/sci/resource/resource.h
+++ b/engines/sci/resource/resource.h
@@ -30,6 +30,7 @@
 #include "sci/resource/decompressor.h"
 #include "sci/sci.h"
 #include "sci/util.h"
+#include "sci/version.h"
 
 namespace Common {
 class File;
@@ -141,6 +142,17 @@ enum ResVersion {
 	kResVersionSci2,
 	kResVersionSci3
 };
+
+/**
+ * Same as Sci::getSciVersion, but this version doesn't assert on unknown SCI
+ * versions. Only used by the fallback detector.
+ */
+SciVersion getSciVersionForDetection();
+
+/**
+ * Convenience function converting an SCI version into a human-readable string.
+ */
+const char *getSciVersionDesc(SciVersion version);
 
 class ResourceManager;
 class ResourceSource;

--- a/engines/sci/sci.h
+++ b/engines/sci/sci.h
@@ -398,22 +398,6 @@ private:
  */
 extern SciEngine *g_sci;
 
-/**
- * Convenience function to obtain the active SCI version.
- */
-SciVersion getSciVersion();
-
-/**
- * Same as above, but this version doesn't assert on unknown SCI versions.
- * Only used by the fallback detector
- */
-SciVersion getSciVersionForDetection();
-
-/**
- * Convenience function converting an SCI version into a human-readable string.
- */
-const char *getSciVersionDesc(SciVersion version);
-
 } // End of namespace Sci
 
 #endif // SCI_SCI_H

--- a/engines/sci/util.cpp
+++ b/engines/sci/util.cpp
@@ -21,6 +21,7 @@
 
 #include "sci/util.h"
 #include "sci/sci.h"
+#include "sci/version.h"
 
 namespace Sci {
 

--- a/engines/sci/version.h
+++ b/engines/sci/version.h
@@ -1,0 +1,43 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SCI_VERSION_H
+#define SCI_VERSION_H
+
+#include "sci/detection.h"
+
+namespace Sci {
+
+/**
+ * Convenience function to obtain the active SCI version. Inline
+ * due to frequent calling.
+ */
+static inline SciVersion getSciVersion() {
+	// FIXME: declared in sci/resource/resource.cpp
+	extern SciVersion g_sciVersion;
+
+	assert(g_sciVersion != SCI_VERSION_NONE);
+	return g_sciVersion;
+}
+
+} // End of namespace Sci
+
+#endif // SCI_VERSION_H

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -1441,7 +1441,15 @@ protected:
 	void upgradeGfxUsageBits();
 	void setGfxUsageBit(int strip, int bit);
 	void clearGfxUsageBit(int strip, int bit);
-	bool testGfxUsageBit(int strip, int bit);
+
+	// speed optimization: inline due to frequent calling
+	bool testGfxUsageBit(int strip, int bit) {
+		assert(strip >= 0 && strip < ARRAYSIZE(gfxUsageBits) / 3);
+		assert(1 <= bit && bit <= 96);
+		bit--;
+		return (gfxUsageBits[3 * strip + bit / 32] & (1 << (bit % 32))) != 0;
+	}
+
 	bool testGfxAnyUsageBits(int strip);
 	bool testGfxOtherUsageBits(int strip, int bit);
 

--- a/engines/scumm/usage_bits.cpp
+++ b/engines/scumm/usage_bits.cpp
@@ -54,13 +54,6 @@ void ScummEngine::clearGfxUsageBit(int strip, int bit) {
 	gfxUsageBits[3 * strip + bit / 32] &= ~(1 << (bit % 32));
 }
 
-bool ScummEngine::testGfxUsageBit(int strip, int bit) {
-	assert(strip >= 0 && strip < ARRAYSIZE(gfxUsageBits) / 3);
-	assert(1 <= bit && bit <= 96);
-	bit--;
-	return (gfxUsageBits[3 * strip + bit / 32] & (1 << (bit % 32))) != 0;
-}
-
 bool ScummEngine::testGfxAnyUsageBits(int strip) {
 	// Exclude the DIRTY and RESTORED bits from the test
 	uint32 bitmask[3] = { 0xFFFFFFFF, 0xFFFFFFFF, 0x3FFFFFFF };


### PR DESCRIPTION
When profiling a few games, we have spotted some functions which repeatedly made it to the top ten most called / cpu eating functions (on a 32 MHz hardware, so that explains why those numbers are so high...)

From the SCI camp we tested Gabriel Knight, Larry 2, Larry 7 and Sierra's Christmas Card 1988. The most CPU intensive functions (shown on Larry 2 intro but it is similar for the others):

8.30% of all spent CPU cycles: `Sci::reg_t::getOffset() const`
6.08%  of all spent CPU cycles: `Sci::getSciVersion()`
1.80%  of all spent CPU cycles: `Sci::reg_t::setOffset(unsigned int)`
1.25%  of all spent CPU cycles: `Sci::Script::offsetIsObject(unsigned int) const`

After applying this PR, the total `run_vm()` cost went from 0.00940s / call, down to 0.00672s / call, which is 28.5% improvement!

During a run of Full Throttle, `testGfxUsageBit()` calls account for 6.2% of all function calls (!) and ~2% of used cycles.

The `getSciVersion` commit is perhaps the most interesting for review purposes; I was thinking about doing what the `FIXME` suggests but that wouldn't be such a win for performance as it could be inlined, sure, but also it would be replaced with another indirect jump caused by `g_sci->getSciVersion()` so I've taken the most efficient path even if it doesn't improve the code.