### PR TITLE
JANITORIAL: DIRECTOR: Fix typos in comments

### DIFF
--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -520,7 +520,7 @@ void Channel::setEditable(bool editable) {
 }
 
 // we may optimize this by only update those attributes when we are changing them
-// but not to pass them to widgets everytime
+// but not to pass them to widgets every time
 void Channel::updateGlobalAttr() {
 	if (!_sprite->_cast)
 		return;

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -718,7 +718,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "secretwriters",		"Secret Writer's Society" },
 
 	// Shareware and freeware
-	{ "101pet",				"Dalmation Adoption" },
+	{ "101pet",				"Dalmatian Adoption" },
 	{ "50ftchicken",		"Attack of the 50-foot Chicken" },
 	{ "alanna",				"The Lost Island of Alanna" },
 	{ "antfarm",			"Ant Farm" },
@@ -7054,7 +7054,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1("shramerica", "Print Activities", "PRINTPAK.EXE", "t:bb0fd2312d141d8cc05f77eb01c54885", 917721, 501),
 	// From SHR Exploration Station, Win version is misspelled on disc
 	MACDEMO1("shramerica", "Demo", "America Rock Demo", "d7c07df0d9f0176877a3c7c095ee0143", 705417, 500),
-	WINDEMO1("shramerica", "Demo", "amercia.exe", "t:c4906b1e01232db6ae2f1e8e365d92a4", 917695, 501),
+	WINDEMO1("shramerica", "Demo", "america.exe", "t:c4906b1e01232db6ae2f1e8e365d92a4", 917695, 501),
 	// From SHR Math Rock
 	MACDEMO1("shramerica", "Demo", "America Rock Demo", "d7c07df0d9f0176877a3c7c095ee0143", 703153, 500),
 

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -7054,7 +7054,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1("shramerica", "Print Activities", "PRINTPAK.EXE", "t:bb0fd2312d141d8cc05f77eb01c54885", 917721, 501),
 	// From SHR Exploration Station, Win version is misspelled on disc
 	MACDEMO1("shramerica", "Demo", "America Rock Demo", "d7c07df0d9f0176877a3c7c095ee0143", 705417, 500),
-	WINDEMO1("shramerica", "Demo", "america.exe", "t:c4906b1e01232db6ae2f1e8e365d92a4", 917695, 501),
+	WINDEMO1("shramerica", "Demo", "amercia.exe", "t:c4906b1e01232db6ae2f1e8e365d92a4", 917695, 501),
 	// From SHR Math Rock
 	MACDEMO1("shramerica", "Demo", "America Rock Demo", "d7c07df0d9f0176877a3c7c095ee0143", 703153, 500),
 

--- a/engines/director/images.cpp
+++ b/engines/director/images.cpp
@@ -112,7 +112,7 @@ bool DIBDecoder::loadStream(Common::SeekableReadStream &stream) {
 		}
 	}
 
-	// For some reason, DIB cast members have the palette indexes reversed
+	// For some reason, DIB cast members have the palette indices reversed
 	if (_bitsPerPixel == 8) {
 		for (int y = 0; y < _surface->h; y++) {
 			for (int x = 0; x < _surface->w; x++) {

--- a/engines/director/lingo/lingo-gr.cpp
+++ b/engines/director/lingo/lingo-gr.cpp
@@ -2257,7 +2257,7 @@ yypcontext_expected_tokens (const yypcontext_t *yyctx,
   int yyn = yypact[+*yyctx->yyssp];
   if (!yypact_value_is_default (yyn))
     {
-      /* Start YYX at -YYN if negative to avoid negative indexes in
+      /* Start YYX at -YYN if negative to avoid negative indices in
          YYCHECK.  In other words, skip the first -YYN actions for
          this state because they are default actions.  */
       int yyxbegin = yyn < 0 ? -yyn : 0;

--- a/engines/director/lingo/xlibs/movemousejp.cpp
+++ b/engines/director/lingo/xlibs/movemousejp.cpp
@@ -35,7 +35,7 @@
  **************************************************/
 
 /*
--- MoveMouse . Implimented by @Sakai Youichi
+-- MoveMouse . Implemented by @Sakai Youichi
 --MoveMouse
 I      mNew                --Creates a new instance of the XObject
 X      mDispose            --Disposes of XObject instance

--- a/engines/director/lingo/xlibs/popupmenuxobj.cpp
+++ b/engines/director/lingo/xlibs/popupmenuxobj.cpp
@@ -46,7 +46,7 @@
  * --      to build the menu list for a PopUp menu.
  * --
  * --      - a menulist can be a continuous string
- * --          with items seperated by semicolons.
+ * --          with items separated by semicolons.
  * --          example: "item1;item2;item3"
  * --
  * --      - a menulist can be a set of strings, each

--- a/engines/director/resource.cpp
+++ b/engines/director/resource.cpp
@@ -662,7 +662,7 @@ bool ProjectorArchive::loadArchive(Common::SeekableReadStream *stream) {
 	tag = stream->readUint32BE();
 	found = false;
 
-	// This loop has neglible performance impact due to the stream being buffered.
+	// This loop has negligible performance impact due to the stream being buffered.
 	// Furthermore, comparing 4 bytes at a time should be pretty fast on modern systems.
 	while (!stream->eos()) {
 		if (tag == MKTAG('D', 'i', 'c', 't') || tag == MKTAG('t', 'c', 'i', 'D')) {


### PR DESCRIPTION
ok, need to get feedback on this one.

Two instances of misspelling in the detection tables
- amercia.exe (mind the character switch) from the [shramerica] director package
   i have not been able to check this, since the demo on ScummVM's download site doesn't hold that .exe file (and the game itself doesn't start anyway in win11, so anyone with more insight, please shout)
- Dalmation game (it's Dalmatian as-in the dog breed, but the misspelling seems to be consistent through package, game and ScummVM naming here...should i let this slip?)

Thank you