### PR TITLE
SCUMM: Colorize box debug rendering; debug draw objects like boxes

### DIFF
--- a/engines/scumm/debugger.h
+++ b/engines/scumm/debugger.h
@@ -35,6 +35,10 @@ public:
 private:
 	ScummEngine *_vm;
 
+	static const int DEBUG_COLOR_COUNT = 32;
+	int _nextColorIndex = 0;
+	int _debugColors[DEBUG_COLOR_COUNT];
+
 	void preEnter() override;
 	void postEnter() override;
 	void onFrame() override;
@@ -72,7 +76,9 @@ private:
 	bool Cmd_ResetCursors(int argc, const char **argv);
 
 	void printBox(int box);
-	void drawBox(int box);
+	void drawBox(int box, int color);
+	void drawRect(int x, int y, int width, int height, int color);
+	int getNextColor();
 };
 
 } // End of namespace Scumm


### PR DESCRIPTION
Draw boxes in scumm debugger with different colors to make them easier to separate visually. Also, draw object rectangles with different colors. See attached screenshots.

![color_boxes](https://github.com/scummvm/scummvm/assets/3799319/c0c0f644-91b9-44ff-97f4-410d525ff124)
![color_objects](https://github.com/scummvm/scummvm/assets/3799319/2c74e09f-a235-4cd8-b22a-9f0f84a8e8fb)
