### PR TITLE
GRAPHICS: Add palette start and size parameters to Surface::convertToInPlace()

### DIFF
--- a/engines/freescape/freescape.cpp
+++ b/engines/freescape/freescape.cpp
@@ -886,7 +886,8 @@ Graphics::ManagedSurface *FreescapeEngine::loadAndConvertNeoImage(Common::Seekab
 	decoder.loadStream(*stream);
 	Graphics::ManagedSurface *surface = new Graphics::ManagedSurface();
 	surface->copyFrom(*decoder.getSurface());
-	surface->convertToInPlace(_gfx->_currentPixelFormat, decoder.getPalette());
+	surface->convertToInPlace(_gfx->_currentPixelFormat, decoder.getPalette(),
+		decoder.getPaletteStartIndex(), decoder.getPaletteColorCount());
 	return surface;
 }
 

--- a/engines/freescape/games/dark/cpc.cpp
+++ b/engines/freescape/games/dark/cpc.cpp
@@ -76,7 +76,7 @@ void DarkEngine::loadAssetsCPCFullGame() {
 	_indicators.push_back(loadBundledImage("dark_jet_indicator"));
 
 	for (auto &it : _indicators)
-		it->convertToInPlace(_gfx->_texturePixelFormat, nullptr);
+		it->convertToInPlace(_gfx->_texturePixelFormat);
 }
 
 void DarkEngine::drawCPCUI(Graphics::Surface *surface) {

--- a/engines/freescape/games/dark/dos.cpp
+++ b/engines/freescape/games/dark/dos.cpp
@@ -132,7 +132,7 @@ void DarkEngine::loadAssetsDOSDemo() {
 	_indicators.push_back(loadBundledImage("dark_jet_indicator"));
 
 	for (auto &it : _indicators)
-		it->convertToInPlace(_gfx->_texturePixelFormat, nullptr);
+		it->convertToInPlace(_gfx->_texturePixelFormat);
 }
 
 void DarkEngine::loadAssetsDOSFullGame() {
@@ -168,7 +168,7 @@ void DarkEngine::loadAssetsDOSFullGame() {
 		_indicators.push_back(loadBundledImage("dark_jet_indicator"));
 
 		for (auto &it : _indicators)
-			it->convertToInPlace(_gfx->_texturePixelFormat, nullptr);
+			it->convertToInPlace(_gfx->_texturePixelFormat);
 
 	} else if (_renderMode == Common::kRenderCGA) {
 		file.open("SCN1C.DAT");

--- a/engines/freescape/games/dark/zx.cpp
+++ b/engines/freescape/games/dark/zx.cpp
@@ -71,7 +71,7 @@ void DarkEngine::loadAssetsZXFullGame() {
 	_indicators.push_back(loadBundledImage("dark_jet_indicator"));
 
 	for (auto &it : _indicators)
-		it->convertToInPlace(_gfx->_texturePixelFormat, nullptr);
+		it->convertToInPlace(_gfx->_texturePixelFormat);
 }
 
 void DarkEngine::loadAssetsZXDemo() {
@@ -113,7 +113,7 @@ void DarkEngine::loadAssetsZXDemo() {
 	_indicators.push_back(loadBundledImage("dark_jet_indicator"));
 
 	for (auto &it : _indicators)
-		it->convertToInPlace(_gfx->_texturePixelFormat, nullptr);
+		it->convertToInPlace(_gfx->_texturePixelFormat);
 }
 
 void DarkEngine::drawZXUI(Graphics::Surface *surface) {

--- a/engines/freescape/games/driller/dos.cpp
+++ b/engines/freescape/games/driller/dos.cpp
@@ -352,8 +352,8 @@ void DrillerEngine::loadAssetsDOSFullGame() {
 	_indicators.push_back(loadBundledImage("driller_tank_indicator"));
 	_indicators.push_back(loadBundledImage("driller_ship_indicator"));
 
-	_indicators[0]->convertToInPlace(_gfx->_texturePixelFormat, nullptr);
-	_indicators[1]->convertToInPlace(_gfx->_texturePixelFormat, nullptr);
+	_indicators[0]->convertToInPlace(_gfx->_texturePixelFormat);
+	_indicators[1]->convertToInPlace(_gfx->_texturePixelFormat);
 }
 
 void DrillerEngine::loadAssetsDOSDemo() {
@@ -389,8 +389,8 @@ void DrillerEngine::loadAssetsDOSDemo() {
 	_indicators.push_back(loadBundledImage("driller_tank_indicator"));
 	_indicators.push_back(loadBundledImage("driller_ship_indicator"));
 
-	_indicators[0]->convertToInPlace(_gfx->_texturePixelFormat, nullptr);
-	_indicators[1]->convertToInPlace(_gfx->_texturePixelFormat, nullptr);
+	_indicators[0]->convertToInPlace(_gfx->_texturePixelFormat);
+	_indicators[1]->convertToInPlace(_gfx->_texturePixelFormat);
 }
 
 void DrillerEngine::drawDOSUI(Graphics::Surface *surface) {

--- a/engines/freescape/games/eclipse/cpc.cpp
+++ b/engines/freescape/games/eclipse/cpc.cpp
@@ -67,7 +67,7 @@ void EclipseEngine::loadAssetsCPCDemo() {
 	//_indicators.push_back(loadBundledImage("dark_jet_indicator"));
 
 	//for (auto &it : _indicators)
-	//	it->convertToInPlace(_gfx->_texturePixelFormat, nullptr);
+	//	it->convertToInPlace(_gfx->_texturePixelFormat);
 }
 
 void EclipseEngine::drawCPCUI(Graphics::Surface *surface) {

--- a/engines/freescape/gfx.cpp
+++ b/engines/freescape/gfx.cpp
@@ -489,7 +489,7 @@ Graphics::Surface *Renderer::convertImageFormatIfNecessary(Graphics::ManagedSurf
 	surface->copyFrom(msurface->rawSurface());
 	byte *palette = (byte *)malloc(sizeof(byte) * 16 * 3);
 	msurface->grabPalette(palette, 0, 16); // Maximum should be 16 colours
-	surface->convertToInPlace(_texturePixelFormat, palette);
+	surface->convertToInPlace(_texturePixelFormat, palette, 0, 16);
 	free(palette);
 	return surface;
 }

--- a/engines/mohawk/myst_graphics.cpp
+++ b/engines/mohawk/myst_graphics.cpp
@@ -217,7 +217,7 @@ void MystGraphics::applyImagePatches(uint16 id, const MohawkSurface *mhkSurface)
 		Graphics::Surface fixSurf;
 		fixSurf.create(15, 11, Graphics::PixelFormat::createFormatCLUT8());
 		fixSurf.copyRectToSurface(markerSwitchInstructionsFixPic, fixSurf.w, 0, 0, fixSurf.w, fixSurf.h);
-		fixSurf.convertToInPlace(_pixelFormat, markerSwitchInstructionsFixPal);
+		fixSurf.convertToInPlace(_pixelFormat, markerSwitchInstructionsFixPal, 0, sizeof(markerSwitchInstructionsFixPal) / 3);
 
 		mhkSurface->getSurface()->copyRectToSurface(fixSurf, 171, 208, Common::Rect(fixSurf.w, fixSurf.h));
 

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -689,10 +689,25 @@ public:
 	 * (that means it might realloc the pixel data).
 	 *
 	 * @param dstFormat  The desired format.
-	 * @param palette    The palette (in RGB888), if the source format has a bpp of 1.
 	 */
-	void convertToInPlace(const PixelFormat &dstFormat, const byte *palette = nullptr) {
-		_innerSurface.convertToInPlace(dstFormat, palette);
+	void convertToInPlace(const PixelFormat &dstFormat) {
+		_innerSurface.convertToInPlace(dstFormat);
+	}
+
+	/**
+	 * Convert the data to another pixel format.
+	 *
+	 * This works in-place. This means it does not create an additional buffer
+	 * for the conversion process. The value of 'pixels' might change though
+	 * (that means it might realloc the pixel data).
+	 *
+	 * @param dstFormat  The desired format.
+	 * @param palette    The palette (in RGB888), if the source format has one.
+	 * @param paletteStart  The starting index of the palette.
+	 * @param paletteCount  The number of colors in the palette.
+	 */
+	void convertToInPlace(const PixelFormat &dstFormat, const byte *palette, byte paletteStart, uint16 paletteCount) {
+		_innerSurface.convertToInPlace(dstFormat, palette, paletteStart, paletteCount);
 	}
 
 	/**

--- a/graphics/surface.cpp
+++ b/graphics/surface.cpp
@@ -475,7 +475,7 @@ Graphics::Surface *Surface::rotoscale(const TransformStruct &transform, bool fil
 	return target;
 }
 
-void Surface::convertToInPlace(const PixelFormat &dstFormat, const byte *palette) {
+void Surface::convertToInPlace(const PixelFormat &dstFormat, const byte *palette, byte paletteStart, uint16 paletteCount) {
 	// Do not convert to the same format and ignore empty surfaces.
 	if (format == dstFormat || pixels == 0) {
 		return;
@@ -504,7 +504,7 @@ void Surface::convertToInPlace(const PixelFormat &dstFormat, const byte *palette
 		uint32 map[256];
 		assert(palette);
 
-		convertPaletteToMap(map, palette, 256, dstFormat);
+		convertPaletteToMap(map, palette + paletteStart, paletteCount, dstFormat);
 		crossBlitMap((byte *)pixels, (const byte *)pixels, w * dstFormat.bytesPerPixel, pitch, w, h, dstFormat.bytesPerPixel, map);
 	} else {
 		crossBlit((byte *)pixels, (const byte *)pixels, w * dstFormat.bytesPerPixel, pitch, w, h, dstFormat, format);

--- a/graphics/surface.h
+++ b/graphics/surface.h
@@ -354,9 +354,27 @@ public:
 	 * @ref create. Otherwise, this function has undefined behavior.
 	 *
 	 * @param dstFormat  The desired format.
-	 * @param palette    The palette (in RGB888), if the source format has a bpp of 1.
 	 */
-	void convertToInPlace(const PixelFormat &dstFormat, const byte *palette = 0);
+	inline void convertToInPlace(const PixelFormat &dstFormat) {
+		convertToInPlace(dstFormat, nullptr, 0, 0);
+	}
+
+	/**
+	 * Convert the data to another pixel format.
+	 *
+	 * This works in-place. This means it does not create an additional buffer
+	 * for the conversion process. The value of 'pixels' might change though
+	 * (that means it might realloc the pixel data).
+	 *
+	 * @b Important: Only use this if you created the surface data using
+	 * @ref create. Otherwise, this function has undefined behavior.
+	 *
+	 * @param dstFormat  The desired format.
+	 * @param palette    The palette (in RGB888), if the source format has one.
+	 * @param paletteStart	The starting index of the palette.
+	 * @param paletteCount	The number of colors in the palette.
+	 */
+	void convertToInPlace(const PixelFormat &dstFormat, const byte *palette, byte paletteStart, uint16 paletteCount);
 
 	/**
 	 * Convert the data to another pixel format.

--- a/gui/imagealbum-dialog.cpp
+++ b/gui/imagealbum-dialog.cpp
@@ -251,7 +251,7 @@ void ImageAlbumDialog::changeToSlot(uint slot) {
 			_imageSupplier->releaseImageSlot(slot);
 
 			if (rescaledGraphic.format.bytesPerPixel == 1)
-				rescaledGraphic.convertToInPlace(Graphics::createPixelFormat<888>(), palette);
+				rescaledGraphic.convertToInPlace(Graphics::createPixelFormat<888>(), palette, 0, 256);
 
 			int32 xCoord = (static_cast<int32>(_imageContainer->getWidth()) - static_cast<int32>(scaledWidth)) / 2u;
 			int32 yCoord = (static_cast<int32>(_imageContainer->getHeight()) - static_cast<int32>(scaledHeight)) / 2u;


### PR DESCRIPTION
This will prevent it from reading out of bounds with smaller palettes.