### PR TITLE
SCUMM: Fix remapping of numpad keys on EVENT_KEYUP

### DIFF
--- a/engines/scumm/input.cpp
+++ b/engines/scumm/input.cpp
@@ -186,14 +186,16 @@ void ScummEngine::parseEvent(Common::Event event) {
 		// remap keypad keys to always have a corresponding ASCII value.
 		// Normally, keypad keys would only have an ASCII value when
 		// NumLock is enabled. This fixes fighting in Indy 3 (Trac #11227)
+
+		_keyPressed = event.kbd;
 		if (_keyPressed.keycode >= Common::KEYCODE_KP0 && _keyPressed.keycode <= Common::KEYCODE_KP9) {
 			_keyPressed.ascii = (_keyPressed.keycode - Common::KEYCODE_KP0) + '0';
 		}
 
-		if (event.kbd.ascii >= 512) {
+		if (_keyPressed.ascii >= 512) {
 			debugC(DEBUG_GENERAL, "keyPressed > 512 (%d)", event.kbd.ascii);
 		} else {
-			_keyDownMap[event.kbd.ascii] = false;
+			_keyDownMap[_keyPressed.ascii] = false;
 
 			// Due to some weird bug with capslock key pressed
 			// generated keydown event is for lower letter but


### PR DESCRIPTION
Dpad buttons are by default remapped to numpad keys. Up/Down are KEYCODE_KP8/KEYCODE_KP2 and Left/right are KEYCODE_KP4/KEYCODE_KP6.

The numpad keys are remapped to have a corresponding ASCII value since the state of the keys are stored in the _keyDownMap array, indexed by the ASCII value.

It was found that the ASCII values were calculated incorrectly for EVENT_KEYUP events but correctly for EVENT_KEY DOWN events. In the latter cases the keyboard event was stored to the _keyPressed member variable. The keycode was checked and if being a numpad key the corresponding ASCII value was calculated. The key state was then stored in the _keyDownMap array using the calculated ASCII value.

For the EVENT_KEYUP events the keyboard event was not stored to the _keyPressed member variable. The keycode was still checked using the _keyPressed variable. However the _keyPressed could have been reset causing the ASCII calculation to fail for the numpad key. The raw ASCII value of the keyboard event was instead being used to reset the key state in the _keyDownMap array causing the numpad key to be left in a pressed state.

This was found when plaing the Lunar Lander mini game in "The Dig" using the virtual gamepad controller in iOS.

Fix it by writing the keyboard event to the _keyPressed variable and use the corresponding ASCII value when reseting the key state in the _keyDownMap array.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
