### PR TITLE
GOB: add CoktelPlayer to tables

### DIFF
--- a/engines/gob/detection/tables.h
+++ b/engines/gob/detection/tables.h
@@ -71,6 +71,7 @@ static const PlainGameDescriptor gobGames[] = {
 	{"adiboudchoubanquise", "Adiboud'chou sur la banquise"},
 	{"adiboudchoucampagne", "Adiboud'chou a la campagne"},
 	{"adiboudchoujunglesavane", "Adiboud'chou dans la jungle et la savane"},
+	{"coktelplayer", "CoktelPlayer"},
 	{0, 0}
 };
 


### PR DESCRIPTION
CoktelPlayer was developed by DrMcCoy.
Can be found here: https://gist.github.com/DrMcCoy/20471e1fa16aebf8c776be4149372d04

CoktelPlayer scene file (coktelplayer.scn) is already added in demoplayer.cpp.
coktelplayer is also added to tables_fallback.h
