### PR TITLE
PINK: PDA open from menu does not change pause level

### DIFF
--- a/engines/pink/objects/actors/lead_actor.cpp
+++ b/engines/pink/objects/actors/lead_actor.cpp
@@ -156,7 +156,7 @@ void LeadActor::loadPDA(const Common::String &pageName) {
 	if (_state != kPDA) {
 		if (_state == kMoving)
 			cancelInteraction();
-		if (_state != kInventory)
+		if (_state != kInventory && !_page->getGame()->getScreen()->isMenuActive())
 			_page->pause(true);
 
 		_stateBeforePDA = _state;
@@ -317,8 +317,9 @@ void LeadActor::onPDAClose() {
 	_page->getGame()->getScreen()->loadStage();
 
 	_state = _stateBeforePDA;
+	_stateBeforePDA = kUndefined;
 	if (_state != kInventory)
-		_page->pause(0);
+		_page->pause(false);
 }
 
 bool LeadActor::isInteractingWith(const Actor *actor) const {

--- a/engines/pink/screen.cpp
+++ b/engines/pink/screen.cpp
@@ -233,6 +233,10 @@ void Screen::pause(bool pause_) {
 	}
 }
 
+bool Screen::isMenuActive() {
+	return _wm != nullptr && _wm->isMenuActive();
+}
+
 void Screen::saveStage() {
 	_savedSprites = _sprites;
 	clear();

--- a/engines/pink/screen.h
+++ b/engines/pink/screen.h
@@ -69,6 +69,7 @@ public:
 	void clear();
 
 	void pause(bool pause);
+	bool isMenuActive();
 
 	void saveStage();
 	void loadStage();


### PR DESCRIPTION
Addresses bug #13860 "PINK: Animations will freeze after exiting PDA"

Basically it prevents pausing again (increasing pauselevel) if the macmenu (popup menu on top of screen, which can be used to open PDA) is active, since that one already pauses the engine.

Tested with Passport to Peril US English version. I am unsure if this would resolve the similar issue mentioned for Hocus Pocus in the same ticket (maybe a different but similar fix is required for that one).
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
