### PR TITLE
ACHIEVEMENTS: Allow to override the default achievements platform

### DIFF
--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -138,6 +138,17 @@ Common::KeymapArray MetaEngine::initKeymaps(const char *target) const {
 	return Keymap::arrayOf(engineKeyMap);
 }
 
+Common::AchievementsPlatform MetaEngine::getAchievementsPlatform(const Common::String &target) const {
+	Common::String extra = ConfMan.get("extra", target);
+	if (extra.contains("GOG")) {
+		return Common::GALAXY_ACHIEVEMENTS;
+	}
+	if (extra.contains("Steam")) {
+		return Common::STEAM_ACHIEVEMENTS;
+	}
+	return Common::UNK_ACHIEVEMENTS;
+}
+
 const Common::AchievementsInfo MetaEngine::getAchievementsInfo(const Common::String &target) const {
 	const Common::AchievementDescriptionList* achievementDescriptionList = getAchievementDescriptionList();
 	if (achievementDescriptionList == nullptr) {
@@ -146,13 +157,7 @@ const Common::AchievementsInfo MetaEngine::getAchievementsInfo(const Common::Str
 
 	Common::String gameId = ConfMan.get("gameid", target);
 
-	Common::AchievementsPlatform platform = Common::UNK_ACHIEVEMENTS;
-	Common::String extra = ConfMan.get("extra", target);
-	if (extra.contains("GOG")) {
-		platform = Common::GALAXY_ACHIEVEMENTS;
-	} else if (extra.contains("Steam")) {
-		platform = Common::STEAM_ACHIEVEMENTS;
-	}
+	const Common::AchievementsPlatform platform = getAchievementsPlatform(target);
 
 	// "(gameId, platform) -> result" search
 	Common::AchievementsInfo result;
@@ -403,7 +408,7 @@ SaveStateList MetaEngine::listSaves(const char *target, bool saveMode) const {
 	SaveStateDescriptor desc(this, autosaveSlot, dummyAutosave);
 	desc.setWriteProtectedFlag(true);
 	desc.setDeletableFlag(false);
-	
+
 	saveList.push_back(desc);
 	Common::sort(saveList.begin(), saveList.end(), SaveStateDescriptorSlotComparator());
 

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -494,6 +494,15 @@ public:
 	};
 
 	/**
+	 * Return the achievements platform to use for the specified target.
+	 *
+	 * @param target  Name of a config manager target.
+	 *
+	 * @return The achievements platform to use for an engine plugin and target.
+	 */
+	virtual Common::AchievementsPlatform getAchievementsPlatform(const Common::String &target) const;
+
+	/**
 	 * Return a list of achievement descriptions for the specified target.
 	 *
 	 * @param target  Name of a config manager target.


### PR DESCRIPTION
This pull requests allow to override the default achievements platform, today this platform comes from the `extra`field from a game description.

**Why?**
In `Thimbleweed Park` I want to propose the steam achievements even for GOG and EPIC games.

**Example**
Here I have a game for GOG but using the Steam achievements:

```cpp
Common::AchievementsPlatform TwpMetaEngine::getAchievementsPlatform(const Common::String &target) const {
	return Common::STEAM_ACHIEVEMENTS;
}
```

<img width="1392" alt="Screenshot 2024-04-23 at 11 56 27" src="https://github.com/scummvm/scummvm/assets/643384/029b2774-0edd-4e04-871a-95771450a5e8">