### PR TITLE
ANDROID: Move game screen at top while displaying keyboard

### DIFF
--- a/backends/graphics/android/android-graphics.cpp
+++ b/backends/graphics/android/android-graphics.cpp
@@ -235,6 +235,17 @@ void AndroidGraphicsManager::refreshScreen() {
 	JNI::swapBuffers();
 }
 
+void AndroidGraphicsManager::syncVirtkeyboardState(bool virtkeybd_on) {
+	_screenAlign = SCREEN_ALIGN_CENTER;
+	if (virtkeybd_on) {
+		_screenAlign |= SCREEN_ALIGN_TOP;
+	} else {
+		_screenAlign |= SCREEN_ALIGN_MIDDLE;
+	}
+	recalculateDisplayAreas();
+	_forceRedraw = true;
+}
+
 void AndroidGraphicsManager::touchControlDraw(int16 x, int16 y, int16 w, int16 h, const Common::Rect &clip) {
 	_targetBuffer->enableBlend(OpenGL::Framebuffer::kBlendModeTraditionalTransparency);
 	OpenGL::Pipeline *pipeline = getPipeline();

--- a/backends/graphics/android/android-graphics.h
+++ b/backends/graphics/android/android-graphics.h
@@ -38,6 +38,8 @@ public:
 	virtual Common::Point getMousePosition() = 0;
 	virtual bool notifyMousePosition(Common::Point &mouse) = 0;
 
+	virtual void syncVirtkeyboardState(bool virtkeybd_on) = 0;
+
 	/**
 	 * A (subset) of the graphic manager's state. This is used when switching
 	 * between different Android graphic managers at runtime.
@@ -99,6 +101,8 @@ protected:
 	bool loadVideoMode(uint requestedWidth, uint requestedHeight, const Graphics::PixelFormat &format) override;
 
 	void refreshScreen() override;
+
+	void syncVirtkeyboardState(bool virtkeybd_on) override;
 
 private:
 	OpenGL::Surface *_touchcontrols;

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -38,11 +38,23 @@ enum {
 	STRETCH_FIT_FORCE_ASPECT = 5
 };
 
+enum {
+	SCREEN_ALIGN_CENTER = 0,
+	SCREEN_ALIGN_LEFT = 1,
+	SCREEN_ALIGN_RIGHT = 2,
+	SCREEN_ALIGN_XMASK = 3,
+	SCREEN_ALIGN_MIDDLE = 0,
+	SCREEN_ALIGN_TOP = 4,
+	SCREEN_ALIGN_BOTTOM = 8,
+	SCREEN_ALIGN_YMASK = 12
+};
+
 class WindowedGraphicsManager : virtual public GraphicsManager {
 public:
 	WindowedGraphicsManager() :
 		_windowWidth(0),
 		_windowHeight(0),
+		_screenAlign(SCREEN_ALIGN_CENTER | SCREEN_ALIGN_MIDDLE),
 		_overlayVisible(false),
 		_overlayInGUI(false),
 		_gameScreenShakeXOffset(0),
@@ -303,6 +315,12 @@ protected:
 	int _windowHeight;
 
 	/**
+	 * How the overlay and game screens are aligned in the window.
+	 * Centered vertically and horizontally by default.
+	 */
+	int _screenAlign;
+
+	/**
 	 * Whether the overlay (i.e. launcher, including the out-of-game launcher)
 	 * is visible or not.
 	 */
@@ -438,8 +456,35 @@ private:
 			}
 		}
 
-		drawRect.left = ((_windowWidth - width) / 2) + _gameScreenShakeXOffset * width / getWidth();
-		drawRect.top = ((_windowHeight - height) / 2) + _gameScreenShakeYOffset * height / getHeight();
+		int alignX, alignY;
+		switch (_screenAlign & SCREEN_ALIGN_XMASK) {
+			default:
+			case SCREEN_ALIGN_CENTER:
+				alignX = ((_windowWidth - width) / 2);
+				break;
+			case SCREEN_ALIGN_LEFT:
+				alignX = 0;
+				break;
+			case SCREEN_ALIGN_RIGHT:
+				alignX = (_windowWidth - width);
+				break;
+		}
+
+		switch (_screenAlign & SCREEN_ALIGN_YMASK) {
+			default:
+			case SCREEN_ALIGN_MIDDLE:
+				alignY = ((_windowHeight - height) / 2);
+				break;
+			case SCREEN_ALIGN_TOP:
+				alignY = 0;
+				break;
+			case SCREEN_ALIGN_BOTTOM:
+				alignY = (_windowHeight - height);
+				break;
+		}
+
+		drawRect.left = alignX + _gameScreenShakeXOffset * width / getWidth();
+		drawRect.top = alignY + _gameScreenShakeYOffset * height / getHeight();
 		drawRect.setWidth(width);
 		drawRect.setHeight(height);
 	}

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -80,6 +80,7 @@ AndroidGraphics3dManager::AndroidGraphics3dManager() :
 	_fullscreen(true),
 	_ar_correction(true),
 	_force_redraw(false),
+	_virtkeybd_on(false),
 	_game_texture(0),
 	_frame_buffer(0),
 	_cursorX(0),
@@ -988,7 +989,11 @@ void AndroidGraphics3dManager::updateScreenRect() {
 			rect.moveTo((JNI::egl_surface_width - rect.width()) / 2, 0);
 		} else {
 			rect.setHeight(round(JNI::egl_surface_width / game_ar));
-			rect.moveTo(0, (JNI::egl_surface_height - rect.height()) / 2);
+			if (_virtkeybd_on) {
+				rect.moveTo(0, (JNI::egl_surface_height - rect.height()));
+			} else {
+				rect.moveTo(0, (JNI::egl_surface_height - rect.height()) / 2);
+			}
 		}
 	}
 
@@ -1098,4 +1103,10 @@ void AndroidGraphics3dManager::touchControlNotifyChanged() {
 
 void AndroidGraphics3dManager::touchControlDraw(int16 x, int16 y, int16 w, int16 h, const Common::Rect &clip) {
 	_touchcontrols_texture->drawTexture(x, y, w, h, clip);
+}
+
+void AndroidGraphics3dManager::syncVirtkeyboardState(bool virtkeybd_on) {
+	_virtkeybd_on = virtkeybd_on;
+	updateScreenRect();
+	_force_redraw = true;
 }

--- a/backends/graphics3d/android/android-graphics3d.h
+++ b/backends/graphics3d/android/android-graphics3d.h
@@ -123,6 +123,8 @@ public:
 	void touchControlNotifyChanged() override;
 	void touchControlDraw(int16 x, int16 y, int16 w, int16 h, const Common::Rect &clip) override;
 
+	void syncVirtkeyboardState(bool virtkeybd_on) override;
+
 protected:
 	void updateScreenRect();
 	void updateCursorScaling();
@@ -152,6 +154,8 @@ private:
 	bool _fullscreen;
 	bool _ar_correction;
 	bool _force_redraw;
+
+	bool _virtkeybd_on;
 
 	// Game layer
 	GLESTexture *_game_texture;

--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -912,6 +912,8 @@ bool OSystem_Android::setGraphicsMode(int mode, uint flags) {
 		switchedManager = true;
 	}
 
+	androidGraphicsManager->syncVirtkeyboardState(_virtkeybd_on);
+
 	if (switchedManager) {
 		// Setup the graphics mode and size first
 		// This is needed so that we can check the supported pixel formats when
@@ -951,6 +953,7 @@ int OSystem_Android::getGraphicsMode() const {
 
 void OSystem_Android::syncVirtkeyboardState(bool virtkeybd_on) {
 	_virtkeybd_on = virtkeybd_on;
+	dynamic_cast<AndroidCommonGraphics *>(_graphicsManager)->syncVirtkeyboardState(virtkeybd_on);
 }
 
 #if defined(USE_OPENGL) && defined(USE_GLAD)

--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -646,7 +646,6 @@ void OSystem_Android::setFeatureState(Feature f, bool enable) {
 
 	switch (f) {
 	case kFeatureVirtualKeyboard:
-		_virtkeybd_on = enable;
 		JNI::showVirtualKeyboard(enable);
 		break;
 	default:
@@ -948,6 +947,10 @@ bool OSystem_Android::setGraphicsMode(int mode, uint flags) {
 int OSystem_Android::getGraphicsMode() const {
 	// We only support one mode
 	return 0;
+}
+
+void OSystem_Android::syncVirtkeyboardState(bool virtkeybd_on) {
+	_virtkeybd_on = virtkeybd_on;
 }
 
 #if defined(USE_OPENGL) && defined(USE_GLAD)

--- a/backends/platform/android/android.h
+++ b/backends/platform/android/android.h
@@ -188,6 +188,8 @@ public:
 	void applyTouchSettings(bool _3dMode, bool overlayShown);
 	void setupTouchMode(int oldValue, int newValue);
 
+	void syncVirtkeyboardState(bool virtkeybd_on);
+
 	void applyOrientationSettings();
 
 	bool pollEvent(Common::Event &event) override;

--- a/backends/platform/android/jni-android.cpp
+++ b/backends/platform/android/jni-android.cpp
@@ -134,6 +134,8 @@ const JNINativeMethod JNI::_natives[] = {
 		(void *)JNI::updateTouch },
 	{ "setupTouchMode", "(II)V",
 		(void *)JNI::setupTouchMode },
+	{ "syncVirtkeyboardState", "(Z)V",
+		(void *)JNI::syncVirtkeyboardState },
 	{ "setPause", "(Z)V",
 		(void *)JNI::setPause },
 	{ "getNativeVersionInfo", "()Ljava/lang/String;",
@@ -961,6 +963,13 @@ void JNI::setupTouchMode(JNIEnv *env, jobject self, jint oldValue, jint newValue
 		return;
 
 	_system->setupTouchMode(oldValue, newValue);
+}
+
+void JNI::syncVirtkeyboardState(JNIEnv *env, jobject self, jboolean newState) {
+	if (!_system)
+		return;
+
+	_system->syncVirtkeyboardState(newState);
 }
 
 void JNI::setPause(JNIEnv *env, jobject self, jboolean value) {

--- a/backends/platform/android/jni-android.h
+++ b/backends/platform/android/jni-android.h
@@ -189,6 +189,7 @@ private:
 							int arg2, int arg3, int arg4, int arg5, int arg6);
 	static void updateTouch(JNIEnv *env, jobject self, int action, int ptr, int x, int y);
 	static void setupTouchMode(JNIEnv *env, jobject self, jint oldValue, jint newValue);
+	static void syncVirtkeyboardState(JNIEnv *env, jobject self, jboolean newState);
 	static void setPause(JNIEnv *env, jobject self, jboolean value);
 
 	static jstring getNativeVersionInfo(JNIEnv *env, jobject self);

--- a/backends/platform/android/org/scummvm/scummvm/ScummVM.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVM.java
@@ -62,6 +62,8 @@ public abstract class ScummVM implements SurfaceHolder.Callback, Runnable {
 	final public native void setupTouchMode(int oldValue, int newValue);
 	final public native void updateTouch(int action, int ptr, int x, int y);
 
+	final public native void syncVirtkeyboardState(boolean newState);
+
 	final public native String getNativeVersionInfo();
 
 	// Callbacks from C++ peer instance

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
@@ -490,6 +490,7 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 							_videoLayout.addView(_screenKeyboard, sKeyboardLayout);
 							_videoLayout.bringChildToFront(_screenKeyboard);
 						}
+						_scummvm.syncVirtkeyboardState(true);
 					}
 				});
 			} else {
@@ -510,10 +511,10 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 						//Log.d(ScummVM.LOG_TAG, "showScreenKeyboardWithoutTextInputField - captureMouse(true)");
 						_main_surface.captureMouse(true);
 						//_main_surface.showSystemMouseCursor(false);
+						_scummvm.syncVirtkeyboardState(false);
 					}
 				});
 			}
-			// TODO Do we need to inform native ScummVM code of keyboard shown state?
 //			_main_surface.nativeScreenKeyboardShown( keyboardWithoutTextInputShown ? 1 : 0 );
 		}
 	}


### PR DESCRIPTION
This change also include a change in windowed.h which let backend specify where the game screen should be placed.
This part needs a careful review.