### PR TITLE
BACKENDS: Avoid passing arguments by value in cloud and networking

### DIFF
--- a/backends/cloud/basestorage.cpp
+++ b/backends/cloud/basestorage.cpp
@@ -31,16 +31,16 @@ namespace Cloud {
 
 BaseStorage::BaseStorage() {}
 
-BaseStorage::BaseStorage(Common::String token, Common::String refreshToken, bool enabled):
+BaseStorage::BaseStorage(const Common::String &token, const Common::String &refreshToken, bool enabled):
 	_token(token), _refreshToken(refreshToken) {
 	_isEnabled = enabled;
 }
 
 BaseStorage::~BaseStorage() {}
 
-void BaseStorage::getAccessToken(Common::String code, Networking::ErrorCallback callback) {
-	Networking::JsonCallback innerCallback = new Common::CallbackBridge<BaseStorage, Networking::ErrorResponse, Networking::JsonResponse>(this, &BaseStorage::codeFlowComplete, callback);
-	Networking::ErrorCallback errorCallback = new Common::CallbackBridge<BaseStorage, Networking::ErrorResponse, Networking::ErrorResponse>(this, &BaseStorage::codeFlowFailed, callback);
+void BaseStorage::getAccessToken(const Common::String &code, Networking::ErrorCallback callback) {
+	Networking::JsonCallback innerCallback = new Common::CallbackBridge<BaseStorage, const Networking::ErrorResponse &, const Networking::JsonResponse &>(this, &BaseStorage::codeFlowComplete, callback);
+	Networking::ErrorCallback errorCallback = new Common::CallbackBridge<BaseStorage, const Networking::ErrorResponse &, const Networking::ErrorResponse &>(this, &BaseStorage::codeFlowFailed, callback);
 
 	Common::String url = Common::String::format("https://cloud.scummvm.org/%s/token/%s", cloudProvider().c_str(), code.c_str());
 	Networking::CurlJsonRequest *request = new Networking::CurlJsonRequest(innerCallback, errorCallback, url);
@@ -48,11 +48,11 @@ void BaseStorage::getAccessToken(Common::String code, Networking::ErrorCallback 
 	addRequest(request);
 }
 
-void BaseStorage::codeFlowComplete(Networking::ErrorCallback callback, Networking::JsonResponse response) {
+void BaseStorage::codeFlowComplete(Networking::ErrorCallback callback, const Networking::JsonResponse &response) {
 	bool success = true;
 	Common::String callbackMessage = "OK";
 
-	Common::JSONValue *json = (Common::JSONValue *)response.value;
+	const Common::JSONValue *json = response.value;
 	if (json == nullptr) {
 		debug(9, "BaseStorage::codeFlowComplete: got NULL instead of JSON!");
 		success = false;
@@ -123,7 +123,7 @@ void BaseStorage::codeFlowComplete(Networking::ErrorCallback callback, Networkin
 	delete callback;
 }
 
-void BaseStorage::codeFlowFailed(Networking::ErrorCallback callback, Networking::ErrorResponse error) {
+void BaseStorage::codeFlowFailed(Networking::ErrorCallback callback, const Networking::ErrorResponse &error) {
 	debug(9, "BaseStorage: code flow failed (%s, %ld):", (error.failed ? "failed" : "interrupted"), error.httpResponseCode);
 	debug(9, "%s", error.response.c_str());
 	CloudMan.removeStorage(this);
@@ -140,7 +140,7 @@ void BaseStorage::refreshAccessToken(BoolCallback callback, Networking::ErrorCal
 		return;
 	}
 
-	Networking::JsonCallback innerCallback = new Common::CallbackBridge<BaseStorage, BoolResponse, Networking::JsonResponse>(this, &BaseStorage::tokenRefreshed, callback);
+	Networking::JsonCallback innerCallback = new Common::CallbackBridge<BaseStorage, const BoolResponse &, const Networking::JsonResponse &>(this, &BaseStorage::tokenRefreshed, callback);
 	if (errorCallback == nullptr)
 		errorCallback = getErrorPrintingCallback();
 
@@ -150,10 +150,10 @@ void BaseStorage::refreshAccessToken(BoolCallback callback, Networking::ErrorCal
 	addRequest(request);
 }
 
-void BaseStorage::tokenRefreshed(BoolCallback callback, Networking::JsonResponse response) {
+void BaseStorage::tokenRefreshed(BoolCallback callback, const Networking::JsonResponse &response) {
 	bool success = true;
 
-	Common::JSONValue *json = response.value;
+	const Common::JSONValue *json = response.value;
 	if (json == nullptr) {
 		debug(9, "BaseStorage::tokenRefreshed: got NULL instead of JSON!");
 		success = false;

--- a/backends/cloud/basestorage.h
+++ b/backends/cloud/basestorage.h
@@ -36,19 +36,19 @@ protected:
 	 * Gets token from cloud.scummvm.org using given code.
 	 * Base implementation for storages with common auth procedure.
 	 */
-	virtual void getAccessToken(Common::String code, Networking::ErrorCallback callback);
+	virtual void getAccessToken(const Common::String &code, Networking::ErrorCallback callback);
 
 	/**
 	 * Handles JSON response which should contain access token requested
 	 * with getAccessToken().
 	 */
-	virtual void codeFlowComplete(Networking::ErrorCallback callback, Networking::JsonResponse response);
+	virtual void codeFlowComplete(Networking::ErrorCallback callback, const Networking::JsonResponse &response);
 
 	/**
 	 * Handles network errors occurred while getting access token requested
 	 * with getAccessToken().
 	 */
-	virtual void codeFlowFailed(Networking::ErrorCallback callback, Networking::ErrorResponse error);
+	virtual void codeFlowFailed(Networking::ErrorCallback callback, const Networking::ErrorResponse &error);
 
 	/**
 	 * Return cloud provider name, used in cloud.scummvm.org endpoints.
@@ -74,7 +74,7 @@ protected:
 	virtual bool canReuseRefreshToken() = 0;
 
 private:
-	void tokenRefreshed(BoolCallback callback, Networking::JsonResponse response);
+	void tokenRefreshed(BoolCallback callback, const Networking::JsonResponse &response);
 
 protected:
 	/** Helper function to save Storage::_isEnabled into config. */
@@ -88,8 +88,8 @@ protected:
 
 public:
 	BaseStorage();
-	BaseStorage(Common::String token, Common::String refreshToken, bool enabled = false);
-	virtual ~BaseStorage();
+	BaseStorage(const Common::String &token, const Common::String &refreshToken, bool enabled = false);
+	~BaseStorage() override;
 
 	/**
 	 * Gets new access_token. Pass a callback, so you could

--- a/backends/cloud/box/boxlistdirectorybyidrequest.h
+++ b/backends/cloud/box/boxlistdirectorybyidrequest.h
@@ -44,16 +44,16 @@ class BoxListDirectoryByIdRequest: public Networking::Request {
 
 	void start();
 	void makeRequest(uint32 offset);
-	void responseCallback(Networking::JsonResponse response);
-	void errorCallback(Networking::ErrorResponse error);
+	void responseCallback(const Networking::JsonResponse &response);
+	void errorCallback(const Networking::ErrorResponse &error);
 	void finishListing(Common::Array<StorageFile> &files);
 public:
-	BoxListDirectoryByIdRequest(BoxStorage *storage, Common::String id, Storage::ListDirectoryCallback cb, Networking::ErrorCallback ecb);
-	virtual ~BoxListDirectoryByIdRequest();
+	BoxListDirectoryByIdRequest(BoxStorage *storage, const Common::String &id, Storage::ListDirectoryCallback cb, Networking::ErrorCallback ecb);
+	~BoxListDirectoryByIdRequest() override;
 
-	virtual void handle();
-	virtual void restart();
-	virtual Common::String date() const;
+	void handle() override;
+	void restart() override;
+	Common::String date() const override;
 };
 
 } // End of namespace Box

--- a/backends/cloud/box/boxstorage.cpp
+++ b/backends/cloud/box/boxstorage.cpp
@@ -41,14 +41,14 @@ namespace Box {
 #define BOX_API_FILES_CONTENT "https://api.box.com/2.0/files/%s/content"
 #define BOX_API_USERS_ME "https://api.box.com/2.0/users/me"
 
-BoxStorage::BoxStorage(Common::String token, Common::String refreshToken, bool enabled):
+BoxStorage::BoxStorage(const Common::String &token, const Common::String &refreshToken, bool enabled):
 	IdStorage(token, refreshToken, enabled) {}
 
-BoxStorage::BoxStorage(Common::String code, Networking::ErrorCallback cb) {
+BoxStorage::BoxStorage(const Common::String &code, Networking::ErrorCallback cb) {
 	getAccessToken(code, cb);
 }
 
-BoxStorage::BoxStorage(Networking::JsonResponse codeFlowJson, Networking::ErrorCallback cb) {
+BoxStorage::BoxStorage(const Networking::JsonResponse &codeFlowJson, Networking::ErrorCallback cb) {
 	codeFlowComplete(cb, codeFlowJson);
 }
 
@@ -62,7 +62,7 @@ bool BoxStorage::needsRefreshToken() { return true; }
 
 bool BoxStorage::canReuseRefreshToken() { return false; }
 
-void BoxStorage::saveConfig(Common::String keyPrefix) {
+void BoxStorage::saveConfig(const Common::String &keyPrefix) {
 	ConfMan.set(keyPrefix + "access_token", _token, ConfMan.kCloudDomain);
 	ConfMan.set(keyPrefix + "refresh_token", _refreshToken, ConfMan.kCloudDomain);
 	saveIsEnabledFlag(keyPrefix);
@@ -72,8 +72,8 @@ Common::String BoxStorage::name() const {
 	return "Box";
 }
 
-void BoxStorage::infoInnerCallback(StorageInfoCallback outerCallback, Networking::JsonResponse response) {
-	Common::JSONValue *json = response.value;
+void BoxStorage::infoInnerCallback(StorageInfoCallback outerCallback, const Networking::JsonResponse &response) {
+	const Common::JSONValue *json = response.value;
 	if (!json) {
 		warning("BoxStorage::infoInnerCallback: NULL passed instead of JSON");
 		delete outerCallback;
@@ -122,7 +122,7 @@ void BoxStorage::infoInnerCallback(StorageInfoCallback outerCallback, Networking
 	delete json;
 }
 
-Networking::Request *BoxStorage::listDirectoryById(Common::String id, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback) {
+Networking::Request *BoxStorage::listDirectoryById(const Common::String &id, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback) {
 	if (!errorCallback)
 		errorCallback = getErrorPrintingCallback();
 	if (!callback)
@@ -130,8 +130,8 @@ Networking::Request *BoxStorage::listDirectoryById(Common::String id, ListDirect
 	return addRequest(new BoxListDirectoryByIdRequest(this, id, callback, errorCallback));
 }
 
-void BoxStorage::createDirectoryInnerCallback(BoolCallback outerCallback, Networking::JsonResponse response) {
-	Common::JSONValue *json = response.value;
+void BoxStorage::createDirectoryInnerCallback(BoolCallback outerCallback, const Networking::JsonResponse &response) {
+	const Common::JSONValue *json = response.value;
 	if (!json) {
 		warning("BoxStorage::createDirectoryInnerCallback: NULL passed instead of JSON");
 		delete outerCallback;
@@ -151,12 +151,12 @@ void BoxStorage::createDirectoryInnerCallback(BoolCallback outerCallback, Networ
 	delete json;
 }
 
-Networking::Request *BoxStorage::createDirectoryWithParentId(Common::String parentId, Common::String directoryName, BoolCallback callback, Networking::ErrorCallback errorCallback) {
+Networking::Request *BoxStorage::createDirectoryWithParentId(const Common::String &parentId, const Common::String &directoryName, BoolCallback callback, Networking::ErrorCallback errorCallback) {
 	if (!errorCallback)
 		errorCallback = getErrorPrintingCallback();
 
 	Common::String url = BOX_API_FOLDERS;
-	Networking::JsonCallback innerCallback = new Common::CallbackBridge<BoxStorage, BoolResponse, Networking::JsonResponse>(this, &BoxStorage::createDirectoryInnerCallback, callback);
+	Networking::JsonCallback innerCallback = new Common::CallbackBridge<BoxStorage, const BoolResponse &, const Networking::JsonResponse &>(this, &BoxStorage::createDirectoryInnerCallback, callback);
 	Networking::CurlJsonRequest *request = new BoxTokenRefresher(this, innerCallback, errorCallback, url.c_str());
 	request->addHeader("Authorization: Bearer " + accessToken());
 	request->addHeader("Content-Type: application/json");
@@ -174,13 +174,13 @@ Networking::Request *BoxStorage::createDirectoryWithParentId(Common::String pare
 	return addRequest(request);
 }
 
-Networking::Request *BoxStorage::upload(Common::String remotePath, Common::String localPath, UploadCallback callback, Networking::ErrorCallback errorCallback) {
+Networking::Request *BoxStorage::upload(const Common::String &remotePath, const Common::String &localPath, UploadCallback callback, Networking::ErrorCallback errorCallback) {
 	if (!errorCallback)
 		errorCallback = getErrorPrintingCallback();
 	return addRequest(new BoxUploadRequest(this, remotePath, localPath, callback, errorCallback));
 }
 
-Networking::Request *BoxStorage::upload(Common::String path, Common::SeekableReadStream *contents, UploadCallback callback, Networking::ErrorCallback errorCallback) {
+Networking::Request *BoxStorage::upload(const Common::String &path, Common::SeekableReadStream *contents, UploadCallback callback, Networking::ErrorCallback errorCallback) {
 	warning("BoxStorage::upload(ReadStream) not implemented");
 	if (errorCallback)
 		(*errorCallback)(Networking::ErrorResponse(nullptr, false, true, "BoxStorage::upload(ReadStream) not implemented", -1));
@@ -193,7 +193,7 @@ bool BoxStorage::uploadStreamSupported() {
 	return false;
 }
 
-Networking::Request *BoxStorage::streamFileById(Common::String id, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) {
+Networking::Request *BoxStorage::streamFileById(const Common::String &id, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) {
 	if (callback) {
 		Common::String url = Common::String::format(BOX_API_FILES_CONTENT, id.c_str());
 		Common::String header = "Authorization: Bearer " + _token;
@@ -207,7 +207,7 @@ Networking::Request *BoxStorage::streamFileById(Common::String id, Networking::N
 }
 
 Networking::Request *BoxStorage::info(StorageInfoCallback callback, Networking::ErrorCallback errorCallback) {
-	Networking::JsonCallback innerCallback = new Common::CallbackBridge<BoxStorage, StorageInfoResponse, Networking::JsonResponse>(this, &BoxStorage::infoInnerCallback, callback);
+	Networking::JsonCallback innerCallback = new Common::CallbackBridge<BoxStorage, const StorageInfoResponse &, const Networking::JsonResponse &>(this, &BoxStorage::infoInnerCallback, callback);
 	Networking::CurlJsonRequest *request = new BoxTokenRefresher(this, innerCallback, errorCallback, BOX_API_USERS_ME);
 	request->addHeader("Authorization: Bearer " + _token);
 	return addRequest(request);
@@ -215,7 +215,7 @@ Networking::Request *BoxStorage::info(StorageInfoCallback callback, Networking::
 
 Common::String BoxStorage::savesDirectoryPath() { return "scummvm/saves/"; }
 
-BoxStorage *BoxStorage::loadFromConfig(Common::String keyPrefix) {
+BoxStorage *BoxStorage::loadFromConfig(const Common::String &keyPrefix) {
 	if (!ConfMan.hasKey(keyPrefix + "access_token", ConfMan.kCloudDomain)) {
 		warning("BoxStorage: no access_token found");
 		return nullptr;
@@ -231,7 +231,7 @@ BoxStorage *BoxStorage::loadFromConfig(Common::String keyPrefix) {
 	return new BoxStorage(accessToken, refreshToken, loadIsEnabledFlag(keyPrefix));
 }
 
-void BoxStorage::removeFromConfig(Common::String keyPrefix) {
+void BoxStorage::removeFromConfig(const Common::String &keyPrefix) {
 	ConfMan.removeKey(keyPrefix + "access_token", ConfMan.kCloudDomain);
 	ConfMan.removeKey(keyPrefix + "refresh_token", ConfMan.kCloudDomain);
 	removeIsEnabledFlag(keyPrefix);

--- a/backends/cloud/box/boxstorage.h
+++ b/backends/cloud/box/boxstorage.h
@@ -30,36 +30,36 @@ namespace Box {
 
 class BoxStorage: public Id::IdStorage {
 	/** This private constructor is called from loadFromConfig(). */
-	BoxStorage(Common::String token, Common::String refreshToken, bool enabled);
+	BoxStorage(const Common::String &token, const Common::String &refreshToken, bool enabled);
 
 	/** Constructs StorageInfo based on JSON response from cloud. */
-	void infoInnerCallback(StorageInfoCallback outerCallback, Networking::JsonResponse json);
+	void infoInnerCallback(StorageInfoCallback outerCallback, const Networking::JsonResponse &json);
 
-	void createDirectoryInnerCallback(BoolCallback outerCallback, Networking::JsonResponse response);
+	void createDirectoryInnerCallback(BoolCallback outerCallback, const Networking::JsonResponse &response);
 
 protected:
 	/**
 	 * @return "box"
 	 */
-	virtual Common::String cloudProvider();
+	Common::String cloudProvider() override;
 
 	/**
 	 * @return kStorageBoxId
 	 */
-	virtual uint32 storageIndex();
+	uint32 storageIndex() override;
 
-	virtual bool needsRefreshToken();
+	bool needsRefreshToken() override;
 
-	virtual bool canReuseRefreshToken();
+	bool canReuseRefreshToken() override;
 
 public:
 	/** This constructor uses OAuth code flow to get tokens. */
-	BoxStorage(Common::String code, Networking::ErrorCallback cb);
+	BoxStorage(const Common::String &code, Networking::ErrorCallback cb);
 
 	/** This constructor extracts tokens from JSON acquired via OAuth code flow. */
-	BoxStorage(Networking::JsonResponse codeFlowJson, Networking::ErrorCallback cb);
+	BoxStorage(const Networking::JsonResponse &codeFlowJson, Networking::ErrorCallback cb);
 
-	virtual ~BoxStorage();
+	~BoxStorage() override;
 
 	/**
 	 * Storage methods, which are used by CloudManager to save
@@ -72,47 +72,47 @@ public:
 	 * @note every Storage must write keyPrefix + "type" key
 	 *       with common value (e.g. "Dropbox").
 	 */
-	virtual void saveConfig(Common::String keyPrefix);
+	void saveConfig(const Common::String &keyPrefix) override;
 
 	/**
 	* Return unique storage name.
 	* @returns  some unique storage name (for example, "Dropbox (user@example.com)")
 	*/
-	virtual Common::String name() const;
+	Common::String name() const override;
 
 	/** Public Cloud API comes down there. */
 
-	virtual Networking::Request *listDirectoryById(Common::String id, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback);
-	virtual Networking::Request *createDirectoryWithParentId(Common::String parentId, Common::String directoryName, BoolCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *listDirectoryById(const Common::String &id, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback) override;
+	Networking::Request *createDirectoryWithParentId(const Common::String &parentId, const Common::String &directoryName, BoolCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	/** Returns UploadStatus struct with info about uploaded file. */
-	virtual Networking::Request *upload(Common::String remotePath, Common::String localPath, UploadCallback callback, Networking::ErrorCallback errorCallback);
-	virtual Networking::Request *upload(Common::String path, Common::SeekableReadStream *contents, UploadCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *upload(const Common::String &remotePath, const Common::String &localPath, UploadCallback callback, Networking::ErrorCallback errorCallback) override;
+	Networking::Request *upload(const Common::String &path, Common::SeekableReadStream *contents, UploadCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	/** Returns whether Storage supports upload(ReadStream). */
-	virtual bool uploadStreamSupported();
+	bool uploadStreamSupported() override;
 
 	/** Returns pointer to Networking::NetworkReadStream. */
-	virtual Networking::Request *streamFileById(Common::String path, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *streamFileById(const Common::String &path, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	/** Returns the StorageInfo struct. */
-	virtual Networking::Request *info(StorageInfoCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *info(StorageInfoCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	/** Returns storage's saves directory path with the trailing slash. */
-	virtual Common::String savesDirectoryPath();
+	Common::String savesDirectoryPath() override;
 
 	/**
 	 * Load token and user id from configs and return BoxStorage for those.
 	 * @return pointer to the newly created BoxStorage or 0 if some problem occurred.
 	 */
-	static BoxStorage *loadFromConfig(Common::String keyPrefix);
+	static BoxStorage *loadFromConfig(const Common::String &keyPrefix);
 
 	/**
 	 * Remove all BoxStorage-related data from config.
 	 */
-	static void removeFromConfig(Common::String keyPrefix);
+	static void removeFromConfig(const Common::String &keyPrefix);
 
-	virtual Common::String getRootDirectoryId();
+	Common::String getRootDirectoryId() override;
 
 	Common::String accessToken() const { return _token; }
 };

--- a/backends/cloud/box/boxtokenrefresher.cpp
+++ b/backends/cloud/box/boxtokenrefresher.cpp
@@ -36,7 +36,7 @@ BoxTokenRefresher::BoxTokenRefresher(BoxStorage *parent, Networking::JsonCallbac
 
 BoxTokenRefresher::~BoxTokenRefresher() {}
 
-void BoxTokenRefresher::tokenRefreshed(Storage::BoolResponse response) {
+void BoxTokenRefresher::tokenRefreshed(const Storage::BoolResponse &response) {
 	if (!response.value) {
 		//failed to refresh token, notify user with NULL in original callback
 		warning("BoxTokenRefresher: failed to refresh token");
@@ -56,7 +56,7 @@ void BoxTokenRefresher::tokenRefreshed(Storage::BoolResponse response) {
 	retry(0);
 }
 
-void BoxTokenRefresher::finishJson(Common::JSONValue *json) {
+void BoxTokenRefresher::finishJson(const Common::JSONValue *json) {
 	if (!json) {
 		//that's probably not an error (200 OK)
 		CurlJsonRequest::finishJson(nullptr);
@@ -98,7 +98,7 @@ void BoxTokenRefresher::finishJson(Common::JSONValue *json) {
 
 			pause();
 			delete json;
-			_parentStorage->refreshAccessToken(new Common::Callback<BoxTokenRefresher, Storage::BoolResponse>(this, &BoxTokenRefresher::tokenRefreshed));
+			_parentStorage->refreshAccessToken(new Common::Callback<BoxTokenRefresher, const Storage::BoolResponse &>(this, &BoxTokenRefresher::tokenRefreshed));
 			return;
 		}
 	}
@@ -107,10 +107,10 @@ void BoxTokenRefresher::finishJson(Common::JSONValue *json) {
 	CurlJsonRequest::finishJson(json);
 }
 
-void BoxTokenRefresher::finishError(Networking::ErrorResponse error, Networking::RequestState state) {
+void BoxTokenRefresher::finishError(const Networking::ErrorResponse &error, Networking::RequestState state) {
 	if (error.httpResponseCode == 401) { // invalid_token
 		pause();
-		_parentStorage->refreshAccessToken(new Common::Callback<BoxTokenRefresher, Storage::BoolResponse>(this, &BoxTokenRefresher::tokenRefreshed));
+		_parentStorage->refreshAccessToken(new Common::Callback<BoxTokenRefresher, const Storage::BoolResponse &>(this, &BoxTokenRefresher::tokenRefreshed));
 		return;
 	}
 
@@ -120,7 +120,7 @@ void BoxTokenRefresher::finishError(Networking::ErrorResponse error, Networking:
 	Request::finishError(error);
 }
 
-void BoxTokenRefresher::setHeaders(Common::Array<Common::String> &headers) {
+void BoxTokenRefresher::setHeaders(const Common::Array<Common::String> &headers) {
 	_headers = headers;
 	curl_slist_free_all(_headersList);
 	_headersList = nullptr;
@@ -128,7 +128,7 @@ void BoxTokenRefresher::setHeaders(Common::Array<Common::String> &headers) {
 		CurlJsonRequest::addHeader(headers[i]);
 }
 
-void BoxTokenRefresher::addHeader(Common::String header) {
+void BoxTokenRefresher::addHeader(const Common::String  &header) {
 	_headers.push_back(header);
 	CurlJsonRequest::addHeader(header);
 }

--- a/backends/cloud/box/boxtokenrefresher.h
+++ b/backends/cloud/box/boxtokenrefresher.h
@@ -34,16 +34,16 @@ class BoxTokenRefresher: public Networking::CurlJsonRequest {
 	BoxStorage *_parentStorage;
 	Common::Array<Common::String> _headers;
 
-	void tokenRefreshed(Storage::BoolResponse response);
+	void tokenRefreshed(const Storage::BoolResponse &response);
 
-	virtual void finishJson(Common::JSONValue *json);
-	virtual void finishError(Networking::ErrorResponse error, Networking::RequestState state = Networking::FINISHED);
+	void finishJson(const Common::JSONValue *json) override;
+	void finishError(const Networking::ErrorResponse &error, Networking::RequestState state = Networking::FINISHED) override;
 public:
 	BoxTokenRefresher(BoxStorage *parent, Networking::JsonCallback callback, Networking::ErrorCallback ecb, const char *url);
-	virtual ~BoxTokenRefresher();
+	~BoxTokenRefresher() override;
 
-	virtual void setHeaders(Common::Array<Common::String> &headers);
-	virtual void addHeader(Common::String header);
+	void setHeaders(const Common::Array<Common::String> &headers) override;
+	void addHeader(const Common::String &header) override;
 };
 
 } // End of namespace Box

--- a/backends/cloud/box/boxuploadrequest.h
+++ b/backends/cloud/box/boxuploadrequest.h
@@ -41,19 +41,19 @@ class BoxUploadRequest: public Networking::Request {
 
 	void start();
 	void resolveId();
-	void idResolvedCallback(Storage::UploadResponse response);
-	void idResolveFailedCallback(Networking::ErrorResponse error);
+	void idResolvedCallback(const Storage::UploadResponse &response);
+	void idResolveFailedCallback(const Networking::ErrorResponse &error);
 	void upload();
-	void uploadedCallback(Networking::JsonResponse response);
-	void notUploadedCallback(Networking::ErrorResponse error);
-	void finishUpload(StorageFile status);
+	void uploadedCallback(const Networking::JsonResponse &response);
+	void notUploadedCallback(const Networking::ErrorResponse &error);
+	void finishUpload(const StorageFile &status);
 
 public:
-	BoxUploadRequest(BoxStorage *storage, Common::String path, Common::String localPath, Storage::UploadCallback callback, Networking::ErrorCallback ecb);
-	virtual ~BoxUploadRequest();
+	BoxUploadRequest(BoxStorage *storage, const Common::String &path, const Common::String &localPath, Storage::UploadCallback callback, Networking::ErrorCallback ecb);
+	~BoxUploadRequest() override;
 
-	virtual void handle();
-	virtual void restart();
+	void handle() override;
+	void restart() override;
 };
 
 } // End of namespace Box

--- a/backends/cloud/cloudmanager.cpp
+++ b/backends/cloud/cloudmanager.cpp
@@ -237,7 +237,7 @@ Common::String CloudManager::getStorageLastSync(uint32 index) {
 	return _storages[index].lastSyncDate;
 }
 
-void CloudManager::setStorageUsername(uint32 index, Common::String name) {
+void CloudManager::setStorageUsername(uint32 index, const Common::String &name) {
 	if (index >= _storages.size())
 		return;
 	_storages[index].username = name;
@@ -251,14 +251,14 @@ void CloudManager::setStorageUsedSpace(uint32 index, uint64 used) {
 	save();
 }
 
-void CloudManager::setStorageLastSync(uint32 index, Common::String date) {
+void CloudManager::setStorageLastSync(uint32 index, const Common::String &date) {
 	if (index >= _storages.size())
 		return;
 	_storages[index].lastSyncDate = date;
 	save();
 }
 
-void CloudManager::connectStorage(uint32 index, Common::String code, Networking::ErrorCallback cb) {
+void CloudManager::connectStorage(uint32 index, const Common::String &code, Networking::ErrorCallback cb) {
 	freeStorages();
 
 	switch (index) {
@@ -309,7 +309,7 @@ void CloudManager::connectStorage(uint32 index, Networking::JsonResponse codeFlo
 }
 
 bool CloudManager::connectStorage(Networking::JsonResponse codeFlowJson, Networking::ErrorCallback cb) {
-	Common::JSONValue *json = (Common::JSONValue *)codeFlowJson.value;
+	const Common::JSONValue *json = codeFlowJson.value;
 	if (json == nullptr || !json->isObject()) {
 		return false;
 	}
@@ -381,7 +381,7 @@ void CloudManager::disconnectStorage(uint32 index) {
 }
 
 
-Networking::Request *CloudManager::listDirectory(Common::String path, Storage::ListDirectoryCallback callback, Networking::ErrorCallback errorCallback, bool recursive) {
+Networking::Request *CloudManager::listDirectory(const Common::String &path, Storage::ListDirectoryCallback callback, Networking::ErrorCallback errorCallback, bool recursive) {
 	Storage *storage = getCurrentStorage();
 	if (storage) {
 		return storage->listDirectory(path, callback, errorCallback, recursive);
@@ -393,7 +393,7 @@ Networking::Request *CloudManager::listDirectory(Common::String path, Storage::L
 	return nullptr;
 }
 
-Networking::Request *CloudManager::downloadFolder(Common::String remotePath, Common::String localPath, Storage::FileArrayCallback callback, Networking::ErrorCallback errorCallback, bool recursive) {
+Networking::Request *CloudManager::downloadFolder(const Common::String &remotePath, const Common::String &localPath, Storage::FileArrayCallback callback, Networking::ErrorCallback errorCallback, bool recursive) {
 	Storage *storage = getCurrentStorage();
 	if (storage) {
 		return storage->downloadFolder(remotePath, localPath, callback, errorCallback, recursive);
@@ -514,7 +514,7 @@ void CloudManager::showCloudDisabledIcon() {
 
 ///// DownloadFolderRequest-related /////
 
-bool CloudManager::startDownload(Common::String remotePath, Common::String localPath) const {
+bool CloudManager::startDownload(const Common::String &remotePath, const Common::String &localPath) const {
 	Storage *storage = getCurrentStorage();
 	if (storage)
 		return storage->startDownload(remotePath, localPath);

--- a/backends/cloud/cloudmanager.h
+++ b/backends/cloud/cloudmanager.h
@@ -90,7 +90,7 @@ class CloudManager : public Common::Singleton<CloudManager>, public Common::Even
 
 public:
 	CloudManager();
-	virtual ~CloudManager();
+	~CloudManager() override;
 
 	/**
 	 * Loads all information from configs and creates current Storage instance.
@@ -178,7 +178,7 @@ public:
 	 * @param   index   Storage's index.
 	 * @param   name    username to set
 	 */
-	void setStorageUsername(uint32 index, Common::String name);
+	void setStorageUsername(uint32 index, const Common::String &name);
 
 	/**
 	 * Set Storage's used space field.
@@ -196,7 +196,7 @@ public:
 	 * @param   index   Storage's index.
 	 * @param   date    date to set
 	 */
-	void setStorageLastSync(uint32 index, Common::String date);
+	void setStorageLastSync(uint32 index, const Common::String &date);
 
 	/**
 	 * Replace Storage which has given index with a
@@ -206,7 +206,7 @@ public:
 	 * @param   code    OAuth2 code received from user
 	 * @param	cb		callback to notify of success or error
 	 */
-	void connectStorage(uint32 index, Common::String code, Networking::ErrorCallback cb = nullptr);
+	void connectStorage(uint32 index, const Common::String &code, Networking::ErrorCallback cb = nullptr);
 
 	/**
 	 * Replace Storage which has given index with a
@@ -237,10 +237,10 @@ public:
 	void disconnectStorage(uint32 index);
 
 	/** Returns ListDirectoryResponse with list of files. */
-	Networking::Request *listDirectory(Common::String path, Storage::ListDirectoryCallback callback, Networking::ErrorCallback errorCallback, bool recursive = false);
+	Networking::Request *listDirectory(const Common::String &path, Storage::ListDirectoryCallback callback, Networking::ErrorCallback errorCallback, bool recursive = false);
 
 	/** Returns Common::Array<StorageFile> with list of files, which were not downloaded. */
-	Networking::Request *downloadFolder(Common::String remotePath, Common::String localPath, Storage::FileArrayCallback callback, Networking::ErrorCallback errorCallback, bool recursive = false);
+	Networking::Request *downloadFolder(const Common::String &remotePath, const Common::String &localPath, Storage::FileArrayCallback callback, Networking::ErrorCallback errorCallback, bool recursive = false);
 
 	/** Return the StorageInfo struct. */
 	Networking::Request *info(Storage::StorageInfoCallback callback, Networking::ErrorCallback errorCallback);
@@ -291,7 +291,7 @@ public:
 	///// DownloadFolderRequest-related /////
 
 	/** Starts a folder download. */
-	bool startDownload(Common::String remotePath, Common::String localPath) const;
+	bool startDownload(const Common::String &remotePath, const Common::String &localPath) const;
 
 	/** Cancels running download. */
 	void cancelDownload() const;

--- a/backends/cloud/downloadrequest.cpp
+++ b/backends/cloud/downloadrequest.cpp
@@ -25,7 +25,7 @@
 
 namespace Cloud {
 
-DownloadRequest::DownloadRequest(Storage *storage, Storage::BoolCallback callback, Networking::ErrorCallback ecb, Common::String remoteFileId, Common::DumpFile *dumpFile):
+DownloadRequest::DownloadRequest(Storage *storage, Storage::BoolCallback callback, Networking::ErrorCallback ecb, const Common::String &remoteFileId, Common::DumpFile *dumpFile):
 	Request(nullptr, ecb), _boolCallback(callback), _localFile(dumpFile), _remoteFileId(remoteFileId), _storage(storage),
 	_remoteFileStream(nullptr), _workingRequest(nullptr), _ignoreCallback(false), _buffer(new byte[DOWNLOAD_REQUEST_BUFFER_SIZE]) {
 	start();
@@ -50,19 +50,19 @@ void DownloadRequest::start() {
 
 	_workingRequest = _storage->streamFileById(
 		_remoteFileId,
-		new Common::Callback<DownloadRequest, Networking::NetworkReadStreamResponse>(this, &DownloadRequest::streamCallback),
-		new Common::Callback<DownloadRequest, Networking::ErrorResponse>(this, &DownloadRequest::streamErrorCallback)
+		new Common::Callback<DownloadRequest, const Networking::NetworkReadStreamResponse &>(this, &DownloadRequest::streamCallback),
+		new Common::Callback<DownloadRequest, const Networking::ErrorResponse &>(this, &DownloadRequest::streamErrorCallback)
 	);
 }
 
-void DownloadRequest::streamCallback(Networking::NetworkReadStreamResponse response) {
+void DownloadRequest::streamCallback(const Networking::NetworkReadStreamResponse &response) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
-	_remoteFileStream = (Networking::NetworkReadStream *)response.value;
+	_remoteFileStream = response.value;
 }
 
-void DownloadRequest::streamErrorCallback(Networking::ErrorResponse error) {
+void DownloadRequest::streamErrorCallback(const Networking::ErrorResponse &error) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
@@ -122,7 +122,7 @@ void DownloadRequest::finishDownload(bool success) {
 		(*_boolCallback)(Storage::BoolResponse(this, success));
 }
 
-void DownloadRequest::finishError(Networking::ErrorResponse error, Networking::RequestState state) {
+void DownloadRequest::finishError(const Networking::ErrorResponse &error, Networking::RequestState state) {
 	if (_localFile)
 		_localFile->close();
 	Request::finishError(error);

--- a/backends/cloud/downloadrequest.h
+++ b/backends/cloud/downloadrequest.h
@@ -42,17 +42,17 @@ class DownloadRequest: public Networking::Request {
 	byte *_buffer;
 
 	void start();
-	void streamCallback(Networking::NetworkReadStreamResponse response);
-	void streamErrorCallback(Networking::ErrorResponse error);
+	void streamCallback(const Networking::NetworkReadStreamResponse &response);
+	void streamErrorCallback(const Networking::ErrorResponse &error);
 	void finishDownload(bool success);
-	virtual void finishError(Networking::ErrorResponse error, Networking::RequestState state = Networking::FINISHED);
+	void finishError(const Networking::ErrorResponse &error, Networking::RequestState state = Networking::FINISHED) override;
 
 public:
-	DownloadRequest(Storage *storage, Storage::BoolCallback callback, Networking::ErrorCallback ecb, Common::String remoteFileId, Common::DumpFile *dumpFile);
-	virtual ~DownloadRequest();
+	DownloadRequest(Storage *storage, Storage::BoolCallback callback, Networking::ErrorCallback ecb, const Common::String &remoteFileId, Common::DumpFile *dumpFile);
+	~DownloadRequest() override;
 
-	virtual void handle();
-	virtual void restart();
+	void handle() override;
+	void restart() override;
 
 	/** Returns a number in range [0, 1], where 1 is "complete". */
 	double getProgress() const;

--- a/backends/cloud/dropbox/dropboxcreatedirectoryrequest.cpp
+++ b/backends/cloud/dropbox/dropboxcreatedirectoryrequest.cpp
@@ -33,7 +33,7 @@ namespace Dropbox {
 
 #define DROPBOX_API_CREATE_FOLDER "https://api.dropboxapi.com/2/files/create_folder"
 
-DropboxCreateDirectoryRequest::DropboxCreateDirectoryRequest(DropboxStorage *storage, Common::String path, Storage::BoolCallback cb, Networking::ErrorCallback ecb):
+DropboxCreateDirectoryRequest::DropboxCreateDirectoryRequest(DropboxStorage *storage, const Common::String &path, Storage::BoolCallback cb, Networking::ErrorCallback ecb):
 	Networking::Request(nullptr, ecb), _storage(storage), _path(path), _boolCallback(cb),
 	_workingRequest(nullptr), _ignoreCallback(false) {
 	start();
@@ -52,8 +52,8 @@ void DropboxCreateDirectoryRequest::start() {
 		_workingRequest->finish();
 	_ignoreCallback = false;
 
-	Networking::JsonCallback innerCallback = new Common::Callback<DropboxCreateDirectoryRequest, Networking::JsonResponse>(this, &DropboxCreateDirectoryRequest::responseCallback);
-	Networking::ErrorCallback errorResponseCallback = new Common::Callback<DropboxCreateDirectoryRequest, Networking::ErrorResponse>(this, &DropboxCreateDirectoryRequest::errorCallback);
+	Networking::JsonCallback innerCallback = new Common::Callback<DropboxCreateDirectoryRequest, const Networking::JsonResponse &>(this, &DropboxCreateDirectoryRequest::responseCallback);
+	Networking::ErrorCallback errorResponseCallback = new Common::Callback<DropboxCreateDirectoryRequest, const Networking::ErrorResponse &>(this, &DropboxCreateDirectoryRequest::errorCallback);
 	Networking::CurlJsonRequest *request = new DropboxTokenRefresher(_storage, innerCallback, errorResponseCallback, DROPBOX_API_CREATE_FOLDER);
 	request->addHeader("Authorization: Bearer " + _storage->accessToken());
 	request->addHeader("Content-Type: application/json");
@@ -66,8 +66,8 @@ void DropboxCreateDirectoryRequest::start() {
 	_workingRequest = ConnMan.addRequest(request);
 }
 
-void DropboxCreateDirectoryRequest::responseCallback(Networking::JsonResponse response) {
-	Common::JSONValue *json = response.value;
+void DropboxCreateDirectoryRequest::responseCallback(const Networking::JsonResponse &response) {
+	const Common::JSONValue *json = response.value;
 	_workingRequest = nullptr;
 	if (_ignoreCallback) {
 		delete json;
@@ -76,7 +76,7 @@ void DropboxCreateDirectoryRequest::responseCallback(Networking::JsonResponse re
 	if (response.request) _date = response.request->date();
 
 	Networking::ErrorResponse error(this, "DropboxCreateDirectoryRequest::responseCallback: unknown error");
-	Networking::CurlJsonRequest *rq = (Networking::CurlJsonRequest *)response.request;
+	const Networking::CurlJsonRequest *rq = (const Networking::CurlJsonRequest *)response.request;
 	if (rq && rq->getNetworkReadStream())
 		error.httpResponseCode = rq->getNetworkReadStream()->httpResponseCode();
 
@@ -113,7 +113,7 @@ void DropboxCreateDirectoryRequest::responseCallback(Networking::JsonResponse re
 	delete json;
 }
 
-void DropboxCreateDirectoryRequest::errorCallback(Networking::ErrorResponse error) {
+void DropboxCreateDirectoryRequest::errorCallback(const Networking::ErrorResponse &error) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;

--- a/backends/cloud/dropbox/dropboxcreatedirectoryrequest.h
+++ b/backends/cloud/dropbox/dropboxcreatedirectoryrequest.h
@@ -40,16 +40,16 @@ class DropboxCreateDirectoryRequest: public Networking::Request {
 	Common::String _date;
 
 	void start();
-	void responseCallback(Networking::JsonResponse response);
-	void errorCallback(Networking::ErrorResponse error);
+	void responseCallback(const Networking::JsonResponse &response);
+	void errorCallback(const Networking::ErrorResponse &error);
 	void finishCreation(bool success);
 public:
-	DropboxCreateDirectoryRequest(DropboxStorage *storage, Common::String path, Storage::BoolCallback cb, Networking::ErrorCallback ecb);
-	virtual ~DropboxCreateDirectoryRequest();
+	DropboxCreateDirectoryRequest(DropboxStorage *storage, const Common::String &path, Storage::BoolCallback cb, Networking::ErrorCallback ecb);
+	~DropboxCreateDirectoryRequest() override;
 
-	virtual void handle();
-	virtual void restart();
-	virtual Common::String date() const;
+	void handle() override;
+	void restart() override;
+	Common::String date() const override;
 };
 
 } // End of namespace Dropbox

--- a/backends/cloud/dropbox/dropboxinforequest.cpp
+++ b/backends/cloud/dropbox/dropboxinforequest.cpp
@@ -54,8 +54,8 @@ void DropboxInfoRequest::start() {
 		_workingRequest->finish();
 	_ignoreCallback = false;
 
-	Networking::JsonCallback innerCallback = new Common::Callback<DropboxInfoRequest, Networking::JsonResponse>(this, &DropboxInfoRequest::userResponseCallback);
-	Networking::ErrorCallback errorResponseCallback = new Common::Callback<DropboxInfoRequest, Networking::ErrorResponse>(this, &DropboxInfoRequest::errorCallback);
+	Networking::JsonCallback innerCallback = new Common::Callback<DropboxInfoRequest, const Networking::JsonResponse &>(this, &DropboxInfoRequest::userResponseCallback);
+	Networking::ErrorCallback errorResponseCallback = new Common::Callback<DropboxInfoRequest, const Networking::ErrorResponse &>(this, &DropboxInfoRequest::errorCallback);
 	Networking::CurlJsonRequest *request = new DropboxTokenRefresher(_storage, innerCallback, errorResponseCallback, DROPBOX_API_GET_CURRENT_ACCOUNT);
 	request->addHeader("Authorization: Bearer " + _storage->accessToken());
 	request->addHeader("Content-Type: application/json");
@@ -64,8 +64,8 @@ void DropboxInfoRequest::start() {
 	_workingRequest = ConnMan.addRequest(request);
 }
 
-void DropboxInfoRequest::userResponseCallback(Networking::JsonResponse response) {
-	Common::JSONValue *json = response.value;
+void DropboxInfoRequest::userResponseCallback(const Networking::JsonResponse &response) {
+	const Common::JSONValue *json = response.value;
 	_workingRequest = nullptr;
 	if (_ignoreCallback) {
 		delete json;
@@ -73,7 +73,7 @@ void DropboxInfoRequest::userResponseCallback(Networking::JsonResponse response)
 	}
 
 	Networking::ErrorResponse error(this, "DropboxInfoRequest::userResponseCallback: unknown error");
-	Networking::CurlJsonRequest *rq = (Networking::CurlJsonRequest *)response.request;
+	const Networking::CurlJsonRequest *rq = (const Networking::CurlJsonRequest *)response.request;
 	if (rq && rq->getNetworkReadStream())
 		error.httpResponseCode = rq->getNetworkReadStream()->httpResponseCode();
 
@@ -108,8 +108,8 @@ void DropboxInfoRequest::userResponseCallback(Networking::JsonResponse response)
 	CloudMan.setStorageUsername(kStorageDropboxId, _email);
 	delete json;
 
-	Networking::JsonCallback innerCallback = new Common::Callback<DropboxInfoRequest, Networking::JsonResponse>(this, &DropboxInfoRequest::quotaResponseCallback);
-	Networking::ErrorCallback errorResponseCallback = new Common::Callback<DropboxInfoRequest, Networking::ErrorResponse>(this, &DropboxInfoRequest::errorCallback);
+	Networking::JsonCallback innerCallback = new Common::Callback<DropboxInfoRequest, const Networking::JsonResponse &>(this, &DropboxInfoRequest::quotaResponseCallback);
+	Networking::ErrorCallback errorResponseCallback = new Common::Callback<DropboxInfoRequest, const Networking::ErrorResponse &>(this, &DropboxInfoRequest::errorCallback);
 	Networking::CurlJsonRequest *request = new DropboxTokenRefresher(_storage, innerCallback, errorResponseCallback, DROPBOX_API_GET_SPACE_USAGE);
 	request->addHeader("Authorization: Bearer " + _storage->accessToken());
 	request->addHeader("Content-Type: application/json");
@@ -118,8 +118,8 @@ void DropboxInfoRequest::userResponseCallback(Networking::JsonResponse response)
 	_workingRequest = ConnMan.addRequest(request);
 }
 
-void DropboxInfoRequest::quotaResponseCallback(Networking::JsonResponse response) {
-	Common::JSONValue *json = response.value;
+void DropboxInfoRequest::quotaResponseCallback(const Networking::JsonResponse &response) {
+	const Common::JSONValue *json = response.value;
 	_workingRequest = nullptr;
 	if (_ignoreCallback) {
 		delete json;
@@ -127,7 +127,7 @@ void DropboxInfoRequest::quotaResponseCallback(Networking::JsonResponse response
 	}
 
 	Networking::ErrorResponse error(this, "DropboxInfoRequest::quotaResponseCallback: unknown error");
-	Networking::CurlJsonRequest *rq = (Networking::CurlJsonRequest *)response.request;
+	const Networking::CurlJsonRequest *rq = (const Networking::CurlJsonRequest *)response.request;
 	if (rq && rq->getNetworkReadStream())
 		error.httpResponseCode = rq->getNetworkReadStream()->httpResponseCode();
 
@@ -173,7 +173,7 @@ void DropboxInfoRequest::quotaResponseCallback(Networking::JsonResponse response
 	delete json;
 }
 
-void DropboxInfoRequest::errorCallback(Networking::ErrorResponse error) {
+void DropboxInfoRequest::errorCallback(const Networking::ErrorResponse &error) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback) return;
 	finishError(error);
@@ -183,7 +183,7 @@ void DropboxInfoRequest::handle() {}
 
 void DropboxInfoRequest::restart() { start(); }
 
-void DropboxInfoRequest::finishInfo(StorageInfo info) {
+void DropboxInfoRequest::finishInfo(const StorageInfo &info) {
 	Request::finishSuccess();
 	if (_infoCallback)
 		(*_infoCallback)(Storage::StorageInfoResponse(this, info));

--- a/backends/cloud/dropbox/dropboxinforequest.h
+++ b/backends/cloud/dropbox/dropboxinforequest.h
@@ -39,16 +39,16 @@ class DropboxInfoRequest: public Networking::Request {
 	bool _ignoreCallback;
 
 	void start();
-	void userResponseCallback(Networking::JsonResponse response);
-	void quotaResponseCallback(Networking::JsonResponse response);
-	void errorCallback(Networking::ErrorResponse error);
-	void finishInfo(StorageInfo info);
+	void userResponseCallback(const Networking::JsonResponse &response);
+	void quotaResponseCallback(const Networking::JsonResponse &response);
+	void errorCallback(const Networking::ErrorResponse &error);
+	void finishInfo(const StorageInfo &info);
 public:
 	DropboxInfoRequest(DropboxStorage *storage, Storage::StorageInfoCallback cb, Networking::ErrorCallback ecb);
-	virtual ~DropboxInfoRequest();
+	~DropboxInfoRequest() override;
 
-	virtual void handle();
-	virtual void restart();
+	void handle() override;
+	void restart() override;
 };
 
 } // End of namespace Dropbox

--- a/backends/cloud/dropbox/dropboxlistdirectoryrequest.h
+++ b/backends/cloud/dropbox/dropboxlistdirectoryrequest.h
@@ -44,16 +44,16 @@ class DropboxListDirectoryRequest: public Networking::Request {
 	Common::String _date;
 
 	void start();
-	void responseCallback(Networking::JsonResponse response);
-	void errorCallback(Networking::ErrorResponse error);
-	void finishListing(Common::Array<StorageFile> &files);
+	void responseCallback(const Networking::JsonResponse &response);
+	void errorCallback(const Networking::ErrorResponse &error);
+	void finishListing(const Common::Array<StorageFile> &files);
 public:
-	DropboxListDirectoryRequest(DropboxStorage *storage, Common::String path, Storage::ListDirectoryCallback cb, Networking::ErrorCallback ecb, bool recursive = false);
-	virtual ~DropboxListDirectoryRequest();
+	DropboxListDirectoryRequest(DropboxStorage *storage, const Common::String &path, Storage::ListDirectoryCallback cb, Networking::ErrorCallback ecb, bool recursive = false);
+	~DropboxListDirectoryRequest() override;
 
-	virtual void handle();
-	virtual void restart();
-	virtual Common::String date() const;
+	void handle() override;
+	void restart() override;
+	Common::String date() const override;
 };
 
 } // End of namespace Dropbox

--- a/backends/cloud/dropbox/dropboxstorage.cpp
+++ b/backends/cloud/dropbox/dropboxstorage.cpp
@@ -39,14 +39,14 @@ namespace Dropbox {
 
 #define DROPBOX_API_FILES_DOWNLOAD "https://content.dropboxapi.com/2/files/download"
 
-DropboxStorage::DropboxStorage(Common::String accessToken, Common::String refreshToken, bool enabled):
+DropboxStorage::DropboxStorage(const Common::String &accessToken, const Common::String &refreshToken, bool enabled):
 	BaseStorage(accessToken, refreshToken, enabled) {}
 
-DropboxStorage::DropboxStorage(Common::String code, Networking::ErrorCallback cb): BaseStorage() {
+DropboxStorage::DropboxStorage(const Common::String &code, Networking::ErrorCallback cb): BaseStorage() {
 	getAccessToken(code, cb);
 }
 
-DropboxStorage::DropboxStorage(Networking::JsonResponse codeFlowJson, Networking::ErrorCallback cb) : BaseStorage() {
+DropboxStorage::DropboxStorage(const Networking::JsonResponse &codeFlowJson, Networking::ErrorCallback cb) : BaseStorage() {
 	codeFlowComplete(cb, codeFlowJson);
 }
 
@@ -60,7 +60,7 @@ bool DropboxStorage::needsRefreshToken() { return true; }
 
 bool DropboxStorage::canReuseRefreshToken() { return true; }
 
-void DropboxStorage::saveConfig(Common::String keyPrefix) {
+void DropboxStorage::saveConfig(const Common::String &keyPrefix) {
 	ConfMan.set(keyPrefix + "access_token", _token, ConfMan.kCloudDomain);
 	ConfMan.set(keyPrefix + "refresh_token", _refreshToken, ConfMan.kCloudDomain);
 	saveIsEnabledFlag(keyPrefix);
@@ -70,15 +70,15 @@ Common::String DropboxStorage::name() const {
 	return "Dropbox";
 }
 
-Networking::Request *DropboxStorage::listDirectory(Common::String path, ListDirectoryCallback outerCallback, Networking::ErrorCallback errorCallback, bool recursive) {
+Networking::Request *DropboxStorage::listDirectory(const Common::String &path, ListDirectoryCallback outerCallback, Networking::ErrorCallback errorCallback, bool recursive) {
 	return addRequest(new DropboxListDirectoryRequest(this, path, outerCallback, errorCallback, recursive));
 }
 
-Networking::Request *DropboxStorage::upload(Common::String path, Common::SeekableReadStream *contents, UploadCallback callback, Networking::ErrorCallback errorCallback) {
+Networking::Request *DropboxStorage::upload(const Common::String &path, Common::SeekableReadStream *contents, UploadCallback callback, Networking::ErrorCallback errorCallback) {
 	return addRequest(new DropboxUploadRequest(this, path, contents, callback, errorCallback));
 }
 
-Networking::Request *DropboxStorage::streamFileById(Common::String path, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) {
+Networking::Request *DropboxStorage::streamFileById(const Common::String &path, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) {
 	Common::JSONObject jsonRequestParameters;
 	jsonRequestParameters.setVal("path", new Common::JSONValue(path));
 	Common::JSONValue value(jsonRequestParameters);
@@ -91,10 +91,10 @@ Networking::Request *DropboxStorage::streamFileById(Common::String path, Network
 	Networking::NetworkReadStreamResponse response = request->execute();
 	if (callback)
 		(*callback)(response);
-	return response.request; // no leak here, response.request == request
+	return request; // no leak here, response.request == request
 }
 
-Networking::Request *DropboxStorage::createDirectory(Common::String path, BoolCallback callback, Networking::ErrorCallback errorCallback) {
+Networking::Request *DropboxStorage::createDirectory(const Common::String &path, BoolCallback callback, Networking::ErrorCallback errorCallback) {
 	if (!errorCallback)
 		errorCallback = getErrorPrintingCallback();
 	return addRequest(new DropboxCreateDirectoryRequest(this, path, callback, errorCallback));
@@ -108,7 +108,7 @@ Networking::Request *DropboxStorage::info(StorageInfoCallback callback, Networki
 
 Common::String DropboxStorage::savesDirectoryPath() { return "/saves/"; }
 
-DropboxStorage *DropboxStorage::loadFromConfig(Common::String keyPrefix) {
+DropboxStorage *DropboxStorage::loadFromConfig(const Common::String &keyPrefix) {
 	if (!ConfMan.hasKey(keyPrefix + "access_token", ConfMan.kCloudDomain)) {
 		warning("DropboxStorage: no access_token found");
 		return nullptr;
@@ -124,7 +124,7 @@ DropboxStorage *DropboxStorage::loadFromConfig(Common::String keyPrefix) {
 	return new DropboxStorage(accessToken, refreshToken, loadIsEnabledFlag(keyPrefix));
 }
 
-void DropboxStorage::removeFromConfig(Common::String keyPrefix) {
+void DropboxStorage::removeFromConfig(const Common::String &keyPrefix) {
 	ConfMan.removeKey(keyPrefix + "access_token", ConfMan.kCloudDomain);
 	ConfMan.removeKey(keyPrefix + "refresh_token", ConfMan.kCloudDomain);
 	removeIsEnabledFlag(keyPrefix);

--- a/backends/cloud/dropbox/dropboxstorage.h
+++ b/backends/cloud/dropbox/dropboxstorage.h
@@ -31,31 +31,31 @@ namespace Dropbox {
 
 class DropboxStorage: public Cloud::BaseStorage {
 	/** This private constructor is called from loadFromConfig(). */
-	DropboxStorage(Common::String token, Common::String refreshToken, bool enabled);
+	DropboxStorage(const Common::String &token, const Common::String &refreshToken, bool enabled);
 
 protected:
 	/**
 	 * @return "dropbox"
 	 */
-	virtual Common::String cloudProvider();
+	Common::String cloudProvider() override;
 
 	/**
 	 * @return kStorageDropboxId
 	 */
-	virtual uint32 storageIndex();
+	uint32 storageIndex() override;
 
-	virtual bool needsRefreshToken();
+	bool needsRefreshToken() override;
 
-	virtual bool canReuseRefreshToken();
+	bool canReuseRefreshToken() override;
 
 public:
 	/** This constructor uses OAuth code flow to get tokens. */
-	DropboxStorage(Common::String code, Networking::ErrorCallback cb);
+	DropboxStorage(const Common::String &code, Networking::ErrorCallback cb);
 
 	/** This constructor extracts tokens from JSON acquired via OAuth code flow. */
-	DropboxStorage(Networking::JsonResponse codeFlowJson, Networking::ErrorCallback cb);
+	DropboxStorage(const Networking::JsonResponse &codeFlowJson, Networking::ErrorCallback cb);
 
-	virtual ~DropboxStorage();
+	~DropboxStorage() override;
 
 	/**
 	 * Storage methods, which are used by CloudManager to save
@@ -68,44 +68,44 @@ public:
 	 * @note every Storage must write keyPrefix + "type" key
 	 *       with common value (e.g. "Dropbox").
 	 */
-	virtual void saveConfig(Common::String keyPrefix);
+	void saveConfig(const Common::String &keyPrefix) override;
 
 	/**
 	* Return unique storage name.
 	* @returns  some unique storage name (for example, "Dropbox (user@example.com)")
 	*/
-	virtual Common::String name() const;
+	Common::String name() const override;
 
 	/** Public Cloud API comes down there. */
 
 	/** Returns ListDirectoryStatus struct with list of files. */
-	virtual Networking::Request *listDirectory(Common::String path, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback, bool recursive = false);
+	Networking::Request *listDirectory(const Common::String &path, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback, bool recursive = false) override;
 
 	/** Returns UploadStatus struct with info about uploaded file. */
-	virtual Networking::Request *upload(Common::String path, Common::SeekableReadStream *contents, UploadCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *upload(const Common::String &path, Common::SeekableReadStream *contents, UploadCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	/** Returns pointer to Networking::NetworkReadStream. */
-	virtual Networking::Request *streamFileById(Common::String path, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *streamFileById(const Common::String &path, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	/** Calls the callback when finished. */
-	virtual Networking::Request *createDirectory(Common::String path, BoolCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *createDirectory(const Common::String &path, BoolCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	/** Returns the StorageInfo struct. */
-	virtual Networking::Request *info(StorageInfoCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *info(StorageInfoCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	/** Returns storage's saves directory path with the trailing slash. */
-	virtual Common::String savesDirectoryPath();
+	Common::String savesDirectoryPath() override;
 
 	/**
 	 * Load token and user id from configs and return DropboxStorage for those.
 	 * @return pointer to the newly created DropboxStorage or 0 if some problem occurred.
 	 */
-	static DropboxStorage *loadFromConfig(Common::String keyPrefix);
+	static DropboxStorage *loadFromConfig(const Common::String &keyPrefix);
 
 	/**
 	 * Remove all DropboxStorage-related data from config.
 	 */
-	static void removeFromConfig(Common::String keyPrefix);
+	static void removeFromConfig(const Common::String &keyPrefix);
 
 	Common::String accessToken() const { return _token; }
 };

--- a/backends/cloud/dropbox/dropboxtokenrefresher.cpp
+++ b/backends/cloud/dropbox/dropboxtokenrefresher.cpp
@@ -36,7 +36,7 @@ DropboxTokenRefresher::DropboxTokenRefresher(DropboxStorage *parent, Networking:
 
 DropboxTokenRefresher::~DropboxTokenRefresher() {}
 
-void DropboxTokenRefresher::tokenRefreshed(Storage::BoolResponse response) {
+void DropboxTokenRefresher::tokenRefreshed(const Storage::BoolResponse &response) {
 	if (!response.value) {
 		//failed to refresh token, notify user with NULL in original callback
 		warning("DropboxTokenRefresher: failed to refresh token");
@@ -56,7 +56,7 @@ void DropboxTokenRefresher::tokenRefreshed(Storage::BoolResponse response) {
 	retry(0);
 }
 
-void DropboxTokenRefresher::finishJson(Common::JSONValue *json) {
+void DropboxTokenRefresher::finishJson(const Common::JSONValue *json) {
 	if (!json) {
 		//that's probably not an error (200 OK)
 		CurlJsonRequest::finishJson(nullptr);
@@ -88,7 +88,7 @@ void DropboxTokenRefresher::finishJson(Common::JSONValue *json) {
 
 			pause();
 			delete json;
-			_parentStorage->refreshAccessToken(new Common::Callback<DropboxTokenRefresher, Storage::BoolResponse>(this, &DropboxTokenRefresher::tokenRefreshed));
+			_parentStorage->refreshAccessToken(new Common::Callback<DropboxTokenRefresher, const Storage::BoolResponse &>(this, &DropboxTokenRefresher::tokenRefreshed));
 			return;
 		}
 	}
@@ -97,17 +97,17 @@ void DropboxTokenRefresher::finishJson(Common::JSONValue *json) {
 	CurlJsonRequest::finishJson(json);
 }
 
-void DropboxTokenRefresher::finishError(Networking::ErrorResponse error, Networking::RequestState state) {
+void DropboxTokenRefresher::finishError(const Networking::ErrorResponse &error, Networking::RequestState state) {
 	if (error.httpResponseCode == 401) {
 		pause();
-		_parentStorage->refreshAccessToken(new Common::Callback<DropboxTokenRefresher, Storage::BoolResponse>(this, &DropboxTokenRefresher::tokenRefreshed));
+		_parentStorage->refreshAccessToken(new Common::Callback<DropboxTokenRefresher, const Storage::BoolResponse &>(this, &DropboxTokenRefresher::tokenRefreshed));
 		return;
 	}
 
 	Request::finishError(error);
 }
 
-void DropboxTokenRefresher::setHeaders(Common::Array<Common::String> &headers) {
+void DropboxTokenRefresher::setHeaders(const Common::Array<Common::String> &headers) {
 	_headers = headers;
 	curl_slist_free_all(_headersList);
 	_headersList = nullptr;
@@ -115,7 +115,7 @@ void DropboxTokenRefresher::setHeaders(Common::Array<Common::String> &headers) {
 		CurlJsonRequest::addHeader(headers[i]);
 }
 
-void DropboxTokenRefresher::addHeader(Common::String header) {
+void DropboxTokenRefresher::addHeader(const Common::String &header) {
 	_headers.push_back(header);
 	CurlJsonRequest::addHeader(header);
 }

--- a/backends/cloud/dropbox/dropboxtokenrefresher.h
+++ b/backends/cloud/dropbox/dropboxtokenrefresher.h
@@ -34,16 +34,16 @@ class DropboxTokenRefresher: public Networking::CurlJsonRequest {
 	DropboxStorage *_parentStorage;
 	Common::Array<Common::String> _headers;
 
-	void tokenRefreshed(Storage::BoolResponse response);
+	void tokenRefreshed(const Storage::BoolResponse &response);
 
-	virtual void finishJson(Common::JSONValue *json);
-	virtual void finishError(Networking::ErrorResponse error, Networking::RequestState state = Networking::FINISHED);
+	void finishJson(const Common::JSONValue *json) override;
+	void finishError(const Networking::ErrorResponse &error, Networking::RequestState state = Networking::FINISHED) override;
 public:
 	DropboxTokenRefresher(DropboxStorage *parent, Networking::JsonCallback callback, Networking::ErrorCallback ecb, const char *url);
-	virtual ~DropboxTokenRefresher();
+	~DropboxTokenRefresher() override;
 
-	virtual void setHeaders(Common::Array<Common::String> &headers);
-	virtual void addHeader(Common::String header);
+	void setHeaders(const Common::Array<Common::String> &headers) override;
+	void addHeader(const Common::String &header) override;
 };
 
 } // End of namespace Dropbox

--- a/backends/cloud/dropbox/dropboxuploadrequest.h
+++ b/backends/cloud/dropbox/dropboxuploadrequest.h
@@ -43,16 +43,16 @@ class DropboxUploadRequest: public Networking::Request {
 
 	void start();
 	void uploadNextPart();
-	void partUploadedCallback(Networking::JsonResponse response);
-	void partUploadedErrorCallback(Networking::ErrorResponse error);
+	void partUploadedCallback(const Networking::JsonResponse &response);
+	void partUploadedErrorCallback(const Networking::ErrorResponse &error);
 	void finishUpload(StorageFile status);
 
 public:
-	DropboxUploadRequest(DropboxStorage *storage, Common::String path, Common::SeekableReadStream *contents, Storage::UploadCallback callback, Networking::ErrorCallback ecb);
-	virtual ~DropboxUploadRequest();
+	DropboxUploadRequest(DropboxStorage *storage, const Common::String &path, Common::SeekableReadStream *contents, Storage::UploadCallback callback, Networking::ErrorCallback ecb);
+	~DropboxUploadRequest() override;
 
-	virtual void handle();
-	virtual void restart();
+	void handle() override;
+	void restart() override;
 };
 
 } // End of namespace Dropbox

--- a/backends/cloud/folderdownloadrequest.cpp
+++ b/backends/cloud/folderdownloadrequest.cpp
@@ -29,7 +29,7 @@
 
 namespace Cloud {
 
-FolderDownloadRequest::FolderDownloadRequest(Storage *storage, Storage::FileArrayCallback callback, Networking::ErrorCallback ecb, Common::String remoteDirectoryPath, Common::String localDirectoryPath, bool recursive):
+FolderDownloadRequest::FolderDownloadRequest(Storage *storage, Storage::FileArrayCallback callback, Networking::ErrorCallback ecb, const Common::String &remoteDirectoryPath, const Common::String &localDirectoryPath, bool recursive):
 	Request(nullptr, ecb), CommandSender(nullptr), _storage(storage), _fileArrayCallback(callback),
 	_remoteDirectoryPath(remoteDirectoryPath), _localDirectoryPath(localDirectoryPath), _recursive(recursive),
 	_workingRequest(nullptr), _ignoreCallback(false), _totalFiles(0) {
@@ -59,13 +59,13 @@ void FolderDownloadRequest::start() {
 	//list directory first
 	_workingRequest = _storage->listDirectory(
 		_remoteDirectoryPath,
-		new Common::Callback<FolderDownloadRequest, Storage::ListDirectoryResponse>(this, &FolderDownloadRequest::directoryListedCallback),
-		new Common::Callback<FolderDownloadRequest, Networking::ErrorResponse>(this, &FolderDownloadRequest::directoryListedErrorCallback),
+		new Common::Callback<FolderDownloadRequest, const Storage::ListDirectoryResponse &>(this, &FolderDownloadRequest::directoryListedCallback),
+		new Common::Callback<FolderDownloadRequest, const Networking::ErrorResponse &>(this, &FolderDownloadRequest::directoryListedErrorCallback),
 		_recursive
 	);
 }
 
-void FolderDownloadRequest::directoryListedCallback(Storage::ListDirectoryResponse response) {
+void FolderDownloadRequest::directoryListedCallback(const Storage::ListDirectoryResponse &response) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
@@ -86,14 +86,14 @@ void FolderDownloadRequest::directoryListedCallback(Storage::ListDirectoryRespon
 	downloadNextFile();
 }
 
-void FolderDownloadRequest::directoryListedErrorCallback(Networking::ErrorResponse error) {
+void FolderDownloadRequest::directoryListedErrorCallback(const Networking::ErrorResponse &error) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
 	finishError(error);
 }
 
-void FolderDownloadRequest::fileDownloadedCallback(Storage::BoolResponse response) {
+void FolderDownloadRequest::fileDownloadedCallback(const Storage::BoolResponse &response) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
@@ -102,7 +102,7 @@ void FolderDownloadRequest::fileDownloadedCallback(Storage::BoolResponse respons
 	downloadNextFile();
 }
 
-void FolderDownloadRequest::fileDownloadedErrorCallback(Networking::ErrorResponse error) {
+void FolderDownloadRequest::fileDownloadedErrorCallback(const Networking::ErrorResponse &error) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
@@ -143,8 +143,8 @@ void FolderDownloadRequest::downloadNextFile() {
 	debug(9, "FolderDownloadRequest: %s -> %s", remotePath.c_str(), localPath.c_str());
 	_workingRequest = _storage->downloadById(
 		_currentFile.id(), localPath,
-		new Common::Callback<FolderDownloadRequest, Storage::BoolResponse>(this, &FolderDownloadRequest::fileDownloadedCallback),
-		new Common::Callback<FolderDownloadRequest, Networking::ErrorResponse>(this, &FolderDownloadRequest::fileDownloadedErrorCallback)
+		new Common::Callback<FolderDownloadRequest, const Storage::BoolResponse &>(this, &FolderDownloadRequest::fileDownloadedCallback),
+		new Common::Callback<FolderDownloadRequest, const Networking::ErrorResponse &>(this, &FolderDownloadRequest::fileDownloadedErrorCallback)
 	);
 }
 

--- a/backends/cloud/folderdownloadrequest.h
+++ b/backends/cloud/folderdownloadrequest.h
@@ -41,18 +41,18 @@ class FolderDownloadRequest: public Networking::Request, public GUI::CommandSend
 	uint64 _downloadedBytes, _totalBytes, _wasDownloadedBytes, _currentDownloadSpeed;
 
 	void start();
-	void directoryListedCallback(Storage::ListDirectoryResponse response);
-	void directoryListedErrorCallback(Networking::ErrorResponse error);
-	void fileDownloadedCallback(Storage::BoolResponse response);
-	void fileDownloadedErrorCallback(Networking::ErrorResponse error);
+	void directoryListedCallback(const Storage::ListDirectoryResponse &response);
+	void directoryListedErrorCallback(const Networking::ErrorResponse &error);
+	void fileDownloadedCallback(const Storage::BoolResponse &response);
+	void fileDownloadedErrorCallback(const Networking::ErrorResponse &error);
 	void downloadNextFile();
 	void finishDownload(Common::Array<StorageFile> &files);
 public:
-	FolderDownloadRequest(Storage *storage, Storage::FileArrayCallback callback, Networking::ErrorCallback ecb, Common::String remoteDirectoryPath, Common::String localDirectoryPath, bool recursive);
-	virtual ~FolderDownloadRequest();
+	FolderDownloadRequest(Storage *storage, Storage::FileArrayCallback callback, Networking::ErrorCallback ecb, const Common::String &remoteDirectoryPath, const Common::String &localDirectoryPath, bool recursive);
+	~FolderDownloadRequest() override;
 
-	virtual void handle();
-	virtual void restart();
+	void handle() override;
+	void restart() override;
 
 	/** Returns a number in range [0, 1], where 1 is "complete". */
 	double getProgress() const;

--- a/backends/cloud/googledrive/googledrivelistdirectorybyidrequest.h
+++ b/backends/cloud/googledrive/googledrivelistdirectorybyidrequest.h
@@ -43,17 +43,17 @@ class GoogleDriveListDirectoryByIdRequest: public Networking::Request {
 	Common::String _date;
 
 	void start();
-	void makeRequest(Common::String pageToken);
-	void responseCallback(Networking::JsonResponse response);
-	void errorCallback(Networking::ErrorResponse error);
+	void makeRequest(const Common::String &pageToken);
+	void responseCallback(const Networking::JsonResponse &response);
+	void errorCallback(const Networking::ErrorResponse &error);
 	void finishListing(Common::Array<StorageFile> &files);
 public:
-	GoogleDriveListDirectoryByIdRequest(GoogleDriveStorage *storage, Common::String id, Storage::ListDirectoryCallback cb, Networking::ErrorCallback ecb);
-	virtual ~GoogleDriveListDirectoryByIdRequest();
+	GoogleDriveListDirectoryByIdRequest(GoogleDriveStorage *storage, const Common::String &id, Storage::ListDirectoryCallback cb, Networking::ErrorCallback ecb);
+	~GoogleDriveListDirectoryByIdRequest() override;
 
-	virtual void handle();
-	virtual void restart();
-	virtual Common::String date() const;
+	void handle() override;
+	void restart() override;
+	Common::String date() const override;
 };
 
 } // End of namespace GoogleDrive

--- a/backends/cloud/googledrive/googledrivestorage.h
+++ b/backends/cloud/googledrive/googledrivestorage.h
@@ -30,39 +30,39 @@ namespace GoogleDrive {
 
 class GoogleDriveStorage: public Id::IdStorage {
 	/** This private constructor is called from loadFromConfig(). */
-	GoogleDriveStorage(Common::String token, Common::String refreshToken, bool enabled);
+	GoogleDriveStorage(const Common::String &token, const Common::String &refreshToken, bool enabled);
 
 	/** Constructs StorageInfo based on JSON response from cloud. */
-	void infoInnerCallback(StorageInfoCallback outerCallback, Networking::JsonResponse json);
+	void infoInnerCallback(StorageInfoCallback outerCallback, const Networking::JsonResponse &json);
 
 	/** Returns bool based on JSON response from cloud. */
-	void createDirectoryInnerCallback(BoolCallback outerCallback, Networking::JsonResponse json);
+	void createDirectoryInnerCallback(BoolCallback outerCallback, const Networking::JsonResponse &json);
 
-	void printInfo(StorageInfoResponse response);
+	void printInfo(const StorageInfoResponse &response);
 
 protected:
 	/**
 	 * @return "gdrive"
 	 */
-	virtual Common::String cloudProvider();
+	Common::String cloudProvider() override;
 
 	/**
 	 * @return kStorageGoogleDriveId
 	 */
-	virtual uint32 storageIndex();
+	uint32 storageIndex() override;
 
-	virtual bool needsRefreshToken();
+	bool needsRefreshToken() override;
 
-	virtual bool canReuseRefreshToken();
+	bool canReuseRefreshToken() override;
 
 public:
 	/** This constructor uses OAuth code flow to get tokens. */
-	GoogleDriveStorage(Common::String code, Networking::ErrorCallback cb);
+	GoogleDriveStorage(const Common::String &code, Networking::ErrorCallback cb);
 
 	/** This constructor extracts tokens from JSON acquired via OAuth code flow. */
-	GoogleDriveStorage(Networking::JsonResponse codeFlowJson, Networking::ErrorCallback cb);
+	GoogleDriveStorage(const Networking::JsonResponse &codeFlowJson, Networking::ErrorCallback cb);
 
-	virtual ~GoogleDriveStorage();
+	~GoogleDriveStorage() override;
 
 	/**
 	 * Storage methods, which are used by CloudManager to save
@@ -75,46 +75,46 @@ public:
 	 * @note every Storage must write keyPrefix + "type" key
 	 *       with common value (e.g. "Dropbox").
 	 */
-	virtual void saveConfig(Common::String keyPrefix);
+	void saveConfig(const Common::String &keyPrefix) override;
 
 	/**
 	* Return unique storage name.
 	* @returns  some unique storage name (for example, "Dropbox (user@example.com)")
 	*/
-	virtual Common::String name() const;
+	Common::String name() const override;
 
 	/** Public Cloud API comes down there. */
 
 	/** Returns Array<StorageFile> - the list of files. */
-	virtual Networking::Request *listDirectoryById(Common::String id, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *listDirectoryById(const Common::String &id, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	/** Returns UploadStatus struct with info about uploaded file. */
-	virtual Networking::Request *upload(Common::String path, Common::SeekableReadStream *contents, UploadCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *upload(const Common::String &path, Common::SeekableReadStream *contents, UploadCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	/** Returns pointer to Networking::NetworkReadStream. */
-	virtual Networking::Request *streamFileById(Common::String id, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *streamFileById(const Common::String &id, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	/** Calls the callback when finished. */
-	virtual Networking::Request *createDirectoryWithParentId(Common::String parentId, Common::String directoryName, BoolCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *createDirectoryWithParentId(const Common::String &parentId, const Common::String &directoryName, BoolCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	/** Returns the StorageInfo struct. */
-	virtual Networking::Request *info(StorageInfoCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *info(StorageInfoCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	/** Returns storage's saves directory path with the trailing slash. */
-	virtual Common::String savesDirectoryPath();
+	Common::String savesDirectoryPath() override;
 
 	/**
 	 * Load token and user id from configs and return GoogleDriveStorage for those.
 	 * @return pointer to the newly created GoogleDriveStorage or 0 if some problem occurred.
 	 */
-	static GoogleDriveStorage *loadFromConfig(Common::String keyPrefix);
+	static GoogleDriveStorage *loadFromConfig(const Common::String &keyPrefix);
 
 	/**
 	 * Remove all GoogleDriveStorage-related data from config.
 	 */
-	static void removeFromConfig(Common::String keyPrefix);
+	static void removeFromConfig(const Common::String &keyPrefix);
 
-	virtual Common::String getRootDirectoryId();
+	Common::String getRootDirectoryId() override;
 
 	Common::String accessToken() const { return _token; }
 };

--- a/backends/cloud/googledrive/googledrivetokenrefresher.cpp
+++ b/backends/cloud/googledrive/googledrivetokenrefresher.cpp
@@ -36,7 +36,7 @@ GoogleDriveTokenRefresher::GoogleDriveTokenRefresher(GoogleDriveStorage *parent,
 
 GoogleDriveTokenRefresher::~GoogleDriveTokenRefresher() {}
 
-void GoogleDriveTokenRefresher::tokenRefreshed(Storage::BoolResponse response) {
+void GoogleDriveTokenRefresher::tokenRefreshed(const Storage::BoolResponse &response) {
 	if (!response.value) {
 		//failed to refresh token, notify user with NULL in original callback
 		warning("GoogleDriveTokenRefresher: failed to refresh token");
@@ -56,7 +56,7 @@ void GoogleDriveTokenRefresher::tokenRefreshed(Storage::BoolResponse response) {
 	retry(0);
 }
 
-void GoogleDriveTokenRefresher::finishJson(Common::JSONValue *json) {
+void GoogleDriveTokenRefresher::finishJson(const Common::JSONValue *json) {
 	if (!json) {
 		//that's probably not an error (200 OK)
 		CurlJsonRequest::finishJson(nullptr);
@@ -99,7 +99,7 @@ void GoogleDriveTokenRefresher::finishJson(Common::JSONValue *json) {
 
 			pause();
 			delete json;
-			_parentStorage->refreshAccessToken(new Common::Callback<GoogleDriveTokenRefresher, Storage::BoolResponse>(this, &GoogleDriveTokenRefresher::tokenRefreshed));
+			_parentStorage->refreshAccessToken(new Common::Callback<GoogleDriveTokenRefresher, const Storage::BoolResponse &>(this, &GoogleDriveTokenRefresher::tokenRefreshed));
 			return;
 		}
 	}
@@ -108,7 +108,7 @@ void GoogleDriveTokenRefresher::finishJson(Common::JSONValue *json) {
 	CurlJsonRequest::finishJson(json);
 }
 
-void GoogleDriveTokenRefresher::setHeaders(Common::Array<Common::String> &headers) {
+void GoogleDriveTokenRefresher::setHeaders(const Common::Array<Common::String> &headers) {
 	_headers = headers;
 	curl_slist_free_all(_headersList);
 	_headersList = nullptr;
@@ -116,7 +116,7 @@ void GoogleDriveTokenRefresher::setHeaders(Common::Array<Common::String> &header
 		CurlJsonRequest::addHeader(headers[i]);
 }
 
-void GoogleDriveTokenRefresher::addHeader(Common::String header) {
+void GoogleDriveTokenRefresher::addHeader(const Common::String &header) {
 	_headers.push_back(header);
 	CurlJsonRequest::addHeader(header);
 }

--- a/backends/cloud/googledrive/googledrivetokenrefresher.h
+++ b/backends/cloud/googledrive/googledrivetokenrefresher.h
@@ -34,15 +34,15 @@ class GoogleDriveTokenRefresher: public Networking::CurlJsonRequest {
 	GoogleDriveStorage *_parentStorage;
 	Common::Array<Common::String> _headers;
 
-	void tokenRefreshed(Storage::BoolResponse response);
+	void tokenRefreshed(const Storage::BoolResponse &response);
 
-	virtual void finishJson(Common::JSONValue *json);
+	void finishJson(const Common::JSONValue *json) override;
 public:
 	GoogleDriveTokenRefresher(GoogleDriveStorage *parent, Networking::JsonCallback callback, Networking::ErrorCallback ecb, const char *url);
-	virtual ~GoogleDriveTokenRefresher();
+	~GoogleDriveTokenRefresher() override;
 
-	virtual void setHeaders(Common::Array<Common::String> &headers);
-	virtual void addHeader(Common::String header);
+	void setHeaders(const Common::Array<Common::String> &headers) override;
+	void addHeader(const Common::String &header) override;
 };
 
 } // End of namespace GoogleDrive

--- a/backends/cloud/googledrive/googledriveuploadrequest.h
+++ b/backends/cloud/googledrive/googledriveuploadrequest.h
@@ -44,23 +44,23 @@ class GoogleDriveUploadRequest: public Networking::Request {
 
 	void start();
 	void resolveId();
-	void idResolvedCallback(Storage::UploadResponse response);
-	void idResolveFailedCallback(Networking::ErrorResponse error);
+	void idResolvedCallback(const Storage::UploadResponse &response);
+	void idResolveFailedCallback(const Networking::ErrorResponse &error);
 	void startUpload();
-	void startUploadCallback(Networking::JsonResponse response);
-	void startUploadErrorCallback(Networking::ErrorResponse error);
+	void startUploadCallback(const Networking::JsonResponse &response);
+	void startUploadErrorCallback(const Networking::ErrorResponse &error);
 	void uploadNextPart();
-	void partUploadedCallback(Networking::JsonResponse response);
-	void partUploadedErrorCallback(Networking::ErrorResponse error);
+	void partUploadedCallback(const Networking::JsonResponse &response);
+	void partUploadedErrorCallback(const Networking::ErrorResponse &error);
 	bool handleHttp308(const Networking::NetworkReadStream *stream);
 	void finishUpload(StorageFile status);
 
 public:
-	GoogleDriveUploadRequest(GoogleDriveStorage *storage, Common::String path, Common::SeekableReadStream *contents, Storage::UploadCallback callback, Networking::ErrorCallback ecb);
-	virtual ~GoogleDriveUploadRequest();
+	GoogleDriveUploadRequest(GoogleDriveStorage *storage, const Common::String &path, Common::SeekableReadStream *contents, Storage::UploadCallback callback, Networking::ErrorCallback ecb);
+	~GoogleDriveUploadRequest() override;
 
-	virtual void handle();
-	virtual void restart();
+	void handle() override;
+	void restart() override;
 };
 
 } // End of namespace GoogleDrive

--- a/backends/cloud/id/idcreatedirectoryrequest.cpp
+++ b/backends/cloud/id/idcreatedirectoryrequest.cpp
@@ -26,7 +26,7 @@
 namespace Cloud {
 namespace Id {
 
-IdCreateDirectoryRequest::IdCreateDirectoryRequest(IdStorage *storage, Common::String parentPath, Common::String directoryName, Storage::BoolCallback cb, Networking::ErrorCallback ecb):
+IdCreateDirectoryRequest::IdCreateDirectoryRequest(IdStorage *storage, const Common::String &parentPath, const Common::String &directoryName, Storage::BoolCallback cb, Networking::ErrorCallback ecb):
 	Networking::Request(nullptr, ecb),
 	_requestedParentPath(parentPath), _requestedDirectoryName(directoryName), _storage(storage), _boolCallback(cb),
 	_workingRequest(nullptr), _ignoreCallback(false) {
@@ -53,8 +53,8 @@ void IdCreateDirectoryRequest::start() {
 	if (prefix.size() > 7)
 		prefix.erase(7);
 	if (prefix.equalsIgnoreCase("ScummVM")) {
-		Storage::BoolCallback callback = new Common::Callback<IdCreateDirectoryRequest, Storage::BoolResponse>(this, &IdCreateDirectoryRequest::createdBaseDirectoryCallback);
-		Networking::ErrorCallback failureCallback = new Common::Callback<IdCreateDirectoryRequest, Networking::ErrorResponse>(this, &IdCreateDirectoryRequest::createdBaseDirectoryErrorCallback);
+		Storage::BoolCallback callback = new Common::Callback<IdCreateDirectoryRequest, const Storage::BoolResponse &>(this, &IdCreateDirectoryRequest::createdBaseDirectoryCallback);
+		Networking::ErrorCallback failureCallback = new Common::Callback<IdCreateDirectoryRequest, const Networking::ErrorResponse &>(this, &IdCreateDirectoryRequest::createdBaseDirectoryErrorCallback);
 		_workingRequest = _storage->createDirectory("ScummVM", callback, failureCallback);
 		return;
 	}
@@ -62,7 +62,7 @@ void IdCreateDirectoryRequest::start() {
 	resolveId();
 }
 
-void IdCreateDirectoryRequest::createdBaseDirectoryCallback(Storage::BoolResponse response) {
+void IdCreateDirectoryRequest::createdBaseDirectoryCallback(const Storage::BoolResponse &response) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
@@ -71,7 +71,7 @@ void IdCreateDirectoryRequest::createdBaseDirectoryCallback(Storage::BoolRespons
 	resolveId();
 }
 
-void IdCreateDirectoryRequest::createdBaseDirectoryErrorCallback(Networking::ErrorResponse error) {
+void IdCreateDirectoryRequest::createdBaseDirectoryErrorCallback(const Networking::ErrorResponse &error) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
@@ -82,8 +82,8 @@ void IdCreateDirectoryRequest::createdBaseDirectoryErrorCallback(Networking::Err
 
 void IdCreateDirectoryRequest::resolveId() {
 	//check whether such folder already exists
-	Storage::UploadCallback innerCallback = new Common::Callback<IdCreateDirectoryRequest, Storage::UploadResponse>(this, &IdCreateDirectoryRequest::idResolvedCallback);
-	Networking::ErrorCallback innerErrorCallback = new Common::Callback<IdCreateDirectoryRequest, Networking::ErrorResponse>(this, &IdCreateDirectoryRequest::idResolveFailedCallback);
+	Storage::UploadCallback innerCallback = new Common::Callback<IdCreateDirectoryRequest, const Storage::UploadResponse &>(this, &IdCreateDirectoryRequest::idResolvedCallback);
+	Networking::ErrorCallback innerErrorCallback = new Common::Callback<IdCreateDirectoryRequest, const Networking::ErrorResponse &>(this, &IdCreateDirectoryRequest::idResolveFailedCallback);
 	Common::String path = _requestedParentPath;
 	if (_requestedParentPath != "")
 		path += "/";
@@ -91,7 +91,7 @@ void IdCreateDirectoryRequest::resolveId() {
 	_workingRequest = _storage->resolveFileId(path, innerCallback, innerErrorCallback);
 }
 
-void IdCreateDirectoryRequest::idResolvedCallback(Storage::UploadResponse response) {
+void IdCreateDirectoryRequest::idResolvedCallback(const Storage::UploadResponse &response) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
@@ -102,7 +102,7 @@ void IdCreateDirectoryRequest::idResolvedCallback(Storage::UploadResponse respon
 	finishCreation(false);
 }
 
-void IdCreateDirectoryRequest::idResolveFailedCallback(Networking::ErrorResponse error) {
+void IdCreateDirectoryRequest::idResolveFailedCallback(const Networking::ErrorResponse &error) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
@@ -119,8 +119,8 @@ void IdCreateDirectoryRequest::idResolveFailedCallback(Networking::ErrorResponse
 				break;
 			}
 
-		Storage::BoolCallback callback = new Common::Callback<IdCreateDirectoryRequest, Storage::BoolResponse>(this, &IdCreateDirectoryRequest::createdDirectoryCallback);
-		Networking::ErrorCallback failureCallback = new Common::Callback<IdCreateDirectoryRequest, Networking::ErrorResponse>(this, &IdCreateDirectoryRequest::createdDirectoryErrorCallback);
+		Storage::BoolCallback callback = new Common::Callback<IdCreateDirectoryRequest, const Storage::BoolResponse &>(this, &IdCreateDirectoryRequest::createdDirectoryCallback);
+		Networking::ErrorCallback failureCallback = new Common::Callback<IdCreateDirectoryRequest, const Networking::ErrorResponse &>(this, &IdCreateDirectoryRequest::createdDirectoryErrorCallback);
 		_workingRequest = _storage->createDirectoryWithParentId(parentId, _requestedDirectoryName, callback, failureCallback);
 		return;
 	}
@@ -128,7 +128,7 @@ void IdCreateDirectoryRequest::idResolveFailedCallback(Networking::ErrorResponse
 	finishError(error);
 }
 
-void IdCreateDirectoryRequest::createdDirectoryCallback(Storage::BoolResponse response) {
+void IdCreateDirectoryRequest::createdDirectoryCallback(const Storage::BoolResponse &response) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
@@ -137,7 +137,7 @@ void IdCreateDirectoryRequest::createdDirectoryCallback(Storage::BoolResponse re
 	finishCreation(response.value);
 }
 
-void IdCreateDirectoryRequest::createdDirectoryErrorCallback(Networking::ErrorResponse error) {
+void IdCreateDirectoryRequest::createdDirectoryErrorCallback(const Networking::ErrorResponse &error) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;

--- a/backends/cloud/id/idcreatedirectoryrequest.h
+++ b/backends/cloud/id/idcreatedirectoryrequest.h
@@ -41,21 +41,21 @@ class IdCreateDirectoryRequest: public Networking::Request {
 	Common::String _date;
 
 	void start();
-	void createdBaseDirectoryCallback(Storage::BoolResponse response);
-	void createdBaseDirectoryErrorCallback(Networking::ErrorResponse error);
+	void createdBaseDirectoryCallback(const Storage::BoolResponse &response);
+	void createdBaseDirectoryErrorCallback(const Networking::ErrorResponse &error);
 	void resolveId();
-	void idResolvedCallback(Storage::UploadResponse response);
-	void idResolveFailedCallback(Networking::ErrorResponse error);
-	void createdDirectoryCallback(Storage::BoolResponse response);
-	void createdDirectoryErrorCallback(Networking::ErrorResponse error);
+	void idResolvedCallback(const Storage::UploadResponse &response);
+	void idResolveFailedCallback(const Networking::ErrorResponse &error);
+	void createdDirectoryCallback(const Storage::BoolResponse &response);
+	void createdDirectoryErrorCallback(const Networking::ErrorResponse &error);
 	void finishCreation(bool success);
 public:
-	IdCreateDirectoryRequest(IdStorage *storage, Common::String parentPath, Common::String directoryName, Storage::BoolCallback cb, Networking::ErrorCallback ecb);
-	virtual ~IdCreateDirectoryRequest();
+	IdCreateDirectoryRequest(IdStorage *storage, const Common::String &parentPath, const Common::String &directoryName, Storage::BoolCallback cb, Networking::ErrorCallback ecb);
+	~IdCreateDirectoryRequest() override;
 
-	virtual void handle();
-	virtual void restart();
-	virtual Common::String date() const;
+	void handle() override;
+	void restart() override;
+	Common::String date() const override;
 };
 
 } // End of namespace Id

--- a/backends/cloud/id/iddownloadrequest.cpp
+++ b/backends/cloud/id/iddownloadrequest.cpp
@@ -26,7 +26,7 @@
 namespace Cloud {
 namespace Id {
 
-IdDownloadRequest::IdDownloadRequest(IdStorage *storage, Common::String remotePath, Common::String localPath, Storage::BoolCallback cb, Networking::ErrorCallback ecb):
+IdDownloadRequest::IdDownloadRequest(IdStorage *storage, const Common::String &remotePath, const Common::String &localPath, Storage::BoolCallback cb, Networking::ErrorCallback ecb):
 	Networking::Request(nullptr, ecb), _requestedFile(remotePath), _requestedLocalFile(localPath), _storage(storage), _boolCallback(cb),
 	_workingRequest(nullptr), _ignoreCallback(false) {
 	start();
@@ -48,36 +48,36 @@ void IdDownloadRequest::start() {
 	_ignoreCallback = false;
 
 	//find file's id
-	Storage::UploadCallback innerCallback = new Common::Callback<IdDownloadRequest, Storage::UploadResponse>(this, &IdDownloadRequest::idResolvedCallback);
-	Networking::ErrorCallback innerErrorCallback = new Common::Callback<IdDownloadRequest, Networking::ErrorResponse>(this, &IdDownloadRequest::idResolveFailedCallback);
+	Storage::UploadCallback innerCallback = new Common::Callback<IdDownloadRequest, const Storage::UploadResponse &>(this, &IdDownloadRequest::idResolvedCallback);
+	Networking::ErrorCallback innerErrorCallback = new Common::Callback<IdDownloadRequest, const Networking::ErrorResponse &>(this, &IdDownloadRequest::idResolveFailedCallback);
 	_workingRequest = _storage->resolveFileId(_requestedFile, innerCallback, innerErrorCallback);
 }
 
-void IdDownloadRequest::idResolvedCallback(Storage::UploadResponse response) {
+void IdDownloadRequest::idResolvedCallback(const Storage::UploadResponse &response) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
 
-	Storage::BoolCallback innerCallback = new Common::Callback<IdDownloadRequest, Storage::BoolResponse>(this, &IdDownloadRequest::downloadCallback);
-	Networking::ErrorCallback innerErrorCallback = new Common::Callback<IdDownloadRequest, Networking::ErrorResponse>(this, &IdDownloadRequest::downloadErrorCallback);
+	Storage::BoolCallback innerCallback = new Common::Callback<IdDownloadRequest, const Storage::BoolResponse &>(this, &IdDownloadRequest::downloadCallback);
+	Networking::ErrorCallback innerErrorCallback = new Common::Callback<IdDownloadRequest, const Networking::ErrorResponse &>(this, &IdDownloadRequest::downloadErrorCallback);
 	_workingRequest = _storage->downloadById(response.value.id(), _requestedLocalFile, innerCallback, innerErrorCallback);
 }
 
-void IdDownloadRequest::idResolveFailedCallback(Networking::ErrorResponse error) {
+void IdDownloadRequest::idResolveFailedCallback(const Networking::ErrorResponse &error) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
 	finishError(error);
 }
 
-void IdDownloadRequest::downloadCallback(Storage::BoolResponse response) {
+void IdDownloadRequest::downloadCallback(const Storage::BoolResponse &response) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
 	finishDownload(response.value);
 }
 
-void IdDownloadRequest::downloadErrorCallback(Networking::ErrorResponse error) {
+void IdDownloadRequest::downloadErrorCallback(const Networking::ErrorResponse &error) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;

--- a/backends/cloud/id/iddownloadrequest.h
+++ b/backends/cloud/id/iddownloadrequest.h
@@ -39,17 +39,17 @@ class IdDownloadRequest: public Networking::Request {
 	bool _ignoreCallback;
 
 	void start();
-	void idResolvedCallback(Storage::UploadResponse response);
-	void idResolveFailedCallback(Networking::ErrorResponse error);
-	void downloadCallback(Storage::BoolResponse response);
-	void downloadErrorCallback(Networking::ErrorResponse error);
+	void idResolvedCallback(const Storage::UploadResponse &response);
+	void idResolveFailedCallback(const Networking::ErrorResponse &error);
+	void downloadCallback(const Storage::BoolResponse &response);
+	void downloadErrorCallback(const Networking::ErrorResponse &error);
 	void finishDownload(bool success);
 public:
-	IdDownloadRequest(IdStorage *storage, Common::String remotePath, Common::String localPath, Storage::BoolCallback cb, Networking::ErrorCallback ecb);
-	virtual ~IdDownloadRequest();
+	IdDownloadRequest(IdStorage *storage, const Common::String &remotePath, const Common::String &localPath, Storage::BoolCallback cb, Networking::ErrorCallback ecb);
+	~IdDownloadRequest() override;
 
-	virtual void handle();
-	virtual void restart();
+	void handle() override;
+	void restart() override;
 
 	/** Returns a number in range [0, 1], where 1 is "complete". */
 	double getProgress() const;

--- a/backends/cloud/id/idlistdirectoryrequest.h
+++ b/backends/cloud/id/idlistdirectoryrequest.h
@@ -44,19 +44,19 @@ class IdListDirectoryRequest: public Networking::Request {
 	Common::String _date;
 
 	void start();
-	void idResolvedCallback(Storage::UploadResponse response);
-	void idResolveErrorCallback(Networking::ErrorResponse error);
+	void idResolvedCallback(const Storage::UploadResponse &response);
+	void idResolveErrorCallback(const Networking::ErrorResponse &error);
 	void listNextDirectory();
-	void listedDirectoryCallback(Storage::FileArrayResponse response);
-	void listedDirectoryErrorCallback(Networking::ErrorResponse error);
-	void finishListing(Common::Array<StorageFile> &files);
+	void listedDirectoryCallback(const Storage::FileArrayResponse &response);
+	void listedDirectoryErrorCallback(const Networking::ErrorResponse &error);
+	void finishListing(const Common::Array<StorageFile> &files);
 public:
-	IdListDirectoryRequest(IdStorage *storage, Common::String path, Storage::ListDirectoryCallback cb, Networking::ErrorCallback ecb, bool recursive = false);
-	virtual ~IdListDirectoryRequest();
+	IdListDirectoryRequest(IdStorage *storage, const Common::String &path, Storage::ListDirectoryCallback cb, Networking::ErrorCallback ecb, bool recursive = false);
+	~IdListDirectoryRequest() override;
 
-	virtual void handle();
-	virtual void restart();
-	virtual Common::String date() const;
+	void handle() override;
+	void restart() override;
+	Common::String date() const override;
 };
 
 } // End of namespace Id

--- a/backends/cloud/id/idresolveidrequest.cpp
+++ b/backends/cloud/id/idresolveidrequest.cpp
@@ -25,7 +25,7 @@
 namespace Cloud {
 namespace Id {
 
-IdResolveIdRequest::IdResolveIdRequest(IdStorage *storage, Common::String path, Storage::UploadCallback cb, Networking::ErrorCallback ecb, bool recursive):
+IdResolveIdRequest::IdResolveIdRequest(IdStorage *storage, const Common::String &path, Storage::UploadCallback cb, Networking::ErrorCallback ecb, bool recursive):
 	Networking::Request(nullptr, ecb),
 	_requestedPath(path), _storage(storage), _uploadCallback(cb),
 	_workingRequest(nullptr), _ignoreCallback(false) {
@@ -52,18 +52,18 @@ void IdResolveIdRequest::start() {
 	listNextDirectory(StorageFile(_currentDirectoryId, 0, 0, true));
 }
 
-void IdResolveIdRequest::listNextDirectory(StorageFile fileToReturn) {
+void IdResolveIdRequest::listNextDirectory(const StorageFile &fileToReturn) {
 	if (_currentDirectory.equalsIgnoreCase(_requestedPath)) {
 		finishFile(fileToReturn);
 		return;
 	}
 
-	Storage::FileArrayCallback callback = new Common::Callback<IdResolveIdRequest, Storage::FileArrayResponse>(this, &IdResolveIdRequest::listedDirectoryCallback);
-	Networking::ErrorCallback failureCallback = new Common::Callback<IdResolveIdRequest, Networking::ErrorResponse>(this, &IdResolveIdRequest::listedDirectoryErrorCallback);
+	Storage::FileArrayCallback callback = new Common::Callback<IdResolveIdRequest, const Storage::FileArrayResponse &>(this, &IdResolveIdRequest::listedDirectoryCallback);
+	Networking::ErrorCallback failureCallback = new Common::Callback<IdResolveIdRequest, const Networking::ErrorResponse &>(this, &IdResolveIdRequest::listedDirectoryErrorCallback);
 	_workingRequest = _storage->listDirectoryById(_currentDirectoryId, callback, failureCallback);
 }
 
-void IdResolveIdRequest::listedDirectoryCallback(Storage::FileArrayResponse response) {
+void IdResolveIdRequest::listedDirectoryCallback(const Storage::FileArrayResponse &response) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
@@ -91,7 +91,7 @@ void IdResolveIdRequest::listedDirectoryCallback(Storage::FileArrayResponse resp
 
 	///debug(9, "IdResolveIdRequest: searching for '%s' in '%s'", currentLevelName.c_str(), _currentDirectory.c_str());
 
-	Common::Array<StorageFile> &files = response.value;
+	const Common::Array<StorageFile> &files = response.value;
 	bool found = false;
 	for (uint32 i = 0; i < files.size(); ++i) {
 		if ((files[i].isDirectory() || lastLevel) && files[i].name().equalsIgnoreCase(currentLevelName)) {
@@ -114,7 +114,7 @@ void IdResolveIdRequest::listedDirectoryCallback(Storage::FileArrayResponse resp
 	}
 }
 
-void IdResolveIdRequest::listedDirectoryErrorCallback(Networking::ErrorResponse error) {
+void IdResolveIdRequest::listedDirectoryErrorCallback(const Networking::ErrorResponse &error) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
@@ -125,7 +125,7 @@ void IdResolveIdRequest::handle() {}
 
 void IdResolveIdRequest::restart() { start(); }
 
-void IdResolveIdRequest::finishFile(StorageFile file) {
+void IdResolveIdRequest::finishFile(const StorageFile &file) {
 	Request::finishSuccess();
 	if (_uploadCallback)
 		(*_uploadCallback)(Storage::UploadResponse(this, file));

--- a/backends/cloud/id/idresolveidrequest.h
+++ b/backends/cloud/id/idresolveidrequest.h
@@ -41,16 +41,16 @@ class IdResolveIdRequest: public Networking::Request {
 	bool _ignoreCallback;
 
 	void start();
-	void listNextDirectory(StorageFile fileToReturn);
-	void listedDirectoryCallback(Storage::FileArrayResponse response);
-	void listedDirectoryErrorCallback(Networking::ErrorResponse error);
-	void finishFile(StorageFile file);
+	void listNextDirectory(const StorageFile &fileToReturn);
+	void listedDirectoryCallback(const Storage::FileArrayResponse &response);
+	void listedDirectoryErrorCallback(const Networking::ErrorResponse &error);
+	void finishFile(const StorageFile &file);
 public:
-	IdResolveIdRequest(IdStorage *storage, Common::String path, Storage::UploadCallback cb, Networking::ErrorCallback ecb, bool recursive = false); //TODO: why upload?
-	virtual ~IdResolveIdRequest();
+	IdResolveIdRequest(IdStorage *storage, const Common::String &path, Storage::UploadCallback cb, Networking::ErrorCallback ecb, bool recursive = false); //TODO: why upload?
+	~IdResolveIdRequest() override;
 
-	virtual void handle();
-	virtual void restart();
+	void handle() override;
+	void restart() override;
 };
 
 } // End of namespace Id

--- a/backends/cloud/id/idstorage.cpp
+++ b/backends/cloud/id/idstorage.cpp
@@ -34,14 +34,14 @@ namespace Id {
 
 IdStorage::IdStorage() {}
 
-IdStorage::IdStorage(Common::String token, Common::String refreshToken, bool enabled):
+IdStorage::IdStorage(const Common::String &token, const Common::String &refreshToken, bool enabled):
 	BaseStorage(token, refreshToken, enabled) {}
 
 IdStorage::~IdStorage() {}
 
-void IdStorage::printFiles(FileArrayResponse response) {
+void IdStorage::printFiles(const FileArrayResponse &response) {
 	debug(9, "IdStorage: files:");
-	Common::Array<StorageFile> &files = response.value;
+	const Common::Array<StorageFile> &files = response.value;
 	for (uint32 i = 0; i < files.size(); ++i) {
 		debug(9, "\t%s%s", files[i].name().c_str(), files[i].isDirectory() ? " (directory)" : "");
 		debug(9, "\t%s", files[i].path().c_str());
@@ -50,11 +50,11 @@ void IdStorage::printFiles(FileArrayResponse response) {
 	}
 }
 
-void IdStorage::printBool(BoolResponse response) {
+void IdStorage::printBool(const BoolResponse &response) {
 	debug(9, "IdStorage: bool: %s", response.value ? "true" : "false");
 }
 
-void IdStorage::printFile(UploadResponse response) {
+void IdStorage::printFile(const UploadResponse &response) {
 	debug(9, "\nIdStorage: uploaded file info:");
 	debug(9, "\tid: %s", response.value.path().c_str());
 	debug(9, "\tname: %s", response.value.name().c_str());
@@ -63,30 +63,30 @@ void IdStorage::printFile(UploadResponse response) {
 }
 
 Storage::ListDirectoryCallback IdStorage::getPrintFilesCallback() {
-	return new Common::Callback<IdStorage, FileArrayResponse>(this, &IdStorage::printFiles);
+	return new Common::Callback<IdStorage, const FileArrayResponse &>(this, &IdStorage::printFiles);
 }
 
-Networking::Request *IdStorage::resolveFileId(Common::String path, UploadCallback callback, Networking::ErrorCallback errorCallback) {
+Networking::Request *IdStorage::resolveFileId(const Common::String &path, UploadCallback callback, Networking::ErrorCallback errorCallback) {
 	if (!errorCallback)
 		errorCallback = getErrorPrintingCallback();
 	if (!callback)
-		callback = new Common::Callback<IdStorage, UploadResponse>(this, &IdStorage::printFile);
+		callback = new Common::Callback<IdStorage, const UploadResponse &>(this, &IdStorage::printFile);
 	return addRequest(new IdResolveIdRequest(this, path, callback, errorCallback));
 }
 
-Networking::Request *IdStorage::listDirectory(Common::String path, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback, bool recursive) {
+Networking::Request *IdStorage::listDirectory(const Common::String &path, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback, bool recursive) {
 	if (!errorCallback)
 		errorCallback = getErrorPrintingCallback();
 	if (!callback)
-		callback = new Common::Callback<IdStorage, FileArrayResponse>(this, &IdStorage::printFiles);
+		callback = new Common::Callback<IdStorage, const FileArrayResponse &>(this, &IdStorage::printFiles);
 	return addRequest(new IdListDirectoryRequest(this, path, callback, errorCallback, recursive));
 }
 
-Networking::Request *IdStorage::createDirectory(Common::String path, BoolCallback callback, Networking::ErrorCallback errorCallback) {
+Networking::Request *IdStorage::createDirectory(const Common::String &path, BoolCallback callback, Networking::ErrorCallback errorCallback) {
 	if (!errorCallback)
 		errorCallback = getErrorPrintingCallback();
 	if (!callback)
-		callback = new Common::Callback<IdStorage, BoolResponse>(this, &IdStorage::printBool);
+		callback = new Common::Callback<IdStorage, const BoolResponse &>(this, &IdStorage::printBool);
 
 	//find out the parent path and directory name
 	Common::String parentPath = "", directoryName = path;
@@ -102,11 +102,11 @@ Networking::Request *IdStorage::createDirectory(Common::String path, BoolCallbac
 	return addRequest(new IdCreateDirectoryRequest(this, parentPath, directoryName, callback, errorCallback));
 }
 
-Networking::Request *IdStorage::streamFile(Common::String path, Networking::NetworkReadStreamCallback outerCallback, Networking::ErrorCallback errorCallback) {
+Networking::Request *IdStorage::streamFile(const Common::String &path, Networking::NetworkReadStreamCallback outerCallback, Networking::ErrorCallback errorCallback) {
 	return addRequest(new IdStreamFileRequest(this, path, outerCallback, errorCallback));
 }
 
-Networking::Request *IdStorage::download(Common::String remotePath, Common::String localPath, BoolCallback callback, Networking::ErrorCallback errorCallback) {
+Networking::Request *IdStorage::download(const Common::String &remotePath, const Common::String &localPath, BoolCallback callback, Networking::ErrorCallback errorCallback) {
 	return addRequest(new IdDownloadRequest(this, remotePath, localPath, callback, errorCallback));
 }
 

--- a/backends/cloud/id/idstorage.h
+++ b/backends/cloud/id/idstorage.h
@@ -44,36 +44,36 @@ namespace Id {
 
 class IdStorage: public Cloud::BaseStorage {
 protected:
-	void printFiles(FileArrayResponse response);
-	void printBool(BoolResponse response);
-	void printFile(UploadResponse response);
+	void printFiles(const FileArrayResponse &response);
+	void printBool(const BoolResponse &response);
+	void printFile(const UploadResponse &response);
 
 	ListDirectoryCallback getPrintFilesCallback();
 
 public:
 	IdStorage();
-	IdStorage(Common::String token, Common::String refreshToken, bool enabled);
-	virtual ~IdStorage();
+	IdStorage(const Common::String &token, const Common::String &refreshToken, bool enabled);
+	~IdStorage() override;
 
 	/** Public Cloud API comes down there. */
 
 	/** Returns StorageFile with the resolved file's id. */
-	virtual Networking::Request *resolveFileId(Common::String path, UploadCallback callback, Networking::ErrorCallback errorCallback);
+	virtual Networking::Request *resolveFileId(const Common::String &path, UploadCallback callback, Networking::ErrorCallback errorCallback);
 
 	/** Returns ListDirectoryStatus struct with list of files. */
-	virtual Networking::Request *listDirectory(Common::String path, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback, bool recursive = false);
-	virtual Networking::Request *listDirectoryById(Common::String id, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback) = 0;
+	Networking::Request *listDirectory(const Common::String &path, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback, bool recursive = false) override;
+	virtual Networking::Request *listDirectoryById(const Common::String &id, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback) = 0;
 
 	/** Calls the callback when finished. */
-	virtual Networking::Request *createDirectory(Common::String path, BoolCallback callback, Networking::ErrorCallback errorCallback);
-	virtual Networking::Request *createDirectoryWithParentId(Common::String parentId, Common::String name, BoolCallback callback, Networking::ErrorCallback errorCallback) = 0;
+	Networking::Request *createDirectory(const Common::String &path, BoolCallback callback, Networking::ErrorCallback errorCallback) override;
+	virtual Networking::Request *createDirectoryWithParentId(const Common::String &parentId, const Common::String &name, BoolCallback callback, Networking::ErrorCallback errorCallback) = 0;
 
 	/** Returns pointer to Networking::NetworkReadStream. */
-	virtual Networking::Request *streamFile(Common::String path, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback);
-	virtual Networking::Request *streamFileById(Common::String id, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) = 0;
+	Networking::Request *streamFile(const Common::String &path, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) override;
+	virtual Networking::Request *streamFileById(const Common::String &id, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) = 0;
 
 	/** Calls the callback when finished. */
-	virtual Networking::Request *download(Common::String remotePath, Common::String localPath, BoolCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *download(const Common::String &remotePath, const Common::String &localPath, BoolCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	virtual Common::String getRootDirectoryId() = 0;
 };

--- a/backends/cloud/id/idstreamfilerequest.cpp
+++ b/backends/cloud/id/idstreamfilerequest.cpp
@@ -25,7 +25,7 @@
 namespace Cloud {
 namespace Id {
 
-IdStreamFileRequest::IdStreamFileRequest(IdStorage *storage, Common::String path, Networking::NetworkReadStreamCallback cb, Networking::ErrorCallback ecb):
+IdStreamFileRequest::IdStreamFileRequest(IdStorage *storage, const Common::String &path, Networking::NetworkReadStreamCallback cb, Networking::ErrorCallback ecb):
 	Networking::Request(nullptr, ecb), _requestedFile(path), _storage(storage), _streamCallback(cb),
 	_workingRequest(nullptr), _ignoreCallback(false) {
 	start();
@@ -47,36 +47,36 @@ void IdStreamFileRequest::start() {
 	_ignoreCallback = false;
 
 	//find file's id
-	Storage::UploadCallback innerCallback = new Common::Callback<IdStreamFileRequest, Storage::UploadResponse>(this, &IdStreamFileRequest::idResolvedCallback);
-	Networking::ErrorCallback innerErrorCallback = new Common::Callback<IdStreamFileRequest, Networking::ErrorResponse>(this, &IdStreamFileRequest::idResolveFailedCallback);
+	Storage::UploadCallback innerCallback = new Common::Callback<IdStreamFileRequest, const Storage::UploadResponse &>(this, &IdStreamFileRequest::idResolvedCallback);
+	Networking::ErrorCallback innerErrorCallback = new Common::Callback<IdStreamFileRequest, const Networking::ErrorResponse &>(this, &IdStreamFileRequest::idResolveFailedCallback);
 	_workingRequest = _storage->resolveFileId(_requestedFile, innerCallback, innerErrorCallback);
 }
 
-void IdStreamFileRequest::idResolvedCallback(Storage::UploadResponse response) {
+void IdStreamFileRequest::idResolvedCallback(const Storage::UploadResponse &response) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
 
-	Networking::NetworkReadStreamCallback innerCallback = new Common::Callback<IdStreamFileRequest, Networking::NetworkReadStreamResponse>(this, &IdStreamFileRequest::streamFileCallback);
-	Networking::ErrorCallback innerErrorCallback = new Common::Callback<IdStreamFileRequest, Networking::ErrorResponse>(this, &IdStreamFileRequest::streamFileErrorCallback);
+	Networking::NetworkReadStreamCallback innerCallback = new Common::Callback<IdStreamFileRequest, const Networking::NetworkReadStreamResponse &>(this, &IdStreamFileRequest::streamFileCallback);
+	Networking::ErrorCallback innerErrorCallback = new Common::Callback<IdStreamFileRequest, const Networking::ErrorResponse &>(this, &IdStreamFileRequest::streamFileErrorCallback);
 	_workingRequest = _storage->streamFileById(response.value.id(), innerCallback, innerErrorCallback);
 }
 
-void IdStreamFileRequest::idResolveFailedCallback(Networking::ErrorResponse error) {
+void IdStreamFileRequest::idResolveFailedCallback(const Networking::ErrorResponse &error) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
 	finishError(error);
 }
 
-void IdStreamFileRequest::streamFileCallback(Networking::NetworkReadStreamResponse response) {
+void IdStreamFileRequest::streamFileCallback(const Networking::NetworkReadStreamResponse &response) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
 	finishStream(response.value);
 }
 
-void IdStreamFileRequest::streamFileErrorCallback(Networking::ErrorResponse error) {
+void IdStreamFileRequest::streamFileErrorCallback(const Networking::ErrorResponse &error) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;

--- a/backends/cloud/id/idstreamfilerequest.h
+++ b/backends/cloud/id/idstreamfilerequest.h
@@ -39,17 +39,17 @@ class IdStreamFileRequest: public Networking::Request {
 	bool _ignoreCallback;
 
 	void start();
-	void idResolvedCallback(Storage::UploadResponse response);
-	void idResolveFailedCallback(Networking::ErrorResponse error);
-	void streamFileCallback(Networking::NetworkReadStreamResponse response);
-	void streamFileErrorCallback(Networking::ErrorResponse error);
+	void idResolvedCallback(const Storage::UploadResponse &response);
+	void idResolveFailedCallback(const Networking::ErrorResponse &error);
+	void streamFileCallback(const Networking::NetworkReadStreamResponse &response);
+	void streamFileErrorCallback(const Networking::ErrorResponse &error);
 	void finishStream(Networking::NetworkReadStream *stream);
 public:
-	IdStreamFileRequest(IdStorage *storage, Common::String path, Networking::NetworkReadStreamCallback cb, Networking::ErrorCallback ecb);
-	virtual ~IdStreamFileRequest();
+	IdStreamFileRequest(IdStorage *storage, const Common::String &path, Networking::NetworkReadStreamCallback cb, Networking::ErrorCallback ecb);
+	~IdStreamFileRequest() override;
 
-	virtual void handle();
-	virtual void restart();
+	void handle() override;
+	void restart() override;
 };
 
 } // End of namespace Id

--- a/backends/cloud/onedrive/onedrivecreatedirectoryrequest.cpp
+++ b/backends/cloud/onedrive/onedrivecreatedirectoryrequest.cpp
@@ -32,7 +32,7 @@ namespace OneDrive {
 
 #define ONEDRIVE_API_SPECIAL_APPROOT "https://graph.microsoft.com/v1.0/drive/special/approot"
 
-OneDriveCreateDirectoryRequest::OneDriveCreateDirectoryRequest(OneDriveStorage *storage, Common::String path, Storage::BoolCallback cb, Networking::ErrorCallback ecb):
+OneDriveCreateDirectoryRequest::OneDriveCreateDirectoryRequest(OneDriveStorage *storage, const Common::String &path, Storage::BoolCallback cb, Networking::ErrorCallback ecb):
 	Networking::Request(nullptr, ecb), _storage(storage), _path(path), _boolCallback(cb),
 	_workingRequest(nullptr), _ignoreCallback(false) {
 	start();
@@ -70,8 +70,8 @@ void OneDriveCreateDirectoryRequest::start() {
 	if (parent != "")
 		url += ":/" + ConnMan.urlEncode(parent) + ":";
 	url += "/children";
-	Networking::JsonCallback innerCallback = new Common::Callback<OneDriveCreateDirectoryRequest, Networking::JsonResponse>(this, &OneDriveCreateDirectoryRequest::responseCallback);
-	Networking::ErrorCallback errorResponseCallback = new Common::Callback<OneDriveCreateDirectoryRequest, Networking::ErrorResponse>(this, &OneDriveCreateDirectoryRequest::errorCallback);
+	Networking::JsonCallback innerCallback = new Common::Callback<OneDriveCreateDirectoryRequest, const Networking::JsonResponse &>(this, &OneDriveCreateDirectoryRequest::responseCallback);
+	Networking::ErrorCallback errorResponseCallback = new Common::Callback<OneDriveCreateDirectoryRequest, const Networking::ErrorResponse &>(this, &OneDriveCreateDirectoryRequest::errorCallback);
 	Networking::CurlJsonRequest *request = new OneDriveTokenRefresher(_storage, innerCallback, errorResponseCallback, url.c_str());
 	request->addHeader("Authorization: Bearer " + _storage->accessToken());
 	request->addHeader("Content-Type: application/json");
@@ -85,8 +85,8 @@ void OneDriveCreateDirectoryRequest::start() {
 	_workingRequest = ConnMan.addRequest(request);
 }
 
-void OneDriveCreateDirectoryRequest::responseCallback(Networking::JsonResponse response) {
-	Common::JSONValue *json = response.value;
+void OneDriveCreateDirectoryRequest::responseCallback(const Networking::JsonResponse &response) {
+	const Common::JSONValue *json = response.value;
 	_workingRequest = nullptr;
 	if (_ignoreCallback) {
 		delete json;
@@ -96,7 +96,7 @@ void OneDriveCreateDirectoryRequest::responseCallback(Networking::JsonResponse r
 		_date = response.request->date();
 
 	Networking::ErrorResponse error(this, "OneDriveCreateDirectoryRequest::responseCallback: unknown error");
-	Networking::CurlJsonRequest *rq = (Networking::CurlJsonRequest *)response.request;
+	const Networking::CurlJsonRequest *rq = (const Networking::CurlJsonRequest *)response.request;
 	if (rq && rq->getNetworkReadStream())
 		error.httpResponseCode = rq->getNetworkReadStream()->httpResponseCode();
 
@@ -124,7 +124,7 @@ void OneDriveCreateDirectoryRequest::responseCallback(Networking::JsonResponse r
 	delete json;
 }
 
-void OneDriveCreateDirectoryRequest::errorCallback(Networking::ErrorResponse error) {
+void OneDriveCreateDirectoryRequest::errorCallback(const Networking::ErrorResponse &error) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;

--- a/backends/cloud/onedrive/onedrivecreatedirectoryrequest.h
+++ b/backends/cloud/onedrive/onedrivecreatedirectoryrequest.h
@@ -40,16 +40,16 @@ class OneDriveCreateDirectoryRequest: public Networking::Request {
 	Common::String _date;
 
 	void start();
-	void responseCallback(Networking::JsonResponse response);
-	void errorCallback(Networking::ErrorResponse error);
+	void responseCallback(const Networking::JsonResponse &response);
+	void errorCallback(const Networking::ErrorResponse &error);
 	void finishCreation(bool success);
 public:
-	OneDriveCreateDirectoryRequest(OneDriveStorage *storage, Common::String path, Storage::BoolCallback cb, Networking::ErrorCallback ecb);
-	virtual ~OneDriveCreateDirectoryRequest();
+	OneDriveCreateDirectoryRequest(OneDriveStorage *storage, const Common::String &path, Storage::BoolCallback cb, Networking::ErrorCallback ecb);
+	~OneDriveCreateDirectoryRequest() override;
 
-	virtual void handle();
-	virtual void restart();
-	virtual Common::String date() const;
+	void handle() override;
+	void restart() override;
+	Common::String date() const override;
 };
 
 } // End of namespace OneDrive

--- a/backends/cloud/onedrive/onedrivelistdirectoryrequest.h
+++ b/backends/cloud/onedrive/onedrivelistdirectoryrequest.h
@@ -46,17 +46,17 @@ class OneDriveListDirectoryRequest: public Networking::Request {
 
 	void start();
 	void listNextDirectory();
-	void listedDirectoryCallback(Networking::JsonResponse response);
-	void listedDirectoryErrorCallback(Networking::ErrorResponse error);
-	void makeRequest(Common::String url);
-	void finishListing(Common::Array<StorageFile> &files);
+	void listedDirectoryCallback(const Networking::JsonResponse &response);
+	void listedDirectoryErrorCallback(const Networking::ErrorResponse &error);
+	void makeRequest(const Common::String &url);
+	void finishListing(const Common::Array<StorageFile> &files);
 public:
-	OneDriveListDirectoryRequest(OneDriveStorage *storage, Common::String path, Storage::ListDirectoryCallback cb, Networking::ErrorCallback ecb, bool recursive = false);
-	virtual ~OneDriveListDirectoryRequest();
+	OneDriveListDirectoryRequest(OneDriveStorage *storage, const Common::String &path, Storage::ListDirectoryCallback cb, Networking::ErrorCallback ecb, bool recursive = false);
+	~OneDriveListDirectoryRequest() override;
 
-	virtual void handle();
-	virtual void restart();
-	virtual Common::String date() const;
+	void handle() override;
+	void restart() override;
+	Common::String date() const override;
 };
 
 } // End of namespace OneDrive

--- a/backends/cloud/onedrive/onedrivestorage.h
+++ b/backends/cloud/onedrive/onedrivestorage.h
@@ -30,36 +30,36 @@ namespace OneDrive {
 
 class OneDriveStorage: public Cloud::BaseStorage {
 	/** This private constructor is called from loadFromConfig(). */
-	OneDriveStorage(Common::String token, Common::String refreshToken, bool enabled);
+	OneDriveStorage(const Common::String &token, const Common::String &refreshToken, bool enabled);
 
 	/** Constructs StorageInfo based on JSON response from cloud. */
-	void infoInnerCallback(StorageInfoCallback outerCallback, Networking::JsonResponse json);
+	void infoInnerCallback(StorageInfoCallback outerCallback, const Networking::JsonResponse &json);
 
-	void fileInfoCallback(Networking::NetworkReadStreamCallback outerCallback, Networking::JsonResponse response);
+	void fileInfoCallback(Networking::NetworkReadStreamCallback outerCallback, const Networking::JsonResponse &response);
 
 protected:
 	/**
 	 * @return "onedrive"
 	 */
-	virtual Common::String cloudProvider();
+	Common::String cloudProvider() override;
 
 	/**
 	 * @return kStorageOneDriveId
 	 */
-	virtual uint32 storageIndex();
+	uint32 storageIndex() override;
 
-	virtual bool needsRefreshToken();
+	bool needsRefreshToken() override;
 
-	virtual bool canReuseRefreshToken();
+	bool canReuseRefreshToken() override;
 
 public:
 	/** This constructor uses OAuth code flow to get tokens. */
-	OneDriveStorage(Common::String code, Networking::ErrorCallback cb);
+	OneDriveStorage(const Common::String &code, Networking::ErrorCallback cb);
 
 	/** This constructor extracts tokens from JSON acquired via OAuth code flow. */
-	OneDriveStorage(Networking::JsonResponse codeFlowJson, Networking::ErrorCallback cb);
+	OneDriveStorage(const Networking::JsonResponse &codeFlowJson, Networking::ErrorCallback cb);
 
-	virtual ~OneDriveStorage();
+	~OneDriveStorage() override;
 
 	/**
 	 * Storage methods, which are used by CloudManager to save
@@ -72,44 +72,44 @@ public:
 	 * @note every Storage must write keyPrefix + "type" key
 	 *       with common value (e.g. "Dropbox").
 	 */
-	virtual void saveConfig(Common::String keyPrefix);
+	void saveConfig(const Common::String &keyPrefix) override;
 
 	/**
 	* Return unique storage name.
 	* @returns  some unique storage name (for example, "Dropbox (user@example.com)")
 	*/
-	virtual Common::String name() const;
+	Common::String name() const override;
 
 	/** Public Cloud API comes down there. */
 
 	/** Returns ListDirectoryStatus struct with list of files. */
-	virtual Networking::Request *listDirectory(Common::String path, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback, bool recursive = false);
+	Networking::Request *listDirectory(const Common::String &path, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback, bool recursive = false) override;
 
 	/** Returns UploadStatus struct with info about uploaded file. */
-	virtual Networking::Request *upload(Common::String path, Common::SeekableReadStream *contents, UploadCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *upload(const Common::String &path, Common::SeekableReadStream *contents, UploadCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	/** Returns pointer to Networking::NetworkReadStream. */
-	virtual Networking::Request *streamFileById(Common::String path, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *streamFileById(const Common::String &path, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	/** Calls the callback when finished. */
-	virtual Networking::Request *createDirectory(Common::String path, BoolCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *createDirectory(const Common::String &path, BoolCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	/** Returns the StorageInfo struct. */
-	virtual Networking::Request *info(StorageInfoCallback callback, Networking::ErrorCallback errorCallback);
+	Networking::Request *info(StorageInfoCallback callback, Networking::ErrorCallback errorCallback) override;
 
 	/** Returns storage's saves directory path with the trailing slash. */
-	virtual Common::String savesDirectoryPath();
+	Common::String savesDirectoryPath() override;
 
 	/**
 	 * Load token and user id from configs and return OneDriveStorage for those.
 	 * @return pointer to the newly created OneDriveStorage or 0 if some problem occurred.
 	 */
-	static OneDriveStorage *loadFromConfig(Common::String keyPrefix);
+	static OneDriveStorage *loadFromConfig(const Common::String &keyPrefix);
 
 	/**
 	 * Remove all OneDriveStorage-related data from config.
 	 */
-	static void removeFromConfig(Common::String keyPrefix);
+	static void removeFromConfig(const Common::String &keyPrefix);
 
 	Common::String accessToken() const { return _token; }
 };

--- a/backends/cloud/onedrive/onedrivetokenrefresher.cpp
+++ b/backends/cloud/onedrive/onedrivetokenrefresher.cpp
@@ -36,7 +36,7 @@ OneDriveTokenRefresher::OneDriveTokenRefresher(OneDriveStorage *parent, Networki
 
 OneDriveTokenRefresher::~OneDriveTokenRefresher() {}
 
-void OneDriveTokenRefresher::tokenRefreshed(Storage::BoolResponse response) {
+void OneDriveTokenRefresher::tokenRefreshed(const Storage::BoolResponse &response) {
 	if (!response.value) {
 		//failed to refresh token, notify user with NULL in original callback
 		warning("OneDriveTokenRefresher: failed to refresh token");
@@ -56,7 +56,7 @@ void OneDriveTokenRefresher::tokenRefreshed(Storage::BoolResponse response) {
 	retry(0);
 }
 
-void OneDriveTokenRefresher::finishJson(Common::JSONValue *json) {
+void OneDriveTokenRefresher::finishJson(const Common::JSONValue *json) {
 	if (!json) {
 		//that's probably not an error (200 OK)
 		CurlJsonRequest::finishJson(nullptr);
@@ -105,7 +105,7 @@ void OneDriveTokenRefresher::finishJson(Common::JSONValue *json) {
 
 			pause();
 			delete json;
-			_parentStorage->refreshAccessToken(new Common::Callback<OneDriveTokenRefresher, Storage::BoolResponse>(this, &OneDriveTokenRefresher::tokenRefreshed));
+			_parentStorage->refreshAccessToken(new Common::Callback<OneDriveTokenRefresher, const Storage::BoolResponse &>(this, &OneDriveTokenRefresher::tokenRefreshed));
 			return;
 		}
 	}
@@ -114,7 +114,7 @@ void OneDriveTokenRefresher::finishJson(Common::JSONValue *json) {
 	CurlJsonRequest::finishJson(json);
 }
 
-void OneDriveTokenRefresher::finishError(Networking::ErrorResponse error, Networking::RequestState state) {
+void OneDriveTokenRefresher::finishError(const Networking::ErrorResponse &error, Networking::RequestState state) {
 	if (error.failed) {
 		Common::JSONValue *value = Common::JSON::parse(error.response.c_str());
 
@@ -137,7 +137,7 @@ void OneDriveTokenRefresher::finishError(Networking::ErrorResponse error, Networ
 	Request::finishError(error); //call closest base class's method
 }
 
-void OneDriveTokenRefresher::setHeaders(Common::Array<Common::String> &headers) {
+void OneDriveTokenRefresher::setHeaders(const Common::Array<Common::String> &headers) {
 	_headers = headers;
 	curl_slist_free_all(_headersList);
 	_headersList = nullptr;
@@ -145,7 +145,7 @@ void OneDriveTokenRefresher::setHeaders(Common::Array<Common::String> &headers) 
 		CurlJsonRequest::addHeader(headers[i]);
 }
 
-void OneDriveTokenRefresher::addHeader(Common::String header) {
+void OneDriveTokenRefresher::addHeader(const Common::String &header) {
 	_headers.push_back(header);
 	CurlJsonRequest::addHeader(header);
 }

--- a/backends/cloud/onedrive/onedrivetokenrefresher.h
+++ b/backends/cloud/onedrive/onedrivetokenrefresher.h
@@ -34,16 +34,16 @@ class OneDriveTokenRefresher: public Networking::CurlJsonRequest {
 	OneDriveStorage *_parentStorage;
 	Common::Array<Common::String> _headers;
 
-	void tokenRefreshed(Storage::BoolResponse response);
+	void tokenRefreshed(const Storage::BoolResponse &response);
 
-	virtual void finishJson(Common::JSONValue *json);
-	virtual void finishError(Networking::ErrorResponse error, Networking::RequestState state = Networking::FINISHED);
+	void finishJson(const Common::JSONValue *json) override;
+	void finishError(const Networking::ErrorResponse &error, Networking::RequestState state = Networking::FINISHED) override;
 public:
 	OneDriveTokenRefresher(OneDriveStorage *parent, Networking::JsonCallback callback, Networking::ErrorCallback ecb, const char *url);
-	virtual ~OneDriveTokenRefresher();
+	~OneDriveTokenRefresher() override;
 
-	virtual void setHeaders(Common::Array<Common::String> &headers);
-	virtual void addHeader(Common::String header);
+	void setHeaders(const Common::Array<Common::String> &headers) override;
+	void addHeader(const Common::String &header) override;
 };
 
 } // End of namespace OneDrive

--- a/backends/cloud/onedrive/onedriveuploadrequest.cpp
+++ b/backends/cloud/onedrive/onedriveuploadrequest.cpp
@@ -35,7 +35,7 @@ namespace OneDrive {
 #define ONEDRIVE_API_SPECIAL_APPROOT_UPLOAD "https://graph.microsoft.com/v1.0/drive/special/approot:/%s:/upload.createSession"
 #define ONEDRIVE_API_SPECIAL_APPROOT_CONTENT "https://graph.microsoft.com/v1.0/drive/special/approot:/%s:/content"
 
-OneDriveUploadRequest::OneDriveUploadRequest(OneDriveStorage *storage, Common::String path, Common::SeekableReadStream *contents, Storage::UploadCallback callback, Networking::ErrorCallback ecb):
+OneDriveUploadRequest::OneDriveUploadRequest(OneDriveStorage *storage, const Common::String &path, Common::SeekableReadStream *contents, Storage::UploadCallback callback, Networking::ErrorCallback ecb):
 	Networking::Request(nullptr, ecb), _storage(storage), _savePath(path), _contentsStream(contents), _uploadCallback(callback),
 	_workingRequest(nullptr), _ignoreCallback(false) {
 	start();
@@ -73,8 +73,8 @@ void OneDriveUploadRequest::uploadNextPart() {
 
 	if (_uploadUrl == "" && (uint32)_contentsStream->size() > UPLOAD_PER_ONE_REQUEST) {
 		Common::String url = Common::String::format(ONEDRIVE_API_SPECIAL_APPROOT_UPLOAD, ConnMan.urlEncode(_savePath).c_str()); //folder must exist
-		Networking::JsonCallback callback = new Common::Callback<OneDriveUploadRequest, Networking::JsonResponse>(this, &OneDriveUploadRequest::partUploadedCallback);
-		Networking::ErrorCallback failureCallback = new Common::Callback<OneDriveUploadRequest, Networking::ErrorResponse>(this, &OneDriveUploadRequest::partUploadedErrorCallback);
+		Networking::JsonCallback callback = new Common::Callback<OneDriveUploadRequest, const Networking::JsonResponse &>(this, &OneDriveUploadRequest::partUploadedCallback);
+		Networking::ErrorCallback failureCallback = new Common::Callback<OneDriveUploadRequest, const Networking::ErrorResponse &>(this, &OneDriveUploadRequest::partUploadedErrorCallback);
 		Networking::CurlJsonRequest *request = new OneDriveTokenRefresher(_storage, callback, failureCallback, url.c_str());
 		request->addHeader("Authorization: Bearer " + _storage->accessToken());
 		request->setBuffer(new byte[1], 0); //use POST
@@ -89,8 +89,8 @@ void OneDriveUploadRequest::uploadNextPart() {
 		url = _uploadUrl;
 	}
 
-	Networking::JsonCallback callback = new Common::Callback<OneDriveUploadRequest, Networking::JsonResponse>(this, &OneDriveUploadRequest::partUploadedCallback);
-	Networking::ErrorCallback failureCallback = new Common::Callback<OneDriveUploadRequest, Networking::ErrorResponse>(this, &OneDriveUploadRequest::partUploadedErrorCallback);
+	Networking::JsonCallback callback = new Common::Callback<OneDriveUploadRequest, const Networking::JsonResponse &>(this, &OneDriveUploadRequest::partUploadedCallback);
+	Networking::ErrorCallback failureCallback = new Common::Callback<OneDriveUploadRequest, const Networking::ErrorResponse &>(this, &OneDriveUploadRequest::partUploadedErrorCallback);
 	Networking::CurlJsonRequest *request = new OneDriveTokenRefresher(_storage, callback, failureCallback, url.c_str());
 	request->addHeader("Authorization: Bearer " + _storage->accessToken());
 	request->usePut();
@@ -115,17 +115,17 @@ void OneDriveUploadRequest::uploadNextPart() {
 	_workingRequest = ConnMan.addRequest(request);
 }
 
-void OneDriveUploadRequest::partUploadedCallback(Networking::JsonResponse response) {
+void OneDriveUploadRequest::partUploadedCallback(const Networking::JsonResponse &response) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
 
 	Networking::ErrorResponse error(this, false, true, "", -1);
-	Networking::CurlJsonRequest *rq = (Networking::CurlJsonRequest *)response.request;
+	const Networking::CurlJsonRequest *rq = (const Networking::CurlJsonRequest *)response.request;
 	if (rq && rq->getNetworkReadStream())
 		error.httpResponseCode = rq->getNetworkReadStream()->httpResponseCode();
 
-	Common::JSONValue *json = response.value;
+	const Common::JSONValue *json = response.value;
 	if (json == nullptr) {
 		error.response = "Failed to parse JSON, null passed!";
 		finishError(error);
@@ -171,7 +171,7 @@ void OneDriveUploadRequest::partUploadedCallback(Networking::JsonResponse respon
 	delete json;
 }
 
-void OneDriveUploadRequest::partUploadedErrorCallback(Networking::ErrorResponse error) {
+void OneDriveUploadRequest::partUploadedErrorCallback(const Networking::ErrorResponse &error) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
@@ -182,7 +182,7 @@ void OneDriveUploadRequest::handle() {}
 
 void OneDriveUploadRequest::restart() { start(); }
 
-void OneDriveUploadRequest::finishUpload(StorageFile file) {
+void OneDriveUploadRequest::finishUpload(const StorageFile &file) {
 	Request::finishSuccess();
 	if (_uploadCallback)
 		(*_uploadCallback)(Storage::UploadResponse(this, file));

--- a/backends/cloud/onedrive/onedriveuploadrequest.h
+++ b/backends/cloud/onedrive/onedriveuploadrequest.h
@@ -42,16 +42,16 @@ class OneDriveUploadRequest: public Networking::Request {
 
 	void start();
 	void uploadNextPart();
-	void partUploadedCallback(Networking::JsonResponse response);
-	void partUploadedErrorCallback(Networking::ErrorResponse error);
-	void finishUpload(StorageFile status);
+	void partUploadedCallback(const Networking::JsonResponse &response);
+	void partUploadedErrorCallback(const Networking::ErrorResponse &error);
+	void finishUpload(const StorageFile &status);
 
 public:
-	OneDriveUploadRequest(OneDriveStorage *storage, Common::String path, Common::SeekableReadStream *contents, Storage::UploadCallback callback, Networking::ErrorCallback ecb);
-	virtual ~OneDriveUploadRequest();
+	OneDriveUploadRequest(OneDriveStorage *storage, const Common::String &path, Common::SeekableReadStream *contents, Storage::UploadCallback callback, Networking::ErrorCallback ecb);
+	~OneDriveUploadRequest() override;
 
-	virtual void handle();
-	virtual void restart();
+	void handle() override;
+	void restart() override;
 };
 
 } // End of namespace OneDrive

--- a/backends/cloud/savessyncrequest.h
+++ b/backends/cloud/savessyncrequest.h
@@ -44,17 +44,17 @@ class SavesSyncRequest: public Networking::Request {
 	uint32 _bytesToDownload, _bytesDownloaded;
 
 	void start();
-	void directoryListedCallback(Storage::ListDirectoryResponse response);
-	void directoryListedErrorCallback(Networking::ErrorResponse error);
-	void directoryCreatedCallback(Storage::BoolResponse response);
-	void directoryCreatedErrorCallback(Networking::ErrorResponse error);
-	void fileDownloadedCallback(Storage::BoolResponse response);
-	void fileDownloadedErrorCallback(Networking::ErrorResponse error);
-	void fileUploadedCallback(Storage::UploadResponse response);
-	void fileUploadedErrorCallback(Networking::ErrorResponse error);
+	void directoryListedCallback(const Storage::ListDirectoryResponse &response);
+	void directoryListedErrorCallback(const Networking::ErrorResponse &error);
+	void directoryCreatedCallback(const Storage::BoolResponse &response);
+	void directoryCreatedErrorCallback(const Networking::ErrorResponse &error);
+	void fileDownloadedCallback(const Storage::BoolResponse &response);
+	void fileDownloadedErrorCallback(const Networking::ErrorResponse &error);
+	void fileUploadedCallback(const Storage::UploadResponse &response);
+	void fileUploadedErrorCallback(const Networking::ErrorResponse &error);
 	void downloadNextFile();
 	void uploadNextFile();
-	virtual void finishError(Networking::ErrorResponse error, Networking::RequestState state = Networking::FINISHED);
+	void finishError(const Networking::ErrorResponse &error, Networking::RequestState state = Networking::FINISHED) override;
 	void finishSync(bool success);
 
 	uint32 getDownloadedBytes() const;
@@ -62,10 +62,10 @@ class SavesSyncRequest: public Networking::Request {
 
 public:
 	SavesSyncRequest(Storage *storage, Storage::BoolCallback callback, Networking::ErrorCallback ecb);
-	virtual ~SavesSyncRequest();
+	~SavesSyncRequest() override;
 
-	virtual void handle();
-	virtual void restart();
+	void handle() override;
+	void restart() override;
 
 	/** Returns a number in range [0, 1], where 1 is "complete". */
 	double getDownloadingProgress() const;

--- a/backends/cloud/storage.cpp
+++ b/backends/cloud/storage.cpp
@@ -46,10 +46,10 @@ void Storage::enable() {
 }
 
 Networking::ErrorCallback Storage::getErrorPrintingCallback() {
-	return new Common::Callback<Storage, Networking::ErrorResponse>(this, &Storage::printErrorResponse);
+	return new Common::Callback<Storage, const Networking::ErrorResponse &>(this, &Storage::printErrorResponse);
 }
 
-void Storage::printErrorResponse(Networking::ErrorResponse error) {
+void Storage::printErrorResponse(const Networking::ErrorResponse &error) {
 	debug(9, "Storage: error response (%s, %ld):", (error.failed ? "failed" : "interrupted"), error.httpResponseCode);
 	debug(9, "%s", error.response.c_str());
 }
@@ -84,7 +84,7 @@ void Storage::requestFinishedCallback(Networking::Request *invalidRequestPointer
 		syncSaves(nullptr, nullptr);
 }
 
-Networking::Request *Storage::upload(Common::String remotePath, Common::String localPath, UploadCallback callback, Networking::ErrorCallback errorCallback) {
+Networking::Request *Storage::upload(const Common::String &remotePath, const Common::String &localPath, UploadCallback callback, Networking::ErrorCallback errorCallback) {
 	if (!errorCallback) errorCallback = getErrorPrintingCallback();
 
 	Common::File *f = new Common::File();
@@ -105,17 +105,17 @@ bool Storage::uploadStreamSupported() {
 	return true;
 }
 
-Networking::Request *Storage::streamFile(Common::String path, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) {
+Networking::Request *Storage::streamFile(const Common::String &path, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) {
 	//most Storages use paths instead of ids, so this should work
 	return streamFileById(path, callback, errorCallback);
 }
 
-Networking::Request *Storage::download(Common::String remotePath, Common::String localPath, BoolCallback callback, Networking::ErrorCallback errorCallback) {
+Networking::Request *Storage::download(const Common::String &remotePath, const Common::String &localPath, BoolCallback callback, Networking::ErrorCallback errorCallback) {
 	//most Storages use paths instead of ids, so this should work
 	return downloadById(remotePath, localPath, callback, errorCallback);
 }
 
-Networking::Request *Storage::downloadById(Common::String remoteId, Common::String localPath, BoolCallback callback, Networking::ErrorCallback errorCallback) {
+Networking::Request *Storage::downloadById(const Common::String &remoteId, const Common::String &localPath, BoolCallback callback, Networking::ErrorCallback errorCallback) {
 	if (!errorCallback) errorCallback = getErrorPrintingCallback();
 
 	Common::DumpFile *f = new Common::DumpFile();
@@ -131,7 +131,7 @@ Networking::Request *Storage::downloadById(Common::String remoteId, Common::Stri
 	return addRequest(new DownloadRequest(this, callback, errorCallback, remoteId, f));
 }
 
-Networking::Request *Storage::downloadFolder(Common::String remotePath, Common::String localPath, FileArrayCallback callback, Networking::ErrorCallback errorCallback, bool recursive) {
+Networking::Request *Storage::downloadFolder(const Common::String &remotePath, const Common::String &localPath, FileArrayCallback callback, Networking::ErrorCallback errorCallback, bool recursive) {
 	if (!_isEnabled) {
 		warning("Storage::downloadFolder: cannot be run while Storage is disabled");
 		if (errorCallback)
@@ -159,9 +159,9 @@ SavesSyncRequest *Storage::syncSaves(BoolCallback callback, Networking::ErrorCal
 		return _savesSyncRequest;
 	}
 	if (!callback)
-		callback = new Common::Callback<Storage, BoolResponse>(this, &Storage::savesSyncDefaultCallback);
+		callback = new Common::Callback<Storage, const BoolResponse &>(this, &Storage::savesSyncDefaultCallback);
 	if (!errorCallback)
-		errorCallback = new Common::Callback<Storage, Networking::ErrorResponse>(this, &Storage::savesSyncDefaultErrorCallback);
+		errorCallback = new Common::Callback<Storage, const Networking::ErrorResponse &>(this, &Storage::savesSyncDefaultErrorCallback);
 	_savesSyncRequest = new SavesSyncRequest(this, callback, errorCallback);
 	_syncRestartRequestsed = false;
 	_runningRequestsMutex.unlock();
@@ -226,7 +226,7 @@ void Storage::cancelSync() {
 	_runningRequestsMutex.unlock();
 }
 
-void Storage::savesSyncDefaultCallback(BoolResponse response) {
+void Storage::savesSyncDefaultCallback(const BoolResponse &response) {
 	_runningRequestsMutex.lock();
 	_savesSyncRequest = nullptr;
 	_runningRequestsMutex.unlock();
@@ -235,7 +235,7 @@ void Storage::savesSyncDefaultCallback(BoolResponse response) {
 		warning("SavesSyncRequest called success callback with `false` argument");
 }
 
-void Storage::savesSyncDefaultErrorCallback(Networking::ErrorResponse error) {
+void Storage::savesSyncDefaultErrorCallback(const Networking::ErrorResponse &error) {
 	_runningRequestsMutex.lock();
 	_savesSyncRequest = nullptr;
 	_runningRequestsMutex.unlock();
@@ -250,7 +250,7 @@ void Storage::savesSyncDefaultErrorCallback(Networking::ErrorResponse error) {
 
 ///// DownloadFolderRequest-related /////
 
-bool Storage::startDownload(Common::String remotePath, Common::String localPath) {
+bool Storage::startDownload(const Common::String &remotePath, const Common::String &localPath) {
 	_runningRequestsMutex.lock();
 	if (_downloadFolderRequest) {
 		warning("Storage::startDownload: there is a download in progress already");
@@ -259,8 +259,8 @@ bool Storage::startDownload(Common::String remotePath, Common::String localPath)
 	}
 	_downloadFolderRequest = (FolderDownloadRequest *)downloadFolder(
 		remotePath, localPath,
-		new Common::Callback<Storage, FileArrayResponse>(this, &Storage::directoryDownloadedCallback),
-		new Common::Callback<Storage, Networking::ErrorResponse>(this, &Storage::directoryDownloadedErrorCallback),
+		new Common::Callback<Storage, const FileArrayResponse &>(this, &Storage::directoryDownloadedCallback),
+		new Common::Callback<Storage, const Networking::ErrorResponse &>(this, &Storage::directoryDownloadedErrorCallback),
 		true
 	);
 	_runningRequestsMutex.unlock();
@@ -342,7 +342,7 @@ Common::String Storage::getDownloadLocalDirectory() {
 	return result;
 }
 
-void Storage::directoryDownloadedCallback(FileArrayResponse response) {
+void Storage::directoryDownloadedCallback(const FileArrayResponse &response) {
 	_runningRequestsMutex.lock();
 	_downloadFolderRequest = nullptr;
 	_runningRequestsMutex.unlock();
@@ -356,7 +356,7 @@ void Storage::directoryDownloadedCallback(FileArrayResponse response) {
 	Common::OSDMessageQueue::instance().addMessage(message);
 }
 
-void Storage::directoryDownloadedErrorCallback(Networking::ErrorResponse error) {
+void Storage::directoryDownloadedErrorCallback(const Networking::ErrorResponse &error) {
 	_runningRequestsMutex.lock();
 	_downloadFolderRequest = nullptr;
 	_runningRequestsMutex.unlock();

--- a/backends/cloud/storage.h
+++ b/backends/cloud/storage.h
@@ -45,17 +45,17 @@ class FolderDownloadRequest;
 
 class Storage {
 public:
-	typedef Networking::Response<Common::Array<StorageFile>&> FileArrayResponse;
-	typedef Networking::Response<StorageInfo> StorageInfoResponse;
+	typedef Networking::Response<const Common::Array<StorageFile> &> FileArrayResponse;
+	typedef Networking::Response<const StorageInfo &> StorageInfoResponse;
 	typedef Networking::Response<bool> BoolResponse;
-	typedef Networking::Response<StorageFile> UploadResponse;
-	typedef Networking::Response<Common::Array<StorageFile> &> ListDirectoryResponse;
+	typedef Networking::Response<const StorageFile &> UploadResponse;
+	typedef Networking::Response<const Common::Array<StorageFile> &> ListDirectoryResponse;
 
-	typedef Common::BaseCallback<FileArrayResponse> *FileArrayCallback;
-	typedef Common::BaseCallback<StorageInfoResponse> *StorageInfoCallback;
-	typedef Common::BaseCallback<BoolResponse> *BoolCallback;
-	typedef Common::BaseCallback<UploadResponse> *UploadCallback;
-	typedef Common::BaseCallback<ListDirectoryResponse> *ListDirectoryCallback;
+	typedef Common::BaseCallback<const FileArrayResponse &> *FileArrayCallback;
+	typedef Common::BaseCallback<const StorageInfoResponse &> *StorageInfoCallback;
+	typedef Common::BaseCallback<const BoolResponse &> *BoolCallback;
+	typedef Common::BaseCallback<const UploadResponse &> *UploadCallback;
+	typedef Common::BaseCallback<const ListDirectoryResponse &> *ListDirectoryCallback;
 
 protected:
 	/** Keeps track of running requests. */
@@ -76,7 +76,7 @@ protected:
 	virtual Networking::ErrorCallback getErrorPrintingCallback();
 
 	/** Prints ErrorResponse contents with debug(). */
-	virtual void printErrorResponse(Networking::ErrorResponse error);
+	virtual void printErrorResponse(const Networking::ErrorResponse &error);
 
 	/**
 	 * Adds request to the ConnMan, but also increases _runningRequestsCount.
@@ -109,7 +109,7 @@ public:
 	 * @note every Storage must write keyPrefix + "type" key
 	 *       with common value (e.g. "Dropbox").
 	 */
-	virtual void saveConfig(Common::String keyPrefix) = 0;
+	virtual void saveConfig(const Common::String  &keyPrefix) = 0;
 
 	/**
 	* Return unique storage name.
@@ -136,31 +136,31 @@ public:
 	 */
 
 	/** Returns ListDirectoryResponse with list of files. */
-	virtual Networking::Request *listDirectory(Common::String path, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback, bool recursive = false) = 0;
+	virtual Networking::Request *listDirectory(const Common::String &path, ListDirectoryCallback callback, Networking::ErrorCallback errorCallback, bool recursive = false) = 0;
 
 	/** Returns StorageFile with info about uploaded file. */
-	virtual Networking::Request *upload(Common::String path, Common::SeekableReadStream *contents, UploadCallback callback, Networking::ErrorCallback errorCallback) = 0;
-	virtual Networking::Request *upload(Common::String remotePath, Common::String localPath, UploadCallback callback, Networking::ErrorCallback errorCallback);
+	virtual Networking::Request *upload(const Common::String &path, Common::SeekableReadStream *contents, UploadCallback callback, Networking::ErrorCallback errorCallback) = 0;
+	virtual Networking::Request *upload(const Common::String &remotePath, const Common::String &localPath, UploadCallback callback, Networking::ErrorCallback errorCallback);
 
 	/** Returns whether Storage supports upload(ReadStream). */
 	virtual bool uploadStreamSupported();
 
 	/** Returns pointer to Networking::NetworkReadStream. */
-	virtual Networking::Request *streamFile(Common::String path, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback);
-	virtual Networking::Request *streamFileById(Common::String id, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) = 0;
+	virtual Networking::Request *streamFile(const Common::String &path, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback);
+	virtual Networking::Request *streamFileById(const Common::String &id, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) = 0;
 
 	/** Calls the callback when finished. */
-	virtual Networking::Request *download(Common::String remotePath, Common::String localPath, BoolCallback callback, Networking::ErrorCallback errorCallback);
-	virtual Networking::Request *downloadById(Common::String remoteId, Common::String localPath, BoolCallback callback, Networking::ErrorCallback errorCallback);
+	virtual Networking::Request *download(const Common::String &remotePath, const Common::String &localPath, BoolCallback callback, Networking::ErrorCallback errorCallback);
+	virtual Networking::Request *downloadById(const Common::String &remoteId, const Common::String &localPath, BoolCallback callback, Networking::ErrorCallback errorCallback);
 
 	/** Returns Common::Array<StorageFile> with list of files, which were not downloaded. */
-	virtual Networking::Request *downloadFolder(Common::String remotePath, Common::String localPath, FileArrayCallback callback, Networking::ErrorCallback errorCallback, bool recursive = false);
+	virtual Networking::Request *downloadFolder(const Common::String &remotePath, const Common::String &localPath, FileArrayCallback callback, Networking::ErrorCallback errorCallback, bool recursive = false);
 
 	/** Calls the callback when finished. */
 	virtual SavesSyncRequest *syncSaves(BoolCallback callback, Networking::ErrorCallback errorCallback);
 
 	/** Calls the callback when finished. */
-	virtual Networking::Request *createDirectory(Common::String path, BoolCallback callback, Networking::ErrorCallback errorCallback) = 0;
+	virtual Networking::Request *createDirectory(const Common::String &path, BoolCallback callback, Networking::ErrorCallback errorCallback) = 0;
 
 	/**
 	 * Returns the StorageInfo struct via <callback>.
@@ -205,16 +205,16 @@ public:
 
 protected:
 	/** Finishes the sync. Shows an OSD message. */
-	virtual void savesSyncDefaultCallback(BoolResponse response);
+	virtual void savesSyncDefaultCallback(const BoolResponse &response);
 
 	/** Finishes the sync. Shows an OSD message. */
-	virtual void savesSyncDefaultErrorCallback(Networking::ErrorResponse error);
+	virtual void savesSyncDefaultErrorCallback(const Networking::ErrorResponse &error);
 
 public:
 	///// DownloadFolderRequest-related /////
 
 	/** Starts a folder download. */
-	virtual bool startDownload(Common::String remotePath, Common::String localPath);
+	virtual bool startDownload(const Common::String &remotePath, const Common::String &localPath);
 
 	/** Cancels running download. */
 	virtual void cancelDownload();
@@ -245,10 +245,10 @@ public:
 
 protected:
 	/** Finishes the download. Shows an OSD message. */
-	virtual void directoryDownloadedCallback(FileArrayResponse response);
+	virtual void directoryDownloadedCallback(const FileArrayResponse &response);
 
 	/** Finishes the download. Shows an OSD message. */
-	virtual void directoryDownloadedErrorCallback(Networking::ErrorResponse error);
+	virtual void directoryDownloadedErrorCallback(const Networking::ErrorResponse &error);
 };
 
 } // End of namespace Cloud

--- a/backends/cloud/storagefile.cpp
+++ b/backends/cloud/storagefile.cpp
@@ -32,7 +32,7 @@ StorageFile::StorageFile() {
 	_isDirectory = false;
 }
 
-StorageFile::StorageFile(Common::String pth, uint32 sz, uint32 ts, bool dir) {
+StorageFile::StorageFile(const Common::String &pth, uint32 sz, uint32 ts, bool dir) {
 	_id = pth;
 	_path = pth;
 
@@ -55,7 +55,7 @@ StorageFile::StorageFile(Common::String pth, uint32 sz, uint32 ts, bool dir) {
 	_isDirectory = dir;
 }
 
-StorageFile::StorageFile(Common::String fileId, Common::String filePath, Common::String fileName, uint32 sz, uint32 ts, bool dir) {
+StorageFile::StorageFile(const Common::String &fileId, const Common::String &filePath, const Common::String &fileName, uint32 sz, uint32 ts, bool dir) {
 	_id = fileId;
 	_path = filePath;
 	_name = fileName;

--- a/backends/cloud/storagefile.h
+++ b/backends/cloud/storagefile.h
@@ -46,8 +46,8 @@ class StorageFile {
 
 public:
 	StorageFile(); //invalid empty file
-	StorageFile(Common::String pth, uint32 sz, uint32 ts, bool dir);
-	StorageFile(Common::String fileId, Common::String filePath, Common::String fileName, uint32 sz, uint32 ts, bool dir);
+	StorageFile(const Common::String &pth, uint32 sz, uint32 ts, bool dir);
+	StorageFile(const Common::String &fileId, const Common::String &filePath, const Common::String &fileName, uint32 sz, uint32 ts, bool dir);
 
 	Common::String id() const { return _id; }
 	Common::String path() const { return _path; }
@@ -56,7 +56,7 @@ public:
 	uint32 timestamp() const { return _timestamp; }
 	bool isDirectory() const { return _isDirectory; }
 
-	void setPath(Common::String path_) { _path = path_; }
+	void setPath(const Common::String &path_) { _path = path_; }
 };
 
 } // End of namespace Cloud

--- a/backends/cloud/storageinfo.h
+++ b/backends/cloud/storageinfo.h
@@ -36,7 +36,7 @@ class StorageInfo {
 	uint64 _usedBytes, _allocatedBytes;
 
 public:
-	StorageInfo(Common::String uid_, Common::String name_, Common::String email_, uint64 used_, uint64 allocated):
+	StorageInfo(const Common::String &uid_, const Common::String &name_, const Common::String &email_, uint64 used_, uint64 allocated):
 		_uid(uid_), _name(name_), _email(email_), _usedBytes(used_), _allocatedBytes(allocated) {}
 
 	Common::String uid() const { return _uid; }

--- a/backends/networking/curl/connectionmanager.cpp
+++ b/backends/networking/curl/connectionmanager.cpp
@@ -100,7 +100,7 @@ Request *ConnectionManager::addRequest(Request *request, RequestCallback callbac
 	return request;
 }
 
-Common::String ConnectionManager::urlEncode(Common::String s) const {
+Common::String ConnectionManager::urlEncode(const Common::String &s) const {
 	if (!_multi)
 		return "";
 #if LIBCURL_VERSION_NUM >= 0x070F04

--- a/backends/networking/curl/connectionmanager.h
+++ b/backends/networking/curl/connectionmanager.h
@@ -89,7 +89,7 @@ class ConnectionManager : public Common::Singleton<ConnectionManager> {
 
 public:
 	ConnectionManager();
-	virtual ~ConnectionManager();
+	~ConnectionManager() override;
 
 	/**
 	 * All libcurl transfers are going through this ConnectionManager.
@@ -114,7 +114,7 @@ public:
 	Request *addRequest(Request *request, RequestCallback callback = nullptr);
 
 	/** Return URL-encoded version of given string. */
-	Common::String urlEncode(Common::String s) const;
+	Common::String urlEncode(const Common::String &s) const;
 
 	static uint32 getCloudRequestsPeriodInMicroseconds();
 

--- a/backends/networking/curl/curljsonrequest.cpp
+++ b/backends/networking/curl/curljsonrequest.cpp
@@ -30,7 +30,7 @@
 
 namespace Networking {
 
-CurlJsonRequest::CurlJsonRequest(JsonCallback cb, ErrorCallback ecb, Common::String url) :
+CurlJsonRequest::CurlJsonRequest(JsonCallback cb, ErrorCallback ecb, const Common::String &url) :
 	CurlRequest(nullptr, ecb, url), _jsonCallback(cb), _contentsStream(DisposeAfterUse::YES),
 	_buffer(new byte[CURL_JSON_REQUEST_BUFFER_SIZE]) {}
 
@@ -71,7 +71,7 @@ void CurlJsonRequest::restart() {
 	//with no stream available next handle() will create another one
 }
 
-void CurlJsonRequest::finishJson(Common::JSONValue *json) {
+void CurlJsonRequest::finishJson(const Common::JSONValue *json) {
 	Request::finishSuccess();
 	if (_jsonCallback)
 		(*_jsonCallback)(JsonResponse(this, json)); //potential memory leak, free it in your callbacks!
@@ -79,7 +79,7 @@ void CurlJsonRequest::finishJson(Common::JSONValue *json) {
 		delete json;
 }
 
-bool CurlJsonRequest::jsonIsObject(Common::JSONValue *item, const char *warningPrefix) {
+bool CurlJsonRequest::jsonIsObject(const Common::JSONValue *item, const char *warningPrefix) {
 	if (item == nullptr) {
 		warning("%s: passed item is NULL", warningPrefix);
 		return false;
@@ -92,7 +92,7 @@ bool CurlJsonRequest::jsonIsObject(Common::JSONValue *item, const char *warningP
 	return false;
 }
 
-bool CurlJsonRequest::jsonContainsObject(Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional) {
+bool CurlJsonRequest::jsonContainsObject(const Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional) {
 	if (!item.contains(key)) {
 		if (isOptional) {
 			return true;
@@ -109,7 +109,7 @@ bool CurlJsonRequest::jsonContainsObject(Common::JSONObject &item, const char *k
 	return false;
 }
 
-bool CurlJsonRequest::jsonContainsString(Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional) {
+bool CurlJsonRequest::jsonContainsString(const Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional) {
 	if (!item.contains(key)) {
 		if (isOptional) {
 			return true;
@@ -126,7 +126,7 @@ bool CurlJsonRequest::jsonContainsString(Common::JSONObject &item, const char *k
 	return false;
 }
 
-bool CurlJsonRequest::jsonContainsIntegerNumber(Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional) {
+bool CurlJsonRequest::jsonContainsIntegerNumber(const Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional) {
 	if (!item.contains(key)) {
 		if (isOptional) {
 			return true;
@@ -143,7 +143,7 @@ bool CurlJsonRequest::jsonContainsIntegerNumber(Common::JSONObject &item, const 
 	return false;
 }
 
-bool CurlJsonRequest::jsonContainsArray(Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional) {
+bool CurlJsonRequest::jsonContainsArray(const Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional) {
 	if (!item.contains(key)) {
 		if (isOptional) {
 			return true;
@@ -160,7 +160,7 @@ bool CurlJsonRequest::jsonContainsArray(Common::JSONObject &item, const char *ke
 	return false;
 }
 
-bool CurlJsonRequest::jsonContainsStringOrIntegerNumber(Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional) {
+bool CurlJsonRequest::jsonContainsStringOrIntegerNumber(const Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional) {
 	if (!item.contains(key)) {
 		if (isOptional) {
 			return true;
@@ -177,7 +177,7 @@ bool CurlJsonRequest::jsonContainsStringOrIntegerNumber(Common::JSONObject &item
 	return false;
 }
 
-bool CurlJsonRequest::jsonContainsAttribute(Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional) {
+bool CurlJsonRequest::jsonContainsAttribute(const Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional) {
 	if (!item.contains(key)) {
 		if (isOptional) {
 			return true;

--- a/backends/networking/curl/curljsonrequest.h
+++ b/backends/networking/curl/curljsonrequest.h
@@ -28,9 +28,9 @@
 
 namespace Networking {
 
-typedef Response<Common::JSONValue *> JsonResponse;
-typedef Common::BaseCallback<JsonResponse> *JsonCallback;
-typedef Common::BaseCallback<Common::JSONValue *> *JSONValueCallback;
+typedef Response<const Common::JSONValue *> JsonResponse;
+typedef Common::BaseCallback<const JsonResponse &> *JsonCallback;
+typedef Common::BaseCallback<const Common::JSONValue *> *JSONValueCallback;
 
 #define CURL_JSON_REQUEST_BUFFER_SIZE 512 * 1024
 
@@ -41,22 +41,22 @@ protected:
 	byte *_buffer;
 
 	/** Sets FINISHED state and passes the JSONValue * into user's callback in JsonResponse. */
-	virtual void finishJson(Common::JSONValue *json);
+	virtual void finishJson(const Common::JSONValue *json);
 
 public:
-	CurlJsonRequest(JsonCallback cb, ErrorCallback ecb, Common::String url);
-	virtual ~CurlJsonRequest();
+	CurlJsonRequest(JsonCallback cb, ErrorCallback ecb, const Common::String &url);
+	~CurlJsonRequest() override;
 
-	virtual void handle();
-	virtual void restart();
+	void handle() override;
+	void restart() override;
 
-	static bool jsonIsObject(Common::JSONValue *item, const char *warningPrefix);
-	static bool jsonContainsObject(Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional = false);
-	static bool jsonContainsString(Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional = false);
-	static bool jsonContainsIntegerNumber(Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional = false);
-	static bool jsonContainsArray(Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional = false);
-	static bool jsonContainsStringOrIntegerNumber(Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional = false);
-	static bool jsonContainsAttribute(Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional = false);
+	static bool jsonIsObject(const Common::JSONValue *item, const char *warningPrefix);
+	static bool jsonContainsObject(const Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional = false);
+	static bool jsonContainsString(const Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional = false);
+	static bool jsonContainsIntegerNumber(const Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional = false);
+	static bool jsonContainsArray(const Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional = false);
+	static bool jsonContainsStringOrIntegerNumber(const Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional = false);
+	static bool jsonContainsAttribute(const Common::JSONObject &item, const char *key, const char *warningPrefix, bool isOptional = false);
 };
 
 } // End of namespace Networking

--- a/backends/networking/curl/curlrequest.cpp
+++ b/backends/networking/curl/curlrequest.cpp
@@ -29,7 +29,7 @@
 
 namespace Networking {
 
-CurlRequest::CurlRequest(DataCallback cb, ErrorCallback ecb, Common::String url):
+CurlRequest::CurlRequest(DataCallback cb, ErrorCallback ecb, const Common::String &url):
 	Request(cb, ecb), _url(url), _stream(nullptr), _headersList(nullptr), _bytesBuffer(nullptr),
 	_bytesBufferSize(0), _uploading(false), _usingPatch(false), _keepAlive(false), _keepAliveIdle(120), _keepAliveInterval(60) {}
 
@@ -78,18 +78,18 @@ Common::String CurlRequest::date() const {
 	return "";
 }
 
-void CurlRequest::setHeaders(Common::Array<Common::String> &headers) {
+void CurlRequest::setHeaders(const Common::Array<Common::String> &headers) {
 	curl_slist_free_all(_headersList);
 	_headersList = nullptr;
 	for (uint32 i = 0; i < headers.size(); ++i)
 		addHeader(headers[i]);
 }
 
-void CurlRequest::addHeader(Common::String header) {
+void CurlRequest::addHeader(const Common::String &header) {
 	_headersList = curl_slist_append(_headersList, header.c_str());
 }
 
-void CurlRequest::addPostField(Common::String keyValuePair) {
+void CurlRequest::addPostField(const Common::String &keyValuePair) {
 	if (_bytesBuffer)
 		warning("CurlRequest: added POST fields would be ignored, because there is buffer present");
 
@@ -102,7 +102,7 @@ void CurlRequest::addPostField(Common::String keyValuePair) {
 		_postFields += "&" + keyValuePair;
 }
 
-void CurlRequest::addFormField(Common::String name, Common::String value) {
+void CurlRequest::addFormField(const Common::String &name, const Common::String &value) {
 	if (_bytesBuffer)
 		warning("CurlRequest: added POST form fields would be ignored, because there is buffer present");
 
@@ -112,7 +112,7 @@ void CurlRequest::addFormField(Common::String name, Common::String value) {
 	_formFields[name] = value;
 }
 
-void CurlRequest::addFormFile(Common::String name, Common::String filename) {
+void CurlRequest::addFormFile(const Common::String &name, const Common::String &filename) {
 	if (_bytesBuffer)
 		warning("CurlRequest: added POST form files would be ignored, because there is buffer present");
 

--- a/backends/networking/curl/curlrequest.h
+++ b/backends/networking/curl/curlrequest.h
@@ -35,7 +35,7 @@ namespace Networking {
 class NetworkReadStream;
 
 typedef Response<NetworkReadStream *> NetworkReadStreamResponse;
-typedef Common::BaseCallback<NetworkReadStreamResponse> *NetworkReadStreamCallback;
+typedef Common::BaseCallback<const NetworkReadStreamResponse &> *NetworkReadStreamCallback;
 
 class CurlRequest: public Request {
 protected:
@@ -52,30 +52,30 @@ protected:
 	bool _keepAlive;
 	long _keepAliveIdle, _keepAliveInterval;
 
-	virtual NetworkReadStream *makeStream();
+	NetworkReadStream *makeStream();
 
 public:
-	CurlRequest(DataCallback cb, ErrorCallback ecb, Common::String url);
-	virtual ~CurlRequest();
+	CurlRequest(DataCallback cb, ErrorCallback ecb, const Common::String &url);
+	~CurlRequest() override;
 
-	virtual void handle();
-	virtual void restart();
-	virtual Common::String date() const;
+	void handle() override;
+	void restart() override;
+	Common::String date() const override;
 
 	/** Replaces all headers with the passed array of headers. */
-	virtual void setHeaders(Common::Array<Common::String> &headers);
+	virtual void setHeaders(const Common::Array<Common::String> &headers);
 
 	/** Adds a header into headers list. */
-	virtual void addHeader(Common::String header);
+	virtual void addHeader(const Common::String &header);
 
 	/** Adds a post field (key=value pair). */
-	virtual void addPostField(Common::String field);
+	virtual void addPostField(const Common::String &field);
 
 	/** Adds a form/multipart field (name, value). */
-	virtual void addFormField(Common::String name, Common::String value);
+	virtual void addFormField(const Common::String &name, const Common::String &value);
 
 	/** Adds a form/multipart file (field name, file name). */
-	virtual void addFormFile(Common::String name, Common::String filename);
+	virtual void addFormFile(const Common::String &name, const Common::String &filename);
 
 	/** Sets bytes buffer. */
 	virtual void setBuffer(byte *buffer, uint32 size);

--- a/backends/networking/curl/networkreadstream.cpp
+++ b/backends/networking/curl/networkreadstream.cpp
@@ -158,7 +158,7 @@ void NetworkReadStream::setupBufferContents(const byte *buffer, uint32 bufferSiz
 	ConnMan.registerEasyHandle(_easy);
 }
 
-void NetworkReadStream::setupFormMultipart(Common::HashMap<Common::String, Common::String> formFields, Common::HashMap<Common::String, Common::String> formFiles) {
+void NetworkReadStream::setupFormMultipart(const Common::HashMap<Common::String, Common::String> &formFields, const Common::HashMap<Common::String, Common::String> &formFiles) {
 	// set POST multipart upload form fields/files
 	struct curl_httppost *formpost = nullptr;
 	struct curl_httppost *lastptr = nullptr;
@@ -193,13 +193,13 @@ void NetworkReadStream::setupFormMultipart(Common::HashMap<Common::String, Commo
 	ConnMan.registerEasyHandle(_easy);
 }
 
-NetworkReadStream::NetworkReadStream(const char *url, curl_slist *headersList, Common::String postFields, bool uploading, bool usingPatch, bool keepAlive, long keepAliveIdle, long keepAliveInterval):
+NetworkReadStream::NetworkReadStream(const char *url, curl_slist *headersList, const Common::String &postFields, bool uploading, bool usingPatch, bool keepAlive, long keepAliveIdle, long keepAliveInterval):
 		_backingStream(DisposeAfterUse::YES), _keepAlive(keepAlive), _keepAliveIdle(keepAliveIdle), _keepAliveInterval(keepAliveInterval), _errorBuffer(nullptr), _errorCode(CURLE_OK) {
 	initCurl(url, headersList);
 	setupBufferContents((const byte *)postFields.c_str(), postFields.size(), uploading, usingPatch, false);
 }
 
-NetworkReadStream::NetworkReadStream(const char *url, curl_slist *headersList, Common::HashMap<Common::String, Common::String> formFields, Common::HashMap<Common::String, Common::String> formFiles, bool keepAlive, long keepAliveIdle, long keepAliveInterval):
+NetworkReadStream::NetworkReadStream(const char *url, curl_slist *headersList, const Common::HashMap<Common::String, Common::String> &formFields, const Common::HashMap<Common::String, Common::String> &formFiles, bool keepAlive, long keepAliveIdle, long keepAliveInterval):
 		_backingStream(DisposeAfterUse::YES), _keepAlive(keepAlive), _keepAliveIdle(keepAliveIdle), _keepAliveInterval(keepAliveInterval), _errorBuffer(nullptr), _errorCode(CURLE_OK) {
 	initCurl(url, headersList);
 	setupFormMultipart(formFields, formFiles);
@@ -211,7 +211,7 @@ NetworkReadStream::NetworkReadStream(const char *url, curl_slist *headersList, c
 	setupBufferContents(buffer, bufferSize, uploading, usingPatch, post);
 }
 
-bool NetworkReadStream::reuse(const char *url, curl_slist *headersList, Common::String postFields, bool uploading, bool usingPatch) {
+bool NetworkReadStream::reuse(const char *url, curl_slist *headersList, const Common::String &postFields, bool uploading, bool usingPatch) {
 	if (!reuseCurl(url, headersList))
 		return false;
 
@@ -220,7 +220,7 @@ bool NetworkReadStream::reuse(const char *url, curl_slist *headersList, Common::
 	return true;
 }
 
-bool NetworkReadStream::reuse(const char *url, curl_slist *headersList, Common::HashMap<Common::String, Common::String> formFields, Common::HashMap<Common::String, Common::String> formFiles) {
+bool NetworkReadStream::reuse(const char *url, curl_slist *headersList, const Common::HashMap<Common::String, Common::String> &formFields, const Common::HashMap<Common::String, Common::String> &formFiles) {
 	if (!reuseCurl(url, headersList))
 		return false;
 

--- a/backends/networking/curl/networkreadstream.h
+++ b/backends/networking/curl/networkreadstream.h
@@ -33,7 +33,7 @@ struct curl_slist;
 
 namespace Networking {
 
-class NetworkReadStream: public Common::ReadStream {
+class NetworkReadStream : public Common::ReadStream {
 	CURL *_easy;
 	Common::MemoryReadWriteStream _backingStream;
 	bool _keepAlive;
@@ -52,7 +52,7 @@ class NetworkReadStream: public Common::ReadStream {
 	void initCurl(const char *url, curl_slist *headersList);
 	bool reuseCurl(const char *url, curl_slist *headersList);
 	void setupBufferContents(const byte *buffer, uint32 bufferSize, bool uploading, bool usingPatch, bool post);
-	void setupFormMultipart(Common::HashMap<Common::String, Common::String> formFields, Common::HashMap<Common::String, Common::String> formFiles);
+	void setupFormMultipart(const Common::HashMap<Common::String, Common::String> &formFields, const Common::HashMap<Common::String, Common::String> &formFiles);
 
 	/**
 	 * Fills the passed buffer with _sendingContentsBuffer contents.
@@ -76,24 +76,24 @@ class NetworkReadStream: public Common::ReadStream {
 	static int curlProgressCallbackOlder(void *p, double dltotal, double dlnow, double ultotal, double ulnow);
 public:
 	/** Send <postFields>, using POST by default. */
-	NetworkReadStream(const char *url, curl_slist *headersList, Common::String postFields, bool uploading = false, bool usingPatch = false, bool keepAlive = false, long keepAliveIdle = 120, long keepAliveInterval = 60);
+	NetworkReadStream(const char *url, curl_slist *headersList, const Common::String &postFields, bool uploading = false, bool usingPatch = false, bool keepAlive = false, long keepAliveIdle = 120, long keepAliveInterval = 60);
 	/** Send <formFields>, <formFiles>, using POST multipart/form. */
 	NetworkReadStream(
 	    const char *url, curl_slist *headersList,
-	    Common::HashMap<Common::String, Common::String> formFields,
-	    Common::HashMap<Common::String, Common::String> formFiles,
+	    const Common::HashMap<Common::String, Common::String> &formFields,
+	    const Common::HashMap<Common::String, Common::String> &formFiles,
 		bool keepAlive = false, long keepAliveIdle = 120, long keepAliveInterval = 60);
 	/** Send <buffer>, using POST by default. */
 	NetworkReadStream(const char *url, curl_slist *headersList, const byte *buffer, uint32 bufferSize, bool uploading = false, bool usingPatch = false, bool post = true, bool keepAlive = false, long keepAliveIdle = 120, long keepAliveInterval = 60);
-	virtual ~NetworkReadStream();
+	~NetworkReadStream() override;
 
 	/** Send <postFields>, using POST by default. */
-	bool reuse(const char *url, curl_slist *headersList, Common::String postFields, bool uploading = false, bool usingPatch = false);
+	bool reuse(const char *url, curl_slist *headersList, const Common::String &postFields, bool uploading = false, bool usingPatch = false);
 	/** Send <formFields>, <formFiles>, using POST multipart/form. */
 	bool reuse(
 		const char *url, curl_slist *headersList,
-		Common::HashMap<Common::String, Common::String> formFields,
-		Common::HashMap<Common::String, Common::String> formFiles);
+		const Common::HashMap<Common::String, Common::String> &formFields,
+		const Common::HashMap<Common::String, Common::String> &formFiles);
 	/** Send <buffer>, using POST by default. */
 	bool reuse(const char *url, curl_slist *headersList, const byte *buffer, uint32 bufferSize, bool uploading = false, bool usingPatch = false, bool post = true);
 
@@ -107,7 +107,7 @@ public:
 	 * with N bytes, reading exactly N bytes from the start should *not*
 	 * set eos; only reading *beyond* the available data should set it.
 	 */
-	virtual bool eos() const;
+	bool eos() const override;
 
 	/**
 	 * Read data from the stream. Subclasses must implement this
@@ -121,7 +121,7 @@ public:
 	 * @param dataSize  number of bytes to be read
 	 * @return the number of bytes which were actually read.
 	 */
-	virtual uint32 read(void *dataPtr, uint32 dataSize);
+	uint32 read(void *dataPtr, uint32 dataSize) override;
 
 	/**
 	 * This method is called by ConnectionManager to indicate

--- a/backends/networking/curl/postrequest.cpp
+++ b/backends/networking/curl/postrequest.cpp
@@ -27,7 +27,7 @@
 
 namespace Networking {
 
-PostRequest::PostRequest(Common::String url, Networking::JSONValueCallback cb, Networking::ErrorCallback ecb):
+PostRequest::PostRequest(const Common::String &url, Networking::JSONValueCallback cb, Networking::ErrorCallback ecb):
 	Networking::Request(nullptr, ecb), _url(url), _jsonCallback(cb),
 	_workingRequest(nullptr), _ignoreCallback(false), _postData(nullptr), _postLen(0), _jsonData(nullptr) {
 
@@ -60,8 +60,8 @@ void PostRequest::start() {
 		_workingRequest->finish();
 	_ignoreCallback = false;
 
-	Networking::JsonCallback innerCallback = new Common::Callback<PostRequest, Networking::JsonResponse>(this, &PostRequest::responseCallback);
-	Networking::ErrorCallback errorResponseCallback = new Common::Callback<PostRequest, Networking::ErrorResponse>(this, &PostRequest::errorCallback);
+	Networking::JsonCallback innerCallback = new Common::Callback<PostRequest, const Networking::JsonResponse &>(this, &PostRequest::responseCallback);
+	Networking::ErrorCallback errorResponseCallback = new Common::Callback<PostRequest, const Networking::ErrorResponse &>(this, &PostRequest::errorCallback);
 	Networking::CurlJsonRequest *request = new Networking::CurlJsonRequest(innerCallback, errorResponseCallback, _url);
 
 	if (_postData && _jsonData) {
@@ -82,8 +82,8 @@ void PostRequest::start() {
 	_workingRequest = ConnMan.addRequest(request);
 }
 
-void PostRequest::responseCallback(Networking::JsonResponse response) {
-	Common::JSONValue *json = response.value;
+void PostRequest::responseCallback(const Networking::JsonResponse &response) {
+	const Common::JSONValue *json = response.value;
 	_workingRequest = nullptr;
 	if (_ignoreCallback) {
 		delete json;
@@ -92,7 +92,7 @@ void PostRequest::responseCallback(Networking::JsonResponse response) {
 	if (response.request) _date = response.request->date();
 
 	Networking::ErrorResponse error(this, "PostRequest::responseCallback: unknown error");
-	Networking::CurlJsonRequest *rq = (Networking::CurlJsonRequest *)response.request;
+	const Networking::CurlJsonRequest *rq = (const Networking::CurlJsonRequest *)response.request;
 	if (rq && rq->getNetworkReadStream())
 		error.httpResponseCode = rq->getNetworkReadStream()->httpResponseCode();
 
@@ -110,7 +110,7 @@ void PostRequest::responseCallback(Networking::JsonResponse response) {
 	delete json;
 }
 
-void PostRequest::errorCallback(Networking::ErrorResponse error) {
+void PostRequest::errorCallback(const Networking::ErrorResponse &error) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;

--- a/backends/networking/curl/postrequest.h
+++ b/backends/networking/curl/postrequest.h
@@ -27,7 +27,7 @@
 
 namespace Networking {
 
-class PostRequest: public Networking::Request {
+class PostRequest : public Networking::Request {
 	Common::String _url;
 	Networking::JSONValueCallback _jsonCallback;
 	Request *_workingRequest;
@@ -40,22 +40,22 @@ class PostRequest: public Networking::Request {
 
 	Common::String _contentType;
 
-	void responseCallback(Networking::JsonResponse response);
-	void errorCallback(Networking::ErrorResponse error);
+	void responseCallback(const Networking::JsonResponse &response);
+	void errorCallback(const Networking::ErrorResponse &error);
 
 public:
-	PostRequest(Common::String url, Networking::JSONValueCallback cb, Networking::ErrorCallback ecb);
-	virtual ~PostRequest();
+	PostRequest(const Common::String &url, Networking::JSONValueCallback cb, Networking::ErrorCallback ecb);
+	~PostRequest() override;
 
 	void start();
 
 	void setPostData(byte *postData, int postLen);
 	void setJSONData(Common::JSONValue *jsonData);
-	void setContentType(Common::String type) { _contentType = type; }
+	void setContentType(const Common::String &type) { _contentType = type; }
 
-	virtual void handle();
-	virtual void restart();
-	virtual Common::String date() const;
+	void handle() override;
+	void restart() override;
+	Common::String date() const override;
 };
 
 } // End of namespace Networking

--- a/backends/networking/curl/request.cpp
+++ b/backends/networking/curl/request.cpp
@@ -23,10 +23,10 @@
 
 namespace Networking {
 
-ErrorResponse::ErrorResponse(Request *rq, Common::String resp):
+ErrorResponse::ErrorResponse(Request *rq, const Common::String &resp):
 	request(rq), interrupted(false), failed(true), response(resp), httpResponseCode(-1) {}
 
-ErrorResponse::ErrorResponse(Request *rq, bool interrupt, bool failure, Common::String resp, long httpCode):
+ErrorResponse::ErrorResponse(Request *rq, bool interrupt, bool failure, const Common::String &resp, long httpCode):
 	request(rq), interrupted(interrupt), failed(failure), response(resp), httpResponseCode(httpCode) {}
 
 Request::Request(DataCallback cb, ErrorCallback ecb):
@@ -62,7 +62,7 @@ RequestState Request::state() const { return _state; }
 
 Common::String Request::date() const { return ""; }
 
-void Request::finishError(ErrorResponse error, RequestState state) {
+void Request::finishError(const ErrorResponse &error, RequestState state) {
 	_state = state;
 	if (_errorCallback)
 		(*_errorCallback)(error);

--- a/backends/networking/curl/request.h
+++ b/backends/networking/curl/request.h
@@ -45,10 +45,10 @@ class Request;
  */
 
 template<typename T> struct Response {
-	Request *request;
+	const Request *request;
 	T value;
 
-	Response(Request *rq, T v) : request(rq), value(v) {}
+	Response(const Request *rq, T v) : request(rq), value(v) {}
 };
 
 /**
@@ -77,13 +77,13 @@ struct ErrorResponse {
 	Common::String response;
 	long httpResponseCode;
 
-	ErrorResponse(Request *rq, Common::String resp);
-	ErrorResponse(Request *rq, bool interrupt, bool failure, Common::String resp, long httpCode);
+	ErrorResponse(Request *rq, const Common::String &resp);
+	ErrorResponse(Request *rq, bool interrupt, bool failure, const Common::String &resp, long httpCode);
 };
 
 typedef Response<void *> DataResponse;
-typedef Common::BaseCallback<DataResponse> *DataCallback;
-typedef Common::BaseCallback<ErrorResponse> *ErrorCallback;
+typedef Common::BaseCallback<const DataResponse &> *DataCallback;
+typedef Common::BaseCallback<const ErrorResponse &> *ErrorCallback;
 
 /**
  * RequestState is used to indicate current Request state.
@@ -148,7 +148,7 @@ protected:
 	uint32 _retryInSeconds;
 
 	/** Sets FINISHED state and calls the _errorCallback with given error. */
-	virtual void finishError(ErrorResponse error, RequestState state = FINISHED);
+	virtual void finishError(const ErrorResponse &error, RequestState state = FINISHED);
 
 	/** Sets FINISHED state. Implementations might extend it if needed. */
 	virtual void finishSuccess();

--- a/backends/networking/curl/session.cpp
+++ b/backends/networking/curl/session.cpp
@@ -25,14 +25,14 @@
 
 namespace Networking {
 
-Session::Session(Common::String prefix):
+Session::Session(const Common::String &prefix):
 	_prefix(prefix), _request(nullptr) {}
 
 Session::~Session() {
 	close();
 }
 
-static Common::String constructUrl(Common::String prefix, Common::String url) {
+static Common::String constructUrl(const Common::String &prefix, const Common::String &url) {
 	// check url prefix
 	if (!prefix.empty()) {
 		if (url.contains("://")) {
@@ -46,17 +46,17 @@ static Common::String constructUrl(Common::String prefix, Common::String url) {
 			if (newUrl.lastChar() != '/' && (url.size() > 0 && url.firstChar() != '/'))
 				newUrl += "/";
 			newUrl += url;
-			url = newUrl;
+			return newUrl;
 		}
 	}
 
 	return url;
 }
 
-SessionRequest *Session::get(Common::String url, Common::String localFile, DataCallback cb, ErrorCallback ecb, bool binary) {
-	url = constructUrl(_prefix, url);
+SessionRequest *Session::get(const Common::String &url, const Common::String &localFile, DataCallback cb, ErrorCallback ecb, bool binary) {
+	Common::String builtUrl = constructUrl(_prefix, url);
 
-	if (url.empty())
+	if (builtUrl.empty())
 		return nullptr;
 
 	// check if request has finished (ready to be replaced)
@@ -68,10 +68,10 @@ SessionRequest *Session::get(Common::String url, Common::String localFile, DataC
 	}
 
 	if (!_request) {
-		_request = new SessionRequest(url, localFile, cb, ecb, binary); // automatically added to ConnMan
+		_request = new SessionRequest(builtUrl, localFile, cb, ecb, binary); // automatically added to ConnMan
 		_request->connectionKeepAlive();
 	} else {
-		_request->reuse(url, localFile, cb, ecb, binary);
+		_request->reuse(builtUrl, localFile, cb, ecb, binary);
 	}
 
 	return _request;

--- a/backends/networking/curl/session.h
+++ b/backends/networking/curl/session.h
@@ -32,10 +32,10 @@ protected:
 	SessionRequest *_request;
 
 public:
-	Session(Common::String prefix = "");
+	Session(const Common::String &prefix = Common::String());
 	~Session();
 
-	SessionRequest *get(Common::String url, Common::String localFile, DataCallback cb = nullptr, ErrorCallback ecb = nullptr, bool binary = false);
+	SessionRequest *get(const Common::String &url, const Common::String &localFile, DataCallback cb = nullptr, ErrorCallback ecb = nullptr, bool binary = false);
 	/**
 	 * @brief Gracefully close the session
 	 *

--- a/backends/networking/curl/sessionrequest.cpp
+++ b/backends/networking/curl/sessionrequest.cpp
@@ -31,7 +31,7 @@
 
 namespace Networking {
 
-SessionRequest::SessionRequest(Common::String url, Common::String localFile, DataCallback cb, ErrorCallback ecb, bool binary):
+SessionRequest::SessionRequest(const Common::String &url, const Common::String &localFile, DataCallback cb, ErrorCallback ecb, bool binary):
 	CurlRequest(cb, ecb, url), _contentsStream(DisposeAfterUse::YES),
 	_buffer(new byte[CURL_SESSION_REQUEST_BUFFER_SIZE]), _text(nullptr), _localFile(nullptr),
 	_started(false), _complete(false), _success(false), _binary(binary) {
@@ -48,7 +48,7 @@ SessionRequest::~SessionRequest() {
 	delete[] _buffer;
 }
 
-void SessionRequest::openLocalFile(Common::String localFile) {
+void SessionRequest::openLocalFile(const Common::String &localFile) {
 	if (localFile.empty())
 		return;
 
@@ -96,7 +96,7 @@ char *SessionRequest::getPreparedContents() {
 	return (char *)result;
 }
 
-void SessionRequest::finishError(ErrorResponse error, RequestState state) {
+void SessionRequest::finishError(const ErrorResponse &error, RequestState state) {
 	_complete = true;
 	_success = false;
 	CurlRequest::finishError(error, PAUSED);
@@ -137,7 +137,7 @@ void SessionRequest::startAndWait() {
 	wait();
 }
 
-void SessionRequest::reuse(Common::String url, Common::String localFile, DataCallback cb, ErrorCallback ecb, bool binary) {
+void SessionRequest::reuse(const Common::String &url, const Common::String &localFile, DataCallback cb, ErrorCallback ecb, bool binary) {
 	_url = url;
 
 	delete _callback;

--- a/backends/networking/curl/sessionrequest.h
+++ b/backends/networking/curl/sessionrequest.h
@@ -61,21 +61,21 @@ protected:
 	/** Prepares raw bytes from _contentsStream. */
 	char *getPreparedContents();
 
-	virtual void finishError(ErrorResponse error, RequestState state = PAUSED);
-	virtual void finishSuccess();
-	void openLocalFile(Common::String localFile);
+	void finishError(const ErrorResponse &error, RequestState state = PAUSED) override;
+	void finishSuccess() override;
+	void openLocalFile(const Common::String &localFile);
 
 public:
-	SessionRequest(Common::String url, Common::String localFile, DataCallback cb = nullptr, ErrorCallback ecb = nullptr, bool binary = false);
-	virtual ~SessionRequest();
+	SessionRequest(const Common::String &url, const Common::String &localFile, DataCallback cb = nullptr, ErrorCallback ecb = nullptr, bool binary = false);
+	~SessionRequest() override;
 
 	void start();
 	void startAndWait();
 
-	void reuse(Common::String url, Common::String localFile, DataCallback cb = nullptr, ErrorCallback ecb = nullptr, bool binary = false);
+	void reuse(const Common::String &url, const Common::String &localFile, DataCallback cb = nullptr, ErrorCallback ecb = nullptr, bool binary = false);
 
-	virtual void handle();
-	virtual void restart();
+	void handle() override;
+	void restart() override;
 
 	/** This request DOES NOT delete automatically after calling callbacks. It gets PAUSED, and in order to make it FINISHED (i.e. delete), this method MUST be called. */
 	void close();

--- a/backends/networking/curl/socket.cpp
+++ b/backends/networking/curl/socket.cpp
@@ -69,7 +69,7 @@ int CurlSocket::ready() {
 	return waitOnSocket(_socket, 1, 0);
 }
 
-bool CurlSocket::connect(Common::String url) {
+bool CurlSocket::connect(const Common::String &url) {
 	_easy = curl_easy_init();
 	if (_easy) {
 		curl_easy_setopt(_easy, CURLOPT_URL, url.c_str());

--- a/backends/networking/curl/socket.h
+++ b/backends/networking/curl/socket.h
@@ -42,7 +42,7 @@ public:
 	CurlSocket();
 	~CurlSocket();
 
-	bool connect(Common::String url);
+	bool connect(const Common::String &url);
 
 	int ready();
 

--- a/backends/networking/curl/url.cpp
+++ b/backends/networking/curl/url.cpp
@@ -48,7 +48,7 @@ int CurlURL::getPort(bool defaultPort) {
 	return -1;
 }
 
-bool CurlURL::parseURL(Common::String url) {
+bool CurlURL::parseURL(const Common::String &url) {
 	warning("libcurl: curl_url requires curl 7.62.0 or later");
 	return false;
 }
@@ -62,7 +62,7 @@ CurlURL::~CurlURL() {
 	}
 }
 
-bool CurlURL::parseURL(Common::String url) {
+bool CurlURL::parseURL(const Common::String &url) {
 	if (_url)
 		curl_url_cleanup(_url);
 

--- a/backends/networking/curl/url.h
+++ b/backends/networking/curl/url.h
@@ -38,7 +38,7 @@ public:
 	 * @retval true if successful.
 	 * @retval false on failure or if using an older version of libcurl.
 	 */
-	bool parseURL(Common::String url);
+	bool parseURL(const Common::String &url);
 
 	/**
 	 * Extracts the scheme of an URL parsed previously by parseURL.

--- a/backends/networking/enet/enet.cpp
+++ b/backends/networking/enet/enet.cpp
@@ -55,7 +55,7 @@ bool ENet::initialize() {
 	return true;
 }
 
-Host *ENet::createHost(Common::String address, int port, int numClients, int numChannels, int incBand, int outBand) {
+Host *ENet::createHost(const Common::String &address, int port, int numClients, int numChannels, int incBand, int outBand) {
 	ENetAddress enetAddress;
 	// NOTE: 0.0.0.0 returns ENET_HOST_ANY normally.
 	enet_address_set_host(&enetAddress, address.c_str());
@@ -70,7 +70,7 @@ Host *ENet::createHost(Common::String address, int port, int numClients, int num
 	return new Host(_host);
 }
 
-Host *ENet::connectToHost(Common::String hostAddress, int hostPort, Common::String address, int port, int timeout, int numChannels, int incBand, int outBand) {
+Host *ENet::connectToHost(const Common::String &hostAddress, int hostPort, const Common::String &address, int port, int timeout, int numChannels, int incBand, int outBand) {
 	ENetAddress enetHostAddress;
 	// NOTE: 0.0.0.0 returns ENET_HOST_ANY normally.
 	enet_address_set_host(&enetHostAddress, hostAddress.c_str());
@@ -106,11 +106,11 @@ Host *ENet::connectToHost(Common::String hostAddress, int hostPort, Common::Stri
 	return nullptr;
 }
 
-Host *ENet::connectToHost(Common::String address, int port, int timeout, int numChannels, int incBand, int outBand) {
+Host *ENet::connectToHost(const Common::String &address, int port, int timeout, int numChannels, int incBand, int outBand) {
 	return connectToHost("0.0.0.0", 0, address, port, timeout, numChannels, incBand, outBand);
 }
 
-Socket *ENet::createSocket(Common::String address, int port) {
+Socket *ENet::createSocket(const Common::String &address, int port) {
 	ENetAddress enetAddress;
 	if (address == "255.255.255.255") {
 		enetAddress.host = ENET_HOST_BROADCAST;

--- a/backends/networking/enet/enet.h
+++ b/backends/networking/enet/enet.h
@@ -54,7 +54,7 @@ public:
 	 * @retval nullptr on failure
 	 * @see Networking::Host
 	 */
-	Host *createHost(Common::String address, int port, int numClients, int numChannels = 1, int incBand = 0, int outBand = 0);
+	Host *createHost(const Common::String &address, int port, int numClients, int numChannels = 1, int incBand = 0, int outBand = 0);
 	/**
 	 * Creates a new ENet Host instance, and attempts to connect to the assigned address and port.
 	 * @param hostAddress the address this host will use to connect to this peer.  "0.0.0.0" may be to used to use the default host.
@@ -69,8 +69,8 @@ public:
 	 * @retval nullptr on failure
 	 * @see Networking::Host
 	 */
-	Host *connectToHost(Common::String hostAddress, int hostPort, Common::String address, int port, int timeout = 5000, int numChannels = 1, int incBand = 0, int outBand = 0);
-	Host *connectToHost(Common::String address, int port, int timeout = 5000, int numChannels = 1, int incBand = 0, int outBand = 0);
+	Host *connectToHost(const Common::String &hostAddress, int hostPort, const Common::String &address, int port, int timeout = 5000, int numChannels = 1, int incBand = 0, int outBand = 0);
+	Host *connectToHost(const Common::String &address, int port, int timeout = 5000, int numChannels = 1, int incBand = 0, int outBand = 0);
 	/**
 	 * Creates a Networking::Socket instance which is a representation of a raw UDP socket.
 	 * Useful for and sending and receiving data that is outside the ENet library protocol.
@@ -80,7 +80,7 @@ public:
 	 * @retval nullptr on failure
 	 * @see Networking::Socket
 	 */
-	Socket *createSocket(Common::String address, int port);
+	Socket *createSocket(const Common::String &address, int port);
 private:
 	/** 
 	 * Indicates if the ENet library has successfully initialized or not.

--- a/backends/networking/enet/host.cpp
+++ b/backends/networking/enet/host.cpp
@@ -67,7 +67,7 @@ uint8 Host::service(int timeout) {
 	return event.type;
 }
 
-bool Host::connectPeer(Common::String address, int port, int timeout, int numChannels) {
+bool Host::connectPeer(const Common::String &address, int port, int timeout, int numChannels) {
 	ENetAddress enetAddress;
 	if (address == "255.255.255.255") {
 		enetAddress.host = ENET_HOST_BROADCAST;
@@ -121,7 +121,7 @@ int Host::getPort() {
 	return _recentPort;
 }
 
-int Host::getPeerIndexFromHost(Common::String host, int port) {
+int Host::getPeerIndexFromHost(const Common::String &host, int port) {
 	for (int i = 0; i < (int)_host->peerCount; i++) {
 		char hostName[50];
 		if (enet_address_get_host_ip(&_host->peers[i].address, hostName, 50) == 0) {
@@ -165,7 +165,7 @@ bool Host::send(const char *data, int peerIndex, int channel, bool reliable) {
 	return true;
 }
 
-bool Host::sendRawData(Common::String address, int port, const char *data) {
+bool Host::sendRawData(const Common::String &address, int port, const char *data) {
 	ENetAddress enetAddress;
 	if (address == "255.255.255.255") {
 		enetAddress.host = ENET_HOST_BROADCAST;

--- a/backends/networking/enet/host.h
+++ b/backends/networking/enet/host.h
@@ -77,7 +77,7 @@ public:
 	 * @retval true on successful.
 	 * @retval false on failure.
 	 */
-	bool connectPeer(Common::String address, int port, int timeout = 5000, int numChannels = 1);
+	bool connectPeer(const Common::String &address, int port, int timeout = 5000, int numChannels = 1);
 	/**
 	 * Disconnects a specific peer from the host.
 	 * @param peerIndex Index of a peer to disconnect.
@@ -106,7 +106,7 @@ public:
 	 * @note This sends data as a raw connection-less UDP socket, the same functionaility as a Networking::Socket object, but retains the address and port this host object is using.
 	 * @note Useful for hole-punching a peer, so it can connect to it.
 	 */
-	bool sendRawData(Common::String address, int port, const char *data);
+	bool sendRawData(const Common::String &address, int port, const char *data);
 
 	/**
 	 * Gets the host name of a peer that have recently connected, disconnected or received packet from.
@@ -128,7 +128,7 @@ public:
 	 * @retval >= 0 containing a peer index if successfully found.
 	 * @retval -1 if not found.
 	 */
-	int getPeerIndexFromHost(Common::String host, int port);
+	int getPeerIndexFromHost(const Common::String &host, int port);
 
 	/**
 	 * Gets the data from the most-recently received packet.

--- a/backends/networking/enet/socket.cpp
+++ b/backends/networking/enet/socket.cpp
@@ -37,7 +37,7 @@ Socket::~Socket() {
 	enet_socket_destroy(_socket);
 }
 
-bool Socket::send(Common::String address, int port, const char *data) {
+bool Socket::send(const Common::String &address, int port, const char *data) {
 	ENetAddress enetAddress;
 	if (address == "255.255.255.255") {
 		enetAddress.host = ENET_HOST_BROADCAST;

--- a/backends/networking/enet/socket.h
+++ b/backends/networking/enet/socket.h
@@ -54,7 +54,7 @@ public:
 	 * @retval true on successful.
 	 * @retval false on failure.
 	 */
-	bool send(Common::String address, int port, const char *data);
+	bool send(const Common::String &address, int port, const char *data);
 	/**
 	 * Checks for received data.
 	 * @retval true if received data.

--- a/backends/networking/sdl_net/client.cpp
+++ b/backends/networking/sdl_net/client.cpp
@@ -183,7 +183,7 @@ Common::String Client::path() const { return _reader.path(); }
 
 Common::String Client::query() const { return _reader.query(); }
 
-Common::String Client::queryParameter(Common::String name) const { return _reader.queryParameter(name); }
+Common::String Client::queryParameter(const Common::String &name) const { return _reader.queryParameter(name); }
 
 Common::String Client::anchor() const { return _reader.anchor(); }
 

--- a/backends/networking/sdl_net/client.h
+++ b/backends/networking/sdl_net/client.h
@@ -103,7 +103,7 @@ public:
 	Common::String method() const;
 	Common::String path() const;
 	Common::String query() const;
-	Common::String queryParameter(Common::String name) const;
+	Common::String queryParameter(const Common::String &name) const;
 	Common::String anchor() const;
 
 	bool noMoreContent() const;

--- a/backends/networking/sdl_net/getclienthandler.cpp
+++ b/backends/networking/sdl_net/getclienthandler.cpp
@@ -155,7 +155,7 @@ void GetClientHandler::handle(Client *client) {
 		client->close();
 }
 
-void GetClientHandler::setHeader(Common::String name, Common::String value) { _specialHeaders[name] = value; }
+void GetClientHandler::setHeader(const Common::String &name, const Common::String &value) { _specialHeaders[name] = value; }
 void GetClientHandler::setResponseCode(long code) { _responseCode = code; }
 
 } // End of namespace Networking

--- a/backends/networking/sdl_net/getclienthandler.h
+++ b/backends/networking/sdl_net/getclienthandler.h
@@ -44,10 +44,10 @@ class GetClientHandler: public ClientHandler {
 
 public:
 	GetClientHandler(Common::SeekableReadStream *stream);
-	virtual ~GetClientHandler();
+	~GetClientHandler() override;
 
-	virtual void handle(Client *client);
-	void setHeader(Common::String name, Common::String value);
+	void handle(Client *client) override;
+	void setHeader(const Common::String &name, const Common::String &value);
 	void setResponseCode(long code);
 };
 

--- a/backends/networking/sdl_net/handlers/connectcloudhandler.cpp
+++ b/backends/networking/sdl_net/handlers/connectcloudhandler.cpp
@@ -53,7 +53,7 @@ ConnectCloudClientHandler::ConnectCloudClientHandler(const ConnectCloudHandler *
 
 ConnectCloudClientHandler::~ConnectCloudClientHandler() {}
 
-void ConnectCloudClientHandler::respond(Client &client, Common::String response, long responseCode) const {
+void ConnectCloudClientHandler::respond(Client &client, const Common::String &response, long responseCode) const {
 	Common::SeekableReadStream *responseStream = HandlerUtils::makeResponseStreamFromString(response);
 	GetClientHandler *responseHandler = new GetClientHandler(responseStream);
 	responseHandler->setResponseCode(responseCode);
@@ -64,7 +64,7 @@ void ConnectCloudClientHandler::respond(Client &client, Common::String response,
 	client.setHandler(responseHandler);
 }
 
-void ConnectCloudClientHandler::respondWithJson(Client &client, bool error, Common::String message, long responseCode) const {
+void ConnectCloudClientHandler::respondWithJson(Client &client, bool error, const Common::String &message, long responseCode) const {
 	Common::JSONObject response;
 	response.setVal("error", new Common::JSONValue(error));
 	response.setVal("message", new Common::JSONValue(message));
@@ -73,11 +73,11 @@ void ConnectCloudClientHandler::respondWithJson(Client &client, bool error, Comm
 	respond(client, json.stringify(true), responseCode);
 }
 
-void ConnectCloudClientHandler::handleError(Client &client, Common::String message, long responseCode) const {
+void ConnectCloudClientHandler::handleError(Client &client, const Common::String &message, long responseCode) const {
 	respondWithJson(client, true, message, responseCode);
 }
 
-void ConnectCloudClientHandler::handleSuccess(Client &client, Common::String message) const {
+void ConnectCloudClientHandler::handleSuccess(Client &client, const Common::String &message) const {
 	respondWithJson(client, false, message);
 }
 
@@ -116,7 +116,7 @@ void ConnectCloudClientHandler::handle(Client *client) {
 		return;
 	}
 
-	Networking::ErrorCallback callback = new Common::Callback<ConnectCloudClientHandler, Networking::ErrorResponse>(this, &ConnectCloudClientHandler::storageConnectionCallback);
+	Networking::ErrorCallback callback = new Common::Callback<ConnectCloudClientHandler, const Networking::ErrorResponse &>(this, &ConnectCloudClientHandler::storageConnectionCallback);
 	Networking::JsonResponse jsonResponse(nullptr, json);
 	if (!CloudMan.connectStorage(jsonResponse, callback)) { // JSON doesn't have "storage" in it or it was invalid
 		delete json;
@@ -125,7 +125,7 @@ void ConnectCloudClientHandler::handle(Client *client) {
 	}
 }
 
-void ConnectCloudClientHandler::storageConnectionCallback(Networking::ErrorResponse response) {
+void ConnectCloudClientHandler::storageConnectionCallback(const Networking::ErrorResponse &response) {
 	if (response.failed || response.interrupted) {
 		Common::String message = "Failed to connect storage.";
 		if (response.failed) {

--- a/backends/networking/sdl_net/handlers/connectcloudhandler.h
+++ b/backends/networking/sdl_net/handlers/connectcloudhandler.h
@@ -30,17 +30,17 @@
 namespace Networking {
 
 class ConnectCloudHandler: public BaseHandler {
-	void handleError(Client &client, Common::String message) const;
-	void setJsonResponseHandler(Client &client, Common::String type, Common::String message) const;
+	void handleError(Client &client, const Common::String &message) const;
+	void setJsonResponseHandler(Client &client, const Common::String &type, const Common::String &message) const;
 
 	Networking::ErrorCallback _storageConnectionCallback;
 
 public:
 	ConnectCloudHandler();
-	virtual ~ConnectCloudHandler();
+	~ConnectCloudHandler() override;
 
-	virtual void handle(Client &client);
-	virtual bool minimalModeSupported() { return true; }
+	void handle(Client &client) override;
+	bool minimalModeSupported() override { return true; }
 
 	void setStorageConnectionCallback(Networking::ErrorCallback cb) { _storageConnectionCallback = cb; }
 	void storageConnected(const Networking::ErrorResponse& response) const;
@@ -52,17 +52,17 @@ class ConnectCloudClientHandler : public ClientHandler {
 	Client *_client;
 	static const int32 SUSPICIOUS_CONTENT_SIZE = 640 * 1024; // 640K ought to be enough for anybody
 
-	void respond(Client &client, Common::String response, long responseCode = 200) const;
-	void respondWithJson(Client &client, bool error, Common::String message, long responseCode = 200) const;
-	void handleError(Client &client, Common::String message, long responseCode) const;
-	void handleSuccess(Client &client, Common::String message) const;
-	void storageConnectionCallback(Networking::ErrorResponse response);
+	void respond(Client &client, const Common::String &response, long responseCode = 200) const;
+	void respondWithJson(Client &client, bool error, const Common::String &message, long responseCode = 200) const;
+	void handleError(Client &client, const Common::String &message, long responseCode) const;
+	void handleSuccess(Client &client, const Common::String &message) const;
+	void storageConnectionCallback(const Networking::ErrorResponse &response);
 
 public:
 	ConnectCloudClientHandler(const ConnectCloudHandler* cloudHandler);
-	virtual ~ConnectCloudClientHandler();
+	~ConnectCloudClientHandler() override;
 
-	virtual void handle(Client *client);
+	void handle(Client *client) override;
 };
 
 } // End of namespace Networking

--- a/backends/networking/sdl_net/handlers/createdirectoryhandler.cpp
+++ b/backends/networking/sdl_net/handlers/createdirectoryhandler.cpp
@@ -32,14 +32,14 @@ CreateDirectoryHandler::CreateDirectoryHandler() {}
 
 CreateDirectoryHandler::~CreateDirectoryHandler() {}
 
-void CreateDirectoryHandler::handleError(Client &client, Common::String message) const {
+void CreateDirectoryHandler::handleError(Client &client, const Common::String &message) const {
 	if (client.queryParameter("answer_json") == "true")
 		setJsonResponseHandler(client, "error", message);
 	else
 		HandlerUtils::setFilesManagerErrorMessageHandler(client, message);
 }
 
-void CreateDirectoryHandler::setJsonResponseHandler(Client &client, Common::String type, Common::String message) const {
+void CreateDirectoryHandler::setJsonResponseHandler(Client &client, const Common::String &type, const Common::String &message) const {
 	Common::JSONObject response;
 	response.setVal("type", new Common::JSONValue(type));
 	response.setVal("message", new Common::JSONValue(message));

--- a/backends/networking/sdl_net/handlers/createdirectoryhandler.h
+++ b/backends/networking/sdl_net/handlers/createdirectoryhandler.h
@@ -27,13 +27,13 @@
 namespace Networking {
 
 class CreateDirectoryHandler: public FilesBaseHandler {
-	void handleError(Client &client, Common::String message) const;
-	void setJsonResponseHandler(Client &client, Common::String type, Common::String message) const;
+	void handleError(Client &client, const Common::String &message) const;
+	void setJsonResponseHandler(Client &client, const Common::String &type, const Common::String &message) const;
 public:
 	CreateDirectoryHandler();
-	virtual ~CreateDirectoryHandler();
+	~CreateDirectoryHandler() override;
 
-	virtual void handle(Client &client);
+	void handle(Client &client) override;
 };
 
 } // End of namespace Networking

--- a/backends/networking/sdl_net/handlers/downloadfilehandler.h
+++ b/backends/networking/sdl_net/handlers/downloadfilehandler.h
@@ -29,9 +29,9 @@ namespace Networking {
 class DownloadFileHandler: public FilesBaseHandler {
 public:
 	DownloadFileHandler();
-	virtual ~DownloadFileHandler();
+	~DownloadFileHandler() override;
 
-	virtual void handle(Client &client);
+	void handle(Client &client) override;
 };
 
 } // End of namespace Networking

--- a/backends/networking/sdl_net/handlers/filesajaxpagehandler.cpp
+++ b/backends/networking/sdl_net/handlers/filesajaxpagehandler.cpp
@@ -34,7 +34,7 @@ FilesAjaxPageHandler::~FilesAjaxPageHandler() {}
 
 namespace {
 
-Common::String encodeDoubleQuotesAndSlashes(Common::String s) {
+Common::String encodeDoubleQuotesAndSlashes(const Common::String &s) {
 	Common::String result = "";
 	for (uint32 i = 0; i < s.size(); ++i)
 		if (s[i] == '"') {

--- a/backends/networking/sdl_net/handlers/filesajaxpagehandler.h
+++ b/backends/networking/sdl_net/handlers/filesajaxpagehandler.h
@@ -29,9 +29,9 @@ namespace Networking {
 class FilesAjaxPageHandler: public FilesBaseHandler {
 public:
 	FilesAjaxPageHandler();
-	virtual ~FilesAjaxPageHandler();
+	~FilesAjaxPageHandler() override;
 
-	virtual void handle(Client &client);
+	void handle(Client &client) override;
 };
 
 } // End of namespace Networking

--- a/backends/networking/sdl_net/handlers/filesbasehandler.cpp
+++ b/backends/networking/sdl_net/handlers/filesbasehandler.cpp
@@ -30,18 +30,19 @@ FilesBaseHandler::FilesBaseHandler() {}
 
 FilesBaseHandler::~FilesBaseHandler() {}
 
-Common::String FilesBaseHandler::parentPath(Common::String path) {
-	if (path.size() && (path.lastChar() == '/' || path.lastChar() == '\\')) path.deleteLastChar();
-	if (!path.empty()) {
-		for (int i = path.size() - 1; i >= 0; --i)
-			if (i == 0 || path[i] == '/' || path[i] == '\\') {
-				path.erase(i);
+Common::String FilesBaseHandler::parentPath(const Common::String &path) {
+	Common::String result = path;
+	if (result.size() && (result.lastChar() == '/' || result.lastChar() == '\\')) result.deleteLastChar();
+	if (!result.empty()) {
+		for (int i = result.size() - 1; i >= 0; --i)
+			if (i == 0 || result[i] == '/' || result[i] == '\\') {
+				result.erase(i);
 				break;
 			}
 	}
-	if (path.size() && path.lastChar() != '/' && path.lastChar() != '\\')
-		path += '/';
-	return path;
+	if (result.size() && result.lastChar() != '/' && result.lastChar() != '\\')
+		result += '/';
+	return result;
 }
 
 bool FilesBaseHandler::transformPath(Common::String &path, Common::String &prefixToRemove, Common::String &prefixToAdd, bool isDirectory) {

--- a/backends/networking/sdl_net/handlers/filesbasehandler.h
+++ b/backends/networking/sdl_net/handlers/filesbasehandler.h
@@ -28,7 +28,7 @@ namespace Networking {
 
 class FilesBaseHandler: public BaseHandler {
 protected:
-	Common::String parentPath(Common::String path);
+	Common::String parentPath(const Common::String &path);
 
 	/**
 	* Transforms virtual <path> into actual file system path.
@@ -41,9 +41,7 @@ protected:
 	bool transformPath(Common::String &path, Common::String &prefixToRemove, Common::String &prefixToAdd, bool isDirectory = true);
 public:
 	FilesBaseHandler();
-	virtual ~FilesBaseHandler();
-
-	virtual void handle(Client &client) = 0;
+	~FilesBaseHandler() override;
 };
 
 } // End of namespace Networking

--- a/backends/networking/sdl_net/handlers/filespagehandler.cpp
+++ b/backends/networking/sdl_net/handlers/filespagehandler.cpp
@@ -35,7 +35,7 @@ FilesPageHandler::FilesPageHandler() {}
 FilesPageHandler::~FilesPageHandler() {}
 
 namespace {
-Common::String encodeDoubleQuotes(Common::String s) {
+Common::String encodeDoubleQuotes(const Common::String &s) {
 	Common::String result = "";
 	for (uint32 i = 0; i < s.size(); ++i)
 		if (s[i] == '"') {
@@ -46,7 +46,7 @@ Common::String encodeDoubleQuotes(Common::String s) {
 	return result;
 }
 
-Common::String encodeHtmlEntities(Common::String s) {
+Common::String encodeHtmlEntities(const Common::String &s) {
 	Common::String result = "";
 	for (uint32 i = 0; i < s.size(); ++i)
 		if (s[i] == '<')
@@ -61,7 +61,7 @@ Common::String encodeHtmlEntities(Common::String s) {
 	return result;
 }
 
-Common::String getDisplayPath(Common::String s) {
+Common::String getDisplayPath(const Common::String &s) {
 	Common::String result = "";
 	for (uint32 i = 0; i < s.size(); ++i)
 		if (s[i] == '\\')
@@ -74,17 +74,18 @@ Common::String getDisplayPath(Common::String s) {
 }
 }
 
-bool FilesPageHandler::listDirectory(Common::String path, Common::String &content, const Common::String &itemTemplate) {
-	if (path == "" || path == "/") {
+bool FilesPageHandler::listDirectory(const Common::String &path_, Common::String &content, const Common::String &itemTemplate) {
+	if (path_ == "" || path_ == "/") {
 		if (ConfMan.hasKey("rootpath", "cloud"))
 			addItem(content, itemTemplate, IT_DIRECTORY, "/root/", Common::convertFromU32String(_("File system root")));
 		addItem(content, itemTemplate, IT_DIRECTORY, "/saves/", Common::convertFromU32String(_("Saved games")));
 		return true;
 	}
 
-	if (HandlerUtils::hasForbiddenCombinations(path))
+	if (HandlerUtils::hasForbiddenCombinations(path_))
 		return false;
 
+	Common::String path = path_;
 	Common::String prefixToRemove = "", prefixToAdd = "";
 	if (!transformPath(path, prefixToRemove, prefixToAdd))
 		return false;
@@ -147,7 +148,7 @@ FilesPageHandler::ItemType FilesPageHandler::detectType(bool isDirectory, const 
 	return IT_UNKNOWN;
 }
 
-void FilesPageHandler::addItem(Common::String &content, const Common::String &itemTemplate, ItemType itemType, Common::String path, Common::String name, Common::String size) const {
+void FilesPageHandler::addItem(Common::String &content, const Common::String &itemTemplate, ItemType itemType, const Common::String &path, const Common::String &name, const Common::String &size) const {
 	Common::String item = itemTemplate, icon;
 	bool isDirectory = (itemType == IT_DIRECTORY || itemType == IT_PARENT_DIRECTORY);
 	switch (itemType) {

--- a/backends/networking/sdl_net/handlers/filespagehandler.h
+++ b/backends/networking/sdl_net/handlers/filespagehandler.h
@@ -41,19 +41,19 @@ class FilesPageHandler: public FilesBaseHandler {
 	 *
 	 * Returns true on success.
 	 */
-	bool listDirectory(Common::String path, Common::String &content, const Common::String &itemTemplate);
+	bool listDirectory(const Common::String &path, Common::String &content, const Common::String &itemTemplate);
 
 	/** Helper method for detecting items' type. */
 	static ItemType detectType(bool isDirectory, const Common::String &name);
 
 	/** Helper method for adding items into the files list. */
-	void addItem(Common::String &content, const Common::String &itemTemplate, ItemType itemType, Common::String path, Common::String name, Common::String size = "") const;
+	void addItem(Common::String &content, const Common::String &itemTemplate, ItemType itemType, const Common::String &path, const Common::String &name, const Common::String &size = Common::String()) const;
 
 public:
 	FilesPageHandler();
-	virtual ~FilesPageHandler();
+	~FilesPageHandler() override;
 
-	virtual void handle(Client &client);
+	void handle(Client &client) override;
 };
 
 } // End of namespace Networking

--- a/backends/networking/sdl_net/handlers/indexpagehandler.h
+++ b/backends/networking/sdl_net/handlers/indexpagehandler.h
@@ -31,10 +31,10 @@ class LocalWebserver;
 class IndexPageHandler: public BaseHandler, public GUI::CommandSender {
 public:
 	IndexPageHandler();
-	virtual ~IndexPageHandler();
+	~IndexPageHandler() override;
 
-	virtual void handle(Client &client);
-	virtual bool minimalModeSupported();
+	void handle(Client &client) override;
+	bool minimalModeSupported() override;
 };
 
 } // End of namespace Networking

--- a/backends/networking/sdl_net/handlers/listajaxhandler.cpp
+++ b/backends/networking/sdl_net/handlers/listajaxhandler.cpp
@@ -32,14 +32,14 @@ ListAjaxHandler::ListAjaxHandler() {}
 
 ListAjaxHandler::~ListAjaxHandler() {}
 
-Common::JSONObject ListAjaxHandler::listDirectory(Common::String path) {
+Common::JSONObject ListAjaxHandler::listDirectory(const Common::String &path_) {
 	Common::JSONArray itemsList;
 	Common::JSONObject errorResult;
 	Common::JSONObject successResult;
 	successResult.setVal("type", new Common::JSONValue("success"));
 	errorResult.setVal("type", new Common::JSONValue("error"));
 
-	if (path == "" || path == "/") {
+	if (path_ == "" || path_ == "/") {
 		if (ConfMan.hasKey("rootpath", "cloud"))
 			addItem(itemsList, IT_DIRECTORY, "/root/", Common::convertFromU32String(_("File system root")));
 		addItem(itemsList, IT_DIRECTORY, "/saves/", Common::convertFromU32String(_("Saved games")));
@@ -47,10 +47,11 @@ Common::JSONObject ListAjaxHandler::listDirectory(Common::String path) {
 		return successResult;
 	}
 
-	if (HandlerUtils::hasForbiddenCombinations(path))
+	if (HandlerUtils::hasForbiddenCombinations(path_))
 		return errorResult;
 
 	Common::String prefixToRemove = "", prefixToAdd = "";
+	Common::String path = path_;
 	if (!transformPath(path, prefixToRemove, prefixToAdd))
 		return errorResult;
 
@@ -112,7 +113,7 @@ ListAjaxHandler::ItemType ListAjaxHandler::detectType(bool isDirectory, const Co
 	return IT_UNKNOWN;
 }
 
-void ListAjaxHandler::addItem(Common::JSONArray &responseItemsList, ItemType itemType, Common::String path, Common::String name, Common::String size) {
+void ListAjaxHandler::addItem(Common::JSONArray &responseItemsList, ItemType itemType, const Common::String &path, const Common::String &name, const Common::String &size) {
 	Common::String icon;
 	bool isDirectory = (itemType == IT_DIRECTORY || itemType == IT_PARENT_DIRECTORY);
 	switch (itemType) {

--- a/backends/networking/sdl_net/handlers/listajaxhandler.h
+++ b/backends/networking/sdl_net/handlers/listajaxhandler.h
@@ -42,19 +42,19 @@ class ListAjaxHandler: public FilesBaseHandler {
 	 *
 	 * Returns JSON with either listed directory or error response.
 	 */
-	Common::JSONObject listDirectory(Common::String path);
+	Common::JSONObject listDirectory(const Common::String &path);
 
 	/** Helper method for detecting items' type. */
 	static ItemType detectType(bool isDirectory, const Common::String &name);
 
 	/** Helper method for adding items into the files list. */
-	static void addItem(Common::JSONArray &responseItemsList, ItemType itemType, Common::String path, Common::String name, Common::String size = "");
+	static void addItem(Common::JSONArray &responseItemsList, ItemType itemType, const Common::String &path, const Common::String &name, const Common::String &size = "");
 
 public:
 	ListAjaxHandler();
-	virtual ~ListAjaxHandler();
+	~ListAjaxHandler() override;
 
-	virtual void handle(Client &client);
+	void handle(Client &client) override;
 };
 
 } // End of namespace Networking

--- a/backends/networking/sdl_net/handlers/resourcehandler.cpp
+++ b/backends/networking/sdl_net/handlers/resourcehandler.cpp
@@ -29,7 +29,7 @@ ResourceHandler::ResourceHandler() {}
 
 ResourceHandler::~ResourceHandler() {}
 
-const char *ResourceHandler::determineMimeType(Common::String &filename) {
+const char *ResourceHandler::determineMimeType(const Common::String &filename) {
 	// text
 	if (filename.hasSuffix(".html")) return "text/html";
 	if (filename.hasSuffix(".css")) return "text/css";

--- a/backends/networking/sdl_net/handlers/resourcehandler.h
+++ b/backends/networking/sdl_net/handlers/resourcehandler.h
@@ -27,13 +27,13 @@
 namespace Networking {
 
 class ResourceHandler: public BaseHandler {
-	static const char *determineMimeType(Common::String &filename);
+	static const char *determineMimeType(const Common::String &filename);
 public:
 	ResourceHandler();
-	virtual ~ResourceHandler();
+	~ResourceHandler() override;
 
-	virtual void handle(Client &client);
-	virtual bool minimalModeSupported();
+	void handle(Client &client) override;
+	bool minimalModeSupported() override;
 };
 
 } // End of namespace Networking

--- a/backends/networking/sdl_net/handlers/uploadfilehandler.h
+++ b/backends/networking/sdl_net/handlers/uploadfilehandler.h
@@ -29,9 +29,9 @@ namespace Networking {
 class UploadFileHandler: public FilesBaseHandler {
 public:
 	UploadFileHandler();
-	virtual ~UploadFileHandler();
+	~UploadFileHandler() override;
 
-	virtual void handle(Client &client);
+	void handle(Client &client) override;
 };
 
 } // End of namespace Networking

--- a/backends/networking/sdl_net/handlerutils.cpp
+++ b/backends/networking/sdl_net/handlerutils.cpp
@@ -74,7 +74,7 @@ Common::ArchiveMemberList HandlerUtils::listArchive() {
 	return resultList;
 }
 
-Common::SeekableReadStream *HandlerUtils::getArchiveFile(Common::String name) {
+Common::SeekableReadStream *HandlerUtils::getArchiveFile(const Common::String &name) {
 	Common::SeekableReadStream *result = nullptr;
 	Common::Archive *zipArchive = getZipArchive();
 	if (zipArchive) {
@@ -98,7 +98,7 @@ Common::String HandlerUtils::readEverythingFromStream(Common::SeekableReadStream
 	return result;
 }
 
-Common::SeekableReadStream *HandlerUtils::makeResponseStreamFromString(Common::String response) {
+Common::SeekableReadStream *HandlerUtils::makeResponseStreamFromString(const Common::String &response) {
 	byte *data = new byte[response.size()];
 	memcpy(data, response.c_str(), response.size());
 	return new Common::MemoryReadStream(data, response.size(), DisposeAfterUse::YES);
@@ -174,11 +174,11 @@ bool HandlerUtils::hasPermittedPrefix(const Common::String &path) {
 	       || normalizePath(prefix).compareTo(normalized + "/") == 0;
 }
 
-bool HandlerUtils::permittedPath(const Common::String path) {
+bool HandlerUtils::permittedPath(const Common::String &path) {
 	return hasPermittedPrefix(path) && !isBlacklisted(path);
 }
 
-void HandlerUtils::setMessageHandler(Client &client, Common::String message, Common::String redirectTo) {
+void HandlerUtils::setMessageHandler(Client &client, const Common::String &message, const Common::String &redirectTo) {
 	Common::String response = "<html><head><title>ScummVM</title><meta charset=\"utf-8\"/></head><body>{message}</body></html>";
 
 	// load stylish response page from the archive
@@ -193,7 +193,7 @@ void HandlerUtils::setMessageHandler(Client &client, Common::String message, Com
 		LocalWebserver::setClientRedirectHandler(client, response, redirectTo);
 }
 
-void HandlerUtils::setFilesManagerErrorMessageHandler(Client &client, Common::String message, Common::String redirectTo) {
+void HandlerUtils::setFilesManagerErrorMessageHandler(Client &client, const Common::String &message, const Common::String &redirectTo) {
 	setMessageHandler(
 		client,
 		Common::String::format(

--- a/backends/networking/sdl_net/handlerutils.h
+++ b/backends/networking/sdl_net/handlerutils.h
@@ -31,18 +31,18 @@ class HandlerUtils {
 public:
 	static Common::Archive *getZipArchive();
 	static Common::ArchiveMemberList listArchive();
-	static Common::SeekableReadStream *getArchiveFile(Common::String name);
+	static Common::SeekableReadStream *getArchiveFile(const Common::String &name);
 	static Common::String readEverythingFromStream(Common::SeekableReadStream *const stream);
-	static Common::SeekableReadStream *makeResponseStreamFromString(Common::String response);
+	static Common::SeekableReadStream *makeResponseStreamFromString(const Common::String &response);
 
 	static Common::String normalizePath(const Common::String &path);
 	static bool hasForbiddenCombinations(const Common::String &path);
 	static bool isBlacklisted(const Common::String &path);
 	static bool hasPermittedPrefix(const Common::String &path);
-	static bool permittedPath(const Common::String path);
+	static bool permittedPath(const Common::String &path);
 
-	static void setMessageHandler(Client &client, Common::String message, Common::String redirectTo = "");
-	static void setFilesManagerErrorMessageHandler(Client &client, Common::String message, Common::String redirectTo = "");
+	static void setMessageHandler(Client &client, const Common::String &message, const Common::String &redirectTo = "");
+	static void setFilesManagerErrorMessageHandler(Client &client, const Common::String &message, const Common::String &redirectTo = "");
 };
 
 } // End of namespace Networking

--- a/backends/networking/sdl_net/localwebserver.cpp
+++ b/backends/networking/sdl_net/localwebserver.cpp
@@ -176,7 +176,7 @@ void LocalWebserver::stop() {
 
 void LocalWebserver::stopOnIdle() { _stopOnIdle = true; }
 
-void LocalWebserver::addPathHandler(Common::String path, BaseHandler *handler) {
+void LocalWebserver::addPathHandler(const Common::String &path, BaseHandler *handler) {
 	if (_pathHandlers.contains(path))
 		warning("LocalWebserver::addPathHandler: path already had a handler");
 	_pathHandlers[path] = handler;
@@ -406,7 +406,7 @@ void LocalWebserver::resolveAddress(void *ipAddress) {
 #endif
 }
 
-void LocalWebserver::setClientGetHandler(Client &client, Common::String response, long code, const char *mimeType) {
+void LocalWebserver::setClientGetHandler(Client &client, const Common::String &response, long code, const char *mimeType) {
 	byte *data = new byte[response.size()];
 	memcpy(data, response.c_str(), response.size());
 	Common::MemoryReadStream *stream = new Common::MemoryReadStream(data, response.size(), DisposeAfterUse::YES);
@@ -421,14 +421,14 @@ void LocalWebserver::setClientGetHandler(Client &client, Common::SeekableReadStr
 	client.setHandler(handler);
 }
 
-void LocalWebserver::setClientRedirectHandler(Client &client, Common::String response, Common::String location, const char *mimeType) {
+void LocalWebserver::setClientRedirectHandler(Client &client, const Common::String &response, const Common::String &location, const char *mimeType) {
 	byte *data = new byte[response.size()];
 	memcpy(data, response.c_str(), response.size());
 	Common::MemoryReadStream *stream = new Common::MemoryReadStream(data, response.size(), DisposeAfterUse::YES);
 	setClientRedirectHandler(client, stream, location, mimeType);
 }
 
-void LocalWebserver::setClientRedirectHandler(Client &client, Common::SeekableReadStream *responseStream, Common::String location, const char *mimeType) {
+void LocalWebserver::setClientRedirectHandler(Client &client, Common::SeekableReadStream *responseStream, const Common::String &location, const char *mimeType) {
 	GetClientHandler *handler = new GetClientHandler(responseStream);
 	handler->setResponseCode(302); //redirect
 	handler->setHeader("Location", location);
@@ -446,7 +446,7 @@ int hexDigit(char c) {
 }
 }
 
-Common::String LocalWebserver::urlDecode(Common::String value) {
+Common::String LocalWebserver::urlDecode(const Common::String &value) {
 	Common::String result = "";
 	uint32 size = value.size();
 	for (uint32 i = 0; i < size; ++i) {
@@ -482,7 +482,7 @@ bool isQueryUnreserved(char c) {
 }
 }
 
-Common::String LocalWebserver::urlEncodeQueryParameterValue(Common::String value) {
+Common::String LocalWebserver::urlEncodeQueryParameterValue(const Common::String &value) {
 	//OK chars = alphanum | "-" | "_" | "." | "!" | "~" | "*" | "'" | "(" | ")"
 	//reserved for query are ";", "/", "?", ":", "@", "&", "=", "+", ","
 	//that means these must be encoded too or otherwise they could malform the query

--- a/backends/networking/sdl_net/localwebserver.h
+++ b/backends/networking/sdl_net/localwebserver.h
@@ -92,13 +92,13 @@ class LocalWebserver : public Common::Singleton<LocalWebserver> {
 	void handleClient(uint32 i);
 	void acceptClient();
 	void resolveAddress(void *ipAddress);
-	void addPathHandler(Common::String path, BaseHandler *handler);
+	void addPathHandler(const Common::String &path, BaseHandler *handler);
 
 public:
 	static const uint32 DEFAULT_SERVER_PORT = 12345;
 
 	LocalWebserver();
-	virtual ~LocalWebserver();
+	~LocalWebserver() override;
 
 	void start(bool useMinimalMode = false);
 	void stop();
@@ -115,12 +115,12 @@ public:
 #endif // USE_LIBCURL
 #endif // USE_CLOUD
 
-	static void setClientGetHandler(Client &client, Common::String response, long code = 200, const char *mimeType = nullptr);
+	static void setClientGetHandler(Client &client, const Common::String &response, long code = 200, const char *mimeType = nullptr);
 	static void setClientGetHandler(Client &client, Common::SeekableReadStream *responseStream, long code = 200, const char *mimeType = nullptr);
-	static void setClientRedirectHandler(Client &client, Common::String response, Common::String location, const char *mimeType = nullptr);
-	static void setClientRedirectHandler(Client &client, Common::SeekableReadStream *responseStream, Common::String location, const char *mimeType = nullptr);
-	static Common::String urlDecode(Common::String value);
-	static Common::String urlEncodeQueryParameterValue(Common::String value);
+	static void setClientRedirectHandler(Client &client, const Common::String &response, const Common::String &location, const char *mimeType = nullptr);
+	static void setClientRedirectHandler(Client &client, Common::SeekableReadStream *responseStream, const Common::String &location, const char *mimeType = nullptr);
+	static Common::String urlDecode(const Common::String &value);
+	static Common::String urlEncodeQueryParameterValue(const Common::String &value);
 };
 
 /** Shortcut for accessing the local webserver. */

--- a/backends/networking/sdl_net/reader.cpp
+++ b/backends/networking/sdl_net/reader.cpp
@@ -151,7 +151,7 @@ bool Reader::readBlockHeadersIntoStream(Common::WriteStream *stream) {
 }
 
 namespace {
-void readFromThatUntilLineEnd(const char *cstr, Common::String needle, Common::String &result) {
+void readFromThatUntilLineEnd(const char *cstr, const Common::String &needle, Common::String &result) {
 	const char *position = strstr(cstr, needle.c_str());
 
 	if (position) {
@@ -233,7 +233,7 @@ void Reader::parseFirstLine(const Common::String &headersToParse) {
 	if (bad) _isBadRequest = true;
 }
 
-void Reader::parsePathQueryAndAnchor(Common::String pathToParse) {
+void Reader::parsePathQueryAndAnchor(const Common::String &pathToParse) {
 	//<path>[?query][#anchor]
 	bool readingPath = true;
 	bool readingQuery = false;
@@ -524,7 +524,7 @@ Common::String Reader::path() const { return _path; }
 
 Common::String Reader::query() const { return _query; }
 
-Common::String Reader::queryParameter(Common::String name) const { return _queryParameters.getValOrDefault(name); }
+Common::String Reader::queryParameter(const Common::String &name) const { return _queryParameters.getValOrDefault(name); }
 
 Common::String Reader::anchor() const { return _anchor; }
 

--- a/backends/networking/sdl_net/reader.h
+++ b/backends/networking/sdl_net/reader.h
@@ -106,7 +106,7 @@ class Reader {
 
 	void handleFirstHeaders(Common::MemoryReadWriteStream *headers);
 	void parseFirstLine(const Common::String &headers);
-	void parsePathQueryAndAnchor(Common::String pathToParse);
+	void parsePathQueryAndAnchor(const Common::String &pathToParse);
 	void parseQueryParameters();
 
 	void makeWindow(uint32 size);
@@ -140,7 +140,7 @@ public:
 	Common::String method() const;
 	Common::String path() const;
 	Common::String query() const;
-	Common::String queryParameter(Common::String name) const;
+	Common::String queryParameter(const Common::String &name) const;
 	Common::String anchor() const;
 
 	static Common::String readEverythingFromMemoryStream(Common::MemoryReadWriteStream *stream);

--- a/backends/networking/sdl_net/uploadfileclienthandler.cpp
+++ b/backends/networking/sdl_net/uploadfileclienthandler.cpp
@@ -30,7 +30,7 @@
 
 namespace Networking {
 
-UploadFileClientHandler::UploadFileClientHandler(Common::String parentDirectoryPath):
+UploadFileClientHandler::UploadFileClientHandler(const Common::String &parentDirectoryPath):
 	_state(UFH_READING_CONTENT), _headersStream(nullptr), _contentStream(nullptr),
 	_parentDirectoryPath(parentDirectoryPath), _uploadedFiles(0) {}
 
@@ -88,7 +88,7 @@ void UploadFileClientHandler::handle(Client *client) {
 }
 
 namespace {
-void readFromThatUntilDoubleQuote(const char *cstr, Common::String needle, Common::String &result) {
+void readFromThatUntilDoubleQuote(const char *cstr, const Common::String &needle, Common::String &result) {
 	const char *position = strstr(cstr, needle.c_str());
 
 	if (position) {
@@ -187,7 +187,7 @@ void UploadFileClientHandler::handleBlockContent(Client *client) {
 	}
 }
 
-void UploadFileClientHandler::setErrorMessageHandler(Client &client, Common::String message) {
+void UploadFileClientHandler::setErrorMessageHandler(Client &client, const Common::String &message) {
 	HandlerUtils::setFilesManagerErrorMessageHandler(client, message);
 	_state = UFH_ERROR;
 }

--- a/backends/networking/sdl_net/uploadfileclienthandler.h
+++ b/backends/networking/sdl_net/uploadfileclienthandler.h
@@ -54,14 +54,14 @@ class UploadFileClientHandler: public ClientHandler {
 
 	void handleBlockHeaders(Client *client);
 	void handleBlockContent(Client *client);
-	void setErrorMessageHandler(Client &client, Common::String message);
+	void setErrorMessageHandler(Client &client, const Common::String &message);
 	void setSuccessHandler(Client &client);
 
 public:
-	UploadFileClientHandler(Common::String parentDirectoryPath);
-	virtual ~UploadFileClientHandler();
+	UploadFileClientHandler(const Common::String &parentDirectoryPath);
+	~UploadFileClientHandler() override;
 
-	virtual void handle(Client *client);
+	void handle(Client *client) override;
 };
 
 } // End of namespace Networking

--- a/engines/testbed/cloud.cpp
+++ b/engines/testbed/cloud.cpp
@@ -86,7 +86,7 @@ const char *CloudTests::getRemoteTestPath() {
 	return "testbed";
 }
 
-void CloudTests::infoCallback(Cloud::Storage::StorageInfoResponse response) {
+void CloudTests::infoCallback(const Cloud::Storage::StorageInfoResponse &response) {
 	ConfParams.setCloudTestCallbackCalled(true);
 	Testsuite::logPrintf("Info! User's ID: %s\n", response.value.uid().c_str());
 	Testsuite::logPrintf("Info! User's email: %s\n", response.value.email().c_str());
@@ -96,7 +96,7 @@ void CloudTests::infoCallback(Cloud::Storage::StorageInfoResponse response) {
 						 static_cast<unsigned long>(response.value.available()));
 }
 
-void CloudTests::directoryListedCallback(Cloud::Storage::FileArrayResponse response) {
+void CloudTests::directoryListedCallback(const Cloud::Storage::FileArrayResponse &response) {
 	ConfParams.setCloudTestCallbackCalled(true);
 	if (response.value.size() == 0) {
 		Testsuite::logPrintf("Warning! Directory is empty!\n");
@@ -123,7 +123,7 @@ void CloudTests::directoryListedCallback(Cloud::Storage::FileArrayResponse respo
 	}
 }
 
-void CloudTests::directoryCreatedCallback(Cloud::Storage::BoolResponse response) {
+void CloudTests::directoryCreatedCallback(const Cloud::Storage::BoolResponse &response) {
 	ConfParams.setCloudTestCallbackCalled(true);
 	if (response.value) {
 		Testsuite::logPrintf("Info! Directory created!\n");
@@ -132,13 +132,13 @@ void CloudTests::directoryCreatedCallback(Cloud::Storage::BoolResponse response)
 	}
 }
 
-void CloudTests::fileUploadedCallback(Cloud::Storage::UploadResponse response) {
+void CloudTests::fileUploadedCallback(const Cloud::Storage::UploadResponse &response) {
 	ConfParams.setCloudTestCallbackCalled(true);
 	Testsuite::logPrintf("Info! Uploaded file into '%s'\n", response.value.path().c_str());
 	Testsuite::logPrintf("Info! It's id = '%s' and size = '%u'\n", response.value.id().c_str(), response.value.size());
 }
 
-void CloudTests::fileDownloadedCallback(Cloud::Storage::BoolResponse response) {
+void CloudTests::fileDownloadedCallback(const Cloud::Storage::BoolResponse &response) {
 	ConfParams.setCloudTestCallbackCalled(true);
 	if (response.value) {
 		Testsuite::logPrintf("Info! File downloaded!\n");
@@ -147,7 +147,7 @@ void CloudTests::fileDownloadedCallback(Cloud::Storage::BoolResponse response) {
 	}
 }
 
-void CloudTests::directoryDownloadedCallback(Cloud::Storage::FileArrayResponse response) {
+void CloudTests::directoryDownloadedCallback(const Cloud::Storage::FileArrayResponse &response) {
 	ConfParams.setCloudTestCallbackCalled(true);
 	if (response.value.size() == 0) {
 		Testsuite::logPrintf("Info! Directory is downloaded successfully!\n");
@@ -156,7 +156,7 @@ void CloudTests::directoryDownloadedCallback(Cloud::Storage::FileArrayResponse r
 	}
 }
 
-void CloudTests::savesSyncedCallback(Cloud::Storage::BoolResponse response) {
+void CloudTests::savesSyncedCallback(const Cloud::Storage::BoolResponse &response) {
 	ConfParams.setCloudTestCallbackCalled(true);
 	if (response.value) {
 		Testsuite::logPrintf("Info! Saves are synced successfully!\n");
@@ -165,7 +165,7 @@ void CloudTests::savesSyncedCallback(Cloud::Storage::BoolResponse response) {
 	}
 }
 
-void CloudTests::errorCallback(Networking::ErrorResponse response) {
+void CloudTests::errorCallback(const Networking::ErrorResponse &response) {
 	ConfParams.setCloudTestErrorCallbackCalled(true);
 	Testsuite::logPrintf("Info! Error Callback was called\n");
 	Testsuite::logPrintf("Info! code = %ld, message = %s\n", response.httpResponseCode, response.response.c_str());
@@ -196,8 +196,8 @@ TestExitStatus CloudTests::testInfo() {
 	}
 
 	if (CloudMan.info(
-			new Common::GlobalFunctionCallback<Cloud::Storage::StorageInfoResponse>(&infoCallback),
-			new Common::GlobalFunctionCallback<Networking::ErrorResponse>(&errorCallback)
+			new Common::GlobalFunctionCallback<const Cloud::Storage::StorageInfoResponse &>(&infoCallback),
+			new Common::GlobalFunctionCallback<const Networking::ErrorResponse &>(&errorCallback)
 		) == nullptr) {
 		Testsuite::logPrintf("Warning! No Request is returned!\n");
 	}
@@ -233,8 +233,8 @@ TestExitStatus CloudTests::testDirectoryListing() {
 
 	if (CloudMan.listDirectory(
 			"",
-			new Common::GlobalFunctionCallback<Cloud::Storage::FileArrayResponse>(&directoryListedCallback),
-			new Common::GlobalFunctionCallback<Networking::ErrorResponse>(&errorCallback)
+			new Common::GlobalFunctionCallback<const Cloud::Storage::FileArrayResponse &>(&directoryListedCallback),
+			new Common::GlobalFunctionCallback<const Networking::ErrorResponse &>(&errorCallback)
 		) == nullptr) {
 		Testsuite::logPrintf("Warning! No Request is returned!\n");
 	}
@@ -275,8 +275,8 @@ TestExitStatus CloudTests::testDirectoryCreating() {
 	// list root directory
 	if (CloudMan.listDirectory(
 			"",
-			new Common::GlobalFunctionCallback<Cloud::Storage::FileArrayResponse>(&directoryListedCallback),
-			new Common::GlobalFunctionCallback<Networking::ErrorResponse>(&errorCallback)
+			new Common::GlobalFunctionCallback<const Cloud::Storage::FileArrayResponse &>(&directoryListedCallback),
+			new Common::GlobalFunctionCallback<const Networking::ErrorResponse &>(&errorCallback)
 		) == nullptr) {
 		Testsuite::logPrintf("Warning! No Request is returned!\n");
 	}
@@ -294,8 +294,8 @@ TestExitStatus CloudTests::testDirectoryCreating() {
 	// create 'testbed'
 	if (CloudMan.getCurrentStorage()->createDirectory(
 			getRemoteTestPath(),
-			new Common::GlobalFunctionCallback<Cloud::Storage::BoolResponse>(&directoryCreatedCallback),
-			new Common::GlobalFunctionCallback<Networking::ErrorResponse>(&errorCallback)
+			new Common::GlobalFunctionCallback<const Cloud::Storage::BoolResponse &>(&directoryCreatedCallback),
+			new Common::GlobalFunctionCallback<const Networking::ErrorResponse &>(&errorCallback)
 		) == nullptr) {
 		Testsuite::logPrintf("Warning! No Request is returned!\n");
 	}
@@ -313,8 +313,8 @@ TestExitStatus CloudTests::testDirectoryCreating() {
 	// list it again
 	if (CloudMan.listDirectory(
 			"",
-			new Common::GlobalFunctionCallback<Cloud::Storage::FileArrayResponse>(&directoryListedCallback),
-			new Common::GlobalFunctionCallback<Networking::ErrorResponse>(&errorCallback)
+			new Common::GlobalFunctionCallback<const Cloud::Storage::FileArrayResponse &>(&directoryListedCallback),
+			new Common::GlobalFunctionCallback<const Networking::ErrorResponse &>(&errorCallback)
 		) == nullptr) {
 		Testsuite::logPrintf("Warning! No Request is returned!\n");
 	}
@@ -368,8 +368,8 @@ TestExitStatus CloudTests::testUploading() {
 		if (CloudMan.getCurrentStorage()->upload(
 				Common::String(getRemoteTestPath()) + "/testfile.txt",
 				node.createReadStream(),
-				new Common::GlobalFunctionCallback<Cloud::Storage::UploadResponse>(&fileUploadedCallback),
-				new Common::GlobalFunctionCallback<Networking::ErrorResponse>(&errorCallback)
+				new Common::GlobalFunctionCallback<const Cloud::Storage::UploadResponse &>(&fileUploadedCallback),
+				new Common::GlobalFunctionCallback<const Networking::ErrorResponse &>(&errorCallback)
 			) == nullptr) {
 			Testsuite::logPrintf("Warning! No Request is returned!\n");
 		}
@@ -378,8 +378,8 @@ TestExitStatus CloudTests::testUploading() {
 		if (CloudMan.getCurrentStorage()->upload(
 				Common::String(getRemoteTestPath()) + "/testfile.txt",
 				filepath.c_str(),
-				new Common::GlobalFunctionCallback<Cloud::Storage::UploadResponse>(&fileUploadedCallback),
-				new Common::GlobalFunctionCallback<Networking::ErrorResponse>(&errorCallback)
+				new Common::GlobalFunctionCallback<const Cloud::Storage::UploadResponse &>(&fileUploadedCallback),
+				new Common::GlobalFunctionCallback<const Networking::ErrorResponse &>(&errorCallback)
 			) == nullptr) {
 			Testsuite::logPrintf("Warning! No Request is returned!\n");
 		}
@@ -400,8 +400,8 @@ TestExitStatus CloudTests::testUploading() {
 
 		if (CloudMan.listDirectory(
 				getRemoteTestPath(),
-				new Common::GlobalFunctionCallback<Cloud::Storage::FileArrayResponse>(&directoryListedCallback),
-				new Common::GlobalFunctionCallback<Networking::ErrorResponse>(&errorCallback)
+				new Common::GlobalFunctionCallback<const Cloud::Storage::FileArrayResponse &>(&directoryListedCallback),
+				new Common::GlobalFunctionCallback<const Networking::ErrorResponse &>(&errorCallback)
 			) == nullptr) {
 			Testsuite::logPrintf("Warning! No Request is returned!\n");
 		}
@@ -448,8 +448,8 @@ TestExitStatus CloudTests::testDownloading() {
 	if (CloudMan.getCurrentStorage()->download(
 			Common::String(getRemoteTestPath()) + "/testfile.txt",
 			filepath.c_str(),
-			new Common::GlobalFunctionCallback<Cloud::Storage::BoolResponse>(&fileDownloadedCallback),
-			new Common::GlobalFunctionCallback<Networking::ErrorResponse>(&errorCallback)
+			new Common::GlobalFunctionCallback<const Cloud::Storage::BoolResponse &>(&fileDownloadedCallback),
+			new Common::GlobalFunctionCallback<const Networking::ErrorResponse &>(&errorCallback)
 		) == nullptr) {
 		Testsuite::logPrintf("Warning! No Request is returned!\n");
 	}
@@ -495,8 +495,8 @@ TestExitStatus CloudTests::testFolderDownloading() {
 	if (CloudMan.downloadFolder(
 			getRemoteTestPath(),
 			filepath.c_str(),
-			new Common::GlobalFunctionCallback<Cloud::Storage::FileArrayResponse>(&directoryDownloadedCallback),
-			new Common::GlobalFunctionCallback<Networking::ErrorResponse>(&errorCallback)
+			new Common::GlobalFunctionCallback<const Cloud::Storage::FileArrayResponse &>(&directoryDownloadedCallback),
+			new Common::GlobalFunctionCallback<const Networking::ErrorResponse &>(&errorCallback)
 		) == nullptr) {
 		Testsuite::logPrintf("Warning! No Request is returned!\n");
 	}
@@ -540,8 +540,8 @@ TestExitStatus CloudTests::testSavesSync() {
 	Common::FSNode node = gameRoot.getFSNode().getChild("downloaded_directory");
 	Common::String filepath = node.getPath();
 	if (CloudMan.syncSaves(
-			new Common::GlobalFunctionCallback<Cloud::Storage::BoolResponse>(&savesSyncedCallback),
-			new Common::GlobalFunctionCallback<Networking::ErrorResponse>(&errorCallback)
+			new Common::GlobalFunctionCallback<const Cloud::Storage::BoolResponse &>(&savesSyncedCallback),
+			new Common::GlobalFunctionCallback<const Networking::ErrorResponse &>(&errorCallback)
 		) == nullptr) {
 		Testsuite::logPrintf("Warning! No Request is returned!\n");
 	}

--- a/engines/testbed/cloud.h
+++ b/engines/testbed/cloud.h
@@ -36,14 +36,14 @@ namespace CloudTests {
 bool waitForCallback();
 bool waitForCallbackMore();
 const char *getRemoteTestPath();
-void infoCallback(Cloud::Storage::StorageInfoResponse response);
-void directoryListedCallback(Cloud::Storage::FileArrayResponse response);
-void directoryCreatedCallback(Cloud::Storage::BoolResponse response);
-void fileUploadedCallback(Cloud::Storage::UploadResponse response);
-void fileDownloadedCallback(Cloud::Storage::BoolResponse response);
-void directoryDownloadedCallback(Cloud::Storage::FileArrayResponse response);
-void savesSyncedCallback(Cloud::Storage::BoolResponse response);
-void errorCallback(Networking::ErrorResponse response);
+void infoCallback(const Cloud::Storage::StorageInfoResponse &response);
+void directoryListedCallback(const Cloud::Storage::FileArrayResponse &response);
+void directoryCreatedCallback(const Cloud::Storage::BoolResponse &response);
+void fileUploadedCallback(const Cloud::Storage::UploadResponse &response);
+void fileDownloadedCallback(const Cloud::Storage::BoolResponse &response);
+void directoryDownloadedCallback(const Cloud::Storage::FileArrayResponse &response);
+void savesSyncedCallback(const Cloud::Storage::BoolResponse &response);
+void errorCallback(const Networking::ErrorResponse &response);
 
 TestExitStatus testInfo();
 TestExitStatus testDirectoryListing();

--- a/gui/cloudconnectionwizard.cpp
+++ b/gui/cloudconnectionwizard.cpp
@@ -79,7 +79,7 @@ CloudConnectionWizard::CloudConnectionWizard() :
 
 	showStep(Step::MODE_SELECT);
 
-	_callback = new Common::Callback<CloudConnectionWizard, Networking::ErrorResponse>(this, &CloudConnectionWizard::storageConnectionCallback);
+	_callback = new Common::Callback<CloudConnectionWizard, const Networking::ErrorResponse &>(this, &CloudConnectionWizard::storageConnectionCallback);
 }
 
 CloudConnectionWizard::~CloudConnectionWizard() {
@@ -470,7 +470,7 @@ void CloudConnectionWizard::removeWidgetChecked(EditTextWidget *&widget) {
 
 // logic
 
-void CloudConnectionWizard::storageConnectionCallback(Networking::ErrorResponse response) {
+void CloudConnectionWizard::storageConnectionCallback(const Networking::ErrorResponse &response) {
 	if (response.failed || response.interrupted) {
 		return;
 	}
@@ -525,7 +525,7 @@ void CloudConnectionWizard::manualModeConnect() {
 
 	// pass JSON to the manager
 	_connecting = true;
-	Networking::ErrorCallback callback = new Common::Callback<CloudConnectionWizard, Networking::ErrorResponse>(this, &CloudConnectionWizard::manualModeStorageConnectionCallback);
+	Networking::ErrorCallback callback = new Common::Callback<CloudConnectionWizard, const Networking::ErrorResponse &>(this, &CloudConnectionWizard::manualModeStorageConnectionCallback);
 	Networking::JsonResponse jsonResponse(nullptr, json);
 	if (!CloudMan.connectStorage(jsonResponse, callback)) { // no "storage" in JSON (or invalid one)
 		_connecting = false;
@@ -550,7 +550,7 @@ void CloudConnectionWizard::manualModeConnect() {
 		_nextStepButton->setEnabled(false);
 }
 
-void CloudConnectionWizard::manualModeStorageConnectionCallback(Networking::ErrorResponse response) {
+void CloudConnectionWizard::manualModeStorageConnectionCallback(const Networking::ErrorResponse &response) {
 	if (response.failed || response.interrupted) {
 		if (response.failed) {
 			const char *knownErrorMessages[] = {

--- a/gui/cloudconnectionwizard.h
+++ b/gui/cloudconnectionwizard.h
@@ -119,9 +119,9 @@ class CloudConnectionWizard : public Dialog {
 	void removeWidgetChecked(EditTextWidget *&widget);
 
 	// logic
-	void storageConnectionCallback(Networking::ErrorResponse response);
+	void storageConnectionCallback(const Networking::ErrorResponse &response);
 	void manualModeConnect();
-	void manualModeStorageConnectionCallback(Networking::ErrorResponse response);
+	void manualModeStorageConnectionCallback(const Networking::ErrorResponse &response);
 
 public:
 	CloudConnectionWizard();

--- a/gui/downloadpacksdialog.cpp
+++ b/gui/downloadpacksdialog.cpp
@@ -68,9 +68,9 @@ struct DialogState {
 	void downloadList();
 	void proceedDownload();
 
-	void downloadListCallback(Networking::DataResponse response);
-	void downloadFileCallback(Networking::DataResponse response);
-	void errorCallback(Networking::ErrorResponse error);
+	void downloadListCallback(const Networking::DataResponse &response);
+	void downloadFileCallback(const Networking::DataResponse &response);
+	void errorCallback(const Networking::ErrorResponse &error);
 
 private:
 	bool takeOneFile();
@@ -79,8 +79,8 @@ private:
 
 void DialogState::downloadList() {
 	Networking::SessionRequest *rq = session.get(Common::String::format("https://downloads.scummvm.org/frs/icons/%s", listfname), "",
-		new Common::Callback<DialogState, Networking::DataResponse>(this, &DialogState::downloadListCallback),
-		new Common::Callback<DialogState, Networking::ErrorResponse>(this, &DialogState::errorCallback),
+		new Common::Callback<DialogState, const Networking::DataResponse &>(this, &DialogState::downloadListCallback),
+		new Common::Callback<DialogState, const Networking::ErrorResponse &>(this, &DialogState::errorCallback),
 		true);
 
 	rq->start();
@@ -104,14 +104,14 @@ bool DialogState::takeOneFile() {
 	Common::String localFile = normalizePath(ConfMan.get("iconspath") + "/" + fname, '/');
 
 	Networking::SessionRequest *rq = session.get(url, localFile,
-		new Common::Callback<DialogState, Networking::DataResponse>(this, &DialogState::downloadFileCallback),
-		new Common::Callback<DialogState, Networking::ErrorResponse>(this, &DialogState::errorCallback));
+		new Common::Callback<DialogState, const Networking::DataResponse &>(this, &DialogState::downloadFileCallback),
+		new Common::Callback<DialogState, const Networking::ErrorResponse &>(this, &DialogState::errorCallback));
 
 	rq->start();
 	return true;
 }
 
-void DialogState::downloadListCallback(Networking::DataResponse r) {
+void DialogState::downloadListCallback(const Networking::DataResponse &r) {
 	Networking::SessionFileResponse *response = static_cast<Networking::SessionFileResponse *>(r.value);
 	Common::MemoryReadStream stream(response->buffer, response->len);
 
@@ -136,7 +136,7 @@ void DialogState::downloadListCallback(Networking::DataResponse r) {
 		dialog->sendCommand(kListDownloadFinishedCmd, 0);
 }
 
-void DialogState::downloadFileCallback(Networking::DataResponse r) {
+void DialogState::downloadFileCallback(const Networking::DataResponse &r) {
 	Networking::SessionFileResponse *response = static_cast<Networking::SessionFileResponse *>(r.value);
 
 	downloadedSize += response->len;
@@ -156,7 +156,7 @@ void DialogState::downloadFileCallback(Networking::DataResponse r) {
 	}
 }
 
-void DialogState::errorCallback(Networking::ErrorResponse error) {
+void DialogState::errorCallback(const Networking::ErrorResponse &error) {
 	Common::U32String message = Common::U32String::format(_("ERROR %d: %s"), error.httpResponseCode, error.response.c_str());
 
 	g_system->taskFinished(OSystem::kDataPackDownload);

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -3358,7 +3358,7 @@ void GlobalOptionsDialog::handleCommand(CommandSender *sender, uint32 cmd, uint3
 	// fall through
 	case kSyncSavesStorageCmd: {
 		CloudMan.syncSaves(
-			new Common::Callback<GlobalOptionsDialog, Cloud::Storage::BoolResponse>(this, &GlobalOptionsDialog::storageSavesSyncedCallback)
+			new Common::Callback<GlobalOptionsDialog, const Cloud::Storage::BoolResponse &>(this, &GlobalOptionsDialog::storageSavesSyncedCallback)
 		);
 		break;
 	}
@@ -3742,11 +3742,11 @@ void GlobalOptionsDialog::reflowNetworkTabLayout() {
 #endif // USE_SDL_NET
 
 #ifdef USE_LIBCURL
-void GlobalOptionsDialog::storageSavesSyncedCallback(Cloud::Storage::BoolResponse response) {
+void GlobalOptionsDialog::storageSavesSyncedCallback(const Cloud::Storage::BoolResponse &response) {
 	_redrawCloudTab = true;
 }
 
-void GlobalOptionsDialog::storageErrorCallback(Networking::ErrorResponse response) {
+void GlobalOptionsDialog::storageErrorCallback(const Networking::ErrorResponse &response) {
 	debug(9, "GlobalOptionsDialog: error response (%s, %ld):", (response.failed ? "failed" : "interrupted"), response.httpResponseCode);
 	debug(9, "%s", response.response.c_str());
 

--- a/gui/options.h
+++ b/gui/options.h
@@ -365,8 +365,8 @@ protected:
 	void setupCloudTab();
 	void shiftWidget(Widget *widget, const char *widgetName, int32 xOffset, int32 yOffset);
 
-	void storageSavesSyncedCallback(Cloud::Storage::BoolResponse response);
-	void storageErrorCallback(Networking::ErrorResponse response);
+	void storageSavesSyncedCallback(const Cloud::Storage::BoolResponse &response);
+	void storageErrorCallback(const Networking::ErrorResponse &response);
 #endif // USE_LIBCURL
 
 #ifdef USE_SDL_NET

--- a/gui/remotebrowser.cpp
+++ b/gui/remotebrowser.cpp
@@ -193,8 +193,8 @@ void RemoteBrowserDialog::listDirectory(const Cloud::StorageFile &node) {
 
 		_workingRequest = CloudMan.listDirectory(
 			node.path(),
-			new Common::Callback<RemoteBrowserDialog, Cloud::Storage::ListDirectoryResponse>(this, &RemoteBrowserDialog::directoryListedCallback),
-			new Common::Callback<RemoteBrowserDialog, Networking::ErrorResponse>(this, &RemoteBrowserDialog::directoryListedErrorCallback),
+			new Common::Callback<RemoteBrowserDialog, const Cloud::Storage::ListDirectoryResponse &>(this, &RemoteBrowserDialog::directoryListedCallback),
+			new Common::Callback<RemoteBrowserDialog, const Networking::ErrorResponse &>(this, &RemoteBrowserDialog::directoryListedErrorCallback),
 			false
 		);
 	}
@@ -204,7 +204,7 @@ void RemoteBrowserDialog::listDirectory(const Cloud::StorageFile &node) {
 	updateListing();
 }
 
-void RemoteBrowserDialog::directoryListedCallback(Cloud::Storage::ListDirectoryResponse response) {
+void RemoteBrowserDialog::directoryListedCallback(const Cloud::Storage::ListDirectoryResponse &response) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;
@@ -215,7 +215,7 @@ void RemoteBrowserDialog::directoryListedCallback(Cloud::Storage::ListDirectoryR
 	_updateList = true;
 }
 
-void RemoteBrowserDialog::directoryListedErrorCallback(Networking::ErrorResponse error) {
+void RemoteBrowserDialog::directoryListedErrorCallback(const Networking::ErrorResponse &error) {
 	_workingRequest = nullptr;
 	if (_ignoreCallback)
 		return;

--- a/gui/remotebrowser.h
+++ b/gui/remotebrowser.h
@@ -64,8 +64,8 @@ protected:
 	void updateListing();
 	void goUp();
 	void listDirectory(const Cloud::StorageFile &node);
-	void directoryListedCallback(Cloud::Storage::ListDirectoryResponse response);
-	void directoryListedErrorCallback(Networking::ErrorResponse error);
+	void directoryListedCallback(const Cloud::Storage::ListDirectoryResponse &response);
+	void directoryListedErrorCallback(const Networking::ErrorResponse &error);
 
 	struct FileListOrder : public Common::BinaryFunction<Cloud::StorageFile, Cloud::StorageFile, bool> {
 		bool operator()(const Cloud::StorageFile &x, const Cloud::StorageFile &y) const {


### PR DESCRIPTION
Use references everywhere it's possible and make things const.
Use override keyword to raise errors when there are discrepancies.

This has been tested with local server, Google Drive and OneDrive.

I expect this change to fix around 180 Coverity errors.