### PR TITLE
BACKENDS: Fix libretro preset loading

### DIFF
--- a/backends/graphics/opengl/pipelines/libretro.h
+++ b/backends/graphics/opengl/pipelines/libretro.h
@@ -117,7 +117,7 @@ private:
 		Graphics::Surface *textureData;
 		GLTexture *glTexture;
 	};
-	Texture loadTexture(const Common::String &fileName, Common::SearchSet &archSet);
+	Texture loadTexture(const Common::Path &fileName, Common::Archive *container, Common::SearchSet &archSet);
 
 	typedef Common::Array<Texture> TextureArray;
 	TextureArray _textures;

--- a/backends/graphics/opengl/pipelines/libretro/parser.cpp
+++ b/backends/graphics/opengl/pipelines/libretro/parser.cpp
@@ -533,22 +533,30 @@ bool PresetParser::parseParameters() {
 	return true;
 }
 
-ShaderPreset *parsePreset(const Common::String &shaderPreset, Common::SearchSet &archSet) {
+ShaderPreset *parsePreset(const Common::Path &shaderPreset, Common::SearchSet &archSet) {
 	Common::SeekableReadStream *stream;
+	Common::Archive *container = nullptr;
+	Common::Path basePath;
 
 	// First try SearchMan, then fallback to filesystem
 	if (archSet.hasFile(shaderPreset)) {
-		stream = archSet.createReadStreamForMember(shaderPreset);
+		Common::ArchiveMemberPtr member = archSet.getMember(shaderPreset, &container);
+		stream = member->createReadStream();
+		basePath = shaderPreset.getParent();
 	} else {
 		Common::FSNode fsnode(shaderPreset);
 		if (!fsnode.exists() || !fsnode.isReadable() || fsnode.isDirectory()
 				|| !(stream = fsnode.createReadStream())) {
-			warning("LibRetro Preset Parsing: Invalid file path '%s'", shaderPreset.c_str());
+			warning("LibRetro Preset Parsing: Invalid file path '%s'", shaderPreset.toString().c_str());
 			return nullptr;
 		}
+#if defined(WIN32)
+		static const char delimiter = '\\';
+#else
+		static const char delimiter = '/';
+#endif
+		basePath = Common::Path(fsnode.getParent().getPath(), delimiter);
 	}
-
-	Common::String basePath(Common::firstPathComponents(shaderPreset, '/'));
 
 	PresetParser parser;
 	ShaderPreset *shader = parser.parseStream(*stream);
@@ -556,10 +564,11 @@ ShaderPreset *parsePreset(const Common::String &shaderPreset, Common::SearchSet 
 	delete stream;
 
 	if (!shader) {
-		warning("LibRetro Preset Parsing: Error while parsing file '%s': %s", shaderPreset.c_str(), parser.getErrorDesc().c_str());
+		warning("LibRetro Preset Parsing: Error while parsing file '%s': %s", shaderPreset.toString().c_str(), parser.getErrorDesc().c_str());
 		return nullptr;
 	}
 
+	shader->container = container;
 	shader->basePath = basePath;
 	return shader;
 }

--- a/backends/graphics/opengl/pipelines/libretro/parser.h
+++ b/backends/graphics/opengl/pipelines/libretro/parser.h
@@ -30,7 +30,7 @@
 namespace OpenGL {
 namespace LibRetro {
 
-ShaderPreset *parsePreset(const Common::String &shaderPreset, Common::SearchSet &archSet);
+ShaderPreset *parsePreset(const Common::Path &shaderPreset, Common::SearchSet &archSet);
 
 } // End of namespace LibRetro
 } // End of namespace OpenGL

--- a/backends/graphics/opengl/pipelines/libretro/types.h
+++ b/backends/graphics/opengl/pipelines/libretro/types.h
@@ -113,7 +113,8 @@ struct ShaderPass {
 };
 
 struct ShaderPreset {
-	Common::String basePath;
+	Common::Archive *container;
+	Common::Path basePath;
 
 	typedef Common::Array<ShaderTexture> TextureArray;
 	TextureArray textures;

--- a/common/archive.cpp
+++ b/common/archive.cpp
@@ -339,17 +339,25 @@ int SearchSet::listMembers(ArchiveMemberList &list) const {
 	return matches;
 }
 
-const ArchiveMemberPtr SearchSet::getMember(const Path &path) const {
+const ArchiveMemberPtr SearchSet::getMember(const Path &path, Archive **container) const {
 	if (path.empty())
 		return ArchiveMemberPtr();
 
 	ArchiveNodeList::const_iterator it = _list.begin();
 	for (; it != _list.end(); ++it) {
-		if (it->_arc->hasFile(path))
+		if (it->_arc->hasFile(path)) {
+			if (container) {
+				*container = it->_arc;
+			}
 			return it->_arc->getMember(path);
+		}
 	}
 
 	return ArchiveMemberPtr();
+}
+
+const ArchiveMemberPtr SearchSet::getMember(const Path &path) const {
+	return getMember(path, nullptr);
 }
 
 SeekableReadStream *SearchSet::createReadStreamForMember(const Path &path) const {

--- a/common/archive.h
+++ b/common/archive.h
@@ -355,6 +355,8 @@ public:
 
 	const ArchiveMemberPtr getMember(const Path &path) const override;
 
+	const ArchiveMemberPtr getMember(const Path &path, Archive **container) const;
+
 	/**
 	 * Implement createReadStreamForMember from the Archive base class. The current policy is
 	 * opening the first file encountered that matches the name.

--- a/common/path.h
+++ b/common/path.h
@@ -208,6 +208,17 @@ public:
 	bool matchPattern(const Path& pattern) const;
 
 	/**
+	 * Normalize path to a canonical form. In particular:
+	 * - trailing separators are removed:  /foo/bar/ -> /foo/bar
+	 * - double separators (= empty components) are removed:   /foo//bar -> /foo/bar
+	 * - dot components are removed:  /foo/./bar -> /foo/bar
+	 * - double dot components are removed:  /foo/baz/../bar -> /foo/bar
+	 *
+	 * @return      the normalized path
+	 */
+	Path normalize() const;
+
+	/**
 	 * Splits into path components. After every component except
 	 * last there is an implied separator. First component is empty
 	 * if path starts with a separator. Last component is empty if

--- a/test/common/path.h
+++ b/test/common/path.h
@@ -66,4 +66,33 @@ class PathTestSuite : public CxxTest::TestSuite
 		TS_ASSERT_EQUALS(p2.getParent().toString('#'), "par#nt/dir/fil#");
 		TS_ASSERT_EQUALS(p2.getParent().getParent().toString('#'), "par#");
 	}
+
+	void test_normalize() {
+		TS_ASSERT_EQUALS(Common::Path("/", '/').normalize().toString(), "/");
+		TS_ASSERT_EQUALS(Common::Path("/foo/bar", '/').normalize().toString(), "/foo/bar");
+		TS_ASSERT_EQUALS(Common::Path("/foo//bar/", '/').normalize().toString(), "/foo/bar");
+		TS_ASSERT_EQUALS(Common::Path("/foo/./bar", '/').normalize().toString(), "/foo/bar");
+		TS_ASSERT_EQUALS(Common::Path("/foo//./bar//", '/').normalize().toString(), "/foo/bar");
+		TS_ASSERT_EQUALS(Common::Path("/foo//.bar//", '/').normalize().toString(), "/foo/.bar");
+
+		TS_ASSERT_EQUALS(Common::Path("", '/').normalize().toString(), "");
+		TS_ASSERT_EQUALS(Common::Path("foo/bar", '/').normalize().toString(), "foo/bar");
+		TS_ASSERT_EQUALS(Common::Path("foo//bar/", '/').normalize().toString(), "foo/bar");
+		TS_ASSERT_EQUALS(Common::Path("foo/./bar", '/').normalize().toString(), "foo/bar");
+		TS_ASSERT_EQUALS(Common::Path("foo//./bar//", '/').normalize().toString(), "foo/bar");
+		TS_ASSERT_EQUALS(Common::Path("foo//.bar//", '/').normalize().toString(), "foo/.bar");
+
+		TS_ASSERT_EQUALS(Common::Path("..", '/').normalize().toString(), "..");
+		TS_ASSERT_EQUALS(Common::Path("../", '/').normalize().toString(), "..");
+		TS_ASSERT_EQUALS(Common::Path("/..", '/').normalize().toString(), "/..");
+		TS_ASSERT_EQUALS(Common::Path("../bar", '/').normalize().toString(), "../bar");
+		TS_ASSERT_EQUALS(Common::Path("foo//../", '/').normalize().toString(), "");
+		TS_ASSERT_EQUALS(Common::Path("foo/../bar", '/').normalize().toString(), "bar");
+		TS_ASSERT_EQUALS(Common::Path("foo//../bar//", '/').normalize().toString(), "bar");
+		TS_ASSERT_EQUALS(Common::Path("foo//..bar//", '/').normalize().toString(), "foo/..bar");
+
+		TS_ASSERT_EQUALS(Common::Path("foo/../../bar//", '/').normalize().toString(), "../bar");
+		TS_ASSERT_EQUALS(Common::Path("../foo/../bar", '/').normalize().toString(), "../bar");
+		TS_ASSERT_EQUALS(Common::Path("../../foo/bar/", '/').normalize().toString(), "../../foo/bar");
+	}
 };


### PR DESCRIPTION
This PR is another try to fix https://forums.scummvm.org/viewtopic.php?p=98550#p98550 like #5140 
Instead of trying several paths, the path from where the shader preset is loaded is used as a base path.
This makes sure that all files are coherent.

For this to work, a function has been added in SearchSet to return the Archive a member pertains to.
In addition, a normalization function has been added to Path object: this avoids lossy transcode to String.
The implementation and tests have been copied from normalizePath function: they both behave the same.

There is still a limitation on Windows: the paths saved in configuration (themepath, iconspath, shader path) all contain backslashes.
The Path objects are created with the / delimiter by default this makes all path above considered as an only path component.
This still works, because Windows seems to accept / and \ as delimiters.