### PR TITLE
NUVIE: Fix Ultima 6 failed assert on click during prompt

### DIFF
--- a/engines/ultima/nuvie/gui/widgets/msg_scroll.cpp
+++ b/engines/ultima/nuvie/gui/widgets/msg_scroll.cpp
@@ -881,7 +881,7 @@ GUI_status MsgScroll::MouseUp(int x, int y, Shared::MouseButton button) {
 	if (button == 1) { // left click == select word
 		if (input_mode) {
 			token_str = get_token_string_at_pos(x, y);
-			if (permit_input != NULL) {
+			if (permit_input != NULL && token_str.length()) {
 				if (strchr(permit_input, token_str[0])
 				        || strchr(permit_input, tolower(token_str[0]))) {
 					input_buf_add_char(token_str[0]);


### PR DESCRIPTION
Fix failed assertion on left-clicking while a "new style" prompt is displayed:

"engines/ultima/shared/std/string.h:93:char& Ultima::Std::string::operator[](size_t):Assertion `idx < _size' failed."

To reproduce the bug:
1. Enable "new style" in video options
2. Go to the two pools near the castle entrance
3. Use the fountain on the top left part of a pool
4. Left-click anywhere while the prompt	is open