### PR TITLE
GUI: Implement handleMouseUp for Grid layout

### DIFF
--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -320,7 +320,12 @@ void GridItemTray::handleMouseDown(int x, int y, int button, int clickCount) {
 	if ((x < 0 || x > _w) || (y > _h || y < -(_grid->_gridItemHeight))) {
 		// Close on clicking outside
 		close();
-	} else if (y < 0 && clickCount >= 2) {
+	}
+}
+
+void GridItemTray::handleMouseUp(int x, int y, int button, int clickCount) {
+	Dialog::handleMouseUp(x, y, button, clickCount);
+	if (y < 0 && clickCount >= 2) {
 		// Run on double clicking thumbnail
 		close();
 		sendCommand(kItemDoubleClickedCmd, _entryID);

--- a/gui/widgets/grid.h
+++ b/gui/widgets/grid.h
@@ -90,6 +90,7 @@ public:
 
 	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data) override;
 	void handleMouseDown(int x, int y, int button, int clickCount) override;
+	void handleMouseUp(int x, int y, int button, int clickCount) override;
 	void handleMouseWheel(int x, int y, int direction) override;
 	void handleMouseMoved(int x, int y, int button) override;
 };


### PR DESCRIPTION
This makes it so that games are started on the release of the left mouse button after a double click, instead of during it being pressed.

This fixes the left mouse button release leaking into the launched game as actual engine input (e.g. the intro video to Broken Sword 1 being skipped, since the left mouse button is one of the valid inputs for skipping videos).