### PR TITLE
 BASE: Enhance --dump-all-detection-entries command

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -1426,6 +1426,12 @@ static void listAudioDevices() {
 /** Dump MD5s from detection entries into STDOUT */
 static void dumpAllDetectionEntries() {
 	const PluginList &plugins = EngineMan.getPlugins();
+
+	printf("scummvm (\n");
+	printf("\tauthor scummvm\n");
+	printf("\tversion %s\n", gScummVMVersion);
+	printf(")\n\n");
+
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); iter++) {
 		const MetaEngineDetection &metaEngine = (*iter)->get<MetaEngineDetection>();
 		metaEngine.dumpDetectionEntries();

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -1428,8 +1428,8 @@ static void dumpAllDetectionEntries() {
 	const PluginList &plugins = EngineMan.getPlugins();
 
 	printf("scummvm (\n");
-	printf("\tauthor scummvm\n");
-	printf("\tversion %s\n", gScummVMVersion);
+	printf("\tauthor \"scummvm\"\n");
+	printf("\tversion \"%s\"\n", gScummVMVersion);
 	printf(")\n\n");
 
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); iter++) {

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -655,8 +655,8 @@ static bool getFilePropertiesIntern(uint md5Bytes, const AdvancedMetaEngine::Fil
 
 // Add backslash before double quotes (") and backslashes themselves (\)
 Common::String escapeString(const char *string) {
-	if (string == nullptr || Common::String(string) == "")
-		return "NULL";
+	if (string == nullptr)
+		return "";
 
 	Common::String res = "";
 
@@ -678,12 +678,12 @@ void AdvancedMetaEngineDetection::dumpDetectionEntries() const {
 		const char *title = ((const PlainGameDescriptor *)_gameIds)->description;
 
 		printf("game (\n");
-		printf("\tname %s\n", escapeString(g->gameId).c_str());
-		printf("\ttitle %s\n", escapeString(title).c_str());
-		printf("\textra %s\n", escapeString(g->extra).c_str());
-		printf("\tlanguage %s\n", escapeString(getLanguageLocale(g->language)).c_str());
-		printf("\tplatform %s\n", escapeString(getPlatformCode(g->platform)).c_str());
-		printf("\tsourcefile %s\n", escapeString(getName()).c_str());
+		printf("\tname \"%s\"\n", escapeString(g->gameId).c_str());
+		printf("\ttitle \"%s\"\n", escapeString(title).c_str());
+		printf("\textra \"%s\"\n", escapeString(g->extra).c_str());
+		printf("\tlanguage \"%s\"\n", escapeString(getLanguageLocale(g->language)).c_str());
+		printf("\tplatform \"%s\"\n", escapeString(getPlatformCode(g->platform)).c_str());
+		printf("\tsourcefile \"%s\"\n", escapeString(getName()).c_str());
 
 		for (auto fileDesc = g->filesDescriptions; fileDesc->fileName; fileDesc++) {
 			const char *fname = fileDesc->fileName;
@@ -693,7 +693,7 @@ void AdvancedMetaEngineDetection::dumpDetectionEntries() const {
 			Common::String md5Prefix = md5PropToGameFile(md5prop);
 			Common::String key = md5;
 			if (md5Prefix != "" && md5.find(':') == Common::String::npos)
-				key = md5Prefix + md5;
+				key = md5Prefix + ':' + md5;
 
 			printf("\trom ( name \"%s\" size %lld md5-%d %s )\n", escapeString(fname).c_str(), static_cast<long long int>(fsize), _md5Bytes, key.c_str());
 		}

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -675,7 +675,10 @@ void AdvancedMetaEngineDetection::dumpDetectionEntries() const {
 
 	for (descPtr = _gameDescriptors; ((const ADGameDescription *)descPtr)->gameId != nullptr; descPtr += _descItemSize) {
 		auto g = ((const ADGameDescription *)descPtr);
-		const char *title = ((const PlainGameDescriptor *)_gameIds)->description;
+		const PlainGameDescriptor *gameDesc = findPlainGameDescriptor(g->gameId, _gameIds);
+		const char *title = "";
+		if (gameDesc != 0)
+			title = gameDesc->description;
 
 		printf("game (\n");
 		printf("\tname \"%s\"\n", escapeString(g->gameId).c_str());
@@ -684,6 +687,7 @@ void AdvancedMetaEngineDetection::dumpDetectionEntries() const {
 		printf("\tlanguage \"%s\"\n", escapeString(getLanguageLocale(g->language)).c_str());
 		printf("\tplatform \"%s\"\n", escapeString(getPlatformCode(g->platform)).c_str());
 		printf("\tsourcefile \"%s\"\n", escapeString(getName()).c_str());
+		printf("\tengine \"%s\"\n", escapeString(getEngineName()).c_str());
 
 		for (auto fileDesc = g->filesDescriptions; fileDesc->fileName; fileDesc++) {
 			const char *fname = fileDesc->fileName;


### PR DESCRIPTION
 - Add a header part for detection by the parser running on the server that checks for file integrity.
 - Add some extra metadata - engine description
 - NULL values are dumped as empty strings delimited by quotes `""`
 - Fix AD Flags
 - Fix game title

Limited to engines using AdvancedDetector.

Original PR is here: #5131 
