### PR TITLE
SLUDGE: Fix bug in logic for removing objects

### DIFF
--- a/engines/sludge/objtypes.cpp
+++ b/engines/sludge/objtypes.cpp
@@ -134,10 +134,8 @@ int ObjectManager::getCombinationFunction(int withThis, int thisObject) {
 }
 
 void ObjectManager::removeObjectType(ObjectType *oT) {
-	_allObjectTypes.remove(oT);
 	delete []oT->allCombis;
-	delete oT;
-	oT = nullptr;
+	_allObjectTypes.remove(oT);
 }
 
 } // End of namespace Sludge

--- a/engines/sludge/people.cpp
+++ b/engines/sludge/people.cpp
@@ -871,10 +871,8 @@ void PeopleManager::removeOneCharacter(int i) {
 			abortFunction(removePerson->continueAfterWalking);
 		removePerson->continueAfterWalking = NULL;
 
-		_allPeople->remove(removePerson);
 		_vm->_objMan->removeObjectType(removePerson->thisType);
-		delete removePerson;
-		removePerson = nullptr;
+		_allPeople->remove(removePerson);
 	}
 }
 


### PR DESCRIPTION
In frasse 1.03, if you go up then right and try to pick up the box, the game would sometimes crash.