### PR TITLE
ANDROID: Improve shortcuts

### DIFF
--- a/backends/platform/android/org/scummvm/scummvm/CompatHelpers.java
+++ b/backends/platform/android/org/scummvm/scummvm/CompatHelpers.java
@@ -181,8 +181,8 @@ class CompatHelpers {
 
 	static class ShortcutCreator {
 		public static Intent createShortcutResultIntent(@NonNull Context context, String id, @NonNull Intent intent, @NonNull String label, @Nullable Drawable icon, @DrawableRes int fallbackIconId) {
-			if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-				return ShortcutCreatorO.createShortcutResultIntent(context, id, intent, label, icon, fallbackIconId);
+			if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N_MR1) {
+				return ShortcutCreatorN_MR1.createShortcutResultIntent(context, id, intent, label, icon, fallbackIconId);
 			} else {
 				return ShortcutCreatorOld.createShortcutResultIntent(context, id, intent, label, icon, fallbackIconId);
 			}
@@ -210,10 +210,9 @@ class CompatHelpers {
 			}
 		}
 
-		@RequiresApi(android.os.Build.VERSION_CODES.O)
-		private static class ShortcutCreatorO {
+		@RequiresApi(android.os.Build.VERSION_CODES.N_MR1)
+		private static class ShortcutCreatorN_MR1 {
 			public static Intent createShortcutResultIntent(Context context, String id, @NonNull Intent intent, @NonNull String label, @Nullable Drawable icon, @DrawableRes int fallbackIconId) {
-				ShortcutManager shortcutManager = context.getSystemService(ShortcutManager.class);
 				ShortcutInfo.Builder builder = new ShortcutInfo.Builder(context, id);
 				builder.setIntent(intent);
 				builder.setShortLabel(label);
@@ -227,7 +226,14 @@ class CompatHelpers {
 					bm = drawableToBitmap(icon);
 					builder.setIcon(Icon.createWithResource(context, fallbackIconId));
 				}
-				Intent result = shortcutManager.createShortcutResultIntent(builder.build());
+				Intent result = null;
+				if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+					final ShortcutManager shortcutManager = context.getSystemService(ShortcutManager.class);
+					result = shortcutManager.createShortcutResultIntent(si);
+				}
+				if (result == null) {
+					result = new Intent();
+				}
 				ShortcutCreatorOld.addToIntent(result, intent, label, bm);
 				return result;
 			}

--- a/backends/platform/android/org/scummvm/scummvm/CompatHelpers.java
+++ b/backends/platform/android/org/scummvm/scummvm/CompatHelpers.java
@@ -26,6 +26,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 
 class CompatHelpers {
@@ -188,6 +193,15 @@ class CompatHelpers {
 			}
 		}
 
+		public static void pushDynamicShortcut(@NonNull Context context, String id, @NonNull Intent intent, @NonNull String label, @Nullable Drawable icon, @DrawableRes int fallbackIconId) {
+			if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+				ShortcutCreatorR.pushDynamicShortcut(context, id, intent, label, icon, fallbackIconId);
+			} else if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N_MR1) {
+				ShortcutCreatorN_MR1.pushDynamicShortcut(context, id, intent, label, icon, fallbackIconId);
+			}
+			// No support for older versions
+		}
+
 		@SuppressWarnings("deprecation")
 		private static class ShortcutCreatorOld {
 			public static Intent createShortcutResultIntent(@NonNull Context context, String ignoredId, @NonNull Intent intent, @NonNull String label, @Nullable Drawable icon, @DrawableRes int fallbackIconId) {
@@ -212,20 +226,31 @@ class CompatHelpers {
 
 		@RequiresApi(android.os.Build.VERSION_CODES.N_MR1)
 		private static class ShortcutCreatorN_MR1 {
-			public static Intent createShortcutResultIntent(Context context, String id, @NonNull Intent intent, @NonNull String label, @Nullable Drawable icon, @DrawableRes int fallbackIconId) {
+			public static ShortcutInfo createShortcutInfo(Context context, String id, @NonNull Intent intent, @NonNull String label, @Nullable Icon icon) {
 				ShortcutInfo.Builder builder = new ShortcutInfo.Builder(context, id);
 				builder.setIntent(intent);
 				builder.setShortLabel(label);
+				builder.setIcon(icon);
+				HashSet<String> categories = new HashSet<>(1);
+				categories.add("actions.intent.START_GAME_EVENT");
+				builder.setCategories(categories);
+				return builder.build();
+			}
+
+			public static Intent createShortcutResultIntent(Context context, String id, @NonNull Intent intent, @NonNull String label, @Nullable Drawable icon, @DrawableRes int fallbackIconId) {
 				Bitmap bm;
+				Icon ic;
 				if (icon != null) {
 					bm = drawableToBitmap(icon);
-					builder.setIcon(Icon.createWithBitmap(bm));
+					ic = Icon.createWithBitmap(bm);
 				} else {
 					icon = DrawableCompat.getDrawable(context, fallbackIconId);
 					Objects.requireNonNull(icon);
 					bm = drawableToBitmap(icon);
-					builder.setIcon(Icon.createWithResource(context, fallbackIconId));
+					ic = Icon.createWithResource(context, fallbackIconId);
 				}
+				ShortcutInfo si = createShortcutInfo(context, id, intent, label, ic);
+
 				Intent result = null;
 				if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
 					final ShortcutManager shortcutManager = context.getSystemService(ShortcutManager.class);
@@ -236,6 +261,81 @@ class CompatHelpers {
 				}
 				ShortcutCreatorOld.addToIntent(result, intent, label, bm);
 				return result;
+			}
+
+			public static void pushDynamicShortcut(@NonNull Context context, String id, @NonNull Intent intent, @NonNull String label, @Nullable Drawable icon, @DrawableRes int fallbackIconId) {
+				Icon ic;
+				if (icon != null) {
+					ic = Icon.createWithBitmap(drawableToBitmap(icon));
+				} else {
+					ic = Icon.createWithResource(context, fallbackIconId);
+				}
+				ShortcutInfo si = createShortcutInfo(context, id, intent, label, ic);
+
+				final ShortcutManager shortcutManager = context.getSystemService(ShortcutManager.class);
+				if (shortcutManager.isRateLimitingActive()) {
+					return;
+				}
+				List<ShortcutInfo> shortcuts = shortcutManager.getDynamicShortcuts();
+				// Sort shortcuts by rank, timestamp and id
+				Collections.sort(shortcuts, new Comparator<ShortcutInfo>() {
+					@Override
+					public int compare(ShortcutInfo a, ShortcutInfo b) {
+						int ret = Integer.compare(a.getRank(), b.getRank());
+						if (ret != 0) {
+							return ret;
+						}
+
+						ret = Long.compare(a.getLastChangedTimestamp(), b.getLastChangedTimestamp());
+						if (ret != 0) {
+							return ret;
+						}
+
+						return a.getId().compareTo(b.getId());
+					}
+				});
+
+				// In old Android versions, only 4 shortcuts are displayed but 5 maximum are supported
+				// Problem: the last one added is not displayed... so stick to 4
+				int maxSize = Math.min(shortcutManager.getMaxShortcutCountPerActivity(), 4);
+				if (shortcuts.size() >= maxSize) {
+					int toRemove = shortcuts.size() - maxSize + 1;
+					ArrayList<String> toRemoveList = new ArrayList<>(toRemove);
+					// Remove the lowest rank, oldest shortcut if we need it
+					for(ShortcutInfo oldSi : shortcuts) {
+						if (oldSi.getId().equals(id)) {
+							// We will update it: no need to make space
+							toRemoveList.clear();
+							break;
+						}
+						if (toRemove > 0) {
+							toRemoveList.add(oldSi.getId());
+							toRemove -= 1;
+						}
+					}
+					shortcutManager.removeDynamicShortcuts(toRemoveList);
+				}
+				shortcuts = new ArrayList<>(1);
+				shortcuts.add(si);
+				shortcutManager.addDynamicShortcuts(shortcuts);
+				shortcutManager.reportShortcutUsed(id);
+			}
+		}
+
+		@RequiresApi(android.os.Build.VERSION_CODES.R)
+		private static class ShortcutCreatorR {
+			public static void pushDynamicShortcut(@NonNull Context context, String id, @NonNull Intent intent, @NonNull String label, @Nullable Drawable icon, @DrawableRes int fallbackIconId) {
+				Icon ic;
+				if (icon != null) {
+					ic = Icon.createWithBitmap(drawableToBitmap(icon));
+				} else {
+					ic = Icon.createWithResource(context, fallbackIconId);
+				}
+				ShortcutInfo si = ShortcutCreatorN_MR1.createShortcutInfo(context, id, intent, label, ic);
+
+				final ShortcutManager shortcutManager = context.getSystemService(ShortcutManager.class);
+				shortcutManager.pushDynamicShortcut(si);
+				// pushDynamicShortcut already reports usage
 			}
 		}
 

--- a/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
+++ b/backends/platform/android/org/scummvm/scummvm/ScummVMActivity.java
@@ -848,6 +848,9 @@ public class ScummVMActivity extends Activity implements OnKeyboardVisibilityLis
 				ScummVMActivity.this, ScummVMActivity.class);
 			setIntent(intent);
 			Log.d(ScummVM.LOG_TAG, "Current activity Intent is: " + data);
+			if (target != null) {
+				ShortcutCreatorActivity.pushShortcut(ScummVMActivity.this, target, intent);
+			}
 		}
 
 		@Override

--- a/backends/platform/android/org/scummvm/scummvm/ShortcutCreatorActivity.java
+++ b/backends/platform/android/org/scummvm/scummvm/ShortcutCreatorActivity.java
@@ -88,7 +88,7 @@ public class ShortcutCreatorActivity extends Activity {
 
 		File iconsPath = INIParser.getPath(parsedIniMap, "scummvm", "iconspath",
 			new File(getFilesDir(), "icons"));
-		FileInputStream[] packsStream = openFiles(iconsPath, "gui-icons.*\\.dat");
+		FileInputStream[] packsStream = openFiles(this, iconsPath, "gui-icons.*\\.dat");
 
 		_cache = new IconsCache(this, defaultStream, packsStream);
 
@@ -123,7 +123,7 @@ public class ShortcutCreatorActivity extends Activity {
 		setResult(RESULT_CANCELED);
 	}
 
-	private FileInputStream openFile(File path) {
+	static private FileInputStream openFile(File path) {
 		 try {
 			return new FileInputStream(path);
 		} catch (FileNotFoundException e) {
@@ -131,7 +131,7 @@ public class ShortcutCreatorActivity extends Activity {
 		}
 	}
 
-	private FileInputStream[] openFiles(File basePath, String regex) {
+	static private FileInputStream[] openFiles(Context context, File basePath, String regex) {
 		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N ||
 			!basePath.getPath().startsWith("/saf/")) {
 			// This is a standard filesystem path
@@ -157,7 +157,7 @@ public class ShortcutCreatorActivity extends Activity {
 		String treeName = baseName.substring(5, slash);
 		String path = baseName.substring(slash);
 
-		SAFFSTree tree = SAFFSTree.findTree(this, treeName);
+		SAFFSTree tree = SAFFSTree.findTree(context, treeName);
 		if (tree == null) {
 			return new FileInputStream[0];
 		}
@@ -273,6 +273,20 @@ public class ShortcutCreatorActivity extends Activity {
 			ret.add(String.format("icons/%s.png", _engineid).toLowerCase());
 
 			return ret;
+		}
+
+		public static Game loadGame(@NonNull Map<String, Map<String, String>> parsedIniMap, String target) {
+			Map<String, String> domain = parsedIniMap.get(target);
+			if (domain == null) {
+				return null;
+			}
+			String engineid = domain.get("engineid");
+			String gameid = domain.get("gameid");
+			String description = domain.get("description");
+			if (description == null) {
+				return null;
+			}
+			return new Game(target, engineid, gameid, description);
 		}
 
 		public static List<Game> loadGames(@NonNull Map<String, Map<String, String>> parsedIniMap) {


### PR DESCRIPTION
This PR does two things.
The shortcut support added recently is extended up to Nougat MR1 (7.1) as I missed a portability trick for this version.
Then, dynamic shortcuts are now supported.
This means that every time a game is started, a shortcut, available by long pressing the ScummVM icon in the launcher, is created and the history contains the 4 last launched games.
This also has the benefit to make shortcut pinning on launcher easier: you just have to long press in the shortcut list and move the shortcut on the launcher.
This should allow users without a launcher supporting shortcut widgets to still be able to pin them.

