### PR TITLE
GUI: Increase position range for a slider value

### DIFF
--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -922,7 +922,7 @@ int SliderWidget::valueToPos(int value) {
 }
 
 int SliderWidget::posToValue(int pos) {
-	return (pos) * (_valueMax - _valueMin) / (_w - 1) + _valueMin;
+	return (((pos) * 2 * (_valueMax - _valueMin) / (_w - 1) + 1) / 2 + _valueMin);
 }
 
 #pragma mark -


### PR DESCRIPTION
This makes it so that half the space before and after a slider value is assigned to that value

Currently for sliders with small value range, the whole space between two consecutive values on the slider is "assigned" to the lower value. Hence, the only ways to set the slider to the highest value is to either use the mouse wheel scroll, or click and drag, or click at a pixel of the far edge of the slider, which is hard to do especially with direct touch interface. 

This PR addresses the final option, making it a bit easier to get the final value when using simple clicks or direct touch. It still uses integer division to get the slider value from the click position, but "divides" the space between two values in half, assigning the first half to the left (smaller) value and the right half to the right (higher).

This was inspired mainly for touchsreen interfaces where simple tap is the main form of interaction (and mouse wheel or click and drag may not be supported or more difficult to pull through).

For a quick test, test with the slider in launcher's grid view for "icons per row" (which goes from 1 to 12). 
On a mobile phone, you can also test in Global Options -> Control with the "Pointer Speed" slider (this was also reported in a tweet today), or the "Joy Deadzone" one.

For reference here's the tweet mentioning the issue: https://twitter.com/therealjbenam/status/1700121630972715165

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
