### PR TITLE
Change orientation detection mechanism on iOS

### DIFF
--- a/backends/platform/ios7/ios7_app_delegate.mm
+++ b/backends/platform/ios7/ios7_app_delegate.mm
@@ -67,14 +67,6 @@
 	[_window setRootViewController:_controller];
 	[_window makeKeyAndVisible];
 
-#if TARGET_OS_IOS
-	[[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
-	[[NSNotificationCenter defaultCenter] addObserver:self
-	                                         selector:@selector(didRotate:)
-	                                             name:@"UIDeviceOrientationDidChangeNotification"
-	                                           object:nil];
-#endif
-
 	// Force creation of the shared instance on the main thread
 	iOS7_buildSharedOSystemInstance();
 
@@ -98,8 +90,16 @@
 	// Make sure we have the correct orientation in case the orientation was changed while
 	// the app was inactive.
 #if TARGET_OS_IOS
-	UIDeviceOrientation screenOrientation = [[UIDevice currentDevice] orientation];
-	[_view deviceOrientationChanged:screenOrientation];
+	UIInterfaceOrientation interfaceOrientation = UIInterfaceOrientationUnknown;
+	if (@available(iOS 13.0, *)) {
+		interfaceOrientation = [[[_view window] windowScene] interfaceOrientation];
+	} else {
+		interfaceOrientation = [[UIApplication sharedApplication] statusBarOrientation];
+	}
+	if (interfaceOrientation != UIInterfaceOrientationUnknown) {
+		[_view interfaceOrientationChanged:interfaceOrientation];
+		[_controller setCurrentOrientation: interfaceOrientation];
+	}
 #endif
 }
 
@@ -122,13 +122,6 @@
 
 - (void)application:(UIApplication *)application didDecodeRestorableStateWithCoder:(NSCoder *)coder {
 	_restoreState = YES;
-}
-
-- (void)didRotate:(NSNotification *)notification {
-#if TARGET_OS_IOS
-	UIDeviceOrientation screenOrientation = [[UIDevice currentDevice] orientation];
-	[_view deviceOrientationChanged:screenOrientation];
-#endif
 }
 
 + (iOS7AppDelegate *)iOS7AppDelegate {

--- a/backends/platform/ios7/ios7_keyboard.mm
+++ b/backends/platform/ios7/ios7_keyboard.mm
@@ -56,11 +56,7 @@
 	// The code only compils with the iOS 9.0+ SDK, and only works on iOS 9.0
 	// or above.
 #ifdef __IPHONE_9_0
-#if __has_builtin(__builtin_available)
 	if ( @available(iOS 9,*) ) {
-#else
-	if ( [self respondsToSelector:@selector(inputAssistantItem)] ) {
-#endif
 		UITextInputAssistantItem* item = [self inputAssistantItem];
 		if (item) {
 			item.leadingBarButtonGroups = @[];

--- a/backends/platform/ios7/ios7_osys_main.h
+++ b/backends/platform/ios7/ios7_osys_main.h
@@ -218,7 +218,7 @@ public:
 
 	bool isConnectionLimited() override;
 
-	virtual Common::String getDefaultLogFileName() { return Common::String("/var/mobile/.scummvm.log"); }
+	virtual Common::String getDefaultLogFileName() override { return Common::String("/var/mobile/.scummvm.log"); }
 
 protected:
 	void initVideoContext();

--- a/backends/platform/ios7/ios7_scummvm_view_controller.h
+++ b/backends/platform/ios7/ios7_scummvm_view_controller.h
@@ -25,7 +25,15 @@
 #include <UIKit/UIKit.h>
 
 
-@interface iOS7ScummVMViewController : UIViewController
+@interface iOS7ScummVMViewController : UIViewController {
+#if TARGET_OS_IOS
+	UIInterfaceOrientation currentOrientation;
+#endif
+}
+
+#if TARGET_OS_IOS
+-(void) setCurrentOrientation:(UIInterfaceOrientation)orientation;
+#endif
 
 @end
 

--- a/backends/platform/ios7/ios7_scummvm_view_controller.mm
+++ b/backends/platform/ios7/ios7_scummvm_view_controller.mm
@@ -20,9 +20,18 @@
  */
 
 #include "backends/platform/ios7/ios7_scummvm_view_controller.h"
-
+#include "backends/platform/ios7/ios7_app_delegate.h"
+#include "backends/platform/ios7/ios7_video.h"
 
 @implementation iOS7ScummVMViewController
+
+- (id)init {
+	self = [super init];
+#if TARGET_OS_IOS
+	self->currentOrientation = UIInterfaceOrientationUnknown;
+#endif
+	return self;
+}
 
 - (BOOL)prefersStatusBarHidden {
 	return YES;
@@ -36,5 +45,44 @@
 	/* This hides the OS cursor so ScummVM has to draw one */
 	return YES;
 }
+
+#if TARGET_OS_IOS
+-(void) setCurrentOrientation:(UIInterfaceOrientation)orientation {
+	if (orientation != currentOrientation) {
+		currentOrientation = orientation;
+		[[iOS7AppDelegate iPhoneView] interfaceOrientationChanged:currentOrientation];
+	}
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+	[super viewDidAppear:animated];
+
+	UIInterfaceOrientation orientationBefore = UIInterfaceOrientationUnknown;
+	if (@available(iOS 13.0, *)) {
+		orientationBefore = [[[[self view] window] windowScene] interfaceOrientation];
+	} else {
+		orientationBefore = [[UIApplication sharedApplication] statusBarOrientation];
+	}
+	if (currentOrientation != UIInterfaceOrientationUnknown)
+		[[iOS7AppDelegate iPhoneView] interfaceOrientationChanged:currentOrientation];
+}
+
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+	[super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+
+	[coordinator animateAlongsideTransition:nil completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+		UIInterfaceOrientation orientationAfter = UIInterfaceOrientationUnknown;
+		if (@available(iOS 13.0, *)) {
+			orientationAfter = [[[[self view] window] windowScene] interfaceOrientation];
+		} else {
+			orientationAfter = [[UIApplication sharedApplication] statusBarOrientation];
+		}
+		if (orientationAfter != UIInterfaceOrientationUnknown && orientationAfter != currentOrientation) {
+			currentOrientation = orientationAfter;
+			[[iOS7AppDelegate iPhoneView] interfaceOrientationChanged:currentOrientation];
+		}
+	}];
+}
+#endif
 
 @end

--- a/backends/platform/ios7/ios7_video.h
+++ b/backends/platform/ios7/ios7_video.h
@@ -117,7 +117,7 @@ uint getSizeNextPOT(uint size);
 - (void)updateMouseCursor;
 
 #if TARGET_OS_IOS
-- (void)deviceOrientationChanged:(UIDeviceOrientation)orientation;
+- (void)interfaceOrientationChanged:(UIInterfaceOrientation)orientation;
 #endif
 
 - (void)showKeyboard;

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -794,11 +794,7 @@ uint getSizeNextPOT(uint size) {
 	// So for now disable this code when compiled with an older SDK, which means it is only
 	// available when running on iOS 11+ if it has been compiled on iOS 11+
 #ifdef __IPHONE_11_0
-#if __has_builtin(__builtin_available)
 	if ( @available(iOS 11, tvOS 11, *) ) {
-#else
-	if ( [[[UIApplication sharedApplication] keyWindow] respondsToSelector:@selector(safeAreaInsets)] ) {
-#endif
 		CGRect screenSize = [[UIScreen mainScreen] bounds];
 		CGRect newFrame = screenSize;
 #if TARGET_OS_IOS

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -686,14 +686,23 @@ uint getSizeNextPOT(uint size) {
 		[self rebuildFrameBuffer];
 	}
 
-	BOOL isLandscape = (self.bounds.size.width > self.bounds.size.height); // UIDeviceOrientationIsLandscape([[UIDevice currentDevice] orientation]);
+#if TARGET_OS_IOS
+	UIInterfaceOrientation interfaceOrientation = UIInterfaceOrientationUnknown;
+	if (@available(iOS 13.0, *)) {
+		interfaceOrientation = [[[self window] windowScene] interfaceOrientation];
+	} else {
+		interfaceOrientation = [[UIApplication sharedApplication] statusBarOrientation];
+	}
+	BOOL isLandscape = UIInterfaceOrientationIsLandscape(interfaceOrientation);
+#else // TVOS
+	BOOL isLandscape = YES;
+#endif
 
 	int screenWidth, screenHeight;
 	if (isLandscape) {
 		screenWidth = MAX(_renderBufferWidth, _renderBufferHeight);
 		screenHeight = MIN(_renderBufferWidth, _renderBufferHeight);
-	}
-	else {
+	} else {
 		screenWidth = MIN(_renderBufferWidth, _renderBufferHeight);
 		screenHeight = MAX(_renderBufferWidth, _renderBufferHeight);
 	}
@@ -794,9 +803,16 @@ uint getSizeNextPOT(uint size) {
 		CGRect newFrame = screenSize;
 #if TARGET_OS_IOS
 		UIEdgeInsets inset = [[[UIApplication sharedApplication] keyWindow] safeAreaInsets];
-		UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
+		UIInterfaceOrientation orientation = UIInterfaceOrientationUnknown;
+		if (@available(iOS 13.0, *)) {
+			orientation = [[[self window] windowScene] interfaceOrientation];
+		} else {
+			orientation = [[UIApplication sharedApplication] statusBarOrientation];
+		}
 		if ( orientation == UIInterfaceOrientationPortrait ) {
 			newFrame = CGRectMake(screenSize.origin.x, screenSize.origin.y + inset.top, screenSize.size.width, screenSize.size.height - inset.top);
+		} else if ( orientation == UIInterfaceOrientationPortraitUpsideDown ) {
+			newFrame = CGRectMake(screenSize.origin.x, screenSize.origin.y, screenSize.size.width, screenSize.size.height - inset.top);
 		} else if ( orientation == UIInterfaceOrientationLandscapeLeft ) {
 			newFrame = CGRectMake(screenSize.origin.x, screenSize.origin.y, screenSize.size.width - inset.right, screenSize.size.height);
 		} else if ( orientation == UIInterfaceOrientationLandscapeRight ) {
@@ -920,11 +936,9 @@ uint getSizeNextPOT(uint size) {
 }
 
 #if TARGET_OS_IOS
-- (void)deviceOrientationChanged:(UIDeviceOrientation)orientation {
+- (void)interfaceOrientationChanged:(UIInterfaceOrientation)orientation {
 	[self addEvent:InternalEvent(kInputOrientationChanged, orientation, 0)];
-
-	BOOL isLandscape = (self.bounds.size.width > self.bounds.size.height);
-	if (isLandscape) {
+	if (UIInterfaceOrientationIsLandscape(orientation)) {
 		[self hideKeyboard];
 	} else {
 		[self showKeyboard];


### PR DESCRIPTION
This should fix incorrect orientation being detected on some devices, which caused the virtual keyboard to appear in landscape mode instead of portrait mode.

This includes three main changes that are tied to each others:
- Use the interface orientation and not the device orientation. This may be different for example when locking the orientation. 
-  Changes the way orientation changes are detected using the documented method. However this means dropping support for iOS 7 as this method is only available since iOS 8, and alternative methods available in iOS 7 have been deprecated in iOS 13. See https://developer.apple.com/documentation/uikit/uiviewcontroller?language=objc
- Properly detect the interface orientation instead of inferring it from the view bounds, which was incorrect on some devices.