### PR TITLE
MM: MM1: Fix bounds check in enhanced mode inventory handling

### DIFF
--- a/engines/mm/mm1/views_enh/character_inventory.cpp
+++ b/engines/mm/mm1/views_enh/character_inventory.cpp
@@ -72,7 +72,7 @@ bool CharacterInventory::msgFocus(const FocusMessage &msg) {
 
 bool CharacterInventory::msgGame(const GameMessage &msg) {
 	if (msg._name == "ITEM" && msg._value >= 0 &&
-			msg._value <= (int)_items.size()) {
+			msg._value < (int)_items.size()) {
 		_selectedItem = msg._value;
 		performAction();
 		return true;


### PR DESCRIPTION
To reproduce the problem:
1. start/load a game in enhanced mode
2. Select a character
3. Press i to open inventory
4. Press a to go to arms view
5. Press r to get the remove item prompt
6. Press a number key one greater than the last item in the list

This should lead to a crash/assert