### PR TITLE
DIRECTOR: Fix missing comma breaking some detection paths

### DIFF
--- a/engines/director/detection_paths.h
+++ b/engines/director/detection_paths.h
@@ -57,7 +57,7 @@ const char *const directoryGlobs[] = {
 	"flugzeuge bauen",
 	"willyhau",
 	"willyraumschiff",				// Willy Werkel (Mulle Meck) series
-	"demo"							// Tivola Demo - Frühjahr '97 sampler
+	"demo",							// Tivola Demo - Frühjahr '97 sampler
 	"demos",						// Headbone samplers
 	"blender",						// Blender CD-ROM magazines
 	"bilder",


### PR DESCRIPTION
Fixes missing comma caught by Coverity from commit cd2b0fd434605e9e2f2d7f485983f2b6e2b1c7f9, which was breaking some detection paths.