### PR TITLE
DIRECTOR: LINGO: Scoped and scopeless lingo score

### DIFF
--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -169,9 +169,13 @@ void Movie::queueFrameEvent(Common::Queue<LingoEvent> &queue, LEvent event, int 
 	if (!script)
 		return;
 
+	// Scopeless statements (ie one lined lingo commands) are executed at enterFrame
+	// A score script can have both scopeless and scoped lingo. (eg. porting from D3.1 to D4)
 	if (event == kEventEnterFrame && script->_eventHandlers.contains(kEventGeneric)) {
-		queue.push(LingoEvent(kEventGeneric, eventId, kScoreScript, scriptId, false, 0));
-	} else if (script->_eventHandlers.contains(event)) {
+		queue.push(LingoEvent(kEventGeneric, eventId, kScoreScript, scriptId, true, 0));
+	}
+
+	if (script->_eventHandlers.contains(event)) {
 		queue.push(LingoEvent(event, eventId, kScoreScript, scriptId, false, 0));
 	}
 }


### PR DESCRIPTION
This patch fixes the behaviour of having both scoped and scopeless lingo in the same score script. It has been observed that movies created with D3.1 that uses scopeless lingo can be ported to D4, in which case the scopeless lingo is executed first, before the scoped lingo. (for example in `put "abc" enterFrame put "enter" end`, abc will be printed first, then enter)

Fix the problem where frames in certain `totaldistortion-win` movies are played spontaneously because enterFrame handlers are not called due to scopeless statements contained in the movie.

--start-movie="ATD/HD/FISMH2H6.DXR"@50 totaldistortion-win