### PR TITLE
MTROPOLIS: remove unused variable

### DIFF
--- a/engines/mtropolis/detection.cpp
+++ b/engines/mtropolis/detection.cpp
@@ -99,13 +99,10 @@ ADDetectedGame MTropolisMetaEngineDetection::fallbackDetect(const FileMap &allFi
 
 	MTropolis::MTropolisGameDescription *desc = &_globalFallbackDesc;
 
-	const char *scriptName = nullptr;
 	if (foundWin) {
 		desc->desc.platform = Common::kPlatformWindows;
-		scriptName = winBootFileName;
 	} else if (foundMac) {
 		desc->desc.platform = Common::kPlatformMacintosh;
-		scriptName = macBootFileName;
 	}
 
 	if (outExtra) {


### PR DESCRIPTION
clang flagged this variable, introduced in 8aadc2fcdff76c500617cc78f001cf57e301a690, as being assigned to but not written. Figured I'd open this as a PR just in case @elasota had a plan for it and it had gotten missed.