### PR TITLE
TETRAEDGE: Prioritize language specific files

### DIFF
--- a/engines/tetraedge/te/te_core.cpp
+++ b/engines/tetraedge/te/te_core.cpp
@@ -216,13 +216,13 @@ Common::FSNode TeCore::findFile(const Common::Path &path) const {
 	};
 
 	const Common::Path langs[] = {
-		"",
 		language(),
 		"en",
 		"de-es-fr-it-en",
 		"en-es-fr-de-it",
 		"es-en-fr-de-it",
-		"de-en-es-fr-it"
+		"de-en-es-fr-it",
+		""
 	};
 
 	// Note: the audio files for a few videos have a weird path


### PR DESCRIPTION
This makes language specific files (have current language in path) take precendence over "global" files.
This will allow avoiding overriding game files when making fan translations (I will update the existing hebrew fan translation for this as well).

I also considered adding the following check in the loop afterwards, so if the directory does not contains current language it will not load it:
```diff
index b08fab55068..87df9745f6d 100644
--- a/engines/tetraedge/te/te_core.cpp
+++ b/engines/tetraedge/te/te_core.cpp
@@ -233,6 +233,8 @@ Common::FSNode TeCore::findFile(const Common::Path &path) const {

        for (int langtype = 0; langtype < ARRAYSIZE(langs); langtype++) {
                const Common::Path &lang = langs[langtype];
+              if (!lang.toString().contains(language()))
+                    continue;
                for (int i = 0; i < ARRAYSIZE(pathSuffixes); i++) {
                        const char *suffix = pathSuffixes[i];
```
But then considered perhaps some existing translation might use `en` as base language, so it should be excluded, and all other options in `langs` list contains `en` anyway, so the check will do nothing.

Thank you