### PR TITLE
AGS: Commits from upstream up to version 3.6.0.48

### DIFF
--- a/engines/ags/engine/ac/draw.cpp
+++ b/engines/ags/engine/ac/draw.cpp
@@ -620,7 +620,7 @@ void reset_objcache_for_sprite(int sprnum, bool deleted) {
 		if (_GP(charcache)[i].sppic == sprnum)
 			_GP(charcache)[i].sppic = -1;
 		if (deleted && ((int)(_GP(actsps)[ACTSP_OBJSOFF + i].SpriteID) == sprnum))
-			_GP(actsps)[i].SpriteID = UINT32_MAX; // invalid sprite ref
+			_GP(actsps)[ACTSP_OBJSOFF + i].SpriteID = UINT32_MAX; // invalid sprite ref
 	}
 }
 

--- a/engines/ags/engine/ac/draw.cpp
+++ b/engines/ags/engine/ac/draw.cpp
@@ -602,14 +602,17 @@ void mark_object_changed(int objid) {
 
 void reset_objcache_for_sprite(int sprnum, bool deleted) {
 	// Check if this sprite is assigned to any game object, and mark these for update;
-	// if the sprite was deleted, also dispose shared textures
+	// if the sprite was deleted, also mark texture objects as invalid.
+	// IMPORTANT!!: do NOT dispose textures themselves here.
+	// * if the next valid image is of the same size, then the texture will be reused;
+	// * BACKWARD COMPAT: keep last images during room transition out!
 	// room objects cache
 	if (_G(croom) != nullptr) {
 		for (size_t i = 0; i < (size_t)_G(croom)->numobj; ++i) {
 			if (_G(objcache)[i].sppic == sprnum)
 				_G(objcache)[i].sppic = -1;
 			if (deleted && ((int)(_GP(actsps)[i].SpriteID) == sprnum))
-				_GP(actsps)[i] = ObjTexture();
+				_GP(actsps)[i].SpriteID = UINT32_MAX; // invalid sprite ref
 		}
 	}
 	// character cache
@@ -617,7 +620,7 @@ void reset_objcache_for_sprite(int sprnum, bool deleted) {
 		if (_GP(charcache)[i].sppic == sprnum)
 			_GP(charcache)[i].sppic = -1;
 		if (deleted && ((int)(_GP(actsps)[ACTSP_OBJSOFF + i].SpriteID) == sprnum))
-			_GP(actsps)[i] = ObjTexture();
+			_GP(actsps)[i].SpriteID = UINT32_MAX; // invalid sprite ref
 	}
 }
 

--- a/engines/ags/engine/ac/dynamic_sprite.cpp
+++ b/engines/ags/engine/ac/dynamic_sprite.cpp
@@ -370,6 +370,12 @@ ScriptDynamicSprite *DynamicSprite_CreateFromDrawingSurface(ScriptDrawingSurface
 }
 
 ScriptDynamicSprite *DynamicSprite_Create(int width, int height, int alphaChannel) {
+	if (width <= 0 || height <= 0) {
+		debug_script_warn("WARNING: DynamicSprite.Create: invalid size %d x %d, will adjust", width, height);
+		width = MAX(1, width);
+		height = MAX(1, height);
+	}
+
 	data_to_game_coords(&width, &height);
 
 	int gotSlot = _GP(spriteset).GetFreeIndex();

--- a/engines/ags/engine/game/game_init.cpp
+++ b/engines/ags/engine/game/game_init.cpp
@@ -417,7 +417,7 @@ HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion dat
 	// NOTE: we must do this before plugin start, because some plugins may
 	// require access to script API at initialization time.
 	//
-	ccSetScriptAliveTimer(10u, 1000u, 150000u);
+	ccSetScriptAliveTimer(1000 / 60u, 1000u, 150000u);
 	ccSetStringClassImpl(&_GP(myScriptStringImpl));
 	setup_script_exports(base_api, compat_api);
 

--- a/engines/ags/engine/gfx/gfx_driver_base.cpp
+++ b/engines/ags/engine/gfx/gfx_driver_base.cpp
@@ -231,15 +231,22 @@ void VideoMemoryGraphicsDriver::UpdateSharedDDB(uint32_t sprite_id, Bitmap *bitm
 		if (txdata)
 			UpdateTextureData(txdata.get(), bitmap, opaque, hasAlpha);
 	}
- }
+}
 
- void VideoMemoryGraphicsDriver::ClearSharedDDB(uint32_t sprite_id) {
+void VideoMemoryGraphicsDriver::ClearSharedDDB(uint32_t sprite_id) {
+	// Reset sprite ID for any remaining shared txdata,
+	// then remove the reference from the cache;
+	// NOTE: we do not delete txdata itself, as it may be temporarily in use
 	const auto found = _txRefs.find(sprite_id);
-	if (found != _txRefs.end())
+	if (found != _txRefs.end()) {
+		auto txdata = found->_value.Data.lock();
+		if (txdata)
+			txdata->ID = UINT32_MAX;
 		_txRefs.erase(found);
- }
+	}
+}
 
- void VideoMemoryGraphicsDriver::DestroyDDB(IDriverDependantBitmap* ddb) {
+void VideoMemoryGraphicsDriver::DestroyDDB(IDriverDependantBitmap* ddb) {
 	uint32_t sprite_id = ddb->GetRefID();
 	DestroyDDBImpl(ddb);
 	// Remove shared object from ref list if no more active refs left

--- a/engines/ags/engine/gfx/gfx_driver_base.h
+++ b/engines/ags/engine/gfx/gfx_driver_base.h
@@ -252,9 +252,9 @@ public:
 	// Get shared texture from cache, or create from bitmap and assign ID
 	IDriverDependantBitmap *GetSharedDDB(uint32_t sprite_id, Bitmap *bitmap, bool hasAlpha, bool opaque) override;
 	// Removes the shared texture reference, will force the texture to recreate next time
-	 void ClearSharedDDB(uint32_t sprite_id) override;
-	 // Updates shared texture data, but only if it is present in the cache
-	 void UpdateSharedDDB(uint32_t sprite_id, Bitmap *bitmap, bool hasAlpha, bool opaque) override;
+	void ClearSharedDDB(uint32_t sprite_id) override;
+	// Updates shared texture data, but only if it is present in the cache
+	void UpdateSharedDDB(uint32_t sprite_id, Bitmap *bitmap, bool hasAlpha, bool opaque) override;
 	void DestroyDDB(IDriverDependantBitmap* ddb) override;
 
 	// Sets stage screen parameters for the current batch.
@@ -349,6 +349,8 @@ private:
 	// - this lets to share same texture data among multiple sprites on screen.
 	// TextureCacheItem stores weak references to the existing texture tiles,
 	// identified by an arbitrary uint32 number.
+	// TODO: a curious topic to consider: reuse released TextureData for
+	// textures of the same size (research potential performance impact).
 	struct TextureCacheItem {
 		GraphicResolution Res;
 		std::weak_ptr<TextureData> Data;

--- a/engines/ags/engine/media/audio/audio.cpp
+++ b/engines/ags/engine/media/audio/audio.cpp
@@ -392,7 +392,7 @@ void remove_clips_of_type_from_queue(int audioType) {
 	int aa;
 	for (aa = 0; aa < _GP(play).new_music_queue_size; aa++) {
 		ScriptAudioClip *clip = &_GP(game).audioClips[_GP(play).new_music_queue[aa].audioClipIndex];
-		if (clip->type == audioType) {
+		if ((audioType == SCR_NO_VALUE) || (clip->type == audioType)) {
 			_GP(play).new_music_queue_size--;
 			for (int bb = aa; bb < _GP(play).new_music_queue_size; bb++)
 				_GP(play).new_music_queue[bb] = _GP(play).new_music_queue[bb + 1];

--- a/engines/ags/engine/script/cc_instance.cpp
+++ b/engines/ags/engine/script/cc_instance.cpp
@@ -786,11 +786,12 @@ int ccInstance::Run(int32_t curpc) {
 
 			// Make sure it's not stuck in a While loop
 			if (arg1.IValue < 0) {
+				++loopIterations;
 				if (flags & INSTF_RUNNING) {
 					// was notified still running, don't do anything
 					flags &= ~INSTF_RUNNING;
 					loopIterations = 0;
-				} else if ((loopIterationCheckDisabled == 0) && (_G(maxWhileLoops) > 0) && (++loopIterations > _G(maxWhileLoops))) {
+				} else if ((loopIterationCheckDisabled == 0) && (_G(maxWhileLoops) > 0) && (loopIterations > _G(maxWhileLoops))) {
 					cc_error("!Script appears to be hung (a while loop ran %d times). The problem may be in a calling function; check the call stack.", (int)loopIterations);
 					return -1;
 				} else if ((loopIterations % 1000) == 0 && (std::chrono::duration_cast<std::chrono::milliseconds>(AGS_Clock::now() - _lastAliveTs) > timeout)) {

--- a/engines/ags/engine/script/cc_instance.cpp
+++ b/engines/ags/engine/script/cc_instance.cpp
@@ -453,7 +453,6 @@ int ccInstance::Run(int32_t curpc) {
 	const auto timeout = std::chrono::milliseconds(_G(timeoutCheckMs));
 	const auto timeout_abort = std::chrono::milliseconds(_G(timeoutAbortMs));
 	_lastAliveTs = AGS_Clock::now();
-	bool timeout_warn = false;
 
 	while ((flags & INSTF_ABORTED) == 0) {
 		if (_G(abort_engine))
@@ -787,34 +786,19 @@ int ccInstance::Run(int32_t curpc) {
 
 			// Make sure it's not stuck in a While loop
 			if (arg1.IValue < 0) {
-				auto now = AGS_Clock::now();
-				auto test_dur = std::chrono::duration_cast<std::chrono::milliseconds>(now - _lastAliveTs);
 				if (flags & INSTF_RUNNING) {
 					// was notified still running, don't do anything
 					flags &= ~INSTF_RUNNING;
-					_lastAliveTs = now;
-					timeout_warn = false;
 					loopIterations = 0;
 				} else if ((loopIterationCheckDisabled == 0) && (_G(maxWhileLoops) > 0) && (++loopIterations > _G(maxWhileLoops))) {
 					cc_error("!Script appears to be hung (a while loop ran %d times). The problem may be in a calling function; check the call stack.", (int)loopIterations);
 					return -1;
-				} else if (test_dur > timeout) {
+				} else if ((loopIterations % 1000) == 0 && (std::chrono::duration_cast<std::chrono::milliseconds>(AGS_Clock::now() - _lastAliveTs) > timeout)) {
 					// minimal timeout occurred
-					if ((timeout_abort.count() > 0) && (test_dur.count() > timeout_abort.count())) {
-						// critical timeout occurred
-						/* CHECKME: disabled, because not working well
-						if (loopIterationCheckDisabled == 0) {
-							cc_error("!Script appears to be hung (no game update for %lld ms). The problem may be in a calling function; check the call stack.", test_dur.count());
-							return -1;
-						}
-						*/
-						if (!timeout_warn) {
-							debug_script_warn("WARNING: script execution hung? (%lld ms)", test_dur.count());
-							timeout_warn = true;
-						}
-					}
+					// NOTE: removed timeout_abort check for now: was working *logically* wrong;
 					// at least let user to manipulate the game window
 					sys_evt_process_pending();
+					_lastAliveTs = AGS_Clock::now();
 				}
 			}
 			break;
@@ -1360,6 +1344,11 @@ void ccInstance::DumpInstruction(const ScriptOperation &op) const {
 
 bool ccInstance::IsBeingRun() const {
 	return pc != 0;
+}
+
+void ccInstance::NotifyAlive() {
+	flags |= INSTF_RUNNING;
+	_lastAliveTs = AGS_Clock::now();
 }
 
 bool ccInstance::_Create(PScript scri, ccInstance *joined) {

--- a/engines/ags/engine/script/cc_instance.h
+++ b/engines/ags/engine/script/cc_instance.h
@@ -169,6 +169,8 @@ public:
 	void    DumpInstruction(const ScriptOperation &op) const;
 	// Tells whether this instance is in the process of executing the byte-code
 	bool    IsBeingRun() const;
+	// Notifies that the game was being updated (script not hanging)
+	void	NotifyAlive();
 
 	// For each import, find the instance that corresponds to it and save it
 	// in resolved_imports[]. Return whether the function is successful

--- a/engines/ags/engine/script/script_runtime.cpp
+++ b/engines/ags/engine/script/script_runtime.cpp
@@ -103,7 +103,7 @@ void ccSetScriptAliveTimer(unsigned sys_poll_timeout, unsigned abort_timeout, un
 void ccNotifyScriptStillAlive() {
 	ccInstance *cur_inst = ccInstance::GetCurrentInstance();
 	if (cur_inst)
-		cur_inst->flags |= INSTF_RUNNING;
+		cur_inst->NotifyAlive();
 }
 
 void ccSetDebugHook(new_line_hook_type jibble) {

--- a/engines/ags/globals.h
+++ b/engines/ags/globals.h
@@ -583,7 +583,7 @@ public:
 
 	// actsps is used for temporary storage of the bitamp and texture
 	// of the latest version of the sprite (room objects and characters);
-	// objects sprites begin with index 0, characters are after MAX_ROOM_OBJECTS
+	// objects sprites begin with index 0, characters are after ACTSP_OBJSOFF
 	std::vector<ObjTexture> *_actsps;
 	// Walk-behind textures (3D renderers only)
 	std::vector<ObjTexture> *_walkbehindobj;

--- a/engines/ags/shared/core/def_version.h
+++ b/engines/ags/shared/core/def_version.h
@@ -22,9 +22,9 @@
 #ifndef AGS_SHARED_CORE_DEFVERSION_H
 #define AGS_SHARED_CORE_DEFVERSION_H
 
-#define ACI_VERSION_STR      "3.6.0.47"
+#define ACI_VERSION_STR      "3.6.0.48"
 #if defined (RC_INVOKED) // for MSVC resource compiler
-#define ACI_VERSION_MSRC_DEF  3.6.0.47
+#define ACI_VERSION_MSRC_DEF  3.6.0.48
 #endif
 
 #define SPECIAL_VERSION ""

--- a/engines/ags/shared/font/fonts.cpp
+++ b/engines/ags/shared/font/fonts.cpp
@@ -393,7 +393,7 @@ size_t split_lines(const char *todis, SplitLines &lines, int wii, int fonnt, siz
 				break;
 			}
 			// add this line; do the temporary terminator trick again
-			const int next_chwas = *split_at;
+			const int next_chwas = ugetc(split_at);
 			*split_at = 0;
 			lines.Add(theline);
 			usetc(split_at, next_chwas);

--- a/engines/ags/shared/util/string.cpp
+++ b/engines/ags/shared/util/string.cpp
@@ -715,7 +715,8 @@ void String::Reverse() {
 void String::ReverseUTF8() {
 	if (_len <= 1)
 		return; // nothing to reverse if 1 char or less
-	// TODO: may this be optimized to not alloc new buffer? or dont care
+	// TODO: may this be optimized to not alloc new buffer?
+	// otherwise, allocate a proper String data buf and replace existing
 	char *newstr = new char[_len + 1];
 	for (char *fw = _cstr, *fw2 = _cstr + 1,
 		*bw = _cstr + _len - 1, *bw2 = _cstr + _len;
@@ -734,6 +735,7 @@ void String::ReverseUTF8() {
 	}
 	newstr[_len] = 0;
 	SetString(newstr);
+	delete[] newstr;
 }
 
 void String::SetAt(size_t index, char c) {


### PR DESCRIPTION
This PR adds the commits from upstream up to version 3.6.0.48, which is the first "patch" release
of the 3.6.0 branch.

As the branch is now considered stable, the changes are just minor bugfixes.

SKIPPED COMMITS:

[Engine: fixed <3.6.0 Animate functions default volume parameter](https://github.com/adventuregamestudio/ags/commit/e8c36158dadcaf48eddafcf853616f2d042b30d2)
Already merged

[Engine: fixed BytesPerSample() incorrectly returning bits per sample](https://github.com/adventuregamestudio/ags/commit/035c50bbd2e6d7701e3dddff92b9b5d7f922f556)
Not present


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
