### PR TITLE
TINSEL: Fix token function calls from non-coroutines

### DIFF
--- a/engines/tinsel/events.cpp
+++ b/engines/tinsel/events.cpp
@@ -170,7 +170,7 @@ void ControlOn() {
  */
 void ControlOff() {
 	if (TinselVersion <= 1) {
-		Control(CONTROL_ON);
+		Control(CONTROL_OFF);
 		return;
 	}
 


### PR DESCRIPTION
Add extra bools to track token status. This allows setting
the owner to nullptr when a token is acquired from a
non-coroutine context / nullContext without marking it as free.

Fixes the following assert in Discworld 1 (see [#13220](https://bugs.scummvm.org/ticket/13220)):

After using the matches on the drainpipe to get the golden chimney
brush, the game switches to non-interactive scenes twice.
When changing back to the original scene, player control should be
disabled while a short animation plays, but this is not the case.
A mouse click by the player during this animation will then initiate
a walk action and cause a failed assert:

```
engines/tinsel/events.cpp:280:
 void Tinsel::WalkProcess(Common::CoroBaseContext*&, const void*):
 Assertion `_ctx->pMover->hCpath != NOPOLY' failed.
```

The game attempts to disable user control via the following call chain:
```
Tinsel::TinselEngine::NextGameCycle()
  Tinsel::ChangeScene()
    Tinsel::DoRestoreSceneFrame()
      Tinsel::Background::StartupBackground()
        Tinsel::ControlStartOff()
	  Tinsel::Control()
            Tinsel::GetControlToken()
```

This will set the owner of the control token to the current coroutine:
`g_tokens[TOKEN_CONTROL].proc = CoroScheduler.getCurrentProcess()`

However, since StartupBackground() is called from a non-coroutine
with a nullContext, getCurrentProcess() will return nullptr,
thereby marking the control token as free and allowing player actions.