### PR TITLE
SCUMM: HE: Fix initialization of mixer channels

### DIFF
--- a/engines/scumm/he/mixer_he.cpp
+++ b/engines/scumm/he/mixer_he.cpp
@@ -274,9 +274,6 @@ int32 HEMixer::matchOffsetToSongId(int32 offset) {
 /* --- SOFTWARE MIXER --- */
 
 bool HEMixer::mixerInitMyMixerSubSystem() {
-	// Init the channel buffers, and kick start the mixer...
-	memset(_mixerChannels, 0, sizeof(_mixerChannels));
-
 	for (int i = 0; i < MIXER_MAX_CHANNELS; i++) {
 		_mixerChannels[i].stream = Audio::makeQueuingAudioStream(MIXER_DEFAULT_SAMPLE_RATE, false);
 		_mixer->playStream(

--- a/engines/scumm/he/mixer_he.h
+++ b/engines/scumm/he/mixer_he.h
@@ -132,20 +132,20 @@ protected:
 		Audio::SoundHandle handle;
 		Audio::QueuingAudioStream *stream = nullptr;
 		Common::File *fileHandle = nullptr;
-		int number;
-		int volume;
-		int frequency;
-		int globType;
-		int globNum;
-		int callbackID;
-		int endSampleAdjustment;
-		uint32 lastReadPosition;
-		uint32 initialSpoolingFileOffset;
-		uint32 sampleLen;
-		uint32 dataOffset;
-		uint32 flags;
-		bool callbackOnNextFrame;
-		bool isUsingStreamOverride;
+		int number = 0;
+		int volume = 0;
+		int frequency = 0;
+		int globType = 0;
+		int globNum = 0;
+		int callbackID = 0;
+		int endSampleAdjustment = 0;
+		uint32 lastReadPosition = 0;
+		uint32 initialSpoolingFileOffset = 0;
+		uint32 sampleLen = 0;
+		uint32 dataOffset = 0;
+		uint32 flags = 0;
+		bool callbackOnNextFrame = false;
+		bool isUsingStreamOverride = false;
 		byte *residualData = nullptr; // For early callbacks
 	};
 


### PR DESCRIPTION
Detected by GCC 13:
```
mixer_he.cpp:278:15: warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct Scumm::HEMixer::HEMixerChannel'; use assignment or value-initialization instead [-Wclass-memaccess]
  278 |         memset(_mixerChannels, 0, sizeof(_mixerChannels));
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
