### PR TITLE
ULTIMA: ULTIMA6: Fix roof drawing

### DIFF
--- a/engines/ultima/nuvie/gui/widgets/map_window.cpp
+++ b/engines/ultima/nuvie/gui/widgets/map_window.cpp
@@ -304,6 +304,10 @@ bool MapWindow::set_windowSize(uint16 width, uint16 height) {
 	}
 	anim_manager->set_area(clip_rect);
 
+	Screen *const gameScreen = Game::get_game()->get_screen();
+	assert(gameScreen);
+	_mapWinSubSurf.create(*gameScreen->get_sdl_surface(), clip_rect);
+
 	reset_mousecenter();
 
 	updateBlacking();
@@ -1302,9 +1306,9 @@ void MapWindow::drawRoofs() {
 						}
 						SDL_BlitSurface(roof_tiles, &src, surface, &dst);
 					} else {
-						byte *ptr = (byte *)roof_tiles->getPixels();
-						ptr += src.left + src.top * 80;
-						screen->blit(dst.left, dst.top, ptr, 8, 16, 16, 80, true, &clip_rect);
+						src.setWidth(16);
+						src.setHeight(16);
+						_mapWinSubSurf.blitFrom(*roof_tiles, src, Common::Point(dst.left, dst.top));
 					}
 				}
 			}
@@ -2651,7 +2655,7 @@ void MapWindow::set_roof_mode(bool roofs) {
 void MapWindow::loadRoofTiles() {
 	Std::string imagefile = map->getRoofTilesetFilename();
 	roof_tiles = SDL_LoadBMP(imagefile.c_str());
-	if (roof_tiles && game->is_orig_style()) {
+	if (roof_tiles) {
 		SDL_SetColorKey(roof_tiles, SDL_TRUE, SDL_MapRGB(roof_tiles->format, 0, 0x70, 0xfc));
 	}
 }

--- a/engines/ultima/nuvie/gui/widgets/map_window.h
+++ b/engines/ultima/nuvie/gui/widgets/map_window.h
@@ -119,6 +119,7 @@ class MapWindow: public GUI_Widget {
 	sint32 vel_x, vel_y; // velocity of automatic map movement (pixels per second)
 
 	Common::Rect clip_rect;
+	Graphics::ManagedSurface _mapWinSubSurf; // sub surface of the screen clipped to MapWindow's clip_rect
 
 	Obj *selected_obj;
 	Actor *look_actor;

--- a/engines/ultima/nuvie/misc/sdl_compat.cpp
+++ b/engines/ultima/nuvie/misc/sdl_compat.cpp
@@ -98,7 +98,7 @@ Graphics::ManagedSurface *SDL_LoadBMP(const char *filename) {
 	Graphics::ManagedSurface *const screenSurface = screen->get_sdl_surface();
 	assert (screenSurface);
 	Graphics::ManagedSurface *dest = new Graphics::ManagedSurface(src->w, src->h, screenSurface->format);
-	dest->blitFrom(*src);
+	dest->blitFrom(*src, decoder.getPalette());
 
 	return dest;
 }


### PR DESCRIPTION
- Fix assert on loading roof bitmap
- Fix garbled roof drawing

Both regressions were introduced in commit c4970c95dc48fdf38891cec3740ccf98dfd090f9
"Fix crash in GUI on surface blit"

Fixes [#14687](https://bugs.scummvm.org/ticket/14687)

Note: The commit message prefix for Ultima 6 is pretty inconsistent in the log, let me know if I should change it.