### PR TITLE
GUI: Keep caret visible in editable widgets while moving it with the keyboard

### DIFF
--- a/gui/widgets/editable.cpp
+++ b/gui/widgets/editable.cpp
@@ -69,6 +69,12 @@ void EditableWidget::init() {
 EditableWidget::~EditableWidget() {
 }
 
+void EditableWidget::drawWidget() {
+	if (_caretVisible) {
+		drawCaret(false, true);
+	}
+}
+
 void EditableWidget::reflowLayout() {
 	Widget::reflowLayout();
 
@@ -526,12 +532,23 @@ int EditableWidget::getSelectionCarretOffset() const {
 	return g_gui.getStringWidth(substr, _font) - _editScrollOffset;
 }
 
-void EditableWidget::drawCaret(bool erase) {
+  void EditableWidget::drawCaret(bool erase, bool useRelativeCoordinates) {
 	// Only draw if item is visible
 	if (!isVisible() || !_boss->isVisible())
 		return;
 
 	Common::Rect editRect = getEditRect();
+
+	int xOff;
+	int yOff;
+
+	if (useRelativeCoordinates) {
+		xOff = getRelX();
+		yOff = getRelY();
+	} else {
+		xOff = getAbsX();
+		yOff = getAbsY();
+	}
 
 	int x = editRect.left;
 	int y = editRect.top;
@@ -554,10 +571,10 @@ void EditableWidget::drawCaret(bool erase) {
 		return;
 
 	if (g_gui.useRTL())
-		x += g_system->getOverlayWidth() - _w - getAbsX() + g_gui.getOverlayOffset();
+		x += g_system->getOverlayWidth() - _w - xOff + g_gui.getOverlayOffset();
 	else
-		x += getAbsX();
-	y += getAbsY();
+		x += xOff;
+	y += yOff;
 
 	g_gui.theme()->drawCaret(Common::Rect(x, y, x + 1, y + editRect.height()), erase);
 

--- a/gui/widgets/editable.h
+++ b/gui/widgets/editable.h
@@ -91,6 +91,8 @@ public:
 	void setSelectionOffset(int newOffset);
 
 protected:
+	void drawWidget() override;
+
 	virtual void startEditMode() = 0;
 	virtual void endEditMode() = 0;
 	virtual void abortEditMode() = 0;
@@ -102,7 +104,7 @@ protected:
 	virtual Common::Rect getEditRect() const = 0;
 	virtual int getCaretOffset() const;
 	virtual int getSelectionCarretOffset() const;
-	void drawCaret(bool erase);
+	void drawCaret(bool erase, bool useRelativeCoordinates = false);
 	bool adjustOffset();
 	void makeCaretVisible();
 

--- a/gui/widgets/edittext.cpp
+++ b/gui/widgets/edittext.cpp
@@ -122,6 +122,8 @@ void EditTextWidget::drawWidget() {
 		                        -_editScrollOffset, false, _font, ThemeEngine::kFontColorNormal, true, 
 		                        _textDrawableArea);
 	}
+
+	EditableWidget::drawWidget();
 }
 
 Common::Rect EditTextWidget::getEditRect() const {

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -613,6 +613,8 @@ void ListWidget::drawWidget() {
 			g_gui.theme()->drawText(r2, buffer, _state, _drawAlign, inverted, _leftPadding, true);
 		}
 	}
+
+	EditableWidget::drawWidget();
 }
 
 Common::Rect ListWidget::getEditRect() const {


### PR DESCRIPTION
Something that's been bugging me for ages is that if you use the arrow keys to move the caret in an editable widget, the caret is not drawn. This makes it hard to know where you will end up.

So imagine my surprise when I realized that the editable widget all along has been trying to force the caret visible. Except it didn't work, because if the widget was also marked as "dirty" (which it usually is?), it's immediately drawn over the caret. To get around this, I've made EditableWidget responsible for drawing the caret as part of the widget when necessary.

To further complicate things, the widget's _x and _y are different depending on when drawCaret() is called. I've added an optional parameter to drawCaret() to choose whether to use relative or absolute coordinates. It seems to work, but I'm not 100% confident.
