### PR TITLE
GRAPHICS: Use crossBlit more for converting surfaces

### DIFF
--- a/graphics/blit.h
+++ b/graphics/blit.h
@@ -99,7 +99,6 @@ bool keyBlit(byte *dst, const byte *src,
  * @return			true if conversion completes successfully,
  *					false if there is an error.
  *
- * @note Blitting to a 3Bpp destination is not supported
  * @note This can convert a surface in place, regardless of the
  *       source and destination format, as long as there is enough
  *       space for the destination. The dstPitch / srcPitch ratio
@@ -127,7 +126,6 @@ bool crossBlit(byte *dst, const byte *src,
  * @return			true if conversion completes successfully,
  *					false if there is an error.
  *
- * @note Blitting to a 3Bpp destination is not supported
  * @note This can convert a surface in place, regardless of the
  *       source and destination format, as long as there is enough
  *       space for the destination. The dstPitch / srcPitch ratio

--- a/graphics/surface.h
+++ b/graphics/surface.h
@@ -374,7 +374,7 @@ public:
 	 */
 	Graphics::Surface *convertTo(const PixelFormat &dstFormat, const byte *srcPalette = 0, int srcPaletteCount = 0, const byte *dstPalette = 0, int dstPaletteCount = 0, DitherMethod method = kDitherFloyd) const;
 
-private:
+protected:
 	void ditherFloyd(const byte *srcPalette, int srcPaletteCount, Surface *dstSurf, const byte *dstPalette, int dstPaletteCount, DitherMethod method, const PixelFormat &dstFormat) const;
 
 public:

--- a/graphics/transparent_surface.h
+++ b/graphics/transparent_surface.h
@@ -128,7 +128,7 @@ struct TransparentSurface : public Graphics::Surface {
 	 */
 	TransparentSurface *rotoscale(const TransformStruct &transform, bool filtering = false) const;
 
-	TransparentSurface *convertTo(const PixelFormat &dstFormat, const byte *palette = 0) const;
+	TransparentSurface *convertTo(const PixelFormat &dstFormat, const byte *srcPalette = 0, int srcPaletteCount = 0, const byte *dstPalette = 0, int dstPaletteCount = 0, DitherMethod method = kDitherFloyd) const;
 
 	float getRatio() {
 		if (!w)


### PR DESCRIPTION
This reduces code duplication, and should help with performance to a degree (especially when converting 1bpp surfaces since we can reduce the amount of `RGBToColor` calls).