### PR TITLE
DIRECTOR: fix loading cursor from main archive

### DIFF
--- a/engines/director/cursor.cpp
+++ b/engines/director/cursor.cpp
@@ -190,6 +190,12 @@ void Cursor::readFromResource(Datum resourceId) {
 				break;
 		}
 
+		// Cursors can be located in the main archive, which may not
+		// be in _allOpenResFiles
+		if (!readSuccessful && g_director->getPlatform() == Common::kPlatformMacintosh) {
+			readSuccessful = readFromArchive(g_director->getMainArchive(), resourceId.asInt());
+		}
+
 		// TODO: figure out where to read custom cursor in windows platform
 		// currently, let's just set arrow for default one.
 		if (g_director->getPlatform() == Common::kPlatformWindows) {


### PR DESCRIPTION
Fixes a bug introduced in 9aa095873683b990ac85b4c06b5fa843dcbd682a. That commit limited reading cursors to open res files, not all *seen* res files. However, that broke the custom cursor in Small Stories for Sleepless Nights for Mac (nemurenu-mac-ja), which stores its cursor in the game's main archive which is already closed at the time the cursor gets loaded.

I scoped this to Mac right now because that's the platform I encountered this on, and the other branches are specific to Windows. However, I'm not sure if this behaviour is actually Mac-specific. @sev- also suggested that possibly the main cast should always be present in `_allOpenResFiles`.

Broken:

![scummvm-nemurenu-mac-ja-00008](https://github.com/scummvm/scummvm/assets/780485/a8cc2a39-27e0-44d5-89ee-2b2ee2ff9459)

Fixed:

![scummvm-nemurenu-mac-ja-00007](https://github.com/scummvm/scummvm/assets/780485/68e6ce57-5009-4f4e-bcab-302970ac970e)
