### PR TITLE
COMMON: Fix listMatchingMembers not working properly with non-default path separator

### DIFF
--- a/common/archive.cpp
+++ b/common/archive.cpp
@@ -94,7 +94,7 @@ int Archive::listMatchingMembers(ArchiveMemberList &list, const Path &pattern, b
 	ArchiveMemberList allNames;
 	listMembers(allNames);
 
-	String patternString = pattern.toString();
+	String patternString = pattern.toString(getPathSeparator());
 	int matches = 0;
 
 	char pathSepString[2] = {getPathSeparator(), '\0'};


### PR DESCRIPTION
This is causing problems when using listMatchingMembers with an archive type that uses the Mac path separator (e.g. StuffIt or Mac VISE).