### PR TITLE
GOB: Get game types from game IDs

### DIFF
--- a/engines/gob/detection/detection.cpp
+++ b/engines/gob/detection/detection.cpp
@@ -93,7 +93,7 @@ ADDetectedGame GobMetaEngineDetection::fallbackDetect(const FileMap &allFiles, c
 
 	const Gob::GOBGameDescription *game = (const Gob::GOBGameDescription *)detectedGame.desc;
 
-	if (game->gameType == Gob::kGameTypeOnceUponATime) {
+	if (!strcmp(game->desc.gameId, "onceupon")) {
 		game = detectOnceUponATime(fslist);
 		if (game) {
 			detectedGame.desc = &game->desc;

--- a/engines/gob/detection/detection.h
+++ b/engines/gob/detection/detection.h
@@ -85,7 +85,6 @@ enum AdditionalGameFlags {
 struct GOBGameDescription {
 	ADGameDescription desc;
 
-	GameType gameType;
 	int32 features;
 	const char *startStkBase;
 	const char *startTotBase;

--- a/engines/gob/detection/tables.h
+++ b/engines/gob/detection/tables.h
@@ -109,7 +109,7 @@ static const GOBGameDescription gameDescriptions[] = {
 	#include "gob/detection/tables_adiboudchou.h"		// Adiboud'chou / Addy Buschu series
 	#include "gob/detection/tables_crousti.h"   // Croustibat
 
-	{ AD_TABLE_END_MARKER, kGameTypeNone, kFeaturesNone, 0, 0, 0}
+	{ AD_TABLE_END_MARKER, kFeaturesNone, 0, 0, 0}
 };
 
 // File-based fallback tables

--- a/engines/gob/detection/tables_adi2.h
+++ b/engines/gob/detection/tables_adi2.h
@@ -42,7 +42,6 @@
 		ADGF_UNSTABLE,
 		GUIO0()
 	},
-	kGameTypeAdi2,
 	kFeaturesNone,
 	"adi2.stk", "ediintro.tot", 0
 },
@@ -56,7 +55,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi2,
 	kFeatures640x400,
 	"adi2.stk", "ediintro.tot", 0
 },
@@ -70,7 +68,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi2,
 	kFeatures640x400,
 	"adi2.stk", "ediintro.tot", 0
 },
@@ -84,7 +81,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi2,
 	kFeatures640x400,
 	"adi2.stk", "ediintro.tot", 0
 },
@@ -98,7 +94,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi2,
 	kFeatures640x400,
 	"adi2.stk", "ediintro.tot", 0
 },
@@ -112,7 +107,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi2,
 	kFeatures640x400,
 	"adi2.stk", "ediintro.tot", 0
 },
@@ -129,7 +123,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi2,
 	kFeatures640x400,
 	"adi2.stk", "ediintro.tot", 0
 },
@@ -143,7 +136,6 @@
 		ADGF_UNSTABLE | ADGF_CD,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi2,
 	kFeatures640x400,
 	"adi2.stk", "ediintro.tot", 0
 },
@@ -157,7 +149,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi2,
 	kFeatures640x400,
 	"adi2.stk", "ediintro.tot", 0
 },
@@ -174,7 +165,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi2,
 	kFeatures640x400,
 	"adi2.stk", "ediintro.tot", 0
 },
@@ -191,7 +181,6 @@
 		ADGF_UNSTABLE,
 		GUIO0()
 	},
-	kGameTypeAdi2,
 	kFeaturesNone,
 	"adi2.stk", "ediintro.tot", 0
 },
@@ -211,7 +200,6 @@
 		ADGF_DEMO,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeAdi2,
 	kFeatures640x480 | kFeaturesSCNDemo,
 	0, 0, 1
 },
@@ -228,7 +216,6 @@
 		ADGF_DEMO,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeAdi2,
 	kFeatures640x480 | kFeaturesSCNDemo,
 	0, 0, 1
 },
@@ -244,7 +231,6 @@
 	  	ADGF_DEMO,
 	  	GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeAdi2,
 	kFeatures640x480 | kFeaturesSCNDemo,
 	0, 0, 1
 },

--- a/engines/gob/detection/tables_adi4.h
+++ b/engines/gob/detection/tables_adi4.h
@@ -42,7 +42,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi4,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -56,7 +55,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi4,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -70,7 +68,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi4,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -84,7 +81,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi4,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -98,7 +94,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi4,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -112,7 +107,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi4,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -126,7 +120,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi4,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -143,7 +136,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi4,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -157,7 +149,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi4,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -171,7 +162,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi4,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -188,7 +178,6 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi4,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -205,7 +194,6 @@
 		ADGF_DEMO | ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi4,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -219,7 +207,6 @@
 		ADGF_DEMO | ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeAdi4,
 	kFeatures640x480,
 	0, 0, 0
 },

--- a/engines/gob/detection/tables_adi5.h
+++ b/engines/gob/detection/tables_adi5.h
@@ -43,7 +43,6 @@
 		ADGF_UNSUPPORTED,
 		GUIO0()
 	},
-	kGameTypeNone,
 	kFeatures640x480,
 	0,0,0
 },
@@ -59,7 +58,6 @@
 		ADGF_UNSUPPORTED,
 		GUIO0()
 	},
-	kGameTypeNone,
 	kFeatures640x480,
 	0,0,0
 },
@@ -77,7 +75,6 @@
 		ADGF_UNSUPPORTED,
 		GUIO0()
 	},
-	kGameTypeNone,
 	kFeatures640x480,
 	0,0,0
 },

--- a/engines/gob/detection/tables_adibou1.h
+++ b/engines/gob/detection/tables_adibou1.h
@@ -42,7 +42,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAdibou1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -57,7 +56,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAdibou1,
 	kFeaturesAdLib | kFeatures16Colors,
 	0, "base.tot", 0
 },
@@ -72,7 +70,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAdibou1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -90,7 +87,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAdibou1,
 	kFeaturesAdLib | kFeatures640x400,
 	0, 0, 0
 },
@@ -105,7 +101,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	 kGameTypeAdibou1,
 	 kFeaturesAdLib | kFeatures640x400,
 	 0, 0, 0
 },
@@ -122,7 +117,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAdibou1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -138,7 +132,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAdibou1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -156,7 +149,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAdibou1,
 	kFeaturesNone,
 	0, 0, 0
 },

--- a/engines/gob/detection/tables_adibou2.h
+++ b/engines/gob/detection/tables_adibou2.h
@@ -42,7 +42,6 @@
 		ADGF_NO_FLAGS,
 		GUIO0()
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -56,7 +55,6 @@
 		ADGF_NO_FLAGS,
 		GUIO0()
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -70,7 +68,6 @@
 		ADGF_NO_FLAGS,
 		GUIO0()
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -85,7 +82,6 @@
 		GF_ENABLE_ADIBOU2_FREE_BANANAS_WORKAROUND | GF_ENABLE_ADIBOU2_FLOWERS_INFINITE_LOOP_WORKAROUND,
 		GUIO0()
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -100,7 +96,6 @@
 		GF_ENABLE_ADIBOU2_FREE_BANANAS_WORKAROUND | GF_ENABLE_ADIBOU2_FLOWERS_INFINITE_LOOP_WORKAROUND,
 		GUIO0()
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -115,7 +110,6 @@
 		GF_ENABLE_ADIBOU2_FREE_BANANAS_WORKAROUND | GF_ENABLE_ADIBOU2_FLOWERS_INFINITE_LOOP_WORKAROUND,
 		GUIO0()
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -130,7 +124,6 @@
 		GF_ENABLE_ADIBOU2_FREE_BANANAS_WORKAROUND | GF_ENABLE_ADIBOU2_FLOWERS_INFINITE_LOOP_WORKAROUND,
 		GUIO0()
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -144,7 +137,6 @@
 		ADGF_NO_FLAGS,
 		GUIO0()
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -162,7 +154,6 @@
 		ADGF_NO_FLAGS,
 		GUIO0()
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -177,7 +168,6 @@
 		ADGF_NO_FLAGS,
 		GUIO0()
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -193,7 +183,6 @@
 		GF_ENABLE_ADIBOU2_FLOWERS_INFINITE_LOOP_WORKAROUND,
 		GUIO0()
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -209,7 +198,6 @@
 		ADGF_NO_FLAGS,
 		GUIO0()
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -226,7 +214,6 @@
 		ADGF_NO_FLAGS,
 		GUIO0()
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -242,7 +229,6 @@
 		GF_ENABLE_ADIBOU2_FLOWERS_INFINITE_LOOP_WORKAROUND,
 		GUIO0()
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -259,7 +245,6 @@
 		GF_ENABLE_ADIBOU2_FLOWERS_INFINITE_LOOP_WORKAROUND,
 		GUIO0()
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -276,7 +261,6 @@
 		ADGF_DEMO,
 		GUIO0()
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -291,7 +275,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -306,7 +289,6 @@
 		ADGF_DEMO,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480 | kFeaturesSCNDemo,
 	0, 0, 9
 },
@@ -321,7 +303,6 @@
 		ADGF_DEMO,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480 | kFeaturesSCNDemo,
 	0, 0, 10
 },
@@ -336,7 +317,6 @@
 		ADGF_DEMO,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480 | kFeaturesSCNDemo,
 	0, 0, 11
 },
@@ -352,7 +332,6 @@
 		ADGF_UNSTABLE,
 		GUIO0()
 	},
-	kGameTypeAdibou2,
 	kFeatures640x480,
 	0, 0, 0
 },

--- a/engines/gob/detection/tables_adibou3.h
+++ b/engines/gob/detection/tables_adibou3.h
@@ -42,7 +42,6 @@
 		ADGF_UNSUPPORTED,
 		GUIO0()
 	},
-	kGameTypeNone,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -57,7 +56,6 @@
 		ADGF_UNSUPPORTED,
 		GUIO0()
 	},
-	kGameTypeNone,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -75,7 +73,6 @@
 		ADGF_UNSUPPORTED,
 		GUIO0()
 	},
-	kGameTypeNone,
 	kFeatures640x480,
 	0,0,0
 },
@@ -91,7 +88,6 @@
 		ADGF_UNSUPPORTED,
 		GUIO0()
 	},
-	kGameTypeNone,
 	kFeatures640x480,
 	0,0,0
 },
@@ -107,7 +103,6 @@
 		ADGF_UNSUPPORTED | ADGF_DEMO,
 		GUIO0()
 	},
-	kGameTypeNone,
 	kFeatures640x480,
 	0,0,0
 },
@@ -123,7 +118,6 @@
 		ADGF_UNSUPPORTED,
 		GUIO0()
 	},
-	kGameTypeNone,
 	kFeatures640x480,
 	0,0,0
 },

--- a/engines/gob/detection/tables_adiboudchou.h
+++ b/engines/gob/detection/tables_adiboudchou.h
@@ -44,7 +44,6 @@
 		ADGF_UNSUPPORTED,
 		GUIO0()
 	},
-	kGameTypeNone,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -60,7 +59,6 @@
 		ADGF_UNSUPPORTED,
 		GUIO0()
 	},
-	kGameTypeNone,
 	kFeatures640x480,
 	0,0,0
 },
@@ -74,7 +72,6 @@
 		ADGF_UNSUPPORTED,
 		GUIO0()
 	},
-	kGameTypeNone,
 	kFeatures640x480,
 	0,0,0
 },
@@ -88,7 +85,6 @@
 		ADGF_UNSUPPORTED,
 		GUIO0()
 	},
-	kGameTypeNone,
 	kFeatures640x480,
 	0,0,0
 },

--- a/engines/gob/detection/tables_adiboupresente.h
+++ b/engines/gob/detection/tables_adiboupresente.h
@@ -42,7 +42,6 @@
 		ADGF_UNSUPPORTED,
 		GUIO0()
 	},
-	kGameTypeNone,
 	kFeatures640x480,
 	0, 0, 0
 },

--- a/engines/gob/detection/tables_bargon.h
+++ b/engines/gob/detection/tables_bargon.h
@@ -42,7 +42,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBargon,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -56,7 +55,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBargon,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -70,7 +68,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBargon,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -84,7 +81,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBargon,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -98,7 +94,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBargon,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -112,7 +107,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBargon,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -129,7 +123,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBargon,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -146,7 +139,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBargon,
 	kFeaturesNone,
 	0, 0, 0
 },

--- a/engines/gob/detection/tables_crousti.h
+++ b/engines/gob/detection/tables_crousti.h
@@ -42,7 +42,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeCrousti,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -56,7 +55,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeCrousti,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -70,7 +68,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeCrousti,
 	kFeaturesAdLib,
 	0, 0, 0
 },

--- a/engines/gob/detection/tables_dynasty.h
+++ b/engines/gob/detection/tables_dynasty.h
@@ -42,7 +42,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeDynasty,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -56,7 +55,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeDynasty,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -70,7 +68,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeDynasty,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -84,7 +81,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeDynasty,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -98,7 +94,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeDynasty,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -112,7 +107,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeDynasty,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -126,7 +120,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeDynasty,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -143,7 +136,6 @@
 		ADGF_DEMO,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeDynasty,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -157,7 +149,6 @@
 		ADGF_DEMO,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeDynasty,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -171,7 +162,6 @@
 		ADGF_DEMO,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeDynasty,
 	kFeatures640x480,
 	"lda1.stk", 0, 0
 },
@@ -185,7 +175,6 @@
 		ADGF_DEMO,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeDynasty,
 	kFeatures640x480,
 	"lda1.stk", 0, 0
 },
@@ -200,7 +189,6 @@
 		ADGF_DEMO,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeDynasty,
 	kFeatures640x480 | kFeaturesSCNDemo,
 	"demo.scn", 0, 1
 },
@@ -216,7 +204,6 @@
 		ADGF_DEMO,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)	
 	},
-	kGameTypeDynastyWood,
 	kFeatures640x480 | kFeaturesSCNDemo,
 	"demo.scn", 0, 1
 },

--- a/engines/gob/detection/tables_fallback.h
+++ b/engines/gob/detection/tables_fallback.h
@@ -41,7 +41,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 		},
-		kGameTypeGob1,
 		kFeaturesNone,
 		0, 0, 0
 	},
@@ -55,7 +54,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 		},
-		kGameTypeGob1,
 		kFeaturesCD,
 		0, 0, 0
 	},
@@ -69,7 +67,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 		},
-		kGameTypeGob2,
 		kFeaturesAdLib,
 		0, 0, 0
 	},
@@ -83,7 +80,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 		},
-		kGameTypeGob2,
 		kFeaturesAdLib,
 		0, 0, 0
 	},
@@ -97,7 +93,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 		},
-		kGameTypeGob2,
 		kFeaturesCD,
 		0, 0, 0
 	},
@@ -111,7 +106,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 		},
-		kGameTypeBargon,
 		kFeaturesNone,
 		0, 0, 0
 	},
@@ -125,7 +119,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 		},
-		kGameTypeGob3,
 		kFeaturesAdLib,
 		0, 0, 0
 	},
@@ -139,7 +132,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 		},
-		kGameTypeGob3,
 		kFeaturesCD,
 		0, 0, 0
 	},
@@ -153,13 +145,12 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 		},
-		kGameTypeWoodruff,
 		kFeatures640x480,
 		0, 0, 0
 	},
 	{ //9
 		{
-			"lostintime",
+			"lit",
 			"unknown",
 			AD_ENTRY1(0, 0),
 			UNK_LANG,
@@ -167,13 +158,12 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 		},
-		kGameTypeLostInTime,
 		kFeaturesAdLib,
 		0, 0, 0
 	},
 	{ //10
 		{
-			"lostintime",
+			"lit",
 			"unknown",
 			AD_ENTRY1(0, 0),
 			UNK_LANG,
@@ -181,13 +171,12 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 		},
-		kGameTypeLostInTime,
 		kFeaturesAdLib,
 		0, 0, 0
 	},
 	{ //11
 		{
-			"lostintime",
+			"lit",
 			"unknown",
 			AD_ENTRY1(0, 0),
 			UNK_LANG,
@@ -195,7 +184,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 		},
-		kGameTypeLostInTime,
 		kFeaturesCD,
 		0, 0, 0
 	},
@@ -209,7 +197,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 		},
-		kGameTypeUrban,
 		kFeatures640x480 | kFeaturesTrueColor,
 		0, 0, 0
 	},
@@ -223,7 +210,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 		},
-		kGameTypePlaytoons,
 		kFeatures640x480,
 		0, 0, 0
 	},
@@ -237,7 +223,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 		},
-		kGameTypePlaytoons,
 		kFeatures640x480,
 		0, 0, 0
 	},
@@ -251,7 +236,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 		},
-		kGameTypePlaytoons,
 		kFeatures640x480,
 		0, 0, 0
 	},
@@ -265,7 +249,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 		},
-		kGameTypePlaytoons,
 		kFeatures640x480,
 		0, 0, 0
 	},
@@ -279,13 +262,12 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 		},
-		kGameTypePlaytoons,
 		kFeatures640x480,
 		0, 0, 0
 	},
 	{ //18
 		{
-			"playtoons construction kit",
+			"playtnck1",
 			"unknown",
 			AD_ENTRY1(0, 0),
 			UNK_LANG,
@@ -293,7 +275,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 		},
-		kGameTypePlaytoons,
 		kFeatures640x480,
 		0, 0, 0
 	},
@@ -307,7 +288,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 		},
-		kGameTypeBambou,
 		kFeatures640x480,
 		0, 0, 0
 	},
@@ -321,7 +301,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 		},
-		kGameTypeFascination,
 		kFeaturesAdLib,
 		"disk0.stk", 0, 0
 	},
@@ -335,7 +314,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 		},
-		kGameTypeGeisha,
 		kFeaturesEGA | kFeaturesAdLib,
 		"disk1.stk", "intro.tot", 0
 	},
@@ -349,7 +327,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 		},
-		kGameTypeLittleRed,
 		kFeaturesAdLib | kFeaturesEGA,
 		0, 0, 0
 	},
@@ -363,7 +340,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 		},
-		kGameTypeLittleRed,
 		kFeaturesNone,
 		0, 0, 0
 	},
@@ -377,7 +353,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 		},
-		kGameTypeOnceUponATime,
 		kFeaturesEGA,
 		0, 0, 0
 	},
@@ -391,7 +366,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 		},
-		kGameTypeAdi2,
 		kFeatures640x400,
 		"adi2.stk", 0, 0
 	},
@@ -405,7 +379,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 		},
-		kGameTypeAdi4,
 		kFeatures640x480,
 		"adif41.stk", 0, 0
 	},
@@ -419,7 +392,6 @@ static const GOBGameDescription fallbackDescs[] = {
 			ADGF_NO_FLAGS,
 			GUIO1(GUIO_NOASPECT)
 		},
-		kGameTypeUrban,
 		kFeaturesAdLib | kFeatures640x480 | kFeaturesSCNDemo,
 		"", "", 8
 	}
@@ -487,7 +459,6 @@ static const GOBGameDescription fallbackOnceUpon[kOnceUponATimeMAX][kOnceUponATi
 				ADGF_NO_FLAGS,
 				GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 			},
-			kGameTypeAbracadabra,
 			kFeaturesAdLib | kFeaturesEGA,
 			0, 0, 0
 		},
@@ -501,7 +472,6 @@ static const GOBGameDescription fallbackOnceUpon[kOnceUponATimeMAX][kOnceUponATi
 				ADGF_NO_FLAGS,
 				GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 			},
-			kGameTypeAbracadabra,
 			kFeaturesEGA,
 			0, 0, 0
 		},
@@ -515,7 +485,6 @@ static const GOBGameDescription fallbackOnceUpon[kOnceUponATimeMAX][kOnceUponATi
 				ADGF_NO_FLAGS,
 				GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 			},
-			kGameTypeAbracadabra,
 			kFeaturesEGA,
 			0, 0, 0
 		}
@@ -531,7 +500,6 @@ static const GOBGameDescription fallbackOnceUpon[kOnceUponATimeMAX][kOnceUponATi
 				ADGF_NO_FLAGS,
 				GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 			},
-			kGameTypeBabaYaga,
 			kFeaturesAdLib | kFeaturesEGA,
 			0, 0, 0
 		},
@@ -545,7 +513,6 @@ static const GOBGameDescription fallbackOnceUpon[kOnceUponATimeMAX][kOnceUponATi
 				ADGF_NO_FLAGS,
 				GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 			},
-			kGameTypeBabaYaga,
 			kFeaturesEGA,
 			0, 0, 0
 		},
@@ -559,7 +526,6 @@ static const GOBGameDescription fallbackOnceUpon[kOnceUponATimeMAX][kOnceUponATi
 				ADGF_NO_FLAGS,
 				GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 			},
-			kGameTypeBabaYaga,
 			kFeaturesEGA,
 			0, 0, 0
 		}

--- a/engines/gob/detection/tables_fascin.h
+++ b/engines/gob/detection/tables_fascin.h
@@ -42,7 +42,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeFascination,
 	kFeaturesAdLib,
 	"disk0.stk", 0, 0
 },
@@ -56,7 +55,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeFascination,
 	kFeaturesAdLib,
 	"disk0.stk", 0, 0
 },
@@ -73,7 +71,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeFascination,
 	kFeaturesAdLib,
 	"disk0.stk", 0, 0
 },
@@ -87,7 +84,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeFascination,
 	kFeaturesAdLib,
 	"disk0.stk", 0, 0
 },
@@ -101,7 +97,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeFascination,
 	kFeaturesAdLib,
 	"intro.stk", 0, 0
 },
@@ -115,7 +110,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeFascination,
 	kFeaturesAdLib,
 	"disk0.stk", 0, 0
 },
@@ -132,7 +126,6 @@
 		ADGF_CD,
 		GUIO1(GUIO_NOSUBTITLES)
 	},
-	kGameTypeFascination,
 	kFeaturesCD,
 	"intro.stk", 0, 0
 },
@@ -146,7 +139,6 @@
 		ADGF_CD,
 		GUIO1(GUIO_NOSUBTITLES)
 	},
-	kGameTypeFascination,
 	kFeaturesCD,
 	"intro.stk", 0, 0
 },
@@ -160,7 +152,6 @@
 		ADGF_CD,
 		GUIO1(GUIO_NOSUBTITLES)
 	},
-	kGameTypeFascination,
 	kFeaturesCD,
 	"intro.stk", 0, 0
 },
@@ -174,7 +165,6 @@
 		ADGF_CD,
 		GUIO1(GUIO_NOSUBTITLES)
 	},
-	kGameTypeFascination,
 	kFeaturesCD,
 	"intro.stk", 0, 0
 },
@@ -188,7 +178,6 @@
 		ADGF_CD,
 		GUIO1(GUIO_NOSUBTITLES)
 	},
-	kGameTypeFascination,
 	kFeaturesCD,
 	"intro.stk", 0, 0
 },
@@ -202,7 +191,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeFascination,
 	kFeaturesNone,
 	"disk0.stk", 0, 0
 },
@@ -219,7 +207,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeFascination,
 	kFeaturesNone,
 	"disk0.stk", 0, 0
 },
@@ -233,7 +220,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeFascination,
 	kFeaturesNone,
 	"disk0.stk", 0, 0
 },
@@ -247,7 +233,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeFascination,
 	kFeaturesNone,
 	"disk0.stk", 0, 0
 },
@@ -261,7 +246,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeFascination,
 	kFeaturesNone,
 	"disk0.stk", 0, 0
 },
@@ -276,7 +260,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeFascination,
 	kFeaturesNone,
 	"disk0.stk", 0, 0
 },
@@ -293,7 +276,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeFascination,
 	kFeaturesNone,
 	"disk0.stk", 0, 0
 },

--- a/engines/gob/detection/tables_geisha.h
+++ b/engines/gob/detection/tables_geisha.h
@@ -42,7 +42,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGeisha,
 	kFeaturesEGA | kFeaturesAdLib,
 	"disk1.stk", "intro.tot", 0
 },
@@ -56,7 +55,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGeisha,
 	kFeaturesEGA | kFeaturesAdLib,
 	"disk1.stk", "intro.tot", 0
 },
@@ -70,7 +68,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGeisha,
 	kFeaturesEGA | kFeaturesAdLib,
 	"disk1.stk", "intro.tot", 0
 },
@@ -84,7 +81,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGeisha,
 	kFeaturesEGA | kFeaturesAdLib,
 	"disk1.stk", "intro.tot", 0
 },
@@ -98,7 +94,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGeisha,
 	kFeaturesEGA | kFeaturesAdLib,
 	"disk1.stk", "intro.tot", 0
 },
@@ -112,7 +107,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGeisha,
 	kFeaturesEGA | kFeaturesAdLib,
 	"disk1.stk", "intro.tot", 0
 },
@@ -126,7 +120,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGeisha,
 	kFeaturesEGA | kFeaturesAdLib,
 	"disk1.stk", "intro.tot", 0
 },
@@ -140,7 +133,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGeisha,
 	kFeaturesEGA | kFeaturesAdLib,
 	"disk1.stk", "intro.tot", 0
 },
@@ -157,7 +149,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGeisha,
 	kFeaturesEGA,
 	"disk1.stk", "intro.tot", 0
 },
@@ -172,7 +163,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGeisha,
 	kFeaturesEGA,
 	"disk1.stk", "intro.tot", 0
 },
@@ -187,7 +177,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGeisha,
 	kFeaturesEGA,
 	"disk1.stk", "intro.tot", 0
 },
@@ -202,7 +191,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGeisha,
 	kFeaturesEGA,
 	"disk1.stk", "intro.tot", 0
 },

--- a/engines/gob/detection/tables_gob1.h
+++ b/engines/gob/detection/tables_gob1.h
@@ -42,7 +42,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesEGA | kFeaturesAdLib,
 	0, 0, 0
 },
@@ -56,7 +55,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesEGA | kFeaturesAdLib,
 	0, 0, 0
 },
@@ -73,7 +71,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -87,7 +84,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -104,7 +100,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -118,7 +113,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -132,7 +126,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -146,7 +139,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -160,7 +152,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -174,7 +165,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -188,7 +178,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -202,7 +191,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -216,7 +204,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -230,7 +217,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -244,7 +230,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -258,7 +243,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -272,7 +256,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -286,7 +269,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -300,7 +282,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -317,7 +298,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -331,7 +311,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -345,7 +324,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -359,7 +337,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -373,7 +350,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -387,7 +363,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -401,7 +376,6 @@
 		ADGF_UNSTABLE,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -416,7 +390,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -434,7 +407,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -449,7 +421,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -464,7 +435,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -479,7 +449,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -494,7 +463,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -509,7 +477,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -524,7 +491,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -539,7 +505,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -554,7 +519,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -569,7 +533,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -583,7 +546,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -597,7 +559,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -611,7 +572,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -625,7 +585,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -639,7 +598,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -656,7 +614,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -670,7 +627,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -684,7 +640,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -698,7 +653,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -712,7 +666,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, "AVT003.TOT", 0
 },
@@ -726,7 +679,6 @@
 		ADGF_DEMO | ADGF_UNSTABLE,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, "AVT008.TOT", 0
 },
@@ -740,7 +692,6 @@
 		ADGF_DEMO | ADGF_UNSTABLE,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob1,
 	kFeaturesAdLib,
 	0, "AVT003.TOT", 0
 },

--- a/engines/gob/detection/tables_gob2.h
+++ b/engines/gob/detection/tables_gob2.h
@@ -42,7 +42,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -56,7 +55,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -70,7 +68,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -84,7 +81,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -98,7 +94,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -112,7 +107,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -126,7 +120,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -140,7 +133,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -154,7 +146,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -171,7 +162,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -185,7 +175,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -199,7 +188,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -213,7 +201,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -227,7 +214,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -241,7 +227,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -255,7 +240,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -269,7 +253,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -283,7 +266,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -297,7 +279,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -311,7 +292,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -325,7 +305,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -339,7 +318,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -357,7 +335,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -372,7 +349,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -387,7 +363,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -402,7 +377,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -417,7 +391,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -432,7 +405,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -446,7 +418,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -460,7 +431,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -474,7 +444,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -492,7 +461,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -507,7 +475,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -524,7 +491,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -538,7 +504,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -552,7 +517,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -566,7 +530,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -580,7 +543,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -598,7 +560,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -615,7 +576,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, "usa.tot", 0
 },
@@ -629,7 +589,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -643,7 +602,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -657,7 +615,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob2,
 	kFeaturesNone,
 	0, 0, 0
 },

--- a/engines/gob/detection/tables_gob3.h
+++ b/engines/gob/detection/tables_gob3.h
@@ -42,7 +42,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -56,7 +55,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -70,7 +68,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -84,7 +81,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -98,7 +94,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -112,7 +107,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -126,7 +120,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -140,7 +133,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -154,7 +146,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -168,7 +159,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -186,7 +176,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -204,7 +193,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -222,7 +210,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -240,7 +227,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -258,7 +244,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -276,7 +261,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -290,7 +274,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -311,7 +294,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -328,7 +310,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesNone,
 	0, "menu.tot", 0
 },
@@ -342,7 +323,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesNone,
 	0, "menu.tot", 0
 },
@@ -359,7 +339,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -373,7 +352,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -387,7 +365,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -401,7 +378,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -415,7 +391,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -429,7 +404,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -443,7 +417,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -457,7 +430,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -471,7 +443,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -485,7 +456,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -499,7 +469,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -516,7 +485,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -530,7 +498,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -544,7 +511,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -558,7 +524,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -572,7 +537,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -586,7 +550,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -600,7 +563,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeGob3,
 	kFeaturesAdLib,
 	0, 0, 0
 },

--- a/engines/gob/detection/tables_inca2.h
+++ b/engines/gob/detection/tables_inca2.h
@@ -42,7 +42,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeInca2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -56,7 +55,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeInca2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -70,7 +68,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeInca2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -86,7 +83,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeInca2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -103,7 +99,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeInca2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -117,7 +112,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeInca2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -131,7 +125,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeInca2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -145,7 +138,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeInca2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -159,7 +151,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeInca2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -173,7 +164,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeInca2,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -190,7 +180,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeInca2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -204,7 +193,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeInca2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -218,7 +206,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeInca2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -232,7 +219,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeInca2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -246,7 +232,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeInca2,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -276,7 +261,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeInca2,
 	kFeaturesAdLib | kFeaturesBATDemo,
 	0, 0, 7
 },

--- a/engines/gob/detection/tables_lit.h
+++ b/engines/gob/detection/tables_lit.h
@@ -42,7 +42,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -56,7 +55,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -70,7 +68,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -84,7 +81,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -101,7 +97,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -115,7 +110,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -129,7 +123,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -143,7 +136,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -157,7 +149,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -171,7 +162,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -185,7 +175,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -199,7 +188,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -213,7 +201,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -227,7 +214,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -241,7 +227,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -255,7 +240,6 @@
 		ADGF_CD,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesCD,
 	0, 0, 0
 },
@@ -272,7 +256,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -286,7 +269,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -300,7 +282,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -314,7 +295,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -328,7 +308,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -342,7 +321,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -359,7 +337,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -374,7 +351,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -391,7 +367,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -406,7 +381,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -424,7 +398,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -441,7 +414,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	"demo.stk", "demo.tot", 0
 },
@@ -455,7 +427,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	"demo.stk", "demo.tot", 0
 },
@@ -469,7 +440,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	"demo.stk", "demo.tot", 0
 },
@@ -485,7 +455,6 @@
 		ADGF_PIRATED,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLostInTime,
 	kFeaturesAdLib,
 	0, 0, 0
 },

--- a/engines/gob/detection/tables_littlered.h
+++ b/engines/gob/detection/tables_littlered.h
@@ -42,7 +42,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLittleRed,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -56,7 +55,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLittleRed,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -70,7 +68,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLittleRed,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -84,7 +81,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLittleRed,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -98,7 +94,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLittleRed,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -115,7 +110,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLittleRed,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -129,7 +123,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLittleRed,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -143,7 +136,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLittleRed,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -157,7 +149,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLittleRed,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -171,7 +162,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLittleRed,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -185,7 +175,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLittleRed,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -199,7 +188,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLittleRed,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -213,7 +201,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLittleRed,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -227,7 +214,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLittleRed,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -241,7 +227,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLittleRed,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -255,7 +240,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLittleRed,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -273,7 +257,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeLittleRed,
 	kFeaturesNone,
 	0, 0, 0
 },

--- a/engines/gob/detection/tables_onceupon.h
+++ b/engines/gob/detection/tables_onceupon.h
@@ -47,7 +47,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAbracadabra,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -66,7 +65,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAbracadabra,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -85,7 +83,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAbracadabra,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -104,7 +101,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAbracadabra,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -123,7 +119,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAbracadabra,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -145,7 +140,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAbracadabra,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -164,7 +158,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAbracadabra,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -183,7 +176,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAbracadabra,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -202,7 +194,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAbracadabra,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -221,7 +212,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeAbracadabra,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -243,7 +233,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBabaYaga,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -262,7 +251,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBabaYaga,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -281,7 +269,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBabaYaga,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -300,7 +287,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBabaYaga,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -319,7 +305,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBabaYaga,
 	kFeaturesAdLib | kFeaturesEGA,
 	0, 0, 0
 },
@@ -341,7 +326,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBabaYaga,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -360,7 +344,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBabaYaga,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -379,7 +362,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBabaYaga,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -398,7 +380,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBabaYaga,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -417,7 +398,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBabaYaga,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -439,7 +419,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBabaYaga,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -458,7 +437,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBabaYaga,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -477,7 +455,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBabaYaga,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -496,7 +473,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBabaYaga,
 	kFeaturesEGA,
 	0, 0, 0
 },
@@ -515,7 +491,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeBabaYaga,
 	kFeaturesEGA,
 	0, 0, 0
 },

--- a/engines/gob/detection/tables_playtoons.h
+++ b/engines/gob/detection/tables_playtoons.h
@@ -43,7 +43,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -58,7 +57,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -73,7 +71,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -88,7 +85,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -111,7 +107,6 @@
 		ADGF_DEMO,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480 | kFeaturesSCNDemo,
 	0, 0, 3
 },
@@ -126,7 +121,6 @@
 		ADGF_DEMO,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480 | kFeaturesSCNDemo,
 	0, 0, 4
 },
@@ -145,7 +139,6 @@
 		ADGF_DEMO,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480 | kFeaturesSCNDemo,
 	0, 0, 5
 },
@@ -163,7 +156,6 @@
 		ADGF_DEMO,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480 | kFeaturesSCNDemo,
 	0, 0, 6
 },
@@ -181,7 +173,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -196,7 +187,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -211,7 +201,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -226,7 +215,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -241,7 +229,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -256,7 +243,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -274,7 +260,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -289,7 +274,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -304,7 +288,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -319,7 +302,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -334,7 +316,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -352,7 +333,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -367,7 +347,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -382,7 +361,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -400,7 +378,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -415,7 +392,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -433,7 +409,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -451,7 +426,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -469,7 +443,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypePlaytoons,
 	kFeatures640x480,
 	"intro2.stk", 0, 0
 },
@@ -487,7 +460,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeBambou,
 	kFeatures640x480,
 	"intro.stk", "intro.tot", 0
 },

--- a/engines/gob/detection/tables_urban.h
+++ b/engines/gob/detection/tables_urban.h
@@ -42,7 +42,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeUrban,
 	kFeatures640x480 | kFeaturesTrueColor,
 	0, 0, 0
 },
@@ -56,7 +55,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeUrban,
 	kFeatures640x480 | kFeaturesTrueColor,
 	0, 0, 0
 },
@@ -70,7 +68,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeUrban,
 	kFeatures640x480 | kFeaturesTrueColor,
 	0, 0, 0
 },
@@ -84,7 +81,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeUrban,
 	kFeatures640x480 | kFeaturesTrueColor,
 	0, 0, 0
 },
@@ -98,7 +94,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeUrban,
 	kFeatures640x480 | kFeaturesTrueColor,
 	0, 0, 0
 },
@@ -112,7 +107,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeUrban,
 	kFeatures640x480 | kFeaturesTrueColor,
 	0, 0, 0
 },
@@ -126,7 +120,6 @@
 		ADGF_NO_FLAGS,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeUrban,
 	kFeatures640x480 | kFeaturesTrueColor,
 	0, 0, 0
 },
@@ -145,7 +138,6 @@
 		ADGF_DEMO,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kGameTypeUrban,
 	kFeatures640x480 | kFeaturesTrueColor | kFeaturesSCNDemo,
 	0, 0, 2
 },

--- a/engines/gob/detection/tables_ween.h
+++ b/engines/gob/detection/tables_ween.h
@@ -42,7 +42,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -56,7 +55,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -70,7 +68,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -84,7 +81,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -98,7 +94,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -112,7 +107,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -126,7 +120,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -144,7 +137,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -158,7 +150,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -172,7 +163,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -186,7 +176,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -201,7 +190,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -216,7 +204,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -234,7 +221,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -248,7 +234,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesNone,
 	0, 0, 0
 },
@@ -265,7 +250,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesAdLib,
 	0, "show.tot", 0
 },
@@ -279,7 +263,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesAdLib,
 	0, "show.tot", 0
 },
@@ -293,7 +276,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -307,7 +289,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesAdLib,
 	0, 0, 0
 },
@@ -321,7 +302,6 @@
 		ADGF_DEMO,
 		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
 	},
-	kGameTypeWeen,
 	kFeaturesAdLib,
 	0, 0, 0
 },

--- a/engines/gob/detection/tables_woodruff.h
+++ b/engines/gob/detection/tables_woodruff.h
@@ -42,7 +42,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -56,7 +55,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -70,7 +68,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -84,7 +81,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -98,7 +94,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -112,7 +107,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -126,7 +120,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -140,7 +133,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -154,7 +146,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -168,7 +159,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -182,7 +172,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -196,7 +185,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -210,7 +198,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -224,7 +211,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -238,7 +224,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -252,7 +237,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -266,7 +250,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -280,7 +263,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -294,7 +276,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -308,7 +289,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -322,7 +302,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -336,7 +315,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -350,7 +328,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -364,7 +341,6 @@
 		ADGF_NO_FLAGS,
 		GUIO2(GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480,
 	0, 0, 0
 },
@@ -382,7 +358,6 @@
 		ADGF_DEMO,
 		GUIO3(GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOASPECT)
 	},
-	kGameTypeWoodruff,
 	kFeatures640x480 | kFeaturesSCNDemo,
 	0, 0, 1
 },

--- a/engines/gob/gameidtotype.h
+++ b/engines/gob/gameidtotype.h
@@ -1,0 +1,86 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * This file is dual-licensed.
+ * In addition to the GPLv3 license mentioned above, this code is also
+ * licensed under LGPL 2.1. See LICENSES/COPYING.LGPL file for the
+ * full text of the license.
+ *
+ */
+
+#ifndef GOB_GAMEIDTOTYPE_H
+#define GOB_GAMEIDTOTYPE_H
+
+#include "gob/detection/detection.h"
+
+namespace Gob {
+
+struct GameIdToType {
+	const char *gameId;
+	GameType gameType;
+};
+
+static const GameIdToType gameIdToType[] = {
+	{                    "gob1", kGameTypeGob1 },
+	{                    "gob2", kGameTypeGob2 },
+	{                    "gob3", kGameTypeGob3 },
+	{                    "ween", kGameTypeWeen },
+	{                  "bargon", kGameTypeBargon },
+	{                "babayaga", kGameTypeBabaYaga },
+	{             "abracadabra", kGameTypeAbracadabra },
+	{               "littlered", kGameTypeLittleRed },
+	{                "onceupon", kGameTypeOnceUponATime },
+	{                 "crousti", kGameTypeCrousti },
+	{                     "lit", kGameTypeLostInTime },
+	{                    "lit1", kGameTypeLostInTime },
+	{                    "lit2", kGameTypeLostInTime },
+	{                   "inca2", kGameTypeInca2 },
+	{                "woodruff", kGameTypeWoodruff },
+	{                 "dynasty", kGameTypeDynasty },
+	{                   "urban", kGameTypeUrban },
+	{              "playtoons1", kGameTypePlaytoons },
+	{              "playtoons2", kGameTypePlaytoons },
+	{              "playtoons3", kGameTypePlaytoons },
+	{              "playtoons4", kGameTypePlaytoons },
+	{              "playtoons5", kGameTypePlaytoons },
+	{               "playtnck1", kGameTypePlaytoons },
+	{               "playtnck2", kGameTypePlaytoons },
+	{               "playtnck3", kGameTypePlaytoons },
+	{           "playtoonsdemo", kGameTypePlaytoons },
+	{                  "bambou", kGameTypeBambou },
+	{             "fascination", kGameTypeFascination },
+	{                  "geisha", kGameTypeGeisha },
+	{                    "adi2", kGameTypeAdi2 },
+	{                    "adi4", kGameTypeAdi4 },
+	{                    "adi5", kGameTypeNone },
+	{                 "adibou1", kGameTypeAdibou1 },
+	{                 "adibou2", kGameTypeAdibou2 },
+	{                 "adibou3", kGameTypeNone },
+	{            "adiboudessin", kGameTypeNone },
+	{          "adiboudchoumer", kGameTypeNone },
+	{     "adiboudchoubanquise", kGameTypeNone },
+	{     "adiboudchoucampagne", kGameTypeNone },
+	{ "adiboudchoujunglesavane", kGameTypeNone },
+	{                   nullptr, kGameTypeNone }
+};
+
+} // End of namespace Gob
+
+#endif // GOB_GAMEIDTOTYPE_H

--- a/engines/gob/gob.h
+++ b/engines/gob/gob.h
@@ -235,6 +235,7 @@ public:
 	~GobEngine() override;
 
 	void initGame(const GOBGameDescription *gd);
+	GameType getGameType(const char *gameId) const;
 };
 
 } // End of namespace Gob

--- a/engines/gob/metaengine.cpp
+++ b/engines/gob/metaengine.cpp
@@ -28,6 +28,7 @@
 #include "engines/advancedDetector.h"
 #include "engines/obsolete.h"
 
+#include "gob/gameidtotype.h"
 #include "gob/gob.h"
 #include "gob/obsolete.h"
 
@@ -75,6 +76,18 @@ Common::Error GobMetaEngine::createInstance(OSystem *syst, Engine **engine, cons
 
 namespace Gob {
 
+GameType GobEngine::getGameType(const char *gameId) const {
+	const GameIdToType *gameInfo = gameIdToType;
+
+	while (gameInfo->gameId != nullptr) {
+		if (!strcmp(gameId, gameInfo->gameId))
+			return gameInfo->gameType;
+		gameInfo++;
+	}
+
+	error("Unknown game ID: %s", gameId);
+}
+
 void GobEngine::initGame(const GOBGameDescription *gd) {
 	if (gd->startTotBase == nullptr)
 		_startTot = "intro.tot";
@@ -88,7 +101,7 @@ void GobEngine::initGame(const GOBGameDescription *gd) {
 
 	_demoIndex = gd->demoIndex;
 
-	_gameType = gd->gameType;
+	_gameType = getGameType(gd->desc.gameId);
 	_features = gd->features;
 	_language = gd->desc.language;
 	_platform = gd->desc.platform;


### PR DESCRIPTION
Remove game types from all of the detection entries. Game types can be deduced from the game ID, so keeping them both in game entries is duplicate and superfluous information.

As an added bonus, several fallback game IDs have been fixed to match their correct values
