### PR TITLE
BACKENDS: OPENGL: Fix FakeTexture palette init. PVS-Studio V1086

### DIFF
--- a/backends/graphics/opengl/texture.cpp
+++ b/backends/graphics/opengl/texture.cpp
@@ -391,8 +391,7 @@ FakeTexture::FakeTexture(GLenum glIntFormat, GLenum glFormat, GLenum glType, con
 	  _palette(nullptr),
 	  _mask(nullptr) {
 	if (_fakeFormat.isCLUT8()) {
-		_palette = new uint32[256];
-		memset(_palette, 0, sizeof(uint32));
+		_palette = new uint32[256]();
 	}
 }
 


### PR DESCRIPTION
Doing this as a PR because I'm not familiar with this graphics code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the initialization process of texture palettes to ensure consistent zeroing out of data for better reliability in graphics rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->