### PR TITLE
TINSEL: Fix out-of-bounds memory corruption

### DIFF
--- a/engines/tinsel/polygons.cpp
+++ b/engines/tinsel/polygons.cpp
@@ -321,9 +321,10 @@ void Poly::nextPoly() {
 	nlistx = (const int32 *)(_pStart + (int)FROM_32(pnodelistx));
 	nlisty = (const int32 *)(_pStart + (int)FROM_32(pnodelisty));
 
-	if (TinselVersion == 0)
+	if (TinselVersion == 0) {
 		// Skip to the last 4 bytes of the record for the hScript value
 		_pData = pRecord + 0x62C;
+	}
 
 	hScript = nextLong(_pData);
 }
@@ -1886,7 +1887,11 @@ void InitPolygons(SCNHANDLE ph, int numPoly, bool bRestart) {
 	if (numPoly > 0) {
 		Poly ptp(_vm->_handle->LockMem(ph));
 
-		for (int i = 0; i < numPoly; ++i, ++ptp) {
+		for (int i = 0; i < numPoly; ++i) {
+			// 'ptp' has already been initialized in its c-tor
+			if (i > 0)
+				++ptp;
+
 			switch (ptp.getType()) {
 			case POLY_PATH:
 				InitPath(ptp, false, i, bRestart);


### PR DESCRIPTION
`for`'s condition is evaluated after the expression(s) so we ended up reading invalid memory in ptp (`numPoly` == 1 so basically it crashed by the end of first loop).

Strangely this corruption has been visible only in DW demo, with asserts enabled and it seems (judging from the lack of similar reports) only on my m68k atari backend.

I couldn't think of a more elegant solution without rewriting too much code.