### PR TITLE
GRAPHICS: Use emmintrin.h for SSE2 intrinsics

### DIFF
--- a/engines/ags/lib/allegro/surface_sse2.cpp
+++ b/engines/ags/lib/allegro/surface_sse2.cpp
@@ -19,7 +19,7 @@
  *
  */
 
-#include <immintrin.h>
+#include <emmintrin.h>
 #include "ags/ags.h"
 #include "ags/globals.h"
 #include "ags/lib/allegro/color.h"

--- a/graphics/blit/blit-sse2.cpp
+++ b/graphics/blit/blit-sse2.cpp
@@ -20,7 +20,7 @@
  */
 
 #include "common/scummsys.h"
-#include <immintrin.h>
+#include <emmintrin.h>
 
 #include "graphics/blit/blit-alpha.h"
 #include "graphics/pixelformat.h"


### PR DESCRIPTION
This just includes the SSE2 intrinsics without the ones from later CPUs.