### PR TITLE
DIRECTOR: Fix black patches in meet-media band

### DIFF
--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -65,7 +65,7 @@ Sprite::Sprite(Frame *frame) {
 	_autoPuppet = kAPNone; // Based on Director in a Nutshell, page 15
 	_immediate = false;
 	_backColor = g_director->_wm->_colorWhite;
-	_foreColor = g_director->_wm->_colorBlack;
+	_foreColor = g_director->_wm->_colorWhite;
 
 	_volume = 0;
 	_stretch = 0;


### PR DESCRIPTION
It has been observed that for `Shape` cast members, the default color is white, as there were no foreColor in frames data for white fore-color casts. This indicates  how director saves more memory by omitting this foreColor(255).

`mediaband-win` used several of transparent white rectangle shape cast to identify hover and click events. Using lingo `rollOver` command However these shapes were set foreColor white which was not being embedded in frames data. This caused the shapes to be rendered black which is default foreColor.