### PR TITLE
SCUMM: Add workaround for MI2 glitch when diving to the Mad Monkey

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2006,6 +2006,18 @@ void ScummEngine_v5::o5_putActorAtObject() {
 	else {
 		x = 240;
 		y = 120;
+
+		// WORKAROUND: When Guybrush dives down to the Mad Monkey, he
+		// is positioned near the anchor (though since it can't be
+		// found yet, it uses this default position). He's then lowered
+		// to the ocean floor by adjusting his elevation. But he will
+		// be drawn for a split second at the unelevated position. This
+		// is a bug in the original game, and we work around it by
+		// adjusting the elevation immediately.
+
+		if (_game.id == GID_MONKEY2 && a->_number == 1 && vm.slot[_currentScript].number == 58 && enhancementEnabled(kEnhMinorBugFixes)) {
+			a->setElevation(99);
+		}
 	}
 	a->putActor(x, y);
 }


### PR DESCRIPTION
As discussed on #engine-scumm ...

Just before Guybrush sinks to the ocean floor, he is drawn at the wrong position for a split second. This happens in the original too, though I found it much easier to spot in ScummVM for some reason. We work around this by setting Guybrush's elevation at the same time as he's put into the room.

Maybe there's a better fix, maybe the comment needs to be reworded. I don't know, I just didn't want it to be lost.

The easiest way to test this is to use boot param 989.