### PR TITLE
TINSEL: Increase maximum sound reels (bug #9625)

### DIFF
--- a/engines/tinsel/play.cpp
+++ b/engines/tinsel/play.cpp
@@ -161,9 +161,10 @@ static int RegisterSoundReel(SCNHANDLE hFilm, int column, int actorCol) {
 	}
 
 	if (i == MAX_SOUNDREELS)
-		error("Out of sound reels in RegisterSoundReel()");
-
-	g_soundReelNumbers[i]++;
+		warning("Out of sound reels in RegisterSoundReel()");
+	else
+		g_soundReelNumbers[i]++;
+		
 	return i;
 }
 

--- a/engines/tinsel/play.h
+++ b/engines/tinsel/play.h
@@ -29,7 +29,7 @@
 
 namespace Tinsel {
 
-#define MAX_SOUNDREELS	5
+#define MAX_SOUNDREELS	10
 
 struct SOUNDREELS {
 	SCNHANDLE hFilm;	// The 'film'


### PR DESCRIPTION
Increases the soundreel pool to 10 from 5 and when running out overwrites the last one

By skipping many dialogue lines in a row it is easy to run out of soundreel slots by doubling the slots it's less likely to happen and by not raising an error when it happens the game will not crash if soundreel slots run out


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
