### PR TITLE
COMMON: Move Gentee Installer loader from V-Cruise to Common

### DIFF
--- a/common/compression/gentee_installer.cpp
+++ b/common/compression/gentee_installer.cpp
@@ -37,9 +37,12 @@ struct HuffmanTreeNode {
 	HuffmanTreeNode *_parent;
 	HuffmanTreeNode *_children[2];
 
-	// NOTE: This must be signed! The decoder is buggy and can produce negative frequency values because
-	// the normalization algorithm is broken (it halves all frequency counts, which causes parent nodes to
-	// desync if both child frequencies are odd) which can cause frequencies to become negative.
+	// NOTE: This must be signed! The decoder uses a broken normalization algorithm which halves all frequency
+	// counts (instead of only halving leaf counts and recomputing parent nodes), which causes parent nodes
+	// to desync if both children have odd frequencies.  This can cause the rebalancing algorithm to assign
+	// negative numbers to frequencies, which in turn affects other comparisons through the decoder.
+	//
+	// We need to accurately replicate this bug to get the correct decode behavior.
 	int32 _freq;
 
 	uint16 _symbol;

--- a/common/compression/gentee_installer.cpp
+++ b/common/compression/gentee_installer.cpp
@@ -25,9 +25,9 @@
 #include "common/bufferedstream.h"
 #include "common/substream.h"
 
-#include "vcruise/gentee_installer.h"
+#include "common/compression/gentee_installer.h"
 
-namespace VCruise {
+namespace Common {
 
 namespace GenteeInstaller {
 
@@ -931,4 +931,4 @@ Common::Archive *createGenteeInstallerArchive(Common::SeekableReadStream *stream
 	return archive;
 }
 
-} // End of namespace VCruise
+} // End of namespace Common

--- a/common/compression/gentee_installer.h
+++ b/common/compression/gentee_installer.h
@@ -24,27 +24,39 @@
 
 #include "common/archive.h"
 
+/**
+ * @file
+ * Gentee Installer decompressor used in engines:
+ *  - vcruise
+ */
+
 namespace Common {
 
-// NOTE for future implementation:
-// A Gentee Installer setup executable can be deployed with a package file (pak1.pak, etc.) or the
-// data can be embedded in the setup executable.  If it's deployed with the executable, then you
-// must read 12 bytes from offset 1008 in the executable file.  Of that, the first 4 bytes is the
-// position of the embedded ginstall.dll compressed data, the next 4 are the compressed size of
-// ginstall.dll, and the next 4 are the decompressed size of ginstall.dll.
-//
-// From that, compute the end position of the DLL data from the DLL position + the compressed size.
-// If that position is less than the end of the file, then the package is embedded in the setup
-// executable starting at that location.
+/** NOTE for future implementation:
+ * A Gentee Installer setup executable can be deployed with a package file (disk1.pak, etc.) or the
+ * data can be embedded in the setup executable.  If it's deployed with the executable, then you
+ * must read 12 bytes from offset 1008 in the executable file.  Of that, the first 4 bytes is the
+ * position of the embedded ginstall.dll compressed data, the next 4 are the compressed size of
+ * ginstall.dll, and the next 4 are the decompressed size of ginstall.dll.
+ *
+ * From that, compute the end position of the DLL data from the DLL position + the compressed size.
+ * If that position is less than the end of the file, then the package is embedded in the setup
+ * executable starting at that location.
+ */
+
 
 /**
  * Loads a Gentee Installer package.
  *
+ * This product appears to have been renamed to CreateInstall in later versions, which also adopted
+ * other compression methods like PPMd.  This version uses LZ77 with adaptive Huffman coding.
+ *
  * @param stream          Data stream to load
  * @param prefixToRemove  Specifies the prefix of extract directives to include, and removes the prefix
+ *                        If you pass an empty string or null, all directives will be included
  * @param threadSafe      If true, all read operations will be wrapped in a mutex-guarded substream
  *
- * @return The number of members added to list.
+ * @return                The Gentee Installer package archive
  */
 Common::Archive *createGenteeInstallerArchive(Common::SeekableReadStream *stream, const char *prefixToRemove, bool threadSafe);
 

--- a/common/compression/gentee_installer.h
+++ b/common/compression/gentee_installer.h
@@ -19,12 +19,12 @@
  *
  */
 
-#ifndef VCRUISE_GENTEEINSTALLER_H
-#define VCRUISE_GENTEEINSTALLER_H
+#ifndef COMMON_GENTEE_INSTALLER_H
+#define COMMON_GENTEE_INSTALLER_H
 
 #include "common/archive.h"
 
-namespace VCruise {
+namespace Common {
 
 // NOTE for future implementation:
 // A Gentee Installer setup executable can be deployed with a package file (pak1.pak, etc.) or the
@@ -48,6 +48,6 @@ namespace VCruise {
  */
 Common::Archive *createGenteeInstallerArchive(Common::SeekableReadStream *stream, const char *prefixToRemove, bool threadSafe);
 
-} // End of namespace VCruise
+} // End of namespace Common
 
 #endif

--- a/common/compression/module.mk
+++ b/common/compression/module.mk
@@ -3,6 +3,7 @@ MODULE := common/compression
 MODULE_OBJS := \
 	clickteam.o \
 	dcl.o \
+	gentee_installer.o \
 	gzio.o \
 	installshield_cab.o \
 	installshieldv3_archive.o \

--- a/engines/vcruise/module.mk
+++ b/engines/vcruise/module.mk
@@ -3,7 +3,6 @@ MODULE := engines/vcruise
 MODULE_OBJS = \
 	audio_player.o \
 	circuitpuzzle.o \
-	gentee_installer.o \
 	metaengine.o \
 	menu.o \
 	runtime.o \

--- a/engines/vcruise/vcruise.cpp
+++ b/engines/vcruise/vcruise.cpp
@@ -21,6 +21,8 @@
 
 #include "engines/util.h"
 
+#include "common/compression/gentee_installer.h"
+
 #include "common/config-manager.h"
 #include "common/events.h"
 #include "common/file.h"
@@ -36,7 +38,6 @@
 
 #include "vcruise/runtime.h"
 #include "vcruise/vcruise.h"
-#include "vcruise/gentee_installer.h"
 
 namespace VCruise {
 
@@ -109,7 +110,7 @@ Common::Error VCruiseEngine::run() {
 		if (!f->open(_gameDescription->desc.filesDescriptions[0].fileName))
 			error("Couldn't open installer package '%s'", _gameDescription->desc.filesDescriptions[0].fileName);
 
-		Common::Archive *installerPackageArchive = createGenteeInstallerArchive(f, "#setuppath#\\", true);
+		Common::Archive *installerPackageArchive = Common::createGenteeInstallerArchive(f, "#setuppath#\\", true);
 		if (!installerPackageArchive)
 			error("Couldn't load installer package '%s'", _gameDescription->desc.filesDescriptions[0].fileName);
 


### PR DESCRIPTION
Adds support for Gentee Installer packages.  This has already been tested against the German and Polish versions of Schizm and appears to work OK.