### PR TITLE
GUI: Show [?] Help button tooltip on dialog launch

### DIFF
--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -634,10 +634,16 @@ void GuiManager::runLoop() {
 		// 2. If the mouse was moved but ended on the same (tooltip enabled) widget,
 		//    then delay showing the tooltip based on the value of kTooltipSameWidgetDelay.
 		uint32 systemMillisNowForTooltipCheck = _system->getMillis(true);
-		if ((_lastTooltipShown.x != _lastMousePosition.x || _lastTooltipShown.y != _lastMousePosition.y)
+		if (_forcedToolTip || ((_lastTooltipShown.x != _lastMousePosition.x || _lastTooltipShown.y != _lastMousePosition.y)
 		    && systemMillisNowForTooltipCheck - _lastMousePosition.time > (uint32)kTooltipDelay
-		    && !activeDialog->isDragging()) {
+		    && !activeDialog->isDragging())) {
 			Widget *wdg = activeDialog->findWidget(_lastMousePosition.x, _lastMousePosition.y);
+
+			if (_forcedToolTip) {
+				wdg = _forcedToolTip;
+				_forcedToolTip = nullptr;
+			}
+
 			if (wdg && (wdg->hasTooltip() || (wdg->getFlags() & WIDGET_DYN_TOOLTIP)) && !(wdg->getFlags() & WIDGET_PRESSED)
 			    && (_lastTooltipShown.wdg != wdg || systemMillisNowForTooltipCheck - _lastTooltipShown.time > (uint32)kTooltipSameWidgetDelay)) {
 				_lastTooltipShown.time = systemMillisNowForTooltipCheck;
@@ -926,6 +932,9 @@ void GuiManager::giveFocusToDialog(Dialog *dialog) {
 }
 
 void GuiManager::setLastMousePos(int16 x, int16 y) {
+	if (_forcedToolTip)
+		return;
+
 	_lastMousePosition.x = x;
 	_lastMousePosition.y = y;
 	_lastMousePosition.time = _system->getMillis(true);

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -243,7 +243,10 @@ protected:
 	void screenChange();
 
 	void giveFocusToDialog(Dialog *dialog);
+	public:
 	void setLastMousePos(int16 x, int16 y);
+
+	Widget *_forcedToolTip = nullptr;
 };
 
 } // End of namespace GUI

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -259,7 +259,7 @@ void LauncherDialog::build() {
 #endif
 		new StaticTextWidget(this, _title + ".Version", Common::U32String(gScummVMFullVersion));
 
-	new ButtonWidget(this, _title + ".HelpButton", Common::U32String("?"), _("Help"), kHelpCmd);
+	_helpButton = new ButtonWidget(this, _title + ".HelpButton", Common::U32String("?"), _("Help"), kHelpCmd);
 
 	if (!g_system->hasFeature(OSystem::kFeatureNoQuit)) {
 		// I18N: Button Quit ScummVM program. Q is the shortcut, Ctrl+Q, put it in parens for non-latin (~Q~)
@@ -357,6 +357,9 @@ void LauncherDialog::open() {
 	Dialog::open();
 
 	updateButtons();
+
+	g_gui.setLastMousePos(_helpButton->getAbsX(), _helpButton->getAbsY());
+	g_gui._forcedToolTip = _helpButton;
 }
 
 void LauncherDialog::close() {

--- a/gui/launcher.h
+++ b/gui/launcher.h
@@ -131,6 +131,7 @@ protected:
 #endif
 	StaticTextWidget	*_searchDesc;
 	ButtonWidget	*_searchClearButton;
+	ButtonWidget    *_helpButton;
 	ButtonWidget	*_addButton;
 	Widget			*_removeButton;
 	Widget			*_startButton;


### PR DESCRIPTION
This is an RFC.

I noticed that users do not quite understand the [?] button, so I had this idea of showing our tooltip on startup. Maybe even record it from "Help" to "Click here for Help".

Here is a quick and dirty hack for making it happen. It is barely noticeable on desktop since we do remove the dialog on the mouse move, but hopefully, on mobile ports, e.g., Android/iOS, it will be more prominent.

It looks like this on startup. The tooltip disappears on mouse move/tapping, this making it noticeable, that "something is there, in the corner".

<img width="756" alt="Screenshot 2024-04-08 at 00 32 46" src="https://github.com/scummvm/scummvm/assets/365188/503bf4d6-7c73-40a6-857f-2f9eae8580a7">
