### PR TITLE
GUI: Move Mass Add list code into MassAddListWidget

### DIFF
--- a/gui/massadd.cpp
+++ b/gui/massadd.cpp
@@ -82,7 +82,7 @@ MassAddDialog::MassAddDialog(const Common::FSNode &startDir)
 	_dirProgressText->setAlign(Graphics::kTextAlignCenter);
 	_gameProgressText->setAlign(Graphics::kTextAlignCenter);
 
-	_list = new ListWidget(this, "MassAdd.GameList");
+	_list = new MassAddListWidget(this, "MassAdd.GameList");
 	_list->setEditable(false);
 	_list->setNumberingMode(kListNumberingOff);
 	_list->setList(l);
@@ -100,7 +100,7 @@ MassAddDialog::MassAddDialog(const Common::FSNode &startDir)
 
 		// Remove trailing slash, so that "/foo" and "/foo/" match.
 		// This works around a bug in the POSIX FS code (and others?)
-		// where paths are not normalized (so FSNodes refering to identical
+		// where paths are not normalized (so FSNodes referring to identical
 		// FS objects may return different values in path()).
 		path.removeTrailingSeparators();
 		if (!path.empty()) {

--- a/gui/massadd.h
+++ b/gui/massadd.h
@@ -32,6 +32,7 @@
 namespace GUI {
 
 class StaticTextWidget;
+class MassAddListWidget;
 
 class MassAddDialog : public Dialog {
 public:
@@ -54,7 +55,7 @@ private:
 	void updateGameList();
 
 	/**
-	 * Map each path occuring in the config file to the target(s) using that path.
+	 * Map each path occurring in the config file to the target(s) using that path.
 	 * Used to detect whether a potential new target is already present in the
 	 * config manager.
 	 */
@@ -69,9 +70,29 @@ private:
 	StaticTextWidget *_dirProgressText;
 	StaticTextWidget *_gameProgressText;
 
-	ListWidget *_list;
+	MassAddListWidget *_list;
 };
 
+class MassAddListWidget : public ListWidget {
+public:
+	MassAddListWidget(Dialog *boss, const Common::String &name)
+		: ListWidget(boss, name) { }
+
+	void appendToSelectedList(bool selected) { _listSelected.push_back(selected); }
+	void clearSelectedList() { _listSelected.clear(); }
+
+protected:
+	ThemeEngine::WidgetStateInfo getItemState(int item) const override {
+		// Display selected/unselected games in mass detection as enabled/disabled items.
+		if (item < (signed int)_listSelected.size() && _listSelected[item]) {
+			return ThemeEngine::kStateEnabled;
+		} else {
+			return ThemeEngine::kStateDisabled;
+		}
+	}
+
+	Common::Array<bool>	_listSelected;
+};
 
 } // End of namespace GUI
 

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -559,11 +559,8 @@ void ListWidget::drawWidget() {
 		if (_selectedItem == pos)
 			inverted = _inversion;
 
-		// Display selected/unselected games in mass detection as enabled/disabled items.
-		if (pos < (signed int)_listSelected.size() && _listSelected[pos])
-			_state = ThemeEngine::kStateEnabled;
-		else
-			_state = ThemeEngine::kStateDisabled;
+		// Get state for drawing the item text
+		ThemeEngine::WidgetStateInfo itemState = getItemState(pos);
 
 		Common::Rect r(getEditRect());
 		int pad = _leftPadding;
@@ -573,7 +570,7 @@ void ListWidget::drawWidget() {
 		if (_numberingMode != kListNumberingOff && g_gui.useRTL() == false) {
 			buffer = Common::String::format("%2d. ", (pos + _numberingMode));
 			g_gui.theme()->drawText(Common::Rect(_x + _hlLeftPadding, y, _x + r.left + _leftPadding, y + fontHeight),
-									buffer, _state, _drawAlign, inverted, _leftPadding, true);
+									buffer, itemState, _drawAlign, inverted, _leftPadding, true);
 			pad = 0;
 		}
 
@@ -599,7 +596,7 @@ void ListWidget::drawWidget() {
 			buffer = _list[pos];
 		}
 
-		drawFormattedText(r1, buffer, _state, _drawAlign, inverted, pad, true, color);
+		drawFormattedText(r1, buffer, itemState, _drawAlign, inverted, pad, true, color);
 
 		// If in numbering mode & using RTL layout in GUI, we print a number suffix after drawing the text
 		if (_numberingMode != kListNumberingOff && g_gui.useRTL()) {
@@ -610,7 +607,7 @@ void ListWidget::drawWidget() {
 			r2.left = r1.right;
 			r2.right = r1.right + rtlPad;
 
-			g_gui.theme()->drawText(r2, buffer, _state, _drawAlign, inverted, _leftPadding, true);
+			g_gui.theme()->drawText(r2, buffer, itemState, _drawAlign, inverted, _leftPadding, true);
 		}
 	}
 

--- a/gui/widgets/list.h
+++ b/gui/widgets/list.h
@@ -96,9 +96,6 @@ protected:
 
 	FilterMatcher	_filterMatcher;
 	void			*_filterMatcherArg;
-
-	Common::Array<bool>	_listSelected;
-
 public:
 	ListWidget(Dialog *boss, const Common::String &name, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0);
 	ListWidget(Dialog *boss, int x, int y, int w, int h, bool scale, const Common::U32String &tooltip = Common::U32String(), uint32 cmd = 0);
@@ -132,9 +129,6 @@ public:
 	void setEditable(bool editable)				{ _editable = editable; }
 	void setEditColor(ThemeEngine::FontColor color) { _editColor = color; }
 	void setFilterMatcher(FilterMatcher matcher, void *arg) { _filterMatcher = matcher; _filterMatcherArg = arg; }
-
-	void appendToSelectedList(bool selected) { _listSelected.push_back(selected); }
-	void clearSelectedList() { _listSelected.clear(); }
 
 	// Made startEditMode/endEditMode for SaveLoadChooser
 	void startEditMode() override;
@@ -180,6 +174,8 @@ protected:
 	void lostFocusWidget() override;
 	void checkBounds();
 	void scrollToCurrent();
+
+	virtual ThemeEngine::WidgetStateInfo getItemState(int item) const { return _state; }
 
 	void drawFormattedText(const Common::Rect &r, const Common::U32String &str, ThemeEngine::WidgetStateInfo state = ThemeEngine::kStateEnabled,
 					Graphics::TextAlign align = Graphics::kTextAlignCenter,


### PR DESCRIPTION
One month ago, https://github.com/scummvm/scummvm/pull/5686 added the ability to change the color in individual list items for the Mass Add dialog. It did this by adding Mass Add logic into the generic `ListWidget`. This broke colors in every other dialog. For example, the save/load list dialog showed all saves as disabled.

I've refactored the Mass Add code out of `ListWidget` into a little subclass; this fixes all the dialogs.

This also fixes the side effect of `Widget::_state` being altered in unpredictable ways based on the last visible item on the Mass Add dialog.