### PR TITLE
DIRECTOR, GRAPHICS: MACGUI: Background director window!

### DIFF
--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -241,6 +241,9 @@ Common::Error DirectorEngine::run() {
 	_stage = new Window(_wm->getNextId(), false, false, false, _wm, this, true);
 	*_stage->_refCount += 1;
 
+	// Set this as background so it doesn't come to foreground when multiple windows present
+	_wm->setBackgroundWindow(_stage);
+
 	if (!desktopEnabled())
 		_stage->disableBorder();
 

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -165,6 +165,7 @@ MacWindowManager::MacWindowManager(uint32 mode, MacPatterns *patterns, Common::L
 
 	_activeWidget = nullptr;
 	_lockedWidget = nullptr;
+	_backgroundWindow = nullptr;
 
 	_mouseDown = false;
 	_hoveredWidget = nullptr;
@@ -344,6 +345,10 @@ void MacWindowManager::setLockedWidget(MacWidget *widget) {
 		return;
 
 	_lockedWidget = widget;
+}
+
+void MacWindowManager::setBackgroundWindow(MacWindow *window) {
+	_backgroundWindow = window;
 }
 
 void MacWindowManager::clearWidgetRefs(MacWidget *widget) {
@@ -1037,7 +1042,7 @@ bool MacWindowManager::processEvent(Common::Event &event) {
 			continue;
 		if (w->hasAllFocus() || (w->isEditable() && event.type == Common::EVENT_KEYDOWN) ||
 				w->getDimensions().contains(event.mouse.x, event.mouse.y)) {
-			if (event.type == Common::EVENT_LBUTTONDOWN || event.type == Common::EVENT_LBUTTONUP)
+			if ((event.type == Common::EVENT_LBUTTONDOWN || event.type == Common::EVENT_LBUTTONUP) && (!_backgroundWindow || w != _backgroundWindow))
 				setActiveWindow(w->getId());
 
 			return w->processEvent(event);

--- a/graphics/macgui/macwindowmanager.h
+++ b/graphics/macgui/macwindowmanager.h
@@ -299,6 +299,13 @@ public:
 	 * @param widget Pointer to the widget to lock, nullptr for no widget
 	 */
 	void setLockedWidget(MacWidget *widget);
+
+	/**
+	 * Sets a background window, which is always active, this window cannot be
+	 * deactivated by clicking outside it, ie it is always in background.
+	 * @param window Pointer to the widget to background, nullptr for no widget
+	 */
+	void setBackgroundWindow(MacWindow *window);
 	
 	MacPatterns  &getBuiltinPatterns() { return _builtinPatterns; }
 
@@ -456,6 +463,7 @@ private:
 
 	MacWidget *_activeWidget;
 	MacWidget *_lockedWidget;
+	MacWindow *_backgroundWindow;
 
 	PauseToken *_screenCopyPauseToken;
 


### PR DESCRIPTION
This patch sets the flag background for score (or main director engine window, It is useful because it prevents the window from jumping to front of other windows (ie from `open` command) and thus shadowing it.

Fixes `title of window` from workshop, where clicking outside opened window used to disappear it beneath the main window.

Also fixes 'totaldistortion-win' sequencer TV, when clicking anywhere except the TV screen, the window used to disappear.