### PR TITLE
ILLUSIONS: Add cheat debug console command

### DIFF
--- a/engines/illusions/bbdou/illusions_bbdou.cpp
+++ b/engines/illusions/bbdou/illusions_bbdou.cpp
@@ -26,6 +26,7 @@
 #include "illusions/bbdou/menusystem_bbdou.h"
 #include "illusions/actor.h"
 #include "illusions/camera.h"
+#include "illusions/console.h"
 #include "illusions/cursor.h"
 #include "illusions/dictionary.h"
 #include "illusions/fileresourcereader.h"
@@ -153,6 +154,8 @@ Common::Error IllusionsEngine_BBDOU::run() {
 	_resSys->addResourceLoader(0x00110000, new BackgroundResourceLoader(this));
 	_resSys->addResourceLoader(0x00120000, new FontResourceLoader(this));
 	_resSys->addResourceLoader(0x00170000, new SpecialCodeLoader(this));
+
+	setDebugger(new Console(this));
 
 	_screen = new Screen16Bit(this, 640, 480);
 	_screenPalette = new NullScreenPalette();

--- a/engines/illusions/console.cpp
+++ b/engines/illusions/console.cpp
@@ -1,0 +1,48 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "illusions/console.h"
+#include "illusions/illusions.h"
+#include "illusions/input.h"
+
+namespace Illusions {
+
+Console::Console(IllusionsEngine *vm) : GUI::Debugger(), _vm(vm) {
+	registerCmd("cheat", WRAP_METHOD(Console, Cmd_cheat));
+}
+
+Console::~Console() {
+}
+
+bool Console::Cmd_cheat(int argc, const char **argv) {
+	if (argc != 1) {
+		debugPrintf("Usage: %s\n", argv[0]);
+		debugPrintf("Switches on/off the cheat mode\n");
+		return true;
+	}
+
+	bool active = !_vm->_input->isCheatModeActive();
+	_vm->_input->setCheatModeActive(active);
+	debugPrintf("Cheat is now %s\n", active ? "ON" : "OFF");
+	return true;
+}
+
+} // End of namespace Illusions

--- a/engines/illusions/console.h
+++ b/engines/illusions/console.h
@@ -1,0 +1,43 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef ILLUSIONS_CONSOLE_H
+#define ILLUSIONS_CONSOLE_H
+
+#include "gui/debugger.h"
+
+namespace Illusions {
+
+class IllusionsEngine;
+
+class Console : public GUI::Debugger {
+private:
+	IllusionsEngine *_vm;
+
+	bool Cmd_cheat(int argc, const char **argv);
+public:
+	Console(IllusionsEngine *vm);
+	~Console() override;
+};
+
+} // End of namespace Illusions
+
+#endif // ILLUSIONS_CONSOLE_H

--- a/engines/illusions/duckman/illusions_duckman.cpp
+++ b/engines/illusions/duckman/illusions_duckman.cpp
@@ -28,6 +28,7 @@
 #include "illusions/duckman/duckman_videoplayer.h"
 #include "illusions/actor.h"
 #include "illusions/camera.h"
+#include "illusions/console.h"
 #include "illusions/cursor.h"
 #include "illusions/dictionary.h"
 #include "illusions/gamresourcereader.h"
@@ -101,6 +102,8 @@ Common::Error IllusionsEngine_Duckman::run() {
 	_resSys->addResourceLoader(0x00110000, new BackgroundResourceLoader(this));
 	_resSys->addResourceLoader(0x00120000, new FontResourceLoader(this));
 	_resSys->addResourceLoader(0x00190000, new GenericResourceLoader(this));
+
+	setDebugger(new Console(this));
 
 	_screen = new Screen8Bit(this, 320, 200);
 	_screenPalette = new ScreenPalette(this);

--- a/engines/illusions/input.cpp
+++ b/engines/illusions/input.cpp
@@ -249,4 +249,8 @@ bool Input::isCheatModeActive() {
 	return _cheatCodeIndex == 7;
 }
 
+void Input::setCheatModeActive(bool active) {
+	_cheatCodeIndex = active ? 7 : 0;
+}
+
 } // End of namespace Illusions

--- a/engines/illusions/input.h
+++ b/engines/illusions/input.h
@@ -91,6 +91,7 @@ public:
 	InputEvent& setInputEvent(uint evt, uint bitMask);
 	bool isCursorMovedByKeyboard() const { return _cursorMovedByKeyboard; }
 	bool isCheatModeActive();
+	void setCheatModeActive(bool active);
 protected:
 	uint _cheatCodeIndex;
 	uint _buttonStates, _newButtons, _buttonsDown;

--- a/engines/illusions/module.mk
+++ b/engines/illusions/module.mk
@@ -17,6 +17,7 @@ MODULE_OBJS := \
 	bbdou/menusystem_bbdou.o \
 	bbdou/scriptopcodes_bbdou.o \
 	camera.o \
+	console.o \
 	cursor.o \
 	dictionary.o \
 	duckman/duckman_credits.o \


### PR DESCRIPTION
As #5954 aims to add keymapper support to ILLUSIONS, it would become possible to map over the keys for the "gosanta" cheat code.
This pull requests adds a debugger console to the engine with a command to set the cheat mode.