### PR TITLE
STARTREK: Fixes for the demo versions

### DIFF
--- a/engines/startrek/detection.cpp
+++ b/engines/startrek/detection.cpp
@@ -221,6 +221,21 @@ static const StarTrekGameDescription gameDescriptions[] = {
 		GF_DEMO,
 	},
 
+	{ // ST25 MAC CD demo
+		{
+			"st25",
+			"Demo",
+			AD_ENTRY1s("Star Trek Data", "r:871fa51c7680c0a43df9622128f1569f", 42361),
+			Common::EN_ANY,
+			Common::kPlatformMacintosh,
+			ADGF_MACRESFORK | ADGF_CD | ADGF_DEMO | ADGF_UNSTABLE,
+			GUIO2(GUIO_RENDERVGA, GUIO_RENDEREGA)
+		},
+		GType_ST25,
+		GF_CDROM | GF_DEMO,
+	},
+
+
 	// These are commented until future notice because I don't have complete information
 	// on them (the file size for data.000 / data.001). Will be relying on people to
 	// report the missing data.

--- a/engines/startrek/detection.cpp
+++ b/engines/startrek/detection.cpp
@@ -47,6 +47,11 @@ static const DebugChannelDef debugFlagList[] = {
 
 namespace StarTrek {
 
+static const char *const directoryGlobs[] = {
+	"misc",
+	0
+};
+
 static const StarTrekGameDescription gameDescriptions[] = {
 	{ // ST25 DOS CD-ROM edition (EN)
 		{
@@ -355,6 +360,8 @@ static const StarTrekGameDescription gameDescriptions[] = {
 class StarTrekMetaEngineDetection : public AdvancedMetaEngineDetection<StarTrek::StarTrekGameDescription> {
 public:
 	StarTrekMetaEngineDetection() : AdvancedMetaEngineDetection(StarTrek::gameDescriptions, starTrekGames) {
+		_maxScanDepth = 2;
+		_directoryGlobs = StarTrek::directoryGlobs;
 	}
 
 	const DebugChannelDef *getDebugChannels() const override {

--- a/engines/startrek/graphics.cpp
+++ b/engines/startrek/graphics.cpp
@@ -48,7 +48,7 @@ Graphics::Graphics(StarTrekEngine *vm) : _vm(vm), _egaMode(false) {
 	if (ConfMan.hasKey("render_mode"))
 		_egaMode = (Common::parseRenderMode(ConfMan.get("render_mode").c_str()) == Common::kRenderEGA) && (_vm->getGameType() != GType_STJR) && !(_vm->getFeatures() & GF_DEMO);
 
-	if (_vm->getGameType() == GType_ST25 && _vm->getPlatform() == Common::kPlatformDOS)
+	if (_vm->getGameType() == GType_ST25 && _vm->getPlatform() != Common::kPlatformAmiga)
 		_font = new Font(_vm);
 
 	_numSprites = 0;

--- a/engines/startrek/resource.cpp
+++ b/engines/startrek/resource.cpp
@@ -175,7 +175,17 @@ Common::MemoryReadStreamEndian *Resource::loadSequentialFile(Common::String file
 }
 
 uint32 Resource::getSequentialFileOffset(uint32 offset, int fileIndex) {
-	Common::SeekableReadStream *dataRunFile = SearchMan.createReadStreamForMember("data.run"); // FIXME: Amiga & Mac need this implemented
+	Common::SeekableReadStream *dataRunFile;
+
+	if (_platform == Common::kPlatformAmiga) {
+		// TODO: Amiga version
+		dataRunFile = nullptr;
+	} else if (_platform == Common::kPlatformMacintosh) {
+		dataRunFile = _macResFork->getResource("Runs");
+	} else {
+		dataRunFile = SearchMan.createReadStreamForMember("data.run");
+	}
+
 	if (!dataRunFile)
 		error("Could not open sequential file");
 

--- a/engines/startrek/sound.cpp
+++ b/engines/startrek/sound.cpp
@@ -40,7 +40,7 @@ Sound::Sound(StarTrekEngine *vm) : _vm(vm) {
 	_midiDriver = nullptr;
 	_loopingMidiTrack = MIDITRACK_0;
 
-	if (_vm->getPlatform() == Common::kPlatformDOS || _vm->getPlatform() == Common::kPlatformMacintosh) {
+	if (_vm->getPlatform() == Common::kPlatformDOS) {
 		_midiDevice = MidiDriver::detectDevice(MDT_PCSPK | MDT_ADLIB | MDT_MIDI | MDT_PREFER_MT32);
 		_midiDriver = MidiDriver::createMidi(_midiDevice);
 		_midiDriver->open();
@@ -60,6 +60,8 @@ Sound::Sound(StarTrekEngine *vm) : _vm(vm) {
 		}
 
 		_midiDriver->setTimerCallback(this, Sound::midiDriverCallback);
+	} else {
+		_vm->_musicWorking = false;
 	}
 
 	_soundHandle = new Audio::SoundHandle();
@@ -424,6 +426,9 @@ void Sound::loadPCMusicFile(const Common::String &baseSoundName) {
 }
 
 void Sound::clearMidiSlot(int slot) {
+	if (!_vm->_musicWorking)
+		return;
+
 	_midiSlots[slot].midiParser->stopPlaying();
 	_midiSlots[slot].midiParser->unloadMusic();
 	_midiSlots[slot].track = -1;

--- a/engines/startrek/sound.cpp
+++ b/engines/startrek/sound.cpp
@@ -24,6 +24,7 @@
 
 #include "common/file.h"
 #include "common/macresman.h"
+#include "common/tokenizer.h"
 
 #include "audio/audiostream.h"
 #include "audio/decoders/raw.h"
@@ -238,18 +239,11 @@ void Sound::playSpeech(const Common::String &basename) {
 	stopPlayingSpeech();
 
 	Audio::QueuingAudioStream *audioQueue = nullptr;
-	Common::String name = basename;
+	Common::StringTokenizer tok(basename, ",");
 
 	// Play a list of comma-separated audio files in sequence (usually there's only one)
-	while (!name.empty()) {
-		uint i = 0;
-		while (i < name.size() && name[i] != ',') {
-			if (name[i] == '\\')
-				name.setChar('/', i);
-			i++;
-		}
-
-		Common::Path filename = Common::Path("voc/").appendComponent(Common::String(name.c_str(), name.c_str() + i) + ".voc");
+	while (!tok.empty()) {
+		Common::Path filename = Common::Path("voc/").append(Common::Path(tok.nextToken() + ".voc", '\\'));
 		debugC(5, kDebugSound, "Playing speech '%s'", filename.toString().c_str());
 		Common::SeekableReadStream *readStream = SearchMan.createReadStreamForMember(filename);
 		if (readStream == nullptr)
@@ -261,8 +255,6 @@ void Sound::playSpeech(const Common::String &basename) {
 				audioQueue = Audio::makeQueuingAudioStream(audioStream->getRate(), audioStream->isStereo());
 			audioQueue->queueAudioStream(audioStream, DisposeAfterUse::YES);
 		}
-
-		name.erase(0, i + 1);
 	}
 
 	if (audioQueue != nullptr) {

--- a/engines/startrek/startrek.cpp
+++ b/engines/startrek/startrek.cpp
@@ -56,8 +56,8 @@ StarTrekEngine::StarTrekEngine(OSystem *syst, const StarTrekGameDescription *gam
 	_sineTable(1024),
 	_cosineTable(1024) {
 
-	if (getPlatform() != Common::kPlatformDOS)
-		error("Only DOS versions of Star Trek: 25th Anniversary are currently supported");
+	if (getPlatform() == Common::kPlatformAmiga)
+		error("Amiga versions of Star Trek: 25th Anniversary are not yet supported");
 	else if (getGameType() == GType_STJR)
 		error("Star Trek: Judgment Rites is not yet supported");
 
@@ -142,6 +142,7 @@ Common::Error StarTrekEngine::run() {
 	SearchMan.addSubDirectoryMatching(gameDataDir, "misc");
 
 	bool isDemo = getFeatures() & GF_DEMO;
+	bool isCd = getFeatures() & GF_CDROM;
 	_resource = new Resource(getPlatform(), isDemo);
 	_gfx = new Graphics(this);
 	_sound = new Sound(this);
@@ -164,7 +165,7 @@ Common::Error StarTrekEngine::run() {
 	}
 
 	if (!loadedSave) {
-		if (!isDemo) {
+		if (isCd || !isDemo) {
 			playIntro();
 			_missionToLoad = "DEMON";
 			_bridgeSequenceToLoad = 0;

--- a/engines/startrek/startrek.cpp
+++ b/engines/startrek/startrek.cpp
@@ -138,6 +138,9 @@ StarTrekEngine::~StarTrekEngine() {
 }
 
 Common::Error StarTrekEngine::run() {
+	const Common::FSNode gameDataDir(ConfMan.getPath("path"));
+	SearchMan.addSubDirectoryMatching(gameDataDir, "misc");
+
 	bool isDemo = getFeatures() & GF_DEMO;
 	_resource = new Resource(getPlatform(), isDemo);
 	_gfx = new Graphics(this);


### PR DESCRIPTION
Note that currently text boxes don't render correctly with either CD demo. The DOS floppy demo also doesn't start yet, and instead gives the error "Room "DEMO0" unimplemented!"