### PR TITLE
DIRECTOR: Dump bitmap as PNGs when --dump-scripts is invoked

### DIFF
--- a/engines/director/castmember/bitmap.cpp
+++ b/engines/director/castmember/bitmap.cpp
@@ -19,12 +19,14 @@
  *
  */
 
+#include "common/config-manager.h"
 #include "common/macresman.h"
 #include "graphics/surface.h"
 #include "graphics/macgui/macwidget.h"
 #include "image/bmp.h"
 #include "image/jpeg.h"
 #include "image/pict.h"
+#include "image/png.h"
 
 #include "director/director.h"
 #include "director/cast.h"
@@ -585,6 +587,19 @@ void BitmapCastMember::load() {
 					}
 
 					debugC(5, kDebugImages, "BitmapCastMember::load(): Bitmap: id: %d, w: %d, h: %d, flags1: %x, flags2: %x bytes: %x, bpp: %d clut: %s", imgId, surf->w, surf->h, _flags1, _flags2, _bytes, _bitsPerPixel, _clut.asString().c_str());
+
+					if (ConfMan.getBool("dump_scripts")) {
+
+						Common::String prepend = "stream";
+						Common::String filename = Common::String::format("./dumps/%s-%s-%d.png", encodePathForDump(prepend).c_str(), tag2str(tag), imgId);
+						Common::DumpFile bitmapFile;
+
+						bitmapFile.open(Common::Path(filename), true);
+						Image::writePNG(bitmapFile, *decoder->getSurface(), decoder->getPalette());
+
+						bitmapFile.close();
+					}
+
 					delete pic;
 					delete decoder;
 					_loaded = true;
@@ -644,6 +659,18 @@ void BitmapCastMember::load() {
 	}
 
 	setPicture(*img, true);
+
+	if (ConfMan.getBool("dump_scripts")) {
+
+		Common::String prepend = "stream";
+		Common::String filename = Common::String::format("./dumps/%s-%s-%d.png", encodePathForDump(prepend).c_str(), tag2str(tag), imgId);
+		Common::DumpFile bitmapFile;
+
+		bitmapFile.open(Common::Path(filename), true);
+		Image::writePNG(bitmapFile, *img->getSurface(), img->getPalette());
+
+		bitmapFile.close();
+	}
 
 	delete img;
 	delete pic;


### PR DESCRIPTION
This Dumps all Bitmap cast members into PNGs when --dump-scripts is invoked.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
