### PR TITLE
DIRECTOR: Add detection entries for Tivola Sampler discs

### DIFF
--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -7787,8 +7787,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1("thesims", "", "maxis.exe", "d62438566e44826960fc16c5c23dbe43", 1915533, 650),
 
 	// Tivola demo/sampler disc, Summer 2000, released in Germany
-	WINGAME2_l("tivolasummer2000", "Sampler", "START32.EXE", "1b8d78ddca650041b8997cac7af3184b", 1675134,
-											   "INTRO.DXR",   "a9c22c2247353e17cc6385eb9cbcb014", 1169358, Common::DE_DEU, 650),
+	WINGAME2_l("tivolasummer2000", "Sampler", "START32.EXE",  "t:6e942f3ee581d326d0a5bd41bc29e220", 1675134,
+											  "INTRO.DXR",    "a9c22c2247353e17cc6385eb9cbcb014",   1169358, Common::DE_DEU, 650),
 
 	// ein Fall für TKKG: Tödliche Schokolade (bilingual DE/EN)
 	MACGAME2("tkkg2", "", "TKKG start", "7ce3e3594ca71914e50806cf934ac714", 1032378,

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -7786,6 +7786,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	WINGAME1("thesims", "", "maxis.exe", "d62438566e44826960fc16c5c23dbe43", 1915533, 650),
 
+	// Tivola demo/sampler disc, Summer 2000, released in Germany
+	WINGAME1_l("tivolas2000", "Sampler", "START32.EXE", "1b8d78ddca650041b8997cac7af3184b", 1675134, Common::DE_DEU, 650),
+
 	// ein Fall für TKKG: Tödliche Schokolade (bilingual DE/EN)
 	MACGAME2("tkkg2", "", "TKKG start", "7ce3e3594ca71914e50806cf934ac714", 1032378,
 						  "SCORE.DXR",  "4d3d5b66729e31d35828e40aee85fe39", 10849, 602),
@@ -8224,9 +8227,6 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Copies provided in The Daily Mirror
 	WINGAME2("thematrix", "", "Presentation.exe", "c1a2e8b7e41fa204009324a9c7db1030", 2212124,
 							  "intro.dir",        "ebe2cac80218c4933ecc609cd8ef27cc", 10368479, 700),
-
-	// Tivola demo/sampler disc, Summer 2000, released in Germany
-	WINGAME1_l("tivolas2000", "Sampler", "START32.EXE", "1b8d78ddca650041b8997cac7af3184b", 1675134, Common::DE_DEU, 650),
 
 	// ein Fall für TKKG: Wer stoppt den Feuerteufel? (bilingual DE/EN)
 	MACGAME2("tkkg7", "", "TKKG-Start", "0944b962ebb00f4b5d5149d220f8449b", 113458,

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -1514,6 +1514,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "sfk",				"Science for Kids Product Demos" },
 	{ "sonywalkman",		"Sony Walkman PRD-155SB / PRD-150" },
 	{ "techiescom",			"techies.com Business Card" },
+	{ "tivolas2000",		"Tivola Demo - Sommer 2000" },
 	{ "tlc",				"The Learning Company Sampler" },
 	{ "ubt",				"Under the Big Top" },
 	{ "vygrpresents",		"Voyager Presents" },
@@ -8223,6 +8224,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Copies provided in The Daily Mirror
 	WINGAME2("thematrix", "", "Presentation.exe", "c1a2e8b7e41fa204009324a9c7db1030", 2212124,
 							  "intro.dir",        "ebe2cac80218c4933ecc609cd8ef27cc", 10368479, 700),
+
+	// Tivola demo/sampler disc, Summer 2000, released in Germany
+	WINGAME1_l("tivolas2000", "Sampler", "START32.EXE", "1b8d78ddca650041b8997cac7af3184b", 1675134, Common::DE_DEU, 650),
 
 	// ein Fall für TKKG: Wer stoppt den Feuerteufel? (bilingual DE/EN)
 	MACGAME2("tkkg7", "", "TKKG-Start", "0944b962ebb00f4b5d5149d220f8449b", 113458,

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -7787,7 +7787,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1("thesims", "", "maxis.exe", "d62438566e44826960fc16c5c23dbe43", 1915533, 650),
 
 	// Tivola demo/sampler disc, Summer 2000, released in Germany
-	WINGAME1_l("tivolasummer2000", "Sampler", "START32.EXE", "1b8d78ddca650041b8997cac7af3184b", 1675134, Common::DE_DEU, 650),
+	WINGAME2_l("tivolasummer2000", "Sampler", "START32.EXE", "1b8d78ddca650041b8997cac7af3184b", 1675134,
+											   "INTRO.DXR",   "a9c22c2247353e17cc6385eb9cbcb014", 1169358, Common::DE_DEU, 650),
 
 	// ein Fall für TKKG: Tödliche Schokolade (bilingual DE/EN)
 	MACGAME2("tkkg2", "", "TKKG start", "7ce3e3594ca71914e50806cf934ac714", 1032378,

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -1514,7 +1514,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "sfk",				"Science for Kids Product Demos" },
 	{ "sonywalkman",		"Sony Walkman PRD-155SB / PRD-150" },
 	{ "techiescom",			"techies.com Business Card" },
-	{ "tivolas2000",		"Tivola Demo - Sommer 2000" },
+	{ "tivolasummer2000",	"Tivola Demo - Sommer 2000" },
 	{ "tlc",				"The Learning Company Sampler" },
 	{ "ubt",				"Under the Big Top" },
 	{ "vygrpresents",		"Voyager Presents" },
@@ -7787,7 +7787,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1("thesims", "", "maxis.exe", "d62438566e44826960fc16c5c23dbe43", 1915533, 650),
 
 	// Tivola demo/sampler disc, Summer 2000, released in Germany
-	WINGAME1_l("tivolas2000", "Sampler", "START32.EXE", "1b8d78ddca650041b8997cac7af3184b", 1675134, Common::DE_DEU, 650),
+	WINGAME1_l("tivolasummer2000", "Sampler", "START32.EXE", "1b8d78ddca650041b8997cac7af3184b", 1675134, Common::DE_DEU, 650),
 
 	// ein Fall für TKKG: Tödliche Schokolade (bilingual DE/EN)
 	MACGAME2("tkkg2", "", "TKKG start", "7ce3e3594ca71914e50806cf934ac714", 1032378,


### PR DESCRIPTION
This PR adds a detection entry for the German sampler disc of Tivola, released in Summer 2000.

It contains various samples and demos of other DIRECTOR games made by the same publisher that can be launched through the START32/START16.EXE projects.

Reported DIRECTOR version according to the file details is 6.5G.