### PR TITLE
BASE: Fix exiting scummvm_main loop in backend not allowing quit

### DIFF
--- a/base/main.cpp
+++ b/base/main.cpp
@@ -103,13 +103,19 @@ static bool launcherDialog() {
 	// blindly be passed to the first game launched from the launcher.
 	ConfMan.getDomain(Common::ConfigManager::kTransientDomain)->clear();
 
+	// If the backend does not allow quitting, loop on the launcher until a game is started
+	bool noQuit = g_system->hasFeature(OSystem::kFeatureNoQuit);
+	bool status = true;
+	do {
 #if defined(__DC__)
-	DCLauncherDialog dlg;
+		DCLauncherDialog dlg;
 #else
-	GUI::LauncherChooser dlg;
-	dlg.selectLauncher();
+		GUI::LauncherChooser dlg;
+		dlg.selectLauncher();
 #endif
-	return (dlg.runModal() != -1);
+		status = (dlg.runModal() != -1);
+	} while (noQuit && nullptr == ConfMan.getActiveDomain());
+	return status;
 }
 
 static const Plugin *detectPlugin() {


### PR DESCRIPTION
On iOS, and possibly emscripten which is the only other backend using `kFeatureNoQuit` currently, closing the launcher dialog without starting a game results in a blank screen and the user has to force close and reopen ScummVM. This was reported in https://bugs.scummvm.org/ticket/14624 using the Esc key, or corresponding iOS gesture, while on the launcher.

The change in this pull request adds a loop to reopen the launcher if it was closed without starting a game and avoid existing  `scummvm_main()`. I have tested that it indeed fixes the issue on the iOS simulator.

This is one of 4 possible solutions I considered. The other three are:
 - Use the same solution, but in `LauncherChooser::runModal()` instead of `launcherDialog()`.
 - Ignore the Escape key in the `LauncherDialog` so that it does not close the dialog (unlike the other dialogs).
 - Do not allow closing the dialog in `Dialog::close()` / `GuiManager::closeTopDialog()` if this is the only dialog in the dialog stack and no game is being started or is running.

The third point is I think a no-go as it prevents switching between the list launcher and the grid launcher.

The second point could work I think (I didn't try it) and could also allow removing the possibility to Quit ScummVM using the Escape key while in the launcher for other backends. I don't know if this is something that we would like, but to me quitting the app using the Escape key seems a bit strange. However I am not sure if the Escape key is the only event that can trigger bug #14624 on iOS, or if there are other ways to close the launcher dialog.

The first point and the solution I implemented are a more global solution and should catch all the cases where the Launcher dialog is closed without starting a game. There is very little difference between the first point and the solution implemented, and it just seemed to be more logical to me to have the loop in `launcherDialog()`.

Let me know if you see a way to improve it, if you see something I overlooked, or if you think I didn't select the best solution.