### PR TITLE
JANITORIAL: DM: Fix scoll typo in inventory.h

### DIFF
--- a/engines/dm/inventory.h
+++ b/engines/dm/inventory.h
@@ -76,7 +76,7 @@ public:
 	void drawPanel(); // @ F0347_INVENTORY_DrawPanel
 	void closeChest(); // @ F0334_INVENTORY_CloseChest
 	void drawPanelScrollTextLine(int16 yPos, char *text); // @ F0340_INVENTORY_DrawPanel_ScrollTextLine
-	void drawPanelScroll(Scroll *scoll); // @ F0341_INVENTORY_DrawPanel_Scroll
+	void drawPanelScroll(Scroll *scroll); // @ F0341_INVENTORY_DrawPanel_Scroll
 	void openAndDrawChest(Thing thingToOpen, Container *chest, bool isPressingEye); // @ F0333_INVENTORY_OpenAndDrawChest
 	void drawIconToViewport(IconIndice iconIndex, int16 xPos, int16 yPos); // @ F0332_INVENTORY_DrawIconToViewport
 	void buildObjectAttributeString(int16 potentialAttribMask, int16 actualAttribMask, const char ** attribStrings,


### PR DESCRIPTION
Separate PR since it touches the code, but i'm pretty sure this is an oversight, since in
inventory.cpp, line 315 it says
`void` InventoryMan::drawPanelScroll(Scroll *scroll) {