### PR TITLE
COMMON: Add emplace, emplace_back, and rvalue push_back to Array

### DIFF
--- a/common/util.h
+++ b/common/util.h
@@ -211,6 +211,11 @@ constexpr remove_reference_t<T> &&move(T &&t) noexcept {
 }
 
 template<class T>
+constexpr T&& forward(remove_reference_t<T> &&t) noexcept {
+	return static_cast<T &&>(t);
+}
+
+template<class T>
 constexpr T&& forward(remove_reference_t<T> &t) noexcept {
 	return static_cast<T &&>(t);
 }


### PR DESCRIPTION
Adds a few more things to Common::Array, in particular emplace, emplace_back (which uses emplace), and rvalue push_back.  Updates both push_back versions to use emplace_back (same approach as MSVCRT).