### PR TITLE
GRAPHICS: Deprecate ManagedSurface methods that implicitly copy pixel data

### DIFF
--- a/engines/ags/lib/allegro/surface.cpp
+++ b/engines/ags/lib/allegro/surface.cpp
@@ -247,29 +247,30 @@ void BITMAP::stretchDraw(const BITMAP *srcBitmap, const Common::Rect &srcRect,
 	// using the optimized paths; for now, we pre-stretch to a temporary surface
 	Graphics::ManagedSurface cropped(const_cast<BITMAP *>(srcBitmap)->getSurface(), srcRect);
 	// We need to use Surface::scale, since ManagedSurface _always_ respects the source alpha, and thus skips transparent pixels
-	Graphics::ManagedSurface stretched(cropped.rawSurface().scale(dstRect.width(), dstRect.height()), DisposeAfterUse::YES);
-	BITMAP temp(&stretched);
-	auto optimizedArgs = DrawInnerArgs(this, &temp, stretched.getBounds(), dstRect, skipTrans, srcAlpha, false, false, -1, -1, -1, false);
+	Graphics::ManagedSurface *stretched = cropped.scale(dstRect.width(), dstRect.height());
+	BITMAP temp(stretched);
+	auto optimizedArgs = DrawInnerArgs(this, &temp, stretched->getBounds(), dstRect, skipTrans, srcAlpha, false, false, -1, -1, -1, false);
 
 #ifdef SCUMMVM_NEON
 	if (_G(simd_flags) & AGS3::Globals::SIMD_NEON) {
 		drawNEON<false>(optimizedArgs);
-		return;
-	}
+	} else
 #endif
 #ifdef SCUMMVM_AVX2
 	if (_G(simd_flags) & AGS3::Globals::SIMD_AVX2) {
 		drawAVX2<false>(optimizedArgs);
-		return;
-	}
+	} else
 #endif
 #ifdef SCUMMVM_SSE2
 	if (_G(simd_flags) & AGS3::Globals::SIMD_SSE2) {
 		drawSSE2<false>(optimizedArgs);
-		return;
-	}
+	} else
 #endif
-	drawGeneric<true>(optimizedArgs);
+	{
+		drawGeneric<true>(optimizedArgs);
+	}
+
+	delete stretched;
 }
 void BITMAP::blendPixel(uint8 aSrc, uint8 rSrc, uint8 gSrc, uint8 bSrc, uint8 &aDest, uint8 &rDest, uint8 &gDest, uint8 &bDest, uint32 alpha, bool useTint, byte *destVal) const {
 	switch (_G(_blender_mode)) {

--- a/engines/bagel/boflib/gfx/bitmap.cpp
+++ b/engines/bagel/boflib/gfx/bitmap.cpp
@@ -599,13 +599,10 @@ ErrorCode CBofBitmap::captureScreen(CBofWindow *pWnd, CBofRect *pSrcRect, CBofRe
 
 		// If we're capturing the screen, we have to convert the format first.
 		if (!_bUseBackdrop || pBackdrop == nullptr) {
-			Graphics::Surface tmp;
-			tmp.copyFrom(*pWnd->getSurface());
-			_bitmap.blitFrom(tmp.convertTo(_bitmap.format, nullptr, 0, _pPalette->getData(), PALETTE_COUNT),
-				cSrcRect,
-				cDestRect);
-			tmp.free();
-
+			Graphics::Surface *tmp = pWnd->getSurface()->rawSurface().convertTo(_bitmap.format, nullptr, 0, _pPalette->getData(), PALETTE_COUNT);
+			_bitmap.blitFrom(*tmp, cSrcRect, cDestRect);
+			tmp->free();
+			delete tmp;
 		} else {
 			// Optimization to use the window's backdrop bitmap instead of doing
 			// an actual screen capture.

--- a/engines/crab/image/Image.cpp
+++ b/engines/crab/image/Image.cpp
@@ -76,8 +76,8 @@ bool Image::load(const Common::Path &path) {
 	ImageDecoder decoder;
 
 	if (fileOpen(path, &file) && decoder.loadStream(file)) {
-		_texture = new Graphics::ManagedSurface(decoder.getSurface()->w, decoder.getSurface()->h, *g_engine->_format);
-		_texture->blitFrom(decoder.getSurface());
+		_texture = new Graphics::ManagedSurface();
+		_texture->convertFrom(*decoder.getSurface(), *g_engine->_format);
 		_w = _texture->w;
 		_h = _texture->h;
 
@@ -207,23 +207,27 @@ void Image::draw(const int &x, const int &y, Rect *clip, const TextureFlipType &
 	case FLIP_D:
 		s.surfacePtr()->flipHorizontal(Common::Rect(s.w, s.h));
 		rotated_surf = rotate(s, kImageRotateBy270);
-		s.copyFrom(rotated_surf);
+		s.copyFrom(*rotated_surf);
+		delete rotated_surf;
 		break;
 
 	case FLIP_DX:
 		rotated_surf = rotate(s, kImageRotateBy90);
-		s.copyFrom(rotated_surf);
+		s.copyFrom(*rotated_surf);
+		delete rotated_surf;
 		break;
 
 	case FLIP_DY:
 		rotated_surf = rotate(s, kImageRotateBy270);
-		s.copyFrom(rotated_surf);
+		s.copyFrom(*rotated_surf);
+		delete rotated_surf;
 		break;
 
 	case FLIP_XYD:
 		s.surfacePtr()->flipVertical(Common::Rect(s.w, s.h));
 		rotated_surf = rotate(s, kImageRotateBy270);
-		s.copyFrom(rotated_surf);
+		s.copyFrom(*rotated_surf);
+		delete rotated_surf;
 		break;
 
 	default:

--- a/engines/director/tests.cpp
+++ b/engines/director/tests.cpp
@@ -120,8 +120,9 @@ void Window::testFontScaling() {
 		k.loadStream(in);
 
 		Graphics::Surface *res = k.getSurface()->convertTo(_wm->_pixelformat, k.getPalette(), k.getPaletteSize(), _wm->getPalette(), _wm->getPaletteSize(), Graphics::kDitherNaive);
+		surface.blitFrom(*res, Common::Point(400, 280));
+		delete res;
 
-		surface.blitFrom(res, Common::Point(400, 280));
 		in.close();
 	} else {
 		warning("b_importFileInto(): Cannot open file %s", path.toString().c_str());

--- a/engines/griffon/resources.cpp
+++ b/engines/griffon/resources.cpp
@@ -144,7 +144,8 @@ Graphics::ManagedSurface *GriffonEngine::loadImage(const char *name, bool colork
 	bitmapDecoder.loadStream(file);
 	file.close();
 
-	Graphics::ManagedSurface *surface = new Graphics::ManagedSurface(bitmapDecoder.getSurface()->convertTo(g_system->getScreenFormat()));
+	Graphics::ManagedSurface *surface = new Graphics::ManagedSurface();
+	surface->convertFrom(*bitmapDecoder.getSurface(), g_system->getScreenFormat());
 
 	if (colorkey)
 		surface->surfacePtr()->applyColorKey(255, 0, 255);

--- a/engines/mm/mm1/data/monsters.cpp
+++ b/engines/mm/mm1/data/monsters.cpp
@@ -97,7 +97,7 @@ Graphics::ManagedSurface Monsters::getMonsterImage(int imgNum) {
 	if (!decoder.loadStream(*entry, 104, 96))
 		error("Failed decoding monster image");
 
-	img.copyFrom(decoder.getSurface());
+	img.copyFrom(*decoder.getSurface());
 
 	return img;
 }

--- a/engines/mm/mm1/maps/maps.cpp
+++ b/engines/mm/mm1/maps/maps.cpp
@@ -362,7 +362,7 @@ void Maps::loadTile() {
 			TILE_WIDTHS[i], TILE_HEIGHTS[i]))
 			error("Failed decoding tile");
 
-		tiles[i].copyFrom(decoder.getSurface());
+		tiles[i].copyFrom(*decoder.getSurface());
 	}
 }
 

--- a/engines/mm/mm1/views/title.cpp
+++ b/engines/mm/mm1/views/title.cpp
@@ -51,7 +51,7 @@ bool Title::msgFocus(const FocusMessage &msg) {
 		if (decoder.loadFile(Common::Path(
 			Common::String::format(g_engine->isEnhanced() ?
 				"gfx/screen%d" : "screen%d", i)))) {
-			_screens[i].copyFrom(decoder.getSurface());
+			_screens[i].copyFrom(*decoder.getSurface());
 		} else {
 			error("Could not load title screen");
 		}

--- a/engines/mtropolis/assets.cpp
+++ b/engines/mtropolis/assets.cpp
@@ -562,7 +562,9 @@ void CachedMToon::decompressQuickTimeFrame(const Common::Array<uint8> &data, siz
 	}
 
 	// Clone the decompressed frame
-	_decompressedFrames[frameIndex].reset(new Graphics::ManagedSurface(surface));
+	Graphics::ManagedSurface *surfaceCopy = new Graphics::ManagedSurface();
+	surfaceCopy->copyFrom(*surface);
+	_decompressedFrames[frameIndex].reset(surfaceCopy);
 }
 
 template<class TSrcNumber, uint32 TSrcLiteralMask, uint32 TSrcTransparentSkipMask, class TDestNumber, uint32 TDestLiteralMask, uint32 TDestTransparentSkipMask>
@@ -636,7 +638,10 @@ void CachedMToon::optimizeNonTemporal(const Graphics::PixelFormat &targetFormatR
 					optimizedSurfRef = srcSurface;
 				} else {
 					optimizedSurfRef.reset();
-					optimizedSurfRef.reset(new Graphics::ManagedSurface(srcSurface->surfacePtr()->convertTo(targetFormat)));
+
+					Graphics::ManagedSurface *newSurface = new Graphics::ManagedSurface();
+					newSurface->convertFrom(*srcSurface, targetFormat);
+					optimizedSurfRef.reset(newSurface);
 				}
 			} else {
 				optimizedSurfRef = srcSurface;

--- a/engines/nancy/state/logo.cpp
+++ b/engines/nancy/state/logo.cpp
@@ -114,7 +114,7 @@ void Logo::init() {
 // play the video before the game logo
 void Logo::playIntroVideo() {
 	if (_tvdVideoDecoder.needsUpdate()) {
-		_videoObj._drawSurface.blitFrom(_tvdVideoDecoder.decodeNextFrame());
+		_videoObj._drawSurface.blitFrom(*_tvdVideoDecoder.decodeNextFrame());
 		_videoObj.setVisible(true);
 	}
 	if (_tvdVideoDecoder.endOfVideo() || (g_nancy->_input->getInput().input & NancyInput::kLeftMouseButtonDown)) {

--- a/engines/tetraedge/te/te_images_sequence.cpp
+++ b/engines/tetraedge/te/te_images_sequence.cpp
@@ -101,7 +101,7 @@ bool TeImagesSequence::load(const Common::FSNode &directory) {
 			_height = pngsurf->h;
 			if (_width < 100 && _height < 100) {
 				Graphics::ManagedSurface *surf = new Graphics::ManagedSurface();
-				surf->copyFrom(pngsurf);
+				surf->copyFrom(*pngsurf);
 				_cachedSurfaces.push_back(surf);
 			} else {
 				_cachedSurfaces.push_back(nullptr);

--- a/engines/twine/movies.cpp
+++ b/engines/twine/movies.cpp
@@ -301,7 +301,7 @@ void Movies::prepareGIF(int index) {
 	_engine->setPalette(0, decoder.getPaletteColorCount(), decoder.getPalette());
 	Graphics::ManagedSurface& target = _engine->_frontVideoBuffer;
 	const Common::Rect surfaceBounds(0, 0, surface->w, surface->h);
-	target.transBlitFrom(surface, surfaceBounds, target.getBounds(), 0, false, 0, 0xff, nullptr, true);
+	target.transBlitFrom(*surface, surfaceBounds, target.getBounds(), 0, false, 0, 0xff, nullptr, true);
 	debug(2, "Show gif with id %i from %s", index, Resources::HQR_FLAGIF_FILE);
 	delete stream;
 	_engine->delaySkip(5000);

--- a/engines/twine/slideshow.cpp
+++ b/engines/twine/slideshow.cpp
@@ -68,7 +68,7 @@ private:
 		}
 
 		Graphics::ManagedSurface &target = _engine->_frontVideoBuffer;
-		target.blitFrom(src);
+		target.blitFrom(*src);
 
 		if (decoder.hasPalette()) {
 			setPalette(decoder.getPalette(), decoder.getPaletteColorCount());

--- a/engines/ultima/ultima8/gumps/cru_credits_gump.cpp
+++ b/engines/ultima/ultima8/gumps/cru_credits_gump.cpp
@@ -61,7 +61,8 @@ CruCreditsGump::CruCreditsGump(Common::SeekableReadStream *txtrs,
 	if (decoder.loadStream(*bmprs)) {
 		// This does an extra copy via the ManagedSurface, but it's a once-off.
 		const Graphics::Surface *bmpsurf = decoder.getSurface();
-		Graphics::ManagedSurface ms(bmpsurf);
+		Graphics::ManagedSurface ms;
+		ms.copyFrom(*bmpsurf);
 		ms.setPalette(decoder.getPalette(), 0, decoder.getPaletteColorCount());
 		Common::Rect srcRect(640, 480);
 		_background->Blit(ms, srcRect, 0, 0);

--- a/engines/ultima/ultima8/gumps/cru_demo_gump.cpp
+++ b/engines/ultima/ultima8/gumps/cru_demo_gump.cpp
@@ -52,7 +52,8 @@ CruDemoGump::CruDemoGump(Common::SeekableReadStream *bmprs, uint32 flags, int32 
 	if (decoder.loadStream(*bmprs)) {
 		// This does an extra copy via the ManagedSurface, but it's a once-off.
 		const Graphics::Surface *bmpsurf = decoder.getSurface();
-		Graphics::ManagedSurface ms(bmpsurf);
+		Graphics::ManagedSurface ms;
+		ms.copyFrom(*bmpsurf);
 		ms.setPalette(decoder.getPalette(), 0, decoder.getPaletteColorCount());
 		Common::Rect srcRect(640, 480);
 		_background->Blit(ms, srcRect, 0, 0);

--- a/engines/ultima/ultima8/gumps/minimap_gump.cpp
+++ b/engines/ultima/ultima8/gumps/minimap_gump.cpp
@@ -143,27 +143,27 @@ void MiniMapGump::PaintThis(RenderSurface *surf, int32 lerp_factor, bool scaled)
 		_minimaps[mapNum] = minimap;
 	}
 
-	Graphics::ManagedSurface ms(minimap->getSurface(), DisposeAfterUse::NO);
+	const Graphics::Surface *ms = minimap->getSurface();
 	Common::Rect r(sx, sy, sx + dims.width(), sy + dims.height());
 
 	if (r.left < 0) {
 		dx -= r.left;
 		r.left = 0;
 	}
-	if (r.right > ms.w) {
-		r.right = ms.w;
+	if (r.right > ms->w) {
+		r.right = ms->w;
 	}
 
 	if (r.top < 0) {
 		dy -= r.top;
 		r.top = 0;
 	}
-	if (r.bottom > ms.h) {
-		r.bottom = ms.h;
+	if (r.bottom > ms->h) {
+		r.bottom = ms->h;
 	}
 
 	if (!r.isEmpty()) {
-		surf->CrossKeyBlitMap(ms, r, dx, dy, map, KEY_COLOR);
+		surf->CrossKeyBlitMap(*ms, r, dx, dy, map, KEY_COLOR);
 	}
 
 	int32 ax = _ax - sx;

--- a/engines/wintermute/base/gfx/osystem/render_ticket.cpp
+++ b/engines/wintermute/base/gfx/osystem/render_ticket.cpp
@@ -98,7 +98,8 @@ bool RenderTicket::operator==(const RenderTicket &t) const {
 
 // Replacement for SDL2's SDL_RenderCopy
 void RenderTicket::drawToSurface(Graphics::Surface *_targetSurface) const {
-	Graphics::ManagedSurface src(getSurface());
+	Graphics::ManagedSurface src;
+	src.copyFrom(*getSurface());
 
 	Common::Rect clipRect;
 	clipRect.setWidth(getSurface()->w);
@@ -132,7 +133,9 @@ void RenderTicket::drawToSurface(Graphics::Surface *_targetSurface) const {
 }
 
 void RenderTicket::drawToSurface(Graphics::Surface *_targetSurface, Common::Rect *dstRect, Common::Rect *clipRect) const {
-	Graphics::ManagedSurface src(getSurface());
+	Graphics::ManagedSurface src;
+	src.copyFrom(*getSurface());
+
 	bool doDelete = false;
 	if (!clipRect) {
 		doDelete = true;

--- a/graphics/macgui/mactext-canvas.cpp
+++ b/graphics/macgui/mactext-canvas.cpp
@@ -654,7 +654,7 @@ void MacTextCanvas::render(int from, int to, int shadow) {
 
 			if (image) {
 				int xOffset = (_text[i].width - _text[i].charwidth) / 2;
-				surface->blitFrom(image, Common::Point(xOffset, _text[i].y));
+				surface->blitFrom(*image, Common::Point(xOffset, _text[i].y));
 
 				Common::Rect bbox(xOffset, _text[i].y, xOffset + image->w, _text[i].y + image->h);
 

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -454,9 +454,8 @@ void MacWindowManager::activateScreenCopy() {
 
 	if (_screen) {
 		if (!_screenCopy)
-			_screenCopy = new ManagedSurface(*_screen);	// Create a copy
-		else
-			*_screenCopy = *_screen;
+			_screenCopy = new ManagedSurface();
+		_screenCopy->copyFrom(*_screen); // Create a copy
 	} else {
 		Surface *surface = g_system->lockScreen();
 
@@ -485,7 +484,7 @@ void MacWindowManager::disableScreenCopy() {
 		return;
 
 	if (_screen)
-		*_screen = *_screenCopy; // restore screen
+		_screen->copyFrom(*_screenCopy); // restore screen
 
 	g_system->copyRectToScreen(_screenCopy->getBasePtr(0, 0), _screenCopy->pitch, 0, 0, _screenCopy->w, _screenCopy->h);
 }

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -666,6 +666,39 @@ public:
 	void copyFrom(const Surface &surf);
 
 	/**
+	 * Convert the data from another surface to a given pixel
+	 * format, reinitializing the surface to match the dimensions
+	 * of the passed surface.
+	 */
+	void convertFrom(const ManagedSurface &surf, const PixelFormat &fmt);
+
+	/**
+	 * Convert the data from another surface to a given pixel
+	 * format, reinitializing the surface to match the dimensions
+	 * of the passed surface.
+	 */
+	void convertFrom(const Surface &surf, const PixelFormat &fmt);
+
+	/**
+	 * Scale the data to the given size.
+	 *
+	 * @param newWidth   The resulting width.
+	 * @param newHeight  The resulting height.
+	 * @param filtering  Whether or not to use bilinear filtering.
+	 */
+	ManagedSurface *scale(int16 newWidth, int16 newHeight, bool filtering = false) const;
+
+	/**
+	 * @brief Rotoscale function; this returns a transformed version of this surface after rotation and
+	 * scaling. Please do not use this if angle == 0, use plain old scaling function.
+	 *
+	 * @param transform a TransformStruct wrapping the required info. @see TransformStruct
+	 * @param filtering Whether or not to use bilinear filtering.
+	 *
+	 */
+	ManagedSurface *rotoscale(const TransformStruct &transform, bool filtering = false) const;
+
+	/**
 	 * Draw a line.
 	 */
 	void drawLine(int x0, int y0, int x1, int y1, uint32 color) {

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -154,11 +154,13 @@ public:
 	 * If disposeAfterUse flag is set (default), the surface will reuse all structures
 	 * from the surface and destroy it, otherwise it will make a copy.
 	 */
+	WARN_DEPRECATED("Use copyFrom() instead")
 	ManagedSurface(Surface *surf, DisposeAfterUse::Flag disposeAfterUse = DisposeAfterUse::YES);
 
 	/**
 	 * Create a managed surface from plain Surface.
 	 */
+	WARN_DEPRECATED("Use copyFrom() instead")
 	ManagedSurface(const Surface *surf);
 
 	/**
@@ -190,6 +192,7 @@ public:
 	 *
 	 * @note If the source has a managed surface, it will be duplicated.
 	 */
+	WARN_DEPRECATED("Use copyFrom() instead")
 	ManagedSurface &operator=(const ManagedSurface &surf);
 
 	/**

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -688,8 +688,10 @@ bool ThemeEngine::addBitmap(const Common::String &filename, const Common::String
 			}
 		}
 
-		if (srcSurface && srcSurface->format.bytesPerPixel != 1)
-			surf = new Graphics::ManagedSurface(srcSurface->convertTo(_overlayFormat));
+		if (srcSurface && srcSurface->format.bytesPerPixel != 1) {
+			surf = new Graphics::ManagedSurface();
+			surf->convertFrom(*srcSurface, _overlayFormat);
+		}
 #else
 		error("No PNG support compiled in");
 #endif
@@ -709,17 +711,17 @@ bool ThemeEngine::addBitmap(const Common::String &filename, const Common::String
 			}
 		}
 
-		if (srcSurface && srcSurface->format.bytesPerPixel != 1)
-			surf = new Graphics::ManagedSurface(srcSurface->convertTo(_overlayFormat));
+		if (srcSurface && srcSurface->format.bytesPerPixel != 1) {
+			surf = new Graphics::ManagedSurface();
+			surf->convertFrom(*srcSurface, _overlayFormat);
+		}
 
 		if (surf)
 			surf->setTransparentColor(surf->format.RGBToColor(0xFF, 0x00, 0xFF));
 	}
 
 	if (_scaleFactor != 1.0 && surf) {
-		Graphics::Surface *tmp2 = surf->rawSurface().scale(surf->w * _scaleFactor, surf->h * _scaleFactor, false);
-
-		Graphics::ManagedSurface *surf2 = new Graphics::ManagedSurface(tmp2);
+		Graphics::ManagedSurface *surf2 = surf->scale(surf->w * _scaleFactor, surf->h * _scaleFactor, false);
 
 		if (surf->hasTransparentColor())
 			surf2->setTransparentColor(surf->getTransparentColor());

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -605,7 +605,7 @@ const Graphics::ManagedSurface *scaleGfx(const Graphics::ManagedSurface *gfx, in
 	w = nw;
 	h = nh;
 
-	return new Graphics::ManagedSurface(gfx->rawSurface().scale(w, h, filtering));
+	return gfx->scale(w, h, filtering);
 }
 
 PicButtonWidget::PicButtonWidget(GuiObject *boss, int x, int y, int w, int h, bool scale, const Common::U32String &tooltip, uint32 cmd, uint8 hotkey)
@@ -660,7 +660,8 @@ void PicButtonWidget::setGfx(const Graphics::ManagedSurface *gfx, int statenum, 
 }
 
 void PicButtonWidget::setGfx(const Graphics::Surface *gfx, int statenum, bool scale) {
-	const Graphics::ManagedSurface *tmpGfx = new Graphics::ManagedSurface(gfx);
+	Graphics::ManagedSurface *tmpGfx = new Graphics::ManagedSurface();
+	tmpGfx->copyFrom(*gfx);
 	setGfx(tmpGfx, statenum, scale);
 	delete tmpGfx;
 }
@@ -993,7 +994,8 @@ void GraphicsWidget::setGfx(const Graphics::ManagedSurface *gfx, bool scale) {
 }
 
 void GraphicsWidget::setGfx(const Graphics::Surface *gfx, bool scale) {
-	const Graphics::ManagedSurface *tmpGfx = new Graphics::ManagedSurface(gfx);
+	Graphics::ManagedSurface *tmpGfx = new Graphics::ManagedSurface();
+	tmpGfx->copyFrom(*gfx);
 	setGfx(tmpGfx, scale);
 	delete tmpGfx;
 }

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -373,7 +373,8 @@ Graphics::ManagedSurface *loadSurfaceFromFile(const Common::String &name, int re
 			if (!srcSurface) {
 				warning("Failed to load surface : %s", name.c_str());
 			} else if (srcSurface->format.bytesPerPixel != 1) {
-				surf = new Graphics::ManagedSurface(srcSurface);
+				surf = new Graphics::ManagedSurface();
+				surf->copyFrom(*srcSurface);
 			}
 		} else {
 			debug(5, "GridWidget: Cannot read file '%s'", name.c_str());


### PR DESCRIPTION
As discussed in https://github.com/scummvm/scummvm/commit/7559ecdf84fff0e2d8bf82001e27d1dd21bc54f8#r142840479, there is some ambiguity about whether some of the `ManagedSurface` constructors copy the pixel data or reuse the memory from the original surface. I also noticed that because those construtors receive a reference rather than a pointer, it's really easy to use it by accident when supplying a pointer to functions like `blitFrom` instead of a reference. This PR deprecates these methods and adapts most of the previous users of it.

There are a few places in the GUI and Wintermute engines where the additional `copyFrom` call shouldn't be necessary, but I've added it to reflect the behaviour of the old code.

The remaining users of the deprecated methods are SLUDGE (which will be addressed in a follow-up PR that refactors `blendBlitTo`), and Nancy (which uses the copy constructors with `Common::Array`, and might be more complicated to deal with).