### PR TITLE
IOS: Support keyboard hardware input set

### DIFF
--- a/backends/platform/ios7/ios7_osys_misc.mm
+++ b/backends/platform/ios7/ios7_osys_misc.mm
@@ -226,7 +226,7 @@ Common::HardwareInputSet *OSystem_iOS7::getHardwareInputSet() {
 		inputSet->addHardwareInputSet(new JoystickHardwareInputSet(defaultJoystickButtons, defaultJoystickAxes));
 	}
 
-  inputSet->addHardwareInputSet(new KeyboardHardwareInputSet(defaultKeys, defaultModifiers));
+	inputSet->addHardwareInputSet(new KeyboardHardwareInputSet(defaultKeys, defaultModifiers));
   
 	return inputSet;
 }

--- a/backends/platform/ios7/ios7_osys_misc.mm
+++ b/backends/platform/ios7/ios7_osys_misc.mm
@@ -226,6 +226,8 @@ Common::HardwareInputSet *OSystem_iOS7::getHardwareInputSet() {
 		inputSet->addHardwareInputSet(new JoystickHardwareInputSet(defaultJoystickButtons, defaultJoystickAxes));
 	}
 
+  inputSet->addHardwareInputSet(new KeyboardHardwareInputSet(defaultKeys, defaultModifiers));
+  
 	return inputSet;
 }
 


### PR DESCRIPTION
IOS: Support keyboard hardware input set

The iOS backend currently supports a virtual keyboard, but none of the keyboard controls are mapped according to the
default mapping of a game. Only the mouse controls and a game controller (if connected) are registered as a hardware
input set currently.

This change adds the keyboard hardware as an input set so that the default controls are mapped, and the user can
use the virtual keyboard to perform actions like opening a game option menu in Blade Runner, for example.

The remapping of keys using the virtual controls is not working reliably on iOS currently, possibly due to the polling 
handling. This can be investigated further and addressed later, but having the default controls mapped is a start. 

![IMG_55139D081E6A-1](https://github.com/scummvm/scummvm/assets/564774/2426b48e-f9a0-4997-b56e-b507beb1d931)
