### PR TITLE
Prevent sleep on iOS while the local web server is running or ScummVM is downloading files

### DIFF
--- a/backends/cloud/storage.cpp
+++ b/backends/cloud/storage.cpp
@@ -57,8 +57,10 @@ void Storage::printErrorResponse(Networking::ErrorResponse error) {
 Networking::Request *Storage::addRequest(Networking::Request *request) {
 	_runningRequestsMutex.lock();
 	++_runningRequestsCount;
-	if (_runningRequestsCount == 1)
+	if (_runningRequestsCount == 1) {
+		g_system->taskStarted(OSystem::kCloudDownload);
 		debug(9, "Storage is working now");
+	}
 	_runningRequestsMutex.unlock();
 	return ConnMan.addRequest(request, new Common::Callback<Storage, Networking::Request *>(this, &Storage::requestFinishedCallback));
 }
@@ -72,8 +74,10 @@ void Storage::requestFinishedCallback(Networking::Request *invalidRequestPointer
 	--_runningRequestsCount;
 	if (_syncRestartRequestsed)
 		restartSync = true;
-	if (_runningRequestsCount == 0 && !restartSync)
+	if (_runningRequestsCount == 0) {
+		g_system->taskFinished(OSystem::kCloudDownload);
 		debug(9, "Storage is not working now");
+	}
 	_runningRequestsMutex.unlock();
 
 	if (restartSync)

--- a/backends/networking/sdl_net/localwebserver.cpp
+++ b/backends/networking/sdl_net/localwebserver.cpp
@@ -143,13 +143,19 @@ void LocalWebserver::start(bool useMinimalMode) {
 	if (numused == -1) {
 		error("LocalWebserver: SDLNet_AddSocket: %s\n", SDLNet_GetError());
 	}
+
+	if (_timerStarted)
+		g_system->taskStarted(OSystem::kLocalServer);
+
 	_handleMutex.unlock();
 }
 
 void LocalWebserver::stop() {
 	_handleMutex.lock();
-	if (_timerStarted)
+	if (_timerStarted) {
 		stopTimer();
+		g_system->taskFinished(OSystem::kLocalServer);
+	}
 
 	if (_serverSocket) {
 		SDLNet_TCP_Close(_serverSocket);

--- a/backends/platform/ios7/ios7_osys_main.cpp
+++ b/backends/platform/ios7/ios7_osys_main.cpp
@@ -91,7 +91,7 @@ OSystem_iOS7::OSystem_iOS7() :
 	_mixer(NULL), _lastMouseTap(0), _queuedEventTime(0),
 	_secondaryTapped(false), _lastSecondaryTap(0),
 	_screenOrientation(kScreenOrientationAuto),
-	_timeSuspended(0) {
+	_timeSuspended(0), _runningTasks(0) {
 	_queuedInputEvent.type = Common::EVENT_INVALID;
 	_touchpadModeEnabled = ConfMan.getBool("touchpad_mode");
 	_mouseClickAndDragEnabled = ConfMan.getBool("clickanddrag_mode");

--- a/backends/platform/ios7/ios7_osys_main.h
+++ b/backends/platform/ios7/ios7_osys_main.h
@@ -61,6 +61,8 @@ protected:
 	CFTimeInterval _startTime;
 	uint32 _timeSuspended;
 
+	int _runningTasks;
+
 	long _lastMouseDown;
 	long _lastMouseTap;
 	long _queuedEventTime;
@@ -90,6 +92,9 @@ public:
 
 	void engineInit() override;
 	void engineDone() override;
+
+	void taskStarted(Task) override;
+	void taskFinished(Task) override;
 
 	void updateStartSettings(const Common::String &executable, Common::String &command, Common::StringMap &settings, Common::StringArray& additionalArgs) override;
 

--- a/backends/platform/ios7/ios7_osys_video.mm
+++ b/backends/platform/ios7/ios7_osys_video.mm
@@ -127,6 +127,24 @@ void OSystem_iOS7::engineDone() {
 #endif
 }
 
+void OSystem_iOS7::taskStarted(Task task) {
+	EventsBaseBackend::taskStarted(task);
+	if (_runningTasks++ == 0) {
+		// Prevent the device going to sleep while a task is running
+		dispatch_async(dispatch_get_main_queue(), ^{
+			[[UIApplication sharedApplication] setIdleTimerDisabled:YES];
+		});
+	}
+}
+void OSystem_iOS7::taskFinished(Task task) {
+	EventsBaseBackend::taskFinished(task);
+	if (--_runningTasks == 0) {
+		dispatch_async(dispatch_get_main_queue(), ^{
+			[[UIApplication sharedApplication] setIdleTimerDisabled:NO];
+		});
+	}
+}
+
 void OSystem_iOS7::updateOutputSurface() {
 	execute_on_main_thread(^ {
 		[[iOS7AppDelegate iPhoneView] initSurface];

--- a/common/system.h
+++ b/common/system.h
@@ -327,6 +327,36 @@ public:
 	virtual void engineDone() { }
 
 	/**
+	 * Identify a task that ScummVM can perform.
+	 */
+	enum Task {
+		/**
+		 * The local server is running, allowing connections from other devices to transfer files.
+		 */
+		kLocalServer,
+
+		/**
+		 * ScummVM is downloading games or synchronizing savegames from the cloud.
+		 */
+		kCloudDownload,
+
+		/**
+		 * ScummVM is downloading an icons or shaders pack.
+		 */
+		kDataPackDownload
+	};
+
+	/**
+	 * Allow the backend to be notified when a task is started.
+	 */
+	virtual void taskStarted(Task) { }
+
+	/**
+	 * Allow the backend to be notified when a task is finished.
+	 */
+	virtual void taskFinished(Task) { }
+
+	/**
 	 * Allow the backend to customize the start settings, such as for example starting
 	 * automatically a game under certain circumstances.
 	 *

--- a/gui/downloadpacksdialog.cpp
+++ b/gui/downloadpacksdialog.cpp
@@ -88,6 +88,7 @@ void DialogState::downloadList() {
 
 void DialogState::proceedDownload() {
 	startTime = lastUpdate = g_system->getMillis();
+	g_system->taskStarted(OSystem::kDataPackDownload);
 	takeOneFile();
 }
 
@@ -142,6 +143,7 @@ void DialogState::downloadFileCallback(Networking::DataResponse r) {
 	if (response->eos) {
 		if (!takeOneFile()) {
 			state = kDownloadComplete;
+			g_system->taskFinished(OSystem::kDataPackDownload);
 			if (dialog)
 				dialog->sendCommand(kDownloadEndedCmd, 0);
 			return;
@@ -157,6 +159,7 @@ void DialogState::downloadFileCallback(Networking::DataResponse r) {
 void DialogState::errorCallback(Networking::ErrorResponse error) {
 	Common::U32String message = Common::U32String::format(_("ERROR %d: %s"), error.httpResponseCode, error.response.c_str());
 
+	g_system->taskFinished(OSystem::kDataPackDownload);
 	if (dialog)
 		dialog->setError(message);
 }


### PR DESCRIPTION
This pull request implements the following:
1. Add new `taskStarted` and `taskFinished` in `OSystem` to notify the backend when starting of finishing a task.
2. Call this new function in the following cases:
    1. Running the local web server
    2. Downloading games or savegames from the cloud.
    3. Download icons and shaders pack.
3. Implement this in the iOS backend to prevent sleep while one of those task is running.

I was also trying to use this to keep the network tasks running in background, which is required for example for the cloud quick connection wizard (as it starts the local web server, and then opens safari which needs to connect to the local web server now in background). But I cannot seem to get this working, so I did not include the code in this pull request.

Also I need to do more checks to make sure the calls to `taskStarted` and `taskFinished` are correctly balanced for all cases.

