### PR TITLE
BACKENDS: OPENGL: Clear screen using opaque black instead of transparent

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -1360,8 +1360,8 @@ void OpenGLGraphicsManager::notifyContextCreate(ContextType type,
 
 	// Setup backbuffer state.
 
-	// Default to black as clear color.
-	_backBuffer.setClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+	// Default to opaque black as clear color.
+	_backBuffer.setClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 
 	_pipeline->setFramebuffer(&_backBuffer);
 

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -969,7 +969,7 @@ void AndroidGraphics3dManager::clearScreen(FixupType type, byte count) {
 
 	for (byte i = 0; i < count; ++i) {
 		// clear screen
-		GLCALL(glClearColor(0, 0, 0, 1 << 16));
+		GLCALL(glClearColor(0.f, 0.f, 0.f, 1.f));
 		GLCALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT));
 
 		switch (type) {


### PR DESCRIPTION
This looks like an overlook since the creation of the backend.
Previous Android backend used this and it shouldn't harm other
platforms.
This should fix a bug on ChromeOS.

In addition a small fix on Android3D is done.