### PR TITLE
SWORD2: Fix support for Korean translation

### DIFF
--- a/engines/sword2/detection_tables.h
+++ b/engines/sword2/detection_tables.h
@@ -81,6 +81,21 @@ static const ADGameDescription gameDescriptions[] = {
 		GUIO0()
 	},
 
+	{ // Korean fan translation
+		"sword2",
+		"",
+		AD_ENTRY6s("general.clu", "31db8564f9187538f24d9fda0677f666", 7059728,
+				   "text.clu",    "9b344d976ca8d19a1cf5aa4413397f6b", 304968,
+				   "speech1.clu", "a403904a0e825356107d228f8f74092e", 176260048,
+				   "docks.clu",   "b39246fbb5b955a29f9a207c69bfc318", 20262263,
+				   "bs2k.fnt",    NULL,                               1222000,
+				   "korean.clu",  NULL,                               -1),
+		Common::KO_KOR,
+		Common::kPlatformWindows,
+		ADGF_NO_FLAGS,
+		GUIO0()
+	},
+
 	{ // GOG.com release version 2.0.0.6
 		"sword2",
 		"GOG",

--- a/engines/sword2/maketext.cpp
+++ b/engines/sword2/maketext.cpp
@@ -69,6 +69,9 @@ namespace Sword2 {
 #define DUD		64	// the first "chequered flag" (dud) symbol in
 				// our character set is in the '@' position
 
+#define KOREAN_CHAR_WIDTH	20
+#define KOREAN_CHAR_HEIGHT	26
+
 namespace {
 Common::String readLine(Common::ReadStream &stream) {
 	Common::String ret = stream.readString('\n');
@@ -203,6 +206,9 @@ uint16 FontRenderer::analyzeSentence(const byte *sentence, uint16 maxWidth, uint
 			int w = 0, l = 0;
 			if (isChinese && (ch & 0x80)) {
 				w = kChineseWidth + _charSpacing;
+				l = 2;
+			} else if (isKoreanChar(ch, sentence[pos+1], fontRes)) {
+				w += wcharWidth(ch, sentence[pos+1], fontRes) + _charSpacing;
 				l = 2;
 			} else {
 				w = charWidth(ch, fontRes) + _charSpacing;
@@ -434,12 +440,21 @@ byte *FontRenderer::buildTextSprite(const byte *sentence, uint32 fontRes, uint8 
 
 				continue;
 			}
-			byte *charPtr = findChar(ch, charSet);
+			byte *charPtr = NULL;
+			if (isKoreanChar(ch, *currTxtLine, fontRes)) {
+				charPtr = findWChar(ch, *currTxtLine++, charSet);
+				j++;
+				frame_head.width = KOREAN_CHAR_WIDTH;
 
-			frame_head.read(charPtr);
+				copyWChar(charPtr, spritePtr, spriteWidth, pen);
+			} else {
+				charPtr = findChar(ch, charSet);
 
-			assert(frame_head.height == char_height);
-			copyChar(charPtr, spritePtr, spriteWidth, pen);
+				frame_head.read(charPtr);
+
+				assert(frame_head.height == char_height);
+				copyChar(charPtr, spritePtr, spriteWidth, pen);
+			}
 
 			// We must remember to free memory for generated character in psx,
 			// as it is extracted differently than pc version (copyed from a
@@ -488,6 +503,20 @@ uint16 FontRenderer::charWidth(byte ch, uint32 fontRes) {
 	_vm->_resman->closeResource(fontRes);
 
 	return frame_head.width;
+}
+
+/**
+ * @param  hi      the KSX1001 code upper byte of the character
+ * @param  lo      the KSX1001 code lower byte of the character
+ * @param  fontRes the font resource id
+ * @return the width of the character
+ */
+
+uint16 FontRenderer::wcharWidth(byte hi, byte lo, uint32 fontRes) {
+	if (isKoreanChar(hi, lo, fontRes)) {
+		return KOREAN_CHAR_WIDTH;
+	}
+	return charWidth(hi, fontRes) + charWidth(lo, fontRes);
 }
 
 /**
@@ -599,6 +628,17 @@ byte *FontRenderer::findChar(byte ch, byte *charSet) {
 	}
 }
 
+byte *FontRenderer::findWChar(byte hi, byte lo, byte *charSet) {
+	uint16 frameWidth = KOREAN_CHAR_WIDTH;
+	uint16 frameHeight = KOREAN_CHAR_HEIGHT;
+	FrameHeader frame_head;
+	byte *charPtr = findChar(0xFF, charSet);
+
+	frame_head.read(charPtr);
+
+	return charPtr + frame_head.size() + frame_head.width * frame_head.height + ((hi - 0xB0) * 94 + (lo - 0xA1)) * frameWidth * frameHeight;
+}
+
 /**
  * Copies a character sprite to the sprite buffer.
  * @param charPtr     pointer to the character sprite
@@ -615,6 +655,11 @@ void FontRenderer::copyChar(const byte *charPtr, byte *spritePtr, uint16 spriteW
 	frame.read(charPtr);
 
 	copyCharRaw(charPtr + FrameHeader::size(), frame.width, frame.height, spritePtr, spriteWidth, pen);
+}
+
+void FontRenderer::copyWChar(const byte *charPtr, byte *spritePtr, uint16 spriteWidth, uint8 pen) {
+
+	copyCharRaw(charPtr, KOREAN_CHAR_WIDTH, KOREAN_CHAR_HEIGHT, spritePtr, spriteWidth, pen);
 }
 
 void FontRenderer::copyCharRaw(const byte *source, uint16 charWidth, uint16 charHeight, byte *spritePtr, uint16 spriteWidth, uint8 pen) {
@@ -656,6 +701,14 @@ void FontRenderer::copyCharRaw(const byte *source, uint16 charWidth, uint16 char
 		}
 		rowPtr += spriteWidth;
 	}
+}
+
+bool FontRenderer::isKoreanChar(byte hi, byte lo, uint32 fontRes) {
+	if (!_vm->_isKorTrs || fontRes != ENGLISH_SPEECH_FONT_ID)
+		return false;
+	if (hi >= 0xB0 && hi <= 0xC8 && lo >= 0xA1 && lo <= 0xFE)
+		return true;
+	return false;
 }
 
 // Distance to keep speech text from edges of screen

--- a/engines/sword2/maketext.h
+++ b/engines/sword2/maketext.h
@@ -103,10 +103,14 @@ private:
 	uint16 analyzeSentence(const byte *sentence, uint16 maxWidth, uint32 fontRes, LineInfo *line, bool isChinese);
 	byte *buildTextSprite(const byte *sentence, uint32 fontRes, uint8 pen, LineInfo *line, uint16 noOfLines, bool isChinese);
 	uint16 charWidth(byte ch, uint32 fontRes);
+	uint16 wcharWidth(byte hi, byte lo, uint32 fontRes);
 	uint16 charHeight(uint32 fontRes);
 	byte *findChar(byte ch, byte *charSet);
+	byte *findWChar(byte hi, byte lo, byte *charSet);
 	void copyChar(const byte *charPtr, byte *spritePtr, uint16 spriteWidth, uint8 pen);
+	void copyWChar(const byte *charPtr, byte *spritePtr, uint16 spriteWidth, uint8 pen);
 	void copyCharRaw(const byte *source, uint16 charWidth, uint16 charHeight, byte *spritePtr, uint16 spriteWidth, uint8 pen);
+	bool isKoreanChar(const byte hi, const byte lo, const uint32 fontRes);
 
 public:
 	FontRenderer(Sword2Engine *vm) : _vm(vm) {

--- a/engines/sword2/resman.cpp
+++ b/engines/sword2/resman.cpp
@@ -232,7 +232,7 @@ bool ResourceManager::init() {
 
 			// Use korean.clu instead of TEXT.CLU
 			if (_vm->_isKorTrs && !scumm_stricmp(_resFiles[i].fileName, "TEXT.CLU"))
-				strcpy_s(_resFiles[i].fileName, 20, "korean.clu");
+				Common::strcpy_s(_resFiles[i].fileName, 20, "korean.clu");
 			_resFiles[i].cd = cdInf[j].cd;
 		}
 	}

--- a/engines/sword2/sword2.cpp
+++ b/engines/sword2/sword2.cpp
@@ -84,6 +84,8 @@ Sword2Engine::Sword2Engine(OSystem *syst, const ADGameDescription *gameDesc) : E
 	_gameSpeed = 1;
 
 	_gmmLoadSlot = -1; // Used to manage GMM Loading
+
+	_isKorTrs = gameDesc->language == Common::KO_KOR;
 }
 
 Sword2Engine::~Sword2Engine() {

--- a/engines/sword2/sword2.h
+++ b/engines/sword2/sword2.h
@@ -198,6 +198,8 @@ public:
 
 	int32 _gameCycle;
 
+	bool _isKorTrs;
+
 #if RIGHT_CLICK_CLEARS_LUGGAGE
 	bool heldIsInInventory();
 #endif


### PR DESCRIPTION
### Broken Sword II: The Smoking Mirror (Windows/Korean)

This supports Korean fan translations.

Korean FAN translation data is available at the link below.

[https://github.com/british-choi/ScummVM-Kor-Trs](https://github.com/british-choi/ScummVM-Kor-Trs)

![image](https://github.com/scummvm/scummvm/assets/64050109/839dab0d-2000-4116-b98d-ccd500db43d9)
