### PR TITLE
COMMON: move mappedEvents declaration out of for loop

### DIFF
--- a/common/events.cpp
+++ b/common/events.cpp
@@ -71,6 +71,7 @@ EventDispatcher::~EventDispatcher() {
 
 void EventDispatcher::dispatch() {
 	Event event;
+	List<Event> mappedEvents;
 
 	dispatchPoll();
 
@@ -91,7 +92,7 @@ void EventDispatcher::dispatch() {
 				assert(event.type != EVENT_CUSTOM_ENGINE_ACTION_END);
 
 				for (List<MapperEntry>::iterator m = _mappers.begin(); m != _mappers.end(); ++m) {
-					List<Event> mappedEvents;
+					mappedEvents.clear();
 					if (!m->mapper->mapEvent(event, mappedEvents))
 						continue;
 


### PR DESCRIPTION
This fixes a segfault on a linux build for armhf Amlogic of the libretro port, occurring everytime a input event is received (e.g. user presses any button).
It seems related to compiler optimization level (as with `-O0` does not occur) and `gcc` version (occurs with v12.2.0 but not with v10.2.0).