### PR TITLE
MM: Enable engine by default

### DIFF
--- a/engines/mm/configure.engine
+++ b/engines/mm/configure.engine
@@ -1,5 +1,5 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine mm "Might and Magic" no "mm1 xeen"
+add_engine mm "Might and Magic" yes "mm1 xeen"
 add_engine mm1 "Might and Magic 1" yes
 add_engine xeen "Might and Magic Xeen" yes


### PR DESCRIPTION
While the `mm1` and `xeen` sub-engines are enabled by default, the `mm` engine itself is not.

This leads to the engine completely being disabled when building in release mode since the engines are not built by default. Assuming that we already announced testing for the subengines, the main engines should be enabled by default as well.