### PR TITLE
TRECISION: Fix thumbnail when using ScummVM menu to save (bug #13834)

### DIFF
--- a/engines/trecision/logic.cpp
+++ b/engines/trecision/logic.cpp
@@ -3988,7 +3988,9 @@ void LogicManager::handleClickControlPanel(uint16 curObj) {
 		if (_vm->_oldRoom == kRoomControlPanel)
 			break;
 		_vm->_curRoom = _vm->_obj[o00EXIT]._goRoom;
+		_vm->_controlPanelSave = true;
 		_vm->dataSave();
+		_vm->_controlPanelSave = false;
 		_vm->showInventoryName(NO_OBJECTS, false);
 		_vm->showIconName();
 		_vm->changeRoom(_vm->_obj[o00EXIT]._goRoom);

--- a/engines/trecision/metaengine.cpp
+++ b/engines/trecision/metaengine.cpp
@@ -68,7 +68,13 @@ void TrecisionMetaEngine::getSavegameThumbnail(Graphics::Surface &thumb) {
 	// We are referencing g_engine here, but this should be safe, as this
 	// method is only used while the engine is running.
 	// TODO: Is there a better way to do this?
-	thumb.copyFrom(((Trecision::TrecisionEngine *)g_engine)->_thumbnail);
+
+	Trecision::TrecisionEngine *engine = (Trecision::TrecisionEngine *)g_engine;
+
+	if (engine->_controlPanelSave)
+		thumb.copyFrom(engine->_thumbnail);
+	else
+		MetaEngine::getSavegameThumbnail(thumb);
 }
 
 SaveStateDescriptor TrecisionMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/trecision/trecision.h
+++ b/engines/trecision/trecision.h
@@ -243,6 +243,7 @@ public:
 	const ADGameDescription *_gameDescription;
 
 	Graphics::Surface _thumbnail;
+	bool _controlPanelSave = false;
 
 	uint16 _curRoom;
 	uint16 _oldRoom;


### PR DESCRIPTION
When saving from the game's control panel, we use the thumbnail that was created before the control panel opened. But when using the ScummVM menu, we need to generate the thumbnail as usual. Otherwise, there may not be any thumbnail at all, causing the save to fail.

The cases I have at least tried are:

- Pressing ESC to save with the game's native save dialog
- Pressing Ctrl+F5 to save with ScummVM's save dialog
- Pressing ESC to save with ScummVM's save dialog (i.e. original dialogs not enabled in the game settings)

But I'm not familiar with this engine, so there may be a better way? I'm submitting this because https://bugs.scummvm.org/ticket/13834 is a prioritized bug for 2.8.0.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
