### PR TITLE
MTROPOLIS: multiple main segment files & Cloud 9 support

### DIFF
--- a/engines/mtropolis/boot.cpp
+++ b/engines/mtropolis/boot.cpp
@@ -2082,7 +2082,7 @@ void findWindowsMainSegment(Common::Archive &fs, Common::Path &resolvedPath, con
 	}
 
 	resolvedPath = fileToUse->getPathInArchive();
-	resolvedIsV2 = !fileToUse->getFileName().hasSuffixIgnoreCase(".mpl") && !filteredFiles.front()->getFileName().hasSuffixIgnoreCase(".c9a");
+	resolvedIsV2 = !fileToUse->getFileName().hasSuffixIgnoreCase(".mpl") && !fileToUse->getFileName().hasSuffixIgnoreCase(".c9a");
 }
 
 bool getMacFileType(Common::Archive &fs, const Common::Path &path, uint32 &outTag) {

--- a/engines/mtropolis/detection.h
+++ b/engines/mtropolis/detection.h
@@ -106,6 +106,7 @@ struct MTropolisGameDescription {
 	int gameID;
 	int gameType;
 	MTropolisGameBootID bootID;
+	const char *mainFileWindows;
 };
 
 #define GAMEOPTION_WIDESCREEN_MOD				GUIO_GAMEOPTIONS1
@@ -114,6 +115,8 @@ struct MTropolisGameDescription {
 #define GAMEOPTION_SOUND_EFFECT_SUBTITLES		GUIO_GAMEOPTIONS4
 #define GAMEOPTION_AUTO_SAVE_AT_CHECKPOINTS		GUIO_GAMEOPTIONS5
 #define GAMEOPTION_ENABLE_SHORT_TRANSITIONS		GUIO_GAMEOPTIONS6
+
+#define MT_DEFAULT_MAINFILE ""
 
 } // End of namespace MTropolis
 

--- a/engines/mtropolis/detection.h
+++ b/engines/mtropolis/detection.h
@@ -99,14 +99,24 @@ enum MTGameFlag {
 };
 
 struct MTropolisGameDescription {
-	AD_GAME_DESCRIPTION_HELPERS(desc);
-
 	ADGameDescription desc;
 
 	int gameID;
 	int gameType;
 	MTropolisGameBootID bootID;
 	const char *mainFileWindows;
+
+	uint32 sizeBuffer() const {
+		uint32 ret = desc.sizeBuffer();
+		ret += ADDynamicDescription::strSizeBuffer(mainFileWindows);
+		return ret;
+	}
+
+	void *toBuffer(void* buffer) {
+		buffer = desc.toBuffer(buffer);
+		buffer = ADDynamicDescription::strToBuffer(buffer, mainFileWindows);
+		return buffer;
+	}
 };
 
 #define GAMEOPTION_WIDESCREEN_MOD				GUIO_GAMEOPTIONS1

--- a/engines/mtropolis/detection_tables.h
+++ b/engines/mtropolis/detection_tables.h
@@ -651,6 +651,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT1,
 		0,
 		MTBOOT_ALBERT1_WIN_EN,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Uncle Albert's Magical Album (French, Windows)
@@ -678,6 +679,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT1,
 		0,
 		MTBOOT_ALBERT1_WIN_FR,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Uncle Albert's Magical Album (Dutch, Windows)
@@ -705,6 +707,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT1,
 		0,
 		MTBOOT_ALBERT1_WIN_NL,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Uncle Albert's Fabulous Voyage (German, Windows)
@@ -759,6 +762,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT2,
 		0,
 		MTBOOT_ALBERT2_WIN_EN,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Uncle Albert's Fabulous Voyage (French, Windows)
@@ -786,6 +790,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT2,
 		0,
 		MTBOOT_ALBERT2_WIN_FR,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Uncle Albert's Fabulous Voyage (Dutch, Windows)
@@ -813,6 +818,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT2,
 		0,
 		MTBOOT_ALBERT2_WIN_NL,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Uncle Albert's Mysterious Island (German, Windows)
@@ -867,6 +873,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT3,
 		0,
 		MTBOOT_ALBERT3_WIN_EN,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Uncle Albert's Mysterious Island (French, Windows)
@@ -894,6 +901,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT3,
 		0,
 		MTBOOT_ALBERT3_WIN_FR,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Uncle Albert's Mysterious Island (Dutch, Windows)
@@ -921,6 +929,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT3,
 		0,
 		MTBOOT_ALBERT3_WIN_NL,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Uncle Albert's Mysterious Island (Catalan, Windows)
@@ -948,6 +957,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT3,
 		0,
 		MTBOOT_ALBERT3_WIN_CA,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // SPQR: The Empire's Darkest Hour Windows CD-ROM

--- a/engines/mtropolis/detection_tables.h
+++ b/engines/mtropolis/detection_tables.h
@@ -53,7 +53,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_MAC_EN,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 	{ // Obsidian Macintosh, data forks only
 		{
@@ -76,7 +76,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_MAC_EN,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 	{ // Obsidian Japanese Macintosh, dumped
 		{
@@ -99,7 +99,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_MAC_JP,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Obsidian Windows, installed
@@ -127,7 +127,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_WIN_EN,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 	{
 		// Obsidian, German Windows, installed
@@ -155,7 +155,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_WIN_DE_INSTALLED,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 	{
 		// Obsidian, German Windows, CD
@@ -181,7 +181,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_WIN_DE_DISC,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 	{
 		// Obsidian, Italian Windows, installed
@@ -208,7 +208,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_WIN_IT,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Obsidian Macintosh demo from standalone CD titled "Demo v1.0 January 1997"
@@ -235,7 +235,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_MAC_EN,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Obsidian PC demo [1996-10-03], found on:
@@ -262,7 +262,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_1,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Obsidian PC demo (same as above, with 8.3 file names), found on PC Gamer Disc 2.12 (1997-01)
@@ -286,7 +286,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_2,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Obsidian PC demo [1996-10-11/22] found on:
@@ -312,7 +312,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_3,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Obsidian PC cinematic demo found on:
@@ -338,7 +338,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_4,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Obsidian PC cinematic demo found on Multimedia Live (PC World) (v2.11, May 1997) [1996-10-03]
@@ -362,7 +362,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_5,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Obsidian PC cinematic demo (identical to the above except for EXE name)
@@ -386,7 +386,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_6,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Obsidian PC cinematic demo (identical to above, but different player version and renamed extensions)
@@ -410,7 +410,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_7,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Muppet Treasure Island English Macintosh Retail
@@ -432,7 +432,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_MAC,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Muppet Treasure Island English Windows Retail
@@ -457,7 +457,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 	{ // Muppet Treasure Island English Windows Retail DVD (OEM pack-in)
 		{
@@ -475,7 +475,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Los Muppets en la Isla del Tesoro (Mexican) [identical to Los Teleñecos en la Isla del Tesoro?]
@@ -500,7 +500,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // I Muppet nell'Isola del Tesoro
@@ -525,7 +525,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Muppet Treasure Island (Russian)
@@ -549,7 +549,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN_RU_DISC,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Muppet Treasure Island (Russian, installed)
@@ -574,7 +574,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN_RU_INSTALLED,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Muppet Treasure Island PC demo found on Score 38 (1997-02) [1996-07-17/19]
@@ -596,7 +596,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_DEMO_WIN,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Uncle Albert's Magical Album (German, Windows)
@@ -624,7 +624,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT1,
 		0,
 		MTBOOT_ALBERT1_WIN_DE,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Uncle Albert's Magical Album (English, Windows)
@@ -651,7 +651,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT1,
 		0,
 		MTBOOT_ALBERT1_WIN_EN,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Uncle Albert's Magical Album (French, Windows)
@@ -679,7 +679,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT1,
 		0,
 		MTBOOT_ALBERT1_WIN_FR,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Uncle Albert's Magical Album (Dutch, Windows)
@@ -707,7 +707,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT1,
 		0,
 		MTBOOT_ALBERT1_WIN_NL,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Uncle Albert's Fabulous Voyage (German, Windows)
@@ -735,7 +735,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT2,
 		0,
 		MTBOOT_ALBERT2_WIN_DE,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Uncle Albert's Fabulous Voyage (English, Windows)
@@ -762,7 +762,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT2,
 		0,
 		MTBOOT_ALBERT2_WIN_EN,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Uncle Albert's Fabulous Voyage (French, Windows)
@@ -790,7 +790,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT2,
 		0,
 		MTBOOT_ALBERT2_WIN_FR,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Uncle Albert's Fabulous Voyage (Dutch, Windows)
@@ -818,7 +818,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT2,
 		0,
 		MTBOOT_ALBERT2_WIN_NL,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Uncle Albert's Mysterious Island (German, Windows)
@@ -846,7 +846,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT3,
 		0,
 		MTBOOT_ALBERT3_WIN_DE,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Uncle Albert's Mysterious Island (English, Windows)
@@ -873,7 +873,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT3,
 		0,
 		MTBOOT_ALBERT3_WIN_EN,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Uncle Albert's Mysterious Island (French, Windows)
@@ -901,7 +901,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT3,
 		0,
 		MTBOOT_ALBERT3_WIN_FR,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Uncle Albert's Mysterious Island (Dutch, Windows)
@@ -929,7 +929,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT3,
 		0,
 		MTBOOT_ALBERT3_WIN_NL,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Uncle Albert's Mysterious Island (Catalan, Windows)
@@ -957,7 +957,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT3,
 		0,
 		MTBOOT_ALBERT3_WIN_CA,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // SPQR: The Empire's Darkest Hour Windows CD-ROM
@@ -978,7 +978,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_SPQR,
 		0,
 		MTBOOT_SPQR_RETAIL_WIN,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // SPQR: The Empire's Darkest Hour Macintosh CD-ROM
@@ -998,7 +998,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_SPQR,
 		0,
 		MTBOOT_SPQR_RETAIL_MAC,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Star Trek: The Game Show demo
@@ -1018,7 +1018,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_STTGS,
 		0,
 		MTBOOT_STTGS_DEMO_WIN,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ // Unit: Rebooted (Music Videos)
@@ -1038,7 +1038,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_UNIT,
 		0,
 		MTBOOT_UNIT_REBOOTED_WIN,
-		MT_DEFAULT_MAINFILE
+		MT_DEFAULT_MAINFILE,
 	},
 
 	{ AD_TABLE_END_MARKER, 0, 0, MTBOOT_INVALID, nullptr }

--- a/engines/mtropolis/detection_tables.h
+++ b/engines/mtropolis/detection_tables.h
@@ -53,6 +53,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_MAC_EN,
+		MT_DEFAULT_MAINFILE
 	},
 	{ // Obsidian Macintosh, data forks only
 		{
@@ -75,6 +76,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_MAC_EN,
+		MT_DEFAULT_MAINFILE
 	},
 	{ // Obsidian Japanese Macintosh, dumped
 		{
@@ -97,6 +99,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_MAC_JP,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian Windows, installed
@@ -124,6 +127,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_WIN_EN,
+		MT_DEFAULT_MAINFILE
 	},
 	{
 		// Obsidian, German Windows, installed
@@ -151,6 +155,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_WIN_DE_INSTALLED,
+		MT_DEFAULT_MAINFILE
 	},
 	{
 		// Obsidian, German Windows, CD
@@ -176,6 +181,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_WIN_DE_DISC,
+		MT_DEFAULT_MAINFILE
 	},
 	{
 		// Obsidian, Italian Windows, installed
@@ -202,6 +208,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_RETAIL_WIN_IT,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian Macintosh demo from standalone CD titled "Demo v1.0 January 1997"
@@ -228,6 +235,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_MAC_EN,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian PC demo [1996-10-03], found on:
@@ -254,6 +262,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_1,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian PC demo (same as above, with 8.3 file names), found on PC Gamer Disc 2.12 (1997-01)
@@ -277,6 +286,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_2,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian PC demo [1996-10-11/22] found on:
@@ -302,6 +312,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_3,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian PC cinematic demo found on:
@@ -327,6 +338,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_4,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian PC cinematic demo found on Multimedia Live (PC World) (v2.11, May 1997) [1996-10-03]
@@ -350,6 +362,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_5,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian PC cinematic demo (identical to the above except for EXE name)
@@ -373,6 +386,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_6,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Obsidian PC cinematic demo (identical to above, but different player version and renamed extensions)
@@ -396,6 +410,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_OBSIDIAN,
 		0,
 		MTBOOT_OBSIDIAN_DEMO_WIN_EN_7,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Muppet Treasure Island English Macintosh Retail
@@ -417,6 +432,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_MAC,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Muppet Treasure Island English Windows Retail
@@ -441,6 +457,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN,
+		MT_DEFAULT_MAINFILE
 	},
 	{ // Muppet Treasure Island English Windows Retail DVD (OEM pack-in)
 		{
@@ -458,6 +475,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Los Muppets en la Isla del Tesoro (Mexican) [identical to Los Teleñecos en la Isla del Tesoro?]
@@ -482,6 +500,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // I Muppet nell'Isola del Tesoro
@@ -506,6 +525,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Muppet Treasure Island (Russian)
@@ -529,6 +549,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN_RU_DISC,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Muppet Treasure Island (Russian, installed)
@@ -553,6 +574,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_RETAIL_WIN_RU_INSTALLED,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Muppet Treasure Island PC demo found on Score 38 (1997-02) [1996-07-17/19]
@@ -574,6 +596,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_MTI,
 		0,
 		MTBOOT_MTI_DEMO_WIN,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Uncle Albert's Magical Album (German, Windows)
@@ -601,6 +624,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT1,
 		0,
 		MTBOOT_ALBERT1_WIN_DE,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Uncle Albert's Magical Album (English, Windows)
@@ -708,6 +732,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT2,
 		0,
 		MTBOOT_ALBERT2_WIN_DE,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Uncle Albert's Fabulous Voyage (English, Windows)
@@ -815,6 +840,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_ALBERT3,
 		0,
 		MTBOOT_ALBERT3_WIN_DE,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Uncle Albert's Mysterious Island (English, Windows)
@@ -942,6 +968,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_SPQR,
 		0,
 		MTBOOT_SPQR_RETAIL_WIN,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // SPQR: The Empire's Darkest Hour Macintosh CD-ROM
@@ -961,6 +988,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_SPQR,
 		0,
 		MTBOOT_SPQR_RETAIL_MAC,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Star Trek: The Game Show demo
@@ -980,6 +1008,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_STTGS,
 		0,
 		MTBOOT_STTGS_DEMO_WIN,
+		MT_DEFAULT_MAINFILE
 	},
 
 	{ // Unit: Rebooted (Music Videos)
@@ -999,9 +1028,10 @@ static const MTropolisGameDescription gameDescriptions[] = {
 		GID_UNIT,
 		0,
 		MTBOOT_UNIT_REBOOTED_WIN,
+		MT_DEFAULT_MAINFILE
 	},
 
-	{ AD_TABLE_END_MARKER, 0, 0, MTBOOT_INVALID }
+	{ AD_TABLE_END_MARKER, 0, 0, MTBOOT_INVALID, nullptr }
 };
 
 } // End of namespace MTropolis


### PR DESCRIPTION
Recreation of PR #5834 after a rebase.
Two changes related to main segment detection:

# Games with multiple main segment files
Numerous games have multiple MPL files (or equivalent). Switching between them is done with the OpenTitle modifier (see also PR #5808). Usually they have a launcher executable that starts the mTropolis player with the correct file.

Currently, ScummVM assumes that only one MPL file exists, and throws an error if there are multiple.
With this change, we allow for multiple MPL files in a title, if the correct main file is specified in the game description from the detection tables.

Doing the equivalent for Mac, if necessary, remains an open task.

Affected titles:
- The Totally Techie World of Young Dilbert: Hi-Tech Hijinks
- The Magic School Bus Discovers Flight
- The Magic School Bus Explores Bugs
- The Magic School Bus Explores the World of Animals
- The Magic School Bus In Concert
- The Magic School Bus Lands on Mars
- The Magic School Bus Volcano Adventure
- The Magic School Bus Whales & Dolphins
- Purple Moon Sampler
- Rugrats: Totally Angelica Boredom Buster
- Easy-Bake Kitchen
- Your Notebook (with help from Amelia)

Furthermore, the demos for I Can Be an Animal Doctor and I Can Be a Dinosaur Finder Demo are affected, as their `.c9a` files (see below) sit right beside each other on the disk.

All those titles will be added to detection in a future PR.

# Cloud 9 Games
Games by the developer Cloud 9 Games have their own stream signature, so far not seen anywhere else. They also use the extension `.c9a` instead of `.mpl`.
Cloud 9 titles ship with mTropolis player 1.0.

Affected titles:
 - How to Draw the Marvel Way
 - I Can Be an Animal Doctor (+Demo)
 - I Can Be a Dinosaur Finder (+Demo)

All those titles will be added to detection in a future PR.