### PR TITLE
SCUMM: Fix GCC warnings

### DIFF
--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -161,7 +161,7 @@ void Actor::initActor(int mode) {
 		memset(_animVariable, 0, sizeof(_animVariable));
 		memset(_palette, 0, sizeof(_palette));
 		memset(_sound, 0, sizeof(_sound));
-		memset(&_cost, 0, sizeof(CostumeData));
+		_cost.reset();
 		_walkdata.reset();
 		_walkdata.point3.x = 32000;
 		_walkScript = 0;

--- a/engines/scumm/actor.h
+++ b/engines/scumm/actor.h
@@ -46,12 +46,8 @@ enum MoveFlags {
 };
 
 struct CostumeData {
-	CostumeData() : animCounter(0), soundCounter(0), soundPos(0), stopped(0) {
-		memset(animType, 0, sizeof(animType));
-		memset(curpos, 0xFF, sizeof(curpos));
-		memset(start, 0xFF, sizeof(start));
-		memset(end, 0xFF, sizeof(end));
-		memset(frame, 0xFF, sizeof(frame));
+	CostumeData() {
+		reset();
 	}
 
 	byte animType[16];
@@ -70,11 +66,15 @@ struct CostumeData {
 	uint32 heCondMaskTable[16];
 
 	void reset() {
+		animCounter = 0;
+		soundCounter = 0;
+		soundPos = 0;
 		stopped = 0;
-		for (int i = 0; i < 16; i++) {
-			animType[i] = 0; // AKAT_Empty
-			curpos[i] = start[i] = end[i] = frame[i] = 0xFFFF;
-		}
+		memset(animType, 0, sizeof(animType)); // AKAT_Empty
+		memset(curpos, 0xFF, sizeof(curpos));
+		memset(start, 0xFF, sizeof(start));
+		memset(end, 0xFF, sizeof(end));
+		memset(frame, 0xFF, sizeof(frame));
 	}
 };
 

--- a/engines/scumm/imuse/imuse_player.cpp
+++ b/engines/scumm/imuse/imuse_player.cpp
@@ -424,7 +424,7 @@ void Player::sysEx(const byte *p, uint16 len) {
 			snprintf((char *)&buf[a * 3], 3 * sizeof(char) + 1, " %02X", (int)p[a]);
 		}
 		if (a < len + 1 && (a * 3 < sizeof(buf) - 2)) {
-			if (a * 3 + 2 < sizeof(buf))
+			if (a * 3 + 2 < int(sizeof(buf)))
 				buf[a * 3] = buf[a * 3 + 1] = buf[a * 3 + 2] = '.';
 			else
 				warning("Player::sysEx(): Message too long (truncated)");

--- a/engines/scumm/players/player_mac_indy3.cpp
+++ b/engines/scumm/players/player_mac_indy3.cpp
@@ -848,7 +848,6 @@ I3MPlayer::I3MPlayer(ScummEngine *vm, Audio::Mixer *mixer) : _vm(vm), _mixer(mix
 	assert(_musicChannels);
 	for (int i = 0; i < _numMusicChannels; ++i)
 		_musicChannels[i] = new MusicChannel(this);
-	memset(&_pcmSnd, 0, sizeof(_pcmSnd));
 }
 
 I3MPlayer::~I3MPlayer() {


### PR DESCRIPTION
* warning: comparison of integer expressions of different signedness
* memset clearing an object of non-trivial type
