### PR TITLE
ANDROID: Fixes on on-screen buttons

### DIFF
--- a/backends/platform/android/android.cpp
+++ b/backends/platform/android/android.cpp
@@ -192,6 +192,7 @@ OSystem_Android::OSystem_Android(int audio_sample_rate, int audio_buffer_size) :
 	_thirdPointerId(-1),
 	_trackball_scale(2),
 	_joystick_scale(10),
+	_engineRunning(false),
 	_defaultConfigFileName(),
 	_defaultLogFileName(),
 	_systemPropertiesSummaryStr(""),
@@ -568,6 +569,28 @@ void OSystem_Android::initBackend() {
 	_audiocdManager = new DefaultAudioCDManager();
 
 	BaseBackend::initBackend();
+}
+
+void OSystem_Android::engineInit() {
+	_engineRunning = true;
+	updateOnScreenControls();
+
+}
+
+void OSystem_Android::engineDone() {
+	_engineRunning = false;
+	updateOnScreenControls();
+}
+
+void OSystem_Android::updateOnScreenControls() {
+	int enableMask = SHOW_ON_SCREEN_ALL;
+	if (!ConfMan.getBool("onscreen_control")) {
+		enableMask = SHOW_ON_SCREEN_NONE;
+	} else if (!_engineRunning) {
+		// Don't show the menu icon if the engine is not running
+		enableMask &= ~SHOW_ON_SCREEN_MENU;
+	}
+	JNI::showOnScreenControls(enableMask);
 }
 
 Common::Path OSystem_Android::getDefaultConfigFileName() {

--- a/backends/platform/android/android.h
+++ b/backends/platform/android/android.h
@@ -165,6 +165,8 @@ private:
 
 	TouchControls _touchControls;
 
+	bool _engineRunning;
+
 	Common::Path _defaultConfigFileName;
 	Common::Path _defaultLogFileName;
 	Common::String _systemPropertiesSummaryStr;
@@ -197,10 +199,19 @@ public:
 		SCREEN_ORIENTATION_PORTRAIT = 1
 	};
 
+	enum {
+		SHOW_ON_SCREEN_NONE = 0,
+		SHOW_ON_SCREEN_MENU = 1,
+		SHOW_ON_SCREEN_INPUT_MODE = 2,
+		SHOW_ON_SCREEN_ALL = 0xffffffff,
+	};
+
 	OSystem_Android(int audio_sample_rate, int audio_buffer_size);
 	virtual ~OSystem_Android();
 
 	void initBackend() override;
+	void engineInit() override;
+	void engineDone() override;
 
 	bool hasFeature(OSystem::Feature f) override;
 	void setFeatureState(OSystem::Feature f, bool enable) override;
@@ -216,6 +227,8 @@ public:
 	void setupTouchMode(int oldValue, int newValue);
 
 	void applyOrientationSettings();
+
+	void updateOnScreenControls();
 
 	bool pollEvent(Common::Event &event) override;
 	Common::HardwareInputSet *getHardwareInputSet() override;

--- a/backends/platform/android/jni-android.cpp
+++ b/backends/platform/android/jni-android.cpp
@@ -420,10 +420,10 @@ void JNI::showVirtualKeyboard(bool enable) {
 	}
 }
 
-void JNI::showOnScreenControls(bool enable) {
+void JNI::showOnScreenControls(int enableMask) {
 	JNIEnv *env = JNI::getEnv();
 
-	env->CallVoidMethod(_jobj, _MID_showOnScreenControls, enable);
+	env->CallVoidMethod(_jobj, _MID_showOnScreenControls, enableMask);
 
 	if (env->ExceptionCheck()) {
 		LOGE("Error trying to show on screen controls");
@@ -796,7 +796,7 @@ void JNI::create(JNIEnv *env, jobject self, jobject asset_manager,
 	FIND_METHOD(, setTextInClipboard, "(Ljava/lang/String;)Z");
 	FIND_METHOD(, isConnectionLimited, "()Z");
 	FIND_METHOD(, showVirtualKeyboard, "(Z)V");
-	FIND_METHOD(, showOnScreenControls, "(Z)V");
+	FIND_METHOD(, showOnScreenControls, "(I)V");
 	FIND_METHOD(, getBitmapResource, "(I)Landroid/graphics/Bitmap;");
 	FIND_METHOD(, setTouchMode, "(I)V");
 	FIND_METHOD(, getTouchMode, "()I");

--- a/backends/platform/android/jni-android.cpp
+++ b/backends/platform/android/jni-android.cpp
@@ -90,7 +90,7 @@ jmethodID JNI::_MID_setTextInClipboard = 0;
 jmethodID JNI::_MID_isConnectionLimited = 0;
 jmethodID JNI::_MID_setWindowCaption = 0;
 jmethodID JNI::_MID_showVirtualKeyboard = 0;
-jmethodID JNI::_MID_showKeyboardControl = 0;
+jmethodID JNI::_MID_showOnScreenControls = 0;
 jmethodID JNI::_MID_getBitmapResource = 0;
 jmethodID JNI::_MID_setTouchMode = 0;
 jmethodID JNI::_MID_getTouchMode = 0;
@@ -420,13 +420,13 @@ void JNI::showVirtualKeyboard(bool enable) {
 	}
 }
 
-void JNI::showKeyboardControl(bool enable) {
+void JNI::showOnScreenControls(bool enable) {
 	JNIEnv *env = JNI::getEnv();
 
-	env->CallVoidMethod(_jobj, _MID_showKeyboardControl, enable);
+	env->CallVoidMethod(_jobj, _MID_showOnScreenControls, enable);
 
 	if (env->ExceptionCheck()) {
-		LOGE("Error trying to show virtual keyboard control");
+		LOGE("Error trying to show on screen controls");
 
 		env->ExceptionDescribe();
 		env->ExceptionClear();
@@ -796,7 +796,7 @@ void JNI::create(JNIEnv *env, jobject self, jobject asset_manager,
 	FIND_METHOD(, setTextInClipboard, "(Ljava/lang/String;)Z");
 	FIND_METHOD(, isConnectionLimited, "()Z");
 	FIND_METHOD(, showVirtualKeyboard, "(Z)V");
-	FIND_METHOD(, showKeyboardControl, "(Z)V");
+	FIND_METHOD(, showOnScreenControls, "(Z)V");
 	FIND_METHOD(, getBitmapResource, "(I)Landroid/graphics/Bitmap;");
 	FIND_METHOD(, setTouchMode, "(I)V");
 	FIND_METHOD(, getTouchMode, "()I");

--- a/backends/platform/android/jni-android.h
+++ b/backends/platform/android/jni-android.h
@@ -91,7 +91,7 @@ public:
 	static bool setTextInClipboard(const Common::U32String &text);
 	static bool isConnectionLimited();
 	static void showVirtualKeyboard(bool enable);
-	static void showOnScreenControls(bool enable);
+	static void showOnScreenControls(int enableMask);
 	static Graphics::Surface *getBitmapResource(BitmapResources resource);
 	static void setTouchMode(int touchMode);
 	static int getTouchMode();

--- a/backends/platform/android/jni-android.h
+++ b/backends/platform/android/jni-android.h
@@ -91,7 +91,7 @@ public:
 	static bool setTextInClipboard(const Common::U32String &text);
 	static bool isConnectionLimited();
 	static void showVirtualKeyboard(bool enable);
-	static void showKeyboardControl(bool enable);
+	static void showOnScreenControls(bool enable);
 	static Graphics::Surface *getBitmapResource(BitmapResources resource);
 	static void setTouchMode(int touchMode);
 	static int getTouchMode();
@@ -153,7 +153,7 @@ private:
 	static jmethodID _MID_isConnectionLimited;
 	static jmethodID _MID_setWindowCaption;
 	static jmethodID _MID_showVirtualKeyboard;
-	static jmethodID _MID_showKeyboardControl;
+	static jmethodID _MID_showOnScreenControls;
 	static jmethodID _MID_getBitmapResource;
 	static jmethodID _MID_setTouchMode;
 	static jmethodID _MID_getTouchMode;

--- a/backends/platform/android/options.cpp
+++ b/backends/platform/android/options.cpp
@@ -476,7 +476,7 @@ void OSystem_Android::applyOrientationSettings() {
 }
 
 void OSystem_Android::applyBackendSettings() {
-	JNI::showKeyboardControl(ConfMan.getBool("onscreen_control"));
+	JNI::showOnScreenControls(ConfMan.getBool("onscreen_control"));
 }
 
 SAFRemoveDialog::SAFRemoveDialog() : GUI::Dialog("SAFBrowser") {

--- a/backends/platform/android/options.cpp
+++ b/backends/platform/android/options.cpp
@@ -476,7 +476,7 @@ void OSystem_Android::applyOrientationSettings() {
 }
 
 void OSystem_Android::applyBackendSettings() {
-	JNI::showOnScreenControls(ConfMan.getBool("onscreen_control"));
+	updateOnScreenControls();
 }
 
 SAFRemoveDialog::SAFRemoveDialog() : GUI::Dialog("SAFBrowser") {

--- a/backends/platform/android/org/scummvm/scummvm/ScummVM.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVM.java
@@ -24,6 +24,9 @@ import javax.microedition.khronos.egl.EGLSurface;
 import javax.microedition.khronos.opengles.GL10;
 
 public abstract class ScummVM implements SurfaceHolder.Callback, Runnable {
+	public static final int SHOW_ON_SCREEN_MENU = 1;
+	public static final int SHOW_ON_SCREEN_INPUT_MODE = 2;
+
 	final protected static String LOG_TAG = "ScummVM";
 	final private AssetManager _asset_manager;
 	final private Object _sem_surface;
@@ -76,7 +79,7 @@ public abstract class ScummVM implements SurfaceHolder.Callback, Runnable {
 	abstract protected boolean isConnectionLimited();
 	abstract protected void setWindowCaption(String caption);
 	abstract protected void showVirtualKeyboard(boolean enable);
-	abstract protected void showOnScreenControls(boolean enable);
+	abstract protected void showOnScreenControls(int enableMask);
 	abstract protected Bitmap getBitmapResource(int resource);
 	abstract protected void setTouchMode(int touchMode);
 	abstract protected int getTouchMode();

--- a/backends/platform/android/org/scummvm/scummvm/ScummVM.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVM.java
@@ -76,7 +76,7 @@ public abstract class ScummVM implements SurfaceHolder.Callback, Runnable {
 	abstract protected boolean isConnectionLimited();
 	abstract protected void setWindowCaption(String caption);
 	abstract protected void showVirtualKeyboard(boolean enable);
-	abstract protected void showKeyboardControl(boolean enable);
+	abstract protected void showOnScreenControls(boolean enable);
 	abstract protected Bitmap getBitmapResource(int resource);
 	abstract protected void setTouchMode(int touchMode);
 	abstract protected int getTouchMode();

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
@@ -758,10 +758,10 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 		}
 
 		@Override
-		protected void showKeyboardControl(final boolean enable) {
+		protected void showOnScreenControls(final boolean enable) {
 			runOnUiThread(new Runnable() {
 				public void run() {
-					showToggleKeyboardBtnIcon(enable);
+					showToggleOnScreenBtnIcons(enable);
 				}
 			});
 		}
@@ -1120,7 +1120,7 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 		if (isScreenKeyboardShown()) {
 			hideScreenKeyboard();
 		}
-		showToggleKeyboardBtnIcon(false);
+		showToggleOnScreenBtnIcons(false);
 	}
 
 
@@ -1294,8 +1294,8 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 //	}
 
 	// Show or hide the semi-transparent onscreen controls
-	// Called by the override of showKeyboardControl()
-	private void showToggleKeyboardBtnIcon(boolean show) {
+	// Called by the override of showOnScreenControls()
+	private void showToggleOnScreenBtnIcons(boolean show) {
 		if (_openMenuBtnIcon != null ) {
 			_openMenuBtnIcon.setVisibility(show ? View.VISIBLE : View.GONE);
 		}

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
@@ -956,6 +956,8 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 
 		_toggleTouchModeKeyboardBtnIcon = new ImageView(this);
 
+		// Hide by default all buttons, they will be shown when native code will start
+		showToggleOnScreenBtnIcons(0);
 		layoutButtonLayout(getResources().getConfiguration().orientation, true);
 
 		_main_surface.setFocusable(true);

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
@@ -783,10 +783,10 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 		}
 
 		@Override
-		protected void showOnScreenControls(final boolean enable) {
+		protected void showOnScreenControls(final int enableMask) {
 			runOnUiThread(new Runnable() {
 				public void run() {
-					showToggleOnScreenBtnIcons(enable);
+					showToggleOnScreenBtnIcons(enableMask);
 				}
 			});
 		}
@@ -1142,7 +1142,7 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 		if (isScreenKeyboardShown()) {
 			hideScreenKeyboard();
 		}
-		showToggleOnScreenBtnIcons(false);
+		showToggleOnScreenBtnIcons(0);
 	}
 
 
@@ -1317,13 +1317,13 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 
 	// Show or hide the semi-transparent onscreen controls
 	// Called by the override of showOnScreenControls()
-	private void showToggleOnScreenBtnIcons(boolean show) {
+	private void showToggleOnScreenBtnIcons(int enableMask) {
 		if (_openMenuBtnIcon != null ) {
-			_openMenuBtnIcon.setVisibility(show ? View.VISIBLE : View.GONE);
+			_openMenuBtnIcon.setVisibility((enableMask & ScummVM.SHOW_ON_SCREEN_MENU) != 0 ? View.VISIBLE : View.GONE);
 		}
 
 		if (_toggleTouchModeKeyboardBtnIcon != null ) {
-			_toggleTouchModeKeyboardBtnIcon.setVisibility(show ? View.VISIBLE : View.GONE);
+			_toggleTouchModeKeyboardBtnIcon.setVisibility((enableMask & ScummVM.SHOW_ON_SCREEN_INPUT_MODE) != 0 ? View.VISIBLE : View.GONE);
 		}
 	}
 

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
@@ -124,6 +124,7 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 	FrameLayout _videoLayout = null;
 
 	private EditableSurfaceView _main_surface = null;
+	private LinearLayout _buttonLayout = null;
 	private ImageView _toggleTouchModeKeyboardBtnIcon = null;
 	private ImageView _openMenuBtnIcon = null;
 
@@ -154,6 +155,8 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 		if (hwKeyboard) {
 			hideScreenKeyboard();
 		}
+
+		layoutButtonLayout(newConfig.orientation, false);
 	}
 
 	private boolean isHWKeyboardConnected() {
@@ -517,6 +520,28 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 				});
 			}
 //			_main_surface.nativeScreenKeyboardShown( keyboardWithoutTextInputShown ? 1 : 0 );
+		}
+	}
+
+	private void layoutButtonLayout(int orientation, boolean force) {
+		int newOrientation = orientation == Configuration.ORIENTATION_LANDSCAPE ? LinearLayout.VERTICAL : LinearLayout.HORIZONTAL;
+
+		if (!force && newOrientation == _buttonLayout.getOrientation()) {
+			return;
+		}
+
+		_buttonLayout.setOrientation(newOrientation);
+		_buttonLayout.removeAllViews();
+		if (newOrientation == LinearLayout.VERTICAL) {
+			_buttonLayout.addView(_openMenuBtnIcon, new FrameLayout.LayoutParams(FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT));
+			_buttonLayout.bringChildToFront(_openMenuBtnIcon);
+			_buttonLayout.addView(_toggleTouchModeKeyboardBtnIcon, new FrameLayout.LayoutParams(FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT));
+			_buttonLayout.bringChildToFront(_toggleTouchModeKeyboardBtnIcon);
+		} else {
+			_buttonLayout.addView(_toggleTouchModeKeyboardBtnIcon, new FrameLayout.LayoutParams(FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT));
+			_buttonLayout.bringChildToFront(_toggleTouchModeKeyboardBtnIcon);
+			_buttonLayout.addView(_openMenuBtnIcon, new FrameLayout.LayoutParams(FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT));
+			_buttonLayout.bringChildToFront(_openMenuBtnIcon);
 		}
 	}
 
@@ -919,22 +944,19 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 
 		_videoLayout.addView(_main_surface, new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
 
-		LinearLayout buttonLayout = new LinearLayout(this);
-		buttonLayout.setOrientation(LinearLayout.HORIZONTAL);
+		_buttonLayout = new LinearLayout(this);
 		FrameLayout.LayoutParams buttonLayoutParams = new FrameLayout.LayoutParams(FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT, Gravity.TOP | Gravity.RIGHT);
 		buttonLayoutParams.topMargin = 5;
 		buttonLayoutParams.rightMargin = 5;
-		_videoLayout.addView(buttonLayout, buttonLayoutParams);
-		_videoLayout.bringChildToFront(buttonLayout);
-
-		_toggleTouchModeKeyboardBtnIcon = new ImageView(this);
-		buttonLayout.addView(_toggleTouchModeKeyboardBtnIcon, new FrameLayout.LayoutParams(FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT));
-		buttonLayout.bringChildToFront(_toggleTouchModeKeyboardBtnIcon);
+		_videoLayout.addView(_buttonLayout, buttonLayoutParams);
+		_videoLayout.bringChildToFront(_buttonLayout);
 
 		_openMenuBtnIcon = new ImageView(this);
 		_openMenuBtnIcon.setImageResource(R.drawable.ic_action_menu);
-		buttonLayout.addView(_openMenuBtnIcon, new FrameLayout.LayoutParams(FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT));
-		buttonLayout.bringChildToFront(_openMenuBtnIcon);
+
+		_toggleTouchModeKeyboardBtnIcon = new ImageView(this);
+
+		layoutButtonLayout(getResources().getConfiguration().orientation, true);
 
 		_main_surface.setFocusable(true);
 		_main_surface.setFocusableInTouchMode(true);


### PR DESCRIPTION
There are two changes:
- make the on screen buttons vertical when in landscape and horizontal when in portrait mode
- hide the menu icon while not in-game

I hope the last one will make the update pass on the store.