### PR TITLE
TINSEL: Add detection for Discworld 1 Macintosh Japanese

### DIFF
--- a/engines/tinsel/detection_tables.h
+++ b/engines/tinsel/detection_tables.h
@@ -526,6 +526,24 @@ static const TinselGameDescription gameDescriptions[] = {
 		TINSEL_V1,
 	},
 
+	{	// Mac Japanese CD
+		{
+			"dw",
+			"CD",
+			AD_ENTRY2s("dw.scn", "55a11596b16130027fb28d8c203655a8", 1430841,
+					   "english.smp", NULL, AD_NO_SIZE),
+			Common::JA_JPN,
+			Common::kPlatformMacintosh,
+			ADGF_CD | ADGF_UNSTABLE,
+			GUIO0()
+		},
+		GID_DW1,
+		0,
+		GF_SCNFILES | GF_ENHANCED_AUDIO_SUPPORT,
+		TINSEL_V1,
+	},
+
+
 	{	// German CD re-release "Neon Edition"
 		// Note: This release has ENGLISH.TXT (with german content) instead of GERMAN.TXT
 		{


### PR DESCRIPTION
I managed to get an original copy of the Japanese *Macintosh* release of Discworld 1.

This PR adds a detection entry for it. Most things appear to work: subtitles, audio, playing. The cursor looks a bit wrong when you interact with an object, though:

![scummvm-dw-cd-mac-ja-00000](https://github.com/user-attachments/assets/146a8d63-508a-4fc9-b8e9-661f5500e45c)

and the inventory also gets corrupted a bit:

![scummvm-dw-cd-mac-ja-00000](https://github.com/user-attachments/assets/6ab5fae7-dc39-4cf7-96b0-cf6db98de62d)

I'm keeping the `ADGF_UNSTABLE` flag because I just played a few scenes from the first act, so I can't guarantee anything about its status (maybe it just crashes at some point later on). I don't have the time to play it more thoroughly yet, or to compare it with the original Classic interpreter, but having it in the detection tables shouldn't hurt.