### PR TITLE
SCUMM HE: BYB01 competitive online play mods: hit power change

### DIFF
--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -653,7 +653,7 @@ int ScummEngine::readVar(uint var) {
 					return powerStatModified;
 				case 1:  // Power swing
 					powerStat = vm.localvar[_currentScript][var];
-					powerStatModified = 20 + powerStat * 7 / 10;;
+					powerStatModified = 10 + powerStat * 17 / 20;;
 					return powerStatModified;
 				default:
 					break;


### PR DESCRIPTION
This PR implements a small change to an existing mod (which is only enabled when the user has the optional "Enable online competitive mods" in ScummVM's game options) for Backyard Baseball 2001 online play. It slightly changes the velocity of hits when the player is using a power swing.

The previous iteration of this mod reduced the velocity of hits with power swings, making them less effective relative to line drive and grounder swings. After 6+ months of competitive play, the consensus among the community is that this has made power swings not viable - using a line drive swing is almost always optimal, which makes gameplay less interesting.

This change is intended to make the decisions on what swing type to use more interesting. This chart shows how the hit's "base power" (really more like the hit's velocity, before some randomness and other factors is added) relates to the batting character's power rating: without any mods ("Seasons 1-3"), with the version currently in master ("Season 4"), and with this branch ("Season 5"). This new version is halfway between the unmodded and current master.

<img width="634" alt="Screenshot 2024-05-14 at 8 14 43 PM" src="https://github.com/scummvm/scummvm/assets/8998576/a486bc95-3081-44af-af6a-2920fb76b5e4">
