### PR TITLE
DIRECTOR: handle void argument to soundBusy

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -3095,9 +3095,14 @@ void LB::b_soundBusy(int nargs) {
 	DirectorSound *sound = g_director->getCurrentWindow()->getSoundManager();
 	Datum whichChannel = g_lingo->pop();
 
-	TYPECHECK(whichChannel, INT);
+	// Horror Tour 2 calls this with a void argument
+	TYPECHECK2(whichChannel, INT, VOID);
+	int channel = whichChannel.u.i;
+	if (whichChannel.type == VOID) {
+		channel = 1;
+	}
 
-	bool isBusy = sound->isChannelActive(whichChannel.u.i);
+	bool isBusy = sound->isChannelActive(channel);
 	Datum result;
 	result.type = INT;
 	result.u.i = isBusy ? 1 : 0;


### PR DESCRIPTION
Horror Tour 2 occasionally calls this with one void argument. It looks like a bug in the original game, but one that original Director doesn't crash on.

It's usually called correctly, but there's a couple places where it ends up being called with a `void` argument.

```
[   16] c_argcpush 1
[   18] cb_call "soundBusy"
```

Not sure if simply hardcoding channel 1 is the right approach though.