### PR TITLE
AGS: Shared: Debugging: Fix outside the range of underlying type 'uint32' on out.h

### DIFF
--- a/engines/ags/shared/debugging/out.h
+++ b/engines/ags/shared/debugging/out.h
@@ -112,7 +112,7 @@ enum MessageType {
 
 // This enumeration is a list of common hard-coded groups, but more could
 // be added via debugging configuration interface (see 'debug/debug.h').
-enum CommonDebugGroup : uint32 {
+enum CommonDebugGroup : uint64 {
 	kDbgGroup_None = SIZE_MAX,
 	// Main debug group is for reporting general engine status and issues
 	kDbgGroup_Main = 0,


### PR DESCRIPTION
AGS: Shared: Debugging:  Fix outside the range of underlying type 'uint32' on out.h

Increase kDbgGroup_None size Max from uint32 size max to uint64 size max changing the type from uint32 to uint64

The change fixes the issue https://bugs.scummvm.org/ticket/14609 that reports an error: enumerator value '18446744073709551615' is outside the range of underlying type 'uint32' {aka 'unsigned int'} when building scummvm on odroid n2+ linux 4.9 EMUELEC.

thx
KR
