### PR TITLE
IOS7: Utilise Arm Neon optimisation 

### DIFF
--- a/backends/platform/ios7/ios7_osys_main.cpp
+++ b/backends/platform/ios7/ios7_osys_main.cpp
@@ -160,6 +160,9 @@ bool OSystem_iOS7::hasFeature(Feature f) {
 	case kFeatureOpenGLForGame:
 	case kFeatureShadersForGame:
 	case kFeatureTouchscreen:
+#ifdef SCUMMVM_NEON
+	case kFeatureCpuNEON:
+#endif
 		return true;
 
 	default:

--- a/configure
+++ b/configure
@@ -3665,6 +3665,7 @@ if test -n "$_host"; then
 			_backend="ios7"
 			_seq_midi=no
 			_timidity=no
+			_ext_neon=yes
 			;;
 		kos32)
 			# neither pkg-config nor *-config work, so we setup everything manually

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -413,6 +413,7 @@ int main(int argc, char *argv[]) {
 		// the files, according to the target.
 		setup.defines.push_back("MACOSX");
 		setup.defines.push_back("IPHONE");
+		setup.defines.push_back("SCUMMVM_NEON");
 	} else if (projectType == kProjectMSVC || projectType == kProjectCodeBlocks) {
 		setup.defines.push_back("WIN32");
 		backendWin32 = true;

--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -1396,13 +1396,18 @@ void XcodeProvider::setupBuildConfiguration(const BuildSetup &setup) {
 	ADD_SETTING_QUOTE_VAR(iPhone_Debug, "PROVISIONING_PROFILE[sdk=iphoneos*]", "");
 	ADD_SETTING(iPhone_Debug, "SDKROOT", "iphoneos");
 	ADD_SETTING_QUOTE(iPhone_Debug, "TARGETED_DEVICE_FAMILY", "1,2");
-	ValueList scummvmIOS_defines;
-	ADD_DEFINE(scummvmIOS_defines, "\"$(inherited)\"");
-	ADD_DEFINE(scummvmIOS_defines, "IPHONE");
-	ADD_DEFINE(scummvmIOS_defines, "IPHONE_IOS7");
+	ValueList scummvmIOSsimulator_defines;
+	ADD_DEFINE(scummvmIOSsimulator_defines, "\"$(inherited)\"");
+	ADD_DEFINE(scummvmIOSsimulator_defines, "IPHONE");
+	ADD_DEFINE(scummvmIOSsimulator_defines, "IPHONE_IOS7");
 	if (CONTAINS_DEFINE(setup.defines, "USE_SDL_NET"))
-		ADD_DEFINE(scummvmIOS_defines, "WITHOUT_SDL");
-	ADD_SETTING_LIST(iPhone_Debug, "GCC_PREPROCESSOR_DEFINITIONS", scummvmIOS_defines, kSettingsNoQuote | kSettingsAsList, 5);
+		ADD_DEFINE(scummvmIOSsimulator_defines, "WITHOUT_SDL");
+	ADD_SETTING_LIST(iPhone_Debug, "\"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*]\"", scummvmIOSsimulator_defines, kSettingsNoQuote | kSettingsAsList, 5);
+	// Separate iphoneos and iphonesimulator definitions since simulator running on x86_64
+	// hosts doesn't support NEON
+	ValueList scummvmIOS_defines = scummvmIOSsimulator_defines;
+	ADD_DEFINE(scummvmIOS_defines, "SCUMMVM_NEON");
+	ADD_SETTING_LIST(iPhone_Debug, "\"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphoneos*]\"", scummvmIOS_defines, kSettingsNoQuote | kSettingsAsList, 5);
 	ADD_SETTING(iPhone_Debug, "ASSETCATALOG_COMPILER_APPICON_NAME", "AppIcon");
 	ADD_SETTING(iPhone_Debug, "ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME", "LaunchImage");
 
@@ -1554,13 +1559,18 @@ void XcodeProvider::setupBuildConfiguration(const BuildSetup &setup) {
 	ADD_SETTING_QUOTE_VAR(tvOS_Debug, "PROVISIONING_PROFILE[sdk=appletvos*]", "");
 	ADD_SETTING(tvOS_Debug, "SDKROOT", "appletvos");
 	ADD_SETTING_QUOTE(tvOS_Debug, "TARGETED_DEVICE_FAMILY", "3");
-	ValueList scummvmTVOS_defines;
-	ADD_DEFINE(scummvmTVOS_defines, "\"$(inherited)\"");
-	ADD_DEFINE(scummvmTVOS_defines, "IPHONE");
-	ADD_DEFINE(scummvmTVOS_defines, "IPHONE_IOS7");
+	ValueList scummvmTVOSsimulator_defines;
+	ADD_DEFINE(scummvmTVOSsimulator_defines, "\"$(inherited)\"");
+	ADD_DEFINE(scummvmTVOSsimulator_defines, "IPHONE");
+	ADD_DEFINE(scummvmTVOSsimulator_defines, "IPHONE_IOS7");
 	if (CONTAINS_DEFINE(setup.defines, "USE_SDL_NET"))
-		ADD_DEFINE(scummvmTVOS_defines, "WITHOUT_SDL");
-	ADD_SETTING_LIST(tvOS_Debug, "GCC_PREPROCESSOR_DEFINITIONS", scummvmTVOS_defines, kSettingsNoQuote | kSettingsAsList, 5);
+		ADD_DEFINE(scummvmTVOSsimulator_defines, "WITHOUT_SDL");
+	ADD_SETTING_LIST(tvOS_Debug, "\"GCC_PREPROCESSOR_DEFINITIONS[sdk=appletvsimulator*]\"", scummvmTVOSsimulator_defines, kSettingsNoQuote | kSettingsAsList, 5);
+	// Separate appletvos and appletvsimulator definitions since simulator running on x86_64
+	// hosts doesn't support NEON
+	ValueList scummvmTVOS_defines = scummvmTVOSsimulator_defines;
+	ADD_DEFINE(scummvmTVOS_defines, "SCUMMVM_NEON");
+	ADD_SETTING_LIST(tvOS_Debug, "\"GCC_PREPROCESSOR_DEFINITIONS[sdk=appletvos*]\"", scummvmTVOS_defines, kSettingsNoQuote | kSettingsAsList, 5);
 	ADD_SETTING(tvOS_Debug, "ASSETCATALOG_COMPILER_APPICON_NAME", "AppIcon");
 	ADD_SETTING(tvOS_Debug, "ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME", "LaunchImage");
 	tvOS_Debug_Object->addProperty("name", "Debug", "", kSettingsNoValue);
@@ -1644,6 +1654,7 @@ void XcodeProvider::setupDefines(const BuildSetup &setup) {
 	REMOVE_DEFINE(_defines, "IPHONE");
 	REMOVE_DEFINE(_defines, "IPHONE_IOS7");
 	REMOVE_DEFINE(_defines, "SDL_BACKEND");
+	REMOVE_DEFINE(_defines, "SCUMMVM_NEON");
 	ADD_DEFINE(_defines, "CONFIG_H");
 	ADD_DEFINE(_defines, "UNIX");
 	ADD_DEFINE(_defines, "HAS_FSEEKO_OFFT_64");

--- a/engines/ags/lib/allegro/surface_neon.cpp
+++ b/engines/ags/lib/allegro/surface_neon.cpp
@@ -19,6 +19,7 @@
  *
  */
 
+#ifdef SCUMMVM_NEON
 #include <arm_neon.h>
 #include "ags/ags.h"
 #include "ags/globals.h"
@@ -917,3 +918,4 @@ template void BITMAP::drawNEON<false>(DrawInnerArgs &);
 template void BITMAP::drawNEON<true>(DrawInnerArgs &);
 
 } // namespace AGS3
+#endif // SCUMMVM_NEON

--- a/graphics/blit/blit-neon.cpp
+++ b/graphics/blit/blit-neon.cpp
@@ -19,6 +19,7 @@
  *
  */
 
+#ifdef SCUMMVM_NEON
 #include "common/scummsys.h"
 #include <arm_neon.h>
 
@@ -463,3 +464,4 @@ void BlendBlit::blitNEON(Args &args, const TSpriteBlendMode &blendMode, const Al
 }
 
 } // end of namespace Graphics
+#endif // SCUMMVM_NEON


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
This PR enables SCUMMVM_NEON for iOS/tvOS, simulators running on x86_64 excluded.
It also add extra preprocessor checks that ARM_NEON really is available if SCUMMVM_NEON is set.
To allow for Arm NEON optimisations SCUMMVM_NEON, __ARM_NEON__ or __ARM_NEON have to be defined.
Else it will bail out do use the default non-optimised functions.

Replaces https://github.com/scummvm/scummvm/pull/5286