### PR TITLE
DIRECTOR: Add demo/preview version of Maths Workshop

### DIFF
--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -1562,6 +1562,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "macos85",			"Mac OS 8.5" },
 	{ "macportable",		"Your Apple Tour of the Macintosh Portable" },
 	{ "mathblasterjr",		"Math Blaster Jr." },
+	{ "mathsworkshop",		"Maths Workshop"},
 	{ "mavisbeacon",		"Mavis Beacon Teaches Typing" },
 	{ "mechwarrior2",		"MechWarrior 2" },
 	{ "meetingmaker",		"Meeting Maker" },
@@ -4643,6 +4644,10 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACDEMO1("mathblasterjr", "Preview v1.0c", "Math Blst Jr. Pwr Mac", "602e61f10c158183218405dd30a09b3f", 60068, 404),
 
 	MACGAME1("mathtest", "", "mathtest (mac)", "cdb27c916044ae4dceb4b7326063fa03", 301925, 400),
+
+	// Demo version of "Maths Workshop", published by Broderbund (1994-1995)
+	// The full game is not made with Director, but with MOHAWK (eriktorbjorn)
+	WINDEMO1t("mathsworkshop", "Preview", "_MATHDAT.EXE", "5306745f0734b6cbd94e4567a0b5805a", 696931, 400),
 
 	// German title is Max und die Geheimformel
 	// German demo from CD ROM Hits 1995-10

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -4647,7 +4647,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	// Demo version of "Maths Workshop", published by Broderbund (1994-1995)
 	// The full game is not made with Director, but with MOHAWK (eriktorbjorn)
-	WINDEMO1t("mathsworkshop", "Preview", "_MATHDAT.EXE", "5306745f0734b6cbd94e4567a0b5805a", 696931, 400),
+	WINDEMO1("mathsworkshop", "Preview", "_MATHDAT.EXE", "t:5306745f0734b6cbd94e4567a0b5805a", 696931, 400),
 
 	// German title is Max und die Geheimformel
 	// German demo from CD ROM Hits 1995-10

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -1562,7 +1562,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "macos85",			"Mac OS 8.5" },
 	{ "macportable",		"Your Apple Tour of the Macintosh Portable" },
 	{ "mathblasterjr",		"Math Blaster Jr." },
-	{ "mathsworkshop",		"Maths Workshop"},
+	{ "mathsworkshop",		"Maths Workshop" },
 	{ "mavisbeacon",		"Mavis Beacon Teaches Typing" },
 	{ "mechwarrior2",		"MechWarrior 2" },
 	{ "meetingmaker",		"Meeting Maker" },


### PR DESCRIPTION
This PR adds a detection entry to a demo/preview version of "Maths Workshop", and [educational title released by Broderbund in 1995](https://www.mobygames.com/game/12160/math-workshop/).

While the full game doesn't run in DIRECTOR, but uses MOHAWK according to @eriktorbjorn, this preview release is made with Director 4.00.

I briefly tested the application and at first glance it seems to work fine using the fallback detection.

I'm submitting this as PR since I'm not that familiar with the DIRECTOR engine. In case we need a new test case for the DIRECTOR buildbot, I uploaded the demo provided by @eriktorbjorn [to our FRS](https://downloads.scummvm.org/frs/demos/director/d4/en/mathsworkshop-demo-win.zip).

I'll create a proper entry for it in the spreadsheet once this is merged.