### PR TITLE
ANDROID: Set a different package name for debug builds

### DIFF
--- a/dists/android/AndroidManifest.xml
+++ b/dists/android/AndroidManifest.xml
@@ -3,7 +3,7 @@
 	xmlns:tools="http://schemas.android.com/tools"
 	android:installLocation="auto"
 	android:launchMode="singleTask"
-	android:sharedUserId="org.scummvm.scummvm"
+	android:sharedUserId="${applicationId}"
 	android:sharedUserMaxSdkVersion="32"
 	tools:targetApi="tiramisu">
 
@@ -39,7 +39,7 @@
 		android:description="@string/app_desc"
 		android:icon="@mipmap/scummvm"
 		android:appCategory="game"
-		android:label="@string/app_name"
+		android:label="@string/app_name${nameSuffix}"
 		android:resizeableActivity="false"
 		android:requestLegacyExternalStorage="true">
 		<activity

--- a/dists/android/build.gradle
+++ b/dists/android/build.gradle
@@ -83,9 +83,12 @@ android {
     }
     buildTypes {
         debug{
+            applicationIdSuffix "debug"
+            manifestPlaceholders = [nameSuffix:"_debug"]
             debuggable true
         }
         release {
+            manifestPlaceholders = [nameSuffix:""]
             debuggable false
             // Enables code shrinking, obfuscation, and optimization for only
             // your project's release build type.

--- a/dists/android/res/values/strings.xml
+++ b/dists/android/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">ScummVM</string>
+	<string name="app_name_debug">ScummVM (debug)</string>
 	<string name="app_desc">Graphic adventure game engine</string>
 	<string name="ok">OK</string>
 	<string name="quit">Quit</string>


### PR DESCRIPTION
This allows to have official release and daily builds side by side.

I expect this will be harmless on existing installations.