### PR TITLE
NEWS: Change news line about GM device setting change

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,7 +30,7 @@ For a more comprehensive changelog of the latest experimental code, see:
      Synthesis) sound driver.
    - Added YUV422 and YUV444 support to Theora decoder.
    - Implemented specialized CPU routines for graphics blitting for ManagedSurface.
-   - Changed default GM device to "auto" for better compatibility.
+   - General MIDI support is now enabled by default.
 
  AGS:
    - Synced with upstream AGS 3.6.0.53.


### PR DESCRIPTION
Change the wording of the news line about the GM device change.

I think "compatibility" suggests something working vs. not working when this is more of a quality change than anything.

I think describing it this way will be clearer about what has changed (General MIDI was previously disabled by default, and now it is not).