### PR TITLE
AGI: Restrict AGIMOUSE feature to AGIMOUSE games

### DIFF
--- a/engines/agi/agi.h
+++ b/engines/agi/agi.h
@@ -116,7 +116,7 @@ enum AgiGameType {
 };
 
 enum AgiGameFeatures {
-	GF_AGIMOUSE    = (1 << 0), // this disables "Click-to-walk mouse interface"
+	GF_AGIMOUSE    = (1 << 0), // marks games created with AGIMOUSE, disables "Click-to-walk mouse interface"
 	GF_AGDS        = (1 << 1), // marks games created with AGDS - all using AGI version 2.440
 	GF_AGI256      = (1 << 2), // marks fanmade AGI-256 games
 	GF_FANMADE     = (1 << 3), // marks fanmade games

--- a/engines/agi/cycle.cpp
+++ b/engines/agi/cycle.cpp
@@ -183,10 +183,10 @@ uint16 AgiEngine::processAGIEvents() {
 
 	// In AGI Mouse emulation mode we must update the mouse-related
 	// vars in every interpreter cycle.
-	//
-	// We run AGIMOUSE always as a side effect
-	setVar(VM_VAR_MOUSE_X, _mouse.pos.x / 2);
-	setVar(VM_VAR_MOUSE_Y, _mouse.pos.y);
+	if (getFeatures() & GF_AGIMOUSE) {
+		setVar(VM_VAR_MOUSE_X, _mouse.pos.x / 2);
+		setVar(VM_VAR_MOUSE_Y, _mouse.pos.y);
+	}
 
 	if (!cycleInnerLoopIsActive()) {
 		// Click-to-walk mouse interface

--- a/engines/agi/op_cmd.cpp
+++ b/engines/agi/op_cmd.cpp
@@ -992,7 +992,7 @@ void cmdSetSimple(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
 	}
 }
 
-// push.script was not available until 2.425, and also not available in 2.440
+// pop.script was not available until 2.425, and also not available in 2.440
 void cmdPopScript(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
 	if ((vm->getVersion() < 0x2425) || (vm->getVersion() == 0x2440)) {
 		// was not available before 2.2425, but also not available in 2.440
@@ -2224,7 +2224,17 @@ void cmdPrintAtV(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
 
 // push.script was not available until 2.425, and also not available in 2.440
 void cmdPushScript(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
-	// We run AGIMOUSE always as a side effect
+	if ((vm->getVersion() < 0x2425) || (vm->getVersion() == 0x2440)) {
+		// was not available before 2.2425, but also not available in 2.440
+		warning("push.script called, although not available for current AGI version");
+		return;
+	}
+
+	debug(0, "push.script");
+}
+
+// The AGIMOUSE interpreter modified push.script to set variables 27-29 to mouse state
+void cmdAgiMousePushScript(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
 	vm->setVar(VM_VAR_MOUSE_BUTTONSTATE, state->_vm->_mouse.button);
 	vm->setVar(VM_VAR_MOUSE_X, vm->_mouse.pos.x / 2);
 	vm->setVar(VM_VAR_MOUSE_Y, vm->_mouse.pos.y);

--- a/engines/agi/opcodes.cpp
+++ b/engines/agi/opcodes.cpp
@@ -462,6 +462,11 @@ void AgiEngine::setupOpCodes(uint16 version) {
 		}
 	}
 
+	// AGIMOUSE games use a modified push.script that updates mouse state
+	if (getFeatures() & GF_AGIMOUSE) {
+		_opCodes[0xab].functionPtr = &cmdAgiMousePushScript;
+	}
+
 	// add invalid entries for every opcode, that is not defined at all
 	for (int opCodeNr = opCodesTableSize; opCodeNr < ARRAYSIZE(_opCodes); opCodeNr++) {
 		_opCodes[opCodeNr].name = "illegal";

--- a/engines/agi/opcodes.h
+++ b/engines/agi/opcodes.h
@@ -208,6 +208,7 @@ void cmdDivV(AgiGame *state, AgiEngine *vm, uint8 *p);  // 0xa8
 void cmdCloseWindow(AgiGame *state, AgiEngine *vm, uint8 *p);
 void cmdSetSimple(AgiGame *state, AgiEngine *vm, uint8 *p);
 void cmdPushScript(AgiGame *state, AgiEngine *vm, uint8 *p);
+void cmdAgiMousePushScript(AgiGame *state, AgiEngine *vm, uint8 *p); // modified 0xab
 void cmdPopScript(AgiGame *state, AgiEngine *vm, uint8 *p);
 void cmdHoldKey(AgiGame *state, AgiEngine *vm, uint8 *p);
 void cmdSetPriBase(AgiGame *state, AgiEngine *vm, uint8 *p);


### PR DESCRIPTION
This fixes overwriting variables 27-29 in all AGI games.

AGIMOUSE was a modified interpreter that wrote mouse state to variables 27-29 so fan games could use mouse functions. We have been doing this unconditionally, and overwriting these variables in all games. When I saw this code, I said "wait, won't that break normal games?" and then looked in the tracker and found a three year old ticket about a fan game named Phil's Quest where you instantly die in ScummVM: https://bugs.scummvm.org/ticket/12747 . The health meter is variable 28, which is AGIMOUSE's x coordinate, so really you die depending on if the mouse is on the left or right side of the screen.

Scanning my corpus of AGI games, I see that these variables are used in plenty of others, so this has caused other subtle problems.

We already track which games use AGIMOUSE in the detection table; now the feature is restricted to just them. I've restored the default push.script code (logging and warning) to match our pop.script code.