### PR TITLE
MTROPOLIS: move assert after nullptr check

### DIFF
--- a/engines/mtropolis/runtime.cpp
+++ b/engines/mtropolis/runtime.cpp
@@ -7704,9 +7704,9 @@ Common::SharedPtr<Modifier> Project::loadModifierObject(ModifierLoaderContext &l
 
 		modifier = factory->createModifier(loaderContext, dataObject);
 	}
-	assert(modifier->getModifierFlags().flagsWereLoaded);
 	if (!modifier)
 		error("Modifier object failed to load");
+	assert(modifier->getModifierFlags().flagsWereLoaded);
 
 	uint32 guid = modifier->getStaticGUID();
 	const Common::HashMap<uint32, Common::SharedPtr<ModifierHooks> > &hooksMap = getRuntime()->getHacks().modifierHooks;


### PR DESCRIPTION
Move the assertion dereferencing the newly created `modifier` after the `nullptr` check for `modifier`
If the modifier is `nullptr` because it could not be created, then the early assertion would cause a segfault.

Naturally this did not affect release builds, but was nonetheless bothersome in debug builds.