### PR TITLE
SCUMM: [RFC, don't merge yet] Change heuristic for identifying Indy 3 Mac sound (bug #14663)

### DIFF
--- a/engines/scumm/sound.cpp
+++ b/engines/scumm/sound.cpp
@@ -529,13 +529,18 @@ void Sound::triggerSound(int soundID) {
 			warning("Scumm::Sound::triggerSound: encountered audio resource with chunk type 'SOUN' and sound type %d", type);
 		}
 	}
-	else if ((_vm->_game.platform == Common::kPlatformMacintosh) && (_vm->_game.id == GID_INDY3) && READ_BE_UINT16(ptr + 8) == 0x1C) {
+	else if ((_vm->_game.platform == Common::kPlatformMacintosh) && (_vm->_game.id == GID_INDY3) && ptr[4] != 0x7F) {
 		// Sound format as used in Indy3 EGA Mac.
 		// It seems to be closely related to the Amiga format, see player_v3a.cpp
+		//
+		// We assume that if byte 5 is 0x7F, it's music because that's
+		// where the priority of the track is stored, and it's always
+		// that value. See player_v2.cpp
+		//
 		// The following is known:
 		// offset 0, 16 LE: total size
 		// offset 2-7: ?
-		// offset 8, 16BE: offset to sound data (0x1C = 28 -> header size 28?)
+		// offset 8, 16BE: offset to sound data (usually 0x1C = 28 -> header size 28?)
 		// offset 10-11: ? another offset, maybe related to looping?
 		// offset 12, 16BE: size of sound data
 		// offset 14-15: ? often the same as 12-13: maybe loop size/end?


### PR DESCRIPTION
This is an attempt at fixing https://bugs.scummvm.org/ticket/14663

Note that it refers to the original 16 color Macintosh version. The one sold these days on Steam is a much later port of the VGA version, as far as I know.

The problem is that we're trying to identify what is a digitized sound (and not a piece of music) in the Macintosh version of Indiana Jones and the Last Crusade by looking at values in a barely understood header, and this value turns out not to be identical in all sounds. One exception (and perhaps the only one?) is the sound used when pouring liquids, e.g. when loosening the torch in the Venice sewers, or when filling the beer stein in the castle Brunwald kitchen.

So here I'm instead trying to look for a value that appears to be constant for all music in the game, and if it's anything different it's a digitized sound. The scary thing is that this value is within one of the unknown parts of the audio header, so I don't know if it's just luck that it seems to work.

Note that I have not played through the whole game with this change. I'm still a bit weary of it from playing through it to test the Macintosh GUI.

I do not own the EGA version, so I can't compare. But I believe it uses synthesized sound effects, not digitized ones?