### PR TITLE
DIRECTOR: fix memory leak in AppleCD

### DIFF
--- a/engines/director/lingo/xlibs/applecdxobj.cpp
+++ b/engines/director/lingo/xlibs/applecdxobj.cpp
@@ -153,6 +153,10 @@ AppleCDXObject::AppleCDXObject(ObjectType ObjectType) :Object<AppleCDXObject>("A
 	}
 }
 
+AppleCDXObject::~AppleCDXObject() {
+	delete _cue;
+}
+
 void AppleCDXObj::m_new(int nargs) {
 	g_lingo->push(g_lingo->_state->me);
 }

--- a/engines/director/lingo/xlibs/applecdxobj.h
+++ b/engines/director/lingo/xlibs/applecdxobj.h
@@ -31,6 +31,7 @@ namespace Director {
 class AppleCDXObject : public Object<AppleCDXObject> {
 public:
 	AppleCDXObject(ObjectType objType);
+	~AppleCDXObject() override;
 	int _inpoint;
 	int _outpoint;
 	// Instead of immediately returning values, methods which return


### PR DESCRIPTION
This was flagged by @sluicebox. I'll get it backported as well.