### PR TITLE
ULTIMA: Improve detection for Ultima 8 and Crusader games

### DIFF
--- a/engines/ultima/detection.cpp
+++ b/engines/ultima/detection.cpp
@@ -65,6 +65,7 @@ UltimaMetaEngineDetection::UltimaMetaEngineDetection() : AdvancedMetaEngineDetec
 	static const char *const DIRECTORY_GLOBS[2] = { "usecode", 0 };
 	_maxScanDepth = 2;
 	_directoryGlobs = DIRECTORY_GLOBS;
+	_flags = kADFlagMatchFullPaths;
 }
 
 REGISTER_PLUGIN_STATIC(ULTIMA_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, UltimaMetaEngineDetection);

--- a/engines/ultima/detection_tables.h
+++ b/engines/ultima/detection_tables.h
@@ -184,7 +184,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"ultima8",
 			"",
-			AD_ENTRY1s("eusecode.flx", "5494165cbf4b07be04a465e28350e086", 1209018),
+			AD_ENTRY1s("usecode/eusecode.flx", "5494165cbf4b07be04a465e28350e086", 1209018),
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
@@ -199,7 +199,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"ultima8",
 			"",
-			AD_ENTRY1s("eusecode.flx", "87c8b584e2947e5e4d99bd8bff6cea2e", 1251108),
+			AD_ENTRY1s("usecode/eusecode.flx", "87c8b584e2947e5e4d99bd8bff6cea2e", 1251108),
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
@@ -214,7 +214,8 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"ultima8",
 			"Gold Edition",
-			AD_ENTRY1s("eusecode.flx", "c61f1dacde591cb39d452264e281f234", 1251108),
+			AD_ENTRY2s("usecode/eusecode.flx", "c61f1dacde591cb39d452264e281f234", 1251108,
+					   "static/eintro.skf", "b34169ece4286735262ac3430c441909", 1297731),
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
@@ -228,7 +229,8 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"ultima8",
 			"Gold Edition",
-			AD_ENTRY1s("fusecode.flx", "4017eb8678ee24af0ce8c7647a05509b", 1300957),
+			AD_ENTRY2s("usecode/fusecode.flx", "4017eb8678ee24af0ce8c7647a05509b", 1300957,
+					   "static/fintro.skf", "58990327f3e155551a69f41e7dcc0d08", 1275321),
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
@@ -242,7 +244,8 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"ultima8",
 			"Gold Edition",
-			AD_ENTRY1s("gusecode.flx", "d69599a46870b66c1b7c02710ed185bd", 1378604),
+			AD_ENTRY2s("usecode/gusecode.flx", "d69599a46870b66c1b7c02710ed185bd", 1378604,
+					   "static/gintro.skf", "4a2f3a996d13dba0528ef73264303bf5", 1264343),
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
@@ -257,7 +260,8 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"ultima8",
 			"Gold Edition",
-			AD_ENTRY1s("eusecode.flx", "cd4b330e09efd232360fd476bcc6a1d1", 1285847),
+			AD_ENTRY2s("usecode/eusecode.flx", "cd4b330e09efd232360fd476bcc6a1d1", 1285847,
+					   "static/eintro.skf", "9f8a9d95248ae3ae4b74a24ab88bf95f", 1233678),
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
@@ -272,7 +276,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"ultima8",
 			"",
-			AD_ENTRY1s("gusecode.flx", "dc981f82c6303548ad1c967cdef1a0ea", 1335445),
+			AD_ENTRY1s("usecode/gusecode.flx", "dc981f82c6303548ad1c967cdef1a0ea", 1335445),
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
@@ -287,7 +291,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"ultima8",
 			"",
-			AD_ENTRY1s("fusecode.flx", "6f7643af10bffa11debea4533ba47061", 1300957),
+			AD_ENTRY1s("usecode/fusecode.flx", "6f7643af10bffa11debea4533ba47061", 1300957),
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
@@ -301,7 +305,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"ultima8",
 			"",
-			AD_ENTRY1s("eusecode.flx", "1abad7a58e052ff3d9664df1ab2ddb86", 1136206),
+			AD_ENTRY1s("usecode/eusecode.flx", "1abad7a58e052ff3d9664df1ab2ddb86", 1136206),
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
@@ -315,7 +319,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"ultima8",
 			"",
-			AD_ENTRY1s("jusecode.flx", "1793bb252b805bf8d59300690987c605", 1208003),
+			AD_ENTRY1s("usecode/jusecode.flx", "1793bb252b805bf8d59300690987c605", 1208003),
 			Common::JA_JPN,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
@@ -333,7 +337,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"remorse",
 			"",
-			AD_ENTRY1s("eusecode.flx", "0a0f64507adc4f280129c735ee9cad42", 556613),
+			AD_ENTRY1s("usecode/eusecode.flx", "0a0f64507adc4f280129c735ee9cad42", 556613),
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_USECODE_DEFAULT,
@@ -348,7 +352,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"remorse",
 			"",
-			AD_ENTRY1s("eusecode.flx", "3fb211f4adfd80595078afc85bdfe7b4", 433143),
+			AD_ENTRY1s("usecode/eusecode.flx", "3fb211f4adfd80595078afc85bdfe7b4", 433143),
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_UNSTABLE,
@@ -363,7 +367,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"remorse",
 			"",
-			AD_ENTRY1s("eusecode.flx", "8c74327e30088ce93f08a15a7f85b3ce", 418556),
+			AD_ENTRY1s("usecode/eusecode.flx", "8c74327e30088ce93f08a15a7f85b3ce", 418556),
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_UNSTABLE | ADGF_USECODE_ORIG,
@@ -378,7 +382,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"remorse",
 			"",
-			AD_ENTRY1s("eusecode.flx", "efbd33d6a5e8f14e9c57f963c3fbe939", 423051),
+			AD_ENTRY1s("usecode/eusecode.flx", "efbd33d6a5e8f14e9c57f963c3fbe939", 423051),
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			ADGF_UNSTABLE | ADGF_USECODE_FR,
@@ -393,7 +397,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"remorse",
 			"",
-			AD_ENTRY1s("eusecode.flx", "36a16d70c97d0379f1133cc743c31313", 558493),
+			AD_ENTRY1s("usecode/eusecode.flx", "36a16d70c97d0379f1133cc743c31313", 558493),
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_USECODE_ES,
@@ -408,7 +412,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"remorse",
 			"Fan Translation",
-			AD_ENTRY1s("eusecode.flx", "a8b5c421c5d74be8c69fcd4fecadd1dd", 559015),
+			AD_ENTRY1s("usecode/eusecode.flx", "a8b5c421c5d74be8c69fcd4fecadd1dd", 559015),
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_USECODE_DEFAULT,
@@ -423,7 +427,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"remorse",
 			"",
-			AD_ENTRY1s("jusecode.flx", "088105959be4f2de1cb9e796e71c5f2d", 554522),
+			AD_ENTRY1s("usecode/jusecode.flx", "088105959be4f2de1cb9e796e71c5f2d", 554522),
 			Common::JA_JPN,
 			Common::kPlatformWindows,
 			ADGF_UNSTABLE | ADGF_USECODE_JA,
@@ -438,7 +442,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"remorse",
 			"Demo",
-			AD_ENTRY1s("eusecode.flx", "41cdca35b62f4b2a7bb4c3b1ec782423", 556613),
+			AD_ENTRY1s("usecode/eusecode.flx", "41cdca35b62f4b2a7bb4c3b1ec782423", 556613),
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_DEMO,
@@ -453,7 +457,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"regret",
 			"",
-			AD_ENTRY1s("eusecode.flx", "1bb360156b7240a1f05eb9bda01c54db", 481652),
+			AD_ENTRY1s("usecode/eusecode.flx", "1bb360156b7240a1f05eb9bda01c54db", 481652),
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_UNSTABLE | ADGF_USECODE_DEFAULT,
@@ -468,7 +472,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"regret",
 			"",
-			AD_ENTRY1s("eusecode.flx", "1824d9725de45a8b49f058c12c6cf5c3", 484445),
+			AD_ENTRY1s("usecode/eusecode.flx", "1824d9725de45a8b49f058c12c6cf5c3", 484445),
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_UNSTABLE | ADGF_USECODE_DE,
@@ -483,7 +487,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"regret",
 			"Demo",
-			AD_ENTRY1s("eusecode.flx", "c6416e4716f3c008dba113a2a460367e", 483174),
+			AD_ENTRY1s("usecode/eusecode.flx", "c6416e4716f3c008dba113a2a460367e", 483174),
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_UNSTABLE | ADGF_DEMO,
@@ -498,7 +502,7 @@ static const UltimaGameDescription GAME_DESCRIPTIONS[] = {
 		{
 			"regret",
 			"",
-			AD_ENTRY1s("eusecode.flx", "f5906654047ed1dab75760da6426ecfa", 478125),
+			AD_ENTRY1s("usecode/eusecode.flx", "f5906654047ed1dab75760da6426ecfa", 478125),
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_UNSTABLE | ADGF_USECODE_ES,


### PR DESCRIPTION
This pull request aims to improve detection for Ultima 8 and Crusader games by specifying paths to detection files and providing more entries.
For Ultima 8 the language prefixed intro movie (*intro.skf) was chosen to be the second entry. It is worth noting that French and German version also contain the English files and are detected as either.
I only have current access to the GOG / Gold CD version, so I would like to have entries for other versions added as well.

For Crusader games, I am unsure of a second entry to pick as videos may not be present until extracted, but might suggest "static/dtable.flx"

The older Ultima all appear to have flat folder structures and should not be affected by the change.
