### PR TITLE
ULTIMA8: Fix impact of certain spaces on text centering

### DIFF
--- a/engines/ultima/ultima8/graphics/fonts/font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/font.cpp
@@ -265,7 +265,8 @@ Std::list<PositionedText> typesetText(Font *font,
 					spaces.append(" ");
 				}
 			}
-			if (foundLF) continue;
+			// no next word?
+			if (foundLF || nextword == text.end()) continue;
 
 			// process word
 			Std::string::const_iterator endofnextword = iter;

--- a/engines/ultima/ultima8/graphics/fonts/font.cpp
+++ b/engines/ultima/ultima8/graphics/fonts/font.cpp
@@ -260,7 +260,9 @@ Std::list<PositionedText> typesetText(Font *font,
 					foundLF = true;
 					break;
 				} else if (T::isTab(iter, u8specials)) {
-					spaces.append("    ");
+					// ignore tabs at beginning of line when centered
+					if (!(curline.empty() && align == Font::TEXT_CENTER))
+						spaces.append("    ");
 				} else if (!curline.empty()) {
 					spaces.append(" ");
 				}


### PR DESCRIPTION
This fixes trailing spaces on the last line of the text impacting centering, as well as tabs at the start of lines.

Fixes #14832.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
