### PR TITLE
GUI: Fix crash in edit game dialog when plugins are unloaded

### DIFF
--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -476,9 +476,8 @@ void EditGameDialog::close() {
 
 	// Cleanup engine widgets before unloading its plugin
 	if (_engineOptions) {
-		// Switch back to Game tab before deleting the widget
-		_tabWidget->setActiveTab(0);
-		_tabWidget->removeWidget(_engineOptions);
+		// Remove the widget from the container before deleting the widget
+		_gameContainer->removeWidget(_engineOptions);
 		delete _engineOptions;
 	}
 


### PR DESCRIPTION
PR #5832 moved the engine options widget into a separate scroll container, but PR #5829 wasn't adapted for this and attempts to remove it from the tab container instead, leaving references to the deleted object.