### PR TITLE
SCUMM: Fix some V2-3 Amiga Player timing issues

### DIFF
--- a/engines/scumm/players/player_mod.cpp
+++ b/engines/scumm/players/player_mod.cpp
@@ -177,7 +177,7 @@ void Player_MOD::do_mix(int16 *data, uint len) {
 				_mixpos = 0;
 				len -= dlen;
 			} else {
-				_mixpos = len;
+				_mixpos += len;
 				dlen = len;
 				len = 0;
 			}

--- a/engines/scumm/players/player_v2a.cpp
+++ b/engines/scumm/players/player_v2a.cpp
@@ -1858,7 +1858,7 @@ Player_V2A::Player_V2A(ScummEngine *scumm, Audio::Mixer *mixer) {
 	}
 
 	_mod = new Player_MOD(mixer);
-	_mod->setUpdateProc(update_proc, this, 60);
+	_mod->setUpdateProc(update_proc, this, _vm->getTimerFrequency() / 4);
 }
 
 Player_V2A::~Player_V2A() {

--- a/engines/scumm/players/player_v3a.cpp
+++ b/engines/scumm/players/player_v3a.cpp
@@ -27,7 +27,7 @@
 namespace Scumm {
 
 Player_V3A::Player_V3A(ScummEngine *scumm, Audio::Mixer *mixer)
-	: Paula(true, mixer->getOutputRate(), mixer->getOutputRate() / 60),
+	: Paula(true, mixer->getOutputRate(), mixer->getOutputRate() / (scumm->getTimerFrequency() / 4)),
 	  _vm(scumm),
 	  _mixer(mixer),
 	  _soundHandle(),


### PR DESCRIPTION
This fixes bug [#14470](https://bugs.scummvm.org/ticket/14470) with a fix provided by athrxx and also put a sort of safeguard in place for when I'll have a bit of time to implement a 50Hz mode for Amiga SCUMM games (which has already been requested a few times). 

Posting it as a PR: while this fix (again, courtesy of athrxx) is certainly logical, I haven't tampered with this part of the codebase enough to directly commit the change to master. The bug was originally introduced here 104b39ef67e4e1ddcf5e6124b8a0844a7062346a when trying to fix another bug which caused music to be playing too fast.

As for the second and third commits, which are pretty straightforward, I report here the commit message:

> (Since the previous commit fixes something that was historically
put in place to fix a player speed issue, it seemed fair to dig into
how the player speed worked.)

> This removes a magic number (60) when specifying the frequency
at which the player should operate. The rationale behind this is that
at some point there's going to be a 50Hz mode for Amiga SCUMM
games (it has already been requested a few times...) and by using
the actual speed at which the SCUMM system operates, the audio
will operate at the correct rate (veryfied by manually switching speed
to 50Hz and comparing with a Maniac Mansion Amiga recording).