### PR TITLE
TETRAEDGE: Skip garbage value entry in inventory data

### DIFF
--- a/engines/tetraedge/game/inventory_objects_xml_parser.cpp
+++ b/engines/tetraedge/game/inventory_objects_xml_parser.cpp
@@ -32,4 +32,13 @@ bool InventoryObjectsXmlParser::parserCallback_Object(ParserNode *node) {
 	return true;
 }
 
+bool InventoryObjectsXmlParser::handleUnknownKey(ParserNode *node) {
+	if (node->name == "value") {
+		warning("Garbage entry <value> in inventory file");
+		return true;
+	}
+	parserError("Unknown key");
+	return false;
+}
+
 } // end namespace Tetraedge

--- a/engines/tetraedge/game/inventory_objects_xml_parser.h
+++ b/engines/tetraedge/game/inventory_objects_xml_parser.h
@@ -45,6 +45,7 @@ public:
 
 	bool parserCallback_document(ParserNode *node) { return true; };
 	bool parserCallback_Object(ParserNode *node);
+	bool handleUnknownKey(ParserNode *node) override;
 
 public:
 	Common::HashMap<Common::String, Inventory::InventoryObjectData> _objects;


### PR DESCRIPTION
There exist a Russian variant of Syberia 2 for mac. It's created by injecting iOS translation into official mac Syberia 2. Unfortunately inventory XML contains a garbage value entry. Ignore it but issue warning.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
