### PR TITLE
CREATE_PROJECT: Reenable OpenGL on Windows ARM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           - platform: arm64
             arch: arm64
             triplet: arm64-windows
-            configFlags: --enable-discord --enable-faad --enable-gif --enable-mikmod --enable-mpeg2 --enable-vpx --disable-opengl
+            configFlags: --enable-discord --enable-faad --enable-gif --enable-mikmod --enable-mpeg2 --enable-vpx
     env:
       CONFIGURATION: Debug
       PLATFORM: ${{ matrix.platform }}
@@ -173,7 +173,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Add Ubuntu Xenial package sources
         if: matrix.platform == 'ubuntu-20.04'
         run: |

--- a/devtools/create_project/msvc.cpp
+++ b/devtools/create_project/msvc.cpp
@@ -42,10 +42,8 @@ MSVCProvider::MSVCProvider(StringList &global_warnings, std::map<std::string, St
 	amd64_disabled_features.push_back("nasm");
 	_arch_disabled_features[ARCH_AMD64] = amd64_disabled_features;
 	// NASM not supported for WoA target
-	// No OpenGL on Windows on ARM
 	StringList arm64_disabled_features;
 	arm64_disabled_features.push_back("nasm");
-	arm64_disabled_features.push_back("opengl");
 	_arch_disabled_features[ARCH_ARM64] = arm64_disabled_features;
 }
 
@@ -80,7 +78,7 @@ std::string MSVCProvider::getLibraryFromFeature(const char *feature, const Build
 		// Feature flags with library dependencies
 		{   "updates", "winsparkle.lib",            nullptr,         nullptr                                           },
 		{       "tts", nullptr,                     nullptr,         "sapi.lib"                                        },
-		{    "opengl", nullptr,                     nullptr,         "opengl32.lib"                                    },
+		{    "opengl", nullptr,                     nullptr,         nullptr                                           },
 		{      "enet", nullptr,                     nullptr,         "winmm.lib ws2_32.lib"                            }
 	};
 


### PR DESCRIPTION
OpenGL was disabled on Windows arm64 since it's not natively supported, however Microsoft has since added a [OpenGL Compatibility Pack](https://devblogs.microsoft.com/directx/announcing-the-opencl-and-opengl-compatibility-pack-for-windows-10-on-arm/) which should resolve the issue.

We don't need to statically link to "opengl32.lib" anymore, since we added GLAD which resolves it dynamically in runtime instead.