### PR TITLE
PINK: Fix localized text encoding

### DIFF
--- a/engines/pink/objects/actions/action_text.cpp
+++ b/engines/pink/objects/actions/action_text.cpp
@@ -100,13 +100,23 @@ void ActionText::start() {
 	screen->getWndManager()._language = language;
 	switch(language) {
 	case Common::DA_DNK:
+		// fall through
 	case Common::ES_ESP:
+		// fall through
 	case Common::FR_FRA:
+		// fall through
 	case Common::PT_BRA:
+		// fall through
+	case Common::DE_DEU:
+		// fall through
+	case Common::IT_ITA:
+		// fall through
+	case Common::NL_NLD:
 		_text = Common::String(str).decode(Common::kWindows1252);
 		break;
 
 	case Common::FI_FIN:
+		// fall through
 	case Common::SE_SWE:
 		_text = Common::String(str).decode(Common::kWindows1257);
 		break;
@@ -126,7 +136,10 @@ void ActionText::start() {
 		_text = Common::String(str).decode(Common::kWindows1251);
 		break;
 
+	case Common::EN_GRB:
+		// fall through
 	case Common::EN_ANY:
+		// fall through
 	default:
 		_text = Common::String(str);
 		break;


### PR DESCRIPTION
Should address bugs #13865 and #13866 PINK: German Umlauts not displayed

Also added text encoding support for the other language codes that are in the detection_tables.h for the PINK engine. Namely, IT_ITA, NL_NLD, and EN_GRB. The NL_NLD one I am uncertain about, but according to wikipedia, Windows-1252 should do for Dutch as well. I cannot test for it though.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
