### PR TITLE
DIRECTOR: Refactor frames loading, Fix `chan` debugger command!

### DIFF
--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -446,7 +446,7 @@ void Score::update() {
 		}
 	}
 
-	loadFrame(_curFrameNumber);
+	loadFrame(_curFrameNumber, true);
 
 	byte tempo = _currentFrame->_mainChannels.tempo;
 
@@ -1455,7 +1455,7 @@ void Score::loadFrames(Common::SeekableReadStreamEndian &stream, uint16 version)
 
 	// Calculate number of frames and their positions
 	// numOfFrames in the header is often incorrect
-	for (_numFrames = 1; loadFrame(_numFrames); _numFrames++) {
+	for (_numFrames = 1; loadFrame(_numFrames, false); _numFrames++) {
 		if (_framesStream->pos() < _framesStreamSize) {
 			// Record the starting offset for next frame
 			_frameOffsets.push_back(_framesStream->pos());
@@ -1466,7 +1466,7 @@ void Score::loadFrames(Common::SeekableReadStreamEndian &stream, uint16 version)
 
 	_currentFrame->reset();
 
-	loadFrame(1);
+	loadFrame(1, true);
 
 	// Read over frame offset array and print each item
 	for (uint i = 0; i < _frameOffsets.size(); i++) {
@@ -1476,7 +1476,7 @@ void Score::loadFrames(Common::SeekableReadStreamEndian &stream, uint16 version)
 	debugC(1, kDebugLoading, "Score::loadFrames(): Number of frames: %d, framesStreamSize: %d", _numFrames, _framesStreamSize);
 }
 
-bool Score::loadFrame(int frameNum) {
+bool Score::loadFrame(int frameNum, bool loadCast) {
 	debugC(7, kDebugLoading, "****** Frame request %d, current pos: %ld", frameNum, _framesStream->pos());
 
 	// Read existing frame (ie already visited)
@@ -1499,8 +1499,10 @@ bool Score::loadFrame(int frameNum) {
 	if (!isFrameRead)
 		return false;
 
-	// Load frame cast
-	setSpriteCasts();
+	if (loadCast) {
+		// Load frame cast
+		setSpriteCasts();
+	}
 
 	return true;
 }
@@ -1588,7 +1590,7 @@ Frame *Score::getFrameData(int frameNum){
 	Frame *frame = _currentFrame;
 	_currentFrame = nullptr; // To avoid later deletion of frame inside renderOneFrame()
 
-	bool isFrameRead = loadFrame(frameNum);
+	bool isFrameRead = loadFrame(frameNum, false);
 
 	// Start restoring all states
 	_curFrameNumber = curFrameNumber;

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -1552,18 +1552,20 @@ Frame *Score::getFrameData(int frameNum){
 	// Be sure to delete this frame after use
 
 	// Backup variables
-	int curFrameNumber = _curFrameNumber;
-	Frame *frame = _currentFrame;
-	_currentFrame = nullptr; // To avoid later deletion of frame inside renderOneFrame()
-
+	int tempFrameNumber = _curFrameNumber;
+	
 	bool isFrameRead = loadFrame(frameNum, false);
+	Frame *tempFrame = _currentFrame;
 
-	// Start restoring all states
-	_curFrameNumber = curFrameNumber;
-	_currentFrame = frame;
+	_currentFrame = new Frame(this, _numChannelsDisplayed);
+	loadFrame(frameNum, true);
+	Frame *frame = _currentFrame;
+
+	_currentFrame = tempFrame;
+	_curFrameNumber = tempFrameNumber;
 
 	if (isFrameRead) {
-		return _currentFrame;
+		return frame;
 	}
 	return nullptr;
 }

--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -73,7 +73,7 @@ public:
 	Movie *getMovie() const { return _movie; }
 
 	void loadFrames(Common::SeekableReadStreamEndian &stream, uint16 version);
-	bool loadFrame(int frame);
+	bool loadFrame(int frame, bool loadCast);
 	bool readOneFrame();
 	void updateFrame(Frame *frame);
 	Frame *getFrameData(int frameNum);

--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -77,7 +77,6 @@ public:
 	bool readOneFrame();
 	void updateFrame(Frame *frame);
 	Frame *getFrameData(int frameNum);
-	void rebuildChannelData(int frameNum);
 
 	void loadLabels(Common::SeekableReadStreamEndian &stream);
 	void loadActions(Common::SeekableReadStreamEndian &stream);
@@ -163,7 +162,7 @@ public:
 	uint8 _currentTempo;
 	CastMemberID _currentPaletteId;
 
-	Common::Array<int64> _frameOffsets;
+	uint _firstFramePosition;
 	uint _framesStreamSize;
 	Common::MemoryReadStreamEndian *_framesStream;
 


### PR DESCRIPTION
This PR:
1. Refactor frames loading to remove rebuildChannelData
2. Improves loading time by loading spriteCast only when required
3. Fix `chan` debugger command!