### PR TITLE
GUI: Change ThemeLayout::setPadding input types to int16

### DIFF
--- a/gui/ThemeLayout.h
+++ b/gui/ThemeLayout.h
@@ -77,7 +77,7 @@ public:
 
 	void addChild(ThemeLayout *child) { _children.push_back(child); }
 
-	void setPadding(int8 left, int8 right, int8 top, int8 bottom) {
+	void setPadding(int16 left, int16 right, int16 top, int16 bottom) {
 		_padding.left = left;
 		_padding.right = right;
 		_padding.top = top;


### PR DESCRIPTION
The theme layout padding values are parsed and stored as 16 bit signed integers. However ThemeLayout::setPadding treated the values as 8 bit signed integeres.

The padding values parsed from the STX file suited for the screen resolution are multiplied with the device content scale factor. The scale factor determines how content is mapped from the logical coordinate space (measured in points) to the device coordinate space (measured in pixels).

If the scale factor and the padding value results in a value greater than 255 it will wrap since the 8 bit type can't hold bigger values than that.

Running the iOS backend in debug configuration on an iPhone 12 mini, having the content scale factor value 3, and drawing the launcher in vertical mode where the bottom padding value is 92, the result became 3 * 92 = 276 which would wrap to 20. That resulted in incorrect layout where the GameList was too high and the buttons in the bottom would not fit on the screen.

Change the input type to int16 in ThemeLayout::setPadding to conform with the padding type used everywhere else.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
