### PR TITLE
BACKENDS: Add the ability to load ScummVM fonts in ImGui

### DIFF
--- a/backends/imgui/imgui_fonts.cpp
+++ b/backends/imgui/imgui_fonts.cpp
@@ -1,0 +1,98 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/file.h"
+#include "common/config-manager.h"
+#include "common/compression/unzip.h"
+#include "backends/imgui/imgui_fonts.h"
+
+namespace {
+
+class FontReader;
+
+class FontArchive {
+	friend class FontReader;
+
+public:
+	void openArchive(const char *archiveName) {
+		if (_archive)
+			delete _archive;
+
+		Common::SeekableReadStream *archiveStream = nullptr;
+		if (ConfMan.hasKey("extrapath")) {
+			Common::FSDirectory extrapath(ConfMan.getPath("extrapath"));
+			archiveStream = extrapath.createReadStreamForMember(archiveName);
+		}
+
+		if (!archiveStream) {
+			archiveStream = SearchMan.createReadStreamForMember(archiveName);
+		}
+
+		_archive = Common::makeZipArchive(archiveStream);
+	}
+
+	~FontArchive() {
+		if (_archive)
+			delete _archive;
+	}
+
+private:
+	Common::Archive *_archive = nullptr;
+};
+
+class FontReader {
+public:
+	FontReader(FontArchive &archive) : _archive(archive) {}
+	bool openFile(Common::File &file, const char *fileName) {
+		if (!_archive._archive)
+			return false;
+		return file.open(Common::Path(fileName, Common::Path::kNoSeparator), *_archive._archive);
+	}
+
+private:
+	FontArchive &_archive;
+};
+
+} // namespace
+
+namespace ImGui {
+
+ImFont *addTTFFontFromArchive(const char *filename, float size_pixels, const ImFontConfig *font_cfg_template, const ImWchar *glyph_ranges) {
+	Common::File f;
+	FontArchive archive;
+	FontReader reader(archive);
+
+	archive.openArchive("fonts.dat");
+	if (!reader.openFile(f, filename)) {
+		archive.openArchive("fonts-cjk.dat");
+		if (!reader.openFile(f, filename)) {
+			return nullptr;
+		}
+	}
+
+	uint size = f.size();
+	uint8 *ttfFile = new uint8[size];
+	f.read(ttfFile, size);
+	ImGuiIO &io = ImGui::GetIO();
+	return io.Fonts->AddFontFromMemoryTTF(ttfFile, size, size_pixels, font_cfg_template, glyph_ranges);
+}
+
+} // namespace ImGui

--- a/backends/imgui/imgui_fonts.h
+++ b/backends/imgui/imgui_fonts.h
@@ -1,0 +1,42 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef BACKENDS_IMGUI_FONTS_H
+#define BACKENDS_IMGUI_FONTS_H
+
+#include "backends/imgui/imgui.h"
+
+namespace ImGui {
+
+/**
+ * Loads and adds a TTF font file from the common fonts archive to ImGui .
+ *
+ * @param filename          The name of the font to load.
+ * @param size_pixels       The size of the font in pixels.
+ * @param font_cfg_template Configuration of the font.
+ * @param glyph_ranges      Glyph ranges array terminated by 0, you need to make sure that your array persist up until the
+ *                          atlas is build (when calling GetTexData*** or Build()). We only copy the pointer, not the data.
+ * @return 0 in case loading fails, otherwise a pointer to the Font object.
+ */
+ImFont *addTTFFontFromArchive(const char *filename, float size_pixels, const ImFontConfig *font_cfg_template = NULL, const ImWchar *glyph_ranges = NULL);
+}
+
+#endif

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -492,8 +492,9 @@ ifdef USE_IMGUI
 MODULE_OBJS += \
 	imgui/imgui.o \
 	imgui/imgui_draw.o \
-	imgui/imgui_widgets.o \
-	imgui/imgui_tables.o
+	imgui/imgui_fonts.o \
+	imgui/imgui_tables.o \
+	imgui/imgui_widgets.o
 endif
 
 ifdef USE_SDL2


### PR DESCRIPTION
Allow to use fonts embedded in `fonts.dat` or `fonts-cjk.dat` in ImGui.

Here is an example how to use it, in this example we merge the default ImGui font with the font `OpenFontIcons.ttf` embedded in `fonts.dat`
```cpp
#include "backends/imgui/imgui_fonts.h"

void onImGuiInit() {
	ImGuiIO &io = ImGui::GetIO();

	io.Fonts->AddFontDefault();

	ImFontConfig icons_config;
	icons_config.MergeMode = true;
	icons_config.PixelSnapH = false;
	icons_config.OversampleH = 3;
	icons_config.OversampleV = 3;
	icons_config.GlyphOffset = {0, 3};

	static const ImWchar icons_ranges[] = {0xE000, 0xF8FF, 0};
	ImGui::addTTFFontFromArchive("OpenFontIcons.ttf", 13.f, &icons_config, icons_ranges);
```

Then you display an icon by using its unicode character: `ImGui::Text("\ue072");`
It will display a ❤️

Here is the list of the icons and their corresponding unicode characters: https://github.com/traverseda/OpenFontIcons