### PR TITLE
GOB: add ADI1 to detection tables

### DIFF
--- a/engines/gob/detection/detection.h
+++ b/engines/gob/detection/detection.h
@@ -60,7 +60,8 @@ enum GameType {
 	kGameTypeOnceUponATime, // Need more inspection to see if Baba Yaga or Abracadabra
 	//kGameTypeAJWorld -> Deprecated, duplicated with kGameTypeAdibou1
 	kGameTypeCrousti = 24, // Explicit value needed to not invalidate save games after removing kGameTypeAJWorld
-	kGameTypeDynastyWood
+	kGameTypeDynastyWood,
+	kGameTypeAdi1
 };
 
 enum Features {

--- a/engines/gob/detection/tables.h
+++ b/engines/gob/detection/tables.h
@@ -67,6 +67,7 @@ static const PlainGameDescriptor gobGames[] = {
 	{"bambou", "Playtoons Limited Edition - Bambou le sauveur de la jungle"},
 	{"fascination", "Fascination"},
 	{"geisha", "Geisha"},
+	{"adi1", "ADI 1"},
 	{"adi2", "ADI 2"},
 	{"adi4", "ADI 4"},
 	{"adi5", "ADI 5"},
@@ -102,7 +103,8 @@ static const GOBGameDescription gameDescriptions[] = {
 	#include "gob/detection/tables_urban.h"     // Urban Runner
 	#include "gob/detection/tables_playtoons.h" // The Playtoons series
 	#include "gob/detection/tables_pierresmagiques.h" // Le pays des Pierres Magiques / The Land of the Magic Stones
-	#include "gob/detection/tables_adi2.h"      // The ADI / Addy 2 series
+	#include "gob/detection/tables_adi1.h"      // The ADI 1 series
+	#include "gob/detection/tables_adi2.h"      // The ADI 2 series
 	#include "gob/detection/tables_adi4.h"      // The ADI / Addy 4 series
 	#include "gob/detection/tables_adi5.h"      // The ADI / Addy 5 series
 	#include "gob/detection/tables_adibou1.h"   // Adibou 1 / A.J.'s World of Discovery / ADI Jr.

--- a/engines/gob/detection/tables_adi1.h
+++ b/engines/gob/detection/tables_adi1.h
@@ -1,0 +1,229 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * This file is dual-licensed.
+ * In addition to the GPLv3 license mentioned above, this code is also
+ * licensed under LGPL 2.1. See LICENSES/COPYING.LGPL file for the
+ * full text of the license.
+ *
+ */
+
+/* Detection tables for the ADI 1 series. */
+
+#ifndef GOB_DETECTION_TABLES_ADI1_H
+#define GOB_DETECTION_TABLES_ADI1_H
+
+// -- French: ADI --
+
+{
+	{
+		"adi1",
+		_s("Missing game code"), // CE1
+		AD_ENTRY1s("adi2.stk", "77f2b5baa30f02eecf0a94f05316c031", 334671),
+		FR_FRA,
+		kPlatformDOS,
+		ADGF_UNSUPPORTED,
+		GUIO0()
+	},
+	kFeaturesEGA,
+	"adi2.stk", "ediintro.tot", 0
+},
+{
+	{
+		"adi1",
+		_s("Missing game code"), // CE2
+		AD_ENTRY1s("adi2.stk", "1f22d389a3f0857cacb25bb174107145", 323562),
+		FR_FRA,
+		kPlatformDOS,
+		ADGF_UNSUPPORTED,
+		GUIO0()
+	},
+	kFeaturesEGA,
+	"adi2.stk", "ediintro.tot", 0
+},
+{
+	{
+		"adi1",
+		_s("Missing game code"), // CM1
+		AD_ENTRY1s("adi2.stk", "78125e8b87dad64d014648883a553b87", 327022),
+		FR_FRA,
+		kPlatformDOS,
+		ADGF_UNSUPPORTED,
+		GUIO0()
+	},
+	kFeaturesEGA,
+	"adi2.stk", "ediintro.tot", 0
+},
+{
+	{
+		"adi1",
+		_s("Missing game code"), // CM2
+		AD_ENTRY1s("adi2.stk", "9084badfe3631ece4598c4016dcee4eb", 335032),
+		FR_FRA,
+		kPlatformDOS,
+		ADGF_UNSUPPORTED,
+		GUIO0()
+	},
+	kFeaturesEGA,
+	"adi2.stk", "ediintro.tot", 0
+},
+{
+	{
+		"adi1",
+		_s("Missing game code"), // 3ème
+		AD_ENTRY1s("adi2.stk", "37de6bae596262071ad23131dc85e505", 334432),
+		FR_FRA,
+		kPlatformDOS,
+		ADGF_UNSUPPORTED,
+		GUIO0()
+	},
+	kFeaturesEGA,
+	"adi2.stk", "ediintro.tot", 0
+},
+{
+	{
+		"adi1",
+		_s("Missing game code"), // 4ème
+		AD_ENTRY1s("adi2.stk", "d662248b3b27e53fccd5355351075236", 344496),
+		FR_FRA,
+		kPlatformDOS,
+		ADGF_UNSUPPORTED,
+		GUIO0()
+	},
+	kFeaturesEGA,
+	"adi2.stk", "ediintro.tot", 0
+},
+{
+	{
+		"adi1",
+		_s("Missing game code"), // 5ème
+		AD_ENTRY1s("adi2.stk", "38ebd0ae0bdd0facee0084e305bf5152", 335780),
+		FR_FRA,
+		kPlatformDOS,
+		ADGF_UNSUPPORTED,
+		GUIO0()
+	},
+	kFeaturesEGA,
+	"adi2.stk", "ediintro.tot", 0
+},
+{
+	{
+		"adi1",
+		_s("Missing game code"), // 6ème
+		AD_ENTRY1s("adi2.stk", "2f24f14c58a062ab25dab7de8fb2489b", 335780),
+		FR_FRA,
+		kPlatformDOS,
+		ADGF_UNSUPPORTED,
+		GUIO0()
+	},
+	kFeaturesEGA,
+	"adi2.stk", "ediintro.tot", 0
+},
+{
+	{
+		"adi1",
+		_s("Missing game code"), // ADIBAC
+		AD_ENTRY1s("adi2.stk", "93377cd4582554258ed421239760a434", 307512),
+		FR_FRA,
+		kPlatformDOS,
+		ADGF_NO_FLAGS,
+		GUIO0()
+	},
+	kFeaturesEGA,
+	"adi2.stk", "ediintro.tot", 0
+},
+
+
+// -- English: ADI --
+
+{
+	{
+		"adi1",
+		_s("Missing game code"), // English 12/13
+		AD_ENTRY1s("adi2.stk", "a3e04e7c575fff9e42d6912d127c2e30", 324550),
+		EN_GRB,
+		kPlatformDOS,
+		ADGF_UNSUPPORTED,
+		GUIO0()
+	},
+	kFeaturesEGA,
+	"adi2.stk", "ediintro.tot", 0
+},
+
+// -- Italian: ADÍ --
+
+{
+	{
+		"adi1",
+		_s("Missing game code"), 
+		AD_ENTRY1s("adi2.stk", "955fd172fb2bae38e25d80e6584fca9e", 319718),
+		IT_ITA,
+		kPlatformDOS,
+		ADGF_UNSUPPORTED,
+		GUIO0()
+	},
+	kFeaturesEGA,
+	"adi2.stk", "ediintro.tot", 0
+},
+{
+	{
+		"adi1",
+		_s("Missing game code"), // Matematica 2a
+		AD_ENTRY1s("adi2.stk", "ff6bc3bd581c686a2796c4b6aee9e27d", 329888),
+		IT_ITA,
+		kPlatformDOS,
+		ADGF_UNSUPPORTED,
+		GUIO0()
+	},
+	kFeaturesEGA,
+	"adi2.stk", "ediintro.tot", 0
+},
+
+// -- Spanish: Adi --
+
+{
+	{
+		"adi1",
+		_s("Missing game code"), // Lengua Espanola 6
+		AD_ENTRY1s("adi2.stk", "bbbe5880b2f62145f8f84b63e5105c95", 317067),
+		ES_ESP,
+		kPlatformDOS,
+		ADGF_UNSUPPORTED,
+		GUIO0()
+	},
+	kFeaturesEGA,
+	"adi2.stk", "ediintro.tot", 0
+},
+{
+	{
+		"adi1",
+		_s("Missing game code"), // Lengua Espanola 8
+		AD_ENTRY1s("adi2.stk", "d5c1f812093b751a445d110734b69519", 327672),
+		ES_ESP,
+		kPlatformDOS,
+		ADGF_UNSUPPORTED,
+		GUIO0()
+	},
+	kFeaturesEGA,
+	"adi2.stk", "ediintro.tot", 0
+},
+
+
+#endif // GOB_DETECTION_TABLES_ADI1_H

--- a/engines/gob/gameidtotype.h
+++ b/engines/gob/gameidtotype.h
@@ -69,6 +69,7 @@ static const GameIdToType gameIdToType[] = {
 	{                  "bambou", kGameTypeBambou },
 	{             "fascination", kGameTypeFascination },
 	{                  "geisha", kGameTypeGeisha },
+	{                    "adi1", kGameTypeAdi1 },
 	{                    "adi2", kGameTypeAdi2 },
 	{                    "adi4", kGameTypeAdi4 },
 	{                    "adi5", kGameTypeNone },


### PR DESCRIPTION
ADI1 can be started in ScummVM. 
ADI2.STK is is the start archive name same as in ADI2. But at this Game it handles about ADI 1 and not ADI 2 to avoid confuse i want to mention it here.