### PR TITLE
COMMON: Add PriorityQueue class

### DIFF
--- a/common/queue.h
+++ b/common/queue.h
@@ -23,6 +23,7 @@
 #define COMMON_QUEUE_H
 
 #include "common/scummsys.h"
+#include "common/array.h"
 #include "common/list.h"
 
 namespace Common {
@@ -84,6 +85,72 @@ public:
 
 private:
 	List<T>	_impl;
+};
+
+/**
+ * Queue ordered by a provided priority function
+ * NOTE: Unlike in the C std library, we have to provde a comparitor that sorts
+ * the array so that the smallest priority comes last
+ */
+template <class _Ty, class _Container = Common::Array<_Ty>, class _Pr = Common::Less<_Ty>>
+class PriorityQueue {
+public:
+	typedef const _Ty& const_reference;
+
+public:
+	PriorityQueue() : c(), comp() {}
+
+	explicit PriorityQueue(const _Pr &_Pred) : c(), comp(_Pred) {}
+
+	PriorityQueue(const _Pr &_Pred, const _Container &_Cont) : c(_Cont), comp(_Pred) {
+		make_heap(c.begin(), c.end(), comp);
+	}
+
+	template <class _InIt>
+	PriorityQueue(_InIt _First, _InIt _Last, const _Pr &_Pred, const _Container &_Cont) : c(_Cont), comp(_Pred) {
+		c.insert(c.end(), _First, _Last);
+		make_heap(c.begin(), c.end(), comp);
+	}
+
+	template <class _InIt>
+	PriorityQueue(_InIt _First, _InIt _Last) : c(_First, _Last), comp() {
+		make_heap(c.begin(), c.end(), comp);
+	}
+
+	template <class _InIt>
+	PriorityQueue(_InIt _First, _InIt _Last, const _Pr &_Pred) : c(_First, _Last), comp(_Pred) {
+		make_heap(c.begin(), c.end(), comp);
+	}
+
+	bool empty() const {
+		return c.empty();
+	}
+
+	size_t size() const {
+		return c.size();
+	}
+
+	const_reference top() const {
+		return c.back();
+	}
+
+	void push(const typename _Container::value_type &_Val) {
+		c.push_back(_Val);
+		Common::sort(c.begin(), c.end(), comp);
+	}
+
+	void pop() {
+		c.pop_back();
+	}
+
+	void swap(PriorityQueue &_Right) {
+		SWAP(c, _Right.c);
+		SWAP(comp, _Right.comp);
+	}
+
+protected:
+	_Container c;
+	_Pr comp;
 };
 
 /** @} */

--- a/common/queue.h
+++ b/common/queue.h
@@ -89,8 +89,8 @@ private:
 
 /**
  * Queue ordered by a provided priority function
- * NOTE: Unlike in the C std library, we have to provde a comparitor that sorts
- * the array so that the smallest priority comes last
+ * NOTE: Unlike in the C std library, we have to provide a comparator that sorts
+ * the array, so that the smallest priority comes last
  */
 template <class _Ty, class _Container = Common::Array<_Ty>, class _Pr = Common::Less<_Ty>>
 class PriorityQueue {

--- a/common/std/functional.h
+++ b/common/std/functional.h
@@ -46,6 +46,18 @@ struct binary_function { // base class for binary functions
 	using result_type = _Result;
 };
 
+// Predicate to check for x being less than y.
+template<class T>
+struct less : public binary_function<T, T, bool> {
+        bool operator()(const T &x, const T &y) const { return x < y; }
+};
+
+// Predicate to check for x being greater than y.
+template<class T>
+struct greater : public binary_function<T, T, bool> {
+        bool operator()(const T &x, const T &y) const { return x > y; }
+};
+
 template <typename _Fty>
 struct function {
 	_Fty *_fn;

--- a/common/std/queue.h
+++ b/common/std/queue.h
@@ -31,7 +31,7 @@
 #ifndef COMMON_STD_QUEUE_H
 #define COMMON_STD_QUEUE_H
 
-#include "common/std/algorithm.h"
+#include "common/std/functional.h"
 #include "common/std/vector.h"
 #include "common/queue.h"
 
@@ -40,36 +40,8 @@ namespace Std {
 template<class T>
 using queue = Common::Queue<T>;
 
-/**
- * FIXME: The current implementation requires the reverse
- * greater/lesser comparitor than the original does.
- * If this is fixed, also change the router finder's use
- */
-template<class T, class Container = vector<T>, class Comparitor = typename Common::Less<T> >
-class priority_queue {
-private:
-	Container _container;
-	Comparitor _comparitor;
-public:
-	priority_queue() {}
-
-	bool empty() const {
-		return _container.empty();
-	}
-
-	const T &top() const {
-		return _container.front();
-	}
-
-	void push(const T &item) {
-		_container.push_back(item);
-		Common::sort(_container.begin(), _container.end(), _comparitor);
-	}
-
-	void pop() {
-		_container.remove_at(0);
-	}
-};
+template<class T, class Container = vector<T>, class Comparitor = less<T> >
+using priority_queue = Common::PriorityQueue<T>;
 
 template<class T>
 class deque {

--- a/engines/ags/engine/ac/route_finder_jps.cpp
+++ b/engines/ags/engine/ac/route_finder_jps.cpp
@@ -123,7 +123,7 @@ private:
 	std::vector<NodeInfo> mapNodes;
 	tFrameId frameId;
 
-	std::priority_queue<Entry, std::vector<Entry>, Common::Less<Entry> > pq;
+	std::priority_queue<Entry, std::vector<Entry>, std::greater<Entry> > pq;
 
 	// temporary buffers:
 	mutable std::vector<int> fpath;

--- a/engines/ags/engine/ac/route_finder_jps.h
+++ b/engines/ags/engine/ac/route_finder_jps.h
@@ -119,7 +119,7 @@ private:
 	std::vector<NodeInfo> mapNodes;
 	tFrameId frameId;
 
-	std::priority_queue<Entry, std::vector<Entry>, Common::Greater<Entry> > pq;
+	std::priority_queue<Entry, std::vector<Entry>, std::greater<Entry> > pq;
 
 	// temporary buffers:
 	mutable std::vector<int> fpath;

--- a/engines/ags/globals.h
+++ b/engines/ags/globals.h
@@ -43,6 +43,7 @@
 #include "ags/engine/media/audio/audio_defines.h"
 #include "ags/engine/script/script.h"
 #include "ags/engine/script/script_runtime.h"
+#include "common/std/algorithm.h"
 #include "common/std/array.h"
 #include "common/std/chrono.h"
 #include "common/std/memory.h"

--- a/engines/twp/clipper/clipper.cpp
+++ b/engines/twp/clipper/clipper.cpp
@@ -1169,7 +1169,7 @@ void ClipperBase::Reset() {
 		return; // ie nothing to process
 	Common::sort(m_MinimaList.begin(), m_MinimaList.end(), LocMinSorter());
 
-	m_Scanbeam = ScanbeamList(); // clears/resets priority_queue
+	m_Scanbeam = ScanbeamList(); // clears/resets PriorityQueue
 	// reset all edges ...
 	for (MinimaList::iterator lm = m_MinimaList.begin(); lm != m_MinimaList.end(); ++lm) {
 		InsertScanbeam(lm->Y);

--- a/engines/twp/clipper/clipper.hpp
+++ b/engines/twp/clipper/clipper.hpp
@@ -50,6 +50,7 @@
 //#define use_deprecated
 
 #include "common/array.h"
+#include "common/queue.h"
 
 namespace ClipperLib {
 
@@ -73,72 +74,6 @@ typedef int64 long64;     //used by Int128 class
 typedef uint64 ulong64;
 
 #endif
-
-/**
- * Queue ordered by a provided priority function
- * NOTE: Unlike in the C std library, we have to provde a comparitor that sorts
- * the array so that the smallest priority comes last
- */
-template <class _Ty, class _Container = Common::Array<_Ty>, class _Pr = Common::Less<_Ty>>
-class priority_queue {
-public:
-	typedef const _Ty& const_reference;
-
-public:
-	priority_queue() : c(), comp() {}
-
-	explicit priority_queue(const _Pr &_Pred) : c(), comp(_Pred) {}
-
-	priority_queue(const _Pr &_Pred, const _Container &_Cont) : c(_Cont), comp(_Pred) {
-		make_heap(c.begin(), c.end(), comp);
-	}
-
-	template <class _InIt>
-	priority_queue(_InIt _First, _InIt _Last, const _Pr &_Pred, const _Container &_Cont) : c(_Cont), comp(_Pred) {
-		c.insert(c.end(), _First, _Last);
-		make_heap(c.begin(), c.end(), comp);
-	}
-
-	template <class _InIt>
-	priority_queue(_InIt _First, _InIt _Last) : c(_First, _Last), comp() {
-		make_heap(c.begin(), c.end(), comp);
-	}
-
-	template <class _InIt>
-	priority_queue(_InIt _First, _InIt _Last, const _Pr &_Pred) : c(_First, _Last), comp(_Pred) {
-		make_heap(c.begin(), c.end(), comp);
-	}
-
-	bool empty() const {
-		return c.empty();
-	}
-
-	size_t size() const {
-		return c.size();
-	}
-
-	const_reference top() const {
-		return c.back();
-	}
-
-	void push(const typename _Container::value_type &_Val) {
-		c.push_back(_Val);
-		Common::sort(c.begin(), c.end(), comp);
-	}
-
-	void pop() {
-		c.pop_back();
-	}
-
-	void swap(priority_queue &_Right) {
-		SWAP(c, _Right.c);
-		SWAP(comp, _Right.comp);
-	}
-
-protected:
-	_Container c;
-	_Pr comp;
-};
 
 struct IntPoint {
   cInt X;
@@ -275,7 +210,7 @@ protected:
   PolyOutList m_PolyOuts;
   TEdge *m_ActiveEdges;
 
-  typedef priority_queue<cInt> ScanbeamList;
+  typedef Common::PriorityQueue<cInt> ScanbeamList;
   ScanbeamList m_Scanbeam;
 };
 //------------------------------------------------------------------------------

--- a/engines/ultima/nuvie/pathfinder/astar_path.h
+++ b/engines/ultima/nuvie/pathfinder/astar_path.h
@@ -67,7 +67,7 @@ public:
 	}
 	sint32 step_cost(const MapCoord &c1, const MapCoord &c2) override;
 protected:
-	/* FIXME: These node functions can be replaced with a priority_queue and a list. */
+	/* FIXME: These node functions can be replaced with a PriorityQueue and a List. */
 	astar_node *find_open_node(astar_node *ncmp);
 	void push_open_node(astar_node *node);
 	astar_node *pop_open_node();

--- a/engines/ultima/shared/std/containers.h
+++ b/engines/ultima/shared/std/containers.h
@@ -87,8 +87,6 @@ public:
 		}
 	};
 public:
-	typedef T reference;
-	typedef const T const_reference;
 
 	vector() : Common::Array<T>() {}
 	vector(size_t newSize) : Common::Array<T>(newSize) {}
@@ -229,69 +227,6 @@ public:
 	reverse_iterator rend() {
 		return reverse_iterator(Common::List<T>::end());
 	}
-};
-
-/**
- * Queue ordered by a provided priority function
- * NOTE: Unlike in the C std library, we have to provde a comparitor that sorts
- * the array so that the smallest priority comes last
- */
-template <class _Ty, class _Container, class _Pr>
-class priority_queue {
-public:
-	priority_queue() : c(), comp() {}
-
-	explicit priority_queue(const _Pr &_Pred) : c(), comp(_Pred) {}
-
-	priority_queue(const _Pr &_Pred, const _Container &_Cont) : c(_Cont), comp(_Pred) {
-		make_heap(c.begin(), c.end(), comp);
-	}
-
-	template <class _InIt>
-	priority_queue(_InIt _First, _InIt _Last, const _Pr &_Pred, const _Container &_Cont) : c(_Cont), comp(_Pred) {
-		c.insert(c.end(), _First, _Last);
-		make_heap(c.begin(), c.end(), comp);
-	}
-
-	template <class _InIt>
-	priority_queue(_InIt _First, _InIt _Last) : c(_First, _Last), comp() {
-		make_heap(c.begin(), c.end(), comp);
-	}
-
-	template <class _InIt>
-	priority_queue(_InIt _First, _InIt _Last, const _Pr &_Pred) : c(_First, _Last), comp(_Pred) {
-		make_heap(c.begin(), c.end(), comp);
-	}
-
-	bool empty() const {
-		return c.empty();
-	}
-
-	size_t size() const {
-		return c.size();
-	}
-
-	typename _Container::const_reference top() const {
-		return c.back();
-	}
-
-	void push(const typename _Container::value_type &_Val) {
-		c.push_back(_Val);
-		Common::sort(c.begin(), c.end(), comp);
-	}
-
-	void pop() {
-		c.pop_back();
-	}
-
-	void swap(priority_queue &_Right) {
-		SWAP(c, _Right.c);
-		SWAP(comp, _Right.comp);
-	}
-
-protected:
-	_Container c;
-	_Pr comp;
 };
 
 } // End of namespace Std

--- a/engines/ultima/ultima8/world/actors/pathfinder.h
+++ b/engines/ultima/ultima8/world/actors/pathfinder.h
@@ -96,7 +96,7 @@ protected:
 	int32 _actorXd, _actorYd, _actorZd;
 
 	Common::Array<PathfindingState> _visited;
-	Std::priority_queue<PathNode *, Std::vector<PathNode *>, PathNodeCmp> _nodes;
+	Common::PriorityQueue<PathNode *, Std::vector<PathNode *>, PathNodeCmp> _nodes;
 
 	/** List of nodes for garbage collection later and order is not important */
 	Std::vector<PathNode *> _cleanupNodes;

--- a/engines/ultima/ultima8/world/sort_item.h
+++ b/engines/ultima/ultima8/world/sort_item.h
@@ -120,10 +120,10 @@ struct SortItem {
 
 	int32   _order;      // Rendering _order. -1 is not yet drawn
 
-	// Note that Common::PriorityQueue could be used here, BUT there is no guarentee that it's implementation
-	// will be friendly to insertions
-	// Alternatively i could use Std::list, BUT there is no guarentee that it will keep wont delete
-	// the unused nodes after doing a clear
+	// Note that Common::PriorityQueue could be used here, BUT there is no guarantee that its implementation
+	// will be friendly to insertions.
+	// Alternatively, we could use Std::list, BUT there is no guarantee that it will keep and won't delete
+	// the unused nodes, after performing a clear()
 	// So the only reasonable solution is to write my own list
 	struct DependsList {
 		struct Node {

--- a/engines/ultima/ultima8/world/sort_item.h
+++ b/engines/ultima/ultima8/world/sort_item.h
@@ -120,7 +120,7 @@ struct SortItem {
 
 	int32   _order;      // Rendering _order. -1 is not yet drawn
 
-	// Note that Std::priority_queue could be used here, BUT there is no guarentee that it's implementation
+	// Note that Common::PriorityQueue could be used here, BUT there is no guarentee that it's implementation
 	// will be friendly to insertions
 	// Alternatively i could use Std::list, BUT there is no guarentee that it will keep wont delete
 	// the unused nodes after doing a clear


### PR DESCRIPTION
This unifies the previous implementations in the Ultima8, Twp and AGS engines.

The AGS engine required some additional modifications since the implementation in `common/std` reversed the order compared to the other implementations. With this change, the pathfinding code matches the original more closely.