### PR TITLE
TETRAEDGE: Fix TeImage output on big-endian hosts

### DIFF
--- a/engines/tetraedge/te/te_image.cpp
+++ b/engines/tetraedge/te/te_image.cpp
@@ -21,6 +21,7 @@
 
 #include "tetraedge/tetraedge.h"
 
+#include "common/endian.h"
 #include "common/rect.h"
 #include "tetraedge/te/te_core.h"
 #include "tetraedge/te/te_image.h"
@@ -53,8 +54,13 @@ void TeImage::create() {
 void TeImage::createImg(uint xsize, uint ysize, Common::SharedPtr<TePalette> &pal,
 			Format teformat, uint bufxsize, uint bufysize) {
 	_teFormat = teformat;
+#ifdef SCUMM_BIG_ENDIAN
+	Graphics::PixelFormat pxformat = ((teformat == TeImage::RGB8) ?
+									  Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0) : Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
+#else
 	Graphics::PixelFormat pxformat = ((teformat == TeImage::RGB8) ?
 									  Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0) : Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
+#endif
 
 	Graphics::ManagedSurface::create(xsize, ysize, pxformat);
 	if (teformat == TeImage::RGBA8)


### PR DESCRIPTION
This appears to fix the [following kind of output](https://bugs.scummvm.org/attachment/ticket/14452/syberia2-macppc.png) for the menus of Syberia on big-endian hosts.

Tested with the Macintosh release from GOG, on a PowerPC G4. Mostly tested with Syberia 2, since Syberia 1 has a very low framerate on this device, for some other reason.

Submitted as a PR, because I'm not very familiar with the game or with the proper way of dealing with `Graphics::PixelFormat`. I just "stole" this from what the Grim engine does in a similar case.

(Please don't close the Trac issue above, as the Theora video slowness issue is still unresolved at the moment.)