### PR TITLE
GRAPHICS: Only invalidate the updated area of the screen in ManagedSurface::blitFrom

### DIFF
--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -430,7 +430,7 @@ void ManagedSurface::blitFromInner(const Surface &src, const Common::Rect &srcRe
 		}
 	}
 
-	addDirtyRect(Common::Rect(0, 0, this->w, this->h));
+	addDirtyRect(destRect);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, uint32 transColor, bool flipped,


### PR DESCRIPTION
This is reported to significantly reduce CPU usage in The Space Bar.