### PR TITLE
AGS: Disable game scanner when detection is dynamic

### DIFF
--- a/engines/ags/ags.cpp
+++ b/engines/ags/ags.cpp
@@ -121,12 +121,15 @@ Common::String AGSEngine::getGameId() const {
 }
 
 Common::Error AGSEngine::run() {
+#ifdef DETECTION_STATIC
+	// The game scanner is not available when detection is dynamic
 	if (debugChannelSet(-1, kDebugScan)) {
 		// Scan the given folder and subfolders for unknown games
 		AGS3::GameScanner scanner;
 		scanner.scan(ConfMan.getPath("path"));
 		return Common::kNoError;
 	}
+#endif
 
 	if (isUnsupportedPre25()) {
 		GUIErrorMessage(_("The selected game uses a pre-2.5 version of the AGS engine, which is not supported."));

--- a/engines/ags/game_scanner.cpp
+++ b/engines/ags/game_scanner.cpp
@@ -32,15 +32,12 @@
 #include "common/hashmap.h"
 #include "common/md5.h"
 
+namespace AGS3 {
 /**
  * When detection is compiled dynamically, detection tables end up in detection plugin and
- * engine cannot link to them so duplicate them in the engine in this case
+ * engine cannot link to them so don't include the feature instead of duplicating the data
  */
-#ifndef DETECTION_STATIC
-#include "ags/detection_tables.h"
-#endif
-
-namespace AGS3 {
+#ifdef DETECTION_STATIC
 
 extern bool define_gamedata_location(const AGS::Shared::String &exe_path);
 extern bool engine_try_init_gamedata(AGS::Shared::String gamepak_path);
@@ -185,5 +182,6 @@ void GameScanner::detectClashes() {
 		gameNames[nameP->description] = true;
 	}
 }
+#endif
 
 } // namespace AGS3

--- a/engines/ags/game_scanner.h
+++ b/engines/ags/game_scanner.h
@@ -28,7 +28,10 @@ namespace AGS3 {
  * A support class for scanning a hierarchy of folders for AGS games,
  * and printing output suitable for posting into the detection tables.
  * Scanning starts from the current directory when ScummVM is started
+ * Only include this code when detection is static, else it forces to
+ * duplicate data
  */
+#ifdef DETECTION_STATIC
 class GameScanner {
 	struct Entry {
 		Common::String _id;
@@ -67,5 +70,6 @@ public:
 	 */
 	void scan(const Common::Path &startFolder);
 };
+#endif
 
 } // namespace AGS3


### PR DESCRIPTION
When detection is in dynamic plugin, the detection tables are included twice. Once in the detection plugin and once in the engine for the game scanner code.
We disable the feature in this case to prevent duplication as this feature is only used in specific cases.