### PR TITLE
ULTIMA: NUVIE: Fix loading lua scripts on Windows

### DIFF
--- a/engines/ultima/nuvie/script/script.cpp
+++ b/engines/ultima/nuvie/script/script.cpp
@@ -904,7 +904,7 @@ bool Script::init() {
 
 	if (run_script(init_str.c_str()) == false) {
 		Std::string errorStr = "Loading ";
-		errorStr.append(path.toString());
+		errorStr.append(path.toString('/'));
 		ConsoleAddError(errorStr);
 		return false;
 	}
@@ -1399,12 +1399,12 @@ bool Script::run_lua_file(const char *filename) {
 	dir = path;
 	build_path(dir, filename, path);
 
-	if (luaL_loadfile(L, path.toString(Common::Path::kNativeSeparator).c_str()) != 0) {
-		DEBUG(0, LEVEL_ERROR, "loading script file %s", path.toString(Common::Path::kNativeSeparator).c_str());
+	if (luaL_loadfile(L, path.toString('/').c_str()) != 0) {
+		DEBUG(0, LEVEL_ERROR, "loading script file %s", path.toString('/').c_str());
 		return false;
 	}
 
-	return call_function(path.toString(Common::Path::kNativeSeparator).c_str(), 0, 0);
+	return call_function(path.toString('/').c_str(), 0, 0);
 }
 
 bool Script::call_moonstone_set_loc(uint8 phase, MapCoord location) {
@@ -2365,7 +2365,7 @@ static int nscript_load(lua_State *L) {
 	dir = path;
 	build_path(dir, file, path);
 
-	if (luaL_loadfile(L, path.toString(Common::Path::kNativeSeparator).c_str()) == LUA_ERRFILE) {
+	if (luaL_loadfile(L, path.toString('/').c_str()) == LUA_ERRFILE) {
 		lua_pop(L, 1);
 		return 0;
 	}


### PR DESCRIPTION
LUA seems to expect a "/" (POSIX) path separator, so using Common::Path::kNativeSeparator made engine unable to find the lua scripts on Windows

The issue was reported on ScummVM discord for Ultima 6 here: https://discord.com/channels/581224060529148060/581224061091446795/1269230221500878881

I've only tested on Windows with latest code from master HEAD (testing with the Ultima 6 version of the game on GOG and our ultima.dat distributable file).
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
