### PR TITLE
GUI: Use Palette class in image album dialog

### DIFF
--- a/engines/mtropolis/plugin/mti.cpp
+++ b/engines/mtropolis/plugin/mti.cpp
@@ -38,6 +38,7 @@
 #include "video/mpegps_decoder.h"
 
 #include "graphics/managed_surface.h"
+#include "graphics/palette.h"
 
 #include "common/file.h"
 namespace MTropolis {
@@ -416,7 +417,7 @@ class PrintModifierImageSupplier : public GUI::ImageAlbumImageSupplier {
 public:
 	PrintModifierImageSupplier(const Common::String &inputPath, bool isMacVersion);
 
-	bool loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, byte (&outPalette)[256 * 3], GUI::ImageAlbumImageMetadata &outMetadata) override;
+	bool loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, Graphics::Palette &outPalette, GUI::ImageAlbumImageMetadata &outMetadata) override;
 	void releaseImageSlot(uint slot) override;
 	uint getNumSlots() const override;
 	Common::U32String getDefaultFileNameForSlot(uint slot) const override;
@@ -437,7 +438,7 @@ PrintModifierImageSupplier::PrintModifierImageSupplier(const Common::String &inp
 		_decoder.reset(new Image::BitmapDecoder());
 }
 
-bool PrintModifierImageSupplier::loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, byte (&outPalette)[256 * 3], GUI::ImageAlbumImageMetadata &outMetadata) {
+bool PrintModifierImageSupplier::loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, Graphics::Palette &outPalette, GUI::ImageAlbumImageMetadata &outMetadata) {
 	Common::ScopedPtr<Common::SeekableReadStream> dataStream(createReadStreamForSlot(slot));
 
 	if (!dataStream)
@@ -454,7 +455,7 @@ bool PrintModifierImageSupplier::loadImageSlot(uint slot, const Graphics::Surfac
 	outHasPalette = _decoder->hasPalette();
 
 	if (_decoder->hasPalette())
-		memcpy(outPalette + _decoder->getPaletteStartIndex() * 3, _decoder->getPalette(), _decoder->getPaletteColorCount() * 3);
+		outPalette.set(_decoder->getPalette(), _decoder->getPaletteStartIndex(), _decoder->getPaletteColorCount());
 
 	outMetadata = GUI::ImageAlbumImageMetadata();
 	outMetadata._orientation = GUI::kImageAlbumImageOrientationLandscape;

--- a/engines/testbed/misc.cpp
+++ b/engines/testbed/misc.cpp
@@ -23,6 +23,8 @@
 #include "common/timer.h"
 #include "common/file.h"
 
+#include "graphics/palette.h"
+
 #include "gui/dialog.h"
 #include "gui/imagealbum-dialog.h"
 
@@ -192,7 +194,7 @@ class ImageAlbumImageSupplier : public GUI::ImageAlbumImageSupplier {
 public:
 	void addFile(const Common::Path &path, Common::FormatInfo::FormatID format, bool dontReportFormat);
 
-	bool loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, byte (&outPalette)[256 * 3], GUI::ImageAlbumImageMetadata &outMetadata) override;
+	bool loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, Graphics::Palette &outPalette, GUI::ImageAlbumImageMetadata &outMetadata) override;
 	void releaseImageSlot(uint slot) override;
 	bool getFileFormatForImageSlot(uint slot, Common::FormatInfo::FormatID &outFormat) const override;
 	Common::SeekableReadStream *createReadStreamForSlot(uint slot) override;
@@ -217,7 +219,7 @@ void ImageAlbumImageSupplier::addFile(const Common::Path &path, Common::FormatIn
 	_slots.push_back(FileInfo(path, format, dontReportFormat));
 }
 
-bool ImageAlbumImageSupplier::loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, byte (&outPalette)[256 * 3], GUI::ImageAlbumImageMetadata &outMetadata) {
+bool ImageAlbumImageSupplier::loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, Graphics::Palette &outPalette, GUI::ImageAlbumImageMetadata &outMetadata) {
 
 	FileInfo &fi = _slots[slot];
 
@@ -244,7 +246,7 @@ bool ImageAlbumImageSupplier::loadImageSlot(uint slot, const Graphics::Surface *
 	outSurface = fi._decoder->getSurface();
 	outHasPalette = fi._decoder->hasPalette();
 	if (fi._decoder->hasPalette())
-		memcpy(outPalette, fi._decoder->getPalette() + fi._decoder->getPaletteStartIndex() * 3, fi._decoder->getPaletteColorCount() * 3);
+		outPalette.set(fi._decoder->getPalette(), fi._decoder->getPaletteStartIndex(), fi._decoder->getPaletteColorCount());
 	outMetadata = GUI::ImageAlbumImageMetadata();
 
 	return true;

--- a/gui/imagealbum-dialog.cpp
+++ b/gui/imagealbum-dialog.cpp
@@ -21,6 +21,8 @@
 
 #include "gui/imagealbum-dialog.h"
 
+#include "graphics/palette.h"
+
 #include "gui/dialog.h"
 #include "gui/filebrowser-dialog.h"
 #include "gui/gui-manager.h"
@@ -164,11 +166,8 @@ void ImageAlbumDialog::changeToSlot(uint slot) {
 
 		const Graphics::Surface *surf = nullptr;
 		bool hasPalette = false;
-		byte palette[256 * 3];
+		Graphics::Palette palette(256);
 		ImageAlbumImageMetadata metadata;
-
-		for (byte &paletteByte : palette)
-			paletteByte = 0;
 
 		if (_imageSupplier->loadImageSlot(slot, surf, hasPalette, palette, metadata)) {
 			if (!canSaveImage) {
@@ -215,7 +214,7 @@ void ImageAlbumDialog::changeToSlot(uint slot) {
 			Graphics::ManagedSurface rescaledGraphic;
 			rescaledGraphic.create(scaledWidth, scaledHeight, surf->format);
 			if (hasPalette)
-				rescaledGraphic.setPalette(palette, 0, 256);
+				rescaledGraphic.setPalette(palette.data(), 0, 256);
 
 			if (needs90Rotate) {
 				bool isClockwise = metadata._viewTransformation == kImageAlbumViewTransformationRotate90CW;
@@ -251,7 +250,7 @@ void ImageAlbumDialog::changeToSlot(uint slot) {
 			_imageSupplier->releaseImageSlot(slot);
 
 			if (rescaledGraphic.format.bytesPerPixel == 1)
-				rescaledGraphic.convertToInPlace(Graphics::createPixelFormat<888>(), palette, 0, 256);
+				rescaledGraphic.convertToInPlace(Graphics::createPixelFormat<888>(), palette.data(), 0, 256);
 
 			int32 xCoord = (static_cast<int32>(_imageContainer->getWidth()) - static_cast<int32>(scaledWidth)) / 2u;
 			int32 yCoord = (static_cast<int32>(_imageContainer->getHeight()) - static_cast<int32>(scaledHeight)) / 2u;
@@ -379,11 +378,8 @@ void ImageAlbumDialog::saveImageInSlot(uint slot) {
 	if (needsConversion) {
 		const Graphics::Surface *surf = nullptr;
 		bool hasPalette = false;
-		byte palette[256 * 3];
+		Graphics::Palette palette(256);
 		ImageAlbumImageMetadata metadata;
-
-		for (byte &paletteByte : palette)
-			paletteByte = 0;
 
 		if (_imageSupplier->loadImageSlot(slot, surf, hasPalette, palette, metadata)) {
 			Common::ScopedPtr<Common::SeekableWriteStream> writeStream;
@@ -400,7 +396,7 @@ void ImageAlbumDialog::saveImageInSlot(uint slot) {
 					assert(saveCallback);
 
 					Common::FormatInfo::ImageSaveProperties saveProps;
-					saveCallback(*writeStream, *surf, hasPalette ? palette : nullptr, saveProps);
+					saveCallback(*writeStream, *surf, hasPalette ? palette.data() : nullptr, saveProps);
 				} else {
 					warning("Failed to open image output stream");
 				}

--- a/gui/imagealbum-dialog.h
+++ b/gui/imagealbum-dialog.h
@@ -34,6 +34,7 @@ class SeekableReadStream;
 
 namespace Graphics {
 
+class Palette;
 struct Surface;
 
 } // End of namespace Graphics
@@ -81,7 +82,7 @@ public:
 	 * @param outMetadata             Outputted metadata for the image
 	 * @return True if the image loaded successfully, false if it failed
 	 */
-	virtual bool loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, byte (&outPalette)[256 * 3], ImageAlbumImageMetadata &outMetadata) = 0;
+	virtual bool loadImageSlot(uint slot, const Graphics::Surface *&outSurface, bool &outHasPalette, Graphics::Palette &outPalette, ImageAlbumImageMetadata &outMetadata) = 0;
 
 	/**
 	 * @brief Releases any resources for an image loaded with loadImageSlot


### PR DESCRIPTION
Split out from #5648 - Replace palette byte arrays with Palette class in image album dialog

Note fi._decoder->getPaletteStartIndex() was always zero in practice but the use during memcpy was different in mtropolis & testbed