### PR TITLE
COMMON: Remove use of fmin/fmax/fminf/fmaxf

### DIFF
--- a/audio/soundfont/vab/psxspu.h
+++ b/audio/soundfont/vab/psxspu.h
@@ -28,6 +28,7 @@
 
 #include "audio/soundfont/common.h"
 #include "common/str.h"
+#include "common/util.h"
 #include "audio/soundfont/vgminstrset.h"
 #include "audio/soundfont/vgmsamp.h"
 #include "audio/soundfont/vgmitem.h"
@@ -170,7 +171,7 @@ void PSXConvADSR(T *realADSR, uint8 Am, uint8 Ar, uint8 Dr, uint8 Sl, uint8 Sm,
 		samples = (unsigned long)(0x60000000 / rate);
 		remainder = 0x60000000 % rate;
 		rate = RateTable[RoundToZero((Ar ^ 0x7F) - 0x18) + 32];
-		samples += ceil(fmax(0, 0x1FFFFFFF - (long) remainder) / (double) rate);
+		samples += ceil(MAX<double>(0, 0x1FFFFFFF - (long) remainder) / (double) rate);
 	}
 	timeInSecs = samples / sampleRate;
 	realADSR->_attack_time = timeInSecs;

--- a/backends/plugins/psp2/psp2-provider.cpp
+++ b/backends/plugins/psp2/psp2-provider.cpp
@@ -41,8 +41,6 @@ void *forceLinkFunctions[] = {
 	(void *)(void *(*)(std::size_t, std::nothrow_t const&))operator new [],
 	(void *)coshf,
 	(void *)fgetc,
-	(void *)fmaxf,
-	(void *)fminf,
 	(void *)frexpf,
 	(void *)getc,
 	(void *)log2f,

--- a/backends/plugins/riscos/riscos-provider.cpp
+++ b/backends/plugins/riscos/riscos-provider.cpp
@@ -57,8 +57,6 @@ void pluginHack() {
 	f = expf(f);
 	f = frexpf(f, NULL);
 	f = ldexpf(f, 1);
-	f = fmaxf(f, f);
-	f = fminf(f, f);
 	f = truncf(f);
 
 	d = nearbyint(d);

--- a/common/forbidden.h
+++ b/common/forbidden.h
@@ -462,6 +462,38 @@
 
 #endif // FORBIDDEN_SYMBOL_EXCEPTION_ctype_h
 
+
+//
+// Disable various symbols from math.h
+//
+#ifndef FORBIDDEN_SYMBOL_EXCEPTION_math_h
+
+	// Use MIN in common/util.h
+	#ifndef FORBIDDEN_SYMBOL_EXCEPTION_fmin
+	#undef fmin
+	#define fmin(a)	FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
+	#endif
+
+	// Use MIN in common/util.h
+	#ifndef FORBIDDEN_SYMBOL_EXCEPTION_fminf
+	#undef fminf
+	#define fminf(a)	FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
+	#endif
+
+	// Use MAX in common/util.h
+	#ifndef FORBIDDEN_SYMBOL_EXCEPTION_fmax
+	#undef fmax
+	#define fmax(a)	FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
+	#endif
+
+	// Use MAX in common/util.h
+	#ifndef FORBIDDEN_SYMBOL_EXCEPTION_fmaxf
+	#undef fmaxf
+	#define fmaxf(a)	FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
+	#endif
+
+#endif // FORBIDDEN_SYMBOL_EXCEPTION_math_h
+
 // No equivalent in ScummVM
 #ifndef FORBIDDEN_SYMBOL_EXCEPTION_mkdir
 #undef mkdir

--- a/engines/grim/emi/costume/emihead.cpp
+++ b/engines/grim/emi/costume/emihead.cpp
@@ -101,7 +101,7 @@ void EMIHead::lookAt(bool entering, const Math::Vector3d &point, float rate, con
 	if (_headRot != lookAtQuat) {
 		Math::Quaternion diff = _headRot.inverse() * lookAtQuat;
 		diff.normalize();
-		float angle = 2 * acos(fminf(fmaxf(diff.w(), -1.0f), 1.0f));
+		float angle = 2 * acos(MIN(MAX(diff.w(), -1.0f), 1.0f));
 		if (diff.w() < 0.0f) {
 			angle = 2 * (float)M_PI - angle;
 		}

--- a/engines/grim/emi/modelemi.cpp
+++ b/engines/grim/emi/modelemi.cpp
@@ -368,7 +368,7 @@ void EMIModel::updateLighting(const Math::Matrix4 &modelToWorld) {
 					if (cosAngle < 0.0f)
 						continue;
 
-					float angle = acos(fminf(cosAngle, 1.0f));
+					float angle = acos(MIN(cosAngle, 1.0f));
 					if (angle > l->_penumbraangle)
 						continue;
 

--- a/engines/grim/emi/sound/track.cpp
+++ b/engines/grim/emi/sound/track.cpp
@@ -89,7 +89,7 @@ void SoundTrack::updatePosition() {
 	if (_volume == 0) {
 		_attenuation = 0.0f;
 	} else {
-		_attenuation = fmaxf(0.0f, 1.0f - distance / (_volume * 100.0f / Audio::Mixer::kMaxChannelVolume));
+		_attenuation = MAX(0.0f, 1.0f - distance / (_volume * 100.0f / Audio::Mixer::kMaxChannelVolume));
 	}
 
 	Math::Matrix4 worldRot = setup->_rot;

--- a/engines/groovie/video/player.cpp
+++ b/engines/groovie/video/player.cpp
@@ -138,7 +138,7 @@ void VideoPlayer::waitFrame() {
 		uint32 millisDiff = currTime - _lastFrameTime;
 		float fMillis = _millisBetweenFrames + _frameTimeDrift;
 		// use floorf instead of roundf, because delayMillis often slightly over-sleeps
-		uint32 millisSleep = fmaxf(0.0f, floorf(fMillis) - float(millisDiff));
+		uint32 millisSleep = MAX(0.0f, floorf(fMillis) - float(millisDiff));
 
 		if (millisSleep > 0) {
 			debugC(7, kDebugVideo, "Groovie::Player: Delaying %d (currTime=%d, _lastFrameTime=%d, millisDiff=%d, _millisBetweenFrame=%.2f, _frameTimeDrift=%.2f)",

--- a/math/vector3d.h
+++ b/math/vector3d.h
@@ -94,7 +94,7 @@ public:
 	 * @return      The computed angle
 	 */
 	inline static Angle angle(const Vector3d& v1, const Vector3d& v2) {
-		return Angle::arcCosine(fminf(fmaxf(dotProduct(v1, v2) / (v1.getMagnitude() * v2.getMagnitude()), -1.0f), 1.0f));
+		return Angle::arcCosine(MIN(MAX(dotProduct(v1, v2) / (v1.getMagnitude() * v2.getMagnitude()), -1.0f), 1.0f));
 	}
 
 	/**


### PR DESCRIPTION
Using `MIN` and `MAX` from `common/util.h` is more portable.