### PR TITLE
TINSEL: Game Option to crop black bars (DW2/NOIR)

### DIFF
--- a/engines/tinsel/detection.h
+++ b/engines/tinsel/detection.h
@@ -26,6 +26,9 @@
 
 namespace Tinsel {
 
+// (Optionally) remove the "baked-in" letterboxing in Discworld 2/Noir.
+#define GAMEOPTION_CROP_HEIGHT_480_TO_432      GUIO_GAMEOPTIONS1
+
 enum TinselGameID {
 	GID_DW1 = 0,
 	GID_DW2 = 1,

--- a/engines/tinsel/detection_tables.h
+++ b/engines/tinsel/detection_tables.h
@@ -625,6 +625,7 @@ static const TinselGameDescription gameDescriptions[] = {
 
 	// ==== Discworld 2 entries ===============================================
 	// Note: All Discworld 2 versions are CD only, therefore we don't add the ADGF_CD flag
+#define DISCWORLD2_GUIOPTIONS GUIO2(GUIO_NOASPECT, GAMEOPTION_CROP_HEIGHT_480_TO_432)
 
 	{	// English Discworld 2 demo
 		{
@@ -635,7 +636,7 @@ static const TinselGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_DEMO,
-			GUIO1(GUIO_NOASPECT)
+			DISCWORLD2_GUIOPTIONS
 		},
 		GID_DW2,
 		0,
@@ -652,7 +653,7 @@ static const TinselGameDescription gameDescriptions[] = {
 			Common::EN_GRB,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOASPECT)
+			DISCWORLD2_GUIOPTIONS
 		},
 		GID_DW2,
 		0,
@@ -669,7 +670,7 @@ static const TinselGameDescription gameDescriptions[] = {
 			Common::EN_USA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOASPECT)
+			DISCWORLD2_GUIOPTIONS
 		},
 		GID_DW2,
 		0,
@@ -686,7 +687,7 @@ static const TinselGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOASPECT)
+			DISCWORLD2_GUIOPTIONS
 		},
 		GID_DW2,
 		0,
@@ -703,7 +704,7 @@ static const TinselGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOASPECT)
+			DISCWORLD2_GUIOPTIONS
 		},
 		GID_DW2,
 		0,
@@ -724,7 +725,7 @@ static const TinselGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOASPECT)
+			DISCWORLD2_GUIOPTIONS
 		},
 		GID_DW2,
 		0,
@@ -744,7 +745,7 @@ static const TinselGameDescription gameDescriptions[] = {
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOASPECT)
+			DISCWORLD2_GUIOPTIONS
 		},
 		GID_DW2,
 		0,
@@ -765,7 +766,7 @@ static const TinselGameDescription gameDescriptions[] = {
 			Common::RU_RUS,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOASPECT)
+			DISCWORLD2_GUIOPTIONS
 		},
 		GID_DW2,
 		0,
@@ -776,6 +777,7 @@ static const TinselGameDescription gameDescriptions[] = {
 	// ==== Discworld Noir entries ===============================================
 	// Note: All Discworld Noir versions are CD only, therefore we don't add the ADGF_CD flag
 
+#define NOIR_GUIOPTIONS GUIO1(GAMEOPTION_CROP_HEIGHT_480_TO_432)
 	{ // Discworld Noir, Windows 3CD version
 		{
 			"noir",
@@ -785,7 +787,7 @@ static const TinselGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_UNSTABLE,
-			GUIO0()
+			NOIR_GUIOPTIONS
 
 		},
 		GID_NOIR,
@@ -803,7 +805,7 @@ static const TinselGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_UNSTABLE | ADGF_DEMO,
-			GUIO0()
+			NOIR_GUIOPTIONS
 		},
 		GID_NOIR,
 		0,

--- a/engines/tinsel/metaengine.cpp
+++ b/engines/tinsel/metaengine.cpp
@@ -20,6 +20,8 @@
  */
 
 #include "common/savefile.h"
+#include "common/config-manager.h"
+#include "common/translation.h"
 
 #include "engines/advancedDetector.h"
 
@@ -29,6 +31,21 @@
 #include "tinsel/savescn.h"	// needed by TinselMetaEngine::
 
 #include "tinsel/detection.h"
+
+static const ADExtraGuiOptionsMap optionsList[] = {
+	{
+		GAMEOPTION_CROP_HEIGHT_480_TO_432,
+		{
+			_s("Remove Black Bars"),
+			_s("The game originally renders at 640x432 which is then presented letterboxed at 640x480. Enabling this option removes the forced letterbox effect, so that the game fits better on screens with an aspect ratio wider than 4:3."),
+			"crop_black_bars",
+			false,
+			0,
+			0
+		}
+	},
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR
+};
 
 namespace Tinsel {
 
@@ -77,6 +94,9 @@ public:
 	void removeSaveState(const char *target, int slot) const override;
 
 	// TODO: Add getSavegameFile(). See comments in loadGameState and removeSaveState
+	
+	void registerDefaultSettings(const Common::String &target) const override;
+	const ADExtraGuiOptionsMap *getAdvancedExtraGuiOptions() const override;
 };
 
 bool TinselMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -196,6 +216,14 @@ void TinselMetaEngine::removeSaveState(const char *target, int slot) const {
 	g_system->getSavefileManager()->removeSavefile(Tinsel::ListEntry(listSlot, Tinsel::LE_NAME));
 	Tinsel::setNeedLoad();
 	Tinsel::getList(g_system->getSavefileManager(), target);
+}
+
+void TinselMetaEngine::registerDefaultSettings(const Common::String &target) const {
+	ConfMan.registerDefault("crop_black_bars", false); // show the black bars by default (original behaviour)
+}
+
+const ADExtraGuiOptionsMap *TinselMetaEngine::getAdvancedExtraGuiOptions() const {
+	return optionsList;
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(TINSEL)

--- a/engines/tinsel/tinsel.cpp
+++ b/engines/tinsel/tinsel.cpp
@@ -1030,6 +1030,8 @@ Common::Error TinselEngine::run() {
 	if (getGameID() == GID_NOIR) {
 		int width = 640;
 		int height = 480;
+		if (ConfMan.getBool("crop_black_bars"))
+			height = 432;
 
 		Graphics::PixelFormat noirFormat(2, 5, 6, 5, 0, 11, 5, 0, 0);
 
@@ -1037,11 +1039,10 @@ Common::Error TinselEngine::run() {
 
 		_screenSurface.create(width, 432, noirFormat);
 	} else if (getGameID() == GID_DW2) {
-#ifndef DW2_EXACT_SIZE
-		initGraphics(640, 480);
-#else
-		initGraphics(640, 432);
-#endif
+		if (ConfMan.getBool("crop_black_bars"))
+			initGraphics(640, 432);
+		else
+			initGraphics(640, 480);
 		_screenSurface.create(640, 432, Graphics::PixelFormat::createFormatCLUT8());
 	} else {
 		initGraphics(320, 200);


### PR DESCRIPTION
Discworld 2 and Discworld Noir both render at 640x432, which by default is letterboxed in a 640x480 virtual window. The user can instead opt for a 640x432 virtual window; to remove the letterboxing.

Add a checkbox option (`GUI::CheckboxWidget`) so the user can remove the forced letterbox effect in Discworld 2 and Discworld Noir. Enabling the option allows the games to fit better in a window that has an aspect ratio wider than 4:3.

![image](https://github.com/scummvm/scummvm/assets/1984342/873e2a79-e093-4633-a770-8c58b1190a74)

With the option disabled (using "Stretch Mode: Fit to Window"):
![image](https://github.com/scummvm/scummvm/assets/1984342/114bc83f-b0a7-425c-9024-1eab98c8bd2a)
With the option enabled (using "Stretch Mode: Fit to Window")
![image](https://github.com/scummvm/scummvm/assets/1984342/d70a7534-fc6e-46e7-91f2-b0f9bb210185)

Note: this replaces the (dormant) pre-processor directive for DW2 (`#ifdef DW2_EXACT_SIZE`) with a user configurable option that is also available for NOIR.

This feature can be tested with the demos for [DW2 and NOIR](https://www.scummvm.org/demos/#other).
___
Refactoring:
- Tidy DW2/NOIR GUI options behind defined GLOBALs (because all detectable variants of DW2 and NOIR use the same GUI options).