### PR TITLE
ANDROID: Bundle CA certificates and cleanups

### DIFF
--- a/backends/networking/curl/connectionmanager.cpp
+++ b/backends/networking/curl/connectionmanager.cpp
@@ -99,7 +99,15 @@ uint32 ConnectionManager::getCloudRequestsPeriodInMicroseconds() {
 }
 
 const char *ConnectionManager::getCaCertPath() {
-#if defined(DATA_PATH)
+#if defined(__ANDROID__)
+	Common::ArchiveMemberPtr member = SearchMan.getMember("cacert.pem");
+	Common::FSNode *node = dynamic_cast<Common::FSNode *>(member.get());
+	if (!node) {
+		return nullptr;
+	}
+
+	return node->getPath().c_str();
+#elif defined(DATA_PATH)
 	static enum {
 		kNotInitialized,
 		kFileNotFound,

--- a/backends/networking/curl/networkreadstream.cpp
+++ b/backends/networking/curl/networkreadstream.cpp
@@ -92,7 +92,7 @@ void NetworkReadStream::initCurl(const char *url, curl_slist *headersList) {
 	curl_easy_setopt(_easy, CURLOPT_NOPROGRESS, 0L);
 	curl_easy_setopt(_easy, CURLOPT_PROGRESSFUNCTION, curlProgressCallbackOlder);
 	curl_easy_setopt(_easy, CURLOPT_PROGRESSDATA, this);
-#if defined NINTENDO_SWITCH || defined ANDROID_PLAIN_PORT || defined PSP2
+#if defined NINTENDO_SWITCH || defined PSP2
 	curl_easy_setopt(_easy, CURLOPT_SSL_VERIFYPEER, 0);
 #endif
 

--- a/backends/platform/android/android.mk
+++ b/backends/platform/android/android.mk
@@ -33,15 +33,28 @@ ifneq ($(DIST_FILES_SHADERS),)
 	$(INSTALL) -c -m 644 $(DIST_FILES_SHADERS) $(PATH_BUILD_ASSETS)/shaders
 endif
 
+ifdef DIST_ANDROID_CACERT_PEM
+$(PATH_BUILD_ASSETS)/cacert.pem: $(DIST_ANDROID_CACERT_PEM) | $(PATH_BUILD_ASSETS)
+	$(INSTALL) -c -m 644 $(DIST_ANDROID_CACERT_PEM) $(PATH_BUILD_ASSETS)/cacert.pem
+else
+ifdef USE_CURL
+$(PATH_BUILD_ASSETS)/cacert.pem: | $(PATH_BUILD_ASSETS)
+	$(QUIET_CURL)$(CURL) -s https://curl.se/ca/cacert.pem --time-cond $(PATH_BUILD_ASSETS)/cacert.pem --output $(PATH_BUILD_ASSETS)/cacert.pem
+androidcacert: | $(PATH_BUILD_ASSETS)
+	$(QUIET_CURL)$(CURL) -s https://curl.se/ca/cacert.pem --time-cond $(PATH_BUILD_ASSETS)/cacert.pem --output $(PATH_BUILD_ASSETS)/cacert.pem
+.PHONY: androidcacert
+endif
+endif
+
 $(PATH_BUILD_LIBSCUMMVM): libscummvm.so | $(PATH_BUILD)
 	$(INSTALL) -d  $(PATH_BUILD_LIB)
 	$(INSTALL) -c -m 644 libscummvm.so $(PATH_BUILD_LIBSCUMMVM)
 
-$(APK_MAIN): $(PATH_BUILD_GRADLE) $(PATH_BUILD_ASSETS) $(PATH_BUILD_LIBSCUMMVM) | $(PATH_BUILD)
+$(APK_MAIN): $(PATH_BUILD_GRADLE) $(PATH_BUILD_ASSETS) $(PATH_BUILD_ASSETS)/cacert.pem $(PATH_BUILD_LIBSCUMMVM) | $(PATH_BUILD)
 	(cd $(PATH_BUILD); ./gradlew assembleDebug)
 	$(CP) $(PATH_BUILD)/build/outputs/apk/debug/$(APK_MAIN) $@
 
-$(APK_MAIN_RELEASE): $(PATH_BUILD_GRADLE) $(PATH_BUILD_ASSETS) $(PATH_BUILD_LIBSCUMMVM) | $(PATH_BUILD)
+$(APK_MAIN_RELEASE): $(PATH_BUILD_GRADLE) $(PATH_BUILD_ASSETS) $(PATH_BUILD_ASSETS)/cacert.pem $(PATH_BUILD_LIBSCUMMVM) | $(PATH_BUILD)
 	(cd $(PATH_BUILD); ./gradlew assembleRelease)
 	$(CP) $(PATH_BUILD)/build/outputs/apk/release/$(APK_MAIN_RELEASE) $@
 

--- a/configure
+++ b/configure
@@ -3377,8 +3377,7 @@ if test -n "$_host"; then
 			_port_mk="backends/platform/3ds/3ds.mk"
 			;;
 		android-arm-v7a | android-arm64-v8a | android-x86 | android-x86_64 | ouya)
-			# also __ANDROID__ is defined by Clang in the NDK
-			DEFINES="$DEFINES -D__ANDROID_PLAIN_PORT__ -DANDROID_PLAIN_PORT"
+			# __ANDROID__ is defined by Clang in the NDK
 			# we link a .so as default
 			append_var LDFLAGS "-shared"
 			append_var LDFLAGS "-Wl,-Bsymbolic,--no-undefined"

--- a/configure
+++ b/configure
@@ -6736,7 +6736,8 @@ test "x$prefix" = xNONE && prefix=/usr/local
 test "x$exec_prefix" = xNONE && exec_prefix='${prefix}'
 
 case $_host_os in
-	ds | mingw*)
+	android | ds | mingw*)
+		# Android don't have a fixed prefix
 		# Windows stores all the external data files in executable file.
 		;;
 	*)
@@ -6747,6 +6748,9 @@ esac
 case $_host in
 	3ds)
 		append_var DEFINES "-DPLUGIN_DIRECTORY=\\\"$datadir/plugins\\\""
+		;;
+	android-*)
+		# Android don't have a fixed prefix
 		;;
 	ds)
 		;;


### PR DESCRIPTION
Bundle CA certificates and make use of it instead of not verifying peers.

Cleanup configure to not define macros pointing to `/usr/local` and remove the `ANDROID_PLAIN_PORT` define which is not used anymore.