### PR TITLE
DIRECTOR: Add remaining detection entries for melements

### DIFF
--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -7717,20 +7717,25 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	WINGAME1("meancity", "", "mc32.exe", "t:746d26c4e79cf5c81f8aaf09709d8488", 1527265, 602),
 
-	// Masters of the Elements - English and German (from lotharsm)
+	// Masters of the Elements
 	// Original Dutch game Meesters van Macht released in 1997
-	// Released in Germany as "Meister Zufall und die Herrscher der Elemente"
-	// Developed by IJsfontein, published by Tivola
-	// File version of MVM.EXE is 6.0.2.32
+	// Developed by IJsfontein
 	// The game disc is a hybrid CD-ROM containing both the Windows and the Macintosh release.
-	MACGAME2("melements", "",	"check.dxr",			  "f48ce7700bbf5f00a03373397b491a87", 898334,
-								"Masters of the Elements", 0, 1034962, 602),
-	WINGAME2("melements", "",	"CHECK.DXR",			  "c31ee30eebd24a8cf31691fc9926daa4", 901820,
-								"MVM.EXE",				  0, 2565921, 602),
-	MACGAME2_l("melements", "", "check.dxr",			  "bd320cbd150d4d54fec798ce0222bc63", 575554,
-								"Meister Zufall",		  "398eb2cdf121feb490097c6323d52267", 1034962, Common::DE_DEU, 602),
-	WINGAME2_l("melements", "", "CHECK.DXR",			  "d1cd0ed95b0e30597e0089bf3e5caf0f", 575414,
-								"MVM.EXE",				  "518a98696fe1122e08410b0f157f21bf", 1512503, Common::DE_DEU, 602),
+	MACGAME1_l("melements", "", "Masters of the Elements", "r:398eb2cdf121feb490097c6323d52267", 1034706, Common::EN_ANY, 602),
+	WINGAME1_l("melements", "", "MVM.EXE",                 "t:a149844f8c90443483f7fe38beb44111", 2565921, Common::EN_ANY, 602),
+
+	// German: "Meister Zufall und die Herrscher der Elemente", published by Tivola
+	MACGAME1_l("melements", "", "Meister Zufall", "r:398eb2cdf121feb490097c6323d52267", 1034706, Common::DE_DEU, 602),
+	WINGAME1_l("melements", "", "MVM.EXE",        "t:31a3726973886c0f3de3ee127f56fcb3", 1512503, Common::DE_DEU, 602),
+
+	// French: "Le Maître des éléments", published by Gallimard Multimédia
+	// Hybrid disc: Mac version needs to be added, unknown projector file/needs extraction?
+	WINGAME1_l("melements", "", "MDE.EXE", "t:8db5c7ffd823515b341cee7acb72b9a8", 2256946, Common::FR_FRA, 602),
+
+	// Dutch: "Meesters van Macht", Netherlands/Belgium release by Karakter Interactive
+	// Game files likely match the original 1997 release since it is the only variant built with Director 6.0.1
+	MACGAME1_l("melements", "", "Meesters van Macht", "r:888e9ea9987e5ef6833d5af3683fcb3a", 115776,  Common::NL_NLD, 601),
+	WINGAME1_l("melements", "", "MVM.EXE",            "t:25ecda33e9fc9aaf70efcd2e124b114a", 2082817, Common::NL_NLD, 601),
 
 	WINGAME1("meetchuck", "", "HORSE.EXE", "b0f3841f6e8005e519445b22de37749b", 1130649, 600),
 


### PR DESCRIPTION
Thanks to the tail checksums for Windows, the detection entries are now unique with only using one file which is the Projector itself.

After years of searching, I can now happily report that now all known language variants are detected, including the release that is most likely the very original one - even though the Dutch variant added here is from a disc that contains a re-release, it is the one with the _lowest_ Director version which is a very strong indicator that this is in fact the original one.

The French release has an HFS partition as well, but it looks like the Projector is embedded in a Setup program since I don't see a file that's obviously a Projector; so this needs more investigation.