### PR TITLE
HDB: Fix double-free on voice playback

### DIFF
--- a/engines/hdb/sound.cpp
+++ b/engines/hdb/sound.cpp
@@ -1634,7 +1634,6 @@ void Sound::playVoice(int index, int actor) {
 #ifdef USE_VORBIS
 		Audio::AudioStream *audioStream = Audio::makeVorbisStream(stream, DisposeAfterUse::YES);
 		if (audioStream == nullptr) {
-			delete stream;
 			return;
 		}
 
@@ -1654,7 +1653,6 @@ void Sound::playVoice(int index, int actor) {
 #ifdef USE_MAD
 		Audio::AudioStream *audioStream = Audio::makeMP3Stream(stream, DisposeAfterUse::YES);
 		if (audioStream == nullptr) {
-			delete stream;
 			return;
 		}
 


### PR DESCRIPTION
Sound::playVoice():
Do not delete source stream on failed MP3/Vorbis decoding. This is already handled by the created Audio::MP3Stream/VorbisStream.

Possibly fixes [#14478](https://bugs.scummvm.org/ticket/14478)