### PR TITLE
JANITORIAL: Fix repetitive warnings about template-id in constructor/destructor

### DIFF
--- a/common/singleton.h
+++ b/common/singleton.h
@@ -41,8 +41,8 @@ namespace Common {
 template<class T>
 class Singleton : NonCopyable {
 private:
-	Singleton<T>(const Singleton<T> &);
-	Singleton<T> &operator=(const Singleton<T> &);
+	Singleton(const Singleton&);
+	Singleton &operator=(const Singleton &);
 
 	/**
 	 * The default object factory used by the template class Singleton.
@@ -88,8 +88,8 @@ public:
 		T::destroyInstance();
 	}
 protected:
-	Singleton<T>()		{ }
-	virtual ~Singleton<T>()	{ }
+	Singleton()		{ }
+	virtual ~Singleton()	{ }
 
 	typedef T	SingletonBaseType;
 

--- a/common/stack.h
+++ b/common/stack.h
@@ -44,7 +44,7 @@ class FixedStack {
 public:
 	typedef uint size_type;
 
-	FixedStack<T, MAX_SIZE>() : _size(0) {}
+	FixedStack() : _size(0) {}
 
 	bool empty() const {
 		return _size <= 0;
@@ -106,8 +106,8 @@ private:
 public:
 	typedef typename Array<T>::size_type size_type;
 
-	Stack<T>() {}
-	Stack<T>(const Array<T> &stackContent) : _stack(stackContent) {}
+	Stack() {}
+	Stack(const Array<T> &stackContent) : _stack(stackContent) {}
 
 	bool empty() const {
 		return _stack.empty();

--- a/engines/adl/graphics.h
+++ b/engines/adl/graphics.h
@@ -49,7 +49,7 @@ protected:
 template <class T>
 class GraphicsMan_v1 : public GraphicsMan {
 public:
-	GraphicsMan_v1<T>(T &display) : _display(display) { this->setBounds(Common::Rect(280, 160)); }
+	GraphicsMan_v1(T &display) : _display(display) { this->setBounds(Common::Rect(280, 160)); }
 
 	void drawLine(const Common::Point &p1, const Common::Point &p2, byte color) const override;
 	void drawShape(Common::ReadStream &shape, Common::Point &pos, byte rotation = 0, byte scaling = 1, byte color = 0x7f) const override;
@@ -69,7 +69,7 @@ private:
 template <class T>
 class GraphicsMan_v2 : public GraphicsMan_v1<T> {
 public:
-	GraphicsMan_v2<T>(T &display) : GraphicsMan_v1<T>(display), _color(0) { }
+	GraphicsMan_v2(T &display) : GraphicsMan_v1<T>(display), _color(0) { }
 	void drawPic(Common::SeekableReadStream &pic, const Common::Point &pos) override;
 
 protected:
@@ -96,7 +96,7 @@ private:
 template <class T>
 class GraphicsMan_v3 : public GraphicsMan_v2<T> {
 public:
-	GraphicsMan_v3<T>(T &display) : GraphicsMan_v2<T>(display) { }
+	GraphicsMan_v3(T &display) : GraphicsMan_v2<T>(display) { }
 
 private:
 	void fillRowLeft(Common::Point p, const byte pattern, const bool stopBit) override;

--- a/engines/startrek/fixedint.h
+++ b/engines/startrek/fixedint.h
@@ -55,7 +55,7 @@ public:
 	 * Constructor from other fixed-point formats.
 	 */
 	template<typename T2, uint otherTB, uint otherDB>
-	explicit TFixedInt<T, totalBits, decimalBits>(const TFixedInt<T2, otherTB, otherDB> &fi) {
+	explicit TFixedInt(const TFixedInt<T2, otherTB, otherDB> &fi) {
 		int diff = otherDB - decimalBits;
 		if (otherDB >= decimalBits)
 			val = fi.raw() >> diff;

--- a/engines/titanic/support/fixed_queue.h
+++ b/engines/titanic/support/fixed_queue.h
@@ -37,7 +37,7 @@ protected:
 	Common::Array<T> _data;
 	size_type _topIndex;
 public:
-	FixedQueue<T, MAX_SIZE>() : _topIndex(0) {
+	FixedQueue() : _topIndex(0) {
 		_data.reserve(MAX_SIZE);
 	}
 


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
Fix repetitive warnings about template-id in constructor/destructor and ensure C++20 compatibility. Warnings encountered when compiling with GCC 14.