### PR TITLE
QUEEN: Allow improved hebrew font in fallback

### DIFF
--- a/engines/queen/detection.cpp
+++ b/engines/queen/detection.cpp
@@ -529,6 +529,8 @@ ADDetectedGame QueenMetaEngineDetection::fallbackDetect(const FileMap &allFiles,
 				} else if (version.features & Queen::GF_TALKIE) {
 					desc.extra = "CD";
 					desc.guiOptions = GAMEOPTION_ALT_INTRO;
+					if (desc.language == Common::HE_ISR)
+						desc.guiOptions = GUIO2(GAMEOPTION_ALT_INTRO, GAMEOPTION_ALT_FONT);
 				}
 
 				return ADDetectedGame(&desc);


### PR DESCRIPTION
Following #4279
This add the GUI option to select improved hebrew font for fallback detection as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced game detection to support Hebrew language, including alternative intro and font options for a better localized experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->