### PR TITLE
GUI: Add allowKdbRepeats() to up/down/left/right actions in launcher

### DIFF
--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -168,21 +168,25 @@ Common::Keymap *GuiManager::getKeymap() const {
 	act = new Action(kStandardActionMoveUp, _("Up"));
 	act->setKeyEvent(KEYCODE_UP);
 	act->addDefaultInputMapping("JOY_UP");
+	act->allowKbdRepeats();
 	guiMap->addAction(act);
 
 	act = new Action(kStandardActionMoveDown, _("Down"));
 	act->setKeyEvent(KEYCODE_DOWN);
 	act->addDefaultInputMapping("JOY_DOWN");
+	act->allowKbdRepeats();
 	guiMap->addAction(act);
 
 	act = new Action(kStandardActionMoveLeft, _("Left"));
 	act->setKeyEvent(KEYCODE_LEFT);
 	act->addDefaultInputMapping("JOY_LEFT");
+	act->allowKbdRepeats();
 	guiMap->addAction(act);
 
 	act = new Action(kStandardActionMoveRight, _("Right"));
 	act->setKeyEvent(KEYCODE_RIGHT);
 	act->addDefaultInputMapping("JOY_RIGHT");
+	act->allowKbdRepeats();
 	guiMap->addAction(act);
 
 	act = new Action(kStandardActionEE, _("???"));


### PR DESCRIPTION
This matches also the behavior as set in engines/metaengine.cpp MetaEngine::initKeymaps()

This change is needed at least to avoid a hack on Android. Setting the "kdbRepeat" flag for events of keeping the arrow keys pressed (on the touch virtual keyboard), as Android supports, would not work to eg. keep going through a list upwards or downwards with the respective arrow key pressed. Instead we had to emulate the behavior of a physical keyboard which sents multiple keypresses (keydown and keyup events), without setting the kbdRepeat flag. However, this hack would work poorly in some game engines (eg. in LBA while rotating Twinsen, the movement becomes "stuttering"). In-games the kbdRepeat flags is respected already due to the setting in engines/metaengine.cpp (as far as I can tell) and resulting movement is more fluid.

If the PR is merged, I'll push a commit that removes the hack code in Android (from its events.cpp)

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
