### PR TITLE
COMMON: Add Bulgarian language code

### DIFF
--- a/common/language.cpp
+++ b/common/language.cpp
@@ -54,6 +54,7 @@ namespace Common {
 
 const LanguageDescription g_languages[] = {
 	{ "ar",    "ar", "Arabic", AR_ARB }, // Modern Standard Arabic
+	{ "bg", "bg_BG", "Bulgarian", BG_BUL },
 	{ "ca", "ca_ES", "Catalan", CA_ESP },
 	{ "zh",    "zh", "Chinese", ZH_ANY }, // Generic Chinese (when only one game version exist)
 	{ "cn", "zh_CN", "Chinese (Simplified)", ZH_CHN },

--- a/common/language.h
+++ b/common/language.h
@@ -44,6 +44,7 @@ class String;
  */
 enum Language : int8 {
 	AR_ARB,
+	BG_BUL,
 	CA_ESP,
 	CS_CZE,
 	DA_DNK,

--- a/dists/scummvm.6
+++ b/dists/scummvm.6
@@ -112,6 +112,8 @@ Select game's language:
 .\" From common/language.cpp, sorted by English name of language
 .It Ar ar
 Arabic (Modern Standard)
+.It Ar bg
+Bulgarian
 .It Ar ca
 Catalan
 .It Ar zh


### PR DESCRIPTION
Need this to allow the language to be set to Bulgarian for the Schizm: Mysterious Journey Steam release.