### PR TITLE
NUVIE: Fix Ultima 6 failed assert on resting

### DIFF
--- a/engines/ultima/nuvie/core/events.cpp
+++ b/engines/ultima/nuvie/core/events.cpp
@@ -328,6 +328,16 @@ bool Events::handleEvent(const Common::Event *event_) {
 	if (game->user_paused())
 		return true;
 
+	// if input was requested, handle it first so other events do not interfere
+	if (input.get_text && scroll->has_input()) {
+		if (active_alt_code) {
+			endAction(); // exit INPUT_MODE
+			alt_code_input(scroll->get_input().c_str());
+		} else {
+			doAction();
+		}
+	}
+
 	switch (event_->type) {
 	case Common::EVENT_MOUSEMOVE:
 		break;
@@ -348,14 +358,6 @@ bool Events::handleEvent(const Common::Event *event_) {
 		break;
 	}
 
-	if (input.get_text && scroll->has_input()) {
-		if (active_alt_code) {
-			endAction(); // exit INPUT_MODE
-			alt_code_input(scroll->get_input().c_str());
-		} else {
-			doAction();
-		}
-	}
 	return true;
 }
 


### PR DESCRIPTION
Fix failed assertion when starting the "rest" action and holding down a number key at the prompt ("How many hours?"):

"core/events.cpp:3189: void Ultima::Nuvie::Events::doAction(): Assertion `input.str' failed."

Give priority to requests for text input in Events::handleEvent() to prevent unrelated events from interfering.

Event handlers can request text input by setting some state (input.get_text, mode, etc.). Events::handleEvent() will then check for input and provide it to a method ultimately determined by current mode. Unrelated events could interfere with this by changing state since they were handled before checking for input requests.