### PR TITLE
SCI: adds support for debugging/executing kernel calls

### DIFF
--- a/engines/sci/console.h
+++ b/engines/sci/console.h
@@ -58,6 +58,7 @@ private:
 	bool cmdSelector(int argc, const char **argv);
 	bool cmdSelectors(int argc, const char **argv);
 	bool cmdKernelFunctions(int argc, const char **argv);
+	bool cmdKernelCall(int argc, const char **argv);
 	bool cmdClassTable(int argc, const char **argv);
 	// Parser
 	bool cmdSuffixes(int argc, const char **argv);


### PR DESCRIPTION
Introduces a new `kerncall` kernel/sub command to the debugger console only to aid in debugging all related SCI games. Similar in vein to using the `send` command.

Example within the SCI debug console:

```sh
) kerncall Random 4 8
kernel call result is: 0000:0008
```

- Additionally, adds a few annotations and clarifications when you are viewing decimal/hex segment ids.
- Lastly, to be more clear renames command: `functions` to `kernfunctions` to list all kernel routines.