### PR TITLE
GRAPHICS: Add a function for creating maps to PaletteLookup

### DIFF
--- a/graphics/palette.cpp
+++ b/graphics/palette.cpp
@@ -95,7 +95,7 @@ byte PaletteLookup::findBestColor(byte cr, byte cg, byte cb, bool useNaiveAlg) {
 }
 
 uint32 *PaletteLookup::createMap(const byte *srcPalette, uint len, bool useNaiveAlg) {
-	if (len <= _paletteSize && memcmp(_palette, srcPalette, len) == 0)
+	if (len <= _paletteSize && memcmp(_palette, srcPalette, len * 3) == 0)
 		return nullptr;
 
 	uint32 *map = new uint32[len];

--- a/graphics/palette.cpp
+++ b/graphics/palette.cpp
@@ -94,4 +94,19 @@ byte PaletteLookup::findBestColor(byte cr, byte cg, byte cb, bool useNaiveAlg) {
 	return bestColor;
 }
 
+uint32 *PaletteLookup::createMap(const byte *srcPalette, uint len, bool useNaiveAlg) {
+	if (len <= _paletteSize && memcmp(_palette, srcPalette, len) == 0)
+		return nullptr;
+
+	uint32 *map = new uint32[len];
+	for (uint i = 0; i < len; i++) {
+		byte r = *srcPalette++;
+		byte g = *srcPalette++;
+		byte b = *srcPalette++;
+
+		map[i] = findBestColor(r, g, b, useNaiveAlg);
+	}
+	return map;
+}
+
 } // end of namespace Graphics

--- a/graphics/palette.h
+++ b/graphics/palette.h
@@ -143,6 +143,18 @@ public:
 	 */
 	byte findBestColor(byte r, byte g, byte b, bool useNaiveAlg = false);
 
+	/**
+	 * @brief This method creates a map from the given palette
+	 *        that can be used by crossBlitMap().
+	 *
+	 * @param palette   the palette data, in interleaved RGB format
+	 * @param len       the number of palette entries to be read
+	 * @param useNaiveAlg            if true, use a simpler algorithm (non-floating point calculations)
+	 *
+	 * @return the created map, or nullptr if one isn't needed.
+	 */
+	uint32 *createMap(const byte *srcPalette, uint len, bool useNaiveAlg = false);
+
 private:
 	byte _palette[256 * 3];
 	uint _paletteSize;


### PR DESCRIPTION
The resulting map can be passed to `Graphics::crossBlitMap()`, which allows for faster conversion of images with different palettes.