### PR TITLE
SWORD1: Fix softlock when saving in hospital

### DIFF
--- a/engines/sword1/logic.cpp
+++ b/engines/sword1/logic.cpp
@@ -111,6 +111,13 @@ void Logic::newScreen(uint32 screen) {
 	if ((screen == 71) && (SwordEngine::isPsx()))
 		_scriptVars[TOP_MENU_DISABLED] = 0;
 
+	// work around bug #14521
+	// In the hospital, after pulling the plug from the socket, it is possible to save the game before Sam the janitor
+	// returns to his position. On loading this save, he will be reset, but _scriptVars[SAM_RETURNING] will still be set to 1.
+	// This causes a softlock when the plug is pulled again.
+	if (screen == 33)
+		_scriptVars[SAM_RETURNING] = 0;
+
 	if (SwordEngine::_systemVars.justRestoredGame) { // if we've just restored a game - we want George to be exactly as saved
 		fnAddHuman(NULL, 0, 0, 0, 0, 0, 0, 0);
 		if (_scriptVars[GEORGE_WALKING]) { // except that if George was walking when we saveed the game


### PR DESCRIPTION
Reset `_scriptVars[SAM_RETURNING]` when changing to scene 33.

In the hospital, after pulling the plug from the socket, it is possible to save the game before Sam the janitor returns to his position.

On loading this save, he will be reset, but `_scriptVars[SAM_RETURNING]` will be set to 1.

This causes a softlock when the plug is pulled again.

Fixes [#14521](https://bugs.scummvm.org/ticket/14521)
