### PR TITLE
ADL: Fix string concatenation warnings

### DIFF
--- a/engines/adl/adl.cpp
+++ b/engines/adl/adl.cpp
@@ -120,8 +120,9 @@ bool AdlEngine::pollEvent(Common::Event &event) const {
 	return false;
 }
 
-Common::String AdlEngine::readString(Common::ReadStream &stream, byte until) const {
+Common::String AdlEngine::readString(Common::ReadStream &stream, byte until, const char *key) const {
 	Common::String str;
+	int keyLength = strlen(key);
 
 	while (1) {
 		byte b = stream.readByte();
@@ -132,8 +133,11 @@ Common::String AdlEngine::readString(Common::ReadStream &stream, byte until) con
 		if (b == until)
 			break;
 
+		if (keyLength)
+			b ^= key[str.size() % keyLength];
+
 		str += b;
-	};
+	}
 
 	return str;
 }

--- a/engines/adl/adl.h
+++ b/engines/adl/adl.h
@@ -274,7 +274,7 @@ protected:
 	virtual void gameLoop();
 	virtual void loadState(Common::ReadStream &stream);
 	virtual void saveState(Common::WriteStream &stream);
-	Common::String readString(Common::ReadStream &stream, byte until = 0) const;
+	Common::String readString(Common::ReadStream &stream, byte until = 0, const char *key = "") const;
 	Common::String readStringAt(Common::SeekableReadStream &stream, uint offset, byte until = 0) const;
 	void extractExeStrings(Common::ReadStream &stream, uint16 printAddr, Common::StringArray &strings) const;
 

--- a/engines/adl/adl_v4.cpp
+++ b/engines/adl/adl_v4.cpp
@@ -175,14 +175,12 @@ void AdlEngine_v4::saveState(Common::WriteStream &stream) {
 }
 
 Common::String AdlEngine_v4::loadMessage(uint idx) const {
-	Common::String str = AdlEngine_v3::loadMessage(idx);
-
-	for (uint i = 0; i < str.size(); ++i) {
-		const char *xorStr = "AVISDURGAN";
-		str.setChar(str[i] ^ xorStr[i % strlen(xorStr)], i);
+	if (_messages[idx]) {
+		StreamPtr strStream(_messages[idx]->createReadStream());
+		return readString(*strStream, 0xff, "AVISDURGAN");
 	}
 
-	return str;
+	return Common::String();
 }
 
 Common::String AdlEngine_v4::getItemDescription(const Item &item) const {


### PR DESCRIPTION
When playing the later ADL games (Time Zone and The Dark Crystals are the ones I have), you will often see warning messages like this:

```
WARNING: Adding \0 to String. This is permitted, but can have unwanted consequences. (This warning will be removed later.)!
```

When the string class was refactored, for a while it was not permitted to add zeroes to a string. Doing so is allowed now, but still discouraged. The problem arises because the engine uses the string class to briefly store encrypted strings, which it then decrypts. With this change, the string is decrypted as it is being read, so only the decrypted string gets stored.

Note that I haven't actually played through these games. I did walk around for a bit in them, as well as Mystery House, Mission Asteroid, and The Wizard and the Princess. I didn't notice any obvious regressions.