### PR TITLE
AGI: Implement motion/cycler overwrite behavior

### DIFF
--- a/engines/agi/op_cmd.cpp
+++ b/engines/agi/op_cmd.cpp
@@ -1535,7 +1535,7 @@ void cmdReverseLoop(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
 	debugC(4, kDebugLevelScripts, "o%d, f%d", objectNr, loopFlag);
 	screenObj->cycle = kCycleRevLoop;
 	screenObj->flags |= (fDontUpdate | fUpdate | fCycling);
-	screenObj->loop_flag = loopFlag;
+	screenObj->setLoopFlag(loopFlag);
 	vm->setFlag(screenObj->loop_flag, false);
 
 	vm->cyclerActivated(screenObj);
@@ -1550,7 +1550,7 @@ void cmdReverseLoopV1(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
 	screenObj->cycle = kCycleRevLoop;
 	vm->setCel(screenObj, 0);
 	screenObj->flags |= (fDontUpdate | fUpdate | fCycling);
-	screenObj->loop_flag = loopFlag;
+	screenObj->setLoopFlag(loopFlag);
 	//screenObj->parm3 = 0;
 }
 
@@ -1562,7 +1562,7 @@ void cmdEndOfLoop(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
 	debugC(4, kDebugLevelScripts, "o%d, f%d", objectNr, loopFlag);
 	screenObj->cycle = kCycleEndOfLoop;
 	screenObj->flags |= (fDontUpdate | fUpdate | fCycling);
-	screenObj->loop_flag = loopFlag;
+	screenObj->setLoopFlag(loopFlag);
 	vm->setFlag(screenObj->loop_flag, false);
 
 	vm->cyclerActivated(screenObj);
@@ -1577,7 +1577,7 @@ void cmdEndOfLoopV1(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
 	screenObj->cycle = kCycleEndOfLoop;
 	vm->setCel(screenObj, 0);
 	screenObj->flags |= (fDontUpdate | fUpdate | fCycling);
-	screenObj->loop_flag = loopFlag;
+	screenObj->setLoopFlag(loopFlag);
 	//screenObj->parm3 = 0;
 }
 

--- a/engines/agi/saveload.cpp
+++ b/engines/agi/saveload.cpp
@@ -645,7 +645,7 @@ int AgiEngine::loadGame(const Common::String &fileName, bool checkId) {
 		screenObj->cycle = (CycleType)in->readByte();
 		if (saveVersion >= 11) {
 			// Version 11+: loop_flag, was previously vt.parm1
-			screenObj->loop_flag = in->readByte();
+			screenObj->setLoopFlag(in->readByte());
 		}
 		screenObj->priority = in->readByte();
 
@@ -688,10 +688,10 @@ int AgiEngine::loadGame(const Common::String &fileName, bool checkId) {
 			if (saveVersion < 7) {
 				// Recreate loop_flag from motion-type (was previously vt.parm1)
 				// vt.parm1 was shared for multiple uses
-				screenObj->loop_flag = oldLoopFlag;
+				screenObj->setLoopFlag(oldLoopFlag);
 			} else {
 				// for Version 7-10 we can't really do anything, it was not saved
-				screenObj->loop_flag = 0; // set it to 0
+				screenObj->setLoopFlag(0); // set it to 0
 			}
 		}
 	}

--- a/engines/agi/view.cpp
+++ b/engines/agi/view.cpp
@@ -46,7 +46,11 @@ void AgiEngine::updateView(ScreenObjEntry *screenObj) {
 			if (++celNr != lastCelNr)
 				break;
 		}
-		setFlag(screenObj->loop_flag, true);
+		if (!screenObj->ignoreLoopFlag) {
+			setFlag(screenObj->loop_flag, true);
+		} else {
+			warning("kCycleEndOfLoop: skip setting flag %d", screenObj->loop_flag);
+		}
 		screenObj->flags &= ~fCycling;
 		screenObj->direction = 0;
 		screenObj->cycle = kCycleNormal;
@@ -57,7 +61,11 @@ void AgiEngine::updateView(ScreenObjEntry *screenObj) {
 			if (celNr)
 				break;
 		}
-		setFlag(screenObj->loop_flag, true);
+		if (!screenObj->ignoreLoopFlag) {
+			setFlag(screenObj->loop_flag, true);
+		} else {
+			warning("kCycleRevLoop: skip setting flag %d", screenObj->loop_flag);
+		}
 		screenObj->flags &= ~fCycling;
 		screenObj->direction = 0;
 		screenObj->cycle = kCycleNormal;

--- a/engines/agi/view.h
+++ b/engines/agi/view.h
@@ -141,9 +141,15 @@ struct ScreenObjEntry {
 	uint8 wander_count;
 	// end of motion related variables
 	uint8 loop_flag;
+	bool ignoreLoopFlag;
 
 	void reset() { memset(this, 0, sizeof(ScreenObjEntry)); }
 	ScreenObjEntry() { reset(); }
+
+	void setLoopFlag(uint8 flag) {
+		loop_flag = flag;
+		ignoreLoopFlag = false;
+	}
 }; // struct vt_entry
 
 } // End of namespace Agi


### PR DESCRIPTION
This PR fixes inaccuracies in several AGI games by implementing motion/cycler overwrite behavior. ScummVM used to do this until a refactor unintentionally altered it. When this was discovered, a workaround was added with new behavior that fixed one instance but caused more inaccuracies.

In original AGI, motion and cycler data were both stored in the same 4 bytes of the screen object structure. If a script ran a motion during a cycler, or a cycler during a motion, then the interpreter would overwrite the previous action's state and let them both run. This caused the bytes from one action to be interpreted as another's state. This could alter a motion, or cause an unintended game flag to be set when a cycler completes.

At least four games rely on this:

- King's Quest I: Jumping at the eagle
- Black Cauldron: Witches disappearing at end of game
- Donald Duck's Playground / AGI Demo: Ducks jumping during introduction
- King's Quest II: We don't know the scene, but our comments say it's affected

When the Sarien code was merged into ScummVM, it used AGI's 4 byte data structure. This meant that overwrites occurred and game behavior matched the original.

In 2016 there was a large graphics rewrite: 8a595e7771aa89d06876e13d7ab6751e26da8982 . Separate properties were created for motions and cyclers. This unintentionally altered behavior because it prevented overwrites. This was discovered a month later when the KQ1 eagle stopped working: https://bugs.scummvm.org/ticket/7046 .

In response to this, a workaround was added to block all motions if a cycler is already active: 5484f0bc58b77bf7dd28debf1b7a53bd138ba28c . This is new behavior. It fixed the KQ1 eagle script, but it altered the results of other scripts. This prevented the ducks from animating in DDP, which was reported 13 months ago in https://bugs.scummvm.org/ticket/14170 , and it prevented the Black Cauldron witches from leaving at the end of the game.

Last month I added an exception to the workaround for DDP so that the intro would work for the 2.8.1 release, but that was a temporary fix.

With that history out of the way...

This PR fixes all of this by implementing AGI motion/cycler overwrites. It does not revert any of the 2016 refactor, it just formally implements the original behavior within the existing structure, and logs more details when overwriting occurs. I am confident that there are other scenes that this fixes which have not been reported yet. (It took six years to find out that a *title screen* was broken!)

There is one specific workaround behavior that I am keeping: preventing an unintentional game flag from being set. That happens when a motion overwrites a cycler and the cycler finishes. If that actually affects any game, it seems more likely that it causes unwanted behavior.

- Fixes Black Cauldron witches not disappearing at end of game
- Properly fixes Donald Duck's Playground intro, bug #14170
- Continues to fix KQ1 eagle jump, bug #7046