### PR TITLE
GRAPHICS: replace deprecated operator

### DIFF
--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -41,7 +41,7 @@ ManagedSurface::ManagedSurface(const ManagedSurface &surf) :
 		w(_innerSurface.w), h(_innerSurface.h), pitch(_innerSurface.pitch), format(_innerSurface.format),
 		_disposeAfterUse(DisposeAfterUse::NO), _owner(nullptr),
 		_transparentColor(0), _transparentColorSet(false), _palette(nullptr) {
-	*this = surf;
+	this->copyFrom(surf);
 }
 
 ManagedSurface::ManagedSurface(int width, int height) :


### PR DESCRIPTION
Compiler warnings flagged that this should be using `copyFrom`:

```
graphics/managed_surface.cpp:44:8: warning: 'operator=' is deprecated: Use copyFrom() instead [-Wdeprecated-declarations]
        *this = surf;
              ^
./graphics/managed_surface.h:195:2: note: 'operator=' has been explicitly marked deprecated here
        WARN_DEPRECATED("Use copyFrom() instead")
        ^
./common/scummsys.h:447:47: note: expanded from macro 'WARN_DEPRECATED'
                #define WARN_DEPRECATED(msg) __attribute__((__deprecated__(msg)))
                                                            ^
1 warning generated.
```

Looks like this might have gotten missed in ff530edcb1f0814cc54f649e678405178e1bd197.