### PR TITLE
CREATE_PROJECT/CI: Support vcpkg integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,44 +16,38 @@ jobs:
             triplet: x86-windows
             arch: x86
             configFlags: --enable-discord --enable-faad --enable-gif --enable-mikmod --enable-mpeg2 --enable-vpx
-            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype fribidi giflib libflac libjpeg-turbo libmad libmikmod libmpeg2 libogg libpng libtheora libvorbis libvpx sdl2 sdl2-net zlib'
             useNasm: 'true'
           - platform: x64
             arch: x64
             triplet: x64-windows
             configFlags: --enable-discord --enable-faad --enable-gif --enable-mikmod --enable-mpeg2 --enable-vpx
-            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype fribidi giflib libflac libjpeg-turbo libmad libmikmod libmpeg2 libogg libpng libtheora libvorbis libvpx sdl2 sdl2-net zlib'
           - platform: arm64
             arch: arm64
             triplet: arm64-windows
-            # fribidi is disabled due to https://github.com/microsoft/vcpkg/issues/11248 [fribidi] Fribidi doesn't cross-compile on x86-64 to target arm/arm64
-            # Note that fribidi is also disabled on arm64 in devtools/create_project/msvc.cpp
-            configFlags: --enable-discord --enable-faad --enable-gif --enable-mikmod --enable-mpeg2 --enable-vpx --disable-fribidi --disable-opengl
-            vcpkgPackages: 'curl discord-rpc faad2 fluidsynth freetype giflib libflac libjpeg-turbo libmad libmikmod libmpeg2 libogg libpng libtheora libvorbis libvpx sdl2 sdl2-net zlib'
+            configFlags: --enable-discord --enable-faad --enable-gif --enable-mikmod --enable-mpeg2 --enable-vpx --disable-opengl
     env:
       CONFIGURATION: Debug
       PLATFORM: ${{ matrix.platform }}
+      VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
+      VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg_installed
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - uses: ilammy/setup-nasm@v1
         if: ${{ matrix.useNasm }} == 'true'
-      - name: Install vcpkg and packages
-        uses: lukka/run-vcpkg@v7
+      - name: Install vcpkg
+        uses: lukka/run-vcpkg@v11
         id: runvcpkg
         with:
-          # temporary hack until create_project / vcpkg incompatibility is resolved.
-          # use a fork of vcpkg with the previous working setup from March 2022
-          # with the the January 2023 fix for msys-libtool's url cherry-picked.
-          vcpkgGitURL: 'https://github.com/sluicebox/vcpkg.git'
-          vcpkgGitCommitId: 47c0c6e2cb7e70edf5799bb48560d7ddbeb6250d
-          vcpkgTriplet: '${{ matrix.triplet }}'
-          vcpkgArguments: '${{ matrix.vcpkgPackages }}'
+          vcpkgGitCommitId: 5a101fc741f41cf05e13fe660168d32c516fb658
+      - name: Integrate vcpkg
+        run: |
+          ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}/vcpkg integrate install
 #      - name: Upload libs
 #        uses: actions/upload-artifact@v3
 #        with:
 #          name: libs-${{ matrix.triplet }}
-#          path: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}
+#          path: ${{ env.VCPKG_INSTALLED_DIR }}\\${{ matrix.triplet }}
       - name: Build create_project
         run: |
           cd devtools/create_project/cmake
@@ -65,19 +59,15 @@ jobs:
         run: |
           mkdir build-scummvm
           cd build-scummvm
-          ../devtools/create_project/cmake/Debug/create_project.exe .. --msvc --enable-all-engines ${{ matrix.configflags }} --use-canonical-lib-names
+          ../devtools/create_project/cmake/Debug/create_project.exe .. --msvc --vcpkg --enable-all-engines ${{ matrix.configflags }}
           ls
-      - name: set SCUMMVM_LIBS env variable
-        run: |
-          echo "SCUMMVM_LIBS=${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}\\debug" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          Copy-Item "${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}\\include" -Destination "${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}\\debug" -Recurse
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1.3
       - name: Build scummvm
         run: |
           cd build-scummvm
           ls
-          msbuild scummvm.sln /m /p:BuildInParallel=true /p:Configuration=${{ env.CONFIGURATION }} /p:PreferredToolArchitecture=x64 /p:Platform=${{ matrix.platform }} /v:minimal
+          msbuild scummvm.sln /m /p:VcpkgEnableManifest=true /p:BuildInParallel=true /p:Configuration=${{ env.CONFIGURATION }} /p:PreferredToolArchitecture=x64 /p:Platform=${{ matrix.platform }} /v:minimal
 #      - name: Upload scummvm
 #        uses: actions/upload-artifact@v3
 #        with:
@@ -87,7 +77,7 @@ jobs:
 #        uses: actions/upload-artifact@v3
 #        with:
 #          name: scummvm-${{ matrix.arch }}
-#          path: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}\\bin\\*.dll
+#          path: ${{ env.VCPKG_INSTALLED_DIR }}\\${{ matrix.triplet }}\\bin\\*.dll
 #      - name: Upload scummvm symbols
 #        uses: actions/upload-artifact@v3
 #        with:
@@ -97,7 +87,7 @@ jobs:
 #        uses: actions/upload-artifact@v3
 #        with:
 #          name: symbols-${{ matrix.arch }}
-#          path: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}\\bin\\*.pdb
+#          path: ${{ env.VCPKG_INSTALLED_DIR }}\\${{ matrix.triplet }}\\bin\\*.pdb
   xcode:
     name: Xcode
     runs-on: macos-latest

--- a/devtools/create_engine/create_engine.cpp
+++ b/devtools/create_engine/create_engine.cpp
@@ -47,7 +47,7 @@ static const char *const FILENAMES[] = {
 	"metaengine.h", "module.mk", "xyzzy.cpp",
 	"xyzzy.h", "POTFILES", nullptr
 };
-const char *const ENGINES = "create_project ..\\.. --use-canonical-lib-names --msvc\n";
+const char *const ENGINES = "create_project ..\\.. --msvc\n";
 
 bool fileExists(const char *name) {
 #ifdef _WIN32

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -298,7 +298,7 @@ int main(int argc, char *argv[]) {
 		} else if (!std::strcmp(argv[i], "--sdl1")) {
 			setup.useSDL2 = false;
 		} else if (!std::strcmp(argv[i], "--use-canonical-lib-names")) {
-			setup.useCanonicalLibNames = true;
+			// Deprecated: Kept here so it doesn't error
 		} else if (!std::strcmp(argv[i], "--use-windows-unicode")) {
 			setup.useWindowsUnicode = true;
 		} else if (!std::strcmp(argv[i], "--use-windows-ansi")) {
@@ -736,9 +736,6 @@ void displayHelp(const char *exe) {
 	        "                            (default: false)\n"
 	        " --tests                    Create project files for the tests\n"
 	        "                            (ignores --build-events and --installer, as well as engine settings)\n"
-	        "                            (default: false)\n"
-	        " --use-canonical-lib-names  Use canonical library names for linking. This makes it easy to use\n"
-	        "                            e.g. vcpkg-provided libraries\n"
 	        "                            (default: false)\n"
 	        " --use-windows-unicode      Use Windows Unicode APIs\n"
 	        "                            (default: true)\n"

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -305,6 +305,8 @@ int main(int argc, char *argv[]) {
 			setup.useWindowsUnicode = false;
 		} else if (!std::strcmp(argv[i], "--use-xcframework")) {
 			setup.useXCFramework = true;
+		} else if (!std::strcmp(argv[i], "--vcpkg")) {
+			setup.useVcpkg = true;
 		} else {
 			std::cerr << "ERROR: Unknown parameter \"" << argv[i] << "\"\n";
 			return -1;
@@ -741,6 +743,8 @@ void displayHelp(const char *exe) {
 	        " --use-windows-unicode      Use Windows Unicode APIs\n"
 	        "                            (default: true)\n"
 	        " --use-windows-ansi         Use Windows ANSI APIs\n"
+	        "                            (default: false)\n"
+	        " --vcpkg                    Use vcpkg-provided libraries instead of pre-built SCUMMVM_LIBS\n"
 	        "                            (default: false)\n"
 	        "\n"
 	        "Engines settings:\n"

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -245,7 +245,6 @@ struct BuildSetup {
 	bool runBuildEvents;       ///< Run build events as part of the build (generate revision number and copy engine/theme data & needed files to the build folder
 	bool createInstaller;      ///< Create installer after the build
 	bool useSDL2;              ///< Whether to use SDL2 or not.
-	bool useCanonicalLibNames; ///< Whether to use canonical libraries names or default ones
 	bool useStaticDetection;   ///< Whether to link detection features inside the executable or not.
 	bool useWindowsUnicode;    ///< Whether to use Windows Unicode APIs or ANSI APIs.
 	bool useXCFramework;       ///< Whether to use Apple XCFrameworks instead of static libraries
@@ -257,7 +256,6 @@ struct BuildSetup {
 		runBuildEvents = false;
 		createInstaller = false;
 		useSDL2 = true;
-		useCanonicalLibNames = false;
 		useStaticDetection = true;
 		useWindowsUnicode = true;
 		useXCFramework = false;

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -249,6 +249,7 @@ struct BuildSetup {
 	bool useStaticDetection;   ///< Whether to link detection features inside the executable or not.
 	bool useWindowsUnicode;    ///< Whether to use Windows Unicode APIs or ANSI APIs.
 	bool useXCFramework;       ///< Whether to use Apple XCFrameworks instead of static libraries
+	bool useVcpkg;             ///< Whether to load libraries from vcpkg or SCUMMVM_LIBS
 
 	BuildSetup() {
 		devTools = false;
@@ -260,6 +261,7 @@ struct BuildSetup {
 		useStaticDetection = true;
 		useWindowsUnicode = true;
 		useXCFramework = false;
+		useVcpkg = false;
 	}
 
 	bool featureEnabled(std::string feature) const;

--- a/devtools/create_project/msbuild.h
+++ b/devtools/create_project/msbuild.h
@@ -41,7 +41,7 @@ protected:
 
 	void writeReferences(const BuildSetup &setup, std::ofstream &output) override;
 
-	void outputGlobalPropFile(const BuildSetup &setup, std::ofstream &properties, MSVC_Architecture arch, const StringList &defines, const std::string &prefix, bool runBuildEvents) override;
+	void outputGlobalPropFile(const BuildSetup &setup, std::ofstream &properties, MSVC_Architecture arch, const StringList &defines, const std::string &prefix) override;
 
 	void createBuildProp(const BuildSetup &setup, bool isRelease, MSVC_Architecture arch, const std::string &configuration) override;
 

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -43,46 +43,44 @@ MSVCProvider::MSVCProvider(StringList &global_warnings, std::map<std::string, St
 	_arch_disabled_features[ARCH_AMD64] = amd64_disabled_features;
 	// NASM not supported for WoA target
 	// No OpenGL on Windows on ARM
-	// https://github.com/microsoft/vcpkg/issues/11248 [fribidi] Fribidi doesn't cross-compile on x86-64 to target arm/arm64
 	StringList arm64_disabled_features;
 	arm64_disabled_features.push_back("nasm");
 	arm64_disabled_features.push_back("opengl");
-	arm64_disabled_features.push_back("fribidi");
 	_arch_disabled_features[ARCH_ARM64] = arm64_disabled_features;
 }
 
 std::string MSVCProvider::getLibraryFromFeature(const char *feature, const BuildSetup &setup, bool isRelease) const {
 	static const MSVCLibrary s_libraries[] = {
 		// Libraries
-		{       "sdl", "SDL.lib",                   "SDLd.lib",      "winmm.lib imm32.lib version.lib setupapi.lib",    nullptr },
-		{      "sdl2", "SDL2.lib",                  "SDL2d.lib",     "winmm.lib imm32.lib version.lib setupapi.lib",    nullptr },
-		{      "zlib", "zlib.lib",                  "zlibd.lib",     nullptr,                                           nullptr },
-		{       "mad", "mad.lib",                   nullptr,         nullptr,                                           "libmad.lib" },
-		{   "fribidi", "fribidi.lib",               nullptr,         nullptr,                                           nullptr },
-		{       "ogg", "ogg.lib",                   nullptr,         nullptr,                                           "libogg_static.lib" },
-		{    "vorbis", "vorbis.lib vorbisfile.lib", nullptr,         nullptr,                                           "libvorbisfile_static.lib libvorbis_static.lib" },
-		{      "flac", "FLAC.lib",                  nullptr,         nullptr,                                           "libFLAC_static.lib win_utf8_io_static.lib" },
-		{       "png", "libpng16.lib",              "libpng16d.lib", nullptr,                                           nullptr },
-		{       "gif", "gif.lib",                   nullptr,         nullptr,                                           nullptr },
-		{      "faad", "faad.lib",                  nullptr,         nullptr,                                           "libfaad.lib" },
-		{    "mikmod", "mikmod.lib",                nullptr,         nullptr,                                           nullptr },
-		{     "mpeg2", "mpeg2.lib",                 nullptr,         nullptr,                                           "libmpeg2.lib" },
-		{ "theoradec", "theora.lib",                nullptr,         nullptr,                                           "libtheora_static.lib" },
-		{       "vpx", "vpx.lib",                   nullptr,         nullptr,                                           nullptr },
-		{ "freetype2", "freetype.lib",              "freetyped.lib", nullptr,                                           nullptr },
-		{      "jpeg", "jpeg.lib",                  nullptr,         nullptr,                                           "jpeg-static.lib" },
-		{"fluidsynth", "fluidsynth.lib",            nullptr,         nullptr,                                           "libfluidsynth.lib" },
-		{ "fluidlite", "fluidlite.lib",             nullptr,         nullptr,                                           nullptr },
-		{   "libcurl", "libcurl.lib",               "libcurl-d.lib", "ws2_32.lib wldap32.lib crypt32.lib normaliz.lib", nullptr },
-		{    "sdlnet", "SDL_net.lib",               nullptr,         "iphlpapi.lib",                                    nullptr },
-		{   "sdl2net", "SDL2_net.lib",              nullptr,         "iphlpapi.lib",                                    "SDL_net.lib" },
-		{   "discord", "discord-rpc.lib",           nullptr,         nullptr,                                           nullptr },
-		{ "retrowave", "retrowave.lib",             nullptr,         nullptr,                                           nullptr },
+		{       "sdl", "SDL.lib",                   "SDLd.lib",      "winmm.lib imm32.lib version.lib setupapi.lib"    },
+		{      "sdl2", "SDL2.lib",                  "SDL2d.lib",     "winmm.lib imm32.lib version.lib setupapi.lib"    },
+		{      "zlib", "zlib.lib",                  "zlibd.lib",     nullptr                                           },
+		{       "mad", "mad.lib",                   nullptr,         nullptr                                           },
+		{   "fribidi", "fribidi.lib",               nullptr,         nullptr                                           },
+		{       "ogg", "ogg.lib",                   nullptr,         nullptr                                           },
+		{    "vorbis", "vorbis.lib vorbisfile.lib", nullptr,         nullptr                                           },
+		{      "flac", "FLAC.lib",                  nullptr,         nullptr                                           },
+		{       "png", "libpng16.lib",              "libpng16d.lib", nullptr                                           },
+		{       "gif", "gif.lib",                   nullptr,         nullptr                                           },
+		{      "faad", "faad.lib",                  nullptr,         nullptr                                           },
+		{    "mikmod", "mikmod.lib",                nullptr,         nullptr                                           },
+		{     "mpeg2", "mpeg2.lib",                 nullptr,         nullptr                                           },
+		{ "theoradec", "theora.lib",                nullptr,         nullptr                                           },
+		{       "vpx", "vpx.lib",                   nullptr,         nullptr                                           },
+		{ "freetype2", "freetype.lib",              "freetyped.lib", nullptr                                           },
+		{      "jpeg", "jpeg.lib",                  nullptr,         nullptr                                           },
+		{"fluidsynth", "fluidsynth.lib",            nullptr,         nullptr                                           },
+		{ "fluidlite", "fluidlite.lib",             nullptr,         nullptr                                           },
+		{   "libcurl", "libcurl.lib",               "libcurl-d.lib", "ws2_32.lib wldap32.lib crypt32.lib normaliz.lib" },
+		{    "sdlnet", "SDL_net.lib",               nullptr,         "iphlpapi.lib"                                    },
+		{   "sdl2net", "SDL2_net.lib",              nullptr,         "iphlpapi.lib"                                    },
+		{   "discord", "discord-rpc.lib",           nullptr,         nullptr                                           },
+		{ "retrowave", "retrowave.lib",             nullptr,         nullptr                                           },
 		// Feature flags with library dependencies
-		{   "updates", "winsparkle.lib",            nullptr,         nullptr,                                           nullptr },
-		{       "tts", nullptr,                     nullptr,         "sapi.lib",                                        nullptr },
-		{    "opengl", nullptr,                     nullptr,         "opengl32.lib",                                    nullptr },
-		{      "enet", nullptr,                     nullptr,         "winmm.lib ws2_32.lib",                            nullptr }
+		{   "updates", "winsparkle.lib",            nullptr,         nullptr                                           },
+		{       "tts", nullptr,                     nullptr,         "sapi.lib"                                        },
+		{    "opengl", nullptr,                     nullptr,         "opengl32.lib"                                    },
+		{      "enet", nullptr,                     nullptr,         "winmm.lib ws2_32.lib"                            }
 	};
 
 	// HACK for switching SDL_net to SDL2_net
@@ -107,20 +105,16 @@ std::string MSVCProvider::getLibraryFromFeature(const char *feature, const Build
 			libs += " ";
 		}
 
-		const char *basename = library->release;
-		if (setup.useCanonicalLibNames) {
+		// Vcpkg already adds the libs
+		if (!setup.useVcpkg) {
+			const char *basename = library->release;
 			// Debug name takes priority
 			if (!isRelease && library->debug) {
 				basename = library->debug;
 			}
-		} else {
-			// Legacy name ignores configuration
-			if (library->legacy) {
-				basename = library->legacy;
+			if (basename) {
+				libs += basename;
 			}
-		}
-		if (basename) {
-			libs += basename;
 		}
 	}
 

--- a/devtools/create_project/msvc.h
+++ b/devtools/create_project/msvc.h
@@ -74,13 +74,13 @@ protected:
 	 * two platform configurations will output their files into different
 	 * directories.
 	 *
+	 * @param setup      Description of the desired build setup.
 	 * @param properties File stream in which to write the property settings.
-	 * @param bits Number of bits the platform supports.
-	 * @param defines Defines the platform needs to have set.
-	 * @param prefix File prefix, used to add additional include paths.
-	 * @param runBuildEvents true if generating a revision number, false otherwise
+	 * @param arch       Target architecture
+	 * @param defines    Defines the platform needs to have set.
+	 * @param prefix     File prefix, used to add additional include paths.
 	 */
-	virtual void outputGlobalPropFile(const BuildSetup &setup, std::ofstream &properties, MSVC_Architecture arch, const StringList &defines, const std::string &prefix, bool runBuildEvents) = 0;
+	virtual void outputGlobalPropFile(const BuildSetup &setup, std::ofstream &properties, MSVC_Architecture arch, const StringList &defines, const std::string &prefix) = 0;
 
 	/**
 	 * Generates the project properties for debug and release settings.
@@ -112,12 +112,13 @@ protected:
 	/**
 	 * Get the command line for copying data files to the build directory.
 	 *
-	 * @param	arch	Target architecture
-	 * @param	setup	Description of the desired build setup.
+	 * @param	arch	   Target architecture
+	 * @param	setup	   Description of the desired build setup.
+	 * @param   isRelease  Type of build file
 	 *
 	 * @return	The post build event.
 	 */
-	std::string getPostBuildEvent(MSVC_Architecture arch, const BuildSetup &setup) const;
+	std::string getPostBuildEvent(MSVC_Architecture arch, const BuildSetup &setup, bool isRelease) const;
 };
 
 } // namespace CreateProjectTool

--- a/devtools/create_project/msvc.h
+++ b/devtools/create_project/msvc.h
@@ -47,7 +47,6 @@ protected:
 		const char *release; ///< Filename of the Release build of the library.
 		const char *debug;   ///< Filename of the Debug build of the library.
 		const char *depends; ///< Win32 libs this library must be linked against.
-		const char *legacy;  ///< Legacy name for old precompiled libraries (deprecated).
 	};
 
 	std::string getLibraryFromFeature(const char *feature, const BuildSetup &setup, bool isRelease) const;

--- a/dists/msvc/create_msvc.bat
+++ b/dists/msvc/create_msvc.bat
@@ -55,28 +55,28 @@ goto done
 echo.
 echo Creating project files with all engines enabled (stable and unstable)
 echo.
-create_project ..\.. --enable-all-engines --use-canonical-lib-names --msvc
+create_project ..\.. --enable-all-engines --msvc
 goto done
 
 :stable
 echo.
 echo Creating normal project files, with only the stable engines enabled
 echo.
-create_project ..\.. --use-canonical-lib-names --msvc
+create_project ..\.. --msvc
 goto done
 
 :tools
 echo.
 echo Creating tools project files
 echo.
-create_project ..\.. --tools --use-canonical-lib-names --msvc
+create_project ..\.. --tools --msvc
 goto done
 
 :tests
 echo.
 echo Creating tests project files
 echo.
-create_project ..\.. --tests --use-canonical-lib-names --msvc
+create_project ..\.. --tests --msvc
 goto done
 
 :clean_check

--- a/ports.mk
+++ b/ports.mk
@@ -647,7 +647,7 @@ endif
 	@echo Creating Code::Blocks project files...
 	@cd $(srcdir)/dists/codeblocks && $(PWD)/devtools/create_project/create_project ../.. --codeblocks >/dev/null && git add -f engines/*.h *.workspace *.cbp
 	@echo Creating MSVC project files...
-	@cd $(srcdir)/dists/msvc && $(PWD)/devtools/create_project/create_project ../.. --use-canonical-lib-names --msvc-version 12 --msvc >/dev/null && git add -f engines/*.h *.sln *.vcxproj *.vcxproj.filters *.props
+	@cd $(srcdir)/dists/msvc && $(PWD)/devtools/create_project/create_project ../.. --msvc-version 12 --msvc >/dev/null && git add -f engines/*.h *.sln *.vcxproj *.vcxproj.filters *.props
 	@echo
 	@echo All is done.
 	@echo Now run

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "scummvm",
+  "version-string": "latest",
+  "dependencies": [
+    "curl",
+    "discord-rpc",
+    "faad2",
+    "fluidsynth",
+    "freetype",
+    "fribidi",
+    "giflib",
+    "libflac",
+    "libjpeg-turbo",
+    "libmad",
+    "libmikmod",
+    "libmpeg2",
+    "libogg",
+    "libpng",
+    "libtheora",
+    "libvorbis",
+    "libvpx",
+    "sdl2",
+    "sdl2-net",
+    "zlib"
+  ]
+}


### PR DESCRIPTION
This PR adds a `--vcpkg` flag to create_project to get library dependencies directly from vcpkg instead of SCUMMVM_LIBS. This allows the CI to keep up with the latest vcpkg updates without requiring hacks and workarounds as libraries change (eg. #4648), and allows developers to use the latest library versions instead of pre-compiled if they prefer.

(based on the work of #2568)