### PR TITLE
WIN32: Re-enable Win32PluginProvider

### DIFF
--- a/backends/platform/sdl/win32/win32-main.cpp
+++ b/backends/platform/sdl/win32/win32-main.cpp
@@ -35,7 +35,7 @@
 
 #include "backends/platform/sdl/win32/win32.h"
 #include "backends/platform/sdl/win32/win32_wrapper.h"
-#include "backends/plugins/sdl/sdl-provider.h"
+#include "backends/plugins/win32/win32-provider.h"
 #include "base/main.h"
 
 int __stdcall WinMain(HINSTANCE /*hInst*/, HINSTANCE /*hPrevInst*/,  LPSTR /*lpCmdLine*/, int /*iShowCmd*/) {
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]) {
 	g_system->init();
 
 #ifdef DYNAMIC_MODULES
-	PluginManager::instance().addPluginProvider(new SDLPluginProvider());
+	PluginManager::instance().addPluginProvider(new Win32PluginProvider());
 #endif
 
 	// Invoke the actual ScummVM main entry point:

--- a/backends/plugins/win32/win32-provider.cpp
+++ b/backends/plugins/win32/win32-provider.cpp
@@ -59,7 +59,7 @@ public:
 		free(tFilename);
 
 		if (!_dlHandle) {
-			debug("Failed loading plugin '%s' (error code %d)", _filename.c_str(), (int32) GetLastError());
+			warning("Failed loading plugin '%s' (error code %d)", _filename.c_str(), (int32) GetLastError());
 			return false;
 		} else {
 			debug(1, "Success loading plugin '%s', handle %p", _filename.c_str(), _dlHandle);
@@ -72,7 +72,7 @@ public:
 		DynamicPlugin::unloadPlugin();
 		if (_dlHandle) {
 			if (!FreeLibrary((HMODULE)_dlHandle))
-				debug("Failed unloading plugin '%s'", _filename.c_str());
+				warning("Failed unloading plugin '%s'", _filename.c_str());
 			else
 				debug(1, "Success unloading plugin '%s'", _filename.c_str());
 			_dlHandle = 0;
@@ -88,10 +88,7 @@ Plugin* Win32PluginProvider::createPlugin(const Common::FSNode &node) const {
 bool Win32PluginProvider::isPluginFilename(const Common::FSNode &node) const {
 	// Check the plugin suffix
 	Common::String filename = node.getName();
-	if (!filename.hasSuffix(".dll"))
-		return false;
-
-	return true;
+	return filename.hasSuffix(".dll");
 }
 
 


### PR DESCRIPTION
In 2006, a refactor removed the only reference to Win32PluginProvider: df5be194098e188f9cd3234af2bea34b67d19da2

Instead, SdlPluginProvider became the provider used in Window builds. It's unclear if the intent really was to disable Win32PluginProvider, as we've been maintaining it ever since.

The two classes are small and effectively do the same thing, but Win32PluginProvider has the advantage of using our Windows string conversion functions for paths, just like the rest of backend code. We've seen problems before where SDL handles encoding differently: 0ab9653556f837ced66f73de8499170dcd3079be