### PR TITLE
SCI: Provide additional errorString context on crash

### DIFF
--- a/engines/sci/sci.h
+++ b/engines/sci/sci.h
@@ -153,6 +153,7 @@ public:
 	void updateSoundMixerVolumes();
 	uint32 getTickCount();
 	void setTickCount(const uint32 ticks);
+	void errorString(const char *buf1, char *buf2, int size) override;
 
 	/**
 	 * Disable support for ScummVM autosaves.


### PR DESCRIPTION
Hello,

As discussed in bug: https://bugs.scummvm.org/ticket/14652

Here is a first draft at providing additional crash context when an error occurs in the SCI vm. This code will attempt to pull critical VM state data to provide additional details of what the user was doing and where they were in the game at the time of crash in addition to the error at the call site.

If the game crashes too early within the VM startup only the original error at the call site is provided.

One additional thing I need to do is provide arguments but I'm unsure how the args should be presented.

Example output when a crash occurs:

```sh
ERROR: something bad happened like a divide by zero
Game: pq4-cd, Version: 1.100.000
Room: 003, Script: 003, Selector: doTitle::changeState(params TODO) @ pc=0030:02ea
```