### PR TITLE
AGS: Convert 24bpp to 32bpp when loading bitmaps

### DIFF
--- a/engines/ags/shared/gfx/image.cpp
+++ b/engines/ags/shared/gfx/image.cpp
@@ -45,7 +45,10 @@ BITMAP *decodeImageStream(Common::SeekableReadStream &stream, color *pal) {
 		const Graphics::Surface *src = decoder.getSurface();
 
 		// Copy the decoded surface
-		Surface *dest = new Surface(src->w, src->h, src->format);
+		int bpp = 8 * src->format.bytesPerPixel;
+		if (bpp == 24)
+			bpp = 32;
+		Surface *dest = (Surface *)create_bitmap_ex(bpp, src->w, src->h);
 		dest->blitFrom(*src);
 
 		// Copy the palette


### PR DESCRIPTION
After commit b458ced "IMAGE: Speed up 16/24/32bpp BMP decoding",
some AGS games which use external BMP files don't work anymore (such as Strangeland or Troll Song)
because some allegro routines only support 1, 2 or 4 BPP.

This PR simply blits to a 32bpp surface after loading (i'm not sure this is the best or fastest way to do so,
please review)

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
