### PR TITLE
ULTIMA: NUVIE: Fix loading custom actor tiles (#14960)

### DIFF
--- a/engines/ultima/nuvie/actors/actor_manager.cpp
+++ b/engines/ultima/nuvie/actors/actor_manager.cpp
@@ -1107,7 +1107,7 @@ void ActorManager::loadAvatarTiles(const Common::Path &datadir) {
 
 	uint8 avatar_portrait = Game::get_game()->get_portrait()->get_avatar_portrait_num();
 
-	Std::set<Std::string> files = getCustomTileFilenames(datadir, "avatar_");
+	Std::set<Std::string> files = getCustomTileFilenames(datadir, "avatar_###_####.bmp");
 
 	for (const Std::string &filename : files) {
 		if (filename.length() != 19) { // avatar_nnn_nnnn.bmp
@@ -1135,7 +1135,7 @@ void ActorManager::loadAvatarTiles(const Common::Path &datadir) {
 void ActorManager::loadNPCTiles(const Common::Path &datadir) {
 	Common::Path imagefile;
 
-	Std::set<Std::string> files = getCustomTileFilenames(datadir, "actor_");
+	Std::set<Std::string> files = getCustomTileFilenames(datadir, "actor_###_####.bmp");
 
 	for (const Std::string &filename : files) {
 		if (filename.length() != 18) { // actor_nnn_nnnn.bmp

--- a/engines/ultima/nuvie/files/nuvie_file_list.cpp
+++ b/engines/ultima/nuvie/files/nuvie_file_list.cpp
@@ -36,23 +36,27 @@ NuvieFileList::~NuvieFileList() {
 }
 
 bool NuvieFileList::open(const Common::Path &directory, const char *search, uint8 s_mode) {
-	Common::FSNode dir(directory);
-	Common::FSList list;
+	Common::ArchiveMemberPtr arcMember = SearchMan.getMember(directory);
 
-	search_prefix.assign(search);
 	sort_mode = s_mode;
 
-	if (!dir.isDirectory()) {
+	if (!arcMember || !arcMember->isDirectory()) {
 		ConsoleAddWarning(Std::string("Failed to open ") + directory.toString());
 		return false;
 	}
 
-	if (!dir.getChildren(list, Common::FSNode::kListFilesOnly)) {
+	Common::ArchiveMemberList children;
+
+	arcMember->listChildren(children);
+	if (children.empty()) {
 		ConsoleAddWarning(Std::string("Failed to get children of ") + directory.toString());
 		return false;
 	};
-	for (const Common::FSNode &node : list)
-		add_filename(node);
+
+	for (const auto &child : children) {
+		if (!child->isDirectory())
+			add_filename(child->getFileName());
+	}
 
 	//sort list by time last modified in decending order.
 	Common::sort(file_list.begin(), file_list.end(), NuvieFileDesc());
@@ -60,10 +64,10 @@ bool NuvieFileList::open(const Common::Path &directory, const char *search, uint
 	return true;
 }
 
-bool NuvieFileList::add_filename(const Common::FSNode &file) {
+bool NuvieFileList::add_filename(const Common::String &fileName) {
 	NuvieFileDesc filedesc;
 	filedesc.m_time = 0;
-	filedesc.filename.assign(file.getFileName());
+	filedesc.filename = fileName;
 
 	file_list.push_front(filedesc);
 

--- a/engines/ultima/nuvie/files/nuvie_file_list.cpp
+++ b/engines/ultima/nuvie/files/nuvie_file_list.cpp
@@ -47,7 +47,7 @@ bool NuvieFileList::open(const Common::Path &directory, const char *search, uint
 
 	Common::ArchiveMemberList children;
 
-	arcMember->listChildren(children);
+	arcMember->listChildren(children, search);
 	if (children.empty()) {
 		ConsoleAddWarning(Std::string("Failed to get children of ") + directory.toString());
 		return false;

--- a/engines/ultima/nuvie/files/nuvie_file_list.h
+++ b/engines/ultima/nuvie/files/nuvie_file_list.h
@@ -56,10 +56,9 @@ class NuvieFileList {
 protected:
 	Std::list<NuvieFileDesc> file_list;
 
-	Std::string search_prefix;
 	uint8 sort_mode;
 protected:
-	bool add_filename(const Common::FSNode &file);
+	bool add_filename(const Common::String &fileName);
 public:
 
 	NuvieFileList();

--- a/engines/ultima/shared/engine/data_archive.cpp
+++ b/engines/ultima/shared/engine/data_archive.cpp
@@ -153,18 +153,7 @@ int UltimaDataArchive::listMatchingMembers(Common::ArchiveMemberList &list, cons
 }
 
 int UltimaDataArchive::listMembers(Common::ArchiveMemberList &list) const {
-	Common::ArchiveMemberList innerList;
-	int result = _zip->listMembers(innerList);
-
-	// Modify the results to change the filename
-	for (Common::ArchiveMemberList::iterator it = innerList.begin();
-		it != innerList.end(); ++it) {
-		Common::ArchiveMemberPtr member = Common::ArchiveMemberPtr(
-			new UltimaDataArchiveMember(*it, _innerfolder));
-		list.push_back(member);
-	}
-
-	return result;
+	return listMatchingMembers(list, "*", true);
 }
 
 const Common::ArchiveMemberPtr UltimaDataArchive::getMember(const Common::Path &path) const {

--- a/engines/ultima/shared/engine/data_archive.cpp
+++ b/engines/ultima/shared/engine/data_archive.cpp
@@ -180,6 +180,9 @@ Common::SeekableReadStream *UltimaDataArchive::createReadStreamForMember(const C
 	return nullptr;
 }
 
+bool UltimaDataArchive::isPathDirectory(const Common::Path &path) const {
+	return _zip->isPathDirectory(innerToPublic(path));
+}
 /*-------------------------------------------------------------------*/
 
 #ifndef RELEASE_BUILD

--- a/engines/ultima/shared/engine/data_archive.cpp
+++ b/engines/ultima/shared/engine/data_archive.cpp
@@ -219,6 +219,19 @@ Common::FSNode UltimaDataArchiveProxy::getNode(const Common::Path &name) const {
 	return node;
 }
 
+int UltimaDataArchiveProxy::listMatchingMembers(Common::ArchiveMemberList &list,
+		const Common::Path &pattern, bool matchPathComponents) const {
+	// Let FSDirectory adjust the filenames for us by using its prefix feature.
+	// Note: dir is intentionally constructed again on each call to prevent stale entries due to caching:
+	// Since this proxy class is intended for use during development, picking up modifications while the
+	// game is running might be useful.
+	const int maxDepth = 255; // chosen arbitrarily
+	Common::FSDirectory dir(_publicFolder, _folder, maxDepth, false, false, true);
+	if (matchPathComponents && pattern == "*")
+		return dir.listMembers(list);
+	else
+		return dir.listMatchingMembers(list, pattern, matchPathComponents);
+}
 #endif
 
 } // End of namespace Shared

--- a/engines/ultima/shared/engine/data_archive.cpp
+++ b/engines/ultima/shared/engine/data_archive.cpp
@@ -56,7 +56,7 @@ public:
 		return _member->getDisplayName();
 	}
 	
-	Common::String getFileName() const override { return getFileName(); }
+	Common::String getFileName() const override { return _member->getFileName(); }
 	Common::String getName() const override { return getPathInArchive().toString('/'); }
 };
 

--- a/engines/ultima/shared/engine/data_archive.cpp
+++ b/engines/ultima/shared/engine/data_archive.cpp
@@ -236,6 +236,10 @@ int UltimaDataArchiveProxy::listMatchingMembers(Common::ArchiveMemberList &list,
 	else
 		return dir.listMatchingMembers(list, pattern, matchPathComponents);
 }
+
+bool UltimaDataArchiveProxy::isPathDirectory(const Common::Path &path) const {
+	return getNode(path).isDirectory();
+}
 #endif
 
 } // End of namespace Shared

--- a/engines/ultima/shared/engine/data_archive.cpp
+++ b/engines/ultima/shared/engine/data_archive.cpp
@@ -58,6 +58,8 @@ public:
 	
 	Common::String getFileName() const override { return _member->getFileName(); }
 	Common::String getName() const override { return getPathInArchive().toString('/'); }
+
+	bool isDirectory() const override { return _member->isDirectory(); }
 };
 
 /*-------------------------------------------------------------------*/

--- a/engines/ultima/shared/engine/data_archive.cpp
+++ b/engines/ultima/shared/engine/data_archive.cpp
@@ -219,6 +219,10 @@ Common::FSNode UltimaDataArchiveProxy::getNode(const Common::Path &name) const {
 	return node;
 }
 
+int UltimaDataArchiveProxy::listMembers(Common::ArchiveMemberList &list) const {
+	return listMatchingMembers(list, "*", true);
+}
+
 int UltimaDataArchiveProxy::listMatchingMembers(Common::ArchiveMemberList &list,
 		const Common::Path &pattern, bool matchPathComponents) const {
 	// Let FSDirectory adjust the filenames for us by using its prefix feature.

--- a/engines/ultima/shared/engine/data_archive.h
+++ b/engines/ultima/shared/engine/data_archive.h
@@ -169,6 +169,8 @@ public:
 	 */
 	Common::SeekableReadStream *createReadStreamForMember(
 		const Common::Path &path) const override;
+
+	bool isPathDirectory(const Common::Path &path) const override;
 };
 
 #endif

--- a/engines/ultima/shared/engine/data_archive.h
+++ b/engines/ultima/shared/engine/data_archive.h
@@ -103,6 +103,8 @@ public:
 	 */
 	Common::SeekableReadStream *createReadStreamForMember(
 		const Common::Path &path) const override;
+
+	bool isPathDirectory(const Common::Path &path) const override;
 };
 
 #ifndef RELEASE_BUILD

--- a/engines/ultima/shared/engine/data_archive.h
+++ b/engines/ultima/shared/engine/data_archive.h
@@ -154,9 +154,7 @@ public:
 	 *
 	 * @return the number of names added to list
 	 */
-	int listMembers(Common::ArchiveMemberList &list) const override {
-		return 0;
-	}
+	int listMembers(Common::ArchiveMemberList &list) const override;
 
 	/**
 	 * Returns a ArchiveMember representation of the given file.

--- a/engines/ultima/shared/engine/data_archive.h
+++ b/engines/ultima/shared/engine/data_archive.h
@@ -146,9 +146,7 @@ public:
 	 * @return the number of members added to list
 	 */
 	int listMatchingMembers(Common::ArchiveMemberList &list,
-			const Common::Path &pattern, bool matchPathComponents = false) const override {
-		return 0;
-	}
+			const Common::Path &pattern, bool matchPathComponents = false) const override;
 
 	/**
 	 * Add all members of the Archive to list.


### PR DESCRIPTION
- Do not ignore parameter `matchPathComponents` in `Common::FSDirectory::listMatchingMembers`.

- Implement/rework some Archive interface methods for `Ultima::Shared::UltimaDataArchive` (used in release builds) and `Ultima::Shared::UltimaDataArchiveProxy` (non-release builds).

- Make `Ultima::Nuvie::NuvieFileList::open()` use SearchMan instead of `Common::FSNode` to look up directories.

Fixes [#14960](https://bugs.scummvm.org/ticket/14960) "The nuvie feature 'Use Custom Actor Tiles' is non functional"

Note: Only tested with Ultima 6 on a Linux system.