### PR TITLE
COMMON: Avoid Quicktime parsing crash on early EOF

### DIFF
--- a/common/formats/quicktime.cpp
+++ b/common/formats/quicktime.cpp
@@ -181,6 +181,9 @@ int QuickTimeParser::readDefault(Atom atom) {
 
 	a.offset = atom.offset;
 
+	if (_fd->eos() || _fd->err() || (_fd->pos() == _fd->size()))
+		return -1;
+
 	while(((total_size + 8) < atom.size) && !_fd->eos() && _fd->pos() < _fd->size() && !err) {
 		a.size = atom.size;
 		a.type = 0;
@@ -231,6 +234,9 @@ int QuickTimeParser::readDefault(Atom atom) {
 		} else {
 			uint32 start_pos = _fd->pos();
 			err = (this->*_parseTable[i].func)(a);
+
+			if (!err && (_fd->eos() || _fd->err()))
+				err = -1;
 
 			uint32 left = a.size - _fd->pos() + start_pos;
 

--- a/test/common/formats/quicktime.h
+++ b/test/common/formats/quicktime.h
@@ -1,0 +1,83 @@
+#include <cxxtest/TestSuite.h>
+#include "common/util.h"
+#include "common/formats/quicktime.h"
+
+static const byte VALID_MOOV_DATA[] = { // a minimally 'correct' quicktime file.
+	// size				'moov'					size				'mdat'
+	0x0, 0x0, 0x0, 0x8, 0x6d, 0x6f, 0x6f, 0x76, 0x0, 0x0, 0x0, 0x8, 0x6d, 0x64, 0x61, 0x74
+};
+
+static const byte VALID_MHDR_DATA[] = { // a 'correct' quicktime file with a header
+	// size	(incl mvhd)	'moov'
+	0x0, 0x0, 0x0, 0x74, 0x6d, 0x6f, 0x6f, 0x76,
+	//size (27*4)		'mvhd'					vers  3bytes flags
+	0x0, 0x0, 0x0, 0x6c, 0x6d, 0x76, 0x68, 0x64, 0x00, 0xff, 0xff, 0xff,
+	// creation				modification			timescale (60?)		length (999 * 60)+ 1
+	0x65, 0x52, 0xef, 0x5b, 0x65, 0x52, 0xef, 0x5b, 0x0, 0x0, 0x0, 0x3c, 0x0, 0x0, 0xea, 0x25,
+	// preferred scale, vol, 		[10 bytes reserved]
+	0x0, 0x0, 0x0, 0x1, 0x0, 0x10, 0,0,0,0,0,0,0,0,0,0,
+	// display matrix, mostly ignored by parser except xMod (0x8000) and yMod (0xa000)
+	0x0, 0x0, 0x80, 0x0, 0,0,0,0,0,0,0,0,0,0,0,0, 0x0, 0x0, 0xa0, 0x0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+	// 7 more 32-bit values
+	0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+	// size				'mdat'
+	0x0, 0x0, 0x0, 0x8, 0x6d, 0x64, 0x61, 0x74
+};
+
+
+class QuickTimeTestParser : public Common::QuickTimeParser {
+public:
+	uint32 getDuration() const { return _duration; }
+	const Common::Rational &getScaleFactorX() const { return _scaleFactorX; }
+	const Common::Rational &getScaleFactorY() const { return _scaleFactorY; }
+	const Common::Array<Track *> &getTracks() const { return _tracks; }
+
+	SampleDesc *readSampleDesc(Track *track, uint32 format, uint32 descSize) override {
+		return nullptr;
+	}
+};
+
+class QuicktimeParserTestSuite : public CxxTest::TestSuite {
+public:
+	void test_streamAtEOS() {
+		QuickTimeTestParser parser;
+		const byte data[] = "";
+		Common::MemoryReadStream stream(data, sizeof(data));
+		stream.readByte(); // read the null char
+		bool result = parser.parseStream(&stream, DisposeAfterUse::NO);
+		TS_ASSERT(!result);
+	}
+
+	void test_streamInvalid() {
+		QuickTimeTestParser parser;
+		const byte data[] = "not a moov";
+		Common::MemoryReadStream stream(data, sizeof(data));
+		bool result = parser.parseStream(&stream, DisposeAfterUse::NO);
+		TS_ASSERT(!result);
+	}
+
+	void test_moov() {
+		QuickTimeTestParser parser;
+		Common::MemoryReadStream stream(VALID_MOOV_DATA, sizeof(VALID_MOOV_DATA));
+		bool result = parser.parseStream(&stream, DisposeAfterUse::NO);
+		TS_ASSERT(result);
+	}
+
+	void test_mhdr() {
+		QuickTimeTestParser parser;
+		Common::MemoryReadStream stream(VALID_MHDR_DATA, sizeof(VALID_MHDR_DATA));
+		bool result = parser.parseStream(&stream, DisposeAfterUse::NO);
+		TS_ASSERT(result);
+		TS_ASSERT_EQUALS(parser.getDuration(), 999*60 + 1);
+		TS_ASSERT_EQUALS(parser.getScaleFactorX(), Common::Rational(0x10000, 0x8000));
+		TS_ASSERT_EQUALS(parser.getScaleFactorY(), Common::Rational(0x10000, 0xa000));
+	}
+
+	void test_mhdrEarlyEOF() {
+		QuickTimeTestParser parser;
+		Common::MemoryReadStream stream(VALID_MHDR_DATA, sizeof(VALID_MHDR_DATA) - 10);
+		bool result = parser.parseStream(&stream, DisposeAfterUse::NO);
+		TS_ASSERT(!result);
+	}
+
+};

--- a/test/module.mk
+++ b/test/module.mk
@@ -5,7 +5,7 @@
 #
 ######################################################################
 
-TESTS        := $(srcdir)/test/common/*.h $(srcdir)/test/audio/*.h $(srcdir)/test/math/*.h $(srcdir)/test/image/*.h
+TESTS        := $(srcdir)/test/common/*.h $(srcdir)/test/common/formats/*.h $(srcdir)/test/audio/*.h $(srcdir)/test/math/*.h $(srcdir)/test/image/*.h
 TEST_LIBS    :=
 
 ifdef POSIX


### PR DESCRIPTION
In parseStream, atom.size is initailized to uint32 max.  If the loop in readDefault then never executes because the stream has hit EOF, that size is passed as-is to seek.  This can cause a crash eg in SeekableSubReadStream because of an int overflow.

If nothing has been read just skip seeking at the end of readDefault. parseStream will correctly return false in this case as no MOOV will be found.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
