### PR TITLE
BACKENDS: Update setImGuiRenderCallback in OSystem

### DIFF
--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -49,7 +49,7 @@ public:
 	virtual bool setGraphicsMode(int mode, uint flags = OSystem::kGfxModeNoFlags) { return (mode == 0); }
 	virtual int getGraphicsMode() const { return 0; }
 #if defined(USE_IMGUI)
-	virtual void setImGuiRenderCallback(void(*render)()) { }
+	virtual void setImGuiRenderCallback(ImGuiCallbacks callbacks) { }
 #endif
 	virtual bool setShader(const Common::Path &fileName) { return false; }
 	virtual const OSystem::GraphicsMode *getSupportedStretchModes() const {

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -306,7 +306,7 @@ void OpenGLSdlGraphicsManager::updateScreen() {
 	}
 
 #if defined(USE_IMGUI) && SDL_VERSION_ATLEAST(2, 0, 0)
-	if (_imGuiRender) {
+	if (_callbacks.render) {
 		_forceRedraw = true;
 	}
 #endif
@@ -465,12 +465,12 @@ void OpenGLSdlGraphicsManager::refreshScreen() {
 #endif
 
 #if defined(USE_IMGUI) && SDL_VERSION_ATLEAST(2, 0, 0)
-	if (_imGuiRender) {
+	if (_callbacks.render) {
 		ImGui_ImplOpenGL3_NewFrame();
 		ImGui_ImplSDL2_NewFrame(_window->getSDLWindow());
 
 		ImGui::NewFrame();
-		_imGuiRender();
+		_callbacks.render();
 		ImGui::Render();
 
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
@@ -556,6 +556,9 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 		notifyContextDestroy();
 
 #ifdef USE_IMGUI
+		if (_callbacks.cleanup) {
+			_callbacks.cleanup();
+		}
 		ImGui_ImplOpenGL3_Shutdown();
 		ImGui_ImplSDL2_Shutdown();
 		ImGui::DestroyContext();
@@ -618,6 +621,9 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 	ImGui::StyleColorsDark();
 	ImGuiIO &io = ImGui::GetIO();
 	io.IniFilename = nullptr;
+	if (_callbacks.init) {
+		_callbacks.init();
+	}
 #endif
 
 	if (SDL_GL_SetSwapInterval(_vsync ? 1 : 0)) {

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -208,10 +208,10 @@ private:
 
 #if defined(USE_IMGUI) && SDL_VERSION_ATLEAST(2, 0, 0)
 public:
-	void setImGuiRenderCallback(void(*render)()) override { _imGuiRender = render; }
+	void setImGuiRenderCallback(ImGuiCallbacks callbacks) override { _callbacks = callbacks; }
 
 protected:
-	void(*_imGuiRender)() = nullptr;
+	ImGuiCallbacks _callbacks;
 #endif
 
 };

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
@@ -120,6 +120,11 @@ protected:
 	int _glContextProfileMask, _glContextMajor, _glContextMinor;
 	SDL_GLContext _glContext;
 	void deinitializeRenderer();
+
+#if defined(USE_IMGUI)
+	bool _imguiInitCalled = false;
+	bool _imguiRenderCalled = false;
+#endif
 #endif
 
 	OpenGL::ContextType _glContextType;

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -74,8 +74,8 @@ int ModularGraphicsBackend::getGraphicsMode() const {
 }
 
 #if defined(USE_IMGUI)
-void ModularGraphicsBackend::setImGuiRenderCallback(void(*render)()) {
-	_graphicsManager->setImGuiRenderCallback(render);
+void ModularGraphicsBackend::setImGuiRenderCallback(ImGuiCallbacks callbacks) {
+	_graphicsManager->setImGuiRenderCallback(callbacks);
 }
 #endif
 

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -68,7 +68,7 @@ public:
 	bool setGraphicsMode(int mode, uint flags = kGfxModeNoFlags) override;
 	int getGraphicsMode() const override;
 #if defined(USE_IMGUI)
-	void setImGuiRenderCallback(void(*render)()) override final;
+	void setImGuiRenderCallback(ImGuiCallbacks callbacks) override final;
 #endif
 	bool setShader(const Common::Path &name) override final;
 	const GraphicsMode *getSupportedStretchModes() const override final;

--- a/common/system.h
+++ b/common/system.h
@@ -148,6 +148,14 @@ enum CursorMaskValue {
 	kCursorMaskPaletteXorColorXnor = 3,
 };
 
+#if defined(USE_IMGUI)
+typedef struct ImGuiCallbacks {
+	void (*init)() = nullptr;
+	void (*render)() = nullptr;
+	void (*cleanup)() = nullptr;
+} ImGuiCallbacks;
+#endif
+
 /**
  * Interface for ScummVM backends.
  *
@@ -915,7 +923,7 @@ public:
 	 *
 	 * @param render The function pointer called while rendering on screen
 	 */
-	virtual void setImGuiRenderCallback(void(*render)()) { }
+	virtual void setImGuiRenderCallback(ImGuiCallbacks callbacks) { }
 #endif
 
 	/**


### PR DESCRIPTION
I added 2 callbacks: `init` and `cleanup`.

The `init` callback is called just after the ImGui initialisation, in this method you can for example add a custom font or even specify a location where to save the ImGui configuration.
The `cleanup`is called just before the ImGui destruction.

To specify these `callbacks` I modified the `setImGuiRenderCallback` in `ModularGraphicsBackend`.
I changed
```cpp
void ModularGraphicsBackend::setImGuiRenderCallback(void(*render)());
```
by
```cpp
typedef struct ImGuiCallbacks {
    void(*init)() = nullptr;
    void(*render)() = nullptr;
    void(*cleanup)() = nullptr;
} ImGuiCallbacks;
void ModularGraphicsBackend::setImGuiRenderCallback(ImGuiCallbacks callbacks);
```

In the engine you can specify the callbacks like this and that's it:
```cpp
#ifdef USE_IMGUI
    ImGuiCallbacks callbacks;
    callbacks.init = onImGuiInit;
    callbacks.render = onImGuiRender;
    callbacks.cleanup = onImGuiCleanup;
    _system->setImGuiRenderCallback(callbacks);
#endif
```