### PR TITLE
AUDIO: Change default GM device back to "null"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@ For a more comprehensive changelog of the latest experimental code, see:
  General:
    - Fixed GLSL version parsing on some OpenGL ES2 platforms.
    - Don't try to use shaders on old OpenGL implementations.
+   - Changed default GM device back to "null" to avoid selecting GM devices
+     that don't support status checks.  This will be improved in a future
+     release.
 
  AGI:
    - Fixed Space Quest 1 version 1.0X freezing in the skimmer.

--- a/audio/mididrv.cpp
+++ b/audio/mididrv.cpp
@@ -248,9 +248,9 @@ MidiDriver::DeviceHandle MidiDriver::detectDevice(int flags) {
 			// If a preferred MT32 or GM device has been selected that device gets returned if available.
 			Common::String devStr;
 			if (flags & MDT_PREFER_MT32)
-				devStr = ConfMan.hasKey("mt32_device") ? ConfMan.get("mt32_device") : Common::String("null");
+				devStr = ConfMan.hasKey("mt32_device") ? ConfMan.get("mt32_device") : Common::String(getDefaultMT32DeviceSetting());
 			else if (flags & MDT_PREFER_GM)
-				devStr = ConfMan.get("gm_device");
+				devStr = ConfMan.hasKey("gm_device") ? ConfMan.get("gm_device") : Common::String(getDefaultGMDeviceSetting());
 
 			if (devStr.empty())
 				devStr = "auto";
@@ -582,4 +582,10 @@ void MidiDriver::midiDriverCommonSysEx(const byte *msg, uint16 length) {
 	}
 }
 
+const char *MidiDriver::getDefaultGMDeviceSetting() {
+	return "null";
+}
 
+const char *MidiDriver::getDefaultMT32DeviceSetting() {
+	return "null";
+}

--- a/audio/mididrv.h
+++ b/audio/mididrv.h
@@ -340,6 +340,12 @@ public:
 	/** Common operations to be done by all drivers on start of sysEx */
 	void midiDriverCommonSysEx(const byte *msg, uint16 length);
 
+	/** Returns the name of the default GM device */
+	static const char *getDefaultGMDeviceSetting();
+
+	/** Returns the name of the default MT-32 device */
+	static const char *getDefaultMT32DeviceSetting();
+
 private:
 	// If detectDevice() detects MT32 and we have a preferred MT32 device
 	// we use this to force getMusicType() to return MT_MT32 so that we don't

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -43,6 +43,7 @@
 #include "gui/ThemeEngine.h"
 
 #include "audio/musicplugin.h"
+#include "audio/mididrv.h"
 
 #include "graphics/renderer.h"
 
@@ -320,8 +321,8 @@ void registerDefaults() {
 	ConfMan.registerDefault("midi_gain", 100);
 
 	ConfMan.registerDefault("music_driver", "auto");
-	ConfMan.registerDefault("mt32_device", "null");
-	ConfMan.registerDefault("gm_device", "auto");
+	ConfMan.registerDefault("mt32_device", MidiDriver::getDefaultMT32DeviceSetting());
+	ConfMan.registerDefault("gm_device", MidiDriver::getDefaultGMDeviceSetting());
 	ConfMan.registerDefault("opl2lpt_parport", "null");
 
 	ConfMan.registerDefault("cdrom", 0);


### PR DESCRIPTION
Changes GM device back to "null" in 2.8.1, pending addition of more status checks for "auto"