### PR TITLE
SCUMM HE: Football online mod: Show full bench when drafting

### DIFF
--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -606,12 +606,6 @@ int ScummEngine::readVar(uint var) {
 				if (_game.id == GID_BASEBALL2001 && _currentRoom == 3 && vm.slot[_currentScript].number == 2099 && var == 32 && readVar(399) == 1) {
 					return 1;
 				}
-				// Mod for Backyard Football online competitive play: allow all 38 backyard kids and pros
-				// to be drafted in an online game. This variable controls how many kids are shown in the
-				// bleachers when drafting.
-				if (_game.id == GID_FOOTBALL && readVar(465) == 1 && _currentRoom == 5 && var == 9) {
-					return 38;
-				}
 			}
 #endif
 

--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -606,6 +606,12 @@ int ScummEngine::readVar(uint var) {
 				if (_game.id == GID_BASEBALL2001 && _currentRoom == 3 && vm.slot[_currentScript].number == 2099 && var == 32 && readVar(399) == 1) {
 					return 1;
 				}
+				// Mod for Backyard Football online competitive play: allow all 38 backyard kids and pros
+				// to be drafted in an online game. This variable controls how many kids are shown in the
+				// bleachers when drafting.
+				if (_game.id == GID_FOOTBALL && readVar(465) == 1 && _currentRoom == 5 && var == 9) {
+					return 38;
+				}
 			}
 #endif
 

--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -1468,6 +1468,12 @@ void ScummEngine_v6::o6_getRandomNumberRange() {
 				rnd = readArray(749, 0, vm.localvar[_currentScript][1]);
 			}
 		}
+		// Mod for Backyard Football online competitive play: allow all 38 backyard kids and pros
+		// to be drafted in an online game. This controls how many kids are shown in the bleachers
+		// when drafting. Without this mod, a random selection of between 31 and 35 kids are shown.
+		if (_game.id == GID_FOOTBALL && readVar(465) == 1 && _currentRoom == 5 && vm.slot[_currentScript].number == 2107) {
+			rnd = 38;
+		}
 	}
 #endif
 	if (VAR_RANDOM_NR != 0xFF)


### PR DESCRIPTION
When playing Backyard Football online, by default only 31 to 35 of the 38 playable characters are draftable in a given game. A random 3 to 7 are not shown sitting in the bleachers when drafting. This makes competitive play difficult, as the draft pool is not the same each game.

This mod, which is only active when the "Online competitive mods" option is enabled, allows all 38 characters to be shown on the draft screen.