### PR TITLE
MACGUI: Fill in upper-left and upper-right corners with black

### DIFF
--- a/graphics/macgui/macmenu.cpp
+++ b/graphics/macgui/macmenu.cpp
@@ -1001,7 +1001,7 @@ bool MacMenu::draw(ManagedSurface *g, bool forceRedraw) {
 
 	_contentIsDirty = false;
 
-	_screen.clear(_wm->_colorBlack);
+	_screen.clear(_wm->_colorGreen);
 
 	bool shouldUseDesktopArc = !(_wm->_mode & kWMModeWin95) || (_wm->_mode & kWMModeForceMacBorder);
 	drawFilledRoundRect(&_screen, r, shouldUseDesktopArc ? kDesktopArc : 0, _wm->_colorWhite);

--- a/graphics/macgui/macmenu.cpp
+++ b/graphics/macgui/macmenu.cpp
@@ -1004,6 +1004,10 @@ bool MacMenu::draw(ManagedSurface *g, bool forceRedraw) {
 	_screen.clear(_wm->_colorGreen);
 
 	bool shouldUseDesktopArc = !(_wm->_mode & kWMModeWin95) || (_wm->_mode & kWMModeForceMacBorder);
+
+	// Fill in the corners with black
+	_screen.fillRect(r, _wm->_colorBlack);
+
 	drawFilledRoundRect(&_screen, r, shouldUseDesktopArc ? kDesktopArc : 0, _wm->_colorWhite);
 
 	r.top = 7;


### PR DESCRIPTION
Previously, only the menu bar was visible in macventure games like shadowgate. The region where the game was to be displayed was filled in with black, preventing the game from being displayed.