### PR TITLE
SCI: fix Hercules and CGA b/w transitions and remove unneeded class

### DIFF
--- a/engines/sci/graphics/gfxdrivers.cpp
+++ b/engines/sci/graphics/gfxdrivers.cpp
@@ -104,37 +104,8 @@ void SCI0_DOSPreVGADriver::assignPalette(const byte *colors) {
 void SCI0_DOSPreVGADriver::setPalette(const byte*, uint, uint) {
 	if (!_palNeedUpdate || !_colors)
 		return;
-	_palNeedUpdate = false;
-	byte *tmp = new byte[768]();
-	memcpy(tmp, _colors, _numColors * 3);
-	g_system->getPaletteManager()->setPalette(tmp, 0, 256);
-	delete[]tmp;
-}
-
-SCI0_EGADriver::SCI0_EGADriver() : SCI0_DOSPreVGADriver(16, 320, 200, 1) {
-	static const byte egaColors[] = {
-		0x00, 0x00, 0x00, 0x00, 0x00, 0xAA, 0x00, 0xAA, 0x00, 0x00, 0xAA, 0xAA,
-		0xAA, 0x00, 0x00, 0xAA, 0x00, 0xAA, 0xAA, 0x55, 0x00, 0xAA, 0xAA, 0xAA,
-		0x55, 0x55, 0x55, 0x55, 0x55, 0xFF, 0x55, 0xFF, 0x55, 0x55, 0xFF, 0xFF,
-		0xFF, 0x55, 0x55, 0xFF, 0x55, 0xFF, 0xFF, 0xFF, 0x55, 0xFF, 0xFF, 0xFF
-	};
-	assignPalette(egaColors);
-}
-
-void SCI0_EGADriver::copyRectToScreen(const byte *src, int pitch, int x, int y, int w, int h) {
-	byte *dst = _compositeBuffer;
-	pitch -= w;
-	for (int i = 0; i < h; ++i) {
-		for (int ii = 0; ii < w; ++ii)
-			*dst++ = *src++;
-		src += pitch;
-	}
-
-	g_system->copyRectToScreen(_compositeBuffer, w, x, y, w, h);
-}
-
-void SCI0_EGADriver::replaceCursor(const void *cursor, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor) {
-	CursorMan.replaceCursor(cursor, w, h, hotspotX, hotspotY, keycolor);
+	_palNeedUpdate = false;;
+	g_system->getPaletteManager()->setPalette(_colors, 0, _numColors);
 }
 
 SCI0_CGADriver::SCI0_CGADriver(bool emulateCGAModeOnEGACard) : SCI0_DOSPreVGADriver(4, 320, 200, 1), _cgaPatterns(nullptr), _disableMode5(emulateCGAModeOnEGACard) {

--- a/engines/sci/graphics/gfxdrivers.cpp
+++ b/engines/sci/graphics/gfxdrivers.cpp
@@ -36,6 +36,10 @@ Common::Point GfxDriver::getMousePos() const {
 	return g_system->getEventManager()->getMousePos();
 }
 
+void GfxDriver::clearRect(const Common::Rect &r) const {
+	g_system->fillScreen(r, 0);
+}
+
 GfxDefaultDriver::GfxDefaultDriver(uint16 screenWidth, uint16 screenHeight) : GfxDriver(screenWidth, screenHeight, 0, 1) {
 	switch (g_sci->getResMan()->getViewType()) {
 	case kViewEga:
@@ -409,6 +413,11 @@ Common::Point SCI0_CGABWDriver::getMousePos() const {
 	return res;
 }
 
+void SCI0_CGABWDriver::clearRect(const Common::Rect &r) const {
+	Common::Rect r2(r.left << 1, r.top << 1, r.right << 1, r.bottom << 1);
+	GfxDriver::clearRect(r2);
+}
+
 const char *SCI0_CGABWDriver::_driverFiles[2] = { "CGA320BW.DRV", "CGA320M.DRV" };
 
 SCI0_HerculesDriver::SCI0_HerculesDriver(int palIndex) : SCI0_DOSPreVGADriver(2, 720, 350, 0), _monochromePatterns(nullptr) {
@@ -501,6 +510,11 @@ Common::Point SCI0_HerculesDriver::getMousePos() const {
 	res.x = CLIP<int>(res.x - 40, 0, 639) >> 1;
 	res.y = CLIP<int>(res.y - 25, 0, 299) * 2 / 3;
 	return res;
+}
+
+void SCI0_HerculesDriver::clearRect(const Common::Rect &r) const {
+	Common::Rect r2((r.left << 1) + 40, (r.top & ~1) * 3 / 2 + (r.top & 1) + 25, (r.right << 1) + 40, (r.bottom & ~1) * 3 / 2 + (r.bottom & 1) + 25);
+	GfxDriver::clearRect(r2);
 }
 
 const char *SCI0_HerculesDriver::_driverFile = "HERCMONO.DRV";

--- a/engines/sci/graphics/gfxdrivers.h
+++ b/engines/sci/graphics/gfxdrivers.h
@@ -40,6 +40,7 @@ public:
 	virtual void copyRectToScreen(const byte *src, int pitch, int x, int y, int w, int h) = 0;
 	virtual void replaceCursor(const void *cursor, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor) = 0;
 	virtual Common::Point getMousePos() const;
+	virtual void clearRect(const Common::Rect &r) const;
 
 protected:
 	const uint16 _screenW;
@@ -100,6 +101,7 @@ public:
 	void copyRectToScreen(const byte *src, int pitch, int x, int y, int w, int h) override;
 	void replaceCursor(const void *cursor, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor) override;
 	Common::Point getMousePos() const override;
+	void clearRect(const Common::Rect &r) const override;
 	static bool validateMode() { return checkDriver(_driverFiles, 2); }
 private:
 	const byte *_monochromePatterns;
@@ -114,6 +116,7 @@ public:
 	void copyRectToScreen(const byte *src, int pitch, int x, int y, int w, int h) override;
 	void replaceCursor(const void *cursor, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor) override;
 	Common::Point getMousePos() const override;
+	void clearRect(const Common::Rect &r) const override;
 	static bool validateMode() { return checkDriver(&_driverFile, 1); }
 private:
 	const byte *_monochromePatterns;

--- a/engines/sci/graphics/gfxdrivers.h
+++ b/engines/sci/graphics/gfxdrivers.h
@@ -72,14 +72,6 @@ private:
 	const byte *_colors;
 };
 
-class SCI0_EGADriver final : public SCI0_DOSPreVGADriver {
-public:
-	SCI0_EGADriver();
-	~SCI0_EGADriver() override {}
-	void copyRectToScreen(const byte *src, int pitch, int x, int y, int w, int h) override;
-	void replaceCursor(const void *cursor, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor) override;
-};
-
 class SCI0_CGADriver final : public SCI0_DOSPreVGADriver {
 public:
 	SCI0_CGADriver(bool emulateCGAModeOnEGACard);

--- a/engines/sci/graphics/screen.cpp
+++ b/engines/sci/graphics/screen.cpp
@@ -161,9 +161,6 @@ GfxScreen::GfxScreen(ResourceManager *resMan, Common::RenderMode renderMode) : _
 		case Common::kRenderHercG:
 			_gfxDrv = new SCI0_HerculesDriver(renderMode == Common::kRenderHercG ? 1 : 0);
 			break;
-		case Common::kRenderEGA:
-			_gfxDrv = new SCI0_EGADriver();
-			break;
 		default:
 			break;
 		}

--- a/engines/sci/graphics/transitions.cpp
+++ b/engines/sci/graphics/transitions.cpp
@@ -25,6 +25,7 @@
 
 #include "sci/sci.h"
 #include "sci/engine/state.h"
+#include "sci/graphics/gfxdrivers.h"
 #include "sci/graphics/screen.h"
 #include "sci/graphics/palette.h"
 #include "sci/graphics/transitions.h"
@@ -283,12 +284,12 @@ void GfxTransitions::copyRectToScreen(const Common::Rect rect, bool blackoutFlag
 		_screen->copyRectToScreen(rect);
 	} else {
 		if (!_screen->getUpscaledHires()) {
-			g_system->fillScreen(rect, 0);
+			_screen->gfxDriver()->clearRect(rect);
 		} else {
 			Common::Rect upscaledRect = rect;
 			_screen->adjustToUpscaledCoordinates(upscaledRect.top, upscaledRect.left);
 			_screen->adjustToUpscaledCoordinates(upscaledRect.bottom, upscaledRect.right);
-			g_system->fillScreen(upscaledRect, 0);
+			_screen->gfxDriver()->clearRect(rect);
 		}
 	}
 }


### PR DESCRIPTION
I noticed that the transitions weren't scaled to the screen resolution. The engine used OSystem::fillScreen() for this which bypassed the mode specific rendering.

I also addressed some things mentioned by @ccawley2011 on the other PR by getting rid of the unneeded EGA driver implementation and an unneeded buffer. These were basically leftovers from when I started the project and didn't yet know what was really needed.