### PR TITLE
GRAPHICS: Switch ManagedSurface to use Palette class

### DIFF
--- a/engines/ags/engine/media/video/video.cpp
+++ b/engines/ags/engine/media/video/video.cpp
@@ -19,6 +19,7 @@
  *
  */
 
+#include "graphics/palette.h"
 #include "video/avi_decoder.h"
 #include "video/flic_decoder.h"
 #include "video/mpegps_decoder.h"
@@ -97,13 +98,14 @@ static bool play_video(Video::VideoDecoder *decoder, const char *name, int flags
 					// Don't need to stretch video after all
 					stretchVideo = false;
 
+				Graphics::Palette p(decoder->getPalette(), 256);
 				if (stretchVideo) {
 					scr.fillRect(Common::Rect(dstRect.Left, dstRect.Top, dstRect.Right + 1, dstRect.Bottom + 1), 0);
 					scr.transBlitFrom(*frame, Common::Rect(0, 0, frame->w, frame->h),
 									  Common::Rect(dstRect.Left, dstRect.Top, dstRect.Right + 1, dstRect.Bottom + 1),
-									  decoder->getPalette());
+									  &p);
 				} else {
-					scr.blitFrom(*frame, Common::Point(dstRect.Left, dstRect.Top), decoder->getPalette());
+					scr.blitFrom(*frame, Common::Point(dstRect.Left, dstRect.Top), &p);
 				}
 			}
 

--- a/engines/ultima/nuvie/misc/sdl_compat.cpp
+++ b/engines/ultima/nuvie/misc/sdl_compat.cpp
@@ -26,6 +26,7 @@
 #include "common/file.h"
 #include "common/textconsole.h"
 #include "graphics/managed_surface.h"
+#include "graphics/palette.h"
 #include "image/bmp.h"
 #include "ultima/nuvie/screen/screen.h"
 
@@ -71,7 +72,8 @@ Graphics::ManagedSurface *SDL_LoadBMP(const Common::Path &filename) {
 	Graphics::ManagedSurface *const screenSurface = screen->get_sdl_surface();
 	assert(screenSurface);
 	Graphics::ManagedSurface *dest = new Graphics::ManagedSurface(src->w, src->h, screenSurface->format);
-	dest->blitFrom(*src, decoder.getPalette());
+	Graphics::Palette p(decoder.getPalette(), 256);
+	dest->blitFrom(*src, &p);
 
 	return dest;
 }

--- a/engines/vcruise/runtime.cpp
+++ b/engines/vcruise/runtime.cpp
@@ -37,6 +37,7 @@
 #include "graphics/fontman.h"
 #include "graphics/wincursor.h"
 #include "graphics/managed_surface.h"
+#include "graphics/palette.h"
 
 #include "image/bmp.h"
 
@@ -2153,7 +2154,8 @@ void Runtime::continuePlayingAnimation(bool loop, bool useStopFrame, bool &outAn
 		copyRect = copyRect.findIntersectingRect(constraintRect);
 
 		if (copyRect.isValidRect() || !copyRect.isEmpty()) {
-			_gameSection.surf->blitFrom(*surface, copyRect, copyRect, _animDecoder->getPalette());
+			Graphics::Palette p(_animDecoder->getPalette(), 256);
+			_gameSection.surf->blitFrom(*surface, copyRect, copyRect, &p);
 			drawSectionToScreen(_gameSection, copyRect);
 		}
 

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -33,6 +33,8 @@
 
 namespace Graphics {
 
+class Palette;
+
 /**
  * @defgroup graphics_managed_surface Managed surface
  * @ingroup graphics
@@ -81,21 +83,21 @@ private:
 	/**
 	 * Local palette for 8-bit images.
 	 */
-	byte _palette[256 * 3];
-	bool _paletteSet;
+	Palette *_palette;
 protected:
 	/**
 	 * Inner method for blitting.
 	 */
 	void blitFromInner(const Surface &src, const Common::Rect &srcRect,
-		const Common::Rect &destRect, const byte *srcPalette);
+		const Common::Rect &destRect, const Palette *srcPalette);
 
 	/**
 	 * Inner method for copying another surface into this one at a given destination position.
 	 */
 	void transBlitFromInner(const Surface &src, const Common::Rect &srcRect,
 		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 overrideColor,
-		uint32 srcAlpha, const byte *srcPalette, const byte *dstPalette, const Surface *mask, bool maskOnly);
+		uint32 srcAlpha, const Palette *srcPalette, const Palette *dstPalette,
+		const Surface *mask, bool maskOnly);
 public:
 	/**
 	 * Clip the given source bounds so the passed destBounds will be entirely on-screen.
@@ -307,24 +309,24 @@ public:
 	/**
 	 * Copy another surface into this one.
 	 */
-	void blitFrom(const Surface &src, const byte *srcPalette = nullptr);
+	void blitFrom(const Surface &src, const Palette *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one at a given destination position.
 	 */
-	void blitFrom(const Surface &src, const Common::Point &destPos, const byte *srcPalette = nullptr);
+	void blitFrom(const Surface &src, const Common::Point &destPos, const Palette *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one at a given destination position.
 	 */
 	void blitFrom(const Surface &src, const Common::Rect &srcRect,
-		const Common::Point &destPos, const byte *srcPalette = nullptr);
+		const Common::Point &destPos, const Palette *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one at a given destination area and perform the potential scaling.
 	 */
 	void blitFrom(const Surface &src, const Common::Rect &srcRect,
-		const Common::Rect &destRect, const byte *srcPalette = nullptr);
+		const Common::Rect &destRect, const Palette *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one at a given destination area and perform the potential scaling.
@@ -360,7 +362,7 @@ public:
 	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
 	 */
 	void transBlitFrom(const Surface &src, uint32 transColor = 0, bool flipped = false,
-		uint32 overrideColor = 0, uint32 srcAlpha = 0xff, const byte *srcPalette = nullptr);
+		uint32 overrideColor = 0, uint32 srcAlpha = 0xff, const Palette *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -375,7 +377,7 @@ public:
 	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
 	 */
 	void transBlitFrom(const Surface &src, const Common::Point &destPos,
-		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff, const byte *srcPalette = nullptr);
+		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff, const Palette *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -386,7 +388,7 @@ public:
 	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
 	 */
 	void transBlitFrom(const Surface &src, const Common::Point &destPos,
-		const ManagedSurface &mask, const byte *srcPalette = nullptr);
+		const ManagedSurface &mask, const Palette *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -397,7 +399,7 @@ public:
 	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
 	 */
 	void transBlitFrom(const Surface &src, const Common::Point &destPos,
-		const Surface &mask, const byte *srcPalette = nullptr);
+		const Surface &mask, const Palette *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -413,7 +415,7 @@ public:
 	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
 	 */
 	void transBlitFrom(const Surface &src, const Common::Rect &srcRect, const Common::Point &destPos,
-		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff, const byte *srcPalette = nullptr);
+		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff, const Palette *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -424,7 +426,7 @@ public:
 	 *						then @p srcRect, allowing for arbitrary scaling of the image.
 	 * @param srcPalette	Palette for the CLUT8  @p src surface.
 	 */
-	void transBlitFrom(const Surface &src, const Common::Rect &srcRect, const Common::Rect &destRect, const byte *srcPalette);
+	void transBlitFrom(const Surface &src, const Common::Rect &srcRect, const Common::Rect &destRect, const Palette *srcPalette);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -444,7 +446,7 @@ public:
 	 */
 	void transBlitFrom(const Surface &src, const Common::Rect &srcRect, const Common::Rect &destRect,
 		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff,
-		const Surface *mask = nullptr, bool maskOnly = false, const byte *srcPalette = nullptr);
+		const Surface *mask = nullptr, bool maskOnly = false, const Palette *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -523,7 +525,7 @@ public:
 	void rawBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect,
 			const Common::Point &destPos) {
 		blitFromInner(src._innerSurface, srcRect, Common::Rect(destPos.x, destPos.y, destPos.x + srcRect.width(),
-			destPos.y + srcRect.height()), src._paletteSet ? src._palette : nullptr);
+			destPos.y + srcRect.height()), src._palette);
 	}
 	
 	/**
@@ -740,16 +742,12 @@ public:
 	/**
 	 * Clear any existing palette.
 	 */
-	void clearPalette() {
-		_paletteSet = false;
-	}
+	void clearPalette();
 
 	/**
 	 * Return true if a palette has been set.
 	 */
-	bool hasPalette() const {
-		return _paletteSet;
-	}
+	bool hasPalette() const;
 
 	/**
 	 * Grab the palette using RGB tuples.

--- a/graphics/palette.cpp
+++ b/graphics/palette.cpp
@@ -28,6 +28,14 @@ Palette::Palette(uint size) : _data(nullptr), _size(size) {
 	}
 }
 
+Palette::Palette(const byte *data, uint size) : _data(nullptr), _size(0) {
+	if (data && size > 0) {
+		_size = size;
+		_data = new byte[_size * 3]();
+		memcpy(_data, data, _size * 3);
+	}
+}
+
 Palette::Palette(const Palette &p) : _data(nullptr), _size(p._size) {
 	if (_size > 0) {
 		_data = new byte[_size * 3]();

--- a/graphics/palette.h
+++ b/graphics/palette.h
@@ -50,6 +50,14 @@ public:
 	 */
 	Palette(uint size);
 
+	/**
+	 * @brief Construct a new Palette object
+	 *
+	 * @param data   the palette data, in interleaved RGB format
+	 * @param size   the number of palette entries
+	 */
+	Palette(const byte *data, uint size);
+
 	Palette(const Palette &p);
 
 	~Palette();


### PR DESCRIPTION
Update many palette usages in managed surface from passed in byte arrays to the Palette class. There were surprisingly few uses of them, several being from decoders that have null palettes when checked.

Palette class can also now take a byte array pointer & size, which allows null and simply will set size to 0