### PR TITLE
AGS: Fix playing CLUT8 videos

### DIFF
--- a/engines/ags/engine/media/video/video.cpp
+++ b/engines/ags/engine/media/video/video.cpp
@@ -74,6 +74,7 @@ static bool play_video(Video::VideoDecoder *decoder, const char *name, int flags
 	bool stretchVideo = (flags & kVideo_Stretch) != 0;
 	bool enableVideo = (flags & kVideo_EnableVideo) != 0;
 	bool enableAudio = (flags & kVideo_EnableAudio) != 0;
+	bool clut8Screen = scr.format.isCLUT8();
 
 	if (!enableAudio)
 		decoder->setVolume(0);
@@ -85,6 +86,8 @@ static bool play_video(Video::VideoDecoder *decoder, const char *name, int flags
 		if (decoder->needsUpdate()) {
 			// Get the next video frame and draw onto the screen
 			const Graphics::Surface *frame = decoder->decodeNextFrame();
+			if (clut8Screen && decoder->hasDirtyPalette())
+				scr.setPalette(decoder->getPalette(), 0, 256);
 
 			if (frame && enableVideo) {
 				Rect dstRect = PlaceInRect(RectWH(0, 0, scr.w, scr.h), RectWH(0, 0, frame->w, frame->h),

--- a/engines/ags/engine/media/video/video.cpp
+++ b/engines/ags/engine/media/video/video.cpp
@@ -99,9 +99,10 @@ static bool play_video(Video::VideoDecoder *decoder, const char *name, int flags
 
 				if (stretchVideo) {
 					scr.transBlitFrom(*frame, Common::Rect(0, 0, frame->w, frame->h),
-					                  Common::Rect(dstRect.Left, dstRect.Top, dstRect.Right + 1, dstRect.Bottom + 1));
+					                  Common::Rect(dstRect.Left, dstRect.Top, dstRect.Right + 1, dstRect.Bottom + 1),
+					                  decoder->getPalette());
 				} else {
-					scr.blitFrom(*frame, Common::Point(dstRect.Left, dstRect.Top));
+					scr.blitFrom(*frame, Common::Point(dstRect.Left, dstRect.Top), decoder->getPalette());
 				}
 			}
 

--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -294,7 +294,7 @@ void ManagedSurface::blitFromInner(const Surface &src, const Common::Rect &srcRe
 		assert(srcFormat.bytesPerPixel == 1 || srcFormat.bytesPerPixel == 2 || srcFormat.bytesPerPixel == 3 || srcFormat.bytesPerPixel == 4);
 		if (srcFormat.bytesPerPixel == 1) {
 			// When the pixel format differs, the destination must be non-paletted
-			assert(!destFormat.isCLUT8() || srcPalette);
+			assert(!destFormat.isCLUT8() && srcPalette);
 		}
 	}
 

--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -226,23 +226,23 @@ void ManagedSurface::copyFrom(const Surface &surf) {
 	memset(_palette, 0, sizeof(_palette));
 }
 
-void ManagedSurface::blitFrom(const Surface &src) {
-	blitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Point(0, 0));
+void ManagedSurface::blitFrom(const Surface &src, const byte *srcPalette) {
+	blitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Point(0, 0), srcPalette);
 }
 
-void ManagedSurface::blitFrom(const Surface &src, const Common::Point &destPos) {
-	blitFrom(src, Common::Rect(0, 0, src.w, src.h), destPos);
+void ManagedSurface::blitFrom(const Surface &src, const Common::Point &destPos, const byte *srcPalette) {
+	blitFrom(src, Common::Rect(0, 0, src.w, src.h), destPos, srcPalette);
 }
 
 void ManagedSurface::blitFrom(const Surface &src, const Common::Rect &srcRect,
-		const Common::Point &destPos) {
+		const Common::Point &destPos, const byte *srcPalette) {
 	blitFromInner(src, srcRect, Common::Rect(destPos.x, destPos.y, destPos.x + srcRect.width(),
-		destPos.y + srcRect.height()), nullptr);
+		destPos.y + srcRect.height()), srcPalette);
 }
 
 void ManagedSurface::blitFrom(const Surface &src, const Common::Rect &srcRect,
-		const Common::Rect &destRect) {
-	blitFromInner(src, srcRect, destRect, nullptr);
+		const Common::Rect &destRect, const byte *srcPalette) {
+	blitFromInner(src, srcRect, destRect, srcPalette);
 }
 
 void ManagedSurface::blitFrom(const ManagedSurface &src) {
@@ -429,40 +429,44 @@ void ManagedSurface::blitFromInner(const Surface &src, const Common::Rect &srcRe
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, uint32 transColor, bool flipped,
-		uint32 overrideColor, uint32 srcAlpha) {
+		uint32 overrideColor, uint32 srcAlpha, const byte *srcPalette) {
 	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(0, 0, this->w, this->h),
-		transColor, flipped, overrideColor, srcAlpha);
+		transColor, flipped, overrideColor, srcAlpha, nullptr, false, srcPalette);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Point &destPos,
-		uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha) {
+		uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha, const byte *srcPalette) {
 	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(destPos.x, destPos.y,
-		destPos.x + src.w, destPos.y + src.h), transColor, flipped, overrideColor, srcAlpha);
+		destPos.x + src.w, destPos.y + src.h), transColor, flipped, overrideColor, srcAlpha, nullptr, false, srcPalette);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Point &destPos,
-		const ManagedSurface &mask) {
+		const ManagedSurface &mask, const byte *srcPalette) {
 	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(destPos.x, destPos.y,
-		destPos.x + src.w, destPos.y + src.h), 0, false, 0, 0xff, &mask._innerSurface, true);
+		destPos.x + src.w, destPos.y + src.h), 0, false, 0, 0xff, &mask._innerSurface, true, srcPalette);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Point &destPos,
-		const Surface &mask) {
+		const Surface &mask, const byte *srcPalette) {
 	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(destPos.x, destPos.y,
-		destPos.x + src.w, destPos.y + src.h), 0, false, 0, 0xff, &mask, true);
+		destPos.x + src.w, destPos.y + src.h), 0, false, 0, 0xff, &mask, true, srcPalette);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Rect &srcRect,
-		const Common::Point &destPos, uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha) {
+		const Common::Point &destPos, uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha, const byte *srcPalette) {
 	transBlitFrom(src, srcRect, Common::Rect(destPos.x, destPos.y,
-		destPos.x + srcRect.width(), destPos.y + srcRect.height()), transColor, flipped, overrideColor, srcAlpha);
+		destPos.x + srcRect.width(), destPos.y + srcRect.height()), transColor, flipped, overrideColor, srcAlpha, nullptr, false, srcPalette);
+}
+
+void ManagedSurface::transBlitFrom(const Surface &src, const Common::Rect &srcRect, const Common::Rect &destRect, const byte *srcPalette) {
+	transBlitFrom(src, srcRect, destRect, 0, false, 0, 0xff, nullptr, false, srcPalette);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Rect &srcRect,
 		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha,
-		const Surface *mask, bool maskOnly) {
+		const Surface *mask, bool maskOnly, const byte *srcPalette) {
 	transBlitFromInner(src, srcRect, destRect, transColor, flipped, overrideColor, srcAlpha,
-		nullptr, nullptr, mask, maskOnly);
+		srcPalette, nullptr, mask, maskOnly);
 }
 
 void ManagedSurface::transBlitFrom(const ManagedSurface &src, uint32 transColor, bool flipped,

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -303,24 +303,24 @@ public:
 	/**
 	 * Copy another surface into this one.
 	 */
-	void blitFrom(const Surface &src);
+	void blitFrom(const Surface &src, const byte *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one at a given destination position.
 	 */
-	void blitFrom(const Surface &src, const Common::Point &destPos);
+	void blitFrom(const Surface &src, const Common::Point &destPos, const byte *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one at a given destination position.
 	 */
 	void blitFrom(const Surface &src, const Common::Rect &srcRect,
-		const Common::Point &destPos);
+		const Common::Point &destPos, const byte *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one at a given destination area and perform the potential scaling.
 	 */
 	void blitFrom(const Surface &src, const Common::Rect &srcRect,
-		const Common::Rect &destRect);
+		const Common::Rect &destRect, const byte *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one at a given destination area and perform the potential scaling.
@@ -353,9 +353,10 @@ public:
 	 * @param overrideColor	Optional color to use instead of non-transparent pixels from
 	 *						the source surface.
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
+	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
 	 */
 	void transBlitFrom(const Surface &src, uint32 transColor = 0, bool flipped = false,
-		uint32 overrideColor = 0, uint32 srcAlpha = 0xff);
+		uint32 overrideColor = 0, uint32 srcAlpha = 0xff, const byte *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -367,9 +368,10 @@ public:
 	 * @param overrideColor	Optional color to use instead of non-transparent pixels from
 	 *						the source surface.
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
+	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
 	 */
 	void transBlitFrom(const Surface &src, const Common::Point &destPos,
-		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff);
+		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff, const byte *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -377,9 +379,10 @@ public:
 	 * @param src			Source surface.
 	 * @param destPos		Destination position to draw the surface.
 	 * @param mask			Mask definition.
+	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
 	 */
 	void transBlitFrom(const Surface &src, const Common::Point &destPos,
-		const ManagedSurface &mask);
+		const ManagedSurface &mask, const byte *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -387,9 +390,10 @@ public:
 	 * @param src			Source surface.
 	 * @param destPos		Destination position to draw the surface.
 	 * @param mask			Mask definition.
+	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
 	 */
 	void transBlitFrom(const Surface &src, const Common::Point &destPos,
-		const Surface &mask);
+		const Surface &mask, const byte *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -402,9 +406,21 @@ public:
 	 * @param overrideColor	Optional color to use instead of non-transparent pixels from
 	 *						the source surface.
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
+	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
 	 */
 	void transBlitFrom(const Surface &src, const Common::Rect &srcRect, const Common::Point &destPos,
-		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff);
+		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff, const byte *srcPalette = nullptr);
+
+	/**
+	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
+	 *
+	 * @param src			Source surface.
+	 * @param srcRect		Subsection of the source surface to draw.
+	 * @param destRect		Destination area to draw the surface in. This can be sized differently
+	 *						then @p srcRect, allowing for arbitrary scaling of the image.
+	 * @param srcPalette	Palette for the CLUT8  @p src surface.
+	 */
+	void transBlitFrom(const Surface &src, const Common::Rect &srcRect, const Common::Rect &destRect, const byte *srcPalette);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -420,10 +436,11 @@ public:
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
 	 * @param mask			Optional parameter with mask definition.
 	 * @param maskOnly		Optional parameter for using mask over @p transColor.
+	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
 	 */
 	void transBlitFrom(const Surface &src, const Common::Rect &srcRect, const Common::Rect &destRect,
 		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff,
-		const Surface *mask = nullptr, bool maskOnly = false);
+		const Surface *mask = nullptr, bool maskOnly = false, const byte *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.


### PR DESCRIPTION
Playing CLUT8  videos (such as FLIC videos) was not working properly:
- If the game itself is CLUT8, it was using the previously set palette from the game and ignore the one from the video decoder, resulting in wrong colors.
- If the game uses 16bit or 32bit colors, it was crashing as the decoder palette was not passed to the blitting code that was expected it.

There were two separate crash:
- If the video is stretched in AGS, it was asserting in `Graphics::transBlitPixel` due to the source palette being a nullptr pointer.
- If the video is not stretched in AGS, it was trying to access 0x0 memory. There was an incorrect assert that was not triggered and should have caught this before getting to the invalid memory access.

The `ManagedSurface` blitting code only allowed blitting from CLUT8 source to non-CLUT8 destination if the source was itself a `ManagedSurface`. This pull request adds the possibility to do this also if the source is a `Surface` (such as a `VideoDecoder` frame). This is used in the AGS engine to fix the crash mentioned above.

Crash call-stack for the CLUT8 -> 16/32bit color (for stretched videos, the non-stretch one is similar but crashes in `ManagedSurface::blitFromInner` instead):
```
Assertion failure: 'srcPalette != nullptr' in graphics/managed_surface.cpp:558 (void Graphics::transBlitPixel(TSRC, TDEST &, const Graphics::PixelFormat &, const Graphics::PixelFormat &, uint32, uint32, const uint32 *, const byte *) [TSRC = unsigned char, TDEST = unsigned int])
  #04  __assert2+40)
  #05  void Graphics::transBlitPixel<unsigned char, unsigned int>(unsigned char, unsigned int&, Graphics::PixelFormat const&, Graphics::PixelFormat const&, unsigned int, unsigned int, unsigned int const*, unsigned char const*)+548)
  #06  void Graphics::transBlit<unsigned char, unsigned int>(Graphics::Surface const&, Common::Rect const&, Graphics::ManagedSurface&, Common::Rect const&, unsigned char, bool, unsigned int, unsigned int, unsigned int const*, unsigned int const*, Graphics::Surface const*, bool)+1048)
  #07  Graphics::ManagedSurface::transBlitFromInner(Graphics::Surface const&, Common::Rect const&, Common::Rect const&, unsigned int, bool, unsigned int, unsigned int, unsigned int const*, unsigned int const*, Graphics::Surface const*, bool)+460)
  #08  Graphics::ManagedSurface::transBlitFrom(Graphics::Surface const&, Common::Rect const&, Common::Rect const&, unsigned int, bool, unsigned int, unsigned int, Graphics::Surface const*, bool)+36)
  #09  AGS3::play_video(Video::VideoDecoder*, char const*, int, AGS3::VideoSkipType, bool)+524)
  #10  AGS3::play_flc_video(int, int, AGS3::VideoSkipType)+72)
```

Example of wrong color for CLUT8 -> CLUT8:
Before
![image](https://user-images.githubusercontent.com/552105/234100998-d8203ffc-3602-46f0-b501-f4c82ab2931b.png)
After
![image](https://user-images.githubusercontent.com/552105/234101051-e1c989de-b139-4dc3-b8d6-b49aa77fa04b.png)

I am opening this pull request to check there is no compilation error before committing (I only compiled with the AGS engine locally) and give the opportunity to those who want to review the changes to the `Graphics::ManagedSurface` code. I think it is straightforward, but I may have overlooked something.