### PR TITLE
BACKENDS: SDL: Use null mixer if audio initialization fails

### DIFF
--- a/backends/mixer/mixer.h
+++ b/backends/mixer/mixer.h
@@ -55,6 +55,11 @@ public:
 	 */
 	virtual int resumeAudio() = 0;
 
+	/**
+	 * Returns true if this is a null device and won't output any audio.
+	 */
+	virtual bool isNullDevice() const { return false; }
+
 protected:
 	/** The mixer implementation */
 	Audio::MixerImpl *_mixer;

--- a/backends/mixer/null/null-mixer.cpp
+++ b/backends/mixer/null/null-mixer.cpp
@@ -53,6 +53,10 @@ int NullMixerManager::resumeAudio() {
 	return 0;
 }
 
+bool NullMixerManager::isNullDevice() const {
+	return true;
+}
+
 void NullMixerManager::update(uint8 callbackPeriod) {
 	if (_audioSuspended) {
 		return;

--- a/backends/mixer/null/null-mixer.h
+++ b/backends/mixer/null/null-mixer.h
@@ -38,11 +38,13 @@ public:
 	NullMixerManager();
 	virtual ~NullMixerManager();
 
-	virtual void init();
+	void init();
 	void update(uint8 callbackPeriod = 10);
 
-	virtual void suspendAudio();
-	virtual int resumeAudio();
+	void suspendAudio() override;
+	int resumeAudio() override;
+
+	bool isNullDevice() const override;
 
 private:
 	uint32 _outputRate;

--- a/backends/mixer/sdl/sdl-mixer.h
+++ b/backends/mixer/sdl/sdl-mixer.h
@@ -33,6 +33,7 @@
  */
 class SdlMixerManager : public MixerManager {
 public:
+	SdlMixerManager();
 	virtual ~SdlMixerManager();
 
 	/**
@@ -79,6 +80,9 @@ protected:
 	 * by subclasses, so it invokes the non-static function callbackHandler()
 	 */
 	static void sdlCallback(void *this_, byte *samples, int len);
+
+	bool _isSubsystemInitialized;
+	bool _isAudioOpen;
 };
 
 #endif

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -190,6 +190,7 @@ MODULE_OBJS += \
 	graphics/sdl/sdl-graphics.o \
 	graphics/surfacesdl/surfacesdl-graphics.o \
 	mixer/sdl/sdl-mixer.o \
+	mixer/null/null-mixer.o \
 	mutex/sdl/sdl-mutex.o \
 	timer/sdl/sdl-timer.o
 

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -41,6 +41,7 @@
 #include "backends/audiocd/sdl/sdl-audiocd.h"
 #endif
 
+#include "backends/mixer/null/null-mixer.h"
 #include "backends/events/default/default-events.h"
 #include "backends/events/sdl/legacy-sdl-events.h"
 #include "backends/keymapper/hardware-input.h"
@@ -303,6 +304,13 @@ void OSystem_SDL::initBackend() {
 		_mixerManager = new SdlMixerManager();
 		// Setup and start mixer
 		_mixerManager->init();
+
+		if (_mixerManager->getMixer() == nullptr) {
+			// Audio was unavailable or disabled
+			delete _mixerManager;
+			_mixerManager = new NullMixerManager();
+			_mixerManager->init();
+		}
 	}
 
 #ifdef ENABLE_EVENTRECORDER

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -364,6 +364,7 @@ void registerDefaults() {
 	ConfMan.registerDefault("joystick_num", 0);
 	ConfMan.registerDefault("confirm_exit", false);
 	ConfMan.registerDefault("disable_sdl_parachute", false);
+	ConfMan.registerDefault("disable_sdl_audio", false);
 
 	ConfMan.registerDefault("disable_display", false);
 	ConfMan.registerDefault("record_mode", "none");
@@ -820,6 +821,9 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 			END_OPTION
 
 			DO_LONG_OPTION_BOOL("disable-sdl-parachute")
+			END_OPTION
+
+			DO_LONG_OPTION_BOOL("disable-sdl-audio")
 			END_OPTION
 
 			DO_LONG_OPTION_BOOL("multi-midi")

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -820,11 +820,13 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 				}
 			END_OPTION
 
+#ifdef SDL_BACKEND
 			DO_LONG_OPTION_BOOL("disable-sdl-parachute")
 			END_OPTION
 
 			DO_LONG_OPTION_BOOL("disable-sdl-audio")
 			END_OPTION
+#endif
 
 			DO_LONG_OPTION_BOOL("multi-midi")
 			END_OPTION


### PR DESCRIPTION
I've attempted to clean this up but unfortunately untangling all of the cases where mixer readiness is not being checked is complicated.  EmulatedOPL doesn't do it, VideoDecoder doesn't do it, only 10 engines are actually checking `isReady` on the mixer because this is such a rare case.

However, it is a case that happens in the real world when the user has no audio output devices enabled.

Anything that fails to check immediately crashes in `playStream`.  Since there is a lot of code that isn't handling this correctly, I think it is better to use a null mixer fallback and add a way of detecting that it is a null device to MixerManager instead.