### PR TITLE
CONFIGURE: Improve libsonivox checks

### DIFF
--- a/configure
+++ b/configure
@@ -5999,8 +5999,15 @@ append_var SONIVOX_LIBS "-lsonivox"
 if test "$_sonivox" = auto; then
 	_sonivox=no
 	cat > $TMPC << EOF
+#include <stddef.h>
 #include <sonivox/eas.h>
-int main(void) { /* delete_fluid_settings(new_fluid_settings()); */ return 0; }
+
+EAS_DATA_HANDLE mEASDataHandle = NULL;
+
+int main(void) {
+	EAS_Init(&mEASDataHandle);
+	return 0;
+}
 EOF
 	cc_check_no_clean $SONIVOX_CFLAGS $SONIVOX_LIBS && _sonivox=yes
 	if test "$_sonivox" != yes && test "$_pkg_config" = "yes" && $_pkgconfig --exists sonivox; then

--- a/configure
+++ b/configure
@@ -6007,9 +6007,16 @@ EOF
 		SONIVOX_LIBS="`$_pkgconfig --static --libs sonivox`"
 		cc_check_no_clean $SONIVOX_CFLAGS $SONIVOX_LIBS && _sonivox=yes
 	fi
-	if test "$_sonivox" != yes && test "$_pkg_config" = "yes" && $_pkgconfig --exists sonivox-static; then
-		SONIVOX_LIBS="`$_pkgconfig --static --libs sonivox-static`"
-		cc_check_no_clean $SONIVOX_CFLAGS $SONIVOX_LIBS && _sonivox=yes
+	if test "$_sonivox" != yes ; then
+		if test "$_pkg_config" = "yes" && $_pkgconfig --exists sonivox-static; then
+			SONIVOX_LIBS="`$_pkgconfig --static --libs sonivox-static`"
+			cc_check_no_clean $SONIVOX_CFLAGS $SONIVOX_LIBS && _sonivox=yes
+		fi
+
+		if test "$_sonivox" != yes ; then
+			SONIVOX_LIBS="-lsonivox-static"
+			cc_check_no_clean $SONIVOX_CFLAGS $SONIVOX_LIBS && _sonivox=yes
+		fi
 	fi
 	cc_check_clean
 fi

--- a/ports.mk
+++ b/ports.mk
@@ -556,6 +556,10 @@ ifdef USE_RETROWAVE
 OSX_STATIC_LIBS += $(STATICLIBPATH)/lib/libRetroWave.a
 endif
 
+ifdef USE_SONIVOX
+OSX_STATIC_LIBS += $(STATICLIBPATH)/lib/libsonivox-static.a
+endif
+
 ifdef USE_SPARKLE
 ifdef MACOSX
 ifneq ($(SPARKLEPATH),)


### PR DESCRIPTION
Two commits improving the libsonivox checks done in `./configure`. The commits messages give the details.

* Upsteam installs a `libsonivox-static.a` file by default, so check for `-lsonivox-static` too, when there's no `pkg-config` available (not all ports have it)
* Do an actual linking test of a libsonivox function inside the configure check.
    * That's what we do for most library checks
    * and it helps catching an upsteam issue at an earlier stage: they unconditionally use a GCC `__builtin` (with no fallback) which is not available before GCC 5.0. The error would only appear when linking the `scummvm` binary; this change helps finding the issue earlier, so that the library won't be used if the compiler is too old (some ports still use GCC < 5.0) and the library hasn't been patched for it.

Tested on OSX PPC and Linux x86-64.