### PR TITLE
NUVIE: Fix Ultima 6 crash on FM-Towns sound load

### DIFF
--- a/engines/ultima/nuvie/files/u6_lib_n.cpp
+++ b/engines/ultima/nuvie/files/u6_lib_n.cpp
@@ -73,11 +73,11 @@ void U6Lib_n::close() {
 	}
 	items = NULL;
 
-	if (data != NULL)
-		data->close();
-
-	if (del_data)
+	if (del_data) {
+		if (data != NULL)
+			data->close();
 		delete data;
+	}
 
 	data = NULL;
 	del_data = false;


### PR DESCRIPTION
U6Lib_n::close(): Do not call close() on NuvieIO buffers passed to us
via U6Lib_n::open(). Let the caller handle this instead.

Prevents a crash caused by the following events:

- The game detects the files of the FM-Towns version
   ("townsu6" in the game directory) and eventually attempts to load
   "sounds1.dat" in TownsSfxManager::loadSound1Dat()

- Here, it creates local objects U6Lib_n "lib" and NuvieIOBuffer "iobuf"

- File data is loaded into "iobuf", which is then passed to "lib" via
   pointer. This pointer is stored by "lib"

- When TownsSfxManager::loadSound1Dat() returns, "iobuf" goes out of
   scope and is destroyed before "lib"

- The destructor of "lib" tries to call close() via the stale pointer,
   thus causing the crash

Fixes [#14429](https://bugs.scummvm.org/ticket/14429)