### PR TITLE
MM: XEEN: workaround for broken canrnage hand animation.

### DIFF
--- a/engines/mm/shared/xeen/sprites.cpp
+++ b/engines/mm/shared/xeen/sprites.cpp
@@ -80,7 +80,7 @@ SpriteResource &SpriteResource::operator=(const SpriteResource &src) {
 void SpriteResource::load(const Common::String &filename) {
 	_filename = filename;
 	Common::File f;
-	if (f.open(filename)) {
+	if (g_engine->getGameID() == GType_MightAndMagic1 && f.open(filename)) {
 		load(f);
 	} else {
 		File f2(filename);


### PR DESCRIPTION
Some resource files from MM1 are opened by ID, that is hash(filename). The ID for "049.att." file is exist and incorrect for this file. MM4-5 games should not use IDs at all.
Not sure if here is the right place to select the way sprite loads. But it fixes bug #14503.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
