### PR TITLE
IOS7: Overload key input

### DIFF
--- a/backends/platform/ios7/ios7_keyboard.h
+++ b/backends/platform/ios7/ios7_keyboard.h
@@ -36,7 +36,7 @@
 - (void)dealloc;
 - (UITextField *)inputView;
 - (void)setInputDelegate:(id)delegate;
-- (void)handleKeyPress:(unichar)c;
+- (void)handleKeyPress:(unichar)c withModifierFlags:(int)f;
 - (void)handleMainMenuKey;
 
 - (void)showKeyboard;

--- a/backends/platform/ios7/ios7_keyboard.mm
+++ b/backends/platform/ios7/ios7_keyboard.mm
@@ -328,6 +328,16 @@
 	return nil;
 }
 
+- (NSArray *)overloadSpecialKeys {
+	NSMutableArray<NSString *> *specialKeys = [[NSMutableArray alloc] initWithObjects:UIKeyInputEscape, UIKeyInputPageUp, UIKeyInputPageDown, nil];
+
+	if (@available(iOS 13.4, *)) {
+		[specialKeys addObject: UIKeyInputHome];
+		[specialKeys addObject: UIKeyInputEnd];
+	}
+	return [self overloadKeys:specialKeys withSelector:@selector(handleSpecialKey:)];
+}
+
 - (int)convertModifierFlags:(UIKeyModifierFlags)flags {
 	return (((flags & UIKeyModifierShift) ? Common::KBD_SHIFT : 0) |
 		((flags & UIKeyModifierControl) ? Common::KBD_CTRL : 0) |
@@ -437,6 +447,23 @@
 			[self fn11Key];
 		} else if (keyCommand.input == UIKeyInputF12) {
 			[self fn12Key];
+		}
+	}
+}
+
+- (void)handleSpecialKey:(UIKeyCommand *)keyCommand {
+	if (keyCommand.input == UIKeyInputEscape) {
+		[self escapeKey:keyCommand];
+	} else if (keyCommand.input == UIKeyInputPageUp) {
+		[softKeyboard handleKeyPress:Common::KEYCODE_PAGEUP withModifierFlags:[self convertModifierFlags:keyCommand.modifierFlags]];
+	} else if (keyCommand.input == UIKeyInputPageDown) {
+		[softKeyboard handleKeyPress:Common::KEYCODE_PAGEDOWN withModifierFlags:[self convertModifierFlags:keyCommand.modifierFlags]];
+	}
+	if (@available(iOS 13.4, *)) {
+		if (keyCommand.input == UIKeyInputHome) {
+			[softKeyboard handleKeyPress:Common::KEYCODE_HOME withModifierFlags:[self convertModifierFlags:keyCommand.modifierFlags]];
+		} else if (keyCommand.input == UIKeyInputEnd) {
+			[softKeyboard handleKeyPress:Common::KEYCODE_END withModifierFlags:[self convertModifierFlags:keyCommand.modifierFlags]];
 		}
 	}
 }

--- a/backends/platform/ios7/ios7_keyboard.mm
+++ b/backends/platform/ios7/ios7_keyboard.mm
@@ -166,7 +166,7 @@
  * Propagate all delete callbacks to the backend.
  */
 -(void)deleteBackward {
-	[softKeyboard handleKeyPress:'\b'];
+	[softKeyboard handleKeyPress:'\b' withModifierFlags:0];
 	[super deleteBackward];
 }
 
@@ -288,23 +288,23 @@
 }
 
 - (void) upArrow: (UIKeyCommand *) keyCommand {
-	[softKeyboard handleKeyPress:Common::KEYCODE_UP];
+	[softKeyboard handleKeyPress:Common::KEYCODE_UP withModifierFlags:0];
 }
 
 - (void) downArrow: (UIKeyCommand *) keyCommand {
-	[softKeyboard handleKeyPress:Common::KEYCODE_DOWN];
+	[softKeyboard handleKeyPress:Common::KEYCODE_DOWN withModifierFlags:0];
 }
 
 - (void) leftArrow: (UIKeyCommand *) keyCommand {
-	[softKeyboard handleKeyPress:Common::KEYCODE_LEFT];
+	[softKeyboard handleKeyPress:Common::KEYCODE_LEFT withModifierFlags:0];
 }
 
 - (void) rightArrow: (UIKeyCommand *) keyCommand {
-	[softKeyboard handleKeyPress:Common::KEYCODE_RIGHT];
+	[softKeyboard handleKeyPress:Common::KEYCODE_RIGHT withModifierFlags:0];
 }
 
 - (void) escapeKey: (UIKeyCommand *) keyCommand {
-	[softKeyboard handleKeyPress:Common::KEYCODE_ESCAPE];
+	[softKeyboard handleKeyPress:Common::KEYCODE_ESCAPE withModifierFlags:0];
 }
 
 - (void) mainMenuKey {
@@ -312,79 +312,79 @@
 }
 
 - (void) escapeKey {
-	[softKeyboard handleKeyPress:Common::KEYCODE_ESCAPE];
+	[softKeyboard handleKeyPress:Common::KEYCODE_ESCAPE withModifierFlags:0];
 }
 
 - (void) tabKey {
-	[softKeyboard handleKeyPress:Common::KEYCODE_TAB];
+	[softKeyboard handleKeyPress:Common::KEYCODE_TAB withModifierFlags:0];
 }
 
 - (void) fn1Key {
-	[softKeyboard handleKeyPress:Common::KEYCODE_F1];
+	[softKeyboard handleKeyPress:Common::KEYCODE_F1 withModifierFlags:0];
 }
 
 - (void) fn2Key {
-	[softKeyboard handleKeyPress:Common::KEYCODE_F2];
+	[softKeyboard handleKeyPress:Common::KEYCODE_F2 withModifierFlags:0];
 }
 
 - (void) fn3Key {
-	[softKeyboard handleKeyPress:Common::KEYCODE_F3];
+	[softKeyboard handleKeyPress:Common::KEYCODE_F3 withModifierFlags:0];
 }
 
 - (void) fn4Key {
-	[softKeyboard handleKeyPress:Common::KEYCODE_F4];
+	[softKeyboard handleKeyPress:Common::KEYCODE_F4 withModifierFlags:0];
 }
 
 - (void) fn5Key {
-	[softKeyboard handleKeyPress:Common::KEYCODE_F5];
+	[softKeyboard handleKeyPress:Common::KEYCODE_F5 withModifierFlags:0];
 }
 
 - (void) fn6Key {
-	[softKeyboard handleKeyPress:Common::KEYCODE_F6];
+	[softKeyboard handleKeyPress:Common::KEYCODE_F6 withModifierFlags:0];
 }
 
 - (void) fn7Key {
-	[softKeyboard handleKeyPress:Common::KEYCODE_F7];
+	[softKeyboard handleKeyPress:Common::KEYCODE_F7 withModifierFlags:0];
 }
 
 - (void) fn8Key {
-	[softKeyboard handleKeyPress:Common::KEYCODE_F8];
+	[softKeyboard handleKeyPress:Common::KEYCODE_F8 withModifierFlags:0];
 }
 
 - (void) fn9Key {
-	[softKeyboard handleKeyPress:Common::KEYCODE_F9];
+	[softKeyboard handleKeyPress:Common::KEYCODE_F9 withModifierFlags:0];
 }
 
 - (void) fn10Key {
-	[softKeyboard handleKeyPress:Common::KEYCODE_F10];
+	[softKeyboard handleKeyPress:Common::KEYCODE_F10 withModifierFlags:0];
 }
 
 - (void) fn11Key {
-	[softKeyboard handleKeyPress:Common::KEYCODE_F11];
+	[softKeyboard handleKeyPress:Common::KEYCODE_F11 withModifierFlags:0];
 }
 
 - (void) fn12Key {
-	[softKeyboard handleKeyPress:Common::KEYCODE_F12];
+	[softKeyboard handleKeyPress:Common::KEYCODE_F12 withModifierFlags:0];
 }
 
 - (void) leftArrowKey {
-	[softKeyboard handleKeyPress:Common::KEYCODE_LEFT];
+	[softKeyboard handleKeyPress:Common::KEYCODE_LEFT withModifierFlags:0];
 }
 
 - (void) upArrowKey {
-	[softKeyboard handleKeyPress:Common::KEYCODE_UP];
+	[softKeyboard handleKeyPress:Common::KEYCODE_UP withModifierFlags:0];
 }
 
 - (void) rightArrowKey {
-	[softKeyboard handleKeyPress:Common::KEYCODE_RIGHT];
+	[softKeyboard handleKeyPress:Common::KEYCODE_RIGHT withModifierFlags:0];
 }
 
 - (void) downArrowKey {
-	[softKeyboard handleKeyPress:Common::KEYCODE_DOWN];
+	[softKeyboard handleKeyPress:Common::KEYCODE_DOWN withModifierFlags:0];
 }
 
 - (void) returnKey {
-	[softKeyboard handleKeyPress:Common::KEYCODE_RETURN];
+	[softKeyboard handleKeyPress:Common::KEYCODE_RETURN withModifierFlags:0];
 }
 
 - (void) switchKeyboardLayout {
@@ -528,7 +528,7 @@
 
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)text {
 	if (text.length) {
-		[inputDelegate handleKeyPress:[text characterAtIndex:0]];
+		[inputDelegate handleKeyPress:[text characterAtIndex:0] withModifierFlags:0];
 	}
 	return YES;
 }
@@ -549,8 +549,8 @@
 	inputDelegate = delegate;
 }
 
-- (void)handleKeyPress:(unichar)c {
-	[inputDelegate handleKeyPress:c];
+- (void)handleKeyPress:(unichar)c withModifierFlags:(int)f {
+	[inputDelegate handleKeyPress:c withModifierFlags:f];
 }
 
 - (void)handleMainMenuKey {

--- a/backends/platform/ios7/ios7_keyboard.mm
+++ b/backends/platform/ios7/ios7_keyboard.mm
@@ -274,6 +274,36 @@
 	}
 }
 
+- (UIKeyCommand *)createKeyCommandForKey:(NSString *)key withModifierFlags:(UIKeyModifierFlags)flags andSelector:(SEL)selector {
+	UIKeyCommand *k = [UIKeyCommand keyCommandWithInput:key modifierFlags:flags action:selector];
+	[self setWantsPriority:k];
+	return k;
+}
+
+- (NSArray *)overloadKeys:(NSArray<NSString *> *)keys withSelector:(SEL)selector {
+	NSMutableArray<UIKeyCommand *> *overloadedKeys = [[NSMutableArray alloc] init];
+	for (NSString *key in keys) {
+		[overloadedKeys addObject:[self createKeyCommandForKey:key withModifierFlags:0 andSelector:selector]];
+		[overloadedKeys addObject:[self createKeyCommandForKey:key withModifierFlags:UIKeyModifierShift andSelector:selector]];
+		[overloadedKeys addObject:[self createKeyCommandForKey:key withModifierFlags:UIKeyModifierControl andSelector:selector]];
+		[overloadedKeys addObject:[self createKeyCommandForKey:key withModifierFlags:UIKeyModifierAlternate andSelector:selector]];
+		[overloadedKeys addObject:[self createKeyCommandForKey:key withModifierFlags:UIKeyModifierCommand andSelector:selector]];
+		// Sticky
+		[overloadedKeys addObject:[self createKeyCommandForKey:key withModifierFlags:UIKeyModifierAlphaShift andSelector:selector]];
+		[overloadedKeys addObject:[self createKeyCommandForKey:key withModifierFlags:UIKeyModifierNumericPad andSelector:selector]];
+	}
+	return overloadedKeys;
+}
+
+- (int)convertModifierFlags:(UIKeyModifierFlags)flags {
+	return (((flags & UIKeyModifierShift) ? Common::KBD_SHIFT : 0) |
+		((flags & UIKeyModifierControl) ? Common::KBD_CTRL : 0) |
+		((flags & UIKeyModifierAlternate) ? Common::KBD_ALT : 0) |
+		((flags & UIKeyModifierCommand) ? Common::KBD_META : 0) |
+		((flags & UIKeyModifierAlphaShift) ? Common::KBD_CAPS : 0) |
+		((flags & UIKeyModifierNumericPad) ? Common::KBD_NUM : 0));
+}
+
 - (NSArray *)keyCommands {
 	UIKeyCommand *upArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputUpArrow modifierFlags: 0 action: @selector(upArrow:)];
 	[self setWantsPriority: upArrow];

--- a/backends/platform/ios7/ios7_keyboard.mm
+++ b/backends/platform/ios7/ios7_keyboard.mm
@@ -288,11 +288,16 @@
 		[overloadedKeys addObject:[self createKeyCommandForKey:key withModifierFlags:UIKeyModifierControl andSelector:selector]];
 		[overloadedKeys addObject:[self createKeyCommandForKey:key withModifierFlags:UIKeyModifierAlternate andSelector:selector]];
 		[overloadedKeys addObject:[self createKeyCommandForKey:key withModifierFlags:UIKeyModifierCommand andSelector:selector]];
-		// Sticky
+		// UIKeyModifierAlphaShift seems broken since iOS 13
 		[overloadedKeys addObject:[self createKeyCommandForKey:key withModifierFlags:UIKeyModifierAlphaShift andSelector:selector]];
 		[overloadedKeys addObject:[self createKeyCommandForKey:key withModifierFlags:UIKeyModifierNumericPad andSelector:selector]];
 	}
 	return overloadedKeys;
+}
+
+- (NSArray *)overloadArrowKeys {
+	NSArray<NSString *> *arrowKeys = [[NSArray alloc] initWithObjects:UIKeyInputUpArrow, UIKeyInputDownArrow, UIKeyInputLeftArrow, UIKeyInputRightArrow, nil];
+	return [self overloadKeys:arrowKeys withSelector:@selector(handleArrowKey:)];
 }
 
 - (int)convertModifierFlags:(UIKeyModifierFlags)flags {
@@ -302,6 +307,18 @@
 		((flags & UIKeyModifierCommand) ? Common::KBD_META : 0) |
 		((flags & UIKeyModifierAlphaShift) ? Common::KBD_CAPS : 0) |
 		((flags & UIKeyModifierNumericPad) ? Common::KBD_NUM : 0));
+}
+
+- (void)handleArrowKey:(UIKeyCommand *)keyCommand {
+	if (keyCommand.input == UIKeyInputUpArrow) {
+		[self upArrow:keyCommand];
+	} else if (keyCommand.input == UIKeyInputDownArrow) {
+		[self downArrow:keyCommand];
+	} else if (keyCommand.input == UIKeyInputLeftArrow) {
+		[self leftArrow:keyCommand];
+	} else {
+		[self rightArrow:keyCommand];
+	}
 }
 
 - (NSArray *)keyCommands {
@@ -318,19 +335,35 @@
 }
 
 - (void) upArrow: (UIKeyCommand *) keyCommand {
-	[softKeyboard handleKeyPress:Common::KEYCODE_UP withModifierFlags:0];
+	if (keyCommand.modifierFlags == UIKeyModifierCommand) {
+		[softKeyboard handleKeyPress:Common::KEYCODE_PAGEUP withModifierFlags:0];
+	} else {
+		[softKeyboard handleKeyPress:Common::KEYCODE_UP withModifierFlags:[self convertModifierFlags:keyCommand.modifierFlags]];
+	}
 }
 
 - (void) downArrow: (UIKeyCommand *) keyCommand {
-	[softKeyboard handleKeyPress:Common::KEYCODE_DOWN withModifierFlags:0];
+	if (keyCommand.modifierFlags == UIKeyModifierCommand) {
+		[softKeyboard handleKeyPress:Common::KEYCODE_PAGEDOWN withModifierFlags:0];
+	} else {
+		[softKeyboard handleKeyPress:Common::KEYCODE_DOWN withModifierFlags:[self convertModifierFlags:keyCommand.modifierFlags]];
+	}
 }
 
 - (void) leftArrow: (UIKeyCommand *) keyCommand {
-	[softKeyboard handleKeyPress:Common::KEYCODE_LEFT withModifierFlags:0];
+	if (keyCommand.modifierFlags == UIKeyModifierCommand) {
+		[softKeyboard handleKeyPress:Common::KEYCODE_HOME withModifierFlags:0];
+	} else {
+		[softKeyboard handleKeyPress:Common::KEYCODE_LEFT withModifierFlags:[self convertModifierFlags:keyCommand.modifierFlags]];
+	}
 }
 
 - (void) rightArrow: (UIKeyCommand *) keyCommand {
-	[softKeyboard handleKeyPress:Common::KEYCODE_RIGHT withModifierFlags:0];
+	if (keyCommand.modifierFlags == UIKeyModifierCommand) {
+		[softKeyboard handleKeyPress:Common::KEYCODE_END withModifierFlags:0];
+	} else {
+		[softKeyboard handleKeyPress:Common::KEYCODE_RIGHT withModifierFlags:[self convertModifierFlags:keyCommand.modifierFlags]];
+	}
 }
 
 - (void) escapeKey: (UIKeyCommand *) keyCommand {

--- a/backends/platform/ios7/ios7_keyboard.mm
+++ b/backends/platform/ios7/ios7_keyboard.mm
@@ -310,6 +310,16 @@
 	return [self overloadKeys:letters withSelector:@selector(handleLetterKey:)];;
 }
 
+- (NSArray *)overloadNumbers {
+	NSString *numbers = @"0123456789";
+	NSMutableArray<NSString *> *numArray = [[NSMutableArray alloc] init];
+	for (NSUInteger x = 0; x < numbers.length; x++) {
+		unichar c = [numbers characterAtIndex:x];
+		[numArray addObject:[NSString stringWithCharacters:&c length:1]];
+	}
+	return [self overloadKeys:numArray withSelector:@selector(handleNumberKey:)];
+}
+
 - (int)convertModifierFlags:(UIKeyModifierFlags)flags {
 	return (((flags & UIKeyModifierShift) ? Common::KBD_SHIFT : 0) |
 		((flags & UIKeyModifierControl) ? Common::KBD_CTRL : 0) |
@@ -340,6 +350,59 @@
 	}
 	[softKeyboard handleKeyPress: c withModifierFlags:[self convertModifierFlags:keyCommand.modifierFlags]];
 }
+
+- (void)handleNumberKey:(UIKeyCommand *)keyCommand {
+	if (keyCommand.modifierFlags == UIKeyModifierCommand) {
+		switch ([[keyCommand input] characterAtIndex:0]) {
+		case '1':
+			[self fn1Key];
+			break;
+		case '2':
+			[self fn2Key];
+			break;
+		case '3':
+			[self fn3Key];
+			break;
+		case '4':
+			[self fn4Key];
+			break;
+		case '5':
+			[self fn5Key];
+			break;
+		case '6':
+			[self fn6Key];
+			break;
+		case '7':
+			[self fn7Key];
+			break;
+		case '8':
+			[self fn8Key];
+			break;
+		case '9':
+			[self fn9Key];
+			break;
+		case '0':
+			[self fn10Key];
+			break;
+		default:
+			break;
+		}
+	} else if (keyCommand.modifierFlags == (UIKeyModifierCommand | UIKeyModifierShift)) {
+		switch ([[keyCommand input] characterAtIndex:0]) {
+		case '1':
+			[self fn11Key];
+			break;
+		case '2':
+			[self fn12Key];
+			break;
+		default:
+			break;
+		}
+	} else {
+		[softKeyboard handleKeyPress: [[keyCommand input] characterAtIndex:0] withModifierFlags:[self convertModifierFlags:keyCommand.modifierFlags]];
+	}
+}
+
 
 - (NSArray *)keyCommands {
 	UIKeyCommand *upArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputUpArrow modifierFlags: 0 action: @selector(upArrow:)];

--- a/backends/platform/ios7/ios7_keyboard.mm
+++ b/backends/platform/ios7/ios7_keyboard.mm
@@ -469,16 +469,19 @@
 }
 
 - (NSArray *)keyCommands {
-	UIKeyCommand *upArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputUpArrow modifierFlags: 0 action: @selector(upArrow:)];
-	[self setWantsPriority: upArrow];
-	UIKeyCommand *downArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputDownArrow modifierFlags: 0 action: @selector(downArrow:)];
-	[self setWantsPriority: downArrow];
-	UIKeyCommand *leftArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputLeftArrow modifierFlags: 0 action: @selector(leftArrow:)];
-	[self setWantsPriority: leftArrow];
-	UIKeyCommand *rightArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputRightArrow modifierFlags: 0 action: @selector(rightArrow:)];
-	[self setWantsPriority: rightArrow];
-	UIKeyCommand *escapeKey = [UIKeyCommand keyCommandWithInput: UIKeyInputEscape modifierFlags: 0 action: @selector(escapeKey:)];
-	return [[NSArray alloc] initWithObjects: upArrow, downArrow, leftArrow, rightArrow, escapeKey, nil];
+	NSMutableArray<UIKeyCommand *> *overloadedKeys = [[NSMutableArray alloc] init];
+	// Arrows
+	[overloadedKeys addObjectsFromArray:[self overloadArrowKeys]];
+	// Roman letters
+	[overloadedKeys addObjectsFromArray:[self overloadRomanLetters]];
+	// Numbers
+	[overloadedKeys addObjectsFromArray:[self overloadNumbers]];
+	// FN keys
+	[overloadedKeys addObjectsFromArray:[self overloadFnKeys]];
+	// ESC, PAGE_UP, PAGE_DOWN, HOME, END
+	[overloadedKeys addObjectsFromArray:[self overloadSpecialKeys]];
+
+	return overloadedKeys;
 }
 
 - (void) upArrow: (UIKeyCommand *) keyCommand {

--- a/backends/platform/ios7/ios7_keyboard.mm
+++ b/backends/platform/ios7/ios7_keyboard.mm
@@ -320,6 +320,14 @@
 	return [self overloadKeys:numArray withSelector:@selector(handleNumberKey:)];
 }
 
+- (NSArray *)overloadFnKeys {
+	if (@available(iOS 13.4, *)) {
+		NSArray<NSString *> *fnKeys = [[NSArray alloc] initWithObjects:UIKeyInputF1, UIKeyInputF2, UIKeyInputF3, UIKeyInputF4, UIKeyInputF5, UIKeyInputF6, UIKeyInputF7, UIKeyInputF8, UIKeyInputF9, UIKeyInputF10, UIKeyInputF11, UIKeyInputF12, nil];
+		return [self overloadKeys:fnKeys withSelector:@selector(handleFnKey:)];
+	}
+	return nil;
+}
+
 - (int)convertModifierFlags:(UIKeyModifierFlags)flags {
 	return (((flags & UIKeyModifierShift) ? Common::KBD_SHIFT : 0) |
 		((flags & UIKeyModifierControl) ? Common::KBD_CTRL : 0) |
@@ -403,6 +411,35 @@
 	}
 }
 
+- (void)handleFnKey:(UIKeyCommand *)keyCommand {
+	if (@available(iOS 13.4, *)) {
+		if (keyCommand.input == UIKeyInputF1) {
+			[self fn1Key];
+		} else if (keyCommand.input == UIKeyInputF2) {
+			[self fn2Key];
+		} else if (keyCommand.input == UIKeyInputF3) {
+			[self fn3Key];
+		} else if (keyCommand.input == UIKeyInputF4) {
+			[self fn4Key];
+		} else if (keyCommand.input == UIKeyInputF5) {
+			[self fn5Key];
+		} else if (keyCommand.input == UIKeyInputF6) {
+			[self fn6Key];
+		} else if (keyCommand.input == UIKeyInputF7) {
+			[self fn7Key];
+		} else if (keyCommand.input == UIKeyInputF8) {
+			[self fn8Key];
+		} else if (keyCommand.input == UIKeyInputF9) {
+			[self fn9Key];
+		} else if (keyCommand.input == UIKeyInputF10) {
+			[self fn10Key];
+		} else if (keyCommand.input == UIKeyInputF11) {
+			[self fn11Key];
+		} else if (keyCommand.input == UIKeyInputF12) {
+			[self fn12Key];
+		}
+	}
+}
 
 - (NSArray *)keyCommands {
 	UIKeyCommand *upArrow = [UIKeyCommand keyCommandWithInput: UIKeyInputUpArrow modifierFlags: 0 action: @selector(upArrow:)];

--- a/backends/platform/ios7/ios7_keyboard.mm
+++ b/backends/platform/ios7/ios7_keyboard.mm
@@ -300,6 +300,16 @@
 	return [self overloadKeys:arrowKeys withSelector:@selector(handleArrowKey:)];
 }
 
+- (NSArray *)overloadRomanLetters {
+	NSString *romanLetters = @"abcdefghijklmnopqrstuvwxyz";
+	NSMutableArray<NSString *> *letters = [[NSMutableArray alloc] init];
+	for (NSUInteger x = 0; x < romanLetters.length; x++) {
+		unichar c = [romanLetters characterAtIndex:x];
+		[letters addObject:[NSString stringWithCharacters:&c length:1]];
+	}
+	return [self overloadKeys:letters withSelector:@selector(handleLetterKey:)];;
+}
+
 - (int)convertModifierFlags:(UIKeyModifierFlags)flags {
 	return (((flags & UIKeyModifierShift) ? Common::KBD_SHIFT : 0) |
 		((flags & UIKeyModifierControl) ? Common::KBD_CTRL : 0) |
@@ -319,6 +329,16 @@
 	} else {
 		[self rightArrow:keyCommand];
 	}
+}
+
+- (void)handleLetterKey:(UIKeyCommand *)keyCommand {
+	UniChar c = [[keyCommand input] characterAtIndex:0];
+	if ((keyCommand.modifierFlags & UIKeyModifierShift) ||
+		(keyCommand.modifierFlags & UIKeyModifierAlphaShift)) {
+		// Convert to capital letter
+		c -= 32;
+	}
+	[softKeyboard handleKeyPress: c withModifierFlags:[self convertModifierFlags:keyCommand.modifierFlags]];
 }
 
 - (NSArray *)keyCommands {

--- a/backends/platform/ios7/ios7_osys_events.cpp
+++ b/backends/platform/ios7/ios7_osys_events.cpp
@@ -100,7 +100,7 @@ bool OSystem_iOS7::pollEvent(Common::Event &event) {
 			return false;
 
 		case kInputKeyPressed:
-			handleEvent_keyPressed(event, internalEvent.value1);
+			handleEvent_keyPressed(event, internalEvent.value1, internalEvent.value2);
 			break;
 
 		case kInputSwipe:
@@ -268,7 +268,7 @@ void OSystem_iOS7::handleEvent_applicationResumed() {
 	rebuildSurface();
 }
 
-void  OSystem_iOS7::handleEvent_keyPressed(Common::Event &event, int keyPressed) {
+void  OSystem_iOS7::handleEvent_keyPressed(Common::Event &event, int keyPressed, int modifierFlags) {
 	int ascii = keyPressed;
 	//printf("key: %i\n", keyPressed);
 
@@ -281,7 +281,7 @@ void  OSystem_iOS7::handleEvent_keyPressed(Common::Event &event, int keyPressed)
 	event.type = Common::EVENT_KEYDOWN;
 	_queuedInputEvent.type = Common::EVENT_KEYUP;
 
-	event.kbd.flags = _queuedInputEvent.kbd.flags = 0;
+	event.kbd.flags = _queuedInputEvent.kbd.flags = modifierFlags;
 	event.kbd.keycode = _queuedInputEvent.kbd.keycode = (Common::KeyCode)keyPressed;
 	event.kbd.ascii = _queuedInputEvent.kbd.ascii = ascii;
 	_queuedEventTime = getMillis() + kQueuedInputEventDelay;

--- a/backends/platform/ios7/ios7_osys_main.h
+++ b/backends/platform/ios7/ios7_osys_main.h
@@ -181,7 +181,7 @@ protected:
 	bool handleEvent_swipe(Common::Event &event, int direction, int touches);
 	bool handleEvent_tap(Common::Event &event, UIViewTapDescription type, int touches);
 	bool handleEvent_longPress(Common::Event &event, UIViewLongPressDescription type, int touches);
-	void handleEvent_keyPressed(Common::Event &event, int keyPressed);
+	void handleEvent_keyPressed(Common::Event &event, int keyPressed, int modifierFlags);
 	void handleEvent_orientationChanged(int orientation);
 	void handleEvent_touchModeChanged();
 	void handleEvent_applicationSuspended();

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -796,11 +796,11 @@ bool iOS7_fetchEvent(InternalEvent *event) {
 	[self addEvent:InternalEvent(kInputTap, kUIViewTapDouble, 2)];
 }
 
-- (void)handleKeyPress:(unichar)c {
+- (void)handleKeyPress:(unichar)c withModifierFlags:(int)f {
 	if (c == '`') {
-		[self addEvent:InternalEvent(kInputKeyPressed, '\033', 0)];
+		[self addEvent:InternalEvent(kInputKeyPressed, '\033', f)];
 	} else {
-		[self addEvent:InternalEvent(kInputKeyPressed, c, 0)];
+		[self addEvent:InternalEvent(kInputKeyPressed, c, f)];
 	}
 }
 


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->

Currently the key inputs are sent to the IOS7 event handler on calls
to the delegate function:
"textField:shouldChangeCharactersInRange:replacementString:"
So when typing on either the software keyboard or a connected HW
keyboard the input is handled by the hidden textfield that is in
focus. The delegate is called on each key input and the character
typed is passed to the IOS7 event handler.

Doing as above has the drawback that if they user holds down a key,
common in games when shooting or moving, the key event is only sent
once. The delegate function is only called once per distinct key
press.

By implementing the keyCommands function and create UIKeyCommands
for a set of keys, the system will call a defined callback function.
This also enables repeatedly calls as long as the key is held down.

Modifier keys can also be configured to create UIKeyCommands to
trigger custom actions. This way we can overload the key functions
when they are pressed at the same time as a modifier key.

Add helper funtions that can be used to create UIKeyCommands for
a set of keys. Keys are represented by their input, e.g. the key
for the character 'c' is defined as a string with only one char,
the 'c', while special keys are represeented by strings defined
by the OS.

Register UIKeyCommands for all types of modifier keys and add a
function that can convert system modifier flags to flags used by
ScummVM.
