### PR TITLE
CREATE_PROJECT: Disable ImGui when creating Xcode project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
             brewPackages: a52dec faad2 flac fluid-synth freetype fribidi giflib jpeg mad libmikmod libmpeg2 libogg libpng libvorbis libvpx sdl2 sdl2_net theora
           - platform: ios7
             buildFlags: -scheme ScummVM-iOS CODE_SIGN_IDENTITY="" CODE_SIGNING_ALLOWED=NO
-            configFlags: --use-xcframework --enable-faad --enable-gif --enable-mikmod --enable-mpeg2 --enable-vpx --disable-nasm --disable-taskbar --disable-tts --disable-imgui
+            configFlags: --use-xcframework --enable-faad --enable-gif --enable-mikmod --enable-mpeg2 --enable-vpx --disable-nasm --disable-taskbar --disable-tts
             packagesUrl: https://downloads.scummvm.org/frs/build/scummvm-ios7-libs-v3.zip
     env:
       BUILDCACHE_MAX_CACHE_SIZE: 2000000000

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -362,6 +362,12 @@ int main(int argc, char *argv[]) {
 		std::cerr << "WARNING: imgui requires opengl, freetype2 and sdl2\n";
 		setFeatureBuildState("imgui", setup.features, false);
 	}
+	// HACK: IMGUI is not available on Xcode
+#ifdef ENABLE_XCODE
+	if (projectType == kProjectXcode) {
+		setFeatureBuildState("imgui", setup.features, false);
+	}
+#endif
 
 	// Disable engines for which we are missing dependencies
 	for (EngineDescList::const_iterator i = setup.engines.begin(); i != setup.engines.end(); ++i) {


### PR DESCRIPTION
This is complicated to support as the Xcode project is used for MacOS and iOS/tvOS where ImGui is not supported.
This needs to avoid building of some files in the engines in a selective way which is not easy to achieve without hacks.