### PR TITLE
SWORD25: Add support for opaque blending modes

### DIFF
--- a/engines/sword25/gfx/dynamicbitmap.cpp
+++ b/engines/sword25/gfx/dynamicbitmap.cpp
@@ -56,7 +56,7 @@ bool DynamicBitmap::createRenderedImage(uint width, uint height) {
 	_originalWidth = _width = width;
 	_originalHeight = _height = height;
 
-	_image->setIsTransparent(false);
+	_image->setAlphaType(Graphics::ALPHA_OPAQUE);
 	_isSolid = true;
 
 	return result;

--- a/engines/sword25/gfx/image/renderedimage.h
+++ b/engines/sword25/gfx/image/renderedimage.h
@@ -104,17 +104,17 @@ public:
 		return true;
 	}
 
-	void setIsTransparent(bool isTransparent) { _isTransparent = isTransparent; }
-	bool isSolid() const override { return !_isTransparent; }
+	void setAlphaType(Graphics::AlphaType alphaType) { _alphaType = alphaType; }
+	bool isSolid() const override { return _alphaType == Graphics::ALPHA_OPAQUE; }
 
 private:
 	Graphics::ManagedSurface _surface;
+	Graphics::AlphaType _alphaType;
 	bool _doCleanup;
-	bool _isTransparent;
 
 	Graphics::ManagedSurface *_backSurface;
 
-	void checkForTransparency();
+	Graphics::AlphaType checkForTransparency() const;
 };
 
 } // End of namespace Sword25


### PR DESCRIPTION
This should provide a performance advantage when playing Theora videos, which don't provide an alpha channel. A potential bug was also fixed with the existing code - `checkForTransparency()` was only run on little endian CPUs, where it would incorrectly examine the red component of each pixel instead of the alpha component.