### PR TITLE
SLUDGE: Fix bg_effects by using ARGB instead of RGBA

### DIFF
--- a/engines/sludge/bg_effects.cpp
+++ b/engines/sludge/bg_effects.cpp
@@ -247,15 +247,15 @@ static inline void blur_createSourceLine(byte *createLine, byte *fromLine, int o
 	memcpy(createLine + overlapOnLeft * 4, fromLine, width * 4);
 
 	for (miniX = 0; miniX < overlapOnLeft; miniX++) {
-		createLine[miniX * 4] = fromLine[0];
-		createLine[miniX * 4 + 1] = fromLine[1];
-		createLine[miniX * 4 + 2] = fromLine[2];
+		createLine[miniX * 4] = fromLine[1];
+		createLine[miniX * 4 + 1] = fromLine[2];
+		createLine[miniX * 4 + 2] = fromLine[3];
 	}
 
 	for (miniX = width + overlapOnLeft; miniX < width + s_matrixEffectWidth - 1; miniX++) {
-		createLine[miniX * 4] = fromLine[width * 4 - 4];
-		createLine[miniX * 4 + 1] = fromLine[width * 4 - 3];
-		createLine[miniX * 4 + 2] = fromLine[width * 4 - 2];
+		createLine[miniX * 4] = fromLine[width * 4 - 3];
+		createLine[miniX * 4 + 1] = fromLine[width * 4 - 2];
+		createLine[miniX * 4 + 2] = fromLine[width * 4 - 1];
 	}
 }
 
@@ -280,11 +280,11 @@ bool GraphicsManager::blurScreen() {
 			for (y = 0; y < s_matrixEffectHeight; y++) {
 				int miniY = CLIP<int>(y - overlapAbove - 1, 0, _sceneHeight - 1);
 
-				blur_createSourceLine(sourceLine[y], (byte *)_origBackdropSurface.getBasePtr(0, miniY), overlapOnLeft, _sceneWidth);
+				blur_createSourceLine(sourceLine[y], (byte *)_backdropSurface.getBasePtr(0, miniY), overlapOnLeft, _sceneWidth);
 			}
 
 			for (y = 0; y < (int)_sceneHeight; y++) {
-				thisLine = (byte *)_origBackdropSurface.getBasePtr(0, y);
+				thisLine = (byte *)_backdropSurface.getBasePtr(0, y);
 
 				//-------------------------
 				// Scroll source lines
@@ -298,7 +298,7 @@ bool GraphicsManager::blurScreen() {
 					int h = s_matrixEffectHeight - 1;
 					int miniY = CLIP<int>(y + (s_matrixEffectHeight - overlapAbove - 1), 0, _sceneHeight - 1);
 
-					blur_createSourceLine(sourceLine[h], (byte *)_origBackdropSurface.getBasePtr(0, miniY), overlapOnLeft, _sceneWidth);
+					blur_createSourceLine(sourceLine[h], (byte *)_backdropSurface.getBasePtr(0, miniY), overlapOnLeft, _sceneWidth);
 				}
 				for (x = 0; x < (int)_sceneWidth; x++) {
 					int totalRed = 0;
@@ -309,9 +309,9 @@ bool GraphicsManager::blurScreen() {
 						byte *pixel = &sourceLine[miniY][x * 4];
 						for (int miniX = 0; miniX < s_matrixEffectWidth; ++miniX) {
 
-							totalRed += pixel[0] **matrixElement;
-							totalGreen += pixel[1] **matrixElement;
-							totalBlue += pixel[2] **matrixElement;
+							totalRed += pixel[1] **matrixElement;
+							totalGreen += pixel[2] **matrixElement;
+							totalBlue += pixel[3] **matrixElement;
 							++matrixElement;
 							pixel += 4;
 						}
@@ -325,13 +325,13 @@ bool GraphicsManager::blurScreen() {
 					totalBlue = (totalBlue + s_matrixEffectDivide / 2) / s_matrixEffectDivide + s_matrixEffectBase;
 					totalBlue = (totalBlue < 0) ? 0 : ((totalBlue > 255) ? 255 : totalBlue);
 
+//					*thisLine = totalAlpha;
+					++thisLine;
 					*thisLine = totalRed;
 					++thisLine;
 					*thisLine = totalGreen;
 					++thisLine;
 					*thisLine = totalBlue;
-					++thisLine;
-//					*thisLine = totalAlpha;
 					++thisLine;
 				}
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the image blurring process for enhanced visual effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->