### PR TITLE
MSVC: Add build configuration for ASan

### DIFF
--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -187,7 +187,7 @@ void MSVCProvider::createWorkspace(const BuildSetup &setup) {
 
 	for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
 		solution << "\t\tDebug|" << getMSVCConfigName(*arch) << " = Debug|" << getMSVCConfigName(*arch) << "\n"
-		         << "\t\tAnalysis|" << getMSVCConfigName(*arch) << " = Analysis|" << getMSVCConfigName(*arch) << "\n"
+		         << "\t\tASan|" << getMSVCConfigName(*arch) << " = ASan|" << getMSVCConfigName(*arch) << "\n"
 		         << "\t\tLLVM|" << getMSVCConfigName(*arch) << " = LLVM|" << getMSVCConfigName(*arch) << "\n"
 		         << "\t\tRelease|" << getMSVCConfigName(*arch) << " = Release|" << getMSVCConfigName(*arch) << "\n";
 	}
@@ -199,8 +199,8 @@ void MSVCProvider::createWorkspace(const BuildSetup &setup) {
 		for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
 			solution << "\t\t{" << i->second << "}.Debug|" << getMSVCConfigName(*arch) << ".ActiveCfg = Debug|" << getMSVCConfigName(*arch) << "\n"
 			         << "\t\t{" << i->second << "}.Debug|" << getMSVCConfigName(*arch) << ".Build.0 = Debug|" << getMSVCConfigName(*arch) << "\n"
-			         << "\t\t{" << i->second << "}.Analysis|" << getMSVCConfigName(*arch) << ".ActiveCfg = Analysis|" << getMSVCConfigName(*arch) << "\n"
-			         << "\t\t{" << i->second << "}.Analysis|" << getMSVCConfigName(*arch) << ".Build.0 = Analysis|" << getMSVCConfigName(*arch) << "\n"
+			         << "\t\t{" << i->second << "}.ASan|" << getMSVCConfigName(*arch) << ".ActiveCfg = ASan|" << getMSVCConfigName(*arch) << "\n"
+			         << "\t\t{" << i->second << "}.ASan|" << getMSVCConfigName(*arch) << ".Build.0 = ASan|" << getMSVCConfigName(*arch) << "\n"
 			         << "\t\t{" << i->second << "}.LLVM|" << getMSVCConfigName(*arch) << ".ActiveCfg = LLVM|" << getMSVCConfigName(*arch) << "\n"
 			         << "\t\t{" << i->second << "}.LLVM|" << getMSVCConfigName(*arch) << ".Build.0 = LLVM|" << getMSVCConfigName(*arch) << "\n"
 			         << "\t\t{" << i->second << "}.Release|" << getMSVCConfigName(*arch) << ".ActiveCfg = Release|" << getMSVCConfigName(*arch) << "\n"
@@ -220,11 +220,11 @@ void MSVCProvider::createOtherBuildFiles(const BuildSetup &setup) {
 	createGlobalProp(setup);
 
 	// Create the configuration property files (for Debug and Release with 32 and 64bits versions)
-	// Note: we use the debug properties for the analysis configuration
+	// Note: we use the debug properties for the asan configuration
 	for (std::list<MSVC_Architecture>::const_iterator arch = _archs.begin(); arch != _archs.end(); ++arch) {
 		createBuildProp(setup, true, *arch, "Release");
 		createBuildProp(setup, false, *arch, "Debug");
-		createBuildProp(setup, false, *arch, "Analysis");
+		createBuildProp(setup, false, *arch, "ASan");
 		createBuildProp(setup, false, *arch, "LLVM");
 	}
 }


### PR DESCRIPTION
Visual Studio 2019 added support for [Address Sanitizer](https://learn.microsoft.com/en-us/cpp/sanitizers/asan?view=msvc-170), a popular tool for debugging memory errors, that most developers aren't even aware it exists.

This PR adds a ASan build configuration to the generated MSVC project with the correct compiler flags in place, so you can easily switch it on and off when debugging code:
![ASan](https://github.com/scummvm/scummvm/assets/603444/7dc404a3-c9ac-4492-be98-fc72db9fe66c)
It's not enabled by default since it runs slower and requires disabling some compiler debug features.

I also removed the obsolete Analysis build configuration (runs static analysis like Coverity), since MSVC added an Analyze menu that does the same thing.