### PR TITLE
TETRAEDGE: Support Hebrew fan translation

### DIFF
--- a/engines/tetraedge/detection.cpp
+++ b/engines/tetraedge/detection.cpp
@@ -45,6 +45,7 @@ static const Common::Language *getGameLanguages() {
 		Common::IT_ITA,
 		Common::ES_ESP,
 		Common::RU_RUS,
+		Common::HE_ISR,  // This is a Fan-translation, which requires additional patch
 		Common::UNK_LANG
 	};
 	return languages;

--- a/engines/tetraedge/game/application.cpp
+++ b/engines/tetraedge/game/application.cpp
@@ -177,12 +177,13 @@ void Application::create() {
 	if (g_engine->gameType() != TetraedgeEngine::kAmerzone) {
 		const Common::Path helpMenuPath("menus/help/help_");
 		Common::Path helpMenuFilePath;
+		Common::String lang(core->language());
 		i = 0;
 		while (i < ARRAYSIZE(allLangs)) {
-			helpMenuFilePath = helpMenuPath.append(core->language() + ".xml");
+			helpMenuFilePath = helpMenuPath.append(lang + ".xml");
 			if (Common::File::exists(helpMenuFilePath))
 				break;
-			core->language(allLangs[i]);
+			lang = allLangs[i];
 			i++;
 		}
 		if (i == ARRAYSIZE(allLangs)) {

--- a/engines/tetraedge/game/application.cpp
+++ b/engines/tetraedge/game/application.cpp
@@ -154,7 +154,7 @@ void Application::create() {
 	textBase.build();
 	 */
 
-	static const char allLangs[][3] = {"en", "fr", "de", "es", "it", "ru"};
+	static const char allLangs[][3] = {"en", "fr", "de", "es", "it", "ru", "he"};
 	const Common::Path textsPath("texts");
 
 	// Try alternate langs..

--- a/engines/tetraedge/te/te_font3.cpp
+++ b/engines/tetraedge/te/te_font3.cpp
@@ -28,6 +28,7 @@
 #include "tetraedge/te/te_core.h"
 #include "graphics/font.h"
 #include "graphics/fonts/ttf.h"
+#include "common/unicode-bidi.h"
 
 namespace Tetraedge {
 
@@ -144,7 +145,10 @@ void TeFont3::draw(TeImage &destImage, const Common::String &str, int fontSize, 
 
 	uint32 uintcol = ((uint32)col.a() << fmt.aShift) | ((uint32)(col.r()) << fmt.rShift)
 						| ((uint32)(col.g()) << fmt.gShift) | ((uint32)(col.b()) << fmt.bShift);
-	font->drawString(&destImage, str, 0, yoff, destImage.w, uintcol, talign);
+	Common::String line(str);
+	if (g_engine->getCore()->language() == "he")
+		line = Common::convertBiDiString(str, Common::kWindows1255);
+	font->drawString(&destImage, line, 0, yoff, destImage.w, uintcol, talign);
 }
 
 bool TeFont3::load(const Common::String &path) {


### PR DESCRIPTION
This adds support for hebrew fan translation of Syberia 1 and 2.
Specifically, if the game is detected as hebrew, the text is converted to the correct BiDi ordering.

Thank you for your amazing work, which have made this possible.
