### PR TITLE
AGS: Fixed std::function bool cast on clang

### DIFF
--- a/engines/ags/lib/std/functional.h
+++ b/engines/ags/lib/std/functional.h
@@ -48,6 +48,10 @@ struct function {
 	operator _Fty &() {
 		return *_fn;
 	}
+
+	operator bool() {
+		return _fn != nullptr;
+	}
 };
 
 } // namespace std

--- a/engines/ags/lib/std/functional.h
+++ b/engines/ags/lib/std/functional.h
@@ -49,7 +49,7 @@ struct function {
 		return *_fn;
 	}
 
-	operator bool() {
+	operator bool() const {
 		return _fn != nullptr;
 	}
 };


### PR DESCRIPTION
On Apple Silicon, clang seems to not compile exactly the same as gcc on Windows or Linux. This leads to a problem with AGS's std::function struct.

Before, when being cast to a boolean, it would return true if _fn was nullptr for some reason, so I added a boolean cast function to std::functional so that casting it to a boolean would be the same as seeing if _fn was not nullptr.