### PR TITLE
GRIM: Add runtime introspection of renderer type used via `renderer_get` console command. Rename `set_renderer` into `renderer_set`.

### DIFF
--- a/engines/grim/debugger.cpp
+++ b/engines/grim/debugger.cpp
@@ -35,8 +35,8 @@ Debugger::Debugger() :
 	registerCmd("check_gamedata", WRAP_METHOD(Debugger, cmd_checkFiles));
 	registerCmd("lua_do", WRAP_METHOD(Debugger, cmd_lua_do));
 	registerCmd("jump", WRAP_METHOD(Debugger, cmd_jump));
-	registerCmd("set_renderer", WRAP_METHOD(Debugger, cmd_set_renderer));
-	registerCmd("get_renderer", WRAP_METHOD(Debugger, cmd_get_renderer));
+	registerCmd("renderer_set", WRAP_METHOD(Debugger, cmd_renderer_set));
+	registerCmd("renderer_get", WRAP_METHOD(Debugger, cmd_renderer_get));
 	registerCmd("save", WRAP_METHOD(Debugger, cmd_save));
 	registerCmd("load", WRAP_METHOD(Debugger, cmd_load));
 }
@@ -90,9 +90,9 @@ bool Debugger::cmd_jump(int argc, const char **argv) {
 	return true;
 }
 
-bool Debugger::cmd_set_renderer(int argc, const char **argv) {
+bool Debugger::cmd_renderer_set(int argc, const char **argv) {
 	if (argc < 2) {
-		debugPrintf("Usage: set_renderer <renderer>\n");
+		debugPrintf("Usage: renderer_set <renderer>\n");
 		debugPrintf("Where <renderer> is 'software', 'opengl' or 'opengl_shaders'\n");
 		return true;
 	}
@@ -108,7 +108,7 @@ bool Debugger::cmd_set_renderer(int argc, const char **argv) {
 	return false;
 }
 
-bool Debugger::cmd_get_renderer(int argc, const char **argv) {
+bool Debugger::cmd_renderer_get(int argc, const char **argv) {
 	auto rendererCodeStr = Graphics::Renderer::getTypeCode(g_grim->getRendererType());
 	debugPrintf("%s\n", rendererCodeStr.c_str());
 	return true;

--- a/engines/grim/debugger.cpp
+++ b/engines/grim/debugger.cpp
@@ -36,6 +36,7 @@ Debugger::Debugger() :
 	registerCmd("lua_do", WRAP_METHOD(Debugger, cmd_lua_do));
 	registerCmd("jump", WRAP_METHOD(Debugger, cmd_jump));
 	registerCmd("set_renderer", WRAP_METHOD(Debugger, cmd_set_renderer));
+	registerCmd("get_renderer", WRAP_METHOD(Debugger, cmd_get_renderer));
 	registerCmd("save", WRAP_METHOD(Debugger, cmd_save));
 	registerCmd("load", WRAP_METHOD(Debugger, cmd_load));
 }
@@ -105,6 +106,12 @@ bool Debugger::cmd_set_renderer(int argc, const char **argv) {
 	ConfMan.set("renderer", Graphics::Renderer::getTypeCode(renderer));
 	g_grim->changeHardwareState();
 	return false;
+}
+
+bool Debugger::cmd_get_renderer(int argc, const char **argv) {
+	auto rendererCodeStr = Graphics::Renderer::getTypeCode(g_grim->getRendererType());
+	debugPrintf("%s\n", rendererCodeStr.c_str());
+	return true;
 }
 
 bool Debugger::cmd_save(int argc, const char **argv) {

--- a/engines/grim/debugger.h
+++ b/engines/grim/debugger.h
@@ -36,6 +36,7 @@ public:
 	bool cmd_checkFiles(int argc, const char **argv);
 	bool cmd_lua_do(int argc, const char **argv);
 	bool cmd_jump(int argc, const char **argv);
+	bool cmd_get_renderer(int argc, const char **argv);
 	bool cmd_set_renderer(int argc, const char **argv);
 	bool cmd_save(int argc, const char **argv);
 	bool cmd_load(int argc, const char **argv);

--- a/engines/grim/debugger.h
+++ b/engines/grim/debugger.h
@@ -36,8 +36,8 @@ public:
 	bool cmd_checkFiles(int argc, const char **argv);
 	bool cmd_lua_do(int argc, const char **argv);
 	bool cmd_jump(int argc, const char **argv);
-	bool cmd_get_renderer(int argc, const char **argv);
-	bool cmd_set_renderer(int argc, const char **argv);
+	bool cmd_renderer_get(int argc, const char **argv);
+	bool cmd_renderer_set(int argc, const char **argv);
 	bool cmd_save(int argc, const char **argv);
 	bool cmd_load(int argc, const char **argv);
 };

--- a/engines/grim/gfx_base.cpp
+++ b/engines/grim/gfx_base.cpp
@@ -46,6 +46,7 @@
 namespace Grim {
 
 GfxBase::GfxBase() :
+		type(Graphics::RendererType::kRendererTypeDefault),
 		_renderBitmaps(true), _renderZBitmaps(true), _shadowModeActive(false),
 		_currentPos(0, 0, 0), _dimLevel(0.0f),
 		_screenWidth(0), _screenHeight(0),

--- a/engines/grim/gfx_base.h
+++ b/engines/grim/gfx_base.h
@@ -28,6 +28,8 @@
 #include "common/str.h"
 #include "common/rect.h"
 
+#include "graphics/renderer.h"
+
 #include "engines/grim/material.h"
 
 namespace Graphics {
@@ -265,6 +267,8 @@ public:
 
 	virtual void createSpecialtyTexture(uint id, const uint8 *data, int width, int height);
 	virtual void createSpecialtyTextureFromScreen(uint id, uint8 *data, int x, int y, int width, int height) = 0;
+
+	Graphics::RendererType type;
 
 	static Math::Matrix4 makeLookMatrix(const Math::Vector3d& pos, const Math::Vector3d& interest, const Math::Vector3d& up);
 	static Math::Matrix4 makeProjMatrix(float fov, float nclip, float fclip);

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -80,6 +80,7 @@ GfxOpenGL::GfxOpenGL() : _smushNumTex(0),
 		_useDepthShader(false), _fragmentProgram(0), _useDimShader(0),
 		_dimFragProgram(0), _maxLights(0), _storedDisplay(nullptr),
 		_emergFont(0), _alpha(1.f) {
+	type = Graphics::RendererType::kRendererTypeOpenGL;
 	// GL_LEQUAL as glDepthFunc ensures that subsequent drawing attempts for
 	// the same triangles are not ignored by the depth test.
 	// That's necessary for EMI where some models have multiple faces which

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -205,6 +205,7 @@ GfxBase *CreateGfxOpenGLShader() {
 }
 
 GfxOpenGLS::GfxOpenGLS() {
+	type = Graphics::RendererType::kRendererTypeOpenGLShaders;
 	_smushTexId = 0;
 	_matrixStack.push(Math::Matrix4());
 	_fov = -1.0;

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -50,6 +50,7 @@ GfxTinyGL::GfxTinyGL() :
 		_alpha(1.f),
 		_currentActor(nullptr), _smushImage(nullptr),
 		_storedDisplay(nullptr) {
+	type = Graphics::RendererType::kRendererTypeTinyGL;
 	// TGL_LEQUAL as tglDepthFunc ensures that subsequent drawing attempts for
 	// the same triangles are not ignored by the depth test.
 	// That's necessary for EMI where some models have multiple faces which

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -1716,6 +1716,10 @@ void GrimEngine::enableCutscene(uint32 number) {
 	_cutsceneEnabled[number] = true;
 }
 
+Graphics::RendererType GrimEngine::getRendererType() {
+	return g_driver->type;
+}
+
 void GrimEngine::setSaveMetaData(const char *meta1, int meta2, const char *meta3) {
 	_saveMeta1 = meta1;
 	_saveMeta2 = meta2;

--- a/engines/grim/grim.h
+++ b/engines/grim/grim.h
@@ -29,6 +29,8 @@
 #include "common/hashmap.h"
 #include "common/events.h"
 
+#include "graphics/renderer.h"
+
 #include "engines/grim/textobject.h"
 #include "engines/grim/iris.h"
 #include "engines/grim/detection.h"
@@ -172,6 +174,8 @@ public:
 	void enableCutscene(uint32 number);
 
 	Commentary *getCommentary() { return _commentary; }
+
+	Graphics::RendererType getRendererType();
 
 	// TODO: Refactor.
 	void setSaveMetaData(const char*, int, const char*);


### PR DESCRIPTION
Also some bugs were noticed (I guess it is not really that they should be reported here, but I don't want to register in the bug tracker):
1. `set_renderer`/`renderer_set` doesn't work properly.
2. Monkey Kombat health bar display is broken. It is always displayed fully. It reproduces with all the renderers.