### PR TITLE
ULTIMA: NUVIE: U6 spellbook fixes

### DIFF
--- a/backends/keymapper/keymapper.h
+++ b/backends/keymapper/keymapper.h
@@ -125,6 +125,11 @@ public:
 	void setEnabled(bool enabled) { _enabled = enabled; }
 
 	/**
+	 * Return the keymapper's enabled state
+	 */
+	bool isEnabled() const { return _enabled; }
+
+	/**
 	 * Clear all the keymaps and hardware input sets
 	 */
 	void clear();

--- a/engines/ultima/nuvie/core/effect.cpp
+++ b/engines/ultima/nuvie/core/effect.cpp
@@ -38,6 +38,8 @@
 #include "ultima/nuvie/core/effect.h"
 #include "ultima/nuvie/core/player.h"
 
+#include "backends/keymapper/keymapper.h"
+
 namespace Ultima {
 namespace Nuvie {
 
@@ -1629,12 +1631,17 @@ uint16 PauseEffect::callback(uint16 msg, CallBack *caller, void *data) {
 }
 
 WizardEyeEffect::WizardEyeEffect(const MapCoord &location, uint16 duration) {
+	// Disable keymapper so Wizard Eye can receive keyboard input.
+	// FIXME: Remove this once the effect can use keymapper-bound keys.
+	g_system->getEventManager()->getKeymapper()->setEnabled(false);
 	game->get_map_window()->wizard_eye_start(location, duration, this);
 }
 
 uint16 WizardEyeEffect::callback(uint16 msg, CallBack *caller, void *data) {
 	if (msg == MESG_EFFECT_COMPLETE) {
 		delete_self();
+		// FIXME: Remove this once the effect can use keymapper-bound keys.
+		g_system->getEventManager()->getKeymapper()->setEnabled(true);
 	}
 
 	return 0;

--- a/engines/ultima/nuvie/core/events.cpp
+++ b/engines/ultima/nuvie/core/events.cpp
@@ -3340,8 +3340,8 @@ void Events::cancelAction() {
 		else {
 
 			scroll->display_string("nothing\n");
-			view_manager->close_spell_mode();
 		}
+		view_manager->close_spell_mode();
 	} else if (mode == USE_MODE) {
 		if (usecode->is_script_running()) {
 			usecode->get_running_script()->resume_with_nil();

--- a/engines/ultima/nuvie/core/events.cpp
+++ b/engines/ultima/nuvie/core/events.cpp
@@ -1020,6 +1020,7 @@ bool Events::look(Obj *obj) {
 					reader = player->get_actor();
 				view_manager->close_all_gumps();
 				view_manager->set_spell_mode(reader, obj, false);
+				gui->lock_input(view_manager->get_current_view());
 				view_manager->get_current_view()->grab_focus();
 				return false;
 			}
@@ -3502,9 +3503,12 @@ void Events::endAction(bool prompt) {
 		// Leaving KEYINPUT_MODE: restore keymapper state.
 		g_system->getEventManager()->getKeymapper()->setEnabled(_keymapperStateBeforeKEYINPUT);
 
-	// Finished selecting a spell for enchant: undo spellbook input locking.
-	if (mode == CAST_MODE && gui->get_locked_widget() && gui->get_locked_widget() == view_manager->get_spell_view())
-		gui->unlock_input();
+	// Finished selecting a spell for enchant or looking at spellbook: undo spellbook input locking.
+	if (mode == CAST_MODE || (mode == LOOK_MODE && !is_looking_at_spellbook())) {
+		const GUI_Widget *const lockedWidget = gui->get_locked_widget();
+		if (lockedWidget && lockedWidget == view_manager->get_spell_view())
+			gui->unlock_input();
+	}
 
 	if (prompt) {
 		scroll->display_string("\n");

--- a/engines/ultima/nuvie/core/events.cpp
+++ b/engines/ultima/nuvie/core/events.cpp
@@ -3213,6 +3213,7 @@ void Events::doAction() {
 			get_inventory_obj(magic->get_actor_from_script());
 		} else if (magic->is_waiting_for_spell()) {
 			get_spell_num(player->get_actor(), magic->get_spellbook_obj());
+			gui->lock_input(view_manager->get_spell_view());
 		} else {
 			endAction(true);
 		}
@@ -3500,6 +3501,10 @@ void Events::endAction(bool prompt) {
 	if (mode == KEYINPUT_MODE)
 		// Leaving KEYINPUT_MODE: restore keymapper state.
 		g_system->getEventManager()->getKeymapper()->setEnabled(_keymapperStateBeforeKEYINPUT);
+
+	// Finished selecting a spell for enchant: undo spellbook input locking.
+	if (mode == CAST_MODE && gui->get_locked_widget() && gui->get_locked_widget() == view_manager->get_spell_view())
+		gui->unlock_input();
 
 	if (prompt) {
 		scroll->display_string("\n");

--- a/engines/ultima/nuvie/core/events.h
+++ b/engines/ultima/nuvie/core/events.h
@@ -225,6 +225,7 @@ private:
 	bool in_control_cheat;
 	bool looking_at_spellbook;
 	bool direction_selects_target;
+	bool _keymapperStateBeforeKEYINPUT;
 
 	uint32 fps_timestamp;
 	uint16 fps_counter;

--- a/engines/ultima/nuvie/gui/gui.cpp
+++ b/engines/ultima/nuvie/gui/gui.cpp
@@ -71,31 +71,34 @@ GUI::~GUI() {
    The widget will be automatically deleted when the GUI is deleted.
  */
 int GUI::AddWidget(GUI_Widget *widget) {
-	int i;
+	int i = numwidgets;
 
+	// This is commented out because it makes it unsafe to call AddWidget
+	// from a widget's event handler: It could delete the calling widget
+	// if it was marked for deletion during event handling.
 	/* Look for deleted widgets */
-	for (i = 0; i < numwidgets; ++i) {
-		if (widgets[i]->Status() == WIDGET_DELETED) {
-			delete widgets[i];
-			break;
-		}
-	}
-	if (i == numwidgets) {
-		/* Expand the widgets array if necessary */
-		if (numwidgets == maxwidgets) {
-			GUI_Widget **newarray;
-			int maxarray;
+	// for (i = 0; i < numwidgets; ++i) {
+	// 	if (widgets[i]->Status() == WIDGET_DELETED) {
+	// 		delete widgets[i];
+	// 		break;
+	// 	}
+	// }
+	// if (i == numwidgets) {
+	/* Expand the widgets array if necessary */
+	if (numwidgets == maxwidgets) {
+		GUI_Widget **newarray;
+		int maxarray;
 
-			maxarray = maxwidgets + WIDGET_ARRAYCHUNK;
-			if ((newarray = (GUI_Widget **)realloc(widgets,
-			                                       maxarray * sizeof(*newarray))) == nullptr) {
-				return -1;
-			}
-			widgets = newarray;
-			maxwidgets = maxarray;
+		maxarray = maxwidgets + WIDGET_ARRAYCHUNK;
+		if ((newarray = (GUI_Widget **)realloc(widgets,
+		                                       maxarray * sizeof(*newarray))) == nullptr) {
+			return -1;
 		}
-		++numwidgets;
+		widgets = newarray;
+		maxwidgets = maxarray;
 	}
+	++numwidgets;
+	// }
 	widgets[i] = widget;
 	widget->PlaceOnScreen(screen, gui_drag_manager, 0, 0);
 

--- a/engines/ultima/nuvie/views/spell_view.cpp
+++ b/engines/ultima/nuvie/views/spell_view.cpp
@@ -431,7 +431,7 @@ GUI_status SpellView::MouseDown(int x, int y, Shared::MouseButton button) {
 	if (button == Shared::BUTTON_RIGHT)
 		return cancel_spell();
 
-	if (selecting_spell_target) { // cast selected spell on the map
+	if (selecting_spell_target && !event_mode) { // cast selected spell on the map
 		if (event->is_looking_at_spellbook()) {
 			close_look();
 			return GUI_YUM;

--- a/engines/ultima/nuvie/views/spell_view_gump.cpp
+++ b/engines/ultima/nuvie/views/spell_view_gump.cpp
@@ -326,6 +326,9 @@ GUI_status SpellViewGump::MouseDown(int x, int y, Shared::MouseButton button) {
 }
 
 GUI_status SpellViewGump::MouseUp(int x, int y, Shared::MouseButton button) {
+	if (button == Shared::BUTTON_RIGHT)
+		return GUI_YUM;
+
 	sint16 spell = getSpell(x, y);
 
 	if (spell != -1 && spell == selected_spell) {

--- a/engines/ultima/nuvie/views/spell_view_gump.cpp
+++ b/engines/ultima/nuvie/views/spell_view_gump.cpp
@@ -347,7 +347,9 @@ GUI_status SpellViewGump::MouseUp(int x, int y, Shared::MouseButton button) {
 	}
 
 
-	return DraggableView::MouseUp(x, y, button);
+	auto ret = DraggableView::MouseUp(x, y, button);
+	grab_focus(); // Dragging releases focus, grab it again
+	return ret;
 }
 
 } // End of namespace Nuvie

--- a/engines/ultima/nuvie/views/spell_view_gump.cpp
+++ b/engines/ultima/nuvie/views/spell_view_gump.cpp
@@ -314,7 +314,8 @@ GUI_status SpellViewGump::MouseDown(int x, int y, Shared::MouseButton button) {
 			close_spellbook();
 			return GUI_YUM;
 		}
-		event->target_spell(); //Simulate a global key down event.
+		if (!event_mode)
+			event->target_spell(); //Simulate a global key down event.
 		if (event->get_mode() == INPUT_MODE)
 			Game::get_game()->get_map_window()->select_target(x, y);
 		if (event->get_mode() != MOVE_MODE)


### PR DESCRIPTION
- Fix regression which made it impossible to enter some spell syllables using the keyboard.
Fixes [#14959](https://bugs.scummvm.org/ticket/14959) "Cannot Cast Spells using Keyboard in Ultima VI"

- Fix crash due to inventory gump deleting itself in its own event handler when opening the spellbook from a look action or for selection of an object to use with the enchant spell.
Fixes [#14957](https://bugs.scummvm.org/ticket/14957) "Using an Enchanted Staff spell crashes the game in Ultima VI"

- Fix some spellbook crashes when selecting a spell for enchant.

- Lock input to spellbook when looking at it so it can be navigated using the keyboard.

- Fix regression which prevented controlling Wizard Eye via the cursor keys.