### PR TITLE
KYRA: Remove engine dependencies from the Halestorm driver

### DIFF
--- a/engines/kyra/sound/drivers/halestorm.h
+++ b/engines/kyra/sound/drivers/halestorm.h
@@ -28,14 +28,24 @@ namespace Audio {
 	class Mixer;
 }
 
+namespace Common {
+	class SeekableReadStream;
+}
+
 namespace Kyra {
 
 class HSSoundSystem;
-class SoundMacRes;
+
+class HalestormLoader {
+public:
+	virtual ~HalestormLoader() {}
+
+	virtual Common::SeekableReadStream *getResource(uint16 id, uint32 type) = 0;
+};
 
 class HalestormDriver {
 public:
-	HalestormDriver(SoundMacRes *res, Audio::Mixer *mixer);
+	HalestormDriver(HalestormLoader *res, Audio::Mixer *mixer);
 	~HalestormDriver();
 
 	enum InterpolationMode {

--- a/engines/kyra/sound/sound_mac_res.h
+++ b/engines/kyra/sound/sound_mac_res.h
@@ -26,6 +26,8 @@
 #include "common/str.h"
 #include "common/mutex.h"
 
+#include "kyra/sound/drivers/halestorm.h"
+
 namespace Common {
 	class Archive;
 	class MacResManager;
@@ -36,13 +38,13 @@ namespace Kyra {
 
 class KyraEngine_v1;
 
-class SoundMacRes {
+class SoundMacRes final : public HalestormLoader {
 public:
 	SoundMacRes(KyraEngine_v1 *vm);
-	~SoundMacRes();
+	~SoundMacRes() override;
 	bool init();
 	bool setQuality(bool hi);
-	Common::SeekableReadStream *getResource(uint16 id, uint32 type);
+	Common::SeekableReadStream *getResource(uint16 id, uint32 type) override;
 
 private:
 	Common::Path _kyraMacExe;


### PR DESCRIPTION
This should make it easier to move the driver into common code later - the Mac version of Star Trek 25th Anniversary appears to use the Halestorm driver as well.