### PR TITLE
SCUMM: Fix runaway freqmod_offset values in player_v2base (bug #13908)

### DIFF
--- a/engines/scumm/players/player_v2base.cpp
+++ b/engines/scumm/players/player_v2base.cpp
@@ -592,9 +592,10 @@ void Player_V2Base::next_freqs(ChannelInfo *channel) {
 	channel->d.volume    += channel->d.volume_delta;
 	channel->d.base_freq += channel->d.freq_delta;
 
-	channel->d.freqmod_offset += channel->d.freqmod_incr;
-	if (channel->d.freqmod_offset > channel->d.freqmod_modulo)
-		channel->d.freqmod_offset -= channel->d.freqmod_modulo;
+	if (channel->d.freqmod_modulo > 0)
+		channel->d.freqmod_offset = (channel->d.freqmod_offset + channel->d.freqmod_incr) % channel->d.freqmod_modulo;
+	else
+		channel->d.freqmod_offset = 0;
 
 	channel->d.freq =
 		(int)(freqmod_table[channel->d.freqmod_table + (channel->d.freqmod_offset >> 4)])


### PR DESCRIPTION
When arriving at Castle Brunwald in the Macintosh version of Indiana Jones and the Last Crusade, we have the case where freqmod_incr is 300 and freqmod_modulo is 32. Simply subtracgint freqmod_modulo isn't enough to keep the value in line, leading to out of bounds access.

I don't know if freqmod_incr can ever be 0, but let's account for that case as well, by setting freqmod_offset to 0.

See https://bugs.scummvm.org/ticket/13908 for details. I have not been able to reproduce the other ASAN bug mentioned there, so maybe that one has already been fixed? Or maybe I just didn't try hard enough.