### PR TITLE
SCUMM HE: Backyard Baseball 2001 competitive changes

### DIFF
--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -495,6 +495,80 @@ void ScummEngine_v6::o6_pushByteVar() {
 }
 
 void ScummEngine_v6::o6_pushWordVar() {
+	#if defined(USE_ENET) && defined(USE_LIBCURL)
+		if (ConfMan.getBool("enable_competitive_mods")) {
+			// Sprinting in competitive Backyard Baseball is considered too weak in its current state. This will increase how effective
+			// it is, limiting the highest speed characters enough to where they cannot go TOO fast.
+			if (_game.id == GID_BASEBALL2001 && _currentRoom == 3 && vm.slot[_currentScript].number == 2095 && readVar(399) == 1) {
+				int offset = _scriptPointer - _scriptOrgPointer;
+				int sprintCounter = readArray(344, vm.localvar[_currentScript][0], 1);
+				int sprintGain = vm.localvar[_currentScript][4];
+				if (offset == 42273) {
+					if (sprintCounter >= 11) {
+						if (vm.localvar[_currentScript][5] == 12 || vm.localvar[_currentScript][5] == 11 || vm.localvar[_currentScript][5] == 10) {
+							sprintGain = 2;
+						} else if (vm.localvar[_currentScript][5] == 9) {
+							sprintGain = 3;
+						} else {
+							sprintGain = 4;
+						}
+					} else if (sprintCounter >= 9) {
+						if (vm.localvar[_currentScript][5] == 12 || vm.localvar[_currentScript][5] == 11 || vm.localvar[_currentScript][5] == 10) {
+							sprintGain = 2;
+						} else {
+							sprintGain = 3;
+						}
+					} else if (sprintCounter >= 7) {
+							sprintGain = 2;
+					} else {
+						sprintGain = 1;
+					}
+					writeVar(0x4000 + 4, sprintGain);
+				}
+			}
+
+			// This code will change the velocity of the hit based on the pitch thrown, and the location of the pitch itself.
+			if (_game.id == GID_BASEBALL2001 && _currentRoom == 4 && vm.slot[_currentScript].number == 2090 && readVar(399) == 1) {
+				int offset = _scriptPointer - _scriptOrgPointer;
+				int powerAdjustment = vm.localvar[_currentScript][4];
+
+				// Checks if the swing is either Power or Line Drive
+				if (offset == 102789 && (readVar(387) == 1||readVar(387) == 2)) {
+					// Checks if the current pitch type is the same as that of the "remembered" pitch type
+					if (readArray(346, 0, 0) == readArray(346, 1, 0)) {
+						// Checks if the current pitch is either a Heat or a Fireball. The reason it adds less than the other pitches
+						// is because in the actual calculation it adds 5 to these two anyway, so this should also balance them out.
+						if (readVar(0x8000 + 10) == 14 || readVar(0x8000 + 10) == 21) {
+							powerAdjustment = powerAdjustment + 15;
+						} else {
+							powerAdjustment = powerAdjustment + 20;
+						}
+					}
+					// Checks if the zone location is the same as that of the previous one. This should slightly reduce the amount of pitching to the exact same location.
+					// Can also be adjusted later if necessary.
+					if (readArray(346, 0, 1) == readArray(346, 1, 1)) {
+						powerAdjustment = powerAdjustment + 20;
+					}
+
+					// write the power adjustment to the result
+					writeVar(0x4000 + 4, powerAdjustment);
+				}
+			}
+
+			// Remember the previous pitch thrown and the previous pitch "zone location", then set those two values to the "remembered" values for later use.
+			if (_game.id == GID_BASEBALL2001 && _currentRoom == 4 && vm.slot[_currentScript].number == 2201 && readVar(399) == 1) {
+				writeArray(346, 1, 0, readArray(346, 0, 0));
+				writeArray(346, 1, 1, readArray(346, 0, 1));
+			}
+
+			// This sets the base cost of a slow ball to 2. Previously it costed the least of every pitch to throw, which resulted in people only using that pitch.
+			if (_game.id == GID_BASEBALL2001 && _currentRoom == 4 && vm.slot[_currentScript].number == 2057 && readVar(399) == 1) {
+				if (readVar(0x4000 + 1) == 15) {
+					writeVar(0x4000 + 2, 2);
+				}
+			}
+		}
+	#endif
 	push(readVar(fetchScriptWord()));
 }
 
@@ -555,6 +629,105 @@ void ScummEngine_v6::o6_eq() {
 	int a = pop();
 	int b = pop();
 
+// BACKYARD BASEBALL 2001 ONLINE CHANGES
+#if defined(USE_ENET) && defined(USE_LIBCURL)
+	if (ConfMan.getBool("enable_competitive_mods")) {
+			// People have been complaining about strikes being visually unclear during online games. This is because the strike zone's visual is not
+			// equal length compared to the actual range in which a strike can be called. These changes should fix that, with some extra leniency in
+			// the corners in particular since they are especially difficult to see visually, due to having four large corner pieces blocking the view.
+
+			// This checks if the pitch's y location is either:
+			// a. at least 2 pixels lower than the top of the zone/at least 3 pixels above the bottom of the zone
+			// b. at least 2 pixels lower than the top of the zone/at least 3 pixels above the bottom of the zone
+			// If either of these are true AND the x value is less than or equal to 279 OR greater than or equal to 354, make the game read as a ball.
+			// The strike zone should be much more lenient in the corners, as well as removing the small advantage of throwing to the farthest right side of the zone.
+			if (_game.id == GID_BASEBALL2001 && _currentRoom == 4 && (vm.slot[_currentScript].number == 2202 || vm.slot[_currentScript].number == 2192) && readVar(399) == 1) {
+				if (((readVar(0x8000 + 12) <= readVar(0x8000 + 29) + 2 || readVar(0x8000 + 12) >= readVar(0x8000 + 30) - 3) && readVar(0x8000 + 11) <= 279) ||
+					((readVar(0x8000 + 12) <= readVar(0x8000 + 29) + 2 || readVar(0x8000 + 12) >= readVar(0x8000 + 30) - 3) && readVar(0x8000 + 11) >= 354)) {
+					writeVar(0x8000 + 16, 2);
+				}
+				// if the ball's y location is 1 pixel higher than the bottom of the zone, then it will be a ball.
+				// This removes the small advantage of throwing at the very bottom of the zone.
+				if (readVar(0x8000 + 12) > readVar(0x8000 + 30) - 1) {
+					writeVar(0x8000 + 16, 2);
+				}
+			}
+
+		// This change affects the angle adjustment for each batting stance when timing your swing. There are complaints that
+		// the game does not give you enough control when batting, resulting in a lot of hits going to the same area. This should
+		// give players more agency on where they want to hit the ball, which will also increase the skill ceiling.
+		if (_game.id == GID_BASEBALL2001 && _currentRoom == 4 && vm.slot[_currentScript].number == 2087 && readVar(399) == 1) {
+			int offset = _scriptPointer - _scriptOrgPointer;
+			// OPEN STANCE ADJUSTMENTS (1 being earliest, 5 being latest)
+			if (offset == 101898 && readVar(447) == 1) {
+				switch (readVar(0x8000 + 1)) {
+				case 1:
+					writeVar(0x4000 + 0, -13);
+					break;
+				case 2:
+					writeVar(0x4000 + 0, -2);
+					break;
+				case 3:
+					writeVar(0x4000 + 0, 10);
+					break;
+				case 4:
+					writeVar(0x4000 + 0, 40);
+					break;
+				case 5:
+					writeVar(0x4000 + 0, 63);
+					break;
+				}
+			}
+			// SQUARED STANCE ADJUSTMENTS (1 being earliest, 5 being latest)
+			if (offset == 101898 && readVar(447) == 2) {
+				switch (readVar(0x8000 + 1)) {
+				case 1:
+					writeVar(0x4000 + 0, -30);
+					break;
+				case 2:
+					writeVar(0x4000 + 0, -7);
+					break;
+				case 3:
+					writeVar(0x4000 + 0, 10);
+					break;
+				case 4:
+					writeVar(0x4000 + 0, 27);
+					break;
+				case 5:
+					writeVar(0x4000 + 0, 45);
+					break;
+				}
+			}
+			// CLOSED STANCE ADJUSTMENTS (1 being earliest, 5 being latest)
+			if (offset == 101898 && readVar(447) == 3) {
+				switch (readVar(0x8000 + 1)) {
+				case 1:
+					writeVar(0x4000 + 0, -47);
+					break;
+				case 2:
+					writeVar(0x4000 + 0, -32);
+					break;
+				case 3:
+					writeVar(0x4000 + 0, 0);
+					break;
+				case 4:
+					writeVar(0x4000 + 0, 15);
+					break;
+				case 5:
+					writeVar(0x4000 + 0, 28);
+					break;
+				}
+			}
+		}
+
+		// This code makes it so that generic players (and Mr. Clanky) play pro player music when hitting home runs.
+		// This is a purely aesthetic change, as they have no home run music by default.
+		if (_game.id == GID_BASEBALL2001 && _currentRoom == 3 && vm.slot[_currentScript].number == 11 && vm.localvar[_currentScript][0] > 61 && readVar(399) == 1) {
+			writeVar(0x4000 + 0, 60);
+		}
+	}
+#endif
+	
 #if defined(USE_ENET) && defined(USE_LIBCURL)
 	int offset = _scriptPointer - _scriptOrgPointer;
 	// WORKAROUND: In Backyard Baseball 2001, The special rules of the Mountain Aire and Wilderness neighborhoods


### PR DESCRIPTION
These are competitive balance changes made for Backyard Baseball 2001's online mode, specifically when the "Enable online competitive mods" setting is checked.

All of these changes were discussed very heavily among the Backyard Sports Online community over the past half year or so. After some private tests on my own they seem to work well enough to make a pull request for! It's likely that I will have to make more adjustments in the future as people play with the changes, since it's a lot all at once and this is my first time making changes to the game like this. shkupfer also posted a change earlier this week which I did not include but is supposed to be part of the competitive update (hopefully he can update the description for it soon).

**Changes:**
- The strike zone is adjusted to better match the graphic. (The strike zone is slightly larger than the graphic suggests, leading to a lot of pitches in the corners and on the bottom and right sides to be strikes when they don't look like they should be.)

- Slow Ball now costs slightly more stamina to use. (now it's more in line with the other regular pitches.)

- Throwing the same pitch twice in a row and/or in the same location, now adds velocity to the ball when you hit it. (This mechanic was previously AI exclusive but is now used for human coaches. We're testing it out for online mode to enforce people to pitch more tactically.)

- The timing of your swing has much greater impact on the direction you hit the ball. (Previously it only slightly impacted the angle, but it was not noticeable enough. Naturally this led to frustration as it felt like the player had little control of where the ball went when they hit it.)

- The "sprinting" function now makes players move much faster than before.