### PR TITLE
KYRA: Fix EoBCoreEngine::_hpIncrPerLevel table lookup

### DIFF
--- a/engines/kyra/engine/eobcommon.cpp
+++ b/engines/kyra/engine/eobcommon.cpp
@@ -1040,10 +1040,10 @@ int EoBCoreEngine::generateCharacterHitpointsByLevel(int charIndex, int levelInd
 
 		int d = getCharacterClassType(c->cClass, i);
 
-		if (c->level[i] <= _hpIncrPerLevel[6 + i])
+		if (c->level[i] <= _hpIncrPerLevel[6 + d])
 			h += rollDice(1, (d >= 0) ? _hpIncrPerLevel[d] : 0);
 		else
-			h += _hpIncrPerLevel[12 + i];
+			h += _hpIncrPerLevel[12 + d];
 
 		h += m;
 	}


### PR DESCRIPTION
KYRA: Fixed level-up hit point gain in eob

Eye of the Beholder uses a table for looking up HP gains when
characters level up. Table is EoBCoreEngine::_hpIncrPerLevel,
has 3 subsections of 6 entries each:

```
+const uint8 EoBCoreEngine::_hpIncrPerLevel[] = {
  10,   #0   # fighter HP die sides
   4,   #1   # mage HP die sides
   8,   #2   # cleric HP die sides
   6,   #3   # thief HP die sides
  10,   #4   # paladin? HP die sides
  10,   #5   # ranger? HP die sides
   9,   #6   # fighter max level to roll HP
  10,   #7   # mage max level to roll HP
   9,   #8   # cleric max level to roll HP
  10,   #9   # thief max level to roll HP
   9,  #10   # paladin? max level to roll HP 
   9,  #11   # ranger? max level to roll HP 
   3,  #12   # fighter static HP
   1,  #13   # mage static HP
   2,  #14   # cleric static HP
   2,  #15   # thief static HP
   3,  #16   # paladin? static HP
   3   #17   # ranger? static HP
};
```

The table is correct (I compared it to the original game manual).

However, when looking up max level to roll dice for HP bonus, and static HP bonuses after that level (table offsets 6 and 12 respectively), scummvm code was incorrectly using the character subclass index i (e.g. for Fighter/Thief, i = 0 for Fighter, i = 1 for Thief), instead of the character class type (fighter/mage/cleric/thief/etc.)


