### PR TITLE
GUI: Fix bug #7124

### DIFF
--- a/gui/dialog.cpp
+++ b/gui/dialog.cpp
@@ -232,7 +232,11 @@ void Dialog::handleMouseUp(int x, int y, int button, int clickCount) {
 	if (w)
 		w->handleMouseUp(x - (w->getAbsX() - _x), y - (w->getAbsY() - _y), button, clickCount);
 
-	_dragWidget = nullptr;
+	if (_dragWidget) {
+		_dragWidget = nullptr;
+		// Fake a mouse move to refresh now hovered widget
+		handleMouseMoved(x, y, button);
+	}
 }
 
 void Dialog::handleMouseWheel(int x, int y, int direction) {

--- a/gui/dialog.h
+++ b/gui/dialog.h
@@ -82,6 +82,8 @@ public:
 	void	setFocusWidget(Widget *widget);
 	Widget *getFocusWidget() { return _focusedWidget; }
 
+	bool isDragging() const { return _dragWidget != nullptr; }
+
 	void setTickleWidget(Widget *widget) { _tickleWidget = widget; }
 	void unSetTickleWidget() { _tickleWidget = nullptr; }
 	Widget *getTickleWidget() { return _tickleWidget; }

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -539,7 +539,8 @@ void GuiManager::runLoop() {
 		//    then delay showing the tooltip based on the value of kTooltipSameWidgetDelay.
 		uint32 systemMillisNowForTooltipCheck = _system->getMillis(true);
 		if ((_lastTooltipShown.x != _lastMousePosition.x || _lastTooltipShown.y != _lastMousePosition.y)
-		    && _lastMousePosition.time + kTooltipDelay < systemMillisNowForTooltipCheck) {
+		    && _lastMousePosition.time + kTooltipDelay < systemMillisNowForTooltipCheck
+		    && !activeDialog->isDragging()) {
 			Widget *wdg = activeDialog->findWidget(_lastMousePosition.x, _lastMousePosition.y);
 			if (wdg && wdg->hasTooltip() && !(wdg->getFlags() & WIDGET_PRESSED)
 			    && (_lastTooltipShown.wdg != wdg || _lastTooltipShown.time + kTooltipSameWidgetDelay < systemMillisNowForTooltipCheck)) {


### PR DESCRIPTION
This PR is two fold:
- The bug #7124 is fixed by sending a fake mouse moved event at the end of drag
- The tooltip caused the drag operation to abort which caused inconsistencies between before and after displaying the tooltip