### PR TITLE
CONFIGURE: Ignore --runstatedir

### DIFF
--- a/configure
+++ b/configure
@@ -1159,6 +1159,7 @@ for ac_option in $@; do
 	--includedir=*)                                      ;;
 	--libexecdir=*)                                      ;;
 	--localstatedir=*)                                   ;;
+	--runstatedir=*)                                     ;;
 	--sharedstatedir=*)                                  ;;
 	--infodir=*)                                         ;;
 	--disable-dependency-tracking)                       ;;


### PR DESCRIPTION
Silently ignore `--runstatedir` flag, which was introduced in Autoconf 2.70.