### PR TITLE
GRAPHICS: Define struct for Palette

### DIFF
--- a/backends/graphics/default-palette.h
+++ b/backends/graphics/default-palette.h
@@ -34,7 +34,7 @@
  */
 class DefaultPaletteManager : public PaletteManager {
 protected:
-	byte _palette[3 * 256];
+	Graphics::Palette _palette;
 
 	/**
 	 * Subclasses should only implement this method and none of the others.
@@ -46,13 +46,11 @@ protected:
 
 public:
 	void setPalette(const byte *colors, uint start, uint num) {
-		assert(start + num <= 256);
-		memcpy(_palette + 3 * start, colors, 3 * num);
+		_palette.set(colors, start, num);
 		setPaletteIntern(colors, start, num);
 	}
 	void grabPalette(byte *colors, uint start, uint num) const {
-		assert(start + num <= 256);
-		memcpy(colors, _palette + 3 * start, 3 * num);
+		_palette.grab(colors, start, num);
 	}
 };
 

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -353,7 +353,7 @@ protected:
 	/**
 	 * The game palette if in CLUT8 mode.
 	 */
-	byte _gamePalette[3 * 256];
+	Graphics::Palette _gamePalette;
 
 	//
 	// Overlay
@@ -444,7 +444,7 @@ protected:
 	/**
 	 * The special cursor palette in case enabled.
 	 */
-	byte _cursorPalette[3 * 256];
+	Graphics::Palette _cursorPalette;
 
 #ifdef USE_SCALERS
 	/**

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -1557,9 +1557,7 @@ bool SurfaceSdlGraphicsManager::saveScreenshot(const Common::Path &filename) con
 	if (sdlPalette) {
 		Graphics::Palette palette(256);
 		for (int i = 0; i < sdlPalette->ncolors; i++) {
-			palette.data[(i * 3) + 0] = sdlPalette->colors[i].r;
-			palette.data[(i * 3) + 1] = sdlPalette->colors[i].g;
-			palette.data[(i * 3) + 2] = sdlPalette->colors[i].b;
+			palette.set(i, sdlPalette->colors[i].r, sdlPalette->colors[i].g, sdlPalette->colors[i].b);
 		}
 
 #ifdef USE_PNG

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -1555,17 +1555,17 @@ bool SurfaceSdlGraphicsManager::saveScreenshot(const Common::Path &filename) con
 
 	SDL_Palette *sdlPalette = _hwScreen->format->palette;
 	if (sdlPalette) {
-		byte palette[256 * 3];
+		Graphics::Palette palette(256);
 		for (int i = 0; i < sdlPalette->ncolors; i++) {
-			palette[(i * 3) + 0] = sdlPalette->colors[i].r;
-			palette[(i * 3) + 1] = sdlPalette->colors[i].g;
-			palette[(i * 3) + 2] = sdlPalette->colors[i].b;
+			palette.data[(i * 3) + 0] = sdlPalette->colors[i].r;
+			palette.data[(i * 3) + 1] = sdlPalette->colors[i].g;
+			palette.data[(i * 3) + 2] = sdlPalette->colors[i].b;
 		}
 
 #ifdef USE_PNG
-		success = Image::writePNG(out, data, palette);
+		success = Image::writePNG(out, data, palette.data);
 #else
-		success = Image::writeBMP(out, data, palette);
+		success = Image::writeBMP(out, data, palette.data);
 #endif
 	} else {
 #ifdef USE_PNG

--- a/engines/chewy/video/cfo_decoder.cpp
+++ b/engines/chewy/video/cfo_decoder.cpp
@@ -326,16 +326,16 @@ void CfoDecoder::CfoVideoTrack::handleCustomFrame() {
 void CfoDecoder::CfoVideoTrack::fadeOut() {
 	for (int j = 0; j < 64; j++) {
 		for (int i = 0; i < 256; i++) {
-			if (_palette[i * 3 + 0] > 0)
-				--_palette[i * 3 + 0];
-			if (_palette[i * 3 + 1] > 0)
-				--_palette[i * 3 + 1];
-			if (_palette[i * 3 + 2] > 0)
-				--_palette[i * 3 + 2];
+			if (_palette.data[i * 3 + 0] > 0)
+				--_palette.data[i * 3 + 0];
+			if (_palette.data[i * 3 + 1] > 0)
+				--_palette.data[i * 3 + 1];
+			if (_palette.data[i * 3 + 2] > 0)
+				--_palette.data[i * 3 + 2];
 		}
 
 		//setScummVMPalette(_palette, 0, 256);
-		g_system->getPaletteManager()->setPalette(_palette, 0, 256);
+		g_system->getPaletteManager()->setPalette(_palette.data, 0, 256);
 		g_system->updateScreen();
 		g_system->delayMillis(10);
 	}

--- a/engines/director/cursor.h
+++ b/engines/director/cursor.h
@@ -53,7 +53,7 @@ class Cursor : public Graphics::MacCursor {
 	bool operator==(const CursorRef &c);
 
 	byte getKeyColor() const override { return _keyColor; }
-	const byte *getPalette() const override { return _usePalette ? _palette : nullptr; }
+	const byte *getPalette() const override { return _usePalette ? _palette.data : nullptr; }
 
  public:
 	Graphics::MacCursorType _cursorType;

--- a/engines/mtropolis/plugin/mti.cpp
+++ b/engines/mtropolis/plugin/mti.cpp
@@ -416,7 +416,7 @@ class PrintModifierImageSupplier : public GUI::ImageAlbumImageSupplier {
 public:
 	PrintModifierImageSupplier(const Common::String &inputPath, bool isMacVersion);
 
-	bool loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, byte (&outPalette)[256 * 3], GUI::ImageAlbumImageMetadata &outMetadata) override;
+	bool loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, Graphics::Palette &outPalette, GUI::ImageAlbumImageMetadata &outMetadata) override;
 	void releaseImageSlot(uint slot) override;
 	uint getNumSlots() const override;
 	Common::U32String getDefaultFileNameForSlot(uint slot) const override;
@@ -437,7 +437,7 @@ PrintModifierImageSupplier::PrintModifierImageSupplier(const Common::String &inp
 		_decoder.reset(new Image::BitmapDecoder());
 }
 
-bool PrintModifierImageSupplier::loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, byte (&outPalette)[256 * 3], GUI::ImageAlbumImageMetadata &outMetadata) {
+bool PrintModifierImageSupplier::loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, Graphics::Palette &outPalette, GUI::ImageAlbumImageMetadata &outMetadata) {
 	Common::ScopedPtr<Common::SeekableReadStream> dataStream(createReadStreamForSlot(slot));
 
 	if (!dataStream)
@@ -454,7 +454,7 @@ bool PrintModifierImageSupplier::loadImageSlot(uint slot, const Graphics::Surfac
 	outHasPalette = _decoder->hasPalette();
 
 	if (_decoder->hasPalette())
-		memcpy(outPalette + _decoder->getPaletteStartIndex() * 3, _decoder->getPalette(), _decoder->getPaletteColorCount() * 3);
+		outPalette.set(_decoder->getPalette(), _decoder->getPaletteStartIndex(), _decoder->getPaletteColorCount());
 
 	outMetadata = GUI::ImageAlbumImageMetadata();
 	outMetadata._orientation = GUI::kImageAlbumImageOrientationLandscape;

--- a/engines/testbed/misc.cpp
+++ b/engines/testbed/misc.cpp
@@ -23,6 +23,8 @@
 #include "common/timer.h"
 #include "common/file.h"
 
+#include "graphics/palette.h"
+
 #include "gui/dialog.h"
 #include "gui/imagealbum-dialog.h"
 
@@ -192,7 +194,7 @@ class ImageAlbumImageSupplier : public GUI::ImageAlbumImageSupplier {
 public:
 	void addFile(const Common::Path &path, Common::FormatInfo::FormatID format, bool dontReportFormat);
 
-	bool loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, byte (&outPalette)[256 * 3], GUI::ImageAlbumImageMetadata &outMetadata) override;
+	bool loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, Graphics::Palette &outPalette, GUI::ImageAlbumImageMetadata &outMetadata) override;
 	void releaseImageSlot(uint slot) override;
 	bool getFileFormatForImageSlot(uint slot, Common::FormatInfo::FormatID &outFormat) const override;
 	Common::SeekableReadStream *createReadStreamForSlot(uint slot) override;
@@ -217,7 +219,7 @@ void ImageAlbumImageSupplier::addFile(const Common::Path &path, Common::FormatIn
 	_slots.push_back(FileInfo(path, format, dontReportFormat));
 }
 
-bool ImageAlbumImageSupplier::loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, byte (&outPalette)[256 * 3], GUI::ImageAlbumImageMetadata &outMetadata) {
+bool ImageAlbumImageSupplier::loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, Graphics::Palette &outPalette, GUI::ImageAlbumImageMetadata &outMetadata) {
 
 	FileInfo &fi = _slots[slot];
 
@@ -244,7 +246,7 @@ bool ImageAlbumImageSupplier::loadImageSlot(uint slot, const Graphics::Surface *
 	outSurface = fi._decoder->getSurface();
 	outHasPalette = fi._decoder->hasPalette();
 	if (fi._decoder->hasPalette())
-		memcpy(outPalette, fi._decoder->getPalette() + fi._decoder->getPaletteStartIndex() * 3, fi._decoder->getPaletteColorCount() * 3);
+		outPalette.set(fi._decoder->getPalette(), fi._decoder->getPaletteStartIndex(), fi._decoder->getPaletteColorCount());
 	outMetadata = GUI::ImageAlbumImageMetadata();
 
 	return true;

--- a/graphics/maccursor.cpp
+++ b/graphics/maccursor.cpp
@@ -25,12 +25,7 @@
 
 namespace Graphics {
 
-MacCursor::MacCursor() {
-	_surface = 0;
-	memset(_palette, 0, 256 * 3);
-
-	_hotspotX = 0;
-	_hotspotY = 0;
+MacCursor::MacCursor() : _surface(nullptr), _palette(256), _hotspotX(0), _hotspotY(0) {
 }
 
 MacCursor::~MacCursor() {
@@ -38,8 +33,9 @@ MacCursor::~MacCursor() {
 }
 
 void MacCursor::clear() {
-	delete[] _surface; _surface = 0;
-	memset(_palette, 0, 256 * 3);
+	delete[] _surface;
+	_surface = nullptr;
+	_palette.clear();
 }
 
 bool MacCursor::readFromStream(Common::SeekableReadStream &stream, bool forceMonochrome, byte monochromeInvertedPixelColor, bool forceCURSFormat) {
@@ -82,9 +78,9 @@ bool MacCursor::readFromCURS(Common::SeekableReadStream &stream, byte monochrome
 	_hotspotX = stream.readUint16BE();
 
 	// Setup a basic palette
-	_palette[1 * 3 + 0] = 0xff;
-	_palette[1 * 3 + 1] = 0xff;
-	_palette[1 * 3 + 2] = 0xff;
+	_palette.data[1 * 3 + 0] = 0xff;
+	_palette.data[1 * 3 + 1] = 0xff;
+	_palette.data[1 * 3 + 2] = 0xff;
 
 	return !stream.eos();
 }
@@ -157,18 +153,18 @@ bool MacCursor::readFromCRSR(Common::SeekableReadStream &stream, bool forceMonoc
 	// Read just high byte of 16-bit color
 	for (int c = 0; c < ctSize; c++) {
 		stream.readUint16BE();
-		_palette[c * 3 + 0] = stream.readUint16BE() >> 8;
-		_palette[c * 3 + 1] = stream.readUint16BE() >> 8;
-		_palette[c * 3 + 2] = stream.readUint16BE() >> 8;
+		_palette.data[c * 3 + 0] = stream.readUint16BE() >> 8;
+		_palette.data[c * 3 + 1] = stream.readUint16BE() >> 8;
+		_palette.data[c * 3 + 2] = stream.readUint16BE() >> 8;
 	}
 
 	// Find black so that Macintosh black (255) can be remapped.
 	// This is necessary because we use 255 for the color key.
 	byte black = 0;
 	for (byte c = 0; c < 255; c++) {
-		if (_palette[c * 3 + 0] == 0 &&
-			_palette[c * 3 + 1] == 0 &&
-			_palette[c * 3 + 2] == 0) {
+		if (_palette.data[c * 3 + 0] == 0 &&
+			_palette.data[c * 3 + 1] == 0 &&
+			_palette.data[c * 3 + 2] == 0) {
 			black = c;
 			break;
 		}

--- a/graphics/maccursor.cpp
+++ b/graphics/maccursor.cpp
@@ -78,9 +78,7 @@ bool MacCursor::readFromCURS(Common::SeekableReadStream &stream, byte monochrome
 	_hotspotX = stream.readUint16BE();
 
 	// Setup a basic palette
-	_palette.data[1 * 3 + 0] = 0xff;
-	_palette.data[1 * 3 + 1] = 0xff;
-	_palette.data[1 * 3 + 2] = 0xff;
+	_palette.set(1, 0xff, 0xff, 0xff);
 
 	return !stream.eos();
 }
@@ -162,9 +160,9 @@ bool MacCursor::readFromCRSR(Common::SeekableReadStream &stream, bool forceMonoc
 	// This is necessary because we use 255 for the color key.
 	byte black = 0;
 	for (byte c = 0; c < 255; c++) {
-		if (_palette.data[c * 3 + 0] == 0 &&
-			_palette.data[c * 3 + 1] == 0 &&
-			_palette.data[c * 3 + 2] == 0) {
+		byte r, g, b;
+		_palette.get(c, r, g, b);
+		if (r == 0 && g == 0 && b == 0) {
 			black = c;
 			break;
 		}

--- a/graphics/maccursor.cpp
+++ b/graphics/maccursor.cpp
@@ -158,15 +158,9 @@ bool MacCursor::readFromCRSR(Common::SeekableReadStream &stream, bool forceMonoc
 
 	// Find black so that Macintosh black (255) can be remapped.
 	// This is necessary because we use 255 for the color key.
-	byte black = 0;
-	for (byte c = 0; c < 255; c++) {
-		byte r, g, b;
-		_palette.get(c, r, g, b);
-		if (r == 0 && g == 0 && b == 0) {
-			black = c;
-			break;
-		}
-	}
+	uint black = _palette.find(0, 0, 0);
+	if (black == Palette::npos || black == 255)
+		black = 0;
 
 	int pixelsPerByte = (iconBounds[2] - iconBounds[0]) / iconRowBytes;
 	int bpp           = 8 / pixelsPerByte;

--- a/graphics/maccursor.h
+++ b/graphics/maccursor.h
@@ -39,6 +39,7 @@
 #include "common/stream.h"
 
 #include "graphics/cursor.h"
+#include "graphics/palette.h"
 
 namespace Graphics {
 
@@ -63,9 +64,9 @@ public:
 
 	const byte *getSurface() const { return _surface; }
 
-	virtual const byte *getPalette() const { return _palette; }
+	virtual const byte *getPalette() const { return _palette.data; }
 	byte getPaletteStartIndex() const { return 0; }
-	uint16 getPaletteCount() const { return 256; }
+	uint16 getPaletteCount() const { return _palette.size; }
 
 	/** Read the cursor's data out of a stream. */
 	bool readFromStream(Common::SeekableReadStream &stream, bool forceMonochrome = false, byte monochromeInvertedPixelColor = 0xff, bool forceCURSFormat = false);
@@ -75,7 +76,7 @@ protected:
 	bool readFromCRSR(Common::SeekableReadStream &stream, bool forceMonochrome, byte monochromeInvertedPixelColor);
 
 	byte *_surface;
-	byte _palette[256 * 3];
+	Palette _palette;
 
 	uint16 _hotspotX; ///< The cursor's hotspot's x coordinate.
 	uint16 _hotspotY; ///< The cursor's hotspot's y coordinate.

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -214,8 +214,7 @@ MacWindowManager::MacWindowManager(uint32 mode, MacPatterns *patterns, Common::L
 	if (g_system->getScreenFormat().isCLUT8())
 		g_system->getPaletteManager()->setPalette(palette, 0, ARRAYSIZE(palette) / 3);
 
-	_palette.set(palette, 0, ARRAYSIZE(palette) / 3);
-	_paletteLookup.setPalette(_palette);
+	_paletteLookup.setPalette(palette, ARRAYSIZE(palette) / 3);
 
 	_fontMan = new MacFontManager(mode, language);
 
@@ -1366,9 +1365,7 @@ void MacWindowManager::popCursor() {
 #define LOOKUPCOLOR(x) _color ## x = findBestColor(palette[kColor ## x * 3], palette[kColor ## x  * 3 + 1], palette[kColor ## x * 3 + 2]);
 
 void MacWindowManager::passPalette(const byte *pal, uint size) {
-	_palette.size = size;
-	_palette.set(pal, 0, size);
-	_paletteLookup.setPalette(_palette);
+	_paletteLookup.setPalette(pal, size);
 
 	LOOKUPCOLOR(White);
 	LOOKUPCOLOR(Gray80);
@@ -1396,9 +1393,10 @@ void MacWindowManager::decomposeColor<uint32>(uint32 color, byte &r, byte &g, by
 
 template <>
 void MacWindowManager::decomposeColor<byte>(uint32 color, byte& r, byte& g, byte& b) {
-	r = *(_palette.data + 3 * (byte)color + 0);
-	g = *(_palette.data + 3 * (byte)color + 1);
-	b = *(_palette.data + 3 * (byte)color + 2);
+	const Palette &palette = _paletteLookup.getPalette();
+	r = *(palette.data + 3 * (byte)color + 0);
+	g = *(palette.data + 3 * (byte)color + 1);
+	b = *(palette.data + 3 * (byte)color + 2);
 }
 
 uint32 MacWindowManager::findBestColor(uint32 color) {

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -1393,10 +1393,7 @@ void MacWindowManager::decomposeColor<uint32>(uint32 color, byte &r, byte &g, by
 
 template <>
 void MacWindowManager::decomposeColor<byte>(uint32 color, byte& r, byte& g, byte& b) {
-	const Palette &palette = _paletteLookup.getPalette();
-	r = *(palette.data + 3 * (byte)color + 0);
-	g = *(palette.data + 3 * (byte)color + 1);
-	b = *(palette.data + 3 * (byte)color + 2);
+	_paletteLookup.getPalette().get(color, r, g, b);
 }
 
 uint32 MacWindowManager::findBestColor(uint32 color) {

--- a/graphics/macgui/macwindowmanager.h
+++ b/graphics/macgui/macwindowmanager.h
@@ -350,8 +350,8 @@ public:
 
 	byte inverter(byte src);
 
-	const byte *getPalette() { return _palette.data; }
-	uint getPaletteSize() { return _palette.size; }
+	const byte *getPalette() { return _paletteLookup.getPalette().data; }
+	uint getPaletteSize() { return _paletteLookup.getPalette().size; }
 
 	void renderZoomBox(bool redraw = false);
 	void addZoomBox(ZoomBox *box);
@@ -451,7 +451,6 @@ private:
 
 	MacPatterns _patterns;
 	MacPatterns _builtinPatterns;
-	Palette _palette;
 
 	MacMenu *_menu;
 	uint32 _menuDelay;

--- a/graphics/macgui/macwindowmanager.h
+++ b/graphics/macgui/macwindowmanager.h
@@ -350,8 +350,8 @@ public:
 
 	byte inverter(byte src);
 
-	const byte *getPalette() { return _palette; }
-	uint getPaletteSize() { return _paletteSize; }
+	const byte *getPalette() { return _palette.data; }
+	uint getPaletteSize() { return _palette.size; }
 
 	void renderZoomBox(bool redraw = false);
 	void addZoomBox(ZoomBox *box);
@@ -451,8 +451,7 @@ private:
 
 	MacPatterns _patterns;
 	MacPatterns _builtinPatterns;
-	byte *_palette;
-	uint _paletteSize;
+	Palette _palette;
 
 	MacMenu *_menu;
 	uint32 _menuDelay;

--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -852,11 +852,13 @@ bool ManagedSurface::hasPalette() const {
 }
 
 void ManagedSurface::grabPalette(byte *colors, uint start, uint num) const {
-	_palette->grab(colors, start, num);
+	if (_palette)
+		_palette->grab(colors, start, num);
 }
 
 void ManagedSurface::grabPalette(Palette &palette, uint start, uint num) const {
-	_palette->grab(palette, start, num);
+	if (_palette)
+		_palette->grab(palette, start, num);
 }
 
 void ManagedSurface::setPalette(const byte *colors, uint start, uint num) {

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -33,6 +33,8 @@
 
 namespace Graphics {
 
+struct Palette;
+
 /**
  * @defgroup graphics_managed_surface Managed surface
  * @ingroup graphics
@@ -81,8 +83,8 @@ private:
 	/**
 	 * Local palette for 8-bit images.
 	 */
-	byte _palette[256 * 3];
-	bool _paletteSet;
+	Palette *_palette;
+
 protected:
 	/**
 	 * Inner method for blitting.
@@ -521,10 +523,7 @@ public:
 	 * Does a blitFrom ignoring any transparency settings
 	 */
 	void rawBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect,
-			const Common::Point &destPos) {
-		blitFromInner(src._innerSurface, srcRect, Common::Rect(destPos.x, destPos.y, destPos.x + srcRect.width(),
-			destPos.y + srcRect.height()), src._paletteSet ? src._palette : nullptr);
-	}
+					 const Common::Point &destPos);
 	
 	/**
 	 * ManagedSurface::blendBlitTo is meant to be a highly optimized
@@ -740,26 +739,24 @@ public:
 	/**
 	 * Clear any existing palette.
 	 */
-	void clearPalette() {
-		_paletteSet = false;
-	}
+	void clearPalette();
 
 	/**
 	 * Return true if a palette has been set.
 	 */
-	bool hasPalette() const {
-		return _paletteSet;
-	}
+	bool hasPalette() const;
 
 	/**
 	 * Grab the palette using RGB tuples.
 	 */
 	void grabPalette(byte *colors, uint start, uint num) const;
+	void grabPalette(Palette &palette, uint start, uint num) const;
 
 	/**
 	 * Set the palette using RGB tuples.
 	 */
 	void setPalette(const byte *colors, uint start, uint num);
+	void setPalette(const Palette &palette, uint start, uint num);
 };
 /** @} */
 } // End of namespace Graphics

--- a/graphics/nine_patch.cpp
+++ b/graphics/nine_patch.cpp
@@ -187,16 +187,16 @@ NinePatchBitmap::NinePatchBitmap(Graphics::ManagedSurface *bmp, bool owns_bitmap
 	uint32 black, white;
 
 	if (bmp->format.isCLUT8()) {
-		byte palette[256 * 3];
+		Palette palette(256);
 		bmp->grabPalette(palette, 0, 256);
 
 		black = (uint32)-1;
 		white = (uint32)-1;
 
 		for (int j = 0; j < 256; j++) {
-			byte r = palette[(j * 3) + 0];
-			byte g = palette[(j * 3) + 1];
-			byte b = palette[(j * 3) + 2];
+			byte r = palette.data[(j * 3) + 0];
+			byte g = palette.data[(j * 3) + 1];
+			byte b = palette.data[(j * 3) + 2];
 
 			if (black == uint32(-1) && r == 0 && g == 0 && b == 0)
 				black = j;
@@ -306,16 +306,16 @@ void NinePatchBitmap::blit(Graphics::ManagedSurface &target, int dx, int dy, int
 		drawRegions(*srf, dx, dy, dw, dh);
 
 		if (srf->format.isCLUT8()) {
-			uint8 palette[256 * 3];
+			Palette palette(256);
 			_bmp->grabPalette(palette, 0, 256);
 
 			for (int i = 0; i < srf->w; ++i) {
 				for (int j = 0; j < srf->h; ++j) {
 					byte color = *(byte*)srf->getBasePtr(i, j);
 					if (color != transColor) {
-						byte r = palette[(color * 3) + 0];
-						byte g = palette[(color * 3) + 1];
-						byte b = palette[(color * 3) + 2];
+						byte r = palette.data[(color * 3) + 0];
+						byte g = palette.data[(color * 3) + 1];
+						byte b = palette.data[(color * 3) + 2];
 						*((byte *)target.getBasePtr(i, j)) = wm->findBestColor(r, g, b);
 					}
 				}

--- a/graphics/nine_patch.cpp
+++ b/graphics/nine_patch.cpp
@@ -194,9 +194,8 @@ NinePatchBitmap::NinePatchBitmap(Graphics::ManagedSurface *bmp, bool owns_bitmap
 		white = (uint32)-1;
 
 		for (int j = 0; j < 256; j++) {
-			byte r = palette.data[(j * 3) + 0];
-			byte g = palette.data[(j * 3) + 1];
-			byte b = palette.data[(j * 3) + 2];
+			byte r, g, b;
+			palette.get(j, r, g, b);
 
 			if (black == uint32(-1) && r == 0 && g == 0 && b == 0)
 				black = j;
@@ -313,9 +312,8 @@ void NinePatchBitmap::blit(Graphics::ManagedSurface &target, int dx, int dy, int
 				for (int j = 0; j < srf->h; ++j) {
 					byte color = *(byte*)srf->getBasePtr(i, j);
 					if (color != transColor) {
-						byte r = palette.data[(color * 3) + 0];
-						byte g = palette.data[(color * 3) + 1];
-						byte b = palette.data[(color * 3) + 2];
+						byte r, g, b;
+						palette.get(color, r, g, b);
 						*((byte *)target.getBasePtr(i, j)) = wm->findBestColor(r, g, b);
 					}
 				}

--- a/graphics/nine_patch.cpp
+++ b/graphics/nine_patch.cpp
@@ -190,20 +190,10 @@ NinePatchBitmap::NinePatchBitmap(Graphics::ManagedSurface *bmp, bool owns_bitmap
 		Palette palette(256);
 		bmp->grabPalette(palette, 0, 256);
 
-		black = (uint32)-1;
-		white = (uint32)-1;
+		black = palette.find(0, 0, 0);
+		white = palette.find(255, 255, 255);
 
-		for (int j = 0; j < 256; j++) {
-			byte r, g, b;
-			palette.get(j, r, g, b);
-
-			if (black == uint32(-1) && r == 0 && g == 0 && b == 0)
-				black = j;
-			else if (white == uint32(-1) && r == 255 && g == 255 && b == 255)
-				white = j;
-		}
-
-		if (black == uint32(-1) || white == uint32(-1))
+		if (black == Palette::npos || white == Palette::npos)
 			goto bad_bitmap;
 	} else {
 		black = bmp->format.RGBToColor(0, 0, 0);

--- a/graphics/palette.cpp
+++ b/graphics/palette.cpp
@@ -150,6 +150,21 @@ byte PaletteLookup::findBestColor(byte cr, byte cg, byte cb, bool useNaiveAlg) {
 	return bestColor;
 }
 
+uint32 *PaletteLookup::createMap(const byte *srcPalette, uint len, bool useNaiveAlg) {
+	if (len <= _palette.size && memcmp(_palette.data, srcPalette, len * 3) == 0)
+		return nullptr;
+
+	uint32 *map = new uint32[len];
+	for (uint i = 0; i < len; i++) {
+		byte r = *srcPalette++;
+		byte g = *srcPalette++;
+		byte b = *srcPalette++;
+
+		map[i] = findBestColor(r, g, b, useNaiveAlg);
+	}
+	return map;
+}
+
 uint32 *PaletteLookup::createMap(const Palette &srcPalette, bool useNaiveAlg) {
 	if (_palette.contains(srcPalette))
 		return nullptr;

--- a/graphics/palette.cpp
+++ b/graphics/palette.cpp
@@ -95,6 +95,7 @@ bool PaletteLookup::setPalette(const byte *palette, uint len) {
 		return false;
 
 	_palette.set(palette, 0, len);
+	_palette.size = len;
 	_colorHash.clear();
 
 	return true;

--- a/graphics/palette.h
+++ b/graphics/palette.h
@@ -111,6 +111,16 @@ public:
 
 namespace Graphics {
 
+/**
+ * @brief Simple struct for handling a palette data.
+ *
+ * The palette data is specified in interleaved RGB format. That is, the
+ * first byte of the memory block 'colors' points at is the red component
+ * of the first new color; the second byte the green component of the first
+ * new color; the third byte the blue component, the last byte to the alpha
+ * (transparency) value. Then the second color starts, and so on. So memory
+ * looks like this: R1-G1-B1-R2-G2-B2-R3-...
+ */
 struct Palette {
 	byte data[256 * 3];
 	uint size;
@@ -135,24 +145,11 @@ struct Palette {
 	 * The palette entries from 'start' till (start+num-1) will be replaced - so
 	 * a full palette update is accomplished via start=0, num=256.
 	 *
-	 * The palette data is specified in interleaved RGB format. That is, the
-	 * first byte of the memory block 'colors' points at is the red component
-	 * of the first new color; the second byte the green component of the first
-	 * new color; the third byte the blue component, the last byte to the alpha
-	 * (transparency) value. Then the second color starts, and so on. So memory
-	 * looks like this: R1-G1-B1-R2-G2-B2-R3-...
-	 *
 	 * @param colors	the new palette data, in interleaved RGB format
 	 * @param start		the first palette entry to be updated
 	 * @param num		the number of palette entries to be updated
 	 *
-	 * @note It is an error if start+num exceeds 256, behavior is undefined
-	 *       in that case (the backend may ignore it silently or assert).
-	 * @note It is an error if this function gets called when the pixel format
-	 *       in use (the return value of getScreenFormat) has more than one
-	 *       byte per pixel.
-	 *
-	 * @see getScreenFormat
+	 * @note It is an error if start+num exceeds 256.
 	 */
 	void set(const byte *colors, uint start, uint num);
 	void set(const Palette &p, uint start, uint num);
@@ -161,32 +158,11 @@ struct Palette {
 	 * Grabs a specified part of the currently active palette.
 	 * The format is the same as for setPalette.
 	 *
-	 * This should return exactly the same RGB data as was setup via previous
-	 * setPalette calls.
-	 *
-	 * For example, for every valid value of start and num of the following
-	 * code:
-	 *
-	 * byte origPal[num*3];
-	 * // Setup origPal's data however you like
-	 * g_system->setPalette(origPal, start, num);
-	 * byte obtainedPal[num*3];
-	 * g_system->grabPalette(obtainedPal, start, num);
-	 *
-	 * the following should be true:
-	 *
-	 * memcmp(origPal, obtainedPal, num*3) == 0
-	 *
-	 * @see setPalette
 	 * @param colors	the palette data, in interleaved RGB format
 	 * @param start		the first platte entry to be read
 	 * @param num		the number of palette entries to be read
 	 *
-	 * @note It is an error if this function gets called when the pixel format
-	 *       in use (the return value of getScreenFormat) has more than one
-	 *       byte per pixel.
-	 *
-	 * @see getScreenFormat
+	 * @note It is an error if start+num exceeds 256.
 	 */
 	void grab(byte *colors, uint start, uint num) const;
 	void grab(Palette &p, uint start, uint num) const;

--- a/graphics/palette.h
+++ b/graphics/palette.h
@@ -231,6 +231,7 @@ public:
 	 *
 	 * @return the created map, or nullptr if one isn't needed.
 	 */
+	uint32 *createMap(const byte *srcPalette, uint len, bool useNaiveAlg = false);
 	uint32 *createMap(const Palette &srcPalette, bool useNaiveAlg = false);
 
 private:

--- a/graphics/palette.h
+++ b/graphics/palette.h
@@ -190,6 +190,8 @@ public:
 	 */
 	PaletteLookup(const byte *palette, uint len);
 
+	const Palette &getPalette() const { return _palette; }
+
 	/**
 	 * @brief Pass palette to the look up. It also compares given palette
 	 * with the current one and resets cache only when their contents is different.

--- a/graphics/palette.h
+++ b/graphics/palette.h
@@ -134,6 +134,9 @@ struct Palette {
 
 	Palette(const Palette &p);
 
+	bool operator==(const Palette &rhs) const { return equals(rhs); }
+	bool operator!=(const Palette &rhs) const { return !equals(rhs); }
+
 	bool equals(const Palette &p) const;
 
 	bool contains(const Palette &p) const;

--- a/graphics/palette.h
+++ b/graphics/palette.h
@@ -141,6 +141,20 @@ struct Palette {
 
 	bool contains(const Palette &p) const;
 
+	void set(uint entry, byte r, byte g, byte b) {
+		assert(entry < size);
+		data[entry * 3 + 0] = r;
+		data[entry * 3 + 1] = g;
+		data[entry * 3 + 2] = b;
+	}
+
+	void get(uint entry, byte &r, byte &g, byte &b) const {
+		assert(entry < size);
+		r = data[entry * 3 + 0];
+		g = data[entry * 3 + 1];
+		b = data[entry * 3 + 2];
+	}
+
 	void clear();
 
 	/**

--- a/graphics/palette.h
+++ b/graphics/palette.h
@@ -122,8 +122,9 @@ namespace Graphics {
  * looks like this: R1-G1-B1-R2-G2-B2-R3-...
  */
 struct Palette {
+	static const uint16 npos = 0xFFFF;
 	byte data[256 * 3];
-	uint size;
+	uint16 size;
 
 	/**
 	 * @brief Construct a new Palette object
@@ -153,6 +154,19 @@ struct Palette {
 		r = data[entry * 3 + 0];
 		g = data[entry * 3 + 1];
 		b = data[entry * 3 + 2];
+	}
+
+	/**
+	 * Finds the index of an exact color from the palette.
+	 *
+	 * @return the palette index or npos if not found
+	 */
+	uint find(byte r, byte g, byte b) const {
+		for (uint i = 0; i < size; i++) {
+			if (data[i * 3 + 0] == r && data[i * 3 + 1] == g && data[i * 3 + 2] == b)
+				return i;
+		}
+		return npos;
 	}
 
 	void clear();

--- a/graphics/scaler/thumbnail_intern.cpp
+++ b/graphics/scaler/thumbnail_intern.cpp
@@ -208,7 +208,7 @@ static bool grabScreen565(Graphics::Surface *surf) {
 		}
 	}
 
-	delete[] palette;
+	delete palette;
 
 	g_system->unlockScreen();
 	return true;

--- a/graphics/scaler/thumbnail_intern.cpp
+++ b/graphics/scaler/thumbnail_intern.cpp
@@ -180,11 +180,11 @@ static bool grabScreen565(Graphics::Surface *surf) {
 
 	surf->create(screen->w, screen->h, Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0));
 
-	byte *palette = 0;
+	Graphics::Palette *palette = nullptr;
 	if (screenFormat.bytesPerPixel == 1) {
-		palette = new byte[256 * 3];
+		palette = new Graphics::Palette(256);
 		assert(palette);
-		g_system->getPaletteManager()->grabPalette(palette, 0, 256);
+		g_system->getPaletteManager()->grabPalette(palette->data, 0, palette->size);
 	}
 
 	for (int y = 0; y < screen->h; ++y) {
@@ -193,9 +193,9 @@ static bool grabScreen565(Graphics::Surface *surf) {
 
 			if (screenFormat.bytesPerPixel == 1) {
 				uint8 pixel = *(uint8 *)screen->getBasePtr(x, y);
-				r = palette[pixel * 3 + 0];
-				g = palette[pixel * 3 + 1];
-				b = palette[pixel * 3 + 2];
+				r = palette->data[pixel * 3 + 0];
+				g = palette->data[pixel * 3 + 1];
+				b = palette->data[pixel * 3 + 2];
 			} else if (screenFormat.bytesPerPixel == 2) {
 				uint16 col = READ_UINT16(screen->getBasePtr(x, y));
 				screenFormat.colorToRGB(col, r, g, b);
@@ -266,9 +266,9 @@ bool createThumbnail(Graphics::Surface *surf, Graphics::ManagedSurface *in) {
 	Graphics::Surface screen;
 
 	if (in->hasPalette()) {
-		uint8 palette[3 * 256];
+		Graphics::Palette palette(256);
 		in->grabPalette(palette, 0, 256);
-		return createThumbnail(surf, (const uint8 *)in->getPixels(), in->w, in->h, palette);
+		return createThumbnail(surf, (const uint8 *)in->getPixels(), in->w, in->h, palette.data);
 	} else {
 		screen.convertFrom(in->rawSurface(), Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0));
 		return createThumbnail(*surf, screen);

--- a/graphics/scaler/thumbnail_intern.cpp
+++ b/graphics/scaler/thumbnail_intern.cpp
@@ -193,9 +193,7 @@ static bool grabScreen565(Graphics::Surface *surf) {
 
 			if (screenFormat.bytesPerPixel == 1) {
 				uint8 pixel = *(uint8 *)screen->getBasePtr(x, y);
-				r = palette->data[pixel * 3 + 0];
-				g = palette->data[pixel * 3 + 1];
-				b = palette->data[pixel * 3 + 2];
+				palette->get(pixel, r, g, b);
 			} else if (screenFormat.bytesPerPixel == 2) {
 				uint16 col = READ_UINT16(screen->getBasePtr(x, y));
 				screenFormat.colorToRGB(col, r, g, b);

--- a/gui/imagealbum-dialog.cpp
+++ b/gui/imagealbum-dialog.cpp
@@ -21,6 +21,8 @@
 
 #include "gui/imagealbum-dialog.h"
 
+#include "graphics/palette.h"
+
 #include "gui/dialog.h"
 #include "gui/filebrowser-dialog.h"
 #include "gui/gui-manager.h"
@@ -164,11 +166,8 @@ void ImageAlbumDialog::changeToSlot(uint slot) {
 
 		const Graphics::Surface *surf = nullptr;
 		bool hasPalette = false;
-		byte palette[256 * 3];
+		Graphics::Palette palette(256);
 		ImageAlbumImageMetadata metadata;
-
-		for (byte &paletteByte : palette)
-			paletteByte = 0;
 
 		if (_imageSupplier->loadImageSlot(slot, surf, hasPalette, palette, metadata)) {
 			if (!canSaveImage) {
@@ -251,7 +250,7 @@ void ImageAlbumDialog::changeToSlot(uint slot) {
 			_imageSupplier->releaseImageSlot(slot);
 
 			if (rescaledGraphic.format.bytesPerPixel == 1)
-				rescaledGraphic.convertToInPlace(Graphics::createPixelFormat<888>(), palette, 0, 256);
+				rescaledGraphic.convertToInPlace(Graphics::createPixelFormat<888>(), palette.data, 0, 256);
 
 			int32 xCoord = (static_cast<int32>(_imageContainer->getWidth()) - static_cast<int32>(scaledWidth)) / 2u;
 			int32 yCoord = (static_cast<int32>(_imageContainer->getHeight()) - static_cast<int32>(scaledHeight)) / 2u;
@@ -379,11 +378,8 @@ void ImageAlbumDialog::saveImageInSlot(uint slot) {
 	if (needsConversion) {
 		const Graphics::Surface *surf = nullptr;
 		bool hasPalette = false;
-		byte palette[256 * 3];
+		Graphics::Palette palette(256);
 		ImageAlbumImageMetadata metadata;
-
-		for (byte &paletteByte : palette)
-			paletteByte = 0;
 
 		if (_imageSupplier->loadImageSlot(slot, surf, hasPalette, palette, metadata)) {
 			Common::ScopedPtr<Common::SeekableWriteStream> writeStream;
@@ -400,7 +396,7 @@ void ImageAlbumDialog::saveImageInSlot(uint slot) {
 					assert(saveCallback);
 
 					Common::FormatInfo::ImageSaveProperties saveProps;
-					saveCallback(*writeStream, *surf, hasPalette ? palette : nullptr, saveProps);
+					saveCallback(*writeStream, *surf, hasPalette ? palette.data : nullptr, saveProps);
 				} else {
 					warning("Failed to open image output stream");
 				}

--- a/gui/imagealbum-dialog.h
+++ b/gui/imagealbum-dialog.h
@@ -34,6 +34,7 @@ class SeekableReadStream;
 
 namespace Graphics {
 
+struct Palette;
 struct Surface;
 
 } // End of namespace Graphics
@@ -81,7 +82,7 @@ public:
 	 * @param outMetadata             Outputted metadata for the image
 	 * @return True if the image loaded successfully, false if it failed
 	 */
-	virtual bool loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, byte (&outPalette)[256 * 3], ImageAlbumImageMetadata &outMetadata) = 0;
+	virtual bool loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, Graphics::Palette &outPalette, ImageAlbumImageMetadata &outMetadata) = 0;
 
 	/**
 	 * @brief Releases any resources for an image loaded with loadImageSlot

--- a/image/codecs/cdtoons.cpp
+++ b/image/codecs/cdtoons.cpp
@@ -47,14 +47,13 @@ static Common::Rect readRect(Common::SeekableReadStream &stream) {
 	return rect;
 }
 
-CDToonsDecoder::CDToonsDecoder(uint16 width, uint16 height) {
+CDToonsDecoder::CDToonsDecoder(uint16 width, uint16 height) : _palette(256) {
 	debugN(5, "CDToons: width %d, height %d\n", width, height);
 
 	_surface = new Graphics::Surface();
 	_surface->create(width, height, Graphics::PixelFormat::createFormatCLUT8());
 
 	_currentPaletteId = 0;
-	memset(_palette, 0, 256 * 3);
 	_dirtyPalette = false;
 }
 
@@ -435,13 +434,13 @@ void CDToonsDecoder::setPalette(byte *data) {
 
 	// A lovely QuickTime palette
 	for (uint i = 0; i < 256; i++) {
-		_palette[i * 3]     = *data;
-		_palette[i * 3 + 1] = *(data + 2);
-		_palette[i * 3 + 2] = *(data + 4);
+		_palette.data[i * 3]     = *data;
+		_palette.data[i * 3 + 1] = *(data + 2);
+		_palette.data[i * 3 + 2] = *(data + 4);
 		data += 6;
 	}
 
-	_palette[0] = _palette[1] = _palette[2] = 0;
+	_palette.data[0] = _palette.data[1] = _palette.data[2] = 0;
 }
 
 } // End of namespace Image

--- a/image/codecs/cdtoons.cpp
+++ b/image/codecs/cdtoons.cpp
@@ -434,13 +434,11 @@ void CDToonsDecoder::setPalette(byte *data) {
 
 	// A lovely QuickTime palette
 	for (uint i = 0; i < 256; i++) {
-		_palette.data[i * 3]     = *data;
-		_palette.data[i * 3 + 1] = *(data + 2);
-		_palette.data[i * 3 + 2] = *(data + 4);
+		_palette.set(i, *data, *(data + 2), *(data + 4));
 		data += 6;
 	}
 
-	_palette.data[0] = _palette.data[1] = _palette.data[2] = 0;
+	_palette.set(0, 0, 0, 0);
 }
 
 } // End of namespace Image

--- a/image/codecs/cdtoons.h
+++ b/image/codecs/cdtoons.h
@@ -22,6 +22,8 @@
 #ifndef IMAGE_CODECS_CDTOONS_H
 #define IMAGE_CODECS_CDTOONS_H
 
+#include "graphics/palette.h"
+
 #include "image/codecs/codec.h"
 
 #include "common/hashmap.h"
@@ -50,12 +52,12 @@ public:
 	Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream) override;
 	Graphics::PixelFormat getPixelFormat() const override { return Graphics::PixelFormat::createFormatCLUT8(); }
 	bool containsPalette() const override { return true; }
-	const byte *getPalette() override { _dirtyPalette = false; return _palette; }
+	const byte *getPalette() override { _dirtyPalette = false; return _palette.data; }
 	bool hasDirtyPalette() const override { return _dirtyPalette; }
 
 private:
 	Graphics::Surface *_surface;
-	byte _palette[256 * 3];
+	Graphics::Palette _palette;
 	bool _dirtyPalette;
 	uint16 _currentPaletteId;
 

--- a/image/codecs/cinepak.cpp
+++ b/image/codecs/cinepak.cpp
@@ -393,7 +393,7 @@ CinepakDecoder::~CinepakDecoder() {
 	delete[] _clipTableBuf;
 
 	delete[] _colorMap;
-	delete[] _ditherPalette;
+	delete _ditherPalette;
 }
 
 const Graphics::Surface *CinepakDecoder::decodeFrame(Common::SeekableReadStream &stream) {
@@ -640,7 +640,7 @@ void CinepakDecoder::setDither(DitherType type, const byte *palette) {
 	assert(canDither(type));
 
 	delete[] _colorMap;
-	delete[] _ditherPalette;
+	delete _ditherPalette;
 
 	_ditherPalette = new Graphics::Palette(256);
 	_ditherPalette->set(palette, 0, 256);

--- a/image/codecs/cinepak.cpp
+++ b/image/codecs/cinepak.cpp
@@ -642,8 +642,8 @@ void CinepakDecoder::setDither(DitherType type, const byte *palette) {
 	delete[] _colorMap;
 	delete[] _ditherPalette;
 
-	_ditherPalette = new byte[256 * 3];
-	memcpy(_ditherPalette, palette, 256 * 3);
+	_ditherPalette = new Graphics::Palette(256);
+	_ditherPalette->set(palette, 0, 256);
 
 	_dirtyPalette = true;
 	_pixelFormat = Graphics::PixelFormat::createFormatCLUT8();
@@ -670,15 +670,15 @@ byte CinepakDecoder::findNearestRGB(int index) const {
 	int diff = 0x7FFFFFFF;
 
 	for (int i = 0; i < 256; i++) {
-		int bDiff = b - (int)_ditherPalette[i * 3 + 2];
+		int bDiff = b - (int)_ditherPalette->data[i * 3 + 2];
 		int curDiffB = diff - (bDiff * bDiff);
 
 		if (curDiffB > 0) {
-			int gDiff = g - (int)_ditherPalette[i * 3 + 1];
+			int gDiff = g - (int)_ditherPalette->data[i * 3 + 1];
 			int curDiffG = curDiffB - (gDiff * gDiff);
 
 			if (curDiffG > 0) {
-				int rDiff = r - (int)_ditherPalette[i * 3];
+				int rDiff = r - (int)_ditherPalette->data[i * 3];
 				int curDiffR = curDiffG - (rDiff * rDiff);
 
 				if (curDiffR > 0) {

--- a/image/codecs/cinepak.h
+++ b/image/codecs/cinepak.h
@@ -24,6 +24,7 @@
 
 #include "common/scummsys.h"
 #include "common/rect.h"
+#include "graphics/palette.h"
 #include "graphics/pixelformat.h"
 
 #include "image/codecs/codec.h"
@@ -77,7 +78,7 @@ public:
 	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override;
 
 	bool containsPalette() const override { return _ditherPalette != 0; }
-	const byte *getPalette() override { _dirtyPalette = false; return _ditherPalette; }
+	const byte *getPalette() override { _dirtyPalette = false; return _ditherPalette->data; }
 	bool hasDirtyPalette() const override { return _dirtyPalette; }
 	bool canDither(DitherType type) const override;
 	void setDither(DitherType type, const byte *palette) override;
@@ -89,7 +90,7 @@ private:
 	Graphics::PixelFormat _pixelFormat;
 	byte *_clipTable, *_clipTableBuf;
 
-	byte *_ditherPalette;
+	Graphics::Palette *_ditherPalette;
 	bool _dirtyPalette;
 	byte *_colorMap;
 	DitherType _ditherType;

--- a/image/codecs/qtrle.cpp
+++ b/image/codecs/qtrle.cpp
@@ -521,8 +521,8 @@ bool QTRLEDecoder::canDither(DitherType type) const {
 void QTRLEDecoder::setDither(DitherType type, const byte *palette) {
 	assert(canDither(type));
 
-	_ditherPalette = new byte[256 * 3];
-	memcpy(_ditherPalette, palette, 256 * 3);
+	_ditherPalette = new Graphics::Palette(256);
+	_ditherPalette->set(palette, 0, 256);
 	_dirtyPalette = true;
 
 	delete[] _colorMap;

--- a/image/codecs/qtrle.cpp
+++ b/image/codecs/qtrle.cpp
@@ -56,7 +56,7 @@ QTRLEDecoder::~QTRLEDecoder() {
 	}
 
 	delete[] _colorMap;
-	delete[] _ditherPalette;
+	delete _ditherPalette;
 }
 
 #define CHECK_STREAM_PTR(n) \

--- a/image/codecs/qtrle.h
+++ b/image/codecs/qtrle.h
@@ -22,6 +22,7 @@
 #ifndef IMAGE_CODECS_QTRLE_H
 #define IMAGE_CODECS_QTRLE_H
 
+#include "graphics/palette.h"
 #include "graphics/pixelformat.h"
 #include "image/codecs/codec.h"
 
@@ -41,7 +42,7 @@ public:
 	Graphics::PixelFormat getPixelFormat() const override;
 
 	bool containsPalette() const override { return _ditherPalette != 0; }
-	const byte *getPalette() override { _dirtyPalette = false; return _ditherPalette; }
+	const byte *getPalette() override { _dirtyPalette = false; return _ditherPalette->data; }
 	bool hasDirtyPalette() const override { return _dirtyPalette; }
 	bool canDither(DitherType type) const override;
 	void setDither(DitherType type, const byte *palette) override;
@@ -51,7 +52,7 @@ private:
 	Graphics::Surface *_surface;
 	uint16 _width, _height;
 	uint32 _paddedWidth;
-	byte *_ditherPalette;
+	Graphics::Palette *_ditherPalette;
 	bool _dirtyPalette;
 	byte *_colorMap;
 

--- a/image/codecs/rpza.cpp
+++ b/image/codecs/rpza.cpp
@@ -48,7 +48,7 @@ RPZADecoder::~RPZADecoder() {
 		delete _surface;
 	}
 
-	delete[] _ditherPalette;
+	delete _ditherPalette;
 	delete[] _colorMap;
 }
 

--- a/image/codecs/rpza.cpp
+++ b/image/codecs/rpza.cpp
@@ -353,8 +353,8 @@ bool RPZADecoder::canDither(DitherType type) const {
 void RPZADecoder::setDither(DitherType type, const byte *palette) {
 	assert(canDither(type));
 
-	_ditherPalette = new byte[256 * 3];
-	memcpy(_ditherPalette, palette, 256 * 3);
+	_ditherPalette = new Graphics::Palette(256);
+	_ditherPalette->set(palette, 0, 256);
 
 	_dirtyPalette = true;
 	_format = Graphics::PixelFormat::createFormatCLUT8();

--- a/image/codecs/rpza.h
+++ b/image/codecs/rpza.h
@@ -22,6 +22,7 @@
 #ifndef IMAGE_CODECS_RPZA_H
 #define IMAGE_CODECS_RPZA_H
 
+#include "graphics/palette.h"
 #include "graphics/pixelformat.h"
 #include "image/codecs/codec.h"
 
@@ -41,7 +42,7 @@ public:
 	Graphics::PixelFormat getPixelFormat() const override { return _format; }
 
 	bool containsPalette() const override { return _ditherPalette != 0; }
-	const byte *getPalette() override { _dirtyPalette = false; return _ditherPalette; }
+	const byte *getPalette() override { _dirtyPalette = false; return _ditherPalette->data; }
 	bool hasDirtyPalette() const override { return _dirtyPalette; }
 	bool canDither(DitherType type) const override;
 	void setDither(DitherType type, const byte *palette) override;
@@ -49,7 +50,7 @@ public:
 private:
 	Graphics::PixelFormat _format;
 	Graphics::Surface *_surface;
-	byte *_ditherPalette;
+	Graphics::Palette *_ditherPalette;
 	bool _dirtyPalette;
 	byte *_colorMap;
 	uint16 _width, _height;

--- a/image/pcx.h
+++ b/image/pcx.h
@@ -24,6 +24,7 @@
 
 #include "common/scummsys.h"
 #include "common/str.h"
+#include "graphics/palette.h"
 #include "image/image_decoder.h"
 
 namespace Common{
@@ -56,15 +57,14 @@ public:
 	void destroy();
 	virtual bool loadStream(Common::SeekableReadStream &stream);
 	virtual const Graphics::Surface *getSurface() const { return _surface; }
-	const byte *getPalette() const { return _palette; }
-	uint16 getPaletteColorCount() const { return _paletteColorCount; }
+	const byte *getPalette() const { return _palette.data; }
+	uint16 getPaletteColorCount() const { return _palette.size; }
 
 private:
 	void decodeRLE(Common::SeekableReadStream &stream, byte *dst, uint32 bytesPerScanline, bool compressed);
 
 	Graphics::Surface *_surface;
-	byte *_palette;
-	uint16 _paletteColorCount;
+	Graphics::Palette _palette;
 };
 /** @} */
 } // End of namespace Image

--- a/image/pict.cpp
+++ b/image/pict.cpp
@@ -35,10 +35,7 @@ namespace Image {
 // https://developer.apple.com/library/archive/documentation/mac/QuickDraw/QuickDraw-461.html
 // https://developer.apple.com/library/archive/documentation/mac/QuickDraw/QuickDraw-269.html
 
-PICTDecoder::PICTDecoder() {
-	_outputSurface = 0;
-	_paletteColorCount = 0;
-	_version = 2;
+PICTDecoder::PICTDecoder() : _outputSurface(nullptr), _palette(0), _version(2) {
 }
 
 PICTDecoder::~PICTDecoder() {
@@ -52,7 +49,8 @@ void PICTDecoder::destroy() {
 		_outputSurface = 0;
 	}
 
-	_paletteColorCount = 0;
+	_palette.clear();
+	_palette.size = 0;
 }
 
 #define OPCODE(a, b, c) _opcodes.push_back(PICTOpcode(a, &PICTDecoder::b, c))
@@ -267,7 +265,7 @@ bool PICTDecoder::loadStream(Common::SeekableReadStream &stream) {
 	setupOpcodesNormal();
 
 	_continueParsing = true;
-	memset(_palette, 0, sizeof(_palette));
+	_palette.clear();
 
 	uint16 fileSize = stream.readUint16BE();
 
@@ -382,13 +380,13 @@ void PICTDecoder::unpackBitsRect(Common::SeekableReadStream &stream, bool withPa
 		// See https://developer.apple.com/library/archive/documentation/mac/QuickDraw/QuickDraw-267.html
 		stream.readUint32BE(); // seed
 		stream.readUint16BE(); // flags
-		_paletteColorCount = stream.readUint16BE() + 1;
+		_palette.size = stream.readUint16BE() + 1;
 
-		for (uint32 i = 0; i < _paletteColorCount; i++) {
+		for (uint32 i = 0; i < _palette.size; i++) {
 			stream.readUint16BE();
-			_palette[i * 3] = stream.readUint16BE() >> 8;
-			_palette[i * 3 + 1] = stream.readUint16BE() >> 8;
-			_palette[i * 3 + 2] = stream.readUint16BE() >> 8;
+			_palette.data[i * 3] = stream.readUint16BE() >> 8;
+			_palette.data[i * 3 + 1] = stream.readUint16BE() >> 8;
+			_palette.data[i * 3 + 2] = stream.readUint16BE() >> 8;
 		}
 	}
 

--- a/image/pict.h
+++ b/image/pict.h
@@ -26,6 +26,8 @@
 #include "common/rect.h"
 #include "common/scummsys.h"
 
+#include "graphics/palette.h"
+
 #include "image/image_decoder.h"
 
 namespace Common {
@@ -62,9 +64,9 @@ public:
 	bool loadStream(Common::SeekableReadStream &stream);
 	void destroy();
 	const Graphics::Surface *getSurface() const { return _outputSurface; }
-	const byte *getPalette() const { return _palette; }
+	const byte *getPalette() const { return _palette.data; }
 	int getPaletteSize() const { return 256; }
-	uint16 getPaletteColorCount() const { return _paletteColorCount; }
+	uint16 getPaletteColorCount() const { return _palette.size; }
 
 	struct PixMap {
 		uint32 baseAddr;
@@ -89,8 +91,7 @@ public:
 
 private:
 	Common::Rect _imageRect;
-	byte _palette[256 * 3];
-	uint16 _paletteColorCount;
+	Graphics::Palette _palette;
 	Graphics::Surface *_outputSurface;
 	bool _continueParsing;
 	int _version;

--- a/video/avi_decoder.h
+++ b/video/avi_decoder.h
@@ -40,6 +40,7 @@ class SeekableReadStream;
 }
 
 namespace Graphics {
+struct Palette;
 struct PixelFormat;
 }
 
@@ -202,7 +203,7 @@ protected:
 
 	class AVIVideoTrack : public FixedRateVideoTrack {
 	public:
-		AVIVideoTrack(int frameCount, const AVIStreamHeader &streamHeader, const BitmapInfoHeader &bitmapInfoHeader, byte *initialPalette = 0);
+		AVIVideoTrack(int frameCount, const AVIStreamHeader &streamHeader, const BitmapInfoHeader &bitmapInfoHeader, Graphics::Palette *initialPalette = nullptr);
 		~AVIVideoTrack();
 
 		void decodeFrame(Common::SeekableReadStream *stream);
@@ -269,8 +270,8 @@ protected:
 	private:
 		AVIStreamHeader _vidsHeader;
 		BitmapInfoHeader _bmInfo;
-		byte _palette[3 * 256];
-		byte *_initialPalette;
+		Graphics::Palette *_palette;
+		Graphics::Palette *_initialPalette;
 		mutable bool _dirtyPalette;
 		int _frameCount, _curFrame;
 		bool _reversed;

--- a/video/coktel_decoder.cpp
+++ b/video/coktel_decoder.cpp
@@ -28,6 +28,8 @@
 #include "common/types.h"
 #include "common/util.h"
 
+#include "graphics/palette.h"
+
 #include "video/coktel_decoder.h"
 
 #include "image/codecs/indeo3.h"
@@ -55,11 +57,11 @@ CoktelDecoder::CoktelDecoder(Audio::Mixer *mixer, Audio::Mixer::SoundType soundT
 	_pauseStartTime(0), _isPaused(false) {
 
 	assert(_mixer);
-
-	memset(_palette, 0, 768);
+	_palette = new Graphics::Palette(256);
 }
 
 CoktelDecoder::~CoktelDecoder() {
+	delete _palette;
 }
 
 bool CoktelDecoder::evaluateSeekFrame(int32 &frame, int whence) const {
@@ -308,7 +310,7 @@ uint32 CoktelDecoder::getFrameCount() const {
 
 const byte *CoktelDecoder::getPalette() {
 	_paletteDirty = false;
-	return _palette;
+	return _palette->data;
 }
 
 bool CoktelDecoder::hasDirtyPalette() const {
@@ -1115,7 +1117,7 @@ bool IMDDecoder::loadStream(Common::SeekableReadStream *stream) {
 
 	// Palette
 	for (int i = 0; i < 768; i++)
-		_palette[i] = _stream->readByte() << 2;
+		_palette->data[i] = _stream->readByte() << 2;
 
 	_paletteDirty = true;
 
@@ -1396,7 +1398,7 @@ void IMDDecoder::processFrame() {
 			_paletteDirty = true;
 
 			for (int i = 0; i < 768; i++)
-				_palette[i] = _stream->readByte() << 2;
+				_palette->data[i] = _stream->readByte() << 2;
 
 			cmd = _stream->readUint16LE();
 		}
@@ -1513,7 +1515,7 @@ bool IMDDecoder::renderFrame(Common::Rect &rect) {
 
 		int count = MIN((255 - index) * 3, 48);
 		for (int i = 0; i < count; i++)
-			_palette[index * 3 + i] = dataPtr[i] << 2;
+			_palette->data[index * 3 + i] = dataPtr[i] << 2;
 
 		dataPtr  += 48;
 		dataSize -= 49;
@@ -1949,7 +1951,7 @@ bool VMDDecoder::loadStream(Common::SeekableReadStream *stream) {
 
 	if (_features & kFeaturesPalette) {
 		for (int i = 0; i < 768; i++)
-			_palette[i] = _stream->readByte() << 2;
+			_palette->data[i] = _stream->readByte() << 2;
 
 		_paletteDirty = true;
 	}
@@ -2372,7 +2374,7 @@ void VMDDecoder::processFrame() {
 				uint8 count = _stream->readByte();
 
 				for (int j = 0; j < ((count + 1) * 3); j++)
-					_palette[index * 3 + j] = _stream->readByte() << 2;
+					_palette->data[index * 3 + j] = _stream->readByte() << 2;
 
 				_stream->skip((255 - count) * 3);
 

--- a/video/coktel_decoder.h
+++ b/video/coktel_decoder.h
@@ -50,6 +50,7 @@ class QueuingAudioStream;
 }
 
 namespace Graphics {
+struct Palette;
 struct PixelFormat;
 }
 
@@ -230,7 +231,7 @@ protected:
 
 	uint32 _startTime;
 
-	byte _palette[768];
+	Graphics::Palette *_palette;
 	bool _paletteDirty;
 
 	bool _isDouble;

--- a/video/dxa_decoder.cpp
+++ b/video/dxa_decoder.cpp
@@ -73,13 +73,12 @@ void DXADecoder::readSoundData(Common::SeekableReadStream *stream) {
 	}
 }
 
-DXADecoder::DXAVideoTrack::DXAVideoTrack(Common::SeekableReadStream *stream) {
+DXADecoder::DXAVideoTrack::DXAVideoTrack(Common::SeekableReadStream *stream) : _palette(256) {
 	_fileStream = stream;
 	_curFrame = -1;
 	_frameStartOffset = 0;
 	_decompBuffer = 0;
 	_inBuffer = 0;
-	memset(_palette, 0, 256 * 3);
 
 	uint8 flags = _fileStream->readByte();
 	_frameCount = _fileStream->readUint16BE();
@@ -465,7 +464,7 @@ void DXADecoder::DXAVideoTrack::decode13(int size) {
 const Graphics::Surface *DXADecoder::DXAVideoTrack::decodeNextFrame() {
 	uint32 tag = _fileStream->readUint32BE();
 	if (tag == MKTAG('C','M','A','P')) {
-		_fileStream->read(_palette, 256 * 3);
+		_fileStream->read(_palette.data, 256 * 3);
 		_dirtyPalette = true;
 	}
 

--- a/video/dxa_decoder.h
+++ b/video/dxa_decoder.h
@@ -23,6 +23,7 @@
 #define VIDEO_DXA_DECODER_H
 
 #include "common/rational.h"
+#include "graphics/palette.h"
 #include "graphics/pixelformat.h"
 #include "video/video_decoder.h"
 
@@ -68,7 +69,7 @@ private:
 		int getCurFrame() const { return _curFrame; }
 		int getFrameCount() const { return _frameCount; }
 		const Graphics::Surface *decodeNextFrame();
-		const byte *getPalette() const { _dirtyPalette = false; return _palette; }
+		const byte *getPalette() const { _dirtyPalette = false; return _palette.data; }
 		bool hasDirtyPalette() const { return _dirtyPalette; }
 
 		void setFrameStartPos();
@@ -103,7 +104,7 @@ private:
 		uint16 _width, _height;
 		uint32 _frameRate;
 		uint32 _frameCount;
-		byte _palette[256 * 3];
+		Graphics::Palette _palette;
 		mutable bool _dirtyPalette;
 		int _curFrame;
 		uint32 _frameStartOffset;

--- a/video/flic_decoder.h
+++ b/video/flic_decoder.h
@@ -22,6 +22,7 @@
 #ifndef VIDEO_FLICDECODER_H
 #define VIDEO_FLICDECODER_H
 
+#include "graphics/palette.h"
 #include "video/video_decoder.h"
 #include "common/list.h"
 #include "common/rect.h"
@@ -77,7 +78,7 @@ protected:
 		uint32 getNextFrameStartTime() const { return _nextFrameStartTime; }
 		virtual const Graphics::Surface *decodeNextFrame();
 		virtual void handleFrame();
-		const byte *getPalette() const { _dirtyPalette = false; return _palette; }
+		const byte *getPalette() const { _dirtyPalette = false; return _palette.data; }
 		bool hasDirtyPalette() const { return _dirtyPalette; }
 
 		const Common::List<Common::Rect> *getDirtyRects() const { return &_dirtyRects; }
@@ -93,7 +94,7 @@ protected:
 
 		uint32 _offsetFrame1;
 		uint32 _offsetFrame2;
-		byte *_palette;
+		Graphics::Palette _palette;
 		mutable bool _dirtyPalette;
 
 		uint32 _frameCount;

--- a/video/hnm_decoder.cpp
+++ b/video/hnm_decoder.cpp
@@ -277,13 +277,11 @@ HNMDecoder::HNMVideoTrack::HNMVideoTrack(uint32 frameCount,
 HNMDecoder::HNM45VideoTrack::HNM45VideoTrack(uint32 width, uint32 height, uint32 frameSize,
         uint32 frameCount, uint32 regularFrameDelayMs, uint32 audioSampleRate,
         const byte *initialPalette) :
-	HNMVideoTrack(frameCount, regularFrameDelayMs, audioSampleRate) {
+	HNMVideoTrack(frameCount, regularFrameDelayMs, audioSampleRate), _palette(256) {
 
 	// Get the currently loaded palette for undefined colors
 	if (initialPalette) {
-		memcpy(_palette, initialPalette, 256 * 3);
-	} else {
-		memset(_palette, 0, 256 * 3);
+		_palette.set(initialPalette, 0, 256);
 	}
 	_dirtyPalette = true;
 
@@ -355,7 +353,7 @@ void HNMDecoder::HNM45VideoTrack::decodePalette(byte *data, uint32 size) {
 			error("Not enough data for palette");
 		}
 
-		byte *palette_ptr = &_palette[start * 3];
+		byte *palette_ptr = &_palette.data[start * 3];
 		for (; count > 0; count--) {
 			byte r = *(data++);
 			byte g = *(data++);

--- a/video/hnm_decoder.h
+++ b/video/hnm_decoder.h
@@ -24,6 +24,7 @@
 
 #include "audio/audiostream.h"
 #include "common/rational.h"
+#include "graphics/palette.h"
 #include "graphics/surface.h"
 #include "video/video_decoder.h"
 
@@ -92,7 +93,7 @@ private:
 		uint16 getHeight() const override { return _surface.h; }
 		Graphics::PixelFormat getPixelFormat() const override { return _surface.format; }
 		const Graphics::Surface *decodeNextFrame() override { return &_surface; }
-		const byte *getPalette() const override { _dirtyPalette = false; return _palette; }
+		const byte *getPalette() const override { _dirtyPalette = false; return _palette.data; }
 		bool hasDirtyPalette() const override { return _dirtyPalette; }
 
 		virtual void newFrame(uint32 frameDelay) override;
@@ -108,7 +109,7 @@ private:
 
 		Graphics::Surface _surface;
 
-		byte _palette[256 * 3];
+		Graphics::Palette _palette;
 		mutable bool _dirtyPalette;
 
 		byte *_frameBufferC;

--- a/video/paco_decoder.cpp
+++ b/video/paco_decoder.cpp
@@ -167,18 +167,18 @@ const byte* PacoDecoder::getPalette(){
 
 const byte* PacoDecoder::PacoVideoTrack::getPalette() const {
 	_dirtyPalette = false;
-	return _palette;
+	return _palette.data;
 }
 
 PacoDecoder::PacoVideoTrack::PacoVideoTrack(
-	uint16 frameRate, uint16 frameCount, uint16 width, uint16 height) {
+	uint16 frameRate, uint16 frameCount, uint16 width, uint16 height) : _palette(256) {
 	_curFrame = 0;
 	_frameRate = frameRate;
 	_frameCount = frameCount;
 
 	_surface = new Graphics::Surface();
 	_surface->create(width, height, Graphics::PixelFormat::createFormatCLUT8());
-	_palette = const_cast<byte *>(quickTimeDefaultPalette256);
+	_palette.set(quickTimeDefaultPalette256, 0, 256);
 	_dirtyPalette = true;
 }
 
@@ -246,12 +246,11 @@ const Graphics::Surface *PacoDecoder::PacoVideoTrack::decodeNextFrame() {
 void PacoDecoder::PacoVideoTrack::handlePalette(Common::SeekableReadStream *fileStream) {
 	uint32 header = fileStream->readUint32BE();
 	if (header == 0x30000000) { // default quicktime palette
-		_palette = const_cast<byte *>(quickTimeDefaultPalette256);
+		_palette.set(quickTimeDefaultPalette256, 0, 256);
 	} else {
 		fileStream->readUint32BE(); // 4 bytes of 00
-		_palette = new byte[256 * 3]();
 		for (int i = 0; i < 256 * 3; i++){
-			_palette[i] = fileStream->readByte();
+			_palette.data[i] = fileStream->readByte();
 		}
 	}
 	_dirtyPalette = true;

--- a/video/paco_decoder.h
+++ b/video/paco_decoder.h
@@ -25,6 +25,7 @@
 #include "audio/audiostream.h"
 #include "common/list.h"
 #include "common/rect.h"
+#include "graphics/palette.h"
 #include "video/video_decoder.h"
 
 namespace Common {
@@ -87,8 +88,7 @@ protected:
 
 	protected:
 		Graphics::Surface *_surface;
-
-		byte *_palette;
+		Graphics::Palette _palette;
 
 		mutable bool _dirtyPalette;
 

--- a/video/qt_decoder.h
+++ b/video/qt_decoder.h
@@ -32,6 +32,7 @@
 
 #include "audio/decoders/quicktime_intern.h"
 #include "common/scummsys.h"
+#include "graphics/palette.h"
 
 #include "video/video_decoder.h"
 
@@ -100,7 +101,7 @@ private:
 		uint16 _bitsPerSample;
 		char _codecName[32];
 		uint16 _colorTableId;
-		byte *_palette;
+		Graphics::Palette _palette;
 		Image::Codec *_videoCodec;
 	};
 
@@ -166,7 +167,7 @@ private:
 		bool _reversed;
 
 		// Forced dithering of frames
-		byte *_forcedDitherPalette;
+		Graphics::Palette *_forcedDitherPalette;
 		byte *_ditherTable;
 		Graphics::Surface *_ditherFrame;
 		const Graphics::Surface *forceDither(const Graphics::Surface &frame);

--- a/video/smk_decoder.cpp
+++ b/video/smk_decoder.cpp
@@ -588,7 +588,7 @@ VideoDecoder::AudioTrack *SmackerDecoder::getAudioTrack(int index) {
 	return (AudioTrack *)track;
 }
 
-SmackerDecoder::SmackerVideoTrack::SmackerVideoTrack(uint32 width, uint32 height, uint32 frameCount, const Common::Rational &frameRate, uint32 flags, uint32 version) {
+SmackerDecoder::SmackerVideoTrack::SmackerVideoTrack(uint32 width, uint32 height, uint32 frameCount, const Common::Rational &frameRate, uint32 flags, uint32 version) : _palette(256) {
 	_surface = new Graphics::Surface();
 	_surface->create(width, height * ((flags & 6) ? 2 : 1), Graphics::PixelFormat::createFormatCLUT8());
 	_dirtyBlocks.set_size(width * height / 16);
@@ -599,7 +599,6 @@ SmackerDecoder::SmackerVideoTrack::SmackerVideoTrack(uint32 width, uint32 height
 	_curFrame = -1;
 	_dirtyPalette = false;
 	_MMapTree = _MClrTree = _FullTree = _TypeTree = 0;
-	memset(_palette, 0, 3 * 256);
 }
 
 SmackerDecoder::SmackerVideoTrack::~SmackerVideoTrack() {
@@ -788,10 +787,9 @@ void SmackerDecoder::SmackerVideoTrack::unpackPalette(Common::SeekableReadStream
 	stream->read(chunk, len);
 	byte *p = chunk;
 
-	byte oldPalette[3 * 256];
-	memcpy(oldPalette, _palette, 3 * 256);
+	Graphics::Palette oldPalette = _palette;
 
-	byte *pal = _palette;
+	byte *pal = _palette.data;
 
 	int sz = 0;
 	byte b0;
@@ -806,9 +804,9 @@ void SmackerDecoder::SmackerVideoTrack::unpackPalette(Common::SeekableReadStream
 			sz += c;
 
 			while (c--) {
-				*pal++ = oldPalette[s + 0];
-				*pal++ = oldPalette[s + 1];
-				*pal++ = oldPalette[s + 2];
+				*pal++ = oldPalette.data[s + 0];
+				*pal++ = oldPalette.data[s + 1];
+				*pal++ = oldPalette.data[s + 2];
 				s += 3;
 			}
 		} else {                       // top 2 bits are 00

--- a/video/smk_decoder.h
+++ b/video/smk_decoder.h
@@ -26,6 +26,7 @@
 #include "common/bitstream.h"
 #include "common/rational.h"
 #include "common/rect.h"
+#include "graphics/palette.h"
 #include "graphics/pixelformat.h"
 #include "graphics/surface.h"
 #include "video/video_decoder.h"
@@ -102,7 +103,7 @@ protected:
 		int getCurFrame() const { return _curFrame; }
 		int getFrameCount() const { return _frameCount; }
 		const Graphics::Surface *decodeNextFrame() { return _surface; }
-		const byte *getPalette() const { _dirtyPalette = false; return _palette; }
+		const byte *getPalette() const { _dirtyPalette = false; return _palette.data; }
 		bool hasDirtyPalette() const { return _dirtyPalette; }
 
 		void readTrees(SmackerBitStream &bs, uint32 mMapSize, uint32 mClrSize, uint32 fullSize, uint32 typeSize);
@@ -121,7 +122,7 @@ protected:
 		Common::Rational _frameRate;
 		uint32 _flags, _version;
 
-		byte _palette[3 * 256];
+		Graphics::Palette _palette;
 		mutable bool _dirtyPalette;
 
 		int _curFrame;


### PR DESCRIPTION
Adding a common definition for palette can allow us to simplify handling of palettes, reduce duplicate logic, and potentially share the memory rather than duplicate in some places.

These commits mostly establish use of the palette struct to replace existing byte arrays throughout non-engine code. Future work can extend to passing the struct by reference for various functions

Please let me know your thoughts and feel free to be brutal :-)