### PR TITLE
AUDIO: Optimize case for !inStereo && outStereo

### DIFF
--- a/audio/rate.cpp
+++ b/audio/rate.cpp
@@ -122,7 +122,7 @@ int RateConverter_Impl<inStereo, outStereo, reverseStereo>::copyConvert(AudioStr
 		outL = (inL * (int)volL) / Audio::Mixer::kMaxMixerVolume;
 		outR = (inR * (int)volR) / Audio::Mixer::kMaxMixerVolume;
 
-		if (outStereo) {
+		if (inStereo && outStereo) {
 			// Output left channel
 			clampedAdd(outBuffer[reverseStereo    ], outL);
 
@@ -132,9 +132,12 @@ int RateConverter_Impl<inStereo, outStereo, reverseStereo>::copyConvert(AudioStr
 			outBuffer += 2;
 		} else {
 			// Output mono channel
-			clampedAdd(outBuffer[0], (outL + outR) / 2);
+			st_sample_t val = clampedAdd(outBuffer[0], (outL + outR) / 2);
 
 			outBuffer += 1;
+
+			if (outStereo)
+				*outBuffer++ = val;
 		}
 	}
 
@@ -182,7 +185,7 @@ int RateConverter_Impl<inStereo, outStereo, reverseStereo>::simpleConvert(AudioS
 		outL = (inL * (int)volL) / Audio::Mixer::kMaxMixerVolume;
 		outR = (inR * (int)volR) / Audio::Mixer::kMaxMixerVolume;
 
-		if (outStereo) {
+		if (inStereo && outStereo) {
 			// output left channel
 			clampedAdd(outBuffer[reverseStereo    ], outL);
 
@@ -192,9 +195,12 @@ int RateConverter_Impl<inStereo, outStereo, reverseStereo>::simpleConvert(AudioS
 			outBuffer += 2;
 		} else {
 			// output mono channel
-			clampedAdd(outBuffer[0], (outL + outR) / 2);
+			st_sample_t val = clampedAdd(outBuffer[0], (outL + outR) / 2);
 
 			outBuffer += 1;
+
+			if (outStereo)
+				*outBuffer++ = val;
 		}
 	}
 	return (outBuffer - outStart) / (outStereo ? 2 : 1);
@@ -247,7 +253,7 @@ int RateConverter_Impl<inStereo, outStereo, reverseStereo>::interpolateConvert(A
 			outL = (inL * (int)volL) / Audio::Mixer::kMaxMixerVolume;
 			outR = (inR * (int)volR) / Audio::Mixer::kMaxMixerVolume;
 
-			if (outStereo) {
+			if (inStereo && outStereo) {
 				// Output left channel
 				clampedAdd(outBuffer[reverseStereo    ], outL);
 
@@ -257,9 +263,12 @@ int RateConverter_Impl<inStereo, outStereo, reverseStereo>::interpolateConvert(A
 				outBuffer += 2;
 			} else {
 				// Output mono channel
-				clampedAdd(outBuffer[0], (outL + outR) / 2);
+				st_sample_t val = clampedAdd(outBuffer[0], (outL + outR) / 2);
 
 				outBuffer += 1;
+
+				if (outStereo)
+					*outBuffer++ = val;
 			}
 
 			// Increment output position

--- a/audio/rate.h
+++ b/audio/rate.h
@@ -46,7 +46,7 @@ enum {
 	ST_SAMPLE_MIN = (-ST_SAMPLE_MAX - 1L)
 };
 
-static inline void clampedAdd(int16& a, int b) {
+static inline int16 clampedAdd(int16& a, int b) {
 	int val;
 #ifdef OUTPUT_UNSIGNED_AUDIO
 	val = (a ^ 0x8000) + b;
@@ -64,6 +64,7 @@ static inline void clampedAdd(int16& a, int b) {
 #else
 	a = val;
 #endif
+	return (int16)val;
 }
 
 /**


### PR DESCRIPTION
This is almost invisible on high-end machines but does it job nicely on lower-end ones (<100 MHz). Instead of calling `clampedAdd` with the same values just copy the value over.

As many (older) games use mono samples nearly always, it can be widely used, especially on platform which do not offer 16-bit mono output (yes, they exist ;)).