### PR TITLE
ENGINES: Initialize mixer volume levels to levels from config

### DIFF
--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -178,6 +178,8 @@ Engine::Engine(OSystem *syst)
 	// Note: Using this dummy palette will actually disable cursor
 	// palettes till the user enables it again.
 	CursorMan.pushCursorPalette(NULL, 0, 0);
+
+	defaultSyncSoundSettings();
 }
 
 Engine::~Engine() {
@@ -793,6 +795,10 @@ void Engine::setGameToLoadSlot(int slot) {
 }
 
 void Engine::syncSoundSettings() {
+	defaultSyncSoundSettings();
+}
+
+void Engine::defaultSyncSoundSettings() {
 	// Sync the engine with the config manager
 	int soundVolumeMusic = ConfMan.getInt("music_volume");
 	int soundVolumeSFX = ConfMan.getInt("sfx_volume");

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -657,6 +657,12 @@ public:
 	virtual int getAutosaveSlot() const {
 		return 0;
 	}
+
+protected:
+	/**
+	 * Syncs the engine's mixer using the default volume syncing behavior.
+	 */
+	void defaultSyncSoundSettings();
 };
 
 


### PR DESCRIPTION
Ran into this while testing Reah.  Basically, `syncSoundSettings` is normally called by the UI any time you leave the menu, however it is not called when launching the game (including when loading a save), which means the engine has to call `syncSoundSettings` itself.

I think it would make sense that if the exiting the UI sets the sound mixer to the expected state by default, then it should be set correctly by default when the game launches too.

I think it is probably not safe to just call `syncSoundSettings` in `runGame` because engines may expect things to be set up a certain way before `syncSoundSettings` is called, however I believe it should be safe to just initialize the mixer.

From what I can tell, every existing engine except for Drascula calls `Engine::syncSoundSettings` in its own `syncSoundSettings` override, and if the engine calls its own `syncSoundSettings` override during startup (which Drascula does) then it won't matter anyway because it'll override this new behavior.

So, basically this removes the need to call `syncSoundSettings` from the engine on startup, which should make engine init slightly simpler.