### PR TITLE
SWORD1: Implement palette fades

### DIFF
--- a/engines/sword1/control.cpp
+++ b/engines/sword1/control.cpp
@@ -344,7 +344,7 @@ uint8 Control::runPanel() {
 	// Set up mouse
 	_mouse->controlPanel(true);
 
-	uint8 mode = 0, newMode = BUTTON_MAIN_PANEL;
+	uint8 mode = BUTTON_MAIN_PANEL, newMode = 0;
 	bool fullRefresh = false;
 	uint8 retVal = CONTROL_NOTHING_DONE;
 

--- a/engines/sword1/control.h
+++ b/engines/sword1/control.h
@@ -35,11 +35,13 @@ class MemoryWriteStreamDynamic;
 
 namespace Sword1 {
 
+class SwordEngine;
 class ObjectMan;
 class ResMan;
 class Mouse;
 class Music;
 class Sound;
+class Screen;
 
 #define SAVEGAME_HEADER MKTAG('B','S','_','1')
 #define SAVEGAME_VERSION 2
@@ -83,7 +85,7 @@ struct ButtonInfo {
 
 class Control {
 public:
-	Control(Common::SaveFileManager *saveFileMan, ResMan *pResMan, ObjectMan *pObjMan, OSystem *system, Mouse *pMouse, Sound *pSound, Music *pMusic);
+	Control(SwordEngine *vm, Common::SaveFileManager *saveFileMan, ResMan *pResMan, ObjectMan *pObjMan, OSystem *system, Mouse *pMouse, Sound *pSound, Music *pMusic, Screen *pScreen);
 	uint8 runPanel();
 	void doRestore();
 	void askForCd();
@@ -146,6 +148,7 @@ private:
 	bool loadCustomStrings(const char* filename);
 	uint8 _customStrings[20][43];
 	const uint8(*_lStrings)[43];
+	SwordEngine *_vm;
 	Common::SaveFileManager *_saveFileMan;
 	ObjectMan *_objMan;
 	ResMan *_resMan;
@@ -153,6 +156,7 @@ private:
 	Mouse *_mouse;
 	Music *_music;
 	Sound *_sound;
+	Screen *_screen;
 	uint8 *_font, *_redFont;
 	uint8 *_screenBuf;
 	Common::KeyState _keyPressed;

--- a/engines/sword1/control.h
+++ b/engines/sword1/control.h
@@ -42,6 +42,7 @@ class Mouse;
 class Music;
 class Sound;
 class Screen;
+class Logic;
 
 #define SAVEGAME_HEADER MKTAG('B','S','_','1')
 #define SAVEGAME_VERSION 2
@@ -85,7 +86,7 @@ struct ButtonInfo {
 
 class Control {
 public:
-	Control(SwordEngine *vm, Common::SaveFileManager *saveFileMan, ResMan *pResMan, ObjectMan *pObjMan, OSystem *system, Mouse *pMouse, Sound *pSound, Music *pMusic, Screen *pScreen);
+	Control(SwordEngine *vm, Common::SaveFileManager *saveFileMan, ResMan *pResMan, ObjectMan *pObjMan, OSystem *system, Mouse *pMouse, Sound *pSound, Music *pMusic, Screen *pScreen, Logic *pLogic);
 	uint8 runPanel();
 	void doRestore();
 	void askForCd();
@@ -157,6 +158,7 @@ private:
 	Music *_music;
 	Sound *_sound;
 	Screen *_screen;
+	Logic *_logic;
 	uint8 *_font, *_redFont;
 	uint8 *_screenBuf;
 	Common::KeyState _keyPressed;

--- a/engines/sword1/eventman.cpp
+++ b/engines/sword1/eventman.cpp
@@ -51,6 +51,8 @@ void EventManager::checkForEvent(Object *compact) {
 					    compact->o_event_list[objCnt].o_event_script;
 					compact->o_tree.o_script_pc[compact->o_tree.o_script_level] =
 					    compact->o_event_list[objCnt].o_event_script;
+
+					break;
 				}
 			}
 	}

--- a/engines/sword1/logic.cpp
+++ b/engines/sword1/logic.cpp
@@ -990,7 +990,7 @@ int Logic::fnPause(Object *cpt, int32 id, int32 pause, int32 d, int32 e, int32 f
 }
 
 int Logic::fnPauseSeconds(Object *cpt, int32 id, int32 pause, int32 d, int32 e, int32 f, int32 z, int32 x) {
-	cpt->o_pause = pause * FRAME_RATE;
+	cpt->o_pause = pause * PAUSE_FRAME_RATE;
 	cpt->o_logic = LOGIC_pause;
 	return SCRIPT_STOP;
 }

--- a/engines/sword1/logic.cpp
+++ b/engines/sword1/logic.cpp
@@ -922,32 +922,33 @@ int Logic::fnFullSetFrame(Object *cpt, int32 id, int32 cdt, int32 spr, int32 fra
 }
 
 int Logic::fnFadeDown(Object *cpt, int32 id, int32 speed, int32 d, int32 e, int32 f, int32 z, int32 x) {
-	_screen->fadeDownPalette();
+	_vm->startFadePaletteDown(speed);
 	return SCRIPT_CONT;
 }
 
 int Logic::fnFadeUp(Object *cpt, int32 id, int32 speed, int32 d, int32 e, int32 f, int32 z, int32 x) {
-	_screen->fadeUpPalette();
+	_vm->startFadePaletteUp(speed);
 	return SCRIPT_CONT;
 }
 
 int Logic::fnCheckFade(Object *cpt, int32 id, int32 c, int32 d, int32 e, int32 f, int32 z, int32 x) {
-	_scriptVars[RETURN_VALUE] = (uint8)_screen->stillFading();
+	_scriptVars[RETURN_VALUE] = _screen->stillFading();
 	return SCRIPT_CONT;
 }
 
 int Logic::fnSetSpritePalette(Object *cpt, int32 id, int32 spritePal, int32 d, int32 e, int32 f, int32 z, int32 x) {
-	_screen->fnSetPalette(184, 72, spritePal, false);
+	_screen->fnSetPalette(184, 72, spritePal);
 	return SCRIPT_CONT;
 }
 
 int Logic::fnSetWholePalette(Object *cpt, int32 id, int32 spritePal, int32 d, int32 e, int32 f, int32 z, int32 x) {
-	_screen->fnSetPalette(0, 256, spritePal, false);
+	_screen->fnSetPalette(0, 256, spritePal);
 	return SCRIPT_CONT;
 }
 
 int Logic::fnSetFadeTargetPalette(Object *cpt, int32 id, int32 spritePal, int32 d, int32 e, int32 f, int32 z, int32 x) {
-	_screen->fnSetPalette(0, 184, spritePal, true);
+	_screen->fnSetFadeTargetPalette(0, 184, spritePal, false);
+	_screen->fnSetFadeTargetPalette(0, 1, 0, true);
 	return SCRIPT_CONT;
 }
 

--- a/engines/sword1/logic.h
+++ b/engines/sword1/logic.h
@@ -53,6 +53,7 @@ class Logic;
 typedef int (Logic::*BSMcodeTable)(Object *, int32, int32, int32, int32, int32, int32, int32);
 
 class Logic {
+	friend class Control;
 public:
 	Logic(SwordEngine *vm, ObjectMan *pObjMan, ResMan *resMan, Screen *pScreen, Mouse *pMouse, Sound *pSound, Music *pMusic, Menu *pMenu, OSystem *system, Audio::Mixer *mixer);
 	~Logic();

--- a/engines/sword1/mouse.cpp
+++ b/engines/sword1/mouse.cpp
@@ -71,12 +71,10 @@ void Mouse::controlPanel(bool on) { // true on entering cpanel, false when leavi
 	if (on) {
 		savedPtrId = _currentPtrId;
 		_mouseOverride = true;
-		setLuggage(0, 0);
 		setPointer(MSE_POINTER, 0);
 	} else {
 		_currentPtrId = savedPtrId;
 		_mouseOverride = false;
-		setLuggage(_currentLuggageId, 0);
 		setPointer(_currentPtrId, 0);
 	}
 }

--- a/engines/sword1/screen.cpp
+++ b/engines/sword1/screen.cpp
@@ -1338,7 +1338,7 @@ void Screen::fnFlash(uint8 color) {
 		return;
 	}
 
-	_system->getPaletteManager()->setPalette(_currentPalette, 0, 1);
+	_system->getPaletteManager()->setPalette(targetColor, 0, 1);
 
 	if (color == FLASH_RED || color == FLASH_BLUE) {
 		// This is what the original did here to induce a small wait cycle

--- a/engines/sword1/screen.cpp
+++ b/engines/sword1/screen.cpp
@@ -210,9 +210,10 @@ void Screen::fnSetFadeTargetPalette(uint8 start, uint16 length, uint32 id, bool 
 	_resMan->resClose(id);
 }
 
-void Screen::fullRefresh() {
+void Screen::fullRefresh(bool soft) {
 	_fullRefresh = true;
-	_system->getPaletteManager()->setPalette(_targetPalette, 0, 256);
+	if (!soft)
+		_system->getPaletteManager()->setPalette(_targetPalette, 0, 256);
 }
 
 int16 Screen::stillFading() {

--- a/engines/sword1/screen.cpp
+++ b/engines/sword1/screen.cpp
@@ -227,47 +227,48 @@ int16 Screen::stillFading() {
 void Screen::fadePalette() {
 	_paletteFadeInfo.fadeCount++;
 
-	if (_paletteFadeInfo.fadeCount == _paletteFadeInfo.paletteIndex) {
-		_paletteFadeInfo.fadeCount = 0;
+	if (_paletteFadeInfo.fadeCount != _paletteFadeInfo.paletteIndex)
+		return;
 
-		if (_paletteFadeInfo.paletteStatus == NO_FADE)
-			return;
+	_paletteFadeInfo.fadeCount = 0;
 
-		// Set the whole palette to the current source.
-		// But first, remember that these are 6 bit values, and
-		// they have to be shifted left two times before using them.
-		byte outPal[256 * 3];
-		for (int i = 0; i < 256 * 3; i++) {
-			// Remember that we previously allowed the RGB values
-			// to go below zero? It's time to account for that;
-			// This contributes to producing the correct palette fading effect.
-			int8 curValueSigned = (int8)_paletteFadeInfo.srcPalette[i];
-			if (curValueSigned < 0)
-				curValueSigned = 0;
+	if (_paletteFadeInfo.paletteStatus == NO_FADE)
+		return;
 
-			outPal[i] = ((byte)curValueSigned) << 2;
-		}
+	// Set the whole palette to the current source.
+	// But first, remember that these are 6 bit values, and
+	// they have to be shifted left two times before using them.
+	byte outPal[256 * 3];
+	for (int i = 0; i < 256 * 3; i++) {
+		// Remember that we previously allowed the RGB values
+		// to go below zero? It's time to account for that;
+		// This contributes to producing the correct palette fading effect.
+		int8 curValueSigned = (int8)_paletteFadeInfo.srcPalette[i];
+		if (curValueSigned < 0)
+			curValueSigned = 0;
 
-		_system->getPaletteManager()->setPalette((const byte *)outPal, 0, 256);
+		outPal[i] = ((byte)curValueSigned) << 2;
+	}
 
-		_paletteFadeInfo.paletteCount--;
+	_system->getPaletteManager()->setPalette((const byte *)outPal, 0, 256);
 
-		if (_paletteFadeInfo.paletteCount == 0) {
-			_paletteFadeInfo.paletteStatus = NO_FADE;
-		} else {
-			if (_paletteFadeInfo.paletteStatus == FADE_DOWN) {
-				// Fade down
-				for (int i = 0; i < 256 * 3; i++) {
-					if (_paletteFadeInfo.srcPalette[i] > 0)
-						_paletteFadeInfo.srcPalette[i]--;
-				}
-			} else if (_paletteFadeInfo.paletteStatus == FADE_UP) {
-				// Fade up
-				for (int i = 0; i < 256 * 3; i++) {
-					// Remember, we might have previously obtained negative values!
-					if ((int8)_paletteFadeInfo.srcPalette[i] < (int8)_paletteFadeInfo.dstPalette[i]) {
-						_paletteFadeInfo.srcPalette[i]++;
-					}
+	_paletteFadeInfo.paletteCount--;
+
+	if (_paletteFadeInfo.paletteCount == 0) {
+		_paletteFadeInfo.paletteStatus = NO_FADE;
+	} else {
+		if (_paletteFadeInfo.paletteStatus == FADE_DOWN) {
+			// Fade down
+			for (int i = 0; i < 256 * 3; i++) {
+				if (_paletteFadeInfo.srcPalette[i] > 0)
+					_paletteFadeInfo.srcPalette[i]--;
+			}
+		} else if (_paletteFadeInfo.paletteStatus == FADE_UP) {
+			// Fade up
+			for (int i = 0; i < 256 * 3; i++) {
+				// Remember, we might have previously obtained negative values!
+				if ((int8)_paletteFadeInfo.srcPalette[i] < (int8)_paletteFadeInfo.dstPalette[i]) {
+					_paletteFadeInfo.srcPalette[i]++;
 				}
 			}
 		}

--- a/engines/sword1/screen.cpp
+++ b/engines/sword1/screen.cpp
@@ -191,12 +191,12 @@ void Screen::fnSetPalette(uint8 start, uint16 length, uint32 id) {
 }
 
 void Screen::fnSetFadeTargetPalette(uint8 start, uint16 length, uint32 id, bool toBlack) {
-	byte *rgbData = nullptr;
+	const uint8 *rgbData = nullptr;
 
 	if (toBlack) {
-		rgbData = const_cast<byte *>(_black);
+		rgbData = _black;
 	} else {
-		rgbData = (byte *) _resMan->openFetchRes(id);
+		rgbData = (const uint8 *) _resMan->openFetchRes(id);
 	}
 
 	if (SwordEngine::_systemVars.wantFade) {
@@ -1313,7 +1313,7 @@ void Screen::spriteClipAndSet(uint16 *pSprX, uint16 *pSprY, uint16 *pSprWidth, u
 }
 
 void Screen::fnFlash(uint8 color) {
-	const byte *targetColor = _white;
+	const uint8 *targetColor = _white;
 
 	switch (color) {
 	case FLASH_RED:
@@ -1344,7 +1344,11 @@ void Screen::fnFlash(uint8 color) {
 	if (color == FLASH_RED || color == FLASH_BLUE) {
 		// This is what the original did here to induce a small wait cycle
 		// to correctly display the color before it is turned back to black...
-		for (int i = 0; i < 20000; ++i);
+		//
+		// for (int i = 0; i < 20000; ++i);
+		//
+		// We induce a delay instead
+		_system->delayMillis(200);
 
 		_system->getPaletteManager()->setPalette(_black, 0, 1);
 	}

--- a/engines/sword1/screen.cpp
+++ b/engines/sword1/screen.cpp
@@ -163,10 +163,18 @@ void Screen::startFadePaletteUp(int speed) {
 		_paletteFadeInfo.fadeCount = 0;
 		_paletteFadeInfo.paletteStatus = FADE_UP;
 	} else {
-		_system->getPaletteManager()->setPalette(_currentPalette, 0, 256);
-
 		// Set up the source palette
 		memcpy((uint8 *)_paletteFadeInfo.srcPalette, (uint8 *)_currentPalette, 256 * 3);
+
+		// Remember: whenever we are showing the palette to the outside world
+		// we have to shift it, because these are 6-bit values!
+		uint8 shiftedPalette[768];
+
+		for (int i = 0; i < sizeof(shiftedPalette); i++) {
+			shiftedPalette[i] = _currentPalette[i] << 2;
+		}
+
+		_system->getPaletteManager()->setPalette(shiftedPalette, 0, 256);
 	}
 }
 

--- a/engines/sword1/screen.cpp
+++ b/engines/sword1/screen.cpp
@@ -215,7 +215,9 @@ void Screen::fnSetFadeTargetPalette(uint8 start, uint16 length, uint32 id, bool 
 		memcpy(_currentPalette + (start * 3), rgbData, length * 3);
 	}
 
-	_resMan->resClose(id);
+	if (!toBlack) {
+		_resMan->resClose(id);
+	}
 }
 
 void Screen::fullRefresh(bool soft) {

--- a/engines/sword1/screen.cpp
+++ b/engines/sword1/screen.cpp
@@ -300,6 +300,10 @@ void Screen::updateScreen() {
 		fnSetFadeTargetPalette(0, 184, _roomDefTable[_currentScreen].palettes[0]);
 		fnSetFadeTargetPalette(184, 72, _roomDefTable[_currentScreen].palettes[1]);
 		fnSetFadeTargetPalette(0, 1, 0, true);
+		// Bug #8636: Force color 255 to black
+		if (SwordEngine::isMac())
+			fnSetFadeTargetPalette(255, 1, 0, true);
+
 		startFadePaletteUp(1);
 		_updatePalette = false;
 	}

--- a/engines/sword1/screen.h
+++ b/engines/sword1/screen.h
@@ -76,6 +76,7 @@ public:
 	void clearScreen();
 	void useTextManager(Text *pTextMan);
 	void draw();
+	void initFadePaletteServer();
 
 	void quitScreen();
 	void newScreen(uint32 screen);
@@ -83,10 +84,12 @@ public:
 	void setScrolling(int16 offsetX, int16 offsetY);
 	void addToGraphicList(uint8 listId, uint32 objId);
 
-	void fadeDownPalette();
-	void fadeUpPalette();
-	void fnSetPalette(uint8 start, uint16 length, uint32 id, bool fadeUp);
-	bool stillFading();
+	void startFadePaletteDown(int speed);
+	void startFadePaletteUp(int speed);
+	void fadePalette();
+	void fnSetPalette(uint8 start, uint16 length, uint32 id);
+	void fnSetFadeTargetPalette(uint8 start, uint16 length, uint32 id, bool toBlack = false);
+	int16 stillFading();
 	void fullRefresh();
 
 	bool showScrollFrame();
@@ -95,11 +98,31 @@ public:
 
 	void fnSetParallax(uint32 screen, uint32 resId);
 	void fnFlash(uint8 color);
-	void fnBorder(uint8 color);
 
 	static void decompressHIF(uint8 *src, uint8 *dest);
 
 private:
+	// The original values are 6-bit RGB numbers, so they have to be shifted
+	const byte _white[3]  = { 63 << 2, 63 << 2, 63 << 2};
+	const byte _red[3]    = { 63 << 2, 0  << 2, 0  << 2};
+	const byte _blue[3]   = { 0  << 2, 0  << 2, 63 << 2};
+	const byte _yellow[3] = { 63 << 2, 63 << 2, 0  << 2};
+	const byte _green[3]  = { 0  << 2, 63 << 2, 0  << 2};
+	const byte _purple[3] = { 32 << 2, 0  << 2, 32 << 2};
+	const byte _black[3]  = { 0  << 2, 0  << 2, 0  << 2};
+	const byte _grey[3]   = { 32 << 2, 32 << 2, 32 << 2};
+
+	struct PaletteFadeInfo {
+		int16 paletteStatus;
+		int16 paletteIndex;
+		int16 paletteCount;
+		int16 fadeCount;
+		byte srcPalette[256 * 3];
+		byte dstPalette[256 * 3];
+	};
+
+	PaletteFadeInfo _paletteFadeInfo;
+
 	// for router debugging
 	void drawLine(uint16 x1, uint16 y1, uint16 x2, uint16 y2);
 	void vline(uint16 x, uint16 y1, uint16 y2);
@@ -125,7 +148,6 @@ private:
 	void decompressRLE0(uint8 *src, uint32 compSize, uint8 *dest);
 	void decompressTony(uint8 *src, uint32 compSize, uint8 *dest);
 	void fastShrink(uint8 *src, uint32 width, uint32 height, uint32 scale, uint8 *dest);
-	void fadePalette();
 
 	void flushPsxCache();
 
@@ -158,10 +180,7 @@ private:
 
 	uint8 _targetPalette[256 * 3];
 	uint8 _currentPalette[256 * 3]; // for fading
-	uint8 _fadingStep;
-	int8  _fadingDirection; // 1 for fade up, -1 for fade down
-	bool _isBlack; // if the logic already faded down the palette, this is set to show the
-	               // mainloop that no further fading is necessary.
+	uint8 _zeroPalette[256 * 3];
 };
 
 } // End of namespace Sword1

--- a/engines/sword1/screen.h
+++ b/engines/sword1/screen.h
@@ -90,7 +90,7 @@ public:
 	void fnSetPalette(uint8 start, uint16 length, uint32 id);
 	void fnSetFadeTargetPalette(uint8 start, uint16 length, uint32 id, bool toBlack = false);
 	int16 stillFading();
-	void fullRefresh();
+	void fullRefresh(bool soft = false);
 
 	bool showScrollFrame();
 	void updateScreen();

--- a/engines/sword1/screen.h
+++ b/engines/sword1/screen.h
@@ -103,22 +103,22 @@ public:
 
 private:
 	// The original values are 6-bit RGB numbers, so they have to be shifted
-	const byte _white[3]  = { 63 << 2, 63 << 2, 63 << 2};
-	const byte _red[3]    = { 63 << 2, 0  << 2, 0  << 2};
-	const byte _blue[3]   = { 0  << 2, 0  << 2, 63 << 2};
-	const byte _yellow[3] = { 63 << 2, 63 << 2, 0  << 2};
-	const byte _green[3]  = { 0  << 2, 63 << 2, 0  << 2};
-	const byte _purple[3] = { 32 << 2, 0  << 2, 32 << 2};
-	const byte _black[3]  = { 0  << 2, 0  << 2, 0  << 2};
-	const byte _grey[3]   = { 32 << 2, 32 << 2, 32 << 2};
+	const uint8 _white[3]  = { 63 << 2, 63 << 2, 63 << 2};
+	const uint8 _red[3]    = { 63 << 2, 0  << 2, 0  << 2};
+	const uint8 _blue[3]   = { 0  << 2, 0  << 2, 63 << 2};
+	const uint8 _yellow[3] = { 63 << 2, 63 << 2, 0  << 2};
+	const uint8 _green[3]  = { 0  << 2, 63 << 2, 0  << 2};
+	const uint8 _purple[3] = { 32 << 2, 0  << 2, 32 << 2};
+	const uint8 _black[3]  = { 0  << 2, 0  << 2, 0  << 2};
+	const uint8 _grey[3]   = { 32 << 2, 32 << 2, 32 << 2};
 
 	struct PaletteFadeInfo {
 		int16 paletteStatus;
 		int16 paletteIndex;
 		int16 paletteCount;
 		int16 fadeCount;
-		byte srcPalette[256 * 3];
-		byte dstPalette[256 * 3];
+		uint8 srcPalette[256 * 3];
+		uint8 dstPalette[256 * 3];
 	};
 
 	PaletteFadeInfo _paletteFadeInfo;

--- a/engines/sword1/sound.cpp
+++ b/engines/sword1/sound.cpp
@@ -199,6 +199,9 @@ int Sound::addToQueue(int32 fxNo) {
 }
 
 void Sound::engine() {
+	// TODO: FX fading step
+
+
 	// first of all, add any random sfx to the queue...
 	for (uint16 cnt = 0; cnt < TOTAL_FX_PER_ROOM; cnt++) {
 		uint16 fxNo = _roomsFixedFx[Logic::_scriptVars[SCREEN]][cnt];

--- a/engines/sword1/sound.h
+++ b/engines/sword1/sound.h
@@ -79,6 +79,7 @@ enum CowMode {
 
 class Sound {
 	friend class SwordConsole;
+	friend class Control;
 public:
 	Sound(Audio::Mixer *mixer, ResMan *pResMan);
 	~Sound();

--- a/engines/sword1/sword1.cpp
+++ b/engines/sword1/sword1.cpp
@@ -779,11 +779,17 @@ uint8 SwordEngine::mainLoop() {
 }
 
 void SwordEngine::waitForFade() {
+	uint32 startTime = _system->getMillis();
 	while (_screen->stillFading()) { // This indirectly also waits for FX to be faded
 		if (_vblCount >= _rate)
 			_vblCount = 0;
 
 		pollInput(0);
+
+		// In the remote event that this wait cycle gets
+		// stuck during debugging, trigger a timeout
+		if (_system->getMillis() - startTime > 2000)
+			break;
 	}
 }
 

--- a/engines/sword1/sword1.cpp
+++ b/engines/sword1/sword1.cpp
@@ -117,6 +117,8 @@ Common::Error SwordEngine::init() {
 	_systemVars.realLanguage = Common::parseLanguage(ConfMan.get("language"));
 	_systemVars.isLangRtl = false;
 	_systemVars.debugMode = (gDebugLevel >= 0);
+	_systemVars.slowMode = false;
+	_systemVars.fastMode = false;
 
 	switch (_systemVars.realLanguage) {
 	case Common::DE_DEU:
@@ -275,30 +277,30 @@ uint8 SwordEngine::checkKeys() {
 			switch (_keyPressed.keycode) {
 			case Common::KEYCODE_1: // Slow mode
 				{
-					if (_slowMode) {
-						_slowMode = false;
+					if (_systemVars.slowMode) {
+						_systemVars.slowMode = false;
 						_targetFrameTime = DEFAULT_FRAME_TIME; // 12.5Hz
 					} else {
-						_slowMode = true;
+						_systemVars.slowMode = true;
 						_targetFrameTime = SLOW_FRAME_TIME; // 2Hz
 					}
 
-					_fastMode = false; // For good measure...
+					_systemVars.fastMode = false; // For good measure...
 
 					_rate = _targetFrameTime / 10;
 				}
 				break;
 			case Common::KEYCODE_4: // Fast mode
 				{
-					if (_fastMode) {
-						_fastMode = false;
+					if (_systemVars.fastMode) {
+						_systemVars.fastMode = false;
 						_targetFrameTime = DEFAULT_FRAME_TIME; // 12.5Hz
 					} else {
-						_fastMode = true;
+						_systemVars.fastMode = true;
 						_targetFrameTime = FAST_FRAME_TIME; // 100Hz
 					}
 
-					_slowMode = false; // For good measure...
+					_systemVars.slowMode = false; // For good measure...
 
 					_rate = _targetFrameTime / 10;
 				}

--- a/engines/sword1/sword1.cpp
+++ b/engines/sword1/sword1.cpp
@@ -161,7 +161,7 @@ Common::Error SwordEngine::init() {
 	_logic->initialize();
 	_objectMan->initialize();
 	_mouse->initialize();
-	_control = new Control(this, _saveFileMan, _resMan, _objectMan, _system, _mouse, _sound, _music, _screen);
+	_control = new Control(this, _saveFileMan, _resMan, _objectMan, _system, _mouse, _sound, _music, _screen, _logic);
 
 	return Common::kNoError;
 }
@@ -259,13 +259,12 @@ uint8 SwordEngine::checkKeys() {
 		case Common::KEYCODE_F5:
 		case Common::KEYCODE_ESCAPE:
 			if ((Logic::_scriptVars[MOUSE_STATUS] & 1) && (Logic::_scriptVars[GEORGE_HOLDING_PIECE] == 0)) {
-				/*
-				 * saveGameFlag = 1;
-				 * snrStatus = 1;
-				*/
 				retCode = _control->runPanel();
-				if (retCode == CONTROL_NOTHING_DONE)
-					_screen->fullRefresh();
+				if (retCode == CONTROL_NOTHING_DONE) {
+					_screen->fullRefresh(true);
+					Logic::_scriptVars[NEW_PALETTE] = 1;
+				}
+
 			}
 			break;
 		default:

--- a/engines/sword1/sword1.cpp
+++ b/engines/sword1/sword1.cpp
@@ -867,13 +867,13 @@ void SwordEngine::fadePaletteStep() {
 void SwordEngine::startFadePaletteDown(int speed) {
 	_screen->startFadePaletteDown(speed);
 
-	// Fade audio here
+	// TODO: Fade audio here
 }
 
 void SwordEngine::startFadePaletteUp(int speed) {
 	_screen->startFadePaletteUp(speed);
 
-	// Fade audio here
+	// TODO: Fade audio here
 }
 
 static void vblCallback(void *refCon) {

--- a/engines/sword1/sword1.h
+++ b/engines/sword1/sword1.h
@@ -80,6 +80,8 @@ struct SystemVars {
 
 class SwordEngine : public Engine {
 	friend class SwordConsole;
+	friend class Screen;
+
 public:
 	SwordEngine(OSystem *syst, const ADGameDescription *gameDesc);
 	~SwordEngine() override;
@@ -102,6 +104,10 @@ public:
 	// Used by timer
 	void updateTopMenu();
 	void updateBottomMenu();
+	void fadePaletteStep();
+	void startFadePaletteDown(int speed);
+	void startFadePaletteUp(int speed);
+	void waitForFade();
 
 protected:
 	// Engine APIs

--- a/engines/sword1/sword1.h
+++ b/engines/sword1/sword1.h
@@ -88,11 +88,20 @@ public:
 
 	uint32 _features;
 
+	int _inTimer = -1; // Is the timer running?
+	int32 _vbl60HzUSecElapsed = 0; // 60 Hz counter for palette fades
+	int _vblCount = 0; // How many vblCallback calls have been made?
+	int _rate = 8;
+
 	bool mouseIsActive();
 
 	static bool isMac() { return _systemVars.platform == Common::kPlatformMacintosh; }
 	static bool isPsx() { return _systemVars.platform == Common::kPlatformPSX; }
 	static bool isWindows() { return _systemVars.platform == Common::kPlatformWindows ; }
+
+	// Used by timer
+	void updateTopMenu();
+	void updateBottomMenu();
 
 protected:
 	// Engine APIs
@@ -116,7 +125,7 @@ protected:
 		return Common::String::format("sword1.%03d", slot);
 	}
 private:
-	void delay(int32 amount);
+	void pollInput(uint32 delay);
 
 	void checkCdFiles();
 	void checkCd();
@@ -124,6 +133,9 @@ private:
 	void flagsToBool(bool *dest, uint8 flags);
 
 	void reinitRes(); //Reinits the resources after a GMM load
+
+	void installTimerRoutines();
+	void uninstallTimerRoutines();
 
 	uint8 mainLoop();
 

--- a/engines/sword1/sword1.h
+++ b/engines/sword1/sword1.h
@@ -76,6 +76,7 @@ struct SystemVars {
 	Common::Platform platform;
 	Common::Language realLanguage;
 	bool isLangRtl;
+	bool debugMode;
 };
 
 class SwordEngine : public Engine {
@@ -93,7 +94,10 @@ public:
 	int _inTimer = -1; // Is the timer running?
 	int32 _vbl60HzUSecElapsed = 0; // 60 Hz counter for palette fades
 	int _vblCount = 0; // How many vblCallback calls have been made?
-	int _rate = 8;
+	int _rate = DEFAULT_FRAME_TIME / 10;
+	int _targetFrameTime = DEFAULT_FRAME_TIME;
+	bool _slowMode = false;
+	bool _fastMode = false;
 
 	bool mouseIsActive();
 
@@ -132,6 +136,7 @@ protected:
 	}
 private:
 	void pollInput(uint32 delay);
+	uint8 checkKeys();
 
 	void checkCdFiles();
 	void checkCd();

--- a/engines/sword1/sword1.h
+++ b/engines/sword1/sword1.h
@@ -61,22 +61,23 @@ class Music;
 class Control;
 
 struct SystemVars {
-	bool    runningFromCd;
-	uint32  currentCD;          // starts at zero, then either 1 or 2 depending on section being played
-	uint32  justRestoredGame;   // see main() in sword.c & New_screen() in gtm_core.c
-
-	uint8   controlPanelMode;   // 1 death screen version of the control panel, 2 = successful end of game, 3 = force restart
-	bool    forceRestart;
-	bool    wantFade;           // when true => fade during scene change, else cut.
-	bool   playSpeech;
-	bool   showText;
-	uint8   language;
-	bool    isDemo;
-	bool    isSpanishDemo;
+	bool             runningFromCd;
+	uint32           currentCD;          // starts at zero, then either 1 or 2 depending on section being played
+	uint32           justRestoredGame;   // see main() in sword.c & New_screen() in gtm_core.c
+	uint8            controlPanelMode;   // 1 death screen version of the control panel, 2 = successful end of game, 3 = force restart
+	bool             forceRestart;
+	bool             wantFade;           // when true => fade during scene change, else cut.
+	bool             playSpeech;
+	bool             showText;
+	uint8            language;
+	bool             isDemo;
+	bool             isSpanishDemo;
 	Common::Platform platform;
 	Common::Language realLanguage;
-	bool isLangRtl;
-	bool debugMode;
+	bool             isLangRtl;
+	bool             debugMode;
+	bool             slowMode;
+	bool             fastMode;
 };
 
 class SwordEngine : public Engine {
@@ -96,8 +97,6 @@ public:
 	int _vblCount = 0; // How many vblCallback calls have been made?
 	int _rate = DEFAULT_FRAME_TIME / 10;
 	int _targetFrameTime = DEFAULT_FRAME_TIME;
-	bool _slowMode = false;
-	bool _fastMode = false;
 
 	bool mouseIsActive();
 

--- a/engines/sword1/sworddefs.h
+++ b/engines/sword1/sworddefs.h
@@ -28,7 +28,9 @@ namespace Sword1 {
 
 #define LOOPED 1
 
-#define FRAME_TIME            80  // 80ms, for exactly 12.5Hz
+#define DEFAULT_FRAME_TIME    80  // 80ms, for exactly 12.5Hz
+#define FAST_FRAME_TIME       10  // 10ms, for 100Hz
+#define SLOW_FRAME_TIME       500 // 500ms, for 2Hz
 #define PAUSE_FRAME_RATE      12  // This frame time is only used in fnPauseSeconds(), like for the original
 #define TIMER_RATE            100
 #define TIMER_USEC            1000000 / TIMER_RATE

--- a/engines/sword1/sworddefs.h
+++ b/engines/sword1/sworddefs.h
@@ -28,13 +28,18 @@ namespace Sword1 {
 
 #define LOOPED 1
 
-#define FRAME_RATE          12                      // number of frames per second (max rate)
-#define SCREEN_WIDTH        640
-#define SCREEN_DEPTH        400
-#define SCREEN_LEFT_EDGE    128
-#define SCREEN_RIGHT_EDGE   (128+SCREEN_WIDTH-1)
-#define SCREEN_TOP_EDGE     128
-#define SCREEN_BOTTOM_EDGE  (128+SCREEN_DEPTH-1)
+#define FRAME_TIME            80  // 80ms, for exactly 12.5Hz
+#define PAUSE_FRAME_RATE      12  // This frame time is only used in fnPauseSeconds(), like for the original
+#define TIMER_RATE            100
+#define TIMER_USEC            1000000 / TIMER_RATE
+#define PALETTE_FADE_RATE     60
+#define PALETTE_FADE_USEC     16667
+#define SCREEN_WIDTH          640
+#define SCREEN_DEPTH          400
+#define SCREEN_LEFT_EDGE      128
+#define SCREEN_RIGHT_EDGE     (128+SCREEN_WIDTH-1)
+#define SCREEN_TOP_EDGE       128
+#define SCREEN_BOTTOM_EDGE    (128+SCREEN_DEPTH-1)
 #define TYPE_FLOOR 1
 #define TYPE_MOUSE 2
 #define TYPE_SPRITE 3


### PR DESCRIPTION
Ahoy! This is the first one of a series of changes and PRs which aim at finishing and implementing all those things from the original Broken Sword 1 executable which we are currently missing in our implementation. We have a great port of the engine and it would be a shame not to finish those last tasks; after all the devil is in the details 🙂

A full list can be seen here: https://wiki.scummvm.org/index.php?title=Sword1

## What am I looking at here?

In this first part I have implemented accurate palette fade-ins and fade-outs. In order to achieve this, one of the necessities was to fix the game timers, which was part of the to-do plan anyway.
Also, I implemented fast and slow modes from the original debug commands because at one point I was going insane debugging this 🙂 

All of this was implemented from the original code, using the DOS implementation as the reference (hence the usage of some kind of emulation of an vertical blank interrupt). Of course this is not the DOS code verbatim:
* Since we apparently don't have files for the WIN95 drivers but only for the DOS ones, I manually rewrote the palette fading routine from x86 asm to C++;
* The original DOS version uses the vblank timer for the top and bottom menus animations, palette fades and in-game frame limiter. In this implementation, the latter is not using the vblank simulation but instead uses our current timer system (with the correct frame time though). This is because our current system is more precise and smooth than an emulated vblank interrupt system (I've reluctantly tried and I'm glad that it failed; I don't want a threaded game timer 🙂).
* The code for fades in the main menu seems to work like it should, but it's adapted for our control panel implementation which is quite different from the original. Said implementation will be changed to match the source code in one of the next PRs for this project (because of the big amount of differences noted in the wiki link above). Needless to say, this future reimplementation will take into account all past contributions and changes (by our past and current devs) which don't have a match on the source code in our possession, for e.g. Mac and PSX support, etc.

Let me know how is it. The moment this is merged, work will be resumed on all the other tasks mentioned on the wiki. Alternatively, if you prefer a bigger PR with more stuff poured into it, let me know.