### PR TITLE
COMMON: Add API for opening an InstallShield cab archive inside of another archive

### DIFF
--- a/common/compression/installshield_cab.h
+++ b/common/compression/installshield_cab.h
@@ -54,6 +54,17 @@ Archive *makeInstallShieldArchive(const Common::Path &baseName);
 /**
  * This factory method creates an Archive instance corresponding to the content
  * of the single- or multi-file InstallShield cabinet with the given base name
+ * in a specified archive.
+ *
+ * May return nullptr in case of a failure.
+ *
+ * @param baseName The base filename, e.g. the "data" in "data1.cab"
+ */
+Archive *makeInstallShieldArchive(const Common::Path &baseName, Common::Archive &archive);
+
+/**
+ * This factory method creates an Archive instance corresponding to the content
+ * of the single- or multi-file InstallShield cabinet with the given base name
  *
  * May return nullptr in case of a failure.
  * 


### PR DESCRIPTION
This adds support for opening InstallShield cab archives from any archive instead of just SearchMan, and hooks it up to the mTropolis engine (so it can be used for Magic School Bus titles).