### PR TITLE
MM: MM1: Fix assert due to invalid char in combat message

### DIFF
--- a/engines/mm/mm1/game/combat.cpp
+++ b/engines/mm/mm1/game/combat.cpp
@@ -934,7 +934,7 @@ void Combat::iterateMonsters1() {
 
 void Combat::iterateMonsters1Inner() {
 	Encounter &enc = g_globals->_encounters;
-	Common::String line1 = Common::String::format("|%s| %s",
+	Common::String line1 = Common::String::format("`%s` %s",
 		g_globals->_currCharacter->_name,
 		STRING["spells.casts_spell"].c_str());
 
@@ -1158,7 +1158,7 @@ void Combat::summonLightning() {
 	SpellsState &ss = g_globals->_spellsState;
 
 	if (_destMonsterNum < _attackersCount) {
-		Common::String line1 = Common::String::format("|%s| %s",
+		Common::String line1 = Common::String::format("`%s` %s",
 			g_globals->_currCharacter->_name,
 			STRING["spells.casts_spell"].c_str());
 
@@ -1316,7 +1316,7 @@ void Combat::fireball() {
 	SpellsState &ss = g_globals->_spellsState;
 
 	if (_destMonsterNum < _attackersCount) {
-		Common::String line1 = Common::String::format("|%s| %s",
+		Common::String line1 = Common::String::format("`%s` %s",
 			g_globals->_currCharacter->_name,
 			STRING["spells.casts_spell"].c_str());
 


### PR DESCRIPTION
Replace ASCII character 124 '|' in combat messages. The character that actually maps to the "vertical bar" glyph in the MM1 font bitmap is 96 '`'.

Values greater than 96 lead to an assert when `MM::BitmapFont::drawChar()` attempts to access the corresponding surface:
``./common/array.h:240: const T& Common::Array<T>::operator[](size_type) const [with T = Graphics::ManagedSurface; size_type = unsigned int]: Assertion `idx < _size' failed.``

Fixes [#14532](https://bugs.scummvm.org/ticket/14532)