### PR TITLE
GUI: rebuild if _aspectCheckbox is expected

### DIFF
--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -2033,6 +2033,8 @@ void OptionsDialog::setupGraphicsTab() {
 			rebuild();
 		} else if (!_stretchPopUp && g_system->hasFeature(OSystem::kFeatureStretchMode)) {
 			rebuild();
+		} else if (!_aspectCheckbox && g_system->hasFeature(OSystem::kFeatureAspectRatioCorrection)) {
+			rebuild();
 		}
 		setGraphicSettingsState(_enableGraphicSettings);
 	}


### PR DESCRIPTION
Fixes or works around https://bugs.scummvm.org/ticket/15243 . This may not be appropriate, but it avoids a segfault (nil _aspectCheckbox) for me when I've specified `--disable-aspect` and switch from SDL to OpenGL, anyway.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
