### PR TITLE
DIRECTOR: Fix lingotests `builtin.lingo` and `sort.lingo` for greener builds.

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -3283,7 +3283,14 @@ void LB::b_scummvmassertequal(int nargs) {
 	Datum d2 = g_lingo->pop();
 	Datum d1 = g_lingo->pop();
 
-	int result = (d1 == d2);
+	int result;
+
+	if (d1.type == ARRAY && d2.type == ARRAY) {
+		result = LC::eqData(d1, d2).u.i;
+	} else {
+		result = (d1 == d2);
+	}
+
 	if (!result) {
 		warning("BUILDBOT: LB::b_scummvmassertequals: %s is not equal %s at line %d", d1.asString().c_str(), d2.asString().c_str(), line.asInt());
 	}

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -411,6 +411,9 @@ CastMember* Movie::createOrReplaceCastMember(CastMemberID memberID, CastMember* 
 	CastMember *result = nullptr;
 
 	if (_casts.contains(memberID.castLib)) {
+		// Delete existing cast member
+		_casts.getVal(memberID.castLib)->eraseCastMember(memberID);
+
 		_casts.getVal(memberID.castLib)->setCastMember(memberID, cast);
 	}
 


### PR DESCRIPTION
1. `sort.lingo` was using `scummvmassertequal` for comparing two arrays, now the code for array equality was absent so added it.
2. `builtin.lingo` throwing errors due to memory leak in when using `b_move`, fixed it.