### PR TITLE
CREATE_PROJECT: Add --libs-path command line parameter that can be used instead of the SCUMMVM_LIBS environment var

### DIFF
--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -307,6 +307,14 @@ int main(int argc, char *argv[]) {
 			setup.useXCFramework = true;
 		} else if (!std::strcmp(argv[i], "--vcpkg")) {
 			setup.useVcpkg = true;
+		} else if (!std::strcmp(argv[i], "--libs-path")) {
+			if (i + 1 >= argc) {
+				std::cerr << "ERROR: Missing \"path\" parameter for \"--libs-path\"!\n";
+				return -1;
+			}
+			std::string libsDir = unifyPath(argv[++i]);
+			removeTrailingSlash(libsDir);
+			setup.libsDir = libsDir;
 		} else {
 			std::cerr << "ERROR: Unknown parameter \"" << argv[i] << "\"\n";
 			return -1;
@@ -741,7 +749,9 @@ void displayHelp(const char *exe) {
 	        "                            (default: true)\n"
 	        " --use-windows-ansi         Use Windows ANSI APIs\n"
 	        "                            (default: false)\n"
-	        " --vcpkg                    Use vcpkg-provided libraries instead of pre-built SCUMMVM_LIBS\n"
+	        " --libs-path path           Specify the path of pre-built libraries instead of using the\n"
+			"                            " LIBS_DEFINE " environment variable\n "
+	        " --vcpkg                    Use vcpkg-provided libraries instead of pre-built libraries\n"
 	        "                            (default: false)\n"
 	        "\n"
 	        "Engines settings:\n"

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -230,6 +230,7 @@ struct BuildSetup {
 	std::string srcDir;     ///< Path to the sources.
 	std::string filePrefix; ///< Prefix for the relative path arguments in the project files.
 	std::string outputDir;  ///< Path where to put the MSVC project files.
+	std::string libsDir;    ///< Path to libraries for MSVC builds.  If absent, use LIBS_DEFINE environment var instead.
 
 	StringList includeDirs; ///< List of additional include paths
 	StringList libraryDirs; ///< List of additional library paths

--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -369,10 +369,17 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 			   << "<Project DefaultTargets=\"Build\" ToolsVersion=\"" << _msvcVersion.project << "\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n"
 			   << "\t<PropertyGroup>\n"
 			   << "\t\t<_PropertySheetDisplayName>" << setup.projectDescription << "_Global</_PropertySheetDisplayName>\n";
+
+	std::string libsPath;
+	if (setup.libsDir.empty())
+		libsPath = "$(" LIBS_DEFINE ")";
+	else
+		libsPath = convertPathToWin(setup.libsDir);
+
 	if (!setup.useVcpkg) {
-		properties << "\t\t<ExecutablePath>$(" << LIBS_DEFINE << ")\\bin;$(" << LIBS_DEFINE << ")\\bin\\" << getMSVCArchName(arch) << ";$(" << LIBS_DEFINE << ")\\$(Configuration)\\bin;$(ExecutablePath)</ExecutablePath>\n"
-				   << "\t\t<LibraryPath>" << libraryDirsList << "$(" << LIBS_DEFINE << ")\\lib\\" << getMSVCArchName(arch) << ";$(" << LIBS_DEFINE << ")\\lib\\" << getMSVCArchName(arch) << "\\$(Configuration);$(" << LIBS_DEFINE << ")\\lib;$(" << LIBS_DEFINE << ")\\$(Configuration)\\lib;$(LibraryPath)</LibraryPath>\n"
-				   << "\t\t<IncludePath>" << includeDirsList << "$(" << LIBS_DEFINE << ")\\include;$(" << LIBS_DEFINE << ")\\include\\" << includeSDL << ";$(IncludePath)</IncludePath>\n";
+		properties << "\t\t<ExecutablePath>" << libsPath << "\\bin;" << libsPath << "\\bin\\" << getMSVCArchName(arch) << ";" << libsPath << "\\$(Configuration)\\bin;$(ExecutablePath)</ExecutablePath>\n"
+				   << "\t\t<LibraryPath>" << libraryDirsList << libsPath << "\\lib\\" << getMSVCArchName(arch) << ";" << libsPath << "\\lib\\" << getMSVCArchName(arch) << "\\$(Configuration);" << libsPath << "\\lib;" << libsPath << "\\$(Configuration)\\lib;$(LibraryPath)</LibraryPath>\n"
+				   << "\t\t<IncludePath>" << includeDirsList << libsPath << "\\include;" << libsPath << "\\include\\" << includeSDL << ";$(IncludePath)</IncludePath>\n";
 	}
 	properties << "\t\t<OutDir>$(Configuration)" << getMSVCArchName(arch) << "\\</OutDir>\n"
 			   << "\t\t<IntDir>$(Configuration)" << getMSVCArchName(arch) << "\\$(ProjectName)\\</IntDir>\n"

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -291,7 +291,15 @@ std::string MSVCProvider::getPostBuildEvent(MSVC_Architecture arch, const BuildS
 		}
 		cmdLine += "bin/&quot; ";
 	} else {
-		cmdLine += " &quot;%" LIBS_DEFINE "%/lib/";
+		std::string libsPath;
+		if (setup.libsDir.empty())
+			libsPath = "%" LIBS_DEFINE "%";
+		else
+			libsPath = convertPathToWin(setup.libsDir);
+
+		cmdLine += " &quot;";
+		cmdLine += libsPath;
+		cmdLine += "/lib/";
 		cmdLine += getMSVCArchName(arch);
 		cmdLine += "/$(Configuration)&quot; ";
 	}


### PR DESCRIPTION
There are various reasons that it may be undesirable to use an environment variable as part of configuring a build, such as the fact that it requires privilege elevation to set, which can make it more complicated to set up in a new build environment.

This adds a `--libs-path` parameter to create_project that lets you specify the path instead of using the environment variable.