### PR TITLE
DIRECTOR: Cast: search for xlib

### DIFF
--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -541,6 +541,16 @@ void Cast::loadCast() {
 		delete r;
 	}
 
+
+	if (_castArchive->hasResource(MKTAG('X', 'C', 'O', 'D'), -1)) {
+		Common::Array<uint16> xcod = _castArchive->getResourceIDList(MKTAG('X', 'C', 'O', 'D'));
+		for (Common::Array<uint16>::iterator iterator = xcod.begin(); iterator != xcod.end(); ++iterator) {
+			Resource res = _castArchive->getResourceDetail(MKTAG('X', 'C', 'O', 'D'), *iterator);
+			debug(0, "Detected XObject '%s'", res.name.c_str());
+			g_lingo->openXLib(res.name, kXObj);
+		}
+	}
+
 	Common::Array<uint16> cinf = _castArchive->getResourceIDList(MKTAG('C', 'i', 'n', 'f'));
 	if (cinf.size() > 0) {
 		debugC(2, kDebugLoading, "****** Loading %d CastLibInfos Cinf", cinf.size());


### PR DESCRIPTION
According to the manual, in addition to separate files, xlibs can be loaded from the shared cast:
 
![Manual's description of where xlibs can be loaded](https://cdn.discordapp.com/attachments/636495083935629325/1108998244912087040/image.png)

However, right now ScummVM only does this search in `probeMacBinary`, which doesn't get called on this resource in this context.

Adding this ensures that the shared cast's xlibs get enabled. Fixes recognizing Journey to the Source's (journey2source, Mac) custom xlib. I have a separate branch where I'm implementing that custom xlib, but I'm opening this as a PR first to make sure everything looks OK for this change on the buildbot.