### PR TITLE
DIRECTOR: Fix memory leaks when changing sharedCast

### DIFF
--- a/engines/director/window.cpp
+++ b/engines/director/window.cpp
@@ -370,6 +370,7 @@ void Window::loadNewSharedCast(Cast *previousSharedCast) {
 	if (previousSharedCast) {
 		g_director->_allSeenResFiles.erase(previousSharedCastPath);
 		g_director->_allOpenResFiles.remove(previousSharedCastPath);
+		delete previousSharedCast->_castArchive;
 		delete previousSharedCast;
 	}
 


### PR DESCRIPTION
When changing from shared casts in `Window::loadNewSharedCast`, and in instance where previousCast need to be deleted, we just deleted the cast itself but not the underlying `Archive`, this resulted in memory leaks. `~Director()` was not deleting this archive because it was being removed from `_allSeenResFiles` in favour of loading new archive.

Fixed by deleting `Archive *_castArchive` of previousCast after erasing its entry from `_allSeenResFiles`.