### PR TITLE
GUI: EditableWidget: Clear selection when handling backspace/delete

### DIFF
--- a/gui/widgets/editable.cpp
+++ b/gui/widgets/editable.cpp
@@ -261,6 +261,7 @@ bool EditableWidget::handleKeyDown(Common::KeyState state) {
 			deleteIndex--;
 			_editString.deleteChar(deleteIndex);
 			setCaretPos(caretVisualPos(deleteIndex));
+			_selCaretPos = -1;
 			dirty = true;
 
 			sendCommand(_cmd, 0);
@@ -285,6 +286,8 @@ bool EditableWidget::handleKeyDown(Common::KeyState state) {
 		if (deleteIndex < (int)_editString.size()) {
 			_editString.deleteChar(deleteIndex);
 			setCaretPos(caretVisualPos(deleteIndex));
+			_selCaretPos = -1;
+			_selOffset = 0;
 			dirty = true;
 
 			sendCommand(_cmd, 0);


### PR DESCRIPTION
Clear the selection after deleting a character.

Not doing so can result in out-of-bounds reads in
`EditTextWidget::drawWidget()`, where `_selCaretPos` and `_selOffset` are used as offsets, and to a failed assertion when calling `EditableWidget::defaultKeyDownHandler()`:

```
gui/widgets/editable.cpp:566:
bool GUI::EditableWidget::setCaretPos(int):
Assertion `newPos >= 0 && newPos <= (int)_editString.size()' failed.
```

Fixes [#14584](https://bugs.scummvm.org/ticket/14584)