### PR TITLE
DS: Report the buffer size to the mixer

### DIFF
--- a/audio/mixer.h
+++ b/audio/mixer.h
@@ -338,6 +338,10 @@ public:
 	/**
 	 * Return the output sample buffer size of the system.
 	 *
+	 * The return value is measured in frame units instead of bytes. It can be converted
+	 * to bytes by multiplying it with the sample size and the number of channels. For
+	 * example, for 16-bit stereo output it should be multiplied by 4.
+	 *
 	 * @return The number of samples processed at each audio callback.
 	 */
 	virtual uint getOutputBufSize() const = 0;

--- a/backends/mixer/maxmod/maxmod-mixer.cpp
+++ b/backends/mixer/maxmod/maxmod-mixer.cpp
@@ -56,7 +56,7 @@ mm_word on_stream_request( mm_word length, mm_addr dest, mm_stream_formats forma
 }
 
 void MaxModMixerManager::init() {
-	_mixer = new Audio::MixerImpl(_freq);
+	_mixer = new Audio::MixerImpl(_freq, _bufSize / 4);
 	assert(_mixer);
 
 	mm_ds_system sys;


### PR DESCRIPTION
I've also added comments to the `Mixer::getOutputBufSize()` functions, so I've opened a PR for it to make sure I've understood it correctly.