### PR TITLE
ENGINES: Add functions to decompose the date and time values from a savegame header

### DIFF
--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -243,12 +243,16 @@ void MetaEngine::getSavegameThumbnail(Graphics::Surface &thumb) {
 }
 
 void MetaEngine::parseSavegameHeader(ExtendedSavegameHeader *header, SaveStateDescriptor *desc) {
-	int day = (header->date >> 24) & 0xFF;
-	int month = (header->date >> 16) & 0xFF;
-	int year = header->date & 0xFFFF;
+	uint8 day = 0;
+	uint8 month = 0;
+	uint16 year = 0;
+	decodeSavegameDate(header, year, month, day);
 	desc->setSaveDate(year, month, day);
-	int hour = (header->time >> 8) & 0xFF;
-	int minutes = header->time & 0xFF;
+
+	uint8 hour = 0;
+	uint8 minutes = 0;
+	decodeSavegameTime(header, hour, minutes);
+
 	desc->setSaveTime(hour, minutes);
 	desc->setPlayTime(header->playtime);
 
@@ -260,6 +264,17 @@ void MetaEngine::fillDummyHeader(ExtendedSavegameHeader *header) {
 	header->date = (20 << 24) | (9 << 16) | 2016;
 	header->time = (9 << 8) | 56;
 	header->playtime = 0;
+}
+
+void MetaEngine::decodeSavegameDate(const ExtendedSavegameHeader *header, uint16 &outYear, uint8 &outMonth, uint8 &outDay) {
+	outYear = static_cast<uint16>(header->date & 0xffff);
+	outMonth = static_cast<uint8>((header->date >> 16) & 0xff);
+	outDay = static_cast<uint8>((header->date >> 24) & 0xff);
+}
+
+void MetaEngine::decodeSavegameTime(const ExtendedSavegameHeader *header, uint8 &outHour, uint8 &outMinute) {
+	outMinute = static_cast<uint16>(header->time & 0xff);
+	outHour = static_cast<uint8>((header->time >> 8) & 0xff);
 }
 
 WARN_UNUSED_RESULT bool MetaEngine::readSavegameHeader(Common::InSaveFile *in, ExtendedSavegameHeader *header, bool skipThumbnail) {

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -559,6 +559,17 @@ public:
 	 * This is used when failing to read the header from a savegame file.
 	 */
 	static void fillDummyHeader(ExtendedSavegameHeader *header);
+
+	/**
+	 * Decode the date from a savegame header into a calendar date.  The month and day are both 1-based.
+	 */
+	static void decodeSavegameDate(const ExtendedSavegameHeader *header, uint16 &outYear, uint8 &outMonth, uint8 &outDay);
+
+	/**
+	 * Decode the time from a savegame header into a wall clock time.
+	 */
+	static void decodeSavegameTime(const ExtendedSavegameHeader *header, uint8 &outHour, uint8 &outMinute);
+
 	/**
 	 * Read the extended savegame header from the given savegame file.
 	 */

--- a/engines/vcruise/vcruise.cpp
+++ b/engines/vcruise/vcruise.cpp
@@ -406,13 +406,15 @@ Common::Error VCruiseEngine::loadMostRecentSave() {
 			continue;
 		}
 
-		// FIXME: Leaky abstraction, date doesn't increase in a way that later dates are always higher numbered so we must do this
-		uint day = (header.date >> 24) & 0xff;
-		uint month = (header.date >> 16) & 0xff;
-		uint year = (header.date & 0xffff);
+		uint8 day = 0;
+		uint8 month = 0;
+		uint16 year = 0;
 
-		uint hour = ((header.time >> 8) & 0xff);
-		uint minute = (header.time & 0xff);
+		uint8 hour = 0;
+		uint8 minute = 0;
+
+		MetaEngine::decodeSavegameDate(&header, year, month, day);
+		MetaEngine::decodeSavegameTime(&header, hour, minute);
 
 		uint64 dateTime = static_cast<uint64>(year) << 32;
 		dateTime |= static_cast<uint64>(month) << 24;


### PR DESCRIPTION
V-Cruise kind of needs this to properly handle the "Continue Game" feature, which loads the most recent save.  Previously, doing that loaded the autosave slot, but that doesn't work correctly if the user has disabled autosaves, so instead it was changed to parse the date from the savegame.

Unfortunately, the date is stored with the most-significant values in the least-significant bit positions, so comparing the raw date value doesn't work, it has to be decomposed.  Also unfortunately, `parseSavegameHeader` doesn't extract the date in a numeric format, it extracts it into a formatted string.

This adds some functions to decompose the savegame date to deal with this problem without the engine having to make assumptions about how the savegame header format stores dates.