### PR TITLE
DIRECTOR: Fix WinFont scaling memory leak when scaling fonts.

### DIFF
--- a/graphics/fonts/winfont.cpp
+++ b/graphics/fonts/winfont.cpp
@@ -321,7 +321,7 @@ void WinFont::drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) con
 	}
 }
 
-int WinFont::getStyle() {
+int WinFont::getStyle() const {
 	int style = kFontStyleRegular;
 
 	// This has been taken from Wine Source

--- a/graphics/fonts/winfont.h
+++ b/graphics/fonts/winfont.h
@@ -68,7 +68,7 @@ public:
 	Common::String getName() const { return _name; }
 	int getCharWidth(uint32 chr) const;
 	void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const;
-	int getStyle();
+	int getStyle() const;
 
 	static WinFont *scaleFont(const WinFont *src, int newSize);
 private:

--- a/graphics/macgui/macfontmanager.cpp
+++ b/graphics/macgui/macfontmanager.cpp
@@ -526,7 +526,24 @@ const Font *MacFontManager::getFont(MacFont *macFont) {
 
 			if (winfont->getFontHeight() != macFont->getSize()) {
 				debug(5, "MacFontManager::getFont(): For font '%s' windows font '%s' is used of a different size %d", macFont->getName().c_str(), winfont->getName().c_str(), winfont->getFontHeight());
-				font = WinFont::scaleFont(winfont, macFont->getSize());
+
+				Common::String fullFontName = Common::String::format("%s-%d-%d", winfont->getName().c_str(), winfont->getStyle(), macFont->getSize());
+
+				if (_winFontRegistry.contains(fullFontName)) {
+					// Check if we have generated this earlier, in that case reuse it.
+					font = _winFontRegistry.getVal(fullFontName);
+				} else {
+					// Generate a scaledFont
+					Graphics::WinFont *scaledWinFont = WinFont::scaleFont(winfont, macFont->getSize());
+					if (scaledWinFont) {
+						debug(5, "MacFontManager::getFont(): Generated scaled winFont %s", fullFontName.c_str());
+
+						// register font generated for reuse
+						_winFontRegistry.setVal(fullFontName, scaledWinFont);
+
+						font = scaledWinFont;
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Memory leak happened because the scaled generated fonts were not being cached or saved anywhere, thus they were not being destructed and freed. Added logic to cache generated font in _winFontRegistry itself.

Leaks observed in `trektech-win` in first few frames itself.