### PR TITLE
MM: MM1: Fix (un)equipping items in enhanced mode

### DIFF
--- a/engines/mm/mm1/views_enh/character_inventory.cpp
+++ b/engines/mm/mm1/views_enh/character_inventory.cpp
@@ -203,6 +203,22 @@ void CharacterInventory::itemSelected() {
 }
 
 void CharacterInventory::selectButton(SelectedButton btnMode) {
+	if (btnMode == BTN_EQUIP && _mode == ARMS_MODE) {
+		// Selecting items to equip only makes sense in BACKPACK_MODE,
+		// so we switch to it:
+		_mode = BACKPACK_MODE;
+		populateItems();
+		redraw();
+		draw();
+	}
+	else if (btnMode == BTN_REMOVE && _mode == BACKPACK_MODE) {
+		// Selecting items to unequip only makes sense in ARMS_MODE,
+		// so we switch to it:
+		_mode = ARMS_MODE;
+		populateItems();
+		redraw();
+		draw();
+	}
 	_selectedButton = btnMode;
 
 	if (_selectedItem != -1) {


### PR DESCRIPTION
- Switch to equipped items view when selecting the unequip action
- Switch to backpack items view when selecting the equip action

Depending on current mode, ViewsEnh::CharacterInventory holds either a list of backpack or equipped items (BACKPACK_MODE/ARMS_MODE).
When calling the equip(/unequip) method, the index of the selected equipment from the list is passed.
However, these methods always access the backpack(/equipped) item list regardless of the current mode.
The use of an invalid index then leads to manipulating the wrong item and/or the use of uninitialized/stale values.

This is fixed by setting the appropriate mode before the call.