### PR TITLE
DIRECTOR: Improve frame loading, add support to lingo override score, refactor frame channels, autopuppet improve

### DIFF
--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -366,7 +366,7 @@ void Channel::setCast(CastMemberID memberID) {
 	_height = _sprite->_height;
 	replaceWidget();
 
-	if (!_sprite->_puppet) {
+	if (!_sprite->_puppet && g_director->getVersion() >= 600) {
 		// Based on Director in a Nutshell, page 15
 		_sprite->_autoPuppet = true;
 	}

--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -366,10 +366,8 @@ void Channel::setCast(CastMemberID memberID) {
 	_height = _sprite->_height;
 	replaceWidget();
 
-	if (!_sprite->_puppet && g_director->getVersion() >= 600) {
-		// Based on Director in a Nutshell, page 15
-		_sprite->setAutoPuppet(kAPCast, true);
-	}
+	// Based on Director in a Nutshell, page 15
+	_sprite->setAutoPuppet(kAPCast, true);
 }
 
 void Channel::setClean(Sprite *nextSprite, int spriteId, bool partial) {
@@ -548,10 +546,8 @@ void Channel::setWidth(int w) {
 		return;
 	_width = MAX<int>(w, 0);
 
-	if (!_sprite->_puppet && g_director->getVersion() >= 600) {
-		// Based on Director in a Nutshell, page 15
-		_sprite->setAutoPuppet(kAPWidth, true);
-	}
+	// Based on Director in a Nutshell, page 15
+	_sprite->setAutoPuppet(kAPWidth, true);
 }
 
 void Channel::setHeight(int h) {
@@ -559,10 +555,8 @@ void Channel::setHeight(int h) {
 		return;
 	_height = MAX<int>(h, 0);
 
-	if (!_sprite->_puppet && g_director->getVersion() >= 600) {
-		// Based on Director in a Nutshell, page 15
-		_sprite->setAutoPuppet(kAPHeight, true);
-	}
+	// Based on Director in a Nutshell, page 15
+	_sprite->setAutoPuppet(kAPHeight, true);
 }
 
 void Channel::setBbox(int l, int t, int r, int b) {
@@ -581,10 +575,8 @@ void Channel::setBbox(int l, int t, int r, int b) {
 	if (_width <= 0 || _height <= 0)
 		_width = _height = 0;
 
-	if (!_sprite->_puppet && g_director->getVersion() >= 600) {
-		// Based on Director in a Nutshell, page 15
-		_sprite->setAutoPuppet(kAPBbox, true);
-	}
+	// Based on Director in a Nutshell, page 15
+	_sprite->setAutoPuppet(kAPBbox, true);
 }
 
 void Channel::setPosition(int x, int y, bool force) {
@@ -597,10 +589,8 @@ void Channel::setPosition(int x, int y, bool force) {
 	_currentPoint = newPos;
 	_sprite->_startPoint = _currentPoint;
 
-	if (!_sprite->_puppet && g_director->getVersion() >= 600) {
-		// Based on Director in a Nutshell, page 15
-		_sprite->setAutoPuppet(kAPLoc, true);
-	}
+	// Based on Director in a Nutshell, page 15
+	_sprite->setAutoPuppet(kAPLoc, true);
 }
 
 // here is the place for deciding whether the widget can be keep or not

--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -595,6 +595,7 @@ void Channel::setPosition(int x, int y, bool force) {
 		newPos.y = MIN(constraintBbox.bottom, MAX(constraintBbox.top, newPos.y));
 	}
 	_currentPoint = newPos;
+	_sprite->_startPoint = _currentPoint;
 
 	if (!_sprite->_puppet && g_director->getVersion() >= 600) {
 		// Based on Director in a Nutshell, page 15

--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -368,7 +368,7 @@ void Channel::setCast(CastMemberID memberID) {
 
 	if (!_sprite->_puppet && g_director->getVersion() >= 600) {
 		// Based on Director in a Nutshell, page 15
-		_sprite->_autoPuppet = true;
+		_sprite->setAutoPuppet(kAPCast, true);
 	}
 }
 
@@ -550,7 +550,7 @@ void Channel::setWidth(int w) {
 
 	if (!_sprite->_puppet && g_director->getVersion() >= 600) {
 		// Based on Director in a Nutshell, page 15
-		_sprite->_autoPuppet = true;
+		_sprite->setAutoPuppet(kAPWidth, true);
 	}
 }
 
@@ -561,7 +561,7 @@ void Channel::setHeight(int h) {
 
 	if (!_sprite->_puppet && g_director->getVersion() >= 600) {
 		// Based on Director in a Nutshell, page 15
-		_sprite->_autoPuppet = true;
+		_sprite->setAutoPuppet(kAPHeight, true);
 	}
 }
 
@@ -583,7 +583,7 @@ void Channel::setBbox(int l, int t, int r, int b) {
 
 	if (!_sprite->_puppet && g_director->getVersion() >= 600) {
 		// Based on Director in a Nutshell, page 15
-		_sprite->_autoPuppet = true;
+		_sprite->setAutoPuppet(kAPBbox, true);
 	}
 }
 
@@ -599,7 +599,7 @@ void Channel::setPosition(int x, int y, bool force) {
 
 	if (!_sprite->_puppet && g_director->getVersion() >= 600) {
 		// Based on Director in a Nutshell, page 15
-		_sprite->_autoPuppet = true;
+		_sprite->setAutoPuppet(kAPLoc, true);
 	}
 }
 

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -36,34 +36,12 @@ Frame::Frame(Score *score, int numChannels) {
 	_vm = score->getMovie()->getVM();
 	_numChannels = numChannels;
 
-
 	reset();
 }
 
 void Frame::reset() {
-	_transDuration = 0;
-	_transType = kTransNone;
-	_transArea = 0;
-	_transChunkSize = 0;
-	_tempo = 0;
-
-	_scoreCachedTempo = 0;
-	_scoreCachedPaletteId = CastMemberID(0, 0);
-
-	_sound1 = CastMemberID(0, 0);
-	_sound2 = CastMemberID(0, 0);
-	_soundType1 = 0;
-	_soundType2 = 0;
-
-	_actionId = CastMemberID(0, 0);
-	_skipFrameFlag = 0;
-	_blend = 0;
-
-	_colorTempo = 0;
-	_colorSound1 = 0;
-	_colorSound2 = 0;
-	_colorScript = 0;
-	_colorTrans = 0;
+	// Reset main channels
+	_mainChannels = MainChannels();
 
 	_sprites.resize(_numChannels + 1);
 
@@ -79,31 +57,31 @@ void Frame::reset() {
 Frame::Frame(const Frame &frame) {
 	_vm = frame._vm;
 	_numChannels = frame._numChannels;
-	_actionId = frame._actionId;
-	_transArea = frame._transArea;
-	_transDuration = frame._transDuration;
-	_transType = frame._transType;
-	_transChunkSize = frame._transChunkSize;
-	_tempo = frame._tempo;
-	_scoreCachedTempo = frame._scoreCachedTempo;
-	_sound1 = frame._sound1;
-	_sound2 = frame._sound2;
-	_soundType1 = frame._soundType1;
-	_soundType2 = frame._soundType2;
-	_skipFrameFlag = frame._skipFrameFlag;
-	_blend = frame._blend;
+	_mainChannels.actionId = frame._mainChannels.actionId;
+	_mainChannels.transArea = frame._mainChannels.transArea;
+	_mainChannels.transDuration = frame._mainChannels.transDuration;
+	_mainChannels.transType = frame._mainChannels.transType;
+	_mainChannels.transChunkSize = frame._mainChannels.transChunkSize;
+	_mainChannels.tempo = frame._mainChannels.tempo;
+	_mainChannels.scoreCachedTempo = frame._mainChannels.scoreCachedTempo;
+	_mainChannels.sound1 = frame._mainChannels.sound1;
+	_mainChannels.sound2 = frame._mainChannels.sound2;
+	_mainChannels.soundType1 = frame._mainChannels.soundType1;
+	_mainChannels.soundType2 = frame._mainChannels.soundType2;
+	_mainChannels.skipFrameFlag = frame._mainChannels.skipFrameFlag;
+	_mainChannels.blend = frame._mainChannels.blend;
 
-	_colorTempo = frame._colorTempo;
-	_colorSound1 = frame._colorSound1;
-	_colorSound2 = frame._colorSound2;
-	_colorScript = frame._colorScript;
-	_colorTrans = frame._colorTrans;
+	_mainChannels.colorTempo = frame._mainChannels.colorTempo;
+	_mainChannels.colorSound1 = frame._mainChannels.colorSound1;
+	_mainChannels.colorSound2 = frame._mainChannels.colorSound2;
+	_mainChannels.colorScript = frame._mainChannels.colorScript;
+	_mainChannels.colorTrans = frame._mainChannels.colorTrans;
 
-	_palette = frame._palette;
+	_mainChannels.palette = frame._mainChannels.palette;
 
 	_score = frame._score;
 
-	debugC(1, kDebugLoading, "Frame. action: %s transType: %d transDuration: %d", _actionId.asString().c_str(), _transType, _transDuration);
+	debugC(1, kDebugLoading, "Frame. action: %s transType: %d transDuration: %d", _mainChannels.actionId.asString().c_str(), _mainChannels.transType, _mainChannels.transDuration);
 
 	_sprites.resize(_numChannels + 1);
 
@@ -174,45 +152,45 @@ void Frame::readMainChannelsD2(Common::MemoryReadStreamEndian &stream, uint16 of
 	while (stream.pos() < finishPosition) {
 		switch (stream.pos() - initPos + offset) {
 		case 0: // Sound/Tempo/Transition
-			_actionId = CastMemberID(stream.readByte(), DEFAULT_CAST_LIB);
+			_mainChannels.actionId = CastMemberID(stream.readByte(), DEFAULT_CAST_LIB);
 			break;
 		case 1:
 			// type: 0x17 for sounds (sound is cast id), 0x16 for MIDI (sound is cmd id)
-			_soundType1 = stream.readByte();
+			_mainChannels.soundType1 = stream.readByte();
 			break;
 		case 2: {
 				// 0x80 is whole stage (vs changed area), rest is duration in 1/4ths of a second
 				uint8 transFlags = stream.readByte();
 				if (transFlags & 0x80)
-					_transArea = 1;
+					_mainChannels.transArea = 1;
 				else
-					_transArea = 0;
-				_transDuration = (transFlags & 0x7f) * 250; // Duration is in 1/4 secs
+					_mainChannels.transArea = 0;
+				_mainChannels.transDuration = (transFlags & 0x7f) * 250; // Duration is in 1/4 secs
 			}
 			break;
 		case 3:
-			_transChunkSize = stream.readByte();
+			_mainChannels.transChunkSize = stream.readByte();
 			break;
 		case 4:
-			_tempo = stream.readByte();
+			_mainChannels.tempo = stream.readByte();
 			break;
 		case 5:
-			_transType = static_cast<TransitionType>(stream.readByte());
+			_mainChannels.transType = static_cast<TransitionType>(stream.readByte());
 			break;
 		case 6:
-			_sound1 = CastMemberID(stream.readUint16(), DEFAULT_CAST_LIB);
+			_mainChannels.sound1 = CastMemberID(stream.readUint16(), DEFAULT_CAST_LIB);
 			break;
 		case 8:
-			_sound2 = CastMemberID(stream.readUint16(), DEFAULT_CAST_LIB);
+			_mainChannels.sound2 = CastMemberID(stream.readUint16(), DEFAULT_CAST_LIB);
 			break;
 		case 10:
-			_soundType2 = stream.readByte();
+			_mainChannels.soundType2 = stream.readByte();
 			break;
 		case 11:
-			_skipFrameFlag = stream.readByte();
+			_mainChannels.skipFrameFlag = stream.readByte();
 			break;
 		case 12:
-			_blend = stream.readByte();
+			_mainChannels.blend = stream.readByte();
 			break;
 		case 13:
 			stream.read(unk, 1);
@@ -226,34 +204,34 @@ void Frame::readMainChannelsD2(Common::MemoryReadStreamEndian &stream, uint16 of
 				// palette
 				int16 paletteId = stream.readSint16();
 				if (paletteId == 0) {
-					_palette.paletteId = CastMemberID(0, 0);
+					_mainChannels.palette.paletteId = CastMemberID(0, 0);
 				} else if (paletteId < 0) {
-					_palette.paletteId = CastMemberID(paletteId, -1);
+					_mainChannels.palette.paletteId = CastMemberID(paletteId, -1);
 				} else {
-					_palette.paletteId = CastMemberID(paletteId, DEFAULT_CAST_LIB);
+					_mainChannels.palette.paletteId = CastMemberID(paletteId, DEFAULT_CAST_LIB);
 				}
 			}
 			break;
 		case 18:
 			// loop points for color cycling
-			_palette.firstColor = g_director->transformColor(stream.readByte() ^ 0x80);
-			_palette.lastColor = g_director->transformColor(stream.readByte() ^ 0x80);
+			_mainChannels.palette.firstColor = g_director->transformColor(stream.readByte() ^ 0x80);
+			_mainChannels.palette.lastColor = g_director->transformColor(stream.readByte() ^ 0x80);
 			break;
 		case 20:
-			_palette.flags = stream.readByte();
-			_palette.colorCycling = (_palette.flags & 0x80) != 0;
-			_palette.normal = (_palette.flags & 0x60) == 0x00;
-			_palette.fadeToBlack = (_palette.flags & 0x60) == 0x60;
-			_palette.fadeToWhite = (_palette.flags & 0x60) == 0x40;
-			_palette.autoReverse = (_palette.flags & 0x10) != 0;
-			_palette.overTime = (_palette.flags & 0x04) != 0;
-			_palette.speed = stream.readByte();
+			_mainChannels.palette.flags = stream.readByte();
+			_mainChannels.palette.colorCycling = (_mainChannels.palette.flags & 0x80) != 0;
+			_mainChannels.palette.normal = (_mainChannels.palette.flags & 0x60) == 0x00;
+			_mainChannels.palette.fadeToBlack = (_mainChannels.palette.flags & 0x60) == 0x60;
+			_mainChannels.palette.fadeToWhite = (_mainChannels.palette.flags & 0x60) == 0x40;
+			_mainChannels.palette.autoReverse = (_mainChannels.palette.flags & 0x10) != 0;
+			_mainChannels.palette.overTime = (_mainChannels.palette.flags & 0x04) != 0;
+			_mainChannels.palette.speed = stream.readByte();
 			break;
 		case 22:
-			_palette.frameCount = stream.readUint16();
+			_mainChannels.palette.frameCount = stream.readUint16();
 			break;
 		case 24:
-			_palette.cycleCount = stream.readUint16();
+			_mainChannels.palette.cycleCount = stream.readUint16();
 			break;
 		case 26:
 			stream.read(unk, 6);
@@ -273,8 +251,8 @@ void Frame::readMainChannelsD2(Common::MemoryReadStreamEndian &stream, uint16 of
 		error("Frame::readMainChannelsD2(): Read %ld extra bytes", stream.pos() - finishPosition);
 	}
 
-	_transChunkSize = CLIP<byte>(_transChunkSize, 0, 128);
-	_transDuration = CLIP<uint16>(_transDuration, 0, 32000);  // restrict to 32 secs
+	_mainChannels.transChunkSize = CLIP<byte>(_mainChannels.transChunkSize, 0, 128);
+	_mainChannels.transDuration = CLIP<uint16>(_mainChannels.transDuration, 0, 32000);  // restrict to 32 secs
 }
 
 void Frame::readSpriteD2(Common::MemoryReadStreamEndian &stream, uint16 offset, uint16 size) {
@@ -422,96 +400,96 @@ void Frame::readMainChannelsD4(Common::MemoryReadStreamEndian &stream, uint16 of
 			}
 			break;
 		case 1:
-			_soundType1 = stream.readByte(); // type: 0x17 for sounds (sound is cast id), 0x16 for MIDI (sound is cmd id)
+			_mainChannels.soundType1 = stream.readByte(); // type: 0x17 for sounds (sound is cast id), 0x16 for MIDI (sound is cmd id)
 			break;
 		case 2: {
 				uint8 transFlags = stream.readByte();
 				if (transFlags & 0x80)  // 0x80 is whole stage (vs changed area), rest is duration in 1/4ths of a second
-					_transArea = 1;
+					_mainChannels.transArea = 1;
 				else
-					_transArea = 0;
-				_transDuration = (transFlags & 0x7f) * 250; // Duration is in 1/4 secs
+					_mainChannels.transArea = 0;
+				_mainChannels.transDuration = (transFlags & 0x7f) * 250; // Duration is in 1/4 secs
 			}
 			break;
 		case 3:
-			_transChunkSize = stream.readByte();
+			_mainChannels.transChunkSize = stream.readByte();
 			break;
 		case 4:
-			_tempo = stream.readByte();
+			_mainChannels.tempo = stream.readByte();
 			break;
 		case 5:
-			_transType = static_cast<TransitionType>(stream.readByte());
+			_mainChannels.transType = static_cast<TransitionType>(stream.readByte());
 			break;
 		case 6:
-			_sound1 = CastMemberID(stream.readUint16(), DEFAULT_CAST_LIB);
+			_mainChannels.sound1 = CastMemberID(stream.readUint16(), DEFAULT_CAST_LIB);
 			break;
 		case 8:
-			_sound2 = CastMemberID(stream.readUint16(), DEFAULT_CAST_LIB);
+			_mainChannels.sound2 = CastMemberID(stream.readUint16(), DEFAULT_CAST_LIB);
 			break;
 		case 10:
-			_soundType2 = stream.readByte();
+			_mainChannels.soundType2 = stream.readByte();
 			break;
 		case 11:
-			_skipFrameFlag = stream.readByte();
+			_mainChannels.skipFrameFlag = stream.readByte();
 			break;
 		case 12:
-			_blend = stream.readByte();
+			_mainChannels.blend = stream.readByte();
 			break;
 		case 13:
-			_colorTempo = stream.readByte();
+			_mainChannels.colorTempo = stream.readByte();
 			break;
 		case 14:
-			_colorSound1 = stream.readByte();
+			_mainChannels.colorSound1 = stream.readByte();
 			break;
 		case 15:
-			_colorSound2 = stream.readByte();
+			_mainChannels.colorSound2 = stream.readByte();
 			break;
 		case 16:
-			_actionId = CastMemberID(stream.readUint16(), DEFAULT_CAST_LIB);
+			_mainChannels.actionId = CastMemberID(stream.readUint16(), DEFAULT_CAST_LIB);
 			break;
 		case 18:
-			_colorScript = stream.readByte();
+			_mainChannels.colorScript = stream.readByte();
 			break;
 		case 19:
-			_colorTrans = stream.readByte();
+			_mainChannels.colorTrans = stream.readByte();
 			break;
 		case 20: {
 				// palette, 13 bytes
 				int16 paletteId = stream.readSint16();
 				if (paletteId == 0) {
-					_palette.paletteId = CastMemberID(0, 0);
+					_mainChannels.palette.paletteId = CastMemberID(0, 0);
 				} else if (paletteId < 0) {
-					_palette.paletteId = CastMemberID(paletteId, -1);
+					_mainChannels.palette.paletteId = CastMemberID(paletteId, -1);
 				} else {
-					_palette.paletteId = CastMemberID(paletteId, DEFAULT_CAST_LIB);
+					_mainChannels.palette.paletteId = CastMemberID(paletteId, DEFAULT_CAST_LIB);
 				}
 			}
 			break;
 		case 22:
 			// loop points for color cycling
-			_palette.firstColor = g_director->transformColor(stream.readByte() + 0x80); // 22
-			_palette.lastColor = g_director->transformColor(stream.readByte() + 0x80); // 23
+			_mainChannels.palette.firstColor = g_director->transformColor(stream.readByte() + 0x80); // 22
+			_mainChannels.palette.lastColor = g_director->transformColor(stream.readByte() + 0x80); // 23
 			break;
 		case 24:
-			_palette.flags = stream.readByte(); // 24
-			_palette.colorCycling = (_palette.flags & 0x80) != 0;
-			_palette.normal = (_palette.flags & 0x60) == 0x00;
-			_palette.fadeToBlack = (_palette.flags & 0x60) == 0x60;
-			_palette.fadeToWhite = (_palette.flags & 0x60) == 0x40;
-			_palette.autoReverse = (_palette.flags & 0x10) != 0;
-			_palette.overTime = (_palette.flags & 0x04) != 0;
-			_palette.speed = stream.readByte(); // 25
+			_mainChannels.palette.flags = stream.readByte(); // 24
+			_mainChannels.palette.colorCycling = (_mainChannels.palette.flags & 0x80) != 0;
+			_mainChannels.palette.normal = (_mainChannels.palette.flags & 0x60) == 0x00;
+			_mainChannels.palette.fadeToBlack = (_mainChannels.palette.flags & 0x60) == 0x60;
+			_mainChannels.palette.fadeToWhite = (_mainChannels.palette.flags & 0x60) == 0x40;
+			_mainChannels.palette.autoReverse = (_mainChannels.palette.flags & 0x10) != 0;
+			_mainChannels.palette.overTime = (_mainChannels.palette.flags & 0x04) != 0;
+			_mainChannels.palette.speed = stream.readByte(); // 25
 			break;
 		case 26:
-			_palette.frameCount = stream.readUint16(); // 26
+			_mainChannels.palette.frameCount = stream.readUint16(); // 26
 			break;
 		case 28:
-			_palette.cycleCount = stream.readUint16(); // 28
+			_mainChannels.palette.cycleCount = stream.readUint16(); // 28
 			break;
 		case 30:
-			_palette.fade = stream.readByte(); // 30
-			_palette.delay = stream.readByte(); // 31
-			_palette.style = stream.readByte(); // 32
+			_mainChannels.palette.fade = stream.readByte(); // 30
+			_mainChannels.palette.delay = stream.readByte(); // 31
+			_mainChannels.palette.style = stream.readByte(); // 32
 			break;
 		case 33:
 			unk1 = stream.readByte();
@@ -529,7 +507,7 @@ void Frame::readMainChannelsD4(Common::MemoryReadStreamEndian &stream, uint16 of
 				warning("Frame::readMainChannelsD4(): STUB: unk4: %d 0x%x", unk1, unk1);
 			break;
 		case 38:
-			_palette.colorCode = stream.readByte();
+			_mainChannels.palette.colorCode = stream.readByte();
 			break;
 		case 39:
 			unk1 = stream.readByte();
@@ -548,8 +526,8 @@ void Frame::readMainChannelsD4(Common::MemoryReadStreamEndian &stream, uint16 of
 		error("Frame::readMainChannelsD4(): Read %ld extra bytes", stream.pos() - finishPosition);
 	}
 
-	_transChunkSize = CLIP<byte>(_transChunkSize, 0, 128);
-	_transDuration = CLIP<uint16>(_transDuration, 0, 32000);  // restrict to 32 secs
+	_mainChannels.transChunkSize = CLIP<byte>(_mainChannels.transChunkSize, 0, 128);
+	_mainChannels.transDuration = CLIP<uint16>(_mainChannels.transDuration, 0, 32000);  // restrict to 32 secs
 }
 
 void Frame::readSpriteD4(Common::MemoryReadStreamEndian &stream, uint16 offset, uint16 size) {
@@ -707,40 +685,40 @@ void Frame::readMainChannelsD5(Common::MemoryReadStreamEndian &stream, uint16 of
 				// Sound/Tempo/Transition
 				uint16 actionCastLib = stream.readUint16();
 				uint16 actionId = stream.readUint16();
-				_actionId = CastMemberID(actionId, actionCastLib);
+				_mainChannels.actionId = CastMemberID(actionId, actionCastLib);
 			}
 			break;
 		case 2: {
 				uint16 actionId = stream.readUint16();
-				_actionId = CastMemberID(actionId, _actionId.castLib);  // Inherit castLinb from previous frame
+				_mainChannels.actionId = CastMemberID(actionId, _mainChannels.actionId.castLib);  // Inherit castLinb from previous frame
 			}
 			break;
 		case 4: {
 				uint16 sound1CastLib = stream.readUint16();
 				uint16 sound1Id = stream.readUint16();
-				_sound1 = CastMemberID(sound1Id, sound1CastLib);
+				_mainChannels.sound1 = CastMemberID(sound1Id, sound1CastLib);
 			}
 			break;
 		case 6: {
 				uint16 sound1Id = stream.readUint16();
-				_sound1 = CastMemberID(sound1Id, _sound1.castLib);	// Inherit castLinb from previous frame
+				_mainChannels.sound1 = CastMemberID(sound1Id, _mainChannels.sound1.castLib);	// Inherit castLinb from previous frame
 			}
 			break;
 		case 8: {
 				uint16 sound2CastLib = stream.readUint16();
 				uint16 sound2Id = stream.readUint16();
-				_sound2 = CastMemberID(sound2Id, sound2CastLib);
+				_mainChannels.sound2 = CastMemberID(sound2Id, sound2CastLib);
 			}
 			break;
 		case 10: {
 				uint16 sound2Id = stream.readUint16();
-				_sound2 = CastMemberID(sound2Id, _sound2.castLib);	// Inherit castLinb from previous frame
+				_mainChannels.sound2 = CastMemberID(sound2Id, _mainChannels.sound2.castLib);	// Inherit castLinb from previous frame
 			}
 			break;
 		case 12: {
 				uint16 transCastLib = stream.readUint16();
 				uint16 transId = stream.readUint16();
-				_trans = CastMemberID(transId, transCastLib);
+				_mainChannels.trans = CastMemberID(transId, transCastLib);
 			}
 			break;
 		case 16:
@@ -752,7 +730,7 @@ void Frame::readMainChannelsD5(Common::MemoryReadStreamEndian &stream, uint16 of
 			warning("Frame::readMainChannelsD5(): STUB: unk2: 0x%02x", unk[0]);
 			break;
 		case 21:
-			_tempo = stream.readByte();
+			_mainChannels.tempo = stream.readByte();
 			break;
 		case 22:
 			stream.read(unk, 2);
@@ -761,28 +739,28 @@ void Frame::readMainChannelsD5(Common::MemoryReadStreamEndian &stream, uint16 of
 		case 24: {
 				int16 paletteCastLib = stream.readSint16();
 				int16 paletteId = stream.readSint16(); // 26
-				_palette.paletteId = CastMemberID(paletteId, paletteCastLib);
+				_mainChannels.palette.paletteId = CastMemberID(paletteId, paletteCastLib);
 			}
 			break;
 		case 28:
-			_palette.speed = stream.readByte(); // 28
-			_palette.flags = stream.readByte(); // 29
-			_palette.colorCycling = (_palette.flags & 0x80) != 0;
-			_palette.normal = (_palette.flags & 0x60) == 0x00;
-			_palette.fadeToBlack = (_palette.flags & 0x60) == 0x60;
-			_palette.fadeToWhite = (_palette.flags & 0x60) == 0x40;
-			_palette.autoReverse = (_palette.flags & 0x10) != 0;
-			_palette.overTime = (_palette.flags & 0x04) != 0;
+			_mainChannels.palette.speed = stream.readByte(); // 28
+			_mainChannels.palette.flags = stream.readByte(); // 29
+			_mainChannels.palette.colorCycling = (_mainChannels.palette.flags & 0x80) != 0;
+			_mainChannels.palette.normal = (_mainChannels.palette.flags & 0x60) == 0x00;
+			_mainChannels.palette.fadeToBlack = (_mainChannels.palette.flags & 0x60) == 0x60;
+			_mainChannels.palette.fadeToWhite = (_mainChannels.palette.flags & 0x60) == 0x40;
+			_mainChannels.palette.autoReverse = (_mainChannels.palette.flags & 0x10) != 0;
+			_mainChannels.palette.overTime = (_mainChannels.palette.flags & 0x04) != 0;
 			break;
 		case 30:
-			_palette.firstColor = g_director->transformColor(stream.readByte() + 0x80); // 30
-			_palette.lastColor = g_director->transformColor(stream.readByte() + 0x80); // 31
+			_mainChannels.palette.firstColor = g_director->transformColor(stream.readByte() + 0x80); // 30
+			_mainChannels.palette.lastColor = g_director->transformColor(stream.readByte() + 0x80); // 31
 			break;
 		case 32:
-			_palette.frameCount = stream.readUint16(); // 32
+			_mainChannels.palette.frameCount = stream.readUint16(); // 32
 			break;
 		case 34:
-			_palette.cycleCount = stream.readUint16(); // 34
+			_mainChannels.palette.cycleCount = stream.readUint16(); // 34
 			break;
 		case 36: {
 				stream.read(unk, 12);
@@ -806,8 +784,8 @@ void Frame::readMainChannelsD5(Common::MemoryReadStreamEndian &stream, uint16 of
 		error("Frame::readMainChannelsD5(): Read %ld extra bytes", stream.pos() - finishPosition);
 	}
 
-	_transChunkSize = CLIP<byte>(_transChunkSize, 0, 128);
-	_transDuration = CLIP<uint16>(_transDuration, 0, 32000);  // restrict to 32 secs
+	_mainChannels.transChunkSize = CLIP<byte>(_mainChannels.transChunkSize, 0, 128);
+	_mainChannels.transDuration = CLIP<uint16>(_mainChannels.transDuration, 0, 32000);  // restrict to 32 secs
 }
 
 void Frame::readSpriteD5(Common::MemoryReadStreamEndian &stream, uint16 offset, uint16 size) {
@@ -1081,20 +1059,20 @@ void readSpriteDataD6(Common::SeekableReadStreamEndian &stream, Sprite &sprite, 
 Common::String Frame::formatChannelInfo() {
 	Common::String result;
 	result += Common::String::format("TMPO:   tempo: %d, skipFrameFlag: %d, blend: %d\n",
-		_tempo, _skipFrameFlag, _blend);
-	if (_palette.paletteId.isNull()) {
+		_mainChannels.tempo, _mainChannels.skipFrameFlag, _mainChannels.blend);
+	if (_mainChannels.palette.paletteId.isNull()) {
 		result += Common::String::format("PAL:    paletteId: %s, firstColor: %d, lastColor: %d, flags: %d, cycleCount: %d, speed: %d, frameCount: %d, fade: %d, delay: %d, style: %d\n",
-			_palette.paletteId.asString().c_str(), _palette.firstColor, _palette.lastColor, _palette.flags,
-			_palette.cycleCount, _palette.speed, _palette.frameCount,
-			_palette.fade, _palette.delay, _palette.style);
+			_mainChannels.palette.paletteId.asString().c_str(), _mainChannels.palette.firstColor, _mainChannels.palette.lastColor, _mainChannels.palette.flags,
+			_mainChannels.palette.cycleCount, _mainChannels.palette.speed, _mainChannels.palette.frameCount,
+			_mainChannels.palette.fade, _mainChannels.palette.delay, _mainChannels.palette.style);
 	} else {
 		result += Common::String::format("PAL:    paletteId: 000\n");
 	}
 	result += Common::String::format("TRAN:   transType: %d, transDuration: %d, transChunkSize: %d\n",
-		_transType, _transDuration, _transChunkSize);
-	result += Common::String::format("SND: 1  sound1: %d, soundType1: %d\n", _sound1.member, _soundType1);
-	result += Common::String::format("SND: 2  sound2: %d, soundType2: %d\n", _sound2.member, _soundType2);
-	result += Common::String::format("LSCR:   actionId: %d\n", _actionId.member);
+		_mainChannels.transType, _mainChannels.transDuration, _mainChannels.transChunkSize);
+	result += Common::String::format("SND: 1  sound1: %d, soundType1: %d\n", _mainChannels.sound1.member, _mainChannels.soundType1);
+	result += Common::String::format("SND: 2  sound2: %d, soundType2: %d\n", _mainChannels.sound2.member, _mainChannels.soundType2);
+	result += Common::String::format("LSCR:   actionId: %d\n", _mainChannels.actionId.member);
 
 	for (int i = 0; i < _numChannels; i++) {
 		Sprite &sprite = *_sprites[i + 1];

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -272,7 +272,7 @@ void Frame::readSpriteD2(Common::MemoryReadStreamEndian &stream, uint16 offset, 
 
 	Sprite &sprite = *_sprites[spritePosition + 1];
 
-	if (sprite._puppet || sprite._autoPuppet) {
+	if (sprite._puppet) {
 		stream.skip(size);
 		return;
 	}
@@ -549,7 +549,7 @@ void Frame::readSpriteD4(Common::MemoryReadStreamEndian &stream, uint16 offset, 
 
 	Sprite &sprite = *_sprites[spritePosition + 1];
 
-	if (sprite._puppet || sprite._autoPuppet) {
+	if (sprite._puppet) {
 		stream.skip(size);
 		return;
 	}
@@ -809,7 +809,7 @@ void Frame::readSpriteD5(Common::MemoryReadStreamEndian &stream, uint16 offset, 
 
 	Sprite &sprite = *_sprites[spritePosition + 1];
 
-	if (sprite._puppet || sprite._autoPuppet) {
+	if (sprite._puppet) {
 		stream.skip(size);
 		return;
 	}
@@ -967,7 +967,7 @@ void Frame::readSpriteD6(Common::MemoryReadStreamEndian &stream, uint16 offset, 
 
 	Sprite &sprite = *_sprites[spritePosition + 1];
 
-	if (sprite._puppet || sprite._autoPuppet) {
+	if (sprite._puppet) {
 		stream.skip(size);
 		return;
 	}
@@ -994,25 +994,46 @@ void readSpriteDataD6(Common::SeekableReadStreamEndian &stream, Sprite &sprite, 
 		case 0:
 			sprite._spriteType = (SpriteType)stream.readByte();
 			break;
-		case 1:
-			sprite._inkData = stream.readByte();
+		case 1: {
+			byte inkData = stream.readByte();
+
+			if (sprite.getAutoPuppet(kAPInk))
+				continue;
+
+			sprite._inkData = inkData;
 
 			sprite._ink = static_cast<InkType>(sprite._inkData & 0x3f);
 			if (sprite._inkData & 0x40)
 				sprite._trails = 1;
 			else
 				sprite._trails = 0;
+			}
+			break;
+		case 2: {
+			uint8 foreColor = stream.readByte();
 
+			if (sprite.getAutoPuppet(kAPForeColor))
+				continue;
+
+			sprite._foreColor = g_director->transformColor(foreColor);
+			}
 			break;
-		case 2:
-			sprite._foreColor = g_director->transformColor((uint8)stream.readByte());
-			break;
-		case 3:
-			sprite._backColor = g_director->transformColor((uint8)stream.readByte());
+		case 3: {
+			uint8 backColor = stream.readByte();
+
+			if (sprite.getAutoPuppet(kAPBackColor))
+				continue;
+
+			sprite._backColor = g_director->transformColor(backColor);
+			}
 			break;
 		case 4: {
 				uint16 castLib = stream.readUint16();
 				uint16 memberID = stream.readUint16();
+
+				if (sprite.getAutoPuppet(kAPCast))
+					continue;
+
 				sprite._castId = CastMemberID(memberID, castLib);
 			}
 			break;
@@ -1022,17 +1043,41 @@ void readSpriteDataD6(Common::SeekableReadStreamEndian &stream, Sprite &sprite, 
 				sprite._scriptId = CastMemberID(scriptMemberID, scriptCastLib);
 			}
 			break;
-		case 12:
-			sprite._startPoint.y = (int16)stream.readUint16();
+		case 12: {
+			uint16 startPointY = stream.readUint16();
+
+			if (sprite.getAutoPuppet(kAPLocV) || sprite.getAutoPuppet(kAPLoc))
+				continue;
+
+			sprite._startPoint.y = startPointY;
 			break;
-		case 14:
-			sprite._startPoint.x = (int16)stream.readUint16();
+			}
+		case 14: {
+			uint16 startPointX = stream.readUint16();
+
+			if (sprite.getAutoPuppet(kAPLocH) || sprite.getAutoPuppet(kAPLoc))
+				continue;
+
+			sprite._startPoint.x = startPointX;
+			}
 			break;
-		case 16:
-			sprite._height = (int16)stream.readUint16();
+		case 16: {
+			uint16 height = stream.readUint16();
+
+			if (sprite.getAutoPuppet(kAPHeight))
+				continue;
+
+			sprite._height = height;
+			}
 			break;
-		case 18:
-			sprite._width = (int16)stream.readUint16();
+		case 18: {
+			uint16 width = stream.readUint16();
+
+			if (sprite.getAutoPuppet(kAPWidth))
+				continue;
+
+			sprite._width = width;
+			}
 			break;
 		case 20:
 			// & 0x0f scorecolor
@@ -1042,12 +1087,20 @@ void readSpriteDataD6(Common::SeekableReadStreamEndian &stream, Sprite &sprite, 
 			// 0x80 moveable
 			sprite._colorcode = stream.readByte();
 
+			if (sprite.getAutoPuppet(kAPMoveable))
+				continue;
+
 			sprite._editable = ((sprite._colorcode & 0x40) == 0x40);
 			sprite._moveable = ((sprite._colorcode & 0x80) == 0x80);
-			sprite._moveable = ((sprite._colorcode & 0x80) == 0x80);
 			break;
-		case 21:
-			sprite._blendAmount = stream.readByte();
+		case 21: {
+			byte blendAmount = stream.readByte();
+
+			if (sprite.getAutoPuppet(kAPBlend))
+				continue;
+
+			sprite._blendAmount = blendAmount;
+			}
 			break;
 		case 22:
 			sprite._thickness = stream.readByte();

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -210,6 +210,8 @@ void Frame::readMainChannelsD2(Common::MemoryReadStreamEndian &stream, uint16 of
 				} else {
 					_mainChannels.palette.paletteId = CastMemberID(paletteId, DEFAULT_CAST_LIB);
 				}
+				if (!_mainChannels.palette.paletteId.isNull())
+					_mainChannels.scoreCachedPaletteId = _mainChannels.palette.paletteId;
 			}
 			break;
 		case 18:
@@ -463,6 +465,8 @@ void Frame::readMainChannelsD4(Common::MemoryReadStreamEndian &stream, uint16 of
 				} else {
 					_mainChannels.palette.paletteId = CastMemberID(paletteId, DEFAULT_CAST_LIB);
 				}
+				if (!_mainChannels.palette.paletteId.isNull())
+					_mainChannels.scoreCachedPaletteId = _mainChannels.palette.paletteId;
 			}
 			break;
 		case 22:
@@ -740,6 +744,8 @@ void Frame::readMainChannelsD5(Common::MemoryReadStreamEndian &stream, uint16 of
 				int16 paletteCastLib = stream.readSint16();
 				int16 paletteId = stream.readSint16(); // 26
 				_mainChannels.palette.paletteId = CastMemberID(paletteId, paletteCastLib);
+				if (!_mainChannels.palette.paletteId.isNull())
+					_mainChannels.scoreCachedPaletteId = _mainChannels.palette.paletteId;
 			}
 			break;
 		case 28:

--- a/engines/director/frame.h
+++ b/engines/director/frame.h
@@ -88,6 +88,60 @@ struct PaletteInfo {
 	}
 };
 
+struct MainChannels {
+	CastMemberID actionId;
+	uint16 transDuration;
+	uint8 transArea; // 1 - Whole Window, 0 - Changing Area
+	uint8 transChunkSize;
+	TransitionType transType;
+	CastMemberID trans;
+	PaletteInfo palette;
+	uint8 tempo;
+
+	uint8 scoreCachedTempo;
+	CastMemberID scoreCachedPaletteId;
+
+	CastMemberID sound1;
+	uint8 soundType1;
+	CastMemberID sound2;
+	uint8 soundType2;
+
+	byte colorTempo;
+	byte colorSound1;
+	byte colorSound2;
+	byte colorScript;
+	byte colorTrans;
+
+	uint8 skipFrameFlag;
+	uint8 blend;
+
+	MainChannels() {
+		transDuration = 0;
+		transType = kTransNone;
+		transArea = 0;
+		transChunkSize = 0;
+		tempo = 0;
+
+		scoreCachedTempo = 0;
+		scoreCachedPaletteId = CastMemberID(0, 0);
+
+		sound1 = CastMemberID(0, 0);
+		sound2 = CastMemberID(0, 0);
+		soundType1 = 0;
+		soundType2 = 0;
+
+		actionId = CastMemberID(0, 0);
+		skipFrameFlag = 0;
+		blend = 0;
+
+		colorTempo = 0;
+		colorSound1 = 0;
+		colorSound2 = 0;
+		colorScript = 0;
+		colorTrans = 0;
+	}
+};
+
 struct FrameEntity {
 	uint16 spriteId;
 	Common::Rect rect;
@@ -134,31 +188,7 @@ private:
 
 public:
 	int _numChannels;
-	CastMemberID _actionId;
-	uint16 _transDuration;
-	uint8 _transArea; // 1 - Whole Window, 0 - Changing Area
-	uint8 _transChunkSize;
-	TransitionType _transType;
-	CastMemberID _trans;
-	PaletteInfo _palette;
-	uint8 _tempo;
-
-	uint8 _scoreCachedTempo;
-	CastMemberID _scoreCachedPaletteId;
-
-	CastMemberID _sound1;
-	uint8 _soundType1;
-	CastMemberID _sound2;
-	uint8 _soundType2;
-
-	byte _colorTempo;
-	byte _colorSound1;
-	byte _colorSound2;
-	byte _colorScript;
-	byte _colorTrans;
-
-	uint8 _skipFrameFlag;
-	uint8 _blend;
+	MainChannels _mainChannels;
 	Common::Array<Sprite *> _sprites;
 	Score *_score;
 	DirectorEngine *_vm;

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -2612,7 +2612,7 @@ void LB::b_puppetSprite(int nargs) {
 }
 
 void LB::b_puppetTempo(int nargs) {
-	g_director->getCurrentMovie()->getScore()->_puppetTempo = g_lingo->pop().asInt();
+	g_director->getCurrentMovie()->getScore()->setPuppetTempo(g_lingo->pop().asInt());
 }
 
 void LB::b_puppetTransition(int nargs) {

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -161,7 +161,7 @@ void Movie::queueFrameEvent(Common::Queue<LingoEvent> &queue, LEvent event, int 
 	// } else {
 
 	assert(_score->_currentFrame != nullptr);
-	CastMemberID scriptId = _score->_currentFrame->_actionId;
+	CastMemberID scriptId = _score->_currentFrame->_mainChannels.actionId;
 	if (!scriptId.member)
 		return;
 

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -1446,6 +1446,11 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 			if (newColor != sprite->_backColor) {
 				sprite->_backColor = newColor;
 				channel->_dirty = true;
+
+				if (!sprite->_puppet && g_director->getVersion() >= 600) {
+					// Based on Director in a Nutshell, page 15
+					sprite->setAutoPuppet(kAPBackColor, true);
+				}
 			}
 		}
 		break;
@@ -1456,6 +1461,11 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 			if (blend != sprite->_blendAmount) {
 				sprite->_blendAmount = blend;
 				channel->_dirty = true;
+			}
+
+			if (!sprite->_puppet && g_director->getVersion() >= 600) {
+				// Based on Director in a Nutshell, page 15
+				sprite->setAutoPuppet(kAPBlend, true);
 			}
 		}
 		break;
@@ -1526,6 +1536,11 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 				sprite->_foreColor = newColor;
 				channel->_dirty = true;
 			}
+
+			if (!sprite->_puppet && g_director->getVersion() >= 600) {
+				// Based on Director in a Nutshell, page 15
+				sprite->setAutoPuppet(kAPForeColor, true);
+			}
 		}
 		break;
 	case kTheHeight:
@@ -1534,6 +1549,12 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 			channel->setHeight(d.asInt());
 			channel->_dirty = true;
 		}
+
+		if (!sprite->_puppet && g_director->getVersion() >= 600) {
+			// Based on Director in a Nutshell, page 15
+			sprite->setAutoPuppet(kAPHeight, true);
+		}
+
 		break;
 	case kTheImmediate:
 		sprite->_immediate = (bool)d.asInt();
@@ -1543,6 +1564,12 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 			sprite->_ink = static_cast<InkType>(d.asInt());
 			channel->_dirty = true;
 		}
+
+		if (!sprite->_puppet && g_director->getVersion() >= 600) {
+			// Based on Director in a Nutshell, page 15
+			sprite->setAutoPuppet(kAPInk, true);
+		}
+
 		break;
 	case kTheLineSize:
 		if (d.asInt() != sprite->_thickness) {
@@ -1567,6 +1594,12 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 			}
 			channel->setPosition(d.asInt(), channel->_currentPoint.y);
 		}
+
+		if (!sprite->_puppet && g_director->getVersion() >= 600) {
+			// Based on Director in a Nutshell, page 15
+			sprite->setAutoPuppet(kAPLocH, true);
+		}
+
 		break;
 	case kTheLocV:
 		if (d.asInt() != channel->_currentPoint.y) {
@@ -1576,9 +1609,21 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 			}
 			channel->setPosition(channel->_currentPoint.x, d.asInt());
 		}
+
+		if (!sprite->_puppet && g_director->getVersion() >= 600) {
+			// Based on Director in a Nutshell, page 15
+			sprite->setAutoPuppet(kAPLocV, true);
+		}
+
 		break;
 	case kTheMoveableSprite:
 		sprite->_moveable = (bool)d.asInt();
+
+		if (!sprite->_puppet && g_director->getVersion() >= 600) {
+			// Based on Director in a Nutshell, page 15
+			sprite->setAutoPuppet(kAPMoveable, true);
+		}
+
 		break;
 	case kTheMovieRate:
 		channel->_movieRate = d.asFloat();
@@ -1616,6 +1661,12 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 			);
 			channel->_dirty = true;
 		}
+
+		if (!sprite->_puppet && g_director->getVersion() >= 600) {
+			// Based on Director in a Nutshell, page 15
+			sprite->setAutoPuppet(kAPRect, true);
+		}
+
 		break;
 	case kTheStartTime:
 		channel->_startTime = d.asInt();
@@ -1668,6 +1719,12 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 			channel->setWidth(d.asInt());
 			channel->_dirty = true;
 		}
+
+		if (!sprite->_puppet && g_director->getVersion() >= 600) {
+			// Based on Director in a Nutshell, page 15
+			sprite->setAutoPuppet(kAPWidth, true);
+		}
+
 		break;
 	default:
 		warning("Lingo::setTheSprite(): Unprocessed setting field \"%s\" of sprite", field2str(field));

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -466,7 +466,7 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 		d.u.s = score->getFrameLabel(score->getCurrentFrameNum());
 		break;
 	case kTheFrameScript:
-		d = score->_currentFrame->_actionId.member;
+		d = score->_currentFrame->_mainChannels.actionId.member;
 		break;
 	case kTheFramePalette:
 		d = score->getCurrentPalette();

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -1447,10 +1447,8 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 				sprite->_backColor = newColor;
 				channel->_dirty = true;
 
-				if (!sprite->_puppet && g_director->getVersion() >= 600) {
-					// Based on Director in a Nutshell, page 15
-					sprite->setAutoPuppet(kAPBackColor, true);
-				}
+				// Based on Director in a Nutshell, page 15
+				sprite->setAutoPuppet(kAPBackColor, true);
 			}
 		}
 		break;
@@ -1463,10 +1461,8 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 				channel->_dirty = true;
 			}
 
-			if (!sprite->_puppet && g_director->getVersion() >= 600) {
-				// Based on Director in a Nutshell, page 15
-				sprite->setAutoPuppet(kAPBlend, true);
-			}
+			// Based on Director in a Nutshell, page 15
+			sprite->setAutoPuppet(kAPBlend, true);
 		}
 		break;
 	case kTheCastNum:
@@ -1537,10 +1533,8 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 				channel->_dirty = true;
 			}
 
-			if (!sprite->_puppet && g_director->getVersion() >= 600) {
-				// Based on Director in a Nutshell, page 15
-				sprite->setAutoPuppet(kAPForeColor, true);
-			}
+			// Based on Director in a Nutshell, page 15
+			sprite->setAutoPuppet(kAPForeColor, true);
 		}
 		break;
 	case kTheHeight:
@@ -1550,10 +1544,8 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 			channel->_dirty = true;
 		}
 
-		if (!sprite->_puppet && g_director->getVersion() >= 600) {
-			// Based on Director in a Nutshell, page 15
-			sprite->setAutoPuppet(kAPHeight, true);
-		}
+		// Based on Director in a Nutshell, page 15
+		sprite->setAutoPuppet(kAPHeight, true);
 
 		break;
 	case kTheImmediate:
@@ -1565,10 +1557,8 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 			channel->_dirty = true;
 		}
 
-		if (!sprite->_puppet && g_director->getVersion() >= 600) {
-			// Based on Director in a Nutshell, page 15
-			sprite->setAutoPuppet(kAPInk, true);
-		}
+		// Based on Director in a Nutshell, page 15
+		sprite->setAutoPuppet(kAPInk, true);
 
 		break;
 	case kTheLineSize:
@@ -1595,10 +1585,8 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 			channel->setPosition(d.asInt(), channel->_currentPoint.y);
 		}
 
-		if (!sprite->_puppet && g_director->getVersion() >= 600) {
-			// Based on Director in a Nutshell, page 15
-			sprite->setAutoPuppet(kAPLocH, true);
-		}
+		// Based on Director in a Nutshell, page 15
+		sprite->setAutoPuppet(kAPLocH, true);
 
 		break;
 	case kTheLocV:
@@ -1610,19 +1598,15 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 			channel->setPosition(channel->_currentPoint.x, d.asInt());
 		}
 
-		if (!sprite->_puppet && g_director->getVersion() >= 600) {
-			// Based on Director in a Nutshell, page 15
-			sprite->setAutoPuppet(kAPLocV, true);
-		}
+		// Based on Director in a Nutshell, page 15
+		sprite->setAutoPuppet(kAPLocV, true);
 
 		break;
 	case kTheMoveableSprite:
 		sprite->_moveable = (bool)d.asInt();
 
-		if (!sprite->_puppet && g_director->getVersion() >= 600) {
-			// Based on Director in a Nutshell, page 15
-			sprite->setAutoPuppet(kAPMoveable, true);
-		}
+		// Based on Director in a Nutshell, page 15
+		sprite->setAutoPuppet(kAPMoveable, true);
 
 		break;
 	case kTheMovieRate:
@@ -1662,10 +1646,8 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 			channel->_dirty = true;
 		}
 
-		if (!sprite->_puppet && g_director->getVersion() >= 600) {
-			// Based on Director in a Nutshell, page 15
-			sprite->setAutoPuppet(kAPRect, true);
-		}
+		// Based on Director in a Nutshell, page 15
+		sprite->setAutoPuppet(kAPRect, true);
 
 		break;
 	case kTheStartTime:
@@ -1720,10 +1702,8 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 			channel->_dirty = true;
 		}
 
-		if (!sprite->_puppet && g_director->getVersion() >= 600) {
-			// Based on Director in a Nutshell, page 15
-			sprite->setAutoPuppet(kAPWidth, true);
-		}
+		// Based on Director in a Nutshell, page 15
+		sprite->setAutoPuppet(kAPWidth, true);
 
 		break;
 	default:

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -63,7 +63,6 @@ Score::Score(Movie *movie) {
 
 	_soundManager = _window->getSoundManager();
 
-	_puppetTempo = 0x00;
 	_puppetPalette = false;
 	_paletteTransitionIndex = 0;
 	memset(_paletteSnapshotBuffer, 0, 768);
@@ -107,6 +106,10 @@ Score::~Score() {
 	if (_currentFrame) {
 		delete _currentFrame;
 	}
+}
+
+void Score::setPuppetTempo(int16 puppetTempo) {
+	_currentFrame->_mainChannels.tempo = puppetTempo;
 }
 
 CastMemberID Score::getCurrentPalette() {
@@ -448,13 +451,7 @@ void Score::update() {
 
 	loadFrame(_curFrameNumber);
 
-	byte tempo = _currentFrame->_mainChannels.scoreCachedTempo;
-	// puppetTempo is overridden by changes in score tempo
-	if (_currentFrame->_mainChannels.tempo || tempo != _lastTempo) {
-		_puppetTempo = 0;
-	} else if (_puppetTempo) {
-		tempo = _puppetTempo;
-	}
+	byte tempo = _currentFrame->_mainChannels.tempo;
 
 	if (tempo) {
 		const bool waitForClickOnly = _vm->getVersion() < 300;
@@ -1531,12 +1528,6 @@ bool Score::readOneFrame() {
 			debugC(4, kDebugLoading, "%s", _currentFrame->formatChannelInfo().c_str());
 		}
 
-		// Precache the current FPS tempo, as this carries forward to frames to the right
-		// of the instruction
-		// Delay type tempos (e.g. wait commands, delays) apply to only a single frame, and are ignored here
-		if (_currentFrame->_mainChannels.tempo && _currentFrame->_mainChannels.tempo <= 120)
-			_currentTempo = _currentFrame->_mainChannels.tempo;
-		_currentFrame->_mainChannels.scoreCachedTempo = _currentFrame->_mainChannels.tempo ? _currentFrame->_mainChannels.tempo : _currentTempo;
 		// Precache the current palette ID, as this carries forward to frames to the right
 		// of the instruction
 		if (!_currentFrame->_mainChannels.palette.paletteId.isNull())

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -395,6 +395,9 @@ void Score::update() {
 		return;
 	}
 
+	for (uint ch = 0; ch < _channels.size(); ch++)
+		*_currentFrame->_sprites[ch] = *_channels[ch]->_sprite;
+
 	if (!_vm->_playbackPaused) {
 		if (_nextFrame) {
 			// With the advent of demand loading frames and due to partial updates, we rebuild our channel data
@@ -516,13 +519,6 @@ void Score::update() {
 		// _movie->processEvent(kEventPrepareFrame);
 		// TODO: Director 6 step: send prepareFrame event to all sprites and the script channel in upcoming frame
 	}
-
-#if 0
-	// FIXME: TODO: This so far brings more problems than fixes
-	for (uint ch = 0; ch < _channels.size(); ch++)
-		if (_channels[ch]->_sprite->_puppet || _channels[ch]->_sprite->_autoPuppet)
-			*_currentFrame->_sprites[ch] = *_channels[ch]->_sprite;
-#endif
 
 	// Window is drawn between the prepareFrame and enterFrame events (Lingo in a Nutshell, p.100)
 	renderFrame(_curFrameNumber);

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -1528,12 +1528,6 @@ bool Score::readOneFrame() {
 			debugC(4, kDebugLoading, "%s", _currentFrame->formatChannelInfo().c_str());
 		}
 
-		// Precache the current palette ID, as this carries forward to frames to the right
-		// of the instruction
-		if (!_currentFrame->_mainChannels.palette.paletteId.isNull())
-			_currentPaletteId = _currentFrame->_mainChannels.palette.paletteId;
-		_currentFrame->_mainChannels.scoreCachedPaletteId = _currentPaletteId;
-
 		debugC(8, kDebugLoading, "Score::readOneFrame(): Frame %d actionId: %s", _curFrameNumber, _currentFrame->_mainChannels.actionId.asString().c_str());
 		return true;
 	} else {

--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -103,6 +103,8 @@ public:
 	int getNextFrame() { return _nextFrame; }
 	uint16 getFramesNum() { return _numFrames; }
 
+	void setPuppetTempo(int16 puppetTempo);
+
 	CastMemberID getCurrentPalette();
 
 	Channel *getChannelById(uint16 id);
@@ -169,7 +171,6 @@ public:
 
 	byte _currentFrameRate;
 
-	byte _puppetTempo;
 	bool _puppetPalette;
 	int _paletteTransitionIndex;
 	byte _paletteSnapshotBuffer[768];

--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -392,6 +392,10 @@ void Sprite::setPattern(uint16 pattern) {
 }
 
 void Sprite::setAutoPuppet(AutoPuppetProperty property, bool value) {
+	// Skip this if we're not in D6 or above (auto-puppet is introduced in D6)
+	if (_puppet || g_director->getVersion() < 600)
+		return;
+
 	if (value)
 		_autoPuppet |= (1 << property);
 	else

--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -62,7 +62,7 @@ Sprite::Sprite(Frame *frame) {
 	_moveable = false;
 	_editable = false;
 	_puppet = false;
-	_autoPuppet = false; // Based on Director in a Nutshell, page 15
+	_autoPuppet = kAPNone; // Based on Director in a Nutshell, page 15
 	_immediate = false;
 	_backColor = g_director->_wm->_colorWhite;
 	_foreColor = g_director->_wm->_colorBlack;
@@ -389,6 +389,17 @@ void Sprite::setPattern(uint16 pattern) {
 	default:
 		return;
 	}
+}
+
+void Sprite::setAutoPuppet(AutoPuppetProperty property, bool value) {
+	if (value)
+		_autoPuppet |= (1 << property);
+	else
+		_autoPuppet &= ~(1 << property);
+}
+
+bool Sprite::getAutoPuppet(AutoPuppetProperty property) {
+	return (_autoPuppet & (1 << property)) != 0;
 }
 
 bool Sprite::checkSpriteType() {

--- a/engines/director/sprite.h
+++ b/engines/director/sprite.h
@@ -29,6 +29,30 @@ class BitmapCastMember;
 class ShapeCastMember;
 class TextCastMember;
 
+/* Director in a Nutshell, page 15:
+The following properties of a sprite are auto-puppeted whenever the property is
+set: backColor, blend, editable, foreColor, beight, ink, loc, locH, locV, member,
+moveable, rect, and width Auto-puppeting of individual properties has no effect
+on the puppet of sprite property. */
+enum AutoPuppetProperty {
+	kAPNone = 0,
+	kAPCast,
+	kAPBackColor,
+	kAPBbox,
+	kAPBlend,
+	kAPEditable,
+	kAPForeColor,
+	kAPHeight,
+	kAPInk,
+	kAPLoc,
+	kAPLocH,
+	kAPLocV,
+	kAPMember,
+	kAPMoveable,
+	kAPRect,
+	kAPWidth,
+};
+
 class Sprite {
 public:
 	Sprite(Frame *frame = nullptr);
@@ -56,6 +80,8 @@ public:
 	MacShape *getShape();
 	uint32 getForeColor();
 	uint32 getBackColor();
+	void setAutoPuppet(AutoPuppetProperty property, bool value);
+	bool getAutoPuppet(AutoPuppetProperty property);
 
 	Frame *_frame;
 	Score *_score;
@@ -85,7 +111,7 @@ public:
 	bool _moveable;
 	bool _editable;
 	bool _puppet;
-	bool _autoPuppet; // autopuppet, based upon Director in a Nutshell, page 15
+	uint32 _autoPuppet; // autopuppet, based upon Director in a Nutshell, page 15
 	bool _immediate;
 	uint32 _backColor;
 	uint32 _foreColor;


### PR DESCRIPTION
1. Copy channel sprites to frame before loading (ie lingo override score changes)
2. Refactor main channels to struct
3. Refactor cache property logic for tempo and palette
4. Improve auto-puppets, support individual property

Total distortion's bed dream game fully working now.