### PR TITLE
BACKENDS: ENET: Fix GCC/MinGW warning

### DIFF
--- a/backends/networking/enet/source/win32.h
+++ b/backends/networking/enet/source/win32.h
@@ -15,6 +15,8 @@
 #endif
 
 #include <stdlib.h>
+#undef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 
 typedef SOCKET ENetSocket;


### PR DESCRIPTION
```
packet.cpp:121:9: warning: declaration of 'byte' shadows a global declaration [-Wshadow]
  121 |     int byte;
      |         ^~~~
In file included from C:/msys64/mingw64/include/wtypes.h:8,
                 from C:/msys64/mingw64/include/winscard.h:10,
                 from C:/msys64/mingw64/include/windows.h:97,
                 from C:/msys64/mingw64/include/winsock2.h:23,
                 from C:/Projects/scummvm/backends/networking/enet/source/win32.h:18,
                 from C:/Projects/scummvm/backends/networking/enet/source/enet.h:16,
                 from C:/Projects/scummvm/backends/networking/enet/source/packet.cpp:7:
C:/msys64/mingw64/include/rpcndr.h:63:25: note: shadowed declaration is here
   63 |   typedef unsigned char byte;
      |                         ^~~~
```

Fix by defining WIN32_LEAN_AND_MEAN, which prevents this typedef.
