### PR TITLE
VIDEO: Add YUV422 and YUV444 to Theora decoder

### DIFF
--- a/graphics/yuv_to_rgb.h
+++ b/graphics/yuv_to_rgb.h
@@ -69,6 +69,21 @@ public:
 	void convert444(Graphics::Surface *dst, LuminanceScale scale, const byte *ySrc, const byte *uSrc, const byte *vSrc, int yWidth, int yHeight, int yPitch, int uvPitch);
 
 	/**
+	 * Convert a YUV422 image to an RGB surface
+	 *
+	 * @param dst     the destination surface
+	 * @param scale   the scale of the luminance values
+	 * @param ySrc    the source of the y component
+	 * @param uSrc    the source of the u component
+	 * @param vSrc    the source of the v component
+	 * @param yWidth  the width of the y surface (must be divisible by 2)
+	 * @param yHeight the height of the y surface
+	 * @param yPitch  the pitch of the y surface
+	 * @param uvPitch the pitch of the u and v surfaces
+	 */
+	void convert422(Graphics::Surface *dst, LuminanceScale scale, const byte *ySrc, const byte *uSrc, const byte *vSrc, int yWidth, int yHeight, int yPitch, int uvPitch);
+
+	/**
 	 * Convert a YUV420 image to an RGB surface
 	 *
 	 * @param dst     the destination surface

--- a/video/theora_decoder.h
+++ b/video/theora_decoder.h
@@ -112,6 +112,7 @@ private:
 		uint16 _surfaceHeight;
 
 		th_dec_ctx *_theoraDecode;
+		th_pixel_fmt _theoraPixelFormat;
 
 		void translateYUVtoRGBA(th_ycbcr_buffer &YUVBuffer);
 	};


### PR DESCRIPTION
This PR adds support for YUV422 and YUV444 Theora video decoding.
Most code was already implemented in yuv_to_rgb.cpp, so the changes are minor.

Format 422 is required to play one of the introductory movies in Downfall Redux. I also tested YUV444 using a sample movie.
Other less common formats (such as 411) are not implemented.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
