### PR TITLE
GUI: Don't parse all available engines and games on startup

### DIFF
--- a/gui/launcher.h
+++ b/gui/launcher.h
@@ -28,6 +28,8 @@
 #endif
 #define kSwitchLauncherDialog -2
 
+#include "common/hashmap.h"
+
 #include "gui/dialog.h"
 #include "gui/widgets/popup.h"
 #include "gui/MetadataParser.h"
@@ -86,11 +88,24 @@ class StaticTextWidget;
 class EditTextWidget;
 class SaveLoadChooser;
 class PopUpWidget;
-class LauncherChooser;
+
+struct LauncherEntry {
+	Common::String key;
+	Common::String engineid;
+	Common::String gameid;
+	Common::String description;
+	Common::String title;
+	const Common::ConfigManager::Domain *domain;
+
+	LauncherEntry(const Common::String &k, const Common::String &e, const Common::String &g,
+				  const Common::String &d, const Common::String &t, const Common::ConfigManager::Domain *v) :
+		key(k), engineid(e), gameid(g), description(d), title(t), domain(v) {
+	}
+};
 
 class LauncherDialog : public Dialog {
 public:
-	LauncherDialog(const Common::String &dialogName, LauncherChooser *chooser);
+	LauncherDialog(const Common::String &dialogName);
 	~LauncherDialog() override;
 
 	void rebuild();
@@ -129,7 +144,6 @@ protected:
 	Common::String	_title;
 	Common::String	_search;
 	MetadataParser	_metadataParser;
-	LauncherChooser *_launcherChooser = nullptr;
 
 #ifndef DISABLE_LAUNCHERDISPLAY_GRID
 	ButtonWidget		*_listButton;
@@ -185,6 +199,8 @@ protected:
 	 */
 	void loadGame(int item);
 
+	Common::Array<LauncherEntry> generateEntries(const Common::ConfigManager::DomainMap &domains);
+
 	/**
 	 * Select the target with the given name in the launcher game list.
 	 * Also scrolls the list so that the newly selected item is visible.
@@ -194,13 +210,14 @@ protected:
 	virtual void selectTarget(const Common::String &target) = 0;
 	virtual int getSelected() = 0;
 private:
+	Common::HashMap<Common::String, Common::StringMap, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> _engines;
+
 	bool checkModifier(int modifier);
 };
 
 class LauncherChooser {
 protected:
 	LauncherDialog *_impl;
-	Common::StringMap _games;
 
 public:
 	LauncherChooser();
@@ -208,11 +225,6 @@ public:
 
 	int runModal();
 	void selectLauncher();
-
-	const Common::StringMap &getGameList() { return _games; }
-
-private:
-	void genGameList();
 };
 
 } // End of namespace GUI


### PR DESCRIPTION
A couple of days ago I decided to take a look at ScummVM startup time. Under normal circumstances there is nothing to observe, even a 100 MHz machine offers a decent startup.

However when running below 100 Mhz (say 32), things go downhill pretty quickly: even if the classic built-in theme is set, it takes 50 seconds (!) to show the good old green launcher. I always assumed it is due to some file I/O but simple profiling has uncovered two offenders:
- `LauncherChooser::genGameList` (about 15 seconds)
- `ThemeEngine::loadTheme` (about 30 seconds)

The former caught my attention as there is nothing special happening, basically just copying strings around. However the issue is that when scummvm is statically linked, there's about 8000 strings to process (all possible variants of `engineid` + `gameid`, disabling engines has no effect here). Even replacing `buildQualifiedGameName` in `genGameList` with `gameid` lead to about 4 seconds speedup so every cycle counted.

After a closer study I have found out that this whole buildup is completely unnecessary. Usually there is a small number of games in `scummvm.ini` so it doesn't make sense to prepare for all 8000 variants to be ready for an immediate use.

So this patch does exactly that -- replaces the generation of all variants with a lazy init, the map is initialised only with `engineid` and `gameid` which are found in a domain. Also it makes the code a bit prettier.

And yes, there's no 15s delay anymore!