### PR TITLE
MM: MM1: Fix GCC ABI Mangling Warnings Caused By Lambda Functions

### DIFF
--- a/engines/mm/mm1/maps/map12.cpp
+++ b/engines/mm/mm1/maps/map12.cpp
@@ -184,6 +184,20 @@ void Map12::polyhedron(unsigned char side1, unsigned char side2) {
 	send(SoundMessage(msg));
 }
 
+void Map12::keyCallbackSpinPolyhedronTwo() {
+	static_cast<Map12 *>(g_maps->_currentMap)->spinPolyhedron(0);
+	g_maps->_currentMap->updateGame();
+}
+
+void Map12::keyCallbackSpinPolyhedronOne(const Common::KeyState &ks) {
+	if (ks.keycode >= Common::KEYCODE_0 && ks.keycode <= Common::KEYCODE_9) {
+		g_events->close();
+		Map12 &map = *static_cast<Map12 *>(g_maps->_currentMap);
+		map.spinPolyhedron(ks.ascii | 0x80);
+		map.none160();
+	}
+}
+
 void Map12::setPolyhedron(int polyIndex) {
 	_polyIndex = polyIndex;
 
@@ -191,27 +205,9 @@ void Map12::setPolyhedron(int polyIndex) {
 		Common::String msg = Common::String::format(
 			STRING["maps.map12.polyhedron2"].c_str(),
 			_data[SELECTIONS + polyIndex]);
-		send(SoundMessage(
-			msg,
-			[]() {
-				static_cast<Map12 *>(g_maps->_currentMap)->spinPolyhedron(0);
-				g_maps->_currentMap->updateGame();
-			}
-		));
-
+		send(SoundMessage(msg, keyCallbackSpinPolyhedronTwo));
 	} else {
-		send(SoundMessage(
-			STRING["maps.map12.polyhedron1"],
-			[](const Common::KeyState &ks) {
-				if (ks.keycode >= Common::KEYCODE_0 &&
-						ks.keycode <= Common::KEYCODE_9) {
-					g_events->close();
-					Map12 &map = *static_cast<Map12 *>(g_maps->_currentMap);
-					map.spinPolyhedron(ks.ascii | 0x80);
-					map.none160();
-				}	
-			}
-		));
+		send(SoundMessage(STRING["maps.map12.polyhedron1"], keyCallbackSpinPolyhedronOne));
 	}
 }
 

--- a/engines/mm/mm1/maps/map12.h
+++ b/engines/mm/mm1/maps/map12.h
@@ -33,6 +33,9 @@ class Map12 : public Map {
 private:
 	int _polyIndex = 0;
 
+	static void keyCallbackSpinPolyhedronTwo();
+	static void keyCallbackSpinPolyhedronOne(const Common::KeyState &ks);
+
 	void special00();
 	void special01();
 	void special02();

--- a/engines/mm/mm1/views/character_info.cpp
+++ b/engines/mm/mm1/views/character_info.cpp
@@ -406,23 +406,22 @@ void CharacterInfo::howMuchEntered(uint amount) {
 	redraw();
 }
 
+void CharacterInfo::abortFunc() {
+	CharacterInfo *view = (CharacterInfo *)g_events->focusedView();
+	view->howMuchAborted();
+}
+
+void CharacterInfo::enterFunc(const Common::String &text) {
+	CharacterInfo *view = (CharacterInfo *)g_events->focusedView();
+	view->howMuchEntered(atoi(text.c_str()));
+}
+
 void CharacterInfo::tradeHowMuch() {
 	clearLines(20, 24);
 	escToGoBack(0);
 	writeString(10, 20, STRING["dialogs.character.how_much"]);
 
-	_textEntry.display(20, 20, 5, true,
-		[]() {
-			CharacterInfo *view =
-				(CharacterInfo *)g_events->focusedView();
-			view->howMuchAborted();
-		},
-		[](const Common::String &text) {
-			CharacterInfo *view =
-				(CharacterInfo *)g_events->focusedView();
-			view->howMuchEntered(atoi(text.c_str()));
-		}
-	);
+	_textEntry.display(20, 20, 5, true, abortFunc, enterFunc);
 }
 
 void CharacterInfo::combatUseItem(Inventory &inv, Inventory::Entry &invEntry, bool isEquipped) {

--- a/engines/mm/mm1/views/character_info.h
+++ b/engines/mm/mm1/views/character_info.h
@@ -49,6 +49,8 @@ private:
 	int _tradeWith = -1;
 	TransferKind _tradeKind = TK_GEMS;
 	TextEntry _textEntry;
+	static void abortFunc();
+	static void enterFunc(const Common::String &text);
 private:
 	/**
 	 * Discards the item at the given index
@@ -84,7 +86,6 @@ private:
 	 * Using an item outside of combat
 	 */
 	void nonCombatUseItem(Inventory &inv, Inventory::Entry &invEntry, bool isEquipped);
-
 public:
 	CharacterInfo() : CharacterBase("CharacterInfo") {}
 	virtual ~CharacterInfo() {}

--- a/engines/mm/mm1/views/spells/cast_spell.cpp
+++ b/engines/mm/mm1/views/spells/cast_spell.cpp
@@ -79,6 +79,21 @@ void CastSpell::setState(State state) {
 	draw();
 }
 
+void CastSpell::abortFunc() {
+	CastSpell *view = (CastSpell *)g_events->focusedView();
+	view->close();
+}
+
+void CastSpell::enterSpellLevelFunc(const Common::String &text) {
+	CastSpell *view = (CastSpell *)g_events->focusedView();
+	view->spellLevelEntered(atoi(text.c_str()));
+}
+
+void CastSpell::enterSpellNumberFunc(const Common::String &text) {
+	CastSpell *view = (CastSpell *)g_events->focusedView();
+	view->spellNumberEntered(atoi(text.c_str()));
+}
+
 void CastSpell::draw() {
 	clearSurface();
 	if (_state == NONE)
@@ -100,34 +115,12 @@ void CastSpell::draw() {
 	switch (_state) {
 	case SELECT_SPELL:
 		_state = NONE;
-		_textEntry.display(27, 20, 1, true,
-			[]() {
-				CastSpell *view =
-					(CastSpell *)g_events->focusedView();
-				view->close();
-			},
-			[](const Common::String &text) {
-				CastSpell *view =
-					(CastSpell *)g_events->focusedView();
-				view->spellLevelEntered(atoi(text.c_str()));
-			}
-			);
+		_textEntry.display(27, 20, 1, true, abortFunc, enterSpellLevelFunc);
 		break;
 
 	case SELECT_NUMBER:
 		_state = NONE;
-		_textEntry.display(27, 21, 1, true,
-			[]() {
-				CastSpell *view =
-					(CastSpell *)g_events->focusedView();
-				view->close();
-			},
-			[](const Common::String &text) {
-				CastSpell *view =
-					(CastSpell *)g_events->focusedView();
-				view->spellNumberEntered(atoi(text.c_str()));
-			}
-			);
+		_textEntry.display(27, 21, 1, true, abortFunc, enterSpellNumberFunc);
 		break;
 
 	case SELECT_CHAR:

--- a/engines/mm/mm1/views/spells/cast_spell.h
+++ b/engines/mm/mm1/views/spells/cast_spell.h
@@ -38,6 +38,9 @@ class CastSpell : public SpellView, public MM1::Game::SpellCasting {
 private:
 	State _state = SELECT_SPELL;
 	TextEntry _textEntry;
+	static void abortFunc();
+	static void enterSpellLevelFunc(const Common::String &text);
+	static void enterSpellNumberFunc(const Common::String &text);
 	int _spellLevel = -1;
 	int _spellNumber = -1;
 	Common::String _spellResult;

--- a/engines/mm/mm1/views_enh/character_manage.cpp
+++ b/engines/mm/mm1/views_enh/character_manage.cpp
@@ -47,6 +47,16 @@ bool CharacterManage::msgUnfocus(const UnfocusMessage &msg) {
 	return true;
 }
 
+void CharacterManage::abortFunc() {
+	CharacterManage *view = static_cast<CharacterManage *>(g_events->focusedView());
+	view->setMode(DISPLAY);
+}
+
+void CharacterManage::enterFunc(const Common::String &name) {
+	CharacterManage *view = static_cast<CharacterManage *>(g_events->focusedView());
+	view->setName(name);
+}
+
 void CharacterManage::draw() {
 	assert(g_globals->_currCharacter);
 	setReduced(false);
@@ -65,16 +75,7 @@ void CharacterManage::draw() {
 	case RENAME:
 		_state = DISPLAY;
 		writeString(80, 172, STRING["dialogs.view_character.name"]);
-		_textEntry.display(130, 180, 15, false,
-			[]() {
-				CharacterManage *view = static_cast<CharacterManage *>(g_events->focusedView());
-				view->setMode(DISPLAY);
-			},
-			[](const Common::String &name) {
-				CharacterManage *view = static_cast<CharacterManage *>(g_events->focusedView());
-				view->setName(name);
-			}
-		);
+		_textEntry.display(130, 180, 15, false, abortFunc, enterFunc);
 		break;
 
 	case DELETE:

--- a/engines/mm/mm1/views_enh/character_manage.h
+++ b/engines/mm/mm1/views_enh/character_manage.h
@@ -40,6 +40,8 @@ private:
 	Common::String _newName;
 	bool _changed = false;
 	TextEntry _textEntry;
+	static void abortFunc();
+	static void enterFunc(const Common::String &name);
 
 	/**
 	 * Set the mode
@@ -50,7 +52,6 @@ private:
 	 * Set a new name
 	 */
 	void setName(const Common::String &newName);
-
 public:
 	CharacterManage();
 	virtual ~CharacterManage() {}

--- a/engines/mm/mm1/views_enh/create_characters.cpp
+++ b/engines/mm/mm1/views_enh/create_characters.cpp
@@ -550,6 +550,18 @@ bool CreateCharacters::msgAction(const ActionMessage &msg) {
 	return false;
 }
 
+void CreateCharacters::abortFunc() {
+	CreateCharacters *view = static_cast<CreateCharacters *>(g_events->focusedView());
+	view->setState(SELECT_CLASS);
+}
+
+void CreateCharacters::enterFunc(const Common::String &name) {
+	CreateCharacters *view = static_cast<CreateCharacters *>(g_events->focusedView());
+
+	view->_newChar._name = name;
+	view->setState(SAVE_PROMPT);
+}
+
 void CreateCharacters::setState(State state) {
 	_state = state;
 
@@ -569,20 +581,7 @@ void CreateCharacters::setState(State state) {
 
 	if (_state == SELECT_NAME) {
 		draw();
-		_textEntry.display(160, 110, 15, false,
-			[]() {
-				CreateCharacters *view = static_cast<CreateCharacters *>(
-					g_events->focusedView());
-				view->setState(SELECT_CLASS);
-			},
-			[](const Common::String &name) {
-				CreateCharacters *view = static_cast<CreateCharacters *>(
-					g_events->focusedView());
-
-				view->_newChar._name = name;
-				view->setState(SAVE_PROMPT);
-			}
-		);
+		_textEntry.display(160, 110, 15, false, abortFunc, enterFunc);
 	} else {
 		redraw();
 	}

--- a/engines/mm/mm1/views_enh/create_characters.h
+++ b/engines/mm/mm1/views_enh/create_characters.h
@@ -65,6 +65,8 @@ class CreateCharacters : public ScrollView {
 
 private:
 	TextEntry _textEntry;
+	static void abortFunc();
+	static void enterFunc(const Common::String &name);
 	Shared::Xeen::SpriteResource _icons;
 	State _state = SELECT_CLASS;
 	NewCharacter _newChar;

--- a/engines/mm/mm1/views_enh/interactions/interaction_query.cpp
+++ b/engines/mm/mm1/views_enh/interactions/interaction_query.cpp
@@ -32,6 +32,16 @@ InteractionQuery::InteractionQuery(const Common::String &name,
 		_maxChars(maxChars) {
 }
 
+void InteractionQuery::abortFunc() {
+	auto *view = static_cast<InteractionQuery *>(g_events->focusedView());
+	view->answerEntry("");
+}
+
+void InteractionQuery::enterFunc(const Common::String &answer) {
+	auto *view = static_cast<InteractionQuery *>(g_events->focusedView());
+	view->answerEntry(answer);
+}
+
 bool InteractionQuery::msgFocus(const FocusMessage &msg) {
 	Interaction::msgFocus(msg);
 	_showEntry = dynamic_cast<TextEntry *>(msg._priorView) == nullptr;
@@ -47,16 +57,7 @@ void InteractionQuery::draw() {
 	int xp = 30; // (_innerBounds.width() / 2) - (_maxChars * 8 / 2);
 	int yp = (8 + _lines.size()) * 9 - 5;
 
-	_textEntry.display(xp, yp, _maxChars, false,
-		[]() {
-			auto *view = static_cast<InteractionQuery *>(g_events->focusedView());
-			view->answerEntry("");
-		},
-		[](const Common::String &answer) {
-			auto *view = static_cast<InteractionQuery *>(g_events->focusedView());
-			view->answerEntry(answer);
-		}
-	);
+	_textEntry.display(xp, yp, _maxChars, false, abortFunc, enterFunc);
 }
 
 void InteractionQuery::answerEntry(const Common::String &answer) {

--- a/engines/mm/mm1/views_enh/interactions/interaction_query.h
+++ b/engines/mm/mm1/views_enh/interactions/interaction_query.h
@@ -33,6 +33,8 @@ namespace Interactions {
 class InteractionQuery : public Interaction {
 private:
 	TextEntry _textEntry;
+	static void abortFunc();
+	static void enterFunc(const Common::String &answer);
 	int _maxChars = 0;
 
 protected:

--- a/engines/mm/mm1/views_enh/trade.cpp
+++ b/engines/mm/mm1/views_enh/trade.cpp
@@ -94,6 +94,16 @@ bool Trade::msgAction(const ActionMessage &msg) {
 	return false;
 }
 
+void Trade::abortFunc() {
+	g_events->close();
+}
+
+void Trade::enterFunc(const Common::String &str) {
+	Trade *view = static_cast<Trade *>(g_events->focusedView());
+	int amount = atoi(str.c_str());
+	view->amountEntered(amount);
+}
+
 void Trade::setMode(TradeMode mode) {
 	_mode = mode;
 
@@ -111,16 +121,7 @@ void Trade::setMode(TradeMode mode) {
 	default:
 		// How much
 		draw();
-		_textEntry.display(70, 157, 5, true,
-			[]() {
-				g_events->close();
-			},
-			[](const Common::String &str) {
-				Trade *view = static_cast<Trade *>(g_events->focusedView());
-				int amount = atoi(str.c_str());
-				view->amountEntered(amount);
-			}
-		);
+		_textEntry.display(70, 157, 5, true, abortFunc, enterFunc);
 	}
 }
 

--- a/engines/mm/mm1/views_enh/trade.h
+++ b/engines/mm/mm1/views_enh/trade.h
@@ -36,6 +36,8 @@ private:
 	TradeMode _mode = TRADE_OPTIONS;
 	Shared::Xeen::SpriteResource _btnIcons;
 	TextEntry _textEntry;
+	static void abortFunc();
+	static void enterFunc(const Common::String &str);
 
 	/**
 	  * Set the display mode


### PR DESCRIPTION
These warnings are emitted from GCC-13 when -Wabi is passed.

The warnings are of the following type:
engines/mm/mm1/views/spells/cast_spell.cpp: In member function ‘MM::MM1::Views::Spells::CastSpell::draw()::<lambda(const Common::String&)>::operator void (*)(const Common::String&)() const’:
engines/mm/mm1/views/spells/cast_spell.cpp:109:25: warning: the mangled name of ‘MM::MM1::Views::Spells::CastSpell::draw()::<lambda(const Common::String&)>::operator void (*)(const Common::String&)() const’ changed between ‘-fabi-version=12’ (‘_ZZN2MM3MM15Views6Spells9CastSpell4drawEvENKUlRKN6Common6StringEE0_cvPFvS7_EEv’) and ‘-fabi-version=18’ (‘_ZZN2MM3MM15Views6Spells9CastSpell4drawEvENKUlRKN6Common6StringEE_cvPFvS7_EEv’) [-Wabi]

They appear to be emitted when a parameter is passed to a lambda (anonymous function).

I tried a few ways to avoid this, but the only way to remove these warnings I found was to replace the lambda functions with regular static class named functions instead.

This PR is mainly in case anyone knows of a better way of solving this?