### PR TITLE
AMIGAOS: (Janitorial) Subsitute mk defines with compiler defines

### DIFF
--- a/backends/graphics3d/opengl/surfacerenderer.cpp
+++ b/backends/graphics3d/opengl/surfacerenderer.cpp
@@ -180,7 +180,7 @@ static const char *const boxVertex =
 	"uniform vec2 sizeWH;\n"
 	"uniform vec2 texcrop;\n"
 // OGLES2 on AmigaOS doesn't support uniform booleans
-#if defined(AMIGAOS)
+#if defined(__amigaos4__)
 	"uniform mediump int flipY;\n"
 #else
 	"uniform bool flipY;\n"
@@ -191,7 +191,7 @@ static const char *const boxVertex =
 		"vec2 pos = offsetXY + position * sizeWH;\n"
 		"pos.x = pos.x * 2.0 - 1.0;\n"
 		"pos.y = pos.y * 2.0 - 1.0;\n"
-#if defined(AMIGAOS)
+#if defined(__amigaos4__)
 		"if (flipY != 0)\n"
 #else
 		"if (flipY)\n"

--- a/backends/networking/enet/source/unix.cpp
+++ b/backends/networking/enet/source/unix.cpp
@@ -453,7 +453,7 @@ enet_socket_send (ENetSocket socket,
         sin.sin_port = ENET_HOST_TO_NET_16 (address -> port);
         sin.sin_addr.s_addr = address -> host;
 
-#ifdef AMIGAOS
+#if defined(__amigaos4__)
         msgHdr.msg_name = (char *)& sin;
 #else
         msgHdr.msg_name = & sin;
@@ -491,7 +491,7 @@ enet_socket_receive (ENetSocket socket,
 
     if (address != NULL)
     {
-#ifdef AMIGAOS
+#if defined(__amigaos4__)
         msgHdr.msg_name = (char *)& sin;
 #else
         msgHdr.msg_name = & sin;

--- a/graphics/opengl/context.cpp
+++ b/graphics/opengl/context.cpp
@@ -208,7 +208,7 @@ void Context::initialize(ContextType contextType) {
 	if (type == kContextGLES2) {
 // OGLES2 on AmigaOS reports GLSL version as 0.9 but we do what is needed to make it work
 // so let's pretend it supports 1.00
-#if defined(AMIGAOS)
+#if defined(__amigaos4__)
 		if (glslVersion < 100) {
 			glslVersion = 100;
 		}

--- a/graphics/opengl/shader.cpp
+++ b/graphics/opengl/shader.cpp
@@ -67,7 +67,7 @@ static const char *const compatFragment =
 	"#endif\n";
 
 // OGLES2 on AmigaOS doesn't support uniform booleans, let's introduce some shim
-#if defined(AMIGAOS)
+#if defined(__amigaos4__)
 static const char *const compatUniformBool =
 	"#define UBOOL mediump int\n"
 	"#define UBOOL_TEST(v) (v != 0)\n";


### PR DESCRIPTION
This is an attempt to clean up and reduce usage of the configure define (AMIGAOS) from actual source files to only .mk files.

There are only six occurances within four source files, over the whole code base, that make use of that define.
-graphics/opengl/shader.cpp
-graphics/opengl/context.cpp
-backends/graphis3d/opengl/surfacerenderer.cpp
-backends/networking/enet/source/unix.cpp
while all other source files use the compiler define for my platform (__amigaos4__).

To not promote the usage of such define in future source file changes (apart .mk) i'd like to get rid of it.

If that doesn't sound logical, please advise

Thank you