### PR TITLE
SCI32: Fix DrawList overflow with a dynamic array

### DIFF
--- a/engines/sci/graphics/frameout.cpp
+++ b/engines/sci/graphics/frameout.cpp
@@ -130,6 +130,7 @@ void GfxFrameout::clear() {
 	_planes.clear();
 	_visiblePlanes.clear();
 	_showList.clear();
+	_screenItemLists.clear();
 }
 
 bool GfxFrameout::detectHiRes() const {
@@ -481,23 +482,23 @@ void GfxFrameout::frameOut(const bool shouldShowBits, const Common::Rect &eraseR
 
 	// SSCI allocated these as static arrays of 100 pointers to
 	// ScreenItemList / RectList
-	ScreenItemListList screenItemLists;
-	EraseListList eraseLists;
-
-	screenItemLists.resize(_planes.size());
-	eraseLists.resize(_planes.size());
+	_screenItemLists.resize(_planes.size());
+	for (DrawList::size_type i = 0; i < _screenItemLists.size(); ++i) {
+		_screenItemLists[i].clear();
+	}
+	EraseListList eraseLists(_planes.size());
 
 	if (g_sci->_gfxRemap32->getRemapCount() > 0 && _remapOccurred) {
 		remapMarkRedraw();
 	}
 
-	calcLists(screenItemLists, eraseLists, eraseRect);
+	calcLists(_screenItemLists, eraseLists, eraseRect);
 
-	for (ScreenItemListList::iterator list = screenItemLists.begin(); list != screenItemLists.end(); ++list) {
+	for (ScreenItemListList::iterator list = _screenItemLists.begin(); list != _screenItemLists.end(); ++list) {
 		list->sort();
 	}
 
-	for (ScreenItemListList::iterator list = screenItemLists.begin(); list != screenItemLists.end(); ++list) {
+	for (ScreenItemListList::iterator list = _screenItemLists.begin(); list != _screenItemLists.end(); ++list) {
 		for (DrawList::iterator drawItem = list->begin(); drawItem != list->end(); ++drawItem) {
 			(*drawItem)->screenItem->getCelObj().submitPalette();
 		}
@@ -507,7 +508,7 @@ void GfxFrameout::frameOut(const bool shouldShowBits, const Common::Rect &eraseR
 
 	for (PlaneList::size_type i = 0; i < _planes.size(); ++i) {
 		drawEraseList(eraseLists[i], *_planes[i]);
-		drawScreenItemList(screenItemLists[i]);
+		drawScreenItemList(_screenItemLists[i]);
 	}
 
 	if (robotIsActive) {

--- a/engines/sci/graphics/frameout.h
+++ b/engines/sci/graphics/frameout.h
@@ -329,6 +329,12 @@ private:
 	RectList _showList;
 
 	/**
+	 * A list of DrawLists used by frameOut(). This is a field to avoid
+	 * constructing and destroying DrawLists on every frame.
+	 */
+	ScreenItemListList _screenItemLists;
+
+	/**
 	 * The amount of extra overdraw that is acceptable when merging two show
 	 * list rectangles together into a single larger rectangle.
 	 *

--- a/engines/sci/graphics/plane32.h
+++ b/engines/sci/graphics/plane32.h
@@ -78,7 +78,7 @@ struct DrawItem {
 	}
 };
 
-typedef StablePointerArray<DrawItem, 250> DrawListBase;
+typedef StablePointerDynamicArray<DrawItem, 250> DrawListBase;
 class DrawList : public DrawListBase {
 private:
 	inline static bool sortHelper(const DrawItem *a, const DrawItem *b) {


### PR DESCRIPTION
This PR replaces a fixed array with `Common::Array`. It fixes an overflow that can occur in LSL7 at the pool entrance when the menu has many items. This also occurred in the original. Sierra used a fixed array, and our SCI32 code is based closely off of the original, so we have the same limit.

The screenshot from a 2019 GOG forum post that led to this:

![lsl7-limit](https://github.com/scummvm/scummvm/assets/22204938/3c812082-978f-42a4-b191-3b2099c68339)

Easy, right? Just replace a fixed array with a dynamic one. But it's tricky, because the array is storage in a template base class with a specific behavior that affects a lot of graphics code with performance implications. I just want to fix the one usage that has an edge case. I think I've come up with a good compromise, and even reduced the heap allocations when rendering a frame.

`Sci::StablePointerArray` is a template base class used in three core types in the SCI32 graphics code. Its interface and behavior matches Sierra's, and a lot of complex performance-sensitive code depends on this. The size of its fixed array is a template parameter.

`StablePointerArray` is the template for three `Sci` graphics types: `DrawList`, `RectList`, and `EraseList`. `DrawList` is the one that can overflow its capacity of 250. I've created `StablePointerDynamicArray`, a separate class with the same interface that uses `Common::Array`, and switched `DrawList` to use that with the same initial capacity. I also promoted the list of `DrawList`s to a field so that they're not all being constructed and destroyed on each frame.

This solution does not spark joy. It feels like a copy-paste-tweak (because it is!) but it's not much code and it seems like the least-worst solution. Other approaches:

- **Increase the 250 capacity.** Simple, but it's unclear what the new capacity should be. I was able to overflow 300. And who knows where else this overflows? Or even in what game? If we're going to fix this, we should fix it for good. I don't want to think about this again. =) 

- **Change `StablePointerArray` to use a dynamic array.** The problems with this are in the other places it is used. Many large allocations would move from the stack to the heap when rendering every frame (at 60fps), and subclasses have other fixed arrays of matching size that would also need to be rewritten to be dynamic and somehow in sync. Once you wade through all the typedefs and templates, you'll see that `StablePointerArray` is strategically used as a stack-based temporary list many times during frame rendering. It gets constructed and destroyed a lot. There would be a performance hit and I suspect it would be noticeable on at least some of the resource-constrained platforms. (The existing render code is already noticeably slower in debug builds on my machine.) The current stack-based usage is deliberate, and it seems wrong to undo that just to handle a rare edge case in an unrelated array.

- **Significantly alter the calling code.** The SCI32 graphics code is large and complex but it works. csnover got it right. It's closely modeled off of the original structure. It's not worth upending that to handle this rare edge case, and it would be high risk.

Now `DrawList` can handle any size and the performance-sensitive `StablePointerArray`s are unaffected. While evaluating the list of `DrawList`s that get constructed and destroyed on each frame, I couldn't see a reason to not just reuse them across frames, so I did that. This satisfies my remaining paranoia about performance regressions. There are now less allocations than before, because most frames no longer construct or destroy any `DrawList`s. Other than that, the calling code is unaffected.

![stable](https://github.com/scummvm/scummvm/assets/22204938/82db20e3-829d-49ae-8a14-6b36fc09eaf3)
