### PR TITLE
DIRECTOR: Make b_getNthFileNameInFolder return "" on no match

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1222,7 +1222,7 @@ void LB::b_getNthFileNameInFolder(int nargs) {
 			break;
 	}
 
-	Datum r;
+	Datum r("");
 	Common::Array<Common::String> fileNameList;
 
 	// First, mix in any files injected from the quirks


### PR DESCRIPTION
The correct behaviour in Director, when polling getNthFileNameInFolder with an index higher than the number of available files, is to return an empty string. Previously our equality logic would coerce VOID to be equal to "", which is not correct, and disguised the issue of us returning VOID in b_getNthFileNameInFolder.

Fixes startup sequence in Team Xtreme: Operation Weather Disaster; however checking for "" is a fairly common pattern as it is the only way of testing how many files there are in a folder with Director's API.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
