### PR TITLE
TITANIC: Fix -Wc++20-compat warning for the C++20 'concept' keyword

### DIFF
--- a/engines/titanic/pet_control/pet_glyphs.cpp
+++ b/engines/titanic/pet_control/pet_glyphs.cpp
@@ -139,7 +139,6 @@ void CPetGlyphs::draw(CScreenManager *screenManager) {
 	if (_highlightIndex != -1) {
 		int index = getHighlightedIndex(_highlightIndex);
 		if (index != -1) {
-			Point tempPoint;
 			Point pt = getPosition(index);
 			pt -= Point(12, 13);
 			_selection.translate(pt.x, pt.y);

--- a/engines/titanic/true_talk/tt_concept.cpp
+++ b/engines/titanic/true_talk/tt_concept.cpp
@@ -308,12 +308,12 @@ int TTconcept::getTheWordId() const {
 	return _wordP ? _wordP->_id : 0;
 }
 
-bool isWordId(const TTconcept *concept, int id) {
-	return concept ? concept->isTheWordId(id) : 0;
+bool isWordId(const TTconcept *conceptP, int id) {
+	return conceptP ? conceptP->isTheWordId(id) : 0;
 }
 
-int getWordId(const TTconcept *concept) {
-	return concept ? concept->getTheWordId() : 0;
+int getWordId(const TTconcept *conceptP) {
+	return conceptP ? conceptP->getTheWordId() : 0;
 }
 
 } // End of namespace Titanic

--- a/engines/titanic/true_talk/tt_concept.h
+++ b/engines/titanic/true_talk/tt_concept.h
@@ -166,9 +166,9 @@ public:
 	int getTheWordId() const;
 };
 
-extern bool isWordId(const TTconcept *concept, int id);
+extern bool isWordId(const TTconcept *conceptP, int id);
 
-extern int getWordId(const TTconcept *concept);
+extern int getWordId(const TTconcept *conceptP);
 
 } // End of namespace Titanic
 

--- a/engines/titanic/true_talk/tt_concept_node.cpp
+++ b/engines/titanic/true_talk/tt_concept_node.cpp
@@ -101,18 +101,18 @@ TTconcept **TTconceptNode::setConcept(int conceptIndex, TTconcept *src) {
 	return conceptPP;
 }
 
-int TTconceptNode::replaceConcept(int mode, int conceptIndex, TTconcept *concept) {
-	TTconcept **conceptPP = setConcept(conceptIndex, concept);
+int TTconceptNode::replaceConcept(int mode, int conceptIndex, TTconcept *conceptP) {
+	TTconcept **conceptPP = setConcept(conceptIndex, conceptP);
 
 	if (mode == 0 || (mode == 1 && !*conceptPP)) {
-		if (!concept || !concept->isValid())
+		if (!conceptP || !conceptP->isValid())
 			return SS_5;
 
 		if (mode == 0 && *conceptPP) {
 			delete *conceptPP;
 		}
 
-		*conceptPP = new TTconcept(*concept);
+		*conceptPP = new TTconcept(*conceptP);
 		return (*conceptPP)->isValid() ? SS_VALID : SS_11;
 	} else {
 		return SS_1;

--- a/engines/titanic/true_talk/tt_concept_node.h
+++ b/engines/titanic/true_talk/tt_concept_node.h
@@ -58,7 +58,7 @@ public:
 	bool isValid() const { return _status == SS_VALID; }
 
 	TTconcept **setConcept(int conceptIndex, TTconcept *src);
-	int replaceConcept(int mode, int conceptIndex, TTconcept *concept);
+	int replaceConcept(int mode, int conceptIndex, TTconcept *conceptP);
 	int changeConcept(int mode, TTconcept **conceptPP, int conceptIndex);
 	bool createConcept(int mode, int conceptIndex, TTword *word);
 

--- a/engines/titanic/true_talk/tt_parser.cpp
+++ b/engines/titanic/true_talk/tt_parser.cpp
@@ -762,7 +762,7 @@ int TTparser::considerRequests(TTword *word) {
 	if (!_nodesP || !word)
 		return 0;
 
-	TTconcept *concept = nullptr;
+	TTconcept *conceptP = nullptr;
 	int status = 0;
 	bool flag = false;
 	bool modifierFlag = false;
@@ -900,7 +900,7 @@ int TTparser::considerRequests(TTword *word) {
 					addNode(SEEK_TO);
 				} else {
 					_sentenceConcept->changeConcept(1, &_sentenceConcept->_concept0P, 4);
-					concept = nullptr;
+					conceptP = nullptr;
 					addNode(SEEK_TO);
 				}
 			} else {
@@ -979,10 +979,10 @@ int TTparser::considerRequests(TTword *word) {
 						addToConceptList(word);
 					break;
 				case WC_ADJECTIVE: {
-					TTconcept *conceptP = TTconcept::findByWordClass(_conceptP, WC_THING);
-					if (conceptP) {
-						conceptP->_string2 += ' ';
-						conceptP->_string2 += word->getText();
+					TTconcept *adjConceptP = TTconcept::findByWordClass(_conceptP, WC_THING);
+					if (adjConceptP) {
+						adjConceptP->_string2 += ' ';
+						adjConceptP->_string2 += word->getText();
 					} else {
 						status = processModifiers(8, word);
 					}
@@ -996,11 +996,11 @@ int TTparser::considerRequests(TTword *word) {
 								currP->_field34 = 1;
 						}
 					} else {
-						TTconcept *conceptP = TTconcept::findByWordClass(_conceptP, WC_ACTION);
+						TTconcept *advConceptP = TTconcept::findByWordClass(_conceptP, WC_ACTION);
 
-						if (conceptP) {
-							conceptP->_string2 += ' ';
-							conceptP->_string2 += word->getText();
+						if (advConceptP) {
+							advConceptP->_string2 += ' ';
+							advConceptP->_string2 += word->getText();
 						} else {
 							tempFlag = true;
 						}
@@ -1022,11 +1022,11 @@ int TTparser::considerRequests(TTword *word) {
 
 		case SEEK_NEW_FRAME:
 			if (word->_wordClass == WC_ACTION && word->_id != 104 && word->_id != 107) {
-				if (concept && (_sentenceConcept->_concept5P || _sentenceConcept->_concept2P)) {
+				if (conceptP && (_sentenceConcept->_concept5P || _sentenceConcept->_concept2P)) {
 					TTsentenceConcept *oldNode = _sentenceConcept;
 					oldNode->_field1C = 2;
 					_sentenceConcept = oldNode->addSibling();
-					concept = nullptr;
+					conceptP = nullptr;
 
 					_sentenceConcept->_concept1P = oldNode->_concept1P;
 					_sentenceConcept->_concept5P = oldNode->_concept5P;
@@ -1060,7 +1060,7 @@ int TTparser::considerRequests(TTword *word) {
 		case SET_ACTION:
 			if (_sentence->fn4(1, 104, _sentenceConcept) ||
 					_sentence->fn4(1, 107, _sentenceConcept)) {
-				concept = _sentenceConcept->_concept1P;
+				conceptP = _sentenceConcept->_concept1P;
 				_sentenceConcept->_concept1P = nullptr;
 				addNode(SEEK_NEW_FRAME);
 			}
@@ -1316,7 +1316,7 @@ int TTparser::considerRequests(TTword *word) {
 		nodeP = nextP;
 	}
 
-	delete concept;
+	delete conceptP;
 	return status;
 }
 
@@ -1362,8 +1362,8 @@ int TTparser::processRequests(TTword *word) {
 }
 
 int TTparser::addToConceptList(TTword *word) {
-	TTconcept *concept = new TTconcept(word, ST_UNKNOWN_SCRIPT);
-	addConcept(concept);
+	TTconcept *conceptP = new TTconcept(word, ST_UNKNOWN_SCRIPT);
+	addConcept(conceptP);
 	return 0;
 }
 
@@ -1374,29 +1374,29 @@ void TTparser::addNode(uint tag) {
 	_nodesP = newNode;
 }
 
-int TTparser::addConcept(TTconcept *concept) {
-	if (!concept)
+int TTparser::addConcept(TTconcept *c) {
+	if (!c)
 		return SS_5;
 
 	if (_conceptP)
-		concept->_nextP = _conceptP;
-	_conceptP = concept;
+		c->_nextP = _conceptP;
+	_conceptP = c;
 
 	return SS_VALID;
 }
 
-void TTparser::removeConcept(TTconcept *concept) {
+void TTparser::removeConcept(TTconcept *c) {
 	// If no concept passed, exit immediately
-	if (!concept)
+	if (!c)
 		return;
 
-	if (_conceptP == concept) {
+	if (_conceptP == c) {
 		// Concept specified is the ver ystart of the linked list, so reset head pointer
 		_conceptP = _conceptP->_nextP;
 	} else {
 		// Scan through the linked list, looking for the specific concept
 		for (TTconcept *currP = _conceptP; currP; currP = currP->_nextP) {
-			if (currP->_nextP == concept) {
+			if (currP->_nextP == c) {
 				// Found match, so unlink the next link from the chain
 				currP->_nextP = currP->_nextP->_nextP;
 				break;
@@ -1405,8 +1405,8 @@ void TTparser::removeConcept(TTconcept *concept) {
 	}
 
 	// FInally, delete the concept
-	concept->_nextP = nullptr;
-	delete concept;
+	c->_nextP = nullptr;
+	delete c;
 }
 
 void TTparser::removeNode(TTparserNode *node) {
@@ -1573,26 +1573,26 @@ int TTparser::fn2(TTword *word) {
 }
 
 int TTparser::checkReferent(TTpronoun *pronoun) {
-	TTconcept *concept;
+	TTconcept *conceptP;
 
 	switch (pronoun->getVal()) {
 	case 0:
 		return 0;
 
 	case 1:
-		concept = new TTconcept(_owner->_script, ST_ROOM_SCRIPT);
+		conceptP = new TTconcept(_owner->_script, ST_ROOM_SCRIPT);
 		break;
 
 	case 2:
-		concept = new TTconcept(_sentence->_npcScript, ST_NPC_SCRIPT);
+		conceptP = new TTconcept(_sentence->_npcScript, ST_NPC_SCRIPT);
 		break;
 
 	default:
-		concept = new TTconcept(pronoun, (ScriptType)pronoun->getVal());
+		conceptP = new TTconcept(pronoun, (ScriptType)pronoun->getVal());
 		break;
 	}
 
-	addConcept(concept);
+	addConcept(conceptP);
 	return 0;
 }
 
@@ -1603,25 +1603,25 @@ void TTparser::conceptChanged(TTconcept *newConcept, TTconcept *oldConcept) {
 		_currentConceptP = newConcept;
 }
 
-bool TTparser::checkConcept2(TTconcept *concept, int conceptMode) {
+bool TTparser::checkConcept2(TTconcept *conceptP, int conceptMode) {
 	switch (conceptMode) {
 	case 3:
-		return concept->checkWordId2();
+		return conceptP->checkWordId2();
 
 	case 5:
-		return concept->checkWordClass();
+		return conceptP->checkWordClass();
 
 	case 8:
-		return concept->checkWordId1();
+		return conceptP->checkWordId1();
 
 	case 9:
-		if (concept->checkWordId3())
+		if (conceptP->checkWordId3())
 			return true;
 
 		if (_sentenceConcept->_concept2P) {
-			if (!_sentenceConcept->_concept2P->checkWordId2() || !concept->checkWordId2()) {
+			if (!_sentenceConcept->_concept2P->checkWordId2() || !conceptP->checkWordId2()) {
 				return _sentenceConcept->_concept2P->checkWordClass() &&
-					concept->checkWordClass();
+					conceptP->checkWordClass();
 			}
 		}
 		break;

--- a/engines/titanic/true_talk/tt_parser.h
+++ b/engines/titanic/true_talk/tt_parser.h
@@ -162,12 +162,12 @@ private:
 	/**
 	 * Add a concept node
 	 */
-	int addConcept(TTconcept *concept);
+	int addConcept(TTconcept *c);
 
 	/**
 	 * Detaches a concept from the main concept list if prseent, then deletes it
 	 */
-	void removeConcept(TTconcept *concept);
+	void removeConcept(TTconcept *c);
 
 	/**
 	 * Detaches a node from the main node list
@@ -184,7 +184,7 @@ private:
 
 	int checkForAction();
 	int fn2(TTword *word);
-	bool checkConcept2(TTconcept *concept, int conceptMode);
+	bool checkConcept2(TTconcept *conceptP, int conceptMode);
 	int filterConcepts(int conceptMode, int conceptIndex);
 	bool resetConcept(TTconcept **conceptPP, int conceptIndex);
 public:

--- a/engines/titanic/true_talk/tt_sentence.cpp
+++ b/engines/titanic/true_talk/tt_sentence.cpp
@@ -168,13 +168,13 @@ bool TTsentence::fn3(const CString &str1, const CString &str2, const CString &st
 bool TTsentence::fn2(int slotIndex, const TTstring &str, const TTconceptNode *node) const {
 	if (!node)
 		node = &_sentenceConcept;
-	TTconcept *concept = getFrameSlot(slotIndex, node);
+	TTconcept *conceptP = getFrameSlot(slotIndex, node);
 
-	if (!concept)
+	if (!conceptP)
 		return str == "isEmpty";
 
 	bool abortFlag = false;
-	switch (concept->_scriptType) {
+	switch (conceptP->_scriptType) {
 	case 1:
 		if (str == "thePlayer")
 			abortFlag = 1;
@@ -194,9 +194,9 @@ bool TTsentence::fn2(int slotIndex, const TTstring &str, const TTconceptNode *no
 		break;
 	}
 
-	TTstring conceptText = concept->getText();
-	if (abortFlag || str == conceptText || concept->compareTo(str)) {
-		delete concept;
+	TTstring conceptText = conceptP->getText();
+	if (abortFlag || str == conceptText || conceptP->compareTo(str)) {
+		delete conceptP;
 		return true;
 	}
 
@@ -227,9 +227,9 @@ bool TTsentence::fn2(int slotIndex, const TTstring &str, const TTconceptNode *no
 
 	if (g_vm->_exeResources._owner->_concept1P && (slotIndex == 0 || slotIndex == 2)) {
 		if (conceptText == "?" && str == g_vm->_exeResources._owner->_concept1P->getText()) {
-			delete concept;
-			concept = getFrameSlot(5, node);
-			conceptText = concept->getText();
+			delete conceptP;
+			conceptP = getFrameSlot(5, node);
+			conceptText = conceptP->getText();
 
 			if (conceptText == "it" || conceptText == "that" || conceptText == "he" ||
 				conceptText == "she" || conceptText == "him" || conceptText == "her" ||
@@ -240,7 +240,7 @@ bool TTsentence::fn2(int slotIndex, const TTstring &str, const TTconceptNode *no
 	}
 
 exit:
-	delete concept;
+	delete conceptP;
 	return abortFlag;
 }
 
@@ -269,10 +269,10 @@ TTconcept *TTsentence::getFrameEntry(int slotIndex, const TTconceptNode *concept
 
 TTconcept *TTsentence::getFrameSlot(int slotIndex, const TTconceptNode *conceptNode) const {
 	TTconcept *newConcept = new TTconcept();
-	TTconcept *concept = getFrameEntry(slotIndex, conceptNode);
+	TTconcept *conceptP = getFrameEntry(slotIndex, conceptNode);
 
-	if (concept)
-		newConcept->copyFrom(concept);
+	if (conceptP)
+		newConcept->copyFrom(conceptP);
 
 	if (!newConcept->isValid()) {
 		delete newConcept;
@@ -283,9 +283,9 @@ TTconcept *TTsentence::getFrameSlot(int slotIndex, const TTconceptNode *conceptN
 }
 
 bool TTsentence::isFrameSlotClass(int slotIndex, WordClass wordClass, const TTconceptNode *conceptNode) const {
-	TTconcept *concept = getFrameEntry(slotIndex, conceptNode);
-	if (concept && concept->_wordP) {
-		return concept->_wordP->isClass(wordClass);
+	TTconcept *conceptP = getFrameEntry(slotIndex, conceptNode);
+	if (conceptP && conceptP->_wordP) {
+		return conceptP->_wordP->isClass(wordClass);
 	} else {
 		return false;
 	}
@@ -304,8 +304,8 @@ int TTsentence::is1C(int val, const TTconceptNode *node) const {
 }
 
 bool TTsentence::isConcept34(int slotIndex, const TTconceptNode *node) const {
-	TTconcept *concept = getFrameEntry(slotIndex, node);
-	return concept && concept->getState();
+	TTconcept *conceptP = getFrameEntry(slotIndex, node);
+	return conceptP && conceptP->getState();
 }
 
 bool TTsentence::localWord(const char *str) const {


### PR DESCRIPTION
This silences some `identifier 'concept' is a keyword in C++20 [-Wc++20-compat]` warnings when building the Titanic engine with G++ 13.

Small notes:

* The renaming was done with Xcode contextual rename function to be sure not to make any mistake.
* For `addConcept()` and `removeConcept()` I'm just using `*c` as the parameter, since the function itself reads a bit ambiguous otherwise, to me.
* The `pet_glyphs.cpp` change is for an unused variable.