### PR TITLE
AGS: Add stubs for AGSTrans plugin

### DIFF
--- a/engines/ags/module.mk
+++ b/engines/ags/module.mk
@@ -350,6 +350,7 @@ MODULE_OBJS = \
 	plugins/ags_shell/ags_shell.o \
 	plugins/ags_tcp_ip/ags_tcp_ip.o \
 	plugins/ags_touch/ags_touch.o \
+	plugins/ags_trans/ags_trans.o \
 	plugins/ags_wadjet_util/ags_wadjet_util.o \
 	plugins/ags_waves/ags_waves.o \
 	plugins/ags_waves/data.o \

--- a/engines/ags/plugins/ags_trans/ags_trans.cpp
+++ b/engines/ags/plugins/ags_trans/ags_trans.cpp
@@ -1,0 +1,81 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * of the License, or(at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ags/plugins/ags_trans/ags_trans.h"
+
+namespace AGS3 {
+namespace Plugins {
+namespace AGSTrans {
+
+const char *AGSTrans::AGS_GetPluginName() {
+	return "AGS Trans";
+}
+
+void AGSTrans::AGS_EngineStartup(IAGSEngine *engine) {
+	PluginBase::AGS_EngineStartup(engine);
+
+	SCRIPT_METHOD(GenerateArray, AGSTrans::GenerateArray);
+	SCRIPT_METHOD(LoadArray, AGSTrans::LoadArray);
+	SCRIPT_METHOD(CreateTransparentOverlay, AGSTrans::CreateTransparentOverlay);
+	SCRIPT_METHOD(CreateColorisedOverlay, AGSTrans::CreateColorisedOverlay);
+	SCRIPT_METHOD(RemoveTransOverlay, AGSTrans::RemoveTransOverlay);
+	SCRIPT_METHOD(ChangeOverlayAlpha, AGSTrans::ChangeOverlayAlpha);
+	SCRIPT_METHOD(ChangeOverlayPosition, AGSTrans::ChangeOverlayPosition);
+}
+
+void AGSTrans::GenerateArray(ScriptMethodParams &params) {
+	// TODO
+	warning("STUB: AGSTrans::GenerateArray");
+}
+
+void AGSTrans::LoadArray(ScriptMethodParams &params) {
+	// TODO
+	warning("STUB: AGSTrans::LoadArray");
+}
+
+void AGSTrans::CreateTransparentOverlay(ScriptMethodParams &params) {
+	// TODO
+	warning("STUB: AGSTrans::CreateTransparentOverlay");
+}
+
+void AGSTrans::CreateColorisedOverlay(ScriptMethodParams &params) {
+	// TODO
+	warning("STUB: AGSTrans::CreateColorisedOverlay");
+}
+
+void AGSTrans::RemoveTransOverlay(ScriptMethodParams &params) {
+	// TODO
+	warning("STUB: AGSTrans::RemoveTransOverlay");
+}
+
+void AGSTrans::ChangeOverlayAlpha(ScriptMethodParams &params) {
+	// TODO
+	warning("STUB: AGSTrans::ChangeOverlayAlpha");
+}
+
+void AGSTrans::ChangeOverlayPosition(ScriptMethodParams &params) {
+	// TODO
+	warning("STUB: AGSTrans::ChangeOverlayPosition");
+}
+
+} // namespace AGSTrans
+} // namespace Plugins
+} // namespace AGS3

--- a/engines/ags/plugins/ags_trans/ags_trans.h
+++ b/engines/ags/plugins/ags_trans/ags_trans.h
@@ -1,0 +1,56 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * of the License, or(at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef AGS_PLUGINS_AGS_TRANS_H
+#define AGS_PLUGINS_AGS_TRANS_H
+
+#include "ags/plugins/ags_plugin.h"
+
+namespace AGS3 {
+namespace Plugins {
+namespace AGSTrans {
+
+class AGSTrans : public PluginBase {
+	SCRIPT_HASH(AGSTrans)
+
+private:
+	void GenerateArray(ScriptMethodParams &params);
+	void LoadArray(ScriptMethodParams &params);
+	void CreateTransparentOverlay(ScriptMethodParams &params);
+	void CreateColorisedOverlay(ScriptMethodParams &params);
+	void RemoveTransOverlay(ScriptMethodParams &params);
+	void ChangeOverlayAlpha(ScriptMethodParams &params);
+	void ChangeOverlayPosition(ScriptMethodParams &params);
+
+public:
+	AGSTrans() : PluginBase() {}
+	virtual ~AGSTrans() {}
+
+	const char *AGS_GetPluginName() override;
+	void AGS_EngineStartup(IAGSEngine *engine) override;
+
+};
+
+} // namespace AGSTrans
+} // namespace Plugins
+} // namespace AGS3
+
+#endif

--- a/engines/ags/plugins/plugin_base.cpp
+++ b/engines/ags/plugins/plugin_base.cpp
@@ -42,6 +42,7 @@
 #include "ags/plugins/ags_sprite_font/ags_sprite_font_clifftop.h"
 #include "ags/plugins/ags_tcp_ip/ags_tcp_ip.h"
 #include "ags/plugins/ags_touch/ags_touch.h"
+#include "ags/plugins/ags_trans/ags_trans.h"
 #include "ags/plugins/ags_wadjet_util/ags_wadjet_util.h"
 #include "ags/plugins/ags_waves/ags_waves.h"
 #include "ags/ags.h"
@@ -132,6 +133,9 @@ Plugins::PluginBase *pluginOpen(const char *filename) {
 
 	if (fname.equalsIgnoreCase("AGSTouch"))
 		return new AGSTouch::AGSTouch();
+
+	if (fname.equalsIgnoreCase("AGSTrans"))
+		return new AGSTrans::AGSTrans();
 
 	if (fname.equalsIgnoreCase("AGSWadjetUtil"))
 		return new AGSWadjetUtil::AGSWadjetUtil();


### PR DESCRIPTION
This PR simply adds stubs for the AGSTrans plugin (which I think was used only in the game
Death Wore Endless Feathers) to draw semitransparent windows.
With the stubs in place the game is playable and completable.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
