### PR TITLE
GRIM: Remove mpeg2 requirement from Monkey4 subengine

### DIFF
--- a/engines/grim/configure.engine
+++ b/engines/grim/configure.engine
@@ -1,4 +1,4 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
 add_engine grim "Grim" yes "monkey4" "Grim Fandango" "16bit highres"
-add_engine monkey4 "Escape from Monkey Island" no "" "" "bink mpeg2"
+add_engine monkey4 "Escape from Monkey Island" no "" "" "bink"


### PR DESCRIPTION
libmpeg2 is only required for the PS2 version, and there's already fallback code for when it's not available.