### PR TITLE
PEGASUS: Use quicktime workaround for movies

### DIFF
--- a/engines/pegasus/movie.cpp
+++ b/engines/pegasus/movie.cpp
@@ -58,6 +58,7 @@ void Movie::initFromMovieFile(const Common::Path &fileName, bool transparent) {
 
 	releaseMovie();
 	_video = new Video::QuickTimeDecoder();
+	_video->enableEditListBoundsCheckQuirk(true);
 	if (!_video->loadFile(fileName)) {
 		// Replace any colon with an underscore, since only macOS
 		// supports that. See PegasusEngine::detectOpeningClosingDirectory()

--- a/engines/pegasus/movie.h
+++ b/engines/pegasus/movie.h
@@ -29,6 +29,7 @@
 
 #include "pegasus/elements.h"
 #include "pegasus/surface.h"
+#include "video/qt_decoder.h"
 
 namespace Video {
 class VideoDecoder;
@@ -72,7 +73,7 @@ public:
 protected:
 	void updateTime() override;
 
-	Video::VideoDecoder *_video;
+	Video::QuickTimeDecoder *_video;
 	Common::Rect _movieBox;
 };
 


### PR DESCRIPTION
This is a proposed solution for bug report #14855

The workaround, enableEditListBoundsCheckQuirk(true), is applied to movies loaded with Movie::initFromMovieFile(), which is where the problematic video file is loaded from.
The problematic video file is under path "Images/AI/Caldoria/XAE1"

Not all files loaded from Movie::initFromMovieFile() need the workaround, but for the few I tested, it didn't seem to have side-effects on them. 

This change, as of yet, does not apply the workaround to video files loaded elsewhere in the engine (ie. outside Movie::initFromMovieFile())

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
