### PR TITLE
AGS: Parser fixes from upstream

### DIFF
--- a/engines/ags/engine/ac/parser.cpp
+++ b/engines/ags/engine/ac/parser.cpp
@@ -242,8 +242,13 @@ int parse_sentence(const char *src_text, int *numwords, short *wordarray, short 
 						const char *textStart = ++text; // begin with next char
 
 						// find where the next word ends
-						while ((text[0] == ',') || (Common::isAlnum((unsigned char)text[0]) != 0))
-							text++;
+						while ((text[0] == ',') || is_valid_word_char(text[0])) {
+							// shift beginning of potential multi-word each time we see a comma
+							if (text[0] == ',')
+								textStart = ++text;
+							else
+								text++;
+						}
 
 						continueSearching = 0;
 
@@ -251,8 +256,11 @@ int parse_sentence(const char *src_text, int *numwords, short *wordarray, short 
 							Common::strcpy_s(thisword, textStart);
 							thisword[text - textStart] = 0;
 							// forward past any multi-word alternatives
-							if (FindMatchingMultiWordWord(thisword, &text) >= 0)
+							if (FindMatchingMultiWordWord(thisword, &text) >= 0) {
+								if (text[0] == 0)
+									break;
 								continueSearching = 1;
+							}
 						}
 					}
 


### PR DESCRIPTION
AGS: Parser fixes from upstream

Compilation of three bug fixes to text parser I recently made in the AGS project, around alternatives syntax:
* stop parsing when reaching end during alternatives skipping (causing an out-of-bounds memory read)
* correctly skip over multi-word alternatives (incorrect parsing of alternative lists)
* use dedicated function to identify word boundaries (affecting dash and apostrophe containing alternatives)

Original PRs:
https://github.com/adventuregamestudio/ags/pull/2442
https://github.com/adventuregamestudio/ags/pull/2443

Just wanted to flag these, if there's a separate process for applying changes from upstream feel free to ignore this PR.