### PR TITLE
DS: Hack to work around ARM/Thumb relocation issues in the SCUMM engine

### DIFF
--- a/backends/plugins/ds/ds-provider.cpp
+++ b/backends/plugins/ds/ds-provider.cpp
@@ -33,6 +33,16 @@
 #include "backends/plugins/ds/ds-provider.h"
 #include "backends/plugins/elf/arm-loader.h"
 
+// HACK: This is needed so that standard library functions that are only
+// used in plugins can be found in the main executable.
+void pluginHack() {
+	volatile double d = 0.0;
+	double d1 = 0.0;
+
+	d = atan2(d, d);
+	d = modf(d, &d1);
+}
+
 class DSDLObject : public ARMDLObject {
 protected:
 	virtual void flushDataCache(void *ptr, uint32 len) const {


### PR DESCRIPTION
Having all libc functions referenced in the main executable works around the issue described in [Trac #14554](https://bugs.scummvm.org/ticket/14554). This allows the SCUMM engine to run correctly, instead of crashing when launching a game.

If this PR is accepted, I plan to create the v2.7.1 release build with this change applied. Hopefully a proper fix will be available before v2.8.0, but I don't know how to do this myself.
