### PR TITLE
MOHAWK: Fix inverted map colors in Myst ME (polish)

### DIFF
--- a/engines/mohawk/myst_graphics.cpp
+++ b/engines/mohawk/myst_graphics.cpp
@@ -223,6 +223,11 @@ void MystGraphics::applyImagePatches(uint16 id, const MohawkSurface *mhkSurface)
 
 		fixSurf.free();
 	}
+
+	// Fix map picture with inverted colors in Myst ME Polish version
+	if (id == 9934 && _vm->isGameVariant(GF_ME) && _vm->getLanguage() == Common::PL_POL) {
+		mhkSurface->getSurface()->convertToInPlace(Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 0, 24));
+	}
 }
 
 void MystGraphics::copyImageSectionToScreen(uint16 image, Common::Rect src, Common::Rect dest) {


### PR DESCRIPTION
The map picture in the Polish version of Myst ME has a weird pixelformat that causes it to look inverted.
This PR simply converts the picture so it looks normal.

It could probably be fixed on load, but I don't know enough about this engine to attempt a different fix.

Can be tested using the GOG version, which includes the Polish language.
Fixes TRAC #12044


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
