### PR TITLE
GUI: Save/Load list input improvements

### DIFF
--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -444,6 +444,7 @@ SaveLoadChooserSimple::SaveLoadChooserSimple(const Common::U32String &title, con
 	_list = new ListWidget(this, "SaveLoadChooser.List");
 	_list->setNumberingMode(kListNumberingZero);
 	_list->setEditable(saveMode);
+	_list->enableQuickSelect(false); // quick select is only useful on sorted list
 
 	_gfxWidget = new GraphicsWidget(this, 0, 0, 10, 10);
 

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -406,11 +406,7 @@ bool ListWidget::handleKeyDown(Common::KeyState state) {
 		case Common::KEYCODE_BACKSPACE:
 		case Common::KEYCODE_DELETE:
 			if (_selectedItem >= 0) {
-				if (_editable) {
-					// Ignore delete and backspace when the list item is editable
-				} else {
-					sendCommand(kListItemRemovalRequestCmd, _selectedItem);
-				}
+				sendCommand(kListItemRemovalRequestCmd, _selectedItem);
 			}
 			break;
 

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -262,11 +262,15 @@ void ListWidget::handleMouseDown(int x, int y, int button, int clickCount) {
 		sendCommand(kListSelectionChangedCmd, _selectedItem);
 	}
 
+	// Notify clients if an item was clicked
+	if (newSelectedItem >= 0) {
+		sendCommand(kListItemSingleClickedCmd, _selectedItem);
+	}
+
 	// TODO: Determine where inside the string the user clicked and place the
 	// caret accordingly.
 	// See _editScrollOffset and EditTextWidget::handleMouseDown.
 	markAsDirty();
-
 }
 
 void ListWidget::handleMouseUp(int x, int y, int button, int clickCount) {
@@ -685,6 +689,7 @@ void ListWidget::startEditMode() {
 		_editColor = ThemeEngine::kFontColorNormal;
 		markAsDirty();
 		g_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, true);
+		sendCommand(kListItemEditModeStartedCmd, _selectedItem);
 	}
 }
 

--- a/gui/widgets/list.h
+++ b/gui/widgets/list.h
@@ -39,9 +39,11 @@ enum NumberingMode {
 
 /// Some special commands
 enum {
-	kListItemDoubleClickedCmd	= 'LIdb',	///< double click on item - 'data' will be item index
+	kListItemSingleClickedCmd	= 'LIsc',	///< single click on item (sent on mouse down) - 'data' will be item index
+	kListItemDoubleClickedCmd	= 'LIdc',	///< double click on item (sent on mouse up) - 'data' will be item index
 	kListItemActivatedCmd		= 'LIac',	///< item activated by return/enter - 'data' will be item index
 	kListItemRemovalRequestCmd	= 'LIrm',	///< request to remove the item with the delete/backspace keys - 'data' will be item index
+	kListItemEditModeStartedCmd = 'LIes',	///< edit mode started - 'data' will be item index
 	kListSelectionChangedCmd	= 'Lsch'	///< selection changed - 'data' will be item index
 };
 


### PR DESCRIPTION
This PR addresses a collection of overlapping input issues on my favorite dialog: the save/load list.

Most of these involve ListWidget's editable mode. The save list is the only editable ListWidget in ScummVM. There are two similar sounding states: editable (you *can* edit items) and edit mode (you're currently editing an item).

Behavior changes:
1. Save list can now be navigated with the keyboard, just like the restore list. Before, changing the selection with the keyboard automatically entered edit mode, so you couldn't press a navigation key more than once. The first key would select an item and the second key would be trapped by edit mode. Pressing the Enter key still enters edit mode. Selecting an item with the mouse still enters edit mode as before, but with a bugfix.
2. Bugfix: clicking on an already selected item in the save list that is *not* in edit mode now places it in edit mode, instead of doing nothing. You could only re-enter edit mode with the mouse by selecting a different item and then clicking back.
3. Pressing an alphanumeric key no longer selects an unpredictable list item. This is ListWidget's Quick Select feature, whose comment states: `Only works in a useful fashion if the list entries are sorted`. Now it's disabled, because this list is unsorted.
4. Pressing Delete or Backspace on the save list now works for deleting an item. Before, they only worked on the restore list, even though both have the same Delete button and functionality.
5. Deleting a save leaves the empty slot selected. Now you can navigate to another slot with the keyboard instead of starting over at the first slot when you press an arrow key. It's now less painful to delete save 80 and then select save 81.
6. Entering edit mode on an "Untitled Save" item now works even when pressing Enter. To reproduce this bug: select an "Untitled Save" item, press Escape to abort edit mode, and then press Enter.

These changes significantly improve the keyboard experience. If you don't use the keyboard then you won't see any differences, although a few rare edge cases are fixed.