### PR TITLE
SCUMM HE: BB01 competitive online play: no double play powerups

### DIFF
--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -594,6 +594,12 @@ int ScummEngine::readVar(uint var) {
 						return _roomVars[var] - 1;
 					}
 				}
+				// Mod for Backyard Baseball 2001 online competitive play: don't give powerups for double plays
+				// Return true for this variable, which dictates whether powerups are disabled, but only in this script
+				// that detects double plays (among other things)
+				if (_game.id == GID_BASEBALL2001 && _currentRoom == 3 && vm.slot[_currentScript].number == 2099 && var == 32 && readVar(399) == 1) {
+					return 1;
+				}
 			}
 #endif
 


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->

This PR implements a mod for competitive online Backyard Baseball 2001 play: not giving players a hitting powerup after double plays. Hitting powerups can decide games, especially when they're low scoring. Since they are given for double plays, the fielding team is incentivized to allow slow runners on-base in hopes of getting a double play, and the offensive team is incentivized to intentionally get out with these slow hitters to avoid these double-play-prone situations.

By disabling powerups for double plays, this kind of intentionally "bad" gameplay won't be incentivized any longer.