### PR TITLE
NUVIE: ULTIMA6: Fix crash in GUI on surface blit

### DIFF
--- a/engines/ultima/nuvie/misc/sdl_compat.cpp
+++ b/engines/ultima/nuvie/misc/sdl_compat.cpp
@@ -27,6 +27,7 @@
 #include "common/textconsole.h"
 #include "graphics/managed_surface.h"
 #include "image/bmp.h"
+#include "ultima/nuvie/screen/screen.h"
 
 namespace Ultima {
 namespace Nuvie {
@@ -92,7 +93,11 @@ Graphics::ManagedSurface *SDL_LoadBMP(const char *filename) {
 		error("Could not load bitmap - %s", filename);
 
 	const Graphics::Surface *src = decoder.getSurface();
-	Graphics::ManagedSurface *dest = new Graphics::ManagedSurface(src->w, src->h, src->format);
+	Screen *const screen = Game::get_game()->get_screen();
+	assert (screen);
+	Graphics::ManagedSurface *const screenSurface = screen->get_sdl_surface();
+	assert (screenSurface);
+	Graphics::ManagedSurface *dest = new Graphics::ManagedSurface(src->w, src->h, screenSurface->format);
 	dest->blitFrom(*src);
 
 	return dest;


### PR DESCRIPTION
SDL_LoadBMP: Return ManagedSurfaces with their PixelFormat matching that of the screen.

This fixes a crash when a surface created from a bitmap is blitted to the screen surface in a GUI dialog.
("ERROR: Surface::transBlitFrom: bytesPerPixel must be 1, 2, or 4")

The bug was introduced in commit
[b458cedca493bcfdfba81bb66554251245489762](https://github.com/scummvm/scummvm/commit/b458cedca493bcfdfba81bb66554251245489762)
"IMAGE: Speed up 16/24/32bpp BMP decoding"