### PR TITLE
AMIGAOS: amigaos.cpp - Set default gfx_mode to "surfacesdl"

### DIFF
--- a/backends/platform/sdl/amigaos/amigaos.cpp
+++ b/backends/platform/sdl/amigaos/amigaos.cpp
@@ -103,7 +103,7 @@ void OSystem_AmigaOS::initBackend() {
 	ConfMan.registerDefault("audio_buffer_size", "2048");
 	ConfMan.registerDefault("aspect_ratio", true);
 	ConfMan.registerDefault("fullscreen", true);
-	ConfMan.registerDefault("gfx_mode", "opengl");
+	ConfMan.registerDefault("gfx_mode", "surfacesdl");
 	ConfMan.registerDefault("stretch_mode", "stretch");
 	ConfMan.registerDefault("gui_mode", "antialias");
 	ConfMan.registerDefault("gui_theme", "scummremastered");
@@ -121,7 +121,7 @@ void OSystem_AmigaOS::initBackend() {
 		ConfMan.setBool("fullscreen", true);
 	}
 	if (!ConfMan.hasKey("gfx_mode")) {
-		ConfMan.set("gfx_mode", "opengl");
+		ConfMan.set("gfx_mode", "surfacesdl");
 	}
 	if (!ConfMan.hasKey("stretch_mode")) {
 		ConfMan.set("stretch_mode", "stretch");


### PR DESCRIPTION
One user caught a GL crash/black screen on starting, while running ScummVM under emulation without any access to OpenGL/MiniGL/OGLES2.

No .ini file was created either.

This happened because gfx_mode was forced to "opengl" by default.

Setting gfx_mode to "surfacesdl" fixed the crash, the black screen and creating a usable .ini file.


...this only touches the AmigaOS target