### PR TITLE
AMIGAOS: Cleanup and free signals via atexit(), 2nd attempt 

### DIFF
--- a/backends/platform/sdl/amigaos/amigaos-main.cpp
+++ b/backends/platform/sdl/amigaos/amigaos-main.cpp
@@ -28,10 +28,6 @@
 #include "backends/plugins/sdl/sdl-provider.h"
 #include "base/main.h"
 
-static void cleanup() {
-	g_system->destroy();
-}
-
 int main(int argc, char *argv[]) {
 
 	// Update support (AmiUpdate):
@@ -67,9 +63,6 @@ int main(int argc, char *argv[]) {
 	g_system = new OSystem_AmigaOS();
 	assert(g_system);
 
-	// Register cleanup function to avoid unfreed signals
-	atexit(cleanup);
-
 	// Pre-initialize the backend.
 	g_system->init();
 
@@ -81,8 +74,7 @@ int main(int argc, char *argv[]) {
 	int res = scummvm_main(argc, argv);
 
 	// Free OSystem.
-	// This is now handled by cleanup() via atexit()
-	//g_system->destroy();
+	g_system->destroy();
 
 	return res;
 }

--- a/backends/platform/sdl/amigaos/amigaos.cpp
+++ b/backends/platform/sdl/amigaos/amigaos.cpp
@@ -27,7 +27,22 @@
 #include "backends/fs/amigaos/amigaos-fs-factory.h"
 #include "backends/dialogs/amigaos/amigaos-dialogs.h"
 
+static bool cleanupDone = false;
+
+static void cleanup() {
+	if (!cleanupDone)
+		g_system->destroy();
+}
+
+OSystem_AmigaOS::~OSystem_AmigaOS() {
+	cleanupDone = true;
+}
+
 void OSystem_AmigaOS::init() {
+	// Register cleanup function to avoid unfreed signals
+	if (atexit(cleanup))
+		warning("Failed to register cleanup function via atexit()");
+
 	// Initialize File System Factory
 	_fsFactory = new AmigaOSFilesystemFactory();
 

--- a/backends/platform/sdl/amigaos/amigaos.h
+++ b/backends/platform/sdl/amigaos/amigaos.h
@@ -27,7 +27,7 @@
 class OSystem_AmigaOS : public OSystem_SDL {
 public:
 	OSystem_AmigaOS() {}
-	virtual ~OSystem_AmigaOS() {}
+	virtual ~OSystem_AmigaOS();
 
 	bool hasFeature(Feature f) override;
 


### PR DESCRIPTION
Second attempt at fixing [#6956](https://bugs.scummvm.org/ticket/6956) "ScummVM returned with unfreed signals (AmigaOS4)".

This only runs the cleanup code if the OSystem_AmigaOS instance has not been destroyed already.

Should prevent crashes after calls to error(), which on AmigaOS already cleans up via OSystem_SDL::fatalError().