### PR TITLE
ENGINES: Prevent save description length overflow

### DIFF
--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -217,6 +217,9 @@ void MetaEngine::appendExtendedSaveToStream(Common::WriteStream *saveFile, uint3
 	saveFile->writeUint16LE(header.time);
 	saveFile->writeUint32LE(playtime);
 
+	if (desc.size() > 0xFF)
+		desc = desc.substr(0, 0xFF);
+
 	saveFile->writeByte(desc.size());
 	saveFile->writeString(desc);
 	saveFile->writeByte(isAutosave);


### PR DESCRIPTION
A long description greater than 255 chars currently breaks the remaining parts of the extended savegame header.
The correct fix is likely to prevent this size before writing, but something should be handled during write. Other options could be to assert or return an error.
