### PR TITLE
DEVTOOLS: Raise minimum cmake version to 3.13

### DIFF
--- a/devtools/create_project/cmake/CMakeLists.txt
+++ b/devtools/create_project/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(create_project)
 
 


### PR DESCRIPTION
Versions less than 3.5 are deprecated. The generated cmake has minimum version 3.13 too.
