### PR TITLE
M4: fixes for test 2 based on observations from the interactive demo

### DIFF
--- a/engines/m4/burger/burger.cpp
+++ b/engines/m4/burger/burger.cpp
@@ -766,7 +766,14 @@ void BurgerEngine::wilburTeleported() {
 		break;
 	}
 
-	if (_G(executing) != WHOLE_GAME) {
+	if (_G(executing) == INTERACTIVE_DEMO)  {
+		if (_G(flags)[kSecondTestPassed] && !_G(flags)[V100]) {
+			_G(game).setRoom(901);
+		} else {
+			_G(flags).reset2();
+			_G(game).setRoom(604);
+		}
+	} else if (_G(executing) != WHOLE_GAME) {
 		_G(game).setRoom(901);
 	} else {
 		if (_G(flags)[kFifthTestPassed]) {

--- a/engines/m4/burger/flags.cpp
+++ b/engines/m4/burger/flags.cpp
@@ -250,6 +250,13 @@ void Flags::reset2() {
 	if (_G(executing) != WHOLE_GAME) {
 		inv_give_to_player("BLOCK OF ICE");
 		inv_give_to_player("PANTYHOSE");
+		if (inv_player_has("KIBBLE")) {
+			inv_move_object("KIBBLE", NOWHERE);
+		}
+	}
+
+	if (_G(executing) == INTERACTIVE_DEMO) {
+		(*this)[kFirstTestPassed] = 1;
 	}
 }
 

--- a/engines/m4/burger/rooms/section6/room602.cpp
+++ b/engines/m4/burger/rooms/section6/room602.cpp
@@ -328,7 +328,7 @@ void Room602::init() {
 
 	if (_G(flags)[V277] == 6003 && _G(flags)[V278] == 1) {
 		_mouseWheel = series_play("612wheel", 0x5ff, 0, -1, 0, -1);
-
+		_series10 = series_play("612magnt", 0x600, 1, -1, 1, -1);
 	} else if (_G(game).room_id == 602) {
 		_mouseWheel = series_show("602wheel", 0x6ff, 0, -1, -1, 0);
 

--- a/engines/m4/burger/rooms/section6/room602.cpp
+++ b/engines/m4/burger/rooms/section6/room602.cpp
@@ -1131,7 +1131,7 @@ void Room602::daemon() {
 			break;
 
 		case 31:
-			player_set_commands_allowed(false);
+			player_set_commands_allowed(true);
 			ws_unhide_walker();
 			_G(wilbur_should) = 10002;
 			wilbur_speech("602w044");

--- a/engines/m4/burger/rooms/section6/room602.cpp
+++ b/engines/m4/burger/rooms/section6/room602.cpp
@@ -383,6 +383,7 @@ void Room602::init() {
 	case 603:
 		ws_hide_walker();
 		if (_G(roomVal7) == 1) {
+			_G(roomVal7) = 0;
 			_G(wilbur_should) = 2;
 			kernel_timing_trigger(30, kCHANGE_WILBUR_ANIMATION);
 		} else {

--- a/engines/m4/burger/rooms/section6/room602.cpp
+++ b/engines/m4/burger/rooms/section6/room602.cpp
@@ -643,9 +643,9 @@ void Room602::daemon() {
 		case 16:
 			if (!_G(flags)[V265]) {
 				if (_G(game).room_id == 602) {
-					_series10 = series_play("602magnt", 0x600, 1, -1, 1);
+					_series10 = series_play("602magnt", 0x600, 1, -1, 1, -1);
 				} else {
-					_series10 = series_play("612magnt", 0x600, 1, -1, 1);
+					_series10 = series_play("612magnt", 0x600, 1, -1, 1, -1);
 				}
 			}
 

--- a/engines/m4/burger/rooms/section6/room602.cpp
+++ b/engines/m4/burger/rooms/section6/room602.cpp
@@ -502,7 +502,7 @@ void Room602::daemon() {
 			break;
 
 		case 58:
-			digi_play_loop("602_004", 3, 255, 6, 602);
+			digi_play("602_004", 3, 255, 6, 602);
 			term_message("*** Play wheel... 1");
 			_G(flags)[V279] = 2;
 			term_message("Run with push.");

--- a/engines/m4/burger/rooms/section6/room602.cpp
+++ b/engines/m4/burger/rooms/section6/room602.cpp
@@ -130,6 +130,7 @@ const seriesPlayBreak Room602::PLAY6[] = {
 const seriesPlayBreak Room602::PLAY7[] = {
 	{  0, 17, nullptr,   1,   0, -1, 2048, 0, nullptr, 0 },
 	{ 18, -1, "602_010", 2, 255, -1,    0, 0, nullptr, 0 },
+	PLAY_BREAK_END
 };
 
 const seriesPlayBreak Room602::PLAY8[] = {

--- a/engines/m4/burger/rooms/section6/room602.cpp
+++ b/engines/m4/burger/rooms/section6/room602.cpp
@@ -1202,6 +1202,7 @@ void Room602::daemon() {
 			break;
 
 		case 42:
+			_G(wilbur_should) = 10002;
 			player_set_commands_allowed(false);
 			ws_unhide_walker();
 			wilbur_speech("602w033", 5);

--- a/engines/m4/burger/rooms/section6/room602.cpp
+++ b/engines/m4/burger/rooms/section6/room602.cpp
@@ -337,7 +337,7 @@ void Room602::init() {
 	}
 
 	_series3 = series_show("602door", 0xf00, 1, -1, -1, 0, 100,
-		_G(flags)[V257] / 21, _G(flags)[V257]);
+		-_G(flags)[V257] / 21, _G(flags)[V257]);
 
 	if (_G(flags)[kGerbilCageDoor] == 1) {
 		_doorShould = 63;

--- a/engines/m4/burger/rooms/section6/room603.cpp
+++ b/engines/m4/burger/rooms/section6/room603.cpp
@@ -260,6 +260,8 @@ void Room603::daemon() {
 				_val1 = 24;
 				series_play_with_breaks(PLAY14, "603hole", 0xfff, -1, 6);
 			} else {
+				_G(wilbur_should) = 20;
+				_val1 = 27;
 				series_play_with_breaks(PLAY15, "603hole", 0xfff, kCHANGE_WILBUR_ANIMATION, 2);
 			}
 

--- a/engines/m4/burger/rooms/section6/room603.cpp
+++ b/engines/m4/burger/rooms/section6/room603.cpp
@@ -402,6 +402,7 @@ void Room603::daemon() {
 			ws_demand_facing(8);
 			ws_hide_walker();
 			Section6::_state2 = 1;
+			_G(roomVal7) = 1;
 
 			if (_G(flags)[kHampsterState] == 6007) {
 				series_play_with_breaks(PLAY4, "603wi01", 0xdff, 6010, 3);
@@ -587,7 +588,7 @@ void Room603::daemon() {
 void Room603::pre_parser() {
 	_G(kernel).trigger_mode = KT_DAEMON;
 
-	if (_G(flags)[kHampsterState] == 6000 && (player_said("TUBE ") || player_said("TUBE  "))) {
+	if (_G(flags)[kHampsterState] == 6006 && (player_said("TUBE ") || player_said("TUBE  "))) {
 		term_message("Can't leave through back tube as gerbils are in the way.");
 		wilbur_speech("600w003");
 		intr_cancel_sentence();

--- a/engines/m4/burger/rooms/section6/room604.cpp
+++ b/engines/m4/burger/rooms/section6/room604.cpp
@@ -471,6 +471,7 @@ void Room604::daemon() {
 				Section6::_state4 = 5;
 				kernel_trigger_dispatch_now(6014);
 				Section6::_gerbilState = 6004;
+				_G(wilbur_should) = 18;
 				series_stream("604mg06", 4, 0xc80, kCHANGE_GERBILS_ANIMATION);
 				series_play("604mg06s", 4, 0xc80, 0, -1);
 				series_play_with_breaks(PLAY4, "604wi08", 0x4ff, kCHANGE_WILBUR_ANIMATION, 3);

--- a/engines/m4/burger/rooms/section6/room604.cpp
+++ b/engines/m4/burger/rooms/section6/room604.cpp
@@ -238,7 +238,7 @@ void Room604::init() {
 	case 603:
 	case 612:
 		if (Section6::_state2) {
-			_G(wilbur_should) = 2;
+			_G(wilbur_should) = 7;
 			kernel_trigger_dispatch_now(kCHANGE_WILBUR_ANIMATION);
 		} else {
 			_G(wilbur_should) = 6;

--- a/engines/m4/burger/rooms/section6/room604.cpp
+++ b/engines/m4/burger/rooms/section6/room604.cpp
@@ -124,12 +124,16 @@ const seriesPlayBreak Room604::PLAY9[] = {
 	PLAY_BREAK_END
 };
 
-const seriesPlayBreak Room604::PLAY10[] = {
+const seriesPlayBreak Room604::PLAY10Demo[] = {
 	{  0,  3, nullptr,   1,   0, -1, 2048, 0, nullptr, 0 },
 	{  4, 14, nullptr,   0,   0, -1,    0, 0, nullptr, 0 },
-	{ 15, 23, "604_008", 1, 255, -1,    0, 0, nullptr, 0 },
-	{  4, 14, nullptr,   0,   0, -1,    0, 0, nullptr, 0 },
-	{ 15, 23, "604_008", 1, 255, -1,    0, 0, nullptr, 0 },
+	{ 15, 23, nullptr,   1, 255, -1,    0, 0, nullptr, 0 },
+	{ 24, -1, nullptr,   0,   0, -1,    0, 0, nullptr, 0 },
+	PLAY_BREAK_END
+};
+
+const seriesPlayBreak Room604::PLAY10[] = {
+	{  0,  3, nullptr,   1,   0, -1, 2048, 0, nullptr, 0 },
 	{  4, 14, nullptr,   0,   0, -1,    0, 0, nullptr, 0 },
 	{ 15, 23, "604_008", 1, 255, -1,    0, 0, nullptr, 0 },
 	{ 24, -1, nullptr,   0,   0, -1,    0, 0, nullptr, 0 },
@@ -418,7 +422,6 @@ void Room604::daemon() {
 		case 3:
 			ws_unhide_walker();
 			player_set_commands_allowed(true);
-
 			switch (_G(flags)[V242]) {
 			case 0:
 				wilbur_speech("604w001");
@@ -502,9 +505,15 @@ void Room604::daemon() {
 			ws_hide_walker();
 			_G(wilbur_should) = 10001;
 			player_set_commands_allowed(false);
-			series_play_with_breaks(PLAY10, "604wi11", 0xa00, kCHANGE_WILBUR_ANIMATION, 3);
+			if (_G(executing) == INTERACTIVE_DEMO) {
+				series_play_with_breaks(PLAY10Demo, "604wi11", 0xa00, kCHANGE_WILBUR_ANIMATION, 3);
+			} else {
+				series_play_with_breaks(PLAY10, "604wi11", 0xa00, kCHANGE_WILBUR_ANIMATION, 3);
+			}
+			// Remove Kibble from inventory
+			kernel_trigger_dispatch_now(2);
 
-			if (_G(flags)[V274] == 0 && _G(flags)[kHampsterState] == 600) {
+			if (_G(flags)[V274] == 0 && _G(flags)[kHampsterState] == 6000) {
 				_G(flags)[kHampsterState] = 6006;
 				_G(flags)[V248] = 1;
 				term_message("The gerbils awaken");

--- a/engines/m4/burger/rooms/section6/room604.h
+++ b/engines/m4/burger/rooms/section6/room604.h
@@ -40,6 +40,7 @@ private:
 	static const seriesPlayBreak PLAY8[];
 	static const seriesPlayBreak PLAY9[];
 	static const seriesPlayBreak PLAY10[];
+	static const seriesPlayBreak PLAY10Demo[];
 	static const seriesPlayBreak PLAY11[];
 	static const seriesPlayBreak PLAY12[];
 	static int32 _state1;

--- a/engines/m4/burger/rooms/section6/section6.cpp
+++ b/engines/m4/burger/rooms/section6/section6.cpp
@@ -317,7 +317,6 @@ void Section6::daemon() {
 					_G(wilbur_should) = 6002;
 					series_play_with_breaks(PLAY1, "604melt", 0x999, kCHANGE_WILBUR_ANIMATION,
 						_G(executing) == WHOLE_GAME ? WITH_SHADOW | PRELOAD_SOUNDS : PRELOAD_SOUNDS);
-
 				}
 				break;
 
@@ -344,7 +343,14 @@ void Section6::daemon() {
 			break;
 
 		case 10015:
-			_G(game).new_room = 608;
+			if (_G(executing) == INTERACTIVE_DEMO) {
+				// After having clicked the teleporter/"failed normally" button we end up here
+				// In the DEMO this click leads to the main menu (it does not restart the test sequence)
+				_G(game).new_section = 9;
+				_G(game).new_room = 901;
+			} else {
+				_G(game).new_room = 608;
+			}
 			break;
 
 		default:


### PR DESCRIPTION
A few fixes for the test 2 that is incuded in the interactive demo. Some changes are specific to the demo and are guarded by a check for `_G(executing) == INTERACTIVE_DEMO` or `_G(executing) != WHOLE_GAME`. 

I believe most fixes (other than the demo specific ones) should apply to the full  game as well, but I cannot test with the full game. 

The fixes were done by noticing bugs and then verifying the original behavior by playing the interactive demo with DosBox.  They are not based in any disassembly of the demo or the original code so they may be doing things differently that the original code.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
