### PR TITLE
BUILD: AUDIO: Drop support for FLAC < 1.1.3

### DIFF
--- a/configure
+++ b/configure
@@ -5219,15 +5219,20 @@ echo "$_retrowave"
 #
 # Check for FLAC
 #
-echocheck "FLAC >= 1.0.1"
+echocheck "FLAC >= 1.1.3"
 if test "$_flac" = auto ; then
 	_flac=no
 	cat > $TMPC << EOF
 #define FLAC__NO_DLL // Like in audio/decoders/flac.cpp
 
+#include <FLAC/export.h>
 #include <FLAC/stream_decoder.h>
 #include <FLAC/format.h>
+
 int main(void) {
+#if !defined(FLAC_API_VERSION_CURRENT) || FLAC_API_VERSION_CURRENT < 8
+	syntax error
+#endif
 	FLAC__StreamDecoder *decoder = FLAC__stream_decoder_new();
 	FLAC__stream_decoder_delete(decoder);
 	return FLAC__STREAM_SYNC_LEN >> 30; /* guaranteed to be 0 */


### PR DESCRIPTION
The following PR updates our FLAC requirement from 1.0.1 (2001) to 1.1.3 (2006), i.e. it drops support for the legacy stream decoder API for which we maintained compatibility code under a `LEGACY_FLAC` guard.

`audio/decoders/flac.cpp` says: *"`LEGACY_FLAC` code can be removed once FLAC-1.1.3 propagates everywhere"*. FLAC 1.1.3+ has probably propagated everywhere, 18 years after its release :p 

AFAIK, the oldest FLAC release we still build against is FLAC 1.2.1, for the OpenDingux and OpenPandora ports ([source 1](https://github.com/scummvm/dockerized-bb/blob/883fd791dbdde2d299323dc3d20dbe5f14f897f0/toolchains/opendingux/packages/flac/build.sh#L4), [source 2](https://github.com/scummvm/dockerized-bb/blob/883fd791dbdde2d299323dc3d20dbe5f14f897f0/toolchains/openpandora/packages/flac/build.sh#L4)). But they're obsolete platforms, and I've checked that it still builds there, though.

I've also tested the configure changes with both a Slackware 12.0 and 12.1 VM (yeah), which are two releases before and after the FLAC 1.1.3+ upgrade.

The main benefit is 100 less LOC in flac.cpp, and a file that's a bit easier to follow.