### PR TITLE
GUI: Adds clear and cls alias for gui console debugger

### DIFF
--- a/gui/console.cpp
+++ b/gui/console.cpp
@@ -133,6 +133,18 @@ void ConsoleDialog::resetPrompt() {
 	_prompt = PROMPT;
 }
 
+void ConsoleDialog::clearBuffer() {
+	// Reset the line buffer.
+	memset(_buffer, ' ', kBufferSize);
+
+	// Along with a few key vars.
+	_currentPos = 0;
+	_scrollLine = _linesPerPage - 1;
+	_firstLineInBuffer = 0;
+
+	updateScrollBuffer();
+}
+
 void ConsoleDialog::slideUpAndClose() {
 	if (_slideMode == kNoSlideMode) {
 		_slideTime = g_system->getMillis();

--- a/gui/console.h
+++ b/gui/console.h
@@ -165,6 +165,7 @@ public:
 
 	void setPrompt(Common::String prompt);
 	void resetPrompt();
+	void clearBuffer();
 
 protected:
 	inline char &buffer(int idx) {

--- a/gui/debugger.cpp
+++ b/gui/debugger.cpp
@@ -73,6 +73,8 @@ Debugger::Debugger() {
 	registerCmd("md5",				WRAP_METHOD(Debugger, cmdMd5));
 	registerCmd("md5mac",			WRAP_METHOD(Debugger, cmdMd5Mac));
 #endif
+	registerCmd("clear",			WRAP_METHOD(Debugger, cmdClearLog));
+	registerCmd("cls",			WRAP_METHOD(Debugger, cmdClearLog)); // alias
 	registerCmd("exec",				WRAP_METHOD(Debugger, cmdExecFile));
 
 	registerCmd("debuglevel",		WRAP_METHOD(Debugger, cmdDebugLevel));
@@ -805,6 +807,13 @@ bool Debugger::cmdDebugFlagEnable(int argc, const char **argv) {
 			debugPrintf("Failed to enable debug flag '%s'\n", argv[1]);
 		}
 	}
+	return true;
+}
+
+bool Debugger::cmdClearLog(int argc, const char **argv) {
+	#ifndef USE_TEXT_CONSOLE_FOR_DEBUGGER
+	_debuggerDialog->clearBuffer();
+	#endif
 	return true;
 }
 

--- a/gui/debugger.h
+++ b/gui/debugger.h
@@ -275,6 +275,7 @@ protected:
 	bool cmdDebugFlagsList(int argc, const char **argv);
 	bool cmdDebugFlagEnable(int argc, const char **argv);
 	bool cmdDebugFlagDisable(int argc, const char **argv);
+	bool cmdClearLog(int argc, const char **argv);
 	bool cmdExecFile(int argc, const char **argv);
 
 #ifndef USE_TEXT_CONSOLE_FOR_DEBUGGER


### PR DESCRIPTION
Hello ScummVM team,

This code adds some simple command logic to the *console* version of the debugger to support clearing the debugger console using: `clear` or `cls` as an alias. 

This support was added to the GUI code (higher up the hierarchy) to provide this as a default feature to all games that might utilize the debugger.

A feature request ticket was created for this awhile back: https://bugs.scummvm.org/ticket/13386 and I've been hoping that this exists as well so I thought to contribute.