### PR TITLE
AGI: Fix AGIMOUSE implementation

### DIFF
--- a/engines/agi/cycle.cpp
+++ b/engines/agi/cycle.cpp
@@ -187,13 +187,6 @@ uint16 AgiEngine::processAGIEvents() {
 	wait(10);
 	uint16 key = doPollKeyboard();
 
-	// In AGI Mouse emulation mode we must update the mouse-related
-	// vars in every interpreter cycle.
-	if (getFeatures() & GF_AGIMOUSE) {
-		setVar(VM_VAR_MOUSE_X, _mouse.pos.x / 2);
-		setVar(VM_VAR_MOUSE_Y, _mouse.pos.y);
-	}
-
 	if (!cycleInnerLoopIsActive()) {
 		// Click-to-walk mouse interface
 		if (_game.playerControl && (screenObjEgo->flags & fAdjEgoXY)) {

--- a/engines/agi/cycle.cpp
+++ b/engines/agi/cycle.cpp
@@ -151,6 +151,12 @@ void AgiEngine::interpretCycle() {
 		_veryFirstInitialCycle = false;
 		artificialDelay_CycleDone();
 		resetControllers();
+
+		// Reset mouse button state after new.room, because we don't poll input.
+		// Otherwise, AGIMOUSE games that call new.room in response to a click
+		// will enter an infinite loop due to the mouse button global (27) never
+		// resetting to zero. Bug #10737
+		_mouse.button = kAgiMouseButtonUp;
 	}
 	_veryFirstInitialCycle = false;
 	artificialDelay_CycleDone();


### PR DESCRIPTION
This PR fixes AGIMOUSE implementation issues. The fan game "DG: The AGIMouse Adventure" is now playable. The buttons can be clicked without freezing and there are no longer phantom clicks after message boxes disappear. https://bugs.scummvm.org/ticket/10737

1. Mouse button state is now reset when changing rooms. The `new.room` opcode stops the current script (logic) execution and re-executes script 0. We don't poll events before re-executing script 0, so if we don't reset this button state, then a script that calls `new.room` in response to a mouse click will keep seeing that click on the next re-execution, call `new.room` again, and loop forever.

2. AGIMOUSE variables are now only set when game scripts ask for them. According to the documentation, and the sample games, that's the entire protocol: http://www.agidev.com/articles/a.php?id=25 . Scripts call opcode 171 so the interpreter can update three variables with mouse state. Our code, imported from the Sarien project, claims that we "must" update these variables on every cycle. That's not the protocol, and that's not even what the code does: it updates the variables whenever events are polled, and it only updates two of the three variables. That breaks game scripts by unexpectedly changing the coordinate variables in the middle of a game cycle. This causes phantom mouse clicks in "DG: The AGIMouse Adventure" after displaying a message box.