### PR TITLE
SHERLOCK: RT: Fix opcode 0xAE (cmdMouseOnOff())

### DIFF
--- a/engines/sherlock/events.cpp
+++ b/engines/sherlock/events.cpp
@@ -119,7 +119,6 @@ void Events::setCursor(const Graphics::Surface &src, int hotspotX, int hotspotY)
 
 		tempSurface.free();
 	}
-	showCursor();
 }
 
 void Events::setCursor(CursorId cursorId, const Common::Point &cursorPos, const Graphics::Surface &surface) {

--- a/engines/sherlock/sherlock.cpp
+++ b/engines/sherlock/sherlock.cpp
@@ -146,6 +146,8 @@ Common::Error SherlockEngine::run() {
 			_startupAutosave = true;
 	}
 
+	_events->showCursor();
+
 	while (!shouldQuit()) {
 		// Prepare for scene, and handle any game-specific scenes. This allows
 		// for game specific cutscenes or mini-games that aren't standard scenes

--- a/engines/sherlock/sherlock.cpp
+++ b/engines/sherlock/sherlock.cpp
@@ -162,6 +162,11 @@ Common::Error SherlockEngine::run() {
 		// Reset the data for the player character (Sherlock)
 		_people->reset();
 
+		// If this is still set from the previous scene, something went wrong.
+		// The next scene's path script or a continued script would be
+		// incorrectly aborted
+		assert(!_talk->_talkToAbort);
+
 		// Initialize and load the scene.
 		_scene->selectScene();
 

--- a/engines/sherlock/sherlock.cpp
+++ b/engines/sherlock/sherlock.cpp
@@ -212,7 +212,7 @@ void SherlockEngine::sceneLoop() {
 }
 
 void SherlockEngine::handleInput() {
-	_canLoadSave = _ui->_menuMode == STD_MODE || _ui->_menuMode == LAB_MODE;
+	_canLoadSave = (_ui->_menuMode == STD_MODE || _ui->_menuMode == LAB_MODE) && _events->isCursorVisible();
 	_events->pollEventsAndWait();
 	_canLoadSave = false;
 

--- a/engines/sherlock/talk.cpp
+++ b/engines/sherlock/talk.cpp
@@ -703,6 +703,7 @@ void Talk::doScript(const Common::String &script) {
 	if (_scriptMoreFlag) {
 		_scriptMoreFlag = 0;
 		str = _scriptStart + _scriptSaveIndex;
+		assert(str <= _scriptEnd);
 	}
 
 	// Check if the script begins with a Stealh Mode Active command

--- a/engines/sherlock/tattoo/tattoo_darts.cpp
+++ b/engines/sherlock/tattoo/tattoo_darts.cpp
@@ -294,6 +294,7 @@ void Darts::playDarts(GameType gameType) {
 	closeDarts();
 	screen.fadeToBlack();
 	screen.setFont(oldFontType);
+	events.showCursor();
 
 	// Flag to return to the Billard's Academy scene
 	scene._goToScene = 26;

--- a/engines/sherlock/tattoo/tattoo_user_interface.cpp
+++ b/engines/sherlock/tattoo/tattoo_user_interface.cpp
@@ -380,7 +380,8 @@ void TattooUserInterface::doStandardControl() {
 	Common::Point mousePos = events.mousePos();
 
 	// Don't do any input processing whilst the prolog is running
-	if (vm._runningProlog)
+	// or the cursor is hidden (e.g. by a call to cmdMouseOnOff())
+	if (vm._runningProlog || !events.isCursorVisible())
 		return;
 
 	// When the end credits are active, any press will open the ScummVM global main menu


### PR DESCRIPTION
Depending on its argument, the opcode does the following in the original game:

0x01: Hide the cursor and disable user input
0x02: Unhide the cursor and re-enable user input

In ScummVM, the opcode was only hiding/unhiding the cursor.
However, this was broken due to frequent showCursor() calls from setCursor().

So this PR does the following:
1. Fix cursor hiding
2. Disable input while cursor is hidden to match original behavior
3. Fix regressions caused by the changes
4. Add asserts pertinent to bug #14610

Fixes [#14610](https://bugs.scummvm.org/ticket/14610)