### PR TITLE
AUDIO: Skip JUNK padding in WAV files

### DIFF
--- a/audio/decoders/wave.cpp
+++ b/audio/decoders/wave.cpp
@@ -62,6 +62,13 @@ bool loadWAVFromStream(Common::SeekableReadStream &stream, int &size, int &rate,
 		stream.read(buf, 4);
 	}
 
+	if (memcmp(buf, "JUNK", 4) == 0) {
+		uint32 junksize = stream.readUint32LE();
+		// skip junk padding (add 1 byte if odd)
+		stream.skip(junksize + (junksize % 2));
+		stream.read(buf, 4);
+	}
+
 	if (memcmp(buf, "fmt ", 4) != 0) {
 		warning("getWavInfo: No 'fmt' header");
 		return false;


### PR DESCRIPTION
WAV files could contain a JUNK chunk for padding, that should be skipped when reading the header
instead of failing to find to 'fmt' chunk.

This is common in recent AGS games.

Reference here https://www.daubnet.com/en/file-format-riff
A similar issue https://github.com/tensorflow/tensorflow/issues/26247

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
