### PR TITLE
SCI: Also show qfg2-agdi characters in import

### DIFF
--- a/engines/sci/engine/file.cpp
+++ b/engines/sci/engine/file.cpp
@@ -554,8 +554,10 @@ reg_t DirSeeker::firstFile(const Common::String &mask, reg_t buffer, SegManager 
 		_files.clear();
 		addAsVirtualFiles("-QfG1-", "qfg1-*");
 		addAsVirtualFiles("-QfG1VGA-", "qfg1vga-*");
-		if (QfGImport > 2)
+		if (QfGImport > 2) {
 			addAsVirtualFiles("-QfG2-", "qfg2-*");
+			addAsVirtualFiles("-QfG2 AGDI-", "qfg2agdi-*");
+		}
 		if (QfGImport > 3)
 			addAsVirtualFiles("-QfG3-", "qfg3-*");
 


### PR DESCRIPTION
This is a trivial change to the character import function in Quest for Glory III-IV, to also show characters created by the QFG2 Remake by AGDI.

Fixes TRAC [14754](https://bugs.scummvm.org/ticket/14754)

I tested the save provided with the bugreport and from my (minimal tbh) experience with the QFG games everything seems to work as it should.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
