### PR TITLE
GRAPHICS: MACGUI: [RFC, needs review] Avoid recursion in Mac menu event processing (bug 14741)

### DIFF
--- a/graphics/macgui/macmenu.cpp
+++ b/graphics/macgui/macmenu.cpp
@@ -1285,16 +1285,6 @@ bool MacMenu::mouseClick(int x, int y) {
 			_wm->activateMenu();
 
 		setActive(true);
-
-		if (_wm->_mode & kWMModalMenuMode) {
-			draw(_wm->_screen);
-			eventLoop();
-
-			// Do not do full refresh as we took care of restoring
-			// the screen. WM is not even aware we were drawing.
-			_wm->setFullRefresh(false);
-		}
-
 		return true;
 	}
 

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -1058,8 +1058,18 @@ bool MacWindowManager::processEvent(Common::Event &event) {
 	}
 
 	// Menu gets events first for shortcuts and menu bar
-	if (_menu && _menu->processEvent(event))
+	if (_menu && _menu->processEvent(event)) {
+		if (_mode & kWMModalMenuMode) {
+			_menu->draw(_screen);
+			_menu->eventLoop();
+
+			// Do not do full refresh as we took care of restoring
+			// the screen. WM is not even aware we were drawing.
+			setFullRefresh(false);
+		}
+
 		return true;
+	}
 
 	if (_activeWindow != -1) {
 		if ((_windows[_activeWindow]->isEditable() && _windows[_activeWindow]->getType() == kWindowWindow &&


### PR DESCRIPTION
This is my attempt at fixing https://bugs.scummvm.org/ticket/14741

However, I don't have  any good test case for how it's _supposed_ to work. Maybe I've broken things, maybe I'm going about this the entirely wrong way. That said...

When moving the mouse through the menu bar, over a part that's not occupied by menu items, the Mac menu class will start calling processEvent() recursively through eventLoop(). This is bad for two reasons: During the recursion (which can easily reach a depth of dozens or even hundreds of calls) there is no delay, so it will use 100% CPU. And once the recursion unwinds, all the delays will come at once.

The visible result is that the mouse cursor moves very sluggishly, and afterwards there may be a noticeable delay. (Though the latter is probably only noticeable if you actively _try_ to stress it.)

This moves the call to eventLoop() to after the first event has been fully processed. Hopefully that will have approximately the same desired effect, without any of the bad side effects.

I've seen the bug happen in the Mac versions of Indiana Jones and the Last Crusade and Loom, but also in Director games like Spaceship Warlock.

This only happens when the GUI is "modal". My main worry is that maybe after my change, the GUI isn't quite modal enough...