### PR TITLE
ENGINES: Really split detection from engine plugins

### DIFF
--- a/backends/platform/libretro/src/libretro-os-utils.cpp
+++ b/backends/platform/libretro/src/libretro-os-utils.cpp
@@ -150,8 +150,6 @@ int OSystem_libretro::testGame(const char *filedata, bool autodetect) {
 		}
 	}
 
-	PluginManager::instance().unloadDetectionPlugin();
-	PluginManager::instance().unloadAllPlugins();
 	PluginManager::destroy();
 	return res;
 }

--- a/backends/plugins/dynamic-plugin.h
+++ b/backends/plugins/dynamic-plugin.h
@@ -98,6 +98,7 @@ public:
 
 	virtual void unloadPlugin() {
 		delete _pluginObject;
+		_pluginObject = nullptr;
 	}
 
 	virtual Common::Path getFileName() const override {

--- a/backends/plugins/dynamic-plugin.h
+++ b/backends/plugins/dynamic-plugin.h
@@ -40,7 +40,7 @@ public:
 	DynamicPlugin(const Common::Path &filename) :
 		_filename(filename) {}
 
-	virtual bool loadPlugin() {
+	bool loadPlugin() override {
 		// Validate the plugin API version
 		IntFunc verFunc = (IntFunc)findSymbol("PLUGIN_getVersion");
 		if (!verFunc) {
@@ -96,12 +96,12 @@ public:
 		return true;
 	}
 
-	virtual void unloadPlugin() {
+	void unloadPlugin() override {
 		delete _pluginObject;
 		_pluginObject = nullptr;
 	}
 
-	virtual Common::Path getFileName() const override {
+	Common::Path getFileName() const override {
 		return _filename;
 	}
 };

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -1053,7 +1053,7 @@ static void listAllGames(const Common::String &engineID) {
 	printf("Game ID                        Full Title                                                 \n"
 	       "------------------------------ -----------------------------------------------------------\n");
 
-	const PluginList &plugins = EngineMan.getPlugins();
+	const PluginList &plugins = EngineMan.getPlugins(PLUGIN_TYPE_ENGINE_DETECTION);
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
 		const MetaEngineDetection &metaEngine = (*iter)->get<MetaEngineDetection>();
 
@@ -1088,7 +1088,7 @@ static void listAllEngines() {
 	printf("Engine ID       Engine Name                                           \n"
 	       "--------------- ------------------------------------------------------\n");
 
-	const PluginList &plugins = EngineMan.getPlugins();
+	const PluginList &plugins = EngineMan.getPlugins(PLUGIN_TYPE_ENGINE_DETECTION);
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
 		const MetaEngineDetection &metaEngine = (*iter)->get<MetaEngineDetection>();
 		printf("%-15s %s\n", metaEngine.getName(), metaEngine.getEngineName());
@@ -1178,7 +1178,7 @@ static void printStatistics(const Common::String &engineID) {
 
 	bool approximation = false;
 	int engineCount = 0, gameCount = 0, variantCount = 0;
-	const PluginList &plugins = EngineMan.getPlugins();
+	const PluginList &plugins = EngineMan.getPlugins(PLUGIN_TYPE_ENGINE_DETECTION);
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
 		const MetaEngineDetection &metaEngine = (*iter)->get<MetaEngineDetection>();
 		if (summary || all || Common::find(engines.begin(), engines.end(), metaEngine.getName()) != engines.end()) {
@@ -1226,7 +1226,7 @@ static void listDebugFlags(const Common::String &engineID) {
 	if (engineID == "global")
 		printDebugFlags(gDebugChannels);
 	else {
-		const PluginList &plugins = EngineMan.getPlugins();
+		const PluginList &plugins = EngineMan.getPlugins(PLUGIN_TYPE_ENGINE_DETECTION);
 		for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
 			const MetaEngineDetection &metaEngine = (*iter)->get<MetaEngineDetection>();
 			if (metaEngine.getName() == engineID) {
@@ -1245,7 +1245,7 @@ static void listDebugFlags(const Common::String &engineID) {
 static void listAllEngineDebugFlags() {
 	printf("Flag name       Flag description                                           \n");
 
-	const PluginList &plugins = EngineMan.getPlugins();
+	const PluginList &plugins = EngineMan.getPlugins(PLUGIN_TYPE_ENGINE_DETECTION);
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
 		const MetaEngineDetection &metaEngine = (*iter)->get<MetaEngineDetection>();
 		printf("--------------- ------------------------------------------------------\n");
@@ -1451,7 +1451,7 @@ static void listAudioDevices() {
 
 /** Dump MD5s from detection entries into STDOUT */
 static void dumpAllDetectionEntries() {
-	const PluginList &plugins = EngineMan.getPlugins();
+	const PluginList &plugins = EngineMan.getPlugins(PLUGIN_TYPE_ENGINE_DETECTION);
 
 	printf("scummvm (\n");
 	printf("\tauthor \"scummvm\"\n");

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -1337,17 +1337,17 @@ static Common::Error listSaves(const Common::String &singleTarget) {
 		Common::String currentTarget;
 		QualifiedGameDescriptor game;
 
-		const Plugin *metaEnginePlugin = nullptr;
+		const Plugin *detectionPlugin = nullptr;
 		const Plugin *enginePlugin = nullptr;
 
 		if (ConfMan.hasGameDomain(*i)) {
 			// The name is a known target
 			currentTarget = *i;
 			EngineMan.upgradeTargetIfNecessary(*i);
-			game = EngineMan.findTarget(*i, &metaEnginePlugin);
+			game = EngineMan.findTarget(*i, &detectionPlugin);
 		} else if (game = findGameMatchingName(*i), !game.gameId.empty()) {
 			// The name is a known game id
-			metaEnginePlugin = EngineMan.findDetectionPlugin(game.engineId);
+			detectionPlugin = EngineMan.findDetectionPlugin(game.engineId);
 			currentTarget = createTemporaryTarget(game.engineId, game.gameId);
 		} else {
 			return Common::Error(Common::kEnginePluginNotFound, Common::String::format("target '%s'", singleTarget.c_str()));
@@ -1356,7 +1356,7 @@ static Common::Error listSaves(const Common::String &singleTarget) {
 		// If we actually found a domain, we're going to change the domain
 		ConfMan.setActiveDomain(currentTarget);
 
-		if (!metaEnginePlugin) {
+		if (!detectionPlugin) {
 			// If the target was specified, treat this as an error, and otherwise skip it.
 			if (!singleTarget.empty())
 				return Common::Error(Common::kMetaEnginePluginNotFound,
@@ -1364,7 +1364,7 @@ static Common::Error listSaves(const Common::String &singleTarget) {
 			printf("MetaEnginePlugin could not be loaded for target '%s'\n", i->c_str());
 			continue;
 		} else {
-			enginePlugin = PluginMan.getEngineFromMetaEngine(metaEnginePlugin);
+			enginePlugin = PluginMan.getEngineFromDetectionPlugin(detectionPlugin);
 
 			if (!enginePlugin) {
 				// If the target was specified, treat this as an error, and otherwise skip it.

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -1026,8 +1026,8 @@ static void listGames(const Common::String &engineID) {
 
 	const PluginList &plugins = EngineMan.getPlugins(PLUGIN_TYPE_ENGINE);
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
-		const Plugin *p = EngineMan.findPlugin((*iter)->getName());
-		/* If for some reason, we can't find the MetaEngine for this Engine, just ignore it */
+		const Plugin *p = EngineMan.findDetectionPlugin((*iter)->getName());
+		/* If for some reason, we can't find the MetaEngineDetection for this Engine, just ignore it */
 		if (!p) {
 			continue;
 		}
@@ -1073,8 +1073,8 @@ static void listEngines() {
 
 	const PluginList &plugins = EngineMan.getPlugins(PLUGIN_TYPE_ENGINE);
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
-		const Plugin *p = EngineMan.findPlugin((*iter)->getName());
-		/* If for some reason, we can't find the MetaEngine for this Engine, just ignore it */
+		const Plugin *p = EngineMan.findDetectionPlugin((*iter)->getName());
+		/* If for some reason, we can't find the MetaEngineDetection for this Engine, just ignore it */
 		if (!p) {
 			continue;
 		}
@@ -1347,7 +1347,7 @@ static Common::Error listSaves(const Common::String &singleTarget) {
 			game = EngineMan.findTarget(*i, &metaEnginePlugin);
 		} else if (game = findGameMatchingName(*i), !game.gameId.empty()) {
 			// The name is a known game id
-			metaEnginePlugin = EngineMan.findPlugin(game.engineId);
+			metaEnginePlugin = EngineMan.findDetectionPlugin(game.engineId);
 			currentTarget = createTemporaryTarget(game.engineId, game.gameId);
 		} else {
 			return Common::Error(Common::kEnginePluginNotFound, Common::String::format("target '%s'", singleTarget.c_str()));
@@ -2019,7 +2019,7 @@ bool processSettings(Common::String &command, Common::StringMap &settings, Commo
 		if (command == "md5" && settings.contains("md5-engine")) {
 			Common::String engineID = settings["md5-engine"];
 
-			const Plugin *plugin = EngineMan.findPlugin(engineID);
+			const Plugin *plugin = EngineMan.findDetectionPlugin(engineID);
 			if (!plugin) {
 				warning("'%s' is an invalid engine ID. Use the --list-engines command to list supported engine IDs", engineID.c_str());
 				return true;

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -1290,8 +1290,7 @@ static Common::Error listRecords(const Common::String &singleTarget) {
 			// The name is a known target
 			currentTarget = *i;
 			EngineMan.upgradeTargetIfNecessary(*i);
-			const Plugin *metaEnginePlugin = nullptr;
-			game = EngineMan.findTarget(*i, &metaEnginePlugin);
+			game = EngineMan.findTarget(*i);
 		} else if (game = findGameMatchingName(*i), !game.gameId.empty()) {
 			currentTarget = createTemporaryTarget(game.engineId, game.gameId);
 		} else {

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -321,7 +321,7 @@ static Common::Error runGame(const Plugin *enginePlugin, OSystem &system, const 
 	keymapper->cleanupGameKeymaps();
 
 	// Free up memory
-	delete engine;
+	metaEngine.deleteInstance(engine, game, meDescriptor);
 
 	// Reset the file/directory mappings
 	SearchMan.clear();

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -751,7 +751,7 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 
 		if (result.getCode() == Common::kNoError) {
 			// Then, get the relevant Engine plugin from MetaEngine.
-			enginePlugin = PluginMan.getEngineFromMetaEngine(plugin);
+			enginePlugin = PluginMan.getEngineFromDetectionPlugin(plugin);
 			if (enginePlugin == nullptr) {
 				result = Common::kEnginePluginNotFound;
 			}

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -519,8 +519,6 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 		if (res.getCode() != Common::kNoError)
 			warning("%s", res.getDesc().c_str());
 
-		PluginManager::instance().unloadDetectionPlugin();
-		PluginManager::instance().unloadAllPlugins();
 		PluginManager::destroy();
 
 		return res.getCode();
@@ -892,8 +890,6 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 	Cloud::CloudManager::destroy();
 #endif
 #endif
-	PluginManager::instance().unloadDetectionPlugin();
-	PluginManager::instance().unloadAllPlugins();
 	PluginManager::destroy();
 	GUI::GuiManager::destroy();
 	Common::ConfigManager::destroy();

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -141,7 +141,7 @@ static Common::Error identifyGame(const Common::String &debugLevels, const Plugi
 		return Common::kUnknownError;
 	}
 
-	*detectionPlugin = EngineMan.findPlugin(engineId);
+	*detectionPlugin = EngineMan.findDetectionPlugin(engineId);
 	if (!*detectionPlugin) {
 		warning("'%s' is an invalid engine ID. Use the --list-engines command to list supported engine IDs", engineId.c_str());
 		return Common::kMetaEnginePluginNotFound;

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -120,7 +120,9 @@ static bool launcherDialog() {
 	return status;
 }
 
-static const Plugin *detectPlugin() {
+static Common::Error identifyGame(const Common::String &debugLevels, const Plugin **detectionPlugin, DetectedGame &game, const void **descriptor) {
+	assert(detectionPlugin);
+
 	// Figure out the engine ID and game ID
 	Common::String engineId = ConfMan.get("engineid");
 	Common::String gameId = ConfMan.get("gameid");
@@ -131,31 +133,39 @@ static const Plugin *detectPlugin() {
 	// At this point the engine ID and game ID must be known
 	if (engineId.empty()) {
 		warning("The engine ID is not set for target '%s'", ConfMan.getActiveDomainName().c_str());
-		return nullptr;
+		return Common::kUnknownError;
 	}
 
 	if (gameId.empty()) {
 		warning("The game ID is not set for target '%s'", ConfMan.getActiveDomainName().c_str());
-		return nullptr;
+		return Common::kUnknownError;
 	}
 
-	const Plugin *plugin = EngineMan.findPlugin(engineId);
-	if (!plugin) {
+	*detectionPlugin = EngineMan.findPlugin(engineId);
+	if (!*detectionPlugin) {
 		warning("'%s' is an invalid engine ID. Use the --list-engines command to list supported engine IDs", engineId.c_str());
-		return nullptr;
+		return Common::kMetaEnginePluginNotFound;
 	}
-
 	// Query the plugin for the game descriptor
-	const MetaEngineDetection &metaEngine = plugin->get<MetaEngineDetection>();
-	printf("   Looking for a plugin supporting this target... %s\n", metaEngine.getEngineName());
+	MetaEngineDetection &metaEngine = (*detectionPlugin)->get<MetaEngineDetection>();
+
+	// before doing anything, we register the debug channels of the (Meta)Engine(Detection)
 	DebugMan.addAllDebugChannels(metaEngine.getDebugChannels());
-	PlainGameDescriptor game = metaEngine.findGame(gameId.c_str());
-	if (!game.gameId) {
-		warning("'%s' is an invalid game ID for the engine '%s'. Use the --list-games option to list supported game IDs", gameId.c_str(), engineId.c_str());
-		return nullptr;
+	// Setup now the debug channels
+	Common::StringTokenizer tokenizer(debugLevels, " ,");
+	while (!tokenizer.empty()) {
+		Common::String token = tokenizer.nextToken();
+		if (token.equalsIgnoreCase("all"))
+			DebugMan.enableAllDebugChannels();
+		else if (!DebugMan.enableDebugChannel(token))
+			warning("Engine does not support debug level '%s'", token.c_str());
 	}
 
-	return plugin;
+	Common::Error result = metaEngine.identifyGame(game, descriptor);
+	if (result.getCode() != Common::kNoError) {
+		warning("Couldn't identify game '%s' for the engine '%s'.", gameId.c_str(), engineId.c_str());
+	}
+	return result;
 }
 
 void saveLastLaunchedTarget(const Common::String &target) {
@@ -168,8 +178,7 @@ void saveLastLaunchedTarget(const Common::String &target) {
 }
 
 // TODO: specify the possible return values here
-static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, OSystem &system, const Common::String &debugLevels) {
-	assert(plugin);
+static Common::Error runGame(const Plugin *enginePlugin, OSystem &system, const DetectedGame &game, const void *meDescriptor) {
 	assert(enginePlugin);
 
 	// Determine the game data path, for validation and error messages
@@ -198,23 +207,6 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 		err = Common::kPathNotDirectory;
 	}
 
-	// Create the game's MetaEngineDetection.
-	const MetaEngineDetection &metaEngineDetection = plugin->get<MetaEngineDetection>();
-
-	// before we instantiate the engine, we register debug channels for it
-	DebugMan.addAllDebugChannels(metaEngineDetection.getDebugChannels());
-
-	// On creation the engine should have set up all debug levels so we can use
-	// the command line arguments here
-	Common::StringTokenizer tokenizer(debugLevels, " ,");
-	while (!tokenizer.empty()) {
-		Common::String token = tokenizer.nextToken();
-		if (token.equalsIgnoreCase("all"))
-			DebugMan.enableAllDebugChannels();
-		else if (!DebugMan.enableDebugChannel(token))
-			warning("Engine does not support debug level '%s'", token.c_str());
-	}
-
 	// Create the game's MetaEngine.
 	MetaEngine &metaEngine = enginePlugin->get<MetaEngine>();
 	if (err.getCode() == Common::kNoError) {
@@ -222,9 +214,8 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 		// Apparently some engines query them in their constructor, thus we
 		// need to set this up before instance creation.
 		metaEngine.registerDefaultSettings(target);
+		err = metaEngine.createInstance(&system, &engine, game, meDescriptor);
 	}
-
-	err = metaEngine.createInstance(&system, &engine);
 
 	// Check for errors
 	if (!engine || err.getCode() != Common::kNoError) {
@@ -232,7 +223,7 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 		// Print a warning; note that scummvm_main will also
 		// display an error dialog, so we don't have to do this here.
 		warning("%s failed to instantiate engine: %s (target '%s', path '%s')",
-			metaEngineDetection.getEngineName(),
+			game.engineId.c_str(),
 			err.getDesc().c_str(),
 			target.c_str(),
 			dir.getPath().toString(Common::Path::kNativeSeparator).c_str()
@@ -245,7 +236,6 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 			ConfMan.removeGameDomain(target.c_str());
 		}
 
-		DebugMan.removeAllDebugChannels();
 		return err;
 	}
 
@@ -255,13 +245,8 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 	// Set the window caption to the game name
 	Common::String caption(ConfMan.get("description"));
 
-	if (caption.empty()) {
-		// here, we don't need to set the debug channels because it has been set earlier
-		PlainGameDescriptor game = metaEngineDetection.findGame(ConfMan.get("gameid").c_str());
-		if (game.description) {
-			caption = game.description;
-		}
-	}
+	if (caption.empty())
+		caption = game.description;
 	if (caption.empty())
 		caption = target;
 	if (!caption.empty())	{
@@ -337,8 +322,6 @@ static Common::Error runGame(const Plugin *plugin, const Plugin *enginePlugin, O
 
 	// Free up memory
 	delete engine;
-
-	DebugMan.removeAllDebugChannels();
 
 	// Reset the file/directory mappings
 	SearchMan.clear();
@@ -760,14 +743,21 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 		EngineMan.upgradeTargetIfNecessary(ConfMan.getActiveDomainName());
 
 		// Try to find a MetaEnginePlugin which feels responsible for the specified game.
-		const Plugin *plugin = detectPlugin();
-
-		// Then, get the relevant Engine plugin from MetaEngine.
 		const Plugin *enginePlugin = nullptr;
-		if (plugin)
-			enginePlugin = PluginMan.getEngineFromMetaEngine(plugin);
+		const Plugin *plugin = nullptr;
+		DetectedGame game;
+		const void *meDescriptor = nullptr;
+		Common::Error result = identifyGame(specialDebug, &plugin, game, &meDescriptor);
 
-		if (enginePlugin) {
+		if (result.getCode() == Common::kNoError) {
+			// Then, get the relevant Engine plugin from MetaEngine.
+			enginePlugin = PluginMan.getEngineFromMetaEngine(plugin);
+			if (enginePlugin == nullptr) {
+				result = Common::kEnginePluginNotFound;
+			}
+		}
+
+		if (result.getCode() == Common::kNoError) {
 			// Unload all plugins not needed for this game, to save memory
 			// Right now, we have a MetaEngine plugin, and we want to unload all except Engine.
 
@@ -795,6 +785,8 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 				Common::PlaybackFile record;
 				record.openRead(recordFileName);
 				debug("info:author=%s name=%s description=%s", record.getHeader().author.c_str(), record.getHeader().name.c_str(), record.getHeader().description.c_str());
+
+				DebugMan.removeAllDebugChannels();
 				break;
 			}
 #endif
@@ -803,10 +795,12 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 				ttsMan->pushState();
 			}
 			// Try to run the game
-			Common::Error result = runGame(plugin, enginePlugin, system, specialDebug);
+			result = runGame(enginePlugin, system, game, meDescriptor);
 			if (ttsMan != nullptr) {
 				ttsMan->popState();
 			}
+
+			DebugMan.removeAllDebugChannels();
 
 #ifdef ENABLE_EVENTRECORDER
 			// Flush Event recorder file. The recorder does not get reinitialized for next game
@@ -874,6 +868,8 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 			PluginManager::instance().loadAllPluginsOfType(PLUGIN_TYPE_ENGINE); // only for cached manager
 			PluginManager::instance().loadDetectionPlugin(); // only for uncached manager
 		} else {
+			DebugMan.removeAllDebugChannels();
+
 			GUI::displayErrorDialog(_("Could not find any engine capable of running the selected game"));
 
 			// Clear the active domain

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -632,8 +632,9 @@ void PluginManager::addToPluginsInMemList(Plugin *plugin) {
 	// The plugin is valid, see if it provides the same module as an
 	// already loaded one and should replace it.
 
-	PluginList::iterator pl = _pluginsInMem[plugin->getType()].begin();
-	while (!found && pl != _pluginsInMem[plugin->getType()].end()) {
+	PluginList &list = _pluginsInMem[plugin->getType()];
+	PluginList::iterator pl = list.begin();
+	while (!found && pl != list.end()) {
 		if (!strcmp(plugin->getName(), (*pl)->getName())) {
 			// Found a duplicated module. Replace the old one.
 			found = true;
@@ -647,7 +648,7 @@ void PluginManager::addToPluginsInMemList(Plugin *plugin) {
 
 	if (!found) {
 		// If it provides a new module, just add it to the list of known plugins in memory.
-		_pluginsInMem[plugin->getType()].push_back(plugin);
+		list.push_back(plugin);
 	}
 }
 

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -334,6 +334,19 @@ const Plugin *PluginManager::getMetaEngineFromEngine(const Plugin *plugin) {
 	return nullptr;
 }
 
+PluginManagerUncached::~PluginManagerUncached() {
+	// Unload from memory all engine plugins without deleting them
+	// They are also referenced from _allEnginePlugins which we clean up here
+	unloadPluginsExcept(PLUGIN_TYPE_ENGINE, nullptr, false);
+
+	for (PluginList::iterator p = _allEnginePlugins.begin(); p != _allEnginePlugins.end(); ++p) {
+		delete *p;
+	}
+	_allEnginePlugins.clear();
+
+	delete _detectionPlugin;
+}
+
 /**
  * This should only be called once by main()
  **/

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -286,54 +286,6 @@ void PluginManager::addPluginProvider(PluginProvider *pp) {
 	_providers.push_back(pp);
 }
 
-const Plugin *PluginManager::getEngineFromDetectionPlugin(const Plugin *plugin) {
-	assert(plugin->getType() == PLUGIN_TYPE_ENGINE_DETECTION);
-
-	const Plugin *enginePlugin = nullptr;
-
-	// Use the engineID from MetaEngine for comparison.
-	Common::String metaEnginePluginName = plugin->getName();
-
-	enginePlugin = PluginMan.findEnginePlugin(metaEnginePluginName);
-
-	if (enginePlugin) {
-		debug(9, "MetaEngine: %s \t matched to \t Engine: %s", plugin->get<MetaEngineDetection>().getEngineName(), enginePlugin->getFileName().toString().c_str());
-		return enginePlugin;
-	}
-
-	debug(9, "MetaEngine: %s couldn't find a match for an engine plugin.", plugin->get<MetaEngineDetection>().getEngineName());
-	return nullptr;
-}
-
-const Plugin *PluginManager::getMetaEngineFromEngine(const Plugin *plugin) {
-	assert(plugin->getType() == PLUGIN_TYPE_ENGINE);
-
-	const Plugin *metaEngine = nullptr;
-
-	PluginList pl = PluginMan.getPlugins(PLUGIN_TYPE_ENGINE_DETECTION);
-
-	// This will return a name of the Engine plugin, which will be identical to
-	// a getEngineID from a relevant MetaEngine.
-	Common::String enginePluginName(plugin->getName());
-
-	for (PluginList::const_iterator itr = pl.begin(); itr != pl.end(); itr++) {
-		Common::String metaEngineName = (*itr)->getName();
-
-		if (metaEngineName.equalsIgnoreCase(enginePluginName)) {
-			metaEngine = (*itr);
-			break;
-		}
-	}
-
-	if (metaEngine) {
-		debug(9, "Engine: %s matched to MetaEngine: %s", plugin->getFileName().toString().c_str(), metaEngine->get<MetaEngineDetection>().getEngineName());
-		return metaEngine;
-	}
-
-	debug(9, "Engine: %s couldn't find a match for a MetaEngine plugin.", plugin->getFileName().toString().c_str());
-	return nullptr;
-}
-
 PluginManagerUncached::~PluginManagerUncached() {
 	// Unload from memory all engine plugins without deleting them
 	// They are also referenced from _allEnginePlugins which we clean up here

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -867,7 +867,7 @@ const Plugin *PluginManager::findEnginePlugin(const Common::String &engineId) {
 	return nullptr;
 }
 
-QualifiedGameDescriptor EngineManager::findTarget(const Common::String &target, const Plugin **plugin) const {
+QualifiedGameDescriptor EngineManager::findTarget(const Common::String &target) const {
 	// Ignore empty targets
 	if (target.empty())
 		return QualifiedGameDescriptor();
@@ -890,9 +890,6 @@ QualifiedGameDescriptor EngineManager::findTarget(const Common::String &target, 
 	if (!desc.gameId) {
 		return QualifiedGameDescriptor();
 	}
-
-	if (plugin)
-		*plugin = foundPlugin;
 
 	return QualifiedGameDescriptor(engine.getName(), desc);
 }

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -704,7 +704,7 @@ QualifiedGameList EngineManager::findGamesMatching(const Common::String &engineI
  **/
 QualifiedGameList EngineManager::findGameInLoadedPlugins(const Common::String &gameId) const {
 	// Find the GameDescriptor for this target
-	const PluginList &plugins = getPlugins();
+	const PluginList &plugins = getPlugins(PLUGIN_TYPE_ENGINE_DETECTION);
 
 	QualifiedGameList results;
 	PluginList::const_iterator iter;
@@ -819,7 +819,7 @@ Common::String EngineManager::createTargetForGame(const DetectedGame &game) {
 }
 
 const Plugin *EngineManager::findDetectionPlugin(const Common::String &engineId) const {
-	const PluginList &plugins = getPlugins();
+	const PluginList &plugins = getPlugins(PLUGIN_TYPE_ENGINE_DETECTION);
 
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); iter++)
 		if (engineId == (*iter)->get<MetaEngineDetection>().getName())

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -286,7 +286,7 @@ void PluginManager::addPluginProvider(PluginProvider *pp) {
 	_providers.push_back(pp);
 }
 
-const Plugin *PluginManager::getEngineFromMetaEngine(const Plugin *plugin) {
+const Plugin *PluginManager::getEngineFromDetectionPlugin(const Plugin *plugin) {
 	assert(plugin->getType() == PLUGIN_TYPE_ENGINE_DETECTION);
 
 	const Plugin *enginePlugin = nullptr;

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -436,6 +436,9 @@ void PluginManagerUncached::loadDetectionPlugin() {
 		return;
 	}
 
+	// Unload all leftover engines before reloading the detection plugin
+	unloadPluginsExcept(PLUGIN_TYPE_ENGINE, nullptr, false);
+
 	if (!_detectionPlugin->loadPlugin()) {
 		debug(9, "Detection plugin was not loaded correctly.");
 		return;

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -671,7 +671,7 @@ QualifiedGameList EngineManager::findGamesMatching(const Common::String &engineI
 
 	if (!engineId.empty()) {
 		// If we got an engine name, look for THE game only in that engine
-		const Plugin *p = EngineMan.findPlugin(engineId);
+		const Plugin *p = EngineMan.findDetectionPlugin(engineId);
 		if (p) {
 			const MetaEngineDetection &engine = p->get<MetaEngineDetection>();
 			DebugMan.addAllDebugChannels(engine.getDebugChannels());
@@ -811,7 +811,7 @@ Common::String EngineManager::createTargetForGame(const DetectedGame &game) {
 	return domain;
 }
 
-const Plugin *EngineManager::findPlugin(const Common::String &engineId) const {
+const Plugin *EngineManager::findDetectionPlugin(const Common::String &engineId) const {
 	const PluginList &plugins = getPlugins();
 
 	for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); iter++)
@@ -871,7 +871,7 @@ QualifiedGameDescriptor EngineManager::findTarget(const Common::String &target, 
 		return QualifiedGameDescriptor();
 
 	// Look for the engine ID
-	const Plugin *foundPlugin = findPlugin(domain->getVal("engineid"));
+	const Plugin *foundPlugin = findDetectionPlugin(domain->getVal("engineid"));
 	if (!foundPlugin) {
 		return QualifiedGameDescriptor();
 	}
@@ -939,7 +939,7 @@ void EngineManager::upgradeTargetForEngineId(const Common::String &target) const
 
 	// First, try to update entries for engines that previously used the "single id" system
 	// Search for an engine whose ID is the game ID
-	const Plugin *plugin = findPlugin(oldGameId);
+	const Plugin *plugin = findDetectionPlugin(oldGameId);
 	if (plugin) {
 		// Run detection on the game path
 		Common::FSNode dir(path);

--- a/base/plugins.h
+++ b/base/plugins.h
@@ -366,6 +366,7 @@ protected:
 	bool loadPluginByFileName(const Common::Path &filename);
 
 public:
+	virtual ~PluginManagerUncached();
 	void init() override;
 	void loadFirstPlugin() override;
 	bool loadNextPlugin() override;

--- a/base/plugins.h
+++ b/base/plugins.h
@@ -319,16 +319,16 @@ public:
 	const Plugin *getMetaEngineFromEngine(const Plugin *plugin);
 
 	/**
-	 * A method which takes in a plugin of type METAENGINE,
-	 * and returns the appropriate & matching ENGINE.
-	 * It uses the MetaEngine's getEngineID to reconstruct the name
+	 * A method which takes in a plugin of type ENGINE_DETECTION,
+	 * and returns the appropriate & matching ENGINE plugin.
+	 * It uses the MetaEngineDetection's getEngineID to reconstruct the name
 	 * of engine plugin, and then tries to matches it with each plugin in memory.
 	 *
-	 * @param A plugin of type METAENGINE.
+	 * @param A plugin of type ENGINE_DETECTION.
 	 *
 	 * @return A plugin of type ENGINE.
 	 */
-	const Plugin *getEngineFromMetaEngine(const Plugin *plugin);
+	const Plugin *getEngineFromDetectionPlugin(const Plugin *plugin);
 
 	// Functions used by the uncached PluginManager
 	virtual void init()	{}

--- a/base/plugins.h
+++ b/base/plugins.h
@@ -292,7 +292,6 @@ protected:
 
 	bool tryLoadPlugin(Plugin *plugin);
 	void addToPluginsInMemList(Plugin *plugin);
-	const Plugin *findEnginePlugin(const Common::String &engineId);
 	const Plugin *findLoadedPlugin(const Common::String &engineId);
 
 	static PluginManager *_instance;
@@ -306,6 +305,15 @@ public:
 	static PluginManager &instance();
 
 	void addPluginProvider(PluginProvider *pp);
+
+	/**
+	 * A method which finds the METAENGINE plugin for the provided engineId
+	 *
+	 * @param engineId The engine ID
+	 *
+	 * @return A plugin of type METAENGINE.
+	 */
+	const Plugin *findEnginePlugin(const Common::String &engineId);
 
 	/**
 	 * A method which takes in a plugin of type ENGINE,

--- a/base/plugins.h
+++ b/base/plugins.h
@@ -315,30 +315,6 @@ public:
 	 */
 	const Plugin *findEnginePlugin(const Common::String &engineId);
 
-	/**
-	 * A method which takes in a plugin of type ENGINE,
-	 * and returns the appropriate & matching METAENGINE.
-	 * It uses the Engine plugin's getName method, which is an identifier,
-	 * and then tries to matches it with each plugin present in memory.
-	 *
-	 * @param plugin A plugin of type ENGINE.
-	 *
-	 * @return A plugin of type METAENGINE.
-	 */
-	const Plugin *getMetaEngineFromEngine(const Plugin *plugin);
-
-	/**
-	 * A method which takes in a plugin of type ENGINE_DETECTION,
-	 * and returns the appropriate & matching ENGINE plugin.
-	 * It uses the MetaEngineDetection's getEngineID to reconstruct the name
-	 * of engine plugin, and then tries to matches it with each plugin in memory.
-	 *
-	 * @param A plugin of type ENGINE_DETECTION.
-	 *
-	 * @return A plugin of type ENGINE.
-	 */
-	const Plugin *getEngineFromDetectionPlugin(const Plugin *plugin);
-
 	// Functions used by the uncached PluginManager
 	virtual void init()	{}
 	virtual void loadFirstPlugin() {}

--- a/base/plugins.h
+++ b/base/plugins.h
@@ -298,6 +298,7 @@ protected:
 	static PluginManager *_instance;
 	PluginManager();
 
+	void unloadAllPlugins();
 public:
 	virtual ~PluginManager();
 
@@ -342,7 +343,6 @@ public:
 	// Functions used only by the cached PluginManager
 	virtual void loadAllPlugins();
 	virtual void loadAllPluginsOfType(PluginType type);
-	void unloadAllPlugins();
 
 	void unloadPluginsExcept(PluginType type, const Plugin *plugin, bool deletePlugin = true);
 

--- a/devtools/create_engine/files/detection.cpp
+++ b/devtools/create_engine/files/detection.cpp
@@ -38,8 +38,8 @@ const DebugChannelDef XyzzyMetaEngineDetection::debugFlagList[] = {
 	DEBUG_CHANNEL_END
 };
 
-XyzzyMetaEngineDetection::XyzzyMetaEngineDetection() : AdvancedMetaEngineDetection(Xyzzy::gameDescriptions,
-	sizeof(ADGameDescription), Xyzzy::xyzzyGames) {
+XyzzyMetaEngineDetection::XyzzyMetaEngineDetection() : AdvancedMetaEngineDetection(
+	Xyzzy::gameDescriptions, Xyzzy::xyzzyGames) {
 }
 
 REGISTER_PLUGIN_STATIC(XYZZY_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, XyzzyMetaEngineDetection);

--- a/devtools/create_engine/files/detection.h
+++ b/devtools/create_engine/files/detection.h
@@ -42,7 +42,7 @@ extern const ADGameDescription gameDescriptions[];
 
 } // End of namespace Xyzzy
 
-class XyzzyMetaEngineDetection : public AdvancedMetaEngineDetection {
+class XyzzyMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 	static const DebugChannelDef debugFlagList[];
 
 public:

--- a/devtools/create_engine/files/metaengine.h
+++ b/devtools/create_engine/files/metaengine.h
@@ -24,7 +24,7 @@
 
 #include "engines/advancedDetector.h"
 
-class XyzzyMetaEngine : public AdvancedMetaEngine {
+class XyzzyMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override;
 

--- a/engines/access/detection.cpp
+++ b/engines/access/detection.cpp
@@ -40,9 +40,9 @@ static const DebugChannelDef debugFlagList[] = {
 
 #include "access/detection_tables.h"
 
-class AccessMetaEngineDetection : public AdvancedMetaEngineDetection {
+class AccessMetaEngineDetection : public AdvancedMetaEngineDetection<Access::AccessGameDescription> {
 public:
-	AccessMetaEngineDetection() : AdvancedMetaEngineDetection(Access::gameDescriptions, sizeof(Access::AccessGameDescription), AccessGames) {
+	AccessMetaEngineDetection() : AdvancedMetaEngineDetection(Access::gameDescriptions, AccessGames) {
 		_maxScanDepth = 3;
 	}
 

--- a/engines/access/detection.h
+++ b/engines/access/detection.h
@@ -33,6 +33,8 @@ enum {
 };
 
 struct AccessGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	int gameID;

--- a/engines/access/metaengine.cpp
+++ b/engines/access/metaengine.cpp
@@ -67,7 +67,7 @@ Common::Platform AccessEngine::getPlatform() const {
 
 } // End of namespace Access
 
-class AccessMetaEngine : public AdvancedMetaEngine {
+class AccessMetaEngine : public AdvancedMetaEngine<Access::AccessGameDescription> {
 public:
 	const char *getName() const override {
 		return "access";
@@ -75,7 +75,7 @@ public:
 
 	bool hasFeature(MetaEngineFeature f) const override;
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Access::AccessGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -100,8 +100,7 @@ bool Access::AccessEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-Common::Error AccessMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Access::AccessGameDescription *gd = (const Access::AccessGameDescription *)desc;
+Common::Error AccessMetaEngine::createInstance(OSystem *syst, Engine **engine, const Access::AccessGameDescription *gd) const {
 	switch (gd->gameID) {
 	case Access::GType_Amazon:
 		*engine = new Access::Amazon::AmazonEngine(syst, gd);

--- a/engines/adl/detection.cpp
+++ b/engines/adl/detection.cpp
@@ -443,9 +443,9 @@ static const AdlGameDescription gameDiskDescriptions[] = {
 	{ AD_TABLE_END_MARKER, GAME_TYPE_NONE, GAME_VER_NONE }
 };
 
-class AdlMetaEngineDetection : public AdvancedMetaEngineDetection {
+class AdlMetaEngineDetection : public AdvancedMetaEngineDetection<AdlGameDescription> {
 public:
-	AdlMetaEngineDetection() : AdvancedMetaEngineDetection(gameFileDescriptions, sizeof(AdlGameDescription), adlGames) { }
+	AdlMetaEngineDetection() : AdvancedMetaEngineDetection(gameFileDescriptions, adlGames) { }
 
 	const char *getEngineName() const override {
 		return "ADL";

--- a/engines/adl/detection.h
+++ b/engines/adl/detection.h
@@ -69,6 +69,8 @@ enum GameVersion {
 };
 
 struct AdlGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 	GameType gameType;
 	GameVersion version;

--- a/engines/adl/metaengine.cpp
+++ b/engines/adl/metaengine.cpp
@@ -139,7 +139,7 @@ Common::Platform getPlatform(const AdlGameDescription &adlDesc) {
 	return adlDesc.desc.platform;
 }
 
-class AdlMetaEngine : public AdvancedMetaEngine {
+class AdlMetaEngine : public AdvancedMetaEngine<AdlGameDescription> {
 public:
 	const char *getName() const override {
 		return "adl";
@@ -156,7 +156,7 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	void removeSaveState(const char *target, int slot) const override;
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const AdlGameDescription *adlGd) const override;
 	Common::KeymapArray initKeymaps(const char *target) const override;
 };
 
@@ -286,9 +286,7 @@ Engine *HiRes4Engine_create(OSystem *syst, const AdlGameDescription *gd);
 Engine *HiRes5Engine_create(OSystem *syst, const AdlGameDescription *gd);
 Engine *HiRes6Engine_create(OSystem *syst, const AdlGameDescription *gd);
 
-Common::Error AdlMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
-	const AdlGameDescription *adlGd = (const AdlGameDescription *)gd;
-
+Common::Error AdlMetaEngine::createInstance(OSystem *syst, Engine **engine, const AdlGameDescription *adlGd) const {
 	switch (adlGd->gameType) {
 	case GAME_TYPE_HIRES1:
 		*engine = HiRes1Engine_create(syst, adlGd);

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -305,7 +305,7 @@ DetectedGames AdvancedMetaEngineDetectionBase::detectGames(const Common::FSList 
 	return detectedGames;
 }
 
-const ExtraGuiOptions AdvancedMetaEngine::getExtraGuiOptions(const Common::String &target) const {
+const ExtraGuiOptions AdvancedMetaEngineBase::getExtraGuiOptions(const Common::String &target) const {
 	const ADExtraGuiOptionsMap *extraGuiOptions = getAdvancedExtraGuiOptions();
 	if (!extraGuiOptions)
 		return ExtraGuiOptions();
@@ -529,7 +529,7 @@ Common::String md5PropToGameFile(MD5Properties flags) {
 	return res;
 }
 
-static bool getFilePropertiesIntern(uint md5Bytes, const AdvancedMetaEngine::FileMap &allFiles, MD5Properties md5prop, const Common::Path &fname, FileProperties &fileProps);
+static bool getFilePropertiesIntern(uint md5Bytes, const AdvancedMetaEngineBase::FileMap &allFiles, MD5Properties md5prop, const Common::Path &fname, FileProperties &fileProps);
 
 bool AdvancedMetaEngineDetectionBase::getFileProperties(const FileMap &allFiles, MD5Properties md5prop, const Common::Path &fname, FileProperties &fileProps) const {
 	Common::String hashname = md5PropToCachePrefix(md5prop);
@@ -554,11 +554,11 @@ bool AdvancedMetaEngineDetectionBase::getFileProperties(const FileMap &allFiles,
 	return res;
 }
 
-bool AdvancedMetaEngine::getFilePropertiesExtern(uint md5Bytes, const FileMap &allFiles, MD5Properties md5prop, const Common::Path &fname, FileProperties &fileProps) const {
+bool AdvancedMetaEngineBase::getFilePropertiesExtern(uint md5Bytes, const FileMap &allFiles, MD5Properties md5prop, const Common::Path &fname, FileProperties &fileProps) const {
 	return getFilePropertiesIntern(md5Bytes, allFiles, md5prop, fname, fileProps);
 }
 
-static bool getFilePropertiesIntern(uint md5Bytes, const AdvancedMetaEngine::FileMap &allFiles, MD5Properties md5prop, const Common::Path &fname, FileProperties &fileProps) {
+static bool getFilePropertiesIntern(uint md5Bytes, const AdvancedMetaEngineBase::FileMap &allFiles, MD5Properties md5prop, const Common::Path &fname, FileProperties &fileProps) {
 	if (md5prop & (kMD5MacResFork | kMD5MacDataFork)) {
 		FileMapArchive fileMapArchive(allFiles);
 		bool is_legacy = ((md5prop & kMD5MacMask) == kMD5MacResOrDataFork);
@@ -1127,7 +1127,7 @@ void AdvancedMetaEngineDetectionBase::detectClashes() const {
 	}
 }
 
-Common::Error AdvancedMetaEngine::createInstance(OSystem *syst, Engine **engine, const DetectedGame &gameDescriptor, const void *meDescriptor) {
+Common::Error AdvancedMetaEngineBase::createInstance(OSystem *syst, Engine **engine, const DetectedGame &gameDescriptor, const void *meDescriptor) {
 	assert(engine);
 
 	const ADGameDescription *adgDesc = (const ADGameDescription *)meDescriptor;
@@ -1169,10 +1169,10 @@ Common::Error AdvancedMetaEngine::createInstance(OSystem *syst, Engine **engine,
 	}
 	initSubSystems(adgDesc);
 
-	return createInstance(syst, engine, adgDesc);
+	return createInstance(syst, engine, meDescriptor);
 }
 
-void AdvancedMetaEngine::initSubSystems(const ADGameDescription *gameDesc) const {
+void AdvancedMetaEngineBase::initSubSystems(const ADGameDescription *gameDesc) const {
 #ifdef ENABLE_EVENTRECORDER
 	if (gameDesc) {
 		g_eventRec.processGameDescription(gameDesc);
@@ -1180,7 +1180,7 @@ void AdvancedMetaEngine::initSubSystems(const ADGameDescription *gameDesc) const
 #endif
 }
 
-bool AdvancedMetaEngine::checkExtendedSaves(MetaEngineFeature f) const {
+bool AdvancedMetaEngineBase::checkExtendedSaves(MetaEngineFeature f) const {
 	return (f == kSavesUseExtendedFormat) ||
 		(f == kSimpleSavesNames) ||
 		(f == kSupportsListSaves) ||

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -45,7 +45,7 @@
  */
 class FileMapArchive : public Common::Archive {
 public:
-	FileMapArchive(const AdvancedMetaEngineDetection::FileMap &fileMap) : _fileMap(fileMap) {}
+	FileMapArchive(const AdvancedMetaEngineDetectionBase::FileMap &fileMap) : _fileMap(fileMap) {}
 
 	bool hasFile(const Common::Path &path) const override {
 		return _fileMap.contains(path);
@@ -53,7 +53,7 @@ public:
 
 	int listMembers(Common::ArchiveMemberList &list) const override {
 		int files = 0;
-		for (AdvancedMetaEngineDetection::FileMap::const_iterator it = _fileMap.begin(); it != _fileMap.end(); ++it) {
+		for (AdvancedMetaEngineDetectionBase::FileMap::const_iterator it = _fileMap.begin(); it != _fileMap.end(); ++it) {
 			list.push_back(Common::ArchiveMemberPtr(new Common::FSNode(it->_value)));
 			++files;
 		}
@@ -62,7 +62,7 @@ public:
 	}
 
 	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override {
-		AdvancedMetaEngineDetection::FileMap::const_iterator it = _fileMap.find(path);
+		AdvancedMetaEngineDetectionBase::FileMap::const_iterator it = _fileMap.find(path);
 		if (it == _fileMap.end()) {
 			return Common::ArchiveMemberPtr();
 		}
@@ -76,7 +76,7 @@ public:
 	}
 
 private:
-	const AdvancedMetaEngineDetection::FileMap &_fileMap;
+	const AdvancedMetaEngineDetectionBase::FileMap &_fileMap;
 };
 
 static Common::String sanitizeName(const char *name, int maxLen) {
@@ -164,7 +164,7 @@ static Common::String generatePreferredTarget(const ADGameDescription *desc, int
 	return res;
 }
 
-DetectedGame AdvancedMetaEngineDetection::toDetectedGame(const ADDetectedGame &adGame, ADDetectedGameExtraInfo *extraInfo) const {
+DetectedGame AdvancedMetaEngineDetectionBase::toDetectedGame(const ADDetectedGame &adGame, ADDetectedGameExtraInfo *extraInfo) const {
 	const ADGameDescription *desc = adGame.desc;
 
 	const char *title;
@@ -219,7 +219,7 @@ DetectedGame AdvancedMetaEngineDetection::toDetectedGame(const ADDetectedGame &a
 	return game;
 }
 
-bool AdvancedMetaEngineDetection::cleanupPirated(ADDetectedGames &matched) const {
+bool AdvancedMetaEngineDetectionBase::cleanupPirated(ADDetectedGames &matched) const {
 	// OKay, now let's sense presence of pirated games
 	if (!matched.empty()) {
 		for (uint j = 0; j < matched.size();) {
@@ -243,7 +243,7 @@ bool AdvancedMetaEngineDetection::cleanupPirated(ADDetectedGames &matched) const
 	return false;
 }
 
-DetectedGames AdvancedMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 skipADFlags, bool skipIncomplete) {
+DetectedGames AdvancedMetaEngineDetectionBase::detectGames(const Common::FSList &fslist, uint32 skipADFlags, bool skipIncomplete) {
 	FileMap allFiles;
 
 	if (fslist.empty())
@@ -334,7 +334,7 @@ const ExtraGuiOptions AdvancedMetaEngine::getExtraGuiOptions(const Common::Strin
 	return options;
 }
 
-Common::Error AdvancedMetaEngineDetection::identifyGame(DetectedGame &game, const void **descriptor) {
+Common::Error AdvancedMetaEngineDetectionBase::identifyGame(DetectedGame &game, const void **descriptor) {
 	Common::Language language = Common::UNK_LANG;
 	Common::Platform platform = Common::kPlatformUnknown;
 	Common::String extra;
@@ -425,7 +425,7 @@ Common::Error AdvancedMetaEngineDetection::identifyGame(DetectedGame &game, cons
 	return Common::kNoError;
 }
 
-void AdvancedMetaEngineDetection::composeFileHashMap(FileMap &allFiles, const Common::FSList &fslist, int depth, const Common::Path &parentName) const {
+void AdvancedMetaEngineDetectionBase::composeFileHashMap(FileMap &allFiles, const Common::FSList &fslist, int depth, const Common::Path &parentName) const {
 	if (depth <= 0)
 		return;
 
@@ -531,7 +531,7 @@ Common::String md5PropToGameFile(MD5Properties flags) {
 
 static bool getFilePropertiesIntern(uint md5Bytes, const AdvancedMetaEngine::FileMap &allFiles, MD5Properties md5prop, const Common::Path &fname, FileProperties &fileProps);
 
-bool AdvancedMetaEngineDetection::getFileProperties(const FileMap &allFiles, MD5Properties md5prop, const Common::Path &fname, FileProperties &fileProps) const {
+bool AdvancedMetaEngineDetectionBase::getFileProperties(const FileMap &allFiles, MD5Properties md5prop, const Common::Path &fname, FileProperties &fileProps) const {
 	Common::String hashname = md5PropToCachePrefix(md5prop);
 		hashname += ':';
 		hashname += fname.toString('/');
@@ -678,7 +678,7 @@ Common::String escapeString(const char *string) {
 	return res;
 }
 
-void AdvancedMetaEngineDetection::dumpDetectionEntries() const {
+void AdvancedMetaEngineDetectionBase::dumpDetectionEntries() const {
 	const byte *descPtr;
 
 	for (descPtr = _gameDescriptors; ((const ADGameDescription *)descPtr)->gameId != nullptr; descPtr += _descItemSize) {
@@ -713,7 +713,7 @@ void AdvancedMetaEngineDetection::dumpDetectionEntries() const {
 	}
 }
 
-ADDetectedGames AdvancedMetaEngineDetection::detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra, uint32 skipADFlags, bool skipIncomplete) {
+ADDetectedGames AdvancedMetaEngineDetectionBase::detectGame(const Common::FSNode &parent, const FileMap &allFiles, Common::Language language, Common::Platform platform, const Common::String &extra, uint32 skipADFlags, bool skipIncomplete) {
 	CachedPropertiesMap filesProps;
 	ADDetectedGames matched;
 
@@ -866,7 +866,7 @@ ADDetectedGames AdvancedMetaEngineDetection::detectGame(const Common::FSNode &pa
 	return matched;
 }
 
-ADDetectedGame AdvancedMetaEngineDetection::detectGameFilebased(const FileMap &allFiles, const ADFileBasedFallback *fileBasedFallback) const {
+ADDetectedGame AdvancedMetaEngineDetectionBase::detectGameFilebased(const FileMap &allFiles, const ADFileBasedFallback *fileBasedFallback) const {
 	const ADFileBasedFallback *ptr;
 	const char* const* filenames;
 
@@ -915,11 +915,11 @@ ADDetectedGame AdvancedMetaEngineDetection::detectGameFilebased(const FileMap &a
 	return result;
 }
 
-PlainGameList AdvancedMetaEngineDetection::getSupportedGames() const {
+PlainGameList AdvancedMetaEngineDetectionBase::getSupportedGames() const {
 	return PlainGameList(_gameIds);
 }
 
-PlainGameDescriptor AdvancedMetaEngineDetection::findGame(const char *gameId) const {
+PlainGameDescriptor AdvancedMetaEngineDetectionBase::findGame(const char *gameId) const {
 	// First search the list of supported gameids for a match.
 	const PlainGameDescriptor *g = findPlainGameDescriptor(gameId, _gameIds);
 	if (g)
@@ -960,7 +960,7 @@ static const char *const grayList[] = {
 	0
 };
 
-AdvancedMetaEngineDetection::AdvancedMetaEngineDetection(const void *descs, uint descItemSize, const PlainGameDescriptor *gameIds)
+AdvancedMetaEngineDetectionBase::AdvancedMetaEngineDetectionBase(const void *descs, uint descItemSize, const PlainGameDescriptor *gameIds)
 	: _gameDescriptors((const byte *)descs), _descItemSize(descItemSize), _gameIds(gameIds) {
 
 	_md5Bytes = 5000;
@@ -977,7 +977,7 @@ AdvancedMetaEngineDetection::AdvancedMetaEngineDetection(const void *descs, uint
 		_grayListMap.setVal(*f, true);
 }
 
-void AdvancedMetaEngineDetection::preprocessDescriptions() {
+void AdvancedMetaEngineDetectionBase::preprocessDescriptions() {
 	if (_hashMapsInited)
 		return;
 
@@ -1036,7 +1036,7 @@ void AdvancedMetaEngineDetection::preprocessDescriptions() {
 #endif
 }
 
-Common::StringArray AdvancedMetaEngineDetection::getPathsFromEntry(const ADGameDescription *g) {
+Common::StringArray AdvancedMetaEngineDetectionBase::getPathsFromEntry(const ADGameDescription *g) {
 	Common::StringArray result;
 	Common::HashMap<Common::String, bool, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> unique;
 
@@ -1061,7 +1061,7 @@ Common::StringArray AdvancedMetaEngineDetection::getPathsFromEntry(const ADGameD
 	return result;
 }
 
-bool AdvancedMetaEngineDetection::isEntryGrayListed(const ADGameDescription *g) const {
+bool AdvancedMetaEngineDetectionBase::isEntryGrayListed(const ADGameDescription *g) const {
 	bool grayIsPresent = false, nonGrayIsPresent = false;
 
 	for (const ADGameFileDescription *fileDesc = g->filesDescriptions; fileDesc->fileName; fileDesc++) {
@@ -1075,7 +1075,7 @@ bool AdvancedMetaEngineDetection::isEntryGrayListed(const ADGameDescription *g) 
 	return (grayIsPresent && !nonGrayIsPresent);
 }
 
-void AdvancedMetaEngineDetection::detectClashes() const {
+void AdvancedMetaEngineDetectionBase::detectClashes() const {
 	// First, check that we do not have duplicated entries in _gameIds
 	Common::HashMap<Common::String, int, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> idsMap;
 

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -604,6 +604,18 @@ template<class Descriptor>
 class AdvancedMetaEngineDetection : public AdvancedMetaEngineDetectionBase {
 protected:
 	AdvancedMetaEngineDetection(const Descriptor *descs, const PlainGameDescriptor *gameIds) : AdvancedMetaEngineDetectionBase(descs, sizeof(Descriptor), gameIds) {}
+
+	Common::Error identifyGame(DetectedGame &game, const void **descriptor) override {
+		assert(descriptor);
+		Common::Error err = AdvancedMetaEngineDetectionBase::identifyGame(game, descriptor);
+		if (err.getCode() != Common::kNoError) {
+			return err;
+		}
+		if (*descriptor) {
+			*descriptor = new ADDynamicGameDescription<Descriptor>(static_cast<const Descriptor *>(*descriptor));
+		}
+		return err;
+	}
 };
 
 /**
@@ -704,6 +716,12 @@ protected:
 	virtual Common::Error createInstance(OSystem *syst, Engine **engine, const Descriptor *desc) const = 0;
 	Common::Error createInstance(OSystem *syst, Engine **engine, const void *desc) const override final {
 		return createInstance(syst, engine, static_cast<const Descriptor *>(desc));
+	}
+
+	void deleteInstance(Engine *engine, const DetectedGame &gameDescriptor, const void *meDescriptor) override {
+		delete engine;
+		delete static_cast<ADDynamicGameDescription<Descriptor> *>(
+                                const_cast<void *>(meDescriptor));
 	}
 
 private:

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -279,7 +279,7 @@ struct ADExtraGuiOptionsMap {
 /**
  * A @ref MetaEngineDetection implementation based on the Advanced Detector code.
  */
-class AdvancedMetaEngineDetection : public MetaEngineDetection {
+class AdvancedMetaEngineDetectionBase : public MetaEngineDetection {
 protected:
 	/**
 	 * Pointer to an array of objects which are either ADGameDescription
@@ -361,12 +361,12 @@ protected:
 	 */
 	 int _fullPathGlobsDepth;
 
-public:
 	/**
 	 * Initialize game detection using AdvancedMetaEngineDetection.
 	 */
-	AdvancedMetaEngineDetection(const void *descs, uint descItemSize, const PlainGameDescriptor *gameIds);
+	AdvancedMetaEngineDetectionBase(const void *descs, uint descItemSize, const PlainGameDescriptor *gameIds);
 
+public:
 	/**
 	 * Return a list of targets supported by the engine.
 	 *
@@ -472,6 +472,12 @@ protected:
 	bool cleanupPirated(ADDetectedGames &matched) const;
 
 	friend class FileMapArchive;
+};
+
+template<class Descriptor>
+class AdvancedMetaEngineDetection : public AdvancedMetaEngineDetectionBase {
+protected:
+	AdvancedMetaEngineDetection(const Descriptor *descs, const PlainGameDescriptor *gameIds) : AdvancedMetaEngineDetectionBase(descs, sizeof(Descriptor), gameIds) {}
 };
 
 /**

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -377,22 +377,15 @@ public:
 	/** Query the engine for a @ref PlainGameDescriptor for the specified gameid, if any. */
 	PlainGameDescriptor findGame(const char *gameId) const override;
 
+	/** Identify the active game and check its data files. */
+	Common::Error identifyGame(DetectedGame &game, const void **descriptor) override;
+
 	/**
 	 * Run the engine's game detector on the given list of files, and return a
 	 * (possibly empty) list of games supported by the engine that were
 	 * found among the given files.
 	 */
 	DetectedGames detectGames(const Common::FSList &fslist, uint32 skipADFlags, bool skipIncomplete) override;
-
-	/**
-	 * A generic createInstance.
-	 *
-	 * For instantiating engine objects, this method is called first,
-	 * and then the subclass implemented createInstance is called from within.
-	 */
-	Common::Error createInstance(OSystem *syst, Engine **engine);
-
-	static Common::StringArray getPathsFromEntry(const ADGameDescription *g);
 
 	uint getMD5Bytes() const override final { return _md5Bytes; }
 
@@ -420,8 +413,8 @@ protected:
 	}
 
 private:
-	void initSubSystems(const ADGameDescription *gameDesc) const;
 	void preprocessDescriptions();
+	static Common::StringArray getPathsFromEntry(const ADGameDescription *g);
 	bool isEntryGrayListed(const ADGameDescription *g) const;
 	void detectClashes() const;
 
@@ -494,7 +487,7 @@ public:
 	 * By the time this is called, it is assumed that there is only one
 	 * plugin engine loaded in memory.
 	 */
-	Common::Error createInstance(OSystem *syst, Engine **engine) override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const DetectedGame &gameDescriptor, const void *metaEngineDescriptor) override;
 
 	/**
 	 * A createInstance implementation for subclasses. To be called after the base
@@ -568,6 +561,9 @@ protected:
 	 * extended save format to work
 	 */
 	bool checkExtendedSaves(MetaEngineFeature f) const;
+
+private:
+	void initSubSystems(const ADGameDescription *gameDesc) const;
 };
 
 /**

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -483,7 +483,7 @@ protected:
 /**
  * A MetaEngine implementation of AdvancedMetaEngine.
  */
-class AdvancedMetaEngine : public MetaEngine {
+class AdvancedMetaEngineBase : public MetaEngine {
 public:
 	/**
 	 * Base createInstance for AdvancedMetaEngine.
@@ -499,7 +499,7 @@ public:
 	 * A createInstance implementation for subclasses. To be called after the base
 	 * createInstance function above is called.
 	 */
-	virtual Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const = 0;
+	virtual Common::Error createInstance(OSystem *syst, Engine **engine, const void *desc) const = 0;
 
 	/**
 	 * Return the name of the engine plugin based on the engineID.
@@ -570,6 +570,19 @@ protected:
 
 private:
 	void initSubSystems(const ADGameDescription *gameDesc) const;
+};
+
+template<class Descriptor>
+class AdvancedMetaEngine : public AdvancedMetaEngineBase {
+protected:
+	virtual Common::Error createInstance(OSystem *syst, Engine **engine, const Descriptor *desc) const = 0;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const void *desc) const override final {
+		return createInstance(syst, engine, static_cast<const Descriptor *>(desc));
+	}
+
+private:
+	// Silence overloaded-virtual warning from clang
+	using AdvancedMetaEngineBase::createInstance;
 };
 
 /**

--- a/engines/agi/detection.cpp
+++ b/engines/agi/detection.cpp
@@ -82,12 +82,12 @@ static const PlainGameDescriptor agiGames[] = {
 
 using namespace Agi;
 
-class AgiMetaEngineDetection : public AdvancedMetaEngineDetection {
+class AgiMetaEngineDetection : public AdvancedMetaEngineDetection<AGIGameDescription> {
 	mutable Common::String _gameid;
 	mutable Common::String _extra;
 
 public:
-	AgiMetaEngineDetection() : AdvancedMetaEngineDetection(Agi::gameDescriptions, sizeof(Agi::AGIGameDescription), agiGames) {
+	AgiMetaEngineDetection() : AdvancedMetaEngineDetection(Agi::gameDescriptions, agiGames) {
 		_guiOptions = GUIO_NOSPEECH GUIO_RENDEREGA GUIO_RENDERCGA GUIO_RENDERHERCAMBER GUIO_RENDERHERCGREEN
 			GUIO_RENDERAMIGA GUIO_RENDERAPPLE2GS GUIO_RENDERATARIST GUIO_RENDERMACINTOSH;
 

--- a/engines/agi/detection.h
+++ b/engines/agi/detection.h
@@ -27,6 +27,8 @@
 namespace Agi {
 
 struct AGIGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	int gameID;

--- a/engines/agi/metaengine.cpp
+++ b/engines/agi/metaengine.cpp
@@ -182,7 +182,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 
 using namespace Agi;
 
-class AgiMetaEngine : public AdvancedMetaEngine {
+class AgiMetaEngine : public AdvancedMetaEngine<Agi::AGIGameDescription> {
 public:
 	const char *getName() const override {
 		return "agi";
@@ -192,7 +192,7 @@ public:
 		return optionsList;
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Agi::AGIGameDescription *gd) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -214,9 +214,7 @@ bool AgiMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSimpleSavesNames);
 }
 
-Common::Error AgiMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Agi::AGIGameDescription *gd = (const Agi::AGIGameDescription *)desc;
-
+Common::Error AgiMetaEngine::createInstance(OSystem *syst, Engine **engine, const Agi::AGIGameDescription *gd) const {
 	switch (gd->gameType) {
 	case Agi::GType_PreAGI:
 		switch (gd->gameID) {

--- a/engines/agos/detection.cpp
+++ b/engines/agos/detection.cpp
@@ -73,9 +73,9 @@ static const char *const directoryGlobs[] = {
 
 using namespace AGOS;
 
-class AgosMetaEngineDetection : public AdvancedMetaEngineDetection {
+class AgosMetaEngineDetection : public AdvancedMetaEngineDetection<AGOS::AGOSGameDescription> {
 public:
-	AgosMetaEngineDetection() : AdvancedMetaEngineDetection(AGOS::gameDescriptions, sizeof(AGOS::AGOSGameDescription), agosGames) {
+	AgosMetaEngineDetection() : AdvancedMetaEngineDetection(AGOS::gameDescriptions, agosGames) {
 		_guiOptions = GUIO1(GUIO_NOLAUNCHLOAD);
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;

--- a/engines/agos/detection.cpp
+++ b/engines/agos/detection.cpp
@@ -85,6 +85,11 @@ public:
 		return Engines::findGameID(gameId, _gameIds, obsoleteGameIDsTable);
 	}
 
+	Common::Error identifyGame(DetectedGame &game, const void **descriptor) override {
+		Engines::upgradeTargetIfNecessary(obsoleteGameIDsTable);
+		return AdvancedMetaEngineDetection::identifyGame(game, descriptor);
+	}
+
 	const char *getName() const override {
 		return "agos";
 	}

--- a/engines/agos/detection.h
+++ b/engines/agos/detection.h
@@ -38,6 +38,8 @@ enum SIMONGameType {
 };
 
 struct AGOSGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	int gameType;

--- a/engines/agos/metaengine.cpp
+++ b/engines/agos/metaengine.cpp
@@ -109,7 +109,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 
 } // End of namespace AGOS
 
-class AgosMetaEngine : public AdvancedMetaEngine {
+class AgosMetaEngine : public AdvancedMetaEngine<AGOS::AGOSGameDescription> {
 public:
 	const char *getName() const override {
 		return "agos";
@@ -121,7 +121,7 @@ public:
 
 	bool hasFeature(MetaEngineFeature f) const override;
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const AGOS::AGOSGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -140,9 +140,7 @@ bool AGOS::AGOSEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsReturnToLauncher);
 }
 
-Common::Error AgosMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const AGOS::AGOSGameDescription *gd = (const AGOS::AGOSGameDescription *)desc;
-
+Common::Error AgosMetaEngine::createInstance(OSystem *syst, Engine **engine, const AGOS::AGOSGameDescription *gd) const {
 	switch (gd->gameType) {
 	case AGOS::GType_PN:
 		*engine = new AGOS::AGOSEngine_PN(syst, gd);

--- a/engines/agos/metaengine.cpp
+++ b/engines/agos/metaengine.cpp
@@ -30,12 +30,10 @@
 #include "backends/keymapper/standard-actions.h"
 
 #include "engines/advancedDetector.h"
-#include "engines/obsolete.h"
 
 #include "agos/intern.h"
 #include "agos/agos.h"
 #include "agos/detection.h"
-#include "agos/obsolete.h"
 
 namespace AGOS {
 
@@ -123,10 +121,6 @@ public:
 
 	bool hasFeature(MetaEngineFeature f) const override;
 
-	Common::Error createInstance(OSystem *syst, Engine **engine) override {
-		Engines::upgradeTargetIfNecessary(obsoleteGameIDsTable);
-		return AdvancedMetaEngine::createInstance(syst, engine);
-	}
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;

--- a/engines/ags/detection.cpp
+++ b/engines/ags/detection.cpp
@@ -71,8 +71,7 @@ const DebugChannelDef AGSMetaEngineDetection::debugFlagList[] = {
 	DEBUG_CHANNEL_END
 };
 
-AGSMetaEngineDetection::AGSMetaEngineDetection() : AdvancedMetaEngineDetection(AGS::GAME_DESCRIPTIONS,
-	        sizeof(AGS::AGSGameDescription), AGS::GAME_NAMES) {
+AGSMetaEngineDetection::AGSMetaEngineDetection() : AdvancedMetaEngineDetection(AGS::GAME_DESCRIPTIONS, AGS::GAME_NAMES) {
 	_flags = kADFlagCanPlayUnknownVariants;
 }
 

--- a/engines/ags/detection.h
+++ b/engines/ags/detection.h
@@ -64,7 +64,7 @@ enum AGSSpriteFontVersion { kAGSSpriteFont = 0, kClifftopGames = 1 };
 } // namespace AGS
 
 
-class AGSMetaEngineDetection : public AdvancedMetaEngineDetection {
+class AGSMetaEngineDetection : public AdvancedMetaEngineDetection<AGS::AGSGameDescription> {
 	mutable Common::String _gameid;
 	mutable Common::String _extra;
 	mutable Common::Path _filename;

--- a/engines/ags/metaengine.cpp
+++ b/engines/ags/metaengine.cpp
@@ -38,9 +38,7 @@ const char *AGSMetaEngine::getName() const {
 	return "ags";
 }
 
-Common::Error AGSMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const AGS::AGSGameDescription *gd = (const AGS::AGSGameDescription *)desc;
-
+Common::Error AGSMetaEngine::createInstance(OSystem *syst, Engine **engine, const AGS::AGSGameDescription *gd) const {
 	*engine = new AGS::AGSEngine(syst, gd);
 	return Common::kNoError;
 }

--- a/engines/ags/metaengine.h
+++ b/engines/ags/metaengine.h
@@ -25,11 +25,13 @@
 #include "engines/achievements.h"
 #include "engines/advancedDetector.h"
 
-class AGSMetaEngine : public AdvancedMetaEngine {
+#include "engines/ags/detection.h"
+
+class AGSMetaEngine : public AdvancedMetaEngine<AGS::AGSGameDescription> {
 public:
 	const char *getName() const override;
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const AGS::AGSGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 

--- a/engines/asylum/detection.cpp
+++ b/engines/asylum/detection.cpp
@@ -43,9 +43,9 @@ static const DebugChannelDef debugFlagList[] = {
 	DEBUG_CHANNEL_END
 };
 
-class AsylumMetaEngineDetection : public AdvancedMetaEngineDetection {
+class AsylumMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	AsylumMetaEngineDetection() : AdvancedMetaEngineDetection(Asylum::gameDescriptions, sizeof(ADGameDescription), asylumGames) {
+	AsylumMetaEngineDetection() : AdvancedMetaEngineDetection(Asylum::gameDescriptions, asylumGames) {
 		_md5Bytes = 0;
 		_maxScanDepth = 4;
 		_directoryGlobs = Asylum::directoryGlobs;

--- a/engines/asylum/metaengine.cpp
+++ b/engines/asylum/metaengine.cpp
@@ -40,7 +40,7 @@
 #include "asylum/asylum.h"
 #include "asylum/shared.h"
 
-class AsylumMetaEngine : public AdvancedMetaEngine {
+class AsylumMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "asylum";

--- a/engines/avalanche/detection.cpp
+++ b/engines/avalanche/detection.cpp
@@ -38,7 +38,7 @@ static const PlainGameDescriptor avalancheGames[] = {
 	{nullptr, nullptr}
 };
 
-static const ADGameDescription gameDescriptions[] = {
+static const AvalancheGameDescription gameDescriptions[] = {
 	{
 		"avalanche", nullptr,
 		AD_ENTRY2s("avalot.sez",	"de10eb353228013da3d3297784f81ff9", 48763,
@@ -52,9 +52,9 @@ static const ADGameDescription gameDescriptions[] = {
 	AD_TABLE_END_MARKER
 };
 
-class AvalancheMetaEngineDetection : public AdvancedMetaEngineDetection {
+class AvalancheMetaEngineDetection : public AdvancedMetaEngineDetection<AvalancheGameDescription> {
 public:
-	AvalancheMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, sizeof(AvalancheGameDescription), avalancheGames) {
+	AvalancheMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, avalancheGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/avalanche/detection.h
+++ b/engines/avalanche/detection.h
@@ -30,6 +30,8 @@
 namespace Avalanche {
 
 struct AvalancheGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 };
 

--- a/engines/avalanche/metaengine.cpp
+++ b/engines/avalanche/metaengine.cpp
@@ -53,13 +53,13 @@ Common::Platform AvalancheEngine::getPlatform() const {
 
 namespace Avalanche {
 
-class AvalancheMetaEngine : public AdvancedMetaEngine {
+class AvalancheMetaEngine : public AdvancedMetaEngine<AvalancheGameDescription> {
 public:
 	const char *getName() const override {
 		return "avalanche";
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const AvalancheGameDescription *gd) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
 	int getMaximumSaveSlot() const override { return 99; }
@@ -68,8 +68,8 @@ public:
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
-Common::Error AvalancheMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
-	*engine = new AvalancheEngine(syst, (const AvalancheGameDescription *)gd);
+Common::Error AvalancheMetaEngine::createInstance(OSystem *syst, Engine **engine, const AvalancheGameDescription *gd) const {
+	*engine = new AvalancheEngine(syst,gd);
 	return Common::kNoError;
 }
 

--- a/engines/bagel/detection.cpp
+++ b/engines/bagel/detection.cpp
@@ -26,7 +26,7 @@ const DebugChannelDef BagelMetaEngineDetection::debugFlagList[] = {
 	DEBUG_CHANNEL_END
 };
 
-BagelMetaEngineDetection::BagelMetaEngineDetection() : AdvancedMetaEngineDetection(Bagel::gameDescriptions, sizeof(ADGameDescription), Bagel::bagelGames) {
+BagelMetaEngineDetection::BagelMetaEngineDetection() : AdvancedMetaEngineDetection(Bagel::gameDescriptions, Bagel::bagelGames) {
 	_guiOptions = GUIO2(GUIO_NOSPEECH, GAMEOPTION_ORIGINAL_SAVELOAD);
 	_flags = kADFlagMatchFullPaths;
 }

--- a/engines/bagel/detection.h
+++ b/engines/bagel/detection.h
@@ -38,7 +38,7 @@ extern const ADGameDescription gameDescriptions[];
 
 } // End of namespace Bagel
 
-class BagelMetaEngineDetection : public AdvancedMetaEngineDetection {
+class BagelMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 	static const DebugChannelDef debugFlagList[];
 
 public:

--- a/engines/bagel/metaengine.h
+++ b/engines/bagel/metaengine.h
@@ -31,7 +31,7 @@ namespace Bagel {
 	};
 }
 
-class BagelMetaEngine : public AdvancedMetaEngine {
+class BagelMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override;
 

--- a/engines/bbvs/detection.cpp
+++ b/engines/bbvs/detection.cpp
@@ -92,9 +92,9 @@ static const char * const directoryGlobs[] = {
 	nullptr
 };
 
-class BbvsMetaEngineDetection : public AdvancedMetaEngineDetection {
+class BbvsMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	BbvsMetaEngineDetection() : AdvancedMetaEngineDetection(Bbvs::gameDescriptions, sizeof(ADGameDescription), bbvsGames) {
+	BbvsMetaEngineDetection() : AdvancedMetaEngineDetection(Bbvs::gameDescriptions, bbvsGames) {
 		_maxScanDepth = 3;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/bbvs/metaengine.cpp
+++ b/engines/bbvs/metaengine.cpp
@@ -44,7 +44,7 @@ bool BbvsEngine::isLoogieAltDemo() const {
 
 } // End of namespace Bbvs
 
-class BbvsMetaEngine : public AdvancedMetaEngine {
+class BbvsMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "bbvs";

--- a/engines/bladerunner/detection.cpp
+++ b/engines/bladerunner/detection.cpp
@@ -53,7 +53,7 @@ static const char *const directoryGlobs[] = {
 };
 } // End of namespace BladeRunner
 
-class BladeRunnerMetaEngineDetection : public AdvancedMetaEngineDetection {
+class BladeRunnerMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
 	BladeRunnerMetaEngineDetection();
 
@@ -66,7 +66,6 @@ public:
 BladeRunnerMetaEngineDetection::BladeRunnerMetaEngineDetection()
 	: AdvancedMetaEngineDetection(
 		BladeRunner::gameDescriptions,
-		sizeof(BladeRunner::gameDescriptions[0]),
 		BladeRunner::bladeRunnerGames) {
 		// Setting this, allows the demo files to be copied in the BladeRunner
 		// game data folder and be detected and subsequently launched without

--- a/engines/bladerunner/metaengine.cpp
+++ b/engines/bladerunner/metaengine.cpp
@@ -121,7 +121,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 
 } // End of namespace BladeRunner
 
-class BladeRunnerMetaEngine : public AdvancedMetaEngine {
+class BladeRunnerMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override;
 

--- a/engines/buried/detection.cpp
+++ b/engines/buried/detection.cpp
@@ -48,11 +48,10 @@ static const char *const directoryGlobs[] = {
 } // End of namespace Buried
 
 
-class BuriedMetaEngineDetection : public AdvancedMetaEngineDetection {
+class BuriedMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
 	BuriedMetaEngineDetection() : AdvancedMetaEngineDetection(
 		Buried::gameDescriptions,
-		sizeof(ADGameDescription),
 		buriedGames) {
 		_guiOptions = GUIO2(GUIO_NOMIDI, GAMEOPTION_ALLOW_SKIP);
 		_flags = kADFlagUseExtraAsHint;

--- a/engines/buried/metaengine.cpp
+++ b/engines/buried/metaengine.cpp
@@ -90,7 +90,7 @@ Common::Language BuriedEngine::getLanguage() const {
 
 } // End of namespace Buried
 
-class BuriedMetaEngine : public AdvancedMetaEngine {
+class BuriedMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "buried";

--- a/engines/cge/detection.cpp
+++ b/engines/cge/detection.cpp
@@ -104,9 +104,9 @@ static const ADGameDescription gameDescriptions[] = {
 	AD_TABLE_END_MARKER
 };
 
-class CGEMetaEngineDetection : public AdvancedMetaEngineDetection {
+class CGEMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	CGEMetaEngineDetection() : AdvancedMetaEngineDetection(CGE::gameDescriptions, sizeof(ADGameDescription), CGEGames) {
+	CGEMetaEngineDetection() : AdvancedMetaEngineDetection(CGE::gameDescriptions, CGEGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/cge/metaengine.cpp
+++ b/engines/cge/metaengine.cpp
@@ -66,7 +66,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class CGEMetaEngine : public AdvancedMetaEngine {
+class CGEMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "cge";

--- a/engines/cge2/detection.cpp
+++ b/engines/cge2/detection.cpp
@@ -94,9 +94,9 @@ static const ADGameDescription gameDescriptions[] = {
 		AD_TABLE_END_MARKER
 };
 
-class CGE2MetaEngineDetection : public AdvancedMetaEngineDetection {
+class CGE2MetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	CGE2MetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, sizeof(ADGameDescription), CGE2Games) {
+	CGE2MetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, CGE2Games) {
 	}
 
 	const char *getName() const override {

--- a/engines/cge2/metaengine.cpp
+++ b/engines/cge2/metaengine.cpp
@@ -81,7 +81,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 		AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class CGE2MetaEngine : public AdvancedMetaEngine {
+class CGE2MetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "cge2";

--- a/engines/chamber/detection.cpp
+++ b/engines/chamber/detection.cpp
@@ -54,9 +54,9 @@ static const ADGameDescription gameDescriptions[] = {
 };
 } // End of namespace Chamber
 
-class ChamberMetaEngineDetection : public AdvancedMetaEngineDetection {
+class ChamberMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	ChamberMetaEngineDetection() : AdvancedMetaEngineDetection(Chamber::gameDescriptions, sizeof(ADGameDescription), Chamber::ChamberGames) {
+	ChamberMetaEngineDetection() : AdvancedMetaEngineDetection(Chamber::gameDescriptions, Chamber::ChamberGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/chamber/metaengine.cpp
+++ b/engines/chamber/metaengine.cpp
@@ -30,7 +30,7 @@ Common::Language ChamberEngine::getLanguage() const {
 
 } // end of namespace Chamber
 
-class ChamberMetaEngine : public AdvancedMetaEngine {
+class ChamberMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "chamber";

--- a/engines/chewy/detection.cpp
+++ b/engines/chewy/detection.cpp
@@ -104,9 +104,9 @@ static const ChewyGameDescription gameDescriptions[] = {
 
 } // namespace Chewy
 
-class ChewyMetaEngineDetection : public AdvancedMetaEngineDetection {
+class ChewyMetaEngineDetection : public AdvancedMetaEngineDetection<Chewy::ChewyGameDescription> {
 public:
-	ChewyMetaEngineDetection() : AdvancedMetaEngineDetection(Chewy::gameDescriptions, sizeof(Chewy::ChewyGameDescription), chewyGames) {
+	ChewyMetaEngineDetection() : AdvancedMetaEngineDetection(Chewy::gameDescriptions, chewyGames) {
 		_maxScanDepth = 2;
 		_flags = kADFlagMatchFullPaths;
 	}

--- a/engines/chewy/detection.h
+++ b/engines/chewy/detection.h
@@ -25,6 +25,8 @@
 namespace Chewy {
 
 struct ChewyGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 };
 

--- a/engines/chewy/metaengine.cpp
+++ b/engines/chewy/metaengine.cpp
@@ -54,7 +54,7 @@ Common::Language ChewyEngine::getLanguage() const {
 
 } // End of namespace Chewy
 
-class ChewyMetaEngine : public AdvancedMetaEngine {
+class ChewyMetaEngine : public AdvancedMetaEngine<Chewy::ChewyGameDescription> {
 public:
 	const char *getName() const override {
 		return "chewy";
@@ -65,7 +65,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Chewy::ChewyGameDescription *desc) const override;
 
 	int getMaximumSaveSlot() const override;
 };
@@ -83,8 +83,8 @@ bool Chewy::ChewyEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-Common::Error ChewyMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Chewy::ChewyEngine(syst, (const Chewy::ChewyGameDescription *)desc);
+Common::Error ChewyMetaEngine::createInstance(OSystem *syst, Engine **engine, const Chewy::ChewyGameDescription *desc) const {
+	*engine = new Chewy::ChewyEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/cine/detection.cpp
+++ b/engines/cine/detection.cpp
@@ -42,9 +42,9 @@ static const DebugChannelDef debugFlagList[] = {
 	DEBUG_CHANNEL_END
 };
 
-class CineMetaEngineDetection : public AdvancedMetaEngineDetection {
+class CineMetaEngineDetection : public AdvancedMetaEngineDetection<Cine::CINEGameDescription> {
 public:
-	CineMetaEngineDetection() : AdvancedMetaEngineDetection(Cine::gameDescriptions, sizeof(Cine::CINEGameDescription), cineGames) {
+	CineMetaEngineDetection() : AdvancedMetaEngineDetection(Cine::gameDescriptions, cineGames) {
 		_guiOptions = GUIO3(GUIO_NOSPEECH, GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_TRANSPARENT_DIALOG_BOXES);
 	}
 

--- a/engines/cine/detection.h
+++ b/engines/cine/detection.h
@@ -39,6 +39,8 @@ enum CineGameFeatures {
 };
 
 struct CINEGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	int gameType;

--- a/engines/cine/metaengine.cpp
+++ b/engines/cine/metaengine.cpp
@@ -74,7 +74,7 @@ Common::Platform CineEngine::getPlatform() const { return _gameDescription->desc
 
 } // End of namespace Cine
 
-class CineMetaEngine : public AdvancedMetaEngine {
+class CineMetaEngine : public AdvancedMetaEngine<Cine::CINEGameDescription> {
 public:
 	const char *getName() const override {
 		return "cine";
@@ -84,7 +84,7 @@ public:
 		return Cine::optionsList;
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Cine::CINEGameDescription *desc) const override;
 
 	bool hasFeature(MetaEngineFeature f) const override;
 	SaveStateList listSaves(const char *target) const override;
@@ -107,8 +107,8 @@ bool Cine::CineEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-Common::Error CineMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Cine::CineEngine(syst, (const Cine::CINEGameDescription *)desc);
+Common::Error CineMetaEngine::createInstance(OSystem *syst, Engine **engine, const Cine::CINEGameDescription *desc) const {
+	*engine = new Cine::CineEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/composer/detection.cpp
+++ b/engines/composer/detection.cpp
@@ -51,9 +51,9 @@ static const char *const directoryGlobs[] = {
 	nullptr
 };
 
-class ComposerMetaEngineDetection : public AdvancedMetaEngineDetection {
+class ComposerMetaEngineDetection : public AdvancedMetaEngineDetection<Composer::ComposerGameDescription> {
 public:
-	ComposerMetaEngineDetection() : AdvancedMetaEngineDetection(Composer::gameDescriptions, sizeof(Composer::ComposerGameDescription), composerGames) {
+	ComposerMetaEngineDetection() : AdvancedMetaEngineDetection(Composer::gameDescriptions, composerGames) {
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/composer/detection.h
+++ b/engines/composer/detection.h
@@ -38,6 +38,8 @@ enum GameFileTypes {
 };
 
 struct ComposerGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	int gameType;

--- a/engines/composer/metaengine.cpp
+++ b/engines/composer/metaengine.cpp
@@ -70,13 +70,13 @@ bool ComposerEngine::loadDetectedConfigFile(Common::INIFile &configFile) const {
 
 } // End of namespace Composer
 
-class ComposerMetaEngine : public AdvancedMetaEngine {
+class ComposerMetaEngine : public AdvancedMetaEngine<Composer::ComposerGameDescription> {
 public:
 	const char *getName() const override {
 		return "composer";
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Composer::ComposerGameDescription *desc) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
 	Common::KeymapArray initKeymaps(const char *target) const override;
@@ -93,8 +93,8 @@ public:
 	}
 };
 
-Common::Error ComposerMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Composer::ComposerEngine(syst, (const Composer::ComposerGameDescription *)desc);
+Common::Error ComposerMetaEngine::createInstance(OSystem *syst, Engine **engine, const Composer::ComposerGameDescription *desc) const {
+	*engine = new Composer::ComposerEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/crab/detection.cpp
+++ b/engines/crab/detection.cpp
@@ -64,7 +64,7 @@ static const ADGameDescription gameDescriptions[] = {
 }
 
 CrabMetaEngineDetection::CrabMetaEngineDetection() : AdvancedMetaEngineDetection(Crab::gameDescriptions,
-																				 sizeof(ADGameDescription), crabGames) {
+																				 crabGames) {
 	_flags = kADFlagMatchFullPaths;
 }
 

--- a/engines/crab/detection.h
+++ b/engines/crab/detection.h
@@ -38,7 +38,7 @@ enum CrabDebugChannels {
 
 } // End of namespace Crab
 
-class CrabMetaEngineDetection : public AdvancedMetaEngineDetection {
+class CrabMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 	static const DebugChannelDef debugFlagList[];
 
 public:

--- a/engines/crab/metaengine.h
+++ b/engines/crab/metaengine.h
@@ -25,7 +25,7 @@
 #include "backends/keymapper/keymapper.h"
 #include "engines/advancedDetector.h"
 
-class CrabMetaEngine : public AdvancedMetaEngine {
+class CrabMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override;
 

--- a/engines/cruise/detection.cpp
+++ b/engines/cruise/detection.cpp
@@ -220,9 +220,9 @@ static const CRUISEGameDescription gameDescriptions[] = {
 
 }
 
-class CruiseMetaEngineDetection : public AdvancedMetaEngineDetection {
+class CruiseMetaEngineDetection : public AdvancedMetaEngineDetection<Cruise::CRUISEGameDescription> {
 public:
-	CruiseMetaEngineDetection() : AdvancedMetaEngineDetection(Cruise::gameDescriptions, sizeof(Cruise::CRUISEGameDescription), cruiseGames) {
+	CruiseMetaEngineDetection() : AdvancedMetaEngineDetection(Cruise::gameDescriptions, cruiseGames) {
 		_guiOptions = GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI);
 	}
 

--- a/engines/cruise/detection.h
+++ b/engines/cruise/detection.h
@@ -25,6 +25,8 @@
 namespace Cruise {
 
 struct CRUISEGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 };
 

--- a/engines/cruise/metaengine.cpp
+++ b/engines/cruise/metaengine.cpp
@@ -43,7 +43,7 @@ Common::Platform CruiseEngine::getPlatform() const {
 
 } // End of namespace Cruise
 
-class CruiseMetaEngine : public AdvancedMetaEngine {
+class CruiseMetaEngine : public AdvancedMetaEngine<Cruise::CRUISEGameDescription> {
 public:
 	const char *getName() const override {
 		return "cruise";
@@ -55,7 +55,7 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	void removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Cruise::CRUISEGameDescription *desc) const override;
 };
 
 bool CruiseMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -122,8 +122,8 @@ SaveStateDescriptor CruiseMetaEngine::querySaveMetaInfos(const char *target, int
 	return SaveStateDescriptor();
 }
 
-Common::Error CruiseMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Cruise::CruiseEngine(syst, (const Cruise::CRUISEGameDescription *)desc);
+Common::Error CruiseMetaEngine::createInstance(OSystem *syst, Engine **engine, const Cruise::CRUISEGameDescription *desc) const {
+	*engine = new Cruise::CruiseEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/cryo/detection.cpp
+++ b/engines/cryo/detection.cpp
@@ -118,9 +118,9 @@ static const ADGameDescription gameDescriptions[] = {
 
 } // End of namespace Cryo
 
-class CryoMetaEngineDetection : public AdvancedMetaEngineDetection {
+class CryoMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	CryoMetaEngineDetection() : AdvancedMetaEngineDetection(Cryo::gameDescriptions, sizeof(ADGameDescription), cryoGames) {
+	CryoMetaEngineDetection() : AdvancedMetaEngineDetection(Cryo::gameDescriptions, cryoGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/cryo/metaengine.cpp
+++ b/engines/cryo/metaengine.cpp
@@ -34,7 +34,7 @@ Common::Platform CryoEngine::getPlatform() const { return _gameDescription->plat
 
 } // End of namespace Cryo
 
-class CryoMetaEngine : public AdvancedMetaEngine {
+class CryoMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "cryo";

--- a/engines/cryomni3d/detection.cpp
+++ b/engines/cryomni3d/detection.cpp
@@ -50,10 +50,9 @@ static const DebugChannelDef debugFlagList[] = {
 
 namespace CryOmni3D {
 
-class CryOmni3DMetaEngineDetection : public AdvancedMetaEngineDetection {
+class CryOmni3DMetaEngineDetection : public AdvancedMetaEngineDetection<CryOmni3DGameDescription> {
 public:
-	CryOmni3DMetaEngineDetection() : AdvancedMetaEngineDetection(CryOmni3D::gameDescriptions,
-				sizeof(CryOmni3DGameDescription), cryomni3DGames) {
+	CryOmni3DMetaEngineDetection() : AdvancedMetaEngineDetection(CryOmni3D::gameDescriptions, cryomni3DGames) {
 		_directoryGlobs = directoryGlobs;
 		_maxScanDepth = 5;
 	}

--- a/engines/cryomni3d/detection.h
+++ b/engines/cryomni3d/detection.h
@@ -46,6 +46,8 @@ enum CryOmni3DGameFeatures {
 };
 
 struct CryOmni3DGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	uint8 gameType;

--- a/engines/cryomni3d/metaengine.cpp
+++ b/engines/cryomni3d/metaengine.cpp
@@ -66,14 +66,14 @@ bool CryOmni3DEngine::hasFeature(EngineFeature f) const {
 }
 
 
-class CryOmni3DMetaEngine : public AdvancedMetaEngine {
+class CryOmni3DMetaEngine : public AdvancedMetaEngine<CryOmni3DGameDescription> {
 public:
 	const char *getName() const override {
 		return "cryomni3d";
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const CryOmni3DGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override { return 999; }
@@ -133,9 +133,7 @@ void CryOmni3DMetaEngine::removeSaveState(const char *target, int slot) const {
 }
 
 Common::Error CryOmni3DMetaEngine::createInstance(OSystem *syst, Engine **engine,
-		const ADGameDescription *desc) const {
-	const CryOmni3DGameDescription *gd = (const CryOmni3DGameDescription *)desc;
-
+		const CryOmni3DGameDescription *gd) const {
 	switch (gd->gameType) {
 	case GType_VERSAILLES:
 #ifdef ENABLE_VERSAILLES

--- a/engines/dialogs.cpp
+++ b/engines/dialogs.cpp
@@ -90,7 +90,7 @@ MainMenuDialog::MainMenuDialog(Engine *engine)
 	if (!g_system->hasFeature(OSystem::kFeatureNoQuit) && (!(ConfMan.getBool("gui_return_to_launcher_at_exit")) || !_engine->hasFeature(Engine::kSupportsReturnToLauncher)))
 		new GUI::ButtonWidget(this, "GlobalMenu.Quit", _("~Q~uit"), Common::U32String(), kQuitCmd);
 
-	_aboutDialog = new GUI::AboutDialog();
+	_aboutDialog = new GUI::AboutDialog(true);
 	_loadDialog = new GUI::SaveLoadChooser(_("Load game:"), _("Load"), false);
 	_saveDialog = new GUI::SaveLoadChooser(_("Save game:"), _("Save"), true);
 }

--- a/engines/director/detection.cpp
+++ b/engines/director/detection.cpp
@@ -82,12 +82,12 @@ static const DebugChannelDef debugFlagList[] = {
 	DEBUG_CHANNEL_END
 };
 
-class DirectorMetaEngineDetection : public AdvancedMetaEngineDetection {
+class DirectorMetaEngineDetection : public AdvancedMetaEngineDetection<Director::DirectorGameDescription> {
 private:
 	Common::HashMap<Common::String, bool, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> _customTarget;
 
 public:
-	DirectorMetaEngineDetection() : AdvancedMetaEngineDetection(Director::gameDescriptions, sizeof(Director::DirectorGameDescription), directorGames) {
+	DirectorMetaEngineDetection() : AdvancedMetaEngineDetection(Director::gameDescriptions, directorGames) {
 		_maxScanDepth = 5;
 		_directoryGlobs = Director::directoryGlobs;
 		_flags = kADFlagMatchFullPaths | kADFlagCanPlayUnknownVariants;

--- a/engines/director/detection.h
+++ b/engines/director/detection.h
@@ -33,6 +33,8 @@ enum DirectorGameGID {
 };
 
 struct DirectorGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	DirectorGameGID gameGID;

--- a/engines/director/metaengine.cpp
+++ b/engines/director/metaengine.cpp
@@ -64,17 +64,17 @@ bool DirectorEngine::hasFeature(EngineFeature f) const {
 
 } // End of Namespace Director
 
-class DirectorMetaEngine : public AdvancedMetaEngine {
+class DirectorMetaEngine : public AdvancedMetaEngine<Director::DirectorGameDescription> {
 public:
 	const char *getName() const override {
 		return "director";
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Director::DirectorGameDescription *desc) const override;
 };
 
-Common::Error DirectorMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Director::DirectorEngine(syst, (const Director::DirectorGameDescription *)desc);
+Common::Error DirectorMetaEngine::createInstance(OSystem *syst, Engine **engine, const Director::DirectorGameDescription *desc) const {
+	*engine = new Director::DirectorEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/dm/detection.cpp
+++ b/engines/dm/detection.cpp
@@ -89,9 +89,9 @@ static const DMADGameDescription gameDescriptions[] = {
 	}
 };
 
-class DMMetaEngineDetection : public AdvancedMetaEngineDetection {
+class DMMetaEngineDetection : public AdvancedMetaEngineDetection<DMADGameDescription> {
 public:
-	DMMetaEngineDetection() : AdvancedMetaEngineDetection(DM::gameDescriptions, sizeof(DMADGameDescription), DMGames) {
+	DMMetaEngineDetection() : AdvancedMetaEngineDetection(DM::gameDescriptions, DMGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/dm/detection.h
+++ b/engines/dm/detection.h
@@ -68,6 +68,8 @@ enum SaveTarget {
 };
 
 struct DMADGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(_desc);
+
 	ADGameDescription _desc;
 
 	SaveTarget _saveTargetToWrite;

--- a/engines/dm/metaengine.cpp
+++ b/engines/dm/metaengine.cpp
@@ -35,13 +35,13 @@
 
 namespace DM {
 
-class DMMetaEngine : public AdvancedMetaEngine {
+class DMMetaEngine : public AdvancedMetaEngine<DMADGameDescription> {
 public:
 	const char *getName() const override {
 		return "dm";
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
+	Common::Error createInstance(OSystem *syst, Engine **engine, const DMADGameDescription *desc) const override {
 		*engine = new DM::DMEngine(syst, (const DMADGameDescription*)desc);
 		return Common::kNoError;
 	}

--- a/engines/draci/detection.cpp
+++ b/engines/draci/detection.cpp
@@ -90,9 +90,9 @@ const ADGameDescription gameDescriptions[] = {
 
 } // End of namespace Draci
 
-class DraciMetaEngineDetection : public AdvancedMetaEngineDetection {
+class DraciMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	DraciMetaEngineDetection() : AdvancedMetaEngineDetection(Draci::gameDescriptions, sizeof(ADGameDescription), draciGames) {
+	DraciMetaEngineDetection() : AdvancedMetaEngineDetection(Draci::gameDescriptions, draciGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/draci/metaengine.cpp
+++ b/engines/draci/metaengine.cpp
@@ -27,7 +27,7 @@
 #include "engines/advancedDetector.h"
 #include "engines/metaengine.h"
 
-class DraciMetaEngine : public AdvancedMetaEngine {
+class DraciMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "draci";

--- a/engines/dragons/detection.cpp
+++ b/engines/dragons/detection.cpp
@@ -119,9 +119,9 @@ static const char * const directoryGlobs[] = {
 	nullptr
 };
 
-class DragonsMetaEngineDetection : public AdvancedMetaEngineDetection {
+class DragonsMetaEngineDetection : public AdvancedMetaEngineDetection<Dragons::DragonsGameDescription> {
 public:
-	DragonsMetaEngineDetection() : AdvancedMetaEngineDetection(Dragons::gameDescriptions, sizeof(Dragons::DragonsGameDescription), dragonsGames) {
+	DragonsMetaEngineDetection() : AdvancedMetaEngineDetection(Dragons::gameDescriptions, dragonsGames) {
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/dragons/detection.h
+++ b/engines/dragons/detection.h
@@ -32,6 +32,8 @@ enum {
 };
 
 struct DragonsGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 	int gameId;
 };

--- a/engines/dragons/dragons.cpp
+++ b/engines/dragons/dragons.cpp
@@ -60,8 +60,8 @@ DragonsEngine *getEngine() {
 	return _engine;
 }
 
-DragonsEngine::DragonsEngine(OSystem *syst, const ADGameDescription *desc) : Engine(syst) {
-	_language = desc->language;
+DragonsEngine::DragonsEngine(OSystem *syst, const DragonsGameDescription *gd) : Engine(syst) {
+	_language = gd->desc.language;
 	_bigfileArchive = nullptr;
 	_dragonRMS = nullptr;
 	_backgroundResourceLoader = nullptr;

--- a/engines/dragons/dragons.h
+++ b/engines/dragons/dragons.h
@@ -245,7 +245,7 @@ private:
 protected:
 	bool hasFeature(EngineFeature f) const override;
 public:
-	DragonsEngine(OSystem *syst, const ADGameDescription *desc);
+	DragonsEngine(OSystem *syst, const DragonsGameDescription *desc);
 	~DragonsEngine();
 
 	void updateEvents();

--- a/engines/dragons/metaengine.cpp
+++ b/engines/dragons/metaengine.cpp
@@ -30,14 +30,14 @@
 #include "base/plugins.h"
 #include "graphics/thumbnail.h"
 
-class DragonsMetaEngine : public AdvancedMetaEngine {
+class DragonsMetaEngine : public AdvancedMetaEngine<Dragons::DragonsGameDescription> {
 public:
 	const char *getName() const override {
 		return "dragons";
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Dragons::DragonsGameDescription *desc) const override;
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
@@ -110,13 +110,12 @@ SaveStateDescriptor DragonsMetaEngine::querySaveMetaInfos(const char *target, in
 	return SaveStateDescriptor();
 }
 
-Common::Error DragonsMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Dragons::DragonsGameDescription *gd = (const Dragons::DragonsGameDescription *)desc;
+Common::Error DragonsMetaEngine::createInstance(OSystem *syst, Engine **engine, const Dragons::DragonsGameDescription *gd) const {
 	const char* urlForRequiredDataFiles = "https://wiki.scummvm.org/index.php?title=Blazing_Dragons#Required_data_files";
 
 	switch (gd->gameId) {
 	case Dragons::kGameIdDragons:
-		*engine = new Dragons::DragonsEngine(syst, desc);
+		*engine = new Dragons::DragonsEngine(syst, gd);
 		break;
 	case Dragons::kGameIdDragonsBadExtraction:
 		GUIErrorMessageWithURL(Common::U32String::format(_("Error: It appears that the game data files were extracted incorrectly.\n\nYou should only extract STR and XA files using the special method. The rest should be copied normally from your game CD.\n\n See %s"), urlForRequiredDataFiles), urlForRequiredDataFiles);

--- a/engines/drascula/detection.cpp
+++ b/engines/drascula/detection.cpp
@@ -293,9 +293,9 @@ static const DrasculaGameDescription gameDescriptions[] = {
 	{ AD_TABLE_END_MARKER }
 };
 
-class DrasculaMetaEngineDetection : public AdvancedMetaEngineDetection {
+class DrasculaMetaEngineDetection : public AdvancedMetaEngineDetection<Drascula::DrasculaGameDescription> {
 public:
-	DrasculaMetaEngineDetection() : AdvancedMetaEngineDetection(Drascula::gameDescriptions, sizeof(Drascula::DrasculaGameDescription), drasculaGames) {
+	DrasculaMetaEngineDetection() : AdvancedMetaEngineDetection(Drascula::gameDescriptions, drasculaGames) {
 		_guiOptions = GUIO2(GUIO_NOMIDI, GAMEOPTION_ORIGINAL_SAVELOAD);
 	}
 

--- a/engines/drascula/detection.h
+++ b/engines/drascula/detection.h
@@ -31,6 +31,8 @@ enum DrasculaGameFeatures {
 };
 
 struct DrasculaGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 };
 

--- a/engines/drascula/metaengine.cpp
+++ b/engines/drascula/metaengine.cpp
@@ -74,7 +74,7 @@ namespace Drascula {
 
 SaveStateDescriptor loadMetaData(Common::ReadStream *s, int slot, bool setPlayTime);
 
-class DrasculaMetaEngine : public AdvancedMetaEngine {
+class DrasculaMetaEngine : public AdvancedMetaEngine<Drascula::DrasculaGameDescription> {
 public:
 	const char *getName() const override {
 		return "drascula";
@@ -84,7 +84,7 @@ public:
 		return Drascula::optionsList;
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Drascula::DrasculaGameDescription *gd) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
 	SaveStateList listSaves(const char *target) const override;
@@ -172,8 +172,8 @@ void DrasculaMetaEngine::removeSaveState(const char *target, int slot) const {
 	g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
-Common::Error DrasculaMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Drascula::DrasculaEngine(syst, (const Drascula::DrasculaGameDescription *)desc);
+Common::Error DrasculaMetaEngine::createInstance(OSystem *syst, Engine **engine, const Drascula::DrasculaGameDescription *desc) const {
+	*engine = new Drascula::DrasculaEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/dreamweb/detection.cpp
+++ b/engines/dreamweb/detection.cpp
@@ -43,11 +43,11 @@ static const DebugChannelDef debugFlagList[] = {
 
 #include "dreamweb/detection_tables.h"
 
-class DreamWebMetaEngineDetection : public AdvancedMetaEngineDetection {
+class DreamWebMetaEngineDetection : public AdvancedMetaEngineDetection<DreamWeb::DreamWebGameDescription> {
 public:
 	DreamWebMetaEngineDetection():
 	AdvancedMetaEngineDetection(DreamWeb::gameDescriptions,
-	sizeof(DreamWeb::DreamWebGameDescription), dreamWebGames) {
+	dreamWebGames) {
 		_guiOptions = GUIO5(GUIO_NOMIDI, GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_BRIGHTPALETTE, GAMEOPTION_TTS_THINGS, GAMEOPTION_TTS_SPEECH);
 	}
 

--- a/engines/dreamweb/detection.h
+++ b/engines/dreamweb/detection.h
@@ -25,6 +25,8 @@
 namespace DreamWeb {
 
 struct DreamWebGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 };
 

--- a/engines/dreamweb/metaengine.cpp
+++ b/engines/dreamweb/metaengine.cpp
@@ -95,7 +95,7 @@ static const ADExtraGuiOptionsMap gameGuiOptions[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class DreamWebMetaEngine : public AdvancedMetaEngine {
+class DreamWebMetaEngine : public AdvancedMetaEngine<DreamWeb::DreamWebGameDescription> {
 public:
 	const char *getName() const override {
 		return "dreamweb";
@@ -105,7 +105,7 @@ public:
 		return gameGuiOptions;
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const DreamWeb::DreamWebGameDescription *desc) const override;
 
 	bool hasFeature(MetaEngineFeature f) const override;
 
@@ -147,8 +147,8 @@ bool DreamWeb::DreamWebEngine::hasFeature(EngineFeature f) const {
 	}
 }
 
-Common::Error DreamWebMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new DreamWeb::DreamWebEngine(syst, (const DreamWeb::DreamWebGameDescription *)desc);
+Common::Error DreamWebMetaEngine::createInstance(OSystem *syst, Engine **engine, const DreamWeb::DreamWebGameDescription *desc) const {
+	*engine = new DreamWeb::DreamWebEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/efh/detection.cpp
+++ b/engines/efh/detection.cpp
@@ -59,9 +59,9 @@ static const DebugChannelDef debugFlagList[] = {
 	{Efh::kDebugGraphics, "graphics", "Graphics debug level"},
 	DEBUG_CHANNEL_END};
 
-class EfhMetaEngineDetection : public AdvancedMetaEngineDetection {
+class EfhMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	EfhMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, sizeof(ADGameDescription), efhGames) {
+	EfhMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, efhGames) {
 	}
 
 	const char *getEngineName() const override {

--- a/engines/efh/metaengine.cpp
+++ b/engines/efh/metaengine.cpp
@@ -57,7 +57,7 @@ Common::Platform EfhEngine::getPlatform() const {
 
 namespace Efh {
 
-class EfhMetaEngine : public AdvancedMetaEngine {
+class EfhMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "efh";

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -1009,13 +1009,13 @@ GUI::Debugger *Engine::getOrCreateDebugger() {
 
 /*
 EnginePlugin *Engine::getMetaEnginePlugin() const {
-	return EngineMan.findPlugin(ConfMan.get("engineid"));
+	return EngineMan.findDetectionPlugin(ConfMan.get("engineid"));
 }
 
 */
 
 MetaEngineDetection &Engine::getMetaEngineDetection() {
-	const Plugin *plugin = EngineMan.findPlugin(ConfMan.get("engineid"));
+	const Plugin *plugin = EngineMan.findDetectionPlugin(ConfMan.get("engineid"));
 	assert(plugin);
 	return plugin->get<MetaEngineDetection>();
 }

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -1007,19 +1007,6 @@ GUI::Debugger *Engine::getOrCreateDebugger() {
 	return _debugger;
 }
 
-/*
-EnginePlugin *Engine::getMetaEnginePlugin() const {
-	return EngineMan.findDetectionPlugin(ConfMan.get("engineid"));
-}
-
-*/
-
-MetaEngineDetection &Engine::getMetaEngineDetection() {
-	const Plugin *plugin = EngineMan.findDetectionPlugin(ConfMan.get("engineid"));
-	assert(plugin);
-	return plugin->get<MetaEngineDetection>();
-}
-
 PauseToken::PauseToken() : _engine(nullptr) {}
 
 PauseToken::PauseToken(Engine *engine) : _engine(engine) {}

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -519,11 +519,6 @@ public:
 	static bool shouldQuit();
 
 	/**
-	 * Return the MetaEngineDetection instance used by this engine.
-	 */
-	static MetaEngineDetection &getMetaEngineDetection();
-
-	/**
 	 * Return the MetaEngine instance used by this engine.
 	 */
 	inline MetaEngine *getMetaEngine() const { return _metaEngine; }

--- a/engines/freescape/detection.cpp
+++ b/engines/freescape/detection.cpp
@@ -928,9 +928,9 @@ static const DebugChannelDef debugFlagList[] = {
 	DEBUG_CHANNEL_END
 };
 
-class FreescapeMetaEngineDetection : public AdvancedMetaEngineDetection {
+class FreescapeMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	FreescapeMetaEngineDetection() : AdvancedMetaEngineDetection(Freescape::gameDescriptions, sizeof(ADGameDescription), Freescape::freescapeGames) {
+	FreescapeMetaEngineDetection() : AdvancedMetaEngineDetection(Freescape::gameDescriptions, Freescape::freescapeGames) {
 		_guiOptions = GUIO7(GUIO_NOMIDI, GAMEOPTION_EXTENDED_TIMER, GAMEOPTION_DISABLE_DEMO_MODE, GAMEOPTION_DISABLE_SENSORS, GAMEOPTION_DISABLE_FALLING, GAMEOPTION_INVERT_Y, GAMEOPTION_AUTHENTIC_GRAPHICS);
 	}
 

--- a/engines/freescape/metaengine.cpp
+++ b/engines/freescape/metaengine.cpp
@@ -125,7 +125,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class FreescapeMetaEngine : public AdvancedMetaEngine {
+class FreescapeMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "freescape";

--- a/engines/glk/detection.cpp
+++ b/engines/glk/detection.cpp
@@ -178,6 +178,12 @@ PlainGameDescriptor GlkMetaEngineDetection::findGame(const char *gameId) const {
 
 #undef FIND_GAME
 
+Common::Error GlkMetaEngineDetection::identifyGame(DetectedGame &game, const void **descriptor) {
+	*descriptor = nullptr;
+	game = DetectedGame(getName(), findGame(ConfMan.get("gameid").c_str()));
+	return game.gameId.empty() ? Common::kUnknownError : Common::kNoError;
+}
+
 DetectedGames GlkMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/, bool /*skipIncomplete*/) {
 #ifndef RELEASE_BUILD
 	// This is as good a place as any to detect multiple sub-engines using the same Ids

--- a/engines/glk/detection.h
+++ b/engines/glk/detection.h
@@ -29,6 +29,8 @@
  * ScummVM Meta Engine interface
  */
 class GlkMetaEngineDetection : public MetaEngineDetection {
+private:
+	Common::String findFileByGameId(const Common::String &gameId);
 public:
 	GlkMetaEngineDetection() : MetaEngineDetection() {}
 
@@ -56,7 +58,7 @@ public:
 	 * (possibly empty) list of games supported by the engine which it was able
 	 * to detect amongst the given files.
 	 */
-	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipUnsupported*/, bool /*skipIncomplete*/) override;
+	DetectedGames detectGames(const Common::FSList &fslist, uint32 skipADFlags = 0, bool skipIncomplete = false) override;
 
 	/**
 	 * Query the engine for a PlainGameDescriptor for the specified gameid, if any.

--- a/engines/glk/detection.h
+++ b/engines/glk/detection.h
@@ -63,6 +63,8 @@ public:
 	 */
 	PlainGameDescriptor findGame(const char *gameId) const override;
 
+	Common::Error identifyGame(DetectedGame &game, const void **descriptor) override;
+
 	/**
 	 * Calls each sub-engine in turn to ensure no game Id accidentally shares the same Id
 	 */

--- a/engines/glk/metaengine.cpp
+++ b/engines/glk/metaengine.cpp
@@ -81,7 +81,8 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine) override;
+	Common::Error createInstance(OSystem *syst, Engine **engine,
+	                             const DetectedGame &gameDescriptor, const void *metaEngineDescriptor) override;
 
 	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
 
@@ -164,7 +165,8 @@ Common::String GlkMetaEngine::findFileByGameId(const Common::String &gameId) con
 	return Common::String();
 }
 
-Common::Error GlkMetaEngine::createInstance(OSystem *syst, Engine **engine) {
+Common::Error GlkMetaEngine::createInstance(OSystem *syst, Engine **engine,
+		const DetectedGame &gameDescriptor, const void *metaEngineDescriptor) {
 #ifndef RELEASE_BUILD
 	Glk::GameDescriptor td = Glk::GameDescriptor::empty();
 #endif

--- a/engines/gnap/detection.cpp
+++ b/engines/gnap/detection.cpp
@@ -77,9 +77,9 @@ static const ADGameDescription gameDescriptions[] = {
 
 } // End of namespace Gnap
 
-class GnapMetaEngineDetection : public AdvancedMetaEngineDetection {
+class GnapMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	GnapMetaEngineDetection() : AdvancedMetaEngineDetection(Gnap::gameDescriptions, sizeof(ADGameDescription), gnapGames) {
+	GnapMetaEngineDetection() : AdvancedMetaEngineDetection(Gnap::gameDescriptions, gnapGames) {
 		_maxScanDepth = 3;
 	}
 

--- a/engines/gnap/metaengine.cpp
+++ b/engines/gnap/metaengine.cpp
@@ -28,7 +28,7 @@
 #include "base/plugins.h"
 #include "graphics/thumbnail.h"
 
-class GnapMetaEngine : public AdvancedMetaEngine {
+class GnapMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "gnap";

--- a/engines/gob/detection/detection.cpp
+++ b/engines/gob/detection/detection.cpp
@@ -51,7 +51,7 @@ static const DebugChannelDef debugFlagList[] = {
 	DEBUG_CHANNEL_END
 };
 
-class GobMetaEngineDetection : public AdvancedMetaEngineDetection {
+class GobMetaEngineDetection : public AdvancedMetaEngineDetection<Gob::GOBGameDescription> {
 public:
 	GobMetaEngineDetection();
 
@@ -85,7 +85,7 @@ private:
 };
 
 GobMetaEngineDetection::GobMetaEngineDetection() :
-	AdvancedMetaEngineDetection(Gob::gameDescriptions, sizeof(Gob::GOBGameDescription), gobGames) {
+	AdvancedMetaEngineDetection(Gob::gameDescriptions, gobGames) {
 
 	_guiOptions = GUIO1(GUIO_NOLAUNCHLOAD);
 }

--- a/engines/gob/detection/detection.cpp
+++ b/engines/gob/detection/detection.cpp
@@ -59,6 +59,11 @@ public:
 		return Engines::findGameID(gameId, _gameIds, obsoleteGameIDsTable);
 	}
 
+	Common::Error identifyGame(DetectedGame &game, const void **descriptor) override {
+		Engines::upgradeTargetIfNecessary(obsoleteGameIDsTable);
+		return AdvancedMetaEngineDetection::identifyGame(game, descriptor);
+	}
+
 	const char *getName() const override {
 		return "gob";
 	}

--- a/engines/gob/detection/detection.h
+++ b/engines/gob/detection/detection.h
@@ -92,29 +92,15 @@ struct GOBGameDescription {
 
 	uint32 sizeBuffer() const {
 		uint32 ret = desc.sizeBuffer();
-		if (startStkBase) {
-			ret += strlen(startStkBase) + 1;
-		}
-		if (startTotBase) {
-			ret += strlen(startTotBase) + 1;
-		}
+		ret += ADDynamicDescription::strSizeBuffer(startStkBase);
+		ret += ADDynamicDescription::strSizeBuffer(startTotBase);
 		return ret;
 	}
 
 	void *toBuffer(void *buffer) {
 		buffer = desc.toBuffer(buffer);
-		if (startStkBase) {
-			int len = strlen(startStkBase) + 1;
-			memcpy((char *)buffer, startStkBase, len);
-			startStkBase = (const char *)buffer;
-			buffer = (char *)buffer + len;
-		}
-		if (startTotBase) {
-			int len = strlen(startTotBase) + 1;
-			memcpy((char *)buffer, startTotBase, len);
-			startTotBase = (const char *)buffer;
-			buffer = (char *)buffer + len;
-		}
+		buffer = ADDynamicDescription::strToBuffer(buffer, startStkBase);
+		buffer = ADDynamicDescription::strToBuffer(buffer, startTotBase);
 		return buffer;
 	}
 };

--- a/engines/gob/detection/detection.h
+++ b/engines/gob/detection/detection.h
@@ -89,6 +89,34 @@ struct GOBGameDescription {
 	const char *startStkBase;
 	const char *startTotBase;
 	uint32 demoIndex;
+
+	uint32 sizeBuffer() const {
+		uint32 ret = desc.sizeBuffer();
+		if (startStkBase) {
+			ret += strlen(startStkBase) + 1;
+		}
+		if (startTotBase) {
+			ret += strlen(startTotBase) + 1;
+		}
+		return ret;
+	}
+
+	void *toBuffer(void *buffer) {
+		buffer = desc.toBuffer(buffer);
+		if (startStkBase) {
+			int len = strlen(startStkBase) + 1;
+			memcpy((char *)buffer, startStkBase, len);
+			startStkBase = (const char *)buffer;
+			buffer = (char *)buffer + len;
+		}
+		if (startTotBase) {
+			int len = strlen(startTotBase) + 1;
+			memcpy((char *)buffer, startTotBase, len);
+			startTotBase = (const char *)buffer;
+			buffer = (char *)buffer + len;
+		}
+		return buffer;
+	}
 };
 
 #define GAMEOPTION_COPY_PROTECTION	GUIO_GAMEOPTIONS1

--- a/engines/gob/metaengine.cpp
+++ b/engines/gob/metaengine.cpp
@@ -26,13 +26,11 @@
  */
 
 #include "engines/advancedDetector.h"
-#include "engines/obsolete.h"
 
 #include "common/translation.h"
 
 #include "gob/gameidtotype.h"
 #include "gob/gob.h"
-#include "gob/obsolete.h"
 
 // For struct GOBGameDescription.
 #include "gob/detection/detection.h"
@@ -59,11 +57,6 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-
-	Common::Error createInstance(OSystem *syst, Engine **engine) override {
-		Engines::upgradeTargetIfNecessary(obsoleteGameIDsTable);
-		return AdvancedMetaEngine::createInstance(syst, engine);
-	}
 
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 

--- a/engines/gob/metaengine.cpp
+++ b/engines/gob/metaengine.cpp
@@ -50,7 +50,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class GobMetaEngine : public AdvancedMetaEngine {
+class GobMetaEngine : public AdvancedMetaEngine<Gob::GOBGameDescription> {
 public:
 	const char *getName() const override {
 		return "gob";
@@ -58,7 +58,7 @@ public:
 
 	bool hasFeature(MetaEngineFeature f) const override;
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Gob::GOBGameDescription *desc) const override;
 
 	const ADExtraGuiOptionsMap *getAdvancedExtraGuiOptions() const override {
 		return optionsList;
@@ -74,8 +74,7 @@ bool Gob::GobEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsReturnToLauncher);
 }
 
-Common::Error GobMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Gob::GOBGameDescription *gd = (const Gob::GOBGameDescription *)desc;
+Common::Error GobMetaEngine::createInstance(OSystem *syst, Engine **engine, const Gob::GOBGameDescription *gd) const {
 	*engine = new Gob::GobEngine(syst);
 	((Gob::GobEngine *)*engine)->initGame(gd);
 	return Common::kNoError;

--- a/engines/griffon/detection.cpp
+++ b/engines/griffon/detection.cpp
@@ -53,9 +53,9 @@ static const ADGameDescription gameDescriptions[] = {
 
 }
 
-class GriffonMetaEngineDetection: public AdvancedMetaEngineDetection {
+class GriffonMetaEngineDetection: public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	GriffonMetaEngineDetection() : AdvancedMetaEngineDetection(Griffon::gameDescriptions, sizeof(ADGameDescription), griffonGames) {
+	GriffonMetaEngineDetection() : AdvancedMetaEngineDetection(Griffon::gameDescriptions, griffonGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/griffon/metaengine.cpp
+++ b/engines/griffon/metaengine.cpp
@@ -50,7 +50,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 
 #endif
 
-class GriffonMetaEngine: public AdvancedMetaEngine {
+class GriffonMetaEngine: public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "griffon";

--- a/engines/grim/detection.cpp
+++ b/engines/grim/detection.cpp
@@ -704,6 +704,11 @@ public:
 		return Engines::findGameID(gameid, _gameIds, obsoleteGameIDsTable);
 	}
 
+	Common::Error identifyGame(DetectedGame &game, const void **descriptor) override {
+		Engines::upgradeTargetIfNecessary(obsoleteGameIDsTable);
+		return AdvancedMetaEngineDetection::identifyGame(game, descriptor);
+	}
+
 	const char *getEngineName() const override {
 		return "Grim";
 	}

--- a/engines/grim/detection.cpp
+++ b/engines/grim/detection.cpp
@@ -694,9 +694,9 @@ static const GrimGameDescription gameDescriptions[] = {
 	{ AD_TABLE_END_MARKER, GType_GRIM }
 };
 
-class GrimMetaEngineDetection : public AdvancedMetaEngineDetection {
+class GrimMetaEngineDetection : public AdvancedMetaEngineDetection<Grim::GrimGameDescription> {
 public:
-	GrimMetaEngineDetection() : AdvancedMetaEngineDetection(Grim::gameDescriptions, sizeof(Grim::GrimGameDescription), grimGames) {
+	GrimMetaEngineDetection() : AdvancedMetaEngineDetection(Grim::gameDescriptions, grimGames) {
 		_guiOptions = GUIO_NOMIDI;
 	}
 

--- a/engines/grim/detection.h
+++ b/engines/grim/detection.h
@@ -38,6 +38,8 @@ enum GrimGameType {
 };
 
 struct GrimGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 	GrimGameType gameType;
 };

--- a/engines/grim/metaengine.cpp
+++ b/engines/grim/metaengine.cpp
@@ -67,11 +67,6 @@ public:
 		return gameGuiOptions;
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine) override {
-		Engines::upgradeTargetIfNecessary(obsoleteGameIDsTable);
-		return AdvancedMetaEngine::createInstance(syst, engine);
-	}
-
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	bool hasFeature(MetaEngineFeature f) const override;

--- a/engines/grim/metaengine.cpp
+++ b/engines/grim/metaengine.cpp
@@ -57,7 +57,7 @@ static const ADExtraGuiOptionsMap gameGuiOptions[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class GrimMetaEngine : public AdvancedMetaEngine {
+class GrimMetaEngine : public AdvancedMetaEngine<Grim::GrimGameDescription> {
 public:
 	const char *getName() const override {
 		return "grim";
@@ -67,7 +67,7 @@ public:
 		return gameGuiOptions;
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Grim::GrimGameDescription *desc) const override;
 
 	bool hasFeature(MetaEngineFeature f) const override;
 
@@ -77,7 +77,7 @@ public:
 
 };
 
-Common::Error GrimMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error GrimMetaEngine::createInstance(OSystem *syst, Engine **engine, const Grim::GrimGameDescription *desc) const {
 	const GrimGameDescription *gd = (const GrimGameDescription *)desc;
 
 	if (gd->gameType == GType_MONKEY4) {

--- a/engines/groovie/detection.cpp
+++ b/engines/groovie/detection.cpp
@@ -275,9 +275,9 @@ static const char *const directoryGlobs[] = {
 	nullptr
 };
 
-class GroovieMetaEngineDetection : public AdvancedMetaEngineDetection {
+class GroovieMetaEngineDetection : public AdvancedMetaEngineDetection<GroovieGameDescription> {
 public:
-	GroovieMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, sizeof(GroovieGameDescription), groovieGames) {
+	GroovieMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, groovieGames) {
 		// Use kADFlagUseExtraAsHint in order to distinguish the 11th hour from
 		// its "Making of" as well as the Clandestiny Trailer; they all share
 		// the same MD5.

--- a/engines/groovie/detection.h
+++ b/engines/groovie/detection.h
@@ -35,6 +35,8 @@ enum EngineVersion {
 };
 
 struct GroovieGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	EngineVersion version; // Version of the engine

--- a/engines/groovie/metaengine.cpp
+++ b/engines/groovie/metaengine.cpp
@@ -118,7 +118,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class GroovieMetaEngine : public AdvancedMetaEngine {
+class GroovieMetaEngine : public AdvancedMetaEngine<GroovieGameDescription> {
 public:
 	const char *getName() const override {
 		return "groovie";
@@ -128,7 +128,7 @@ public:
 		return optionsList;
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const GroovieGameDescription *gd) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
 	SaveStateList listSaves(const char *target) const override;
@@ -138,13 +138,13 @@ public:
 	int getAutosaveSlot() const override;
 };
 
-Common::Error GroovieMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
+Common::Error GroovieMetaEngine::createInstance(OSystem *syst, Engine **engine, const GroovieGameDescription *gd) const {
 #ifndef ENABLE_GROOVIE2
-	if (((const GroovieGameDescription *)gd)->version != kGroovieT7G)
+	if (gd->version != kGroovieT7G)
 		return Common::Error(Common::kUnsupportedGameidError, _s("GroovieV2 support is not compiled in"));
 #endif
 
-	*engine = new GroovieEngine(syst, (const GroovieGameDescription *)gd);
+	*engine = new GroovieEngine(syst,gd);
 	return Common::kNoError;
 }
 

--- a/engines/hadesch/detection.cpp
+++ b/engines/hadesch/detection.cpp
@@ -69,9 +69,9 @@ static const char *const directoryGlobs[] = {
 };
 }
 
-class HadeschMetaEngineDetection : public AdvancedMetaEngineDetection {
+class HadeschMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	HadeschMetaEngineDetection() : AdvancedMetaEngineDetection(Hadesch::gameDescriptions, sizeof(ADGameDescription), Hadesch::hadeschGames) {
+	HadeschMetaEngineDetection() : AdvancedMetaEngineDetection(Hadesch::gameDescriptions, Hadesch::hadeschGames) {
 		// mac puts wd.pod in Hades - Copy To Hard Drive/Hades Challenge/World. So we need 4 levels
 		_maxScanDepth = 4;
 		_directoryGlobs = Hadesch::directoryGlobs;

--- a/engines/hadesch/metaengine.cpp
+++ b/engines/hadesch/metaengine.cpp
@@ -26,7 +26,7 @@
 #include "hadesch/hadesch.h"
 #include "engines/advancedDetector.h"
 
-class HadeschMetaEngine : public AdvancedMetaEngine {
+class HadeschMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	bool hasFeature(MetaEngineFeature f) const override {
 		return

--- a/engines/hdb/detection.cpp
+++ b/engines/hdb/detection.cpp
@@ -113,9 +113,9 @@ static const ADGameDescription gameDescriptions[] = {
 
 } // End of namespace HDB
 
-class HDBMetaEngineDetection : public AdvancedMetaEngineDetection {
+class HDBMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	HDBMetaEngineDetection() : AdvancedMetaEngineDetection(HDB::gameDescriptions, sizeof(ADGameDescription), hdbGames) {
+	HDBMetaEngineDetection() : AdvancedMetaEngineDetection(HDB::gameDescriptions, hdbGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/hdb/metaengine.cpp
+++ b/engines/hdb/metaengine.cpp
@@ -78,7 +78,7 @@ bool HDBGame::isHandango() const {
 
 } // End of namespace HDB
 
-class HDBMetaEngine : public AdvancedMetaEngine {
+class HDBMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "hdb";

--- a/engines/hopkins/detection.cpp
+++ b/engines/hopkins/detection.cpp
@@ -44,9 +44,9 @@ const static char *const directoryGlobs[] = {
 	nullptr
 };
 
-class HopkinsMetaEngineDetection : public AdvancedMetaEngineDetection {
+class HopkinsMetaEngineDetection : public AdvancedMetaEngineDetection<Hopkins::HopkinsGameDescription> {
 public:
-	HopkinsMetaEngineDetection() : AdvancedMetaEngineDetection(Hopkins::gameDescriptions, sizeof(Hopkins::HopkinsGameDescription), hopkinsGames) {
+	HopkinsMetaEngineDetection() : AdvancedMetaEngineDetection(Hopkins::gameDescriptions, hopkinsGames) {
 		_maxScanDepth = 3;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/hopkins/detection.h
+++ b/engines/hopkins/detection.h
@@ -25,6 +25,8 @@
 namespace Hopkins {
 
 struct HopkinsGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 };
 

--- a/engines/hopkins/metaengine.cpp
+++ b/engines/hopkins/metaengine.cpp
@@ -86,7 +86,7 @@ const Common::String &HopkinsEngine::getTargetName() const {
 
 } // End of namespace Hopkins
 
-class HopkinsMetaEngine : public AdvancedMetaEngine {
+class HopkinsMetaEngine : public AdvancedMetaEngine<Hopkins::HopkinsGameDescription> {
 public:
 	const char *getName() const override {
 		return "hopkins";
@@ -97,7 +97,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Hopkins::HopkinsGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -122,8 +122,8 @@ bool Hopkins::HopkinsEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-Common::Error HopkinsMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Hopkins::HopkinsEngine(syst, (const Hopkins::HopkinsGameDescription *)desc);
+Common::Error HopkinsMetaEngine::createInstance(OSystem *syst, Engine **engine, const Hopkins::HopkinsGameDescription *desc) const {
+	*engine = new Hopkins::HopkinsEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/hpl1/detection.cpp
+++ b/engines/hpl1/detection.cpp
@@ -43,7 +43,7 @@ const DebugChannelDef Hpl1MetaEngineDetection::debugFlagList[] = {
 	DEBUG_CHANNEL_END};
 
 Hpl1MetaEngineDetection::Hpl1MetaEngineDetection() : AdvancedMetaEngineDetection(Hpl1::GAME_DESCRIPTIONS,
-																				 sizeof(ADGameDescription), Hpl1::GAME_NAMES) {
+																				 Hpl1::GAME_NAMES) {
 }
 
 REGISTER_PLUGIN_STATIC(HPL1_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, Hpl1MetaEngineDetection);

--- a/engines/hpl1/detection.h
+++ b/engines/hpl1/detection.h
@@ -32,7 +32,7 @@ extern const ADGameDescription GAME_DESCRIPTIONS[];
 
 } // namespace Hpl1
 
-class Hpl1MetaEngineDetection : public AdvancedMetaEngineDetection {
+class Hpl1MetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 	static const DebugChannelDef debugFlagList[];
 
 public:

--- a/engines/hpl1/metaengine.h
+++ b/engines/hpl1/metaengine.h
@@ -24,7 +24,7 @@
 
 #include "engines/advancedDetector.h"
 
-class Hpl1MetaEngine : public AdvancedMetaEngine {
+class Hpl1MetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override;
 

--- a/engines/hugo/detection.cpp
+++ b/engines/hugo/detection.cpp
@@ -127,9 +127,9 @@ static const HugoGameDescription gameDescriptions[] = {
 	{AD_TABLE_END_MARKER, kGameTypeNone}
 };
 
-class HugoMetaEngineDetection : public AdvancedMetaEngineDetection {
+class HugoMetaEngineDetection : public AdvancedMetaEngineDetection<HugoGameDescription> {
 public:
-	HugoMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, sizeof(HugoGameDescription), hugoGames) {
+	HugoMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, hugoGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/hugo/detection.h
+++ b/engines/hugo/detection.h
@@ -48,6 +48,8 @@ enum GameVariant {
 };
 
 struct HugoGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 	GameType gameType;
 };

--- a/engines/hugo/metaengine.cpp
+++ b/engines/hugo/metaengine.cpp
@@ -39,13 +39,13 @@ const char *HugoEngine::getGameId() const {
 	return _gameDescription->desc.gameId;
 }
 
-class HugoMetaEngine : public AdvancedMetaEngine {
+class HugoMetaEngine : public AdvancedMetaEngine<HugoGameDescription> {
 public:
 	const char *getName() const override {
 		return "hugo";
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const HugoGameDescription *gd) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
 	int getMaximumSaveSlot() const override;
@@ -62,9 +62,9 @@ public:
 	}
 };
 
-Common::Error HugoMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
-	*engine = new HugoEngine(syst, (const HugoGameDescription *)gd);
-	((HugoEngine *)*engine)->initGame((const HugoGameDescription *)gd);
+Common::Error HugoMetaEngine::createInstance(OSystem *syst, Engine **engine, const HugoGameDescription *gd) const {
+	*engine = new HugoEngine(syst,gd);
+	((HugoEngine *)*engine)->initGame(gd);
 	return Common::kNoError;
 }
 

--- a/engines/hypno/detection.cpp
+++ b/engines/hypno/detection.cpp
@@ -281,9 +281,9 @@ static const char *const directoryGlobs[] = {
 	nullptr
 };
 
-class HypnoMetaEngineDetection : public AdvancedMetaEngineDetection {
+class HypnoMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	HypnoMetaEngineDetection() : AdvancedMetaEngineDetection(Hypno::gameDescriptions, sizeof(ADGameDescription), Hypno::hypnoGames) {
+	HypnoMetaEngineDetection() : AdvancedMetaEngineDetection(Hypno::gameDescriptions, Hypno::hypnoGames) {
 		_guiOptions = GUIO6(GUIO_NOMIDI, GAMEOPTION_ORIGINAL_CHEATS, GAMEOPTION_INFINITE_HEALTH, GAMEOPTION_INFINITE_AMMO, GAMEOPTION_UNLOCK_ALL_LEVELS, GAMEOPTION_RESTORED_CONTENT);
 		_maxScanDepth = 3;
 		_directoryGlobs = directoryGlobs;

--- a/engines/hypno/metaengine.cpp
+++ b/engines/hypno/metaengine.cpp
@@ -85,7 +85,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class HypnoMetaEngine : public AdvancedMetaEngine {
+class HypnoMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "hypno";

--- a/engines/icb/detection.cpp
+++ b/engines/icb/detection.cpp
@@ -305,9 +305,9 @@ static const IcbGameDescription gameDescriptions[] = {
 	{ AD_TABLE_END_MARKER, GType_ICB }
 };
 
-class IcbMetaEngineDetection : public AdvancedMetaEngineDetection {
+class IcbMetaEngineDetection : public AdvancedMetaEngineDetection<IcbGameDescription> {
 public:
-	IcbMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, sizeof(IcbGameDescription), icbGames) {
+	IcbMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, icbGames) {
 		_guiOptions = GUIO_NOMIDI;
 		_flags = kADFlagMatchFullPaths;
 	}

--- a/engines/icb/detection.h
+++ b/engines/icb/detection.h
@@ -32,6 +32,8 @@ enum IcbGameType {
 };
 
 struct IcbGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 	IcbGameType gameType;
 };

--- a/engines/icb/metaengine.cpp
+++ b/engines/icb/metaengine.cpp
@@ -27,20 +27,19 @@
 
 namespace ICB {
 
-class IcbMetaEngine : public AdvancedMetaEngine {
+class IcbMetaEngine : public AdvancedMetaEngine<IcbGameDescription> {
 public:
 	const char *getName() const override {
 		return "icb";
 	}
 	bool hasFeature(MetaEngineFeature f) const override { return false; }
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const IcbGameDescription *desc) const override;
 
 	Common::KeymapArray initKeymaps(const char *target) const override;
 };
 
-Common::Error IcbMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const IcbGameDescription *gd = (const IcbGameDescription *)desc;
+Common::Error IcbMetaEngine::createInstance(OSystem *syst, Engine **engine, const IcbGameDescription *gd) const {
 	*engine = new IcbEngine(syst, gd);
 	return Common::kNoError;
 }

--- a/engines/illusions/detection.cpp
+++ b/engines/illusions/detection.cpp
@@ -109,9 +109,9 @@ static const char * const directoryGlobs[] = {
 	nullptr
 };
 
-class IllusionsMetaEngineDetection : public AdvancedMetaEngineDetection {
+class IllusionsMetaEngineDetection : public AdvancedMetaEngineDetection<Illusions::IllusionsGameDescription> {
 public:
-	IllusionsMetaEngineDetection() : AdvancedMetaEngineDetection(Illusions::gameDescriptions, sizeof(Illusions::IllusionsGameDescription), illusionsGames) {
+	IllusionsMetaEngineDetection() : AdvancedMetaEngineDetection(Illusions::gameDescriptions, illusionsGames) {
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/illusions/detection.h
+++ b/engines/illusions/detection.h
@@ -32,6 +32,8 @@ enum {
 };
 
 struct IllusionsGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 	int gameId;
 };

--- a/engines/illusions/metaengine.cpp
+++ b/engines/illusions/metaengine.cpp
@@ -44,14 +44,14 @@ Common::Language IllusionsEngine::getGameLanguage() const {
 
 } // End of namespace Illusions
 
-class IllusionsMetaEngine : public AdvancedMetaEngine {
+class IllusionsMetaEngine : public AdvancedMetaEngine<Illusions::IllusionsGameDescription> {
 public:
 	const char *getName() const override {
 		return "illusions";
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Illusions::IllusionsGameDescription *desc) const override;
 
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
@@ -124,8 +124,7 @@ SaveStateDescriptor IllusionsMetaEngine::querySaveMetaInfos(const char *target, 
 	return SaveStateDescriptor();
 }
 
-Common::Error IllusionsMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Illusions::IllusionsGameDescription *gd = (const Illusions::IllusionsGameDescription *)desc;
+Common::Error IllusionsMetaEngine::createInstance(OSystem *syst, Engine **engine, const Illusions::IllusionsGameDescription *gd) const {
 	switch (gd->gameId) {
 	case Illusions::kGameIdBBDOU:
 		*engine = new Illusions::IllusionsEngine_BBDOU(syst, gd);

--- a/engines/immortal/detection.cpp
+++ b/engines/immortal/detection.cpp
@@ -26,7 +26,7 @@
 #include "immortal/detection_tables.h"
 
 ImmortalMetaEngineDetection::ImmortalMetaEngineDetection() : AdvancedMetaEngineDetection(Immortal::gameDescriptions,
-	sizeof(ADGameDescription), Immortal::immortalGames) {
+	Immortal::immortalGames) {
 }
 
 REGISTER_PLUGIN_STATIC(IMMORTAL_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, ImmortalMetaEngineDetection);

--- a/engines/immortal/detection.h
+++ b/engines/immortal/detection.h
@@ -35,7 +35,7 @@ extern const ADGameDescription gameDescriptions[];
 
 } // namespace Immortal
 
-class ImmortalMetaEngineDetection : public AdvancedMetaEngineDetection {
+class ImmortalMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 	static const DebugChannelDef debugFlagList[];
 
 public:

--- a/engines/immortal/metaengine.h
+++ b/engines/immortal/metaengine.h
@@ -26,7 +26,7 @@
 #include "engines/achievements.h"
 #include "engines/advancedDetector.h"
 
-class ImmortalMetaEngine : public AdvancedMetaEngine {
+class ImmortalMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override;
 

--- a/engines/kingdom/detection.cpp
+++ b/engines/kingdom/detection.cpp
@@ -88,9 +88,9 @@ static const ADGameDescription gameDescriptions[] = {
 
 } // End of namespace Kingdom
 
-class KingdomMetaEngineDetection : public AdvancedMetaEngineDetection {
+class KingdomMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	KingdomMetaEngineDetection() : AdvancedMetaEngineDetection(Kingdom::gameDescriptions, sizeof(ADGameDescription), kingdomGames) {
+	KingdomMetaEngineDetection() : AdvancedMetaEngineDetection(Kingdom::gameDescriptions, kingdomGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/kingdom/metaengine.cpp
+++ b/engines/kingdom/metaengine.cpp
@@ -37,7 +37,7 @@ Common::Platform KingdomGame::getPlatform() const { return _gameDescription->pla
 } // End of namespace Kingdom
 
 
-class KingdomMetaEngine : public AdvancedMetaEngine {
+class KingdomMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "kingdom";

--- a/engines/kyra/detection.cpp
+++ b/engines/kyra/detection.cpp
@@ -52,9 +52,9 @@ const char *const directoryGlobs[] = {
 
 } // End of anonymous namespace
 
-class KyraMetaEngineDetection : public AdvancedMetaEngineDetection {
+class KyraMetaEngineDetection : public AdvancedMetaEngineDetection<KYRAGameDescription> {
 public:
-	KyraMetaEngineDetection() : AdvancedMetaEngineDetection(adGameDescs, sizeof(KYRAGameDescription), gameList) {
+	KyraMetaEngineDetection() : AdvancedMetaEngineDetection(adGameDescs, gameList) {
 		_md5Bytes = 1024 * 1024;
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;

--- a/engines/kyra/detection.h
+++ b/engines/kyra/detection.h
@@ -65,6 +65,8 @@ struct GameFlags {
 namespace {
 
 struct KYRAGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	Kyra::GameFlags flags;

--- a/engines/kyra/metaengine.cpp
+++ b/engines/kyra/metaengine.cpp
@@ -156,7 +156,7 @@ const ADExtraGuiOptionsMap gameGuiOptions[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class KyraMetaEngine : public AdvancedMetaEngine {
+class KyraMetaEngine : public AdvancedMetaEngine<KYRAGameDescription> {
 public:
 	const char *getName() const override {
 		return "kyra";
@@ -167,7 +167,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const KYRAGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -198,9 +198,7 @@ bool Kyra::KyraEngine_v1::hasFeature(EngineFeature f) const {
 	    (f == kSupportsSubtitleOptions);
 }
 
-Common::Error KyraMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const KYRAGameDescription *gd = (const KYRAGameDescription *)desc;
-
+Common::Error KyraMetaEngine::createInstance(OSystem *syst, Engine **engine, const KYRAGameDescription *gd) const {
 	Kyra::GameFlags flags = gd->flags;
 
 	flags.lang = gd->desc.language;

--- a/engines/lab/detection.cpp
+++ b/engines/lab/detection.cpp
@@ -94,9 +94,9 @@ static const char *const directoryGlobs[] = {
 
 
 
-class LabMetaEngineDetection : public AdvancedMetaEngineDetection {
+class LabMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	LabMetaEngineDetection() : AdvancedMetaEngineDetection(labDescriptions, sizeof(ADGameDescription), lab_setting) {
+	LabMetaEngineDetection() : AdvancedMetaEngineDetection(labDescriptions, lab_setting) {
 		_maxScanDepth = 4;
 		_directoryGlobs = directoryGlobs;
 		_flags = kADFlagUseExtraAsHint;

--- a/engines/lab/metaengine.cpp
+++ b/engines/lab/metaengine.cpp
@@ -42,7 +42,7 @@ uint32 LabEngine::getFeatures() const {
 
 } // End of namespace Lab
 
-class LabMetaEngine : public AdvancedMetaEngine {
+class LabMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "lab";

--- a/engines/lastexpress/detection.cpp
+++ b/engines/lastexpress/detection.cpp
@@ -221,9 +221,9 @@ static const char *const directoryGlobs[] = {
 		nullptr
 };
 
-class LastExpressMetaEngineDetection : public AdvancedMetaEngineDetection {
+class LastExpressMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	LastExpressMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, sizeof(ADGameDescription), lastExpressGames) {
+	LastExpressMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, lastExpressGames) {
 		_guiOptions = GUIO2(GUIO_NOSUBTITLES, GUIO_NOSFX);
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;

--- a/engines/lastexpress/metaengine.cpp
+++ b/engines/lastexpress/metaengine.cpp
@@ -25,7 +25,7 @@
 
 namespace LastExpress {
 
-class LastExpressMetaEngine : public AdvancedMetaEngine {
+class LastExpressMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "lastexpress";
@@ -42,7 +42,7 @@ protected:
 };
 
 Common::Error LastExpressMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
-	*engine = new LastExpressEngine(syst, (const ADGameDescription *)gd);
+	*engine = new LastExpressEngine(syst, gd);
 	return Common::kNoError;
 }
 

--- a/engines/lilliput/detection.cpp
+++ b/engines/lilliput/detection.cpp
@@ -114,9 +114,9 @@ static const LilliputGameDescription gameDescriptions[] = {
 	{AD_TABLE_END_MARKER, kGameTypeNone}
 };
 
-class LilliputMetaEngineDetection : public AdvancedMetaEngineDetection {
+class LilliputMetaEngineDetection : public AdvancedMetaEngineDetection<LilliputGameDescription> {
 public:
-	LilliputMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, sizeof(LilliputGameDescription), lilliputGames) {
+	LilliputMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, lilliputGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/lilliput/detection.h
+++ b/engines/lilliput/detection.h
@@ -33,6 +33,8 @@ enum GameType {
 };
 
 struct LilliputGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 	GameType gameType;
 };

--- a/engines/lilliput/metaengine.cpp
+++ b/engines/lilliput/metaengine.cpp
@@ -43,13 +43,13 @@ const char *LilliputEngine::getGameId() const {
 
 namespace Lilliput {
 
-class LilliputMetaEngine : public AdvancedMetaEngine {
+class LilliputMetaEngine : public AdvancedMetaEngine<LilliputGameDescription> {
 public:
 	const char *getName() const override {
 		return "lilliput";
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const LilliputGameDescription *gd) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
 	int getMaximumSaveSlot() const override;
@@ -66,9 +66,9 @@ public:
 	}
 };
 
-Common::Error LilliputMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
-	*engine = new LilliputEngine(syst, (const LilliputGameDescription *)gd);
-	((LilliputEngine *)*engine)->initGame((const LilliputGameDescription *)gd);
+Common::Error LilliputMetaEngine::createInstance(OSystem *syst, Engine **engine, const LilliputGameDescription *gd) const {
+	*engine = new LilliputEngine(syst,gd);
+	((LilliputEngine *)*engine)->initGame(gd);
 	return Common::kNoError;
 }
 

--- a/engines/lure/detection.cpp
+++ b/engines/lure/detection.cpp
@@ -242,9 +242,9 @@ static const LureGameDescription gameDescriptions[] = {
 
 } // End of namespace Lure
 
-class LureMetaEngineDetection : public AdvancedMetaEngineDetection {
+class LureMetaEngineDetection : public AdvancedMetaEngineDetection<Lure::LureGameDescription> {
 public:
-	LureMetaEngineDetection() : AdvancedMetaEngineDetection(Lure::gameDescriptions, sizeof(Lure::LureGameDescription), lureGames) {
+	LureMetaEngineDetection() : AdvancedMetaEngineDetection(Lure::gameDescriptions, lureGames) {
 		_md5Bytes = 1024;
 
 		// Use kADFlagUseExtraAsHint to distinguish between EGA and VGA versions

--- a/engines/lure/detection.h
+++ b/engines/lure/detection.h
@@ -34,6 +34,8 @@ enum {
 };
 
 struct LureGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	uint32 features;

--- a/engines/lure/metaengine.cpp
+++ b/engines/lure/metaengine.cpp
@@ -80,7 +80,7 @@ LureLanguage LureEngine::getLureLanguage() const {
 
 } // End of namespace Lure
 
-class LureMetaEngine : public AdvancedMetaEngine {
+class LureMetaEngine : public AdvancedMetaEngine<Lure::LureGameDescription> {
 public:
 	const char *getName() const override {
 		return "lure";
@@ -91,7 +91,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Lure::LureGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -113,8 +113,8 @@ bool Lure::LureEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-Common::Error LureMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Lure::LureEngine(syst, (const Lure::LureGameDescription *)desc);
+Common::Error LureMetaEngine::createInstance(OSystem *syst, Engine **engine, const Lure::LureGameDescription *desc) const {
+	*engine = new Lure::LureEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/m4/detection.cpp
+++ b/engines/m4/detection.cpp
@@ -44,7 +44,7 @@ static const char *const DIRECTORY_GLOBS[] = {
 };
 
 M4MetaEngineDetection::M4MetaEngineDetection() : AdvancedMetaEngineDetection(M4::gameDescriptions,
-		sizeof(M4::M4GameDescription), M4::m4Games) {
+		M4::m4Games) {
 	_guiOptions = GUIO1(GAMEOPTION_ORIGINAL_SAVELOAD);
 	_maxScanDepth = 2;
 	_directoryGlobs = DIRECTORY_GLOBS;

--- a/engines/m4/detection.h
+++ b/engines/m4/detection.h
@@ -65,7 +65,7 @@ struct M4GameDescription {
 
 } // End of namespace M4
 
-class M4MetaEngineDetection : public AdvancedMetaEngineDetection {
+class M4MetaEngineDetection : public AdvancedMetaEngineDetection<M4::M4GameDescription> {
 	static const DebugChannelDef debugFlagList[];
 
 public:

--- a/engines/m4/detection.h
+++ b/engines/m4/detection.h
@@ -55,6 +55,8 @@ enum Features {
 };
 
 struct M4GameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	int gameType;

--- a/engines/m4/metaengine.cpp
+++ b/engines/m4/metaengine.cpp
@@ -55,9 +55,7 @@ const ADExtraGuiOptionsMap *M4MetaEngine::getAdvancedExtraGuiOptions() const {
 	return M4::optionsList;
 }
 
-Common::Error M4MetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const M4::M4GameDescription *gd = (const M4::M4GameDescription *)desc;
-
+Common::Error M4MetaEngine::createInstance(OSystem *syst, Engine **engine, const M4::M4GameDescription *gd) const {
 	switch (gd->gameType) {
 	case M4::GType_Burger:
 		*engine = new M4::Burger::BurgerEngine(syst, gd);

--- a/engines/m4/metaengine.h
+++ b/engines/m4/metaengine.h
@@ -25,7 +25,9 @@
 #include "graphics/surface.h"
 #include "engines/advancedDetector.h"
 
-class M4MetaEngine : public AdvancedMetaEngine {
+#include "engines/m4/detection.h"
+
+class M4MetaEngine : public AdvancedMetaEngine<M4::M4GameDescription> {
 private:
 	Common::InSaveFile *getOriginalSave(const Common::String &saveName) const;
 
@@ -37,7 +39,7 @@ public:
 
 	const char *getName() const override;
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const M4::M4GameDescription *desc) const override;
 
 	/**
 	 * Determine whether the engine supports the specified MetaEngine feature.

--- a/engines/macventure/detection.cpp
+++ b/engines/macventure/detection.cpp
@@ -82,9 +82,9 @@ namespace MacVenture {
 
 SaveStateDescriptor loadMetaData(Common::SeekableReadStream *s, int slot, bool skipThumbnail = true);
 
-class MacVentureMetaEngineDetection : public AdvancedMetaEngineDetection {
+class MacVentureMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	MacVentureMetaEngineDetection() : AdvancedMetaEngineDetection(MacVenture::gameDescriptions, sizeof(ADGameDescription), macventureGames) {
+	MacVentureMetaEngineDetection() : AdvancedMetaEngineDetection(MacVenture::gameDescriptions, macventureGames) {
 		_guiOptions = GUIO1(GUIO_NOMIDI);
 	}
 

--- a/engines/macventure/metaengine.cpp
+++ b/engines/macventure/metaengine.cpp
@@ -39,7 +39,7 @@ namespace MacVenture {
 
 SaveStateDescriptor loadMetaData(Common::SeekableReadStream *s, int slot, bool skipThumbnail = true);
 
-class MacVentureMetaEngine : public AdvancedMetaEngine {
+class MacVentureMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "macventure";

--- a/engines/made/detection.cpp
+++ b/engines/made/detection.cpp
@@ -36,9 +36,9 @@ static const PlainGameDescriptor madeGames[] = {
 
 #include "made/detection_tables.h"
 
-class MadeMetaEngineDetection : public AdvancedMetaEngineDetection {
+class MadeMetaEngineDetection : public AdvancedMetaEngineDetection<Made::MadeGameDescription> {
 public:
-	MadeMetaEngineDetection() : AdvancedMetaEngineDetection(Made::gameDescriptions, sizeof(Made::MadeGameDescription), madeGames) {
+	MadeMetaEngineDetection() : AdvancedMetaEngineDetection(Made::gameDescriptions, madeGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/made/detection.h
+++ b/engines/made/detection.h
@@ -41,6 +41,8 @@ enum MadeGameFeatures {
 };
 
 struct MadeGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	int gameID;

--- a/engines/made/metaengine.cpp
+++ b/engines/made/metaengine.cpp
@@ -64,7 +64,7 @@ uint16 MadeEngine::getVersion() const {
 
 } // End of namespace Made
 
-class MadeMetaEngine : public AdvancedMetaEngine {
+class MadeMetaEngine : public AdvancedMetaEngine<Made::MadeGameDescription> {
 public:
 	const char *getName() const override {
 		return "made";
@@ -75,7 +75,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Made::MadeGameDescription *desc) const override;
 
 	Common::KeymapArray initKeymaps(const char *target) const override;
 };
@@ -90,8 +90,8 @@ bool Made::MadeEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsReturnToLauncher);
 }
 
-Common::Error MadeMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Made::MadeEngine(syst, (const Made::MadeGameDescription *)desc);
+Common::Error MadeMetaEngine::createInstance(OSystem *syst, Engine **engine, const Made::MadeGameDescription *desc) const {
+	*engine = new Made::MadeEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/mads/detection.cpp
+++ b/engines/mads/detection.cpp
@@ -45,9 +45,9 @@ static const DebugChannelDef debugFlagList[] = {
 
 #include "mads/detection_tables.h"
 
-class MADSMetaEngineDetection : public AdvancedMetaEngineDetection {
+class MADSMetaEngineDetection : public AdvancedMetaEngineDetection<MADS::MADSGameDescription> {
 public:
-	MADSMetaEngineDetection() : AdvancedMetaEngineDetection(MADS::gameDescriptions, sizeof(MADS::MADSGameDescription), MADSGames) {
+	MADSMetaEngineDetection() : AdvancedMetaEngineDetection(MADS::gameDescriptions, MADSGames) {
 		_maxScanDepth = 3;
 	}
 

--- a/engines/mads/detection.h
+++ b/engines/mads/detection.h
@@ -39,6 +39,8 @@ enum {
 };
 
 struct MADSGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	int gameID;

--- a/engines/mads/metaengine.cpp
+++ b/engines/mads/metaengine.cpp
@@ -156,7 +156,7 @@ Common::Platform MADSEngine::getPlatform() const {
 
 } // End of namespace MADS
 
-class MADSMetaEngine : public AdvancedMetaEngine {
+class MADSMetaEngine : public AdvancedMetaEngine<MADS::MADSGameDescription> {
 public:
 	const char *getName() const override {
 		return "mads";
@@ -167,7 +167,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const MADS::MADSGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -192,8 +192,8 @@ bool MADS::MADSEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-Common::Error MADSMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new MADS::MADSEngine(syst, (const MADS::MADSGameDescription *)desc);
+Common::Error MADSMetaEngine::createInstance(OSystem *syst, Engine **engine, const MADS::MADSGameDescription *desc) const {
+	*engine = new MADS::MADSEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "engines/metaengine.h"
+#include "engines/engine.h"
 
 #include "backends/keymapper/action.h"
 #include "backends/keymapper/keymap.h"
@@ -340,6 +341,10 @@ WARN_UNUSED_RESULT bool MetaEngine::readSavegameHeader(Common::InSaveFile *in, E
 //////////////////////////////////////////////
 // MetaEngine default implementations
 //////////////////////////////////////////////
+
+void MetaEngine::deleteInstance(Engine *engine, const DetectedGame &gameDescriptor, const void *meDescriptor) {
+	delete engine;
+}
 
 int MetaEngine::findEmptySaveSlot(const char *target) {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -142,6 +142,9 @@ public:
 	/** Query the engine for a PlainGameDescriptor for the specified gameid, if any. */
 	virtual PlainGameDescriptor findGame(const char *gameId) const = 0;
 
+	/** Identify the active game and check its data files. */
+	virtual Common::Error identifyGame(DetectedGame &game, const void **descriptor) = 0;
+
 	/**
 	 * Run the engine's game detector on the given list of files, and return a
 	 * (possibly empty) list of games supported by the engine that were
@@ -241,13 +244,16 @@ public:
 	 * The MetaEngine queries the ConfMan singleton for data like the target,
 	 * gameid, path etc.
 	 *
-	 * @param syst    Pointer to the global OSystem object.
-	 * @param engine  Pointer to a pointer that the MetaEngine sets to
-	 *                the newly created Engine, or 0 in case of an error.
+	 * @param syst            Pointer to the global OSystem object.
+	 * @param engine          Pointer to a pointer that the MetaEngine sets to
+	 *                        the newly created Engine, or 0 in case of an error.
+	 * @param gameDescriptor  Detected game as returned by MetaEngineDetection::identifyGame
+	 * @param meDescriptor    Pointer to a meta engine specific descriptor as returned by
+	 *                        MetaEngineDetection::identifyGame
 	 *
 	 * @return A Common::Error describing the error that occurred, or kNoError.
 	 */
-	virtual Common::Error createInstance(OSystem *syst, Engine **engine) = 0;
+	virtual Common::Error createInstance(OSystem *syst, Engine **engine, const DetectedGame &gameDescriptor, const void *meDescriptor) = 0;
 
 	/**
 	 * Return a list of all save states associated with the given target.

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -604,7 +604,7 @@ public:
 	const PluginList &getPlugins(const PluginType fetchPluginType) const;
 
 	/** Find a target. */
-	QualifiedGameDescriptor findTarget(const Common::String &target, const Plugin **plugin = NULL) const;
+	QualifiedGameDescriptor findTarget(const Common::String &target) const;
 
 	/**
 	 * List games matching the specified criteria.

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -128,7 +128,7 @@ public:
 	virtual ~MetaEngineDetection() {}
 
 	/** Get the engine ID. */
-	virtual const char *getName() const = 0;
+	virtual const char *getName() const override = 0;
 
 	/** Get the engine name. */
 	virtual const char *getEngineName() const = 0;
@@ -235,7 +235,7 @@ public:
 	 * engineID of "scumm". ScummMetaEngine inherits MetaEngine and provides the name
 	 * "Scumm". This way, an Engine can be easily matched with a MetaEngine.
 	 */
-	virtual const char *getName() const = 0;
+	virtual const char *getName() const override = 0;
 
 	/**
 	 * Instantiate an engine instance based on the settings of

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -596,7 +596,7 @@ public:
 	DetectionResults detectGames(const Common::FSList &fslist, uint32 skipADFlags = 0, bool skipIncomplete = false);
 
 	/** Find a plugin by its engine ID. */
-	const Plugin *findPlugin(const Common::String &engineId) const;
+	const Plugin *findDetectionPlugin(const Common::String &engineId) const;
 
 	/**
 	 * Get the list of all plugins for the type specified.

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -600,12 +600,8 @@ public:
 
 	/**
 	 * Get the list of all plugins for the type specified.
-	 *
-	 * By default, it will get METAENGINES, for now.
-	 * If usage of actual engines never occurs, the default arguments can be skipped,
-	 * and always have it return PLUGIN_TYPE_ENGINE_DETECTION.
 	 */
-	const PluginList &getPlugins(const PluginType fetchPluginType = PLUGIN_TYPE_ENGINE_DETECTION) const;
+	const PluginList &getPlugins(const PluginType fetchPluginType) const;
 
 	/** Find a target. */
 	QualifiedGameDescriptor findTarget(const Common::String &target, const Plugin **plugin = NULL) const;

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -256,6 +256,20 @@ public:
 	virtual Common::Error createInstance(OSystem *syst, Engine **engine, const DetectedGame &gameDescriptor, const void *meDescriptor) = 0;
 
 	/**
+	 * Deinstantiate an engine instance.
+	 * The default implementation merely deletes the engine.
+	 *
+	 * The MetaEngine queries the ConfMan singleton for data like the target,
+	 * gameid, path etc.
+	 *
+	 * @param engine          Pointer to the Engine that MetaEngine created.
+	 * @param gameDescriptor  Detected game as returned by MetaEngineDetection::identifyGame
+	 * @param meDescriptor    Pointer to a meta engine specific descriptor as returned by
+	 *                        MetaEngineDetection::identifyGame
+	 */
+	virtual void deleteInstance(Engine *engine, const DetectedGame &gameDescriptor, const void *meDescriptor);
+
+	/**
 	 * Return a list of all save states associated with the given target.
 	 *
 	 * The returned list is guaranteed to be sorted by slot numbers. That

--- a/engines/mm/detection.cpp
+++ b/engines/mm/detection.cpp
@@ -49,10 +49,10 @@ static const DebugChannelDef DEBUG_FLAT_LIST[] = {
 
 #include "mm/detection_tables.h"
 
-class MMMetaEngineDetection : public AdvancedMetaEngineDetection {
+class MMMetaEngineDetection : public AdvancedMetaEngineDetection<MM::MightAndMagicGameDescription> {
 public:
 	MMMetaEngineDetection() : AdvancedMetaEngineDetection(MM::GAME_DESCRIPTIONS,
-		sizeof(MM::MightAndMagicGameDescription), MIGHT_AND_MAGIC_GAMES) {
+		MIGHT_AND_MAGIC_GAMES) {
 		_maxScanDepth = 3;
 	}
 

--- a/engines/mm/detection.h
+++ b/engines/mm/detection.h
@@ -41,6 +41,8 @@ enum GameFeature {
 };
 
 struct MightAndMagicGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	int gameID;

--- a/engines/mm/metaengine.cpp
+++ b/engines/mm/metaengine.cpp
@@ -87,7 +87,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class MMMetaEngine : public AdvancedMetaEngine {
+class MMMetaEngine : public AdvancedMetaEngine<MM::MightAndMagicGameDescription> {
 private:
 	/**
 	 * Gets the game Id given a target string
@@ -104,7 +104,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const MM::MightAndMagicGameDescription *desc) const override;
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	Common::KeymapArray initKeymaps(const char *target) const override;
@@ -119,9 +119,7 @@ bool MMMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSupportsLoadingDuringStartup);
 }
 
-Common::Error MMMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const MM::MightAndMagicGameDescription *gd = (const MM::MightAndMagicGameDescription *)desc;
-
+Common::Error MMMetaEngine::createInstance(OSystem *syst, Engine **engine, const MM::MightAndMagicGameDescription *gd) const {
 	switch (gd->gameID) {
 #ifdef ENABLE_MM1
 	case MM::GType_MightAndMagic1:

--- a/engines/mohawk/detection.cpp
+++ b/engines/mohawk/detection.cpp
@@ -93,9 +93,9 @@ static const char *const directoryGlobs[] = {
 	nullptr
 };
 
-class MohawkMetaEngineDetection : public AdvancedMetaEngineDetection {
+class MohawkMetaEngineDetection : public AdvancedMetaEngineDetection<Mohawk::MohawkGameDescription> {
 public:
-	MohawkMetaEngineDetection() : AdvancedMetaEngineDetection(Mohawk::gameDescriptions, sizeof(Mohawk::MohawkGameDescription), mohawkGames) {
+	MohawkMetaEngineDetection() : AdvancedMetaEngineDetection(Mohawk::gameDescriptions, mohawkGames) {
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/mohawk/detection.h
+++ b/engines/mohawk/detection.h
@@ -68,6 +68,25 @@ struct MohawkGameDescription {
 	uint8 gameType;
 	uint32 features;
 	const char *appName;
+
+	uint32 sizeBuffer() const {
+		uint32 ret = desc.sizeBuffer();
+		if (appName) {
+			ret += strlen(appName) + 1;
+		}
+		return ret;
+	}
+
+	void *toBuffer(void *buffer) {
+		buffer = desc.toBuffer(buffer);
+		if (appName) {
+			int len = strlen(appName) + 1;
+			memcpy((char *)buffer, appName, len);
+			appName = (const char *)buffer;
+			buffer = (char *)buffer + len;
+		}
+		return buffer;
+	}
 };
 
 } // End of namespace Mohawk

--- a/engines/mohawk/detection.h
+++ b/engines/mohawk/detection.h
@@ -71,20 +71,13 @@ struct MohawkGameDescription {
 
 	uint32 sizeBuffer() const {
 		uint32 ret = desc.sizeBuffer();
-		if (appName) {
-			ret += strlen(appName) + 1;
-		}
+		ret += ADDynamicDescription::strSizeBuffer(appName);
 		return ret;
 	}
 
 	void *toBuffer(void *buffer) {
 		buffer = desc.toBuffer(buffer);
-		if (appName) {
-			int len = strlen(appName) + 1;
-			memcpy((char *)buffer, appName, len);
-			appName = (const char *)buffer;
-			buffer = (char *)buffer + len;
-		}
+		buffer = ADDynamicDescription::strToBuffer(buffer, appName);
 		return buffer;
 	}
 };

--- a/engines/mohawk/metaengine.cpp
+++ b/engines/mohawk/metaengine.cpp
@@ -121,14 +121,14 @@ bool MohawkEngine_Riven::hasFeature(EngineFeature f) const {
 
 } // End of Namespace Mohawk
 
-class MohawkMetaEngine : public AdvancedMetaEngine {
+class MohawkMetaEngine : public AdvancedMetaEngine<Mohawk::MohawkGameDescription> {
 public:
 	const char *getName() const override {
 		return "mohawk";
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Mohawk::MohawkGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateList listSavesForPrefix(const char *prefix, const char *extension) const;
@@ -280,9 +280,7 @@ Common::KeymapArray MohawkMetaEngine::initKeymaps(const char *target) const {
 	return AdvancedMetaEngine::initKeymaps(target);
 }
 
-Common::Error MohawkMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Mohawk::MohawkGameDescription *gd = (const Mohawk::MohawkGameDescription *)desc;
-
+Common::Error MohawkMetaEngine::createInstance(OSystem *syst, Engine **engine, const Mohawk::MohawkGameDescription *gd) const {
 	switch (gd->gameType) {
 	case Mohawk::GType_MYST:
 	case Mohawk::GType_MAKINGOF:

--- a/engines/mortevielle/detection.cpp
+++ b/engines/mortevielle/detection.cpp
@@ -38,10 +38,9 @@ static const DebugChannelDef debugFlagList[] = {
 
 #include "mortevielle/detection_tables.h"
 
-class MortevielleMetaEngineDetection : public AdvancedMetaEngineDetection {
+class MortevielleMetaEngineDetection : public AdvancedMetaEngineDetection<Mortevielle::MortevielleGameDescription> {
 public:
-	MortevielleMetaEngineDetection() : AdvancedMetaEngineDetection(Mortevielle::MortevielleGameDescriptions, sizeof(Mortevielle::MortevielleGameDescription),
-		MortevielleGame) {
+	MortevielleMetaEngineDetection() : AdvancedMetaEngineDetection(Mortevielle::MortevielleGameDescriptions, MortevielleGame) {
 		_md5Bytes = 512;
 		// Use kADFlagUseExtraAsHint to distinguish between original and improved versions
 		// (i.e. use or not of the game data file).

--- a/engines/mortevielle/detection.h
+++ b/engines/mortevielle/detection.h
@@ -32,6 +32,8 @@ enum {
 };
 
 struct MortevielleGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 	Common::Language originalLanguage;
 	uint8 dataFeature;

--- a/engines/mortevielle/metaengine.cpp
+++ b/engines/mortevielle/metaengine.cpp
@@ -38,13 +38,13 @@ bool MortevielleEngine::useOriginalData() const { return _gameDescription->dataF
 
 } // End of namespace Mortevielle
 
-class MortevielleMetaEngine : public AdvancedMetaEngine {
+class MortevielleMetaEngine : public AdvancedMetaEngine<Mortevielle::MortevielleGameDescription> {
 public:
 	const char *getName() const override {
 		return "mortevielle";
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Mortevielle::MortevielleGameDescription *desc) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
 	int getMaximumSaveSlot() const override;
@@ -60,8 +60,8 @@ public:
 	}
 };
 
-Common::Error MortevielleMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Mortevielle::MortevielleEngine(syst, (const Mortevielle::MortevielleGameDescription *)desc);
+Common::Error MortevielleMetaEngine::createInstance(OSystem *syst, Engine **engine, const Mortevielle::MortevielleGameDescription *desc) const {
+	*engine = new Mortevielle::MortevielleEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/mtropolis/detection.cpp
+++ b/engines/mtropolis/detection.cpp
@@ -53,9 +53,9 @@ static const char *const directoryGlobs[] = {
 	nullptr
 };
 
-class MTropolisMetaEngineDetection : public AdvancedMetaEngineDetection {
+class MTropolisMetaEngineDetection : public AdvancedMetaEngineDetection<MTropolis::MTropolisGameDescription> {
 public:
-	MTropolisMetaEngineDetection() : AdvancedMetaEngineDetection(MTropolis::gameDescriptions, sizeof(MTropolis::MTropolisGameDescription), mTropolisGames) {
+	MTropolisMetaEngineDetection() : AdvancedMetaEngineDetection(MTropolis::gameDescriptions, mTropolisGames) {
 		_guiOptions = GUIO3(GAMEOPTION_DYNAMIC_MIDI, GAMEOPTION_LAUNCH_DEBUG, GAMEOPTION_ENABLE_SHORT_TRANSITIONS);
 		_maxScanDepth = 3;
 		_directoryGlobs = directoryGlobs;

--- a/engines/mtropolis/detection.h
+++ b/engines/mtropolis/detection.h
@@ -99,6 +99,8 @@ enum MTGameFlag {
 };
 
 struct MTropolisGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	int gameID;

--- a/engines/mtropolis/metaengine.cpp
+++ b/engines/mtropolis/metaengine.cpp
@@ -125,7 +125,7 @@ Common::Platform MTropolisEngine::getPlatform() const {
 
 } // End of namespace MTropolis
 
-class MTropolisMetaEngine : public AdvancedMetaEngine {
+class MTropolisMetaEngine : public AdvancedMetaEngine<MTropolis::MTropolisGameDescription> {
 public:
 	const char *getName() const override {
 		return "mtropolis";
@@ -136,7 +136,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const MTropolis::MTropolisGameDescription *desc) const override;
 
 	Common::Array<Common::Keymap *> initKeymaps(const char *target) const override;
 
@@ -147,7 +147,7 @@ bool MTropolisMetaEngine::hasFeature(MetaEngineFeature f) const {
 	return checkExtendedSaves(f);
 }
 
-Common::Error MTropolisMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error MTropolisMetaEngine::createInstance(OSystem *syst, Engine **engine, const MTropolis::MTropolisGameDescription *desc) const {
 	*engine = new MTropolis::MTropolisEngine(syst, reinterpret_cast<const MTropolis::MTropolisGameDescription *>(desc));
 	return Common::kNoError;
 }

--- a/engines/mutationofjb/detection.cpp
+++ b/engines/mutationofjb/detection.cpp
@@ -96,9 +96,9 @@ static const char *const mutationofjbDirectoryGlobs[] = {
 	nullptr
 };
 
-class MutationOfJBMetaEngineDetection : public AdvancedMetaEngineDetection {
+class MutationOfJBMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	MutationOfJBMetaEngineDetection() : AdvancedMetaEngineDetection(mutationofjbDescriptions, sizeof(ADGameDescription), mutationofjbGames) {
+	MutationOfJBMetaEngineDetection() : AdvancedMetaEngineDetection(mutationofjbDescriptions, mutationofjbGames) {
 		_maxScanDepth = 2;
 		_directoryGlobs = mutationofjbDirectoryGlobs;
 	}

--- a/engines/mutationofjb/metaengine.cpp
+++ b/engines/mutationofjb/metaengine.cpp
@@ -28,7 +28,7 @@
 
 #include "engines/advancedDetector.h"
 
-class MutationOfJBMetaEngine : public AdvancedMetaEngine {
+class MutationOfJBMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "mutationofjb";

--- a/engines/myst3/detection.cpp
+++ b/engines/myst3/detection.cpp
@@ -205,9 +205,9 @@ static const Myst3GameDescription gameDescriptions[] = {
 	{ AD_TABLE_END_MARKER, 0 }
 };
 
-class Myst3MetaEngineDetection : public AdvancedMetaEngineDetection {
+class Myst3MetaEngineDetection : public AdvancedMetaEngineDetection<Myst3GameDescription> {
 public:
-	Myst3MetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, sizeof(Myst3GameDescription), myst3Games) {
+	Myst3MetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, myst3Games) {
 		_guiOptions = GUIO5(GUIO_NOMIDI, GUIO_NOSFX, GUIO_NOSPEECH, GUIO_NOSUBTITLES, GAMEOPTION_WIDESCREEN_MOD);
 		_maxScanDepth = 3;
 		_directoryGlobs = directoryGlobs;

--- a/engines/myst3/detection.h
+++ b/engines/myst3/detection.h
@@ -33,6 +33,8 @@ enum GameLocalizationType {
 };
 
 struct Myst3GameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 	uint32 localizationType;
 };

--- a/engines/myst3/metaengine.cpp
+++ b/engines/myst3/metaengine.cpp
@@ -49,7 +49,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class Myst3MetaEngine : public AdvancedMetaEngine {
+class Myst3MetaEngine : public AdvancedMetaEngine<Myst3GameDescription> {
 public:
 	const char *getName() const override {
 		return "myst3";
@@ -150,13 +150,13 @@ public:
 		return 999;
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Myst3GameDescription *desc) const override;
 
 	// TODO: Add getSavegameFile()
 };
 
-Common::Error Myst3MetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Myst3Engine(syst, (const Myst3GameDescription *)desc);
+Common::Error Myst3MetaEngine::createInstance(OSystem *syst, Engine **engine, const Myst3GameDescription *desc) const {
+	*engine = new Myst3Engine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/nancy/detection.cpp
+++ b/engines/nancy/detection.cpp
@@ -756,9 +756,9 @@ static const Nancy::NancyGameDescription gameDescriptions[] = {
 	{ AD_TABLE_END_MARKER, Nancy::kGameTypeNone }
 };
 
-class NancyMetaEngineDetection : public AdvancedMetaEngineDetection {
+class NancyMetaEngineDetection : public AdvancedMetaEngineDetection<Nancy::NancyGameDescription> {
 public:
-	NancyMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, sizeof(Nancy::NancyGameDescription), nancyGames) {
+	NancyMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, nancyGames) {
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 		_guiOptions = GUIO2(GUIO_NOMIDI, GUIO_NOASPECT);

--- a/engines/nancy/detection.h
+++ b/engines/nancy/detection.h
@@ -47,6 +47,8 @@ enum NancyGameFlags {
 };
 
 struct NancyGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 	GameType gameType;
 };

--- a/engines/nancy/metaengine.cpp
+++ b/engines/nancy/metaengine.cpp
@@ -101,14 +101,14 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class NancyMetaEngine : public AdvancedMetaEngine {
+class NancyMetaEngine : public AdvancedMetaEngine<Nancy::NancyGameDescription> {
 public:
 	const char *getName() const override {
 		return "nancy";
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Nancy::NancyGameDescription *gd) const override;
 
 	int getMaximumSaveSlot() const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
@@ -134,9 +134,9 @@ bool NancyMetaEngine::hasFeature(MetaEngineFeature f) const {
 		checkExtendedSaves(f);
 }
 
-Common::Error NancyMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
+Common::Error NancyMetaEngine::createInstance(OSystem *syst, Engine **engine, const Nancy::NancyGameDescription *gd) const {
 	if (gd) {
-		*engine = Nancy::NancyEngine::create(((const Nancy::NancyGameDescription *)gd)->gameType, syst, (const Nancy::NancyGameDescription *)gd);
+		*engine = Nancy::NancyEngine::create(gd->gameType, syst, gd);
 	}
 
 	if (gd) {

--- a/engines/neverhood/detection.cpp
+++ b/engines/neverhood/detection.cpp
@@ -130,9 +130,9 @@ static const ADGameDescription gameDescriptions[] = {
 } // End of namespace Neverhood
 
 
-class NeverhoodMetaEngineDetection : public AdvancedMetaEngineDetection {
+class NeverhoodMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	NeverhoodMetaEngineDetection() : AdvancedMetaEngineDetection(Neverhood::gameDescriptions, sizeof(ADGameDescription), neverhoodGames) {
+	NeverhoodMetaEngineDetection() : AdvancedMetaEngineDetection(Neverhood::gameDescriptions, neverhoodGames) {
 		_guiOptions = GUIO5(GUIO_NOMIDI, GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_SKIP_HALL_OF_RECORDS,
 				    GAMEOPTION_SCALE_MAKING_OF_VIDEOS, GAMEOPTION_REPEAT_WILLIE_HINT);
 	}

--- a/engines/neverhood/metaengine.cpp
+++ b/engines/neverhood/metaengine.cpp
@@ -56,7 +56,7 @@ bool NeverhoodEngine::applyResourceFixes() const {
 
 } // End of namespace Neverhood
 
-class NeverhoodMetaEngine : public AdvancedMetaEngine {
+class NeverhoodMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "neverhood";

--- a/engines/ngi/detection.cpp
+++ b/engines/ngi/detection.cpp
@@ -185,9 +185,9 @@ static const NGIGameDescription gameDescriptions[] = {
 
 } // End of namespace NGI
 
-class NGIMetaEngineDetection : public AdvancedMetaEngineDetection {
+class NGIMetaEngineDetection : public AdvancedMetaEngineDetection<NGI::NGIGameDescription> {
 public:
-	NGIMetaEngineDetection() : AdvancedMetaEngineDetection(NGI::gameDescriptions, sizeof(NGI::NGIGameDescription), ngiGames) {
+	NGIMetaEngineDetection() : AdvancedMetaEngineDetection(NGI::gameDescriptions, ngiGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/ngi/detection.h
+++ b/engines/ngi/detection.h
@@ -32,6 +32,8 @@ enum NGIGameId {
 };
 
 struct NGIGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	int gameId;

--- a/engines/ngi/metaengine.cpp
+++ b/engines/ngi/metaengine.cpp
@@ -54,7 +54,7 @@ int NGIEngine::getGameGID() const {
 
 } // End of namspace Fullpipe
 
-class NGIMetaEngine : public AdvancedMetaEngine {
+class NGIMetaEngine : public AdvancedMetaEngine<NGI::NGIGameDescription> {
 public:
 	const char *getName() const override {
 		return "ngi";
@@ -64,7 +64,7 @@ public:
 
 	int getMaximumSaveSlot() const override { return 99; }
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const NGI::NGIGameDescription *desc) const override;
 };
 
 bool NGIMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -79,8 +79,8 @@ bool NGI::NGIEngine::hasFeature(EngineFeature f) const {
 }
 
 
-Common::Error NGIMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new NGI::NGIEngine(syst, (const NGI::NGIGameDescription *)desc);
+Common::Error NGIMetaEngine::createInstance(OSystem *syst, Engine **engine, const NGI::NGIGameDescription *desc) const {
+	*engine = new NGI::NGIEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/parallaction/detection.cpp
+++ b/engines/parallaction/detection.cpp
@@ -226,9 +226,9 @@ static const PARALLACTIONGameDescription gameDescriptions[] = {
 
 }
 
-class ParallactionMetaEngineDetection : public AdvancedMetaEngineDetection {
+class ParallactionMetaEngineDetection : public AdvancedMetaEngineDetection<Parallaction::PARALLACTIONGameDescription> {
 public:
-	ParallactionMetaEngineDetection() : AdvancedMetaEngineDetection(Parallaction::gameDescriptions, sizeof(Parallaction::PARALLACTIONGameDescription), parallactionGames) {
+	ParallactionMetaEngineDetection() : AdvancedMetaEngineDetection(Parallaction::gameDescriptions, parallactionGames) {
 		_guiOptions = GUIO1(GUIO_NOLAUNCHLOAD);
 	}
 

--- a/engines/parallaction/detection.h
+++ b/engines/parallaction/detection.h
@@ -41,6 +41,8 @@ enum ParallactionGameType {
 };
 
 struct PARALLACTIONGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	int gameType;

--- a/engines/parallaction/metaengine.cpp
+++ b/engines/parallaction/metaengine.cpp
@@ -43,14 +43,14 @@ Common::Platform Parallaction::getPlatform() const { return _gameDescription->de
 
 } // End of namespace Parallaction
 
-class ParallactionMetaEngine : public AdvancedMetaEngine {
+class ParallactionMetaEngine : public AdvancedMetaEngine<Parallaction::PARALLACTIONGameDescription> {
 public:
 	const char *getName() const override {
 		return "parallaction";
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Parallaction::PARALLACTIONGameDescription *desc) const override;
 	Common::KeymapArray initKeymaps(const char *target) const override;
 
 	SaveStateList listSaves(const char *target) const override;
@@ -79,9 +79,7 @@ bool Parallaction::Parallaction::hasFeature(EngineFeature f) const {
 		(f == kSupportsReturnToLauncher);
 }
 
-Common::Error ParallactionMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Parallaction::PARALLACTIONGameDescription *gd = (const Parallaction::PARALLACTIONGameDescription *)desc;
-
+Common::Error ParallactionMetaEngine::createInstance(OSystem *syst, Engine **engine, const Parallaction::PARALLACTIONGameDescription *gd) const {
 	switch (gd->gameType) {
 	case Parallaction::GType_Nippon:
 		*engine = new Parallaction::Parallaction_ns(syst, gd);

--- a/engines/pegasus/detection.cpp
+++ b/engines/pegasus/detection.cpp
@@ -144,9 +144,9 @@ static const PegasusGameDescription gameDescriptions[] = {
 } // End of namespace Pegasus
 
 
-class PegasusMetaEngineDetection : public AdvancedMetaEngineDetection {
+class PegasusMetaEngineDetection : public AdvancedMetaEngineDetection<Pegasus::PegasusGameDescription> {
 public:
-	PegasusMetaEngineDetection() : AdvancedMetaEngineDetection(Pegasus::gameDescriptions, sizeof(Pegasus::PegasusGameDescription), pegasusGames) {
+	PegasusMetaEngineDetection() : AdvancedMetaEngineDetection(Pegasus::gameDescriptions, pegasusGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/pegasus/detection.h
+++ b/engines/pegasus/detection.h
@@ -31,6 +31,8 @@ enum {
 };
 
 struct PegasusGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 };
 

--- a/engines/pegasus/metaengine.cpp
+++ b/engines/pegasus/metaengine.cpp
@@ -64,14 +64,14 @@ bool PegasusEngine::isLinux() const {
 
 } // End of namespace Pegasus
 
-class PegasusMetaEngine : public AdvancedMetaEngine {
+class PegasusMetaEngine : public AdvancedMetaEngine<Pegasus::PegasusGameDescription> {
 public:
 	const char *getName() const override {
 		return "pegasus";
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Pegasus::PegasusGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override { return 999; }
@@ -127,8 +127,8 @@ Common::KeymapArray PegasusMetaEngine::initKeymaps(const char *target) const {
 	return Pegasus::PegasusEngine::initKeymaps();
 }
 
-Common::Error PegasusMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Pegasus::PegasusEngine(syst, (const Pegasus::PegasusGameDescription *)desc);
+Common::Error PegasusMetaEngine::createInstance(OSystem *syst, Engine **engine, const Pegasus::PegasusGameDescription *desc) const {
+	*engine = new Pegasus::PegasusEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/petka/detection.cpp
+++ b/engines/petka/detection.cpp
@@ -41,9 +41,9 @@ static const DebugChannelDef debugFlagList[] = {
 
 #include "petka/detection_tables.h"
 
-class PetkaMetaEngineDetection : public AdvancedMetaEngineDetection {
+class PetkaMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	PetkaMetaEngineDetection() : AdvancedMetaEngineDetection(Petka::gameDescriptions, sizeof(ADGameDescription), petkaGames) {
+	PetkaMetaEngineDetection() : AdvancedMetaEngineDetection(Petka::gameDescriptions, petkaGames) {
 		_gameIds = petkaGames;
 		_maxScanDepth = 2;
 	}

--- a/engines/petka/metaengine.cpp
+++ b/engines/petka/metaengine.cpp
@@ -26,7 +26,7 @@
 
 #include "petka/petka.h"
 
-class PetkaMetaEngine : public AdvancedMetaEngine {
+class PetkaMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "petka";

--- a/engines/pink/detection.cpp
+++ b/engines/pink/detection.cpp
@@ -48,9 +48,9 @@ static const DebugChannelDef debugFlagList[] = {
 };
 
 
-class PinkMetaEngineDetection : public AdvancedMetaEngineDetection {
+class PinkMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	PinkMetaEngineDetection() : AdvancedMetaEngineDetection(Pink::gameDescriptions, sizeof(ADGameDescription), pinkGames) {
+	PinkMetaEngineDetection() : AdvancedMetaEngineDetection(Pink::gameDescriptions, pinkGames) {
 		_gameIds = pinkGames;
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;

--- a/engines/pink/metaengine.cpp
+++ b/engines/pink/metaengine.cpp
@@ -33,7 +33,7 @@ Common::Language PinkEngine::getLanguage() const {
 
 } // End of Namespace Pink
 
-class PinkMetaEngine : public AdvancedMetaEngine {
+class PinkMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "pink";

--- a/engines/playground3d/detection.cpp
+++ b/engines/playground3d/detection.cpp
@@ -42,9 +42,9 @@ static const ADGameDescription playground3dDescriptions[] = {
 	AD_TABLE_END_MARKER
 };
 
-class Playground3dMetaEngineDetection : public AdvancedMetaEngineDetection {
+class Playground3dMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	Playground3dMetaEngineDetection() : AdvancedMetaEngineDetection(playground3dDescriptions, sizeof(ADGameDescription), playground3d_setting) {
+	Playground3dMetaEngineDetection() : AdvancedMetaEngineDetection(playground3dDescriptions, playground3d_setting) {
 		_md5Bytes = 512;
 	}
 

--- a/engines/playground3d/metaengine.cpp
+++ b/engines/playground3d/metaengine.cpp
@@ -27,7 +27,7 @@
 
 #include "playground3d/playground3d.h"
 
-class Playground3dMetaEngine : public AdvancedMetaEngine {
+class Playground3dMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "playground3d";

--- a/engines/plumbers/detection.cpp
+++ b/engines/plumbers/detection.cpp
@@ -66,9 +66,9 @@ static const ADGameDescription gameDescriptions[] = {
 
 } // End of namespace Plumbers
 
-class PlumbersMetaEngineDetection : public AdvancedMetaEngineDetection {
+class PlumbersMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	PlumbersMetaEngineDetection() : AdvancedMetaEngineDetection(Plumbers::gameDescriptions, sizeof(ADGameDescription), plumbersGames) {
+	PlumbersMetaEngineDetection() : AdvancedMetaEngineDetection(Plumbers::gameDescriptions, plumbersGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/plumbers/metaengine.cpp
+++ b/engines/plumbers/metaengine.cpp
@@ -33,7 +33,7 @@ const char *PlumbersGame::getGameId() const { return _gameDescription->gameId; }
 Common::Platform PlumbersGame::getPlatform() const { return _gameDescription->platform; }
 } // End of namespace Plumbers
 
-class PlumbersMetaEngine : public AdvancedMetaEngine {
+class PlumbersMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 	const char *getName() const override {
 		return "plumbers";
 	}

--- a/engines/prince/detection.cpp
+++ b/engines/prince/detection.cpp
@@ -161,9 +161,9 @@ const static char *const directoryGlobs[] = {
 	nullptr
 };
 
-class PrinceMetaEngineDetection : public AdvancedMetaEngineDetection {
+class PrinceMetaEngineDetection : public AdvancedMetaEngineDetection<Prince::PrinceGameDescription> {
 public:
-	PrinceMetaEngineDetection() : AdvancedMetaEngineDetection(Prince::gameDescriptions, sizeof(Prince::PrinceGameDescription), princeGames) {
+	PrinceMetaEngineDetection() : AdvancedMetaEngineDetection(Prince::gameDescriptions, princeGames) {
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/prince/detection.h
+++ b/engines/prince/detection.h
@@ -40,6 +40,8 @@ enum {
 };
 
 struct PrinceGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 	PrinceGameType gameType;
 };

--- a/engines/prince/metaengine.cpp
+++ b/engines/prince/metaengine.cpp
@@ -43,13 +43,13 @@ Common::Language PrinceEngine::getLanguage() const {
 
 } // End of namespace Prince
 
-class PrinceMetaEngine : public AdvancedMetaEngine {
+class PrinceMetaEngine : public AdvancedMetaEngine<Prince::PrinceGameDescription> {
 public:
 	const char *getName() const override {
 		return "prince";
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Prince::PrinceGameDescription *desc) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 
 	int getMaximumSaveSlot() const override { return 99; }
@@ -158,8 +158,8 @@ void PrinceMetaEngine::removeSaveState(const char *target, int slot) const {
 	g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
-Common::Error PrinceMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Prince::PrinceEngine(syst, (const Prince::PrinceGameDescription *)desc);
+Common::Error PrinceMetaEngine::createInstance(OSystem *syst, Engine **engine, const Prince::PrinceGameDescription *desc) const {
+	*engine = new Prince::PrinceEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/private/detection.cpp
+++ b/engines/private/detection.cpp
@@ -245,9 +245,9 @@ static const char *const directoryGlobs[] = {
 	nullptr
 };
 
-class PrivateMetaEngineDetection : public AdvancedMetaEngineDetection {
+class PrivateMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	PrivateMetaEngineDetection() : AdvancedMetaEngineDetection(Private::gameDescriptions, sizeof(ADGameDescription), Private::privateGames) {
+	PrivateMetaEngineDetection() : AdvancedMetaEngineDetection(Private::gameDescriptions, Private::privateGames) {
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/private/metaengine.cpp
+++ b/engines/private/metaengine.cpp
@@ -24,7 +24,7 @@
 
 #include "private/private.h"
 
-class PrivateMetaEngine : public AdvancedMetaEngine {
+class PrivateMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "private";

--- a/engines/queen/detection.cpp
+++ b/engines/queen/detection.cpp
@@ -474,9 +474,9 @@ static const QueenGameDescription gameDescriptions[] = {
 
 } // End of namespace Queen
 
-class QueenMetaEngineDetection : public AdvancedMetaEngineDetection {
+class QueenMetaEngineDetection : public AdvancedMetaEngineDetection<Queen::QueenGameDescription> {
 public:
-	QueenMetaEngineDetection() : AdvancedMetaEngineDetection(Queen::gameDescriptions, sizeof(Queen::QueenGameDescription), queenGames) {
+	QueenMetaEngineDetection() : AdvancedMetaEngineDetection(Queen::gameDescriptions, queenGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/queen/detection.h
+++ b/engines/queen/detection.h
@@ -25,6 +25,8 @@
 namespace Queen {
 
 struct QueenGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 };
 

--- a/engines/queen/metaengine.cpp
+++ b/engines/queen/metaengine.cpp
@@ -56,7 +56,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class QueenMetaEngine : public AdvancedMetaEngine {
+class QueenMetaEngine : public AdvancedMetaEngine<Queen::QueenGameDescription> {
 public:
 	const char *getName() const override {
 		return "queen";
@@ -67,7 +67,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Queen::QueenGameDescription *desc) const override;
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override { return 99; }
 	void removeSaveState(const char *target, int slot) const override;
@@ -117,8 +117,8 @@ void QueenMetaEngine::removeSaveState(const char *target, int slot) const {
 	g_system->getSavefileManager()->removeSavefile(filename);
 }
 
-Common::Error QueenMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Queen::QueenEngine(syst); //FIXME , (const Queen::QueenGameDescription *)desc);
+Common::Error QueenMetaEngine::createInstance(OSystem *syst, Engine **engine, const Queen::QueenGameDescription *desc) const {
+	*engine = new Queen::QueenEngine(syst); //FIXME ,desc);
 	return Common::kNoError;
 }
 

--- a/engines/saga/detection.cpp
+++ b/engines/saga/detection.cpp
@@ -34,9 +34,9 @@ static const PlainGameDescriptor sagaGames[] = {
 
 #include "saga/detection_tables.h"
 
-class SagaMetaEngineDetection : public AdvancedMetaEngineDetection {
+class SagaMetaEngineDetection : public AdvancedMetaEngineDetection<Saga::SAGAGameDescription> {
 public:
-	SagaMetaEngineDetection() : AdvancedMetaEngineDetection(Saga::gameDescriptions, sizeof(Saga::SAGAGameDescription), sagaGames) {
+	SagaMetaEngineDetection() : AdvancedMetaEngineDetection(Saga::gameDescriptions, sagaGames) {
 		static const char *const DIRECTORY_GLOBS[3] = { "music", "ITE Data Files", nullptr };
 		_maxScanDepth = 2;
 		_directoryGlobs = DIRECTORY_GLOBS;

--- a/engines/saga/detection.h
+++ b/engines/saga/detection.h
@@ -118,6 +118,22 @@ struct SAGAGameDescription {
 	GameIntroList introList;
 	// Only used if GF_INSTALLER is set
 	ADGameFileDescription filesInArchive[5];
+
+	uint32 sizeBuffer() const {
+		uint32 ret = desc.sizeBuffer();
+		for(int i = 0; i < ARRAYSIZE(filesInArchive); i++) {
+			ret += filesInArchive[i].sizeBuffer();
+		}
+		return ret;
+	}
+
+	void *toBuffer(void *buffer) {
+		buffer = desc.toBuffer(buffer);
+		for(int i = 0; i < ARRAYSIZE(filesInArchive); i++) {
+			buffer = filesInArchive[i].toBuffer(buffer);
+		}
+		return buffer;
+	}
 };
 
 #define GAMEOPTION_COPY_PROTECTION	GUIO_GAMEOPTIONS1

--- a/engines/saga/metaengine.cpp
+++ b/engines/saga/metaengine.cpp
@@ -85,7 +85,7 @@ const ADGameFileDescription *SagaEngine::getArchivesDescriptions() const {
 
 } // End of namespace Saga
 
-class SagaMetaEngine : public AdvancedMetaEngine {
+class SagaMetaEngine : public AdvancedMetaEngine<Saga::SAGAGameDescription> {
 public:
 	const char *getName() const override {
 		return "saga";
@@ -97,7 +97,7 @@ public:
 
 	bool hasFeature(MetaEngineFeature f) const override;
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Saga::SAGAGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -123,9 +123,7 @@ bool Saga::SagaEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-Common::Error SagaMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Saga::SAGAGameDescription *gd = (const Saga::SAGAGameDescription *)desc;
-
+Common::Error SagaMetaEngine::createInstance(OSystem *syst, Engine **engine, const Saga::SAGAGameDescription *gd) const {
 	switch (gd->gameId) {
 	case Saga::GID_IHNM:
 #ifndef ENABLE_IHNM

--- a/engines/saga2/detection.cpp
+++ b/engines/saga2/detection.cpp
@@ -127,9 +127,9 @@ static const char *const directoryGlobs[] = {
 	nullptr
 };
 
-class Saga2MetaEngineDetection : public AdvancedMetaEngineDetection {
+class Saga2MetaEngineDetection : public AdvancedMetaEngineDetection<Saga2::SAGA2GameDescription> {
 public:
-	Saga2MetaEngineDetection() : AdvancedMetaEngineDetection(Saga2::gameDescriptions, sizeof(Saga2::SAGA2GameDescription), Saga2::saga2Games) {
+	Saga2MetaEngineDetection() : AdvancedMetaEngineDetection(Saga2::gameDescriptions, Saga2::saga2Games) {
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/saga2/detection.h
+++ b/engines/saga2/detection.h
@@ -40,6 +40,8 @@ enum GameFileTypes {
 };
 
 struct SAGA2GameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	int gameId;

--- a/engines/saga2/metaengine.cpp
+++ b/engines/saga2/metaengine.cpp
@@ -22,13 +22,13 @@
 #include "saga2/saga2.h"
 #include "engines/advancedDetector.h"
 
-class Saga2MetaEngine : public AdvancedMetaEngine {
+class Saga2MetaEngine : public AdvancedMetaEngine<Saga2::SAGA2GameDescription> {
 public:
 	const char *getName() const override {
 		return "saga2";
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Saga2::SAGA2GameDescription *desc) const override;
 	bool hasFeature(MetaEngineFeature f) const override;
 };
 
@@ -38,8 +38,7 @@ bool Saga2MetaEngine::hasFeature(MetaEngineFeature f) const {
 		checkExtendedSaves(f);
 }
 
-Common::Error Saga2MetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Saga2::SAGA2GameDescription *gd = (const Saga2::SAGA2GameDescription *)desc;
+Common::Error Saga2MetaEngine::createInstance(OSystem *syst, Engine **engine, const Saga2::SAGA2GameDescription *gd) const {
 	*engine = new Saga2::Saga2Engine(syst, gd);
 	return Common::kNoError;
 }

--- a/engines/saga2/metaengine.cpp
+++ b/engines/saga2/metaengine.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "saga2/saga2.h"
+#include "saga2/detection.h"
 #include "engines/advancedDetector.h"
 
 class Saga2MetaEngine : public AdvancedMetaEngine<Saga2::SAGA2GameDescription> {

--- a/engines/sci/detection.cpp
+++ b/engines/sci/detection.cpp
@@ -266,7 +266,7 @@ ADDetectedGame SciMetaEngineDetection::fallbackDetect(const FileMap &allFiles, c
 		return ADDetectedGame();
 	}
 
-	ADDetectedGame game = enginePlugin->get<AdvancedMetaEngine>().fallbackDetectExtern(_md5Bytes, allFiles, fslist);
+	ADDetectedGame game = enginePlugin->get<AdvancedMetaEngineBase>().fallbackDetectExtern(_md5Bytes, allFiles, fslist);
 	if (!game.desc) {
 		return game;
 	}

--- a/engines/sci/detection.cpp
+++ b/engines/sci/detection.cpp
@@ -251,7 +251,7 @@ ADDetectedGame SciMetaEngineDetection::fallbackDetect(const FileMap &allFiles, c
 		}
 	}
 
-	const Plugin *metaEnginePlugin = EngineMan.findPlugin(getName());
+	const Plugin *metaEnginePlugin = EngineMan.findDetectionPlugin(getName());
 	if (!metaEnginePlugin) {
 		return ADDetectedGame();
 	}

--- a/engines/sci/detection.cpp
+++ b/engines/sci/detection.cpp
@@ -251,12 +251,12 @@ ADDetectedGame SciMetaEngineDetection::fallbackDetect(const FileMap &allFiles, c
 		}
 	}
 
-	const Plugin *metaEnginePlugin = EngineMan.findDetectionPlugin(getName());
-	if (!metaEnginePlugin) {
+	const Plugin *detectionPlugin = EngineMan.findDetectionPlugin(getName());
+	if (!detectionPlugin) {
 		return ADDetectedGame();
 	}
 
-	const Plugin *enginePlugin = PluginMan.getEngineFromMetaEngine(metaEnginePlugin);
+	const Plugin *enginePlugin = PluginMan.getEngineFromDetectionPlugin(detectionPlugin);
 	if (!enginePlugin) {
 		static bool warn = true;
 		if (warn) {

--- a/engines/sci/detection.cpp
+++ b/engines/sci/detection.cpp
@@ -179,9 +179,9 @@ static const char *const directoryGlobs[] = {
 	nullptr
 };
 
-class SciMetaEngineDetection : public AdvancedMetaEngineDetection {
+class SciMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	SciMetaEngineDetection() : AdvancedMetaEngineDetection(Sci::SciGameDescriptions, sizeof(ADGameDescription), s_sciGameTitles) {
+	SciMetaEngineDetection() : AdvancedMetaEngineDetection(Sci::SciGameDescriptions, s_sciGameTitles) {
 		_maxScanDepth = 3;
 		_directoryGlobs = directoryGlobs;
 		// Use SCI fallback detection results instead of the partial matches found by

--- a/engines/sci/detection.cpp
+++ b/engines/sci/detection.cpp
@@ -251,12 +251,7 @@ ADDetectedGame SciMetaEngineDetection::fallbackDetect(const FileMap &allFiles, c
 		}
 	}
 
-	const Plugin *detectionPlugin = EngineMan.findDetectionPlugin(getName());
-	if (!detectionPlugin) {
-		return ADDetectedGame();
-	}
-
-	const Plugin *enginePlugin = PluginMan.getEngineFromDetectionPlugin(detectionPlugin);
+	const Plugin *enginePlugin = PluginMan.findEnginePlugin(getName());
 	if (!enginePlugin) {
 		static bool warn = true;
 		if (warn) {

--- a/engines/sci/metaengine.cpp
+++ b/engines/sci/metaengine.cpp
@@ -179,7 +179,7 @@ static Common::String convertSierraGameId(Common::String sierraId, SciVersion sc
 
 namespace Sci {
 
-class SciMetaEngine : public AdvancedMetaEngine {
+class SciMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "sci";
@@ -441,7 +441,7 @@ static ADGameDescription s_fallbackDesc = {
 	GUIO3(GAMEOPTION_PREFER_DIGITAL_SFX, GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_MIDI_MODE)
 };
 
-Common::Platform getSciFallbackDetectionPlatform(const AdvancedMetaEngine::FileMap &allFiles) {
+Common::Platform getSciFallbackDetectionPlatform(const AdvancedMetaEngineBase::FileMap &allFiles) {
 	// Data1 contains both map and volume for SCI1.1+ Mac games
 	if (allFiles.contains("Data1"))
 		return Common::kPlatformMacintosh;
@@ -461,7 +461,7 @@ Common::Platform getSciFallbackDetectionPlatform(const AdvancedMetaEngine::FileM
 	return Common::kPlatformDOS;
 }
 
-bool necessarySciResourceFilesFound(const AdvancedMetaEngine::FileMap &allFiles) {
+bool necessarySciResourceFilesFound(const AdvancedMetaEngineBase::FileMap &allFiles) {
 	bool foundResMap = false;
 	bool foundRes000 = false;
 
@@ -487,7 +487,7 @@ bool necessarySciResourceFilesFound(const AdvancedMetaEngine::FileMap &allFiles)
 	return foundResMap && foundRes000;
 }
 
-bool isSciCDVersion(const AdvancedMetaEngine::FileMap &allFiles) {
+bool isSciCDVersion(const AdvancedMetaEngineBase::FileMap &allFiles) {
 	// Determine if we got a CD version and set the CD flag accordingly, by checking for
 	// resource.aud for SCI1.1 CD games, or audio001.002 for SCI1 CD games. We assume that
 	// the file should be over 10MB, as it contains all the game speech and is usually

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -83,6 +83,7 @@ public:
 
 	PlainGameList getSupportedGames() const override;
 	PlainGameDescriptor findGame(const char *gameid) const override;
+	Common::Error identifyGame(DetectedGame &game, const void **descriptor) override;
 	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/, bool /*skipIncomplete*/) override;
 
 	uint getMD5Bytes() const override {
@@ -104,6 +105,12 @@ PlainGameList ScummMetaEngineDetection::getSupportedGames() const {
 
 PlainGameDescriptor ScummMetaEngineDetection::findGame(const char *gameid) const {
 	return Engines::findGameID(gameid, gameDescriptions, obsoleteGameIDsTable);
+}
+
+Common::Error ScummMetaEngineDetection::identifyGame(DetectedGame &game, const void **descriptor) {
+	*descriptor = nullptr;
+	game = DetectedGame(getName(), findGame(ConfMan.get("gameid").c_str()));
+	return game.gameId.empty() ? Common::kUnknownError : Common::kNoError;
 }
 
 static Common::String generatePreferredTarget(const DetectorResult &x) {

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -259,7 +259,8 @@ bool Scumm::ScummEngine::enhancementEnabled(int32 cls) {
  *
  * This is heavily based on our MD5 detection scheme.
  */
-Common::Error ScummMetaEngine::createInstance(OSystem *syst, Engine **engine) {
+Common::Error ScummMetaEngine::createInstance(OSystem *syst, Engine **engine,
+	const DetectedGame &gameDescriptor, const void *metaEngineDescriptor) {
 	assert(syst);
 	assert(engine);
 	const char *gameid = ConfMan.get("gameid").c_str();

--- a/engines/scumm/metaengine.h
+++ b/engines/scumm/metaengine.h
@@ -29,7 +29,8 @@ class ScummMetaEngine : public MetaEngine {
 
 	bool hasFeature(MetaEngineFeature f) const override;
 
-	Common::Error createInstance(OSystem *syst, Engine **engine) override;
+	Common::Error createInstance(OSystem *syst, Engine **engine,
+	                             const DetectedGame &gameDescriptor, const void *metaEngineDescriptor) override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;

--- a/engines/sherlock/detection.cpp
+++ b/engines/sherlock/detection.cpp
@@ -40,10 +40,9 @@ static const DebugChannelDef debugFlagList[] = {
 
 #include "sherlock/detection_tables.h"
 
-class SherlockMetaEngineDetection : public AdvancedMetaEngineDetection {
+class SherlockMetaEngineDetection : public AdvancedMetaEngineDetection<Sherlock::SherlockGameDescription> {
 public:
-	SherlockMetaEngineDetection() : AdvancedMetaEngineDetection(Sherlock::gameDescriptions, sizeof(Sherlock::SherlockGameDescription),
-		sherlockGames) {}
+	SherlockMetaEngineDetection() : AdvancedMetaEngineDetection(Sherlock::gameDescriptions, sherlockGames) {}
 
 	const char *getName() const override {
 		return "sherlock";

--- a/engines/sherlock/detection.h
+++ b/engines/sherlock/detection.h
@@ -32,6 +32,8 @@ enum GameType {
 };
 
 struct SherlockGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	GameType gameID;

--- a/engines/sherlock/metaengine.cpp
+++ b/engines/sherlock/metaengine.cpp
@@ -136,7 +136,7 @@ Common::Language SherlockEngine::getLanguage() const {
 } // End of namespace Sherlock
 
 
-class SherlockMetaEngine : public AdvancedMetaEngine {
+class SherlockMetaEngine : public AdvancedMetaEngine<Sherlock::SherlockGameDescription> {
 public:
 	const char *getName() const override {
 		return "sherlock";
@@ -149,7 +149,7 @@ public:
 	/**
 	 * Creates an instance of the game engine
 	 */
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Sherlock::SherlockGameDescription *desc) const override;
 
 	/**
 	 * Returns a list of features the game's MetaEngine support
@@ -177,8 +177,7 @@ public:
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
-Common::Error SherlockMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Sherlock::SherlockGameDescription *gd = (const Sherlock::SherlockGameDescription *)desc;
+Common::Error SherlockMetaEngine::createInstance(OSystem *syst, Engine **engine, const Sherlock::SherlockGameDescription *gd) const {
 	switch (gd->gameID) {
 	case Sherlock::GType_SerratedScalpel:
 		*engine = new Sherlock::Scalpel::ScalpelEngine(syst, gd);

--- a/engines/sky/detection.cpp
+++ b/engines/sky/detection.cpp
@@ -67,6 +67,7 @@ public:
 
 	PlainGameList getSupportedGames() const override;
 	PlainGameDescriptor findGame(const char *gameid) const override;
+	Common::Error identifyGame(DetectedGame &game, const void **descriptor) override;
 	DetectedGames detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/, bool /*skipIncomplete*/) override;
 
 	uint getMD5Bytes() const override {
@@ -101,6 +102,12 @@ PlainGameDescriptor SkyMetaEngineDetection::findGame(const char *gameid) const {
 	if (0 == scumm_stricmp(gameid, skySetting.gameId))
 		return skySetting;
 	return PlainGameDescriptor::empty();
+}
+
+Common::Error SkyMetaEngineDetection::identifyGame(DetectedGame &game, const void **descriptor) {
+	*descriptor = nullptr;
+	game = DetectedGame(getName(), findGame(ConfMan.get("gameid").c_str()));
+	return game.gameId.empty() ? Common::kUnknownError : Common::kNoError;
 }
 
 DetectedGames SkyMetaEngineDetection::detectGames(const Common::FSList &fslist, uint32 /*skipADFlags*/, bool /*skipIncomplete*/) {

--- a/engines/sky/metaengine.cpp
+++ b/engines/sky/metaengine.cpp
@@ -44,7 +44,8 @@ class SkyMetaEngine : public MetaEngine {
 
 	bool hasFeature(MetaEngineFeature f) const override;
 
-	Common::Error createInstance(OSystem *syst, Engine **engine) override;
+	Common::Error createInstance(OSystem *syst, Engine **engine,
+	                             const DetectedGame &gameDescriptor, const void *metaEngineDescriptor);
 
 	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;
 
@@ -144,7 +145,8 @@ Common::KeymapArray SkyMetaEngine::initKeymaps(const char *target) const {
 	return keymaps;
 }
 
-Common::Error SkyMetaEngine::createInstance(OSystem *syst, Engine **engine) {
+Common::Error SkyMetaEngine::createInstance(OSystem *syst, Engine **engine,
+	const DetectedGame &gameDescriptor, const void *metaEngineDescriptor) {
 	assert(engine);
 	*engine = new Sky::SkyEngine(syst);
 	return Common::kNoError;

--- a/engines/sludge/detection.cpp
+++ b/engines/sludge/detection.cpp
@@ -75,9 +75,9 @@ static Sludge::SludgeGameDescription s_fallbackDesc =
 
 static char s_fallbackFileNameBuffer[51];
 
-class SludgeMetaEngineDetection : public AdvancedMetaEngineDetection {
+class SludgeMetaEngineDetection : public AdvancedMetaEngineDetection<Sludge::SludgeGameDescription> {
 public:
-	SludgeMetaEngineDetection() : AdvancedMetaEngineDetection(Sludge::gameDescriptions, sizeof(Sludge::SludgeGameDescription), sludgeGames) {
+	SludgeMetaEngineDetection() : AdvancedMetaEngineDetection(Sludge::gameDescriptions, sludgeGames) {
 		_maxScanDepth = 1;
 	}
 

--- a/engines/sludge/detection.h
+++ b/engines/sludge/detection.h
@@ -25,6 +25,8 @@
 namespace Sludge {
 
 struct SludgeGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 	uint languageID;
 };

--- a/engines/sludge/metaengine.cpp
+++ b/engines/sludge/metaengine.cpp
@@ -36,14 +36,14 @@ const char *SludgeEngine::getGameFile() const {
 
 } // End of namespace Sludge
 
-class SludgeMetaEngine : public AdvancedMetaEngine {
+class SludgeMetaEngine : public AdvancedMetaEngine<Sludge::SludgeGameDescription> {
 public:
 	const char *getName() const override {
 		return "sludge";
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
-		*engine = new Sludge::SludgeEngine(syst, (const Sludge::SludgeGameDescription *)desc);
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Sludge::SludgeGameDescription *desc) const override {
+		*engine = new Sludge::SludgeEngine(syst, desc);
 		return Common::kNoError;
 	}
 };

--- a/engines/stark/detection.cpp
+++ b/engines/stark/detection.cpp
@@ -401,9 +401,9 @@ static const ADGameDescription gameDescriptions[] = {
 	AD_TABLE_END_MARKER
 };
 
-class StarkMetaEngineDetection : public AdvancedMetaEngineDetection {
+class StarkMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	StarkMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, sizeof(ADGameDescription), starkGames) {
+	StarkMetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, starkGames) {
 		_guiOptions = GUIO4(GUIO_NOMIDI, GAMEOPTION_ASSETS_MOD, GAMEOPTION_LINEAR_FILTERING, GAMEOPTION_FONT_ANTIALIASING);
 	}
 

--- a/engines/stark/metaengine.cpp
+++ b/engines/stark/metaengine.cpp
@@ -68,7 +68,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class StarkMetaEngine : public AdvancedMetaEngine {
+class StarkMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "stark";

--- a/engines/startrek/detection.cpp
+++ b/engines/startrek/detection.cpp
@@ -352,9 +352,9 @@ static const StarTrekGameDescription gameDescriptions[] = {
 
 } // End of namespace StarTrek
 
-class StarTrekMetaEngineDetection : public AdvancedMetaEngineDetection {
+class StarTrekMetaEngineDetection : public AdvancedMetaEngineDetection<StarTrek::StarTrekGameDescription> {
 public:
-	StarTrekMetaEngineDetection() : AdvancedMetaEngineDetection(StarTrek::gameDescriptions, sizeof(StarTrek::StarTrekGameDescription), starTrekGames) {
+	StarTrekMetaEngineDetection() : AdvancedMetaEngineDetection(StarTrek::gameDescriptions, starTrekGames) {
 	}
 
 	const DebugChannelDef *getDebugChannels() const override {

--- a/engines/startrek/detection.h
+++ b/engines/startrek/detection.h
@@ -37,6 +37,8 @@ enum StarTrekGameFeatures {
 };
 
 struct StarTrekGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	uint8 gameType;

--- a/engines/startrek/metaengine.cpp
+++ b/engines/startrek/metaengine.cpp
@@ -53,14 +53,14 @@ Common::Language StarTrekEngine::getLanguage() const {
 
 } // End of Namespace StarTrek
 
-class StarTrekMetaEngine : public AdvancedMetaEngine {
+class StarTrekMetaEngine : public AdvancedMetaEngine<StarTrek::StarTrekGameDescription> {
 public:
 	const char *getName() const override {
 		return "startrek";
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const StarTrek::StarTrekGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -80,8 +80,8 @@ bool StarTrekMetaEngine::hasFeature(MetaEngineFeature f) const {
 	    (f == kSimpleSavesNames);
 }
 
-Common::Error StarTrekMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new StarTrek::StarTrekEngine(syst, (const StarTrek::StarTrekGameDescription *)desc);
+Common::Error StarTrekMetaEngine::createInstance(OSystem *syst, Engine **engine, const StarTrek::StarTrekGameDescription *desc) const {
+	*engine = new StarTrek::StarTrekEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/supernova/detection.cpp
+++ b/engines/supernova/detection.cpp
@@ -89,9 +89,9 @@ static const ADGameDescription gameDescriptions[] = {
 };
 }
 
-class SupernovaMetaEngineDetection: public AdvancedMetaEngineDetection {
+class SupernovaMetaEngineDetection: public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	SupernovaMetaEngineDetection() : AdvancedMetaEngineDetection(Supernova::gameDescriptions, sizeof(ADGameDescription), supernovaGames) {
+	SupernovaMetaEngineDetection() : AdvancedMetaEngineDetection(Supernova::gameDescriptions, supernovaGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/supernova/metaengine.cpp
+++ b/engines/supernova/metaengine.cpp
@@ -58,7 +58,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class SupernovaMetaEngine : public AdvancedMetaEngine {
+class SupernovaMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "supernova";

--- a/engines/sword1/detection.cpp
+++ b/engines/sword1/detection.cpp
@@ -42,9 +42,9 @@ static const char *const directoryGlobs[] = {
 	nullptr
 };
 
-class SwordMetaEngineDetection : public AdvancedMetaEngineDetection {
+class SwordMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	SwordMetaEngineDetection() : AdvancedMetaEngineDetection(Sword1::gameDescriptions, sizeof(ADGameDescription), swordGames) {
+	SwordMetaEngineDetection() : AdvancedMetaEngineDetection(Sword1::gameDescriptions, swordGames) {
 		_guiOptions = GUIO2(GUIO_NOMIDI, GUIO_NOASPECT);
 		_flags = kADFlagMatchFullPaths;
 		_directoryGlobs = directoryGlobs;

--- a/engines/sword1/detection.cpp
+++ b/engines/sword1/detection.cpp
@@ -54,6 +54,11 @@ public:
 		return Engines::findGameID(gameId, _gameIds, obsoleteGameIDsTable);
 	}
 
+	Common::Error identifyGame(DetectedGame &game, const void **descriptor) override {
+		Engines::upgradeTargetIfNecessary(obsoleteGameIDsTable);
+		return AdvancedMetaEngineDetection::identifyGame(game, descriptor);
+	}
+
 	const char *getName() const override {
 		return "sword1";
 	}

--- a/engines/sword1/metaengine.cpp
+++ b/engines/sword1/metaengine.cpp
@@ -54,7 +54,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 
 } // End of namespace Sword1
 
-class SwordMetaEngine : public AdvancedMetaEngine {
+class SwordMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "sword1";

--- a/engines/sword1/metaengine.cpp
+++ b/engines/sword1/metaengine.cpp
@@ -20,12 +20,10 @@
  */
 
 #include "engines/advancedDetector.h"
-#include "engines/obsolete.h"
 
 #include "sword1/sword1.h"
 #include "sword1/control.h"
 #include "sword1/logic.h"
-#include "sword1/obsolete.h"
 
 #include "common/savefile.h"
 #include "common/system.h"
@@ -72,10 +70,6 @@ public:
 		return Sword1::optionsList;
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine) override {
-		Engines::upgradeTargetIfNecessary(obsoleteGameIDsTable);
-		return AdvancedMetaEngine::createInstance(syst, engine);
-	}
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {

--- a/engines/sword2/detection.cpp
+++ b/engines/sword2/detection.cpp
@@ -43,9 +43,9 @@ static const char *const directoryGlobs[] = {
 	nullptr
 };
 
-class Sword2MetaEngineDetection : public AdvancedMetaEngineDetection {
+class Sword2MetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	Sword2MetaEngineDetection() : AdvancedMetaEngineDetection(Sword2::gameDescriptions, sizeof(ADGameDescription), sword2Games) {
+	Sword2MetaEngineDetection() : AdvancedMetaEngineDetection(Sword2::gameDescriptions, sword2Games) {
 		_guiOptions = GUIO3(GUIO_NOMIDI, GUIO_NOASPECT, GAMEOPTION_OBJECT_LABELS);
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;

--- a/engines/sword2/detection.cpp
+++ b/engines/sword2/detection.cpp
@@ -55,6 +55,11 @@ public:
 		return Engines::findGameID(gameId, _gameIds, obsoleteGameIDsTable);
 	}
 
+	Common::Error identifyGame(DetectedGame &game, const void **descriptor) override {
+		Engines::upgradeTargetIfNecessary(obsoleteGameIDsTable);
+		return AdvancedMetaEngineDetection::identifyGame(game, descriptor);
+	}
+
 	const char *getName() const override {
 		return "sword2";
 	}

--- a/engines/sword2/metaengine.cpp
+++ b/engines/sword2/metaengine.cpp
@@ -22,7 +22,6 @@
  */
 
 #include "engines/advancedDetector.h"
-#include "engines/obsolete.h"
 
 #include "common/config-manager.h"
 #include "common/events.h"
@@ -34,7 +33,6 @@
 
 #include "sword2/sword2.h"
 #include "sword2/saveload.h"
-#include "sword2/obsolete.h"
 
 namespace Sword2 {
 
@@ -71,10 +69,6 @@ public:
 	int getMaximumSaveSlot() const override;
 	void removeSaveState(const char *target, int slot) const override;
 
-	Common::Error createInstance(OSystem *syst, Engine **engine) override {
-		Engines::upgradeTargetIfNecessary(obsoleteGameIDsTable);
-		return AdvancedMetaEngine::createInstance(syst, engine);
-	}
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 };
 

--- a/engines/sword2/metaengine.cpp
+++ b/engines/sword2/metaengine.cpp
@@ -53,7 +53,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 
 } // End of namespace Sword2
 
-class Sword2MetaEngine : public AdvancedMetaEngine {
+class Sword2MetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "sword2";

--- a/engines/sword25/detection.cpp
+++ b/engines/sword25/detection.cpp
@@ -42,9 +42,9 @@ static const char *const directoryGlobs[] = {
 	0
 };
 
-class Sword25MetaEngineDetection : public AdvancedMetaEngineDetection {
+class Sword25MetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	Sword25MetaEngineDetection() : AdvancedMetaEngineDetection(Sword25::gameDescriptions, sizeof(ADGameDescription), sword25Game) {
+	Sword25MetaEngineDetection() : AdvancedMetaEngineDetection(Sword25::gameDescriptions, sword25Game) {
 		_guiOptions = GUIO2(GUIO_NOMIDI, GAMEOPTION_ENGLISH_SPEECH);
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;

--- a/engines/sword25/metaengine.cpp
+++ b/engines/sword25/metaengine.cpp
@@ -47,7 +47,7 @@ uint32 Sword25Engine::getGameFlags() const { return _gameDescription->flags; }
 
 } // End of namespace Sword25
 
-class Sword25MetaEngine : public AdvancedMetaEngine {
+class Sword25MetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "sword25";

--- a/engines/teenagent/detection.cpp
+++ b/engines/teenagent/detection.cpp
@@ -202,9 +202,9 @@ static const ADGameDescription teenAgentGameDescriptions[] = {
 
 
 
-class TeenAgentMetaEngineDetection : public AdvancedMetaEngineDetection {
+class TeenAgentMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	TeenAgentMetaEngineDetection() : AdvancedMetaEngineDetection(teenAgentGameDescriptions, sizeof(ADGameDescription), teenAgentGames) {
+	TeenAgentMetaEngineDetection() : AdvancedMetaEngineDetection(teenAgentGameDescriptions, teenAgentGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/teenagent/metaengine.cpp
+++ b/engines/teenagent/metaengine.cpp
@@ -34,7 +34,7 @@ enum {
 	MAX_SAVES = 20
 };
 
-class TeenAgentMetaEngine : public AdvancedMetaEngine {
+class TeenAgentMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "teenagent";

--- a/engines/testbed/detection.cpp
+++ b/engines/testbed/detection.cpp
@@ -48,9 +48,9 @@ static const ADGameDescription testbedDescriptions[] = {
 	AD_TABLE_END_MARKER
 };
 
-class TestbedMetaEngineDetection : public AdvancedMetaEngineDetection {
+class TestbedMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	TestbedMetaEngineDetection() : AdvancedMetaEngineDetection(testbedDescriptions, sizeof(ADGameDescription), testbed_setting) {
+	TestbedMetaEngineDetection() : AdvancedMetaEngineDetection(testbedDescriptions, testbed_setting) {
 		_md5Bytes = 512;
 	}
 

--- a/engines/testbed/metaengine.cpp
+++ b/engines/testbed/metaengine.cpp
@@ -27,7 +27,7 @@
 
 #include "testbed/testbed.h"
 
-class TestbedMetaEngine : public AdvancedMetaEngine {
+class TestbedMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "testbed";

--- a/engines/tetraedge/detection.cpp
+++ b/engines/tetraedge/detection.cpp
@@ -33,7 +33,7 @@ const DebugChannelDef TetraedgeMetaEngineDetection::debugFlagList[] = {
 };
 
 TetraedgeMetaEngineDetection::TetraedgeMetaEngineDetection() : AdvancedMetaEngineDetection(Tetraedge::GAME_DESCRIPTIONS,
-	sizeof(ADGameDescription), Tetraedge::GAME_NAMES) {
+	Tetraedge::GAME_NAMES) {
 	_flags = kADFlagMatchFullPaths;
 }
 

--- a/engines/tetraedge/detection.h
+++ b/engines/tetraedge/detection.h
@@ -40,7 +40,7 @@ extern const ADGameDescription GAME_DESCRIPTIONS[];
 
 } // namespace Tetraedge
 
-class TetraedgeMetaEngineDetection : public AdvancedMetaEngineDetection {
+class TetraedgeMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 	static const DebugChannelDef debugFlagList[];
 
 public:

--- a/engines/tetraedge/metaengine.h
+++ b/engines/tetraedge/metaengine.h
@@ -28,7 +28,7 @@
 #define GAMEOPTION_CORRECT_MOVIE_ASPECT GUIO_GAMEOPTIONS1
 #define GAMEOPTION_RESTORE_SCENES GUIO_GAMEOPTIONS2
 
-class TetraedgeMetaEngine : public AdvancedMetaEngine {
+class TetraedgeMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override;
 

--- a/engines/tinsel/detection.cpp
+++ b/engines/tinsel/detection.cpp
@@ -45,9 +45,9 @@ static const DebugChannelDef debugFlagList[] = {
 
 #include "tinsel/detection_tables.h"
 
-class TinselMetaEngineDetection : public AdvancedMetaEngineDetection {
+class TinselMetaEngineDetection : public AdvancedMetaEngineDetection<Tinsel::TinselGameDescription> {
 public:
-	TinselMetaEngineDetection() : AdvancedMetaEngineDetection(Tinsel::gameDescriptions, sizeof(Tinsel::TinselGameDescription), tinselGames) {
+	TinselMetaEngineDetection() : AdvancedMetaEngineDetection(Tinsel::gameDescriptions, tinselGames) {
 	}
 
 	const char *getName() const  override{

--- a/engines/tinsel/detection.h
+++ b/engines/tinsel/detection.h
@@ -67,6 +67,8 @@ enum TinselEngineVersion {
 };
 
 struct TinselGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	int gameID;

--- a/engines/tinsel/metaengine.cpp
+++ b/engines/tinsel/metaengine.cpp
@@ -79,13 +79,13 @@ bool TinselEngine::isV1CD() const {
 
 } // End of namespace Tinsel
 
-class TinselMetaEngine : public AdvancedMetaEngine {
+class TinselMetaEngine : public AdvancedMetaEngine<Tinsel::TinselGameDescription> {
 public:
 	const char *getName() const  override{
 		return "tinsel";
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Tinsel::TinselGameDescription *desc) const override;
 
 	bool hasFeature(MetaEngineFeature f) const override;
 	SaveStateList listSaves(const char *target) const override;
@@ -190,8 +190,8 @@ SaveStateList TinselMetaEngine::listSaves(const char *target) const {
 	return saveList;
 }
 
-Common::Error TinselMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Tinsel::TinselEngine(syst, (const Tinsel::TinselGameDescription *)desc);
+Common::Error TinselMetaEngine::createInstance(OSystem *syst, Engine **engine, const Tinsel::TinselGameDescription *desc) const {
+	*engine = new Tinsel::TinselEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/titanic/detection.cpp
+++ b/engines/titanic/detection.cpp
@@ -42,9 +42,9 @@ static const PlainGameDescriptor TitanicGames[] = {
 
 #include "titanic/detection_tables.h"
 
-class TitanicMetaEngineDetection : public AdvancedMetaEngineDetection {
+class TitanicMetaEngineDetection : public AdvancedMetaEngineDetection<Titanic::TitanicGameDescription> {
 public:
-	TitanicMetaEngineDetection() : AdvancedMetaEngineDetection(Titanic::gameDescriptions, sizeof(Titanic::TitanicGameDescription), TitanicGames) {
+	TitanicMetaEngineDetection() : AdvancedMetaEngineDetection(Titanic::gameDescriptions, TitanicGames) {
 		_maxScanDepth = 3;
 	}
 

--- a/engines/titanic/detection.h
+++ b/engines/titanic/detection.h
@@ -25,6 +25,8 @@
 namespace Titanic {
 
 struct TitanicGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 };
 

--- a/engines/titanic/metaengine.cpp
+++ b/engines/titanic/metaengine.cpp
@@ -44,14 +44,14 @@ Common::Language TitanicEngine::getLanguage() const {
 
 } // End of namespace Titanic
 
-class TitanicMetaEngine : public AdvancedMetaEngine {
+class TitanicMetaEngine : public AdvancedMetaEngine<Titanic::TitanicGameDescription> {
 public:
 	const char *getName() const override {
 		return "titanic";
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Titanic::TitanicGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -78,8 +78,8 @@ bool Titanic::TitanicEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-Common::Error TitanicMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Titanic::TitanicEngine(syst, (const Titanic::TitanicGameDescription *)desc);
+Common::Error TitanicMetaEngine::createInstance(OSystem *syst, Engine **engine, const Titanic::TitanicGameDescription *desc) const {
+	*engine = new Titanic::TitanicEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/toltecs/detection.cpp
+++ b/engines/toltecs/detection.cpp
@@ -221,9 +221,9 @@ static const ToltecsGameDescription gameDescriptions[] = {
 
 } // End of namespace Toltecs
 
-class ToltecsMetaEngineDetection : public AdvancedMetaEngineDetection {
+class ToltecsMetaEngineDetection : public AdvancedMetaEngineDetection<Toltecs::ToltecsGameDescription> {
 public:
-	ToltecsMetaEngineDetection() : AdvancedMetaEngineDetection(Toltecs::gameDescriptions, sizeof(Toltecs::ToltecsGameDescription), toltecsGames) {
+	ToltecsMetaEngineDetection() : AdvancedMetaEngineDetection(Toltecs::gameDescriptions, toltecsGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/toltecs/detection.h
+++ b/engines/toltecs/detection.h
@@ -25,6 +25,8 @@
 namespace Toltecs {
 
 struct ToltecsGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 };
 

--- a/engines/toltecs/metaengine.cpp
+++ b/engines/toltecs/metaengine.cpp
@@ -58,7 +58,7 @@ Common::Language ToltecsEngine::getLanguage() const {
 
 } // End of namespace Toltecs
 
-class ToltecsMetaEngine : public AdvancedMetaEngine {
+class ToltecsMetaEngine : public AdvancedMetaEngine<Toltecs::ToltecsGameDescription> {
 public:
 	const char *getName() const override {
 		return "toltecs";
@@ -69,7 +69,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Toltecs::ToltecsGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -96,8 +96,8 @@ bool Toltecs::ToltecsEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-Common::Error ToltecsMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Toltecs::ToltecsEngine(syst, (const Toltecs::ToltecsGameDescription *)desc);
+Common::Error ToltecsMetaEngine::createInstance(OSystem *syst, Engine **engine, const Toltecs::ToltecsGameDescription *desc) const {
+	*engine = new Toltecs::ToltecsEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/tony/detection.cpp
+++ b/engines/tony/detection.cpp
@@ -47,9 +47,9 @@ static const char *const directoryGlobs[] = {
 	0
 };
 
-class TonyMetaEngineDetection : public AdvancedMetaEngineDetection {
+class TonyMetaEngineDetection : public AdvancedMetaEngineDetection<Tony::TonyGameDescription> {
 public:
-	TonyMetaEngineDetection() : AdvancedMetaEngineDetection(Tony::gameDescriptions, sizeof(Tony::TonyGameDescription), tonyGames) {
+	TonyMetaEngineDetection() : AdvancedMetaEngineDetection(Tony::gameDescriptions, tonyGames) {
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/tony/detection.h
+++ b/engines/tony/detection.h
@@ -29,6 +29,8 @@ enum {
 };
 
 struct TonyGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 };
 

--- a/engines/tony/metaengine.cpp
+++ b/engines/tony/metaengine.cpp
@@ -50,14 +50,14 @@ bool TonyEngine::isCompressed() const {
 
 } // End of namespace Tony
 
-class TonyMetaEngine : public AdvancedMetaEngine {
+class TonyMetaEngine : public AdvancedMetaEngine<Tony::TonyGameDescription> {
 public:
 	const char *getName() const override {
 		return "tony";
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Tony::TonyGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -82,8 +82,8 @@ bool Tony::TonyEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-Common::Error TonyMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Tony::TonyEngine(syst, (const Tony::TonyGameDescription *)desc);
+Common::Error TonyMetaEngine::createInstance(OSystem *syst, Engine **engine, const Tony::TonyGameDescription *desc) const {
+	*engine = new Tony::TonyEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/toon/detection.cpp
+++ b/engines/toon/detection.cpp
@@ -165,9 +165,9 @@ static const char * const directoryGlobs[] = {
 	0
 };
 
-class ToonMetaEngineDetection : public AdvancedMetaEngineDetection {
+class ToonMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	ToonMetaEngineDetection() : AdvancedMetaEngineDetection(Toon::gameDescriptions, sizeof(ADGameDescription), toonGames) {
+	ToonMetaEngineDetection() : AdvancedMetaEngineDetection(Toon::gameDescriptions, toonGames) {
 		_maxScanDepth = 3;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/engines/toon/metaengine.cpp
+++ b/engines/toon/metaengine.cpp
@@ -34,7 +34,7 @@
 #include "graphics/thumbnail.h"
 #include "toon/toon.h"
 
-class ToonMetaEngine : public AdvancedMetaEngine {
+class ToonMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "toon";

--- a/engines/touche/detection.cpp
+++ b/engines/touche/detection.cpp
@@ -138,9 +138,9 @@ static const char *const directoryGlobs[] = {
 	0
 };
 
-class ToucheMetaEngineDetection : public AdvancedMetaEngineDetection {
+class ToucheMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	ToucheMetaEngineDetection() : AdvancedMetaEngineDetection(Touche::gameDescriptions, sizeof(ADGameDescription), toucheGames) {
+	ToucheMetaEngineDetection() : AdvancedMetaEngineDetection(Touche::gameDescriptions, toucheGames) {
 		_md5Bytes = 4096;
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;

--- a/engines/touche/metaengine.cpp
+++ b/engines/touche/metaengine.cpp
@@ -28,7 +28,7 @@
 
 #include "touche/touche.h"
 
-class ToucheMetaEngine : public AdvancedMetaEngine {
+class ToucheMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "touche";

--- a/engines/trecision/detection.cpp
+++ b/engines/trecision/detection.cpp
@@ -219,9 +219,9 @@ static const char *const directoryGlobs[] = {
 	0
 };
 
-class TrecisionMetaEngineDetection : public AdvancedMetaEngineDetection {
+class TrecisionMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	TrecisionMetaEngineDetection() : AdvancedMetaEngineDetection(Trecision::gameDescriptions, sizeof(ADGameDescription), trecisionGames) {
+	TrecisionMetaEngineDetection() : AdvancedMetaEngineDetection(Trecision::gameDescriptions, trecisionGames) {
 		_maxScanDepth = 2;
 		_directoryGlobs = directoryGlobs;
 		_guiOptions = GUIO2(GUIO_NOMIDI, GAMEOPTION_ORIGINAL_SAVELOAD);

--- a/engines/trecision/metaengine.cpp
+++ b/engines/trecision/metaengine.cpp
@@ -45,7 +45,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class TrecisionMetaEngine : public AdvancedMetaEngine {
+class TrecisionMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 	const char *getName() const override {
 		return "trecision";
 	}

--- a/engines/tsage/detection.cpp
+++ b/engines/tsage/detection.cpp
@@ -42,9 +42,9 @@ static const DebugChannelDef debugFlagList[] = {
 
 #include "tsage/detection_tables.h"
 
-class TSageMetaEngineDetection : public AdvancedMetaEngineDetection {
+class TSageMetaEngineDetection : public AdvancedMetaEngineDetection<TsAGE::tSageGameDescription> {
 public:
-	TSageMetaEngineDetection() : AdvancedMetaEngineDetection(TsAGE::gameDescriptions, sizeof(TsAGE::tSageGameDescription), tSageGameTitles) {
+	TSageMetaEngineDetection() : AdvancedMetaEngineDetection(TsAGE::gameDescriptions, tSageGameTitles) {
 	}
 
 	const char *getName() const override {

--- a/engines/tsage/detection.h
+++ b/engines/tsage/detection.h
@@ -42,6 +42,8 @@ enum {
 };
 
 struct tSageGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	int gameID;

--- a/engines/tsage/metaengine.cpp
+++ b/engines/tsage/metaengine.cpp
@@ -58,7 +58,7 @@ enum {
 	MAX_SAVES = 100
 };
 
-class TSageMetaEngine : public AdvancedMetaEngine {
+class TSageMetaEngine : public AdvancedMetaEngine<TsAGE::tSageGameDescription> {
 public:
 	const char *getName() const override {
 		return "tsage";
@@ -80,8 +80,8 @@ public:
 		}
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
-		*engine = new TsAGE::TSageEngine(syst, (const TsAGE::tSageGameDescription *)desc);
+	Common::Error createInstance(OSystem *syst, Engine **engine, const TsAGE::tSageGameDescription *desc) const override {
+		*engine = new TsAGE::TSageEngine(syst, desc);
 		return Common::kNoError;
 	}
 

--- a/engines/tucker/detection.cpp
+++ b/engines/tucker/detection.cpp
@@ -115,9 +115,9 @@ static const ADGameDescription tuckerDemoGameDescription = {
 	GUIO1(GUIO_NOMIDI)
 };
 
-class TuckerMetaEngineDetection : public AdvancedMetaEngineDetection {
+class TuckerMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	TuckerMetaEngineDetection() : AdvancedMetaEngineDetection(tuckerGameDescriptions, sizeof(ADGameDescription), tuckerGames) {
+	TuckerMetaEngineDetection() : AdvancedMetaEngineDetection(tuckerGameDescriptions, tuckerGames) {
 		_md5Bytes = 512;
 	}
 

--- a/engines/tucker/metaengine.cpp
+++ b/engines/tucker/metaengine.cpp
@@ -28,7 +28,7 @@
 
 #include "tucker/tucker.h"
 
-class TuckerMetaEngine : public AdvancedMetaEngine {
+class TuckerMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "tucker";

--- a/engines/twine/detection.cpp
+++ b/engines/twine/detection.cpp
@@ -413,9 +413,9 @@ static const ADGameDescription twineGameDescriptions[] = {
 	AD_TABLE_END_MARKER
 };
 
-class TwinEMetaEngineDetection : public AdvancedMetaEngineDetection {
+class TwinEMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	TwinEMetaEngineDetection() : AdvancedMetaEngineDetection(twineGameDescriptions, sizeof(ADGameDescription), twineGames) {
+	TwinEMetaEngineDetection() : AdvancedMetaEngineDetection(twineGameDescriptions, twineGames) {
 		_guiOptions = GUIO12(GAMEOPTION_WALL_COLLISION, GAMEOPTION_DISABLE_SAVE_MENU,  GAMEOPTION_DEBUG, GAMEOPTION_AUDIO_CD, GAMEOPTION_SOUND, GAMEOPTION_VOICES, GAMEOPTION_TEXT, GAMEOPTION_MOVIES, GAMEOPTION_MOUSE, GAMEOPTION_USA_VERSION, GAMEOPTION_HIGH_RESOLUTION, GAMEOPTION_TEXT_TO_SPEECH);
 	}
 

--- a/engines/twine/metaengine.cpp
+++ b/engines/twine/metaengine.cpp
@@ -165,7 +165,7 @@ static const ADExtraGuiOptionsMap twineOptionsList[] = {
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
-class TwinEMetaEngine : public AdvancedMetaEngine {
+class TwinEMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "twine";

--- a/engines/twp/detection.cpp
+++ b/engines/twp/detection.cpp
@@ -42,7 +42,7 @@ const DebugChannelDef TwpMetaEngineDetection::debugFlagList[] = {
 
 TwpMetaEngineDetection::TwpMetaEngineDetection()
 	: AdvancedMetaEngineDetection(Twp::gameDescriptions,
-								  sizeof(Twp::TwpGameDescription), Twp::twpGames) {
+								  Twp::twpGames) {
 }
 
 DetectedGame TwpMetaEngineDetection::toDetectedGame(const ADDetectedGame &adGame, ADDetectedGameExtraInfo *extraInfo) const {

--- a/engines/twp/detection.h
+++ b/engines/twp/detection.h
@@ -56,6 +56,8 @@ enum LanguageSupported {
 
 extern const PlainGameDescriptor twpGames[];
 struct TwpGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 	GameXorKey xorKey;
 	LanguageSupported languageSupported;

--- a/engines/twp/detection.h
+++ b/engines/twp/detection.h
@@ -65,7 +65,7 @@ extern const TwpGameDescription gameDescriptions[];
 
 } // End of namespace Twp
 
-class TwpMetaEngineDetection : public AdvancedMetaEngineDetection {
+class TwpMetaEngineDetection : public AdvancedMetaEngineDetection<Twp::TwpGameDescription> {
 	static const DebugChannelDef debugFlagList[];
 
 public:

--- a/engines/twp/metaengine.cpp
+++ b/engines/twp/metaengine.cpp
@@ -49,8 +49,8 @@ const char *TwpMetaEngine::getName() const {
 	return "twp";
 }
 
-Common::Error TwpMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Twp::TwpEngine(syst, (const Twp::TwpGameDescription *)(desc));
+Common::Error TwpMetaEngine::createInstance(OSystem *syst, Engine **engine, const Twp::TwpGameDescription *desc) const {
+	*engine = new Twp::TwpEngine(syst,(desc));
 	return Common::kNoError;
 }
 

--- a/engines/twp/metaengine.h
+++ b/engines/twp/metaengine.h
@@ -24,11 +24,11 @@
 
 #include "engines/advancedDetector.h"
 
-class TwpMetaEngine : public AdvancedMetaEngine {
+class TwpMetaEngine : public AdvancedMetaEngine<Twp::TwpGameDescription> {
 public:
 	const char *getName() const override;
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Twp::TwpGameDescription *desc) const override;
 
 	/**
 	 * Determine whether the engine supports the specified MetaEngine feature.

--- a/engines/ultima/detection.cpp
+++ b/engines/ultima/detection.cpp
@@ -61,7 +61,7 @@ const DebugChannelDef UltimaMetaEngineDetection::debugFlagList[] = {
 };
 
 UltimaMetaEngineDetection::UltimaMetaEngineDetection() : AdvancedMetaEngineDetection(Ultima::GAME_DESCRIPTIONS,
-	        sizeof(Ultima::UltimaGameDescription), Ultima::ULTIMA_GAMES) {
+	        Ultima::ULTIMA_GAMES) {
 	static const char *const DIRECTORY_GLOBS[2] = { "usecode", 0 };
 	_maxScanDepth = 2;
 	_directoryGlobs = DIRECTORY_GLOBS;

--- a/engines/ultima/detection.h
+++ b/engines/ultima/detection.h
@@ -82,7 +82,7 @@ struct UltimaGameDescription {
 
 } // End of namespace Ultima
 
-class UltimaMetaEngineDetection : public AdvancedMetaEngineDetection {
+class UltimaMetaEngineDetection : public AdvancedMetaEngineDetection<Ultima::UltimaGameDescription> {
 	static const DebugChannelDef debugFlagList[];
 
 public:

--- a/engines/ultima/detection.h
+++ b/engines/ultima/detection.h
@@ -63,6 +63,8 @@ enum UltimaGameFlags {
 };
 
 struct UltimaGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 	GameId gameId;
 	uint32 features;

--- a/engines/ultima/metaengine.cpp
+++ b/engines/ultima/metaengine.cpp
@@ -179,8 +179,7 @@ const ADExtraGuiOptionsMap *UltimaMetaEngine::getAdvancedExtraGuiOptions() const
 	return optionsList;
 }
 
-Common::Error UltimaMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	const Ultima::UltimaGameDescription *gd = (const Ultima::UltimaGameDescription *)desc;
+Common::Error UltimaMetaEngine::createInstance(OSystem *syst, Engine **engine, const Ultima::UltimaGameDescription *gd) const {
 	switch (gd->gameId) {
 #ifdef ENABLE_ULTIMA1
 	case Ultima::GAME_ULTIMA1:

--- a/engines/ultima/metaengine.h
+++ b/engines/ultima/metaengine.h
@@ -27,7 +27,7 @@
 
 #define MAX_SAVES 99
 
-class UltimaMetaEngine : public AdvancedMetaEngine {
+class UltimaMetaEngine : public AdvancedMetaEngine<Ultima::UltimaGameDescription> {
 private:
 	/**
 	 * Gets the game Id given a target string
@@ -37,7 +37,7 @@ public:
 	const char *getName() const override;
 	const ADExtraGuiOptionsMap *getAdvancedExtraGuiOptions() const override;
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Ultima::UltimaGameDescription *desc) const override;
 	int getMaximumSaveSlot() const override;
 
 	/**

--- a/engines/vcruise/detection.cpp
+++ b/engines/vcruise/detection.cpp
@@ -46,9 +46,9 @@ static const char *const g_vcruiseDirectoryGlobs[] = {
 
 #include "vcruise/detection_tables.h"
 
-class VCruiseMetaEngineDetection : public AdvancedMetaEngineDetection {
+class VCruiseMetaEngineDetection : public AdvancedMetaEngineDetection<VCruise::VCruiseGameDescription> {
 public:
-	VCruiseMetaEngineDetection() : AdvancedMetaEngineDetection(VCruise::gameDescriptions, sizeof(VCruise::VCruiseGameDescription), g_vcruiseGames) {
+	VCruiseMetaEngineDetection() : AdvancedMetaEngineDetection(VCruise::gameDescriptions, g_vcruiseGames) {
 		_guiOptions = GUIO4(GAMEOPTION_FAST_ANIMATIONS, GAMEOPTION_INCREASE_DRAG_DISTANCE, GAMEOPTION_LAUNCH_DEBUG, GAMEOPTION_SKIP_MENU);
 		_maxScanDepth = 3;
 		_directoryGlobs = g_vcruiseDirectoryGlobs;

--- a/engines/vcruise/detection.h
+++ b/engines/vcruise/detection.h
@@ -47,6 +47,8 @@ enum VCruiseGameFlag {
 };
 
 struct VCruiseGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 
 	VCruiseGameID gameID;

--- a/engines/vcruise/metaengine.cpp
+++ b/engines/vcruise/metaengine.cpp
@@ -96,7 +96,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 
 } // End of namespace VCruise
 
-class VCruiseMetaEngine : public AdvancedMetaEngine {
+class VCruiseMetaEngine : public AdvancedMetaEngine<VCruise::VCruiseGameDescription> {
 public:
 	const char *getName() const override {
 		return "vcruise";
@@ -107,7 +107,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const VCruise::VCruiseGameDescription *desc) const override;
 
 	Common::Array<Common::Keymap *> initKeymaps(const char *target) const override;
 };
@@ -123,7 +123,7 @@ bool VCruiseMetaEngine::hasFeature(MetaEngineFeature f) const {
 	return checkExtendedSaves(f);
 }
 
-Common::Error VCruiseMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
+Common::Error VCruiseMetaEngine::createInstance(OSystem *syst, Engine **engine, const VCruise::VCruiseGameDescription *desc) const {
 	*engine = new VCruise::VCruiseEngine(syst, reinterpret_cast<const VCruise::VCruiseGameDescription *>(desc));
 	return Common::kNoError;
 }

--- a/engines/voyeur/detection.cpp
+++ b/engines/voyeur/detection.cpp
@@ -39,9 +39,9 @@ static const DebugChannelDef debugFlagList[] = {
 
 #include "voyeur/detection_tables.h"
 
-class VoyeurMetaEngineDetection : public AdvancedMetaEngineDetection {
+class VoyeurMetaEngineDetection : public AdvancedMetaEngineDetection<Voyeur::VoyeurGameDescription> {
 public:
-	VoyeurMetaEngineDetection() : AdvancedMetaEngineDetection(Voyeur::gameDescriptions, sizeof(Voyeur::VoyeurGameDescription), voyeurGames) {
+	VoyeurMetaEngineDetection() : AdvancedMetaEngineDetection(Voyeur::gameDescriptions, voyeurGames) {
 		_maxScanDepth = 3;
 	}
 

--- a/engines/voyeur/detection.h
+++ b/engines/voyeur/detection.h
@@ -25,6 +25,8 @@
 namespace Voyeur {
 
 struct VoyeurGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 };
 

--- a/engines/voyeur/metaengine.cpp
+++ b/engines/voyeur/metaengine.cpp
@@ -69,7 +69,7 @@ bool VoyeurEngine::getIsDemo() const {
 
 } // End of namespace Voyeur
 
-class VoyeurMetaEngine : public AdvancedMetaEngine {
+class VoyeurMetaEngine : public AdvancedMetaEngine<Voyeur::VoyeurGameDescription> {
 public:
 	const char *getName() const override {
 		return "voyeur";
@@ -80,7 +80,7 @@ public:
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const Voyeur::VoyeurGameDescription *desc) const override;
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
 	void removeSaveState(const char *target, int slot) const override;
@@ -104,8 +104,8 @@ bool Voyeur::VoyeurEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-Common::Error VoyeurMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new Voyeur::VoyeurEngine(syst, (const Voyeur::VoyeurGameDescription *)desc);
+Common::Error VoyeurMetaEngine::createInstance(OSystem *syst, Engine **engine, const Voyeur::VoyeurGameDescription *desc) const {
+	*engine = new Voyeur::VoyeurEngine(syst,desc);
 	return Common::kNoError;
 }
 

--- a/engines/wage/detection.cpp
+++ b/engines/wage/detection.cpp
@@ -39,9 +39,9 @@ static const PlainGameDescriptor wageGames[] = {
 
 #include "wage/detection_tables.h"
 
-class WageMetaEngineDetection : public AdvancedMetaEngineDetection {
+class WageMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	WageMetaEngineDetection() : AdvancedMetaEngineDetection(Wage::gameDescriptions, sizeof(ADGameDescription), wageGames) {
+	WageMetaEngineDetection() : AdvancedMetaEngineDetection(Wage::gameDescriptions, wageGames) {
 		_md5Bytes = 2 * 1024 * 1024;
 		_guiOptions = GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI);
 	}

--- a/engines/wage/metaengine.cpp
+++ b/engines/wage/metaengine.cpp
@@ -40,7 +40,7 @@ const char *WageEngine::getGameFile() const {
 
 } // End of namespace Wage
 
-class WageMetaEngine : public AdvancedMetaEngine {
+class WageMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "wage";

--- a/engines/watchmaker/detection.cpp
+++ b/engines/watchmaker/detection.cpp
@@ -66,9 +66,9 @@ static const ADGameDescription gameDescriptions[] = {
 
 } // End of namespace Watchmaker
 
-class WatchmakerMetaEngineDetection : public AdvancedMetaEngineDetection {
+class WatchmakerMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
-	WatchmakerMetaEngineDetection() : AdvancedMetaEngineDetection(Watchmaker::gameDescriptions, sizeof(ADGameDescription), watchmakerGames) {
+	WatchmakerMetaEngineDetection() : AdvancedMetaEngineDetection(Watchmaker::gameDescriptions, watchmakerGames) {
 	}
 
 	const char *getName() const override {

--- a/engines/watchmaker/metaengine.cpp
+++ b/engines/watchmaker/metaengine.cpp
@@ -35,7 +35,7 @@ Common::Platform WatchmakerGame::getPlatform() const {
 }
 } // End of namespace Watchmaker
 
-class WatchmakerMetaEngine : public AdvancedMetaEngine {
+class WatchmakerMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 	const char *getName() const override {
 		return "watchmaker";
 	}

--- a/engines/wintermute/detection.cpp
+++ b/engines/wintermute/detection.cpp
@@ -100,7 +100,7 @@ public:
 		if (metaEnginePlugin) {
 			const Plugin *enginePlugin = PluginMan.getEngineFromMetaEngine(metaEnginePlugin);
 			if (enginePlugin) {
-				return enginePlugin->get<AdvancedMetaEngine>().fallbackDetectExtern(_md5Bytes, allFiles, fslist);
+				return enginePlugin->get<AdvancedMetaEngineBase>().fallbackDetectExtern(_md5Bytes, allFiles, fslist);
 			} else {
 				static bool warn = true;
 				if (warn) {

--- a/engines/wintermute/detection.cpp
+++ b/engines/wintermute/detection.cpp
@@ -95,10 +95,10 @@ public:
 			}
 		}
 
-		const Plugin *metaEnginePlugin = EngineMan.findDetectionPlugin(getName());
+		const Plugin *detectionPlugin = EngineMan.findDetectionPlugin(getName());
 
-		if (metaEnginePlugin) {
-			const Plugin *enginePlugin = PluginMan.getEngineFromMetaEngine(metaEnginePlugin);
+		if (detectionPlugin) {
+			const Plugin *enginePlugin = PluginMan.getEngineFromDetectionPlugin(detectionPlugin);
 			if (enginePlugin) {
 				return enginePlugin->get<AdvancedMetaEngineBase>().fallbackDetectExtern(_md5Bytes, allFiles, fslist);
 			} else {

--- a/engines/wintermute/detection.cpp
+++ b/engines/wintermute/detection.cpp
@@ -51,9 +51,9 @@ static const char *const directoryGlobs[] = {
 	0
 };
 
-class WintermuteMetaEngineDetection : public AdvancedMetaEngineDetection {
+class WintermuteMetaEngineDetection : public AdvancedMetaEngineDetection<WMEGameDescription> {
 public:
-	WintermuteMetaEngineDetection() : AdvancedMetaEngineDetection(Wintermute::gameDescriptions, sizeof(WMEGameDescription), Wintermute::wintermuteGames) {
+	WintermuteMetaEngineDetection() : AdvancedMetaEngineDetection(Wintermute::gameDescriptions, Wintermute::wintermuteGames) {
 		// Use kADFlagUseExtraAsHint to distinguish between SD and HD versions
 		// of J.U.L.I.A. when their datafiles sit in the same directory (e.g. in Steam distribution).
 		_flags = kADFlagUseExtraAsHint;

--- a/engines/wintermute/detection.cpp
+++ b/engines/wintermute/detection.cpp
@@ -95,7 +95,7 @@ public:
 			}
 		}
 
-		const Plugin *metaEnginePlugin = EngineMan.findPlugin(getName());
+		const Plugin *metaEnginePlugin = EngineMan.findDetectionPlugin(getName());
 
 		if (metaEnginePlugin) {
 			const Plugin *enginePlugin = PluginMan.getEngineFromMetaEngine(metaEnginePlugin);

--- a/engines/wintermute/detection.cpp
+++ b/engines/wintermute/detection.cpp
@@ -95,21 +95,16 @@ public:
 			}
 		}
 
-		const Plugin *detectionPlugin = EngineMan.findDetectionPlugin(getName());
-
-		if (detectionPlugin) {
-			const Plugin *enginePlugin = PluginMan.getEngineFromDetectionPlugin(detectionPlugin);
-			if (enginePlugin) {
-				return enginePlugin->get<AdvancedMetaEngineBase>().fallbackDetectExtern(_md5Bytes, allFiles, fslist);
-			} else {
-				static bool warn = true;
-				if (warn) {
-					warning("Engine plugin for Wintermute not present. Fallback detection is disabled.");
-					warn = false;
-				}
+		const Plugin *enginePlugin = PluginMan.findEnginePlugin(getName());
+		if (!enginePlugin) {
+			static bool warn = true;
+			if (warn) {
+				warning("Engine plugin for Wintermute not present. Fallback detection is disabled.");
+				warn = false;
 			}
+			return ADDetectedGame();
 		}
-		return ADDetectedGame();
+		return enginePlugin->get<AdvancedMetaEngineBase>().fallbackDetectExtern(_md5Bytes, allFiles, fslist);
 	}
 
 };

--- a/engines/wintermute/detection.h
+++ b/engines/wintermute/detection.h
@@ -129,6 +129,8 @@ enum WintermuteGameFeatures {
 };
 
 struct WMEGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(adDesc);
+
 	ADGameDescription adDesc;
 	WMETargetExecutable targetExecutable;
 };

--- a/engines/wintermute/metaengine.cpp
+++ b/engines/wintermute/metaengine.cpp
@@ -94,7 +94,7 @@ static ADGameDescription s_fallbackDesc = {
 
 static char s_fallbackExtraBuf[256];
 
-class WintermuteMetaEngine : public AdvancedMetaEngine {
+class WintermuteMetaEngine : public AdvancedMetaEngine<WMEGameDescription> {
 public:
 	const char *getName() const override {
 		return "wintermute";
@@ -104,9 +104,7 @@ public:
 		return gameGuiOptions;
 	}
 
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {
-		const WMEGameDescription *gd = (const WMEGameDescription *)desc;
-
+	Common::Error createInstance(OSystem *syst, Engine **engine, const WMEGameDescription *gd) const override {
 #ifndef ENABLE_FOXTAIL
 		if (gd->targetExecutable >= FOXTAIL_OLDEST_VERSION && gd->targetExecutable <= FOXTAIL_LATEST_VERSION) {
 			return Common::Error(Common::kUnsupportedGameidError, _s("FoxTail support is not compiled in"));

--- a/engines/zvision/detection.cpp
+++ b/engines/zvision/detection.cpp
@@ -30,9 +30,9 @@
 #include "zvision/detection.h"
 #include "zvision/detection_tables.h"
 
-class ZVisionMetaEngineDetection : public AdvancedMetaEngineDetection {
+class ZVisionMetaEngineDetection : public AdvancedMetaEngineDetection<ZVision::ZVisionGameDescription> {
 public:
-	ZVisionMetaEngineDetection() : AdvancedMetaEngineDetection(ZVision::gameDescriptions, sizeof(ZVision::ZVisionGameDescription), ZVision::zVisionGames) {
+	ZVisionMetaEngineDetection() : AdvancedMetaEngineDetection(ZVision::gameDescriptions, ZVision::zVisionGames) {
 		_maxScanDepth = 2;
 		_directoryGlobs = ZVision::directoryGlobs;
 	}

--- a/engines/zvision/detection.h
+++ b/engines/zvision/detection.h
@@ -37,6 +37,8 @@ enum ZVisionFeatures {
 };
 
 struct ZVisionGameDescription {
+	AD_GAME_DESCRIPTION_HELPERS(desc);
+
 	ADGameDescription desc;
 	ZVisionGameId gameId;
 };

--- a/engines/zvision/metaengine.cpp
+++ b/engines/zvision/metaengine.cpp
@@ -115,7 +115,7 @@ uint32 ZVision::getFeatures() const {
 
 } // End of namespace ZVision
 
-class ZVisionMetaEngine : public AdvancedMetaEngine {
+class ZVisionMetaEngine : public AdvancedMetaEngine<ZVision::ZVisionGameDescription> {
 public:
 	const char *getName() const override {
 		return "zvision";
@@ -127,7 +127,7 @@ public:
 
 	bool hasFeature(MetaEngineFeature f) const override;
 	Common::KeymapArray initKeymaps(const char *target) const override;
-	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
+	Common::Error createInstance(OSystem *syst, Engine **engine, const ZVision::ZVisionGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
@@ -300,8 +300,8 @@ Common::KeymapArray ZVisionMetaEngine::initKeymaps(const char *target) const {
 	return keymaps;
 }
 
-Common::Error ZVisionMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {
-	*engine = new ZVision::ZVision(syst, (const ZVision::ZVisionGameDescription *)desc);
+Common::Error ZVisionMetaEngine::createInstance(OSystem *syst, Engine **engine, const ZVision::ZVisionGameDescription *desc) const {
+	*engine = new ZVision::ZVision(syst,desc);
 	return Common::kNoError;
 }
 

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -763,7 +763,7 @@ SDL_Surface *EventRecorder::getSurface(int width, int height) {
 
 bool EventRecorder::switchMode() {
 	const Plugin *detectionPlugin = EngineMan.findDetectionPlugin(ConfMan.get("engineid"));
-	const Plugin *plugin = PluginMan.getEngineFromMetaEngine(detectionPlugin);
+	const Plugin *plugin = PluginMan.getEngineFromDetectionPlugin(detectionPlugin);
 	bool metaInfoSupport = plugin->get<MetaEngine>().hasFeature(MetaEngine::kSavesSupportMetaInfo);
 	bool featuresSupport = metaInfoSupport &&
 						  g_engine->canSaveGameStateCurrently() &&
@@ -812,7 +812,7 @@ bool EventRecorder::checkForContinueGame() {
 void EventRecorder::deleteTemporarySave() {
 	if (_temporarySlot == -1) return;
 	const Plugin *detectionPlugin = EngineMan.findDetectionPlugin(ConfMan.get("engineid"));
-	const Plugin *plugin = PluginMan.getEngineFromMetaEngine(detectionPlugin);
+	const Plugin *plugin = PluginMan.getEngineFromDetectionPlugin(detectionPlugin);
 	const Common::String target = ConfMan.getActiveDomainName();
 	 plugin->get<MetaEngine>().removeSaveState(target.c_str(), _temporarySlot);
 	_temporarySlot = -1;

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -762,8 +762,7 @@ SDL_Surface *EventRecorder::getSurface(int width, int height) {
 }
 
 bool EventRecorder::switchMode() {
-	const Plugin *detectionPlugin = EngineMan.findDetectionPlugin(ConfMan.get("engineid"));
-	const Plugin *plugin = PluginMan.getEngineFromDetectionPlugin(detectionPlugin);
+	const Plugin *plugin = PluginMan.findEnginePlugin(ConfMan.get("engineid"));
 	bool metaInfoSupport = plugin->get<MetaEngine>().hasFeature(MetaEngine::kSavesSupportMetaInfo);
 	bool featuresSupport = metaInfoSupport &&
 						  g_engine->canSaveGameStateCurrently() &&
@@ -811,8 +810,7 @@ bool EventRecorder::checkForContinueGame() {
 
 void EventRecorder::deleteTemporarySave() {
 	if (_temporarySlot == -1) return;
-	const Plugin *detectionPlugin = EngineMan.findDetectionPlugin(ConfMan.get("engineid"));
-	const Plugin *plugin = PluginMan.getEngineFromDetectionPlugin(detectionPlugin);
+	const Plugin *plugin = PluginMan.findEnginePlugin(ConfMan.get("engineid"));
 	const Common::String target = ConfMan.getActiveDomainName();
 	 plugin->get<MetaEngine>().removeSaveState(target.c_str(), _temporarySlot);
 	_temporarySlot = -1;

--- a/gui/EventRecorder.cpp
+++ b/gui/EventRecorder.cpp
@@ -762,7 +762,7 @@ SDL_Surface *EventRecorder::getSurface(int width, int height) {
 }
 
 bool EventRecorder::switchMode() {
-	const Plugin *detectionPlugin = EngineMan.findPlugin(ConfMan.get("engineid"));
+	const Plugin *detectionPlugin = EngineMan.findDetectionPlugin(ConfMan.get("engineid"));
 	const Plugin *plugin = PluginMan.getEngineFromMetaEngine(detectionPlugin);
 	bool metaInfoSupport = plugin->get<MetaEngine>().hasFeature(MetaEngine::kSavesSupportMetaInfo);
 	bool featuresSupport = metaInfoSupport &&
@@ -811,7 +811,7 @@ bool EventRecorder::checkForContinueGame() {
 
 void EventRecorder::deleteTemporarySave() {
 	if (_temporarySlot == -1) return;
-	const Plugin *detectionPlugin = EngineMan.findPlugin(ConfMan.get("engineid"));
+	const Plugin *detectionPlugin = EngineMan.findDetectionPlugin(ConfMan.get("engineid"));
 	const Plugin *plugin = PluginMan.getEngineFromMetaEngine(detectionPlugin);
 	const Common::String target = ConfMan.getActiveDomainName();
 	 plugin->get<MetaEngine>().removeSaveState(target.c_str(), _temporarySlot);

--- a/gui/about.cpp
+++ b/gui/about.cpp
@@ -84,7 +84,7 @@ static const char *const gpl_text[] = {
 
 #include "gui/credits.h"
 
-AboutDialog::AboutDialog()
+AboutDialog::AboutDialog(bool inGame)
 	: Dialog(10, 20, 300, 174),
 	  _scrollPos(0), _scrollTime(0), _willClose(false), _autoScroll(true) {
 
@@ -158,17 +158,17 @@ AboutDialog::AboutDialog()
 	Common::StringArray enginesDetected;
 #if defined(UNCACHED_PLUGINS) && defined(DYNAMIC_MODULES) && !defined(DETECTION_STATIC)
 	// Unload all MetaEnginesDetection if we're using uncached plugins to save extra memory.
-	PluginMan.unloadDetectionPlugin();
+	if (!inGame) PluginMan.unloadDetectionPlugin();
 #endif
-	PluginMan.loadFirstPlugin();
+	if (!inGame) PluginMan.loadFirstPlugin();
 	do {
 		const PluginList &plugins = EngineMan.getPlugins(PLUGIN_TYPE_ENGINE);
 		for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
 			enginesDetected.push_back((*iter)->getName());
 		}
-	} while (PluginMan.loadNextPlugin());
+	} while (!inGame && PluginMan.loadNextPlugin());
 
-	PluginMan.loadDetectionPlugin();
+	if (!inGame) PluginMan.loadDetectionPlugin();
 
 	for (Common::StringArray::iterator iter = enginesDetected.begin(); iter != enginesDetected.end(); iter++) {
 		Common::String str;
@@ -176,7 +176,7 @@ AboutDialog::AboutDialog()
 		const Plugin *p = EngineMan.findDetectionPlugin(*iter);
 
 		if (!p) {
-			warning("Cannot find plugin for %s", iter->c_str());
+			if (!inGame) warning("Cannot find plugin for %s", iter->c_str());
 			continue;
 		}
 

--- a/gui/about.cpp
+++ b/gui/about.cpp
@@ -160,7 +160,7 @@ AboutDialog::AboutDialog()
 	for (; iter != plugins.end(); ++iter) {
 		Common::String str;
 
-		const Plugin *p = EngineMan.findPlugin((*iter)->getName());
+		const Plugin *p = EngineMan.findDetectionPlugin((*iter)->getName());
 
 		if (!p) {
 			warning("Cannot find plugin for %s", (*iter)->getName());

--- a/gui/about.cpp
+++ b/gui/about.cpp
@@ -156,12 +156,20 @@ AboutDialog::AboutDialog(bool inGame)
 	addLine(engines);
 
 	Common::StringArray enginesDetected;
+
+	uint32 beginTime = g_system->getMillis(true);
 #if defined(UNCACHED_PLUGINS) && defined(DYNAMIC_MODULES) && !defined(DETECTION_STATIC)
 	// Unload all MetaEnginesDetection if we're using uncached plugins to save extra memory.
 	if (!inGame) PluginMan.unloadDetectionPlugin();
 #endif
 	if (!inGame) PluginMan.loadFirstPlugin();
 	do {
+		uint32 currentTime = g_system->getMillis(true);
+		if (currentTime - beginTime > 1500) {
+			// Too slow
+			enginesDetected.clear();
+			break;
+		}
 		const PluginList &plugins = EngineMan.getPlugins(PLUGIN_TYPE_ENGINE);
 		for (PluginList::const_iterator iter = plugins.begin(); iter != plugins.end(); ++iter) {
 			enginesDetected.push_back((*iter)->getName());

--- a/gui/about.h
+++ b/gui/about.h
@@ -48,7 +48,7 @@ protected:
 	EEHandler	*_eeHandler;
 
 public:
-	AboutDialog();
+	AboutDialog(bool inGame = false);
 
 	void open() override;
 	void close() override;

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -101,13 +101,13 @@ EditGameDialog::EditGameDialog(const Common::String &domain)
 
 	// Retrieve the plugin, since we need to access the engine's MetaEngine
 	// implementation.
-	const Plugin *metaEnginePlugin = nullptr;
+	const Plugin *detectionPlugin = nullptr;
 	const Plugin *enginePlugin = nullptr;
-	QualifiedGameDescriptor qgd = EngineMan.findTarget(domain, &metaEnginePlugin);
-	if (!metaEnginePlugin) {
+	QualifiedGameDescriptor qgd = EngineMan.findTarget(domain, &detectionPlugin);
+	if (!detectionPlugin) {
 		warning("MetaEnginePlugin for target \"%s\" not found!", domain.c_str());
 	} else {
-		enginePlugin = PluginMan.getEngineFromMetaEngine(metaEnginePlugin);
+		enginePlugin = PluginMan.getEngineFromDetectionPlugin(detectionPlugin);
 		if (!enginePlugin) {
 			warning("Engine Plugin for target \"%s\" not found! Game specific settings might be missing.", domain.c_str());
 		}

--- a/gui/editgamedialog.h
+++ b/gui/editgamedialog.h
@@ -62,6 +62,7 @@ public:
 
 	void open() override;
 	void apply() override;
+	void close() override;
 	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data) override;
 
 protected:

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -533,15 +533,15 @@ void LauncherDialog::loadGame(int item) {
 	EngineMan.upgradeTargetIfNecessary(target);
 
 	// Look for the plugin
-	const Plugin *detectionPlugin = nullptr;
 	const Plugin *enginePlugin = nullptr;
-	EngineMan.findTarget(target, &detectionPlugin);
+	QualifiedGameDescriptor game = EngineMan.findTarget(target);
 
-	// If we found a relevant plugin, find the matching engine plugin.
-	if (detectionPlugin) {
-		enginePlugin = PluginMan.getEngineFromDetectionPlugin(detectionPlugin);
-	}
+#if defined(UNCACHED_PLUGINS) && defined(DYNAMIC_MODULES) && !defined(DETECTION_STATIC)
+	// Unload all MetaEnginesDetection if we're using uncached plugins to save extra memory.
+	PluginMan.unloadDetectionPlugin();
+#endif
 
+	enginePlugin = PluginMan.findEnginePlugin(game.engineId);
 	if (enginePlugin) {
 		assert(enginePlugin->getType() == PLUGIN_TYPE_ENGINE);
 		const MetaEngine &metaEngine = enginePlugin->get<MetaEngine>();
@@ -562,6 +562,8 @@ void LauncherDialog::loadGame(int item) {
 		MessageDialog dialog(_("ScummVM could not find any engine capable of running the selected game!"), _("OK"));
 		dialog.runModal();
 	}
+
+	PluginMan.loadDetectionPlugin(); // only for uncached manager
 }
 
 Common::Array<LauncherEntry> LauncherDialog::generateEntries(const Common::ConfigManager::DomainMap &domains) {

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -589,7 +589,7 @@ Common::Array<LauncherEntry> LauncherDialog::generateEntries(const Common::Confi
 
 		Common::StringMap &engineMap = _engines[engineid];
 		if (!engineMap.contains(gameid)) {
-			const Plugin *plugin = EngineMan.findPlugin(engineid);
+			const Plugin *plugin = EngineMan.findDetectionPlugin(engineid);
 			if (plugin) {
 				PlainGameDescriptor gd = plugin->get<MetaEngineDetection>().findGame(gameid.c_str());
 				if (gd.description)

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -533,13 +533,13 @@ void LauncherDialog::loadGame(int item) {
 	EngineMan.upgradeTargetIfNecessary(target);
 
 	// Look for the plugin
-	const Plugin *metaEnginePlugin = nullptr;
+	const Plugin *detectionPlugin = nullptr;
 	const Plugin *enginePlugin = nullptr;
-	EngineMan.findTarget(target, &metaEnginePlugin);
+	EngineMan.findTarget(target, &detectionPlugin);
 
 	// If we found a relevant plugin, find the matching engine plugin.
-	if (metaEnginePlugin) {
-		enginePlugin = PluginMan.getEngineFromMetaEngine(metaEnginePlugin);
+	if (detectionPlugin) {
+		enginePlugin = PluginMan.getEngineFromDetectionPlugin(detectionPlugin);
 	}
 
 	if (enginePlugin) {

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -2870,7 +2870,7 @@ bool GlobalOptionsDialog::updateAutosavePeriod(int newValue) {
 		// note that engineid isn't present on games that predate it
 		// and haven't been run since it was introduced.
 		const Common::String engine = domain.getValOrDefault("engineid");
-		if (const Plugin *detectionPlugin = EngineMan.findPlugin(engine)) {
+		if (const Plugin *detectionPlugin = EngineMan.findDetectionPlugin(engine)) {
 			if (const Plugin *plugin = PluginMan.getEngineFromMetaEngine(detectionPlugin)) {
 				MetaEngine &metaEngine = plugin->get<MetaEngine>();
 				const int autoSaveSlot = metaEngine.getAutosaveSlot();

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -2871,7 +2871,7 @@ bool GlobalOptionsDialog::updateAutosavePeriod(int newValue) {
 		// and haven't been run since it was introduced.
 		const Common::String engine = domain.getValOrDefault("engineid");
 		if (const Plugin *detectionPlugin = EngineMan.findDetectionPlugin(engine)) {
-			if (const Plugin *plugin = PluginMan.getEngineFromMetaEngine(detectionPlugin)) {
+			if (const Plugin *plugin = PluginMan.getEngineFromDetectionPlugin(detectionPlugin)) {
 				MetaEngine &metaEngine = plugin->get<MetaEngine>();
 				const int autoSaveSlot = metaEngine.getAutosaveSlot();
 				if (autoSaveSlot < 0)


### PR DESCRIPTION
This (big) PR is a try to make a proper split between detection and engine plugins.
This allows to have uncached plugins manager really unload the detection while playing games and should give more room for constrained devices.

The big work behind it is with AdvancedDetector where the game description is copied from libdetection to the heap with all of its pointed data.
This required me to rename AdvancedMetaEngine and AdvancedMetaEngineDetection classes to a Base variant and to create new templated classes which properly handle the types. These new classes only contain the glue to handle the dynamic data.

Now, the MetaEngine is also repsonsible of cleaning the engine (after having created it) as this lets it cleanup its own data (the game descriptions allocated on heap).

Some cleanup to plugins code (removing functions expecting both plugins loaded at the same time) and some memory leaks were fixed at the same time.
The event recorder (which used some plugins related functions) is build fixed but untested: I didn't manage to make the game switch work.

I did tries with several engines (including AGS and Glk) with various actions to ensure everything is covered but more tests should be needed, especially on constrained devices.

To use uncached plugins manager on standard Linux, I configured my tree like this:
`CXXFLAGS=-DUNCACHED_PLUGINS ./configure --enable-all-engines --enable-plugins --default-dynamic --enable-detection-dynamic --enable-eventrecorder`

I think the plugin code could be cleaned up more (for example by tracking plugins dependency and avoid special treatment for detection) but current state seems to work and more work can be done afterwards.