### PR TITLE
IOS7: Ensure that the NEON code is enabled

### DIFF
--- a/backends/platform/ios7/ios7_osys_main.cpp
+++ b/backends/platform/ios7/ios7_osys_main.cpp
@@ -162,6 +162,11 @@ bool OSystem_iOS7::hasFeature(Feature f) {
 	case kFeatureTouchscreen:
 		return true;
 
+#if defined(__ARM_NEON__) || defined(__aarch64__)
+	case kFeatureCpuNEON:
+		return true; // If NEON can be used in this file, assume it's always available.
+#endif
+
 	default:
 		return ModularGraphicsBackend::hasFeature(f);
 	}

--- a/configure
+++ b/configure
@@ -3664,6 +3664,7 @@ if test -n "$_host"; then
 			_backend="ios7"
 			_seq_midi=no
 			_timidity=no
+			_ext_neon=yes
 			;;
 		kos32)
 			# neither pkg-config nor *-config work, so we setup everything manually


### PR DESCRIPTION
This has not been tested. `create_project` will also need to be updated to ensure that `SCUMMVM_NEON` is defined for ARM targets (and `SCUMMVM_SSE2` and `SCUMMVM_AVX2` for x86 targets).