### PR TITLE
NANCY: Fix some alloc-dealloc mismatches

### DIFF
--- a/engines/nancy/cif.cpp
+++ b/engines/nancy/cif.cpp
@@ -105,7 +105,7 @@ CifFile::~CifFile() {
 }
 
 Common::SeekableReadStream *CifFile::createReadStream() const {
-	byte *buf = new byte[_info.size];
+	byte *buf = (byte *)malloc(_info.size);
 
 	bool success = true;
 
@@ -127,7 +127,8 @@ Common::SeekableReadStream *CifFile::createReadStream() const {
 
 	if (!success) {
 		warning("Failed to read data for CifFile '%s'", _info.name.toString().c_str());
-		delete[] buf;
+		free(buf);
+		buf = nullptr;
 		_stream->clearErr();
 		return nullptr;
 	}

--- a/engines/nancy/cif.cpp
+++ b/engines/nancy/cif.cpp
@@ -215,7 +215,7 @@ Common::SeekableReadStream *CifTree::createReadStreamForMember(const Common::Pat
 	}
 
 	const CifInfo &info = _fileMap[path];
-	byte *buf = new byte[info.size];
+	byte *buf = (byte *)malloc(info.size);
 
 	bool success = true;
 
@@ -237,7 +237,8 @@ Common::SeekableReadStream *CifTree::createReadStreamForMember(const Common::Pat
 
 	if (!success) {
 		warning("Failed to read data for '%s' from CifTree '%s'", info.name.toString().c_str(), _name.toString().c_str());
-		delete[] buf;
+		free(buf);
+		buf = nullptr;
 		_stream->clearErr();
 		return nullptr;
 	}

--- a/engines/nancy/commontypes.cpp
+++ b/engines/nancy/commontypes.cpp
@@ -563,7 +563,7 @@ void StaticData::readData(Common::SeekableReadStream &stream, Common::Language l
 		case MKTAG('P', 'A', 'T', 'C') :
 			// Patch file
 			patchBufSize = nextSectionOffset - stream.pos();
-			patchBuf = new byte[patchBufSize];
+			patchBuf = (byte *)malloc(patchBufSize);
 			stream.read(patchBuf, patchBufSize);
 			break;
 		case MKTAG('P', 'A', 'S', 'S') :

--- a/engines/nancy/iff.cpp
+++ b/engines/nancy/iff.cpp
@@ -111,7 +111,7 @@ Common::SeekableReadStream *IFF::getChunkStream(const Common::String &id, uint i
 	const byte *chunk = getChunk(stringToId(id), size, index);
 
 	if (chunk) {
-		byte *dup = new byte[size];
+		byte *dup = (byte *)malloc(size);
 		memcpy(dup, chunk, size);
 		return new Common::MemoryReadStream(dup, size, DisposeAfterUse::YES);
 	}


### PR DESCRIPTION
Reported by asan
@fracturehill as discussed

Edit discussed below - adding:

1. CifTree::createReadStreamForMember's `buf` is free()d by way of Common::DisposablePtr<unsigned char const, Common::MemoryReadStream::CastFreeDeleter>::~DisposablePtr()

```
ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs free) on 0x7f454e5e3800
    #0 0x7f45812b76a8 in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x562d8170717e in Common::MemoryReadStream::CastFreeDeleter::operator()(unsigned char const*) common/memstream.h:47
    #2 0x562d8170717e in Common::DisposablePtr<unsigned char const, Common::MemoryReadStream::CastFreeDeleter>::~DisposablePtr() common/ptr.h:670
    #3 0x562d81707289 in Common::MemoryReadStream::~MemoryReadStream() common/memstream.h:43
    #4 0x562d827b2b18 in Common::MemoryReadStream::~MemoryReadStream() common/memstream.h:43
    #5 0x562d8112af1c in Nancy::ResourceManager::loadImage(Common::Path const&, Graphics::ManagedSurface&, Common::String const&, Common::Rect*, Common::Rect*) engines/nancy/resource.cpp:178
    #6 0x562d816ce753 in Nancy::GraphicsManager::init() engines/nancy/graphics.cpp:64
    #7 0x562d810fea2a in Nancy::NancyEngine::bootGameEngine() engines/nancy/nancy.cpp:468
    #8 0x562d81102300 in Nancy::NancyEngine::setState(Nancy::NancyState::NancyState, Nancy::NancyState::NancyState) engines/nancy/nancy.cpp:210
    #9 0x562d8110322b in Nancy::NancyEngine::run() engines/nancy/nancy.cpp:266
    #10 0x562d8106700c in runGame base/main.cpp:311
[...]

0x7f454e5e3800 is located 0 bytes inside of 653900-byte region [0x7f454e5e3800,0x7f454e68324c)
allocated by thread T0 here:
    #0 0x7f45812b9628 in operator new[](unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:98
    #1 0x562d815ed532 in Nancy::CifTree::createReadStreamForMember(Common::Path const&) const engines/nancy/cif.cpp:219
    #2 0x562d826df0d2 in Common::SearchSet::createReadStreamForMember(Common::Path const&) const common/archive.cpp:515
    #3 0x562d81129298 in Nancy::ResourceManager::loadImage(Common::Path const&, Graphics::ManagedSurface&, Common::String const&, Common::Rect*, Common::Rect*) engines/nancy/resource.cpp:114
    #4 0x562d816ce753 in Nancy::GraphicsManager::init() engines/nancy/graphics.cpp:64
    #5 0x562d810fea2a in Nancy::NancyEngine::bootGameEngine() engines/nancy/nancy.cpp:468
    #6 0x562d81102300 in Nancy::NancyEngine::setState(Nancy::NancyState::NancyState, Nancy::NancyState::NancyState) engines/nancy/nancy.cpp:210
    #7 0x562d8110322b in Nancy::NancyEngine::run() engines/nancy/nancy.cpp:266
    #8 0x562d8106700c in runGame base/main.cpp:311
[...]
```

2. StaticData::readData's `patchBuf` is free()d by way of Common::DisposablePtr<unsigned char const, Common::MemoryReadStream::CastFreeDeleter>::~DisposablePtr()

```
ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs free) on 0x62200001f900
    #0 0x7f9791ab76a8 in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x563bc77c4052 in Common::MemoryReadStream::CastFreeDeleter::operator()(unsigned char const*) common/memstream.h:47
    #2 0x563bc77c4052 in Common::DisposablePtr<unsigned char const, Common::MemoryReadStream::CastFreeDeleter>::~DisposablePtr() common/ptr.h:670
    #3 0x563bc77c415d in Common::MemoryReadStream::~MemoryReadStream() common/memstream.h:43
    #4 0x563bc886f9ec in Common::MemoryReadStream::~MemoryReadStream() common/memstream.h:43
    #5 0x563bc76a9565 in Nancy::CifTree::~CifTree() engines/nancy/cif.cpp:185
    #6 0x563bc76b62f0 in Nancy::PatchTree::~PatchTree() engines/nancy/cif.h:117
    #7 0x563bc76b63b0 in Nancy::PatchTree::~PatchTree() engines/nancy/cif.h:117
    #8 0x563bc879700d in Common::SearchSet::clear() common/archive.cpp:396
    #9 0x563bc87a57fb in Common::SearchManager::clear() common/archive.cpp:561
    #10 0x563bc71213ff in runGame base/main.cpp:327
[...]

0x62200001f900 is located 0 bytes inside of 4938-byte region [0x62200001f900,0x622000020c4a)
allocated by thread T0 here:
    #0 0x7f9791ab9628 in operator new[](unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:98
    #1 0x563bc76d62a6 in Nancy::StaticData::readData(Common::SeekableReadStream&, Common::Language, unsigned int, signed char, signed char) engines/nancy/commontypes.cpp:566
    #2 0x563bc71b026d in Nancy::NancyEngine::readDatFile() engines/nancy/nancy.cpp:638
    #3 0x563bc71b41e2 in Nancy::NancyEngine::bootGameEngine() engines/nancy/nancy.cpp:412
    #4 0x563bc71bc300 in Nancy::NancyEngine::setState(Nancy::NancyState::NancyState, Nancy::NancyState::NancyState) engines/nancy/nancy.cpp:210
    #5 0x563bc71bd22b in Nancy::NancyEngine::run() engines/nancy/nancy.cpp:266
    #6 0x563bc712100c in runGame base/main.cpp:311
[...]
```

3. IFF::getChunkStream's `dup` is free()d by way of Common::DisposablePtr<unsigned char const, Common::MemoryReadStream::CastFreeDeleter>::~DisposablePtr()

```
ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs free) on 0x62e0004d4400
    #0 0x7fde2b8b76a8 in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x55ff38c69052 in Common::MemoryReadStream::CastFreeDeleter::operator()(unsigned char const*) common/memstream.h:47
    #2 0x55ff38c69052 in Common::DisposablePtr<unsigned char const, Common::MemoryReadStream::CastFreeDeleter>::~DisposablePtr() common/ptr.h:670
    #3 0x55ff38c6915d in Common::MemoryReadStream::~MemoryReadStream() common/memstream.h:43
    #4 0x55ff39d149ec in Common::MemoryReadStream::~MemoryReadStream() common/memstream.h:43
    #5 0x55ff38660bb4 in Nancy::NancyEngine::bootGameEngine() engines/nancy/nancy.cpp:500
    #6 0x55ff38661300 in Nancy::NancyEngine::setState(Nancy::NancyState::NancyState, Nancy::NancyState::NancyState) engines/nancy/nancy.cpp:210
    #7 0x55ff3866222b in Nancy::NancyEngine::run() engines/nancy/nancy.cpp:266
    #8 0x55ff385c600c in runGame base/main.cpp:311
[...]

0x62e0004d4400 is located 0 bytes inside of 42531-byte region [0x62e0004d4400,0x62e0004dea23)
allocated by thread T0 here:
    #0 0x7fde2b8b9628 in operator new[](unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:98
    #1 0x55ff38c41d7a in Nancy::IFF::getChunkStream(Common::String const&, unsigned int) const engines/nancy/iff.cpp:114
    #2 0x55ff38660971 in Nancy::NancyEngine::bootGameEngine() engines/nancy/nancy.cpp:498
    #3 0x55ff38661300 in Nancy::NancyEngine::setState(Nancy::NancyState::NancyState, Nancy::NancyState::NancyState) engines/nancy/nancy.cpp:210
    #4 0x55ff3866222b in Nancy::NancyEngine::run() engines/nancy/nancy.cpp:266
    #5 0x55ff385c600c in runGame base/main.cpp:311
[...]
```

4. CifFile::createReadStream's `buf` is free()d by way of Common::DisposablePtr<unsigned char const, Common::MemoryReadStream::CastFreeDeleter>::~DisposablePtr()

```
ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs free) on 0x632000240800
    #0 0x7fcc868b76a8 in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x562c18b0002a in Common::MemoryReadStream::CastFreeDeleter::operator()(unsigned char const*) common/memstream.h:47
    #2 0x562c18b0002a in Common::DisposablePtr<unsigned char const, Common::MemoryReadStream::CastFreeDeleter>::~DisposablePtr() common/ptr.h:670
    #3 0x562c18b00135 in Common::MemoryReadStream::~MemoryReadStream() common/memstream.h:43
    #4 0x562c19bab9c4 in Common::MemoryReadStream::~MemoryReadStream() common/memstream.h:43
    #5 0x562c18ad81f1 in Nancy::IFF::IFF(Common::SeekableReadStream*) engines/nancy/iff.cpp:52
    #6 0x562c18518b5f in Nancy::ResourceManager::loadIFF(Common::Path const&) engines/nancy/resource.cpp:202
    #7 0x562c184f7904 in Nancy::NancyEngine::bootGameEngine() engines/nancy/nancy.cpp:493
    #8 0x562c184f8300 in Nancy::NancyEngine::setState(Nancy::NancyState::NancyState, Nancy::NancyState::NancyState) engines/nancy/nancy.cpp:210
    #9 0x562c184f922b in Nancy::NancyEngine::run() engines/nancy/nancy.cpp:266
    #10 0x562c1845d00c in runGame base/main.cpp:311
[...]

0x632000240800 is located 0 bytes inside of 81800-byte region [0x632000240800,0x632000254788)
allocated by thread T0 here:
    #0 0x7fcc868b9628 in operator new[](unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:98
    #1 0x562c189e295d in Nancy::CifFile::createReadStream() const engines/nancy/cif.cpp:108
    #2 0x562c18518aeb in Nancy::ResourceManager::loadIFF(Common::Path const&) engines/nancy/resource.cpp:188
    #3 0x562c184f7904 in Nancy::NancyEngine::bootGameEngine() engines/nancy/nancy.cpp:493
    #4 0x562c184f8300 in Nancy::NancyEngine::setState(Nancy::NancyState::NancyState, Nancy::NancyState::NancyState) engines/nancy/nancy.cpp:210
    #5 0x562c184f922b in Nancy::NancyEngine::run() engines/nancy/nancy.cpp:266
    #6 0x562c1845d00c in runGame base/main.cpp:311
[...]
```
