### PR TITLE
COMMON: Use uninitialized_move when resizing arrays

### DIFF
--- a/common/algorithm.h
+++ b/common/algorithm.h
@@ -95,6 +95,63 @@ Out copy_if(In first, In last, Out dst, Op op) {
  */
 
 /**
+ * @name Move templates
+ * @{
+ */
+
+/**
+ * Move data from the range [first, last) to [dst, dst + (last - first)).
+ *
+ * The function requires the range [dst, dst + (last - first)) to be valid.
+ * It also requires dst not to be in the range [first, last).
+ */
+template<class In, class Out>
+Out move(In first, In last, Out dst) {
+	while (first != last)
+		*dst++ = Common::move(*first++);
+	return dst;
+}
+
+/**
+ * Move data from the range [first, last) to [dst - (last - first), dst).
+ *
+ * The function requires the range [dst - (last - first), dst) to be valid.
+ * It also requires dst not to be in the range [first, last).
+ *
+ * Unlike move, move_backward moves the data from the end to the beginning.
+ */
+template<class In, class Out>
+Out move_backward(In first, In last, Out dst) {
+	while (first != last)
+		*--dst = Common::move(*--last);
+	return dst;
+}
+
+/**
+ * Move data from the range [first, last) to [dst, dst + (last - first)).
+ *
+ * The function requires the range [dst, dst + (last - first)) to be valid.
+ * It also requires dst not to be in the range [first, last).
+ *
+ * Unlike move or move_backward, it does not move all data. It only moves
+ * a data element when operator() of the op parameter returns true for the
+ * passed data element.
+ */
+template<class In, class Out, class Op>
+Out move_if(In first, In last, Out dst, Op op) {
+	while (first != last) {
+		if (op(*first))
+			*dst++ = Common::move(*first);
+		++first;
+	}
+	return dst;
+}
+
+/**
+ * @}
+ */
+
+/**
  * @name Fill templates
  * @{
  */

--- a/common/array.h
+++ b/common/array.h
@@ -219,8 +219,8 @@ public:
 	/** Remove an element at the given position from the array and return the value of that element. */
 	T remove_at(size_type idx) {
 		assert(idx < _size);
-		T tmp = _storage[idx];
-		copy(_storage + idx + 1, _storage + _size, _storage + idx);
+		T tmp = Common::move(_storage[idx]);
+		move(_storage + idx + 1, _storage + _size, _storage + idx);
 		_size--;
 		// We also need to destroy the last object properly here.
 		_storage[_size].~T();
@@ -286,7 +286,7 @@ public:
 
 	/** Erase the element at @p pos position and return an iterator pointing to the next element in the array. */
 	iterator erase(iterator pos) {
-		copy(pos + 1, _storage + _size, pos);
+		move(pos + 1, _storage + _size, pos);
 		_size--;
 		// We also need to destroy the last object properly here.
 		_storage[_size].~T();
@@ -295,7 +295,7 @@ public:
 
 	/** Erase the elements from @p first to @p last and return an iterator pointing to the next element in the array. */
 	iterator erase(iterator first, iterator last) {
-		copy(last, _storage + _size, first);
+		move(last, _storage + _size, first);
 
 		int count = (last - first);
 		_size -= count;
@@ -361,8 +361,8 @@ public:
 		allocCapacity(newCapacity);
 
 		if (oldStorage) {
-			// Copy old data
-			uninitialized_copy(oldStorage, oldStorage + _size, _storage);
+			// Move old data
+			uninitialized_move(oldStorage, oldStorage + _size, _storage);
 			freeStorage(oldStorage, _size);
 		}
 	}
@@ -469,30 +469,30 @@ protected:
 				// storage to avoid conflicts.
 				allocCapacity(roundUpCapacity(_size + n));
 
-				// Copy the data from the old storage till the position where
+				// Move the data from the old storage till the position where
 				// we insert new data
-				uninitialized_copy(oldStorage, oldStorage + idx, _storage);
+				uninitialized_move(oldStorage, oldStorage + idx, _storage);
 				// Copy the data we insert
 				uninitialized_copy(first, last, _storage + idx);
-				// Afterwards, copy the old data from the position where we
+				// Afterwards, move the old data from the position where we
 				// insert.
-				uninitialized_copy(oldStorage + idx, oldStorage + _size, _storage + idx + n);
+				uninitialized_move(oldStorage + idx, oldStorage + _size, _storage + idx + n);
 
 				freeStorage(oldStorage, _size);
 			} else if (idx + n <= _size) {
 				// Make room for the new elements by shifting back
 				// existing ones.
 				// 1. Move a part of the data to the uninitialized area
-				uninitialized_copy(_storage + _size - n, _storage + _size, _storage + _size);
+				uninitialized_move(_storage + _size - n, _storage + _size, _storage + _size);
 				// 2. Move a part of the data to the initialized area
-				copy_backward(pos, _storage + _size - n, _storage + _size);
+				move_backward(pos, _storage + _size - n, _storage + _size);
 
 				// Insert the new elements.
 				copy(first, last, pos);
 			} else {
-				// Copy the old data from the position till the end to the new
+				// Move the old data from the position till the end to the new
 				// place.
-				uninitialized_copy(pos, _storage + _size, _storage + idx + n);
+				uninitialized_move(pos, _storage + _size, _storage + idx + n);
 
 				// Copy a part of the new data to the position inside the
 				// initialized space.

--- a/common/memory.h
+++ b/common/memory.h
@@ -22,7 +22,7 @@
 #ifndef COMMON_MEMORY_H
 #define COMMON_MEMORY_H
 
-#include "common/scummsys.h"
+#include "common/util.h"
 
 namespace Common {
 
@@ -59,6 +59,18 @@ template<class In, class Type>
 Type *uninitialized_copy(In first, In last, Type *dst) {
 	while (first != last)
 		new ((void *)dst++) Type(*first++);
+	return dst;
+}
+
+/**
+ * Moves data from the range [first, last) to [dst, dst + (last - first)).
+ * It requires the range [dst, dst + (last - first)) to be valid and
+ * uninitialized.
+ */
+template<class In, class Type>
+Type *uninitialized_move(In first, In last, Type *dst) {
+	while (first != last)
+		new ((void *)dst++) Type(Common::move(*first++));
 	return dst;
 }
 

--- a/common/std/vector.h
+++ b/common/std/vector.h
@@ -39,16 +39,6 @@
 
 namespace Std {
 
-template<class In, class Type>
-Type *uninitialized_move(In first, In last, Type *dst) {
-	while (first != last) {
-		Type &t = *new ((void *)dst++) Type();
-		t = Std::move(*first++);
-	}
-
-	return dst;
-}
-
 template<class T>
 class vector {
 public:
@@ -501,8 +491,8 @@ public:
 		allocCapacity(newCapacity);
 
 		if (oldStorage) {
-			// Copy old data
-			uninitialized_move(oldStorage, oldStorage + _size, _storage);
+			// Move old data
+			Common::uninitialized_move(oldStorage, oldStorage + _size, _storage);
 			freeStorage(oldStorage, _size);
 		}
 	}

--- a/common/std/vector.h
+++ b/common/std/vector.h
@@ -285,8 +285,8 @@ public:
 	/** Remove an element at the given position from the array and return the value of that element. */
 	T remove_at(size_type idx) {
 		assert(idx < _size);
-		T tmp = _storage[idx];
-		Common::copy(_storage + idx + 1, _storage + _size, _storage + idx);
+		T tmp = Common::move(_storage[idx]);
+		Common::move(_storage + idx + 1, _storage + _size, _storage + idx);
 		_size--;
 		// We also need to destroy the last object properly here.
 		_storage[_size].~T();
@@ -359,15 +359,16 @@ public:
 
 	/** Erase the element at @p pos position and return an iterator pointing to the next element in the array. */
 	iterator erase(iterator pos) {
-		Common::copy(pos + 1, _storage + _size, pos);
+		Common::move(pos + 1, _storage + _size, pos);
 		_size--;
 		// We also need to destroy the last object properly here.
 		_storage[_size].~T();
 		return pos;
 	}
 
+	/** Erase the elements from @p first to @p last and return an iterator pointing to the next element in the array. */
 	iterator erase(iterator first, iterator last) {
-		Common::copy(last, this->_storage + this->_size, first);
+		Common::move(last, this->_storage + this->_size, first);
 
 		int count = (last - first);
 		this->_size -= count;
@@ -581,30 +582,30 @@ protected:
 				// storage to avoid conflicts.
 				allocCapacity(roundUpCapacity(_size + n));
 
-				// Copy the data from the old storage till the position where
+				// Move the data from the old storage till the position where
 				// we insert new data
-				Common::uninitialized_copy(oldStorage, oldStorage + idx, _storage);
+				Common::uninitialized_move(oldStorage, oldStorage + idx, _storage);
 				// Copy the data we insert
 				Common::uninitialized_copy(first, last, _storage + idx);
-				// Afterwards, copy the old data from the position where we
+				// Afterwards, move the old data from the position where we
 				// insert.
-				Common::uninitialized_copy(oldStorage + idx, oldStorage + _size, _storage + idx + n);
+				Common::uninitialized_move(oldStorage + idx, oldStorage + _size, _storage + idx + n);
 
 				freeStorage(oldStorage, _size);
 			} else if (idx + n <= _size) {
 				// Make room for the new elements by shifting back
 				// existing ones.
 				// 1. Move a part of the data to the uninitialized area
-				Common::uninitialized_copy(_storage + _size - n, _storage + _size, _storage + _size);
+				Common::uninitialized_move(_storage + _size - n, _storage + _size, _storage + _size);
 				// 2. Move a part of the data to the initialized area
-				Common::copy_backward(pos, _storage + _size - n, _storage + _size);
+				Common::move_backward(pos, _storage + _size - n, _storage + _size);
 
 				// Insert the new elements.
 				Common::copy(first, last, pos);
 			} else {
-				// Copy the old data from the position till the end to the new
+				// Move the old data from the position till the end to the new
 				// place.
-				Common::uninitialized_copy(pos, _storage + _size, _storage + idx + n);
+				Common::uninitialized_move(pos, _storage + _size, _storage + idx + n);
 
 				// Copy a part of the new data to the position inside the
 				// initialized space.

--- a/engines/sci/graphics/lists32.h
+++ b/engines/sci/graphics/lists32.h
@@ -60,6 +60,13 @@ public:
 			}
 		}
 	}
+	StablePointerArray(StablePointerArray &&other) : _size(other._size) {
+		other._size = 0;
+		for (size_type i = 0; i < _size; ++i) {
+			_items[i] = other._items[i];
+			other._items[i] = nullptr;
+		}
+	}
 	~StablePointerArray() {
 		for (size_type i = 0; i < _size; ++i) {
 			delete _items[i];
@@ -75,6 +82,16 @@ public:
 			} else {
 				_items[i] = new T(*other._items[i]);
 			}
+		}
+	}
+
+	void operator=(StablePointerArray &&other) {
+		clear();
+		_size = other._size;
+		other._size = 0;
+		for (size_type i = 0; i < _size; ++i) {
+			_items[i] = other._items[i];
+			other._items[i] = nullptr;
 		}
 	}
 
@@ -217,6 +234,9 @@ public:
 			}
 		}
 	}
+	StablePointerDynamicArray(StablePointerDynamicArray &&other) {
+		_items = Common::move(other._items);
+	}
 	~StablePointerDynamicArray() {
 		for (size_type i = 0; i < _items.size(); ++i) {
 			delete _items[i];
@@ -232,6 +252,10 @@ public:
 				_items.push_back(new T(*other._items[i]));
 			}
 		}
+	}
+	void operator=(StablePointerDynamicArray &&other) {
+		clear();
+		_items = Common::move(other._items);
 	}
 
 	T *const &operator[](size_type index) const {


### PR DESCRIPTION
This should reduce the amount of memory copying when amending an array of objects that have move constructors.
