### PR TITLE
SCUMM HE: Additional data in login payload, hit quality mod

### DIFF
--- a/base/version.cpp
+++ b/base/version.cpp
@@ -55,7 +55,6 @@
  * to properly work in exports (i.e. release tar balls etc.).
  */
 const char gScummVMVersion[] = SCUMMVM_VERSION SCUMMVM_REVISION;
-const char gScummVMVersionLite[] = SCUMMVM_VERSION;
 #if defined(__amigaos4__) || defined(__MORPHOS__)
 static const char *version_cookie __attribute__((used)) = "$VER: ScummVM " SCUMMVM_VERSION SCUMMVM_REVISION " (" AMIGA_DATE ")";
 #endif

--- a/base/version.h
+++ b/base/version.h
@@ -23,7 +23,6 @@
 #define BASE_VERSION_H
 
 extern const char gScummVMVersion[];     // e.g. "0.4.1"
-extern const char gScummVMVersionLite[]; // e.g. "0.4.1" (without version control revisions)
 extern const char gScummVMBuildDate[];   // e.g. "2003-06-24"
 extern const char gScummVMVersionDate[]; // e.g. "0.4.1 (2003-06-24)"
 extern const char gScummVMCompiler[];    // e.g. "GCC 11.2.0"

--- a/engines/scumm/he/net/net_lobby.cpp
+++ b/engines/scumm/he/net/net_lobby.cpp
@@ -429,7 +429,7 @@ void Lobby::login(const char *userName, const char *password) {
 	loginRequestParameters.setVal("user", new Common::JSONValue(_userName));
 	loginRequestParameters.setVal("pass", new Common::JSONValue((Common::String)password));
 	loginRequestParameters.setVal("game", new Common::JSONValue((Common::String)_gameName));
-	loginRequestParameters.setVal("version", new Common::JSONValue(gScummVMVersionLite));
+	loginRequestParameters.setVal("version", new Common::JSONValue(gScummVMFullVersion));
 	loginRequestParameters.setVal("competitive_mods", new Common::JSONValue(ConfMan.getBool("enable_competitive_mods")));
 
 	send(loginRequestParameters);

--- a/engines/scumm/he/net/net_lobby.cpp
+++ b/engines/scumm/he/net/net_lobby.cpp
@@ -430,6 +430,7 @@ void Lobby::login(const char *userName, const char *password) {
 	loginRequestParameters.setVal("pass", new Common::JSONValue((Common::String)password));
 	loginRequestParameters.setVal("game", new Common::JSONValue((Common::String)_gameName));
 	loginRequestParameters.setVal("version", new Common::JSONValue(gScummVMVersionLite));
+	loginRequestParameters.setVal("competitive_mods", new Common::JSONValue(ConfMan.getBool("enable_competitive_mods")));
 
 	send(loginRequestParameters);
 }

--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -577,6 +577,26 @@ int ScummEngine::readVar(uint var) {
 		if (_game.heversion >= 80) {
 			var &= 0xFFF;
 			assertRange(0, var, _numRoomVariables - 1, "room variable (reading)");
+
+#if defined(USE_ENET) && defined(USE_LIBCURL)
+			if (ConfMan.getBool("enable_competitive_mods")) {
+				// Mod for Backyard Baseball 2001 online competitive play: increase hit quality
+				// for pitches on the inside corners
+				if (_game.id == GID_BASEBALL2001 &&
+					_currentRoom == 4 && vm.slot[_currentScript].number == 2085 &&  // The script that calculates hit quality
+					readVar(399) == 1 &&  // Check that we're playing online
+					var == 2 &&  // Reading room variable 2, which is the zone that the ball is pitched to
+					readVar(447) == 1  // And the batter is in an open stance
+				) {
+					if (_roomVars[0] == 1 && (_roomVars[var] == 9 || _roomVars[var] == 37)) {  // Right-handed batter
+						return _roomVars[var] + 1;
+					} else if (_roomVars[0] == 2 && (_roomVars[var] == 13 || _roomVars[var] == 41)) {  // Left-handed batter
+						return _roomVars[var] - 1;
+					}
+				}
+			}
+#endif
+
 			return _roomVars[var];
 
 		} else if (_game.version <= 3 && !(_game.id == GID_INDY3 && _game.platform == Common::kPlatformFMTowns) &&


### PR DESCRIPTION
This PR contains three changes, hope it's OK that I've combined them in this PR:
* Adds whether the user has competitive play mods enabled (`ConfMan.getBool("enable_competitive_mods")`) to the payload sent to the lobby server with the login request. We can log this on the server end, and maybe at some point in the future will want to use it on the server end to make it so that players with these mods enabled can only play against others who have them enabled, and players without them can only play opponents without them. Otherwise, we can end up with confusing or unfair gameplay.
* Sends `gScummVMFullVersion`, which includes the build timestamp, as `version` in the login request. We've made some bugfixes and changes to online play more frequently than ScummVM releases new versions, and having the full version can help us diagnose bugs and issues that users are having. It would be cool if we could send the git commit hash or something, but I guess this will do - [this comment](https://github.com/scummvm/scummvm/blob/f7990d0d154f9b71169a320bb4b8d404054f5fb9/base/version.cpp#L32) implies that this is the closest we can get, which works fine for our purposes.
* Implements a competitive play mod that increases hit quality for pitches on the lower-inside and upper-inside corners of the strike zone when the batter is using an open stance. For competitive players who understand the game's mechanics, these pitches are much easier to throw then they are to hit well. The optimal strategy for pitchers is usually to throw pitches in these locations repeatedly, which makes gameplay less fun. For more on how this mechanic works, see [this sheet](https://docs.google.com/spreadsheets/d/1MuY5J9ExhDQmay0__12_nei2gjBzDFn5HL513JVSVWM/edit#gid=658283984) (note the difference between the "Current" and "Proposed" sheets).