### PR TITLE
ENGINES: Allow specifying a start position for initGraphicsAny()

### DIFF
--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -324,12 +324,12 @@ void initGraphicsModes(const Graphics::ModeList &modes) {
  * Inits any of the modes in "modes". "modes" is in the order of preference.
  * Return value is index in modes of resulting mode.
  */
-int initGraphicsAny(const Graphics::ModeWithFormatList &modes) {
+int initGraphicsAny(const Graphics::ModeWithFormatList &modes, int start) {
 	int candidate = -1;
 	OSystem::TransactionError gfxError = OSystem::kTransactionSizeChangeFailed;
 	int last_width = 0, last_height = 0;
 
-	for (candidate = 0; candidate < (int)modes.size(); candidate++) {
+	for (candidate = start; candidate < (int)modes.size(); candidate++) {
 		g_system->beginGFXTransaction();
 		initCommonGFX();
 #ifdef USE_RGB_COLOR

--- a/engines/util.h
+++ b/engines/util.h
@@ -84,6 +84,6 @@ void initGraphics3d(int width, int height);
  * Inits any of the modes in "modes". "modes" is in the order of preference.
  * Return value is index in modes of resulting mode.
  */
-int initGraphicsAny(const Graphics::ModeWithFormatList &modes);
+int initGraphicsAny(const Graphics::ModeWithFormatList &modes, int start = 0);
 /** @} */
 #endif


### PR DESCRIPTION
This is intended to allow configurable resolutions with fallbacks to lower resolutions, such as with this example:

```
	Graphics::PixelFormat format = Graphics::PixelFormat::createFormatCLUT8();
	Graphics::ModeWithFormatList modes = {
		Graphics::ModeWithFormat(_screenRect.width() >> 0, _screenRect.height() >> 0, format),
		Graphics::ModeWithFormat(_screenRect.width() >> 1, _screenRect.height() >> 1, format),
		Graphics::ModeWithFormat(_screenRect.width() >> 1, _screenRect.height() >> 2, format),
		Graphics::ModeWithFormat(_screenRect.width() >> 2, _screenRect.height() >> 2, format),
	};
	int mode = initGraphicsAny(modes, ConfMan.getInt("resolution"));
```