### PR TITLE
CI: Fix macosx build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,13 +99,14 @@ jobs:
           path: ${{ env.VCPKG_INSTALLED_DIR }}\\${{ matrix.triplet }}\\bin\\*.pdb
   xcode:
     name: Xcode
-    runs-on: macos-latest
+    # macos-14 is arm64. macosx build currently fails on macos-14.
+    runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: macosx
-            buildFlags: -scheme ScummVM-macOS
+            buildFlags: -scheme ScummVM-macOS -destination 'platform=macOS,arch=x86_64'
             configFlags: --disable-nasm --enable-faad --enable-gif --enable-mikmod --enable-mpeg2 --enable-vpx
             brewPackages: a52dec faad2 flac fluid-synth freetype fribidi giflib jpeg mad libmikmod libmpeg2 libogg libpng libvorbis libvpx sdl2 sdl2_net theora
           - platform: ios7


### PR DESCRIPTION
CI has been breaking since github changed `macos-latest` from `macos-12` to `macos-14`. This also changed the architecture to arm64; that's the only option for `macos-14`.

`macos-13` works and is x86_64. We can still call this an upgrade!

I've also set the `xcodebuild` target because that will be a problem going forward; it's been warning that it's just choosing the first one, which makes the architecture unpredictable once more are available.

https://github.com/actions/runner-images/issues/9741

https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/