### PR TITLE
COMMON: Add a log watcher

### DIFF
--- a/common/debug.cpp
+++ b/common/debug.cpp
@@ -184,11 +184,15 @@ bool debugChannelSet(int level, uint32 debugChannels) {
 
 #ifndef DISABLE_TEXT_CONSOLE
 
-static void debugHelper(const char *s, va_list va, bool caret = true) {
+static void debugHelper(const char *s, va_list va, int level, uint32 debugChannels, bool caret = true) {
 	Common::String buf = Common::String::vformat(s, va);
 
 	if (caret)
 		buf += '\n';
+
+	Common::LogWatcher logWatcher = Common::getLogWatcher();
+	if (logWatcher)
+   		(*logWatcher)(LogMessageType::kDebug, level, debugChannels, buf.c_str());
 
 	if (g_system)
 		g_system->logMessage(LogMessageType::kDebug, buf.c_str());
@@ -203,7 +207,7 @@ void debug(const char *s, ...) {
 		return;
 
 	va_start(va, s);
-	debugHelper(s, va);
+	debugHelper(s, va, 0, 0);
 	va_end(va);
 }
 
@@ -214,7 +218,7 @@ void debug(int level, const char *s, ...) {
 		return;
 
 	va_start(va, s);
-	debugHelper(s, va);
+	debugHelper(s, va, level, 0);
 	va_end(va);
 
 }
@@ -226,7 +230,7 @@ void debugN(const char *s, ...) {
 		return;
 
 	va_start(va, s);
-	debugHelper(s, va, false);
+	debugHelper(s, va, 0, 0, false);
 	va_end(va);
 }
 
@@ -237,7 +241,7 @@ void debugN(int level, const char *s, ...) {
 		return;
 
 	va_start(va, s);
-	debugHelper(s, va, false);
+	debugHelper(s, va, level, 0, false);
 	va_end(va);
 }
 
@@ -250,7 +254,7 @@ void debugC(int level, uint32 debugChannels, const char *s, ...) {
 			return;
 
 	va_start(va, s);
-	debugHelper(s, va);
+	debugHelper(s, va, level, debugChannels);
 	va_end(va);
 }
 
@@ -263,7 +267,7 @@ void debugCN(int level, uint32 debugChannels, const char *s, ...) {
 			return;
 
 	va_start(va, s);
-	debugHelper(s, va, false);
+	debugHelper(s, va, level, debugChannels, false);
 	va_end(va);
 }
 
@@ -276,7 +280,7 @@ void debugC(uint32 debugChannels, const char *s, ...) {
 			return;
 
 	va_start(va, s);
-	debugHelper(s, va);
+	debugHelper(s, va, 0, debugChannels);
 	va_end(va);
 }
 
@@ -289,7 +293,7 @@ void debugCN(uint32 debugChannels, const char *s, ...) {
 			return;
 
 	va_start(va, s);
-	debugHelper(s, va, false);
+	debugHelper(s, va, 0, debugChannels, false);
 	va_end(va);
 }
 

--- a/common/log.h
+++ b/common/log.h
@@ -1,0 +1,64 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef COMMON_LOG_H
+#define COMMON_LOG_H
+
+#include "common/scummsys.h"
+
+namespace LogMessageType {
+/**
+ * Enumeration for log message types.
+ * @ingroup common_system
+ *
+ */
+enum Type {
+	kInfo,    /**< Info logs. */
+	kError,   /**< Error logs. */
+	kWarning, /**< Warning logs. */
+	kDebug    /**< Debug logs. */
+};
+
+} // End of namespace LogMessageType
+
+namespace Common {
+
+/**
+ * A callback that is invoked by debug, warning and error methods.
+ *
+ * A typical example would be a function that shows a debug
+ * console and displays the given message in it.
+ */
+typedef void (*LogWatcher)(LogMessageType::Type type, int level, uint32 debugChannels, const char *message);
+
+/**
+ * Set the watcher used by debug, error and warning methods.
+ */
+void setLogWatcher(LogWatcher f);
+
+/**
+ * Get the watcher used by debug, error and warning methods.
+ */
+LogWatcher getLogWatcher();
+
+} // namespace Common
+
+#endif

--- a/common/system.h
+++ b/common/system.h
@@ -30,6 +30,7 @@
 #include "common/str-array.h" // For OSystem::updateStartSettings()
 #include "common/hash-str.h" // For OSystem::updateStartSettings()
 #include "common/path.h"
+#include "common/log.h"
 #include "graphics/pixelformat.h"
 #include "graphics/mode.h"
 #include "graphics/opengl/context.h"
@@ -111,21 +112,6 @@ struct TimeDate {
 	int tm_year;    /**< Year - 1900. */
 	int tm_wday;    /**< Days since Sunday (0 - 6). */
 };
-
-namespace LogMessageType {
-/**
- * Enumeration for log message types.
- * @ingroup common_system
- *
- */
-enum Type {
-	kInfo,    /**< Info logs. */
-	kError,   /**< Error logs. */
-	kWarning, /**< Warning logs. */
-	kDebug    /**< Debug logs. */
-};
-
-} // End of namespace LogMessageType
 
 /**
 * Pixel mask modes for cursor graphics.

--- a/common/textconsole.cpp
+++ b/common/textconsole.cpp
@@ -33,6 +33,16 @@ void setErrorOutputFormatter(OutputFormatter f) {
 	s_errorOutputFormatter = f;
 }
 
+static LogWatcher s_logWatcher = nullptr;
+
+void setLogWatcher(LogWatcher f) {
+	s_logWatcher = f;
+}
+
+LogWatcher getLogWatcher() {
+	return s_logWatcher;
+}
+
 static ErrorHandler s_errorHandler = nullptr;
 
 void setErrorHandler(ErrorHandler handler) {
@@ -52,6 +62,9 @@ void warning(const char *s, ...) {
 	va_start(va, s);
 	output = Common::String::vformat(s, va);
 	va_end(va);
+
+	if (Common::s_logWatcher)
+   		(*Common::s_logWatcher)(LogMessageType::kWarning, 0, 0, output.c_str());
 
 	output = "WARNING: " + output + "!\n";
 
@@ -88,6 +101,9 @@ void NORETURN_PRE error(const char *s, ...) {
 	buf_output[STRINGBUFLEN - 2] = '\0';
 	buf_output[STRINGBUFLEN - 1] = '\0';
 	Common::strcat_s(buf_output, "!\n");
+
+	if (Common::s_logWatcher)
+   		(*Common::s_logWatcher)(LogMessageType::kError, 0, 0, buf_output);
 
 	if (g_system)
 		g_system->logMessage(LogMessageType::kError, buf_output);


### PR DESCRIPTION
This allows to specify a log watcher:
```c++
static void onLog(LogMessageType::Type type, int level, uint32 debugChannels, const char *message) {
	switch (type) {
	case LogMessageType::kError:
		// TODO: error
		break;
	case LogMessageType::kWarning:
		// TODO: warning
		break;
	case LogMessageType::kInfo:
		// TODO: info
		break;
	case LogMessageType::kDebug:
		// TODO: debug
		break;
	}
}

Common::setLogWatcher(onLog);
```

When a log watcher is set, it will receive each message logged by theses methods:
* `error()`
* `warning()`
* all debug methods: `debug()`, `debugN()` and `debugC()`, `debugCN()`

It can be useful for example to create a logger with `ImGui`:
![Screenshot 2024-05-23 at 20 29 52](https://github.com/scummvm/scummvm/assets/643384/eaaec308-aa6b-48ac-b44d-f0e01ce55a39)
