### PR TITLE
COMMON: Move string length calculation to a separate function for nicer debugging

### DIFF
--- a/common/str-base.cpp
+++ b/common/str-base.cpp
@@ -106,14 +106,8 @@ TEMPLATE BASESTRING::BaseString(const value_type *str) : _size(0), _str(_storage
 	if (str == nullptr) {
 		_storage[0] = 0;
 		_size = 0;
-	} else {
-		uint32 len = 0;
-		const value_type *s = str;
-		while (*s++) {
-			++len;
-		}
-		initWithValueTypeStr(str, len);
-	}
+	} else
+		initWithValueTypeStr(str, cStrLen(str));
 }
 
 TEMPLATE BASESTRING::BaseString(const value_type *str, uint32 len) : _size(0), _str(_storage) {
@@ -839,6 +833,14 @@ TEMPLATE void BASESTRING::assign(const value_type *str) {
 TEMPLATE uint BASESTRING::getUnsignedValue(uint pos) const {
 	const int shift = (sizeof(uint) - sizeof(value_type)) * 8;
 	return ((uint)_str[pos]) << shift >> shift;
+}
+
+TEMPLATE uint32 BASESTRING::cStrLen(const value_type *str) {
+	uint32 len = 0;
+	while (str[len])
+		len++;
+
+	return len;
 }
 
 // Hash function for strings, taken from CPython.

--- a/common/str-base.cpp
+++ b/common/str-base.cpp
@@ -852,6 +852,11 @@ TEMPLATE uint BASESTRING::hash() const {
 	return hashResult ^ _size;
 }
 
+template<>
+uint32 BaseString<char>::cStrLen(const value_type *str) {
+	return static_cast<uint32>(strlen(str));
+}
+
 template class BaseString<char>;
 template class BaseString<uint16>;
 template class BaseString<u32char_type_t>;

--- a/common/str-base.h
+++ b/common/str-base.h
@@ -259,6 +259,8 @@ protected:
 	bool pointerInOwnBuffer(const value_type *str) const;
 
 	uint getUnsignedValue(uint pos) const;
+
+	static uint32 cStrLen(const value_type *str);
 };
 }
 #endif


### PR DESCRIPTION
This is mainly a QOL change for debugging in Visual Studio but also a minor performance optimization.

By default the keybinds for debugging in Visual Studio are F11 to Step Into, F10 to Step Over, Shift-F11 to Step Out.  It's nice to be able to just use Step Over and Step Into because they don't require an awkward 2-button keystroke.  Step Out is also prone to randomly misbehaving with optimizations on because it doesn't work properly with inlined function calls.

Attempting to step into a call that requires an implicit conversion of a char string to a `Common::String` frequently lands in the `BaseString` constructor that has its own strlen-like loop, which is slow to step through so it would be nice to be able to skip over it with just one Step Over keystroke.

This moves the string length calculation to a separate call and makes the char version call strlen, which is faster because standard library strlens employ optimizations like using SSE2 to null-check many characters at once, and is also skipped over by default in VS even when using Step Into.