### PR TITLE
COMMON: Extend Tokenizer classes to allow extraction of delimiters around tokens

### DIFF
--- a/common/tokenizer.cpp
+++ b/common/tokenizer.cpp
@@ -61,6 +61,36 @@ StringArray StringTokenizer::split() {
 	return res;
 }
 
+String StringTokenizer::delimitersAtTokenBegin() const {
+	// First token appears at beginning of the string, or no tokens have been extracted yet
+	if (_tokenBegin == 0)
+		return String();
+
+	// Iterate backwards until we hit either the previous token, or the beginning of the input string
+	int delimitersBegin;
+	for (delimitersBegin = _tokenBegin - 1; delimitersBegin >= 0 && _delimiters.contains(_str[delimitersBegin]); delimitersBegin--)
+		;
+
+	++delimitersBegin;
+	
+	// Return the delimiters
+	return String(_str.c_str() + delimitersBegin, _tokenBegin - delimitersBegin);
+}
+
+String StringTokenizer::delimitersAtTokenEnd() const {
+	// Last token appears at end of the string, or no tokens have been extracted yet
+	if (_tokenEnd == 0 || _tokenEnd == _str.size())
+		return String();
+
+	// Iterate forwards until we hit either the next token, or the end of the input string
+	uint delimitersEnd;
+	for (delimitersEnd = _tokenEnd; delimitersEnd < _str.size() && _delimiters.contains(_str[delimitersEnd]); delimitersEnd++)
+		;
+	
+	// Return the delimiters
+	return String(_str.c_str() + _tokenEnd, delimitersEnd - _tokenEnd);
+}
+
 U32StringTokenizer::U32StringTokenizer(const U32String &str, const String &delimiters) : _str(str), _delimiters(delimiters) {
 	reset();
 }
@@ -85,18 +115,15 @@ U32String U32StringTokenizer::nextToken() {
 	// Skip delimiters when present at the beginning, to point to the next token
 	// For example, the below loop will set _tokenBegin & _tokenEnd to 'H' for the string -> "!!--=Hello World"
 	// And subsequently, skip all delimiters in the beginning of the next word.
-	while (_tokenBegin != _str.end() && _delimiters.contains(*_tokenBegin)) {
+	_tokenBegin = _tokenEnd;
+	while (_tokenBegin != _str.end() && _delimiters.contains(*_tokenBegin))
 		_tokenBegin++;
-		_tokenEnd++;
-	}
+	_tokenEnd = _tokenBegin;
 
 	// Loop and advance _tokenEnd until we find a delimiter at the end of a word/string
 	while (_tokenBegin != _str.end() && _tokenEnd != _str.end()) {
 		if (_delimiters.contains(*_tokenEnd)) {
-			U32String token(_tokenBegin, _tokenEnd);
-			_tokenEnd++;
-			_tokenBegin = _tokenEnd;
-			return token;
+			return U32String(_tokenBegin, _tokenEnd);
 		}
 		_tokenEnd++;
 	}
@@ -115,6 +142,36 @@ U32StringArray U32StringTokenizer::split() {
 		res.push_back(nextToken());
 
 	return res;
+}
+
+U32String U32StringTokenizer::delimitersAtTokenBegin() const {
+	// First token appears at beginning of the string, or no tokens have been extracted yet
+	if (_tokenBegin == _str.begin())
+		return U32String();
+
+	// Iterate backwards until we hit either the previous token, or the beginning of the input string
+	U32String::const_iterator delimitersBegin;
+	for (delimitersBegin = _tokenBegin - 1; delimitersBegin >= _str.begin() && _delimiters.contains(*delimitersBegin); delimitersBegin--)
+		;
+
+	++delimitersBegin;
+	
+	// Return the delimiters
+	return U32String(delimitersBegin, _tokenBegin - delimitersBegin);
+}
+
+U32String U32StringTokenizer::delimitersAtTokenEnd() const {
+	// Last token appears at end of the string, or no tokens have been extracted yet
+	if (_tokenEnd == _str.begin() || _tokenEnd == _str.end())
+		return String();
+
+	// Iterate forwards until we hit either the next token, or the end of the input string
+	U32String::const_iterator delimitersEnd;
+	for (delimitersEnd = _tokenEnd; delimitersEnd < _str.end() && _delimiters.contains(*delimitersEnd); delimitersEnd++)
+		;
+	
+	// Return the delimiters
+	return U32String(_tokenEnd, delimitersEnd - _tokenEnd);
 }
 
 

--- a/common/tokenizer.h
+++ b/common/tokenizer.h
@@ -56,6 +56,9 @@ public:
 	String nextToken(); ///< Returns the next token from the string (Or an empty string if there are no more tokens)
 	StringArray split(); ///< Returns StringArray with all tokens. Beware of the memory usage
 
+	String delimitersAtTokenBegin() const; ///< Returns a String with all delimiters between the current and previous token
+	String delimitersAtTokenEnd() const;   ///< Returns a String with all delimiters between the current and next token
+
 private:
 	const String _str;        ///< The string to be tokenized
 	const String _delimiters; ///< String containing all the delimiter characters
@@ -83,6 +86,9 @@ public:
 	bool empty() const; ///< Returns true if there are no more tokens left in the string, false otherwise
 	U32String nextToken(); ///< Returns the next token from the string (Or an empty string if there are no more tokens)
 	U32StringArray split(); ///< Returns StringArray with all tokens. Beware of the memory usage
+
+	U32String delimitersAtTokenBegin() const; ///< Returns a U32String with all delimiters between the current and previous token
+	U32String delimitersAtTokenEnd() const;   ///< Returns a U32String with all delimiters between the current and next token
 
 private:
 	const U32String _str;        ///< The unicode string to be tokenized


### PR DESCRIPTION
This PR extends the StringTokenizer and U32StringTokenizer
classes with two new functions each. When called, they return
a substring of the original input, containing the lists of all
delimiters immediately surrounding the token that is
currently being processed.

Take the following string, when using ", " as a delimiter list:
"  Hey, hi, hello!   "

If we call nextToken() once, its return value will be the
string "Hey". The functions added in this PR allow us to
get the delimiters surrounding the "Hey". Thus, our output
will be the following:

delimitersAtTokenBegin() will return "   "
delimitersAtTokenEnd() will return ", "

Calling nextToken() again will change the functions' output
to the delimiters surrounding the token "hi", and so on.
They also take into account cases where a token is at the
beginning and at the end of the input string, in which case
their return value is an empty string.

The motivation behind this is better support for the Nancy
engine's rudimentary hypertext format, which uses braced
control tokens (e.g. <n>) to dictate how a string needs to
be rendered. The current implementation makes some
very incorrect assumptions about the input data, and
the functions added in this PR will allow me to easily fix that.