### PR TITLE
AGS: Fix blending of hires fonts in alfont

### DIFF
--- a/engines/ags/lib/alfont/alfont.cpp
+++ b/engines/ags/lib/alfont/alfont.cpp
@@ -178,10 +178,30 @@ uint32_t __preservedalpha_blender_trans24(uint32_t x, uint32_t y, uint32_t n) {
 
 /* replaces set_trans_blender() */
 void set_preservedalpha_trans_blender(int r, int g, int b, int a) {
+	// TODO: The current putpixel() implementation does not support blending in DRAW_MODE_TRANS mode (which is not implemented),
+	// so we can't just call set_blender_mode() here.
+	// The actual blending is done by the apply_trans_blender() function, just before the putpixel() calls
+
 	//set_blender_mode(__skiptranspixels_blender_trans15, __skiptranspixels_blender_trans16, __preservedalpha_blender_trans24, r, g, b, a);
-	set_blender_mode(kAlphaPreservedBlenderMode, r, g, b, a);
+	//set_blender_mode(kAlphaPreservedBlenderMode, r, g, b, a);
 }
 
+/* blends a pixel using the alternative blenders, this is a replacement
+ * for the previous function using set_blender_mode
+ */
+int apply_trans_blender(BITMAP *bmp, int color1, int color2, int alpha) {
+	switch (bitmap_color_depth(bmp)) {
+	case 15:
+		return __skiptranspixels_blender_trans15(color1, color2, alpha);
+	case 16:
+		return __skiptranspixels_blender_trans16(color1, color2, alpha);
+	case 24:
+	case 32:
+		return __preservedalpha_blender_trans24(color1, color2, alpha);
+	default:
+		return color1;
+	}
+}
 
 /* helpers */
 
@@ -1545,13 +1565,15 @@ void alfont_textout_aa_ex(BITMAP *bmp, ALFONT_FONT *f, const char *s, int x, int
 					for (bmp_y = real_y; bmp_y < max_bmp_y; bmp_y++) {
 						for (bmp_x = real_x; bmp_x < max_bmp_x; bmp_x++) {
 							const int alpha = *bmp_p++;
-
+							const int orig_color = color;
 							if (alpha) {
 								if (alpha >= 255)
 									solid_mode();
 								else {
 									drawing_mode(DRAW_MODE_TRANS, NULL, 0, 0);
 									set_preservedalpha_trans_blender(0, 0, 0, alpha);
+									// apply blending
+									color = apply_trans_blender(bmp, color, getpixel(bmp, bmp_x, bmp_y), alpha);
 								}
 								if (first_x > bmp_x) first_x = bmp_x;
 								if (final_x < bmp_x) final_x = bmp_x;
@@ -1590,6 +1612,8 @@ void alfont_textout_aa_ex(BITMAP *bmp, ALFONT_FONT *f, const char *s, int x, int
 									putpixel(bmp, bmp_x, bmp_y, color);
 								}
 							}
+							if (color != orig_color) // restore original color
+								color = orig_color;
 						}
 					}
 				} else { //restore original pic


### PR DESCRIPTION
When displaying hires fonts, alfont applies an alternative blending mode which was not implemented, causing hi-res text to display improperly in multiple games (Mage's Initiation, Starship Quasar and Larry Lotter the most relevant cases).
This is not related to the recent Freetype discussions (those bugs are mostly related to the lowres fonts)

Before
![scummvm-mage-00001](https://github.com/scummvm/scummvm/assets/1673892/d1ae655b-76c5-401a-ba84-c0c972ae98f7)
After
![scummvm-mage-00000](https://github.com/scummvm/scummvm/assets/1673892/d03e0675-4273-420c-9e1a-a5d1751ef0a7)

Before
![scummvm-myburdentokeep-00002](https://github.com/scummvm/scummvm/assets/1673892/f850cf14-f537-4c6b-b4e2-09e624821366)

After
![scummvm-myburdentokeep-00001](https://github.com/scummvm/scummvm/assets/1673892/940e539a-ba0c-4de0-85cc-e84856d50feb)


Fixes [13758](https://bugs.scummvm.org/ticket/13758) and some of the issues in [12940](https://bugs.scummvm.org/ticket/12940)

<!---

Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
