### PR TITLE
COMMON: fix MacResManager native resource forks

### DIFF
--- a/common/fs.cpp
+++ b/common/fs.cpp
@@ -362,6 +362,18 @@ void FSDirectory::cacheDirectoryRecursive(FSNode node, int depth, const Path& pr
 				}
 			} else {
 				_fileCache[name] = *it;
+
+#ifdef MACOSX
+				// On Mac, check for native resource fork
+				String rsrcName = it->getPath() + "/..namedfork/rsrc";
+				FSNode rsrc = FSNode(rsrcName);
+
+				Path cacheName = prefix.join(it->getRealName() + "/..namedfork/rsrc");
+
+				if (rsrc.exists()) {
+					_fileCache[cacheName] = rsrc;
+				}
+#endif
 			}
 		}
 	}

--- a/common/macresman.cpp
+++ b/common/macresman.cpp
@@ -274,8 +274,7 @@ bool MacResManager::open(const Path &fileName, Archive &archive) {
 	// Check the actual fork on a Mac computer. It's even worse than __MACOSX as
 	// it's present on any HFS(+) and appears even after copying macbin on HFS(+).
 	const ArchiveMemberPtr archiveMember = archive.getMember(fileName);
-	const Common::FSNode *plainFsNode = dynamic_cast<const Common::FSNode *>(archiveMember.get());
-	if (plainFsNode) {
+	if (archiveMember.get()) {
 		// This could be a MacBinary file that still has a
 		// resource fork; if it is, it needs to get opened as MacBinary
 		// and not treated as raw.
@@ -286,9 +285,8 @@ bool MacResManager::open(const Path &fileName, Archive &archive) {
 		}
 		delete stream;
 
-		String fullPath = plainFsNode->getPath() + "/..namedfork/rsrc";
-		FSNode resFsNode = FSNode(fullPath);
-		SeekableReadStream *macResForkRawStream = resFsNode.createReadStream();
+		Path fullPath = archiveMember.get()->getPathInArchive().join("/..namedfork/rsrc");
+		SeekableReadStream *macResForkRawStream = archive.createReadStreamForMember(fullPath);
 		if (!isMacBinaryFile && macResForkRawStream && loadFromRawFork(macResForkRawStream)) {
 			_baseFileName = fileName;
 			return true;


### PR DESCRIPTION
These broke in the archive refactor, b8acbe6bee730a9024e73acc769b54285be9afde/#5108, because it removed the ability to directly convert an `ArchiveMember` to an `FSNode`. There also isn't a way to get full non-relative paths anymore, which is what the `FSNode` cast was doing before; it made it possible to just get the raw path on disk and turn it into the magic path to the resource fork.

This is based on an approach suggested by @elasota, to make use of the existing archive code by making the archives aware of the resource forks. I'm not 100% sold mainly because it feels awkward to me - the rest of the code is based on iterating the actual filesystem, but resource forks aren't "real" files and can't be listed/iterated the same way real files are. That means it instead has to manually construct their magic paths and test for existence before adding it to the cache set.

Note that this version doesn't yet work: `archive.createReadStreamForMember(fullPath)` isn't actually returning the resource fork as I expected it to, even though I confirmed the cache key and the `fullPath` are the same string.

Thinking about alternatives, a few other thoughts include:

* Restore the ability to obtain full paths. That's slightly weird because most "archives" don't have a raw path on disk the way that `SearchSet` does, but it would make it possible to return to the old behaviour.
* Give `Archive` a new method to request a stream for the resource fork, instead of the data fork, which on Mac would construct the magic path and return a stream.