### PR TITLE
DIRECTOR: Improve screenshot comparison of previous builds

### DIFF
--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -145,6 +145,7 @@ private:
 	void playQueuedSound();
 
 	void screenShot();
+	bool checkShotSimilarity(const Graphics::Surface *surface1, const Graphics::Surface *surface2);
 
 	bool processImmediateFrameScript(Common::String s, int id);
 	bool processFrozenScripts();

--- a/engines/director/types.h
+++ b/engines/director/types.h
@@ -32,6 +32,11 @@ enum {
 	kFewFamesMaxCounter = 19,
 };
 
+enum {
+	kShotColorDiffThreshold = 2,
+	kShotPercentPixelThreshold = 1
+};
+
 #define kQuirksCacheArchive "quirks"
 
 enum MovieFlag {


### PR DESCRIPTION
This patch adds simple pixel-by-pixel comparison of screenshots between builds. It is helpful to detect regressions in graphics rendering.