### PR TITLE
COMMON: BUILD: Try detecting UBSan when not using configure

### DIFF
--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -262,6 +262,14 @@
 //
 #if !defined(HAVE_CONFIG_H)
 
+	// If -fsanitize=undefined or -fsanitize=alignment is in use, and the
+	// compiler happens to report it, make sure SCUMM_NEED_ALIGNMENT is
+	// defined, in order to avoid false positives when not using the
+	// "configure" script to enable UBSan.
+	#if __has_feature(undefined_behavior_sanitizer)
+		#define SCUMM_NEED_ALIGNMENT
+	#endif
+
 	#if defined(__DC__) || \
 		  defined(__DS__) || \
 		  defined(__3DS__) || \


### PR DESCRIPTION
Newer versions of Clang can tell us when UBSan has been enabled, which is useful to define `SCUMM_NEED_ALIGNMENT` when `-fsanitize=alignment` is in use (see https://reviews.llvm.org/D52386).

Can be useful to avoid some false positives about alignment when doing a build with UBSan but without using the `configure` script which already tries to detect this setting (see earlier PR #4208). NetBSD does a similar thing, it seems.

A good example is building and running a v7/v8 SCUMM game, through an Xcode build where UBSan is enabled through its UI (Product > Scheme > Edit Scheme… > Diagnostics > Undefined Behavior Sanitizer).