### PR TITLE
COMMON: Implement Cue sheet parser

### DIFF
--- a/common/formats/cue.cpp
+++ b/common/formats/cue.cpp
@@ -19,7 +19,7 @@
  *
  */
 
-#include "common/str.h"
+#include "common/debug.h"
 #include "common/formats/cue.h"
 
 namespace Common {
@@ -150,8 +150,41 @@ void CueSheet::parseHeaderContext(const char *line) {
 		_files[_currentFile].type = (CueFileType)lookupInTable(fileTypes, type.c_str());
 
 		_context = kCueContextFiles;
+
+		debug(5, "File: %s, type: %s (%d)", _files[_currentFile].name.c_str(), type.c_str(), _files[_currentFile].type);
+	} else if (command == "TITLE") {
+		_metadata.title = nexttok(s, &s);
+
+		debug(5, "Title: %s", _metadata.title.c_str());
+	} else if (command == "REM") {
+		String subcommand = nexttok(s, &s);
+
+		if (subcommand == "DATE") {
+			_metadata.date = nexttok(s, &s);
+			debug(5, "Date: %s", _metadata.date.c_str());
+		} else if (subcommand == "GENRE") {
+			_metadata.genre = nexttok(s, &s);
+			debug(5, "Genre: %s", _metadata.genre.c_str());
+		} else {
+			warning("Unprocessed REM subcommand %s", subcommand.c_str());
+		}
 	}
 }
+
+LookupTable trackTypes[] = {
+	{ "AUDIO",      CueSheet::kCueFileTypeAudio }, // Audio (sector size: 2352)
+	{ "CDG",        CueSheet::kCueFileTypeCDG }, // Karaoke CD+G (sector size: 2448)
+	{ "MODE1_RAW",  CueSheet::kCueFileTypeMode1_Raw }, // CD-ROM Mode 1 data (raw) (sector size: 2352), used by cdrdao
+	{ "MODE1/2048", CueSheet::kCueFileTypeMode1_2048 }, // CD-ROM Mode 1 data (cooked) (sector size: 2048)
+	{ "MODE1/2352", CueSheet::kCueFileTypeMode1_2352 }, // CD-ROM Mode 1 data (raw) (sector size: 2352)
+	{ "MODE2_RAW",  CueSheet::kCueFileTypeMode2_Raw }, // CD-ROM Mode 2 data (raw) (sector size: 2352), used by cdrdao
+	{ "MODE2/2048", CueSheet::kCueFileTypeMode2_2048 }, // CD-ROM Mode 2 XA form-1 data (sector size: 2048)
+	{ "MODE2/2324", CueSheet::kCueFileTypeMode2_2324 }, // CD-ROM Mode 2 XA form-2 data (sector size: 2324)
+	{ "MODE2/2336", CueSheet::kCueFileTypeMode2_2366 }, // CD-ROM Mode 2 data (sector size: 2336)
+	{ "MODE2/2352", CueSheet::kCueFileTypeMode2_2352 }, // CD-ROM Mode 2 data (raw) (sector size: 2352)
+	{ "CDI/2336",   CueSheet::kCueFileTypeCDI_2336 }, // CDI Mode 2 data
+	{ "CDI/2352",   CueSheet::kCueFileTypeCDI_2352 }, // CDI Mode 2 data
+};
 
 void CueSheet::parseFilesContext(const char *line) {
 }

--- a/common/formats/cue.cpp
+++ b/common/formats/cue.cpp
@@ -170,6 +170,10 @@ void CueSheet::parseHeaderContext(const char *line) {
 		_metadata.performer = nexttok(s, &s);
 
 		debug(5, "Performer: %s", _metadata.performer.c_str());
+	} else if (command == "CATALOG") {
+		_metadata.catalog = nexttok(s, &s);
+
+		debug(5, "Catalog: %s", _metadata.catalog.c_str());
 	} else if (command == "REM") {
 		String subcommand = nexttok(s, &s);
 
@@ -190,18 +194,19 @@ void CueSheet::parseHeaderContext(const char *line) {
 }
 
 LookupTable trackTypes[] = {
-	{ "AUDIO",      CueSheet::kCueFileTypeAudio }, // Audio (sector size: 2352)
-	{ "CDG",        CueSheet::kCueFileTypeCDG }, // Karaoke CD+G (sector size: 2448)
-	{ "MODE1_RAW",  CueSheet::kCueFileTypeMode1_Raw }, // CD-ROM Mode 1 data (raw) (sector size: 2352), used by cdrdao
-	{ "MODE1/2048", CueSheet::kCueFileTypeMode1_2048 }, // CD-ROM Mode 1 data (cooked) (sector size: 2048)
-	{ "MODE1/2352", CueSheet::kCueFileTypeMode1_2352 }, // CD-ROM Mode 1 data (raw) (sector size: 2352)
-	{ "MODE2_RAW",  CueSheet::kCueFileTypeMode2_Raw }, // CD-ROM Mode 2 data (raw) (sector size: 2352), used by cdrdao
-	{ "MODE2/2048", CueSheet::kCueFileTypeMode2_2048 }, // CD-ROM Mode 2 XA form-1 data (sector size: 2048)
-	{ "MODE2/2324", CueSheet::kCueFileTypeMode2_2324 }, // CD-ROM Mode 2 XA form-2 data (sector size: 2324)
-	{ "MODE2/2336", CueSheet::kCueFileTypeMode2_2366 }, // CD-ROM Mode 2 data (sector size: 2336)
-	{ "MODE2/2352", CueSheet::kCueFileTypeMode2_2352 }, // CD-ROM Mode 2 data (raw) (sector size: 2352)
-	{ "CDI/2336",   CueSheet::kCueFileTypeCDI_2336 }, // CDI Mode 2 data
-	{ "CDI/2352",   CueSheet::kCueFileTypeCDI_2352 }, // CDI Mode 2 data
+	{ "AUDIO",      CueSheet::kCueFileTypeAudio },		// Audio (sector size: 2352)
+	{ "CDG",        CueSheet::kCueFileTypeCDG },		// Karaoke CD+G (sector size: 2448)
+	{ "MODE1_RAW",  CueSheet::kCueFileTypeMode1_Raw },	// CD-ROM Mode 1 data (raw) (sector size: 2352), used by cdrdao
+	{ "MODE1/2048", CueSheet::kCueFileTypeMode1_2048 },	// CD-ROM Mode 1 data (cooked) (sector size: 2048)
+	{ "MODE1/2352", CueSheet::kCueFileTypeMode1_2352 },	// CD-ROM Mode 1 data (raw) (sector size: 2352)
+	{ "MODE2_RAW",  CueSheet::kCueFileTypeMode2_Raw },	// CD-ROM Mode 2 data (raw) (sector size: 2352), used by cdrdao
+	{ "MODE2/2048", CueSheet::kCueFileTypeMode2_2048 },	// CD-ROM Mode 2 XA form-1 data (sector size: 2048)
+	{ "MODE2/2324", CueSheet::kCueFileTypeMode2_2324 },	// CD-ROM Mode 2 XA form-2 data (sector size: 2324)
+	{ "MODE2/2336", CueSheet::kCueFileTypeMode2_2366 },	// CD-ROM Mode 2 data (sector size: 2336)
+	{ "MODE2/2352", CueSheet::kCueFileTypeMode2_2352 },	// CD-ROM Mode 2 data (raw) (sector size: 2352)
+	{ "CDI/2336",   CueSheet::kCueFileTypeCDI_2336 },	// CDI Mode 2 data
+	{ "CDI/2352",   CueSheet::kCueFileTypeCDI_2352 },	// CDI Mode 2 data
+	{ 0, 0 }
 };
 
 void CueSheet::parseFilesContext(const char *line) {
@@ -232,6 +237,14 @@ void CueSheet::parseFilesContext(const char *line) {
 
 }
 
+LookupTable trackFlags[] = {
+	{ "4CH",  CueSheet::kCueTrackFlag4ch  },
+	{ "DCP",  CueSheet::kCueTrackFlagDCP  },
+	{ "PRE",  CueSheet::kCueTrackFlagPre  },
+	{ "SCMS", CueSheet::kCueTrackFlagSCMS },
+	{ 0, 0 }
+};
+
 void CueSheet::parseTracksContext(const char *line) {
 	const char *s = line;
 
@@ -257,6 +270,19 @@ void CueSheet::parseTracksContext(const char *line) {
 		_files[_currentFile].tracks[_currentTrack].pregap = parseMSF(nexttok(s, &s).c_str());
 
 		debug(5, "Track pregap: %d", _files[_currentFile].tracks[_currentTrack].pregap);
+	} else if (command == "FLAGS") {
+		String flag;
+		uint32 flags = 0;
+
+		while (*s) {
+			flag = nexttok(s, &s);
+
+			flags |= lookupInTable(trackFlags, flag.c_str());
+		}
+
+		_files[_currentFile].tracks[_currentTrack].flags = flags;
+
+		debug(5, "Track flags: %d", _files[_currentFile].tracks[_currentTrack].flags);
 	} else if (command == "FILE") {
 		parseHeaderContext(line);
 	} else if (command == "PERFORMER") {

--- a/common/formats/cue.cpp
+++ b/common/formats/cue.cpp
@@ -106,12 +106,12 @@ CueSheet::CueSheet(const char *sheet) {
 	}
 }
 
-struct LookupTable {
+struct CueLookupTable {
 	const char *key;
 	int value;
 };
 
-static int lookupInTable(LookupTable *table, const char *key) {
+int CueSheet::lookupInTable(CueLookupTable *table, const char *key) {
 	while (table->key) {
 		if (!strcmp(key, table->key))
 			return table->value;
@@ -119,7 +119,7 @@ static int lookupInTable(LookupTable *table, const char *key) {
 		table++;
 	}
 
-	error("CueSheet::lookupInTable(): Unknown token %s", key);
+	error("CueSheet::lookupInTable(): Unknown lookup token %s at line %d", key, _lineNum);
 }
 
 int CueSheet::parseMSF(const char *str) {
@@ -131,7 +131,7 @@ int CueSheet::parseMSF(const char *str) {
 	return frm + 75 * (sec + 60 * min);
 }
 
-LookupTable fileTypes[] = {
+CueLookupTable fileTypes[] = {
 	{ "BINARY",   CueSheet::kCueFileTypeBinary },
 	{ "AIFF",     CueSheet::kCueFileTypeAIFF },
 	{ "WAVE",     CueSheet::kCueFileTypeWave },
@@ -186,14 +186,14 @@ void CueSheet::parseHeaderContext(const char *line) {
 		} else if (subcommand == "COMMENT") {
 			debug(5, "Skipping Comment: %s", s);
 		} else {
-			warning("CueSheet: Unprocessed REM subcommand %s", subcommand.c_str());
+			warning("CueSheet: Unprocessed REM subcommand %s at line %d", subcommand.c_str(), _lineNum);
 		}
 	} else {
-		warning("CueSheet: Unprocessed command %s", command.c_str());
+		warning("CueSheet: Unprocessed command %s at line %d", command.c_str(), _lineNum);
 	}
 }
 
-LookupTable trackTypes[] = {
+CueLookupTable trackTypes[] = {
 	{ "AUDIO",      CueSheet::kCueFileTypeAudio },		// Audio (sector size: 2352)
 	{ "CDG",        CueSheet::kCueFileTypeCDG },		// Karaoke CD+G (sector size: 2448)
 	{ "MODE1_RAW",  CueSheet::kCueFileTypeMode1_Raw },	// CD-ROM Mode 1 data (raw) (sector size: 2352), used by cdrdao
@@ -209,7 +209,7 @@ LookupTable trackTypes[] = {
 	{ 0, 0 }
 };
 
-LookupTable trackTypesSectorSizes[] = {
+CueLookupTable trackTypesSectorSizes[] = {
 	{ "AUDIO",      2352 },
 	{ "CDG",        2448 },
 	{ "MODE1_RAW",  2352 },
@@ -235,7 +235,7 @@ void CueSheet::parseFilesContext(const char *line) {
 		String trackType = nexttok(s, &s);
 
 		if (trackNum < 0 || (_currentTrack > 0 && _currentTrack + 1 != trackNum)) {
-			warning("CueSheet: Incorrect track number. Expected %d but got %d", _currentTrack + 1, trackNum);
+			warning("CueSheet: Incorrect track number. Expected %d but got %d at line %d", _currentTrack + 1, trackNum, _lineNum);
 		} else {
 			for (int i = _files[_currentFile].tracks.size(); i <= trackNum; i++)
 				_files[_currentFile].tracks.push_back(CueTrack());
@@ -249,12 +249,12 @@ void CueSheet::parseFilesContext(const char *line) {
 
 		_context = kCueContextTracks;
 	} else {
-		warning("CueSheet: Unprocessed file command %s", command.c_str());
+		warning("CueSheet: Unprocessed file command %s at line %d", command.c_str(), _lineNum);
 	}
 
 }
 
-LookupTable trackFlags[] = {
+CueLookupTable trackFlags[] = {
 	{ "4CH",  CueSheet::kCueTrackFlag4ch  },
 	{ "DCP",  CueSheet::kCueTrackFlagDCP  },
 	{ "PRE",  CueSheet::kCueTrackFlagPre  },
@@ -307,7 +307,7 @@ void CueSheet::parseTracksContext(const char *line) {
 
 		debug(5, "Track performer: %s", _files[_currentFile].tracks[_currentTrack].performer.c_str());
 	} else {
-		warning("CueSheet: Unprocessed track command %s", command.c_str());
+		warning("CueSheet: Unprocessed track command %s at line %d", command.c_str(), _lineNum);
 	}
 }
 

--- a/common/formats/cue.cpp
+++ b/common/formats/cue.cpp
@@ -179,6 +179,8 @@ void CueSheet::parseHeaderContext(const char *line) {
 		} else if (subcommand == "GENRE") {
 			_metadata.genre = nexttok(s, &s);
 			debug(5, "Genre: %s", _metadata.genre.c_str());
+		} else if (subcommand == "COMMENT") {
+			debug(5, "Skipping Comment: %s", s);
 		} else {
 			warning("CueSheet: Unprocessed REM subcommand %s", subcommand.c_str());
 		}

--- a/common/formats/cue.cpp
+++ b/common/formats/cue.cpp
@@ -209,6 +209,22 @@ LookupTable trackTypes[] = {
 	{ 0, 0 }
 };
 
+LookupTable trackTypesSectorSizes[] = {
+	{ "AUDIO",      2352 },
+	{ "CDG",        2448 },
+	{ "MODE1_RAW",  2352 },
+	{ "MODE1/2048", 2048 },
+	{ "MODE1/2352", 2352 },
+	{ "MODE2_RAW",  2352 },
+	{ "MODE2/2048", 2048 },
+	{ "MODE2/2324", 2324 },
+	{ "MODE2/2336", 2336 },
+	{ "MODE2/2352", 2352 },
+	{ "CDI/2336",   2336 },
+	{ "CDI/2352",   2352 },
+	{ 0, 0 }
+};
+
 void CueSheet::parseFilesContext(const char *line) {
 	const char *s = line;
 
@@ -226,6 +242,7 @@ void CueSheet::parseFilesContext(const char *line) {
 
 			_currentTrack = trackNum;
 			_files[_currentFile].tracks[_currentTrack].type = (CueTrackType)lookupInTable(trackTypes, trackType.c_str());
+			_files[_currentFile].tracks[_currentTrack].size = lookupInTable(trackTypesSectorSizes, trackType.c_str());
 
 			debug(5, "Track: %d type: %s (%d)", trackNum, trackType.c_str(), _files[_currentFile].tracks[_currentTrack].type);
 		}

--- a/common/formats/cue.cpp
+++ b/common/formats/cue.cpp
@@ -170,7 +170,6 @@ void CueSheet::parseHeaderContext(const char *line) {
 
 		String type = nexttok(s, &s);
 
-		_files[_currentFile].type = kFileTypeBinary;
 		_files[_currentFile].type = (FileType)lookupInTable(fileTypes, type.c_str());
 
 		_context = kContextFiles;
@@ -253,7 +252,7 @@ void CueSheet::parseFilesContext(const char *line) {
 		if (trackNum < 0 || (_currentTrack > 0 && _currentTrack + 1 != trackNum)) {
 			warning("CueSheet: Incorrect track number. Expected %d but got %d at line %d", _currentTrack + 1, trackNum, _lineNum);
 		} else {
-			for (int i = _files[_currentFile].tracks.size(); i <= trackNum; i++)
+			for (uint i = _files[_currentFile].tracks.size(); i <= trackNum; i++)
 				_files[_currentFile].tracks.push_back(CueTrack());
 
 			_currentTrack = trackNum;
@@ -293,7 +292,7 @@ void CueSheet::parseTracksContext(const char *line) {
 		int indexNum = atoi(nexttok(s, &s).c_str());
 		int frames = parseMSF(nexttok(s, &s).c_str());
 
-		for (int i = _files[_currentFile].tracks[_currentTrack].indices.size(); i <= indexNum; i++)
+		for (uint i = _files[_currentFile].tracks[_currentTrack].indices.size(); i <= indexNum; i++)
 			_files[_currentFile].tracks[_currentTrack].indices.push_back(0);
 
 		_files[_currentFile].tracks[_currentTrack].indices[indexNum] = frames;

--- a/common/formats/cue.cpp
+++ b/common/formats/cue.cpp
@@ -253,6 +253,10 @@ void CueSheet::parseTracksContext(const char *line) {
 		_files[_currentFile].tracks[_currentTrack].indices[indexNum] = frames;
 
 		debug(5, "Index: %d, frames: %d", indexNum, frames);
+	} else if (command == "PREGAP") {
+		_files[_currentFile].tracks[_currentTrack].pregap = parseMSF(nexttok(s, &s).c_str());
+
+		debug(5, "Track pregap: %d", _files[_currentFile].tracks[_currentTrack].pregap);
 	} else if (command == "FILE") {
 		parseHeaderContext(line);
 	} else if (command == "PERFORMER") {

--- a/common/formats/cue.cpp
+++ b/common/formats/cue.cpp
@@ -26,9 +26,9 @@
 namespace Common {
 
 enum {
-	kCueContextHeader,
-	kCueContextFiles,
-	kCueContextTracks,
+	kContextHeader,
+	kContextFiles,
+	kContextTracks,
 };
 
 static String nexttok(const char *s, const char **newP = nullptr) {
@@ -75,7 +75,7 @@ CueSheet::CueSheet(SeekableReadStream *stream) {
 
 void CueSheet::parse(const char *sheet) {
 	String line;
-	_context = kCueContextHeader;
+	_context = kContextHeader;
 	const char *s = sheet;
 
 	while (*s) {
@@ -104,15 +104,15 @@ void CueSheet::parse(const char *sheet) {
 			continue;
 
 		switch (_context) {
-		case kCueContextHeader:
+		case kContextHeader:
 			parseHeaderContext(line.c_str());
 			break;
 
-		case kCueContextFiles:
+		case kContextFiles:
 			parseFilesContext(line.c_str());
 			break;
 
-		case kCueContextTracks:
+		case kContextTracks:
 			parseTracksContext(line.c_str());
 			break;
 
@@ -122,12 +122,12 @@ void CueSheet::parse(const char *sheet) {
 	}
 }
 
-struct CueLookupTable {
+struct CueSheet::LookupTable {
 	const char *key;
 	int value;
 };
 
-int CueSheet::lookupInTable(CueLookupTable *table, const char *key) {
+int CueSheet::lookupInTable(LookupTable *table, const char *key) {
 	while (table->key) {
 		if (!strcmp(key, table->key))
 			return table->value;
@@ -147,12 +147,12 @@ int CueSheet::parseMSF(const char *str) {
 	return frm + 75 * (sec + 60 * min);
 }
 
-CueLookupTable fileTypes[] = {
-	{ "BINARY",   CueSheet::kCueFileTypeBinary },
-	{ "AIFF",     CueSheet::kCueFileTypeAIFF },
-	{ "WAVE",     CueSheet::kCueFileTypeWave },
-	{ "MP3",      CueSheet::kCueFileTypeMP3 },
-	{ "MOTOROLA", CueSheet::kCueFileTypeMotorola },
+CueSheet::LookupTable fileTypes[] = {
+	{ "BINARY",   CueSheet::kFileTypeBinary },
+	{ "AIFF",     CueSheet::kFileTypeAIFF },
+	{ "WAVE",     CueSheet::kFileTypeWave },
+	{ "MP3",      CueSheet::kFileTypeMP3 },
+	{ "MOTOROLA", CueSheet::kFileTypeMotorola },
 	{ 0, 0 }
 };
 
@@ -170,10 +170,10 @@ void CueSheet::parseHeaderContext(const char *line) {
 
 		String type = nexttok(s, &s);
 
-		_files[_currentFile].type = kCueFileTypeBinary;
-		_files[_currentFile].type = (CueFileType)lookupInTable(fileTypes, type.c_str());
+		_files[_currentFile].type = kFileTypeBinary;
+		_files[_currentFile].type = (FileType)lookupInTable(fileTypes, type.c_str());
 
-		_context = kCueContextFiles;
+		_context = kContextFiles;
 
 		_currentTrack = -1;
 
@@ -209,23 +209,23 @@ void CueSheet::parseHeaderContext(const char *line) {
 	}
 }
 
-CueLookupTable trackTypes[] = {
-	{ "AUDIO",      CueSheet::kCueFileTypeAudio },		// Audio (sector size: 2352)
-	{ "CDG",        CueSheet::kCueFileTypeCDG },		// Karaoke CD+G (sector size: 2448)
-	{ "MODE1_RAW",  CueSheet::kCueFileTypeMode1_Raw },	// CD-ROM Mode 1 data (raw) (sector size: 2352), used by cdrdao
-	{ "MODE1/2048", CueSheet::kCueFileTypeMode1_2048 },	// CD-ROM Mode 1 data (cooked) (sector size: 2048)
-	{ "MODE1/2352", CueSheet::kCueFileTypeMode1_2352 },	// CD-ROM Mode 1 data (raw) (sector size: 2352)
-	{ "MODE2_RAW",  CueSheet::kCueFileTypeMode2_Raw },	// CD-ROM Mode 2 data (raw) (sector size: 2352), used by cdrdao
-	{ "MODE2/2048", CueSheet::kCueFileTypeMode2_2048 },	// CD-ROM Mode 2 XA form-1 data (sector size: 2048)
-	{ "MODE2/2324", CueSheet::kCueFileTypeMode2_2324 },	// CD-ROM Mode 2 XA form-2 data (sector size: 2324)
-	{ "MODE2/2336", CueSheet::kCueFileTypeMode2_2366 },	// CD-ROM Mode 2 data (sector size: 2336)
-	{ "MODE2/2352", CueSheet::kCueFileTypeMode2_2352 },	// CD-ROM Mode 2 data (raw) (sector size: 2352)
-	{ "CDI/2336",   CueSheet::kCueFileTypeCDI_2336 },	// CDI Mode 2 data
-	{ "CDI/2352",   CueSheet::kCueFileTypeCDI_2352 },	// CDI Mode 2 data
+CueSheet::LookupTable trackTypes[] = {
+	{ "AUDIO",      CueSheet::kTrackTypeAudio },		// Audio (sector size: 2352)
+	{ "CDG",        CueSheet::kTrackTypeCDG },			// Karaoke CD+G (sector size: 2448)
+	{ "MODE1_RAW",  CueSheet::kTrackTypeMode1_Raw },	// CD-ROM Mode 1 data (raw) (sector size: 2352), used by cdrdao
+	{ "MODE1/2048", CueSheet::kTrackTypeMode1_2048 },	// CD-ROM Mode 1 data (cooked) (sector size: 2048)
+	{ "MODE1/2352", CueSheet::kTrackTypeMode1_2352 },	// CD-ROM Mode 1 data (raw) (sector size: 2352)
+	{ "MODE2_RAW",  CueSheet::kTrackTypeMode2_Raw },	// CD-ROM Mode 2 data (raw) (sector size: 2352), used by cdrdao
+	{ "MODE2/2048", CueSheet::kTrackTypeMode2_2048 },	// CD-ROM Mode 2 XA form-1 data (sector size: 2048)
+	{ "MODE2/2324", CueSheet::kTrackTypeMode2_2324 },	// CD-ROM Mode 2 XA form-2 data (sector size: 2324)
+	{ "MODE2/2336", CueSheet::kTrackTypeMode2_2366 },	// CD-ROM Mode 2 data (sector size: 2336)
+	{ "MODE2/2352", CueSheet::kTrackTypeMode2_2352 },	// CD-ROM Mode 2 data (raw) (sector size: 2352)
+	{ "CDI/2336",   CueSheet::kTrackTypeCDI_2336 },		// CDI Mode 2 data
+	{ "CDI/2352",   CueSheet::kTrackTypeCDI_2352 },		// CDI Mode 2 data
 	{ 0, 0 }
 };
 
-CueLookupTable trackTypesSectorSizes[] = {
+CueSheet::LookupTable trackTypesSectorSizes[] = {
 	{ "AUDIO",      2352 },
 	{ "CDG",        2448 },
 	{ "MODE1_RAW",  2352 },
@@ -257,24 +257,24 @@ void CueSheet::parseFilesContext(const char *line) {
 				_files[_currentFile].tracks.push_back(CueTrack());
 
 			_currentTrack = trackNum;
-			_files[_currentFile].tracks[_currentTrack].type = (CueTrackType)lookupInTable(trackTypes, trackType.c_str());
+			_files[_currentFile].tracks[_currentTrack].type = (TrackType)lookupInTable(trackTypes, trackType.c_str());
 			_files[_currentFile].tracks[_currentTrack].size = lookupInTable(trackTypesSectorSizes, trackType.c_str());
 
 			debug(5, "Track: %d type: %s (%d)", trackNum, trackType.c_str(), _files[_currentFile].tracks[_currentTrack].type);
 		}
 
-		_context = kCueContextTracks;
+		_context = kContextTracks;
 	} else {
 		warning("CueSheet: Unprocessed file command %s at line %d", command.c_str(), _lineNum);
 	}
 
 }
 
-CueLookupTable trackFlags[] = {
-	{ "4CH",  CueSheet::kCueTrackFlag4ch  },
-	{ "DCP",  CueSheet::kCueTrackFlagDCP  },
-	{ "PRE",  CueSheet::kCueTrackFlagPre  },
-	{ "SCMS", CueSheet::kCueTrackFlagSCMS },
+CueSheet::LookupTable trackFlags[] = {
+	{ "4CH",  CueSheet::kTrackFlag4ch  },
+	{ "DCP",  CueSheet::kTrackFlagDCP  },
+	{ "PRE",  CueSheet::kTrackFlagPre  },
+	{ "SCMS", CueSheet::kTrackFlagSCMS },
 	{ 0, 0 }
 };
 

--- a/common/formats/cue.cpp
+++ b/common/formats/cue.cpp
@@ -1,0 +1,118 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/formats/cue.h"
+
+namespace Common {
+
+enum {
+	kCueContextHeader,
+	kCueContextFiles,
+	kCueContextTracks,
+};
+
+static String nexttok(const char *s, const char **newP = nullptr) {
+	String res;
+
+	// Scan first non-whitespace
+	while (*s && (*s == ' ' || *s == '\t')) // If we see a whitespace
+		s++;
+
+	if (*s == '"') { // If it is a string then scan till end quote
+		s++; // skip the quote
+
+		while (*s && *s != '"')
+			res += *s++;
+
+		if (*s == '"')
+			s++;
+	} else {
+		while (*s && *s != ' ' && *s != '\t' && *s != '\n' && *s != '\r')
+			res += *s++;
+	}
+
+	if (newP)
+		*newP = s;
+
+	return res;
+}
+
+
+CueSheet::CueSheet(const char *sheet) {
+	String line;
+	_context = kCueContextHeader;
+	const char *s = sheet;
+	int lineNum = 0;
+
+	while (*s) {
+		line.clear();
+
+		// Get a line
+		while (*s && *s != '\n' && *s != '\r') // If we see a whitespace
+			line += *s++;
+
+		// Skip any newlines and line feeds
+		while (*s == '\n' || *s == '\r') {
+			if (*s == '\n')
+				lineNum++;
+
+			s++;
+		}
+
+
+		if (line.empty())
+			continue;
+
+		String firstToken = nexttok(line.c_str()); // Peek into comments
+
+		// Skip non-conformant comments
+		if (firstToken[0] == ';' || (firstToken.size() > 1 && firstToken[0] == '/' && firstToken[1] == '/'))
+			continue;
+
+		switch (_context) {
+		case kCueContextHeader:
+			parseHeaderContext(line.c_str());
+			break;
+
+		case kCueContextFiles:
+			parseFilesContext(line.c_str());
+			break;
+
+		case kCueContextTracks:
+			parseTracksContext(line.c_str());
+			break;
+
+		default:
+			error("CueSheet: bad context %d at line %d", _context, lineNum);
+		}
+	}
+}
+
+void CueSheet::parseHeaderContext(const char *line) {
+}
+
+void CueSheet::parseFilesContext(const char *line) {
+}
+
+void CueSheet::parseTracksContext(const char *line) {
+}
+
+} // End of namespace Common

--- a/common/formats/cue.cpp
+++ b/common/formats/cue.cpp
@@ -128,7 +128,7 @@ int CueSheet::parseMSF(const char *str) {
 	if (sscanf(str, "%d:%d:%d", &min, &sec, &frm) != 3)
 		warning("Malformed MSF at line %d: %s", _lineNum, str);
 
-	return frm + 75 * sec + 75 * 60 * min;
+	return frm + 75 * (sec + 60 * min);
 }
 
 LookupTable fileTypes[] = {
@@ -255,6 +255,10 @@ void CueSheet::parseTracksContext(const char *line) {
 		debug(5, "Index: %d, frames: %d", indexNum, frames);
 	} else if (command == "FILE") {
 		parseHeaderContext(line);
+	} else if (command == "PERFORMER") {
+		_files[_currentFile].tracks[_currentTrack].performer = nexttok(s, &s);
+
+		debug(5, "Track performer: %s", _files[_currentFile].tracks[_currentTrack].performer.c_str());
 	} else {
 		warning("CueSheet: Unprocessed track command %s", command.c_str());
 	}

--- a/common/formats/cue.cpp
+++ b/common/formats/cue.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "common/debug.h"
+#include "common/stream.h"
 #include "common/formats/cue.h"
 
 namespace Common {
@@ -58,6 +59,21 @@ static String nexttok(const char *s, const char **newP = nullptr) {
 
 
 CueSheet::CueSheet(const char *sheet) {
+	parse(sheet);
+}
+
+CueSheet::CueSheet(SeekableReadStream *stream) {
+	int size = stream->size();
+	char *data = (char *)calloc(size + 1, 1); // null-terminated string
+
+	stream->read(data, size);
+
+	parse(data);
+
+	free(data);
+}
+
+void CueSheet::parse(const char *sheet) {
 	String line;
 	_context = kCueContextHeader;
 	const char *s = sheet;

--- a/common/formats/cue.h
+++ b/common/formats/cue.h
@@ -44,9 +44,36 @@ public:
 		kCueFileTypeMotorola,
 	};
 
+	enum CueTrackType {
+		kCueFileTypeAudio,
+		kCueFileTypeCDG,
+		kCueFileTypeMode1_Raw,
+		kCueFileTypeMode1_2048,
+		kCueFileTypeMode1_2352,
+		kCueFileTypeMode2_Raw,
+		kCueFileTypeMode2_2048,
+		kCueFileTypeMode2_2324,
+		kCueFileTypeMode2_2366,
+		kCueFileTypeMode2_2352,
+		kCueFileTypeCDI_2336,
+		kCueFileTypeCDI_2352,
+	};
+
+	struct CueTrack {
+		int number = 0;
+		CueTrackType type;
+		String title;
+	};
+
 	struct CueFile {
 		String name;
 		CueFileType type = kCueFileTypeBinary;
+	};
+
+	struct CueMetadate {
+		String title;
+		String date;
+		String genre;
 	};
 
 private:
@@ -58,7 +85,8 @@ private:
 	int _context;
 	int _currentFile = -1;
 
-	Common::Array<CueFile> _files;
+	Array<CueFile> _files;
+	CueMetadate _metadata;
 };
 
 } // End of namespace Common

--- a/common/formats/cue.h
+++ b/common/formats/cue.h
@@ -63,6 +63,7 @@ public:
 		int number = 0;
 		CueTrackType type;
 		String title;
+		String performer;
 		Array<int> indices;
 	};
 

--- a/common/formats/cue.h
+++ b/common/formats/cue.h
@@ -27,7 +27,6 @@
 namespace Common {
 
 class SeekableReadStream;
-struct CueLookupTable;
 
 /**
  * A class able to load and parse Cue sheets
@@ -38,39 +37,39 @@ public:
 	CueSheet(SeekableReadStream *stream);
 
 public:
-	enum CueFileType {
-		kCueFileTypeBinary,
-		kCueFileTypeAIFF,
-		kCueFileTypeWave,
-		kCueFileTypeMP3,
-		kCueFileTypeMotorola,
+	enum FileType {
+		kFileTypeBinary,
+		kFileTypeAIFF,
+		kFileTypeWave,
+		kFileTypeMP3,
+		kFileTypeMotorola,
 	};
 
-	enum CueTrackType {
-		kCueFileTypeAudio,		// Audio (sector size: 2352)
-		kCueFileTypeCDG,		// Karaoke CD+G (sector size: 2448)
-		kCueFileTypeMode1_Raw,	// CD-ROM Mode 1 data (raw) (sector size: 2352), used by cdrdao
-		kCueFileTypeMode1_2048,	// CD-ROM Mode 1 data (cooked) (sector size: 2048)
-		kCueFileTypeMode1_2352,	// CD-ROM Mode 1 data (raw) (sector size: 2352)
-		kCueFileTypeMode2_Raw,	// CD-ROM Mode 2 data (raw) (sector size: 2352), used by cdrdao
-		kCueFileTypeMode2_2048,	// CD-ROM Mode 2 XA form-1 data (sector size: 2048)
-		kCueFileTypeMode2_2324,	// CD-ROM Mode 2 XA form-2 data (sector size: 2324)
-		kCueFileTypeMode2_2366,	// CD-ROM Mode 2 data (sector size: 2336)
-		kCueFileTypeMode2_2352,	// CD-ROM Mode 2 data (raw) (sector size: 2352)
-		kCueFileTypeCDI_2336,	// CDI Mode 2 data
-		kCueFileTypeCDI_2352,	// CDI Mode 2 data
+	enum TrackType {
+		kTrackTypeAudio,		// Audio (sector size: 2352)
+		kTrackTypeCDG,			// Karaoke CD+G (sector size: 2448)
+		kTrackTypeMode1_Raw,	// CD-ROM Mode 1 data (raw) (sector size: 2352), used by cdrdao
+		kTrackTypeMode1_2048,	// CD-ROM Mode 1 data (cooked) (sector size: 2048)
+		kTrackTypeMode1_2352,	// CD-ROM Mode 1 data (raw) (sector size: 2352)
+		kTrackTypeMode2_Raw,	// CD-ROM Mode 2 data (raw) (sector size: 2352), used by cdrdao
+		kTrackTypeMode2_2048,	// CD-ROM Mode 2 XA form-1 data (sector size: 2048)
+		kTrackTypeMode2_2324,	// CD-ROM Mode 2 XA form-2 data (sector size: 2324)
+		kTrackTypeMode2_2366,	// CD-ROM Mode 2 data (sector size: 2336)
+		kTrackTypeMode2_2352,	// CD-ROM Mode 2 data (raw) (sector size: 2352)
+		kTrackTypeCDI_2336,		// CDI Mode 2 data
+		kTrackTypeCDI_2352,		// CDI Mode 2 data
 	};
 
-	enum CueTrackFlags {
-		kCueTrackFlag4ch  = 1 << 0, // Four channel audio
-		kCueTrackFlagDCP  = 1 << 1, // Digital copy permitted
-		kCueTrackFlagPre  = 1 << 2, // Pre-emphasis enabled, for audio tracks only
-		kCueTrackFlagSCMS = 1 << 3, // Serial copy management system
+	enum TrackFlags {
+		kTrackFlag4ch  = 1 << 0, // Four channel audio
+		kTrackFlagDCP  = 1 << 1, // Digital copy permitted
+		kTrackFlagPre  = 1 << 2, // Pre-emphasis enabled, for audio tracks only
+		kTrackFlagSCMS = 1 << 3, // Serial copy management system
 	};
 
 	struct CueTrack {
 		int number = 0;
-		CueTrackType type;
+		TrackType type;
 		String title;
 		String performer;
 		Array<int> indices;
@@ -81,7 +80,7 @@ public:
 
 	struct CueFile {
 		String name;
-		CueFileType type = kCueFileTypeBinary;
+		FileType type = kFileTypeBinary;
 		Array<CueTrack> tracks;
 	};
 
@@ -93,10 +92,12 @@ public:
 		String catalog;
 	};
 
+	struct LookupTable;
+
 private:
 	void parse(const char *sheet);
 
-	int lookupInTable(CueLookupTable *table, const char *key);
+	int lookupInTable(LookupTable *table, const char *key);
 	int parseMSF(const char *str);
 
 	void parseHeaderContext(const char *line);

--- a/common/formats/cue.h
+++ b/common/formats/cue.h
@@ -22,9 +22,7 @@
 #ifndef COMMON_FORMATS_CUE_H
 #define COMMON_FORMATS_CUE_H
 
-#include "common/hash-str.h"
-#include "common/str.h"
-#include "common/types.h"
+#include "common/array.h"
 
 namespace Common {
 
@@ -37,6 +35,20 @@ class CueSheet {
 public:
 	CueSheet(const char *sheet);
 
+public:
+	enum CueFileType {
+		kCueFileTypeBinary,
+		kCueFileTypeAIFF,
+		kCueFileTypeWave,
+		kCueFileTypeMP3,
+		kCueFileTypeMotorola,
+	};
+
+	struct CueFile {
+		String name;
+		CueFileType type = kCueFileTypeBinary;
+	};
+
 private:
 	void parseHeaderContext(const char *line);
 	void parseFilesContext(const char *line);
@@ -44,6 +56,9 @@ private:
 
 private:
 	int _context;
+	int _currentFile = -1;
+
+	Common::Array<CueFile> _files;
 };
 
 } // End of namespace Common

--- a/common/formats/cue.h
+++ b/common/formats/cue.h
@@ -63,30 +63,38 @@ public:
 		int number = 0;
 		CueTrackType type;
 		String title;
+		Array<int> indices;
 	};
 
 	struct CueFile {
 		String name;
 		CueFileType type = kCueFileTypeBinary;
+		Array<CueTrack> tracks;
 	};
 
-	struct CueMetadate {
+	struct CueMetadata {
 		String title;
 		String date;
 		String genre;
+		String performer;
 	};
 
 private:
+	int parseMSF(const char *str);
+
 	void parseHeaderContext(const char *line);
 	void parseFilesContext(const char *line);
 	void parseTracksContext(const char *line);
 
 private:
+	int _lineNum = 0;
 	int _context;
 	int _currentFile = -1;
+	int _currentTrack = -1;
 
 	Array<CueFile> _files;
-	CueMetadate _metadata;
+	CueMetadata _metadata;
+
 };
 
 } // End of namespace Common

--- a/common/formats/cue.h
+++ b/common/formats/cue.h
@@ -1,0 +1,51 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef COMMON_FORMATS_CUE_H
+#define COMMON_FORMATS_CUE_H
+
+#include "common/hash-str.h"
+#include "common/str.h"
+#include "common/types.h"
+
+namespace Common {
+
+class SeekableReadStream;
+
+/**
+ * A class able to load and parse Cue sheets
+ */
+class CueSheet {
+public:
+	CueSheet(const char *sheet);
+
+private:
+	void parseHeaderContext(const char *line);
+	void parseFilesContext(const char *line);
+	void parseTracksContext(const char *line);
+
+private:
+	int _context;
+};
+
+} // End of namespace Common
+
+#endif

--- a/common/formats/cue.h
+++ b/common/formats/cue.h
@@ -65,6 +65,7 @@ public:
 		String title;
 		String performer;
 		Array<int> indices;
+		int pregap = 0;
 	};
 
 	struct CueFile {

--- a/common/formats/cue.h
+++ b/common/formats/cue.h
@@ -45,18 +45,25 @@ public:
 	};
 
 	enum CueTrackType {
-		kCueFileTypeAudio,
-		kCueFileTypeCDG,
-		kCueFileTypeMode1_Raw,
-		kCueFileTypeMode1_2048,
-		kCueFileTypeMode1_2352,
-		kCueFileTypeMode2_Raw,
-		kCueFileTypeMode2_2048,
-		kCueFileTypeMode2_2324,
-		kCueFileTypeMode2_2366,
-		kCueFileTypeMode2_2352,
-		kCueFileTypeCDI_2336,
-		kCueFileTypeCDI_2352,
+		kCueFileTypeAudio,		// Audio (sector size: 2352)
+		kCueFileTypeCDG,		// Karaoke CD+G (sector size: 2448)
+		kCueFileTypeMode1_Raw,	// CD-ROM Mode 1 data (raw) (sector size: 2352), used by cdrdao
+		kCueFileTypeMode1_2048,	// CD-ROM Mode 1 data (cooked) (sector size: 2048)
+		kCueFileTypeMode1_2352,	// CD-ROM Mode 1 data (raw) (sector size: 2352)
+		kCueFileTypeMode2_Raw,	// CD-ROM Mode 2 data (raw) (sector size: 2352), used by cdrdao
+		kCueFileTypeMode2_2048,	// CD-ROM Mode 2 XA form-1 data (sector size: 2048)
+		kCueFileTypeMode2_2324,	// CD-ROM Mode 2 XA form-2 data (sector size: 2324)
+		kCueFileTypeMode2_2366,	// CD-ROM Mode 2 data (sector size: 2336)
+		kCueFileTypeMode2_2352,	// CD-ROM Mode 2 data (raw) (sector size: 2352)
+		kCueFileTypeCDI_2336,	// CDI Mode 2 data
+		kCueFileTypeCDI_2352,	// CDI Mode 2 data
+	};
+
+	enum CueTrackFlags {
+		kCueTrackFlag4ch  = 1 << 0, // Four channel audio
+		kCueTrackFlagDCP  = 1 << 1, // Digital copy permitted
+		kCueTrackFlagPre  = 1 << 2, // Pre-emphasis enabled, for audio tracks only
+		kCueTrackFlagSCMS = 1 << 3, // Serial copy management system
 	};
 
 	struct CueTrack {
@@ -66,6 +73,7 @@ public:
 		String performer;
 		Array<int> indices;
 		int pregap = 0;
+		uint32 flags;
 	};
 
 	struct CueFile {
@@ -79,6 +87,7 @@ public:
 		String date;
 		String genre;
 		String performer;
+		String catalog;
 	};
 
 private:

--- a/common/formats/cue.h
+++ b/common/formats/cue.h
@@ -74,6 +74,7 @@ public:
 		Array<int> indices;
 		int pregap = 0;
 		uint32 flags;
+		int size = 2352;
 	};
 
 	struct CueFile {

--- a/common/formats/cue.h
+++ b/common/formats/cue.h
@@ -27,6 +27,7 @@
 namespace Common {
 
 class SeekableReadStream;
+struct CueLookupTable;
 
 /**
  * A class able to load and parse Cue sheets
@@ -92,6 +93,7 @@ public:
 	};
 
 private:
+	int lookupInTable(CueLookupTable *table, const char *key);
 	int parseMSF(const char *str);
 
 	void parseHeaderContext(const char *line);

--- a/common/formats/cue.h
+++ b/common/formats/cue.h
@@ -35,6 +35,7 @@ struct CueLookupTable;
 class CueSheet {
 public:
 	CueSheet(const char *sheet);
+	CueSheet(SeekableReadStream *stream);
 
 public:
 	enum CueFileType {
@@ -93,6 +94,8 @@ public:
 	};
 
 private:
+	void parse(const char *sheet);
+
 	int lookupInTable(CueLookupTable *table, const char *key);
 	int parseMSF(const char *str);
 

--- a/common/formats/module.mk
+++ b/common/formats/module.mk
@@ -1,6 +1,7 @@
 MODULE := common/formats
 
 MODULE_OBJS := \
+	cue.o \
 	formatinfo.o \
 	iff_container.o \
 	ini-file.o \

--- a/engines/director/tests.cpp
+++ b/engines/director/tests.cpp
@@ -25,6 +25,7 @@
 
 #include "common/memstream.h"
 #include "common/macresman.h"
+#include "common/formats/cue.h"
 
 #include "graphics/fonts/macfont.h"
 #include "graphics/macgui/macfontmanager.h"
@@ -300,6 +301,25 @@ const byte testMovie[] = {
 void Window::runTests() {
 	Common::MemoryReadStream *movie = new Common::MemoryReadStream(testMovie, ARRAYSIZE(testMovie));
 	Common::SeekableReadStream *stream = Common::wrapCompressedReadStream(movie);
+
+	const char *cueTest =
+"PERFORMER \"Bloc Party\"\n"
+"TITLE \"Silent Alarm\"\n"
+"FILE \"Bloc Party - Silent Alarm.flac\" WAVE\n"
+   "TRACK 01 AUDIO\n"
+      "TITLE \"Like Eating Glass\"\n"
+      "PERFORMER \"Bloc Party\"\n"
+      "INDEX 00 00:00:00\n"
+      "INDEX 01 03:22:70\n"
+   "TRACK 02 AUDIO\n"
+      "TITLE \"Helicopter\"\n"
+      "PERFORMER \"Bloc Party\"\n"
+      "INDEX 00 07:42:69\n"
+      "INDEX 01 07:44:69\n"
+"";
+
+
+	Common::CueSheet cue(cueTest);
 
 	initGraphics(640, 480);
 


### PR DESCRIPTION
By request of @mistydemeo 

This is an extensible parser for Cue sheets. It does not implement _all_ the known tags, I decided to go with a pragmatic approach and add them as long as I see unprocessed commands. The missing things are reported via warnings and full parsing trace is visible at debug level 5.

The class does not implement any access API to the parsed data structures, as I need more information regarding usage. This is a trivial task since the data is kept in a neat hierarchy with nested `Common::Array` lists.

Also, I added a simple test to the Director engine, so you could see the implementation in action. To invoke the test, run `./scummvm -p engines/director/lingo/tests --debugflags=text -d5  --auto-detect`

Any feedback is welcome.