### PR TITLE
MOHAWK: MYST: Skip fade steps on slower machines

### DIFF
--- a/engines/mohawk/myst_graphics.cpp
+++ b/engines/mohawk/myst_graphics.cpp
@@ -706,18 +706,29 @@ void MystGraphics::fadeToBlack() {
 	// This is only for the demo
 	assert(!_vm->isGameVariant(GF_ME));
 
-	// Linear fade in 64 steps
-	for (int i = 63; i >= 0; i--) {
+	// Linear fade in 64 steps or less
+	uint32 startTime = _vm->_system->getMillis();
+	uint32 endTime = startTime + 640;
+	uint32 time, i;
+
+	do {
 		byte palette[256 * 3];
 		byte *src = _palette;
 		byte *dst = palette;
 
-		for (uint j = 0; j < sizeof(palette); j++)
-			*dst++ = *src++ * i / 64;
+		time = _vm->_system->getMillis();
+		i = (endTime - time) / 10;
+
+		if (time < endTime) {
+			for (uint j = 0; j < sizeof(palette); j++)
+				*dst++ = *src++ * i / 64;
+		} else {
+			memset(palette, 0, sizeof(palette));
+		}
 
 		_vm->_system->getPaletteManager()->setPalette(palette, 0, 256);
 		_vm->doFrame();
-	}
+	} while (time < endTime);
 }
 
 void MystGraphics::fadeFromBlack() {
@@ -726,18 +737,28 @@ void MystGraphics::fadeFromBlack() {
 
 	copyBackBufferToScreen(_viewport);
 
-	// Linear fade in 64 steps
-	for (int i = 0; i < 64; i++) {
+	// Linear fade in 64 steps or less
+	uint32 startTime = _vm->_system->getMillis();
+	uint32 endTime = startTime + 640;
+	uint32 time, i;
+
+	do {
 		byte palette[256 * 3];
 		byte *src = _palette;
 		byte *dst = palette;
+		time = _vm->_system->getMillis();
+		i = (time - startTime) / 10;
 
-		for (uint j = 0; j < sizeof(palette); j++)
-			*dst++ = *src++ * i / 64;
+		if (time < endTime) {
+			for (uint j = 0; j < sizeof(palette); j++)
+				*dst++ = *src++ * i / 64;
+		} else {
+			memcpy(palette, _palette, sizeof(palette));
+		}
 
 		_vm->_system->getPaletteManager()->setPalette(palette, 0, 256);
 		_vm->doFrame();
-	}
+	} while (time < endTime);
 
 	// Set the full palette
 	_vm->_system->getPaletteManager()->setPalette(_palette, 0, 256);


### PR DESCRIPTION
Fading in and out is a simple palette-based effect, but can be very slow on backends that exclusively use true colour.