### PR TITLE
ULTIMA8: Add debugger command to benchmark shape frame painting

### DIFF
--- a/engines/ultima/ultima8/misc/debugger.h
+++ b/engines/ultima/ultima8/misc/debugger.h
@@ -183,6 +183,7 @@ private:
 	bool cmdInvertScreen(int argc, const char **argv);
 	bool cmdPlayMovie(int argc, const char **argv);
 	bool cmdPlayMusic(int argc, const char **argv);
+	bool cmdBenchmarkRenderSurface(int argc, const char **argv);
 
 #ifdef DEBUG
 	bool cmdVisualDebugPathfinder(int argc, const char **argv);


### PR DESCRIPTION
In efforts to be sure changes in #5288 do not adversely effect performance, I made a quick benchmark command for the GUI debugger.
I don't think I could easily use unit tests to benchmark this currently, although that may be worth investigating further. Is there a better way to do this type of test?

I think I would need a larger sampling to claim improvement in that PR, but here's the current stats.
RenderSurface::benchmark 1 2 50000

Current:
[2023-08-26 17:04:18] Paint: 233
[2023-08-26 17:04:18] PaintNoClip: 211
[2023-08-26 17:04:18] PaintTranslucent: 258
[2023-08-26 17:04:19] PaintMirrored: 267
[2023-08-26 17:04:23] PaintInvisible: 3975
[2023-08-26 17:04:26] PaintHighlight: 2626
[2023-08-26 17:04:30] PaintHighlightInvis: 4198

PR 5288:
[2023-08-26 16:44:04] Paint: 229
[2023-08-26 16:44:04] PaintNoClip: 198
[2023-08-26 16:44:04] PaintTranslucent: 257
[2023-08-26 16:44:05] PaintMirrored: 239
[2023-08-26 16:44:09] PaintInvisible: 3760
[2023-08-26 16:44:11] PaintHighlight: 2546
[2023-08-26 16:44:15] PaintHighlightInvis: 3989
