### PR TITLE
MACGUI: Encode UTF-8 in windows mode

### DIFF
--- a/engines/pink/objects/actions/action_text.cpp
+++ b/engines/pink/objects/actions/action_text.cpp
@@ -122,7 +122,7 @@ void ActionText::start() {
 		break;
 
 	case Common::HE_ISR:
-		_text = Common::String(str).decode(Common::kWindows1251);
+		_text = Common::String(str).decode(Common::kWindows1255);
 		if (!_centered) {
 			align = Graphics::kTextAlignRight;
 		}

--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -71,6 +71,8 @@ bool MacFontRun::equals(MacFontRun &to) {
 }
 
 Common::CodePage MacFontRun::getEncoding() {
+	if (wm->_mode & kWMModeWin95)
+		return Common::kUtf8;
 	return wm->_fontMan->getFontEncoding(fontId);
 }
 


### PR DESCRIPTION
This fixes hebrew rendering of PDA in Pink,
by avoiding usage of "lossy" codepage when on windows mode (utf-8 should be reversible in regards to utf-32)
also reverts commit 2fe812db972b5ccfe5034142be3273db313b1e8f from #5127.