### PR TITLE
TEST: Improve tests

### DIFF
--- a/backends/platform/null/null.cpp
+++ b/backends/platform/null/null.cpp
@@ -77,7 +77,7 @@ typedef void (*sighandler_t)(int);
 
 class OSystem_NULL : public ModularMixerBackend, public ModularGraphicsBackend, Common::EventSource {
 public:
-	OSystem_NULL();
+	OSystem_NULL(bool silenceLogs);
 	virtual ~OSystem_NULL();
 
 	virtual void initBackend();
@@ -101,9 +101,11 @@ private:
 #elif defined(WIN32)
 	DWORD _startTime;
 #endif
+	bool _silenceLogs;
 };
 
-OSystem_NULL::OSystem_NULL() {
+OSystem_NULL::OSystem_NULL(bool silenceLogs) :
+	_silenceLogs(silenceLogs) {
 	#if defined(__amigaos4__)
 		_fsFactory = new AmigaOSFilesystemFactory();
 	#elif defined(__MORPHOS__)
@@ -228,6 +230,9 @@ void OSystem_NULL::quit() {
 }
 
 void OSystem_NULL::logMessage(LogMessageType::Type type, const char *message) {
+	if (_silenceLogs)
+		return;
+
 	FILE *output = 0;
 
 	if (type == LogMessageType::kInfo || type == LogMessageType::kDebug)
@@ -244,13 +249,13 @@ void OSystem_NULL::addSysArchivesToSearchSet(Common::SearchSet &s, int priority)
 	s.add("gui/themes", new Common::FSDirectory("gui/themes", 4), priority);
 }
 
-OSystem *OSystem_NULL_create() {
-	return new OSystem_NULL();
+OSystem *OSystem_NULL_create(bool silenceLogs) {
+	return new OSystem_NULL(silenceLogs);
 }
 
 #ifndef NULL_DRIVER_USE_FOR_TEST
 int main(int argc, char *argv[]) {
-	g_system = OSystem_NULL_create();
+	g_system = OSystem_NULL_create(false);
 	assert(g_system);
 
 	// Invoke the actual ScummVM main entry point:
@@ -262,7 +267,8 @@ int main(int argc, char *argv[]) {
 
 #else /* USE_NULL_DRIVER */
 
-OSystem *OSystem_NULL_create() {
+OSystem *OSystem_NULL_create(bool silenceLogs) {
+	(void)silenceLogs;
 	return NULL;
 }
 

--- a/test/common/str-helper.h
+++ b/test/common/str-helper.h
@@ -1,0 +1,23 @@
+#ifndef TEST_COMMON_HELPER_H
+#define TEST_COMMON_HELPER_H
+
+#include "common/str.h"
+
+namespace CxxTest
+{
+    CXXTEST_TEMPLATE_INSTANTIATION
+    class ValueTraits<const Common::String &>
+    {
+        ValueTraits &operator=( const ValueTraits & );
+		Common::String _str;
+
+    public:
+        ValueTraits( const Common::String &value ) : _str( value ) {}
+        ValueTraits( const ValueTraits &other ) : _str( other._str ) {}
+        const char *asString( void ) const { return _str.c_str(); }
+    };
+	CXXTEST_COPY_CONST_TRAITS( Common::String &);
+	CXXTEST_COPY_TRAITS( Common::String, const Common::String &);
+}
+
+#endif

--- a/test/common/str.h
+++ b/test/common/str.h
@@ -3,6 +3,8 @@
 #include "common/str.h"
 #include "common/ustr.h"
 
+#include "test/common/str-helper.h"
+
 class StringTestSuite : public CxxTest::TestSuite
 {
 	public:

--- a/test/null_osystem.cpp
+++ b/test/null_osystem.cpp
@@ -3,8 +3,16 @@
 #include "null_osystem.h"
 #include "../backends/platform/null/null.cpp"
 
+//#define DISPLAY_ERROR_MESSAGES
+
 void Common::install_null_g_system() {
-	g_system = OSystem_NULL_create();
+#ifdef DISPLAY_ERROR_MESSAGES
+	const bool silenceLogs = false;
+#else
+	const bool silenceLogs = true;
+#endif
+
+	g_system = OSystem_NULL_create(silenceLogs);
 }
 
 bool BaseBackend::setScaler(const char *name, int factor) {


### PR DESCRIPTION
This PR contains two things:
- it makes warnings silent by default in tests as the INI tests and blending are quite spammy while their output isn't really useful while just checking if tests are good.
- it also adds a pretty-printer for Common::String. This allows to display the string content instead of raw bytes of the class.