### PR TITLE
DIRECTOR: Manage filmloop composed of other filmloops.

### DIFF
--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -121,6 +121,12 @@ CastMember *Cast::getCastMember(int castId, bool load) {
 		_loadMutex = false;
 		result->load();
 		while (!_loadQueue.empty()) {
+			// prevents double loading of a filmloop of filmloop
+			if (_loadQueue.back()->_type == kCastFilmLoop) {
+				CastMember *subfilmloop = _loadQueue.back();
+				_loadQueue.pop_back();
+				subfilmloop->load();
+			}
 			_loadQueue.back()->load();
 			_loadQueue.pop_back();
 		}

--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -472,10 +472,12 @@ void Sprite::setCast(CastMemberID memberID) {
 				}
 			}
 			break;
+		case kCastFilmLoop:
 		case kCastShape:
 		case kCastText: 	// fall-through
 			break;
 		default:
+			debugC(3, kDebugImages, "Sprite::setCast(): Setting bbox of castId %s , type: %s to 0", memberID.asString().c_str(), castType2str(_cast->_type));
 			_width = dims.width();
 			_height = dims.height();
 			break;


### PR DESCRIPTION
This patch adds support for filmloops composed of other filmloops. It also fixes a bug in the filmloop bbox computation during Sprite::setCast() , we have to create a case kCastFilmLoop to prevent it from going to default case as the default case equates it to dims which is initialrect (0 value) , so the setCast function basically made film loop bbox 0.

trello link:- https://trello.com/c/uOzokEHj/712-fish-in-aquarium-is-not-displayed


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
