### PR TITLE
COMMON: clear mappedEvents list only if empty

### DIFF
--- a/common/events.cpp
+++ b/common/events.cpp
@@ -18,7 +18,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
 #include "common/events.h"
 
 #include "common/system.h"
@@ -92,7 +91,9 @@ void EventDispatcher::dispatch() {
 				assert(event.type != EVENT_CUSTOM_ENGINE_ACTION_END);
 
 				for (List<MapperEntry>::iterator m = _mappers.begin(); m != _mappers.end(); ++m) {
-					mappedEvents.clear();
+					if (!mappedEvents.empty())
+						mappedEvents.clear();
+
 					if (!m->mapper->mapEvent(event, mappedEvents))
 						continue;
 


### PR DESCRIPTION
This is still related to #5677, which seems to have  not solved completely the issue, as segfault is still reported on RPi4 armv7 builds (ref https://github.com/libretro/scummvm/issues/54).
Though looks like redundant, checking if `mappedEvents` list is empty before clearing it seems to solve the issue, as otherwise at the second loop in the for cycle, clearing the empty list will cause segfault (as `_anchor._next` becomes `null` for no apparent reason).
Not sure if root cause is some gcc v12.2 bug (as compiling with `-O0` works properly) or it's some subtle bug somewhere else causing memory corruption for 32bit arm builds.
@bluegr 