### PR TITLE
JANITORIAL: Add Daily Build link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ For the impatient among you, here is how to get ScummVM running in five simple s
 
 To report a bug, go to the ScummVM [Issue Tracker](https://bugs.scummvm.org/) and log in with your GitHub account.
 
-Please make sure the bug is reproducible, and still occurs in the latest git/Daily build version. Also check the [compatibility list](https://www.scummvm.org/compatibility/) for that game, to ensure the issue is not already known. Please do not report bugs for games that are not listed as completable on the [Supported Games](https://wiki.scummvm.org/index.php?title=Category:Supported_Games) wiki page, or on the compatibility list. We already know those games have bugs!
+Please make sure the bug is reproducible, and still occurs in the latest git/[Daily build](https://buildbot.scummvm.org/#/dailybuilds) version. Also check the [compatibility list](https://www.scummvm.org/compatibility/) for that game, to ensure the issue is not already known. Please do not report bugs for games that are not listed as completable on the [Supported Games](https://wiki.scummvm.org/index.php?title=Category:Supported_Games) wiki page, or on the compatibility list. We already know those games have bugs!
 
 Please include the following information in the bug report:
 
-- ScummVM version (test the latest git/Daily build)
+- ScummVM version (test the latest git/[Daily build](https://buildbot.scummvm.org/#/dailybuilds))
 - Bug details, including instructions for how to reproduce the bug. If possible, include log files, screenshots, and any other relevant information.
 - Game language
 - Game version (for example, talkie or floppy)


### PR DESCRIPTION
It took me a while to find where the daily builds are. Since they will often be accessed by developers who may not have the website open, it could be helpful to link directly to them from the source code repository README.