### PR TITLE
ULTIMA: ULTIMA6: Ranged combat rework

### DIFF
--- a/devtools/create_ultima/files/ultima6/scripts/u6/actor.lua
+++ b/devtools/create_ultima/files/ultima6/scripts/u6/actor.lua
@@ -1622,30 +1622,35 @@ function combat_range_weapon_1D5F9(attacker, target_x, target_y, target_z, weapo
       if map_is_water(target_x,target_y,target_z) == false then
 	      local obj = Obj.new(317); --fire field
           obj.temporary = true
-	      Obj.moveToMap(obj, target_x, target_y, target_z)
+	      Obj.moveToMap(obj, pre_coll_tiles[1].x, pre_coll_tiles[1].y, pre_coll_tiles[1].z)
       end
 
    elseif weapon_obj_n == 0x24 or weapon_obj_n == 0x25 or weapon_obj_n == 0x26 then
       --spear, throwing axe, dagger
 
-      --remove unreadied throwing weapons from inventory first so weapon stays readied
-      local removal_candidate = nil
-      for inv_obj in actor_inventory(attacker) do
-          if inv_obj.obj_n == weapon_obj_n then
-              removal_candidate = inv_obj
-              if removal_candidate.readied ~= true then
+      -- Only remove thrown weapon from attacker if distance to target is > 1,
+      -- else just skip handling and keep the item
+      if abs(coll_tiles[1].x - attacker.x) > 1 or abs(coll_tiles[1].y - attacker.y) > 1 then
+         --remove unreadied throwing weapons from inventory first so weapon stays readied
+         local removal_candidate = nil
+         for inv_obj in actor_inventory(attacker) do
+            if inv_obj.obj_n == weapon_obj_n then
+               removal_candidate = inv_obj
+               if removal_candidate.readied ~= true then
                   break
-              end
-          end
-      end
-      if removal_candidate ~= nil then
-          Actor.inv_remove_obj(attacker, removal_candidate)
-          if map_is_water(target_x,target_y,target_z) == false then
-              local obj = Obj.new(weapon_obj_n);
-              obj.ok_to_take = true
-              obj.temporary = true
-              Obj.moveToMap(obj, target_x, target_y, target_z)
-          end
+               end
+            end
+         end
+         if removal_candidate ~= nil then
+            Actor.inv_remove_obj(attacker, removal_candidate)
+            -- Do not place thrown weapon if target is an actor
+            if (coll_tiles[1].foe == mil or coll_tiles[1].foe.luatype ~= "actor") and map_is_water(pre_coll_tiles[1].x, pre_coll_tiles[1].y, pre_coll_tiles[1].z) == false then
+               local obj = Obj.new(weapon_obj_n);
+               obj.ok_to_take = true
+               obj.temporary = true
+               Obj.moveToMap(obj, pre_coll_tiles[1].x, pre_coll_tiles[1].y, pre_coll_tiles[1].z)
+            end
+         end
       end
    elseif weapon_obj_n == 0x29 or weapon_obj_n == 0x2a or weapon_obj_n == 0x32 or weapon_obj_n == 0x36 then
       --bow, crossbow, triple crossbow, magic bow

--- a/devtools/create_ultima/files/ultima6/scripts/u6/actor.lua
+++ b/devtools/create_ultima/files/ultima6/scripts/u6/actor.lua
@@ -1536,7 +1536,7 @@ function actor_attack(attacker, target_x, target_y, target_z, weapon, foe)
 
       if weapon_obj_n == 0x31 then --boomerang
          if attacker.x ~= 0 and attacker.y ~= 0 then --hack to stop return projectile if the avatar has died
-         	projectile(projectile_weapon_tbl[weapon_obj_n][1], target_x, target_y, attacker.x, attacker.y, projectile_weapon_tbl[weapon_obj_n][3], projectile_weapon_tbl[weapon_obj_n][4])
+            projectile(projectile_weapon_tbl[weapon_obj_n][1], coll_tiles[1].x, coll_tiles[1].y, attacker.x, attacker.y, projectile_weapon_tbl[weapon_obj_n][3], projectile_weapon_tbl[weapon_obj_n][4])
          end
       end
    end

--- a/devtools/create_ultima/files/ultima6/scripts/u6/actor.lua
+++ b/devtools/create_ultima/files/ultima6/scripts/u6/actor.lua
@@ -1561,7 +1561,7 @@ function combat_range_weapon_1D5F9(attacker, target_x, target_y, target_z, weapo
 
    --set up targets table
    if weapon_obj_n == 0x32 then --triple crossbow
-      local index = ((attacker.y - target_y + 5) * 11) + (attacker.x - target_x + 5) + 1
+      local index = ((target_y - attacker.y + 5) * 11) + (target_x - attacker.x + 5) + 1
       targets = {
          {x=target_x,
           y=target_y,

--- a/devtools/create_ultima/files/ultima6/scripts/u6/actor.lua
+++ b/devtools/create_ultima/files/ultima6/scripts/u6/actor.lua
@@ -1597,9 +1597,9 @@ function combat_range_weapon_1D5F9(attacker, target_x, target_y, target_z, weapo
    -- Projectile animation
    -- TODO: Animation currently does its own collision checking. This should only be done once.
    if weapon_obj_n == 0x32 then --triple crossbow
-      projectile_anim_multi(projectile_weapon_tbl[weapon_obj_n][1], attacker.x, attacker.y, targets, projectile_weapon_tbl[weapon_obj_n][3], 0, projectile_weapon_tbl[weapon_obj_n][2])
+      projectile_anim_multi(projectile_weapon_tbl[weapon_obj_n][1], attacker.x, attacker.y, coll_tiles, projectile_weapon_tbl[weapon_obj_n][3], 0, projectile_weapon_tbl[weapon_obj_n][2])
    else
-      projectile(projectile_weapon_tbl[weapon_obj_n][1], attacker.x, attacker.y, target_x, target_y, projectile_weapon_tbl[weapon_obj_n][3], projectile_weapon_tbl[weapon_obj_n][4])
+      projectile(projectile_weapon_tbl[weapon_obj_n][1], attacker.x, attacker.y, coll_tiles[1].x, coll_tiles[1].y, projectile_weapon_tbl[weapon_obj_n][3], projectile_weapon_tbl[weapon_obj_n][4])
    end
 
    if weapon_obj_n == 0x5b then

--- a/engines/ultima/nuvie/core/map.cpp
+++ b/engines/ultima/nuvie/core/map.cpp
@@ -750,6 +750,8 @@ bool Map::lineTest(int start_x, int start_y, int end_x, int end_y, uint8 level,
 	uint32 count;
 	int xtile = start_x;
 	int ytile = start_y;
+	int xtile_prev = xtile;
+	int ytile_prev = ytile;
 
 
 	if (deltax >= deltay) {
@@ -786,11 +788,16 @@ bool Map::lineTest(int start_x, int start_y, int end_x, int end_y, uint8 level,
 	for (uint32 i = 0; i < count; i++) {
 		//  only test for collision if tile coordinates have changed
 		if ((scale_factor_log2 == 0 || x >> scale_factor_log2 != xtile || y >> scale_factor_log2 != ytile)) {
+			xtile_prev = xtile;
+			ytile_prev = ytile;
 			xtile = x >> scale_factor_log2; //  scale back down to tile
 			ytile = y >> scale_factor_log2; //  space if necessary
 			//  test the current location
-			if ((i >= skip) && (testIntersection(xtile, ytile, level, flags, Result, excluded_obj) == true))
+			if ((i >= skip) && (testIntersection(xtile, ytile, level, flags, Result, excluded_obj) == true)) {
+				Result.pre_hit_x = xtile_prev;
+				Result.pre_hit_y = ytile_prev;
 				return true;
+			}
 		}
 
 		if (d < 0) {

--- a/engines/ultima/nuvie/core/map.h
+++ b/engines/ultima/nuvie/core/map.h
@@ -68,6 +68,8 @@ public:
 
 	int     hit_x;      // x coord where object / actor was hit
 	int     hit_y;      // y coord where object / actor was hit
+	int     pre_hit_x;
+	int     pre_hit_y;
 	uint8   hit_level;  // map level where object / actor was hit
 	Actor  *hitActor;
 	Obj    *hitObj;

--- a/engines/ultima/nuvie/script/script.cpp
+++ b/engines/ultima/nuvie/script/script.cpp
@@ -3146,14 +3146,15 @@ static int nscript_map_line_test(lua_State *L) {
 
 /***
 Returns the first point on a line between x,y and x1, y1 where a missile boundary tile is crossed
-If no boundary tiles are crossed on the line then x1, y1 are returned
+Additionally returns the point checked before the hit
+If no boundary tiles are crossed on the line then x1, y1 are returned for both points
 @function map_line_hit_check
 @int x
 @int y
 @int x1
 @int y1
 @int z
-@treturn int,int an x,y coord
+@treturn int,int,int,int x,y coords
 @within map
  */
 static int nscript_map_line_hit_check(lua_State *L) {
@@ -3171,12 +3172,17 @@ static int nscript_map_line_hit_check(lua_State *L) {
 	if (map->lineTest(x, y, x1, y1, level, LT_HitMissileBoundary, result, 0, nullptr, true)) {
 		lua_pushinteger(L, result.hit_x);
 		lua_pushinteger(L, result.hit_y);
+		lua_pushinteger(L, result.pre_hit_x);
+		lua_pushinteger(L, result.pre_hit_y);
 	} else {
+		lua_pushinteger(L, x1);
+		lua_pushinteger(L, y1);
+		// no collision, return starting coordinates again instead of pre_hit_x/y
 		lua_pushinteger(L, x1);
 		lua_pushinteger(L, y1);
 	}
 
-	return 2;
+	return 4;
 }
 
 /***


### PR DESCRIPTION
This aims to make ranged attacks behave closer to the original.
Fixes the following differences:

1. If a ranged attack is blocked, it should hit the blocking object (e.g. a closed door)
2. When failing a ranged attack roll the target coordinates are shifted randomly and another attack roll is made: It should be possible to roll against the same target again when the random shift is zero
3. The attack roll should be done before checking for collisions, so coordinates get shifted even if there is no line of fire to the target
4. In case a thrown weapon is blocked by an object, it should be placed on the tile traversed before the collision occurred (i.e. not on a door/wall)
5. Thrown weapons should only be placed on the map and removed from the attacker if the distance to the target is greater than one
6. Thrown weapons should not be placed on the map if the target is an actor (the item should still be removed from the attacker in this case)
7. The target calculation for triple crossbow additional projectiles was incorrect
8. The attacker should not be able to hit itself on a miss

Most of the changes are in the lua scripts, so ultima.dat needs to be regenerated for testing this (alternatively, the game's extra path can be set to "devtools/create_ultima").