### PR TITLE
SCUMM: Fix detection of Chinese Full Throttle

### DIFF
--- a/engines/scumm/detection_internal.h
+++ b/engines/scumm/detection_internal.h
@@ -216,7 +216,7 @@ static Common::Language detectLanguage(const Common::FSList &fslist, byte id, co
 	// First try to detect Chinese translation.
 	Common::FSNode fontFile;
 
-	if (searchFSNode(fslist, "chinese_gb16x12.fnt", fontFile)) {
+	if (searchFSNode(fslist, "chinese_gb16x12.fnt", fontFile) || (searchFSNode(fslist, "video", fontFile) && fontFile.getChild("chinese_gb16x12.fnt").exists())) {
 		debugC(0, kDebugGlobalDetection, "Chinese detected");
 		return Common::ZH_CHN;
 	}


### PR DESCRIPTION
Chinese Full Throttle puts the font in video directory. ScummVM accepts it there in the game but not in the detection. So user needs to select language manually in order for it to work. Check the second location as well


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
