### PR TITLE
VOYEUR: Add Interplay logo animation sequence (logo8.exe)

### DIFF
--- a/engines/voyeur/voyeur.h
+++ b/engines/voyeur/voyeur.h
@@ -94,6 +94,8 @@ private:
 	void initStamp();
 	void closeStamp();
 
+	void showLogo8Intro();
+
 	/**
 	 * Shows the game ending title animation
 	 */

--- a/video/mve_decoder.h
+++ b/video/mve_decoder.h
@@ -46,6 +46,7 @@ namespace Video {
  *
  * Video decoder used in engines:
  *  - kingdom
+ *  - voyeur
  */
 class MveDecoder : public VideoDecoder {
 	bool _done;


### PR DESCRIPTION
This PR adds the Interplay logo animation to Voyeur. The animation is stored inside `logo8.exe` It is encoded as a MVE video stream.

Left mouse click, space or Escape will skip the video.

<img width="1074" alt="voyeur_logo8" src="https://github.com/scummvm/scummvm/assets/11899359/f70947fa-16a3-478a-9a26-8c05936791e3">

