### PR TITLE
ULTIMA: Use macros for Ultima 6 detection entries

### DIFF
--- a/engines/ultima/detection_tables.h
+++ b/engines/ultima/detection_tables.h
@@ -31,6 +31,20 @@ namespace Ultima {
 #define GUI_OPTIONS_MARTIAN_DREAMS GUIO0()
 #define GUI_OPTIONS_SAVAGE_EMPIRE  GUIO0()
 
+// Ultima 6 normal mode only
+#define ENTRY_ULTIMA6_NORMAL(FILENAME, MD5, FILESIZE, LANG, PLATFORM) {{"ultima6", 0, AD_ENTRY1s(FILENAME, MD5, FILESIZE), LANG, PLATFORM, ADGF_NO_FLAGS, GUI_OPTIONS_ULTIMA6}, GAME_ULTIMA6, 0}
+
+// Ultima 6 enhanced mode only
+#define ENTRY_ULTIMA6_ENHANCED(FILENAME, MD5, FILESIZE, LANG, PLATFORM) {{"ultima6_enh", 0, AD_ENTRY1s(FILENAME, MD5, FILESIZE), LANG, PLATFORM, ADGF_NO_FLAGS, GUI_OPTIONS_ULTIMA6}, GAME_ULTIMA6, GF_VGA_ENHANCED}
+
+// Ultima 6 both normal and enhanced mode (this should normally be used)
+#define ENTRY_ULTIMA6(FILENAME, MD5, FILESIZE, LANG, PLATFORM) \
+	ENTRY_ULTIMA6_NORMAL(FILENAME, MD5, FILESIZE, LANG, PLATFORM), \
+	ENTRY_ULTIMA6_ENHANCED(FILENAME, MD5, FILESIZE, LANG, PLATFORM)
+
+// Ultima 6 normal mode only - unstable (currently only used for the PC98 version)
+#define ENTRY_ULTIMA6_NORMAL_UNSTABLE(FILENAME, MD5, FILESIZE, LANG, PLATFORM) {{"ultima6", 0, AD_ENTRY1s(FILENAME, MD5, FILESIZE), LANG, PLATFORM, ADGF_UNSTABLE, GUI_OPTIONS_ULTIMA6}, GAME_ULTIMA6, 0}
+
 static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 #ifdef ENABLE_ULTIMA1
 	{
@@ -119,218 +133,50 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 
 #ifdef ENABLE_ULTIMA6
 	// GOG Ultima VI
-	{
-		{
-			"ultima6",
-			0,
-			AD_ENTRY1s("converse.a", "5065716423ef1389e3f7b4946d815c26", 162615),
-			Common::EN_ANY,
-			Common::kPlatformDOS,
-			ADGF_NO_FLAGS,
-			GUI_OPTIONS_ULTIMA6
-		},
-		GAME_ULTIMA6,
-		0
-	},
-
-	// GOG Ultima VI - Enhanced
-	{
-		{
-			"ultima6_enh",
-			0,
-			AD_ENTRY1s("converse.a", "5065716423ef1389e3f7b4946d815c26", 162615),
-			Common::EN_ANY,
-			Common::kPlatformDOS,
-			ADGF_NO_FLAGS,
-			GUI_OPTIONS_ULTIMA6
-		},
-		GAME_ULTIMA6,
-		GF_VGA_ENHANCED
-	},
+	ENTRY_ULTIMA6("converse.a", "5065716423ef1389e3f7b4946d815c26", 162615,
+				Common::EN_ANY,
+				Common::kPlatformDOS),
 
 	// Ultima VI - French patch by Docwise Dragon
 	// https://sirjohn.de/en/ultima6/ultima-vi-french-translation-patch/
 	// Note: Not all user interface elements are translated in ScummVM
-	{
-		{
-			"ultima6",
-			0,
-			AD_ENTRY1s("converse.a", "35c95d56737d957db7e72193e810053b", 182937),
-			Common::FR_FRA,
-			Common::kPlatformDOS,
-			ADGF_NO_FLAGS,
-			GUI_OPTIONS_ULTIMA6
-		},
-		GAME_ULTIMA6,
-		0
-	},
-
-	// Ultima VI - Enhanced - French patch by Docwise Dragon
-	// https://sirjohn.de/en/ultima6/ultima-vi-french-translation-patch/
-	// Note: Not all user interface elements are translated in ScummVM
-	{
-		{
-			"ultima6_enh",
-			0,
-			AD_ENTRY1s("converse.a", "35c95d56737d957db7e72193e810053b", 182937),
-			Common::FR_FRA,
-			Common::kPlatformDOS,
-			ADGF_NO_FLAGS,
-			GUI_OPTIONS_ULTIMA6
-		},
-		GAME_ULTIMA6,
-		GF_VGA_ENHANCED
-	},
+	ENTRY_ULTIMA6("converse.a", "35c95d56737d957db7e72193e810053b", 182937,
+				Common::FR_FRA,
+				Common::kPlatformDOS),
 
 	// Ultima VI - German Patch https://sirjohn.de/ultima-6/
 	// Note: Not all user interface elements are translated in ScummVM
-	{
-		{
-			"ultima6",
-			0,
-			AD_ENTRY1s("converse.a", "ae979230b97f8813bdf8f82698847435", 198627),
-			Common::DE_DEU,
-			Common::kPlatformDOS,
-			ADGF_NO_FLAGS,
-			GUI_OPTIONS_ULTIMA6
-		},
-		GAME_ULTIMA6,
-		0
-	},
-
-	// Ultima VI - German Patch https://sirjohn.de/ultima-6/
-	// Note: Not all user interface elements are translated in ScummVM
-	{
-		{
-			"ultima6_enh",
-			0,
-			AD_ENTRY1s("converse.a", "ae979230b97f8813bdf8f82698847435", 198627),
-			Common::DE_DEU,
-			Common::kPlatformDOS,
-			ADGF_NO_FLAGS,
-			GUI_OPTIONS_ULTIMA6
-		},
-		GAME_ULTIMA6,
-		GF_VGA_ENHANCED
-	},
+	ENTRY_ULTIMA6("converse.a", "ae979230b97f8813bdf8f82698847435", 198627,
+				Common::DE_DEU,
+				Common::kPlatformDOS),
 
 	// Ultima VI - German Patch 1.6 https://sirjohn.de/ultima-6/
 	// Note: Not all user interface elements are translated in ScummVM
-	{
-		{
-			"ultima6",
-			0,
-			AD_ENTRY1s("converse.a", "5242f0228bbc9c3a60c7aa6071499688", 198797),
-			Common::DE_DEU,
-			Common::kPlatformDOS,
-			ADGF_NO_FLAGS,
-			GUI_OPTIONS_ULTIMA6
-		},
-		GAME_ULTIMA6,
-		0
-	},
+	// FIXME: Why is there no "enhanced" entry for this? If this is intentional it should be documented.
+	ENTRY_ULTIMA6_NORMAL("converse.a", "5242f0228bbc9c3a60c7aa6071499688", 198797,
+				Common::DE_DEU,
+				Common::kPlatformDOS),
 
 	// PC98 Ultima 6
-	{
-		{
-			"ultima6",
-			0,
-			AD_ENTRY1s("converse.a", "99975e79e7cae3ee24a8e33982f60fe4", 190920),
-			Common::JA_JPN,
-			Common::kPlatformPC98,
-			ADGF_UNSTABLE,
-			GUI_OPTIONS_ULTIMA6
-		},
-		GAME_ULTIMA6,
-		0
-	},
+	ENTRY_ULTIMA6_NORMAL_UNSTABLE("converse.a", "99975e79e7cae3ee24a8e33982f60fe4", 190920,
+				Common::JA_JPN,
+				Common::kPlatformPC98),
 
 	// Ultima VI - Nitpickers Delight older version
-	{
-		{
-			"ultima6",
-			0,
-			AD_ENTRY1s("converse.a", "5c15ba2a75fb921b715a1a0bf0152bac", 165874),
-			Common::EN_ANY,
-			Common::kPlatformDOS,
-			ADGF_NO_FLAGS,
-			GUI_OPTIONS_ULTIMA6
-		},
-		GAME_ULTIMA6,
-		0
-	},
-	{
-		{
-			"ultima6_enh",
-			0,
-			AD_ENTRY1s("converse.a","5c15ba2a75fb921b715a1a0bf0152bac", 165874),
-			Common::EN_ANY,
-			Common::kPlatformDOS,
-			ADGF_NO_FLAGS,
-			GUI_OPTIONS_ULTIMA6
-		},
-		GAME_ULTIMA6,
-		GF_VGA_ENHANCED
-	},
+	ENTRY_ULTIMA6("converse.a", "5c15ba2a75fb921b715a1a0bf0152bac", 165874,
+				Common::EN_ANY,
+				Common::kPlatformDOS),
 
 	// Ultima VI - Nitpickers Delight newer version
-	{
-		{
-			"ultima6",
-			0,
-			AD_ENTRY1s("converse.a", "9f77c84a03efc77df2d53544d1275da8", 167604),
-			Common::EN_ANY,
-			Common::kPlatformDOS,
-			ADGF_NO_FLAGS,
-			GUI_OPTIONS_ULTIMA6
-		},
-		GAME_ULTIMA6,
-		0
-	},
-	{
-		{
-			"ultima6_enh",
-			0,
-			AD_ENTRY1s("converse.a", "9f77c84a03efc77df2d53544d1275da8", 167604),
-			Common::EN_ANY,
-			Common::kPlatformDOS,
-			ADGF_NO_FLAGS,
-			GUI_OPTIONS_ULTIMA6
-		},
-		GAME_ULTIMA6,
-		GF_VGA_ENHANCED
-	},
-	
+	ENTRY_ULTIMA6("converse.a", "9f77c84a03efc77df2d53544d1275da8", 167604,
+				Common::EN_ANY,
+				Common::kPlatformDOS),
+
 	// Ultima VI - alternative release
 	// TRAC #14659
-	{
-		{
-			"ultima6",
-			0,
-			AD_ENTRY1s("converse.a", "ee22a6ac3964f9ff11a48fcb3f4a9389", 162458),
-			Common::EN_ANY,
-			Common::kPlatformDOS,
-			ADGF_NO_FLAGS,
-			GUI_OPTIONS_ULTIMA6
-		},
-		GAME_ULTIMA6,
-		0
-	},
-	// Ultima VI - alternative release - Enhanced
-	// TRAC #14659
-	{
-		{
-			"ultima6_enh",
-			0,
-			AD_ENTRY1s("converse.a", "ee22a6ac3964f9ff11a48fcb3f4a9389", 162458),
-			Common::EN_ANY,
-			Common::kPlatformDOS,
-			ADGF_NO_FLAGS,
-			GUI_OPTIONS_ULTIMA6
-		},
-		GAME_ULTIMA6,
-		GF_VGA_ENHANCED
-	},
+	ENTRY_ULTIMA6("converse.a", "ee22a6ac3964f9ff11a48fcb3f4a9389", 162458,
+				Common::EN_ANY,
+				Common::kPlatformDOS),
 #endif
 
 #ifdef ENABLE_ULTIMA8

--- a/engines/ultima/detection_tables.h
+++ b/engines/ultima/detection_tables.h
@@ -316,6 +316,21 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		GAME_ULTIMA6,
 		0
 	},
+	// Ultima VI - alternative release - Enhanced
+	// TRAC #14659
+	{
+		{
+			"ultima6_enh",
+			0,
+			AD_ENTRY1s("converse.a", "ee22a6ac3964f9ff11a48fcb3f4a9389", 162458),
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_NO_FLAGS,
+			GUI_OPTIONS_ULTIMA6
+		},
+		GAME_ULTIMA6,
+		GF_VGA_ENHANCED
+	},
 #endif
 
 #ifdef ENABLE_ULTIMA8

--- a/engines/ultima/detection_tables.h
+++ b/engines/ultima/detection_tables.h
@@ -152,8 +152,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 
 	// Ultima VI - German Patch 1.6 https://sirjohn.de/ultima-6/
 	// Note: Not all user interface elements are translated in ScummVM
-	// FIXME: Why is there no "enhanced" entry for this? If this is intentional it should be documented.
-	ENTRY_ULTIMA6_NORMAL("converse.a", "5242f0228bbc9c3a60c7aa6071499688", 198797,
+	ENTRY_ULTIMA6("converse.a", "5242f0228bbc9c3a60c7aa6071499688", 198797,
 				Common::DE_DEU,
 				Common::kPlatformDOS),
 


### PR DESCRIPTION
- Add/fix detection entry for alt version ([#14659](https://bugs.scummvm.org/ticket/14659))
This was already added as "non-enhanced" in commit dcb4d9e91b8087056ed20a15a4b33ee2d94d97e5, but the entry for "enhanced" mode is missing.
- Add/fix detection entry for SirJohn's German fan translation v1.6
Like above: Adds missing "enhanced" entry. Normal mode was already present.
- Convert Ultima 6 detection table entries to macros to avoid repetition and make adding new versions less error-prone