### PR TITLE
MM: MM1: Fix portrait validation

### DIFF
--- a/engines/mm/mm1/data/character.cpp
+++ b/engines/mm/mm1/data/character.cpp
@@ -232,8 +232,8 @@ void Character::synchronize(Common::Serializer &s, int portraitNum) {
 	if (s.isLoading()) {
 		if (portraitNum != -1)
 			_portrait = portraitNum;
-		else if (portraitNum >= NUM_PORTRAITS)
-			// Ensure only valid portrait numbers are specified
+		if (_portrait >= NUM_PORTRAITS)
+			// Ensure portrait number is valid
 			_portrait = 0;
 	}
 


### PR DESCRIPTION
This assumes the intention was to guard against both: invalid portrait numbers passed in portraitNum and also invalid values loaded from the save.

@dreammaster Is this correct?