### PR TITLE
GOB: updated fallback detection to latest changes

### DIFF
--- a/engines/gob/detection/tables_fallback.h
+++ b/engines/gob/detection/tables_fallback.h
@@ -386,7 +386,7 @@ static const GOBGameDescription fallbackDescs[] = {
 			GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 		},
 		kGameTypeAdi2,
-		kFeatures640x480,
+		kFeatures640x400,
 		"adi2.stk", 0, 0
 	},
 	{ //26
@@ -395,7 +395,7 @@ static const GOBGameDescription fallbackDescs[] = {
 			"",
 			AD_ENTRY1(0, 0),
 			UNK_LANG,
-			kPlatformDOS,
+			kPlatformWindows,
 			ADGF_NO_FLAGS,
 			GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 		},


### PR DESCRIPTION
- use for Adi 2 640x400 instead of 640x480 like in tables_adi2.h
- set for Adi 4 Platform from DOS to Windows like in tables_adi4.h