### PR TITLE
COMMON: String performance improvements

### DIFF
--- a/common/fs.cpp
+++ b/common/fs.cpp
@@ -168,8 +168,13 @@ U32String FSNode::getDisplayName() const {
 
 String FSNode::getName() const {
 	assert(_realNode);
+
 	// We transparently decode any punycode-named files
-	return punycode_decodefilename(_realNode->getName());
+	String name = _realNode->getName();
+	if (!punycode_hasprefix(name))
+		return name;
+
+	return punycode_decodefilename(name);
 }
 
 String FSNode::getFileName() const {

--- a/common/str-base.cpp
+++ b/common/str-base.cpp
@@ -720,20 +720,36 @@ TEMPLATE void BASESTRING::wordWrap(const uint32 maxLength) {
 #endif
 
 TEMPLATE void BASESTRING::toLowercase() {
-	makeUnique();
-	for (uint32 i = 0; i < _size; ++i) {
-		if (_str[i] > 0 && _str[i] < 128) {
-			_str[i] = tolower(_str[i]);
-		}
-	}
+	toCase(tolower);
 }
 
 TEMPLATE void BASESTRING::toUppercase() {
-	makeUnique();
-	for (uint32 i = 0; i < _size; ++i) {
-		if (_str[i] > 0 && _str[i] < 128) {
-			_str[i] = toupper(_str[i]);
+	toCase(toupper);
+}
+
+TEMPLATE void BASESTRING::toCase(int (*caseChangeFunc)(int)) {
+	uint32 sz = _size;
+	T *buf = _str;
+
+	uint32 i = 0;
+	for ( ; i < sz; ++i) {
+		value_type ch = buf[i];
+		if (ch > 0 && ch < 128) {
+			value_type newCh = static_cast<value_type>(caseChangeFunc(buf[i]));
+			if (ch != newCh) {
+				makeUnique();
+				buf = _str;
+				buf[i] = newCh;
+				i++;
+				break;
+			}
 		}
+	}
+
+	for (; i < sz; ++i) {
+		value_type ch = buf[i];
+		if (ch > 0 && ch < 128)
+			buf[i] = static_cast<value_type>(caseChangeFunc(ch));
 	}
 }
 

--- a/common/str-base.h
+++ b/common/str-base.h
@@ -263,6 +263,8 @@ protected:
 
 	uint getUnsignedValue(uint pos) const;
 
+	void toCase(int (*caseChangeFunc)(int));
+
 	static uint32 cStrLen(const value_type *str);
 };
 }


### PR DESCRIPTION
Some performance improvements to avoid unnecessary string construction and copies:
- Changes toLowercase and toUppercase to avoid calling makeUnique if the string doesn't require any modification.
- Changes FSNode::getName to avoid calling `punycode_decodefilename` and the subsequent String -> U32String -> String conversions if the filename isn't punycode.  This should significantly speed up `AdvancedMetaEngineDetection::composeFileHashMap`