### PR TITLE
SCUMM: (HE) - fix wiz drawing mem leaks

### DIFF
--- a/engines/scumm/gfx.cpp
+++ b/engines/scumm/gfx.cpp
@@ -2541,7 +2541,7 @@ void Gdi::drawBMAPBg(const byte *ptr, VirtScreen *vs) {
 			break;
 
 		WizSimpleBitmap dstBitmap;
-		dstBitmap.bufferPtr = (WizRawPixel *)dst;
+		dstBitmap.bufferPtr = WizPxShrdBuffer(dst, false);
 		dstBitmap.bitmapWidth = vs->w;
 		dstBitmap.bitmapHeight = vs->h;
 		Common::Rect fillRect(0, 0, (dstBitmap.bitmapWidth - 1), (dstBitmap.bitmapHeight - 1));
@@ -2604,14 +2604,14 @@ void Gdi::drawBMAPObject(const byte *ptr, VirtScreen *vs, int obj, int x, int y,
 
 	byte code = *bmapPtr++;
 	int scrX = _vm->_screenStartStrip * 8 * _vm->_bytesPerPixel;
-	WizRawPixel *dst = (WizRawPixel *)(_vm->_virtscr[kMainVirtScreen].backBuf + scrX);
+	WizPxShrdBuffer dst(_vm->_virtscr[kMainVirtScreen].backBuf + scrX, false);
 
 	switch (code) {
 	case BMCOMP_RLE8BIT:
 	case BMCOMP_TRLE8BIT:
 	{
 		Common::Rect rScreen(0, 0, vs->w, vs->h);
-		((ScummEngine_v71he *)_vm)->_wiz->auxDecompTRLEImage(dst, bmapPtr, vs->w, vs->h, x + scrX, y, w, h, &rScreen, nullptr);
+		((ScummEngine_v71he *)_vm)->_wiz->auxDecompTRLEImage(dst(), bmapPtr, vs->w, vs->h, x + scrX, y, w, h, &rScreen, nullptr);
 		break;
 	}
 	case BMCOMP_SOLID_COLOR_FILL:
@@ -2623,7 +2623,7 @@ void Gdi::drawBMAPObject(const byte *ptr, VirtScreen *vs, int obj, int x, int y,
 			break;
 
 		WizSimpleBitmap dstBitmap;
-		dstBitmap.bufferPtr = (WizRawPixel *)dst;
+		dstBitmap.bufferPtr = dst;
 		dstBitmap.bitmapWidth = w;
 		dstBitmap.bitmapHeight = h;
 		Common::Rect fillRect(x + scrX, y, x + scrX + w - 1, y + h - 1);

--- a/engines/scumm/he/gfx_comp/trle_comp.cpp
+++ b/engines/scumm/he/gfx_comp/trle_comp.cpp
@@ -420,7 +420,7 @@ void Wiz::trleFLIPDecompressPrim(
 
 	// Call the primitive image renderer...
 	trleFLIPDecompImageHull(
-		bitmapPtr->bufferPtr, bufferWidth, &destRect, imagePtr->data,
+		bitmapPtr->bufferPtr(), bufferWidth, &destRect, imagePtr->data,
 		&sourceRect, extraPtr, conversionTable, functionPtr);
 }
 
@@ -1303,8 +1303,8 @@ void Wiz::trleFLIP90DegreeRotateCore(WizSimpleBitmap *dstBitmap, int x, int y, c
 	}
 
 	// Finally get down to business and do the blit!
-	WizRawPixel8  *dst8  = ((WizRawPixel8  *)dstBitmap->bufferPtr) + dstX + (dstY * dstBitmap->bitmapWidth);
-	WizRawPixel16 *dst16 = ((WizRawPixel16 *)dstBitmap->bufferPtr) + dstX + (dstY * dstBitmap->bitmapWidth);
+	WizRawPixel8  *dst8  = ((WizRawPixel8  *)dstBitmap->bufferPtr()) + dstX + (dstY * dstBitmap->bitmapWidth);
+	WizRawPixel16 *dst16 = ((WizRawPixel16 *)dstBitmap->bufferPtr()) + dstX + (dstY * dstBitmap->bitmapWidth);
 
 	if (!_uses16BitColor) {
 		dstPtr = (WizRawPixel *)dst8;
@@ -1350,7 +1350,7 @@ void Wiz::trleFLIPDecompressImage(
 		trleFLIPCheckAlphaSetup();
 
 	// General setup for the primitives
-	fakeBitmap.bufferPtr = bufferPtr;
+	fakeBitmap.bufferPtr = WizPxShrdBuffer(bufferPtr, false);
 	fakeBitmap.bitmapWidth = bufferWidth;
 	fakeBitmap.bitmapHeight = bufferHeight;
 
@@ -1429,7 +1429,7 @@ void Wiz::trleFLIPRotate90DecompressImage(
 		trleFLIPCheckAlphaSetup();
 
 	// General setup for the primitives
-	fakeBitmap.bufferPtr = bufferPtr;
+	fakeBitmap.bufferPtr = WizPxShrdBuffer(bufferPtr, false);
 	fakeBitmap.bitmapWidth = bufferWidth;
 	fakeBitmap.bitmapHeight = bufferHeight;
 

--- a/engines/scumm/he/gfx_primitives_he.cpp
+++ b/engines/scumm/he/gfx_primitives_he.cpp
@@ -33,9 +33,9 @@ int Wiz::pgReadPixel(const WizSimpleBitmap *srcBM, int x, int y, int defaultValu
 		return defaultValue;
 	} else {
 		if (_uses16BitColor) {
-			return *(((WizRawPixel16 *)srcBM->bufferPtr) + y * srcBM->bitmapWidth + x);
+			return *(((WizRawPixel16 *)srcBM->bufferPtr()) + y * srcBM->bitmapWidth + x);
 		} else {
-			return *(((WizRawPixel8 *)srcBM->bufferPtr) + y * srcBM->bitmapWidth + x);
+			return *(((WizRawPixel8 *)srcBM->bufferPtr()) + y * srcBM->bitmapWidth + x);
 		}
 	}
 }
@@ -43,9 +43,9 @@ int Wiz::pgReadPixel(const WizSimpleBitmap *srcBM, int x, int y, int defaultValu
 void Wiz::pgWritePixel(WizSimpleBitmap *srcBM, int x, int y, WizRawPixel value) {
 	if ((x >= 0) && (y >= 0) && (x < srcBM->bitmapWidth) && (y < srcBM->bitmapHeight)) {
 		if (_uses16BitColor) {
-			*(((WizRawPixel16 *)srcBM->bufferPtr) + y * srcBM->bitmapWidth + x) = value;
+			*(((WizRawPixel16 *)srcBM->bufferPtr()) + y * srcBM->bitmapWidth + x) = value;
 		} else {
-			*(((WizRawPixel8 *)srcBM->bufferPtr) + y * srcBM->bitmapWidth + x) = value;
+			*(((WizRawPixel8 *)srcBM->bufferPtr()) + y * srcBM->bitmapWidth + x) = value;
 		}
 	}
 }
@@ -53,9 +53,9 @@ void Wiz::pgWritePixel(WizSimpleBitmap *srcBM, int x, int y, WizRawPixel value) 
 void Wiz::pgClippedWritePixel(WizSimpleBitmap *srcBM, int x, int y, const Common::Rect *clipRectPtr, WizRawPixel value) {
 	if ((x >= clipRectPtr->left) && (y >= clipRectPtr->top) && (x <= clipRectPtr->right) && (y <= clipRectPtr->bottom)) {
 		if (_uses16BitColor) {
-			*(((WizRawPixel16 *)srcBM->bufferPtr) + y * srcBM->bitmapWidth + x) = value;
+			*(((WizRawPixel16 *)srcBM->bufferPtr()) + y * srcBM->bitmapWidth + x) = value;
 		} else {
-			*(((WizRawPixel8 *)srcBM->bufferPtr) + y * srcBM->bitmapWidth + x) = value;
+			*(((WizRawPixel8 *)srcBM->bufferPtr()) + y * srcBM->bitmapWidth + x) = value;
 		}
 	}
 }
@@ -395,8 +395,8 @@ void Wiz::pgDrawSolidRect(WizSimpleBitmap *destBM, const Common::Rect *rectPtr, 
 	cw = x2 - x1 + 1;
 	ch = y2 - y1 + 1;
 
-	d16bit = ((WizRawPixel16 *)destBM->bufferPtr) + y1 * dw + x1;
-	d8bit = ((WizRawPixel8 *)destBM->bufferPtr) + y1 * dw + x1;
+	d16bit = ((WizRawPixel16 *)destBM->bufferPtr()) + y1 * dw + x1;
+	d8bit = ((WizRawPixel8 *)destBM->bufferPtr()) + y1 * dw + x1;
 
 	if (cw > 1) {
 		while (--ch >= 0) {
@@ -465,7 +465,7 @@ void Wiz::pgHistogramBitmapSubRect(int *tablePtr, const WizSimpleBitmap *bitmapP
 		clipRect.bottom = (bitmapPtr->bitmapHeight - 1);
 
 		if (findRectOverlap(&rect, &clipRect)) {
-			srcPtr = ((WizRawPixel8 *)bitmapPtr->bufferPtr) + bitmapPtr->bitmapWidth * rect.top + rect.left;
+			srcPtr = ((WizRawPixel8 *)bitmapPtr->bufferPtr()) + bitmapPtr->bitmapWidth * rect.top + rect.left;
 
 			w = getRectWidth(&rect);
 			h = getRectHeight(&rect);
@@ -489,9 +489,9 @@ void Wiz::pgSimpleBitmapFromDrawBuffer(WizSimpleBitmap *bitmapPtr, bool backgrou
 	bitmapPtr->bitmapHeight = vs->h;
 
 	if (background) {
-		bitmapPtr->bufferPtr = (WizRawPixel *)vs->getBackPixels(0, vs->topline);
+		bitmapPtr->bufferPtr = WizPxShrdBuffer(vs->getBackPixels(0, vs->topline), false);
 	} else {
-		bitmapPtr->bufferPtr = (WizRawPixel *)vs->getPixels(0, vs->topline);
+		bitmapPtr->bufferPtr = WizPxShrdBuffer(vs->getPixels(0, vs->topline), false);
 	}
 }
 
@@ -577,11 +577,11 @@ void Wiz::pgDrawRawDataFormatImage(WizRawPixel *bufferPtr, const WizRawPixel *ra
 	}
 
 	// Setup the fake simple bitmaps...
-	dstBitmap.bufferPtr = bufferPtr;
+	dstBitmap.bufferPtr = WizPxShrdBuffer(bufferPtr, false);
 	dstBitmap.bitmapWidth = bufferWidth;
 	dstBitmap.bitmapHeight = bufferHeight;
 
-	srcBitmap.bufferPtr = const_cast<WizRawPixel *>(rawData);
+	srcBitmap.bufferPtr = WizPxShrdBuffer(const_cast<WizRawPixel *>(rawData), false);
 	srcBitmap.bitmapWidth = width;
 	srcBitmap.bitmapHeight = height;
 
@@ -625,10 +625,10 @@ void Wiz::pgSimpleBlit(WizSimpleBitmap *destBM, Common::Rect *destRect, WizSimpl
 	cw = abs(sourceRect->right - sourceRect->left) + 1;
 	ch = abs(sourceRect->bottom - sourceRect->top) + 1;
 
-	d8 = ((WizRawPixel8 *)destBM->bufferPtr) + destRect->top * dw + destRect->left;
-	s8 = ((WizRawPixel8 *)sourceBM->bufferPtr) + sourceRect->top * sw + sourceRect->left;
-	d16 = ((WizRawPixel16 *)destBM->bufferPtr) + destRect->top * dw + destRect->left;
-	s16 = ((WizRawPixel16 *)sourceBM->bufferPtr) + sourceRect->top * sw + sourceRect->left;
+	d8 = ((WizRawPixel8 *)destBM->bufferPtr()) + destRect->top * dw + destRect->left;
+	s8 = ((WizRawPixel8 *)sourceBM->bufferPtr()) + sourceRect->top * sw + sourceRect->left;
+	d16 = ((WizRawPixel16 *)destBM->bufferPtr()) + destRect->top * dw + destRect->left;
+	s16 = ((WizRawPixel16 *)sourceBM->bufferPtr()) + sourceRect->top * sw + sourceRect->left;
 
 	// Going up or down?
 	if (sourceRect->top > sourceRect->bottom) {
@@ -687,10 +687,10 @@ void Wiz::pgSimpleBlitRemapColors(WizSimpleBitmap *destBM, Common::Rect *destRec
 	cw = abs(sourceRect->right - sourceRect->left) + 1;
 	ch = abs(sourceRect->bottom - sourceRect->top) + 1;
 
-	d8 = ((WizRawPixel8 *)destBM->bufferPtr) + destRect->top * dw + destRect->left;
-	s8 = ((WizRawPixel8 *)sourceBM->bufferPtr) + sourceRect->top * sw + sourceRect->left;
-	d16 = ((WizRawPixel16 *)destBM->bufferPtr) + destRect->top * dw + destRect->left;
-	s16 = ((WizRawPixel16 *)sourceBM->bufferPtr) + sourceRect->top * sw + sourceRect->left;
+	d8 = ((WizRawPixel8 *)destBM->bufferPtr()) + destRect->top * dw + destRect->left;
+	s8 = ((WizRawPixel8 *)sourceBM->bufferPtr()) + sourceRect->top * sw + sourceRect->left;
+	d16 = ((WizRawPixel16 *)destBM->bufferPtr()) + destRect->top * dw + destRect->left;
+	s16 = ((WizRawPixel16 *)sourceBM->bufferPtr()) + sourceRect->top * sw + sourceRect->left;
 
 	// Going up or down?
 	if (sourceRect->top > sourceRect->bottom) {
@@ -750,10 +750,10 @@ void Wiz::pgSimpleBlitTransparentRemapColors(WizSimpleBitmap *destBM, Common::Re
 	cw = abs(sourceRect->right - sourceRect->left) + 1;
 	ch = abs(sourceRect->bottom - sourceRect->top) + 1;
 
-	d8 = ((WizRawPixel8 *)destBM->bufferPtr) + destRect->top * dw + destRect->left;
-	s8 = ((WizRawPixel8 *)sourceBM->bufferPtr) + sourceRect->top * sw + sourceRect->left;
-	d16 = ((WizRawPixel16 *)destBM->bufferPtr) + destRect->top * dw + destRect->left;
-	s16 = ((WizRawPixel16 *)sourceBM->bufferPtr) + sourceRect->top * sw + sourceRect->left;
+	d8 = ((WizRawPixel8 *)destBM->bufferPtr()) + destRect->top * dw + destRect->left;
+	s8 = ((WizRawPixel8 *)sourceBM->bufferPtr()) + sourceRect->top * sw + sourceRect->left;
+	d16 = ((WizRawPixel16 *)destBM->bufferPtr()) + destRect->top * dw + destRect->left;
+	s16 = ((WizRawPixel16 *)sourceBM->bufferPtr()) + sourceRect->top * sw + sourceRect->left;
 
 	// Going up or down?
 	if (sourceRect->top > sourceRect->bottom) {
@@ -813,10 +813,10 @@ void Wiz::pgSimpleBlitMixColors(WizSimpleBitmap *destBM, Common::Rect *destRect,
 	cw = abs(sourceRect->right - sourceRect->left) + 1;
 	ch = abs(sourceRect->bottom - sourceRect->top) + 1;
 
-	d8 = ((WizRawPixel8 *)destBM->bufferPtr) + destRect->top * dw + destRect->left;
-	s8 = ((WizRawPixel8 *)sourceBM->bufferPtr) + sourceRect->top * sw + sourceRect->left;
-	d16 = ((WizRawPixel16 *)destBM->bufferPtr) + destRect->top * dw + destRect->left;
-	s16 = ((WizRawPixel16 *)sourceBM->bufferPtr) + sourceRect->top * sw + sourceRect->left;
+	d8 = ((WizRawPixel8 *)destBM->bufferPtr()) + destRect->top * dw + destRect->left;
+	s8 = ((WizRawPixel8 *)sourceBM->bufferPtr()) + sourceRect->top * sw + sourceRect->left;
+	d16 = ((WizRawPixel16 *)destBM->bufferPtr()) + destRect->top * dw + destRect->left;
+	s16 = ((WizRawPixel16 *)sourceBM->bufferPtr()) + sourceRect->top * sw + sourceRect->left;
 
 	// Going up or down?
 	if (sourceRect->top > sourceRect->bottom) {
@@ -876,10 +876,10 @@ void Wiz::pgSimpleBlitTransparentMixColors(WizSimpleBitmap *destBM, Common::Rect
 	cw = abs(sourceRect->right - sourceRect->left) + 1;
 	ch = abs(sourceRect->bottom - sourceRect->top) + 1;
 
-	d8 = ((WizRawPixel8 *)destBM->bufferPtr) + destRect->top * dw + destRect->left;
-	s8 = ((WizRawPixel8 *)sourceBM->bufferPtr) + sourceRect->top * sw + sourceRect->left;
-	d16 = ((WizRawPixel16 *)destBM->bufferPtr) + destRect->top * dw + destRect->left;
-	s16 = ((WizRawPixel16 *)sourceBM->bufferPtr) + sourceRect->top * sw + sourceRect->left;
+	d8 = ((WizRawPixel8 *)destBM->bufferPtr()) + destRect->top * dw + destRect->left;
+	s8 = ((WizRawPixel8 *)sourceBM->bufferPtr()) + sourceRect->top * sw + sourceRect->left;
+	d16 = ((WizRawPixel16 *)destBM->bufferPtr()) + destRect->top * dw + destRect->left;
+	s16 = ((WizRawPixel16 *)sourceBM->bufferPtr()) + sourceRect->top * sw + sourceRect->left;
 
 	// Going up or down?
 	if (sourceRect->top > sourceRect->bottom) {
@@ -939,10 +939,10 @@ void Wiz::pgTransparentSimpleBlit(WizSimpleBitmap *destBM, Common::Rect *destRec
 	cw = abs(sourceRect->right - sourceRect->left) + 1;
 	ch = abs(sourceRect->bottom - sourceRect->top) + 1;
 
-	d8 = ((WizRawPixel8 *)destBM->bufferPtr) + destRect->top * dw + destRect->left;
-	s8 = ((WizRawPixel8 *)sourceBM->bufferPtr) + sourceRect->top * sw + sourceRect->left;
-	d16 = ((WizRawPixel16 *)destBM->bufferPtr) + destRect->top * dw + destRect->left;
-	s16 = ((WizRawPixel16 *)sourceBM->bufferPtr) + sourceRect->top * sw + sourceRect->left;
+	d8 = ((WizRawPixel8 *)destBM->bufferPtr()) + destRect->top * dw + destRect->left;
+	s8 = ((WizRawPixel8 *)sourceBM->bufferPtr()) + sourceRect->top * sw + sourceRect->left;
+	d16 = ((WizRawPixel16 *)destBM->bufferPtr()) + destRect->top * dw + destRect->left;
+	s16 = ((WizRawPixel16 *)sourceBM->bufferPtr()) + sourceRect->top * sw + sourceRect->left;
 
 	tColor = (int)transparentColor;
 
@@ -1102,11 +1102,11 @@ void Wiz::pgDraw8BppFormatImage(WizRawPixel *bufferPtr, const byte *rawData, int
 	}
 
 	// Setup the fake simple bitmaps...
-	dstBitmap.bufferPtr = bufferPtr;
+	dstBitmap.bufferPtr = WizPxShrdBuffer(bufferPtr, false);
 	dstBitmap.bitmapWidth = bufferWidth;
 	dstBitmap.bitmapHeight = bufferHeight;
 
-	srcBitmap.bufferPtr = (WizRawPixel *)const_cast<byte *>(rawData);
+	srcBitmap.bufferPtr = WizPxShrdBuffer(const_cast<byte *>(rawData), false);
 	srcBitmap.bitmapWidth = width;
 	srcBitmap.bitmapHeight = height;
 
@@ -1129,8 +1129,8 @@ void Wiz::pgDraw8BppSimpleBlit(WizSimpleBitmap *destBM, Common::Rect *destRect, 
 	cw = abs(sourceRect->right - sourceRect->left) + 1;
 	ch = abs(sourceRect->bottom - sourceRect->top) + 1;
 
-	d16 = ((WizRawPixel16 *)destBM->bufferPtr) + destRect->top * dw + destRect->left;
-	s8 = ((const WizRawPixel8 *)sourceBM->bufferPtr) + sourceRect->top * sw + sourceRect->left;
+	d16 = ((WizRawPixel16 *)destBM->bufferPtr()) + destRect->top * dw + destRect->left;
+	s8 = ((const WizRawPixel8 *)sourceBM->bufferPtr()) + sourceRect->top * sw + sourceRect->left;
 
 	// Going up or down?
 	if (sourceRect->top > sourceRect->bottom) {
@@ -1172,8 +1172,8 @@ void Wiz::pgDraw8BppTransparentSimpleBlit(WizSimpleBitmap *destBM, Common::Rect 
 	sw = sourceBM->bitmapWidth;
 	cw = abs(sourceRect->right - sourceRect->left) + 1;
 	ch = abs(sourceRect->bottom - sourceRect->top) + 1;
-	d16 = ((WizRawPixel16 *)destBM->bufferPtr) + destRect->top * dw + destRect->left;
-	s8 = ((const WizRawPixel8 *)sourceBM->bufferPtr) + sourceRect->top * sw + sourceRect->left;
+	d16 = ((WizRawPixel16 *)destBM->bufferPtr()) + destRect->top * dw + destRect->left;
+	s8 = ((const WizRawPixel8 *)sourceBM->bufferPtr()) + sourceRect->top * sw + sourceRect->left;
 
 	// Going up or down?
 	if (sourceRect->top > sourceRect->bottom) {
@@ -1259,8 +1259,8 @@ void Wiz::pgDrawImageWith16BitZBuffer(WizSimpleBitmap *psbDst, const WizSimpleBi
 	const int drawHeight = (prcClip->bottom - prcClip->top + 1);
 
 	WizRawPixel *pSrc = (WizRawPixel *)const_cast<byte *>(imgData) + (prcClip->top - y) * width + (prcClip->left - x);
-	WizRawPixel *pDst = (WizRawPixel *)psbDst->bufferPtr + prcClip->top * dstWidth + prcClip->left;
-	WizRawPixel *pZB = (WizRawPixel *)psbZBuffer->bufferPtr + prcClip->top * dstWidth + prcClip->left;
+	WizRawPixel *pDst = psbDst->bufferPtr() + prcClip->top * dstWidth + prcClip->left;
+	WizRawPixel *pZB = psbZBuffer->bufferPtr() + prcClip->top * dstWidth + prcClip->left;
 
 	for (int row = 0; row < drawHeight; ++row) {
 		for (int col = 0; col < drawWidth; ++col, ++pZB, ++pDst, ++pSrc) {
@@ -1661,8 +1661,8 @@ void Wiz::pgBlit90DegreeRotateCore(WizSimpleBitmap *dstBitmap, int x, int y, con
 	srcOffset = srcBitmap->bitmapWidth;
 
 	if (!_uses16BitColor) {
-		dst8 = ((WizRawPixel8 *)dstBitmap->bufferPtr) + dstX + (dstY * dstBitmap->bitmapWidth);
-		src8 = ((WizRawPixel8 *)srcBitmap->bufferPtr) + clippedSrcRect.left + (clippedSrcRect.top * srcBitmap->bitmapWidth);
+		dst8 = ((WizRawPixel8 *)dstBitmap->bufferPtr()) + dstX + (dstY * dstBitmap->bitmapWidth);
+		src8 = ((WizRawPixel8 *)srcBitmap->bufferPtr()) + clippedSrcRect.left + (clippedSrcRect.top * srcBitmap->bitmapWidth);
 
 		while (--h >= 0) {
 			(*srcTransferFP)(this, (WizRawPixel *)dst8, dstStep, (const WizRawPixel *)src8, w, userParam, userParam2);
@@ -1670,8 +1670,8 @@ void Wiz::pgBlit90DegreeRotateCore(WizSimpleBitmap *dstBitmap, int x, int y, con
 			src8 += srcOffset;
 		}
 	} else {
-		dst16 = ((WizRawPixel16 *)dstBitmap->bufferPtr) + dstX + (dstY * dstBitmap->bitmapWidth);
-		src16 = ((WizRawPixel16 *)srcBitmap->bufferPtr) + clippedSrcRect.left + (clippedSrcRect.top * srcBitmap->bitmapWidth);
+		dst16 = ((WizRawPixel16 *)dstBitmap->bufferPtr()) + dstX + (dstY * dstBitmap->bitmapWidth);
+		src16 = ((WizRawPixel16 *)srcBitmap->bufferPtr()) + clippedSrcRect.left + (clippedSrcRect.top * srcBitmap->bitmapWidth);
 
 		while (--h >= 0) {
 			(*srcTransferFP)(this, (WizRawPixel *)dst16, dstStep, (const WizRawPixel *)src16, w, userParam, userParam2);

--- a/engines/scumm/he/wiz_he.cpp
+++ b/engines/scumm/he/wiz_he.cpp
@@ -22,6 +22,7 @@
 #ifdef ENABLE_HE
 
 #include "common/archive.h"
+#include "common/ptr.h"
 #include "common/system.h"
 #include "graphics/cursorman.h"
 #include "graphics/primitives.h"
@@ -34,6 +35,10 @@
 #include "scumm/he/moonbase/moonbase.h"
 
 namespace Scumm {
+
+#ifdef WIZ_DEBUG_BUFFERS
+Common::Array<DbgEntry> *WizPxShrdBuffer::_allocLocs = 0;
+#endif
 
 Wiz::Wiz(ScummEngine_v71he *vm) : _vm(vm) {
 	_wizBufferIndex = 0;
@@ -59,16 +64,16 @@ void Wiz::processWizImageCaptureCmd(const WizImageCommand *params) {
 void Wiz::takeAWiz(int globnum, int x1, int y1, int x2, int y2, bool back, bool compress) {
 	int bufferWidth, bufferHeight;
 	Common::Rect rect, clipRect;
-	WizRawPixel *srcPtr;
+	WizPxShrdBuffer srcPtr;
 
 	VirtScreen *pvs = &_vm->_virtscr[kMainVirtScreen];
 	bufferWidth = pvs->w;
 	bufferHeight = pvs->h;
 
 	if (back) {
-		srcPtr = (WizRawPixel *)pvs->getBackPixels(0, 0);
+		srcPtr = WizPxShrdBuffer(pvs->getBackPixels(0, 0), false);
 	} else {
-		srcPtr = (WizRawPixel *)pvs->getPixels(0, 0);
+		srcPtr = WizPxShrdBuffer(pvs->getPixels(0, 0), false);
 	}
 
 	rect.left = x1;
@@ -122,13 +127,13 @@ void Wiz::bufferAWiz(int image, int state, int x, int y, int z, int flags, int o
 	++_wizBufferIndex;
 }
 
-byte *Wiz::drawAWiz(int image, int state, int x, int y, int z, int flags, int optionalShadowImage, int optionalZBufferImage, Common::Rect *optionalClipRect, int whichPalette, WizSimpleBitmap *optionalBitmapOverride) {
+WizPxShrdBuffer &&Wiz::drawAWiz(int image, int state, int x, int y, int z, int flags, int optionalShadowImage, int optionalZBufferImage, Common::Rect *optionalClipRect, int whichPalette, WizSimpleBitmap *optionalBitmapOverride) {
 	return drawAWizEx(image, state, x, y, z, flags,
 		optionalShadowImage, optionalZBufferImage, optionalClipRect,
 		whichPalette, optionalBitmapOverride, nullptr);
 }
 
-byte *Wiz::drawAWizEx(int image, int state, int x, int y, int z, int flags, int optionalShadowImage, int optionalZBufferImage, Common::Rect *optionalClipRect, int whichPalette, WizSimpleBitmap *optionalBitmapOverride, const WizImageCommand *optionalICmdPtr) {
+WizPxShrdBuffer &&Wiz::drawAWizEx(int image, int state, int x, int y, int z, int flags, int optionalShadowImage, int optionalZBufferImage, Common::Rect *optionalClipRect, int whichPalette, WizSimpleBitmap *optionalBitmapOverride, const WizImageCommand *optionalICmdPtr) {
 	const WizRawPixel *colorConversionTable;
 	Common::Rect *clipRectPtr;
 
@@ -158,7 +163,7 @@ byte *Wiz::drawAWizEx(int image, int state, int x, int y, int z, int flags, int 
 		}
 
 		// Call the primitive renderer.
-		return (byte *)drawAWizPrimEx(image, state, x, y, z,
+		return drawAWizPrimEx(image, state, x, y, z,
 			optionalShadowImage, optionalZBufferImage, clipRectPtr,
 			flags, optionalBitmapOverride, colorConversionTable, optionalICmdPtr);
 	} else {
@@ -166,23 +171,23 @@ byte *Wiz::drawAWizEx(int image, int state, int x, int y, int z, int flags, int 
 			image, state, x, flags, _vm->_game.heversion <= 90 ? 0x05 : _vm->VAR(_vm->VAR_WIZ_TRANSPARENT_COLOR),
 			optionalBitmapOverride, colorConversionTable, optionalShadowImage);
 
-		return nullptr;
+		return Common::move(WizPxShrdBuffer());
 	}
 }
 
-void *Wiz::drawAWizPrim(int globNum, int state, int x, int y, int z, int shadowImage, int zbufferImage, const Common::Rect *optionalClipRect, int flags, WizSimpleBitmap *optionalBitmapOverride, const WizRawPixel *optionalColorConversionTable) {
+WizPxShrdBuffer &&Wiz::drawAWizPrim(int globNum, int state, int x, int y, int z, int shadowImage, int zbufferImage, const Common::Rect *optionalClipRect, int flags, WizSimpleBitmap *optionalBitmapOverride, const WizRawPixel *optionalColorConversionTable) {
 	return drawAWizPrimEx(globNum, state, x, y, z,
 		shadowImage, zbufferImage, optionalClipRect, flags,
 		optionalBitmapOverride, optionalColorConversionTable, 0);
 }
 
-void *Wiz::drawAWizPrimEx(int globNum, int state, int x, int y, int z, int shadowImage, int zbufferImage, const Common::Rect *optionalClipRect, int flags, WizSimpleBitmap *optionalBitmapOverride, const WizRawPixel *optionalColorConversionTable, const WizImageCommand *optionalICmdPtr) {
+WizPxShrdBuffer &&Wiz::drawAWizPrimEx(int globNum, int state, int x, int y, int z, int shadowImage, int zbufferImage, const Common::Rect *optionalClipRect, int flags, WizSimpleBitmap *optionalBitmapOverride, const WizRawPixel *optionalColorConversionTable, const WizImageCommand *optionalICmdPtr) {
 	int destWidth, destHeight, srcWidth, srcHeight, srcComp, remapId;
 	byte *srcData, *srcPtr, *stateHeader, *remapPtr;
 	const byte *shadowPtr;
 	Common::Rect destRect, clipRect;
 	bool markUpdates;
-	WizRawPixel *destPtr;
+	WizPxShrdBuffer destPtr;
 
 	markUpdates = true;
 	remapPtr = nullptr;
@@ -285,17 +290,17 @@ void *Wiz::drawAWizPrimEx(int globNum, int state, int x, int y, int z, int shado
 		destWidth = srcWidth;
 		destHeight = srcHeight;
 		if (_uses16BitColor) {
-			destPtr = (WizRawPixel *)malloc(destWidth * destHeight * sizeof(WizRawPixel16));
+			destPtr = WizPxShrdBufferD(malloc(destWidth * destHeight * sizeof(WizRawPixel16)), true);
 		} else {
-			destPtr = (WizRawPixel *)malloc(destWidth * destHeight * sizeof(WizRawPixel8));
+			destPtr = WizPxShrdBufferD(malloc(destWidth * destHeight * sizeof(WizRawPixel8)), true);
 		}
 
-		if (!destPtr) {
+		if (!destPtr()) {
 			warning("Wiz::drawAWizPrimEx(): Not enough memory for image operation (print / other)");
-			return nullptr;
+			return Common::move(WizPxShrdBuffer());
 		} else if (flags & kWRFAlloc) {
 			memset8BppConversion(
-				destPtr,
+				destPtr(),
 				_vm->_game.heversion < 95 ? 0x05 : _vm->VAR(_vm->VAR_WIZ_TRANSPARENT_COLOR),
 				destWidth * destHeight,
 				optionalColorConversionTable);
@@ -314,9 +319,9 @@ void *Wiz::drawAWizPrimEx(int globNum, int state, int x, int y, int z, int shado
 			destHeight = pvs->h;
 
 			if (flags & kWRFForeground) {
-				destPtr = (WizRawPixel *)pvs->getPixels(0, pvs->topline);
+				destPtr = WizPxShrdBuffer(pvs->getPixels(0, pvs->topline), false);
 			} else {
-				destPtr = (WizRawPixel *)pvs->getBackPixels(0, pvs->topline);
+				destPtr = WizPxShrdBuffer(pvs->getBackPixels(0, pvs->topline), false);
 			}
 		}
 	}
@@ -329,7 +334,7 @@ void *Wiz::drawAWizPrimEx(int globNum, int state, int x, int y, int z, int shado
 
 	if (optionalClipRect && (!(flags & (kWRFPrint | kWRFAlloc)))) {
 		if (!findRectOverlap(&clipRect, optionalClipRect)) {
-			return nullptr;
+			return Common::move(WizPxShrdBuffer());
 		}
 	}
 
@@ -338,7 +343,7 @@ void *Wiz::drawAWizPrimEx(int globNum, int state, int x, int y, int z, int shado
 		WizSimpleBitmap sbZBuffer;
 		sbZBuffer.bitmapHeight = 0;
 		sbZBuffer.bitmapWidth = 0;
-		sbZBuffer.bufferPtr = nullptr;
+		sbZBuffer.bufferPtr = WizPxShrdBuffer();
 
 		dwSetSimpleBitmapStructFromImage(zbufferImage, 0, &sbZBuffer);
 
@@ -374,17 +379,17 @@ void *Wiz::drawAWizPrimEx(int globNum, int state, int x, int y, int z, int shado
 		} else if (_vm->_game.heversion <= 98 && !(flags & (kWRFHFlip | kWRFVFlip))) {
 			if (flags & kWRFRemap) {
 				auxDecompRemappedTRLEImage(
-					destPtr, srcData + _vm->_resourceHeaderSize, destWidth, destHeight,
+					destPtr(), srcData + _vm->_resourceHeaderSize, destWidth, destHeight,
 					x, y, srcWidth, srcHeight, &clipRect, remapPtr + _vm->_resourceHeaderSize + 4,
 					optionalColorConversionTable);
 			} else if (!shadowPtr) {
 				auxDecompTRLEImage(
-					destPtr, srcData + _vm->_resourceHeaderSize, destWidth, destHeight,
+					destPtr(), srcData + _vm->_resourceHeaderSize, destWidth, destHeight,
 					x, y, srcWidth, srcHeight, &clipRect,
 					optionalColorConversionTable);
 			} else {
 				auxDecompMixColorsTRLEImage(
-					destPtr, srcData + _vm->_resourceHeaderSize, destWidth, destHeight,
+					destPtr(), srcData + _vm->_resourceHeaderSize, destWidth, destHeight,
 					x, y, srcWidth, srcHeight, &clipRect, shadowPtr,
 					optionalColorConversionTable);
 			}
@@ -398,7 +403,7 @@ void *Wiz::drawAWizPrimEx(int globNum, int state, int x, int y, int z, int shado
 				dataPtr = remapPtr + _vm->_resourceHeaderSize + 4;
 
 			trleFLIPDecompressImage(
-				destPtr, srcData + _vm->_resourceHeaderSize, destWidth, destHeight,
+				destPtr(), srcData + _vm->_resourceHeaderSize, destWidth, destHeight,
 				x, y, srcWidth, srcHeight, &clipRect, flags, dataPtr,
 				optionalColorConversionTable,
 				optionalICmdPtr);
@@ -423,7 +428,7 @@ void *Wiz::drawAWizPrimEx(int globNum, int state, int x, int y, int z, int shado
 		if (_uses16BitColor && srcComp != kWCTNone16Bpp && srcComp != kWCTNone16BppBigEndian) {
 				if (srcComp == kWCTNone) {
 					pgDraw8BppFormatImage(
-						destPtr, (byte *)(srcData + _vm->_resourceHeaderSize), destWidth, destHeight,
+						destPtr(), (byte *)(srcData + _vm->_resourceHeaderSize), destWidth, destHeight,
 						x, y, srcWidth, srcHeight, &clipRect, flags, dataPtr, transColorOverride,
 						optionalColorConversionTable);
 				} else {
@@ -444,7 +449,7 @@ void *Wiz::drawAWizPrimEx(int globNum, int state, int x, int y, int z, int shado
 
 			// Use the native transfer function...
 			pgDrawRawDataFormatImage(
-				destPtr, (WizRawPixel *)(srcData + _vm->_resourceHeaderSize), destWidth, destHeight,
+				destPtr(), (WizRawPixel *)(srcData + _vm->_resourceHeaderSize), destWidth, destHeight,
 				x, y, srcWidth, srcHeight, &clipRect, flags, dataPtr, transColorOverride);
 		}
 	}
@@ -453,10 +458,9 @@ void *Wiz::drawAWizPrimEx(int globNum, int state, int x, int y, int z, int shado
 	if (flags & kWRFPrint) {
 		warning("Wiz::drawAWizPrimEx(): Printing not yet supported");
 
-		if (_vm->_game.heversion <= 99 || (flags & kWRFAlloc) == 0) {
-			free(destPtr);
-			destPtr = nullptr;
-		}
+		if (_vm->_game.heversion <= 99 || (flags & kWRFAlloc) == 0)
+			destPtr = WizPxShrdBuffer();
+
 	} else {
 		if (!(flags & kWRFAlloc) && markUpdates) {
 			destRect.left = x;
@@ -476,10 +480,10 @@ void *Wiz::drawAWizPrimEx(int globNum, int state, int x, int y, int z, int shado
 		}
 	}
 
-	return destPtr;
+	return Common::move(destPtr);
 }
 
-void Wiz::buildAWiz(const WizRawPixel *bufPtr, int bufWidth, int bufHeight, const byte *palettePtr, const Common::Rect *rectPtr, int compressionType, int globNum, int transparentColor) {
+void Wiz::buildAWiz(const WizPxShrdBuffer &bufPtr, int bufWidth, int bufHeight, const byte *palettePtr, const Common::Rect *rectPtr, int compressionType, int globNum, int transparentColor) {
 	int dataSize, globSize, dataOffset, counter, height, width;
 	Common::Rect compRect;
 	byte *ptr;
@@ -511,7 +515,7 @@ void Wiz::buildAWiz(const WizRawPixel *bufPtr, int bufWidth, int bufHeight, cons
 
 	if (compressionType == kWCTTRLE) {
 		dataSize = trleCompressImageArea(
-			nullptr, bufPtr, bufWidth, compRect.left, compRect.top, compRect.right, compRect.bottom,
+			nullptr, bufPtr(), bufWidth, compRect.left, compRect.top, compRect.right, compRect.bottom,
 			(WizRawPixel)transparentColor);
 	} else if (isUncompressedFormatTypeID(compressionType)) {
 		dataSize = ((getRectWidth(&compRect) * getRectHeight(&compRect)) * sizeof(WizRawPixel));
@@ -569,7 +573,7 @@ void Wiz::buildAWiz(const WizRawPixel *bufPtr, int bufWidth, int bufHeight, cons
 	if (compressionType == kWCTTRLE) {
 		if (!_uses16BitColor) {
 			trleCompressImageArea(
-				ptr + dataOffset, bufPtr, bufWidth,
+				ptr + dataOffset, bufPtr(), bufWidth,
 				compRect.left, compRect.top, compRect.right, compRect.bottom,
 				(byte)transparentColor);
 		} else {
@@ -580,7 +584,7 @@ void Wiz::buildAWiz(const WizRawPixel *bufPtr, int bufWidth, int bufHeight, cons
 		Common::Rect dstRect;
 
 		// Src setup
-		srcBitmap.bufferPtr = const_cast<WizRawPixel *>(bufPtr);
+		srcBitmap.bufferPtr = bufPtr;
 		srcBitmap.bitmapWidth = bufWidth;
 		srcBitmap.bitmapHeight = bufHeight;
 
@@ -588,7 +592,7 @@ void Wiz::buildAWiz(const WizRawPixel *bufPtr, int bufWidth, int bufHeight, cons
 		width = getRectWidth(&compRect);
 		height = getRectHeight(&compRect);
 
-		dstBitmap.bufferPtr = (WizRawPixel *)(ptr + dataOffset);
+		dstBitmap.bufferPtr = WizPxShrdBuffer(ptr + dataOffset, false);
 		dstBitmap.bitmapWidth = width;
 		dstBitmap.bitmapHeight = height;
 
@@ -659,7 +663,7 @@ int Wiz::pixelHitTestWizPrim(int globNum, int state, int x, int y, int32 flags) 
 
 		srcData = getWizStateDataPrim(globNum, state);
 
-		srcBitmap.bufferPtr = (WizRawPixel *)(srcData + _vm->_resourceHeaderSize);
+		srcBitmap.bufferPtr = WizPxShrdBuffer(srcData + _vm->_resourceHeaderSize, false);
 		srcBitmap.bitmapWidth = srcWidth;
 		srcBitmap.bitmapHeight = srcHeight;
 
@@ -759,7 +763,7 @@ int Wiz::hitTestWizPrim(int globNum, int state, int x, int y, int32 flags) {
 
 		srcData = getWizStateDataPrim(globNum, state) + _vm->_resourceHeaderSize;
 
-		srcBitmap.bufferPtr = (WizRawPixel *)const_cast<byte *>(srcData);
+		srcBitmap.bufferPtr = WizPxShrdBuffer(const_cast<byte *>(srcData), false);
 		srcBitmap.bitmapWidth = srcWidth;
 		srcBitmap.bitmapHeight = srcHeight;
 
@@ -859,8 +863,8 @@ void Wiz::processWizImagePolyCaptureCmd(const WizImageCommand *params) {
 
 	// Create the buffers to hold the source and destination image bitmaps...
 	WizSimpleBitmap srcBitmap, destBitmap;
-	srcBitmap.bufferPtr = nullptr;
-	destBitmap.bufferPtr = nullptr;
+	srcBitmap.bufferPtr = WizPxShrdBuffer();
+	destBitmap.bufferPtr = WizPxShrdBuffer();
 
 	// Build a bounding rect for the polys and set the appropriate sizes in the bitmaps...
 	Common::Rect destPolyRect;
@@ -869,14 +873,14 @@ void Wiz::processWizImagePolyCaptureCmd(const WizImageCommand *params) {
 	polyBuildBoundingRect(_polygons[polygon2].points, _polygons[polygon2].numPoints, destPolyRect);
 	destBitmap.bitmapWidth = getRectWidth(&destPolyRect);
 	destBitmap.bitmapHeight = getRectHeight(&destPolyRect);
-	destBitmap.bufferPtr = (WizRawPixel *)malloc(destBitmap.bitmapWidth * destBitmap.bitmapHeight * sizeof(WizRawPixel));
+	destBitmap.bufferPtr = WizPxShrdBufferD(malloc(destBitmap.bitmapWidth * destBitmap.bitmapHeight * sizeof(WizRawPixel)), true);
 
-	if (!destBitmap.bufferPtr) {
+	if (!destBitmap.bufferPtr()) {
 		error("Wiz::processWizImagePolyCaptureCmd(): Could not allocate destination buffer");
 	}
 
 	// Fill with transparent color...
-	rawPixelMemset(destBitmap.bufferPtr,
+	rawPixelMemset(destBitmap.bufferPtr(),
 					_vm->VAR(_vm->VAR_WIZ_TRANSPARENT_COLOR),
 					destBitmap.bitmapWidth * destBitmap.bitmapHeight);
 
@@ -945,13 +949,13 @@ void Wiz::processWizImagePolyCaptureCmd(const WizImageCommand *params) {
 		}
 
 		// Create the bitmap...
-		srcBitmap.bufferPtr = (WizRawPixel *)malloc(srcBitmap.bitmapWidth * srcBitmap.bitmapHeight * sizeof(WizRawPixel));
-		if (!srcBitmap.bufferPtr) {
+		srcBitmap.bufferPtr = WizPxShrdBufferD(malloc(srcBitmap.bitmapWidth * srcBitmap.bitmapHeight * sizeof(WizRawPixel)), true);
+		if (!srcBitmap.bufferPtr()) {
 			error("Wiz::processWizImagePolyCaptureCmd(): Could not allocate source buffer");
 		}
 
 		// Set it all to transparent...
-		rawPixelMemset(srcBitmap.bufferPtr,
+		rawPixelMemset(srcBitmap.bufferPtr(),
 						_vm->VAR(_vm->VAR_WIZ_TRANSPARENT_COLOR),
 						srcBitmap.bitmapWidth * srcBitmap.bitmapHeight);
 
@@ -981,28 +985,26 @@ void Wiz::processWizImagePolyCaptureCmd(const WizImageCommand *params) {
 		}
 
 		// Create the bitmap...
-		srcBitmap.bufferPtr = (WizRawPixel *)malloc(srcBitmap.bitmapWidth * srcBitmap.bitmapHeight * sizeof(WizRawPixel));
-		if (!srcBitmap.bufferPtr) {
+		srcBitmap.bufferPtr = WizPxShrdBufferD(malloc(srcBitmap.bitmapWidth * srcBitmap.bitmapHeight * sizeof(WizRawPixel)), true);
+		if (!srcBitmap.bufferPtr()) {
 			error("Wiz::processWizImagePolyCaptureCmd(): Could not allocate source buffer");
 		}
 
 		// Set it all to transparent...
-		rawPixelMemset(srcBitmap.bufferPtr,
+		rawPixelMemset(srcBitmap.bufferPtr(),
 						_vm->VAR(_vm->VAR_WIZ_TRANSPARENT_COLOR),
 						srcBitmap.bitmapWidth * srcBitmap.bitmapHeight);
 
 		// Fill it with screen data...
 		WizRawPixel *screenPtr = (WizRawPixel *)pvs->getPixels(srcPolyRect.left, srcPolyRect.top);
-		WizRawPixel *destPtr;
-
-		destPtr = srcBitmap.bufferPtr;
+		WizPxShrdBuffer destPtr = srcBitmap.bufferPtr;
 
 		int screenRowLen = 640;
 		int destRowLen = srcBitmap.bitmapWidth;
 
 		if (_uses16BitColor) {
 			WizRawPixel16 *screen16 = (WizRawPixel16 *)screenPtr;
-			WizRawPixel16 *dest16 = (WizRawPixel16 *)destPtr;
+			WizRawPixel16 *dest16 = (WizRawPixel16 *)destPtr();
 
 			for (int i = 0; i < srcBitmap.bitmapHeight; ++i) {
 				memcpy(dest16, screen16, destRowLen);
@@ -1011,7 +1013,7 @@ void Wiz::processWizImagePolyCaptureCmd(const WizImageCommand *params) {
 			}
 		} else {
 			WizRawPixel8 *screen8 = (WizRawPixel8 *)screenPtr;
-			WizRawPixel8 *dest8 = (WizRawPixel8 *)destPtr;
+			WizRawPixel8 *dest8 = (WizRawPixel8 *)destPtr();
 
 			for (int i = 0; i < srcBitmap.bitmapHeight; ++i) {
 				memcpy(dest8, screen8, destRowLen);
@@ -1056,7 +1058,7 @@ void Wiz::processWizImagePolyCaptureCmd(const WizImageCommand *params) {
 			xmapColorTable, isHintColor, (WizRawPixel)hintColor);
 
 	} else if (oneToOneRect) { // If a one to one copy is performed, just copy this bitmap...
-		memcpy(destBitmap.bufferPtr, srcBitmap.bufferPtr, destBitmap.bitmapHeight * destBitmap.bitmapWidth);
+		memcpy(destBitmap.bufferPtr(), srcBitmap.bufferPtr(), destBitmap.bitmapHeight * destBitmap.bitmapWidth);
 	} else { // Otherwise fallback to regular warping...
 		WarpWizPoint polypoints[5];
 		for (int i = 0; i < 5; i++) {
@@ -1076,10 +1078,7 @@ void Wiz::processWizImagePolyCaptureCmd(const WizImageCommand *params) {
 	}
 
 	// Now build a Wiz with the destination bitmap and throw the bitmaps away...
-	if (srcBitmap.bufferPtr) {
-		free(srcBitmap.bufferPtr);
-		srcBitmap.bufferPtr = nullptr;
-	}
+	srcBitmap.bufferPtr = WizPxShrdBuffer();
 
 	uint8 *palPtr = nullptr;
 	if (_vm->_game.heversion >= 99) {
@@ -1097,10 +1096,7 @@ void Wiz::processWizImagePolyCaptureCmd(const WizImageCommand *params) {
 			  params->image,
 			  _vm->VAR(_vm->VAR_WIZ_TRANSPARENT_COLOR));
 
-	if (destBitmap.bufferPtr) {
-		free(destBitmap.bufferPtr);
-		destBitmap.bufferPtr = nullptr;
-	}
+	destBitmap.bufferPtr = WizPxShrdBuffer();
 
 	_vm->_res->setModified(rtImage, params->image);
 }
@@ -1146,7 +1142,8 @@ void Wiz::loadWizCursor(int resId, int palette, bool useColor) {
 	if (palette != 0)
 		colorConversionTable = (WizRawPixel *) _vm->getHEPaletteSlot(palette);
 
-	byte *cursor = (byte *)drawAWizPrim(resId, 0, 0, 0, 0, 0, 0, nullptr, kWRFAlloc, nullptr, colorConversionTable);
+	WizPxShrdBuffer cursorBuffer = drawAWizPrim(resId, 0, 0, 0, 0, 0, 0, nullptr, kWRFAlloc, nullptr, colorConversionTable);
+	byte *cursor = (byte*)cursorBuffer();
 
 	int32 cw, ch;
 	getWizImageDim(resId, 0, cw, ch);
@@ -1167,8 +1164,6 @@ void Wiz::loadWizCursor(int resId, int palette, bool useColor) {
 
 	// Since we set up cursor palette for default cursor, disable it now...
 	CursorMan.disableCursorPalette(true);
-
-	free(cursor);
 }
 
 #define ADD_REQUIRED_IMAGE(whatImageIsRequired) {                                                                                    \
@@ -1531,7 +1526,7 @@ bool Wiz::dwSetSimpleBitmapStructFromImage(int imageNum, int imageState, WizSimp
 	}
 
 	// Hook up the image info to the simple bitmap info...
-	destBM->bufferPtr = (WizRawPixel *)(dataPtr + _vm->_resourceHeaderSize);
+	destBM->bufferPtr = WizPxShrdBuffer(dataPtr + _vm->_resourceHeaderSize, false);
 	destBM->bitmapWidth = imageWidth;
 	destBM->bitmapHeight = imageHeight;
 
@@ -1681,7 +1676,7 @@ void Wiz::dwAltSourceDrawWiz(int maskImage, int maskState, int x, int y, int sou
 	// Finally call the primitive...
 	if (maskCompressionType == kWCTTRLE) {
 		trleFLIPAltSourceDecompressImage(
-			destBitmapPtr->bufferPtr, maskDataPtr,
+			destBitmapPtr->bufferPtr(), maskDataPtr,
 			destBitmapPtr->bitmapWidth, destBitmapPtr->bitmapHeight,
 			sourceBufferPtr, srcBitmapWidth, srcBitmapHeight, srcBitsPerPixel,
 			x, y, maskWidth, maskHeight, &clipRect, flags, conversionTable,
@@ -1689,7 +1684,7 @@ void Wiz::dwAltSourceDrawWiz(int maskImage, int maskState, int x, int y, int sou
 
 	} else if (maskCompressionType == kWCTMRLEWithLineSizePrefix) {
 		mrleFLIPAltSourceDecompressImage(
-			destBitmapPtr->bufferPtr, maskDataPtr,
+			destBitmapPtr->bufferPtr(), maskDataPtr,
 			destBitmapPtr->bitmapWidth, destBitmapPtr->bitmapHeight,
 			sourceBufferPtr, srcBitmapWidth, srcBitmapHeight, srcBitsPerPixel,
 			x, y, maskWidth, maskHeight, &clipRect, flags, conversionTable);
@@ -1903,7 +1898,7 @@ void Wiz::handleRotate90SpecialCase(int image, int state, int x, int y, int shad
 	if (compressionType == kWCTTRLE) {
 		int dest_w, dest_h, src_w, src_h;
 		const byte *compressedDataPtr;
-		WizRawPixel *dest_p;
+		WizPxShrdBuffer dest_p;
 
 		// Get the size of the compressed image...
 		src_w = w;
@@ -1925,14 +1920,14 @@ void Wiz::handleRotate90SpecialCase(int image, int state, int x, int y, int shad
 			dest_h = pvs->h;
 
 			if (flags & kWRFForeground) {
-				dest_p = (WizRawPixel *)pvs->getPixels(0, 0);
+				dest_p = WizPxShrdBuffer(pvs->getPixels(0, 0), false);
 			} else {
-				dest_p = (WizRawPixel *)pvs->getBackPixels(0, 0);
+				dest_p = WizPxShrdBuffer(pvs->getBackPixels(0, 0), false);
 			}
 		}
 
 		trleFLIPRotate90DecompressImage(
-			dest_p, compressedDataPtr, dest_w, dest_h, x, y, src_w, src_h,
+			dest_p(), compressedDataPtr, dest_w, dest_h, x, y, src_w, src_h,
 			clipRect, flags, nullptr, optionalColorConversionTable,
 			nullptr);
 
@@ -1950,7 +1945,7 @@ void Wiz::handleRotate90SpecialCase(int image, int state, int x, int y, int shad
 	}
 
 	// Get the image from the basic drawing function...
-	srcBitmap.bufferPtr = (WizRawPixel *)drawAWizPrim(
+	srcBitmap.bufferPtr = drawAWizPrim(
 		image, state, 0, 0, 0, 0, 0, 0, kWRFAlloc,
 		0, optionalColorConversionTable);
 
@@ -1977,8 +1972,7 @@ void Wiz::handleRotate90SpecialCase(int image, int state, int x, int y, int shad
 	}
 
 	// Free up the temporary pointer...
-	free(srcBitmap.bufferPtr);
-	srcBitmap.bufferPtr = nullptr;
+	srcBitmap.bufferPtr = WizPxShrdBuffer();
 
 	// Update the screen? (If not writing to another bitmap...)
 	if (!optionalBitmapOverride) {
@@ -2267,7 +2261,7 @@ int Wiz::createHistogramArrayForImage(int image, int state, const Common::Rect *
 		} else if (src_c == kWCTNone) {
 			WizSimpleBitmap srcBitmap;
 
-			srcBitmap.bufferPtr = (WizRawPixel *)(src_d + _vm->_resourceHeaderSize);
+			srcBitmap.bufferPtr = WizPxShrdBuffer(src_d + _vm->_resourceHeaderSize, false);
 			srcBitmap.bitmapWidth = src_w;
 			srcBitmap.bitmapHeight = src_h;
 

--- a/engines/scumm/he/wiz_he.cpp
+++ b/engines/scumm/he/wiz_he.cpp
@@ -127,13 +127,13 @@ void Wiz::bufferAWiz(int image, int state, int x, int y, int z, int flags, int o
 	++_wizBufferIndex;
 }
 
-WizPxShrdBuffer &&Wiz::drawAWiz(int image, int state, int x, int y, int z, int flags, int optionalShadowImage, int optionalZBufferImage, Common::Rect *optionalClipRect, int whichPalette, WizSimpleBitmap *optionalBitmapOverride) {
+WizPxShrdBuffer Wiz::drawAWiz(int image, int state, int x, int y, int z, int flags, int optionalShadowImage, int optionalZBufferImage, Common::Rect *optionalClipRect, int whichPalette, WizSimpleBitmap *optionalBitmapOverride) {
 	return drawAWizEx(image, state, x, y, z, flags,
 		optionalShadowImage, optionalZBufferImage, optionalClipRect,
 		whichPalette, optionalBitmapOverride, nullptr);
 }
 
-WizPxShrdBuffer &&Wiz::drawAWizEx(int image, int state, int x, int y, int z, int flags, int optionalShadowImage, int optionalZBufferImage, Common::Rect *optionalClipRect, int whichPalette, WizSimpleBitmap *optionalBitmapOverride, const WizImageCommand *optionalICmdPtr) {
+WizPxShrdBuffer Wiz::drawAWizEx(int image, int state, int x, int y, int z, int flags, int optionalShadowImage, int optionalZBufferImage, Common::Rect *optionalClipRect, int whichPalette, WizSimpleBitmap *optionalBitmapOverride, const WizImageCommand *optionalICmdPtr) {
 	const WizRawPixel *colorConversionTable;
 	Common::Rect *clipRectPtr;
 
@@ -171,17 +171,17 @@ WizPxShrdBuffer &&Wiz::drawAWizEx(int image, int state, int x, int y, int z, int
 			image, state, x, flags, _vm->_game.heversion <= 90 ? 0x05 : _vm->VAR(_vm->VAR_WIZ_TRANSPARENT_COLOR),
 			optionalBitmapOverride, colorConversionTable, optionalShadowImage);
 
-		return Common::move(WizPxShrdBuffer());
+		return WizPxShrdBuffer();
 	}
 }
 
-WizPxShrdBuffer &&Wiz::drawAWizPrim(int globNum, int state, int x, int y, int z, int shadowImage, int zbufferImage, const Common::Rect *optionalClipRect, int flags, WizSimpleBitmap *optionalBitmapOverride, const WizRawPixel *optionalColorConversionTable) {
+WizPxShrdBuffer Wiz::drawAWizPrim(int globNum, int state, int x, int y, int z, int shadowImage, int zbufferImage, const Common::Rect *optionalClipRect, int flags, WizSimpleBitmap *optionalBitmapOverride, const WizRawPixel *optionalColorConversionTable) {
 	return drawAWizPrimEx(globNum, state, x, y, z,
 		shadowImage, zbufferImage, optionalClipRect, flags,
 		optionalBitmapOverride, optionalColorConversionTable, 0);
 }
 
-WizPxShrdBuffer &&Wiz::drawAWizPrimEx(int globNum, int state, int x, int y, int z, int shadowImage, int zbufferImage, const Common::Rect *optionalClipRect, int flags, WizSimpleBitmap *optionalBitmapOverride, const WizRawPixel *optionalColorConversionTable, const WizImageCommand *optionalICmdPtr) {
+WizPxShrdBuffer Wiz::drawAWizPrimEx(int globNum, int state, int x, int y, int z, int shadowImage, int zbufferImage, const Common::Rect *optionalClipRect, int flags, WizSimpleBitmap *optionalBitmapOverride, const WizRawPixel *optionalColorConversionTable, const WizImageCommand *optionalICmdPtr) {
 	int destWidth, destHeight, srcWidth, srcHeight, srcComp, remapId;
 	byte *srcData, *srcPtr, *stateHeader, *remapPtr;
 	const byte *shadowPtr;
@@ -297,7 +297,7 @@ WizPxShrdBuffer &&Wiz::drawAWizPrimEx(int globNum, int state, int x, int y, int 
 
 		if (!destPtr()) {
 			warning("Wiz::drawAWizPrimEx(): Not enough memory for image operation (print / other)");
-			return Common::move(WizPxShrdBuffer());
+			return WizPxShrdBuffer();
 		} else if (flags & kWRFAlloc) {
 			memset8BppConversion(
 				destPtr(),
@@ -334,7 +334,7 @@ WizPxShrdBuffer &&Wiz::drawAWizPrimEx(int globNum, int state, int x, int y, int 
 
 	if (optionalClipRect && (!(flags & (kWRFPrint | kWRFAlloc)))) {
 		if (!findRectOverlap(&clipRect, optionalClipRect)) {
-			return Common::move(WizPxShrdBuffer());
+			return WizPxShrdBuffer();
 		}
 	}
 
@@ -480,7 +480,7 @@ WizPxShrdBuffer &&Wiz::drawAWizPrimEx(int globNum, int state, int x, int y, int 
 		}
 	}
 
-	return Common::move(destPtr);
+	return destPtr;
 }
 
 void Wiz::buildAWiz(const WizPxShrdBuffer &bufPtr, int bufWidth, int bufHeight, const byte *palettePtr, const Common::Rect *rectPtr, int compressionType, int globNum, int transparentColor) {

--- a/engines/scumm/he/wiz_he.h
+++ b/engines/scumm/he/wiz_he.h
@@ -22,6 +22,8 @@
 #if !defined(SCUMM_HE_WIZ_HE_H) && defined(ENABLE_HE)
 #define SCUMM_HE_WIZ_HE_H
 
+//#define WIZ_DEBUG_BUFFERS
+
 #include "common/rect.h"
 
 namespace Scumm {
@@ -264,12 +266,96 @@ struct FloodFillCommand {
 	}
 };
 
+#ifdef WIZ_DEBUG_BUFFERS
+#define WizPxShrdBufferD(a, b) WizPxShrdBuffer(a, b, __FUNCTION__, __LINE__)
+struct DbgEntry {
+	DbgEntry(const void *a, const char *lpr, int ln) : addr(a), crefs(0), msg(Common::String::format("   buffer allocated in: %s(), line %d\n", lpr, ln)) {}
+	bool operator==(const void *ptr) const { return addr == ptr; }
+	const void *addr;
+	Common::String msg;
+	int crefs;
+};
+#else
+#define WizPxShrdBufferD(a, b) WizPxShrdBuffer(a, b)
+#endif
+
+class WizPxShrdBuffer {
+public:
+#ifdef WIZ_DEBUG_BUFFERS
+	static void dbgLeakRpt() {
+		for (Common::Array<DbgEntry>::iterator i = _allocLocs->begin(); i != _allocLocs->end(); ++i)
+			debug("Leaked: \n%s (refcnt: %d)\n\n", i->msg.c_str(), i->crefs);
+		_allocLocs->clear();
+		delete _allocLocs;
+		_allocLocs = nullptr;
+	}
+	static Common::Array<DbgEntry> *_allocLocs;
+#endif
+	WizPxShrdBuffer() : _buff(nullptr), _lifes(nullptr) {}
+#ifdef WIZ_DEBUG_BUFFERS
+	WizPxShrdBuffer(void *buff, bool hasOwnerShip) : WizPxShrdBuffer(buff, hasOwnerShip, 0, 0) {}
+	WizPxShrdBuffer(void *buff, bool hasOwnerShip, const char *func, int line)
+#else
+	WizPxShrdBuffer(void *buff, bool hasOwnerShip)
+#endif
+		: _buff(reinterpret_cast<WizRawPixel *>(buff)), _lifes(nullptr) {
+		if (hasOwnerShip) {
+#ifdef WIZ_DEBUG_BUFFERS
+			if (!_allocLocs)
+				_allocLocs = new Common::Array<DbgEntry>();
+			_allocLocs->push_back(DbgEntry(buff, func, line));
+#endif
+			*(_lifes = new int) = 1;
+		}
+	}
+	WizPxShrdBuffer(const WizPxShrdBuffer &other) : _buff(other._buff), _lifes(other._lifes) {
+		if (_lifes)
+			++*_lifes;
+	}
+	WizPxShrdBuffer(const WizPxShrdBuffer &&other) noexcept : _buff(other._buff), _lifes(other._lifes) {
+		if (_lifes)
+			++*_lifes;
+	}
+	~WizPxShrdBuffer() {
+		if (_lifes && !--*_lifes) {
+			free(_buff);
+#ifdef WIZ_DEBUG_BUFFERS
+			Common::Array<DbgEntry>::iterator i = Common::find(_allocLocs->begin(), _allocLocs->end(), _buff);
+			if (i != _allocLocs->end())
+				_allocLocs->erase(i);
+#endif
+		}
+		if (_lifes && !*_lifes)
+			delete _lifes;
+	}
+	WizRawPixel *operator()() const { return _buff; }
+	WizPxShrdBuffer &operator=(const WizPxShrdBuffer &other) {
+		if ((_lifes = other._lifes) != nullptr) ++*_lifes;
+		_buff = other._buff;
+#ifdef WIZ_DEBUG_BUFFERS
+		Common::Array<DbgEntry>::iterator i = Common::find(_allocLocs->begin(), _allocLocs->end(), _buff);
+		if (i != _allocLocs->end())
+			++i->crefs;
+#endif
+		return *this;
+	}
+	WizPxShrdBuffer &&operator=(WizPxShrdBuffer &&other) {
+		_lifes = other._lifes;
+		_buff = other._buff;
+		return Common::move(*this);
+	}
+	bool operator==(WizRawPixel *ptr) const { return _buff == ptr; }
+private:
+	WizRawPixel *_buff;
+	int *_lifes;
+};
+
 struct WizSimpleBitmap {
-	WizRawPixel *bufferPtr;
+	WizPxShrdBuffer bufferPtr;
 	int32 bitmapWidth;
 	int32 bitmapHeight;
 
-	WizSimpleBitmap() : bufferPtr(nullptr), bitmapWidth(0), bitmapHeight(0) {
+	WizSimpleBitmap() : bufferPtr(), bitmapWidth(0), bitmapHeight(0) {
 
 	}
 };
@@ -543,6 +629,11 @@ public:
 	WizRawPixel _compareBufferB[640];
 
 	Wiz(ScummEngine_v71he *vm);
+	~Wiz() {
+#ifdef WIZ_DEBUG_BUFFERS
+		WizPxShrdBuffer::dbgLeakRpt();
+#endif
+	}
 
 	void clearWizBuffer();
 	Common::Rect _wizClipRect;
@@ -622,13 +713,13 @@ public:
 	void takeAWiz(int globnum, int x1, int y1, int x2, int y2, bool back, bool compress);
 	void simpleDrawAWiz(int image, int state, int x, int y, int flags);
 	void bufferAWiz(int image, int state, int x, int y, int z, int flags, int optionalShadowImage, int optionalZBufferImage, int whichPalette);
-	byte *drawAWiz(int image, int state, int x, int y, int z, int flags, int optionalShadowImage, int optionalZBufferImage,
+	WizPxShrdBuffer &&drawAWiz(int image, int state, int x, int y, int z, int flags, int optionalShadowImage, int optionalZBufferImage,
 				   Common::Rect *optionalClipRect, int whichPalette, WizSimpleBitmap *optionalBitmapOverride);
-	byte *drawAWizEx(int image, int state, int x, int y, int z, int flags, int optionalShadowImage, int optionalZBufferImage, Common::Rect *optionalClipRect,
+	WizPxShrdBuffer &&drawAWizEx(int image, int state, int x, int y, int z, int flags, int optionalShadowImage, int optionalZBufferImage, Common::Rect *optionalClipRect,
 					 int whichPalette, WizSimpleBitmap *optionalBitmapOverride, const WizImageCommand *optionalICmdPtr);
-	void *drawAWizPrim(int globNum, int state, int x, int y, int z, int shadowImage, int zbufferImage, const Common::Rect *optionalClipRect, int flags, WizSimpleBitmap *optionalBitmapOverride, const WizRawPixel *optionalColorConversionTable);
-	void *drawAWizPrimEx(int globNum, int state, int x, int y, int z, int shadowImage, int zbufferImage, const Common::Rect *optionalClipRect, int flags, WizSimpleBitmap *optionalBitmapOverride, const WizRawPixel *optionalColorConversionTable, const WizImageCommand *optionalICmdPtr);
-	void buildAWiz(const WizRawPixel *bufPtr, int bufWidth, int bufHeight, const byte *palettePtr, const Common::Rect *rectPtr, int compressionType, int globNum, int transparentColor);
+	WizPxShrdBuffer &&drawAWizPrim(int globNum, int state, int x, int y, int z, int shadowImage, int zbufferImage, const Common::Rect *optionalClipRect, int flags, WizSimpleBitmap *optionalBitmapOverride, const WizRawPixel *optionalColorConversionTable);
+	WizPxShrdBuffer &&drawAWizPrimEx(int globNum, int state, int x, int y, int z, int shadowImage, int zbufferImage, const Common::Rect *optionalClipRect, int flags, WizSimpleBitmap *optionalBitmapOverride, const WizRawPixel *optionalColorConversionTable, const WizImageCommand *optionalICmdPtr);
+	void buildAWiz(const WizPxShrdBuffer &bufPtr, int bufWidth, int bufHeight, const byte *palettePtr, const Common::Rect *rectPtr, int compressionType, int globNum, int transparentColor);
 
 	int	pixelHitTestWiz(int image, int state, int x, int y, int32 flags);
 	int pixelHitTestWizPrim(int image, int state, int x, int y, int32 flags);

--- a/engines/scumm/he/wizwarp_he.cpp
+++ b/engines/scumm/he/wizwarp_he.cpp
@@ -77,7 +77,7 @@ bool Wiz::warpDrawWiz(int image, int state, int polygon, int32 flags, int transp
 
 bool Wiz::warpDrawWizTo4Points(int image, int state, const WarpWizPoint *dstPoints, int32 flags, int transparentColor, const Common::Rect *optionalClipRect, WizSimpleBitmap *optionalDestBitmap, const WizRawPixel *optionalColorConversionTable, const byte *colorMixTable) {
 	WizSimpleBitmap dstBitmap, srcBitmap;
-	bool rValue, freeBitmapBits;
+	bool rValue;
 	Common::Rect updateRect;
 	int x, y;
 	WarpWizPoint srcPoints[4];
@@ -97,8 +97,6 @@ bool Wiz::warpDrawWizTo4Points(int image, int state, const WarpWizPoint *dstPoin
 		if (!srcBitmap.bufferPtr()) {
 			return false;
 		}
-
-		freeBitmapBits = true;
 	} else {
 		ptr = (byte *)getWizStateDataPrim(image, state);
 		if (!ptr)
@@ -106,7 +104,6 @@ bool Wiz::warpDrawWizTo4Points(int image, int state, const WarpWizPoint *dstPoin
 
 		// Map the srcBitmap to the Wiz data...
 		srcBitmap.bufferPtr = WizPxShrdBuffer(ptr + _vm->_resourceHeaderSize, false);
-		freeBitmapBits = false;
 	}
 
 	// Fill in the dest bitmap structure...
@@ -127,15 +124,7 @@ bool Wiz::warpDrawWizTo4Points(int image, int state, const WarpWizPoint *dstPoin
 			error("Wiz::warpDrawWizTo4Points(): Missing drawing buffer?");
 		}
 
-		if (_uses16BitColor) {
-			WizRawPixel16 *buf16 = (WizRawPixel16 *)dstBitmap.bufferPtr();
-			buf16 += pvs->xstart;
-			dstBitmap.bufferPtr = WizPxShrdBuffer(buf16, false);
-		} else {
-			WizRawPixel8 *buf8 = (WizRawPixel8 *)dstBitmap.bufferPtr();
-			buf8 += pvs->xstart;
-			dstBitmap.bufferPtr = WizPxShrdBuffer(buf8, false);
-		}
+		dstBitmap.bufferPtr += (pvs->xstart * (_uses16BitColor ? 2 : 1));
 	}
 
 	// Find the bounding rect and double check the coords...

--- a/engines/scumm/he/wizwarp_he.cpp
+++ b/engines/scumm/he/wizwarp_he.cpp
@@ -92,9 +92,9 @@ bool Wiz::warpDrawWizTo4Points(int image, int state, const WarpWizPoint *dstPoin
 	if ((getWizCompressionType(image, state) != kWCTNone) ||
 		(optionalColorConversionTable != nullptr) || (flags & (kWRFHFlip | kWRFVFlip | kWRFRemap))) {
 
-		srcBitmap.bufferPtr = (WizRawPixel *)drawAWizPrim(image, state, 0, 0, 0, 0, 0, 0, kWRFAlloc | flags, 0, optionalColorConversionTable);
+		srcBitmap.bufferPtr = drawAWizPrim(image, state, 0, 0, 0, 0, 0, 0, kWRFAlloc | flags, 0, optionalColorConversionTable);
 
-		if (!srcBitmap.bufferPtr) {
+		if (!srcBitmap.bufferPtr()) {
 			return false;
 		}
 
@@ -105,7 +105,7 @@ bool Wiz::warpDrawWizTo4Points(int image, int state, const WarpWizPoint *dstPoin
 			error("Wiz::warpDrawWizTo4Points(): Image %d missing data", image);
 
 		// Map the srcBitmap to the Wiz data...
-		srcBitmap.bufferPtr = (WizRawPixel *)(ptr + _vm->_resourceHeaderSize);
+		srcBitmap.bufferPtr = WizPxShrdBuffer(ptr + _vm->_resourceHeaderSize, false);
 		freeBitmapBits = false;
 	}
 
@@ -118,23 +118,23 @@ bool Wiz::warpDrawWizTo4Points(int image, int state, const WarpWizPoint *dstPoin
 		dstBitmap.bitmapHeight = pvs->h;
 
 		if (flags & kWRFForeground) {
-			dstBitmap.bufferPtr = (WizRawPixel *)pvs->getPixels(0, pvs->topline);
+			dstBitmap.bufferPtr = WizPxShrdBuffer(pvs->getPixels(0, pvs->topline), false);
 		} else {
-			dstBitmap.bufferPtr = (WizRawPixel *)pvs->getBackPixels(0, pvs->topline);
+			dstBitmap.bufferPtr = WizPxShrdBuffer(pvs->getBackPixels(0, pvs->topline), false);
 		}
 
-		if (!dstBitmap.bufferPtr) {
+		if (!dstBitmap.bufferPtr()) {
 			error("Wiz::warpDrawWizTo4Points(): Missing drawing buffer?");
 		}
 
 		if (_uses16BitColor) {
-			WizRawPixel16 *buf16 = (WizRawPixel16 *)dstBitmap.bufferPtr;
+			WizRawPixel16 *buf16 = (WizRawPixel16 *)dstBitmap.bufferPtr();
 			buf16 += pvs->xstart;
-			dstBitmap.bufferPtr = (WizRawPixel *)buf16;
+			dstBitmap.bufferPtr = WizPxShrdBuffer(buf16, false);
 		} else {
-			WizRawPixel8 *buf8 = (WizRawPixel8 *)dstBitmap.bufferPtr;
+			WizRawPixel8 *buf8 = (WizRawPixel8 *)dstBitmap.bufferPtr();
 			buf8 += pvs->xstart;
-			dstBitmap.bufferPtr = (WizRawPixel *)buf8;
+			dstBitmap.bufferPtr = WizPxShrdBuffer(buf8, false);
 		}
 	}
 
@@ -202,10 +202,7 @@ bool Wiz::warpDrawWizTo4Points(int image, int state, const WarpWizPoint *dstPoin
 	}
 
 	// Clean up...
-	if (freeBitmapBits) {
-		free(srcBitmap.bufferPtr);
-		srcBitmap.bufferPtr = nullptr;
-	}
+	srcBitmap.bufferPtr = WizPxShrdBuffer();
 
 	return rValue;
 }
@@ -413,20 +410,20 @@ void Wiz::warpProcessDrawSpansA(WizSimpleBitmap *dstBitmap, const WizSimpleBitma
 	const WizRawPixel8 *src8;
 	const WizRawPixel16 *src16;
 
-	WizRawPixel8 *dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr;
-	WizRawPixel16 *dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr;
+	WizRawPixel8 *dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr();
+	WizRawPixel16 *dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr();
 
 	sw = srcBitmap->bitmapWidth;
 
-	src8 = (WizRawPixel8 *)srcBitmap->bufferPtr;
-	src16 = (WizRawPixel16 *)srcBitmap->bufferPtr;
+	src8 = (WizRawPixel8 *)srcBitmap->bufferPtr();
+	src16 = (WizRawPixel16 *)srcBitmap->bufferPtr();
 
 	for (int yCounter = count; --yCounter >= 0;) {
 		if (!_uses16BitColor) {
-			dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr;
+			dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr();
 			dst8 += drawSpans->dstOffset;
 		} else {
-			dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr;
+			dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr();
 			dst16 += drawSpans->dstOffset;
 		}
 
@@ -453,11 +450,11 @@ void Wiz::warpProcessDrawSpansA(WizSimpleBitmap *dstBitmap, const WizSimpleBitma
 void Wiz::warpProcessDrawSpansTransparent(WizSimpleBitmap *dstBitmap, const WizSimpleBitmap *srcBitmap, const WarpWizOneDrawSpan *drawSpans, int count, WizRawPixel transparentColor) {
 	int xStep, yStep, sw, xOffset, yOffset;
 
-	const WizRawPixel8 *src8 = (WizRawPixel8 *)srcBitmap->bufferPtr;
-	const WizRawPixel16 *src16 = (WizRawPixel16 *)srcBitmap->bufferPtr;
+	const WizRawPixel8 *src8 = (WizRawPixel8 *)srcBitmap->bufferPtr();
+	const WizRawPixel16 *src16 = (WizRawPixel16 *)srcBitmap->bufferPtr();
 
-	WizRawPixel8 *dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr;
-	WizRawPixel16 *dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr;
+	WizRawPixel8 *dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr();
+	WizRawPixel16 *dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr();
 
 	WizRawPixel srcColor;
 
@@ -465,10 +462,10 @@ void Wiz::warpProcessDrawSpansTransparent(WizSimpleBitmap *dstBitmap, const WizS
 
 	for (int yCounter = count; --yCounter >= 0;) {
 		if (!_uses16BitColor) {
-			dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr;
+			dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr();
 			dst8 += drawSpans->dstOffset;
 		} else {
-			dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr;
+			dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr();
 			dst16 += drawSpans->dstOffset;
 		}
 
@@ -505,8 +502,8 @@ void Wiz::warpProcessDrawSpansTransparent(WizSimpleBitmap *dstBitmap, const WizS
 void Wiz::warpProcessDrawSpansTransparentFiltered(WizSimpleBitmap *dstBitmap, const WizSimpleBitmap *srcBitmap, const WarpWizOneDrawSpan *drawSpans, int count, WizRawPixel transparentColor, const byte *pXmapColorTable, bool bIsHintColor, WizRawPixel hintColor) {
 	int srcWidth = srcBitmap->bitmapWidth;
 
-	const WizRawPixel8 *src8 = (WizRawPixel8 *)srcBitmap->bufferPtr;
-	const WizRawPixel16 *src16 = (WizRawPixel16 *)srcBitmap->bufferPtr;
+	const WizRawPixel8 *src8 = (WizRawPixel8 *)srcBitmap->bufferPtr();
+	const WizRawPixel16 *src16 = (WizRawPixel16 *)srcBitmap->bufferPtr();
 
 	bool bSkipFilter = false;
 
@@ -514,8 +511,8 @@ void Wiz::warpProcessDrawSpansTransparentFiltered(WizSimpleBitmap *dstBitmap, co
 	WizRawPixel srcColor, srcColorN, srcColorS, srcColorE, srcColorW;
 	int iCurrentX, iCurrentY, iXScan, iYScan;
 
-	WizRawPixel8 *dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr;
-	WizRawPixel16 *dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr;
+	WizRawPixel8 *dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr();
+	WizRawPixel16 *dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr();
 
 	// Set up a rect for clipping if needed
 	Common::Rect aSrcRect;  // Source rectangle for clipping...
@@ -528,10 +525,10 @@ void Wiz::warpProcessDrawSpansTransparentFiltered(WizSimpleBitmap *dstBitmap, co
 
 	for (int yCounter = count; --yCounter >= 0;) {
 		if (!_uses16BitColor) {
-			dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr;
+			dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr();
 			dst8 += drawSpans->dstOffset;
 		} else {
-			dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr;
+			dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr();
 			dst16 += drawSpans->dstOffset;
 		}
 
@@ -727,20 +724,20 @@ void Wiz::warpProcessDrawSpansMixColors(WizSimpleBitmap *dstBitmap, const WizSim
 	int xStep, yStep, sw, xOffset, yOffset;
 	WizRawPixel srcColor;
 
-	const WizRawPixel8 *src8 = (WizRawPixel8 *)srcBitmap->bufferPtr;
-	const WizRawPixel16 *src16 = (WizRawPixel16 *)srcBitmap->bufferPtr;
+	const WizRawPixel8 *src8 = (WizRawPixel8 *)srcBitmap->bufferPtr();
+	const WizRawPixel16 *src16 = (WizRawPixel16 *)srcBitmap->bufferPtr();
 
-	WizRawPixel8 *dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr;
-	WizRawPixel16 *dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr;
+	WizRawPixel8 *dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr();
+	WizRawPixel16 *dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr();
 
 	sw = srcBitmap->bitmapWidth;
 
 	for (int yCounter = count; --yCounter >= 0;) {
 		if (!_uses16BitColor) {
-			dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr;
+			dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr();
 			dst8 += drawSpans->dstOffset;
 		} else {
-			dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr;
+			dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr();
 			dst16 += drawSpans->dstOffset;
 		}
 
@@ -832,10 +829,10 @@ void Wiz::warpFillSpanWithLine(WarpWizOneSpanTable *st, const WarpWizPoint *dstA
 
 void Wiz::warpProcessDrawSpansSampled(WizSimpleBitmap *dstBitmap, const WizSimpleBitmap *srcBitmap, const WarpWizOneDrawSpan *drawSpans, int count) {
 	// Setup read pointer and clipping limits for the sampling rect...
-	const WizRawPixel8 *src8 = (WizRawPixel8 *)srcBitmap->bufferPtr;
-	const WizRawPixel16 *src16 = (WizRawPixel16 *)srcBitmap->bufferPtr;
-	WizRawPixel8 *dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr;
-	WizRawPixel16 *dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr;
+	const WizRawPixel8 *src8 = (WizRawPixel8 *)srcBitmap->bufferPtr();
+	const WizRawPixel16 *src16 = (WizRawPixel16 *)srcBitmap->bufferPtr();
+	WizRawPixel8 *dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr();
+	WizRawPixel16 *dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr();
 
 	int sw = srcBitmap->bitmapWidth;
 	int srcXLimit = (srcBitmap->bitmapWidth - 1);
@@ -844,10 +841,10 @@ void Wiz::warpProcessDrawSpansSampled(WizSimpleBitmap *dstBitmap, const WizSimpl
 	// Process all of the spans in this span collection...
 	for (int yCounter = count; --yCounter >= 0;) {
 		if (!_uses16BitColor) {
-			dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr;
+			dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr();
 			dst8 += drawSpans->dstOffset;
 		} else {
-			dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr;
+			dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr();
 			dst16 += drawSpans->dstOffset;
 		}
 
@@ -945,10 +942,10 @@ void Wiz::warpProcessDrawSpansSampled(WizSimpleBitmap *dstBitmap, const WizSimpl
 
 void Wiz::warpProcessDrawSpansTransparentSampled(WizSimpleBitmap *dstBitmap, const WizSimpleBitmap *srcBitmap, const WarpWizOneDrawSpan *drawSpans, int count, WizRawPixel transparentColor) {
 	// Setup read pointer and clipping limits for the sampling rect...
-	const WizRawPixel8 *src8 = (WizRawPixel8 *)srcBitmap->bufferPtr;
-	const WizRawPixel16 *src16 = (WizRawPixel16 *)srcBitmap->bufferPtr;
-	WizRawPixel8 *dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr;
-	WizRawPixel16 *dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr;
+	const WizRawPixel8 *src8 = (WizRawPixel8 *)srcBitmap->bufferPtr();
+	const WizRawPixel16 *src16 = (WizRawPixel16 *)srcBitmap->bufferPtr();
+	WizRawPixel8 *dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr();
+	WizRawPixel16 *dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr();
 
 	int sw = srcBitmap->bitmapWidth;
 	int srcXLimit = (srcBitmap->bitmapWidth - 1);
@@ -957,10 +954,10 @@ void Wiz::warpProcessDrawSpansTransparentSampled(WizSimpleBitmap *dstBitmap, con
 	// Process all of the spans in this span collection...
 	for (int yCounter = count; --yCounter >= 0;) {
 		if (!_uses16BitColor) {
-			dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr;
+			dst8 = (WizRawPixel8 *)dstBitmap->bufferPtr();
 			dst8 += drawSpans->dstOffset;
 		} else {
-			dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr;
+			dst16 = (WizRawPixel16 *)dstBitmap->bufferPtr();
 			dst16 += drawSpans->dstOffset;
 		}
 


### PR DESCRIPTION
Currently, buffers get allocated that do not get freed. Apparently, the reason is that it is not well known when it is actually safe to do that.
The spy watch mini game in Spy Fox 3 leaks A LOT.  This here should hopefully fix the situation. Or at least give some inspiration on how to fix it...
