### PR TITLE
GRAPHICS: Add simplified blitting routines to ManagedSurface

### DIFF
--- a/engines/sword25/gfx/image/renderedimage.cpp
+++ b/engines/sword25/gfx/image/renderedimage.cpp
@@ -140,7 +140,7 @@ RenderedImage::RenderedImage(const Common::String &filename, bool &result) :
 	delete[] pFileData;
 
 	_doCleanup = true;
-	_alphaType = checkForTransparency();
+	_alphaType = _surface.detectAlpha();
 
 	return;
 }
@@ -258,26 +258,6 @@ void RenderedImage::copyDirectly(int posX, int posY) {
 	h = CLIP((int)h, 0, (int)MAX((int)_backSurface->h - posY, 0));
 
 	g_system->copyRectToScreen(data, _backSurface->pitch, posX, posY, w, h);
-}
-
-Graphics::AlphaType RenderedImage::checkForTransparency() const {
-	// Check if the source bitmap has any transparent pixels at all
-	Graphics::AlphaType alphaType = Graphics::ALPHA_OPAQUE;
-	uint32 mask = _surface.format.ARGBToColor(0xff, 0, 0, 0);
-	const uint32 *data = (const uint32 *)_surface.getPixels();
-
-	for (int i = 0; i < _surface.h; i++) {
-		for (int j = 0; j < _surface.w; j++) {
-			if ((*data & mask) != mask) {
-				if ((*data & mask) != 0)
-					return Graphics::ALPHA_FULL;
-				else
-					alphaType = Graphics::ALPHA_BINARY;
-			}
-			data++;
-		}
-	}
-	return alphaType;
 }
 
 } // End of namespace Sword25

--- a/engines/sword25/gfx/image/renderedimage.h
+++ b/engines/sword25/gfx/image/renderedimage.h
@@ -113,8 +113,6 @@ private:
 	bool _doCleanup;
 
 	Graphics::ManagedSurface *_backSurface;
-
-	Graphics::AlphaType checkForTransparency() const;
 };
 
 } // End of namespace Sword25

--- a/engines/wintermute/base/gfx/osystem/base_surface_osystem.cpp
+++ b/engines/wintermute/base/gfx/osystem/base_surface_osystem.cpp
@@ -73,39 +73,6 @@ BaseSurfaceOSystem::~BaseSurfaceOSystem() {
 	renderer->invalidateTicketsFromSurface(this);
 }
 
-Graphics::AlphaType hasTransparencyType(const Graphics::Surface *surf) {
-	if (surf->format.bytesPerPixel != 4) {
-		warning("hasTransparencyType:: non 32 bpp surface passed as argument");
-		return Graphics::ALPHA_OPAQUE;
-	}
-	uint8 r, g, b, a;
-	bool seenAlpha = false;
-	bool seenFullAlpha = false;
-	for (int i = 0; i < surf->h; i++) {
-		if (seenFullAlpha) {
-			break;
-		}
-		for (int j = 0; j < surf->w; j++) {
-			uint32 pix = *(const uint32 *)surf->getBasePtr(j, i);
-			surf->format.colorToARGB(pix, a, r, g, b);
-			if (a != 255) {
-				seenAlpha = true;
-				if (a != 0) {
-					seenFullAlpha = true;
-					break;
-				}
-			}
-		}
-	}
-	if (seenFullAlpha) {
-		return Graphics::ALPHA_FULL;
-	} else if (seenAlpha) {
-		return Graphics::ALPHA_BINARY;
-	} else {
-		return Graphics::ALPHA_OPAQUE;
-	}
-}
-
 //////////////////////////////////////////////////////////////////////////
 bool BaseSurfaceOSystem::create(const Common::String &filename, bool defaultCK, byte ckRed, byte ckGreen, byte ckBlue, int lifeTime, bool keepLoaded) {
 	/*  BaseRenderOSystem *renderer = static_cast<BaseRenderOSystem *>(_gameRef->_renderer); */
@@ -188,7 +155,7 @@ bool BaseSurfaceOSystem::finishLoad() {
 		_surface->applyColorKey(_ckRed, _ckGreen, _ckBlue, replaceAlpha);
 	}
 
-	_alphaType = hasTransparencyType(_surface);
+	_alphaType = _surface->detectAlpha();
 	_valid = true;
 
 	_gameRef->addMem(_width * _height * 4);

--- a/graphics/VectorRenderer.h
+++ b/graphics/VectorRenderer.h
@@ -51,6 +51,7 @@ typedef void (VectorRenderer::*DrawingFunctionCallback)(const Common::Rect &, co
 struct DrawStep {
 	DrawingFunctionCallback drawingCall; /**< Pointer to drawing function */
 	Graphics::ManagedSurface *blitSrc;
+	Graphics::AlphaType alphaType;
 
 	struct Color {
 		uint8 r, g, b;
@@ -99,6 +100,7 @@ struct DrawStep {
 	DrawStep() {
 		drawingCall = nullptr;
 		blitSrc = nullptr;
+		alphaType = Graphics::ALPHA_OPAQUE;
 		// fgColor, bgColor, gradColor1, gradColor2, bevelColor initialized by Color default constructor
 		autoWidth = autoHeight = false;
 		x = y = w = h = 0;
@@ -472,7 +474,7 @@ public:
 	void drawCallback_BITMAP(const Common::Rect &area, const DrawStep &step) {
 		uint16 x, y, w, h;
 		stepGetPositions(step, area, x, y, w, h);
-		blitManagedSurface(step.blitSrc, Common::Point(x, y));
+		blitManagedSurface(step.blitSrc, Common::Point(x, y), step.alphaType);
 	}
 
 	void drawCallback_CROSS(const Common::Rect &area, const DrawStep &step) {
@@ -523,7 +525,7 @@ public:
 	 */
 	virtual void blitSurface(const Graphics::ManagedSurface *source, const Common::Rect &r) = 0;
 
-	virtual void blitManagedSurface(const Graphics::ManagedSurface *source, const Common::Point &p) = 0;
+	virtual void blitManagedSurface(const Graphics::ManagedSurface *source, const Common::Point &p, Graphics::AlphaType alphaType) = 0;
 
 	/**
 	 * Draws a string into the screen. Wrapper for the Graphics::Font string drawing

--- a/graphics/VectorRendererSpec.cpp
+++ b/graphics/VectorRendererSpec.cpp
@@ -785,7 +785,7 @@ blitSurface(const Graphics::ManagedSurface *source, const Common::Rect &r) {
 
 template<typename PixelType>
 void VectorRendererSpec<PixelType>::
-blitManagedSurface(const Graphics::ManagedSurface *source, const Common::Point &p) {
+blitManagedSurface(const Graphics::ManagedSurface *source, const Common::Point &p, Graphics::AlphaType alphaType) {
 	Common::Rect drawRect(p.x, p.y, p.x + source->w, p.y + source->h);
 	drawRect.clip(_clippingArea);
 	drawRect.translate(-p.x, -p.y);
@@ -803,7 +803,11 @@ blitManagedSurface(const Graphics::ManagedSurface *source, const Common::Point &
 		np = p;
 	}
 
-	_activeSurface->blitFrom(*source, drawRect, np);
+	if (alphaType != Graphics::ALPHA_OPAQUE) {
+		_activeSurface->transBlitFrom(*source, drawRect, np);
+	} else {
+		_activeSurface->simpleBlitFrom(*source, drawRect, np);
+	}
 }
 
 template<typename PixelType>

--- a/graphics/VectorRendererSpec.h
+++ b/graphics/VectorRendererSpec.h
@@ -88,7 +88,7 @@ public:
 
 	void fillSurface() override;
 	void blitSurface(const Graphics::ManagedSurface *source, const Common::Rect &r) override;
-	void blitManagedSurface(const Graphics::ManagedSurface *source, const Common::Point &p) override;
+	void blitManagedSurface(const Graphics::ManagedSurface *source, const Common::Point &p, Graphics::AlphaType alphaType) override;
 
 	void applyScreenShading(GUI::ThemeEngine::ShadingStyle shadingStyle) override;
 

--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -228,6 +228,73 @@ void ManagedSurface::copyFrom(const Surface &surf) {
 	}
 }
 
+void ManagedSurface::simpleBlitFrom(const Surface &src, const Palette *srcPalette) {
+	simpleBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Point(0, 0), srcPalette);
+}
+
+void ManagedSurface::simpleBlitFrom(const Surface &src, const Common::Point &destPos, const Palette *srcPalette) {
+	simpleBlitFrom(src, Common::Rect(0, 0, src.w, src.h), destPos, srcPalette);
+}
+
+void ManagedSurface::simpleBlitFrom(const Surface &src, const Common::Rect &srcRect,
+		const Common::Point &destPos, const Palette *srcPalette) {
+	simpleBlitFromInner(src, srcRect, destPos, srcPalette, false, 0);
+}
+
+void ManagedSurface::simpleBlitFrom(const ManagedSurface &src) {
+	simpleBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Point(0, 0));
+}
+
+void ManagedSurface::simpleBlitFrom(const ManagedSurface &src, const Common::Point &destPos) {
+	simpleBlitFrom(src, Common::Rect(0, 0, src.w, src.h), destPos);
+}
+
+void ManagedSurface::simpleBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect,
+		const Common::Point &destPos) {
+	simpleBlitFromInner(src._innerSurface, srcRect, destPos, src._palette,
+		src._transparentColorSet, src._transparentColor);
+}
+
+void ManagedSurface::simpleBlitFromInner(const Surface &src, const Common::Rect &srcRect,
+		const Common::Point &destPos, const Palette *srcPalette,
+		bool transparentColorSet, uint transparentColor) {
+
+	Common::Rect srcRectC = srcRect;
+	Common::Rect dstRectC = srcRect;
+
+	dstRectC.moveTo(destPos.x, destPos.y);
+	clip(srcRectC, dstRectC);
+
+	const byte *srcPtr = (const byte *)src.getBasePtr(srcRectC.left, srcRectC.top);
+	byte *dstPtr = (byte *)getBasePtr(dstRectC.left, dstRectC.top);
+
+	if (src.format.isCLUT8()) {
+		assert(srcPalette);
+		assert(format.isCLUT8());
+
+		uint32 map[256];
+		convertPaletteToMap(map, srcPalette->data(), srcPalette->size(), format);
+
+		if (transparentColorSet) {
+			crossKeyBlitMap(dstPtr, srcPtr, pitch, src.pitch, srcRectC.width(), srcRectC.height(),
+				format.bytesPerPixel, map, transparentColor);
+		} else {
+			crossBlitMap(dstPtr, srcPtr, pitch, src.pitch, srcRectC.width(), srcRectC.height(),
+				format.bytesPerPixel, map);
+		}
+	} else {
+		if (transparentColorSet) {
+			crossKeyBlit(dstPtr, srcPtr, pitch, src.pitch, srcRectC.width(), srcRectC.height(),
+				format, src.format, transparentColor);
+		} else {
+			crossBlit(dstPtr, srcPtr, pitch, src.pitch, srcRectC.width(), srcRectC.height(),
+				format, src.format);
+		}
+	}
+
+	addDirtyRect(dstRectC);
+}
+
 void ManagedSurface::blitFrom(const Surface &src, const Palette *srcPalette) {
 	blitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Point(0, 0), srcPalette);
 }

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -88,6 +88,13 @@ protected:
 	/**
 	 * Inner method for blitting.
 	 */
+	void simpleBlitFromInner(const Surface &src, const Common::Rect &srcRect,
+		const Common::Point &destPos, const Palette *srcPalette,
+		bool transparentColorSet, uint transparentColor);
+
+	/**
+	 * Inner method for blitting.
+	 */
 	void blitFromInner(const Surface &src, const Common::Rect &srcRect,
 		const Common::Rect &destRect, const Palette *srcPalette);
 
@@ -305,6 +312,38 @@ public:
 	const Common::Rect getBounds() const {
 		return Common::Rect(0, 0, this->w, this->h);
 	}
+
+	/**
+	 * Copy another surface into this one.
+	 */
+	void simpleBlitFrom(const Surface &src, const Palette *srcPalette = nullptr);
+
+	/**
+	 * Copy another surface into this one at a given destination position.
+	 */
+	void simpleBlitFrom(const Surface &src, const Common::Point &destPos, const Palette *srcPalette = nullptr);
+
+	/**
+	 * Copy another surface into this one at a given destination position.
+	 */
+	void simpleBlitFrom(const Surface &src, const Common::Rect &srcRect,
+		const Common::Point &destPos, const Palette *srcPalette = nullptr);
+
+	/**
+	 * Copy another surface into this one.
+	 */
+	void simpleBlitFrom(const ManagedSurface &src);
+
+	/**
+	 * Copy another surface into this one at a given destination position.
+	 */
+	void simpleBlitFrom(const ManagedSurface &src, const Common::Point &destPos);
+
+	/**
+	 * Copy another surface into this one at a given destination position.
+	 */
+	void simpleBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect,
+		const Common::Point &destPos);
 
 	/**
 	 * Copy another surface into this one.

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -714,6 +714,13 @@ public:
 	}
 
 	/**
+	 * Checks if the given surface contains alpha transparency
+	 */
+	AlphaType detectAlpha() const {
+		return _innerSurface.detectAlpha();
+	}
+
+	/**
 	 * Return a sub-area of the screen, but only add a single initial dirty rect
 	 * for the retrieved area.
 	 */

--- a/graphics/surface.cpp
+++ b/graphics/surface.cpp
@@ -443,6 +443,28 @@ bool Surface::setAlpha(uint8 alpha, bool skipTransparent) {
 	                          skipTransparent, alpha);
 }
 
+AlphaType Surface::detectAlpha() const {
+	if (format.isCLUT8() || format.aBits() == 0)
+		return ALPHA_OPAQUE;
+
+	const uint32 mask = format.ARGBToColor(0xff, 0, 0, 0);
+	AlphaType alphaType = ALPHA_OPAQUE;
+
+	for (int y = 0; y < h; y++) {
+		for (int x = 0; x < w; x++) {
+			uint32 pixel = getPixel(x, y);
+			if ((pixel & mask) != mask) {
+				if ((pixel & mask) == 0)
+					alphaType = ALPHA_BINARY;
+				else
+					return ALPHA_FULL;
+			}
+		}
+	}
+
+	return alphaType;
+}
+
 Graphics::Surface *Surface::scale(int16 newWidth, int16 newHeight, bool filtering) const {
 	Graphics::Surface *target = new Graphics::Surface();
 

--- a/graphics/surface.h
+++ b/graphics/surface.h
@@ -32,6 +32,7 @@ struct Point;
 }
 
 #include "graphics/pixelformat.h"
+#include "graphics/transform_struct.h"
 
 namespace Graphics {
 
@@ -511,6 +512,11 @@ public:
 	 * @param skipTransparent  if set to true, then do not touch pixels with alpha=0
 	 */
 	bool setAlpha(uint8 alpha, bool skipTransparent = false);
+
+	/**
+	 * Checks if the given surface contains alpha transparency
+	 */
+	AlphaType detectAlpha() const;
 
 	/**
 	 * Scale the data to the given size.

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -1240,7 +1240,7 @@ void ThemeEngine::drawPopUpWidget(const Common::Rect &r, const Common::U32String
 	}
 }
 
-void ThemeEngine::drawManagedSurface(const Common::Point &p, const Graphics::ManagedSurface &surface) {
+void ThemeEngine::drawManagedSurface(const Common::Point &p, const Graphics::ManagedSurface &surface, Graphics::AlphaType alphaType) {
 	if (!ready())
 		return;
 
@@ -1248,7 +1248,7 @@ void ThemeEngine::drawManagedSurface(const Common::Point &p, const Graphics::Man
 		return;
 
 	_vectorRenderer->setClippingRect(_clip);
-	_vectorRenderer->blitManagedSurface(&surface, p);
+	_vectorRenderer->blitManagedSurface(&surface, p, alphaType);
 
 	Common::Rect dirtyRect = Common::Rect(p.x, p.y, p.x + surface.w, p.y + surface.h);
 	dirtyRect.clip(_clip);

--- a/gui/ThemeEngine.h
+++ b/gui/ThemeEngine.h
@@ -469,7 +469,7 @@ public:
 	void drawDropDownButton(const Common::Rect &r, uint32 dropdownWidth, const Common::U32String &str,
 	                        WidgetStateInfo buttonState, bool inButton, bool inDropdown, bool rtl = false);
 
-	void drawManagedSurface(const Common::Point &p, const Graphics::ManagedSurface &surface);
+	void drawManagedSurface(const Common::Point &p, const Graphics::ManagedSurface &surface, Graphics::AlphaType alphaType);
 
 	void drawSlider(const Common::Rect &r, int width, WidgetStateInfo state = kStateEnabled, bool rtl = false);
 

--- a/gui/ThemeParser.cpp
+++ b/gui/ThemeParser.cpp
@@ -537,6 +537,8 @@ bool ThemeParser::parseDrawStep(ParserNode *stepNode, Graphics::DrawStep *drawst
 
 			if (!drawstep->blitSrc)
 				return parserError("The given filename hasn't been loaded into the GUI.");
+
+			drawstep->alphaType = drawstep->blitSrc->detectAlpha();
 		}
 
 		if (functionName == "roundedsq" || functionName == "circle" || functionName == "tab") {

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -319,6 +319,7 @@ protected:
 	void drawWidget() override;
 
 	Graphics::ManagedSurface _gfx[kPicButtonStateMax + 1];
+	Graphics::AlphaType _alphaType[kPicButtonStateMax + 1];
 	bool _showButton;
 };
 
@@ -454,6 +455,7 @@ protected:
 	void drawWidget() override;
 
 	Graphics::ManagedSurface _gfx;
+	Graphics::AlphaType _alphaType;
 };
 
 class PathWidget : public StaticTextWidget {

--- a/gui/widgets/grid.h
+++ b/gui/widgets/grid.h
@@ -102,6 +102,9 @@ protected:
 	Common::HashMap<int, const Graphics::ManagedSurface *> _platformIcons;
 	Common::HashMap<int, const Graphics::ManagedSurface *> _languageIcons;
 	Common::HashMap<int, const Graphics::ManagedSurface *> _extraIcons;
+	Common::HashMap<int, Graphics::AlphaType> _platformIconsAlpha;
+	Common::HashMap<int, Graphics::AlphaType> _languageIconsAlpha;
+	Common::HashMap<int, Graphics::AlphaType> _extraIconsAlpha;
 	Graphics::ManagedSurface *_disabledIconOverlay;
 	// Images are mapped by filename -> surface.
 	Common::HashMap<Common::String, const Graphics::ManagedSurface *> _loadedSurfaces;
@@ -173,9 +176,9 @@ public:
 	void unloadSurfaces(Common::HashMap<T, const Graphics::ManagedSurface *> &surfaces);
 
 	const Graphics::ManagedSurface *filenameToSurface(const Common::String &name);
-	const Graphics::ManagedSurface *languageToSurface(Common::Language languageCode);
-	const Graphics::ManagedSurface *platformToSurface(Common::Platform platformCode);
-	const Graphics::ManagedSurface *demoToSurface(const Common::String extraString);
+	const Graphics::ManagedSurface *languageToSurface(Common::Language languageCode, Graphics::AlphaType &alphaType);
+	const Graphics::ManagedSurface *platformToSurface(Common::Platform platformCode, Graphics::AlphaType &alphaType);
+	const Graphics::ManagedSurface *demoToSurface(const Common::String extraString, Graphics::AlphaType &alphaType);
 	const Graphics::ManagedSurface *disabledThumbnail();
 
 	/// Update _visibleEntries from _allEntries and returns true if reload is required.
@@ -232,6 +235,7 @@ public:
 class GridItemWidget : public ContainerWidget, public CommandSender {
 protected:
 	Graphics::ManagedSurface _thumbGfx;
+	Graphics::AlphaType _thumbAlpha;
 
 	GridItemInfo	*_activeEntry;
 	GridWidget		*_grid;

--- a/gui/widgets/richtext.cpp
+++ b/gui/widgets/richtext.cpp
@@ -231,7 +231,7 @@ void RichTextWidget::drawWidget() {
 
 	_txtWnd->draw(_surface, 0, _scrolledY, _textWidth, _textHeight, 0, 0);
 
-	g_gui.theme()->drawManagedSurface(Common::Point(_x + _innerMargin, _y + _innerMargin), *_surface);
+	g_gui.theme()->drawManagedSurface(Common::Point(_x + _innerMargin, _y + _innerMargin), *_surface, Graphics::ALPHA_FULL);
 }
 
 void RichTextWidget::draw() {


### PR DESCRIPTION
This makes use of the common blitting routines like `crossBlit`. Compared to `blitFrom()`, this should provide:
- Faster blitting when the source and destination format are the same.
- Faster blitting with paletted sources and true colour destinations.
- More effective dirty rectangle tracking (`blitFrom` simply marked the entire surface as dirty).
- Direct handling of colour keys (`blitFrom` redirects attempts to use colour keys to `transBlitFrom` instead).
The downside is that it doesn't do alpha transparency or scaling.

This PR also makes use of this in the GUI for bitmaps without alpha. This should be most noticeable in themes like `scummmodern` that use .bmp images instead of .svg images.