### PR TITLE
Fix various -Wformat warnings on 32-bit archs

### DIFF
--- a/audio/decoders/qdm2.cpp
+++ b/audio/decoders/qdm2.cpp
@@ -2499,7 +2499,7 @@ bool QDM2Stream::qdm2_decodeFrame(Common::SeekableReadStream &in, QueuingAudioSt
 	}
 
 	if ((in.size() - in.pos()) < _packetSize) {
-		debug(1, "QDM2Stream::qdm2_decodeFrame Insufficient Packet Data in Input Stream Found: %ld Need: %d", in.size() - in.pos(), _packetSize);
+		debug(1, "QDM2Stream::qdm2_decodeFrame Insufficient Packet Data in Input Stream Found: %ld Need: %d", long(in.size() - in.pos()), _packetSize);
 		return false;
 	}
 

--- a/engines/director/resource.cpp
+++ b/engines/director/resource.cpp
@@ -692,7 +692,7 @@ bool ProjectorArchive::loadArchive(Common::SeekableReadStream *stream) {
 			size = SWAP_BYTES_32(size);
 		}
 
-		debugC(1, kDebugLoading, "Entry: %s offset %lX tag %s size %d", arr[i].c_str(), stream->pos() - 8, tag2str(tag), size);
+		debugC(1, kDebugLoading, "Entry: %s offset %lX tag %s size %d", arr[i].c_str(), long(stream->pos() - 8), tag2str(tag), size);
 
 		Entry entry;
 

--- a/engines/freescape/loaders/8bitBinaryLoader.cpp
+++ b/engines/freescape/loaders/8bitBinaryLoader.cpp
@@ -191,7 +191,7 @@ Object *FreescapeEngine::load8bitObject(Common::SeekableReadStream *file) {
 			// instructions = getInstructions(conditionSource);
 			debugC(1, kFreescapeDebugParser, "%s", conditionSource.c_str());
 		}
-		debugC(1, kFreescapeDebugParser, "End of object at %lx", file->pos());
+		debugC(1, kFreescapeDebugParser, "End of object at %lx", long(file->pos()));
 
 		if (!GeometricObject::isPolygon(objectType))
 			position = 32 * position;
@@ -219,7 +219,7 @@ Object *FreescapeEngine::load8bitObject(Common::SeekableReadStream *file) {
 			byteSizeOfObject = 0;
 		}
 		assert(byteSizeOfObject == 0);
-		debugC(1, kFreescapeDebugParser, "End of object at %lx", file->pos());
+		debugC(1, kFreescapeDebugParser, "End of object at %lx", long(file->pos()));
 		// create an entrance
 		return new Entrance(
 			objectID,
@@ -260,7 +260,7 @@ Object *FreescapeEngine::load8bitObject(Common::SeekableReadStream *file) {
 			conditionSource = detokenise8bitCondition(conditionArray, instructions);
 			debugC(1, kFreescapeDebugParser, "%s", conditionSource.c_str());
 		}
-		debugC(1, kFreescapeDebugParser, "End of object at %lx", file->pos());
+		debugC(1, kFreescapeDebugParser, "End of object at %lx", long(file->pos()));
 		// create an entrance
 		return new Sensor(
 			objectID,
@@ -436,7 +436,7 @@ Area *FreescapeEngine::load8bitArea(Common::SeekableReadStream *file, uint16 nco
 	debugC(1, kFreescapeDebugParser, "Area %d", areaNumber);
 	debugC(1, kFreescapeDebugParser, "Flags: %d Objects: %d", areaFlags, numberOfObjects);
 	// debug("Condition Ptr: %x", cPtr);
-	debugC(1, kFreescapeDebugParser, "Pos before first object: %lx", file->pos());
+	debugC(1, kFreescapeDebugParser, "Pos before first object: %lx", long(file->pos()));
 
 	uint8 gasPocketX = 0;
 	uint8 gasPocketY = 0;
@@ -533,7 +533,7 @@ Area *FreescapeEngine::load8bitArea(Common::SeekableReadStream *file, uint16 nco
 		debugC(1, kFreescapeDebugParser, "%s", conditionSource.c_str());
 	}
 
-	debugC(1, kFreescapeDebugParser, "End of area at %lx", file->pos());
+	debugC(1, kFreescapeDebugParser, "End of area at %lx", long(file->pos()));
 	return area;
 }
 
@@ -607,7 +607,7 @@ void FreescapeEngine::load8bitBinary(Common::SeekableReadStream *file, int offse
 		loadDemoData(file, offset + demoDataTable, 128); // TODO: check this size
 
 	file->seek(offset + globalByteCodeTable);
-	debugC(1, kFreescapeDebugParser, "Position: %lx\n", file->pos());
+	debugC(1, kFreescapeDebugParser, "Position: %lx\n", long(file->pos()));
 
 	uint8 numConditions = readField(file, 8);
 	debugC(1, kFreescapeDebugParser, "%d global conditions", numConditions);
@@ -615,7 +615,7 @@ void FreescapeEngine::load8bitBinary(Common::SeekableReadStream *file, int offse
 		FCLInstructionVector instructions;
 		// get the length
 		uint32 lengthOfCondition = readField(file, 8);
-		debugC(1, kFreescapeDebugParser, "length of condition: %d at %lx", lengthOfCondition, file->pos());
+		debugC(1, kFreescapeDebugParser, "length of condition: %d at %lx", lengthOfCondition, long(file->pos()));
 		// get the condition
 		Common::Array<uint8> conditionArray = readArray(file, lengthOfCondition);
 		// debug("Global condition %d", numConditions + 1);
@@ -661,7 +661,7 @@ void FreescapeEngine::load8bitBinary(Common::SeekableReadStream *file, int offse
 		file->seek(offset + 0xc8);
 	// file->seek(offset + 0x4f); //CPC
 
-	debugC(1, kFreescapeDebugParser, "areas index at: %lx", file->pos());
+	debugC(1, kFreescapeDebugParser, "areas index at: %lx", long(file->pos()));
 	uint16 *fileOffsetForArea = new uint16[numberOfAreas];
 	for (uint16 area = 0; area < numberOfAreas; area++) {
 		fileOffsetForArea[area] = readField(file, 16);

--- a/engines/groovie/video/roq.cpp
+++ b/engines/groovie/video/roq.cpp
@@ -545,7 +545,7 @@ bool ROQPlayer::processBlock() {
 	}
 
 	if (endpos != _file->pos() && !_file->eos()) {
-		warning("Groovie::ROQ: BLOCK %04x Should have ended at %ld, and has ended at %d", blockHeader.type, endpos, (int)_file->pos());
+		warning("Groovie::ROQ: BLOCK %04x Should have ended at %lld, and has ended at %lld", blockHeader.type, (long long)endpos, (long long)_file->pos());
 		warning("Ensure you've copied the files correctly according to the wiki.");
 		_file->seek(MIN(_file->pos(), endpos));
 	}
@@ -699,7 +699,7 @@ bool ROQPlayer::processBlockQuadVector(ROQBlockHeader &blockHeader) {
 		}
 		_file->skip(skipBytes);
 		if (skipBytes != 2) {
-			warning("Groovie::ROQ: Skipped %ld bytes", skipBytes);
+			warning("Groovie::ROQ: Skipped %lld bytes", (long long)skipBytes);
 		}
 	}
 	return true;

--- a/engines/saga2/interp.cpp
+++ b/engines/saga2/interp.cpp
@@ -560,7 +560,7 @@ static void print_stack(int16 *_stackBase, int16 *stack) {
 	debugC(3, kDebugScripts, "]");
 }
 
-#define D_OP(x) debugC(1, kDebugScripts, "[%04ld 0x%04lx]: %s", (pc - _codeSeg - 1), (pc - _codeSeg - 1), #x)
+#define D_OP(x) debugC(1, kDebugScripts, "[%04ld 0x%04lx]: %s", long(pc - _codeSeg - 1), long(pc - _codeSeg - 1), #x)
 #define D_OP1(x) debugC(1, kDebugScripts, "[%04ld 0x%04lx]: %s = %d", long(pc - _codeSeg - 1), long(pc - _codeSeg - 1), #x, *stack)
 #define D_OP2(x) debugC(1, kDebugScripts, "[%04ld 0x%04lx]: %s [%p] = %d", long(pc - _codeSeg - 1), long(pc - _codeSeg - 1), #x, (void *)addr, *stack)
 #define D_OP3(x) debugC(1, kDebugScripts, "[%04ld 0x%04lx]: %s [%p] %d", long(pc - _codeSeg - 1), long(pc - _codeSeg - 1), #x, (void *)addr, *addr)


### PR DESCRIPTION
Some `-Wformat` warnings show up in the build logs of some of our 32-bits ports (such as Android 32 bit, Dreamcast, Debian i686…), when calling a printf-like function with something like `%ld` and an argument that's not guaranteed to be the same size as a `long` by default.

This is a proposal for fixing this.

The general idea is just to use an explicit cast to `long`, since it looks like this is what is done in general in the codebase (?), and AFAICS the impacted engines are for older games with no real-world possibility of 64-bit file offsets, especially for some simple debug output. Casting to `long long` is another possibility (which is potentially even better), but I just tried to follow the existing "style" of each component.