### PR TITLE
CGE2: Fix Sfinx crash in builds without TTS

### DIFF
--- a/engines/cge2/vmenu.cpp
+++ b/engines/cge2/vmenu.cpp
@@ -155,7 +155,7 @@ void VMenu::touch(uint16 mask, V2D pos, Common::KeyCode keyCode) {
 
 		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 		if (_lastN != n) {
-			if (ttsMan != nullptr)
+			if (ttsMan != nullptr && ConfMan.getBool("tts_enabled_objects"))
 				ttsMan->say(_menu[n]->_text, Common::TextToSpeechManager::INTERRUPT);
 			_lastN = n;
 		}

--- a/engines/cge2/vmenu.cpp
+++ b/engines/cge2/vmenu.cpp
@@ -155,7 +155,8 @@ void VMenu::touch(uint16 mask, V2D pos, Common::KeyCode keyCode) {
 
 		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 		if (_lastN != n) {
-			ttsMan->say(_menu[n]->_text, Common::TextToSpeechManager::INTERRUPT);
+			if (ttsMan != nullptr)
+				ttsMan->say(_menu[n]->_text, Common::TextToSpeechManager::INTERRUPT);
 			_lastN = n;
 		}
 


### PR DESCRIPTION
Add nullptr check before using TTS in the exit dialog.

Fixes [#14383](https://bugs.scummvm.org/ticket/14383)

Also make sure TTS only plays in the exit dialog when enabled in the game
options ("Enable Text to Speech for Objects and Options").