### PR TITLE
DIRECTOR: Change preloading of frames to demand loading

### DIFF
--- a/engines/director/debugger.cpp
+++ b/engines/director/debugger.cpp
@@ -230,7 +230,7 @@ bool Debugger::cmdInfo(int argc, const char **argv) {
 	debugPrintf("Copy protected: %d\n", cast->_isProtected);
 	debugPrintf("Remap palettes when needed flag: %d\n", movie->_remapPalettesWhenNeeded);
 	debugPrintf("Allow outdated Lingo flag: %d\n", movie->_allowOutdatedLingo);
-	debugPrintf("Frame count: %d\n", score->_frames.size());
+	debugPrintf("Frame count: %d\n", score->getTotalFrames());
 	debugPrintf("Cast member count: %d\n", cast->getCastSize());
 	debugPrintf("\n");
 	return true;
@@ -268,7 +268,7 @@ bool Debugger::cmdMovie(int argc, const char **argv) {
 bool Debugger::cmdChannels(int argc, const char **argv) {
 	Score *score = g_director->getCurrentMovie()->getScore();
 
-	int maxSize = (int)score->_frames.size();
+	int maxSize = (int)score->getTotalFrames();
 	int frameId = score->getCurrentFrame();
 	if (argc == 1) {
 		debugPrintf("Channel info for current frame %d of %d\n", frameId, maxSize);
@@ -281,7 +281,7 @@ bool Debugger::cmdChannels(int argc, const char **argv) {
 
 	if (frameId >= 1 && frameId <= maxSize) {
 		debugPrintf("Channel info for frame %d of %d\n", frameId, maxSize);
-		debugPrintf("%s\n", score->_frames[frameId-1]->formatChannelInfo().c_str());
+		debugPrintf("%s\n", score->quickSelect(frameId-1)->formatChannelInfo().c_str());
 	} else {
 		debugPrintf("Must specify a frame number between 1 and %d.\n", maxSize);
 	}

--- a/engines/director/events.cpp
+++ b/engines/director/events.cpp
@@ -113,8 +113,8 @@ bool Window::processEvent(Common::Event &event) {
 
 bool Movie::processEvent(Common::Event &event) {
 	Score *sc = getScore();
-	if (sc->getCurrentFrame() >= sc->_frames.size()) {
-		warning("processEvents: request to access frame %d of %d", sc->getCurrentFrame(), sc->_frames.size() - 1);
+	if (sc->getCurrentFrame() >= sc->getTotalFrames()) {
+		warning("processEvents: request to access frame %d of %d", sc->getCurrentFrame(), sc->getTotalFrames() - 1);
 		return false;
 	}
 	uint16 spriteId = 0;

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1508,7 +1508,7 @@ void LB::b_preLoad(int nargs) {
 	// We always pretend we preloaded all frames
 	// Returning the number of the last frame successfully "loaded"
 	if (nargs == 0) {
-		g_lingo->_theResult = Datum((int)g_director->getCurrentMovie()->getScore()->_frames.size());
+		g_lingo->_theResult = Datum((int)g_director->getCurrentMovie()->getScore()->getTotalFrames());
 		return;
 	}
 
@@ -2288,7 +2288,7 @@ void LB::b_move(int nargs) {
 	b_erase(1);
 	Score *score = movie->getScore();
 	uint16 frame = score->getCurrentFrame();
-	Frame *currentFrame = score->_frames[frame];
+	Frame *currentFrame = score->_frame;
 	auto channels = score->_channels;
 
 	score->renderFrame(frame, kRenderForceUpdate);
@@ -2317,7 +2317,7 @@ void LB::b_move(int nargs) {
 void LB::b_moveableSprite(int nargs) {
 	Movie *movie = g_director->getCurrentMovie();
 	Score *score = movie->getScore();
-	Frame *frame = score->_frames[score->getCurrentFrame()];
+	Frame *frame = score->_frame;
 
 	if (g_lingo->_currentChannelId == -1) {
 		warning("b_moveableSprite: channel Id is missing");
@@ -2348,7 +2348,7 @@ void LB::b_pasteClipBoardInto(int nargs) {
 
 	Score *score = movie->getScore();
 	uint16 frame = score->getCurrentFrame();
-	Frame *currentFrame = score->_frames[frame];
+	Frame *currentFrame = score->_frame;
 	auto channels = score->_channels;
 
 	castMember->setModified(true);
@@ -2521,8 +2521,8 @@ void LB::b_immediateSprite(int nargs) {
 			if (sc->getNextFrame() && !sp->_immediate) {
 				// same as puppetSprite
 				Channel *channel = sc->getChannelById(sprite.asInt());
-
-				channel->replaceSprite(sc->_frames[sc->getNextFrame()]->_sprites[sprite.asInt()]);
+				// TODO: Fix logic here for next sprite
+				channel->replaceSprite(sc->_frame->_sprites[sprite.asInt()]);
 				channel->_dirty = true;
 			}
 
@@ -2563,7 +2563,8 @@ void LB::b_puppetSprite(int nargs) {
 				// sprite in new frame before setting puppet (Majestic).
 				Channel *channel = sc->getChannelById(sprite.asInt());
 
-				channel->replaceSprite(sc->_frames[sc->getNextFrame()]->_sprites[sprite.asInt()]);
+				// TODO: Fix this properly.
+				channel->replaceSprite(sc->_frame->_sprites[sprite.asInt()]);
 				channel->_dirty = true;
 			}
 
@@ -2720,15 +2721,18 @@ void LB::b_zoomBox(int nargs) {
 	// Looks for endSprite in the next frame
 	Common::Rect endRect = score->_channels[endSpriteId]->getBbox();
 	if (endRect.isEmpty()) {
-		if ((uint)curFrame + 1 < score->_frames.size()) {
-			Channel endChannel(nullptr, score->_frames[curFrame + 1]->_sprites[endSpriteId]);
-			endRect = endChannel.getBbox();
+		if ((uint)curFrame + 1 < score->getTotalFrames()) {
+			Frame* nextFrame = score->quickSelect(curFrame + 1);
+			if (nextFrame) {
+				Channel endChannel(nullptr, nextFrame->_sprites[endSpriteId]);
+				endRect = endChannel.getBbox();
+			}
 		}
 	}
 
 	if (endRect.isEmpty()) {
 		if ((uint)curFrame - 1 > 0) {
-			Channel endChannel(nullptr, score->_frames[curFrame - 1]->_sprites[endSpriteId]);
+			Channel endChannel(nullptr, score->quickSelect(curFrame - 1)->_sprites[endSpriteId]);
 			endRect = endChannel.getBbox();
 		}
 	}

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -119,7 +119,7 @@ void Movie::queueSpriteEvent(Common::Queue<LingoEvent> &queue, LEvent event, int
 	 * When more than one movie script [...]
 	 * [D4 docs] */
 
-	Frame *currentFrame = _score->_frames[_score->getCurrentFrame()];
+	Frame *currentFrame = _score->_frame;
 	assert(currentFrame != nullptr);
 	Sprite *sprite = _score->getSpriteById(spriteId);
 
@@ -160,8 +160,8 @@ void Movie::queueFrameEvent(Common::Queue<LingoEvent> &queue, LEvent event, int 
 	// 	entity = score->getCurrentFrame();
 	// } else {
 
-	assert(_score->_frames[_score->getCurrentFrame()] != nullptr);
-	CastMemberID scriptId = _score->_frames[_score->getCurrentFrame()]->_actionId;
+	assert(_score->_frame != nullptr);
+	CastMemberID scriptId = _score->_frame->_actionId;
 	if (!scriptId.member)
 		return;
 

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -462,7 +462,7 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 		d.u.s = score->getFrameLabel(score->getCurrentFrame());
 		break;
 	case kTheFrameScript:
-		d = score->_frames[score->getCurrentFrame()]->_actionId.member;
+		d = score->_frame->_actionId.member;
 		break;
 	case kTheFramePalette:
 		d = score->getCurrentPalette();
@@ -519,7 +519,7 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 		d = (int)(_vm->getMacTicks() - movie->_lastEventTime);
 		break;
 	case kTheLastFrame:
-		d = (int)score->_frames.size() - 1;
+		d = (int)score->getTotalFrames() - 1;
 		break;
 	case kTheLastKey:
 		d = (int)(_vm->getMacTicks() - movie->_lastKeyTime);

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -232,7 +232,7 @@ bool Movie::loadArchive() {
 	}
 
 	_score->loadFrames(*r, _version);
-	delete r;
+	// delete r;
 
 	// Action list
 	if ((r = _movieArchive->getMovieResourceIfPresent(MKTAG('V', 'W', 'A', 'C'))) != nullptr) {
@@ -240,7 +240,7 @@ bool Movie::loadArchive() {
 		delete r;
 	}
 
-	_score->setSpriteCasts();
+	// _score->setSpriteCasts(); TODO: Dynamic loading change this
 
 	return true;
 }

--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -25,6 +25,7 @@
 //#include "graphics/macgui/macwindowmanager.h"
 
 #include "director/cursor.h"
+#include "director/frame.h"
 
 namespace Graphics {
 	struct Surface;
@@ -74,6 +75,10 @@ public:
 	Movie *getMovie() const { return _movie; }
 
 	void loadFrames(Common::SeekableReadStreamEndian &stream, uint16 version);
+	bool loadFrame(int frame);
+	bool readOneFrame(bool saveOffset = false);
+	Frame *quickSelect(int frameNum);
+
 	void loadLabels(Common::SeekableReadStreamEndian &stream);
 	void loadActions(Common::SeekableReadStreamEndian &stream);
 	void loadSampleSounds(uint type);
@@ -91,8 +96,9 @@ public:
 	void stopPlay();
 
 	void setCurrentFrame(uint16 frameId) { _nextFrame = frameId; }
-	uint16 getCurrentFrame() { return _currentFrame; }
+	uint16 getCurrentFrame() { return _curFrameNumber; }
 	int getNextFrame() { return _nextFrame; }
+	int getTotalFrames() { return _numFrames; }
 
 	CastMemberID getCurrentPalette();
 
@@ -140,10 +146,24 @@ private:
 
 public:
 	Common::Array<Channel *> _channels;
-	Common::Array<Frame *> _frames;
 	Common::SortedArray<Label *> *_labels;
 	Common::HashMap<uint16, Common::String> _actions;
 	Common::HashMap<uint16, bool> _immediateActions;
+
+	// On demand frames loading
+	uint32 _version;
+	Frame *_frame;
+	uint32 _curFrameNumber;
+	uint32 _numFrames;
+	uint32 _framesVersion;
+	uint32 _numChannels;
+	byte _channelData[kChannelDataSize];
+	uint8 _currentTempo;
+	CastMemberID _currentPaletteId;
+
+	Common::Array<int64> _frameOffsets;
+	uint _framesStreamSize;
+	Common::SeekableReadStreamEndian *_framesStream;
 
 	byte _currentFrameRate;
 
@@ -173,7 +193,6 @@ private:
 	Movie *_movie;
 	Window *_window;
 
-	uint16 _currentFrame;
 	uint16 _nextFrame;
 	int _currentLabel;
 	DirectorSound *_soundManager;


### PR DESCRIPTION
Frames are now loaded on demand, when they are first accessed. Also the starting offsets of each frames are stored in a special array, so any previously visited frame might have quick access time. Much of the work is done in Score class itself.

Warning: This commit is not yet complete. There are various issues and crashes on the way.

Demand loading of frames is implemented to replicate the behavior of the original engine. The original engine does not load frames until it is accessed, this property when used with lingo is exploited to allow changes in sprite properties when there is no next frame changes of that property. In essential what happened was that for a non puppet sprites, the game can have its property changed and rendered until there was full refresh (in form of jumps, etc) of screen. This was not possible with precached frames.

The first example use was seen in movie `ATD\HD\bdDREAMA.DXR` of game 'totaldistortion-win'.

**Rigorous testing is recommended before merge.**