### PR TITLE
KINGDOM: Fix skipping and quitting demo movie

### DIFF
--- a/engines/kingdom/kingdom.cpp
+++ b/engines/kingdom/kingdom.cpp
@@ -55,6 +55,7 @@ KingdomGame::KingdomGame(OSystem *syst, const ADGameDescription *gameDesc) : Eng
 
 	_asPtr = nullptr;
 	_quit = false;
+	_demoMovieSkipped = false;
 	_kingartEntries = nullptr;
 
 	_tickCount = 0;
@@ -527,6 +528,9 @@ void KingdomGame::playMovie(int movieNum) {
 				case Common::EVENT_KEYDOWN:
 					if (event.kbd.keycode == Common::KEYCODE_ESCAPE) {
 						skipMovie = true;
+						if (movieNum == 54) {
+							_demoMovieSkipped = true;
+						}
 					}
 				default:
 					break;

--- a/engines/kingdom/kingdom.h
+++ b/engines/kingdom/kingdom.h
@@ -151,6 +151,7 @@ namespace Kingdom {
 		bool _iconsClosed;
 		bool _oldIconsClosed;
 		int _pMovie;
+		bool _demoMovieSkipped;
 		bool _keyActive;
 		bool _iconRedraw;
 		bool _quit;

--- a/engines/kingdom/logic.cpp
+++ b/engines/kingdom/logic.cpp
@@ -505,10 +505,12 @@ void Logic::gameHelp() {
 		// The demo isn't saving pMovie.
 		// It's obviously a bug and this behavior wasn't kept in ScummVM
 		int oldPMovie = _vm->_pMovie;
-		while(!_vm->_keyActive) {
+		_vm->_demoMovieSkipped = false;
+		while(!_vm->_keyActive && !_vm->shouldQuit() && !_vm->_demoMovieSkipped) {
 			_vm->playMovie(54);
 			_vm->fadeToBlack2();
 		}
+		_vm->_demoMovieSkipped = false;
 		_vm->_pMovie = oldPMovie;
 		_vm->_noIFScreen = false;
 		_vm->showPic(106);

--- a/engines/kingdom/logic1.cpp
+++ b/engines/kingdom/logic1.cpp
@@ -54,11 +54,13 @@ void Logic::GPL1_11() {
 		_vm->_keyActive = false;
 		_vm->_noIFScreen = true;
 		_vm->playSound(0);
-		while(!_vm->_keyActive) {
+		_vm->_demoMovieSkipped = false;
+		while(!_vm->_keyActive && !_vm->shouldQuit() && !_vm->_demoMovieSkipped) {
 			_vm->fadeToBlack2();
 			_vm->playMovie(54);
 		}
-		GPLogic1_SubSP10();
+		_vm->_demoMovieSkipped = false;
+		GPLogic1_SubSP10(); // return to main menu
 		break;
 	case 0x194:
 		// CHECKME	_QuitFlag = 2;
@@ -75,7 +77,9 @@ void Logic::GPL1_11() {
 		_vm->_cursorDrawn = false;
 		_vm->fadeToBlack2();
 		_vm->playSound(0);
+		_vm->_demoMovieSkipped = false;
 		_vm->playMovie(54);
+		_vm->_demoMovieSkipped = false;
 		GPLogic1_SubSP10();
 		break;
 	default:


### PR DESCRIPTION
The detection that the demo movie was skipped is done by the external flag _demoMovieSkipped

This is not as clean as it would be updating a reference parameter variable from within playMovie() but that would require changing the signature of playMovie and all of its calls

This should fix the issue with the demo and full game both not being able to skip the demo movie (launch the game and select "Demo" from the main menu). And in addition, quitting the game (force quitting with Alt+F4, or via the ScummVM GMM -> Quit) would soft-lock ScummVM.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
