### PR TITLE
GRAPHICS: Use custom stream callbacks for loading TTF fonts

### DIFF
--- a/engines/bladerunner/subtitles.cpp
+++ b/engines/bladerunner/subtitles.cpp
@@ -258,8 +258,8 @@ void Subtitles::init(void) {
 		_useUTF8 = false;
 	} else if (_subtitlesInfo.fontType == Subtitles::kSubtitlesFontTypeTTF) {
 #if defined(USE_FREETYPE2)
-		Common::ScopedPtr<Common::SeekableReadStream> stream(_vm->getResourceStream(_subtitlesInfo.fontName));
-		_font = Graphics::loadTTFFont(*stream, 18);
+		Common::SeekableReadStream *stream = _vm->getResourceStream(_subtitlesInfo.fontName);
+		_font = Graphics::loadTTFFont(stream, DisposeAfterUse::YES, 18);
 		_useUTF8 = true;
 #else
 		warning("Subtitles require a TTF font but this ScummVM build doesn't support it.");

--- a/engines/buried/graphics.cpp
+++ b/engines/buried/graphics.cpp
@@ -113,9 +113,7 @@ Graphics::Font *GraphicsManager::createArialFont(int size, bool bold) const {
 	Graphics::Font *font;
 
 	if (stream) {
-		font = Graphics::loadTTFFont(*stream, size, Graphics::kTTFSizeModeCharacter, 96, 96, _vm->isTrueColor() ? Graphics::kTTFRenderModeLight : Graphics::kTTFRenderModeMonochrome);
-
-		delete stream;
+		font = Graphics::loadTTFFont(stream, DisposeAfterUse::YES, size, Graphics::kTTFSizeModeCharacter, 96, 96, _vm->isTrueColor() ? Graphics::kTTFRenderModeLight : Graphics::kTTFRenderModeMonochrome);
 	} else {
 		const char *fname;
 		if (bold)
@@ -591,7 +589,7 @@ Graphics::Font *GraphicsManager::createMSGothicFont(int size, bool bold) const {
 	// TODO: Fake a bold version
 	if (stream) {
 		// Force monochrome, since the original uses the bitmap glyphs in the font
-		font = Graphics::loadTTFFont(*stream, size, Graphics::kTTFSizeModeCharacter, 96, 96, Graphics::kTTFRenderModeMonochrome);
+		font = Graphics::loadTTFFont(stream, DisposeAfterUse::YES, size, Graphics::kTTFSizeModeCharacter, 96, 96, Graphics::kTTFRenderModeMonochrome);
 	} else {
 		font = Graphics::loadTTFFontFromArchive("VL-Gothic-Regular.ttf", size, Graphics::kTTFSizeModeCharacter, 96, 96, Graphics::kTTFRenderModeMonochrome);
 	}
@@ -599,7 +597,6 @@ Graphics::Font *GraphicsManager::createMSGothicFont(int size, bool bold) const {
 	if (!font)
 		error("Failed to load MS Gothic font");
 
-	delete stream;
 	return font;
 }
 

--- a/engines/crab/text/TextManager.cpp
+++ b/engines/crab/text/TextManager.cpp
@@ -70,9 +70,9 @@ void TextManager::init() {
 				uint pos = stringToNumber<uint>(id->value());
 				if (_font.size() <= pos)
 					_font.resize(pos + 1);
-				Common::File file;
-				fileOpen(path->value(), &file);
-				_font[pos] = Graphics::loadTTFFont(file, stringToNumber<int>(size->value()));
+				Common::File *file = new Common::File();
+				fileOpen(path->value(), file);
+				_font[pos] = Graphics::loadTTFFont(file, DisposeAfterUse::YES, stringToNumber<int>(size->value()));
 			}
 		}
 	}

--- a/engines/glk/screen.cpp
+++ b/engines/glk/screen.cpp
@@ -120,16 +120,16 @@ void Screen::loadFonts(Common::Archive *archive) {
 }
 
 const Graphics::Font *Screen::loadFont(FACES face, Common::Archive *archive, double size, double aspect, int style) {
-	Common::File f;
+	Common::File *f = new Common::File();
 	const char *const FILENAMES[8] = {
 		"GoMono-Regular.ttf", "GoMono-Bold.ttf", "GoMono-Italic.ttf", "GoMono-Bold-Italic.ttf",
 		"NotoSerif-Regular.ttf", "NotoSerif-Bold.ttf", "NotoSerif-Italic.ttf", "NotoSerif-Bold-Italic.ttf"
 	};
 
-	if (!f.open(FILENAMES[face], *archive))
+	if (!f->open(FILENAMES[face], *archive))
 		error("Could not load %s from fonts file", FILENAMES[face]);
 
-	return Graphics::loadTTFFont(f, (int)size, Graphics::kTTFSizeModeCharacter);
+	return Graphics::loadTTFFont(f, DisposeAfterUse::YES, (int)size, Graphics::kTTFSizeModeCharacter);
 }
 
 FACES Screen::getFontId(const Common::String &name) {

--- a/engines/glk/zcode/screen.cpp
+++ b/engines/glk/zcode/screen.cpp
@@ -117,12 +117,11 @@ void FrotzScreen::loadExtraFonts(Common::Archive *archive) {
 
 	// Add Runic font. It provides cleaner versions of the runic characters in the
 	// character graphics font
-	Common::File f;
-	if (!f.open("NotoSansRunic-Regular.ttf", *archive))
+	Common::File *f = new Common::File();
+	if (!f->open("NotoSansRunic-Regular.ttf", *archive))
 		error("Could not load font");
 
-	_fonts.push_back(Graphics::loadTTFFont(f, g_conf->_propInfo._size, Graphics::kTTFSizeModeCharacter));
-	f.close();
+	_fonts.push_back(Graphics::loadTTFFont(f, DisposeAfterUse::YES, g_conf->_propInfo._size, Graphics::kTTFSizeModeCharacter));
 }
 
 } // End of namespace ZCode

--- a/engines/gnap/gnap.cpp
+++ b/engines/gnap/gnap.cpp
@@ -234,10 +234,9 @@ Common::Error GnapEngine::run() {
 
 #ifdef USE_FREETYPE2
 	Common::SeekableReadStream *stream = _exe->getResource(Common::kWinFont, 2000);
-	_font = Graphics::loadTTFFont(*stream, 24);
+	_font = Graphics::loadTTFFont(stream, DisposeAfterUse::YES, 24);
 	if (!_font)
 		warning("Unable to load font");
-	delete stream;
 #else
 	_font = nullptr;
 #endif

--- a/engines/grim/font.cpp
+++ b/engines/grim/font.cpp
@@ -378,7 +378,6 @@ void FontTTF::restoreState(SaveGame *state) {
 		stream = g_resourceloader->openNewStreamFile(fname.c_str(), true);
 		loadTTF(fname, stream, size);
 	}
-	delete stream;
 }
 
 void BitmapFont::render(Graphics::Surface &buf, const Common::String &currentLine,
@@ -420,7 +419,7 @@ void FontTTF::loadTTF(const Common::String &filename, Common::SeekableReadStream
 	_filename = filename;
 	_size = size;
 #ifdef USE_FREETYPE2
-	_font = Graphics::loadTTFFont(*data, size);
+	_font = Graphics::loadTTFFont(data, DisposeAfterUse::YES, size);
 #else
 	_font = nullptr;
 #endif

--- a/engines/mohawk/myst_graphics.cpp
+++ b/engines/mohawk/myst_graphics.cpp
@@ -94,8 +94,7 @@ void MystGraphics::loadMenuFont() {
 
 	Common::SeekableReadStream *fontStream = SearchMan.createReadStreamForMember(menuFontName);
 	if (fontStream) {
-		_menuFont = Graphics::loadTTFFont(*fontStream, fontSize);
-		delete fontStream;
+		_menuFont = Graphics::loadTTFFont(fontStream, DisposeAfterUse::YES, fontSize);
 	} else
 #endif
 	{

--- a/engines/mohawk/riven_graphics.cpp
+++ b/engines/mohawk/riven_graphics.cpp
@@ -824,8 +824,7 @@ void RivenGraphics::loadMenuFont() {
 
 	Common::SeekableReadStream *stream = SearchMan.createReadStreamForMember(fontName);
 	if (stream) {
-		_menuFont = Graphics::loadTTFFont(*stream, fontHeight);
-		delete stream;
+		_menuFont = Graphics::loadTTFFont(stream, DisposeAfterUse::YES, fontHeight);
 	}
 #endif
 

--- a/engines/myst3/subtitles.cpp
+++ b/engines/myst3/subtitles.cpp
@@ -97,8 +97,7 @@ void FontSubtitles::loadResources() {
 
 	Common::SeekableReadStream *s = SearchMan.createReadStreamForMember(ttfFile);
 	if (s) {
-		_font = Graphics::loadTTFFont(*s, _fontSize * _scale);
-		delete s;
+		_font = Graphics::loadTTFFont(s, DisposeAfterUse::YES, _fontSize * _scale);
 	} else {
 		warning("Unable to load the subtitles font '%s'", ttfFile);
 	}

--- a/engines/stark/services/fontprovider.cpp
+++ b/engines/stark/services/fontprovider.cpp
@@ -135,9 +135,8 @@ FontProvider::FontHolder::FontHolder(FontProvider *fontProvider, const Common::S
 		bool stemDarkening = StarkSettings->isFontAntialiasingEnabled();
 
 		_font = Common::SharedPtr<Graphics::Font>(
-				Graphics::loadTTFFont(*s, _scaledHeight, Graphics::kTTFSizeModeCell, 0, 0, renderMode, nullptr, stemDarkening)
+				Graphics::loadTTFFont(s, DisposeAfterUse::YES, _scaledHeight, Graphics::kTTFSizeModeCell, 0, 0, renderMode, nullptr, stemDarkening)
 		);
-		delete s;
 	} else {
 		warning("Unable to load the font '%s'", ttfFileName.toString().c_str());
 	}

--- a/engines/tetraedge/te/te_font3.cpp
+++ b/engines/tetraedge/te/te_font3.cpp
@@ -46,7 +46,7 @@ Graphics::Font *TeFont3::getAtSize(uint size) {
 		error("TeFont3::: Couldn't open font file %s.", getAccessName().toString(Common::Path::kNativeSeparator).c_str());
 
 	_fontFile.seek(0);
-	Graphics::Font *newFont = Graphics::loadTTFFont(_fontFile, size, Graphics::kTTFSizeModeCharacter, 0, 0, Graphics::kTTFRenderModeNormal);
+	Graphics::Font *newFont = Graphics::loadTTFFont(&_fontFile, DisposeAfterUse::NO, size, Graphics::kTTFSizeModeCharacter, 0, 0, Graphics::kTTFRenderModeNormal);
 	if (!newFont) {
 		error("TeFont3::: Couldn't load font %s at size %d.", _loadedPath.toString(Common::Path::kNativeSeparator).c_str(), size);
 	}

--- a/engines/ultima/ultima8/gfx/fonts/font_manager.cpp
+++ b/engines/ultima/ultima8/gfx/fonts/font_manager.cpp
@@ -90,6 +90,7 @@ Font *FontManager::getTTFont(unsigned int fontnum) {
 
 
 Graphics::Font *FontManager::getTTF_Font(const Common::Path &filename, int pointsize, bool antialiasing) {
+#ifdef USE_FREETYPE2
 	TTFId id;
 	id._filename = filename;
 	id._pointSize = pointsize;
@@ -100,20 +101,21 @@ Graphics::Font *FontManager::getTTF_Font(const Common::Path &filename, int point
 	if (iter != _ttfFonts.end())
 		return iter->_value;
 
-	Common::File fontids;
-	if (!fontids.open(filename)) {
+	Common::File* fontids = new Common::File();
+	if (!fontids->open(filename)) {
 		warning("Failed to open TTF: %s", filename.toString().c_str());
+		delete fontids;
 		return nullptr;
 	}
 
-#ifdef USE_FREETYPE2
 	// open font using ScummVM TTF API
 	// Note: The RWops and ReadStream will be deleted by the TTF_Font
 	Graphics::TTFRenderMode mode = antialiasing ? Graphics::kTTFRenderModeNormal : Graphics::kTTFRenderModeMonochrome;
-	Graphics::Font *font = Graphics::loadTTFFont(fontids, pointsize, Graphics::kTTFSizeModeCharacter, 0, 0, mode, 0, false);
+	Graphics::Font *font = Graphics::loadTTFFont(fontids, DisposeAfterUse::YES, pointsize, Graphics::kTTFSizeModeCharacter, 0, 0, mode, 0, false);
 
 	if (!font) {
 		warning("Failed to open TTF: %s", filename.toString().c_str());
+		delete fontids;
 		return nullptr;
 	}
 

--- a/engines/vcruise/runtime.cpp
+++ b/engines/vcruise/runtime.cpp
@@ -1501,9 +1501,11 @@ Runtime::Runtime(OSystem *system, Audio::Mixer *mixer, MidiDriver *midiDrv, cons
 
 #ifdef USE_FREETYPE2
 	if (_gameID == GID_AD2044) {
-		Common::File f;
-		if (f.open("gfx/AD2044.TTF"))
-			_subtitleFontKeepalive.reset(Graphics::loadTTFFont(f, 16, Graphics::kTTFSizeModeCharacter, 108, 72, Graphics::kTTFRenderModeLight));
+		Common::File *f = new Common::File();
+		if (f->open("gfx/AD2044.TTF"))
+			_subtitleFontKeepalive.reset(Graphics::loadTTFFont(f, DisposeAfterUse::YES, 16, Graphics::kTTFSizeModeCharacter, 108, 72, Graphics::kTTFRenderModeLight));
+		else
+			delete f;
 	} else
 		_subtitleFontKeepalive.reset(Graphics::loadTTFFontFromArchive("NotoSans-Regular.ttf", 16, Graphics::kTTFSizeModeCharacter, 0, 0, Graphics::kTTFRenderModeLight));
 

--- a/engines/wintermute/base/font/base_font_truetype.cpp
+++ b/engines/wintermute/base/font/base_font_truetype.cpp
@@ -583,7 +583,7 @@ bool BaseFontTT::initFont() {
 		fallbackFilename = "FreeSans.ttf";
 	}
 
-	Common::SeekableReadStream *file = BaseFileManager::getEngineInstance()->openFile(_fontFile);
+	Common::SeekableReadStream *file = BaseFileManager::getEngineInstance()->openFile(_fontFile, true, false);
 	if (!file) {
 		if (Common::String(_fontFile) != "arial.ttf") {
 			warning("%s has no replacement font yet, using FreeSans for now (if available)", _fontFile);
@@ -593,10 +593,8 @@ bool BaseFontTT::initFont() {
 	}
 
 	if (file) {
-		_deletableFont = Graphics::loadTTFFont(*file, _fontHeight, Graphics::kTTFSizeModeCharacter, 96); // Use the same dpi as WME (96 vs 72).
+		_deletableFont = Graphics::loadTTFFont(file, DisposeAfterUse::YES, _fontHeight, Graphics::kTTFSizeModeCharacter, 96); // Use the same dpi as WME (96 vs 72).
 		_font = _deletableFont;
-		BaseFileManager::getEngineInstance()->closeFile(file);
-		file = nullptr;
 	}
 
 	// Fallback2: Try load the font from the common fonts archive:

--- a/engines/zvision/text/truetype_font.cpp
+++ b/engines/zvision/text/truetype_font.cpp
@@ -117,14 +117,15 @@ bool StyledTTFont::loadFont(const Common::String &fontName, int32 point, uint st
 
 	bool sharp = (_style & TTF_STYLE_SHARP) == TTF_STYLE_SHARP;
 
-	Common::File file;
+	Common::File *file = new Common::File();
 	Graphics::Font *newFont;
-	if (!file.open(Common::Path(newFontName)) && !_engine->getSearchManager()->openFile(file, Common::Path(newFontName)) &&
-		!file.open(Common::Path(liberationFontName)) && !_engine->getSearchManager()->openFile(file, Common::Path(liberationFontName)) &&
-		!file.open(Common::Path(freeFontName)) && !_engine->getSearchManager()->openFile(file, Common::Path(freeFontName))) {
+	if (!file->open(Common::Path(newFontName)) && !_engine->getSearchManager()->openFile(*file, Common::Path(newFontName)) &&
+		!file->open(Common::Path(liberationFontName)) && !_engine->getSearchManager()->openFile(*file, Common::Path(liberationFontName)) &&
+		!file->open(Common::Path(freeFontName)) && !_engine->getSearchManager()->openFile(*file, Common::Path(freeFontName))) {
 		newFont = Graphics::loadTTFFontFromArchive(liberationFontName, point, Graphics::kTTFSizeModeCell, 0, 0, (sharp ? Graphics::kTTFRenderModeMonochrome : Graphics::kTTFRenderModeNormal));
+		delete file;
 	} else {
-		newFont = Graphics::loadTTFFont(file, point, Graphics::kTTFSizeModeCell, 0, 0, (sharp ? Graphics::kTTFRenderModeMonochrome : Graphics::kTTFRenderModeNormal));
+		newFont = Graphics::loadTTFFont(file, DisposeAfterUse::YES, point, Graphics::kTTFSizeModeCell, 0, 0, (sharp ? Graphics::kTTFRenderModeMonochrome : Graphics::kTTFRenderModeNormal));
 	}
 
 	if (newFont == nullptr) {

--- a/graphics/fonts/ttf.h
+++ b/graphics/fonts/ttf.h
@@ -98,7 +98,7 @@ enum TTFSizeMode {
  *                   supported.
  * @return 0 in case loading fails, otherwise a pointer to the Font object.
  */
-Font *loadTTFFont(Common::SeekableReadStream &stream, int size, TTFSizeMode sizeMode = kTTFSizeModeCharacter, uint xdpi = 0, uint ydpi = 0, TTFRenderMode renderMode = kTTFRenderModeLight, const uint32 *mapping = 0, bool stemDarkening = false);
+Font *loadTTFFont(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse, int size, TTFSizeMode sizeMode = kTTFSizeModeCharacter, uint xdpi = 0, uint ydpi = 0, TTFRenderMode renderMode = kTTFRenderModeLight, const uint32 *mapping = 0, bool stemDarkening = false);
 
 /**
  * Loads a TTF font file from the common fonts archive.

--- a/graphics/macgui/macfontmanager.cpp
+++ b/graphics/macgui/macfontmanager.cpp
@@ -901,7 +901,7 @@ void MacFontManager::generateTTFFont(MacFont &toFont, Common::SeekableReadStream
 	// TODO: Handle getSlant() flags
 
 	stream->seek(0);
-	Font *font = Graphics::loadTTFFont(*stream, toFont.getSize(), Graphics::kTTFSizeModeCharacter, 0, 0, Graphics::kTTFRenderModeMonochrome);
+	Font *font = Graphics::loadTTFFont(stream, DisposeAfterUse::NO, toFont.getSize(), Graphics::kTTFSizeModeCharacter, 0, 0, Graphics::kTTFRenderModeMonochrome);
 
 	if (!font) {
 		warning("Failed to generate font '%s'", toPrintable(getFontName(toFont)).c_str());

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -1748,11 +1748,12 @@ const Graphics::Font *ThemeEngine::loadScalableFont(const Common::String &filena
 	for (Common::ArchiveMemberList::const_iterator i = members.begin(), end = members.end(); i != end; ++i) {
 		Common::SeekableReadStream *stream = (*i)->createReadStream();
 		if (stream) {
-			font = Graphics::loadTTFFont(*stream, pointsize, Graphics::kTTFSizeModeCharacter, 0, 0, Graphics::kTTFRenderModeLight);
-			delete stream;
+			font = Graphics::loadTTFFont(stream, DisposeAfterUse::YES, pointsize, Graphics::kTTFSizeModeCharacter, 0, 0, Graphics::kTTFRenderModeLight);
 
 			if (font)
 				return font;
+
+			delete stream;
 		}
 	}
 

--- a/video/subtitles.cpp
+++ b/video/subtitles.cpp
@@ -241,13 +241,16 @@ Subtitles::~Subtitles() {
 }
 
 void Subtitles::setFont(const char *fontname, int height) {
-	Common::File file;
-
 	_fontHeight = height;
 
 #ifdef USE_FREETYPE2
-	if (file.open(fontname)) {
-		_font = Graphics::loadTTFFont(file, _fontHeight, Graphics::kTTFSizeModeCharacter, 96);
+	Common::File *file = new Common::File();
+	if (file->open(fontname)) {
+		_font = Graphics::loadTTFFont(file, DisposeAfterUse::YES, _fontHeight, Graphics::kTTFSizeModeCharacter, 96);
+		if (!_font)
+			delete file;
+	} else {
+		delete file;
 	}
 
 	if (!_font) {


### PR DESCRIPTION
This reduces memory usage when loading larger fonts - the ZipArchive class already loads the entire file into memory, so requiring a second block of memory for use with FreeType is an issue when dealing with CJK files which can go up to 8 MB.