### PR TITLE
JANITORIAL: Fix GCC 14 warnings

### DIFF
--- a/common/singleton.h
+++ b/common/singleton.h
@@ -41,8 +41,8 @@ namespace Common {
 template<class T>
 class Singleton : NonCopyable {
 private:
-	Singleton<T>(const Singleton<T> &);
-	Singleton<T> &operator=(const Singleton<T> &);
+	Singleton(const Singleton<T> &);
+	Singleton &operator=(const Singleton<T> &);
 
 	/**
 	 * The default object factory used by the template class Singleton.
@@ -88,8 +88,8 @@ public:
 		T::destroyInstance();
 	}
 protected:
-	Singleton<T>()		{ }
-	virtual ~Singleton<T>()	{ }
+	Singleton()		{ }
+	virtual ~Singleton()	{ }
 
 	typedef T	SingletonBaseType;
 

--- a/common/stack.h
+++ b/common/stack.h
@@ -44,7 +44,7 @@ class FixedStack {
 public:
 	typedef uint size_type;
 
-	FixedStack<T, MAX_SIZE>() : _size(0) {}
+	FixedStack() : _size(0) {}
 
 	bool empty() const {
 		return _size <= 0;
@@ -106,8 +106,8 @@ private:
 public:
 	typedef typename Array<T>::size_type size_type;
 
-	Stack<T>() {}
-	Stack<T>(const Array<T> &stackContent) : _stack(stackContent) {}
+	Stack() {}
+	Stack(const Array<T> &stackContent) : _stack(stackContent) {}
 
 	bool empty() const {
 		return _stack.empty();

--- a/engines/startrek/fixedint.h
+++ b/engines/startrek/fixedint.h
@@ -55,7 +55,7 @@ public:
 	 * Constructor from other fixed-point formats.
 	 */
 	template<typename T2, uint otherTB, uint otherDB>
-	explicit TFixedInt<T, totalBits, decimalBits>(const TFixedInt<T2, otherTB, otherDB> &fi) {
+	explicit TFixedInt(const TFixedInt<T2, otherTB, otherDB> &fi) {
 		int diff = otherDB - decimalBits;
 		if (otherDB >= decimalBits)
 			val = fi.raw() >> diff;


### PR DESCRIPTION
Example:

```
singleton.h:44:21: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
   44 |         Singleton<T>(const Singleton<T> &);
```