### PR TITLE
COMMON: Return an iterator for List::insert

### DIFF
--- a/common/list.h
+++ b/common/list.h
@@ -74,8 +74,9 @@ public:
 	/**
 	 * Insert an @p element before @p pos.
 	 */
-	void insert(iterator pos, const t_T &element) {
+	iterator insert(iterator pos, const t_T &element) {
 		insert(pos._node, element);
+		return --pos;
 	}
 
 	/**

--- a/common/std/list.h
+++ b/common/std/list.h
@@ -64,12 +64,6 @@ public:
 	}
 };
 public:
-	typename Common::List<T>::iterator insert(typename Common::List<T>::iterator pos,
-			const T &element) {
-		Common::List<T>::insert(pos, element);
-		return --pos;
-	}
-
 	reverse_iterator rbegin() {
 		return reverse_iterator(Common::List<T>::reverse_begin());
 	}

--- a/engines/ultima/shared/std/containers.h
+++ b/engines/ultima/shared/std/containers.h
@@ -217,12 +217,6 @@ public:
 		bool operator!=(const reverse_iterator &rhs) { return _it != rhs._it; }
 	};
 public:
-	typename Common::List<T>::iterator insert(typename Common::List<T>::iterator pos,
-			const T &element) {
-		Common::List<T>::insert(pos, element);
-		return pos;
-	}
-
 	reverse_iterator rbegin() {
 		return reverse_iterator(Common::List<T>::reverse_begin());
 	}

--- a/engines/ultima/ultima8/world/current_map.cpp
+++ b/engines/ultima/ultima8/world/current_map.cpp
@@ -1200,7 +1200,7 @@ bool CurrentMap::sweepTest(const Point3 &start, const Point3 &end,
 					}
 
 					// Now add it
-					sw_it = hit->insert(sw_it, SweepItem(other_item->getObjId(), first, last, touch, touch_floor, blocking, dirs));
+					hit->insert(sw_it, SweepItem(other_item->getObjId(), first, last, touch, touch_floor, blocking, dirs));
 
 					//debugC(kDebugCollision, "Hit item %u (%d, %d, %d) at first: %d, last: %d",
 					//	   other_item->getObjId(), other[0], other[1], other[2], first, last);

--- a/test/common/list.h
+++ b/test/common/list.h
@@ -100,9 +100,15 @@ class ListTestSuite : public CxxTest::TestSuite
 		++iter;
 		++iter;
 
-		// Now insert some values here
+		// Insert a value before the final one
 		container.insert(iter, 42);
-		container.insert(iter, 43);
+
+		// Insert another value before the final one and check the return value
+		iter = container.insert(iter, 43);
+		TS_ASSERT_EQUALS(*iter, 43);
+
+		// Insert a value before the previously inserted one
+		container.insert(iter, 44);
 
 		// Verify contents are correct
 		iter = container.begin();
@@ -116,6 +122,10 @@ class ListTestSuite : public CxxTest::TestSuite
 		TS_ASSERT_DIFFERS(iter, container.end());
 
 		TS_ASSERT_EQUALS(*iter, 42);
+		++iter;
+		TS_ASSERT_DIFFERS(iter, container.end());
+
+		TS_ASSERT_EQUALS(*iter, 44);
 		++iter;
 		TS_ASSERT_DIFFERS(iter, container.end());
 


### PR DESCRIPTION
This matches the C++ standard library, and removes the need for some overrides in subclasses.

The implementation in the Ultima engine didn't look correct, but it was only used in one place.