### PR TITLE
COMMON: Use getPathInArchive() in dumpArchive() to get filename and fix directory issue

### DIFF
--- a/common/archive.cpp
+++ b/common/archive.cpp
@@ -26,6 +26,7 @@
 #include "common/textconsole.h"
 #include "common/memstream.h"
 #include "common/punycode.h"
+#include "common/debug.h"
 
 namespace Common {
 
@@ -88,9 +89,8 @@ void Archive::dumpArchive(String destPath) {
 	uint dataSize = 0;
 
 	for (auto &f : files) {
-		Common::String filename = Common::punycode_encodefilename(f->getName());
-		warning("File: %s", filename.c_str());
-
+		Common::Path filePath = f->getPathInArchive().punycodeEncode();
+		debug(1, "File: %s", filePath.toString().c_str());
 		Common::SeekableReadStream *stream = f->createReadStream();
 
 		uint32 len = stream->size();
@@ -103,9 +103,9 @@ void Archive::dumpArchive(String destPath) {
 		stream->read(data, len);
 
 		Common::DumpFile out;
-		Common::String outname = destPath + filename;
-		if (!out.open(outname, true)) {
-			warning("Archive::dumpArchive(): Can not open dump file %s", outname.c_str());
+		Common::Path outPath = Common::Path(destPath).join(filePath);
+		if (!out.open(outPath.toString(), true)) {
+			warning("Archive::dumpArchive(): Can not open dump file %s", outPath.toString().c_str());
 		} else {
 			out.write(data, len);
 			out.flush();


### PR DESCRIPTION
The dumped games through `dumpArchive()` were not able to get detected. This was because the `f->getName()` ends up having `/` and further puny encoding the filename with the `/` makes it unable to detect properly.

This PR fixes this by using the Path::punycodeEncode() and the new getPathInArchive().

Also fixes: the archive's contents were being dumped one directory back the `destPath`


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
