### PR TITLE
COMMON: Handle writing failure in dumpArchive when not enough storage

### DIFF
--- a/common/archive.cpp
+++ b/common/archive.cpp
@@ -92,6 +92,9 @@ Common::Error Archive::dumpArchive(String destPath) {
 		Common::Path filePath = f->getPathInArchive().punycodeEncode();
 		debug(1, "File: %s", filePath.toString().c_str());
 
+		// skip if f represents a directory
+		if (filePath.toString().lastChar() == '/') continue;
+
 		Common::SeekableReadStream *stream = f->createReadStream();
 
 		uint32 len = stream->size();
@@ -106,7 +109,7 @@ Common::Error Archive::dumpArchive(String destPath) {
 		Common::DumpFile out;
 		Common::Path outPath = Common::Path(destPath).join(filePath);
 		if (!out.open(outPath.toString(), true)) {
-			warning("Archive::dumpArchive(): Can not open dump file %s", outPath.toString().c_str());
+			return Common::Error(Common::kCreatingFileFailed, "Cannot open/create dump file " + outPath.toString());
 		} else {
 			uint32 writtenBytes = out.write(data, len);
 			if (writtenBytes < len) {

--- a/common/archive.cpp
+++ b/common/archive.cpp
@@ -80,7 +80,7 @@ int Archive::listMatchingMembers(ArchiveMemberList &list, const Path &pattern, b
 	return matches;
 }
 
-void Archive::dumpArchive(String destPath) {
+Common::Error Archive::dumpArchive(String destPath) {
 	Common::ArchiveMemberList files;
 
 	listMembers(files);
@@ -91,6 +91,7 @@ void Archive::dumpArchive(String destPath) {
 	for (auto &f : files) {
 		Common::Path filePath = f->getPathInArchive().punycodeEncode();
 		debug(1, "File: %s", filePath.toString().c_str());
+
 		Common::SeekableReadStream *stream = f->createReadStream();
 
 		uint32 len = stream->size();
@@ -107,7 +108,14 @@ void Archive::dumpArchive(String destPath) {
 		if (!out.open(outPath.toString(), true)) {
 			warning("Archive::dumpArchive(): Can not open dump file %s", outPath.toString().c_str());
 		} else {
-			out.write(data, len);
+			uint32 writtenBytes = out.write(data, len);
+			if (writtenBytes < len) {
+				// Not all data was written
+				out.close();
+				delete stream;
+				free(data);
+				return Common::Error(Common::kWritingFailed, "Not enough storage space! Please free up some storage and try again");
+			}
 			out.flush();
 			out.close();
 		}
@@ -116,6 +124,7 @@ void Archive::dumpArchive(String destPath) {
 	}
 
 	free(data);
+	return Common::kNoError;
 }
 
 char Archive::getPathSeparator() const {

--- a/common/archive.h
+++ b/common/archive.h
@@ -29,6 +29,7 @@
 #include "common/hashmap.h"
 #include "common/hash-str.h"
 #include "common/singleton.h"
+#include "common/error.h"
 
 namespace Common {
 
@@ -168,7 +169,7 @@ public:
 	/**
 	 * Dump all files from the archive to the given directory
 	 */
-	void dumpArchive(String destPath);
+	Common::Error dumpArchive(String destPath);
 
 	/**
 	 * Returns the separator used by internal paths in the archive


### PR DESCRIPTION
Added check in `Archive::dumpArchive()` to determine if there is not enough storage left. 
Also, changed the return type to `Common::Error` to handle different error scenarios.
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
