### PR TITLE
AGS/GLK: Fixes for ports having 'char' unsigned by default

### DIFF
--- a/engines/ags/engine/ac/game_setup.h
+++ b/engines/ags/engine/ac/game_setup.h
@@ -100,7 +100,7 @@ struct GameSetup {
 
 	// User's overrides and hacks
 	int   override_script_os; // pretend engine is running on this eScriptSystemOSID
-	char  override_multitasking; // -1 for none, 0 or 1 to lock in the on/off mode
+	signed char  override_multitasking; // -1 for none, 0 or 1 to lock in the on/off mode
 	bool  override_upscale; // whether upscale old games that supported that
 	// assume game data version when restoring legacy save format
 	GameDataVersion legacysave_assume_dataver = kGameVersion_Undefined;

--- a/engines/glk/tads/tads2/qa_scriptor.cpp
+++ b/engines/glk/tads/tads2/qa_scriptor.cpp
@@ -63,7 +63,7 @@ char *qasgets(char *buf, int bufl) {
 	/* keep going until we find something we like */
 	for (;;)
 	{
-		char c;
+		int c;
 
 		/*
 		 *   Read the next character of input.  If it's not a newline,
@@ -104,7 +104,7 @@ char *qasgets(char *buf, int bufl) {
 				/* return the command */
 				return buf;
 			}
-		} else if ((int)c == EOF) {
+		} else if (c == EOF) {
 			/* end of file - close the script and return eof */
 			qasclose();
 			return nullptr;


### PR DESCRIPTION
Some ports, such as OSX PPC or (AFAICS) AmigaOS, have `char` being unsigned by default.

Doing [an AmigaOS build](https://wiki.scummvm.org/index.php?title=Compiling_ScummVM/Docker) for the AGS or GLK engine, or looking at [the buildbot logs for it](https://buildbot.scummvm.org/#/builders/58/builds/11522), reveals a couple of issues with the AGS and GLK engines:

```
    C++      engines/ags/engine/ac/global_game.o
engines/ags/engine/ac/global_game.cpp: In function 'void AGS3::SetMultitasking(int)':
engines/ags/engine/ac/global_game.cpp:670:41: warning: comparison is always true due to limited range of data type [-Wtype-limits]
  if ((_GP(usetup).override_multitasking >= 0) && (mode != _GP(usetup).override_multitasking)) {


    C++      engines/glk/tads/tads2/qa_scriptor.o
engines/glk/tads/tads2/qa_scriptor.cpp: In function 'char* Glk::TADS::TADS2::qasgets(char*, int)':
engines/glk/tads/tads2/qa_scriptor.cpp:107:21: warning: comparison is always false due to limited range of data type [-Wtype-limits]
   } else if ((int)c == EOF) {
                     ^

```

The commits below should fix this and be pretty self-explanatory.