### PR TITLE
DIRECTOR: Make absolute path coherent with path separator

### DIFF
--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -175,7 +175,7 @@ Common::String DirectorEngine::getCurrentPath() const { return _currentWindow->g
 Common::String DirectorEngine::getCurrentAbsolutePath() {
 	Common::String currentPath = getCurrentPath();
 	Common::String result;
-	result += (getPlatform() == Common::kPlatformWindows) ? "C:\\" : "";
+	result += (getPlatform() == Common::kPlatformWindows && _version >= 400) ? "C:\\" : "";
 	result += convertPath(currentPath);
 	return result;
 }


### PR DESCRIPTION
Path separator is set to \ only on director 4+ and Windows platform in DirectorEngine constructor.
Don't use a \ separator in getCurrentAbsolutePath on versions older than Director 4.
