### PR TITLE
BASE: Fix path parsing in command line

### DIFF
--- a/common/path.cpp
+++ b/common/path.cpp
@@ -1119,4 +1119,23 @@ Path Path::fromConfig(const String &value) {
 	return Path(value, '/').punycodeDecode();
 }
 
+Path Path::fromCommandLine(const String &value) {
+	if (value.empty()) {
+		return Path();
+	}
+
+	// WIN32 accepts / and \ as separators
+#if defined(WIN32)
+	if (strchr(value.c_str(), Path::kNativeSeparator)) {
+		String value_ = value;
+		// User may have mixed \ and /
+		// As / is forbidden in paths under WIN32, this will never be a collision
+		value_.replace(Path::kNativeSeparator, '/');
+		return Path(value_, '/');
+	}
+#endif
+	// Unlike for options the paths provided by the user are not punyencoded
+	return Path(value, '/');
+}
+
 } // End of namespace Common

--- a/common/path.h
+++ b/common/path.h
@@ -557,9 +557,14 @@ public:
 	}
 
 	/**
-	 * Used by ConfigManager to parse a configuration value in a bacwards compatible way
+	 * Used by ConfigManager to parse a configuration value in a backwards compatible way
 	 */
 	static Path fromConfig(const String &value);
+
+	/**
+	 * Creates a path from a string given by the user
+	 */
+	static Path fromCommandLine(const String &value);
 };
 
 /** @} */

--- a/common/punycode.cpp
+++ b/common/punycode.cpp
@@ -151,6 +151,10 @@ String punycode_encode(const U32String &src) {
 		// endings
 		if (src[h - 1] == ' ' || src[h - 1] == '.')
 			return dst + '-';
+		if (srclen > 4 && src[0] == 'x' && src[1] == 'n' &&
+			src[2] == '-' && src[3] == '-')
+			return dst + '-';
+
 
 		return src;
 	}

--- a/test/common/path.h
+++ b/test/common/path.h
@@ -405,6 +405,12 @@ class PathTestSuite : public CxxTest::TestSuite
 		Common::Path p5 = p4.punycodeEncode();
 		TS_ASSERT_EQUALS(p5.toString('/'), "parent/dir/xn--Sound Manager 3.1  SoundLib-lba84k/Sound");
 
+		Common::Path p6 = p3.punycodeEncode();
+		TS_ASSERT_EQUALS(p6.toString('/'), "parent/dir/xn--xn--Sound Manager 3.1  SoundLib-lba84k-/Sound");
+
+		Common::Path p7 = p6.punycodeDecode();
+		TS_ASSERT_EQUALS(p7.toString('/'), "parent/dir/xn--Sound Manager 3.1  SoundLib-lba84k/Sound");
+
 		typedef Common::HashMap<Common::Path, bool,
 				Common::Path::IgnoreCaseAndMac_Hash, Common::Path::IgnoreCaseAndMac_EqualTo> TestPathMap;
 		TestPathMap map;


### PR DESCRIPTION
This will avoid spurious warnings on Windows.
This also allows Windows users to use / instead of \ separator. We use the same method everywhere: when checking if the path exists, when reading directly from converting and when reading from the configuration generated from the command line.

I don't have a Windows at hand currently, so I put it as a PR to have someone else check it. :grin: 