### PR TITLE
DISTS: Fix numerous problems with resource compilation on Win32 MinGW build

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -220,17 +220,27 @@ endif
 	$(QUIET_AS)$(AS) $(ASFLAGS) $(<) -o $@
 
 # Build rule for Windows resource files
-# The regular expression is a portable form of ^(.*\s(FILE|ICON|RT_MANIFEST|DATA)|#include)\s+"([^"]*)".*$
-# This finds lines in the form '... FILE "path/file.ext" ...' (and also ICON and #include)
-# and replaces them with the $(srcdir)/path/file.ext \
-# The second sed removes winresrc.h (system include) and config.h (not in srcdir, printed
-# by the echo before sed), and strips the trailing backslash on the last line.
+# This has multiple passes to generate the deps file:
+# First is to include config.h and config.mk
+# Second is to process all #include "*.h" form includes into source-tree deps
+# Third is to process all #include "*.rh" form includes into build-tree deps
+# Fourth is to process all FILE, ICON, RT_MANIFEST, and DATA lines into source-tree deps
+# The regexes are portable forms of:
+#     ^#include\s+"([^"]*).h".*$
+#     ^#include\s+"([^"]*).rh".*$
+#     ^(.*\s(FILE|ICON|RT_MANIFEST|DATA))\s+"([^"]*)".*$
+# The first sed removes winresrc.h (system include) and config.h (not in srcdir, printed
+# by the echo before sed), the last strips the trailing backslash on the last line.
 %.o: %.rc
 	$(QUIET)$(MKDIR) $(*D)
 	$(QUIET)$(MKDIR) $(*D)/$(DEPDIR)
 	$(QUIET)echo "$@: $< config.h config.mk \\" > $(*D)/$(DEPDIR)/scummvm.d
-	$(QUIET)sed -n 's:^\(.*[[:space:]]\(FILE\|ICON\|RT_MANIFEST\|DATA\)\|#include\)[[:space:]][[:space:]]*"\([^"]*\)".*$$:    $(srcdir)/\3 \\:p; ' $(<) | \
-		sed '/winresrc\.h\|config\.h/d; $$ s/ \\//' >> $(*D)/$(DEPDIR)/scummvm.d
+	$(QUIET)sed -n 's:^\#include[[:space:]][[:space:]]*"\([^"]*\.h\)".*$$:    $(srcdir)/\1 \\:p; ' $(<) | \
+		sed '/winresrc\.h\|config\.h/d' >> $(*D)/$(DEPDIR)/scummvm.d
+	$(QUIET)sed -n 's:^\#include[[:space:]][[:space:]]*"\([^"]*\.rh\)".*$$:    \1 \\:p; ' $(<) \
+		>> $(*D)/$(DEPDIR)/scummvm.d
+	$(QUIET)sed -n 's:^\(.*[[:space:]]\(FILE\|ICON\|RT_MANIFEST\|DATA\)\)[[:space:]][[:space:]]*"\([^"]*\)".*$$:    $(srcdir)/\3 \\:p; ' $(<) | \
+		sed '$$ s/ \\//' >> $(*D)/$(DEPDIR)/scummvm.d
 	$(QUIET_WINDRES)$(WINDRES) $(WINDRESFLAGS) $(CPPFLAGS) $(<) -o $@
 
 ifdef USE_NASM
@@ -406,16 +416,19 @@ DIST_FILES_VKEYBD:=$(addprefix $(srcdir)/backends/vkeybd/packs/,vkeybd_default.z
 endif
 
 # Engine data files
+DIST_FILES_ENGINEDATA_BASE_CORE_SOURCE:=$(srcdir)/dists/engine-data/engine_data_core.mk
 DIST_FILES_LIST=
--include $(srcdir)/dists/engine-data/engine_data_core.mk
+-include $(DIST_FILES_ENGINEDATA_BASE_CORE_SOURCE)
 DIST_FILES_ENGINEDATA_BASE_CORE:=$(DIST_FILES_LIST)
 
+DIST_FILES_ENGINEDATA_BASE_SOURCE:=$(srcdir)/dists/engine-data/engine_data.mk
 DIST_FILES_LIST=
--include $(srcdir)/dists/engine-data/engine_data.mk
+-include $(DIST_FILES_ENGINEDATA_BASE_SOURCE)
 DIST_FILES_ENGINEDATA_BASE:=$(DIST_FILES_LIST)
 
+DIST_FILES_ENGINEDATA_BASE_BIG_SOURCE:=$(srcdir)/dists/engine-data/engine_data_big.mk
 DIST_FILES_LIST=
--include $(srcdir)/dists/engine-data/engine_data_big.mk
+-include $(DIST_FILES_ENGINEDATA_BASE_BIG_SOURCE)
 DIST_FILES_ENGINEDATA_BASE_BIG:=$(DIST_FILES_LIST)
 
 DIST_FILES_ENGINEDATA:=$(addprefix $(srcdir)/,$(DIST_FILES_ENGINEDATA_BASE_CORE) $(DIST_FILES_ENGINEDATA_BASE))

--- a/backends/platform/sdl/win32/win32.mk
+++ b/backends/platform/sdl/win32/win32.mk
@@ -11,14 +11,16 @@ clean: clean-win32-resource-embed
 .PHONY: clean-win32-resource-embed
 
 define win32-resource-embed-macro=
-$(1): configure.stamp
-	@echo '    GENERATE' $$@
-	@echo $$(foreach filename,$$($(2)),$$(filename)) | sed -e 's/ /\n/g' | sed -E 's/(.*\/)(.+)/\2 FILE "\1\2"/g' >> $$@
+$(1): configure.stamp $(foreach filename,$($(2)), $(srcdir)/$(filename)) $($(2)_SOURCE)
+	$(QUIET)echo '    GENERATE' $$@
+	$(QUIET)mkdir -p $$(dir $$@)
+	$(QUIET)echo -n '' > $$@
+	$(QUIET)echo $$(foreach filename,$$($(2)),$$(filename)) | sed -e 's/ /\n/g' | sed -E 's/(.*\/)(.+)/\2 FILE "\1\2"/g' >> $$@
 
 dists/scummvm.o: $(1)
 
 clean-win32-resource-embed-$(1):
-	$(RM) $(srcdir)/$(1)
+	$(RM) $(1)
 
 clean-win32-resource-embed: clean-win32-resource-embed-$(1)
 


### PR DESCRIPTION
Fixes multiple issues with the new resource files on Win32 builds.

Make .rh files dependent on their contents (maybe they should be deps of the .rc file, but this seems slightly easier)
Make .rh files dependent on the .mk file that their item lists come from
Fix .rh files not creating destination directory
Fix .rh dependencies of .rc file being source-relative instead of build-relative
Fix .rh clean paths being source-relative instead of build-relative
Fix .rh generation appending to the old .rh instead of overwriting