### PR TITLE
AGS: Fix name of Sounds directory being lower-case

### DIFF
--- a/engines/ags/plugins/ags_waves/sound.cpp
+++ b/engines/ags/plugins/ags_waves/sound.cpp
@@ -47,7 +47,7 @@ void AGSWaves::SFX_Play(ScriptMethodParams &params) {
 	_mixer->stopHandle(effect._soundHandle);
 
 	Common::FSNode fsNode = ::AGS::g_vm->getGameFolder().getChild(
-		"sounds").getChild(Common::String::format("sound%d.sfx", sfxNum));
+		"Sounds").getChild(Common::String::format("sound%d.sfx", sfxNum));
 
 	Audio::AudioStream *sound = loadOGG(fsNode);
 


### PR DESCRIPTION
Implementation is looking into "sounds" directory instead of "Sounds".
I noticed there are no sound effects on Strangeland (GOG) when playing on Linux. Looking at AGSWaves sources, it's looking for samples in "Sounds" not "sounds" directory.
Changing one letter allows game sound to function properly. Problem is not visible on Windows, as it's not case-sensitive.