### PR TITLE
TWP: bump "give" distance and handle empty text lines gracefully

### DIFF
--- a/engines/twp/motor.cpp
+++ b/engines/twp/motor.cpp
@@ -566,6 +566,11 @@ SayLineAt::SayLineAt(const Math::Vector2d &pos, const Color &color, Common::Shar
 
 void SayLineAt::say(const Common::String &text) {
 	Common::String txt(text);
+	if (txt.size() == 0) {
+		debugC(kDebugGame, "say: skipping empty line");
+		return;
+	}
+
 	if (txt[0] == '$') {
 		HSQUIRRELVM v = g_twp->getVm();
 		SQInteger top = sq_gettop(v);
@@ -662,7 +667,8 @@ void SayLineAt::onUpdate(float elapsed) {
 
 void SayLineAt::disable() {
 	Motor::disable();
-	_node->remove();
+	if (_node)
+		_node->remove();
 }
 
 Jiggle::Jiggle(Node *node, float amount) : _amount(amount), _node(node) {

--- a/engines/twp/object.cpp
+++ b/engines/twp/object.cpp
@@ -27,7 +27,7 @@
 #include "twp/squtil.h"
 
 #define MIN_TALK_DIST 60
-#define MIN_GIVE_DIST 30
+#define MIN_GIVE_DIST 35
 #define MIN_USE_DIST 15
 
 namespace Twp {


### PR DESCRIPTION
Hi!

This PR fixes two issues with TWP (GOG/1.0.958) that prevent game completion. Quoting the respective commit messages:
 
### TWP: increase maximum "give" distance

(This was reported as https://bugs.scummvm.org/ticket/15285)
 
Commit 7dd6c4ba627 (TWP: Fix give minimum distance, 2024-03-07) increased the maximum distance for allowing objects to be given from 15 to 30. This works fine for most of the game, but there is at least one instance where 30 prevents a crucial transaction: Ransome exchanging wallets with Willie. This is visible in the following debug log:
    
```
Give 'ransomeWallet' to 'willie'
exec(currentActor,9,ransomeWallet,willie)
noun1.inInventory: YES and noun1.touchable: YES nowalk: NO
walk to obj willie: (1533.000000,91.000000)
walk to obj ransome: 1503.000000,91.000000, 1
Give 'ransomeWallet' to 'willie'
actorArrived
actor arrived with facing 1
call actorArrived callback
actorArrived: exec sentence
actorArrived: noun2 min_dist: 30.265491 > 30.000000 ?
translate(@30087): Willie
sayline: ransome, @24882
talking ransome audio stopped
Give 'ransomeWallet' to 'willie'
talking ransome: @24882
Load lip RANSOME_24882.lip
Lip RANSOME_24882.lip loaded
loadActorSpeech RANSOME_24882.ogg
talking ransome audio id: 250087, dur: 1821
sayLine 'He is too far away.'
```
    
Here we can see Ransome moving within 30.27 distance units from Willie without being obstructed by anything, however this is not close enough for "give" to work. Let's bump MIN_GIVE_DIST to 35, which fixes the issue.

### TWP: ignore empty text lines
    
The SayLineAt class assumes that lines are non-empty strings and accesses the first line character liberally. There is however at least one instance of an empty line returned by the game script that causes the engine to crash:
    
```
saylineAt: (160,85) text=@25923 color=rgba(1.000000,0.800000,0.000000,1.000000) duration=5.000000
sayLine 'Long minutes of furious berry picking later...'
add breakwhilecond name=breakwhiletalking(all) pid=300115, Helpers.bnut (1103)
add breakwhilecond name=breakwhilesound(-16408) pid=300110, playBearSounds ForestMaze.bnut (444)
talking @25923: ended
Resume task: 300115, Helpers.bnut (1103)
cutsceneOverride
create cutscene override
saylineAt: (160,85) text= color=rgba(1.000000,0.800000,0.000000,1.000000) duration=0.000000
scummvm: ./common/str-base.h:183: Common::BaseString<T>::value_type Common::BaseString<T>::operator[](int) const [with T = char; value_type = char]: Assertion `idx < (int)_size' failed.
```
    
I'm not sure whether this is an engine or a game bug (GOG/1.0.958), however it seems reasonable to avoid crashing when receiving an empty line. While we could fix SayLineAt() to handle empty lines gracefully, it looks more straightforward to completely avoid using empty lines returned by the game script in the first place.

