### PR TITLE
COMMON: Add alternate stream support for Mac resource forks and Finder info

### DIFF
--- a/backends/fs/abstract-fs.cpp
+++ b/backends/fs/abstract-fs.cpp
@@ -35,3 +35,7 @@ const char *AbstractFSNode::lastPathComponent(const Common::String &str, const c
 
 	return cur + 1;
 }
+
+Common::SeekableReadStream *AbstractFSNode::createReadStreamForAltStream(Common::AltStreamType altStreamType) {
+	return nullptr;
+}

--- a/backends/fs/abstract-fs.h
+++ b/backends/fs/abstract-fs.h
@@ -183,6 +183,16 @@ public:
 	virtual Common::SeekableReadStream *createReadStream() = 0;
 
 	/**
+	 * Creates a SeekableReadStream instance corresponding to an alternate
+	 * stream of the file referred by this node. This assumes that the node
+	 * actually refers to a readable file and the alt stream exists.
+	 * If either is not the case, 0 is returned.
+	 *
+	 * @return pointer to the stream object, 0 in case of a failure
+	 */
+	virtual Common::SeekableReadStream *createReadStreamForAltStream(Common::AltStreamType altStreamType);
+
+	/**
 	 * Creates a WriteStream instance corresponding to the file
 	 * referred by this node. This assumes that the node actually refers
 	 * to a readable file. If this is not the case, 0 is returned.

--- a/backends/fs/posix/posix-fs.cpp
+++ b/backends/fs/posix/posix-fs.cpp
@@ -269,6 +269,17 @@ Common::SeekableReadStream *POSIXFilesystemNode::createReadStream() {
 	return PosixIoStream::makeFromPath(getPath(), false);
 }
 
+Common::SeekableReadStream *POSIXFilesystemNode::createReadStreamForAltStream(Common::AltStreamType altStreamType) {
+#ifdef MACOSX
+	if (altStreamType == Common::AltStreamType::MacResourceFork) {
+		// Check the actual fork on a Mac computer
+		return PosixIoStream::makeFromPath(getPath() + "/..namedfork/rsrc", false);
+	}
+#endif
+
+	return nullptr;
+}
+
 Common::SeekableWriteStream *POSIXFilesystemNode::createWriteStream() {
 	return PosixIoStream::makeFromPath(getPath(), true);
 }

--- a/backends/fs/posix/posix-fs.h
+++ b/backends/fs/posix/posix-fs.h
@@ -66,6 +66,7 @@ public:
 	AbstractFSNode *getParent() const override;
 
 	Common::SeekableReadStream *createReadStream() override;
+	Common::SeekableReadStream *createReadStreamForAltStream(Common::AltStreamType altStreamType) override;
 	Common::SeekableWriteStream *createWriteStream() override;
 	bool createDirectory() override;
 

--- a/common/compression/gentee_installer.cpp
+++ b/common/compression/gentee_installer.cpp
@@ -585,6 +585,7 @@ public:
 	ArchiveItem(Common::SeekableReadStream *stream, Common::Mutex *guardMutex, const Common::String &path, const Common::String &name, int64 filePos, uint compressedSize, uint decompressedSize, bool isCompressed);
 
 	Common::SeekableReadStream *createReadStream() const override;
+	Common::SeekableReadStream *createReadStreamForAltStream(Common::AltStreamType altStreamType) const override;
 	Common::String getName() const override;
 	Common::Path getPathInArchive() const override { return getName(); }
 	Common::String getFileName() const override { return getName(); }
@@ -621,6 +622,10 @@ Common::SeekableReadStream *ArchiveItem::createReadStream() const {
 		return new DecompressingStream(sliceSubstream, _compressedSize, _decompressedSize);
 	else
 		return sliceSubstream;
+}
+
+Common::SeekableReadStream *ArchiveItem::createReadStreamForAltStream(Common::AltStreamType altStreamType) const {
+	return nullptr;
 }
 
 Common::String ArchiveItem::getName() const {

--- a/common/compression/vise.cpp
+++ b/common/compression/vise.cpp
@@ -66,23 +66,19 @@ private:
 
 	class ArchiveMember : public Common::ArchiveMember {
 	public:
-		enum SubstreamType {
-			kSubstreamTypeData,
-			kSubstreamTypeResource,
-			kSubstreamTypeFinderInfo,
-		};
-
-		ArchiveMember(Common::SeekableReadStream *archiveStream, const FileDesc *fileDesc, SubstreamType substreamType);
+		ArchiveMember(Common::SeekableReadStream *archiveStream, const FileDesc *fileDesc);
 
 		Common::SeekableReadStream *createReadStream() const override;
+		Common::SeekableReadStream *createReadStreamForAltStream(Common::AltStreamType altStreamType) const override;
 		Common::String getName() const override;
 		Common::Path getPathInArchive() const override;
 		Common::String getFileName() const override;
 
 	private:
+		Common::SeekableReadStream *createReadStreamForDataStream(bool isResFork) const;
+
 		Common::SeekableReadStream *_archiveStream;
 		const FileDesc *_fileDesc;
-		SubstreamType _substreamType;
 	};
 
 public:
@@ -96,23 +92,28 @@ public:
 	int listMembers(Common::ArchiveMemberList &list) const override;
 	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
 	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
+	Common::SeekableReadStream *createReadStreamForMemberAltStream(const Common::Path &path, Common::AltStreamType altStreamType) const override;
 	char getPathSeparator() const override;
 
 private:
-	bool getFileDescIndex(const Common::Path &path, uint &outIndex, ArchiveMember::SubstreamType &outSubstreamType) const;
+	bool getFileDescIndex(const Common::Path &path, uint &outIndex) const;
 
 	Common::SeekableReadStream *_archiveStream;
 	Common::Array<FileDesc> _fileDescs;
 	Common::Array<DirectoryDesc> _directoryDescs;
 };
 
-MacVISEArchive::ArchiveMember::ArchiveMember(Common::SeekableReadStream *archiveStream, const FileDesc *fileDesc, SubstreamType substreamType)
-	: _archiveStream(archiveStream), _fileDesc(fileDesc), _substreamType(substreamType) {
+MacVISEArchive::ArchiveMember::ArchiveMember(Common::SeekableReadStream *archiveStream, const FileDesc *fileDesc)
+	: _archiveStream(archiveStream), _fileDesc(fileDesc) {
 }
 
 Common::SeekableReadStream *MacVISEArchive::ArchiveMember::createReadStream() const {
-	if (_substreamType == kSubstreamTypeFinderInfo) {
-		Common::MacFinderInfoData *finfoData = static_cast<Common::MacFinderInfoData*>(malloc(sizeof(Common::MacFinderInfoData)));
+	return createReadStreamForDataStream(false);
+}
+
+Common::SeekableReadStream *MacVISEArchive::ArchiveMember::createReadStreamForAltStream(Common::AltStreamType altStreamType) const {
+	if (altStreamType == AltStreamType::MacFinderInfo) {
+		Common::MacFinderInfoData *finfoData = static_cast<Common::MacFinderInfoData *>(malloc(sizeof(Common::MacFinderInfoData)));
 
 		if (!finfoData)
 			return nullptr;
@@ -126,6 +127,13 @@ Common::SeekableReadStream *MacVISEArchive::ArchiveMember::createReadStream() co
 		return new Common::MemoryReadStream(reinterpret_cast<const byte *>(finfoData), sizeof(Common::MacFinderInfoData), DisposeAfterUse::YES);
 	}
 
+	if (altStreamType == AltStreamType::MacResourceFork)
+		return createReadStreamForDataStream(true);
+
+	return nullptr;
+}
+
+Common::SeekableReadStream *MacVISEArchive::ArchiveMember::createReadStreamForDataStream(bool isResFork) const {
 	static const uint8 vl3DeobfuscationTable[] = {
 		0x6a, 0xb7, 0x36, 0xec, 0x15, 0xd9, 0xc8, 0x73, 0xe8, 0x38, 0x9a, 0xdf, 0x21, 0x25, 0xd0, 0xcc,
 		0xfd, 0xdc, 0x16, 0xd7, 0xe3, 0x43, 0x05, 0xc5, 0x8f, 0x48, 0xda, 0xf2, 0x3f, 0x10, 0x23, 0x6c,
@@ -145,11 +153,14 @@ Common::SeekableReadStream *MacVISEArchive::ArchiveMember::createReadStream() co
 		0x86, 0xdd, 0x5f, 0x42, 0xd3, 0x02, 0x61, 0x95, 0x0c, 0x5c, 0xa5, 0xcd, 0xc0, 0x07, 0xe2, 0xf3,
 	};
 
-	const bool isResFork = (_substreamType == kSubstreamTypeResource);
-
 	uint32 uncompressedSize = isResFork ? _fileDesc->uncompressedResSize : _fileDesc->uncompressedDataSize;
 	uint32 compressedSize = isResFork ? _fileDesc->compressedResSize : _fileDesc->compressedDataSize;
 	uint32 filePosition = _fileDesc->positionInArchive;
+
+	if (uncompressedSize == 0 && !isResFork) {
+		// Always return a stream for the data fork, even if it's empty
+		return new Common::MemoryReadStream(nullptr, 0, DisposeAfterUse::NO);
+	}
 
 	if (isResFork)
 		filePosition += _fileDesc->compressedDataSize;
@@ -201,21 +212,11 @@ Common::String MacVISEArchive::ArchiveMember::getName() const {
 }
 
 Common::Path MacVISEArchive::ArchiveMember::getPathInArchive() const {
-	if (_substreamType == kSubstreamTypeFinderInfo)
-		return _fileDesc->fullPath.append(".finf", ':');
-	else if (_substreamType == kSubstreamTypeResource)
-		return _fileDesc->fullPath.append(".rsrc", ':');
-	else
-		return _fileDesc->fullPath;
+	return _fileDesc->fullPath;
 }
 
 Common::String MacVISEArchive::ArchiveMember::getFileName() const {
-	if (_substreamType == kSubstreamTypeFinderInfo)
-		return _fileDesc->name + ".finf";
-	else if (_substreamType == kSubstreamTypeResource)
-		return _fileDesc->name + ".rsrc";
-	else
-		return _fileDesc->name;
+	return _fileDesc->name;
 }
 
 MacVISEArchive::FileDesc::FileDesc() : type{0, 0, 0, 0}, creator{0, 0, 0, 0}, compressedDataSize(0), uncompressedDataSize(0), compressedResSize(0), uncompressedResSize(0), positionInArchive(0) {
@@ -360,8 +361,7 @@ const MacVISEArchive::FileDesc *MacVISEArchive::getFileDesc(const Common::Path &
 
 bool MacVISEArchive::hasFile(const Common::Path &path) const {
 	uint index = 0;
-	ArchiveMember::SubstreamType substreamType = ArchiveMember::kSubstreamTypeData;
-	return getFileDescIndex(path, index, substreamType);
+	return getFileDescIndex(path, index);
 }
 
 int MacVISEArchive::listMembers(Common::ArchiveMemberList &list) const {
@@ -369,16 +369,7 @@ int MacVISEArchive::listMembers(Common::ArchiveMemberList &list) const {
 	for (uint fileIndex = 0; fileIndex < _fileDescs.size(); fileIndex++) {
 		const FileDesc &desc = _fileDescs[fileIndex];
 
-		if (desc.uncompressedDataSize) {
-			list.push_back(Common::ArchiveMemberPtr(new ArchiveMember(_archiveStream, &desc, ArchiveMember::kSubstreamTypeData)));
-			numMembers++;
-		}
-		if (desc.uncompressedResSize) {
-			list.push_back(Common::ArchiveMemberPtr(new ArchiveMember(_archiveStream, &desc, ArchiveMember::kSubstreamTypeResource)));
-			numMembers++;
-		}
-
-		list.push_back(Common::ArchiveMemberPtr(new ArchiveMember(nullptr, &desc, ArchiveMember::kSubstreamTypeFinderInfo)));
+		list.push_back(Common::ArchiveMemberPtr(new ArchiveMember(_archiveStream, &desc)));
 		numMembers++;
 	}
 	return numMembers;
@@ -386,11 +377,10 @@ int MacVISEArchive::listMembers(Common::ArchiveMemberList &list) const {
 
 const Common::ArchiveMemberPtr MacVISEArchive::getMember(const Common::Path &path) const {
 	uint descIndex = 0;
-	ArchiveMember::SubstreamType substreamType = ArchiveMember::kSubstreamTypeData;
-	if (!getFileDescIndex(path, descIndex, substreamType))
+	if (!getFileDescIndex(path, descIndex))
 		return nullptr;
 
-	return Common::ArchiveMemberPtr(new ArchiveMember(_archiveStream, &_fileDescs[descIndex], substreamType));
+	return Common::ArchiveMemberPtr(new ArchiveMember(_archiveStream, &_fileDescs[descIndex]));
 }
 
 Common::SeekableReadStream *MacVISEArchive::createReadStreamForMember(const Common::Path &path) const {
@@ -401,34 +391,23 @@ Common::SeekableReadStream *MacVISEArchive::createReadStreamForMember(const Comm
 	return archiveMember->createReadStream();
 }
 
+Common::SeekableReadStream *MacVISEArchive::createReadStreamForMemberAltStream(const Common::Path &path, Common::AltStreamType altStreamType) const {
+	Common::ArchiveMemberPtr archiveMember = getMember(path);
+	if (!archiveMember)
+		return nullptr;
+
+	return archiveMember->createReadStreamForAltStream(altStreamType);
+}
+
 char MacVISEArchive::getPathSeparator() const {
 	return ':';
 }
 
-bool MacVISEArchive::getFileDescIndex(const Common::Path &path, uint &outIndex, ArchiveMember::SubstreamType &outSubstreamType) const {
-	Common::String convertedPath = path.toString(getPathSeparator());
-
-	ArchiveMember::SubstreamType substreamType = ArchiveMember::kSubstreamTypeData;
-	if (convertedPath.hasSuffix(".rsrc")) {
-		substreamType = ArchiveMember::kSubstreamTypeResource;
-		convertedPath = convertedPath.substr(0, convertedPath.size() - 5);
-	} else if (convertedPath.hasSuffix(".finf")) {
-		substreamType = ArchiveMember::kSubstreamTypeFinderInfo;
-		convertedPath = convertedPath.substr(0, convertedPath.size() - 5);
-	}
-
-	Common::Path filePath(convertedPath, getPathSeparator());
-
+bool MacVISEArchive::getFileDescIndex(const Common::Path &path, uint &outIndex) const {
 	for (uint descIndex = 0; descIndex < _fileDescs.size(); descIndex++) {
 		const FileDesc &desc = _fileDescs[descIndex];
 
-		if (desc.fullPath == filePath) {
-			if (substreamType == ArchiveMember::SubstreamType::kSubstreamTypeData && desc.uncompressedDataSize == 0)
-				return false;
-			if (substreamType == ArchiveMember::SubstreamType::kSubstreamTypeResource && desc.uncompressedResSize == 0)
-				return false;
-
-			outSubstreamType = substreamType;
+		if (desc.fullPath == path) {
 			outIndex = descIndex;
 			return true;
 		}

--- a/common/formats/prodos.cpp
+++ b/common/formats/prodos.cpp
@@ -172,6 +172,10 @@ Common::SeekableReadStream *ProDOSFile::createReadStream() const {
 	return new Common::MemoryReadStream(finalData, _eof, DisposeAfterUse::YES);
 }
 
+Common::SeekableReadStream *ProDOSFile::createReadStreamForAltStream(Common::AltStreamType altStreamType) const {
+	return nullptr;
+}
+
 // --- ProDOSDisk methods ---
 
 /* The time and date are compressed into 16bit words, so to make them useable

--- a/common/formats/prodos.h
+++ b/common/formats/prodos.h
@@ -90,6 +90,7 @@ public:
 	Common::Path getPathInArchive() const override;                       // Returns _name
 	Common::String getFileName() const override;                          // Returns _name
 	Common::SeekableReadStream *createReadStream() const override;        // This is what the archive needs to create a file
+	Common::SeekableReadStream *createReadStreamForAltStream(Common::AltStreamType altStreamType) const override;
 	void getDataBlock(byte *memOffset, int offset, int size) const;       // Gets data up to the size of a single data block (512 bytes)
 	int parseIndexBlock(byte *memOffset, int blockNum, int cSize) const;  // Uses getDataBlock() on every pointer in the index file, adding them to byte * memory block
 

--- a/common/fs.h
+++ b/common/fs.h
@@ -256,9 +256,19 @@ public:
 	 * referred by this node. This assumes that the node actually refers
 	 * to a readable file. If this is not the case, 0 is returned.
 	 *
-	 * @return Pointer to the stream object, 0 in case of a failure.
+	 * @return Pointer to the stream object, nullptr in case of a failure.
 	 */
 	SeekableReadStream *createReadStream() const override;
+
+	/**
+	 * Create a SeekableReadStream instance corresponding to an alternate stream
+	 * of the file referred by this node. This assumes that the node actually
+	 * refers to a readable file and the alternate stream exists.  If either is
+	 * not the case, nullptr is returned.
+	 *
+	 * @return Pointer to the stream object, nullptr in case of a failure.
+	 */
+	SeekableReadStream *createReadStreamForAltStream(AltStreamType altStreamType) const override;
 
 	/**
 	 * Create a WriteStream instance corresponding to the file

--- a/engines/grim/lab.h
+++ b/engines/grim/lab.h
@@ -42,6 +42,7 @@ public:
 	Common::String getFileName() const override { return _name; }
 	Common::Path getPathInArchive() const override { return _name; }
 	Common::SeekableReadStream *createReadStream() const override;
+	Common::SeekableReadStream *createReadStreamForAltStream(Common::AltStreamType altStreamType) const override { return nullptr; }
 	friend class Lab;
 };
 

--- a/engines/mm/shared/utils/engine_data.cpp
+++ b/engines/mm/shared/utils/engine_data.cpp
@@ -45,6 +45,9 @@ public:
 	Common::SeekableReadStream *createReadStream() const override {
 		return _member->createReadStream();
 	}
+	Common::SeekableReadStream *createReadStreamForAltStream(Common::AltStreamType altStreamType) const override {
+		return nullptr;
+	}
 	Common::String getName() const override {
 		Common::String name = _member->getName();
 		assert(name.hasPrefixIgnoreCase(_innerfolder));

--- a/engines/mtropolis/boot.cpp
+++ b/engines/mtropolis/boot.cpp
@@ -506,8 +506,10 @@ void SPQRGameDataHandler::unpackAdditionalFiles(Common::Array<Common::SharedPtr<
 		debug(1, "Unpacking files...");
 
 		for (const MacVISE3InstallerUnpackRequest &request : unpackRequests) {
+			Common::Path requestPath(request.fileName, ':');
+
 			Common::MacFinderInfo finfo;
-			if (!Common::MacResManager::getFileFinderInfo(request.fileName, *archive, finfo))
+			if (!Common::MacResManager::getFileFinderInfo(requestPath, *archive, finfo))
 				error("Couldn't get Finder info for file '%s'", request.fileName);
 
 			FileIdentification ident;
@@ -518,14 +520,14 @@ void SPQRGameDataHandler::unpackAdditionalFiles(Common::Array<Common::SharedPtr<
 
 			if (request.extractResources) {
 				Common::SharedPtr<Common::MacResManager> resMan(new Common::MacResManager());
-				if (!resMan->open(request.fileName, *archive))
+				if (!resMan->open(requestPath, *archive))
 					error("Failed to open Mac res manager for file '%s'", request.fileName);
 
 				ident.resMan = resMan;
 			}
 
 			if (request.extractData)
-				ident.stream.reset(archive->createReadStreamForMember(request.fileName));
+				ident.stream.reset(archive->createReadStreamForMember(requestPath));
 
 			files.push_back(ident);
 		}

--- a/engines/stark/formats/xarc.cpp
+++ b/engines/stark/formats/xarc.cpp
@@ -39,6 +39,7 @@ public:
 	XARCMember(const XARCArchive *xarc, Common::ReadStream &stream, uint32 offset);
 
 	Common::SeekableReadStream *createReadStream() const override;
+	Common::SeekableReadStream *createReadStreamForAltStream(Common::AltStreamType altStreamType) const override;
 	Common::String getName() const override { return _name; }
 	Common::Path getPathInArchive() const { return _name; }
 	Common::String getFileName() const { return _name; }
@@ -74,6 +75,10 @@ XARCMember::XARCMember(const XARCArchive *xarc, Common::ReadStream &stream, uint
 
 Common::SeekableReadStream *XARCMember::createReadStream() const {
 	return _xarc->createReadStreamForMember(this);
+}
+
+Common::SeekableReadStream *XARCMember::createReadStreamForAltStream(Common::AltStreamType altStreamType) const {
+	return nullptr;
 }
 
 Common::String XARCMember::readString(Common::ReadStream &stream) {

--- a/engines/ultima/shared/engine/data_archive.cpp
+++ b/engines/ultima/shared/engine/data_archive.cpp
@@ -44,6 +44,9 @@ public:
 	Common::SeekableReadStream *createReadStream() const override {
 		return _member->createReadStream();
 	}
+	Common::SeekableReadStream *createReadStreamForAltStream(Common::AltStreamType altStreamType) const override {
+		return _member->createReadStreamForAltStream(altStreamType);
+	}
 	Common::String getName() const override {
 		Common::String name = _member->getName();
 		assert(name.hasPrefixIgnoreCase(_innerfolder));

--- a/engines/wintermute/base/file/base_file_entry.cpp
+++ b/engines/wintermute/base/file/base_file_entry.cpp
@@ -52,6 +52,10 @@ Common::SeekableReadStream *BaseFileEntry::createReadStream() const {
 	return file;
 }
 
+Common::SeekableReadStream *BaseFileEntry::createReadStreamForAltStream(Common::AltStreamType altStreamType) const {
+	return nullptr;
+}
+
 //////////////////////////////////////////////////////////////////////////
 BaseFileEntry::BaseFileEntry() {
 	_package = nullptr;

--- a/engines/wintermute/base/file/base_file_entry.h
+++ b/engines/wintermute/base/file/base_file_entry.h
@@ -39,6 +39,7 @@ class BasePackage;
 class BaseFileEntry : public Common::ArchiveMember {
 public:
 	Common::SeekableReadStream *createReadStream() const override;
+	Common::SeekableReadStream *createReadStreamForAltStream(Common::AltStreamType altStreamType) const override;
 	Common::String getName() const override { return _filename; }
 	Common::Path getPathInArchive() const override { return _filename; }
 	Common::String getFileName() const override { return _filename; }


### PR DESCRIPTION
This sort of redoes PR #5189 to use an alternate stream API instead of having to handle the FS quirks of named streams on OSX.

This attempts to ensure that a stream is always openable for a file that exists even if it's empty, so opening an empty data fork from a StuffIt or VISE archive returns an empty memory stream instead of nullptr.