### PR TITLE
CREATE_PROJECT/CI: Add libmikmod support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,8 @@ jobs:
         include:
           - platform: macosx
             buildFlags: -scheme ScummVM-macOS
-            configFlags: --disable-nasm --enable-faad --enable-gif --enable-mpeg2 --enable-vpx
-            brewPackages: a52dec faad2 flac fluid-synth freetype fribidi giflib jpeg mad libmpeg2 libogg libpng libvorbis libvpx sdl2 sdl2_net theora
+            configFlags: --disable-nasm --enable-faad --enable-gif --enable-mikmod --enable-mpeg2 --enable-vpx
+            brewPackages: a52dec faad2 flac fluid-synth freetype fribidi giflib jpeg mad libmikmod libmpeg2 libogg libpng libvorbis libvpx sdl2 sdl2_net theora
           - platform: ios7
             buildFlags: -scheme ScummVM-iOS CODE_SIGN_IDENTITY="" CODE_SIGNING_ALLOWED=NO
             configFlags: --disable-nasm --disable-opengl --disable-theoradec --disable-mpeg2 --disable-taskbar --disable-tts --disable-fribidi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,11 +160,11 @@ jobs:
           - platform: ubuntu-latest
             sdlConfig: sdl2-config
             cxx: ccache g++
-            aptPackages: 'liba52-dev libcurl4-openssl-dev libfaad-dev libflac-dev libfluidsynth-dev libfreetype6-dev libfribidi-dev libgif-dev libgtk-3-dev libjpeg-turbo8-dev libmad0-dev libmpeg2-4-dev libogg-dev libpng-dev libsdl2-dev libsdl2-net-dev libsndio-dev libspeechd-dev libtheora-dev libunity-dev libvorbis-dev libvpx-dev zlib1g-dev'
+            aptPackages: 'liba52-dev libcurl4-openssl-dev libfaad-dev libflac-dev libfluidsynth-dev libfreetype6-dev libfribidi-dev libgif-dev libgtk-3-dev libjpeg-turbo8-dev libmad0-dev libmikmod-dev libmpeg2-4-dev libogg-dev libpng-dev libsdl2-dev libsdl2-net-dev libsndio-dev libspeechd-dev libtheora-dev libunity-dev libvorbis-dev libvpx-dev zlib1g-dev'
           - platform: ubuntu-20.04
             sdlConfig: sdl-config
             cxx: ccache g++-4.8
-            aptPackages: 'g++-4.8 liba52-dev libcurl4-openssl-dev libfaad-dev libflac-dev libfluidsynth-dev libfreetype6-dev libfribidi-dev libgif-dev libgtk-3-dev libjpeg-turbo8-dev libmad0-dev libmpeg2-4-dev libogg-dev libpng-dev libsdl-net1.2-dev libsdl1.2-dev libsndio-dev libspeechd-dev libtheora-dev libunity-dev libvorbis-dev libvpx-dev zlib1g-dev'
+            aptPackages: 'g++-4.8 liba52-dev libcurl4-openssl-dev libfaad-dev libflac-dev libfluidsynth-dev libfreetype6-dev libfribidi-dev libgif-dev libgtk-3-dev libjpeg-turbo8-dev libmad0-dev libmikmod-dev libmpeg2-4-dev libogg-dev libpng-dev libsdl-net1.2-dev libsdl1.2-dev libsndio-dev libspeechd-dev libtheora-dev libunity-dev libvorbis-dev libvpx-dev zlib1g-dev'
     env:
       SDL_CONFIG: ${{ matrix.sdlConfig }}
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,21 +15,21 @@ jobs:
           - platform: win32
             triplet: x86-windows
             arch: x86
-            configFlags: --enable-discord --enable-faad --enable-gif --enable-mpeg2 --enable-vpx
-            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype fribidi giflib libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis libvpx sdl2 sdl2-net zlib'
+            configFlags: --enable-discord --enable-faad --enable-gif --enable-mikmod --enable-mpeg2 --enable-vpx
+            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype fribidi giflib libflac libjpeg-turbo libmad libmikmod libmpeg2 libogg libpng libtheora libvorbis libvpx sdl2 sdl2-net zlib'
             useNasm: 'true'
           - platform: x64
             arch: x64
             triplet: x64-windows
-            configFlags: --enable-discord --enable-faad --enable-gif --enable-mpeg2 --enable-vpx
-            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype fribidi giflib libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis libvpx sdl2 sdl2-net zlib'
+            configFlags: --enable-discord --enable-faad --enable-gif --enable-mikmod --enable-mpeg2 --enable-vpx
+            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype fribidi giflib libflac libjpeg-turbo libmad libmikmod libmpeg2 libogg libpng libtheora libvorbis libvpx sdl2 sdl2-net zlib'
           - platform: arm64
             arch: arm64
             triplet: arm64-windows
             # fribidi is disabled due to https://github.com/microsoft/vcpkg/issues/11248 [fribidi] Fribidi doesn't cross-compile on x86-64 to target arm/arm64
             # Note that fribidi is also disabled on arm64 in devtools/create_project/msvc.cpp
-            configFlags: --enable-discord --enable-faad --enable-gif --enable-mpeg2 --enable-vpx --disable-fribidi --disable-opengl
-            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype giflib libflac libjpeg-turbo libmad libmpeg2 libogg libpng libtheora libvorbis libvpx sdl2 sdl2-net zlib'
+            configFlags: --enable-discord --enable-faad --enable-gif --enable-mikmod --enable-mpeg2 --enable-vpx --disable-fribidi --disable-opengl
+            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype giflib libflac libjpeg-turbo libmad libmikmod libmpeg2 libogg libpng libtheora libvorbis libvpx sdl2 sdl2-net zlib'
     env:
       CONFIGURATION: Debug
       PLATFORM: ${{ matrix.platform }}

--- a/audio/mods/impulsetracker.cpp
+++ b/audio/mods/impulsetracker.cpp
@@ -23,6 +23,12 @@
 // mikmod headers.
 #define FORBIDDEN_SYMBOL_EXCEPTION_FILE
 
+// On Windows, unlink and setjmp may also be triggered.
+#if defined(WIN32)
+#define FORBIDDEN_SYMBOL_EXCEPTION_unlink
+#define FORBIDDEN_SYMBOL_EXCEPTION_setjmp
+#endif
+
 #include "audio/mods/impulsetracker.h"
 
 #ifdef USE_MIKMOD

--- a/devtools/create_project/cmake.cpp
+++ b/devtools/create_project/cmake.cpp
@@ -48,6 +48,7 @@ const CMakeProvider::Library *CMakeProvider::getLibraryFromFeature(const char *f
 		LibraryProps("sdlnet", "SDL2_net", kSDLVersion2).Libraries("SDL2_net"),
 		LibraryProps("flac", "flac").Libraries("FLAC"),
 		LibraryProps("mad", "mad").Libraries("mad"),
+		LibraryProps("mikmod", "mikmod").Libraries("mikmod"),
 		LibraryProps("ogg", "ogg").Libraries("ogg"),
 		LibraryProps("vorbis", "vorbisfile vorbis").Libraries("vorbisfile vorbis"),
 		LibraryProps("tremor", "vorbisidec").Libraries("vorbisidec"),

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1066,6 +1066,7 @@ const Feature s_features[] = {
 	{       "png",         "USE_PNG", true, true,  "libpng support" },
 	{       "gif",         "USE_GIF", true, false, "libgif support" },
 	{      "faad",        "USE_FAAD", true, false, "AAC support" },
+	{    "mikmod",      "USE_MIKMOD", true, false, "libmikmod support" },
 	{     "mpeg2",       "USE_MPEG2", true, true,  "MPEG-2 support" },
 	{ "theoradec",   "USE_THEORADEC", true, true,  "Theora decoding support" },
 	{       "vpx",         "USE_VPX", true, false, "VP8/VP9 decoding support" },

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -65,6 +65,7 @@ std::string MSVCProvider::getLibraryFromFeature(const char *feature, const Build
 		{       "png", "libpng16.lib",              "libpng16d.lib", nullptr,                                           nullptr },
 		{       "gif", "gif.lib",                   nullptr,         nullptr,                                           nullptr },
 		{      "faad", "faad.lib",                  nullptr,         nullptr,                                           "libfaad.lib" },
+		{    "mikmod", "mikmod.lib",                nullptr,         nullptr,                                           nullptr },
 		{     "mpeg2", "mpeg2.lib",                 nullptr,         nullptr,                                           "libmpeg2.lib" },
 		{ "theoradec", "theora.lib",                nullptr,         nullptr,                                           "libtheora_static.lib" },
 		{       "vpx", "vpx.lib",                   nullptr,         nullptr,                                           nullptr },

--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -502,6 +502,9 @@ void XcodeProvider::setupFrameworksBuildPhase(const BuildSetup &setup) {
 	if (CONTAINS_DEFINE(setup.defines, "USE_MAD")) {
 		DEF_LOCALLIB_STATIC("libmad");
 	}
+	if (CONTAINS_DEFINE(setup.defines, "USE_MIKMOD")) {
+		DEF_LOCALLIB_STATIC("libmikmod");
+	}
 	if (CONTAINS_DEFINE(setup.defines, "USE_MPEG2")) {
 		DEF_LOCALLIB_STATIC("libmpeg2");
 	}
@@ -625,6 +628,9 @@ void XcodeProvider::setupFrameworksBuildPhase(const BuildSetup &setup) {
 	if (CONTAINS_DEFINE(setup.defines, "USE_MAD")) {
 		frameworks_iOS.push_back("libmad.a");
 	}
+	if (CONTAINS_DEFINE(setup.defines, "USE_MIKMOD")) {
+		frameworks_iOS.push_back("libmikmod.a");
+	}
 	if (CONTAINS_DEFINE(setup.defines, "USE_MPEG2")) {
 		frameworks_iOS.push_back("libmpeg2.a");
 	}
@@ -715,6 +721,9 @@ void XcodeProvider::setupFrameworksBuildPhase(const BuildSetup &setup) {
 	}
 	if (CONTAINS_DEFINE(setup.defines, "USE_MAD")) {
 		frameworks_osx.push_back("libmad.a");
+	}
+	if (CONTAINS_DEFINE(setup.defines, "USE_MIKMOD")) {
+		frameworks_osx.push_back("libmikmod.a");
 	}
 	if (CONTAINS_DEFINE(setup.defines, "USE_MPEG2")) {
 		frameworks_osx.push_back("libmpeg2.a");


### PR DESCRIPTION
This continues the work from PR #4836 so that the libmikmod library (used by the Sludge engine) may also be used in `create_project` and in our CI builds.

Done as a best-effort; I'm not 100% sure all `create_project` changes are correct.

Tested with an Xcode and an MSVC build, and with the Github Actions I'm also updating in the same PR.