### PR TITLE
GRAPHICS: MACGUI: TTF support in Markdown

### DIFF
--- a/graphics/macgui/macfontmanager.cpp
+++ b/graphics/macgui/macfontmanager.cpp
@@ -645,11 +645,23 @@ int MacFontManager::registerFontName(Common::String name, int preferredId) {
 	return id;
 }
 
-int MacFontManager::registerTTFFont(const Common::Array<TTFMap>& ttfList) {
+int MacFontManager::registerTTFFont(const Common::Array<TTFMap> &ttfList) {
 	int defaultValue = 1;
+	int realId = 100;
+	auto checkId = [&](int id) {
+		for (auto &&i : ttfList) {
+			if (_fontInfo.contains(id + i.slant)) {
+				return true;
+			}
+		}
+		return false;
+	};
+
+	while (checkId(realId))
+		realId++;
 
 	for (auto &&i : ttfList) {
-		int id = 1000;
+		int id = realId;
 		Common::String name = i.ttfName;
 
 		if (name.empty()) {
@@ -658,9 +670,9 @@ int MacFontManager::registerTTFFont(const Common::Array<TTFMap>& ttfList) {
 			continue;
 		}
 
-		if (_fontIds.contains(name)){
+		if (_fontIds.contains(name)) {
 			if (defaultValue == 1)
-				defaultValue = id;
+				defaultValue = _fontIds[name];
 			continue;
 		}
 
@@ -678,12 +690,12 @@ int MacFontManager::registerTTFFont(const Common::Array<TTFMap>& ttfList) {
 	return defaultValue;
 }
 
-int MacFontManager::getFamilyId(int newId, int newSlant){
+int MacFontManager::getFamilyId(int newId, int newSlant) {
 	if (_fontInfo.contains(newId + newSlant)) {
 		return newId + newSlant;
 	}
-	warning("MacFontManager::getFamilyId(): No font with slant %d found, setting to kMacFontBold | kMacFontItalic", newSlant);
-	return newId + (kMacFontBold | kMacFontItalic);
+	warning("MacFontManager::getFamilyId(): No font with slant %d found, setting to kMacFontRegular", newSlant);
+	return newId;
 }
 
 void MacFont::setName(const char *name) {

--- a/graphics/macgui/macfontmanager.cpp
+++ b/graphics/macgui/macfontmanager.cpp
@@ -513,14 +513,23 @@ const Font *MacFontManager::getFont(MacFont *macFont) {
 			if (pFont != _uniFonts.end()) {
 				font = pFont->_value;
 			} else {
-				font = Graphics::loadTTFFontFromArchive("FreeSans.ttf", macFont->getSize(), Graphics::kTTFSizeModeCharacter, 0, 0, Graphics::kTTFRenderModeMonochrome);
-				_uniFonts[macFont->getSize()] = font;
+				int newId = macFont->getId();
+				int newSlant = macFont->getSlant();
+				int familyId = getFamilyId(newId, newSlant);
+				if (_fontInfo.contains(familyId)) {
+					font = Graphics::loadTTFFontFromArchive(_fontInfo[familyId]->name, macFont->getSize(), Graphics::kTTFSizeModeCharacter, 0, 0, Graphics::kTTFRenderModeMonochrome);
+					_uniFonts[macFont->getSize()] = font;
+				} else {
+					font = Graphics::loadTTFFontFromArchive("FreeSans.ttf", macFont->getSize(), Graphics::kTTFSizeModeCharacter, 0, 0, Graphics::kTTFRenderModeMonochrome);
+					_uniFonts[macFont->getSize()] = font;
+				}
 			}
 		} else {
 			int newId = macFont->getId();
 			int newSlant = macFont->getSlant();
 			int familyId = getFamilyId(newId, newSlant);
 			font = Graphics::loadTTFFontFromArchive(_fontInfo[familyId]->name, macFont->getSize(), Graphics::kTTFSizeModeCharacter, 0, 0, Graphics::kTTFRenderModeMonochrome);
+			_uniFonts[macFont->getSize()] = font;
 		}
 	}
 #endif

--- a/graphics/macgui/macfontmanager.h
+++ b/graphics/macgui/macfontmanager.h
@@ -33,6 +33,11 @@ namespace Common {
 
 namespace Graphics {
 
+struct TTFMap {
+	const char *ttfName;
+	uint16 slant;
+};
+
 class MacFONTFont;
 class MacFontFamily;
 
@@ -173,6 +178,10 @@ public:
 	const Common::Array<MacFontFamily *> &getFontFamilies() { return _fontFamilies; }
 
 	void printFontRegistry(int debugLevel, uint32 channel);
+
+	int registerTTFFont(const Common::Array<Graphics::TTFMap> &ttfList);
+
+	int getFamilyId(int newId, int newSlant);
 
 private:
 	void loadFontsBDF();

--- a/gui/widgets/richtext.cpp
+++ b/gui/widgets/richtext.cpp
@@ -34,6 +34,13 @@
 
 namespace GUI {
 
+Common::Array<Graphics::TTFMap> ttfFamily = {
+	{"NotoSans-Regular.ttf", Graphics::kMacFontRegular},
+	{"NotoSans-Bold.ttf", Graphics::kMacFontBold},
+	{"NotoSerif-Italic.ttf", Graphics::kMacFontItalic},
+	{"NotoSerif-Bold-Italic.ttf", Graphics::kMacFontBold | Graphics::kMacFontItalic},
+};
+
 RichTextWidget::RichTextWidget(GuiObject *boss, int x, int y, int w, int h, bool scale, const Common::U32String &text, const Common::U32String &tooltip)
 	: Widget(boss, x, y, w, h, scale, tooltip), CommandSender(nullptr)  {
 
@@ -189,7 +196,8 @@ void RichTextWidget::createWidget() {
 
 	const int fontHeight = g_gui.xmlEval()->getVar("Globals.Font.Height", 25);
 
-	Graphics::MacFont macFont(Graphics::kMacFontNewYork, fontHeight, Graphics::kMacFontRegular);
+	int newId = wm->_fontMan->registerTTFFont(ttfFamily);
+	Graphics::MacFont macFont(newId, fontHeight, Graphics::kMacFontRegular);
 
 	_txtWnd = new Graphics::MacText(Common::U32String(), wm, &macFont, fg, bg, _textWidth, Graphics::kTextAlignLeft);
 


### PR DESCRIPTION
# Add support for ttf file in markdown

I used "GoMono-Regular.ttf" in this case.

![image](https://github.com/scummvm/scummvm/assets/101713235/aa98460b-5242-432c-9fa7-ef3330e1e728)
