### PR TITLE
GUI: Fix usage of dummy autosave in empty autosave slot

### DIFF
--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -636,7 +636,7 @@ void SaveLoadChooserSimple::updateSelection(bool redraw) {
 		if (!_saveList[selItem].getLocked() && desc.getSaveSlot() >= 0 && !desc.getDescription().empty())
 			_saveList[selItem] = desc;
 
-		isDeletable = desc.getDeletableFlag() && _delSupport;
+		isDeletable = _saveList[selItem].getDeletableFlag() && _delSupport;
 		isWriteProtected = desc.getWriteProtectedFlag() ||
 			_saveList[selItem].getWriteProtectedFlag();
 		isLocked = desc.getLocked();
@@ -1159,10 +1159,10 @@ void SaveLoadChooserGrid::updateSaves() {
 		} else {
 			curButton.button->setGfx(kThumbnailWidth, kThumbnailHeight2, 0, 0, 0);
 		}
-		curButton.description->setLabel(Common::U32String(Common::String::format("%d. ", saveSlot)) + desc.getDescription());
+		curButton.description->setLabel(Common::U32String(Common::String::format("%d. ", saveSlot)) + _saveList[i].getDescription());
 
 		Common::U32String tooltip(_("Name: "));
-		tooltip += desc.getDescription();
+		tooltip += _saveList[i].getDescription();
 
 		if (_saveDateSupport) {
 			const Common::U32String &saveDate = desc.getSaveDate();
@@ -1191,7 +1191,9 @@ void SaveLoadChooserGrid::updateSaves() {
 		// In save mode we disable the button, when it's write protected.
 		// TODO: Maybe we should not display it at all then?
 		// We also disable and description the button if slot is locked
-		if ((_saveMode && desc.getWriteProtectedFlag()) || desc.getLocked()) {
+		isWriteProtected = desc.getWriteProtectedFlag() ||
+			_saveList[i].getWriteProtectedFlag();
+		if ((_saveMode && isWriteProtected) || desc.getLocked()) {
 			curButton.button->setEnabled(false);
 		} else {
 			curButton.button->setEnabled(true);

--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -1191,7 +1191,7 @@ void SaveLoadChooserGrid::updateSaves() {
 		// In save mode we disable the button, when it's write protected.
 		// TODO: Maybe we should not display it at all then?
 		// We also disable and description the button if slot is locked
-		isWriteProtected = desc.getWriteProtectedFlag() ||
+		bool isWriteProtected = desc.getWriteProtectedFlag() ||
 			_saveList[i].getWriteProtectedFlag();
 		if ((_saveMode && isWriteProtected) || desc.getLocked()) {
 			curButton.button->setEnabled(false);

--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -1145,6 +1145,8 @@ void SaveLoadChooserGrid::hideButtons() {
 void SaveLoadChooserGrid::updateSaves() {
 	hideButtons();
 
+	bool isWriteProtected = false;
+
 	for (uint i = _curPage * _entriesPerPage, curNum = 0; i < _saveList.size() && curNum < _entriesPerPage; ++i, ++curNum) {
 		const uint saveSlot = _saveList[i].getSaveSlot();
 
@@ -1191,7 +1193,7 @@ void SaveLoadChooserGrid::updateSaves() {
 		// In save mode we disable the button, when it's write protected.
 		// TODO: Maybe we should not display it at all then?
 		// We also disable and description the button if slot is locked
-		bool isWriteProtected = desc.getWriteProtectedFlag() ||
+		isWriteProtected = desc.getWriteProtectedFlag() ||
 			_saveList[i].getWriteProtectedFlag();
 		if ((_saveMode && isWriteProtected) || desc.getLocked()) {
 			curButton.button->setEnabled(false);


### PR DESCRIPTION
This PR seeks to clean up a few anomalies related to setting up an empty autosave slot in the Save dialog.

The dummy autosave exists to write protect an otherwise empty autosave slot, and as a bonus, also identifies the autosave slot. This is achieved by accessing the dummy autosave settings stored in the _saveList array.

Currently, this approach is only applied when setting the Save button in List View.

Other aspects of an empty autosave slot, such as the Delete button (List View) and the autosave button (Grid View), are currently set up using a less consistent approach.

This results in most engines displaying these anomalies in the Save dialog:
- in List View, the (empty) autosave slot’s Delete button is enabled, but, if selected, does nothing except launch the Delete Confirmation dialog.
- in Grid View, the empty autosave button is identified only by its slot number, though, if selected, the Savename Dialog launches and displays the dummy autosave name.
- in Grid View, the autosave button is enabled, allowing user access to the empty autosave slot.

We fix these issues by redirecting the relevant calls for getWriteProtectedFlag(), getDeletableFlag() and getDescription() to target the correct dummy autosave settings stored in the _saveList array.

Since the changes are minimal, I’ve included them all in a single commit.

Edit: I failed to define the isWriteProtected variable type initially, then reverted that change to match how it's initialized and used in updateSelection().
Unfortunately, I'm unable to squash these extra commits into the original commit without closing this PR and starting over, so, if necessary, please do so on my behalf. Thanks..

