### PR TITLE
ZVISION: Fix addDir after 2.9.0 path changes

### DIFF
--- a/engines/zvision/file/search_manager.cpp
+++ b/engines/zvision/file/search_manager.cpp
@@ -176,8 +176,7 @@ bool SearchManager::loadZix(const Common::Path &name) {
 			Common::Path path_(path);
 			if (!path_.empty()) {
 				for (Common::List<Common::Path>::iterator it = _dirList.begin(); it != _dirList.end(); ++it) {
-					// FIXME: ignoreCase
-					if (path_ == *it) {
+					if (path_.equalsIgnoreCase(*it)) {
 						path_ = *it;
 						break;
 					}
@@ -215,8 +214,7 @@ bool SearchManager::loadZix(const Common::Path &name) {
 void SearchManager::addDir(const Common::Path &name) {
 	Common::Path path;
 	for (Common::List<Common::Path>::iterator it = _dirList.begin(); it != _dirList.end(); ++it)
-		// FIXME: ignore case
-		if (name == *it) {
+		if (name.normalize().equalsIgnoreCase((*it).normalize())) {
 			path = *it;
 			break;
 		}

--- a/engines/zvision/file/search_manager.cpp
+++ b/engines/zvision/file/search_manager.cpp
@@ -214,7 +214,7 @@ bool SearchManager::loadZix(const Common::Path &name) {
 void SearchManager::addDir(const Common::Path &name) {
 	Common::Path path;
 	for (Common::List<Common::Path>::iterator it = _dirList.begin(); it != _dirList.end(); ++it)
-		if (name.normalize().equalsIgnoreCase((*it).normalize())) {
+		if (name.equalsIgnoreCase(*it)) {
 			path = *it;
 			break;
 		}
@@ -256,7 +256,7 @@ void SearchManager::listDirRecursive(Common::List<Common::Path> &_list, const Co
 	Common::FSList fsList;
 	if (fsNode.getChildren(fsList)) {
 
-		_list.push_back(fsNode.getPath());
+		_list.push_back(fsNode.getPath().normalize());
 
 		if (depth > 1)
 			for (Common::FSList::const_iterator it = fsList.begin(); it != fsList.end(); ++it)


### PR DESCRIPTION
Also comparison is now ignoring case (uses equalsIgnoreCase)

This fix was required since, as reported in #15132, the subtitles addon (within a subfolder "Addon") would no longer work in ScummVM 2.9.0git. As far as I've tested, apart from the ignoreCase comparison, normalize() has to be applied at least on the iterator of the _dirList, since those paths end with a separator ("/").


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
