### PR TITLE
CREATE_PROJECT: Quiet VS "structure was padded due to alignment specifier" warning

### DIFF
--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -596,6 +596,8 @@ int main(int argc, char *argv[]) {
 		// 4610 (object 'class' can never be instantiated - user-defined constructor required)
 		//   "correct" but harmless (as is 4510)
 		//
+		// 4324 (structure was padded due to alignment specifier)
+		//
 		////////////////////////////////////////////////////////////////////////////
 
 		globalWarnings.push_back("4068");
@@ -605,6 +607,7 @@ int main(int argc, char *argv[]) {
 		globalWarnings.push_back("4244");
 		globalWarnings.push_back("4250");
 		globalWarnings.push_back("4310");
+		globalWarnings.push_back("4324");
 		globalWarnings.push_back("4345");
 		globalWarnings.push_back("4351");
 		globalWarnings.push_back("4512");


### PR DESCRIPTION
Not sure why this is even a warning since the whole point of the alignment specifier is to pad if the structure is misaligned, but it is, so this turns the warning off.

This is triggering from the PROCESS structure introduced in `common/coroutines.h`