### PR TITLE
CREATE_PROJECT: Default to C++11 and support MacPorts /opt/local/lib

### DIFF
--- a/devtools/create_project/cmake.cpp
+++ b/devtools/create_project/cmake.cpp
@@ -85,6 +85,8 @@ void CMakeProvider::createWorkspace(const BuildSetup &setup) {
 	workspace << "project(" << setup.projectDescription << ")\n\n";
 
 	workspace << R"(set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_STANDARD 11) # Globally enable C++11
+
 find_package(PkgConfig QUIET)
 include(CMakeParseArguments)
 

--- a/devtools/create_project/cmake.cpp
+++ b/devtools/create_project/cmake.cpp
@@ -176,6 +176,9 @@ if (TARGET SDL2::SDL2)
 endif()
 include_directories(${SDL2_INCLUDE_DIRS})
 
+# Explicitly support MacPorts (hopefully harmless on other platforms)
+link_directories(/opt/local/lib)
+
 )";
 
 	for (const Feature &feature : setup.features) {


### PR DESCRIPTION
Some small changes to the CMake generator to let it support macOS with libraries installed from MacPorts.

Also an adjustment to support C++11 globally in the generated CMake files.

Pushing this as a PR in case someone disagrees with the global adding of /opt/local/lib.