### PR TITLE
JANITORIAL: Replace directly dereferenced dynamic_cast with static_cast

### DIFF
--- a/backends/events/ds/ds-events.cpp
+++ b/backends/events/ds/ds-events.cpp
@@ -72,7 +72,7 @@ void DSEventSource::addEventsToQueue() {
 		if (held & KEY_TOUCH) {
 			touchPosition touchPos;
 			touchRead(&touchPos);
-			event.mouse = dynamic_cast<OSystem_DS *>(g_system)->transformPoint(touchPos.px, touchPos.py);
+			event.mouse = static_cast<OSystem_DS *>(g_system)->transformPoint(touchPos.px, touchPos.py);
 
 			if (event.mouse.x != _lastTouch.x || event.mouse.y != _lastTouch.y) {
 				event.type = Common::EVENT_MOUSEMOVE;

--- a/backends/events/psp2sdl/psp2sdl-events.cpp
+++ b/backends/events/psp2sdl/psp2sdl-events.cpp
@@ -230,8 +230,8 @@ void PSP2EventSource::preprocessFingerMotion(SDL_Event *event) {
 	if (numFingersDown >= 1) {
 		int x = _mouseX;
 		int y = _mouseY;
-		int xMax = dynamic_cast<WindowedGraphicsManager *>(_graphicsManager)->getWindowWidth() - 1;
-		int yMax = dynamic_cast<WindowedGraphicsManager *>(_graphicsManager)->getWindowHeight() - 1;
+		int xMax = static_cast<WindowedGraphicsManager *>(_graphicsManager)->getWindowWidth() - 1;
+		int yMax = static_cast<WindowedGraphicsManager *>(_graphicsManager)->getWindowHeight() - 1;
 
 		if (port == 0 && !ConfMan.getBool("frontpanel_touchpad_mode")) {
 			convertTouchXYToGameXY(event->tfinger.x, event->tfinger.y, &x, &y);
@@ -383,8 +383,8 @@ void PSP2EventSource::preprocessFingerMotion(SDL_Event *event) {
 }
 
 void PSP2EventSource::convertTouchXYToGameXY(float touchX, float touchY, int *gameX, int *gameY) {
-	int screenH = dynamic_cast<WindowedGraphicsManager *>(_graphicsManager)->getWindowHeight();
-	int screenW = dynamic_cast<WindowedGraphicsManager *>(_graphicsManager)->getWindowWidth();
+	int screenH = static_cast<WindowedGraphicsManager *>(_graphicsManager)->getWindowHeight();
+	int screenW = static_cast<WindowedGraphicsManager *>(_graphicsManager)->getWindowWidth();
 
 	const int dispW = TOUCHSCREEN_WIDTH;
 	const int dispH = TOUCHSCREEN_HEIGHT;

--- a/backends/events/sdl/legacy-sdl-events.cpp
+++ b/backends/events/sdl/legacy-sdl-events.cpp
@@ -127,7 +127,7 @@ bool LegacySdlEventSource::handleKbdMouse(Common::Event &event) {
 
 	if (_km.x != oldKmX || _km.y != oldKmY) {
 		if (_graphicsManager) {
-			dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->getWindow()->warpMouseInWindow((Uint16)(_km.x / MULTIPLIER), (Uint16)(_km.y / MULTIPLIER));
+			static_cast<SdlGraphicsManager *>(_graphicsManager)->getWindow()->warpMouseInWindow((Uint16)(_km.x / MULTIPLIER), (Uint16)(_km.y / MULTIPLIER));
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
@@ -239,8 +239,8 @@ void LegacySdlEventSource::checkScreenChange() {
 		return;
 	}
 
-	int newMaxX = dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->getWindowWidth()  - 1;
-	int newMaxY = dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->getWindowHeight() - 1;
+	int newMaxX = static_cast<SdlGraphicsManager *>(_graphicsManager)->getWindowWidth()  - 1;
+	int newMaxY = static_cast<SdlGraphicsManager *>(_graphicsManager)->getWindowHeight() - 1;
 
 	if (_km.x_max != newMaxX || _km.y_max != newMaxY) {
 		resetKeyboardEmulation(newMaxX, newMaxY);

--- a/backends/graphics/android/android-graphics.cpp
+++ b/backends/graphics/android/android-graphics.cpp
@@ -77,7 +77,7 @@ AndroidGraphicsManager::AndroidGraphicsManager() :
 	_touchcontrols->updateGLTexture();
 
 	// not in 3D, not in overlay
-	dynamic_cast<OSystem_Android *>(g_system)->applyTouchSettings(false, false);
+	static_cast<OSystem_Android *>(g_system)->applyTouchSettings(false, false);
 }
 
 AndroidGraphicsManager::~AndroidGraphicsManager() {
@@ -114,7 +114,7 @@ void AndroidGraphicsManager::initSurface() {
 		_touchcontrols->recreate();
 		_touchcontrols->updateGLTexture();
 	}
-	dynamic_cast<OSystem_Android *>(g_system)->getTouchControls().init(
+	static_cast<OSystem_Android *>(g_system)->getTouchControls().init(
 	    this, JNI::egl_surface_width, JNI::egl_surface_height);
 
 	handleResize(JNI::egl_surface_width, JNI::egl_surface_height);
@@ -127,7 +127,7 @@ void AndroidGraphicsManager::deinitSurface() {
 	LOGD("deinitializing 2D surface");
 
 	// Deregister us from touch control
-	dynamic_cast<OSystem_Android *>(g_system)->getTouchControls().init(
+	static_cast<OSystem_Android *>(g_system)->getTouchControls().init(
 	    nullptr, 0, 0);
 	if (_touchcontrols) {
 		_touchcontrols->destroy();
@@ -161,7 +161,7 @@ void AndroidGraphicsManager::showOverlay(bool inGUI) {
 	if (inGUI) {
 		_old_touch_mode = JNI::getTouchMode();
 		// not in 3D, in overlay
-		dynamic_cast<OSystem_Android *>(g_system)->applyTouchSettings(false, true);
+		static_cast<OSystem_Android *>(g_system)->applyTouchSettings(false, true);
 	} else if (_overlayInGUI) {
 		// Restore touch mode active before overlay was shown
 		JNI::setTouchMode(_old_touch_mode);
@@ -206,7 +206,7 @@ void AndroidGraphicsManager::refreshScreen() {
 	//ENTER();
 
 	// Last minute draw of touch controls
-	dynamic_cast<OSystem_Android *>(g_system)->getTouchControls().draw();
+	static_cast<OSystem_Android *>(g_system)->getTouchControls().draw();
 
 	JNI::swapBuffers();
 }

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -116,7 +116,7 @@ AndroidGraphics3dManager::AndroidGraphics3dManager() :
 	initSurface();
 
 	// in 3D, not in overlay
-	dynamic_cast<OSystem_Android *>(g_system)->applyTouchSettings(true, false);
+	static_cast<OSystem_Android *>(g_system)->applyTouchSettings(true, false);
 }
 
 AndroidGraphics3dManager::~AndroidGraphics3dManager() {
@@ -205,7 +205,7 @@ void AndroidGraphics3dManager::initSurface() {
 	if (_touchcontrols_texture) {
 		_touchcontrols_texture->reinit();
 	}
-	dynamic_cast<OSystem_Android *>(g_system)->getTouchControls().init(
+	static_cast<OSystem_Android *>(g_system)->getTouchControls().init(
 	    this, JNI::egl_surface_width, JNI::egl_surface_height);
 
 	updateScreenRect();
@@ -239,7 +239,7 @@ void AndroidGraphics3dManager::deinitSurface() {
 		_mouse_texture->release();
 	}
 
-	dynamic_cast<OSystem_Android *>(g_system)->getTouchControls().init(
+	static_cast<OSystem_Android *>(g_system)->getTouchControls().init(
 	    nullptr, 0, 0);
 	if (_touchcontrols_texture) {
 		_touchcontrols_texture->release();
@@ -335,7 +335,7 @@ void AndroidGraphics3dManager::updateScreen() {
 		}
 	}
 
-	dynamic_cast<OSystem_Android *>(g_system)->getTouchControls().draw();
+	static_cast<OSystem_Android *>(g_system)->getTouchControls().draw();
 
 	if (!JNI::swapBuffers()) {
 		LOGW("swapBuffers failed: 0x%x", glGetError());
@@ -503,7 +503,7 @@ void AndroidGraphics3dManager::showOverlay(bool inGUI) {
 	if (inGUI) {
 		_old_touch_mode = JNI::getTouchMode();
 		// in 3D, in overlay
-		dynamic_cast<OSystem_Android *>(g_system)->applyTouchSettings(true, true);
+		static_cast<OSystem_Android *>(g_system)->applyTouchSettings(true, true);
 	} else if (_overlay_in_gui) {
 		// Restore touch mode active before overlay was shown
 		JNI::setTouchMode(_old_touch_mode);
@@ -730,7 +730,7 @@ void AndroidGraphics3dManager::warpMouse(int x, int y) {
 	e.type = Common::EVENT_MOUSEMOVE;
 	e.mouse = sMouse;
 
-	dynamic_cast<OSystem_Android *>(g_system)->pushEvent(e);
+	static_cast<OSystem_Android *>(g_system)->pushEvent(e);
 }
 
 void AndroidGraphics3dManager::updateCursorScaling() {

--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -247,7 +247,7 @@ OSystem_Android::~OSystem_Android() {
 	_savefileManager = 0;
 
 	// Uninitialize surface now to avoid it to be done later when touch controls are destroyed
-	dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->deinitSurface();
+	static_cast<AndroidCommonGraphics *>(_graphicsManager)->deinitSurface();
 
 	delete _logger;
 	_logger = nullptr;

--- a/backends/platform/android/android.h
+++ b/backends/platform/android/android.h
@@ -88,7 +88,7 @@ extern void checkGlError(const char *expr, const char *file, int line);
 
 #define GLTHREADCHECK \
 	do { \
-		assert(dynamic_cast<OSystem_Android *>(g_system)->isRunningInMainThread()); \
+		assert(static_cast<OSystem_Android *>(g_system)->isRunningInMainThread()); \
 	} while (false)
 
 #else

--- a/backends/platform/android/events.cpp
+++ b/backends/platform/android/events.cpp
@@ -575,7 +575,7 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 
 			e.type = Common::EVENT_MOUSEMOVE;
 
-			e.mouse = dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
+			e.mouse = static_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
 
 			{
 				int16 *c;
@@ -620,7 +620,7 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 				return;
 			}
 
-			e.mouse = dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
+			e.mouse = static_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
 
 			pushEvent(e);
 
@@ -672,7 +672,7 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 
 	case JE_DOWN:
 //		LOGD("JE_DOWN");
-		_touch_pt_down = dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
+		_touch_pt_down = static_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
 		_touch_pt_scroll.x = -1;
 		_touch_pt_scroll.y = -1;
 		break;
@@ -711,7 +711,7 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 		e.type = Common::EVENT_MOUSEMOVE;
 
 		if (_touch_mode == TOUCH_MODE_TOUCHPAD) {
-			e.mouse = dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
+			e.mouse = static_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
 		} else {
 			e.mouse.x = arg1;
 			e.mouse.y = arg2;
@@ -786,7 +786,7 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 		e.type = Common::EVENT_MOUSEMOVE;
 
 		if (_touch_mode == TOUCH_MODE_TOUCHPAD) {
-			e.mouse = dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
+			e.mouse = static_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
 		} else {
 			e.mouse.x = arg1;
 			e.mouse.y = arg2;
@@ -855,7 +855,7 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 		e.type = Common::EVENT_MOUSEMOVE;
 
 		if (_touch_mode == TOUCH_MODE_TOUCHPAD) {
-			e.mouse = dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
+			e.mouse = static_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
 		} else {
 			e.mouse.x = arg3;
 			e.mouse.y = arg4;
@@ -946,7 +946,7 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 					return;
 				}
 
-//				e.mouse = dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
+//				e.mouse = static_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
 //
 //				_event_queue_lock->lock();
 //
@@ -1038,7 +1038,7 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 		return;
 
 	case JE_BALL:
-		e.mouse = dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
+		e.mouse = static_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
 
 		switch (arg1) {
 		case AMOTION_EVENT_ACTION_DOWN:
@@ -1171,7 +1171,7 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 		e.type = Common::EVENT_WHEELUP;
 		e.mouse.x = arg1;
 		e.mouse.y = arg2;
-//		e.mouse = dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
+//		e.mouse = static_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
 
 		pushEvent(e);
 
@@ -1182,7 +1182,7 @@ void OSystem_Android::pushEvent(int type, int arg1, int arg2, int arg3,
 		e.type = Common::EVENT_WHEELDOWN;
 		e.mouse.x = arg1;
 		e.mouse.y = arg2;
-//		e.mouse = dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
+//		e.mouse = static_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
 
 		pushEvent(e);
 
@@ -1420,15 +1420,15 @@ bool OSystem_Android::pollEvent(Common::Event &event) {
 
 			if (JNI::egl_surface_width > 0 && JNI::egl_surface_height > 0) {
 				// surface changed
-				dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->deinitSurface();
-				dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->initSurface();
+				static_cast<AndroidCommonGraphics *>(_graphicsManager)->deinitSurface();
+				static_cast<AndroidCommonGraphics *>(_graphicsManager)->initSurface();
 
 				event.type = Common::EVENT_SCREEN_CHANGED;
 
 				return true;
 			} else {
 				// surface lost
-				dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->deinitSurface();
+				static_cast<AndroidCommonGraphics *>(_graphicsManager)->deinitSurface();
 			}
 		}
 
@@ -1462,7 +1462,7 @@ bool OSystem_Android::pollEvent(Common::Event &event) {
 
 	if (Common::isMouseEvent(event)) {
 		if (_graphicsManager)
-			return dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->notifyMousePosition(event.mouse);
+			return static_cast<AndroidCommonGraphics *>(_graphicsManager)->notifyMousePosition(event.mouse);
 	}
 
 	return true;
@@ -1486,7 +1486,7 @@ void OSystem_Android::setupTouchMode(int oldValue, int newValue) {
 
 	if (newValue == TOUCH_MODE_TOUCHPAD) {
 		// Make sure we have a proper touch point if we switch to touchpad mode with finger down
-		_touch_pt_down = dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
+		_touch_pt_down = static_cast<AndroidCommonGraphics *>(_graphicsManager)->getMousePosition();
 		_touch_pt_scroll.x = -1;
 		_touch_pt_scroll.y = -1;
 	}

--- a/backends/platform/android/touchcontrols.cpp
+++ b/backends/platform/android/touchcontrols.cpp
@@ -325,7 +325,7 @@ void TouchControls::buttonDown(Common::JoystickButton jb) {
 	Common::Event ev;
 	ev.type = Common::EVENT_JOYBUTTON_DOWN;
 	ev.joystick.button = jb;
-	dynamic_cast<OSystem_Android *>(g_system)->pushEvent(ev);
+	static_cast<OSystem_Android *>(g_system)->pushEvent(ev);
 }
 
 void TouchControls::buttonUp(Common::JoystickButton jb) {
@@ -336,7 +336,7 @@ void TouchControls::buttonUp(Common::JoystickButton jb) {
 	Common::Event ev;
 	ev.type = Common::EVENT_JOYBUTTON_UP;
 	ev.joystick.button = jb;
-	dynamic_cast<OSystem_Android *>(g_system)->pushEvent(ev);
+	static_cast<OSystem_Android *>(g_system)->pushEvent(ev);
 }
 
 void TouchControls::buttonPress(Common::JoystickButton jb) {
@@ -349,5 +349,5 @@ void TouchControls::buttonPress(Common::JoystickButton jb) {
 	ev1.joystick.button = jb;
 	ev2.type = Common::EVENT_JOYBUTTON_UP;
 	ev2.joystick.button = jb;
-	dynamic_cast<OSystem_Android *>(g_system)->pushEvent(ev1, ev2);
+	static_cast<OSystem_Android *>(g_system)->pushEvent(ev1, ev2);
 }

--- a/backends/platform/libretro/src/libretro-os.cpp
+++ b/backends/platform/libretro/src/libretro-os.cpp
@@ -1293,11 +1293,11 @@ public:
 	void Quit() {
 		Common::Event ev;
 		ev.type = Common::EVENT_QUIT;
-		dynamic_cast<OSystem_RETRO *>(g_system)->getEventManager()->pushEvent(ev);
+		static_cast<OSystem_RETRO *>(g_system)->getEventManager()->pushEvent(ev);
 	}
 
 	void Reset() {
-		dynamic_cast<OSystem_RETRO *>(g_system)->getEventManager()->resetQuit();
+		static_cast<OSystem_RETRO *>(g_system)->getEventManager()->resetQuit();
 	}
 
 	void destroy() {
@@ -1311,19 +1311,19 @@ OSystem *retroBuildOS() {
 }
 
 const Graphics::Surface &getScreen() {
-	return dynamic_cast<OSystem_RETRO *>(g_system)->getScreen();
+	return static_cast<OSystem_RETRO *>(g_system)->getScreen();
 }
 
 void retroProcessMouse(retro_input_state_t aCallback, int device, float gamepad_cursor_speed, float gamepad_acceleration_time, bool analog_response_is_quadratic, int analog_deadzone, float mouse_speed) {
-	dynamic_cast<OSystem_RETRO *>(g_system)->processMouse(aCallback, device, gamepad_cursor_speed, gamepad_acceleration_time, analog_response_is_quadratic, analog_deadzone, mouse_speed);
+	static_cast<OSystem_RETRO *>(g_system)->processMouse(aCallback, device, gamepad_cursor_speed, gamepad_acceleration_time, analog_response_is_quadratic, analog_deadzone, mouse_speed);
 }
 
 void retroQuit() {
-	dynamic_cast<OSystem_RETRO *>(g_system)->Quit();
+	static_cast<OSystem_RETRO *>(g_system)->Quit();
 }
 
 int retroTestGame(const char *game_id, bool autodetect) {
-	return dynamic_cast<OSystem_RETRO *>(g_system)->TestGame(game_id, autodetect);
+	return static_cast<OSystem_RETRO *>(g_system)->TestGame(game_id, autodetect);
 }
 
 void retroSetSystemDir(const char *aPath) {
@@ -1335,17 +1335,17 @@ void retroSetSaveDir(const char *aPath) {
 }
 
 void retroKeyEvent(bool down, unsigned keycode, uint32_t character, uint16_t key_modifiers) {
-	dynamic_cast<OSystem_RETRO *>(g_system)->processKeyEvent(down, keycode, character, key_modifiers);
+	static_cast<OSystem_RETRO *>(g_system)->processKeyEvent(down, keycode, character, key_modifiers);
 }
 
 void retroReset() {
-	dynamic_cast<OSystem_RETRO *>(g_system)->Reset();
+	static_cast<OSystem_RETRO *>(g_system)->Reset();
 }
 
 uint8 getThreadSwitchCaller(){
-	return dynamic_cast<OSystem_RETRO *>(g_system)->getThreadSwitchCaller();
+	return static_cast<OSystem_RETRO *>(g_system)->getThreadSwitchCaller();
 }
 
 void retroDestroy() {
-	dynamic_cast<OSystem_RETRO *>(g_system)->destroy();
+	static_cast<OSystem_RETRO *>(g_system)->destroy();
 }

--- a/backends/platform/n64/osys_n64_utilities.cpp
+++ b/backends/platform/n64/osys_n64_utilities.cpp
@@ -82,7 +82,7 @@ void vblCallback(void) {
 		sndCallback();
 	}
 
-	dynamic_cast<OSystem_N64 *>(g_system)->readControllerAnalogInput();
+	static_cast<OSystem_N64 *>(g_system)->readControllerAnalogInput();
 }
 
 void sndCallback() {

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -106,7 +106,7 @@ OSystem_SDL::~OSystem_SDL() {
 	delete _savefileManager;
 	_savefileManager = nullptr;
 	if (_graphicsManager) {
-		dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->deactivateManager();
+		static_cast<SdlGraphicsManager *>(_graphicsManager)->deactivateManager();
 	}
 	delete _graphicsManager;
 	_graphicsManager = nullptr;
@@ -312,7 +312,7 @@ void OSystem_SDL::initBackend() {
 	// so the virtual keyboard can be initialized, but we have to add the
 	// graphics manager as an event observer after initializing the event
 	// manager.
-	dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->activateManager();
+	static_cast<SdlGraphicsManager *>(_graphicsManager)->activateManager();
 }
 
 #if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
@@ -430,7 +430,7 @@ void OSystem_SDL::detectAntiAliasingSupport() {
 void OSystem_SDL::engineInit() {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	if (_graphicsManager) {
-		dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->unlockWindowSize();
+		static_cast<SdlGraphicsManager *>(_graphicsManager)->unlockWindowSize();
 	}
 	// Disable screen saver when engine starts
 	SDL_DisableScreenSaver();
@@ -454,7 +454,7 @@ void OSystem_SDL::engineInit() {
 void OSystem_SDL::engineDone() {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	if (_graphicsManager) {
-		dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->unlockWindowSize();
+		static_cast<SdlGraphicsManager *>(_graphicsManager)->unlockWindowSize();
 	}
 	SDL_EnableScreenSaver();
 #endif
@@ -543,7 +543,7 @@ void OSystem_SDL::fatalError() {
 Common::KeymapArray OSystem_SDL::getGlobalKeymaps() {
 	Common::KeymapArray globalMaps = BaseBackend::getGlobalKeymaps();
 
-	Common::Keymap *keymap = dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->getKeymap();
+	Common::Keymap *keymap = static_cast<SdlGraphicsManager *>(_graphicsManager)->getKeymap();
 	globalMaps.push_back(keymap);
 
 	return globalMaps;

--- a/devtools/scumm-md5.txt
+++ b/devtools/scumm-md5.txt
@@ -368,6 +368,7 @@ tentacle	Day of the Tentacle
 
 	e47bcf709d7ab8470bdbfaf02d434e60	-1	ko	DOS	Floppy	Floppy	Fan translation	ScummVM-Kor
 	a4b30b29a419d49a2ab33bd4414939d1	-1	ko	All?	-	CD	Fan translation	ScummVM-Kor
+	3b22276a925732fef7981be31f9e4c9a	7932	he	DOS	CD	1.6	Hebrew fan translation
 
 samnmax	Sam &amp; Max Hit the Road
 	3b301b7892f883ce42ab4be6a274fea6	9040	en	DOS	Floppy	Floppy	-	Andrea Petrucci

--- a/engines/glk/tads/os_frob_tads.cpp
+++ b/engines/glk/tads/os_frob_tads.cpp
@@ -122,44 +122,44 @@ char *osfgets(char *buf, size_t count, osfildef *fp) {
 }
 
 int osfputs(const char *str, osfildef *fp) {
-	return dynamic_cast<Common::WriteStream *>(fp)->write(str, strlen(str)) == strlen(str) ? 0 : -1;
+	return static_cast<Common::WriteStream *>(fp)->write(str, strlen(str)) == strlen(str) ? 0 : -1;
 }
 
 void os_fprintz(osfildef *fp, const char *str) {
-	dynamic_cast<Common::WriteStream *>(fp)->write(str, strlen(str));
+	static_cast<Common::WriteStream *>(fp)->write(str, strlen(str));
 }
 
 void os_fprint(osfildef *fp, const char *str, size_t len) {
 	Common::String s(str, str + MIN(len, strlen(str)));
-	dynamic_cast<Common::WriteStream *>(fp)->write(s.c_str(), s.size());
+	static_cast<Common::WriteStream *>(fp)->write(s.c_str(), s.size());
 }
 
 int osfwb(osfildef *fp, const void *buf, size_t bufl) {
-	return dynamic_cast<Common::WriteStream *>(fp)->write(buf, bufl) == bufl ? 0 : 1;
+	return static_cast<Common::WriteStream *>(fp)->write(buf, bufl) == bufl ? 0 : 1;
 }
 
 int osfflush(osfildef *fp) {
-	return dynamic_cast<Common::WriteStream *>(fp)->flush() ? 0 : 1;
+	return static_cast<Common::WriteStream *>(fp)->flush() ? 0 : 1;
 }
 
 int osfgetc(osfildef *fp) {
-	return dynamic_cast<Common::ReadStream *>(fp)->readByte();
+	return static_cast<Common::ReadStream *>(fp)->readByte();
 }
 
 int osfrb(osfildef *fp, void *buf, size_t bufl) {
-	return dynamic_cast<Common::ReadStream *>(fp)->read(buf, bufl) == bufl ? 0 : 1;
+	return static_cast<Common::ReadStream *>(fp)->read(buf, bufl) == bufl ? 0 : 1;
 }
 
 size_t osfrbc(osfildef *fp, void *buf, size_t bufl) {
-	return dynamic_cast<Common::ReadStream *>(fp)->read(buf, bufl);
+	return static_cast<Common::ReadStream *>(fp)->read(buf, bufl);
 }
 
 long osfpos(osfildef *fp) {
-	return dynamic_cast<Common::SeekableReadStream *>(fp)->pos();
+	return static_cast<Common::SeekableReadStream *>(fp)->pos();
 }
 
 int osfseek(osfildef *fp, long pos, int mode) {
-	return dynamic_cast<Common::SeekableReadStream *>(fp)->seek(pos, mode);
+	return static_cast<Common::SeekableReadStream *>(fp)->seek(pos, mode);
 }
 
 void osfcls(osfildef *fp) {

--- a/engines/grim/emi/sound/scxtrack.cpp
+++ b/engines/grim/emi/sound/scxtrack.cpp
@@ -69,7 +69,7 @@ bool SCXTrack::isPlaying() {
 Audio::Timestamp SCXTrack::getPos() {
 	if (!_stream || _looping)
 		return Audio::Timestamp(0);
-	return dynamic_cast<SCXStream*>(_stream)->getPos();
+	return static_cast<SCXStream*>(_stream)->getPos();
 }
 
 bool SCXTrack::play() {


### PR DESCRIPTION
The advantage of dynamic_cast over static_cast is that it provides runtime validation for the type, such that if the concrete type is not an instance of the target type, it returns null. If the result is immediately dereferenced, then it would be null dereference and crash anyway.

Replace all theses usages with static_cast.
