### PR TITLE
SCUMM: Adjust v80 default cursor palette map.

### DIFF
--- a/engines/scumm/cursor.cpp
+++ b/engines/scumm/cursor.cpp
@@ -551,7 +551,7 @@ void ScummEngine_v80he::setDefaultCursor() {
 				if (_bytesPerPixel == 2)
 					WRITE_UINT16(_grabbedCursor + (y * _cursor.width + x) * 2, get16BitColor(palette[pixel * 3], palette[pixel * 3 + 1], palette[pixel * 3 + 2]));
 				else
-					_grabbedCursor[y * _cursor.width + x] = (pixel == 0) ? 0xfd : 0xfe;
+					_grabbedCursor[y * _cursor.width + x] = pixel + 0xfd;
 			}
 		}
 	}


### PR DESCRIPTION
This is functionally the same, but adds the palette index offset rather than a check condition.

My motivation is to suggest the DefaultWinCursor & BusyWinCursor should include palette entries for the key color rather than using a palette start index of 1. The Scumm engine remap of DefaultWinCursor is the one odd place that would need adjustment for that to be possible as far as I can tell. This change would make that possible as the last three palette values are reserved for replacement by cursors in SCUMM (also done for v70)