### PR TITLE
MTROPOLIS: add fallback palette to MovieElement blitting

### DIFF
--- a/engines/mtropolis/elements.cpp
+++ b/engines/mtropolis/elements.cpp
@@ -500,8 +500,7 @@ MovieElement::MovieElement()
 	: _cacheBitmap(false), _alternate(false), _playEveryFrame(false), _reversed(false), /* _haveFiredAtLastCel(false), */
 	  /* _haveFiredAtFirstCel(false), */_shouldPlayIfNotPaused(true), _needsReset(true), _currentPlayState(kMediaStateStopped),
 	  _assetID(0), _maxTimestamp(0), _timeScale(0), _currentTimestamp(0), _volume(100),
-	  _displayFrame(nullptr), _fallbackPalette(0) {
-	initFallbackPalette();
+	  _displayFrame(nullptr) {
 }
 
 MovieElement::~MovieElement() {
@@ -771,7 +770,9 @@ void MovieElement::render(Window *window) {
 		Graphics::ManagedSurface *target = window->getSurface().get();
 		Common::Rect srcRect(0, 0, displaySurface->w, displaySurface->h);
 		Common::Rect destRect(_cachedAbsoluteOrigin.x, _cachedAbsoluteOrigin.y, _cachedAbsoluteOrigin.x + _rect.width(), _cachedAbsoluteOrigin.y + _rect.height());
-		target->blitFrom(*displaySurface, srcRect, destRect, &_fallbackPalette);
+
+		initFallbackPalette();
+		target->blitFrom(*displaySurface, srcRect, destRect, _fallbackPalette.get());
 	}
 }
 
@@ -954,9 +955,10 @@ void MovieElement::stopSubtitles() {
 }
 
 void MovieElement::initFallbackPalette() {
-	// TODO: determine correct content of fallback movie palette
-	Palette palette;
-	_fallbackPalette = Graphics::Palette(palette.getPalette(), palette.kNumColors);
+	if (!_fallbackPalette) {
+		const Palette &globalPalette = getRuntime()->getGlobalPalette();
+		_fallbackPalette = Common::ScopedPtr<Graphics::Palette>(new Graphics::Palette(globalPalette.getPalette(), globalPalette.kNumColors));
+	}
 }
 
 void MovieElement::onPauseStateChanged() {

--- a/engines/mtropolis/elements.cpp
+++ b/engines/mtropolis/elements.cpp
@@ -500,7 +500,8 @@ MovieElement::MovieElement()
 	: _cacheBitmap(false), _alternate(false), _playEveryFrame(false), _reversed(false), /* _haveFiredAtLastCel(false), */
 	  /* _haveFiredAtFirstCel(false), */_shouldPlayIfNotPaused(true), _needsReset(true), _currentPlayState(kMediaStateStopped),
 	  _assetID(0), _maxTimestamp(0), _timeScale(0), _currentTimestamp(0), _volume(100),
-	  _displayFrame(nullptr) {
+	  _displayFrame(nullptr), _fallbackPalette(0) {
+	initFallbackPalette();
 }
 
 MovieElement::~MovieElement() {
@@ -770,7 +771,7 @@ void MovieElement::render(Window *window) {
 		Graphics::ManagedSurface *target = window->getSurface().get();
 		Common::Rect srcRect(0, 0, displaySurface->w, displaySurface->h);
 		Common::Rect destRect(_cachedAbsoluteOrigin.x, _cachedAbsoluteOrigin.y, _cachedAbsoluteOrigin.x + _rect.width(), _cachedAbsoluteOrigin.y + _rect.height());
-		target->blitFrom(*displaySurface, srcRect, destRect);
+		target->blitFrom(*displaySurface, srcRect, destRect, &_fallbackPalette);
 	}
 }
 
@@ -950,6 +951,12 @@ IntRange MovieElement::computeRealRange() const {
 void MovieElement::stopSubtitles() {
 	if (_subtitles)
 		_subtitles->stop();
+}
+
+void MovieElement::initFallbackPalette() {
+	// TODO: determine correct content of fallback movie palette
+	Palette palette;
+	_fallbackPalette = Graphics::Palette(palette.getPalette(), palette.kNumColors);
 }
 
 void MovieElement::onPauseStateChanged() {

--- a/engines/mtropolis/elements.h
+++ b/engines/mtropolis/elements.h
@@ -23,6 +23,7 @@
 #define MTROPOLIS_ELEMENTS_H
 
 #include "graphics/fontman.h"
+#include "graphics/palette.h"
 
 #include "mtropolis/data.h"
 #include "mtropolis/runtime.h"
@@ -120,6 +121,8 @@ private:
 
 	void stopSubtitles();
 
+	void initFallbackPalette();
+
 	MiniscriptInstructionOutcome scriptSetRange(MiniscriptThread *thread, const DynamicValue &value);
 	MiniscriptInstructionOutcome scriptSetRangeStart(MiniscriptThread *thread, const DynamicValue &value);
 	MiniscriptInstructionOutcome scriptSetRangeEnd(MiniscriptThread *thread, const DynamicValue &value);
@@ -173,6 +176,8 @@ private:
 	Common::SharedPtr<SubtitlePlayer> _subtitles;
 
 	Common::Array<int> _damagedFrames;
+
+	Graphics::Palette _fallbackPalette;
 };
 
 class ImageElement : public VisualElement {

--- a/engines/mtropolis/elements.h
+++ b/engines/mtropolis/elements.h
@@ -177,7 +177,7 @@ private:
 
 	Common::Array<int> _damagedFrames;
 
-	Graphics::Palette _fallbackPalette;
+	Common::ScopedPtr<Graphics::Palette> _fallbackPalette;
 };
 
 class ImageElement : public VisualElement {


### PR DESCRIPTION
Without a palette provided to `blitFrom` here, there would be assertions and `nullptr` segfaults in `Graphics::ManagedSurface::blitFromInner`.
Observed in _MindGym_ and _The Day The World Broke_.
The palette content is not correct yet. Both titles render the video with the wrong colors.

Stacktrace for the assertion:
```
assert(!destFormat.isCLUT8() && srcPalette && srcPalette->size() > 0);

Graphics::ManagedSurface::blitFromInner(const Graphics::Surface & src, const Common::Rect & srcRect, const Common::Rect & destRect, const Graphics::Palette * srcPalette) Line 299
Graphics::ManagedSurface::blitFrom(const Graphics::Surface & src, const Common::Rect & srcRect, const Common::Rect & destRect, const Graphics::Palette * srcPalette) Line 247
MTropolis::MovieElement::render(MTropolis::Window * window) Line 805
```

Stacktrace for the `nullptr` segfault (`get` called on `nullptr`):
```
Graphics::Palette::get(unsigned int entry, unsigned char & r, unsigned char & g, unsigned char & b) Line 83
Graphics::ManagedSurface::blitFromInner(const Graphics::Surface & src, const Common::Rect & srcRect, const Common::Rect & destRect, const Graphics::Palette * srcPalette) Line 372
Graphics::ManagedSurface::blitFrom(const Graphics::Surface & src, const Common::Rect & srcRect, const Common::Rect & destRect, const Graphics::Palette * srcPalette) Line 247
```


