### PR TITLE
COMMON: Making INI parser to ignore garbage values

### DIFF
--- a/common/formats/ini-file.cpp
+++ b/common/formats/ini-file.cpp
@@ -88,7 +88,14 @@ bool INIFile::loadFromSaveFile(const String &filename) {
 	delete loadFile;
 	return status;
 }
-
+bool INIFile::isAscii(const String& str) {
+    for (char c : str) {
+        if (c < 32 || c > 126) {
+            return false;
+        }
+    }
+    return true;
+}
 bool INIFile::loadFromStream(SeekableReadStream &stream) {
 	static const byte UTF8_BOM[] = {0xEF, 0xBB, 0xBF};
 	Section section;
@@ -112,9 +119,10 @@ bool INIFile::loadFromStream(SeekableReadStream &stream) {
 		}
 
 		line.trim();
+		// Check for lines containing control characters and ignore them
 
-		if (line.size() == 0) {
-			// Do nothing
+		if (line.size() == 0 || !isAscii(line)) {
+			// If there is no string in a line or have non-ascii then it will ignore it
 		} else if (line[0] == '#' || line[0] == ';' || line.hasPrefix("//")) {
 			// Accumulate comments here. Once we encounter either the start
 			// of a new section, or a key-value-pair, we associate the value

--- a/common/formats/ini-file.h
+++ b/common/formats/ini-file.h
@@ -125,6 +125,8 @@ public:
 	void	setKey(const String &key, const String &section, const String &value); /*!< Assign a @p value to a @p key in a @p section. */
 	void	removeKey(const String &key, const String &section); /*!< Remove a @p key from this @p section. */
 
+	bool    isAscii(const String &filename); /*!< Checks if the given string consists of ASCII characters */
+
 	const SectionList getSections() const { return _sections; } /*!< Get a list of sections in this INI file. */
 	const SectionKeyList getKeys(const String &section) const; /*!< Get a list of keys in a @p section. */
 


### PR DESCRIPTION
The pull request resolve a bug in French sheila(https://bugs.scummvm.org/ticket/13920)
in INI Parser
- Added a function to check if Line contains garbage then ignore it