### PR TITLE
GUI: Fix Console newlines passed to `debug`

### DIFF
--- a/gui/console.cpp
+++ b/gui/console.cpp
@@ -780,8 +780,7 @@ int ConsoleDialog::vprintFormat(int dummy, const char *format, va_list argptr) {
 	const int size = buf.size();
 
 	print(buf.c_str());
-	buf.trim();
-	debug("%s", buf.c_str());
+	debugN("%s", buf.c_str());
 
 	return size;
 }


### PR DESCRIPTION
In a7d4d0f232231eb3d22c85d35ddfbcc2be0e587c, Console output was passed to `debug` so that it would appear in stdout and scummvm.log, but the code added a newline to every `ConsoleDialog::debugPrintf` string that didn't already end in one. This is a problem for Console code that builds lines with multiple `debugPrintf` calls. SCI's Console has many commands and most of them print output this way; this has been filling the debug output with unreadable partial lines. Other engines are affected, really any `debugPrintf` call that doesn't end in \n.

Now the code doesn't alter the newlines (or other whitespace). The `debug` output now matches the intended Console output.

After:

```
Call stack (current base: 0x0):
 0: script 994 - DEMO::play()
     obj@0001:0094 pc=0004:019e sp=ST:0000 fp=ST:0000 argp:ST:0001
 1: script 994 - DEMO::doit()
     by 0 obj@0001:0094 pc=0004:0302 sp=ST:0002 fp=ST:0002 argp:ST:0001
 2: script 999 - regions::eachElementDo(0000:0078)
     by 1 obj@0004:0062 pc=0003:020d sp=ST:0008 fp=ST:0005 argp:ST:0003
 3: script 994 - rm8::doit()
     by 2 obj@0014:00a6 pc=0004:08eb sp=ST:000a fp=ST:000a argp:ST:0009
 4: script 8 - rm8Script::doit()
     by 3 obj@0014:024c pc=0014:0108 sp=ST:0031 fp=ST:000c argp:ST:000b
 5: script 255 - export 0 (0000:0008, 0000:0000, 0000:00a0, 0014:02b2, 0000:0052, 0002:029 0000:0032, 0000:0042, 0000:03e7, 0000:008c, 0000:00fa)
     by 4 obj@0014:024c pc=0005:135f sp=ST:043a fp=ST:003d argp:ST:0031
 6: script 255 - Dialog::doit(0015:0007)
     by 5 obj@0015:0005 pc=0005:0985 sp=ST:0443 fp=ST:043d argp:ST:043b
 7: script 999 - Event::new()
     by 6 obj@0003:05d6 pc=0003:05c7 sp=ST:0446 fp=ST:0445 argp:ST:0444
 8:[7]  kGetEvent(0000:7fff, 0015:0062)
     by 7 obj@0000:0000 pc:none argp:ST:0446
```

Before:
```
Call stack (current base: 0x0):
0: script 994 -
DEMO::play(
)
obj@0001:0094
pc=0004:019e
sp=ST:0000
fp=ST:0000
argp:ST:0001

1: script 994 -
DEMO::doit(
)
by 0
obj@0001:0094
pc=0004:0302
sp=ST:0002
fp=ST:0002
argp:ST:0001

2: script 999 -
regions::eachElementDo(
0000:0078
)
...
```