### PR TITLE
MACVENTURE: Fix loading filenames with unicode characters

### DIFF
--- a/engines/macventure/macventure.cpp
+++ b/engines/macventure/macventure.cpp
@@ -32,6 +32,7 @@
 #include "common/debug.h"
 #include "common/error.h"
 #include "common/config-manager.h"
+#include "common/str-enc.h"
 #include "engines/util.h"
 
 #include "macventure/macventure.h"
@@ -40,20 +41,6 @@
 #include "common/file.h"
 
 namespace MacVenture {
-
-// HACK, see below
-void toASCII(Common::String &str) {
-	debugC(3, kMVDebugMain, "toASCII: %s", str.c_str());
-	Common::String::iterator it = str.begin();
-	for (; it != str.end(); it++) {
-		if (*it == '\216') {
-			str.replace(it, it + 1, "e");
-		}
-		if (*it == '\210') {
-			str.replace(it, it + 1, "a");
-		}
-	}
-}
 
 enum {
 	kMaxMenuTitleLength = 30
@@ -467,9 +454,8 @@ Common::Path MacVentureEngine::getStartGameFileName() {
 	char *fileName = new char[length + 1];
 	res->read(fileName, length);
 	fileName[length] = '\0';
-	Common::String result = Common::String(fileName, length);
-	// HACK, see definition of toASCII
-	toASCII(result);
+
+	Common::U32String result(fileName, Common::kMacRoman);
 
 	delete[] fileName;
 	delete res;

--- a/engines/macventure/stringtable.h
+++ b/engines/macventure/stringtable.h
@@ -33,10 +33,9 @@
 #include "macventure/macventure.h"
 
 #include "common/file.h"
+#include "common/str-enc.h"
 
 namespace MacVenture {
-
-extern void toASCII(Common::String &str);
 
 enum StringTableID {
 	kErrorStringTableID = 0x80,
@@ -89,9 +88,9 @@ private:
 			char *str = new char[strLength + 1];
 			res->read(str, strLength);
 			str[strLength] = '\0';
-			// HACK until a proper special char implementation is found, this will have to do.
-			Common::String result = Common::String(str);
-			toASCII(result);
+
+			Common::U32String result(str, Common::kMacRoman);
+
 			debugC(4, kMVDebugText, "Loaded string %s", str);
 			_strings.push_back(Common::String(result));
 			delete[] str;


### PR DESCRIPTION
files in games like "Déjà Vu" are dumped to disk after being unicode encoded, whereas the game expected them to be in MacRoman