### PR TITLE
WIN32: Use static runtime linking for plugins

### DIFF
--- a/configure
+++ b/configure
@@ -4863,7 +4863,7 @@ POST_OBJS_FLAGS := -Wl,-no-whole-archive
 		_plugin_suffix=".dll"
 _mak_plugins='
 PLUGIN_EXTRA_DEPS	= $(EXECUTABLE)
-PLUGIN_LDFLAGS		+= -Wl,--enable-auto-import -shared ./libscummvm.a
+PLUGIN_LDFLAGS		+= -Wl,--enable-auto-import -shared -static-libgcc -static-libstdc++ ./libscummvm.a
 PRE_OBJS_FLAGS		:= -Wl,--whole-archive
 POST_OBJS_FLAGS		:= -Wl,--export-all-symbols -Wl,--no-whole-archive -Wl,--out-implib,./libscummvm.a
 '


### PR DESCRIPTION
Currently, building plugins with the win9x buildbot toolchain produces DLLs that aren't redistributable. They dynamically link to libgcc and libstd++. We just need to set the same LDFLAGS on the plugins as we do on the ScummVM executable. This effect can also be seen when building with MinGW-w64/MSYS2.

I don't know why, but the mxe buildbot toolchain already produces statically linked plugin DLLs. I tested that it continues to work when adding these flags. (Output is unchanged.)