### PR TITLE
SCI: Dither QuickTime videos in paletted screen modes

### DIFF
--- a/engines/sci/graphics/screen.cpp
+++ b/engines/sci/graphics/screen.cpp
@@ -966,7 +966,7 @@ void GfxScreen::debugShowMap(int mapNo) {
 }
 
 void GfxScreen::scale2x(const SciSpan<const byte> &src, SciSpan<byte> &dst, int16 srcWidth, int16 srcHeight, byte bytesPerPixel) {
-	assert(bytesPerPixel == 1 || bytesPerPixel == 2);
+	assert(bytesPerPixel == 1 || bytesPerPixel == 2 || bytesPerPixel == 3 || bytesPerPixel == 4);
 	const int newWidth = srcWidth * 2;
 	const int pitch = newWidth * bytesPerPixel;
 	const byte *srcPtr = src.getUnsafeDataAt(0, srcWidth * srcHeight * bytesPerPixel);
@@ -998,6 +998,55 @@ void GfxScreen::scale2x(const SciSpan<const byte> &src, SciSpan<byte> &dst, int1
 				dstPtr[pitch + 2] = color;
 				dstPtr[pitch + 3] = color2;
 				dstPtr += 4;
+			}
+			dstPtr += pitch;
+		}
+	} else if (bytesPerPixel == 3) {
+		for (int y = 0; y < srcHeight; y++) {
+			for (int x = 0; x < srcWidth; x++) {
+				const byte color = *srcPtr++;
+				const byte color2 = *srcPtr++;
+				const byte color3 = *srcPtr++;
+				dstPtr[0] = color;
+				dstPtr[1] = color2;
+				dstPtr[2] = color3;
+				dstPtr[3] = color;
+				dstPtr[4] = color2;
+				dstPtr[5] = color3;
+				dstPtr[pitch] = color;
+				dstPtr[pitch + 1] = color2;
+				dstPtr[pitch + 2] = color3;
+				dstPtr[pitch + 3] = color;
+				dstPtr[pitch + 4] = color2;
+				dstPtr[pitch + 5] = color3;
+				dstPtr += 6;
+			}
+			dstPtr += pitch;
+		}
+	} else if (bytesPerPixel == 4) {
+		for (int y = 0; y < srcHeight; y++) {
+			for (int x = 0; x < srcWidth; x++) {
+				const byte color = *srcPtr++;
+				const byte color2 = *srcPtr++;
+				const byte color3 = *srcPtr++;
+				const byte color4 = *srcPtr++;
+				dstPtr[0] = color;
+				dstPtr[1] = color2;
+				dstPtr[2] = color3;
+				dstPtr[3] = color4;
+				dstPtr[4] = color;
+				dstPtr[5] = color2;
+				dstPtr[6] = color3;
+				dstPtr[7] = color4;
+				dstPtr[pitch] = color;
+				dstPtr[pitch + 1] = color2;
+				dstPtr[pitch + 2] = color3;
+				dstPtr[pitch + 3] = color4;
+				dstPtr[pitch + 4] = color;
+				dstPtr[pitch + 5] = color2;
+				dstPtr[pitch + 6] = color3;
+				dstPtr[pitch + 7] = color4;
+				dstPtr += 8;
 			}
 			dstPtr += pitch;
 		}

--- a/engines/sci/graphics/screen.cpp
+++ b/engines/sci/graphics/screen.cpp
@@ -987,16 +987,12 @@ void GfxScreen::scale2x(const SciSpan<const byte> &src, SciSpan<byte> &dst, int1
 	} else if (bytesPerPixel == 2) {
 		for (int y = 0; y < srcHeight; y++) {
 			for (int x = 0; x < srcWidth; x++) {
-				const byte color = *srcPtr++;
-				const byte color2 = *srcPtr++;
-				dstPtr[0] = color;
-				dstPtr[1] = color2;
-				dstPtr[2] = color;
-				dstPtr[3] = color2;
-				dstPtr[pitch] = color;
-				dstPtr[pitch + 1] = color2;
-				dstPtr[pitch + 2] = color;
-				dstPtr[pitch + 3] = color2;
+				const uint16 color = *(const uint16 *)srcPtr;
+				*(uint16 *)(dstPtr + 0) = color;
+				*(uint16 *)(dstPtr + 2) = color;
+				*(uint16 *)(dstPtr + pitch + 0) = color;
+				*(uint16 *)(dstPtr + pitch + 2) = color;
+				srcPtr += 2;
 				dstPtr += 4;
 			}
 			dstPtr += pitch;
@@ -1026,26 +1022,12 @@ void GfxScreen::scale2x(const SciSpan<const byte> &src, SciSpan<byte> &dst, int1
 	} else if (bytesPerPixel == 4) {
 		for (int y = 0; y < srcHeight; y++) {
 			for (int x = 0; x < srcWidth; x++) {
-				const byte color = *srcPtr++;
-				const byte color2 = *srcPtr++;
-				const byte color3 = *srcPtr++;
-				const byte color4 = *srcPtr++;
-				dstPtr[0] = color;
-				dstPtr[1] = color2;
-				dstPtr[2] = color3;
-				dstPtr[3] = color4;
-				dstPtr[4] = color;
-				dstPtr[5] = color2;
-				dstPtr[6] = color3;
-				dstPtr[7] = color4;
-				dstPtr[pitch] = color;
-				dstPtr[pitch + 1] = color2;
-				dstPtr[pitch + 2] = color3;
-				dstPtr[pitch + 3] = color4;
-				dstPtr[pitch + 4] = color;
-				dstPtr[pitch + 5] = color2;
-				dstPtr[pitch + 6] = color3;
-				dstPtr[pitch + 7] = color4;
+				const uint32 color = *(const uint32 *)srcPtr;
+				*(uint32 *)(dstPtr + 0) = color;
+				*(uint32 *)(dstPtr + 4) = color;
+				*(uint32 *)(dstPtr + pitch + 0) = color;
+				*(uint32 *)(dstPtr + pitch + 4) = color;
+				srcPtr += 4;
 				dstPtr += 8;
 			}
 			dstPtr += pitch;


### PR DESCRIPTION
This is an initial (untested) proof of concept for [Trac #14173](https://bugs.scummvm.org/ticket/14173). Only King's Quest 6 is affected - since the SCI32 code doesn't appear to change modes when loading QuickTime videos, I'm assuming that the Mac version of King's Quest 7 only uses palette-based codecs.