### PR TITLE
COMMON: Don't use mutexes on atari

### DIFF
--- a/common/mutex.cpp
+++ b/common/mutex.cpp
@@ -19,6 +19,8 @@
  *
  */
 
+#ifndef SINGLE_THREADED
+
 #include "common/debug.h"
 #include "common/mutex.h"
 #include "common/system.h"
@@ -75,3 +77,5 @@ bool StackLock::unlock() {
 }
 
 } // End of namespace Common
+
+#endif

--- a/common/mutex.h
+++ b/common/mutex.h
@@ -45,6 +45,7 @@ public:
 	virtual bool unlock() = 0;
 };
 
+#ifndef SINGLE_THREADED
 /**
  * Auxillary class to (un)lock a mutex on the stack.
  */
@@ -78,6 +79,22 @@ public:
 };
 
 /** @} */
+
+#else
+
+class StackLock final {
+public:
+	explicit StackLock(MutexInternal *mutex, const char *mutexName = nullptr) {}
+	explicit StackLock(const Mutex &mutex, const char *mutexName = nullptr) {}
+};
+
+class Mutex final {
+public:
+	void lock() {}
+	void unlock() {}
+};
+
+#endif
 
 } // End of namespace Common
 

--- a/common/str-base.cpp
+++ b/common/str-base.cpp
@@ -37,6 +37,7 @@ MemoryPool *g_refCountPool = nullptr; // FIXME: This is never freed right now
 Mutex *g_refCountPoolMutex = nullptr;
 
 void lockMemoryPoolMutex() {
+#ifndef SINGLE_THREADED
 	// The Mutex class can only be used once g_system is set and initialized,
 	// but we may use the String class earlier than that (it is for example
 	// used in the OSystem_POSIX constructor). However in those early stages
@@ -46,11 +47,14 @@ void lockMemoryPoolMutex() {
 	if (!g_refCountPoolMutex)
 		g_refCountPoolMutex = new Mutex();
 	g_refCountPoolMutex->lock();
+#endif
 }
 
 void unlockMemoryPoolMutex() {
+#ifndef SINGLE_THREADED
 	if (g_refCountPoolMutex)
 		g_refCountPoolMutex->unlock();
+#endif
 }
 
 TEMPLATE void BASESTRING::releaseMemoryPoolMutex() {

--- a/configure
+++ b/configure
@@ -3987,7 +3987,9 @@ case $_backend in
 		fi
 		;;
 	atari)
-		define_in_config_if_yes yes "ATARI"
+		add_line_to_config_mk 'ATARI = 1'
+		append_var DEFINES "-DATARI"
+		append_var DEFINES "-DSINGLE_THREADED"
 		append_var DEFINES "-DDISABLE_LAUNCHERDISPLAY_GRID"
 		append_var DEFINES "-DDISABLE_SID"
 		append_var DEFINES "-DDISABLE_NES_APU"


### PR DESCRIPTION
This is a pretty non-invasive change but I'm posting it for visibility whether you don't have a better idea how to eliminate those mutexes in a single-threaded backend.

It's not like `NullMutexInternal` takes a huge amount of cycles but pollutes the CPU caches and in tight loops takes precious cycles to the level that those calls are visible in profiler.
