### PR TITLE
ENGINES: Show splash screens on 3D engines

### DIFF
--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -459,6 +459,12 @@ void initGraphics3d(int width, int height) {
 		g_system->setFeatureState(OSystem::kFeatureVSync, ConfMan.getBool("vsync")); // TODO: Replace this with initCommonGFX()
 		g_system->setStretchMode(ConfMan.get("stretch_mode").c_str()); // TODO: Replace this with initCommonGFX()
 	g_system->endGFXTransaction();
+
+	if (!splash && !GUI::GuiManager::instance()._launched) {
+		Common::Event event;
+		g_system->getEventManager()->pollEvent(event);
+		splashScreen();
+	}
 }
 
 void GUIErrorMessageWithURL(const Common::U32String &msg, const char *url) {


### PR DESCRIPTION
Without the below it shows the splash in the resolution `initGraphics3d()` was called with, there's probably a proper way to fix this but I'm not familiar enough with the code base.
```c++
Common::Event event;
g_system->getEventManager()->pollEvent(event);
```