### PR TITLE
JANITORIAL: AGS: Fix seeked typos

### DIFF
--- a/engines/ags/engine/ac/inv_window.cpp
+++ b/engines/ags/engine/ac/inv_window.cpp
@@ -222,7 +222,7 @@ void InventoryScreen::Prepare() {
 	// the engine to be used in the built-in inventory window.
 	// If they did not exist engine first fell back to sprites 0, 1, 2 instead.
 	// Fun fact: this fallback does not seem to be intentional, and was a
-	// coincidental result of SpriteCache incorrectly remembering "last seeked
+	// coincidental result of SpriteCache incorrectly remembering "last seek'd
 	// sprite" as 2041/2042/2043 while in fact stream was after sprite 0.
 	if (!_GP(spriteset).DoesSpriteExist(2041) || !_GP(spriteset).DoesSpriteExist(2042) || !_GP(spriteset).DoesSpriteExist(2043)) {
 		debug_script_warn("InventoryScreen: one or more of the inventory screen graphics (sprites 2041, 2042, 2043) does not exist, fallback to sprites 0, 1, 2 instead");

--- a/engines/ags/shared/util/buffered_stream.cpp
+++ b/engines/ags/shared/util/buffered_stream.cpp
@@ -147,9 +147,9 @@ int32_t BufferedStream::ReadByte() {
 size_t BufferedStream::Write(const void *buffer, size_t size) {
 	const uint8_t *from = static_cast<const uint8_t*>(buffer);
 	while (size > 0) {
-		if (_position < _bufferPosition || // seeked before buffer pos
-			_position > _bufferPosition + _buffer.size() || // seeked beyond buffer pos
-			_position >= _bufferPosition + (soff_t) BufferSize) // seeked, or exceeded buffer limit
+		if (_position < _bufferPosition || // seek'd before buffer pos
+			_position > _bufferPosition + _buffer.size() || // seek'd beyond buffer pos
+			_position >= _bufferPosition + (soff_t) BufferSize) // seek'd, or exceeded buffer limit
 		{
 			FlushBuffer(_position);
 		}


### PR DESCRIPTION
Creating it's personal PR, because i don't really have a strong opinion on this one, but it' s still wrong :-)

"seeked" is wrong, "sought" doesn't fit as it refers to the "seeking" in-code, so maybe "seek'd" would be common ground?

Feel free to reject