### PR TITLE
MTROPOLIS: add ability to play external video files

### DIFF
--- a/engines/mtropolis/elements.cpp
+++ b/engines/mtropolis/elements.cpp
@@ -649,10 +649,14 @@ void MovieElement::activate() {
 			movieDataStream = new Common::SafeSeekableSubReadStream(stream, movieAsset->getMovieDataPos(), movieAsset->getMovieDataPos() + movieAsset->getMovieDataSize(), DisposeAfterUse::NO);
 		} else if (!movieAsset->getExtFileName().empty()) {
 			Common::File *file = new Common::File();
-			file->open(Common::Path(movieAsset->getExtFileName()));
-			assert(file->isOpen());
-			if (!file->isOpen())
-				warning("Unable to open external video file %s", movieAsset->getExtFileName().c_str());
+
+			if (!file->open(Common::Path(Common::String("VIDEO/") + movieAsset->getExtFileName()))) {
+				warning("Movie asset could not be opened: %s", movieAsset->getExtFileName().c_str());
+				delete file;
+				_videoDecoder.reset();
+				return;
+			}
+
 			movieDataStream = file;
 		} else {
 			// If no data size, the movie data is all over the file and the MOOV atom may be after it.

--- a/engines/mtropolis/elements.cpp
+++ b/engines/mtropolis/elements.cpp
@@ -648,22 +648,8 @@ void MovieElement::activate() {
 			qtDecoder->setChunkBeginOffset(movieAsset->getMovieDataPos());
 			movieDataStream = new Common::SafeSeekableSubReadStream(stream, movieAsset->getMovieDataPos(), movieAsset->getMovieDataPos() + movieAsset->getMovieDataSize(), DisposeAfterUse::NO);
 		} else if (!movieAsset->getExtFileName().empty()) {
-			Common::File *file = nullptr;
-
-			for (const char *videoDirectory : {"", "Video", "video", "VIDEO"}) {
-				delete file;
-				file = new Common::File();
-
-				Common::String pathString = videoDirectory;
-				if (!pathString.empty())
-					pathString += Common::Path::kNativeSeparator;
-				pathString += movieAsset->getExtFileName();
-
-				file->open(Common::Path(pathString, Common::Path::kNativeSeparator));
-				if (file->isOpen())
-					break;
-			}
-
+			Common::File *file = new Common::File();
+			file->open(Common::Path(movieAsset->getExtFileName()));
 			assert(file->isOpen());
 			if (!file->isOpen())
 				warning("Unable to open external video file %s", movieAsset->getExtFileName().c_str());

--- a/engines/mtropolis/mtropolis.cpp
+++ b/engines/mtropolis/mtropolis.cpp
@@ -56,7 +56,6 @@ namespace MTropolis {
 MTropolisEngine::MTropolisEngine(OSystem *syst, const MTropolisGameDescription *gameDesc) : Engine(syst), _gameDescription(gameDesc), _saveWriter(nullptr), _isTriggeredAutosave(false) {
 	const Common::FSNode gameDataDir(ConfMan.getPath("path"));
 	SearchMan.addSubDirectoryMatching(gameDataDir, "Resource");
-	SearchMan.addSubDirectoryMatching(gameDataDir, "Video");
 
 	bootAddSearchPaths(gameDataDir, *gameDesc);
 }

--- a/engines/mtropolis/mtropolis.cpp
+++ b/engines/mtropolis/mtropolis.cpp
@@ -56,6 +56,7 @@ namespace MTropolis {
 MTropolisEngine::MTropolisEngine(OSystem *syst, const MTropolisGameDescription *gameDesc) : Engine(syst), _gameDescription(gameDesc), _saveWriter(nullptr), _isTriggeredAutosave(false) {
 	const Common::FSNode gameDataDir(ConfMan.getPath("path"));
 	SearchMan.addSubDirectoryMatching(gameDataDir, "Resource");
+	SearchMan.addSubDirectoryMatching(gameDataDir, "Video");
 
 	bootAddSearchPaths(gameDataDir, *gameDesc);
 }


### PR DESCRIPTION
Plenty of mTropolis games have video files in a directory named `Video` - or some spelling thereof - on the CD.
This patch adds the capability to play those external video files.

Games that can demonstrate this capability will be added to the detection in a future PR.
Pending other patches to make them startable, this feature would be demonstrable with:
 - _Hercules & Xena Learning Adventure: Quest for the Scrolls_
 - _The Magical World of Beatrix Potter_