### PR TITLE
COMMON: Refactor ArchiveMember directory support

### DIFF
--- a/common/fs.h
+++ b/common/fs.h
@@ -106,8 +106,7 @@ public:
 	 * used (usually the root directory).
 	 */
 	explicit FSNode(const Path &path);
-
-	virtual ~FSNode() {}
+	~FSNode();
 
 	/**
 	 * Compare the name of this node to the name of another. Directories
@@ -223,7 +222,13 @@ public:
 	 * Or even replace isDirectory by a getType() method that can return values like
 	 * kDirNodeType, kFileNodeType, kInvalidNodeType.
 	 */
-	bool isDirectory() const;
+	bool isDirectory() const override;
+
+	/**
+	 * Adds the immediate children of this FSNode to a list, optionally matching a pattern.
+	 * Has no effect if this FSNode is not a directory.
+	 */
+	void listChildren(Common::ArchiveMemberList &childList, const char *pattern = nullptr) const override;
 
 	/**
 	 * Indicate whether the object referred by this node can be read from or not.
@@ -258,7 +263,7 @@ public:
 	 *
 	 * @return Pointer to the stream object, nullptr in case of a failure.
 	 */
-	SeekableReadStream *createReadStream() const override;
+	SeekableReadStream *createReadStream() const;
 
 	/**
 	 * Create a SeekableReadStream instance corresponding to an alternate stream
@@ -268,7 +273,7 @@ public:
 	 *
 	 * @return Pointer to the stream object, nullptr in case of a failure.
 	 */
-	SeekableReadStream *createReadStreamForAltStream(AltStreamType altStreamType) const override;
+	SeekableReadStream *createReadStreamForAltStream(AltStreamType altStreamType) const;
 
 	/**
 	 * Create a WriteStream instance corresponding to the file
@@ -409,6 +414,11 @@ public:
 	 * is needed for success.
 	 */
 	bool hasFile(const Path &path) const override;
+
+	/**
+	 * Check if a specified subpath is a directory.
+	 */
+	bool isPathDirectory(const Path &path) const override;
 
 	/**
 	 * Return a list of matching file names. Pattern can use GLOB wildcards.

--- a/common/str.cpp
+++ b/common/str.cpp
@@ -638,6 +638,7 @@ bool matchString(const char *str, const char *pat, bool ignoreCase, const char *
 	const char *p = nullptr;
 	const char *q = nullptr;
 	bool escaped = false;
+	bool noExclusions = (wildcardExclusions == nullptr || !*wildcardExclusions);
 
 	for (;;) {
 		if (wildcardExclusions && strchr(wildcardExclusions, *str)) {
@@ -662,8 +663,8 @@ bool matchString(const char *str, const char *pat, bool ignoreCase, const char *
 				p = nullptr;
 				q = nullptr;
 			}
-			// If pattern ended with * -> match
-			if (!*pat)
+			// If pattern ended with * and there are no exclusions -> match
+			if (!*pat && noExclusions)
 				return true;
 			break;
 

--- a/engines/sword25/package/packagemanager.cpp
+++ b/engines/sword25/package/packagemanager.cpp
@@ -272,36 +272,17 @@ int PackageManager::doSearch(Common::ArchiveMemberList &list, const Common::Stri
 
 		// Create a list of the matching names
 		for (Common::ArchiveMemberList::iterator it = memberList.begin(); it != memberList.end(); ++it) {
-			Common::String name;
-			bool matchType;
-
-			// FSNode->getName() returns only name of the file, without the directory
-			// getPath() returns full path in the FS. Thus, we're getting it and
-			// removing the root from it.
-			if (_extractedFiles) {
-				Common::FSNode *node = (Common::FSNode *)(it->get());
-
-				name = node->getPath().substr(_directoryName.size());
-
-				for (uint c = 0; c < name.size(); c++) {
-					if (name[c] == '\\')
-						name.replace(c, 1, "/");
-				}
-
-				matchType = (((typeFilter & PackageManager::FT_DIRECTORY) && node->isDirectory()) ||
-					((typeFilter & PackageManager::FT_FILE) && !node->isDirectory()));
-			} else {
-				name = (*it)->getName();
-				matchType = ((typeFilter & PackageManager::FT_DIRECTORY) && name.hasSuffix("/")) ||
-				((typeFilter & PackageManager::FT_FILE) && !name.hasSuffix("/"));
-			}
+			Common::Path name = (*it)->getPathInArchive();
+			bool isDirectory = (*it)->isDirectory();
+			bool matchType = (((typeFilter & PackageManager::FT_DIRECTORY) && isDirectory) ||
+							  ((typeFilter & PackageManager::FT_FILE) && !isDirectory));
 
 			if (matchType) {
 
 				// Do not add duplicate files
 				bool found = false;
 				for (Common::ArchiveMemberList::iterator it1 = list.begin(); it1 != list.end(); ++it1) {
-					if ((*it1)->getName() == name) {
+					if ((*it1)->getPathInArchive() == name) {
 						found = true;
 						break;
 					}
@@ -309,7 +290,7 @@ int PackageManager::doSearch(Common::ArchiveMemberList &list, const Common::Stri
 
 				if (!found) {
 					list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(name, *(*i)->archive)));
-					debug(9, "> %s", name.c_str());
+					debug(9, "> %s", name.toString().c_str());
 				}
 				num++;
 			}


### PR DESCRIPTION
This adds a few new functions:
- `Archive::isPathDirectory`: Returns true if a specified path is a directory
- `ArchiveMember:isDirectory`: Returns true if the archive member is a directory
- `ArchiveMember::listChildren`: Lists the children of an archive member

This also introduces some potentially-breaking functionality changes:
- `Common::String::matchString` will no longer match excluded characters with a trailing asterisk.  This was apparently unintentional, and causes `listMatchingMembers` and similar to not behave the same way for `FSDirectory` as it does for other archive types that support listing members.
- `ZipArchive` now strips trailing path separators from directory entries.  The directory detection code has also been updated to detect directory entries without trailing path separators from the external file attributes field.

Finally, it updates Sword 2.5's package manager to be compatible with this change.

Further testing is needed.