### PR TITLE
ANDROID: Get HiDPI density from Android metrics

### DIFF
--- a/backends/graphics/android/android-graphics.cpp
+++ b/backends/graphics/android/android-graphics.cpp
@@ -211,14 +211,11 @@ void AndroidGraphicsManager::hideOverlay() {
 }
 
 float AndroidGraphicsManager::getHiDPIScreenFactor() const {
-	// TODO: Use JNI to get DisplayMetrics.density, which according to the documentation
-	// seems to be what we want.
-	// "On a medium-density screen, DisplayMetrics.density equals 1.0; on a high-density
-	//  screen it equals 1.5; on an extra-high-density screen, it equals 2.0; and on a
-	//  low-density screen, it equals 0.75. This figure is the factor by which you should
-	//  multiply the dp units in order to get the actual pixel count for the current screen."
-
-	return 2.f;
+	JNI::DPIValues dpi;
+	JNI::getDPI(dpi);
+	// Scale down the Android factor else the GUI is too big and
+	// there is not much options to go smaller
+	return dpi[2] / 1.2;
 }
 
 bool AndroidGraphicsManager::loadVideoMode(uint requestedWidth, uint requestedHeight, const Graphics::PixelFormat &format) {
@@ -226,7 +223,6 @@ bool AndroidGraphicsManager::loadVideoMode(uint requestedWidth, uint requestedHe
 
 	// We get this whenever a new resolution is requested. Since Android is
 	// using a fixed output size we do nothing like that here.
-	// TODO: Support screen rotation
 	return true;
 }
 

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -980,7 +980,7 @@ void AndroidGraphics3dManager::updateScreenRect() {
 
 	if (w && h && _ar_correction) {
 
-		float dpi[2];
+		JNI::DPIValues dpi;
 		JNI::getDPI(dpi);
 
 		float screen_ar;
@@ -1069,14 +1069,11 @@ void AndroidGraphics3dManager::clearScreen(FixupType type, byte count) {
 }
 
 float AndroidGraphics3dManager::getHiDPIScreenFactor() const {
-	// TODO: Use JNI to get DisplayMetrics.density, which according to the documentation
-	// seems to be what we want.
-	// "On a medium-density screen, DisplayMetrics.density equals 1.0; on a high-density
-	//  screen it equals 1.5; on an extra-high-density screen, it equals 2.0; and on a
-	//  low-density screen, it equals 0.75. This figure is the factor by which you should
-	//  multiply the dp units in order to get the actual pixel count for the current screen."
-
-	return 2.f;
+	JNI::DPIValues dpi;
+	JNI::getDPI(dpi);
+	// Scale down the Android factor else the GUI is too big and
+	// there is not much options to go smaller
+	return dpi[2] / 1.2;
 }
 
 AndroidCommonGraphics::State AndroidGraphics3dManager::getState() const {

--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -527,14 +527,6 @@ void OSystem_Android::initBackend() {
 		ConfMan.setPath("browser_lastpath", "/");
 	}
 
-	if (!ConfMan.hasKey("gui_scale")) {
-		// Until a proper scale detection is done (especially post PR https://github.com/scummvm/scummvm/pull/3264/commits/8646dfca329b6fbfdba65e0dc0802feb1382dab2),
-		// set scale by default to large, if not set, and then let the user set it manually from the launcher -> Options -> Misc tab
-		// Otherwise the screen may default to very tiny and indiscernible text and be barely usable.
-		// TODO We need a proper scale detection for Android, see: (float) AndroidGraphicsManager::getHiDPIScreenFactor() in android/graphics.cpp
-		ConfMan.setInt("gui_scale", 125); // "Large" (see gui/options.cpp and guiBaseValues[])
-	}
-
 	Common::String basePath = JNI::getScummVMBasePath();
 
 	_savefileManager = new AndroidSaveFileManager(Common::Path(basePath, Common::Path::kNativeSeparator).joinInPlace("saves"));

--- a/backends/platform/android/jni-android.h
+++ b/backends/platform/android/jni-android.h
@@ -78,7 +78,12 @@ public:
 	static void wakeupForQuit();
 
 	static void setWindowCaption(const Common::U32String &caption);
-	static void getDPI(float *values);
+
+	/**
+	 * Array members of DPIValues are xdpi, ydpi, density
+	 **/
+	typedef float DPIValues[3];
+	static void getDPI(DPIValues &values);
 	static void displayMessageOnOSD(const Common::U32String &msg);
 	static bool openUrl(const Common::String &url);
 	static bool hasTextInClipboard();

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
@@ -663,9 +663,18 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 		protected void getDPI(float[] values) {
 			DisplayMetrics metrics = new DisplayMetrics();
 			getWindowManager().getDefaultDisplay().getMetrics(metrics);
+			Configuration config = getResources().getConfiguration();
 
 			values[0] = metrics.xdpi;
 			values[1] = metrics.ydpi;
+			// "On a medium-density screen, DisplayMetrics.density equals 1.0; on a high-density
+			//  screen it equals 1.5; on an extra-high-density screen, it equals 2.0; and on a
+			//  low-density screen, it equals 0.75. This figure is the factor by which you should
+			//  multiply the dp units in order to get the actual pixel count for the current screen."
+			//  In addition, take into account the fontScale setting set by the user.
+			//  We are not supposed to take this value directly because of non-linear scaling but
+			//  as we are doing our own rendering there is not much choice
+			values[2] = metrics.density * config.fontScale;
 		}
 
 		@Override
@@ -974,9 +983,9 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 		                                                        }
 		                                                    });
 
-		float[] dpiValues = new float[] { 0.0f, 0.0f };
+		float[] dpiValues = new float[] { 0.0f, 0.0f, 0.0f };
 		_scummvm.getDPI(dpiValues);
-		Log.d(ScummVM.LOG_TAG, "Current xdpi: " + dpiValues[0] + " and ydpi: " + dpiValues[1]);
+		Log.d(ScummVM.LOG_TAG, "Current xdpi: " + dpiValues[0] + ", ydpi: " + dpiValues[1] + " and density: " + dpiValues[2]);
 
 		// Currently in release builds version string does not contain the revision info
 		// but in debug builds (daily builds) this should be there (see base/internal_version_h)


### PR DESCRIPTION
This makes the scaling more adapted to the smartphone screen.

I added some correction factor because without it, I found the texts quite big.