### PR TITLE
BASE: silence clang warning

### DIFF
--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -566,12 +566,12 @@ bool ensureAccessibleDirectoryForPathOption(Common::FSNode &node,
 		usage("Non-existent path '%s' for option %s%c%s", option, \
 				isLongCmd ? "--" : "-", \
 				isLongCmd ? longCmd[0] : shortCmd, \
-				isLongCmd ? longCmd + 1 : ""); \
+				isLongCmd ? (longCmd) + 1 : ""); \
 	} else if (!ensureAccessibleDirectoryForPathOption(node, false, true, true)) { \
 		usage("Non-readable path '%s' for option %s%c%s", option, \
 				isLongCmd ? "--" : "-", \
 				isLongCmd ? longCmd[0] : shortCmd, \
-				isLongCmd ? longCmd + 1 : ""); \
+				isLongCmd ? (longCmd) + 1 : ""); \
 	} \
 	settings[longCmd] = node.getPath().toConfig();
 


### PR DESCRIPTION
clang interprets this expression as possibly a mistaken attempt to add a number to the string, rather than to index into the string. Adding parens around the string silences the warning.

Sample warning:

```
base/commandLine.cpp:917:4: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                        DO_LONG_OPTION_PATH("extrapath")
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
base/commandLine.cpp:593:41: note: expanded from macro 'DO_LONG_OPTION_PATH'
#define DO_LONG_OPTION_PATH(longCmd)    DO_OPTION_PATH(0, longCmd)
                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
base/commandLine.cpp:569:25: note: expanded from macro 'DO_OPTION_PATH'
                                isLongCmd ? longCmd + 1 : ""); \
                                            ~~~~~~~~^~~
base/commandLine.cpp:914:4: note: use array indexing to silence this warning
base/commandLine.cpp:593:41: note: expanded from macro 'DO_LONG_OPTION_PATH'
#define DO_LONG_OPTION_PATH(longCmd)    DO_OPTION_PATH(0, longCmd)
                                        ^
base/commandLine.cpp:569:25: note: expanded from macro 'DO_OPTION_PATH'
                                isLongCmd ? longCmd + 1 : ""); \
                                                    ^
```