### PR TITLE
AUDIO: Fix problem where fluidsynth soundfont could not be loaded

### DIFF
--- a/audio/softsynth/fluidsynth.cpp
+++ b/audio/softsynth/fluidsynth.cpp
@@ -285,11 +285,11 @@ Common::Path MidiDriver_FluidSynth::getSoundFontPath() const {
 	if (path.empty())
 		return path;
 
-	// First check if this is a full path
-	Common::Path fullPath(g_system->getFilesystemFactory()->getSystemFullPath(path.toString(Common::Path::kNativeSeparator)), Common::Path::kNativeSeparator);
-	Common::FSNode fileNode(fullPath);
-	if (fileNode.exists())
-		return fullPath;
+	Common::FSNode fileNode(path);
+	if (fileNode.exists()) {
+		// Return the full system path to the soundfont
+		return Common::Path(g_system->getFilesystemFactory()->getSystemFullPath(path.toString(Common::Path::kNativeSeparator)), Common::Path::kNativeSeparator);
+	}
 
 	// Then check with soundfontpath
 	if (ConfMan.hasKey("soundfontpath")) {


### PR DESCRIPTION
The user can specify a custom soundfont to be used with fluidsynth. There was previously a hack for the iOS7 backend to get the path to the document folder where the user can put files in a sandboxed environment. This hack was removed in commit:
cac06647571a3352cb108faad48af9271a69ce36

The problem however occurred when creating a FSNode from the full system path because FSNode uses makeFileNodePath, which already prepends the root. So the full path is added twice which causes the fileNode.exists() to fail.

Create the FSNode from the path to the soundfont and check if the file exist. If so then return the full path.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
