### PR TITLE
GOB: Preload chunk before unpacking

### DIFF
--- a/engines/gob/dataio.cpp
+++ b/engines/gob/dataio.cpp
@@ -21,6 +21,7 @@
 
 #include "common/endian.h"
 #include "common/types.h"
+#include "common/bufferedstream.h"
 #include "common/memstream.h"
 #include "common/substream.h"
 
@@ -418,12 +419,15 @@ Common::SeekableReadStream *DataIO::getFile(File &file) {
 	Common::SeekableReadStream *rawData =
 		new Common::SafeSeekableSubReadStream(&file.archive->file, file.offset, file.offset + file.size);
 
+	Common::SeekableReadStream *bufferedRawData =
+		Common::wrapBufferedSeekableReadStream(rawData, 4096, DisposeAfterUse::NO);
+
 	if (file.compression == 0)
-		return rawData;
+		return bufferedRawData;
 
-	Common::SeekableReadStream *unpackedData = unpack(*rawData, file.compression);
+	Common::SeekableReadStream *unpackedData = unpack(*bufferedRawData, file.compression);
 
-	delete rawData;
+	delete bufferedRawData;
 
 	return unpackedData;
 }


### PR DESCRIPTION
This leads to a massive speedup on atari: between the credits screen and the actual game loading takes 3m30s (!) on a 66 MHz machine, with this change it takes 5s (!!!)

I think the reason why nobody has noticed so far is that glibc (etc) implementation of fseek() contains an optimisation for `0, SEEK_CUR` and `<current offset>, SEEK_SET` respectively, i.e. that it doesn't really seek in such case.

I hope I got it right, that `0xFFFF` worries me a little but should be harmless with my changes. The only problem I can see is that if some part of code expects to read from a chunk _and not finish it_ (not sure whether that can happen but current code supports it) -- my change reads the whole chunk at once.