### PR TITLE
COMMON: Avoid including engine headers in common code for DebugChannelDef

### DIFF
--- a/audio/decoders/quicktime.h
+++ b/audio/decoders/quicktime.h
@@ -35,6 +35,7 @@
 #include "common/types.h"
 
 namespace Common {
+	class Path;
 	class SeekableReadStream;
 	class String;
 }

--- a/backends/audiocd/win32/win32-audiocd.cpp
+++ b/backends/audiocd/win32/win32-audiocd.cpp
@@ -54,6 +54,7 @@
 #include "common/array.h"
 #include "common/config-manager.h"
 #include "common/debug.h"
+#include "common/fs.h"
 #include "common/mutex.h"
 #include "common/queue.h"
 #include "common/str.h"

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -25,6 +25,8 @@
 #include "backends/graphics/opengl/framebuffer.h"
 #include "backends/graphics/windowed.h"
 
+#include "base/plugins.h"
+
 #include "common/frac.h"
 #include "common/mutex.h"
 #include "common/ustr.h"

--- a/backends/networking/curl/url.cpp
+++ b/backends/networking/curl/url.cpp
@@ -23,6 +23,7 @@
 #include <curl/curl.h>
 #include "backends/networking/curl/url.h"
 #include "common/debug.h"
+#include "common/textconsole.h"
 
 namespace Networking {
 

--- a/backends/networking/enet/socket.cpp
+++ b/backends/networking/enet/socket.cpp
@@ -24,6 +24,7 @@
 #include "backends/networking/enet/source/enet.h"
 #include "backends/networking/enet/socket.h"
 #include "common/debug.h"
+#include "common/textconsole.h"
 
 namespace Networking {
 

--- a/common/compression/gzio.cpp
+++ b/common/compression/gzio.cpp
@@ -39,6 +39,7 @@
 #include "common/stream.h"
 #include "common/ptr.h"
 #include "common/memstream.h"
+#include "common/textconsole.h"
 #include "common/compression/deflate.h"
 
 

--- a/common/compression/powerpacker.cpp
+++ b/common/compression/powerpacker.cpp
@@ -22,6 +22,7 @@
 #include "common/compression/powerpacker.h"
 #include "common/memstream.h"
 #include "common/debug.h"
+#include "common/textconsole.h"
 
 namespace Common {
 

--- a/common/debug-channels.h
+++ b/common/debug-channels.h
@@ -30,7 +30,21 @@
 #include "common/singleton.h"
 #include "common/str.h"
 
-#include "engines/metaengine.h"
+/**
+ * debug channels structure
+ */
+struct DebugChannelDef {
+	uint32 channel;				/*!< enum value, channel id, e.g. kDebugGlobalDetection */
+	const char *name;			/*!< name of debug channel, e.g. "detection" */
+	const char *description;	/*!< description of debug channel, e.g. "track scripts" */
+};
+
+/**
+ * delimiter of the array of DebugChannelDef
+ */
+#define DEBUG_CHANNEL_END {0, NULL, NULL}
+
+extern const DebugChannelDef gDebugChannels[];
 
 namespace Common {
 

--- a/common/debug.h
+++ b/common/debug.h
@@ -24,8 +24,6 @@
 
 #include "common/scummsys.h"
 
-#include "engines/metaengine.h"
-
 #ifdef DISABLE_TEXT_CONSOLE
 
 inline void debug(const char *s, ...) {}
@@ -166,8 +164,6 @@ enum GlobalDebugLevels {
 	kDebugLevelMainGUI,
 	kDebugLevelMacGUI,
 };
-
-extern const DebugChannelDef gDebugChannels[];
 
 /** @} */
 

--- a/common/events.h
+++ b/common/events.h
@@ -23,6 +23,7 @@
 #define COMMON_EVENTS_H
 
 #include "common/keyboard.h"
+#include "common/path.h"
 #include "common/queue.h"
 #include "common/rect.h"
 #include "common/noncopyable.h"

--- a/engines/access/resources.h
+++ b/engines/access/resources.h
@@ -25,6 +25,7 @@
 #include "common/scummsys.h"
 #include "common/array.h"
 #include "common/language.h"
+#include "common/path.h"
 #include "common/rect.h"
 #include "common/str-array.h"
 #include "common/stream.h"

--- a/engines/adl/console.h
+++ b/engines/adl/console.h
@@ -25,6 +25,7 @@
 #include "gui/debugger.h"
 
 #include "common/hashmap.h"
+#include "common/path.h"
 
 namespace Common {
 class String;

--- a/engines/ags/lib/freetype-2.1.3/ftutil.cpp
+++ b/engines/ags/lib/freetype-2.1.3/ftutil.cpp
@@ -41,6 +41,7 @@
 #include "ags/lib/freetype-2.1.3/ftmemory.h"
 
 #include "common/debug.h"
+#include "common/textconsole.h"
 
 
 namespace AGS3 {

--- a/engines/asylum/system/text.h
+++ b/engines/asylum/system/text.h
@@ -22,6 +22,7 @@
 #ifndef ASYLUM_SYSTEM_TEXT_H
 #define ASYLUM_SYSTEM_TEXT_H
 
+#include "common/ptr.h"
 #include "common/rect.h"
 #include "common/scummsys.h"
 #include "graphics/font.h"

--- a/engines/bagel/dialogs/save_dialog.h
+++ b/engines/bagel/dialogs/save_dialog.h
@@ -29,6 +29,8 @@
 #include "bagel/boflib/gui/button.h"
 #include "bagel/boflib/gui/edit_text.h"
 
+#include "engines/savestate.h"
+
 namespace Bagel {
 
 #define NUM_BUTTONS 6

--- a/engines/chewy/chewy.cpp
+++ b/engines/chewy/chewy.cpp
@@ -22,6 +22,7 @@
 #include "common/config-manager.h"
 #include "common/fs.h"
 #include "common/system.h"
+#include "engines/metaengine.h"
 #include "engines/util.h"
 #include "chewy/chewy.h"
 #include "chewy/cursor.h"

--- a/engines/chewy/chewy.h
+++ b/engines/chewy/chewy.h
@@ -31,6 +31,7 @@
 #include "common/memstream.h"
 #include "common/random.h"
 #include "engines/engine.h"
+#include "engines/savestate.h"
 #include "graphics/screen.h"
 
 namespace Chewy {

--- a/engines/chewy/detail.h
+++ b/engines/chewy/detail.h
@@ -22,6 +22,7 @@
 #ifndef CHEWY_DETAIL_H
 #define CHEWY_DETAIL_H
 
+#include "common/path.h"
 #include "common/scummsys.h"
 #include "common/stream.h"
 #include "chewy/ngstypes.h"

--- a/engines/crab/GameParam.h
+++ b/engines/crab/GameParam.h
@@ -32,6 +32,8 @@
 #define CRAB_GAMEPARAM_H
 
 #include "common/hashmap.h"
+#include "common/hash-str.h"
+#include "common/list.h"
 #include "common/rect.h"
 #include "common/str.h"
 #include "crab/loaders.h"

--- a/engines/crab/TMX/TMXLayer.h
+++ b/engines/crab/TMX/TMXLayer.h
@@ -35,6 +35,8 @@
 #include "crab/image/Image.h"
 #include "crab/TMX/TileInfo.h"
 
+#include "common/list.h"
+
 namespace Crab {
 
 namespace TMX {

--- a/engines/crab/image/ImageManager.h
+++ b/engines/crab/image/ImageManager.h
@@ -38,6 +38,8 @@
 #include "crab/image/Image.h"
 #include "crab/TMX/TMXTileSet.h"
 
+#include "common/hashmap.h"
+
 namespace Crab {
 
 // We use this object as the key for all image assets

--- a/engines/crab/loaders.h
+++ b/engines/crab/loaders.h
@@ -32,6 +32,7 @@
 #define CRAB_LOADERS_H
 
 #include "common/debug.h"
+#include "common/path.h"
 #include "common/str.h"
 #include "crab/color.h"
 #include "crab/gametype.h"

--- a/engines/cryomni3d/dialogs_manager.h
+++ b/engines/cryomni3d/dialogs_manager.h
@@ -25,6 +25,7 @@
 #include "common/array.h"
 #include "common/hash-str.h"
 #include "common/hashmap.h"
+#include "common/path.h"
 #include "common/rect.h"
 #include "common/str.h"
 #include "common/str-array.h"

--- a/engines/cryomni3d/font_manager.h
+++ b/engines/cryomni3d/font_manager.h
@@ -23,6 +23,7 @@
 #define CRYOMNI3D_FONT_MANAGER_H
 
 #include "common/array.h"
+#include "common/path.h"
 #include "common/str.h"
 #include "common/str-enc.h"
 #include "common/ustr.h"

--- a/engines/draci/font.h
+++ b/engines/draci/font.h
@@ -23,6 +23,7 @@
 #define DRACI_FONT_H
 
 #include "graphics/font.h"
+#include "common/path.h"
 
 namespace Draci {
 

--- a/engines/freescape/gfx.h
+++ b/engines/freescape/gfx.h
@@ -22,6 +22,7 @@
 #ifndef FREESCAPE_GFX_H
 #define FREESCAPE_GFX_H
 
+#include "common/hashmap.h"
 #include "common/rendermode.h"
 #include "common/rect.h"
 

--- a/engines/hopkins/graphics.h
+++ b/engines/hopkins/graphics.h
@@ -25,6 +25,7 @@
 #include "common/scummsys.h"
 #include "common/array.h"
 #include "common/endian.h"
+#include "common/path.h"
 #include "common/rect.h"
 #include "graphics/surface.h"
 

--- a/engines/hpl1/debug.h
+++ b/engines/hpl1/debug.h
@@ -23,6 +23,7 @@
 #define HPL1_DEBUG_H
 
 #include "common/debug.h"
+#include "common/textconsole.h"
 
 #define HPL1_UNIMPLEMENTED(fnName) error("call to unimplemented function " #fnName)
 

--- a/engines/hypno/boyz/boyz.cpp
+++ b/engines/hypno/boyz/boyz.cpp
@@ -24,6 +24,9 @@
 
 #include "common/events.h"
 
+#include "engines/metaengine.h"
+#include "engines/savestate.h"
+
 namespace Hypno {
 
 static const chapterEntry rawChapterTable[] = {

--- a/engines/hypno/wet/wet.cpp
+++ b/engines/hypno/wet/wet.cpp
@@ -25,6 +25,9 @@
 
 #include "hypno/hypno.h"
 
+#include "engines/metaengine.h"
+#include "engines/savestate.h"
+
 namespace Hypno {
 
 static const char *failedDetectionError = \

--- a/engines/icb/fn_routines_ed.cpp
+++ b/engines/icb/fn_routines_ed.cpp
@@ -26,6 +26,7 @@
 
 #include "engines/icb/fn_routines.h"
 #include "common/debug.h"
+#include "common/textconsole.h"
 
 namespace ICB {
 

--- a/engines/macventure/windows.h
+++ b/engines/macventure/windows.h
@@ -31,6 +31,7 @@
 #define MACVENTURE_WINDOWS_H
 
 #include "common/rect.h"
+#include "common/str.h"
 #include "common/array.h"
 
 namespace MacVenture {

--- a/engines/mads/assets.h
+++ b/engines/mads/assets.h
@@ -23,6 +23,7 @@
 #define MADS_ASSETS_H
 
 #include "common/array.h"
+#include "common/path.h"
 #include "mads/palette.h"
 
 namespace MADS {

--- a/engines/mads/msurface.h
+++ b/engines/mads/msurface.h
@@ -23,6 +23,7 @@
 #define MADS_MSURFACE_H
 
 #include "common/scummsys.h"
+#include "common/path.h"
 #include "common/rect.h"
 #include "graphics/screen.h"
 #include "mads/palette.h"

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -25,6 +25,7 @@
 #include "common/scummsys.h"
 #include "common/error.h"
 #include "common/array.h"
+#include "common/debug-channels.h"
 
 #include "engines/achievements.h"
 #include "engines/game.h"
@@ -74,20 +75,6 @@ struct ExtraGuiOption {
 	byte groupId;        /*!< Id for the checkbox's group, or 0 for no group. */
 	byte groupLeaderId;  /*!< When this checkbox is unchecked, disable all checkboxes in this group. One leader per group. */
 };
-
-/**
- * debug channels structure
- */
-struct DebugChannelDef {
-	uint32 channel;				/*!< enum value, channel id, e.g. kDebugGlobalDetection */
-	const char *name;			/*!< name of debug channel, e.g. "detection" */
-	const char *description;	/*!< description of debug channel, e.g. "track scripts" */
-};
-
-/**
- * delimiter of the array of DebugChannelDef
- */
-#define DEBUG_CHANNEL_END {0, NULL, NULL}
 
 /**
  * Array of ExtraGuiOption structures.

--- a/engines/mm/shared/utils/strings_data.h
+++ b/engines/mm/shared/utils/strings_data.h
@@ -23,6 +23,7 @@
 #define MM_UTILS_STRINGS_DATA_H
 
 #include "common/hash-str.h"
+#include "common/path.h"
 
 namespace MM {
 

--- a/engines/mtropolis/runtime.h
+++ b/engines/mtropolis/runtime.h
@@ -22,6 +22,7 @@
 #ifndef MTROPOLIS_RUNTIME_H
 #define MTROPOLIS_RUNTIME_H
 
+#include "common/archive.h"
 #include "common/array.h"
 #include "common/events.h"
 #include "common/language.h"

--- a/engines/mutationofjb/font.h
+++ b/engines/mutationofjb/font.h
@@ -24,6 +24,7 @@
 
 #include "common/scummsys.h"
 #include "common/hashmap.h"
+#include "common/path.h"
 #include "graphics/font.h"
 #include "graphics/managed_surface.h"
 #include "graphics/surface.h"

--- a/engines/mutationofjb/widgets/labelwidget.h
+++ b/engines/mutationofjb/widgets/labelwidget.h
@@ -24,6 +24,8 @@
 
 #include "mutationofjb/widgets/widget.h"
 
+#include "common/str.h"
+
 namespace MutationOfJB {
 
 class LabelWidget : public Widget {

--- a/engines/nancy/commontypes.h
+++ b/engines/nancy/commontypes.h
@@ -24,6 +24,7 @@
 
 #include "common/rect.h"
 #include "common/array.h"
+#include "common/language.h"
 #include "common/str.h"
 #include "math/vector3d.h"
 

--- a/engines/nancy/cursor.h
+++ b/engines/nancy/cursor.h
@@ -23,6 +23,7 @@
 #define NANCY_CURSOR_H
 
 #include "common/array.h"
+#include "common/stream.h"
 
 #include "graphics/managed_surface.h"
 

--- a/engines/nancy/enginedata.h
+++ b/engines/nancy/enginedata.h
@@ -24,6 +24,9 @@
 
 #include "engines/nancy/commontypes.h"
 
+#include "common/hash-str.h"
+#include "common/path.h"
+
 namespace Nancy {
 
 // Data types corresponding to chunks found inside BOOT

--- a/engines/nancy/graphics.h
+++ b/engines/nancy/graphics.h
@@ -22,6 +22,8 @@
 #ifndef NANCY_GRAPHICS_H
 #define NANCY_GRAPHICS_H
 
+#include "common/path.h"
+
 #include "graphics/screen.h"
 
 #include "engines/nancy/font.h"

--- a/engines/nancy/renderobject.h
+++ b/engines/nancy/renderobject.h
@@ -22,6 +22,7 @@
 #ifndef NANCY_RENDEROBJECT_H
 #define NANCY_RENDEROBJECT_H
 
+#include "common/path.h"
 #include "graphics/managed_surface.h"
 
 namespace Nancy {

--- a/engines/nancy/util.h
+++ b/engines/nancy/util.h
@@ -21,6 +21,8 @@
 #ifndef NANCY_UTIL_H
 #define NANCY_UTIL_H
 
+#include "common/array.h"
+#include "common/path.h"
 #include "common/rect.h"
 #include "common/serializer.h"
 

--- a/engines/petka/objects/object.h
+++ b/engines/petka/objects/object.h
@@ -23,6 +23,7 @@
 #define PETKA_OBJECT_H
 
 #include "common/rect.h"
+#include "common/str.h"
 
 #include "petka/base.h"
 

--- a/engines/pink/gui.cpp
+++ b/engines/pink/gui.cpp
@@ -22,6 +22,8 @@
 #include "common/config-manager.h"
 #include "common/translation.h"
 
+#include "engines/metaengine.h"
+
 #include "graphics/macgui/macwindowmanager.h"
 #include "graphics/macgui/macmenu.h"
 

--- a/engines/playground3d/playground3d.cpp
+++ b/engines/playground3d/playground3d.cpp
@@ -21,6 +21,7 @@
 
 #include "common/scummsys.h"
 #include "common/config-manager.h"
+#include "common/error.h"
 #include "common/events.h"
 
 #include "graphics/renderer.h"

--- a/engines/sherlock/tattoo/widget_credits.h
+++ b/engines/sherlock/tattoo/widget_credits.h
@@ -24,6 +24,7 @@
 
 #include "common/array.h"
 #include "common/rect.h"
+#include "common/str.h"
 
 namespace Sherlock {
 

--- a/engines/stark/resources/anim.h
+++ b/engines/stark/resources/anim.h
@@ -22,6 +22,7 @@
 #ifndef STARK_RESOURCES_ANIM_H
 #define STARK_RESOURCES_ANIM_H
 
+#include "common/path.h"
 #include "common/rect.h"
 #include "common/str.h"
 

--- a/engines/stark/resources/image.h
+++ b/engines/stark/resources/image.h
@@ -22,6 +22,7 @@
 #ifndef STARK_RESOURCES_IMAGE_H
 #define STARK_RESOURCES_IMAGE_H
 
+#include "common/path.h"
 #include "common/rect.h"
 #include "common/str.h"
 

--- a/engines/stark/ui/cursor.h
+++ b/engines/stark/ui/cursor.h
@@ -23,6 +23,7 @@
 #define STARK_UI_CURSOR_H
 
 #include "common/rect.h"
+#include "common/str.h"
 #include "common/scummsys.h"
 
 namespace Stark {

--- a/engines/stark/ui/menu/fmvmenu.h
+++ b/engines/stark/ui/menu/fmvmenu.h
@@ -25,6 +25,8 @@
 #include "engines/stark/ui/menu/locationscreen.h"
 #include "engines/stark/visual/text.h"
 
+#include "common/path.h"
+
 namespace Stark {
 
 class FMVWidget;

--- a/engines/tetraedge/te/te_button_layout.h
+++ b/engines/tetraedge/te/te_button_layout.h
@@ -27,6 +27,8 @@
 #include "tetraedge/te/te_signal.h"
 #include "tetraedge/te/te_timer.h"
 
+#include "common/path.h"
+
 namespace Common {
 struct Point;
 }

--- a/engines/tetraedge/te/te_camera.h
+++ b/engines/tetraedge/te/te_camera.h
@@ -22,6 +22,7 @@
 #ifndef TETRAEDGE_TE_TE_CAMERA_H
 #define TETRAEDGE_TE_TE_CAMERA_H
 
+#include "common/path.h"
 #include "common/str.h"
 #include "math/ray.h"
 

--- a/engines/tetraedge/te/te_image.h
+++ b/engines/tetraedge/te/te_image.h
@@ -22,6 +22,7 @@
 #ifndef TETRAEDGE_TE_TE_IMAGE_H
 #define TETRAEDGE_TE_TE_IMAGE_H
 
+#include "common/fs.h"
 #include "common/ptr.h"
 #include "common/stream.h"
 #include "common/types.h"

--- a/engines/tetraedge/te/te_pick_mesh.h
+++ b/engines/tetraedge/te/te_pick_mesh.h
@@ -24,6 +24,8 @@
 
 #include "tetraedge/te/te_vector3f32.h"
 
+#include "common/array.h"
+
 namespace Tetraedge {
 
 class TePickMesh {

--- a/engines/tetraedge/te/te_xml_gui.h
+++ b/engines/tetraedge/te/te_xml_gui.h
@@ -22,6 +22,7 @@
 #ifndef TETRAEDGE_TE_TE_XML_GUI_H
 #define TETRAEDGE_TE_TE_XML_GUI_H
 
+#include "common/hash-str.h"
 #include "common/str.h"
 #include "common/path.h"
 

--- a/engines/titanic/star_control/fvector.cpp
+++ b/engines/titanic/star_control/fvector.cpp
@@ -22,6 +22,7 @@
 #include "titanic/star_control/fvector.h"
 #include "titanic/star_control/fpose.h"
 
+#include "common/str.h"
 #include "common/math.h"
 
 namespace Titanic {

--- a/engines/twine/renderer/redraw.h
+++ b/engines/twine/renderer/redraw.h
@@ -24,6 +24,7 @@
 
 #include "common/scummsys.h"
 #include "common/rect.h"
+#include "common/str.h"
 #include "twine/shared.h"
 
 namespace TwinE {

--- a/engines/ultima/shared/gfx/bitmap.h
+++ b/engines/ultima/shared/gfx/bitmap.h
@@ -23,6 +23,7 @@
 #define ULTIMA_BITMAP_H
 
 #include "ultima/shared/core/lzw.h"
+#include "common/path.h"
 #include "common/stream.h"
 #include "graphics/managed_surface.h"
 

--- a/engines/ultima/shared/gfx/sprites.h
+++ b/engines/ultima/shared/gfx/sprites.h
@@ -23,6 +23,7 @@
 #define ULTIMA_SPRITES_H
 
 #include "common/array.h"
+#include "common/path.h"
 #include "graphics/managed_surface.h"
 #include "ultima/shared/core/rect.h"
 

--- a/engines/ultima/ultima8/gfx/fonts/font_manager.h
+++ b/engines/ultima/ultima8/gfx/fonts/font_manager.h
@@ -24,6 +24,7 @@
 
 #include "ultima/shared/std/containers.h"
 #include "ultima/shared/std/string.h"
+#include "common/path.h"
 #include "graphics/font.h"
 
 namespace Ultima {

--- a/engines/ultima/ultima8/gfx/shape.h
+++ b/engines/ultima/ultima8/gfx/shape.h
@@ -24,6 +24,8 @@
 
 #include "ultima/shared/std/containers.h"
 
+#include "common/stream.h"
+
 namespace Ultima {
 namespace Ultima8 {
 

--- a/engines/vcruise/script.h
+++ b/engines/vcruise/script.h
@@ -24,6 +24,7 @@
 
 #include "common/array.h"
 #include "common/hashmap.h"
+#include "common/path.h"
 #include "common/ptr.h"
 #include "common/types.h"
 

--- a/engines/watchmaker/watchmaker.cpp
+++ b/engines/watchmaker/watchmaker.cpp
@@ -21,6 +21,7 @@
 
 #include "watchmaker/watchmaker.h"
 #include "watchmaker/console.h"
+#include "common/error.h"
 #include "engines/util.h"
 
 namespace Watchmaker {

--- a/engines/zvision/scripting/actions.h
+++ b/engines/zvision/scripting/actions.h
@@ -22,6 +22,7 @@
 #ifndef ZVISION_ACTIONS_H
 #define ZVISION_ACTIONS_H
 
+#include "common/path.h"
 #include "common/str.h"
 #include "common/rect.h"
 

--- a/engines/zvision/scripting/controls/hotmov_control.h
+++ b/engines/zvision/scripting/controls/hotmov_control.h
@@ -25,6 +25,7 @@
 #include "zvision/scripting/control.h"
 
 #include "common/array.h"
+#include "common/path.h"
 #include "common/rect.h"
 
 namespace Video {

--- a/engines/zvision/scripting/controls/lever_control.h
+++ b/engines/zvision/scripting/controls/lever_control.h
@@ -25,6 +25,7 @@
 #include "zvision/scripting/control.h"
 
 #include "common/list.h"
+#include "common/path.h"
 #include "common/rect.h"
 
 namespace Video {

--- a/engines/zvision/scripting/controls/titler_control.h
+++ b/engines/zvision/scripting/controls/titler_control.h
@@ -26,6 +26,7 @@
 
 #include "graphics/surface.h"
 
+#include "common/path.h"
 #include "common/rect.h"
 #include "common/array.h"
 

--- a/engines/zvision/scripting/effects/animation_effect.h
+++ b/engines/zvision/scripting/effects/animation_effect.h
@@ -23,6 +23,7 @@
 #define ZVISION_ANIMATION_NODE_H
 
 #include "zvision/scripting/scripting_effect.h"
+#include "common/path.h"
 #include "common/rect.h"
 #include "common/list.h"
 

--- a/graphics/fonts/amigafont.h
+++ b/graphics/fonts/amigafont.h
@@ -24,6 +24,10 @@
 
 #include "graphics/font.h"
 
+namespace Common {
+class SeekableReadStream;
+}
+
 namespace Graphics {
 
 class AmigaFont : public Font {

--- a/graphics/scaler/downscaler.cpp
+++ b/graphics/scaler/downscaler.cpp
@@ -19,6 +19,7 @@
  *
  */
 #include "common/debug.h"
+#include "common/textconsole.h"
 #include "graphics/scaler/downscaler.h"
 #include "graphics/scaler/intern.h"
 

--- a/graphics/tinygl/zbuffer.h
+++ b/graphics/tinygl/zbuffer.h
@@ -33,6 +33,7 @@
 #include "graphics/tinygl/gl.h"
 
 #include "common/rect.h"
+#include "common/textconsole.h"
 
 namespace TinyGL {
 


### PR DESCRIPTION
This makes the common code more self-contained, and should hopefully fix iOS and tvOS builds for now.