### PR TITLE
MTROPOLIS: support loading cue source as string

### DIFF
--- a/engines/mtropolis/plugin/standard.cpp
+++ b/engines/mtropolis/plugin/standard.cpp
@@ -250,6 +250,9 @@ MediaCueMessengerModifier::~MediaCueMessengerModifier() {
 	case kCueSourceLabel:
 		_cueSource.destruct<Label, &CueSourceUnion::asLabel>();
 		break;
+	case kCueSourceString:
+		// No destruct necessary, string is not in union
+		break;
 	default:
 		_cueSource.destruct<uint64, &CueSourceUnion::asUnset>();
 		break;
@@ -304,6 +307,10 @@ bool MediaCueMessengerModifier::load(const PlugInModifierLoaderContext &context,
 		_cueSourceType = kCueSourceLabel;
 		if (!_cueSource.asLabel.load(data.executeAt.value.asLabel))
 			return false;
+		break;
+	case Data::PlugInTypeTaggedValue::kString:
+		_cueSourceType = kCueSourceString;
+		_cueSource.asString = data.executeAt.value.asString;
 		break;
 	default:
 		return false;

--- a/engines/mtropolis/plugin/standard.h
+++ b/engines/mtropolis/plugin/standard.h
@@ -124,19 +124,23 @@ private:
 		kCueSourceIntegerRange,
 		kCueSourceVariableReference,
 		kCueSourceLabel,
+		kCueSourceString,
 
 		kCueSourceInvalid = -1,
 	};
 
-	union CueSourceUnion {
+	struct CueSourceUnion {
 		CueSourceUnion();
 		~CueSourceUnion();
 
-		int32 asInt;
-		IntRange asIntRange;
-		uint32 asVarRefGUID;
-		Label asLabel;
-		uint64 asUnset;
+		union {
+			int32 asInt;
+			IntRange asIntRange;
+			uint32 asVarRefGUID;
+			Label asLabel;
+			uint64 asUnset;
+		};
+		Common::String asString;	//String object in the union would prevent copyability
 
 		template<class T, T (CueSourceUnion::*TMember)>
 		void construct(const T &value);


### PR DESCRIPTION
Add support for loading the cue source of `MediaCueMessengerModifier` as a string.
Without supporting strings, the modifier will not be instantiated during boot. (Incidentially, this is how the segfault from PR #5801 was discovered.)

This constellation occurs in the retail version of _Star Trek: The Game Show_. Adding this game version to detection is subject of a future PR.

Evaluating the cue source string is not implemented yet. Support for the game is not far enough yet to trigger the situation where the cue happens. 