### PR TITLE
SCI: Improve debugger disassembly selector name context when push0, push1, push2 related opcodes are used.

### DIFF
--- a/engines/sci/engine/scriptdebug.cpp
+++ b/engines/sci/engine/scriptdebug.cpp
@@ -256,7 +256,14 @@ reg_t disassemble(EngineState *s, reg_t pos, const Object *obj, bool printBWTag,
 					separator = ", ";
 				}
 
-				if (opcode == op_pushi && param_value < kernel->getSelectorNamesSize()) {
+				// Give additional selector name context for all number push scenarios.
+				if (opcode == op_push0) {
+					debugN("%s%s", separator, kernel->getSelectorName(0).c_str());
+				} else if (opcode == op_push1) {
+					debugN("%s%s", separator, kernel->getSelectorName(1).c_str());
+				} else if (opcode == op_push2) {
+					debugN("%s%s", separator, kernel->getSelectorName(2).c_str());
+				} else if (opcode == op_pushi && param_value < kernel->getSelectorNamesSize()) {
 					debugN("%s%s", separator, kernel->getSelectorName(param_value).c_str());
 				}
 			}


### PR DESCRIPTION
Possible matching selector names are always shown in the debugger disassembly when a `pushi` opcode is encountered. This is great as it gives additional context when push is used for call/send related invocations.

It would be nice to additionally show the *possible* matching `selector` methods/properties when `push0`, `push1` or `push2` are encountered because selector names start at 0 so the disassembly never shows selectors 0 through 2 inclusive.

For example when doing a disassembly of LSL6: selector names are never shown for `y`, `x` or `view` because their selector values are: 0, 1, and 2 respectively for this games selector table.