### PR TITLE
GRAPHICS: MACGUI: remove unused variable

### DIFF
--- a/graphics/macgui/macmenu.cpp
+++ b/graphics/macgui/macmenu.cpp
@@ -240,7 +240,6 @@ MacMenu *MacMenu::createMenuFromPEexe(Common::PEResources *exe, MacWindowManager
 	Common::Stack<bool> popups;
 
 	int depth = 0;
-	int curMenuItemId = 0;
 	bool lastPopUp = false;
 	while (depth >= 0) {
 		uint16 flags = menuData->readUint16LE();
@@ -275,9 +274,6 @@ MacMenu *MacMenu::createMenuFromPEexe(Common::PEResources *exe, MacWindowManager
 					if (menus.size())
 						menus.pop();
 				}
-
-				if (depth == 0)
-					curMenuItemId++;
 
 				lastPopUp = popups.pop();
 			}


### PR DESCRIPTION
This was introduced way back in 99f458dafa10e96c671159b74f9cefa9b795ee34, at which time it was used. It looks like over the years the code has mutated a little bit, and in its current form this variable was added to but never actually read. I only realized when clang flagged it as a warning.