### PR TITLE
COMMON: Add variants of memset for 16-bit, 32-bit and 64-bit values

### DIFF
--- a/common/memory.cpp
+++ b/common/memory.cpp
@@ -1,0 +1,73 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/memory.h"
+#include "common/util.h"
+
+namespace Common {
+
+void memset8(uint64 *dst, uint64 val, size_t count) {
+	if (!count)
+		return;
+
+	int n = (count + 7) >> 3;
+	switch (count % 8) {
+	default:
+	case 0:	do {
+	       		*dst++ = val; // fall through
+	case 7:		*dst++ = val; // fall through
+	case 6:		*dst++ = val; // fall through
+	case 5:		*dst++ = val; // fall through
+	case 4:		*dst++ = val; // fall through
+	case 3:		*dst++ = val; // fall through
+	case 2:		*dst++ = val; // fall through
+	case 1:		*dst++ = val;
+	       	} while (--n > 0);
+	}
+}
+
+void memset4(uint32 *dst, uint32 val, size_t count) {
+	if (!IS_ALIGNED(dst, 8) && count) {
+		*dst++ = val;
+		count -= 1;
+	}
+
+	memset8((uint64 *)dst, val | ((uint64)val << 32), count >> 1);
+
+	if (count & 1) {
+		dst[count & ~1] = val;
+	}
+}
+
+void memset2(uint16 *dst, uint16 val, size_t count) {
+	if (!IS_ALIGNED(dst, 4) && count) {
+		*dst++ = val;
+		count -= 1;
+	}
+
+	memset4((uint32 *)dst, val | ((uint32)val << 16), count >> 1);
+
+	if (count & 1) {
+		dst[count & ~1] = val;
+	}
+}
+
+} // End of namespace Common

--- a/common/memory.cpp
+++ b/common/memory.cpp
@@ -24,7 +24,7 @@
 
 namespace Common {
 
-void memset8(uint64 *dst, uint64 val, size_t count) {
+void memset64(uint64 *dst, uint64 val, size_t count) {
 	if (!count)
 		return;
 
@@ -44,26 +44,26 @@ void memset8(uint64 *dst, uint64 val, size_t count) {
 	}
 }
 
-void memset4(uint32 *dst, uint32 val, size_t count) {
+void memset32(uint32 *dst, uint32 val, size_t count) {
 	if (!IS_ALIGNED(dst, 8) && count) {
 		*dst++ = val;
 		count -= 1;
 	}
 
-	memset8((uint64 *)dst, val | ((uint64)val << 32), count >> 1);
+	memset64((uint64 *)dst, val | ((uint64)val << 32), count >> 1);
 
 	if (count & 1) {
 		dst[count & ~1] = val;
 	}
 }
 
-void memset2(uint16 *dst, uint16 val, size_t count) {
+void memset16(uint16 *dst, uint16 val, size_t count) {
 	if (!IS_ALIGNED(dst, 4) && count) {
 		*dst++ = val;
 		count -= 1;
 	}
 
-	memset4((uint32 *)dst, val | ((uint32)val << 16), count >> 1);
+	memset32((uint32 *)dst, val | ((uint32)val << 16), count >> 1);
 
 	if (count & 1) {
 		dst[count & ~1] = val;

--- a/common/memory.h
+++ b/common/memory.h
@@ -35,6 +35,22 @@ namespace Common {
  */
 
 /**
+ * Fills memory [dst, dst + count) with the value val.
+ *
+ * This is a replacement function for Common::fill, using an unrolled
+ * loop to maximize performance on most architectures.
+ *
+ * This fill operation is extensively used throughout the graphics code,
+ * so this counts as one of the main bottlenecks. Please replace it with
+ * assembly when possible!
+ *
+ * Note that pointers passed to these functions must be aligned correctly.
+ */
+void memset2(uint16 *dst, uint16 val, size_t count);
+void memset4(uint32 *dst, uint32 val, size_t count);
+void memset8(uint64 *dst, uint64 val, size_t count);
+
+/**
  * Copies data from the range [first, last) to [dst, dst + (last - first)).
  * It requires the range [dst, dst + (last - first)) to be valid and
  * uninitialized.

--- a/common/memory.h
+++ b/common/memory.h
@@ -46,9 +46,9 @@ namespace Common {
  *
  * Note that pointers passed to these functions must be aligned correctly.
  */
-void memset2(uint16 *dst, uint16 val, size_t count);
-void memset4(uint32 *dst, uint32 val, size_t count);
-void memset8(uint64 *dst, uint64 val, size_t count);
+void memset16(uint16 *dst, uint16 val, size_t count);
+void memset32(uint32 *dst, uint32 val, size_t count);
+void memset64(uint64 *dst, uint64 val, size_t count);
 
 /**
  * Copies data from the range [first, last) to [dst, dst + (last - first)).

--- a/common/module.mk
+++ b/common/module.mk
@@ -16,6 +16,7 @@ MODULE_OBJS := \
 	language.o \
 	localization.o \
 	macresman.o \
+	memory.o \
 	memorypool.o \
 	md5.o \
 	mutex.o \

--- a/graphics/VectorRendererSpec.cpp
+++ b/graphics/VectorRendererSpec.cpp
@@ -425,42 +425,28 @@ namespace Graphics {
 /**
  * Fills several pixels in a row with a given color.
  *
- * This is a replacement function for Common::fill, using an unrolled
- * loop to maximize performance on most architectures.
- * This function may (and should) be overloaded in any child renderers
- * for portable platforms with platform-specific assembly code.
- *
- * This fill operation is extensively used throughout the renderer, so this
- * counts as one of the main bottlenecks. Please replace it with assembly
- * when possible!
- *
  * @param first Pointer to the first pixel to fill.
  * @param last Pointer to the last pixel to fill.
  * @param color Color of the pixel
  */
 template<typename PixelType>
 void colorFill(PixelType *first, PixelType *last, PixelType color) {
+	STATIC_ASSERT(sizeof(PixelType) == 1 || sizeof(PixelType) == 2 || sizeof(PixelType) == 4, Unsupported_PixelType);
+
 	int count = (last - first);
-	if (!count)
-		return;
-	int n = (count + 7) >> 3;
-	switch (count % 8) {
-	default:
-	case 0:	do {
-	       		*first++ = color; // fall through
-	case 7:		*first++ = color; // fall through
-	case 6:		*first++ = color; // fall through
-	case 5:		*first++ = color; // fall through
-	case 4:		*first++ = color; // fall through
-	case 3:		*first++ = color; // fall through
-	case 2:		*first++ = color; // fall through
-	case 1:		*first++ = color;
-	       	} while (--n > 0);
-	}
+
+	if (sizeof(PixelType) == 1)
+		memset((uint8 *)first, color, count);
+	else if (sizeof(PixelType) == 2)
+		Common::memset2((uint16 *)first, color, count);
+	else
+		Common::memset4((uint32 *)first, color, count);
 }
 
 template<typename PixelType>
 void colorFillClip(PixelType *first, PixelType *last, PixelType color, int realX, int realY, Common::Rect &clippingArea) {
+	STATIC_ASSERT(sizeof(PixelType) == 1 || sizeof(PixelType) == 2 || sizeof(PixelType) == 4, Unsupported_PixelType);
+
 	if (realY < clippingArea.top || realY >= clippingArea.bottom)
 		return;
 
@@ -481,23 +467,12 @@ void colorFillClip(PixelType *first, PixelType *last, PixelType color, int realX
 		count -= diff;
 	}
 
-	if (!count)
-		return;
-
-	int n = (count + 7) >> 3;
-	switch (count % 8) {
-	default:
-	case 0:	do {
-	       		*first++ = color; // fall through
-	case 7:		*first++ = color; // fall through
-	case 6:		*first++ = color; // fall through
-	case 5:		*first++ = color; // fall through
-	case 4:		*first++ = color; // fall through
-	case 3:		*first++ = color; // fall through
-	case 2:		*first++ = color; // fall through
-	case 1:		*first++ = color;
-	       	} while (--n > 0);
-	}
+	if (sizeof(PixelType) == 1)
+		memset((uint8 *)first, color, count);
+	else if (sizeof(PixelType) == 2)
+		Common::memset2((uint16 *)first, color, count);
+	else
+		Common::memset4((uint32 *)first, color, count);
 }
 
 /**

--- a/graphics/VectorRendererSpec.cpp
+++ b/graphics/VectorRendererSpec.cpp
@@ -438,9 +438,9 @@ void colorFill(PixelType *first, PixelType *last, PixelType color) {
 	if (sizeof(PixelType) == 1)
 		memset((uint8 *)first, color, count);
 	else if (sizeof(PixelType) == 2)
-		Common::memset2((uint16 *)first, color, count);
+		Common::memset16((uint16 *)first, color, count);
 	else
-		Common::memset4((uint32 *)first, color, count);
+		Common::memset32((uint32 *)first, color, count);
 }
 
 template<typename PixelType>
@@ -470,9 +470,9 @@ void colorFillClip(PixelType *first, PixelType *last, PixelType color, int realX
 	if (sizeof(PixelType) == 1)
 		memset((uint8 *)first, color, count);
 	else if (sizeof(PixelType) == 2)
-		Common::memset2((uint16 *)first, color, count);
+		Common::memset16((uint16 *)first, color, count);
 	else
-		Common::memset4((uint32 *)first, color, count);
+		Common::memset32((uint32 *)first, color, count);
 }
 
 /**

--- a/graphics/surface.cpp
+++ b/graphics/surface.cpp
@@ -225,10 +225,10 @@ void Surface::hLine(int x, int y, int x2, uint32 color) {
 		memset(ptr, (byte)color, x2 - x + 1);
 	} else if (format.bytesPerPixel == 2) {
 		uint16 *ptr = (uint16 *)getBasePtr(x, y);
-		Common::memset2(ptr, (uint16)color, x2 - x + 1);
+		Common::memset16(ptr, (uint16)color, x2 - x + 1);
 	} else if (format.bytesPerPixel == 4) {
 		uint32 *ptr = (uint32 *)getBasePtr(x, y);
-		Common::memset4(ptr, (uint32)color, x2 - x + 1);
+		Common::memset32(ptr, (uint32)color, x2 - x + 1);
 	} else {
 		error("Surface::hLine: bytesPerPixel must be 1, 2, or 4");
 	}
@@ -303,12 +303,12 @@ void Surface::fillRect(Common::Rect r, uint32 color) {
 	} else {
 		if (format.bytesPerPixel == 2) {
 			while (height--) {
-				Common::memset2((uint16 *)ptr, (uint16)color, width);
+				Common::memset16((uint16 *)ptr, (uint16)color, width);
 				ptr += pitch;
 			}
 		} else {
 			while (height--) {
-				Common::memset4((uint32 *)ptr, (uint32)color, width);
+				Common::memset32((uint32 *)ptr, (uint32)color, width);
 				ptr += pitch;
 			}
 		}

--- a/graphics/tinygl/zbuffer.cpp
+++ b/graphics/tinygl/zbuffer.cpp
@@ -89,7 +89,7 @@ void FrameBuffer::clear(int clearZ, int z, int clearColor, int r, int g, int b,
 			memset(_zbuf, zc[0], sizeof(uint) * _pbufWidth * _pbufHeight);
 		} else {
 			// Cannot use memset, use a variant working on integers (possibly slower)
-			Common::memset4((uint32 *)_zbuf, z, _pbufWidth * _pbufHeight);
+			Common::memset32((uint32 *)_zbuf, z, _pbufWidth * _pbufHeight);
 		}
 	}
 	if (clearColor) {
@@ -105,10 +105,10 @@ void FrameBuffer::clear(int clearZ, int z, int clearColor, int r, int g, int b,
 			// Cannot use memset, use a variant working on shorts/ints (possibly slower)
 			switch(_pbufBpp) {
 			case 2:
-				Common::memset2((uint16 *)pp, color, _pbufWidth * _pbufHeight);
+				Common::memset16((uint16 *)pp, color, _pbufWidth * _pbufHeight);
 				break;
 			case 4:
-				Common::memset4((uint32 *)pp, color, _pbufWidth * _pbufHeight);
+				Common::memset32((uint32 *)pp, color, _pbufWidth * _pbufHeight);
 				break;
 			default:
 				error("Unsupported pixel size %i", _pbufBpp);
@@ -137,7 +137,7 @@ void FrameBuffer::clearRegion(int x, int y, int w, int h, bool clearZ, int z,
 		} else {
 			// Cannot use memset, use a variant working on integers (possibly slower)
 			while (height--) {
-				Common::memset4((uint32 *)zbuf, z, w);
+				Common::memset32((uint32 *)zbuf, z, w);
 				zbuf += _pbufWidth;
 			}
 		}
@@ -160,10 +160,10 @@ void FrameBuffer::clearRegion(int x, int y, int w, int h, bool clearZ, int z,
 			while (height--) {
 				switch(_pbufBpp) {
 				case 2:
-					Common::memset2((uint16 *)pp, color, w);
+					Common::memset16((uint16 *)pp, color, w);
 					break;
 				case 4:
-					Common::memset4((uint32 *)pp, color, w);
+					Common::memset32((uint32 *)pp, color, w);
 					break;
 				default:
 					error("Unsupported pixel size %i", _pbufBpp);

--- a/test/common/memory.h
+++ b/test/common/memory.h
@@ -1,0 +1,63 @@
+#include <cxxtest/TestSuite.h>
+
+#include "common/memory.h"
+
+class MemoryTestSuite : public CxxTest::TestSuite {
+public:
+	void test_memset2() {
+		uint16    expected[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+		const uint16 step1[8] = { 0, 1, 1, 1, 1, 1, 1, 0 };
+		const uint16 step2[8] = { 0, 1, 2, 2, 2, 2, 1, 0 };
+		const uint16 step3[8] = { 0, 1, 2, 3, 3, 2, 1, 0 };
+
+		Common::memset2(expected + 1, 1, 6);
+
+		TS_ASSERT_EQUALS(memcmp(expected, step1, sizeof(expected)), 0);
+
+		Common::memset2(expected + 2, 2, 4);
+
+		TS_ASSERT_EQUALS(memcmp(expected, step2, sizeof(expected)), 0);
+
+		Common::memset2(expected + 3, 3, 2);
+
+		TS_ASSERT_EQUALS(memcmp(expected, step3, sizeof(expected)), 0);
+	}
+
+	void test_memset4() {
+		uint32    expected[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+		const uint32 step1[8] = { 0, 1, 1, 1, 1, 1, 1, 0 };
+		const uint32 step2[8] = { 0, 1, 2, 2, 2, 2, 1, 0 };
+		const uint32 step3[8] = { 0, 1, 2, 3, 3, 2, 1, 0 };
+
+		Common::memset4(expected + 1, 1, 6);
+
+		TS_ASSERT_EQUALS(memcmp(expected, step1, sizeof(expected)), 0);
+
+		Common::memset4(expected + 2, 2, 4);
+
+		TS_ASSERT_EQUALS(memcmp(expected, step2, sizeof(expected)), 0);
+
+		Common::memset4(expected + 3, 3, 2);
+
+		TS_ASSERT_EQUALS(memcmp(expected, step3, sizeof(expected)), 0);
+	}
+
+	void test_memset8() {
+		uint64    expected[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+		const uint64 step1[8] = { 0, 1, 1, 1, 1, 1, 1, 0 };
+		const uint64 step2[8] = { 0, 1, 2, 2, 2, 2, 1, 0 };
+		const uint64 step3[8] = { 0, 1, 2, 3, 3, 2, 1, 0 };
+
+		Common::memset8(expected + 1, 1, 6);
+
+		TS_ASSERT_EQUALS(memcmp(expected, step1, sizeof(expected)), 0);
+
+		Common::memset8(expected + 2, 2, 4);
+
+		TS_ASSERT_EQUALS(memcmp(expected, step2, sizeof(expected)), 0);
+
+		Common::memset8(expected + 3, 3, 2);
+
+		TS_ASSERT_EQUALS(memcmp(expected, step3, sizeof(expected)), 0);
+	}
+};

--- a/test/common/memory.h
+++ b/test/common/memory.h
@@ -4,59 +4,59 @@
 
 class MemoryTestSuite : public CxxTest::TestSuite {
 public:
-	void test_memset2() {
+	void test_memset16() {
 		uint16    expected[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
 		const uint16 step1[8] = { 0, 1, 1, 1, 1, 1, 1, 0 };
 		const uint16 step2[8] = { 0, 1, 2, 2, 2, 2, 1, 0 };
 		const uint16 step3[8] = { 0, 1, 2, 3, 3, 2, 1, 0 };
 
-		Common::memset2(expected + 1, 1, 6);
+		Common::memset16(expected + 1, 1, 6);
 
 		TS_ASSERT_EQUALS(memcmp(expected, step1, sizeof(expected)), 0);
 
-		Common::memset2(expected + 2, 2, 4);
+		Common::memset16(expected + 2, 2, 4);
 
 		TS_ASSERT_EQUALS(memcmp(expected, step2, sizeof(expected)), 0);
 
-		Common::memset2(expected + 3, 3, 2);
+		Common::memset16(expected + 3, 3, 2);
 
 		TS_ASSERT_EQUALS(memcmp(expected, step3, sizeof(expected)), 0);
 	}
 
-	void test_memset4() {
+	void test_memset32() {
 		uint32    expected[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
 		const uint32 step1[8] = { 0, 1, 1, 1, 1, 1, 1, 0 };
 		const uint32 step2[8] = { 0, 1, 2, 2, 2, 2, 1, 0 };
 		const uint32 step3[8] = { 0, 1, 2, 3, 3, 2, 1, 0 };
 
-		Common::memset4(expected + 1, 1, 6);
+		Common::memset32(expected + 1, 1, 6);
 
 		TS_ASSERT_EQUALS(memcmp(expected, step1, sizeof(expected)), 0);
 
-		Common::memset4(expected + 2, 2, 4);
+		Common::memset32(expected + 2, 2, 4);
 
 		TS_ASSERT_EQUALS(memcmp(expected, step2, sizeof(expected)), 0);
 
-		Common::memset4(expected + 3, 3, 2);
+		Common::memset32(expected + 3, 3, 2);
 
 		TS_ASSERT_EQUALS(memcmp(expected, step3, sizeof(expected)), 0);
 	}
 
-	void test_memset8() {
+	void test_memset64() {
 		uint64    expected[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
 		const uint64 step1[8] = { 0, 1, 1, 1, 1, 1, 1, 0 };
 		const uint64 step2[8] = { 0, 1, 2, 2, 2, 2, 1, 0 };
 		const uint64 step3[8] = { 0, 1, 2, 3, 3, 2, 1, 0 };
 
-		Common::memset8(expected + 1, 1, 6);
+		Common::memset64(expected + 1, 1, 6);
 
 		TS_ASSERT_EQUALS(memcmp(expected, step1, sizeof(expected)), 0);
 
-		Common::memset8(expected + 2, 2, 4);
+		Common::memset64(expected + 2, 2, 4);
 
 		TS_ASSERT_EQUALS(memcmp(expected, step2, sizeof(expected)), 0);
 
-		Common::memset8(expected + 3, 3, 2);
+		Common::memset64(expected + 3, 3, 2);
 
 		TS_ASSERT_EQUALS(memcmp(expected, step3, sizeof(expected)), 0);
 	}


### PR DESCRIPTION
The implementation is based on the one in VectorRendererSpec, and has been modified to use larger memory stores where possible.