### PR TITLE
SCUMM: Fix crash when missing TRS file in Full Throttle

### DIFF
--- a/engines/scumm/insane/insane.cpp
+++ b/engines/scumm/insane/insane.cpp
@@ -1383,7 +1383,9 @@ void Insane::smlayer_setActorFacing(int actornum, int actnum, int frame, int dir
 
 const char *Insane::handleTrsTag(int32 trsId) {
 	debugC(DEBUG_INSANE, "Insane::handleTrsTag(%d)", trsId);
-	return _player->getString(trsId);
+	if (_player != nullptr) {
+		return _player->getString(trsId);
+	} else return nullptr;
 }
 
 bool Insane::smush_eitherNotStartNewFrame() {

--- a/engines/scumm/insane/insane.cpp
+++ b/engines/scumm/insane/insane.cpp
@@ -1385,7 +1385,10 @@ const char *Insane::handleTrsTag(int32 trsId) {
 	debugC(DEBUG_INSANE, "Insane::handleTrsTag(%d)", trsId);
 	if (_player != nullptr) {
 		return _player->getString(trsId);
-	} else return nullptr;
+	} else {
+		warning("Couldn't load Trs block corresponding to id {%d}, are you maybe missing a TRS subtitle file?", trsId);
+		return nullptr;
+	}
 }
 
 bool Insane::smush_eitherNotStartNewFrame() {

--- a/engines/scumm/smush/smush_player.cpp
+++ b/engines/scumm/smush/smush_player.cpp
@@ -669,7 +669,9 @@ void SmushPlayer::handleTextResource(uint32 subType, int32 subSize, Common::Seek
 }
 
 const char *SmushPlayer::getString(int id) {
-	return _strings->get(id);
+	if (_strings != nullptr) {
+		return _strings->get(id);
+	} else return nullptr;
 }
 
 bool SmushPlayer::readString(const char *file) {

--- a/engines/scumm/smush/smush_player.cpp
+++ b/engines/scumm/smush/smush_player.cpp
@@ -671,7 +671,10 @@ void SmushPlayer::handleTextResource(uint32 subType, int32 subSize, Common::Seek
 const char *SmushPlayer::getString(int id) {
 	if (_strings != nullptr) {
 		return _strings->get(id);
-	} else return nullptr;
+	} else {
+		warning("Couldn't load string with id {%d}, are you maybe missing a TRS subtitle file?", id);
+		return nullptr;
+	}
 }
 
 bool SmushPlayer::readString(const char *file) {


### PR DESCRIPTION
This was inspired by bug report https://bugs.scummvm.org/ticket/14876

It is a naive fix, whereby I've added checks for nullptr where Visual Studio debugging would crash with exception, due to trying to access a nullptr pointer.

It works for the specific crash case, but someone more familiar with the engines should review it.

The crash itself seems to be caused by the game data folder missing the resource file for subtitles in that scene (which I think is the "DATA\MINEROAD.TRS").


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
