### PR TITLE
TETRAEDGE: Syberia shadow rendering

### DIFF
--- a/engines/tetraedge/game/characters_shadow_opengl.cpp
+++ b/engines/tetraedge/game/characters_shadow_opengl.cpp
@@ -131,9 +131,7 @@ void CharactersShadowOpenGL::draw(InGameScene *scene) {
 	glEnable(GL_BLEND);
 	renderer->setCurrentColor(scene->shadowColor());
 
-	Common::Array<TeIntrusivePtr<TeModel>> &models =
-			(g_engine->gameType() == TetraedgeEngine::kSyberia ?
-					scene->zoneModels() : scene->shadowReceivingObjects());
+	Common::Array<TeIntrusivePtr<TeModel>> &models = scene->shadowReceivingObjects());
 	for (TeIntrusivePtr<TeModel> model : models) {
 		if (model->meshes().size() > 0 && model->meshes()[0]->materials().empty()) {
 			model->meshes()[0]->defaultMaterial(TeIntrusivePtr<Te3DTexture>());


### PR DESCRIPTION
TETRAEDGE: Disable rendering of walkable paths as shadows/shaded areias in Syberia

The engine renders the walkable areas of Syberia 1 as shadow or shaded areas. 
This seems like it was fixed for Syberia 2 but the same issue is present in Syberia 1.
Disabling the check for Syberia 1 in the CharactersShadowOpenGL::draw call 
and instead using only shadowReceivingObjects fixes this issue.

Below are screenshots of before, after and a wireframe of the mesh that was 
incorrectly drawn.
The shadows are most noticable in the area around the chair and tables in the 
left foreground of the scene.


**Before:**
![OriginalShadows](https://github.com/scummvm/scummvm/assets/47980168/e8f05396-b69c-4aeb-9621-c580b71db8a8)
**After:**
![FixedNoShadows](https://github.com/scummvm/scummvm/assets/47980168/8ce3aa49-fce0-4bc9-8b67-80200161a113)
**Wireframe**:
![wireframe](https://github.com/scummvm/scummvm/assets/47980168/38e76283-d369-4612-bc20-c04a9bb1a20c)
