### PR TITLE
MACOSX: Fix macOS builds with plugins (as used for OSX PPC releases)

### DIFF
--- a/backends/plugins/sdl/macosx/macosx-provider.cpp
+++ b/backends/plugins/sdl/macosx/macosx-provider.cpp
@@ -29,7 +29,7 @@
 #include "common/fs.h"
 
 void MacOSXPluginProvider::addCustomDirectories(Common::FSList &dirs) const {
-	Common::String bundlePath = getResourceAppBundlePathMacOSX();
+	Common::Path bundlePath(getResourceAppBundlePathMacOSX(), Common::Path::kNativeSeparator);
 	if (!bundlePath.empty())
 		dirs.push_back(Common::FSNode(bundlePath));
 }


### PR DESCRIPTION
This fises macOS builds using `--enable-plugins`, as used for building the OSX PPC releases

```

backends/plugins/sdl/macosx/macosx-provider.cpp:34:18: error: no matching conversion for functional-style cast from 'Common::String' to 'Common::FSNode'
                dirs.push_back(Common::FSNode(bundlePath));
                               ^~~~~~~~~~~~~~~~~~~~~~~~~
./common/fs.h:69:7: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'Common::String' to 'const Common::FSNode' for 1st argument
class FSNode : public ArchiveMember {
      ^
./common/fs.h:80:2: note: candidate constructor not viable: no known conversion from 'Common::String' to 'AbstractFSNode *' for 1st argument
        FSNode(AbstractFSNode *realNode);
        ^
./common/fs.h:108:11: note: candidate constructor not viable: no known conversion from 'Common::String' to 'const Common::Path' for 1st argument
        explicit FSNode(const Path &path);
                 ^
./common/fs.h:97:2: note: candidate constructor not viable: requires 0 arguments, but 1 was provided
        FSNode();
        ^
1 error generated.
make: *** [backends/plugins/sdl/macosx/macosx-provider.o] Error 1
```