### PR TITLE
ULTIMA: NUVIE: Fix cheat keys

### DIFF
--- a/engines/ultima/nuvie/metaengine.cpp
+++ b/engines/ultima/nuvie/metaengine.cpp
@@ -229,6 +229,9 @@ Common::KeymapArray MetaEngine::initKeymaps(const Common::String &gameId) {
 	for (int i = 0; i < ARRAYSIZE(PerPartyMemberActionDescriptions); i++)
 		keyMap->addAction(actionDescriptionFromNuvieAction(PerPartyMemberActionDescriptions[i]));
 
+	for (int i = 0; i < ARRAYSIZE(CheatKeyDescriptions); ++i)
+		keyMap->addAction(actionDescriptionFromNuvieAction(CheatKeyDescriptions[i]));
+
 	return keymapArray;
 }
 


### PR DESCRIPTION
Cheat keys were no longer working since commit
12a47d956ee00f62ed235c4009eb57ad0dbda19d

This seems to be an oversight, as they were defined but not added to the keymap.
Re-add them.