### PR TITLE
BURIED : fix explosion timer

### DIFF
--- a/engines/buried/environ/castle.cpp
+++ b/engines/buried/environ/castle.cpp
@@ -175,7 +175,7 @@ private:
 	bool _timerStarted;
 	//uint32 _startTime;
 	bool _walkthrough;
-}; 
+};
 
 ExplodingWallSafeDistance::ExplodingWallSafeDistance(BuriedEngine *vm, Window *viewWindow, const LocationStaticData &sceneStaticData, const Location &priorLocation) :
 		SceneBase(vm, viewWindow, sceneStaticData, priorLocation) {

--- a/engines/buried/environ/castle.cpp
+++ b/engines/buried/environ/castle.cpp
@@ -175,17 +175,15 @@ private:
 	bool _timerStarted;
 	//uint32 _startTime;
 	bool _walkthrough;
-};
+}; 
 
 ExplodingWallSafeDistance::ExplodingWallSafeDistance(BuriedEngine *vm, Window *viewWindow, const LocationStaticData &sceneStaticData, const Location &priorLocation) :
 		SceneBase(vm, viewWindow, sceneStaticData, priorLocation) {
 	_timerStarted = false;
 
-	if (((SceneViewWindow *)viewWindow)->getGlobalFlags().cgMWCatapultData == 0) {
-		((SceneViewWindow *)viewWindow)->getGlobalFlags().cgMWCatapultData = g_system->getMillis();
-		_vm->_sound->playSoundEffect(_vm->getFilePath(_staticData.location.timeZone, _staticData.location.environment, 13), 127, false, true);
-	}
-
+	((SceneViewWindow *)viewWindow)->getGlobalFlags().cgMWCatapultData = g_system->getMillis();
+	_vm->_sound->playSoundEffect(_vm->getFilePath(_staticData.location.timeZone, _staticData.location.environment, 13), 127, false, true);
+	
 	_walkthrough = ((SceneViewWindow *)viewWindow)->getGlobalFlags().generalWalkthroughMode == 1;
 }
 


### PR DESCRIPTION
in reference to  [Trac #13769](https://bugs.scummvm.org/ticket/13769) , during loading of global flag cgMWCatapultData with older value , there was a conflict with getMillis() which has been fixed by reinitalizing cgMWCatapultData to zero . This fixed the explosion timer , which was struck due to failing of condition `(timer + CATAPULT_TIMEOUT_VALUE < g_system->getMillis())) ` 
