### PR TITLE
DIRECTOR: XOBJ: Make CueSheet in AppleCDXObject a SharedPtr

### DIFF
--- a/engines/director/lingo/xlibs/applecdxobj.cpp
+++ b/engines/director/lingo/xlibs/applecdxobj.cpp
@@ -144,13 +144,12 @@ AppleCDXObject::AppleCDXObject(ObjectType ObjectType) :Object<AppleCDXObject>("A
 	_objType = ObjectType;
 	_inpoint = 0;
 	_outpoint = 0;
-	_cue = nullptr;
 
 	Common::File cuefile;
 	if (cuefile.open("disc.cue")) {
 		Common::String cuestring = cuefile.readString(0, cuefile.size());
 
-		_cue = new Common::CueSheet(cuestring.c_str());
+		_cue = Common::SharedPtr<Common::CueSheet>(new Common::CueSheet(cuestring.c_str()));
 	}
 }
 
@@ -160,9 +159,6 @@ void AppleCDXObj::m_new(int nargs) {
 
 void AppleCDXObj::m_dispose(int nargs) {
 	g_director->_system->getAudioCDManager()->stop();
-
-	AppleCDXObject *me = static_cast<AppleCDXObject *>(g_lingo->_state->me.u.obj);
-	delete me->_cue;
 }
 
 void AppleCDXObj::m_still(int nargs) {

--- a/engines/director/lingo/xlibs/applecdxobj.h
+++ b/engines/director/lingo/xlibs/applecdxobj.h
@@ -22,6 +22,8 @@
 #ifndef DIRECTOR_LINGO_XLIBS_APPLECDXOBJ_H
 #define DIRECTOR_LINGO_XLIBS_APPLECDXOBJ_H
 
+#include "common/ptr.h"
+
 namespace Common {
 	class CueSheet;
 }
@@ -37,7 +39,7 @@ public:
 	// a value store it internally and return it via a subsequent
 	// call to mGetValue.
 	int _returnValue;
-	Common::CueSheet *_cue;
+	Common::SharedPtr<Common::CueSheet> _cue;
 };
 
 namespace AppleCDXObj {


### PR DESCRIPTION
XObjects are cloned by LC::call, which apparently has a magic copy constructor. This means that any raw pointers inside the XObject will get thrown into the cloned object, upsetting the fragile kayfabe of ownership which underpins memory safety in C++.

Fixes the first movie switch in Classical Cats.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
