### PR TITLE
GIT: Ignore variables.dmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -299,3 +299,6 @@ dists/emscripten/emsdk-*
 #Ignore Atari/FreeMiNT files
 scummvm.gtp
 scummvm.ttp
+
+#Ignore GOB Engine files
+variables.dmp


### PR DESCRIPTION
Generated by GobConsole when executing dump_Vars, The File will be generated in the same Directory where the ScummVM exec is stored. For your own compiled versions it wants to upload the File to the GitHub repository.