### PR TITLE
TUCKER: Fix bottom exit for UpperCorridor

### DIFF
--- a/engines/tucker/tucker.cpp
+++ b/engines/tucker/tucker.cpp
@@ -3064,10 +3064,21 @@ bool TuckerEngine::testLocationMask(int x, int y) {
 	if (_locationMaskType > 0 || _locationMaskIgnore) {
 		return true;
 	}
-	if (_location == kLocationSubwayTunnel || _location == kLocationKitchen) {
+
+	if (_location == kLocationSubwayTunnel
+		|| _location == kLocationKitchen
+		|| (_location == kLocationTopCorridor && _nextLocation == kLocationBottomCorridor)
+		) {
 		y -= 3;
 	}
 	const int offset = y * 640 + x;
+	if (offset >= (640 * 140)) {
+		// NOTE This causes multiple warning printouts in the console in problematic locations such as kLocationTopCorridor.
+		// TODO If all problematic locations are accounted for and returning true is the proper thing to do for all,
+		// we could keep only the "return true" statement here and remove the warning (or change it to a high level debug).
+		warning("testLocationMask: offset (%d, %d) is out of bounds for location: %d, nextLocation: %d", x, y, _location, _nextLocation);
+		return true;
+	}
 	return (_locationBackgroundMaskBuf[offset] > 0);
 }
 


### PR DESCRIPTION
This is a fix for tracker issue #15264

The cause seems to have been that a method was trying to access unallocated space.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
