### PR TITLE
MACOS: Migrate to Sparkle 2 API for updates

### DIFF
--- a/configure
+++ b/configure
@@ -5591,7 +5591,7 @@ echo "$_a52"
 #
 case $_host_os in
 	darwin*)
-		echocheck "Sparkle"
+		echocheck "Sparkle >= 2.0"
 		if test "$_updates" = no; then
 			_sparkle=no
 		else
@@ -5605,7 +5605,7 @@ case $_host_os in
 				cat > $TMPC << EOF
 #include <Cocoa/Cocoa.h>
 #include <Sparkle/Sparkle.h>
-int main(void) { SUUpdater *updater = [SUUpdater sharedUpdater]; return 0; }
+int main(void) { SPUStandardUpdaterController *updater = [[SPUStandardUpdaterController alloc] initWithUpdaterDelegate:nil userDriverDelegate:nil]; return 0; }
 EOF
 				cc_check $SPARKLE_CFLAGS $SPARKLE_LIBS -framework Sparkle -ObjC++ -lobjc && _sparkle=yes
 			fi


### PR DESCRIPTION
I didn't push that code directly as this would break buildbot macOS builds. This can be merged once Sparkle has been updated to version 2 on buildbot.

**Important:** We will also need to migrate to an EdDSA signature before the next release, but this is not included in this pull request. See https://sparkle-project.org/documentation/eddsa-migration/ for details.

This was tested on a Mac M1 with Sparkle 2.5.2.

