### PR TITLE
DIRECTOR: add support for absolute timing CD audio playback via cuesheets

### DIFF
--- a/backends/audiocd/audiocd.h
+++ b/backends/audiocd/audiocd.h
@@ -73,6 +73,20 @@ public:
 		Audio::Mixer::SoundType soundType = Audio::Mixer::kMusicSoundType) = 0;
 
 	/**
+	 * Start audio CD playback at a specific absolute timestamp
+	 * @param startFrame     the frame at which playback should start (75 frames = 1 second).
+	 * @param numLoops       how often playback should be repeated (<=0 means infinitely often).
+	 * @param duration       the number of frames to play.
+	 * @param onlyEmulate    determines if the track should be emulated only
+	 * @param soundType      What sound type to play as. By default, it's as music
+	 * @param cuesheet       The name of the cuesheet to use for timing data
+	 * @note The @c onlyEmulate parameter is deprecated.
+	 * @return @c true if the track started playing, @c false otherwise
+	 */
+	virtual bool playAbsolute(int startFrame, int numLoops, int duration, bool onlyEmulate = false,
+		Audio::Mixer::SoundType soundType = Audio::Mixer::kMusicSoundType, const char *cuesheet = "disc.cue") = 0;
+
+	/**
 	 * Get if audio is being played.
 	 * @return true if CD audio is playing
 	 */

--- a/backends/audiocd/default/default-audiocd.cpp
+++ b/backends/audiocd/default/default-audiocd.cpp
@@ -25,6 +25,7 @@
 #include "common/file.h"
 #include "common/system.h"
 #include "common/util.h"
+#include "common/formats/cue.h"
 
 DefaultAudioCDManager::DefaultAudioCDManager() {
 	_cd.playing = false;
@@ -132,6 +133,27 @@ bool DefaultAudioCDManager::play(int track, int numLoops, int startFrame, int du
 	}
 
 	return false;
+}
+
+bool DefaultAudioCDManager::playAbsolute(int startFrame, int numLoops, int duration, bool onlyEmulate,
+		Audio::Mixer::SoundType soundType, const char *cuesheet) {
+
+	Common::File *cuefile = new Common::File();
+	if (!cuefile->open(cuesheet)) {
+		return false;
+	}
+	Common::String cuestring = cuefile->readString(0, cuefile->size());
+	Common::CueSheet cue(cuestring.c_str());
+
+	Common::CueSheet::CueTrack *track = cue.getTrackAtFrame(startFrame);
+	if (track == nullptr) {
+		warning("Unable to locate track for frame %i", startFrame);
+		return false;
+	} else {
+		warning("Playing from frame %i", startFrame);
+	}
+
+	return play(track->number, numLoops, startFrame - track->indices[0], duration, onlyEmulate);
 }
 
 void DefaultAudioCDManager::stop() {

--- a/backends/audiocd/default/default-audiocd.h
+++ b/backends/audiocd/default/default-audiocd.h
@@ -41,6 +41,8 @@ public:
 	virtual void close();
 	virtual bool play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate = false,
 		Audio::Mixer::SoundType soundType = Audio::Mixer::kMusicSoundType);
+	virtual bool playAbsolute(int startFrame, int numLoops, int duration, bool onlyEmulate = false,
+		Audio::Mixer::SoundType soundType = Audio::Mixer::kMusicSoundType, const char *cuesheet = "disc.cue");
 	virtual void stop();
 	virtual bool isPlaying() const;
 	virtual void setVolume(byte volume);

--- a/common/formats/cue.cpp
+++ b/common/formats/cue.cpp
@@ -252,14 +252,16 @@ void CueSheet::parseFilesContext(const char *line) {
 		if (trackNum < 0 || (_currentTrack > 0 && _currentTrack + 1 != trackNum)) {
 			warning("CueSheet: Incorrect track number. Expected %d but got %d at line %d", _currentTrack + 1, trackNum, _lineNum);
 		} else {
-			for (int i = (int)_files[_currentFile].tracks.size(); i <= trackNum; i++)
-				_files[_currentFile].tracks.push_back(CueTrack());
+			for (int i = (int)_tracks.size(); i <= trackNum; i++)
+				_tracks.push_back(CueTrack());
 
 			_currentTrack = trackNum;
-			_files[_currentFile].tracks[_currentTrack].type = (TrackType)lookupInTable(trackTypes, trackType.c_str());
-			_files[_currentFile].tracks[_currentTrack].size = lookupInTable(trackTypesSectorSizes, trackType.c_str());
+			_tracks[_currentTrack].number = trackNum;
+			_tracks[_currentTrack].type = (TrackType)lookupInTable(trackTypes, trackType.c_str());
+			_tracks[_currentTrack].size = lookupInTable(trackTypesSectorSizes, trackType.c_str());
+			_tracks[_currentTrack].file = _files[_currentFile];
 
-			debug(5, "Track: %d type: %s (%d)", trackNum, trackType.c_str(), _files[_currentFile].tracks[_currentTrack].type);
+			debug(5, "Track: %d type: %s (%d)", trackNum, trackType.c_str(), _tracks[_currentTrack].type);
 		}
 
 		_context = kContextTracks;
@@ -285,23 +287,23 @@ void CueSheet::parseTracksContext(const char *line) {
 	if (command == "TRACK") {
 		parseFilesContext(line);
 	} else if (command == "TITLE") {
-		_files[_currentFile].tracks[_currentTrack].title = nexttok(s, &s);
+		_tracks[_currentTrack].title = nexttok(s, &s);
 
-		debug(5, "Track title: %s", _files[_currentFile].tracks[_currentTrack].title.c_str());
+		debug(5, "Track title: %s", _tracks[_currentTrack].title.c_str());
 	} else if (command == "INDEX") {
 		int indexNum = atoi(nexttok(s, &s).c_str());
 		int frames = parseMSF(nexttok(s, &s).c_str());
 
-		for (int i = (int)_files[_currentFile].tracks[_currentTrack].indices.size(); i <= indexNum; i++)
-			_files[_currentFile].tracks[_currentTrack].indices.push_back(0);
+		for (int i = (int)_tracks[_currentTrack].indices.size(); i <= indexNum; i++)
+			_tracks[_currentTrack].indices.push_back(0);
 
-		_files[_currentFile].tracks[_currentTrack].indices[indexNum] = frames;
+		_tracks[_currentTrack].indices[indexNum] = frames;
 
 		debug(5, "Index: %d, frames: %d", indexNum, frames);
 	} else if (command == "PREGAP") {
-		_files[_currentFile].tracks[_currentTrack].pregap = parseMSF(nexttok(s, &s).c_str());
+		_tracks[_currentTrack].pregap = parseMSF(nexttok(s, &s).c_str());
 
-		debug(5, "Track pregap: %d", _files[_currentFile].tracks[_currentTrack].pregap);
+		debug(5, "Track pregap: %d", _tracks[_currentTrack].pregap);
 	} else if (command == "FLAGS") {
 		String flag;
 		uint32 flags = 0;
@@ -312,18 +314,73 @@ void CueSheet::parseTracksContext(const char *line) {
 			flags |= lookupInTable(trackFlags, flag.c_str());
 		}
 
-		_files[_currentFile].tracks[_currentTrack].flags = flags;
+		_tracks[_currentTrack].flags = flags;
 
-		debug(5, "Track flags: %d", _files[_currentFile].tracks[_currentTrack].flags);
+		debug(5, "Track flags: %d", _tracks[_currentTrack].flags);
 	} else if (command == "FILE") {
 		parseHeaderContext(line);
 	} else if (command == "PERFORMER") {
-		_files[_currentFile].tracks[_currentTrack].performer = nexttok(s, &s);
+		_tracks[_currentTrack].performer = nexttok(s, &s);
 
-		debug(5, "Track performer: %s", _files[_currentFile].tracks[_currentTrack].performer.c_str());
+		debug(5, "Track performer: %s", _tracks[_currentTrack].performer.c_str());
 	} else {
 		warning("CueSheet: Unprocessed track command %s at line %d", command.c_str(), _lineNum);
 	}
+}
+
+Array<CueSheet::CueFile> CueSheet::files() {
+	return _files;
+}
+
+Array<CueSheet::CueTrack> CueSheet::tracks() {
+	return _tracks;
+}
+
+CueSheet::CueTrack *CueSheet::getTrack(int tracknum) {
+	for (uint i = 0; i < _tracks.size(); i++) {
+		if (_tracks[i].number == tracknum) {
+			return &_tracks[i];
+		}
+	}
+
+	return nullptr;
+}
+
+CueSheet::CueTrack *CueSheet::getTrackAtFrame(int frame) {
+	for (uint i = 0; i < _tracks.size(); i++) {
+		if (_tracks[i].indices.size() == 0) {
+			continue;
+		}
+
+		// Inside pregap
+		if (frame >= _tracks[i].indices[0] && frame < _tracks[i].indices.back()) {
+			debug(5, "CueSheet::getTrackAtFrame: Returning track %i (pregap)", i);
+			return &_tracks[i];
+		}
+
+		// Between index 1 and the start of the subsequent track
+		if (i < _tracks.size() && frame > _tracks[i].indices.back() && frame < _tracks[i+1].indices[0]) {
+			debug(5, "CueSheet::getTrackAtFrame: Returning track %i (inside content)", i);
+			return &_tracks[i];
+		}
+	}
+
+	// Not found within any tracks, but could be in the final track.
+	// Note: this looks weird, but is correct (or correct-ish).
+	// The cuesheet tracks the *starting* index of a song, but not
+	// the *duration* of a track. Without having access to the raw
+	// disc data, we don't actually know how long this track is.
+	// As a result, if we see any frame that comes after the
+	// start of the final track, we need to assume it's
+	// a part of that track.
+	if (frame > _tracks.back().indices.back()) {
+		debug(5, "CueSheet::getTrackAtFrame: Returning final track");
+		return &_tracks.back();
+	}
+
+	// Still not found; could indicate a gap between indices
+	warning("CueSheet::getTrackAtFrame: Not returning a track; does the cuesheet have a gap between indices?");
+	return nullptr;
 }
 
 } // End of namespace Common

--- a/common/formats/cue.h
+++ b/common/formats/cue.h
@@ -67,8 +67,14 @@ public:
 		kTrackFlagSCMS = 1 << 3, // Serial copy management system
 	};
 
+	struct CueFile {
+		String name;
+		FileType type = kFileTypeBinary;
+	};
+
 	struct CueTrack {
 		int number = 0;
+		CueFile file;
 		TrackType type;
 		String title;
 		String performer;
@@ -76,12 +82,6 @@ public:
 		int pregap = 0;
 		uint32 flags;
 		int size = 2352;
-	};
-
-	struct CueFile {
-		String name;
-		FileType type = kFileTypeBinary;
-		Array<CueTrack> tracks;
 	};
 
 	struct CueMetadata {
@@ -93,6 +93,11 @@ public:
 	};
 
 	struct LookupTable;
+
+	Array<CueFile> files();
+	Array<CueTrack> tracks();
+	CueTrack *getTrack(int tracknum);
+	CueTrack *getTrackAtFrame(int frame);
 
 private:
 	void parse(const char *sheet);
@@ -111,6 +116,7 @@ private:
 	int _currentTrack = -1;
 
 	Array<CueFile> _files;
+	Array<CueTrack> _tracks;
 	CueMetadata _metadata;
 
 };

--- a/engines/director/lingo/xlibs/applecdxobj.cpp
+++ b/engines/director/lingo/xlibs/applecdxobj.cpp
@@ -22,6 +22,7 @@
 /*************************************
  *
  * USED IN:
+ * Classical Cats
  * The Daedalus Encounter
  *
  *************************************/
@@ -84,6 +85,9 @@
  * --
  */
 
+#include "backends/audiocd/audiocd.h"
+#include "common/file.h"
+#include "common/formats/cue.h"
 #include "director/director.h"
 #include "director/lingo/lingo.h"
 #include "director/lingo/lingo-object.h"
@@ -101,8 +105,15 @@ const char *AppleCDXObj::fileNames[] = {
 static MethodProto xlibMethods[] = {
 	{ "new",					AppleCDXObj::m_new,			0,	0,	400 },	// D4
 	{ "Service",				AppleCDXObj::m_service,		0,	0,	400 },	// D4
+	{ "Still",				AppleCDXObj::m_still,		0,	0,	400 },	// D4
 	{ "ReadStatus",				AppleCDXObj::m_readStatus,	0,	0,	400 },	// D4
+	{ "GetValue",				AppleCDXObj::m_getValue,	0,	0,	400 },	// D4
 	{ "Eject",    				AppleCDXObj::m_eject,		0,	0,	400 },	// D4
+	{ "SetInPoint",    				AppleCDXObj::m_setInPoint,		1,	1,	400 },	// D4
+	{ "SetOutPoint",    				AppleCDXObj::m_setOutPoint,		1,	1,	400 },	// D4
+	{ "PlayCue",    				AppleCDXObj::m_playCue,		0,	0,	400 },	// D4
+	{ "PlaySegment",    				AppleCDXObj::m_playSegment,		0,	0,	400 },	// D4
+	{ "ReadPos",    				AppleCDXObj::m_readPos,		0,	0,	400 },	// D4
     { nullptr, nullptr, 0, 0, 0 }
 };
 
@@ -124,17 +135,82 @@ void AppleCDXObj::close(int type) {
 
 AppleCDXObject::AppleCDXObject(ObjectType ObjectType) :Object<AppleCDXObject>("AppleCD") {
 	_objType = ObjectType;
+	_inpoint = 0;
+	_outpoint = 0;
+	_cue = nullptr;
+
+	Common::File *cuefile = new Common::File();
+	if (cuefile->open("disc.cue")) {
+		Common::String cuestring = cuefile->readString(0, cuefile->size());
+
+		_cue = new Common::CueSheet(cuestring.c_str());
+	}
 }
 
 void AppleCDXObj::m_new(int nargs) {
 	g_lingo->push(g_lingo->_state->me);
 }
 
+void AppleCDXObj::m_still(int nargs) {
+	g_director->_system->getAudioCDManager()->stop();
+}
+
+// Not implemented yet; needs to be able to return appropriate values
+// for playing/paused.
 void AppleCDXObj::m_service(int nargs) {
 	g_lingo->push(Datum(0));
 }
 
 void AppleCDXObj::m_readStatus(int nargs) {
+}
+
+void AppleCDXObj::m_getValue(int nargs) {
+	AppleCDXObject *me = static_cast<AppleCDXObject *>(g_lingo->_state->me.u.obj);
+
+	g_lingo->push(Datum(me->_returnValue));
+}
+
+void AppleCDXObj::m_setInPoint(int nargs) {
+	AppleCDXObject *me = static_cast<AppleCDXObject *>(g_lingo->_state->me.u.obj);
+
+	int inpoint = g_lingo->pop().asInt();
+	debug(5, "AppleCDXObj::setInPoint: %i", inpoint);
+	me->_inpoint = inpoint;
+}
+
+void AppleCDXObj::m_setOutPoint(int nargs) {
+	AppleCDXObject *me = static_cast<AppleCDXObject *>(g_lingo->_state->me.u.obj);
+
+	int outpoint = g_lingo->pop().asInt();
+	debug(5, "AppleCDXObj::setOutPoint: %i", outpoint);
+	me->_outpoint = outpoint;
+}
+
+void AppleCDXObj::m_playCue(int nargs) {
+	// Essentially a noop for us; this asks the drive to seek to that point,
+	// then poll until it does. We don't have seek times, so we'll
+	// simply noop.
+}
+
+void AppleCDXObj::m_playSegment(int nargs) {
+	// Performs playback at the pre-specified absolute point on the disc,
+	// using the values from setInPoint and setOutPoint
+	AppleCDXObject *me = static_cast<AppleCDXObject *>(g_lingo->_state->me.u.obj);
+
+	g_director->_system->getAudioCDManager()->playAbsolute(me->_inpoint, -1, 0, 0);
+}
+
+void AppleCDXObj::m_readPos(int nargs) {
+	AppleCDXObject *me = static_cast<AppleCDXObject *>(g_lingo->_state->me.u.obj);
+
+	AudioCDManager::Status status = g_director->_system->getAudioCDManager()->getStatus();
+	if (me->_cue) {
+		// ScummVM currently doesn't support specifying the exact frame, so we pretend we're at the first frame of the song
+		Common::CueSheet::CueTrack *track = me->_cue->getTrack(status.track);
+		if (track != nullptr) {
+			me->_returnValue = track->indices[0];
+		}
+	}
 }
 
 void AppleCDXObj::m_eject(int nargs) {

--- a/engines/director/lingo/xlibs/applecdxobj.h
+++ b/engines/director/lingo/xlibs/applecdxobj.h
@@ -22,11 +22,22 @@
 #ifndef DIRECTOR_LINGO_XLIBS_APPLECDXOBJ_H
 #define DIRECTOR_LINGO_XLIBS_APPLECDXOBJ_H
 
+namespace Common {
+	class CueSheet;
+}
+
 namespace Director {
 
 class AppleCDXObject : public Object<AppleCDXObject> {
 public:
 	AppleCDXObject(ObjectType objType);
+	int _inpoint;
+	int _outpoint;
+	// Instead of immediately returning values, methods which return
+	// a value store it internally and return it via a subsequent
+	// call to mGetValue.
+	int _returnValue;
+	Common::CueSheet *_cue;
 };
 
 namespace AppleCDXObj {
@@ -38,8 +49,15 @@ void open(int type);
 void close(int type);
 
 void m_new(int nargs);
+void m_still(int nargs);
 void m_service(int nargs);
 void m_readStatus(int nargs);
+void m_getValue(int nargs);
+void m_setInPoint(int nargs);
+void m_setOutPoint(int nargs);
+void m_playCue(int nargs);
+void m_playSegment(int nargs);
+void m_readPos(int nargs);
 void m_eject(int nargs);
 
 } // End of namespace AppleCDXObj

--- a/engines/director/lingo/xlibs/cdromxobj.cpp
+++ b/engines/director/lingo/xlibs/cdromxobj.cpp
@@ -23,6 +23,7 @@
  *
  * USED IN:
  * The Apartment 2.0
+ * Cellofania
  *
  *************************************/
 
@@ -294,12 +295,17 @@ void CDROMXObj::m_playName(int nargs) {
 }
 
 void CDROMXObj::m_playAbsTime(int nargs) {
+	CDROMXObject *me = static_cast<CDROMXObject *>(g_lingo->_state->me.u.obj);
+
 	Datum min = g_lingo->pop();
 	Datum sec = g_lingo->pop();
 	Datum frac = g_lingo->pop();
-	// Can't implement this without implementing a full CD TOC, since
-	// it doesn't interact with songs at the "track" level.
-	debug(5, "STUB: CDROMXObj::m_playAbsTime Request to play starting at %i:%i.%i", min.asInt(), sec.asInt(), frac.asInt());
+
+	int startFrame = (min.asInt() * 60 * 75) + (sec.asInt() * 75) + frac.asInt();
+	debug(5, "CDROMXObj::m_playAbsTime: playing at frame %i", startFrame);
+	g_director->_system->getAudioCDManager()->playAbsolute(startFrame, -1, 0);
+	me->_cdda_status = g_director->_system->getAudioCDManager()->getStatus();
+
 	g_lingo->push(Datum());
 }
 


### PR DESCRIPTION
This adds support for playing CD audio via absolute timecodes instead of via track numbers. This is needed for several Director games. In order for this to work via CD audio emulation, we need access to a full table of contents for the disc. We can't just use the audio files for the CD tracks, because in almost every case, a data track comes before the first CD track - it's impossible to know what absolute sector an audio track begins and ends that without knowing the size of the data track.

To fix this, I've made use of cuesheets in order to have access to a full table of contents of the disc. In absolute playback mode, we check to see if the game directory has a file named `disc.cue`, and if so, we parse that and use it as the TOC. I'm using the new cuesheet parser that @sev- wrote. It's been updated with a few changes to accommodate this:

* Several methods have been added to `Common::CueSheet` to allow retrieving tracks.
* The parser has been reoriented so that the internal code keeps a flat array of tracks, instead of having tracks belong to files. This makes the track getter methods more convenient, and also eliminates a quirk where there were a few "fake" empty tracks inside file arrays.

The generic emulation-based CD audio player has been updated with a new `playAbsolute` method which takes an absolute timecode as its argument. At the moment, the macOS CD code doesn't implement `playAbsolute`; it's effectively a form of emulation already, which reads the AIFF files that macOS exposes instead of lower-level CDDA playback methods, and so we don't have access to the disc's TOC.

I've tested with Classical Cats for Mac. Results so far: it works great, and is playing back music as expected. There is a quirk where it's always playing from frame 0, but that's not the fault of the xlib - I haven't checked where the number is coming from, but it seems to be assigned in lingo outside the xlib.

Marking as draft because I haven't yet implemented true absolute playback support for the Windows or SDL CD-ROM devices. Also marking as a draft for feedback from @sev- on the changes to the cuesheet code.