### PR TITLE
Ultima: Remove extra space in quest of the avatar name

### DIFF
--- a/engines/ultima/detection.cpp
+++ b/engines/ultima/detection.cpp
@@ -33,7 +33,7 @@ static const PlainGameDescriptor ULTIMA_GAMES[] = {
 #ifndef RELEASE_BUILD
 	{ "ultima1", "Ultima I: The First Age of Darkness" }, 
 #endif
-	{ "ultima4", "Ultima IV:  Quest of the Avatar" },
+	{ "ultima4", "Ultima IV: Quest of the Avatar" },
 	{ "ultima4_enh", "Ultima IV: Quest of the Avatar - Enhanced" },
 	{ "ultima6", "Ultima VI: The False Prophet" },
 	{ "ultima6_enh", "Ultima VI: The False Prophet - Enhanced" },


### PR DESCRIPTION
Noticed this while updating some retroarch thumbnails when the name detected never made the correct named thumbnail appear, then noticed the extra space.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
