### PR TITLE
GLOBAL: Bulk MSVC warning cleanup

### DIFF
--- a/engines/ags/engine/script/cc_instance.cpp
+++ b/engines/ags/engine/script/cc_instance.cpp
@@ -1038,7 +1038,7 @@ int ccInstance::Run(int32_t curpc) {
 					// call only supports a 32-bit value. This is fine in most cases, since
 					// methods mostly set the ptr on GlobalReturnValue, so it doesn't reach here.
 					// But just in case, throw a wobbly if it reaches here with a 64-bit pointer
-					if (fnResult._ptr > (void *)0xffffffff)
+					if (fnResult._ptr > reinterpret_cast<void *>(static_cast<uintptr>(0xffffffffu)))
 						error("Uhandled 64-bit pointer result from plugin method call");
 
 					return_value.SetPluginArgument(fnResult);

--- a/engines/asylum/system/text.cpp
+++ b/engines/asylum/system/text.cpp
@@ -171,6 +171,7 @@ void Text::drawChinese(const Common::U32String &utext) {
 	uint8 color = 0;
 	// TODO: Add more colors
 	switch (_fontResource->getResourceId()) {
+	case 0: // Case to quiet VS C4065 warning
 	default:
 		debug(5, "Unrecognized font resource 0x%x for string %s", _fontResource->getResourceId(), utext.encode().c_str());
 		color = 1;

--- a/engines/bladerunner/vqa_decoder.cpp
+++ b/engines/bladerunner/vqa_decoder.cpp
@@ -1206,7 +1206,7 @@ bool VQADecoder::VQAVideoTrack::decodeFrame(Graphics::Surface *surface) {
 		uint32 dst_y = 0;
 		void  *dstPtr = nullptr;
 
-		assert(_vpointerSize == 2 * (blocks_per_column * blocks_per_line));
+		assert(_vpointerSize == 2u * (blocks_per_column * blocks_per_line));
 		// Create a pointer to the second half of the frame data:
 		const uint8 *srcB = src + (blocks_per_column * blocks_per_line);
 

--- a/engines/buried/scene_view.cpp
+++ b/engines/buried/scene_view.cpp
@@ -1182,7 +1182,7 @@ bool SceneViewWindow::pushTransition(Graphics::Surface *curBackground, Graphics:
 		break;
 	case 2: // Push left
 		for (int i = 0; i < DIB_FRAME_WIDTH; i += stripSize) {
-			curBackground->move(-stripSize, 0, curBackground->h);
+			curBackground->move(-static_cast<int>(stripSize), 0, curBackground->h);
 
 			for (int j = 0; j < curBackground->h; j++)
 				memcpy(curBackground->getBasePtr(curBackground->w - (int)stripSize, j), newBackground->getBasePtr(i, j), stripSize * newBackground->format.bytesPerPixel);
@@ -1193,7 +1193,7 @@ bool SceneViewWindow::pushTransition(Graphics::Surface *curBackground, Graphics:
 		break;
 	case 3: // Push up
 		for (int i = 0; i < DIB_FRAME_HEIGHT; i += stripSize) {
-			curBackground->move(0, -stripSize, curBackground->h);
+			curBackground->move(0, -static_cast<int>(stripSize), curBackground->h);
 
 			for (uint j = 0; j < stripSize; j++)
 				memcpy(curBackground->getBasePtr(0, curBackground->h - stripSize + j), newBackground->getBasePtr(0, i + j), newBackground->w * newBackground->format.bytesPerPixel);

--- a/engines/chamber/cga.cpp
+++ b/engines/chamber/cga.cpp
@@ -417,7 +417,7 @@ NB! Line must not wrap around the edge
 void cga_DrawVLine(uint16 x, uint16 y, uint16 l, byte color, byte *target) {
 	uint16 ofs;
 	/*pixels are starting from top bits of byte*/
-	uint16 mask = ~(3 << ((CGA_PIXELS_PER_BYTE - 1) * CGA_BITS_PER_PIXEL));
+	uint16 mask = static_cast<uint16>((~(3 << ((CGA_PIXELS_PER_BYTE - 1) * CGA_BITS_PER_PIXEL))) & 0xffff);
 	byte pixel = color << ((CGA_PIXELS_PER_BYTE - 1) * CGA_BITS_PER_PIXEL);
 
 	mask >>= (x % CGA_PIXELS_PER_BYTE) * CGA_BITS_PER_PIXEL;
@@ -444,7 +444,7 @@ NB! Line must not wrap around the edge
 void cga_DrawHLine(uint16 x, uint16 y, uint16 l, byte color, byte *target) {
 	uint16 ofs;
 	/*pixels are starting from top bits of byte*/
-	uint16 mask = ~(3 << ((CGA_PIXELS_PER_BYTE - 1) * CGA_BITS_PER_PIXEL));
+	uint16 mask = static_cast<uint16>((~(3 << ((CGA_PIXELS_PER_BYTE - 1) * CGA_BITS_PER_PIXEL))) & 0xffff);
 	byte pixel = color << ((CGA_PIXELS_PER_BYTE - 1) * CGA_BITS_PER_PIXEL);
 
 	mask >>= (x % CGA_PIXELS_PER_BYTE) * CGA_BITS_PER_PIXEL;
@@ -458,7 +458,7 @@ void cga_DrawHLine(uint16 x, uint16 y, uint16 l, byte color, byte *target) {
 		pixel >>= CGA_BITS_PER_PIXEL;
 		if (mask == 0xFF) {
 			ofs++;
-			mask = ~(3 << ((CGA_PIXELS_PER_BYTE - 1) * CGA_BITS_PER_PIXEL));
+			mask = static_cast<uint16>((~(3 << ((CGA_PIXELS_PER_BYTE - 1) * CGA_BITS_PER_PIXEL))) & 0xffff);
 			pixel = color << ((CGA_PIXELS_PER_BYTE - 1) * CGA_BITS_PER_PIXEL);
 		}
 	}

--- a/engines/chamber/input.cpp
+++ b/engines/chamber/input.cpp
@@ -85,7 +85,7 @@ void clearKeyboard(void) {
 
 void setInputButtons(byte keys) {
 	if (keys & 2)
-		right_button = ~0;
+		right_button = 0xff;
 	if (keys & 1)
 		right_button = 0;
 	buttons = keys;

--- a/engines/chamber/room.cpp
+++ b/engines/chamber/room.cpp
@@ -668,7 +668,7 @@ void beforeChangeZone(byte index) {
 
 	oldspot = script_byte_vars.cur_spot_idx;
 
-	script_byte_vars.need_draw_spots = ~0;
+	script_byte_vars.need_draw_spots = 0xff;
 
 	selectPerson(PersonOffset(kPersScifi));
 	animateSpot(&anim57);

--- a/engines/chamber/script.cpp
+++ b/engines/chamber/script.cpp
@@ -523,17 +523,17 @@ Perform math/logic operation on two operands
 uint16 mathOp(byte op, uint16 op1, uint16 op2) {
 	if (op & MATHOP_CMP) {
 		if (op & MATHOP_EQ)
-			if (op1 == op2) return ~0;
+			if (op1 == op2) return 0xffff;
 		if (op & MATHOP_B)
-			if (op1 < op2) return ~0;
+			if (op1 < op2) return 0xffff;
 		if (op & MATHOP_A)
-			if (op1 > op2) return ~0;
+			if (op1 > op2) return 0xffff;
 		if (op & MATHOP_NEQ)
-			if (op1 != op2) return ~0;
+			if (op1 != op2) return 0xffff;
 		if (op & MATHOP_LE)
-			if ((int16)op1 <= (int16)op2) return ~0;
+			if ((int16)op1 <= (int16)op2) return 0xffff;
 		if (op & MATHOP_GE)
-			if ((int16)op1 >= (int16)op2) return ~0;
+			if ((int16)op1 >= (int16)op2) return 0xffff;
 		return 0;
 	} else {
 		if (op & MATHOP_ADD)
@@ -3262,7 +3262,7 @@ uint16 CMD_4_EnergyLevel(void) {
 	popDirtyRects(DirtyRectBubble);
 
 	cur_dlg_index = 0;
-	ifgm_flag2 = ~0;
+	ifgm_flag2 = 0xff;
 
 	if (script_byte_vars.psy_energy != 0)
 		anim = 41 + (script_byte_vars.psy_energy / 16);

--- a/engines/cine/anim.cpp
+++ b/engines/cine/anim.cpp
@@ -432,11 +432,11 @@ void freeAnimDataRange(byte startIdx, byte numIdx) {
 		}
 
 		// Make sure last accessed index is in bounds
-		if (startIdx + numIdx > g_cine->_animDataTable.size()) {
+		if (static_cast<uint>(startIdx + numIdx) > g_cine->_animDataTable.size()) {
 			numIdx = (byte)(g_cine->_animDataTable.size() - startIdx);
 		}
 		assert(startIdx < g_cine->_animDataTable.size());
-		assert(startIdx + numIdx <= g_cine->_animDataTable.size());
+		assert(static_cast<uint>(startIdx + numIdx) <= g_cine->_animDataTable.size());
 	}
 
 	for (byte i = 0; i < numIdx; i++) {

--- a/engines/director/sound.cpp
+++ b/engines/director/sound.cpp
@@ -370,7 +370,7 @@ void DirectorSound::loadSampleSounds(uint type) {
 	for (auto &it : g_director->_allOpenResFiles) {
 		Common::Array<uint16> idList = g_director->_allSeenResFiles[it]->getResourceIDList(tag);
 		for (uint j = 0; j < idList.size(); j++) {
-			if ((idList[j] & 0xFF) == type) {
+			if (static_cast<uint>(idList[j] & 0xFF) == type) {
 				id = idList[j];
 				archive = g_director->_allSeenResFiles[it];
 				break;

--- a/engines/dragons/background.cpp
+++ b/engines/dragons/background.cpp
@@ -393,11 +393,11 @@ uint16 ScaleLayer::getScale(uint16 y) {
 			local_v0_368 = pSVar4->_y - pSVar6->_y;
 			uVar1 = uVar5;
 			if (local_v0_368 != 0) {
-				iVar3 = ((uVar5 & 0xffffu) - (uVar7 & 0xffffu)) * (uint)(uint16)(y - pSVar6->_y);
+				uint uVar3 = ((uVar5 & 0xffffu) - (uVar7 & 0xffffu)) * (uint)(uint16)(y - pSVar6->_y);
 
-				assert(((uint16)local_v0_368 != 0xffffu) || (iVar3 != (int)-0x80000000));
+				assert(((uint16)local_v0_368 != 0xffffu) || (uVar3 != 0x80000000u));
 
-				return (uVar7 + iVar3 / (int)(uint)(uint16)local_v0_368) & 0xffff;
+				return (uVar7 + static_cast<int>(uVar3) / (int)(uint)(uint16)local_v0_368) & 0xffff;
 			}
 		}
 	}

--- a/engines/freescape/loaders/8bitBinaryLoader.cpp
+++ b/engines/freescape/loaders/8bitBinaryLoader.cpp
@@ -529,9 +529,9 @@ Area *FreescapeEngine::load8bitArea(Common::SeekableReadStream *file, uint16 nco
 		} else if (!(isDemo() && isCastle()))
 			error("Failed to read an object!");
 	}
-	long int endLastObject = file->pos();
+	int64 endLastObject = file->pos();
 	debugC(1, kFreescapeDebugParser, "Last position %lx", endLastObject);
-	assert(endLastObject == base + cPtr || areaNumber == 192);
+	assert(endLastObject == static_cast<int64>(base + cPtr) || areaNumber == 192);
 	file->seek(base + cPtr);
 	uint8 numConditions = readField(file, 8);
 	debugC(1, kFreescapeDebugParser, "%d area conditions at %x of area %d", numConditions, base + cPtr, areaNumber);

--- a/engines/gob/inter_v7.cpp
+++ b/engines/gob/inter_v7.cpp
@@ -1137,7 +1137,7 @@ void Inter_v7::o7_fillRect(OpFuncParams &params) {
 
 			for (int y = 0; y < _vm->_draw->_spriteBottom; y++) {
 				for (int x = 0; x < _vm->_draw->_spriteRight; x++) {
-					if ((colorToReplace & 0xFF) == newSurface->get(x, y).get())
+					if ((colorToReplace & 0xFFu) == newSurface->get(x, y).get())
 						newSurface->putPixel(x, y, _vm->_draw->_backColor);
 				}
 			}

--- a/engines/hypno/grammar_mis.y
+++ b/engines/hypno/grammar_mis.y
@@ -76,7 +76,7 @@ init: {
 	if (smenu_idx)
 		delete smenu_idx;
 	smenu_idx = new Common::Array<uint32>();
-	smenu_idx->push_back(-1);
+	smenu_idx->push_back((uint32)-1);
 	if (stack)
 		delete stack;
 	stack = new Hypno::HotspotsStack();
@@ -134,7 +134,7 @@ line: MENUTOK mflag mflag mflag {
 		Hotspots *cur = stack->back();
 		Hotspot *hot = &(*cur)[idx];
 
-		smenu_idx->push_back(-1);
+		smenu_idx->push_back((uint32)-1);
 		hot->smenu = new Hotspots();
 		stack->push_back(hot->smenu);
 		debugC(1, kHypnoDebugParser, "SUBMENU");

--- a/engines/icb/breath.cpp
+++ b/engines/icb/breath.cpp
@@ -74,7 +74,7 @@ Breath::Breath() {
 #define SMOKE_IC (32)
 #define SMOKE_IS (4)
 
-#define BREATH_DY (-(g_icb->getRandomSource()->getRandomNumber(2 - 1)))
+#define BREATH_DY (-static_cast<int>(g_icb->getRandomSource()->getRandomNumber(2 - 1)))
 #define BREATH_DZ (g_icb->getRandomSource()->getRandomNumber(4 - 1))
 #define BREATH_DC (-4)
 #define BREATH_DS (2)

--- a/engines/icb/function.cpp
+++ b/engines/icb/function.cpp
@@ -3452,7 +3452,7 @@ mcodeFunctionReturnCodes _game_session::fn_set_manual_interact_object(int32 &, i
 
 mcodeFunctionReturnCodes _game_session::fn_cancel_manual_interact_object(int32 &, int32 *) {
 	// Clear the script-forced object interact id.
-	player.cur_interact_id = -1;
+	player.cur_interact_id = (uint32)-1;
 
 	// Calling script can continue.
 	return IR_CONT;

--- a/engines/icb/gfx/psx_pcgpu.cpp
+++ b/engines/icb/gfx/psx_pcgpu.cpp
@@ -34,7 +34,7 @@
 namespace ICB {
 
 // Defaults for the OT list
-#define UNLINKED_ADDR (void *)(0xDEADBEAF)
+#define UNLINKED_ADDR (reinterpret_cast<void *>(static_cast<uintptr>(0xDEADBEAF)))
 #define UNLINKED_LEN (0x6666)
 
 // For storing user data in the OT entry e.g. texture pointer

--- a/engines/immortal/immortal.h
+++ b/engines/immortal/immortal.h
@@ -224,7 +224,7 @@ public:
 	const uint8  kTextLeft    = 8;
 	const uint8  kTextTop     = 4;
 	const uint8  kGaugeX      = 0;
-	const uint8  kGaugeY      = -13;                    // ???
+	const uint8  kGaugeY      = static_cast<uint8>((-13) & 0xff);                    // ???
 	const uint16 kScreenBMW   = 160;                    // Screen BitMap Width?
 	const uint16 kChrW        = 64;
 	const uint16 kChrH        = 32;

--- a/engines/immortal/logic.cpp
+++ b/engines/immortal/logic.cpp
@@ -118,9 +118,9 @@ void ImmortalEngine::logic() {
 			levelDrawAll();
 			updateHitGauge();
 
-			_dim = 0;
+			_dim = false;
 			if ((_level == 0) && (/*_currentLevel.getShowRoom()*/0 == 0) && (_rooms[_currentRoom]->roomLighted() == false) && (/*getNumBullets()*/ 0 == 0)) {
-				_dim += 1;
+				_dim = true;
 			}
 
 			if (_level == 7) {

--- a/engines/myst3/archive.cpp
+++ b/engines/myst3/archive.cpp
@@ -275,7 +275,7 @@ Common::String ResourceDescription::getTextData(uint index) const {
 	memset(decrypted, 0, sizeof(decrypted));
 
 	uint8 *out = &decrypted[0];
-	while (cnt / 4 < (_subentry->metadata.size() + 2) && cnt < 89) {
+	while (cnt / 4u < (_subentry->metadata.size() + 2) && cnt < 89) {
 		// XORed text stored in little endian 32 bit words
 		*out++ = (getMiscData(cnt / 4) >> (8 * (3 - (cnt % 4)))) ^ key++;
 		cnt++;

--- a/engines/nancy/graphics.cpp
+++ b/engines/nancy/graphics.cpp
@@ -324,7 +324,7 @@ void GraphicsManager::rotateBlit(const Graphics::ManagedSurface &src, Graphics::
 void GraphicsManager::crossDissolve(const Graphics::ManagedSurface &from, const Graphics::ManagedSurface &to, byte alpha, Graphics::ManagedSurface &inResult) {
 	assert(from.getBounds() == to.getBounds() && to.getBounds() == inResult.getBounds());
 	inResult.blitFrom(from, Common::Point());
-	inResult.transBlitFrom(to, -1, false, 0, alpha);
+	inResult.transBlitFrom(to, (uint32)-1, false, 0, alpha);
 }
 
 void GraphicsManager::debugDrawToScreen(const Graphics::ManagedSurface &surf) {

--- a/engines/petka/interfaces/interface.cpp
+++ b/engines/petka/interfaces/interface.cpp
@@ -72,7 +72,7 @@ void Interface::removeTexts() {
 	for (uint i = 0; i < _objs.size();) {
 		if (_objs[i]->_resourceId == -2) {
 			g_vm->videoSystem()->addDirtyRect(((QText *)_objs[i])->getRect());
-			g_vm->resMgr()->removeResource(-2);
+			g_vm->resMgr()->removeResource((uint32)-2);
 			delete _objs[i];
 			_objs.remove_at(i);
 		} else {

--- a/engines/petka/objects/heroes.cpp
+++ b/engines/petka/objects/heroes.cpp
@@ -297,7 +297,7 @@ void QObjectPetka::stopWalk() {
 	Common::List<QMessage> &list = g_vm->getQSystem()->_messages;
 	for (Common::List<QMessage>::iterator it = list.begin(); it != list.end(); ++it) {
 		if (it->opcode == kWalked && it->objId == _id) {
-			it->objId = -1;
+			it->objId = (uint16)-1;
 		}
 
 	}

--- a/engines/petka/objects/object.cpp
+++ b/engines/petka/objects/object.cpp
@@ -53,7 +53,7 @@ QVisibleObject::QVisibleObject()
 	: _resourceId(-1), _z(240) {}
 
 QMessageObject::QMessageObject() {
-	_id = -1;
+	_id = (uint16)-1;
 	_status = 0;
 	_time = 0;
 	_dialogColor = -1;

--- a/engines/petka/objects/text.cpp
+++ b/engines/petka/objects/text.cpp
@@ -45,14 +45,14 @@ QText::QText(const Common::U32String &text, uint16 textColor, uint16 outlineColo
 	rect.bottom += 4;
 
 	_rect = Common::Rect((640 - rect.width()) / 2, 479 - rect.height(), 639 - (640 - rect.width()) / 2, 479);
-	Graphics::Surface *s = g_vm->resMgr()->getSurface(-2, rect.width(), rect.height());
+	Graphics::Surface *s = g_vm->resMgr()->getSurface((uint32)-2, rect.width(), rect.height());
 
 	drawText(*s, 0, 630, text, textColor, *font, Graphics::kTextAlignCenter);
 	drawOutline(s, outlineColor);
 }
 
 void QText::draw() {
-	const Graphics::Surface *s = g_vm->resMgr()->getSurface(-2);
+	const Graphics::Surface *s = g_vm->resMgr()->getSurface((uint32)-2);
 	if (s) {
 		g_vm->videoSystem()->transBlitFrom(*s, Common::Point((640 - s->w) / 2, 479 - s->h));
 	}
@@ -138,7 +138,7 @@ QTextDescription::QTextDescription(const Common::U32String &desc, uint32 frame) 
 	flc->setFrame(frame);
 
 	const Graphics::Surface *frameS = flc->getCurrentFrame();
-	Graphics::Surface *s = g_vm->resMgr()->getSurface(-2, 640, 480);
+	Graphics::Surface *s = g_vm->resMgr()->getSurface((uint32)-2, 640, 480);
 
 	Graphics::Surface *convS = frameS->convertTo(s->format, flc->getPalette());
 	s->copyRectToSurface(*convS, 0, 0, _rect);
@@ -161,7 +161,7 @@ void QTextDescription::onClick(Common::Point p) {
 void QTextDescription::draw() {
 	QManager *resMgr = g_vm->resMgr();
 	VideoSystem *videoSys = g_vm->videoSystem();
-	Graphics::Surface *s = resMgr->getSurface(-2);
+	Graphics::Surface *s = resMgr->getSurface((uint32)-2);
 	FlicDecoder *flc = resMgr->getFlic(6008);
 
 	for (auto &dirty : videoSys->rects()) {
@@ -195,7 +195,7 @@ QTextChoice::QTextChoice(const Common::Array<Common::U32String> &choices, uint16
 
 	_rect = Common::Rect((640 - w) / 2, 479 - h, 639 - (640 - w) / 2, 479);
 
-	Graphics::Surface *s = g_vm->resMgr()->getSurface(-2, w, h);
+	Graphics::Surface *s = g_vm->resMgr()->getSurface((uint32)-2, w, h);
 
 	int y = 0;
 	for (uint i = 0; i < _choices.size(); ++i) {
@@ -218,7 +218,7 @@ void QTextChoice::onMouseMove(Common::Point p) {
 	}
 
 	if (newChoice != _activeChoice) {
-		Graphics::Surface *s = g_vm->resMgr()->getSurface(-2);
+		Graphics::Surface *s = g_vm->resMgr()->getSurface((uint32)-2);
 		auto *font = g_vm->getTextFont();
 
 		s->fillRect(Common::Rect(s->w, s->h), 0);

--- a/engines/watchmaker/classes/do_action.cpp
+++ b/engines/watchmaker/classes/do_action.cpp
@@ -66,6 +66,7 @@ void doDoor(WGame &game, int32 obj) {
 
 	anim = init.Obj[obj].anim[CurPlayer];
 	switch (obj) {
+	case 0: // Quiet VS C4065 warning
 	default:
 		anim = init.Obj[obj].anim[CurPlayer];
 		if (init.Obj[obj].goroom)

--- a/engines/watchmaker/ll/ll_anim.cpp
+++ b/engines/watchmaker/ll/ll_anim.cpp
@@ -1441,7 +1441,7 @@ void StartAnim(WGame &game, int32 an) {
 	h->flags = 0;
 	h->CurFrame = 0;
 	h->LastFrame = -3;
-	h->LoopStart = -1;
+	h->LoopStart = (uint16)-1;
 	h->LoopEnd = 0;
 	h->LoopMask = 0;
 	for (a = 0; a < MAX_SUBANIMS; a++) {


### PR DESCRIPTION
This cleans up all Visual Studio warnings except for the following, which need further investigation:

Glk:
```
_G(_hulkImageOffset) = -0x7ff;
```
_hulkImageOffset is a size_t


Immortal:
```
	Common::Array<SFlame> f7{SFlame(576 - 384, (112 + 32) - 256, kFlameNormal), SFlame(576 - 384, (112 + 32) - 256, kFlameNormal),
	                         SFlame(928 - 384, (48 + 32) - 256,  kFlameNormal)};
```
Several of these values are negative, but the SFlame constructor takes a uint16

Watchmaker:
- Several casts of rCreateSurface result from int to gTexture*.  rCreateSurface is currently stubbed and always returns 0, but there is some inconsistency of whether it is supposed to return an int or pointer.

- `PointInside2DRectangle` performs arithmetic on `inside_flag` which is a bool, and then returns it.  It's also returned as an int by `PointInside`, so maybe it should be returning an int?  Not sure.

Some of these fix files generated by Flex not including stdint.h and then redefining integer limit values, only to include a file that includes stdint.h in VS.  This needs to be fixed in Flex itself though.