### PR TITLE
📊 Add command line option to print statistics  

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -1122,8 +1122,8 @@ static void printStatistics(const Common::String &engineID) {
 	}
 
 	if (!summary)
-		printf("Engine ID        Number of games    Added targets\n"
-		       "--------------- ---------------- ----------------\n");
+		printf("Engine ID        Number of games    Game variants    Added targets\n"
+		       "--------------- ---------------- ---------------- ----------------\n");
 
 	int targetCount = 0;
 	Common::HashMap<Common::String, int> engineTargetCount;
@@ -1147,8 +1147,8 @@ static void printStatistics(const Common::String &engineID) {
 		++targetCount;
 	}
 
-
-	int engineCount = 0, gameCount = 0;
+	bool approximation = false;
+	int engineCount = 0, gameCount = 0, variantCount = 0;
 	const PluginList &plugins = EngineMan.getPlugins();
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
 		const MetaEngineDetection &metaEngine = (*iter)->get<MetaEngineDetection>();
@@ -1156,18 +1156,30 @@ static void printStatistics(const Common::String &engineID) {
 			PlainGameList list = metaEngine.getSupportedGames();
 			++engineCount;
 			gameCount += list.size();
+			int variants = metaEngine.getGameVariantCount();
+			if (variants == -1) {
+				approximation = true;
+				variantCount += list.size();
+			} else
+				variantCount += variants;
 			if (!summary) {
 				int targets = 0;
 				Common::HashMap<Common::String, int>::const_iterator engineIter = engineTargetCount.find(metaEngine.getName());
 				if (engineIter != engineTargetCount.end())
 					targets = engineIter->_value;
-				printf("%-15s %16d %16d\n", metaEngine.getName(), list.size(), targets);
+				if (variants != -1)
+					printf("%-15s %16d %16d %16d\n", metaEngine.getName(), list.size(), variants, targets);
+				else
+					printf("%-15s %16d %16s %16d\n", metaEngine.getName(), list.size(), "?", targets);
 			}
 		}
 	}
 	if (engines.size() != 1) {
-		printf("--------------- ---------------- ----------------\n");
-		printf("Engines: %6d Games: %9d Targets: %7d\n", engineCount, gameCount, targetCount);
+		printf("--------------- ---------------- ---------------- ----------------\n");
+		if (approximation)
+			printf("Engines: %6d Games: %9d Variants: %5d+ Targets: %7d\n", engineCount, gameCount, variantCount, targetCount);
+		else
+			printf("Engines: %6d Games: %9d Variants: %6d Targets: %7d\n", engineCount, gameCount, variantCount, targetCount);
 	}
 }
 

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -91,7 +91,7 @@ static const char HELP_STRING1[] =
 	"  --game=ID                In combination with --add or --detect only adds or attempts to\n"
 	"                           detect the game with id ID.\n"
 	"  --engine=ID              In combination with --list-games, --list-all-games, or --stats only lists\n"
-	"                           games for this engine.\n"
+	"                           games for this engine. Multiple engines can be listed separated by a coma.\n"
 	"  --auto-detect            Display a list of games from current or specified directory\n"
 	"                           and start the first one. Use --path=PATH to specify a directory.\n"
 	"  --recursive              In combination with --add or --detect recurse down all subdirectories\n"
@@ -985,6 +985,11 @@ unknownOption:
 /** List all available game IDs, i.e. all games which any loaded plugin supports. */
 static void listGames(const Common::String &engineID) {
 	const bool all = engineID.empty();
+	Common::StringArray engines;
+	if (!all) {
+		Common::StringTokenizer tokenizer(engineID, ",");
+		engines = tokenizer.split();
+	}
 
 	printf("Game ID                        Full Title                                                 \n"
 	       "------------------------------ -----------------------------------------------------------\n");
@@ -997,7 +1002,7 @@ static void listGames(const Common::String &engineID) {
 			continue;
 		}
 
-		if (all || (p->getName() == engineID)) {
+		if (all || Common::find(engines.begin(), engines.end(), p->getName()) != engines.end()) {
 			PlainGameList list = p->get<MetaEngineDetection>().getSupportedGames();
 			for (PlainGameList::const_iterator v = list.begin(); v != list.end(); ++v) {
 				printf("%-30s %s\n", buildQualifiedGameName(p->get<MetaEngineDetection>().getName(), v->gameId).c_str(), v->description);
@@ -1009,6 +1014,11 @@ static void listGames(const Common::String &engineID) {
 /** List all known game IDs, i.e. all games which can be detected. */
 static void listAllGames(const Common::String &engineID) {
 	const bool any = engineID.empty();
+	Common::StringArray engines;
+	if (!any) {
+		Common::StringTokenizer tokenizer(engineID, ",");
+		engines = tokenizer.split();
+	}
 
 	printf("Game ID                        Full Title                                                 \n"
 	       "------------------------------ -----------------------------------------------------------\n");
@@ -1017,7 +1027,7 @@ static void listAllGames(const Common::String &engineID) {
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
 		const MetaEngineDetection &metaEngine = (*iter)->get<MetaEngineDetection>();
 
-		if (any || (metaEngine.getName() == engineID)) {
+		if (any || Common::find(engines.begin(), engines.end(), metaEngine.getName()) != engines.end()) {
 			PlainGameList list = metaEngine.getSupportedGames();
 			for (PlainGameList::const_iterator v = list.begin(); v != list.end(); ++v) {
 				printf("%-30s %s\n", buildQualifiedGameName(metaEngine.getName(), v->gameId).c_str(), v->description);

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -396,6 +396,13 @@ public:
 
 	uint getMD5Bytes() const override final { return _md5Bytes; }
 
+	int getGameVariantCount() const override final {
+		uint count = 0;
+		for (const byte *descPtr = _gameDescriptors; ((const ADGameDescription *)descPtr)->gameId != nullptr; descPtr += _descItemSize)
+			++count;
+		return count;
+	}
+
 protected:
 	/**
 	 * A hashmap of files and their MD5 checksums.

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -165,6 +165,11 @@ public:
 	/** Returns the number of bytes used for MD5-based detection, or 0 if not supported. */
 	virtual uint getMD5Bytes() const = 0;
 
+	/** Returns the number of game variants or -1 if unknown */
+	virtual int getGameVariantCount() const {
+		return -1;
+	}
+
 	/**
 	 * The default version of this method will just parse the options string from
 	 * the config manager. However it also allows the meta engine to post process

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -88,6 +88,12 @@ public:
 	uint getMD5Bytes() const override {
 		 return 1024 * 1024;
 	}
+	int getGameVariantCount() const override {
+		int entries = 0;
+		for (const GameSettings *g = gameVariantsTable; g->gameid; ++g)
+			++entries;
+		return entries;
+	}
 
 	Common::String parseAndCustomizeGuiOptions(const Common::String &optionsString, const Common::String &domain) const override;
 };

--- a/engines/sky/detection.cpp
+++ b/engines/sky/detection.cpp
@@ -72,6 +72,13 @@ public:
 	uint getMD5Bytes() const override {
 		return 0;
 	}
+
+	int getGameVariantCount() const override {
+		int entries = 0;
+		for (const SkyVersion *sv = skyVersions; sv->dinnerTableEntries; ++sv)
+			++entries;
+		return entries;
+	}
 };
 
 const char *SkyMetaEngineDetection::getEngineName() const {


### PR DESCRIPTION
This adds the `--stats` command line option to print the number of engines, games, game variants, and added targets. This is related to https://bugs.scummvm.org/ticket/13741 that already includes commands to obtain a similar result. But I though an easier way to obtain it would not hurt.

This can be combined with `--engine=` to list statistics for the specified engine. This accepts a list of multiple engines separated by a coma, and the special value `all`.

And while I was at it, I also made separate commits to support specifying multiple engines with `--engine=` for the `--list-games`, `--list-all-games`, and `--list-targets` options as well.

With no engine specified, only a summary is printed:
```
scummvm % ./scummvm --stats                      
--------------- ---------------- ---------------- ----------------
Engines:    102 Games:      8764 Variants:  13070 Targets:     169
```

When specifying one engines, the stats for that engine are printed:
```
scummvm % ./scummvm --stats --engine=ags         
Engine ID        Number of games    Game variants    Added targets
--------------- ---------------- ---------------- ----------------
ags                         3285             4756              113
```

When specifying two or more engines, the stats for those engine as well as the summary are printed:
```
scummvm % ./scummvm --stats --engine=ags,director
Engine ID        Number of games    Game variants    Added targets
--------------- ---------------- ---------------- ----------------
ags                         3285             4756              113
director                    1570             3509                3
--------------- ---------------- ---------------- ----------------
Engines:      2 Games:      4855 Variants:   8265 Targets:     116
```

The special value `all` allows getting the stats for all the engines:
```
scummvm % ./scummvm --stats --engine=all
Engine ID        Number of games    Game variants    Added targets
--------------- ---------------- ---------------- ----------------
scumm                         72              153               11
access                         2                6                0
adl                            7                6                1
agi                           27              398                2
agos                          11              144                1
ags                         3285             4756              113
asylum                         1               21                0
avalanche                      1                1                0
bbvs                           1                5                2
bladerunner                    3               19                0
buried                         1               30                0
cge                            1                9                1
cge2                           1                7                1
chamber                        1                2                0
chewy                          1                5                0
cine                           2               38                0
composer                       9               40                0
cruise                         1               15                0
cryo                           1                7                0
cryomni3d                      2               31                1
director                    1570             3509                3
dm                             1                4                0
draci                          1                4                0
dragons                        1                6                0
drascula                       1               17                1
dreamweb                       1               19                4
efh                            1                2                0
freescape                      6               54                0
glk                         3264                ?                1
gnap                           1                6                0
gob                           36              401                0
griffon                        1                1                1
grim                           2               39                0
groovie                        7               34                0
hadesch                        1                7                0
hdb                            1                8                0
hopkins                        1               12                0
hpl1                           1                2                0
hugo                           3                6                0
hypno                          4               21                0
icb                            2               17                0
illusions                      2                5                0
immortal                       1                1                1
kingdom                        1                3                0
kyra                           6              149                0
lab                            1                4                0
lastexpress                    1                9                0
lilliput                       2                5                0
lure                           1               13                1
macventure                     4               14                0
made                           4               32                0
mads                           4                6                0
mm                             0                0                0
mohawk                        42              219                2
mortevielle                    1                5                0
mtropolis                      7               25                0
mutationofjb                   1                3                0
myst3                          1               33                0
nancy                          7               19                0
neverhood                      1                8                0
ngi                            3                9                0
parallaction                   2                8                0
pegasus                        1                8                0
petka                          2                5                0
pink                           2               28                0
playground3d                   1                1                0
plumbers                       1                2                0
prince                         1                9                1
private                        1               19                0
queen                          1               32                0
saga                           2               61                0
saga2                          2                3                0
sci                           80              603                7
sherlock                       2               18                0
sky                            1               11                1
sludge                        16               40                0
stark                          1               28                1
startrek                       2               16                0
supernova                      2                5                2
sword1                         1               40                1
sword2                         1               29                1
sword25                        1               13                2
teenagent                      1                7                0
testbed                        1                1                1
tetraedge                      3                6                2
tinsel                         3               40                0
titanic                        1                2                0
toltecs                        1               13                0
tony                           1               12                0
toon                           1                8                0
touche                         1                9                0
trecision                      2               17                0
tsage                          5               17                0
tucker                         1                8                0
twine                          3              115                0
ultima                        12               46                2
vcruise                        2               27                0
voyeur                         1                3                0
wage                           9              247                0
watchmaker                     1                1                0
wintermute                   164             1074                0
zvision                        2               14                1
--------------- ---------------- ---------------- ----------------
Engines:    102 Games:      8764 Variants:  13070 Targets:     169
```