### PR TITLE
AGS: Fix AmigaOS crash on exit (#15015)

### DIFF
--- a/engines/ags/engine/ac/global_game.cpp
+++ b/engines/ags/engine/ac/global_game.cpp
@@ -499,7 +499,7 @@ void EndSkippingUntilCharStops() {
 }
 
 void StartCutscene(int skipwith) {
-	static ScriptPosition last_cutscene_script_pos;
+	ScriptPosition &last_cutscene_script_pos = _GP(last_cutscene_script_pos);
 
 	if (is_in_cutscene()) {
 		quitprintf("!StartCutscene: already in a cutscene; previous started in \"%s\", line %d",

--- a/engines/ags/globals.cpp
+++ b/engines/ags/globals.cpp
@@ -275,6 +275,9 @@ Globals::Globals() {
 	// global_dialog.cpp globals
 	_last_in_dialog_request_script_pos = new ScriptPosition();
 
+	// global_game.cpp globals
+	_last_cutscene_script_pos = new ScriptPosition();
+
 	// graphics_mode.cpp globals
 	_SavedFullscreenSetting = new ActiveDisplaySetting();
 	_SavedWindowedSetting = new ActiveDisplaySetting();
@@ -531,6 +534,9 @@ Globals::~Globals() {
 
 	// global_dialog.cpp globals
 	delete _last_in_dialog_request_script_pos;
+
+	// global_game.cpp globals
+	delete _last_cutscene_script_pos;
 
 	// graphics_mode.cpp globals
 	delete _SavedFullscreenSetting;

--- a/engines/ags/globals.h
+++ b/engines/ags/globals.h
@@ -910,6 +910,16 @@ public:
 	/**@}*/
 
 	/**
+	 * @defgroup agsglobal_gameglobals global_game globals
+	 * @ingroup agsglobals
+	 * @{
+	 */
+
+	ScriptPosition *_last_cutscene_script_pos;
+
+	/**@}*/
+
+	/**
 	 * @defgroup agsglobal_objectglobals global_object globals
 	 * @ingroup agsglobals
 	 * @{


### PR DESCRIPTION
 Replace local static "last_cutscene_script_pos" with field.

Fixes [#15015](https://bugs.scummvm.org/ticket/15015) "AGS games lead to a reproducable crash on exiting ScummVM"