### PR TITLE
WATCHMAKER: Fix MSVC linker failure

### DIFF
--- a/engines/watchmaker/classes/do_keyboard.cpp
+++ b/engines/watchmaker/classes/do_keyboard.cpp
@@ -58,6 +58,8 @@ uint16 bnd_lev;
 extern int16 NextDlg;   //from doDialog.c
 extern uint8 tasti_per_sfx1;    //from main.c
 
+void t3dLoadOutdoorLights(const char *pname, t3dBODY *b, int32 ora);
+
 void ProcessKBInput() {
 	// TODO: Currently we're polling this in the PollEvent flow.
 	return;
@@ -389,7 +391,6 @@ void ProcessKeyboard(WGame &game) {
 
 
 		if (KeyDown(Common::KEYCODE_LSHIFT)) {
-			void t3dLoadOutdoorLights(const char *pname, t3dBODY * b, int32 ora);
 			if (KeyUp(Common::KEYCODE_F1)) t3dLoadOutdoorLights("c:\\wm\\LMaps\\rxt.t3d", t3dRxt, 1030);
 			if (KeyUp(Common::KEYCODE_F2)) t3dLoadOutdoorLights("c:\\wm\\LMaps\\rxt.t3d", t3dRxt, 1530);
 			if (KeyUp(Common::KEYCODE_F3)) t3dLoadOutdoorLights("c:\\wm\\LMaps\\rxt.t3d", t3dRxt, 1930);

--- a/engines/watchmaker/ll/ll_diary.cpp
+++ b/engines/watchmaker/ll/ll_diary.cpp
@@ -38,6 +38,8 @@ namespace Watchmaker {
 
 char bDiariesStoppedByTimeInc = 0;
 
+void t3dLoadOutdoorLights(const char *pname, t3dBODY *b, int32 ora);
+
 /* -----------------26/11/1999 16.19-----------------
  *                      StartDiary
  * --------------------------------------------------*/
@@ -311,7 +313,6 @@ void ContinueDiary(WGame &game, int32 an) {
  *                  UpdateAllClocks
  * --------------------------------------------------*/
 void UpdateAllClocks(WGame &game) {
-	void t3dLoadOutdoorLights(const char *pname, t3dBODY * b, int32 ora);
 	char str[255];
 	t3dMESH *mesh;
 	Init &init = game.init;


### PR DESCRIPTION
Per commit description, this happens because C-style local function prototypes wind up in the global scope, causing them to be linked against a symbol that doesn't exist, because the actual implementation is in the `Watchmaker` namespace.