### PR TITLE
DIRECTOR: Fix regression, string and symbol comparison working again.

### DIFF
--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -1271,6 +1271,16 @@ Datum LC::compareArrays(Datum (*compareFunc)(Datum, Datum), Datum d1, Datum d2, 
 			b = value ? t.v : t.p;
 		}
 
+		// Special case, we can retrieve symbolic key by giving their string representation, ie
+		// for arr [a: "abc", "b": "def"], both getProp(arr, "a") and getProp(arr, #a) will return "abc",
+		// vice-versa is also true, ie getProp(arr, "b") and getProp(arr, #b) will return "def"
+		if (a.type == SYMBOL && b.type == STRING) {
+			a = Datum(a.asString());
+		} else if (a.type == STRING && b.type == SYMBOL) {
+            b = Datum(b.asString());
+        }
+
+
 		res = compareFunc(a, b);
 		if (!location) {
 			if (res.u.i == 0) {

--- a/engines/director/lingo/tests/lists.lingo
+++ b/engines/director/lingo/tests/lists.lingo
@@ -48,7 +48,7 @@ set res to machinery = a
 set res to machinery >= a
 
 -- property Array tests
-set propArray to [501: "cast", 502: "value", 1.5: "script", a: "score", #b: "member"]
+set propArray to [501: "cast", 502: "value", 1.5: "script", a: "score", #b: "member", "color": "red"]
 set var to getPropAt(propArray, 1)
 scummvmAssertEqual(var, 501)
 set var to getAt(propArray, 1)
@@ -58,6 +58,10 @@ set var to getProp(propArray, 1.5)
 scummvmAssertEqual(var, "script")
 set var to getProp(propArray, #a)
 scummvmAssertEqual(var, "score")
+set var to getProp(propArray, "a")
+scummvmAssertEqual(var, "score")
+set var to getProp(propArray, #color)
+scummvmAssertEqual(var, "red")
 set var to getProp(propArray, #b)
 scummvmAssertEqual(var, "member")
 
@@ -139,3 +143,15 @@ put 5 + b -- rect(25, 25, 25, 25)
 set proplist_without_keys = ["key": "value", "keyless expr 1", "keyless expr 2"]
 set proplist_with_keys = ["key": "value", 2: "keyless expr 1", 3: "keyless expr 2"]
 scummvmAssert(proplist_without_keys = proplist_with_keys)
+
+-- list with symbol or string as key
+set templst to [#mood: 1]
+set tempmood to the mood of templst
+scummvmAssert(tempmood = 1)
+put templst
+
+-- assign and check
+set the mood of templst to 2
+set tempmood to the mood of templst
+scummvmAssert(tempmood = 2)
+put templst


### PR DESCRIPTION
This was a regression, where the comparison between string and symbol
was broken in commit https://github.com/scummvm/scummvm/commit/343e3af14fd135244d2d9b4abed9e54275c1469d, This
was originally implemented in https://github.com/scummvm/scummvm/commit/236dd400381874f80eb94029741c5c6d984cc961.