### PR TITLE
DIRECTOR: Add detection for Jan Lindblad presenterar den sjungande Fågelboken

### DIFF
--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -5468,6 +5468,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// lindblad.exe file, and I assume all the data files are functionally
 	// the same, even if they have resource and data forks.
 	WINGAME1_l("singingbirdbook", "", "lindblad.exe", "t:713376834e4e94d87ad931a66c3575fc", 698995, Common::SE_SWE, 404),
+	MACGAME1_l("singingbirdbook", "", "xn--Den Sjungande Fgelboken-y8b", "fc608944b366a5f450fa6f11625ce75f", 482582, Common::SE_SWE, 404),
 
 	// Published by Pearson in association with the Ski Club of Great Britain
 	WINDEMO1("skieurope96", "Demo", "SKI.EXE", "3643257d68fadce83611760435ca5cd4", 696861, 404),

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -5467,7 +5467,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 	// Macromedia 4.0.4. But dumping that version still gives you the
 	// lindblad.exe file, and I assume all the data files are functionally
 	// the same, even if they have resource and data forks.
-	WINGAME1t_l("singingbirdbook", "", "lindblad.exe", "713376834e4e94d87ad931a66c3575fc", 698995, Common::SE_SWE, 404),
+	WINGAME1_l("singingbirdbook", "", "lindblad.exe", "t:713376834e4e94d87ad931a66c3575fc", 698995, Common::SE_SWE, 404),
 
 	// Published by Pearson in association with the Ski Club of Great Britain
 	WINDEMO1("skieurope96", "Demo", "SKI.EXE", "3643257d68fadce83611760435ca5cd4", 696861, 404),

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -419,7 +419,6 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "shrmess",			"Schoolhouse Rock!: 1st-4th Grade Math Essentials" },
 	{ "simpsonsplayer",		"The Simpsons Cartoon Player" },
 	{ "simpsonsstudio",		"The Simpsons Cartoon Studio" },
-	{ "singingbirdbook",		"Jan Lindblad presenterar den sjungande Fågelboken" },
 	{ "sinkha",				"Sinkha: The 3D Multimedia Novel" },
 	{ "sinkha1",			"Sinkha: Hyleyn" },
 	{ "sinkha2",			"Sinkha: Atmosphere / Planet of the Clouds" },
@@ -1422,6 +1421,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "polis3",				"Polis 3: Vargspår" },
 	{ "requiem",			"Requiem: en mordgåta på 1600-talet" },
 	{ "rymdjakten",			"Rymdjakten" },
+	{ "singingbirdbook",		"Jan Lindblad presenterar den sjungande Fågelboken" },
 	{ "sverigejakten",		"Sverigejakten"},
 	{ "speltajm",			"Trazan & Banarne presenterar Speltajm" },
 	{ "xtown1",				"CrossTown: Giftet" },
@@ -2260,13 +2260,6 @@ static const DirectorGameDescription gameDescriptions[] = {
 							   "Shared.Dir", "89f558d6a6535c16ec440948d86988b8", 3570542, 404),
 	WINDEMO2t("wrath", "Demo", "WRATH.EXE",	 "5d0ee796571b99d402a06438ae2f3d56", 696815,
 							   "SHARED.DIR", "e709f7b88f6241e4f45632beb0533ac1", 3570542, 404),
-
-	// Jan Lindblad presenterar den sjungande Fågelboken
-	// There is also a Macintosh version which also appears to be using
-	// Macromedia 4.0.4. But dumping that version still gives you the
-	// lindblad.exe file, and I assume all the data files are functionally
-	// the same, even if they have resource and data forks.
-	WINGAME1t_l("singingbirdbook", "", "lindblad.exe", "713376834e4e94d87ad931a66c3575fc", 698995, Common::SE_SWE, 404),
 
 //////////////////////////////////////////////////
 //
@@ -5468,6 +5461,13 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	// Win version is D5
 	MACGAME1("simpsontrivia", "v3.1", "Simpsons Trivia 3.1", "db9b7f11aea52a294d2986a94a184000", 58354, 403),
+
+	// Jan Lindblad presenterar den sjungande Fågelboken
+	// There is also a Macintosh version which also appears to be using
+	// Macromedia 4.0.4. But dumping that version still gives you the
+	// lindblad.exe file, and I assume all the data files are functionally
+	// the same, even if they have resource and data forks.
+	WINGAME1t_l("singingbirdbook", "", "lindblad.exe", "713376834e4e94d87ad931a66c3575fc", 698995, Common::SE_SWE, 404),
 
 	// Published by Pearson in association with the Ski Club of Great Britain
 	WINDEMO1("skieurope96", "Demo", "SKI.EXE", "3643257d68fadce83611760435ca5cd4", 696861, 404),

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -419,6 +419,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "shrmess",			"Schoolhouse Rock!: 1st-4th Grade Math Essentials" },
 	{ "simpsonsplayer",		"The Simpsons Cartoon Player" },
 	{ "simpsonsstudio",		"The Simpsons Cartoon Studio" },
+	{ "singingbirdbook",		"Jan Lindblad presenterar den sjungande Fågelboken" },
 	{ "sinkha",				"Sinkha: The 3D Multimedia Novel" },
 	{ "sinkha1",			"Sinkha: Hyleyn" },
 	{ "sinkha2",			"Sinkha: Atmosphere / Planet of the Clouds" },
@@ -2259,6 +2260,13 @@ static const DirectorGameDescription gameDescriptions[] = {
 							   "Shared.Dir", "89f558d6a6535c16ec440948d86988b8", 3570542, 404),
 	WINDEMO2t("wrath", "Demo", "WRATH.EXE",	 "5d0ee796571b99d402a06438ae2f3d56", 696815,
 							   "SHARED.DIR", "e709f7b88f6241e4f45632beb0533ac1", 3570542, 404),
+
+	// Jan Lindblad presenterar den sjungande Fågelboken
+	// There is also a Macintosh version which also appears to be using
+	// Macromedia 4.0.4. But dumping that version still gives you the
+	// lindblad.exe file, and I assume all the data files are functionally
+	// the same, even if they have resource and data forks.
+	WINGAME1t_l("singingbirdbook", "", "lindblad.exe", "713376834e4e94d87ad931a66c3575fc", 698995, Common::SE_SWE, 404),
 
 //////////////////////////////////////////////////
 //


### PR DESCRIPTION
This is my attempt at adding detection for Jan Lindblad presenterar den sjungande Fågelboken:

![image](https://github.com/scummvm/scummvm/assets/601765/26cfb69f-54fb-4a7e-ab57-063bca1269b5)

(The original price tag says 595.00 SEK, or about $56. I paid quite a bit less for it at my local thrift store!)

It starts, which is encouraging:

![image](https://github.com/scummvm/scummvm/assets/601765/b2808894-8ab4-4879-aead-35900e1c7b58)

But while you can click on the buttons, and they depress, they never pop back up and nothing else happens. There is also a Macintosh version on the CD, but extracting it with the Dumper Companion still gives you the Windows EXE in addition to the Mac one, so I don't know if there's any need for a separate detection entry for it? Though a bunch of the files get extracted as MacBinary, so maybe it is needed after all?