### PR TITLE
GRAPHICS: Change pitch from int16 to int32

### DIFF
--- a/engines/ags/lib/allegro/surface.h
+++ b/engines/ags/lib/allegro/surface.h
@@ -32,7 +32,8 @@ class BITMAP {
 private:
 	Graphics::ManagedSurface *_owner;
 	public:
-	int16 &w, &h, &pitch;
+	int16 &w, &h;
+	int32 &pitch;
 	Graphics::PixelFormat &format;
 	bool clip;
 	int ct, cb, cl, cr;

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -103,7 +103,7 @@ public:
 public:
 	int16 &w;           /*!< Width of the surface rectangle. */
 	int16 &h;           /*!< Height of the surface rectangle. */
-	int16 &pitch;       /*!< Pitch of the surface rectangle. See @ref Surface::pitch. */
+	int32 &pitch;       /*!< Pitch of the surface rectangle. See @ref Surface::pitch. */
 	PixelFormat &format; /*!< Pixel format of the surface. See @ref PixelFormat. */
 public:
 	/**

--- a/graphics/surface.h
+++ b/graphics/surface.h
@@ -79,7 +79,7 @@ struct Surface {
 	 *
 	 * @note This might not equal w * bytesPerPixel.
 	 */
-	int16 pitch;
+	int32 pitch;
 
 protected:
 	/**


### PR DESCRIPTION
Chronicle of Innsmouth - Mountains of Madness allocates a very big (about 9000x300) surface used for a scrolling scene.
This causes pitch to overflow in Surface::create causing a segfault as reported in [14456](https://bugs.scummvm.org/ticket/14456)

Note: this does not make the game playable (yet), as it uses a still unsupported plugin to play videos and do other graphics trickery.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
