### PR TITLE
GRAPHICS: Remove use of TransparentSurface in MacGUI code

### DIFF
--- a/engines/wage/guiborders.cpp
+++ b/engines/wage/guiborders.cpp
@@ -53,6 +53,8 @@ namespace Wage {
 // to print out similar pictures, use
 //   bmpDecoder.getSurface()->debugPrint(0, 0, 0, 0, 0, 1);
 // in MacWindowBorder::loadBorder()
+//
+// TODO: Store these as XPM files?
 
 static const char *wage_border_inact_title[] = {
 "......................................  ..  ..  ......................................",
@@ -230,6 +232,12 @@ static const char *wage_border_act[] = {
 "..                                    ..                                    ..",
 "..................................          .................................."};
 
+static const byte wage_border_palette[] = {
+	0,   0,   0,
+	255, 255, 255,
+	255, 0,   255
+};
+
 void Gui::loadBorders() {
 	_consoleWindow->enableScrollbar(true);
 	loadBorder(_sceneWindow, wage_border_inact_title, ARRAYSIZE(wage_border_inact_title), Graphics::kWindowBorderTitle, 22);
@@ -241,25 +249,26 @@ void Gui::loadBorders() {
 void Gui::loadBorder(Graphics::MacWindow *target, const char *border[], uint height, uint32 flags, int titlePos) {
 	uint width = strlen(border[0]) / 2;
 
-	Graphics::Surface source;
-
-	source.create(width, height, Graphics::TransparentSurface::getSupportedPixelFormat());
+	Graphics::ManagedSurface *surface = new Graphics::ManagedSurface();
+	surface->create(width, height, Graphics::PixelFormat::createFormatCLUT8());
+	surface->setPalette(wage_border_palette, 0, 3);
+	surface->setTransparentColor(2);
 
 	for (uint y = 0; y < height; y++) {
-		uint32 *dst = (uint32 *)source.getBasePtr(0, y);
+		byte *dst = (byte *)surface->getBasePtr(0, y);
 
 		for (uint x = 0; x < width; x++) {
 			switch(border[y][x * 2]) {
 			case ' ':
-				*dst = MS_RGB(0, 0, 0);
+				*dst = 0;
 				break;
 
 			case '#':
-				*dst = MS_RGB(0xff, 0xff, 0xff);
+				*dst = 1;
 				break;
 
 			case '.':
-				*dst = MS_RGB(0xff, 0, 0xff);
+				*dst = 2;
 				break;
 
 			default:
@@ -269,10 +278,6 @@ void Gui::loadBorder(Graphics::MacWindow *target, const char *border[], uint hei
 			dst++;
 		}
 	}
-
-	Graphics::TransparentSurface *surface = new Graphics::TransparentSurface(source, true);
-
-	source.free();
 
 	Graphics::BorderOffsets offsets;
 	offsets.left = 16;

--- a/graphics/macgui/macwindow.cpp
+++ b/graphics/macgui/macwindow.cpp
@@ -356,7 +356,7 @@ void MacWindow::loadBorder(Common::SeekableReadStream &file, uint32 flags, Borde
 	_macBorder.loadBorder(file, flags, offsets);
 }
 
-void MacWindow::setBorder(Graphics::TransparentSurface *surface, uint32 flags, BorderOffsets offsets) {
+void MacWindow::setBorder(Graphics::ManagedSurface *surface, uint32 flags, BorderOffsets offsets) {
 	_macBorder.setBorder(surface, flags, offsets);
 }
 

--- a/graphics/macgui/macwindow.h
+++ b/graphics/macgui/macwindow.h
@@ -25,7 +25,6 @@
 #include "common/stream.h"
 
 #include "graphics/managed_surface.h"
-#include "graphics/transparent_surface.h"
 #include "graphics/nine_patch.h"
 #include "graphics/palette.h"
 #include "graphics/font.h"
@@ -332,7 +331,7 @@ public:
 	 */
 	void loadBorder(Common::SeekableReadStream &file, uint32 flags, int lo = -1, int ro = -1, int to = -1, int bo = -1);
 	void loadBorder(Common::SeekableReadStream &file, uint32 flags, BorderOffsets offsets);
-	void setBorder(Graphics::TransparentSurface *surface, uint32 flags, BorderOffsets offsets);
+	void setBorder(Graphics::ManagedSurface *surface, uint32 flags, BorderOffsets offsets);
 	void disableBorder();
 	void loadInternalBorder(uint32 flags);
 	/**

--- a/graphics/macgui/macwindowborder.h
+++ b/graphics/macgui/macwindowborder.h
@@ -26,7 +26,6 @@
 #include "common/list.h"
 
 #include "graphics/managed_surface.h"
-#include "graphics/transparent_surface.h"
 #include "graphics/primitives.h"
 
 #include "image/bmp.h"
@@ -92,7 +91,7 @@ public:
 	 * @param The border type indicated by flag
 	 * @param The title position of bmp image
 	 */
-	void addBorder(TransparentSurface *source, uint32 flags, int titlePos = 0);
+	void addBorder(ManagedSurface *source, uint32 flags, int titlePos = 0);
 
 	/**
 	 * Accessor function for the custom offsets.
@@ -154,8 +153,8 @@ public:
 	void loadBorder(Common::SeekableReadStream &file, uint32 flags, BorderOffsets offsets);
 	void loadInternalBorder(uint32 flags);
 
-	void setBorder(Graphics::TransparentSurface *surface, uint32 flags, int lo = -1, int ro = -1, int to = -1, int bo = -1);
-	void setBorder(Graphics::TransparentSurface *surface, uint32 flags, BorderOffsets offsets);
+	void setBorder(Graphics::ManagedSurface *surface, uint32 flags, int lo = -1, int ro = -1, int to = -1, int bo = -1);
+	void setBorder(Graphics::ManagedSurface *surface, uint32 flags, BorderOffsets offsets);
 private:
 	int _scrollPos, _scrollSize;
 	Common::String _title;

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -838,33 +838,23 @@ void MacWindowManager::loadDesktop() {
 		return;
 
 	Image::BitmapDecoder bmpDecoder;
-	Graphics::Surface *source;
-	_desktopBmp = new Graphics::TransparentSurface();
-
 	bmpDecoder.loadStream(*file);
-	source = bmpDecoder.getSurface()->convertTo(_desktopBmp->getSupportedPixelFormat(), bmpDecoder.getPalette());
 
-	_desktopBmp->copyFrom(*source);
+	const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 24, 16, 8, 0);
+	_desktopBmp = bmpDecoder.getSurface()->convertTo(requiredFormat_4byte, bmpDecoder.getPalette());
 
 	delete file;
-	source->free();
-	delete source;
 }
 
 void MacWindowManager::setDesktopColor(byte r, byte g, byte b) {
 	cleanupDesktopBmp();
-	_desktopBmp = new Graphics::TransparentSurface();
-	uint32 color = MS_RGB(r, g, b);
 
-	const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 0, 8, 16, 24);
-	Graphics::ManagedSurface *source = new Graphics::ManagedSurface();
-	source->create(10, 10, requiredFormat_4byte);
-	Common::Rect area = source->getBounds();
-	source->fillRect(area, color);
+	const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 24, 16, 8, 0);
+	uint32 color = requiredFormat_4byte.RGBToColor(r, g, b);
 
-	_desktopBmp->copyFrom(*source);
-	source->free();
-	delete source;
+	_desktopBmp = new Graphics::Surface();
+	_desktopBmp->create(10, 10, requiredFormat_4byte);
+	_desktopBmp->fillRect(Common::Rect(10, 10), color);
 }
 
 void MacWindowManager::drawDesktop() {

--- a/graphics/macgui/macwindowmanager.h
+++ b/graphics/macgui/macwindowmanager.h
@@ -424,7 +424,7 @@ private:
 	void adjustDimensions(const Common::Rect &clip, const Common::Rect &dims, int &adjWidth, int &adjHeight);
 
 public:
-	TransparentSurface *_desktopBmp;
+	Surface *_desktopBmp;
 	ManagedSurface *_desktop;
 	PixelFormat _pixelformat;
 

--- a/graphics/nine_patch.h
+++ b/graphics/nine_patch.h
@@ -51,8 +51,7 @@
 
 namespace Graphics {
 
-struct TransparentSurface;
-struct Surface;
+class ManagedSurface;
 class MacWindowManager;
 
 struct NinePatchMark {
@@ -71,27 +70,25 @@ public:
 	NinePatchSide() : _fix(0) { _m.clear(); }
 	~NinePatchSide();
 
-	bool init(Graphics::TransparentSurface *bmp, bool vertical, int titlePos = 0, int *titleIndex = nullptr);
+	bool init(Graphics::ManagedSurface *bmp, bool vertical, uint32 black, uint32 white, int titlePos = 0, int *titleIndex = nullptr);
 
 	void calcOffsets(int len, int titleIndex = 0, int titleWidth = 0);
 };
 
 class NinePatchBitmap {
-	Graphics::TransparentSurface *_bmp;
+	Graphics::ManagedSurface *_bmp;
 	NinePatchSide _h, _v;
 	Common::Rect _padding;
 	bool _destroy_bmp;
 	int _width, _height;
 	int _cached_dw, _cached_dh;
 	int _titleIndex, _titleWidth, _titlePos;
-	Common::HashMap<uint32, int> _cached_colors;
 
 public:
-	NinePatchBitmap(Graphics::TransparentSurface *bmp, bool owns_bitmap, int titlePos = 0);
+	NinePatchBitmap(Graphics::ManagedSurface *bmp, bool owns_bitmap, int titlePos = 0);
 	~NinePatchBitmap();
 
-	void blit(Graphics::Surface &target, int dx, int dy, int dw, int dh, byte *palette = NULL, int numColors = 0, MacWindowManager *wm = NULL, uint32 transColor = 0);
-	void blitClip(Graphics::Surface &target, Common::Rect clip, int dx, int dy, int dw, int dh);
+	void blit(Graphics::ManagedSurface &target, int dx, int dy, int dw, int dh, MacWindowManager *wm = NULL);
 	void modifyTitleWidth(int titleWidth);
 
 	int getWidth() { return _width; }
@@ -101,18 +98,12 @@ public:
 	int getTitleWidth() { return _titleWidth; }
 	// always call it after you calc the offset, such as after you call blit, then you will get the right offset
 	int getTitleOffset();
-	Graphics::TransparentSurface *getSource() { return _bmp; }
+	Graphics::ManagedSurface *getSource() { return _bmp; }
 	Common::Rect &getPadding() { return _padding; }
 
 private:
 
-	void drawRegions(Graphics::Surface &target, int dx, int dy, int dw, int dh);
-
-	// Assumes color is in the palette
-	byte getColorIndex(uint32 target, byte *palette);
-	uint32 grayscale(uint32 color);
-	uint32 grayscale(byte r, byte g, byte b);
-	byte closestGrayscale(uint32 color, byte* palette, int paletteLength);
+	void drawRegions(Graphics::ManagedSurface &target, int dx, int dy, int dw, int dh);
 };
 
 } // end of namespace Graphics


### PR DESCRIPTION
The NinePatch code only needed colour key transparency instead of full alpha blending, so it should be faster to use `ManagedSurface::blitFrom` with a paletted source instead of using `blendBlitFrom` and extra intermediate surfaces.

Only the WAGE engine has been tested with these changes.
