### PR TITLE
DIRECTOR/FREESCAPE: Fix -Wformat warnings on 32-bit platforms

### DIFF
--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -247,14 +247,14 @@ void Frame::readMainChannelsD2(Common::MemoryReadStreamEndian &stream, uint16 of
 			break;
 		default:
 			// This means that a `case` label has to be split at this position
-			error("Frame::readMainChannelsD2(): Miscomputed field position: %ld", stream.pos() - initPos + offset);
+			error("Frame::readMainChannelsD2(): Miscomputed field position: %lld", stream.pos() - initPos + offset);
 			break;
 		}
 	}
 
 	if (stream.pos() > finishPosition) {
 		// This means that the relevant `case` label reads too many bytes and must be split
-		error("Frame::readMainChannelsD2(): Read %ld extra bytes", stream.pos() - finishPosition);
+		error("Frame::readMainChannelsD2(): Read %lld extra bytes", stream.pos() - finishPosition);
 	}
 
 	_mainChannels.transChunkSize = CLIP<byte>(_mainChannels.transChunkSize, 0, 128);
@@ -281,7 +281,7 @@ void Frame::readSpriteD2(Common::MemoryReadStreamEndian &stream, uint16 offset, 
 
 	if (stream.pos() > finishPosition) {
 		// This means that the relevant `case` label reads too many bytes and must be split
-		error("Frame::readSpriteD2(): Read %ld extra bytes", stream.pos() - finishPosition);
+		error("Frame::readSpriteD2(): Read %lld extra bytes", stream.pos() - finishPosition);
 	}
 }
 
@@ -376,7 +376,7 @@ void readSpriteDataD2(Common::SeekableReadStreamEndian &stream, Sprite &sprite, 
 			break;
 		default:
 			// This means that a `case` label has to be split at this position
-			error("readSpriteDataD2(): Miscomputed field position: %ld", stream.pos() - startPosition);
+			error("readSpriteDataD2(): Miscomputed field position: %lld", stream.pos() - startPosition);
 		}
 	}
 
@@ -555,14 +555,14 @@ void Frame::readMainChannelsD4(Common::MemoryReadStreamEndian &stream, uint16 of
 			break;
 		default:
 			// This means that a `case` label has to be split at this position
-			error("Frame::readMainChannelsD4(): Miscomputed field position: %ld", stream.pos() - initPos + offset);
+			error("Frame::readMainChannelsD4(): Miscomputed field position: %lld", stream.pos() - initPos + offset);
 			break;
 		}
 	}
 
 	if (stream.pos() > finishPosition) {
 		// This means that the relevant `case` label reads too many bytes and must be split
-		error("Frame::readMainChannelsD4(): Read %ld extra bytes", stream.pos() - finishPosition);
+		error("Frame::readMainChannelsD4(): Read %lld extra bytes", stream.pos() - finishPosition);
 	}
 
 	_mainChannels.transChunkSize = CLIP<byte>(_mainChannels.transChunkSize, 0, 128);
@@ -589,7 +589,7 @@ void Frame::readSpriteD4(Common::MemoryReadStreamEndian &stream, uint16 offset, 
 
 	if (stream.pos() > finishPosition) {
 		// This means that the relevant `case` label reads too many bytes and must be split
-		error("Frame::readSpriteD4(): Read %ld extra bytes", stream.pos() - finishPosition);
+		error("Frame::readSpriteD4(): Read %lld extra bytes", stream.pos() - finishPosition);
 	}
 }
 
@@ -706,7 +706,7 @@ void readSpriteDataD4(Common::SeekableReadStreamEndian &stream, Sprite &sprite, 
 			break;
 		default:
 			// This means that a `case` label has to be split at this position
-			error("readSpriteDataD4(): Miscomputed field position: %ld", stream.pos() - startPosition);
+			error("readSpriteDataD4(): Miscomputed field position: %lld", stream.pos() - startPosition);
 		}
 	}
 
@@ -857,14 +857,14 @@ void Frame::readMainChannelsD5(Common::MemoryReadStreamEndian &stream, uint16 of
 			break;
 		default:
 			// This means that a `case` label has to be split at this position
-			error("Frame::readMainChannelsD5(): Miscomputed field position: %ld", stream.pos() - initPos + offset);
+			error("Frame::readMainChannelsD5(): Miscomputed field position: %lld", stream.pos() - initPos + offset);
 			break;
 		}
 	}
 
 	if (stream.pos() > finishPosition) {
 		// This means that the relevant `case` label reads too many bytes and must be split
-		error("Frame::readMainChannelsD5(): Read %ld extra bytes", stream.pos() - finishPosition);
+		error("Frame::readMainChannelsD5(): Read %lld extra bytes", stream.pos() - finishPosition);
 	}
 
 	_mainChannels.transChunkSize = CLIP<byte>(_mainChannels.transChunkSize, 0, 128);
@@ -891,7 +891,7 @@ void Frame::readSpriteD5(Common::MemoryReadStreamEndian &stream, uint16 offset, 
 
 	if (fieldPosition > finishPosition) {
 		// This means that the relevant `case` label reads too many bytes and must be split
-		error("Frame::readSpriteD5(): Read %ld extra bytes", stream.pos() - finishPosition);
+		error("Frame::readSpriteD5(): Read %lld extra bytes", stream.pos() - finishPosition);
 	}
 
 	// Sometimes removed sprites leave garbage in the channel
@@ -1026,7 +1026,7 @@ void readSpriteDataD5(Common::SeekableReadStreamEndian &stream, Sprite &sprite, 
 			break;
 		default:
 			// This means that a `case` label has to be split at this position
-			error("readSpriteDataD5(): Miscomputed field position: %ld", stream.pos() - startPosition);
+			error("readSpriteDataD5(): Miscomputed field position: %lld", stream.pos() - startPosition);
 		}
 	}
 
@@ -1089,7 +1089,7 @@ void Frame::readSpriteD6(Common::MemoryReadStreamEndian &stream, uint16 offset, 
 
 	if (stream.pos() > finishPosition) {
 		// This means that the relevant `case` label reads too many bytes and must be split
-		error("Frame::readSpriteD6(): Read %ld extra bytes", stream.pos() - finishPosition);
+		error("Frame::readSpriteD6(): Read %lld extra bytes", stream.pos() - finishPosition);
 	}
 
 	// Sometimes removed sprites leave garbage in the channel
@@ -1226,7 +1226,7 @@ void readSpriteDataD6(Common::SeekableReadStreamEndian &stream, Sprite &sprite, 
 			break;
 		default:
 			// This means that a `case` label has to be split at this position
-			error("readSpriteDataD6(): Miscomputed field position: %ld", stream.pos() - startPosition);
+			error("readSpriteDataD6(): Miscomputed field position: %lld", stream.pos() - startPosition);
 		}
 	}
 }

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -1677,13 +1677,13 @@ void Score::loadFrames(Common::SeekableReadStreamEndian &stream, uint16 version)
 }
 
 bool Score::loadFrame(int frameNum, bool loadCast) {
-	debugC(7, kDebugLoading, "****** Frame request %d, current pos: %ld, current frame number: %d", frameNum, _framesStream->pos(), _curFrameNumber);
+	debugC(7, kDebugLoading, "****** Frame request %d, current pos: %lld, current frame number: %d", frameNum, _framesStream->pos(), _curFrameNumber);
 
 	int sourceFrame = _curFrameNumber;
 	int targetFrame = frameNum;
 
 	if (frameNum <= (int)_curFrameNumber) {
-		debugC(7, kDebugLoading, "****** Resetting frame %d to start %ld", sourceFrame, _framesStream->pos());
+		debugC(7, kDebugLoading, "****** Resetting frame %d to start %lld", sourceFrame, _framesStream->pos());
 		// If we are going back, we need to rebuild frames from start
 		_currentFrame->reset();
 		sourceFrame = 0;
@@ -1696,7 +1696,7 @@ bool Score::loadFrame(int frameNum, bool loadCast) {
 			it->reset();
 	}
 
-	debugC(7, kDebugLoading, "****** Source frame %d to Destination frame %d, current offset %ld", sourceFrame, targetFrame, _framesStream->pos());
+	debugC(7, kDebugLoading, "****** Source frame %d to Destination frame %d, current offset %lld", sourceFrame, targetFrame, _framesStream->pos());
 
 	while (sourceFrame < targetFrame - 1 && readOneFrame()) {
 		sourceFrame++;

--- a/engines/freescape/games/castle/castle.cpp
+++ b/engines/freescape/games/castle/castle.cpp
@@ -359,7 +359,7 @@ void CastleEngine::loadRiddles(Common::SeekableReadStream *file, int offset, int
 		}
 
 	}
-	debugC(1, kFreescapeDebugParser, "End of riddles at %lx", file->pos());
+	debugC(1, kFreescapeDebugParser, "End of riddles at %llx", file->pos());
 }
 
 void CastleEngine::drawFullscreenRiddleAndWait(uint16 riddle) {

--- a/engines/freescape/games/castle/dos.cpp
+++ b/engines/freescape/games/castle/dos.cpp
@@ -72,7 +72,7 @@ void CastleEngine::loadDOSFonts(Common::SeekableReadStream *file, int pos) {
 		}
 		//debugN("\n");
 	}
-	debug("%lx", file->pos());
+	debug("%llx", file->pos());
 	_fontPlane1.set_size(64 * 59);
 	_fontPlane1.set_bits(bufferPlane1);
 

--- a/engines/freescape/games/palettes.cpp
+++ b/engines/freescape/games/palettes.cpp
@@ -145,7 +145,7 @@ void FreescapeEngine::loadPalettes(Common::SeekableReadStream *file, int offset)
 		if (label == 255)
 			break;
 		auto palette = new byte[16][3];
-		debugC(1, kFreescapeDebugParser, "Loading palette for area: %d at %lx", label, file->pos());
+		debugC(1, kFreescapeDebugParser, "Loading palette for area: %d at %llx", label, file->pos());
 		for (int c = 0; c < 16; c++) {
 			int v = file->readUint16BE();
 			r = (v & 0xf00) >> 8;

--- a/engines/freescape/loaders/8bitBinaryLoader.cpp
+++ b/engines/freescape/loaders/8bitBinaryLoader.cpp
@@ -664,7 +664,7 @@ Area *FreescapeEngine::load8bitArea(Common::SeekableReadStream *file, uint16 nco
 	}
 
 	int64 endLastObject = file->pos();
-	debugC(1, kFreescapeDebugParser, "Last position %lx", endLastObject);
+	debugC(1, kFreescapeDebugParser, "Last position %llx", endLastObject);
 	debugC(1, kFreescapeDebugParser, "endLastObject is supposed to be %x", base + cPtr);
 	if ((isDark() || isEclipse()) && (isAmiga() || isAtariST()))
 		assert(endLastObject <= static_cast<int64>(base + cPtr) + 4);

--- a/engines/freescape/loaders/8bitImage.cpp
+++ b/engines/freescape/loaders/8bitImage.cpp
@@ -105,7 +105,7 @@ Graphics::ManagedSurface *FreescapeEngine::load8bitBinImage(Common::SeekableRead
 		load8bitBinImageRow(file, surface, row);
 
 	assert(startImage + imageSize == file->pos());
-	debugC(1, kFreescapeDebugParser, "Last position: %lx", file->pos());
+	debugC(1, kFreescapeDebugParser, "Last position: %llx", file->pos());
 	return surface;
 }
 

--- a/engines/freescape/sound.cpp
+++ b/engines/freescape/sound.cpp
@@ -530,7 +530,7 @@ void FreescapeEngine::loadSoundsFx(Common::SeekableReadStream *file, int offset,
 		assert(zero == 0);
 		int size = file->readUint16BE();
 		int sampleRate = file->readUint16BE();
-		debugC(1, kFreescapeDebugParser, "Loading sound: %d (size: %d, sample rate: %d) at %lx", i, size, sampleRate, file->pos());
+		debugC(1, kFreescapeDebugParser, "Loading sound: %d (size: %d, sample rate: %d) at %llx", i, size, sampleRate, file->pos());
 		byte *data = (byte *)malloc(size * sizeof(byte));
 		file->read(data, size);
 		sound->sampleRate = sampleRate;


### PR DESCRIPTION
The following PR fixes GCC `-Wformat` warnings on 32-bits platforms in the DIRECTOR and FREESCAPE engines.

It's just a switch from `%ld` to `%lld` for int64 types.

Any objection?