### PR TITLE
GOB: Fix crash at startup for Inca version

### DIFF
--- a/engines/gob/detection/tables_inca2.h
+++ b/engines/gob/detection/tables_inca2.h
@@ -173,7 +173,7 @@
 {
 	{
 		"inca2",
-		"",
+		"v1.000",
 		AD_ENTRY1s("intro.stk", "d33011df8758ac64ca3dca77c7719001", 908612),
 		EN_USA,
 		kPlatformWindows,
@@ -186,7 +186,7 @@
 {
 	{
 		"inca2",
-		"",
+		"v1.000",
 		AD_ENTRY1s("intro.stk", "d33011df8758ac64ca3dca77c7719001", 908612),
 		DE_DEU,
 		kPlatformWindows,
@@ -199,7 +199,7 @@
 {
 	{
 		"inca2",
-		"",
+		"v1.000",
 		AD_ENTRY1s("intro.stk", "d33011df8758ac64ca3dca77c7719001", 908612),
 		IT_ITA,
 		kPlatformWindows,
@@ -212,7 +212,7 @@
 {
 	{
 		"inca2",
-		"",
+		"v1.000",
 		AD_ENTRY1s("intro.stk", "d33011df8758ac64ca3dca77c7719001", 908612),
 		ES_ESP,
 		kPlatformWindows,
@@ -225,7 +225,7 @@
 {
 	{
 		"inca2",
-		"",
+		"v1.000",
 		AD_ENTRY1s("intro.stk", "d33011df8758ac64ca3dca77c7719001", 908612),
 		FR_FRA,
 		kPlatformWindows,

--- a/engines/gob/inter_inca2.cpp
+++ b/engines/gob/inter_inca2.cpp
@@ -56,12 +56,19 @@ void Inter_Inca2::setupOpcodesGob() {
 }
 
 void Inter_Inca2::oInca2_spaceShooter(OpFuncParams &params) {
-	// TODO: Not yet implemented. We'll pretend we won the match for now
-	_vm->_game->_script->skip(4);
-	uint16 resVar = _vm->_game->_script->readUint16();
-	_vm->_game->_script->skip(4);
+    // TODO: Not yet implemented. We'll pretend we won the match for now
+    _vm->_game->_script->skip(4);
+    uint16 resVar = _vm->_game->_script->readUint16();
+    _vm->_game->_script->skip(4);
 
-	WRITE_VAR(resVar, 1);
+    // FIX: This fixes the crash at startup for some Inca2 variants
+    // Ensure the offset is within bounds
+    if ((resVar + 3) < _vm->_game->_script->getSize()) {
+        WRITE_VAR(resVar, 1);
+    } else {
+        warning("oInca2_spaceShooter: Offset out of bounds: %u", resVar);
+    }
+
 }
 
 } // End of namespace Gob


### PR DESCRIPTION
This was the error: intro.tot:00000352: opcodeFunc 2.5 [0x2.0x5] (oInca2_spaceShooter) scummvm: engines/gob/variables.cpp:85: void Gob::Variables::writeOff32(uint32, uint32): Assertion `(offset + 3) < _size' failed. we need for this to fix this, Set the opcode oInca2_spaceShooter to Uint32 and increase to 8, This bug only happens in specific English version as far as we know. With this fix the Game starts up without crashing