### PR TITLE
AGI: Fix missing words from our dictionary

### DIFF
--- a/engines/agi/words.cpp
+++ b/engines/agi/words.cpp
@@ -80,6 +80,8 @@ int Words::loadDictionary(const char *fname) {
 
 	// Loop through alphabet, as words in the dictionary file are sorted by
 	// first character
+	char str[64] = { 0 };
+	char c;
 	for (int i = 0; i < 26; i++) {
 		fp.seek(i * 2, SEEK_SET);
 		int offset = fp.readUint16BE();
@@ -89,7 +91,6 @@ int Words::loadDictionary(const char *fname) {
 		int k = fp.readByte();
 		while (!fp.eos() && !fp.err()) {
 			// Read next word
-			char c, str[64];
 			do {
 				c = fp.readByte();
 				str[k++] = (c ^ 0x7F) & 0x7F;
@@ -106,6 +107,8 @@ int Words::loadDictionary(const char *fname) {
 				newWord->word = Common::String(str, k);
 				newWord->id = fp.readUint16BE();
 				_dictionaryWords[i].push_back(newWord);
+			} else {
+				fp.readUint16BE();
 			}
 
 			k = fp.readByte();


### PR DESCRIPTION
This fixes bug #15000 "V Demo does not recognize valid word ammunition"

Our code was actually not parsing correctly many (all?) words starting with "a" in this particular game.

I've also quickly checked with Space Quest 0 AGI fan made game and it seems that the workaround code (which was made for a bug reported for that game) still works with my fix. 

Of course someone more familiar with the AGI engine should review this.
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
