### PR TITLE
MM: MM1: Fix crash on roster load

### DIFF
--- a/engines/mm/mm1/data/roster.cpp
+++ b/engines/mm/mm1/data/roster.cpp
@@ -51,7 +51,7 @@ void Roster::load() {
 
 		while (!sf->eos()) {
 			uint32 chunk = sf->readUint32BE();
-			if (chunk == MKTAG('M', 'A', 'P', 'S')) {
+			if (!sf->eos() && chunk == MKTAG('M', 'A', 'P', 'S')) {
 				sf->skip(4);	// Skip chunk size
 				g_maps->synchronize(s);
 			}


### PR DESCRIPTION
Do not ignore EOS when loading roster save.
This prevents a comparison with an uninitialized variable.

Fixes [#14509](https://bugs.scummvm.org/ticket/14509)
