### PR TITLE
COMMON: Add new Rect constructors to make construction from coordinate+size easier

### DIFF
--- a/common/rect.h
+++ b/common/rect.h
@@ -151,6 +151,16 @@ struct Rect {
 	 */
 	constexpr Rect(int16 w, int16 h) : top(0), left(0), bottom(h), right(w) {}
 	/**
+	 * Create a rectangle with the top-left corner at the position @p topLeft
+	 * and the bottom-right corner at the position @p bottomRight.
+	 *
+	 * The @p topLeft x value must be greater or equal @p bottomRight x and
+	 * @p topLeft y must be greater or equal @p bottomRight y.
+	 */
+	Rect(const Point &topLeft, const Point &bottomRight) : top(topLeft.y), left(topLeft.x), bottom(bottomRight.y), right(bottomRight.x) {
+		assert(isValidRect());
+	}
+	/**
 	 * Create a rectangle with the top-left corner at the given position (x1, y1)
 	 * and the bottom-right corner at the position (x2, y2).
 	 *

--- a/common/rect.h
+++ b/common/rect.h
@@ -161,6 +161,12 @@ struct Rect {
 		assert(isValidRect());
 	}
 	/**
+	 * Create a rectangle with the top-left corner at the position @p topLeft
+	 * and the given width @p w and height @p h.
+	 */
+	constexpr Rect(const Point &topLeft, int16 w, int16 h) : top(topLeft.y), left(topLeft.x), bottom(topLeft.y + h), right(topLeft.x + w) {
+	}
+	/**
 	 * Create a rectangle with the top-left corner at the given position (x1, y1)
 	 * and the bottom-right corner at the position (x2, y2).
 	 *


### PR DESCRIPTION
This adds some new constructors to Rect for constructing a rect from a top-left coordinate and either a bottom-right coordinate or a width and height.

Currently, this requires constructing a rect as:
`Rect(coord.x, coord.y, coord.x + size.x, coord.y + size.y)`

Most of the subexpressions in that are duplicated, which creates opportunities for mistakes, such as when constructing multiple rects.

With this change, you construct as:
`Rect(coord, coord + size)` or `Rect(coord, size.x, size.y)`

This doesn't add the ability to do `Rect(coord, size)` since it would have the same signature.  I opted to use top-left and bottom-right coordinates given the two options, since "`Point`" more intuitively makes sense as a coordinate than a size.