### PR TITLE
ICB: compile fix for GCC 14

### DIFF
--- a/engines/icb/common/px_array.h
+++ b/engines/icb/common/px_array.h
@@ -100,9 +100,9 @@ const Type &T_MYACTARRAY::operator[](uint32 n) const {
 	// It is permissable to look at an element that has not been defined, as the constructor assures
 	// that the contents are valid
 	if (n >= m_userPosition) {
-		// We must cast this to a type that can change
-		((const rcActArray<Type> *)this)->ResizeArray(n);
-		((const rcActArray<Type> *)this)->m_userPosition = n + 1;
+		// Remove any 'constness' for a resize
+		(const_cast<rcActArray<Type> *>(this))->ResizeArray(n);
+		(const_cast<rcActArray<Type> *>(this))->m_userPosition = n + 1;
 	}
 
 	return (*(m_contents[n]));
@@ -304,8 +304,8 @@ template <class Type> const Type rcIntArray<Type>::operator[](uint32 index) cons
 	// It is permissable to look at an element that has not been defined, as it will have been set to 0
 	if (index >= m_userPosition) {
 		// Remove any 'constness' for a resize
-		((const rcIntArray<Type> *)this)->ResizeArray(index);
-		((const rcIntArray<Type> *)this)->m_userPosition = index + 1;
+		(const_cast<rcIntArray<Type> *>(this))->ResizeArray(index);
+		(const_cast<rcIntArray<Type> *>(this))->m_userPosition = index + 1;
 	}
 
 	return m_contents[index];


### PR DESCRIPTION
I found a compile problem when building scummvm 2.8 for Fedora rawhide:

- Fedora 38: OK (GCC 13.2.1)
- Fedora 39: OK (GCC 13.2.1)
- Fedora rawhide / upcoming F40: doesn't compile (GCC 14.0.1):
```
g++ -MMD -MF "engines/icb/.deps/actor.d" -MQ "engines/icb/actor.o" -MP -Wall -O2  -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer   -Wshadow -W -Wno-unused-parameter -Wno-empty-body -fno-operator-names -std=c++11 -pedantic -Wno-address-of-packed-member -O2 -Wuninitialized -fPIC  -I/usr/include/gtk-3.0 -I/usr/include/pango-1.0 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/cairo -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include -I/usr/include/atk-1.0 -I/usr/include/harfbuzz -I/usr/include/freetype2 -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/at-spi2-atk/2.0 -I/usr/include/cloudproviders -I/usr/include/webp -I/usr/include/blkid -I/usr/include/at-spi-2.0 -I/usr/include/gio-unix-2.0 -I/usr/include/libmount -I/usr/include/pixman-1 -I/usr/include/libxml2 -I/usr/include/fribidi -I/usr/include/sysprof-6 -pthread -I/usr/include/libpng16 -DWITH_GZFILEOP -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/harfbuzz -I/usr/include/sysprof-6 -pthread -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -DWITH_GZFILEOP -Wno-long-long -Wno-multichar -Wno-unknown-pragmas -Wno-reorder -Wpointer-arith -Wcast-qual -Wnon-virtual-dtor -Wwrite-strings -fno-exceptions -fcheck-new -DHAVE_CONFIG_H -DRELEASE_BUILD -DSDL_BACKEND -DUSE_SDL2 -DHAS_GETADDRINFO -DHAS_GETNAMEINFO -DHAS_GETHOSTBYADDR_R -DHAS_GETHOSTBYNAME_R -DHAS_POLL -DHAS_FCNTL -DHAS_INET_PTON -DHAS_INET_NTOP -DHAS_MSGHDR_FLAGS -DHAS_SOCKLEN_T -DPOSIX -DHAS_POSIX_SPAWN -DHAS_FSEEKO_OFFT_64 -DDATA_PATH=\"/usr/share/scummvm\" -DPLUGIN_DIRECTORY=\"/usr/lib64/scummvm\" -DENABLE_SCUMM=DYNAMIC_PLUGIN -DENABLE_SCUMM_7_8 -DENABLE_HE -DENABLE_ACCESS=DYNAMIC_PLUGIN -DENABLE_ADL=DYNAMIC_PLUGIN -DENABLE_AGI=DYNAMIC_PLUGIN -DENABLE_AGOS=DYNAMIC_PLUGIN -DENABLE_AGOS2 -DENABLE_AGS=DYNAMIC_PLUGIN -DENABLE_ASYLUM=DYNAMIC_PLUGIN -DENABLE_AVALANCHE=DYNAMIC_PLUGIN -DENABLE_BBVS=DYNAMIC_PLUGIN -DENABLE_BLADERUNNER=DYNAMIC_PLUGIN -DENABLE_BURIED=DYNAMIC_PLUGIN -DENABLE_CGE=DYNAMIC_PLUGIN -DENABLE_CGE2=DYNAMIC_PLUGIN -DENABLE_CHAMBER=DYNAMIC_PLUGIN -DENABLE_CHEWY=DYNAMIC_PLUGIN -DENABLE_CINE=DYNAMIC_PLUGIN -DENABLE_COMPOSER=DYNAMIC_PLUGIN -DENABLE_CRAB=DYNAMIC_PLUGIN -DENABLE_CRUISE=DYNAMIC_PLUGIN -DENABLE_CRYO=DYNAMIC_PLUGIN -DENABLE_CRYOMNI3D=DYNAMIC_PLUGIN -DENABLE_VERSAILLES -DENABLE_DIRECTOR=DYNAMIC_PLUGIN -DENABLE_DM=DYNAMIC_PLUGIN -DENABLE_DRACI=DYNAMIC_PLUGIN -DENABLE_DRAGONS=DYNAMIC_PLUGIN -DENABLE_DRASCULA=DYNAMIC_PLUGIN -DENABLE_DREAMWEB=DYNAMIC_PLUGIN -DENABLE_EFH=DYNAMIC_PLUGIN -DENABLE_FREESCAPE=DYNAMIC_PLUGIN -DENABLE_GLK=DYNAMIC_PLUGIN -DENABLE_GNAP=DYNAMIC_PLUGIN -DENABLE_GOB=DYNAMIC_PLUGIN -DENABLE_GRIFFON=DYNAMIC_PLUGIN -DENABLE_GRIM=DYNAMIC_PLUGIN -DENABLE_MONKEY4 -DENABLE_GROOVIE=DYNAMIC_PLUGIN -DENABLE_GROOVIE2 -DENABLE_HADESCH=DYNAMIC_PLUGIN -DENABLE_HDB=DYNAMIC_PLUGIN -DENABLE_HOPKINS=DYNAMIC_PLUGIN -DENABLE_HPL1=DYNAMIC_PLUGIN -DENABLE_HUGO=DYNAMIC_PLUGIN -DENABLE_HYPNO=DYNAMIC_PLUGIN -DENABLE_ICB=DYNAMIC_PLUGIN -DENABLE_ILLUSIONS=DYNAMIC_PLUGIN -DENABLE_IMMORTAL=DYNAMIC_PLUGIN -DENABLE_KINGDOM=DYNAMIC_PLUGIN -DENABLE_KYRA=DYNAMIC_PLUGIN -DENABLE_LOL -DENABLE_EOB -DENABLE_LAB=DYNAMIC_PLUGIN -DENABLE_LASTEXPRESS=DYNAMIC_PLUGIN -DENABLE_LILLIPUT=DYNAMIC_PLUGIN -DENABLE_LURE=DYNAMIC_PLUGIN -DENABLE_MACVENTURE=DYNAMIC_PLUGIN -DENABLE_MADE=DYNAMIC_PLUGIN -DENABLE_MADS=DYNAMIC_PLUGIN -DENABLE_MADSV2 -DENABLE_MM=DYNAMIC_PLUGIN -DENABLE_MM1 -DENABLE_XEEN -DENABLE_MOHAWK=DYNAMIC_PLUGIN -DENABLE_CSTIME -DENABLE_MYST -DENABLE_MYSTME -DENABLE_RIVEN -DENABLE_MORTEVIELLE=DYNAMIC_PLUGIN -DENABLE_MTROPOLIS=DYNAMIC_PLUGIN -DENABLE_MUTATIONOFJB=DYNAMIC_PLUGIN -DENABLE_MYST3=DYNAMIC_PLUGIN -DENABLE_NANCY=DYNAMIC_PLUGIN -DENABLE_NEVERHOOD=DYNAMIC_PLUGIN -DENABLE_NGI=DYNAMIC_PLUGIN -DENABLE_PARALLACTION=DYNAMIC_PLUGIN -DENABLE_PEGASUS=DYNAMIC_PLUGIN -DENABLE_PETKA=DYNAMIC_PLUGIN -DENABLE_PINK=DYNAMIC_PLUGIN -DENABLE_PLAYGROUND3D=DYNAMIC_PLUGIN -DENABLE_PLUMBERS=DYNAMIC_PLUGIN -DENABLE_PRINCE=DYNAMIC_PLUGIN -DENABLE_PRIVATE=DYNAMIC_PLUGIN -DENABLE_QUEEN=DYNAMIC_PLUGIN -DENABLE_SAGA=DYNAMIC_PLUGIN -DENABLE_IHNM -DENABLE_SAGA2=DYNAMIC_PLUGIN -DENABLE_SCI=DYNAMIC_PLUGIN -DENABLE_SCI32 -DENABLE_SHERLOCK=DYNAMIC_PLUGIN -DENABLE_SKY=DYNAMIC_PLUGIN -DENABLE_SLUDGE=DYNAMIC_PLUGIN -DENABLE_STARK=DYNAMIC_PLUGIN -DENABLE_STARTREK=DYNAMIC_PLUGIN -DENABLE_SUPERNOVA=DYNAMIC_PLUGIN -DENABLE_SWORD1=DYNAMIC_PLUGIN -DENABLE_SWORD2=DYNAMIC_PLUGIN -DENABLE_SWORD25=DYNAMIC_PLUGIN -DENABLE_TEENAGENT=DYNAMIC_PLUGIN -DENABLE_TESTBED=DYNAMIC_PLUGIN -DENABLE_TETRAEDGE=DYNAMIC_PLUGIN -DENABLE_TINSEL=DYNAMIC_PLUGIN -DENABLE_TITANIC=DYNAMIC_PLUGIN -DENABLE_TOLTECS=DYNAMIC_PLUGIN -DENABLE_TONY=DYNAMIC_PLUGIN -DENABLE_TOON=DYNAMIC_PLUGIN -DENABLE_TOUCHE=DYNAMIC_PLUGIN -DENABLE_TRECISION=DYNAMIC_PLUGIN -DENABLE_TSAGE=DYNAMIC_PLUGIN -DENABLE_TUCKER=DYNAMIC_PLUGIN -DENABLE_TWINE=DYNAMIC_PLUGIN -DENABLE_ULTIMA=DYNAMIC_PLUGIN -DENABLE_ULTIMA1 -DENABLE_ULTIMA4 -DENABLE_ULTIMA6 -DENABLE_ULTIMA8 -DENABLE_VCRUISE=DYNAMIC_PLUGIN -DENABLE_VOYEUR=DYNAMIC_PLUGIN -DENABLE_WAGE=DYNAMIC_PLUGIN -DENABLE_WATCHMAKER=DYNAMIC_PLUGIN -DENABLE_WINTERMUTE=DYNAMIC_PLUGIN -DENABLE_FOXTAIL -DENABLE_HEROCRAFT -DENABLE_WME3D -DENABLE_ZVISION=DYNAMIC_PLUGIN -I. -I. -I./engines -I/usr/include/SDL2 -D_REENTRANT       -I/usr/include/libpng16 -DWITH_GZFILEOP        -I/usr/include/fribidi -c engines/icb/actor.cpp -o engines/icb/actor.o
In file included from ./engines/icb/debug.h:32,
                 from ./engines/icb/string_vest.h:31,
                 from ./engines/icb/p4.h:32,
                 from ./engines/icb/global_objects.h:30,
                 from engines/icb/actor.cpp:27:
./engines/icb/common/px_array.h: In member function ‘const Type& ICB::rcActArray<Type>::operator[](uint32) const’:
./engines/icb/common/px_array.h:105:66: error: assignment of member ‘m_userPosition’ in read-only object
  105 |                 ((const rcActArray<Type> *)this)->m_userPosition = n + 1;
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
./engines/icb/common/px_array.h: In member function ‘const Type ICB::rcIntArray<Type>::operator[](uint32) const’:
./engines/icb/common/px_array.h:308:66: error: assignment of member ‘m_userPosition’ in read-only object
  308 |                 ((const rcIntArray<Type> *)this)->m_userPosition = index + 1;
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
make: *** [Makefile.common:177: engines/icb/actor.o] Error 1
```
- it looks like that the code was originally OK (use a cast to remove const to allow modifiactions), commit 
610e9e4f65bb929cf0167528fd426ee7f6a57578 added a cast _to_ const (contradicting the comments)
- since the data structures should be modified, they can't be const

The suggested patch uses C++-style const_cast to remove the constness.