### PR TITLE
ANDROID: Fix build and improve SIMD detection

### DIFF
--- a/backends/platform/android/android.h
+++ b/backends/platform/android/android.h
@@ -177,8 +177,6 @@ private:
 	mutable void *_gles2DL;
 #endif
 
-	bool _neonSupport; // bool for whether or not arm NEON is supported
-
 	static void *timerThreadFunc(void *arg);
 	static void *audioThreadFunc(void *arg);
 	Common::String getSystemProperty(const char *name) const;

--- a/backends/platform/android/module.mk
+++ b/backends/platform/android/module.mk
@@ -9,6 +9,16 @@ MODULE_OBJS := \
 	snprintf.o \
 	touchcontrols.o
 
+ifdef NEED_ANDROID_CPUFEATURES
+MODULE_OBJS += \
+	cpu-features.o
+$(MODULE)/android.o: CXXFLAGS += "-I$(ANDROID_NDK_ROOT)/sources/android/cpufeatures"
+# We don't configure a C compiler, use a C++ one in C mode
+$(MODULE)/cpu-features.o: $(ANDROID_NDK_ROOT)/sources/android/cpufeatures/cpu-features.c
+	$(QUIET)$(MKDIR) $(*D)
+	$(QUIET_CXX)$(CXX) $(CXXFLAGS) $(CPPFLAGS) -x c -std=c99 -c $(<) -o $@
+endif
+
 # We don't use rules.mk but rather manually update OBJS and MODULE_DIRS.
 MODULE_OBJS := $(addprefix $(MODULE)/, $(MODULE_OBJS))
 OBJS := $(MODULE_OBJS) $(OBJS)

--- a/configure
+++ b/configure
@@ -2108,7 +2108,6 @@ if test "$_host_os" = android; then
 
 	case $_host_cpu in
 	aarch64)
-		add_line_to_config_mk 'NEED_ANDROID_CPUFEATURES = 1'
 		;;
 	arm|i686|x86_64)
 		add_line_to_config_mk 'NEED_ANDROID_CPUFEATURES = 1'

--- a/configure
+++ b/configure
@@ -2106,6 +2106,15 @@ if test "$_host_os" = android; then
 		append_var LDFLAGS "-target ${_android_target}"
 	fi
 
+	case $_host_cpu in
+	aarch64)
+		add_line_to_config_mk 'NEED_ANDROID_CPUFEATURES = 1'
+		;;
+	arm|i686|x86_64)
+		add_line_to_config_mk 'NEED_ANDROID_CPUFEATURES = 1'
+		;;
+	esac
+
 	# These values can get overriden below by environments variables
 	_ar="$_android_toolchain/bin/$_ar"
 	_as="$_android_toolchain/bin/$_as"


### PR DESCRIPTION
Fix the build by building cpu-features which is only provided as source in NDK.
As it's a C file and we don't set up a C compiler, make the C++ compiler (clang++) fallback on C and select proper standard.

Make the detection more static: architecture is determined at build time and don't try to cache the detection result.
cpu-features already caches it and our code is called only once: the first time blitting is used.

SSE2 is mandatory on Android x86 NDK so is expected to be always available.
It's also always available on x86_64 per specification of instruction set.
NEON is always available on armv8 which is the base of aarch64. This saves us some detection.