### PR TITLE
ALL: Fixed typo when erasing window-size

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -714,7 +714,7 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 
 				settings["last_window_width"] = w;
 				settings["last_window_height"] = h;
-				settings.erase("window_size");
+				settings.erase("window-size");
 			END_OPTION
 #endif
 


### PR DESCRIPTION
When parsing the command line option "window-size" the DO_LONG_OPTION inserts "window-size" into the settings StringMap. This is soon later deleted, but instead of deleting "window-size" it deletes the non-existent setting "window_size". This is needed because width and height are stored in "last_window_width" and "last_window_height" respectively and "window-size" is not used anywhere afterwords.