### PR TITLE
MTROPOLIS: multiple main segment files & Cloud 9 support

### DIFF
--- a/engines/mtropolis/boot.cpp
+++ b/engines/mtropolis/boot.cpp
@@ -2032,7 +2032,7 @@ void findWindowsMainSegment(Common::Archive &fs, Common::Path &resolvedPath, con
 	}
 
 	resolvedPath = fileToUse->getPathInArchive();
-	resolvedIsV2 = !fileToUse->getFileName().hasSuffixIgnoreCase(".mpl") && !filteredFiles.front()->getFileName().hasSuffixIgnoreCase(".c9a");
+	resolvedIsV2 = !fileToUse->getFileName().hasSuffixIgnoreCase(".mpl") && !fileToUse->getFileName().hasSuffixIgnoreCase(".c9a");
 }
 
 bool getMacFileType(Common::Archive &fs, const Common::Path &path, uint32 &outTag) {

--- a/engines/mtropolis/boot.cpp
+++ b/engines/mtropolis/boot.cpp
@@ -2004,7 +2004,7 @@ void findWindowsMainSegment(Common::Archive &fs, Common::Path &resolvedPath, con
 
 	for (const Common::ArchiveMemberPtr &archiveMember : allFiles) {
 		Common::String fileName = archiveMember->getFileName();
-		if (fileName.hasSuffixIgnoreCase(".mpl") || fileName.hasSuffixIgnoreCase(".mfw") || fileName.hasSuffixIgnoreCase(".mfx")) {
+		if (fileName.hasSuffixIgnoreCase(".mpl") || fileName.hasSuffixIgnoreCase(".mfw") || fileName.hasSuffixIgnoreCase(".mfx") || fileName.hasSuffixIgnoreCase(".c9a")) {
 			filteredFiles.push_back(archiveMember);
 			debug(4, "Identified possible main segment file %s", fileName.c_str());
 		}
@@ -2032,7 +2032,7 @@ void findWindowsMainSegment(Common::Archive &fs, Common::Path &resolvedPath, con
 	}
 
 	resolvedPath = fileToUse->getPathInArchive();
-	resolvedIsV2 = !fileToUse->getFileName().hasSuffixIgnoreCase(".mpl");
+	resolvedIsV2 = !fileToUse->getFileName().hasSuffixIgnoreCase(".mpl") && !filteredFiles.front()->getFileName().hasSuffixIgnoreCase(".c9a");
 }
 
 bool getMacFileType(Common::Archive &fs, const Common::Path &path, uint32 &outTag) {
@@ -2050,6 +2050,7 @@ enum SegmentSignatureType {
 
 	kSegmentSignatureMacV1,
 	kSegmentSignatureWinV1,
+	kSegmentSignatureCloud9V1,
 	kSegmentSignatureMacV2,
 	kSegmentSignatureWinV2,
 	kSegmentSignatureCrossV2,
@@ -2060,13 +2061,14 @@ const uint kSignatureHeaderSize = 10;
 SegmentSignatureType identifyStreamBySignature(byte (&header)[kSignatureHeaderSize]) {
 	const byte macV1Signature[kSignatureHeaderSize] = {0, 0, 0xaa, 0x55, 0xa5, 0xa5, 0, 0, 0, 0};
 	const byte winV1Signature[kSignatureHeaderSize] = {1, 0, 0xa5, 0xa5, 0x55, 0xaa, 0, 0, 0, 0};
+	const byte cloud9V1Signature[kSignatureHeaderSize] = {8, 0, 0xa5, 0xa5, 0x55, 0xaa, 0, 0, 0, 0};
 	const byte macV2Signature[kSignatureHeaderSize] = {0, 0, 0xaa, 0x55, 0xa5, 0xa5, 2, 0, 0, 0};
 	const byte winV2Signature[kSignatureHeaderSize] = {1, 0, 0xa5, 0xa5, 0x55, 0xaa, 0, 0, 0, 2};
 	const byte crossV2Signature[kSignatureHeaderSize] = {8, 0, 0xa5, 0xa5, 0x55, 0xaa, 0, 0, 0, 2};
 
-	const byte *signatures[5] = {macV1Signature, winV1Signature, macV2Signature, winV2Signature, crossV2Signature};
+	const byte *signatures[6] = {macV1Signature, winV1Signature, cloud9V1Signature, macV2Signature, winV2Signature, crossV2Signature};
 
-	for (int i = 0; i < 5; i++) {
+	for (int i = 0; i < ARRAYSIZE(signatures); i++) {
 		const byte *signature = signatures[i];
 
 		if (!memcmp(signature, header, kSignatureHeaderSize))

--- a/engines/mtropolis/boot.cpp
+++ b/engines/mtropolis/boot.cpp
@@ -1996,7 +1996,7 @@ void findMacPlayer(Common::Archive &fs, Common::Path &resolvedPath, PlayerType &
 	resolvedPlayerType = bestPlayerType;
 }
 
-void findWindowsMainSegment(Common::Archive &fs, Common::Path &resolvedPath, bool &resolvedIsV2) {
+void findWindowsMainSegment(Common::Archive &fs, Common::Path &resolvedPath, const MTropolisGameDescription &gamedesc, bool &resolvedIsV2) {
 	Common::ArchiveMemberList allFiles;
 	Common::ArchiveMemberList filteredFiles;
 
@@ -2015,11 +2015,24 @@ void findWindowsMainSegment(Common::Archive &fs, Common::Path &resolvedPath, boo
 	if (filteredFiles.size() == 0)
 		error("Couldn't find any main segment files");
 
-	if (filteredFiles.size() != 1)
-		error("Found multiple main segment files");
+	auto &fileToUse = filteredFiles.front();
 
-	resolvedPath = filteredFiles.front()->getPathInArchive();
-	resolvedIsV2 = !filteredFiles.front()->getFileName().hasSuffixIgnoreCase(".mpl");
+	if (filteredFiles.size() != 1) {
+		if (gamedesc.mainFileWindows && *gamedesc.mainFileWindows) {
+			const auto predicate = [&gamedesc](const Common::ArchiveMemberPtr &x) { return x->getFileName().hasPrefixIgnoreCase(gamedesc.mainFileWindows); };
+			const auto match = Common::find_if(filteredFiles.begin(), filteredFiles.end(), predicate);
+			if (match == filteredFiles.end()) {
+				error("Designated main segment file not found. Expected file %s", gamedesc.mainFileWindows);
+			} else {
+				fileToUse = *match;
+			}
+		} else {
+			error("Found multiple main segment files");
+		}
+	}
+
+	resolvedPath = fileToUse->getPathInArchive();
+	resolvedIsV2 = !fileToUse->getFileName().hasSuffixIgnoreCase(".mpl");
 }
 
 bool getMacFileType(Common::Archive &fs, const Common::Path &path, uint32 &outTag) {
@@ -2413,7 +2426,7 @@ BootConfiguration bootProject(const MTropolisGameDescription &gameDesc) {
 		Boot::findMacMainSegment(*vfs, mainSegmentLocation, isV2Project);
 	} else if (gameDesc.desc.platform == Common::kPlatformWindows) {
 		Boot::findWindowsPlayer(*vfs, playerLocation, playerType);
-		Boot::findWindowsMainSegment(*vfs, mainSegmentLocation, isV2Project);
+		Boot::findWindowsMainSegment(*vfs, mainSegmentLocation, gameDesc, isV2Project);
 	}
 
 	{

--- a/engines/mtropolis/detection.h
+++ b/engines/mtropolis/detection.h
@@ -93,6 +93,7 @@ struct MTropolisGameDescription {
 	int gameID;
 	int gameType;
 	MTropolisGameBootID bootID;
+	const char *mainFileWindows;
 };
 
 #define GAMEOPTION_WIDESCREEN_MOD				GUIO_GAMEOPTIONS1
@@ -101,6 +102,8 @@ struct MTropolisGameDescription {
 #define GAMEOPTION_SOUND_EFFECT_SUBTITLES		GUIO_GAMEOPTIONS4
 #define GAMEOPTION_AUTO_SAVE_AT_CHECKPOINTS		GUIO_GAMEOPTIONS5
 #define GAMEOPTION_ENABLE_SHORT_TRANSITIONS		GUIO_GAMEOPTIONS6
+
+#define MT_DEFAULT_MAINFILE ""
 
 } // End of namespace MTropolis
 

--- a/engines/mtropolis/detection_tables.h
+++ b/engines/mtropolis/detection_tables.h
@@ -51,6 +51,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_MAC_EN,
+		MT_DEFAULT_MAINFILE
 	},
 	{ // Obsidian Macintosh, data forks only
 		{
@@ -73,6 +74,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_MAC_EN,
+		MT_DEFAULT_MAINFILE
 	},
 	{ // Obsidian Japanese Macintosh, dumped
 		{
@@ -95,6 +97,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_MAC_JP,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian Windows, installed
@@ -122,6 +125,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_WIN_EN,
+		MT_DEFAULT_MAINFILE
 	},
 	{
 		// Obsidian, German Windows, installed
@@ -149,6 +153,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_WIN_DE_INSTALLED,
+		MT_DEFAULT_MAINFILE
 	},
 	{
 		// Obsidian, German Windows, CD
@@ -174,6 +179,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_WIN_DE_DISC,
+		MT_DEFAULT_MAINFILE
 	},
 	{
 		// Obsidian, Italian Windows, installed
@@ -200,6 +206,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_WIN_IT,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian Macintosh demo from standalone CD titled "Demo v1.0 January 1997"
@@ -226,6 +233,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_MAC_EN,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian PC demo [1996-10-03], found on:
@@ -252,6 +260,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_1,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian PC demo (same as above, with 8.3 file names), found on PC Gamer Disc 2.12 (1997-01)
@@ -275,6 +284,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_2,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian PC demo [1996-10-11/22] found on:
@@ -300,6 +310,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_3,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian PC cinematic demo found on:
@@ -325,6 +336,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_4,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian PC cinematic demo found on Multimedia Live (PC World) (v2.11, May 1997) [1996-10-03]
@@ -348,6 +360,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_5,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian PC cinematic demo (identical to the above except for EXE name)
@@ -371,6 +384,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_6,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian PC cinematic demo (identical to above, but different player version and renamed extensions)
@@ -394,6 +408,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_7,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Muppet Treasure Island English Macintosh Retail
@@ -415,6 +430,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_MAC,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Muppet Treasure Island English Windows Retail
@@ -439,6 +455,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN,
+		MT_DEFAULT_MAINFILE
 	},
 	{ // Muppet Treasure Island English Windows Retail DVD (OEM pack-in)
 		{
@@ -456,6 +473,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Los Muppets en la Isla del Tesoro (Mexican) [identical to Los Teleñecos en la Isla del Tesoro?]
@@ -480,6 +498,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // I Muppet nell'Isola del Tesoro
@@ -504,6 +523,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Muppet Treasure Island (Russian)
@@ -527,6 +547,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN_RU_DISC,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Muppet Treasure Island (Russian, installed)
@@ -551,6 +572,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN_RU_INSTALLED,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Muppet Treasure Island PC demo found on Score 38 (1997-02) [1996-07-17/19]
@@ -572,6 +594,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_DEMO_WIN,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Uncle Albert's Magical Album (German, Windows)
@@ -599,6 +622,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT1,
 		0,
 		MTBOOT_ALBERT1_WIN_DE,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Uncle Albert's Fabulous Voyage (German, Windows)
@@ -626,6 +650,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT2,
 		0,
 		MTBOOT_ALBERT2_WIN_DE,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Uncle Albert's Mysterious Island (German, Windows)
@@ -653,6 +678,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT3,
 		0,
 		MTBOOT_ALBERT3_WIN_DE,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // SPQR: The Empire's Darkest Hour Windows CD-ROM
@@ -673,6 +699,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_SPQR,
 		0,
 		MTBOOT_SPQR_RETAIL_WIN,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // SPQR: The Empire's Darkest Hour Macintosh CD-ROM
@@ -692,6 +719,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_SPQR,
 		0,
 		MTBOOT_SPQR_RETAIL_MAC,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Star Trek: The Game Show demo
@@ -711,6 +739,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_STTGS,
 		0,
 		MTBOOT_STTGS_DEMO_WIN,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Unit: Rebooted (Music Videos)
@@ -730,9 +759,10 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_UNIT,
 		0,
 		MTBOOT_UNIT_REBOOTED_WIN,
+		MT_DEFAULT_MAINFILE
 	},
 
-	{ AD_TABLE_END_MARKER, 0, 0, MTBOOT_INVALID }
+	{ AD_TABLE_END_MARKER, 0, 0, MTBOOT_INVALID, nullptr }
 };
 
 } // End of namespace MTropolis


### PR DESCRIPTION
Two changes related to main segment detection:

# Games with multiple main segment files
Numerous games have multiple MPL files (or equivalent). Switching between them is done with the OpenTitle modifier (see also PR #5808). Usually they have a launcher executable that starts the mTropolis player with the correct file.

Currently, ScummVM assumes that only one MPL file exists, and throws an error if there are multiple.
With this change, we allow for multiple MPL files in a title, if the correct main file is specified in the game description from the detection tables.

Doing the equivalent for Mac, if necessary, remains an open task.

Affected titles:
- The Totally Techie World of Young Dilbert: Hi-Tech Hijinks
- The Magic School Bus Discovers Flight
- The Magic School Bus Explores Bugs
- The Magic School Bus Explores the World of Animals
- The Magic School Bus In Concert
- The Magic School Bus Lands on Mars
- The Magic School Bus Volcano Adventure
- The Magic School Bus Whales & Dolphins
- Purple Moon Sampler
- Rugrats: Totally Angelica Boredom Buster
- Easy-Bake Kitchen
- Your Notebook (with help from Amelia)
- I Can Be an Animal Doctor Demo*
- I Can Be a Dinosaur Finder Demo*

*These two demos are not interlinked, but their `.c9a` files (see below) sit right beside each other on the disk.

All those titles will be added to detection in a future PR.

# Cloud 9 Games
Games by the developer Cloud 9 Games have their own stream signature, so far not seen anywhere else. They also use the extension `.c9a` instead of `.mpl`.
Cloud 9 titles ship with mTropolis player 1.0.

Affected titles:
 - How to Draw the Marvel Way
 - I Can Be an Animal Doctor (+Demo)
 - I Can Be a Dinosaur Finder (+Demo)

All those titles will be added to detection in a future PR.