### PR TITLE
Revert "GRAPHICS: Make the Graphics::PixelFormat constructors constexpr"

### DIFF
--- a/graphics/pixelformat.h
+++ b/graphics/pixelformat.h
@@ -142,10 +142,11 @@ struct PixelFormat {
 	byte rShift, gShift, bShift, aShift; /**< Binary left shift of each color component in the pixel value. */
 
 	/** Default constructor that creates a null pixel format. */
-	constexpr PixelFormat() :
-		bytesPerPixel(0),
-		rLoss(0), gLoss(0), bLoss(0), aLoss(0),
-		rShift(0), gShift(0), bShift(0), aShift(0) {}
+	inline PixelFormat() {
+		bytesPerPixel =
+		rLoss = gLoss = bLoss = aLoss =
+		rShift = gShift = bShift = aShift = 0;
+	}
 
 	/** Construct a pixel format based on the provided arguments.
 	 *
@@ -165,18 +166,19 @@ struct PixelFormat {
 	 *  @endcode
 	 */
 
-	constexpr PixelFormat(byte BytesPerPixel,
+	inline PixelFormat(byte BytesPerPixel,
 						byte RBits, byte GBits, byte BBits, byte ABits,
-						byte RShift, byte GShift, byte BShift, byte AShift) :
-		bytesPerPixel(BytesPerPixel),
-		rLoss(8 - RBits),
-		gLoss(8 - GBits),
-		bLoss(8 - BBits),
-		aLoss(8 - ABits),
-		rShift(RShift),
-		gShift(GShift),
-		bShift(BShift),
-		aShift(AShift) {}
+						byte RShift, byte GShift, byte BShift, byte AShift) {
+		bytesPerPixel = BytesPerPixel;
+		rLoss = 8 - RBits;
+		gLoss = 8 - GBits;
+		bLoss = 8 - BBits;
+		aLoss = 8 - ABits;
+		rShift = RShift;
+		gShift = GShift;
+		bShift = BShift;
+		aShift = AShift;
+	}
 
 	/** Define a CLUT8 pixel format. */
 	static inline PixelFormat createFormatCLUT8() {


### PR DESCRIPTION
This reverts commit 6522c6e11d2cfb60bef8972bfa4ee5716b012873. Fixes bug #14837 and bug #14905

This commit broke various engines in the 3DS port under varying conditions, details of which can be found [here](https://bugs.scummvm.org/ticket/14905#comment:8).

This is a quick fix. As I stated in the link above, I suspect that the cause might be related to how the 3DS port handles plugins linking, but I can't be sure as that's outside my level of knowledge.