### PR TITLE
IMAGE: Remove palette start from image decoder.

### DIFF
--- a/engines/cryomni3d/cryomni3d.cpp
+++ b/engines/cryomni3d/cryomni3d.cpp
@@ -191,8 +191,7 @@ bool CryOmni3DEngine::displayHLZ(const Common::Path &filepath, uint32 timeout) {
 	}
 
 	if (imageDecoder->hasPalette()) {
-		const byte *palette = imageDecoder->getPalette();
-		setPalette(palette, imageDecoder->getPaletteStartIndex(), imageDecoder->getPaletteColorCount());
+		setPalette(imageDecoder->getPalette(), 0, imageDecoder->getPaletteColorCount());
 	}
 
 	const Graphics::Surface *frame = imageDecoder->getSurface();

--- a/engines/cryomni3d/fixed_image.cpp
+++ b/engines/cryomni3d/fixed_image.cpp
@@ -107,7 +107,7 @@ void ZonFixedImage::load(const Common::Path &image, const char *zone) {
 }
 
 void ZonFixedImage::display() const {
-	_engine.setupPalette(_imageDecoder->getPalette(), _imageDecoder->getPaletteStartIndex(),
+	_engine.setupPalette(_imageDecoder->getPalette(), 0,
 	                     _imageDecoder->getPaletteColorCount());
 
 	g_system->copyRectToScreen(_imageSurface->getPixels(), _imageSurface->pitch, 0, 0,

--- a/engines/cryomni3d/versailles/documentation.cpp
+++ b/engines/cryomni3d/versailles/documentation.cpp
@@ -326,7 +326,7 @@ Common::String Versailles_Documentation::docAreaHandleSummary() {
 	// No box for 6
 	boxes.setupBox(7, 0, 480 - _sprites->getCursor(225).getHeight(), 640, 480);
 
-	_engine->setupPalette(imageDecoder->getPalette(), imageDecoder->getPaletteStartIndex(),
+	_engine->setupPalette(imageDecoder->getPalette(), 0,
 	                      imageDecoder->getPaletteColorCount());
 
 	_engine->setCursor(181);
@@ -445,7 +445,7 @@ Common::String Versailles_Documentation::docAreaHandleTimeline() {
 	_fontManager->setCharSpacing(1);
 	_fontManager->setSurface(&docSurface);
 
-	_engine->setupPalette(imageDecoder->getPalette(), imageDecoder->getPaletteStartIndex(),
+	_engine->setupPalette(imageDecoder->getPalette(), 0,
 	                      imageDecoder->getPaletteColorCount());
 
 	_fontManager->displayStr(78, 10, (*_messages)[73]);
@@ -957,7 +957,7 @@ Common::String Versailles_Documentation::docAreaHandleGeneralMap() {
 
 	_fontManager->setSurface(&mapSurface);
 
-	_engine->setupPalette(imageDecoder->getPalette(), imageDecoder->getPaletteStartIndex(),
+	_engine->setupPalette(imageDecoder->getPalette(), 0,
 	                      imageDecoder->getPaletteColorCount());
 
 	_engine->setCursor(181);
@@ -1179,7 +1179,7 @@ Common::String Versailles_Documentation::docAreaHandleCastleMap() {
 
 	_fontManager->setSurface(&mapSurface);
 
-	_engine->setupPalette(imageDecoder->getPalette(), imageDecoder->getPaletteStartIndex(),
+	_engine->setupPalette(imageDecoder->getPalette(), 0,
 	                      imageDecoder->getPaletteColorCount());
 
 	_engine->setCursor(181);
@@ -1473,7 +1473,7 @@ void Versailles_Documentation::drawRecordData(Graphics::ManagedSurface &surface,
 	Image::ImageDecoder *imageDecoder = _engine->loadHLZ(backgroundPath);
 	const Graphics::Surface *bgFrame = imageDecoder->getSurface();
 
-	_engine->setupPalette(imageDecoder->getPalette(), imageDecoder->getPaletteStartIndex(),
+	_engine->setupPalette(imageDecoder->getPalette(), 0,
 	                      imageDecoder->getPaletteColorCount());
 
 	surface.create(bgFrame->w, bgFrame->h, bgFrame->format);

--- a/engines/cryomni3d/versailles/engine.cpp
+++ b/engines/cryomni3d/versailles/engine.cpp
@@ -643,9 +643,8 @@ void CryOmni3DEngine_Versailles::loadCursorsPalette() {
 		error("Failed to load BMP file");
 	}
 
-	_cursorPalette = new byte[3 * (bmpDecoder.getPaletteColorCount() +
-	                               bmpDecoder.getPaletteStartIndex())]();
-	memcpy(_cursorPalette + 3 * bmpDecoder.getPaletteStartIndex(), bmpDecoder.getPalette(),
+	_cursorPalette = new byte[3 * bmpDecoder.getPaletteColorCount()]();
+	memcpy(_cursorPalette, bmpDecoder.getPalette(),
 	       3 * bmpDecoder.getPaletteColorCount());
 }
 
@@ -1209,7 +1208,7 @@ void CryOmni3DEngine_Versailles::doPlaceChange() {
 				_currentPlace->setupWarpConstraints(_omni3dMan);
 				_omni3dMan.setSourceSurface(_currentWarpImage->getSurface());
 
-				setupPalette(_currentWarpImage->getPalette(), _currentWarpImage->getPaletteStartIndex(),
+				setupPalette(_currentWarpImage->getPalette(), 0,
 				             _currentWarpImage->getPaletteColorCount(), !_fadedPalette);
 
 				setMousePos(Common::Point(320, 240)); // Center of screen
@@ -1648,7 +1647,7 @@ void CryOmni3DEngine_Versailles::animateWarpTransition(const Transition *transit
 }
 
 void CryOmni3DEngine_Versailles::redrawWarp() {
-	setupPalette(_currentWarpImage->getPalette(), _currentWarpImage->getPaletteStartIndex(),
+	setupPalette(_currentWarpImage->getPalette(), 0,
 	             _currentWarpImage->getPaletteColorCount(), true);
 	if (_forceRedrawWarp) {
 		const Graphics::Surface *result = _omni3dMan.getSurface();
@@ -1721,7 +1720,7 @@ void CryOmni3DEngine_Versailles::displayObject(const Common::String &imgName,
 
 	if (imageDecoder->hasPalette()) {
 		// We don't need to calculate transparency but it's simpler to call this function
-		setupPalette(imageDecoder->getPalette(), imageDecoder->getPaletteStartIndex(),
+		setupPalette(imageDecoder->getPalette(), 0,
 		             imageDecoder->getPaletteColorCount());
 	}
 

--- a/engines/cryomni3d/versailles/menus.cpp
+++ b/engines/cryomni3d/versailles/menus.cpp
@@ -143,7 +143,7 @@ uint CryOmni3DEngine_Versailles::displayOptions() {
 
 	while (!shouldAbort() && !end) {
 		if (resetScreen) {
-			setPalette(imageDecoder->getPalette(), imageDecoder->getPaletteStartIndex(),
+			setPalette(imageDecoder->getPalette(), 0,
 			           imageDecoder->getPaletteColorCount());
 			// _cursorPalette has only 248 colors as 8 last colors are for translucency
 			setPalette(_cursorPalette + 240 * 3, 240, 8);
@@ -1011,7 +1011,7 @@ void CryOmni3DEngine_Versailles::displayCredits() {
 	byte palette[256 * 3];
 	memset(palette, 0, 256 * 3);
 	// getPalette returns the first color not index 0
-	memcpy(palette + 3 * imageDecoder->getPaletteStartIndex(), imageDecoder->getPalette(),
+	memcpy(palette, imageDecoder->getPalette(),
 	       3 * imageDecoder->getPaletteColorCount());
 	copySubPalette(palette, _cursorPalette, 240, 8);
 

--- a/engines/freescape/freescape.cpp
+++ b/engines/freescape/freescape.cpp
@@ -1020,7 +1020,7 @@ Graphics::ManagedSurface *FreescapeEngine::loadAndConvertNeoImage(Common::Seekab
 	Graphics::ManagedSurface *surface = new Graphics::ManagedSurface();
 	surface->copyFrom(*decoder.getSurface());
 	surface->convertToInPlace(_gfx->_currentPixelFormat, decoder.getPalette(),
-		decoder.getPaletteStartIndex(), decoder.getPaletteColorCount());
+		0, decoder.getPaletteColorCount());
 	return surface;
 }
 

--- a/engines/freescape/freescape.cpp
+++ b/engines/freescape/freescape.cpp
@@ -1019,8 +1019,7 @@ Graphics::ManagedSurface *FreescapeEngine::loadAndConvertNeoImage(Common::Seekab
 	decoder.loadStream(*stream);
 	Graphics::ManagedSurface *surface = new Graphics::ManagedSurface();
 	surface->copyFrom(*decoder.getSurface());
-	surface->convertToInPlace(_gfx->_currentPixelFormat, decoder.getPalette(),
-		0, decoder.getPaletteColorCount());
+	surface->convertToInPlace(_gfx->_currentPixelFormat, decoder.getPalette(), decoder.getPaletteColorCount());
 	return surface;
 }
 

--- a/engines/freescape/gfx.cpp
+++ b/engines/freescape/gfx.cpp
@@ -489,7 +489,7 @@ Graphics::Surface *Renderer::convertImageFormatIfNecessary(Graphics::ManagedSurf
 	surface->copyFrom(msurface->rawSurface());
 	byte *palette = (byte *)malloc(sizeof(byte) * 16 * 3);
 	msurface->grabPalette(palette, 0, 16); // Maximum should be 16 colours
-	surface->convertToInPlace(_texturePixelFormat, palette, 0, 16);
+	surface->convertToInPlace(_texturePixelFormat, palette, 16);
 	free(palette);
 	return surface;
 }

--- a/engines/glk/debugger.cpp
+++ b/engines/glk/debugger.cpp
@@ -104,7 +104,7 @@ void Debugger::saveRawPicture(const RawDecoder &rd, Common::WriteStream &ws) {
 	const Graphics::Surface *surface = rd.getSurface();
 	const byte *palette = rd.getPalette();
 	int paletteCount = rd.getPaletteColorCount();
-	int palStart = rd.getPaletteStartIndex();
+	int palStart = 0;
 	bool hasTransColor = rd.hasTransparentColor();
 	uint32 transColor = rd.getTransparentColor();
 

--- a/engines/mohawk/myst_graphics.cpp
+++ b/engines/mohawk/myst_graphics.cpp
@@ -217,7 +217,7 @@ void MystGraphics::applyImagePatches(uint16 id, const MohawkSurface *mhkSurface)
 		Graphics::Surface fixSurf;
 		fixSurf.create(15, 11, Graphics::PixelFormat::createFormatCLUT8());
 		fixSurf.copyRectToSurface(markerSwitchInstructionsFixPic, fixSurf.w, 0, 0, fixSurf.w, fixSurf.h);
-		fixSurf.convertToInPlace(_pixelFormat, markerSwitchInstructionsFixPal, 0, sizeof(markerSwitchInstructionsFixPal) / 3);
+		fixSurf.convertToInPlace(_pixelFormat, markerSwitchInstructionsFixPal, sizeof(markerSwitchInstructionsFixPal) / 3);
 
 		mhkSurface->getSurface()->copyRectToSurface(fixSurf, 171, 208, Common::Rect(fixSurf.w, fixSurf.h));
 

--- a/engines/mtropolis/plugin/mti.cpp
+++ b/engines/mtropolis/plugin/mti.cpp
@@ -455,7 +455,7 @@ bool PrintModifierImageSupplier::loadImageSlot(uint slot, const Graphics::Surfac
 	outHasPalette = _decoder->hasPalette();
 
 	if (_decoder->hasPalette())
-		outPalette.set(_decoder->getPalette(), _decoder->getPaletteStartIndex(), _decoder->getPaletteColorCount());
+		outPalette.set(_decoder->getPalette(), 0, _decoder->getPaletteColorCount());
 
 	outMetadata = GUI::ImageAlbumImageMetadata();
 	outMetadata._orientation = GUI::kImageAlbumImageOrientationLandscape;

--- a/engines/nancy/resource.cpp
+++ b/engines/nancy/resource.cpp
@@ -77,7 +77,7 @@ bool ResourceManager::loadImage(const Common::Path &name, Graphics::ManagedSurfa
 			Image::BitmapDecoder bmpDec;
 			bmpDec.loadStream(*stream);
 			surf.copyFrom(*bmpDec.getSurface());
-			surf.setPalette(bmpDec.getPalette(), bmpDec.getPaletteStartIndex(), MIN<uint>(256, bmpDec.getPaletteColorCount())); // LOGO.BMP reports 257 colors
+			surf.setPalette(bmpDec.getPalette(), 0, MIN<uint>(256, bmpDec.getPaletteColorCount())); // LOGO.BMP reports 257 colors
 		}
 	}
 

--- a/engines/testbed/misc.cpp
+++ b/engines/testbed/misc.cpp
@@ -246,7 +246,7 @@ bool ImageAlbumImageSupplier::loadImageSlot(uint slot, const Graphics::Surface *
 	outSurface = fi._decoder->getSurface();
 	outHasPalette = fi._decoder->hasPalette();
 	if (fi._decoder->hasPalette())
-		outPalette.set(fi._decoder->getPalette(), fi._decoder->getPaletteStartIndex(), fi._decoder->getPaletteColorCount());
+		outPalette.set(fi._decoder->getPalette(), 0, fi._decoder->getPaletteColorCount());
 	outMetadata = GUI::ImageAlbumImageMetadata();
 
 	return true;

--- a/engines/twine/renderer/screens.cpp
+++ b/engines/twine/renderer/screens.cpp
@@ -144,7 +144,7 @@ static bool loadImageDelayViaDecoder(TwinEEngine *engine, const Common::Path &fi
 		source->free();
 		delete source;
 	} else {
-		engine->setPalette(decoder.getPaletteStartIndex(), decoder.getPaletteColorCount(), decoder.getPalette());
+		engine->setPalette(0, decoder.getPaletteColorCount(), decoder.getPalette());
 		target.transBlitFrom(*src, rect, target.getBounds(), 0, false, 0, 0xff, nullptr, true);
 	}
 	if (engine->delaySkip(1000 * seconds)) {

--- a/engines/ultima/ultima8/gumps/cru_credits_gump.cpp
+++ b/engines/ultima/ultima8/gumps/cru_credits_gump.cpp
@@ -61,7 +61,7 @@ CruCreditsGump::CruCreditsGump(Common::SeekableReadStream *txtrs,
 		// This does an extra copy via the ManagedSurface, but it's a once-off.
 		const Graphics::Surface *bmpsurf = decoder.getSurface();
 		Graphics::ManagedSurface ms(bmpsurf);
-		ms.setPalette(decoder.getPalette(), decoder.getPaletteStartIndex(), decoder.getPaletteColorCount());
+		ms.setPalette(decoder.getPalette(), 0, decoder.getPaletteColorCount());
 		Common::Rect srcRect(640, 480);
 		_background->Blit(ms, srcRect, 0, 0);
 	} else {

--- a/engines/ultima/ultima8/gumps/cru_demo_gump.cpp
+++ b/engines/ultima/ultima8/gumps/cru_demo_gump.cpp
@@ -52,7 +52,7 @@ CruDemoGump::CruDemoGump(Common::SeekableReadStream *bmprs, uint32 flags, int32 
 		// This does an extra copy via the ManagedSurface, but it's a once-off.
 		const Graphics::Surface *bmpsurf = decoder.getSurface();
 		Graphics::ManagedSurface ms(bmpsurf);
-		ms.setPalette(decoder.getPalette(), decoder.getPaletteStartIndex(), decoder.getPaletteColorCount());
+		ms.setPalette(decoder.getPalette(), 0, decoder.getPaletteColorCount());
 		Common::Rect srcRect(640, 480);
 		_background->Blit(ms, srcRect, 0, 0);
 	} else {

--- a/graphics/macgui/macwindowborder.cpp
+++ b/graphics/macgui/macwindowborder.cpp
@@ -228,14 +228,14 @@ void MacWindowBorder::loadBorder(Common::SeekableReadStream &file, uint32 flags,
 
 	Graphics::ManagedSurface *surface = new Graphics::ManagedSurface();
 	surface->copyFrom(*bmpDecoder.getSurface());
-	surface->setPalette(bmpDecoder.getPalette(), bmpDecoder.getPaletteStartIndex(),
+	surface->setPalette(bmpDecoder.getPalette(), 0,
 	                    bmpDecoder.getPaletteColorCount());
 
 	if (surface->format.isCLUT8()) {
 		const byte *palette = bmpDecoder.getPalette();
 		for (int i = 0; i < bmpDecoder.getPaletteColorCount(); i++) {
 			if (palette[0] == 255 && palette[1] == 0 && palette[2] == 255) {
-				surface->setTransparentColor(bmpDecoder.getPaletteStartIndex() + i);
+				surface->setTransparentColor(i);
 				break;
 			}
 			palette += 3;

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -705,11 +705,10 @@ public:
 	 *
 	 * @param dstFormat  The desired format.
 	 * @param palette    The palette (in RGB888), if the source format has one.
-	 * @param paletteStart  The starting index of the palette.
 	 * @param paletteCount  The number of colors in the palette.
 	 */
-	void convertToInPlace(const PixelFormat &dstFormat, const byte *palette, byte paletteStart, uint16 paletteCount) {
-		_innerSurface.convertToInPlace(dstFormat, palette, paletteStart, paletteCount);
+	void convertToInPlace(const PixelFormat &dstFormat, const byte *palette, uint16 paletteCount) {
+		_innerSurface.convertToInPlace(dstFormat, palette, paletteCount);
 	}
 
 	/**

--- a/graphics/surface.cpp
+++ b/graphics/surface.cpp
@@ -475,7 +475,7 @@ Graphics::Surface *Surface::rotoscale(const TransformStruct &transform, bool fil
 	return target;
 }
 
-void Surface::convertToInPlace(const PixelFormat &dstFormat, const byte *palette, byte paletteStart, uint16 paletteCount) {
+void Surface::convertToInPlace(const PixelFormat &dstFormat, const byte *palette, uint16 paletteCount) {
 	// Do not convert to the same format and ignore empty surfaces.
 	if (format == dstFormat || pixels == 0) {
 		return;
@@ -504,7 +504,7 @@ void Surface::convertToInPlace(const PixelFormat &dstFormat, const byte *palette
 		uint32 map[256];
 		assert(palette);
 
-		convertPaletteToMap(map, palette + paletteStart, paletteCount, dstFormat);
+		convertPaletteToMap(map, palette, paletteCount, dstFormat);
 		crossBlitMap((byte *)pixels, (const byte *)pixels, w * dstFormat.bytesPerPixel, pitch, w, h, dstFormat.bytesPerPixel, map);
 	} else {
 		crossBlit((byte *)pixels, (const byte *)pixels, w * dstFormat.bytesPerPixel, pitch, w, h, dstFormat, format);

--- a/graphics/surface.h
+++ b/graphics/surface.h
@@ -356,7 +356,7 @@ public:
 	 * @param dstFormat  The desired format.
 	 */
 	inline void convertToInPlace(const PixelFormat &dstFormat) {
-		convertToInPlace(dstFormat, nullptr, 0, 0);
+		convertToInPlace(dstFormat, nullptr, 0);
 	}
 
 	/**
@@ -371,10 +371,9 @@ public:
 	 *
 	 * @param dstFormat  The desired format.
 	 * @param palette    The palette (in RGB888), if the source format has one.
-	 * @param paletteStart	The starting index of the palette.
 	 * @param paletteCount	The number of colors in the palette.
 	 */
-	void convertToInPlace(const PixelFormat &dstFormat, const byte *palette, byte paletteStart, uint16 paletteCount);
+	void convertToInPlace(const PixelFormat &dstFormat, const byte *palette, uint16 paletteCount);
 
 	/**
 	 * Convert the data to another pixel format.

--- a/gui/imagealbum-dialog.cpp
+++ b/gui/imagealbum-dialog.cpp
@@ -250,7 +250,7 @@ void ImageAlbumDialog::changeToSlot(uint slot) {
 			_imageSupplier->releaseImageSlot(slot);
 
 			if (rescaledGraphic.format.bytesPerPixel == 1)
-				rescaledGraphic.convertToInPlace(Graphics::createPixelFormat<888>(), palette.data(), 0, 256);
+				rescaledGraphic.convertToInPlace(Graphics::createPixelFormat<888>(), palette.data(), 256);
 
 			int32 xCoord = (static_cast<int32>(_imageContainer->getWidth()) - static_cast<int32>(scaledWidth)) / 2u;
 			int32 yCoord = (static_cast<int32>(_imageContainer->getHeight()) - static_cast<int32>(scaledHeight)) / 2u;

--- a/image/image_decoder.h
+++ b/image/image_decoder.h
@@ -106,8 +106,6 @@ public:
 	 */
 	virtual bool hasPalette() const { return getPaletteColorCount() != 0; }
 
-	/** Return the starting index of the palette. */
-	virtual byte getPaletteStartIndex() const { return 0; }
 	/** Return the number of colors in the palette. */
 	virtual uint16 getPaletteColorCount() const { return 0; }
 


### PR DESCRIPTION
Part of ongoing cleanup of palette handling: The palette start value was always zero, adding complexity without benefit, and removal may ease adoption of the palette class.