### PR TITLE
ULTIMA6: patch nuvie.cfg parsing by extracting text from child

### DIFF
--- a/engines/ultima/shared/conf/xml_tree.cpp
+++ b/engines/ultima/shared/conf/xml_tree.cpp
@@ -130,8 +130,12 @@ bool XMLTree::checkRoot(const Common::String &key) const {
 void XMLTree::value(const Common::String &key, Common::String &ret,
 					const char *defaultvalue) const {
 	const XMLNode *sub = _tree->subtree(key);
-	if (sub)
+	if (sub) { 
 		ret = sub->text();
+		if (ret.empty())
+			if (sub->firstChild())
+				ret = sub->firstChild()->text();
+	}	
 	else
 		ret = defaultvalue;
 }


### PR DESCRIPTION
Re-enables nuvie.cfg file parsing that were impacted by XMLNode enhancement, picking the text value of first child if current subtree text is empty. Fixes issue #15207.