### PR TITLE
NUVIE: ULTIMA6: Fix crash in FM-Towns converse gump

### DIFF
--- a/engines/ultima/nuvie/gui/widgets/msg_scroll.cpp
+++ b/engines/ultima/nuvie/gui/widgets/msg_scroll.cpp
@@ -450,6 +450,9 @@ bool MsgScroll::can_fit_token_on_msgline(MsgLine *msg_line, MsgText *token) {
 bool MsgScroll::parse_token(MsgText *token) {
 	MsgLine *msg_line = NULL;
 
+	if (!(token && token->s.length()))
+		return true;
+
 	if (!msg_buf.empty())
 		msg_line = msg_buf.back(); // retrieve the last line from the scroll buffer.
 


### PR DESCRIPTION
MsgScroll::parse_token(): Skip token parsing when length is 0.

Prevents failed assertion when opening a converse gump with the FM-Towns data files installed and game style set to "new style":

engines/ultima/shared/std/string.h:93:
 char& Ultima::Std::string::operator\[\](size_t):
 Assertion `idx < _size' failed.

The call chain is as follows:
```
ConverseGump::parse_token()
  parse_fm_towns_token(token) // <-- this can truncate string token->s
                                     to length 0
  MsgScroll::parse_token(token) // <-- token->s[0] is accessed here
                                       without checking length
```