### PR TITLE
TEST: Various fixes on blending tests

### DIFF
--- a/test/image/blending.h
+++ b/test/image/blending.h
@@ -837,7 +837,11 @@ public:
 		int numIters = 0, numItersScaled = 0;
 		double oldTime = 0.0, newTime = 0.0, genericTime = 0.0;
 		double oldTimeScaled = 0.0, newTimeScaled = 0.0, genericTimeScaled = 0.0;
+#ifdef SLOW_TESTS
 		const int iters = 2500;
+#else
+		const int iters = 1;
+#endif
 
 		for (int blendMode = 0; blendMode < Graphics::NUM_BLEND_MODES; blendMode++) {
 		for (int alphaType = 0; alphaType <= Graphics::ALPHA_FULL; alphaType++) {
@@ -907,6 +911,7 @@ public:
 	}
 
 	void test_blend_blit_unfiltered() {
+#ifdef SLOW_TESTS
 		Common::Rect dsts[] = {
 			Common::Rect(4, 4, 4+16, 4+16), // Case 0 (source clipping)
 			Common::Rect(24, 20, 24+16, 20+16), // Case 1 (outside of destination)
@@ -1073,5 +1078,9 @@ public:
 		} // blend
 
 		baseSurface.free();
+#else
+		// This kills warning about unused function
+		(void)areSurfacesEqual;
+#endif
 	}
 };

--- a/test/image/blending.h
+++ b/test/image/blending.h
@@ -20,6 +20,7 @@
  */
 
 #include <cxxtest/TestSuite.h>
+#include "test/instrset_detect.h"
 
 #if defined(HAVE_CONFIG_H)
 #include "config.h"
@@ -809,10 +810,14 @@ public:
 		Graphics::BlendBlit::blitFunc = Graphics::BlendBlit::blitNEON;
 #endif
 #ifdef SCUMMVM_SSE2
-		Graphics::BlendBlit::blitFunc = Graphics::BlendBlit::blitSSE2;
+		if (instrset_detect() >= 2) {
+			Graphics::BlendBlit::blitFunc = Graphics::BlendBlit::blitSSE2;
+		}
 #endif
 #ifdef SCUMMVM_AVX2
-		Graphics::BlendBlit::blitFunc = Graphics::BlendBlit::blitAVX2;
+		if (instrset_detect() >= 8) {
+			Graphics::BlendBlit::blitFunc = Graphics::BlendBlit::blitAVX2;
+		}
 #endif
 		Graphics::Surface baseSurface, destSurface;
 		baseSurface.create(103, 103, OldTransparentSurface::OldTransparentSurface::getSupportedPixelFormat());

--- a/test/image/blending.h
+++ b/test/image/blending.h
@@ -63,12 +63,12 @@ struct OldTransparentSurface : public Graphics::Surface {
 	                  int width = -1, int height = -1,
 	                  TSpriteBlendMode blend = BLEND_NORMAL);
 	Common::Rect blitClip(Graphics::Surface &target, Common::Rect clippingArea,
-						int posX = 0, int posY = 0,
-						int flipping = FLIP_NONE,
-						Common::Rect *pPartRect = nullptr,
-						uint color = MS_ARGB(255, 255, 255, 255),
-						int width = -1, int height = -1,
-						TSpriteBlendMode blend = BLEND_NORMAL);
+	                      int posX = 0, int posY = 0,
+	                      int flipping = FLIP_NONE,
+	                      Common::Rect *pPartRect = nullptr,
+	                      uint color = MS_ARGB(255, 255, 255, 255),
+	                      int width = -1, int height = -1,
+	                      TSpriteBlendMode blend = BLEND_NORMAL);
 	OldTransparentSurface *scale(int16 newWidth, int16 newHeight, bool filtering = false) const;
 	AlphaType _alphaMode;
 };
@@ -741,8 +741,8 @@ OldTransparentSurface *OldTransparentSurface::scale(int16 newWidth, int16 newHei
 
 #ifdef TEST_IMAGE_BLENDING_SAVE
 static int save_bitmap(const char *path, const Graphics::Surface *surf) {
-    Common::FSNode fileNode(path);
-    Common::SeekableWriteStream *out = fileNode.createWriteStream();
+	Common::FSNode fileNode(path);
+	Common::SeekableWriteStream *out = fileNode.createWriteStream();
 #ifdef SCUMM_LITTLE_ENDIAN
 	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 16, 8, 0, 0);
 #else
@@ -788,7 +788,7 @@ static int save_bitmap(const char *path, const Graphics::Surface *surf) {
 #endif
 
 static bool areSurfacesEqual(const Graphics::Surface *a, const Graphics::Surface *b) {
-    if (a->w != b->w || a->h != b->h) return false;
+	if (a->w != b->w || a->h != b->h) return false;
 	return memcmp(a->getPixels(), b->getPixels(), a->h * a->pitch) == 0;
 }
 
@@ -805,36 +805,36 @@ public:
 #ifdef SCUMMVM_AVX2
 		Graphics::BlendBlit::blitFunc = Graphics::BlendBlit::blitAVX2;
 #endif
-	    Graphics::Surface baseSurface, destSurface;
-	    baseSurface.create(103, 103, OldTransparentSurface::OldTransparentSurface::getSupportedPixelFormat());
-	    destSurface.create(256, 256, OldTransparentSurface::OldTransparentSurface::getSupportedPixelFormat());
-	    for (int y = 0; y < baseSurface.h; y++) {
-	    	for (int x = 0; x < baseSurface.w; x++) {
-                int i = x / 4 + y / 4;
-	    		baseSurface.setPixel(x, y, baseSurface.format.ARGBToColor((i & 16) * 255, (i & 1) * 255, (i & 2) * 255, (i & 4) * 255));
-	    	}
-	    }
+		Graphics::Surface baseSurface, destSurface;
+		baseSurface.create(103, 103, OldTransparentSurface::OldTransparentSurface::getSupportedPixelFormat());
+		destSurface.create(256, 256, OldTransparentSurface::OldTransparentSurface::getSupportedPixelFormat());
+		for (int y = 0; y < baseSurface.h; y++) {
+			for (int x = 0; x < baseSurface.w; x++) {
+				int i = x / 4 + y / 4;
+				baseSurface.setPixel(x, y, baseSurface.format.ARGBToColor((i & 16) * 255, (i & 1) * 255, (i & 2) * 255, (i & 4) * 255));
+			}
+		}
 
-	    OldTransparentSurface::OldTransparentSurface oldSurf(baseSurface, true);
-	    OldTransparentSurface::OldTransparentSurface oldSurfDest(destSurface, true);
-	    Graphics::ManagedSurface managedSurf(&baseSurface, DisposeAfterUse::NO);
-	    Graphics::ManagedSurface managedSurfDest(&destSurface, DisposeAfterUse::NO);
+		OldTransparentSurface::OldTransparentSurface oldSurf(baseSurface, true);
+		OldTransparentSurface::OldTransparentSurface oldSurfDest(destSurface, true);
+		Graphics::ManagedSurface managedSurf(&baseSurface, DisposeAfterUse::NO);
+		Graphics::ManagedSurface managedSurfDest(&destSurface, DisposeAfterUse::NO);
 
 		int numIters = 0, numItersScaled = 0;
 		double oldTime = 0.0, newTime = 0.0, genericTime = 0.0;
 		double oldTimeScaled = 0.0, newTimeScaled = 0.0, genericTimeScaled = 0.0;
 		const int iters = 2500;
 
-        for (int blendMode = 0; blendMode < Graphics::NUM_BLEND_MODES; blendMode++) {
-        for (int alphaType = 0; alphaType <= Graphics::ALPHA_FULL; alphaType++) {
-        for (int flipping = 0; flipping <= 3; flipping++) {
+		for (int blendMode = 0; blendMode < Graphics::NUM_BLEND_MODES; blendMode++) {
+		for (int alphaType = 0; alphaType <= Graphics::ALPHA_FULL; alphaType++) {
+		for (int flipping = 0; flipping <= 3; flipping++) {
 		for (uint32 color = 0xffffffff; color != 0; color = (color == 0xffffffff ? 0x7f7f7f7f : 0)) {
-            oldSurfDest.fillRect(Common::Rect(0, 0, oldSurfDest.w, oldSurfDest.h), oldSurfDest.format.ARGBToColor(255, 255, 255, 255));
-            managedSurfDest.fillRect(Common::Rect(0, 0, managedSurfDest.w, managedSurfDest.h), managedSurfDest.format.ARGBToColor(255, 255, 255, 255));
-            oldSurf._alphaMode = (Graphics::AlphaType)alphaType;
+			oldSurfDest.fillRect(Common::Rect(0, 0, oldSurfDest.w, oldSurfDest.h), oldSurfDest.format.ARGBToColor(255, 255, 255, 255));
+			managedSurfDest.fillRect(Common::Rect(0, 0, managedSurfDest.w, managedSurfDest.h), managedSurfDest.format.ARGBToColor(255, 255, 255, 255));
+			oldSurf._alphaMode = (Graphics::AlphaType)alphaType;
 			uint32 oldStart = g_system->getMillis();
 			for (int i = 0; i < iters; i++) {
-            	oldSurf.blit(oldSurfDest, 0, 0, flipping, nullptr, color, -1, -1, (Graphics::TSpriteBlendMode)blendMode);
+				oldSurf.blit(oldSurfDest, 0, 0, flipping, nullptr, color, -1, -1, (Graphics::TSpriteBlendMode)blendMode);
 			}
 			oldTime += g_system->getMillis() - oldStart;
 			uint32 newStart = g_system->getMillis();
@@ -842,7 +842,7 @@ public:
 				managedSurf.blendBlitTo(managedSurfDest, 0, 0, flipping, nullptr, color, -1, -1, (Graphics::TSpriteBlendMode)blendMode, (Graphics::AlphaType)alphaType);
 			}
 			newTime += g_system->getMillis() - newStart;
-            managedSurfDest.fillRect(Common::Rect(0, 0, managedSurfDest.w, managedSurfDest.h), managedSurfDest.format.ARGBToColor(255, 255, 255, 255));
+			managedSurfDest.fillRect(Common::Rect(0, 0, managedSurfDest.w, managedSurfDest.h), managedSurfDest.format.ARGBToColor(255, 255, 255, 255));
 			Graphics::BlendBlit::BlitFunc oldFunc = Graphics::BlendBlit::blitFunc;
 			Graphics::BlendBlit::blitFunc = Graphics::BlendBlit::blitGeneric;
 			uint32 genericStart = g_system->getMillis();
@@ -854,12 +854,12 @@ public:
 			numIters ++;
 
 			// scaled
-            oldSurfDest.fillRect(Common::Rect(0, 0, oldSurfDest.w, oldSurfDest.h), oldSurfDest.format.ARGBToColor(255, 255, 255, 255));
-            managedSurfDest.fillRect(Common::Rect(0, 0, managedSurfDest.w, managedSurfDest.h), managedSurfDest.format.ARGBToColor(255, 255, 255, 255));
-            oldSurf._alphaMode = (Graphics::AlphaType)alphaType;
+			oldSurfDest.fillRect(Common::Rect(0, 0, oldSurfDest.w, oldSurfDest.h), oldSurfDest.format.ARGBToColor(255, 255, 255, 255));
+			managedSurfDest.fillRect(Common::Rect(0, 0, managedSurfDest.w, managedSurfDest.h), managedSurfDest.format.ARGBToColor(255, 255, 255, 255));
+			oldSurf._alphaMode = (Graphics::AlphaType)alphaType;
 			oldStart = g_system->getMillis();
 			for (int i = 0; i < iters; i++) {
-            	oldSurf.blit(oldSurfDest, 0, 0, flipping, nullptr, color, oldSurfDest.w, oldSurfDest.h, (Graphics::TSpriteBlendMode)blendMode);
+				oldSurf.blit(oldSurfDest, 0, 0, flipping, nullptr, color, oldSurfDest.w, oldSurfDest.h, (Graphics::TSpriteBlendMode)blendMode);
 			}
 			oldTimeScaled += g_system->getMillis() - oldStart;
 			newStart = g_system->getMillis();
@@ -867,7 +867,7 @@ public:
 				managedSurf.blendBlitTo(managedSurfDest, 0, 0, flipping, nullptr, color, managedSurfDest.w, managedSurfDest.h, (Graphics::TSpriteBlendMode)blendMode, (Graphics::AlphaType)alphaType);
 			}
 			newTimeScaled += g_system->getMillis() - newStart;
-            managedSurfDest.fillRect(Common::Rect(0, 0, managedSurfDest.w, managedSurfDest.h), managedSurfDest.format.ARGBToColor(255, 255, 255, 255));
+			managedSurfDest.fillRect(Common::Rect(0, 0, managedSurfDest.w, managedSurfDest.h), managedSurfDest.format.ARGBToColor(255, 255, 255, 255));
 			Graphics::BlendBlit::blitFunc = Graphics::BlendBlit::blitGeneric;
 			genericStart = g_system->getMillis();
 			for (int i = 0; i < iters; i++) {
@@ -877,9 +877,9 @@ public:
 			genericTimeScaled += g_system->getMillis() - genericStart;
 			numItersScaled++;
 		} // color
-        } // flipping
-        } // alpha
-        } // blend
+		} // flipping
+		} // alpha
+		} // blend
 
 		debug("Old TransparentSurface::blit avg time per %d iters (in milliseconds): %f\n", iters, oldTime / numIters);
 		debug("New ManagedSurface::blendBlitTo (non SIMD) avg time per %d iters (in milliseconds): %f\n", iters, genericTime / numIters);
@@ -888,175 +888,175 @@ public:
 		debug("New SCALING ManagedSurface::blendBlitTo (non SIMD) avg time per %d iters (in milliseconds): %f\n", iters, genericTimeScaled / numItersScaled);
 		debug("New SCALING ManagedSurface::blendBlitTo avg time per %d iters (in milliseconds): %f\n", iters, newTimeScaled / numItersScaled);
 
-	    baseSurface.free();
+		baseSurface.free();
 	}
 
-    void test_blend_blit_unfiltered() {
-        Common::Rect dsts[] = {
-            Common::Rect(4, 4, 4+16, 4+16), // Case 0 (source clipping)
-            Common::Rect(24, 20, 24+16, 20+16), // Case 1 (outside of destination)
-            Common::Rect(0, 0, 32, 32), // Case 2 (stretching bigger)
-            Common::Rect(3, 3, 3+8, 3+8), // Case 3 (stretching smaller)
-            Common::Rect(8, 4, 8+32, 4+32), // Case 4 (stretching outside of destination)
-            Common::Rect(-4, -4, -4+16, -4+16), // Case 5 (outside of destination 2)
-            Common::Rect(-16, -16, 32+16, 32+16), // Case 6 (completely bigger)
-        }, srcs[] = {
-            Common::Rect(0, 0, 16, 16), // Case 0 (source clipping)
-            Common::Rect(0, 0, 16, 16), // Case 1 (outside of destination)
-            Common::Rect(0, 0, 16, 16), // Case 2 (stretching)
-            Common::Rect(0, 0, 16, 16), // Case 3 (stretching smaller)
-            Common::Rect(0, 0, 16, 16), // Case 4 (stretching outside of destination)
-            Common::Rect(0, 0, 16, 16), // Case 5 (outside of destination 2)
-            Common::Rect(0, 0, 16, 16), // Case 6 (completely bigger)
-        };
+	void test_blend_blit_unfiltered() {
+		Common::Rect dsts[] = {
+			Common::Rect(4, 4, 4+16, 4+16), // Case 0 (source clipping)
+			Common::Rect(24, 20, 24+16, 20+16), // Case 1 (outside of destination)
+			Common::Rect(0, 0, 32, 32), // Case 2 (stretching bigger)
+			Common::Rect(3, 3, 3+8, 3+8), // Case 3 (stretching smaller)
+			Common::Rect(8, 4, 8+32, 4+32), // Case 4 (stretching outside of destination)
+			Common::Rect(-4, -4, -4+16, -4+16), // Case 5 (outside of destination 2)
+			Common::Rect(-16, -16, 32+16, 32+16), // Case 6 (completely bigger)
+		}, srcs[] = {
+			Common::Rect(0, 0, 16, 16), // Case 0 (source clipping)
+			Common::Rect(0, 0, 16, 16), // Case 1 (outside of destination)
+			Common::Rect(0, 0, 16, 16), // Case 2 (stretching)
+			Common::Rect(0, 0, 16, 16), // Case 3 (stretching smaller)
+			Common::Rect(0, 0, 16, 16), // Case 4 (stretching outside of destination)
+			Common::Rect(0, 0, 16, 16), // Case 5 (outside of destination 2)
+			Common::Rect(0, 0, 16, 16), // Case 6 (completely bigger)
+		};
 
-	    Graphics::Surface baseSurface, destSurface;
-	    baseSurface.create(16, 16, OldTransparentSurface::OldTransparentSurface::getSupportedPixelFormat());
-	    destSurface.create(32, 32, OldTransparentSurface::OldTransparentSurface::getSupportedPixelFormat());
-	    for (int y = 0; y < baseSurface.h; y++) {
-	    	for (int x = 0; x < baseSurface.w; x++) {
-                int i = x / 4 + y / 4;
-	    		baseSurface.setPixel(x, y, baseSurface.format.ARGBToColor((i & 16) * 255, (i & 1) * 255, (i & 2) * 255, (i & 4) * 255));
-	    	}
-	    }
+		Graphics::Surface baseSurface, destSurface;
+		baseSurface.create(16, 16, OldTransparentSurface::OldTransparentSurface::getSupportedPixelFormat());
+		destSurface.create(32, 32, OldTransparentSurface::OldTransparentSurface::getSupportedPixelFormat());
+		for (int y = 0; y < baseSurface.h; y++) {
+			for (int x = 0; x < baseSurface.w; x++) {
+				int i = x / 4 + y / 4;
+				baseSurface.setPixel(x, y, baseSurface.format.ARGBToColor((i & 16) * 255, (i & 1) * 255, (i & 2) * 255, (i & 4) * 255));
+			}
+		}
 
-	    OldTransparentSurface::OldTransparentSurface oldSurf(baseSurface, true);
-	    OldTransparentSurface::OldTransparentSurface oldSurfDest(destSurface, true);
-	    Graphics::TransparentSurface newSurf(baseSurface, true);
-	    Graphics::TransparentSurface newSurfDest(destSurface, true);
-	    Graphics::ManagedSurface managedSurf(&baseSurface, DisposeAfterUse::NO);
-	    Graphics::ManagedSurface managedSurfDest(&destSurface, DisposeAfterUse::NO);
-        const char *blendModes[] = {
-            "BLEND_NORMAL",
-            "BLEND_ADDITIVE",
-            "BLEND_SUBTRACTIVE",
-            "BLEND_MULTIPLY",
-        }, *alphaTypes[] = {
-            "ALPHA_OPAQUE",
-            "ALPHA_BINARY",
-            "ALPHA_FULL",
-        }, *flipNames[] = {
-            "FLIP_NONE",
-            "FLIP_H",
-            "FLIP_V",
-            "FLIP_HV",
-        }, *rectNames[] = {
-            "0 -> (source clipping)",
-            "1 -> (outside of destination)",
-            "2 -> (stretching bigger)",
-            "3 -> (stretching smaller)",
-            "4 -> (stretching outside of destination)",
-            "5 -> (outside of destination)",
+		OldTransparentSurface::OldTransparentSurface oldSurf(baseSurface, true);
+		OldTransparentSurface::OldTransparentSurface oldSurfDest(destSurface, true);
+		Graphics::TransparentSurface newSurf(baseSurface, true);
+		Graphics::TransparentSurface newSurfDest(destSurface, true);
+		Graphics::ManagedSurface managedSurf(&baseSurface, DisposeAfterUse::NO);
+		Graphics::ManagedSurface managedSurfDest(&destSurface, DisposeAfterUse::NO);
+		const char *blendModes[] = {
+			"BLEND_NORMAL",
+			"BLEND_ADDITIVE",
+			"BLEND_SUBTRACTIVE",
+			"BLEND_MULTIPLY",
+		}, *alphaTypes[] = {
+			"ALPHA_OPAQUE",
+			"ALPHA_BINARY",
+			"ALPHA_FULL",
+		}, *flipNames[] = {
+			"FLIP_NONE",
+			"FLIP_H",
+			"FLIP_V",
+			"FLIP_HV",
+		}, *rectNames[] = {
+			"0 -> (source clipping)",
+			"1 -> (outside of destination)",
+			"2 -> (stretching bigger)",
+			"3 -> (stretching smaller)",
+			"4 -> (stretching outside of destination)",
+			"5 -> (outside of destination)",
 			"6 -> (completely bigger)"
-        };
+		};
 
-        for (int blendMode = 0; blendMode < Graphics::NUM_BLEND_MODES; blendMode++) {
-        for (int alphaType = 0; alphaType <= Graphics::ALPHA_FULL; alphaType++) {
-        for (int ba = 255; ba >= 0; ba = (ba == 255 ? 128 : (ba == 128 ? 0 : -1))) {
-        for (int br = 255; br >= 0; br = (br == 255 ? 128 : (br == 128 ? 0 : -1))) {
-        for (int bg = 255; bg >= 0; bg = (bg == 255 ? 128 : (bg == 128 ? 0 : -1))) {
-        for (int bb = 255; bb >= 0; bb = (bb == 255 ? 128 : (bb == 128 ? 0 : -1))) {
-        for (int a = 255; a >= 0; a = (a == 255 ? 128 : (a == 128 ? 0 : -1))) {
-        for (int r = 255; r >= 0; r = (r == 255 ? 128 : (r == 128 ? 0 : -1))) {
-        for (int g = 255; g >= 0; g = (g == 255 ? 128 : (g == 128 ? 0 : -1))) {
-        for (int b = 255; b >= 0; b = (b == 255 ? 128 : (b == 128 ? 0 : -1))) {
-        for (int flipping = 0; flipping <= 3; flipping++) {
-        for (int rect = 0; rect < (int)(sizeof(srcs)/sizeof(srcs[0])); rect++) {
-            oldSurfDest.fillRect(Common::Rect(0, 0, oldSurfDest.w, oldSurfDest.h), oldSurfDest.format.ARGBToColor(ba, br, bg, bb));
-            oldSurf._alphaMode = (Graphics::AlphaType)alphaType;
-            Common::Rect ret1 = oldSurf.blit(oldSurfDest, dsts[rect].left, dsts[rect].top, flipping, &srcs[rect], MS_ARGB(a, r, g, b), dsts[rect].width(), dsts[rect].height(), (Graphics::TSpriteBlendMode)blendMode);
-            newSurfDest.fillRect(Common::Rect(0, 0, newSurfDest.w, newSurfDest.h), newSurfDest.format.ARGBToColor(ba, br, bg, bb));
-            newSurf.setAlphaMode((Graphics::AlphaType)alphaType);
-            Common::Rect ret2 = newSurf.blit(newSurfDest, dsts[rect].left, dsts[rect].top, flipping, &srcs[rect], MS_ARGB(a, r, g, b), dsts[rect].width(), dsts[rect].height(), (Graphics::TSpriteBlendMode)blendMode);
-            managedSurfDest.fillRect(Common::Rect(0, 0, managedSurfDest.w, managedSurfDest.h), managedSurfDest.format.ARGBToColor(ba, br, bg, bb));
-            Common::Rect ret3 = managedSurf.blendBlitTo(managedSurfDest, dsts[rect].left, dsts[rect].top, flipping, &srcs[rect], MS_ARGB(a, r, g, b), dsts[rect].width(), dsts[rect].height(), (Graphics::TSpriteBlendMode)blendMode, (Graphics::AlphaType)alphaType);
+		for (int blendMode = 0; blendMode < Graphics::NUM_BLEND_MODES; blendMode++) {
+		for (int alphaType = 0; alphaType <= Graphics::ALPHA_FULL; alphaType++) {
+		for (int ba = 255; ba >= 0; ba = (ba == 255 ? 128 : (ba == 128 ? 0 : -1))) {
+		for (int br = 255; br >= 0; br = (br == 255 ? 128 : (br == 128 ? 0 : -1))) {
+		for (int bg = 255; bg >= 0; bg = (bg == 255 ? 128 : (bg == 128 ? 0 : -1))) {
+		for (int bb = 255; bb >= 0; bb = (bb == 255 ? 128 : (bb == 128 ? 0 : -1))) {
+		for (int a = 255; a >= 0; a = (a == 255 ? 128 : (a == 128 ? 0 : -1))) {
+		for (int r = 255; r >= 0; r = (r == 255 ? 128 : (r == 128 ? 0 : -1))) {
+		for (int g = 255; g >= 0; g = (g == 255 ? 128 : (g == 128 ? 0 : -1))) {
+		for (int b = 255; b >= 0; b = (b == 255 ? 128 : (b == 128 ? 0 : -1))) {
+		for (int flipping = 0; flipping <= 3; flipping++) {
+		for (int rect = 0; rect < (int)(sizeof(srcs)/sizeof(srcs[0])); rect++) {
+			oldSurfDest.fillRect(Common::Rect(0, 0, oldSurfDest.w, oldSurfDest.h), oldSurfDest.format.ARGBToColor(ba, br, bg, bb));
+			oldSurf._alphaMode = (Graphics::AlphaType)alphaType;
+			Common::Rect ret1 = oldSurf.blit(oldSurfDest, dsts[rect].left, dsts[rect].top, flipping, &srcs[rect], MS_ARGB(a, r, g, b), dsts[rect].width(), dsts[rect].height(), (Graphics::TSpriteBlendMode)blendMode);
+			newSurfDest.fillRect(Common::Rect(0, 0, newSurfDest.w, newSurfDest.h), newSurfDest.format.ARGBToColor(ba, br, bg, bb));
+			newSurf.setAlphaMode((Graphics::AlphaType)alphaType);
+			Common::Rect ret2 = newSurf.blit(newSurfDest, dsts[rect].left, dsts[rect].top, flipping, &srcs[rect], MS_ARGB(a, r, g, b), dsts[rect].width(), dsts[rect].height(), (Graphics::TSpriteBlendMode)blendMode);
+			managedSurfDest.fillRect(Common::Rect(0, 0, managedSurfDest.w, managedSurfDest.h), managedSurfDest.format.ARGBToColor(ba, br, bg, bb));
+			Common::Rect ret3 = managedSurf.blendBlitTo(managedSurfDest, dsts[rect].left, dsts[rect].top, flipping, &srcs[rect], MS_ARGB(a, r, g, b), dsts[rect].width(), dsts[rect].height(), (Graphics::TSpriteBlendMode)blendMode, (Graphics::AlphaType)alphaType);
 
 			if (ret1 != ret2 || ret2 != ret3 || ret1 != ret3) {
-                warning("blendMode: %s, alphaType: %s, a: %d, r: %d, g: %d, b: %d, flipping: %s, test rect id: %s",
-                    blendModes[blendMode], alphaTypes[alphaType], a, r, g, b, flipNames[flipping], rectNames[rect]);
+				warning("blendMode: %s, alphaType: %s, a: %d, r: %d, g: %d, b: %d, flipping: %s, test rect id: %s",
+				        blendModes[blendMode], alphaTypes[alphaType], a, r, g, b, flipNames[flipping], rectNames[rect]);
 				warning("old: Rect(%d, %d, %d, %d)", ret1.left, ret1.top, ret1.width(), ret1.height());
 				warning("new: Rect(%d, %d, %d, %d)", ret2.left, ret2.top, ret2.width(), ret2.height());
 				warning("managed: Rect(%d, %d, %d, %d)", ret3.left, ret3.top, ret3.width(), ret3.height());
-                TS_FAIL("Return sizes are not equal!");
+				TS_FAIL("Return sizes are not equal!");
 			}
 
-            if (!areSurfacesEqual(&oldSurfDest, &newSurfDest)) {
-                warning("blendMode: %s, alphaType: %s, a: %d, r: %d, g: %d, b: %d, flipping: %s, test rect id: %s",
-                    blendModes[blendMode], alphaTypes[alphaType], a, r, g, b, flipNames[flipping], rectNames[rect]);
+			if (!areSurfacesEqual(&oldSurfDest, &newSurfDest)) {
+				warning("blendMode: %s, alphaType: %s, a: %d, r: %d, g: %d, b: %d, flipping: %s, test rect id: %s",
+				        blendModes[blendMode], alphaTypes[alphaType], a, r, g, b, flipNames[flipping], rectNames[rect]);
 #ifdef TEST_IMAGE_BLENDING_SAVE
-                save_bitmap("sourceSurf.bmp", &newSurf);
-                save_bitmap("oldSurfDest.bmp", &oldSurfDest);
-                save_bitmap("newSurfDest.bmp", &newSurfDest);
-                save_bitmap("managedSurfDest.bmp", managedSurfDest.surfacePtr());
+				save_bitmap("sourceSurf.bmp", &newSurf);
+				save_bitmap("oldSurfDest.bmp", &oldSurfDest);
+				save_bitmap("newSurfDest.bmp", &newSurfDest);
+				save_bitmap("managedSurfDest.bmp", managedSurfDest.surfacePtr());
 #endif
-                TS_FAIL("oldSurfDest and newSurfDest are not equal!");
-                return;
-            }
-            if (!areSurfacesEqual(&oldSurfDest, managedSurfDest.surfacePtr())) {
-                warning("blendMode: %s, alphaType: %s, a: %d, r: %d, g: %d, b: %d, flipping: %s, test rect id: %s",
-                    blendModes[blendMode], alphaTypes[alphaType], a, r, g, b, flipNames[flipping], rectNames[rect]);
+				TS_FAIL("oldSurfDest and newSurfDest are not equal!");
+				return;
+			}
+			if (!areSurfacesEqual(&oldSurfDest, managedSurfDest.surfacePtr())) {
+				warning("blendMode: %s, alphaType: %s, a: %d, r: %d, g: %d, b: %d, flipping: %s, test rect id: %s",
+				        blendModes[blendMode], alphaTypes[alphaType], a, r, g, b, flipNames[flipping], rectNames[rect]);
 #ifdef TEST_IMAGE_BLENDING_SAVE
-                save_bitmap("sourceSurf.bmp", &newSurf);
-                save_bitmap("oldSurfDest.bmp", &oldSurfDest);
-                save_bitmap("newSurfDest.bmp", &newSurfDest);
-                save_bitmap("managedSurfDest.bmp", managedSurfDest.surfacePtr());
+				save_bitmap("sourceSurf.bmp", &newSurf);
+				save_bitmap("oldSurfDest.bmp", &oldSurfDest);
+				save_bitmap("newSurfDest.bmp", &newSurfDest);
+				save_bitmap("managedSurfDest.bmp", managedSurfDest.surfacePtr());
 #endif
-                TS_FAIL("oldSurfDest and managedSurfDest are not equal!");
-                return;
-            }
-            if (!areSurfacesEqual(&newSurfDest, managedSurfDest.surfacePtr())) {
-                warning("blendMode: %s, alphaType: %s, a: %d, r: %d, g: %d, b: %d, flipping: %s, test rect id: %s",
-                    blendModes[blendMode], alphaTypes[alphaType], a, r, g, b, flipNames[flipping], rectNames[rect]);
+				TS_FAIL("oldSurfDest and managedSurfDest are not equal!");
+				return;
+			}
+			if (!areSurfacesEqual(&newSurfDest, managedSurfDest.surfacePtr())) {
+				warning("blendMode: %s, alphaType: %s, a: %d, r: %d, g: %d, b: %d, flipping: %s, test rect id: %s",
+				        blendModes[blendMode], alphaTypes[alphaType], a, r, g, b, flipNames[flipping], rectNames[rect]);
 #ifdef TEST_IMAGE_BLENDING_SAVE
-                save_bitmap("sourceSurf.bmp", &newSurf);
-                save_bitmap("oldSurfDest.bmp", &oldSurfDest);
-                save_bitmap("newSurfDest.bmp", &newSurfDest);
-                save_bitmap("managedSurfDest.bmp", managedSurfDest.surfacePtr());
+				save_bitmap("sourceSurf.bmp", &newSurf);
+				save_bitmap("oldSurfDest.bmp", &oldSurfDest);
+				save_bitmap("newSurfDest.bmp", &newSurfDest);
+				save_bitmap("managedSurfDest.bmp", managedSurfDest.surfacePtr());
 #endif
-                TS_FAIL("newSurfDest and managedSurfDest are not equal!");
-                return;
-            }
+				TS_FAIL("newSurfDest and managedSurfDest are not equal!");
+				return;
+			}
 
 			
-            oldSurfDest.fillRect(Common::Rect(0, 0, oldSurfDest.w, oldSurfDest.h), oldSurfDest.format.ARGBToColor(ba, br, bg, bb));
-            oldSurf._alphaMode = (Graphics::AlphaType)alphaType;
-            ret1 = oldSurf.blitClip(oldSurfDest, Common::Rect(2, 2, oldSurfDest.w - 2, oldSurfDest.h - 2), dsts[rect].left, dsts[rect].top, flipping, &srcs[rect], MS_ARGB(a, r, g, b), dsts[rect].width(), dsts[rect].height(), (Graphics::TSpriteBlendMode)blendMode);
-            newSurfDest.fillRect(Common::Rect(0, 0, newSurfDest.w, newSurfDest.h), newSurfDest.format.ARGBToColor(ba, br, bg, bb));
-            newSurf.setAlphaMode((Graphics::AlphaType)alphaType);
-            ret2 = newSurf.blitClip(newSurfDest, Common::Rect(2, 2, oldSurfDest.w - 2, oldSurfDest.h - 2), dsts[rect].left, dsts[rect].top, flipping, &srcs[rect], MS_ARGB(a, r, g, b), dsts[rect].width(), dsts[rect].height(), (Graphics::TSpriteBlendMode)blendMode);
-            if (!areSurfacesEqual(&oldSurfDest, &newSurfDest)) {
-                warning("BLIT_CLIP blendMode: %s, alphaType: %s, a: %d, r: %d, g: %d, b: %d, flipping: %s, test rect id: %s",
-                    blendModes[blendMode], alphaTypes[alphaType], a, r, g, b, flipNames[flipping], rectNames[rect]);
+			oldSurfDest.fillRect(Common::Rect(0, 0, oldSurfDest.w, oldSurfDest.h), oldSurfDest.format.ARGBToColor(ba, br, bg, bb));
+			oldSurf._alphaMode = (Graphics::AlphaType)alphaType;
+			ret1 = oldSurf.blitClip(oldSurfDest, Common::Rect(2, 2, oldSurfDest.w - 2, oldSurfDest.h - 2), dsts[rect].left, dsts[rect].top, flipping, &srcs[rect], MS_ARGB(a, r, g, b), dsts[rect].width(), dsts[rect].height(), (Graphics::TSpriteBlendMode)blendMode);
+			newSurfDest.fillRect(Common::Rect(0, 0, newSurfDest.w, newSurfDest.h), newSurfDest.format.ARGBToColor(ba, br, bg, bb));
+			newSurf.setAlphaMode((Graphics::AlphaType)alphaType);
+			ret2 = newSurf.blitClip(newSurfDest, Common::Rect(2, 2, oldSurfDest.w - 2, oldSurfDest.h - 2), dsts[rect].left, dsts[rect].top, flipping, &srcs[rect], MS_ARGB(a, r, g, b), dsts[rect].width(), dsts[rect].height(), (Graphics::TSpriteBlendMode)blendMode);
+			if (!areSurfacesEqual(&oldSurfDest, &newSurfDest)) {
+				warning("BLIT_CLIP blendMode: %s, alphaType: %s, a: %d, r: %d, g: %d, b: %d, flipping: %s, test rect id: %s",
+				        blendModes[blendMode], alphaTypes[alphaType], a, r, g, b, flipNames[flipping], rectNames[rect]);
 #ifdef TEST_IMAGE_BLENDING_SAVE
-                save_bitmap("sourceSurfBlipClip.bmp", &newSurf);
-                save_bitmap("oldSurfDestBlitClip.bmp", &oldSurfDest);
-                save_bitmap("newSurfDestBlitClip.bmp", &newSurfDest);
-                save_bitmap("managedSurfDest.bmp", managedSurfDest.surfacePtr());
+				save_bitmap("sourceSurfBlipClip.bmp", &newSurf);
+				save_bitmap("oldSurfDestBlitClip.bmp", &oldSurfDest);
+				save_bitmap("newSurfDestBlitClip.bmp", &newSurfDest);
+				save_bitmap("managedSurfDest.bmp", managedSurfDest.surfacePtr());
 #endif
-                TS_FAIL("oldSurfDest and newSurfDest are not equal with blipClip!");
-                return;
-            }
+				TS_FAIL("oldSurfDest and newSurfDest are not equal with blipClip!");
+				return;
+			}
 			if (ret1 != ret2) {
-                warning("blendMode: %s, alphaType: %s, a: %d, r: %d, g: %d, b: %d, flipping: %s, test rect id: %s",
-                    blendModes[blendMode], alphaTypes[alphaType], a, r, g, b, flipNames[flipping], rectNames[rect]);
+				warning("blendMode: %s, alphaType: %s, a: %d, r: %d, g: %d, b: %d, flipping: %s, test rect id: %s",
+				        blendModes[blendMode], alphaTypes[alphaType], a, r, g, b, flipNames[flipping], rectNames[rect]);
 				warning("old: Rect(%d, %d, %d, %d)", ret1.left, ret1.top, ret1.width(), ret1.height());
 				warning("new: Rect(%d, %d, %d, %d)", ret2.left, ret2.top, ret2.width(), ret2.height());
 				warning("managed: Rect(%d, %d, %d, %d)", ret3.left, ret3.top, ret3.width(), ret3.height());
-                TS_FAIL("Return sizes are not equal for blitClip!");
+				TS_FAIL("Return sizes are not equal for blitClip!");
 			}
-        } // rect
-        } // flipping
-        } // b
-        } // g
-        } // r
-        } // a
-        } // bb
-        } // bg
-        } // br
-        } // ba
-        } // alpha
-        } // blend
+		} // rect
+		} // flipping
+		} // b
+		} // g
+		} // r
+		} // a
+		} // bb
+		} // bg
+		} // br
+		} // ba
+		} // alpha
+		} // blend
 
-	    baseSurface.free();
-    }
+		baseSurface.free();
+	}
 };

--- a/test/image/blending.h
+++ b/test/image/blending.h
@@ -44,6 +44,12 @@
 #include "graphics/transparent_surface.h"
 #include "graphics/transform_tools.h"
 
+#if NULL_OSYSTEM_IS_AVAILABLE
+#define BENCHMARK_TIME 1
+#else
+#define BENCHMARK_TIME 0
+#endif
+
 namespace OldTransparentSurface {
 
 using namespace Graphics;
@@ -795,6 +801,9 @@ static bool areSurfacesEqual(const Graphics::Surface *a, const Graphics::Surface
 class BlendBlitUnfilteredTestSuite : public CxxTest::TestSuite {
 public:
 	void test_blend_speed() {
+#if BENCHMARK_TIME
+		Common::install_null_g_system();
+
 		Graphics::BlendBlit::blitFunc = Graphics::BlendBlit::blitGeneric;
 #ifdef SCUMMVM_NEON
 		Graphics::BlendBlit::blitFunc = Graphics::BlendBlit::blitNEON;
@@ -889,6 +898,7 @@ public:
 		debug("New SCALING ManagedSurface::blendBlitTo avg time per %d iters (in milliseconds): %f\n", iters, newTimeScaled / numItersScaled);
 
 		baseSurface.free();
+#endif
 	}
 
 	void test_blend_blit_unfiltered() {

--- a/test/instrset_detect.h
+++ b/test/instrset_detect.h
@@ -1,0 +1,236 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// This file is derived from instrset_detect.cpp and instrset.h with minor style changes
+/*****************************************************************************
+* Author:        Agner Fog
+* Date created:  2012-05-30
+* Last modified: 2022-07-20
+* Version:       2.02.00
+* Project:       vector class library
+* Description:
+* Functions for checking which instruction sets are supported.
+*
+* (c) Copyright 2012-2022 Agner Fog.
+* Apache License version 2.0 or later.
+******************************************************************************/
+
+#ifndef INSTRSET_DETECT_H
+#define INSTRSET_DETECT_H
+
+#if defined(__x86_64__) || defined(__amd64) || defined(_M_X64)  || defined(_M_AMD64) || \
+	defined(__i386__)   || defined(__i386)  || defined(_M_IX86)
+
+#include <stdint.h>                    // Define integer types with known size
+#include <limits.h>                    // Define INT_MAX
+
+// Header files for non-vector intrinsic functions including _BitScanReverse(int), __cpuid(int[4],int), _xgetbv(int)
+#ifdef _MSC_VER                        // Microsoft compiler or compatible Intel compiler
+#include <intrin.h>
+#pragma warning(disable: 6323 4514 4710 4711) // Diasble annoying warnings
+#else
+#include <x86intrin.h>                 // Gcc or Clang compiler
+#endif
+
+// Define interface to cpuid instruction.
+// input:  functionnumber = leaf (eax), ecxleaf = subleaf(ecx)
+// output: output[0] = eax, output[1] = ebx, output[2] = ecx, output[3] = edx
+static inline void cpuid(int output[4], int functionnumber, int ecxleaf = 0) {
+#if defined(__GNUC__) || defined(__clang__)           // use inline assembly, Gnu/AT&T syntax
+    int a, b, c, d;
+    __asm("cpuid" : "=a"(a), "=b"(b), "=c"(c), "=d"(d) : "a"(functionnumber), "c"(ecxleaf) : );
+    output[0] = a;
+    output[1] = b;
+    output[2] = c;
+    output[3] = d;
+
+#elif defined (_MSC_VER)                              // Microsoft compiler, intrin.h included
+    __cpuidex(output, functionnumber, ecxleaf);       // intrinsic function for CPUID
+
+#else                                                 // unknown platform. try inline assembly with masm/intel syntax
+    __asm {
+        mov eax, functionnumber
+        mov ecx, ecxleaf
+        cpuid;
+        mov esi, output
+        mov[esi], eax
+        mov[esi + 4], ebx
+        mov[esi + 8], ecx
+        mov[esi + 12], edx
+    }
+#endif
+}
+
+
+// Define interface to xgetbv instruction
+static inline uint64_t xgetbv (int ctr) {
+#if (defined (_MSC_FULL_VER) && _MSC_FULL_VER >= 160040000) || (defined (__INTEL_COMPILER) && __INTEL_COMPILER >= 1200)
+    // Microsoft or Intel compiler supporting _xgetbv intrinsic
+
+    return uint64_t(_xgetbv(ctr));                    // intrinsic function for XGETBV
+
+#elif defined(__GNUC__) ||  defined (__clang__)       // use inline assembly, Gnu/AT&T syntax
+
+   uint32_t a, d;
+   __asm("xgetbv" : "=a"(a),"=d"(d) : "c"(ctr) : );
+   return a | (uint64_t(d) << 32);
+
+#else  // #elif defined (_WIN32)                      // other compiler. try inline assembly with masm/intel/MS syntax
+   uint32_t a, d;
+    __asm {
+        mov ecx, ctr
+        _emit 0x0f
+        _emit 0x01
+        _emit 0xd0 ; // xgetbv
+        mov a, eax
+        mov d, edx
+    }
+   return a | (uint64_t(d) << 32);
+
+#endif
+}
+
+/* find supported instruction set
+    return value:
+    0           = 80386 instruction set
+    1  or above = SSE (XMM) supported by CPU (not testing for OS support)
+    2  or above = SSE2
+    3  or above = SSE3
+    4  or above = Supplementary SSE3 (SSSE3)
+    5  or above = SSE4.1
+    6  or above = SSE4.2
+    7  or above = AVX supported by CPU and operating system
+    8  or above = AVX2
+    9  or above = AVX512F
+   10  or above = AVX512VL, AVX512BW, AVX512DQ
+*/
+static int instrset_detect(void) {
+
+    static int iset = -1;                                  // remember value for next call
+    if (iset >= 0) {
+        return iset;                                       // called before
+    }
+    iset = 0;                                              // default value
+    int abcd[4] = {0,0,0,0};                               // cpuid results
+    cpuid(abcd, 0);                                        // call cpuid function 0
+    if (abcd[0] == 0) return iset;                         // no further cpuid function supported
+    cpuid(abcd, 1);                                        // call cpuid function 1 for feature flags
+    if ((abcd[3] & (1 <<  0)) == 0) return iset;           // no floating point
+    if ((abcd[3] & (1 << 23)) == 0) return iset;           // no MMX
+    if ((abcd[3] & (1 << 15)) == 0) return iset;           // no conditional move
+    if ((abcd[3] & (1 << 24)) == 0) return iset;           // no FXSAVE
+    if ((abcd[3] & (1 << 25)) == 0) return iset;           // no SSE
+    iset = 1;                                              // 1: SSE supported
+    if ((abcd[3] & (1 << 26)) == 0) return iset;           // no SSE2
+    iset = 2;                                              // 2: SSE2 supported
+    if ((abcd[2] & (1 <<  0)) == 0) return iset;           // no SSE3
+    iset = 3;                                              // 3: SSE3 supported
+    if ((abcd[2] & (1 <<  9)) == 0) return iset;           // no SSSE3
+    iset = 4;                                              // 4: SSSE3 supported
+    if ((abcd[2] & (1 << 19)) == 0) return iset;           // no SSE4.1
+    iset = 5;                                              // 5: SSE4.1 supported
+    if ((abcd[2] & (1 << 23)) == 0) return iset;           // no POPCNT
+    if ((abcd[2] & (1 << 20)) == 0) return iset;           // no SSE4.2
+    iset = 6;                                              // 6: SSE4.2 supported
+    if ((abcd[2] & (1 << 27)) == 0) return iset;           // no OSXSAVE
+    if ((xgetbv(0) & 6) != 6)       return iset;           // AVX not enabled in O.S.
+    if ((abcd[2] & (1 << 28)) == 0) return iset;           // no AVX
+    iset = 7;                                              // 7: AVX supported
+    cpuid(abcd, 7);                                        // call cpuid leaf 7 for feature flags
+    if ((abcd[1] & (1 <<  5)) == 0) return iset;           // no AVX2
+    iset = 8;
+    if ((abcd[1] & (1 << 16)) == 0) return iset;           // no AVX512
+    cpuid(abcd, 0xD);                                      // call cpuid leaf 0xD for feature flags
+    if ((abcd[0] & 0x60) != 0x60)   return iset;           // no AVX512
+    iset = 9;
+    cpuid(abcd, 7);                                        // call cpuid leaf 7 for feature flags
+    if ((abcd[1] & (1 << 31)) == 0) return iset;           // no AVX512VL
+    if ((abcd[1] & 0x40020000) != 0x40020000) return iset; // no AVX512BW, AVX512DQ
+    iset = 10;
+    return iset;
+}
+
+// detect if CPU supports the FMA3 instruction set
+static inline bool hasFMA3(void) {
+    if (instrset_detect() < 7) return false;               // must have AVX
+    int abcd[4];                                           // cpuid results
+    cpuid(abcd, 1);                                        // call cpuid function 1
+    return ((abcd[2] & (1 << 12)) != 0);                   // ecx bit 12 indicates FMA3
+}
+
+// detect if CPU supports the FMA4 instruction set
+static inline bool hasFMA4(void) {
+    if (instrset_detect() < 7) return false;               // must have AVX
+    int abcd[4];                                           // cpuid results
+    cpuid(abcd, 0x80000001);                               // call cpuid function 0x80000001
+    return ((abcd[2] & (1 << 16)) != 0);                   // ecx bit 16 indicates FMA4
+}
+
+// detect if CPU supports the XOP instruction set
+static inline bool hasXOP(void) {
+    if (instrset_detect() < 7) return false;               // must have AVX
+    int abcd[4];                                           // cpuid results
+    cpuid(abcd, 0x80000001);                               // call cpuid function 0x80000001
+    return ((abcd[2] & (1 << 11)) != 0);                   // ecx bit 11 indicates XOP
+}
+
+// detect if CPU supports the AVX512ER instruction set
+static inline bool hasAVX512ER(void) {
+    if (instrset_detect() < 9) return false;               // must have AVX512F
+    int abcd[4];                                           // cpuid results
+    cpuid(abcd, 7);                                        // call cpuid function 7
+    return ((abcd[1] & (1 << 27)) != 0);                   // ebx bit 27 indicates AVX512ER
+}
+
+// detect if CPU supports the AVX512VBMI instruction set
+static inline bool hasAVX512VBMI(void) {
+    if (instrset_detect() < 10) return false;              // must have AVX512BW
+    int abcd[4];                                           // cpuid results
+    cpuid(abcd, 7);                                        // call cpuid function 7
+    return ((abcd[2] & (1 << 1)) != 0);                    // ecx bit 1 indicates AVX512VBMI
+}
+
+// detect if CPU supports the AVX512VBMI2 instruction set
+static inline bool hasAVX512VBMI2(void) {
+    if (instrset_detect() < 10) return false;              // must have AVX512BW
+    int abcd[4];                                           // cpuid results
+    cpuid(abcd, 7);                                        // call cpuid function 7
+    return ((abcd[2] & (1 << 6)) != 0);                    // ecx bit 6 indicates AVX512VBMI2
+}
+
+// detect if CPU supports the F16C instruction set
+static inline bool hasF16C(void) {
+    if (instrset_detect() < 7) return false;               // must have AVX
+    int abcd[4];                                           // cpuid results
+    cpuid(abcd, 1);                                        // call cpuid function 1
+    return ((abcd[2] & (1 << 29)) != 0);                   // ecx bit 29 indicates F16C
+}
+
+// detect if CPU supports the AVX512_FP16 instruction set
+static inline bool hasAVX512FP16(void) {
+    if (instrset_detect() < 10) return false;              // must have AVX512
+    int abcd[4];                                           // cpuid results
+    cpuid(abcd, 7);                                        // call cpuid function 1
+    return ((abcd[3] & (1 << 23)) != 0);                   // edx bit 23 indicates AVX512_FP16
+}
+
+#endif
+#endif


### PR DESCRIPTION
This PR contains various fixes:
- indentation is changed to tabs
- null backend is initialized as needed (it's needed when only blending tests are built)
- the instruction set supported by x86 processor is checked before making use of it (this uses code from https://github.com/vectorclass/version2/)
- slow tests are not built by default to keep unit testing efficient