### PR TITLE
GUI: Don't enforce full redraw upon closing tool tip

### DIFF
--- a/gui/Tooltip.cpp
+++ b/gui/Tooltip.cpp
@@ -97,4 +97,19 @@ void Tooltip::drawDialog(DrawLayer layerToDraw) {
 	}
 }
 
+void Tooltip::close() {
+	// copy&paste from Dialog::close()
+	_visible = false;
+
+	if (_mouseWidget) {
+		_mouseWidget->handleMouseLeft(0);
+		_mouseWidget = nullptr;
+	}
+	releaseFocus();
+	g_gui.closeTopDialog(false);
+
+	// instead of kRedrawCloseDialog schedule kRedrawTopDialog of the parent
+	g_gui.scheduleTopDialogRedraw();
+}
+
 }

--- a/gui/Tooltip.h
+++ b/gui/Tooltip.h
@@ -43,6 +43,8 @@ public:
 
 	void receivedFocus(int x = -1, int y = -1) override {}
 protected:
+	void close() override;
+
 	void handleMouseDown(int x, int y, int button, int clickCount) override {
 		close();
 		_parent->handleMouseDown(x + (getAbsX() - _parent->getAbsX()), y + (getAbsY() - _parent->getAbsY()), button, clickCount);

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -614,7 +614,7 @@ void GuiManager::openDialog(Dialog *dialog) {
 		dialog->reflowLayout();
 }
 
-void GuiManager::closeTopDialog() {
+void GuiManager::closeTopDialog(bool redraw) {
 	// Don't do anything if no dialog is open
 	if (_dialogStack.empty())
 		return;
@@ -627,10 +627,12 @@ void GuiManager::closeTopDialog() {
 		giveFocusToDialog(dialog);
 	}
 
-	if (_redrawStatus != kRedrawFull)
-		_redrawStatus = kRedrawCloseDialog;
+	if (redraw) {
+		if (_redrawStatus != kRedrawFull)
+			_redrawStatus = kRedrawCloseDialog;
 
-	redraw();
+		this->redraw();
+	}
 }
 
 void GuiManager::setupCursor() {

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -71,6 +71,7 @@ typedef Common::FixedStack<Dialog *> DialogStack;
  */
 class GuiManager : public Common::Singleton<GuiManager>, public CommandSender {
 	friend class Dialog;
+	friend class Tooltip;
 	friend class Common::Singleton<SingletonBaseType>;
 	GuiManager();
 	~GuiManager() override;
@@ -211,7 +212,7 @@ protected:
 	void restoreState();
 
 	void openDialog(Dialog *dialog);
-	void closeTopDialog();
+	void closeTopDialog(bool redraw = true);
 
 	void redraw();
 


### PR DESCRIPTION
Follow-up of #4953 -- this makes tool tips noticeably faster as even a three letter tooltip would require a complete clearOverlay() & grabOverlay() & build the dialog stack.

This way it redraws only its parent dialog (dialog is key here; not parent widget).

One day I or perhaps someone else find the courage to implement a proper window manager into ScummVM, that way `kRedrawCloseDialog` would restore the underlying widget(s) (it is the "s" which makes this quite a complex change).