### PR TITLE
HELP: Added explanation what ScummVM is and where to get help for Android and iOS

### DIFF
--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -1028,6 +1028,18 @@ void *OSystem_Android::getOpenGLProcAddress(const char *name) const {
 
 static const char * const helpTabs[] = {
 
+_s("Getting help"),
+"",
+_s(
+"## Help, I'm lost!\n"
+"\n"
+"First, make sure you have the games and necessary game files ready. Check the **Where to Get the Games** section under the **General** tab. Once obtained, follow the steps outlined in the **Adding Games** tab to finish adding them on this device. Take a moment to review this process carefully, as some users encountered challenges here owing to recent Android changes.\n"
+"\n"
+"Need more help? Refer to our [online documentation for Android](https://docs.scummvm.org/en/latest/other_platforms/android.html). Got questions? Swing by our [support forums](https://forums.scummvm.org/viewforum.php?f=17) or hop on our [Discord server](https://discord.gg/4cDsMNtcpG), which includes an [Android support channel](https://discord.com/channels/581224060529148060/1135579923185139862).\n"
+"\n"
+"Oh, and heads up, many of our supported games are intentionally tricky, sometimes mind-bogglingly so. If you're stuck in a game, think about checking out a game walkthrough. Good luck!\n"
+),
+
 _s("Touch Controls"),
 "android-help.zip",
 _s(

--- a/backends/platform/ios7/ios7_osys_misc.mm
+++ b/backends/platform/ios7/ios7_osys_misc.mm
@@ -246,6 +246,18 @@ void OSystem_iOS7::handleEvent_applicationClearState() {
 #if TARGET_OS_IOS
 static const char * const helpTabs[] = {
 
+_s("Getting help"),
+"",
+_s(
+"## Help, I'm lost!\n"
+"\n"
+"First, make sure you have the games and necessary game files ready. Check the **Where to Get the Games** section under the **General** tab. Once obtained, follow the steps outlined in the **Adding Games** tab to finish adding them on this device.\n"
+"\n"
+"Need more help? Refer to our [online documentation for iOS](https://docs.scummvm.org/en/latest/other_platforms/ios.html). Got questions? Swing by our [support forums](https://forums.scummvm.org/viewforum.php?f=15) or hop on our [Discord server](https://discord.gg/4cDsMNtcpG), which includes an [iOS support channel](https://discord.com/channels/581224060529148060/1149456560922316911).\n"
+"\n"
+"Oh, and heads up, many of our supported games are intentionally tricky, sometimes mind-bogglingly so. If you're stuck in a game, think about checking out a game walkthrough. Good luck!\n"
+),
+
 _s("Touch Controls"),
 "ios-help.zip",
 _s(

--- a/gui/helpdialog.cpp
+++ b/gui/helpdialog.cpp
@@ -38,6 +38,14 @@ static const char * const helpTabs[] = {
 _s("General"),
 "",
 _s(
+"## ScummVM at a Glance\n"
+"\n"
+"ScummVM is a modern reimplementation of various game engines. Once you transfer the original game data to your device, it endeavors to use it to faithfully recreate the original gaming experience. \n"
+"\n"
+"ScummVM isn't your typical emulator of DOS, Windows, or some console. Rather than a one-size-fits-all approach, it takes a meticulous route, implementing the precise game logic for each specific title or engine it supports. ScummVM will not work with game engines it does not support.\n"
+"\n"
+"ScummVM is developed by a team of volunteers and is free software. We lack an extensive testing team, possess only a limited range of devices, and cannot always address every request. We also do not run advertisements or sell you anything. Please be mindful of this when you submit a complaint or a bug report.\n"
+"\n"
 "## Where to get the games\n"
 "\n"
 "Visit [our Wiki](https://wiki.scummvm.org/index.php?title=Where_to_get_the_games) for a detailed list of supported games and where to purchase them.\n"


### PR DESCRIPTION
I want to avoid mistakes with the Android port, where many users were lost, so I am trying to squeeze in a last-minute change to the help.

Please review it and tell me what you think. I would really like to squeeze it into 2.8.0 in both ports.

The help is not yet translatable due to fonts, so it is not a problem that we will get no translations update.

If the porters agree, then it could get as a subtag only for Android and iOS, perhaps 2.8.0.1, or distributed as a patch (of course, it then be backported to branch-2-8 and branch-2-8-0).