### PR TITLE
GRAPHICS: Fix an incorrect bpp in SurfaceSdl when applying cursor mask

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -2050,7 +2050,7 @@ void SurfaceSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, 
 		if (format->aBits() > 0)
 			formatWithAlpha = *format;
 
-		const uint outBPP = format->bytesPerPixel;
+		const uint outBPP = formatWithAlpha.bytesPerPixel;
 
 		Common::Array<byte> maskedImage;
 		maskedImage.resize(numPixels * outBPP);


### PR DESCRIPTION
I found a small bug in SurfaceSdl's cursor masks, source bpp is wrongly taken as output bpp when creating the masked image (visible only if the source bpp is != 4).