### PR TITLE
ENGINES: Optimize string handling

### DIFF
--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -575,7 +575,11 @@ const char *md5PropToGameFile(MD5Properties flags) {
 static bool getFilePropertiesIntern(uint md5Bytes, const AdvancedMetaEngine::FileMap &allFiles, MD5Properties md5prop, const Common::String &fname, FileProperties &fileProps);
 
 bool AdvancedMetaEngineDetection::getFileProperties(const FileMap &allFiles, MD5Properties md5prop, const Common::String &fname, FileProperties &fileProps) const {
-	Common::String hashname = Common::String::format("%s:%s:%d", md5PropToCachePrefix(md5prop), fname.c_str(), _md5Bytes);
+	Common::String hashname = md5PropToCachePrefix(md5prop);
+		hashname += ':';
+		hashname += fname;
+		hashname += ':';
+		hashname += Common::String::format("%d", _md5Bytes);
 
 	if (MD5Man.contains(hashname)) {
 		fileProps.md5 = MD5Man.getMD5(hashname);
@@ -725,7 +729,9 @@ ADDetectedGames AdvancedMetaEngineDetection::detectGame(const Common::FSNode &pa
 		for (fileDesc = g->filesDescriptions; fileDesc->fileName; fileDesc++) {
 			MD5Properties md5prop = gameFileToMD5Props(fileDesc, g->flags);
 			Common::String fname = fileDesc->fileName;
-			Common::String key = Common::String::format("%s:%s", md5PropToCachePrefix(md5prop), fname.c_str());
+			Common::String key = md5PropToCachePrefix(md5prop);
+				key += ':';
+				key += fname;
 
 			if (filesProps.contains(key))
 				continue;
@@ -773,7 +779,9 @@ ADDetectedGames AdvancedMetaEngineDetection::detectGame(const Common::FSNode &pa
 		for (fileDesc = game.desc->filesDescriptions; fileDesc->fileName; fileDesc++) {
 			Common::String tstr = fileDesc->fileName;
 			MD5Properties md5prop = gameFileToMD5Props(fileDesc, g->flags);
-			Common::String key = Common::String::format("%s:%s", md5PropToCachePrefix(md5prop), tstr.c_str());
+			Common::String key = md5PropToCachePrefix(md5prop);
+				key += ':';
+				key += tstr;
 
 			if (!filesProps.contains(key) || filesProps[key].size == -1) {
 				allFilesPresent = false;


### PR DESCRIPTION
[v]snprintf() / [v]fprintf() used in String::format() gets called roughly a million times (!) when adding a game.

Reducing the number of calls into libc leads to about 10% speed improvement on the atari backend (which is counting in seconds!)

I wish I could get rid of that `Common::String::format("%d", _md5Bytes);` construct, too. But even in its present form (i.e. with just reduced content passed to `String::format`) it leads to a measurable speed-up.