### PR TITLE
ANDROID: Remove deprecation warnings

### DIFF
--- a/backends/platform/android/org/scummvm/scummvm/CompatHelpers.java
+++ b/backends/platform/android/org/scummvm/scummvm/CompatHelpers.java
@@ -1,5 +1,10 @@
 package org.scummvm.scummvm;
 
+import android.media.AudioAttributes;
+import android.media.AudioFormat;
+import android.media.AudioManager;
+import android.media.AudioTrack;
+
 import android.view.View;
 import android.view.Window;
 import android.view.WindowInsets;
@@ -50,6 +55,86 @@ class CompatHelpers {
 				WindowInsetsController insetsController = window.getInsetsController();
 				insetsController.hide(WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars());
 				insetsController.setSystemBarsBehavior(WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+			}
+		}
+	}
+
+	static class AudioTrackCompat {
+		public static class AudioTrackCompatReturn {
+			public AudioTrack audioTrack;
+			public int bufferSize;
+		}
+
+		public static AudioTrackCompatReturn make(int sample_rate, int buffer_size) {
+			if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+				return AudioTrackCompatM.make(sample_rate, buffer_size);
+			} else if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+				return AudioTrackCompatLollipop.make(sample_rate, buffer_size);
+			} else {
+				return AudioTrackCompatOld.make(sample_rate, buffer_size);
+			}
+		}
+
+		/**
+		 * Support for Android KitKat or lower
+		 */
+		@SuppressWarnings("deprecation")
+		private static class AudioTrackCompatOld {
+			public static AudioTrackCompatReturn make(int sample_rate, int buffer_size) {
+				AudioTrackCompatReturn ret = new AudioTrackCompatReturn();
+				ret.audioTrack = new AudioTrack(
+					AudioManager.STREAM_MUSIC,
+					sample_rate,
+					AudioFormat.CHANNEL_OUT_STEREO,
+					AudioFormat.ENCODING_PCM_16BIT,
+					buffer_size,
+					AudioTrack.MODE_STREAM);
+				ret.bufferSize = buffer_size;
+				return ret;
+			}
+		}
+
+		@RequiresApi(android.os.Build.VERSION_CODES.LOLLIPOP)
+		private static class AudioTrackCompatLollipop {
+			public static AudioTrackCompatReturn make(int sample_rate, int buffer_size) {
+				AudioTrackCompatReturn ret = new AudioTrackCompatReturn();
+				ret.audioTrack = new AudioTrack(
+					new AudioAttributes.Builder()
+						.setUsage(AudioAttributes.USAGE_MEDIA)
+						.setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+						.build(),
+					new AudioFormat.Builder()
+						.setSampleRate(sample_rate)
+						.setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+						.setChannelMask(AudioFormat.CHANNEL_OUT_STEREO).build(),
+					buffer_size,
+					AudioTrack.MODE_STREAM,
+					AudioManager.AUDIO_SESSION_ID_GENERATE);
+				ret.bufferSize = buffer_size;
+				return ret;
+			}
+		}
+
+		@RequiresApi(android.os.Build.VERSION_CODES.M)
+		private static class AudioTrackCompatM {
+			public static AudioTrackCompatReturn make(int sample_rate, int buffer_size) {
+				AudioTrackCompatReturn ret = new AudioTrackCompatReturn();
+				ret.audioTrack = new AudioTrack(
+					new AudioAttributes.Builder()
+						.setUsage(AudioAttributes.USAGE_MEDIA)
+						.setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+						.build(),
+					new AudioFormat.Builder()
+						.setSampleRate(sample_rate)
+						.setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+						.setChannelMask(AudioFormat.CHANNEL_OUT_STEREO).build(),
+					buffer_size,
+					AudioTrack.MODE_STREAM,
+					AudioManager.AUDIO_SESSION_ID_GENERATE);
+				// Keep track of the actual obtained audio buffer size, if supported.
+				// We just requested 16 bit PCM stereo pcm so there are 4 bytes per frame.
+				ret.bufferSize = ret.audioTrack.getBufferSizeInFrames() * 4;
+				return ret;
 			}
 		}
 	}

--- a/backends/platform/android/org/scummvm/scummvm/CompatHelpers.java
+++ b/backends/platform/android/org/scummvm/scummvm/CompatHelpers.java
@@ -1,0 +1,56 @@
+package org.scummvm.scummvm;
+
+import android.view.View;
+import android.view.Window;
+import android.view.WindowInsets;
+import android.view.WindowInsetsController;
+
+import androidx.annotation.RequiresApi;
+
+class CompatHelpers {
+	static class HideSystemStatusBar {
+
+		public static void hide(final Window window) {
+			if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+				HideSystemStatusBarR.hide(window);
+			} else if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
+				HideSystemStatusBarKitKat.hide(window);
+			} else {
+				HideSystemStatusBarJellyBean.hide(window);
+			}
+		}
+
+		@RequiresApi(android.os.Build.VERSION_CODES.JELLY_BEAN)
+		@SuppressWarnings("deprecation")
+		private static class HideSystemStatusBarJellyBean {
+			public static void hide(final Window window) {
+				View view = window.getDecorView();
+				view.setSystemUiVisibility(
+					view.getSystemUiVisibility() |
+					View.SYSTEM_UI_FLAG_LOW_PROFILE);
+			}
+		}
+
+		@RequiresApi(android.os.Build.VERSION_CODES.KITKAT)
+		@SuppressWarnings("deprecation")
+		private static class HideSystemStatusBarKitKat {
+			public static void hide(final Window window) {
+				View view = window.getDecorView();
+				view.setSystemUiVisibility(
+					(view.getSystemUiVisibility() & ~View.SYSTEM_UI_FLAG_IMMERSIVE) |
+					View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY |
+					View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
+					View.SYSTEM_UI_FLAG_FULLSCREEN);
+			}
+		}
+
+		@RequiresApi(android.os.Build.VERSION_CODES.R)
+		private static class HideSystemStatusBarR {
+			public static void hide(final Window window) {
+				WindowInsetsController insetsController = window.getInsetsController();
+				insetsController.hide(WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars());
+				insetsController.setSystemBarsBehavior(WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+			}
+		}
+	}
+}

--- a/backends/platform/android/org/scummvm/scummvm/CompatHelpers.java
+++ b/backends/platform/android/org/scummvm/scummvm/CompatHelpers.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.view.Window;
 import android.view.WindowInsets;
 import android.view.WindowInsetsController;
+import android.view.accessibility.AccessibilityEvent;
 
 import androidx.annotation.RequiresApi;
 
@@ -137,5 +138,32 @@ class CompatHelpers {
 				return ret;
 			}
 		}
+	}
+
+	static class AccessibilityEventConstructor {
+		public static AccessibilityEvent make(int eventType) {
+			if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+				return AccessibilityEventConstructorR.make(eventType);
+			} else {
+				return AccessibilityEventConstructorOld.make(eventType);
+			}
+
+		}
+
+		@SuppressWarnings("deprecation")
+		private static class AccessibilityEventConstructorOld {
+			public static AccessibilityEvent make(int eventType) {
+				return AccessibilityEvent.obtain(eventType);
+			}
+		}
+
+		@RequiresApi(android.os.Build.VERSION_CODES.R)
+		private static class AccessibilityEventConstructorR {
+			public static AccessibilityEvent make(int eventType) {
+				return new AccessibilityEvent(eventType);
+			}
+		}
+
+
 	}
 }

--- a/backends/platform/android/org/scummvm/scummvm/CustomKeyboardView.java
+++ b/backends/platform/android/org/scummvm/scummvm/CustomKeyboardView.java
@@ -1071,7 +1071,7 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
 
 	private void sendAccessibilityEventForUnicodeCharacter(int eventType, int code) {
 		if (mAccessibilityManager.isEnabled()) {
-			AccessibilityEvent event = AccessibilityEvent.obtain(eventType);
+			AccessibilityEvent event = CompatHelpers.AccessibilityEventConstructor.make(eventType);
 			onInitializeAccessibilityEvent(event);
 			final String text;
 			switch (code) {

--- a/backends/platform/android/org/scummvm/scummvm/ExternalStorage.java
+++ b/backends/platform/android/org/scummvm/scummvm/ExternalStorage.java
@@ -481,8 +481,8 @@ public class ExternalStorage {
 		map.add(DATA_DIRECTORY_INT);
 		map.add(ctx.getFilesDir().getPath());
 
-		map.add(DATA_DIRECTORY_EXT);
 		if (ctx.getExternalFilesDir(null) != null) {
+			map.add(DATA_DIRECTORY_EXT);
 			map.add(ctx.getExternalFilesDir(null).getPath());
 		}
 

--- a/backends/platform/android/org/scummvm/scummvm/ScummVM.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVM.java
@@ -4,7 +4,6 @@ import androidx.annotation.NonNull;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.PixelFormat;
-import android.media.AudioAttributes;
 import android.media.AudioFormat;
 import android.media.AudioManager;
 import android.media.AudioTrack;
@@ -291,11 +290,10 @@ public abstract class ScummVM implements SurfaceHolder.Callback, Runnable {
 	}
 
 	private void initAudio() throws Exception {
-		_sample_rate = AudioTrack.getNativeOutputSampleRate(
-									AudioManager.STREAM_MUSIC);
+		_sample_rate = AudioTrack.getNativeOutputSampleRate(AudioManager.STREAM_MUSIC);
 		_buffer_size = AudioTrack.getMinBufferSize(_sample_rate,
-									AudioFormat.CHANNEL_OUT_STEREO,
-									AudioFormat.ENCODING_PCM_16BIT);
+		                                           AudioFormat.CHANNEL_OUT_STEREO,
+		                                           AudioFormat.ENCODING_PCM_16BIT);
 
 		// ~50ms
 		int buffer_size_want = (_sample_rate * 2 * 2 / 20) & ~1023;
@@ -310,33 +308,10 @@ public abstract class ScummVM implements SurfaceHolder.Callback, Runnable {
 		Log.i(LOG_TAG, String.format(Locale.ROOT, "Using %d bytes buffer for %dHz audio",
 										_buffer_size, _sample_rate));
 
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-			_audio_track = new AudioTrack(
-				new AudioAttributes.Builder()
-					.setUsage(AudioAttributes.USAGE_MEDIA)
-					.setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
-					.build(),
-				new AudioFormat.Builder()
-					.setSampleRate(_sample_rate)
-					.setEncoding(AudioFormat.ENCODING_PCM_16BIT)
-					.setChannelMask(AudioFormat.CHANNEL_OUT_STEREO).build(),
-				_buffer_size,
-				AudioTrack.MODE_STREAM,
-				AudioManager.AUDIO_SESSION_ID_GENERATE);
-
-			// Keep track of the actual obtained audio buffer size, if supported.
-			// We just requested 16 bit PCM stereo pcm so there are 4 bytes per frame.
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-				_buffer_size = _audio_track.getBufferSizeInFrames() * 4;
-		} else {
-			//support for Android KitKat or lower
-			_audio_track = new AudioTrack(AudioManager.STREAM_MUSIC,
-				_sample_rate,
-				AudioFormat.CHANNEL_OUT_STEREO,
-				AudioFormat.ENCODING_PCM_16BIT,
-				_buffer_size,
-				AudioTrack.MODE_STREAM);
-		}
+		CompatHelpers.AudioTrackCompat.AudioTrackCompatReturn audioTrackRet =
+			CompatHelpers.AudioTrackCompat.make(_sample_rate, _buffer_size);
+		_audio_track = audioTrackRet.audioTrack;
+		_buffer_size = audioTrackRet.bufferSize;
 
 		if (_audio_track.getState() != AudioTrack.STATE_INITIALIZED)
 			throw new Exception(

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
@@ -17,9 +17,8 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Rect;
 import android.media.AudioManager;
+import android.net.ConnectivityManager;
 import android.net.Uri;
-import android.net.wifi.WifiInfo;
-import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
@@ -750,13 +749,8 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 
 		@Override
 		protected boolean isConnectionLimited() {
-			// The WIFI Service must be looked up on the Application Context or memory will leak on devices < Android N (According to Android Studio warning)
-			WifiManager wifiMgr = (WifiManager)getApplicationContext().getSystemService(Context.WIFI_SERVICE);
-			if (wifiMgr != null && wifiMgr.isWifiEnabled()) {
-				WifiInfo wifiInfo = wifiMgr.getConnectionInfo();
-				return (wifiInfo == null || wifiInfo.getNetworkId() == -1); //WiFi is on, but it's not connected to any network
-			}
-			return true;
+			ConnectivityManager cm = (ConnectivityManager)getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
+			return cm == null || cm.isActiveNetworkMetered();
 		}
 
 		@Override

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
@@ -923,7 +923,7 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 		safSyncObject = new Object();
 
 		_videoLayout = new FrameLayout(this);
-		SetLayerType.get().setLayerType(_videoLayout);
+		_videoLayout.setLayerType(android.view.View.LAYER_TYPE_NONE, null);
 		getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 		setContentView(_videoLayout);
 		_videoLayout.setFocusable(true);
@@ -931,7 +931,7 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 		_videoLayout.requestFocus();
 
 		_main_surface = new EditableSurfaceView(this);
-		SetLayerType.get().setLayerType(_main_surface);
+		_main_surface.setLayerType(android.view.View.LAYER_TYPE_NONE, null);
 
 		_videoLayout.addView(_main_surface, new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
 
@@ -2130,38 +2130,6 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 	// -------------------------------------------------------------------------------------------
 
 } // end of ScummVMActivity
-
-abstract class SetLayerType {
-
-	public static SetLayerType get() {
-		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB) {
-			return SetLayerTypeHoneycomb.Holder.sInstance;
-		} else {
-			return SetLayerTypeDummy.Holder.sInstance;
-		}
-	}
-
-	public abstract void setLayerType(final View view);
-
-	private static class SetLayerTypeHoneycomb extends SetLayerType {
-		private static class Holder {
-			private static final SetLayerTypeHoneycomb sInstance = new SetLayerTypeHoneycomb();
-		}
-
-		public void setLayerType(final View view) {
-			view.setLayerType(android.view.View.LAYER_TYPE_NONE, null);
-			//view.setLayerType(android.view.View.LAYER_TYPE_HARDWARE, null);
-		}
-	}
-
-	private static class SetLayerTypeDummy extends SetLayerType {
-		private static class Holder {
-			private static final SetLayerTypeDummy sInstance = new SetLayerTypeDummy();
-		}
-
-		public void setLayerType(final View view) { }
-	}
-}
 
 // Used to define the interface for a callback after ScummVM thread has finished
 interface MyScummVMDestroyedCallback {

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
@@ -184,7 +184,8 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 							//_inputManager.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
 							//_inputManager.showSoftInput(_main_surface, InputMethodManager.SHOW_FORCED);
 
-							_inputManager.toggleSoftInputFromWindow(_main_surface.getWindowToken(), InputMethodManager.SHOW_IMPLICIT, InputMethodManager.HIDE_IMPLICIT_ONLY);
+							// This is deprecated and we show the keyboard just below
+							//_inputManager.toggleSoftInputFromWindow(_main_surface.getWindowToken(), InputMethodManager.SHOW_IMPLICIT, InputMethodManager.HIDE_IMPLICIT_ONLY);
 							_inputManager.showSoftInput(_main_surface, InputMethodManager.SHOW_IMPLICIT);
 							getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
 						} else {

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
@@ -13,6 +13,7 @@ import android.content.UriPermission;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Rect;
@@ -684,9 +685,10 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 
 		@Override
 		protected void getDPI(float[] values) {
-			DisplayMetrics metrics = new DisplayMetrics();
-			getWindowManager().getDefaultDisplay().getMetrics(metrics);
-			Configuration config = getResources().getConfiguration();
+			Resources resources = getResources();
+
+			DisplayMetrics metrics = resources.getDisplayMetrics();
+			Configuration config = resources.getConfiguration();
 
 			values[0] = metrics.xdpi;
 			values[1] = metrics.ydpi;

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMEventsBase.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMEventsBase.java
@@ -343,36 +343,8 @@ public class ScummVMEventsBase implements
 			}
 		}
 
-		// The KeyEvent.ACTION_MULTIPLE constant was deprecated in API level 29 (Q).
-		// No longer used by the input system.
-		// getAction() value: multiple duplicate key events have occurred in a row, or a complex string is being delivered.
-		//    If the key code is not KEYCODE_UNKNOWN then the getRepeatCount() method returns the number of times the given key code should be executed.
-		//    Otherwise, if the key code is KEYCODE_UNKNOWN, then this is a sequence of characters as returned by getCharacters().
-		//    sequence of characters
-		// getCharacters() is also deprecated in API level 29
-		//    For the special case of a ACTION_MULTIPLE event with key code of KEYCODE_UNKNOWN,
-		//    this is a raw string of characters associated with the event. In all other cases it is null.
-		// TODO What is the use case for this?
-		//  Does it make sense to keep it with a Build.VERSION.SDK_INT < Build.VERSION_CODES.Q check?
 		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-			if (action == KeyEvent.ACTION_MULTIPLE
-				&& keyCode == KeyEvent.KEYCODE_UNKNOWN) {
-				final KeyCharacterMap m = KeyCharacterMap.load(e.getDeviceId());
-				final KeyEvent[] es = m.getEvents(e.getCharacters().toCharArray());
-
-				if (es == null) {
-					return true;
-				}
-
-				for (KeyEvent s : es) {
-					_scummvm.pushEvent(JE_KEY,
-						s.getAction(),
-						s.getKeyCode(),
-						eventUnicodeChar & KeyCharacterMap.COMBINING_ACCENT_MASK,
-						s.getMetaState(),
-						s.getRepeatCount(),
-						0);
-				}
+			if (onKeyMultiple(action, keyCode, e)) {
 				return true;
 			}
 		}
@@ -470,6 +442,45 @@ public class ScummVMEventsBase implements
 		return true;
 	}
 
+	/**
+	 * This gets called only on Android < Q
+	 */
+	@SuppressWarnings("deprecation")
+	private boolean onKeyMultiple(int action, int keyCode, KeyEvent e) {
+		// The KeyEvent.ACTION_MULTIPLE constant was deprecated in API level 29 (Q).
+		// No longer used by the input system.
+		// getAction() value: multiple duplicate key events have occurred in a row, or a complex string is being delivered.
+		//    If the key code is not KEYCODE_UNKNOWN then the getRepeatCount() method returns the number of times the given key code should be executed.
+		//    Otherwise, if the key code is KEYCODE_UNKNOWN, then this is a sequence of characters as returned by getCharacters().
+		//    sequence of characters
+		// getCharacters() is also deprecated in API level 29
+		//    For the special case of a ACTION_MULTIPLE event with key code of KEYCODE_UNKNOWN,
+		//    this is a raw string of characters associated with the event. In all other cases it is null.
+		// TODO What is the use case for this?
+		//  Does it make sense to keep it with a Build.VERSION.SDK_INT < Build.VERSION_CODES.Q check?
+		if (action == KeyEvent.ACTION_MULTIPLE
+			&& keyCode == KeyEvent.KEYCODE_UNKNOWN) {
+			final KeyCharacterMap m = KeyCharacterMap.load(e.getDeviceId());
+			final KeyEvent[] es = m.getEvents(e.getCharacters().toCharArray());
+
+			if (es == null) {
+				return true;
+			}
+
+			for (KeyEvent s : es) {
+				_scummvm.pushEvent(JE_KEY,
+					s.getAction(),
+					s.getKeyCode(),
+					s.getUnicodeChar() & KeyCharacterMap.COMBINING_ACCENT_MASK,
+					s.getMetaState(),
+					s.getRepeatCount(),
+					0);
+			}
+			return true;
+		}
+
+		return false;
+	}
 
 	/** Aux method to provide a description for a MotionEvent action
 	 *  Given an action int, returns a string description

--- a/backends/platform/android/org/scummvm/scummvm/SplashActivity.java
+++ b/backends/platform/android/org/scummvm/scummvm/SplashActivity.java
@@ -31,9 +31,7 @@ public class SplashActivity extends Activity {
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
-
 		super.onCreate(savedInstanceState);
-		hideSystemUI();
 
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
 		    && Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU
@@ -47,6 +45,12 @@ public class SplashActivity extends Activity {
 			startActivity(new Intent(this, ScummVMActivity.class));
 			finish();
 		}
+	}
+
+	@Override
+	public void onResume() {
+		super.onResume();
+		CompatHelpers.HideSystemStatusBar.hide(getWindow());
 	}
 
 	@Override
@@ -73,35 +77,11 @@ public class SplashActivity extends Activity {
 		finish();
 	}
 
-	// TODO setSystemUiVisibility is introduced in API 11 and deprecated in API 30 - When we move to API 30 we will have to replace this code
-	//	https://developer.android.com/training/system-ui/immersive.html#java
-	//
-	//  The code sample in the url below contains code to switch between immersive and default mode
-	//	https://github.com/android/user-interface-samples/tree/master/AdvancedImmersiveMode
-	//  We could do something similar by making it a Global UI option.
-	@TargetApi(Build.VERSION_CODES.KITKAT)
-	private void hideSystemUI() {
-		// Enables regular immersive mode.
-		// For "lean back" mode, remove SYSTEM_UI_FLAG_IMMERSIVE.
-		// Or for "sticky immersive," replace it with SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-		View decorView = getWindow().getDecorView();
-		decorView.setSystemUiVisibility(
-			View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-				// Set the content to appear under the system bars so that the
-				// content doesn't resize when the system bars hide and show.
-				| View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-				| View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-				| View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-				// Hide the nav bar and status bar
-				| View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-				| View.SYSTEM_UI_FLAG_FULLSCREEN);
-	}
-
 	@Override
 	public void onWindowFocusChanged(boolean hasFocus) {
 		super.onWindowFocusChanged(hasFocus);
 		if (hasFocus) {
-			hideSystemUI();
+			CompatHelpers.HideSystemStatusBar.hide(getWindow());
 		}
 	}
 


### PR DESCRIPTION
This is a bunch of commits which remove deprecated warnings mainly by isolating code inside its own function in a class dedicated to compatibility shims.
There is also some API changes to determine if connection is limited (metered) and to make the application immersive.

This has been tested on API level 34 (U).
I will test later on API levels 29 (Q) and 19 (Kit Kat).
I could test on 16 (Jelly Bean) with an emulator too.