### PR TITLE
BACKENDS: OPENGL: Use multiple potential base paths to load preset

### DIFF
--- a/backends/graphics/opengl/pipelines/libretro.cpp
+++ b/backends/graphics/opengl/pipelines/libretro.cpp
@@ -389,27 +389,34 @@ bool LibRetroPipeline::loadTextures(Common::SearchSet &archSet) {
 		 i = _shaderPreset->textures.begin(), end = _shaderPreset->textures.end();
 		 i != end; ++i) {
 
-		// Unify the path separator slashes to be all in the same direction
+		// Unify the path separator slashes trying to get a filename with all slashes in the same direction
 		Common::String fileName[] = { Common::normalizePath(Common::Path(_shaderPreset->basePath, '\\').toString('\\') + Common::String("\\")  + Common::Path(i->fileName, '/').toString('\\'), '\\'),
-		                              Common::normalizePath(Common::Path(_shaderPreset->basePath, '/').toString('/') + Common::String("/") + Common::Path(i->fileName, '/').toString('/'), '/') };
+		                              Common::normalizePath(Common::Path(_shaderPreset->basePath, '/').toString('/') + Common::String("/") + Common::Path(i->fileName, '/').toString('/'), '/'),
+		                              "" };
+		// We add an extra candidate entry (will be used only for searching via SearchMan)
+		// which seems to catch the case for some shader dependencies
+		fileName[2] = Common::Path(fileName[0], '\\').toString('/');
+
 		Common::SeekableReadStream *stream = nullptr;
 
 		Common::String validFileNameStr;
 
-		// First try SearchMan, then fallback to filesystem
+		// First try filesystem, then fallback to SearchMan
 		for (int j = 0; j < 2; ++j) {
-			if (archSet.hasFile(fileName[j])) {
-				stream = archSet.createReadStreamForMember(fileName[j]);
+			Common::FSNode fsnode(fileName[j]);
+			if (fsnode.exists() && fsnode.isReadable() && !fsnode.isDirectory()
+			    && (stream = fsnode.createReadStream())) {
 				validFileNameStr = fileName[j];
 				break;
 			}
 		}
 
 		if (stream == nullptr) {
-			for (int j = 0; j < 2; ++j) {
-				Common::FSNode fsnode(fileName[j]);
-				if (fsnode.exists() && fsnode.isReadable() && !fsnode.isDirectory()
-				    && (stream = fsnode.createReadStream())) {
+			// SearchMan searches additionally for the extra potential filename entry,
+			// which seems to work as a fallback
+			for (int j = 0; j < 3; ++j) {
+				if (archSet.hasFile(fileName[j])) {
+					stream = archSet.createReadStreamForMember(fileName[j]);
 					validFileNameStr = fileName[j];
 					break;
 				}
@@ -417,7 +424,7 @@ bool LibRetroPipeline::loadTextures(Common::SearchSet &archSet) {
 		}
 
 		if (stream == nullptr) {
-			warning("LibRetroPipeline::loadTextures: Invalid file path. Tried: '%s' and '%s'", fileName[0].c_str(), fileName[1].c_str());
+			warning("LibRetroPipeline::loadTextures: Invalid file path. Tried: '%s', '%s' and '%s'", fileName[0].c_str(), fileName[1].c_str(), fileName[2].c_str());
 			return false;
 		} else {
 			delete stream;
@@ -487,28 +494,35 @@ bool LibRetroPipeline::loadPasses(Common::SearchSet &archSet) {
 		 i = _shaderPreset->passes.begin(), end = _shaderPreset->passes.end();
 		 i != end; ++i) {
 
-		// Unify the path separator slashes to be all in the same direction
+		// Unify the path separator slashes trying to get a filename with all slashes in the same direction
 		// Note that i->fileName is expected to always use '/' (Unix folder separator)
 		Common::String fileName[] = { Common::normalizePath(Common::Path(_shaderPreset->basePath, '\\').toString('\\') + Common::String("\\")  + Common::Path(i->fileName, '/').toString('\\'), '\\'),
-		                              Common::normalizePath(Common::Path(_shaderPreset->basePath, '/').toString('/') + Common::String("/") + Common::Path(i->fileName, '/').toString('/'), '/') };
+		                              Common::normalizePath(Common::Path(_shaderPreset->basePath, '/').toString('/') + Common::String("/") + Common::Path(i->fileName, '/').toString('/'), '/'),
+		                              "" };
+		// We add an extra candidate entry (will be used only for searching via SearchMan)
+		// which seems to catch the case for some shader dependencies
+		fileName[2] = Common::Path(fileName[0], '\\').toString('/');
+
 		Common::SeekableReadStream *stream = nullptr;
 
 		Common::String validFileNameStr;
 
-		// First try SearchMan, then fallback to filesystem
+		// First try filesystem, then fallback to SearchMan
 		for (int j = 0; j < 2; ++j) {
-			if (archSet.hasFile(fileName[j])) {
-				stream = archSet.createReadStreamForMember(fileName[j]);
+			Common::FSNode fsnode(fileName[j]);
+			if (fsnode.exists() && fsnode.isReadable() && !fsnode.isDirectory()
+			    && (stream = fsnode.createReadStream())) {
 				validFileNameStr = fileName[j];
 				break;
 			}
 		}
 
 		if (stream == nullptr) {
-			for (int j = 0; j < 2; ++j) {
-				Common::FSNode fsnode(fileName[j]);
-				if (fsnode.exists() && fsnode.isReadable() && !fsnode.isDirectory()
-				    && (stream = fsnode.createReadStream())) {
+			// SearchMan searches additionally for the extra potential filename entry,
+			// which seems to work as a fallback
+			for (int j = 0; j < 3; ++j) {
+				if (archSet.hasFile(fileName[j])) {
+					stream = archSet.createReadStreamForMember(fileName[j]);
 					validFileNameStr = fileName[j];
 					break;
 				}
@@ -516,7 +530,7 @@ bool LibRetroPipeline::loadPasses(Common::SearchSet &archSet) {
 		}
 
 		if (stream == nullptr) {
-			warning("LibRetroPipeline::loadPasses: Invalid file path. Tried: '%s' and '%s'", fileName[0].c_str(), fileName[1].c_str());
+			warning("LibRetroPipeline::loadPasses: Invalid file path. Tried: '%s', '%s' and '%s'", fileName[0].c_str(), fileName[1].c_str(), fileName[2].c_str());
 			return false;
 		}
 

--- a/backends/graphics/opengl/pipelines/libretro/parser.cpp
+++ b/backends/graphics/opengl/pipelines/libretro/parser.cpp
@@ -548,7 +548,18 @@ ShaderPreset *parsePreset(const Common::String &shaderPreset, Common::SearchSet 
 		}
 	}
 
-	Common::String basePath(Common::firstPathComponents(shaderPreset, '/'));
+	// Unify the path separator slashes to (hopefully) be all in the same direction,
+	// so that firstPathComponents() can return a valid result
+	Common::String basePath[] = { Common::firstPathComponents(Common::normalizePath(Common::Path(shaderPreset, '/').toString('/'), '/'), '/'),
+	                              Common::firstPathComponents(Common::normalizePath(Common::Path(shaderPreset, '\\').toString('\\'), '\\'), '\\') };
+
+	Common::String basePathStr = Common::String(".");
+	for (int j = 0; j < 2; ++j) {
+		if (!basePath[j].empty()) {
+			basePathStr = basePath[j];
+			break;
+		}
+	}
 
 	PresetParser parser;
 	ShaderPreset *shader = parser.parseStream(*stream);
@@ -560,7 +571,7 @@ ShaderPreset *parsePreset(const Common::String &shaderPreset, Common::SearchSet 
 		return nullptr;
 	}
 
-	shader->basePath = basePath;
+	shader->basePath = basePathStr;
 	return shader;
 }
 


### PR DESCRIPTION
Also use "." as preset basepath when the basepath is empty

This was tested on Windows 10, Android and Ubuntu Linux and works. 

Possible drawbacks:
- The change in the LibRetroPipeline::loadTextures() method was mostly done for consistency with the code change in  LibRetroPipeline::loadPasses(). Also we may not really need to open a stream for reading and then delete it (?) just to decide on a valid filename.
- Assumes either '/' or '\\' path separators. Are we neglecting other cases?
- We now prioritize searching the File System over SearchMan
- ~Tested only on Windows so far (will test on Android and Linux shortly)~
- ~The comments say that we "unify" the path separators, but that's actually an "attempt to unify" the path separators, and then test if the results can be valid filenames for SearchMan or File System.~

The PR addresses problems reported for loading some shaders either from the list (including ones in the distributed shaders.dat file) or by pointing ScummVM to an external file (via "Pick File Instead").

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
