### PR TITLE
ULTIMA: Fix building when ultima6 is the only enabled ultima subengine

### DIFF
--- a/engines/ultima/metaengine.cpp
+++ b/engines/ultima/metaengine.cpp
@@ -247,7 +247,7 @@ SaveStateDescriptor UltimaMetaEngine::querySaveMetaInfos(const char *target, int
 }
 
 Common::KeymapArray UltimaMetaEngine::initKeymaps(const char *target) const {
-#if defined(ENABLE_ULTIMA4) || defined(ENABLE_ULTIMA8)
+#if defined(ENABLE_ULTIMA4) || defined(ENABLE_ULTIMA6) || defined(ENABLE_ULTIMA8)
 	const Common::String gameId = getGameId(target);
 #endif
 


### PR DESCRIPTION
Make sure gameId is defined in UltimaMetaEngine::initKeymaps when only ultima6 is enabled.

To reproduce the build failure:
./configure --disable-all-engines --enable-engine=ultima6 && make

This currently results in:
```
engines/ultima/metaengine.cpp: In member function ‘virtual Common::KeymapArray UltimaMetaEngine::initKeymaps(const char*) const’:
engines/ultima/metaengine.cpp:259:13: error: ‘gameId’ was not declared in this scope; did you mean ‘getGameId’?
  259 |         if (gameId == "ultima6" || gameId == "ultima6_enh"
      |             ^~~~~~
      |             getGameId
make: *** [Makefile.common:178: engines/ultima/metaengine.o] Error 1
```