### PR TITLE
DOCS: Update Sphinx to latest version

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3"
 
 sphinx:
   configuration: doc/docportal/conf.py

--- a/NEWS.md
+++ b/NEWS.md
@@ -2140,7 +2140,7 @@ For a more comprehensive changelog of the latest experimental code, see:
  Windows port:
    - Changed default savegames location for Windows NT4/2000/XP/Vista/7.
      (The migration batch file can be used to copy savegames from the old
-      default location, to the new default location).
+     default location, to the new default location).
 
 
 #### 1.4.1 "Subwoofer Release" (2012-01-27)

--- a/doc/docportal/_static/custom.css
+++ b/doc/docportal/_static/custom.css
@@ -136,17 +136,15 @@ h4 {
 	color: #000000;
 }
 
-/* Change color of tabs*/
+/* Change color of tabs and cards */
 
-.tabbed-set > input:checked + label {
-	border-color: #cc6600 !important;
-	color: #cc6600 !important;
-}
-
-.tabbed-set > label {
-	color: #fd962e !important;
-}
-
-.tabbed-content {
-	box-shadow: 0 -0.0625rem #ffd3a8, 0 0.0625rem #ffd3a8 !important;
+body {
+	--sd-color-tabs-underline-active: #cc6600;
+	--sd-color-tabs-label-active: #cc6600;
+	--sd-color-tabs-label-inactive: #fd962e;
+	--sd-color-tabs-label-hover: #cc6600;
+	--sd-color-tabs-underline-hover: #ffd3a8;
+	--sd-color-tabs-overline: #ffd3a8;
+	--sd-color-tabs-underline: #ffd3a8;
+	--sd-color-card-header: rgba(0,0,0,0.03);
 }

--- a/doc/docportal/advanced_topics/autostart.rst
+++ b/doc/docportal/advanced_topics/autostart.rst
@@ -5,10 +5,9 @@ Autostart
 Use the autostart feature to automatically start or add games. The available features and the way they work depend on the system on which ScummVM is running.
 
 
-.. tabbed:: General
+.. tab-set::
 
-    .. panels::
-        :column: col-lg-12
+    .. tab-item:: General
 
         On most systems, such as Windows and Linux, ScummVM can detect and start a game located in the same folder as the ScummVM executable, as long as it is a game supported by ScummVM. It is the equivalent of using the ``--path`` and ``--auto-detect`` :doc:`command line options <../advanced_topics/command_line>`. This also works on macOS when ScummVM is built as a command line application and not as a .app bundle.
 
@@ -17,10 +16,7 @@ Use the autostart feature to automatically start or add games. The available fea
         - Rename the executable file to ``scummvm-auto.xxx``, where ``.xxx`` is the file type extension (if applicable).
         - Create an empty file named ``scummvm-autorun`` in the same folder as both the executable and the chosen game. Either leave the file empty, or use it to specify any further command line options. Specify one option per line.
 
-.. tabbed:: macOS
-
-    .. panels::
-        :column: col-lg-12
+    .. tab-item:: macOS
 
         The following information are only correct when ScummVM is built as a .app bundle. When ScummVM is built as a command line application it behaves as on Windows and Linux.
 
@@ -44,10 +40,7 @@ Use the autostart feature to automatically start or add games. The available fea
 
         Note that modifying a signed bundle will invalidate the signature. So the bundle needs to be signed again after for example adding a ``game`` folder inside the ScummVM.app bundle.
 
-.. tabbed:: iOS
-
-    .. panels::
-        :column: col-lg-12
+    .. tab-item:: iOS
 
         ScummVM can automatically detect and run a supported game included in the ScummVM.app bundle. The game files simply need to be in the ``ScummVM.app/game/`` folder.
 

--- a/doc/docportal/advanced_topics/command_line.rst
+++ b/doc/docportal/advanced_topics/command_line.rst
@@ -61,15 +61,13 @@ Use the ``game id`` or ``--auto-detect`` to start games with default settings fo
 
 The full ``game id`` contains both an engine name and a game name. For example, the game id for Full Throttle is ``scumm:ft``, where ``scumm`` is the engine name. In many cases where there is no ambiguity, you can omit the engine name when specifying a ``game id`` on the command line. For example, both ``scumm:ft`` and ``ft`` can be used. However, if there is an ambiguity with the game name, the full ``game id`` must be used. For example, for Indiana Jones and the Fate of Atlantis only ``scumm:atlantis`` can be used as there would otherwise be an ambiguity with ``cryomni3d:atlantis``.
 
+.. tab-set::
 
-.. tabbed:: Windows
+    .. tab-item:: Windows
 
-    .. panels::
-        :column: col-lg-12
+        .. card::
 
-        The following examples assume that the path to ScummVM is ``C:\Program Files\ScummVM\scummvm.exe``.
-
-        ^^^^
+            The following examples assume that the path to ScummVM is ``C:\Program Files\ScummVM\scummvm.exe``.
 
         To run Monkey Island, fullscreen (``-f``), if the game has already been added to ScummVM under the `target` name `monkey1`:
 
@@ -85,18 +83,15 @@ The full ``game id`` contains both an engine name and a game name. For example, 
 
             C:\Program Files\ScummVM\scummvm.exe -f -n -p "D:\resource" scumm:ft
 
-.. tabbed:: macOS
+    .. tab-item:: macOS
 
-    .. panels::
-        :column: col-lg-12
+        .. card::
 
-        The following examples assume the path to the ScummVM app is ``Applications/ScummVM.app``.
+            The following examples assume the path to the ScummVM app is ``Applications/ScummVM.app``.
 
         If you are unsure of the path to the app, drag the ScummVM app icon into the Terminal window. This prints the path to the ScummVM app.
 
         To run ScummVM from the command line, add ``/Contents/MacOS/scummvm`` to that path.
-
-        ^^^^
 
         To run Monkey Island, fullscreen (``-f``), if the game has already been added to ScummVM under the `target` name `monkey1`:
 
@@ -111,14 +106,11 @@ The full ``game id`` contains both an engine name and a game name. For example, 
 
             /Applications/ScummVM.app/Contents/MacOS/scummvm -f -n -p "/Volumes/Full Throttle/resource" scumm:ft
 
-.. tabbed:: Linux
+    .. tab-item:: Linux
 
-    .. panels::
-        :column: col-lg-12
+        .. card::
 
-        The following examples assume the path to ScummVM is ``/usr/games/scummvm``.
-
-        ^^^^^^
+            The following examples assume the path to ScummVM is ``/usr/games/scummvm``.
 
         To run Monkey Island, fullscreen (``-f``), if the game has already been added to ScummVM under the `target` name `monkey1`:
 

--- a/doc/docportal/advanced_topics/configuration_file.rst
+++ b/doc/docportal/advanced_topics/configuration_file.rst
@@ -12,45 +12,37 @@ Location
 
 The configuration file saves to different default locations, depending on the platform. The configuration file path is also displayed on the :doc:`../settings/paths` tab.
 
+.. tab-set::
 
-.. tabbed:: Windows
+    .. tab-item:: Windows
 
-	.. panels::
-		:column: col-lg-12 mb-2
+        ``%APPDATA%\ScummVM\scummvm.ini``
 
-		``%APPDATA%\ScummVM\scummvm.ini``
-
-		For Windows 95/98/ME, the file is at ``C:\WINDOWS\scummvm.ini``
+        For Windows 95/98/ME, the file is at ``C:\WINDOWS\scummvm.ini``
 
 
-.. tabbed:: macOS
+    .. tab-item:: macOS
 
-	.. panels::
-		:column: col-lg-12 mb-2
+        ``~/Library/Preferences/ScummVM Preferences``
 
-		``~/Library/Preferences/ScummVM Preferences``
+        .. note::
 
-		.. note::
+            If an earlier version of ScummVM was installed on your system, the configuration file remains in the previous default location of ``~/.scummvmrc``.
 
-			If an earlier version of ScummVM was installed on your system, the configuration file remains in the previous default location of ``~/.scummvmrc``.
+        .. tip::
 
-		.. tip::
-
-			To see the Library folder, press :kbd:`Option` when clicking **Go** in the Finder menu.
+            To see the Library folder, press :kbd:`Option` when clicking **Go** in the Finder menu.
 
 
-.. tabbed:: Linux
+    .. tab-item:: Linux
 
-	.. panels::
-		:column: col-lg-12 mb-2
+        ScummVM follows the XDG Base Directory Specification, so by default the configuration file is found at ``~/.config/scummvm/scummvm.ini``, but its location might vary depending on the value of the ``XDG_CONFIG_HOME`` environment variable.
 
-		ScummVM follows the XDG Base Directory Specification, so by default the configuration file is found at ``~/.config/scummvm/scummvm.ini``, but its location might vary depending on the value of the ``XDG_CONFIG_HOME`` environment variable.
+        If ScummVM was installed using Snap, the configuration file is found at ``~/snap/scummvm/current/.config/scummvm/scummvm.ini``
 
-		If ScummVM was installed using Snap, the configuration file is found at ``~/snap/scummvm/current/.config/scummvm/scummvm.ini``
+        .. note::
 
-		.. note::
-
-			``.config`` is a hidden directory. To view it use ``ls -a`` on the command line.
+            ``.config`` is a hidden directory. To view it use ``ls -a`` on the command line.
 
 
 
@@ -510,37 +502,26 @@ There are many recognized configuration keys. In the table below, each key is ei
 .. _screenshotpath:
 
 Screenshot path
-====================
-	The default location for the screenshotpath depends on your system.
+===============
+
+The default location for the screenshotpath depends on your system.
 
 
-	.. tabbed:: Windows
+.. tab-set::
 
-		.. panels::
-			:column: col-lg-12 mb-2
+    .. tab-item:: Windows
 
-			In ``%USERPROFILE%\Pictures\ScummVM Screenshots``
+        In ``%USERPROFILE%\Pictures\ScummVM Screenshots``
 
-	.. tabbed:: macOS
+    .. tab-item:: macOS
 
-		.. panels::
-			:column: col-lg-12 mb-2
-
-			On the Desktop.
+        On the Desktop.
 
 
-	.. tabbed:: Linux
+    .. tab-item:: Linux
 
-		.. panels::
-			:column: col-lg-12 mb-2
+        In the XDG Pictures user directory, for example ``~/Pictures/ScummVM Screenshots``
 
-			In the XDG Pictures user directory, for example ``~/Pictures/ScummVM Screenshots``
+    .. tab-item:: Any other OS
 
-	.. tabbed:: Any other OS
-
-		.. panels::
-			:column: col-lg-12 mb-2
-
-			In the current directory.
-
-
+        In the current directory.

--- a/doc/docportal/conf.py
+++ b/doc/docportal/conf.py
@@ -28,15 +28,12 @@ author = 'CadiH'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 
-import sphinx_rtd_theme
-
 extensions = [
 
     "sphinx_rtd_theme",
-    "sphinx_panels",
-    "sphinx_mdinclude"
+    "sphinx_design",
+    "sphinx_mdinclude",
 ]
-extensions.append('sphinx_tabs.tabs')
 souce_suffix = ['.rst','.md']
 
 # Add any paths that contain templates here, relative to this directory.
@@ -81,8 +78,6 @@ def setup(app):
 
 master_doc = 'index'
 html_sidebars = {'**': ['localtoc.html']}
-
-panels_add_fontawesome_latex = True
 
 #Options for LaTex Output
 

--- a/doc/docportal/help/report_bugs.rst
+++ b/doc/docportal/help/report_bugs.rst
@@ -27,25 +27,16 @@ The ScummVM log file
 
 To help you report a bug, you can find error messages in the ScummVM log file. The location of this file varies depending on your operating system.
 
+.. tab-set::
 
-.. tabbed:: Windows
+    .. tab-item:: Windows
 
-	.. panels::
-		:column: col-lg-12 mb-2
+        ``%APPDATA%\ScummVM\Logs\scummvm.log``
 
-		``%APPDATA%\ScummVM\Logs\scummvm.log``
+    .. tab-item:: macOS
 
-.. tabbed:: macOS
+        ``~/Library/Logs/scummvm.log``
 
-	.. panels::
-		:column: col-lg-12 mb-2
+    .. tab-item:: Linux
 
-		``~/Library/Logs/scummvm.log``
-
-.. tabbed:: Linux
-
-	.. panels::
-		:column: col-lg-12 mb-2
-
-		We use the XDG Base Directory Specification, so by default the file will be ``~/.cache/scummvm/logs/scummvm.log`` but its location might vary depending on the value of the ``XDG_CACHE_HOME`` environment variable.
-
+        We use the XDG Base Directory Specification, so by default the file will be ``~/.cache/scummvm/logs/scummvm.log`` but its location might vary depending on the value of the ``XDG_CACHE_HOME`` environment variable.

--- a/doc/docportal/index.rst
+++ b/doc/docportal/index.rst
@@ -41,11 +41,6 @@
       settings/lan
       settings/misc
       settings/paths
-      
-      
-      
-    
-
 
 .. toctree::
       :caption: Advanced topics
@@ -58,7 +53,6 @@
       advanced_topics/understand_audio
       advanced_topics/understand_graphics
       advanced_topics/understand_search_box
-      
 
 .. toctree::
       :caption: Help
@@ -93,95 +87,106 @@ Start here!
 
 We have a user manual section covering **THE BASICS**:
 
-.. panels::
-      :container: text-center mb-4
+.. grid:: 2
+    :class-container: sd-text-center
+    :gutter: 3
 
-      Installation
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      :doc:`Installing ScummVM on a computer <use_scummvm/install_computer>`
+    .. grid-item-card::
 
-      :doc:`use_scummvm/the_launcher`
+        Installation
+        ^^^^^^^^^^^^
 
-      ---
+        :doc:`Installing ScummVM on a computer <use_scummvm/install_computer>`
 
-      Playing games
-      ^^^^^^^^^^^^^^^
-      :doc:`use_scummvm/game_files`
+        :doc:`use_scummvm/the_launcher`
 
-      :doc:`use_scummvm/mac_game_files`
+    .. grid-item-card::
 
-      :doc:`use_scummvm/add_play_games`
+        Playing games
+        ^^^^^^^^^^^^^
 
-      :doc:`use_scummvm/save_load_games`
+        :doc:`use_scummvm/game_files`
 
-      ---
+        :doc:`use_scummvm/mac_game_files`
 
+        :doc:`use_scummvm/add_play_games`
 
-      Controls and settings
-      ^^^^^^^^^^^^^^^^^^^^^^^
-      :doc:`use_scummvm/keyboard_shortcuts`
+        :doc:`use_scummvm/save_load_games`
 
-      :doc:`use_scummvm/how_to_settings`
+    .. grid-item-card::
 
-      ---
+        Controls and settings
+        ^^^^^^^^^^^^^^^^^^^^^
 
-      Useful features
-      ^^^^^^^^^^^^^^^^
+        :doc:`use_scummvm/keyboard_shortcuts`
 
-      :doc:`use_scummvm/connect_cloud`
+        :doc:`use_scummvm/how_to_settings`
 
-      :doc:`use_scummvm/LAN`
+    .. grid-item-card::
+
+        Useful features
+        ^^^^^^^^^^^^^^^
+
+        :doc:`use_scummvm/connect_cloud`
+
+        :doc:`use_scummvm/LAN`
 
 .. _platformspecific:
 
 We also have guides on how to get ScummVM running on a wide range of other platforms:
 
 
-.. panels::
-      :container: text-center mb-4
+.. grid:: 2
+    :class-container: sd-text-center
+    :gutter: 3
 
-      Handheld consoles
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      :doc:`other_platforms/nintendo_3ds`
+    .. grid-item-card::
 
-      :doc:`other_platforms/nintendo_ds`
+        Handheld consoles
+        ^^^^^^^^^^^^^^^^^
 
-      :doc:`other_platforms/nintendo_switch`
+        :doc:`other_platforms/nintendo_3ds`
 
-      :doc:`other_platforms/playstation_portable`
+        :doc:`other_platforms/nintendo_ds`
 
-      :doc:`other_platforms/playstation_vita`
+        :doc:`other_platforms/nintendo_switch`
 
-      ---
+        :doc:`other_platforms/playstation_portable`
 
-      Other consoles
-      ^^^^^^^^^^^^^^^^
+        :doc:`other_platforms/playstation_vita`
 
-      :doc:`other_platforms/playstation_3`
+    .. grid-item-card::
 
-      :doc:`other_platforms/sega_dreamcast`
+        Other consoles
+        ^^^^^^^^^^^^^^
 
-      ---
+        :doc:`other_platforms/playstation_3`
 
-      Phones and tablets
-      ^^^^^^^^^^^^^^^
-      :doc:`other_platforms/ios`
+        :doc:`other_platforms/sega_dreamcast`
 
-      :doc:`other_platforms/tvos`
+    .. grid-item-card::
 
-      :doc:`other_platforms/android`
+        Phones and tablets
+        ^^^^^^^^^^^^^^^^^^
 
-      ---
+        :doc:`other_platforms/ios`
 
-      Other operating systems
-      ^^^^^^^^^^^^^^^^^^^^^^^
-      :doc:`other_platforms/amigaos_4`
+        :doc:`other_platforms/tvos`
 
-      :doc:`other_platforms/atari`
+        :doc:`other_platforms/android`
 
-      :doc:`other_platforms/morphos`
+    .. grid-item-card::
 
-      :doc:`other_platforms/risc_os`
+        Other operating systems
+        ^^^^^^^^^^^^^^^^^^^^^^^
+
+        :doc:`other_platforms/amigaos_4`
+
+        :doc:`other_platforms/atari`
+
+        :doc:`other_platforms/morphos`
+
+        :doc:`other_platforms/risc_os`
 
 
 
@@ -197,28 +202,31 @@ For our more experienced users, ScummVM features a command line interface, as we
 In this section, we also take a deep dive into understanding the graphics and audio settings.
 
 
-.. panels::
-      :container: text-center mb-4
+.. grid:: 2
+    :class-container: sd-text-center
+    :gutter: 3
 
-      Advanced features
-      ^^^^^^^^^^^^^^^^^^^^
-      
-      :doc:`advanced_topics/autostart`
-      
-      :doc:`advanced_topics/configuration_file`
+    .. grid-item-card::
 
-      :doc:`advanced_topics/command_line`
+        Advanced features
+        ^^^^^^^^^^^^^^^^^
 
-      ---
+        :doc:`advanced_topics/autostart`
 
-      Understanding the settings
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        :doc:`advanced_topics/configuration_file`
 
-      :doc:`The audio settings <advanced_topics/understand_audio>`
+        :doc:`advanced_topics/command_line`
 
-      :doc:`The graphics settings <advanced_topics/understand_graphics>`
+    .. grid-item-card::
 
-      :doc:`The search box <advanced_topics/understand_search_box>`
+        Understanding the settings
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+        :doc:`The audio settings <advanced_topics/understand_audio>`
+
+        :doc:`The graphics settings <advanced_topics/understand_graphics>`
+
+        :doc:`The search box <advanced_topics/understand_search_box>`
 
 
 
@@ -229,9 +237,10 @@ ScummVM is still under development. While we do our best to make sure that as ma
 
 If you are having problems with any aspect of ScummVM, take a look at our help section.
 
-.. panels::
-      :container: text-center mb-4
-      :column: col-lg-12
+.. grid:: 1
+    :class-container: sd-text-center
+
+    .. grid-item-card::
 
       :doc:`help/faq`
 

--- a/doc/docportal/index.rst
+++ b/doc/docportal/index.rst
@@ -87,7 +87,7 @@ Start here!
 
 We have a user manual section covering **THE BASICS**:
 
-.. grid:: 2
+.. grid:: 1 1 2 2
     :class-container: sd-text-center
     :gutter: 3
 
@@ -136,7 +136,7 @@ We have a user manual section covering **THE BASICS**:
 We also have guides on how to get ScummVM running on a wide range of other platforms:
 
 
-.. grid:: 2
+.. grid:: 1 1 2 2
     :class-container: sd-text-center
     :gutter: 3
 
@@ -202,7 +202,7 @@ For our more experienced users, ScummVM features a command line interface, as we
 In this section, we also take a deep dive into understanding the graphics and audio settings.
 
 
-.. grid:: 2
+.. grid:: 1 1 2 2
     :class-container: sd-text-center
     :gutter: 3
 

--- a/doc/docportal/requirements.txt
+++ b/doc/docportal/requirements.txt
@@ -1,13 +1,4 @@
-sphinx-tabs==3.3.1
-sphinx-panels==0.6.0
-sphinx<5
-docutils==0.17
-sphinx_rtd_theme==1.0.0
-sphinx-mdinclude==0.5.3
-
-# Dependencies of sphinx<5
-sphinxcontrib_applehelp==1.0.4
-sphinxcontrib_devhelp==1.0.2
-sphinxcontrib_htmlhelp==2.0.1
-sphinxcontrib_serializinghtml==1.1.5
-sphinxcontrib_qthelp==1.0.3
+sphinx~=7.2
+sphinx-design~=0.5
+sphinx_rtd_theme~=2.0
+sphinx-mdinclude~=0.5

--- a/doc/docportal/settings/keymaps.rst
+++ b/doc/docportal/settings/keymaps.rst
@@ -53,7 +53,7 @@ Global
 Global Main Menu
 	*keymap_global_MENU*
 
-.. _mute:
+.. _keymap_mute:
 
 Toggle mute
 	*keymap_global_MUTE*
@@ -63,7 +63,7 @@ Toggle mute
 Quit
 	*keymap_global_QUIT*
 
-.. _debug:
+.. _keymap_debug:
 
 Open Debugger
 	*keymap_global_DEBUGGER*

--- a/doc/docportal/use_scummvm/install_computer.rst
+++ b/doc/docportal/use_scummvm/install_computer.rst
@@ -5,107 +5,109 @@ Installing ScummVM
 
 This page explains how to install ScummVM on a computer. For all other platforms, see the relevant :ref:`platform guide <platformspecific>`.
 
-.. tabbed:: Windows
+.. tab-set::
 
-    There are two ways to install ScummVM on Windows: use the installer, or install manually.
+    .. tab-item:: Windows
 
-    .. dropdown:: Installing ScummVM using the installer
-        :open:
+        There are two ways to install ScummVM on Windows: use the installer, or install manually.
 
-        Download the Windows installer for your operating system from the `ScummVM downloads page <https://www.scummvm.org/downloads/>`_, and double click the downloaded file. The installer guides you through the install process, and adds a shortcut to the Start Menu. There is also an option to add a shortcut to the desktop.
+        .. dropdown:: Installing ScummVM using the installer
+            :open:
 
-        To run ScummVM, either navigate to desktop and double click the ScummVM shortcut, or go to **Start > All Apps > ScummVM**. For Windows XP, go to **Start > All Apps > ScummVM**.
+            Download the Windows installer for your operating system from the `ScummVM downloads page <https://www.scummvm.org/downloads/>`_, and double click the downloaded file. The installer guides you through the install process, and adds a shortcut to the Start Menu. There is also an option to add a shortcut to the desktop.
 
-    .. dropdown:: Installing ScummVM manually
+            To run ScummVM, either navigate to desktop and double click the ScummVM shortcut, or go to **Start > All Apps > ScummVM**. For Windows XP, go to **Start > All Apps > ScummVM**.
 
-        Download the Windows zip file for your operating system (32bit or 64bit). To extract the files, right-click the folder and select **Extract All**.
+        .. dropdown:: Installing ScummVM manually
 
-        To run ScummVM from the extracted folder, find the ``scummvm.exe`` file and double click it.
+            Download the Windows zip file for your operating system (32bit or 64bit). To extract the files, right-click the folder and select **Extract All**.
 
-    .. dropdown:: Running ScummVM in portable mode
+            To run ScummVM from the extracted folder, find the ``scummvm.exe`` file and double click it.
 
-        Starting with ScummVM 2.6.0, ScummVM offers a portable mode. Instead of storing saved games, icons and screenshots in your user's directory, they are stored in the same folder as the ScummVM executable.
+        .. dropdown:: Running ScummVM in portable mode
 
-        To run ScummVM in portable mode, create an empty file called ``scummvm.ini`` in the folder where you extracted the ScummVM zipfile.
+            Starting with ScummVM 2.6.0, ScummVM offers a portable mode. Instead of storing saved games, icons and screenshots in your user's directory, they are stored in the same folder as the ScummVM executable.
 
-.. tabbed:: macOS
+            To run ScummVM in portable mode, create an empty file called ``scummvm.ini`` in the folder where you extracted the ScummVM zipfile.
 
-    .. dropdown:: Installing ScummVM using the disk image
-        :open:
+    .. tab-item:: macOS
 
-        Download the recommended disk image file from the `ScummVM downloads page <https://www.scummvm.org/downloads/>`_. After the download has completed, double click the file to mount the disk image file. A window containing the ScummVM icon opens. Drag this icon into your Applications folder to install ScummVM.
+        .. dropdown:: Installing ScummVM using the disk image
+            :open:
 
-        To run ScummVM, click on the icon in the Applications folder.
+            Download the recommended disk image file from the `ScummVM downloads page <https://www.scummvm.org/downloads/>`_. After the download has completed, double click the file to mount the disk image file. A window containing the ScummVM icon opens. Drag this icon into your Applications folder to install ScummVM.
 
-        .. note::
+            To run ScummVM, click on the icon in the Applications folder.
 
-            macOS includes technology called Gatekeeper, which checks to ensure only trusted software is run on your Mac. ScummVM is not available from the App Store, so follow the steps on this `Apple support page <https://support.apple.com/en-us/HT202491>`_ to allow ScummVM to run.
+            .. note::
 
-.. tabbed:: Linux
+                macOS includes technology called Gatekeeper, which checks to ensure only trusted software is run on your Mac. ScummVM is not available from the App Store, so follow the steps on this `Apple support page <https://support.apple.com/en-us/HT202491>`_ to allow ScummVM to run.
 
-
-   There are multiple ways to install ScummVM on Linux: use the Snap Store, Flathub or the software repository, or manually install the release binary.
-
-    .. dropdown::  Installing ScummVM using the Snap Store
-        :open:
-
-        A Snap is an app that is bundled with its dependencies, which makes the install on any Linux operating system very easy. Snap comes pre-installed on Debian and Ubuntu-based distributions, but can be installed on any Linux distribution by following the instructions on the `Snapcraft website <https://snapcraft.io/>`_.
-
-        The ScummVM Snap comes with a selection of freeware games and demos pre-loaded.
-
-        Enter the following on the command line to install the ScummVM Snap:
-
-        .. code:: bash
-
-            sudo snap install scummvm
-
-        To run ScummVM, enter ``scummvm`` on the command line, or launch ScummVM through the desktop interface by clicking **Menu > Games > ScummVM**.
-
-    .. dropdown:: Installing ScummVM using Flathub
-
-        Flathub is another way to install apps for Linux, by using Flatpak. Flatpak comes standard with Fedora-based distributions, but can be installed on any Linux operating system.  The `Flathub website <https://flatpak.org/setup/>`_ has excellent install instructions.
-
-        When Flatpak is installed, enter the following on the command line to install ScummVM:
-
-        .. code:: bash
-
-            flatpak install flathub org.scummvm.ScummVM
-
-        Some distributions have the option to install Flatpaks through the graphical desktop interface. Navigate to the `ScummVM Flatpak page <https://flathub.org/apps/details/org.scummvm.ScummVM>`_ , click the **INSTALL** button and then follow the install process.
-
-        To run ScummVM, enter the following on the command line:
-
-        .. code:: bash
-
-            flatpak run org.scummvm.ScummVM
-
-        To pass :doc:`Command line arguments <../advanced_topics/command_line>`, add them after the Flatpak ``run`` command.
-
-        .. note::
-
-            The Flatpak version of ScummVM is sandboxed, meaning that any games need to be copied into the Documents folder to be accessible by ScummVM.
+    .. tab-item:: Linux
 
 
-    .. dropdown:: Installing ScummVM using the software repository
+        There are multiple ways to install ScummVM on Linux: use the Snap Store, Flathub or the software repository, or manually install the release binary.
 
-        ScummVM is found in the software repositories of many Linux distributions.
+        .. dropdown::  Installing ScummVM using the Snap Store
+            :open:
 
-        .. caution::
+            A Snap is an app that is bundled with its dependencies, which makes the install on any Linux operating system very easy. Snap comes pre-installed on Debian and Ubuntu-based distributions, but can be installed on any Linux distribution by following the instructions on the `Snapcraft website <https://snapcraft.io/>`_.
 
-            The repositories might not contain the most up-to-date version of ScummVM.
+            The ScummVM Snap comes with a selection of freeware games and demos pre-loaded.
 
-        To run ScummVM, enter ``scummvm`` on the command line, or launch ScummVM through the desktop interface by clicking **Menu > Games > ScummVM**.
+            Enter the following on the command line to install the ScummVM Snap:
+
+            .. code:: bash
+
+                sudo snap install scummvm
+
+            To run ScummVM, enter ``scummvm`` on the command line, or launch ScummVM through the desktop interface by clicking **Menu > Games > ScummVM**.
+
+        .. dropdown:: Installing ScummVM using Flathub
+
+            Flathub is another way to install apps for Linux, by using Flatpak. Flatpak comes standard with Fedora-based distributions, but can be installed on any Linux operating system.  The `Flathub website <https://flatpak.org/setup/>`_ has excellent install instructions.
+
+            When Flatpak is installed, enter the following on the command line to install ScummVM:
+
+            .. code:: bash
+
+                flatpak install flathub org.scummvm.ScummVM
+
+            Some distributions have the option to install Flatpaks through the graphical desktop interface. Navigate to the `ScummVM Flatpak page <https://flathub.org/apps/details/org.scummvm.ScummVM>`_ , click the **INSTALL** button and then follow the install process.
+
+            To run ScummVM, enter the following on the command line:
+
+            .. code:: bash
+
+                flatpak run org.scummvm.ScummVM
+
+            To pass :doc:`Command line arguments <../advanced_topics/command_line>`, add them after the Flatpak ``run`` command.
+
+            .. note::
+
+                The Flatpak version of ScummVM is sandboxed, meaning that any games need to be copied into the Documents folder to be accessible by ScummVM.
 
 
-    .. dropdown:: Installing ScummVM using the release binaries
+        .. dropdown:: Installing ScummVM using the software repository
 
-        Binary packages are only released for Debian and Ubuntu. On the `ScummVM downloads page <https://www.scummvm.org/downloads/>`_, find and download the ScummVM package that corresponds to your operating system and architecture. To install a DEB package, either double click on the downloaded DEB file to use the graphical installer, or, if that's not available, use the command line.
+            ScummVM is found in the software repositories of many Linux distributions.
 
-        .. code:: bash
+            .. caution::
 
-            sudo apt install /path/to/downloaded/file.deb
+                The repositories might not contain the most up-to-date version of ScummVM.
 
-        Replace ``/path/to/downloaded/file.deb`` with the actual path to the downloaded DEB package. The APT software manager handles the installation.
+            To run ScummVM, enter ``scummvm`` on the command line, or launch ScummVM through the desktop interface by clicking **Menu > Games > ScummVM**.
 
-        To run ScummVM, enter ``scummvm`` on the command line, or launch ScummVM through the desktop interface by clicking **Menu > Games > ScummVM**.
+
+        .. dropdown:: Installing ScummVM using the release binaries
+
+            Binary packages are only released for Debian and Ubuntu. On the `ScummVM downloads page <https://www.scummvm.org/downloads/>`_, find and download the ScummVM package that corresponds to your operating system and architecture. To install a DEB package, either double click on the downloaded DEB file to use the graphical installer, or, if that's not available, use the command line.
+
+            .. code:: bash
+
+                sudo apt install /path/to/downloaded/file.deb
+
+            Replace ``/path/to/downloaded/file.deb`` with the actual path to the downloaded DEB package. The APT software manager handles the installation.
+
+            To run ScummVM, enter ``scummvm`` on the command line, or launch ScummVM through the desktop interface by clicking **Menu > Games > ScummVM**.
 

--- a/doc/docportal/use_scummvm/mac_game_files.rst
+++ b/doc/docportal/use_scummvm/mac_game_files.rst
@@ -58,17 +58,13 @@ Creating the ISO image
 
     If you are accessing HFS+ media in macOS, or HFS media on a macOS 10.14 Mojave system or older, this step is not required when using the Python dumper in MAC mode.
 
-.. tabbed:: Windows
+.. tab-set::
 
-    .. panels::
-        :column: col-lg-12
+    .. tab-item:: Windows
 
         Use an application such as `IsoBuster <https://www.isobuster.com>`_ to create an ISO image of the CD.
 
-.. tabbed:: macOS
-
-    .. panels::
-        :column: col-lg-12
+    .. tab-item:: macOS
 
         Use the following commands in the Terminal to find the identifier of the media, and then create an ISO image of that media.
 
@@ -139,10 +135,7 @@ Creating the ISO image
                 681574400 bytes transferred in 396.380454 secs (1719495 bytes/sec)
                 iMac:~ ego$ drutil tray eject
 
-.. tabbed:: Linux
-
-    .. panels::
-        :column: col-lg-12
+    .. tab-item:: Linux
 
         Use the following commands to create an ISO image from an inserted HFS or HFS+ medium.
 
@@ -204,19 +197,15 @@ Installation
 *************
 Install machfs, and xattr if using macOS:
 
-.. tabbed:: macOS
+.. tab-set::
 
-    .. panels::
-        :column: col-lg-12
+    .. tab-item:: macOS
 
         .. code-block::
 
             pip3 install machfs xattr
 
-.. tabbed:: Others
-
-    .. panels::
-        :column: col-lg-12
+    .. tab-item:: Others
 
         .. code-block::
 
@@ -286,19 +275,15 @@ Other methods
 
 There are other ways to access HFS and HFS+ media on Windows, macOS, and Linux. These methods require you to copy the files manually.
 
-.. tabbed:: Windows
+.. tab-set::
 
-    .. panels::
-        :column: col-lg-12
+    .. tab-item:: Windows
 
         For Windows, `HFS Explorer <http://www.catacombae.org/hfsexplorer/>`_  is a basic and free option, which gives you read-only access to both HFS and HFS+ drives. Use the installer rather than the zip file, to ensure it is installed correctly. For files with a resource fork you will need to use the option to extract as MacBinary. Extract files that only have a data fork as a "raw copy, data fork".
 
         Alternatively, `HFVExplorer <https://www.emaculation.com/doku.php/hfvexplorer>`_ can also be used for HFS drives. There is no option to extract as MacBinary, but you can extract files with a resource fork as AppleDouble using the "extract data and resource fork(s)" option.
 
-.. tabbed:: macOS
-
-    .. panels::
-        :column: col-lg-12
+    .. tab-item:: macOS
 
         On macOS you can read HFS+ volumes, and in some cases HFS volumes, and copy the files in the usual way in the Finder. Some discs shipped with hidden files that need to be copied. To view hidden files in macOS, press :kbd:`Cmd+Shift+.` in a Finder window.
 
@@ -314,11 +299,7 @@ There are other ways to access HFS and HFS+ media on Windows, macOS, and Linux. 
            * If files contain invalid characters.
            * If you plan to transfer those files to a different system.
 
-.. tabbed:: Linux
-
-    .. panels::
-        :column: col-lg-12
-
+    .. tab-item:: Linux
 
         Access HFS+ drives using ``hfsplus``. To use hfsplus, use the command line:
 

--- a/doc/docportal/use_scummvm/save_load_games.rst
+++ b/doc/docportal/use_scummvm/save_load_games.rst
@@ -49,33 +49,25 @@ The save directory can be changed with the savepath setting in the :doc:`Paths t
 
 Default saved game paths are shown below.
 
-.. tabbed:: Windows
+.. tab-set::
 
-	.. panels::
-		:column: col-lg-12 mb-2
+    .. tab-item:: Windows
 
-		``%APPDATA%\ScummVM\Saved games``
-
-
-.. tabbed:: macOS
-
-	.. panels::
-		:column: col-lg-12 mb-2
-
-		``~/Documents/ScummVM Savegames/``
+        ``%APPDATA%\ScummVM\Saved games``
 
 
-.. tabbed:: Linux/Unix
+    .. tab-item:: macOS
 
-	.. panels::
-		:column: col-lg-12 mb-2
+        ``~/Documents/ScummVM Savegames/``
 
 
-		ScummVM follows the XDG Base Directory Specification, so by default the saved games can be found at ``~/.local/share/scummvm/saves/``, but this location might vary depending on the value of the ``XDG_DATA_HOME`` environment variable.
+    .. tab-item:: Linux/Unix
 
-		``.local`` is a hidden directory. To view it use ``ls -a`` on the command line.
+        ScummVM follows the XDG Base Directory Specification, so by default the saved games can be found at ``~/.local/share/scummvm/saves/``, but this location might vary depending on the value of the ``XDG_DATA_HOME`` environment variable.
 
-		If ScummVM was installed using Snap, the saves can be found at ``~/snap/scummvm/current/.local/share/scummvm/saves/``
+        ``.local`` is a hidden directory. To view it use ``ls -a`` on the command line.
+
+        If ScummVM was installed using Snap, the saves can be found at ``~/snap/scummvm/current/.local/share/scummvm/saves/``
 
 
 


### PR DESCRIPTION
- Only enforce major versions and not specific versions of packages
- Replace obsolete sphinx_panels extension by sphinx_design which is
  maintained
- Remove useless sphinx_tabs.tabs (tabs from sphinx_panels were used)
- Only enforce Python 3 instead of setting the minor version

This also fixes the documentation build and remove warnings.