### PR TITLE
GUI: Fix saveload display of selected empty items

### DIFF
--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -740,6 +740,7 @@ void SaveLoadChooserSimple::updateSaveList() {
 	int saveSlot = 0;
 	Common::U32StringArray saveNames;
 	ThemeEngine::FontColor color = ThemeEngine::kFontColorNormal;
+	Common::U32String emptyDesc;
 	for (SaveStateList::const_iterator x = _saveList.begin(); x != _saveList.end(); ++x) {
 		// Handle gaps in the list of save games
 		saveSlot = x->getSaveSlot();
@@ -747,7 +748,7 @@ void SaveLoadChooserSimple::updateSaveList() {
 			while (curSlot < saveSlot) {
 				SaveStateDescriptor dummySave(_metaEngine, curSlot, "");
 				_saveList.insert_at(curSlot, dummySave);
-				saveNames.push_back(GUI::ListWidget::getThemeColor(color) + dummySave.getDescription());
+				saveNames.push_back(emptyDesc);
 				curSlot++;
 			}
 
@@ -785,8 +786,6 @@ void SaveLoadChooserSimple::updateSaveList() {
 	}
 #endif
 
-	Common::U32String emptyDesc;
-	color = ThemeEngine::kFontColorNormal;
 	for (int i = curSlot; i <= maximumSaveSlots; i++) {
 		saveNames.push_back(emptyDesc);
 		SaveStateDescriptor dummySave(_metaEngine, i, "");


### PR DESCRIPTION
This PR fixes a minor display regression in the save-load list dialog introduced two years ago: 829c600a02ad6124006ae8cc784a873f52140637

That commit altered how *some* empty slots are rendered when selected. Empty slots that appear before the last save stopped drawing selection color over the text area. Empty slots that appear after the last save continue to correctly draw the selection color across the row.

![gap](https://github.com/scummvm/scummvm/assets/22204938/3cd88d11-df01-42e5-89a7-d9032d3621a6)

![end](https://github.com/scummvm/scummvm/assets/22204938/e0d23a29-d871-4642-9f2f-4e743f0f51e2)

It looks to me like there are two bugs in the code:
1. The code blocks for creating empty "gap" slots and empty "end" slots are inconsistent.
2. Rendering an item with an empty string produces a much different result than rendering an item with an empty string *and* an embedded text color, even though there is no text to color.

I am only addressing the first bug because it's easy, because I selfishly only care about this one symptom, and because I'm unfamiliar with the color code. If it's not intentional, consider this a bug report @sev- =)

My change reverts the attempt to set a text color on an empty string; now the code blocks are in sync. Even if there was text to color, I don't think it would have worked, because it uses the stale color from the previous loop iteration, so it was unpredictable.

