### PR TITLE
GRIM: allow user cancellation of md5 game integrity check

### DIFF
--- a/engines/grim/md5check.h
+++ b/engines/grim/md5check.h
@@ -30,6 +30,7 @@ class MD5Check {
 public:
 	static bool checkFiles();
 	static void startCheckFiles();
+	static bool userCanceled();
 	static bool advanceCheck(int *pos, int *total);
 	inline static bool advanceCheck() { return advanceCheck(NULL, NULL); }
 	static void clear();
@@ -45,6 +46,7 @@ private:
 	};
 	static bool checkMD5(const MD5Sum &sums, const char *md5);
 
+	static bool _userCanceled;
 	static bool _initted;
 	static Common::Array<MD5Sum> *_files;
 	static int _iterator;

--- a/engines/grim/md5checkdialog.cpp
+++ b/engines/grim/md5checkdialog.cpp
@@ -91,7 +91,7 @@ void MD5CheckDialog::handleTickle() {
 	_progressSliderWidget->setValue(p * 100 / t);
 	_progressSliderWidget->markAsDirty();
 
-	if (p == t) {
+	if (p == t || MD5Check::userCanceled()) {
 		setResult(_checkOk);
 		close();
 	}


### PR DESCRIPTION
Hello ScummVM devs,

This PR attempts to fix/improve a grim engine bug: https://bugs.scummvm.org/ticket/14159 where the MD5 integrity check that occurs when adding a game can take long and is not cancelable by the end user.

This change gives the end user the ability to stop between each successive MD5 check at any time and causes the integrity check to bail early with a final warning message before returning to the default ScummVM screen. 