### PR TITLE
DIRECTOR: Anonymous function access object

### DIFF
--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -247,7 +247,11 @@ void Lingo::pushContext(const Symbol funcSym, bool allowRetVal, Datum defaultRet
 
 	_state->script = funcSym.u.defn;
 
-	_state->me = funcSym.target;
+	// Do not set the context for anonymous functions that are called from factory
+	// ie something like b_do(), which is called from mNew() should have access to instance
+	// variables, thus it is in same context as the caller.
+	if (!(funcSym.anonymous && _state->me.type == OBJECT && _state->me.u.obj->getObjType() & (kFactoryObj | kScriptObj)))
+		_state->me = funcSym.target;
 
 	if (funcSym.ctx) {
 		_state->context = funcSym.ctx;

--- a/engines/director/lingo/tests/factory-do.lingo
+++ b/engines/director/lingo/tests/factory-do.lingo
@@ -1,0 +1,18 @@
+abc(mNew)
+
+factory abc
+method mNew
+    instance avar
+    set avar to "a variable"
+    set res1 = me(callDo)
+    scummvmAssertEqual(res1, "a variable")
+    me(setDo)
+    scummvmAssertEqual(avar, 100)
+    
+method callDo
+    set myvar = 0
+    do("set myvar = avar")
+    return myvar
+
+method setDo
+    do("set avar = 100")

--- a/engines/director/resource.cpp
+++ b/engines/director/resource.cpp
@@ -332,6 +332,9 @@ Archive *DirectorEngine::loadEXE(const Common::Path &movie) {
 
 		if (result)
 			result->setPathName(movie.toString(g_director->_dirSeparator));
+		else {
+			delete exeStream;
+		}
 
 		return result;
 	}


### PR DESCRIPTION
  Anonymous functions are allowed to access the instance variables that are in scope, just like localVariables. This patch restores the  original behavior by not resetting `_state->_me` when a context is pushed that belongs to anonymous function while it is being called from object, ie `kFactoryObj | kScriptObj`. Commands like `do("set instanceVar = 1")` and `do("set abc = instanceVar")` will now work.

Fixes food maker in food bar where up/down buttons were not working.

--start-movie="ATD\HD\cfTWR4FO.DXR" totaldistortion-win