### PR TITLE
SCI: Show SRT subtitles on SCI32 videos

### DIFF
--- a/engines/sci/graphics/video32.cpp
+++ b/engines/sci/graphics/video32.cpp
@@ -647,6 +647,8 @@ VMDPlayer::IOStatus VMDPlayer::open(const Common::String &fileName, const OpenFl
 		if (flags & kOpenFlagMute) {
 			_decoder->setVolume(0);
 		}
+
+		// Try load fan-made SRT subtitles for current video
 		Common::String subtitlesName = Common::String::format("%s.srt", fileName.c_str());
 		_subtitles.loadSRTFile(subtitlesName.c_str());
 
@@ -1216,6 +1218,7 @@ void DuckPlayer::open(const GuiResourceId resourceId, const int displayMode, con
 		g_sci->_gfxFrameout->setPixelFormat(_decoder->getPixelFormat());
 	}
 
+	// Try load fan-made SRT subtitles for current video
 	Common::String subtitlesName = Common::String::format("%s.srt", fileName.c_str());
 	_subtitles.loadSRTFile(subtitlesName.c_str());
 

--- a/engines/sci/graphics/video32.cpp
+++ b/engines/sci/graphics/video32.cpp
@@ -121,6 +121,21 @@ bool VideoPlayer::endHQVideo() {
 	return false;
 }
 
+void VideoPlayer::setSubtitlePosition() const {
+	const int16 overlayHeight = g_system->getOverlayHeight(),
+				overlayWidth = g_system->getOverlayWidth(),
+				drawHeight = _drawRect.height(),
+				drawWidth = _drawRect.width();
+	_subtitles.setBBox(
+		Common::Rect(
+			(_drawRect.left + 20) * overlayWidth / drawWidth,
+			(_drawRect.bottom - 80) * overlayHeight / drawHeight,
+			(_drawRect.right - 20)  * overlayWidth / drawWidth,
+			(_drawRect.bottom - 10) * overlayHeight / drawHeight
+		)
+	);
+}
+
 VideoPlayer::EventFlags VideoPlayer::playUntilEvent(const EventFlags flags, const uint32 maxSleepMs) {
 	// Flushing all the keyboard and mouse events out of the event manager keeps
 	// events queued from before the start of playback from accidentally
@@ -132,9 +147,7 @@ VideoPlayer::EventFlags VideoPlayer::playUntilEvent(const EventFlags flags, cons
 	EventFlags stopFlag = kEventFlagNone;
 
 	if (_subtitles.isLoaded()) {
-		const int16 h = g_system->getOverlayHeight(),
-			        w = g_system->getOverlayWidth();
-		_subtitles.setBBox(Common::Rect(20, h - 120, w - 20, h - 20));
+		setSubtitlePosition();
 		_subtitles.setColor(0xff, 0xff, 0xff);
 		_subtitles.setFont("FreeSans.ttf");
 
@@ -286,6 +299,8 @@ void VideoPlayer::renderFrame(const Graphics::Surface &nextFrame) const {
 	g_system->copyRectToScreen(convertedFrame->getPixels(), convertedFrame->pitch, _drawRect.left, _drawRect.top, _drawRect.width(), _drawRect.height());
 	g_sci->_gfxFrameout->updateScreen();
 
+	if (_subtitles.isLoaded())
+		setSubtitlePosition();
 	_subtitles.drawSubtitle(_decoder->getTime(), true);
 
 	if (freeConvertedFrame) {

--- a/engines/sci/graphics/video32.h
+++ b/engines/sci/graphics/video32.h
@@ -33,6 +33,7 @@
 #include "sci/video/robot_decoder.h" // for RobotDecoder
 #include "sci/sound/audio32.h"    // for Audio32::kMaxVolume
 #include "video/avi_decoder.h"    // for AVIDecoder::setVolume
+#include "video/subtitles.h"      // for Video::Subtitles
 
 namespace Video {
 class AdvancedVMDDecoder;
@@ -183,6 +184,9 @@ protected:
 	 * Current frame rendered by playUntilEvent()
 	 */
 	const Graphics::Surface* _currentFrame;
+
+
+	Video::Subtitles _subtitles;
 
 #ifdef USE_RGB_COLOR
 	/**

--- a/engines/sci/graphics/video32.h
+++ b/engines/sci/graphics/video32.h
@@ -191,7 +191,9 @@ protected:
 	 */
 	const Graphics::Surface* _currentFrame;
 
-
+	/**
+	 * Video SRT subtitles used by fan translation projects for phantasmagoria 1 & 2.
+	 */
 	mutable Video::Subtitles _subtitles;
 
 #ifdef USE_RGB_COLOR

--- a/engines/sci/graphics/video32.h
+++ b/engines/sci/graphics/video32.h
@@ -169,6 +169,12 @@ protected:
 	void setDrawRect(const int16 x, const int16 y, const int16 width, const int16 height);
 
 	/**
+	 * Sets the subtitle position according to the draw rect and overlay size.
+	 * 
+	 */
+	void setSubtitlePosition() const;
+
+	/**
 	 * The rectangle where the video will be drawn, in screen coordinates.
 	 */
 	Common::Rect _drawRect;
@@ -186,7 +192,7 @@ protected:
 	const Graphics::Surface* _currentFrame;
 
 
-	Video::Subtitles _subtitles;
+	mutable Video::Subtitles _subtitles;
 
 #ifdef USE_RGB_COLOR
 	/**

--- a/video/subtitles.cpp
+++ b/video/subtitles.cpp
@@ -216,7 +216,7 @@ bool SRTParser::parseFile(const char *fname) {
 	return true;
 }
 
-Common::String SRTParser::getSubtitle(uint32 timestamp) {
+Common::String SRTParser::getSubtitle(uint32 timestamp) const {
 	SRTEntry test(0, timestamp, 0, "");
 	SRTEntry *testptr = &test;
 
@@ -299,7 +299,7 @@ void Subtitles::setPadding(uint16 horizontal, uint16 vertical) {
 	_vPad = vertical;
 }
 
-bool Subtitles::drawSubtitle(uint32 timestamp, bool force) {
+bool Subtitles::drawSubtitle(uint32 timestamp, bool force) const {
 	Common::String subtitle;
 	if (_loaded) {
 		subtitle = _srtParser.getSubtitle(timestamp);
@@ -375,7 +375,7 @@ bool Subtitles::drawSubtitle(uint32 timestamp, bool force) {
 	return true;
 }
 
-void Subtitles::renderSubtitle() {
+void Subtitles::renderSubtitle() const {
 	_surface->fillRect(Common::Rect(0, 0, _surface->w, _surface->h), _transparentColor);
 
 	Common::Array<Common::U32String> lines;

--- a/video/subtitles.h
+++ b/video/subtitles.h
@@ -52,7 +52,7 @@ public:
 
 	void cleanup();
 	bool parseFile(const char *fname);
-	Common::String getSubtitle(uint32 timestamp);
+	Common::String getSubtitle(uint32 timestamp) const;
 
 private:
 	Common::Array<SRTEntry *> _entries;
@@ -69,11 +69,11 @@ public:
 	void setBBox(const Common::Rect bbox);
 	void setColor(byte r, byte g, byte b);
 	void setPadding(uint16 horizontal, uint16 vertical);
-	bool drawSubtitle(uint32 timestamp, bool force = false);
+	bool drawSubtitle(uint32 timestamp, bool force = false) const;
 	bool isLoaded() const { return _loaded || _subtitleDev; }
 
 private:
-	void renderSubtitle();
+	void renderSubtitle() const;
 
 	SRTParser _srtParser;
 	bool _loaded;
@@ -85,13 +85,13 @@ private:
 
 	Graphics::Surface *_surface;
 
-	Common::Rect _drawRect;
+	mutable Common::Rect _drawRect;
 	Common::Rect _requestedBBox;
-	Common::Rect _realBBox;
-	int16 _lastOverlayWidth, _lastOverlayHeight;
+	mutable Common::Rect _realBBox;
+	mutable int16 _lastOverlayWidth, _lastOverlayHeight;
 
 	Common::String _fname;
-	Common::String _subtitle;
+	mutable Common::String _subtitle;
 	uint32 _color;
 	uint32 _blackColor;
 	uint32 _transparentColor;


### PR DESCRIPTION
This allows reading subtitles from SRT files during videos in SCI32 games,
specifically Phantasmagoria and Phantasmagoria 2.

Some notes:
- Subtitles filenames have both the extension of the video and srt extension (e.g. `30.vmd.srt`, to prevent case of having e.g. twice 30.srt for two different video types... I am not sure if games may have the same number there or not.
- I have considered limiting the subtitles to the video display area (which is usually smaller then the whole screen, but it had issues when using OpenGL renderer (different place when resizing differently)
- Might be possible (and better) to utilize the mechanism used by Gabriel Knight 2 Subtitle patch instead
- Perhaps the drawing of subtitles should be delegated to the game itself somehow, so the TTF font rendering on overlay wiuld not look out of place.
- There are other games using those formats, and their display area of video may be different.
- Most of the functionality is inside the base video class, only the loading is per format.

More comments are welcome!
