### PR TITLE
SCUMM: [RFC] Remove copy protection bypass for Macintosh Monkey Island 1

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2779,9 +2779,6 @@ void ScummEngine_v5::o5_startScript() {
 		// in LucasArts Classic Adventures (PC Disk)
 		if (_game.id == GID_MONKEY_VGA && script == 152)
 			return;
-		// Copy protection was disabled in LucasArts Mac CD Game Pack II (Macintosh CD)
-		if (_game.id == GID_MONKEY && _game.platform == Common::kPlatformMacintosh && script == 155)
-			return;
 	}
 
 	runScript(script, (op & 0x20) != 0, (op & 0x40) != 0, data);


### PR DESCRIPTION
For the longest time, we've been bypassing the copy protection in the Macintosh version of The Secret of Monkey Island, with the justification that it was disabled in the LucasArts Mac CD Games Pack II. However, in that version the copy protection was stripped from the game script, so there is no need for ScummVM to do anything.

The game is included on both of the Mac CD Games Packs, but they're not the same. The one in the first pack, which does have the copy protection, has more files than the one in the second pack:

![image](https://github.com/scummvm/scummvm/assets/601765/96f7bc4c-0d6b-4d52-b4e1-5de78d5caa6b)

![image](https://github.com/scummvm/scummvm/assets/601765/ac4d75dd-9374-4150-81de-7b961cdb3412)

They're both complete games, though. The total size of the files are roughly the same:

![image](https://github.com/scummvm/scummvm/assets/601765/21221a97-db00-4282-a224-e441b592fbd6)

So to me, the correct behavior - _if_ the first version was always sold with a code wheel, and I do _not_ know this for certain - would be to not bypass the copy protection at all for the Mac version, because the second version doesn't need any bypass.

Of course, I am cutting off the branch I'm sitting on here, because I don't have the code wheel. (The guy who sold it to me years ago apparently only had the CD, not the manual.) But we all have to make sacrifices. :-)