### PR TITLE
ULTIMA6: add ios gamepad d-pad key bindings

### DIFF
--- a/devtools/create_ultima/files/ultima6/defaultkeys.txt
+++ b/devtools/create_ultima/files/ultima6/defaultkeys.txt
@@ -163,3 +163,7 @@ joy8	game_menu_dialog
 joy9	new_command_bar
 joy10	move
 joy11	look
+joy12	walk_north
+joy13	walk_south
+joy14	walk_west
+joy15	walk_east


### PR DESCRIPTION
ULTIMA6: add ios gamepad d-pad key bindings

Allows the use of Dpad-mode Directional button overlays
on iOS 15 or later devices when playing ultima6-based games.