### PR TITLE
GUI: Handle Copy and Paste events in ConsoleDialog

### DIFF
--- a/gui/console.cpp
+++ b/gui/console.cpp
@@ -534,6 +534,30 @@ void ConsoleDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data
 	}
 }
 
+void ConsoleDialog::handleOtherEvent(const Common::Event &evt) {
+	if (evt.type == Common::EVENT_CUSTOM_ENGINE_ACTION_START) {
+		switch (evt.customType) {
+			case kActionCopy:
+				{
+					Common::String userInput = getUserInput();
+					if (!userInput.empty())
+						g_system->setTextInClipboard(userInput);
+				}
+				break;
+			case kActionPaste:
+				if (g_system->hasTextInClipboard()) {
+					Common::U32String text = g_system->getTextFromClipboard();
+					insertIntoPrompt(text.encode().c_str());
+					scrollToCurrent();
+					drawLine(pos2line(_currentPos));
+				}
+				break;
+			default:
+				break;
+		}
+	}
+}
+
 void ConsoleDialog::specialKeys(Common::KeyCode keycode) {
 	switch (keycode) {
 	case Common::KEYCODE_a:
@@ -557,21 +581,6 @@ void ConsoleDialog::specialKeys(Common::KeyCode keycode) {
 	case Common::KEYCODE_w:
 		killLastWord();
 		g_gui.scheduleTopDialogRedraw();
-		break;
-	case Common::KEYCODE_v:
-		if (g_system->hasTextInClipboard()) {
-			Common::U32String text = g_system->getTextFromClipboard();
-			insertIntoPrompt(text.encode().c_str());
-			scrollToCurrent();
-			drawLine(pos2line(_currentPos));
-		}
-		break;
-	case Common::KEYCODE_c:
-		{
-			Common::String userInput = getUserInput();
-			if (!userInput.empty())
-				g_system->setTextInClipboard(userInput);
-		}
 		break;
 	default:
 		break;

--- a/gui/console.h
+++ b/gui/console.h
@@ -144,6 +144,7 @@ public:
 	void handleMouseWheel(int x, int y, int direction) override;
 	void handleKeyDown(Common::KeyState state) override;
 	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data) override;
+	void handleOtherEvent(const Common::Event &evt) override;
 
 	int printFormat(int dummy, MSVC_PRINTF const char *format, ...) GCC_PRINTF(3, 4);
 	int vprintFormat(int dummy, const char *format, va_list argptr);


### PR DESCRIPTION
ConsoleDialog had a hard-coded handler for Copy and Paste shortcuts. These shortcuts are now handled by the keymapper and produce Copy and Paste events.

Fixes CTRL+C and CTRL+V in the console on Windows builds.
