### PR TITLE
OPENDINGUX: remove -ffast-math

### DIFF
--- a/configure
+++ b/configure
@@ -3859,8 +3859,8 @@ if test -n "$_host"; then
 			_sysroot=`$CXX --print-sysroot`
 			_sdlpath=$_sysroot/usr/bin
 			append_var DEFINES  "-DDINGUX -DOPENDINGUX -DREDUCE_MEMORY_USAGE -DUNCACHED_PLUGINS"
-			append_var CXXFLAGS "-ffast-math -fdata-sections -ffunction-sections -mplt"
-			append_var LDFLAGS  "-ffast-math -fdata-sections -ffunction-sections -mplt"
+			append_var CXXFLAGS "-fdata-sections -ffunction-sections -mplt"
+			append_var LDFLAGS  "-fdata-sections -ffunction-sections -mplt"
 			append_var LDFLAGS  "-O3 -Wl,--as-needed,--gc-sections"
 			if [ x"$_dynamic_modules" != xyes ]; then
 				append_var CXXFLAGS "-mno-shared"


### PR DESCRIPTION
While this flag did not exhibit known issues on the initial opendingux port, it is rather unsafe and hard to guarantee it won't in future builds.

Remove it for better stability.