### PR TITLE
PINK: Disable the Songs entry from the demo menu

### DIFF
--- a/engines/pink/gui.cpp
+++ b/engines/pink/gui.cpp
@@ -179,6 +179,16 @@ void PinkEngine::initMenu() {
 
 	Graphics::MacMenuSubMenu *subMenu = _menu->getSubmenu(nullptr, 0);
 	if (subMenu) {
+
+		if (isPerilDemo()) {
+			// From the first submenu ("Game"), disable the (zero indexed) item 5 ("Songs").
+			// Use setEnabled() rather than removeMenuItem() since the latter removes the item
+			// out of the list changing the index for the items that follow.
+			// The effect is that "Songs" will be greyed out for the demo, since it's not available for it.
+			// The original demo does not have the "Songs" item in the menu at all.
+			_menu->setEnabled( _menu->getSubMenuItem(_menu->getMenuItem(0), 5), false);
+		}
+
 		SaveStateList saves = listSaves();
 		if (!saves.empty()) {
 			_menu->removeMenuItem(subMenu, kRecentSaveId);
@@ -228,6 +238,7 @@ void PinkEngine::executeMenuCommand(uint id) {
 	case kExitAction:
 		openMainMenuDialog();
 		break;
+
 	case kSongsAction:
 		initModule("Muzik", "", nullptr);
 		break;

--- a/engines/pink/pink.cpp
+++ b/engines/pink/pink.cpp
@@ -51,6 +51,9 @@ PinkEngine::PinkEngine(OSystem *system, const ADGameDescription *desc)
 	SearchMan.addSubDirectoryMatching(gameDataDir, "install");
 
 	g_paletteLookup = new Graphics::PaletteLookup;
+
+	_isPeril = !strcmp(_desc->gameId, kPeril);
+	_isPerilDemo = _isPeril  && (_desc->flags & ADGF_DEMO);
 }
 
 PinkEngine::~PinkEngine() {
@@ -314,7 +317,11 @@ void PinkEngine::pauseEngineIntern(bool pause) {
 }
 
 bool PinkEngine::isPeril() const {
-	return !strcmp(_desc->gameId, kPeril);
+	return _isPeril;
+}
+
+bool PinkEngine::isPerilDemo() const {
+	return _isPerilDemo;
 }
 
 }

--- a/engines/pink/pink.h
+++ b/engines/pink/pink.h
@@ -122,6 +122,7 @@ public:
 	void changeScene();
 
 	bool isPeril() const;
+	bool isPerilDemo() const;
 
 	void setVariable(Common::String &variable, Common::String &value);
 	bool checkValueOfVariable(const Common::String &variable, const Common::String &value) const;
@@ -176,6 +177,8 @@ private:
 	PDAMgr _pdaMgr;
 
 	const ADGameDescription *_desc;
+	bool _isPeril;
+	bool _isPerilDemo;
 };
 
 WARN_UNUSED_RESULT bool readSaveHeader(Common::InSaveFile &in, SaveStateDescriptor &desc, bool skipThumbnail = true);


### PR DESCRIPTION
This is aimed at and tested for the German Demo menu of Passport to Peril

In the original demo (ran with Windows 3.11), the menu item for "Songs" is missing from the menu. In this fix we disable it (greyed out) because the code for removing an item from the menu causes shifting of the subsequent menu items which leads to unreliable code and potential future bugs if it's not accounted for.

I should clarify that clicking on the Songs menu item in the demo crashes the engine with assert fault at https://github.com/scummvm/scummvm/blob/6c954858dfcf88b4ebb01f0b53cf183a38c3367a/engines/pink/file.cpp#L104

Potential issues to consider with this approach:
- Could there be other demos of Passport to Peril that support this Music item? This fix, as is, applies to any demo for Passport to Peril, and not specifically to the German demo.
- If there's a reason to want to match how the menu appears on the demo, then removeMenuItem() should be used, but moved to the end of the initMenu() method to avoid issues with the index shifting of the subsequent menu items. Also one of the menu horizontal separators (the one above, or the one below "Songs") will have to be removed as well.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
