### PR TITLE
CGE: Make ALT+X trigger quit() only on initial keypress

### DIFF
--- a/engines/cge/events.cpp
+++ b/engines/cge/events.cpp
@@ -72,7 +72,7 @@ bool Keyboard::getKey(Common::Event &event) {
 		_vm->loadGameDialog();
 		return false;
 	case Common::KEYCODE_x:
-		if (event.kbd.flags & Common::KBD_ALT) {
+		if (event.type == Common::EVENT_KEYDOWN && (event.kbd.flags & Common::KBD_ALT)) {
 			_vm->quit();
 			return false;
 		}


### PR DESCRIPTION
To see the current issue, open Soltys, skip intro, wait until character is playable in Screen 1, and press `ALT`+`X` once. `CGEEngine::quit()` gets executed twice and the Quit Menu will toggle twice, disappearing. Keeping `ALT`+`X` pressed makes it keep toggling. Normal intended behavior can be seen by mouse-clicking the Quit button. This fixes the keyboard route. 
