### PR TITLE
SCI: tweak to scriptdebug.cpp disassembler logic because the new logging wasn't quite working how I expected.

### DIFF
--- a/engines/sci/engine/scriptdebug.cpp
+++ b/engines/sci/engine/scriptdebug.cpp
@@ -152,7 +152,12 @@ reg_t disassemble(EngineState *s, reg_t pos, const Object *obj, bool printBWTag,
 	debugN("%-5s", opcodeNames[opcode]);
 #endif
 
-	static const char *defaultSeparator = "\t\t; ";
+	static const char *defaultSeparator = "\t\t;";
+	
+	// Provide additional selector name context for push0, push1, push2 opcodes.
+	if (opcode >= op_push0 && opcode <= op_push2) {
+		debugN("\t%s%s", defaultSeparator, kernel->getSelectorName(opcode - op_push0).c_str());
+	}
 
 	i = 0;
 	while (g_sci->_opcode_formats[opcode][i]) {
@@ -256,10 +261,8 @@ reg_t disassemble(EngineState *s, reg_t pos, const Object *obj, bool printBWTag,
 					separator = ", ";
 				}
 
-				// Provide additional selector name context for all integer push scenarios.
-				if (opcode >= op_push0 && opcode <= op_push2) {
-    				debugN("%s%s", separator, kernel->getSelectorName(opcode - op_push0).c_str());
-				} else if (opcode == op_pushi && param_value < kernel->getSelectorNamesSize()) {
+				// Provide additional selector name context for pushi opcodes.
+				if (opcode == op_pushi && param_value < kernel->getSelectorNamesSize()) {
 					debugN("%s%s", separator, kernel->getSelectorName(param_value).c_str());
 				}
 			}

--- a/engines/sci/engine/scriptdebug.cpp
+++ b/engines/sci/engine/scriptdebug.cpp
@@ -152,7 +152,7 @@ reg_t disassemble(EngineState *s, reg_t pos, const Object *obj, bool printBWTag,
 	debugN("%-5s", opcodeNames[opcode]);
 #endif
 
-	static const char *defaultSeparator = "\t\t;";
+	static const char *defaultSeparator = "\t\t; ";
 	
 	// Provide additional selector name context for push0, push1, push2 opcodes.
 	if (opcode >= op_push0 && opcode <= op_push2) {


### PR DESCRIPTION
Followup patch from a few weeks ago that only affects debug logging when disassembling SCI scripts.

- These opcodes weren't showing up with their selectors in all scenarios
- Improves output formatting.

Sample output:

```sh
0048:03cc: 0x76,                                // push0			;y
0048:03cd: 0x78,                                // push1			;x
```