### PR TITLE
DIRECTOR: Add multiple resources in exe using ProjectorArchive

### DIFF
--- a/engines/director/archive.h
+++ b/engines/director/archive.h
@@ -149,6 +149,36 @@ protected:
 	Common::HashMap<uint32, KeyMap> _keyData;
 };
 
+/*******************************************
+ *
+ * Projector Archive
+ *
+ *******************************************/
+
+class ProjectorArchive : public Common::Archive {
+public:
+	ProjectorArchive(Common::String path);
+	~ProjectorArchive() override;
+
+	bool hasFile(const Common::Path &path) const override;
+	int listMembers(Common::ArchiveMemberList &list) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
+	bool isLoaded() { return _isLoaded; }
+private:
+	Common::SeekableReadStream *createBufferedReadStream();
+	bool loadArchive(Common::SeekableReadStream *stream);
+
+	struct Entry {
+		uint32 offset;
+		uint32 size;
+	};
+	typedef Common::HashMap<Common::String, Entry, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> FileMap;
+	FileMap _files;
+	Common::String _path;
+
+	bool _isLoaded;
+};
 } // End of namespace Director
 
 #endif

--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -290,12 +290,17 @@ Common::CodePage DirectorEngine::getPlatformEncoding() {
 	return getEncoding(getPlatform(), getLanguage());
 }
 
+Common::String DirectorEngine::getRawEXEName() const {
+	// Returns raw executable name (without getting overloaded from --start-movie option)
+	return Common::punycode_decodefilename(Common::lastPathComponent(_gameDescription->desc.filesDescriptions[0].fileName, '/'));
+}
+
 Common::String DirectorEngine::getEXEName() const {
 	StartMovie startMovie = getStartMovie();
 	if (startMovie.startMovie.size() > 0)
 		return startMovie.startMovie;
 
-	return Common::punycode_decodefilename(Common::lastPathComponent(_gameDescription->desc.filesDescriptions[0].fileName, '/'));
+	return getRawEXEName();
 }
 
 void DirectorEngine::parseOptions() {

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -159,6 +159,7 @@ public:
 	Common::Language getLanguage() const;
 	Common::String getTargetName() { return _targetName; }
 	const char *getExtra();
+	Common::String getRawEXEName() const;
 	Common::String getEXEName() const;
 	StartMovie getStartMovie() const;
 	void parseOptions();

--- a/engines/director/resource.cpp
+++ b/engines/director/resource.cpp
@@ -559,7 +559,7 @@ Common::SeekableReadStream *ProjectorArchive::createBufferedReadStream() {
 	if (!stream)
 		error("ProjectorArchive::createBufferedReadStream(): Cannot open %s", _path.c_str());
 
-	return Common::wrapBufferedSeekableReadStream(stream, READ_BUFFER_SIZE, DisposeAfterUse::NO);
+	return Common::wrapBufferedSeekableReadStream(stream, READ_BUFFER_SIZE, DisposeAfterUse::YES);
 }
 
 ProjectorArchive::~ProjectorArchive() {

--- a/engines/director/resource.cpp
+++ b/engines/director/resource.cpp
@@ -545,6 +545,10 @@ ProjectorArchive::ProjectorArchive(Common::String path)
 
 	// Buffer 100K into memory
 	Common::SeekableReadStream *stream = createBufferedReadStream();
+	if (!stream) {
+		_isLoaded = false;
+		return;
+	}
 
 	// Build our filemap using the buffered stream
 	_isLoaded = loadArchive(stream);
@@ -556,8 +560,10 @@ Common::SeekableReadStream *ProjectorArchive::createBufferedReadStream() {
 	const uint32 READ_BUFFER_SIZE = 1024 * 100;
 
 	Common::SeekableReadStream *stream = SearchMan.createReadStreamForMember(_path);
-	if (!stream)
-		error("ProjectorArchive::createBufferedReadStream(): Cannot open %s", _path.c_str());
+	if (!stream) {
+		warning("ProjectorArchive::createBufferedReadStream(): Cannot open %s", _path.c_str());
+		return nullptr;
+	}
 
 	return Common::wrapBufferedSeekableReadStream(stream, READ_BUFFER_SIZE, DisposeAfterUse::YES);
 }


### PR DESCRIPTION
1. Moved ProjectorArchive declaration to archive.h
2. getRawExeName to get executable file name without overriding from --start-movie parameter
3. Used multiarchive to detect and add resource files to searchman