### PR TITLE
ULTIMA: NUVIE: Fix input in cutscenes/character creation

### DIFF
--- a/engines/ultima/nuvie/script/script.cpp
+++ b/engines/ultima/nuvie/script/script.cpp
@@ -49,6 +49,7 @@
 #include "ultima/nuvie/core/magic.h"
 #include "ultima/nuvie/files/tmx_map.h"
 #include "ultima/nuvie/files/u6_lib_n.h"
+#include "backends/keymapper/keymapper.h"
 
 namespace Ultima {
 namespace Nuvie {
@@ -940,7 +941,13 @@ bool Script::play_cutscene(const char *script_file) {
 
 	ConsoleHide();
 
-	return run_lua_file(script_file_path.c_str());
+	// FIXME: For now we disable the keymapper during cutscenes so input works correctly
+	// (e.g. for character name entry or skipping the intro)
+
+	g_system->getEventManager()->getKeymapper()->setEnabled(false);
+	bool retVal = run_lua_file(script_file_path.c_str());
+	g_system->getEventManager()->getKeymapper()->setEnabled(true);
+	return retVal;
 }
 
 MovementStatus Script::call_player_before_move_action(sint16 *rel_x, sint16 *rel_y) {


### PR DESCRIPTION
Fix regression introduced in commit 12a47d956ee00f62ed235c4009eb57ad0dbda19d

Keys bound via the keymapper were no longer usable in cutscenes, including the intro. This made it impossible to enter a name in the character creation screen or to skip a scene with the default keybinds.