### PR TITLE
COMMON: Add API for loading InstallShieldV3 from a stream

### DIFF
--- a/common/compression/installshieldv3_archive.cpp
+++ b/common/compression/installshieldv3_archive.cpp
@@ -56,8 +56,20 @@ bool InstallShieldV3::open(const Common::FSNode &node) {
 	return read();
 }
 
+bool InstallShieldV3::open(Common::SeekableReadStream *stream) {
+	close();
+
+	if (stream == nullptr)
+		return false;
+
+	_stream = stream;
+
+	return read();
+}
+
 void InstallShieldV3::close() {
-	delete _stream; _stream = nullptr;
+	delete _stream;
+	_stream = nullptr;
 	_map.clear();
 }
 

--- a/common/compression/installshieldv3_archive.h
+++ b/common/compression/installshieldv3_archive.h
@@ -39,6 +39,7 @@ public:
 
 	bool open(const Common::String &filename);
 	bool open(const Common::FSNode &node);
+	bool open(Common::SeekableReadStream *stream);
 	void close();
 	bool isOpen() const { return _stream != nullptr; }
 


### PR DESCRIPTION
Adds a function to open an InstallShieldV3 archive from a stream instead of just FSNode and filename.

To be used by mTropolis fallback loader.