### PR TITLE
SLUDGE: Fix drawModeDark colourmix values by swapping them

### DIFF
--- a/engines/sludge/people.cpp
+++ b/engines/sludge/people.cpp
@@ -333,6 +333,15 @@ enum drawModes {
 };
 
 void PeopleManager::setMyDrawMode(OnScreenPerson *moveMe, int h) {
+	int hasBadDrawMode = 0;
+
+	if (gameVersion > VERSION(1, 7)) {
+		hasBadDrawMode = 1;
+		warning("Versions above 1.7 have bad values set for drawModeDark");
+	}
+
+	const int colourMix[2][3] = { {64, 128, 192}, {192, 128, 64} };
+
 	switch (h) {
 	case drawModeTransparent3:
 		moveMe->r = moveMe->g = moveMe->b = 0;
@@ -356,17 +365,17 @@ void PeopleManager::setMyDrawMode(OnScreenPerson *moveMe, int h) {
 		break;
 	case drawModeDark1:
 		moveMe->r = moveMe->g = moveMe->b = 0;
-		moveMe->colourmix = 192;
+		moveMe->colourmix = colourMix[hasBadDrawMode][0];
 		moveMe->transparency = 0;
 		break;
 	case drawModeDark2:
 		moveMe->r = moveMe->g = moveMe->b = 0;
-		moveMe->colourmix = 128;
+		moveMe->colourmix = colourMix[hasBadDrawMode][1];
 		moveMe->transparency = 0;
 		break;
 	case drawModeDark3:
 		moveMe->r = moveMe->g = moveMe->b = 0;
-		moveMe->colourmix = 64;
+		moveMe->colourmix = colourMix[hasBadDrawMode][2];
 		moveMe->transparency = 0;
 		break;
 	case drawModeBlack:


### PR DESCRIPTION
In Out of Order, if you visit the alley that goes to the surgery you will notice a jarring transition between colours on Hurford.