### PR TITLE
VIDEO: Fix signed/unsigned mismatch potentially breaking DXA seek.

### DIFF
--- a/video/dxa_decoder.cpp
+++ b/video/dxa_decoder.cpp
@@ -69,7 +69,7 @@ void DXADecoder::readSoundData(Common::SeekableReadStream *stream) {
 
 		addStreamTrack(Audio::makeWAVStream(stream->readStream(size), DisposeAfterUse::YES));
 	} else if (tag != MKTAG('N','U','L','L')) {
-		stream->skip(-4);
+		stream->seek(-4, SEEK_CUR);
 	}
 }
 


### PR DESCRIPTION
Fixes VS warning that can potentially cause wrong behavior in DXA decoder:
`dxa_decoder.cpp(72,18): warning C4245: 'argument': conversion from 'int' to 'uint32', signed/unsigned mismatch`

`skip` accepts a uint32 parameter and then passes it to `seek` which accepts an int64.  This is problematic because converting -4 to a uint32 may cause it to become 4294967292, causing the seek to fail if the underlying stream doesn't demote it back to 32-bit.