### PR TITLE
ANDROID: Various fixes around rotation and resize of activity

### DIFF
--- a/backends/graphics/android/android-graphics.cpp
+++ b/backends/graphics/android/android-graphics.cpp
@@ -138,6 +138,25 @@ void AndroidGraphicsManager::deinitSurface() {
 	JNI::deinitSurface();
 }
 
+void AndroidGraphicsManager::resizeSurface() {
+
+	// If we had lost surface just init it again
+	if (!JNI::haveSurface()) {
+		initSurface();
+		return;
+	}
+
+	// Recreate the EGL surface, context is preserved
+	JNI::deinitSurface();
+	JNI::initSurface();
+
+	dynamic_cast<OSystem_Android *>(g_system)->getTouchControls().init(
+	    this, JNI::egl_surface_width, JNI::egl_surface_height);
+
+	handleResize(JNI::egl_surface_width, JNI::egl_surface_height);
+}
+
+
 void AndroidGraphicsManager::updateScreen() {
 	//ENTER();
 

--- a/backends/graphics/android/android-graphics.h
+++ b/backends/graphics/android/android-graphics.h
@@ -33,6 +33,7 @@ public:
 
 	virtual void initSurface() = 0;
 	virtual void deinitSurface() = 0;
+	virtual void resizeSurface() = 0;
 
 	virtual Common::Point getMousePosition() = 0;
 	virtual bool notifyMousePosition(Common::Point &mouse) = 0;
@@ -71,6 +72,7 @@ public:
 
 	virtual void initSurface() override;
 	virtual void deinitSurface() override;
+	virtual void resizeSurface() override;
 
 	virtual AndroidCommonGraphics::State getState() const override;
 	virtual bool setState(const AndroidCommonGraphics::State &state) override;

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -202,6 +202,10 @@ void AndroidGraphics3dManager::initSurface() {
 		_mouse_texture->reinit();
 	}
 
+	if (_mouse_texture_palette && _mouse_texture != _mouse_texture_palette) {
+		_mouse_texture_palette->reinit();
+	}
+
 	if (_touchcontrols_texture) {
 		_touchcontrols_texture->reinit();
 	}
@@ -237,6 +241,10 @@ void AndroidGraphics3dManager::deinitSurface() {
 
 	if (_mouse_texture) {
 		_mouse_texture->release();
+	}
+
+	if (_mouse_texture_palette && _mouse_texture != _mouse_texture_palette) {
+		_mouse_texture_palette->release();
 	}
 
 	dynamic_cast<OSystem_Android *>(g_system)->getTouchControls().init(
@@ -823,6 +831,7 @@ void AndroidGraphics3dManager::setMouseCursor(const void *buf, uint w, uint h,
 				_mouse_texture_rgb = new GLES8888Texture();
 			}
 			_mouse_texture_rgb->setLinearFilter(_graphicsMode == 1);
+			_mouse_texture_rgb->reinit();
 		}
 
 		_mouse_texture = _mouse_texture_rgb;

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -547,7 +547,9 @@ void AndroidGraphics3dManager::showOverlay(bool inGUI) {
 		}
 	}
 
-	warpMouse(_overlay_texture->width() / 2, _overlay_texture->height() / 2);
+	if (inGUI) {
+		warpMouse(_overlay_texture->width() / 2, _overlay_texture->height() / 2);
+	}
 }
 
 void AndroidGraphics3dManager::hideOverlay() {

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -250,6 +250,31 @@ void AndroidGraphics3dManager::deinitSurface() {
 	JNI::deinitSurface();
 }
 
+void AndroidGraphics3dManager::resizeSurface() {
+	LOGD("resizing 3D surface");
+
+	if (!JNI::haveSurface()) {
+		initSurface();
+		return;
+	}
+
+	JNI::deinitSurface();
+	JNI::initSurface();
+
+	_screenChangeID = JNI::surface_changeid;
+
+	if (_overlay_texture) {
+		initOverlay();
+	}
+
+	dynamic_cast<OSystem_Android *>(g_system)->getTouchControls().init(
+	    this, JNI::egl_surface_width, JNI::egl_surface_height);
+
+	updateScreenRect();
+	// double buffered, flip twice
+	clearScreen(kClearUpdate, 2);
+}
+
 void AndroidGraphics3dManager::updateScreen() {
 	//ENTER();
 

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -127,9 +127,14 @@ AndroidGraphics3dManager::~AndroidGraphics3dManager() {
 	glBindRenderbuffer(GL_RENDERBUFFER, 0);
 	glUseProgram(0);
 
+	// Cleanup framebuffer before destroying context
+	delete _frame_buffer;
+	_frame_buffer = nullptr;
+
 	deinitSurface();
 
-	delete _frame_buffer;
+	// These textures have been cleaned in deinitSurface
+	// Deleting them now without a context is harmless
 	delete _game_texture;
 	delete _overlay_texture;
 	delete _overlay_background;

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -106,7 +106,7 @@ AndroidGraphics3dManager::AndroidGraphics3dManager() :
 		// If not 16, this must be 24 or 32 bpp so make use of them
 		_game_texture = new GLES888Texture();
 		_overlay_texture = new GLES8888Texture();
-		_overlay_background = new GLES888Texture();
+		_overlay_background = new GLES8888Texture();
 		_mouse_texture_palette = new GLESFakePalette8888Texture();
 	}
 	_mouse_texture = _mouse_texture_palette;
@@ -526,10 +526,12 @@ void AndroidGraphics3dManager::showOverlay(bool inGUI) {
 			}
 
 			GLCALL(glViewport(0, 0, JNI::egl_surface_width, JNI::egl_surface_height));
+			_overlay_background->reinit();
 			_overlay_background->allocBuffer(_overlay_texture->width(), _overlay_texture->height());
 			_overlay_background->setDrawRect(0, 0,
 			                                 JNI::egl_surface_width, JNI::egl_surface_height);
 			_overlay_background->readPixels();
+			_overlay_background->setGameTexture();
 
 			// Restore game viewport
 			GLCALL(glViewport(savedViewport[0], savedViewport[1], savedViewport[2], savedViewport[3]));

--- a/backends/graphics3d/android/android-graphics3d.h
+++ b/backends/graphics3d/android/android-graphics3d.h
@@ -39,6 +39,7 @@ public:
 
 	virtual void initSurface() override;
 	virtual void deinitSurface() override;
+	virtual void resizeSurface() override;
 
 	virtual AndroidCommonGraphics::State getState() const override;
 	virtual bool setState(const AndroidCommonGraphics::State &state) override;

--- a/backends/graphics3d/android/texture.cpp
+++ b/backends/graphics3d/android/texture.cpp
@@ -141,7 +141,6 @@ GLESBaseTexture::GLESBaseTexture(GLenum glFormat, GLenum glType,
 	_pixelFormat(pixelFormat),
 	_palettePixelFormat(),
 	_is_game_texture(false) {
-	GLCALL(glGenTextures(1, &_texture_name));
 }
 
 GLESBaseTexture::~GLESBaseTexture() {
@@ -156,6 +155,10 @@ void GLESBaseTexture::release() {
 }
 
 void GLESBaseTexture::reinit() {
+	if (_texture_name) {
+		release();
+	}
+
 	GLCALL(glGenTextures(1, &_texture_name));
 
 	initSize();
@@ -164,6 +167,10 @@ void GLESBaseTexture::reinit() {
 }
 
 void GLESBaseTexture::initSize() {
+	if (!_texture_name) {
+		return;
+	}
+
 	// Allocate room for the texture now, but pixel data gets uploaded
 	// later (perhaps with multiple TexSubImage2D operations).
 	GLCALL(glBindTexture(GL_TEXTURE_2D, _texture_name));
@@ -184,6 +191,10 @@ void GLESBaseTexture::setLinearFilter(bool value) {
 		_glFilter = GL_NEAREST;
 	}
 
+	if (!_texture_name) {
+		return;
+	}
+
 	GLCALL(glBindTexture(GL_TEXTURE_2D, _texture_name));
 
 	GLCALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, _glFilter));
@@ -191,13 +202,13 @@ void GLESBaseTexture::setLinearFilter(bool value) {
 }
 
 void GLESBaseTexture::allocBuffer(GLuint w, GLuint h) {
+	if (w == _surface.w && h == _surface.h) {
+		return;
+	}
+
 	_surface.w = w;
 	_surface.h = h;
 	_surface.format = _pixelFormat;
-
-	if (w == _texture_width && h == _texture_height) {
-		return;
-	}
 
 	if (_npot_supported) {
 		_texture_width = _surface.w;
@@ -212,6 +223,10 @@ void GLESBaseTexture::allocBuffer(GLuint w, GLuint h) {
 
 void GLESBaseTexture::drawTexture(GLshort x, GLshort y, GLshort w, GLshort h,
                                   const Common::Rect &clip) {
+	if (!_texture_name) {
+		return;
+	}
+
 	if (_all_dirty) {
 		_dirty_rect.top = 0;
 		_dirty_rect.left = 0;
@@ -230,7 +245,7 @@ void GLESBaseTexture::drawTexture(GLshort x, GLshort y, GLshort w, GLshort h,
 		GLCALL(glTexSubImage2D(GL_TEXTURE_2D, 0,
 		                       _dirty_rect.left, _dirty_rect.top,
 		                       _dirty_rect.width(), _dirty_rect.height(),
-				       _glFormat, _glType, tex));
+		                       _glFormat, _glType, tex));
 	}
 
 

--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -246,8 +246,9 @@ OSystem_Android::~OSystem_Android() {
 	delete _savefileManager;
 	_savefileManager = 0;
 
-	// Uninitialize surface now to avoid it to be done later when touch controls are destroyed
-	dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->deinitSurface();
+	// Uninitialize graphics manager now to avoid it to be done later when touch controls are destroyed
+	delete _graphicsManager;
+	_graphicsManager = 0;
 
 	delete _logger;
 	_logger = nullptr;

--- a/backends/platform/android/android.h
+++ b/backends/platform/android/android.h
@@ -223,7 +223,7 @@ public:
 	void *getOpenGLProcAddress(const char *name) const override;
 #endif
 
-#ifdef ANDROID_DEBUG_GL_CALLS
+#ifdef ANDROID_DEBUG_GL
 	bool isRunningInMainThread() { return pthread_self() == _main_thread; }
 #endif
 

--- a/backends/platform/android/events.cpp
+++ b/backends/platform/android/events.cpp
@@ -1417,7 +1417,8 @@ bool OSystem_Android::pollEvent(Common::Event &event) {
 	if (pthread_self() == _main_thread) {
 		if (_screen_changeid != JNI::surface_changeid) {
 			_screen_changeid = JNI::surface_changeid;
-
+			// If we loose the surface, don't deinit as we loose the EGL context and this may lead to crashes
+			// Keep a dangling surface until we get a resize
 			if (JNI::egl_surface_width > 0 && JNI::egl_surface_height > 0) {
 				// surface changed
 				dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->resizeSurface();
@@ -1425,9 +1426,6 @@ bool OSystem_Android::pollEvent(Common::Event &event) {
 				event.type = Common::EVENT_SCREEN_CHANGED;
 
 				return true;
-			} else {
-				// surface lost
-				dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->deinitSurface();
 			}
 		}
 

--- a/backends/platform/android/events.cpp
+++ b/backends/platform/android/events.cpp
@@ -1420,8 +1420,7 @@ bool OSystem_Android::pollEvent(Common::Event &event) {
 
 			if (JNI::egl_surface_width > 0 && JNI::egl_surface_height > 0) {
 				// surface changed
-				dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->deinitSurface();
-				dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->initSurface();
+				dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->resizeSurface();
 
 				event.type = Common::EVENT_SCREEN_CHANGED;
 

--- a/backends/platform/android/org/scummvm/scummvm/ScummVM.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVM.java
@@ -167,10 +167,10 @@ public abstract class ScummVM implements SurfaceHolder.Callback, Runnable {
 
 		int res = main(_args);
 
+		destroy();
+
 		deinitEGL();
 		deinitAudio();
-
-		destroy();
 
 		// Don't exit force-ably here!
 		if (_svm_destroyed_callback != null) {

--- a/backends/platform/android/org/scummvm/scummvm/ScummVM.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVM.java
@@ -109,13 +109,6 @@ public abstract class ScummVM implements SurfaceHolder.Callback, Runnable {
 	// SurfaceHolder callback
 	final public void surfaceChanged(SurfaceHolder holder, int format,
 										int width, int height) {
-		// the orientation may reset on standby mode and the theme manager
-		// could assert when using a portrait resolution. so lets not do that.
-		if (height > width) {
-			Log.d(LOG_TAG, String.format(Locale.ROOT, "Ignoring surfaceChanged: %dx%d (%d)",
-											width, height, format));
-			return;
-		}
 
 		PixelFormat pixelFormat = new PixelFormat();
 		PixelFormat.getPixelFormatInfo(format, pixelFormat);

--- a/backends/platform/android/org/scummvm/scummvm/ScummVM.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVM.java
@@ -413,7 +413,8 @@ public abstract class ScummVM implements SurfaceHolder.Callback, Runnable {
 				score += 10;
 
 			// penalize for wasted bits
-			score -= value - size;
+			if (value > size)
+				score -= value - size;
 
 			return score;
 		}

--- a/backends/platform/android/org/scummvm/scummvm/ScummVM.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVM.java
@@ -438,8 +438,9 @@ public abstract class ScummVM implements SurfaceHolder.Callback, Runnable {
 			score += weightBits(EGL10.EGL_GREEN_SIZE, 6);
 			score += weightBits(EGL10.EGL_BLUE_SIZE, 5);
 			score += weightBits(EGL10.EGL_ALPHA_SIZE, 0);
-			score += weightBits(EGL10.EGL_DEPTH_SIZE, 0);
-			score += weightBits(EGL10.EGL_STENCIL_SIZE, 0);
+			// Prefer 24 bits depth
+			score += weightBits(EGL10.EGL_DEPTH_SIZE, 24);
+			score += weightBits(EGL10.EGL_STENCIL_SIZE, 8);
 
 			return score;
 		}
@@ -535,6 +536,10 @@ public abstract class ScummVM implements SurfaceHolder.Callback, Runnable {
 						good = false;
 				}
 				if (attr.get(EGL10.EGL_BUFFER_SIZE) < bitsPerPixel)
+					good = false;
+
+				// Force a config with a depth buffer and a stencil buffer when rendering directly on backbuffer
+				if ((attr.get(EGL10.EGL_DEPTH_SIZE) == 0) || (attr.get(EGL10.EGL_STENCIL_SIZE) == 0))
 					good = false;
 
 				int score = attr.weight();

--- a/dists/android/AndroidManifest.xml
+++ b/dists/android/AndroidManifest.xml
@@ -46,7 +46,8 @@
 			android:name=".SplashActivity"
 			android:exported="true"
 			android:banner="@drawable/leanback_icon"
-			android:configChanges="orientation|keyboard|keyboardHidden|screenSize"
+			android:configChanges="orientation|keyboard|keyboardHidden|screenSize|smallestScreenSize|screenLayout"
+			android:resizeableActivity="true"
 			android:theme="@style/SplashTheme"
 			android:windowSoftInputMode="adjustResize">
 			<intent-filter>
@@ -61,7 +62,8 @@
 			android:name=".ScummVMActivity"
 			android:exported="false"
 			android:banner="@drawable/leanback_icon"
-			android:configChanges="orientation|keyboard|keyboardHidden|screenSize"
+			android:configChanges="orientation|keyboard|keyboardHidden|screenSize|smallestScreenSize|screenLayout"
+			android:resizeableActivity="true"
 			android:launchMode="singleInstance"
 			android:theme="@style/AppTheme"
 			android:windowSoftInputMode="adjustResize">

--- a/dists/android/AndroidManifest.xml
+++ b/dists/android/AndroidManifest.xml
@@ -18,9 +18,6 @@
 		android:name="android.hardware.wifi"
 		android:required="false" />
 	<uses-feature
-		android:name="android.hardware.screen.landscape"
-		android:required="false" />
-	<uses-feature
 		android:name="android.hardware.touchscreen"
 		android:required="false" />
 	<uses-feature
@@ -50,7 +47,6 @@
 			android:exported="true"
 			android:banner="@drawable/leanback_icon"
 			android:configChanges="orientation|keyboard|keyboardHidden|screenSize"
-			android:screenOrientation="landscape"
 			android:theme="@style/SplashTheme"
 			android:windowSoftInputMode="adjustResize">
 			<intent-filter>
@@ -67,7 +63,6 @@
 			android:banner="@drawable/leanback_icon"
 			android:configChanges="orientation|keyboard|keyboardHidden|screenSize"
 			android:launchMode="singleInstance"
-			android:screenOrientation="landscape"
 			android:theme="@style/AppTheme"
 			android:windowSoftInputMode="adjustResize">
 		</activity>


### PR DESCRIPTION
This PR includes #2724 which enabled rotation.
Now, resize is enabled too: the user can split the screen with ScummVM running in half of the screen.

A bunch of fixes is also included:
- the framebuffer is not used when it's not needed, this may improve performance
- overlay background never worked before and is now fixed
- Android textures implementation got several fixes
- several code paths where GL functions were called without a valid context have been removed.
