### PR TITLE
TINSEL: Fix DW2 deadlock in PCMMusicPlayer when loading scene

### DIFF
--- a/engines/tinsel/music.cpp
+++ b/engines/tinsel/music.cpp
@@ -839,6 +839,11 @@ void PCMMusicPlayer::restoreThatTune(void *voidPtr) {
 void PCMMusicPlayer::setMusicSceneDetails(SCNHANDLE hScript,
 		SCNHANDLE hSegment, const char *fileName) {
 
+	// A call to setVol(uint8) later in this method will lock the mixer.
+	// To match the locking order of the audio thread and prevent a deadlock,
+	// we preemptively lock it here first.
+	// See bug #13953
+	Common::StackLock mixerLock(_vm->_mixer->mutex());
 	Common::StackLock lock(_mutex);
 
 	stop();


### PR DESCRIPTION
This fixes a potential deadlock due to different locking order:

Audio thread:
A: `Audio::MixerImpl::_mutex` in `Audio::MixerImpl::mixCallback(unsigned char*, unsigned int)`
B: `Tinsel::PCMMusicPlayer::_mutex` in `Tinsel::PCMMusicPlayer::readBuffer(short*, int)`

Main thread:
A: `Tinsel::PCMMusicPlayer::_mutex` in `Tinsel::PCMMusicPlayer::setMusicSceneDetails(unsigned int, unsigned int, char const*)`
B: `Audio::MixerImpl::_mutex` in `Audio::MixerImpl::setChannelVolume(Audio::SoundHandle, unsigned char)`

Fixes [#13953](https://bugs.scummvm.org/ticket/13953)

The ticket contains info on how to reproduce the problem.