### PR TITLE
COMMON/MATH: Add some constexpr constructors to Array/List/String/Rect and the Matrix base-classes.

### DIFF
--- a/common/array.h
+++ b/common/array.h
@@ -64,7 +64,7 @@ protected:
 	T *_storage;  /*!< Memory used for element storage. */
 
 public:
-	Array() : _capacity(0), _size(0), _storage(nullptr) {}
+	constexpr Array() : _capacity(0), _size(0), _storage(nullptr) {}
 
 	/**
 	 * Construct an array with @p count default-inserted instances of @p T. No

--- a/common/list.h
+++ b/common/list.h
@@ -59,10 +59,7 @@ public:
 	/**
 	 * Construct a new empty list.
 	 */
-	List() {
-		_anchor._prev = &_anchor;
-		_anchor._next = &_anchor;
-	}
+	constexpr List() : _anchor(&_anchor, &_anchor) {}
 	List(const List<t_T> &list) {  /*!< Construct a new list as a copy of the given @p list. */
 		_anchor._prev = &_anchor;
 		_anchor._next = &_anchor;

--- a/common/list_intern.h
+++ b/common/list_intern.h
@@ -31,8 +31,11 @@ template<typename T> class List;
 
 namespace ListInternal {
 	struct NodeBase {
-		NodeBase *_prev;
-		NodeBase *_next;
+		NodeBase *_prev = nullptr;
+		NodeBase *_next = nullptr;
+
+		constexpr NodeBase() = default;
+		constexpr NodeBase(NodeBase *prev, NodeBase *next) : _prev(prev), _next(next) {}
 	};
 
 	template<typename T>

--- a/common/rect.h
+++ b/common/rect.h
@@ -46,12 +46,12 @@ struct Point {
 	int16 x;	/*!< The horizontal position of the point. */
 	int16 y;	/*!< The vertical position of the point. */
 
-	Point() : x(0), y(0) {}
+	constexpr Point() : x(0), y(0) {}
 
 	/**
 	 * Create a point with position defined by @p x1 and @p y1.
 	 */
-	Point(int16 x1, int16 y1) : x(x1), y(y1) {}
+	constexpr Point(int16 x1, int16 y1) : x(x1), y(y1) {}
 	/**
 	 * Determine whether the position of two points is the same.
 	 */
@@ -145,11 +145,11 @@ struct Rect {
 	int16 top, left;		/*!< The point at the top left of the rectangle (part of the Rect). */
 	int16 bottom, right;	/*!< The point at the bottom right of the rectangle (not part of the Rect). */
 
-	Rect() : top(0), left(0), bottom(0), right(0) {}
+	constexpr Rect() : top(0), left(0), bottom(0), right(0) {}
 	/**
 	 * Create a rectangle with the top-left corner at position (0, 0) and the given width @p w and height @p h.
 	 */
-	Rect(int16 w, int16 h) : top(0), left(0), bottom(h), right(w) {}
+	constexpr Rect(int16 w, int16 h) : top(0), left(0), bottom(h), right(w) {}
 	/**
 	 * Create a rectangle with the top-left corner at the given position (x1, y1)
 	 * and the bottom-right corner at the position (x2, y2).

--- a/common/str-base.h
+++ b/common/str-base.h
@@ -81,7 +81,7 @@ protected:
 
 public:
 	/** Construct a new empty string. */
-	BaseString() : _size(0), _str(_storage) { _storage[0] = 0; }
+	constexpr BaseString() : _size(0), _str(_storage), _storage{0} {}
 
 	/** Construct a copy of the given string. */
 	BaseString(const BaseString &str);

--- a/common/str.h
+++ b/common/str.h
@@ -66,7 +66,7 @@ public:
 	typedef unsigned char unsigned_type;
 
 	/** Construct a new empty string. */
-	String() : BaseString<char>() {}
+	constexpr String() : BaseString<char>() {}
 
 	/** Construct a new string from the given NULL-terminated C string. */
 	String(const char *str) : BaseString<char>(str) {}

--- a/common/ustr.h
+++ b/common/ustr.h
@@ -59,7 +59,7 @@ public:
 	typedef uint32 unsigned_type; /*!< Unsigned version of the underlying type. */
 public:
 	/** Construct a new empty string. */
-	U32String() : BaseString<u32char_type_t>() {}
+	constexpr U32String() : BaseString<u32char_type_t>() {}
 
 	/** Construct a new string from the given null-terminated C string. */
 	explicit U32String(const value_type *str) : BaseString<u32char_type_t>(str) {}

--- a/math/matrix.h
+++ b/math/matrix.h
@@ -143,7 +143,7 @@ public:
 	Matrix<rows, cols> &operator/=(const Matrix<rows, cols> &m);
 
 protected:
-	MatrixBase();
+	constexpr MatrixBase() = default;
 	MatrixBase(const float *data);
 	MatrixBase(const MatrixBase<rows, cols> &m);
 	MatrixBase &operator=(const MatrixBase<rows, cols> &m);
@@ -154,7 +154,7 @@ protected:
 		return *static_cast<Matrix<rows, cols> *>(this); }
 
 private:
-	float _values[rows * cols];
+	float _values[rows * cols] = { 0.0f };
 };
 
 /**
@@ -164,7 +164,7 @@ private:
 template<int r, int c>
 class MatrixType : public MatrixBase<r, c> {
 protected:
-	MatrixType() : MatrixBase<r, c>() { }
+	constexpr MatrixType() : MatrixBase<r, c>() { }
 	MatrixType(const float *data) : MatrixBase<r, c>(data) { }
 	MatrixType(const MatrixBase<r, c> &m) : MatrixBase<r, c>(m) { }
 };
@@ -179,7 +179,7 @@ protected:
 template<int r, int c>
 class Matrix : public MatrixType<r, c> {
 public:
-	Matrix() : MatrixType<r, c>() { }
+	constexpr Matrix() : MatrixType<r, c>() { }
 	Matrix(const float *data) : MatrixType<r, c>(data) { }
 	Matrix(const MatrixBase<r, c> &m) : MatrixType<r, c>(m) { }
 };
@@ -214,13 +214,6 @@ bool operator!=(const Matrix<r, c> &m1, const Matrix<r, c> &m2);
 
 
 // Constructors
-template<int rows, int cols>
-MatrixBase<rows, cols>::MatrixBase() {
-	for (int i = 0; i < rows * cols; ++i) {
-		_values[i] = 0.f;
-	}
-}
-
 template<int rows, int cols>
 MatrixBase<rows, cols>::MatrixBase(const float *data) {
 	setData(data);

--- a/math/matrix3.cpp
+++ b/math/matrix3.cpp
@@ -23,14 +23,6 @@
 
 namespace Math {
 
-Matrix<3, 3>::Matrix() :
-	MatrixType<3, 3>(), Rotation3D<Matrix<3, 3> >() {
-}
-
-Matrix<3, 3>::Matrix(const MatrixBase<3, 3> &m) :
-	MatrixType<3, 3>(m), Rotation3D<Matrix<3, 3> >() {
-}
-
 void swap (float &a, float &b) {
 	float c = a; a = b; b = c;
 }

--- a/math/matrix3.h
+++ b/math/matrix3.h
@@ -31,8 +31,10 @@ namespace Math {
 template<>
 class Matrix<3, 3> : public MatrixType<3, 3>, public Rotation3D<Matrix<3, 3> > {
 public:
-	Matrix();
-	Matrix(const MatrixBase<3, 3> &m);
+	Matrix() : MatrixType<3, 3>(), Rotation3D<Matrix<3, 3> >() {}
+	Matrix(const MatrixBase<3, 3> &m) :
+		MatrixType<3, 3>(m), Rotation3D<Matrix<3, 3> >() {
+	}
 
 	void transpose();
 

--- a/math/rotation3d.h
+++ b/math/rotation3d.h
@@ -52,7 +52,7 @@ enum EulerOrder {
 template<class T>
 class Rotation3D : public Transform<T> {
 public:
-	Rotation3D();
+	constexpr Rotation3D();
 
 	/**
 	 * Constructor and assignment from buildFromEuler
@@ -101,7 +101,7 @@ public:
 };
 
 template<class T>
-Rotation3D<T>::Rotation3D() : Transform<T>() {}
+constexpr Rotation3D<T>::Rotation3D() : Transform<T>() {}
 
 template<class T>
 void Rotation3D<T>::buildFromEuler(const Angle &first, const Angle &second, const Angle &third, EulerOrder order) {

--- a/math/transform.h
+++ b/math/transform.h
@@ -27,7 +27,7 @@ namespace Math {
 template<class T>
 class Transform {
 public:
-	Transform() {}
+	constexpr Transform() {}
 
 protected:
 	inline const T &getMatrix() const { return *static_cast<const T *>(this); }


### PR DESCRIPTION
While working on some code that had a large amount of global variables, I wanted to get rid of the global constructor warnings that ensued once I started to use our collections/string classes in these global variables. While the globals will eventually go away in my codebase, there are also constants that would benefit from not having to run constructors.

After having a bit of a look, it seems that as long as there is a constexpr constructor available (which requires that all members are also constexpr-constructible), we can avoid global constructors.

So this is a quick attempt at adding constexpr constructors to the above mentioned classes, as well as the beginnings of supporting this in the Matrix classes as well, however the Matrix attempt is currently blocked by the logic for initializing with the identity matrix, as calling setToIdentity() triggers a warning about this being a C++14 extension.

Similarly the constructor for Common::String has to use an initializer list for the storage array, for which I've seen some comments on StackOverflow that mention that initializing arrays in the initializer list might have problems in some versions of MSVC.

This needs a fair bit of testing across compilers to be sure it doesn't break the compile on some platform, and the overall benefit boils down to being able to create compile time constants of classes that contain these classes.