### PR TITLE
GOB: Fix GCC Compiler warning in console.cpp

### DIFF
--- a/engines/gob/console.cpp
+++ b/engines/gob/console.cpp
@@ -90,8 +90,9 @@ bool GobConsole::cmd_dumpVars(int argc, const char **argv) {
 	Common::DumpFile file;
 
 	const char *outFile = "variables.dmp";
-    if (!file.open(outFile))
+    if (!file.open(outFile)) {
         return true;
+	}
 
 	file.write(_vm->_inter->_variables->getAddressOff8(0), _vm->_inter->_variables->getSize());
 


### PR DESCRIPTION
Fixes this Compiler warning:

engines/gob/console.cpp: In member function ‘bool Gob::GobConsole::cmd_dumpVars(int, const char**)’: engines/gob/console.cpp:93:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
   93 |     if (!file.open(outFile))
      |     ^~
engines/gob/console.cpp:96:9: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
   96 |         file.write(_vm->_inter->_variables->getAddressOff8(0), _vm->_inter->_variables->getSize());
      |         ^~~~