### PR TITLE
IMGUI: Some cleanups

### DIFF
--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -48,6 +48,9 @@ public:
 	virtual int getDefaultGraphicsMode() const { return 0; }
 	virtual bool setGraphicsMode(int mode, uint flags = OSystem::kGfxModeNoFlags) { return (mode == 0); }
 	virtual int getGraphicsMode() const { return 0; }
+#if defined(USE_IMGUI)
+	virtual void setImGuiRenderCallback(void(*render)()) { }
+#endif
 	virtual bool setShader(const Common::Path &fileName) { return false; }
 	virtual const OSystem::GraphicsMode *getSupportedStretchModes() const {
 		static const OSystem::GraphicsMode noStretchModes[] = {{"NONE", "Normal", 0}, {nullptr, nullptr, 0 }};
@@ -113,11 +116,6 @@ public:
 
 	virtual void saveScreenshot() {}
 	virtual bool lockMouse(bool lock) { return false; }
-
-	virtual void setImGuiRenderCallback(void(*render)()) { _imGuiRender = render; }
-
-protected:
-	void(*_imGuiRender)() = nullptr;
 };
 
 #endif

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -665,9 +665,7 @@ void OpenGLGraphicsManager::updateScreen() {
 	    && !_osdMessageSurface && !_osdIconSurface
 #endif
 	    ) {
-#if !defined(USE_IMGUI)
 		return;
-#endif
 	}
 
 	// Update changes to textures.

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -458,7 +458,7 @@ void OpenGLSdlGraphicsManager::refreshScreen() {
 	}
 #endif
 
-#ifdef USE_IMGUI
+#if defined(USE_IMGUI) && SDL_VERSION_ATLEAST(2, 0, 0)
 	if(_imGuiRender) {
 		ImGui_ImplOpenGL3_NewFrame();
 		ImGui_ImplSDL2_NewFrame(_window->getSDLWindow());

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -305,6 +305,12 @@ void OpenGLSdlGraphicsManager::updateScreen() {
 		--_ignoreResizeEvents;
 	}
 
+#if defined(USE_IMGUI) && SDL_VERSION_ATLEAST(2, 0, 0)
+	if (_imGuiRender) {
+		_forceRedraw = true;
+	}
+#endif
+
 	OpenGLGraphicsManager::updateScreen();
 }
 

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -205,6 +205,15 @@ protected:
 
 private:
 	void toggleFullScreen();
+
+#if defined(USE_IMGUI) && SDL_VERSION_ATLEAST(2, 0, 0)
+public:
+	void setImGuiRenderCallback(void(*render)()) override { _imGuiRender = render; }
+
+protected:
+	void(*_imGuiRender)() = nullptr;
+#endif
+
 };
 
 #endif

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -689,7 +689,7 @@ void OpenGLSdlGraphics3dManager::updateScreen() {
 	}
 #endif
 
-#ifdef USE_IMGUI
+#if defined(USE_IMGUI) && SDL_VERSION_ATLEAST(2, 0, 0)
 	if (_imGuiRender) {
 		ImGui_ImplOpenGL3_NewFrame();
 		ImGui_ImplSDL2_NewFrame(_window->getSDLWindow());

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
@@ -120,7 +120,6 @@ protected:
 	int _glContextProfileMask, _glContextMajor, _glContextMinor;
 	SDL_GLContext _glContext;
 	void deinitializeRenderer();
-	bool _imguiInit = false;
 #endif
 
 	OpenGL::ContextType _glContextType;

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -73,6 +73,12 @@ int ModularGraphicsBackend::getGraphicsMode() const {
 	return _graphicsManager->getGraphicsMode();
 }
 
+#if defined(USE_IMGUI)
+void ModularGraphicsBackend::setImGuiRenderCallback(void(*render)()) {
+	_graphicsManager->setImGuiRenderCallback(render);
+}
+#endif
+
 bool ModularGraphicsBackend::setShader(const Common::Path &fileName) {
 	return _graphicsManager->setShader(fileName);
 }

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -67,6 +67,9 @@ public:
 	int getDefaultGraphicsMode() const override;
 	bool setGraphicsMode(int mode, uint flags = kGfxModeNoFlags) override;
 	int getGraphicsMode() const override;
+#if defined(USE_IMGUI)
+	void setImGuiRenderCallback(void(*render)()) override final;
+#endif
 	bool setShader(const Common::Path &name) override final;
 	const GraphicsMode *getSupportedStretchModes() const override final;
 	int getDefaultStretchMode() const override final;

--- a/common/system.h
+++ b/common/system.h
@@ -907,6 +907,17 @@ public:
 	virtual void *getOpenGLProcAddress(const char *name) const { return nullptr; }
 #endif
 
+#if defined(USE_IMGUI)
+	/**
+	 * Set the address for ImGui rendering callback
+	 *
+	 * This is only supported on select backends desktop oriented
+	 *
+	 * @param render The function pointer called while rendering on screen
+	 */
+	virtual void setImGuiRenderCallback(void(*render)()) { }
+#endif
+
 	/**
 	 * Load the specified shader.
 	 *

--- a/configure
+++ b/configure
@@ -6775,12 +6775,31 @@ echo "$_discord"
 #
 echocheck "ImGui"
 
-if test "$_opengl" = yes ; then
-  define_in_config_if_yes "$_imgui" 'USE_IMGUI'
-  echo "$_imgui"
+if test "$_imgui" != no ; then
+	if test "$_opengl" = yes ; then
+		case $_backend in
+			sdl)
+				if test "$_sdlMajorVersionNumber" -ge 2 ; then
+					_imgui=yes
+					echo "yes"
+				else
+					_imgui=no
+					echo "no (backend unsupported)"
+				fi
+				;;
+			*)
+				# For now, only SDL supports ImGui
+				_imgui=no
+				echo "no (backend unsupported)"
+				;;
+		esac
+	else
+		echo "no (requires OpenGL)"
+	fi
 else
-  echo "no (requires OpenGL)"
+	echo "$_imgui"
 fi
+define_in_config_if_yes "$_imgui" 'USE_IMGUI'
 
 #
 # Enable vkeybd / event recorder

--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -291,10 +291,7 @@ Common::Error DirectorEngine::run() {
 
 #ifdef USE_IMGUI
 	onImGuiInit();
-	ModularGraphicsBackend *gfxBackend = dynamic_cast<ModularGraphicsBackend *>(_system);
-	if (gfxBackend) {
-		gfxBackend->getGraphicsManager()->setImGuiRenderCallback(onImGuiRender);
-	}
+	_system->setImGuiRenderCallback(onImGuiRender);
 #endif
 
 	bool loop = true;
@@ -324,6 +321,7 @@ Common::Error DirectorEngine::run() {
 	}
 
 #ifdef USE_IMGUI
+	_system->setImGuiRenderCallback(nullptr);
 	onImGuiCleanup();
 #endif
 

--- a/engines/twp/twp.cpp
+++ b/engines/twp/twp.cpp
@@ -872,10 +872,7 @@ Common::Error TwpEngine::run() {
 
 #ifdef USE_IMGUI
 	onImGuiInit();
-	ModularGraphicsBackend *gfxBackend = dynamic_cast<ModularGraphicsBackend *>(_system);
-	if (gfxBackend) {
-		gfxBackend->getGraphicsManager()->setImGuiRenderCallback(onImGuiRender);
-	}
+	_system->setImGuiRenderCallback(onImGuiRender);
 #endif
 
 	// Simple event handling loop
@@ -1103,6 +1100,7 @@ Common::Error TwpEngine::run() {
 	}
 
 #ifdef USE_IMGUI
+	_system->setImGuiRenderCallback(nullptr);
 	onImGuiCleanup();
 #endif
 


### PR DESCRIPTION
This is various changes to:
- make `setImGuiRenderCallback` directly available from OSystem as this avoids dynamic_cast (for ImGui enabled target only),
- remove the `_imGuiRender` from the `GraphicsManager` abstract class,
- make ImGui more robust related to context changes in OpenGLSdlGraphics3dManager and remove the state variable,
- make USE_IMGUI defined only when it's actually supported (that is SDL2+ only),
- reset to `nullptr` ImGui callback while exiting engine (to avoid calling a function which could disappear if in a plugin).

This has been tested on SDL2 with TWP and Director and it builds on SDL1 (Win9x) toolchain.

@sev- I add you to reviewers as I touch OSystem interface.