### PR TITLE
GOB: add opcode for specfic Adibou 2 German version

### DIFF
--- a/engines/gob/inter.h
+++ b/engines/gob/inter.h
@@ -691,6 +691,7 @@ protected:
 	void setupOpcodesFunc() override;
 	void setupOpcodesGob() override;
 
+	void o7_appligarden();
 	void o7_draw0x0C();
 	void o7_setCursorToLoadFromExec();
 	void o7_freeMult();
@@ -732,6 +733,7 @@ protected:
 
 	void o7_oemToANSI(OpGobParams &params);
 	void o7_gob0x201(OpGobParams &params);
+	void o7_appligarden(OpGobParams &params);
 
 private:
 	INIConfig _inis;

--- a/engines/gob/inter_v7.cpp
+++ b/engines/gob/inter_v7.cpp
@@ -106,6 +106,7 @@ void Inter_v7::setupOpcodesGob() {
 
 	OPCODEGOB(420, o7_oemToANSI);
 	OPCODEGOB(513, o7_gob0x201);
+	OPCODEGOB(777, o7_appligarden);
 }
 
 void Inter_v7::o7_draw0x0C() {
@@ -1412,4 +1413,10 @@ void Inter_v7::o7_gob0x201(OpGobParams &params) {
 
 	WRITE_VAR(varIndex, 1);
 }
+
+void Inter_v7::o7_appligarden(OpGobParams &params) {
+	_vm->_game->_script->skip(0);
+	return;
+}
+
 } // End of namespace Gob


### PR DESCRIPTION
This PR is for adding the opcode for following reason: if you leave in one specfic German version of Adibou 2 (ADI Junior 2) the Application   and want to return to the Garden of Adibou, Then the Console was printing an unimplemented opcode, so we can get rid of this message,