### PR TITLE
FileBrowser: support setting a default name

### DIFF
--- a/engines/director/lingo/xlibs/fileio.cpp
+++ b/engines/director/lingo/xlibs/fileio.cpp
@@ -222,7 +222,7 @@ void FileIO::m_new(int nargs) {
 		Common::String mask = prefix + "*.txt";
 		dirSeparator = '/';
 
-		GUI::FileBrowserDialog browser(nullptr, "txt", option.equalsIgnoreCase("write") ? GUI::kFBModeSave : GUI::kFBModeLoad, mask.c_str());
+		GUI::FileBrowserDialog browser(nullptr, "txt", option.equalsIgnoreCase("write") ? GUI::kFBModeSave : GUI::kFBModeLoad, mask.c_str(), origpath.c_str());
 		if (browser.runModal() <= 0) {
 			g_lingo->push(Datum(kErrorFileNotFound));
 			return;

--- a/gui/filebrowser-dialog.cpp
+++ b/gui/filebrowser-dialog.cpp
@@ -38,7 +38,7 @@ enum {
 	kChooseCmd = 'Chos'
 };
 
-FileBrowserDialog::FileBrowserDialog(const char *title, const char *fileExtension, int mode, const char *fileMask)
+FileBrowserDialog::FileBrowserDialog(const char *title, const char *fileExtension, int mode, const char *fileMask, const char *initialFilename)
 	: Dialog("FileBrowser"), _mode(mode), _fileExt(fileExtension) {
 
 	if (fileMask == NULL) {
@@ -52,7 +52,7 @@ FileBrowserDialog::FileBrowserDialog(const char *title, const char *fileExtensio
 	new StaticTextWidget(this, "FileBrowser.Headline", title ? Common::convertToU32String(title) :
 					mode == kFBModeLoad ? _("Choose file for loading") : _("Enter filename for saving"));
 
-	_fileName = new EditTextWidget(this, "FileBrowser.Filename", Common::U32String());
+	_fileName = new EditTextWidget(this, "FileBrowser.Filename", Common::U32String(initialFilename));
 
 	if (mode == kFBModeLoad)
 		_fileName->setEnabled(false);

--- a/gui/filebrowser-dialog.h
+++ b/gui/filebrowser-dialog.h
@@ -38,7 +38,7 @@ enum {
 
 class FileBrowserDialog : public Dialog {
 public:
-	FileBrowserDialog(const char *title, const char *fileExtension, int mode, const char *fileMask = NULL);
+	FileBrowserDialog(const char *title, const char *fileExtension, int mode, const char *fileMask = NULL, const char *initialFilename = NULL);
 
 	void open() override;
 


### PR DESCRIPTION
Certain callers may want to specify a default filename for their savegames. This is used in Director, where the file browser can be constructed with the filename field prefilled. I've implemented this by adding a second optional positional argument.

For example, when the player starts a new game or loads an existing game in Ganbare! Inuchan 2 (ganbareinuchan2), the game prefills the name `INU.DAT`. Right now, ScummVM ignores the provided string and initializes the UI with no filename; with this patch, it works as expected.

I figured I'd open a PR for this since it's modifying the signature of a function outside the Director namespace.