### PR TITLE
AMIGAOS: Fix typo and revert default aspect ratio

### DIFF
--- a/backends/platform/sdl/amigaos/amigaos.cpp
+++ b/backends/platform/sdl/amigaos/amigaos.cpp
@@ -28,7 +28,7 @@
 #include "backends/dialogs/amigaos/amigaos-dialogs.h"
 
 void OSystem_AmigaOS::init() {
-	// Initialze File System Factory
+	// Initialize File System Factory
 	_fsFactory = new AmigaOSFilesystemFactory();
 
 	// Invoke parent implementation of this method

--- a/backends/platform/sdl/amigaos/amigaos.cpp
+++ b/backends/platform/sdl/amigaos/amigaos.cpp
@@ -101,7 +101,6 @@ void OSystem_AmigaOS::initBackend() {
 	}
 	// First time user defaults
 	ConfMan.registerDefault("audio_buffer_size", "2048");
-	ConfMan.registerDefault("aspect_ratio", true);
 	ConfMan.registerDefault("fullscreen", true);
 	ConfMan.registerDefault("gfx_mode", "surfacesdl");
 	ConfMan.registerDefault("stretch_mode", "stretch");
@@ -113,9 +112,6 @@ void OSystem_AmigaOS::initBackend() {
 	// First time .ini defaults
 	if (!ConfMan.hasKey("audio_buffer_size")) {
 		ConfMan.set("audio_buffer_size", "2048");
-	}
-	if (!ConfMan.hasKey("aspect_ratio")) {
-		ConfMan.setBool("aspect_ratio", true);
 	}
 	if (!ConfMan.hasKey("fullscreen")) {
 		ConfMan.setBool("fullscreen", true);


### PR DESCRIPTION
- Fixed a typo in comment
- Reverted the locally set default aspect ratio setting (was set to true) since #5668 will (hopefully) be merged into main which will bring said setting