### PR TITLE
DREAMWEB: Fix save parsing in querySaveMetaInfos

### DIFF
--- a/engines/dreamweb/metaengine.cpp
+++ b/engines/dreamweb/metaengine.cpp
@@ -151,7 +151,7 @@ SaveStateList DreamWebMetaEngine::listSaves(const char *target) const {
 		if (!stream)
 			error("cannot open save file %s", file.c_str());
 		char name[17] = {};
-		stream->seek(0x61);
+		stream->seek(0x61); // The actual description string starts at desc[1]
 		stream->read(name, sizeof(name) - 1);
 		delete stream;
 
@@ -180,19 +180,16 @@ SaveStateDescriptor DreamWebMetaEngine::querySaveMetaInfos(const char *target, i
 		DreamWeb::FileHeader header;
 		in->read((uint8 *)&header, sizeof(DreamWeb::FileHeader));
 
-		Common::String saveName;
-		byte descSize = header.len(0);
-		byte i;
+		char name[17] = {};
+		in->skip(1); // The actual description string starts at desc[1]
+		in->read(name, sizeof(name) - 1);
 
-		for (i = 0; i < descSize; i++)
-			saveName += (char)in->readByte();
-
-		SaveStateDescriptor desc(this, slot, saveName);
+		SaveStateDescriptor desc(this, slot, name);
 
 		// Check if there is a ScummVM data block
 		if (header.len(6) == SCUMMVM_BLOCK_MAGIC_SIZE) {
 			// Skip the game data
-			for (i = 1; i <= 5; i++)
+			for (byte i = 1; i <= 5; i++)
 				in->skip(header.len(i));
 
 			uint32 tag = in->readUint32BE();


### PR DESCRIPTION
Save parsing in `querySaveMetaInfos` had an off-by-one error. `listSaves` contains the correct parsing.

This caused save descriptions to accumulate a leading junk byte (0x02). As saves were loaded and re-saved, this added more junk bytes until the ScummVM list GUI either displayed an empty string or crashed.

This bug affected users differently depending on if they used the list or grid view for saving and loading.

`querySaveMetaInfos` parsing now matches `listSaves`.

Fixes bug #14561


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
