### PR TITLE
Add kFeatureTouchscreen to OSystem to identify backends with a touchscreen

### DIFF
--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -633,7 +633,8 @@ bool OSystem_Android::hasFeature(Feature f) {
 			f == kFeatureOpenUrl ||
 			f == kFeatureClipboardSupport ||
 			f == kFeatureKbdMouseSpeed ||
-			f == kFeatureJoystickDeadzone) {
+			f == kFeatureJoystickDeadzone ||
+			f == kFeatureTouchscreen) {
 		return true;
 	}
 	/* Even if we are using the 2D graphics manager,

--- a/backends/platform/ds/ds-graphics.cpp
+++ b/backends/platform/ds/ds-graphics.cpp
@@ -219,7 +219,7 @@ void OSystem_DS::setSubScreen(int32 x, int32 y, int32 sx, int32 sy) {
 }
 
 bool OSystem_DS::hasFeature(Feature f) {
-	return (f == kFeatureCursorPalette) || (f == kFeatureStretchMode) || (f == kFeatureVirtualKeyboard);
+	return (f == kFeatureCursorPalette) || (f == kFeatureStretchMode) || (f == kFeatureVirtualKeyboard) || (f == kFeatureTouchscreen);
 }
 
 void OSystem_DS::setFeatureState(Feature f, bool enable) {

--- a/backends/platform/ds/portdefs.h
+++ b/backends/platform/ds/portdefs.h
@@ -56,9 +56,4 @@ typedef unsigned int uint;
 #define STREAM_AUDIO_FROM_DISK
 #endif
 
-// FIXME: Since I can't change the engine at the moment (post lockdown) this define can go here.
-// This define changes the mouse-relative motion which doesn't make sense on a touch screen to
-// a more conventional form of input where the menus can be clicked on.
-#define LURE_CLICKABLE_MENUS
-
 #endif

--- a/backends/platform/ios7/ios7_osys_main.cpp
+++ b/backends/platform/ios7/ios7_osys_main.cpp
@@ -159,6 +159,7 @@ bool OSystem_iOS7::hasFeature(Feature f) {
 	case kFeatureKbdMouseSpeed:
 	case kFeatureOpenGLForGame:
 	case kFeatureShadersForGame:
+	case kFeatureTouchscreen:
 		return true;
 
 	default:

--- a/backends/platform/wii/osystem.cpp
+++ b/backends/platform/wii/osystem.cpp
@@ -176,7 +176,8 @@ bool OSystem_Wii::hasFeature(Feature f) {
 	return (f == kFeatureFullscreenMode) ||
 			(f == kFeatureAspectRatioCorrection) ||
 			(f == kFeatureCursorPalette) ||
-			(f == kFeatureOverlaySupportsAlpha);
+			(f == kFeatureOverlaySupportsAlpha) ||
+			(f == kFeatureTouchscreen);
 }
 
 void OSystem_Wii::setFeatureState(Feature f, bool enable) {

--- a/common/system.h
+++ b/common/system.h
@@ -581,6 +581,13 @@ public:
 		kFeatureNoQuit,
 
 		/**
+		* The presence of this feature indicates that the backend uses a touchscreen.
+		*
+		* This feature has no associated state.
+		*/
+		kFeatureTouchscreen,
+
+		/**
 		* Arm-v8 requires NEON extensions, but before that, NEON was just
 		* optional, so this signifies that the processor can use NEON.
 		*/

--- a/engines/lure/menu.cpp
+++ b/engines/lure/menu.cpp
@@ -123,7 +123,7 @@ uint8 Menu::execute() {
 	_surfaceMenu = nullptr;
 	_selectedIndex = 0;
 
-	while (mouse.lButton() || mouse.rButton()) {
+	while (mouse.lButton() || mouse.rButton() || g_system->hasFeature(OSystem::kFeatureTouchscreen)) {
 		while (events.pollEvent()) {
 			if (engine.shouldQuit()) return MENUITEM_NONE;
 
@@ -162,6 +162,16 @@ uint8 Menu::execute() {
 				if (_selectedIndex != 0) toggleHighlightItem(_selectedIndex);
 				_selectedIndex = index;
 				if (_selectedIndex != 0) toggleHighlightItem(_selectedIndex);
+			}
+		}
+
+		if (g_system->hasFeature(OSystem::kFeatureTouchscreen)) {
+			// Close menu only when a sub menu is shown and
+			// the user has either clicked on a selected index
+			// or no index (outside the sub menu == cancelled)
+			if (mouse.lButton() &&
+				_surfaceMenu != nullptr)  {
+				break;
 			}
 		}
 


### PR DESCRIPTION
This pull request adds the `kFeatureTouchscreen` enum value to `OSystem` to allow backends to indicate that they use a touchscreen. This is currently done in the iOS, Android, DS, and Wii backends (the ones that defined the `LURE_CLICKABLE_MENUS` define).

Another commit use this new feature in the lure engine to replace the `LURE_CLICKABLE_MENUS` define.

I imagine that other engines could make use of it to adapt their controls to be more adapted to touchscreens.

I also have in mind that it could for example be used in the `GUI::ScrollContainerWidget`, in the `ListWidget`, and in the `GridWidget` to allow scrolling with a left mouse button press and drag on the widget (and not just on the scrollbar). Maybe other widgets could also benefit from it.

@larsamannen, I think you had an additional fix for the top menu in lure as well? Should this be added to this PR?