### PR TITLE
AGS: Use a namespace alias to keep std namespace as in original code

### DIFF
--- a/engines/ags/engine/ac/asset_helper.h
+++ b/engines/ags/engine/ac/asset_helper.h
@@ -59,7 +59,7 @@ AssetPath get_voice_over_assetpath(const String &filename);
 // TODO: it is preferrable to let our Stream define custom readable window instead,
 // keeping this as simple as possible for now (we may require a stream classes overhaul).
 struct AGS_PACKFILE_OBJ {
-	Std::unique_ptr<Stream> stream;
+	std::unique_ptr<Stream> stream;
 	size_t asset_size = 0u;
 	size_t remains = 0u;
 };

--- a/engines/ags/engine/ac/character.cpp
+++ b/engines/ags/engine/ac/character.cpp
@@ -1088,7 +1088,7 @@ int Character_GetAnimationVolume(CharacterInfo *chaa) {
 
 void Character_SetAnimationVolume(CharacterInfo *chaa, int newval) {
 
-	_GP(charextra)[chaa->index_id].anim_volume = Std::min(newval, 100); // negative means default
+	_GP(charextra)[chaa->index_id].anim_volume = std::min(newval, 100); // negative means default
 }
 
 int Character_GetBaseline(CharacterInfo *chaa) {
@@ -2100,7 +2100,7 @@ int GetCharacterFrameVolume(CharacterInfo * chi) {
 		if (zoom_level <= 0)
 			zoom_level = 100;
 		else
-			zoom_level = Std::min(zoom_level, 100);
+			zoom_level = std::min(zoom_level, 100);
 		frame_vol = frame_vol * zoom_level / 100;
 	}
 	return frame_vol;
@@ -2335,7 +2335,7 @@ void _displayspeech(const char *texx, int aschar, int xx, int yy, int widd, int 
 	_GP(play).speech_in_post_state = false;
 
 	if (isPause) {
-		postpone_scheduled_music_update_by(Std::chrono::milliseconds(_GP(play).messagetime * 1000 / _G(frames_per_second)));
+		postpone_scheduled_music_update_by(std::chrono::milliseconds(_GP(play).messagetime * 1000 / _G(frames_per_second)));
 		// Set a post-state right away, as we only need to wait for a messagetime timer
 		_GP(play).speech_in_post_state = true;
 		GameLoopUntilValueIsNegative(&_GP(play).messagetime);

--- a/engines/ags/engine/ac/character_info_engine.cpp
+++ b/engines/ags/engine/ac/character_info_engine.cpp
@@ -64,7 +64,7 @@ int CharacterInfo::get_blocking_bottom() {
 	return y + 3;
 }
 
-void CharacterInfo::UpdateMoveAndAnim(int &char_index, CharacterExtras *chex, Std::vector<int> &followingAsSheep) {
+void CharacterInfo::UpdateMoveAndAnim(int &char_index, CharacterExtras *chex, std::vector<int> &followingAsSheep) {
 	int res;
 
 	if (on != 1) return;
@@ -344,7 +344,7 @@ int CharacterInfo::update_character_animating(int &aa, int &doing_nothing) {
 	return 0;
 }
 
-void CharacterInfo::update_character_follower(int &aa, Std::vector<int> &followingAsSheep, int &doing_nothing) {
+void CharacterInfo::update_character_follower(int &aa, std::vector<int> &followingAsSheep, int &doing_nothing) {
 	if ((following >= 0) && (followinfo == FOLLOW_ALWAYSONTOP)) {
 		// an always-on-top follow
 		followingAsSheep.push_back(aa);

--- a/engines/ags/engine/ac/draw.cpp
+++ b/engines/ags/engine/ac/draw.cpp
@@ -79,7 +79,7 @@ using namespace AGS::Engine;
 int _places_r = 3, _places_g = 2, _places_b = 3;
 
 ObjTexture::ObjTexture(ObjTexture &&o) {
-	*this = Std::move(o);
+	*this = std::move(o);
 }
 
 ObjTexture::~ObjTexture() {
@@ -96,7 +96,7 @@ ObjTexture &ObjTexture::operator=(ObjTexture &&o) {
 		assert(_G(gfxDriver));
 		_G(gfxDriver)->DestroyDDB(Ddb);
 	}
-	Bmp = Std::move(o.Bmp);
+	Bmp = std::move(o.Bmp);
 	Ddb = o.Ddb;
 	o.Ddb = nullptr;
 	Pos = o.Pos;
@@ -871,7 +871,7 @@ static bool spritelistentry_room_less(const SpriteListEntry &e1, const SpriteLis
 
 // copy the sorted sprites into the Things To Draw list
 static void draw_sprite_list(bool is_room) {
-	Std::sort(_GP(sprlist).begin(), _GP(sprlist).end(), is_room ? spritelistentry_room_less : spritelistentry_less);
+	std::sort(_GP(sprlist).begin(), _GP(sprlist).end(), is_room ? spritelistentry_room_less : spritelistentry_less);
 	_GP(thingsToDrawList).insert(_GP(thingsToDrawList).end(),
 		_GP(sprlist).begin(), _GP(sprlist).end());
 }
@@ -948,7 +948,7 @@ Bitmap *recycle_bitmap(Bitmap *bimp, int coldep, int wid, int hit, bool make_tra
 	return bimp;
 }
 
-void recycle_bitmap(Std::unique_ptr<Shared::Bitmap> &bimp, int coldep, int wid, int hit, bool make_transparent) {
+void recycle_bitmap(std::unique_ptr<Shared::Bitmap> &bimp, int coldep, int wid, int hit, bool make_transparent) {
 	bimp.reset(recycle_bitmap(bimp.release(), coldep, wid, hit, make_transparent));
 }
 
@@ -1056,14 +1056,14 @@ static void apply_tint_or_light(int actspsindex, int light_level,
 	auto &actsp = _GP(actsps)[actspsindex];
 	// we can only do tint/light if the colour depths match
 	if (_GP(game).GetColorDepth() == actsp.Bmp->GetColorDepth()) {
-		Std::unique_ptr<Bitmap> oldwas;
+		std::unique_ptr<Bitmap> oldwas;
 		// if the caller supplied a source bitmap, ->Blit from it
 		// (used as a speed optimisation where possible)
 		if (blitFrom)
 			oldwas.reset(blitFrom);
 		// otherwise, make a new target bmp
 		else {
-			oldwas = Std::move(actsp.Bmp);
+			oldwas = std::move(actsp.Bmp);
 			actsp.Bmp.reset(BitmapHelper::CreateBitmap(oldwas->GetWidth(), oldwas->GetHeight(), coldept));
 		}
 		Bitmap *active_spr = actsp.Bmp.get();
@@ -1110,7 +1110,7 @@ static void apply_tint_or_light(int actspsindex, int light_level,
 // * if transformation is necessary - writes into dst and returns dst;
 // * if no transformation is necessary - simply returns src;
 // Used for software render mode only.
-static Bitmap *transform_sprite(Bitmap *src, bool src_has_alpha, Std::unique_ptr<Bitmap> &dst,
+static Bitmap *transform_sprite(Bitmap *src, bool src_has_alpha, std::unique_ptr<Bitmap> &dst,
 								const Size dst_sz, GraphicFlip flip = Shared::kFlip_None) {
 	if ((src->GetSize() == dst_sz) && (flip == kFlip_None))
 		return src; // No transform: return source image
@@ -2000,7 +2000,7 @@ void draw_gui_and_overlays() {
 	}
 	// If adding control textures, sort the ui list, and then pass into renderer,
 	// adding controls and creating sub-batches as necessary
-	Std::sort(_GP(sprlist).begin(), _GP(sprlist).end(), spritelistentry_less);
+	std::sort(_GP(sprlist).begin(), _GP(sprlist).end(), spritelistentry_less);
 	for (const auto &s : _GP(sprlist)) {
 		invalidate_sprite(s.x, s.y, s.ddb, false);
 		_G(gfxDriver)->DrawSprite(s.x, s.y, s.ddb);

--- a/engines/ags/engine/ac/draw.h
+++ b/engines/ags/engine/ac/draw.h
@@ -33,7 +33,7 @@
 namespace AGS3 {
 namespace AGS {
 namespace Shared {
-typedef Std::shared_ptr<Shared::Bitmap> PBitmap;
+typedef std::shared_ptr<Shared::Bitmap> PBitmap;
 } // namespace Shared
 
 namespace Engine {
@@ -67,7 +67,7 @@ struct ObjTexture {
 	uint32_t SpriteID = UINT32_MAX;
 	// Raw bitmap; used for software render mode,
 	// or when particular object types require generated image.
-	Std::unique_ptr<Shared::Bitmap> Bmp;
+	std::unique_ptr<Shared::Bitmap> Bmp;
 	// Corresponding texture, created by renderer
 	Engine::IDriverDependantBitmap *Ddb = nullptr;
 	// Sprite's position
@@ -89,7 +89,7 @@ struct ObjTexture {
 // ObjectCache stores cached object data, used to determine
 // if active sprite / texture should be reconstructed
 struct ObjectCache {
-	Std::unique_ptr<AGS::Shared::Bitmap> image;
+	std::unique_ptr<AGS::Shared::Bitmap> image;
 	bool  in_use = false;
 	int   sppic = 0;
 	short tintr = 0, tintg = 0, tintb = 0, tintamnt = 0, tintlight = 0;
@@ -151,7 +151,7 @@ void mark_current_background_dirty();
 
 // Avoid freeing and reallocating the memory if possible
 Shared::Bitmap *recycle_bitmap(Shared::Bitmap *bimp, int coldep, int wid, int hit, bool make_transparent = false);
-void recycle_bitmap(Std::unique_ptr<Shared::Bitmap> &bimp, int coldep, int wid, int hit, bool make_transparent = false);
+void recycle_bitmap(std::unique_ptr<Shared::Bitmap> &bimp, int coldep, int wid, int hit, bool make_transparent = false);
 Engine::IDriverDependantBitmap* recycle_ddb_sprite(Engine::IDriverDependantBitmap *ddb, uint32_t sprite_id, Shared::Bitmap *source, bool has_alpha = false, bool opaque = false);
 inline Engine::IDriverDependantBitmap* recycle_ddb_bitmap(Engine::IDriverDependantBitmap *ddb, Shared::Bitmap *source, bool has_alpha = false, bool opaque = false) {
 	return recycle_ddb_sprite(ddb, UINT32_MAX, source, has_alpha, opaque);
@@ -244,7 +244,7 @@ Shared::Bitmap *ReplaceBitmapWithSupportedFormat(Shared::Bitmap *bitmap);
 // (old systems or uncommon gfx modes, and similar stuff).
 // Original bitmap **gets deleted** if a new bitmap had to be created.
 Shared::Bitmap *PrepareSpriteForUse(Shared::Bitmap *bitmap, bool has_alpha);
-// Same as above, but compatible for Std::shared_ptr.
+// Same as above, but compatible for std::shared_ptr.
 Shared::PBitmap PrepareSpriteForUse(Shared::PBitmap bitmap, bool has_alpha);
 // Makes a screenshot corresponding to the last screen render and returns it as a bitmap
 // of the requested width and height and game's native color depth.

--- a/engines/ags/engine/ac/draw_software.cpp
+++ b/engines/ags/engine/ac/draw_software.cpp
@@ -134,7 +134,7 @@ void init_invalid_regions(int view_index, const Size &surf_size, const Rect &vie
 			_GP(RoomCamPositions).resize(view_index + 1);
 		}
 		_GP(RoomCamRects)[view_index].Init(surf_size, viewport);
-		_GP(RoomCamPositions)[view_index] = Std::make_pair(-1000, -1000);
+		_GP(RoomCamPositions)[view_index] = std::make_pair(-1000, -1000);
 	}
 }
 
@@ -202,7 +202,7 @@ void invalidate_rect_on_surf(int x1, int y1, int x2, int y2, DirtyRects &rects) 
 	rects.NumDirtyRegions++;
 
 	// ** Span code
-	Std::vector<IRRow> &dirtyRow = rects.DirtyRows;
+	std::vector<IRRow> &dirtyRow = rects.DirtyRows;
 	int s, foundOne;
 	// add this rect to the list for this row
 	for (a = y1; a <= y2; a++) {
@@ -326,7 +326,7 @@ void update_invalid_region(Bitmap *ds, Bitmap *src, const DirtyRects &rects, boo
 	if (rects.NumDirtyRegions == WHOLESCREENDIRTY) {
 		ds->Blit(src, src_x, src_y, dst_x, dst_y, rects.SurfaceSize.Width, rects.SurfaceSize.Height);
 	} else {
-		const Std::vector<IRRow> &dirtyRow = rects.DirtyRows;
+		const std::vector<IRRow> &dirtyRow = rects.DirtyRows;
 		const int surf_height = rects.SurfaceSize.Height;
 		// TODO: is this IsMemoryBitmap check is still relevant?
 		// If bitmaps properties match and no transform required other than linear offset
@@ -370,7 +370,7 @@ void update_invalid_region(Bitmap *ds, color_t fill_color, const DirtyRects &rec
 	if (rects.NumDirtyRegions == WHOLESCREENDIRTY) {
 		ds->FillRect(rects.Viewport, fill_color);
 	} else {
-		const Std::vector<IRRow> &dirtyRow = rects.DirtyRows;
+		const std::vector<IRRow> &dirtyRow = rects.DirtyRows;
 		const int surf_height = rects.SurfaceSize.Height;
 		{
 			const AGS::Shared::PlaneScaling &tf = rects.Room2Screen;

--- a/engines/ags/engine/ac/draw_software.h
+++ b/engines/ags/engine/ac/draw_software.h
@@ -71,7 +71,7 @@ struct DirtyRects {
 	// The dirty rects are saved in coordinates limited to (0,0)->(camera size) rather than room or screen coords
 	PlaneScaling Screen2DirtySurf;
 
-	Std::vector<IRRow> DirtyRows;
+	std::vector<IRRow> DirtyRows;
 	Rect DirtyRegions[MAXDIRTYREGIONS];
 	size_t NumDirtyRegions;
 

--- a/engines/ags/engine/ac/dynobj/cc_dynamic_array.cpp
+++ b/engines/ags/engine/ac/dynobj/cc_dynamic_array.cpp
@@ -131,7 +131,7 @@ void CCDynamicArray::WriteFloat(const char *address, intptr_t offset, float val)
 	*(float *)(const_cast<char *>(address) + offset) = val;
 }
 
-DynObjectRef DynamicArrayHelpers::CreateStringArray(const Std::vector<const char *> items) {
+DynObjectRef DynamicArrayHelpers::CreateStringArray(const std::vector<const char *> items) {
 	// NOTE: we need element size of "handle" for array of managed pointers
 	DynObjectRef arr = _GP(globalDynamicArray).Create(items.size(), sizeof(int32_t), true);
 	if (!arr.second)

--- a/engines/ags/engine/ac/dynobj/cc_dynamic_array.h
+++ b/engines/ags/engine/ac/dynobj/cc_dynamic_array.h
@@ -58,7 +58,7 @@ struct CCDynamicArray final : ICCDynamicObject {
 // Helper functions for setting up dynamic arrays.
 namespace DynamicArrayHelpers {
 // Create array of managed strings
-DynObjectRef CreateStringArray(const Std::vector<const char *>);
+DynObjectRef CreateStringArray(const std::vector<const char *>);
 } // namespace DynamicArrayHelpers
 
 } // namespace AGS3

--- a/engines/ags/engine/ac/dynobj/cc_dynamic_object.h
+++ b/engines/ags/engine/ac/dynobj/cc_dynamic_object.h
@@ -43,7 +43,7 @@ class Stream;
 using namespace AGS; // FIXME later
 
 // A pair of managed handle and abstract object pointer
-typedef Std::pair<int32_t, void *> DynObjectRef;
+typedef std::pair<int32_t, void *> DynObjectRef;
 
 
 // OBJECT-BASED SCRIPTING RUNTIME FUNCTIONS

--- a/engines/ags/engine/ac/dynobj/managed_object_pool.cpp
+++ b/engines/ags/engine/ac/dynobj/managed_object_pool.cpp
@@ -230,7 +230,7 @@ void ManagedObjectPool::WriteToDisk(Stream *out) {
 	// use this opportunity to clean up any non-referenced pointers
 	RunGarbageCollection();
 
-	Std::vector<char> serializeBuffer;
+	std::vector<char> serializeBuffer;
 	serializeBuffer.resize(SERIALIZE_BUFFER_SIZE);
 
 	out->WriteInt32(OBJECT_CACHE_MAGIC_NUMBER);
@@ -278,7 +278,7 @@ int ManagedObjectPool::ReadFromDisk(Stream *in, ICCObjectReader *reader) {
 	}
 
 	char typeNameBuffer[200];
-	Std::vector<char> serializeBuffer;
+	std::vector<char> serializeBuffer;
 	serializeBuffer.resize(SERIALIZE_BUFFER_SIZE);
 
 	auto version = in->ReadInt32();

--- a/engines/ags/engine/ac/dynobj/managed_object_pool.h
+++ b/engines/ags/engine/ac/dynobj/managed_object_pool.h
@@ -76,9 +76,9 @@ private:
 	int objectCreationCounter;  // used to do garbage collection every so often
 
 	int32_t nextHandle{}; // TODO: manage nextHandle's going over INT32_MAX !
-	Std::queue<int32_t> available_ids;
-	Std::vector<ManagedObject> objects;
-	Std::unordered_map<const char *, int32_t, Pointer_Hash> handleByAddress;
+	std::queue<int32_t> available_ids;
+	std::vector<ManagedObject> objects;
+	std::unordered_map<const char *, int32_t, Pointer_Hash> handleByAddress;
 
 	void Init(int32_t theHandle, const char *theAddress, ICCDynamicObject *theCallback, ScriptValueType objType);
 	int Remove(ManagedObject &o, bool force = false);

--- a/engines/ags/engine/ac/dynobj/script_dict.h
+++ b/engines/ags/engine/ac/dynobj/script_dict.h
@@ -21,7 +21,7 @@
 
 //=============================================================================
 //
-// Managed script object wrapping Std::map<String, String> and
+// Managed script object wrapping std::map<String, String> and
 // unordered_map<String, String>.
 //
 // TODO: support wrapping non-owned Dictionary, passed by the reference, -
@@ -61,8 +61,8 @@ public:
 	virtual bool Remove(const char *key) = 0;
 	virtual bool Set(const char *key, const char *value) = 0;
 	virtual int GetItemCount() = 0;
-	virtual void GetKeys(Std::vector<const char *> &buf) const = 0;
-	virtual void GetValues(Std::vector<const char *> &buf) const = 0;
+	virtual void GetKeys(std::vector<const char *> &buf) const = 0;
+	virtual void GetValues(std::vector<const char *> &buf) const = 0;
 protected:
 	// Write object data into the provided stream
 	void Serialize(const char *address, AGS::Shared::Stream *out) override;
@@ -124,11 +124,11 @@ public:
 	int GetItemCount() override {
 		return _dic.size();
 	}
-	void GetKeys(Std::vector<const char *> &buf) const override {
+	void GetKeys(std::vector<const char *> &buf) const override {
 		for (auto it = _dic.begin(); it != _dic.end(); ++it)
 			buf.push_back(it->_key.GetCStr());
 	}
-	void GetValues(Std::vector<const char *> &buf) const override {
+	void GetValues(std::vector<const char *> &buf) const override {
 		for (auto it = _dic.begin(); it != _dic.end(); ++it)
 			buf.push_back(it->_value.GetCStr());
 	}
@@ -180,10 +180,10 @@ private:
 	TDict _dic;
 };
 
-typedef ScriptDictImpl< Std::map<String, String>, true, true > ScriptDict;
-typedef ScriptDictImpl< Std::map<String, String, IgnoreCase_LessThan>, true, false > ScriptDictCI;
-typedef ScriptDictImpl< Std::unordered_map<String, String>, false, true > ScriptHashDict;
-typedef ScriptDictImpl< Std::unordered_map<String, String, IgnoreCase_Hash, IgnoreCase_EqualTo>, false, false > ScriptHashDictCI;
+typedef ScriptDictImpl< std::map<String, String>, true, true > ScriptDict;
+typedef ScriptDictImpl< std::map<String, String, IgnoreCase_LessThan>, true, false > ScriptDictCI;
+typedef ScriptDictImpl< std::unordered_map<String, String>, false, true > ScriptHashDict;
+typedef ScriptDictImpl< std::unordered_map<String, String, IgnoreCase_Hash, IgnoreCase_EqualTo>, false, false > ScriptHashDictCI;
 
 } // namespace AGS3
 

--- a/engines/ags/engine/ac/dynobj/script_set.h
+++ b/engines/ags/engine/ac/dynobj/script_set.h
@@ -21,7 +21,7 @@
 
 //=============================================================================
 //
-// Managed script object wrapping Std::set<String> and unordered_set<String>.
+// Managed script object wrapping std::set<String> and unordered_set<String>.
 //
 // TODO: support wrapping non-owned Set, passed by the reference, -
 // that would let expose internal engine's sets using same interface.
@@ -59,7 +59,7 @@ public:
 	virtual bool Contains(const char *item) const = 0;
 	virtual bool Remove(const char *item) = 0;
 	virtual int GetItemCount() const = 0;
-	virtual void GetItems(Std::vector<const char *> &buf) const = 0;
+	virtual void GetItems(std::vector<const char *> &buf) const = 0;
 
 protected:
 	// Write object data into the provided stream
@@ -106,7 +106,7 @@ public:
 	int GetItemCount() const override {
 		return _set.size();
 	}
-	void GetItems(Std::vector<const char *> &buf) const override {
+	void GetItems(std::vector<const char *> &buf) const override {
 		for (auto it = _set.begin(); it != _set.end(); ++it)
 			buf.push_back(it->GetCStr());
 	}
@@ -146,10 +146,10 @@ private:
 	TSet _set;
 };
 
-typedef ScriptSetImpl< Std::set<String>, true, true > ScriptSet;
-typedef ScriptSetImpl< Std::set<String, IgnoreCase_LessThan>, true, false > ScriptSetCI;
-typedef ScriptSetImpl< Std::unordered_set<String>, false, true > ScriptHashSet;
-typedef ScriptSetImpl< Std::unordered_set<String, IgnoreCase_Hash, IgnoreCase_EqualTo>, false, false > ScriptHashSetCI;
+typedef ScriptSetImpl< std::set<String>, true, true > ScriptSet;
+typedef ScriptSetImpl< std::set<String, IgnoreCase_LessThan>, true, false > ScriptSetCI;
+typedef ScriptSetImpl< std::unordered_set<String>, false, true > ScriptHashSet;
+typedef ScriptSetImpl< std::unordered_set<String, IgnoreCase_Hash, IgnoreCase_EqualTo>, false, false > ScriptHashSetCI;
 
 } // namespace AGS3
 

--- a/engines/ags/engine/ac/event.cpp
+++ b/engines/ags/engine/ac/event.cpp
@@ -356,7 +356,7 @@ void processallevents() {
 	// and they must NOT be processed here, but instead discarded at the end
 	// of this function; otherwise game may glitch.
 	// TODO: need to redesign engine events system?
-	Std::vector<EventHappened> evtCopy = _GP(events);
+	std::vector<EventHappened> evtCopy = _GP(events);
 
 	int room_was = _GP(play).room_changes;
 

--- a/engines/ags/engine/ac/game.cpp
+++ b/engines/ags/engine/ac/game.cpp
@@ -882,7 +882,7 @@ void save_game(int slotn, const char *descript) {
 
 	VALIDATE_STRING(descript);
 	String nametouse = get_save_game_path(slotn);
-	Std::unique_ptr<Bitmap> screenShot;
+	std::unique_ptr<Bitmap> screenShot;
 
 	// WORKAROUND: AGS originally only creates savegames if the game flags
 	// that it supports it. But we want it all the time for ScummVM GMM,
@@ -890,7 +890,7 @@ void save_game(int slotn, const char *descript) {
 	if ((/*_GP(game).options[OPT_SAVESCREENSHOT] != 0*/ true) && _G(saveThumbnail))
 		screenShot.reset(create_savegame_screenshot());
 
-	Std::unique_ptr<Stream> out(StartSavegame(nametouse, descript, screenShot.get()));
+	std::unique_ptr<Stream> out(StartSavegame(nametouse, descript, screenShot.get()));
 	if (out == nullptr) {
 		Display("ERROR: Unable to open savegame file for writing!");
 		return;
@@ -947,7 +947,7 @@ bool read_savedgame_screenshot(const String &savedgame, int &want_shot) {
 
 // Test if the game file contains expected GUID / legacy id
 bool test_game_guid(const String &filepath, const String &guid, int legacy_id) {
-	Std::unique_ptr<AssetManager> amgr(new AssetManager());
+	std::unique_ptr<AssetManager> amgr(new AssetManager());
 	if (amgr->AddLibrary(filepath) != kAssetNoError)
 		return false;
 	MainGameSource src;

--- a/engines/ags/engine/ac/game_state.cpp
+++ b/engines/ags/engine/ac/game_state.cpp
@@ -110,7 +110,7 @@ PViewport GameState::GetRoomViewport(int index) const {
 	return _roomViewports[index];
 }
 
-const Std::vector<PViewport> &GameState::GetRoomViewportsZOrdered() const {
+const std::vector<PViewport> &GameState::GetRoomViewportsZOrdered() const {
 	return _roomViewportsSorted;
 }
 
@@ -142,7 +142,7 @@ void GameState::UpdateViewports() {
 	if (_roomViewportZOrderChanged) {
 		auto old_sort = _roomViewportsSorted;
 		_roomViewportsSorted = _roomViewports;
-		Std::sort(_roomViewportsSorted.begin(), _roomViewportsSorted.end(), ViewportZOrder);
+		std::sort(_roomViewportsSorted.begin(), _roomViewportsSorted.end(), ViewportZOrder);
 		for (size_t i = 0; i < _roomViewportsSorted.size(); ++i) {
 			if (i >= old_sort.size() || _roomViewportsSorted[i] != old_sort[i])
 				_roomViewportsSorted[i]->SetChangedVisible();
@@ -213,7 +213,7 @@ VpPoint GameState::ScreenToRoomImpl(int scrx, int scry, int view_index, bool cli
 		view = GetRoomViewportAt(scrx, scry);
 		if (!view) {
 			if (clip_viewport)
-				return Std::make_pair(Point(), -1);
+				return std::make_pair(Point(), -1);
 			view = _roomViewports[0]; // use primary viewport
 		}
 	} else {
@@ -379,8 +379,8 @@ bool GameState::IsIgnoringInput() const {
 }
 
 void GameState::SetIgnoreInput(int timeout_ms) {
-	if (AGS_Clock::now() + Std::chrono::milliseconds(timeout_ms) > _ignoreUserInputUntilTime)
-		_ignoreUserInputUntilTime = AGS_Clock::now() + Std::chrono::milliseconds(timeout_ms);
+	if (AGS_Clock::now() + std::chrono::milliseconds(timeout_ms) > _ignoreUserInputUntilTime)
+		_ignoreUserInputUntilTime = AGS_Clock::now() + std::chrono::milliseconds(timeout_ms);
 }
 
 void GameState::ClearIgnoreInput() {

--- a/engines/ags/engine/ac/game_state.h
+++ b/engines/ags/engine/ac/game_state.h
@@ -44,7 +44,7 @@ namespace AGS {
 namespace Shared {
 class Bitmap;
 class Stream;
-typedef Std::shared_ptr<Bitmap> PBitmap;
+typedef std::shared_ptr<Bitmap> PBitmap;
 } // namespace Shared
 
 namespace Engine {
@@ -228,14 +228,14 @@ struct GameState {
 	int   gamma_adjustment = 0;
 	short temporarily_turned_off_character = 0;  // Hide Player Charactr ticked
 	short inv_backwards_compatibility = 0;  // tells to use legacy inv_* variables
-	Std::vector<int> gui_draw_order; // used only for hit detection now
-	Std::vector<AGS::Shared::String> do_once_tokens;
+	std::vector<int> gui_draw_order; // used only for hit detection now
+	std::vector<AGS::Shared::String> do_once_tokens;
 	int   text_min_display_time_ms = 0;
 	int   ignore_user_input_after_text_timeout_ms = 0;
 	int32_t default_audio_type_volumes[MAX_AUDIO_TYPES];
 
 	// Dynamic custom property values for characters and items
-	Std::vector<AGS::Shared::StringIMap> charProps;
+	std::vector<AGS::Shared::StringIMap> charProps;
 	AGS::Shared::StringIMap invProps[MAX_INV];
 
 	// Dynamic speech state
@@ -286,7 +286,7 @@ struct GameState {
 	// Returns Room viewport object by it's main index
 	PViewport  GetRoomViewport(int index) const;
 	// Returns Room viewport object by index in z-order
-	const Std::vector<PViewport> &GetRoomViewportsZOrdered() const;
+	const std::vector<PViewport> &GetRoomViewportsZOrdered() const;
 	// Finds room viewport at the given screen coordinates; returns nullptr if non found
 	PViewport  GetRoomViewportAt(int x, int y) const;
 	// Returns Room viewport position in absolute coordinates (with main viewport offset);
@@ -407,15 +407,15 @@ private:
 	Rect _uiViewport;
 	// Room viewports define place on screen where the room camera's
 	// contents are drawn.
-	Std::vector<PViewport> _roomViewports;
+	std::vector<PViewport> _roomViewports;
 	// Vector of viewports sorted in z-order.
-	Std::vector<PViewport> _roomViewportsSorted;
+	std::vector<PViewport> _roomViewportsSorted;
 	// Cameras defines the position of a "looking eye" inside the room.
-	Std::vector<PCamera> _roomCameras;
+	std::vector<PCamera> _roomCameras;
 	// We keep handles to the script refs to viewports and cameras, so that we
 	// could address them and invalidate as the actual object gets destroyed.
-	Std::vector<int32_t> _scViewportHandles;
-	Std::vector<int32_t> _scCameraHandles;
+	std::vector<int32_t> _scViewportHandles;
+	std::vector<int32_t> _scCameraHandles;
 
 	// Tells that the main viewport's position has changed since last game update
 	bool  _mainViewportHasChanged = false;

--- a/engines/ags/engine/ac/global_audio.cpp
+++ b/engines/ags/engine/ac/global_audio.cpp
@@ -552,7 +552,7 @@ static void stop_voice_clip_impl() {
 	_GP(play).music_master_volume = _GP(play).music_vol_was;
 	// update the music in a bit (fixes two speeches follow each other
 	// and music going up-then-down)
-	schedule_music_update_at(AGS_Clock::now() + Std::chrono::milliseconds(500));
+	schedule_music_update_at(AGS_Clock::now() + std::chrono::milliseconds(500));
 	stop_and_destroy_channel(SCHAN_SPEECH);
 }
 

--- a/engines/ags/engine/ac/global_game.cpp
+++ b/engines/ags/engine/ac/global_game.cpp
@@ -176,7 +176,7 @@ int LoadSaveSlotScreenshot(int slnum, int width, int height) {
 	return gotSlot;
 }
 
-void FillSaveList(Std::vector<SaveListItem> &saves, size_t max_count) {
+void FillSaveList(std::vector<SaveListItem> &saves, size_t max_count) {
 	if (max_count == 0)
 		return; // duh
 

--- a/engines/ags/engine/ac/global_game.h
+++ b/engines/ags/engine/ac/global_game.h
@@ -51,7 +51,7 @@ void RestoreGameSlot(int slnum);
 void DeleteSaveSlot(int slnum);
 int  GetSaveSlotDescription(int slnum, char *desbuf);
 int  LoadSaveSlotScreenshot(int slnum, int width, int height);
-void FillSaveList(Std::vector<SaveListItem> &saves, size_t max_count = -1);
+void FillSaveList(std::vector<SaveListItem> &saves, size_t max_count = -1);
 void PauseGame();
 void UnPauseGame();
 int  IsGamePaused();

--- a/engines/ags/engine/ac/gui.cpp
+++ b/engines/ags/engine/ac/gui.cpp
@@ -412,7 +412,7 @@ bool sort_gui_less(const int g1, const int g2) {
 }
 
 void update_gui_zorder() {
-	Std::sort(_GP(play).gui_draw_order.begin(), _GP(play).gui_draw_order.end(), sort_gui_less);
+	std::sort(_GP(play).gui_draw_order.begin(), _GP(play).gui_draw_order.end(), sort_gui_less);
 }
 
 void export_gui_controls(int ee) {

--- a/engines/ags/engine/ac/listbox.cpp
+++ b/engines/ags/engine/ac/listbox.cpp
@@ -67,7 +67,7 @@ void ListBox_Clear(GUIListBox *listbox) {
 	listbox->Clear();
 }
 
-static void FillSaveList(Std::set<String> &files, const String &filePattern) {
+static void FillSaveList(std::set<String> &files, const String &filePattern) {
 	size_t wildcard = filePattern.FindChar('*');
 	assert(wildcard != String::NoIndex);
 	Common::String prefix(filePattern.GetCStr(), wildcard);
@@ -92,7 +92,7 @@ static void FillSaveList(Std::set<String> &files, const String &filePattern) {
 	}
 }
 
-void FillDirList(Std::set<String> &files, const String &path) {
+void FillDirList(std::set<String> &files, const String &path) {
 	String dirName = Path::GetDirectoryPath(path);
 	String filePattern = Path::get_filename(path);
 
@@ -124,13 +124,13 @@ void ListBox_FillDirList(GUIListBox *listbox, const char *filemask) {
 
 	// TODO: support listing assets from AssetMgr
 
-	Std::set<String> files;
+	std::set<String> files;
 	FillDirList(files, rp.FullPath);
 	if (!rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
 		FillDirList(files, rp.AltPath);
 
 	// TODO: method for adding item batch to speed up update
-	for (Std::set<String>::const_iterator it = files.begin(); it != files.end(); ++it) {
+	for (std::set<String>::const_iterator it = files.begin(); it != files.end(); ++it) {
 		listbox->AddItem(*it);
 	}
 }

--- a/engines/ags/engine/ac/overlay.cpp
+++ b/engines/ags/engine/ac/overlay.cpp
@@ -423,7 +423,7 @@ size_t add_screen_overlay_impl(bool roomlayer, int x, int y, int type, int sprnu
 		_GP(play).speech_face_schandle = over.associatedOverlayHandle;
 	}
 	over.MarkChanged();
-	_GP(screenover).push_back(Std::move(over));
+	_GP(screenover).push_back(std::move(over));
 	return _GP(screenover).size() - 1;
 }
 
@@ -456,10 +456,10 @@ Point get_overlay_position(const ScreenOverlay &over) {
 			data_to_game_coord(_GP(game).chars[charid].x),
 			data_to_game_coord(_GP(game).chars[charid].get_effective_y()) - height).first;
 		Bitmap *pic = over.GetImage();
-		int tdxp = Std::max(0, screenpt.X - pic->GetWidth() / 2);
+		int tdxp = std::max(0, screenpt.X - pic->GetWidth() / 2);
 		int tdyp = screenpt.Y - get_fixed_pixel_size(5);
 		tdyp -= pic->GetHeight();
-		tdyp = Std::max(5, tdyp);
+		tdyp = std::max(5, tdyp);
 
 		if ((tdxp + pic->GetWidth()) >= ui_view.GetWidth())
 			tdxp = (ui_view.GetWidth() - pic->GetWidth()) - 1;

--- a/engines/ags/engine/ac/room.cpp
+++ b/engines/ags/engine/ac/room.cpp
@@ -382,7 +382,7 @@ static void update_all_viewcams_with_newroom() {
 // from the room file itself.
 HError LoadRoomScript(RoomStruct *room, int newnum) {
 	String filename = String::FromFormat("room%d.o", newnum);
-	Std::unique_ptr<Stream> in(_GP(AssetMgr)->OpenAsset(filename));
+	std::unique_ptr<Stream> in(_GP(AssetMgr)->OpenAsset(filename));
 	if (in) {
 		PScript script(ccScript::CreateFromStream(in.get()));
 		if (!script)
@@ -896,7 +896,7 @@ void new_room(int newnum, CharacterInfo *forchar) {
 
 void set_room_placeholder() {
 	_GP(thisroom).InitDefaults();
-	Std::shared_ptr<Bitmap> dummy_bg(new Bitmap(1, 1, 8));
+	std::shared_ptr<Bitmap> dummy_bg(new Bitmap(1, 1, 8));
 	_GP(thisroom).BgFrames[0].Graphic = dummy_bg;
 	_GP(thisroom).HotspotMask = dummy_bg;
 	_GP(thisroom).RegionMask = dummy_bg;

--- a/engines/ags/engine/ac/room_status.h
+++ b/engines/ags/engine/ac/room_status.h
@@ -61,17 +61,17 @@ enum RoomStatSvgVersion {
 struct RoomStatus {
 	int   beenhere = 0;
 	uint32_t numobj = 0;
-	Std::vector<RoomObject> obj;
+	std::vector<RoomObject> obj;
 	uint32_t tsdatasize = 0;
-	Std::vector<char> tsdata;
+	std::vector<char> tsdata;
 	Interaction intrHotspot[MAX_ROOM_HOTSPOTS];
-	Std::vector<Interaction> intrObject;
+	std::vector<Interaction> intrObject;
 	Interaction intrRegion[MAX_ROOM_REGIONS];
 	Interaction intrRoom;
 
 	Shared::StringIMap roomProps;
 	Shared::StringIMap hsProps[MAX_ROOM_HOTSPOTS];
-	Std::vector<Shared::StringIMap> objProps;
+	std::vector<Shared::StringIMap> objProps;
 	HotspotState hotspot[MAX_ROOM_HOTSPOTS];
 	int8  region_enabled[MAX_ROOM_REGIONS];
 	short walkbehind_base[MAX_WALK_BEHINDS];

--- a/engines/ags/engine/ac/route_finder_impl.cpp
+++ b/engines/ags/engine/ac/route_finder_impl.cpp
@@ -85,7 +85,7 @@ void get_lastcpos(int &lastcx_, int &lastcy_) {
 static int find_route_jps(int fromx, int fromy, int destx, int desty) {
 	sync_nav_wallscreen();
 
-	Std::vector<int> path, cpath;
+	std::vector<int> path, cpath;
 	path.clear();
 	cpath.clear();
 

--- a/engines/ags/engine/ac/route_finder_jps.cpp
+++ b/engines/ags/engine/ac/route_finder_jps.cpp
@@ -32,6 +32,8 @@
 #include "common/std/functional.h"
 #include "common/std/xutility.h"
 
+#include "ags/lib/std.h"
+
 namespace AGS3 {
 
 // TODO: this could be cleaned up/simplified ...

--- a/engines/ags/engine/ac/route_finder_jps.cpp
+++ b/engines/ags/engine/ac/route_finder_jps.cpp
@@ -58,13 +58,13 @@ public:
 
 	// ncpath = navpoint-compressed path
 	// opath = path composed of individual grid elements
-	NavResult NavigateRefined(int sx, int sy, int ex, int ey, Std::vector<int> &opath,
-	                          Std::vector<int> &ncpath);
+	NavResult NavigateRefined(int sx, int sy, int ex, int ey, std::vector<int> &opath,
+	                          std::vector<int> &ncpath);
 
-	NavResult Navigate(int sx, int sy, int ex, int ey, Std::vector<int> &opath);
+	NavResult Navigate(int sx, int sy, int ex, int ey, std::vector<int> &opath);
 
 	bool TraceLine(int srcx, int srcy, int targx, int targy, int &lastValidX, int &lastValidY) const;
-	bool TraceLine(int srcx, int srcy, int targx, int targy, Std::vector<int> *rpath = nullptr) const;
+	bool TraceLine(int srcx, int srcy, int targx, int targy, std::vector<int> *rpath = nullptr) const;
 
 	inline void SetMapRow(int y, const unsigned char *row) {
 		map[y] = row;
@@ -97,7 +97,7 @@ private:
 
 	int mapWidth;
 	int mapHeight;
-	Std::vector<const unsigned char *> map;
+	std::vector<const unsigned char *> map;
 
 	typedef unsigned short tFrameId;
 	typedef int tPrev;
@@ -120,15 +120,15 @@ private:
 	static const float DIST_SCALE_PACK;
 	static const float DIST_SCALE_UNPACK;
 
-	Std::vector<NodeInfo> mapNodes;
+	std::vector<NodeInfo> mapNodes;
 	tFrameId frameId;
 
-	Std::priority_queue<Entry, Std::vector<Entry>, Common::Less<Entry> > pq;
+	std::priority_queue<Entry, std::vector<Entry>, Common::Less<Entry> > pq;
 
 	// temporary buffers:
-	mutable Std::vector<int> fpath;
-	Std::vector<int> ncpathIndex;
-	Std::vector<int> rayPath, orayPath;
+	mutable std::vector<int> fpath;
+	std::vector<int> ncpathIndex;
+	std::vector<int> rayPath, orayPath;
 
 	// temps for routing towards unreachable areas
 	int cnode;
@@ -329,7 +329,7 @@ int Navigation::FindJump(int x, int y, int dx, int dy, int ex, int ey) {
 	return nodiag ? -1 : FindJump(x, y, dx, dy, ex, ey);
 }
 
-Navigation::NavResult Navigation::Navigate(int sx, int sy, int ex, int ey, Std::vector<int> &opath) {
+Navigation::NavResult Navigation::Navigate(int sx, int sy, int ex, int ey, std::vector<int> &opath) {
 	IncFrameId();
 
 	if (!Passable(sx, sy)) {
@@ -474,7 +474,7 @@ Navigation::NavResult Navigation::Navigate(int sx, int sy, int ex, int ey, Std::
 			sort[ni].index = pneig[ni];
 		}
 
-		Std::sort(sort, sort + ncount);
+		std::sort(sort, sort + ncount);
 
 		int succ[8];
 		int nsucc = 0;
@@ -614,12 +614,12 @@ Navigation::NavResult Navigation::Navigate(int sx, int sy, int ex, int ey, Std::
 		}
 	}
 
-	Std::reverse(opath.begin(), opath.end());
+	std::reverse(opath.begin(), opath.end());
 	return NAV_PATH;
 }
 
 Navigation::NavResult Navigation::NavigateRefined(int sx, int sy, int ex, int ey,
-	Std::vector<int> &opath, Std::vector<int> &ncpath) {
+	std::vector<int> &opath, std::vector<int> &ncpath) {
 	ncpath.clear();
 
 	NavResult res = Navigate(sx, sy, ex, ey, opath);
@@ -656,7 +656,7 @@ Navigation::NavResult Navigation::NavigateRefined(int sx, int sy, int ex, int ey
 
 		if (!TraceLine(fx, fy, tx, ty, &rayPath)) {
 			assert(rayPath.back() == opath[i]);
-			Std::swap(rayPath, orayPath);
+			std::swap(rayPath, orayPath);
 
 			if (!last)
 				continue;
@@ -691,7 +691,7 @@ Navigation::NavResult Navigation::NavigateRefined(int sx, int sy, int ex, int ey
 		fy = ty;
 	}
 
-	Std::swap(opath, fpath);
+	std::swap(opath, fpath);
 
 	// validate cpath
 	for (int i = 0; i < (int)ncpath.size() - 1; i++) {
@@ -783,7 +783,7 @@ bool Navigation::TraceLine(int srcx, int srcy, int targx, int targy, int &lastVa
 	return res;
 }
 
-bool Navigation::TraceLine(int srcx, int srcy, int targx, int targy, Std::vector<int> *rpath) const {
+bool Navigation::TraceLine(int srcx, int srcy, int targx, int targy, std::vector<int> *rpath) const {
 	if (rpath)
 		rpath->clear();
 

--- a/engines/ags/engine/ac/route_finder_jps.h
+++ b/engines/ags/engine/ac/route_finder_jps.h
@@ -54,13 +54,13 @@ public:
 
 	// ncpath = navpoint-compressed path
 	// opath = path composed of individual grid elements
-	NavResult NavigateRefined(int sx, int sy, int ex, int ey, Std::vector<int> &opath,
-	                          Std::vector<int> &ncpath);
+	NavResult NavigateRefined(int sx, int sy, int ex, int ey, std::vector<int> &opath,
+	                          std::vector<int> &ncpath);
 
-	NavResult Navigate(int sx, int sy, int ex, int ey, Std::vector<int> &opath);
+	NavResult Navigate(int sx, int sy, int ex, int ey, std::vector<int> &opath);
 
 	bool TraceLine(int srcx, int srcy, int targx, int targy, int &lastValidX, int &lastValidY) const;
-	bool TraceLine(int srcx, int srcy, int targx, int targy, Std::vector<int> *rpath = nullptr) const;
+	bool TraceLine(int srcx, int srcy, int targx, int targy, std::vector<int> *rpath = nullptr) const;
 
 	inline void SetMapRow(int y, const unsigned char *row) {
 		map[y] = row;
@@ -93,7 +93,7 @@ private:
 
 	int mapWidth;
 	int mapHeight;
-	Std::vector<const unsigned char *> map;
+	std::vector<const unsigned char *> map;
 
 	typedef unsigned short tFrameId;
 	typedef int tPrev;
@@ -116,15 +116,15 @@ private:
 	static const float DIST_SCALE_PACK;
 	static const float DIST_SCALE_UNPACK;
 
-	Std::vector<NodeInfo> mapNodes;
+	std::vector<NodeInfo> mapNodes;
 	tFrameId frameId;
 
-	Std::priority_queue<Entry, Std::vector<Entry>, Common::Greater<Entry> > pq;
+	std::priority_queue<Entry, std::vector<Entry>, Common::Greater<Entry> > pq;
 
 	// temporary buffers:
-	mutable Std::vector<int> fpath;
-	Std::vector<int> ncpathIndex;
-	Std::vector<int> rayPath, orayPath;
+	mutable std::vector<int> fpath;
+	std::vector<int> ncpathIndex;
+	std::vector<int> rayPath, orayPath;
 
 	// temps for routing towards unreachable areas
 	int cnode;

--- a/engines/ags/engine/ac/screen_overlay.h
+++ b/engines/ags/engine/ac/screen_overlay.h
@@ -120,7 +120,7 @@ struct ScreenOverlay {
 private:
 	int _flags = 0; // OverlayFlags
 	bool _hasChanged = false;
-	Std::shared_ptr<Shared::Bitmap> _pic; // owned bitmap
+	std::shared_ptr<Shared::Bitmap> _pic; // owned bitmap
 	int _sprnum = -1; // sprite reference
 };
 

--- a/engines/ags/engine/ac/script_containers.cpp
+++ b/engines/ags/engine/ac/script_containers.cpp
@@ -112,7 +112,7 @@ int Dict_GetItemCount(ScriptDictBase *dic) {
 }
 
 void *Dict_GetKeysAsArray(ScriptDictBase *dic) {
-	Std::vector<const char *> items;
+	std::vector<const char *> items;
 	dic->GetKeys(items);
 	if (items.size() == 0)
 		return nullptr;
@@ -121,7 +121,7 @@ void *Dict_GetKeysAsArray(ScriptDictBase *dic) {
 }
 
 void *Dict_GetValuesAsArray(ScriptDictBase *dic) {
-	Std::vector<const char *> items;
+	std::vector<const char *> items;
 	dic->GetValues(items);
 	if (items.size() == 0)
 		return nullptr;
@@ -241,7 +241,7 @@ int Set_GetItemCount(ScriptSetBase *set) {
 }
 
 void *Set_GetItemsAsArray(ScriptSetBase *set) {
-	Std::vector<const char *> items;
+	std::vector<const char *> items;
 	set->GetItems(items);
 	if (items.size() == 0)
 		return nullptr;

--- a/engines/ags/engine/ac/sys_events.cpp
+++ b/engines/ags/engine/ac/sys_events.cpp
@@ -129,7 +129,7 @@ static int mouse_button_poll() {
 	int result = _G(mouse_button_state) | _G(mouse_accum_button_state);
 	if (now >= _G(mouse_clear_at_time)) {
 		_G(mouse_accum_button_state) = 0;
-		_G(mouse_clear_at_time) = now + Std::chrono::milliseconds(50);
+		_G(mouse_clear_at_time) = now + std::chrono::milliseconds(50);
 	}
 	return result;
 }

--- a/engines/ags/engine/ac/timer.cpp
+++ b/engines/ags/engine/ac/timer.cpp
@@ -33,9 +33,9 @@ namespace {
 const auto MAXIMUM_FALL_BEHIND = 3; // number of full frames
 }
 
-Std::chrono::microseconds GetFrameDuration() {
+std::chrono::microseconds GetFrameDuration() {
 	if (_G(framerate_maxed)) {
-		return Std::chrono::microseconds(0);
+		return std::chrono::microseconds(0);
 	}
 	return _G(tick_duration);
 }
@@ -45,7 +45,7 @@ int setTimerFps(int new_fps) {
 	if (new_fps <= 0)
 		return _G(framerate);
 	int old_fps = _G(framerate);
-	_G(tick_duration) = Std::chrono::microseconds(1000000LL / new_fps);
+	_G(tick_duration) = std::chrono::microseconds(1000000LL / new_fps);
 	_G(framerate) = new_fps;
 	_G(framerate_maxed) = new_fps >= 1000;
 
@@ -63,7 +63,7 @@ void WaitForNextFrame() {
 	const auto frameDuration = GetFrameDuration();
 
 	// early exit if we're trying to maximise framerate
-	if (frameDuration <= Std::chrono::milliseconds::zero()) {
+	if (frameDuration <= std::chrono::milliseconds::zero()) {
 		_G(last_tick_time) = _G(next_frame_timestamp);
 		_G(next_frame_timestamp) = now;
 		// suspend while the game is being switched out
@@ -81,7 +81,7 @@ void WaitForNextFrame() {
 
 	if (_G(next_frame_timestamp) > now) {
 		auto frame_time_remaining = _G(next_frame_timestamp) - now;
-		Std::this_thread::sleep_for(frame_time_remaining);
+		std::this_thread::sleep_for(frame_time_remaining);
 	}
 
 	_G(last_tick_time) = _G(next_frame_timestamp);

--- a/engines/ags/engine/ac/timer.h
+++ b/engines/ags/engine/ac/timer.h
@@ -32,9 +32,9 @@ namespace AGS3 {
 
 // use high resolution clock only if we know it is monotonic/steady.
 // refer to https://stackoverflow.com/a/38253266/84262
-using AGS_Clock = Std::conditional <
-                  Std::chrono::high_resolution_clock::is_steady,
-                  Std::chrono::high_resolution_clock, Std::chrono::steady_clock
+using AGS_Clock = std::conditional <
+                  std::chrono::high_resolution_clock::is_steady,
+                  std::chrono::high_resolution_clock, std::chrono::steady_clock
                   >::type;
 
 // Sleeps for time remaining until the next game frame, updates next frame timestamp

--- a/engines/ags/engine/ac/timer.h
+++ b/engines/ags/engine/ac/timer.h
@@ -26,6 +26,8 @@
 #include "common/std/chrono.h"
 #include "common/std/xtr1common.h"
 
+#include "ags/lib/std.h"
+
 namespace AGS3 {
 
 // use high resolution clock only if we know it is monotonic/steady.

--- a/engines/ags/engine/ac/translation.cpp
+++ b/engines/ags/engine/ac/translation.cpp
@@ -60,7 +60,7 @@ bool init_translation(const String &lang, const String &fallback_lang) {
 	_G(trans_name) = lang;
 	_G(trans_filename) = String::FromFormat("%s.tra", lang.GetCStr());
 
-	Std::unique_ptr<Stream> in(_GP(AssetMgr)->OpenAsset(_G(trans_filename)));
+	std::unique_ptr<Stream> in(_GP(AssetMgr)->OpenAsset(_G(trans_filename)));
 	if (in == nullptr) {
 		Debug::Printf(kDbgMsg_Error, "Cannot open translation: %s", _G(trans_filename).GetCStr());
 		return false;
@@ -126,12 +126,12 @@ bool init_translation(const String &lang, const String &fallback_lang) {
 		Debug::Printf("Game's source encoding hint: own: %d, from TRA: %s", game_codepage, _GP(trans).StrOptions["gameencoding"].GetCStr());
 		if (!key_enc.IsEmpty()) {
 			StringMap conv_map;
-			Std::vector<char> ascii; // ascii buffer
+			std::vector<char> ascii; // ascii buffer
 			Debug::Printf("Converting UTF-8 TRA keys to the game's encoding (%s)", key_enc.GetCStr());
 			for (const auto &item : _GP(trans).Dict) {
 				ascii.resize(item._key.GetLength() + 1); // ascii len will be <= utf-8 len
 				StrUtil::ConvertUtf8ToAscii(item._key.GetCStr(), key_enc.GetCStr(), &ascii[0], ascii.size());
-				conv_map.insert(Std::make_pair(String(&ascii[0]), item._value));
+				conv_map.insert(std::make_pair(String(&ascii[0]), item._value));
 			}
 			_GP(trans).Dict = conv_map;
 		}

--- a/engines/ags/engine/debugging/debug.cpp
+++ b/engines/ags/engine/debugging/debug.cpp
@@ -73,7 +73,7 @@ IAGSEditorDebugger *GetEditorDebugger(const char * /*instanceToken*/) {
 
 #endif
 
-void send_message_to_debugger(const Std::vector<Std::pair<String, String> > &tag_values, const String &command) {
+void send_message_to_debugger(const std::vector<std::pair<String, String> > &tag_values, const String &command) {
 	String messageToSend = String::FromFormat(R"(<?xml version=" 1.0 " encoding=" Windows - 1252 "?><Debugger Command=" % s ">)", command.GetCStr());
 #if AGS_PLATFORM_OS_WINDOWS
 	messageToSend.Append(String::FromFormat("  <EngineWindow>%d</EngineWindow> ", (int)sys_win_get_window()));
@@ -118,8 +118,8 @@ PDebugOutput create_log_output(const String &name, const String &path = "", LogF
 }
 
 // Parses a string where each character defines a single log group; returns list of real group names.
-Std::vector<String> parse_log_multigroup(const String &group_str) {
-	Std::vector<String> grplist;
+std::vector<String> parse_log_multigroup(const String &group_str) {
+	std::vector<String> grplist;
 	for (size_t i = 0; i < group_str.GetLength(); ++i) {
 		switch (group_str[i]) {
 		case 'm':
@@ -157,11 +157,11 @@ MessageType get_messagetype_from_string(const String &mt) {
 	return kDbgMsg_None;
 }
 
-typedef Std::pair<CommonDebugGroup, MessageType> DbgGroupOption;
+typedef std::pair<CommonDebugGroup, MessageType> DbgGroupOption;
 
 void apply_log_config(const ConfigTree &cfg, const String &log_id,
                       bool def_enabled,
-                      Std::initializer_list<DbgGroupOption> def_opts) {
+                      std::initializer_list<DbgGroupOption> def_opts) {
 	String value = CfgReadString(cfg, "log", log_id);
 	if (value.IsEmpty() && !def_enabled)
 		return;
@@ -337,7 +337,7 @@ bool send_state_to_debugger(const String& msg, const String& errorMsg) {
 	if (callStack.IsEmpty())
 		return false;
 
-	Std::vector<Std::pair<String, String>> script_info = {{"ScriptState", callStack}};
+	std::vector<std::pair<String, String>> script_info = {{"ScriptState", callStack}};
 
 	if (!errorMsg.IsEmpty()) {
 		script_info.emplace_back("ErrorMessage", errorMsg);

--- a/engines/ags/engine/debugging/log_file.h
+++ b/engines/ags/engine/debugging/log_file.h
@@ -76,7 +76,7 @@ public:
 	void         CloseFile();
 
 private:
-	Std::unique_ptr<Stream> _file;
+	std::unique_ptr<Stream> _file;
 	String                _filePath;
 	OpenMode              _openMode;
 };

--- a/engines/ags/engine/debugging/message_buffer.cpp
+++ b/engines/ags/engine/debugging/message_buffer.cpp
@@ -55,7 +55,7 @@ void MessageBuffer::Send(const String &out_id) {
 			String::FromFormat("WARNING: output %s lost exceeding buffer: %zu debug messages\n", out_id.GetCStr(), (unsigned)_msgLost),
 		    gr.UID.ID, gr.OutputName, kDbgMsg_All));
 	}
-	for (Std::vector<DebugMessage>::const_iterator it = _buffer.begin(); it != _buffer.end(); ++it) {
+	for (std::vector<DebugMessage>::const_iterator it = _buffer.begin(); it != _buffer.end(); ++it) {
 		_GP(DbgMgr).SendMessage(out_id, *it);
 	}
 }

--- a/engines/ags/engine/debugging/message_buffer.h
+++ b/engines/ags/engine/debugging/message_buffer.h
@@ -55,7 +55,7 @@ public:
 
 private:
 	const size_t    _bufferLimit;
-	Std::vector<DebugMessage> _buffer;
+	std::vector<DebugMessage> _buffer;
 	size_t          _msgLost;
 };
 

--- a/engines/ags/engine/game/game_init.cpp
+++ b/engines/ags/engine/game/game_init.cpp
@@ -287,7 +287,7 @@ void LoadFonts(GameSetupStruct &game, GameDataVersion data_ver) {
 }
 
 void LoadLipsyncData() {
-	Std::unique_ptr<Stream> speechsync(_GP(AssetMgr)->OpenAsset("syncdata.dat", "voice"));
+	std::unique_ptr<Stream> speechsync(_GP(AssetMgr)->OpenAsset("syncdata.dat", "voice"));
 	if (!speechsync)
 		return;
 	// this game has voice lip sync
@@ -360,12 +360,12 @@ HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion dat
 	_GP(charextra).resize(game.numcharacters);
 	_GP(mls).resize(game.numcharacters + MAX_ROOM_OBJECTS + 1);
 	init_game_drawdata();
-	_GP(views) = Std::move(ents.Views);
+	_GP(views) = std::move(ents.Views);
 
 	_GP(play).charProps.resize(game.numcharacters);
-	_G(dialog) = Std::move(ents.Dialogs);
-	_G(old_dialog_scripts) = Std::move(ents.OldDialogScripts);
-	_G(old_speech_lines) = Std::move(ents.OldSpeechLines);
+	_G(dialog) = std::move(ents.Dialogs);
+	_G(old_dialog_scripts) = std::move(ents.OldDialogScripts);
+	_G(old_speech_lines) = std::move(ents.OldSpeechLines);
 	_G(old_dialog_scripts) = ents.OldDialogScripts;
 	_G(old_speech_lines) = ents.OldSpeechLines;
 

--- a/engines/ags/engine/game/savegame.h
+++ b/engines/ags/engine/game/savegame.h
@@ -45,7 +45,7 @@ using Shared::Stream;
 using Shared::String;
 using Shared::Version;
 
-typedef Std::shared_ptr<Stream> PStream;
+typedef std::shared_ptr<Stream> PStream;
 
 //-----------------------------------------------------------------------------
 // Savegame version history
@@ -111,7 +111,7 @@ struct SavegameSource {
 	// Savegame format version
 	SavegameVersion     Version;
 	// A ponter to the opened stream
-	Std::unique_ptr<Stream> InputStream;
+	std::unique_ptr<Stream> InputStream;
 
 	SavegameSource();
 };
@@ -150,7 +150,7 @@ struct SavegameDescription {
 	int                 ColorDepth;
 
 	String              UserText;
-	Std::unique_ptr<Bitmap> UserImage;
+	std::unique_ptr<Bitmap> UserImage;
 
 	SavegameDescription();
 };

--- a/engines/ags/engine/game/savegame_components.cpp
+++ b/engines/ags/engine/game/savegame_components.cpp
@@ -778,7 +778,7 @@ HSaveError ReadOverlays(Stream *in, int32_t cmp_ver, const PreservedParams & /*p
 			over.scaleWidth = over.GetImage()->GetWidth();
 			over.scaleHeight = over.GetImage()->GetHeight();
 		}
-		_GP(screenover).push_back(Std::move(over));
+		_GP(screenover).push_back(std::move(over));
 	}
 	return HSaveError::None();
 }
@@ -1154,7 +1154,7 @@ void component_handlers_free() {
 	delete g_componentHandlers;
 }
 
-typedef Std::map<String, ComponentHandler> HandlersMap;
+typedef std::map<String, ComponentHandler> HandlersMap;
 void GenerateHandlersMap(HandlersMap &map) {
 	map.clear();
 	for (int i = 0; !(*g_componentHandlers)[i].Name.IsEmpty(); ++i)
@@ -1204,7 +1204,7 @@ HSaveError ReadComponent(Stream *in, SvgCmpReadHelper &hlp, ComponentInfo &info)
 		componentName = "Dynamic Surfaces";
 
 	const ComponentHandler *handler = nullptr;
-	Std::map<String, ComponentHandler>::const_iterator it_hdr = hlp.Handlers.find(componentName);
+	std::map<String, ComponentHandler>::const_iterator it_hdr = hlp.Handlers.find(componentName);
 	if (it_hdr != hlp.Handlers.end())
 		handler = &it_hdr->_value;
 

--- a/engines/ags/engine/game/savegame_internal.h
+++ b/engines/ags/engine/game/savegame_internal.h
@@ -35,7 +35,7 @@ namespace Engine {
 
 using AGS::Shared::Bitmap;
 
-typedef Std::shared_ptr<Bitmap> PBitmap;
+typedef std::shared_ptr<Bitmap> PBitmap;
 
 // PreservedParams keeps old values of particular gameplay
 // parameters that are saved before the save restoration
@@ -49,7 +49,7 @@ struct PreservedParams {
 	int GameOptions[GameSetupStructBase::MAX_OPTIONS]{};
 	// Script global data sizes
 	size_t GlScDataSize = 0u;
-	Std::vector<size_t> ScMdDataSize;
+	std::vector<size_t> ScMdDataSize;
 
 	PreservedParams();
 };
@@ -71,16 +71,16 @@ enum ViewportSaveFlags {
 struct RestoredData {
 	int                     FPS;
 	// Unserialized bitmaps for dynamic surfaces
-	Std::vector<Bitmap *>    DynamicSurfaces;
+	std::vector<Bitmap *>    DynamicSurfaces;
 	// Scripts global data
 	struct ScriptData {
-		Std::vector<char>	Data;
+		std::vector<char>	Data;
 		size_t              Len;
 
 		ScriptData();
 	};
 	ScriptData              GlobalScript;
-	Std::vector<ScriptData> ScriptModules;
+	std::vector<ScriptData> ScriptModules;
 	// Room data (has to be be preserved until room is loaded)
 	PBitmap                 RoomBkgScene[MAX_ROOM_BGFRAMES];
 	int16_t                 RoomLightLevels[MAX_ROOM_REGIONS];
@@ -129,8 +129,8 @@ struct RestoredData {
 		int Width = 0;
 		int Height = 0;
 	};
-	Std::vector<ViewportData> Viewports;
-	Std::vector<CameraData> Cameras;
+	std::vector<ViewportData> Viewports;
+	std::vector<CameraData> Cameras;
 	int32_t Camera0_Flags = 0; // flags for primary camera, when data is read in legacy order
 
 	RestoredData();

--- a/engines/ags/engine/game/savegame_v321.cpp
+++ b/engines/ags/engine/game/savegame_v321.cpp
@@ -83,7 +83,7 @@ inline bool AssertGameContent(HSaveError &err, int game_val, int sav_val, const 
 }
 
 template<typename TObject>
-inline bool AssertAndCopyGameContent(const Std::vector<TObject> &old_list, Std::vector<TObject> &new_list,
+inline bool AssertAndCopyGameContent(const std::vector<TObject> &old_list, std::vector<TObject> &new_list,
 									 HSaveError &err, const char *content_name, bool warn_only = false) {
 	if (!AssertGameContent(err, old_list.size(), new_list.size(), content_name, warn_only))
 		return false;
@@ -254,13 +254,13 @@ static HSaveError restore_game_gui(Stream *in) {
 	// (could be unintentional side effect). Here we emulate this for
 	// upgraded games by letting read **less** data from saves, and copying
 	// missing elements from reserved game data.
-	const Std::vector<GUIMain> res_guis = Std::move(_GP(guis));
-	const Std::vector<GUIButton> res_guibuts = Std::move(_GP(guibuts));
-	const Std::vector<GUIInvWindow> res_guiinv = Std::move(_GP(guiinv));
-	const Std::vector<GUILabel> res_guilabels = Std::move(_GP(guilabels));
-	const Std::vector<GUIListBox> res_guilist = Std::move(_GP(guilist));
-	const Std::vector<GUISlider> res_guislider = Std::move(_GP(guislider));
-	const Std::vector<GUITextBox> res_guitext = Std::move(_GP(guitext));
+	const std::vector<GUIMain> res_guis = std::move(_GP(guis));
+	const std::vector<GUIButton> res_guibuts = std::move(_GP(guibuts));
+	const std::vector<GUIInvWindow> res_guiinv = std::move(_GP(guiinv));
+	const std::vector<GUILabel> res_guilabels = std::move(_GP(guilabels));
+	const std::vector<GUIListBox> res_guilist = std::move(_GP(guilist));
+	const std::vector<GUISlider> res_guislider = std::move(_GP(guislider));
+	const std::vector<GUITextBox> res_guitext = std::move(_GP(guitext));
 
 	HError guierr = GUI::ReadGUI(in, true);
 	if (!guierr)
@@ -319,7 +319,7 @@ static void restore_game_ambientsounds(Stream *in, RestoredData &r_data) {
 	}
 }
 
-static void ReadOverlays_Aligned(Stream *in, Std::vector<bool> &has_bitmap, size_t num_overs) {
+static void ReadOverlays_Aligned(Stream *in, std::vector<bool> &has_bitmap, size_t num_overs) {
 	AlignedStream align_s(in, Shared::kAligned_Read);
 	has_bitmap.resize(num_overs);
 	for (size_t i = 0; i < num_overs; ++i) {
@@ -333,7 +333,7 @@ static void ReadOverlays_Aligned(Stream *in, Std::vector<bool> &has_bitmap, size
 static void restore_game_overlays(Stream *in) {
 	size_t num_overs = in->ReadInt32();
 	_GP(screenover).resize(num_overs);
-	Std::vector<bool> has_bitmap;
+	std::vector<bool> has_bitmap;
 	ReadOverlays_Aligned(in, has_bitmap, num_overs);
 	for (size_t i = 0; i < num_overs; ++i) {
 		if (has_bitmap[i])
@@ -463,7 +463,7 @@ HSaveError restore_save_data_v321(Stream *in, GameDataVersion data_ver, const Pr
 	ccScript *compsc = _GP(game).compiled_script;
 	CharacterInfo *chwas = _GP(game).chars;
 	WordsDictionary *olddict = _GP(game).dict;
-	Std::vector<String> mesbk(MAXGLOBALMES);
+	std::vector<String> mesbk(MAXGLOBALMES);
 	for (size_t i = 0; i < MAXGLOBALMES; ++i)
 		mesbk[i] = _GP(game).messages[i];
 

--- a/engines/ags/engine/game/viewport.cpp
+++ b/engines/ags/engine/game/viewport.cpp
@@ -121,7 +121,7 @@ void Camera::UnlinkFromViewport(int id) {
 	}
 }
 
-const Std::vector<ViewportRef> &Camera::GetLinkedViewports() const {
+const std::vector<ViewportRef> &Camera::GetLinkedViewports() const {
 	return _viewportRefs;
 }
 
@@ -187,21 +187,21 @@ void Viewport::LinkCamera(PCamera cam) {
 VpPoint Viewport::RoomToScreen(int roomx, int roomy, bool clip) const {
 	auto cam = _camera.lock();
 	if (!cam)
-		return Std::make_pair(Point(), -1);
+		return std::make_pair(Point(), -1);
 	const Rect &camr = cam->GetRect();
 	Point screen_pt = _transform.Scale(Point(roomx - camr.Left, roomy - camr.Top));
 	if (clip && !_position.IsInside(screen_pt))
-		return Std::make_pair(Point(), -1);
-	return Std::make_pair(screen_pt, _id);
+		return std::make_pair(Point(), -1);
+	return std::make_pair(screen_pt, _id);
 }
 
 VpPoint Viewport::ScreenToRoom(int scrx, int scry, bool clip, bool convert_cam_to_data) const {
 	Point screen_pt(scrx, scry);
 	if (clip && !_position.IsInside(screen_pt))
-		return Std::make_pair(Point(), -1);
+		return std::make_pair(Point(), -1);
 	auto cam = _camera.lock();
 	if (!cam)
-		return Std::make_pair(Point(), -1);
+		return std::make_pair(Point(), -1);
 
 	const Rect &camr = cam->GetRect();
 	Point p = _transform.UnScale(screen_pt);
@@ -212,7 +212,7 @@ VpPoint Viewport::ScreenToRoom(int scrx, int scry, bool clip, bool convert_cam_t
 		p.X += camr.Left;
 		p.Y += camr.Top;
 	}
-	return Std::make_pair(p, _id);
+	return std::make_pair(p, _id);
 }
 
 } // namespace AGS3

--- a/engines/ags/engine/game/viewport.h
+++ b/engines/ags/engine/game/viewport.h
@@ -38,17 +38,17 @@ namespace AGS3 {
 class Camera;
 class Viewport;
 
-typedef Std::shared_ptr<Camera> PCamera;
-typedef Std::shared_ptr<Viewport> PViewport;
-typedef Std::weak_ptr<Camera> CameraRef;
-typedef Std::weak_ptr<Viewport> ViewportRef;
+typedef std::shared_ptr<Camera> PCamera;
+typedef std::shared_ptr<Viewport> PViewport;
+typedef std::weak_ptr<Camera> CameraRef;
+typedef std::weak_ptr<Viewport> ViewportRef;
 
 // TODO: move to utility header
 // From https://stackoverflow.com/questions/45507041/how-to-check-if-weak-ptr-is-empty-non-assigned
 // Tests that weak_ptr is empty (was not initialized with valid reference)
 template <typename T>
-bool is_uninitialized(Std::weak_ptr<T> const &weak) {
-	using wt = Std::weak_ptr<T>;
+bool is_uninitialized(std::weak_ptr<T> const &weak) {
+	using wt = std::weak_ptr<T>;
 	return !weak.owner_before(wt{}) &&!wt{} .owner_before(weak);
 }
 
@@ -88,7 +88,7 @@ public:
 	// Unlinks this camera from a given viewport; does nothing if link did not exist
 	void UnlinkFromViewport(int id);
 	// Get the array of linked viewport references
-	const Std::vector<ViewportRef> &GetLinkedViewports() const;
+	const std::vector<ViewportRef> &GetLinkedViewports() const;
 
 	// Tell if this camera has changed recently
 	inline bool HasChangedPosition() const {
@@ -110,7 +110,7 @@ private:
 	// Locked or following player automatically
 	bool _locked = false;
 	// Linked viewport refs, used to notify viewports of camera changes
-	Std::vector<ViewportRef> _viewportRefs;
+	std::vector<ViewportRef> _viewportRefs;
 	// Flags that tell whether this camera's position on screen has changed recently
 	bool _hasChangedPosition = false;
 	bool _hasChangedSize = false;
@@ -119,7 +119,7 @@ private:
 
 // A result of coordinate conversion between screen and the room,
 // tells which viewport was used to pass the "touch" through.
-typedef Std::pair<Point, int> VpPoint;
+typedef std::pair<Point, int> VpPoint;
 
 
 // Viewport class defines a rectangular area on game screen where the contents

--- a/engines/ags/engine/gfx/ali_3d_scummvm.cpp
+++ b/engines/ags/engine/gfx/ali_3d_scummvm.cpp
@@ -77,7 +77,7 @@ int ScummVMRendererGraphicsDriver::GetDisplayDepthForNativeDepth(int native_colo
 }
 
 IGfxModeList *ScummVMRendererGraphicsDriver::GetSupportedModeList(int color_depth) {
-	Std::vector<DisplayMode> modes;
+	std::vector<DisplayMode> modes;
 	sys_get_desktop_modes(modes, color_depth);
 	if ((modes.size() == 0) && color_depth == 32) {
 		// Pretend that 24-bit are 32-bit

--- a/engines/ags/engine/gfx/ali_3d_scummvm.h
+++ b/engines/ags/engine/gfx/ali_3d_scummvm.h
@@ -115,7 +115,7 @@ public:
 
 class ScummVMRendererGfxModeList : public IGfxModeList {
 public:
-	ScummVMRendererGfxModeList(const Std::vector<DisplayMode> &modes)
+	ScummVMRendererGfxModeList(const std::vector<DisplayMode> &modes)
 		: _modes(modes) {
 	}
 
@@ -132,7 +132,7 @@ public:
 	}
 
 private:
-	Std::vector<DisplayMode> _modes;
+	std::vector<DisplayMode> _modes;
 };
 
 
@@ -146,13 +146,13 @@ struct ALSpriteBatch {
 	// Optional model transformation, to be applied to each sprite
 	SpriteTransform Transform;
 	// Intermediate surface which will be drawn upon and transformed if necessary
-	Std::shared_ptr<Bitmap> Surface;
+	std::shared_ptr<Bitmap> Surface;
 	// Whether surface is a parent surface's region (e.g. virtual screen)
 	bool IsParentRegion = false;
 	// Tells whether the surface is treated as opaque or transparent
 	bool Opaque = false;
 };
-typedef Std::vector<ALSpriteBatch> ALSpriteBatches;
+typedef std::vector<ALSpriteBatch> ALSpriteBatches;
 
 
 class ScummVMRendererGraphicsDriver : public GraphicsDriverBase {
@@ -233,7 +233,7 @@ public:
 		return false; /* not supported */
 	}
 
-	typedef Std::shared_ptr<ScummVMRendererGfxFilter> PSDLRenderFilter;
+	typedef std::shared_ptr<ScummVMRendererGfxFilter> PSDLRenderFilter;
 
 	void SetGraphicsFilter(PSDLRenderFilter filter);
 
@@ -263,7 +263,7 @@ private:
 	int _lastTexPitch = -1;
 
 	// Original virtual screen created and managed by the renderer.
-	Std::unique_ptr<Bitmap> _origVirtualScreen;
+	std::unique_ptr<Bitmap> _origVirtualScreen;
 	// Current virtual screen bitmap; may be either pointing to _origVirtualScreen,
 	// or provided by external user (for example - plugin).
 	// Its pixels are copied to the video texture to be presented by SDL_Renderer.
@@ -277,7 +277,7 @@ private:
 	// Sprite batches (parent scene nodes)
 	ALSpriteBatches _spriteBatches;
 	// List of sprites to render
-	Std::vector<ALDrawListEntry> _spriteList;
+	std::vector<ALDrawListEntry> _spriteList;
 
 	void InitSpriteBatch(size_t index, const SpriteBatchDesc &desc) override;
 	void ResetAllBatches() override;

--- a/engines/ags/engine/gfx/gfx_driver_base.cpp
+++ b/engines/ags/engine/gfx/gfx_driver_base.cpp
@@ -89,7 +89,7 @@ bool GraphicsDriverBase::GetVsync() const {
 void GraphicsDriverBase::BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform,
 	GraphicFlip flip, PBitmap surface) {
 	_spriteBatchDesc.push_back(SpriteBatchDesc(_actSpriteBatch, viewport, transform, flip, surface));
-	_spriteBatchRange.push_back(Std::make_pair(GetLastDrawEntryIndex(), (size_t) SIZE_MAX));
+	_spriteBatchRange.push_back(std::make_pair(GetLastDrawEntryIndex(), (size_t) SIZE_MAX));
 	_actSpriteBatch = _spriteBatchDesc.size() - 1;
 	InitSpriteBatch(_actSpriteBatch, _spriteBatchDesc[_actSpriteBatch]);
 }
@@ -213,7 +213,7 @@ IDriverDependantBitmap *VideoMemoryGraphicsDriver::GetSharedDDB(uint32_t sprite_
 	}
 
 	// Create and add a new element
-	Std::shared_ptr<TextureData> txdata(CreateTextureData(bitmap->GetWidth(), bitmap->GetHeight(), opaque));
+	std::shared_ptr<TextureData> txdata(CreateTextureData(bitmap->GetWidth(), bitmap->GetHeight(), opaque));
 	txdata->ID = sprite_id;
 	UpdateTextureData(txdata.get(), bitmap, opaque, hasAlpha);
 	// only add into the map when has valid sprite ID

--- a/engines/ags/engine/gfx/gfx_driver_base.h
+++ b/engines/ags/engine/gfx/gfx_driver_base.h
@@ -67,7 +67,7 @@ struct SpriteBatchDesc {
 	}
 };
 
-typedef Std::vector<SpriteBatchDesc> SpriteBatchDescs;
+typedef std::vector<SpriteBatchDesc> SpriteBatchDescs;
 
 // The single sprite entry in the render list
 template<class T_DDB>
@@ -179,7 +179,7 @@ protected:
 	SpriteBatchDescs _spriteBatchDesc;
 	// The range of sprites in this sprite batch (counting nested sprites):
 	// the last of the previous batch, and the last of the current.
-	Std::vector<Std::pair<size_t, size_t>> _spriteBatchRange;
+	std::vector<std::pair<size_t, size_t>> _spriteBatchRange;
 	// The index of a currently filled sprite batch
 	size_t _actSpriteBatch;
 	// The index of a currently rendered sprite batch
@@ -266,10 +266,10 @@ protected:
 	// Update texture data from the given bitmap
 	virtual void UpdateTextureData(TextureData *txdata, Bitmap *bmp, bool opaque, bool hasAlpha) = 0;
 	// Create DDB using preexisting texture data
-	virtual IDriverDependantBitmap *CreateDDB(Std::shared_ptr<TextureData> txdata,
+	virtual IDriverDependantBitmap *CreateDDB(std::shared_ptr<TextureData> txdata,
 		  int width, int height, int color_depth, bool opaque) = 0;
 	// Retrieve shared texture data object from the given DDB
-	virtual Std::shared_ptr<TextureData> GetTextureData(IDriverDependantBitmap *ddb) = 0;
+	virtual std::shared_ptr<TextureData> GetTextureData(IDriverDependantBitmap *ddb) = 0;
 	virtual void DestroyDDBImpl(IDriverDependantBitmap* ddb) = 0;
 
 	// Stage screens are raw bitmap buffers meant to be sent to plugins on demand
@@ -325,10 +325,10 @@ private:
 	// pair, and subbitmaps for raw drawing on separate stages.
 	struct StageScreen {
 		Rect Position; // bitmap size and pos preset (bitmap may be created later)
-		Std::unique_ptr<Bitmap> Raw;
+		std::unique_ptr<Bitmap> Raw;
 		IDriverDependantBitmap *DDB = nullptr;
 	};
-	Std::vector<StageScreen> _stageScreens;
+	std::vector<StageScreen> _stageScreens;
 	// Flag which indicates whether stage screen was drawn upon during engine
 	// callback and has to be inserted into sprite stack.
 	bool _stageScreenDirty;
@@ -341,7 +341,7 @@ private:
 		int Green = -1;
 		int Blue = -1;
 	};
-	Std::vector<ScreenFx> _fxPool;
+	std::vector<ScreenFx> _fxPool;
 	size_t _fxIndex; // next free pool item
 
 	// Texture short-term cache:
@@ -353,12 +353,12 @@ private:
 	// textures of the same size (research potential performance impact).
 	struct TextureCacheItem {
 		GraphicResolution Res;
-		Std::weak_ptr<TextureData> Data;
+		std::weak_ptr<TextureData> Data;
 		TextureCacheItem() = default;
-		TextureCacheItem(Std::shared_ptr<TextureData> data, const GraphicResolution &res)
+		TextureCacheItem(std::shared_ptr<TextureData> data, const GraphicResolution &res)
 			: Data(data), Res(res) {}
 	};
-	Std::unordered_map<uint32_t, TextureCacheItem> _txRefs;
+	std::unordered_map<uint32_t, TextureCacheItem> _txRefs;
 };
 
 } // namespace Engine

--- a/engines/ags/engine/gfx/gfx_driver_factory.h
+++ b/engines/ags/engine/gfx/gfx_driver_factory.h
@@ -45,7 +45,7 @@ using Shared::StringV;
 class IGraphicsDriver;
 class IGfxFilter;
 struct GfxFilterInfo;
-typedef Std::shared_ptr<IGfxFilter> PGfxFilter;
+typedef std::shared_ptr<IGfxFilter> PGfxFilter;
 
 
 class IGfxDriverFactory {

--- a/engines/ags/engine/gfx/gfx_driver_factory_base.h
+++ b/engines/ags/engine/gfx/gfx_driver_factory_base.h
@@ -76,7 +76,7 @@ public:
 			return PGfxFilter();
 		}
 
-		Std::shared_ptr<TGfxFilterClass> filter(CreateFilter(id));
+		std::shared_ptr<TGfxFilterClass> filter(CreateFilter(id));
 		if (!filter) {
 			filter_error = "Filter does not exist";
 			return PGfxFilter();

--- a/engines/ags/engine/gfx/gfxfilter.h
+++ b/engines/ags/engine/gfx/gfxfilter.h
@@ -69,7 +69,7 @@ public:
 	virtual Rect GetDestination() const = 0;
 };
 
-typedef Std::shared_ptr<IGfxFilter> PGfxFilter;
+typedef std::shared_ptr<IGfxFilter> PGfxFilter;
 
 } // namespace Engine
 } // namespace AGS

--- a/engines/ags/engine/gfx/graphics_driver.h
+++ b/engines/ags/engine/gfx/graphics_driver.h
@@ -41,7 +41,7 @@ namespace AGS {
 
 namespace Shared {
 class Bitmap;
-typedef Std::shared_ptr<Shared::Bitmap> PBitmap;
+typedef std::shared_ptr<Shared::Bitmap> PBitmap;
 } // namespace Shared
 
 namespace Engine {
@@ -49,7 +49,7 @@ namespace Engine {
 // Forward declaration
 class IDriverDependantBitmap;
 class IGfxFilter;
-typedef Std::shared_ptr<IGfxFilter> PGfxFilter;
+typedef std::shared_ptr<IGfxFilter> PGfxFilter;
 using Shared::PBitmap;
 
 enum TintMethod {

--- a/engines/ags/engine/gui/gui_dialog.cpp
+++ b/engines/ags/engine/gui/gui_dialog.cpp
@@ -350,7 +350,7 @@ int enternumberwindow(char *prompttext) {
 }
 
 int roomSelectorWindow(int currentRoom, int numRooms,
-		const Std::vector<int> &roomNumbers, const Std::vector<String> &roomNames) {
+		const std::vector<int> &roomNumbers, const std::vector<String> &roomNames) {
 	char labeltext[200];
 	Common::strcpy_s(labeltext, get_global_message(MSG_SAVEDIALOG));
 	const int wnd_width = 240;

--- a/engines/ags/engine/gui/gui_dialog.h
+++ b/engines/ags/engine/gui/gui_dialog.h
@@ -48,7 +48,7 @@ void preparesavegamelist(int ctrllist);
 void enterstringwindow(const char *prompttext, char *stouse);
 int  enternumberwindow(char *prompttext);
 int  roomSelectorWindow(int currentRoom, int numRooms,
-	const Std::vector<int> &roomNumbers, const Std::vector<AGS::Shared::String> &roomNames);
+	const std::vector<int> &roomNumbers, const std::vector<AGS::Shared::String> &roomNames);
 int  myscimessagebox(const char *lpprompt, char *btn1, char *btn2);
 int  quitdialog();
 

--- a/engines/ags/engine/main/engine.cpp
+++ b/engines/ags/engine/main/engine.cpp
@@ -330,7 +330,7 @@ void engine_init_audio() {
 		Debug::Printf("Initializing audio");
 		try {
 			audio_core_init(); // audio core system
-		} catch (Std::runtime_error ex) {
+		} catch (std::runtime_error ex) {
 			Debug::Printf(kDbgMsg_Error, "Failed to initialize audio: %s", ex.what());
 			usetup.audio_backend = 0;
 		}
@@ -978,12 +978,12 @@ void engine_set_config(const ConfigTree cfg) {
 	post_config();
 }
 
-static bool print_info_needs_game(const Std::set<String> &keys) {
+static bool print_info_needs_game(const std::set<String> &keys) {
 	return keys.count("all") > 0 || keys.count("config") > 0 || keys.count("configpath") > 0 ||
 	       keys.count("data") > 0 || keys.count("filepath") > 0 || keys.count("gameproperties") > 0;
 }
 
-static void engine_print_info(const Std::set<String> &keys, ConfigTree *user_cfg) {
+static void engine_print_info(const std::set<String> &keys, ConfigTree *user_cfg) {
 	const bool all = keys.count("all") > 0;
 	ConfigTree data;
 	if (all || keys.count("engine") > 0) {

--- a/engines/ags/engine/main/game_file.cpp
+++ b/engines/ags/engine/main/game_file.cpp
@@ -57,16 +57,16 @@ using namespace AGS::Shared;
 using namespace AGS::Engine;
 
 // Test if engine supports extended capabilities required to run the game
-bool test_game_caps(const Std::set<String> &caps, Std::set<String> &failed_caps) {
+bool test_game_caps(const std::set<String> &caps, std::set<String> &failed_caps) {
 	// Currently we support nothing special
 	failed_caps = caps;
 	return caps.size() == 0;
 }
 
 // Forms a simple list of capability names
-String get_caps_list(const Std::set<String> &caps) {
+String get_caps_list(const std::set<String> &caps) {
 	String caps_list;
-	for (Std::set<String>::const_iterator it = caps.begin(); it != caps.end(); ++it) {
+	for (std::set<String>::const_iterator it = caps.begin(); it != caps.end(); ++it) {
 		caps_list.Append("\n\t");
 		caps_list.Append(*it);
 	}
@@ -95,7 +95,7 @@ HGameFileError game_file_first_open(MainGameSource &src) {
 		return err;
 
 	// Test the extended caps
-	Std::set<String> failed_caps;
+	std::set<String> failed_caps;
 	if (!test_game_caps(src.Caps, failed_caps)) {
 		String caps_list = get_caps_list(failed_caps);
 		return new MainGameFileError(kMGFErr_CapsNotSupported, String::FromFormat("Missing engine caps: %s", caps_list.GetCStr()));
@@ -127,7 +127,7 @@ static inline HError MakeScriptLoadError(const char *name) {
 // in the already loaded game data.
 HError LoadGameScripts(LoadedGameEntities &ents) {
 	// Global script
-	Std::unique_ptr<Stream> in(_GP(AssetMgr)->OpenAsset("GlobalScript.o"));
+	std::unique_ptr<Stream> in(_GP(AssetMgr)->OpenAsset("GlobalScript.o"));
 	if (in) {
 		PScript script(ccScript::CreateFromStream(in.get()));
 		if (!script)
@@ -144,7 +144,7 @@ HError LoadGameScripts(LoadedGameEntities &ents) {
 	}
 	// Script modules
 	// First load a modules list
-	Std::vector<String> modules;
+	std::vector<String> modules;
 	in.reset(_GP(AssetMgr)->OpenAsset("ScriptModules.lst"));
 	if (in) {
 		TextStreamReader reader(in.get());

--- a/engines/ags/engine/main/game_run.cpp
+++ b/engines/ags/engine/main/game_run.cpp
@@ -748,10 +748,10 @@ static void game_loop_update_loop_counter() {
 
 static void game_loop_update_fps() {
 	auto t2 = AGS_Clock::now();
-	auto duration = Std::chrono::duration_cast<Std::chrono::milliseconds>(t2 - _G(t1));
+	auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - _G(t1));
 	auto frames = _G(loopcounter) - _G(lastcounter);
 
-	if (duration >= Std::chrono::milliseconds(1000) && frames > 0) {
+	if (duration >= std::chrono::milliseconds(1000) && frames > 0) {
 		_G(fps) = 1000.0f * frames / duration.count();
 		_G(t1) = t2;
 		_G(lastcounter) = _G(loopcounter);
@@ -771,7 +771,7 @@ void set_loop_counter(unsigned int new_counter) {
 	_G(loopcounter) = new_counter;
 	_G(t1) = AGS_Clock::now();
 	_G(lastcounter) = _G(loopcounter);
-	_G(fps) = Std::numeric_limits<float>::quiet_NaN();
+	_G(fps) = std::numeric_limits<float>::quiet_NaN();
 }
 
 void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int extraX, int extraY) {

--- a/engines/ags/engine/main/game_start.cpp
+++ b/engines/ags/engine/main/game_start.cpp
@@ -62,7 +62,7 @@ void start_game_init_editor_debugging() {
 	_GP(usetup).override_multitasking = -1;
 	SetMultitasking(1);
 
-	auto waitUntil = AGS_Clock::now() + Std::chrono::milliseconds(500);
+	auto waitUntil = AGS_Clock::now() + std::chrono::milliseconds(500);
 	while (waitUntil > AGS_Clock::now()) {
 		// pick up any breakpoints in game_start
 		check_for_messages_from_debugger();

--- a/engines/ags/engine/main/graphics_mode.cpp
+++ b/engines/ags/engine/main/graphics_mode.cpp
@@ -214,7 +214,7 @@ bool try_init_compatible_mode(const DisplayMode &dm) {
 		Debug::Printf("Maximal allowed window size: %d x %d", device_size.Width, device_size.Height);
 	DisplayMode dm_compat = dm;
 
-	Std::unique_ptr<IGfxModeList> modes(_G(gfxDriver)->GetSupportedModeList(dm.ColorDepth));
+	std::unique_ptr<IGfxModeList> modes(_G(gfxDriver)->GetSupportedModeList(dm.ColorDepth));
 
 	// Windowed mode
 	if (dm.IsWindowed()) {

--- a/engines/ags/engine/main/update.cpp
+++ b/engines/ags/engine/main/update.cpp
@@ -201,7 +201,7 @@ void update_player_view() {
 		_G(playerchar)->view = _G(playerchar)->defview;
 }
 
-void update_character_move_and_anim(Std::vector<int> &followingAsSheep) {
+void update_character_move_and_anim(std::vector<int> &followingAsSheep) {
 	// move & animate characters
 	for (int aa = 0; aa < _GP(game).numcharacters; aa++) {
 		if (_GP(game).chars[aa].on != 1) continue;
@@ -213,7 +213,7 @@ void update_character_move_and_anim(Std::vector<int> &followingAsSheep) {
 	}
 }
 
-void update_following_exactly_characters(const Std::vector<int> &followingAsSheep) {
+void update_following_exactly_characters(const std::vector<int> &followingAsSheep) {
 	// update location of all following_exactly characters
 	for (size_t i = 0; i < followingAsSheep.size(); ++i) {
 		CharacterInfo *chi = &_GP(game).chars[followingAsSheep[i]];
@@ -437,7 +437,7 @@ void update_stuff() {
 
 	_G(our_eip) = 22;
 
-	Std::vector<int> followingAsSheep;
+	std::vector<int> followingAsSheep;
 
 	update_character_move_and_anim(followingAsSheep);
 

--- a/engines/ags/engine/media/audio/audio.cpp
+++ b/engines/ags/engine/media/audio/audio.cpp
@@ -684,7 +684,7 @@ void schedule_music_update_at(AGS_Clock::time_point at) {
 	_G(music_update_at) = at;
 }
 
-void postpone_scheduled_music_update_by(Std::chrono::milliseconds duration) {
+void postpone_scheduled_music_update_by(std::chrono::milliseconds duration) {
 	if (!_G(music_update_scheduled)) {
 		return;
 	}

--- a/engines/ags/engine/media/audio/audio.h
+++ b/engines/ags/engine/media/audio/audio.h
@@ -118,7 +118,7 @@ void        newmusic(int mnum);
 
 extern void cancel_scheduled_music_update();
 extern void schedule_music_update_at(AGS_Clock::time_point);
-extern void postpone_scheduled_music_update_by(Std::chrono::milliseconds);
+extern void postpone_scheduled_music_update_by(std::chrono::milliseconds);
 
 } // namespace AGS3
 

--- a/engines/ags/engine/media/video/video.cpp
+++ b/engines/ags/engine/media/video/video.cpp
@@ -55,7 +55,7 @@ namespace AGS3 {
 using AGS::Shared::AssetManager;
 
 static bool play_video(Video::VideoDecoder *decoder, const char *name, int flags, VideoSkipType skip, bool showError) {
-	Std::unique_ptr<Stream> video_stream(_GP(AssetMgr)->OpenAsset(name));
+	std::unique_ptr<Stream> video_stream(_GP(AssetMgr)->OpenAsset(name));
 	if (!video_stream) {
 		if (showError)
 			Display("Unable to load video '%s'", name);

--- a/engines/ags/engine/platform/base/ags_platform_driver.cpp
+++ b/engines/ags/engine/platform/base/ags_platform_driver.cpp
@@ -75,7 +75,7 @@ void AGSPlatformDriver::PauseApplication() {
 void AGSPlatformDriver::ResumeApplication() {
 }
 
-void AGSPlatformDriver::GetSystemDisplayModes(Std::vector<DisplayMode> &dms) {
+void AGSPlatformDriver::GetSystemDisplayModes(std::vector<DisplayMode> &dms) {
 }
 
 bool AGSPlatformDriver::EnterFullscreenMode(const DisplayMode &dm) {
@@ -148,7 +148,7 @@ void AGSPlatformDriver::YieldCPU() {
 	// NOTE: this is called yield, but if we actually yield instead of delay,
 	// we get a massive increase in CPU usage.
 	this->Delay(10);
-	//Std::this_thread::yield();
+	//std::this_thread::yield();
 }
 
 void AGSPlatformDriver::InitialiseAbufAtStartup() {
@@ -255,16 +255,16 @@ int cd_player_control(int cmdd, int datt) {
 
 void AGSPlatformDriver::Delay(int millis) {
 	auto now = AGS_Clock::now();
-	auto delayUntil = now + Std::chrono::milliseconds(millis);
+	auto delayUntil = now + std::chrono::milliseconds(millis);
 
 	for (;;) {
 		if (now >= delayUntil) {
 			break;
 		}
 
-		auto duration = MIN<Std::chrono::milliseconds>(delayUntil - now,
+		auto duration = MIN<std::chrono::milliseconds>(delayUntil - now,
 		                _G(MaximumDelayBetweenPolling));
-		Std::this_thread::sleep_for(duration);
+		std::this_thread::sleep_for(duration);
 		now = AGS_Clock::now(); // update now
 
 		if (now >= delayUntil) {

--- a/engines/ags/engine/platform/base/ags_platform_driver.h
+++ b/engines/ags/engine/platform/base/ags_platform_driver.h
@@ -158,7 +158,7 @@ struct AGSPlatformDriver
 	// Called when the application is being resumed.
 	virtual void ResumeApplication();
 	// Returns a list of supported display modes
-	virtual void GetSystemDisplayModes(Std::vector<Engine::DisplayMode> &dms);
+	virtual void GetSystemDisplayModes(std::vector<Engine::DisplayMode> &dms);
 	// Switch to system fullscreen mode; store previous mode parameters
 	virtual bool EnterFullscreenMode(const Engine::DisplayMode &dm);
 	// Return back to the mode was before switching to fullscreen

--- a/engines/ags/engine/platform/base/sys_main.cpp
+++ b/engines/ags/engine/platform/base/sys_main.cpp
@@ -61,7 +61,7 @@ int sys_get_desktop_resolution(int &width, int &height) {
 	return 0;
 }
 
-void sys_get_desktop_modes(Std::vector<AGS::Engine::DisplayMode> &dms, int color_depth) {
+void sys_get_desktop_modes(std::vector<AGS::Engine::DisplayMode> &dms, int color_depth) {
 #ifdef TODO
 	SDL_DisplayMode mode;
 	const int display_id = DEFAULT_DISPLAY_INDEX;

--- a/engines/ags/engine/platform/base/sys_main.h
+++ b/engines/ags/engine/platform/base/sys_main.h
@@ -50,7 +50,7 @@ void sys_set_background_mode(bool on);
 // Queries current desktop resolution.
 int sys_get_desktop_resolution(int &width, int &height);
 // Queries supported desktop modes.
-void sys_get_desktop_modes(Std::vector<AGS::Engine::DisplayMode> &dms, int color_depth = 0);
+void sys_get_desktop_modes(std::vector<AGS::Engine::DisplayMode> &dms, int color_depth = 0);
 // Sets output driver for the backend's renderer
 void sys_renderer_set_output(const AGS::Shared::String &name);
 

--- a/engines/ags/engine/platform/scummvm/scummvm_platform_driver.cpp
+++ b/engines/ags/engine/platform/scummvm/scummvm_platform_driver.cpp
@@ -55,7 +55,7 @@ struct ScummVMPlatformDriver : AGSPlatformDriver {
 	void ShutdownCDPlayer() override;
 	bool LockMouseToWindow() override;
 	void UnlockMouse() override;
-	void GetSystemDisplayModes(Std::vector<Engine::DisplayMode> &dms) override;
+	void GetSystemDisplayModes(std::vector<Engine::DisplayMode> &dms) override;
 };
 
 
@@ -144,7 +144,7 @@ bool ScummVMPlatformDriver::LockMouseToWindow() {
 void ScummVMPlatformDriver::UnlockMouse() {
 }
 
-void ScummVMPlatformDriver::GetSystemDisplayModes(Std::vector<Engine::DisplayMode> &dms) {
+void ScummVMPlatformDriver::GetSystemDisplayModes(std::vector<Engine::DisplayMode> &dms) {
 	dms.clear();
 	GFX_MODE_LIST *gmlist = get_gfx_mode_list(GFX_SCUMMVM);
 	for (int i = 0; i < gmlist->num_modes; ++i) {

--- a/engines/ags/engine/script/cc_instance.cpp
+++ b/engines/ags/engine/script/cc_instance.cpp
@@ -455,9 +455,9 @@ int ccInstance::Run(int32_t curpc) {
 	unsigned loopIterations = 0u;      // any loop iterations (needed for timeout test)
 	unsigned loopCheckIterations = 0u; // loop iterations accumulated only if check is enabled
 
-	const auto timeout = Std::chrono::milliseconds(_G(timeoutCheckMs));
+	const auto timeout = std::chrono::milliseconds(_G(timeoutCheckMs));
 	// NOTE: removed timeout_abort check for now: was working *logically* wrong;
-	//const auto timeout_abort = Std::chrono::milliseconds(_G(timeoutAbortMs));
+	//const auto timeout_abort = std::chrono::milliseconds(_G(timeoutAbortMs));
 	_lastAliveTs = AGS_Clock::now();
 
 	while ((flags & INSTF_ABORTED) == 0) {
@@ -802,7 +802,7 @@ int ccInstance::Run(int32_t curpc) {
 					cc_error("!Script appears to be hung (a while loop ran %d times). The problem may be in a calling function; check the call stack.", (int)loopCheckIterations);
 					return -1;
 				} else if ((loopIterations & 0x3FF) == 0 && // test each 1024 loops (arbitrary)
-						   (Std::chrono::duration_cast<Std::chrono::milliseconds>(AGS_Clock::now() - _lastAliveTs) > timeout)) {
+						   (std::chrono::duration_cast<std::chrono::milliseconds>(AGS_Clock::now() - _lastAliveTs) > timeout)) {
 					// minimal timeout occurred
 					// NOTE: removed timeout_abort check for now: was working *logically* wrong;
 					sys_evt_process_pending();
@@ -1626,7 +1626,7 @@ bool ccInstance::AddGlobalVar(const ScriptVariable &glvar) {
 		/* return false; */
 		Debug::Printf(kDbgMsg_Warn, "WARNING: global variable refers to data beyond allocated buffer (%d, %d)", glvar.ScAddress, globaldatasize);
 	}
-	globalvars->insert(Std::make_pair(glvar.ScAddress, glvar));
+	globalvars->insert(std::make_pair(glvar.ScAddress, glvar));
 	return true;
 }
 

--- a/engines/ags/engine/script/cc_instance.h
+++ b/engines/ags/engine/script/cc_instance.h
@@ -98,8 +98,8 @@ struct ScriptPosition {
 // Running instance of the script
 struct ccInstance {
 public:
-	typedef Std::unordered_map<int32_t, ScriptVariable> ScVarMap;
-	typedef Std::shared_ptr<ScVarMap>                   PScVarMap;
+	typedef std::unordered_map<int32_t, ScriptVariable> ScVarMap;
+	typedef std::shared_ptr<ScVarMap>                   PScVarMap;
 public:
 	int32_t flags;
 	PScVarMap globalvars;

--- a/engines/ags/engine/script/non_blocking_script_function.h
+++ b/engines/ags/engine/script/non_blocking_script_function.h
@@ -34,7 +34,7 @@ struct NonBlockingScriptFunction {
 	RuntimeScriptValue params[3];
 	bool roomHasFunction;
 	bool globalScriptHasFunction;
-	Std::vector<bool> moduleHasFunction;
+	std::vector<bool> moduleHasFunction;
 	bool atLeastOneImplementationExists;
 
 	NonBlockingScriptFunction(const char *funcName, int numParams) {

--- a/engines/ags/engine/script/script.cpp
+++ b/engines/ags/engine/script/script.cpp
@@ -203,7 +203,7 @@ int create_global_script() {
 
 	ccSetOption(SCOPT_AUTOIMPORT, 1);
 
-	Std::vector<ccInstance *> instances_for_resolving;
+	std::vector<ccInstance *> instances_for_resolving;
 	for (size_t i = 0; i < _G(numScriptModules); ++i) {
 		_GP(moduleInst)[i] = ccInstance::CreateFromScript(_GP(scriptModules)[i]);
 		if (_GP(moduleInst)[i] == nullptr)

--- a/engines/ags/engine/script/system_imports.h
+++ b/engines/ags/engine/script/system_imports.h
@@ -46,9 +46,9 @@ struct SystemImports {
 private:
 	// Note we can't use a hash-map here, because we sometimes need to search
 	// by partial keys.
-	typedef Std::map<String, uint32_t> IndexMap;
+	typedef std::map<String, uint32_t> IndexMap;
 
-	Std::vector<ScriptImport> imports;
+	std::vector<ScriptImport> imports;
 	IndexMap btree;
 
 public:

--- a/engines/ags/globals.cpp
+++ b/engines/ags/globals.cpp
@@ -122,18 +122,18 @@ Globals::Globals() {
 	_GameStaticManager = new StaticGame();
 
 	// asset_manager.cpp globals
-	_AssetMgr = new Std::unique_ptr<Shared::AssetManager>();
+	_AssetMgr = new std::unique_ptr<Shared::AssetManager>();
 
 	// audio.cpp globals
-	_audioChannels = new Std::array<SOUNDCLIP *>(TOTAL_AUDIO_CHANNELS);
-	_ambient = new Std::array<AmbientSound>(MAX_GAME_CHANNELS);
+	_audioChannels = new std::array<SOUNDCLIP *>(TOTAL_AUDIO_CHANNELS);
+	_ambient = new std::array<AmbientSound>(MAX_GAME_CHANNELS);
 	_scrAudioChannel = new ScriptAudioChannel[MAX_GAME_CHANNELS];
 
 	// button.cpp globals
-	_animbuts = new Std::vector<AnimatingGUIButton>();
+	_animbuts = new std::vector<AnimatingGUIButton>();
 
 	// cc_instance.cpp globals
-	_InstThreads = new Std::deque<ccInstance *>();
+	_InstThreads = new std::deque<ccInstance *>();
 	_GlobalReturnValue = new RuntimeScriptValue();
 
 	// cc_options.cpp globals
@@ -157,12 +157,12 @@ Globals::Globals() {
 	_pushbuttonlightcolor = COL253;
 
 	// debug.cpp globals
-	_fps = Std::numeric_limits<float>::quiet_NaN();
+	_fps = std::numeric_limits<float>::quiet_NaN();
 	_display_fps = kFPS_Hide;
 	_debug_line = new String[DEBUG_CONSOLE_NUMLINES];
-	_DebugMsgBuff = new Std::unique_ptr<AGS::Engine::MessageBuffer>();
-	_DebugLogFile = new Std::unique_ptr<AGS::Engine::LogFile>();
-	_DebugConsole = new Std::unique_ptr<AGS::Engine::ConsoleOutputTarget>();
+	_DebugMsgBuff = new std::unique_ptr<AGS::Engine::MessageBuffer>();
+	_DebugLogFile = new std::unique_ptr<AGS::Engine::LogFile>();
+	_DebugConsole = new std::unique_ptr<AGS::Engine::ConsoleOutputTarget>();
 
 	// debug_manager.cpp globals
 	_DbgMgr = new AGS::Shared::DebugManager();
@@ -174,22 +174,22 @@ Globals::Globals() {
 	_topBar = new TopBarSettings();
 
 	// draw.cpp globals
-	_CameraDrawData = new Std::vector<RoomCameraDrawData>();
-	_sprlist = new Std::vector<SpriteListEntry>();
-	_thingsToDrawList = new Std::vector<SpriteListEntry>();
+	_CameraDrawData = new std::vector<RoomCameraDrawData>();
+	_sprlist = new std::vector<SpriteListEntry>();
+	_thingsToDrawList = new std::vector<SpriteListEntry>();
 	_dynamicallyCreatedSurfaces = new AGS::Shared::Bitmap *[MAX_DYNAMIC_SURFACES];
 	Common::fill(_dynamicallyCreatedSurfaces, _dynamicallyCreatedSurfaces +
 	             MAX_DYNAMIC_SURFACES, (AGS::Shared::Bitmap *)nullptr);
 
-	_actsps = new Std::vector<ObjTexture>();
-	_walkbehindobj = new Std::vector<ObjTexture>();
-	_guibg = new Std::vector<ObjTexture>();
-	_guiobjbg = new Std::vector<ObjTexture>();
+	_actsps = new std::vector<ObjTexture>();
+	_walkbehindobj = new std::vector<ObjTexture>();
+	_guibg = new std::vector<ObjTexture>();
+	_guiobjbg = new std::vector<ObjTexture>();
 
-	_guiobjddb = new Std::vector<Engine::IDriverDependantBitmap *>();
-	_guiobjoff = new Std::vector<Point>();
-	_guiobjddbref = new Std::vector<int>();
-	_overlaybmp = new Std::vector<Std::unique_ptr<Shared::Bitmap> >();
+	_guiobjddb = new std::vector<Engine::IDriverDependantBitmap *>();
+	_guiobjoff = new std::vector<Point>();
+	_guiobjddbref = new std::vector<int>();
+	_overlaybmp = new std::vector<std::unique_ptr<Shared::Bitmap> >();
 	_debugRoomMaskObj =  new ObjTexture();
 	_debugMoveListObj = new ObjTexture();
 
@@ -202,17 +202,17 @@ Globals::Globals() {
 	// draw_software.cpp globals
 	_BlackRects = new DirtyRects();
 	_GlobalOffs = new Point();
-	_RoomCamRects = new Std::vector<DirtyRects>();
-	_RoomCamPositions = new Std::vector<Std::pair<int, int> >();
+	_RoomCamRects = new std::vector<DirtyRects>();
+	_RoomCamPositions = new std::vector<std::pair<int, int> >();
 
 	// engine.cpp globals
 	_ResPaths = new ResourcePaths();
 
 	// event.cpp globals
-	_events = new Std::vector<EventHappened>();
+	_events = new std::vector<EventHappened>();
 
 	// fonts.cpp globals
-	_fonts = new Std::vector<AGS::Shared::Font>();
+	_fonts = new std::vector<AGS::Shared::Font>();
 	_ttfRenderer = new TTFFontRenderer();
 	_wfnRenderer = new WFNFontRenderer();
 	_Lines = new SplitLines();
@@ -229,7 +229,7 @@ Globals::Globals() {
 	_ccDynamicAudioClip = new CCAudioClip();
 	_ccDynamicAudio = new CCAudioChannel();
 	_myScriptStringImpl = new ScriptString();
-	_guis = new Std::vector<AGS::Shared::GUIMain>();
+	_guis = new std::vector<AGS::Shared::GUIMain>();
 	_play = new GameState();
 	_game = new GameSetupStruct();
 	_spriteset = new AGS::Shared::SpriteCache(_game->SpriteInfos);
@@ -240,12 +240,12 @@ Globals::Globals() {
 	_scrHotspot = new ScriptHotspot[MAX_ROOM_HOTSPOTS];
 	_scrRegion = new ScriptRegion[MAX_ROOM_REGIONS];
 	_scrInv = new ScriptInvItem[MAX_INV];
-	_charcache = new Std::vector<ObjectCache>();
+	_charcache = new std::vector<ObjectCache>();
 	_objcache = new ObjectCache[MAX_ROOM_OBJECTS];
-	_screenovercache = new Std::vector<Point>();
-	_charextra = new Std::vector<CharacterExtras>();
-	_mls = new Std::vector<MoveList>();
-	_views = new Std::vector<ViewStruct>();
+	_screenovercache = new std::vector<Point>();
+	_charextra = new std::vector<CharacterExtras>();
+	_mls = new std::vector<MoveList>();
+	_views = new std::vector<ViewStruct>();
 	_saveGameDirectory = AGS::Shared::SAVE_FOLDER_PREFIX;
 
 	// game_init.cpp globals
@@ -284,7 +284,7 @@ Globals::Globals() {
 	_GameScaling = new AGS::Shared::PlaneScaling();
 
 	// gui_button.cpp globals
-	_guibuts = new Std::vector<AGS::Shared::GUIButton>();
+	_guibuts = new std::vector<AGS::Shared::GUIButton>();
 
 	// gui_dlaog.cpp globals
 	Common::fill(_filenumbers, _filenumbers + MAXSAVEGAMES_20, 0);
@@ -295,19 +295,19 @@ Globals::Globals() {
 	_smes = new CSCIMessage();
 
 	// gui_inv.cpp globals
-	_guiinv = new Std::vector<AGS::Shared::GUIInvWindow>();
+	_guiinv = new std::vector<AGS::Shared::GUIInvWindow>();
 
 	// gui_label.cpp globals
-	_guilabels = new Std::vector<AGS::Shared::GUILabel>();
+	_guilabels = new std::vector<AGS::Shared::GUILabel>();
 
 	// gui_listbox.cpp globals
-	_guilist = new Std::vector<AGS::Shared::GUIListBox>();
+	_guilist = new std::vector<AGS::Shared::GUIListBox>();
 
 	// gui_slider.cpp globals
-	_guislider = new Std::vector<AGS::Shared::GUISlider>();
+	_guislider = new std::vector<AGS::Shared::GUISlider>();
 
 	// gui_textbox.cpp globals
-	_guitext = new Std::vector<AGS::Shared::GUITextBox>();
+	_guitext = new std::vector<AGS::Shared::GUITextBox>();
 
 	// interactions.cpp globals
 	_globalvars = new InteractionVariable[MAX_GLOBAL_VARIABLES];
@@ -324,7 +324,7 @@ Globals::Globals() {
 	_mouse = new Mouse();
 
 	// overlay.cpp globals
-	_screenover = new Std::vector<ScreenOverlay>();
+	_screenover = new std::vector<ScreenOverlay>();
 
 	// plugins globals
 	_engineExports = new Plugins::Core::EngineExports();
@@ -340,7 +340,7 @@ Globals::Globals() {
 	// route_finder_impl.cpp globals
 	_navpoints = new int32_t[MAXNEEDSTAGES];
 	_nav = new Navigation();
-	_route_finder_impl = new Std::unique_ptr<IRouteFinder>();
+	_route_finder_impl = new std::unique_ptr<IRouteFinder>();
 
 	// screen.cpp globals
 	_old_palette = new color[256];
@@ -360,10 +360,10 @@ Globals::Globals() {
 	_runDialogOptionRepExecFunc = new NonBlockingScriptFunction("dialog_options_repexec", 1);
 	_runDialogOptionCloseFunc = new NonBlockingScriptFunction("dialog_options_close", 1);
 	_scsystem = new ScriptSystem();
-	_scriptModules = new Std::vector<PScript>();
-	_moduleInst = new Std::vector<ccInstance *>();
-	_moduleInstFork = new Std::vector<ccInstance *>();
-	_moduleRepExecAddr = new Std::vector<RuntimeScriptValue>();
+	_scriptModules = new std::vector<PScript>();
+	_moduleInst = new std::vector<ccInstance *>();
+	_moduleInstFork = new std::vector<ccInstance *>();
+	_moduleRepExecAddr = new std::vector<RuntimeScriptValue>();
 
 	// script_runtime.cpp globals
 	Common::fill(_loadedInstances, _loadedInstances + MAX_LOADED_INSTANCES,

--- a/engines/ags/globals.h
+++ b/engines/ags/globals.h
@@ -269,7 +269,7 @@ public:
 	 * @{
 	 */
 
-	Std::unique_ptr<Shared::AssetManager> *_AssetMgr;
+	std::unique_ptr<Shared::AssetManager> *_AssetMgr;
 
 	/**@}*/
 
@@ -282,7 +282,7 @@ public:
 	// We don't have many places where we delay longer than a frame, but where we
 	// do, we should give the audio layer a chance to update.
 	// 16 milliseconds is rough period for 60fps
-	const Std::chrono::milliseconds _MaximumDelayBetweenPolling = Std::chrono::milliseconds(16);
+	const std::chrono::milliseconds _MaximumDelayBetweenPolling = std::chrono::milliseconds(16);
 
 	/**@}*/
 
@@ -313,8 +313,8 @@ public:
 	 * @{
 	 */
 
-	Std::array<SOUNDCLIP *> *_audioChannels;
-	Std::array<AmbientSound> *_ambient;
+	std::array<SOUNDCLIP *> *_audioChannels;
+	std::array<AmbientSound> *_ambient;
 
 	ScriptAudioChannel *_scrAudioChannel;
 	int _reserved_channel_count = 0;
@@ -341,7 +341,7 @@ public:
 	 * @{
 	 */
 
-	Std::vector<AnimatingGUIButton> *_animbuts;
+	std::vector<AnimatingGUIButton> *_animbuts;
 
 	/**@}*/
 
@@ -384,7 +384,7 @@ public:
 	// In AGS currently only one thread is running, others are waiting in the queue.
 	// An example situation is repeatedly_execute_always callback running while
 	// another instance is waiting at the blocking action or Wait().
-	Std::deque<ccInstance *> *_InstThreads;
+	std::deque<ccInstance *> *_InstThreads;
 	// [IKM] 2012-10-21:
 	// NOTE: This is temporary solution (*sigh*, one of many) which allows certain
 	// exported functions return value as a RuntimeScriptValue object;
@@ -506,7 +506,7 @@ public:
 		int lineNumber = 0;
 	};
 
-	Std::vector<Breakpoint> _breakpoints;
+	std::vector<Breakpoint> _breakpoints;
 
 	int _debug_flags = 0;
 
@@ -515,9 +515,9 @@ public:
 
 	float _fps;
 	int _display_fps;
-	Std::unique_ptr<AGS::Engine::MessageBuffer> *_DebugMsgBuff;
-	Std::unique_ptr<AGS::Engine::LogFile> *_DebugLogFile;
-	Std::unique_ptr<AGS::Engine::ConsoleOutputTarget> *_DebugConsole;
+	std::unique_ptr<AGS::Engine::MessageBuffer> *_DebugMsgBuff;
+	std::unique_ptr<AGS::Engine::LogFile> *_DebugLogFile;
+	std::unique_ptr<AGS::Engine::ConsoleOutputTarget> *_DebugConsole;
 
 	/**@}*/
 
@@ -537,7 +537,7 @@ public:
 	 * @{
 	 */
 
-	Std::vector<DialogTopic> _dialog;
+	std::vector<DialogTopic> _dialog;
 	ScriptDialogOptionsRendering *_ccDialogOptionsRendering;
 	ScriptDrawingSurface *_dialogOptionsRenderingSurface = nullptr;
 
@@ -549,8 +549,8 @@ public:
 	int _said_text = 0;
 	int _longestline = 0;
 	// Old dialog support
-	Std::vector<Std::vector<uint8_t>> _old_dialog_scripts;
-	Std::vector<String> _old_speech_lines;
+	std::vector<std::vector<uint8_t>> _old_dialog_scripts;
+	std::vector<String> _old_speech_lines;
 
 	/**@}*/
 
@@ -578,11 +578,11 @@ public:
 	 * @{
 	 */
 
-	Std::vector<RoomCameraDrawData> *_CameraDrawData;
+	std::vector<RoomCameraDrawData> *_CameraDrawData;
 	// Two lists of sprites to push into renderer during next render pass
 	// thingsToDrawList - is the main list, unsorted, drawn in the index order
-	Std::vector<SpriteListEntry> *_thingsToDrawList;
-	Std::vector<SpriteListEntry> *_sprlist;
+	std::vector<SpriteListEntry> *_thingsToDrawList;
+	std::vector<SpriteListEntry> *_sprlist;
 
 	AGS::Engine::IGraphicsDriver *_gfxDriver = nullptr;
 	AGS::Engine::IDriverDependantBitmap *_blankImage = nullptr;
@@ -592,17 +592,17 @@ public:
 	// actsps is used for temporary storage of the bitamp and texture
 	// of the latest version of the sprite (room objects and characters);
 	// objects sprites begin with index 0, characters are after ACTSP_OBJSOFF
-	Std::vector<ObjTexture> *_actsps;
+	std::vector<ObjTexture> *_actsps;
 	// Walk-behind textures (3D renderers only)
-	Std::vector<ObjTexture> *_walkbehindobj;
+	std::vector<ObjTexture> *_walkbehindobj;
 	// GUI surfaces
-	Std::vector<ObjTexture> *_guibg;
+	std::vector<ObjTexture> *_guibg;
 	// GUI control surfaces
-	Std::vector<ObjTexture> *_guiobjbg;
+	std::vector<ObjTexture> *_guiobjbg;
 	// first control texture index of each GUI
-	Std::vector<int> *_guiobjddbref;
+	std::vector<int> *_guiobjddbref;
 	// Overlay's cached transformed bitmap, for software mode
-	Std::vector<Std::unique_ptr<Shared::Bitmap> > *_overlaybmp;
+	std::vector<std::unique_ptr<Shared::Bitmap> > *_overlaybmp;
 	// For debugging room masks
 	ObjTexture *_debugRoomMaskObj;
 	ObjTexture *_debugMoveListObj;
@@ -621,8 +621,8 @@ public:
 	color *_palette;
 	COLOR_MAP *_maincoltable;
 
-	Std::vector<Engine::IDriverDependantBitmap *> *_guiobjddb;
-	Std::vector<Point> *_guiobjoff; // because surface may be larger than logical position
+	std::vector<Engine::IDriverDependantBitmap *> *_guiobjddb;
+	std::vector<Point> *_guiobjoff; // because surface may be larger than logical position
 
 	/**@}*/
 
@@ -638,10 +638,10 @@ public:
 	DirtyRects *_BlackRects;
 	Point *_GlobalOffs;
 	// Dirty rects object for the single room camera
-	Std::vector<DirtyRects> *_RoomCamRects;
+	std::vector<DirtyRects> *_RoomCamRects;
 	// Saved room camera offsets to know if we must invalidate whole surface.
 	// TODO: if we support rotation then we also need to compare full transform!
-	Std::vector<Std::pair<int, int> > *_RoomCamPositions;
+	std::vector<std::pair<int, int> > *_RoomCamPositions;
 
 	/**@}*/
 
@@ -686,7 +686,7 @@ public:
 	int _in_enters_screen = 0, _done_es_error = 0;
 	int _in_leaves_screen = -1;
 
-	Std::vector<EventHappened> *_events;
+	std::vector<EventHappened> *_events;
 
 	const char *_evblockbasename = nullptr;
 	int _evblocknum = 0;
@@ -721,7 +721,7 @@ public:
 	 * @{
 	 */
 
-	Std::vector<AGS::Shared::Font> *_fonts;
+	std::vector<AGS::Shared::Font> *_fonts;
 	TTFFontRenderer *_ttfRenderer;
 	WFNFontRenderer *_wfnRenderer;
 	SplitLines *_Lines;
@@ -742,7 +742,7 @@ public:
 	AGS::Shared::RoomStruct *_thisroom;
 	RoomStatus *_troom; // used for non-saveable rooms, eg. intro
 
-	Std::vector<AGS::Shared::GUIMain> *_guis;
+	std::vector<AGS::Shared::GUIMain> *_guis;
 	CCGUIObject *_ccDynamicGUIObject;
 	CCCharacter *_ccDynamicCharacter;
 	CCHotspot *_ccDynamicHotspot;
@@ -766,16 +766,16 @@ public:
 	ScriptRegion *_scrRegion;
 	ScriptInvItem *_scrInv;
 	ScriptDialog *_scrDialog = nullptr;
-	Std::vector<ViewStruct> *_views;
+	std::vector<ViewStruct> *_views;
 	// Cached character and object states, used to determine
 	// whether these require texture update
-	Std::vector<ObjectCache> *_charcache;
+	std::vector<ObjectCache> *_charcache;
 	ObjectCache *_objcache;
-	Std::vector<Point> *_screenovercache;
-	Std::vector<CharacterExtras> *_charextra;
+	std::vector<Point> *_screenovercache;
+	std::vector<CharacterExtras> *_charextra;
 	// MoveLists for characters and room objects; NOTE: 1-based array!
 	// object sprites begin with index 1, characters are after MAX_ROOM_OBJECTS + 1
-	Std::vector<MoveList> *_mls;
+	std::vector<MoveList> *_mls;
 
 	GameSetup *_usetup;
 	AGS::Shared::String _saveGameDirectory;
@@ -969,7 +969,7 @@ public:
 	 * @{
 	 */
 
-	Std::vector<AGS::Shared::GUIButton> *_guibuts;
+	std::vector<AGS::Shared::GUIButton> *_guibuts;
 
 	/**@}*/
 
@@ -1002,7 +1002,7 @@ public:
 	 * @{
 	 */
 
-	Std::vector<AGS::Shared::GUIInvWindow> *_guiinv;
+	std::vector<AGS::Shared::GUIInvWindow> *_guiinv;
 
 	/**@}*/
 
@@ -1012,7 +1012,7 @@ public:
 	 * @{
 	 */
 
-	Std::vector<AGS::Shared::GUILabel> *_guilabels;
+	std::vector<AGS::Shared::GUILabel> *_guilabels;
 
 	/**@}*/
 
@@ -1022,7 +1022,7 @@ public:
 	 * @{
 	 */
 
-	Std::vector<AGS::Shared::GUIListBox> *_guilist;
+	std::vector<AGS::Shared::GUIListBox> *_guilist;
 
 	/**@}*/
 
@@ -1044,7 +1044,7 @@ public:
 	 * @{
 	 */
 
-	Std::vector<AGS::Shared::GUISlider> *_guislider;
+	std::vector<AGS::Shared::GUISlider> *_guislider;
 
 	/**@}*/
 
@@ -1054,7 +1054,7 @@ public:
 	 * @{
 	 */
 
-	Std::vector<AGS::Shared::GUITextBox> *_guitext;
+	std::vector<AGS::Shared::GUITextBox> *_guitext;
 
 	/**@}*/
 
@@ -1108,7 +1108,7 @@ public:
 	bool _justDisplayVersion = false;
 	bool _justRunSetup = false;
 	bool _justTellInfo = false;
-	Std::set<String> _tellInfoKeys;
+	std::set<String> _tellInfoKeys;
 	int _loadSaveGameOnStartup = -1;
 
 	// ScummVM GUIO-controlled flags
@@ -1185,7 +1185,7 @@ public:
 	 * @{
 	 */
 
-	Std::vector<ScreenOverlay> *_screenover;
+	std::vector<ScreenOverlay> *_screenover;
 	int _is_complete_overlay = 0;
 
 	/**@}*/
@@ -1238,7 +1238,7 @@ public:
 	int _num_navpoints = 0;
 	AGS::Shared::Bitmap *_wallscreen = nullptr;
 	int _lastcx = 0, _lastcy = 0;
-	Std::unique_ptr<IRouteFinder> *_route_finder_impl;
+	std::unique_ptr<IRouteFinder> *_route_finder_impl;
 
 	/**@}*/
 
@@ -1288,10 +1288,10 @@ public:
 
 	ScriptSystem *_scsystem;
 
-	Std::vector<PScript> *_scriptModules;
-	Std::vector<ccInstance *> *_moduleInst;
-	Std::vector<ccInstance *> *_moduleInstFork;
-	Std::vector<RuntimeScriptValue> *_moduleRepExecAddr;
+	std::vector<PScript> *_scriptModules;
+	std::vector<ccInstance *> *_moduleInst;
+	std::vector<ccInstance *> *_moduleInstFork;
+	std::vector<RuntimeScriptValue> *_moduleRepExecAddr;
 	size_t _numScriptModules = 0;
 
 	/**@}*/
@@ -1360,7 +1360,7 @@ public:
 	 * @{
 	 */
 
-	Std::chrono::microseconds _tick_duration = Std::chrono::microseconds(1000000LL / 40);
+	std::chrono::microseconds _tick_duration = std::chrono::microseconds(1000000LL / 40);
 	bool _framerate_maxed = false;
 	int _framerate = 0;
 
@@ -1380,8 +1380,8 @@ public:
 	String _trans_name, _trans_filename;
 	long _lang_offs_start = 0;
 	char _transFileName[MAX_PATH_SZ] = { 0 };
-	Std::vector<uint16> _wcsbuf; // widechar buffer
-	Std::vector<char> _mbbuf;  // utf8 buffer
+	std::vector<uint16> _wcsbuf; // widechar buffer
+	std::vector<char> _mbbuf;  // utf8 buffer
 
 	/**@}*/
 
@@ -1411,7 +1411,7 @@ public:
 	WalkBehindMethodEnum _walkBehindMethod = DrawOverCharSprite;
 	int _walk_behind_baselines_changed = 0;
 	Rect _walkBehindAABB[MAX_WALK_BEHINDS]; // WB bounding box
-	Std::vector<WalkBehindColumn> _walkBehindCols; // precalculated WB positions
+	std::vector<WalkBehindColumn> _walkBehindCols; // precalculated WB positions
 
 	/**@}*/
 

--- a/engines/ags/lib/std.h
+++ b/engines/ags/lib/std.h
@@ -1,0 +1,35 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef AGS_LIB_STD_H
+#define AGS_LIB_STD_H
+
+// Declare Std namespace
+namespace Std {
+}
+
+// Map Common::Std to AGS3::std
+namespace AGS3 {
+	namespace std = ::Std;
+} // namespace AGS3
+
+
+#endif

--- a/engines/ags/plugins/ags_plugin.cpp
+++ b/engines/ags/plugins/ags_plugin.cpp
@@ -843,7 +843,7 @@ void pl_run_plugin_init_gfx_hooks(const char *driverName, void *data) {
 	}
 }
 
-Engine::GameInitError pl_register_plugins(const Std::vector<PluginInfo> &infos) {
+Engine::GameInitError pl_register_plugins(const std::vector<PluginInfo> &infos) {
 	_GP(plugins).clear();
 	_GP(plugins).reserve(MAXPLUGINS);
 

--- a/engines/ags/plugins/ags_sprite_font/sprite_font_renderer.h
+++ b/engines/ags/plugins/ags_sprite_font/sprite_font_renderer.h
@@ -35,7 +35,7 @@ protected:
 	IAGSEngine *_engine;
 	SpriteFont *getFontFor(int fontNum);
 	void Draw(BITMAP *src, BITMAP *dest, int destx, int desty, int srcx, int srcy, int width, int height);
-	Std::vector<SpriteFont *> _fonts;
+	std::vector<SpriteFont *> _fonts;
 
 public:
 	SpriteFontRenderer(IAGSEngine *engine);

--- a/engines/ags/plugins/ags_sprite_font/variable_width_font.h
+++ b/engines/ags/plugins/ags_sprite_font/variable_width_font.h
@@ -35,7 +35,7 @@ public:
 	int SpriteNumber = 0;
 	int FontReplaced = 0;
 	int Spacing = 0;
-	Std::map<char, CharacterEntry> characters;
+	std::map<char, CharacterEntry> characters;
 	// Clifftop Games custom plugin support
 	int LineHeightAdjust = 0;
 	int LineSpacingAdjust = 0;

--- a/engines/ags/plugins/ags_sprite_font/variable_width_sprite_font.h
+++ b/engines/ags/plugins/ags_sprite_font/variable_width_sprite_font.h
@@ -33,7 +33,7 @@ namespace AGSSpriteFont {
 class VariableWidthSpriteFontRenderer : public IAGSFontRenderer2 {
 protected:
 	IAGSEngine *_engine;
-	Std::vector<VariableWidthFont *> _fonts;
+	std::vector<VariableWidthFont *> _fonts;
 
 	VariableWidthFont *getFontFor(int fontNum);
 	void Draw(BITMAP *src, BITMAP *dest, int destx, int desty, int srcx, int srcy, int width, int height);

--- a/engines/ags/plugins/plugin_engine.h
+++ b/engines/ags/plugins/plugin_engine.h
@@ -49,7 +49,7 @@ NumberPtr pl_run_plugin_hooks(int event, NumberPtr data);
 void pl_run_plugin_init_gfx_hooks(const char *driverName, void *data);
 int  pl_run_plugin_debug_hooks(const char *scriptfile, int linenum);
 // Tries to register plugins, either by loading dynamic libraries, or getting any kind of replacement
-Engine::GameInitError pl_register_plugins(const Std::vector<Shared::PluginInfo> &infos);
+Engine::GameInitError pl_register_plugins(const std::vector<Shared::PluginInfo> &infos);
 bool pl_is_plugin_loaded(const char *pl_name);
 
 //returns whether _any_ plugins want a particular event

--- a/engines/ags/shared/ac/character_info.h
+++ b/engines/ags/shared/ac/character_info.h
@@ -132,14 +132,14 @@ struct CharacterInfo {
 	//
 	// [IKM] 2016-08-26: these methods should NOT be in CharacterInfo class,
 	// bit in distinct runtime character class!
-	void UpdateMoveAndAnim(int &char_index, CharacterExtras *chex, Std::vector<int> &followingAsSheep);
+	void UpdateMoveAndAnim(int &char_index, CharacterExtras *chex, std::vector<int> &followingAsSheep);
 	void UpdateFollowingExactlyCharacter();
 
 	int  update_character_walking(CharacterExtras *chex);
 	void update_character_moving(int &char_index, CharacterExtras *chex, int &doing_nothing);
 	int  update_character_animating(int &char_index, int &doing_nothing);
 	void update_character_idle(CharacterExtras *chex, int &doing_nothing);
-	void update_character_follower(int &char_index, Std::vector<int> &followingAsSheep, int &doing_nothing);
+	void update_character_follower(int &char_index, std::vector<int> &followingAsSheep, int &doing_nothing);
 
 	void ReadFromFile(Shared::Stream *in, GameDataVersion data_ver, int save_ver = -1);
 	void WriteToFile(Shared::Stream *out);

--- a/engines/ags/shared/ac/game_setup_struct.cpp
+++ b/engines/ags/shared/ac/game_setup_struct.cpp
@@ -352,7 +352,7 @@ void GameSetupStruct::ReadAudioClips_Aligned(Shared::Stream *in, size_t count) {
 }
 
 void GameSetupStruct::ReadFromSaveGame_v321(Stream *in, GameDataVersion data_ver, char *gswas, ccScript *compsc, CharacterInfo *chwas,
-											WordsDictionary *olddict, Std::vector<String> &mesbk) {
+											WordsDictionary *olddict, std::vector<String> &mesbk) {
 	ReadInvInfo_Aligned(in);
 	ReadMouseCursors_Aligned(in);
 

--- a/engines/ags/shared/ac/game_setup_struct.h
+++ b/engines/ags/shared/ac/game_setup_struct.h
@@ -39,8 +39,8 @@ namespace Shared {
 struct AssetLibInfo;
 struct Interaction;
 struct InteractionScripts;
-typedef Std::shared_ptr<Interaction> PInteraction;
-typedef Std::shared_ptr<InteractionScripts> PInteractionScripts;
+typedef std::shared_ptr<Interaction> PInteraction;
+typedef std::shared_ptr<InteractionScripts> PInteractionScripts;
 } // namespace Shared
 } // namespace AGS
 
@@ -54,36 +54,36 @@ struct GameSetupStruct : public GameSetupStructBase {
 	// This array is used only to read data into;
 	// font parameters are then put and queried in the fonts module
 	// TODO: split into installation params (used only when reading) and runtime params
-	Std::vector<FontInfo> fonts;
+	std::vector<FontInfo> fonts;
 	InventoryItemInfo invinfo[MAX_INV]{};
-	Std::vector<MouseCursor> mcurs;
-	Std::vector<PInteraction> intrChar;
+	std::vector<MouseCursor> mcurs;
+	std::vector<PInteraction> intrChar;
 	PInteraction intrInv[MAX_INV];
-	Std::vector<PInteractionScripts> charScripts;
-	Std::vector<PInteractionScripts> invScripts;
+	std::vector<PInteractionScripts> charScripts;
+	std::vector<PInteractionScripts> invScripts;
 	// TODO: why we do not use this in the engine instead of
 	// _G(loaded_game_file_version)?
 	int               filever;  // just used by editor
 	Shared::String    compiled_with; // version of AGS this data was created by
 	char              lipSyncFrameLetters[MAXLIPSYNCFRAMES][50];
 	AGS::Shared::PropertySchema propSchema;
-	Std::vector<AGS::Shared::StringIMap> charProps;
+	std::vector<AGS::Shared::StringIMap> charProps;
 	AGS::Shared::StringIMap invProps[MAX_INV];
 	// NOTE: although the view names are stored in game data, they are never
 	// used, nor registered as script exports; numeric IDs are used to
 	// reference views instead.
-	Std::vector<Shared::String> viewNames;
+	std::vector<Shared::String> viewNames;
 	Shared::String    invScriptNames[MAX_INV];
-	Std::vector<Shared::String> dialogScriptNames;
+	std::vector<Shared::String> dialogScriptNames;
 	char              guid[MAX_GUID_LENGTH];
 	char              saveGameFileExtension[MAX_SG_EXT_LENGTH];
 	// NOTE: saveGameFolderName is generally used to create game subdirs in common user directories
 	char              saveGameFolderName[MAX_SG_FOLDER_LEN];
 	int               roomCount;
-	Std::vector<int>  roomNumbers;
-	Std::vector<Shared::String> roomNames;
-	Std::vector<ScriptAudioClip> audioClips;
-	Std::vector<AudioClipType> audioClipTypes;
+	std::vector<int>  roomNumbers;
+	std::vector<Shared::String> roomNames;
+	std::vector<ScriptAudioClip> audioClips;
+	std::vector<AudioClipType> audioClipTypes;
 	// A clip to play when player gains score in game
 	// TODO: find out why OPT_SCORESOUND option cannot be used to store this in >=3.2 games
 	int               scoreClipID;
@@ -102,7 +102,7 @@ struct GameSetupStruct : public GameSetupStructBase {
 	// There could be other collection types, more optimal for this case. For example,
 	// we could use a kind of hash map containing fixed-sized arrays, where size of
 	// array is calculated based on key spread factor.
-	Std::vector<SpriteInfo> SpriteInfos;
+	std::vector<SpriteInfo> SpriteInfos;
 
 	// Get game's native color depth (bits per pixel)
 	inline int GetColorDepth() const {
@@ -160,7 +160,7 @@ struct GameSetupStruct : public GameSetupStructBase {
 
 	// Functions for reading and writing appropriate data from/to save game
 	void ReadFromSaveGame_v321(Shared::Stream *in, GameDataVersion data_ver, char *gswas, ccScript *compsc, CharacterInfo *chwas,
-							   WordsDictionary *olddict, Std::vector<String> &mesbk);
+							   WordsDictionary *olddict, std::vector<String> &mesbk);
 
 	void ReadFromSavegame(Shared::Stream *in);
 	void WriteForSavegame(Shared::Stream *out);

--- a/engines/ags/shared/ac/sprite_cache.cpp
+++ b/engines/ags/shared/ac/sprite_cache.cpp
@@ -60,7 +60,7 @@ SpriteInfo::SpriteInfo()
 namespace AGS {
 namespace Shared {
 
-SpriteCache::SpriteCache(Std::vector<SpriteInfo> &sprInfos)
+SpriteCache::SpriteCache(std::vector<SpriteInfo> &sprInfos)
 	: _sprInfos(sprInfos), _maxCacheSize(DEFAULTCACHESIZE_KB * 1024u),
 	_cacheSize(0u), _lockedSize(0u) {
 }
@@ -235,7 +235,7 @@ void SpriteCache::DisposeOldest() {
 	assert(_mru.size() > 0);
 	if (_mru.size() == 0)
 		return;
-	auto it = Std::prev(_mru.end());
+	auto it = std::prev(_mru.end());
 	const auto sprnum = *it;
 	// Safety check: must be a sprite from resources
 	// TODO: compare with latest upstream
@@ -248,7 +248,7 @@ void SpriteCache::DisposeOldest() {
 		if (!(_spriteData[sprnum].Flags & SPRCACHEFLAG_REMAPPED))
 			Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Error, "SpriteCache::DisposeOldest: in MRU list sprite %d is external or does not exist", sprnum);
 		_mru.erase(it);
-		// Std::list::erase() invalidates iterators to the erased item.
+		// std::list::erase() invalidates iterators to the erased item.
 		// But our implementation does not.
 		_spriteData[sprnum].MruIt._node = nullptr;
 		return;
@@ -263,7 +263,7 @@ void SpriteCache::DisposeOldest() {
 	}
 	// Remove from the mru list
 	_mru.erase(it);
-	// Std::list::erase() invalidates iterators to the erased item.
+	// std::list::erase() invalidates iterators to the erased item.
 	// But our implementation does not.
 	_spriteData[sprnum].MruIt._node = nullptr;
 }
@@ -295,7 +295,7 @@ void SpriteCache::Precache(sprkey_t index) {
 		sprSize = _spriteData[index].Size;
 		// Remove locked sprite from the MRU list
 		_mru.erase(_spriteData[index].MruIt);
-		// Std::list::erase() invalidates iterators to the erased item.
+		// std::list::erase() invalidates iterators to the erased item.
 		// But our implementation does not.
 		_spriteData[index].MruIt._node = nullptr;
 	}
@@ -366,7 +366,7 @@ void SpriteCache::RemapSpriteToSprite0(sprkey_t index) {
 }
 
 int SpriteCache::SaveToFile(const String &filename, int store_flags, SpriteCompression compress, SpriteFileIndex &index) {
-	Std::vector<Std::pair<bool, Bitmap *>> sprites;
+	std::vector<std::pair<bool, Bitmap *>> sprites;
 	for (size_t i = 0; i < _spriteData.size(); ++i) {
 		// NOTE: this is a horrible hack:
 		// because Editor expects slightly different RGB order, it swaps colors
@@ -374,7 +374,7 @@ int SpriteCache::SaveToFile(const String &filename, int store_flags, SpriteCompr
 		// unfix that fix to save the data in a way that engine will expect.
 		// TODO: perhaps adjust the editor to NOT need this?!
 		pre_save_sprite(_spriteData[i].Image);
-		sprites.push_back(Std::make_pair(DoesSpriteExist(i), _spriteData[i].Image));
+		sprites.push_back(std::make_pair(DoesSpriteExist(i), _spriteData[i].Image));
 	}
 	return SaveSpriteFile(filename, sprites, &_file, store_flags, compress, index);
 }
@@ -382,7 +382,7 @@ int SpriteCache::SaveToFile(const String &filename, int store_flags, SpriteCompr
 HError SpriteCache::InitFile(const String &filename, const String &sprindex_filename) {
 	Reset();
 
-	Std::vector<Size> metrics;
+	std::vector<Size> metrics;
 	HError err = _file.OpenFile(filename, sprindex_filename, metrics);
 	if (!err)
 		return err;

--- a/engines/ags/shared/ac/sprite_cache.h
+++ b/engines/ags/shared/ac/sprite_cache.h
@@ -89,7 +89,7 @@ public:
 	static const sprkey_t MAX_SPRITE_INDEX = INT32_MAX - 1;
 	static const size_t   MAX_SPRITE_SLOTS = INT32_MAX;
 
-	SpriteCache(Std::vector<SpriteInfo> &sprInfos);
+	SpriteCache(std::vector<SpriteInfo> &sprInfos);
 	~SpriteCache();
 
 	// Loads sprite reference information and inits sprite stream
@@ -166,7 +166,7 @@ private:
 		// (some of these bitmaps may be assigned from outside of the cache)
 		Shared::Bitmap *Image = nullptr; // actual bitmap
 		// MRU list reference
-		Std::list<sprkey_t>::iterator MruIt;
+		std::list<sprkey_t>::iterator MruIt;
 
 		// Tells if there actually is a registered sprite in this slot
 		bool DoesSpriteExist() const;
@@ -179,9 +179,9 @@ private:
 	};
 
 	// Provided map of sprite infos, to fill in loaded sprite properties
-	Std::vector<SpriteInfo> &_sprInfos;
+	std::vector<SpriteInfo> &_sprInfos;
 	// Array of sprite references
-	Std::vector<SpriteData> _spriteData;
+	std::vector<SpriteData> _spriteData;
 
 	SpriteFile _file;
 
@@ -192,7 +192,7 @@ private:
 	// MRU list: the way to track which sprites were used recently.
 	// When clearing up space for new sprites, cache first deletes the sprites
 	// that were last time used long ago.
-	Std::list<sprkey_t> _mru;
+	std::list<sprkey_t> _mru;
 
 	// Initialize the empty sprite slot
 	void        InitNullSpriteParams(sprkey_t index);

--- a/engines/ags/shared/ac/sprite_file.cpp
+++ b/engines/ags/shared/ac/sprite_file.cpp
@@ -64,7 +64,7 @@ static size_t lookup_palette(uint32_t col, uint32_t palette[256], uint32_t ncols
 // Converts a 16/32-bit image into the indexed 8-bit pixel data with palette;
 // NOTE: the palette will contain colors in the same format as the source image.
 // only succeeds if the total number of colors used in the image is < 257.
-static bool CreateIndexedBitmap(const Bitmap *image, Std::vector<uint8_t> &dst_data,
+static bool CreateIndexedBitmap(const Bitmap *image, std::vector<uint8_t> &dst_data,
 	uint32_t palette[256], uint32_t &pal_count) {
 	const int src_bpp = image->GetBPP();
 	if (src_bpp < 2) { assert(0); return false; }
@@ -157,7 +157,7 @@ SpriteFile::SpriteFile() {
 }
 
 HError SpriteFile::OpenFile(const String &filename, const String &sprindex_filename,
-		Std::vector<Size> &metrics) {
+		std::vector<Size> &metrics) {
 	Close();
 
 	char buff[20];
@@ -251,7 +251,7 @@ sprkey_t SpriteFile::GetTopmostSprite() const {
 }
 
 bool SpriteFile::LoadSpriteIndexFile(const String &filename, int expectedFileID,
-	soff_t spr_initial_offs, sprkey_t topmost, Std::vector<Size> &metrics) {
+	soff_t spr_initial_offs, sprkey_t topmost, std::vector<Size> &metrics) {
 	Stream *fidx = _GP(AssetMgr)->OpenAsset(filename);
 	if (fidx == nullptr) {
 		return false;
@@ -291,9 +291,9 @@ bool SpriteFile::LoadSpriteIndexFile(const String &filename, int expectedFileID,
 	}
 
 	sprkey_t numsprits = topmost_index + 1;
-	Std::vector<int16_t> rspritewidths; rspritewidths.resize(numsprits);
-	Std::vector<int16_t> rspriteheights; rspriteheights.resize(numsprits);
-	Std::vector<soff_t>  spriteoffs; spriteoffs.resize(numsprits);
+	std::vector<int16_t> rspritewidths; rspritewidths.resize(numsprits);
+	std::vector<int16_t> rspriteheights; rspriteheights.resize(numsprits);
+	std::vector<soff_t>  spriteoffs; spriteoffs.resize(numsprits);
 
 	fidx->ReadArrayOfInt16(&rspritewidths[0], numsprits);
 	fidx->ReadArrayOfInt16(&rspriteheights[0], numsprits);
@@ -336,7 +336,7 @@ static inline void ReadSprHeader(SpriteDatHeader &hdr, Stream *in,
 }
 
 HError SpriteFile::RebuildSpriteIndex(Stream *in, sprkey_t topmost,
-		Std::vector<Size> &metrics) {
+		std::vector<Size> &metrics) {
 	topmost = MIN(topmost, (sprkey_t)_spriteData.size() - 1);
 	for (sprkey_t i = 0; !in->EOS() && (i <= topmost); ++i) {
 		_spriteData[i].Offset = in->GetPosition();
@@ -378,7 +378,7 @@ HError SpriteFile::LoadSprite(sprkey_t index, Shared::Bitmap *&sprite) {
 	}
 	ImBufferPtr im_data(image->GetDataForWriting(), w * h * bpp, bpp);
 	// (Optional) Handle storage options, reverse
-	Std::vector<uint8_t> indexed_buf;
+	std::vector<uint8_t> indexed_buf;
 	uint32_t palette[256];
 	uint32_t pal_bpp = GetPaletteBPP(hdr.SFormat);
 	if (pal_bpp > 0) { // read palette if format assumes one
@@ -438,7 +438,7 @@ HError SpriteFile::LoadSprite(sprkey_t index, Shared::Bitmap *&sprite) {
 	return HError::None();
 }
 
-HError SpriteFile::LoadRawData(sprkey_t index, SpriteDatHeader &hdr, Std::vector<uint8_t> &data) {
+HError SpriteFile::LoadRawData(sprkey_t index, SpriteDatHeader &hdr, std::vector<uint8_t> &data) {
 	hdr = SpriteDatHeader();
 	data.resize(0);
 	if (index < 0 || (size_t)index >= _spriteData.size())
@@ -483,7 +483,7 @@ void SpriteFile::SeekToSprite(sprkey_t index) {
 
 
 // Finds the topmost occupied slot index
-static sprkey_t FindTopmostSprite(const Std::vector<Std::pair<bool, Bitmap *>> &sprites) {
+static sprkey_t FindTopmostSprite(const std::vector<std::pair<bool, Bitmap *>> &sprites) {
 	sprkey_t topmost = -1;
 	for (sprkey_t i = 0; i < static_cast<sprkey_t>(sprites.size()); ++i)
 		if (sprites[i].first)
@@ -492,10 +492,10 @@ static sprkey_t FindTopmostSprite(const Std::vector<Std::pair<bool, Bitmap *>> &
 }
 
 int SaveSpriteFile(const String &save_to_file,
-		const Std::vector<Std::pair<bool, Bitmap *> > &sprites,
+		const std::vector<std::pair<bool, Bitmap *> > &sprites,
 		SpriteFile *read_from_file,
 		int store_flags, SpriteCompression compress, SpriteFileIndex &index) {
-	Std::unique_ptr<Stream> output(File::CreateFile(save_to_file));
+	std::unique_ptr<Stream> output(File::CreateFile(save_to_file));
 	if (output == nullptr)
 		return -1;
 
@@ -503,9 +503,9 @@ int SaveSpriteFile(const String &save_to_file,
 	SpriteFileWriter writer(output);
 	writer.Begin(store_flags, compress, lastslot);
 
-	Std::unique_ptr<Bitmap> temp_bmp; // for disposing temp sprites
-	Std::vector<uint8_t> membuf; // for loading raw sprite data
-	Std::vector<uint32_t> palette;
+	std::unique_ptr<Bitmap> temp_bmp; // for disposing temp sprites
+	std::vector<uint8_t> membuf; // for loading raw sprite data
+	std::vector<uint32_t> palette;
 
 	const bool diff_compress =
 		read_from_file &&
@@ -575,7 +575,7 @@ int SaveSpriteIndex(const String &filename, const SpriteFileIndex &index) {
 	return 0;
 }
 
-SpriteFileWriter::SpriteFileWriter(Std::unique_ptr<Stream> &out) : _out(out) {
+SpriteFileWriter::SpriteFileWriter(std::unique_ptr<Stream> &out) : _out(out) {
 }
 
 void SpriteFileWriter::Begin(int store_flags, SpriteCompression compress, sprkey_t last_slot) {
@@ -616,7 +616,7 @@ void SpriteFileWriter::WriteBitmap(Bitmap *image) {
 	int h = image->GetHeight();
 	ImBufferCPtr im_data(image->GetData(), w * h * bpp, bpp);
 	// (Optional) Handle storage options
-	Std::vector<uint8_t> indexed_buf;
+	std::vector<uint8_t> indexed_buf;
 	uint32_t palette[256];
 	uint32_t pal_count = 0;
 	SpriteFormat sformat = kSprFmt_Undefined;

--- a/engines/ags/shared/ac/sprite_file.h
+++ b/engines/ags/shared/ac/sprite_file.h
@@ -92,9 +92,9 @@ typedef int32_t sprkey_t;
 // SpriteFileIndex contains sprite file's table of contents
 struct SpriteFileIndex {
 	int SpriteFileIDCheck = 0; // tag matching sprite file and index file
-	Std::vector<int16_t> Widths;
-	Std::vector<int16_t> Heights;
-	Std::vector<soff_t>  Offsets;
+	std::vector<int16_t> Widths;
+	std::vector<int16_t> Heights;
+	std::vector<soff_t>  Offsets;
 
 	inline size_t GetCount() const {
 		return Offsets.size();
@@ -132,7 +132,7 @@ public:
 	SpriteFile();
 	// Loads sprite reference information and inits sprite stream
 	HError      OpenFile(const String &filename, const String &sprindex_filename,
-		Std::vector<Size> &metrics);
+		std::vector<Size> &metrics);
 	// Closes stream; no reading will be possible unless opened again
 	void        Close();
 
@@ -144,15 +144,15 @@ public:
 
 	// Loads sprite index file
 	bool        LoadSpriteIndexFile(const String &filename, int expectedFileID,
-		soff_t spr_initial_offs, sprkey_t topmost, Std::vector<Size> &metrics);
+		soff_t spr_initial_offs, sprkey_t topmost, std::vector<Size> &metrics);
 	// Rebuilds sprite index from the main sprite file
 	HError      RebuildSpriteIndex(Stream *in, sprkey_t topmost,
-		Std::vector<Size> &metrics);
+		std::vector<Size> &metrics);
 
 	// Loads an image data and creates a ready bitmap
 	HError      LoadSprite(sprkey_t index, Bitmap *&sprite);
 	// Loads a raw sprite element data into the buffer, stores header info separately
-	HError      LoadRawData(sprkey_t index, SpriteDatHeader &hdr, Std::vector<uint8_t> &data);
+	HError      LoadRawData(sprkey_t index, SpriteDatHeader &hdr, std::vector<uint8_t> &data);
 
 private:
 	// Seek stream to sprite
@@ -166,8 +166,8 @@ private:
 	};
 
 	// Array of sprite references
-	Std::vector<SpriteRef> _spriteData;
-	Std::unique_ptr<Stream> _stream; // the sprite stream
+	std::vector<SpriteRef> _spriteData;
+	std::unique_ptr<Stream> _stream; // the sprite stream
 	SpriteFileVersion _version = kSprfVersion_Current;
 	int _storeFlags = 0; // storage flags, specify how sprites may be stored
 	SpriteCompression _compress = kSprCompress_None; // sprite compression typ
@@ -179,7 +179,7 @@ private:
 // over slot by slot, then call Finalize to let it close the format correctly.
 class SpriteFileWriter {
 public:
-	SpriteFileWriter(Std::unique_ptr<Stream> &out);
+	SpriteFileWriter(std::unique_ptr<Stream> &out);
 	~SpriteFileWriter() {
 	}
 
@@ -207,14 +207,14 @@ private:
 		const uint8_t *im_data, size_t im_data_sz, int im_bpp,
 		const uint32_t palette[256]);
 
-	Std::unique_ptr<Stream> &_out;
+	std::unique_ptr<Stream> &_out;
 	int _storeFlags = 0;
 	SpriteCompression _compress = kSprCompress_None;
 	soff_t _lastSlotPos = -1; // last slot save position in file
 	// sprite index accumulated on write for reporting back to user
 	SpriteFileIndex _index;
 	// compression buffer
-	Std::vector<uint8_t> _membuf;
+	std::vector<uint8_t> _membuf;
 };
 
 // Saves all sprites to file; fills in index data for external use.
@@ -223,7 +223,7 @@ private:
 // tells if sprite exists and Bitmap pointer may be null;
 // If a sprite's bitmap is missing, it will try reading one from the input file stream.
 int SaveSpriteFile(const String &save_to_file,
-	const Std::vector<Std::pair<bool, Bitmap *> > &sprites,
+	const std::vector<std::pair<bool, Bitmap *> > &sprites,
 	SpriteFile *read_from_file, // optional file to read missing sprites from
 	int store_flags, SpriteCompression compress, SpriteFileIndex &index);
 // Saves sprite index table in a separate file

--- a/engines/ags/shared/ac/view.cpp
+++ b/engines/ags/shared/ac/view.cpp
@@ -158,7 +158,7 @@ void ViewStruct272::ReadFromFile(Stream *in) {
 	}
 }
 
-void Convert272ViewsToNew(const Std::vector<ViewStruct272> &oldv, Std::vector<ViewStruct> &newv) {
+void Convert272ViewsToNew(const std::vector<ViewStruct272> &oldv, std::vector<ViewStruct> &newv) {
 	for (size_t a = 0; a < oldv.size(); a++) {
 		newv[a].Initialize(oldv[a].numloops);
 

--- a/engines/ags/shared/ac/view.h
+++ b/engines/ags/shared/ac/view.h
@@ -58,7 +58,7 @@ struct ViewFrame {
 struct ViewLoopNew {
 	int numFrames;
 	int   flags;
-	Std::vector<ViewFrame> frames;
+	std::vector<ViewFrame> frames;
 	// NOTE: we still need numFrames for backward compatibility:
 	// some older versions could allocate extra frame(s) for safety,
 	// but have to report "logical" number of frames for the engine API.
@@ -75,7 +75,7 @@ struct ViewLoopNew {
 
 struct ViewStruct {
 	int numLoops;
-	Std::vector<ViewLoopNew> loops;
+	std::vector<ViewLoopNew> loops;
 
 	ViewStruct();
 	void Initialize(int loopCount);
@@ -94,7 +94,7 @@ struct ViewStruct272 {
 	void ReadFromFile(Shared::Stream *in);
 };
 
-extern void Convert272ViewsToNew(const Std::vector<ViewStruct272> &oldv, Std::vector<ViewStruct> &newv);
+extern void Convert272ViewsToNew(const std::vector<ViewStruct272> &oldv, std::vector<ViewStruct> &newv);
 
 } // namespace AGS3
 

--- a/engines/ags/shared/core/asset.h
+++ b/engines/ags/shared/core/asset.h
@@ -51,10 +51,10 @@ struct AssetLibInfo {
 	String BasePath;                   // full path to the base filename
 	String BaseDir;                    // library's directory
 	String BaseFileName;               // library's base (head) filename
-	Std::vector<String> LibFileNames;  // filename for each library part
+	std::vector<String> LibFileNames;  // filename for each library part
 
 	// Library contents
-	Std::vector<AssetInfo> AssetInfos; // information on contained assets
+	std::vector<AssetInfo> AssetInfos; // information on contained assets
 };
 
 } // namespace Shared

--- a/engines/ags/shared/core/asset_manager.cpp
+++ b/engines/ags/shared/core/asset_manager.cpp
@@ -39,7 +39,7 @@ inline static bool IsAssetLibDir(const AssetLibInfo *lib) {
 
 bool AssetManager::AssetLibEx::TestFilter(const String &filter) const {
 	return filter == "*" ||
-		(Std::find(Filters.begin(), Filters.end(), filter) != Filters.end());
+		(std::find(Filters.begin(), Filters.end(), filter) != Filters.end());
 }
 
 bool AssetManager::LibsByPriority::operator()(const AssetLibInfo *lib1, const AssetLibInfo *lib2) const {
@@ -82,7 +82,7 @@ AssetManager::AssetManager() {
 void AssetManager::SetSearchPriority(AssetSearchPriority priority) {
 	_libsByPriority.Priority = priority;
 
-	Std::sort(_activeLibs.begin(), _activeLibs.end(), _libsByPriority);
+	std::sort(_activeLibs.begin(), _activeLibs.end(), _libsByPriority);
 }
 
 AssetSearchPriority AssetManager::GetSearchPriority() const {
@@ -112,7 +112,7 @@ AssetError AssetManager::AddLibrary(const String &path, const String &filters, c
 	if (err != kAssetNoError)
 		return err;
 	lib->Filters = filters.Split(',');
-	auto place = Std::upper_bound(_activeLibs.begin(), _activeLibs.end(), lib, _libsByPriority);
+	auto place = std::upper_bound(_activeLibs.begin(), _activeLibs.end(), lib, _libsByPriority);
 	_activeLibs.insert(place, lib);
 	if (out_lib)
 		*out_lib = lib;
@@ -163,12 +163,12 @@ bool AssetManager::DoesAssetExist(const String &asset_name, const String &filter
 	return false;
 }
 
-void AssetManager::FindAssets(Std::vector<String> &assets, const String &wildcard,
+void AssetManager::FindAssets(std::vector<String> &assets, const String &wildcard,
 		const String &filter) const {
 	String pattern = StrUtil::WildcardToRegex(wildcard);
 
 	for (const auto *lib : _activeLibs) {
-		auto match = Std::find(lib->Filters.begin(), lib->Filters.end(), filter);
+		auto match = std::find(lib->Filters.begin(), lib->Filters.end(), filter);
 		if (match == lib->Filters.end())
 			continue; // filter does not match
 
@@ -186,13 +186,13 @@ void AssetManager::FindAssets(Std::vector<String> &assets, const String &wildcar
 	}
 
 	// Sort and remove duplicates
-	Std::sort(assets.begin(), assets.end());
-	assets.erase(Std::unique(assets.begin(), assets.end()), assets.end());
+	std::sort(assets.begin(), assets.end());
+	assets.erase(std::unique(assets.begin(), assets.end()), assets.end());
 }
 
 AssetError AssetManager::RegisterAssetLib(const String &path, AssetLibEx *&out_lib) {
 	// Test for a directory
-	Std::unique_ptr<AssetLibEx> lib;
+	std::unique_ptr<AssetLibEx> lib;
 	if (File::IsDirectory(path)) {
 		lib.reset(new AssetLibEx());
 		lib->BasePath = Path::MakeAbsolutePath(path);

--- a/engines/ags/shared/core/asset_manager.h
+++ b/engines/ags/shared/core/asset_manager.h
@@ -111,7 +111,7 @@ public:
 	}
 	// Searches in all the registered locations and collects a list of
     // assets using given wildcard pattern
-    void FindAssets(Std::vector<String> &assets, const String &wildcard,
+    void FindAssets(std::vector<String> &assets, const String &wildcard,
 		const String &filter = "") const;
 	// Open asset stream in the given work mode; returns null if asset is not found or cannot be opened
 	// This method only searches in libraries that do not have any defined filters
@@ -130,8 +130,8 @@ public:
 private:
 	// AssetLibEx combines library info with extended internal data required for the manager
 	struct AssetLibEx : AssetLibInfo {
-		Std::vector<String> Filters; // asset filters this library is matching to
-		Std::vector<String> RealLibFiles; // fixed up library filenames
+		std::vector<String> Filters; // asset filters this library is matching to
+		std::vector<String> RealLibFiles; // fixed up library filenames
 
 		bool TestFilter(const String &filter) const;
 	};
@@ -143,8 +143,8 @@ private:
 	Stream *OpenAssetFromLib(const AssetLibEx *lib, const String &asset_name) const;
 	Stream *OpenAssetFromDir(const AssetLibEx *lib, const String &asset_name) const;
 
-	Std::vector<AssetLibEx *> _libs;
-	Std::vector<AssetLibEx *> _activeLibs;
+	std::vector<AssetLibEx *> _libs;
+	std::vector<AssetLibEx *> _activeLibs;
 
 	struct LibsByPriority {
 		AssetSearchPriority Priority = kAssetPriorityDir;

--- a/engines/ags/shared/core/types.h
+++ b/engines/ags/shared/core/types.h
@@ -29,6 +29,7 @@
 #define AGS_SHARED_CORE_TYPES_H
 
 #include "common/scummsys.h"
+#include "ags/lib/std.h"
 
 namespace AGS3 {
 

--- a/engines/ags/shared/debugging/debug_manager.cpp
+++ b/engines/ags/shared/debugging/debug_manager.cpp
@@ -56,7 +56,7 @@ void DebugOutput::SetGroupFilter(DebugGroupID id, MessageType verbosity) {
 	if (key != kDbgGroup_None)
 		_groupFilter[key] = verbosity;
 	else
-		_unresolvedGroups.insert(Std::make_pair(id.SID, verbosity));
+		_unresolvedGroups.insert(std::make_pair(id.SID, verbosity));
 }
 
 void DebugOutput::SetAllGroupFilters(MessageType verbosity) {

--- a/engines/ags/shared/debugging/debug_manager.h
+++ b/engines/ags/shared/debugging/debug_manager.h
@@ -97,13 +97,13 @@ private:
 	bool            _enabled;
 	MessageType     _defaultVerbosity;
 	// Set of permitted groups' numeric IDs
-	Std::vector<MessageType> _groupFilter;
+	std::vector<MessageType> _groupFilter;
 	// Set of unresolved groups, which numeric IDs are not yet known
-	typedef Std::unordered_map<String, MessageType, IgnoreCase_Hash, IgnoreCase_EqualTo> GroupNameToMTMap;
+	typedef std::unordered_map<String, MessageType, IgnoreCase_Hash, IgnoreCase_EqualTo> GroupNameToMTMap;
 	GroupNameToMTMap _unresolvedGroups;
 };
 
-typedef Std::shared_ptr<DebugOutput> PDebugOutput;
+typedef std::shared_ptr<DebugOutput> PDebugOutput;
 
 
 class DebugManager {
@@ -147,9 +147,9 @@ private:
 		}
 	};
 
-	typedef Std::vector<DebugGroup> GroupVector;
-	typedef Std::unordered_map<String, DebugGroupID, IgnoreCase_Hash, IgnoreCase_EqualTo> GroupByStringMap;
-	typedef Std::unordered_map<String, OutputSlot, IgnoreCase_Hash, IgnoreCase_EqualTo> OutMap;
+	typedef std::vector<DebugGroup> GroupVector;
+	typedef std::unordered_map<String, DebugGroupID, IgnoreCase_Hash, IgnoreCase_EqualTo> GroupByStringMap;
+	typedef std::unordered_map<String, OutputSlot, IgnoreCase_Hash, IgnoreCase_EqualTo> OutMap;
 
 	void RegisterGroup(const DebugGroup &id);
 	void SendMessage(OutputSlot &out, const DebugMessage &msg);

--- a/engines/ags/shared/font/fonts.cpp
+++ b/engines/ags/shared/font/fonts.cpp
@@ -90,7 +90,7 @@ static void font_post_init(size_t fontNumber) {
 			height = font.Renderer->GetTextHeight(height_test_string, fontNumber);
 		}
 
-		font.Metrics.Height = Std::max(0, height);
+		font.Metrics.Height = std::max(0, height);
 		font.Metrics.RealHeight = font.Metrics.Height;
 	}
 	// Use either nominal or real pixel height to define font's logical height
@@ -298,7 +298,7 @@ int get_text_lines_surf_height(size_t fontNumber, size_t numlines) {
 }
 
 // Replaces AGS-specific linebreak tags with common '\n'
-void unescape_script_string(const char *cstr, Std::vector<char> &out) {
+void unescape_script_string(const char *cstr, std::vector<char> &out) {
 	out.clear();
 	// Handle the special case of the first char
 	if (cstr[0] == '[') {

--- a/engines/ags/shared/font/fonts.h
+++ b/engines/ags/shared/font/fonts.h
@@ -144,7 +144,7 @@ bool ShouldAntiAliasText();
 
 // SplitLines class represents a list of lines and is meant to reduce
 // subsequent memory (de)allocations if used often during game loops
-// and drawing. For that reason it is not equivalent to Std::vector,
+// and drawing. For that reason it is not equivalent to std::vector,
 // but keeps constructed String buffers intact for most time.
 // TODO: implement proper strings pool.
 class SplitLines {
@@ -171,10 +171,10 @@ public:
 	}
 
 	// An auxiliary line processing buffer
-	Std::vector<char> LineBuf;
+	std::vector<char> LineBuf;
 
 private:
-	Std::vector<Shared::String> _pool;
+	std::vector<Shared::String> _pool;
 	size_t _count; // actual number of lines in use
 };
 

--- a/engines/ags/shared/font/ttf_font_renderer.cpp
+++ b/engines/ags/shared/font/ttf_font_renderer.cpp
@@ -87,12 +87,12 @@ static int GetAlfontFlags(int load_mode) {
 
 // Loads a TTF font of a certain size
 static ALFONT_FONT *LoadTTF(const String &filename, int fontSize, int alfont_flags) {
-	Std::unique_ptr<Stream> reader(_GP(AssetMgr)->OpenAsset(filename));
+	std::unique_ptr<Stream> reader(_GP(AssetMgr)->OpenAsset(filename));
 	if (!reader)
 		return nullptr;
 
 	const size_t lenof = reader->GetLength();
-	Std::vector<char> buf; buf.resize(lenof);
+	std::vector<char> buf; buf.resize(lenof);
 	reader->Read(&buf.front(), lenof);
 	reader.reset();
 

--- a/engines/ags/shared/font/ttf_font_renderer.h
+++ b/engines/ags/shared/font/ttf_font_renderer.h
@@ -74,7 +74,7 @@ private:
 		ALFONT_FONT *AlFont;
 		FontRenderParams Params;
 	};
-	Std::map<int, FontData> _fontData;
+	std::map<int, FontData> _fontData;
 };
 
 } // namespace AGS3

--- a/engines/ags/shared/font/wfn_font.cpp
+++ b/engines/ags/shared/font/wfn_font.cpp
@@ -98,7 +98,7 @@ WFNError WFNFont::ReadFromFile(Stream *in, const soff_t data_size) {
 	in->ReadArrayOfInt16((int16_t *)offset_table, char_count);
 
 	// Read all referenced offsets in an unsorted vector
-	Std::vector<uint16_t> offs;
+	std::vector<uint16_t> offs;
 	offs.reserve(char_count); // reserve max possible offsets
 	for (size_t i = 0; i < char_count; ++i) {
 		const uint16_t off = offset_table[i];
@@ -111,12 +111,12 @@ WFNError WFNFont::ReadFromFile(Stream *in, const soff_t data_size) {
 		offs.push_back(off);
 	}
 	// sort offsets vector and remove any duplicates
-	Std::sort(offs.begin(), offs.end());
+	std::sort(offs.begin(), offs.end());
 #if AGS_PLATFORM_SCUMMVM
 	// TODO: See if this works correctly
-	Std::unique(offs.begin(), offs.end());
+	std::unique(offs.begin(), offs.end());
 #else
-	Std::vector<uint16_t>(offs.begin(), Std::unique(offs.begin(), offs.end())).swap(offs);
+	std::vector<uint16_t>(offs.begin(), std::unique(offs.begin(), offs.end())).swap(offs);
 #endif
 
 	// Now that we know number of valid character items, parse and store character data
@@ -135,7 +135,7 @@ WFNError WFNFont::ReadFromFile(Stream *in, const soff_t data_size) {
 	// since the items are sorted, the pixel data will be stored sequentially as well.
 	// At this point offs and _items have related elements in the same order.
 	_pixelData.resize(total_pixel_size);
-	Std::vector<uint8_t>::iterator pixel_it = _pixelData.begin(); // write ptr
+	std::vector<uint8_t>::iterator pixel_it = _pixelData.begin(); // write ptr
 	for (size_t i = 0; i < _items.size(); ++i) {
 		const size_t pixel_data_size = _items[i].GetRequiredPixelSize();
 		if (pixel_data_size == 0) {
@@ -179,7 +179,7 @@ WFNError WFNFont::ReadFromFile(Stream *in, const soff_t data_size) {
 				_refs[i] = &_items[i];
 			else {
 				// we know beforehand that such item must exist
-				Std::vector<uint16_t>::const_iterator at = Std::lower_bound(offs.begin(), offs.end(), off);
+				std::vector<uint16_t>::const_iterator at = std::lower_bound(offs.begin(), offs.end(), off);
 				assert(at != offs.end() && *at == off && // should not normally fail
 				       at - offs.begin() >= 0 && static_cast<size_t>(at - offs.begin()) < _items.size());
 				_refs[i] = &_items[at - offs.begin()]; // set up reference to item

--- a/engines/ags/shared/font/wfn_font.h
+++ b/engines/ags/shared/font/wfn_font.h
@@ -98,9 +98,9 @@ public:
 	WFNError ReadFromFile(AGS::Shared::Stream *in, const soff_t data_size = 0);
 
 protected:
-	Std::vector<const WFNChar *> _refs;      // reference array, contains pointers to elements of _items
-	Std::vector<WFNChar>        _items;     // actual character items
-	Std::vector<uint8_t>        _pixelData; // pixel data array
+	std::vector<const WFNChar *> _refs;      // reference array, contains pointers to elements of _items
+	std::vector<WFNChar>        _items;     // actual character items
+	std::vector<uint8_t>        _pixelData; // pixel data array
 };
 
 } // namespace AGS3

--- a/engines/ags/shared/font/wfn_font_renderer.cpp
+++ b/engines/ags/shared/font/wfn_font_renderer.cpp
@@ -103,10 +103,10 @@ static int RenderChar(Bitmap *ds, const int at_x, const int at_y, Rect clip,
 	const unsigned char *actdata = wfn_char.Data;
 	const int bytewid = wfn_char.GetRowByteCount();
 
-	int sx = Std::max(at_x, clip.Left), ex = clip.Right + 1;
-	int sy = Std::max(at_y, clip.Top), ey = clip.Bottom + 1;
-	int sw = Std::max(0, clip.Left - at_x);
-	int sh = Std::max(0, clip.Top - at_y);
+	int sx = std::max(at_x, clip.Left), ex = clip.Right + 1;
+	int sy = std::max(at_y, clip.Top), ey = clip.Bottom + 1;
+	int sw = std::max(0, clip.Left - at_x);
+	int sh = std::max(0, clip.Top - at_y);
 	for (int h = sh, y = sy; h < height && y < ey; ++h, y += scale) {
 		for (int w = sw, x = sx; w < width && x < ex; ++w, x += scale) {
 			if (((actdata[h * bytewid + (w / 8)] & (0x80 >> (w % 8))) != 0)) {

--- a/engines/ags/shared/font/wfn_font_renderer.h
+++ b/engines/ags/shared/font/wfn_font_renderer.h
@@ -23,6 +23,7 @@
 #define AGS_SHARED_FONT_WFN_FONT_RENDERER_H
 
 #include "common/std/map.h"
+#include "ags/lib/std.h"
 #include "ags/shared/font/ags_font_renderer.h"
 
 namespace AGS3 {

--- a/engines/ags/shared/font/wfn_font_renderer.h
+++ b/engines/ags/shared/font/wfn_font_renderer.h
@@ -63,7 +63,7 @@ private:
 		WFNFont *Font;
 		FontRenderParams Params;
 	};
-	Std::map<int, FontData> _fontData;
+	std::map<int, FontData> _fontData;
 };
 
 } // namespace AGS3

--- a/engines/ags/shared/game/custom_properties.h
+++ b/engines/ags/shared/game/custom_properties.h
@@ -86,7 +86,7 @@ struct PropertyDesc {
 
 // NOTE: AGS has case-insensitive property IDs
 // Schema - a map of property descriptions
-typedef Std::unordered_map<String, PropertyDesc, IgnoreCase_Hash, IgnoreCase_EqualTo> PropertySchema;
+typedef std::unordered_map<String, PropertyDesc, IgnoreCase_Hash, IgnoreCase_EqualTo> PropertySchema;
 
 
 namespace Properties {

--- a/engines/ags/shared/game/interactions.cpp
+++ b/engines/ags/shared/game/interactions.cpp
@@ -141,7 +141,7 @@ void InteractionCommandList::Reset() {
 	TimesRun = 0;
 }
 
-void InteractionCommandList::Read_Aligned(Stream *in, Std::vector<bool> &cmd_children) {
+void InteractionCommandList::Read_Aligned(Stream *in, std::vector<bool> &cmd_children) {
 	AlignedStream align_s(in, Shared::kAligned_Read);
 	for (size_t i = 0; i < Cmds.size(); ++i) {
 		bool has_children;
@@ -155,7 +155,7 @@ void InteractionCommandList::Read_v321(Stream *in) {
 	size_t cmd_count = in->ReadInt32();
 	TimesRun = in->ReadInt32();
 
-	Std::vector<bool> cmd_children;
+	std::vector<bool> cmd_children;
 	Cmds.resize(cmd_count);
 	cmd_children.resize(cmd_count);
 	Read_Aligned(in, cmd_children);

--- a/engines/ags/shared/game/interactions.h
+++ b/engines/ags/shared/game/interactions.h
@@ -90,7 +90,7 @@ struct InteractionValue {
 
 
 struct InteractionCommandList;
-typedef Std::unique_ptr<InteractionCommandList> UInterCmdList;
+typedef std::unique_ptr<InteractionCommandList> UInterCmdList;
 
 // InteractionCommand represents a single command (action), an item of Command List
 struct InteractionCommand {
@@ -116,7 +116,7 @@ struct InteractionCommand {
 };
 
 
-typedef Std::vector<InteractionCommand> InterCmdVector;
+typedef std::vector<InteractionCommand> InterCmdVector;
 // InteractionCommandList represents a list of commands (actions) that need to be
 // performed on particular game event
 struct InteractionCommandList {
@@ -132,7 +132,7 @@ struct InteractionCommandList {
 	void Write_v321(Stream *out) const;
 
 protected:
-	void Read_Aligned(Shared::Stream *in, Std::vector<bool> &cmd_children);
+	void Read_Aligned(Shared::Stream *in, std::vector<bool> &cmd_children);
 	void Write_Aligned(Shared::Stream *out) const;
 };
 
@@ -149,7 +149,7 @@ struct InteractionEvent {
 	InteractionEvent &operator = (const InteractionEvent &ic);
 };
 
-typedef Std::vector<InteractionEvent> InterEvtVector;
+typedef std::vector<InteractionEvent> InterEvtVector;
 // Interaction is the list of events and responses for a game or game object
 struct Interaction {
 	// The first few event types depend on the item - ID's of 100+ are
@@ -178,7 +178,7 @@ struct Interaction {
 	Interaction &operator =(const Interaction &inter);
 };
 
-typedef Std::shared_ptr<Interaction> PInteraction;
+typedef std::shared_ptr<Interaction> PInteraction;
 
 
 // Legacy pre-3.0 kind of global and local room variables
@@ -194,7 +194,7 @@ struct InteractionVariable {
 	void Write(Stream *out) const;
 };
 
-typedef Std::vector<InteractionVariable> InterVarVector;
+typedef std::vector<InteractionVariable> InterVarVector;
 
 
 // A list of script function names for all supported events
@@ -204,7 +204,7 @@ struct InteractionScripts {
 	static InteractionScripts *CreateFromStream(Stream *in);
 };
 
-typedef Std::shared_ptr<InteractionScripts> PInteractionScripts;
+typedef std::shared_ptr<InteractionScripts> PInteractionScripts;
 
 } // namespace Shared
 } // namespace AGS

--- a/engines/ags/shared/game/main_game_file.cpp
+++ b/engines/ags/shared/game/main_game_file.cpp
@@ -227,7 +227,7 @@ HGameFileError ReadDialogScript(PScript &dialog_script, Stream *in, GameDataVers
 	return HGameFileError::None();
 }
 
-HGameFileError ReadScriptModules(Std::vector<PScript> &sc_mods, Stream *in, GameDataVersion data_ver) {
+HGameFileError ReadScriptModules(std::vector<PScript> &sc_mods, Stream *in, GameDataVersion data_ver) {
 	if (data_ver >= kGameVersion_270) { // 2.7.0+ script modules
 		int count = in->ReadInt32();
 		sc_mods.resize(count);
@@ -242,7 +242,7 @@ HGameFileError ReadScriptModules(Std::vector<PScript> &sc_mods, Stream *in, Game
 	return HGameFileError::None();
 }
 
-void ReadViewStruct272_Aligned(Std::vector<ViewStruct272> &oldv, Stream *in, size_t count) {
+void ReadViewStruct272_Aligned(std::vector<ViewStruct272> &oldv, Stream *in, size_t count) {
 	AlignedStream align_s(in, Shared::kAligned_Read);
 	oldv.resize(count);
 	for (size_t i = 0; i < count; ++i) {
@@ -251,7 +251,7 @@ void ReadViewStruct272_Aligned(Std::vector<ViewStruct272> &oldv, Stream *in, siz
 	}
 }
 
-void ReadViews(GameSetupStruct &game, Std::vector<ViewStruct> &views, Stream *in, GameDataVersion data_ver) {
+void ReadViews(GameSetupStruct &game, std::vector<ViewStruct> &views, Stream *in, GameDataVersion data_ver) {
 	views.resize(game.numviews);
 	if (data_ver > kGameVersion_272) // 3.x views
 	{
@@ -260,16 +260,16 @@ void ReadViews(GameSetupStruct &game, Std::vector<ViewStruct> &views, Stream *in
 		}
 	} else // 2.x views
 	{
-		Std::vector<ViewStruct272> oldv;
+		std::vector<ViewStruct272> oldv;
 		ReadViewStruct272_Aligned(oldv, in, game.numviews);
 		Convert272ViewsToNew(oldv, views);
 	}
 }
 
-void ReadDialogs(Std::vector<DialogTopic> &dialog,
-                 Std::vector<Std::vector<uint8_t>> &old_dialog_scripts,
-                 Std::vector<String> &old_dialog_src,
-                 Std::vector<String> &old_speech_lines,
+void ReadDialogs(std::vector<DialogTopic> &dialog,
+                 std::vector<std::vector<uint8_t>> &old_dialog_scripts,
+                 std::vector<String> &old_dialog_src,
+                 std::vector<String> &old_speech_lines,
                  Stream *in, GameDataVersion data_ver, int dlg_count) {
 	dialog.resize(dlg_count);
 	for (int i = 0; i < dlg_count; ++i) {
@@ -364,7 +364,7 @@ void ReadDialogs(Std::vector<DialogTopic> &dialog,
 	}
 }
 
-HGameFileError ReadPlugins(Std::vector<PluginInfo> &infos, Stream *in) {
+HGameFileError ReadPlugins(std::vector<PluginInfo> &infos, Stream *in) {
 	int fmt_ver = in->ReadInt32();
 	if (fmt_ver != 1)
 		return new MainGameFileError(kMGFErr_PluginDataFmtNotSupported, String::FromFormat("Version: %d, supported: %d", fmt_ver, 1));
@@ -392,7 +392,7 @@ HGameFileError ReadPlugins(Std::vector<PluginInfo> &infos, Stream *in) {
 // Create the missing audioClips data structure for 3.1.x games.
 // This is done by going through the data files and adding all music*.*
 // and sound*.* files to it.
-void BuildAudioClipArray(const Std::vector<String> &assets, Std::vector<ScriptAudioClip> &audioclips) {
+void BuildAudioClipArray(const std::vector<String> &assets, std::vector<ScriptAudioClip> &audioclips) {
 	char temp_name[30];
 	int temp_number;
 	char temp_extension[10];
@@ -507,8 +507,8 @@ void UpgradeAudio(GameSetupStruct &game, LoadedGameEntities &ents, GameDataVersi
 	// ourselves, then add this information to game struct.
 
 	// Create soundClips and audioClipTypes structures.
-	Std::vector<AudioClipType> audiocliptypes;
-	Std::vector<ScriptAudioClip> audioclips;
+	std::vector<AudioClipType> audiocliptypes;
+	std::vector<ScriptAudioClip> audioclips;
 
 	// TODO: find out what is 4 (maybe music, sound, ambient sound, voice?)
 	audiocliptypes.resize(4);
@@ -520,7 +520,7 @@ void UpgradeAudio(GameSetupStruct &game, LoadedGameEntities &ents, GameDataVersi
 	audiocliptypes[3].reservedChannels = 0;
 
 	audioclips.reserve(1000);
-	Std::vector<String> assets;
+	std::vector<String> assets;
 	// Read audio clip names from from registered libraries
 	for (size_t i = 0; i < _GP(AssetMgr)->GetLibraryCount(); ++i) {
 		const AssetLibInfo *game_lib = _GP(AssetMgr)->GetLibraryInfo(i);
@@ -609,7 +609,7 @@ void UpgradeMouseCursors(GameSetupStruct &game, GameDataVersion data_ver) {
 }
 
 // Adjusts score clip id, depending on game data version
-void RemapLegacySoundNums(GameSetupStruct &game, Std::vector<ViewStruct> &views, GameDataVersion data_ver) {
+void RemapLegacySoundNums(GameSetupStruct &game, std::vector<ViewStruct> &views, GameDataVersion data_ver) {
 	if (data_ver >= kGameVersion_320)
 		return;
 

--- a/engines/ags/shared/game/main_game_file.h
+++ b/engines/ags/shared/game/main_game_file.h
@@ -79,7 +79,7 @@ String GetMainGameFileErrorText(MainGameFileErrorType err);
 
 typedef TypedCodeError<MainGameFileErrorType, GetMainGameFileErrorText> MainGameFileError;
 typedef ErrorHandle<MainGameFileError> HGameFileError;
-typedef Std::unique_ptr<Stream> UStream;
+typedef std::unique_ptr<Stream> UStream;
 
 // MainGameSource defines a successfully opened main game file
 struct MainGameSource {
@@ -97,7 +97,7 @@ struct MainGameSource {
 	String              CompiledWith;
 	// Extended engine capabilities required by the game; their primary use
 	// currently is to let "alternate" game formats indicate themselves
-	Std::set<String>    Caps;
+	std::set<String>    Caps;
 	// A ponter to the opened stream
 	UStream             InputStream;
 
@@ -111,25 +111,25 @@ struct MainGameSource {
 // code refactoring.
 struct LoadedGameEntities {
 	GameSetupStruct &Game;
-	Std::vector<DialogTopic> Dialogs;
-	Std::vector<ViewStruct> Views;
+	std::vector<DialogTopic> Dialogs;
+	std::vector<ViewStruct> Views;
 	PScript                 GlobalScript;
 	PScript                 DialogScript;
-	Std::vector<PScript>    ScriptModules;
-	Std::vector<PluginInfo> PluginInfos;
+	std::vector<PScript>    ScriptModules;
+	std::vector<PluginInfo> PluginInfos;
 
 	// Original sprite data (when it was read into const-sized arrays)
 	size_t                  SpriteCount;
-	Std::vector<uint8_t>	SpriteFlags; // SPF_* flags
+	std::vector<uint8_t>	SpriteFlags; // SPF_* flags
 
 	// Old dialog support
 	// legacy compiled dialog script of its own format,
 	// requires separate interpreting
-	Std::vector<Std::vector<uint8_t>> OldDialogScripts;
+	std::vector<std::vector<uint8_t>> OldDialogScripts;
 	// probably, actual dialog script sources kept within some older games
-	Std::vector<String>     OldDialogSources;
+	std::vector<String>     OldDialogSources;
 	// speech texts displayed during dialog
-	Std::vector<String>     OldSpeechLines;
+	std::vector<String>     OldSpeechLines;
 
 	LoadedGameEntities(GameSetupStruct &game);
 	~LoadedGameEntities();
@@ -156,7 +156,7 @@ HGameFileError     UpdateGameData(LoadedGameEntities &ents, GameDataVersion data
 // Ensures that the game saves directory path is valid
 void               FixupSaveDirectory(GameSetupStruct &game);
 // Maps legacy sound numbers to real audio clips
-void               RemapLegacySoundNums(GameSetupStruct &game, Std::vector<ViewStruct> &views, GameDataVersion data_ver);
+void               RemapLegacySoundNums(GameSetupStruct &game, std::vector<ViewStruct> &views, GameDataVersion data_ver);
 
 } // namespace Shared
 } // namespace AGS

--- a/engines/ags/shared/game/plugin_info.h
+++ b/engines/ags/shared/game/plugin_info.h
@@ -42,7 +42,7 @@ struct PluginInfo {
 	// (File)name of plugin
 	String      Name;
 	// Custom data for plugin
-	Std::vector<char> Data;
+	std::vector<char> Data;
 	size_t      DataLen;
 
 	PluginInfo() : DataLen(0) {

--- a/engines/ags/shared/game/room_file.cpp
+++ b/engines/ags/shared/game/room_file.cpp
@@ -487,7 +487,7 @@ HRoomFileError ReadRoomData(RoomStruct *room, Stream *in, RoomFileVersion data_v
 		new RoomFileError(kRoomFileErr_BlockListFailed, err);
 }
 
-HRoomFileError UpdateRoomData(RoomStruct *room, RoomFileVersion data_ver, bool game_is_hires, const Std::vector<SpriteInfo> &sprinfos) {
+HRoomFileError UpdateRoomData(RoomStruct *room, RoomFileVersion data_ver, bool game_is_hires, const std::vector<SpriteInfo> &sprinfos) {
 	if (data_ver < kRoomVersion_200_final)
 		room->MaskResolution = room->BgFrames[0].Graphic->GetWidth() > 320 ? kRoomHiRes : kRoomLoRes;
 	if (data_ver < kRoomVersion_3508) {

--- a/engines/ags/shared/game/room_file.h
+++ b/engines/ags/shared/game/room_file.h
@@ -91,9 +91,9 @@ String GetRoomBlockName(RoomFileBlock id);
 typedef TypedCodeError<RoomFileErrorType, GetRoomFileErrorText> RoomFileError;
 typedef ErrorHandle<RoomFileError> HRoomFileError;
 #ifdef AGS_PLATFORM_SCUMMVM
-typedef Std::shared_ptr<Stream> UStream;
+typedef std::shared_ptr<Stream> UStream;
 #else
-typedef Std::unique_ptr<Stream> UStream;
+typedef std::unique_ptr<Stream> UStream;
 #endif
 
 
@@ -117,7 +117,7 @@ HRoomFileError OpenRoomFileFromAsset(const String &filename, RoomDataSource &src
 HRoomFileError ReadRoomData(RoomStruct *room, Stream *in, RoomFileVersion data_ver);
 // Applies necessary updates, conversions and fixups to the loaded data
 // making it compatible with current engine
-HRoomFileError UpdateRoomData(RoomStruct *room, RoomFileVersion data_ver, bool game_is_hires, const Std::vector<SpriteInfo> &sprinfos);
+HRoomFileError UpdateRoomData(RoomStruct *room, RoomFileVersion data_ver, bool game_is_hires, const std::vector<SpriteInfo> &sprinfos);
 // Extracts text script from the room file, if it's available.
 // Historically, text sources were kept inside packed room files before AGS 3.*.
 HRoomFileError ExtractScriptText(String &script, Stream *in, RoomFileVersion data_ver);

--- a/engines/ags/shared/game/room_struct.cpp
+++ b/engines/ags/shared/game/room_struct.cpp
@@ -226,7 +226,7 @@ int RoomStruct::GetRegionTintLuminance(int id) const {
 	return 0;
 }
 
-void load_room(const String &filename, RoomStruct *room, bool game_is_hires, const Std::vector<SpriteInfo> &sprinfos) {
+void load_room(const String &filename, RoomStruct *room, bool game_is_hires, const std::vector<SpriteInfo> &sprinfos) {
 	room->Free();
 	room->InitDefaults();
 

--- a/engines/ags/shared/game/room_struct.h
+++ b/engines/ags/shared/game/room_struct.h
@@ -57,7 +57,7 @@ namespace AGS3 {
 
 struct ccScript;
 struct SpriteInfo;
-typedef Std::shared_ptr<ccScript> PScript;
+typedef std::shared_ptr<ccScript> PScript;
 
 // TODO: move the following enums under AGS::Shared namespace
 // later, when more engine source is put in AGS namespace and
@@ -120,7 +120,7 @@ namespace Shared {
 class Bitmap;
 class Stream;
 
-typedef Std::shared_ptr<Bitmap> PBitmap;
+typedef std::shared_ptr<Bitmap> PBitmap;
 
 // Various room options
 struct RoomOptions {
@@ -350,7 +350,7 @@ public:
 	// Room entities
 	size_t                  HotspotCount;
 	RoomHotspot             Hotspots[MAX_ROOM_HOTSPOTS];
-	Std::vector<RoomObjectInfo> Objects;
+	std::vector<RoomObjectInfo> Objects;
 	size_t                  RegionCount;
 	RoomRegion              Regions[MAX_ROOM_REGIONS];
 	size_t                  WalkAreaCount;
@@ -382,7 +382,7 @@ private:
 
 
 // Loads new room data into the given RoomStruct object
-void load_room(const String &filename, RoomStruct *room, bool game_is_hires, const Std::vector<SpriteInfo> &sprinfos);
+void load_room(const String &filename, RoomStruct *room, bool game_is_hires, const std::vector<SpriteInfo> &sprinfos);
 // Checks if it's necessary and upscales low-res room backgrounds and masks for the high resolution game
 // NOTE: it does not upscale object coordinates, because that is usually done when the room is loaded
 void UpscaleRoomBackground(RoomStruct *room, bool game_is_hires);

--- a/engines/ags/shared/game/tra_file.cpp
+++ b/engines/ags/shared/game/tra_file.cpp
@@ -84,7 +84,7 @@ HError ReadTraBlock(Translation &tra, Stream *in, TraFileBlock block, const Stri
 			read_string_decrypt(in, translation, sizeof(translation));
 			if (!original[0] && !translation[0])
 				break;
-			tra.Dict.insert(Std::make_pair(String(original), String(translation)));
+			tra.Dict.insert(std::make_pair(String(original), String(translation)));
 		}
 		return HError::None();
 	}
@@ -184,7 +184,7 @@ HError ReadTraData(Translation &tra, Stream *in) {
 }
 
 // TODO: perhaps merge with encrypt/decrypt utilities
-static const char *EncryptText(Std::vector<char> &en_buf, const String &s) {
+static const char *EncryptText(std::vector<char> &en_buf, const String &s) {
 	if (en_buf.size() < s.GetLength() + 1)
 		en_buf.resize(s.GetLength() + 1);
 	strncpy(&en_buf.front(), s.GetCStr(), s.GetLength() + 1);
@@ -193,20 +193,20 @@ static const char *EncryptText(Std::vector<char> &en_buf, const String &s) {
 }
 
 // TODO: perhaps merge with encrypt/decrypt utilities
-static const char *EncryptEmptyString(Std::vector<char> &en_buf) {
+static const char *EncryptEmptyString(std::vector<char> &en_buf) {
 	en_buf[0] = 0;
 	encrypt_text(&en_buf.front());
 	return &en_buf.front();
 }
 
 void WriteGameID(const Translation &tra, Stream *out) {
-	Std::vector<char> en_buf;
+	std::vector<char> en_buf;
 	out->WriteInt32(tra.GameUid);
 	StrUtil::WriteString(EncryptText(en_buf, tra.GameName), tra.GameName.GetLength() + 1, out);
 }
 
 void WriteDict(const Translation &tra, Stream *out) {
-	Std::vector<char> en_buf;
+	std::vector<char> en_buf;
 	for (const auto &kv : tra.Dict) {
 		const String &src = kv._key;
 		const String &dst = kv._value;

--- a/engines/ags/shared/gui/gui_listbox.h
+++ b/engines/ags/shared/gui/gui_listbox.h
@@ -75,8 +75,8 @@ public:
 	int32_t               RowHeight;
 	int32_t               VisibleItemCount;
 
-	Std::vector<String>   Items;
-	Std::vector<int16_t>  SavedGameIndex;
+	std::vector<String>   Items;
+	std::vector<int16_t>  SavedGameIndex;
 	int32_t               SelectedItem;
 	int32_t               TopItem;
 	Point                 MousePos;

--- a/engines/ags/shared/gui/gui_main.cpp
+++ b/engines/ags/shared/gui/gui_main.cpp
@@ -145,7 +145,7 @@ int32_t GUIMain::GetControlID(int32_t index) const {
 	return _ctrlRefs[index].second;
 }
 
-const Std::vector<int> &GUIMain::GetControlsDrawOrder() const {
+const std::vector<int> &GUIMain::GetControlsDrawOrder() const {
 	return _ctrlDrawOrder;
 }
 
@@ -403,8 +403,8 @@ bool GUIControlZOrder(const GUIObject *e1, const GUIObject *e2) {
 }
 
 void GUIMain::ResortZOrder() {
-	Std::vector<GUIObject *> ctrl_sort = _controls;
-	Std::sort(ctrl_sort.begin(), ctrl_sort.end(), GUIControlZOrder);
+	std::vector<GUIObject *> ctrl_sort = _controls;
+	std::sort(ctrl_sort.begin(), ctrl_sort.end(), GUIControlZOrder);
 
 	_ctrlDrawOrder.resize(ctrl_sort.size());
 	for (size_t i = 0; i < ctrl_sort.size(); ++i)
@@ -661,8 +661,8 @@ Line CalcFontGraphicalVExtent(int font) {
 	// * custom vertical offset set by user (if non-zero),
 	// * font's real graphical height
 	int font_yoffset = get_fontinfo(font).YOffset;
-	int yoff = Std::min(0, font_yoffset);       // only if yoff is negative
-	int height_off = Std::max(0, font_yoffset); // only if yoff is positive
+	int yoff = std::min(0, font_yoffset);       // only if yoff is negative
+	int height_off = std::max(0, font_yoffset); // only if yoff is positive
 	return Line(0, yoff, 0, get_font_surface_height(font) + height_off);
 }
 

--- a/engines/ags/shared/gui/gui_main.h
+++ b/engines/ags/shared/gui/gui_main.h
@@ -124,7 +124,7 @@ public:
 	// Gets child control's global ID, looks up with child's index
 	int32_t GetControlID(int32_t index) const;
 	// Gets an array of child control indexes in the z-order, from bottom to top
-	const Std::vector<int> &GetControlsDrawOrder() const;
+	const std::vector<int> &GetControlsDrawOrder() const;
 
 	// Child control management
 	// Note that currently GUIMain does not own controls (should not delete them)
@@ -205,12 +205,12 @@ private:
 
 	// Array of types and control indexes in global GUI object arrays;
 	// maps GUI child slots to actual controls and used for rebuilding Controls array
-	typedef Std::pair<GUIControlType, int32_t> ControlRef;
-	Std::vector<ControlRef> _ctrlRefs;
+	typedef std::pair<GUIControlType, int32_t> ControlRef;
+	std::vector<ControlRef> _ctrlRefs;
 	// Array of child control references (not exclusively owned!)
-	Std::vector<GUIObject *> _controls;
+	std::vector<GUIObject *> _controls;
 	// Sorted array of controls in z-order.
-	Std::vector<int>         _ctrlDrawOrder;
+	std::vector<int>         _ctrlDrawOrder;
 };
 
 

--- a/engines/ags/shared/script/cc_script.h
+++ b/engines/ags/shared/script/cc_script.h
@@ -78,7 +78,7 @@ protected:
 	void        Free();
 };
 
-typedef Std::shared_ptr<ccScript> PScript;
+typedef std::shared_ptr<ccScript> PScript;
 
 } // namespace AGS3
 

--- a/engines/ags/shared/util/buffered_stream.cpp
+++ b/engines/ags/shared/util/buffered_stream.cpp
@@ -59,7 +59,7 @@ BufferedStream::~BufferedStream() {
 void BufferedStream::FillBufferFromPosition(soff_t position) {
 	FileStream::Seek(position, kSeekBegin);
 	// remember to restrict to the end position!
-	size_t fill_size = Std::min(BufferSize, static_cast<size_t>(_end - position));
+	size_t fill_size = std::min(BufferSize, static_cast<size_t>(_end - position));
 	_buffer.resize(fill_size);
 	auto sz = FileStream::Read(_buffer.data(), fill_size);
 	_buffer.resize(sz);
@@ -106,7 +106,7 @@ size_t BufferedStream::Read(void *buffer, size_t size) {
 	if (size >= BufferSize) {
 		FileStream::Seek(_position, kSeekBegin);
 		// remember to restrict to the end position!
-		size_t fill_size = Std::min(size, static_cast<size_t>(_end - _position));
+		size_t fill_size = std::min(size, static_cast<size_t>(_end - _position));
 		size_t sz = FileStream::Read(buffer, fill_size);
 		_position += sz;
 		return sz;
@@ -154,7 +154,7 @@ size_t BufferedStream::Write(const void *buffer, size_t size) {
 			FlushBuffer(_position);
 		}
 		size_t pos_in_buff = static_cast<size_t>(_position - _bufferPosition);
-		size_t chunk_sz = Std::min(size, BufferSize - pos_in_buff);
+		size_t chunk_sz = std::min(size, BufferSize - pos_in_buff);
 		if (_buffer.size() < pos_in_buff + chunk_sz)
 			_buffer.resize(pos_in_buff + chunk_sz);
 		memcpy(_buffer.data() + pos_in_buff, from, chunk_sz);
@@ -163,7 +163,7 @@ size_t BufferedStream::Write(const void *buffer, size_t size) {
 		size -= chunk_sz;
 	}
 
-	_end = Std::max(_end, _position);
+	_end = std::max(_end, _position);
 	return from - static_cast<const uint8_t*>(buffer);
 
 }

--- a/engines/ags/shared/util/buffered_stream.h
+++ b/engines/ags/shared/util/buffered_stream.h
@@ -42,7 +42,7 @@ public:
 	// Needs tuning depending on the platform.
 	static const size_t BufferSize = 1024u * 8;
 
-	// The constructor may raise Std::runtime_error if
+	// The constructor may raise std::runtime_error if
 	// - there is an issue opening the file (does not exist, locked, permissions, etc)
 	// - the open mode could not be determined
 	// - could not determine the length of the stream
@@ -79,7 +79,7 @@ private:
 
 	soff_t _position = 0; // absolute read/write offset
 	soff_t _bufferPosition = 0; // buffer's location relative to file
-	Std::vector<uint8_t> _buffer;
+	std::vector<uint8_t> _buffer;
 };
 
 

--- a/engines/ags/shared/util/compress.cpp
+++ b/engines/ags/shared/util/compress.cpp
@@ -320,7 +320,7 @@ void skip_rle_bitmap8(Stream *in) {
 	int w = in->ReadInt16();
 	int h = in->ReadInt16();
 	// Unpack the pixels into temp buf
-	Std::vector<uint8_t> buf;
+	std::vector<uint8_t> buf;
 	buf.resize(w * h);
 	cunpackbitl(&buf[0], w * h, in);
 	// Skip RGB palette
@@ -347,7 +347,7 @@ void lzw_decompress(uint8_t *data, size_t data_sz, int /*image_bpp*/, Shared::St
 		in->Read(data, data_sz);
 		return;
 	}
-	Std::vector<uint8_t> in_buf(in_sz);
+	std::vector<uint8_t> in_buf(in_sz);
 	in->Read(in_buf.data(), in_sz);
 	lzwexpand(in_buf.data(), in_sz, data, data_sz);
 }
@@ -356,7 +356,7 @@ void save_lzw(Stream *out, const Bitmap *bmpp, const RGB(*pal)[256]) {
 	// First write original bitmap's info and data into the memory buffer
 	// NOTE: we must do this purely for backward compatibility with old room formats:
 	// because they also included bmp width and height into compressed data!
-	Std::vector<uint8_t> membuf;
+	std::vector<uint8_t> membuf;
 	{
 		VectorStream memws(membuf, kStream_Write);
 		int w = bmpp->GetWidth(), h = bmpp->GetHeight(), bpp = bmpp->GetBPP();
@@ -402,8 +402,8 @@ Bitmap *load_lzw(Stream *in, int dst_bpp, RGB(*pal)[256]) {
 	const soff_t end_pos = in->GetPosition() + comp_sz;
 
 	// First decompress data into the memory buffer
-	Std::vector<uint8_t> inbuf(comp_sz);
-	Std::vector<uint8_t> membuf(uncomp_sz);
+	std::vector<uint8_t> inbuf(comp_sz);
+	std::vector<uint8_t> membuf(uncomp_sz);
 	in->Read(inbuf.data(), comp_sz);
 	lzwexpand(inbuf.data(), comp_sz, membuf.data(), uncomp_sz);
 

--- a/engines/ags/shared/util/directory.cpp
+++ b/engines/ags/shared/util/directory.cpp
@@ -91,7 +91,7 @@ String GetCurrentDirectory() {
 #endif
 }
 
-static bool GetFilesImpl(const String &dir_path, Std::vector<String> &files, bool isDirectories) {
+static bool GetFilesImpl(const String &dir_path, std::vector<String> &files, bool isDirectories) {
 	Common::FSNode fsNode(dir_path.GetCStr());
 	Common::FSList fsList;
 
@@ -104,11 +104,11 @@ static bool GetFilesImpl(const String &dir_path, Std::vector<String> &files, boo
 	return true;
 }
 
-bool GetDirs(const String &dir_path, Std::vector<String> &dirs) {
+bool GetDirs(const String &dir_path, std::vector<String> &dirs) {
 	return GetFilesImpl(dir_path, dirs, true);
 }
 
-bool GetFiles(const String &dir_path, Std::vector<String> &files) {
+bool GetFiles(const String &dir_path, std::vector<String> &files) {
 	return GetFilesImpl(dir_path, files, false);
 }
 
@@ -153,8 +153,8 @@ FindFileRecursive FindFileRecursive::Open(const String &path, const String &wild
 	if (ffile.AtEnd() && fdir.AtEnd())
 		return {}; // return invalid object
 	FindFileRecursive ff;
-	ff._fdir = Std::move(fdir);
-	ff._ffile = Std::move(ffile);
+	ff._fdir = std::move(fdir);
+	ff._ffile = std::move(ffile);
 	// Try get the first matching entry
 	if (ff._ffile.AtEnd() && !ff.Next())
 		return {}; // return invalid object
@@ -202,9 +202,9 @@ bool FindFileRecursive::PushDir(const String &sub) {
 	FindFile ffile = FindFile::OpenFiles(path);
 	if (ffile.AtEnd() && fdir.AtEnd())
 		return false; // dir is empty, or error
-	_fdirs.push(Std::move(_fdir)); // save previous dir iterator
-	_fdir = Std::move(fdir);
-	_ffile = Std::move(ffile);
+	_fdirs.push(std::move(_fdir)); // save previous dir iterator
+	_fdir = std::move(fdir);
+	_ffile = std::move(ffile);
 	_fullDir = path;
 	_curDir = Path::ConcatPaths(_curDir, sub);
 	return true;
@@ -214,7 +214,7 @@ bool FindFileRecursive::PopDir() {
 	if (_fdirs.empty())
 		return false; // no more parent levels
 	// restore parent level
-	_fdir = Std::move(_fdirs.top());
+	_fdir = std::move(_fdirs.top());
 	_fdirs.pop();
 	_fullDir = Path::GetParent(_fullDir);
 	_curDir = Path::GetParent(_curDir);

--- a/engines/ags/shared/util/directory.h
+++ b/engines/ags/shared/util/directory.h
@@ -53,9 +53,9 @@ String SetCurrentDirectory(const String &path);
 String GetCurrentDirectory();
 
 // Get list of subdirs found in the given directory
-bool   GetDirs(const String &dir_path, Std::vector<String> &dirs);
+bool   GetDirs(const String &dir_path, std::vector<String> &dirs);
 // Get list of files found in the given directory
-bool   GetFiles(const String &dir_path, Std::vector<String> &files);
+bool   GetFiles(const String &dir_path, std::vector<String> &files);
 
 } // namespace Directory
 

--- a/engines/ags/shared/util/error.h
+++ b/engines/ags/shared/util/error.h
@@ -37,11 +37,11 @@ namespace AGS {
 namespace Shared {
 
 class Error;
-typedef Std::shared_ptr<Error> PError;
+typedef std::shared_ptr<Error> PError;
 
 //
 // A simple struct, that provides several fields to describe an error in the program.
-// If wanted, may be reworked into subclass of Std::exception.
+// If wanted, may be reworked into subclass of std::exception.
 //
 class Error {
 public:
@@ -72,7 +72,7 @@ public:
 		return _innerError;
 	}
 	// Full error message combines general description and comment.
-	// NOTE: if made a child of Std::exception, FullMessage may be substituted
+	// NOTE: if made a child of std::exception, FullMessage may be substituted
 	// or complemented with virtual const char* what().
 	String FullMessage() const {
 		String msg;
@@ -116,7 +116,7 @@ public:
 	ErrorHandle() {}
 	ErrorHandle(T *err) : _error(err) {
 	}
-	ErrorHandle(Std::shared_ptr<T> err) : _error(err) {
+	ErrorHandle(std::shared_ptr<T> err) : _error(err) {
 	}
 
 	bool HasError() const {
@@ -136,7 +136,7 @@ public:
 	}
 
 private:
-	Std::shared_ptr<T> _error;
+	std::shared_ptr<T> _error;
 };
 
 

--- a/engines/ags/shared/util/file.cpp
+++ b/engines/ags/shared/util/file.cpp
@@ -152,7 +152,7 @@ Stream *File::OpenFile(const String &filename, FileOpenMode open_mode, FileWorkM
 		delete fs;
 		fs = nullptr;
 	}
-	//  } catch (Std::runtime_error) {
+	//  } catch (std::runtime_error) {
 	//      fs = nullptr;
 	//  }
 

--- a/engines/ags/shared/util/file_stream.h
+++ b/engines/ags/shared/util/file_stream.h
@@ -40,7 +40,7 @@ public:
 	};
 
 	// Represents an open file object
-	// The constructor may raise Std::runtime_error if
+	// The constructor may raise std::runtime_error if
 	// - there is an issue opening the file (does not exist, locked, permissions, etc)
 	// - the open mode could not be determined
 	FileStream(const String &file_name, FileOpenMode open_mode, FileWorkMode work_mode,

--- a/engines/ags/shared/util/geometry.cpp
+++ b/engines/ags/shared/util/geometry.cpp
@@ -45,7 +45,7 @@ float DistanceBetween(const Rect &r1, const Rect &r2) {
 	);
 	int inner_width = MAX(0, rect_outer.GetWidth() - r1.GetWidth() - r2.GetWidth());
 	int inner_height = MAX(0, rect_outer.GetHeight() - r1.GetHeight() - r2.GetHeight());
-	return static_cast<float>(Std::sqrt((inner_width ^ 2) + (inner_height ^ 2)));
+	return static_cast<float>(std::sqrt((inner_width ^ 2) + (inner_height ^ 2)));
 }
 
 Size ProportionalStretch(int dest_w, int dest_h, int item_w, int item_h) {

--- a/engines/ags/shared/util/ini_file.h
+++ b/engines/ags/shared/util/ini_file.h
@@ -44,10 +44,10 @@ class IniFile {
 public:
 	// Position of a string in the line of text:
 	// is defined by a pair of first and next-after-last character indices
-	typedef Std::pair<size_t, size_t> StrPos;
+	typedef std::pair<size_t, size_t> StrPos;
 	// Location of section in the array of text lines:
 	// is defined by a pair of first and next-after-last line indices
-	typedef Std::pair<size_t, size_t> SectionPos;
+	typedef std::pair<size_t, size_t> SectionPos;
 
 	inline static bool IsValidStrPos(const StrPos &pos) {
 		return pos.first < pos.second;
@@ -83,7 +83,7 @@ public:
 		StrPos  Value; // position of item value
 	};
 	// Linked list of items
-	typedef Std::list<ItemDef> LItems;
+	typedef std::list<ItemDef> LItems;
 	typedef LItems::iterator          ItemIterator;
 	typedef LItems::const_iterator    ConstItemIterator;
 
@@ -129,7 +129,7 @@ public:
 	};
 
 	// Linked list of sections
-	typedef Std::list<SectionDef>     LSections;
+	typedef std::list<SectionDef>     LSections;
 	typedef LSections::iterator       SectionIterator;
 	typedef LSections::const_iterator ConstSectionIterator;
 

--- a/engines/ags/shared/util/ini_util.cpp
+++ b/engines/ags/shared/util/ini_util.cpp
@@ -125,7 +125,7 @@ void CfgWriteString(ConfigTree &cfg, const String &sectn, const String &item, co
 // IniUtil
 //-----------------------------------------------------------------------------
 
-typedef Std::unique_ptr<Stream>       UStream;
+typedef std::unique_ptr<Stream>       UStream;
 typedef StringOrderMap::const_iterator StrStrOIter;
 typedef ConfigTree::const_iterator    ConfigNode;
 typedef IniFile::SectionIterator      SectionIterator;
@@ -212,7 +212,7 @@ bool IniUtil::Merge(const String &file, const ConfigTree &tree) {
 
 	// Remember the sections we find in file, if some sections are not found,
 	// they will be appended to the end of file.
-	Std::map<String, bool> sections_found;
+	std::map<String, bool> sections_found;
 	for (ConfigNode it = tree.begin(); it != tree.end(); ++it)
 		sections_found[it->_key] = false;
 
@@ -228,7 +228,7 @@ bool IniUtil::Merge(const String &file, const ConfigTree &tree) {
 		// Remember the items we find in this section, if some items are not found,
 		// they will be appended to the end of section.
 		const StringOrderMap &subtree = tree_node->_value;
-		Std::map<String, bool> items_found;
+		std::map<String, bool> items_found;
 		for (StrStrOIter keyval = subtree.begin(); keyval != subtree.end(); ++keyval)
 			items_found[keyval->_key] = false;
 
@@ -248,7 +248,7 @@ bool IniUtil::Merge(const String &file, const ConfigTree &tree) {
 
 		// Append new items
 		if (!sections_found[secname]) {
-			for (Std::map<String, bool>::const_iterator item_f = items_found.begin(); item_f != items_found.end(); ++item_f) {
+			for (std::map<String, bool>::const_iterator item_f = items_found.begin(); item_f != items_found.end(); ++item_f) {
 				if (item_f->_value)
 					continue; // item was already found
 				StrStrOIter keyval = subtree.find(item_f->_key);
@@ -259,7 +259,7 @@ bool IniUtil::Merge(const String &file, const ConfigTree &tree) {
 	}
 
 	// Add new sections
-	for (Std::map<String, bool>::const_iterator sec_f = sections_found.begin(); sec_f != sections_found.end(); ++sec_f) {
+	for (std::map<String, bool>::const_iterator sec_f = sections_found.begin(); sec_f != sections_found.end(); ++sec_f) {
 		if (sec_f->_value)
 			continue;
 		SectionIterator sec = ini.InsertSection(ini.End(), sec_f->_key);

--- a/engines/ags/shared/util/ini_util.h
+++ b/engines/ags/shared/util/ini_util.h
@@ -36,8 +36,8 @@ namespace AGS3 {
 namespace AGS {
 namespace Shared {
 
-typedef Std::map<String, String>         StringOrderMap;
-typedef Std::map<String, StringOrderMap> ConfigTree;
+typedef std::map<String, String>         StringOrderMap;
+typedef std::map<String, StringOrderMap> ConfigTree;
 
 //
 // Helper functions for parsing values in a ConfigTree

--- a/engines/ags/shared/util/math.h
+++ b/engines/ags/shared/util/math.h
@@ -30,6 +30,8 @@
 
 #include "common/std/limits.h"
 
+#include "ags/lib/std.h"
+
 namespace AGS3 {
 
 #ifndef M_PI

--- a/engines/ags/shared/util/math.h
+++ b/engines/ags/shared/util/math.h
@@ -82,7 +82,7 @@ inline T Surplus(const T &larger, const T &smaller) {
 // returns same value converted if it's in range, or provided replacement if it's not.
 template <typename T, typename TBig>
 inline T InRangeOrDef(const TBig &val, const T &def) {
-	return (val >= Std::numeric_limits<T>::min() && val <= Std::numeric_limits<T>::max()) ?
+	return (val >= std::numeric_limits<T>::min() && val <= std::numeric_limits<T>::max()) ?
 		static_cast<T>(val) : def;
 }
 

--- a/engines/ags/shared/util/memory_compat.h
+++ b/engines/ags/shared/util/memory_compat.h
@@ -30,8 +30,8 @@ namespace AGS3 {
 #if __cplusplus < 201402L && !((defined(_MSC_VER) && _MSC_VER >= 1900))
 namespace std {
 template<typename T, typename... Args>
-Std::unique_ptr<T> make_unique(Args &&... args) {
-return Std::unique_ptr<T>(new T(Std::forward<Args>(args)...));
+std::unique_ptr<T> make_unique(Args &&... args) {
+return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 } // std
 #endif

--- a/engines/ags/shared/util/memory_stream.cpp
+++ b/engines/ags/shared/util/memory_stream.cpp
@@ -124,7 +124,7 @@ bool MemoryStream::Seek(soff_t offset, StreamSeek origin) {
 		return false;
 	}
 	_pos = static_cast<size_t>(MAX<soff_t>(0, pos));
-	_pos = Std::min(_len, _pos); // clamp to EOS
+	_pos = std::min(_len, _pos); // clamp to EOS
 	return true;
 }
 
@@ -152,12 +152,12 @@ int32_t MemoryStream::WriteByte(uint8_t val) {
 }
 
 
-VectorStream::VectorStream(const Std::vector<uint8_t> &cbuf, DataEndianess stream_endianess)
+VectorStream::VectorStream(const std::vector<uint8_t> &cbuf, DataEndianess stream_endianess)
 	: MemoryStream(&cbuf.front(), cbuf.size(), stream_endianess)
 	, _vec(nullptr) {
 }
 
-VectorStream::VectorStream(Std::vector<uint8_t> &buf, StreamWorkMode mode, DataEndianess stream_endianess)
+VectorStream::VectorStream(std::vector<uint8_t> &buf, StreamWorkMode mode, DataEndianess stream_endianess)
 	: MemoryStream(((mode == kStream_Read) && (buf.size() > 0)) ? &buf.front() : nullptr, buf.size(), mode, stream_endianess)
 	, _vec(&buf) {
 }

--- a/engines/ags/shared/util/memory_stream.h
+++ b/engines/ags/shared/util/memory_stream.h
@@ -26,7 +26,7 @@
  // itself, but works with the provided C-buffer pointer, which means that the
  // buffer object *must* persist until stream is closed.
  //
- // VectorStream is a specialized implementation that works with Std::vector.
+ // VectorStream is a specialized implementation that works with std::vector.
  // Unlike base MemoryStream provides continiously resizing buffer for writing.
  // TODO: separate StringStream for reading & writing String object?
  //
@@ -91,12 +91,12 @@ private:
 
 class VectorStream : public MemoryStream {
 public:
-	// Construct memory stream in the read-only mode over a const Std::vector;
+	// Construct memory stream in the read-only mode over a const std::vector;
 	// vector must persist in memory until the stream is closed.
-	VectorStream(const Std::vector<uint8_t> &cbuf, DataEndianess stream_endianess = kLittleEndian);
-	// Construct memory stream in the chosen mode over a given Std::vector;
+	VectorStream(const std::vector<uint8_t> &cbuf, DataEndianess stream_endianess = kLittleEndian);
+	// Construct memory stream in the chosen mode over a given std::vector;
 	// vector must persist in memory until the stream is closed.
-	VectorStream(Std::vector<uint8_t> &buf, StreamWorkMode mode, DataEndianess stream_endianess = kLittleEndian);
+	VectorStream(std::vector<uint8_t> &buf, StreamWorkMode mode, DataEndianess stream_endianess = kLittleEndian);
 	~VectorStream() override {}
 
 	void    Close() override;
@@ -108,7 +108,7 @@ public:
 	int32_t WriteByte(uint8_t b) override;
 
 private:
-	Std::vector<uint8_t> *_vec = nullptr; // writeable vector (may be null)
+	std::vector<uint8_t> *_vec = nullptr; // writeable vector (may be null)
 };
 
 } // namespace Shared

--- a/engines/ags/shared/util/path.cpp
+++ b/engines/ags/shared/util/path.cpp
@@ -226,7 +226,7 @@ String MakePath(const String &parent, const String &filename, const String &ext)
 	return path;
 }
 
-Std::vector<String> Split(const String &path) {
+std::vector<String> Split(const String &path) {
 	return path.Split('/');
 }
 

--- a/engines/ags/shared/util/path.h
+++ b/engines/ags/shared/util/path.h
@@ -88,7 +88,7 @@ String  ConcatPaths(String &buf, const String &parent, const String &child);
 // Creates path by combining directory, file name and extension
 String  MakePath(const String &parent, const String &filename, const String &ext);
 // Splits path into components, divided by path separator
-Std::vector<String> Split(const String &path);
+std::vector<String> Split(const String &path);
 
 // Subsitutes illegal characters with '_'. This function uses a combined set
 // of illegal chars from all the supported platforms to make a name that

--- a/engines/ags/shared/util/proxy_stream.h
+++ b/engines/ags/shared/util/proxy_stream.h
@@ -28,7 +28,7 @@ namespace AGS3 {
 namespace AGS {
 namespace Shared {
 
-// TODO: replace with Std::shared_ptr!!!
+// TODO: replace with std::shared_ptr!!!
 enum ObjectOwnershipPolicy {
 	kReleaseAfterUse,
 	kDisposeAfterUse

--- a/engines/ags/shared/util/string.cpp
+++ b/engines/ags/shared/util/string.cpp
@@ -378,8 +378,8 @@ String String::Section(char separator, size_t first, size_t last,
 	return String();
 }
 
-Std::vector<String> String::Split(char separator) const {
-	Std::vector<String> result;
+std::vector<String> String::Split(char separator) const {
+	std::vector<String> result;
 	if (!separator)
 		return result;
 

--- a/engines/ags/shared/util/string.h
+++ b/engines/ags/shared/util/string.h
@@ -265,7 +265,7 @@ public:
 	// Splits the string into segments divided by the instances of a given character,
 	// including empty segments e.g. if separators follow each other;
 	// returns at least one segment (equal to full string if no separator was found)
-	Std::vector<String> Split(char separator) const;
+	std::vector<String> Split(char separator) const;
 
 	//-------------------------------------------------------------------------
 	// String modification methods

--- a/engines/ags/shared/util/string_types.h
+++ b/engines/ags/shared/util/string_types.h
@@ -105,9 +105,9 @@ namespace AGS3 {
 namespace AGS {
 namespace Shared {
 
-typedef Std::vector<String> StringV;
-typedef Std::unordered_map<String, String> StringMap;
-typedef Std::unordered_map<String, String, IgnoreCase_Hash, IgnoreCase_EqualTo> StringIMap;
+typedef std::vector<String> StringV;
+typedef std::unordered_map<String, String> StringMap;
+typedef std::unordered_map<String, String, IgnoreCase_Hash, IgnoreCase_EqualTo> StringIMap;
 
 } // namespace Shared
 } // namespace AGS

--- a/engines/ags/shared/util/string_utils.cpp
+++ b/engines/ags/shared/util/string_utils.cpp
@@ -108,8 +108,8 @@ String StrUtil::Unescape(const String &s) {
 String StrUtil::WildcardToRegex(const String &wildcard) {
 	// https://stackoverflow.com/questions/40195412/c11-regex-search-for-exact-string-escape
 	// matches any characters that need to be escaped in RegEx
-	Std::regex esc{ R"([-[\]{}()*+?.,\^$|#\s])" };
-	Common::String sanitized = Std::regex_replace(wildcard.GetCStr(), esc, R"(\$&)");
+	std::regex esc{ R"([-[\]{}()*+?.,\^$|#\s])" };
+	Common::String sanitized = std::regex_replace(wildcard.GetCStr(), esc, R"(\$&)");
 	// convert (now escaped) wildcard "\\*" and "\\?" into ".*" and "." respectively
 	String pattern(sanitized.c_str());
 	pattern.Replace("\\*", ".*");
@@ -238,7 +238,7 @@ void StrUtil::ReadStringMap(StringMap &map, Stream *in) {
 	for (size_t i = 0; i < count; ++i) {
 		String key = StrUtil::ReadString(in);
 		String value = StrUtil::ReadString(in);
-		map.insert(Std::make_pair(key, value));
+		map.insert(std::make_pair(key, value));
 	}
 }
 
@@ -257,7 +257,7 @@ size_t StrUtil::ConvertUtf8ToAscii(const char *mbstr, const char *loc_name, char
 		return static_cast<size_t>(snprintf(out_cstr, out_sz, "%s", mbstr));
 	}
 	// First convert utf-8 string into widestring;
-	Std::vector<wchar_t> wcsbuf; // widechar buffer
+	std::vector<wchar_t> wcsbuf; // widechar buffer
 	wcsbuf.resize(Utf8::GetLength(mbstr) + 1);
 	// NOTE: we don't use mbstowcs, because unfortunately ".utf-8" locale
 	// is not normally supported on all systems (e.g. Windows 7 and earlier)

--- a/engines/ags/tests/test_gfx.cpp
+++ b/engines/ags/tests/test_gfx.cpp
@@ -66,10 +66,10 @@ void Test_GfxSpeed(bool enableSimd, size_t blenderModeStart, size_t blenderModeE
 					uint32 start, end;
 					_G(_blender_mode) = (AGS3::BlenderMode)blenderModes[mode];
 					//if (runs == 2) debug("Dest: %d bpp, Gfx: %d bpp, Blender: %s, Stretched: false, Iters: %d\n", bpps[dest], bpps[gfx], modeNames[mode], benchRuns[runs]);
-					start = Std::chrono::high_resolution_clock::now();
+					start = std::chrono::high_resolution_clock::now();
 					for (int i = 0; i < benchRuns[runs]; i++)
 						destinations[dest]->Blit(graphics[gfx], 0, 0, kBitmap_Transparency);
-					end = Std::chrono::high_resolution_clock::now();
+					end = std::chrono::high_resolution_clock::now();
 					timeNotStretched += end - start;
 					numItersNotStretched += benchRuns[runs];
 					if (mode == kArgbToArgbBlender || mode == kRgbToRgbBlender || mode == kRgbToArgbBlender || mode == kArgbToRgbBlender) {
@@ -79,10 +79,10 @@ void Test_GfxSpeed(bool enableSimd, size_t blenderModeStart, size_t blenderModeE
 					time += end - start;
 					//if (runs == 2) debug("exec time (mills): %u\n\n", end - start);
 					//if (runs == 2) debug("Dest: %d bpp, Gfx: %d bpp, Blender: %s, Stretched: true, Iters: %d\n", bpps[dest], bpps[gfx], modeNames[mode], benchRuns[runs]);
-					start = Std::chrono::high_resolution_clock::now();
+					start = std::chrono::high_resolution_clock::now();
 					for (int i = 0; i < benchRuns[runs]; i++)
 						destinations[dest]->StretchBlt(graphics[gfx], Rect(0, 0, 99, 99), kBitmap_Transparency);
-					end = Std::chrono::high_resolution_clock::now();
+					end = std::chrono::high_resolution_clock::now();
 					time += end - start;
 					numIters += benchRuns[runs] * 2;
 					//if (runs == 2) debug("exec time (mills): %u\n\n", end - start);
@@ -208,31 +208,31 @@ void Test_BlenderModes() {
 											default:
 												tolerance = 0;
 											}
-											if (Std::abs((int)a - (int)(simdCol >> 24)) > tolerance) {
+											if (std::abs((int)a - (int)(simdCol >> 24)) > tolerance) {
 												printInfo();
 												assert(false && "a is over the tolerance");
 											}
-											if (Std::abs((int)r - (int)((simdCol >> 16) & 0xff)) > tolerance) {
+											if (std::abs((int)r - (int)((simdCol >> 16) & 0xff)) > tolerance) {
 												printInfo();
 												assert(false && "r is over the tolerance");
 											}
-											if (Std::abs((int)g - (int)((simdCol >> 8) & 0xff)) > tolerance) {
+											if (std::abs((int)g - (int)((simdCol >> 8) & 0xff)) > tolerance) {
 												printInfo();
 												assert(false && "g is over the tolerance");
 											}
-											if (Std::abs((int)b - (int)(simdCol & 0xff)) > tolerance) {
+											if (std::abs((int)b - (int)(simdCol & 0xff)) > tolerance) {
 												printInfo();
 												assert(false && "b is over the tolerance");
 											}
-											if (Std::abs((int)b16 - (int)(simd2bppCol & 0x1f)) > tolerance16) {
+											if (std::abs((int)b16 - (int)(simd2bppCol & 0x1f)) > tolerance16) {
 												printInfo();
 												assert(false && "b16 is over the tolerance");
 											}
-											if (Std::abs((int)g16 - (int)((simd2bppCol >> 5) & 0x3f)) > tolerance16) {
+											if (std::abs((int)g16 - (int)((simd2bppCol >> 5) & 0x3f)) > tolerance16) {
 												printInfo();
 												assert(false && "g16 is over the tolerance");
 											}
-											if (Std::abs((int)r16 - (int)(simd2bppCol >> 11)) > tolerance16) {
+											if (std::abs((int)r16 - (int)(simd2bppCol >> 11)) > tolerance16) {
 												printInfo();
 												assert(false && "r16 is over the tolerance");
 											}

--- a/engines/ags/tests/test_string.cpp
+++ b/engines/ags/tests/test_string.cpp
@@ -468,7 +468,7 @@ void Test_String() {
 	// Test Split
 	{
 		String str1 = "C:\\Games\\AGS\\MyNewGame\\";
-		Std::vector<String> result = str1.Split('\\');
+		std::vector<String> result = str1.Split('\\');
 		assert(result.size() == 5);
 		assert(strcmp(result[0], "C:") == 0);
 		assert(strcmp(result[1], "Games") == 0);


### PR DESCRIPTION
A new header is created to setup the namespace aliasing and it's included at key places to minimize changes from upstream.
Then changes of c2a476411c539c591752c03c57a7899f79f492a5 are reverted partially.

This PR will make sure everything builds fine.