### PR TITLE
SCI32: Mark PQ:SWAT demo as unsupported

### DIFF
--- a/engines/sci/detection_tables.h
+++ b/engines/sci/detection_tables.h
@@ -4453,11 +4453,13 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 
 	// Police Quest: SWAT - English DOS/Windows Demo (from jvprat)
 	// Executable scanning reports "2.100.002", VERSION file reports "0.001.200"
-	{"pqswat", "Demo", {
+	// Currently unsupported, since this demo uses Version 4 of Robot videos,
+	// which we haven't implemented yet in RobotDecoder (bug #14388)
+	{"pqswat", _s("This demo uses an unimplemented version of Robot videos"), {
 		{"resource.map", 0, "8c96733ef94c21526792f7ca4e3f2120", 1648},
 		{"resource.000", 0, "d8892f1b8c56c8f7704325460f49b300", 3676175},
 		AD_LISTEND},
-		Common::EN_ANY, Common::kPlatformDOS, ADGF_DEMO, GUIO_PQSWAT_DEMO },
+		Common::EN_ANY, Common::kPlatformDOS, ADGF_DEMO | ADGF_UNSUPPORTED, GUIO_PQSWAT_DEMO },
 
 	// Police Quest: SWAT - English DOS (from GOG.com)
 	// Executable scanning reports "2.100.002", VERSION file reports "1.0c"

--- a/engines/sci/video/robot_decoder.cpp
+++ b/engines/sci/video/robot_decoder.cpp
@@ -372,6 +372,7 @@ void RobotDecoder::initStream(const GuiResourceId robotId) {
 	_robotId = robotId;
 
 	const uint16 id = stream->readUint16LE();
+	// TODO: id 0x3d for PQ:SWAT demo?
 	if (id != 0x16) {
 		error("Invalid robot file %s", fileName.c_str());
 	}


### PR DESCRIPTION
See [bug #14388](https://bugs.scummvm.org/ticket/14388) for details: the PQ:SWAT demo (`pqswat-win-demo-en.zip`) requires version 4 robot decoding, which is not implemented yet.

Submitting this as a PR just in case, since I'm not really familiar with the way this engine is maintained :)