### PR TITLE
DIRECTOR: Allow using of 'me' in setting `the` expressions

### DIFF
--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -622,7 +622,14 @@ void LC::cb_thepush() {
 			g_lingo->push(g_lingo->_state->me.u.obj->getProp(name));
 			return;
 		}
-		warning("cb_thepush: me object has no property '%s'", name.c_str());
+
+		if (name == "me") {
+			// Special case: push the me object itself
+			g_lingo->push(g_lingo->_state->me);
+			return;
+		}
+
+		warning("cb_thepush: me object has no property '%s', type: %d", name.c_str(), g_lingo->_state->me.type);
 	} else {
 		warning("cb_thepush: no me object");
 	}


### PR DESCRIPTION
Statements like `set the perFrameHook to me` where `me` was used to refer own object and setting `the` property of it were not allowed. This patch fixes this by returning current object from `me`.

'totaldistortion-win' uses this feature to set `the perFrameHook` to current factory mAtFrame method.

Additionally game