### PR TITLE
DIRECTOR: Workaround m_perform to send allowRetVal to handler

### DIFF
--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -1645,6 +1645,11 @@ void LC::call(const Symbol &funcSym, int nargs, bool allowRetVal) {
 			// Pushing an entire stack frame is not necessary
 			Datum retMe = g_lingo->_state->me;
 			g_lingo->_state->me = target;
+
+			// WORKAROUND: m_Perform needs to know if value should be returned or not (to create a new context frames for handles)
+			if (funcSym.name->equals("perform"))
+				g_lingo->push(Datum(allowRetVal));
+
 			(*funcSym.u.bltin)(nargs);
 			g_lingo->_state->me = retMe;
 		} else {

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -490,6 +490,8 @@ void LM::m_put(int nargs) {
 // Other
 
 void LM::m_perform(int nargs) {
+	bool allowRetVal = g_lingo->pop().asInt() != 0; // Pop allowRetVal that should be used for the LC::Call
+
 	// Lingo doesn't seem to bother cloning the object when
 	// mNew is called with mPerform
 	Datum d(g_lingo->_state->me);
@@ -498,7 +500,12 @@ void LM::m_perform(int nargs) {
 	Symbol funcSym = me->getMethod(*methodName.u.s);
 	// Object methods expect the first argument to be the object
 	g_lingo->_stack.insert_at(g_lingo->_stack.size() - nargs + 1, d);
-	LC::call(funcSym, nargs, true);
+	LC::call(funcSym, nargs, allowRetVal);
+
+	if (allowRetVal) {
+		// If the method expects a return value, push dummy on stack
+		g_lingo->pushVoid();
+	}
 }
 
 // XObject

--- a/engines/director/lingo/tests/mperform.lingo
+++ b/engines/director/lingo/tests/mperform.lingo
@@ -1,0 +1,25 @@
+abc(mNew)
+abc(callPerform)
+
+factory abc
+method mnew
+  put "init"
+
+method callMe
+  put "Am i called?"
+  return "a1"
+
+method callMe2
+  put "Am i called2?"
+
+method callMe3
+  put "Am I called3?"
+
+method callPerform
+  put "stepped into matFrame"
+  set retval to me(mPerform, "callMe")
+  me(mPerform, "callMe2")
+  me(mPerform, "callMe3")
+  put "returned" && retval
+
+  scummvmAssertEqual(retval, "a1")


### PR DESCRIPTION
There are some builtins and methods that require this boolean allowRetVal to decide if they need to return anything, or pass them on, one such example is `m_perform` which can be called with or without a return.

Fixes problem where multiple `m_perform` inside `mAtFrame` were giving error of returning too many values.