### PR TITLE
COMMON: Add a mode to the INI parser to ignore garbage in some files

### DIFF
--- a/common/formats/ini-file.cpp
+++ b/common/formats/ini-file.cpp
@@ -59,23 +59,23 @@ void INIFile::clear() {
 	_sections.clear();
 }
 
-bool INIFile::loadFromFile(const String &filename) {
+bool INIFile::loadFromFile(const String &filename, bool strictParser) {
 	File file;
 	if (file.open(filename))
-		return loadFromStream(file);
+		return loadFromStream(file, strictParser);
 	else
 		return false;
 }
 
-bool INIFile::loadFromFileOrDataFork(const String &filename) {
+bool INIFile::loadFromFileOrDataFork(const String &filename, bool strictParser) {
 	SeekableReadStream *file = Common::MacResManager::openFileOrDataFork(filename);
 	if (file)
-		return loadFromStream(*file);
+		return loadFromStream(*file, strictParser);
 	else
 		return false;
 }
 
-bool INIFile::loadFromSaveFile(const String &filename) {
+bool INIFile::loadFromSaveFile(const String &filename, bool strictParser) {
 	assert(g_system);
 	SaveFileManager *saveFileMan = g_system->getSavefileManager();
 	SeekableReadStream *loadFile;
@@ -84,17 +84,18 @@ bool INIFile::loadFromSaveFile(const String &filename) {
 	if (!(loadFile = saveFileMan->openForLoading(filename)))
 		return false;
 
-	bool status = loadFromStream(*loadFile);
+	bool status = loadFromStream(*loadFile, strictParser);
 	delete loadFile;
 	return status;
 }
 
-bool INIFile::loadFromStream(SeekableReadStream &stream) {
+bool INIFile::loadFromStream(SeekableReadStream &stream, bool strictParser) {
 	static const byte UTF8_BOM[] = {0xEF, 0xBB, 0xBF};
 	Section section;
 	KeyValue kv;
 	String comment;
 	int lineno = 0;
+	int nonAsciilineCount = 0;
 	section.name = _defaultSectionName;
 
 	// TODO: Detect if a section occurs multiple times (or likewise, if
@@ -115,6 +116,9 @@ bool INIFile::loadFromStream(SeekableReadStream &stream) {
 
 		if (line.size() == 0) {
 			// Do nothing
+		} else if (strictParser && !Common::isPrint(line[0])) {
+			// Non-ASCII character at the beginning of the line, count lines
+			nonAsciilineCount++;
 		} else if (line[0] == '#' || line[0] == ';' || line.hasPrefix("//")) {
 			// Accumulate comments here. Once we encounter either the start
 			// of a new section, or a key-value-pair, we associate the value
@@ -198,6 +202,9 @@ bool INIFile::loadFromStream(SeekableReadStream &stream) {
 			section.keys.push_back(kv);
 		}
 	}
+	if (nonAsciilineCount)
+		warning("loadFromStream(): %d lines with non-ASCII garbage ignored", nonAsciilineCount);
+
 
 	// Save last section
 	if (!section.name.empty())

--- a/common/formats/ini-file.h
+++ b/common/formats/ini-file.h
@@ -105,10 +105,46 @@ public:
 	/** Reset everything stored in this INI file. */
 	void	clear();
 
-	bool	loadFromFile(const String &filename); /*!< Load configuration from a file. */
-	bool	loadFromFileOrDataFork(const String &filename); /*!< Load configuration from a file in MacBinary format. */
-	bool	loadFromSaveFile(const String &filename); /*!< Load configuration from a save file. */
-	bool	loadFromStream(SeekableReadStream &stream); /*!< Load configuration from a @ref SeekableReadStream. */
+	/**
+	 * Load configuration from a file.
+	 *
+	 * @param filename     Name of an INI file to parse
+	 * @param strictParser Do not allow garbage to be present in the file (default true)
+	 *
+	 * @return  True if file was parsed successfully
+	 */
+	bool	loadFromFile(const String &filename, bool strictParser = true);
+
+	/**
+	 * Load configuration from a file in MacBinary format.
+	 *
+	 * @param filename     Name of an INI file to parse
+	 * @param strictParser Do not allow garbage to be present in the file (default true)
+	 *
+	 * @return  True if file was parsed successfully
+	 */
+	bool	loadFromFileOrDataFork(const String &filename, bool strictParser = true);
+
+	/**
+	 * Load configuration from a save file.
+	 *
+	 * @param filename     Name of an INI file to parse
+	 * @param strictParser Do not allow garbage to be present in the file (default true)
+	 *
+	 * @return  True if file was parsed successfully
+	 */
+	bool	loadFromSaveFile(const String &filename, bool strictParser = true);
+
+	/**
+	 * Load configuration from a @ref SeekableReadStream.
+	 *
+	 * @param stream       Name of an stream to parse
+	 * @param strictParser Do not allow garbage to be present in the file (default true)
+	 *
+	 * @return  True if file was parsed successfully
+	 */
+	bool	loadFromStream(SeekableReadStream &stream, bool strictParser = true);
+
 	bool	saveToFile(const String &filename); /*!< Save the current configuration to a file. */
 	bool	saveToSaveFile(const String &filename); /*!< Save the current configuration to a save file. */
 	bool	saveToStream(WriteStream &stream); /*!< Save the current configuration to a @ref WriteStream. */

--- a/engines/mohawk/livingbooks.cpp
+++ b/engines/mohawk/livingbooks.cpp
@@ -302,7 +302,10 @@ void MohawkEngine_LivingBooks::pauseEngineIntern(bool pause) {
 
 void MohawkEngine_LivingBooks::loadBookInfo(const Common::String &filename) {
 	_bookInfoFile.allowNonEnglishCharacters();
-	if (!_bookInfoFile.loadFromFile(filename))
+
+	// WORKAROUND: Sheila FR has garbage in INI file. Running parser in non-strict mode
+	// and ignore non-ASCII characters. Bug #13920
+	if (!_bookInfoFile.loadFromFile(filename, false))
 		error("Could not open %s as a config file", filename.c_str());
 
 	_title = getStringFromConfig("BookInfo", "title");


### PR DESCRIPTION
The pull request resolve a bug in French sheila(https://bugs.scummvm.org/ticket/13920)
in INI Parser

- Added a  flag  strictParser Do not allow garbage to be present in the file (default true)
- Added a condition to check for Non-Ascii

