### PR TITLE
NUVIE: Fix input handling of modifier keys

### DIFF
--- a/engines/ultima/nuvie/keybinding/keys.cpp
+++ b/engines/ultima/nuvie/keybinding/keys.cpp
@@ -367,12 +367,13 @@ KeyMap::iterator KeyBinder::get_sdlkey_index(const Common::KeyState &key) {
 }
 
 bool KeyBinder::HandleEvent(const Common::Event *ev) {
-	Common::KeyState key = ev->kbd.keycode;
+	Common::KeyState key = ev->kbd;
 	KeyMap::iterator sdlkey_index;
 
 	if (ev->type != Common::EVENT_KEYDOWN)
 		return false;
 
+	key.flags &= ~Common::KBD_STICKY;
 	sdlkey_index = get_sdlkey_index(key);
 	if (sdlkey_index != _bindings.end())
 		return DoAction((*sdlkey_index)._value);


### PR DESCRIPTION
Do not discard modifier keys (CTRL, ALT, etc.) when looking up keybinds.