### PR TITLE
GLK: Various detection tables updated

### DIFF
--- a/engines/glk/adrift/detection_tables.h
+++ b/engines/glk/adrift/detection_tables.h
@@ -979,6 +979,7 @@ const PlainGameDescriptor ADRIFT_GAME_LIST[] = {
 
 	// French games
 	{ "bellesmeres",        "Belles-Mères" },
+	{ "enquete",            "Enquête à Hauts Risques" },
 	{ "largo",              "Largo Winch" },
 	{ "lesfeux",            "Les Feux de l'Enfer" },
 	{ "quiatuedana",        "Qui a tué Dana ?" },
@@ -2475,6 +2476,7 @@ const GlkDetectionEntry ADRIFT_GAMES[] = {
 
 	// French games
 	DT_ENTRYL1("bellesmeres", Common::FR_FRA, "130318", "3d556ba5448b4bce8e7b0ee818bd1e79", 73972744),
+	DT_ENTRYL1("enquete", Common::FR_FRA, "160906", "56157297a33db4855bf2a6eb2b06ef38", 156919),
 	DT_ENTRYL1("largo", Common::FR_FRA, "061022", "2544ee9502a97511b27fee722508bd2c", 282396),
 	DT_ENTRYL1("lesfeux", Common::FR_FRA, "050928", "b3534d72ce3d2a5bd40d1b0d922419a4", 54162),
 	DT_ENTRYL1("quiatuedana", Common::FR_FRA, "050928", "d22079f4b173d33272bb5f3e97f71aae", 20034),

--- a/engines/glk/glulx/detection_tables.h
+++ b/engines/glk/glulx/detection_tables.h
@@ -34,6 +34,7 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "18rooms17",          "18 Rooms to Home (Room 17)" },
 	{ "18rooms18",          "18 Rooms to Home (Room 18)" },
 	{ "1kcupid",            "1K Cupid" },
+	{ "4thidea",            "A Fourth Idea" },
 	{ "5secsimulation",     "The Five-Second Simulation" },
 	{ "acbs",               "A Cock and Bull Story" },
 	{ "accfinsolutisle",    "Accounting and Finance Solution Island" },
@@ -43,10 +44,10 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "adv350_glulx",       "Adventure, 350 Point Colossal Cave" },
 	{ "adventmirror",       "Advent Mirror" },
 	{ "adventura",          "Adventura" },
+	{ "advwackaxe",         "Adventures of Wack Ax" },
 	{ "ailihphilia",        "Ailihphilia" },
 	{ "airport",            "The Airport" },
 	{ "alabaster",          "Alabaster" },
-	{ "aliasthemagpie",     "Alias 'The Magpie'" },
 	{ "anchorhead",         "Anchorhead" },
 	{ "anchorheadse",       "Anchorhead: Special Edition" },
 	{ "andelmanyard",       "Andelmans' Yard" },
@@ -73,6 +74,7 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "beingthere",         "Being There" },
 	{ "beyond_glulx",       "Beyond" },
 	{ "bigfootbluff",       "Bigfoot Bluff" },
+	{ "blackhouse",         "Black House" },
 	{ "bluelacuna",         "Blue Lacuna" },
 	{ "bluelattuce",        "Blue Lattuce" },
 	{ "bootscraper",        "The Boot-Scraper" },
@@ -80,6 +82,7 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "btyt",               "Bigger Than You Think" },
 	{ "bureaucrocy_glulx",  "Bureaucrocy" },
 	{ "buygold",            "Buy Gold" },
+	{ "cafesim2k",          "Cafe Simulator 2000" },
 	{ "candlewindless",     "Candle Flames in Windless Air" },
 	{ "canyouescape",       "Can You Escape" },
 	{ "captverdeterre",     "Captain Verdeterre's Plunder" },
@@ -97,6 +100,7 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "colderlight",        "The Colder Light" },
 	{ "comp01tr",           "Comp01ter Game: N0n C0mp0s Ment1s" },
 	{ "confhist",           "Conflicting Histories" },
+	{ "connect",            "Connect" },
 	{ "cos",                "City of Secrets" },
 	{ "cosmoserve_glulx",   "CosmoServe: An Adventure for the BBS-Enslaved" },
 	{ "counterfeitmonkey",  "Counterfeit Monkey" },
@@ -120,6 +124,7 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "deathofftc",         "Death Off the Cuff" },
 	{ "delfina",            "Delfina" },
 	{ "diaperquest",        "Diaper Quest" },
+	{ "digestion",          "Digestion.CO" },
 	{ "discovertheworld",   "Discover The World" },
 	{ "dondive",            "Don’t Dive Into Blood, Kids" },
 	{ "donotmeddle",        "Do Not Meddle" },
@@ -161,10 +166,12 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "further_glulx",      "Further" },
 	{ "gaiawebch12",        "Gaia-Web Chapter 12: The Silence of the Thunder" },
 	{ "gatewayferrets",     "Gateway of the Ferrets" },
+	{ "genderdiscr",        "Gender Discrimination" },
 	{ "genesisquest",       "Genesis Quest" },
 	{ "getout",             "Get Out!" },
 	{ "ghost",              "Ghost" },
 	{ "ghosteringtonnight", "Ghosterington Night" },
+	{ "gibraltar",          "Gibraltar" },
 	{ "glass_glulx",        "Glass" },
 	{ "glkchess",           "Glk Chess" },
 	{ "glkebook",           "GlkeBook" },
@@ -192,10 +199,13 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "jasonandmedea",      "Jason and Medea" },
 	{ "kerkerkruip",        "Kerkerkruip" },
 	{ "keyfeatures",        "Key Features" },
+	{ "kidnapped",          "Kidnapped" },
 	{ "kingshredspatches",  "The King of Shreds and Patches" },
 	{ "klaustrophobia",     "Klaustrophobia" },
 	{ "koa",                "Kingdom of Amphibia" },
 	{ "lastresort",         "Last Resort" },
+	{ "latorre_glulx",      "La Torre" },
+	{ "lighthouse",         "Lighthouse" },
 	{ "limeergot",          "Lime Ergot" },
 	{ "limen",              "Limen" },
 	{ "lmg",                "The Little Match Girl" },
@@ -208,12 +218,15 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "lockeddoor11",       "Locked Door XI: The US Theatrical Cut" },
 	{ "lockkey",            "Lock and Key" },
 	{ "lonelytroll",        "The Lonely Troll" },
+	{ "lostulla",           "Lost in Ulla" },
 	{ "lupercalia_glulx",   "Lupercalia" },
 	{ "lurkinghorror2",     "The Lurking Horror II: The Lurkening" },
+	{ "magicbullet",        "Magic BUllet" },
 	{ "makechange",         "Maybe make some change" },
 	{ "makingme",           "The Making of Me" },
 	{ "mariel",             "Mariel" },
 	{ "maryjaneoftomorrow", "The Mary Jane of Tomorrow" },
+	{ "mehplace_glulx",     "The Meh Place" },
 	{ "mgaeb",              "My Girlfriend's an Evil Bitch" },
 	{ "midnightsnack",      "Midnight Snack" },
 	{ "milk",               "Mr. Leg Needs Some Milk" },
@@ -235,6 +248,7 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "newcat",             "New Cat" },
 	{ "nightmare",          "Nightmare" },
 	{ "nssri",              "No Sign Should Remain Inert" },
+	{ "ntta",               "Now and Then and Then Again" },
 	{ "officegoose",        "Office Goose" },
 	{ "oldfogey",           "Old Fogey" },
 	{ "oliviasorphanorium", "Olivia's Orphanorium" },
@@ -249,6 +263,7 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "pinched",            "Pinched" },
 	{ "pizzadelivery",      "Pizza Delivery" },
 	{ "portfoliopiece",     "Portfolio Piece" },
+	{ "pyramidescape",      "Pyramid Escape" },
 	{ "pytho_glulx",        "Pytho's Mask" },
 	{ "questarete",         "Quest for Arete" },
 	{ "raidersstones",      "Raiders of the Holy Stones" },
@@ -263,11 +278,13 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "roguelikegoose",     "Roguelike Goose" },
 	{ "roscovian",          "The Roscovian Palladium" },
 	{ "runoregonleg",       "Run for the Oregon Legislature!" },
+	{ "sabotage",           "Sabotage!" },
 	{ "safe_glulx",         "Safe" },
-	{ "sagebrushcactus",    "'Mid the sagebrush and the cactus" },
+	{ "sagebrushcactus",    "'Mid the Sagebrush and the Cactus" },
 	{ "samfortunepi",       "Sam Fortune - Private Investigator" },
 	{ "sanddancer_glulx",   "Sand-Dancer" },
 	{ "scrollthief",        "The Scroll Thief" },
+	{ "secretlab",          "The Secret Lab" },
 	{ "secretletter",       "Jack Toresal and the Secret Letter" },
 	{ "section1awakened",   "Section 1 - Awakened" },
 	{ "seedscafe",          "Seeds Cafe" },
@@ -282,19 +299,26 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "skugalake",          "Visit Skuga Lake" },
 	{ "slouchbedlam",       "Slouching Towards Bedlam" },
 	{ "smittenkittens",     "Smitten Kittens" },
+	{ "sobrevive",          "Sobrevive" },
 	{ "spaceship",          "Spaceship!" },
 	{ "speedracer",         "Speed Racer" },
 	{ "spelunking2",        "IFDB Spelunking 2" },
 	{ "spirI7wrak",         "SpirI7wrak" },
 	{ "starlight_glulx",    "Starlight" },
+	{ "station9",           "Station 9" },
 	{ "stew",               "Stew" },
+	{ "stormonboard",       "Storm Onboard the Bastille Cargo Vessel" },
+	{ "stretchlimo",        "Stratch Limo" },
+	{ "sunlight",           "Sunlight" },
 	{ "superluminal",       "Superluminal Vagrant Twin" },
+	{ "survive_glulx",      "Survive" },
 	{ "tacofiction",        "Taco Fiction" },
 	{ "take",               "Take (by Amelia Pinnolla)" },
 	{ "tangledtowertales",  "Tangled Tower Tales" },
 	{ "tblw_glulx",         "The Blood Lust Warrior" },
 	{ "tcom",               "The Colour of Magic" },
 	{ "terminatorchaser",   "Terminator Chaser" },
+	{ "terrorunder",        "Terror of the Underground" },
 	{ "theabbey",           "The Abbey" },
 	{ "theabsenceoflaw",    "The Absence of Law" },
 	{ "theargument",        "The Argument" },
@@ -327,6 +351,7 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "tobysnose",          "Toby’s Nose" },
 	{ "todayisthesame",     "Today is the Same as Any Other" },
 	{ "tohellinahamper",    "To Hell in a Hamper" },
+	{ "trenton",            "Trenton" },
 	{ "trialofthetnuop",    "Trial of the Inuop" },
 	{ "trollslayer",        "Trollslayer" },
 	{ "tryagain",           "Try Again" },
@@ -341,6 +366,9 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "valleyofsteel",      "Valley of Steel" },
 	{ "veryvile_glulx",     "Prime Pro-Rhyme Row #1: Very Vile Fairy File" },
 	{ "walking",            "Walking" },
+	{ "welcomerr",          "Welcome to Ready Reader One and the Aldrich Library" },
+	{ "whenrome",           "When in Rome 1: Accounting for Taste" },
+	{ "whenrome2",          "When in Rome 2: Far From Home" },
 	{ "whitehouses",        "White Houses" },
 	{ "winterstormdraco",   "Winter Storm Draco" },
 	{ "wishertheurgist",    "Wisher, Theurgist, Fatalist" },
@@ -509,7 +537,7 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "if17_hauntedp",      "Haunted P" },                                                              //   78th Place
 
 	// IFComp 2018
-	{ "if18_aliasmagpie",   "Alias The Magpie" },                                                       //    1st Place
+	{ "if18_aliasmagpie",   "Alias 'The Magpie'" },                                                     //    1st Place
 	{ "if18_arithmancer",   "Junior Arithmancer" },                                                     //    7th Place
 	{ "if18_engarde",       "En Garde" },                                                               //   14th Place
 	{ "if18_rcm301303",     "Terminal Interface for Models RCM301303" },                                //   16th Place
@@ -892,7 +920,7 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	// Spring Thing 2021 - Main Festival
 	{ "stc21_weightsoul",   "The Weight of a Soul" },                                                   // Best in Show
 	{ "stc21_baggage",      "Baggage" },                                                                //      Entrant
-	{ "stc21_meantucker",   "Mean Mother Trucker" },                                                    //      Entrant
+	{ "stc21_meantrucker",  "Mean Mother Trucker" },                                                    //      Entrant
 
 	// Spring Thing 2021 - Back Garden
 	{ "stc21_shorofcash",   "So I Was Short of Cash and Took on a Quest" },                             //      Entrant
@@ -922,34 +950,34 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "archcivesuliroya",   "Archives Culinaires Royales - Période d’Essai" },
 	{ "astressolitaires",   "Astres Solitaires" },
 	{ "ekphrasis",          "Ekphrasis" },
-	{ "fautedeservo",       "Faute de Servo" },
 	{ "heuresduvent",       "Les Heures du Vent" },
 	{ "latempete",          "La Tempête" },
 	{ "kebabhante",         "Le Kébab Hanté" },
 	{ "lieuxcommuns_glulx", "Lieux communs" },
 	{ "petitgnome_glulx",   "Petit Gnome" },
+	{ "rendezvous",         "Rendez-vous au Lavoir" },
 	{ "sarvegne_glulx",     "Sarvegne" },
 	{ "scarabeekatana",     "Le Scarabee et le Katana" },
 	{ "tempetebermudes",    "Tempete sur les Bermudes" },
 	{ "templefeu",          "Le Temple de Feu" },
 	{ "tourorastre",        "La Tour d'Orastre" },
 
-	// French Comp 2007
+	// French Comp 2007 (French)
 	{ "frc_souterraine",    "Souterraine" },                                                            //    4th Place
 	{ "frc_ilephare_glulx", "L'Ile du Phare Abandonné" },                                               //    5th Place
 
-	// French Comp 2008
+	// French Comp 2008 (French)
 	{ "frc_survivre",       "Survivre" },                                                               //    3rd Place
 
-	// French Comp 2013
+	// French Comp 2013 (French)
 	{ "frc_noirdencre",     "Noir d'Encre" },                                                           //    2nd Place
 
-	// French Comp 2015
+	// French Comp 2015 (French)
 	{ "frc_sourire",        "Sourire de Bois" },                                                        //    2nd Place
 	{ "frc_comedie",        "Comédie" },                                                                //    3rd Place
 
-	// French Comp 2018
-	{ "frc_fauteservo",     "Faute de servo" },                                                         //    2nd Place
+	// French Comp 2018 (French)
+	{ "frc_fauteservo",     "Faute de Servo" },                                                         //    2nd Place
 	{ "frc_latempete",      "La Tempête" },                                                             //    4th Place
 
 	// German games
@@ -969,17 +997,17 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "sonntagnachmittag",  "An Einem Sonntagnachmittag" },
 	{ "spaterbesuch",       "Ein Später Besuch" },
 
-	// Textfire Grand Prix 2005
+	// Textfire Grand Prix 2005 (German)
 	{ "tgp_bananerepublik", "Bananenrepublik" },                                                        //    2nd Place
 
-	// Textfire Grand Prix 2010
+	// Textfire Grand Prix 2010 (German)
 	{ "tgp_ares",           "Ares" },                                                                   //    1st Place
 
-	// Textfire Grand Prix 2011
+	// Textfire Grand Prix 2011 (German)
 	{ "tgp_roteblum",       "Die Rote Blume" },                                                         //    1st Place
 	{ "tgp_schiesbefehl",   "Schießbefehl" },                                                           //    3rd Place
 
-	// Textfire Grand Prix 2014
+	// Textfire Grand Prix 2014 (German)
 	{ "tgp_treffen",         "Treffen am Nebelgrat" },                                                  //    1st Place
 	{ "tgp_dersigkeitenlad", "Der Süßigkeitenladen" },                                                  //    4th Place
 
@@ -995,8 +1023,10 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "erisvalle",          "Le Lande di Erisvalle" },
 	{ "fugacropoli_glulx",  "Fuga dall'Acropoli" },
 	{ "giardino_glulx",     "Il Giardino Incantato" },
+	{ "kinesis",            "Kinesis" },
 	{ "littlefalls_glulx",  "Little Falls" },
 	{ "lucifinanza_glulx",  "Luci della Finanza" },
+	{ "marconi_glulx",      "Visita al Marconi" },
 	{ "pietraluna_glulx",   "La Pietra della Luna" },
 	{ "ormechisciano",      "Le Orme del Chisciano" },
 	{ "perlesaggezza",      "Aladino e le Perle di Saggezza" },
@@ -1018,60 +1048,94 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "volonta_glulx",      "La Volontà dei Morti" },
 	{ "zigamusita_glulx",   "Zigamus: Zombi al Vigamus!" },
 
-	// Marmellata d'Avventura 2018
+	// Marmellata d'Avventura 2018 (Italian)
 	{ "parcochuddy",        "Parco di Chuddy" },
 	{ "dejavu_glulx",       "Déjà Vu" },
 	{ "cosmicmatryoshka",   "Cosmic Matryoshka" },
 	{ "bouvet",             "Passaggio tra i Ghiacci" },
 	{ "baseantartica",      "Base Antartica Siegfried" },
 
-	// Marmellata d'Avventura 2019
+	// Marmellata d'Avventura 2019 (Italian)
 	{ "piccolopopolo",      "Il Piccolo Popolo in Sala Giochi" },
 	{ "fregatogettoni",     "Ti Hanno Fregato i Gettoni!" },
 	{ "iosonoaugust",       "Io Sono August" },
 	{ "george_glulx",       "George" },
 
 	// Spanish games
+	{ "abismo_glulx",       "El Abismo" },
 	{ "acman",              "Acman Fever" },
+	{ "acuario_glulx",      "Acuario" },
 	{ "bajando",            "¡Bajandose!" },
+	{ "cajadecerillas",     "Desambiguación con Caja de Cerillas" },
+	{ "cajacerillek",       "La Caja de Cerillek" },
+	{ "cangrejo",           "La Venganza del Cangrejo" },
+	{ "ciuthan",            "El Paraisos Perdidos" },
+	{ "comodiablo",         "Como el Diablo Esnifando una Raya" },
 	{ "conrumbo_glulx",     "Con Rumbo" },
 	{ "copernico86",        "Copérnico 86" },
 	{ "cumpleanos",         "Cumpleanos" },
+	{ "dagon_glulx",        "Dagon" },
 	{ "discos",             "Bar de Seppo" },
 	{ "dwight_glulx",       "El Extraño Caso de Randolph Dwight" },
+	{ "elcristalrojo",      "El Cristal Rojo" },
 	{ "eldiadespues",       "El Dia Despues" },
 	{ "elexpreso",          "El Expreso de Los Vampiros" },
+	{ "elhobbit",           "El Hobbit" },
 	{ "elultimojedi",       "El Ultimo Jedi" },
 	{ "ensaladasensorial",  "Ensalada Sensorial" },
 	{ "entrevista",         "Entrevista" },
 	{ "ergotdelima_glulx",  "Ergot de Lima" },
+	{ "escapedoom",         "Escape Doom" },
+	{ "estacion_glulx",     "Secuestro" },
 	{ "explosin",           "La Explosin Fulminante" },
 	{ "finmortal",          "Fórmula Inmortal" },
+	{ "genio",              "El Genio" },
 	{ "globitoscolores",    "Globitos de Colores" },
 	{ "graffi",             "Graffi, Mi Perro Virtual" },
 	{ "grutahorror",        "La Gruta del Horror" },
-	{ "historiashampa",     "Historias del Hampa" },
+	{ "hampa_glulx",        "Historias del Hampa" },
+	{ "jugueteria",         "La Jugueteria del Mago Zacarias" },
+	{ "kavija",             "Kavija" },
 	{ "laarana",            "La Arana" },
 	{ "lacaja",             "La Caja" },
 	{ "lanochedelensayo",   "La Noche del Ensayo" },
+	{ "lastumbas",          "Las Tumbas de los Enanos de los Reinos" },
+	{ "lazona",             "La Zona" },
 	{ "legado",             "El Legado" },
+	{ "legin",              "Legin de las Tinieblas" },
 	{ "libreriasix",        "Demo de la Librería SIX" },
+	{ "mapa_glulx",         "El Mapa" },
+	{ "matrioska",          "Matrioska" },
+	{ "matrioskabamo",      "Bisabuela, Abuela, Madre, y Olga" },
 	{ "mcarras",            "McArra's Quest Reloaded" },
 	{ "megacorp2",          "Megacorp II" },
 	{ "memorias_glulx",     "Memorias de reXXe" },
 	{ "mono3cartes",        "Mono con Tres Cartas" },
 	{ "moria",              "Moria" },
 	{ "multivampi7",        "MultiVampI7" },
+	{ "naufrago",           "Naufrago" },
+	{ "nocheinvierno",      "En una Noche de Invierno Apareci el Trapero Cantando Bajo tu Ventana" },
 	{ "nochemetro",         "Una Noche en el Metro" },
 	{ "olvido_glulx",       "Olvido Mortal" },
 	{ "ork1",               "Ork 1" },
 	{ "ork2",               "Ork 2" },
 	{ "osobipolar",         "Oso Bipolar" },
+	{ "panico",             "Panico en el Pau Vila" },
 	{ "piratescharaibes",   "Pirates des Charaïbes" },
+	{ "poetico",            "Generador Poetico" },
+	{ "pyat",               "Pyat" },
+	{ "relojes_glulx",      "Un Lugar en Ninguna Parte Pero en Algún Momento" },
+	{ "saboteur",           "Saboteur" },
 	{ "sgw_glulx",          "Test Para SGW" },
+	{ "sinsalida",          "Sin Salida" },
+	{ "subterranea",        "Subterranea" },
+	{ "tiros_xx",              "Un Día Duro en la Sala de Tiro" },
 	{ "ultimohogar_glulx",  "Misterio en el Ultimo Hogar" },
+	{ "umami",              "El Dia del Umami" },
 	{ "vainsville",         "Vainsville" },
+	{ "venenarius",         "Venenarius Verborum" },
 	{ "viejaantonieta",     "La Vieja Antonieta" },
+	{ "yan",                "La Venganza de Yan" },
 
 	// XComp 2008 (Spanish)
 	{ "xc08_damusix",       "Damusixa" },
@@ -1085,15 +1149,15 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	// Ectocomp 2022 - Le Grand Guignol (Spanish)
 	{ "ec22_estadop_glulx",  "Estado Profundo" },                                                       //    2nd Place
 
-	// Premios Hispanos 2002
+	// Premios Hispanos 2002 (Spanish)
 	{ "ph02_demoespacio",   "La Gema Karssakis" },
 	{ "ph02_insomnio",      "Insomnio de una Noche de Verano" },
-	{ "ph02_legador",       "El Legado" },
+	{ "ph02_legado",        "El Legado" },
 	{ "ph02_oder",          "Obituario" },
 	{ "ph02_regente_glulx", "El Anillo Regente" },
 	{ "ph02_salondwight",   "El Salón de Randolph Dwighto" },
 
-	// Premios Hispanos 2003
+	// Premios Hispanos 2003 (Spanish)
 	{ "ph03_dioszaglx",     "Dios en Zapatillas" },
 	{ "ph03_dwight_glulx",  "L'Extraño Caso de Randolph Dwight" },
 	{ "ph03_enterrado",     "Enterrado Vivo" },
@@ -1102,27 +1166,27 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "ph03_sinsentido",    "Sin sentido" },
 	{ "ph03_zerogrados",    "Zero Grados" },
 
-	// Premios Hispanos 2004
+	// Premios Hispanos 2004 (Spanish)
 	{ "ph04_orfeo2",        "Orfeo en los Infiernos" },
 	{ "ph04_primeranoche",  "Dracula - Episodio 1: La Primera Noche" },
 	{ "ph04_regente",       "El Anillo Regente" },
 	{ "ph04_remakorp04",    "Remakorp" },
 	{ "ph04_vhalen1",       "Los Extraordinarios Casos del Dr. Van Halen: Misterio en la Catedral" },
 
-	// Premios Hispanos 2005
+	// Premios Hispanos 2005 (Spanish)
 	{ "ph05_ahs",           "Los Alegres Hombres de Sherwood" },
 	{ "ph05_musa",          "La Musa" },
 	{ "ph05_rur",           "Las Aventuras de Rudolphine Rur" },
 	{ "ph05_sarimek",       "La Caja de Sarimek" },
 
-	// Premios Hispanos 2006
+	// Premios Hispanos 2006 (Spanish)
 	{ "ph06_007altosecret", "007 Alto Secreto" },
 	{ "ph06_laconferencia", "La Conferencia" },
 	{ "ph06_paee_glulx",    "Paee" },
 	{ "ph06_remakorp06",    "Remakorp" },
 	{ "ph06_wizlair",       "Bienvenido a Wiz Lair" },
 
-	// Premios Hispanos 2007
+	// Premios Hispanos 2007 (Spanish)
 	{ "ph07_diabloesnifan", "Como el Diablo Esnifando una Raya" },
 	{ "ph07_diana925",      "Diana v925" },
 	{ "ph07_edificio25",    "El Edificio 25" },
@@ -1131,21 +1195,22 @@ const PlainGameDescriptor GLULXE_GAME_LIST[] = {
 	{ "ph07_htec_glulx",    "Hierba Tras el Cristal" },
 	{ "ph07_regresoaleden", "Regreso al Edén" },
 
-	// Premios Hispanos 2008
+	// Premios Hispanos 2008 (Spanish)
 	{ "ph08_alienlaventur", "ALIEN: La Aventura" },
 	{ "ph08_diana_glulx",   "Diana" },
 	{ "ph08_espiritusidra", "El Espiritu de la Sidra" },
 	{ "ph08_puj",           "Puj" },
 
-	// Premios Hispanos 2009
-	{ "ph09_anillo3",       "Anillo 3 - Original" },
+	// Premios Hispanos 2009 (Spanish)
+	{ "ph09_anillo3",       "Anillo III - Diseno Original" },
 	{ "ph09_hhorcus_glulx", "Homo Homini Orcus" },
 	{ "ph09_kerulen_glulx", "Ke rulen los petas" },
 	{ "ph09_lae_glulx",     "La Aventura Espacial" },
 	{ "ph09_lobosaldeanos", "Recibidor de Lobos y Aldeanos" },
 	{ "ph09_reliquiatolti", "Las Reliquias de Tolti Aph" },
+	{ "ph09_visit_glulx",   "Visitantes" },
 
-	// Premios Hispanos 2010
+	// Premios Hispanos 2010 (Spanish)
 	{ "ph10_lpc_glulx",     "La Pequena Cerillera" },
 	{ "ph10_heroemazmorra", "Heroes de la Mazmorra" },
 	{ "ph10_piedrapt",      "Piedra, Papel, Tijeras" },
@@ -1239,24 +1304,23 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("18rooms17", "150820", "0ec74f878a95266823a6037879d86207", 885332),
 	DT_ENTRY1("18rooms18", "150820", "537efb13b1ceb5d6c5d4e534bd623561", 821588),
 	DT_ENTRY1("1kcupid", "181215", "2ec3dfeb872cc73606c00164b96cf9de", 835274),
+	DT_ENTRY1("4thidea", "180422", "cfdf614eac577dc282d202b1cb358dd1", 647592),
 	DT_ENTRY1("5secsimulation", "230817", "1291371feac011c32149a54bc21aaa9b", 2030354),
 	DT_ENTRY1("acbs", "170705", "6b108c327301ccba5de41f3b98772b33", 1334066),
 	DT_ENTRY1("accfinsolutisle", "230228", "01e1b6a52aaf69f3ce4c0e8d7afb0553", 593148),
 	DT_ENTRY1("acg", "070501", "1a3eb782d28dd8ae8da40f21adb174f0", 817408),
 	DT_ENTRY1("acmj", "220607", "581a2d9a0df17a2852cf28a14bd78a46", 602220),
 	DT_ENTRY1("adventdoor", "200229", "3d19ccc746a18d46847a88957aa5a2ac", 750766),
-	DT_ENTRY1("adv350_glulx", "961209/v1", "cf232df2a3364a6f0821a8ef631c81a1", 167424),
-	DT_ENTRY1("adv350_glulx", "961209/v2", "e1939485dc2d4aab637144fc842b479d", 195406),
+	DT_ENTRY1("adv350_glulx", "961209/blb", "e1939485dc2d4aab637144fc842b479d", 195406),
+	DT_ENTRY1("adv350_glulx", "961209/ulx", "cf232df2a3364a6f0821a8ef631c81a1", 167424),
 	DT_ENTRY1("adventmirror", "221204", "59a15b7ce9b122f19bebd214d5290c48", 718768),
 	DT_ENTRY1("adventura", "171031", "4ca16a77854814124e1ab8df7270ed20", 659912),
+	DT_ENTRY1("advwackaxe", "220323", "d47cc7c4d04cb636447a7af1f05294f2", 612810),
 	DT_ENTRY1("ailihphilia", "181112", "6ede6899e1ddf208d2a096a58e45586f", 1199402),
 	DT_ENTRY1("ailihphilia", "220228", "d52dd34d4e48692afd7ead53ee30a026", 1317440),
 	DT_ENTRY1("airport", "080204", "d3db494abc309a42b4dccfa53243a783", 234728),
 	DT_ENTRY1("alabaster", "090604", "3e7913a97275d57d4f2fcec7b014b167", 3374558),
 	DT_ENTRY1("alabaster", "090609", "7f664b6eef28485a2f85a1831b041246", 3132122),
-	DT_ENTRY1("aliasthemagpie", "181017", "783cf48cbd582f6f169880f50792c163", 1815796),
-	DT_ENTRY1("aliasthemagpie", "190206", "a4281a03b797582ea53aa203b1eb7236", 1875956),
-	DT_ENTRY1("aliasthemagpie", "220210", "1475b9fc5c4bb8b1e128b9bb255e238b", 1766254),
 	DT_ENTRY1("anchorhead", "??????", "8913be5c1feeca879111c356daf87291", 18634158),
 	DT_ENTRY1("anchorheadse", "070202/Demo", "f2e60c4c3aad4c6a2b18d4d20040ed76", 635974),
 	DT_ENTRY1("andelmanyard", "221124", "b965b85c050000f2c32c7822e1aa3d84", 1110132),
@@ -1286,12 +1350,13 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("beautyaustere", "190516", "9176001159f15db15a3f674ddd5642f8", 2129538),
 	DT_ENTRY1("beautyaustere", "220220", "456b687530dd14817ac2268ddde4fd3a", 2129538),
 	DT_ENTRY1("bedtimestory", "100522", "120f2a347c98136224d083235d2a8deb", 814536),
-	DT_ENTRY1("beingthere", "10???\?/v1", "6a7f51d6c09acca156e3ceadce7edcb9", 6005766),
-	DT_ENTRY1("beingthere", "10???\?/v2", "c89b1ca56c2eeff6643bbf28ff131492", 6091270),
-	DT_ENTRY1("beingthere", "10???\?/v3", "395781974d66468baa8e159c1110e030", 6091014),
-	DT_ENTRY1("beingthere", "10???\?/v4", "77348d5fd0a6d3d180c371c36e35ef7d", 733696),
-	DT_ENTRY1("beyond_glulx", "100115", "64a351bc6757a58080b801a14d878fc2", 1303364),
+	DT_ENTRY1("beingthere", "10???\?/gblorb/v1", "6a7f51d6c09acca156e3ceadce7edcb9", 6005766),
+	DT_ENTRY1("beingthere", "10???\?/gblorb/v2", "c89b1ca56c2eeff6643bbf28ff131492", 6091270),
+	DT_ENTRY1("beingthere", "10???\?/gblorb/v3", "395781974d66468baa8e159c1110e030", 6091014),
+	DT_ENTRY1("beingthere", "10???\?/ulx", "77348d5fd0a6d3d180c371c36e35ef7d", 733696),
+	DT_ENTRY1("beyond_glulx", "100115/gblorb", "64a351bc6757a58080b801a14d878fc2", 1303364),
 	DT_ENTRY1("bigfootbluff", "220405", "5bbb4d099e4709953b5dc471c8e23895", 857344),
+	DT_ENTRY1("blackhouse", "200620", "3532f126e10ec126bc182a8c5d95e583", 1058718),
 	DT_ENTRY1("bluelacuna", "090304", "86c24b7fa879780038056d5e9a084a28", 5649260),
 	DT_ENTRY1("bluelacuna", "100717", "8a2cd2e898f7375d39393b56ed64c5dd", 5673294),
 	DT_ENTRY1("bluelattuce", "210404", "6d9f050be0d0323487ec1a2647e2896d", 744184),
@@ -1301,6 +1366,7 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("bureaucrocy_glulx", "140401", "530a9efefff27ce37d75e5dc8de8ad5d", 565522),
 	DT_ENTRY1("bureaucrocy_glulx", "140601", "823c8b5425fa537a84b52fb07c997d84", 3396486),
 	DT_ENTRY1("buygold", "160302", "7db70c24b2533800187a1884ca9eacf1", 897480),
+	DT_ENTRY1("cafesim2k", "230108", "6f182f2dfbe95c0fd49af886ab7ea702", 609272),
 	DT_ENTRY1("candlewindless", "170828", "8decde9d474d5888d46684b8958c3a3d", 2281490),
 	DT_ENTRY1("canyouescape", "131027", "330ec51e1f138a5f28df687c749ac959", 339406),
 	DT_ENTRY1("captverdeterre", "131003", "56c78de876c57b0e02725e4d8752f139", 1549998),
@@ -1316,11 +1382,13 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("chickensexer", "130112", "f7a13d6f9b1f9941537f0b7c047b3c8f", 520920),
 	DT_ENTRY1("childrenloblolly", "220117", "1e2ebaa7bc46054d38eed6283ce71517", 824276),
 	DT_ENTRY1("chipmonk", "190725", "dfd2a54378d96e2e0de203b52879501e", 647590),
+	DT_ENTRY1("chipmonk", "190726", "a06bc3c52edbde321a01e9fc20c30ec0", 647578),
 	DT_ENTRY1("chunkyblues", "140105", "5daa6dc28b71338b573da7993da992fe", 1260820),
 	DT_ENTRY1("codetopia", "171103", "40f486f5a68fee9d99623167cf750874", 682480),
 	DT_ENTRY1("colderlight", "120312", "eed41f2779bdf940f84b4e0a33036e69", 1192960),
 	DT_ENTRY1("comp01tr", "012001", "1d51522ee3057a3f7206fa83c151a6de", 149760),
 	DT_ENTRY1("confhist", "190603", "7409eea74565594355edb7fd6f64ee5c", 646882),
+	DT_ENTRY1("connect", "080219", "bd17ceca40baa51711333562e5890e27", 311808),
 	DT_ENTRY1("cos", "030624", "21bbf38c4e358ff2fd34e3d7424c8d36", 8462908),
 	DT_ENTRY1("cosmoserve_glulx", "171005", "a0e995309ba2b1bc0fda138da86ca366", 1798024),
 	DT_ENTRY1("counterfeitmonkey", "140316", "e1af6e5ef16a94e8ae92c0d9137f34c0", 14802926),
@@ -1355,6 +1423,7 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("delfina", "130405", "a1df66ae3c344359a16556f82fe8b2f7", 144896),
 	DT_ENTRY1("diaperquest", "171224", "31d355119d0aa4c719cd8093457857b3", 417101284),
 	DT_ENTRY1("diaperquest", "230711", "f6087fd135f1dc1656134d5b54e976d7", 515505238),
+	DT_ENTRY1("digestion", "200105", "5f51a3d53b1bd866adcdceca198f91e2", 626186),
 	DT_ENTRY1("discovertheworld", "150731", "77b1b18260082d25f4de51318e885eaa", 17127846),
 	DT_ENTRY1("discovertheworld", "160210/gblorb", "b4126bafda2e406876d0363bd57f29e5", 17120678),
 	DT_ENTRY1("discovertheworld", "160210/ulx", "0bfa12b07f5ec7675d49fa83a0b8c48a", 979456),
@@ -1387,6 +1456,7 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("exigentseasons", "220219", "7ee8c390fbddb20b72934a517e52a17e", 1616972),
 	DT_ENTRY1("exilesrose", "141224", "835a56a03b22769112973226097089a8", 774838),
 	DT_ENTRY1("explosin", "130405", "f450f82970ddf00a7b357979ff3b05c5", 173824),
+	DT_ENTRY1("familiar", "190705", "a6fc1a34ada97e61fc013ab9384f5ec8", 2294282),
 	DT_ENTRY1("familiar", "200702", "4e347fdc86a979e865fa790d94bbf30a", 2294330),
 	DT_ENTRY1("farmquest", "111028", "e49e02b73047fb16427c8882035a4be6", 415940),
 	DT_ENTRY1("fate_glulx", "111107", "3ca956a59c56f9b5f894f477507a9618", 1000634),
@@ -1400,20 +1470,23 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("flexiblesurvival", "230412", "429e583862248f2bebed062d61dee351", 530020822),
 	DT_ENTRY1("flexiblesurvival", "230823", "955fdbc53b20674f9f8f60da7def91b6", 561995476),
 	DT_ENTRY1("foreverwarped", "190430", "c28b14e637f1b6a87b3baf5ae3bde606", 528388),
+	DT_ENTRY1("fourdiopolis", "160503", "321cc543667b45c312a24d7ccd4a681d", 494488),
 	DT_ENTRY1("fourdiopolis", "160814", "438e3b23e53b9c6c86293269b6d6e37f", 528280),
 	DT_ENTRY1("further_glulx", "150117", "227bf3da188ae42e43b8b88b66561252", 682770),
 	DT_ENTRY1("gaiawebch12", "160104", "876c8ad8648b4035db67d09f38e9f4d4", 2458080),
 	DT_ENTRY1("gatewayferrets", "191206", "0db20a85e6f044d0968dd1c6eea47c2f", 776178),
 	DT_ENTRY1("gatewayferrets", "200920", "ab44f6f10cee5628f7f5df22f3cb29dc", 778482),
+	DT_ENTRY1("genderdiscr", "200101", "0cded9f3514f8c4f6c8bf7e9f100bace", 655304),
 	DT_ENTRY1("genesisquest", "140319", "c51f6d78e73aa0d846a2e38d4c187cfc", 1647616),
 	DT_ENTRY1("getout", "190823", "61d1b8622f47bf01027d6537dcdb256a", 641758),
 	DT_ENTRY1("ghost", "210716", "8a612292dd5c09cabb64ad0cb41d842b", 794292),
 	DT_ENTRY1("ghosteringtonnight", "150815", "29ee591bd93084b5a450f2324d47de3b", 1940030),
+	DT_ENTRY1("gibraltar", "230319", "f80b674a774ba83126ebbfd5cffb0a37", 585940),
 	DT_ENTRY1("glass_glulx", "230725", "a4f83219c8f0790e21ccda51666417af", 786644),
 	DT_ENTRY1("glkchess", "02????", "43a14ea7a35d7944504d3017f33fd40b", 252340),
 	DT_ENTRY1("glkebook", "040506", "1dc4d02840ee7cbf61dc359bc6a69c22", 61162),
 	DT_ENTRY1("greenmountains", "110116", "4049179c3a28703705de72be734e05bc", 337868),
-	DT_ENTRY1("grutahorror", "150603/Demo", "6de4254acadf5f063dd6211ed3d5a47b", 149248),
+	DT_ENTRY1("greenmountains", "110116", "4049179c3a28703705de72be734e05bc", 337868),
 	DT_ENTRY1("hadeanlands_glulx", "141017", "01fa9a91b0f72d411ae065971f2c681b", 2487728),
 	DT_ENTRY1("hardpuzzle1", "151117", "ee0a36c15599629bfc4fef9d3d83f70f", 601068),
 	DT_ENTRY1("hardpuzzle2", "151209", "db2880a4bf6539b30b922c83d1f35877", 626752),
@@ -1424,12 +1497,15 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("heuresduvent", "080220", "86a98d19085a3889fbedf09ec60da723", 3067312),
 	DT_ENTRY1("hippoelmstr_glulx", "150906", "6dc98840f5c51d62d40e49f935b7bcaf", 563456),
 	DT_ENTRY1("hobbit", "010911", "87212129f54fd80c1f31104eee222f2c", 183642),
-	DT_ENTRY1("hobbitredux_glulx", "170425/v1", "766d0af2efc767d387ba30eeb0db81d2", 622482),
-	DT_ENTRY1("hobbitredux_glulx", "170425/v2", "d0850bafc2ad394e37ee0a5d1d9c508e", 582656),
+	DT_ENTRY1("hobbitredux_glulx", "170420/gblorb", "46447034fcd3b49ee91adef1233eaacd", 709904),
+	DT_ENTRY1("hobbitredux_glulx", "170420/ulx", "a939eb829bd2da2c06dcf8ff75fa6098", 670464),
+	DT_ENTRY1("hobbitredux_glulx", "170425/gblorb", "766d0af2efc767d387ba30eeb0db81d2", 622482),
+	DT_ENTRY1("hobbitredux_glulx", "170425/ulx", "d0850bafc2ad394e37ee0a5d1d9c508e", 582656),
 	DT_ENTRY1("horpyr_glulx", "201110", "7630ceeff588d9df3cebedd5a7a0f571", 701186),
 	DT_ENTRY1("houseofmemories", "200426", "bb74ef8a7831af2d99c9aaae1e02b743", 679844),
 	DT_ENTRY1("houseofmystery", "180608", "97e29a1a074ab5b46f5b7edf9914a957", 1252656),
 	DT_ENTRY1("houseofmystery", "180929", "4b34547babe73117e6575d559b71d1e5", 2486390),
+	DT_ENTRY1("houseofmystery", "181011", "dab14d8fb257bcd1265fe32e87269c90", 2486390),
 	DT_ENTRY1("hungerdaemon","141014", "d514152d4720e8f8219bb61f71e45f93", 1495948),
 	DT_ENTRY1("hungerdaemon","141202", "9908fa1aad277bbc968587ea388d179f", 1496460),
 	DT_ENTRY1("idolsofwar","080127", "8df7126ed848f25567ff63f06b639e29", 757616),
@@ -1449,32 +1525,39 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("kerkerkruip", "180723", "c9fdb51f5faf0c93c8637f39da7d196c", 13276734),
 	DT_ENTRY1("kerkerkruip", "181128", "9d53de4f71f3b3d9629f466b9ea96615", 14261770),
 	DT_ENTRY1("keyfeatures", "120106", "4c5693c1bf4c38a4d9737cb3e12c55ca", 437150),
+	DT_ENTRY1("kidnapped", "151102", "d24c2a6ef6a2a1ec2b49889085d955c6", 640662),
 	DT_ENTRY1("kingshredspatches", "090722", "87765824be7facf6400a392633f84602", 4340676),
 	DT_ENTRY1("klaustrophobia", "110926", "d8751353ff883a1439c4c90cac2991fa", 3599478),
 	DT_ENTRY1("koa", "000001", "f70361a47c2e9571a4fdc72ce7453197", 1085696),
 	DT_ENTRY1("lastresort", "070213", "bc26a4383290d3c04657ea58841b3d91", 787200),
+	DT_ENTRY1("lighthouse", "190425", "e48e7fd705e3ca33893b6603a8c05821", 668430),
 	DT_ENTRY1("limeergot", "151130", "1290543b3d72115bc31201ed244b5011", 1008590),
 	DT_ENTRY1("limeergot", "200613", "ceddde1d3d9a7d5d05d6d3804b518a66", 675054),
 	DT_ENTRY1("limen", "210814", "d196f9bb0ea07b178b6b3fb7b5eb8649", 683000),
 	DT_ENTRY1("lmg", "21????", "6971b9abeb982f95e7a6ee40d2777a9a", 1010446),
 	DT_ENTRY1("lmg", "211230", "cb11a323ae160cbbb6f504518259c92d", 810790),
-	DT_ENTRY1("lmg2", "22????", "6aafe5f0c98aebcc810c25ac545894d8", 1199082),
+	DT_ENTRY1("lmg2", "22???\?/v1", "6aafe5f0c98aebcc810c25ac545894d8", 1199082),
+	DT_ENTRY1("lmg2", "22???\?/v2", "86bbab4c5b9eb203de069fdad7e302d4", 1190198),
 	DT_ENTRY1("lmg3", "22????", "182ad974ff1d772da612c36b8cd5a675", 2298392),
 	DT_ENTRY1("lmgqueenvampires", "230720", "2182c4795ecf3c386233f771dad2324d", 844836),
+	DT_ENTRY1("lmgrevolver", "230316", "d8c187b572d0bbe8167034dc194ecb0a", 861784),
 	DT_ENTRY1("lmgrevolver", "230718", "cf22c81efcfb95a153416974dad6b2f3", 861784),
 	DT_ENTRY1("lmstvg_glulx", "080404", "9dc7716acde7bc5bdc460f11f7ad51f9", 312920),
 	DT_ENTRY1("lockeddoor10", "220202", "10002a1896d514b08416cffbf673f8c1", 989882),
 	DT_ENTRY1("lockeddoor11", "220214", "d96f42aec8da45f0c194a28ce3c1892e", 1019760),
 	DT_ENTRY1("lockkey", "1.12", "6f621089d571d2dada889e4367f4d20b", 269862),
 	DT_ENTRY1("lonelytroll", "220501", "05b1503fa7d757ec8417a777afa9a86e", 2334570),
+	DT_ENTRY1("lostulla", "181017", "755c28429bb1f1813e5c9c203dda8fb5", 652202),
 	DT_ENTRY1("lupercalia_glulx", "140825/gblorb", "f87528179286bebdabec853b245b90d3", 1044122),
 	DT_ENTRY1("lurkinghorror2", "200129", "37b7a3cab7803143cef98dc7181100ef", 782810),
+	DT_ENTRY1("magicbullet", "220219", "58b0fbc52f25b4e6ca0439bab5002eae", 1921844),
 	DT_ENTRY1("makechange", "120107", "0ee70eea03ca810bf0de3dcecfd9c741", 6456118),
 	DT_ENTRY1("makingme", "220209", "96f4346cdf887a6ced4026e13ecc64ea", 2082406),
 	DT_ENTRY1("mariel", "110620", "4ff1f6bdcdbf92f8ff87509a72417deb", 1802472),
 	DT_ENTRY1("maryjaneoftomorrow", "160605", "b8842f2deb9b283cccd272c0dbfc2369", 10344070),
 	DT_ENTRY1("mgaeb", "110326", "9e79d4c25be31698254648579288e6dc", 676818),
 	DT_ENTRY1("mgaeb", "110514", "cac71aa460e0461deefd93be2e89c402", 931540),
+	DT_ENTRY1("mehplace_glulx", "?????\?/gblorb", "0254e6555f1e47a1c95692a4b78dcec3", 666818),
 	DT_ENTRY1("midnightsnack", "230101", "1c97703470406638f16874faacaa7b9c", 761726),
 	DT_ENTRY1("midnightsnack", "230207", "8b0d36c890557649eacaa818c35f6fe9", 685916),
 	DT_ENTRY1("milk", "151030", "d5e5cfcdcf1daaf0eb58891156f19f24", 608444),
@@ -1489,6 +1572,7 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("mugglestudies", "120314", "0053d3c68896176ae8637752f5a855ee", 1320898),
 	DT_ENTRY1("mystery", "160508", "cbd8c64ebfe2c1d7da7d3739764283ae", 1127312),
 	DT_ENTRY1("narco", "1.07", "5dc6eac35d115b03f40ec61ce6e90c9d", 505840),
+	DT_ENTRY1("nautilisia_glulx", "170228", "6b5d2d3495f8d6504d440c0296058213", 2168164),
 	DT_ENTRY1("nautilisia_glulx", "230724", "15d9382cda45b8e8a51a8fddb6144303", 899378),
 	DT_ENTRY1("necronskeep", "110101", "880e7b8dc89efd3a6bd8410136e9132e", 750696),
 	DT_ENTRY1("necronskeep", "180120", "d533b9a3e11bd99f32ec7dcdccbae903", 749160),
@@ -1500,6 +1584,7 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("nightmare", "150927", "5a1800ab91062b1edf96671d4de15fb5", 646038),
 	DT_ENTRY1("nssri", "180606/v1", "c8e18e3c0ea50ecab2723fa581997acc", 1376102),
 	DT_ENTRY1("nssri", "180606/v2", "452fefbff5479f6aacf1b70a396c029d", 1393304),
+	DT_ENTRY1("ntta", "210527", "e2ed4c9432b960ec997cae55d2615077", 1066998),
 	DT_ENTRY1("officegoose", "200101", "3def1e8a27f8d12b26d93ede124d99f7", 571742),
 	DT_ENTRY1("oldfogey", "160512", "bb1cc12fcc2c0d606d237cb8bed8ef7e", 612406),
 	DT_ENTRY1("oliviasorphanorium", "121118", "f0719bf95ca31e2bf964ebf11628b9ba", 1279388),
@@ -1507,6 +1592,7 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("onefishtwofish", "211124", "3bc129b1b3f8fc5afe9ae3b8f550e222", 741406),
 	DT_ENTRY1("ottumwa_glulx", "021409", "1fc1da4f374493bee3a13c143beeba58", 537712),
 	DT_ENTRY1("oxfordportal", "191004", "4e96d704dc870682e058a8f64c6eaa0f", 670668),
+	DT_ENTRY1("panico", "191128", "c3e1e8f5d1c6a77b02a3c922ad17e998", 45659406),
 	DT_ENTRY1("patanoir", "131204", "b328b1edff8f94715898ff0a58e845f9", 877876),
 	DT_ENTRY1("phoenixfire", "190204", "1aab4fc41f54524f98988045aa6be1df", 767690),
 	DT_ENTRY1("photopia_glulx", "10274/v1", "eab3f6371531c78b2e80803e1636da7d", 627050),
@@ -1515,6 +1601,7 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("pinched", "130116", "a6087088eddc38bbed669d531993c688", 1107350),
 	DT_ENTRY1("pizzadelivery", "181115", "d47886a06ab5ec9ed256d56fefc75b8a", 620486),
 	DT_ENTRY1("portfoliopiece", "170510", "efd348ae57ca688962388a410d273451", 636614),
+	DT_ENTRY1("pyramidescape", "191025", "c61a7f0139dc1640d564b70329fe8c7c", 627932),
 	DT_ENTRY1("pytho_glulx", "020223", "3bfe1fa8468e96538b084db5c5feac55", 437408),
 	DT_ENTRY1("questarete", "201128", "79584dc6a3d92df171abd11ee6d87899", 889814),
 	DT_ENTRY1("raidersstones", "220116", "285cb947b9dbf4ad4ccd9606b4c34d44", 1485424),
@@ -1522,6 +1609,7 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("rar", "160423", "d45b8709505785738bb6f935c6e2cb2e", 881040),
 	DT_ENTRY1("rar", "210223", "c11438b2277fb7492eee824b07a97b54", 886160),
 	DT_ENTRY1("recursocclusion", "120211", "a7f8bbafa8e544e5f39747306d10a6f2", 400946),
+	DT_ENTRY1("reliquestolti", "101025", "13c88f101a32f0d77a674894e5ac759e", 1064790),
 	DT_ENTRY1("reliquestolti", "201217", "ff8a901036c37ebb8631f0d68feafd55", 1385920),
 	DT_ENTRY1("renegadebrainwave", "190829", "eed4d25007a3c838376c52ba197efacb", 56396628),
 	DT_ENTRY1("renegadebrainwave", "191202", "1d6cf39b2983e40bc6c71e7bee8a31c7", 1675666),
@@ -1539,12 +1627,14 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("roguelikegoose", "200112/ulx", "c528b65f923cea2b665f325582f5e620", 582144),
 	DT_ENTRY1("roscovian", "170223", "92cdf2dcc8d7e7d2ba1c20d906f8ec8d", 981888),
 	DT_ENTRY1("runoregonleg", "110703", "d173c41644b3b10dd74660329c51b8b7", 426752),
+	DT_ENTRY1("sabotage", "070107", "63716a56dca0f345b7363d4949a50dae", 235926),
 	DT_ENTRY1("safe_glulx", "110109", "95af9e7de6e31fdeff6bd3cf7969434d", 648720),
 	DT_ENTRY1("sagebrushcactus", "100918", "de27a377b78387126b77552bccf0a085", 640246),
 	DT_ENTRY1("samfortunepi", "090510", "f177d973432b7a27302f1a79c8106f72", 706326),
 	DT_ENTRY1("sanddancer_glulx", "10????", "bb85a76031aeb0eececa614b562b092c", 1023228),
 	DT_ENTRY1("scrollthief", "150729", "9c26a3dc0f4fb681bf79f681e63c0d76", 2367848),
 	DT_ENTRY1("scrollthief", "160701", "4ba7874db08126bb177afd511ab16542", 2602042),
+	DT_ENTRY1("secretlab", "180531", "fd41d8b22f1718b6542ba222b771e3d7", 642500),
 	DT_ENTRY1("secretletter", "150107", "152f91e432a49c3f61a8ecd7bca1d6c4", 2274048),
 	DT_ENTRY1("section1awakened", "150812", "e05b999f193566771ff08679d5512143", 625112),
 	DT_ENTRY1("seedscafe", "210206", "3014cd94a6505def8f3e1754b73d22f2", 652732),
@@ -1556,34 +1646,43 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("shufflearound", "140914", "31ce78bff3833e5d2224abc4e63e6923", 3091868),
 	DT_ENTRY1("shufflearound", "150328", "00b2a517ec539936b96e84fabb91e5db", 3208092),
 	DT_ENTRY1("signalerror", "111116", "739510541192f01467b319b70ed7bf1f", 2138394),
-	DT_ENTRY1("libreriasix", "170723/Demo", "2d1fdfe386c08fdacd620b7497bcd88f", 8661160),
-	DT_ENTRY1("libreriasix", "200914/Demo", "e62655c358677fd4b17e0f2ed1587a86", 8661788),
+	DT_ENTRY1("libreriasix", "000927/Demo", "79cc859f9d84e701715dead61f386318", 217250),
 	DT_ENTRY1("skmmc", "150116", "46aee190f69d75592d72b1e3c573b6a8", 831452),
 	DT_ENTRY1("skmmc", "210225", "79ed9814187c89fb036a622e9e935cc4", 840668),
 	DT_ENTRY1("skugalake", "23????", "1d5b685c36c3e65e1eec7fa7f6a7398c", 1956132),
 	DT_ENTRY1("slouchbedlam", "140613", "c3ee4e636fb1ef2a0438dc3a08d4c1eb", 982754),
 	DT_ENTRY1("smittenkittens", "160816", "c3402d5d8b94675af5e3e0069366d4fd", 1240942),
+	DT_ENTRY1("sobrevive", "120116/v1", "9dbb27aa8e02dad0e3a7eeebfb6fa41f", 3591036),
+	DT_ENTRY1("sobrevive", "120116/v2", "81797e3609a2ac1d68ad6d18e3e40091", 3590012),
 	DT_ENTRY1("spaceship", "090928", "e52390cba328a8c863150ce4651fa71f", 1429732),
 	DT_ENTRY1("speedracer", "190617", "10d61f0fa2c3cbe122112f32d05e03a0", 613834),
 	DT_ENTRY1("spelunking2", "160617", "cea78493dd4dc54a8b3e01f73cc85d76", 1528034),
 	DT_ENTRY1("spirI7wrak", "141218", "d7e58b86d1c6e06ecdc83ebbb7b20242", 2631214),
 	DT_ENTRY1("starlight_glulx", "151119", "ee4d2ed91518392981bf3cfd0fcf644d", 885152),
+	DT_ENTRY1("station9", "151020", "258ed781320fdc23f8d38491ea719736", 720278),
 	DT_ENTRY1("stew", "201110", "a76e3b32917f42796c0b0d2cb5e3644d", 783486),
+	DT_ENTRY1("stormonboard", "180315", "c250320bc1280d67551b3e3074e09de2", 656888),
+	DT_ENTRY1("stretchlimo", "190530", "ed829978186c8fcc89d3636981d91bae", 810586),
+	DT_ENTRY1("sunlight", "150822", "e6e1ecccffec97b7ffe42a1463058bae", 699370),
 	DT_ENTRY1("superluminal", "160316", "7beb275a3e66b7b9840019caa3041723", 1162788),
+	DT_ENTRY1("survive_glulx", "120116/v1", "3557857576cdb150b9fc187ab2a9a195", 693836),
+	DT_ENTRY1("survive_glulx", "120116/v2", "f12286ec445006dca4f458fd6527c8c7", 693068),
 	DT_ENTRY1("tacofiction", "130422", "766be6495cb312d8270587c4d45d7e6a", 1928530),
 	DT_ENTRY1("take", "161012", "86add6a232eb106a9731795bdb905df8", 689732),
 	DT_ENTRY1("take", "190912", "9efe841949980cc88d670c055ded479c", 710724),
 	DT_ENTRY1("tangledtowertales", "201031", "1d0490125ca4706eea233bc83b57065a", 660390),
 	DT_ENTRY1("tblw_glulx", "121030/ulx", "be3811744ecd7fbcf9024dc116029330", 477440),
-	DT_ENTRY1("tcom", "121103/v1", "24feef55d07cc46bcc5479ce580cbe3e", 246272),
-	DT_ENTRY1("tcom", "121103/v2", "67504ebc3d525f6a29fa800b6e12229d", 326226),
+	DT_ENTRY1("tcom", "121103/gblorb", "67504ebc3d525f6a29fa800b6e12229d", 326226),
+	DT_ENTRY1("tcom", "121103/ulx", "24feef55d07cc46bcc5479ce580cbe3e", 246272),
 	DT_ENTRY1("terminatorchaser", "150315", "ac10ba4e7d15ebe4262cb3b9d683ef12", 1698614),
+	DT_ENTRY1("terrorunder", "160214", "28ccee6d403e7c591b2774ab7dfc5cef", 646308),
 	DT_ENTRY1("theabbey", "080626", "3abcc1b85a36efb73815e1cd37143210", 645274),
 	DT_ENTRY1("theabsenceoflaw", "170102", "210e6dc1d5c0fc1f4340ae9ee5bdcf4e", 1332522),
 	DT_ENTRY1("theargument", "100930", "8e9ce765f4224ddede6a911e9b9cd213", 453980),
 	DT_ENTRY1("thebigfall", "210624", "4fcfb19c283e3860aa463dd9e3a77263", 1342530),
 	DT_ENTRY1("thebigfall", "210711", "dad981d1fde0f573fd7c4b4d2652ca69", 1389634),
 	DT_ENTRY1("thebigfall", "210814", "7b5f8df5b909e2ca49ab7aedf1661f56", 1389378),
+	DT_ENTRY1("thebox", "160720", "cc286c87678e99e8c3c8ec929d90f929", 1371546),
 	DT_ENTRY1("thebox", "170813", "91ec66de5a2b6d9e9e889835857c03e7", 1371546),
 	DT_ENTRY1("thefourthriddle", "181228", "07f018d38c164615890adc44855fb15b", 1281176),
 	DT_ENTRY1("thefourthriddle", "19????", "542b3d3226a06eebfc5b2c15f90006c2", 1282708),
@@ -1619,6 +1718,7 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("tohellinahamper", "170412", "f12baa1762e29c9528baec31347a18b0", 973550),
 	DT_ENTRY1("tohellinahamper", "191217", "40cccc5fcce65c03e41dfa664487de10", 1978492),
 	DT_ENTRY1("tohellinahamper", "220307", "a026cda26522215f00a21915cdd8be3f", 1980028),
+	DT_ENTRY1("trenton", "191115", "d0a34ca27034f1cbc529b803c7af8c56", 1974446),
 	DT_ENTRY1("trialofthetnuop", "170813", "d8a34dc6c9b0e2d037d8cc3de006f42b", 616062),
 	DT_ENTRY1("trollslayer", "151112", "fa3dee31c195732ad6a13a6e0b54d625", 920230),
 	DT_ENTRY1("tryagain", "160922", "64de60e3dbc7eb492a34a0a693156659", 626116),
@@ -1634,10 +1734,18 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("valleyofsteel", "150905", "51ed5b33ecc8d7d461ab769464e9345b", 1853536),
 	DT_ENTRY1("veryvile_glulx", "191112", "95221a549e608bd2ed7f2b450abe44f1", 758774),
 	DT_ENTRY1("walking", "200626", "0a8f6530e5a619ad9e0764a645e8404d", 822256),
+	DT_ENTRY1("welcomerr", "?????\?/v1", "4a2d0c64e65db84c4a27e0e874be4bf5", 647576),
+	DT_ENTRY1("welcomerr", "?????\?/v2", "747fcc1b4f944deb122dc47175e372f4", 632216),
+	DT_ENTRY1("welcomerr", "?????\?/v3", "6f22d9d651dbb259b26f9dfda553b545", 632216),
+	DT_ENTRY1("welcomerr", "?????\?/v4", "b345f9fd7663280ef0c464da582d511b", 648088),
+	DT_ENTRY1("welcomerr", "?????\?/v5", "ad8f06ea028f49f3b68ef148b9caadfc", 646040),
+	DT_ENTRY1("whenrome", "201217", "40bff7c2c115218c183e0537ff5bb6f0", 1112940),
+	DT_ENTRY1("whenrome2", "201217", "8e648a0e20508da4364b488a71e0b812", 1110566),
 	DT_ENTRY1("whitehouses", "140613", "a23e7e70964bfafbd9a491f7a1afd56e", 714240),
 	DT_ENTRY1("winterstormdraco", "150928/v1", "b4835af78525e56420f138c2e5f6806c", 812124),
 	DT_ENTRY1("winterstormdraco", "150928/v2", "9dec2d8a67e575d66a378ede00d58804", 811868),
 	DT_ENTRY1("wishertheurgist", "160708", "4bbe0b3a29d57d1428e6cd6cf7c97fce", 824204),
+	DT_ENTRY1("wizardsniffer", "170928", "7771f0f04fe2c2aa81d05f2f2832b027", 1238732),
 	DT_ENTRY1("wizardsniffer", "171007", "834fbcad9b93f6fab461ad4b8ff48bb5", 1240012),
 	DT_ENTRY1("wof", "100515", "7de6ef1ecdec5066f65b1283b9203dc6", 10185552),
 	DT_ENTRY1("wolfsmoon", "19????", "0da312872d3eee662404392acc0ec75b", 6976802),
@@ -1727,6 +1835,8 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("if11_tacofiction", "111009", "c0338f36c652d48a77380c95b8eec508", 1944464),
 	DT_ENTRY1("if11_six", "110930", "499fbc129639b4653928326f19e61c0a", 8819288),
 	DT_ENTRY1("if11_six", "120805", "2705921eee09a568959584be1929b6b7", 8663464),
+	DT_ENTRY1("if11_six", "170723", "2d1fdfe386c08fdacd620b7497bcd88f", 8661160),
+	DT_ENTRY1("if11_six", "200914", "e62655c358677fd4b17e0f2ed1587a86", 8661788),
 	DT_ENTRY1("if11_patanoir", "110925", "cbdfc2d2cbffdd5137afa6843666344b", 793140),
 	DT_ENTRY1("if11_patanoir", "111201", "e03b27c359d71d7794ef68efe1952a72", 813876),
 	DT_ENTRY1("if11_doctorm", "110930", "3df7bf1234c74bc035370fe8fb800707", 1289106),
@@ -1800,6 +1910,7 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("if14_transparent", "150401", "3f4e5effb8ed8f4d0c3f277bb47ba161", 11084272),
 	DT_ENTRY1("if14_transparent", "150626", "13dc495dc3ed802e663b193bd862b994", 2284454),
 	DT_ENTRY1("if14_uglyoafs", "140928", "cdd8fcdc5057dedabda23df19ff5de46", 604552),
+	DT_ENTRY1("if14_uglyoafs", "141026", "a493c30460fd7de08ff38b10bdc1e5f3", 643182),
 	DT_ENTRY1("if14_uglyoafs", "150403", "39ba113801d9b90d506b356f6b3ba25a", 660078),
 	DT_ENTRY1("if14_jessedoorway", "140927", "f950714c28edfd199f8bc275be7e1018", 1187326),
 	DT_ENTRY1("if14_andyetitmoves", "140925", "137ddc2c132b6d86232f96af7698b2f4", 941732),
@@ -1826,6 +1937,7 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("if15_shireton", "151108", "eacf822d45454421f6c17b5249f52eab", 1170886),
 	DT_ENTRY1("if15_gotomomi", "150927", "242aaef8bfd5a1938063e326689e85d5", 1149914),
 	DT_ENTRY1("if15_gotomomi", "151020", "343bcf1cce9f5faf14ac37e067148ccb", 1156708),
+	DT_ENTRY1("if15_gotomomi", "151119", "c1cd7ca62a0d739866e648788cad6d51", 1158756),
 	DT_ENTRY1("if15_probcompound", "150928", "5dca1e6de048865163fae9d23dd3da1b", 785086),
 	DT_ENTRY1("if15_probcompound", "151108", "f9296f3c83eefaad4768a41bd8adb7da", 796862),
 	DT_ENTRY1("if15_probcompound", "160330", "e8f9773c2d960c6fc9c21a1d1e6a99a9", 1111230),
@@ -1875,6 +1987,7 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRY1("if17_wordoftheday", "171015", "a5d8c17ca616bd51c58182768be5c378", 4550570),
 	DT_ENTRY1("if17_wordoftheday", "171129", "c45a9d68e80765ceff7654366fa47328", 4506970),
 	DT_ENTRY1("if17_wordoftheday", "171217", "8379d1196518774873e24b5b60fa863f", 4506970),
+	DT_ENTRY1("if17_wordoftheday", "180101", "aa01631b6f288cf5c55f5a640974e124", 4506970),
 	DT_ENTRY1("if17_swigian", "170928", "6056cefcbb2e9e59408591108cf82c62", 785090),
 	DT_ENTRY1("if17_swigian", "171022", "a43957d757dabcd30e0274f2e83e21e6", 789186),
 	DT_ENTRY1("if17_castlethread", "170928", "c86947230252a4129bb21e2f9a29a828", 1328210),
@@ -1889,6 +2002,10 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 
 	// IFComp 2018
 	DT_ENTRY1("if18_aliasmagpie", "180928", "3e5628127d58133a9d761068f68d878a", 1814004),
+	DT_ENTRY1("if18_aliasmagpie", "181017", "783cf48cbd582f6f169880f50792c163", 1815796),
+	DT_ENTRY1("if18_aliasmagpie", "190206", "a4281a03b797582ea53aa203b1eb7236", 1875956),
+	DT_ENTRY1("if18_aliasmagpie", "190616", "b5fb058f5af317bacff2aa6ade2ef7d6", 1717358),
+	DT_ENTRY1("if18_aliasmagpie", "220210", "1475b9fc5c4bb8b1e128b9bb255e238b", 1766254),
 	DT_ENTRY1("if18_arithmancer", "180829", "8e1b3192eacc54bc9a4fdf4e9484f1b7", 1340328),
 	DT_ENTRY1("if18_arithmancer", "181009", "a2be6e6f0b1369a6a2c6e1b679924ac6", 1340840),
 	DT_ENTRY1("if18_arithmancer", "181118", "3382a778cea8f9f6b863f68df1cacdef", 1342888),
@@ -2352,7 +2469,8 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	// Spring Thing 2021 - Main Festival
 	DT_ENTRY1("stc21_weightsoul", "210411", "8b185707d6f9d2717e2e174cf2b85bd4", 7355482),
 	DT_ENTRY1("stc21_baggage", "210420", "8a9ef5d1f024ad5da0511e9daa8c2718", 708860),
-	DT_ENTRY1("stc21_meantucker", "210319", "3347b37ec08d1d3a465904cd49c01302", 1041210),
+	DT_ENTRY1("stc21_meantrucker", "210319", "3347b37ec08d1d3a465904cd49c01302", 1041210),
+	DT_ENTRY1("stc21_meantrucker", "210404", "32d5ec569f116f3736fbf5b6456d9c85", 1051706),
 
 	// Spring Thing 2021 - Back Garden
 	DT_ENTRY1("stc21_shorofcash", "210328", "5e2b63af2799df4644413f8827eb4a4b", 721126),
@@ -2391,12 +2509,12 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRYL1("astressolitaires", Common::FR_FRA, "210324", "20c40a53ee276ff877350f5e3e94e8f4", 2485834),
 	DT_ENTRYL1("ekphrasis", Common::FR_FRA, "050718/v1", "009ca5994d9e8fe6cfb400a9da00b123", 64609308),
 	DT_ENTRYL1("ekphrasis", Common::FR_FRA, "050718/v2", "edf22f51cb1ddb6775127f5c1f4d389a", 64609308),
-	DT_ENTRYL1("fautedeservo", Common::FR_FRA, "180106", "9746a5c59bc0f160b8553781479afb3e", 926096),
 	DT_ENTRYL1("kebabhante", Common::FR_FRA, "171022", "3e739bd3062390e6ce87022aa772de29", 219392),
 	DT_ENTRYL1("latempete", Common::FR_FRA, "230109", "42122cf49a8d6aee9e91ee949108c408", 1169304),
 	DT_ENTRYL0("lieuxcommuns_glulx", Common::FR_FRA, "6e18273de25a0b882b0cf01770003146", 15659070),
 	DT_ENTRYL1("lieuxcommuns_glulx", Common::FR_FRA, "090606", "df7add410161b8a2093b61e2efb7b68f", 14870456),
 	DT_ENTRYL1("petitgnome_glulx", Common::FR_FRA, "061101/gblorb", "a996d5c798c97965f5487ea0a14bea8c", 316422),
+	DT_ENTRYL1("rendezvous", Common::FR_FRA, "071110", "1dd21be086c115179fb26dbe00d89bac", 9563714),
 	DT_ENTRYL1("sarvegne_glulx", Common::FR_FRA, "061022/blb", "3238e643504cdfa3acbeda7d99fa5d26", 591068),
 	DT_ENTRYL1("sarvegne_glulx", Common::FR_FRA, "061101/blb", "518ab27b773bb51f57c6526655f38e6f", 594306),
 	DT_ENTRYL1("scarabeekatana", Common::FR_FRA, "070906", "e2ca97ca5579b544765e744964c9624f", 651590),
@@ -2405,22 +2523,23 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRYL1("templefeu", Common::FR_FRA, "070731", "73c3a0486d41a41c454108298014fac0", 2576096),
 	DT_ENTRYL1("tourorastre", Common::FR_FRA, "170802", "6c7c91ec162a1b2fd5e23d9d6fc79193", 1664626),
 
-	// French Comp 2007
+	// French Comp 2007 (French)
 	DT_ENTRYL1("frc_souterraine", Common::FR_FRA,"071227", "504942416635dd03d4d30ba88dd8f4e4", 2709508),
 	DT_ENTRYL1("frc_ilephare_glulx", Common::FR_FRA, "071220/blb", "3e25bff50b9e333474ecfb5d6a362656", 3395902),
 
-	// French Comp 2008
+	// French Comp 2008 (French)
 	DT_ENTRYL1("frc_survivre", Common::FR_FRA, "081122", "2840c7831b55d88ca93ef40b83c8612b", 1006394),
 
-	// French Comp 2013
+	// French Comp 2013 (French)
 	DT_ENTRYL1("frc_noirdencre", Common::FR_FRA, "140110", "bdaf2ed62da378fb178d95269b3a46e0", 3427824),
 
-	// French Comp 2015
+	// French Comp 2015 (French)
 	DT_ENTRYL1("frc_sourire", Common::FR_FRA,"150201", "491aa8e98ac471c5e1b5713e135c5ecf", 783616),
 	DT_ENTRYL1("frc_comedie", Common::FR_FRA,"150201", "2f8089c76a46e1c6d74fcda950649680", 843520),
 
-	// French Comp 2018
-	DT_ENTRYL1("frc_fauteservo", Common::FR_FRA,"180107", "15caa46facfae8417c855c41e4dbfb45", 1101762),
+	// French Comp 2018 (French)
+	DT_ENTRYL1("frc_fauteservo", Common::FR_FRA, "180106", "9746a5c59bc0f160b8553781479afb3e", 926096),
+	DT_ENTRYL1("frc_fauteservo", Common::FR_FRA, "180107", "15caa46facfae8417c855c41e4dbfb45", 1101762),
 	DT_ENTRYL1("frc_latempete", Common::FR_FRA, "200813", "f983ef39032a8d932cf91e7fa25effbb", 1158808),
 
 	// German games
@@ -2447,18 +2566,18 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRYL1("sonntagnachmittag", Common::DE_DEU, "141114", "762c003565858d952a21ac81904670e2", 712716),
 	DT_ENTRYL1("spaterbesuch", Common::DE_DEU, "191013", "24bd852ecb47a6f01cdaa9be80195f4a", 9608754),
 
-	// Textfire Grand Prix 2005
+	// Textfire Grand Prix 2005 (German)
 	DT_ENTRYL1("tgp_bananerepublik", Common::DE_DEU, "050330", "dad950c45fb67d80fc37aa716e88d9bb", 368640),
 
-	// Textfire Grand Prix 2010
+	// Textfire Grand Prix 2010 (German)
 	DT_ENTRYL1("tgp_ares", Common::DE_DEU, "110517", "4dfe7cfab60e04a9030ba56c97579c0a", 3313846),
 
-	// Textfire Grand Prix 2011
+	// Textfire Grand Prix 2011 (German)
 	DT_ENTRYL1("tgp_roteblum", Common::DE_DEU, "110331", "8e752fdcaa3e9f051ff50535e2c8f18e", 1038772),
 	DT_ENTRYL1("tgp_schiesbefehl", Common::DE_DEU, "110311", "c9551891b01c10be5f1aa214be17a0ef", 236544),
 	DT_ENTRYL1("tgp_schiesbefehl", Common::DE_DEU, "131119", "200bc928fd7a028e755de4d962c2e054", 448458),
 
-	// Textfire Grand Prix 2014
+	// Textfire Grand Prix 2014 (German)
 	DT_ENTRYL1("tgp_treffen", Common::DE_DEU, "140331", "e395219a697b34fbbcb90ed03bf35a5b", 1727130),
 	DT_ENTRYL1("tgp_dersigkeitenlad", Common::DE_DEU, "140401", "3dd57df785437293386076a062a7a415", 1619138),
 
@@ -2479,23 +2598,26 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRYL1("erisvalle", Common::IT_ITA, "230114/v2", "add2a8d7f04cb8349fc1a9dcc283834b", 2504172),
 	DT_ENTRYL1("fugacropoli_glulx", Common::IT_ITA, "170417/ulx", "a1854b697a364c6086821cbe5cfe00c5", 150528),
 	DT_ENTRYL1("giardino_glulx", Common::IT_ITA, "200415/ulx", "3a3c8479551b3fac3b78e6720e053013", 177152),
+	DT_ENTRYL1("kinesis", Common::IT_ITA, "071118", "b2a460f98c17b21ef61f75a211284e2e", 537594),
 	DT_ENTRYL1("littlefalls_glulx", Common::IT_ITA, "050527/blb/v1", "61fa3eeb8554067bee261a8b25d5b6df", 8893090),
 	DT_ENTRYL1("littlefalls_glulx", Common::IT_ITA, "050527/blb/v2", "1923cbbc755224dc294bba1f69c345da", 2789836),
 	DT_ENTRYL1("lucifinanza_glulx", Common::IT_ITA, "200529/ulx", "bcdbbbd18205671cb54e57a57ff0eb46", 162304),
+	DT_ENTRYL1("marconi_glulx", Common::IT_ITA, "150606", "3193874e690914db034362d6b9741957", 2285090),
 	DT_ENTRYL1("ormechisciano", Common::IT_ITA, "1507??", "e6fc43637dc4777f89058fda2c0c4b84", 3747600 ),
 	DT_ENTRYL1("ormechisciano", Common::IT_ITA, "1507?\?/Corrupt", "065bae91b36289e95f166774537865d1", 68965774 ),
 	DT_ENTRYL1("ormechisciano", Common::IT_ITA, "1512??", "fc39fb3bfd0413db6c248363d1247476", 3748624 ),
 	DT_ENTRYL1("ormechisciano", Common::IT_ITA, "1512?\?/Corrupt", "15813602f622f0f576f118df5d57096e", 68959282 ),
-	DT_ENTRYL1("pietraluna_glulx", Common::IT_ITA, "110106", "8834e0273fc730b8f6dcd38bbba2894d", 1060656),
+	DT_ENTRYL1("pietraluna_glulx", Common::IT_ITA, "110106/gblorb", "8834e0273fc730b8f6dcd38bbba2894d", 1060656),
 	DT_ENTRYL1("pietraluna_glulx", Common::IT_ITA, "120206/gblorb", "0c124b7c9d8c34183ce57ed17051ff5e", 1061462),
+	DT_ENTRYL1("pietraluna_glulx", Common::IT_ITA, "170801", "32c4b45f10cf8aa4ae1ba4def720522b", 1061206),
 	DT_ENTRYL1("perlesaggezza", Common::IT_ITA, "090704/gblorb", "20f9897448cdbfb9b08168063d8635b8", 2625430),
 	DT_ENTRYL1("perlesaggezza", Common::IT_ITA, "090704/ulx", "4455ac5a92b6022d17d062e342aa5a48", 758784),
 	DT_ENTRYL1("perlesaggezza", Common::IT_ITA, "091120", "24db1f7186ac2cce1f28d1557caa366f", 2640022),
 	DT_ENTRYL1("poesia_glulx", Common::IT_ITA, "398874/blb", "de6d58b378dee41d273f7bb3c5da4220", 978440),
 	DT_ENTRYL1("romamisteriosa", Common::IT_ITA, "151029/v1", "38d06ceb33d122d4cfaea69503b68980", 3754804),
 	DT_ENTRYL1("romamisteriosa", Common::IT_ITA, "151029/v2", "e9ad5c1585fb4f7ceff8ba5d4f9db1bf", 3754804),
-	DT_ENTRYL1("schizo", Common::IT_ITA, "180907/v1", "3531f6066802f53f9b095b5221fac4d2", 6198900),
-	DT_ENTRYL1("schizo", Common::IT_ITA, "180907/v2", "30ff0bffbe7e1c11ea4a7ec30e0b8c76", 194560),
+	DT_ENTRYL1("schizo", Common::IT_ITA, "180907/blb", "3531f6066802f53f9b095b5221fac4d2", 6198900),
+	DT_ENTRYL1("schizo", Common::IT_ITA, "180907/ulx", "30ff0bffbe7e1c11ea4a7ec30e0b8c76", 194560),
 	DT_ENTRYL1("sfidaignoto", Common::IT_ITA, "200425", "10acc6e8bc7a810d73d296c159cd4cc0", 130048),
 	DT_ENTRYL1("slenderman", Common::IT_ITA, "140721/v1", "6765e1c656f4dd1af25235bc9b11585c", 1156562),
 	DT_ENTRYL1("slenderman", Common::IT_ITA, "140721/v2", "b6a73057d3ff8e54011eab2556c2332c", 13465166),
@@ -2513,11 +2635,12 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRYL1("tesla_glulx", Common::IT_ITA, "160613/ulx", "5fe9377dba7797a7dadd706254b764f4", 137216),
 	DT_ENTRYL1("umbrarumregni", Common::IT_ITA, "10????", "8b74a3f0248a5a8bb223fd39027a53ce", 2068748),
 	DT_ENTRYL1("villamorgana_glulx", Common::IT_ITA, "090404", "88feac9efb31e7e6bd832bda02ff0cfa", 1263196),
+	DT_ENTRYL1("villamorgana_glulx", Common::IT_ITA, "210728", "0dfa29ce8c655acb8653317efe5cf687", 829234),
 	DT_ENTRYL1("vita_glulx", Common::IT_ITA, "161803/ulx", "c22bc96b208bb64548134be10e903fcf", 229376 ),
 	DT_ENTRYL1("volonta_glulx", Common::IT_ITA, "150624/ulx", "d8f132e49637a76c3710a1c1725f2e44", 254720 ),
 	DT_ENTRYL1("zigamusita_glulx", Common::IT_ITA, "200426/ulx", "3f3fc6623b64f99f2e845c2c5f83e375", 143616 ),
 
-	// Marmellata d'Avventura 2018
+	// Marmellata d'Avventura 2018 (Italian)
 	DT_ENTRYL1("parcochuddy", Common::IT_ITA, "180401", "c36099356e69e3e0eb9e99952e455946", 871778 ),
 	DT_ENTRYL1("dejavu_glulx", Common::IT_ITA, "1803311/ulx", "577c6f704ae5ae3dfbc0326600abd982", 161024),
 	DT_ENTRYL1("cosmicmatryoshka", Common::IT_ITA, "180401", "e490055615289f8e0aaf1da15dd5c8a9", 928886),
@@ -2527,7 +2650,7 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRYL1("bouvet", Common::IT_ITA, "210810/ulx", "19b24981cd929f4cd3f995818053fd17", 129024),
 	DT_ENTRYL1("baseantartica", Common::IT_ITA, "180401", "e717639352a925c00e854f8b7be47e48", 1367494),
 
-	// Marmellata d'Avventura 2019
+	// Marmellata d'Avventura 2019 (Italian)
 	DT_ENTRYL1("piccolopopolo", Common::IT_ITA, "191208", "c89929157dfcccf2f75de717ad7b5c63", 3189740),
 	DT_ENTRYL1("fregatogettoni", Common::IT_ITA, "140721/v1", "aec497cc0bf37a6f1055837ce13d513a", 6763760),
 	DT_ENTRYL1("fregatogettoni", Common::IT_ITA, "140721/v2", "76de0882951804bc1c4daa9c2d90dc41", 1041518),
@@ -2536,35 +2659,71 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRYL1("george_glulx", Common::IT_ITA, "191209", "99ab71b1be78930945dcb33c884e4e3e", 884736),
 
 	// Spanish games
+	DT_ENTRYL1("abismo_glulx", Common::ES_ESP, "012002", "cab1ccde1583cac6eddf650a7bad8f4e", 133530),
 	DT_ENTRYL1("acman", Common::ES_ESP, "020826", "e8c4e178d0c9c2521cdf9aa31c5ea622", 168278),
+	DT_ENTRYL1("acuario_glulx", Common::ES_ESP, "120121", "265f0f32579dd010ae4b6f994e37747d", 1354890),
+	DT_ENTRYL1("acuario_glulx", Common::ES_ESP, "120122", "ee28af0187a7e172568135bcef8402f1", 1355658),
 	DT_ENTRYL1("bajando", Common::ES_ESP, "001003", "f8edfd70eec40e18c1680ea3f6c1525b", 150016),
+	DT_ENTRYL1("cajadecerillas", Common::ES_ESP, "100804", "657479f71ccb42576f6ba97b7786c79e", 152320),
+	DT_ENTRYL1("cajacerillek", Common::ES_ESP, "100226", "9e05b4f475b0524c8cccdd0ef19dad13", 179756),
+	DT_ENTRYL1("cangrejo", Common::ES_ESP, "120817", "a537f7fbf44c5528c079d47532103d79", 1035392),
+	DT_ENTRYL1("ciuthan", Common::ES_ESP, "010924", "20483609321614bf6345e37eacba1c83", 823736),
+	DT_ENTRYL1("comodiablo", Common::ES_ESP, "071220", "946a9ac0338609bf1cf51b80323db101", 3638848),
 	DT_ENTRYL1("conrumbo_glulx", Common::ES_ESP, "010527", "024946d9d10190694d90dedd34ab648e", 127744),
 	DT_ENTRYL1("copernico86", Common::ES_ESP, "200515", "1251b6503a701d07aaff21d1b2059567", 1101844),
 	DT_ENTRYL1("cumpleanos", Common::ES_ESP, "130406", "d0bd4eff1c203b29bee74285d9277e76", 151296),
+	DT_ENTRYL1("dagon_glulx", Common::ES_ESP, "09????", "ff9a0dc313bda0a27e71bd79fcc157f8", 2716310),
 	DT_ENTRYL1("discos", Common::ES_ESP, "001003/Demo", "86db5ba5e7472e7377ea0a828a4bfe60", 471420),
 	DT_ENTRYL1("dracula1_glulx", Common::ES_ESP, "071227", "a2266f816a8e6afa324ad98e8ddb707b", 467354),
 	DT_ENTRYL1("dracula2_glulx", Common::ES_ESP, "080819", "c9ff350c10f4ef88db667e58a3696938", 715450),
 	DT_ENTRYL1("dwight_glulx", Common::ES_ESP, "041108", "e88efb47bc4feb5b8131c970d0560989", 310786),
 	DT_ENTRYL1("dwight_glulx", Common::ES_ESP, "150211/blb", "3921f994e736f61d0b431d930e3d54f9", 301314),
+	DT_ENTRYL1("elcristalrojo", Common::ES_ESP, "100413", "2a89d8567019164d9fb8bd0f1233a6e3", 5207024),
 	DT_ENTRYL1("eldiadespues", Common::ES_ESP, "120115", "a6cd3450877db0ab30da0627066fc811", 1637516),
+	DT_ENTRYL1("elhobbit", Common::ES_ESP, "????", "bbc16dd8ea07363892a3709ded4e4658", 359328),
 	DT_ENTRYL1("elultimojedi", Common::ES_ESP, "130728", "5f4ba8e224a52ee94e49842d577c2276", 74312818),
 	DT_ENTRYL1("ensaladasensorial", Common::ES_ESP, "000925", "a841d6881143763412425150073e1fa5", 225042),
 	DT_ENTRYL1("entrevista", Common::ES_ESP, "??????", "3addab0d41a396a874dc15661a8a858c", 3626570),
 	DT_ENTRYL1("ergotdelima_glulx", Common::ES_ESP, "200614", "aaff81fb2288f59fc9a298ab1f08efb1", 806892),
+	DT_ENTRYL1("escapedoom", Common::ES_ESP, "170402", "4afc4fd9de99e688ec859a619b1eec7d", 10961896),
+	DT_ENTRYL1("estacion_glulx", Common::ES_ESP, "071222", "ea97b832d688fe0427ae1b91d32a748c", 602232),
+	DT_ENTRYL1("estacion_glulx", Common::ES_ESP, "080126/gblorb/v1", "1467f18274a293f872213ee5a2a2c592", 191216),
+	DT_ENTRYL1("estacion_glulx", Common::ES_ESP, "080126/gblorb/v2", "b6dc19540872b6759a083ad7502a2096", 837712),
+	DT_ENTRYL1("estacion_glulx", Common::ES_ESP, "080126/blb", "f45bf08dc212c39f3b104b1a294a3645", 646520),
 	DT_ENTRYL1("finmortal", Common::ES_ESP, "120728", "2ba86956f81c34b669af3fdedc8611a7", 9708920),
+	DT_ENTRYL1("genio", Common::ES_ESP, "120817", "90ab8e97a47f0e160fbbcec41b790438", 1316880),
 	DT_ENTRYL1("globitoscolores", Common::ES_ESP, "111003", "af6cd29cef8ab1a6dee43953a4ed4dac", 125184),
 	DT_ENTRYL1("graffi", Common::ES_ESP, "131102", "e265cb7a45e88b316f2f583e5fb9c3e6", 2139526),
-	DT_ENTRYL1("historiashampa", Common::ES_ESP, "120621", "355713215a36ea8b4ac86789222a0119", 452864),
+	DT_ENTRYL1("grutahorror", Common::ES_ESP, "150603/Demo", "6de4254acadf5f063dd6211ed3d5a47b", 149248),
+	DT_ENTRYL1("hampa_glulx", Common::ES_ESP, "120621/ulx", "355713215a36ea8b4ac86789222a0119", 452864),
+	DT_ENTRYL1("jugueteria", Common::ES_ESP, "020817", "90842ec41139955b18c3ece1b8067e57", 1960450),
+	DT_ENTRYL1("kavija", Common::ES_ESP, "120817", "404884b4bae0eb4276118b6c8e7b1e99", 783574),
 	DT_ENTRYL1("laarana", Common::ES_ESP, "??????", "f5c36a907d84f0d12cf5cdded93abec9", 370024),
 	DT_ENTRYL1("lacaja", Common::ES_ESP, "111003", "fd6c8b12a73037cd4eb40f19b0551202", 106496),
 	DT_ENTRYL1("lanochedelensayo", Common::ES_ESP, "100122", "23845407e62d47b5d51267492137e05e", 2527892),
-	DT_ENTRYL0("legado", Common::ES_ESP, "3f5652cfb07d22c1cf668c33fc92a611", 513472),
+	DT_ENTRYL1("lastumbas", Common::ES_ESP, "??????", "0ebc4429452015a77265b168103b65b5", 1221252),
+	DT_ENTRYL1("latorre_glulx", Common::ES_ESP, "050702/ulx", "5595ff08e43ff22ad0e1b1f3f8ece823", 156160),
+	DT_ENTRYL1("lazona", Common::ES_ESP, "?????\?/Corrupt", "a4142e82e481828103db5300ac20ca6e", 37133834),
+	DT_ENTRYL1("legado", Common::ES_ESP, "090520/gblorb", "5613d785c8654580568d0c8684073901", 534634),
+	DT_ENTRYL1("legado", Common::ES_ESP, "090520/blb", "c514b3ff34a6fed92551e260f5b006fb", 533444),
+	DT_ENTRYL1("legado", Common::ES_ESP, "090520/ulx", "8c1699b68bb1a18d7ec3845dd7b3eb96", 77056),
+	DT_ENTRYL1("legin", Common::ES_ESP, "?????\?/v1", "c7ee0051f293b520aad4c46e5530f783", 169004),
+	DT_ENTRYL1("legin", Common::ES_ESP, "?????\?/v2", "f3e28b8acd49224717a3b55e035f9cce", 170284),
+	DT_ENTRYL1("mapa_glulx", Common::ES_ESP, "010711", "9a57b0f2bcbdb19fe1ff408120ccbb57", 115968),
+	DT_ENTRYL1("matrioska", Common::ES_ESP, "110712", "6ff2e610ac6635bc5d4ecf9923abc4c1", 126464),
+	DT_ENTRYL1("matrioskabamo", Common::ES_ESP, "110701", "96977ed3270acc7ae25e83f010aad894", 163628),
+	DT_ENTRYL1("matrioskabamo", Common::ES_ESP, "110803", "e5cba4bf1184f549174d9a1956c48b6e", 164396),
 	DT_ENTRYL1("mcarras", Common::ES_ESP, "050611", "c3538b22b71c9a31459bbdd3fc40b5d0", 3123192),
 	DT_ENTRYL1("megacorp2", Common::ES_ESP, "??????", "3d0e2115028077310339e38e4bf1be1d", 7410334),
+	DT_ENTRYL1("memorias_glulx", Common::ES_ESP, "020613", "fce09dac0a9f8b1f89745256561f6f97", 350502),
 	DT_ENTRYL1("memorias_glulx", Common::ES_ESP, "020613", "fce09dac0a9f8b1f89745256561f6f97", 350502),
 	DT_ENTRYL1("mono3cartes", Common::ES_ESP, "020826", "06dbeb486ced4e536d421672f8bb51f5", 202934),
 	DT_ENTRYL1("moria", Common::ES_ESP, "021203", "81fb5e199a0c489fc9536712cdf55b6a", 454868),
 	DT_ENTRYL1("multivampi7", Common::ES_ESP, "090119", "76fb8bc371977cbb913976798bb127d9", 465572),
+	DT_ENTRYL1("naufrago", Common::ES_ESP, "0905?\?/blb", "a9ec28492bc5b35a19e5a90c5c5104fd", 1606162),
+	DT_ENTRYL1("naufrago", Common::ES_ESP, "0905?\?/gblorb", "89094d8c109f8c22f22b774438cd4063", 1607340),
+	DT_ENTRYL1("naufrago", Common::ES_ESP, "0905?\?/ulx", "d07e71d52a176a5b3fac727b9168b2d0", 103424),
+	DT_ENTRYL1("nocheinvierno", Common::ES_ESP, "081201", "a0dd89b16e442568ad7d70c5a59b905b", 3406904),
 	DT_ENTRYL1("nochemetro", Common::ES_ESP, "131030", "381433b6afecc1fee2884a6a9baa8291", 2618694),
 	DT_ENTRYL1("olvido_glulx", Common::ES_ESP, "030330", "cd8a286d63f5b9b3135519fc2880b9dd", 174848),
 	DT_ENTRYL1("olvido_glulx", Common::ES_ESP, "031103", "0790e71c1d76609a83db3b7285e55e55", 351894),
@@ -2572,12 +2731,27 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRYL1("ork2", Common::ES_ESP, "020826/Demo", "97aec59216c8710b76a1c561df3c58ce", 153344),
 	DT_ENTRYL1("osobipolar", Common::ES_ESP, "020826/Demo", "d1ffd264274337c94102ae000352d7a0", 209494),
 	DT_ENTRYL1("piratescharaibes", Common::ES_ESP, "120518", "5e4901d210d7f6b5cc250fd55757cf0b", 902092),
+	DT_ENTRYL1("poetico", Common::ES_ESP, "100726", "5cef1ef4ba7ca3c096bc4b3085ec4b1b", 3340694),
+	DT_ENTRYL1("pyat", Common::ES_ESP, "110717", "d469a072d7d24d689b5d4b2135d6cbb0", 1376246),
+	DT_ENTRYL1("relojes_glulx", Common::ES_ESP, "040509/ulx", "9c663cc32227d62040e59dbb3d31117a", 112640),
+	DT_ENTRYL1("saboteur", Common::ES_ESP, "120817", "c5281166d22a3b096e3aed2d7c69e544", 8761740 ),
 	DT_ENTRYL1("sgw_glulx", Common::ES_ESP, "070807/Demo/blb", "c60f60c8101eda644d33ce9bc2b49183", 396246),
 	DT_ENTRYL1("sgw_glulx", Common::ES_ESP, "070807/Demo/ulx", "29f996500209a2f8246f919ad2e7ade2", 158720),
-	DT_ENTRYL1("sixdemo", Common::ES_ESP, "000927", "79cc859f9d84e701715dead61f386318", 217250),
+	DT_ENTRYL1("sinsalida", Common::ES_ESP, "??????", "b50ac34b056f0a60d6b12e7f7c36c4b2", 397734),
+	DT_ENTRYL1("subterranea", Common::ES_ESP, "071225", "9259cedd2c3d6b8e0d5a4bf92a299f1a", 2678650),
+	DT_ENTRYL1("subterranea", Common::ES_ESP, "080626", "f2b9677691325a2991f6afd1e677546c", 2677626),
+	DT_ENTRYL1("subterranea", Common::ES_ESP, "160621", "9dec7e3ac1faa38b9589a19da8916428", 2677882),
+	DT_ENTRYL1("tiros_xx", Common::ES_ESP, "030111", "a1be4ffdbb0a088d0fa85788f3ec546a", 162816),
+	DT_ENTRYL1("tiros_xx", Common::ES_ESP, "030623", "70596067caeb3039ea34d3daeedadecc", 172032),
+	DT_ENTRYL1("ultimohogar_glulx", Common::ES_ESP, "021224", "28ca16f056e5ea7844012860016a1efa", 677912),
 	DT_ENTRYL1("ultimohogar_glulx", Common::ES_ESP, "021225", "08d4168a767dce4899640a000d2809d8", 663576),
+	DT_ENTRYL1("umami", Common::ES_ESP, "070807/blb", "e8cba9e025710bbbdd464b4b15c9baf4", 394562),
+	DT_ENTRYL1("umami", Common::ES_ESP, "070807/ulx", "6ac36d33f9bd4f31b54c8d01b3891957", 132096),
+	DT_ENTRYL1("vainsville", Common::ES_ESP, "160806", "392d69ae2125949e67416640274da60d", 1021280),
 	DT_ENTRYL1("vainsville", Common::ES_ESP, "220306", "7fd41aa7621e76a850477a5d8497b7da", 1022048),
+	DT_ENTRYL1("venenarius", Common::ES_ESP, "091130", "9d6a1b7fc5042b7a05ba056b9dd0b0d3", 382992),
 	DT_ENTRYL1("viejaantonieta", Common::ES_ESP, "130405", "f34e185cfcfb518d54f2d70357bf098f", 134144),
+	DT_ENTRYL1("yan", Common::ES_ESP, "120817", "4cb0ea54785ff0d4579448c1375f5f47", 10343538),
 
 	// XComp 2008 (Spanish)
 	DT_ENTRYL1("xc08_damusix", Common::ES_ESP, "080716/Demo", "c654432ff20ff06421f7ef46192d6a0e", 2307978),
@@ -2591,42 +2765,46 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	// Ectocomp 2022 - Le Grand Guignol (Spanish)
 	DT_ENTRYL1("ec22_estadop_glulx", Common::ES_ESP, "221027", "8bbf39eed65125accc5703be50ebbea4", 697134),
 
-	// Premios Hispanos 2002
+	// Premios Hispanos 2002 (Spanish)
 	DT_ENTRYL1("ph02_demoespacio", Common::ES_ESP, "020726", "6e915e11cf880dd56ac38f2cf3afa1af", 169472),
 	DT_ENTRYL1("ph02_insomnio", Common::ES_ESP, "020802", "2242057928285679d513ed01094c7503", 236372),
-	DT_ENTRYL1("ph02_legador", Common::ES_ESP, "021114", "40e4a7848e03e3671fb95debe64e42d3", 53504),
+	DT_ENTRYL1("ph02_insomnio", Common::ES_ESP, "021220", "d4cbd17217a483fdece3bd38bef9f711", 237396),
+	DT_ENTRYL1("ph02_legado", Common::ES_ESP, "021114", "40e4a7848e03e3671fb95debe64e42d3", 53504),
+	DT_ENTRYL1("ph02_legado", Common::ES_ESP, "030222/Corrupt", "3f5652cfb07d22c1cf668c33fc92a611", 513472),
 	DT_ENTRYL1("ph02_oder", Common::ES_ESP, "Corrupt", "07e6993cb70fdf3d794fec0cc47e89fa", 1175810),
 	DT_ENTRYL1("ph02_regente_glulx", Common::ES_ESP, "021129", "7c8608e214821c55bc9224ccfd5beb44", 273092),
 	DT_ENTRYL1("ph02_salondwight", Common::ES_ESP, "021116", "04d1af01052792915ed8a420ffd61663", 171010),
 
-	// Premios Hispanos 2003
+	// Premios Hispanos 2003 (Spanish)
 	DT_ENTRYL1("ph03_dioszaglx", Common::ES_ESP, "040107", "7a88c6cf9bfb9a7ffbcee11d1a8331c3", 270560),
 	DT_ENTRYL1("ph03_enterrado", Common::ES_ESP, "030222", "59f098c568c7d6272d3fc05a2719929c", 243532),
 	DT_ENTRYL1("ph03_enterrado2", Common::ES_ESP, "030222/Corrupt", "b8c699cbde3633752f404cf565ee0bd9", 1884292),
-	DT_ENTRYL1("ph03_quenoche", Common::ES_ESP, "031015", "a25e309fdb703009c8555eb28204582e", 831748),
+	DT_ENTRYL1("ph03_quenoche", Common::ES_ESP, "031015/blb", "a25e309fdb703009c8555eb28204582e", 831748),
+	DT_ENTRYL1("ph03_quenoche", Common::ES_ESP, "031015/gblorb", "aa01c058ab6b54ec92f9677b34c9ab77", 833128),
 	DT_ENTRYL1("ph03_sinsentido", Common::ES_ESP, "Corrupt", "d5bc98e9b81c886149de4cb62f399d75", 109568),
 	DT_ENTRYL1("ph03_zerogrados", Common::ES_ESP, "030319", "e4eb8c2faebee284c6e75efb63df9265", 1092752),
 	DT_ENTRYL1("ph03_dwight_glulx", Common::ES_ESP, "031115", "44aee922daacc3ae0a062e1e1a2c6fd2", 252930),
 
-	// Premios Hispanos 2004
+	// Premios Hispanos 2004 (Spanish)
 	DT_ENTRYL1("ph04_orfeo2", Common::ES_ESP, "040805", "66d2ceb53fcbea54c4743bd49f9fb46a", 805086),
 	DT_ENTRYL1("ph04_orfeo2", Common::ES_ESP, "051018", "617c18c7edc92cc3a5a2a621ab33e89c", 786910),
 	DT_ENTRYL1("ph04_primeranoche", Common::ES_ESP, "040731", "dd4d59714c464569696d0439ea5c359d", 473000),
-	DT_ENTRYL1("ph04_regente", Common::ES_ESP, "040830", "a8c731d15a03daa1ab66b83bd3683b1c", 364342),
+	DT_ENTRYL1("ph04_regente", Common::ES_ESP, "040830/blb", "a8c731d15a03daa1ab66b83bd3683b1c", 364342),
+	DT_ENTRYL1("ph04_regente", Common::ES_ESP, "040830/gblorb", "c39f0aad4ec8bd737454ee961db26f3c", 365590),
 	DT_ENTRYL1("ph04_remakorp04", Common::ES_ESP, "040729", "85bacb79e85944a6dbfe9c8d9a47a0fb", 579046),
 	DT_ENTRYL1("ph04_vhalen1", Common::ES_ESP, "04???\?/Corrupt", "68234ccba90471707f53327efb2d7128", 710042),
 
-	// Premios Hispanos 2005
+	// Premios Hispanos 2005 (Spanish)
 	DT_ENTRYL1("ph05_ahs", Common::ES_ESP, "Corrupt", "45af7e13982b5605d8340e70208b8e51", 28142348),
 	DT_ENTRYL1("ph05_ahs", Common::ES_ESP, "05???\?/Corrupt", "62f06caf7ba03dc2594df46cbe3f1459", 19625058),
 	DT_ENTRYL1("ph05_musa", Common::ES_ESP, "050605", "b872295179826ff8b2bf20be45007dc0", 519830),
-	DT_ENTRYL1("ph05_rur", Common::ES_ESP, "?????\?/v1/Corrupt", "4d7dab1227494292f37107da1729392e", 3432966),
-	DT_ENTRYL1("ph05_rur", Common::ES_ESP, "?????\?/v2/Corrupt", "de15e8cdd8523c774b66950a0232a0f9", 413184),
-	DT_ENTRYL1("ph05_rur", Common::ES_ESP, "1106???\?/v1", "160413ab0c3b1fdd4346ee493c4b3e46", 3493080),
-	DT_ENTRYL1("ph05_rur", Common::ES_ESP, "1106???\?/v2", "b5238a903be352f491c46ce58b80cefd", 433920),
+	DT_ENTRYL1("ph05_rur", Common::ES_ESP, "?????\?/blb/Corrupt", "4d7dab1227494292f37107da1729392e", 3432966),
+	DT_ENTRYL1("ph05_rur", Common::ES_ESP, "?????\?/ulx/Corrupt", "de15e8cdd8523c774b66950a0232a0f9", 413184),
+	DT_ENTRYL1("ph05_rur", Common::ES_ESP, "1106???\?/blb", "160413ab0c3b1fdd4346ee493c4b3e46", 3493080),
+	DT_ENTRYL1("ph05_rur", Common::ES_ESP, "1106???\?/ulx", "b5238a903be352f491c46ce58b80cefd", 433920),
 	DT_ENTRYL1("ph05_sarimek", Common::ES_ESP, "Corrupt", "a20f085b591590ee351bfc464c3c41f4", 2018160),
 
-	// Premios Hispanos 2006
+	// Premios Hispanos 2006 (Spanish)
 	DT_ENTRYL1("ph06_007altosecret", Common::ES_ESP, "?????\?/Corrupt", "a788bffad0435ff5183fd6aba47af9ba", 12773890),
 	DT_ENTRYL1("ph06_laconferencia", Common::ES_ESP, "060108", "03152d0cdb6e633d3fdba957a609178b", 3672520),
 	DT_ENTRYL1("ph06_paee_glulx", Common::ES_ESP, "040729", "9967379e527801ddc12b5734253f3ac2", 3027412),
@@ -2634,24 +2812,32 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRYL1("ph06_wizlair", Common::ES_ESP, "090726", "2e1d6621fb1301887f4e21bdb5949252", 8912740),
 	DT_ENTRYL1("ph06_wizlair", Common::ES_ESP, "061116", "0218e2e3ccac3acef7c54dc503e4b417", 1039800),
 
-	// Premios Hispanos 2007
+	// Premios Hispanos 2007 (Spanish)
 	DT_ENTRYL1("ph07_diabloesnifan", Common::ES_ESP, "080104", "8e3b5b634a49ea2cad06dadcc2f5ca38", 3640896),
 	DT_ENTRYL1("ph07_diana925", Common::ES_ESP, "070709", "e0aeb430f8c1588510e7017bed0ff798", 1084174),
 	DT_ENTRYL1("ph07_edificio25", Common::ES_ESP, "070830", "01a51bf002abee1aafb7e8ba2dae1847", 4197682),
+	DT_ENTRYL1("ph07_edificio25", Common::ES_ESP, "140822", "67ebe19ab49567f10fc7234dc4386317", 4282166),
 	DT_ENTRYL1("ph07_elmuseo", Common::ES_ESP, "071004", "0f33297f84f235d90872a236a8a608d4", 772418),
-	DT_ENTRYL1("ph07_edc_glulx", Common::ES_ESP, "070831", "1ef25e518189aede8375da09e2d35735", 2174384),
+	DT_ENTRYL1("ph07_edc_glulx", Common::ES_ESP, "070831/blb", "1ef25e518189aede8375da09e2d35735", 2174384),
+	DT_ENTRYL1("ph07_edc_glulx", Common::ES_ESP, "070831/gblorb", "0b5023b15faf9f731fb2fef7f57729af", 2376634),
+	DT_ENTRYL1("ph07_edc_glulx", Common::ES_ESP, "081022/blb", "00ed7db0dc81b5d2da55ed0b085d8008", 2144072),
+	DT_ENTRYL1("ph07_edc_glulx", Common::ES_ESP, "?????\?/Corrupt", "648bf70b1e86a59d4622318ff90a451a", 244992),
 	DT_ENTRYL1("ph07_htec_glulx", Common::ES_ESP, "160313", "824a8d7690acff631fb207e5af93f4d1", 2160114),
 	DT_ENTRYL1("ph07_regresoaleden", Common::ES_ESP, "03????", "0304187b411ef1211c73ff7415c23fe7", 6974410),
 	DT_ENTRYL1("ph07_regresoaleden", Common::ES_ESP, "070831", "4bf96ba47fd82da0f452e8cca8d58b04", 6613376),
+	DT_ENTRYL1("ph07_regresoaleden", Common::ES_ESP, "150917", "6e93673310637cb3aebe6447294b3c01", 6953976),
 
-	// Premios Hispanos 2008
+	// Premios Hispanos 2008 (Spanish)
 	DT_ENTRYL1("ph08_alienlaventur", Common::ES_ESP, "081124", "e09c0e91e53a07c768eb473deae9619c", 6884846),
 	DT_ENTRYL1("ph08_alienlaventur", Common::ES_ESP, "180729", "0ae34bbdbcdb04fdda7aeab945d79549", 18044224),
 	DT_ENTRYL1("ph08_diana_glulx", Common::ES_ESP, "080722", "5962ec1f0f1e1a60753e4c4fa8c5c1c8", 240456),
+	DT_ENTRYL1("ph08_diana_glulx", Common::ES_ESP, "080806/blb", "9e6cf41d8af4938b5bcfd1334642adcb", 226632),
+	DT_ENTRYL1("ph08_diana_glulx", Common::ES_ESP, "080806/gblorb", "a1e3e6ae6d669695719244df257c0bad", 227812),
 	DT_ENTRYL1("ph08_espiritusidra", Common::ES_ESP, "08????", "6735b842ebeb95991734a8fb02537e81", 10655248),
 	DT_ENTRYL1("ph08_puj", Common::ES_ESP, "080524", "2fb5a2d444972ca62a6124c9c1d6672a", 3392294),
+	DT_ENTRYL1("ph08_puj", Common::ES_ESP, "120817", "b0b63673ea1e21bc3bd801211e07e988", 3391526),
 
-	// Premios Hispanos 2009
+	// Premios Hispanos 2009 (Spanish)
 	DT_ENTRYL1("ph09_anillo3", Common::ES_ESP, "090429", "baa43907bbb36b9be8dd6a4391b4c936", 12527130),
 	DT_ENTRYL1("ph09_anillo3", Common::ES_ESP, "15????", "4f373c2855fa7a0b826d27b7c426a50f", 46345462),
 	DT_ENTRYL1("ph09_hhorcus_glulx", Common::ES_ESP, "100818", "48e7d8f6cd53506778e035eeab6c545c", 4191072),
@@ -2661,8 +2847,11 @@ const GlkDetectionEntry GLULXE_GAMES[] = {
 	DT_ENTRYL1("ph09_lobosaldeanos", Common::ES_ESP, "090804", "50d44a5ee839f5c764965a0ef9f36d5b", 548806),
 	DT_ENTRYL1("ph09_reliquiatolti", Common::ES_ESP, "090318", "3ce83f626170af423fe9017d42b538aa", 939564),
 	DT_ENTRYL1("ph09_reliquiatolti", Common::ES_ESP, "090811", "80373c10f5cacce1ba486faf7192fe93", 947358),
+	DT_ENTRYL1("ph09_visit_glulx", Common::ES_ESP, "091130/blb", "f29daf3e4a0fd9132a4f403863a289eb", 239936),
+	DT_ENTRYL1("ph09_visit_glulx", Common::ES_ESP, "091206", "f12286ec445006dca4f458fd6527c8c7", 693068),
+	DT_ENTRYL1("ph09_visit_glulx", Common::ES_ESP, "091206", "c5bd98a4c6194fd6135ea1144aadc9fc", 433166),
 
-	// Premios Hispanos 2010
+	// Premios Hispanos 2010 (Spanish)
 	DT_ENTRYL1("ph10_lpc_glulx", Common::ES_ESP, "181013/Corrupt", "c29c9ffb0936cfd69ef4e0135556ec9a", 14311360),
 	DT_ENTRYL1("ph10_lpc_glulx", Common::ES_ESP, "181013", "338f5403c94cbadfe88ea0388eb65c60", 14301120 ),
 	DT_ENTRYL1("ph10_heroemazmorra", Common::ES_ESP, "10???\?/v1", "707aaa1f096db0786e693b501070593b", 8253216),

--- a/engines/glk/zcode/detection_tables.h
+++ b/engines/glk/zcode/detection_tables.h
@@ -239,6 +239,7 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "checkerhaunt",       "A Checkered Haunting" },
 	{ "cheesedoff_zcode",   "Cheesed Off!" },
 	{ "cheeseshop",         "Cheeseshop" },
+	{ "chengara",           "Chengara" },
 	{ "cheshirecat_zcode",  "Save the Cheshire Cat!" },
 	{ "chico",              "Chico and I Ran" },
 	{ "childsplay",         "Child’s Play" },
@@ -246,6 +247,7 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "christminster",      "Christminster" },
 	{ "cia",                "C.I.A. Adventure" },
 	{ "classchallenge",     "Class Challenge" },
+	{ "classroom",          "The Classroom Done" },
 	{ "cleanair",           "Clean Air" },
 	{ "cliffedge",          "Edge of the Cliff" },
 	{ "cockandbull",        "A Cock and Bull Story" },
@@ -288,6 +290,7 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "dayishothitler",     "The Day I Shot Hitler" },
 	{ "dd4",                "Dutch Dapper IV: The Final Voyage" },
 	{ "dday",               "D-Day" },
+	{ "deadmen",            "Down Among the Dead Men" },
 	{ "deadmeat",           "Dead Meat in the Pit" },
 	{ "deadreckon_zcode",   "Dead Reckoning" },
 	{ "death",              "Death to my Enemies" },
@@ -399,6 +402,7 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "gowest",             "Go West" },
 	{ "greaterthan",        "> by @" },
 	{ "greatpancake",       "The Great Pancake Detectives - Case #27" },
+	{ "greenblood",         "Green Blood" },
 	{ "greenrain",          "A Green Rain" },
 	{ "greensboro",         "Greensboro Sit-In" },
 	{ "growingup",          "Growing Up" },
@@ -414,6 +418,7 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "hauntedhouse",       "Haunted House" },
 	{ "hauntings",          "Hauntings" },
 	{ "headcase",           "Head Case" },
+	{ "heartice",           "Heart of Ice" },
 	{ "heidi",              "Heidi" },
 	{ "heist",              "Heist: The Crime of the Century" },
 	{ "heliopause",         "Hoist Sail for the Heliopause and Home" },
@@ -423,6 +428,7 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "hibernated1",        "Hibernated 1 - This Place is Death (Director's Cut)" },
 	{ "hiddennazi",         "The Game Formerly Known as Hidden Nazi Mode" },
 	{ "hiddenverbiage",     "Hidden Verbiage" },
+	{ "hideseek",           "Hide Seek" },
 	{ "hidepachyderm",      "Hide a Pachyderm!" },
 	{ "hippoelmstr_zcode",  "Hippo on Elm Street" },
 	{ "hipponewyear",       "And a Hippo New Year" },
@@ -519,9 +525,11 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "magicmuffin",        "Magic Muffin - The Desert" },
 	{ "makeitgood",         "Make it Good" },
 	{ "mansion",            "Mansion" },
+	{ "mapa_zcode",         "El Mapa" },
 	{ "martyquest",         "Back to the Future - Marty Quest" },
 	{ "medusa",             "Medusa" },
 	{ "meetingrobb",        "Meeting Robb Sherwin" },
+	{ "mehplace_zcode",     "The Meh Place" },
 	{ "memorylane",         "Memory Lane" },
 	{ "mercurytrucking",    "The Mercury Trucking Company" },
 	{ "mercy",              "Mercy" },
@@ -545,7 +553,10 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "mortlakemanor",      "Mortlake Manor" },
 	{ "motelcalifornia",    "Motel California" },
 	{ "mountain",           "Mountain" },
-	{ "mousequest",         "Mouse Quest Chapter 1 - The Arrival of Winter" },
+	{ "mousequest",         "Mouse Quest - Chapter 1: The Arrival of Winter" },
+	{ "mousequest2",        "Mouse Quest - Chapter 2: Down the Coble Creek" },
+	{ "mousequest3",        "Mouse Quest - Chapter 3: The Council of Mice" },
+	{ "mousequest4",        "Mouse Quest - Chapter 4: The Forgotten Hero" },
 	{ "mrscrabtree",        "Mrs. Crabtree's Geography Class" },
 	{ "mst3k1",             "Mystery Science Theater 3000 Presents 'Detective'" },
 	{ "mst3k2",             "Mystery Science Theater 3000 Presents 'A Fable'" },
@@ -563,6 +574,7 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "myunclegeorge",      "My Uncle George" },
 	{ "nameless",           "Endless, Nameless" },
 	{ "nascarexperience",   "The Realistic Nascar eXperience" },
+	{ "necklace",           "Necklace of Skulls" },
 	{ "nemeanlion",         "The Nemean Lion" },
 	{ "nemesismacana",      "Nemesis Macana" },
 	{ "neverplayed_zcode",  "So, You've Never Played a Text Adventure Before, Huh?" },
@@ -662,7 +674,6 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "rota",               "The Reliques of Tolti-Aph" },
 	{ "rpn",                "RPN" },
 	{ "rtdoom",             "Return to Doom" },
-	{ "sabotage",           "Sabotage" },
 	{ "safe_zcode",         "Safe" },
 	{ "samegame",           "SameGame, Another Episode in the Z-Machine Abuse Saga" },
 	{ "samhain",            "Samhain: Pick Up the Jack O' Lantern and Die" },
@@ -729,7 +740,7 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "sunburst",           "Sunburst: A C64 Science Fiction Adventure Game" },
 	{ "sundayafternoon",    "Sunday Afternoon" },
 	{ "surfboard",          "Surfboard" },
-	{ "survive",            "Survive" },
+	{ "survive_zcode",      "Survive" },
 	{ "sutwin",             "The Space Under the Window" },
 	{ "suvehnux",           "Suveh Nux" },
 	{ "swineback",          "Swineback Ridge" },
@@ -2380,54 +2391,54 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "verdeterre",         "Le Butin du Capitaine Verdeterre" },
 	{ "vindaloofr",         "Vindaloo" },
 
-	// French games: French Comp 2005
+	// French Comp 2005 (French)
 	{ "frc_cercledesgros",  "Le Cercle des Gros Geeks Disparus" },                                      //    1st Place
 	{ "frc_dreamlands",     "Echappee Belle Dans Les Contrees du Reve" },                               //    2nd Place
 	{ "frc_templedefeu",    "Le Temple de Feu" },                                                       //    3rd Place
 
-	// French games: French Comp 2006
+	// French Comp 2006 (French)
 	{ "frc_citeeaux",       "La Cité des Eaux" },                                                       //    1st Place
 	{ "frc_sarvegne",       "Sarvegne" },                                                               //    2nd Place
 
-	// French games: French Comp 2007
+	// French Comp 2007 (French)
 	{ "frc_heuresduvent",   "Heures Du Vent" },                                                         //    1st Place
 	{ "frc_divinebonace",   "Divine Bonace" },                                                          //    2nd Place
 	{ "frc_brrr",           "Brrr!" },                                                                  //    3rd Place
 	{ "frc_ilephare_zcode", "L'Ile du Phare Abandonné" },                                               //    5th Place
 
-	// French games: French Comp 2008
+	// French Comp 2008 (French)
 	{ "frc_brume",          "Brume" },                                                                  //    1st Place
 	{ "frc_lettresvolees",  "Les Lettres Volées" },                                                     //    2nd Place
 	{ "frc_louplachevre",   "Le Loup, la Chèvre, et la Salade" },                                       //    4th Place
 
-	// French games: French Comp 2009
+	// French Comp 2009 (French)
 	{ "frc_catapole",       "Catapole" },                                                               //    1st Place
 	{ "frc_chambresyrion",  "La Chambre de Syrion" },                                                   //    2nd Place
 	{ "frc_mechants",       "Les Méchants Meurent au Moins deux Fois" },                                //    3rd Place
 
-	// French games: French Comp 2011
+	//French Comp 2011 (French)
 	{ "frc_aventureszeus",  "Les Aventures de Zeus" },                                                  //    1st Place
 	{ "frc_dardenfer",      "Dard d'Enfer" },                                                           //    2nd Place
 	{ "frc_terreciel",      "Entre Terre et Ciel" },                                                    //    3rd Place
 	{ "frc_astrologue",     "La Grande Prédiction ou l'Astrologue Etourdi" },                           //    4th Place
 	{ "frc_homelandsec",    "Homeland Security" },                                                      //    5th Place
 
-	// French games: French Comp 2013
+	// French Comp 2013 (French)
 	{ "frc_lifeonmarsfr",   "Life on Mars?" },                                                          //    1st Place
 	{ "frc_sourcedezig",    "La Source de Zig" },                                                       //    3rd Place
 	{ "frc_trac",           "Trac" },                                                                   //    4th Place
 
-	// French games: French Comp 2015
+	// French Comp 2015 (French)
 	{ "frc_envol",          "L'Envol" },                                                                //    1st Place
 
-	// French games: French Comp 2016
+	// French Comp 2016 (French)
 	{ "frc_tipelau",        "Tipelau" },                                                                //    2nd Place
 	{ "frc_diamantblanc",   "Le Diamant Blanc" },                                                       //    3rd Place
 
-	// French games: French Comp 2018
+	// French Comp 2018 (French)
 	{ "frc_exil",           "L'Exil" },                                                                 //    5th Place
 
-	// French games: French Comp 2021
+	// French Comp 2021 (French)
 	{ "frc_donjon",          "Le Donjon de BatteMan" },                                                 //      Entrant
 	{ "frc_stationspatial",  "Station Spatiale S16: Prologue" },                                        //      Entrant
 
@@ -2454,48 +2465,48 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "wasserhasser",       "Wasser-Hasser" },
 	{ "wichtel",            "Wichtel" },
 
-	// German games: Textfire Grand Prix 2002
+	// Textfire Grand Prix 2002 (German)
 	{ "tgp_eden",           "Eden" },                                                                   //    1st Place
 	{ "tgp_bewerbung",      "Die Bewerbung" },                                                          //    3rd Place
 	{ "tgp_seite",          "Mein Leben für Seite Drei" },                                              //    4th Place
 
-	// German games: Textfire Grand Prix 2003
+	// Textfire Grand Prix 2003 (German)
 	{ "tgp_linear",         "Linear" },                                                                 //    1st Place
 
-	// German games: Textfire Grand Prix 2004
+	// Textfire Grand Prix 2004 (German)
 	{ "tgp_jazteg",         "Jazz auf Tegemis" },                                                       //    1st Place
 	{ "tgp_spater",         "Zwei Jahre später" },                                                      //    4th Place
 	{ "tgp_unterwelt",      "Unterwelt" },                                                              //    5th Place
 	{ "tgp_die5",           "Die 5 Kammer" },                                                           //    8th Place
 	{ "tgp_dichter",        "Dichter" },                                                                //    9th Place
 
-	// German games: Textfire Grand Prix 2005
+	// Textfire Grand Prix 2005 (German)
 	{ "tgp_kopialbuch",     "Das Kopialbuch" },                                                         //    1st Place
 
-	// German games: Textfire Grand Prix 2006
+	// Textfire Grand Prix 2006 (German)
 	{ "tgp_felleisen",      "Das Felleisen" },                                                          //    1st Place
 	{ "tgp_pmason",         "P. Mason und der Schlitzerhans und die Busenkathi" },                      //    2nd Place
 
-	// German games: Textfire Grand Prix 2010
+	// Textfire Grand Prix 2010 (German)
 	{ "tgp_hausaufgabe",    "Die Hausaufgabe" },                                                        //    3rd Place
 	{ "tgp_absturzmomente", "Absturzmomente" },                                                         //    4th Place
 
-	// German games: Textfire Grand Prix 2011
+	// Textfire Grand Prix 2011 (German)
 	{ "tgp_gorgonir",       "Gorgonir" },                                                               //    2nd Place
 	{ "tgp_ausgerechnet",   "Ausgerechnet Mamph Pamph!" },                                              //    4th Place
 
-	// German games: IF Grand Prix 2015
+	// IF Grand Prix 2015 (German)
 	{ "tgp_dieakte",        "Die Akte Paul Bennet" },                                                   //    1st Place
 	{ "tgp_lilie",          "Die Schwarze Lilie" },                                                     //    1st Place
 
-	// German games: IF Grand Prix 2016
+	// IF Grand Prix 2016 (German)
 	{ "tgp_emilia",         "Der Tag an dem Emilia W. Verschwand" },                                    //    3rd Place
 
-	// German games: IF Grand Prix 2022
+	// IF Grand Prix 2022 (German)
 	{ "tgp_schief",         "Schief" },                                                                 //    1st Place
 	{ "tgp_dieerstenacht",  "Die Erste Nacht" },                                                        //    2nd Place
 
-	// German games: IF Grand Prix 2023
+	// IF Grand Prix 2023 (German)
 	{ "tgp_fischstaebchen", "Fischstaebchen" },                                                         //    3rd Place
 	{ "tgp_gennorden",      "Gen Norden" },                                                             //    4th Place
 
@@ -2528,7 +2539,7 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "lazyjones",          "Lazy Jones e il Meritato Riposo" },
 	{ "littlefalls_zcode",  "Little Falls" },
 	{ "lucifinanza_zcode",  "Luci della Finanza" },
-	{ "marconi",            "Visita al Marconi" },
+	{ "marconi_zcode",      "Visita al Marconi" },
 	{ "noalpitour",         "No Alpitour" },
 	{ "noavventura",        "Non Sarà un'Avventura" },
 	{ "oldwest1",           "Pecos Town, Old West Episode I" },
@@ -2558,14 +2569,14 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "zombie",             "Uno Zombie a Deadville" },
 	{ "zorkita",            "Zork I: Il Grande Impero Sotterraneo" },
 
-	// Italian games: Marmellata d'Avventura 2018
+	// Marmellata d'Avventura 2018 (Italian)
 	{ "ma_lastprigioniero", "I Cinque Feudi" },
 	{ "ma_skepto",          "Skepto!" },
 	{ "ma_dejavu_zcode",    "Déjà Vu" },
 	{ "ma_lazystranocaso",  "Lazy Jones e lo Strano Caso" },
 	{ "ma_pilastri",        "Sigehao - I Quattro Pilastri" },
 
-	// Italian games: Marmellata d'Avventura 2019
+	// Marmellata d'Avventura 2019 (Italian)
 	{ "ma_salagamescastle", "La Sala dei Giochi del Castello del Signore di Ylourgne in Averoigne" },
 	{ "ma_tesorosalagames", "Il Tesoro della Sala Giochi" },
 	{ "ma_lazysalagiochi",  "Lazy Jones e la Sala Giochi" },
@@ -2582,11 +2593,12 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "zenin",              "Zenin na Begu" },
 
 	// Spanish games
-	{ "abismo",             "El Abismo" },
-	{ "acuario",            "Acuario" },
+	{ "abismo_zcode",       "El Abismo" },
+	{ "acuario_zcode",      "Acuario" },
 	{ "adso",               "Adso de Melk" },
 	{ "alicia",             "A Trves del Espejo" },
 	{ "anillo",             "El Anillo" },
+	{ "anillo3",            "Anillo III" },
 	{ "avent",              "Aventurilandia" },
 	{ "aventura",           "Aventura" },
 	{ "bicho",              "El Bicho" },
@@ -2598,32 +2610,39 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "cronicasparaiso",    "Cronicas del Paraiso" },
 	{ "cruzado",            "El Cruzado" },
 	{ "cueva",              "La Oscura Cueva" },
+	{ "dagon_zcode",        "Dagon" },
 	{ "despert",            "El Despertar" },
 	{ "draculasp",          "Dracula: Episodio 1, La Primera Noche" },
 	{ "ecss",               "es.comp.sistemas.sinclair" },
 	{ "edaylobo",           "Eda y el Lobo" },
 	{ "elcontinente",       "El Continente" },
 	{ "ellibro",            "El Libro" },
+	{ "elpuzzle",           "El Puzzle" },
 	{ "encierro",           "Encierro" },
 	{ "ergotdelima_zcode",  "Ergot de Lima" },
-	{ "estacion",           "Secuestro" },
+	{ "estacion_zcode",     "Secuestro" },
 	{ "excessus",           "Excessus" },
 	{ "forrajeo",           "Forrajeo" },
 	{ "fotopia",            "Fotopia" },
 	{ "geo",                "Geo" },
 	{ "gorron",             "El Gorron del Tren" },
-	{ "hampa",              "Historias del Hampa" },
+	{ "hampa_zcode",        "Historias del Hampa" },
 	{ "heredar",            "Heredar!" },
 	{ "heresville",         "Heresville" },
 	{ "imposibl",           "Imposible" },
 	{ "islamisteriosa",     "La Isla Misteriosa" },
 	{ "juguete",            "Jugueteria" },
 	{ "laberinto",          "Un Laberinto Acordado" },
+	{ "latorre_zcode",      "La Torre" },
+	{ "laverja",            "La Verja" },
+	{ "legion",             "Legin de las Tinieblas" },
 	{ "logicinv",           "Lógica Inversa" },
 	{ "maquina",            "Maquina" },
 	{ "marsmenace",         "Mars Menace From Outer Space" },
 	{ "memorias_zcode",     "Memorias de reXXe" },
 	{ "mpdroidone",         "Operacion MPDroid1" },
+	{ "nada",               "La Nada" },
+	{ "pantalla",           "Pantallas y Más Pantallas..." },
 	{ "paraiso",            "Llave Hacia el Paraíso" },
 	{ "perseo",             "Perseo y Andromeda" },
 	{ "peso",               "Una Cuestión de Peso" },
@@ -2636,6 +2655,7 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "redencionmomificad", "Redención Momificada" },
 	{ "reflejos",           "Reflejos Blancos" },
 	{ "regalo",             "El Regalo de Gorbag" },
+	{ "relojes_zcode",      "Un Lugar en Ninguna Parte Pero en Algún Momento" },
 	{ "roleando",           "Roleando" },
 	{ "saee",               "Saee" },
 	{ "sgw_zcode",          "Test Para SGW" },
@@ -2647,16 +2667,17 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "tribu",              "La TrIbU" },
 	{ "varenna",            "Varenna Quest I: El Castillo de la Rosa Negra" },
 	{ "waxworksspa",        "Adventura de Misterio #11: Museo de Cera" },
+	{ "werewolf",           "Lobos y Aldeanos" },
 	{ "zipi",               "Zipi" },
 	{ "zna",                "Zna No es una Aventura" },
 
-	// Spanish games: Ectocomp 2017 - Le Grand Guignol
+	// Ectocomp 2017 - Le Grand Guignol (Spanish)
 	{ "ec17_decolor",       "Decolor" },                                                                //    3rd Place
 
-	// Spanish games: Ectocomp 2022 - Le Grand Guignol
+	// Ectocomp 2022 - Le Grand Guignol (Spanish)
 	{ "ec22_estadop_zcode", "Estado Profundo" },                                                        //    2nd Place
 
-	// Spanish games: Premios Hispanos 2000
+	// Premios Hispanos 2000 (Spanish)
 	{ "ph00_abalanzate",    "Abalanzate" },
 	{ "ph00_alemanes",      "Golpe a Los Nazis" },
 	{ "ph00_aparato",       "El Aparato" },
@@ -2674,7 +2695,7 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "ph00_torre",         "Misterio en la Torre" },
 	{ "ph00_tokland",       "La Isla de Tokland" },
 
-	// Spanish games: Premios Hispanos 2001
+	// Premios Hispanos 2001 (Spanish)
 	{ "ph01_aciegas",       "A Ciegas" },
 	{ "ph01_celos",         "Un Asunto de Celos" },
 	{ "ph01_ch3ch2oh",      "CH3-CH2-OH" },
@@ -2685,7 +2706,7 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "ph01_ocaso",         "Ocaso Mortal I: The Bug" },
 	{ "ph01_segapark",      "Aventurero en el Segapark" },
 
-	// Spanish games: Premios Hispanos 2002
+	// Premios Hispanos 2002 (Spanish)
 	{ "ph02_asesinato",     "Asesinato en el Continental" },
 	{ "ph02_aveces",        "A Veces..." },
 	{ "ph02_cv",            "Curriculum Vitae" },
@@ -2701,7 +2722,7 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "ph02_sombras",       "Sombras de Moria" },
 	{ "ph02_ultimohogar",   "Misterio en el Ultimo Hogar" },
 
-	// Spanish games: Premios Hispanos 2003
+	// Premios Hispanos 2003 (Spanish)
 	{ "ph03_aluzine",       "Aluzine" },
 	{ "ph03_array",         "Array" },
 	{ "ph03_castillo",      "El Castillo de los Lamentos" },
@@ -2714,14 +2735,14 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "ph03_otrpalab",      "En Otras Palabras" },
 	{ "ph03_rural",         "La Aventura Rural" },
 
-	// Spanish games: Premios Hispanos 2004
+	// Premios Hispanos 2004 (Spanish)
 	{ "ph04_islas",         "El Archipielago" },
 	{ "ph04_lamansion",     "La Mansion" },
 	{ "ph04_navidad",       "Una Pequena Historia de Navidad" },
 	{ "ph04_oculta",        "La Cara Oculta de la Luna" },
 	{ "ph04_remi",          "ReminiscenciaRol" },
 
-	// Spanish games: Premios Hispanos 2005
+	// Premios Hispanos 2005 (Spanish)
 	{ "ph05_castilsilenco", "El Castillo del Silencio" },
 	{ "ph05_pozo",          "Al Fondo del Pozo" },
 	{ "ph05_elprotector",   "El Protector" },
@@ -2730,7 +2751,7 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "ph05_trono",         "El Trono de Inglaterra" },
 	{ "ph05_romanfredo",    "Romanfredo" },
 
-	// Spanish games: Premios Hispanos 2006
+	// Premios Hispanos 2006 (Spanish)
 	{ "ph06_draculasp2",    "Dracula: Episodio 2, La Llegada" },
 	{ "ph06_elgatocheko",   "El Gato Cheko" },
 	{ "ph06_goteras",       "Goteras" },
@@ -2738,7 +2759,7 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "ph06_regreso",       "El Regreso" },
 	{ "ph06_resaca",        "Resaca" },
 
-	// Spanish games: into Premios Hispanos 2007
+	// Premios Hispanos 2007 (Spanish)
 	{ "ph07_030307",        "Unidad 030307" },
 	{ "ph07_afuera",        "Afuera" },
 	{ "ph07_aod",           "Antes o Despuses" },
@@ -2751,7 +2772,7 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "ph07_mausoleo",      "Yuriko in the Mausoleo" },
 	{ "ph07_umami",         "El Día del Umami" },
 
-	// Spanish games: Premios Hispanos 2008
+	// Premios Hispanos 2008 (Spanish)
 	{ "ph08_diana_zcode",   "Diana" },
 	{ "ph08_emmy",          "Museo Poetico Emmy" },
 	{ "ph08_gambito",       "El Gambito Slagar" },
@@ -2765,7 +2786,7 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "ph08_sonrisas",      "Sonrisas... Y Lagrimas" },
 	{ "ph08_venenaverbo",   "Venenarius Verborum" },
 
-	// Spanish games: Premios Hispanos 2009
+	// Premios Hispanos 2009 (Spanish)
 	{ "ph09_amanda",        "Amanda" },
 	{ "ph09_gorbag",        "El Regalo de Gorbag" },
 	{ "ph09_hhorcus_zcode", "Homo Homini Orcus" },
@@ -2774,9 +2795,9 @@ const PlainGameDescriptor ZCODE_GAME_LIST[] = {
 	{ "ph09_megara",        "Los Placeres de Megara" },
 	{ "ph09_panajo",        "Pan de Ajo" },
 	{ "ph09_sm6ascenso",    "Serie Minúscula #6: El Ascenso de Kunelar" },
-	{ "ph09_visitantes",    "Visitantes" },
+	{ "ph09_visit_zcode",   "Visitantes" },
 
-	// Spanish games: Premios Hispanos 2010
+	// Premios Hispanos 2010 (Spanish)
 	{ "ph10_azul",          "Azul Fuerte" },
 	{ "ph10_lpc_zcode",     "La Pequena Cerillera" },
 	{ "ph10_modusvivendi",  "Modus Vivendi" },
@@ -3958,6 +3979,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY0("cheesedoff_zcode", "160724", "f22a5e611479057236e0a8af31b62e70", 448080),
 	ENTRY0("cheeseshop", "021230/v1", "88329068474b92abf4b4363c177f6971", 85504),
 	ENTRY0("cheeseshop", "021230/v2", "cbf746a948b66ae8d2a65e52134654b4", 85504),
+	ENTRY0("chengara", "090621", "1ae7fc0b20586b7ff76b4d4340dd3abc", 222720),
 	ENTRY0("cheshirecat_zcode", "140803", "69dced03ab92e1efeae0ea4a496743d5", 78848),
 	ENTRY0("cheshirecat_zcode", "141012", "0a8c570fb7499bcc35109fdf7320132b", 79872),
 	ENTRY0("cheshirecat_zcode", "150918/z5", "97f1096761d27951a1715c627390b6ba", 76800),
@@ -3967,7 +3989,9 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY0("cia", "961218", "2cdacedf416e7a575de47412e1d164f8", 54784),
 	ENTRY0("classchallenge", "190724", "d6caad7ab6a6964f0526f5b4c7a41316", 163840),
 	ENTRY0("classchallenge", "201112", "cf1cc6017a784a8f52daaaa7c617772a", 163840),
+	ENTRY0("classroom", "210320", "ee18db643cc029257dfe838d56aa5f86", 321536),
 	ENTRY0("cleanair", "190608", "3e5a972edf102956f6973c9fc7a8d388", 410302),
+	ENTRY0("cleanair", "220825", "a988a1fd11f394316632c1759b2eb4a5", 414916),
 	ENTRY0("cliffedge", "111030", "2bcba042a3b56fb010c9ab0e64cecad5", 324608),
 	ENTRY0("cockandbull", "170401", "6036a188e9def979678697ce7be14171", 895024),
 	ENTRY0("clockwork", "200725", "e7a388799d227c9b8b114a4b398b500a", 40344),
@@ -4023,6 +4047,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY0("dayinlife", "080406", "ad0b46d14e3a8d577a58f0d93d700f4f", 173558),
 	ENTRY0("dd4", "030207", "c5921ad782bc25cbd7e3f8c8b1412a4a", 163328),
 	ENTRY0("dday", "110720", "897fbdf9cb2468b09c30961524d36ae5", 266364),
+	ENTRY0("deadmen", "200825", "d6d9516a7f2ca84d3397df54504ceb68", 230340),
 	ENTRY0("deadmeat", "170527", "c0f127f032ade1f46267028371e68e5b", 252374),
 	ENTRY0("deadmeat", "170617", "beed7ee4185f9ddf31f3b94db8ff4ec0", 252374),
 	ENTRY0("deadreckon_zcode", "030730", "1232dc599a00548bcc2d6453a01c5e50", 87040),
@@ -4152,6 +4177,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY0("gowest", "120425", "2c1e329d9cde395785f8323a740a361e", 251988),
 	ENTRY0("greatpancake", "180117", "9f4e359b40bc53631937c2c44ee5082c", 264268),
 	ENTRY0("greaterthan", "100415", "f7e6e82cda24f2e6f8f06f74323aa19f", 232844),
+	ENTRY0("greenblood", "200825", "3a0b9d06df3ccbca6e2bdfcefa8a8c35", 184936),
 	ENTRY0("greenrain", "100611", "f28e8e500d4fbc94d59f5bfdb9cf7f4d", 275516),
 	ENTRY0("greensboro", "080712", "dd7bd20aa69092b009f9f5503c01f124", 141714),
 	ENTRY0("growingup", "110825", "9bada495ce70bfcae2566f01b844d20a", 267720),
@@ -4168,6 +4194,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY0("hauntedhouse", "170103", "6d1a6caced27d901c09896ac74de6022", 400078),
 	ENTRY0("hauntings", "111109", "931b910ab47044e8792c4d5adc5163e3", 225792),
 	ENTRY0("headcase", "230310", "d05d6cef1edfa94fe52b76f25477b7f7", 613492),
+	ENTRY0("heartice", "200825", "68b954b47816ee47297cf1a51f816f51", 232408),
 	ENTRY0("heidi", "051112", "0b13ec8dec91b35662a62c7a60b54ddb", 83456),
 	ENTRY0("heist", "990217", "d37eab3288f34d5673f72d8697835e8e", 358400),
 	ENTRY0("heliopause", "100703", "423b5192b31eb0705a928b3900b6b208", 389388),
@@ -4177,6 +4204,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY0("hibernated1", "220625", "6b64251594ac07e042bde09689a388c1", 94208),
 	ENTRY0("hibernated1", "220814/z3", "a97e01c8d4545660ff4522bf2640f3af", 91136),
 	ENTRY0("hibernated1", "220814/z5", "df80b9e7979960cab74ac95fe290eb3f", 94208),
+	ENTRY0("hideseek", "210409", "a3a8cedd516bd3bf37b1cb3922709a07", 321536),
 	ENTRY0("hiddennazi", "100911", "93521e3903e1fa63cfb7ababebd4c3e1", 367570),
 	ENTRY0("hiddenverbiage", "181127", "736af995f8cb87601fe170695efa7180", 477130),
 	ENTRY0("hidepachyderm", "140705", "5e46b32c2897c46097b379f2eef7f5fa", 215040),
@@ -4244,6 +4272,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY0("kennykoala", "220501/z3", "064f6ee27d2716e5056d27b77eb232a4", 74752),
 	ENTRY0("kennykoala", "220501/z5", "467939dbb4493db7c91cc98b4c25d3f7", 77312 ),
 	ENTRY0("kentishplover", "200118", "d06991d44cdedc0ce4cbf17b3aa79f76", 162816),
+	ENTRY0("kentishplover", "200119", "07d9e4de03a8b80200d0e9124e162f57", 162304),
 	ENTRY0("kentishplover", "200213", "2c93242398a841ad069e81fa3b2c80f1", 163328),
 	ENTRY0("kidnapsea", "110608", "ddcf23cb530746544e0f416337dcf6bc", 191488),
 	ENTRY0("kierkegaardsspider", "120413", "19f457515033fd938856e6507b8a6bc1", 254414),
@@ -4295,11 +4324,14 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY0("makeitgood", "091227", "061af5747715511a5ac5a3476278a914", 495616),
 	ENTRY0("mansion", "010505", "cb310588d3ebdfe419b16ed29f5bc8df", 107008),
 	ENTRY0("mansion", "220406", "0bef5d345f25200423aa4828ab6e15c6", 108544),
-	ENTRY0("marconi", "150606", "5bd573961828acb20766ed203d373f60", 137728),
+	ENTRY0("mapa_zcode", "010711", "57e67b50fe180f9073da28548bd73a5f", 70144),
+	ENTRY0("marconi_zcode", "150606", "5bd573961828acb20766ed203d373f60", 137728),
 	ENTRY0("martyquest", "120430", "80b274b7feb7c19ee0aeba85dac0d688", 268272),
 	ENTRY0("medusa", "030314", "f9e93b13a6f940ef0d25cfef559e36c8", 109056),
 	ENTRY0("meetingrobb", "190928", "b3fb96f61f8c5a01f637cdbfe582612e", 464290),
 	ENTRY0("meetingrobb", "191002", "9eb2560176aaaaa2f7fd820944891ec3", 464290),
+	ENTRY0("mehplace_zcode", "?????\?/zblorb/v1", "407a01a7709a13dad6582c212ced97f4", 456130),
+	ENTRY0("mehplace_zcode", "?????\?/zblorb/v2", "32aef84c45a635f3014e67a34ffcf217", 459714),
 	ENTRY0("memorylane", "230311/z3", "34a1ce5f414e01c3e0a97c723cbca4d0", 104960),
 	ENTRY0("memorylane", "230311/z5", "33ca0166735982befe7ca3569df99389", 108544),
 	ENTRY0("mercy", "980217", "865d53d9764636ddf1bcaa2b703673a6", 97792),
@@ -4324,7 +4356,10 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY0("mortlakemanor", "120304", "80d317fd404451e436e9c36de5445de8", 261632),
 	ENTRY0("motelcalifornia", "110329", "67a1855ce59354e8eeff4f2a684811bc", 331712),
 	ENTRY0("mountain", "030317", "b84bb15597f7aa53ae407e2d996c0c6c", 103424),
-	ENTRY0("mousequest", "100509", "2993b235743e6a6a4d69063e80c187d9", 325062),
+	ENTRY0("mousequest", "????", "2993b235743e6a6a4d69063e80c187d9", 325062),
+	ENTRY0("mousequest2", "????", "32531caa725d44ddbbe720b05a364a11", 323014),
+	ENTRY0("mousequest3", "????", "4820cc5cf2aa9dbdc1c660146cdcf79e", 352198),
+	ENTRY0("mousequest4", "????", "8480dd58a0c6b3e0dae916f2aa8b19a2", 439238),
 	ENTRY0("mrscrabtree", "130225", "3ce7aebc7cdad846e1bdc8f46823f4b3", 235520),
 	ENTRY0("mst3k1", "000715", "0a0748937d23bf380cd139de874df32d", 141312),
 	ENTRY0("mst3k2", "981104", "55dc31376ee9e99700e4ad144c5670af", 83456),
@@ -4344,6 +4379,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY0("myunclegeorge", "090714", "dbdf7f0ea10c10ae2654d58e6ab9d1a4", 179090),
 	ENTRY0("nameless", "131206", "197a58d317be0e6060c490bd40baf8a1", 472064),
 	ENTRY0("nascarexperience", "130827", "d45dc3ab1f9898cf85a09854db0a6b17", 152576),
+	ENTRY0("necklace", "200825", "61cd8722a6030361c09e317189e27cd7", 217972),
 	ENTRY0("nemeanlion", "081113", "c298fdabefb085ca297f0f0917e2fd4e", 77824),
 	ENTRY0("nemesismacana", "120503/z8", "8f5ab052cc4f4f808a40add1be324c3b", 356352),
 	ENTRY0("nemesismacana", "120503/zblorb", "d24a6aaa2d9430b668fb7bda7caf9b42", 397226),
@@ -4529,7 +4565,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY0("sunburst", "070222", "9f1eee6db8dce7cfb803e5c430fe942a", 65532),
 	ENTRY0("sundayafternoon", "121213", "73d9c96d54922bcd58781aff41e449ed", 347136),
 	ENTRY0("surfboard", "201027", "b3e4c1784465d78111b3eda7b7969647", 180224),
-	ENTRY0("survive", "120116", "5391b23b5d02a9ff853ef93f76bb73f6", 89088),
+	ENTRY0("survive_zcode", "120116", "5391b23b5d02a9ff853ef93f76bb73f6", 89088),
 	ENTRY0("sutwin", "970402", "b4fe3b29aab816470906ce3ae0613ba4", 31744),
 	ENTRY0("suvehnux", "150314", "c085af56acb090e7e4c8af6f69ed216f", 248320),
 	ENTRY0("swineback", "060422", "853342a5b088a2998201123b0c5faa73", 111104),
@@ -5255,8 +5291,8 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY0("if14_15minutes", "140929", "794388850a60ce63f181efb194519bee", 402308),
 	ENTRY0("if14_15minutes", "141021", "8f99e176b2fd4387219b808515c75d0e", 402308),
 	ENTRY0("if14_teaceremony", "140918", "f8b04f52fc3294539405893474413e16", 268352),
-	ENTRY0("if14_enigmasd", "140929", "3e2bfc7b4a45cb0bf3936cb7b164ee17", 414884),
-	ENTRY0("if14_enigmasd", "141020", "5f933e199785495bc884d003a4579b9b", 415396),
+	ENTRY0("if14_enigma_sd", "140929", "3e2bfc7b4a45cb0bf3936cb7b164ee17", 414884),
+	ENTRY0("if14_enigma_sd", "141020", "5f933e199785495bc884d003a4579b9b", 415396),
 	ENTRY0("if14_blacklily", "140926", "16e3dee79b000c19e3f211af3bea9266", 188364),
 	ENTRY0("if14_blacklily", "150318", "f74981accbff8eaa36e07bb175640ea2", 199124),
 	ENTRY0("if14_tower", "140912", "9e4e1ffe01254b8f45f22c79d664cbb2", 390132),
@@ -5799,6 +5835,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY0("shd_everythinggame", "150418/zblorb", "130aa6031169e969258ef8e6e1105f52", 1490056),
 	ENTRY0("shd_headingeast", "150507", "ee6869fc4d02966a7ebc7681ae751dc2", 109568),
 	ENTRY0("shd_seeksorrow", "150505", "0e37bd629858f51e2c83649973170dec", 1362330),
+	ENTRY0("shd_seeksorrow", "160505", "e985ee4cff0da7f034cc76fdf5a65f6e", 1365918),
 	ENTRY0("shd_seeksorrow", "160602", "6108059cd52dc1aba9112b554d6aee0f", 1365918),
 
 	// SmoochieComp 2001
@@ -6417,54 +6454,54 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("verdeterre", "150805", "a2bd16f0dbf5cae8cf90ce71c4c71fb4", 1402584, Common::FR_FRA),
 	ENTRY1("vindaloofr", "021001", "95642b4ec28e36f1e250d343c1342bba", 98816, Common::FR_FRA),
 
-	// French games: French Comp 2005
+	// French Comp 2005 (French)
 	ENTRY1("frc_cercledesgros", "051008", "091a9ab30302eb20d421ccbd0c530439", 128512, Common::FR_FRA),
 	ENTRY1("frc_dreamlands", "050908", "79cecc22e3f020a3ccc23912122785d4", 79872, Common::FR_FRA),
 	ENTRY1("frc_templedefeu", "080317", "ce4d11a46341d6307f4cd2bb303d1c74", 134656, Common::FR_FRA),
 
-	// French games: French Comp 2006
+	// French Comp 2006 (French)
 	ENTRY1("frc_citeeaux", "061024", "aec85f8500c931d478d43bb25d75cf90", 159232, Common::FR_FRA),
 	ENTRY1("frc_sarvegne", "081227", "5f6b489cd12c151e4bf67822a5d22b8a", 239104, Common::FR_FRA),
 
-	// French games: French Comp 2007
+	// French Comp 2007 (French)
 	ENTRY1("frc_heuresduvent", "080220", "5b9470352594bb79edee84ecc0134e4e", 337920, Common::FR_FRA),
 	ENTRY1("frc_divinebonace", "070711", "a09271e95d3720d1e8016600b7871906", 103936, Common::FR_FRA),
 	ENTRY1("frc_brrr", "070709", "8657c6e47832ce1a1a976fc1107e16fc", 73216, Common::FR_FRA),
 	ENTRY1("frc_ilephare_zcode", "071220/z5", "b9a70f4bbebbcdca4c52baa6dbac143f", 102912, Common::FR_FRA),
 
-	// French games: French Comp 2008
+	// French Comp 2008 (French)
 	ENTRY1("frc_brume", "100424", "b661a3f9a2f9a3700c6cfee216063615", 152576, Common::FR_FRA),
 	ENTRY0("frc_lettresvolees", "081227", "2590cafc6a7b22b40bd3765c16a0e3d0", 250880),
 	ENTRY1("frc_louplachevre", "081121", "473a02087280f01a81e4ee4035249ed5", 98304, Common::FR_FRA),
 
-	// French games: French Comp 2009
+	// French Comp 2009 (French)
 	ENTRY1("frc_catapole", "100114", "e326f5ab2f236791b5b8f122d75bdb7d", 156672, Common::FR_FRA),
 	ENTRY1("frc_chambresyrion", "100111", "7db1461b938e392ced1d36747525437d", 123392, Common::FR_FRA),
 	ENTRY1("frc_mechants", "100117", "0d580033a9b180484ea6c8bbc2b6106b", 270848, Common::FR_FRA),
 
-	// French games: French Comp 2011
+	// French Comp 2011 (French)
 	ENTRY1("frc_aventureszeus", "120122", "bef1f77e9dfd65d7d39350e3c50b40ce", 91136, Common::FR_FRA),
 	ENTRY1("frc_dardenfer", "120822", "fea4fe5607327d8f0c15c88b65ac5d9a", 275968, Common::FR_FRA),
 	ENTRY1("frc_terreciel", "120122", "cf24a28bea8bb8f80e006acebbef8e33", 245248, Common::FR_FRA),
 	ENTRY1("frc_astrologue", "120122", "4259e9bb2a97152e454ba8feda4f9a04", 198656, Common::FR_FRA),
 	ENTRY1("frc_homelandsec", "120124", "ea70cf57b134c45c2234c976d06d1948", 155136, Common::FR_FRA),
 
-	// French games: French Comp 2013
+	// French Comp 2013 (French)
 	ENTRY1("frc_lifeonmarsfr", "140108", "8ef2f4e9dfe63bcce9ff7726cdcca7ea", 163840, Common::FR_FRA),
 	ENTRY1("frc_sourcedezig", "140102", "675d4956a12d6a23cf2a7d491e13cbff", 88064, Common::FR_FRA),
 	ENTRY1("frc_trac", "131213", "5db3d7270a0b2c7b8dab1672b2f24b8c", 334848, Common::FR_FRA),
 
-	// French games: French Comp 2015
+	// French Comp 2015 (French)
 	ENTRY1("frc_envol", "150201", "5aa75d7b333fdb69c71601d95d2def30", 157696, Common::FR_FRA),
 
-	// French games: French Comp 2016
+	// French Comp 2016 (French)
 	ENTRY1("frc_tipelau", "160104", "e4c8b0d99ceab57393db70b64dcd49c4", 173568, Common::FR_FRA),
 	ENTRY1("frc_diamantblanc", "160103", "d349be5b008ee06ad93bb7342d5ffbea", 167936, Common::FR_FRA),
 
-	// French games: French Comp 2018
+	// French Comp 2018 (French)
 	ENTRY1("frc_exil", "180114", "ff9628e84c46771168b5be5a9e23acd9", 107520, Common::FR_FRA),
 
-	// French games: French Comp 2021
+	// French Comp 2021 (French)
 	ENTRY1("frc_donjon", "210110", "923d5ef805cb1ab6ecaef82e35750b7f", 201728, Common::FR_FRA),
 	ENTRY1("frc_stationspatial", "210110", "6b9e23599bb921aaf4fc744d80e193f5", 130048, Common::FR_FRA),
 
@@ -6498,51 +6535,51 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("wasserhasser", "140105/zblorb", "1d332f660aec117a4460d0555a2b30f6", 165336, Common::DE_DEU),
 	ENTRY1("wichtel", "021006", "f52166e02c6bd5e0311145683f415ef5", 88576, Common::DE_DEU),
 
-	// German games: Textfire Grand Prix 2002
+	// Textfire Grand Prix 2002 (German)
 	ENTRY1("tgp_eden", "020401/z5", "cac7c7f917cc93824f41efa96bf77e57", 120320, Common::DE_DEU),
 	ENTRY1("tgp_eden", "020401/zblorb", "73a6cf485aa833ca895b0f860493cfce", 221618, Common::DE_DEU),
 	ENTRY1("tgp_bewerbung", "020429", "5b2a90b66bfcf4564b37dab92afe846a", 114688, Common::DE_DEU),
 	ENTRY1("tgp_seite", "020330", "7f1bcab47897d5bbed1351aea77e6f56", 169984, Common::DE_DEU),
 
-	// German games: Textfire Grand Prix 2003
+	// Textfire Grand Prix 2003 (German)
 	ENTRY1("tgp_linear", "030331", "427dd13d669e139f31011da42cdd6c6c", 116736, Common::DE_DEU),
 
-	// German games: Textfire Grand Prix 2004
+	// Textfire Grand Prix 2004 (German)
 	ENTRY1("tgp_jazteg", "040522", "6635a44223e0017418acdeb0c78a9c7a", 192000, Common::DE_DEU),
 	ENTRY1("tgp_spater", "040330", "1dc330438f4f064b5bbc22e3f80d1c2c", 84208, Common::DE_DEU),
 	ENTRY1("tgp_unterwelt", "040330", "606d95b5e66ccdeb54febbbf2de7c60c", 92160, Common::DE_DEU),
 	ENTRY1("tgp_die5", "200304", "2a2139d806fc179c98cf8633f671559f", 121344, Common::DE_DEU),
 	ENTRY1("tgp_dichter", "040222", "ea4afef4907aa5d232fe61168ceca08d", 13808, Common::DE_DEU),
 
-	// German games: Textfire Grand Prix 2005
+	// Textfire Grand Prix 2005 (German)
 	ENTRY1("tgp_kopialbuch", "050330", "3e4b21e39f57ad741fae18b4836e1d64", 151040, Common::DE_DEU),
 
-	// German games: Textfire Grand Prix 2006
+	// Textfire Grand Prix 2006 (German)
 	ENTRY1("tgp_felleisen", "060331", "51b62cb229fde3719ddc616f450ba1e2", 131072, Common::DE_DEU),
 	ENTRY1("tgp_pmason", "060329", "7c7ec84f10d40a90f76685558abaf81c", 138240, Common::DE_DEU),
 
-	// German games: Textfire Grand Prix 2010
+	// Textfire Grand Prix 2010 (German)
 	ENTRY1("tgp_hausaufgabe", "100405", "74a0227fcee105fed02e7458ab8a4e51", 199168, Common::DE_DEU),
 	ENTRY1("tgp_absturzmomente", "100405", "eac3e7f2a6eff119dd4141dc1af7608e", 283542, Common::DE_DEU),
 
-	// German games: Textfire Grand Prix 2011
+	// Textfire Grand Prix 2011 (German)
 	ENTRY1("tgp_gorgonir", "110330", "7b1f7c22b6fb7aceb630958e19c76e54", 542304, Common::DE_DEU),
 	ENTRY1("tgp_ausgerechnet", "110403", "5c4cc7e4689850d0726423cb4d14f6d0", 158720, Common::DE_DEU),
 
-	// German games: IF Grand Prix 2015
+	// IF Grand Prix 2015 (German)
 	ENTRY1("tgp_dieakte", "141113", "a4e9bc0f32e66c521e21373ec67e7b8f", 264704, Common::DE_DEU),
 	ENTRY1("tgp_dieakte", "150514", "f85adc48c759f62636cb435f2fc7dbee", 279040, Common::DE_DEU),
 	ENTRY1("tgp_lilie", "150318", "645bb70a097de033452216d5ef85c8dd", 241256, Common::DE_DEU),
 
-	// German games: IF Grand Prix 2016
+	// IF Grand Prix 2016 (German)
 	ENTRY1("tgp_emilia", "160401", "bb5872728bbc705c3dbaee32e2629d7c", 161280, Common::DE_DEU),
 
-	// German games: IF Grand Prix 2022
+	// IF Grand Prix 2022 (German)
 	ENTRY1("tgp_schief", "220401", "8e74eeb93f60b63ec4eee8a7db80880b", 515794, Common::DE_DEU),
 	ENTRY1("tgp_schief", "220404", "78aaa2553d490488b96bda6abe9a7aa7", 516306, Common::DE_DEU),
 	ENTRY1("tgp_dieerstenacht", "220326", "c9a1532c6122c33ac40fd4cf19f41dbb", 104412, Common::DE_DEU),
 
-	// German games: IF Grand Prix 2023
+	// IF Grand Prix 2023 (German)
 	ENTRY1("tgp_fischstaebchen", "230401", "6c07ebfdcfe23bfcac98cc2a8fdf2c48", 869242, Common::DE_DEU),
 	ENTRY1("tgp_gennorden", "230331", "dcc67e5b97f6aaf5f0c7e90a3c62f128", 208896, Common::DE_DEU),
 
@@ -6619,6 +6656,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("zazie", "990506", "74f0a21352b3f6f52e94309e5a02feaf", 114688, Common::IT_ITA),
 	ENTRY1("zazie", "030113", "906b9a3e02b2080ce7f06595c8bdcbb3", 89600, Common::IT_ITA),
 	ENTRY1("zenfactorspa", "100524", "22373bcd74d843ce647c4bd7b6a4404b", 288256, Common::IT_ITA),
+	ENTRY1("zigamusita_zcode", "160227", "016f92fcf0125765da1ed8b3d8863fab", 98816, Common::IT_ITA),
 	ENTRY1("zigamusita_zcode", "200426/z5", "72ef8669029dce42ec1e1f73ef66fa3c", 98816, Common::IT_ITA),
 	ENTRY1("zombie", "180601", "aa5956094aa8e909f63679a67fb52b14", 134144, Common::IT_ITA),
 	ENTRY1("zombie", "180820", "19a1369039b5226f86323ab19e7aea96", 135168, Common::IT_ITA),
@@ -6626,14 +6664,14 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("zorkita", "000031", "3d85a97ddfc1fb0f6bfbf1cb00b4df7b", 192512, Common::IT_ITA),
 	ENTRY1("zorkita", "v6/000031", "be15759f2273cdaf124dbc40436244b0", 192512, Common::IT_ITA),
 
-	// Italian games: Marmellata d'Avventura 2018
+	// Marmellata d'Avventura 2018 (Italian)
 	ENTRY1("ma_lastprigioniero", "180723", "e658aef675c3b44a5027f52b49d53abb", 199168, Common::IT_ITA),
 	ENTRY1("ma_skepto", "989484", "b1642bac5df936d0d6e56e141a4fd120", 145408, Common::IT_ITA),
 	ENTRY1("ma_dejavu_zcode", "180331/z5", "2fdfccb2539bf6d73ea5b86fe1cb7e81", 116224, Common::IT_ITA),
 	ENTRY1("ma_lazystranocaso", "180331", "6d78774d7c8cc30f8bed2e33458e7fc5", 175616, Common::IT_ITA),
 	ENTRY1("ma_pilastri", "180330", "ff72f757570e2a9d0675507c05a6bf69", 75776, Common::IT_ITA),
 
-	// Italian games: Marmellata d'Avventura 2019
+	// Marmellata d'Avventura 2019 (Italian)
 	ENTRY1("ma_salagamescastle", "191222", "6285d40140396eb6b45a3900d4e79577", 239616, Common::IT_ITA),
 	ENTRY1("ma_tesorosalagames", "191210", "bce5e94aa0667c83a869f9a71774086f", 137216, Common::IT_ITA),
 	ENTRY1("ma_lazysalagiochi", "191215", "f8f5030501e6640dbfef11c850967e93", 114176, Common::IT_ITA),
@@ -6650,12 +6688,13 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("zenin", "070628", "bda2d35eb0614374d02bae623d3a22ec", 90112, Common::SK_SVK),
 
 	// Spanish games
-	ENTRY1("abismo", "022001", "d99185503ef97dcad3a3bb10d6063b76", 94208, Common::ES_ESP),
-	ENTRY1("acuario", "120122", "b0439b17a37760be2d12579e4fc5cb75", 116224, Common::ES_ESP),
+	ENTRY1("abismo_zcode", "022001", "d99185503ef97dcad3a3bb10d6063b76", 94208, Common::ES_ESP),
+	ENTRY1("acuario_zcode", "120122", "b0439b17a37760be2d12579e4fc5cb75", 116224, Common::ES_ESP),
 	ENTRY1("adv", "971209", "2c38b40ffbc8c29fff29acbbefa317e8", 126976, Common::ES_ESP),
 	ENTRY1("adso", "010806", "260d3c709d4efe5538a1f10e725172c6", 116224, Common::ES_ESP),
 	ENTRY1("alicia", "980703", "5070504a35d51bdd7f09c67330170d8c", 65536, Common::ES_ESP),
 	ENTRY1("anillo", "990610", "e071a84c1348e49ccd339be6329ea4e0", 75776, Common::ES_ESP),
+	ENTRY1("anillo3", "15????", "046c9f3c20f190637ff9d1fd94abbcb4", 96256, Common::ES_ESP),
 	ENTRY1("avent", "961111", "7d3f5a62df58d20631f2f38623c26810", 76288, Common::ES_ESP),
 	ENTRY1("aventura", "971209", "5bee30fdf0d157186a3336ac2a977913", 128000, Common::ES_ESP),
 	ENTRY1("bicho", "000402", "b82fba5bce71304bd2545b3c5a987b3b", 61952, Common::ES_ESP),
@@ -6669,6 +6708,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("cruzado", "990610", "d872429765f5c378b35bbb4cd44d7fba", 65024, Common::ES_ESP),
 	ENTRY1("cueva", "150301/z5", "e0a6f6e6949944b7793f2822af687f2f", 74752, Common::ES_ESP),
 	ENTRY1("cueva", "150301/zblorb", "fb45c478ca1c30151186a7703a1040fc", 76172, Common::ES_ESP),
+	ENTRY1("dagon_zcode", "09????", "69f01d02b13d7d873970848da5da0e6e", 190464, Common::ES_ESP),
 	ENTRY1("despert", "980909", "f6c469e0931c9f18f149e1b6da484436", 129536, Common::ES_ESP),
 	ENTRY1("despert", "990519", "2d2bb65c166c24f89dc30be8021309b7", 128000, Common::ES_ESP),
 	ENTRY1("draculasp", "020709", "8466396cd5c66595fee8803f442e2e88", 100352, Common::ES_ESP),
@@ -6677,10 +6717,11 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("edaylobo", "020714", "5a7733503f33e5c63922e04086fef93b", 79360, Common::ES_ESP),
 	ENTRY1("elcontinente", "080402", "6dd46c1e1f58734017f3775b31aac455", 161792, Common::ES_ESP),
 	ENTRY1("ellibro", "030923", "33a3b35529ab33713913f8b92cc8ad8a", 109568, Common::ES_ESP),
+	ENTRY1("elpuzzle", "00???\?/Corrupt", "4285418449df52fff8192db61969280e", 229976, Common::ES_ESP),
 	ENTRY1("encierro", "010101", "083514ce5d9718020083ddd00d85e279", 247808, Common::ES_ESP),
 	ENTRY1("ergotdelima_zcode", "170616/z8", "c0b8265d11c2bb2dd6dd62801fb7ed73", 382464, Common::ES_ESP),
 	ENTRY1("ergotdelima_zcode", "170616/zblorb", "0bcc4c1c8cc24165cb8f02f17f00682d", 606834, Common::ES_ESP),
-	ENTRY1("estacion", "080126", "2a8d4eb4c600ce76f05f03cf862a9328", 92672, Common::ES_ESP),
+	ENTRY1("estacion_zcode", "080126", "2a8d4eb4c600ce76f05f03cf862a9328", 92672, Common::ES_ESP),
 	ENTRY1("excessus", "990610", "5bb56f1cf94a376fb34bfaf9c07791f1", 58880, Common::ES_ESP),
 	ENTRY1("forrajeo", "010101", "d86123253ae4b35570013dd87e48036a", 108032, Common::ES_ESP),
 	ENTRY1("fotopia", "991213", "bb067cca7cd769c20e7bb5dc9ed09c65", 214016, Common::ES_ESP),
@@ -6689,7 +6730,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("gorron", "001127", "74a82670f409c93607e72860552ddda2", 104960, Common::ES_ESP),
 	ENTRY1("gorron", "001205", "639f4ab6b26cc6b6e2023fa848f00d92", 74240, Common::ES_ESP),
 	ENTRY1("gorron", "020726", "67a7a86523a72c85b9cc0a0cf730ee75", 80896, Common::ES_ESP),
-	ENTRY1("hampa", "120621", "7db989262feb3c36e5e6b46eeab7447a", 277504, Common::ES_ESP),
+	ENTRY1("hampa_zcode", "120621/z8", "7db989262feb3c36e5e6b46eeab7447a", 277504, Common::ES_ESP),
 	ENTRY1("heredar", "980907", "d63cdbaf4f65a1fd6bca4f1c14317b38", 56832, Common::ES_ESP),
 	ENTRY1("heresville", "990610", "6b8c930f5b874e0c5a629b6385b0fb30", 70144, Common::ES_ESP),
 	ENTRY1("heresville", "001025", "7d4dfdf7911b926a44c66a355faddf8e", 71168, Common::ES_ESP),
@@ -6700,9 +6741,24 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("islamisteriosa", "120113", "56ce52bdf2d9a51786a4b38cf5cc3725", 236544, Common::ES_ESP),
 	ENTRY1("juguete", "010529", "28b197d2889a7f6c7c8a00c5d8f6c605", 107520, Common::ES_ESP),
 	ENTRY1("laberinto", "081027", "968500b509f1da10153186dfb3d89a37", 164352, Common::ES_ESP),
+	ENTRY1("latorre_zcode", "001031", "7b993efc82e58225d06f86eeb4a62812", 91648, Common::ES_ESP),
+	ENTRY1("latorre_zcode", "001101", "0dda3de17af3eba86fb81fc1d5c926ea", 92672, Common::ES_ESP),
+	ENTRY1("latorre_zcode", "010329", "d4ea29e86a8ca925951224c74a00be0f", 70144, Common::ES_ESP),
+	ENTRY1("latorre_zcode", "010329/v1", "f3583ab9b0eaa47d5153133a628a0666", 70144, Common::ES_ESP),
+	ENTRY1("latorre_zcode", "010329/v2", "39226e9f683f48e6b99895b9a230a577", 70656, Common::ES_ESP),
+	ENTRY1("latorre_zcode", "010329/v3", "498ce02c038595577c56c4c57f6319f9", 70656, Common::ES_ESP),
+	ENTRY1("latorre_zcode", "010329/v4", "dfba87a9e0e6f2701d79a37dda9fc36b", 71168, Common::ES_ESP),
+	ENTRY1("latorre_zcode", "010329/v5", "5bf372c65c8abb3d2cded008147e5630", 71168, Common::ES_ESP),
+	ENTRY1("latorre_zcode", "020530/v1", "b29230110159ad197c88e22e482865bf", 94720, Common::ES_ESP),
+	ENTRY1("latorre_zcode", "020530/v2", "4e5fce18a37f427ae22a1804318febc3", 95232, Common::ES_ESP),
+	ENTRY1("latorre_zcode", "020530/v3", "ffa4d3d6701b228ee95f626d101b9fcb", 98816, Common::ES_ESP),
+	ENTRY1("latorre_zcode", "050702/z5", "e81e82829e35a4d6956ebfc9b883968f", 100352, Common::ES_ESP),
+	ENTRY1("laverja", "070416", "283e88358e58bde90c5a00e593642fbb", 64000, Common::ES_ESP),
+	ENTRY1("legion", "??????", "c7ee0051f293b520aad4c46e5530f783", 169004, Common::ES_ESP),
 	ENTRY1("logicinv", "000809", "0c02dd96b334038619a7a7346ae34a47", 61952, Common::ES_ESP),
 	ENTRY1("logicinv", "000909", "e7225635756c1e4a6a2c990bb8709345", 61952, Common::ES_ESP),
 	ENTRY1("maquina", "980915", "3229392e8493a2ba08efd3ce53d27ee3", 59392, Common::ES_ESP),
+	ENTRY1("marsmenace", "160109", "9d31cc5e05145d355fe7650a723eaa77", 422400, Common::ES_ESP),
 	ENTRY1("marsmenace", "160210", "c2804882005d945917d765b32c6d39ec", 427008, Common::ES_ESP),
 	ENTRY1("memorias_zcode", "000824", "e0af9b9bbef7ff5f9d1281e32e2db488", 65024, Common::ES_ESP),
 	ENTRY1("memorias_zcode", "010325", "91ab4377ff9ced804949d3e854ab431e", 137216, Common::ES_ESP),
@@ -6710,6 +6766,8 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("memorias_zcode", "140726", "25881186f8b84b888fcaae67724d1557", 365568, Common::ES_ESP),
 	ENTRY1("memorias_zcode", "150220", "6796107900bad430d8531c44f306ddbc", 460312, Common::ES_ESP),
 	ENTRY1("mpdroidone", "170820", "ea6bf4230bf6f267f76e191d84fb9804", 353792, Common::ES_ESP),
+	ENTRY1("nada", "010924/Corrupt", "66e0ed01d50e7082e56cffda54fd2d6b", 79872, Common::ES_ESP),
+	ENTRY1("pantalla", "060205", "c7b85db26b1bf03d9e0cc58bcc89758f", 64512, Common::ES_ESP),
 	ENTRY1("paraiso", "000214", "28abb3f35a041ea425b9ec3e93086440", 68096, Common::ES_ESP),
 	ENTRY1("perseo", "150428", "5242114f236e71848be5f6c92fdcb6ef", 26624, Common::ES_ESP),
 	ENTRY1("peso", "981021", "db6fa2c6d6e9d385e0625f9b66c84f6b", 65536, Common::ES_ESP),
@@ -6721,10 +6779,11 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("pyramid", "150427", "7b0f878f298d131024568d9364cf54e7", 29184, Common::ES_ESP),
 	ENTRY1("quenoche", "031015", "0085e1d917110642a700551536770d8d", 101376, Common::ES_ESP),
 	ENTRY1("quovadis", "031110/Demo", "fdebdc9b5ff49977ecec03c9d6800e9c", 63488, Common::ES_ESP),
+	ENTRY1("raro", "000402", "dcbe2202d09a7f5b7dfd6ffb96438fd4", 58880, Common::ES_ESP),
 	ENTRY1("redencionmomificad", "161212", "4e1370baee1a5713a792998f8ff5ce93", 117760, Common::ES_ESP),
 	ENTRY1("reflejos", "010101", "7edc3b30022e97978ea93ef5c22edccd", 144384, Common::ES_ESP),
-	ENTRY1("raro", "000402", "dcbe2202d09a7f5b7dfd6ffb96438fd4", 58880, Common::ES_ESP),
 	ENTRY1("regalo", "100104", "8d7ea3a09f39d1d2de103e5117ad3224", 336064, Common::ES_ESP),
+	ENTRY1("relojes_zcode", "040509/z5", "da0c9341ef8b15f726a18c22bf78877c", 66048, Common::ES_ESP),
 	ENTRY1("roleando", "071221", "09f5aaad79cbb12084241d8d26199ea6", 124416, Common::ES_ESP),
 	ENTRY1("saee", "000721", "d37e0681b1bc1ebbf001d1a37cbd355c", 29696, Common::ES_ESP),
 	ENTRY1("saee", "010308", "0ad5c5a78ea37c53bb614f4bc6f7754f", 31232, Common::ES_ESP),
@@ -6739,17 +6798,18 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("tuuli", "180501", "9382d5a2886dd7681203128a183ebae3", 671650, Common::ES_ESP),
 	ENTRY1("varenna", "190399", "2b984b69649ff9de6c13438e4fb81172", 174592, Common::ES_ESP),
 	ENTRY1("waxworksspa", "140301", "d0de29f4f375f6ce12539f9f26800ae3", 31232, Common::ES_ESP),
+	ENTRY1("werewolf", "99????", "40010f97d191c074f55e045c0a780d0f", 126464, Common::ES_ESP),
 	ENTRY1("zipi", "990707", "98067b8edc5edadf54c66c4becfa8a3c", 9728, Common::ES_ESP),
 	ENTRY1("zna", "000803", "8e6da0f9124591a68d736e3d1036ec98", 59392, Common::ES_ESP),
 	ENTRY1("zna", "001122", "d4652457908490465a0a4b17965cc695", 64000, Common::ES_ESP),
 
-	// Spanish games: Ectocomp 2017 - Le Grand Guignol
+	// Ectocomp 2017 - Le Grand Guignol (Spanish)
 	ENTRY1("ec17_decolor", "171106", "d6fb4727e8ee20d22dbbe17d5673c878", 104960, Common::ES_ESP),
 
-	// Spanish games: Ectocomp 2022 - Le Grand Guignol
+	// Ectocomp 2022 - Le Grand Guignol (Spanish)
 	ENTRY1("ec22_estadop_zcode", "230428", "7da49889125934b46036a89de3e6d3b3", 474158, Common::ES_ESP),
 
-	// Spanish games: Premios Hispanos 2000
+	// Premios Hispanos 2000 (Spanish)
 	ENTRY1("ph00_abalanzate", "001116", "d235b2e983f74f6176aea5b1d1418a78", 79872, Common::ES_ESP),
 	ENTRY1("ph00_alemanes", "000405", "859f5aaec930da12b42e5dbfe42723e9", 82432, Common::ES_ESP),
 	ENTRY1("ph00_aparato", "000428", "46c40135d29e3fda669d974bb1b76b20", 63488, Common::ES_ESP),
@@ -6776,7 +6836,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("ph00_torre", "000208/v2", "a132c528864576ef5df1ee46c76a5c61", 126464, Common::ES_ESP),
 	ENTRY1("ph00_tokland", "001130", "7f5c796474c250f418a47fa9285e3116", 139776, Common::ES_ESP),
 
-	// Spanish games: Premios Hispanos 2001
+	// Premios Hispanos 2001 (Spanish)
 	ENTRY1("ph01_aciegas", "010927", "6825eaa8b9a2cc73293329bfacee1311", 78848, Common::ES_ESP),
 	ENTRY1("ph01_celos", "010403", "6f4dc34a02fe5eb872ffe99faa06fb79", 69632, Common::ES_ESP),
 	ENTRY1("ph01_ch3ch2oh", "010912", "1a4a689b28c4a17c69e7f8e662a63801", 66048, Common::ES_ESP),
@@ -6792,7 +6852,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("ph01_ocaso", "020215/v2", "6b47826cde5cb4bb7777bcb735dd76cc", 164352, Common::ES_ESP),
 	ENTRY1("ph01_segapark", "010506", "2d02fd8559b885868aac6a4adcc09198", 75776, Common::ES_ESP),
 
-	// Spanish games: Premios Hispanos 2002
+	// Premios Hispanos 2002 (Spanish)
 	ENTRY1("ph02_asesinato", "020222", "988085754ca9b41f7ade080d9b9262ff", 79872, Common::ES_ESP),
 	ENTRY1("ph02_aveces", "021024", "3e0c409d60bda50121c47094e30cd24c", 81920, Common::ES_ESP),
 	ENTRY1("ph02_aveces", "030218", "b4232196474c2dc8ae992779e2f5deae", 80384, Common::ES_ESP),
@@ -6811,7 +6871,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("ph02_sombras", "021127", "72b83812567f8a4c9cd523b6a09a9c65", 121856, Common::ES_ESP),
 	ENTRY1("ph02_ultimohogar", "021225", "45edda9ec6eb400f409681d3f2b052d4", 122368, Common::ES_ESP),
 
-	// Spanish games: Premios Hispanos 2003
+	// Premios Hispanos 2003 (Spanish)
 	ENTRY1("ph03_aluzine", "122103", "8d974b6777b04a288db409bfc777bd22", 78336, Common::ES_ESP),
 	ENTRY1("ph03_array", "040107", "8a8e81e62d5762329bfa3d5c7a503d87", 74752, Common::ES_ESP),
 	ENTRY1("ph03_castillo", "031122", "0c6b8c77106dba58e81223c5d5c1da5f", 95744, Common::ES_ESP),
@@ -6828,7 +6888,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("ph03_otrpalab", "010102", "1df1630200c6e9a631bb71af494c7d81", 67072, Common::ES_ESP),
 	ENTRY1("ph03_rural", "031104", "ef441ece688cbeef11eef548d0c54aa1", 105472, Common::ES_ESP),
 
-	// Spanish games: Premios Hispanos 2004
+	// Premios Hispanos 2004 (Spanish)
 	ENTRY1("ph04_islas", "050531", "3d7cee978d4f69e41e8af1a8ccda2b9d", 369152, Common::ES_ESP),
 	ENTRY1("ph04_lamansion", "010103/v1", "332cf78fb9eb0a0a60895bf85b73a7f8", 138752, Common::ES_ESP),
 	ENTRY1("ph04_lamansion", "010103/v2", "0acd4655161f834b562b5560353877bd", 138752, Common::ES_ESP),
@@ -6837,7 +6897,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("ph04_remi", "040801", "8c724781c9356c5c94d2ccfe7dd38aba", 102400, Common::ES_ESP),
 	ENTRY1("ph04_remi", "050107", "9c91d2d67a112caa5f51aae4dfc6d4f9", 102912, Common::ES_ESP),
 
-	// Spanish games: Premios Hispanos 2005
+	// Premios Hispanos 2005 (Spanish)
 	ENTRY1("ph05_bardo", "050918", "7fbedef94068625973d94d672549f0ab", 156672, Common::ES_ESP),
 	ENTRY1("ph05_castilsilenco", "031205", "09ef4bbe2455f592941c817cd17cd865", 77824, Common::ES_ESP),
 	ENTRY1("ph05_elprotector", "010103/v1", "3189852634dcc62258c4e3af727bac46", 154624, Common::ES_ESP),
@@ -6850,7 +6910,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("ph05_trono", "060105/z5", "27576046399a460904d06942d534549c", 198656, Common::ES_ESP),
 	ENTRY1("ph05_trono", "060105/zblorb", "87bfb28edc44caf30706f3643277ce51", 200052, Common::ES_ESP),
 
-	// Spanish games: Premios Hispanos 2006
+	// Premios Hispanos 2006 (Spanish)
 	ENTRY1("ph06_draculasp2", "060331", "eec7853595240864f25c34da9083ca8b", 108032, Common::ES_ESP),
 	ENTRY1("ph06_draculasp2", "080819", "4de47380bf5d802f295a487eaf1499c6", 123392, Common::ES_ESP),
 	ENTRY1("ph06_elgatocheko", "061106", "3e668bdd0359ea7bdd6953f063ad0aaf", 110080, Common::ES_ESP),
@@ -6861,13 +6921,13 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("ph06_regreso", "060704", "21565444255a18e57988d983a283962b", 114176, Common::ES_ESP),
 	ENTRY1("ph06_resaca", "060713", "868eb485714fbc34358bff2dfa9335d0", 152576, Common::ES_ESP),
 
-	// Spanish games: Premios Hispanos 2007
+	// Premios Hispanos 2007 (Spanish)
 	ENTRY1("ph07_030307", "070303", "1483dca6052bb366ac32ef4901064b11", 143872, Common::ES_ESP),
 	ENTRY1("ph07_afuera", "010101", "9ed80d0b530f38cce7a7b2c0f1b6ccd9", 116224, Common::ES_ESP),
 	ENTRY1("ph07_aod", "071128", "6e486ac2bc483fab7bb713fa9e954e46", 178176, Common::ES_ESP),
 	ENTRY1("ph07_boxman", "071223", "a1c807338a3a5db6a26d3a27004a54cb", 71680, Common::ES_ESP),
 	ENTRY1("ph07_boxman", "080205", "384ea944adc4be83396c5368a3ba5ed9", 71680, Common::ES_ESP),
-	ENTRY1("ph07_edc_zcode", "070831", "3c4b4c9963fbcf69d858f6d16d9b584b", 126464, Common::ES_ESP),
+	ENTRY1("ph07_edc_zcode", "070831/z5", "3c4b4c9963fbcf69d858f6d16d9b584b", 126464, Common::ES_ESP),
 	ENTRY1("ph07_faro07", "070803", "54fdad7789f03d4c7644835bd295ad1f", 94208, Common::ES_ESP),
 	ENTRY1("ph07_htec_zcode", "071222", "64cf677261e13fb9fa6e071c3c864ae0", 222816, Common::ES_ESP),
 	ENTRY1("ph07_htec_zcode", "111128", "1e4369aae046805529ca8b490c9e5774", 394904, Common::ES_ESP),
@@ -6878,11 +6938,12 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("ph07_mausoleo", "071223", "a4356d2f89052328323a3dd2ce069658", 164864, Common::ES_ESP),
 	ENTRY1("ph07_umami", "070807", "86a045a71db97910e78ba402b33c5c7d", 80384, Common::ES_ESP),
 
-	// Spanish games: Premios Hispanos 2008
+	// Premios Hispanos 2008 (Spanish)
 	ENTRY1("ph08_diana_zcode", "080806", "2b117f98896856713a418bcd782be568", 107008, Common::ES_ESP),
 	ENTRY1("ph08_emmy", "080915", "92890016648bbfe1290f71d9a903afc9", 79872, Common::ES_ESP),
 	ENTRY1("ph08_gambito", "081202", "6ea6121f1891d46fe8cc957ef8939d68", 235990 , Common::ES_ESP),
 	ENTRY1("ph08_mushahierba", "081021", "2d28f401d63f163e5d34115fec07df72", 207240, Common::ES_ESP),
+	ENTRY1("ph08_pincoya", "010101", "a453de0f39d10cd9eb3ca028457b2b1a", 167424, Common::ES_ESP),
 	ENTRY1("ph08_pincoya", "010102", "bafb201726dd331308cdf34ec1e478cb", 168960, Common::ES_ESP),
 	ENTRY1("ph08_pronto", "080720", "a48b81b1c97d6074e3679659f9dce23a", 270826, Common::ES_ESP),
 	ENTRY1("ph08_sm1pesadilla", "080430", "79f8cb30a31146e08465acd9038ba7e6", 604046, Common::ES_ESP),
@@ -6895,7 +6956,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("ph08_venenaverbo", "160516", "0a89f0ad5b3df50ff6f32d961cce2c00", 192512, Common::ES_ESP),
 	ENTRY1("ph08_venenaverbo", "160517", "1c7c3ce13621f78e7cf6752a2b0fc58b", 192512, Common::ES_ESP),
 
-	// Spanish games: Premios Hispanos 2009
+	// Premios Hispanos 2009 (Spanish)
 	ENTRY1("ph09_amanda", "091110/z5", "11b63cb4c4ca11b86e835c1b00f9c5ae", 132096, Common::ES_ESP),
 	ENTRY1("ph09_amanda", "091110/zblorb", "c373f508436b06081cd76039dc17582e", 342504, Common::ES_ESP),
 	ENTRY1("ph09_gorbag", "100104", "581e67f731d6b1d0d40bfc38cb531bf9", 199168, Common::ES_ESP),
@@ -6907,11 +6968,12 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY1("ph09_megara", "091204/z5", "94b7019ed62d257344ef39727011c250", 214016, Common::ES_ESP),
 	ENTRY1("ph09_megara", "091204/zblorb", "6798f8acb0c0c60d1026a1e9a6469b55", 472716, Common::ES_ESP),
 	ENTRY1("ph09_panajo", "010102", "3969bf7b2dd00b342e6c0b4ec797919a", 124416, Common::ES_ESP),
+	ENTRY1("ph09_panajo", "010102", "3969bf7b2dd00b342e6c0b4ec797919a", 124416, Common::ES_ESP),
 	ENTRY1("ph09_sm6ascenso", "090409/z5", "108dd4e7623634e6ff7ca976118dfa29", 220672, Common::ES_ESP),
 	ENTRY1("ph09_sm6ascenso", "090409/zblorb", "352b9bb39f2fff76b409025670169a98", 380434, Common::ES_ESP),
-	ENTRY1("ph09_visitantes", "091130", "d8e7c7376b11f022e109069e4ad3b22a", 87040, Common::ES_ESP),
+	ENTRY1("ph09_visit_zcode", "091130/z5", "d8e7c7376b11f022e109069e4ad3b22a", 87040, Common::ES_ESP),
 
-	// Spanish games: Premios Hispanos 2010
+	// Premios Hispanos 2010 (Spanish)
 	ENTRY1("ph10_azul", "101223/z5", "a9b6daf1a3b3da110d1d17c1587feeef", 260096, Common::ES_ESP),
 	ENTRY1("ph10_azul", "101223/zblorb", "f6b9cd8892425e7cb97465baf950b602", 362332, Common::ES_ESP),
 	ENTRY1("ph10_lpc_zcode", "101213/z5", "b4e747ef59bf719b2edecf6b3796883f", 110592, Common::ES_ESP),
@@ -7619,6 +7681,7 @@ const FrotzGameDescription FROTZ_GAMES[] = {
 	ENTRY0("theultimatum", "190429", "fb639da6d478a4fbf98e7d665898128d", 158720),
 	ENTRY0("theuntoldstory", "200725", "d8be5eb87abdb0fb4f38a02fe51dc5bd", 158208),
 	ENTRY0("thevirtgrandnation", "201103", "d213d8213d5816463fac57157e89c4e7", 175104),
+	ENTRY0("thewallet", "210501", "671b69cc29a54377beaae50f9cd9cd7f", 328704),
 	ENTRY0("thewallet", "210519", "375f70bb3b6451233751446035a18521", 165888),
 	ENTRY0("thewizardcrystal", "150620", "b0a6cd566dce360e5b0ae33c601d9ce0", 164352),
 	ENTRY0("thewizardslair", "150619", "a61b54e81e5b3b3898773546748aa874", 164352),


### PR DESCRIPTION
This PR updates various GLK subsystem:

- ADRIFT: 2 new entries
- GLULX: 138 new entries
- ZCODE: 43 new entries

plus minimal adjustments for Competition titles and for gameIDs to avoids clashing.
