### PR TITLE
IOS7: Defer screen edge system gestures on orientation changes

### DIFF
--- a/backends/platform/ios7/ios7_scummvm_view_controller.mm
+++ b/backends/platform/ios7/ios7_scummvm_view_controller.mm
@@ -49,7 +49,7 @@
 #if TARGET_OS_IOS
 
 - (UIRectEdge)preferredScreenEdgesDeferringSystemGestures {
-	return UIRectEdgeLeft | UIRectEdgeBottom | UIRectEdgeRight;
+	return UIRectEdgeAll;
 }
 
 - (UIInterfaceOrientation)interfaceOrientation {
@@ -111,6 +111,9 @@
 		UIInterfaceOrientation orientationAfter = [self interfaceOrientation];
 		if (orientationAfter != UIInterfaceOrientationUnknown) {
 			[self setCurrentOrientation:orientationAfter];
+			if (@available(iOS 11.0, *)) {
+				[self setNeedsUpdateOfScreenEdgesDeferringSystemGestures];
+			}
 		}
 	}];
 }


### PR DESCRIPTION
The system gestures on screen edges took precedence over the tap gestures again after screen rotations.
Call function setNeedsUpdateOfScreenEdgesDeferringSystemGestures on orientation changes to notify the system that it needs to read the edges from the view controller’s
preferredScreenEdgesDeferringSystemGestures property again.

Defer system gestures on all edges since the top changes when rotating the device.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
