### PR TITLE
GRAPHICS: MACGUI: [RFC] Attempt to fix suspected threading threading issues in the Macintosh Window Manager

### DIFF
--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -242,6 +242,8 @@ void MacWindowManager::cleanupDesktopBmp() {
 }
 
 MacWindowManager::~MacWindowManager() {
+	Common::StackLock lock(_mutex);
+
 	for (Common::HashMap<uint, BaseMacWindow *>::iterator it = _windows.begin(); it != _windows.end(); it++)
 		delete it->_value;
 
@@ -271,6 +273,8 @@ void MacWindowManager::setDesktopMode(uint32 mode) {
 }
 
 void MacWindowManager::setScreen(ManagedSurface *screen) {
+	Common::StackLock lock(_mutex);
+
 	_screen = screen;
 	delete _screenCopy;
 	_screenCopy = nullptr;
@@ -304,6 +308,8 @@ int MacWindowManager::getHeight() {
 }
 
 void MacWindowManager::resizeScreen(int w, int h) {
+	Common::StackLock lock(_mutex);
+
 	if (!_screen)
 		error("MacWindowManager::resizeScreen(): Trying to creating surface on non-existing screen");
 	_screenDims = Common::Rect(w, h);
@@ -447,6 +453,8 @@ void MacWindowManager::activateMenu() {
 }
 
 void MacWindowManager::activateScreenCopy() {
+	Common::StackLock lock(_mutex);
+
 	if (_screen) {
 		if (!_screenCopy)
 			_screenCopy = new ManagedSurface(*_screen);	// Create a copy
@@ -467,6 +475,8 @@ void MacWindowManager::activateScreenCopy() {
 }
 
 void MacWindowManager::disableScreenCopy() {
+	Common::StackLock lock(_mutex);
+
 	if (_screenCopyPauseToken) {
 		_screenCopyPauseToken->clear();
 		delete _screenCopyPauseToken;
@@ -884,6 +894,8 @@ void MacWindowManager::drawDesktop() {
 }
 
 void MacWindowManager::draw() {
+	Common::StackLock lock(_mutex);
+
 	removeMarked();
 
 	Common::Rect bounds = getScreenBounds();
@@ -1153,6 +1165,8 @@ void MacWindowManager::addZoomBox(ZoomBox *box) {
 }
 
 void MacWindowManager::renderZoomBox(bool redraw) {
+	Common::StackLock lock(_mutex);
+
 	if (!_zoomBoxes.size())
 		return;
 

--- a/graphics/macgui/macwindowmanager.h
+++ b/graphics/macgui/macwindowmanager.h
@@ -24,6 +24,7 @@
 
 #include "common/hashmap.h"
 #include "common/list.h"
+#include "common/mutex.h"
 #include "common/stack.h"
 #include "common/events.h"
 
@@ -433,6 +434,7 @@ public:
 	Common::Rect _screenDims;
 
 private:
+	Common::Mutex _mutex;
 	Common::List<BaseMacWindow *> _windowStack;
 	Common::HashMap<uint, BaseMacWindow *> _windows;
 


### PR DESCRIPTION
While working on the menu handling for the Macintosh versions of Indiana Jones and the Last Crusade and Loom, I've had the screen go mysteriously black on me two or three times. I think it's been when the menus have been either about to be activated or inactivated, which makes me suspect that it's a threading issue. The menus are activated by a timer, so anything that timer function touches could be at risk.

So I've added a mutex to try and guard against this. But threading is something I generally try to avoid (the Last Crusade GUI, despite its many timed animations, remain steadfastly single-threaded), so I don't know if I'm doing this right. At all.
