### PR TITLE
SCUMM: Attempt to fix Mac menu screen corruption (bug #15006)

### DIFF
--- a/engines/pink/screen.cpp
+++ b/engines/pink/screen.cpp
@@ -102,7 +102,7 @@ Screen::Screen(PinkEngine *vm)
 
 	_wm->setScreen(&_surface);
 	_wm->setMenuHotzone(Common::Rect(0, 0, 640, 23));
-	_wm->setMenuDelay(250000);
+	_wm->setMenuDelay(250);
 	_wm->setEngineRedrawCallback(this, redrawCallback);
 
 	_textFont = nullptr;

--- a/engines/scumm/gfx.cpp
+++ b/engines/scumm/gfx.cpp
@@ -4297,7 +4297,7 @@ void ScummEngine::transitionEffect(int a) {
 		// Draw the current state to the screen and wait
 		// for the appropriate number of quarter frames
 		if (!_fastMode) {
-			waitForTimer(delay);
+			waitForTimer(delay, true);
 		}
 	}
 }
@@ -4455,9 +4455,9 @@ void ScummEngine::dissolveEffect(int width, int height) {
 		if (canHalt) {
 			canHalt = false;
 			if (_game.platform == Common::kPlatformAmiga) {
-				waitForTimer(4);
+				waitForTimer(4, true);
 			} else {
-				waitForTimer(1);
+				waitForTimer(1, true);
 			}
 		}
 	}
@@ -4518,7 +4518,7 @@ void ScummEngine::scrollEffect(int dir) {
 					vs->w * m, step * m);
 			}
 
-			waitForTimer(delay);
+			waitForTimer(delay, true);
 			y += step;
 		}
 		break;
@@ -4540,7 +4540,7 @@ void ScummEngine::scrollEffect(int dir) {
 					vs->w * m, step * m);
 			}
 
-			waitForTimer(delay);
+			waitForTimer(delay, true);
 			y += step;
 		}
 		break;
@@ -4556,7 +4556,7 @@ void ScummEngine::scrollEffect(int dir) {
 				(vs->w - step) * m, 0,
 				step * m, vs->h * m);
 
-			waitForTimer(delay);
+			waitForTimer(delay, true);
 			x += step;
 		}
 		break;
@@ -4572,7 +4572,7 @@ void ScummEngine::scrollEffect(int dir) {
 				0, 0,
 				step, vs->h);
 
-			waitForTimer(delay);
+			waitForTimer(delay, true);
 			x += step;
 		}
 		break;

--- a/engines/scumm/macgui/macgui_impl.cpp
+++ b/engines/scumm/macgui/macgui_impl.cpp
@@ -156,7 +156,7 @@ void MacGuiImpl::initialize() {
 
 	if (_vm->isUsingOriginalGUI()) {
 		_windowManager->setMenuHotzone(Common::Rect(640, 23));
-		_windowManager->setMenuDelay(250000);
+		_windowManager->setMenuDelay(250);
 
 		Common::MacResManager resource;
 		Graphics::MacMenu *menu = _windowManager->addMenu();

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2497,7 +2497,7 @@ Common::Error ScummEngine::go() {
 	return Common::kNoError;
 }
 
-void ScummEngine::waitForTimer(int quarterFrames) {
+void ScummEngine::waitForTimer(int quarterFrames, bool freezeMacGui) {
 	uint32 endTime, cur;
 	uint32 msecDelay = getIntegralTime(quarterFrames * (1000 / _timerFrequency));
 
@@ -2522,7 +2522,7 @@ void ScummEngine::waitForTimer(int quarterFrames) {
 		towns_updateGfx();
 #endif
 
-		if (_macGui)
+		if (_macGui && !freezeMacGui)
 			_macGui->updateWindowManager();
 
 		_system->updateScreen();

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -632,7 +632,7 @@ public:
 protected:
 	virtual void parseEvent(Common::Event event);
 
-	void waitForTimer(int quarterFrames);
+	void waitForTimer(int quarterFrames, bool freezeMacGui = false);
 	uint32 _lastWaitTime;
 
 	void setTimerAndShakeFrequency();

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -21,7 +21,6 @@
 #include "common/array.h"
 #include "common/list.h"
 #include "common/system.h"
-#include "common/timer.h"
 
 #include "graphics/cursorman.h"
 #include "graphics/managed_surface.h"
@@ -152,8 +151,6 @@ static const byte macCursorCrossBar[] = {
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 };
 
-static void menuTimerHandler(void *refCon);
-
 MacWindowManager::MacWindowManager(uint32 mode, MacPatterns *patterns, Common::Language language) {
 	_screen = nullptr;
 	_screenCopy = nullptr;
@@ -175,7 +172,7 @@ MacWindowManager::MacWindowManager(uint32 mode, MacPatterns *patterns, Common::L
 
 	_menu = 0;
 	_menuDelay = 0;
-	_menuTimerActive = false;
+	_menuTimer = 0;
 
 	_engineP = nullptr;
 	_engineR = nullptr;
@@ -258,8 +255,6 @@ MacWindowManager::~MacWindowManager() {
 
 	cleanupDesktopBmp();
 	cleanupDataBundle();
-
-	g_system->getTimerManager()->removeTimerProc(&menuTimerHandler);
 }
 
 void MacWindowManager::setDesktopMode(uint32 mode) {
@@ -999,6 +994,14 @@ void MacWindowManager::draw() {
 		}
 	}
 
+	if (_menuTimer && g_system->getMillis() >= _menuTimer) {
+		if (_menuHotzone.contains(_lastMousePos)) {
+			activateMenu();
+		}
+
+		_menuTimer = 0;
+	}
+
 	// Menu is drawn on top of everything and always
 	if (_menu && !(_mode & kWMModeFullscreen)) {
 		if (_fullRefresh)
@@ -1019,18 +1022,6 @@ void MacWindowManager::draw() {
 	_fullRefresh = false;
 }
 
-static void menuTimerHandler(void *refCon) {
-	MacWindowManager *wm = (MacWindowManager *)refCon;
-
-	if (wm->_menuHotzone.contains(wm->_lastMousePos)) {
-		wm->activateMenu();
-	}
-
-	wm->_menuTimerActive = false;
-
-	g_system->getTimerManager()->removeTimerProc(&menuTimerHandler);
-}
-
 bool MacWindowManager::processEvent(Common::Event &event) {
 	switch (event.type) {
 	case Common::EVENT_MOUSEMOVE:
@@ -1049,10 +1040,8 @@ bool MacWindowManager::processEvent(Common::Event &event) {
 
 	if (_menu && !_menu->isVisible()) {
 		if ((_mode & kWMModeAutohideMenu) && event.type == Common::EVENT_MOUSEMOVE) {
-			if (!_menuTimerActive && _menuHotzone.contains(event.mouse)) {
-				_menuTimerActive = true;
-
-				g_system->getTimerManager()->installTimerProc(&menuTimerHandler, _menuDelay, this, "menuWindowCursor");
+			if (!_menuTimer && _menuHotzone.contains(event.mouse)) {
+				_menuTimer = g_system->getMillis() + _menuDelay;
 			}
 		}
 	}

--- a/graphics/macgui/macwindowmanager.h
+++ b/graphics/macgui/macwindowmanager.h
@@ -402,7 +402,7 @@ public:
 	Common::Point _lastMousePos;
 	Common::Rect _menuHotzone;
 
-	bool _menuTimerActive;
+	uint32 _menuTimer;
 	bool _mouseDown;
 
 	uint32 _colorBlack, _colorGray80, _colorGray88, _colorGrayEE, _colorWhite, _colorGreen, _colorGreen2;


### PR DESCRIPTION
This is my attempt at fixing https://bugs.scummvm.org/ticket/15006 where the screen gets corrupted if the Mac menu opens at the wrong time.

When the mouse cursor reaches the top of the screen, a timer is set to activate the menu. The timer function then pauses the game, makes a copy of the current screen (to be used for restoring the screen once the menu closes, I believe?), and tells the menu to activate.

The problem appears to be that if the SCUMM engine is in the middle of a graphics transition (e.g. when walking between rooms), the screen will keep changing even though the game is paused.

This patch does two things:

First, I suspect the timer itself can be the cause of unexpected behavior, so I've eliminated that. I've also moved the screen copying to right before the menu is drawn. (I hope I put that in the right place!) I had hoped that this would take care of the problem, but it doesn't.

Second, the `waitForTimer()` function used for delays will update the Mac GUI, so that may still cause the menu to appear mid-transition. I've added an optional parameter to tell it to not update the Mac GUI. I don't know if this is the best approach, so I've made them separate commits. The other option I could think of would be to make an engine pause also pause the transition. But then we'd probably have the situation where you can ask the Mac GUI for a save dialog in mid-transition, and that may not be ideal.

This patch will _not_ apply cleanly to the 2.8 branch, since it makes a _small_ change to the SCUMM Mac GUI code, and that has seen a _lot_ of restructuring in master. But it should be simple to backport it.