### PR TITLE
VIDEO: Use endian-safe loads in for type 12 DXA frames

### DIFF
--- a/video/dxa_decoder.cpp
+++ b/video/dxa_decoder.cpp
@@ -209,7 +209,7 @@ void DXADecoder::DXAVideoTrack::decode12(int size) {
 						  ((*dat & 0x0F) << shiftTbl[type-10].sh2);
 					dat++;
 				} else {
-					diffMap = *(unsigned short*)dat;
+					diffMap = READ_BE_UINT16(dat);
 					dat += 2;
 				}
 


### PR DESCRIPTION
See scummvm/scummvm-tools#68 for more details regarding this change.
