### PR TITLE
COMMON: Fix incorrect StuffIt directory paths

### DIFF
--- a/common/compression/stuffit.cpp
+++ b/common/compression/stuffit.cpp
@@ -202,7 +202,9 @@ bool StuffItArchive::open(Common::SeekableReadStream *stream, bool flattenTree) 
 		if (dirCheckMethod == 33) {
 			// End of folder
 			if (!flattenTree && dirPrefix.size() > 0) {
-				size_t secondLastDelimiter = dirPrefix.rfind(':', dirPrefix.size() - 1);
+				size_t secondLastDelimiter = Common::String::npos;
+				if (dirPrefix.size() > 1)
+					secondLastDelimiter = dirPrefix.rfind(':', dirPrefix.size() - 2);
 
 				if (secondLastDelimiter == Common::String::npos) {
 					// Only one level deep


### PR DESCRIPTION
Cherry-picked from PR #5108

PR #5060 has an off-by-one error in the directory termination (rfind needs to start at size-2 because the last character is a path separator unless the prefix is empty), which causes subpaths to be incorrect.  This fixes it.