### PR TITLE
GRAPHICS: Use target pragmas instead of compiler flags to prevent ODR problems

### DIFF
--- a/configure
+++ b/configure
@@ -6966,6 +6966,15 @@ case $_host_cpu in
 		;;
 esac
 
+if test "$have_gcc" = yes; then
+	# Need 4.9 for pragma target
+	if (test $_cxx_major -lt 4) || (test $_cxx_major -eq 4 && test $_cxx_minor -lt 9); then
+		_ext_sse2=no
+		_ext_avx2=no
+		_ext_neon=no
+	fi
+fi
+
 define_in_config_if_yes "$_ext_sse2" 'SCUMMVM_SSE2'
 echo_n "Enabling x86/amd64 SSE2... "
 echo "$_ext_sse2"

--- a/graphics/blit/blit-avx2.cpp
+++ b/graphics/blit/blit-avx2.cpp
@@ -20,10 +20,16 @@
  */
 
 #include "common/scummsys.h"
-#include <immintrin.h>
 
 #include "graphics/blit/blit-alpha.h"
 #include "graphics/pixelformat.h"
+
+#include <immintrin.h>
+
+#ifdef __GNUC__
+#pragma GCC push_options
+#pragma GCC target("avx2")
+#endif
 
 namespace Graphics {
 
@@ -300,3 +306,7 @@ void BlendBlit::blitAVX2(Args &args, const TSpriteBlendMode &blendMode, const Al
 }
 
 } // End of namespace Graphics
+
+#ifdef __GNUC__
+#pragma GCC pop_options
+#endif

--- a/graphics/blit/blit-neon.cpp
+++ b/graphics/blit/blit-neon.cpp
@@ -22,10 +22,20 @@
 #include "common/scummsys.h"
 
 #ifdef SCUMMVM_NEON
-#include <arm_neon.h>
 
 #include "graphics/blit/blit-alpha.h"
 #include "graphics/pixelformat.h"
+
+#include <arm_neon.h>
+
+#ifdef __GNUC__
+#pragma GCC push_options
+
+#if !defined(__aarch64__)
+#pragma GCC target("fpu=neon")
+#endif // !defined(__aarch64__)
+
+#endif // __GNUC__
 
 namespace Graphics {
 
@@ -299,4 +309,9 @@ void BlendBlit::blitNEON(Args &args, const TSpriteBlendMode &blendMode, const Al
 }
 
 } // end of namespace Graphics
+
+#ifdef __GNUC__
+#pragma GCC pop_options
+#endif
+
 #endif // SCUMMVM_NEON

--- a/graphics/blit/blit-sse2.cpp
+++ b/graphics/blit/blit-sse2.cpp
@@ -20,10 +20,21 @@
  */
 
 #include "common/scummsys.h"
-#include <immintrin.h>
 
 #include "graphics/blit/blit-alpha.h"
 #include "graphics/pixelformat.h"
+
+#include <emmintrin.h>
+
+#ifdef __GNUC__
+#pragma GCC push_options
+
+#ifndef __x86_64__
+#pragma GCC target("sse2")
+#endif
+
+#endif
+
 
 namespace Graphics {
 
@@ -301,3 +312,8 @@ void BlendBlit::blitSSE2(Args &args, const TSpriteBlendMode &blendMode, const Al
 }
 
 } // End of namespace Graphics
+
+#ifdef __GNUC__
+#pragma GCC pop_options
+#endif
+

--- a/graphics/module.mk
+++ b/graphics/module.mk
@@ -144,17 +144,14 @@ endif
 ifdef SCUMMVM_NEON
 MODULE_OBJS += \
 	blit/blit-neon.o
-$(MODULE)/blit/blit-neon.o: CXXFLAGS += $(NEON_CXXFLAGS)
 endif
 ifdef SCUMMVM_SSE2
 MODULE_OBJS += \
 	blit/blit-sse2.o
-$(MODULE)/blit/blit-sse2.o: CXXFLAGS += -msse2
 endif
 ifdef SCUMMVM_AVX2
 MODULE_OBJS += \
 	blit/blit-avx2.o
-$(MODULE)/blit/blit-avx2.o: CXXFLAGS += -mavx2
 endif
 
 # Include common rules


### PR DESCRIPTION
This removes the compiler command line arch specifications from the SIMD blit code and replaces them with pragmas that only affect the blit code functions.

This prevents the functions defined in the headers from being compiled with instruction set extensions, which in turn prevents them from replacing definitions of the same functions defined in other modules due to the C++ one definition rule.