### PR TITLE
TWINE: Fade-in characters starting from the right when playing in Hebrew

### DIFF
--- a/engines/twine/text.h
+++ b/engines/twine/text.h
@@ -65,15 +65,20 @@ private:
 		int32 inChar = 0;
 		int32 inPixel = 0;
 	};
+	struct LineCharacter {
+		int16 chr = 0;
+		int16 x = 0;
+	};
 	WordSize getWordSize(const char *completeText, char *wordBuf, int32 wordBufSize);
 	uint16 getNextChar(const char *&dialogue);
 	void processTextLine();
+	void appendProgressiveTextBuffer(const char *s, int &x, uint &i);
 	// draw next page arrow polygon
 	void renderContinueReadingTriangle();
 	/**
 	 * @see fadeInCharacters
 	 */
-	void fillFadeInBuffer(int16 x, int16 y, int16 chr);
+	void fillFadeInBuffer(int16 baseX, int16 y, const LineCharacter &chr);
 	/**
 	 * Blend in characters for a text scrolling in
 	 *
@@ -84,14 +89,14 @@ private:
 
 	TextBankId _currentBankIdx = TextBankId::None;
 
-	char _progressiveTextBuffer[256] {'\0'};
+	LineCharacter _progressiveTextBuffer[256];
 	const char *_currentTextPosition = nullptr;
 
-	int32 _dialTextXPos = 0;
+	int32 _dialTextBaseXPos = 0;
 	int32 _dialTextYPos = 0;
 
 	/** Current position of in the buffer of characters that are currently faded in */
-	const char *_progressiveTextBufferPtr = nullptr;
+	const LineCharacter *_progressiveTextBufferPtr = nullptr;
 
 	int32 _dialTextBoxCurrentLine = 0;
 	struct BlendInCharacter {
@@ -137,6 +142,7 @@ private:
 	int32 _dialTextBoxMaxX = 0; // dialogueBoxParam2
 
 	bool _isShiftJIS = false;
+	bool _isVisualRTL = false;
 
 	bool displayText(TextId index, bool showText, bool playVox, bool loop);
 public:
@@ -193,6 +199,7 @@ public:
 	void initInventoryDialogueBox();
 
 	void initText(TextId index);
+	void initLine();
 	void initInventoryText(InventoryItems index);
 	void initItemFoundText(InventoryItems index);
 	void fadeInRemainingChars();


### PR DESCRIPTION
Hebrew translation use ISO-8859-8 in visual ordering. This is nasty but we can't change it. Instead do the best with what we have. One of problems is that characters fade in in the order that is reverse to reading order. This patch improves this and sets a groundwork for other RTL languages, hopefully in logical ordering.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
