### PR TITLE
AUDIO: Change default GM device to "auto"

### DIFF
--- a/audio/mididrv.cpp
+++ b/audio/mididrv.cpp
@@ -250,13 +250,12 @@ MidiDriver::DeviceHandle MidiDriver::detectDevice(int flags) {
 			if (flags & MDT_PREFER_MT32)
 				devStr = ConfMan.hasKey("mt32_device") ? ConfMan.get("mt32_device") : Common::String("null");
 			else if (flags & MDT_PREFER_GM)
-				devStr = ConfMan.hasKey("gm_device") ? ConfMan.get("gm_device") : Common::String("null");
-			else
+				devStr = ConfMan.get("gm_device");
+
+			if (devStr.empty())
 				devStr = "auto";
 
-			// Default to Null device here, since we also register a default null setting for
-			// the MT32 or GM device in the config manager.
-			hdl = getDeviceHandle(devStr.empty() ? Common::String("null") : devStr);
+			hdl = getDeviceHandle(devStr);
 			const MusicType type = getMusicType(hdl);
 
 			// If we have a "Don't use GM/MT-32" setting we skip this part and jump

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -321,7 +321,7 @@ void registerDefaults() {
 
 	ConfMan.registerDefault("music_driver", "auto");
 	ConfMan.registerDefault("mt32_device", "null");
-	ConfMan.registerDefault("gm_device", "null");
+	ConfMan.registerDefault("gm_device", "auto");
 	ConfMan.registerDefault("opl2lpt_parport", "null");
 
 	ConfMan.registerDefault("cdrom", 0);

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -483,7 +483,7 @@ void OptionsDialog::build() {
 
 	if (_multiMidiCheckbox) {
 		if (!loadMusicDeviceSetting(_gmDevicePopUp, "gm_device"))
-			_gmDevicePopUp->setSelected(0);
+			_gmDevicePopUp->setSelected(1);
 
 		// Multi midi setting
 		_multiMidiCheckbox->setState(ConfMan.getBool("multi_midi", _domain));


### PR DESCRIPTION
This mainly came about because Obsidian uses QuickTime MIDI originally, and Windows MIDI (while not amazing) is much closer to the QuickTime MIDI sound font than AdLib.  However, by default the `MDT_PREFER_GM` flag does nothing because the default GM device is "null" (a.k.a. "Don't use General MIDI music").

I discussed a few possible scenarios with @athrxx :
- If a game prefers using AdLib to GM, then it can just not pass `MDT_PREFER_GM` to `detectDevice` and it will get AdLib instead even when a GM device is configured.
- If a user wants to force a GM device even when the game isn't using `MDT_PREFER_GM`, they can set it as the music device in the "Audio" tab (or "music_driver" config option).
- If there is a problem with a GM device, then `detectDevice` should skip it if `checkDevice` is properly implemented.

The main possible problem scenario I am concerned about is if there is some music device where either `checkDevice` isn't implemented properly, or if it's some device that it isn't possible to check the status of and silently eats the MIDI data when it can't output it, so would like to get some more feedback on that possibility from someone who understands MIDI devices better.