### PR TITLE
M4: Orion burger fix for using kibble in test2 and a general sound unload fix

### DIFF
--- a/engines/m4/burger/burger.cpp
+++ b/engines/m4/burger/burger.cpp
@@ -290,7 +290,7 @@ void BurgerEngine::global_daemon() {
 			break;
 		case 10009:
 			ws_unhide_walker(_G(my_walker));
-			_G(wilbur_should) = 10018;
+			_G(wilbur_should) = 10010;
 			_G(walker).wilbur_speech("602w012x", kCHANGE_WILBUR_ANIMATION);
 			break;
 		case 10010:

--- a/engines/m4/platform/sound/digi.cpp
+++ b/engines/m4/platform/sound/digi.cpp
@@ -83,7 +83,7 @@ void Digi::unload(const Common::String &name) {
 		// Stop it if it's playing
 		for (int channel = 0; channel < MAX_CHANNELS; ++channel) {
 			if (_channels[channel]._name == name)
-				stop(channel);
+				stop(channel, true);
 		}
 
 		// Remove the underlying resource
@@ -166,7 +166,7 @@ Common::String Digi::expand_name_2_RAW(const Common::String &name, int32 room_nu
 	}
 }
 
-void Digi::stop(uint channel) {
+void Digi::stop(uint channel, bool calledFromUnload) {
 	assert(channel < 4);
 
 	Channel &c = _channels[channel];
@@ -177,7 +177,9 @@ void Digi::stop(uint channel) {
 		c._trigger = -1;
 		c._name.clear();
 
-		digi_unload(name);
+		if (!calledFromUnload) {
+			digi_unload(name);
+		}
 	}
 }
 

--- a/engines/m4/platform/sound/digi.h
+++ b/engines/m4/platform/sound/digi.h
@@ -95,7 +95,7 @@ public:
 	int32 play(const Common::String &name, uint channel, int32 vol, int32 trigger, int32 room_num = -1);
 	int32 play_loop(const Common::String &name, uint channel, int32 vol, int32 trigger, int32 room_num = -1);
 	void playFootsteps();
-	void stop(uint channel);
+	void stop(uint channel, bool calledFromUnload = false);
 	void flush_mem();
 
 	void read_another_chunk();


### PR DESCRIPTION
This PR fixes the issue of not playing the correct speech sequence when using the kibble from Wilbur's inventory

It also fixes an issue that was detecting during testing the above fix, whereby some sounds would not play a second time. This was due to the unload() method for sounds being called twice in some cases, which seems unintended.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
