### PR TITLE
NUVIE: ULTIMA6: Fix out-of-bounds read in FM-Towns sound decoder

### DIFF
--- a/engines/ultima/nuvie/sound/decoder/fm_towns_decoder_stream.cpp
+++ b/engines/ultima/nuvie/sound/decoder/fm_towns_decoder_stream.cpp
@@ -75,7 +75,7 @@ int FMtownsDecoderStream::readBuffer(sint16 *buffer, const int numSamples) {
 	//DEBUG(0,LEVEL_INFORMATIONAL, "numSamples = %d. buf_pos = %d, buf_len = %d\n", numSamples, buf_pos, buf_len);
 
 	for (; j < numSamples && i < buf_len;) {
-		buffer[j] = convertSample(READ_LE_UINT16(&raw_audio_buf[i]));
+		buffer[j] = convertSample(static_cast<uint16>(raw_audio_buf[i]));
 		j++;
 		i++;
 	}


### PR DESCRIPTION
FMtownsDecoderStream::readBuffer():
Do not treat the contents of raw_audio_buf as 16-bit values via READ_LE_UINT16. The FM-Towns audio consists of 8-bit samples, so no endianness handling is needed.

This fixes an out-of-bounds read when the last element of unsigned char *raw_audio_buf is accessed as an uint16.

The bug does not result in bad audio, since the additional bits are zeroed in FMtownsDecoderStream::convertSample().

Note: Fix was only tested on LE machines.