### PR TITLE
GUI: Collapsed game groups are persisted

### DIFF
--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -957,6 +957,7 @@ LauncherDisplayType getRequestedLauncherType() {
 class LauncherSimple : public LauncherDialog {
 public:
 	LauncherSimple(const Common::String &title, LauncherChooser *chooser);
+	~LauncherSimple() override;
 
 	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data) override;
 	void handleKeyDown(Common::KeyState state) override;
@@ -978,6 +979,7 @@ private:
 class LauncherGrid : public LauncherDialog {
 public:
 	LauncherGrid(const Common::String &title, LauncherChooser *chooser);
+	~LauncherGrid() override;
 
 	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data) override;
 	void handleKeyDown(Common::KeyState state) override;
@@ -1043,6 +1045,10 @@ LauncherSimple::LauncherSimple(const Common::String &title, LauncherChooser *cho
 	: LauncherDialog(title, chooser),
 	_list(nullptr) {
 	build();
+}
+
+LauncherSimple::~LauncherSimple() {
+	_list->saveClosedGroups(Common::U32String(groupingModes[_groupBy].name));
 }
 
 void LauncherSimple::selectTarget(const Common::String &target) {
@@ -1144,6 +1150,9 @@ void LauncherSimple::updateListing() {
 	// Update the filter settings, those are lost when "setList"
 	// is called.
 	_list->setFilter(_searchWidget->getEditString());
+	
+	// Close groups that the user closed earlier
+	_list->loadClosedGroups(Common::U32String(groupingModes[_groupBy].name));
 }
 
 void LauncherSimple::groupEntries(const Common::Array<LauncherEntry> &metadata) {
@@ -1282,6 +1291,7 @@ void LauncherSimple::handleCommand(CommandSender *sender, uint32 cmd, uint32 dat
 		// Change the grouping criteria
 		GroupingMethod newGroupBy = (GroupingMethod)data;
 		if (_groupBy != newGroupBy) {
+			_list->saveClosedGroups(Common::U32String(groupingModes[_groupBy].name));
 			_groupBy = newGroupBy;
 			const GroupingMode *mode = groupingModes;
 			while (mode->name) {
@@ -1334,6 +1344,10 @@ LauncherGrid::LauncherGrid(const Common::String &title, LauncherChooser *chooser
 	: LauncherDialog(title, chooser),
 	_grid(nullptr), _gridItemSizeSlider(nullptr), _gridItemSizeLabel(nullptr) {
 	build();
+}
+
+LauncherGrid::~LauncherGrid() {
+	_grid->saveClosedGroups(Common::U32String(groupingModes[_groupBy].name));
 }
 
 void LauncherGrid::groupEntries(const Common::Array<LauncherEntry> &metadata) {
@@ -1475,6 +1489,8 @@ void LauncherGrid::handleCommand(CommandSender *sender, uint32 cmd, uint32 data)
 		_grid->setFilter(Common::U32String());
 		break;
 	case kSetGroupMethodCmd: {
+		_grid->saveClosedGroups(Common::U32String(groupingModes[_groupBy].name));
+	
 		// Change the grouping criteria
 		GroupingMethod newGroupBy = (GroupingMethod)data;
 		if (_groupBy != newGroupBy) {
@@ -1545,6 +1561,8 @@ void LauncherGrid::updateListing() {
 		// Select the last entry if the list has been reduced
 		_grid->setSelected(gridList.size() - 1);
 	updateButtons();
+
+	_grid->loadClosedGroups(Common::U32String(groupingModes[_groupBy].name));
 }
 
 void LauncherGrid::updateButtons() {

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -209,6 +209,44 @@ void GridWidget::toggleGroup(int groupID) {
 	reflowLayout();
 }
 
+void GridWidget::loadClosedGroups(const Common::U32String &groupName) {
+	// Recalls what groups were closed from the config
+	if (ConfMan.hasKey("group_" + groupName, ConfMan.kApplicationDomain)) {
+		const Common::String &val = ConfMan.get("group_" + groupName, ConfMan.kApplicationDomain);
+		Common::StringTokenizer hiddenGroups(val);
+
+		for (Common::String tok = hiddenGroups.nextToken(); tok.size(); tok = hiddenGroups.nextToken()) {
+			// See if the hidden group is in our group headers still, if so, hide it
+			for (Common::U32StringArray::size_type i = 0; i < _groupHeaders.size(); ++i) {
+				if (_groupHeaders[i] == tok || (tok == "unnamed" && _groupHeaders[i].size() == 0)) {
+					_groupExpanded[i] = false;
+					break;
+				}
+			}
+		}
+		sortGroups();
+		// TODO: Replace reflowLayout with only the necessary sequence of steps
+		// reflowLayout();
+	}
+}
+
+void GridWidget::saveClosedGroups(const Common::U32String &groupName) {
+	// Save the hidden groups to the config
+	Common::String hiddenGroups;
+	for (Common::U32StringArray::size_type i = 0; i < _groupHeaders.size(); ++i) {
+		if (!_groupExpanded[i]) {
+			if (_groupHeaders[i].size()) {
+				hiddenGroups += _groupHeaders[i];
+			} else {
+				hiddenGroups += "unnamed";
+			}
+			hiddenGroups += ' ';
+		}
+	}
+	ConfMan.set("group_" + groupName, hiddenGroups, ConfMan.kApplicationDomain);
+	ConfMan.flushToDisk();
+}
+
 void GridItemWidget::handleMouseDown(int x, int y, int button, int clickCount) {
 	if (_activeEntry->isHeader) {
 		_grid->_selectedEntry = nullptr;

--- a/gui/widgets/grid.h
+++ b/gui/widgets/grid.h
@@ -189,6 +189,8 @@ public:
 	void sortGroups();
 	bool groupExpanded(int groupID) { return _groupExpanded[groupID]; }
 	void toggleGroup(int groupID);
+	void loadClosedGroups(const Common::U32String &groupName);
+	void saveClosedGroups(const Common::U32String &groupName);
 
 	void reloadThumbnails();
 	void loadFlagIcons();
@@ -210,7 +212,6 @@ public:
 
 	void handleMouseWheel(int x, int y, int direction) override;
 	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data) override;
-
 	void reflowLayout() override;
 
 	bool wantsFocus() override { return true; }

--- a/gui/widgets/groupedlist.cpp
+++ b/gui/widgets/groupedlist.cpp
@@ -23,6 +23,7 @@
 #include "common/frac.h"
 #include "common/tokenizer.h"
 #include "common/translation.h"
+#include "common/config-manager.h"
 
 #include "gui/widgets/groupedlist.h"
 #include "gui/widgets/scrollbar.h"
@@ -153,6 +154,42 @@ void GroupedListWidget::sortGroups() {
 	} else {
 		markAsDirty();
 	}
+}
+
+void GroupedListWidget::loadClosedGroups(const Common::U32String &groupName) {
+	// Recalls what groups were closed from the config
+	if (ConfMan.hasKey("group_" + groupName, ConfMan.kApplicationDomain)) {
+		const Common::String &val = ConfMan.get("group_" + groupName, ConfMan.kApplicationDomain);
+		Common::StringTokenizer hiddenGroups(val);
+
+		for (Common::String tok = hiddenGroups.nextToken(); tok.size(); tok = hiddenGroups.nextToken()) {
+			// See if the hidden group is in our group headers still, if so, hide it
+			for (Common::U32StringArray::size_type i = 0; i < _groupHeaders.size(); ++i) {
+				if (_groupHeaders[i] == tok || (tok == "unnamed" && _groupHeaders[i].size() == 0)) {
+					_groupExpanded[i] = false;
+					break;
+				}
+			}
+		}
+		sortGroups();
+	}
+}
+
+void GroupedListWidget::saveClosedGroups(const Common::U32String &groupName) {
+	// Save the hidden groups to the config
+	Common::String hiddenGroups;
+	for (Common::U32StringArray::size_type i = 0; i < _groupHeaders.size(); ++i) {
+		if (!_groupExpanded[i]) {
+			if (_groupHeaders[i].size()) {
+				hiddenGroups += _groupHeaders[i];
+			} else {
+				hiddenGroups += "unnamed";
+			}
+			hiddenGroups += ' ';
+		}
+	}
+	ConfMan.set("group_" + groupName, hiddenGroups, ConfMan.kApplicationDomain);
+	ConfMan.flushToDisk();
 }
 
 void GroupedListWidget::setSelected(int item) {

--- a/gui/widgets/groupedlist.h
+++ b/gui/widgets/groupedlist.h
@@ -52,6 +52,8 @@ public:
 
 	void setGroupHeaderFormat(const Common::U32String &prefix, const Common::U32String &suffix);
 	void groupByAttribute();
+	void loadClosedGroups(const Common::U32String &groupName);
+	void saveClosedGroups(const Common::U32String &groupName);
 
 	void setSelected(int item);
 	int getSelected() const { return (_selectedItem == -1) ? _selectedItem : _listIndex[_selectedItem]; }


### PR DESCRIPTION
GroupedListWidget and GridWidget can save what groups they have collapsed to the config file and reload them. "launcher.cpp" uses those functions to persist those collapsed groups through
  - changing how the games are grouped by
  - going from list to grid mode and vice versa
  - quitting scummvm and starting it again