### PR TITLE
Revert "ENGINES: Allow shouldQuit to return true immediately"

### DIFF
--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -64,7 +64,6 @@
 
 // FIXME: HACK for error()
 Engine *g_engine = 0;
-bool Engine::_quitRequested;
 
 // Output formatter for debug() and error() which invokes
 // the errorString method of the active engine, if any.
@@ -154,7 +153,6 @@ Engine::Engine(OSystem *syst)
 		_lastAutosaveTime(_system->getMillis()) {
 
 	g_engine = this;
-	_quitRequested = false;
 	Common::setErrorOutputFormatter(defaultOutputFormatter);
 	Common::setErrorHandler(defaultErrorHandler);
 
@@ -985,13 +983,11 @@ void Engine::quitGame() {
 
 	event.type = Common::EVENT_QUIT;
 	g_system->getEventManager()->pushEvent(event);
-	_quitRequested = true;
 }
 
 bool Engine::shouldQuit() {
 	Common::EventManager *eventMan = g_system->getEventManager();
-	return eventMan->shouldQuit() || eventMan->shouldReturnToLauncher()
-		|| _quitRequested;
+	return (eventMan->shouldQuit() || eventMan->shouldReturnToLauncher());
 }
 
 GUI::Debugger *Engine::getOrCreateDebugger() {

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -233,13 +233,9 @@ private:
 	 * Optional debugger for the engine.
 	 */
 	GUI::Debugger *_debugger;
-
-	/**
-	 * Flag for whether the quitGame method has been called
-	 */
-	static bool _quitRequested;
-
 public:
+
+
 	/**
 	 * Engine features.
 	 *


### PR DESCRIPTION
This reverts commit 741620e4bc3c11b9bbe567ac4ef789975a6efe0e.

This commit breaks several engines like scumm and sword1 because they call quitEngine function without polling the event loop afterwards.
Purging the event loop after the engine has finished would solve this, but the EVENT_QUIT message is supposed to be processed while the engine is still running to let user confirm the quit action (if the setting is enabled).
