### PR TITLE
TINSEL: DW1 - Use PSX audio data with PC version

### DIFF
--- a/engines/tinsel/detection.h
+++ b/engines/tinsel/detection.h
@@ -28,6 +28,8 @@ namespace Tinsel {
 
 // (Optionally) remove the "baked-in" letterboxing in Discworld 2/Noir.
 #define GAMEOPTION_CROP_HEIGHT_480_TO_432      GUIO_GAMEOPTIONS1
+// Discworld 1: (Optionally) use the PSX audio data with the PC DOS version(s).
+#define GAMEOPTION_PSX_AUDIO_DATA_OVERRIDE     GUIO_GAMEOPTIONS2
 
 enum TinselGameID {
 	GID_DW1 = 0,

--- a/engines/tinsel/detection_tables.h
+++ b/engines/tinsel/detection_tables.h
@@ -378,7 +378,7 @@ static const TinselGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_CD,
-			GUIO0()
+			GUIO1(GAMEOPTION_PSX_AUDIO_DATA_OVERRIDE)
 		},
 		GID_DW1,
 		0,

--- a/engines/tinsel/metaengine.cpp
+++ b/engines/tinsel/metaengine.cpp
@@ -44,6 +44,17 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 			0
 		}
 	},
+	{
+		GAMEOPTION_PSX_AUDIO_DATA_OVERRIDE,
+		{
+			_s("Use PSX Audio Data"),
+			_s("I have put the PSX audio data in my Discworld PC data folder, please make it work."),
+			"psx_audio_data",
+			false,
+			0,
+			0
+		}
+	},
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
@@ -220,6 +231,7 @@ void TinselMetaEngine::removeSaveState(const char *target, int slot) const {
 
 void TinselMetaEngine::registerDefaultSettings(const Common::String &target) const {
 	ConfMan.registerDefault("crop_black_bars", false); // show the black bars by default (original behaviour)
+	ConfMan.registerDefault("psx_audio_data", false);
 }
 
 const ADExtraGuiOptionsMap *TinselMetaEngine::getAdvancedExtraGuiOptions() const {

--- a/engines/tinsel/sound.h
+++ b/engines/tinsel/sound.h
@@ -59,7 +59,8 @@ protected:
 		kVOCMode,
 		kMP3Mode,
 		kVorbisMode,
-		kFLACMode
+		kFLACMode,
+		kXAADPCMMode
 	};
 
 	struct Channel {


### PR DESCRIPTION
This follows on from: https://forums.scummvm.org/viewtopic.php?p=95576#p95576

I completed a playthrough of Discworld 1 (detection: `English CD v2`) a few years ago using the audio data (ENGLISH.IDX/ENGLISH.SMP) from the PAL PlayStation version (I quickly modified the scummvm source code to do so). I can't remember if I used `ENGLISH.TXT` from the PC or PSX version. I did notice some mismatching audio and subtitles (less that 5 instances IIRC), but I do not know if these are unique to this PC/PSX _combo_ or not. **So, overall this Frankenstein combo of 'English PC CD v2 + PSX AD-PCM audio data' works "OK", and gives clearer digital audio to the PC version**.

A: Should this combo be made accessible to scummvm users as an "unsupported feature"? 

B: Or would scummvm only want to support this combo in a form similar to 'monkey 1/2 ultimate talkie'?

_I have no time currently to try to create B, but enabling A might lead to someone else creating B. Or a least lead to reports that could help inform the creation of B._

Route A would assume that (at least) the scummvm user will copy ENGLISH.IDX and ENGLISH.SMP from the PSX version to their folder for the PC version.

If the A route is acceptable, then I have 2 proposed working solutions **both** in this draft PR:

1. A tick box so the user can say "I want to use the PSX audio data please" (currently only enabled for detection: `English CD v2`). Text is WIP.
![image](https://github.com/scummvm/scummvm/assets/1984342/0d66b90e-9740-43b1-9584-e45e3c397789)
2. The ability to read "PSX " in the first four bytes of ENGLISH.IDX to signal that the paired ENGLISH.SMP uses PSX AD-PCM data. If this method is desired, the 'scummvm tools' will be modified to be able to add this stamp to the IDX file in the same way as "OGG ", "MP3 ", and "FLAC" are added already.
![image](https://github.com/scummvm/scummvm/assets/1984342/dbcc4900-6c46-43ec-924e-14b590372707)

Potential Option 3. - The only other option I can think of is to "partial detect" the PSX audio data, but this seems messy.
____
I prefer option 2, but it is a bit more work for the end user than option 1. Option 3 is the least work for the user, but detection might be off unless I acquire all DW1 variants...