### PR TITLE
PINK: Clear global game variables on New Game

### DIFF
--- a/engines/pink/constants.h
+++ b/engines/pink/constants.h
@@ -132,11 +132,6 @@ enum {
 };
 
 enum {
-	kLoadingSave = 1,
-	kLoadingNewGame = 0
-};
-
-enum {
 	kOrbMajorVersion = 2,
 	kOrbMinorVersion = 0,
 	kBroMajorVersion = 1,

--- a/engines/pink/cursor_mgr.cpp
+++ b/engines/pink/cursor_mgr.cpp
@@ -34,6 +34,7 @@ CursorMgr::CursorMgr(PinkEngine *game, Page *page)
 void CursorMgr::setCursor(byte index, Common::Point point, const Common::String &itemName) {
 	switch (index) {
 	case kClickableFirstFrameCursor:
+		// fall through
 	case kPDAClickableFirstFrameCursor:
 		startAnimation(index);
 		hideItem();

--- a/engines/pink/gui.cpp
+++ b/engines/pink/gui.cpp
@@ -210,8 +210,7 @@ void PinkEngine::executeMenuCommand(uint id) {
 
 	switch (id) {
 	case kNewGameAction: {
-		const Common::String moduleName = _modules[0]->getName();
-		initModule(moduleName, "", nullptr);
+		initModule(_modules[0]->getName(), "", nullptr);
 		break;
 	}
 	case kLoadSave:

--- a/engines/pink/objects/module.cpp
+++ b/engines/pink/objects/module.cpp
@@ -65,7 +65,7 @@ void Module::init(bool isLoadingSave, const Common::String &pageName) {
 void Module::changePage(const Common::String &pageName) {
 	_page->unload();
 	_page = findPage(pageName);
-	_page->init(kLoadingNewGame);
+	_page->init(false);
 }
 
 GamePage *Module::findPage(const Common::String &pageName) const {

--- a/engines/pink/objects/pages/game_page.cpp
+++ b/engines/pink/objects/pages/game_page.cpp
@@ -185,7 +185,7 @@ void GamePage::unload() {
 
 void GamePage::clear() {
 	Page::clear();
-	_variables.clear(1);
+	_variables.clear(true);
 
 	for (uint i = 0; i < _handlers.size(); ++i) {
 		delete _handlers[i];

--- a/engines/pink/pink.cpp
+++ b/engines/pink/pink.cpp
@@ -187,13 +187,19 @@ void PinkEngine::initModule(const Common::String &moduleName, const Common::Stri
 	if (_module)
 		removeModule();
 
+	if (moduleName == _modules[0]->getName()) {
+		// new game
+		_variables.clear();
+		debugC(6, kPinkDebugGeneral, "Global Game Variables cleared");
+	}
+
 	addModule(moduleName);
 	if (saveFile)
 		_module->loadState(*saveFile);
 
 	debugC(6, kPinkDebugGeneral, "Module added");
 
-	_module->init(saveFile ? kLoadingSave : kLoadingNewGame, pageName);
+	_module->init(saveFile != nullptr, pageName);
 }
 
 void PinkEngine::changeScene() {


### PR DESCRIPTION
This addresses the cause for #13869 PINK: Can't pickup the poker in sir Manley's house

However:
1. this will not retroactively fix the broken saved games that carry stale global game variables from other playthroughs
2. It will not set the "appropriate" global game variables if the player uses the debug console to jump to different modules and pages back and forth.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
