### PR TITLE
NANCY: Highlight Done button in Game Setup

### DIFF
--- a/engines/nancy/state/setupmenu.cpp
+++ b/engines/nancy/state/setupmenu.cpp
@@ -179,7 +179,8 @@ void SetupMenu::init() {
 	_scrollbars[2]->setPosition(ConfMan.getInt("sfx_volume") / 255.0);
 
 	_exitButton = new UI::Button(5, _background._drawSurface,
-		_setupData->_buttonDownSrcs.back(), _setupData->_buttonDests.back());
+		_setupData->_buttonDownSrcs.back(), _setupData->_buttonDests.back(),
+		_setupData->_doneButtonHighlightSrc);
 	_exitButton->init();
 	_exitButton->setVisible(false);
 


### PR DESCRIPTION
Highlight "Done" on hover in Game Setup as the original games do and as is done for main menu buttons.