### PR TITLE
TINSEL: Initialize remaining sound reels when loading old save

### DIFF
--- a/engines/tinsel/saveload.cpp
+++ b/engines/tinsel/saveload.cpp
@@ -341,6 +341,11 @@ static void syncSavedData(Common::Serializer &s, SAVED_DATA &sd, int numInterp, 
 		int numReels = s.getVersion() >= 4 ? MAX_SOUNDREELS : 5;
 		for (int i = 0; i < numReels; ++i)
 			syncSoundReel(s, sd.SavedSoundReels[i]);
+		// For old saves we zero the remaining sound reels
+		if (s.isLoading() && numReels < MAX_SOUNDREELS) {
+			const auto reelSize = sizeof sd.SavedSoundReels[0];
+			memset(&sd.SavedSoundReels[numReels], 0, reelSize * (MAX_SOUNDREELS - numReels));
+		}
 	}
 }
 


### PR DESCRIPTION
MAX_SOUNDREELS was increased from 5 to 10 in commit [40f57bd67b6cc3c5b106b0f6f297d466f90dc972](https://github.com/scummvm/scummvm/commit/40f57bd67b6cc3c5b106b0f6f297d466f90dc972).

When loading an old save with less than 10 reels, the remaining ones are currently not reset. (The global holding the reels (Tinsel::g_soundReels) is, but the buffer the data is loaded into (static Tinsel::SAVED_DATA Tinsel::g_sgData) is not. Its contents are then memcpy'ied over).

This might only be a theoretical problem, since it would require creating/loading a save with more than 5 active reels first before then loading a save in the old format.