### PR TITLE
ULTIMA4: Support pixel formats other than RGB565

### DIFF
--- a/engines/ultima/ultima4/controllers/intro_controller.cpp
+++ b/engines/ultima/ultima4/controllers/intro_controller.cpp
@@ -189,7 +189,7 @@ IntroController::IntroController() : Controller(1),
 	Common::fill(&_questionTree[0], &_questionTree[15], -1);
 
 	// Setup a separate image surface for rendering the animated map on
-	_mapScreen = Image::create(g_screen->w, g_screen->h, false, Image::HARDWARE);
+	_mapScreen = Image::create(g_screen->w, g_screen->h, g_screen->format);
 	_mapArea.setDest(_mapScreen);
 
 	// initialize menus
@@ -1493,8 +1493,7 @@ void IntroController::getTitleSourceData() {
 			_titles[i]._srcImage = Image::create(
 				_titles[i]._rw * info->_prescale,
 				_titles[i]._rh * info->_prescale,
-			    info->_image->isIndexed() && _titles[i]._method != MAP,
-				Image::HARDWARE);
+				_titles[i]._method == MAP ? _mapScreen->format() : info->_image->format());
 			if (_titles[i]._srcImage->isIndexed())
 				_titles[i]._srcImage->setPaletteFromImage(info->_image);
 
@@ -1590,14 +1589,12 @@ void IntroController::getTitleSourceData() {
 		if (_titles[i]._srcImage)
 			_titles[i]._srcImage->alphaOff();
 
-		bool indexed = info->_image->isIndexed() && _titles[i]._method != MAP;
 		// create the initial animation frame
 		_titles[i]._destImage = Image::create(
 			2 + (_titles[i]._prescaled ? SCALED(_titles[i]._rw) : _titles[i]._rw) * info->_prescale ,
-		    2 + (_titles[i]._prescaled ? SCALED(_titles[i]._rh) : _titles[i]._rh) * info->_prescale,
-		    indexed,
-			Image::HARDWARE);
-		if (indexed)
+			2 + (_titles[i]._prescaled ? SCALED(_titles[i]._rh) : _titles[i]._rh) * info->_prescale,
+			_titles[i]._method == MAP ? _mapScreen->format() : info->_image->format());
+		if (_titles[i]._destImage->isIndexed())
 			_titles[i]._destImage->setPaletteFromImage(info->_image);
 	}
 

--- a/engines/ultima/ultima4/gfx/image.h
+++ b/engines/ultima/ultima4/gfx/image.h
@@ -78,19 +78,17 @@ private:
 
 	uint getColor(byte r, byte g, byte b, byte a);
 public:
-	enum Type {
-		HARDWARE,
-		SOFTWARE
-	};
+	/**
+	 * Creates a new palette based image.  Scale is stored to allow drawing
+	 * using U4 (320x200) coordinates, regardless of the actual image scale.
+	 */
+	static Image *create(int w, int h);
 
 	/**
-	 * Creates a new image.  Scale is stored to allow drawing using U4
+	 * Creates a new RGB image.  Scale is stored to allow drawing using U4
 	 * (320x200) coordinates, regardless of the actual image scale.
-	 * Indexed is true for palette based images, or false for RGB images.
-	 * Image type determines whether to create a hardware (i.e. video ram)
-	 * or software (i.e. normal ram) image.
 	 */
-	static Image *create(int w, int h, bool paletted, Type type);
+	static Image *create(int w, int h, const Graphics::PixelFormat &format);
 
 	/**
 	 * Create a special purpose image the represents the whole screen.
@@ -100,14 +98,14 @@ public:
 	/**
 	 * Creates a duplicate of another image
 	 */
-	static Image *duplicate(Image *image);
+	static Image *duplicate(Image *image, const Graphics::PixelFormat &format);
 
 	/**
 	 * Frees the image.
 	 */
 	~Image();
 
-	void create(int w, int h, bool paletted);
+	void createInternal(int w, int h, const Graphics::PixelFormat &format);
 
 	/* palette handling */
 	/**
@@ -246,6 +244,9 @@ public:
 	}
 	int height() const {
 		return _surface->h;
+	}
+	Graphics::PixelFormat format() const {
+		return _surface->format;
 	}
 	bool isIndexed() const {
 		return _paletted;

--- a/engines/ultima/ultima4/gfx/imagemgr.cpp
+++ b/engines/ultima/ultima4/gfx/imagemgr.cpp
@@ -562,7 +562,7 @@ ImageInfo *ImageMgr::get(const Common::String &name, bool returnUnscaled) {
 				warning("can't load image \"%s\" with type \"%s\"", info->_filename.c_str(), filetype.c_str());
 			} else {
 				const Graphics::Surface *surface = decoder->getSurface();
-				unscaled = Image::create(surface->w, surface->h, decoder->hasPalette(), Image::HARDWARE);
+				unscaled = Image::create(surface->w, surface->h, surface->format);
 				unscaled->blitFrom(*surface);
 
 				if (decoder->hasPalette()) {
@@ -620,10 +620,12 @@ ImageInfo *ImageMgr::get(const Common::String &name, bool returnUnscaled) {
 		break;
 	case FIXUP_BLACKTRANSPARENCYHACK:
 		//Apply transparency shadow hack to ultima4 ega and vga upgrade classic graphics.
-		Image *unscaled_original = unscaled;
-		unscaled = Image::duplicate(unscaled);
-		delete unscaled_original;
 		if (Settings::getInstance()._enhancements && Settings::getInstance()._enhancementsOptions._u4TileTransparencyHack) {
+			// TODO: Pick a more optimal pixel format?
+			Image *unscaled_original = unscaled;
+			unscaled = Image::duplicate(unscaled, Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
+			delete unscaled_original;
+
 			int transparency_shadow_size = Settings::getInstance()._enhancementsOptions._u4TrileTransparencyHackShadowBreadth;
 			int black_index = 0;
 			int opacity = Settings::getInstance()._enhancementsOptions._u4TileTransparencyHackPixelShadowOpacity;

--- a/engines/ultima/ultima4/gfx/scale.cpp
+++ b/engines/ultima/ultima4/gfx/scale.cpp
@@ -22,6 +22,7 @@
 #include "ultima/ultima4/gfx/image.h"
 #include "ultima/ultima4/gfx/scale.h"
 #include "ultima/ultima4/core/utils.h"
+#include "common/system.h"
 
 namespace Ultima {
 namespace Ultima4 {
@@ -58,7 +59,7 @@ Image *scalePoint(Image *src, int scale, int n) {
 	int x, y, i, j;
 	Image *dest;
 
-	dest = Image::create(src->width() * scale, src->height() * scale, src->isIndexed(), Image::HARDWARE);
+	dest = Image::create(src->width() * scale, src->height() * scale, src->format());
 	if (!dest)
 		return nullptr;
 
@@ -92,7 +93,8 @@ Image *scale2xBilinear(Image *src, int scale, int n) {
 	/* this scaler works only with images scaled by 2x */
 	assertMsg(scale == 2, "invalid scale: %d", scale);
 
-	dest = Image::create(src->width() * scale, src->height() * scale, false, Image::HARDWARE);
+	Graphics::PixelFormat format = src->isIndexed() ? g_system->getScreenFormat() : src->format();
+	dest = Image::create(src->width() * scale, src->height() * scale, format);
 	if (!dest)
 		return nullptr;
 
@@ -194,7 +196,8 @@ Image *scale2xSaI(Image *src, int scale, int N) {
 	/* this scaler works only with images scaled by 2x */
 	assertMsg(scale == 2, "invalid scale: %d", scale);
 
-	dest = Image::create(src->width() * scale, src->height() * scale, false, Image::HARDWARE);
+	Graphics::PixelFormat format = src->isIndexed() ? g_system->getScreenFormat() : src->format();
+	dest = Image::create(src->width() * scale, src->height() * scale, format);
 	if (!dest)
 		return nullptr;
 
@@ -360,7 +363,7 @@ Image *scaleScale2x(Image *src, int scale, int n) {
 	/* this scaler works only with images scaled by 2x or 3x */
 	assertMsg(scale == 2 || scale == 3, "invalid scale: %d", scale);
 
-	dest = Image::create(src->width() * scale, src->height() * scale, src->isIndexed(), Image::HARDWARE);
+	dest = Image::create(src->width() * scale, src->height() * scale, src->format());
 	if (!dest)
 		return nullptr;
 

--- a/engines/ultima/ultima4/gfx/screen.cpp
+++ b/engines/ultima/ultima4/gfx/screen.cpp
@@ -83,11 +83,10 @@ Screen::~Screen() {
 }
 
 void Screen::init() {
-	Graphics::PixelFormat SCREEN_FORMAT(2, 5, 6, 5, 0, 11, 5, 0, 0);
 	Common::Point size(SCREEN_WIDTH * settings._scale, SCREEN_HEIGHT * settings._scale);
 
-	initGraphics(size.x, size.y, &SCREEN_FORMAT);
-	create(size.x, size.y, SCREEN_FORMAT);
+	initGraphics(size.x, size.y, nullptr);
+	create(size.x, size.y, g_system->getScreenFormat());
 
 	loadMouseCursors();
 	screenLoadGraphicsFromConf();
@@ -1344,7 +1343,7 @@ Image *Screen::screenScale(Image *src, int scale, int n, int filter) {
 		dest = (*scalerGet("point"))(src, scale, n);
 
 	if (!dest)
-		dest = Image::duplicate(src);
+		dest = Image::duplicate(src, src->format());
 
 	if (isTransparent)
 		dest->setTransparentIndex(transparentIndex);
@@ -1366,7 +1365,7 @@ Image *Screen::screenScaleDown(Image *src, int scale) {
 
 	src->alphaOff();
 
-	dest = Image::create(src->width() / scale, src->height() / scale, src->isIndexed(), Image::HARDWARE);
+	dest = Image::create(src->width() / scale, src->height() / scale, src->format());
 	if (!dest)
 		return nullptr;
 

--- a/engines/ultima/ultima4/map/tile.cpp
+++ b/engines/ultima/ultima4/map/tile.cpp
@@ -158,16 +158,18 @@ void Tile::loadImage() {
 			info->_image->alphaOff();
 
 		if (info) {
-			_w = (subimage ? subimage->width() *_scale : info->_width * _scale / info->_prescale);
-			_h = (subimage ? (subimage->height() * _scale) / _frames : (info->_height * _scale / info->_prescale) / _frames);
-			_image = Image::create(_w, _h * _frames, false, Image::HARDWARE);
-
-
-			//info->image->alphaOff();
-
 			// Draw the tile from the image we found to our tile image
 			Image *tiles = info->_image;
 			assert(tiles);
+
+			_w = (subimage ? subimage->width() *_scale : info->_width * _scale / info->_prescale);
+			_h = (subimage ? (subimage->height() * _scale) / _frames : (info->_height * _scale / info->_prescale) / _frames);
+			_image = Image::create(_w, _h * _frames, tiles->format());
+
+			if (_image->isIndexed())
+				_image->setPaletteFromImage(tiles);
+
+			//info->image->alphaOff();
 
 			if (subimage) {
 				tiles->drawSubRectOn(_image, 0, 0,

--- a/engines/ultima/ultima4/views/tileview.cpp
+++ b/engines/ultima/ultima4/views/tileview.cpp
@@ -30,6 +30,7 @@
 #include "ultima/ultima4/map/tileset.h"
 #include "ultima/ultima4/views/tileview.h"
 #include "ultima/ultima4/ultima4.h"
+#include "common/system.h"
 
 namespace Ultima {
 namespace Ultima4 {
@@ -41,7 +42,7 @@ TileView::TileView(int x, int y, int columns, int rows) :
 	_tileWidth = TILE_WIDTH;
 	_tileHeight = TILE_HEIGHT;
 	_tileSet = g_tileSets->get("base");
-	_animated = Image::create(SCALED(_tileWidth), SCALED(_tileHeight), false, Image::HARDWARE);
+	_animated = Image::create(SCALED(_tileWidth), SCALED(_tileHeight), g_system->getScreenFormat());
 	_dest = nullptr;
 }
 
@@ -52,7 +53,7 @@ TileView::TileView(int x, int y, int columns, int rows, const Common::String &ti
 	_tileWidth = TILE_WIDTH;
 	_tileHeight = TILE_HEIGHT;
 	_tileSet = g_tileSets->get(tileset);
-	_animated = Image::create(SCALED(_tileWidth), SCALED(_tileHeight), false, Image::HARDWARE);
+	_animated = Image::create(SCALED(_tileWidth), SCALED(_tileHeight), g_system->getScreenFormat());
 	_dest = nullptr;
 }
 
@@ -69,7 +70,7 @@ void TileView::reinit() {
 		delete _animated;
 		_animated = nullptr;
 	}
-	_animated = Image::create(SCALED(_tileWidth), SCALED(_tileHeight), false, Image::HARDWARE);
+	_animated = Image::create(SCALED(_tileWidth), SCALED(_tileHeight), _dest ? _dest->format() : g_system->getScreenFormat());
 }
 
 void TileView::loadTile(MapTile &mapTile) {

--- a/engines/ultima/ultima4/views/view.cpp
+++ b/engines/ultima/ultima4/views/view.cpp
@@ -81,7 +81,7 @@ void View::drawHighlighted() {
 	Image *screen = imageMgr->get("screen")->_image;
 
 	Image *tmp = Image::create(SCALED(_highlightBounds.width()),
-		SCALED(_highlightBounds.height()), false, Image::SOFTWARE);
+		SCALED(_highlightBounds.height()), screen->format());
 	if (!tmp)
 		return;
 


### PR DESCRIPTION
This allows Ultima IV to start on the Nintendo DS, which doesn't support RGB565, and should help performance on other platforms that require converting from RGB565 in software.