### PR TITLE
TETRAEDGE: Encode text before draw

### DIFF
--- a/engines/tetraedge/te/te_font3.h
+++ b/engines/tetraedge/te/te_font3.h
@@ -86,7 +86,9 @@ public:
 private:
 	void init();
 	Graphics::Font *getAtSize(uint size);
+	Common::CodePage codePage() const;
 
+	Common::CodePage _codePage;
 	Common::File _fontFile;
 	Common::HashMap<uint, Graphics::Font *> _fonts;
 	Common::String _loadedPath;


### PR DESCRIPTION
This fixes an issue in the text drawing where the glyphs to use are implicitly casted to uint32 and does not get the current glyph range in the font.
I understand that implicit conversion from 8-bit encoding as-is is similiar to Latin-1 encoding, please correct me if it's not the case... I didn't notice problem with these languages but I'm not a native speaker.

Specifically, it fixes russian translation and allow better integration in the hebrew fan translation...

before:
![syberia-rus-daily](https://user-images.githubusercontent.com/10459948/233170410-f7cfa185-87a9-461a-b426-a28ec9a62dba.png)

after:
![syberia-rus](https://user-images.githubusercontent.com/10459948/233170450-2403002b-9f89-4cc8-8333-671f1c5e77bc.png)

(Also not a native speaker, but it seems to match the voice over)

Thank you