### PR TITLE
DIRECTOR: Fix immediate execution of lingo scripts after frame jumping or opening movie

### DIFF
--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -406,7 +406,6 @@ void Score::update() {
 	if (_curFrameNumber >= getFramesNum()) {
 		Window *window = _vm->getCurrentWindow();
 		if (!window->_movieStack.empty()) {
-			warning("Are we changing movie?");
 			MovieReference ref = window->_movieStack.back();
 			window->_movieStack.pop_back();
 			if (!ref.movie.empty()) {

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -360,7 +360,13 @@ void Score::update() {
 				updateWidgets(true);
 				_window->render();
 			}
-			processFrozenScripts();
+
+			// Don't process frozen script if we use jump instructions
+			// like "go to frame", or open a new movie.
+			if (!_nextFrame || _nextFrame == _curFrameNumber) {
+				processFrozenScripts();
+			}
+
 			return;
 		}
 	}


### PR DESCRIPTION
1. totaldistortion dream games, `Ok` button sticking is fixed.
2. `rect of window` takes window rect than default [0, 0, 1, 1]

Fix: https://trello.com/c/J3frDAgc/616-d4-openwindow-should-load-the-movie-right-away