### PR TITLE
GRAPHICS: Fix a transparency issue when using cursor masks with high-color in SurfaceSdl

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -114,6 +114,7 @@ public:
 	int16 getOverlayWidth() const override { return _videoMode.overlayWidth; }
 
 	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override;
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask, bool disableKeyColor);
 	void setCursorPalette(const byte *colors, uint start, uint num) override;
 
 #ifdef USE_OSD
@@ -384,6 +385,7 @@ protected:
 #else
 	byte _mouseKeyColor;
 #endif
+	bool _disableMouseKeyColor;
 	byte _mappedMouseKeyColor;
 	bool _cursorDontScale;
 	bool _cursorPaletteDisabled;


### PR DESCRIPTION
This is a fix for a bug I mentioned in https://github.com/scummvm/scummvm/pull/5315#issuecomment-1735288260, that occurs when using cursor masks in a high-color context with SurfaceSdl.

SurfaceSdl honors the cursor mask by creating intermediary masked_image, where the pixels made transparent by the mask are replaced by an ARGB color with alpha = 0 (ARGB 0x00000000). The problem is that the cursor surface still has a key color attached to it, which is set to 0 by the recursive call:

`setMouseCursor(&maskedImage[0], w, h, hotspotX, hotspotY, 0, dontScale, &formatWithAlpha, nullptr);`

and then passed to SDL_SetColorKey, which is _not_ sensitive to the alpha channel, so opaque black ARGB 0xFF000000 wrongly becomes transparent as well.

This PR provides an option to disable the unneeded color key in this case, which fixes the issue.

Example on the Adibou2/Anglais extension.
Without the fix :
 
![image](https://github.com/user-attachments/assets/cc76bc8d-bf9f-407d-9c1a-e2330b988461)

With the fix :

![image](https://github.com/user-attachments/assets/140bab08-ff89-43dc-b788-e11d82da891b)
