### PR TITLE
ULTIMA4: Fix crash when pressing ESC after Cast

### DIFF
--- a/engines/ultima/ultima4/controllers/read_player_controller.cpp
+++ b/engines/ultima/ultima4/controllers/read_player_controller.cpp
@@ -51,7 +51,7 @@ bool ReadPlayerController::keyPressed(int key) {
 }
 
 int ReadPlayerController::getPlayer() {
-	return _value - '1';
+	return _value == 27 ? -1 : _value - '1';
 }
 
 int ReadPlayerController::waitFor() {


### PR DESCRIPTION
If user presses esc while selecting a character the controller returns -22 instead of the expected -1. This led to an out of bounds array reference and a crash.
