### PR TITLE
NUVIE: Fix passable actor movement

### DIFF
--- a/engines/ultima/nuvie/actors/actor.cpp
+++ b/engines/ultima/nuvie/actors/actor.cpp
@@ -422,7 +422,7 @@ bool Actor::can_be_moved() {
 }
 
 bool Actor::can_be_passed(Actor *other) {
-// ethereal actors can always pass us
+	// ethereal actors can always pass us
 	return (other->ethereal || is_passable());
 }
 

--- a/engines/ultima/nuvie/actors/actor.cpp
+++ b/engines/ultima/nuvie/actors/actor.cpp
@@ -422,7 +422,8 @@ bool Actor::can_be_moved() {
 }
 
 bool Actor::can_be_passed(Actor *other) {
-	return (other->is_passable() || is_passable());
+// ethereal actors can always pass us
+	return (other->ethereal || is_passable());
 }
 
 uint8 Actor::get_object_readiable_location(Obj *obj) {

--- a/engines/ultima/nuvie/actors/u6_actor.cpp
+++ b/engines/ultima/nuvie/actors/u6_actor.cpp
@@ -1520,7 +1520,7 @@ bool U6Actor::can_twitch() {
 
 bool U6Actor::can_be_passed(Actor *other) {
 	U6Actor *other_ = static_cast<U6Actor *>(other);
-	return (Actor::can_be_passed(other_) && other_->current_movetype != current_movetype);
+	return (Actor::can_be_passed(other_) || other_->current_movetype != current_movetype);
 }
 
 void U6Actor::print() {

--- a/engines/ultima/nuvie/actors/u6_actor.cpp
+++ b/engines/ultima/nuvie/actors/u6_actor.cpp
@@ -1520,7 +1520,9 @@ bool U6Actor::can_twitch() {
 
 bool U6Actor::can_be_passed(Actor *other) {
 	U6Actor *other_ = static_cast<U6Actor *>(other);
-	return (Actor::can_be_passed(other_) || other_->current_movetype != current_movetype);
+// Sherry the mouse can pass others if they are in a party with her.
+	bool is_sherry = is_in_party() && other_->is_in_party() && other_->obj_n == OBJ_U6_MOUSE;
+	return (Actor::can_be_passed(other_) || other_->current_movetype != current_movetype || is_sherry);
 }
 
 void U6Actor::print() {

--- a/engines/ultima/nuvie/actors/u6_actor.cpp
+++ b/engines/ultima/nuvie/actors/u6_actor.cpp
@@ -1520,7 +1520,7 @@ bool U6Actor::can_twitch() {
 
 bool U6Actor::can_be_passed(Actor *other) {
 	U6Actor *other_ = static_cast<U6Actor *>(other);
-// Sherry the mouse can pass others if they are in a party with her.
+	// Sherry the mouse can pass others if they are in a party with her.
 	bool is_sherry = is_in_party() && other_->is_in_party() && other_->obj_n == OBJ_U6_MOUSE;
 	return (Actor::can_be_passed(other_) || other_->current_movetype != current_movetype || is_sherry);
 }


### PR DESCRIPTION
- Do not allow actors marked as passable to pass others who are not

- Allow others to pass actors marked as passable even if they share
    the same movetype (e.g. a mouse should not block the Avatar despite
    both having movetype MOVETYPE_U6_LAND)

- Allow Sherry the mouse to move onto tiles occupied by party members


Fixes [#14396](https://bugs.scummvm.org/ticket/14396)