### PR TITLE
GRAPHICS: Fixed crash while trying fonts-cjk.dat

### DIFF
--- a/graphics/fonts/ttf.cpp
+++ b/graphics/fonts/ttf.cpp
@@ -912,6 +912,7 @@ Font *loadTTFFontFromArchive(const Common::String &filename, int size, TTFSizeMo
 		delete archive;
 
 		// Trying fonts-cjk.dat
+		archiveStream = nullptr;
 		if (ConfMan.hasKey("extrapath")) {
 			Common::FSDirectory extrapath(ConfMan.get("extrapath"));
 			archiveStream = extrapath.createReadStreamForMember("fonts-cjk.dat");


### PR DESCRIPTION
Attempting to access fonts-cjk.dat on win32 results in a crash.

The `archiveStream` variable must be initialized before attempting to access fonts-cjk.dat.

This is a debug log run on Win32 MSYS2.

```
$ ./scummvm.exe -d9
Debuglevel (from command line): 9
Using SDL Video Driver "windows"
OpenGL: GL context initialized
OpenGL version: 4.0.0 - Build 10.18.10.4358
OpenGL vendor: Intel
OpenGL renderer: Intel(R) HD Graphics 2500
OpenGL: version 4.0
OpenGL: GLSL version string: 4.00 - Build 10.18.10.4358
OpenGL: GLSL version: 400
OpenGL: Max texture size: 16384
OpenGL: NPOT texture support: 1
OpenGL: Shader support: 1
OpenGL: Shader support for engines: 1
OpenGL: Multitexture support: 1
OpenGL: FBO support: 1
OpenGL: Multisample FBO support: 1
OpenGL: Multisample max number: 8
OpenGL: Packed pixels support: 1
OpenGL: Packed depth stencil support: 1
OpenGL: Unpack subimage support: 1
OpenGL: OpenGL ES depth 24 support: 0
OpenGL: Texture edge clamping support: 1
OpenGL: Texture border clamping support: 1
OpenGL: Texture mirror repeat support: 1
OpenGL: Texture max level support: 1
Invalid joystick: 0
Using SDL Audio Driver "wasapi"
SDL mixer sound format: 33056 differs from desired: 32784
Output sample rate: 44100 Hz
Output buffer size: 1024 samples
Output channels: 2
OpenGL: GL context initialized
OpenGL version: 4.0.0 - Build 10.18.10.4358
OpenGL vendor: Intel
OpenGL renderer: Intel(R) HD Graphics 2500
OpenGL: version 4.0
OpenGL: GLSL version string: 4.00 - Build 10.18.10.4358
OpenGL: GLSL version: 400
OpenGL: Max texture size: 16384
OpenGL: NPOT texture support: 1
OpenGL: Shader support: 1
OpenGL: Shader support for engines: 1
OpenGL: Multitexture support: 1
OpenGL: FBO support: 1
OpenGL: Multisample FBO support: 1
OpenGL: Multisample max number: 8
OpenGL: Packed pixels support: 1
OpenGL: Packed depth stencil support: 1
OpenGL: Unpack subimage support: 1
OpenGL: OpenGL ES depth 24 support: 0
OpenGL: Texture edge clamping support: 1
OpenGL: Texture border clamping support: 1
OpenGL: Texture mirror repeat support: 1
OpenGL: Texture max level support: 1
Opening hashed: shaders.dat
generateZipSet: Loaded pack file: shaders.dat
HardwareInput with ID 'JOY_START' not known
HardwareInput with ID 'JOY_LEFT_STICK_Y-' not known
HardwareInput with ID 'JOY_LEFT_STICK_Y+' not known
HardwareInput with ID 'JOY_LEFT_STICK_X-' not known
HardwareInput with ID 'JOY_LEFT_STICK_X+' not known
HardwareInput with ID 'JOY_RIGHT_SHOULDER' not known
CPU extensions:
SSE2(enabled) AVX2(disabled) NEON(not supported)
dpi: 96 default: 96
Setting 728 x 499 -> 728 x 499 -- 1
Opening hashed: gui-icons.dat
generateZipSet: Loaded pack file: gui-icons.dat
Opening hashed: THEMERC
Opening hashed: THEMERC
Opening hashed: THEMERC
Opening hashed: THEMERC
Opening hashed: THEMERC
Opening hashed: THEMERC
Opening hashed: THEMERC
Opening hashed: THEMERC
Loading theme SCUMMREMASTERED.ZIP
Opening hashed: THEMERC
File::open: opening 'NotoSansKR-Bold.otf' failed
Segmentation fault

```