### PR TITLE
AGS: Remove function FileCloseNotify

### DIFF
--- a/engines/ags/shared/util/file_stream.cpp
+++ b/engines/ags/shared/util/file_stream.cpp
@@ -48,12 +48,6 @@ bool FileStream::HasErrors() const {
 void FileStream::Close() {
 	delete _file;
 	_file = nullptr;
-	if (FileCloseNotify) {
-		CloseNotifyArgs args;
-		args.Filepath = _fileName;
-		args.WorkMode = _workMode;
-		FileCloseNotify(args);
-	}
 }
 
 bool FileStream::Flush() {
@@ -199,8 +193,6 @@ void FileStream::Open(const String &file_name, FileOpenMode open_mode, FileWorkM
 		_fileName = file_name;
 	}
 }
-
-FileStream::FFileCloseNotify FileStream::FileCloseNotify = nullptr;
 
 String FileStream::getSaveName(const String &filename) {
 	return String(filename.GetCStr() + strlen(SAVE_FOLDER_PREFIX));

--- a/engines/ags/shared/util/file_stream.h
+++ b/engines/ags/shared/util/file_stream.h
@@ -39,10 +39,6 @@ public:
 		FileWorkMode WorkMode;
 	};
 
-	// definition of function called when file closes
-	typedef std::function<void(const CloseNotifyArgs &args)> FFileCloseNotify;
-
-	static FFileCloseNotify FileCloseNotify;
 	// Represents an open file object
 	// The constructor may raise std::runtime_error if
 	// - there is an issue opening the file (does not exist, locked, permissions, etc)


### PR DESCRIPTION
In AGS there is a possibility to define a function, FileCloseNotify with arguments, which is called when closing a file. This possibility seems not to be used by any of the engines supported by ScummVM since it's set to nullptr. This is not a problem in itself. Hoewever when enabling compiler optimisiations the compiler may optimise away the FileCloseNotify definition. This was discovered when compiling iOS with Apple Clang in "Release" mode that the if-case in the code block below was removed while the args parameter was left:
    if (FileCloseNotify) {
         CloseNotifyArgs args;
         args.Filepath = _fileName;
         args.WorkMode = _workMode;
         FileCloseNotify(args);
     }

This caused a nullptr exception since FileCloseNotify was nullptr. A bit strange behavior by the compiler which could remove the entire code block above.

Since the FileCloseNotify is not used in ScummVM, remove it as it only seems to be used in upstream by the emscripten code which is not part of the ScummVM repository.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
This PR fix a crash when running some AGS games (e.g King’s quest 3 redux) in iOS (perhaps also macOS) with compiler optimisations enabled, which is the case when building "Release" mode for iOS.