### PR TITLE
BASE: Ensure folder path when file path set in command line

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -678,6 +678,12 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 					usage("Non-existent game path '%s'", option);
 				} else if (!path.isWritable()) {
 					usage("Non-writable screenshot path '%s'", option);
+				} else if (!path.isDirectory()
+				           && path.getParent().isDirectory()
+				           && path.getParent().isWritable()) {
+					// The path.getParent().isDirectory() check is redundant but included for clarifying
+					// the purpose of this case, which is to get the folder path part from a file path
+					settings["screenshotpath"] = path.getParent().getPath().toString(Common::Path::kNativeSeparator);
 				}
 			END_OPTION
 #endif
@@ -778,6 +784,12 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 					usage("Non-existent game path '%s'", option);
 				} else if (!path.isReadable()) {
 					usage("Non-readable game path '%s'", option);
+				} else if (!path.isDirectory()
+				           && path.getParent().isDirectory()
+				           && path.getParent().isReadable()) {
+					// The path.getParent().isDirectory() check is redundant but included for clarifying
+					// the purpose of this case, which is to get the folder path part from a file path
+					settings["path"] = path.getParent().getPath().toString(Common::Path::kNativeSeparator);
 				}
 			END_OPTION
 
@@ -874,6 +886,12 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 					usage("Non-existent saved games path '%s'", option);
 				} else if (!path.isWritable()) {
 					usage("Non-writable saved games path '%s'", option);
+				} else if (!path.isDirectory()
+				           && path.getParent().isDirectory()
+				           && path.getParent().isWritable()) {
+					// The path.getParent().isDirectory() check is redundant but included for clarifying
+					// the purpose of this case, which is to get the folder path part from a file path
+					settings["savepath"] = path.getParent().getPath().toString(Common::Path::kNativeSeparator);
 				}
 			END_OPTION
 
@@ -883,16 +901,28 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 					usage("Non-existent extra path '%s'", option);
 				} else if (!path.isReadable()) {
 					usage("Non-readable extra path '%s'", option);
+				} else if (!path.isDirectory()
+				           && path.getParent().isDirectory()
+				           && path.getParent().isReadable()) {
+					// The path.getParent().isDirectory() check is redundant but included for clarifying
+					// the purpose of this case, which is to get the folder path part from a file path
+					settings["extrapath"] = path.getParent().getPath().toString(Common::Path::kNativeSeparator);
 				}
 			END_OPTION
 
 			DO_LONG_OPTION("iconspath")
-			Common::FSNode path(option);
-			if (!path.exists()) {
-				usage("Non-existent icons path '%s'", option);
-			} else if (!path.isReadable()) {
-				usage("Non-readable icons path '%s'", option);
-			}
+				Common::FSNode path(option);
+				if (!path.exists()) {
+					usage("Non-existent icons path '%s'", option);
+				} else if (!path.isReadable()) {
+					usage("Non-readable icons path '%s'", option);
+				} else if (!path.isDirectory()
+				           && path.getParent().isDirectory()
+				           && path.getParent().isReadable()) {
+					// The path.getParent().isDirectory() check is redundant but included for clarifying
+					// the purpose of this case, which is to get the folder path part from a file path
+					settings["iconspath"] = path.getParent().getPath().toString(Common::Path::kNativeSeparator);
+				}
 			END_OPTION
 
 			DO_LONG_OPTION("md5-path")
@@ -933,6 +963,12 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 					usage("Non-existent theme path '%s'", option);
 				} else if (!path.isReadable()) {
 					usage("Non-readable theme path '%s'", option);
+				} else if (!path.isDirectory()
+				           && path.getParent().isDirectory()
+				           && path.getParent().isReadable()) {
+					// The path.getParent().isDirectory() check is redundant but included for clarifying
+					// the purpose of this case, which is to get the folder path part from a file path
+					settings["themepath"] = path.getParent().getPath().toString(Common::Path::kNativeSeparator);
 				}
 			END_OPTION
 

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -482,29 +482,36 @@ static Common::String createTemporaryTarget(const Common::String &engineId, cons
  * If the path given on command line is a file path, the method will use the parent folder path instead,
  * updating the "settings" table and checking the readability / writeability requirements for that one.
  * This method is to be used from within parseCommandLine() method.
- * Note: The method assumes that path.exists() check was already done and is true.
+ * Note 1: The method assumes that path.exists() check was already done and is true.
+ * Note 2: The method will work with paths that are symbolic links to folders (isDirectory() returns true),
+ * but for symbolic links to files it will not deduce a valid folder path and will just return false.
  *
- * @param settings A reference to the settings map used by parseCommandLine() 
+ * @param settings A reference to the settings map used by parseCommandLine()
  * @param optionKeyStr The key string for updating the value for this path option on the settings map, if needed
  * @param path The path node that was created from the command line value for this path option
  * @param ensureWriteable A boolean flag that is set true if the path should be writeable, false otherwise
+ * @param ensureReadable A boolean flag that is set true if the path should be readable, false otherwise
+ * @param acceptFile true if the command line option allows (tolerates) a file path to deduce the folder path from
  * @return true if given path was already a folder path or, if it was a file path, then a parent folder path
  * was deduced from it, and the path (original or deduced respectively) meets the specified
  * readability / writeability requirements.
  */
-bool ensureAccessibleDirectoryForPathOption(Common::StringMap &settings, const Common::String optionKeyStr, const Common::FSNode &path, bool ensureWriteable) {
+bool ensureAccessibleDirectoryForPathOption(Common::StringMap &settings,
+                                            const Common::String optionKeyStr,
+                                            const Common::FSNode &path,
+                                            bool ensureWriteable,
+                                            bool ensureReadable,
+                                            bool acceptFile) {
 	if (path.isDirectory()) {
-		if ((ensureWriteable && path.isWritable())
-		    || (!ensureWriteable && path.isReadable()))  {
+		if ((!ensureWriteable || path.isWritable())
+		    && (!ensureReadable || path.isReadable())
+		    && (ensureWriteable || ensureReadable)) {
 			return true;
 		}
-	} else if (path.getParent().isDirectory()
-	           && ((ensureWriteable && path.getParent().isWritable()) 
-	                || (!ensureWriteable && path.getParent().isReadable())) ) {
-		// The path.getParent().isDirectory() check is redundant but included for clarifying
-		// the purpose of this case, which is to get the folder path part from a file path
-		settings[optionKeyStr] = path.getParent().getPath().toString(Common::Path::kNativeSeparator);
-		return true;
+	} else if (acceptFile
+		    && ensureAccessibleDirectoryForPathOption(settings, optionKeyStr, path.getParent(), ensureWriteable, ensureReadable, false)) {
+			settings[optionKeyStr] = path.getParent().getPath().toString(Common::Path::kNativeSeparator);
+			return true;
 	}
 	return false;
 }
@@ -709,7 +716,7 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 				Common::FSNode path(option);
 				if (!path.exists()) {
 					usage("Non-existent screenshot path '%s'", option);
-				} else if (!ensureAccessibleDirectoryForPathOption(settings, "screenshotpath", path, true)) {
+				} else if (!ensureAccessibleDirectoryForPathOption(settings, "screenshotpath", path, true, false, true)) {
 					usage("Non-writable screenshot path '%s'", option);
 				}
 			END_OPTION
@@ -809,7 +816,7 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 				Common::FSNode path(option);
 				if (!path.exists()) {
 					usage("Non-existent game path '%s'", option);
-				} else if (!ensureAccessibleDirectoryForPathOption(settings, "path", path, false)) {
+				} else if (!ensureAccessibleDirectoryForPathOption(settings, "path", path, false, true, true)) {
 					usage("Non-readable game path '%s'", option);
 				}
 			END_OPTION
@@ -905,7 +912,7 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 				Common::FSNode path(option);
 				if (!path.exists()) {
 					usage("Non-existent saved games path '%s'", option);
-				} else if (!ensureAccessibleDirectoryForPathOption(settings, "savepath", path, true)) {
+				} else if (!ensureAccessibleDirectoryForPathOption(settings, "savepath", path, true, true, true)) {
 					usage("Non-writable saved games path '%s'", option);
 				}
 			END_OPTION
@@ -914,7 +921,7 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 				Common::FSNode path(option);
 				if (!path.exists()) {
 					usage("Non-existent extra path '%s'", option);
-				} else if (!ensureAccessibleDirectoryForPathOption(settings, "extrapath", path, false)) {
+				} else if (!ensureAccessibleDirectoryForPathOption(settings, "extrapath", path, false, true, true)) {
 					usage("Non-readable extra path '%s'", option);
 				}
 			END_OPTION
@@ -923,7 +930,7 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 				Common::FSNode path(option);
 				if (!path.exists()) {
 					usage("Non-existent icons path '%s'", option);
-				} else if (!ensureAccessibleDirectoryForPathOption(settings, "iconspath", path, false)) {
+				} else if (!ensureAccessibleDirectoryForPathOption(settings, "iconspath", path, true, true, true)) {
 					usage("Non-readable icons path '%s'", option);
 				}
 			END_OPTION
@@ -964,7 +971,7 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 				Common::FSNode path(option);
 				if (!path.exists()) {
 					usage("Non-existent theme path '%s'", option);
-				} else if (!ensureAccessibleDirectoryForPathOption(settings, "themepath", path, false)) {
+				} else if (!ensureAccessibleDirectoryForPathOption(settings, "themepath", path, false, true, true)) {
 					usage("Non-readable theme path '%s'", option);
 				}
 			END_OPTION

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -708,7 +708,7 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 			DO_LONG_OPTION("screenshotpath")
 				Common::FSNode path(option);
 				if (!path.exists()) {
-					usage("Non-existent game path '%s'", option);
+					usage("Non-existent screenshot path '%s'", option);
 				} else if (!ensureAccessibleDirectoryForPathOption(settings, "screenshotpath", path, true)) {
 					usage("Non-writable screenshot path '%s'", option);
 				}


### PR DESCRIPTION
The "soundfont" option is excluded from this, since that is expected to be a file path.

The PR is submitted for consideration as an extension to the command line to allow more leniency with the path arguments, ie. when a file path is set for a folder path argument in command line, it is converted to the appropriate folder path for the file, so that scummvm won't throw an error and exit.

The motivation for the PR was the discussion in this forum thread: <https://forums.scummvm.org/viewtopic.php?t=17015>

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
