### PR TITLE
GUI lowres fixes and tweaks

### DIFF
--- a/gui/browser.cpp
+++ b/gui/browser.cpp
@@ -74,7 +74,7 @@ BrowserDialog::BrowserDialog(const Common::U32String &title, bool dirBrowser)
 	_showHiddenWidget = new CheckboxWidget(this, "Browser.Hidden", _("Show hidden files"), _("Show files marked with the hidden attribute"), kHiddenCmd);
 
 	// Buttons
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		new ButtonWidget(this, "Browser.Up", _("Go up"), _("Go to previous directory level"), kGoUpCmd);
 	else
 		new ButtonWidget(this, "Browser.Up", _c("Go up", "lowres"), _("Go to previous directory level"), kGoUpCmd);

--- a/gui/browser.cpp
+++ b/gui/browser.cpp
@@ -74,7 +74,7 @@ BrowserDialog::BrowserDialog(const Common::U32String &title, bool dirBrowser)
 	_showHiddenWidget = new CheckboxWidget(this, "Browser.Hidden", _("Show hidden files"), _("Show files marked with the hidden attribute"), kHiddenCmd);
 
 	// Buttons
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		new ButtonWidget(this, "Browser.Up", _("Go up"), _("Go to previous directory level"), kGoUpCmd);
 	else
 		new ButtonWidget(this, "Browser.Up", _c("Go up", "lowres"), _("Go to previous directory level"), kGoUpCmd);

--- a/gui/downloaddialog.cpp
+++ b/gui/downloaddialog.cpp
@@ -59,7 +59,7 @@ DownloadDialog::DownloadDialog(uint32 storageId, LauncherDialog *launcher) :
 	_percentLabel = new StaticTextWidget(this, "GlobalOptions_Cloud_DownloadDialog.PercentText", Common::String::format("%u %%", progress));
 	_downloadSizeLabel = new StaticTextWidget(this, "GlobalOptions_Cloud_DownloadDialog.DownloadSize", Common::U32String());
 	_downloadSpeedLabel = new StaticTextWidget(this, "GlobalOptions_Cloud_DownloadDialog.DownloadSpeed", Common::U32String());
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		_cancelButton = new ButtonWidget(this, "GlobalOptions_Cloud_DownloadDialog.MainButton", _("Cancel download"), Common::U32String(), kDownloadDialogButtonCmd);
 	else
 		_cancelButton = new ButtonWidget(this, "GlobalOptions_Cloud_DownloadDialog.MainButton", _c("Cancel download", "lowres"), Common::U32String(), kDownloadDialogButtonCmd);

--- a/gui/downloaddialog.cpp
+++ b/gui/downloaddialog.cpp
@@ -59,7 +59,7 @@ DownloadDialog::DownloadDialog(uint32 storageId, LauncherDialog *launcher) :
 	_percentLabel = new StaticTextWidget(this, "GlobalOptions_Cloud_DownloadDialog.PercentText", Common::String::format("%u %%", progress));
 	_downloadSizeLabel = new StaticTextWidget(this, "GlobalOptions_Cloud_DownloadDialog.DownloadSize", Common::U32String());
 	_downloadSpeedLabel = new StaticTextWidget(this, "GlobalOptions_Cloud_DownloadDialog.DownloadSpeed", Common::U32String());
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		_cancelButton = new ButtonWidget(this, "GlobalOptions_Cloud_DownloadDialog.MainButton", _("Cancel download"), Common::U32String(), kDownloadDialogButtonCmd);
 	else
 		_cancelButton = new ButtonWidget(this, "GlobalOptions_Cloud_DownloadDialog.MainButton", _c("Cancel download", "lowres"), Common::U32String(), kDownloadDialogButtonCmd);

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -131,14 +131,14 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	tab->addTab(_("Game"), "GameOptions_Game");
 
 	// GUI:  Label & edit widget for the game ID
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		new StaticTextWidget(tab, "GameOptions_Game.Id", _("ID:"), _("Short game identifier used for referring to saved games and running the game from the command line"));
 	else
 		new StaticTextWidget(tab, "GameOptions_Game.Id", _c("ID:", "lowres"), _("Short game identifier used for referring to saved games and running the game from the command line"));
 	_domainWidget = new DomainEditTextWidget(tab, "GameOptions_Game.Domain", _domain, _("Short game identifier used for referring to saved games and running the game from the command line"));
 
 	// GUI:  Label & edit widget for the description
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		new StaticTextWidget(tab, "GameOptions_Game.Name", _("Name:"), _("Full title of the game"));
 	else
 		new StaticTextWidget(tab, "GameOptions_Game.Name", _c("Name:", "lowres"), _("Full title of the game"));
@@ -160,7 +160,7 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	}
 
 	// Platform popup
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		_platformPopUpDesc = new StaticTextWidget(tab, "GameOptions_Game.PlatformPopupDesc", _("Platform:"), _("Platform the game was originally designed for"));
 	else
 		_platformPopUpDesc = new StaticTextWidget(tab, "GameOptions_Game.PlatformPopupDesc", _c("Platform:", "lowres"), _("Platform the game was originally designed for"));
@@ -188,12 +188,12 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	//
 	// 3) The graphics tab
 	//
-	_graphicsTabId = tab->addTab(g_gui.getGUIWidth() > 320 ? _("Graphics") : _("GFX"), "GameOptions_Graphics", false);
+	_graphicsTabId = tab->addTab(g_gui.useLowResGUI() ? _("GFX") : _("Graphics"), "GameOptions_Graphics", false);
 	ScrollContainerWidget *graphicsContainer = new ScrollContainerWidget(tab, "GameOptions_Graphics.Container", "GameOptions_Graphics_Container", kGraphicsTabContainerReflowCmd);
 	graphicsContainer->setBackgroundType(ThemeEngine::kWidgetBackgroundNo);
 	graphicsContainer->setTarget(this);
 
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		_globalGraphicsOverride = new CheckboxWidget(graphicsContainer, "GameOptions_Graphics_Container.EnableTabCheckbox", _("Override global graphic settings"), Common::U32String(), kCmdGlobalGraphicsOverride);
 	else
 		_globalGraphicsOverride = new CheckboxWidget(graphicsContainer, "GameOptions_Graphics_Container.EnableTabCheckbox", _c("Override global graphic settings", "lowres"), Common::U32String(), kCmdGlobalGraphicsOverride);
@@ -218,7 +218,7 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	//
 	int backendTabId = tab->addTab(_("Backend"), "GameOptions_Backend", false);
 
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		_globalBackendOverride = new CheckboxWidget(tab, "GameOptions_Backend.EnableTabCheckbox", _("Override global backend settings"), Common::U32String(), kCmdGlobalBackendOverride);
 	else
 		_globalBackendOverride = new CheckboxWidget(tab, "GameOptions_Backend.EnableTabCheckbox", _c("Override global backend settings", "lowres"), Common::U32String(), kCmdGlobalBackendOverride);
@@ -237,7 +237,7 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	//
 	tab->addTab(_("Audio"), "GameOptions_Audio");
 
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		_globalAudioOverride = new CheckboxWidget(tab, "GameOptions_Audio.EnableTabCheckbox", _("Override global audio settings"), Common::U32String(), kCmdGlobalAudioOverride);
 	else
 		_globalAudioOverride = new CheckboxWidget(tab, "GameOptions_Audio.EnableTabCheckbox", _c("Override global audio settings", "lowres"), Common::U32String(), kCmdGlobalAudioOverride);
@@ -248,12 +248,12 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	//
 	// 5) The volume tab
 	//
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		tab->addTab(_("Volume"), "GameOptions_Volume");
 	else
 		tab->addTab(_c("Volume", "lowres"), "GameOptions_Volume");
 
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		_globalVolumeOverride = new CheckboxWidget(tab, "GameOptions_Volume.EnableTabCheckbox", _("Override global volume settings"), Common::U32String(), kCmdGlobalVolumeOverride);
 	else
 		_globalVolumeOverride = new CheckboxWidget(tab, "GameOptions_Volume.EnableTabCheckbox", _c("Override global volume settings", "lowres"), Common::U32String(), kCmdGlobalVolumeOverride);
@@ -269,7 +269,7 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	if (showMidi) {
 		tab->addTab(_("MIDI"), "GameOptions_MIDI");
 
-		if (g_gui.getGUIWidth() > 320)
+		if (!g_gui.useLowResGUI())
 			_globalMIDIOverride = new CheckboxWidget(tab, "GameOptions_MIDI.EnableTabCheckbox", _("Override global MIDI settings"), Common::U32String(), kCmdGlobalMIDIOverride);
 		else
 			_globalMIDIOverride = new CheckboxWidget(tab, "GameOptions_MIDI.EnableTabCheckbox", _c("Override global MIDI settings", "lowres"), Common::U32String(), kCmdGlobalMIDIOverride);
@@ -284,7 +284,7 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	if (showMidi) {
 		tab->addTab(_("MT-32"), "GameOptions_MT32");
 
-		if (g_gui.getGUIWidth() > 320)
+		if (!g_gui.useLowResGUI())
 			_globalMT32Override = new CheckboxWidget(tab, "GameOptions_MT32.EnableTabCheckbox", _("Override global MT-32 settings"), Common::U32String(), kCmdGlobalMT32Override);
 		else
 			_globalMT32Override = new CheckboxWidget(tab, "GameOptions_MT32.EnableTabCheckbox", _c("Override global MT-32 settings", "lowres"), Common::U32String(), kCmdGlobalMT32Override);
@@ -295,7 +295,7 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	//
 	// 8) The Paths tab
 	//
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		tab->addTab(_("Paths"), "GameOptions_Paths");
 	else
 		tab->addTab(_c("Paths", "lowres"), "GameOptions_Paths");
@@ -304,14 +304,14 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	// in the small version of the GUI.
 
 	// GUI:  Button + Label for the game path
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		new ButtonWidget(tab, "GameOptions_Paths.Gamepath", _("Game Path:"), Common::U32String(), kCmdGameBrowser);
 	else
 		new ButtonWidget(tab, "GameOptions_Paths.Gamepath", _c("Game Path:", "lowres"), Common::U32String(), kCmdGameBrowser);
 	_gamePathWidget = new StaticTextWidget(tab, "GameOptions_Paths.GamepathText", gamePath);
 
 	// GUI:  Button + Label for the additional path
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		new ButtonWidget(tab, "GameOptions_Paths.Extrapath", _("Extra Path:"), _("Specifies path to additional data used by the game"), kCmdExtraBrowser);
 	else
 		new ButtonWidget(tab, "GameOptions_Paths.Extrapath", _c("Extra Path:", "lowres"), _("Specifies path to additional data used by the game"), kCmdExtraBrowser);
@@ -320,7 +320,7 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	_extraPathClearButton = addClearButton(tab, "GameOptions_Paths.ExtraPathClearButton", kCmdExtraPathClear);
 
 	// GUI:  Button + Label for the save path
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		new ButtonWidget(tab, "GameOptions_Paths.Savepath", _("Save Path:"), _("Specifies where your saved games are put"), kCmdSaveBrowser);
 	else
 		new ButtonWidget(tab, "GameOptions_Paths.Savepath", _c("Save Path:", "lowres"), _("Specifies where your saved games are put"), kCmdSaveBrowser);

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -131,14 +131,14 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	tab->addTab(_("Game"), "GameOptions_Game");
 
 	// GUI:  Label & edit widget for the game ID
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		new StaticTextWidget(tab, "GameOptions_Game.Id", _("ID:"), _("Short game identifier used for referring to saved games and running the game from the command line"));
 	else
 		new StaticTextWidget(tab, "GameOptions_Game.Id", _c("ID:", "lowres"), _("Short game identifier used for referring to saved games and running the game from the command line"));
 	_domainWidget = new DomainEditTextWidget(tab, "GameOptions_Game.Domain", _domain, _("Short game identifier used for referring to saved games and running the game from the command line"));
 
 	// GUI:  Label & edit widget for the description
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		new StaticTextWidget(tab, "GameOptions_Game.Name", _("Name:"), _("Full title of the game"));
 	else
 		new StaticTextWidget(tab, "GameOptions_Game.Name", _c("Name:", "lowres"), _("Full title of the game"));
@@ -160,7 +160,7 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	}
 
 	// Platform popup
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		_platformPopUpDesc = new StaticTextWidget(tab, "GameOptions_Game.PlatformPopupDesc", _("Platform:"), _("Platform the game was originally designed for"));
 	else
 		_platformPopUpDesc = new StaticTextWidget(tab, "GameOptions_Game.PlatformPopupDesc", _c("Platform:", "lowres"), _("Platform the game was originally designed for"));
@@ -188,12 +188,12 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	//
 	// 3) The graphics tab
 	//
-	_graphicsTabId = tab->addTab(g_system->getOverlayWidth() > 320 ? _("Graphics") : _("GFX"), "GameOptions_Graphics", false);
+	_graphicsTabId = tab->addTab(g_gui.getGUIWidth() > 320 ? _("Graphics") : _("GFX"), "GameOptions_Graphics", false);
 	ScrollContainerWidget *graphicsContainer = new ScrollContainerWidget(tab, "GameOptions_Graphics.Container", "GameOptions_Graphics_Container", kGraphicsTabContainerReflowCmd);
 	graphicsContainer->setBackgroundType(ThemeEngine::kWidgetBackgroundNo);
 	graphicsContainer->setTarget(this);
 
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		_globalGraphicsOverride = new CheckboxWidget(graphicsContainer, "GameOptions_Graphics_Container.EnableTabCheckbox", _("Override global graphic settings"), Common::U32String(), kCmdGlobalGraphicsOverride);
 	else
 		_globalGraphicsOverride = new CheckboxWidget(graphicsContainer, "GameOptions_Graphics_Container.EnableTabCheckbox", _c("Override global graphic settings", "lowres"), Common::U32String(), kCmdGlobalGraphicsOverride);
@@ -218,7 +218,7 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	//
 	int backendTabId = tab->addTab(_("Backend"), "GameOptions_Backend", false);
 
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		_globalBackendOverride = new CheckboxWidget(tab, "GameOptions_Backend.EnableTabCheckbox", _("Override global backend settings"), Common::U32String(), kCmdGlobalBackendOverride);
 	else
 		_globalBackendOverride = new CheckboxWidget(tab, "GameOptions_Backend.EnableTabCheckbox", _c("Override global backend settings", "lowres"), Common::U32String(), kCmdGlobalBackendOverride);
@@ -237,7 +237,7 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	//
 	tab->addTab(_("Audio"), "GameOptions_Audio");
 
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		_globalAudioOverride = new CheckboxWidget(tab, "GameOptions_Audio.EnableTabCheckbox", _("Override global audio settings"), Common::U32String(), kCmdGlobalAudioOverride);
 	else
 		_globalAudioOverride = new CheckboxWidget(tab, "GameOptions_Audio.EnableTabCheckbox", _c("Override global audio settings", "lowres"), Common::U32String(), kCmdGlobalAudioOverride);
@@ -248,12 +248,12 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	//
 	// 5) The volume tab
 	//
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		tab->addTab(_("Volume"), "GameOptions_Volume");
 	else
 		tab->addTab(_c("Volume", "lowres"), "GameOptions_Volume");
 
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		_globalVolumeOverride = new CheckboxWidget(tab, "GameOptions_Volume.EnableTabCheckbox", _("Override global volume settings"), Common::U32String(), kCmdGlobalVolumeOverride);
 	else
 		_globalVolumeOverride = new CheckboxWidget(tab, "GameOptions_Volume.EnableTabCheckbox", _c("Override global volume settings", "lowres"), Common::U32String(), kCmdGlobalVolumeOverride);
@@ -269,7 +269,7 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	if (showMidi) {
 		tab->addTab(_("MIDI"), "GameOptions_MIDI");
 
-		if (g_system->getOverlayWidth() > 320)
+		if (g_gui.getGUIWidth() > 320)
 			_globalMIDIOverride = new CheckboxWidget(tab, "GameOptions_MIDI.EnableTabCheckbox", _("Override global MIDI settings"), Common::U32String(), kCmdGlobalMIDIOverride);
 		else
 			_globalMIDIOverride = new CheckboxWidget(tab, "GameOptions_MIDI.EnableTabCheckbox", _c("Override global MIDI settings", "lowres"), Common::U32String(), kCmdGlobalMIDIOverride);
@@ -284,7 +284,7 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	if (showMidi) {
 		tab->addTab(_("MT-32"), "GameOptions_MT32");
 
-		if (g_system->getOverlayWidth() > 320)
+		if (g_gui.getGUIWidth() > 320)
 			_globalMT32Override = new CheckboxWidget(tab, "GameOptions_MT32.EnableTabCheckbox", _("Override global MT-32 settings"), Common::U32String(), kCmdGlobalMT32Override);
 		else
 			_globalMT32Override = new CheckboxWidget(tab, "GameOptions_MT32.EnableTabCheckbox", _c("Override global MT-32 settings", "lowres"), Common::U32String(), kCmdGlobalMT32Override);
@@ -295,7 +295,7 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	//
 	// 8) The Paths tab
 	//
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		tab->addTab(_("Paths"), "GameOptions_Paths");
 	else
 		tab->addTab(_c("Paths", "lowres"), "GameOptions_Paths");
@@ -304,14 +304,14 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	// in the small version of the GUI.
 
 	// GUI:  Button + Label for the game path
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		new ButtonWidget(tab, "GameOptions_Paths.Gamepath", _("Game Path:"), Common::U32String(), kCmdGameBrowser);
 	else
 		new ButtonWidget(tab, "GameOptions_Paths.Gamepath", _c("Game Path:", "lowres"), Common::U32String(), kCmdGameBrowser);
 	_gamePathWidget = new StaticTextWidget(tab, "GameOptions_Paths.GamepathText", gamePath);
 
 	// GUI:  Button + Label for the additional path
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		new ButtonWidget(tab, "GameOptions_Paths.Extrapath", _("Extra Path:"), _("Specifies path to additional data used by the game"), kCmdExtraBrowser);
 	else
 		new ButtonWidget(tab, "GameOptions_Paths.Extrapath", _c("Extra Path:", "lowres"), _("Specifies path to additional data used by the game"), kCmdExtraBrowser);
@@ -320,7 +320,7 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 	_extraPathClearButton = addClearButton(tab, "GameOptions_Paths.ExtraPathClearButton", kCmdExtraPathClear);
 
 	// GUI:  Button + Label for the save path
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		new ButtonWidget(tab, "GameOptions_Paths.Savepath", _("Save Path:"), _("Specifies where your saved games are put"), kCmdSaveBrowser);
 	else
 		new ButtonWidget(tab, "GameOptions_Paths.Savepath", _c("Save Path:", "lowres"), _("Specifies where your saved games are put"), kCmdSaveBrowser);

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -107,6 +107,8 @@ public:
 	float getScaleFactor() const { return _scaleFactor; }
 	void computeScaleFactor();
 
+	bool useLowResGUI() const { return _baseWidth <= 320; }
+
 	bool useRTL() const { return _useRTL; }
 	void setLanguageRTL();
 

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -107,7 +107,7 @@ public:
 	float getScaleFactor() const { return _scaleFactor; }
 	void computeScaleFactor();
 
-	bool useLowResGUI() const { return _baseWidth <= 320; }
+	bool useLowResGUI() const { return _baseWidth <= 450; }
 
 	bool useRTL() const { return _useRTL; }
 	void setLanguageRTL();

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -235,7 +235,7 @@ void LauncherDialog::build() {
 	Common::String grouping = ConfMan.get("grouping");
 	const GroupingMode *mode = groupingModes;
 	while (mode->name) {
-		if (mode->lowresDescription && g_gui.getGUIWidth() <= 320) {
+		if (mode->lowresDescription && g_gui.useLowResGUI()) {
 			_grpChooserPopup->appendEntry(_c(mode->lowresDescription, "group"), mode->id);
 		} else {
 			_grpChooserPopup->appendEntry(_c(mode->description, "group"), mode->id);
@@ -284,7 +284,7 @@ void LauncherDialog::build() {
 	_removeButton =
 		// I18N: Button caption. R is the shortcut, Ctrl+R, put it in parens for non-latin (~R~)
 		new ButtonWidget(this, _title + ".RemoveGameButton", _("~R~emove Game"), _("Remove game from the list. The game data files stay intact"), kRemoveGameCmd, 0, _c("~R~emove Game", "lowres"));
-	if (g_gui.getGUIWidth() > 320) {
+	if (!g_gui.useLowResGUI()) {
 		// I18N: Button caption. Mass add games
 		addButton->appendEntry(_("Mass Add..."), kMassAddGameCmd);
 	} else {

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -279,11 +279,11 @@ void LauncherDialog::build() {
 	// Above the lowest button rows: two more buttons (directly below the list box)
 	DropdownButtonWidget *addButton =
 		// I18N: Button caption. A is the shortcut, Ctrl+A, put it in parens for non-latin (~A~)
-		new DropdownButtonWidget(this, _title + ".AddGameButton", _("~A~dd Game..."), _("Add games to the list"), kAddGameCmd, 0, _c("~A~dd Game...", "lowres"));
+		new DropdownButtonWidget(this, _title + ".AddGameButton", _("~A~dd Game..."), _("Add games to the list"), kAddGameCmd, 0, _c("~A~dd...", "lowres"));
 	_addButton = addButton;
 	_removeButton =
 		// I18N: Button caption. R is the shortcut, Ctrl+R, put it in parens for non-latin (~R~)
-		new ButtonWidget(this, _title + ".RemoveGameButton", _("~R~emove Game"), _("Remove game from the list. The game data files stay intact"), kRemoveGameCmd, 0, _c("~R~emove Game", "lowres"));
+		new ButtonWidget(this, _title + ".RemoveGameButton", _("~R~emove Game"), _("Remove game from the list. The game data files stay intact"), kRemoveGameCmd, 0, _c("~R~emove", "lowres"));
 	if (!g_gui.useLowResGUI()) {
 		// I18N: Button caption. Mass add games
 		addButton->appendEntry(_("Mass Add..."), kMassAddGameCmd);

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -235,7 +235,7 @@ void LauncherDialog::build() {
 	Common::String grouping = ConfMan.get("grouping");
 	const GroupingMode *mode = groupingModes;
 	while (mode->name) {
-		if (mode->lowresDescription && g_system->getOverlayWidth() <= 320) {
+		if (mode->lowresDescription && g_gui.getGUIWidth() <= 320) {
 			_grpChooserPopup->appendEntry(_c(mode->lowresDescription, "group"), mode->id);
 		} else {
 			_grpChooserPopup->appendEntry(_c(mode->description, "group"), mode->id);
@@ -284,7 +284,7 @@ void LauncherDialog::build() {
 	_removeButton =
 		// I18N: Button caption. R is the shortcut, Ctrl+R, put it in parens for non-latin (~R~)
 		new ButtonWidget(this, _title + ".RemoveGameButton", _("~R~emove Game"), _("Remove game from the list. The game data files stay intact"), kRemoveGameCmd, 0, _c("~R~emove Game", "lowres"));
-	if (g_system->getOverlayWidth() > 320) {
+	if (g_gui.getGUIWidth() > 320) {
 		// I18N: Button caption. Mass add games
 		addButton->appendEntry(_("Mass Add..."), kMassAddGameCmd);
 	} else {

--- a/gui/onscreendialog.cpp
+++ b/gui/onscreendialog.cpp
@@ -64,26 +64,26 @@ OnScreenDialog::OnScreenDialog(bool isRecord) : Dialog("OnScreenDialog") {
 		GUI::PicButtonWidget *button;
 
 		button = new PicButtonWidget(this, "OnScreenDialog.StopButton", Common::U32String(), kStopCmd, 0);
-		if (g_system->getOverlayWidth() > 320)
+		if (g_gui.getGUIWidth() > 320)
 			button->setGfxFromTheme(ThemeEngine::kImageStopButton);
 		else
 			button->setGfxFromTheme(ThemeEngine::kImageStopSmallButton);
 
 		if (isRecord) {
 			button = new PicButtonWidget(this, "OnScreenDialog.EditButton", Common::U32String(), kEditCmd, 0);
-			if (g_system->getOverlayWidth() > 320)
+			if (g_gui.getGUIWidth() > 320)
 				button->setGfxFromTheme(ThemeEngine::kImageEditButton);
 			else
 				button->setGfxFromTheme(ThemeEngine::kImageEditSmallButton);
 		} else {
 			button = new PicButtonWidget(this, "OnScreenDialog.SwitchModeButton", Common::U32String(), kSwitchModeCmd, 0);
-			if (g_system->getOverlayWidth() > 320)
+			if (g_gui.getGUIWidth() > 320)
 				button->setGfxFromTheme(ThemeEngine::kImageSwitchModeButton);
 			else
 				button->setGfxFromTheme(ThemeEngine::kImageSwitchModeSmallButton);
 
 			button = new PicButtonWidget(this, "OnScreenDialog.FastReplayButton", Common::U32String(), kFastModeCmd, 0);
-			if (g_system->getOverlayWidth() > 320)
+			if (g_gui.getGUIWidth() > 320)
 				button->setGfxFromTheme(ThemeEngine::kImageFastReplayButton);
 			else
 				button->setGfxFromTheme(ThemeEngine::kImageFastReplaySmallButton);
@@ -91,7 +91,7 @@ OnScreenDialog::OnScreenDialog(bool isRecord) : Dialog("OnScreenDialog") {
 	} else
 #endif
 	{
-		if (g_system->getOverlayWidth() > 320)
+		if (g_gui.getGUIWidth() > 320)
 			new ButtonWidget(this, "OnScreenDialog.StopButton", Common::U32String("[ ]"), _("Stop"), kStopCmd);
 		else
 			new ButtonWidget(this, "OnScreenDialog.StopButton", Common::U32String("[]"), _("Stop"), kStopCmd);

--- a/gui/onscreendialog.cpp
+++ b/gui/onscreendialog.cpp
@@ -64,26 +64,26 @@ OnScreenDialog::OnScreenDialog(bool isRecord) : Dialog("OnScreenDialog") {
 		GUI::PicButtonWidget *button;
 
 		button = new PicButtonWidget(this, "OnScreenDialog.StopButton", Common::U32String(), kStopCmd, 0);
-		if (g_gui.getGUIWidth() > 320)
+		if (!g_gui.useLowResGUI())
 			button->setGfxFromTheme(ThemeEngine::kImageStopButton);
 		else
 			button->setGfxFromTheme(ThemeEngine::kImageStopSmallButton);
 
 		if (isRecord) {
 			button = new PicButtonWidget(this, "OnScreenDialog.EditButton", Common::U32String(), kEditCmd, 0);
-			if (g_gui.getGUIWidth() > 320)
+			if (!g_gui.useLowResGUI())
 				button->setGfxFromTheme(ThemeEngine::kImageEditButton);
 			else
 				button->setGfxFromTheme(ThemeEngine::kImageEditSmallButton);
 		} else {
 			button = new PicButtonWidget(this, "OnScreenDialog.SwitchModeButton", Common::U32String(), kSwitchModeCmd, 0);
-			if (g_gui.getGUIWidth() > 320)
+			if (!g_gui.useLowResGUI())
 				button->setGfxFromTheme(ThemeEngine::kImageSwitchModeButton);
 			else
 				button->setGfxFromTheme(ThemeEngine::kImageSwitchModeSmallButton);
 
 			button = new PicButtonWidget(this, "OnScreenDialog.FastReplayButton", Common::U32String(), kFastModeCmd, 0);
-			if (g_gui.getGUIWidth() > 320)
+			if (!g_gui.useLowResGUI())
 				button->setGfxFromTheme(ThemeEngine::kImageFastReplayButton);
 			else
 				button->setGfxFromTheme(ThemeEngine::kImageFastReplaySmallButton);
@@ -91,7 +91,7 @@ OnScreenDialog::OnScreenDialog(bool isRecord) : Dialog("OnScreenDialog") {
 	} else
 #endif
 	{
-		if (g_gui.getGUIWidth() > 320)
+		if (!g_gui.useLowResGUI())
 			new ButtonWidget(this, "OnScreenDialog.StopButton", Common::U32String("[ ]"), _("Stop"), kStopCmd);
 		else
 			new ButtonWidget(this, "OnScreenDialog.StopButton", Common::U32String("[]"), _("Stop"), kStopCmd);

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -1391,7 +1391,7 @@ void OptionsDialog::addControlControls(GuiObject *boss, const Common::String &pr
 
 	// Keyboard and joystick mouse speed
 	if (g_system->hasFeature(OSystem::kFeatureKbdMouseSpeed)) {
-		if (g_gui.getGUIWidth() > 320)
+		if (!g_gui.useLowResGUI())
 			_kbdMouseSpeedDesc = new StaticTextWidget(boss, prefix + "grKbdMouseSpeedDesc", _("Pointer Speed:"), _("Speed for keyboard/joystick mouse pointer control"));
 		else
 			_kbdMouseSpeedDesc = new StaticTextWidget(boss, prefix + "grKbdMouseSpeedDesc", _c("Pointer Speed:", "lowres"), _("Speed for keyboard/joystick mouse pointer control"));
@@ -1404,7 +1404,7 @@ void OptionsDialog::addControlControls(GuiObject *boss, const Common::String &pr
 
 	// Joystick deadzone
 	if (g_system->hasFeature(OSystem::kFeatureJoystickDeadzone)) {
-		if (g_gui.getGUIWidth() > 320)
+		if (!g_gui.useLowResGUI())
 			_joystickDeadzoneDesc = new StaticTextWidget(boss, prefix + "grJoystickDeadzoneDesc", _("Joy Deadzone:"), _("Analog joystick Deadzone"));
 		else
 			_joystickDeadzoneDesc = new StaticTextWidget(boss, prefix + "grJoystickDeadzoneDesc", _c("Joy Deadzone:", "lowres"), _("Analog joystick Deadzone"));
@@ -1442,10 +1442,10 @@ void OptionsDialog::addAchievementsControls(GuiObject *boss, const Common::Strin
 	uint16 width;
 	uint16 textline_numchars;  // max number of chars in textline
 	uint16 progressBarWidth;
-	uint16 commentDelta = g_gui.getGUIWidth() <= 320 ? 20 : 30; // textline left tabbing
+	uint16 commentDelta = g_gui.useLowResGUI() ? 20 : 30; // textline left tabbing
 	float scale_factor = g_gui.getScaleFactor();
 
-	if (g_gui.getGUIWidth() > 320) { // hires
+	if (!g_gui.useLowResGUI()) { // hires
 		width = 440 + 800 * (scale_factor - 1);
 		textline_numchars = 70 + 80 * (scale_factor - 1);
 		progressBarWidth = 240;
@@ -1531,7 +1531,7 @@ void OptionsDialog::addStatisticsControls(GuiObject *boss, const Common::String 
 	uint16 yStep = lineHeight;
 	uint16 ySmallStep = yStep / 3;
 	uint16 yPos = lineHeight;
-	uint16 width = g_gui.getGUIWidth() <= 320 ? 240 : 410;
+	uint16 width = g_gui.useLowResGUI() ? 240 : 410;
 
 	for (uint16 idx = 0; idx < nMax ; idx++) {
 		const Common::StatDescription *descr = AchMan.getStatDescription(idx);
@@ -1550,7 +1550,7 @@ void OptionsDialog::addStatisticsControls(GuiObject *boss, const Common::String 
 void OptionsDialog::addGraphicControls(GuiObject *boss, const Common::String &prefix) {
 	const OSystem::GraphicsMode *gm = g_system->getSupportedGraphicsModes();
 	Common::String context;
-	if (g_gui.getGUIWidth() <= 320)
+	if (g_gui.useLowResGUI())
 		context = "lowres";
 
 	// The GFX mode popup
@@ -1615,7 +1615,7 @@ void OptionsDialog::addGraphicControls(GuiObject *boss, const Common::String &pr
 		updateScaleFactors(_scalerPopUp->getSelectedTag());
 	}
 
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		_shaderButton = new ButtonWidget(boss, prefix + "grShaderButton", _("Shader:"), _("Specifies path to the shader used for scaling the game screen"), kChooseShaderCmd);
 	else
 		_shaderButton = new ButtonWidget(boss, prefix + "grShaderButton", _c("Shader Path:", "lowres"), _("Specifies path to the shader used for scaling the game screen"), kChooseShaderCmd);
@@ -1639,7 +1639,7 @@ void OptionsDialog::addGraphicControls(GuiObject *boss, const Common::String &pr
 
 	Common::Array<Graphics::RendererTypeDescription> rt = Graphics::Renderer::listTypes();
 	if (!rt.empty()) {
-		if (g_gui.getGUIWidth() > 320)
+		if (!g_gui.useLowResGUI())
 			_rendererTypePopUpDesc = new StaticTextWidget(boss, prefix + "grRendererTypePopupDesc", _("Game 3D Renderer:"));
 		else
 			_rendererTypePopUpDesc = new StaticTextWidget(boss, prefix + "grRendererTypePopupDesc", _c("Game 3D Renderer:", "lowres"));
@@ -1649,7 +1649,7 @@ void OptionsDialog::addGraphicControls(GuiObject *boss, const Common::String &pr
 		_rendererTypePopUp->appendEntry("");
 		for (Common::Array<Graphics::RendererTypeDescription>::iterator it = rt.begin();
 		        it != rt.end(); ++it) {
-			if (g_gui.getGUIWidth() > 320) {
+			if (!g_gui.useLowResGUI()) {
 				_rendererTypePopUp->appendEntry(_(it->description), it->id);
 			} else {
 				_rendererTypePopUp->appendEntry(_c(it->description, "lowres"), it->id);
@@ -1691,7 +1691,7 @@ void OptionsDialog::enableShaderControls(bool enable) {
 
 void OptionsDialog::addAudioControls(GuiObject *boss, const Common::String &prefix) {
 	// The MIDI mode popup & a label
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		_midiPopUpDesc = new StaticTextWidget(boss, prefix + "auMidiPopupDesc", _domain == Common::ConfigManager::kApplicationDomain ? _("Preferred device:") : _("Music device:"), _domain == Common::ConfigManager::kApplicationDomain ? _("Specifies preferred sound device or sound card emulator") : _("Specifies output sound device or sound card emulator"));
 	else
 		_midiPopUpDesc = new StaticTextWidget(boss, prefix + "auMidiPopupDesc", _domain == Common::ConfigManager::kApplicationDomain ? _c("Preferred dev.:", "lowres") : _c("Music device:", "lowres"), _domain == Common::ConfigManager::kApplicationDomain ? _("Specifies preferred sound device or sound card emulator") : _("Specifies output sound device or sound card emulator"));
@@ -1770,7 +1770,7 @@ void OptionsDialog::addMIDIControls(GuiObject *boss, const Common::String &prefi
 	}
 
 	// SoundFont
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		_soundFontButton = new ButtonWidget(boss, prefix + "mcFontButton", _("SoundFont:"), _("SoundFont is supported by some audio cards, FluidSynth and Timidity"), kChooseSoundFontCmd);
 	else
 		_soundFontButton = new ButtonWidget(boss, prefix + "mcFontButton", _c("SoundFont:", "lowres"), _("SoundFont is supported by some audio cards, FluidSynth and Timidity"), kChooseSoundFontCmd);
@@ -1796,7 +1796,7 @@ void OptionsDialog::addMT32Controls(GuiObject *boss, const Common::String &prefi
 	_mt32DevicePopUp = new PopUpWidget(boss, prefix + "auPrefMt32Popup");
 
 	// Native mt32 setting
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		_mt32Checkbox = new CheckboxWidget(boss, prefix + "mcMt32Checkbox", _("True Roland MT-32 (disable GM emulation)"), _("Check if you want to use your real hardware Roland-compatible sound device connected to your computer"));
 	else
 		_mt32Checkbox = new CheckboxWidget(boss, prefix + "mcMt32Checkbox", _c("True Roland MT-32 (no GM emulation)", "lowres"), _("Check if you want to use your real hardware Roland-compatible sound device connected to your computer"));
@@ -1837,7 +1837,7 @@ void OptionsDialog::addMT32Controls(GuiObject *boss, const Common::String &prefi
 // make use of the widgets. The launcher range is 0-255. SCUMM's 0-9
 void OptionsDialog::addSubtitleControls(GuiObject *boss, const Common::String &prefix, int maxSliderVal) {
 
-	if (g_gui.getGUIWidth() > 320) {
+	if (!g_gui.useLowResGUI()) {
 		_subToggleDesc = new StaticTextWidget(boss, prefix + "subToggleDesc", _("Text and speech:"));
 
 		_subToggleGroup = new RadiobuttonGroup(boss, kSubtitleToggle);
@@ -1877,7 +1877,7 @@ void OptionsDialog::addSubtitleControls(GuiObject *boss, const Common::String &p
 void OptionsDialog::addVolumeControls(GuiObject *boss, const Common::String &prefix) {
 
 	// Volume controllers
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		_musicVolumeDesc = new StaticTextWidget(boss, prefix + "vcMusicText", _("Music volume:"));
 	else
 		_musicVolumeDesc = new StaticTextWidget(boss, prefix + "vcMusicText", _c("Music volume:", "lowres"));
@@ -1891,7 +1891,7 @@ void OptionsDialog::addVolumeControls(GuiObject *boss, const Common::String &pre
 
 	_muteCheckbox = new CheckboxWidget(boss, prefix + "vcMuteCheckbox", _("Mute all"), Common::U32String(), kMuteAllChanged);
 
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		_sfxVolumeDesc = new StaticTextWidget(boss, prefix + "vcSfxText", _("SFX volume:"), _("Special sound effects volume"));
 	else
 		_sfxVolumeDesc = new StaticTextWidget(boss, prefix + "vcSfxText", _c("SFX volume:", "lowres"), _("Special sound effects volume"));
@@ -1903,7 +1903,7 @@ void OptionsDialog::addVolumeControls(GuiObject *boss, const Common::String &pre
 	_sfxVolumeSlider->setMaxValue(Audio::Mixer::kMaxMixerVolume);
 	_sfxVolumeLabel->setFlags(WIDGET_CLEARBG);
 
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		_speechVolumeDesc = new StaticTextWidget(boss, prefix + "vcSpeechText" , _("Speech volume:"));
 	else
 		_speechVolumeDesc = new StaticTextWidget(boss, prefix + "vcSpeechText" , _c("Speech volume:", "lowres"));
@@ -2001,7 +2001,7 @@ void OptionsDialog::updateSpeechVolume(const int newValue) const {
 
 void OptionsDialog::reflowLayout() {
 	if (_graphicsTabId != -1 && _tabWidget)
-		_tabWidget->setTabTitle(_graphicsTabId, g_gui.getGUIWidth() > 320 ? _("Graphics") : _("GFX"));
+		_tabWidget->setTabTitle(_graphicsTabId, g_gui.useLowResGUI() ? _("GFX") : _("Graphics"));
 
 	Dialog::reflowLayout();
 	setupGraphicsTab();
@@ -2175,7 +2175,7 @@ void GlobalOptionsDialog::build() {
 	//
 	// 1) The graphics tab
 	//
-	_graphicsTabId = tab->addTab(g_gui.getGUIWidth() > 320 ? _("Graphics") : _("GFX"), "GlobalOptions_Graphics", false);
+	_graphicsTabId = tab->addTab(g_gui.useLowResGUI() ? _("GFX") : _("Graphics"), "GlobalOptions_Graphics", false);
 	ScrollContainerWidget *graphicsContainer = new ScrollContainerWidget(tab, "GlobalOptions_Graphics.Container", "GlobalOptions_Graphics_Container", kGraphicsTabContainerReflowCmd);
 	graphicsContainer->setTarget(this);
 	graphicsContainer->setBackgroundType(ThemeEngine::kWidgetBackgroundNo);
@@ -2234,7 +2234,7 @@ void GlobalOptionsDialog::build() {
 	addAudioControls(tab, "GlobalOptions_Audio.");
 	addSubtitleControls(tab, "GlobalOptions_Audio.");
 
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		tab->addTab(_("Volume"), "GlobalOptions_Volume");
 	else
 		tab->addTab(_c("Volume", "lowres"), "GlobalOptions_Volume");
@@ -2257,11 +2257,11 @@ void GlobalOptionsDialog::build() {
 	//
 	// 5) The Paths tab
 	//
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		_pathsTabId = tab->addTab(_("Paths"), "GlobalOptions_Paths");
 	else
 		_pathsTabId = tab->addTab(_c("Paths", "lowres"), "GlobalOptions_Paths");
-	addPathsControls(tab, "GlobalOptions_Paths.", g_gui.getGUIWidth() <= 320);
+	addPathsControls(tab, "GlobalOptions_Paths.", g_gui.useLowResGUI());
 
 	//
 	// 6) The GUI tab
@@ -2270,7 +2270,7 @@ void GlobalOptionsDialog::build() {
 	ScrollContainerWidget *guiContainer = new ScrollContainerWidget(tab, "GlobalOptions_GUI.Container", "GlobalOptions_GUI_Container");
 	guiContainer->setTarget(this);
 	guiContainer->setBackgroundType(ThemeEngine::kWidgetBackgroundNo);
-	addGUIControls(guiContainer, "GlobalOptions_GUI_Container.", g_gui.getGUIWidth() <= 320);
+	addGUIControls(guiContainer, "GlobalOptions_GUI_Container.", g_gui.useLowResGUI());
 
 	//
 	// 7) The miscellaneous tab
@@ -2279,14 +2279,14 @@ void GlobalOptionsDialog::build() {
 	ScrollContainerWidget *miscContainer = new ScrollContainerWidget(tab, "GlobalOptions_Misc.Container", "GlobalOptions_Misc_Container");
 	miscContainer->setTarget(this);
 	miscContainer->setBackgroundType(ThemeEngine::kWidgetBackgroundNo);
-	addMiscControls(miscContainer, "GlobalOptions_Misc_Container.", g_gui.getGUIWidth() <= 320);
+	addMiscControls(miscContainer, "GlobalOptions_Misc_Container.", g_gui.useLowResGUI());
 
 #ifdef USE_CLOUD
 #ifdef USE_LIBCURL
 	//
 	// 8) The Cloud tab (remote storages)
 	//
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		tab->addTab(_("Cloud"), "GlobalOptions_Cloud", false);
 	else
 		tab->addTab(_c("Cloud", "lowres"), "GlobalOptions_Cloud", false);
@@ -2296,17 +2296,17 @@ void GlobalOptionsDialog::build() {
 	container->setBackgroundType(ThemeEngine::kWidgetBackgroundNo);
 	setTarget(container);
 
-	addCloudControls(container, "GlobalOptions_Cloud_Container.", g_gui.getGUIWidth() <= 320);
+	addCloudControls(container, "GlobalOptions_Cloud_Container.", g_gui.useLowResGUI());
 #endif // USE_LIBCURL
 #ifdef USE_SDL_NET
 	//
 	// 9) The LAN tab (local "cloud" webserver)
 	//
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		tab->addTab(_("LAN"), "GlobalOptions_Network");
 	else
 		tab->addTab(_c("LAN", "lowres"), "GlobalOptions_Network");
-	addNetworkControls(tab, "GlobalOptions_Network.", g_gui.getGUIWidth() <= 320);
+	addNetworkControls(tab, "GlobalOptions_Network.", g_gui.useLowResGUI());
 #endif // USE_SDL_NET
 #endif // USE_CLOUD
 
@@ -2314,7 +2314,7 @@ void GlobalOptionsDialog::build() {
 	// 10) Accessibility
 	//
 #ifdef USE_TTS
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		tab->addTab(_("Accessibility"), "GlobalOptions_Accessibility");
 	else
 		tab->addTab(_c("Accessibility", "lowres"), "GlobalOptions_Accessibility");

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -1391,7 +1391,7 @@ void OptionsDialog::addControlControls(GuiObject *boss, const Common::String &pr
 
 	// Keyboard and joystick mouse speed
 	if (g_system->hasFeature(OSystem::kFeatureKbdMouseSpeed)) {
-		if (g_system->getOverlayWidth() > 320)
+		if (g_gui.getGUIWidth() > 320)
 			_kbdMouseSpeedDesc = new StaticTextWidget(boss, prefix + "grKbdMouseSpeedDesc", _("Pointer Speed:"), _("Speed for keyboard/joystick mouse pointer control"));
 		else
 			_kbdMouseSpeedDesc = new StaticTextWidget(boss, prefix + "grKbdMouseSpeedDesc", _c("Pointer Speed:", "lowres"), _("Speed for keyboard/joystick mouse pointer control"));
@@ -1404,7 +1404,7 @@ void OptionsDialog::addControlControls(GuiObject *boss, const Common::String &pr
 
 	// Joystick deadzone
 	if (g_system->hasFeature(OSystem::kFeatureJoystickDeadzone)) {
-		if (g_system->getOverlayWidth() > 320)
+		if (g_gui.getGUIWidth() > 320)
 			_joystickDeadzoneDesc = new StaticTextWidget(boss, prefix + "grJoystickDeadzoneDesc", _("Joy Deadzone:"), _("Analog joystick Deadzone"));
 		else
 			_joystickDeadzoneDesc = new StaticTextWidget(boss, prefix + "grJoystickDeadzoneDesc", _c("Joy Deadzone:", "lowres"), _("Analog joystick Deadzone"));
@@ -1442,10 +1442,10 @@ void OptionsDialog::addAchievementsControls(GuiObject *boss, const Common::Strin
 	uint16 width;
 	uint16 textline_numchars;  // max number of chars in textline
 	uint16 progressBarWidth;
-	uint16 commentDelta = g_system->getOverlayWidth() <= 320 ? 20 : 30; // textline left tabbing
+	uint16 commentDelta = g_gui.getGUIWidth() <= 320 ? 20 : 30; // textline left tabbing
 	float scale_factor = g_gui.getScaleFactor();
 
-	if (g_system->getOverlayWidth() > 320) { // hires
+	if (g_gui.getGUIWidth() > 320) { // hires
 		width = 440 + 800 * (scale_factor - 1);
 		textline_numchars = 70 + 80 * (scale_factor - 1);
 		progressBarWidth = 240;
@@ -1531,7 +1531,7 @@ void OptionsDialog::addStatisticsControls(GuiObject *boss, const Common::String 
 	uint16 yStep = lineHeight;
 	uint16 ySmallStep = yStep / 3;
 	uint16 yPos = lineHeight;
-	uint16 width = g_system->getOverlayWidth() <= 320 ? 240 : 410;
+	uint16 width = g_gui.getGUIWidth() <= 320 ? 240 : 410;
 
 	for (uint16 idx = 0; idx < nMax ; idx++) {
 		const Common::StatDescription *descr = AchMan.getStatDescription(idx);
@@ -1550,7 +1550,7 @@ void OptionsDialog::addStatisticsControls(GuiObject *boss, const Common::String 
 void OptionsDialog::addGraphicControls(GuiObject *boss, const Common::String &prefix) {
 	const OSystem::GraphicsMode *gm = g_system->getSupportedGraphicsModes();
 	Common::String context;
-	if (g_system->getOverlayWidth() <= 320)
+	if (g_gui.getGUIWidth() <= 320)
 		context = "lowres";
 
 	// The GFX mode popup
@@ -1615,7 +1615,7 @@ void OptionsDialog::addGraphicControls(GuiObject *boss, const Common::String &pr
 		updateScaleFactors(_scalerPopUp->getSelectedTag());
 	}
 
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		_shaderButton = new ButtonWidget(boss, prefix + "grShaderButton", _("Shader:"), _("Specifies path to the shader used for scaling the game screen"), kChooseShaderCmd);
 	else
 		_shaderButton = new ButtonWidget(boss, prefix + "grShaderButton", _c("Shader Path:", "lowres"), _("Specifies path to the shader used for scaling the game screen"), kChooseShaderCmd);
@@ -1639,7 +1639,7 @@ void OptionsDialog::addGraphicControls(GuiObject *boss, const Common::String &pr
 
 	Common::Array<Graphics::RendererTypeDescription> rt = Graphics::Renderer::listTypes();
 	if (!rt.empty()) {
-		if (g_system->getOverlayWidth() > 320)
+		if (g_gui.getGUIWidth() > 320)
 			_rendererTypePopUpDesc = new StaticTextWidget(boss, prefix + "grRendererTypePopupDesc", _("Game 3D Renderer:"));
 		else
 			_rendererTypePopUpDesc = new StaticTextWidget(boss, prefix + "grRendererTypePopupDesc", _c("Game 3D Renderer:", "lowres"));
@@ -1649,7 +1649,7 @@ void OptionsDialog::addGraphicControls(GuiObject *boss, const Common::String &pr
 		_rendererTypePopUp->appendEntry("");
 		for (Common::Array<Graphics::RendererTypeDescription>::iterator it = rt.begin();
 		        it != rt.end(); ++it) {
-			if (g_system->getOverlayWidth() > 320) {
+			if (g_gui.getGUIWidth() > 320) {
 				_rendererTypePopUp->appendEntry(_(it->description), it->id);
 			} else {
 				_rendererTypePopUp->appendEntry(_c(it->description, "lowres"), it->id);
@@ -1691,7 +1691,7 @@ void OptionsDialog::enableShaderControls(bool enable) {
 
 void OptionsDialog::addAudioControls(GuiObject *boss, const Common::String &prefix) {
 	// The MIDI mode popup & a label
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		_midiPopUpDesc = new StaticTextWidget(boss, prefix + "auMidiPopupDesc", _domain == Common::ConfigManager::kApplicationDomain ? _("Preferred device:") : _("Music device:"), _domain == Common::ConfigManager::kApplicationDomain ? _("Specifies preferred sound device or sound card emulator") : _("Specifies output sound device or sound card emulator"));
 	else
 		_midiPopUpDesc = new StaticTextWidget(boss, prefix + "auMidiPopupDesc", _domain == Common::ConfigManager::kApplicationDomain ? _c("Preferred dev.:", "lowres") : _c("Music device:", "lowres"), _domain == Common::ConfigManager::kApplicationDomain ? _("Specifies preferred sound device or sound card emulator") : _("Specifies output sound device or sound card emulator"));
@@ -1770,7 +1770,7 @@ void OptionsDialog::addMIDIControls(GuiObject *boss, const Common::String &prefi
 	}
 
 	// SoundFont
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		_soundFontButton = new ButtonWidget(boss, prefix + "mcFontButton", _("SoundFont:"), _("SoundFont is supported by some audio cards, FluidSynth and Timidity"), kChooseSoundFontCmd);
 	else
 		_soundFontButton = new ButtonWidget(boss, prefix + "mcFontButton", _c("SoundFont:", "lowres"), _("SoundFont is supported by some audio cards, FluidSynth and Timidity"), kChooseSoundFontCmd);
@@ -1796,7 +1796,7 @@ void OptionsDialog::addMT32Controls(GuiObject *boss, const Common::String &prefi
 	_mt32DevicePopUp = new PopUpWidget(boss, prefix + "auPrefMt32Popup");
 
 	// Native mt32 setting
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		_mt32Checkbox = new CheckboxWidget(boss, prefix + "mcMt32Checkbox", _("True Roland MT-32 (disable GM emulation)"), _("Check if you want to use your real hardware Roland-compatible sound device connected to your computer"));
 	else
 		_mt32Checkbox = new CheckboxWidget(boss, prefix + "mcMt32Checkbox", _c("True Roland MT-32 (no GM emulation)", "lowres"), _("Check if you want to use your real hardware Roland-compatible sound device connected to your computer"));
@@ -1837,7 +1837,7 @@ void OptionsDialog::addMT32Controls(GuiObject *boss, const Common::String &prefi
 // make use of the widgets. The launcher range is 0-255. SCUMM's 0-9
 void OptionsDialog::addSubtitleControls(GuiObject *boss, const Common::String &prefix, int maxSliderVal) {
 
-	if (g_system->getOverlayWidth() > 320) {
+	if (g_gui.getGUIWidth() > 320) {
 		_subToggleDesc = new StaticTextWidget(boss, prefix + "subToggleDesc", _("Text and speech:"));
 
 		_subToggleGroup = new RadiobuttonGroup(boss, kSubtitleToggle);
@@ -1877,7 +1877,7 @@ void OptionsDialog::addSubtitleControls(GuiObject *boss, const Common::String &p
 void OptionsDialog::addVolumeControls(GuiObject *boss, const Common::String &prefix) {
 
 	// Volume controllers
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		_musicVolumeDesc = new StaticTextWidget(boss, prefix + "vcMusicText", _("Music volume:"));
 	else
 		_musicVolumeDesc = new StaticTextWidget(boss, prefix + "vcMusicText", _c("Music volume:", "lowres"));
@@ -1891,7 +1891,7 @@ void OptionsDialog::addVolumeControls(GuiObject *boss, const Common::String &pre
 
 	_muteCheckbox = new CheckboxWidget(boss, prefix + "vcMuteCheckbox", _("Mute all"), Common::U32String(), kMuteAllChanged);
 
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		_sfxVolumeDesc = new StaticTextWidget(boss, prefix + "vcSfxText", _("SFX volume:"), _("Special sound effects volume"));
 	else
 		_sfxVolumeDesc = new StaticTextWidget(boss, prefix + "vcSfxText", _c("SFX volume:", "lowres"), _("Special sound effects volume"));
@@ -1903,7 +1903,7 @@ void OptionsDialog::addVolumeControls(GuiObject *boss, const Common::String &pre
 	_sfxVolumeSlider->setMaxValue(Audio::Mixer::kMaxMixerVolume);
 	_sfxVolumeLabel->setFlags(WIDGET_CLEARBG);
 
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		_speechVolumeDesc = new StaticTextWidget(boss, prefix + "vcSpeechText" , _("Speech volume:"));
 	else
 		_speechVolumeDesc = new StaticTextWidget(boss, prefix + "vcSpeechText" , _c("Speech volume:", "lowres"));
@@ -2001,7 +2001,7 @@ void OptionsDialog::updateSpeechVolume(const int newValue) const {
 
 void OptionsDialog::reflowLayout() {
 	if (_graphicsTabId != -1 && _tabWidget)
-		_tabWidget->setTabTitle(_graphicsTabId, g_system->getOverlayWidth() > 320 ? _("Graphics") : _("GFX"));
+		_tabWidget->setTabTitle(_graphicsTabId, g_gui.getGUIWidth() > 320 ? _("Graphics") : _("GFX"));
 
 	Dialog::reflowLayout();
 	setupGraphicsTab();
@@ -2175,7 +2175,7 @@ void GlobalOptionsDialog::build() {
 	//
 	// 1) The graphics tab
 	//
-	_graphicsTabId = tab->addTab(g_system->getOverlayWidth() > 320 ? _("Graphics") : _("GFX"), "GlobalOptions_Graphics", false);
+	_graphicsTabId = tab->addTab(g_gui.getGUIWidth() > 320 ? _("Graphics") : _("GFX"), "GlobalOptions_Graphics", false);
 	ScrollContainerWidget *graphicsContainer = new ScrollContainerWidget(tab, "GlobalOptions_Graphics.Container", "GlobalOptions_Graphics_Container", kGraphicsTabContainerReflowCmd);
 	graphicsContainer->setTarget(this);
 	graphicsContainer->setBackgroundType(ThemeEngine::kWidgetBackgroundNo);
@@ -2234,7 +2234,7 @@ void GlobalOptionsDialog::build() {
 	addAudioControls(tab, "GlobalOptions_Audio.");
 	addSubtitleControls(tab, "GlobalOptions_Audio.");
 
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		tab->addTab(_("Volume"), "GlobalOptions_Volume");
 	else
 		tab->addTab(_c("Volume", "lowres"), "GlobalOptions_Volume");
@@ -2257,11 +2257,11 @@ void GlobalOptionsDialog::build() {
 	//
 	// 5) The Paths tab
 	//
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		_pathsTabId = tab->addTab(_("Paths"), "GlobalOptions_Paths");
 	else
 		_pathsTabId = tab->addTab(_c("Paths", "lowres"), "GlobalOptions_Paths");
-	addPathsControls(tab, "GlobalOptions_Paths.", g_system->getOverlayWidth() <= 320);
+	addPathsControls(tab, "GlobalOptions_Paths.", g_gui.getGUIWidth() <= 320);
 
 	//
 	// 6) The GUI tab
@@ -2270,7 +2270,7 @@ void GlobalOptionsDialog::build() {
 	ScrollContainerWidget *guiContainer = new ScrollContainerWidget(tab, "GlobalOptions_GUI.Container", "GlobalOptions_GUI_Container");
 	guiContainer->setTarget(this);
 	guiContainer->setBackgroundType(ThemeEngine::kWidgetBackgroundNo);
-	addGUIControls(guiContainer, "GlobalOptions_GUI_Container.", g_system->getOverlayWidth() <= 320);
+	addGUIControls(guiContainer, "GlobalOptions_GUI_Container.", g_gui.getGUIWidth() <= 320);
 
 	//
 	// 7) The miscellaneous tab
@@ -2279,14 +2279,14 @@ void GlobalOptionsDialog::build() {
 	ScrollContainerWidget *miscContainer = new ScrollContainerWidget(tab, "GlobalOptions_Misc.Container", "GlobalOptions_Misc_Container");
 	miscContainer->setTarget(this);
 	miscContainer->setBackgroundType(ThemeEngine::kWidgetBackgroundNo);
-	addMiscControls(miscContainer, "GlobalOptions_Misc_Container.", g_system->getOverlayWidth() <= 320);
+	addMiscControls(miscContainer, "GlobalOptions_Misc_Container.", g_gui.getGUIWidth() <= 320);
 
 #ifdef USE_CLOUD
 #ifdef USE_LIBCURL
 	//
 	// 8) The Cloud tab (remote storages)
 	//
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		tab->addTab(_("Cloud"), "GlobalOptions_Cloud", false);
 	else
 		tab->addTab(_c("Cloud", "lowres"), "GlobalOptions_Cloud", false);
@@ -2296,17 +2296,17 @@ void GlobalOptionsDialog::build() {
 	container->setBackgroundType(ThemeEngine::kWidgetBackgroundNo);
 	setTarget(container);
 
-	addCloudControls(container, "GlobalOptions_Cloud_Container.", g_system->getOverlayWidth() <= 320);
+	addCloudControls(container, "GlobalOptions_Cloud_Container.", g_gui.getGUIWidth() <= 320);
 #endif // USE_LIBCURL
 #ifdef USE_SDL_NET
 	//
 	// 9) The LAN tab (local "cloud" webserver)
 	//
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		tab->addTab(_("LAN"), "GlobalOptions_Network");
 	else
 		tab->addTab(_c("LAN", "lowres"), "GlobalOptions_Network");
-	addNetworkControls(tab, "GlobalOptions_Network.", g_system->getOverlayWidth() <= 320);
+	addNetworkControls(tab, "GlobalOptions_Network.", g_gui.getGUIWidth() <= 320);
 #endif // USE_SDL_NET
 #endif // USE_CLOUD
 
@@ -2314,7 +2314,7 @@ void GlobalOptionsDialog::build() {
 	// 10) Accessibility
 	//
 #ifdef USE_TTS
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		tab->addTab(_("Accessibility"), "GlobalOptions_Accessibility");
 	else
 		tab->addTab(_c("Accessibility", "lowres"), "GlobalOptions_Accessibility");

--- a/gui/remotebrowser.cpp
+++ b/gui/remotebrowser.cpp
@@ -52,7 +52,7 @@ RemoteBrowserDialog::RemoteBrowserDialog(const Common::U32String &title):
 	_fileList->setNumberingMode(kListNumberingOff);
 	_fileList->setEditable(false);
 
-	if (g_gui.getGUIWidth() > 320)
+	if (!g_gui.useLowResGUI())
 		new ButtonWidget(this, "Browser.Up", _("Go up"), _("Go to previous directory level"), kGoUpCmd);
 	else
 		new ButtonWidget(this, "Browser.Up", _c("Go up", "lowres"), _("Go to previous directory level"), kGoUpCmd);

--- a/gui/remotebrowser.cpp
+++ b/gui/remotebrowser.cpp
@@ -52,7 +52,7 @@ RemoteBrowserDialog::RemoteBrowserDialog(const Common::U32String &title):
 	_fileList->setNumberingMode(kListNumberingOff);
 	_fileList->setEditable(false);
 
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getGUIWidth() > 320)
 		new ButtonWidget(this, "Browser.Up", _("Go up"), _("Go to previous directory level"), kGoUpCmd);
 	else
 		new ButtonWidget(this, "Browser.Up", _c("Go up", "lowres"), _("Go to previous directory level"), kGoUpCmd);

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -434,7 +434,7 @@ void ButtonWidget::setLowresLabel(const Common::U32String &label) {
 const Common::U32String &ButtonWidget::getLabel() {
 	bool useLowres = false;
 	if (!_lowresLabel.empty())
-		useLowres = g_gui.getGUIWidth() <= 320;
+		useLowres = g_gui.useLowResGUI();
 	_hotkey = useLowres ? _lowresHotkey : _highresHotkey;
 	return useLowres ? _lowresLabel : _label;
 }

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -434,7 +434,7 @@ void ButtonWidget::setLowresLabel(const Common::U32String &label) {
 const Common::U32String &ButtonWidget::getLabel() {
 	bool useLowres = false;
 	if (!_lowresLabel.empty())
-		useLowres = g_system->getOverlayWidth() <= 320;
+		useLowres = g_gui.getGUIWidth() <= 320;
 	_hotkey = useLowres ? _lowresHotkey : _highresHotkey;
 	return useLowres ? _lowresLabel : _label;
 }


### PR DESCRIPTION
The changes in this pull request started from @larsamannen showing on Discord a screenshot from an iPhone 12 mini where the labels of the launcher buttons get cut off:

The discussion initially revolved around the need to have use 3 or 4 rows of buttons instead of 2 rows. But looking at the code I realised that we had a bug in our code on HiDPI screens  to determine if lowres labels should be used or not. The first commit in this pull request fixes that.

And then I decided to go a bit further and added commits to:
1. Factorize the condition to determine if lowres labels should be used or not by adding a function in GuiManager.
2. Change the condition to switch to lowres labels for width <= 450 instead of width <= 320.
3. Change the lowres labels for the `Add Game...` and `Remove Game` buttons.

The result of those changes is that the 2 rows of 4 buttons now fit on the iPhone 12 mini:

| Before | After |
|--------|------|
| ![image](https://github.com/scummvm/scummvm/assets/552105/68c2d11c-f46a-4353-9fd9-73f24db3c9c4) | ![image](https://github.com/scummvm/scummvm/assets/552105/16700072-28bf-4fda-9783-449549ced23a)

The first commit is I think a no-brainer as it fixes a bug where the HiDPI scaling was not taken into account to determine if lowres labels should be used or not.

I am unsure about the other commits though. They also impact the lowres landscape layout in which there is no need to shorten the `Add Game...` and `Remove Game` labels even at a width of 320 pixels.

So we may decide not to land those additional commits and instead work on a different portrait lowres layout for the themes.


