### PR TITLE
ULTIMA8: Interpret book page breaks correctly

### DIFF
--- a/engines/ultima/ultima8/graphics/fonts/font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/font.cpp
@@ -39,10 +39,10 @@ void Font::getTextSize(const Std::string &text,
 					   int32 &resultwidth, int32 &resultheight,
 					   unsigned int &remaining,
 					   int32 width, int32 height, TextAlign align,
-					   bool u8specials) {
+					   bool u8specials, bool pagebreaks) {
 	Std::list<PositionedText> tmp;
 	tmp = typesetText<Traits>(this, text, remaining,
-	                          width, height, align, u8specials,
+	                          width, height, align, u8specials, pagebreaks,
 	                          resultwidth, resultheight);
 }
 
@@ -180,7 +180,7 @@ CHECKME: any others? (page breaks for books?)
 template<class T>
 Std::list<PositionedText> typesetText(Font *font,
 	const Std::string &text, unsigned int &remaining, int32 width, int32 height,
-	Font::TextAlign align, bool u8specials, int32 &resultwidth,
+	Font::TextAlign align, bool u8specials, bool pagebreaks, int32 &resultwidth,
 	int32 &resultheight, Std::string::size_type cursor) {
 
 	debugC(kDebugGraphics, "typeset (%d, %d) %s", width, height, text.c_str());
@@ -205,6 +205,7 @@ Std::list<PositionedText> typesetText(Font *font,
 	while (true) {
 		if (iter == text.end() || breakhere || T::isBreak(iter, u8specials)) {
 			// break here
+			bool atpagebreak = pagebreaks && T::isPageBreak(iter, u8specials);
 			int32 stringwidth = 0, stringheight = 0;
 			font->getStringSize(curline, stringwidth, stringheight);
 			line._dims.left = 0;
@@ -239,7 +240,7 @@ Std::list<PositionedText> typesetText(Font *font,
 				curlinestart = iter;
 			}
 
-			if (height != 0 && totalheight + font->getHeight() > height) {
+			if (atpagebreak || (height != 0 && totalheight + font->getHeight() > height)) {
 				// next line won't fit
 				remaining = curlinestart - text.begin();
 				break;
@@ -366,14 +367,14 @@ template
 Std::list<PositionedText> typesetText<Font::Traits>
 (Font *font, const Std::string &text,
  unsigned int &remaining, int32 width, int32 height,
- Font::TextAlign align, bool u8specials,
+ Font::TextAlign align, bool u8specials, bool pagebreaks,
  int32 &resultwidth, int32 &resultheight, Std::string::size_type cursor);
 
 template
 Std::list<PositionedText> typesetText<Font::SJISTraits>
 (Font *font, const Std::string &text,
  unsigned int &remaining, int32 width, int32 height,
- Font::TextAlign align, bool u8specials,
+ Font::TextAlign align, bool u8specials, bool pagebreaks,
  int32 &resultwidth, int32 &resultheight, Std::string::size_type cursor);
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/graphics/fonts/font.h
+++ b/engines/ultima/ultima8/graphics/fonts/font.h
@@ -72,10 +72,12 @@ public:
 	//! \param height The height of the target rectangle, or 0 for unlimited
 	//! \param align Alignment of the text (left, right, center)
 	//! \param u8specials If true, interpret the special characters U8 uses
+	//! \param pagebreaks If true (and u8specials too), stop at U8 pagebreaks
 	//! \return the rendered text in a RenderedText object
 	virtual RenderedText *renderText(const Std::string &text,
 	    unsigned int &remaining, int32 width = 0, int32 height = 0,
 		TextAlign align = TEXT_LEFT, bool u8specials = false,
+		bool pagebreaks = false,
 		Std::string::size_type cursor = Std::string::npos) = 0;
 
 	//! get the dimensions of a rendered string
@@ -85,12 +87,13 @@ public:
 	//! \param remaining Returns index of the first character not printed
 	//! \param width The width of the target rectangle, or 0 for unlimited
 	//! \param height The height of the target rectangle, or 0 for unlimited
-	//! \param u8specials If true, interpret the special characters U8 uses
 	//! \param align Alignment of the text (left, right, center)
+	//! \param u8specials If true, interpret the special characters U8 uses
+	//! \param pagebreaks If true (and u8specials too), stop at U8 pagebreaks
 	virtual void getTextSize(const Std::string &text,
 		int32 &resultwidth, int32 &resultheight, unsigned int &remaining,
 		int32 width = 0, int32 height = 0, TextAlign align = TEXT_LEFT,
-		bool u8specials = false);
+		bool u8specials = false, bool pagebreaks = false);
 
 	void setHighRes(bool hr) {
 		_highRes = hr;
@@ -119,6 +122,10 @@ protected:
 			char c = *i;
 			return (c == '\n' ||
 			        (u8specials && (c == '\n' || c == '~' || c == '*')));
+		}
+		static bool isPageBreak(Std::string::const_iterator &i, bool u8specials) {
+			char c = *i;
+			return (u8specials && c == '*');
 		}
 		static bool canBreakAfter(Std::string::const_iterator &i);
 		static void advance(Std::string::const_iterator &i) {
@@ -164,7 +171,8 @@ template<class T>
 Std::list<PositionedText> typesetText(Font *font,
 	const Std::string &text, unsigned int &remaining,
 	int32 width, int32 height, Font::TextAlign align,
-	bool u8specials, int32 &resultwidth, int32 &resultheight,
+	bool u8specials, bool pagebreaks,
+	int32 &resultwidth, int32 &resultheight,
 	Std::string::size_type cursor = Std::string::npos);
 
 } // End of namespace Ultima8

--- a/engines/ultima/ultima8/graphics/fonts/jp_font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/jp_font.cpp
@@ -78,22 +78,22 @@ void JPFont::getTextSize(const Std::string &text,
 						 int32 &resultwidth, int32 &resultheight,
 						 unsigned int &remaining,
 						 int32 width, int32 height, TextAlign align,
-						 bool u8specials) {
+						 bool u8specials, bool pagebreaks) {
 	Std::list<PositionedText> tmp;
 	tmp = typesetText<SJISTraits>(this, text, remaining,
-	                              width, height, align, u8specials,
+	                              width, height, align, u8specials, pagebreaks,
 	                              resultwidth, resultheight);
 }
 
 RenderedText *JPFont::renderText(const Std::string &text,
 								 unsigned int &remaining,
 								 int32 width, int32 height, TextAlign align,
-								 bool u8specials,
+								 bool u8specials, bool pagebreaks,
 								 Std::string::size_type cursor) {
 	int32 resultwidth, resultheight;
 	Std::list<PositionedText> lines;
 	lines = typesetText<SJISTraits>(this, text, remaining,
-	                                width, height, align, u8specials,
+	                                width, height, align, u8specials, pagebreaks,
 	                                resultwidth, resultheight,
 	                                cursor);
 

--- a/engines/ultima/ultima8/graphics/fonts/jp_font.h
+++ b/engines/ultima/ultima8/graphics/fonts/jp_font.h
@@ -44,11 +44,13 @@ public:
 		int32 &width, int32 &height) override;
 	void getTextSize(const Std::string &text, int32 &resultwidth,
 		int32 &resultheight, unsigned int &remaining, int32 width = 0,
-		int32 height = 0, TextAlign align = TEXT_LEFT, bool u8specials = false) override;
+		int32 height = 0, TextAlign align = TEXT_LEFT,
+		bool u8specials = false, bool pagebreaks = false) override;
 
 	RenderedText *renderText(const Std::string &text,
 		unsigned int &remaining, int32 width = 0, int32 height = 0,
 		TextAlign align = TEXT_LEFT, bool u8specials = false,
+		bool pagebreaks = false,
 		Std::string::size_type cursor = Std::string::npos) override;
 
 protected:

--- a/engines/ultima/ultima8/graphics/fonts/shape_font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/shape_font.cpp
@@ -121,12 +121,12 @@ int ShapeFont::charToFrameNum(char c) const {
 RenderedText *ShapeFont::renderText(const Std::string &text,
 									unsigned int &remaining,
 									int32 width, int32 height, TextAlign align,
-									bool u8specials,
+									bool u8specials, bool pagebreaks,
 									Std::string::size_type cursor) {
 	int32 resultwidth, resultheight;
 	Std::list<PositionedText> lines;
 	lines = typesetText<Traits>(this, text, remaining,
-	                            width, height, align, u8specials,
+	                            width, height, align, u8specials, pagebreaks,
 	                            resultwidth, resultheight, cursor);
 
 	return new ShapeRenderedText(lines, resultwidth, resultheight,

--- a/engines/ultima/ultima8/graphics/fonts/shape_font.h
+++ b/engines/ultima/ultima8/graphics/fonts/shape_font.h
@@ -67,6 +67,7 @@ public:
 	RenderedText *renderText(const Std::string &text,
 		unsigned int &remaining, int32 width = 0, int32 height = 0,
 		TextAlign align = TEXT_LEFT, bool u8specials = false,
+		bool pagebreaks = false,
 		Std::string::size_type cursor = Std::string::npos) override;
 };
 

--- a/engines/ultima/ultima8/graphics/fonts/tt_font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/tt_font.cpp
@@ -105,15 +105,15 @@ void TTFont::getTextSize(const Std::string &text,
 						 int32 &resultWidth, int32 &resultHeight,
 						 unsigned int &remaining,
 						 int32 width, int32 height, TextAlign align,
-						 bool u8specials) {
+						 bool u8specials, bool pagebreaks) {
 	Std::list<PositionedText> tmp;
 	if (!_SJIS)
 		tmp = typesetText<Traits>(this, text, remaining,
-		                          width, height, align, u8specials,
+		                          width, height, align, u8specials, pagebreaks,
 		                          resultWidth, resultHeight);
 	else
 		tmp = typesetText<SJISTraits>(this, text, remaining,
-		                              width, height, align, u8specials,
+		                              width, height, align, u8specials, pagebreaks,
 		                              resultWidth, resultHeight);
 }
 
@@ -189,15 +189,15 @@ void TTFont::addTextBorder(Graphics::ManagedSurface &textSurf, uint32 *texBuf, c
 }
 
 RenderedText *TTFont::renderText(const Std::string &text, unsigned int &remaining,
-		int32 width, int32 height, TextAlign align, bool u8specials,
+		int32 width, int32 height, TextAlign align, bool u8specials, bool pagebreaks,
 		Std::string::size_type cursor) {
 	int32 resultWidth, resultHeight, lineHeight;
 	Std::list<PositionedText> lines;
 	if (!_SJIS)
-		lines = typesetText<Traits>(this, text, remaining, width, height, align, u8specials,
+		lines = typesetText<Traits>(this, text, remaining, width, height, align, u8specials, pagebreaks,
 			resultWidth, resultHeight, cursor);
 	else
-		lines = typesetText<SJISTraits>(this, text, remaining, width, height, align, u8specials,
+		lines = typesetText<SJISTraits>(this, text, remaining, width, height, align, u8specials, pagebreaks,
 			resultWidth, resultHeight, cursor);
 	lineHeight = _ttfFont->getFontHeight();
 

--- a/engines/ultima/ultima8/graphics/fonts/tt_font.h
+++ b/engines/ultima/ultima8/graphics/fonts/tt_font.h
@@ -49,11 +49,12 @@ public:
 	void getTextSize(const Std::string &text,
 		int32 &resultwidth, int32 &resultheight, unsigned int &remaining,
 		int32 width = 0, int32 height = 0, TextAlign align = TEXT_LEFT,
-		bool u8specials = false) override;
+		bool u8specials = false, bool pagebreaks = false) override;
 
 	RenderedText *renderText(const Std::string &text,
 		unsigned int &remaining, int32 width = 0, int32 height = 0,
 		TextAlign align = TEXT_LEFT, bool u8specials = false,
+		bool pagebreaks = false,
 		Std::string::size_type cursor = Std::string::npos) override;
 
 protected:

--- a/engines/ultima/ultima8/gumps/book_gump.cpp
+++ b/engines/ultima/ultima8/gumps/book_gump.cpp
@@ -66,11 +66,11 @@ void BookGump::InitGump(Gump *newparent, bool take_focus) {
 	}
 
 	// Create the TextWidgets (NOTE: they _must_ have exactly the same _dims)
-	TextWidget *widget = new TextWidget(9, 5, _text, true, 9, 123, 129); //!! constants
+	TextWidget *widget = new TextWidget(9, 5, _text, true, 9, 123, 129, Font::TEXT_LEFT, true); //!! constants
 	widget->InitGump(this);
 	_textWidgetL = widget->getObjId();
 
-	widget = new TextWidget(150, 5, _text, true, 9, 123, 129); //!! constants
+	widget = new TextWidget(150, 5, _text, true, 9, 123, 129, Font::TEXT_LEFT, true); //!! constants
 	widget->InitGump(this);
 	_textWidgetR = widget->getObjId();
 	widget->setupNextText();

--- a/engines/ultima/ultima8/gumps/scroll_gump.cpp
+++ b/engines/ultima/ultima8/gumps/scroll_gump.cpp
@@ -52,7 +52,7 @@ void ScrollGump::InitGump(Gump *newparent, bool take_focus) {
 	ModalGump::InitGump(newparent, take_focus);
 
 	// Create the TextWidget
-	Gump *widget = new TextWidget(22, 29, _text, true, 9, 204, 115); //!! constants
+	Gump *widget = new TextWidget(22, 29, _text, true, 9, 204, 115, Font::TEXT_LEFT, true); //!! constants
 	widget->InitGump(this);
 	_textWidget = widget->getObjId();
 

--- a/engines/ultima/ultima8/gumps/widgets/edit_widget.cpp
+++ b/engines/ultima/ultima8/gumps/widgets/edit_widget.cpp
@@ -147,7 +147,8 @@ void EditWidget::renderText() {
 		_cachedText = font->renderText(_text, remaining,
 		                               max_width, max_height,
 		                               Font::TEXT_LEFT,
-		                               false, cv ? _cursor : Std::string::npos);
+		                               false, false,
+		                               cv ? _cursor : Std::string::npos);
 
 		// Trim text to fit
 		if (remaining < _text.length()) {

--- a/engines/ultima/ultima8/gumps/widgets/text_widget.cpp
+++ b/engines/ultima/ultima8/gumps/widgets/text_widget.cpp
@@ -38,10 +38,11 @@ TextWidget::TextWidget() : Gump(), _gameFont(false), _fontNum(0), _blendColour(0
 }
 
 TextWidget::TextWidget(int x, int y, const Std::string &txt, bool gamefont, int font,
-					   int w, int h, Font::TextAlign align) :
+					   int w, int h, Font::TextAlign align, bool dopaging) :
 	Gump(x, y, w, h), _text(txt), _gameFont(gamefont), _fontNum(font),
 	_blendColour(0), _currentStart(0), _currentEnd(0), _tx(0), _ty(0),
-	_targetWidth(w), _targetHeight(h), _cachedText(nullptr), _textAlign(align) {
+	_doPaging(dopaging), _targetWidth(w), _targetHeight(h),
+	_cachedText(nullptr), _textAlign(align) {
 }
 
 TextWidget::~TextWidget(void) {
@@ -110,7 +111,7 @@ bool TextWidget::setupNextText() {
 
 	unsigned int remaining;
 	font->getTextSize(_text.substr(_currentStart), _tx, _ty, remaining,
-	                  _targetWidth, _targetHeight, _textAlign, true);
+	                  _targetWidth, _targetHeight, _textAlign, true, _doPaging);
 
 
 	_dims.top = -font->getBaseline();
@@ -153,7 +154,7 @@ void TextWidget::renderText() {
 		_cachedText = font->renderText(_text.substr(_currentStart,
 		                               _currentEnd - _currentStart),
 		                               remaining, _targetWidth, _targetHeight,
-		                               _textAlign, true);
+		                               _textAlign, true, _doPaging);
 	}
 }
 
@@ -248,7 +249,7 @@ bool TextWidget::loadData(Common::ReadStream *rs, uint32 version) {
 	int32 tx, ty;
 	unsigned int remaining;
 	font->getTextSize(_text.substr(_currentStart), tx, ty, remaining,
-	                  _targetWidth, _targetHeight, _textAlign, true);
+	                  _targetWidth, _targetHeight, _textAlign, true, _doPaging);
 
 	// Y offset is always baseline
 	_dims.top = -font->getBaseline();

--- a/engines/ultima/ultima8/gumps/widgets/text_widget.h
+++ b/engines/ultima/ultima8/gumps/widgets/text_widget.h
@@ -42,6 +42,7 @@ protected:
 	int             _fontNum;
 	uint32          _blendColour;
 	int32           _tx, _ty;
+	bool            _doPaging;
 
 	unsigned int    _currentStart; //!< start of currently displaying text
 	unsigned int    _currentEnd;   //!< start of remaining text
@@ -56,7 +57,8 @@ public:
 	TextWidget();
 	TextWidget(int x, int y, const Std::string &txt, bool gamefont, int fontnum,
 	           int width = 0, int height = 0,
-	           Font::TextAlign align = Font::TEXT_LEFT);
+	           Font::TextAlign align = Font::TEXT_LEFT,
+	           bool dopaging = false);
 	~TextWidget() override;
 
 	// Init the gump, call after construction


### PR DESCRIPTION
Now interpreting page breaks in scrolls and books. Verified the behaviour of those two gumps in dosbox. Also verified that plaques treat '*' as a linebreak.

Fixes #14833.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
