### PR TITLE
GUI: Add ability to force DPI scaling via config

### DIFF
--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -25,6 +25,7 @@
 
 #include "common/textconsole.h"
 #include "common/util.h"
+#include "common/config-manager.h"
 
 #include "icons/scummvm.xpm"
 
@@ -289,6 +290,9 @@ void SdlWindow::getDisplayDpi(float *dpi, float *defaultDpi) const {
 }
 
 float SdlWindow::getDpiScalingFactor() const {
+	if (ConfMan.hasKey("forced_dpi_scaling"))
+		return ConfMan.getInt("forced_dpi_scaling") / 100.f;
+
 	float dpi, defaultDpi;
 	getDisplayDpi(&dpi, &defaultDpi);
 	float ratio = dpi / defaultDpi;

--- a/doc/docportal/advanced_topics/configuration_file.rst
+++ b/doc/docportal/advanced_topics/configuration_file.rst
@@ -227,6 +227,7 @@ There are many recognized configuration keys. In the table below, each key is ei
 		":ref:`font_override <fontoverride>`",boolean,false,
 		":ref:`footsteps <footsteps>`",boolean,true,
 		":ref:`force_2d_renderer <2d>`",boolean,false,
+		forced_dpi_scaling,integer,,"Overrides DPI scaling factor reported by the system."
 		":ref:`frameLimit <framelimit>`",boolean,true,
 		":ref:`frameSkip <frameskip>`",boolean,false,
 		":ref:`frames_per_secondfl <fpsfl>`",boolean,false,


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->

Adds a config option `forced_dpi_scaling` to override the DPI scaling reported by the system.  Useful for locked down systems where the reported value is consistently incorrect or if users want to override their system value for whatever reason.  
For instance, we force this value to `100` on builds sent to Steam Decks.

This is pretty much a hack-workaround, so understandable if this doesn't get merged.