### PR TITLE
SURFACESDL: Move the AspectRatio class into the graphics manager class

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -78,7 +78,7 @@ const OSystem::GraphicsMode s_supportedStretchModes[] = {
 };
 #endif
 
-AspectRatio::AspectRatio(int w, int h) {
+SurfaceSdlGraphicsManager::AspectRatio::AspectRatio(int w, int h) {
 	// TODO : Validation and so on...
 	// Currently, we just ensure the program don't instantiate non-supported aspect ratios
 	_kw = w;
@@ -86,7 +86,7 @@ AspectRatio::AspectRatio(int w, int h) {
 }
 
 #if defined(USE_ASPECT)
-static AspectRatio getDesiredAspectRatio() {
+SurfaceSdlGraphicsManager::AspectRatio SurfaceSdlGraphicsManager::getDesiredAspectRatio() {
 	const size_t AR_COUNT = 4;
 	const char *desiredAspectRatioAsStrings[AR_COUNT] = {	"auto",				"4/3",				"16/9",				"16/10" };
 	const AspectRatio desiredAspectRatios[AR_COUNT] = {		AspectRatio(0, 0),	AspectRatio(4,3),	AspectRatio(16,9),	AspectRatio(16,10) };

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -44,18 +44,6 @@ enum {
 };
 
 
-class AspectRatio {
-	int _kw, _kh;
-public:
-	AspectRatio() { _kw = _kh = 0; }
-	AspectRatio(int w, int h);
-
-	bool isAuto() const { return (_kw | _kh) == 0; }
-
-	int kw() const { return _kw; }
-	int kh() const { return _kh; }
-};
-
 /**
  * SDL graphics manager
  */
@@ -166,6 +154,20 @@ protected:
 	void updateOSD();
 	void drawOSD();
 #endif
+
+	class AspectRatio {
+		int _kw, _kh;
+	public:
+		AspectRatio() { _kw = _kh = 0; }
+		AspectRatio(int w, int h);
+
+		bool isAuto() const { return (_kw | _kh) == 0; }
+
+		int kw() const { return _kw; }
+		int kh() const { return _kh; }
+	};
+
+	static AspectRatio getDesiredAspectRatio();
 
 	bool gameNeedsAspectRatioCorrection() const override {
 		return _videoMode.aspectRatioCorrection;


### PR DESCRIPTION
This moves the class definition out of the global namespace.