### PR TITLE
AGI: Multiple detection entries imported from TRAC

### DIFF
--- a/engines/agi/detection_tables.h
+++ b/engines/agi/detection_tables.h
@@ -838,9 +838,9 @@ static const AGIGameDescription gameDescriptions[] = {
 	// Menus not tested
 	GAME("sq2", "2.0C/A 5.25\"/ST", "bd71fe54869e86945041700f1804a651", 0x2917, GID_SQ2),
 
-	// Space Quest 2 (3.5") 2.0C [AGI 2.917]
+	// Space Quest 2 (PC 3.5") 2.0C [AGI 2.917]
 	// TRAC #14287
-	GAME("sq2", "2.0C 3.5\"", "b394eaae1dfe4203378e02641178959c", 0x2917, GID_SQ2),
+	GAME_PS("sq2", "2.0C 3.5\"", "b394eaae1dfe4203378e02641178959c", 426, 0x2917, GID_SQ2, Common::kPlatformDOS),
 
 	// Space Quest 2 (PC 5.25") 2.0C [AGI 2.917]
 	// TRAC #14286

--- a/engines/agi/detection_tables.h
+++ b/engines/agi/detection_tables.h
@@ -838,6 +838,10 @@ static const AGIGameDescription gameDescriptions[] = {
 	// TRAC #14286
 	GAME("sq2", "2.0C 5.25\"", "7d29fccae8765ae298cfe720a6d771b1", 0x2917, GID_SQ2),
 
+	// Space Quest 2 (PC 5.25") 2.0D [AGI 2.936]
+	// TRAC #13274
+	GAME_LPS("sq2", "2.0D 1988-03-14 5.25\"", "0884ea4e127e333986568775fb21600b", 426, Common::EN_USA, 0x2936, GID_SQ2, Common::kPlatformDOS),
+
 	// Space Quest 2 (PC 3.5") 2.0F [AGI 2.936]
 	GAME("sq2", "2.0F 1989-01-05 3.5\"", "28add5125484302d213911df60d2aded", 0x2936, GID_SQ2),
 

--- a/engines/agi/detection_tables.h
+++ b/engines/agi/detection_tables.h
@@ -474,6 +474,10 @@ static const AGIGameDescription gameDescriptions[] = {
 	// King's Quest 2 (PC 5.25"/3.5") 2.2 [AGI 2.426]
 	GAME("kq2", "2.2 1987-05-07 5.25\"/3.5\"", "b944c4ff18fb8867362dc21cc688a283", 0x2917, GID_KQ2),
 
+	// King's Quest 2 (PC 5.25"/3.5") 2.2 [AGI 2.426] with fanmade Spanish translation
+	// TRAC #14604
+	GAME_LPS("kq2", "2.2 1987-05-07 5.25\"/3.5\"", "252354b72d7062228cfe1b6f8211c761", 543, Common::ES_ESP, 0x2917, GID_KQ2, Common::kPlatformDOS),
+
 	// King's Quest 2 (Russian)
 	GAME_LPS("kq2", "", "35211c574ececebdc723b23e35f99275", 543, Common::RU_RUS, 0x2917, GID_KQ2, Common::kPlatformDOS),
 

--- a/engines/agi/detection_tables.h
+++ b/engines/agi/detection_tables.h
@@ -546,6 +546,10 @@ static const AGIGameDescription gameDescriptions[] = {
 	// Menus not tested
 	GAME3("kq4", "2.2 1988-09-27 3.5\"", "kq4dir", "7470b3aeb49d867541fc66cc8454fb7d", 0x3086, GID_KQ4),
 
+	// King's Quest 4 (PC 5.25") 2.2 9/27/88 [AGI 3.002.086]
+	// TRAC #13734
+	GAME3_PS("kq4", "2.2 1988-09-27 5.25\"", "kq4dir", "106219d71140823f6bec1d9747128796", 2786, 0x3086, 0, GID_KQ4, Common::kPlatformDOS),
+
 	// King's Quest 4 (PC 5.25") 2.3 9/27/88 [AGI 3.002.086]
 	GAME3("kq4", "2.3 1988-09-27", "kq4dir", "6d7714b8b61466a5f5981242b993498f", 0x3086, GID_KQ4),
 

--- a/engines/agi/detection_tables.h
+++ b/engines/agi/detection_tables.h
@@ -842,7 +842,7 @@ static const AGIGameDescription gameDescriptions[] = {
 	GAME("sq2", "2.0F 1989-01-05 3.5\"", "28add5125484302d213911df60d2aded", 0x2936, GID_SQ2),
 
 	// Space Quest 2 (PC 5.25") 2.0F [AGI 2.936]
-	GAME("sq2", "2.0F 1989-01-05 3.5\"", "bb5a44d0bea416f2cd4c3385eaa21af4", 0x2936, GID_SQ2),
+	GAME("sq2", "2.0F 1989-01-05 5.25\"", "bb5a44d0bea416f2cd4c3385eaa21af4", 0x2936, GID_SQ2),
 
 	// Space Quest 2 (CoCo3 360k) [AGI 2.023]
 	GAME_PS("sq2", "", "12973d39b892dc9d280257fd271e9597", 768, 0x2440, GID_SQ2, Common::kPlatformCoCo3),

--- a/engines/agi/detection_tables.h
+++ b/engines/agi/detection_tables.h
@@ -834,6 +834,10 @@ static const AGIGameDescription gameDescriptions[] = {
 	// Menus not tested
 	GAME("sq2", "2.0C/A 5.25\"/ST", "bd71fe54869e86945041700f1804a651", 0x2917, GID_SQ2),
 
+	// Space Quest 2 (3.5") 2.0C [AGI 2.917]
+	// TRAC #14287
+	GAME("sq2", "2.0C 3.5\"", "b394eaae1dfe4203378e02641178959c", 0x2917, GID_SQ2),
+
 	// Space Quest 2 (5.25") 2.0C [AGI 2.917]
 	// TRAC #14286
 	GAME("sq2", "2.0C 5.25\"", "7d29fccae8765ae298cfe720a6d771b1", 0x2917, GID_SQ2),

--- a/engines/agi/detection_tables.h
+++ b/engines/agi/detection_tables.h
@@ -834,6 +834,10 @@ static const AGIGameDescription gameDescriptions[] = {
 	// Menus not tested
 	GAME("sq2", "2.0C/A 5.25\"/ST", "bd71fe54869e86945041700f1804a651", 0x2917, GID_SQ2),
 
+	// Space Quest 2 (5.25") 2.0C [AGI 2.917]
+	// TRAC #14286
+	GAME("sq2", "2.0C 5.25\"", "7d29fccae8765ae298cfe720a6d771b1", 0x2917, GID_SQ2),
+
 	// Space Quest 2 (PC 3.5") 2.0F [AGI 2.936]
 	GAME("sq2", "2.0F 1989-01-05 3.5\"", "28add5125484302d213911df60d2aded", 0x2936, GID_SQ2),
 

--- a/engines/agi/detection_tables.h
+++ b/engines/agi/detection_tables.h
@@ -842,9 +842,9 @@ static const AGIGameDescription gameDescriptions[] = {
 	// TRAC #14287
 	GAME("sq2", "2.0C 3.5\"", "b394eaae1dfe4203378e02641178959c", 0x2917, GID_SQ2),
 
-	// Space Quest 2 (5.25") 2.0C [AGI 2.917]
+	// Space Quest 2 (PC 5.25") 2.0C [AGI 2.917]
 	// TRAC #14286
-	GAME("sq2", "2.0C 5.25\"", "7d29fccae8765ae298cfe720a6d771b1", 0x2917, GID_SQ2),
+	GAME_PS("sq2", "2.0C 5.25\"", "7d29fccae8765ae298cfe720a6d771b1", 426, 0x2917, GID_SQ2, Common::kPlatformDOS),
 
 	// Space Quest 2 (PC 5.25") 2.0D [AGI 2.936]
 	// TRAC #13274


### PR DESCRIPTION
Hi all,

submitting this as PR due to the various macros used in the AGI detection.

This resolves the following tickets:

[TRAC #13734](https://bugs.scummvm.org/ticket/13734)
[TRAC #14286](https://bugs.scummvm.org/ticket/14286)
[TRAC #13274](https://bugs.scummvm.org/ticket/13274)
[TRAC #14287](https://bugs.scummvm.org/ticket/14287)
[TRAC #14604](https://bugs.scummvm.org/ticket/14604)