### PR TITLE
XEEN: Fix crash in MM4 ending cutscene (branch 2-7)

### DIFF
--- a/engines/xeen/worldofxeen/clouds_cutscenes.cpp
+++ b/engines/xeen/worldofxeen/clouds_cutscenes.cpp
@@ -688,6 +688,7 @@ bool CloudsCutscenes::showCloudsEnding2() {
 	WAIT(5);
 
 	Graphics::ManagedSurface savedBg;
+	savedBg.create(screen.w, screen.h, screen.format);
 	savedBg.blitFrom(screen);
 
 	// Close up of King Roland
@@ -767,6 +768,7 @@ bool CloudsCutscenes::showCloudsEnding3() {
 
 	// Zooming into the mirror
 	screen.freePages();
+	savedBg.create(screen.w, screen.h, screen.format);
 	savedBg.blitFrom(screen);
 
 	const int XLIST3[9] = { 0, -5, -10, -15, -24, -30, -39, -50, -59 };


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->

The Mignt and Magic 4 game crashes in ending cutscene.
Looks like a Graphics::ManagedSurface-s are not initialised properly.
I guessed a way how it should be created.
Now I can watch a whole ending.

Monster animations int this cutscene is still missing a death frames.

See also https://bugs.scummvm.org/ticket/14431