### PR TITLE
CI: Use Discord RPC lib in Ubuntu runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,10 +161,12 @@ jobs:
             sdlConfig: sdl2-config
             cxx: ccache g++
             aptPackages: 'liba52-dev libcurl4-openssl-dev libfaad-dev libflac-dev libfluidsynth-dev libfreetype6-dev libfribidi-dev libgif-dev libgtk-3-dev libjpeg-turbo8-dev libmad0-dev libmikmod-dev libmpeg2-4-dev libogg-dev libpng-dev libsdl2-dev libsdl2-net-dev libsndio-dev libspeechd-dev libtheora-dev libunity-dev libvorbis-dev libvpx-dev zlib1g-dev'
+            configFlags: --enable-discord --with-discord-prefix=/usr/local
           - platform: ubuntu-20.04
             sdlConfig: sdl-config
             cxx: ccache g++-4.8
             aptPackages: 'g++-4.8 liba52-dev libcurl4-openssl-dev libfaad-dev libflac-dev libfluidsynth-dev libfreetype6-dev libfribidi-dev libgif-dev libgtk-3-dev libjpeg-turbo8-dev libmad0-dev libmikmod-dev libmpeg2-4-dev libogg-dev libpng-dev libsdl-net1.2-dev libsdl1.2-dev libsndio-dev libspeechd-dev libtheora-dev libunity-dev libvorbis-dev libvpx-dev zlib1g-dev'
+            configFlags: --enable-discord --with-discord-prefix=/usr/local
     env:
       SDL_CONFIG: ${{ matrix.sdlConfig }}
     defaults:
@@ -183,6 +185,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install ${{ matrix.aptPackages }}
+      - name: Download and install Discord RPC libraries
+        run: |
+          curl -L -o discord-rpc-linux.zip https://github.com/discord/discord-rpc/releases/download/v3.4.0/discord-rpc-linux.zip
+          echo 'dac1f5dc6bedaeab1cc3c2c7fd4261e00838c81619c3ee325f3723c3d55ee03a discord-rpc-linux.zip' | sha256sum --check && unzip discord-rpc-linux.zip
+          sudo cp -v -pR discord-rpc/linux-dynamic/include/*.* /usr/local/include/
+          sudo cp -v -pR discord-rpc/linux-dynamic/lib/*.* /usr/local/lib/
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:


### PR DESCRIPTION
This adds [discord-rpc](https://github.com/discord/discord-rpc) support to the Ubuntu runners, so that CI has better coverage for this part of the code, even under Linux.

There's no real package for discord-rpc it seems, but we already `curl` so pre-built binaries for the Windows runners, anyway.

Any objection?