### PR TITLE
DIRECTOR: revert changes to openResFile

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1240,13 +1240,19 @@ void LB::b_openDA(int nargs) {
 void LB::b_openResFile(int nargs) {
 	Datum d = g_lingo->pop();
 	Common::String resPath = g_director->getCurrentWindow()->getCurrentPath() + d.asString();
-	resPath = pathMakeRelative(resPath);
+
+	if (g_director->getPlatform() == Common::kPlatformWindows) {
+ 		warning("STUB: BUILDBOT: b_openResFile(%s) on Windows", d.asString().c_str());
+ 		return;
+ 	}
 
 	if (!g_director->_allOpenResFiles.contains(resPath)) {
-		Archive *arch = g_director->openArchive(resPath);
-		if (arch) {
-			// Track responsibility. closeResFile may only close resource files opened by openResFile.
+		MacArchive *arch = new MacArchive();
+		if (arch->openFile(pathMakeRelative(resPath))) {
 			g_director->_openResFiles.setVal(resPath, arch);
+			g_director->_allOpenResFiles.setVal(resPath, arch);
+		} else {
+			delete arch;
 		}
 	}
 }


### PR DESCRIPTION
In 6e47994fc793f122768565185b1d6c6052aca2d9, openResFile was changed to use the new `openArchive` method. However, that method tries to treat the file as a Director archive and it may not be. This broke, for example, loading external cursors via `openResFile`. This reverts to the previous behaviour.

Tested by confirming that mominoki-mac-ja's cursor works again.

cc @moralrecordings 