### PR TITLE
DIRECTOR: Rebuild frames when there is jump to current frame

### DIFF
--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -405,8 +405,7 @@ void Score::update() {
 		if (_nextFrame) {
 			// With the advent of demand loading frames and due to partial updates, we rebuild our channel data
 			// when jumping.
-			if (_nextFrame != _curFrameNumber)
-				rebuildChannelData(_nextFrame);
+			rebuildChannelData(_nextFrame);
 			_curFrameNumber = _nextFrame;
 		}
 		else if (!_window->_newMovieStarted)


### PR DESCRIPTION
Initially, the frames data were only being reset and rebuild when jumps were made to frame that is different than current one, ie this in case when `_nextFrame != _curFrameNumber`, this however had problems with `majestic-mac` not opening and stuck on loading screen.

Fixed problem where `majestic-mac` would constantly jump to main-menu screen (ie same frame) and would not load the game.