### PR TITLE
MADE: TeraDrive Manhole

### DIFF
--- a/engines/made/detection_tables.h
+++ b/engines/made/detection_tables.h
@@ -524,6 +524,23 @@ static const MadeGameDescription gameDescriptions[] = {
 	},
 
 	{
+		// The Manhole Sega TeraDrive
+		{
+			"manhole",
+			"TeraDrive",
+			AD_ENTRY1s("manhole.dat", "14522ee9139ca0823ac0cc15805e1fcc", 112303),
+			Common::JA_JPN,
+			Common::kPlatformDOS,
+			ADGF_UNSTABLE,
+			GUIO1(GUIO_NOSPEECH)
+		},
+		GID_MANHOLE,
+		0,
+		GF_FLOPPY,
+		3,
+	},
+
+	{
 		// Leather Goddesses of Phobos 2 (English)
 		{
 			"lgop2",


### PR DESCRIPTION
This is a rare release of The Manhole for Sega's TeraDrive computer, which contains both an IBM DOS PC and a Sega Genesis. This game mostly runs on the DOS half, but uses the Genesis hardware for sound. According to screenshots, it seems to be largely based on the FM Towns version and uses its 256 colour art, but was released on a floppy. It doesn't boot; it immediately crashes with "Failed to find picture 10!".

I'm unclear whether we need a new platform for this or if it counts as "DOS".