### PR TITLE
GRAPHICS: Add move constructors to ManagedSurface

### DIFF
--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -41,7 +41,7 @@ ManagedSurface::ManagedSurface(const ManagedSurface &surf) :
 		w(_innerSurface.w), h(_innerSurface.h), pitch(_innerSurface.pitch), format(_innerSurface.format),
 		_disposeAfterUse(DisposeAfterUse::NO), _owner(nullptr),
 		_transparentColor(0), _transparentColorSet(false), _palette(nullptr) {
-	this->copyFrom(surf);
+	*this = surf;
 }
 
 ManagedSurface::ManagedSurface(ManagedSurface &&surf) :

--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -44,6 +44,28 @@ ManagedSurface::ManagedSurface(const ManagedSurface &surf) :
 	this->copyFrom(surf);
 }
 
+ManagedSurface::ManagedSurface(ManagedSurface &&surf) :
+		w(_innerSurface.w), h(_innerSurface.h), pitch(_innerSurface.pitch), format(_innerSurface.format),
+		_disposeAfterUse(surf._disposeAfterUse), _owner(surf._owner), _offsetFromOwner(surf._offsetFromOwner),
+		_transparentColor(surf._transparentColor), _transparentColorSet(surf._transparentColorSet),
+		_palette(surf._palette) {
+
+	_innerSurface.setPixels(surf.getPixels());
+	_innerSurface.w = surf.w;
+	_innerSurface.h = surf.h;
+	_innerSurface.pitch = surf.pitch;
+	_innerSurface.format = surf.format;
+
+	// Reset the old surface
+	surf._innerSurface.init(0, 0, 0, NULL, PixelFormat());
+	surf._disposeAfterUse = DisposeAfterUse::NO;
+	surf._owner = nullptr;
+	surf._offsetFromOwner = Common::Point();
+	surf._transparentColor = 0;
+	surf._transparentColorSet = false;
+	surf._palette = nullptr;
+}
+
 ManagedSurface::ManagedSurface(int width, int height) :
 		w(_innerSurface.w), h(_innerSurface.h), pitch(_innerSurface.pitch), format(_innerSurface.format),
 		_disposeAfterUse(DisposeAfterUse::NO), _owner(nullptr),
@@ -136,6 +158,37 @@ ManagedSurface &ManagedSurface::operator=(const ManagedSurface &surf) {
 		_transparentColor = surf._transparentColor;
 		_palette = surf._palette ? new Palette(*surf._palette) : nullptr;
 	}
+
+	return *this;
+}
+
+ManagedSurface &ManagedSurface::operator=(ManagedSurface &&surf) {
+	// Free any current surface
+	free();
+
+	_disposeAfterUse = surf._disposeAfterUse;
+	_owner = surf._owner;
+	_offsetFromOwner = surf._offsetFromOwner;
+
+	_innerSurface.setPixels(surf.getPixels());
+	_innerSurface.w = surf.w;
+	_innerSurface.h = surf.h;
+	_innerSurface.pitch = surf.pitch;
+	_innerSurface.format = surf.format;
+
+	// Copy miscellaneous properties
+	_transparentColorSet = surf._transparentColorSet;
+	_transparentColor = surf._transparentColor;
+	_palette = surf._palette;
+
+	// Reset the old surface
+	surf._innerSurface.init(0, 0, 0, NULL, PixelFormat());
+	surf._disposeAfterUse = DisposeAfterUse::NO;
+	surf._owner = nullptr;
+	surf._offsetFromOwner = Common::Point();
+	surf._transparentColor = 0;
+	surf._transparentColorSet = false;
+	surf._palette = nullptr;
 
 	return *this;
 }

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -131,6 +131,7 @@ public:
 	 * this surface will create its own surface of the same size and copy
 	 * the contents from the source surface.
 	 */
+	WARN_DEPRECATED("Use copyFrom(), a move constructor or supply bounds")
 	ManagedSurface(const ManagedSurface &surf);
 
 	/**
@@ -197,7 +198,7 @@ public:
 	 *
 	 * @note If the source has a managed surface, it will be duplicated.
 	 */
-	WARN_DEPRECATED("Use copyFrom() instead")
+	WARN_DEPRECATED("Use copyFrom() or a move constructor instead")
 	ManagedSurface &operator=(const ManagedSurface &surf);
 
 	/**

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -134,6 +134,11 @@ public:
 	ManagedSurface(const ManagedSurface &surf);
 
 	/**
+	 * Create a managed surface from another one.
+	 */
+	ManagedSurface(ManagedSurface &&surf);
+
+	/**
 	 * Create the managed surface.
 	 */
 	ManagedSurface(int width, int height);
@@ -194,6 +199,11 @@ public:
 	 */
 	WARN_DEPRECATED("Use copyFrom() instead")
 	ManagedSurface &operator=(const ManagedSurface &surf);
+
+	/**
+	 * Reassign one managed surface to another one.
+	 */
+	ManagedSurface &operator=(ManagedSurface &&surf);
 
 	/**
 	 * Return true if the surface has not yet been allocated.


### PR DESCRIPTION
Among other things, having move constructors allow returning a ManagedSurface object from a function without having to make copies of the pixel data.

I've also deprecated the copy constructor and restored its previous behaviour. I don't know if it (or `operator=`) can ever be fully removed because `Common::Array` needs it, but for now it'll help to identify places where unnecessary copies are occurring.