### PR TITLE
DIRECTOR: Journey to the Source: add Quicktime xlib

### DIFF
--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -79,6 +79,7 @@
 #include "director/lingo/xlibs/prefpath.h"
 #include "director/lingo/xlibs/printomatic.h"
 #include "director/lingo/xlibs/qtmovie.h"
+#include "director/lingo/xlibs/quicktime.h"
 #include "director/lingo/xlibs/registercomponent.h"
 #include "director/lingo/xlibs/serialportxobj.h"
 #include "director/lingo/xlibs/soundjam.h"
@@ -210,6 +211,7 @@ static struct XLibProto {
 	{ PrefPath::fileNames,				PrefPath::open,				PrefPath::close,			kXObj,					400 },	// D4
 	{ PrintOMaticXObj::fileNames,		PrintOMaticXObj::open,		PrintOMaticXObj::close,		kXObj,					400 },	// D4
 	{ QTMovie::fileNames,				QTMovie::open,				QTMovie::close,				kXObj,					400 },	// D4
+	{ Quicktime::fileNames,				Quicktime::open,				Quicktime::close,				kXObj,					300 },	// D3
 	{ RearWindowXObj::fileNames,		RearWindowXObj::open,		RearWindowXObj::close,		kXObj,					400 },	// D4
 	{ RegisterComponent::fileNames,		RegisterComponent::open,	RegisterComponent::close,	kXObj,					400 },	// D4
 	{ SerialPortXObj::fileNames,		SerialPortXObj::open,		SerialPortXObj::close,		kXObj,					200 },	// D2

--- a/engines/director/lingo/xlibs/quicktime.cpp
+++ b/engines/director/lingo/xlibs/quicktime.cpp
@@ -1,0 +1,131 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*************************************
+ *
+ * USED IN:
+ * Journey to the Source
+ *
+ *************************************/
+
+#include "director/director.h"
+#include "director/window.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/lingo-utils.h"
+#include "director/lingo/xlibs/quicktime.h"
+#include "video/qt_decoder.h"
+
+namespace Director {
+
+const char *Quicktime::xlibName = "quicktime";
+const char *Quicktime::fileNames[] = {
+    "quicktime",
+    "QuickTime",
+    nullptr
+};
+
+static MethodProto xlibMethods[] = {
+    { "playStage",       Quicktime::m_playStage,      3, 3,  300 },
+    // Defined in the xobj itself but never used
+    // { "mPlaySmall",      Quicktime::m_playSmall,      3, 3,  300 },
+    { nullptr, nullptr, 0, 0, 0 }
+};
+
+void Quicktime::open(int type) {
+    if (type == kXObj) {
+        QuicktimeObject::initMethods(xlibMethods);
+        QuicktimeObject *xobj = new QuicktimeObject(kXObj);
+        g_lingo->exposeXObject(xlibName, xobj);
+    }
+}
+
+void Quicktime::close(int type) {
+    if (type == kXObj) {
+        QuicktimeObject::cleanupMethods();
+        g_lingo->_globalvars[xlibName] = Datum();
+    }
+}
+
+QuicktimeObject::QuicktimeObject(ObjectType ObjectType) :Object<QuicktimeObject>("QuickTime") {
+    _objType = ObjectType;
+}
+
+void Quicktime::m_playStage(int nargs) {
+    int top = g_lingo->pop().asInt();
+    int left = g_lingo->pop().asInt();
+    Common::String movieTitle = g_lingo->pop().asString();
+
+    // Provided file path begins with the volume
+    Common::Path filePath = findPath(movieTitle);
+
+    Video::QuickTimeDecoder *video = new Video::QuickTimeDecoder();
+    if (!video->loadFile(filePath)) {
+        g_lingo->push(Datum());
+        return;
+    }
+
+    if (!video->isPlaying()) {
+        video->setRate(1);
+        video->start();
+    }
+
+    Graphics::Surface const *frame = nullptr;
+    bool keepPlaying = true;
+    Common::Event event;
+    while (!video->endOfVideo()) {
+        if (g_system->getEventManager()->pollEvent(event)) {
+            switch(event.type) {
+                case Common::EVENT_QUIT:
+                    g_director->processEventQUIT();
+                    // fallthrough
+                case Common::EVENT_RBUTTONDOWN:
+                case Common::EVENT_LBUTTONDOWN:
+                    keepPlaying = false;
+                    break;
+                default:
+                    break;
+            }
+        }
+        if (!keepPlaying)
+            break;
+        if (video->needsUpdate()) {
+            frame = video->decodeNextFrame();
+            if (frame != nullptr)
+                g_system->copyRectToScreen(frame->getPixels(), frame->pitch, left, top, frame->w, frame->h);
+        }
+        g_system->updateScreen();
+        g_director->delayMillis(10);
+    }
+
+    if (frame != nullptr)
+        // Display the last frame after the video is done
+        g_director->getCurrentWindow()->getSurface()->copyRectToSurface(
+            frame->getPixels(), frame->pitch, left, top, frame->w, frame->h
+        );
+
+    video->close();
+    delete video;
+
+    g_lingo->push(Datum());
+}
+
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/quicktime.h
+++ b/engines/director/lingo/xlibs/quicktime.h
@@ -1,0 +1,46 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XLIBS_QUICKTIME_H
+#define DIRECTOR_LINGO_XLIBS_QUICKTIME_H
+
+namespace Director {
+
+class QuicktimeObject : public Object<QuicktimeObject> {
+public:
+    QuicktimeObject(ObjectType objType);
+};
+
+namespace Quicktime {
+
+extern const char *xlibName;
+extern const char *fileNames[];
+
+void open(int type);
+void close(int type);
+
+void m_playStage(int nargs);
+
+} // End of namespace Quicktime
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -100,6 +100,7 @@ MODULE_OBJS = \
 	lingo/xlibs/printomatic.o \
 	lingo/xlibs/qtmovie.o \
 	lingo/xlibs/qtvr.o \
+	lingo/xlibs/quicktime.o \
 	lingo/xlibs/registercomponent.o \
 	lingo/xlibs/serialportxobj.o \
 	lingo/xlibs/soundjam.o \


### PR DESCRIPTION
This xlib is specific to Journey to the Source (and possibly other discs by Grid Media). I've tested with the Mac version and it's largely working as expected now, aside from a minor issue related to [movies being loaded late in ScummVM](https://trello.com/c/J3frDAgc/616-d4-openwindow-should-load-the-movie-right-away).

I haven't implemented incorporating the video's palette yet - the method used by XPlayAnim doesn't work here. To work around that, I've added a quirk that sets it to run in 32bpp mode. That's why I'm opening a PR - I figured this is more of a temporary hack than a permanent fix, and I wasn't sure if other devs would mind me adding it.