### PR TITLE
IOS7: Add iPad app icons to Info.plist

### DIFF
--- a/ports.mk
+++ b/ports.mk
@@ -246,6 +246,7 @@ ios7bundle: scummvm-static-ios
 			print "\t\t\t<key>CFBundleIconFiles</key>";\
 			print "\t\t\t<array>";\
 			print "\t\t\t\t<string>AppIcon76x76</string>";\
+			print "\t\t\t\t<string>AppIcon83.5x83.5</string>";\
 			print "\t\t\t</array>";\
 			print "\t\t</dict>";\
 			print "\t</dict>";\

--- a/ports.mk
+++ b/ports.mk
@@ -238,6 +238,18 @@ ios7bundle: scummvm-static-ios
 			print "\t\t</dict>";\
 			print "\t</dict>";\
 			s=2}\
+		/<key>CFBundleIcons~ipad<\/key>/ {\
+			print $$0;\
+			print "\t<dict>";\
+			print "\t\t<key>CFBundlePrimaryIcon</key>";\
+			print "\t\t<dict>";\
+			print "\t\t\t<key>CFBundleIconFiles</key>";\
+			print "\t\t\t<array>";\
+			print "\t\t\t\t<string>AppIcon76x76</string>";\
+			print "\t\t\t</array>";\
+			print "\t\t</dict>";\
+			print "\t</dict>";\
+			s=2}\
 		/<key>UILaunchImages<\/key>/ {\
 			print $$0;\
 			print "\t<array>";\


### PR DESCRIPTION
The 76x76 app icon files (1x and 2x) are present, but appear to not be referenced by Info.plist.

I noticed after signing and installing https://downloads.scummvm.org/frs/scummvm/2.8.0/scummvm-2.8.0-ios9-armv7.ipa on an iPad 3rd gen that there was no app icon. I'll assume that this wasn't caught in the appstore release since it uses the asset catalog instead (?) 

It was resolved on my end by simply referencing the existing 76x76 icon files present in the bundle, using the existing ~ipad specific info.plist key. 

While looking through the current repo it didn't strike me as taking this into account yet, but if you think I've misunderstood something feel free to simply close this.

Sincerely,
big fan

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
