### PR TITLE
GRIM: Revert removal of W/A for nil in luaD_call (Bug #14987)

### DIFF
--- a/engines/grim/lua/ldo.cpp
+++ b/engines/grim/lua/ldo.cpp
@@ -233,8 +233,20 @@ int32 luaD_call(StkId base, int32 nResults) {
 			firstResult = callC(fvalue(funcObj), base);
 		} else {
 			TObject *im = luaT_getimbyObj(funcObj, IM_FUNCTION);
-			if (ttype(im) == LUA_T_NIL)
-				lua_error("call expression not a function");
+			if (ttype(im) == LUA_T_NIL) {
+				// NOTE: Originally this throwed the lua_error. Anyway it is commented here because
+				// when in year 4 bi.exit() calls bi.book.act:free(). But bi.book.act is nil,
+				// hence it enters this branch and the error blocks the game.
+				// Now we try instead to survive and go on with the function.
+				lua_Task *t = lua_state->task;
+				lua_state->task = t->next;
+				lua_state->prevTask = tmpTask;
+				luaM_free(t);
+
+				warning("Lua: call expression not a function");
+				return 1;
+				// 				lua_error("call expression not a function");
+			}
 			luaD_callTM(im, (lua_state->stack.top - lua_state->stack.stack) - (base - 1), nResults);
 			continue;
 		}


### PR DESCRIPTION
Original removal in 2c997d175cbc1b9a6ff0c5a1bb58bb4bc7776c00

Without this W/A we get stuck after opening the security door, see bug #14987.

This W/A does not resolve the issue with the walk cycle getting stuck.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
