### PR TITLE
GMM: Provide explanation why save/load is disabled

### DIFF
--- a/devtools/create_engine/files/xyzzy.h
+++ b/devtools/create_engine/files/xyzzy.h
@@ -74,10 +74,10 @@ public:
 		    (f == kSupportsReturnToLauncher);
 	};
 
-	bool canLoadGameStateCurrently() override {
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return true;
 	}
-	bool canSaveGameStateCurrently() override {
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return true;
 	}
 

--- a/devtools/create_engine/files_events/xyzzy.h
+++ b/devtools/create_engine/files_events/xyzzy.h
@@ -81,10 +81,10 @@ public:
 		    (f == kSupportsReturnToLauncher);
 	};
 
-	bool canLoadGameStateCurrently() override {
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return true;
 	}
-	bool canSaveGameStateCurrently() override {
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return true;
 	}
 

--- a/engines/access/access.cpp
+++ b/engines/access/access.cpp
@@ -497,11 +497,11 @@ Common::Error AccessEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-bool AccessEngine::canLoadGameStateCurrently() {
+bool AccessEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return _canSaveLoad;
 }
 
-bool AccessEngine::canSaveGameStateCurrently() {
+bool AccessEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return _canSaveLoad;
 }
 

--- a/engines/access/access.h
+++ b/engines/access/access.h
@@ -283,12 +283,12 @@ public:
 	/**
 	 * Returns true if a savegame can currently be loaded
 	 */
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	* Returns true if the game can currently be saved
 	*/
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	 * Read in a savegame header

--- a/engines/adl/adl.cpp
+++ b/engines/adl/adl.cpp
@@ -929,7 +929,7 @@ Common::Error AdlEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-bool AdlEngine::canLoadGameStateCurrently() {
+bool AdlEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return _canRestoreNow;
 }
 
@@ -1016,7 +1016,7 @@ Common::Error AdlEngine::saveGameState(int slot, const Common::String &desc, boo
 	return Common::kNoError;
 }
 
-bool AdlEngine::canSaveGameStateCurrently() {
+bool AdlEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	if (!_canSaveNow)
 		return false;
 

--- a/engines/adl/adl.h
+++ b/engines/adl/adl.h
@@ -263,7 +263,7 @@ protected:
 	// Engine
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::String getSaveStateName(int slot) const override;
 	int getAutosaveSlot() const override { return 15; }
 
@@ -466,7 +466,7 @@ private:
 	// Engine
 	Common::Error run() override;
 	bool hasFeature(EngineFeature f) const override;
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	// Text input
 	byte convertKey(uint16 ascii) const;

--- a/engines/adl/adl_v2.cpp
+++ b/engines/adl/adl_v2.cpp
@@ -623,13 +623,13 @@ int AdlEngine_v2::o_initDisk(ScriptEnv &e) {
 	return 0;
 }
 
-bool AdlEngine_v2::canSaveGameStateCurrently() {
+bool AdlEngine_v2::canSaveGameStateCurrently(Common::U32String *msg) {
 	if (!_canSaveNow)
 		return false;
 
 	// Back up first visit flag as it may be changed by this test
 	const bool isFirstTime = getCurRoom().isFirstTime;
-	const bool retval = AdlEngine::canSaveGameStateCurrently();
+	const bool retval = AdlEngine::canSaveGameStateCurrently(msg);
 
 	getCurRoom().isFirstTime = isFirstTime;
 

--- a/engines/adl/adl_v2.h
+++ b/engines/adl/adl_v2.h
@@ -47,7 +47,7 @@ protected:
 	void takeItem(byte noun) override;
 
 	// Engine
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	void mapExeStrings(const Common::StringArray &strings);
 	void insertDisk(byte volume);

--- a/engines/adl/hires6.cpp
+++ b/engines/adl/hires6.cpp
@@ -59,7 +59,7 @@ private:
 	void printString(const Common::String &str) override;
 
 	// Engine
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	int o_fluteSound(ScriptEnv &e);
 
@@ -139,7 +139,7 @@ int HiRes6Engine::o_fluteSound(ScriptEnv &e) {
 	return 0;
 }
 
-bool HiRes6Engine::canSaveGameStateCurrently() {
+bool HiRes6Engine::canSaveGameStateCurrently(Common::U32String *msg) {
 	if (!_canSaveNow)
 		return false;
 
@@ -148,7 +148,7 @@ bool HiRes6Engine::canSaveGameStateCurrently() {
 	const byte var24 = getVar(24);
 	const bool abortScript = _abortScript;
 
-	const bool retval = AdlEngine_v5::canSaveGameStateCurrently();
+	const bool retval = AdlEngine_v5::canSaveGameStateCurrently(msg);
 
 	setVar(2, var2);
 	setVar(24, var24);

--- a/engines/agi/agi.h
+++ b/engines/agi/agi.h
@@ -793,8 +793,8 @@ public:
 
 	const char *getDiskName(uint16 id);
 
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	const byte *getFontData();
 

--- a/engines/agi/metaengine.cpp
+++ b/engines/agi/metaengine.cpp
@@ -414,6 +414,10 @@ bool AgiBase::canLoadGameStateCurrently(Common::U32String *msg) {
 			}
 		}
 	}
+
+	if (msg)
+		*msg = _("This game does not support loading");
+
 	return false;
 }
 
@@ -432,6 +436,10 @@ bool AgiBase::canSaveGameStateCurrently(Common::U32String *msg) {
 			}
 		}
 	}
+
+	if (msg)
+		*msg = _("This game does not support saving");
+
 	return false;
 }
 

--- a/engines/agi/metaengine.cpp
+++ b/engines/agi/metaengine.cpp
@@ -399,7 +399,7 @@ SaveStateDescriptor AgiMetaEngine::querySaveMetaInfos(const char *target, int sl
 
 namespace Agi {
 
-bool AgiBase::canLoadGameStateCurrently() {
+bool AgiBase::canLoadGameStateCurrently(Common::U32String *msg) {
 	if (!(getGameType() == GType_PreAGI)) {
 		if (getFlag(VM_FLAG_MENUS_ACCESSIBLE)) {
 			if (!_noSaveLoadAllowed) {
@@ -417,7 +417,7 @@ bool AgiBase::canLoadGameStateCurrently() {
 	return false;
 }
 
-bool AgiBase::canSaveGameStateCurrently() {
+bool AgiBase::canSaveGameStateCurrently(Common::U32String *msg) {
 	if (getGameID() == GID_BC) // Technically in Black Cauldron we may save anytime
 		return true;
 

--- a/engines/ags/ags.cpp
+++ b/engines/ags/ags.cpp
@@ -288,12 +288,12 @@ Common::FSNode AGSEngine::getGameFolder() {
 	return Common::FSNode(ConfMan.get("path"));
 }
 
-bool AGSEngine::canLoadGameStateCurrently() {
+bool AGSEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return !_GP(thisroom).Options.SaveLoadDisabled &&
 	       !_G(inside_script) && !_GP(play).fast_forward && !_G(no_blocking_functions);
 }
 
-bool AGSEngine::canSaveGameStateCurrently() {
+bool AGSEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return !_GP(thisroom).Options.SaveLoadDisabled &&
 	       !_G(inside_script) && !_GP(play).fast_forward && !_G(no_blocking_functions);
 }

--- a/engines/ags/ags.h
+++ b/engines/ags/ags.h
@@ -145,12 +145,12 @@ public:
 	/**
 	 * Indicate whether a game state can be loaded.
 	 */
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	 * Indicate whether a game state can be saved.
 	 */
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	 * Load a savegame

--- a/engines/asylum/asylum.cpp
+++ b/engines/asylum/asylum.cpp
@@ -669,15 +669,25 @@ void AsylumEngine::checkAchievements() {
 // Save/Load
 //////////////////////////////////////////////////////////////////////////
 bool AsylumEngine::canLoadGameStateCurrently(Common::U32String *msg) {
-	return (!checkGameVersion("Demo")
-		&& (_handler == _scene || _handler == _menu)
-		&& !speech()->getSoundResourceId());
+	if (checkGameVersion("Demo")) {
+		if (msg)
+			*msg = _("This game does not support loading");
+
+		return false;
+	}
+
+	return ((_handler == _scene || _handler == _menu) && !speech()->getSoundResourceId());
 }
 
 bool AsylumEngine::canSaveGameStateCurrently(Common::U32String *msg) {
-	return (!checkGameVersion("Demo")
-		&& (_handler == _scene)
-		&& !speech()->getSoundResourceId());
+	if (checkGameVersion("Demo")) {
+		if (msg)
+			*msg = _("This game does not support saving");
+
+		return false;
+	}
+
+	return ((_handler == _scene) && !speech()->getSoundResourceId());
 }
 
 bool AsylumEngine::canSaveAutosaveCurrently() {

--- a/engines/asylum/asylum.cpp
+++ b/engines/asylum/asylum.cpp
@@ -668,13 +668,13 @@ void AsylumEngine::checkAchievements() {
 //////////////////////////////////////////////////////////////////////////
 // Save/Load
 //////////////////////////////////////////////////////////////////////////
-bool AsylumEngine::canLoadGameStateCurrently() {
+bool AsylumEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return (!checkGameVersion("Demo")
 		&& (_handler == _scene || _handler == _menu)
 		&& !speech()->getSoundResourceId());
 }
 
-bool AsylumEngine::canSaveGameStateCurrently() {
+bool AsylumEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return (!checkGameVersion("Demo")
 		&& (_handler == _scene)
 		&& !speech()->getSoundResourceId());

--- a/engines/asylum/asylum.h
+++ b/engines/asylum/asylum.h
@@ -70,8 +70,8 @@ class VideoPlayer;
 class AsylumEngine: public Engine, public Common::Serializable {
 protected:
 	// Engine APIs
-	virtual Common::Error run();
-	virtual bool hasFeature(EngineFeature f) const;
+	virtual Common::Error run() override;
+	virtual bool hasFeature(EngineFeature f) const override;
 
 public:
 	enum StartGameType {
@@ -187,7 +187,7 @@ public:
 	void updateReverseStereo();
 
 	// Serializable
-	void saveLoadWithSerializer(Common::Serializer &s);
+	void saveLoadWithSerializer(Common::Serializer &s) override;
 
 	bool checkGameVersion(const char *version) { return !strcmp(_gameDescription->extra, version); }
 	bool isAltDemo() { return Common::File::exists("asylum.dat"); }
@@ -198,12 +198,12 @@ public:
 	EventHandler *getEventHandler() { return _handler; }
 
 	// Save/Load
-	int getAutosaveSlot() const { return getMetaEngine()->getAutosaveSlot(); }
-	bool canLoadGameStateCurrently();
-	Common::Error loadGameState(int slot);
-	bool canSaveGameStateCurrently();
-	bool canSaveAutosaveCurrently();
-	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false);
+	int getAutosaveSlot() const override { return getMetaEngine()->getAutosaveSlot(); }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	Common::Error loadGameState(int slot) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveAutosaveCurrently() override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
 private:
 	const ADGameDescription *_gameDescription;

--- a/engines/avalanche/avalanche.cpp
+++ b/engines/avalanche/avalanche.cpp
@@ -325,7 +325,7 @@ void AvalancheEngine::synchronize(Common::Serializer &sz) {
 
 }
 
-bool AvalancheEngine::canSaveGameStateCurrently() {
+bool AvalancheEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return (_animationsEnabled && _alive);
 }
 
@@ -366,7 +366,7 @@ bool AvalancheEngine::saveGame(const int16 slot, const Common::String &desc) {
 	return true;
 }
 
-bool AvalancheEngine::canLoadGameStateCurrently() {
+bool AvalancheEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return (_animationsEnabled);
 }
 

--- a/engines/avalanche/avalanche.h
+++ b/engines/avalanche/avalanche.h
@@ -106,10 +106,10 @@ public:
 	const char *getCopyrightString() const;
 
 	void synchronize(Common::Serializer &sz);
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool saveGame(const int16 slot, const Common::String &desc);
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
 	bool loadGame(const int16 slot);
 	Common::String expandDate(int d, int m, int y);

--- a/engines/bbvs/bbvs.h
+++ b/engines/bbvs/bbvs.h
@@ -435,8 +435,8 @@ public:
 
 	bool _isSaveAllowed;
 
-	bool canLoadGameStateCurrently() override { return _isSaveAllowed; }
-	bool canSaveGameStateCurrently() override { return _isSaveAllowed; }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return _isSaveAllowed; }
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override { return _isSaveAllowed; }
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &description, bool isAutosave = false) override;
 	void savegame(const char *filename, const char *description);

--- a/engines/bladerunner/bladerunner.cpp
+++ b/engines/bladerunner/bladerunner.cpp
@@ -267,7 +267,7 @@ bool BladeRunnerEngine::hasFeature(EngineFeature f) const {
 		f == kSupportsSavingDuringRuntime;
 }
 
-bool BladeRunnerEngine::canLoadGameStateCurrently() {
+bool BladeRunnerEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return
 		playerHasControl() &&
 		_gameIsRunning &&
@@ -307,7 +307,7 @@ Common::Error BladeRunnerEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-bool BladeRunnerEngine::canSaveGameStateCurrently() {
+bool BladeRunnerEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return
 		playerHasControl() &&
 		_gameIsRunning &&

--- a/engines/bladerunner/bladerunner.h
+++ b/engines/bladerunner/bladerunner.h
@@ -349,9 +349,9 @@ public:
 	~BladeRunnerEngine() override;
 
 	bool hasFeature(EngineFeature f) const override;
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	/**
 	* NOTE: Disable support for external autosave (ScummVM's feature).

--- a/engines/buried/buried.h
+++ b/engines/buried/buried.h
@@ -142,8 +142,8 @@ public:
 	void showPoints();
 
 	// Save/Load
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::String getSaveStateName(int slot) const override {
 		return Common::String::format("buried.%03d", slot);
 	}

--- a/engines/buried/saveload.cpp
+++ b/engines/buried/saveload.cpp
@@ -47,11 +47,11 @@ namespace Buried {
 
 #define SAVEGAME_CURRENT_VERSION 1
 
-bool BuriedEngine::canLoadGameStateCurrently() {
+bool BuriedEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return !isDemo() && _mainWindow && !_yielding;
 }
 
-bool BuriedEngine::canSaveGameStateCurrently() {
+bool BuriedEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return !isDemo() && _mainWindow && !_yielding && ((FrameWindow *)_mainWindow)->isGameInProgress();
 }
 

--- a/engines/buried/saveload.cpp
+++ b/engines/buried/saveload.cpp
@@ -48,11 +48,25 @@ namespace Buried {
 #define SAVEGAME_CURRENT_VERSION 1
 
 bool BuriedEngine::canLoadGameStateCurrently(Common::U32String *msg) {
-	return !isDemo() && _mainWindow && !_yielding;
+	if (isDemo()) {
+		if (msg)
+			*msg = _("This game does not support loading");
+
+		return false;
+	}
+
+	return _mainWindow && !_yielding;
 }
 
 bool BuriedEngine::canSaveGameStateCurrently(Common::U32String *msg) {
-	return !isDemo() && _mainWindow && !_yielding && ((FrameWindow *)_mainWindow)->isGameInProgress();
+	if (isDemo()) {
+		if (msg)
+			*msg = _("This game does not support saving");
+
+		return false;
+	}
+
+	return _mainWindow && !_yielding && ((FrameWindow *)_mainWindow)->isGameInProgress();
 }
 
 void BuriedEngine::checkForOriginalSavedGames() {
@@ -117,7 +131,7 @@ void BuriedEngine::convertSavedGame(Common::String oldFile, Common::String newFi
 		warning("Saved game %s is using an unsupported format, skipping", oldFile.c_str());
 		return;
 	}
-	
+
 	// Set necessary properties from the old save
 	Common::Serializer inS(inFile, nullptr);
 	Common::Error res = syncSaveData(inS, location, flags, inventoryItems);

--- a/engines/cge/cge.cpp
+++ b/engines/cge/cge.cpp
@@ -246,11 +246,11 @@ bool CGEEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-bool CGEEngine::canLoadGameStateCurrently() {
+bool CGEEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return (_startupMode == 0) && _mouse->_active;
 }
 
-bool CGEEngine::canSaveGameStateCurrently() {
+bool CGEEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return (_startupMode == 0) && _mouse->_active &&
 				_commandHandler->idle() && !_hero->_flags._hide;
 }

--- a/engines/cge/cge.h
+++ b/engines/cge/cge.h
@@ -136,8 +136,8 @@ public:
 	CGEEngine(OSystem *syst, const ADGameDescription *gameDescription);
 	~CGEEngine() override;
 	bool hasFeature(EngineFeature f) const override;
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 

--- a/engines/cge2/cge2.h
+++ b/engines/cge2/cge2.h
@@ -154,8 +154,8 @@ private:
 public:
 	CGE2Engine(OSystem *syst, const ADGameDescription *gameDescription);
 	bool hasFeature(EngineFeature f) const override;
-	bool canSaveGameStateCurrently() override;
-	bool canLoadGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Language getLanguage() const;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error loadGameState(int slot) override;

--- a/engines/cge2/saveload.cpp
+++ b/engines/cge2/saveload.cpp
@@ -41,7 +41,7 @@ namespace CGE2 {
 #define kSavegameCheckSum (1997 + _now + _sex + kWorldHeight)
 #define kBadSVG           99
 
-bool CGE2Engine::canSaveGameStateCurrently() {
+bool CGE2Engine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return (_gamePhase == kPhaseInGame) && _mouse->_active &&
 		_commandHandler->idle() && (_soundStat._wait == nullptr);
 }
@@ -73,7 +73,7 @@ void CGE2Engine::saveGame(int slotNumber, const Common::String &desc) {
 	delete saveFile;
 }
 
-bool CGE2Engine::canLoadGameStateCurrently() {
+bool CGE2Engine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return (_gamePhase == kPhaseInGame) && _mouse->_active;
 }
 

--- a/engines/chamber/chamber.h
+++ b/engines/chamber/chamber.h
@@ -49,8 +49,8 @@ public:
 
 	Common::Error run() override;
 	bool hasFeature(EngineFeature f) const override;
-	bool canLoadGameStateCurrently() override { return true; }
-	bool canSaveGameStateCurrently() override { return true; }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return true; }
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override { return true; }
 	Common::Error loadGameStream(Common::SeekableReadStream *stream) override;
 	Common::Error saveGameStream(Common::WriteStream *stream, bool isAutosave = false) override;
 	void syncGameStream(Common::Serializer &s);

--- a/engines/chewy/chewy.h
+++ b/engines/chewy/chewy.h
@@ -82,10 +82,10 @@ public:
 	uint32 getFeatures() const;
 	Common::Language getLanguage() const;
 
-	bool canLoadGameStateCurrently() override {
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return _canLoad;
 	}
-	bool canSaveGameStateCurrently() override {
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return _canSave;
 	}
 	void setCanLoadSave(bool canLoadSave) {

--- a/engines/cine/cine.h
+++ b/engines/cine/cine.h
@@ -126,8 +126,8 @@ public:
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::String getSaveStateName(int slot) const override;
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	const CINEGameDescription *_gameDescription;
 	Common::File _partFileHandle;

--- a/engines/cine/metaengine.cpp
+++ b/engines/cine/metaengine.cpp
@@ -340,11 +340,11 @@ Common::String CineEngine::getSaveStateName(int slot) const {
 	return getMetaEngine()->getSavegameFile(slot, _targetName.c_str());
 }
 
-bool CineEngine::canLoadGameStateCurrently() {
+bool CineEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return (!disableSystemMenu && !inMenu);
 }
 
-bool CineEngine::canSaveGameStateCurrently() {
+bool CineEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return (allowPlayerInput && !disableSystemMenu && !inMenu);
 }
 

--- a/engines/composer/composer.h
+++ b/engines/composer/composer.h
@@ -153,9 +153,9 @@ protected:
 	void syncListReverse(Common::Serializer &ser, Common::List<T> &data, Common::Serializer::Version minVersion = 0, Common::Serializer::Version maxVersion = Common::Serializer::kLastVersion);
 	template <typename T>
 	void sync(Common::Serializer &ser, T &data, Common::Serializer::Version minVersion, Common::Serializer::Version maxVersion);
-	bool canLoadGameStateCurrently() override { return true; }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return true; }
 	Common::Error loadGameState(int slot) override;
-	bool canSaveGameStateCurrently() override { return true; }
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override { return true; }
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
 public:

--- a/engines/crab/crab.cpp
+++ b/engines/crab/crab.cpp
@@ -179,7 +179,7 @@ Common::Error CrabEngine::syncGame(Common::Serializer &s) {
 	return Common::kNoError;
 }
 
-bool CrabEngine::canSaveGameStateCurrently() {
+bool CrabEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return _screenSettings->_inGame;
 }
 

--- a/engines/crab/crab.h
+++ b/engines/crab/crab.h
@@ -152,11 +152,11 @@ public:
 			   (f == kSupportsReturnToLauncher);
 	};
 
-	bool canLoadGameStateCurrently() override {
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return true;
 	}
 
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	 * Uses a serializer to allow implementing savegame

--- a/engines/cruise/cruise.cpp
+++ b/engines/cruise/cruise.cpp
@@ -200,7 +200,7 @@ Common::Error CruiseEngine::loadGameState(int slot) {
 	return loadSavegameData(slot);
 }
 
-bool CruiseEngine::canLoadGameStateCurrently() {
+bool CruiseEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return playerMenuEnabled != 0;
 }
 
@@ -208,7 +208,7 @@ Common::Error CruiseEngine::saveGameState(int slot, const Common::String &desc, 
 	return saveSavegameData(slot, desc);
 }
 
-bool CruiseEngine::canSaveGameStateCurrently() {
+bool CruiseEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return (playerMenuEnabled != 0) && (userEnabled != 0);
 }
 

--- a/engines/cruise/cruise.h
+++ b/engines/cruise/cruise.h
@@ -92,9 +92,9 @@ public:
 
 	static const char *getSavegameFile(int saveGameIdx);
 	Common::Error loadGameState(int slot) override;
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::String getSaveStateName(int slot) const override { return getSavegameFile(slot); }
 	void syncSoundSettings() override;
 

--- a/engines/cryomni3d/cryomni3d.h
+++ b/engines/cryomni3d/cryomni3d.h
@@ -95,8 +95,8 @@ public:
 	Common::Language getLanguage() const;
 
 	bool hasFeature(EngineFeature f) const override;
-	bool canLoadGameStateCurrently() override { return _canLoadSave; }
-	bool canSaveGameStateCurrently() override { return _canLoadSave; }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return _canLoadSave; }
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override { return _canLoadSave; }
 
 	void setCanLoadSave(bool canLoadSave) { _canLoadSave = canLoadSave; }
 	static const uint kSaveDescriptionLen = 20;

--- a/engines/dialogs.cpp
+++ b/engines/dialogs.cpp
@@ -66,13 +66,8 @@ MainMenuDialog::MainMenuDialog(Engine *engine)
 
 	new GUI::ButtonWidget(this, "GlobalMenu.Resume", _("~R~esume"), Common::U32String(), kPlayCmd, 'P');
 
-	_loadButton = new GUI::ButtonWidget(this, "GlobalMenu.Load", _("~L~oad"), Common::U32String(), kLoadCmd);
-	_loadButton->setVisible(_engine->hasFeature(Engine::kSupportsLoadingDuringRuntime));
-	_loadButton->setEnabled(_engine->hasFeature(Engine::kSupportsLoadingDuringRuntime));
-
-	_saveButton = new GUI::ButtonWidget(this, "GlobalMenu.Save", _("~S~ave"), Common::U32String(), kSaveCmd);
-	_saveButton->setVisible(_engine->hasFeature(Engine::kSupportsSavingDuringRuntime));
-	_saveButton->setEnabled(_engine->hasFeature(Engine::kSupportsSavingDuringRuntime));
+	new GUI::ButtonWidget(this, "GlobalMenu.Load", _("~L~oad"), Common::U32String(), kLoadCmd);
+	new GUI::ButtonWidget(this, "GlobalMenu.Save", _("~S~ave"), Common::U32String(), kSaveCmd);
 
 	new GUI::ButtonWidget(this, "GlobalMenu.Options", _("~O~ptions"), Common::U32String(), kOptionsCmd);
 
@@ -152,11 +147,6 @@ void MainMenuDialog::handleCommand(GUI::CommandSender *sender, uint32 cmd, uint3
 }
 
 void MainMenuDialog::reflowLayout() {
-	if (_engine->hasFeature(Engine::kSupportsLoadingDuringRuntime))
-		_loadButton->setEnabled(_engine->canLoadGameStateCurrently());
-	if (_engine->hasFeature(Engine::kSupportsSavingDuringRuntime))
-		_saveButton->setEnabled(_engine->canSaveGameStateCurrently());
-
 	// Overlay size might have changed since the construction of the dialog.
 	// Update labels when it might be needed
 	// FIXME: it might be better to declare GUI::StaticTextWidget::setLabel() virtual
@@ -198,6 +188,24 @@ void MainMenuDialog::reflowLayout() {
 }
 
 void MainMenuDialog::save() {
+	if (!_engine->hasFeature(Engine::kSupportsSavingDuringRuntime)) {
+		GUI::MessageDialog dialog(_("This game does not support saving from the menu. Use in-game interface"));
+		dialog.runModal();
+
+		return;
+	}
+
+	Common::U32String msg;
+	if (!_engine->canSaveGameStateCurrently(&msg)) {
+		if (msg.empty())
+			msg = _("This game cannot be saved at this time. Please try again later");
+
+		GUI::MessageDialog dialog(msg);
+		dialog.runModal();
+
+		return;
+	}
+
 	int slot = _saveDialog->runModalWithCurrentTarget();
 
 	if (slot >= 0) {
@@ -221,6 +229,24 @@ void MainMenuDialog::save() {
 }
 
 void MainMenuDialog::load() {
+	if (!_engine->hasFeature(Engine::kSupportsLoadingDuringRuntime)) {
+		GUI::MessageDialog dialog(_("This game does not support loading from the menu. Use in-game interface"));
+		dialog.runModal();
+
+		return;
+	}
+
+	Common::U32String msg;
+	if (!_engine->canLoadGameStateCurrently(&msg)) {
+		if (msg.empty())
+			msg = _("This game cannot be loaded at this time. Please try again later");
+
+		GUI::MessageDialog dialog(msg);
+		dialog.runModal();
+
+		return;
+	}
+
 	int slot = _loadDialog->runModalWithCurrentTarget();
 
 	_engine->setGameToLoadSlot(slot);

--- a/engines/dialogs.h
+++ b/engines/dialogs.h
@@ -67,8 +67,6 @@ protected:
 	GUI::GraphicsWidget  *_logo;
 
 	GUI::ButtonWidget    *_returnToLauncherButton;
-	GUI::ButtonWidget    *_loadButton;
-	GUI::ButtonWidget    *_saveButton;
 	GUI::ButtonWidget    *_helpButton;
 
 	GUI::Dialog          *_aboutDialog;

--- a/engines/dm/dm.cpp
+++ b/engines/dm/dm.cpp
@@ -226,7 +226,7 @@ Common::Error DMEngine::loadGameState(int slot) {
 	return Common::kNoGameDataFoundError;
 }
 
-bool DMEngine::canLoadGameStateCurrently() {
+bool DMEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return _canLoadFromGMM;
 }
 

--- a/engines/dm/dm.h
+++ b/engines/dm/dm.h
@@ -175,7 +175,7 @@ public:
 	bool hasFeature(EngineFeature f) const override;
 
 	Common::Error loadGameState(int slot) override;
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	bool isDemo() const;
 

--- a/engines/draci/draci.cpp
+++ b/engines/draci/draci.cpp
@@ -452,7 +452,7 @@ Common::Error DraciEngine::loadGameState(int slot) {
 	return loadSavegameData(slot, this);
 }
 
-bool DraciEngine::canLoadGameStateCurrently() {
+bool DraciEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return (_game->getLoopStatus() == kStatusOrdinary) &&
 		(_game->getLoopSubstatus() == kOuterLoop);
 }
@@ -461,7 +461,7 @@ Common::Error DraciEngine::saveGameState(int slot, const Common::String &desc, b
 	return saveSavegameData(slot, desc, *this);
 }
 
-bool DraciEngine::canSaveGameStateCurrently() {
+bool DraciEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return (_game->getLoopStatus() == kStatusOrdinary) &&
 		(_game->getLoopSubstatus() == kOuterLoop);
 }

--- a/engines/draci/draci.h
+++ b/engines/draci/draci.h
@@ -69,9 +69,9 @@ public:
 	static Common::String getSavegameFile(int saveGameIdx);
 	Common::String getSaveStateName(int slot) const override { return getSavegameFile(slot); }
 	Common::Error loadGameState(int slot) override;
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	Screen *_screen;
 	Mouse *_mouse;

--- a/engines/dragons/dragons.cpp
+++ b/engines/dragons/dragons.cpp
@@ -1230,12 +1230,12 @@ void DragonsEngine::reset_screen_maybe() {
 	//TODO
 }
 
-bool DragonsEngine::canLoadGameStateCurrently() {
+bool DragonsEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	//player has control and not currently talking to anyone.
 	return isInputEnabled() && isFlagSet(ENGINE_FLAG_8) && !isFlagSet(Dragons::ENGINE_FLAG_100);
 }
 
-bool DragonsEngine::canSaveGameStateCurrently() {
+bool DragonsEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return isInputEnabled() && !_inventory->isOpen() && isFlagSet(ENGINE_FLAG_8) && !isFlagSet(Dragons::ENGINE_FLAG_100);
 }
 

--- a/engines/dragons/dragons.h
+++ b/engines/dragons/dragons.h
@@ -256,9 +256,9 @@ public:
 	static kReadSaveHeaderError readSaveHeader(Common::SeekableReadStream *in, SaveHeader &header, bool skipThumbnail = true);
 
 	Common::Error loadGameState(int slot) override;
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave) override;
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	void syncSoundSettings() override;
 
 	void updateActorSequences();

--- a/engines/drascula/drascula.h
+++ b/engines/drascula/drascula.h
@@ -325,9 +325,9 @@ public:
 	void syncSoundSettings() override;
 
 	Common::Error loadGameState(int slot) override;
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	Common::RandomSource *_rnd;
 	const DrasculaGameDescription *_gameDescription;

--- a/engines/drascula/saveload.cpp
+++ b/engines/drascula/saveload.cpp
@@ -194,7 +194,7 @@ Common::Error DrasculaEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-bool DrasculaEngine::canLoadGameStateCurrently() {
+bool DrasculaEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return _canSaveLoad;
 }
 
@@ -203,7 +203,7 @@ Common::Error DrasculaEngine::saveGameState(int slot, const Common::String &desc
 	return Common::kNoError;
 }
 
-bool DrasculaEngine::canSaveGameStateCurrently() {
+bool DrasculaEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return _canSaveLoad;
 }
 

--- a/engines/dreamweb/dreamweb.h
+++ b/engines/dreamweb/dreamweb.h
@@ -119,8 +119,8 @@ public:
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	uint8 randomNumber() { return _rnd.getRandomNumber(255); }
 

--- a/engines/dreamweb/dreamweb.h
+++ b/engines/dreamweb/dreamweb.h
@@ -119,9 +119,6 @@ public:
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
-	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
-	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
-
 	uint8 randomNumber() { return _rnd.getRandomNumber(255); }
 
 	void mouseCall(uint16 *x, uint16 *y, uint16 *state); //fill mouse pos and button state

--- a/engines/dreamweb/metaengine.cpp
+++ b/engines/dreamweb/metaengine.cpp
@@ -251,11 +251,11 @@ Common::Error DreamWebEngine::saveGameState(int slot, const Common::String &desc
 	return Common::kNoError;
 }
 
-bool DreamWebEngine::canLoadGameStateCurrently() {
+bool DreamWebEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return false;
 }
 
-bool DreamWebEngine::canSaveGameStateCurrently() {
+bool DreamWebEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return false;
 }
 

--- a/engines/dreamweb/metaengine.cpp
+++ b/engines/dreamweb/metaengine.cpp
@@ -251,14 +251,6 @@ Common::Error DreamWebEngine::saveGameState(int slot, const Common::String &desc
 	return Common::kNoError;
 }
 
-bool DreamWebEngine::canLoadGameStateCurrently(Common::U32String *msg) {
-	return false;
-}
-
-bool DreamWebEngine::canSaveGameStateCurrently(Common::U32String *msg) {
-	return false;
-}
-
 Common::Language DreamWebEngine::getLanguage() const {
 	return _gameDescription->desc.language;
 }

--- a/engines/efh/efh.h
+++ b/engines/efh/efh.h
@@ -277,8 +277,8 @@ public:
 
 	// savegames.cpp
 	Common::String getSavegameFilename(int slot);
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 

--- a/engines/efh/savegames.cpp
+++ b/engines/efh/savegames.cpp
@@ -33,11 +33,11 @@ Common::String EfhEngine::getSavegameFilename(int slot) {
 	return _targetName + Common::String::format("-%03d.SAV", slot);
 }
 
-bool EfhEngine::canLoadGameStateCurrently() {
+bool EfhEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return true;
 }
 
-bool EfhEngine::canSaveGameStateCurrently() {
+bool EfhEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return _saveAuthorized;
 }
 

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -874,7 +874,7 @@ Common::Error Engine::loadGameStream(Common::SeekableReadStream *stream) {
 	return Common::kReadingFailed;
 }
 
-bool Engine::canLoadGameStateCurrently() {
+bool Engine::canLoadGameStateCurrently(Common::U32String *msg) {
 	// Do not allow loading by default
 	return false;
 }
@@ -901,7 +901,7 @@ Common::Error Engine::saveGameStream(Common::WriteStream *stream, bool isAutosav
 	return Common::kWritingFailed;
 }
 
-bool Engine::canSaveGameStateCurrently() {
+bool Engine::canSaveGameStateCurrently(Common::U32String *msg) {
 	// Do not allow saving by default
 	return false;
 }

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -444,8 +444,10 @@ public:
 
 	/**
 	 * Indicate whether a game state can be loaded.
+	 *
+	 * @param msg        Optional pointer to message explaining why it is disabled
 	 */
-	virtual bool canLoadGameStateCurrently();
+	virtual bool canLoadGameStateCurrently(Common::U32String *msg = nullptr);
 
 	/**
 	 * Save a game state.
@@ -470,8 +472,10 @@ public:
 
 	/**
 	 * Indicate whether a game state can be saved.
+	 *
+	 * @param msg        Optional pointer to message explaining why it is disabled
 	 */
-	virtual bool canSaveGameStateCurrently();
+	virtual bool canSaveGameStateCurrently(Common::U32String *msg = nullptr);
 
 	/**
 	 * Show the ScummVM save dialog, allowing users to save their game.

--- a/engines/freescape/freescape.h
+++ b/engines/freescape/freescape.h
@@ -411,9 +411,9 @@ public:
 	void takeDamageFromSensor();
 
 	bool hasFeature(EngineFeature f) const override;
-	bool canLoadGameStateCurrently() override { return true; }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return true; }
 	bool canSaveAutosaveCurrently() override { return false; }
-	bool canSaveGameStateCurrently() override { return true; }
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override { return true; }
 	Common::Error loadGameStream(Common::SeekableReadStream *stream) override;
 	Common::Error saveGameStream(Common::WriteStream *stream, bool isAutosave = false) override;
 	virtual Common::Error saveGameStreamExtended(Common::WriteStream *stream, bool isAutosave = false);

--- a/engines/glk/POTFILES
+++ b/engines/glk/POTFILES
@@ -8,6 +8,7 @@ engines/glk/advsys/vm.cpp
 engines/glk/alan2/alan2.cpp
 engines/glk/comprehend/game.cpp
 engines/glk/glulx/glulx.cpp
+engines/glk/magnetic/magnetic.h
 engines/glk/quest/quest.cpp
 engines/glk/scott/scott.cpp
 engines/glk/zcode/detection.cpp

--- a/engines/glk/comprehend/comprehend.h
+++ b/engines/glk/comprehend/comprehend.h
@@ -195,14 +195,14 @@ public:
 	/**
 	 * Returns true if a savegame can be loaded
 	 */
-	bool canLoadGameStateCurrently() override {
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return !_disableSaves && GlkAPI::canLoadGameStateCurrently();
 	}
 
 	/**
 	 * Returns true if the game can be saved
 	 */
-	bool canSaveGameStateCurrently() override {
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return !_disableSaves && GlkAPI::canSaveGameStateCurrently();
 	}
 

--- a/engines/glk/glk.cpp
+++ b/engines/glk/glk.cpp
@@ -151,13 +151,13 @@ Common::Error GlkEngine::run() {
 	return Common::kNoError;
 }
 
-bool GlkEngine::canLoadGameStateCurrently() {
+bool GlkEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	// Only allow savegames by default when sub-engines are waiting for a line
 	Window *win = _windows->getFocusWindow();
 	return win && (win->_lineRequest || win->_lineRequestUni);
 }
 
-bool GlkEngine::canSaveGameStateCurrently() {
+bool GlkEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	// Only allow savegames by default when sub-engines are waiting for a line
 	Window *win = _windows->getFocusWindow();
 	return win && (win->_lineRequest || win->_lineRequestUni);

--- a/engines/glk/glk.h
+++ b/engines/glk/glk.h
@@ -137,12 +137,12 @@ public:
 	/**
 	 * Returns true if a savegame can be loaded
 	 */
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	 * Returns true if the game can be saved
 	 */
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	 * Returns the language

--- a/engines/glk/magnetic/magnetic.h
+++ b/engines/glk/magnetic/magnetic.h
@@ -25,6 +25,7 @@
 #define GLK_MAGNETIC_MAGNETIC
 
 #include "common/scummsys.h"
+#include "common/translation.h"
 #include "glk/glk_api.h"
 #include "glk/magnetic/magnetic_types.h"
 #include "glk/magnetic/magnetic_defs.h"
@@ -1386,6 +1387,9 @@ public:
 	 * The Magnetic engine currently doesn't support loading savegames from the GMM
 	 */
 	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override {
+		if (msg)
+			*msg = _("This game does not support loading from the menu. Use in-game interface");
+
 		return false;
 	}
 
@@ -1393,6 +1397,9 @@ public:
 	 * The Magnetic engine currently doesn't support saving games from the GMM
 	 */
 	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override {
+		if (msg)
+			*msg = _("This game does not support saving from the menu. Use in-game interface");
+
 		return false;
 	}
 

--- a/engines/glk/magnetic/magnetic.h
+++ b/engines/glk/magnetic/magnetic.h
@@ -1385,14 +1385,14 @@ public:
 	/**
 	 * The Magnetic engine currently doesn't support loading savegames from the GMM
 	 */
-	bool canLoadGameStateCurrently() override {
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return false;
 	}
 
 	/**
 	 * The Magnetic engine currently doesn't support saving games from the GMM
 	 */
-	bool canSaveGameStateCurrently() override {
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return false;
 	}
 

--- a/engines/glk/quest/quest.h
+++ b/engines/glk/quest/quest.h
@@ -76,14 +76,14 @@ public:
 	/**
 	 * Returns true if a savegame can be loaded
 	 */
-	bool canLoadGameStateCurrently() override {
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return _runner != nullptr && GlkAPI::canLoadGameStateCurrently();
 	}
 
 	/**
 	 * Returns true if the game can be saved
 	 */
-	bool canSaveGameStateCurrently() override {
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return _runner != nullptr && GlkAPI::canLoadGameStateCurrently();
 	}
 

--- a/engines/griffon/griffon.h
+++ b/engines/griffon/griffon.h
@@ -444,8 +444,8 @@ private:
 
 	// Common engine overrides
 	void pauseEngineIntern(bool pause) override;
-	bool canLoadGameStateCurrently() override { return true; }
-	bool canSaveGameStateCurrently() override { return _gameMode == kGameModePlay; }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return true; }
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override { return _gameMode == kGameModePlay; }
 	int getAutosaveSlot() const override { return 4; }
 	bool hasFeature(EngineFeature f) const override;
 

--- a/engines/grim/grim.h
+++ b/engines/grim/grim.h
@@ -85,7 +85,7 @@ public:
 	Common::Language getGameLanguage() { return _gameLanguage; }
 	Common::Platform getGamePlatform() { return _gamePlatform; }
 	virtual const char *getUpdateFilename();
-	bool canLoadGameStateCurrently() override { return true; }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return true; }
 	Common::Error loadGameState(int slot) override;
 	bool isRemastered() const { return !!(_gameFlags & ADGF_REMASTERED); }
 

--- a/engines/groovie/groovie.cpp
+++ b/engines/groovie/groovie.cpp
@@ -397,7 +397,7 @@ void GroovieEngine::syncSoundSettings() {
 		mute ? 0 : ConfMan.getInt("speech_volume"));
 }
 
-bool GroovieEngine::canLoadGameStateCurrently() {
+bool GroovieEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	// TODO: verify the engine has been initialized
 	if (isDemo())
 		return false;
@@ -407,7 +407,7 @@ bool GroovieEngine::canLoadGameStateCurrently() {
 		return false;
 }
 
-bool GroovieEngine::canSaveGameStateCurrently() {
+bool GroovieEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	// TODO: verify the engine has been initialized
 	if (isDemo())
 		return false;

--- a/engines/groovie/groovie.h
+++ b/engines/groovie/groovie.h
@@ -132,8 +132,8 @@ protected:
 
 	bool hasFeature(EngineFeature f) const override;
 
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	void syncSoundSettings() override;

--- a/engines/hadesch/hadesch.h
+++ b/engines/hadesch/hadesch.h
@@ -113,8 +113,8 @@ public:
 
 	bool hasFeature(EngineFeature f) const override;
 
-	bool canLoadGameStateCurrently() override { return true; }
-	bool canSaveGameStateCurrently() override { return _persistent._currentRoomId != 0; }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return true; }
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override { return _persistent._currentRoomId != 0; }
 	Common::Error loadGameStream(Common::SeekableReadStream *stream) override;
 	Common::Error saveGameStream(Common::WriteStream *stream, bool isAutosave = false) override;
 

--- a/engines/hdb/hdb.h
+++ b/engines/hdb/hdb.h
@@ -209,8 +209,8 @@ public:
 
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error loadGameState(int slot) override;
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	void saveGame(Common::OutSaveFile *out);
 	void loadGame(Common::InSaveFile *in);
 

--- a/engines/hdb/saveload.cpp
+++ b/engines/hdb/saveload.cpp
@@ -31,7 +31,7 @@
 
 namespace HDB {
 
-bool HDBGame::canSaveGameStateCurrently() {
+bool HDBGame::canSaveGameStateCurrently(Common::U32String *msg) {
 	return (_gameState == GAME_PLAY && !_ai->cinematicsActive());
 }
 
@@ -82,7 +82,7 @@ Common::Error HDBGame::saveGameState(int slot, const Common::String &desc, bool 
 	return Common::kNoError;
 }
 
-bool HDBGame::canLoadGameStateCurrently() {
+bool HDBGame::canLoadGameStateCurrently(Common::U32String *msg) {
 	return _gameState == GAME_PLAY;
 }
 

--- a/engines/hopkins/hopkins.cpp
+++ b/engines/hopkins/hopkins.cpp
@@ -77,14 +77,14 @@ HopkinsEngine::~HopkinsEngine() {
 /**
  * Returns true if it is currently okay to restore a game
  */
-bool HopkinsEngine::canLoadGameStateCurrently() {
+bool HopkinsEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return !_globals->_exitId && !_globals->_cityMapEnabledFl && _events->_mouseFl && _globals->_curRoomNum != 0;
 }
 
 /**
  * Returns true if it is currently okay to save the game
  */
-bool HopkinsEngine::canSaveGameStateCurrently() {
+bool HopkinsEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return !_globals->_exitId && !_globals->_cityMapEnabledFl && _events->_mouseFl
 		&& _globals->_curRoomNum != 0 && !isUnderwaterSubScene();
 }

--- a/engines/hopkins/hopkins.h
+++ b/engines/hopkins/hopkins.h
@@ -160,8 +160,8 @@ public:
 	const Common::String &getTargetName() const;
 
 	int getRandomNumber(int maxNumber);
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 

--- a/engines/hpl1/hpl1.h
+++ b/engines/hpl1/hpl1.h
@@ -82,7 +82,7 @@ public:
 			   (f == kSupportsArbitraryResolutions);
 	};
 
-	bool canLoadGameStateCurrently() override {
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return true;
 	}
 

--- a/engines/hugo/hugo.cpp
+++ b/engines/hugo/hugo.cpp
@@ -713,11 +713,11 @@ void HugoEngine::endGame() {
 	_status._viewState = kViewExit;
 }
 
-bool HugoEngine::canLoadGameStateCurrently() {
+bool HugoEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return true;
 }
 
-bool HugoEngine::canSaveGameStateCurrently() {
+bool HugoEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return (_status._viewState == kViewPlay);
 }
 

--- a/engines/hugo/hugo.h
+++ b/engines/hugo/hugo.h
@@ -238,8 +238,8 @@ public:
 		return *s_Engine;
 	}
 
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	bool loadHugoDat();
 
 	int8 getTPS() const;

--- a/engines/hypno/hypno.h
+++ b/engines/hypno/hypno.h
@@ -144,9 +144,9 @@ public:
 	bool cursorMask(Common::Point);
 
 	virtual void loadGame(const Common::String &nextLevel, int score, int puzzleDifficulty, int combatDifficulty);
-	bool canLoadGameStateCurrently() override { return (isDemo() ? false : true); }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return (isDemo() ? false : true); }
 	bool canSaveAutosaveCurrently() override { return false; }
-	bool canSaveGameStateCurrently() override { return (isDemo() ? false : true); }
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override { return (isDemo() ? false : true); }
 	Common::String _checkpoint;
 
 	Common::String _prefixDir;

--- a/engines/illusions/illusions.h
+++ b/engines/illusions/illusions.h
@@ -221,8 +221,8 @@ public:
 
 	bool _isSaveAllowed;
 
-	bool canLoadGameStateCurrently() override { return _isSaveAllowed; }
-	bool canSaveGameStateCurrently() override { return _isSaveAllowed; }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return _isSaveAllowed; }
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override { return _isSaveAllowed; }
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error removeGameState(int slot);

--- a/engines/immortal/immortal.h
+++ b/engines/immortal/immortal.h
@@ -745,10 +745,10 @@ public:
 		    (f == kSupportsReturnToLauncher);
 	};
 
-	bool canLoadGameStateCurrently() override {
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return true;
 	}
-	bool canSaveGameStateCurrently() override {
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return true;
 	}
 

--- a/engines/kyra/kyra_v1.h
+++ b/engines/kyra/kyra_v1.h
@@ -356,8 +356,8 @@ protected:
 
 	bool _isSaveAllowed;
 
-	bool canLoadGameStateCurrently() override { return _isSaveAllowed; }
-	bool canSaveGameStateCurrently() override { return _isSaveAllowed; }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return _isSaveAllowed; }
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override { return _isSaveAllowed; }
 	int getAutosaveSlot() const override { return 999; }
 
 	const char *getSavegameFilename(int num);

--- a/engines/lab/lab.cpp
+++ b/engines/lab/lab.cpp
@@ -213,11 +213,11 @@ Common::Error LabEngine::saveGameState(int slot, const Common::String &desc, boo
 	return (result) ? Common::kNoError : Common::kUserCanceled;
 }
 
-bool LabEngine::canLoadGameStateCurrently() {
+bool LabEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return !_introPlaying;
 }
 
-bool LabEngine::canSaveGameStateCurrently() {
+bool LabEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return !_introPlaying;
 }
 

--- a/engines/lab/lab.h
+++ b/engines/lab/lab.h
@@ -222,8 +222,8 @@ public:
 
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	bool isMainDisplay() const { return _mainDisplay; }
 

--- a/engines/lure/lure.h
+++ b/engines/lure/lure.h
@@ -129,10 +129,10 @@ public:
 		Common::String s(desc);
 		return saveGame(slot, s) ? Common::kNoError : Common::kReadingFailed;
 	}
-	bool canLoadGameStateCurrently() override {
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return _saveLoadAllowed && !Fights.isFighting();
 	}
-	bool canSaveGameStateCurrently() override {
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return _saveLoadAllowed && !Fights.isFighting();
 	}
 };

--- a/engines/macventure/macventure.h
+++ b/engines/macventure/macventure.h
@@ -193,8 +193,8 @@ public:
 	Common::Error run() override;
 
 	bool scummVMSaveLoadDialog(bool isSave);
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	void newGame();

--- a/engines/macventure/saveload.cpp
+++ b/engines/macventure/saveload.cpp
@@ -196,11 +196,11 @@ bool MacVentureEngine::scummVMSaveLoadDialog(bool isSave) {
 	return saveGameState(slot, desc).getCode() == Common::kNoError;
 }
 
-bool MacVentureEngine::canLoadGameStateCurrently() {
+bool MacVentureEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return true;
 }
 
-bool MacVentureEngine::canSaveGameStateCurrently() {
+bool MacVentureEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return true;
 }
 

--- a/engines/mads/mads.cpp
+++ b/engines/mads/mads.cpp
@@ -185,13 +185,13 @@ int MADSEngine::getRandomNumber(int minNumber, int maxNumber) {
 	return minNumber + _randomSource.getRandomNumber(range);
 }
 
-bool MADSEngine::canLoadGameStateCurrently() {
+bool MADSEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return !_game->_winStatus && !_game->globals()[5]
 		&& _dialogs->_pendingDialog == DIALOG_NONE
 		&& _events->_cursorId != CURSOR_WAIT;
 }
 
-bool MADSEngine::canSaveGameStateCurrently() {
+bool MADSEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return !_game->_winStatus && !_game->globals()[5]
 		&& _dialogs->_pendingDialog == DIALOG_NONE
 		&& _events->_cursorId != CURSOR_WAIT

--- a/engines/mads/mads.h
+++ b/engines/mads/mads.h
@@ -121,12 +121,12 @@ public:
 	/**
 	* Returns true if it is currently okay to restore a game
 	*/
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	* Returns true if it is currently okay to save the game
 	*/
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	 * Handles loading a game via the GMM

--- a/engines/mm/mm1/mm1.cpp
+++ b/engines/mm/mm1/mm1.cpp
@@ -138,7 +138,7 @@ bool MM1Engine::setupEnhanced() {
 	return true;
 }
 
-bool MM1Engine::canSaveGameStateCurrently() {
+bool MM1Engine::canSaveGameStateCurrently(Common::U32String *msg) {
 	if (!g_events)
 		return false;
 
@@ -147,7 +147,7 @@ bool MM1Engine::canSaveGameStateCurrently() {
 		dynamic_cast<ViewsEnh::Game *>(view) != nullptr;
 }
 
-bool MM1Engine::canLoadGameStateCurrently() {
+bool MM1Engine::canLoadGameStateCurrently(Common::U32String *msg) {
 	if (!g_events)
 		return false;
 

--- a/engines/mm/mm1/mm1.h
+++ b/engines/mm/mm1/mm1.h
@@ -85,12 +85,12 @@ public:
 	/**
 	 * Returns true if a game can be saved
 	 */
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	 * Returns true if a savegame can be loaded
 	 */
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	 * Saves or loads a savegame

--- a/engines/mm/xeen/xeen.cpp
+++ b/engines/mm/xeen/xeen.cpp
@@ -188,11 +188,11 @@ Common::Error XeenEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-bool XeenEngine::canLoadGameStateCurrently() {
+bool XeenEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return _mode != MODE_STARTUP;
 }
 
-bool XeenEngine::canSaveGameStateCurrently() {
+bool XeenEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return _mode != MODE_COMBAT && _mode != MODE_STARTUP && _mode != MODE_SCRIPT_IN_PROGRESS
 		&& (_map->mazeData()._mazeFlags & RESTRICTION_SAVE) == 0;
 }

--- a/engines/mm/xeen/xeen.h
+++ b/engines/mm/xeen/xeen.h
@@ -244,12 +244,12 @@ public:
 	/**
 	 * Returns true if a savegame can currently be loaded
 	 */
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	* Returns true if the game can currently be saved
 	*/
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	* Returns true if an autosave can be created

--- a/engines/mohawk/myst.cpp
+++ b/engines/mohawk/myst.cpp
@@ -1080,7 +1080,7 @@ bool MohawkEngine_Myst::isInteractive() const {
 	return !_stack->isScriptRunning() && !_waitingOnBlockingOperation;
 }
 
-bool MohawkEngine_Myst::canLoadGameStateCurrently() {
+bool MohawkEngine_Myst::canLoadGameStateCurrently(Common::U32String *msg) {
 	bool isInMenu = _stack->getStackId() == kMenuStack;
 
 	if (!isInMenu) {
@@ -1101,7 +1101,7 @@ bool MohawkEngine_Myst::canLoadGameStateCurrently() {
 	return true;
 }
 
-bool MohawkEngine_Myst::canSaveGameStateCurrently() {
+bool MohawkEngine_Myst::canSaveGameStateCurrently(Common::U32String *msg) {
 	if (!canLoadGameStateCurrently()) {
 		return false;
 	}

--- a/engines/mohawk/myst.h
+++ b/engines/mohawk/myst.h
@@ -188,8 +188,8 @@ public:
 	 */
 	bool isInteractive() const;
 	bool isGameStarted() const;
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::String getSaveStateName(int slot) const override {

--- a/engines/mohawk/riven.cpp
+++ b/engines/mohawk/riven.cpp
@@ -279,11 +279,11 @@ void MohawkEngine_Riven::processInput() {
 				} else if (!isGameVariant(GF_25TH)) {
 					openMainMenuDialog();
 				}
-					
+
 				if (!isGameVariant(GF_DEMO) && hasGameEnded()) {
 					// Attempt to autosave before exiting
 					saveAutosaveIfEnabled();
-				}	
+				}
 				break;
 			case kRivenActionPlayIntroVideos:
 				// Play the intro videos in the demo
@@ -755,6 +755,9 @@ bool MohawkEngine_Riven::isZipVisitedCard(const Common::String &hotspotName) con
 
 bool MohawkEngine_Riven::canLoadGameStateCurrently(Common::U32String *msg) {
 	if (isGameVariant(GF_DEMO)) {
+		if (msg)
+			*msg = _("This game does not support loading");
+
 		return false;
 	}
 
@@ -766,7 +769,14 @@ bool MohawkEngine_Riven::canLoadGameStateCurrently(Common::U32String *msg) {
 }
 
 bool MohawkEngine_Riven::canSaveGameStateCurrently(Common::U32String *msg) {
-	return canLoadGameStateCurrently() && isGameStarted();
+	if (isGameVariant(GF_DEMO)) {
+		if (msg)
+			*msg = _("This game does not support saving");
+
+		return false;
+	}
+
+	return canLoadGameStateCurrently(msg) && isGameStarted();
 }
 
 bool MohawkEngine_Riven::hasGameEnded() const {

--- a/engines/mohawk/riven.cpp
+++ b/engines/mohawk/riven.cpp
@@ -753,7 +753,7 @@ bool MohawkEngine_Riven::isZipVisitedCard(const Common::String &hotspotName) con
 	return foundMatch;
 }
 
-bool MohawkEngine_Riven::canLoadGameStateCurrently() {
+bool MohawkEngine_Riven::canLoadGameStateCurrently(Common::U32String *msg) {
 	if (isGameVariant(GF_DEMO)) {
 		return false;
 	}
@@ -765,7 +765,7 @@ bool MohawkEngine_Riven::canLoadGameStateCurrently() {
 	return true;
 }
 
-bool MohawkEngine_Riven::canSaveGameStateCurrently() {
+bool MohawkEngine_Riven::canSaveGameStateCurrently(Common::U32String *msg) {
 	return canLoadGameStateCurrently() && isGameStarted();
 }
 

--- a/engines/mohawk/riven.h
+++ b/engines/mohawk/riven.h
@@ -106,8 +106,8 @@ public:
 	// Display debug rectangles around the hotspots
 	bool _showHotspots;
 
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::String getSaveStateName(int slot) const override {

--- a/engines/mortevielle/mortevielle.cpp
+++ b/engines/mortevielle/mortevielle.cpp
@@ -176,7 +176,7 @@ bool MortevielleEngine::hasFeature(EngineFeature f) const {
 /**
  * Return true if a game can currently be loaded
  */
-bool MortevielleEngine::canLoadGameStateCurrently() {
+bool MortevielleEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	// Saving is only allowed in the main game event loop
 	return _inMainGameLoop;
 }
@@ -184,7 +184,7 @@ bool MortevielleEngine::canLoadGameStateCurrently() {
 /**
  * Return true if a game can currently be saved
  */
-bool MortevielleEngine::canSaveGameStateCurrently() {
+bool MortevielleEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	// Loading is only allowed in the main game event loop
 	return _inMainGameLoop;
 }

--- a/engines/mortevielle/mortevielle.h
+++ b/engines/mortevielle/mortevielle.h
@@ -432,8 +432,8 @@ public:
 	MortevielleEngine(OSystem *system, const MortevielleGameDescription *gameDesc);
 	~MortevielleEngine() override;
 	bool hasFeature(EngineFeature f) const override;
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error run() override;

--- a/engines/mtropolis/mtropolis.h
+++ b/engines/mtropolis/mtropolis.h
@@ -73,7 +73,7 @@ public:
 
 	Common::Error saveGameStream(Common::WriteStream *stream, bool isAutosave) override;
 	bool canSaveAutosaveCurrently() override;
-	bool canSaveGameStateCurrently() override;	
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;	
 
 public:
 	void handleEvents();

--- a/engines/mtropolis/saveload.cpp
+++ b/engines/mtropolis/saveload.cpp
@@ -252,7 +252,7 @@ bool MTropolisEngine::canSaveAutosaveCurrently() {
 	return canSaveGameStateCurrently();
 }
 
-bool MTropolisEngine::canSaveGameStateCurrently() {
+bool MTropolisEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	if (!_runtime->isIdle())
 		return false;
 

--- a/engines/mutationofjb/mutationofjb.cpp
+++ b/engines/mutationofjb/mutationofjb.cpp
@@ -119,7 +119,7 @@ bool MutationOfJBEngine::hasFeature(Engine::EngineFeature f) const {
 	return false;
 }
 
-bool MutationOfJBEngine::canLoadGameStateCurrently() {
+bool MutationOfJBEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return _game->loadSaveAllowed();
 }
 
@@ -142,7 +142,7 @@ Common::Error MutationOfJBEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-bool MutationOfJBEngine::canSaveGameStateCurrently() {
+bool MutationOfJBEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return _game->loadSaveAllowed();
 }
 

--- a/engines/mutationofjb/mutationofjb.h
+++ b/engines/mutationofjb/mutationofjb.h
@@ -65,9 +65,9 @@ public:
 	void setCursorState(CursorState cursorState);
 
 	bool hasFeature(EngineFeature f) const override;
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 
 	const ADGameDescription *getGameDescription() const;

--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -1498,12 +1498,12 @@ void Myst3Engine::dragItem(uint16 statusVar, uint16 movie, uint16 frame, uint16 
 	}
 }
 
-bool Myst3Engine::canSaveGameStateCurrently() {
+bool Myst3Engine::canSaveGameStateCurrently(Common::U32String *msg) {
 	bool inMenuWithNoGameLoaded = _state->getLocationRoom() == kRoomMenu && _state->getMenuSavedAge() == 0;
 	return canLoadGameStateCurrently() && !inMenuWithNoGameLoaded && _cursor->isVisible();
 }
 
-bool Myst3Engine::canLoadGameStateCurrently() {
+bool Myst3Engine::canLoadGameStateCurrently(Common::U32String *msg) {
 	// Loading from the GMM is only possible when the game is interactive
 	// This is to prevent loading from inner loops. Loading while
 	// in an inner loop can cause the exit condition to never happen,

--- a/engines/myst3/myst3.h
+++ b/engines/myst3/myst3.h
@@ -118,8 +118,8 @@ public:
 	bool isTextLanguageEnglish() const;
 	bool isWideScreenModEnabled() const;
 
-	bool canSaveGameStateCurrently() override;
-	bool canLoadGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error loadGameState(Common::String fileName, TransitionType transition);
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;

--- a/engines/nancy/nancy.cpp
+++ b/engines/nancy/nancy.cpp
@@ -119,11 +119,11 @@ Common::Error NancyEngine::saveGameStream(Common::WriteStream *stream, bool isAu
 	return synchronize(ser);
 }
 
-bool NancyEngine::canLoadGameStateCurrently() {
+bool NancyEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return canSaveGameStateCurrently();
 }
 
-bool NancyEngine::canSaveGameStateCurrently() {
+bool NancyEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	// TODO also disable during secondary movie
 	return State::Scene::hasInstance() &&
 			NancySceneState._state == State::Scene::kRun &&

--- a/engines/nancy/nancy.h
+++ b/engines/nancy/nancy.h
@@ -84,8 +84,8 @@ public:
 
 	Common::Error loadGameStream(Common::SeekableReadStream *stream) override;
 	Common::Error saveGameStream(Common::WriteStream *stream, bool isAutosave = false) override;
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	void secondChance();
 

--- a/engines/neverhood/neverhood.h
+++ b/engines/neverhood/neverhood.h
@@ -117,8 +117,8 @@ public:
 
 	bool _isSaveAllowed;
 
-	bool canLoadGameStateCurrently() override { return _isSaveAllowed; }
-	bool canSaveGameStateCurrently() override { return _isSaveAllowed; }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return _isSaveAllowed; }
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override { return _isSaveAllowed; }
 
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &description, bool isAutosave = false) override;

--- a/engines/ngi/ngi.h
+++ b/engines/ngi/ngi.h
@@ -372,8 +372,8 @@ public:
 	Common::Error saveGameState(int slot, const Common::String &description, bool isAutosave = false) override;
 	Common::String getSaveStateName(int slot) const override;
 
-	bool canLoadGameStateCurrently() override { return true; }
-	bool canSaveGameStateCurrently() override { return _isSaveAllowed; }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return true; }
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override { return _isSaveAllowed; }
 	bool hasFeature(EngineFeature f) const override;
 
 };

--- a/engines/pegasus/pegasus.cpp
+++ b/engines/pegasus/pegasus.cpp
@@ -211,11 +211,11 @@ Common::Error PegasusEngine::run() {
 	return Common::kNoError;
 }
 
-bool PegasusEngine::canLoadGameStateCurrently() {
+bool PegasusEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return _loadAllowed && !isDemo();
 }
 
-bool PegasusEngine::canSaveGameStateCurrently() {
+bool PegasusEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return _saveAllowed && !isDemo() && g_neighborhood;
 }
 

--- a/engines/pegasus/pegasus.h
+++ b/engines/pegasus/pegasus.h
@@ -77,8 +77,8 @@ public:
 	// Engine stuff
 	const PegasusGameDescription *_gameDescription;
 	bool hasFeature(EngineFeature f) const override;
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 

--- a/engines/petka/POTFILES
+++ b/engines/petka/POTFILES
@@ -1,0 +1,1 @@
+engines/petka/saveload.cpp

--- a/engines/petka/petka.h
+++ b/engines/petka/petka.h
@@ -122,10 +122,10 @@ public:
 	void pushMouseMoveEvent();
 
 	Common::Error loadGameState(int slot) override;
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave) override;
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	int getAutosaveSlot() const override { return - 1;}
 

--- a/engines/petka/saveload.cpp
+++ b/engines/petka/saveload.cpp
@@ -21,6 +21,7 @@
 
 #include "common/system.h"
 #include "common/savefile.h"
+#include "common/translation.h"
 
 #include "engines/savestate.h"
 
@@ -95,7 +96,14 @@ Common::Error PetkaEngine::saveGameState(int slot, const Common::String &desci, 
 }
 
 bool PetkaEngine::canSaveGameStateCurrently(Common::U32String *msg) {
-	if (isDemo() || !_qsystem)
+	if (isDemo()) {
+		if (msg)
+			*msg = _("This game does not support saving");
+
+		return false;
+	}
+
+	if (!_qsystem)
 		return false;
 
 	Interface *panel = _qsystem->_panelInterface.get();
@@ -108,7 +116,14 @@ bool PetkaEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 }
 
 bool PetkaEngine::canLoadGameStateCurrently(Common::U32String *msg) {
-	return !isDemo() && _qsystem;
+	if (isDemo()) {
+		if (msg)
+			*msg = _("This game does not support loading");
+
+		return false;
+	}
+
+	return _qsystem;
 }
 
 int PetkaEngine::getSaveSlot() {
@@ -149,4 +164,3 @@ Common::String generateSaveName(int slot, const char *gameId) {
 }
 
 }
-

--- a/engines/petka/saveload.cpp
+++ b/engines/petka/saveload.cpp
@@ -94,7 +94,7 @@ Common::Error PetkaEngine::saveGameState(int slot, const Common::String &desci, 
 	return Common::kNoError;
 }
 
-bool PetkaEngine::canSaveGameStateCurrently() {
+bool PetkaEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	if (isDemo() || !_qsystem)
 		return false;
 
@@ -107,7 +107,7 @@ bool PetkaEngine::canSaveGameStateCurrently() {
 	return prev == _qsystem->_mainInterface.get() && (curr == saveLoad || curr == panel);
 }
 
-bool PetkaEngine::canLoadGameStateCurrently() {
+bool PetkaEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return !isDemo() && _qsystem;
 }
 

--- a/engines/pink/pink.cpp
+++ b/engines/pink/pink.cpp
@@ -295,11 +295,11 @@ void PinkEngine::setCursor(uint cursorIndex) {
 	CursorMan.showMouse(true);
 }
 
-bool PinkEngine::canLoadGameStateCurrently() {
+bool PinkEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return true;
 }
 
-bool PinkEngine::canSaveGameStateCurrently() {
+bool PinkEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return true;
 }
 

--- a/engines/pink/pink.h
+++ b/engines/pink/pink.h
@@ -102,10 +102,10 @@ public:
 	bool hasFeature(EngineFeature f) const override;
 
 	Common::Error loadGameState(int slot) override;
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::String getSaveStateName(int slot) const override {
 		return Common::String::format("%s.s%02d", _targetName.c_str(), slot);
 	}

--- a/engines/prince/prince.h
+++ b/engines/prince/prince.h
@@ -279,8 +279,8 @@ public:
 
 	bool hasFeature(EngineFeature f) const override;
 	void pauseEngineIntern(bool pause) override;
-	bool canSaveGameStateCurrently() override;
-	bool canLoadGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error loadGameState(int slot) override;
 

--- a/engines/prince/saveload.cpp
+++ b/engines/prince/saveload.cpp
@@ -113,7 +113,7 @@ WARN_UNUSED_RESULT bool PrinceEngine::readSavegameHeader(Common::InSaveFile *in,
 	return true;
 }
 
-bool PrinceEngine::canSaveGameStateCurrently() {
+bool PrinceEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	if (_mouseFlag && _mouseFlag != 3) {
 		if (_mainHero->_visible) {
 			// 29 - Basement
@@ -128,7 +128,7 @@ bool PrinceEngine::canSaveGameStateCurrently() {
 	return false;
 }
 
-bool PrinceEngine::canLoadGameStateCurrently() {
+bool PrinceEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	if (_mouseFlag && _mouseFlag != 3) {
 		if (_mainHero->_visible) {
 			// 29 - Basement

--- a/engines/private/private.h
+++ b/engines/private/private.h
@@ -180,13 +180,13 @@ public:
 	bool cursorMask(Common::Point);
 
 	bool hasFeature(EngineFeature f) const override;
-	bool canLoadGameStateCurrently() override {
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return true;
 	}
 	bool canSaveAutosaveCurrently() override  {
 		return false;
 	}
-	bool canSaveGameStateCurrently() override {
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return true;
 	}
 

--- a/engines/queen/queen.cpp
+++ b/engines/queen/queen.cpp
@@ -169,11 +169,11 @@ bool QueenEngine::canLoadOrSave() const {
 	return !_input->cutawayRunning() && !(_resource->isDemo() || _resource->isInterview()) && _gameStarted;
 }
 
-bool QueenEngine::canLoadGameStateCurrently() {
+bool QueenEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return canLoadOrSave();
 }
 
-bool QueenEngine::canSaveGameStateCurrently() {
+bool QueenEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return canLoadOrSave();
 }
 

--- a/engines/queen/queen.h
+++ b/engines/queen/queen.h
@@ -93,8 +93,8 @@ public:
 	void update(bool checkPlayerInput = false);
 
 	bool canLoadOrSave() const;
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error loadGameState(int slot) override;
 	int getAutosaveSlot() const override { return 99; }

--- a/engines/saga/metaengine.cpp
+++ b/engines/saga/metaengine.cpp
@@ -302,12 +302,12 @@ Common::Error SagaEngine::saveGameState(int slot, const Common::String &desc, bo
 	return Common::kNoError;	// TODO: return success/failure
 }
 
-bool SagaEngine::canLoadGameStateCurrently() {
+bool SagaEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return !_scene->isInIntro() &&
 		(_interface->getMode() == kPanelMain || _interface->getMode() == kPanelChapterSelection);
 }
 
-bool SagaEngine::canSaveGameStateCurrently() {
+bool SagaEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return !_scene->isInIntro() &&
 		(_interface->getMode() == kPanelMain || _interface->getMode() == kPanelChapterSelection);
 }

--- a/engines/saga/saga.h
+++ b/engines/saga/saga.h
@@ -623,8 +623,8 @@ public:
 	const Common::Rect &getDisplayClip() const { return _displayClip;}
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	const GameDisplayInfo &getDisplayInfo();
 
 	int getLanguageIndex();

--- a/engines/saga2/saga2.h
+++ b/engines/saga2/saga2.h
@@ -113,8 +113,8 @@ public:
 	bool hasFeature(EngineFeature f) const override;
 	const ADGameFileDescription *getFilesDescriptions() const;
 	int getGameId() const;
-	bool canLoadGameStateCurrently() override { return true; }
-	bool canSaveGameStateCurrently() override { return true; }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return true; }
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override { return true; }
 	Common::Error loadGameStream(Common::SeekableReadStream *stream) override;
 	Common::Error saveGameStream(Common::WriteStream *stream, bool isAutosave = false) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave) override;

--- a/engines/sci/metaengine.cpp
+++ b/engines/sci/metaengine.cpp
@@ -449,7 +449,7 @@ Common::Error SciEngine::saveGameState(int slot, const Common::String &desc, boo
 	return res ? Common::kNoError : Common::kWritingFailed;
 }
 
-bool SciEngine::canLoadGameStateCurrently() {
+bool SciEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 #ifdef ENABLE_SCI32
 	const Common::String &guiOptions = ConfMan.get("guioptions");
 	if (getSciVersion() >= SCI_VERSION_2) {
@@ -464,7 +464,7 @@ bool SciEngine::canLoadGameStateCurrently() {
 	return !_gamestate->executionStackBase;
 }
 
-bool SciEngine::canSaveGameStateCurrently() {
+bool SciEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return
 		_features->canSaveFromGMM() &&
 		!_gamestate->executionStackBase &&

--- a/engines/sci/sci.h
+++ b/engines/sci/sci.h
@@ -146,8 +146,8 @@ public:
 	Console *getSciDebugger();
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	void syncSoundSettings() override; ///< from ScummVM to the game
 	void updateSoundMixerVolumes();
 	uint32 getTickCount();

--- a/engines/scumm/POTFILES
+++ b/engines/scumm/POTFILES
@@ -6,6 +6,7 @@ engines/scumm/dialogs.cpp
 engines/scumm/help.cpp
 engines/scumm/input.cpp
 engines/scumm/metaengine.cpp
+engines/scumm/saveload.cpp
 engines/scumm/scumm.cpp
 engines/scumm/he/sound_he.cpp
 engines/scumm/imuse/drivers/amiga.cpp

--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -24,6 +24,7 @@
 #include "common/savefile.h"
 #include "common/serializer.h"
 #include "common/system.h"
+#include "common/translation.h"
 
 #include "scumm/actor.h"
 #include "scumm/charset.h"
@@ -92,8 +93,12 @@ bool ScummEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	//
 	// Except the earliest HE Games (3DO and initial DOS version of
 	// puttputt), which didn't offer scripted load/save screens.
-	if (_game.heversion >= 62)
+	if (_game.heversion >= 62) {
+		if (msg)
+			*msg = _("This game does not support loading from the menu. Use in-game interface");
+
 		return false;
+	}
 
 	// COMI always disables saving/loading (to tell the truth:
 	// the main menu) via its scripts, thus we need to make an
@@ -160,8 +165,12 @@ bool ScummEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	//
 	// Except the earliest HE Games (3DO and initial DOS version of
 	// puttputt), which didn't offer scripted load/save screens.
-	if (_game.heversion >= 62)
+	if (_game.heversion >= 62) {
+		if (msg)
+			*msg = _("This game does not support saving from the menu. Use in-game interface");
+
 		return false;
+	}
 
 #ifdef ENABLE_SCUMM_7_8
 	// COMI always disables saving/loading (to tell the truth:

--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -78,7 +78,7 @@ Common::Error ScummEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-bool ScummEngine::canLoadGameStateCurrently() {
+bool ScummEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	if (!_setupIsComplete)
 		return false;
 
@@ -141,7 +141,7 @@ Common::Error ScummEngine::saveGameState(int slot, const Common::String &desc, b
 	return Common::kNoError;
 }
 
-bool ScummEngine::canSaveGameStateCurrently() {
+bool ScummEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	if (!_setupIsComplete)
 		return false;
 

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -589,9 +589,9 @@ public:
 	void syncSoundSettings() override;
 
 	Common::Error loadGameState(int slot) override;
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	void pauseEngineIntern(bool pause) override;
 

--- a/engines/sherlock/sherlock.cpp
+++ b/engines/sherlock/sherlock.cpp
@@ -289,11 +289,11 @@ void SherlockEngine::synchronize(Serializer &s) {
 		s.syncAsByte(_flags[idx]);
 }
 
-bool SherlockEngine::canLoadGameStateCurrently() {
+bool SherlockEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return _canLoadSave;
 }
 
-bool SherlockEngine::canSaveGameStateCurrently() {
+bool SherlockEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return _canLoadSave;
 }
 

--- a/engines/sherlock/sherlock.h
+++ b/engines/sherlock/sherlock.h
@@ -142,12 +142,12 @@ public:
 	/**
 	 * Returns true if a savegame can be loaded
 	 */
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	 * Returns true if the game can be saved
 	 */
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	 * Called by the GMM to load a savegame

--- a/engines/sherlock/tattoo/tattoo.cpp
+++ b/engines/sherlock/tattoo/tattoo.cpp
@@ -202,12 +202,12 @@ void TattooEngine::saveConfig() {
 	ConfMan.flushToDisk();
 }
 
-bool TattooEngine::canLoadGameStateCurrently() {
+bool TattooEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	TattooUserInterface &ui = *(TattooUserInterface *)_ui;
 	return _canLoadSave && !ui._creditsWidget.active() && !_runningProlog;
 }
 
-bool TattooEngine::canSaveGameStateCurrently() {
+bool TattooEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	TattooUserInterface &ui = *(TattooUserInterface *)_ui;
 	return _canLoadSave && !ui._creditsWidget.active() && !_runningProlog;
 }

--- a/engines/sherlock/tattoo/tattoo.h
+++ b/engines/sherlock/tattoo/tattoo.h
@@ -104,12 +104,12 @@ public:
 	/**
 	 * Returns true if a savegame can be loaded
 	 */
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	 * Returns true if the game can be saved
 	 */
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 };
 
 } // End of namespace Tattoo

--- a/engines/sky/metaengine.cpp
+++ b/engines/sky/metaengine.cpp
@@ -386,13 +386,13 @@ Common::Error SkyEngine::saveGameState(int slot, const Common::String &desc, boo
 	return Common::kNoError;
 }
 
-bool SkyEngine::canLoadGameStateCurrently() {
+bool SkyEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return _systemVars->pastIntro
 	    && _skyControl->loadSaveAllowed()
 	    && !_skyControl->isControlPanelOpen();
 }
 
-bool SkyEngine::canSaveGameStateCurrently() {
+bool SkyEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return _systemVars->pastIntro
 	    && _skyControl->loadSaveAllowed()
 	    && !_skyControl->isControlPanelOpen();

--- a/engines/sky/sky.h
+++ b/engines/sky/sky.h
@@ -101,8 +101,8 @@ public:
 
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::String getSaveStateName(int slot) const override {
 		return Common::String::format("SKY-VM.%03d", slot);
 	}

--- a/engines/stark/stark.cpp
+++ b/engines/stark/stark.cpp
@@ -357,7 +357,7 @@ bool StarkEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsReturnToLauncher);
 }
 
-bool StarkEngine::canLoadGameStateCurrently() {
+bool StarkEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return !StarkUserInterface->isInSaveLoadMenuScreen();
 }
 
@@ -424,7 +424,7 @@ Common::Error StarkEngine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-bool StarkEngine::canSaveGameStateCurrently() {
+bool StarkEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	// Disallow saving when there is no level loaded or when a script is running
 	// or when the save & load menu is currently displayed
 	return StarkGlobal->getLevel() && StarkGlobal->getCurrent() && StarkUserInterface->isInteractive() && !StarkUserInterface->isInSaveLoadMenuScreen();

--- a/engines/stark/stark.h
+++ b/engines/stark/stark.h
@@ -79,8 +79,8 @@ protected:
 	// Engine APIs
 	Common::Error run() override;
 	bool hasFeature(EngineFeature f) const override;
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	void pauseEngineIntern(bool pause) override;

--- a/engines/supernova/supernova.cpp
+++ b/engines/supernova/supernova.cpp
@@ -659,7 +659,7 @@ bool SupernovaEngine::quitGameDialog() {
 }
 
 
-bool SupernovaEngine::canLoadGameStateCurrently() {
+bool SupernovaEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return _allowLoadGame;
 }
 
@@ -667,7 +667,7 @@ Common::Error SupernovaEngine::loadGameState(int slot) {
 	return (loadGame(slot) ? Common::kNoError : Common::kReadingFailed);
 }
 
-bool SupernovaEngine::canSaveGameStateCurrently() {
+bool SupernovaEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	// Do not allow saving when either _allowSaveGame, _animationEnabled or _guiEnabled is false
 	return _allowSaveGame && _gm->canSaveGameStateCurrently();
 }

--- a/engines/supernova/supernova.h
+++ b/engines/supernova/supernova.h
@@ -65,9 +65,9 @@ public:
 
 	Common::Error run() override;
 	Common::Error loadGameState(int slot) override;
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	bool hasFeature(EngineFeature f) const override;
 	void pauseEngineIntern(bool pause) override;
 

--- a/engines/sword1/metaengine.cpp
+++ b/engines/sword1/metaengine.cpp
@@ -191,7 +191,7 @@ Common::Error SwordEngine::loadGameState(int slot) {
 	return Common::kNoError;    // TODO: return success/failure
 }
 
-bool SwordEngine::canLoadGameStateCurrently() {
+bool SwordEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return (mouseIsActive() && !_control->isPanelShown()); // Disable GMM loading when game panel is shown
 }
 
@@ -201,7 +201,7 @@ Common::Error SwordEngine::saveGameState(int slot, const Common::String &desc, b
 	return Common::kNoError;    // TODO: return success/failure
 }
 
-bool SwordEngine::canSaveGameStateCurrently() {
+bool SwordEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return (mouseIsActive() && !_control->isPanelShown() && Logic::_scriptVars[SCREEN] != 91);
 }
 

--- a/engines/sword1/sword1.h
+++ b/engines/sword1/sword1.h
@@ -146,9 +146,9 @@ protected:
 	void syncSoundSettings() override;
 
 	Common::Error loadGameState(int slot) override;
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::String getSaveStateName(int slot) const override {
 		return Common::String::format("sword1.%03d", slot);
 	}

--- a/engines/sword2/sword2.cpp
+++ b/engines/sword2/sword2.cpp
@@ -575,7 +575,7 @@ Common::Error Sword2Engine::saveGameState(int slot, const Common::String &desc, 
 		return Common::kUnknownError;
 }
 
-bool Sword2Engine::canSaveGameStateCurrently() {
+bool Sword2Engine::canSaveGameStateCurrently(Common::U32String *msg) {
 	bool canSave = true;
 
 	// No save if dead
@@ -605,7 +605,7 @@ Common::Error Sword2Engine::loadGameState(int slot) {
 	return Common::kNoError;
 }
 
-bool Sword2Engine::canLoadGameStateCurrently() {
+bool Sword2Engine::canLoadGameStateCurrently(Common::U32String *msg) {
 	bool canLoad = true;
 
 	// No load if mouse is disabled

--- a/engines/sword2/sword2.h
+++ b/engines/sword2/sword2.h
@@ -162,9 +162,9 @@ public:
 
 	// GMM Loading/Saving
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	uint32 _features;
 

--- a/engines/teenagent/teenagent.h
+++ b/engines/teenagent/teenagent.h
@@ -89,8 +89,8 @@ public:
 	Common::String getSaveStateName(int slot) const override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-	bool canLoadGameStateCurrently() override { return true; }
-	bool canSaveGameStateCurrently() override { return !_sceneBusy; }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return true; }
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override { return !_sceneBusy; }
 	bool hasFeature(EngineFeature f) const override;
 
 	void init();

--- a/engines/tetraedge/tetraedge.cpp
+++ b/engines/tetraedge/tetraedge.cpp
@@ -151,11 +151,11 @@ bool TetraedgeEngine::isGameDemo() const {
 	return (_gameDescription->flags & ADGF_DEMO) != 0;
 }
 
-bool TetraedgeEngine::canLoadGameStateCurrently() {
+bool TetraedgeEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return _game && _application && !_application->mainMenu().isEntered();
 }
 
-bool TetraedgeEngine::canSaveGameStateCurrently() {
+bool TetraedgeEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return canSaveAutosaveCurrently() && !_application->isLockCursor();
 }
 

--- a/engines/tetraedge/tetraedge.h
+++ b/engines/tetraedge/tetraedge.h
@@ -110,8 +110,8 @@ public:
 			(f == kSupportsQuitDialogOverride);
 	};
 
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	bool canSaveAutosaveCurrently() override;
 
 	/**

--- a/engines/tinsel/metaengine.cpp
+++ b/engines/tinsel/metaengine.cpp
@@ -260,10 +260,10 @@ Common::Error TinselEngine::saveGameState(int slot, const Common::String &desc, 
 }
 #endif
 
-bool TinselEngine::canLoadGameStateCurrently() { return !_bmv->MoviePlaying(); }
+bool TinselEngine::canLoadGameStateCurrently(Common::U32String *msg) { return !_bmv->MoviePlaying(); }
 
 #if 0
-bool TinselEngine::canSaveGameStateCurrently() { return isCursorShown(); }
+bool TinselEngine::canSaveGameStateCurrently(Common::U32String *msg) { return isCursorShown(); }
 #endif
 
 } // End of namespace Tinsel

--- a/engines/tinsel/tinsel.h
+++ b/engines/tinsel/tinsel.h
@@ -139,7 +139,7 @@ protected:
 #if 0
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false);
 #endif
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 #if 0
 	bool canSaveGameStateCurrently();
 #endif

--- a/engines/titanic/titanic.cpp
+++ b/engines/titanic/titanic.cpp
@@ -176,7 +176,7 @@ void TitanicEngine::setRoomNames() {
 	delete r;
 }
 
-bool TitanicEngine::canLoadGameStateCurrently() {
+bool TitanicEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	CGameManager *gameManager = _window->_gameManager;
 	CScreenManager *screenMan = CScreenManager::_screenManagerPtr;
 
@@ -205,7 +205,7 @@ bool TitanicEngine::canLoadGameStateCurrently() {
 	return true;
 }
 
-bool TitanicEngine::canSaveGameStateCurrently() {
+bool TitanicEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	CGameManager *gameManager = _window->_gameManager;
 	if (!gameManager)
 		return false;

--- a/engines/titanic/titanic.h
+++ b/engines/titanic/titanic.h
@@ -133,12 +133,12 @@ public:
 	/**
 	 * Returns true if a savegame can be loaded
 	 */
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	 * Returns true if the game can be saved
 	 */
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	 * Called by the GMM to load a savegame

--- a/engines/toltecs/toltecs.h
+++ b/engines/toltecs/toltecs.h
@@ -211,8 +211,8 @@ public:
 
 	bool _isSaveAllowed;
 
-	bool canLoadGameStateCurrently() override { return _isSaveAllowed; }
-	bool canSaveGameStateCurrently() override { return _isSaveAllowed; }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return _isSaveAllowed; }
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override { return _isSaveAllowed; }
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &description, bool isAutosave = false) override;
 	void savegame(const char *filename, const char *description);

--- a/engines/tony/tony.cpp
+++ b/engines/tony/tony.cpp
@@ -736,11 +736,11 @@ uint32 TonyEngine::getTime() {
 	return g_system->getMillis();
 }
 
-bool TonyEngine::canLoadGameStateCurrently() {
+bool TonyEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return GLOBALS._gfxEngine != NULL && GLOBALS._gfxEngine->canLoadSave();
 }
 
-bool TonyEngine::canSaveGameStateCurrently() {
+bool TonyEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return GLOBALS._gfxEngine != NULL && GLOBALS._gfxEngine->canLoadSave();
 }
 

--- a/engines/tony/tony.h
+++ b/engines/tony/tony.h
@@ -161,8 +161,8 @@ public:
 		return &_theEngine;
 	}
 
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -3771,11 +3771,11 @@ void ToonEngine::pauseEngineIntern(bool pause) {
 	}
 }
 
-bool ToonEngine::canSaveGameStateCurrently() {
+bool ToonEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return !_gameState->_inMenu && !_gameState->_inInventory && !_gameState->_inConversation && !_gameState->_inCutaway && !_gameState->_mouseHidden && !_moviePlayer->isPlaying();
 }
 
-bool ToonEngine::canLoadGameStateCurrently() {
+bool ToonEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return !_gameState->_inMenu && !_gameState->_inInventory && !_gameState->_inConversation && !_gameState->_inCutaway && !_gameState->_mouseHidden && !_moviePlayer->isPlaying();
 }
 

--- a/engines/toon/toon.h
+++ b/engines/toon/toon.h
@@ -212,8 +212,8 @@ public:
 	void doMagnifierEffect();
 	void drawCustomText(int16 x, int16 y, const char *line, Graphics::Surface *frame, byte color);
 	bool showConversationText() const;
-	bool canSaveGameStateCurrently() override;
-	bool canLoadGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 	void pauseEngineIntern(bool pause) override;
 	void syncSoundSettings() override;
 

--- a/engines/touche/touche.cpp
+++ b/engines/touche/touche.cpp
@@ -3406,11 +3406,11 @@ void ToucheEngine::updatePalette() {
 	_system->getPaletteManager()->setPalette(_paletteBuffer, 0, 256);
 }
 
-bool ToucheEngine::canLoadGameStateCurrently() {
+bool ToucheEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return _gameState == kGameStateGameLoop && _flagsTable[618] == 0 && !_hideInventoryTexts;
 }
 
-bool ToucheEngine::canSaveGameStateCurrently() {
+bool ToucheEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return _gameState == kGameStateGameLoop && _flagsTable[618] == 0 && !_hideInventoryTexts;
 }
 

--- a/engines/touche/touche.h
+++ b/engines/touche/touche.h
@@ -619,8 +619,8 @@ protected:
 	void loadGameStateData(Common::ReadStream *stream);
 	Common::Error saveGameState(int num, const Common::String &description, bool isAutosave = false) override;
 	Common::Error loadGameState(int num) override;
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::String getSaveStateName(int slot) const override {
 		return Common::String::format("%s.%d", _targetName.c_str(), slot);
 	}

--- a/engines/trecision/trecision.h
+++ b/engines/trecision/trecision.h
@@ -169,8 +169,8 @@ public:
 	bool isDemo() const { return _gameDescription->flags & ADGF_DEMO; }
 	bool isAmiga() const { return _gameDescription->platform == Common::kPlatformAmiga; }
 	bool hasFeature(EngineFeature f) const override;
-	bool canLoadGameStateCurrently() override { return canPlayerInteract() && _curRoom != kRoomIntro; }
-	bool canSaveGameStateCurrently() override { return canPlayerInteract() && _curRoom != kRoomIntro; }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return canPlayerInteract() && _curRoom != kRoomIntro; }
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override { return canPlayerInteract() && _curRoom != kRoomIntro; }
 	Common::Error loadGameStream(Common::SeekableReadStream *stream) override;
 	Common::Error saveGameStream(Common::WriteStream *stream, bool isAutosave = false) override;
 	bool syncGameStream(Common::Serializer &ser);

--- a/engines/tsage/tsage.cpp
+++ b/engines/tsage/tsage.cpp
@@ -143,14 +143,14 @@ Common::Error TSageEngine::run() {
 /**
  * Returns true if it is currently okay to restore a game
  */
-bool TSageEngine::canLoadGameStateCurrently() {
+bool TSageEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return (g_globals != NULL) && (g_globals->_game != NULL) && g_globals->_game->canLoadGameStateCurrently();
 }
 
 /**
  * Returns true if it is currently okay to save the game
  */
-bool TSageEngine::canSaveGameStateCurrently() {
+bool TSageEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return (g_globals != NULL) && (g_globals->_game != NULL) && g_globals->_game->canSaveGameStateCurrently();
 }
 

--- a/engines/tsage/tsage.h
+++ b/engines/tsage/tsage.h
@@ -61,8 +61,8 @@ public:
 
 	virtual Common::Error init();
 	Common::Error run() override;
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	void syncSoundSettings() override;

--- a/engines/tucker/saveload.cpp
+++ b/engines/tucker/saveload.cpp
@@ -283,11 +283,11 @@ bool TuckerEngine::canLoadOrSave() const {
 	return !_player && _cursorState != kCursorStateDisabledHidden;
 }
 
-bool TuckerEngine::canLoadGameStateCurrently() {
+bool TuckerEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return canLoadOrSave();
 }
 
-bool TuckerEngine::canSaveGameStateCurrently() {
+bool TuckerEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return canLoadOrSave();
 }
 

--- a/engines/tucker/tucker.h
+++ b/engines/tucker/tucker.h
@@ -745,8 +745,8 @@ protected:
 	}
 
 	bool canLoadOrSave() const;
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	virtual bool existsSavegame();
 
 	void handleIntroSequence();

--- a/engines/twine/twine.cpp
+++ b/engines/twine/twine.cpp
@@ -394,7 +394,7 @@ void TwinEEngine::wipeSaveSlot(int slot) {
 	saveFileMan->removeSavefile(saveFile);
 }
 
-bool TwinEEngine::canSaveGameStateCurrently() { return _scene->isGameRunning(); }
+bool TwinEEngine::canSaveGameStateCurrently(Common::U32String *msg) { return _scene->isGameRunning(); }
 
 Common::Error TwinEEngine::loadGameStream(Common::SeekableReadStream *stream) {
 	debug("load game stream");

--- a/engines/twine/twine.h
+++ b/engines/twine/twine.h
@@ -238,8 +238,8 @@ public:
 	Common::Error run() override;
 	bool hasFeature(EngineFeature f) const override;
 
-	bool canLoadGameStateCurrently() override { return true; }
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return true; }
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	Common::Error loadGameStream(Common::SeekableReadStream *stream) override;
 	Common::Error saveGameStream(Common::WriteStream *stream, bool isAutosave = false) override;

--- a/engines/ultima/shared/engine/ultima.h
+++ b/engines/ultima/shared/engine/ultima.h
@@ -117,7 +117,7 @@ public:
 	/**
 	 * Indicates whether a game state can be loaded.
 	 */
-	bool canLoadGameStateCurrently() override {
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return canLoadGameStateCurrently(false);
 	}
 
@@ -130,7 +130,7 @@ public:
 	/**
 	 * Indicates whether a game state can be saved.
 	 */
-	bool canSaveGameStateCurrently() override {
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override {
 		return canSaveGameStateCurrently(false);
 	}
 };

--- a/engines/ultima/ultima8/ultima8.cpp
+++ b/engines/ultima/ultima8/ultima8.cpp
@@ -911,7 +911,7 @@ void Ultima8Engine::writeSaveInfo(Common::WriteStream *ws) {
 	_game->writeSaveInfo(ws);
 }
 
-bool Ultima8Engine::canSaveGameStateCurrently() {
+bool Ultima8Engine::canSaveGameStateCurrently(Common::U32String *msg) {
 	// Can't save when avatar in stasis during cutscenes
 	if (_avatarInStasis || _cruStasis)
 		return false;

--- a/engines/ultima/ultima8/ultima8.h
+++ b/engines/ultima/ultima8/ultima8.h
@@ -315,12 +315,12 @@ public:
 	/**
 	 * Returns true if a savegame can be loaded
 	 */
-	bool canLoadGameStateCurrently() override { return true; }
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override { return true; }
 
 	/**
 	 * Returns true if the game can be saved
 	 */
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	/**
 	 * Load a game

--- a/engines/vcruise/vcruise.cpp
+++ b/engines/vcruise/vcruise.cpp
@@ -334,11 +334,11 @@ bool VCruiseEngine::canSaveAutosaveCurrently() {
 	return _runtime->canSave(false);
 }
 
-bool VCruiseEngine::canSaveGameStateCurrently() {
+bool VCruiseEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return _runtime->canSave(false);
 }
 
-bool VCruiseEngine::canLoadGameStateCurrently() {
+bool VCruiseEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return _runtime->canLoad();
 }
 

--- a/engines/vcruise/vcruise.h
+++ b/engines/vcruise/vcruise.h
@@ -57,8 +57,8 @@ public:
 	Common::Error loadGameStream(Common::SeekableReadStream *stream) override;
 
 	bool canSaveAutosaveCurrently() override;
-	bool canSaveGameStateCurrently() override;
-	bool canLoadGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	void initializePath(const Common::FSNode &gamePath) override;
 

--- a/engines/voyeur/voyeur.cpp
+++ b/engines/voyeur/voyeur.cpp
@@ -755,14 +755,14 @@ void VoyeurEngine::showEndingNews() {
 /**
  * Returns true if it is currently okay to restore a game
  */
-bool VoyeurEngine::canLoadGameStateCurrently() {
+bool VoyeurEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return _voyeurArea == AREA_APARTMENT;
 }
 
 /**
  * Returns true if it is currently okay to save the game
  */
-bool VoyeurEngine::canSaveGameStateCurrently() {
+bool VoyeurEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return _voyeurArea == AREA_APARTMENT;
 }
 

--- a/engines/voyeur/voyeur.h
+++ b/engines/voyeur/voyeur.h
@@ -204,8 +204,8 @@ public:
 	bool getIsDemo() const;
 
 	int getRandomNumber(int maxNumber);
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	void loadGame(int slot);

--- a/engines/wage/metaengine.cpp
+++ b/engines/wage/metaengine.cpp
@@ -79,11 +79,11 @@ int WageMetaEngine::getMaximumSaveSlot() const { return 999; }
 
 namespace Wage {
 
-bool WageEngine::canLoadGameStateCurrently() {
+bool WageEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return true;
 }
 
-bool WageEngine::canSaveGameStateCurrently() {
+bool WageEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return true;
 }
 

--- a/engines/wage/wage.h
+++ b/engines/wage/wage.h
@@ -133,8 +133,8 @@ public:
 
 	Common::Error run() override;
 
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 
 	const char *getGameFile() const;
 	void processTurn(Common::String *textInput, Designed *clickInput);

--- a/engines/wintermute/wintermute.cpp
+++ b/engines/wintermute/wintermute.cpp
@@ -341,11 +341,11 @@ Common::Error WintermuteEngine::saveGameState(int slot, const Common::String &de
 	return Common::kNoError;
 }
 
-bool WintermuteEngine::canSaveGameStateCurrently() {
+bool WintermuteEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return true;
 }
 
-bool WintermuteEngine::canLoadGameStateCurrently() {
+bool WintermuteEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return true;
 }
 

--- a/engines/wintermute/wintermute.h
+++ b/engines/wintermute/wintermute.h
@@ -60,9 +60,9 @@ public:
 	bool hasFeature(EngineFeature f) const override;
 	Common::SaveFileManager *getSaveFileMan() { return _saveFileMan; }
 	Common::Error loadGameState(int slot) override;
-	bool canLoadGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-	bool canSaveGameStateCurrently() override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	// For detection-purposes:
 	static bool getGameInfo(const Common::FSList &fslist, Common::String &name, Common::String &caption);
 private:

--- a/engines/zvision/metaengine.cpp
+++ b/engines/zvision/metaengine.cpp
@@ -163,11 +163,11 @@ Common::Error ZVision::ZVision::saveGameState(int slot, const Common::String &de
 	return Common::kNoError;
 }
 
-bool ZVision::ZVision::canLoadGameStateCurrently() {
+bool ZVision::ZVision::canLoadGameStateCurrently(Common::U32String *msg) {
 	return !_videoIsPlaying;
 }
 
-bool ZVision::ZVision::canSaveGameStateCurrently() {
+bool ZVision::ZVision::canSaveGameStateCurrently(Common::U32String *msg) {
 	Location currentLocation = _scriptManager->getCurrentLocation();
 	return !_videoIsPlaying && currentLocation.world != 'g' && !(currentLocation.room == 'j' || currentLocation.room == 'a');
 }

--- a/engines/zvision/zvision.h
+++ b/engines/zvision/zvision.h
@@ -255,8 +255,8 @@ public:
 
 	// Engine features
 	bool hasFeature(EngineFeature f) const override;
-	bool canLoadGameStateCurrently() override;
-	bool canSaveGameStateCurrently() override;
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
+	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error loadGameState(int slot) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 


### PR DESCRIPTION
As discussed on Discord, here is my patch for showing explanations to the users why save/load is not possible at the moment.

Instead of hiding the Sabe/Load buttons or disabling them, we now always show them, but display a pop-up message in case operation is not possible.

There could be 2 reasons in general and at least one more which is engine-specific:

* The engine does not allow save/load from GMM at all. We used to hide the button. Now we show a generic message `"This game does not support saving from the menu. Use in-game interface"`
* The engine does not allow save/load at the moment. We then show `"This game cannot be saved at this time. Please try again later"` by default

Both these messages sit in engines/dialogs.cpp

Then there are more complicated versions:
* The engine disables saves for some specific games, but an in-game interface is there to save. A notable example is Windows HE games. In this case, the engine returns message matching the first case above
* A certain version of a game, demos so far, do not support save/load at all. In this case, I show a simplified message `"This game does not support saving"`. It was identified in several engines

Please, provide your feedback/reviews, I'd like to have this pushed in the 2.8.0 release as well