### PR TITLE
ULTIMA8: Support reading of Pentagram save game files

### DIFF
--- a/engines/ultima/metaengine.cpp
+++ b/engines/ultima/metaengine.cpp
@@ -213,6 +213,21 @@ SaveStateList UltimaMetaEngine::listSaves(const char *target) const {
 	return saveList;
 }
 
+SaveStateDescriptor UltimaMetaEngine::querySaveMetaInfos(const char *target, int slot) const {
+	SaveStateDescriptor desc = AdvancedMetaEngine::querySaveMetaInfos(target, slot);
+	if (!desc.isValid() && slot > 0) {
+		Common::String gameId = getGameId(target);
+		if (gameId == "ultima8") {
+			Common::String filename = getSavegameFile(slot, target);
+			desc = SaveStateDescriptor(this, slot, Common::U32String());
+			if (!Ultima::Ultima8::MetaEngine::querySaveMetaInfos(filename, desc))
+				return SaveStateDescriptor();
+		}
+	}
+
+	return desc;
+}
+
 Common::KeymapArray UltimaMetaEngine::initKeymaps(const char *target) const {
 	const Common::String gameId = getGameId(target);
 	if (gameId == "ultima4" || gameId == "ultima4_enh")

--- a/engines/ultima/metaengine.h
+++ b/engines/ultima/metaengine.h
@@ -46,6 +46,11 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 
 	/**
+	 * Return meta information from the specified save state.
+	 */
+	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
+
+	/**
 	 * Initialize keymaps
 	 */
 	Common::KeymapArray initKeymaps(const char *target) const override;

--- a/engines/ultima/ultima8/filesys/savegame.h
+++ b/engines/ultima/ultima8/filesys/savegame.h
@@ -35,15 +35,9 @@ class ZipFile;
 class IDataSource;
 
 class SavegameReader {
-	struct FileEntry {
-		uint _offset;
-		uint _size;
-		FileEntry() : _offset(0), _size(0) {}
-	};
 private:
 	ExtendedSavegameHeader _header;
-	Common::HashMap<Common::String, FileEntry> _index;
-	Common::SeekableReadStream *_file;
+	Common::Archive *_archive;
 	uint32 _version;
 public:
 	explicit SavegameReader(Common::SeekableReadStream *rs, bool metadataOnly = false);

--- a/engines/ultima/ultima8/games/game_info.cpp
+++ b/engines/ultima/ultima8/games/game_info.cpp
@@ -154,10 +154,10 @@ Std::string GameInfo::getPrintableMD5() const {
 bool GameInfo::match(GameInfo &other, bool ignoreMD5) const {
 	if (_type != other._type) return false;
 	if (_language != other._language) return false;
-	if (version != other.version) return false;
-
 	if (ignoreMD5) return true;
 
+	// NOTE: Version and MD5 hash are not currently set
+	if (version != other.version) return false;
 	return (memcmp(_md5, other._md5, 16) == 0);
 }
 

--- a/engines/ultima/ultima8/metaengine.cpp
+++ b/engines/ultima/ultima8/metaengine.cpp
@@ -22,6 +22,9 @@
 #include "ultima/ultima8/metaengine.h"
 #include "ultima/ultima8/misc/debugger.h"
 #include "ultima/ultima8/ultima8.h"
+#include "ultima/ultima8/filesys/savegame.h"
+#include "common/savefile.h"
+#include "common/system.h"
 #include "common/translation.h"
 #include "backends/keymapper/action.h"
 #include "backends/keymapper/standard-actions.h"
@@ -235,6 +238,18 @@ Common::String MetaEngine::getMethod(KeybindingAction keyAction, bool isPress) {
 	}
 
 	return Common::String();
+}
+
+bool MetaEngine::querySaveMetaInfos(const Common::String &filename, SaveStateDescriptor& desc) {
+	Common::ScopedPtr<Common::InSaveFile> f(g_system->getSavefileManager()->openForLoading(filename));
+
+	if (f) {
+		SavegameReader sg(f.get(), true);
+		desc.setDescription(sg.getDescription());
+		return sg.isValid();
+	}
+
+	return false;
 }
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/metaengine.h
+++ b/engines/ultima/ultima8/metaengine.h
@@ -78,6 +78,11 @@ public:
 	 * Execute an engine keymap release action
 	 */
 	static void releaseAction(KeybindingAction keyAction);
+
+	/**
+	 * Return meta information from the specified save state for saves that do not have ExtendedSavegameHeader
+	 */
+	static bool querySaveMetaInfos(const Common::String &filename, SaveStateDescriptor &desc);
 };
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/ultima8.cpp
+++ b/engines/ultima/ultima8/ultima8.cpp
@@ -1239,7 +1239,7 @@ Common::Error Ultima8Engine::loadGameStream(Common::SeekableReadStream *stream) 
 		return Common::Error(Common::kReadingFailed, "Invalid or corrupt savegame: missing GameInfo");
 	}
 
-	if (!_gameInfo->match(saveinfo)) {
+	if (!_gameInfo->match(saveinfo, true)) {
 		Std::string message = "Game mismatch\n";
 		message += "Running _game: " + _gameInfo->getPrintDetails()  + "\n";
 		message += "Savegame    : " + saveinfo.getPrintDetails();


### PR DESCRIPTION
Fixes bug #14043

Hello everyone! I'm looking for feedback on this change. Our Ultima 8 save game handling comes mostly from Pentagram, but there are incompatibilities as Pentagram saved to a zip archive and our engine used a different method.

This change makes the save game reader determine which archive method to choose based on the file's magic number.
