### PR TITLE
BACKENDS: IMGUI: Use ScummVM facilities to get function pointers

### DIFF
--- a/backends/imgui/backends/imgui_impl_opengl3_loader.h
+++ b/backends/imgui/backends/imgui_impl_opengl3_loader.h
@@ -56,6 +56,11 @@
 #ifndef __gl3w_h_
 #define __gl3w_h_
 
+#if defined(IMGL3W_SCUMMVM_LOADER)
+#define FORBIDDEN_SYMBOL_ALLOW_ALL
+#include "common/system.h"
+#endif
+
 // Adapted from KHR/khrplatform.h to avoid including entire file.
 #ifndef __khrplatform_h_
 typedef          float         khronos_float_t;
@@ -610,7 +615,20 @@ extern "C" {
 
 #define GL3W_ARRAY_SIZE(x)  (sizeof(x) / sizeof((x)[0]))
 
-#if defined(_WIN32)
+#if defined(IMGL3W_SCUMMVM_LOADER)
+static int open_libgl(void)
+{
+    return GL3W_OK;
+}
+
+static void close_libgl(void) { }
+
+static GL3WglProc get_proc(const char *proc)
+{
+	return (GL3WglProc)g_system->getOpenGLProcAddress(proc);
+}
+
+#elif defined(_WIN32)
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN 1
 #endif

--- a/backends/imgui/backends/imgui_impl_opengl3_scummvm.cpp
+++ b/backends/imgui/backends/imgui_impl_opengl3_scummvm.cpp
@@ -161,6 +161,7 @@
 // - You may need to regenerate imgui_impl_opengl3_loader.h to add new symbols. See https://github.com/dearimgui/gl3w_stripped
 // - You can temporarily use an unstripped version. See https://github.com/dearimgui/gl3w_stripped/releases
 // Changes to this backend using new APIs should be accompanied by a regenerated stripped loader version.
+#define IMGL3W_SCUMMVM_LOADER
 #define IMGL3W_IMPL
 #include "backends/imgui/backends/imgui_impl_opengl3_loader.h"
 #endif


### PR DESCRIPTION
This should fix builds of Raspberry Pi and Switch