### PR TITLE
DIRECTOR: .exe is a valid movie ext

### DIFF
--- a/engines/director/util.cpp
+++ b/engines/director/util.cpp
@@ -828,8 +828,8 @@ bool hasExtension(Common::String filename) {
 
 Common::String testExtensions(Common::String component, Common::String initialPath, Common::String convPath) {
 	const char *extsD3[] = { ".MMM", nullptr };
-	const char *extsD4[] = { ".DIR", ".DXR", nullptr };
-	const char *extsD5[] = { ".DIR", ".DXR", ".CST", ".CXT", nullptr };
+	const char *extsD4[] = { ".DIR", ".DXR", ".EXE", nullptr };
+	const char *extsD5[] = { ".DIR", ".DXR", ".CST", ".CXT", ".EXE", nullptr };
 
 	const char **exts = nullptr;
 	if (g_director->getVersion() < 400) {


### PR DESCRIPTION
Fixes the Windows version of Mylk (D4), which tries to return to the main screen by opening mylk.exe via a call to open the movie "MYLK". This can be tested by opening the pane next to the lake, entering that screen, then clicking back. Without this fix, the game will stay stuck on that screen with the warning "Movie MYLK does not exist".

@moralrecordings Is the .exe extension also possibly valid for D5, or should I remove that addition?