### PR TITLE
AUDIO: Add support for manually setting sounds' sample rate

### DIFF
--- a/audio/mixer.cpp
+++ b/audio/mixer.cpp
@@ -652,7 +652,7 @@ int Channel::mix(int16 *data, uint len) {
 		_samplesConsumed = _samplesDecoded;
 		_mixerTimeStamp = g_system->getMillis(true);
 		_pauseTime = 0;
-		res = _converter->flow(*_stream, data, len, _volL, _volR);
+		res = _converter->convert(*_stream, data, len, _volL, _volR);
 		_samplesDecoded += res;
 	}
 

--- a/audio/mixer.h
+++ b/audio/mixer.h
@@ -255,6 +255,31 @@ public:
 	virtual int8 getChannelBalance(SoundHandle handle) = 0;
 
 	/**
+	 * Set the sample rate for the given handle.
+	 * 
+	 * @param handle 	The sound to affect.
+	 * @param rate		The new sample rate. Must be less than 131072
+	*/
+	virtual void setChannelRate(SoundHandle handle, uint32 rate) = 0;
+
+	/**
+	 * Get the sample rate for the given handle.
+	 * 
+	 * @param handle 	The sound to affect.
+	 * 
+	 * @return The current sample rate of the channel.
+	*/
+	virtual uint32 getChannelRate(SoundHandle handle) = 0;
+
+	/**
+	 * Reset the sample rate of the channel back to its
+	 * AudioStream's native rate.
+	 * 
+	 * @param handle 	The sound to affect.
+	*/
+	virtual void resetChannelRate(SoundHandle handle) = 0;
+
+	/**
 	 * Get an approximation of for how long the channel has been playing.
 	 */
 	virtual uint32 getSoundElapsedTime(SoundHandle handle) = 0;

--- a/audio/mixer_intern.h
+++ b/audio/mixer_intern.h
@@ -118,6 +118,9 @@ public:
 	virtual byte getChannelVolume(SoundHandle handle);
 	virtual void setChannelBalance(SoundHandle handle, int8 balance);
 	virtual int8 getChannelBalance(SoundHandle handle);
+	virtual void setChannelRate(SoundHandle handle, uint32 rate);
+	virtual uint32 getChannelRate(SoundHandle handle);
+	virtual void resetChannelRate(SoundHandle handle);
 
 	virtual uint32 getSoundElapsedTime(SoundHandle handle);
 	virtual Timestamp getElapsedTime(SoundHandle handle);

--- a/engines/sci/sound/audio32.cpp
+++ b/engines/sci/sound/audio32.cpp
@@ -234,7 +234,7 @@ Audio32::~Audio32() {
 
 int Audio32::writeAudioInternal(Audio::AudioStream &sourceStream, Audio::RateConverter &converter, Audio::st_sample_t *targetBuffer, const int numSamples, const Audio::st_volume_t leftVolume, const Audio::st_volume_t rightVolume) {
 	const int samplePairsToRead = numSamples >> 1;
-	const int samplePairsWritten = converter.flow(sourceStream, targetBuffer, samplePairsToRead, leftVolume, rightVolume);
+	const int samplePairsWritten = converter.convert(sourceStream, targetBuffer, samplePairsToRead, leftVolume, rightVolume);
 	return samplePairsWritten << 1;
 }
 

--- a/engines/sword1/music.cpp
+++ b/engines/sword1/music.cpp
@@ -246,7 +246,7 @@ void Music::mixer(int16 *buf, uint32 len) {
 	memset(buf, 0, 2 * len * sizeof(int16));
 	for (int i = 0; i < ARRAYSIZE(_handles); i++)
 		if (_handles[i].streaming() && _converter[i])
-			_converter[i]->flow(_handles[i], buf, len, _volumeL, _volumeR);
+			_converter[i]->convert(_handles[i], buf, len, _volumeL, _volumeR);
 }
 
 void Music::setVolume(uint8 volL, uint8 volR) {


### PR DESCRIPTION
One of the Nancy Drew games has a puzzle that changes sounds' sample
rates to arbitrary values while they're playing. The initial plan for supporting
this feature was to create a custom AudioStream subclass; however, all
my attempts at doing so resulted in crackling and overly complicated code.

This PR is based around a rewrite of the RateConverter class merging
the previously separate CopyRateConverter, SimpleRateConverter,
and LinearRateConverter subclasses into a single class that supports
setting the input and output rates after creation. The optimized
code paths of those classes have been moved to separate functions,
with the correct one being picked on the fly.

The Mixer class has been upgraded to make use of the new feature,
so all an engine needs to do to change the playback speed of a sound is
to call the newly-added setChannelRate() function.