### PR TITLE
BASE: Allow engines to return to launcher when quitting

### DIFF
--- a/base/main.cpp
+++ b/base/main.cpp
@@ -325,9 +325,8 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 	// Run the engine
 	Common::Error result = engine->run();
 
-	// Make sure we do not return to the launcher if this is not possible.
-	if (!engine->hasFeature(Engine::kSupportsReturnToLauncher))
-		ConfMan.setBool("gui_return_to_launcher_at_exit", false, Common::ConfigManager::kTransientDomain);
+	// Make sure we return to the launcher if this is possible.
+	ConfMan.setBool("gui_return_to_launcher_at_exit", engine->hasFeature(Engine::kSupportsReturnToLauncher), Common::ConfigManager::kTransientDomain);
 
 	// Inform backend that the engine finished
 	system.engineDone();


### PR DESCRIPTION
Currently, the only way to return back to the launcher
from a running engine is to use the option in the GMM;
attempting to use any in-game quit option results in
ScummVM just exiting instead. This PR makes sure the
relevant ConfMan option actually gets set to true,
allowing the feature to work properly.