### PR TITLE
DIRECTOR: Add (preliminary) support for Tivola Spring 1999 demo

### DIFF
--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -1787,6 +1787,7 @@ namespace Director {
 #define MACGAME2_l(t,e,f1,m1,s1,f2,m2,s2,l,v) GENGAME2_(t,e,f1,m1,s1,f2,m2,s2,l,Common::kPlatformMacintosh,ADGF_MACRESFORK,v)
 #define PIPGAME2_l(t,e,f1,m1,s1,f2,m2,s2,l,v) GENGAME2_(t,e,f1,m1,s1,f2,m2,s2,l,Common::kPlatformPippin,ADGF_MACRESFORK,v)
 #define WINGAME2_l(t,e,f1,m1,s1,f2,m2,s2,l,v) GENGAME2_(t,e,f1,m1,s1,f2,m2,s2,l,Common::kPlatformWindows,ADGF_NO_FLAGS,v)
+#define MACGAME2f_l(t,e,f1,m1,s1,f2,m2,s2,l,v,fl) GENGAME2_(t,e,f1,m1,s1,f2,m2,s2,l,Common::kPlatformMacintosh, (fl|ADGF_MACRESFORK), v)
 #define WINGAME2t_l(t,e,f1,m1,s1,f2,m2,s2,l,v) GENGAME2t_(t,e,f1,m1,s1,f2,m2,s2,l,Common::kPlatformWindows,ADGF_NO_FLAGS,v)
 #define FMTGAME2_l(t,e,f1,m1,s1,f2,m2,s2,l,v) GENGAME2_(t,e,f1,m1,s1,f2,m2,s2,l,Common::kPlatformFMTowns,ADGF_NO_FLAGS,v)
 #define MACDEMO2_l(t,e,f1,m1,s1,f2,m2,s2,l,v) GENGAME2_(t,e,f1,m1,s1,f2,m2,s2,l,Common::kPlatformMacintosh,(ADGF_MACRESFORK|ADGF_DEMO),v)
@@ -6989,6 +6990,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	// Tivola demo/sampler disc, Spring 1999, released in Germany
 	// Director 5 version
+	MACGAME2f_l("tivolaspring1999", "Sampler", "Start5",       "r:2d2ac01320f4c2dce8e156cda5c73fe8", 716741,
+											   "Intro.dxr",    "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 501, GF_32BPP),
 	WINGAME2f_l("tivolaspring1999", "Sampler", "START516.EXE", "t:c41376e07342bc08880efbe3bf417e10", 938281,
 											   "INTRO.DXR",    "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 501, GF_32BPP),
 

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -2193,13 +2193,6 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Korean Windows version is named 'Time Girl'
 	WINGAME1_l("timegal", "", "TIMEGIRL.EXE", "0e5a7734bdc74198a62171ea4d51a364", 687457, Common::KO_KOR, 400),
 
-	// Tivola demo/sampler disc, Spring 1999, released in Germany
-	// Director 4 version
-	MACGAME2f_l("tivolaspring1999", "Sampler/D4", "Start4",       "r:55b351ff9e11799b4e71f75cb246302c", 484752,
-												  "Intro.dxr",    "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 401, GF_32BPP),
-	WINGAME2f_l("tivolaspring1999", "Sampler/D4", "START416.EXE", "t:0499c4f00a3b0c061ff883f8222e091d", 698543,
-												  "INTRO.DXR",    "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 401, GF_32BPP),
-
 	// Found on
 	// 1995-08-16 Mac/Win hybrid v1.2 release of SimTower
 	// 1995-10-28 Mac/Win hybrid release of Marty
@@ -6995,13 +6988,6 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1("texas", "", "Texas Tourism", "ad32f236d2637602b7299e6b748a7571", 705417, 500),
 	WINGAME1t("texas", "", "TEXAS32.EXE", "ac6cf1ba40918db9d7fa1dd837169834", 1410513, 501),
 
-	// Tivola demo/sampler disc, Spring 1999, released in Germany
-	// Director 5 version
-	MACGAME2f_l("tivolaspring1999", "Sampler/D5", "Start5",       "r:2d2ac01320f4c2dce8e156cda5c73fe8", 716741,
-												  "Intro.dxr",    "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 501, GF_32BPP),
-	WINGAME2f_l("tivolaspring1999", "Sampler/D5", "START516.EXE", "t:c41376e07342bc08880efbe3bf417e10", 938281,
-												  "INTRO.DXR",    "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 501, GF_32BPP),
-
 	// ein Fall für TKKG: Katjas Geheimnis (bilingual DE/EN)
 	MACGAME2("tkkg1", "", "TKKG start", "6e7e31d05709e1d38d63f4df6a59eec0", 719005,
 						  "SCORE.DXR",  "9ffb87ff9d3110435da99a052279fb4c", 10434, 501),
@@ -7837,18 +7823,10 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1("thesims", "", "maxis.exe", "d62438566e44826960fc16c5c23dbe43", 1915533, 650),
 
 	// Tivola demo/sampler disc, Spring 1999, released in Germany
-	// Director 6 version
-	MACGAME2f_l("tivolaspring1999", "Sampler/D6", "Start",       "r:34be958e28922244011f9f0be46c5b57", 1030506,
+	MACGAME2f_l("tivolaspring1999", "Sampler",	  "Start",       "r:34be958e28922244011f9f0be46c5b57", 1030506,
 												  "Intro.dxr",   "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 601, GF_32BPP),
-	WINGAME2f_l("tivolaspring1999", "Sampler/D6", "START16.EXE", "t:a7fbc5507e75ea320562965671db3e0d", 1396929,
+	WINGAME2f_l("tivolaspring1999", "Sampler",	  "START16.EXE", "t:a7fbc5507e75ea320562965671db3e0d", 1396929,
 												  "INTRO.DXR",   "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 601, GF_32BPP),
-
-	// Tivola demo/sampler disc, Spring 1999, released in Germany
-	// Director 6 version, alternative executable
-	MACGAME2f_l("tivolaspring1999", "Sampler/D6", "Start6",       "r:55d01cca925752c170ac1e9c01d1f87e", 1029126,
-												  "Intro.dxr",    "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 601, GF_32BPP),
-	WINGAME2f_l("tivolaspring1999", "Sampler/D6", "START616.EXE", "t:c7199189543f4d55e536e62d21bec032", 1247283,
-												  "INTRO.DXR",    "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 601, GF_32BPP),
 
 	// Tivola demo/sampler disc, Summer 2000, released in Germany
 	MACGAME2_l("tivolasummer2000", "Sampler", "Start",       "r:4f9ad1f256e6840067f44a1c9ad80233", 1031458,

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -2193,6 +2193,13 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Korean Windows version is named 'Time Girl'
 	WINGAME1_l("timegal", "", "TIMEGIRL.EXE", "0e5a7734bdc74198a62171ea4d51a364", 687457, Common::KO_KOR, 400),
 
+	// Tivola demo/sampler disc, Spring 1999, released in Germany
+	// Director 4 version
+	MACGAME2f_l("tivolaspring1999", "Sampler/D4", "Start4",       "r:55b351ff9e11799b4e71f75cb246302c", 484752,
+												  "Intro.dxr",    "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 401, GF_32BPP),
+	WINGAME2f_l("tivolaspring1999", "Sampler/D4", "START416.EXE", "t:0499c4f00a3b0c061ff883f8222e091d", 698543,
+												  "INTRO.DXR",    "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 401, GF_32BPP),
+
 	// Found on
 	// 1995-08-16 Mac/Win hybrid v1.2 release of SimTower
 	// 1995-10-28 Mac/Win hybrid release of Marty

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -1518,6 +1518,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "sfk",				"Science for Kids Product Demos" },
 	{ "sonywalkman",		"Sony Walkman PRD-155SB / PRD-150" },
 	{ "techiescom",			"techies.com Business Card" },
+	{ "tivolaspring1999",	"Tivola Demo - Frühling 1999" }, // Contains D4, D5 and D6 executables
 	{ "tivolasummer2000",	"Tivola Demo - Sommer 2000" },
 	{ "tlc",				"The Learning Company Sampler" },
 	{ "ubt",				"Under the Big Top" },
@@ -1776,6 +1777,7 @@ namespace Director {
 #define MACGAME2tf(t,e,f1,m1,s1,f2,m2,s2,v,fl)	GENGAME2t_(t,e,f1,m1,s1,f2,m2,s2,Common::EN_ANY,Common::kPlatformMacintosh,(fl|ADGF_MACRESFORK),v)
 #define PIPGAME2(t,e,f1,m1,s1,f2,m2,s2,v)	GENGAME2_(t,e,f1,m1,s1,f2,m2,s2,Common::EN_ANY,Common::kPlatformPippin,ADGF_MACRESFORK,v)
 #define WINGAME2(t,e,f1,m1,s1,f2,m2,s2,v)	GENGAME2_(t,e,f1,m1,s1,f2,m2,s2,Common::EN_ANY,Common::kPlatformWindows,ADGF_NO_FLAGS,v)
+#define WINGAME2f_l(t,e,f1,m1,s1,f2,m2,s2,l,v,fl) GENGAME2_(t,e,f1,m1,s1,f2,m2,s2,l,Common::kPlatformWindows,(fl|ADGF_NO_FLAGS),v)
 #define WINGAME2t(t,e,f1,m1,s1,f2,m2,s2,v)	GENGAME2t_(t,e,f1,m1,s1,f2,m2,s2,Common::EN_ANY,Common::kPlatformWindows,ADGF_NO_FLAGS,v)
 #define WINGAME2tf(t,e,f1,m1,s1,f2,m2,s2,v,fl)	GENGAME2t_(t,e,f1,m1,s1,f2,m2,s2,Common::EN_ANY,Common::kPlatformWindows,(fl|ADGF_NO_FLAGS),v)
 #define FMTGAME2(t,e,f1,m1,s1,f2,m2,s2,v)	GENGAME2_(t,e,f1,m1,s1,f2,m2,s2,Common::EN_ANY,Common::kPlatformFMTowns,ADGF_NO_FLAGS,v)
@@ -6984,6 +6986,11 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	MACGAME1("texas", "", "Texas Tourism", "ad32f236d2637602b7299e6b748a7571", 705417, 500),
 	WINGAME1t("texas", "", "TEXAS32.EXE", "ac6cf1ba40918db9d7fa1dd837169834", 1410513, 501),
+
+	// Tivola demo/sampler disc, Spring 1999, released in Germany
+	// Director 5 version
+	WINGAME2f_l("tivolaspring1999", "Sampler", "START516.EXE", "t:c41376e07342bc08880efbe3bf417e10", 938281,
+											   "INTRO.DXR",    "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 501, GF_32BPP),
 
 	// ein Fall für TKKG: Katjas Geheimnis (bilingual DE/EN)
 	MACGAME2("tkkg1", "", "TKKG start", "6e7e31d05709e1d38d63f4df6a59eec0", 719005,

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -7836,6 +7836,20 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	WINGAME1("thesims", "", "maxis.exe", "d62438566e44826960fc16c5c23dbe43", 1915533, 650),
 
+	// Tivola demo/sampler disc, Spring 1999, released in Germany
+	// Director 6 version
+	MACGAME2f_l("tivolaspring1999", "Sampler/D6", "Start",       "r:34be958e28922244011f9f0be46c5b57", 1030506,
+												  "Intro.dxr",   "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 601, GF_32BPP),
+	WINGAME2f_l("tivolaspring1999", "Sampler/D6", "START16.EXE", "t:a7fbc5507e75ea320562965671db3e0d", 1396929,
+												  "INTRO.DXR",   "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 601, GF_32BPP),
+
+	// Tivola demo/sampler disc, Spring 1999, released in Germany
+	// Director 6 version, alternative executable
+	MACGAME2f_l("tivolaspring1999", "Sampler/D6", "Start6",       "r:55d01cca925752c170ac1e9c01d1f87e", 1029126,
+												  "Intro.dxr",    "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 601, GF_32BPP),
+	WINGAME2f_l("tivolaspring1999", "Sampler/D6", "START616.EXE", "t:c7199189543f4d55e536e62d21bec032", 1247283,
+												  "INTRO.DXR",    "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 601, GF_32BPP),
+
 	// Tivola demo/sampler disc, Summer 2000, released in Germany
 	MACGAME2_l("tivolasummer2000", "Sampler", "Start",       "r:4f9ad1f256e6840067f44a1c9ad80233", 1031458,
 											  "Intro.dxr",   "d:a9c22c2247353e17cc6385eb9cbcb014", 1169358, Common::DE_DEU, 650),

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -6990,10 +6990,10 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	// Tivola demo/sampler disc, Spring 1999, released in Germany
 	// Director 5 version
-	MACGAME2f_l("tivolaspring1999", "Sampler", "Start5",       "r:2d2ac01320f4c2dce8e156cda5c73fe8", 716741,
-											   "Intro.dxr",    "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 501, GF_32BPP),
-	WINGAME2f_l("tivolaspring1999", "Sampler", "START516.EXE", "t:c41376e07342bc08880efbe3bf417e10", 938281,
-											   "INTRO.DXR",    "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 501, GF_32BPP),
+	MACGAME2f_l("tivolaspring1999", "Sampler/D5", "Start5",       "r:2d2ac01320f4c2dce8e156cda5c73fe8", 716741,
+												  "Intro.dxr",    "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 501, GF_32BPP),
+	WINGAME2f_l("tivolaspring1999", "Sampler/D5", "START516.EXE", "t:c41376e07342bc08880efbe3bf417e10", 938281,
+												  "INTRO.DXR",    "d:fc34f90b4cf6e2b205414d6165dae050", 1302996, Common::DE_DEU, 501, GF_32BPP),
 
 	// ein Fall für TKKG: Katjas Geheimnis (bilingual DE/EN)
 	MACGAME2("tkkg1", "", "TKKG start", "6e7e31d05709e1d38d63f4df6a59eec0", 719005,

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -56,6 +56,7 @@
 #include "director/lingo/xlibs/fileio.h"
 #include "director/lingo/xlibs/findfolder.h"
 #include "director/lingo/xlibs/findsys.h"
+#include "director/lingo/xlibs/findwin.h"
 #include "director/lingo/xlibs/flushxobj.h"
 #include "director/lingo/xlibs/fplayxobj.h"
 #include "director/lingo/xlibs/gpid.h"
@@ -198,6 +199,7 @@ static struct XLibProto {
 	{ FileIO::fileNames,				FileIO::open,				FileIO::close,				kXObj | kXtraObj,		200 },	// D2
 	{ FindFolder::fileNames,			FindFolder::open,			FindFolder::close,			kXObj,					300 },	// D3
 	{ FindSys::fileNames,				FindSys::open,				FindSys::close,				kXObj,					400 },	// D4
+	{ FindWin::fileNames,				FindWin::open,				FindWin::close,				kXObj,					400 },	// D4
 	{ FlushXObj::fileNames,				FlushXObj::open,			FlushXObj::close,			kXObj,					300 },	// D3
 	{ FPlayXObj::fileNames,				FPlayXObj::open,			FPlayXObj::close,			kXObj,					200 },	// D2
 	{ GpidXObj::fileNames,				GpidXObj::open,				GpidXObj::close,			kXObj,					400 },	// D4

--- a/engines/director/lingo/xlibs/findwin.cpp
+++ b/engines/director/lingo/xlibs/findwin.cpp
@@ -1,0 +1,86 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*************************************
+ *
+ * USED IN:
+ * tivolaspring1999
+ *
+ *************************************/
+
+/*
+-- FindWin. Returns path to Windows directory. Mark_Carolan@aapda.com.au
+--FindWin
+I      mNew                --Creates a new instance of the XObject
+X      mDispose            --Disposes of XObject instance
+S      mDo                 --Return the System directory path as a string
+ */
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/xlibs/findwin.h"
+
+
+namespace Director {
+
+// The name is different from the obj filename.
+const char *FindWin::xlibName = "FindWin";
+const char *FindWin::fileNames[] = {
+	"FindWin",
+	nullptr
+};
+
+static MethodProto xlibMethods[] = {
+	{ "new",		FindWin::m_new,			 0, 0,	400 },	// D4
+	{ "do",			FindWin::m_do,			 0, 0,  400 },	// D4
+	{ nullptr, nullptr, 0, 0, 0 }
+};
+
+void FindWin::open(int type) {
+	if (type == kXObj) {
+		FindWinXObject::initMethods(xlibMethods);
+		FindWinXObject *xobj = new FindWinXObject(kXObj);
+		g_lingo->exposeXObject(xlibName, xobj);
+	}
+}
+
+void FindWin::close(int type) {
+	if (type == kXObj) {
+		FindWinXObject::cleanupMethods();
+		g_lingo->_globalvars[xlibName] = Datum();
+	}
+}
+
+
+FindWinXObject::FindWinXObject(ObjectType ObjectType) : Object<FindWinXObject>("FindWin") {
+	_objType = ObjectType;
+}
+
+void FindWin::m_new(int nargs) {
+	g_lingo->push(g_lingo->_state->me);
+}
+
+void FindWin::m_do(int nargs) {
+	g_lingo->push(Common::String("C:\\WINDOWS\\"));
+}
+
+} // End of namespace Director

--- a/engines/director/lingo/xlibs/findwin.h
+++ b/engines/director/lingo/xlibs/findwin.h
@@ -1,0 +1,47 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XLIBS_FINDWIN_H
+#define DIRECTOR_LINGO_XLIBS_FINDWIN_H
+
+namespace Director {
+
+class FindWinXObject : public Object<FindWinXObject> {
+public:
+	FindWinXObject(ObjectType objType);
+};
+
+namespace FindWin {
+
+extern const char *xlibName;
+extern const char *fileNames[];
+
+void open(int type);
+void close(int type);
+
+void m_new(int nargs);
+void m_do(int nargs);
+
+} // End of namespace FindWin
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -79,6 +79,7 @@ MODULE_OBJS = \
 	lingo/xlibs/fileio.o \
 	lingo/xlibs/findfolder.o \
 	lingo/xlibs/findsys.o \
+	lingo/xlibs/findwin.o \
 	lingo/xlibs/flushxobj.o \
 	lingo/xlibs/fplayxobj.o \
 	lingo/xlibs/gpid.o \


### PR DESCRIPTION
Submitting as PR due to the new macro I defined. I did this because without this, the movies refuse to play after complaining about a too low color depth.

Launching the game currently fails:

```
Starting v501 Director game
Director pixelformat is: RGBA8888@4
WARNING: NinePatchBitmap::NinePatchBitmap(): Bad bitmap!
WARNING: NinePatchBitmap::NinePatchBitmap(): Bad bitmap!
WARNING: Lingo Inited!
WARNING: No LINGO.INI!
WARNING: DirectorEngine::loadEXEv5(): PJ95 projector pflags: 00000012  flags: 00000017!
WARNING: RIFX: type: APPL!
WARNING: mmap: version: 4c1!
WARNING: RIFX: type: MV93!
WARNING: mmap: version: 4c1!
WARNING: FSDirectory::createReadStreamForMemberAltStream: Can't create stream for file 'START516.EXE' alt stream type 2!
WARNING: Cast::loadCastInfo(): BUILDBOT: extra 6 strings!
WARNING: STUB: Score::loadFrames(): frame1Offset: 0x14, version: 7, spriteRecordSize: 0x18, numChannels: 50, numChannelsDisplayed: 48!
WARNING: BUILDBOT: Uncaught Lingo error: Lingo::getTheField(): member 0 of castLib 1 not found!
WARNING: BUILDBOT: Uncaught Lingo error: Lingo::getTheField(): member 0 of castLib 1 not found!
WARNING: BUILDBOT: Uncaught Lingo error: Lingo::getTheField(): member 0 of castLib 1 not found!
WARNING: BUILDBOT: Uncaught Lingo error: Lingo::getTheField(): member 0 of castLib 1 not found!
WARNING: BUILDBOT: Uncaught Lingo error: Lingo::getTheField(): member 0 of castLib 1 not found!
... ad infinitum
```

The error message about START516.EXE is a bit confusing to me, because this should be the start movie...

The new macro is most likely necessary for the D4 and D6 variants as well (yes, it is _that_ disc with the possible buildbot candidates).