### PR TITLE
SAGA2: move call to delayMillis in updatePalette()

### DIFF
--- a/engines/saga2/vpal.cpp
+++ b/engines/saga2/vpal.cpp
@@ -218,8 +218,9 @@ bool PaletteManager::updatePalette() {
 			assertCurrentPalette();
 
 			g_system->updateScreen();
-			g_system->delayMillis(10);
 		}
+		g_system->delayMillis(10);
+
 		return true;
 	}
 }


### PR DESCRIPTION
Everytime [this test](https://github.com/scummvm/scummvm/blob/0589fe091250cafccda8f9eaaf935ed678a04daf/engines/saga2/vpal.cpp#L214) fails (actually it does at least when `elapsedTime = 0`) the engine stucks in an infinite loop if the backend uses calls to `g_system` methods to call the timer handler.
Moving the call to `delayMillis` outside the test block solves the issue (provided that the backend uses `delayMillis` to call the timer handler), as `elapsedTime` can progress whether interpolated `tempPalette` is already equal to `_currentPalette` or not.