### PR TITLE
AMIGAOS: Revert a compiler flag and more cleanup

### DIFF
--- a/configure
+++ b/configure
@@ -2844,28 +2844,26 @@ case $_host_os in
 		# AmigaOS (PPC) target
 		_port_mk="backends/platform/sdl/amigaos/amigaos.mk"
 		add_line_to_config_mk 'AMIGAOS = 1'
+		# -mlongcall is needed to fix relocation errors,
+		# otherwise we crash with big engines (i.e. AGS)
+		append_var CXXFLAGS "-mlongcall"
 		# Enable full optimizations for non-debug builds
 		if test "$_debug_build" = no; then
 			_optimization_level=-O3
 		else
 			_optimization_level=-O0
-			append_var CXXFLAGS "-fno-omit-frame-pointer"
-			append_var CXXFLAGS "-fno-strict-aliasing"
-			append_var CXXFLAGS "-fstack-protector"
-			# Dependencies might also be compiled with stack protection
-			append_var LDFLAGS "-fstack-protector"
 			define_in_config_if_yes "$_debug_build" 'DEBUG_BUILD'
 		fi
-		# When building dynamic, add everything possible as plugin
-		# and leave out resources by default to save binary size
+		# dynamic builds leave out resources to save binary size
+		# and detection features *must* be static
 		if test "$_dynamic_modules" = yes ; then
 			_builtin_resources=no
-			_detection_features_static=no
 			_plugins_default=dynamic
-		else
+		#else
+			_plugins_default=static
 			_static_build=yes
 		fi
-		# Use 'long' for ScummVM's 4 byte typedef, because AmigaOS
+		# use 'long' for ScummVM's 4 byte typedef, because AmigaOS
 		# already typedefs (u)int32 as (unsigned) long and suppress
 		# those noisy format warnings caused by the 'long' 4 byte
 		append_var CXXFLAGS "-Wno-format"
@@ -7230,7 +7228,6 @@ case $_host_os in
 		;;
 	amigaos*)
 		# In release mode use LTO to improve performance
-		# and dead code elimination to reduce binary size
 		if test "$_release_build" = yes; then
 			append_var CXXFLAGS "-flto"
 			append_var PLUGIN_LDFLAGS "-flto=jobserver"


### PR DESCRIPTION
- revert -mlongcall as gcc flag

in https://github.com/raziel-/scummvm/commit/8366119da3ff867621b9164575c9df36225eabcd
i tested with only one engine, to not make testing the changes as time consuming
as it would have been, given i had to rebuild scummvm every time (yes, it's a
strange platform and no, most of the make tricks to speed things up won't work) :-)

So, the engine i used for testing was AGI.
All went well, nothing bad happened and i removed some flags in the mentioned PR.

Until i began to test the AGS engine due to an exit crash and then things went
downhill. I got strange crashes right on start, ELF library errors and random
errors all over the place.

i don't know what the size peak for -mshortcall is (i did not test with different
sized engines as i would have to build every engine on it's own for every test, together
with the accompanying scummvm - due to the detection features being built in - see below)

well, AGI seems to be small enough to work with shortcall, AGS definitely is not,
only when i reverted -mlongcall back in, my binary started working again without crashing.

- remove _detection_features_dynamic=yes, so that it is being set to static by default

another one of those "who would have known" moments.
as soon as this was in place, ELF library threw an error about not being able to resolve symbol ''
in ags.plugin and such
it seems and i am speculating here, that my platforms shared objects implementation cannot
call a plugin from within another plugin...so, if i have detection.plugin in use and try to access
ags.plugin, it will bomb gloriously.
well, who would have known? :-/

- some more compiler flags removed

they add absolutely nothing to debug logs, so away with them

- one obsolete comment remnant removed

if possible please backport to 2.8.1, otherwise the amigaos4 build is not usable

thank you