### PR TITLE
COMMON: Clean up archive path handling, add getFileName and getPathInArchive to ArchiveMember

### DIFF
--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -455,14 +455,13 @@ int Win32ResourceArchive::listMembers(Common::ArchiveMemberList &list) const {
 	int count = 0;
 
 	for (FilenameList::const_iterator i = _files.begin(); i != _files.end(); ++i, ++count)
-		list.push_back(Common::ArchiveMemberPtr(new Common::GenericArchiveMember(*i, this)));
+		list.push_back(Common::ArchiveMemberPtr(new Common::GenericArchiveMember(*i, *this)));
 
 	return count;
 }
 
 const Common::ArchiveMemberPtr Win32ResourceArchive::getMember(const Common::Path &path) const {
-	Common::String name = path.toString();
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(path, *this));
 }
 
 Common::SeekableReadStream *Win32ResourceArchive::createReadStreamForMember(const Common::Path &path) const {

--- a/common/archive.cpp
+++ b/common/archive.cpp
@@ -29,16 +29,28 @@
 
 namespace Common {
 
-GenericArchiveMember::GenericArchiveMember(const String &name, const Archive *parent)
-	: _parent(parent), _name(name) {
+GenericArchiveMember::GenericArchiveMember(const String &pathStr, const Archive &parent)
+	: _parent(parent), _path(pathStr, parent.getPathSeparator()) {
+}
+
+GenericArchiveMember::GenericArchiveMember(const Path &path, const Archive &parent)
+	: _parent(parent), _path(path) {
 }
 
 String GenericArchiveMember::getName() const {
-	return _name;
+	return _path.toString(_parent.getPathSeparator());
+}
+
+Path GenericArchiveMember::getPathInArchive() const {
+	return _path;
+}
+
+String GenericArchiveMember::getFileName() const {
+	return _path.getLastComponent().toString(_parent.getPathSeparator());
 }
 
 SeekableReadStream *GenericArchiveMember::createReadStream() const {
-	return _parent->createReadStreamForMember(_name);
+	return _parent.createReadStreamForMember(_path);
 }
 
 
@@ -49,7 +61,10 @@ int Archive::listMatchingMembers(ArchiveMemberList &list, const Path &pattern, b
 
 	String patternString = pattern.toString();
 	int matches = 0;
-	const char *wildcardExclusions = matchPathComponents ? NULL : "/";
+
+	char pathSepString[2] = {getPathSeparator(), '\0'};
+
+	const char *wildcardExclusions = matchPathComponents ? NULL : pathSepString;
 
 	ArchiveMemberList::const_iterator it = allNames.begin();
 	for (; it != allNames.end(); ++it) {

--- a/common/archive.h
+++ b/common/archive.h
@@ -58,7 +58,15 @@ class ArchiveMember {
 public:
 	virtual ~ArchiveMember() { }
 	virtual SeekableReadStream *createReadStream() const = 0; /*!< Create a read stream. */
-	virtual String getName() const = 0; /*!< Get the name of the archive member. */
+
+	/**
+	* @deprecated Get the name of the archive member.  This may be a file name or a full path depending on archive type.
+	 *            DEPRECATED: Use getFileName or getPathInArchive instead, which always returns one or the other.
+	 */
+	virtual String getName() const = 0;
+
+	virtual Path getPathInArchive() const = 0; /*!< Get the full path of the archive member relative to the containing archive root. */
+	virtual String getFileName() const = 0; /*!< Get the file name of the archive member relative to its containing directory within the archive. */
 	virtual U32String getDisplayName() const { return getName(); } /*!< Get the display name of the archive member. */
 };
 
@@ -86,12 +94,18 @@ class Archive;
  * is destroyed.
  */
 class GenericArchiveMember : public ArchiveMember {
-	const Archive *_parent;
-	const String _name;
 public:
-	GenericArchiveMember(const String &name, const Archive *parent); /*!< Create a generic archive member that belongs to the @p parent archive. */
-	String getName() const; /*!< Get the name of a generic archive member. */
-	SeekableReadStream *createReadStream() const; /*!< Create a read stream. */
+	GenericArchiveMember(const Common::String &pathStr, const Archive &parent); /*!< Create a generic archive member that belongs to the @p parent archive. */
+	GenericArchiveMember(const Common::Path &path, const Archive &parent); /*!< Create a generic archive member that belongs to the @p parent archive. */
+
+	String getName() const override;        /*!< Get the name of a generic archive member. */
+	Path getPathInArchive() const override;       /*!< Get the full path of the archive member relative to the containing archive root. */
+	String getFileName() const override; /*!< Get the file name of the archive member relative to its containing directory within the archive. */
+	SeekableReadStream *createReadStream() const override; /*!< Create a read stream. */
+
+private:
+	const Archive &_parent;
+	const Common::Path _path;
 };
 
 

--- a/common/compression/clickteam.cpp
+++ b/common/compression/clickteam.cpp
@@ -474,7 +474,7 @@ int ClickteamInstaller::listMembers(ArchiveMemberList &list) const {
 	for (Common::HashMap<Common::String, ClickteamFileDescriptor, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo>::const_iterator i = _files.begin(), end = _files.end();
 	     i != end; ++i) {
 		if (!i->_value._isReferenceMissing) {
-			list.push_back(ArchiveMemberList::value_type(new GenericArchiveMember(i->_key, this)));
+			list.push_back(ArchiveMemberList::value_type(new GenericArchiveMember(i->_key, *this)));
 			++members;
 		}
 	}
@@ -491,7 +491,7 @@ const ArchiveMemberPtr ClickteamInstaller::getMember(const Path &path) const {
 	if (el._isReferenceMissing)
 		return nullptr;
 
-	return Common::SharedPtr<Common::ArchiveMember>(new GenericArchiveMember(el._fileName, this));
+	return Common::SharedPtr<Common::ArchiveMember>(new GenericArchiveMember(el._fileName, *this));
 }
 
 Common::SharedArchiveContents ClickteamInstaller::readContentsForPath(const Common::String& translated) const {

--- a/common/compression/gentee_installer.cpp
+++ b/common/compression/gentee_installer.cpp
@@ -586,6 +586,8 @@ public:
 
 	Common::SeekableReadStream *createReadStream() const override;
 	Common::String getName() const override;
+	Common::Path getPathInArchive() const override { return getName(); }
+	Common::String getFileName() const override { return getName(); }
 
 	const Common::String &getPath() const;
 

--- a/common/compression/installshield_cab.cpp
+++ b/common/compression/installshield_cab.cpp
@@ -278,8 +278,7 @@ int InstallShieldCabinet::listMembers(ArchiveMemberList &list) const {
 }
 
 const ArchiveMemberPtr InstallShieldCabinet::getMember(const Path &path) const {
-	String name = path.toString();
-	return ArchiveMemberPtr(new GenericArchiveMember(name, this));
+	return ArchiveMemberPtr(new GenericArchiveMember(path, *this));
 }
 
 SeekableReadStream *InstallShieldCabinet::createReadStreamForMember(const Path &path) const {

--- a/common/compression/installshieldv3_archive.cpp
+++ b/common/compression/installshieldv3_archive.cpp
@@ -134,7 +134,7 @@ int InstallShieldV3::listMembers(Common::ArchiveMemberList &list) const {
 
 const Common::ArchiveMemberPtr InstallShieldV3::getMember(const Common::Path &path) const {
 	Common::String name = path.toString();
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *InstallShieldV3::createReadStreamForMember(const Common::Path &path) const {

--- a/common/compression/stuffit.cpp
+++ b/common/compression/stuffit.cpp
@@ -279,8 +279,7 @@ int StuffItArchive::listMembers(Common::ArchiveMemberList &list) const {
 }
 
 const Common::ArchiveMemberPtr StuffItArchive::getMember(const Common::Path &path) const {
-	Common::String name = path.toString(':');
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(path, *this));
 }
 
 Common::SharedArchiveContents StuffItArchive::readContentsForPath(const Common::String& name) const {

--- a/common/compression/unarj.cpp
+++ b/common/compression/unarj.cpp
@@ -775,7 +775,7 @@ int ArjArchive::listMembers(ArchiveMemberList &list) const {
 
 	ArjHeadersMap::const_iterator it = _headers.begin();
 	for ( ; it != _headers.end(); ++it) {
-		list.push_back(ArchiveMemberList::value_type(new GenericArchiveMember(it->_value[0]._header->filename, this)));
+		list.push_back(ArchiveMemberList::value_type(new GenericArchiveMember(Common::String(it->_value[0]._header->filename), *this)));
 		matches++;
 	}
 
@@ -787,7 +787,7 @@ const ArchiveMemberPtr ArjArchive::getMember(const Path &path) const {
 	if (!hasFile(name))
 		return ArchiveMemberPtr();
 
-	return ArchiveMemberPtr(new GenericArchiveMember(name, this));
+	return ArchiveMemberPtr(new GenericArchiveMember(name, *this));
 }
 
 Common::SharedArchiveContents ArjArchive::readContentsForPath(const Common::String& name) const {

--- a/common/compression/unzip.cpp
+++ b/common/compression/unzip.cpp
@@ -1025,7 +1025,7 @@ int ZipArchive::listMembers(ArchiveMemberList &list) const {
 	const unz_s *const archive = (const unz_s *)_zipFile;
 	for (ZipHash::const_iterator i = archive->_hash.begin(), end = archive->_hash.end();
 	     i != end; ++i) {
-		list.push_back(ArchiveMemberList::value_type(new GenericArchiveMember(i->_key, this)));
+		list.push_back(ArchiveMemberList::value_type(new GenericArchiveMember(i->_key, *this)));
 		++members;
 	}
 
@@ -1037,7 +1037,7 @@ const ArchiveMemberPtr ZipArchive::getMember(const Path &path) const {
 	if (!hasFile(name))
 		return ArchiveMemberPtr();
 
-	return ArchiveMemberPtr(new GenericArchiveMember(name, this));
+	return ArchiveMemberPtr(new GenericArchiveMember(path, *this));
 }
 
 Common::SharedArchiveContents ZipArchive::readContentsForPath(const Common::String& name) const {

--- a/common/formats/prodos.cpp
+++ b/common/formats/prodos.cpp
@@ -50,6 +50,14 @@ Common::String ProDOSFile::getName() const {
 	return Common::String(_name);
 }
 
+Common::String ProDOSFile::getFileName() const {
+	return Common::String(_name);
+}
+
+Common::Path ProDOSFile::getPathInArchive() const {
+	return Common::Path(_name);
+}
+
 /* This method is used to get a single block of data from the disk,
  * but is not strictly 512 bytes. This is so that it can get only what
  * it needs when in the final block. It then adds it into the allocated

--- a/common/formats/prodos.h
+++ b/common/formats/prodos.h
@@ -87,6 +87,8 @@ public:
 
 	// -- These are the Common::ArchiveMember related functions --
 	Common::String getName() const override;                              // Returns _name
+	Common::Path getPathInArchive() const override;                       // Returns _name
+	Common::String getFileName() const override;                          // Returns _name
 	Common::SeekableReadStream *createReadStream() const override;        // This is what the archive needs to create a file
 	void getDataBlock(byte *memOffset, int offset, int size) const;       // Gets data up to the size of a single data block (512 bytes)
 	int parseIndexBlock(byte *memOffset, int blockNum, int cSize) const;  // Uses getDataBlock() on every pointer in the index file, adding them to byte * memory block

--- a/common/fs.h
+++ b/common/fs.h
@@ -249,7 +249,7 @@ public:
 	 *
 	 * @return Pointer to the stream object, 0 in case of a failure.
 	 */
-	virtual SeekableReadStream *createReadStream() const;
+	SeekableReadStream *createReadStream() const override;
 
 	/**
 	 * Create a WriteStream instance corresponding to the file

--- a/common/fs.h
+++ b/common/fs.h
@@ -157,7 +157,7 @@ public:
 	 *
 	 * @return The display name.
 	 */
-	virtual U32String getDisplayName() const;
+	U32String getDisplayName() const override;
 
 	/**
 	 * Return a string representation of the name of the file. This can be
@@ -167,7 +167,23 @@ public:
 	 *
 	 * @return The file name.
 	 */
-	virtual String getName() const;
+	String getName() const override;
+
+	/**
+	 * Return a string representation of the name of the file.
+	 *
+	 * @return The file name.
+	 */
+	String getFileName() const override;
+
+	/**
+	 * Return a string representation of the name of the file.  Since FSNode
+	 * parents are always the parent FSDirectory, this will not return a full
+	 * path, only the file name.
+	 *
+	 * @return The file name.
+	 */
+	Common::Path getPathInArchive() const override;
 
 	/**
 	 * Return a string representation of the file that is suitable for

--- a/engines/director/game-quirks.cpp
+++ b/engines/director/game-quirks.cpp
@@ -249,7 +249,7 @@ int CachedArchive::listMembers(Common::ArchiveMemberList &list) const {
 	int count = 0;
 
 	for (FileMap::const_iterator i = _files.begin(); i != _files.end(); ++i) {
-		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(i->_key, this)));
+		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(i->_key, *this)));
 		++count;
 	}
 
@@ -261,7 +261,7 @@ const Common::ArchiveMemberPtr CachedArchive::getMember(const Common::Path &path
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *CachedArchive::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/director/resource.cpp
+++ b/engines/director/resource.cpp
@@ -728,7 +728,7 @@ int ProjectorArchive::listMembers(Common::ArchiveMemberList &list) const {
 	int count = 0;
 
 	for (FileMap::const_iterator i = _files.begin(); i != _files.end(); ++i) {
-		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(i->_key, this)));
+		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(i->_key, *this)));
 		++count;
 	}
 
@@ -741,7 +741,7 @@ const Common::ArchiveMemberPtr ProjectorArchive::getMember(const Common::Path &p
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *ProjectorArchive::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/dreamweb/rnca_archive.cpp
+++ b/engines/dreamweb/rnca_archive.cpp
@@ -73,7 +73,7 @@ bool RNCAArchive::hasFile(const Common::Path &path) const {
 
 int RNCAArchive::listMembers(Common::ArchiveMemberList &list) const {
 	for (FileMap::const_iterator i = _files.begin(), end = _files.end(); i != end; ++i) {
-		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(i->_key, this)));
+		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(i->_key, *this)));
 	}
 
 	return _files.size();
@@ -84,7 +84,7 @@ const Common::ArchiveMemberPtr RNCAArchive::getMember(const Common::Path &path) 
 	if (!_files.contains(translated))
 		return nullptr;
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(_files.getVal(translated)._fileName, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(_files.getVal(translated)._fileName, *this));
 }
 
 Common::SharedArchiveContents RNCAArchive::readContentsForPath(const Common::String& translated) const {

--- a/engines/glk/blorb.cpp
+++ b/engines/glk/blorb.cpp
@@ -50,7 +50,7 @@ bool Blorb::hasFile(const Common::Path &path) const {
 
 int Blorb::listMembers(Common::ArchiveMemberList &list) const {
 	for (uint idx = 0; idx < _chunks.size(); ++idx) {
-		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(_chunks[idx]._filename, this)));
+		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(_chunks[idx]._filename, *this)));
 	}
 
 	return (int)_chunks.size();
@@ -61,7 +61,7 @@ const Common::ArchiveMemberPtr Blorb::getMember(const Common::Path &path) const 
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *Blorb::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/glk/comprehend/pics.cpp
+++ b/engines/glk/comprehend/pics.cpp
@@ -387,7 +387,7 @@ const Common::ArchiveMemberPtr Pics::getMember(const Common::Path &path) const {
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *Pics::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/glk/hugo/resource_archive.cpp
+++ b/engines/glk/hugo/resource_archive.cpp
@@ -64,7 +64,7 @@ const Common::ArchiveMemberPtr ResourceArchive::getMember(const Common::Path &pa
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(path, *this));
 }
 
 Common::SeekableReadStream *ResourceArchive::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/glk/zcode/pics.cpp
+++ b/engines/glk/zcode/pics.cpp
@@ -124,7 +124,7 @@ bool Pics::hasFile(const Common::Path &path) const {
 
 int Pics::listMembers(Common::ArchiveMemberList &list) const {
 	for (uint idx = 0; idx < _index.size(); ++idx) {
-		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(_index[idx]._filename, this)));
+		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(_index[idx]._filename, *this)));
 	}
 
 	return (int)_index.size();
@@ -135,7 +135,7 @@ const Common::ArchiveMemberPtr Pics::getMember(const Common::Path &path) const {
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *Pics::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/glk/zcode/sound_folder.cpp
+++ b/engines/glk/zcode/sound_folder.cpp
@@ -55,7 +55,7 @@ bool SoundSubfolder::hasFile(const Common::Path &path) const {
 int SoundSubfolder::listMembers(Common::ArchiveMemberList &list) const {
 	int total = 0;
 	for (Common::StringMap::iterator i = _filenames.begin(); i != _filenames.end(); ++i) {
-		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember((*i)._key, this)));
+		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember((*i)._key, *this)));
 		++total;
 	}
 
@@ -67,7 +67,7 @@ const Common::ArchiveMemberPtr SoundSubfolder::getMember(const Common::Path &pat
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *SoundSubfolder::createReadStreamForMember(const Common::Path &path) const {
@@ -123,7 +123,7 @@ int SoundZip::listMembers(Common::ArchiveMemberList &list) const {
 	int total = 0;
 
 	for (Common::StringMap::iterator i = _filenames.begin(); i != _filenames.end(); ++i) {
-		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember((*i)._key, this)));
+		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember((*i)._key, *this)));
 		++total;
 	}
 
@@ -135,7 +135,7 @@ const Common::ArchiveMemberPtr SoundZip::getMember(const Common::Path &path) con
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 
 }
 

--- a/engines/grim/lab.h
+++ b/engines/grim/lab.h
@@ -39,6 +39,8 @@ class LabEntry : public Common::ArchiveMember {
 public:
 	LabEntry(const Common::String &name, uint32 offset, uint32 len, Lab *parent);
 	Common::String getName() const override { return _name; }
+	Common::String getFileName() const override { return _name; }
+	Common::Path getPathInArchive() const override { return _name; }
 	Common::SeekableReadStream *createReadStream() const override;
 	friend class Lab;
 };

--- a/engines/grim/update/lang_filter.cpp
+++ b/engines/grim/update/lang_filter.cpp
@@ -110,8 +110,7 @@ int LangFilter::listMembers(Common::ArchiveMemberList &list) const {
 }
 
 const Common::ArchiveMemberPtr LangFilter::getMember(const Common::Path &path) const {
-	Common::String name = path.toString();
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(path, *this));
 }
 
 Common::SeekableReadStream *LangFilter::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/grim/update/mscab.cpp
+++ b/engines/grim/update/mscab.cpp
@@ -159,7 +159,7 @@ int MsCabinet::listMembers(Common::ArchiveMemberList &list) const {
 
 const Common::ArchiveMemberPtr MsCabinet::getMember(const Common::Path &path) const {
 	Common::String name = path.toString();
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *MsCabinet::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/hypno/libfile.cpp
+++ b/engines/hypno/libfile.cpp
@@ -110,7 +110,7 @@ int LibFile::listMembers(Common::ArchiveMemberList &list) const {
 
 const Common::ArchiveMemberPtr LibFile::getMember(const Common::Path &path) const {
 	Common::String name = path.toString();
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *LibFile::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/kyra/resource/resource_intern.cpp
+++ b/engines/kyra/resource/resource_intern.cpp
@@ -47,7 +47,7 @@ int PlainArchive::listMembers(Common::ArchiveMemberList &list) const {
 	int count = 0;
 
 	for (FileMap::const_iterator i = _files.begin(); i != _files.end(); ++i) {
-		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(i->_key, this)));
+		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(i->_key, *this)));
 		++count;
 	}
 
@@ -59,7 +59,7 @@ const Common::ArchiveMemberPtr PlainArchive::getMember(const Common::Path &path)
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *PlainArchive::createReadStreamForMember(const Common::Path &path) const {
@@ -106,7 +106,7 @@ int TlkArchive::listMembers(Common::ArchiveMemberList &list) const {
 
 	for (; count < _entryCount; ++count) {
 		const Common::String name = Common::String::format("%08u.AUD", _fileEntries[count * 2 + 0]);
-		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(name, this)));
+		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(name, *this)));
 	}
 
 	return count;
@@ -117,7 +117,7 @@ const Common::ArchiveMemberPtr TlkArchive::getMember(const Common::Path &path) c
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *TlkArchive::createReadStreamForMember(const Common::Path &path) const {
@@ -202,7 +202,7 @@ int CachedArchive::listMembers(Common::ArchiveMemberList &list) const {
 	int count = 0;
 
 	for (FileMap::const_iterator i = _files.begin(); i != _files.end(); ++i) {
-		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(i->_key, this)));
+		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(i->_key, *this)));
 		++count;
 	}
 
@@ -214,7 +214,7 @@ const Common::ArchiveMemberPtr CachedArchive::getMember(const Common::Path &path
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *CachedArchive::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/lastexpress/data/archive.cpp
+++ b/engines/lastexpress/data/archive.cpp
@@ -82,7 +82,7 @@ int HPFArchive::listMembers(Common::ArchiveMemberList &list) const {
 	int numMembers = 0;
 
 	for (FileMap::const_iterator i = _files.begin(); i != _files.end(); ++i) {
-		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(i->_key, this)));
+		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(i->_key, *this)));
 		numMembers++;
 	}
 
@@ -94,7 +94,7 @@ const Common::ArchiveMemberPtr HPFArchive::getMember(const Common::Path &path) c
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *HPFArchive::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/lastexpress/resource.cpp
+++ b/engines/lastexpress/resource.cpp
@@ -176,7 +176,7 @@ const Common::ArchiveMemberPtr ResourceManager::getMember(const Common::Path &pa
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *ResourceManager::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/mads/mps_installer.cpp
+++ b/engines/mads/mps_installer.cpp
@@ -69,7 +69,7 @@ bool MpsInstaller::hasFile(const Common::Path &path) const {
 
 int MpsInstaller::listMembers(Common::ArchiveMemberList &list) const {
 	for (FileMap::const_iterator i = _files.begin(), end = _files.end(); i != end; ++i) {
-		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(i->_key, this)));
+		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(i->_key, *this)));
 	}
 
 	return _files.size();
@@ -80,7 +80,7 @@ const Common::ArchiveMemberPtr MpsInstaller::getMember(const Common::Path &path)
 	if (!_files.contains(translated))
 		return nullptr;
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(_files.getVal(translated)._fileName, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(_files.getVal(translated)._fileName, *this));
 }
 
 Common::SharedArchiveContents MpsInstaller::readContentsForPath(const Common::String& translated) const {

--- a/engines/mads/resources.cpp
+++ b/engines/mads/resources.cpp
@@ -114,7 +114,7 @@ int HagArchive::listMembers(Common::ArchiveMemberList &list) const {
 
 		for (i = hagIndex._entries.begin(); i != hagIndex._entries.end(); ++i) {
 			list.push_back(Common::ArchiveMemberList::value_type(
-				new Common::GenericArchiveMember((*i)._resourceName, this)));
+				new Common::GenericArchiveMember((*i)._resourceName, *this)));
 			++members;
 		}
 	}
@@ -127,7 +127,7 @@ const Common::ArchiveMemberPtr HagArchive::getMember(const Common::Path &path) c
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *HagArchive::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/mm/shared/utils/engine_data.cpp
+++ b/engines/mm/shared/utils/engine_data.cpp
@@ -53,6 +53,8 @@ public:
 	Common::U32String getDisplayName() const override {
 		return _member->getDisplayName();
 	}
+	Common::String getFileName() const override { return getName(); }
+	Common::Path getPathInArchive() const override { return getName(); }
 };
 
 /**
@@ -197,7 +199,7 @@ const Common::ArchiveMemberPtr DataArchive::getMember(const Common::Path &path) 
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(path, *this));
 }
 
 Common::SeekableReadStream *DataArchive::createReadStreamForMember(const Common::Path &path) const {
@@ -219,7 +221,7 @@ const Common::ArchiveMemberPtr DataArchiveProxy::getMember(const Common::Path &p
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(path, *this));
 }
 
 Common::SeekableReadStream *DataArchiveProxy::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/mm/shared/xeen/cc_archive.cpp
+++ b/engines/mm/shared/xeen/cc_archive.cpp
@@ -146,7 +146,7 @@ const Common::ArchiveMemberPtr BaseCCArchive::getMember(const Common::Path &path
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(Common::String(name), *this));
 }
 
 int BaseCCArchive::listMembers(Common::ArchiveMemberList &list) const {

--- a/engines/mohawk/installer_archive.cpp
+++ b/engines/mohawk/installer_archive.cpp
@@ -120,7 +120,7 @@ int InstallerArchive::listMembers(Common::ArchiveMemberList &list) const {
 
 const Common::ArchiveMemberPtr InstallerArchive::getMember(const Common::Path &path) const {
 	Common::String name = path.toString();
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *InstallerArchive::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/ngi/ngiarchive.cpp
+++ b/engines/ngi/ngiarchive.cpp
@@ -109,7 +109,7 @@ int NGIArchive::listMembers(Common::ArchiveMemberList &list) const {
 
 	NgiHeadersMap::const_iterator it = _headers.begin();
 	for ( ; it != _headers.end(); ++it) {
-		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(it->_value->filename, this)));
+		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(Common::Path(it->_value->filename), *this)));
 		matches++;
 	}
 
@@ -121,7 +121,7 @@ const Common::ArchiveMemberPtr NGIArchive::getMember(const Common::Path &path) c
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *NGIArchive::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/parallaction/disk_ns.cpp
+++ b/engines/parallaction/disk_ns.cpp
@@ -149,7 +149,7 @@ bool NSArchive::hasFile(const Common::Path &path) const {
 
 int NSArchive::listMembers(Common::ArchiveMemberList &list) const {
 	for (uint32 i = 0; i < _numFiles; i++) {
-		list.push_back(Common::SharedPtr<Common::GenericArchiveMember>(new Common::GenericArchiveMember(_archiveDir[i], this)));
+		list.push_back(Common::SharedPtr<Common::GenericArchiveMember>(new Common::GenericArchiveMember(Common::String(_archiveDir[i]), *this)));
 	}
 	return _numFiles;
 }
@@ -163,7 +163,7 @@ const Common::ArchiveMemberPtr NSArchive::getMember(const Common::Path &path) co
 		item = _archiveDir[index];
 	}
 
-	return Common::SharedPtr<Common::GenericArchiveMember>(new Common::GenericArchiveMember(item, this));
+	return Common::SharedPtr<Common::GenericArchiveMember>(new Common::GenericArchiveMember(Common::String(item), *this));
 }
 
 

--- a/engines/prince/archive.cpp
+++ b/engines/prince/archive.cpp
@@ -139,7 +139,7 @@ int PtcArchive::listMembers(Common::ArchiveMemberList &list) const {
 	int matches = 0;
 
 	for (FileMap::const_iterator it = _items.begin(); it != _items.end(); ++it) {
-		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(it->_key, this)));
+		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(it->_key, *this)));
 		matches++;
 	}
 
@@ -151,7 +151,7 @@ const Common::ArchiveMemberPtr PtcArchive::getMember(const Common::Path &path) c
 	if (!_items.contains(name)) {
 		Common::ArchiveMemberPtr();
 	}
-	return Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *PtcArchive::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/stark/formats/xarc.cpp
+++ b/engines/stark/formats/xarc.cpp
@@ -40,6 +40,8 @@ public:
 
 	Common::SeekableReadStream *createReadStream() const override;
 	Common::String getName() const override { return _name; }
+	Common::Path getPathInArchive() const { return _name; }
+	Common::String getFileName() const { return _name; }
 	uint32 getLength() const { return _length; }
 	uint32 getOffset() const { return _offset; }
 

--- a/engines/sword25/package/packagemanager.cpp
+++ b/engines/sword25/package/packagemanager.cpp
@@ -308,7 +308,7 @@ int PackageManager::doSearch(Common::ArchiveMemberList &list, const Common::Stri
 				}
 
 				if (!found) {
-					list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(name, (*i)->archive)));
+					list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(name, *(*i)->archive)));
 					debug(9, "> %s", name.c_str());
 				}
 				num++;

--- a/engines/trecision/fastfile.cpp
+++ b/engines/trecision/fastfile.cpp
@@ -88,8 +88,7 @@ int FastFile::listMembers(Common::ArchiveMemberList &list) const {
 }
 
 const Common::ArchiveMemberPtr FastFile::getMember(const Common::Path &path) const {
-	Common::String name = path.toString();
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(path, *this));
 }
 
 Common::SeekableReadStream *FastFile::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/ultima/shared/engine/data_archive.cpp
+++ b/engines/ultima/shared/engine/data_archive.cpp
@@ -52,6 +52,9 @@ public:
 	Common::U32String getDisplayName() const override {
 		return _member->getDisplayName();
 	}
+	
+	Common::String getFileName() const override { return getName(); }
+	Common::Path getPathInArchive() const override { return getName(); }
 };
 
 /*-------------------------------------------------------------------*/
@@ -164,7 +167,7 @@ const Common::ArchiveMemberPtr UltimaDataArchive::getMember(const Common::Path &
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *UltimaDataArchive::createReadStreamForMember(const Common::Path &path) const {
@@ -186,7 +189,7 @@ const Common::ArchiveMemberPtr UltimaDataArchiveProxy::getMember(const Common::P
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *UltimaDataArchiveProxy::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/ultima/shared/engine/resources.cpp
+++ b/engines/ultima/shared/engine/resources.cpp
@@ -65,7 +65,7 @@ bool Resources::hasFile(const Common::Path &path) const {
 
 int Resources::listMembers(Common::ArchiveMemberList &list) const {
 	for (uint idx = 0; idx < _localResources.size(); ++idx) {
-		list.push_back(Common::ArchiveMemberPtr(new Common::GenericArchiveMember(_localResources[idx]._name, this)));
+		list.push_back(Common::ArchiveMemberPtr(new Common::GenericArchiveMember(_localResources[idx]._name, *this)));
 	}
 
 	return _localResources.size();
@@ -76,7 +76,7 @@ const Common::ArchiveMemberPtr Resources::getMember(const Common::Path &path) co
 	if (!hasFile(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *Resources::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/ultima/ultima8/filesys/savegame.cpp
+++ b/engines/ultima/ultima8/filesys/savegame.cpp
@@ -80,7 +80,7 @@ bool FileEntryArchive::hasFile(const Common::Path &path) const {
 int FileEntryArchive::listMembers(Common::ArchiveMemberList &list) const {
 	list.clear();
 	for (Common::HashMap<Common::String, FileEntry>::const_iterator it = _index.begin(); it != _index.end(); ++it)
-		list.push_back(Common::ArchiveMemberPtr(new Common::GenericArchiveMember(it->_key, this)));
+		list.push_back(Common::ArchiveMemberPtr(new Common::GenericArchiveMember(it->_key, *this)));
 
 	return list.size();
 }
@@ -90,7 +90,7 @@ const Common::ArchiveMemberPtr FileEntryArchive::getMember(const Common::Path &p
 		return nullptr;
 
 	Common::String name = path.toString();
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *FileEntryArchive::createReadStreamForMember(const Common::Path &path) const {

--- a/engines/wintermute/base/file/base_file_entry.h
+++ b/engines/wintermute/base/file/base_file_entry.h
@@ -40,6 +40,8 @@ class BaseFileEntry : public Common::ArchiveMember {
 public:
 	Common::SeekableReadStream *createReadStream() const override;
 	Common::String getName() const override { return _filename; }
+	Common::Path getPathInArchive() const override { return _filename; }
+	Common::String getFileName() const override { return _filename; }
 	uint32 _timeDate2;
 	uint32 _timeDate1;
 	uint32 _flags;

--- a/engines/zvision/file/zfs_archive.cpp
+++ b/engines/zvision/file/zfs_archive.cpp
@@ -112,7 +112,7 @@ int ZfsArchive::listMembers(Common::ArchiveMemberList &list) const {
 	int matches = 0;
 
 	for (ZfsEntryHeaderMap::const_iterator it = _entryHeaders.begin(); it != _entryHeaders.end(); ++it) {
-		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(it->_value->name, this)));
+		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(it->_value->name, *this)));
 		matches++;
 	}
 
@@ -124,7 +124,7 @@ const Common::ArchiveMemberPtr ZfsArchive::getMember(const Common::Path &path) c
 	if (!_entryHeaders.contains(name))
 		return Common::ArchiveMemberPtr();
 
-	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, this));
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(name, *this));
 }
 
 Common::SeekableReadStream *ZfsArchive::createReadStreamForMember(const Common::Path &path) const {


### PR DESCRIPTION
Reworked this to hopefully minimize regression risk.  This partially refactors archive path handling to better handle full paths and alternate path separators.

The main thing motivating this is a few things:
- The default implementation of `Archive::listMatchingMembers` calls `getName` to determine the path to match, which acts as if `getName` returns a full path, except it may not.  In particular, `FSNode` archive members always return only the file name.
- ArchiveMember lacks a way to get the path of a file relative to the archive root.

I mainly want these to make a VFS for mTropolis to make dealing with installers easier (basically, the VFS would be an archive containing hardlinks to other archives - in order do to that though, it needs to be possible to scan an archive subpath).

The previous version of this tried just making `getName` always return only the filename, but that would require checking a LOT of engines for regressions which I think makes this too big of a project.  Instead, this adds `getFileName` and `getPathInArchive` and deprecates `getName`.  This is absolutely NOT guaranteed to work correctly with all existing cases (some engines may be returning full paths from `getFileName`, if they actually support them), but it will provide a smoother path to making this work in a sensible way.

This also changes GenericArchiveMember to accept a path instead of a string.  This should transparently support existing cases since `getName` will return the path converted using the same path separator, except for StuffIt (see below).

This also changes `FSDirectory` to return `FSDirectoryFile` as the archive member type.  The reason for this is so that when calling `getMember` with a subpath of a directory, it will return a `FSDirectoryFile` for which `getPathInArchive` returns the relative path **from the directory that `getMember` was called on** instead of the parent of the file, keeping the principle that passing `getPathInArchive` back to `getMember` should always return the same thing.

The only case this will cause a change in behavior is directly constructing a path using an incompatible separator, which is currently only possible for StuffIt and VISE archives since they are the only ones that use alternate path separators, and the StuffIt loader flattens the directory tree by default.

However, this should **improve** support for MacOS filenames with slashes in them, since `StuffItArchive::getMember` will no longer interpret the slash as a separator.