### PR TITLE
TINYGL: initial implementation of tglPolygonStipple

### DIFF
--- a/graphics/tinygl/api.cpp
+++ b/graphics/tinygl/api.cpp
@@ -285,10 +285,11 @@ void tglStencilOp(TGLenum sfail, TGLenum dpfail, TGLenum dppass) {
 
 void tglPolygonStipple(const TGLubyte *mask) {
 	TinyGL::GLContext *c = TinyGL::gl_get_context();
-	TinyGL::GLParam p[2];
+	TinyGL::GLParam p[129];
 
 	p[0].op = TinyGL::OP_PolygonStipple;
-	c->polygon_stipple_pattern = (void *)mask;
+	for (int i = 0; i < 128; i++)
+		p[i + 1].ui = mask[i];
 
 	c->gl_add_op(p);
 }

--- a/graphics/tinygl/api.cpp
+++ b/graphics/tinygl/api.cpp
@@ -283,6 +283,16 @@ void tglStencilOp(TGLenum sfail, TGLenum dpfail, TGLenum dppass) {
 	c->gl_add_op(p);
 }
 
+void tglPolygonStipple(const TGLubyte *mask) {
+	TinyGL::GLContext *c = TinyGL::gl_get_context();
+	TinyGL::GLParam p[2];
+
+	p[0].op = TinyGL::OP_PolygonStipple;
+	c->polygon_stipple_pattern = (void *)mask;
+
+	c->gl_add_op(p);
+}
+
 void tglPolygonMode(TGLenum face, TGLenum mode) {
 	TinyGL::GLContext *c = TinyGL::gl_get_context();
 	TinyGL::GLParam p[3];

--- a/graphics/tinygl/init.cpp
+++ b/graphics/tinygl/init.cpp
@@ -298,6 +298,10 @@ void GLContext::init(int screenW, int screenH, Graphics::PixelFormat pixelFormat
 	depth_func = TGL_LESS;
 	depth_write_mask = true;
 
+	// stipple
+	polygon_stipple_enabled = false;
+	memset(polygon_stipple_pattern, 0, sizeof(polygon_stipple_pattern));
+
 	// stencil
 	stencil_test_enabled = false;
 	stencil_test_func = TGL_ALWAYS;

--- a/graphics/tinygl/init.cpp
+++ b/graphics/tinygl/init.cpp
@@ -300,7 +300,7 @@ void GLContext::init(int screenW, int screenH, Graphics::PixelFormat pixelFormat
 
 	// stipple
 	polygon_stipple_enabled = false;
-	memset(polygon_stipple_pattern, 0, sizeof(polygon_stipple_pattern));
+	memset(polygon_stipple_pattern, 0xff, sizeof(polygon_stipple_pattern));
 
 	// stencil
 	stencil_test_enabled = false;

--- a/graphics/tinygl/misc.cpp
+++ b/graphics/tinygl/misc.cpp
@@ -93,6 +93,9 @@ void GLContext::glopEnableDisable(GLParam *p) {
 	case TGL_ALPHA_TEST:
 		alpha_test_enabled = v != 0;
 		break;
+	case TGL_POLYGON_STIPPLE:
+		polygon_stipple_enabled = v != 0;
+		break;
 	case TGL_STENCIL_TEST:
 		stencil_test_enabled = v != 0;
 		break;
@@ -199,6 +202,10 @@ void GLContext::glopPolygonMode(GLParam *p) {
 
 void GLContext::glopHint(GLParam *) {
 	// do nothing
+}
+
+void GLContext::glopPolygonStipple(GLParam *p) {
+	// do nothing?
 }
 
 void GLContext::glopPolygonOffset(GLParam *p) {

--- a/graphics/tinygl/misc.cpp
+++ b/graphics/tinygl/misc.cpp
@@ -205,7 +205,9 @@ void GLContext::glopHint(GLParam *) {
 }
 
 void GLContext::glopPolygonStipple(GLParam *p) {
-	// do nothing?
+	for (int i = 0; i < 128; i++) {
+		polygon_stipple_pattern[i] = p[i + 1].ui;
+	}
 }
 
 void GLContext::glopPolygonOffset(GLParam *p) {

--- a/graphics/tinygl/opinfo.h
+++ b/graphics/tinygl/opinfo.h
@@ -84,6 +84,8 @@ ADD_OP(DepthFunc, 1, "%d")
 ADD_OP(StencilFunc, 3, "%C %d %d")
 ADD_OP(StencilOp, 3, "%C %C %C")
 
+ADD_OP(PolygonStipple, 1, "%d")
+
 ADD_OP(Fog, 5, "%d %f %f %f %f")
 
 ADD_OP(CallList, 1, "%d")

--- a/graphics/tinygl/opinfo.h
+++ b/graphics/tinygl/opinfo.h
@@ -84,7 +84,7 @@ ADD_OP(DepthFunc, 1, "%d")
 ADD_OP(StencilFunc, 3, "%C %d %d")
 ADD_OP(StencilOp, 3, "%C %C %C")
 
-ADD_OP(PolygonStipple, 1, "%d")
+ADD_OP(PolygonStipple, 128, "%d")
 
 ADD_OP(Fog, 5, "%d %f %f %f %f")
 
@@ -101,6 +101,6 @@ ADD_OP(DrawArrays, 3, "%C %d %d")
 ADD_OP(DrawElements, 4, "%C %d %C %p")
 
 // opengl 1.1 polygon offset
-ADD_OP(PolygonOffset, 128, "%f %f")
+ADD_OP(PolygonOffset, 2, "%f %f")
 
 #undef ADD_OP

--- a/graphics/tinygl/opinfo.h
+++ b/graphics/tinygl/opinfo.h
@@ -101,6 +101,6 @@ ADD_OP(DrawArrays, 3, "%C %d %d")
 ADD_OP(DrawElements, 4, "%C %d %C %p")
 
 // opengl 1.1 polygon offset
-ADD_OP(PolygonOffset, 2, "%f %f")
+ADD_OP(PolygonOffset, 128, "%f %f")
 
 #undef ADD_OP

--- a/graphics/tinygl/zbuffer.h
+++ b/graphics/tinygl/zbuffer.h
@@ -619,7 +619,7 @@ public:
 		_polygonStippleEnabled = enable;
 	}
 
-	void setPolygonStipplePattern(void *stipple) {
+	void setPolygonStipplePattern(byte *stipple) {
 		_polygonStipplePattern = stipple;
 	}
 
@@ -791,7 +791,7 @@ private:
 	int _stencilDppass;
 
 	bool _polygonStippleEnabled;
-	void *_polygonStipplePattern;
+	byte *_polygonStipplePattern;
 	int _depthFunc;
 	int _offsetStates;
 	float _offsetFactor;

--- a/graphics/tinygl/zbuffer.h
+++ b/graphics/tinygl/zbuffer.h
@@ -619,7 +619,7 @@ public:
 		_polygonStippleEnabled = enable;
 	}
 
-	void setPolygonStipplePattern(byte *stipple) {
+	void setPolygonStipplePattern(const byte *stipple) {
 		_polygonStipplePattern = stipple;
 	}
 
@@ -791,7 +791,7 @@ private:
 	int _stencilDppass;
 
 	bool _polygonStippleEnabled;
-	byte *_polygonStipplePattern;
+	const byte *_polygonStipplePattern;
 	int _depthFunc;
 	int _offsetStates;
 	float _offsetFactor;

--- a/graphics/tinygl/zbuffer.h
+++ b/graphics/tinygl/zbuffer.h
@@ -361,7 +361,7 @@ private:
 	                       int &dzdx, int &drdx, int &dgdx, int &dbdx, uint dadx,
 	                       uint &fog, int fog_r, int fog_g, int fog_b, int &dfdx);
 
-	template <bool kDepthWrite, bool kLightsMode, bool kSmoothMode, bool kFogMode, bool kEnableAlphaTest, bool kEnableScissor, bool kEnableBlending, bool kStencilEnabled, bool kStippleEnabled, bool kDepthTestEnabled>
+	template <bool kDepthWrite, bool kLightsMode, bool kSmoothMode, bool kFogMode, bool kEnableAlphaTest, bool kEnableScissor, bool kEnableBlending, bool kStencilEnabled, bool kDepthTestEnabled>
 	void putPixelTexture(int fbOffset, const TexelBuffer *texture,
 	                     uint wrap_s, uint wrap_t, uint *pz, byte *ps, int _a,
 	                     int x, int y, uint &z, int &t, int &s,

--- a/graphics/tinygl/zbuffer.h
+++ b/graphics/tinygl/zbuffer.h
@@ -355,13 +355,13 @@ private:
 		}
 	}
 
-	template <bool kDepthWrite, bool kSmoothMode, bool kFogMode, bool kEnableAlphaTest, bool kEnableScissor, bool kEnableBlending, bool kStencilEnabled, bool kDepthTestEnabled>
+	template <bool kDepthWrite, bool kSmoothMode, bool kFogMode, bool kEnableAlphaTest, bool kEnableScissor, bool kEnableBlending, bool kStencilEnabled, bool kStippleEnabled, bool kDepthTestEnabled>
 	void putPixelNoTexture(int fbOffset, uint *pz, byte *ps, int _a,
 	                       int x, int y, uint &z, uint &r, uint &g, uint &b, uint &a,
 	                       int &dzdx, int &drdx, int &dgdx, int &dbdx, uint dadx,
 	                       uint &fog, int fog_r, int fog_g, int fog_b, int &dfdx);
 
-	template <bool kDepthWrite, bool kLightsMode, bool kSmoothMode, bool kFogMode, bool kEnableAlphaTest, bool kEnableScissor, bool kEnableBlending, bool kStencilEnabled, bool kDepthTestEnabled>
+	template <bool kDepthWrite, bool kLightsMode, bool kSmoothMode, bool kFogMode, bool kEnableAlphaTest, bool kEnableScissor, bool kEnableBlending, bool kStencilEnabled, bool kStippleEnabled, bool kDepthTestEnabled>
 	void putPixelTexture(int fbOffset, const TexelBuffer *texture,
 	                     uint wrap_s, uint wrap_t, uint *pz, byte *ps, int _a,
 	                     int x, int y, uint &z, int &t, int &s,
@@ -369,7 +369,7 @@ private:
 	                     int &dzdx, int &dsdx, int &dtdx, int &drdx, int &dgdx, int &dbdx, uint dadx,
 	                     uint &fog, int fog_r, int fog_g, int fog_b, int &dfdx);
 
-	template <bool kDepthWrite, bool kEnableScissor, bool kStencilEnabled, bool kDepthTestEnabled>
+	template <bool kDepthWrite, bool kEnableScissor, bool kStencilEnabled, bool StippleEnabled, bool kDepthTestEnabled>
 	void putPixelDepth(uint *pz, byte *ps, int _a, int x, int y, uint &z, int &dzdx);
 
 
@@ -615,6 +615,14 @@ public:
 		_stencilWriteMask = stencilWriteMask;
 	}
 
+	void enablePolygonStipple(bool enable) {
+		_polygonStippleEnabled = enable;
+	}
+
+	void setPolygonStipplePattern(void *stipple) {
+		_polygonStipplePattern = stipple;
+	}
+
 	void setStencilTestFunc(int stencilFunc, int stencilValue, uint stencilMask) {
 		_stencilTestFunc = stencilFunc;
 		_stencilRefVal = stencilValue;
@@ -675,7 +683,12 @@ private:
 
 	template <bool kInterpRGB, bool kInterpZ, bool kInterpST, bool kInterpSTZ, bool kSmoothMode,
 	          bool kDepthWrite, bool kFogMode, bool kAlphaTestEnabled, bool kEnableScissor,
-	          bool kBlendingEnabled, bool kStencilEnabled, bool kDepthTestEnabled>
+	          bool kBlendingEnabled, bool kStencilEnabled, bool kStippleEnabled, bool kDepthTestEnabled>
+	void fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint *p2);
+
+	template <bool kInterpRGB, bool kInterpZ, bool kInterpST, bool kInterpSTZ, bool kSmoothMode,
+	          bool kDepthWrite, bool kFogMode, bool kAlphaTestEnabled, bool kEnableScissor,
+	          bool kBlendingEnabled, bool kStencilEnabled, bool kStippleEnabled>
 	void fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint *p2);
 
 	template <bool kInterpRGB, bool kInterpZ, bool kInterpST, bool kInterpSTZ, bool kSmoothMode,
@@ -776,6 +789,9 @@ private:
 	int _stencilSfail;
 	int _stencilDpfail;
 	int _stencilDppass;
+
+	bool _polygonStippleEnabled;
+	void *_polygonStipplePattern;
 	int _depthFunc;
 	int _offsetStates;
 	float _offsetFactor;

--- a/graphics/tinygl/zdirtyrect.cpp
+++ b/graphics/tinygl/zdirtyrect.cpp
@@ -453,6 +453,8 @@ RasterizationDrawCall::RasterizationState RasterizationDrawCall::captureState() 
 	state.stencilSfail = c->stencil_sfail;
 	state.stencilDpfail = c->stencil_dpfail;
 	state.stencilDppass = c->stencil_dppass;
+	state.polygonStipplePattern = c->polygon_stipple_pattern;
+	state.polygonStippleEnabled = c->polygon_stipple_enabled;
 	state.offsetStates = c->offset_states;
 	state.offsetFactor = c->offset_factor;
 	state.offsetUnits = c->offset_units;
@@ -502,6 +504,8 @@ void RasterizationDrawCall::applyState(const RasterizationDrawCall::Rasterizatio
 	c->fb->setOffsetUnits(state.offsetUnits);
 	c->fb->setFogEnabled(state.fogEnabled);
 	c->fb->setFogColor(state.fogColorR, state.fogColorG, state.fogColorB);
+	c->fb->setPolygonStipplePattern(state.polygonStipplePattern);
+	c->fb->enablePolygonStipple(state.polygonStippleEnabled);
 
 	c->blending_enabled = state.enableBlending;
 	c->source_blending_factor = state.sfactor;

--- a/graphics/tinygl/zdirtyrect.cpp
+++ b/graphics/tinygl/zdirtyrect.cpp
@@ -453,7 +453,6 @@ RasterizationDrawCall::RasterizationState RasterizationDrawCall::captureState() 
 	state.stencilSfail = c->stencil_sfail;
 	state.stencilDpfail = c->stencil_dpfail;
 	state.stencilDppass = c->stencil_dppass;
-	state.polygonStipplePattern = c->polygon_stipple_pattern;
 	state.polygonStippleEnabled = c->polygon_stipple_enabled;
 	state.offsetStates = c->offset_states;
 	state.offsetFactor = c->offset_factor;
@@ -482,6 +481,7 @@ RasterizationDrawCall::RasterizationState RasterizationDrawCall::captureState() 
 
 	memcpy(state.viewportScaling, c->viewport.scale._v, sizeof(c->viewport.scale._v));
 	memcpy(state.viewportTranslation, c->viewport.trans._v, sizeof(c->viewport.trans._v));
+	memcpy(state.polygonStipplePattern, c->polygon_stipple_pattern, sizeof(c->polygon_stipple_pattern));
 
 	return state;
 }

--- a/graphics/tinygl/zdirtyrect.h
+++ b/graphics/tinygl/zdirtyrect.h
@@ -139,7 +139,7 @@ private:
 		int stencilDpfail;
 		int stencilDppass;
 		bool polygonStippleEnabled;
-		byte *polygonStipplePattern;
+		byte polygonStipplePattern[128];
 		GLTexture *texture;
 		uint wrapS, wrapT;
 		bool fogEnabled;

--- a/graphics/tinygl/zdirtyrect.h
+++ b/graphics/tinygl/zdirtyrect.h
@@ -139,7 +139,7 @@ private:
 		int stencilDpfail;
 		int stencilDppass;
 		bool polygonStippleEnabled;
-		void *polygonStipplePattern;
+		byte *polygonStipplePattern;
 		GLTexture *texture;
 		uint wrapS, wrapT;
 		bool fogEnabled;

--- a/graphics/tinygl/zdirtyrect.h
+++ b/graphics/tinygl/zdirtyrect.h
@@ -138,6 +138,8 @@ private:
 		int stencilSfail;
 		int stencilDpfail;
 		int stencilDppass;
+		bool polygonStippleEnabled;
+		void *polygonStipplePattern;
 		GLTexture *texture;
 		uint wrapS, wrapT;
 		bool fogEnabled;

--- a/graphics/tinygl/zgl.h
+++ b/graphics/tinygl/zgl.h
@@ -454,7 +454,7 @@ struct GLContext {
 
 	// stipple
 	bool polygon_stipple_enabled;
-	void *polygon_stipple_pattern;
+	byte polygon_stipple_pattern[128];
 
 	// blit test
 	Common::List<BlitImage *> _blitImages;

--- a/graphics/tinygl/zgl.h
+++ b/graphics/tinygl/zgl.h
@@ -452,6 +452,10 @@ struct GLContext {
 
 	bool _enableDirtyRectangles;
 
+	// stipple
+	bool polygon_stipple_enabled;
+	void *polygon_stipple_pattern;
+
 	// blit test
 	Common::List<BlitImage *> _blitImages;
 

--- a/graphics/tinygl/ztriangle.cpp
+++ b/graphics/tinygl/ztriangle.cpp
@@ -34,15 +34,14 @@ namespace TinyGL {
 
 static const int NB_INTERP = 8;
 
-static bool applyStipplePattern(int x, int y, void *stipplePattern) {
+static bool applyStipplePattern(int x, int y, byte *stipple) {
 
-	byte *stipple = (byte *)stipplePattern;
 	int stippleX = x % 32;
 	int stippleY = y % 32;
 	int byteIndex = stippleY * 4 + (stippleX / 8); // 4 bytes per row
 	int bitIndex = stippleX % 8;
 
-    byte bitmask = 1 << (7 - bitIndex);
+	byte bitmask = 1 << (7 - bitIndex);
 	return (stipple[byteIndex] & bitmask);
 }
 

--- a/graphics/tinygl/ztriangle.cpp
+++ b/graphics/tinygl/ztriangle.cpp
@@ -34,7 +34,7 @@ namespace TinyGL {
 
 static const int NB_INTERP = 8;
 
-static bool applyStipplePattern(int x, int y, byte *stipple) {
+static bool applyStipplePattern(int x, int y, const byte *stipple) {
 
 	int stippleX = x % 32;
 	int stippleY = y % 32;

--- a/graphics/tinygl/ztriangle.cpp
+++ b/graphics/tinygl/ztriangle.cpp
@@ -91,7 +91,7 @@ void FrameBuffer::putPixelNoTexture(int fbOffset, uint *pz, byte *ps, int _a,
 	}
 }
 
-template <bool kDepthWrite, bool kLightsMode, bool kSmoothMode, bool kFogMode, bool kEnableAlphaTest, bool kEnableScissor, bool kEnableBlending, bool kStencilEnabled, bool kStippleEnabled, bool kDepthTestEnabled>
+template <bool kDepthWrite, bool kLightsMode, bool kSmoothMode, bool kFogMode, bool kEnableAlphaTest, bool kEnableScissor, bool kEnableBlending, bool kStencilEnabled, bool kDepthTestEnabled>
 void FrameBuffer::putPixelTexture(int fbOffset, const TexelBuffer *texture,
                                   uint wrap_s, uint wrap_t, uint *pz, byte *ps, int _a,
                                   int x, int y, uint &z, int &t, int &s,
@@ -99,9 +99,6 @@ void FrameBuffer::putPixelTexture(int fbOffset, const TexelBuffer *texture,
                                   int &dzdx, int &dsdx, int &dtdx, int &drdx, int &dgdx, int &dbdx, uint dadx,
                                   uint &fog, int fog_r, int fog_g, int fog_b, int &dfdx) {
 	if (kEnableScissor && scissorPixel(x + _a, y)) {
-		return;
-	}
-	if (kStippleEnabled && !applyStipplePattern(x + _a, y, _polygonStipplePattern)) {
 		return;
 	}
 
@@ -583,7 +580,7 @@ void FrameBuffer::fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint 
 						zinv = (float)(1.0 / fz);
 					}
 					for (int _a = 0; _a < NB_INTERP; _a++) {
-						putPixelTexture<kDepthWrite, kInterpRGB, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kStippleEnabled, kDepthTestEnabled>
+						putPixelTexture<kDepthWrite, kInterpRGB, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kDepthTestEnabled>
 						               (pp, texture, _wrapS, _wrapT, pz, ps, _a, x, y, z, t, s, r, g, b, a, dzdx, dsdx, dtdx, drdx, dgdx, dbdx, dadx, fog, fog_r, fog_g, fog_b, dfdx);
 					}
 					pp += NB_INTERP;
@@ -610,7 +607,7 @@ void FrameBuffer::fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint 
 				}
 
 				while (n >= 0) {
-					putPixelTexture<kDepthWrite, kInterpRGB, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kStippleEnabled, kDepthTestEnabled>
+					putPixelTexture<kDepthWrite, kInterpRGB, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kDepthTestEnabled>
 					               (pp, texture, _wrapS, _wrapT, pz, ps, 0, x, y, z, t, s, r, g, b, a, dzdx, dsdx, dtdx, drdx, dgdx, dbdx, dadx, fog, fog_r, fog_g, fog_b, dfdx);
 					pp += 1;
 					if (kInterpZ) {

--- a/graphics/tinygl/ztriangle.cpp
+++ b/graphics/tinygl/ztriangle.cpp
@@ -34,7 +34,19 @@ namespace TinyGL {
 
 static const int NB_INTERP = 8;
 
-template <bool kDepthWrite, bool kSmoothMode, bool kFogMode, bool kEnableAlphaTest, bool kEnableScissor, bool kEnableBlending, bool kStencilEnabled, bool kDepthTestEnabled>
+static bool applyStipplePattern(int x, int y, void *stipplePattern) {
+
+	byte *stipple = (byte *)stipplePattern;
+	int stippleX = x % 32;
+	int stippleY = y % 32;
+	int byteIndex = stippleY * 4 + (stippleX / 8); // 4 bytes per row
+	int bitIndex = stippleX % 8;
+
+    byte bitmask = 1 << (7 - bitIndex);
+	return (stipple[byteIndex] & bitmask);
+}
+
+template <bool kDepthWrite, bool kSmoothMode, bool kFogMode, bool kEnableAlphaTest, bool kEnableScissor, bool kEnableBlending, bool kStencilEnabled, bool kStippleEnabled, bool kDepthTestEnabled>
 void FrameBuffer::putPixelNoTexture(int fbOffset, uint *pz, byte *ps, int _a,
                                     int x, int y, uint &z, uint &r, uint &g, uint &b, uint &a,
                                     int &dzdx, int &drdx, int &dgdx, int &dbdx, uint dadx,
@@ -42,6 +54,11 @@ void FrameBuffer::putPixelNoTexture(int fbOffset, uint *pz, byte *ps, int _a,
 	if (kEnableScissor && scissorPixel(x + _a, y)) {
 		return;
 	}
+
+	if (kStippleEnabled && !applyStipplePattern(x + _a, y, _polygonStipplePattern)) {
+		return;
+	}
+
 	if (kStencilEnabled) {
 		bool stencilResult = stencilTest(ps[_a]);
 		if (!stencilResult) {
@@ -75,7 +92,7 @@ void FrameBuffer::putPixelNoTexture(int fbOffset, uint *pz, byte *ps, int _a,
 	}
 }
 
-template <bool kDepthWrite, bool kLightsMode, bool kSmoothMode, bool kFogMode, bool kEnableAlphaTest, bool kEnableScissor, bool kEnableBlending, bool kStencilEnabled, bool kDepthTestEnabled>
+template <bool kDepthWrite, bool kLightsMode, bool kSmoothMode, bool kFogMode, bool kEnableAlphaTest, bool kEnableScissor, bool kEnableBlending, bool kStencilEnabled, bool kStippleEnabled, bool kDepthTestEnabled>
 void FrameBuffer::putPixelTexture(int fbOffset, const TexelBuffer *texture,
                                   uint wrap_s, uint wrap_t, uint *pz, byte *ps, int _a,
                                   int x, int y, uint &z, int &t, int &s,
@@ -85,6 +102,10 @@ void FrameBuffer::putPixelTexture(int fbOffset, const TexelBuffer *texture,
 	if (kEnableScissor && scissorPixel(x + _a, y)) {
 		return;
 	}
+	if (kStippleEnabled && !applyStipplePattern(x + _a, y, _polygonStipplePattern)) {
+		return;
+	}
+
 	if (kStencilEnabled) {
 		bool stencilResult = stencilTest(ps[_a]);
 		if (!stencilResult) {
@@ -130,11 +151,16 @@ void FrameBuffer::putPixelTexture(int fbOffset, const TexelBuffer *texture,
 	}
 }
 
-template <bool kDepthWrite, bool kEnableScissor, bool kStencilEnabled, bool kDepthTestEnabled>
+template <bool kDepthWrite, bool kEnableScissor, bool kStencilEnabled, bool kStippleEnabled, bool kDepthTestEnabled>
 void FrameBuffer::putPixelDepth(uint *pz, byte *ps, int _a, int x, int y, uint &z, int &dzdx) {
 	if (kEnableScissor && scissorPixel(x + _a, y)) {
 		return;
 	}
+
+	/*if (kStippleEnabled && !applyStipplePattern(x + _a, y, _polygonStipplePattern)) {
+		return;
+	}*/
+
 	if (kStencilEnabled) {
 		bool stencilResult = stencilTest(ps[_a]);
 		if (!stencilResult) {
@@ -159,7 +185,7 @@ void FrameBuffer::putPixelDepth(uint *pz, byte *ps, int _a, int x, int y, uint &
 
 template <bool kInterpRGB, bool kInterpZ, bool kInterpST, bool kInterpSTZ, bool kSmoothMode,
           bool kDepthWrite, bool kFogMode, bool kAlphaTestEnabled, bool kEnableScissor,
-          bool kBlendingEnabled, bool kStencilEnabled, bool kDepthTestEnabled>
+          bool kBlendingEnabled, bool kStencilEnabled, bool kStippleEnabled, bool kDepthTestEnabled>
 void FrameBuffer::fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint *p2) {
 	const TexelBuffer *texture;
 	float fdzdx = 0, fndzdx = 0, ndszdx = 0, ndtzdx = 0;
@@ -438,10 +464,10 @@ void FrameBuffer::fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint 
 					ps = ps1 + x1;
 				}
 				while (n >= 3) {
-					putPixelDepth<kDepthWrite, kEnableScissor, kStencilEnabled, kDepthTestEnabled>(pz, ps, 0, x, y, z, dzdx);
-					putPixelDepth<kDepthWrite, kEnableScissor, kStencilEnabled, kDepthTestEnabled>(pz, ps, 1, x, y, z, dzdx);
-					putPixelDepth<kDepthWrite, kEnableScissor, kStencilEnabled, kDepthTestEnabled>(pz, ps, 2, x, y, z, dzdx);
-					putPixelDepth<kDepthWrite, kEnableScissor, kStencilEnabled, kDepthTestEnabled>(pz, ps, 3, x, y, z, dzdx);
+					putPixelDepth<kDepthWrite, kEnableScissor, kStencilEnabled, kStippleEnabled, kDepthTestEnabled>(pz, ps, 0, x, y, z, dzdx);
+					putPixelDepth<kDepthWrite, kEnableScissor, kStencilEnabled, kStippleEnabled, kDepthTestEnabled>(pz, ps, 1, x, y, z, dzdx);
+					putPixelDepth<kDepthWrite, kEnableScissor, kStencilEnabled, kStippleEnabled, kDepthTestEnabled>(pz, ps, 2, x, y, z, dzdx);
+					putPixelDepth<kDepthWrite, kEnableScissor, kStencilEnabled, kStippleEnabled, kDepthTestEnabled>(pz, ps, 3, x, y, z, dzdx);
 					if (kInterpZ) {
 						pz += 4;
 					}
@@ -452,7 +478,7 @@ void FrameBuffer::fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint 
 					x += 4;
 				}
 				while (n >= 0) {
-					putPixelDepth<kDepthWrite, kEnableScissor, kStencilEnabled, kDepthTestEnabled>(pz, ps, 0, x, y, z, dzdx);
+					putPixelDepth<kDepthWrite, kEnableScissor, kStencilEnabled, kStippleEnabled, kDepthTestEnabled>(pz, ps, 0, x, y, z, dzdx);
 					if (kInterpZ) {
 						pz += 1;
 					}
@@ -484,13 +510,13 @@ void FrameBuffer::fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint 
 					ps = ps1 + x1;
 				}
 				while (n >= 3) {
-					putPixelNoTexture<kDepthWrite, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kDepthTestEnabled>
+					putPixelNoTexture<kDepthWrite, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kStippleEnabled, kDepthTestEnabled>
 					                 (pp, pz, ps, 0, x, y, z, r, g, b, a, dzdx, drdx, dgdx, dbdx, dadx, fog, fog_r, fog_g, fog_b, dfdx);
-					putPixelNoTexture<kDepthWrite, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kDepthTestEnabled>
+					putPixelNoTexture<kDepthWrite, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kStippleEnabled, kDepthTestEnabled>
 					                 (pp, pz, ps, 1, x, y, z, r, g, b, a, dzdx, drdx, dgdx, dbdx, dadx, fog, fog_r, fog_g, fog_b, dfdx);
-					putPixelNoTexture<kDepthWrite, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kDepthTestEnabled>
+					putPixelNoTexture<kDepthWrite, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kStippleEnabled, kDepthTestEnabled>
 					                 (pp, pz, ps, 2, x, y, z, r, g, b, a, dzdx, drdx, dgdx, dbdx, dadx, fog, fog_r, fog_g, fog_b, dfdx);
-					putPixelNoTexture<kDepthWrite, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kDepthTestEnabled>
+					putPixelNoTexture<kDepthWrite, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kStippleEnabled, kDepthTestEnabled>
 					                 (pp, pz, ps, 3, x, y, z, r, g, b, a, dzdx, drdx, dgdx, dbdx, dadx, fog, fog_r, fog_g, fog_b, dfdx);
 					pp += 4;
 					if (kInterpZ) {
@@ -503,7 +529,7 @@ void FrameBuffer::fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint 
 					x += 4;
 				}
 				while (n >= 0) {
-					putPixelNoTexture<kDepthWrite, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kDepthTestEnabled>
+					putPixelNoTexture<kDepthWrite, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kStippleEnabled, kDepthTestEnabled>
 					                 (pp, pz, ps, 0, x, y, z, r, g, b, a, dzdx, drdx, dgdx, dbdx, dadx, fog, fog_r, fog_g, fog_b, dfdx);
 					pp += 1;
 					if (kInterpZ) {
@@ -558,7 +584,7 @@ void FrameBuffer::fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint 
 						zinv = (float)(1.0 / fz);
 					}
 					for (int _a = 0; _a < NB_INTERP; _a++) {
-						putPixelTexture<kDepthWrite, kInterpRGB, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kDepthTestEnabled>
+						putPixelTexture<kDepthWrite, kInterpRGB, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kStippleEnabled, kDepthTestEnabled>
 						               (pp, texture, _wrapS, _wrapT, pz, ps, _a, x, y, z, t, s, r, g, b, a, dzdx, dsdx, dtdx, drdx, dgdx, dbdx, dadx, fog, fog_r, fog_g, fog_b, dfdx);
 					}
 					pp += NB_INTERP;
@@ -585,7 +611,7 @@ void FrameBuffer::fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint 
 				}
 
 				while (n >= 0) {
-					putPixelTexture<kDepthWrite, kInterpRGB, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kDepthTestEnabled>
+					putPixelTexture<kDepthWrite, kInterpRGB, kSmoothMode, kFogMode, kAlphaTestEnabled, kEnableScissor, kBlendingEnabled, kStencilEnabled, kStippleEnabled, kDepthTestEnabled>
 					               (pp, texture, _wrapS, _wrapT, pz, ps, 0, x, y, z, t, s, r, g, b, a, dzdx, dsdx, dtdx, drdx, dgdx, dbdx, dadx, fog, fog_r, fog_g, fog_b, dfdx);
 					pp += 1;
 					if (kInterpZ) {
@@ -660,9 +686,18 @@ void FrameBuffer::fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint 
 	}
 }
 
-template <bool kInterpRGB, bool kInterpZ, bool kInterpST, bool kInterpSTZ, bool kSmoothMode, bool kDepthWrite, bool kFogMode, bool kEnableAlphaTest, bool kEnableScissor, bool kEnableBlending, bool kStencilEnabled>
+template <bool kInterpRGB, bool kInterpZ, bool kInterpST, bool kInterpSTZ, bool kSmoothMode, bool kDepthWrite, bool kFogMode, bool kEnableAlphaTest, bool kEnableScissor, bool kEnableBlending, bool kStencilEnabled, bool kStippleEnabled>
 void FrameBuffer::fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint *p2) {
 	if (_depthTestEnabled) {
+		fillTriangle<kInterpRGB, kInterpZ, kInterpST, kInterpSTZ, kSmoothMode, kDepthWrite, kFogMode, kEnableAlphaTest, kEnableScissor, kEnableBlending, kStencilEnabled, kStippleEnabled, true>(p0, p1, p2);
+	} else {
+		fillTriangle<kInterpRGB, kInterpZ, kInterpST, kInterpSTZ, kSmoothMode, kDepthWrite, kFogMode, kEnableAlphaTest, kEnableScissor, kEnableBlending, kStencilEnabled, kStippleEnabled, false>(p0, p1, p2);
+	}
+}
+
+template <bool kInterpRGB, bool kInterpZ, bool kInterpST, bool kInterpSTZ, bool kSmoothMode, bool kDepthWrite, bool kFogMode, bool kEnableAlphaTest, bool kEnableScissor, bool kEnableBlending, bool kStencilEnabled>
+void FrameBuffer::fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint *p2) {
+	if (_polygonStippleEnabled) {
 		fillTriangle<kInterpRGB, kInterpZ, kInterpST, kInterpSTZ, kSmoothMode, kDepthWrite, kFogMode, kEnableAlphaTest, kEnableScissor, kEnableBlending, kStencilEnabled, true>(p0, p1, p2);
 	} else {
 		fillTriangle<kInterpRGB, kInterpZ, kInterpST, kInterpSTZ, kSmoothMode, kDepthWrite, kFogMode, kEnableAlphaTest, kEnableScissor, kEnableBlending, kStencilEnabled, false>(p0, p1, p2);


### PR DESCRIPTION
This is a quick and dirty implementation of glPolygonStipple for TinyGL. It seem to work, but there are some glitches here and there. I expect to have some discussion and improvements before merging this. For instance, it is not clear for me if the stipple pattern should be used for the depth buffer or not (that part is commented).

![image](https://github.com/scummvm/scummvm/assets/110782/286dacce-de07-40b5-98c3-fce24ddd1841)
