### PR TITLE
DIRECTOR: Move _lastPalette to DirectorEngine

### DIFF
--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -1267,6 +1267,10 @@ void Cast::loadCastInfo(Common::SeekableReadStreamEndian &stream, uint16 id) {
 		warning("STUB: Cast::loadCastInfo(): Film loop cast member info not yet supported for version %d", _version);
 	}
 
+	// For PaletteCastMember, run load() as we need it right now
+	if (member->_type == kCastPalette)
+		member->load();
+
 	ci->autoHilite = castInfo.flags & 2;
 	ci->scriptId = castInfo.scriptId;
 	if (ci->scriptId != 0)

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -260,6 +260,7 @@ public:
 	uint16 _wmWidth;
 	uint16 _wmHeight;
 	byte _fpsLimit;
+	CastMemberID _lastPalette;
 
 private:
 	byte _currentPalette[768];

--- a/engines/director/graphics.cpp
+++ b/engines/director/graphics.cpp
@@ -133,14 +133,8 @@ void DirectorEngine::loadDefaultPalettes() {
 
 PaletteV4 *DirectorEngine::getPalette(const CastMemberID &id) {
 	if (!_loadedPalettes.contains(id)) {
-		CastMember *member = getCurrentMovie()->getCastMember(id);
-		if (member && member->_type == kCastPalette) {
-			member->load();
-		}
-		if (!_loadedPalettes.contains(id)) {
-			warning("DirectorEngine::getPalette(): Palette %s not found", id.asString().c_str());
-			return nullptr;
-		}
+		warning("DirectorEngine::getPalette(): Palette %s not found", id.asString().c_str());
+		return nullptr;
 	}
 
 	return &_loadedPalettes[id];
@@ -161,13 +155,12 @@ bool DirectorEngine::setPalette(const CastMemberID &id) {
 	if (id.isNull()) {
 		// Palette id of 0 is unused
 		return false;
-	} 
+	}
 
 	PaletteV4 *pal = getPalette(id);
 	if (!pal)
 		return false;
 	setPalette(pal->palette, pal->length);
-
 	return true;
 }
 

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -2427,10 +2427,10 @@ void LB::b_puppetPalette(int nargs) {
 
 		// FIXME: set system palette decided by platform, should be fixed after windows palette is working.
 		// try to set mac system palette if lastPalette is 0.
-		if (score->_lastPalette.isNull())
+		if (g_director->_lastPalette.isNull())
 			g_director->setPalette(CastMemberID(kClutSystemMac, -1));
 		else
-			g_director->setPalette(score->_lastPalette);
+			g_director->setPalette(g_director->_lastPalette);
 	}
 
 	// TODO: Implement advanced features that use these.

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -66,7 +66,6 @@ Score::Score(Movie *movie) {
 
 	_puppetTempo = 0x00;
 	_puppetPalette = false;
-	_lastPalette = CastMemberID(0, 0);
 	_paletteTransitionIndex = 0;
 	memset(_paletteSnapshotBuffer, 0, 768);
 
@@ -105,7 +104,7 @@ Score::~Score() {
 }
 
 CastMemberID Score::getCurrentPalette() {
-	return _lastPalette;
+	return g_director->_lastPalette;
 }
 
 bool Score::processImmediateFrameScript(Common::String s, int id) {
@@ -275,12 +274,6 @@ void Score::startPlay() {
 
 		return;
 	}
-
-	_lastPalette = _frames[_currentFrame]->_palette.paletteId;
-	if (_lastPalette.isNull())
-		_lastPalette = _movie->getCast()->_defaultPalette;
-	debugC(2, kDebugImages, "Score::startPlay(): palette changed to %s", _lastPalette.asString().c_str());
-	_vm->setPalette(_lastPalette);
 
 	// All frames in the same movie have the same number of channels
 	if (_playState != kPlayStopped)
@@ -800,17 +793,17 @@ void Score::setLastPalette(uint16 frameId) {
 
 	// If the palette is defined in the frame and doesn't match
 	// the current one, set it
-	bool paletteChanged = (currentPalette != _lastPalette) && (!currentPalette.isNull());
+	bool paletteChanged = (currentPalette != g_director->_lastPalette) && (!currentPalette.isNull());
 	if (paletteChanged) {
 		debugC(2, kDebugImages, "Score::setLastPalette(): palette changed to %s, from %s", currentPalette.asString().c_str(), isCachedPalette ? "cache" :"frame");
-		_lastPalette = currentPalette;
+		g_director->_lastPalette = currentPalette;
 		_paletteTransitionIndex = 0;
 
 		// Switch to a new palette immediately if:
 		// - this is color cycling mode, or
 		// - the cached palette ID is different (i.e. we jumped in the score)
 		if (_frames[frameId]->_palette.colorCycling || isCachedPalette)
-			g_director->setPalette(_lastPalette);
+			g_director->setPalette(g_director->_lastPalette);
 	}
 
 }
@@ -1615,9 +1608,9 @@ Common::String Score::formatChannelInfo() {
 		result += Common::String::format("PAL:    paletteId: %s, firstColor: %d, lastColor: %d, flags: %d, cycleCount: %d, speed: %d, frameCount: %d, fade: %d, delay: %d, style: %d, currentId: %s, defaultId: %s\n",
 			frame._palette.paletteId.asString().c_str(), frame._palette.firstColor, frame._palette.lastColor, frame._palette.flags,
 			frame._palette.cycleCount, frame._palette.speed, frame._palette.frameCount,
-			frame._palette.fade, frame._palette.delay, frame._palette.style, _lastPalette.asString().c_str(), defaultPalette.asString().c_str());
+			frame._palette.fade, frame._palette.delay, frame._palette.style, g_director->_lastPalette.asString().c_str(), defaultPalette.asString().c_str());
 	} else {
-		result += Common::String::format("PAL:    paletteId: 000, currentId: %s, defaultId: %s\n", _lastPalette.asString().c_str(), defaultPalette.asString().c_str());
+		result += Common::String::format("PAL:    paletteId: 000, currentId: %s, defaultId: %s\n", g_director->_lastPalette.asString().c_str(), defaultPalette.asString().c_str());
 	}
 	result += Common::String::format("TRAN:   transType: %d, transDuration: %d, transChunkSize: %d\n",
 		frame._transType, frame._transDuration, frame._transChunkSize);

--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -149,7 +149,6 @@ public:
 
 	byte _puppetTempo;
 	bool _puppetPalette;
-	CastMemberID _lastPalette;
 	int _paletteTransitionIndex;
 	byte _paletteSnapshotBuffer[768];
 
@@ -178,7 +177,6 @@ private:
 	uint16 _nextFrame;
 	int _currentLabel;
 	DirectorSound *_soundManager;
-	int _currentPalette;
 
 	int _previousBuildBotBuild = -1;
 };


### PR DESCRIPTION
If the destination movie uses a palette cast member in the same location as the source, but with different data; Director will assume that the old palette is correct right up until it has to switch to something else via the score.

Additionally, ensure that all palettes are loaded into the index when the Cast is loaded, not just single ones that haven't been loaded before.

Fixes movie transitions and palette rendering in Phibos: Following the Comet.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
