### PR TITLE
JANITORIAL: AGS: Fix a bunch of typos in comments

### DIFF
--- a/engines/ags/engine/ac/draw.cpp
+++ b/engines/ags/engine/ac/draw.cpp
@@ -1582,7 +1582,7 @@ void prepare_characters_for_drawing() {
 			_GP(charextra)[aa].height = newheight;
 		} else {
 			// draw at original size, so just use the sprite width and height
-			// TODO: store width and height always, that's much simplier to use for reference!
+			// TODO: store width and height always, that's much simpler to use for reference!
 			_GP(charextra)[aa].width = 0;
 			_GP(charextra)[aa].height = 0;
 			newwidth = src_sprwidth;

--- a/engines/ags/engine/ac/drawing_surface.cpp
+++ b/engines/ags/engine/ac/drawing_surface.cpp
@@ -172,7 +172,7 @@ void DrawingSurface_DrawImageImpl(ScriptDrawingSurface *sds, Bitmap *src,
 	Math::ClampLength(src_y, src_height, 0, src->GetHeight());
 
 	// TODO: possibly optimize by not making a stretched intermediate bitmap
-	// if simplier blit/draw_sprite could be called (no translucency with alpha channel).
+	// if simpler blit/draw_sprite could be called (no translucency with alpha channel).
 	bool needToFreeBitmap = false;
 	if (dst_width != src->GetWidth() || dst_height != src->GetHeight() ||
 		src_width != src->GetWidth() || src_height != src->GetHeight()) {

--- a/engines/ags/engine/ac/game.cpp
+++ b/engines/ags/engine/ac/game.cpp
@@ -977,7 +977,7 @@ HSaveError load_game(const String &path, int slotNumber, bool &data_overwritten)
 	SavegameDescription desc;
 	err = OpenSavegame(path, src, desc, kSvgDesc_EnvInfo);
 
-	// saved in incompatible enviroment
+	// saved in incompatible environment
 	if (!err)
 		return err;
 	// CHECKME: is this color depth test still essential? if yes, is there possible workaround?

--- a/engines/ags/engine/ac/sprite_list_entry.h
+++ b/engines/ags/engine/ac/sprite_list_entry.h
@@ -34,7 +34,7 @@ struct SpriteListEntry {
 	int x = 0, y = 0;
 	int zorder = 0;
 	// Tells if this item should take priority during sort if z1 == z2
-	// TODO: this is some compatibility feature - find out if may be omited and done without extra struct?
+	// TODO: this is some compatibility feature - find out if may be omitted and done without extra struct?
 	bool takesPriorityIfEqual = false;
 	// Mark for the render stage callback (if >= 0 other fields are ignored)
 	int renderStage = -1;

--- a/engines/ags/engine/game/savegame.cpp
+++ b/engines/ags/engine/game/savegame.cpp
@@ -179,9 +179,9 @@ HSaveError ReadDescription(Stream *in, SavegameVersion &svg_ver, SavegameDescrip
 		return new SavegameError(kSvgErr_FormatVersionNotSupported,
 		                         String::FromFormat("Required: %d, supported: %d - %d.", svg_ver, kSvgVersion_LowestSupported, kSvgVersion_Current));
 
-	// Enviroment information
+	// Environment information
 	if (svg_ver >= kSvgVersion_351)
-		in->ReadInt32(); // enviroment info size
+		in->ReadInt32(); // environment info size
 	if (elems & kSvgDesc_EnvInfo) {
 		desc.EngineName = StrUtil::ReadString(in);
 		desc.EngineVersion.SetFromString(StrUtil::ReadString(in));
@@ -682,7 +682,7 @@ void WriteDescription(Stream *out, const String &user_text, const Bitmap *user_i
 	out->WriteInt32(kSvgVersion_Current);
 	soff_t env_pos = out->GetPosition();
 	out->WriteInt32(0);
-	// Enviroment information
+	// Environment information
 	StrUtil::WriteString(get_engine_name(), out);
 	StrUtil::WriteString(_G(EngineVersion).LongString, out);
 	StrUtil::WriteString(_GP(game).guid, out);

--- a/engines/ags/engine/game/savegame.h
+++ b/engines/ags/engine/game/savegame.h
@@ -126,7 +126,7 @@ enum SavegameDescElem {
 	kSvgDesc_All = kSvgDesc_EnvInfo | kSvgDesc_UserText | kSvgDesc_UserImage
 };
 
-// SavegameDescription describes savegame with information about the enviroment
+// SavegameDescription describes savegame with information about the environment
 // it was created in, and custom data provided by user
 struct SavegameDescription {
 	// Name of the engine that saved the game

--- a/engines/ags/engine/game/viewport.h
+++ b/engines/ags/engine/game/viewport.h
@@ -206,7 +206,7 @@ private:
 	// Position of the viewport on screen
 	Rect _position;
 	// TODO: Camera reference (when supporting multiple cameras)
-	// Coordinate tranform between camera and viewport
+	// Coordinate transform between camera and viewport
 	// TODO: need to add rotate conversion to let script API support that;
 	// (maybe use full 3D matrix for that)
 	AGS::Shared::PlaneScaling _transform;

--- a/engines/ags/engine/gfx/ali_3d_scummvm.cpp
+++ b/engines/ags/engine/gfx/ali_3d_scummvm.cpp
@@ -388,7 +388,7 @@ void ScummVMRendererGraphicsDriver::RenderToBackBuffer() {
 	// with blending and translucency; it seems you'd have to first stretch the original sprite onto a
 	// temp buffer and then TransBlendBlt / LitBlendBlt it to the final destination. Of course, doing
 	// that here would slow things down significantly, so if we ever go that way sprite caching will
-	// be required (similarily to how AGS caches flipped/scaled object sprites now for).
+	// be required (similarly to how AGS caches flipped/scaled object sprites now for).
 	//
 
 	const size_t last_batch_to_rend = _spriteBatchDesc.size() - 1;

--- a/engines/ags/engine/gfx/graphics_driver.h
+++ b/engines/ags/engine/gfx/graphics_driver.h
@@ -104,7 +104,7 @@ public:
 	virtual void SetTintMethod(TintMethod method) = 0;
 	// Initialize given display mode
 	virtual bool SetDisplayMode(const DisplayMode &mode) = 0;
-	// Updates previously set display mode, accomodating to the new screen size
+	// Updates previously set display mode, accommodating to the new screen size
 	virtual void UpdateDeviceScreen(const Size &screen_size) = 0;
 	// Gets if a graphics mode was initialized
 	virtual bool IsModeSet() const = 0;

--- a/engines/ags/engine/main/config.cpp
+++ b/engines/ags/engine/main/config.cpp
@@ -59,7 +59,7 @@ WindowSetup parse_window_mode(const String &option, bool as_windowed, WindowSetu
 	// in which case we'll use either a resizing window or a REAL fullscreen mode
 	const WindowMode exp_wmode = as_windowed ? kWnd_Windowed : kWnd_Fullscreen;
 	// Note that for "desktop" we return "default" for windowed, this will result
-	// in refering to the  desktop size but resizing in accordance to the scaling style
+	// in referring to the  desktop size but resizing in accordance to the scaling style
 	if (option.CompareNoCase("desktop") == 0)
 		return as_windowed ? WindowSetup(exp_wmode) : WindowSetup(get_desktop_size(), exp_wmode);
 	// "Native" means using game resolution as a window size

--- a/engines/ags/engine/main/engine.cpp
+++ b/engines/ags/engine/main/engine.cpp
@@ -745,7 +745,7 @@ void engine_init_game_settings() {
 
 	GUI::Options.DisabledStyle = static_cast<GuiDisableStyle>(_GP(game).options[OPT_DISABLEOFF]);
 	GUI::Options.ClipControls = _GP(game).options[OPT_CLIPGUICONTROLS] != 0;
-	// Force GUI metrics recalculation, accomodating for loaded fonts
+	// Force GUI metrics recalculation, accommodating for loaded fonts
 	GUI::MarkForFontUpdate(-1);
 
 	memset(&_GP(play).walkable_areas_on[0], 1, MAX_WALK_AREAS + 1);

--- a/engines/ags/engine/main/graphics_mode.cpp
+++ b/engines/ags/engine/main/graphics_mode.cpp
@@ -238,7 +238,7 @@ bool try_init_compatible_mode(const DisplayMode &dm) {
 	if (!result && dm.IsWindowed()) {
 		// When initializing windowed mode we could start with any random window size;
 		// if that did not work, try to find nearest supported mode, as with fullscreen mode,
-		// except refering to max window size as an upper bound
+		// except referring to max window size as an upper bound
 		if (find_nearest_supported_mode(*modes.get(), screen_size, dm.ColorDepth, nullptr, &device_size, dm_compat)) {
 			dm_compat.Vsync = dm.Vsync;
 			dm_compat.Mode = kWnd_Windowed;

--- a/engines/ags/engine/script/script_api.h
+++ b/engines/ags/engine/script/script_api.h
@@ -59,7 +59,7 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
 }
 
 // Helper macros for script functions;
-// asserting for internal mistakes; supressing "unused param" warnings
+// asserting for internal mistakes; suppressing "unused param" warnings
 #define ASSERT_SELF(METHOD) \
     (void)params; (void)param_count; \
     assert((self != NULL) && "Object pointer is null in call to API function")

--- a/engines/ags/globals.h
+++ b/engines/ags/globals.h
@@ -758,7 +758,7 @@ public:
 	// TODO: IMPORTANT!!
 	// we cannot simply replace these arrays with vectors, or other C++ containers,
 	// until we implement safe management of such containers in script exports
-	// system. Noteably we would need an alternate to StaticArray class to track
+	// system. Notably we would need an alternate to StaticArray class to track
 	// access to their elements.
 	ScriptObject *_scrObj;
 	ScriptGUI *_scrGui = nullptr;
@@ -839,7 +839,7 @@ public:
 	 */
 
 	 // Following struct instructs the engine to run game loops until
-	 // certain condition is not fullfilled.
+	 // certain condition is not fulfilled.
 	struct RestrictUntil {
 		int type = 0; // type of condition, UNTIL_* constant
 		int disabled_for = 0; // FOR_* constant

--- a/engines/ags/lib/allegro/surface_avx2.cpp
+++ b/engines/ags/lib/allegro/surface_avx2.cpp
@@ -190,7 +190,7 @@ static inline __m256i blendTintSpriteSIMD(__m256i srcCols, __m256i destCols, __m
 	// srcCols[2] = A | R | G | B
 	// srcCols[3] = A | R | G | B
 	//  ->
-	// to 4 float32x4_t's each being a seperate channel with each lane
+	// to 4 float32x4_t's each being a separate channel with each lane
 	// corresponding to their respective srcCols lane
 	// dda = { A[0], A[1], A[2], A[3] }
 	// ddr = { R[0], R[1], R[2], R[3] }

--- a/engines/ags/lib/allegro/surface_neon.cpp
+++ b/engines/ags/lib/allegro/surface_neon.cpp
@@ -151,7 +151,7 @@ static inline uint32x4_t rgbBlendSIMD(uint32x4_t srcCols, uint32x4_t destCols, u
 	srcCols = vandq_u32(srcCols, vmovq_n_u32(0xff00));
 	srcCols = vorrq_u32(srcCols, srcColsCopy);
 
-	// Remeber that alpha is not alphas, but rather the alpha of destCols
+	// Remember that alpha is not alphas, but rather the alpha of destCols
 	if (preserveAlpha) {
 		srcCols = vandq_u32(srcCols, vmovq_n_u32(0x00ffffff));
 		srcCols = vorrq_u32(srcCols, alpha);
@@ -203,7 +203,7 @@ static inline uint32x4_t blendTintSpriteSIMD(uint32x4_t srcCols, uint32x4_t dest
 	// srcCols[2] = A | R | G | B
 	// srcCols[3] = A | R | G | B
 	//  ->
-	// to 4 float32x4_t's each being a seperate channel with each lane
+	// to 4 float32x4_t's each being a separate channel with each lane
 	// corresponding to their respective srcCols lane
 	// dda = { A[0], A[1], A[2], A[3] }
 	// ddr = { R[0], R[1], R[2], R[3] }
@@ -220,7 +220,7 @@ static inline uint32x4_t blendTintSpriteSIMD(uint32x4_t srcCols, uint32x4_t dest
 	ssg = vmulq_n_f32(vcvtq_f32_u32(vandq_u32(vshrq_n_u32(srcCols, 8), vmovq_n_u32(0xff))), 1.0 / 255.0);
 	ssb = vmulq_n_f32(vcvtq_f32_u32(vandq_u32(srcCols, vmovq_n_u32(0xff))), 1.0 / 255.0);
 
-	// Get the maxes and mins (needed for HSV->RGB and visa-versa)
+	// Get the maxes and mins (needed for HSV->RGB and vice-versa)
 	float32x4_t dmaxes = vmaxq_f32(ddr, vmaxq_f32(ddg, ddb));
 	float32x4_t smaxes = vmaxq_f32(ssr, vmaxq_f32(ssg, ssb));
 	float32x4_t smins = vminq_f32(ssr, vminq_f32(ssg, ssb));
@@ -255,9 +255,9 @@ static inline uint32x4_t blendTintSpriteSIMD(uint32x4_t srcCols, uint32x4_t dest
 		val = vmaxq_f32(val, vmovq_n_f32(0.0));
 	}
 
-	// then it stiches the HSV back together
+	// then it stitches the HSV back together
 	// the hue and saturation come from the source (tint) color, and the value comes from
-	// the destinaion (real source) color
+	// the destination (real source) color
 	chroma = vmulq_f32(val, vmulq_f32(vsubq_f32(smaxes, smins), vrecpeq_f32(vaddq_f32(smaxes, eplison0))));
 	float32x4_t hprime_mod2 = vmulq_n_f32(hue, 1.0 / 2.0);
 	hprime_mod2 = vmulq_n_f32(vsubq_f32(hprime_mod2, vcvtq_f32_s32(vcvtq_s32_f32(hprime_mod2))), 2.0);
@@ -472,7 +472,7 @@ static void drawInner4BppWithConv(BITMAP::DrawInnerArgs &args) {
 	const uint32x4_t addIndexesFlipped = {3, 2, 1, 0};
 	uint32x4_t addIndexes = args.horizFlip ? addIndexesFlipped : addIndexesNormal;
 
-	// This is so that we can calculate in parralell the pixel indexes for scaled drawing
+	// This is so that we can calculate in parallel the pixel indexes for scaled drawing
 	uint32x4_t scaleAdds = {0, (uint32)args.scaleX, (uint32)args.scaleX*2, (uint32)args.scaleX*3};
 
 	// Clip the bounds ahead of time (so we don't waste time checking if we are in bounds when
@@ -561,7 +561,7 @@ static void drawInner4BppWithConv(BITMAP::DrawInnerArgs &args) {
 				scaleXCtr += args.scaleX*4;
 
 				// Now this is pretty much the same as before with non-scaled code, except that we use
-				// our dummy source buffer instead of the actuall source bitmap
+				// our dummy source buffer instead of the actual source bitmap
 				byte *destPtr = &destP[destX * (uintptr_t)DestBytesPerPixel];
 				uint32x4_t skipMask = vcgeq_u32(vaddq_u32(vdupq_n_u32(xCtr), addIndexes), xCtrWidthSIMD);
 				drawPixelSIMD<DestBytesPerPixel, SrcBytesPerPixel>(destPtr, (const byte *)srcBuffer, tint, alphas, maskedAlphas, transColors, 1, 0, args.srcAlpha, args.skipTrans, args.horizFlip, args.useTint, skipMask);
@@ -571,7 +571,7 @@ static void drawInner4BppWithConv(BITMAP::DrawInnerArgs &args) {
 			// The only exception here is scaling drawing this is because:
 			// 1) if statements are costly, and the less we do the faster this loop is
 			// 2) with this, the only branch in the normal drawing loop is the width check
-			// 3) the scaling code will actually draw the until the last 4 pixels of the image
+			// 3) the scaling code will actually draw until the last 4 pixels of the image
 			//    and do the extra if checks because the scaling code is already much slower
 			//    than the normal drawing loop, and the less duplicate code helps here.
 			if (yCtr + 1 != yCtrHeight) destP += args.destArea.pitch;
@@ -651,7 +651,7 @@ static void drawInner2Bpp(BITMAP::DrawInnerArgs &args) {
 	uint16x8_t addIndexesFlipped = {7, 6, 5, 4, 3, 2, 1, 0};
 	uint16x8_t addIndexes = args.horizFlip ? addIndexesFlipped : addIndexesNormal;
 
-	// This is so that we can calculate in parralell the pixel indexes for scaled drawing
+	// This is so that we can calculate in parallel the pixel indices for scaled drawing
 	uint32x4_t scaleAdds = {0, (uint32)args.scaleX, (uint32)args.scaleX*2, (uint32)args.scaleX*3};
 	uint32x4_t scaleAdds2 = {(uint32)args.scaleX*4, (uint32)args.scaleX*5, (uint32)args.scaleX*6, (uint32)args.scaleX*7};
 
@@ -732,7 +732,7 @@ static void drawInner2Bpp(BITMAP::DrawInnerArgs &args) {
 			for (int xCtr = xCtrStart, xCtrBpp = xCtrBppStart, destX = args.xStart, scaleXCtr = xCtrStart * args.scaleX; xCtr < xCtrWidth; destX += 8, xCtr += 8, xCtrBpp += 16) {
 				if (yCtr + 1 == yCtrHeight && xCtr + 8 > xCtrWidth) break;
 				uint32x4_t indexes = vdupq_n_u32(scaleXCtr), indexes2 = vdupq_n_u32(scaleXCtr);
-				// Calculate in parallel the indexes of the pixels
+				// Calculate in parallel the indices of the pixels
 				indexes = vmulq_n_u32(vshrq_n_u32(vaddq_u32(indexes, scaleAdds), BITMAP::SCALE_THRESHOLD_BITS), 2);
 				indexes2 = vmulq_n_u32(vshrq_n_u32(vaddq_u32(indexes2, scaleAdds2), BITMAP::SCALE_THRESHOLD_BITS), 2);
 				// Simply memcpy them in. memcpy has no real performance overhead here
@@ -747,7 +747,7 @@ static void drawInner2Bpp(BITMAP::DrawInnerArgs &args) {
 				scaleXCtr += args.scaleX*8;
 
 				// Now this is pretty much the same as before with non-scaled code, except that we use
-				// our dummy source buffer instead of the actuall source bitmap
+				// our dummy source buffer instead of the actual source bitmap
 				byte *destPtr = &destP[destX * 2];
 				uint16x8_t skipMask = vcgeq_u16(vaddq_u16(vdupq_n_u16(xCtr), addIndexes), xCtrWidthSIMD);
 				drawPixelSIMD2Bpp(destPtr, (const byte *)srcBuffer, tint, alphas, transColors, 1, 0, args.srcAlpha, args.skipTrans, args.horizFlip, args.useTint, skipMask);
@@ -757,7 +757,7 @@ static void drawInner2Bpp(BITMAP::DrawInnerArgs &args) {
 			// The only exception here is scaling drawing this is because:
 			// 1) if statements are costly, and the less we do the faster this loop is
 			// 2) with this, the only branch in the normal drawing loop is the width check
-			// 3) the scaling code will actually draw the until the last 4 pixels of the image
+			// 3) the scaling code will actually draw until the last 4 pixels of the image
 			//    and do the extra if checks because the scaling code is already much slower
 			//    than the normal drawing loop, and the less duplicate code helps here.
 			if (yCtr + 1 != yCtrHeight) destP += args.destArea.pitch;
@@ -827,7 +827,7 @@ static void drawInner1Bpp(BITMAP::DrawInnerArgs &args) {
 	const int xDir = args.horizFlip ? -1 : 1;
 	uint8x16_t transColors = vmovq_n_u8(args.transColor);
 
-	// This is so that we can calculate in parralell the pixel indexes for scaled drawing
+	// This is so that we can calculate in parallel the pixel indices for scaled drawing
 	uint32x4_t scaleAdds1 = {0, (uint32)args.scaleX, (uint32)args.scaleX*2, (uint32)args.scaleX*3};
 	uint32x4_t scaleAdds2 = {(uint32)args.scaleX*4, (uint32)args.scaleX*5, (uint32)args.scaleX*6, (uint32)args.scaleX*7};
 	uint32x4_t scaleAdds3 = {(uint32)args.scaleX*8, (uint32)args.scaleX*9, (uint32)args.scaleX*10, (uint32)args.scaleX*11};
@@ -878,7 +878,7 @@ static void drawInner1Bpp(BITMAP::DrawInnerArgs &args) {
 		for (; xCtr + 16 < xCtrWidth; destX += 16, xCtr += 16) {
 			byte *destPtr = &destP[destX];
 
-			// Here we dont use the drawPixelSIMD function because 1bpp bitmaps in allegro
+			// Here we don't use the drawPixelSIMD function because 1bpp bitmaps in allegro
 			// can't have any blending applied to them
 			uint8x16_t destCols = vld1q_u8(destPtr);
 			uint8x16_t srcCols = vld1q_u8(srcP + xDir * xCtr);
@@ -936,7 +936,7 @@ static void drawInner1Bpp(BITMAP::DrawInnerArgs &args) {
 			*destVal = *srcCol;
 		}
 		if (args.horizFlip) srcP -= 15; // Undo what we did up there
-		destP += args.destArea.pitch; // Goto next row
+		destP += args.destArea.pitch; // Go to next row
 		// Only advance the src row by 1 every time like this if we don't scale
 		if (!Scale) srcP += args.vertFlip ? -args.src.pitch : args.src.pitch;
 	}

--- a/engines/ags/lib/allegro/surface_sse2.cpp
+++ b/engines/ags/lib/allegro/surface_sse2.cpp
@@ -194,7 +194,7 @@ static inline __m128i blendTintSpriteSIMD(__m128i srcCols, __m128i destCols, __m
 	// srcCols[2] = A | R | G | B
 	// srcCols[3] = A | R | G | B
 	//  ->
-	// to 4 float32x4_t's each being a seperate channel with each lane
+	// to 4 float32x4_t's each being a separate channel with each lane
 	// corresponding to their respective srcCols lane
 	// dda = { A[0], A[1], A[2], A[3] }
 	// ddr = { R[0], R[1], R[2], R[3] }

--- a/engines/ags/lib/freetype-2.1.3/autohint/ahhint.cpp
+++ b/engines/ags/lib/freetype-2.1.3/autohint/ahhint.cpp
@@ -949,7 +949,7 @@ static FT_Error ah_hinter_load(AH_Hinter hinter, FT_UInt glyph_index, FT_Int32 l
 		ah_outline_save(outline, gloader);
 
 		/* we now need to hint the metrics according to the change in */
-		/* width/positioning that occured during the hinting process  */
+		/* width/positioning that occurred during the hinting process  */
 		{
 			FT_Pos old_advance, old_rsb, old_lsb, new_lsb;
 			AH_Edge edge1 = outline->vert_edges; /* leftmost edge  */

--- a/engines/ags/lib/freetype-2.1.3/ftmemory.h
+++ b/engines/ags/lib/freetype-2.1.3/ftmemory.h
@@ -90,7 +90,7 @@ void FT_Free(FT_Memory memory, void **P);
 /*                                                                       */
 /* The following macros are variants of their FT_MEM_XXXX equivalents;   */
 /* they are used to set an _implicit_ `error' variable and return TRUE   */
-/* if an error occured (i.e. if 'error != 0').                           */
+/* if an error occurred (i.e. if 'error != 0').                           */
 /*                                                                       */
 
 #define FT_ALLOC(_pointer_, _size_) FT_SET_ERROR(FT_MEM_ALLOC(_pointer_, _size_))

--- a/engines/ags/plugins/ags_plugin.cpp
+++ b/engines/ags/plugins/ags_plugin.cpp
@@ -404,7 +404,7 @@ AGSObject *IAGSEngine::GetObject(int32 num) {
 }
 BITMAP *IAGSEngine::CreateBlankBitmap(int32 width, int32 height, int32 coldep) {
 	// [IKM] We should not create Bitmap object here, because
-	// a) we are returning raw allegro bitmap and therefore loosing control over it
+	// a) we are returning raw allegro bitmap and therefore losing control over it
 	// b) plugin won't use Bitmap anyway
 	BITMAP *tempb = create_bitmap_ex(coldep, width, height);
 	clear_to_color(tempb, bitmap_mask_color(tempb));

--- a/engines/ags/shared/game/main_game_file.cpp
+++ b/engines/ags/shared/game/main_game_file.cpp
@@ -306,7 +306,7 @@ void ReadDialogs(std::vector<DialogTopic> &dialog,
 
 	// Read the dialog lines
 	//
-	// TODO: investigate this: these strings were read much simplier in the editor, see code:
+	// TODO: investigate this: these strings were read much simpler in the editor, see code:
 	/*
 	    char stringbuffer[1000];
 	    for (bb=0;bb<thisgame.numdlgmessage;bb++) {

--- a/engines/ags/shared/util/data_ext.h
+++ b/engines/ags/shared/util/data_ext.h
@@ -21,13 +21,13 @@
 
  //=============================================================================
  //
- // A simple data extension format which may be useful as an ammendment to
+ // A simple data extension format which may be useful as an amendment to
  // any data file in the game.
  //
  // Format consists of a list of "blocks", each preceded with an integer and an
  // optional string identifier, and a size in bytes which lets a reader to skip
  // the block completely if necessary.
- // Because the serialization algorithm was accomodated to be shared among
+ // Because the serialization algorithm was accommodated to be shared among
  // several existing data files, few things in the meta info may be read
  // slightly differently depending on flags passed into the function.
  //

--- a/engines/ags/tests/test_gfx.cpp
+++ b/engines/ags/tests/test_gfx.cpp
@@ -43,7 +43,7 @@ void Test_GfxSpeed(bool enableSimd, size_t blenderModeStart, size_t blenderModeE
 	uint oldSimdFlags = _G(simd_flags);
 	if (!enableSimd) _G(simd_flags) = AGS3::Globals::SIMD_NONE;
 	if (enableSimd) debug("SIMD optimizations: true\n");
-	else debug("SIMD optmizations: false\n");
+	else debug("SIMD optimizations: false\n");
 	Bitmap *benchgfx32 = BitmapHelper::CreateBitmap(100, 100, 32);
 	Bitmap *benchgfx16 = BitmapHelper::CreateBitmapCopy(benchgfx32, 16);
 	Bitmap *benchgfx8 = BitmapHelper::CreateBitmap(100, 100, 8);
@@ -250,7 +250,7 @@ void Test_BlenderModes() {
 
 void Test_GfxTransparency() {
 	// Test that every transparency which is a multiple of 10 is converted
-	// forth and back without loosing precision
+	// forth and back without losing precision
 	const size_t arr_sz = 11;
 	const int trans100[arr_sz] = { 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 };
 	int trans255[arr_sz] = { 0 };


### PR DESCRIPTION
I left out some typos in the game detection data base, since i'm pretty sure they are meant to be spelled wrong.

If not, here are my findings for anyone who wants to take a look:

/engines/ags/detection_tables.h
existance < (instead of > existence <) found on line 90 at position 5
	{ "existance", "Existance" },

/engines/ags/detection_tables.h
existance < (instead of > existence <) found on line 90 at position 18
	{ "existance", "Existance" },

/engines/ags/detection_tables.h
mistery < (instead of > mystery <) found on line 2055 at position 28
	{ "misterybigwhoop", "The Mistery of Big Whoop" },

/engines/ags/detection_tables.h
creche < (instead of > crèche <) found on line 2855 at position 39
	{ "silentnightcreche", "Silent Night Creche" },

/engines/ags/detection_tables.h
teh < (instead of > the <) found on line 3088 at position 18
	{ "tehhorror", "Teh Horror!" },

/engines/ags/detection_tables.h
extreem < (instead of > extreme <) found on line 3434 at position 39
	{ "vegetablepatch", "Vegetable Patch Extreem Turbo" },

/engines/ags/detection_tables.h
extreem < (instead of > extreme <) found on line 3435 at position 40
	{ "vegetablepatch2", "Vegetable Patch Extreem Turbo 2" },

/engines/ags/detection_tables.h
existance < (instead of > existence <) found on line 3917 at position 19
	PRE_25_ENTRY_EN("existance", "ac2game.dat", "21dbb6216639ad5817de893385c2e5b0", 420912),

/engines/ags/detection_tables.h
creche < (instead of > crèche <) found on line 8398 at position 38
	GAME_ENTRY_EN("silentnightcreche", "creche.exe", "3b7cceb3e4bdb031dc5d8f290936e94b", 2821363),

NB:
Is ScummVM aware of foreign letters?
So, at least "Silent Night Creche" could become "Silent Night Crèche" in the launcher?