### PR TITLE
COMMON: Fix translation of error messages

### DIFF
--- a/common/error.cpp
+++ b/common/error.cpp
@@ -78,11 +78,27 @@ static String errorToString(ErrorCode errorCode) {
 }
 
 Error::Error(ErrorCode code)
-	: _code(code), _desc(errorToString(code)) {
+	: _code(code), _desc() {
 }
 
 Error::Error(ErrorCode code, const String &desc)
-	: _code(code), _desc(errorToString(code) + " (" + desc + ")") {
+	: _code(code), _desc(desc) {
+}
+
+String Error::getDesc() const {
+	if (!_desc.empty()) {
+		return Common::String::format("%s (%s)", errorToString(_code).c_str(), _desc.c_str());
+	} else {
+		return errorToString(_code);
+	}
+}
+
+U32String Error::getTranslatedDesc() const {
+	if (!_desc.empty()) {
+		return Common::U32String::format("%S (%S)", _(errorToString(_code)).c_str(), _(_desc).c_str());
+	} else {
+		return _(errorToString(_code));
+	}
 }
 
 

--- a/common/error.h
+++ b/common/error.h
@@ -100,9 +100,14 @@ public:
 	Error(ErrorCode code, const String &extra);
 
 	/**
-	 * Get the description of this error.
+	 * Get the untranslated description of this error.
 	 */
-	const String &getDesc() const { return _desc; }
+	String getDesc() const;
+
+	/**
+	 * Get the translated description of this error.
+	 */
+	U32String getTranslatedDesc() const;
 
 	/**
 	 * Get the error code of this error.

--- a/gui/error.cpp
+++ b/gui/error.cpp
@@ -23,8 +23,6 @@
 #include "gui/message.h"
 #include "gui/error.h"
 
-#include "common/translation.h"
-
 namespace GUI {
 
 void displayErrorDialog(const Common::U32String &text) {
@@ -35,7 +33,7 @@ void displayErrorDialog(const Common::U32String &text) {
 void displayErrorDialog(const Common::Error &error, const Common::U32String &extraText) {
 	Common::U32String errorText(extraText);
 	errorText += Common::U32String(" ");
-	errorText += _(error.getDesc());
+	errorText += error.getTranslatedDesc();
 	GUI::MessageDialog alert(errorText);
 	alert.runModal();
 }


### PR DESCRIPTION
Normally, translating the error description only happens in `GUI::displayErrorDialog()` so that the English version can still be used for console logs, but because the string was modified in the `Common::Error` constructor, it doesn't match any of the original strings in `translation.dat`.