### PR TITLE
GOB: Use playtoonsdemo for Non-interactive demo

### DIFF
--- a/engines/gob/detection/tables.h
+++ b/engines/gob/detection/tables.h
@@ -56,6 +56,7 @@ static const PlainGameDescriptor gobGames[] = {
 	{"playtnck1", "Playtoons Construction Kit 1 - Monsters"},
 	{"playtnck2", "Playtoons Construction Kit 2 - Knights"},
 	{"playtnck3", "Playtoons Construction Kit 3 - Far West"},
+	{"playtoonsdemo", "Playtoons Demo"},
 	{"bambou", "Playtoons Limited Edition - Bambou le sauveur de la jungle"},
 	{"fascination", "Fascination"},
 	{"geisha", "Geisha"},

--- a/engines/gob/detection/tables_playtoons.h
+++ b/engines/gob/detection/tables_playtoons.h
@@ -88,8 +88,8 @@
 },
 {
 	{
-		"playtoons1",
-		"Non-Interactive Demo",
+		"playtoonsdemo",
+		"Non-Interactive",
 		{
 			{"play123.scn", 0, "4689a31f543915e488c3bc46ea358add", 258},
 			{"archi.vmd", 0, "a410fcc8116bc173f038100f5857191c", 5617210},


### PR DESCRIPTION
similar like dynastywood id

This Non-Interactive demo contains VMD's for every Playtoons game and not Playtoons 1 only.

This Demo is listed with the gameid already as playtoonsdemo under the Game Demos site of scummvm.org