### PR TITLE
AUDIO: Fix integer sign extension issue in RJP1 envelope scaling

### DIFF
--- a/audio/mods/rjp1.cpp
+++ b/audio/mods/rjp1.cpp
@@ -472,7 +472,7 @@ void Rjp1::modulateVolumeEnvelope(Rjp1Channel *channel) {
 	if (channel->envelopeMode) {
 		int16 es = channel->envelopeScale;
 		if (es) {
-			int8 m = channel->envelopeEnd1;
+			uint8 m = channel->envelopeEnd1;
 			if (m == 0) {
 				es = 0;
 			} else {


### PR DESCRIPTION
Resolve an issue where the value was incorrectly treated as a signed integer during multiplication/division. This was causing fluctuations in volume, with levels varying up and down.

The original code reads the envelopeEnd(1 and 2) value as a byte, extends it to a word then ANDs it with 0x00FF before multiplying/dividing.
