### PR TITLE
SCUMM: Improve Trac#1675 and Trac#2715 bugfixes for German Indy3

### DIFF
--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -1502,9 +1502,14 @@ int ScummEngine::resStrLen(const byte *src) {
 			chr = *src++;
 			num++;
 
-			// WORKAROUND for bug #1675, a script bug in Indy3. See also
-			// the corresponding code in ScummEngine::convertMessageToString().
-			if (_game.id == GID_INDY3 && chr == 0x2E) {
+			// WORKAROUND for bugs #1675 and #2715, script bugs in German Indy3.
+			// For more information, See the the corresponding workaround in
+			// ScummEngine::convertMessageToString().
+			if (_game.id == GID_INDY3 && _language == Common::DE_DEU &&
+			    ((_roomResource == 23 && chr == 0x2E) ||
+			     (_roomResource == 21 && chr == 0x20))) {
+				num--;
+				src--;
 				continue;
 			}
 

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -1432,19 +1432,16 @@ int ScummEngine::convertMessageToString(const byte *msg, byte *dst, int dstSize)
 		if (chr == 0xFF) {
 			chr = src[num++];
 
-			// WORKAROUND for bug #1675, a script bug in Indy3. Apparently,
-			// a german 'sz' was encoded incorrectly as 0xFF2E. We replace
-			// this by the correct encoding here. See also ScummEngine::resStrLen().
-			if (_game.id == GID_INDY3 && chr == 0x2E) {
-				*dst++ = 0xE1;
-				continue;
-			}
-
-			// WORKAROUND for bug #2715: Yet another script bug in Indy3.
-			// Once more a german 'sz' was encoded incorrectly, but this time
-			// they simply encoded it as 0xFF instead of 0xE1. Happens twice
-			// in script 71.
-			if (_game.id == GID_INDY3 && chr == 0x20 && vm.slot[_currentScript].number == 71) {
+			// WORKAROUND for bugs #1675 and #2715, script bugs in German Indy3.
+			// Some German 'sz' (Eszett) characters were encoded incorrectly as
+			// 0xFF instead of 0xE1, triggering convertMessageToString() and then
+			// causing a fatal error there. We replace this by the correct encoding
+			// here. At least the DOS and Amiga German releases are affected.
+			//
+			// See also ScummEngine::resStrLen().
+			if (_game.id == GID_INDY3 && _language == Common::DE_DEU &&
+				((_roomResource == 23 && chr == 0x2E) ||
+				 (_roomResource == 21 && chr == 0x20))) {
 				num--;
 				*dst++ = 0xE1;
 				continue;


### PR DESCRIPTION
So I have now have my own (DOS) copy of the censored German release of Indy3, and I had the time to look at some of the workarounds we've added for it, nearly 20 years ago… and I've found some issues.

## Explanations

This PR does the following (just copying my own commit message):

- Fix an off-by-one in `resStrLen()` return value, and apply its workaround for [Trac#2715](https://bugs.scummvm.org/ticket/2715) too.
- Merge the two `convertMessageToString()` workarounds into a single one, and fix another off-by-one in the [Trac#1675](https://bugs.scummvm.org/ticket/1675) case.
- Restrict both workarounds to the German release of Indy3 (DOS release checked against my own copy, Amiga release tested by gabberhead).
- Restrict both workarounds to the two rooms using the wrong byte for the German Eszett character -- but don't limit it to a particular script number (i.e. intentionally drop the `vm.slot[_currentScript].number == 71` check), because the faulty lines can be triggered by some global scripts too (e.g. highlighting a dialogue option).

This should fix the following problems:

1. the use-case in [Trac#2715](https://bugs.scummvm.org/ticket/2715) still triggering a fatal `string escape sequence 32 unknown` error in `convertMessagetoString()`, when one highlights the `"Woher weiß ich, daß SIE kein Spion sind?"` line.
2. the missing full stop at the end of the `"…irgendwo hier im Schloß."` line from the drunk guard.

## Testing this PR

1. Own an original German release of Indy3
2. Load each of the savegames listed in the Trac issues above, and trigger the dialogue options which were documented there
3. Also test *highlighting* the "Woher weiß ich, daß SIE kein Spion sind?" dialogue option line from Indy: it shouldn't crash anymore.

## Particular help needed

If any of our SCUMM lords can check whether my `num--; src--;` change in `ScummEngine::resStrLen()` is alright. My brain is not the best one regarding off-by-ones ;)

If anyone has the Atari German release of Indy3, having a test there could be cool too. But so far, the result appeared to be identical between the German Amiga and DOS releases.