### PR TITLE
COMMON: Add INIFile::requireKeyValueDelimiter(), Fix Sheila Rae

### DIFF
--- a/common/formats/ini-file.cpp
+++ b/common/formats/ini-file.cpp
@@ -53,6 +53,7 @@ bool INIFile::isValidName(const String &name) const {
 INIFile::INIFile() {
 	_allowNonEnglishCharacters = false;
 	_suppressValuelessLineWarning = false;
+	_requireKeyValueDelimiter = false;
 }
 
 void INIFile::clear() {
@@ -174,6 +175,11 @@ bool INIFile::loadFromStream(SeekableReadStream &stream) {
 			if (!p) {
 				if (!_suppressValuelessLineWarning)
 					warning("Config file buggy: Junk found in line %d: '%s'", lineno, line.c_str());
+
+				// there is no '=' on this line. skip if delimiter is required.
+				if (_requireKeyValueDelimiter)
+					continue;
+
 				kv.key = line;
 				kv.value.clear();
 			}  else {
@@ -479,6 +485,10 @@ void INIFile::allowNonEnglishCharacters() {
 
 void INIFile::suppressValuelessLineWarning() {
 	_suppressValuelessLineWarning = true;
+}
+
+void INIFile::requireKeyValueDelimiter() {
+	_requireKeyValueDelimiter = true;
 }
 
 } // End of namespace Common

--- a/common/formats/ini-file.h
+++ b/common/formats/ini-file.h
@@ -133,11 +133,24 @@ public:
 	void allowNonEnglishCharacters(); /*!< Allow non-English characters in this INI file. */
 	void suppressValuelessLineWarning(); /*!< Disable warnings for lines that contain only keys. */
 
+	/**
+	 * Requires that every key/value line have a delimiter character.
+	 * Otherwise, lines that don't contain a delimiter are interpreted as
+	 * if the entire line is a key with an empty value. This can cause
+	 * unexpected junk lines to reach engines. (bug #13920)
+	 *
+	 * It may be better if instead this were the default behavior for
+	 * clients to disable if needed, but first we would need to identify
+	 * everything that depends on the current behavior.
+	 */
+	void requireKeyValueDelimiter();
+
 private:
 	String		_defaultSectionName;
 	SectionList _sections;
 	bool _allowNonEnglishCharacters;
 	bool _suppressValuelessLineWarning;
+	bool _requireKeyValueDelimiter;
 
 	Section *getSection(const String &section);
 	const Section *getSection(const String &section) const;

--- a/engines/mohawk/livingbooks.cpp
+++ b/engines/mohawk/livingbooks.cpp
@@ -153,6 +153,9 @@ MohawkEngine_LivingBooks::MohawkEngine_LivingBooks(OSystem *syst, const MohawkGa
 	SearchMan.addSubDirectoryMatching(gameDataDir, "Rugrats Adventure Game", 0, 2);
 	// CarmenTQ
 	SearchMan.addSubDirectoryMatching(gameDataDir, "95instal", 0, 4);
+
+	// Sheila Rae, the Brave (Europe version) contains a junk line (bug #13920) 
+	_bookInfoFile.requireKeyValueDelimiter();
 }
 
 MohawkEngine_LivingBooks::~MohawkEngine_LivingBooks() {


### PR DESCRIPTION
The INI parser currently interprets lines that don't contain a key-value delimiter (the `=` character) as if the entire line is a key with an empty value. The European version of Sheila Rae, the Brave contains this INI file:

![image](https://github.com/scummvm/scummvm/assets/22204938/921e409b-31ec-43b9-9e14-9db82698e4a5)

That junk line of 0x7F characters gets parsed as key with no value, the Mohawk Little Books engine iterates over key/values in `Globals` and does further parsing, and the unexpected 0x7F causes an `error` on engine init.

I don't think the current INI parser behavior is a good default, but at this point engines must already depend on it, so changing it would certainly break something. I've added a flag to enable stricter parsing that ignores lines without a delimiter and enabled it for Mohawk Little Books. (I think is also how Windows' parser behaves/behaved, but I'm going off of memory.)

I'm hoping this is self-contained enough that we can get it in the 2.8.0 release.

Fixes bug #13920