### PR TITLE
DIRECTOR : Fix physical energy game bar not filled in total distortion.

### DIFF
--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -113,7 +113,7 @@ Channel::~Channel() {
 }
 
 DirectorPlotData Channel::getPlotData() {
-	DirectorPlotData pd(g_director, _sprite->_spriteType, _sprite->_ink, _sprite->_blend, _sprite->getBackColor(), _sprite->getForeColor());
+	DirectorPlotData pd(g_director, _sprite->_spriteType, _sprite->_ink, _sprite->_blendAmount, _sprite->getBackColor(), _sprite->getForeColor());
 	pd.colorWhite = 0;
 	pd.colorBlack = 255;
 	pd.dst = nullptr;
@@ -160,8 +160,7 @@ const Graphics::Surface *Channel::getMask(bool forceMatte) {
 		_sprite->_ink == kInkTypeLight ||
 		_sprite->_ink == kInkTypeSub ||
 		_sprite->_ink == kInkTypeDark ||
-		_sprite->_blendAmount > 0 ||
-		_sprite->_blend > 0;
+		_sprite->_blendAmount > 0;
 
 	Common::Rect bbox(getBbox());
 
@@ -173,6 +172,10 @@ const Graphics::Surface *Channel::getMask(bool forceMatte) {
 			BitmapCastMember *bitmap = ((BitmapCastMember *)_sprite->_cast);
 			// 1-bit images only require a matte for the matte ink type
 			if (bitmap->_bitsPerPixel == 1 && _sprite->_ink != kInkTypeMatte) {
+				// 1-bit images will not blend with kInkTypeCopy, whereas 8-bit images will.
+				if (_sprite->_ink == kInkTypeCopy) {
+                    _sprite->_blendAmount = 0;
+                }
 				return nullptr;
 			}
 			return bitmap->getMatte(bbox);

--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -113,7 +113,7 @@ Channel::~Channel() {
 }
 
 DirectorPlotData Channel::getPlotData() {
-	DirectorPlotData pd(g_director, _sprite->_spriteType, _sprite->_ink, _sprite->_blendAmount, _sprite->getBackColor(), _sprite->getForeColor());
+	DirectorPlotData pd(g_director, _sprite->_spriteType, _sprite->_ink, _sprite->_blend, _sprite->getBackColor(), _sprite->getForeColor());
 	pd.colorWhite = 0;
 	pd.colorBlack = 255;
 	pd.dst = nullptr;
@@ -160,7 +160,8 @@ const Graphics::Surface *Channel::getMask(bool forceMatte) {
 		_sprite->_ink == kInkTypeLight ||
 		_sprite->_ink == kInkTypeSub ||
 		_sprite->_ink == kInkTypeDark ||
-		_sprite->_blendAmount > 0;
+		_sprite->_blendAmount > 0 ||
+		_sprite->_blend > 0;
 
 	Common::Rect bbox(getBbox());
 

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -1139,13 +1139,13 @@ Common::String Frame::formatChannelInfo() {
 	for (int i = 0; i < _numChannels; i++) {
 		Sprite &sprite = *_sprites[i + 1];
 		if (sprite._castId.member) {
-			result += Common::String::format("CH: %-3d castId: %s, [inkData: 0x%02x [ink: %d, trails: %d, line: %d], %dx%d@%d,%d type: %d (%s) fg: %d bg: %d], script: %s, colorcode: 0x%x, blendAmount: 0x%x, unk3: 0x%x\n",
+			result += Common::String::format("CH: %-3d castId: %s, [inkData: 0x%02x [ink: %d, trails: %d, line: %d], %dx%d@%d,%d type: %d (%s) fg: %d bg: %d], script: %s, colorcode: 0x%x, blendAmount: 0x%x, blend: 0x%x, unk3: 0x%x\n",
 				i + 1, sprite._castId.asString().c_str(), sprite._inkData,
 				sprite._ink, sprite._trails, sprite._thickness, sprite._width, sprite._height,
 				sprite._startPoint.x, sprite._startPoint.y,
 				sprite._spriteType, spriteType2str(sprite._spriteType), sprite._foreColor,
 				sprite._backColor, sprite._scriptId.asString().c_str(), sprite._colorcode,
-				sprite._blendAmount, sprite._unk3);
+				sprite._blendAmount, sprite._blend, sprite._unk3);
 		} else {
 			result += Common::String::format("CH: %-3d castId: 000\n", i + 1);
 		}

--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -64,6 +64,8 @@ Sprite::Sprite(Frame *frame) {
 	_backColor = g_director->_wm->_colorWhite;
 	_foreColor = g_director->_wm->_colorWhite;
 
+	_blend = 0;
+
 	_volume = 0;
 	_stretch = 0;
 }
@@ -108,6 +110,8 @@ Sprite& Sprite::operator=(const Sprite &sprite) {
 	_backColor = sprite._backColor;
 	_foreColor = sprite._foreColor;
 
+	_blend = sprite._blend;
+	
 	_volume = sprite._volume;
 	_stretch = sprite._stretch;
 

--- a/engines/director/sprite.h
+++ b/engines/director/sprite.h
@@ -116,6 +116,8 @@ public:
 	uint32 _backColor;
 	uint32 _foreColor;
 
+	byte _blend;
+	
 	byte _volume;
 	byte _stretch;
 };


### PR DESCRIPTION
It is partial revert of 3cb61c54d749f385817fb8674236d4046af54271

Steps to reproduce:
1. Start Total Distortion
2. Start a new game / load game
3. Click on the "Options" button
4. The physical energy bar is not visible

Trello card : https://trello.com/c/mpZTlPoZ/628-physical-energy-game-bar-not-filled


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
