### PR TITLE
AGS: Add stubs for ags_spritevideo plugin

### DIFF
--- a/engines/ags/module.mk
+++ b/engines/ags/module.mk
@@ -349,6 +349,7 @@ MODULE_OBJS = \
 	plugins/ags_sprite_font/variable_width_font.o \
 	plugins/ags_sprite_font/variable_width_sprite_font.o \
 	plugins/ags_sprite_font/variable_width_sprite_font_clifftop.o \
+	plugins/ags_sprite_video/ags_sprite_video.o \
 	plugins/ags_shell/ags_shell.o \
 	plugins/ags_tcp_ip/ags_tcp_ip.o \
 	plugins/ags_touch/ags_touch.o \

--- a/engines/ags/plugins/ags_sprite_video/ags_sprite_video.cpp
+++ b/engines/ags/plugins/ags_sprite_video/ags_sprite_video.cpp
@@ -1,0 +1,174 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * of the License, or(at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ags/plugins/ags_sprite_video/ags_sprite_video.h"
+#include "common/debug.h"
+
+namespace AGS3 {
+namespace Plugins {
+namespace AGSSpriteVideo {
+
+const char *AGSSpriteVideo::AGS_GetPluginName() {
+	return "AGS SpriteVideo Plugin";
+}
+
+int LoopsPerSecond;
+char video_filename[200];
+
+struct D3D : public IAGSScriptManagedObject {
+public:
+	int Dispose(const char *address, bool force) override {
+		delete this;
+		return true;
+	}
+	const char *GetType() override {
+		return "D3D";
+	};
+	int Serialize(const char *address, char *buffer, int bufsize) override {
+		return 0;
+	}
+};
+
+struct D3DVideo : public IAGSScriptManagedObject {
+public:
+	int Dispose(const char *address, bool force) override {
+		delete this;
+		return true;
+	}
+	const char *GetType() override {
+		return "D3DVideo";
+	};
+	int Serialize(const char *address, char *buffer, int bufsize) override {
+		return 0;
+	}
+};
+
+void AGSSpriteVideo::AGS_EngineStartup(IAGSEngine *engine) {
+	PluginBase::AGS_EngineStartup(engine);
+
+	SCRIPT_METHOD(D3D::SetLoopsPerSecond^1, AGSSpriteVideo::SetLoopsPerSecond);
+	SCRIPT_METHOD(D3D::OpenVideo^1, AGSSpriteVideo::OpenVideo);
+	SCRIPT_METHOD(D3D::OpenSprite, AGSSpriteVideo::OpenSprite);
+	SCRIPT_METHOD(D3D::OpenSpriteFile, AGSSpriteVideo::OpenSpriteFile);
+
+	SCRIPT_METHOD(D3D_Video::get_scaling, AGSSpriteVideo::get_scaling);
+	SCRIPT_METHOD(D3D_Video::set_scaling, AGSSpriteVideo::set_scaling);
+	SCRIPT_METHOD(D3D_Video::get_relativeTo, AGSSpriteVideo::get_relativeTo);
+	SCRIPT_METHOD(D3D_Video::set_relativeTo, AGSSpriteVideo::set_relativeTo);
+	SCRIPT_METHOD(D3D_Video::get_isLooping, AGSSpriteVideo::get_isLooping);
+	SCRIPT_METHOD(D3D_Video::set_isLooping, AGSSpriteVideo::set_isLooping);
+	SCRIPT_METHOD(D3D_Video::SetAnchor^2, AGSSpriteVideo::SetAnchor);
+	SCRIPT_METHOD(D3D_Video::Autoplay^0, AGSSpriteVideo::Autoplay);
+	SCRIPT_METHOD(D3D_Video::IsAutoplaying, AGSSpriteVideo::IsAutoplaying);
+	SCRIPT_METHOD(D3D_Video::StopAutoplay, AGSSpriteVideo::StopAutoplay);
+}
+
+void AGSSpriteVideo::SetLoopsPerSecond(ScriptMethodParams &params) {
+	PARAMS1(int, loops);
+
+	debug(0, "AGSSpriteVideo: STUB - D3D SetLoopsPerSecond: %d", loops);
+	LoopsPerSecond = loops;
+}
+
+void AGSSpriteVideo::OpenVideo(ScriptMethodParams &params) {
+	PARAMS1(char *, filename);
+
+	debug(0, "AGSSpriteVideo: STUB - D3D OpenVideo: %s", filename);
+	D3DVideo *video = new D3DVideo();
+	_engine->RegisterManagedObject(video, video);
+	strncpy(video_filename, filename, sizeof(video_filename) - 1);
+	LoopsPerSecond = 40;
+
+	params._result = video;
+}
+
+void AGSSpriteVideo::OpenSprite(ScriptMethodParams &params) {
+	// PARAMS1(int, graphic);
+
+	debug(0, "AGSSpriteVideo: STUB - D3D OpenSprite");
+	params._result = 0;
+}
+
+void AGSSpriteVideo::OpenSpriteFile(ScriptMethodParams &params) {
+	// PARAMS2(char *, filename, int, filtering);
+
+	debug(0, "AGSSpriteVideo: STUB - D3D OpenSpriteFile");
+	params._result = 0;
+}
+
+void AGSSpriteVideo::get_scaling(ScriptMethodParams &params) {
+	debug(0, "AGSSpriteVideo: STUB - D3DVideo get_scaling");
+	params._result = 1;
+}
+
+void AGSSpriteVideo::set_scaling(ScriptMethodParams &params) {
+	// PARAMS1(float, scaling);
+
+	debug(0, "AGSSpriteVideo: STUB - D3DVideo set_scaling");
+}
+
+void AGSSpriteVideo::get_relativeTo(ScriptMethodParams &params) {
+	debug(0, "AGSSpriteVideo: STUB - D3DVideo get_relativeTo");
+	params._result = 1;
+}
+
+void AGSSpriteVideo::set_relativeTo(ScriptMethodParams &params) {
+	// PARAMS1(int, relative_to);
+
+	debug(0, "AGSSpriteVideo: STUB - D3DVideo set_relativeTo");
+}
+
+void AGSSpriteVideo::get_isLooping(ScriptMethodParams &params) {
+	debug(0, "AGSSpriteVideo: STUB - D3DVideo get_isLooping");
+	params._result = false;
+}
+
+void AGSSpriteVideo::set_isLooping(ScriptMethodParams &params) {
+	// PARAMS1(bool, looping);
+
+	debug(0, "AGSSpriteVideo: STUB - D3DVideo set_isLooping");
+}
+
+void AGSSpriteVideo::SetAnchor(ScriptMethodParams &params) {
+	// PARAMS2(float, x, float, y);
+
+	debug(0, "AGSSpriteVideo: STUB - D3DVideo SetAnchor");
+}
+
+void AGSSpriteVideo::Autoplay(ScriptMethodParams &params) {
+
+	debug(0, "AGSSpriteVideo: STUB - D3DVideo Autoplay");
+	warning("Current video: %s", video_filename);
+	warning("Video playback is not yet implemented");
+}
+
+void AGSSpriteVideo::IsAutoplaying(ScriptMethodParams &params) {
+	debug(0, "AGSSpriteVideo: STUB - D3D IsAutoPlaying");
+	params._result = false;
+}
+
+void AGSSpriteVideo::StopAutoplay(ScriptMethodParams &params) {
+	debug(0, "AGSSpriteVideo: STUB - D3D StopAutoplay");
+}
+
+} // namespace AGSSpriteVideo
+} // namespace Plugins
+} // namespace AGS3

--- a/engines/ags/plugins/ags_sprite_video/ags_sprite_video.h
+++ b/engines/ags/plugins/ags_sprite_video/ags_sprite_video.h
@@ -1,0 +1,64 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * of the License, or(at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef AGS_PLUGINS_AGS_SPRITE_VIDEO_H
+#define AGS_PLUGINS_AGS_SPRITE_VIDEO_H
+
+#include "ags/plugins/ags_plugin.h"
+
+namespace AGS3 {
+namespace Plugins {
+namespace AGSSpriteVideo {
+
+class AGSSpriteVideo : public PluginBase {
+	SCRIPT_HASH(AGSSpriteVideo)
+protected:
+	void SetLoopsPerSecond(ScriptMethodParams &params);
+	void OpenVideo(ScriptMethodParams &params);
+	void OpenSprite(ScriptMethodParams &params);
+	void OpenSpriteFile(ScriptMethodParams &params);
+
+	void get_scaling(ScriptMethodParams &params);
+	void set_scaling(ScriptMethodParams &params);
+	void get_relativeTo(ScriptMethodParams &params);
+	void set_relativeTo(ScriptMethodParams &params);
+	void get_isLooping(ScriptMethodParams &params);
+	void set_isLooping(ScriptMethodParams &params);
+	void SetAnchor(ScriptMethodParams &params);
+	void Autoplay(ScriptMethodParams &params);
+	void IsAutoplaying(ScriptMethodParams &params);
+	void StopAutoplay(ScriptMethodParams &params);
+
+
+public:
+	AGSSpriteVideo() : PluginBase() {}
+	virtual ~AGSSpriteVideo() {}
+
+	const char *AGS_GetPluginName() override;
+	void AGS_EngineStartup(IAGSEngine *engine) override;
+};
+
+
+} // namespace AGSSpriteVideo
+} // namespace Plugins
+} // namespace AGS3
+
+#endif

--- a/engines/ags/plugins/plugin_base.cpp
+++ b/engines/ags/plugins/plugin_base.cpp
@@ -42,6 +42,7 @@
 #include "ags/plugins/ags_sock/ags_sock.h"
 #include "ags/plugins/ags_sprite_font/ags_sprite_font.h"
 #include "ags/plugins/ags_sprite_font/ags_sprite_font_clifftop.h"
+#include "ags/plugins/ags_sprite_video/ags_sprite_video.h"
 #include "ags/plugins/ags_tcp_ip/ags_tcp_ip.h"
 #include "ags/plugins/ags_touch/ags_touch.h"
 #include "ags/plugins/ags_trans/ags_trans.h"
@@ -93,6 +94,9 @@ Plugins::PluginBase *pluginOpen(const char *filename) {
 
 	if (fname.equalsIgnoreCase("agsCreditz2"))
 		return new AGSCreditz::AGSCreditz2();
+
+	if (fname.equalsIgnoreCase("ags_d3d") || fname.equalsIgnoreCase("ags_spritevideo"))
+		return new AGSSpriteVideo::AGSSpriteVideo();
 
 	if (fname.equalsIgnoreCase("AGS_Fire"))
 		return new AGSFire::AGSFire();


### PR DESCRIPTION
This PR adds stubs for the ags_spritevideo plugin, which is a dropin replacement for the old D3D plugin.
The D3D plugin was used in Chronicle of Innsmouth - Mountains of Madness to play some "videos" which are
still images with little animation, used mostly during the intro and the final part of the game.

With the stubs in place the game is playable (not yet confirmed as completable)



<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
