### PR TITLE
GRAPHICS: OPENGL: Don't patch glad.h

### DIFF
--- a/graphics/opengl/context.cpp
+++ b/graphics/opengl/context.cpp
@@ -20,6 +20,12 @@
  */
 
 #define GLAD_GL_IMPLEMENTATION
+// sscanf_s is used by glad on MSVC only
+// we can't know before c=config.h is loaded that GLAD will be used
+// but at this time it will be too late to allow sscanf_s
+#ifdef _MSC_VER
+#define FORBIDDEN_SYMBOL_EXCEPTION_sscanf_s
+#endif
 
 #include "graphics/opengl/context.h"
 

--- a/graphics/opengl/glad.h
+++ b/graphics/opengl/glad.h
@@ -7750,11 +7750,11 @@ GLAD_API_CALL int gladLoadGLES2( GLADloadfunc load);
 #ifndef GLAD_IMPL_UTIL_C_
 #define GLAD_IMPL_UTIL_C_
 
-//#ifdef _MSC_VER
-//#define GLAD_IMPL_UTIL_SSCANF sscanf_s
-//#else
+#ifdef _MSC_VER
+#define GLAD_IMPL_UTIL_SSCANF sscanf_s
+#else
 #define GLAD_IMPL_UTIL_SSCANF sscanf
-//#endif
+#endif
 
 #endif /* GLAD_IMPL_UTIL_C_ */
 
@@ -13173,7 +13173,7 @@ int gladLoadGLES2( GLADloadfunc load) {
 
 
 
-
+ 
 
 
 #ifdef __cplusplus
@@ -13181,3 +13181,4 @@ int gladLoadGLES2( GLADloadfunc load) {
 #endif
 
 #endif /* GLAD_GL_IMPLEMENTATION */
+


### PR DESCRIPTION
As the file is autogenerated, avoid patching it.
Instead allow sscanf_s in context.cpp. That's the only place where GLAD will need to use sscanf_s as it's where GLAD implementation is enabled (GLAD_GL_IMPLEMENTATION is defined here).

All other places which use GLAD, only use it for the GL headers.

Making a PR to check it still builds.