### PR TITLE
DIRECTOR: Add D4 workaround for freezing behaviour fix (backport)

### DIFF
--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -541,7 +541,9 @@ void Score::update() {
 			}
 		}
 		// If another frozen state gets triggered, wait another update() before thawing
-		if (_window->frozenLingoStateCount() > 0)
+		if ((_vm->getVersion() < 400) && _window->frozenLingoStateCount() > 0)
+			return;
+		else if ((_vm->getVersion() >= 400) && _window->frozenLingoStateCount() > count)
 			return;
 	}
 


### PR DESCRIPTION
Freezing changed pretty significantly in D4, so it figures that the conditions for a frame update would change with it.

Fixes regression where loading save games in The Dark Eye would result in a white screen.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
