### PR TITLE
COMMON: Skip possible UTF-8 BOM when reading INI files

### DIFF
--- a/common/config-manager.cpp
+++ b/common/config-manager.cpp
@@ -171,6 +171,7 @@ void ConfigManager::addDomain(const String &domainName, const ConfigManager::Dom
 
 
 bool ConfigManager::loadFromStream(SeekableReadStream &stream) {
+	static const byte UTF8_BOM[] = {0xEF, 0xBB, 0xBF};
 	String domainName;
 	String comment;
 	Domain domain;
@@ -196,6 +197,11 @@ bool ConfigManager::loadFromStream(SeekableReadStream &stream) {
 
 		// Read a line
 		String line = stream.readLine();
+
+		// Skip UTF-8 byte-order mark if added by a text editor.
+		if (lineno == 1 && memcmp(line.c_str(), UTF8_BOM, 3) == 0) {
+			line.erase(0, 3);
+		}
 
 		if (line.size() == 0) {
 			// Do nothing

--- a/common/formats/ini-file.cpp
+++ b/common/formats/ini-file.cpp
@@ -90,6 +90,7 @@ bool INIFile::loadFromSaveFile(const String &filename) {
 }
 
 bool INIFile::loadFromStream(SeekableReadStream &stream) {
+	static const byte UTF8_BOM[] = {0xEF, 0xBB, 0xBF};
 	Section section;
 	KeyValue kv;
 	String comment;
@@ -104,6 +105,11 @@ bool INIFile::loadFromStream(SeekableReadStream &stream) {
 
 		// Read a line
 		String line = stream.readLine();
+
+		// Skip UTF-8 byte-order mark if added by a text editor.
+		if (lineno == 1 && memcmp(line.c_str(), UTF8_BOM, 3) == 0) {
+			line.erase(0, 3);
+		}
 
 		line.trim();
 


### PR DESCRIPTION
After briefly considering a more complex solution including detection additional encoding byte-order marks, I thought it would be best to simply read and skip UTF-8 BOM when reading INI files. This would at least prevent someone like me from accidentally wiping out their scummvm.ini files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of UTF-8 byte-order mark (BOM) in configuration files to ensure proper parsing and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->