### PR TITLE
CREATE_PROJECT: Exclude MT32Emu source files if the feature is disabled.

### DIFF
--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1628,10 +1628,13 @@ void ProjectProvider::createProject(BuildSetup &setup) {
 		createModuleList(setup.srcDir + "/graphics", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/gui", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/audio", setup.defines, setup.testDirs, in, ex);
-		createModuleList(setup.srcDir + "/audio/softsynth/mt32", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/video", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/image", setup.defines, setup.testDirs, in, ex);
 		createModuleList(setup.srcDir + "/math", setup.defines, setup.testDirs, in, ex);
+
+		if (getFeatureBuildState("mt32emu", setup.features))
+			createModuleList(setup.srcDir + "/audio/softsynth/mt32", setup.defines, setup.testDirs, in, ex);
+
 		if (setup.tests) {
 			createModuleList(setup.srcDir + "/test", setup.defines, setup.testDirs, in, ex);
 		} else {


### PR DESCRIPTION
Turns out MT32Emu is compiled in even if the feature is disabled, and the linker is unable to remove `SERVICE_VTABLE` for some reason which results in most of the code being included as well.

This removes the source files from the VS solution if the feature is disabled.