### PR TITLE
DOCS: Fix docs build for 2.8

### DIFF
--- a/doc/docportal/requirements.txt
+++ b/doc/docportal/requirements.txt
@@ -4,3 +4,10 @@ sphinx<5
 docutils==0.17
 sphinx_rtd_theme==1.0.0
 sphinx-mdinclude==0.5.3
+
+# Dependencies of sphinx<5
+sphinxcontrib_applehelp==1.0.4
+sphinxcontrib_devhelp==1.0.2
+sphinxcontrib_htmlhelp==2.0.1
+sphinxcontrib_serializinghtml==1.1.5
+sphinxcontrib_qthelp==1.0.3


### PR DESCRIPTION
Make a PR to have CI check before merge. This is a cherry-pick of 9e188bff2029bb55f8e4384a602220968135b295.

Latest versions of sphinxcontrib dropped sphinx requirement and checks the version at runtime.
By pinning to the latest versions supporting Sphinx 4, build succeeds.