### PR TITLE
SURFACESDL: [RFC] Possible fix for scaler crash (bug #14872)

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -683,6 +683,11 @@ void SurfaceSdlGraphicsManager::setGraphicsModeIntern() {
 
 		_scalerPlugin = &_scalerPlugins[_videoMode.scalerIndex]->get<ScalerPluginObject>();
 		_scaler = _scalerPlugin->createInstance(format);
+
+		if (_mouseScaler != nullptr) {
+			delete _mouseScaler;
+			_mouseScaler = _scalerPlugin->createInstance(_cursorFormat);
+		}
 	}
 
 	_scaler->setFactor(_videoMode.scaleFactor);


### PR DESCRIPTION
As discussed in https://bugs.scummvm.org/ticket/14872 it seems like when the scaler changes, the cursor scaler doesn't always change along with it. In this particular bug report, that caused it to use the HQ scaler for the mouse cursor, which normally isn't allowed. That, in combination with some hinky pointer arithmetics (that's also described in the bug report), then caused ScummVM to crash.

I hope that changing SurfaceSdlGraphicsManager::setGraphicsModeIntern() to refresh _mouseScaler along with _scaler (though only if there is a _mouseScaler to begin with, since I don't know if that's guaranteed) is the correct fix for it. I don't call _mouseScaler_>setFactor() because that's always left to SurfaceSdlGraphicsManager::blitCursor().

I don't know if the crash also points to some bug in the HQ scaler, and unfortunately I have only been able to reproduce the crash with the Macintosh versions of Loom and Indiana Jones and the Last Crusade so far.