### PR TITLE
GOB: Use ADGF_CD flag for gob games + general cleanup

### DIFF
--- a/engines/gob/detection/tables.h
+++ b/engines/gob/detection/tables.h
@@ -31,9 +31,7 @@ using namespace Common;
 // Game IDs and proper names
 static const PlainGameDescriptor gobGames[] = {
 	{"gob1", "Gobliiins"},
-	{"gob1cd", "Gobliiins CD"},
 	{"gob2", "Gobliins 2"},
-	{"gob2cd", "Gobliins 2 CD"},
 	{"ween", "Ween: The Prophecy"},
 	{"bargon", "Bargon Attack"},
 	{"babayaga", "Once Upon A Time: Baba Yaga"},
@@ -41,7 +39,6 @@ static const PlainGameDescriptor gobGames[] = {
 	{"littlered", "Once Upon A Time: Little Red Riding Hood"},
 	{"onceupon", "Once Upon A Time"},
 	{"gob3", "Goblins Quest 3"},
-	{"gob3cd", "Goblins Quest 3 CD"},
 	{"crousti", "Croustibat"},
 	{"lit1", "Lost in Time Part 1"},
 	{"lit2", "Lost in Time Part 2"},

--- a/engines/gob/detection/tables_fallback.h
+++ b/engines/gob/detection/tables_fallback.h
@@ -41,7 +41,7 @@ static const GOBGameDescription fallbackDescs[] = {
 	},
 	{ //1
 		{
-			"gob1cd",
+			"gob1",
 			"unknown",
 			AD_ENTRY1(0, 0),
 			UNK_LANG,
@@ -69,7 +69,7 @@ static const GOBGameDescription fallbackDescs[] = {
 	},
 	{ //3
 		{
-			"gob2mac",
+			"gob2",
 			"unknown",
 			AD_ENTRY1(0, 0),
 			UNK_LANG,
@@ -83,7 +83,7 @@ static const GOBGameDescription fallbackDescs[] = {
 	},
 	{ //4
 		{
-			"gob2cd",
+			"gob2",
 			"unknown",
 			AD_ENTRY1(0, 0),
 			UNK_LANG,
@@ -125,7 +125,7 @@ static const GOBGameDescription fallbackDescs[] = {
 	},
 	{ //7
 		{
-			"gob3cd",
+			"gob3",
 			"unknown",
 			AD_ENTRY1(0, 0),
 			UNK_LANG,

--- a/engines/gob/detection/tables_fascin.h
+++ b/engines/gob/detection/tables_fascin.h
@@ -119,7 +119,7 @@
 {
 	{
 		"fascination",
-		"CD Version (Censored)",
+		"CD (Censored)",
 		AD_ENTRY1s("intro.stk", "9c61e9c22077f72921f07153e37ccf01", 545953),
 		EN_ANY,
 		kPlatformDOS,
@@ -133,7 +133,7 @@
 {
 	{
 		"fascination",
-		"CD Version (Censored)",
+		"CD (Censored)",
 		AD_ENTRY1s("intro.stk", "9c61e9c22077f72921f07153e37ccf01", 545953),
 		FR_FRA,
 		kPlatformDOS,
@@ -147,7 +147,7 @@
 {
 	{
 		"fascination",
-		"CD Version (Censored)",
+		"CD (Censored)",
 		AD_ENTRY1s("intro.stk", "9c61e9c22077f72921f07153e37ccf01", 545953),
 		DE_DEU,
 		kPlatformDOS,
@@ -161,7 +161,7 @@
 {
 	{
 		"fascination",
-		"CD Version (Censored)",
+		"CD (Censored)",
 		AD_ENTRY1s("intro.stk", "9c61e9c22077f72921f07153e37ccf01", 545953),
 		IT_ITA,
 		kPlatformDOS,
@@ -175,7 +175,7 @@
 {
 	{
 		"fascination",
-		"CD Version (Censored)",
+		"CD (Censored)",
 		AD_ENTRY1s("intro.stk", "9c61e9c22077f72921f07153e37ccf01", 545953),
 		ES_ESP,
 		kPlatformDOS,

--- a/engines/gob/detection/tables_fascin.h
+++ b/engines/gob/detection/tables_fascin.h
@@ -123,7 +123,7 @@
 		AD_ENTRY1s("intro.stk", "9c61e9c22077f72921f07153e37ccf01", 545953),
 		EN_ANY,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO1(GUIO_NOSUBTITLES)
 	},
 	kGameTypeFascination,
@@ -137,7 +137,7 @@
 		AD_ENTRY1s("intro.stk", "9c61e9c22077f72921f07153e37ccf01", 545953),
 		FR_FRA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO1(GUIO_NOSUBTITLES)
 	},
 	kGameTypeFascination,
@@ -151,7 +151,7 @@
 		AD_ENTRY1s("intro.stk", "9c61e9c22077f72921f07153e37ccf01", 545953),
 		DE_DEU,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO1(GUIO_NOSUBTITLES)
 	},
 	kGameTypeFascination,
@@ -165,7 +165,7 @@
 		AD_ENTRY1s("intro.stk", "9c61e9c22077f72921f07153e37ccf01", 545953),
 		IT_ITA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO1(GUIO_NOSUBTITLES)
 	},
 	kGameTypeFascination,
@@ -179,7 +179,7 @@
 		AD_ENTRY1s("intro.stk", "9c61e9c22077f72921f07153e37ccf01", 545953),
 		ES_ESP,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO1(GUIO_NOSUBTITLES)
 	},
 	kGameTypeFascination,

--- a/engines/gob/detection/tables_gob1.h
+++ b/engines/gob/detection/tables_gob1.h
@@ -90,12 +90,12 @@
 
 { // Provided by pykman in the forums.
 	{
-		"gob1cd",
-		"Polish",
+		"gob1",
+		"CD",
 		AD_ENTRY1s("intro.stk", "97d2443948b2e367cf567fe7e101f5f2", 4049267),
-		UNK_LANG,
+		PL_POL,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob1,
@@ -104,12 +104,12 @@
 },
 { // CD 1.000 version.
 	{
-		"gob1cd",
-		"v1.000",
+		"gob1",
+		"CD v1.000",
 		AD_ENTRY1("intro.stk", "2fbf4b5b82bbaee87eb45d4404c28998"),
 		EN_USA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob1,
@@ -118,12 +118,12 @@
 },
 { // CD 1.000 version.
 	{
-		"gob1cd",
-		"v1.000",
+		"gob1",
+		"CD v1.000",
 		AD_ENTRY1("intro.stk", "2fbf4b5b82bbaee87eb45d4404c28998"),
 		DE_DEU,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob1,
@@ -132,12 +132,12 @@
 },
 { // CD 1.000 version.
 	{
-		"gob1cd",
-		"v1.000",
+		"gob1",
+		"CD v1.000",
 		AD_ENTRY1("intro.stk", "2fbf4b5b82bbaee87eb45d4404c28998"),
 		FR_FRA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob1,
@@ -146,12 +146,12 @@
 },
 { // CD 1.000 version.
 	{
-		"gob1cd",
-		"v1.000",
+		"gob1",
+		"CD v1.000",
 		AD_ENTRY1("intro.stk", "2fbf4b5b82bbaee87eb45d4404c28998"),
 		IT_ITA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob1,
@@ -160,12 +160,12 @@
 },
 { // CD 1.000 version.
 	{
-		"gob1cd",
-		"v1.000",
+		"gob1",
+		"CD v1.000",
 		AD_ENTRY1("intro.stk", "2fbf4b5b82bbaee87eb45d4404c28998"),
 		ES_ESP,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob1,
@@ -174,12 +174,12 @@
 },
 { // CD 1.02 version. Multilingual
 	{
-		"gob1cd",
-		"v1.02",
+		"gob1",
+		"CD v1.02",
 		AD_ENTRY1("intro.stk", "8bd873137b6831c896ee8ad217a6a398"),
 		EN_USA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob1,
@@ -188,12 +188,12 @@
 },
 { // CD 1.02 version. Multilingual
 	{
-		"gob1cd",
-		"v1.02",
+		"gob1",
+		"CD v1.02",
 		AD_ENTRY1("intro.stk", "8bd873137b6831c896ee8ad217a6a398"),
 		DE_DEU,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob1,
@@ -202,12 +202,12 @@
 },
 { // CD 1.02 version. Multilingual
 	{
-		"gob1cd",
-		"v1.02",
+		"gob1",
+		"CD v1.02",
 		AD_ENTRY1("intro.stk", "8bd873137b6831c896ee8ad217a6a398"),
 		FR_FRA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob1,
@@ -216,12 +216,12 @@
 },
 { // CD 1.02 version. Multilingual
 	{
-		"gob1cd",
-		"v1.02",
+		"gob1",
+		"CD v1.02",
 		AD_ENTRY1("intro.stk", "8bd873137b6831c896ee8ad217a6a398"),
 		IT_ITA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob1,
@@ -230,12 +230,12 @@
 },
 { // CD 1.02 version. Multilingual
 	{
-		"gob1cd",
-		"v1.02",
+		"gob1",
+		"CD v1.02",
 		AD_ENTRY1("intro.stk", "8bd873137b6831c896ee8ad217a6a398"),
 		ES_ESP,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob1,
@@ -244,12 +244,12 @@
 },
 { // Supplied by goodoldgeorg in bug report #4375
 	{
-		"gob1cd",
-		"v1.02",
+		"gob1",
+		"CD v1.02",
 		AD_ENTRY1s("intro.stk", "40d4a53818f4fce3f5997d02c3fafe73", 4049248),
 		HU_HUN,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob1,
@@ -258,12 +258,12 @@
 },
 { // Supplied by goodoldgeorg in bug report #4375
 	{
-		"gob1cd",
-		"v1.02",
+		"gob1",
+		"CD v1.02",
 		AD_ENTRY1s("intro.stk", "40d4a53818f4fce3f5997d02c3fafe73", 4049248),
 		FR_FRA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob1,
@@ -272,12 +272,12 @@
 },
 { // Supplied by goodoldgeorg in bug report #4375
 	{
-		"gob1cd",
-		"v1.02",
+		"gob1",
+		"CD v1.02",
 		AD_ENTRY1s("intro.stk", "40d4a53818f4fce3f5997d02c3fafe73", 4049248),
 		ES_ESP,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob1,
@@ -286,12 +286,12 @@
 },
 { // Supplied by goodoldgeorg in bug report #4375
 	{
-		"gob1cd",
-		"v1.02",
+		"gob1",
+		"CD v1.02",
 		AD_ENTRY1s("intro.stk", "40d4a53818f4fce3f5997d02c3fafe73", 4049248),
 		IT_ITA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob1,
@@ -402,12 +402,12 @@
 
 { // Supplied by Svipur in bug report #14531 (Adapted to CD by A.P.$lasH)
 	{
-		"gob1cd",
-		"",
+		"gob1",
+		"CD adaptatiton",
 		AD_ENTRY1s("intro.stk", "dd3975b66f37d2f360f34ee1f83041f1", 3231773),
 		RU_RUS,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob1,

--- a/engines/gob/detection/tables_gob2.h
+++ b/engines/gob/detection/tables_gob2.h
@@ -157,12 +157,12 @@
 
 {
 	{
-		"gob2cd",
-		"v1.000",
+		"gob2",
+		"CD v1.000",
 		AD_ENTRY1("intro.stk", "9de5fbb41cf97182109e5fecc9d90347"),
 		EN_USA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob2,
@@ -171,12 +171,12 @@
 },
 { // Supplied by pykman in bug report #5365
 	{
-		"gob2cd",
-		"v2.01 Polish",
+		"gob2",
+		"CD v2.01",
 		AD_ENTRY1s("intro.stk", "3025f05482b646c18c2c79c615a3a1df", 5011726),
-		UNK_LANG,
+		PL_POL,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob2,
@@ -185,12 +185,12 @@
 },
 {
 	{
-		"gob2cd",
-		"v2.01",
+		"gob2",
+		"CD v2.01",
 		AD_ENTRY1("intro.stk", "24a6b32757752ccb1917ce92fd7c2a04"),
 		EN_ANY,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob2,
@@ -199,12 +199,12 @@
 },
 {
 	{
-		"gob2cd",
-		"v2.01",
+		"gob2",
+		"CD v2.01",
 		AD_ENTRY1("intro.stk", "24a6b32757752ccb1917ce92fd7c2a04"),
 		DE_DEU,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob2,
@@ -213,12 +213,12 @@
 },
 {
 	{
-		"gob2cd",
-		"v2.01",
+		"gob2",
+		"CD v2.01",
 		AD_ENTRY1("intro.stk", "24a6b32757752ccb1917ce92fd7c2a04"),
 		FR_FRA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob2,
@@ -227,12 +227,12 @@
 },
 {
 	{
-		"gob2cd",
-		"v2.01",
+		"gob2",
+		"CD v2.01",
 		AD_ENTRY1("intro.stk", "24a6b32757752ccb1917ce92fd7c2a04"),
 		IT_ITA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob2,
@@ -241,12 +241,12 @@
 },
 {
 	{
-		"gob2cd",
-		"v2.01",
+		"gob2",
+		"CD v2.01",
 		AD_ENTRY1("intro.stk", "24a6b32757752ccb1917ce92fd7c2a04"),
 		ES_ESP,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob2,
@@ -255,12 +255,12 @@
 },
 { // Hebrew fan translation
 	{
-		"gob2cd",
-		"v2.01",
+		"gob2",
+		"CD v2.01",
 		AD_ENTRY1s("intro.stk", "b768039f8d0a12c39ca28dcd33d584ba", 4696209),
 		HE_ISR,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob2,
@@ -269,12 +269,12 @@
 },
 { // Supplied by goodoldgeorg in bug report #4375
 	{
-		"gob2cd",
-		"v1.02",
+		"gob2",
+		"CD v1.02",
 		AD_ENTRY1s("intro.stk", "5ba85a4769a1ab03a283dd694588d526", 5006236),
 		HU_HUN,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob2,
@@ -283,12 +283,12 @@
 },
 { // Supplied by goodoldgeorg in bug report #4375
 	{
-		"gob2cd",
-		"v1.02",
+		"gob2",
+		"CD v1.02",
 		AD_ENTRY1s("intro.stk", "5ba85a4769a1ab03a283dd694588d526", 5006236),
 		FR_FRA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob2,
@@ -297,12 +297,12 @@
 },
 { // Supplied by goodoldgeorg in bug report #4375
 	{
-		"gob2cd",
-		"v1.02",
+		"gob2",
+		"CD v1.02",
 		AD_ENTRY1s("intro.stk", "5ba85a4769a1ab03a283dd694588d526", 5006236),
 		DE_DEU,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob2,
@@ -311,12 +311,12 @@
 },
 { // Supplied by goodoldgeorg in bug report #4375
 	{
-		"gob2cd",
-		"v1.02",
+		"gob2",
+		"CD v1.02",
 		AD_ENTRY1s("intro.stk", "5ba85a4769a1ab03a283dd694588d526", 5006236),
 		ES_ESP,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob2,
@@ -325,12 +325,12 @@
 },
 { // Supplied by goodoldgeorg in bug report #4375
 	{
-		"gob2cd",
-		"v1.02",
+		"gob2",
+		"CD v1.02",
 		AD_ENTRY1s("intro.stk", "5ba85a4769a1ab03a283dd694588d526", 5006236),
 		IT_ITA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob2,

--- a/engines/gob/detection/tables_gob3.h
+++ b/engines/gob/detection/tables_gob3.h
@@ -348,12 +348,12 @@
 
 {
 	{
-		"gob3cd",
-		"v1.000",
+		"gob3",
+		"CD v1.000",
 		AD_ENTRY1("intro.stk", "6f2c226c62dd7ab0ab6f850e89d3fc47"),
 		EN_USA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob3,
@@ -362,12 +362,12 @@
 },
 { // Supplied by pykman in bug report #5365
 	{
-		"gob3cd",
-		"v1.02 Polish",
+		"gob3",
+		"CD v1.02",
 		AD_ENTRY1s("intro.stk", "978afddcac81bb95a04757b61f78471c", 619825),
-		UNK_LANG,
+		PL_POL,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob3,
@@ -376,12 +376,12 @@
 },
 { // Supplied by paul66 and noizert in bug reports #3045 and #3137
 	{
-		"gob3cd",
-		"v1.02",
+		"gob3",
+		"CD v1.02",
 		AD_ENTRY1("intro.stk", "c3e9132ea9dc0fb866b6d60dcda10261"),
 		EN_ANY,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob3,
@@ -390,12 +390,12 @@
 },
 { // Supplied by paul66 and noizert in bug reports #3045 and #3137
 	{
-		"gob3cd",
-		"v1.02",
+		"gob3",
+		"CD v1.02",
 		AD_ENTRY1("intro.stk", "c3e9132ea9dc0fb866b6d60dcda10261"),
 		DE_DEU,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob3,
@@ -404,12 +404,12 @@
 },
 { // Supplied by paul66 and noizert in bug reports #3045 and #3137
 	{
-		"gob3cd",
-		"v1.02",
+		"gob3",
+		"CD v1.02",
 		AD_ENTRY1("intro.stk", "c3e9132ea9dc0fb866b6d60dcda10261"),
 		FR_FRA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob3,
@@ -418,12 +418,12 @@
 },
 { // Supplied by paul66 and noizert in bug reports #3045 and #3137
 	{
-		"gob3cd",
-		"v1.02",
+		"gob3",
+		"CD v1.02",
 		AD_ENTRY1("intro.stk", "c3e9132ea9dc0fb866b6d60dcda10261"),
 		IT_ITA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob3,
@@ -432,12 +432,12 @@
 },
 { // Supplied by paul66 and noizert in bug reports #3045 and #3137
 	{
-		"gob3cd",
-		"v1.02",
+		"gob3",
+		"CD v1.02",
 		AD_ENTRY1("intro.stk", "c3e9132ea9dc0fb866b6d60dcda10261"),
 		ES_ESP,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob3,
@@ -446,12 +446,12 @@
 },
 { // Supplied by goodoldgeorg in bug report #4375
 	{
-		"gob3cd",
-		"v1.02",
+		"gob3",
+		"CD v1.02",
 		AD_ENTRY1s("intro.stk", "bfd7d4c6fedeb2cfcc8baa4d5ddb1f74", 616220),
 		HU_HUN,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob3,
@@ -460,12 +460,12 @@
 },
 { // Supplied by goodoldgeorg in bug report #4375
 	{
-		"gob3cd",
-		"v1.02",
+		"gob3",
+		"CD v1.02",
 		AD_ENTRY1s("intro.stk", "bfd7d4c6fedeb2cfcc8baa4d5ddb1f74", 616220),
 		FR_FRA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob3,
@@ -474,12 +474,12 @@
 },
 { // Supplied by goodoldgeorg in bug report #4375
 	{
-		"gob3cd",
-		"v1.02",
+		"gob3",
+		"CD v1.02",
 		AD_ENTRY1s("intro.stk", "bfd7d4c6fedeb2cfcc8baa4d5ddb1f74", 616220),
 		DE_DEU,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob3,
@@ -488,12 +488,12 @@
 },
 { // Supplied by goodoldgeorg in bug report #4375
 	{
-		"gob3cd",
-		"v1.02",
+		"gob3",
+		"CD v1.02",
 		AD_ENTRY1s("intro.stk", "bfd7d4c6fedeb2cfcc8baa4d5ddb1f74", 616220),
 		ES_ESP,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeGob3,

--- a/engines/gob/detection/tables_lit.h
+++ b/engines/gob/detection/tables_lit.h
@@ -82,14 +82,17 @@
 	kFeaturesAdLib,
 	0, 0, 0
 },
+
+// -- DOS CD --
+
 {
 	{
 		"lit",
-		"v1.00",
+		"CD v1.00",
 		AD_ENTRY1s("intro.stk", "6263d09e996c1b4e84ef2d650b820e57", 4831170),
 		EN_USA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeLostInTime,
@@ -99,11 +102,11 @@
 {
 	{
 		"lit",
-		"v1.00",
+		"CD v1.00",
 		AD_ENTRY1s("intro.stk", "6263d09e996c1b4e84ef2d650b820e57", 4831170),
 		FR_FRA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeLostInTime,
@@ -113,11 +116,11 @@
 {
 	{
 		"lit",
-		"v1.00",
+		"CD v1.00",
 		AD_ENTRY1s("intro.stk", "6263d09e996c1b4e84ef2d650b820e57", 4831170),
 		IT_ITA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeLostInTime,
@@ -127,11 +130,11 @@
 {
 	{
 		"lit",
-		"v1.00",
+		"CD v1.00",
 		AD_ENTRY1s("intro.stk", "6263d09e996c1b4e84ef2d650b820e57", 4831170),
 		DE_DEU,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeLostInTime,
@@ -141,11 +144,11 @@
 {
 	{
 		"lit",
-		"v1.00",
+		"CD v1.00",
 		AD_ENTRY1s("intro.stk", "6263d09e996c1b4e84ef2d650b820e57", 4831170),
 		ES_ESP,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeLostInTime,
@@ -155,11 +158,11 @@
 {
 	{
 		"lit",
-		"v1.00",
+		"CD v1.00",
 		AD_ENTRY1s("intro.stk", "6263d09e996c1b4e84ef2d650b820e57", 4831170),
 		EN_GRB,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeLostInTime,
@@ -169,11 +172,11 @@
 { // Supplied by SiRoCs in bug report #3943
 	{
 		"lit",
-		"v1.00",
+		"CD v1.00",
 		AD_ENTRY1s("intro.stk", "795be7011ec31bf5bb8ce4efdb9ee5d3", 4838904),
 		EN_USA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeLostInTime,
@@ -183,11 +186,11 @@
 { // Supplied by SiRoCs in bug report #3943
 	{
 		"lit",
-		"v1.00",
+		"CD v1.00",
 		AD_ENTRY1s("intro.stk", "795be7011ec31bf5bb8ce4efdb9ee5d3", 4838904),
 		FR_FRA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeLostInTime,
@@ -197,11 +200,11 @@
 { // Supplied by SiRoCs in bug report #3943
 	{
 		"lit",
-		"v1.00",
+		"CD v1.00",
 		AD_ENTRY1s("intro.stk", "795be7011ec31bf5bb8ce4efdb9ee5d3", 4838904),
 		IT_ITA,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeLostInTime,
@@ -211,11 +214,11 @@
 { // Supplied by SiRoCs in bug report #3943
 	{
 		"lit",
-		"v1.00",
+		"CD v1.00",
 		AD_ENTRY1s("intro.stk", "795be7011ec31bf5bb8ce4efdb9ee5d3", 4838904),
 		DE_DEU,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeLostInTime,
@@ -225,11 +228,11 @@
 { // Supplied by SiRoCs in bug report #3943
 	{
 		"lit",
-		"v1.00",
+		"CD v1.00",
 		AD_ENTRY1s("intro.stk", "795be7011ec31bf5bb8ce4efdb9ee5d3", 4838904),
 		ES_ESP,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeLostInTime,
@@ -239,11 +242,11 @@
 { // Supplied by SiRoCs in bug report #3943
 	{
 		"lit",
-		"v1.00",
+		"CD v1.00",
 		AD_ENTRY1s("intro.stk", "795be7011ec31bf5bb8ce4efdb9ee5d3", 4838904),
 		EN_GRB,
 		kPlatformDOS,
-		ADGF_NO_FLAGS,
+		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
 	kGameTypeLostInTime,

--- a/engines/gob/obsolete.h
+++ b/engines/gob/obsolete.h
@@ -24,6 +24,10 @@
 
 static const Engines::ObsoleteGameID obsoleteGameIDsTable[] = {
 	{"ajworld", "adibou1", Common::kPlatformUnknown},
+	{"gob1cd", "gob1", Common::kPlatformDOS},
+	{"gob1mac", "gob1", Common::kPlatformMacintosh},
+	{"gob2cd", "gob2", Common::kPlatformDOS},
+	{"gob3cd", "gob3", Common::kPlatformDOS},
 	{0, 0, Common::kPlatformUnknown}
 };
 


### PR DESCRIPTION
General cleanup of the GOB detection tables, for uniformity with the other engines.
- Remove gob1cd, gob2cd, gob3cd identifiers and use the AD flag instead (gob1-cd, ...)
- Move "CD" string to description instead of using the game name (e.g. Gobliiins 2 CD (DOS/English) -> Gobliins 2 (CD/DOS/English)
- A couple minor fixes


 
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
