### PR TITLE
SCUMM HE: Bugfix: Allow turned-around runners on pop-ups to turn back around

### DIFF
--- a/engines/scumm/he/script_v72he.cpp
+++ b/engines/scumm/he/script_v72he.cpp
@@ -185,7 +185,6 @@ int ScummEngine_v72he::readArray(int array, int idx2, int idx1) {
 			readVar(399) == 1 &&  // This checks that we're playing online
 			readVar(0x8000 + 11) == 1 &&  // The ball is a pop-up
 			readVar(291) < 2 &&  // Less than two outs
-			readVar(300) == 0 &&  // Ball hasn't bounced
 			// This is the array of baserunner status info, and the value in position 8 specifies whether the runner is forced
 			array == 295 && idx1 == 8) {
 			return 0;


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->

The competitive play mod implemented in [this PR](https://github.com/scummvm/scummvm/pull/4829) introduced a bug in which, after turning around on a pop-up, the runner is "stuck" - they can't be turned _back_ around, and won't move until another runner reaches the base that they're standing on. [Here's](https://medal.tv/games/requested/clips/16SSgpxQP-1n6O/M3DmWPBn2dV9?invite=cr-MSxnVFAsMjUwNjI5Nzcs) an example of this bug in action.

This PR fixes this issue. [Here's a clip](https://streamable.com/zigteu) of the same situation as the above clip, with this fix.