### PR TITLE
DIRECTOR: Fix visibility issue when setting window properties

### DIFF
--- a/engines/director/window.cpp
+++ b/engines/director/window.cpp
@@ -223,8 +223,6 @@ void Window::setStageColor(uint32 stageColor, bool forceReset) {
 void Window::setTitleVisible(bool titleVisible) {
 	MacWindow::setTitleVisible(titleVisible);
 	updateBorderType();
-
-	setVisible(true); // Activate this window on top
 }
 
 Datum Window::getStageRect() {
@@ -262,14 +260,10 @@ void Window::setModal(bool modal) {
 		_wm->setLockedWidget(this);
 		_isModal = true;
 	}
-
-	setVisible(true); // Activate this window on top
 }
 
 void Window::setFileName(Common::String filename) {
 	setNextMovie(filename);
-
-	setVisible(true); // Activate this window on top
 }
 
 void Window::reset() {


### PR DESCRIPTION
This patch fixes the behaviour of windows when setting their properties (e.g. titleVisibility, Modal, etc) from the lingo.

Initially the window was set to be visible when the property was set, but this is not the expected behaviour. The window should only be visible when the `open` command is called. Removed `setVisible(true)` from various window properties assignment functions.

Fixes popupmenu overlay in `meet-mediaband` and white rectangle when opening `mcluhan-win`.

--start-movie="main\stvimenu.dxr" mediaband-win