### PR TITLE
Add More Non-Portable Functions to Forbidden Header

### DIFF
--- a/common/forbidden.h
+++ b/common/forbidden.h
@@ -494,6 +494,20 @@
 
 #endif // FORBIDDEN_SYMBOL_EXCEPTION_math_h
 
+// Use Common::String::format
+#ifndef FORBIDDEN_SYMBOL_EXCEPTION_itoa
+#undef itoa
+#define itoa(a,b,c)	FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
+#endif
+
+// Use Common::String::format
+#ifndef FORBIDDEN_SYMBOL_EXCEPTION_uitoa
+#undef uitoa
+#define uitoa(a,b,c)	FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
+#endif
+
+// FIXME: Forbid atoi as well?
+
 // No equivalent in ScummVM
 #ifndef FORBIDDEN_SYMBOL_EXCEPTION_mkdir
 #undef mkdir

--- a/common/forbidden.h
+++ b/common/forbidden.h
@@ -627,6 +627,18 @@
 #define strdup(a)	FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
 #endif
 
+// Use Common::String.toLowercase()
+#ifndef FORBIDDEN_SYMBOL_EXCEPTION_strlwr
+#undef strlwr
+#define strlwr(a)	FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
+#endif
+
+// Use Common::String.toUppercase()
+#ifndef FORBIDDEN_SYMBOL_EXCEPTION_strupr
+#undef strupr
+#define strupr(a)	FORBIDDEN_look_at_common_forbidden_h_for_more_info SYMBOL !%*
+#endif
+
 /*
  * We also would like to disable the following symbols;
  * however, these are also frequently used in regular code,

--- a/common/ustr.cpp
+++ b/common/ustr.cpp
@@ -196,13 +196,13 @@ int U32String::vformat(const value_type *fmt, const value_type *fmtEnd, U32Strin
 			// fallthrough intended
 			case 'd':
 				int_temp = va_arg(args, int);
-				itoa(int_temp, buffer, 10);
+				ustr_helper_itoa(int_temp, buffer, 10);
 
 				output += buffer;
 				break;
 			case 'u':
 				uint_temp = va_arg(args, uint);
-				uitoa(uint_temp, buffer, 10);
+				ustr_helper_uitoa(uint_temp, buffer, 10);
 
 				output += buffer;
 				break;
@@ -234,18 +234,18 @@ int U32String::vformat(const value_type *fmt, const value_type *fmtEnd, U32Strin
 	return output.size();
 }
 
-U32String::value_type* U32String::itoa(int num, value_type* str, uint base) {
+U32String::value_type* U32String::ustr_helper_itoa(int num, value_type* str, uint base) {
 	if (num < 0) {
 		str[0] = '-';
-		uitoa(-num, str + 1, base);
+		ustr_helper_uitoa(-num, str + 1, base);
 	} else {
-		uitoa(num, str, base);
+		ustr_helper_uitoa(num, str, base);
 	}
 
 	return str;
 }
 
-U32String::value_type* U32String::uitoa(uint num, value_type* str, uint base) {
+U32String::value_type* U32String::ustr_helper_uitoa(uint num, value_type* str, uint base) {
 	int i = 0;
 
 	if (num) {

--- a/common/ustr.h
+++ b/common/ustr.h
@@ -194,13 +194,13 @@ private:
 	 * Helper function for vformat. Convert an int to a string.
 	 * Minimal implementation, only for base 10.
 	 */
-	static value_type* itoa(int num, value_type* str, uint base);
+	static value_type* ustr_helper_itoa(int num, value_type* str, uint base);
 
 	/**
 	 * Helper function for vformat. Convert an unsigned int to a string.
 	 * Minimal implementation, only for base 10.
 	 */
-	static value_type* uitoa(uint num, value_type* str, uint base);
+	static value_type* ustr_helper_uitoa(uint num, value_type* str, uint base);
 
 	void decodeInternal(const char *str, uint32 len, CodePage page);
 	void decodeOneByte(const char *str, uint32 len, CodePage page);

--- a/engines/glk/hugo/hemisc.cpp
+++ b/engines/glk/hugo/hemisc.cpp
@@ -2170,9 +2170,9 @@ HUGO_FILE TrytoOpen(char *f, char *p, char *d)
 		strcpy(envvar, "hugo_");        /* the actual var. name */
 		strcat(envvar, d);
 
-		if (getenv(strupr(envvar)))
+		if (getenv(hugo_strupr(envvar)))
 		{
-			hugo_makepath(temppath, "", getenv(strupr(envvar)), fname, ext);
+			hugo_makepath(temppath, "", getenv(hugo_strupr(envvar)), fname, ext);
 
 			if ((tempfile = HUGO_FOPEN(temppath, p)))
 			{

--- a/engines/glk/hugo/heparse.cpp
+++ b/engines/glk/hugo/heparse.cpp
@@ -1656,7 +1656,7 @@ CheckWord:
 		/* a number */
 		case NUMBER_T:
 			if ((STARTS_AS_NUMBER(word[*wordnum])) &&
-				!strcmp(itoa(atoi(word[*wordnum]), num, 10, sizeof(num)), word[*wordnum]))
+				!strcmp(hugo_itoa(atoi(word[*wordnum]), num, 10, sizeof(num)), word[*wordnum]))
 			{
 				if (obj_match_state==1)
 					var[xobject] = atoi(word[*wordnum]);
@@ -1739,7 +1739,7 @@ CheckWordorString:
 
 					/* or a number */
 					else if ((p==NUMBER_T && STARTS_AS_NUMBER(word[*wordnum])) &&
-						!strcmp(word[*wordnum], itoa(atoi(word[*wordnum]), num, 10, sizeof(num))))
+						!strcmp(word[*wordnum], hugo_itoa(atoi(word[*wordnum]), num, 10, sizeof(num))))
 					{
 						grammaraddr = nextsyntax;
 						if (*wordnum != objstart)
@@ -1852,7 +1852,7 @@ CheckXobjectFinish:
 							goto CheckXobjectFinish;
 						}
 						else if ((p==NUMBER_T && STARTS_AS_NUMBER(word[*wordnum])) &&
-							!strcmp(word[*wordnum], itoa(atoi(word[*wordnum]), num, 10, sizeof(num))))
+							!strcmp(word[*wordnum], hugo_itoa(atoi(word[*wordnum]), num, 10, sizeof(num))))
 						{
 							objfinish = i;
 							break;
@@ -1984,7 +1984,7 @@ int Hugo::Parse() {
 			wd[i] = FindWord(word[i]);
 
 			/* Numbers -32768 to 32767 are valid...*/
-			if (!strcmp(word[i], itoa(atoi(word[i]), num, 10, sizeof(num))))
+			if (!strcmp(word[i], hugo_itoa(atoi(word[i]), num, 10, sizeof(num))))
 			{
 #if !defined (MATH_16BIT)
 				if (atoi(word[i]) > 32767 || atoi(word[i]) < -32768)
@@ -2415,12 +2415,12 @@ void Hugo::SeparateWords() {
 			   as the modified word, storing the original hh:mm
 			   in parse$:
 			*/
-			if (!strcmp(w1, itoa((int)n1, temp, 10, sizeof(temp))) &&
-				!strcmp(w2, itoa((int)n2, temp, 10, sizeof(temp))) &&
+			if (!strcmp(w1, hugo_itoa((int)n1, temp, 10, sizeof(temp))) &&
+				!strcmp(w2, hugo_itoa((int)n2, temp, 10, sizeof(temp))) &&
 				(n1 > 0 && n1 < 25) && (n2 >= 0 && n2 < 60))
 			{
 				Common::strcpy_s(parseerr, word[i]);
-				itoa(n1 * 60 + n2, word[i], 10, strlen(word[i]) + 1);
+				hugo_itoa(n1 * 60 + n2, word[i], 10, strlen(word[i]) + 1);
 			}
 		}
 	}

--- a/engines/glk/hugo/heres.cpp
+++ b/engines/glk/hugo/heres.cpp
@@ -267,7 +267,7 @@ long Hugo::FindResource(const char *filename, const char *resname) {
 
 
 	/* Open the resourcefile */
-	//strupr(filename);
+	//hugo_strupr(filename);
 
 #if !defined (GLK)
 	/* stdio implementation */
@@ -437,7 +437,7 @@ int Hugo::GetResourceParameters(char *filename, char *resname, int restype) {
 
 	if (MEM(codeptr++)!=EOL_T)	/* two or more parameters */
 	{
-		strupr(filename);
+		hugo_strupr(filename);
 		Common::strcpy_s(resname, MAX_RES_PATH, GetWord(GetValue()));
 		if (MEM(codeptr++)==COMMA_T)
 		{

--- a/engines/glk/hugo/herun.cpp
+++ b/engines/glk/hugo/herun.cpp
@@ -842,7 +842,7 @@ void Hugo::RunInput() {
 	if (debugger_collapsing) return;
 #endif
 
-	Common::strcpy_s(buffer, Rtrim(strlwr(buffer)));
+	Common::strcpy_s(buffer, Rtrim(hugo_strlwr(buffer)));
 
 	SeparateWords();
 

--- a/engines/glk/hugo/herun.cpp
+++ b/engines/glk/hugo/herun.cpp
@@ -1038,14 +1038,14 @@ void Hugo::RunPrint() {
 					if (!hexnumber)
 					{
 						// FIXME: This code has identical branch code since the cast to unsigned int of a
-						//        is reversed by passing this to itoa as this has the function signature of:
-						//        char * itoa(int value, char *str, int base)
+						//        is reversed by passing this to hugo_itoa as this has the function signature of:
+						//        char * hugo_itoa(int value, char *str, int base)
 #if 0
 						if (capital)
-							itoa((unsigned int)a, line, 10);
+							hugo_itoa((unsigned int)a, line, 10);
 						else
 #endif
-							itoa(a, line, 10, sizeof(line));
+							hugo_itoa(a, line, 10, sizeof(line));
 						capital = 0;
 					}
 					else

--- a/engines/glk/hugo/heset.cpp
+++ b/engines/glk/hugo/heset.cpp
@@ -144,8 +144,8 @@ GetNextWord:
 				if ((unsigned short)wd[a]!=UNKNOWN_WORD)
 					Common::strcpy_s(buffer+t, sizeof(buffer) - t, GetWord(wd[a]));
 				else
-					itoa(parsed_number, buffer+t, 10, sizeof(buffer) - t);
-			        word[a] = buffer + t;
+					hugo_itoa(parsed_number, buffer+t, 10, sizeof(buffer) - t);
+				word[a] = buffer + t;
 				t+=strlen(word[a])+1;
 			}
 

--- a/engines/glk/hugo/hugo.h
+++ b/engines/glk/hugo/hugo.h
@@ -1122,7 +1122,7 @@ private:
 		return _random.getRandomNumber(0xffffff);
 	}
 
-	char *itoa(int value, char *str, int base, size_t str_size) {
+	char *hugo_itoa(int value, char *str, int base, size_t str_size) {
 		assert(base == 10);
 		Common::sprintf_s(str, str_size, "%d", value);
 		return str;

--- a/engines/glk/hugo/stringfn.cpp
+++ b/engines/glk/hugo/stringfn.cpp
@@ -103,13 +103,13 @@ char *StringFunctions::GetTempString() {
 	return r;
 }
 
-char *StringFunctions::strlwr(char *s) {
+char *StringFunctions::hugo_strlwr(char *s) {
 	for (char *sp = s; *sp; ++sp)
 		*sp = tolower(*sp);
 	return s;
 }
 
-char *StringFunctions::strupr(char *s) {
+char *StringFunctions::hugo_strupr(char *s) {
 	for (char *sp = s; *sp; ++sp)
 		*sp = toupper(*sp);
 	return s;

--- a/engines/glk/hugo/stringfn.h
+++ b/engines/glk/hugo/stringfn.h
@@ -57,9 +57,9 @@ public:
 
 	char *hugo_strcpy(char *s, const char *t);
 
-	char *strlwr(char *s);
+	char *hugo_strlwr(char *s);
 
-	char *strupr(char *s);
+	char *hugo_strupr(char *s);
 };
 
 } // End of namespace Hugo

--- a/engines/hugo/parser_v1d.cpp
+++ b/engines/hugo/parser_v1d.cpp
@@ -313,7 +313,7 @@ void Parser_v1d::lineHandler() {
 		return;
 	}
 
-	Utils::strlwr(_vm->_line);                      // Convert to lower case
+	Utils::hugo_strlwr(_vm->_line);                      // Convert to lower case
 
 	// God Mode cheat commands:
 	// goto <screen>                                Takes hero to named screen

--- a/engines/hugo/parser_v1w.cpp
+++ b/engines/hugo/parser_v1w.cpp
@@ -64,7 +64,7 @@ void Parser_v1w::lineHandler() {
 		return;
 	}
 
-	Utils::strlwr(_vm->_line);                      // Convert to lower case
+	Utils::hugo_strlwr(_vm->_line);                      // Convert to lower case
 
 	// God Mode cheat commands:
 	// goto <screen>                                Takes hero to named screen

--- a/engines/hugo/parser_v2d.cpp
+++ b/engines/hugo/parser_v2d.cpp
@@ -63,7 +63,7 @@ void Parser_v2d::lineHandler() {
 		return;
 	}
 
-	Utils::strlwr(_vm->_line);                      // Convert to lower case
+	Utils::hugo_strlwr(_vm->_line);                      // Convert to lower case
 
 	// God Mode cheat commands:
 	// goto <screen>                                Takes hero to named screen

--- a/engines/hugo/parser_v3d.cpp
+++ b/engines/hugo/parser_v3d.cpp
@@ -63,7 +63,7 @@ void Parser_v3d::lineHandler() {
 		return;
 	}
 
-	Utils::strlwr(_vm->_line);                      // Convert to lower case
+	Utils::hugo_strlwr(_vm->_line);                      // Convert to lower case
 
 	// God Mode cheat commands:
 	// goto <screen>                                Takes hero to named screen

--- a/engines/hugo/util.cpp
+++ b/engines/hugo/util.cpp
@@ -120,7 +120,7 @@ bool yesNoBox(const Common::U32String &msg) {
 	return (dialog.runModal() == GUI::kMessageOK);
 }
 
-char *strlwr(char *buffer) {
+char *hugo_strlwr(char *buffer) {
 	char *result = buffer;
 
 	while (*buffer != '\0') {

--- a/engines/hugo/util.h
+++ b/engines/hugo/util.h
@@ -65,7 +65,7 @@ bool yesNoBox(const Common::U32String &msg);
  * @param buffer	string to convert to lower case
  * @return the string which was passed in
  */
-char *strlwr(char *buffer);
+char *hugo_strlwr(char *buffer);
 
 } // End of namespace Utils
 

--- a/engines/wintermute/base/base_string_table.cpp
+++ b/engines/wintermute/base/base_string_table.cpp
@@ -86,7 +86,7 @@ char *BaseStringTable::getKey(const char *str) const {
 	char *key = new char[value - str];
 	Common::strlcpy(key, str + 1, (size_t)(value - str));
 
-	BasePlatform::strlwr(key);
+	BasePlatform::wintermute_strlwr(key);
 
 	char *newStr;
 
@@ -123,7 +123,7 @@ void BaseStringTable::expand(char **str) const {
 	char *key = new char[value - *str];
 	Common::strlcpy(key, *str + 1, (size_t)(value - *str));
 
-	BasePlatform::strlwr(key);
+	BasePlatform::wintermute_strlwr(key);
 
 	value++;
 
@@ -172,7 +172,7 @@ const char *BaseStringTable::expandStatic(const char *string) const {
 
 	char *key = new char[value - string];
 	Common::strlcpy(key, string + 1, (size_t)(value - string - 1));
-	BasePlatform::strlwr(key);
+	BasePlatform::wintermute_strlwr(key);
 
 	value++;
 

--- a/engines/wintermute/platform_osystem.cpp
+++ b/engines/wintermute/platform_osystem.cpp
@@ -252,7 +252,7 @@ AnsiString BasePlatform::getPlatformName() {
 }
 
 //////////////////////////////////////////////////////////////////////////
-char *BasePlatform::strlwr(char *string) {
+char *BasePlatform::wintermute_strlwr(char *string) {
 	if (string) {
 		for (size_t i = 0; i < strlen(string); ++i) {
 			string[i] = tolower(string[i]);

--- a/engines/wintermute/platform_osystem.h
+++ b/engines/wintermute/platform_osystem.h
@@ -55,7 +55,7 @@ public:
 	static bool copyRect(Rect32 *lprcDst, Rect32 *lprcSrc);
 
 	// string functions
-	static char *strlwr(char *string);
+	static char *wintermute_strlwr(char *string);
 
 private:
 	// Set by initialize on game-startup, the object referred to is also deleted by deinit in WintermuteEngine


### PR DESCRIPTION
This PR includes the changes to the forbidden header for several string processing functions which can be problematic for portability and which have good alternatives in the standard Common::String class.

There are several equivalent local implementations of these functions with the same name in several engines which required prefix naming to avoid matching this forbidden pattern. It should be noted that these should probably be refactored over time if possible.
