### PR TITLE
GRAPHICS: MACGUI: Improve image quality in markdown documents

### DIFF
--- a/graphics/image-archive.cpp
+++ b/graphics/image-archive.cpp
@@ -1,0 +1,101 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "graphics/image-archive.h"
+#include "graphics/surface.h"
+
+#include "common/archive.h"
+#include "common/compression/unzip.h"
+
+#include "image/png.h"
+
+namespace Graphics {
+
+ImageArchive::~ImageArchive() {
+	reset();
+
+	delete _imageArchive;
+}
+
+void ImageArchive::reset() {
+#ifdef USE_PNG
+	for (auto &i : _imageCache)
+		delete i._value;
+	_imageCache.clear();
+#endif
+}
+
+bool ImageArchive::setImageArchive(const Common::Path &fname) {
+	reset();
+
+	delete _imageArchive;
+	_imageArchive = Common::makeZipArchive(fname);
+
+	if (!_imageArchive)
+		warning("ImageArchive::setImageArchive(): Could not find %s. Images will not be rendered", fname.toString().c_str());
+	return _imageArchive != nullptr;
+}
+
+const Surface *ImageArchive::getImageSurface(const Common::Path &fname, int w, int h) {
+#ifndef USE_PNG
+	warning("ImageArchive::getImageSurface(): PNG support not compiled. Cannot load file %s", fname.toString().c_str());
+
+	return nullptr;
+#else
+	if (_imageCache.contains(fname)) {
+		// TODO: Handle the case where a previously loaded image hasn't been scaled.
+		const Surface *surf = _imageCache[fname];
+		if (surf && surf->w == w && surf->h == h)
+			return surf;
+	}
+
+	if (!_imageArchive) {
+		warning("ImageArchive::getImageSurface(): Image Archive was not loaded. Use setImageArchive()");
+		return _imageCache[fname];
+	}
+
+	Common::SeekableReadStream *stream = _imageArchive->createReadStreamForMember(fname);
+
+	if (!stream) {
+		warning("ImageArchive::getImageSurface(): Cannot open file %s", fname.toString().c_str());
+		return _imageCache[fname];
+	}
+
+	Image::PNGDecoder decoder;
+	if (!decoder.loadStream(*stream)) {
+		warning("ImageArchive::getImageSurface(): Cannot load file %s", fname.toString().c_str());
+
+		return _imageCache[fname];
+	}
+
+	if (_imageCache.contains(fname)) {
+		delete _imageCache[fname];
+		_imageCache.erase(fname);
+	}
+
+	const Graphics::Surface *surf = decoder.getSurface();
+	_imageCache[fname] = surf->scale(w ? w : surf->w, h ? h : surf->h, true);
+	return _imageCache[fname];
+#endif // USE_PNG
+}
+
+} // End of namespace Graphics
+

--- a/graphics/image-archive.h
+++ b/graphics/image-archive.h
@@ -1,0 +1,63 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef GRAPHICS_IMAGE_ARCHIVE_H
+#define GRAPHICS_IMAGE_ARCHIVE_H
+
+#include "common/hashmap.h"
+#include "common/path.h"
+
+namespace Common {
+class Archive;
+}
+
+namespace Graphics {
+struct Surface;
+
+/**
+ * Helper class for loading PNG images from zip files.
+ */
+class ImageArchive {
+public:
+	~ImageArchive();
+
+	/* Frees all previously loaded images. */
+	void reset();
+
+	/* Open a new zip archive, after closing the previous one. */
+	bool setImageArchive(const Common::Path &fname);
+
+	/* Retrieve an image from the cache, or load it from the archive if it hasn't been loaded previously. */
+	const Surface *getImageSurface(const Common::Path &fname) {
+		return getImageSurface(fname, 0, 0);
+	}
+	const Surface *getImageSurface(const Common::Path &fname, int w, int h);
+
+private:
+#ifdef USE_PNG
+	Common::HashMap<Common::Path, Surface *, Common::Path::IgnoreCase_Hash, Common::Path::IgnoreCase_EqualTo> _imageCache;
+#endif
+	Common::Archive *_imageArchive = nullptr;
+};
+
+} // End of namespace Graphics
+
+#endif

--- a/graphics/macgui/mactext-canvas.cpp
+++ b/graphics/macgui/mactext-canvas.cpp
@@ -650,13 +650,11 @@ void MacTextCanvas::render(int from, int to, int shadow) {
 
 	for (int i = myFrom; i != myTo; i += delta) {
 		if (!_text[i].picfname.empty()) {
-			const Surface *image = _macText->getImageSurface(_text[i].picfname);
-
-			int xOffset = (_text[i].width - _text[i].charwidth) / 2;
-			Common::Rect bbox(xOffset, _text[i].y, xOffset + _text[i].charwidth, _text[i].y + _text[i].height);
+			const Surface *image = _imageArchive.getImageSurface(_text[i].picfname, _text[i].charwidth, _text[i].height);
 
 			if (image) {
-				surface->blitFrom(image, Common::Rect(0, 0, image->w, image->h), bbox);
+				int xOffset = (_text[i].width - _text[i].charwidth) / 2;
+				surface->blitFrom(image, Common::Point(xOffset, _text[i].y));
 
 				D(9, "MacTextCanvas::render: Image %d x %d bbox: %d, %d, %d, %d", image->w, image->h, bbox.left, bbox.top,
 						bbox.right, bbox.bottom);
@@ -859,7 +857,7 @@ int MacTextCanvas::getLineWidth(int lineNum, bool enforce, int col) {
 		return line->width;
 
 	if (!line->picfname.empty()) {
-		const Surface *image = _macText->getImageSurface(line->picfname);
+		const Surface *image = _imageArchive.getImageSurface(line->picfname);
 
 		if (image) {
 			line->width = _maxWidth;

--- a/graphics/macgui/mactext-canvas.h
+++ b/graphics/macgui/mactext-canvas.h
@@ -23,6 +23,7 @@
 #define GRAPHICS_MACGUI_MACTEXTCANVAS_H
 
 #include "graphics/macgui/macwindowmanager.h"
+#include "graphics/image-archive.h"
 
 namespace Graphics {
 
@@ -122,6 +123,7 @@ public:
 	bool _macFontMode = true;
 	MacText *_macText;
 	MacFontRun _defaultFormatting;
+	ImageArchive _imageArchive;
 
 public:
 	~MacTextCanvas();

--- a/graphics/macgui/mactext.h
+++ b/graphics/macgui/mactext.h
@@ -24,10 +24,6 @@
 
 #include "graphics/macgui/mactext-canvas.h"
 
-namespace Image {
-class PNGDecoder;
-}
-
 namespace Graphics {
 
 struct SelectedText {
@@ -122,7 +118,7 @@ public:
 	int getMouseLine(int x, int y);
 	Common::U32String getMouseLink(int x, int y);
 
-	void setImageArchive(const Common::Path &name);
+	bool setImageArchive(const Common::Path &name) { return _canvas._imageArchive.setImageArchive(name); }
 
 private:
 	MacFontRun getTextChunks(int start, int end);
@@ -184,7 +180,6 @@ public:
 	// Markdown
 public:
 	void setMarkdownText(const Common::U32String &str);
-	const Surface *getImageSurface(const Common::Path &fname);
 
 private:
 	void init(uint32 fgcolor, uint32 bgcolor, int maxWidth, TextAlign textAlignment, int interlinear, uint16 textShadow, bool macFontMode);
@@ -241,11 +236,6 @@ private:
 	SelectedText _selectedText;
 
 	MacMenu *_menu;
-
-#ifdef USE_PNG
-	Common::HashMap<Common::Path, Image::PNGDecoder *, Common::Path::IgnoreCase_Hash, Common::Path::IgnoreCase_EqualTo> _imageCache;
-#endif
-	Common::Archive *_imageArchive = nullptr;
 };
 
 int getStringWidth(MacFontRun &format, const Common::U32String &str);

--- a/graphics/module.mk
+++ b/graphics/module.mk
@@ -20,6 +20,7 @@ MODULE_OBJS := \
 	fonts/ttf.o \
 	fonts/winfont.o \
 	framelimiter.o \
+	image-archive.o \
 	korfont.o \
 	larryScale.o \
 	maccursor.o \


### PR DESCRIPTION
Images are now pre-scaled with bilinear filtering. The relevant code has also been split out from the rest of the MacGUI code to allow easier reuse.