### PR TITLE
MTROPOLIS: Add support for 'Unit Re-Booted'

### DIFF
--- a/engines/mtropolis/boot.cpp
+++ b/engines/mtropolis/boot.cpp
@@ -1025,6 +1025,20 @@ const ManifestFile sttgsDemoWinFiles[] = {
 	{nullptr, MTFT_AUTO}
 };
 
+const ManifestFile unitWinFiles[] = {
+	{"UNIT32.EXE", MTFT_PLAYER},
+	{"DATA.MFX", MTFT_MAIN},
+	{"CURSORS.C32", MTFT_EXTENSION},
+	{"BASIC.X32", MTFT_SPECIAL},
+	{"EXTRAS.R32", MTFT_SPECIAL},
+	{nullptr, MTFT_AUTO}
+};
+
+const char *unitWinDirectories[] = {
+	"MPLUGINS",
+	nullptr
+};
+
 const Game games[] = {
 	// Obsidian - Retail - Macintosh - English
 	{
@@ -1207,6 +1221,14 @@ const Game games[] = {
 		MTBOOT_STTGS_DEMO_WIN,
 		sttgsDemoWinFiles,
 		nullptr,
+		nullptr,
+		GameDataHandlerFactory<STTGSGameDataHandler>::create
+	},
+	// Unit: Rebooted
+	{
+		MTBOOT_UNIT_REBOOTED_WIN,
+		unitWinFiles,
+		unitWinDirectories,
 		nullptr,
 		GameDataHandlerFactory<STTGSGameDataHandler>::create
 	},

--- a/engines/mtropolis/detection.cpp
+++ b/engines/mtropolis/detection.cpp
@@ -34,6 +34,7 @@ static const PlainGameDescriptor mTropolisGames[] = {
 	{"albert3", "Uncle Albert's Mysterious Island"},
 	{"spqr", "SPQR: The Empire's Darkest Hour"},
 	{"sttgs", "Star Trek: The Game Show"},
+	{"unit", "Unit: Re-Booted"},
 	{nullptr, nullptr}
 };
 

--- a/engines/mtropolis/detection.h
+++ b/engines/mtropolis/detection.h
@@ -35,6 +35,7 @@ enum MTropolisGameID {
 	GID_ALBERT3				= 5,
 	GID_SPQR				= 6,
 	GID_STTGS				= 7,
+	GID_UNIT				= 8,
 };
 
 // Boot IDs - These can be shared across different variants if the file list and other properties are identical.
@@ -68,6 +69,8 @@ enum MTropolisGameBootID {
 	MTBOOT_SPQR_RETAIL_MAC,
 
 	MTBOOT_STTGS_DEMO_WIN,
+
+	MTBOOT_UNIT_REBOOTED_WIN,
 };
 
 enum MTGameFlag {

--- a/engines/mtropolis/detection_tables.h
+++ b/engines/mtropolis/detection_tables.h
@@ -666,6 +666,25 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		MTBOOT_STTGS_DEMO_WIN,
 	},
 
+	{ // Unit: Rebooted (Music Videos)
+		{
+			"unit",
+			"",
+			{
+				// { "UNIT32.EXE", 0, "c23dccd2b7a525a9f7bb8505f7c7f2d4", 1085952 },
+				{ "DATA.MFX", 0, "9a3a0c2f11173c7af3f16d42a2b7c1b7", 194625739 },
+				AD_LISTEND
+			},
+			Common::EN_ANY,
+			Common::kPlatformWindows,
+			ADGF_UNSTABLE,
+			GUIO0()
+		},
+		GID_UNIT,
+		0,
+		MTBOOT_UNIT_REBOOTED_WIN,
+	},
+
 	{ AD_TABLE_END_MARKER, 0, 0, MTBOOT_INVALID }
 };
 

--- a/engines/mtropolis/miniscript.cpp
+++ b/engines/mtropolis/miniscript.cpp
@@ -380,7 +380,7 @@ bool MiniscriptParser::parse(const Data::MiniscriptProgram &program, Common::Sha
 	}
 
 	Common::MemoryReadStreamEndian stream(&program.bytecode[0], program.bytecode.size(), program.isBigEndian);
-	Data::DataReader reader(0, stream, program.projectFormat);
+	Data::DataReader reader(0, stream, program.projectFormat, program.projectEngineVersion);
 
 	Common::Array<InstructionData> rawInstructions;
 	rawInstructions.resize(program.numOfInstructions);
@@ -450,7 +450,7 @@ bool MiniscriptParser::parse(const Data::MiniscriptProgram &program, Common::Sha
 			dataLoc = &rawInstruction.contents[0];
 
 		Common::MemoryReadStreamEndian instrContentsStream(static_cast<const byte *>(dataLoc), rawInstruction.contents.size(), reader.isBigEndian());
-		Data::DataReader instrContentsReader(0, instrContentsStream, reader.getProjectFormat());
+		Data::DataReader instrContentsReader(0, instrContentsStream, reader.getProjectFormat(), reader.getProjectEngineVersion());
 
 		if (!rawInstruction.instrFactory->create(&programData[baseOffset + rawInstruction.pdPosition], rawInstruction.flags, instrContentsReader, miniscriptInstructions[i], parserFeedback)) {
 			// Destroy any already-created instructions

--- a/engines/mtropolis/mtropolis.cpp
+++ b/engines/mtropolis/mtropolis.cpp
@@ -161,21 +161,22 @@ Common::Error MTropolisEngine::run() {
 			preferredHeight = 360;
 			HackSuites::addObsidianImprovedWidescreen(*_gameDescription, _runtime->getHacks());
 		}
-	}
-
-	if (_gameDescription->gameID == GID_MTI) {
+	} else if (_gameDescription->gameID == GID_MTI) {
 		preferredWidth = 640;
 		preferredHeight = 480;
 		preferredColorDepthMode = kColorDepthMode8Bit;
 		enhancedColorDepthMode = kColorDepthMode32Bit;
 
 		HackSuites::addMTIQuirks(*_gameDescription, _runtime->getHacks());
-	}
-
-	if (_gameDescription->gameID == GID_SPQR) {
+	} else if (_gameDescription->gameID == GID_SPQR) {
 		preferredWidth = 640;
 		preferredHeight = 480;
 		preferredColorDepthMode = kColorDepthMode8Bit;
+		enhancedColorDepthMode = kColorDepthMode32Bit;
+	} else if (_gameDescription->gameID == GID_UNIT) {
+		preferredWidth = 640;
+		preferredHeight = 480;
+		preferredColorDepthMode = kColorDepthMode32Bit;
 		enhancedColorDepthMode = kColorDepthMode32Bit;
 	}
 

--- a/engines/mtropolis/plugin/standard_data.cpp
+++ b/engines/mtropolis/plugin/standard_data.cpp
@@ -32,7 +32,7 @@ CursorModifier::CursorModifier() : haveRemoveWhen(false) {
 }
 
 DataReadErrorCode CursorModifier::load(PlugIn &plugIn, const PlugInModifier &prefix, DataReader &reader) {
-	if (prefix.plugInRevision != 0 && prefix.plugInRevision != 1)
+	if (prefix.plugInRevision != 0 && prefix.plugInRevision != 1 && prefix.plugInRevision != 2)
 		return kDataReadErrorUnsupportedRevision;
 
 	if (!applyWhen.load(reader))

--- a/engines/mtropolis/runtime.h
+++ b/engines/mtropolis/runtime.h
@@ -2522,6 +2522,7 @@ private:
 	Common::Array<LabelTree> _labelTree;
 	Common::Array<LabelSuperGroup> _labelSuperGroups;
 	Data::ProjectFormat _projectFormat;
+	Data::ProjectEngineVersion _projectEngineVersion;
 	bool _isBigEndian;
 
 	Common::Array<AssetDesc *> _assetsByID;


### PR DESCRIPTION
_Unit: Re-Booted_ is [music CD](https://en.wikipedia.org/wiki/Unit_(album)) with a data partition which includes an
mTropolis-based music video program.

This is not much of a game, but uses some variants of the headers and data
structures which are nice to support and should help with future projects.

Known issues:
* Palette for the menu is a bit broken, needs some work
* The bottom-most button in the menu still crashes trying to load a PlugInModifier version 2001