### PR TITLE
GRIM: Fix support for Korean translation for Grim Fandango

### DIFF
--- a/engines/grim/detection.cpp
+++ b/engines/grim/detection.cpp
@@ -229,6 +229,20 @@ static const GrimGameDescription gameDescriptions[] = {
 		},
 		GType_GRIM
 	},
+	{
+		// Grim Fandango Korean Fan translation (patched)
+		{
+			"grim",
+			"",
+			AD_ENTRY2s("VOX0001.LAB", "444f05f2af689c1bffd179b8b6a632bd", 57993159,
+					   "grim.ko.tab", NULL, -1),
+			Common::KO_KOR,
+			Common::kPlatformWindows,
+			ADGF_NO_FLAGS,
+			GUI_OPTIONS_GRIME
+		},
+		GType_GRIM
+	},
 /*	{
 		// Grim Fandango German version (patched)
 		{

--- a/engines/grim/font.h
+++ b/engines/grim/font.h
@@ -51,7 +51,7 @@ public:
 	const Common::String &getFilename() const { return _filename; }
 
 	// for Korean Translate
-	int32 getWCharKernedWidth(unsigned char hi, unsigned char lo) const { return getCharKernedWidth(hi) + getCharKernedWidth(lo); }
+	int32 getWCharKernedWidth(byte hi, byte char lo) const { return getCharKernedWidth(hi) + getCharKernedWidth(lo); }
 	bool isKoreanChar(const byte hi, const byte lo) const { return (hi >= 0xB0 && hi <= 0xC8 && lo >= 0xA1 && lo <= 0xFE); }
 
 	static Font *getByFileName(const Common::String& fileName);
@@ -149,7 +149,7 @@ public:
 	void restoreState(SaveGame *state);
 
 	// for Korean Translate
-	int32 getWCharKernedWidth(unsigned char hi, unsigned char lo) const { return _font->getCharWidth(Common::convertUHCToUCS(hi, lo)); }
+	int32 getWCharKernedWidth(byte hi, byte lo) const { return _font->getCharWidth(Common::convertUHCToUCS(hi, lo)); }
 
 private:
 	Graphics::Font *_font;

--- a/engines/grim/font.h
+++ b/engines/grim/font.h
@@ -51,7 +51,7 @@ public:
 	const Common::String &getFilename() const { return _filename; }
 
 	// for Korean Translate
-	int32 getWCharKernedWidth(byte hi, byte char lo) const { return getCharKernedWidth(hi) + getCharKernedWidth(lo); }
+	int32 getWCharKernedWidth(byte hi, byte lo) const { return getCharKernedWidth(hi) + getCharKernedWidth(lo); }
 	bool isKoreanChar(const byte hi, const byte lo) const { return (hi >= 0xB0 && hi <= 0xC8 && lo >= 0xA1 && lo <= 0xFE); }
 
 	static Font *getByFileName(const Common::String& fileName);

--- a/engines/grim/font.h
+++ b/engines/grim/font.h
@@ -50,6 +50,10 @@ public:
 	virtual bool is8Bit() const = 0;
 	const Common::String &getFilename() const { return _filename; }
 
+	// for Korean Translate
+	int32 getWCharKernedWidth(unsigned char hi, unsigned char lo) const { return getCharKernedWidth(hi) + getCharKernedWidth(lo); }
+	bool isKoreanChar(const byte hi, const byte lo) const { return (hi >= 0xB0 && hi <= 0xC8 && lo >= 0xA1 && lo <= 0xFE); }
+
 	static Font *getByFileName(const Common::String& fileName);
 	static Font *getFirstFont();
 	static void save(const Font *font, SaveGame *state);
@@ -137,12 +141,15 @@ public:
 	int32 getCharKernedWidth(uint32 c) const override { return _font->getCharWidth(c); }
 	int32 getFontWidth() const override { return getCharKernedWidth('w'); }
 
-	int getKernedStringLength(const Common::String &text) const override { return _font->getStringWidth(text); }
+	int getKernedStringLength(const Common::String &text) const override;
 	void render(Graphics::Surface &buf, const Common::String &currentLine, const Graphics::PixelFormat &pixelFormat, uint32 blackColor, uint32 color, uint32 colorKey) const override;
 	bool is8Bit() const override { return false; }
 
 	void saveState(SaveGame *state) const;
 	void restoreState(SaveGame *state);
+
+	// for Korean Translate
+	int32 getWCharKernedWidth(unsigned char hi, unsigned char lo) const { return _font->getCharWidth(Common::convertUHCToUCS(hi, lo)); }
 
 private:
 	Graphics::Font *_font;

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -274,6 +274,12 @@ GfxBase *GrimEngine::createRenderer(int screenW, int screenH) {
 #endif
 			0;
 
+	// For Grim Fandango, Korean fan translation can only use OpenGL renderer
+	if (getGameType() == GType_GRIM && g_grim->getGameLanguage() == Common::KO_KOR) {
+		availableRendererTypes &= ~Graphics::kRendererTypeOpenGLShaders;
+		availableRendererTypes &= ~Graphics::kRendererTypeTinyGL;
+	}
+
 	// For Grim Fandango, OpenGL renderer without shaders is preferred if available
 	if (desiredRendererType == Graphics::kRendererTypeDefault &&
 		(availableRendererTypes & Graphics::kRendererTypeOpenGL) &&

--- a/engines/grim/localize.cpp
+++ b/engines/grim/localize.cpp
@@ -40,6 +40,7 @@ Localizer::Localizer() {
 	bool isFrench = g_grim->getGameLanguage() == Common::FR_FRA;
 	bool isItalian = g_grim->getGameLanguage() == Common::IT_ITA;
 	bool isSpanish = g_grim->getGameLanguage() == Common::ES_ESP;
+	bool isKorean = g_grim->getGameLanguage() == Common::KO_KOR;	// Korean Fan Translation
 	bool isTranslatedGrimDemo = (isGerman || isFrench || isItalian || isSpanish) && isGrimDemo;
 	bool isPS2 = g_grim->getGamePlatform() == Common::kPlatformPS2;
 
@@ -54,6 +55,8 @@ Localizer::Localizer() {
 			filename = Common::String("grim.") + g_grim->getLanguagePrefix() + Common::String(".tab"); // TODO: Detect based on language.
 		} else if (isTranslatedGrimDemo) {
 			filename = "language.tab";
+		} else if (isKorean) {
+			filename = "grim.ko.tab";
 		} else {
 			filename = "grim.tab";
 		}

--- a/engines/grim/md5check.cpp
+++ b/engines/grim/md5check.cpp
@@ -483,7 +483,10 @@ void MD5Check::init() {
 			MD5SUM("data001.lab", data001)
 			MD5SUM("data000.lab", data000)
 			MD5SUM("credits.lab", credits)
-			if (g_grim->getGameLanguage() != Common::EN_ANY && g_grim->getGameLanguage() != Common::ZH_CHN && g_grim->getGameLanguage() != Common::RU_RUS) {
+			if (g_grim->getGameLanguage() != Common::EN_ANY 
+				&& g_grim->getGameLanguage() != Common::ZH_CHN 
+				&& g_grim->getGameLanguage() != Common::RU_RUS
+				&& g_grim->getGameLanguage() != Common::KO_KOR) {
 				MD5SUM("local.lab", local)
 			}
 			if (g_grim->getGameLanguage() == Common::ZH_CHN) {

--- a/engines/grim/resource.cpp
+++ b/engines/grim/resource.cpp
@@ -392,6 +392,29 @@ Font *ResourceLoader::loadFont(const Common::String &filename) {
 			result->loadTTF(font, stream, s);
 			return result;
 		}
+	} else if (g_grim->getGameType() == GType_GRIM && g_grim->getGameLanguage() == Common::KO_KOR) {
+		Common::String name = filename + ".txt";
+		stream = openNewStreamFile(name, true);
+		if (stream) {
+			Common::String line = stream->readLine();
+			Common::String font;
+			Common::String size;
+			for (uint i = 0; i < line.size(); ++i) {
+				if (line[i] == ' ') {
+					font = Common::String(line.c_str(), i);
+					size = Common::String(line.c_str() + i + 1, line.size() - i - 2);
+				}
+			}
+
+			int s = atoi(size.c_str());
+			delete stream;
+			stream = openNewStreamFile(font.c_str(), true);
+			FontTTF *result = new FontTTF();
+			result->loadTTF(filename, stream, s);
+			delete stream;
+
+			return result;
+		}
 	}
 
 	stream = openNewStreamFile(filename.c_str(), true);

--- a/engines/grim/textobject.cpp
+++ b/engines/grim/textobject.cpp
@@ -218,11 +218,11 @@ void TextObject::setupTextReal(S msg, Common::String (*convert)(const S &s)) {
 	for (uint i = 0; i < msg.size(); i++) {
 		message += msg[i];
 		currLine += msg[i];
-		if (i < msg.size()-1 && g_grim->getGameType() == GType_GRIM && g_grim->getGameLanguage() == Common::KO_KOR && _font->isKoreanChar(msg[i], msg[i+1])) {
+		if (i < msg.size() - 1 && g_grim->getGameType() == GType_GRIM && g_grim->getGameLanguage() == Common::KO_KOR && _font->isKoreanChar(msg[i], msg[i + 1])) {
 			isMultiByte = true;
-			message += msg[i+1];
-			currLine += msg[i+1];
-			lineWidth += _font->getWCharKernedWidth(msg[i], msg[i+1]);
+			message += msg[i + 1];
+			currLine += msg[i + 1];
+			lineWidth += _font->getWCharKernedWidth(msg[i], msg[i + 1]);
 			i++;
 		} else {
 			isMultiByte = false;
@@ -232,12 +232,12 @@ void TextObject::setupTextReal(S msg, Common::String (*convert)(const S &s)) {
 		if (currLine.size() > 1 && lineWidth > maxWidth) {
 			if (isMultiByte) {
 				// Remove 2byte code
-				lineWidth -= _font->getWCharKernedWidth(msg[i-1], msg[i]);
+				lineWidth -= _font->getWCharKernedWidth(msg[i - 1], msg[i]);
 				message.deleteLastChar();
 				message.deleteLastChar();
 				currLine.deleteLastChar();
 				currLine.deleteLastChar();
-				i-=2;
+				i -= 2;
 			} else {
 				if (currLine.contains(' ')) {
 					while (currLine.lastChar() != ' ' && currLine.size() > 1) {

--- a/engines/grim/textobject.cpp
+++ b/engines/grim/textobject.cpp
@@ -214,30 +214,50 @@ void TextObject::setupTextReal(S msg, Common::String (*convert)(const S &s)) {
 	S currLine;
 	_numberLines = 1;
 	int lineWidth = 0;
+	bool isMultiByte = false;
 	for (uint i = 0; i < msg.size(); i++) {
 		message += msg[i];
 		currLine += msg[i];
-		lineWidth += _font->getCharKernedWidth(msg[i]);
+		if (i < msg.size()-1 && g_grim->getGameType() == GType_GRIM && g_grim->getGameLanguage() == Common::KO_KOR && _font->isKoreanChar(msg[i], msg[i+1])) {
+			isMultiByte = true;
+			message += msg[i+1];
+			currLine += msg[i+1];
+			lineWidth += _font->getWCharKernedWidth(msg[i], msg[i+1]);
+			i++;
+		} else {
+			isMultiByte = false;
+			lineWidth += _font->getCharKernedWidth(msg[i]);
+		}
 
 		if (currLine.size() > 1 && lineWidth > maxWidth) {
-			if (currLine.contains(' ')) {
-				while (currLine.lastChar() != ' ' && currLine.size() > 1) {
-					lineWidth -= _font->getCharKernedWidth(currLine.lastChar());
-					message.deleteLastChar();
-					currLine.deleteLastChar();
-					--i;
+			if (isMultiByte) {
+				// Remove 2byte code
+				lineWidth -= _font->getWCharKernedWidth(msg[i-1], msg[i]);
+				message.deleteLastChar();
+				message.deleteLastChar();
+				currLine.deleteLastChar();
+				currLine.deleteLastChar();
+				i-=2;
+			} else {
+				if (currLine.contains(' ')) {
+					while (currLine.lastChar() != ' ' && currLine.size() > 1) {
+						lineWidth -= _font->getCharKernedWidth(currLine.lastChar());
+						message.deleteLastChar();
+						currLine.deleteLastChar();
+						--i;
+					}
+				} else { // if it is a unique word
+					bool useDash = !(g_grim->getGameLanguage() == Common::Language::ZH_CHN || g_grim->getGameLanguage() == Common::Language::ZH_TWN);
+					int dashWidth = useDash ? _font->getCharKernedWidth('-') : 0;
+					while (lineWidth + dashWidth > maxWidth && currLine.size() > 1) {
+						lineWidth -= _font->getCharKernedWidth(currLine.lastChar());
+						message.deleteLastChar();
+						currLine.deleteLastChar();
+						--i;
+					}
+					if (useDash)
+						message += '-';
 				}
-			} else { // if it is a unique word
-				bool useDash = !(g_grim->getGameLanguage() == Common::Language::ZH_CHN || g_grim->getGameLanguage() == Common::Language::ZH_TWN);
-				int dashWidth = useDash ? _font->getCharKernedWidth('-') : 0;
-				while (lineWidth + dashWidth > maxWidth && currLine.size() > 1) {
-					lineWidth -= _font->getCharKernedWidth(currLine.lastChar());
-					message.deleteLastChar();
-					currLine.deleteLastChar();
-					--i;
-				}
-				if (useDash)
-					message += '-';
 			}
 			message += '\n';
 			currLine.clear();


### PR DESCRIPTION
Grim Fandango (Windows/Korean)

This supports Korean fan translations. (Korean fan translations are only available for openGL renderer.)

Korean FAN translation data is available at the link below.

[https://github.com/british-choi/ScummVM-Kor-Trs](https://github.com/british-choi/ScummVM-Kor-Trs)

![image](https://github.com/scummvm/scummvm/assets/64050109/ae11cdda-3e0e-4a83-bf36-132794c726a7)
