### PR TITLE
SAGA: Fix use-after-free on handling actor action

### DIFF
--- a/engines/saga/actor_walk.cpp
+++ b/engines/saga/actor_walk.cpp
@@ -192,6 +192,7 @@ void Actor::updateActorsScene(int actorsEntrance) {
 	_protagonist = nullptr;
 
 	for (ActorDataArray::iterator actor = _actors.begin(); actor != _actors.end(); ++actor) {
+		actor->_lastZone = nullptr;
 		actor->_inScene = false;
 		actor->_spriteList.clear();
 		if ((actor->_flags & (kProtagonist | kFollower)) || (actor->_index == 0)) {


### PR DESCRIPTION
On switching scenes:
Reset _actor->_lastZone in Actor::updateActorsScene().

Actors can store a pointer to a HitZone in _lastZone (see Actor::handleActions()).

The HitZone pointed to is held by ObjectMap vm->_scene->_objectMap in array _hitZoneList.

When changing scenes the array elements are cleared via ObjectMap::clear() and _lastZone can become stale since only some code paths reset it (e.g. Actor::takeExit()).

The stale pointer is then passed to Actor::stepZoneAction() from Actor::handleActions() and dereferenced.

Fixes [#13661](https://bugs.scummvm.org/ticket/13661)

Thanks to @dwatteau for building and testing on OSX PPC.