### PR TITLE
DIRECTOR: Improve checking for recursive enterFrame

### DIFF
--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -524,8 +524,12 @@ void Score::update() {
 		// Triggers the frame script in D2-3, explicit enterFrame handlers in D4+
 		// D4 will only process recursive enterFrame handlers to a depth of 2.
 		// Any more will be ignored.
-		if ((_vm->getVersion() >= 400) && (count < 2)) {
-			_movie->processEvent(kEventEnterFrame);
+		if ((_vm->getVersion() >= 400)) {
+			if (count < 2 || _window->recursiveEnterFrameCount() < 2)
+				_movie->processEvent(kEventEnterFrame);
+			else {
+				warning("Score::update(): ignoring recursive enterFrame handler, frozenLingoStateCount: %d, enterFrames: %d", count, _window->recursiveEnterFrameCount());
+			}
 		} else if ((_vm->getVersion() < 400) || _movie->_allowOutdatedLingo) {
 			// Force a flush of any frozen scripts before raising enterFrame
 			if (!processFrozenScripts())

--- a/engines/director/window.cpp
+++ b/engines/director/window.cpp
@@ -533,4 +533,23 @@ void Window::thawLingoState() {
 	_frozenLingoStates.pop_back();
 }
 
+// Check how many times previous enterFrame is called recursively, D4 will only process recursive enterFrame handlers to a depth of 2.
+// Therefore look into frozen lingo states and count previous pending enterFrame calls
+// eg. in a movie, frame 1 has an enterFrame handler that calls go(2), frame 2 has an enterFrame handler that calls go(3), now after
+// each frame is processed and it encounters a frame jump instruction (like go, open), it freezes the lingo state and then processes
+// the next frame. How do we know number of times enterFrame is called? Simple look into frozen lingo states for enterFrame calls.
+int Window::recursiveEnterFrameCount() {
+	int count = 0;
+
+	for (int i = _frozenLingoStates.size() - 1; i >= 0; i--) {
+		LingoState *state = _frozenLingoStates[i];
+		CFrame *frame = state->callstack.back();
+		if (frame->sp.name->equalsIgnoreCase("enterFrame")) {
+			count++;
+		}
+	}
+
+	return count;
+}
+
 } // End of namespace Director

--- a/engines/director/window.h
+++ b/engines/director/window.h
@@ -158,6 +158,7 @@ public:
 	uint32 frozenLingoStateCount() { return _frozenLingoStates.size(); };
 	void freezeLingoState();
 	void thawLingoState();
+	int recursiveEnterFrameCount();
 
 	// events.cpp
 	bool processEvent(Common::Event &event) override;


### PR DESCRIPTION
In the original engine, the enterFrame handler can only be called recursively upto second depth, and the third call will be ignored. This was formerly implemented by counting number of frozen lingo states, however there are cases where the lingo state is frozen, while enterFrame handler not called, so the count is not accurate.

This patch improves the logic by counting the number of enterFrame in frozen lingo states as well, so it can be identified that these previous frames are indeed of `enterFrame` handler.

Fixes bug where the elevator when jumping to next floor (yellow one) broke dimensional movement in `totaldistortion-win`.
