### PR TITLE
DEVTOOLS: Add support for AVX2 and SSE2 to create_projects

### DIFF
--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1131,8 +1131,8 @@ const Feature s_features[] = {
 	{  "builtin-resources",             "BUILTIN_RESOURCES", false, true,  "include resources (e.g. engine data, fonts) into the binary" },
 	{     "detection-full",                "DETECTION_FULL", false, true,  "Include detection objects for all engines" },
 	{   "detection-static", "USE_DETECTION_FEATURES_STATIC", false, true,  "Static linking of detection objects for engines." },
-	{               "avx2",                  "SCUMMVM_AVX2", false, true,  "Intel AVX2 support" },
-	{               "sse2",                  "SCUMMVM_SSE2", false, true,  "Intel SSE2 support" },
+	{           "ext-avx2",                  "SCUMMVM_AVX2", false, true,  "Intel AVX2 support" },
+	{           "ext-sse2",                  "SCUMMVM_SSE2", false, true,  "Intel SSE2 support" },
 };
 
 const Tool s_tools[] = {

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -418,6 +418,8 @@ int main(int argc, char *argv[]) {
 		setup.defines.push_back("SCUMMVM_NEON");
 	} else if (projectType == kProjectMSVC || projectType == kProjectCodeBlocks) {
 		setup.defines.push_back("WIN32");
+		setup.defines.push_back("SCUMMVM_AVX2");
+		setup.defines.push_back("SCUMMVM_SSE2");
 		backendWin32 = true;
 	} else {
 		// As a last resort, select the backend files to build based on the platform used to build create_project.
@@ -1129,6 +1131,8 @@ const Feature s_features[] = {
 	{  "builtin-resources",             "BUILTIN_RESOURCES", false, true,  "include resources (e.g. engine data, fonts) into the binary"},
 	{     "detection-full",                "DETECTION_FULL", false, true,  "Include detection objects for all engines" },
 	{   "detection-static", "USE_DETECTION_FEATURES_STATIC", false, true,  "Static linking of detection objects for engines."},
+	{               "avx2",                  "SCUMMVM_AVX2", false, true,  "Intel AVX2 support"},
+	{               "sse2",                  "SCUMMVM_SSE2", false, true,  "Intel SSE2 support"},
 };
 
 const Tool s_tools[] = {

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1118,21 +1118,21 @@ const Feature s_features[] = {
 	{     "opengl_shaders",            "USE_OPENGL_SHADERS", false, true,  "OpenGL support (shaders) in 3d games" },
 	{            "taskbar",                   "USE_TASKBAR", false, true,  "Taskbar integration support" },
 	{              "cloud",                     "USE_CLOUD", false, true,  "Cloud integration support" },
-	{               "enet",                       "USE_ENET", false, true,  "ENet networking support" },
+	{               "enet",                      "USE_ENET", false, true,  "ENet networking support" },
 	{        "translation",               "USE_TRANSLATION", false, true,  "Translation support" },
-	{             "vkeybd",                 "ENABLE_VKEYBD", false, false, "Virtual keyboard support"},
-	{      "eventrecorder",          "ENABLE_EVENTRECORDER", false, false, "Event recorder support"},
-	{            "updates",                   "USE_UPDATES", false, false, "Updates support"},
-	{            "dialogs",                "USE_SYSDIALOGS", false, true,  "System dialogs support"},
+	{             "vkeybd",                 "ENABLE_VKEYBD", false, false, "Virtual keyboard support" },
+	{      "eventrecorder",          "ENABLE_EVENTRECORDER", false, false, "Event recorder support" },
+	{            "updates",                   "USE_UPDATES", false, false, "Updates support" },
+	{            "dialogs",                "USE_SYSDIALOGS", false, true,  "System dialogs support" },
 	{         "langdetect",                "USE_DETECTLANG", false, true,  "System language detection support" }, // This feature actually depends on "translation", there
-	                                                                                                           // is just no current way of properly detecting this...
-	{       "text-console", "USE_TEXT_CONSOLE_FOR_DEBUGGER", false, false, "Text console debugger" }, // This feature is always applied in xcode projects
-	{                "tts",                       "USE_TTS", false, true,  "Text to speech support"},
-	{  "builtin-resources",             "BUILTIN_RESOURCES", false, true,  "include resources (e.g. engine data, fonts) into the binary"},
+	                                                                                                              // is just no current way of properly detecting this...
+	{       "text-console", "USE_TEXT_CONSOLE_FOR_DEBUGGER", false, false, "Text console debugger" },  // This feature is always applied in xcode projects
+	{                "tts",                       "USE_TTS", false, true,  "Text to speech support" },
+	{  "builtin-resources",             "BUILTIN_RESOURCES", false, true,  "include resources (e.g. engine data, fonts) into the binary" },
 	{     "detection-full",                "DETECTION_FULL", false, true,  "Include detection objects for all engines" },
-	{   "detection-static", "USE_DETECTION_FEATURES_STATIC", false, true,  "Static linking of detection objects for engines."},
-	{               "avx2",                  "SCUMMVM_AVX2", false, true,  "Intel AVX2 support"},
-	{               "sse2",                  "SCUMMVM_SSE2", false, true,  "Intel SSE2 support"},
+	{   "detection-static", "USE_DETECTION_FEATURES_STATIC", false, true,  "Static linking of detection objects for engines." },
+	{               "avx2",                  "SCUMMVM_AVX2", false, true,  "Intel AVX2 support" },
+	{               "sse2",                  "SCUMMVM_SSE2", false, true,  "Intel SSE2 support" },
 };
 
 const Tool s_tools[] = {

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -46,8 +46,8 @@ MSVCProvider::MSVCProvider(StringList &global_warnings, std::map<std::string, St
 	StringList arm64_disabled_features;
 	arm64_disabled_features.push_back("nasm");
 	arm64_disabled_features.push_back("opengl");
-	arm64_disabled_features.push_back("avx2");
-	arm64_disabled_features.push_back("sse2");
+	arm64_disabled_features.push_back("ext-avx2");
+	arm64_disabled_features.push_back("ext-sse2");
 	_arch_disabled_features[ARCH_ARM64] = arm64_disabled_features;
 }
 

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -46,6 +46,8 @@ MSVCProvider::MSVCProvider(StringList &global_warnings, std::map<std::string, St
 	StringList arm64_disabled_features;
 	arm64_disabled_features.push_back("nasm");
 	arm64_disabled_features.push_back("opengl");
+	arm64_disabled_features.push_back("avx2");
+	arm64_disabled_features.push_back("sse2");
 	_arch_disabled_features[ARCH_ARM64] = arm64_disabled_features;
 }
 

--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -1656,7 +1656,7 @@ void XcodeProvider::setupAdditionalSources(std::string targetName, Property &fil
 void XcodeProvider::setupDefines(const BuildSetup &setup) {
 
 	for (StringList::const_iterator i = setup.defines.begin(); i != setup.defines.end(); ++i) {
-		if (*i == "USE_NASM")  // Not supported on Mac
+		if (*i == "USE_NASM" || *i == "SCUMMVM_AVX2" || *i == "SCUMMVM_SSE2")
 			continue;
 
 		ADD_DEFINE(_defines, *i);
@@ -1666,8 +1666,6 @@ void XcodeProvider::setupDefines(const BuildSetup &setup) {
 	REMOVE_DEFINE(_defines, "IPHONE");
 	REMOVE_DEFINE(_defines, "IPHONE_IOS7");
 	REMOVE_DEFINE(_defines, "SDL_BACKEND");
-	REMOVE_DEFINE(_defines, "SCUMMVM_AVX2");
-	REMOVE_DEFINE(_defines, "SCUMMVM_SSE2");
 	REMOVE_DEFINE(_defines, "SCUMMVM_NEON");
 	ADD_DEFINE(_defines, "CONFIG_H");
 	ADD_DEFINE(_defines, "UNIX");

--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -1666,6 +1666,8 @@ void XcodeProvider::setupDefines(const BuildSetup &setup) {
 	REMOVE_DEFINE(_defines, "IPHONE");
 	REMOVE_DEFINE(_defines, "IPHONE_IOS7");
 	REMOVE_DEFINE(_defines, "SDL_BACKEND");
+	REMOVE_DEFINE(_defines, "SCUMMVM_AVX2");
+	REMOVE_DEFINE(_defines, "SCUMMVM_SSE2");
 	REMOVE_DEFINE(_defines, "SCUMMVM_NEON");
 	ADD_DEFINE(_defines, "CONFIG_H");
 	ADD_DEFINE(_defines, "UNIX");


### PR DESCRIPTION
This PR adds support for both the Intel AVX2 and SSE2 CPU extensions to create_projects.

Tested with VS 2022 on the AMD64 target.