### PR TITLE
3DS: Limit the linear heap to 10 MB

### DIFF
--- a/backends/platform/3ds/main.cpp
+++ b/backends/platform/3ds/main.cpp
@@ -32,6 +32,10 @@ enum {
 // Set the size of the stack.
 u32 __stacksize__ = 64 * 1024;
 
+// Set the size of the linear heap to allow a larger application heap.
+u32 __ctru_heap_size        = 0;
+u32 __ctru_linear_heap_size = 10 * 1024 * 1024;
+
 int main(int argc, char *argv[]) {
 	// Initialize basic libctru stuff
 	cfguInit();

--- a/backends/platform/3ds/osystem-graphics.cpp
+++ b/backends/platform/3ds/osystem-graphics.cpp
@@ -30,9 +30,9 @@
 
 // Used to transfer the final rendered display to the framebuffer
 #define DISPLAY_TRANSFER_FLAGS                                                    \
-		(GX_TRANSFER_FLIP_VERT(0) | GX_TRANSFER_OUT_TILED(0) |                    \
-		 GX_TRANSFER_RAW_COPY(0) | GX_TRANSFER_IN_FORMAT(GX_TRANSFER_FMT_RGBA8) | \
-		 GX_TRANSFER_OUT_FORMAT(GX_TRANSFER_FMT_RGB8) |                           \
+		(GX_TRANSFER_FLIP_VERT(0) | GX_TRANSFER_OUT_TILED(0) |                   \
+		 GX_TRANSFER_RAW_COPY(0) | GX_TRANSFER_IN_FORMAT(GX_TRANSFER_FMT_RGB8) | \
+		 GX_TRANSFER_OUT_FORMAT(GX_TRANSFER_FMT_RGB8) |                          \
 		 GX_TRANSFER_SCALING(GX_TRANSFER_SCALE_NO))
 #define TEXTURE_TRANSFER_FLAGS(in, out)                             \
 		(GX_TRANSFER_FLIP_VERT(1) | GX_TRANSFER_OUT_TILED(1) |  \
@@ -72,13 +72,13 @@ void OSystem_3DS::init3DSGraphics() {
 	int topScreenWidth = gfxIsWide() ? 800 : 400;
 
 	_renderTargetTop =
-	    C3D_RenderTargetCreate(240, topScreenWidth, GPU_RB_RGBA8, GPU_RB_DEPTH24_STENCIL8);
+	    C3D_RenderTargetCreate(240, topScreenWidth, GPU_RB_RGB8, -1);
 	C3D_RenderTargetClear(_renderTargetTop, C3D_CLEAR_ALL, 0x0000000, 0);
 	C3D_RenderTargetSetOutput(_renderTargetTop, GFX_TOP, GFX_LEFT,
 	                          DISPLAY_TRANSFER_FLAGS);
 
 	_renderTargetBottom =
-	    C3D_RenderTargetCreate(240, 320, GPU_RB_RGBA8, GPU_RB_DEPTH24_STENCIL8);
+	    C3D_RenderTargetCreate(240, 320, GPU_RB_RGB8, -1);
 	C3D_RenderTargetClear(_renderTargetBottom, C3D_CLEAR_ALL, 0x00000000, 0);
 	C3D_RenderTargetSetOutput(_renderTargetBottom, GFX_BOTTOM, GFX_LEFT,
 	                          DISPLAY_TRANSFER_FLAGS);
@@ -107,6 +107,8 @@ void OSystem_3DS::init3DSGraphics() {
 
 	C3D_DepthTest(false, GPU_GEQUAL, GPU_WRITE_ALL);
 	C3D_CullFace(GPU_CULL_NONE);
+
+	_overlay.create(320, 240, &DEFAULT_MODE, true);
 }
 
 void OSystem_3DS::destroy3DSGraphics() {
@@ -221,8 +223,7 @@ void OSystem_3DS::initSize(uint width, uint height,
 		_transactionDetails.formatChanged = true;
 	}
 
-	_gameTopTexture.create(width, height, _gfxState.gfxMode);
-	_overlay.create(400, 320, &DEFAULT_MODE);
+	_gameTopTexture.create(width, height, _gfxState.gfxMode, true);
 	_gameScreen.create(width, height, _pfGame);
 
 	_focusDirty = true;

--- a/backends/platform/3ds/osystem.h
+++ b/backends/platform/3ds/osystem.h
@@ -55,6 +55,7 @@ enum GraphicsModeID {
 	RGB565,
 	RGB555,
 	RGB5A1,
+	RGBA4,
 	CLUT8
 };
 

--- a/backends/platform/3ds/sprite.cpp
+++ b/backends/platform/3ds/sprite.cpp
@@ -48,7 +48,7 @@ Sprite::~Sprite() {
 	//
 }
 
-void Sprite::create(uint16 width, uint16 height, const GfxMode3DS *mode) {
+void Sprite::create(uint16 width, uint16 height, const GfxMode3DS *mode, bool vram) {
 	free();
 
 	actualWidth = width;
@@ -62,7 +62,11 @@ void Sprite::create(uint16 width, uint16 height, const GfxMode3DS *mode) {
 
 	if (width && height) {
 		pixels = linearAlloc(h * pitch);
-		C3D_TexInit(&texture, w, h, mode->textureFormat);
+		if (vram) {
+			if (!C3D_TexInitVRAM(&texture, w, h, mode->textureFormat))
+				C3D_TexInit(&texture, w, h, mode->textureFormat);
+		} else
+			C3D_TexInit(&texture, w, h, mode->textureFormat);
 		assert(pixels && texture.data);
 		clear();
 	}

--- a/backends/platform/3ds/sprite.h
+++ b/backends/platform/3ds/sprite.h
@@ -41,7 +41,7 @@ class Sprite : public Graphics::Surface {
 public:
 	Sprite();
 	~Sprite();
-	void create(uint16 width, uint16 height, const GfxMode3DS *mode);
+	void create(uint16 width, uint16 height, const GfxMode3DS *mode, bool vram = false);
 	void free();
 	void convertToInPlace(const Graphics::PixelFormat &dstFormat, const byte *palette = 0);
 	void transfer();


### PR DESCRIPTION
The memory allocated to processes on the 3DS is divided between the application heap (which is used by malloc) and the linear heap (which is used for memory that's used by hardware devices). Normally libctru divides this up semi-evenly, but this results in there being more linear memory than is strictly necessary and not enough regular memory for some engines. (especially on the old 3DS). This reduces the amount of linear memory that ScummVM needs so that a limit of 10 MB can be enforced, allowing the application heap to grow larger.

There's potentially some additional room for improvement by moving the `gfxInitDefault` framebuffer into VRAM as well, but it looks like it'll need initialising to avoid graphics corruption and I'm not sure what's the best way to do that.

On the old 3DS, there is now 41 MB of application memory available compared to the previous amount of 24 MB. The New 3DS has not been tested with these changes. 