### PR TITLE
GRAPHICS: Add scaling for winfont

### DIFF
--- a/graphics/fonts/winfont.h
+++ b/graphics/fonts/winfont.h
@@ -70,6 +70,7 @@ public:
 	void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const;
 	int getStyle();
 
+	static WinFont *scaleFont(const WinFont *src, int newSize);
 private:
 	bool loadFromEXE(Common::WinResources *exe, const Common::String &fileName, const WinFontDirEntry &dirEntry);
 

--- a/graphics/macgui/macfontmanager.cpp
+++ b/graphics/macgui/macfontmanager.cpp
@@ -524,8 +524,10 @@ const Font *MacFontManager::getFont(MacFont *macFont) {
 			font = _winFontRegistry.getVal(_fontInfo.getVal(id)->name);
 			const Graphics::WinFont *winfont = (const Graphics::WinFont *)font;
 
-			if (winfont->getFontHeight() != macFont->getSize())
+			if (winfont->getFontHeight() != macFont->getSize()) {
 				debug(5, "MacFontManager::getFont(): For font '%s' windows font '%s' is used of a different size %d", macFont->getName().c_str(), winfont->getName().c_str(), winfont->getFontHeight());
+				font = WinFont::scaleFont(winfont, macFont->getSize());
+			}
 		}
 	}
 


### PR DESCRIPTION
Allow scaling of window font, ie FON, FNT. Internally this uses same implementation as BDFScaling and MacFontScaling. Uses function scaleSingleGlyph to scale each glyph.

Fonts in `mcluhan-win` used some of these fonts where the sizes
were different than parsed.