### PR TITLE
COMMON: Add createReadStreamForMemberAltStream to FSDirectory

### DIFF
--- a/common/fs.cpp
+++ b/common/fs.cpp
@@ -390,6 +390,23 @@ SeekableReadStream *FSDirectory::createReadStreamForMember(const Path &path) con
 	return stream;
 }
 
+SeekableReadStream *FSDirectory::createReadStreamForMemberAltStream(const Path &path, AltStreamType altStreamType) const {
+	if (path.toString().empty() || !_node.isDirectory())
+		return nullptr;
+
+	FSNode *node = lookupCache(_fileCache, path);
+	if (!node)
+		return nullptr;
+
+	debug(5, "FSDirectory::createReadStreamForMemberAltStream('%s', %i) -> '%s'", path.toString().c_str(), static_cast<int>(altStreamType), node->getPath().c_str());
+
+	SeekableReadStream *stream = node->createReadStreamForAltStream(altStreamType);
+	if (!stream)
+		warning("FSDirectory::createReadStreamForMemberAltStream: Can't create stream for file '%s' alt stream type %i", Common::toPrintable(path.toString()).c_str(), static_cast<int>(altStreamType));
+
+	return stream;
+}
+
 FSDirectory *FSDirectory::getSubDirectory(const Path &name, int depth, bool flat, bool ignoreClashes) {
 	return getSubDirectory(Path(), name, depth, flat, ignoreClashes);
 }

--- a/common/fs.h
+++ b/common/fs.h
@@ -441,6 +441,12 @@ public:
 	 * for success.
 	 */
 	SeekableReadStream *createReadStreamForMember(const Path &path) const override;
+
+	/**
+	 * Open an alternate stream for a specified file. A full match of relative path and file name is needed
+	 * for success.
+	 */
+	SeekableReadStream *createReadStreamForMemberAltStream(const Path &path, AltStreamType altStreamType) const override;
 };
 
 /** @} */


### PR DESCRIPTION
OS X resource streams were changed to load as an alt stream from FSNode, and a forwarding method was added to FSDirectoryFile, but not to FSDirectory, which is probably why some games are failing to load resources on OS X.

This should hopefully fix https://bugs.scummvm.org/ticket/14753