### PR TITLE
TETRAEDGE: Cache Resource Files

### DIFF
--- a/engines/tetraedge/te/te_core.h
+++ b/engines/tetraedge/te/te_core.h
@@ -67,9 +67,13 @@ public:
 	bool _coreNotReady;
 
 private:
+
+	Common::FSNode GetFile(const Common::Path & path) const;
+
 	TeILoc *_loc;
 
 	Common::HashMap<Common::String, Common::String, Common::CaseSensitiveString_Hash, Common::CaseSensitiveString_EqualTo> _fileSystemFlags;
+	Common::FSDirectory _resourcesRoot;
 
 	TeTimer _activityTrackingTimer;
 };


### PR DESCRIPTION
TETRAEDGE: Cache Resource Files

Modify TeCore's file searching behaviour to make use of a 
Common::FSDirectory cache of the games resources folder.
This greatly reduces the time spent when looking up 
resources during gameplay and loading.
The original behaviour exhibited multi second long
pauses when navigating Syberia 1's main menu and
longer pauses when trying to load a saved game.
With these changes all pause is eliminated.

The pauses were observed on a Windows 10 machine
with powerful hardware (5700x cpu and nvme SSD) so 
the appearance and length of them were unexpected.



<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
