### PR TITLE
STARK: Fix not loading ssn sounds in Steam version

### DIFF
--- a/engines/stark/resources/sound.cpp
+++ b/engines/stark/resources/sound.cpp
@@ -78,7 +78,7 @@ Audio::RewindableAudioStream *Sound::makeAudioStream() {
 		// The 2 CD version uses Ogg Vorbis
 		Common::Path filename = _filename;
 		Common::String baseName(filename.baseName());
-		if (baseName.hasSuffix(".iss") || baseName.hasSuffix(".isn")) {
+		if (baseName.hasSuffix(".iss") || baseName.hasSuffix(".isn") || baseName.hasSuffix(".ssn")) {
 			baseName = Common::String(baseName.c_str(), baseName.size() - 4) + ".ovs";
 			filename = _filename.getParent().appendComponent(baseName);
 		}


### PR DESCRIPTION
This should address bug report #12956 about the missing sounds

It seems that the Steam version of TLJ has the .ssn sounds (found in the GOG version) as ovs (ogg vorbis) sounds.

I have tested with the provided saved game, and this fixes the sounds that were not loading (I think it's trains arriving/leaving sfx)

I only have the GOG version and the Steam versions of the game to test. I do not have any of the CDs version(s).


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
