### PR TITLE
COMMON: Upgrade InstallShield archive code

### DIFF
--- a/common/compression/installshield_cab.cpp
+++ b/common/compression/installshield_cab.cpp
@@ -225,7 +225,8 @@ bool InstallShieldCabinet::open(const String &baseName) {
 
 					// Check if the file is split across volumes
 					if (fileIndex == volumeHeader.lastFileIndex &&
-						entry.compressedSize != headerHeader.lastFileSizeCompressed) {
+						entry.compressedSize != headerHeader.lastFileSizeCompressed &&
+						headerHeader.lastFileSizeCompressed != 0) {
 						
 						entry.flags |= kSplit;
 					}


### PR DESCRIPTION
This PR adds support for InstallShield cabinets with files split across
volumes. It should, in theory, also add support for format v5
cabinets with multiple volumes, but I don't have any on hand
to test with.

Code is based on unshield.