### PR TITLE
TETRAEDGE: Switch from Common::FSNode to Common::Path

### DIFF
--- a/engines/tetraedge/game/amerzone_game.cpp
+++ b/engines/tetraedge/game/amerzone_game.cpp
@@ -124,7 +124,7 @@ bool AmerzoneGame::changeWarp(const Common::String &rawZone, const Common::Strin
 
 	dotpos = sceneXml.rfind('.');
 	Common::String sceneLua = sceneXml.substr(0, dotpos) + ".lua";
-	_luaScript.load(core->findFileNew(zone.getParent().appendComponent(sceneLua)));
+	_luaScript.load(core->findFile(zone.getParent().appendComponent(sceneLua)));
 	_luaScript.execute();
 	_luaScript.execute("OnWarpEnter");
 	if (fadeFlag) {

--- a/engines/tetraedge/game/amerzone_game.cpp
+++ b/engines/tetraedge/game/amerzone_game.cpp
@@ -124,7 +124,7 @@ bool AmerzoneGame::changeWarp(const Common::String &rawZone, const Common::Strin
 
 	dotpos = sceneXml.rfind('.');
 	Common::String sceneLua = sceneXml.substr(0, dotpos) + ".lua";
-	_luaScript.load(core->findFile(zone.getParent().appendComponent(sceneLua)));
+	_luaScript.load(core->findFileNew(zone.getParent().appendComponent(sceneLua)));
 	_luaScript.execute();
 	_luaScript.execute("OnWarpEnter");
 	if (fadeFlag) {

--- a/engines/tetraedge/game/amerzone_game.cpp
+++ b/engines/tetraedge/game/amerzone_game.cpp
@@ -123,8 +123,7 @@ bool AmerzoneGame::changeWarp(const Common::String &rawZone, const Common::Strin
 	_yAngleMax = _orientationY + 55.0f;
 
 	dotpos = sceneXml.rfind('.');
-	Common::String sceneLua = sceneXml.substr(0, dotpos);
-	sceneLua += ".lua";
+	Common::String sceneLua = sceneXml.substr(0, dotpos) + ".lua";
 	_luaScript.load(core->findFile(zone.getParent().appendComponent(sceneLua)));
 	_luaScript.execute();
 	_luaScript.execute("OnWarpEnter");

--- a/engines/tetraedge/game/application.cpp
+++ b/engines/tetraedge/game/application.cpp
@@ -122,20 +122,20 @@ void Application::create() {
 	TeCore *core = g_engine->getCore();
 	// Cache some fonts
 	if (g_engine->gameIsAmerzone()) {
-		resmgr->getResource<TeFont2>(core->findFileNew("Common/Fonts/Arial_r_10.tef"));
-		resmgr->getResource<TeFont2>(core->findFileNew("Common/Fonts/Arial_r_12.tef"));
-		resmgr->getResource<TeFont2>(core->findFileNew("Common/Fonts/Arial_r_16.tef"));
-		resmgr->getResource<TeFont2>(core->findFileNew("Common/Fonts/Colaborate-Regular_r_16.tef"));
-		resmgr->getResource<TeFont2>(core->findFileNew("Common/Fonts/Colaborate-Regular_r_24.tef"));
-		resmgr->getResource<TeFont2>(core->findFileNew("Common/Fonts/Credits.tef"));
-		resmgr->getResource<TeFont2>(core->findFileNew("Common/Fonts/FontLoadingMenu.tef"));
+		resmgr->getResource<TeFont2>(core->findFile("Common/Fonts/Arial_r_10.tef"));
+		resmgr->getResource<TeFont2>(core->findFile("Common/Fonts/Arial_r_12.tef"));
+		resmgr->getResource<TeFont2>(core->findFile("Common/Fonts/Arial_r_16.tef"));
+		resmgr->getResource<TeFont2>(core->findFile("Common/Fonts/Colaborate-Regular_r_16.tef"));
+		resmgr->getResource<TeFont2>(core->findFile("Common/Fonts/Colaborate-Regular_r_24.tef"));
+		resmgr->getResource<TeFont2>(core->findFile("Common/Fonts/Credits.tef"));
+		resmgr->getResource<TeFont2>(core->findFile("Common/Fonts/FontLoadingMenu.tef"));
 	} else {
-		_fontComic = resmgr->getResource<TeFont3>(core->findFileNew("Common/Fonts/ComicRelief.ttf"));
-		_fontArgh = resmgr->getResource<TeFont3>(core->findFileNew("Common/Fonts/Argh.ttf"));
-		_fontArial = resmgr->getResource<TeFont3>(core->findFileNew("Common/Fonts/arial.ttf"));
-		_fontChaucer = resmgr->getResource<TeFont3>(core->findFileNew("Common/Fonts/CHAUCER.TTF"));
-		_fontColaborate = resmgr->getResource<TeFont3>(core->findFileNew("Common/Fonts/Colaborate-Regular.otf"));
-		_fontProDisplay = resmgr->getResource<TeFont3>(core->findFileNew("Common/Fonts/ProDisplay.ttf"));
+		_fontComic = resmgr->getResource<TeFont3>(core->findFile("Common/Fonts/ComicRelief.ttf"));
+		_fontArgh = resmgr->getResource<TeFont3>(core->findFile("Common/Fonts/Argh.ttf"));
+		_fontArial = resmgr->getResource<TeFont3>(core->findFile("Common/Fonts/arial.ttf"));
+		_fontChaucer = resmgr->getResource<TeFont3>(core->findFile("Common/Fonts/CHAUCER.TTF"));
+		_fontColaborate = resmgr->getResource<TeFont3>(core->findFile("Common/Fonts/Colaborate-Regular.otf"));
+		_fontProDisplay = resmgr->getResource<TeFont3>(core->findFile("Common/Fonts/ProDisplay.ttf"));
 	}
 
 	// The app prebuilds some fonts.. cover letters, numbers, a few accented chars, and punctuation.
@@ -170,7 +170,7 @@ void Application::create() {
 	int i = 0;
 	Common::Path textFilePath;
 	while (i < ARRAYSIZE(allLangs)) {
-		textFilePath = core->findFileNew(textsPath.join(core->language() + ".xml"));
+		textFilePath = core->findFile(textsPath.join(core->language() + ".xml"));
 		if (Common::File::exists(textFilePath))
 			break;
 		core->language(allLangs[i]);

--- a/engines/tetraedge/game/application.cpp
+++ b/engines/tetraedge/game/application.cpp
@@ -122,20 +122,20 @@ void Application::create() {
 	TeCore *core = g_engine->getCore();
 	// Cache some fonts
 	if (g_engine->gameIsAmerzone()) {
-		resmgr->getResource<TeFont2>(core->findFile("Common/Fonts/Arial_r_10.tef"));
-		resmgr->getResource<TeFont2>(core->findFile("Common/Fonts/Arial_r_12.tef"));
-		resmgr->getResource<TeFont2>(core->findFile("Common/Fonts/Arial_r_16.tef"));
-		resmgr->getResource<TeFont2>(core->findFile("Common/Fonts/Colaborate-Regular_r_16.tef"));
-		resmgr->getResource<TeFont2>(core->findFile("Common/Fonts/Colaborate-Regular_r_24.tef"));
-		resmgr->getResource<TeFont2>(core->findFile("Common/Fonts/Credits.tef"));
-		resmgr->getResource<TeFont2>(core->findFile("Common/Fonts/FontLoadingMenu.tef"));
+		resmgr->getResource<TeFont2>(core->findFileNew("Common/Fonts/Arial_r_10.tef"));
+		resmgr->getResource<TeFont2>(core->findFileNew("Common/Fonts/Arial_r_12.tef"));
+		resmgr->getResource<TeFont2>(core->findFileNew("Common/Fonts/Arial_r_16.tef"));
+		resmgr->getResource<TeFont2>(core->findFileNew("Common/Fonts/Colaborate-Regular_r_16.tef"));
+		resmgr->getResource<TeFont2>(core->findFileNew("Common/Fonts/Colaborate-Regular_r_24.tef"));
+		resmgr->getResource<TeFont2>(core->findFileNew("Common/Fonts/Credits.tef"));
+		resmgr->getResource<TeFont2>(core->findFileNew("Common/Fonts/FontLoadingMenu.tef"));
 	} else {
-		_fontComic = resmgr->getResource<TeFont3>(core->findFile("Common/Fonts/ComicRelief.ttf"));
-		_fontArgh = resmgr->getResource<TeFont3>(core->findFile("Common/Fonts/Argh.ttf"));
-		_fontArial = resmgr->getResource<TeFont3>(core->findFile("Common/Fonts/arial.ttf"));
-		_fontChaucer = resmgr->getResource<TeFont3>(core->findFile("Common/Fonts/CHAUCER.TTF"));
-		_fontColaborate = resmgr->getResource<TeFont3>(core->findFile("Common/Fonts/Colaborate-Regular.otf"));
-		_fontProDisplay = resmgr->getResource<TeFont3>(core->findFile("Common/Fonts/ProDisplay.ttf"));
+		_fontComic = resmgr->getResource<TeFont3>(core->findFileNew("Common/Fonts/ComicRelief.ttf"));
+		_fontArgh = resmgr->getResource<TeFont3>(core->findFileNew("Common/Fonts/Argh.ttf"));
+		_fontArial = resmgr->getResource<TeFont3>(core->findFileNew("Common/Fonts/arial.ttf"));
+		_fontChaucer = resmgr->getResource<TeFont3>(core->findFileNew("Common/Fonts/CHAUCER.TTF"));
+		_fontColaborate = resmgr->getResource<TeFont3>(core->findFileNew("Common/Fonts/Colaborate-Regular.otf"));
+		_fontProDisplay = resmgr->getResource<TeFont3>(core->findFileNew("Common/Fonts/ProDisplay.ttf"));
 	}
 
 	// The app prebuilds some fonts.. cover letters, numbers, a few accented chars, and punctuation.

--- a/engines/tetraedge/game/application.cpp
+++ b/engines/tetraedge/game/application.cpp
@@ -168,10 +168,10 @@ void Application::create() {
 
 	// Try alternate langs..
 	int i = 0;
-	Common::FSNode textFileNode;
+	Common::Path textFilePath;
 	while (i < ARRAYSIZE(allLangs)) {
-		textFileNode = core->findFile(textsPath.join(core->language() + ".xml"));
-		if (textFileNode.isReadable())
+		textFilePath = core->findFileNew(textsPath.join(core->language() + ".xml"));
+		if (Common::File::exists(textFilePath))
 			break;
 		core->language(allLangs[i]);
 		i++;
@@ -180,7 +180,7 @@ void Application::create() {
 		error("Couldn't find texts/[lang].xml for any language.");
 	}
 
-	_loc.load(textFileNode);
+	_loc.load(textFilePath);
 	core->addLoc(&_loc);
 
 	if (!g_engine->gameIsAmerzone()) {

--- a/engines/tetraedge/game/billboard.cpp
+++ b/engines/tetraedge/game/billboard.cpp
@@ -37,7 +37,7 @@ bool Billboard::load(const Common::Path &path) {
 	TeIntrusivePtr<Te3DTexture> texture = Te3DTexture::makeInstance();
 	SyberiaGame *game = dynamic_cast<SyberiaGame *>(g_engine->getGame());
 	TeCore *core = g_engine->getCore();
-	Common::Path texPath = core->findFileNew(game->sceneZonePath().join(path));
+	Common::Path texPath = core->findFile(game->sceneZonePath().join(path));
 	texture->load(texPath);
 	_model->setName(path.toString('/'));
 	Common::Array<TeVector3f32> quad;

--- a/engines/tetraedge/game/billboard.cpp
+++ b/engines/tetraedge/game/billboard.cpp
@@ -37,8 +37,8 @@ bool Billboard::load(const Common::Path &path) {
 	TeIntrusivePtr<Te3DTexture> texture = Te3DTexture::makeInstance();
 	SyberiaGame *game = dynamic_cast<SyberiaGame *>(g_engine->getGame());
 	TeCore *core = g_engine->getCore();
-	Common::FSNode texnode = core->findFile(game->sceneZonePath().join(path));
-	texture->load(texnode);
+	Common::Path texPath = core->findFileNew(game->sceneZonePath().join(path));
+	texture->load(texPath);
 	_model->setName(path.toString('/'));
 	Common::Array<TeVector3f32> quad;
 	quad.resize(4);

--- a/engines/tetraedge/game/character.cpp
+++ b/engines/tetraedge/game/character.cpp
@@ -420,7 +420,7 @@ bool Character::loadModel(const Common::String &mname, bool unused) {
 		// Only Syberia 1 has the simple shadow.
 		TeIntrusivePtr<Te3DTexture> shadow = Te3DTexture::makeInstance();
 		TeCore *core = g_engine->getCore();
-		shadow->load(core->findFileNew("models/Textures/simple_shadow_alpha.tga"));
+		shadow->load(core->findFile("models/Textures/simple_shadow_alpha.tga"));
 
 		for (int i = 0; i < 2; i++) {
 			TeModel *pmodel = new TeModel();
@@ -1122,7 +1122,7 @@ Character::Water::Water() {
 	quad[3] = camMatrix.mult3x3(TeVector3f32( 0.1f, 0.0f, -0.1f));
 	const TeQuaternion noRot = TeQuaternion::fromEuler(TeVector3f32(0, 0, 0));
 	TeIntrusivePtr<Te3DTexture> tex = Te3DTexture::makeInstance();
-	tex->load(g_engine->getCore()->findFileNew("texturesIngame/EauOndine1.tga"));
+	tex->load(g_engine->getCore()->findFile("texturesIngame/EauOndine1.tga"));
 	_model->setQuad(tex, quad, TeColor(255, 0, 0, 0));
 	_model->setRotation(noRot);
 	_model->setScale(TeVector3f32(0.5, 0.5, 0.5));

--- a/engines/tetraedge/game/character.cpp
+++ b/engines/tetraedge/game/character.cpp
@@ -420,7 +420,7 @@ bool Character::loadModel(const Common::String &mname, bool unused) {
 		// Only Syberia 1 has the simple shadow.
 		TeIntrusivePtr<Te3DTexture> shadow = Te3DTexture::makeInstance();
 		TeCore *core = g_engine->getCore();
-		shadow->load(core->findFile("models/Textures/simple_shadow_alpha.tga"));
+		shadow->load(core->findFileNew("models/Textures/simple_shadow_alpha.tga"));
 
 		for (int i = 0; i < 2; i++) {
 			TeModel *pmodel = new TeModel();
@@ -1122,7 +1122,7 @@ Character::Water::Water() {
 	quad[3] = camMatrix.mult3x3(TeVector3f32( 0.1f, 0.0f, -0.1f));
 	const TeQuaternion noRot = TeQuaternion::fromEuler(TeVector3f32(0, 0, 0));
 	TeIntrusivePtr<Te3DTexture> tex = Te3DTexture::makeInstance();
-	tex->load(g_engine->getCore()->findFile("texturesIngame/EauOndine1.tga"));
+	tex->load(g_engine->getCore()->findFileNew("texturesIngame/EauOndine1.tga"));
 	_model->setQuad(tex, quad, TeColor(255, 0, 0, 0));
 	_model->setRotation(noRot);
 	_model->setScale(TeVector3f32(0.5, 0.5, 0.5));

--- a/engines/tetraedge/game/document.cpp
+++ b/engines/tetraedge/game/document.cpp
@@ -38,7 +38,7 @@ void Document::load(const Common::String &name) {
 	addChild(_gui.layoutChecked("object"));
 	setName(name);
 	const Common::Path sprPath = spritePath();
-	_gui.spriteLayoutChecked("upLayout")->load(g_engine->getCore()->findFile(sprPath));
+	_gui.spriteLayoutChecked("upLayout")->load(g_engine->getCore()->findFileNew(sprPath));
 	_gui.buttonLayoutChecked("object")->onMouseClickValidated().add(this, &Document::onButtonDown);
 	TeITextLayout *txtLayout = _gui.textLayout("text");
 	if (!txtLayout)

--- a/engines/tetraedge/game/document.cpp
+++ b/engines/tetraedge/game/document.cpp
@@ -38,7 +38,7 @@ void Document::load(const Common::String &name) {
 	addChild(_gui.layoutChecked("object"));
 	setName(name);
 	const Common::Path sprPath = spritePath();
-	_gui.spriteLayoutChecked("upLayout")->load(g_engine->getCore()->findFileNew(sprPath));
+	_gui.spriteLayoutChecked("upLayout")->load(g_engine->getCore()->findFile(sprPath));
 	_gui.buttonLayoutChecked("object")->onMouseClickValidated().add(this, &Document::onButtonDown);
 	TeITextLayout *txtLayout = _gui.textLayout("text");
 	if (!txtLayout)

--- a/engines/tetraedge/game/documents_browser.cpp
+++ b/engines/tetraedge/game/documents_browser.cpp
@@ -123,7 +123,7 @@ void DocumentsBrowser::loadZoomed() {
 }
 
 void DocumentsBrowser::loadXMLFile(const Common::Path &path) {
-	Common::Path xmlPath = g_engine->getCore()->findFileNew(path);
+	Common::Path xmlPath = g_engine->getCore()->findFile(path);
 	Common::File xmlfile;
 	xmlfile.open(xmlPath);
 	int64 fileLen = xmlfile.size();
@@ -306,9 +306,9 @@ void DocumentsBrowser::showDocument(const Common::String &docName, int startPage
 	TeCore *core = g_engine->getCore();
 	const char *pathPattern = g_engine->gameIsAmerzone() ? "DocumentsBrowser/Documents/%s_zoomed_%d" : "DocumentsBrowser/Documents/Documents/%s_zoomed_%d";
 	const Common::Path docPathBase(Common::String::format(pathPattern, docName.c_str(), (int)startPage));
-	Common::Path docPath = core->findFileNew(docPathBase.append(".png"));
+	Common::Path docPath = core->findFile(docPathBase.append(".png"));
 	if (!Common::File::exists(docPath)) {
-		docPath = core->findFileNew(docPathBase.append(".jpg"));
+		docPath = core->findFile(docPathBase.append(".jpg"));
 		if (!Common::File::exists(docPath)) {
 			// Probably the end of the doc
 			if (startPage == 0)
@@ -323,7 +323,7 @@ void DocumentsBrowser::showDocument(const Common::String &docName, int startPage
 	sprite->load(docPath);
 	TeVector2s32 spriteSize = sprite->_tiledSurfacePtr->tiledTexture()->totalSize();
 
-	Common::Path luaPath = core->findFileNew(docPathBase.append(".lua"));
+	Common::Path luaPath = core->findFile(docPathBase.append(".lua"));
 	if (Common::File::exists(luaPath)) {
 		_zoomedDocGui.load(luaPath);
 		sprite->addChild(_zoomedDocGui.layoutChecked("root"));

--- a/engines/tetraedge/game/documents_browser.cpp
+++ b/engines/tetraedge/game/documents_browser.cpp
@@ -306,12 +306,10 @@ void DocumentsBrowser::showDocument(const Common::String &docName, int startPage
 	TeCore *core = g_engine->getCore();
 	const char *pathPattern = g_engine->gameIsAmerzone() ? "DocumentsBrowser/Documents/%s_zoomed_%d" : "DocumentsBrowser/Documents/Documents/%s_zoomed_%d";
 	const Common::Path docPathBase(Common::String::format(pathPattern, docName.c_str(), (int)startPage));
-	Common::Path docPath = docPathBase.append(".png");
-	Common::FSNode docNode = core->findFile(docPath);
-	if (!docNode.exists()) {
-		docPath = docPathBase.append(".jpg");
-		docNode = core->findFile(docPath);
-		if (!docNode.exists()) {
+	Common::Path docPath = core->findFileNew(docPathBase.append(".png"));
+	if (!Common::File::exists(docPath)) {
+		docPath = core->findFileNew(docPathBase.append(".jpg"));
+		if (!Common::File::exists(docPath)) {
 			// Probably the end of the doc
 			if (startPage == 0)
 				warning("Can't find first page of doc named %s", docName.c_str());
@@ -322,12 +320,12 @@ void DocumentsBrowser::showDocument(const Common::String &docName, int startPage
 	Application *app = g_engine->getApplication();
 	app->captureFade();
 	TeSpriteLayout *sprite = _gui.spriteLayoutChecked("zoomedSprite");
-	sprite->load(docNode);
+	sprite->load(docPath);
 	TeVector2s32 spriteSize = sprite->_tiledSurfacePtr->tiledTexture()->totalSize();
 
-	Common::FSNode luaNode = core->findFile(docPathBase.append(".lua"));
-	if (luaNode.exists()) {
-		_zoomedDocGui.load(luaNode);
+	Common::Path luaPath = core->findFileNew(docPathBase.append(".lua"));
+	if (Common::File::exists(luaPath)) {
+		_zoomedDocGui.load(luaPath);
 		sprite->addChild(_zoomedDocGui.layoutChecked("root"));
 
 		TeButtonLayout *btn;

--- a/engines/tetraedge/game/documents_browser.cpp
+++ b/engines/tetraedge/game/documents_browser.cpp
@@ -123,9 +123,9 @@ void DocumentsBrowser::loadZoomed() {
 }
 
 void DocumentsBrowser::loadXMLFile(const Common::Path &path) {
-	Common::FSNode node = g_engine->getCore()->findFile(path);
+	Common::Path xmlPath = g_engine->getCore()->findFileNew(path);
 	Common::File xmlfile;
-	xmlfile.open(node);
+	xmlfile.open(xmlPath);
 	int64 fileLen = xmlfile.size();
 	char *buf = new char[fileLen + 1];
 	buf[fileLen] = '\0';

--- a/engines/tetraedge/game/in_game_scene.cpp
+++ b/engines/tetraedge/game/in_game_scene.cpp
@@ -1025,7 +1025,7 @@ bool InGameScene::loadObjectMaterials(const Common::String &name) {
 			continue;
 
 		Common::Path mpath = _loadedPath.join(name).join(obj._name + ".png");
-		if (img.load(core->findFile(mpath))) {
+		if (img.load(core->findFileNew(mpath))) {
 			Te3DTexture *tex = Te3DTexture::makeInstance();
 			tex->load(img);
 			obj._model->meshes()[0]->defaultMaterial(tex);

--- a/engines/tetraedge/game/in_game_scene.cpp
+++ b/engines/tetraedge/game/in_game_scene.cpp
@@ -665,7 +665,7 @@ TeVector2f32 InGameScene::layerSize() {
 	return TeVector2f32(sz.x(), sz.y());
 }
 
-bool InGameScene::load(const Common::FSNode &sceneNode) {
+bool InGameScene::load(const Common::Path &scenePath) {
 	// Syberia 1 has loadActZones function contents inline.
 	loadActZones();
 
@@ -683,13 +683,13 @@ bool InGameScene::load(const Common::FSNode &sceneNode) {
 	if (Common::File::exists(lightsPath))
 		loadLights(lightsPath);
 
-	if (!sceneNode.isReadable())
+	if (!Common::File::exists(scenePath))
 		return false;
 
 	close();
-	_loadedPath = sceneNode.getParent().getPath();
+	_loadedPath = scenePath.getParent();
 	Common::File scenefile;
-	if (!scenefile.open(sceneNode))
+	if (!scenefile.open(scenePath))
 		return false;
 
 	uint32 ncameras = scenefile.readUint32LE();

--- a/engines/tetraedge/game/in_game_scene.cpp
+++ b/engines/tetraedge/game/in_game_scene.cpp
@@ -205,7 +205,7 @@ Billboard *InGameScene::billboard(const Common::String &name) {
 }
 
 bool InGameScene::changeBackground(const Common::Path &name) {
-	Common::Path path = g_engine->getCore()->findFileNew(name);
+	Common::Path path = g_engine->getCore()->findFile(name);
 	if (Common::File::exists(path)) {
 		_bgGui.spriteLayoutChecked("root")->load(path);
 		if (g_engine->gameType() == TetraedgeEngine::kSyberia2)
@@ -679,7 +679,7 @@ bool InGameScene::load(const Common::FSNode &sceneNode) {
 	_shadowLightNo = -1;
 
 	TeCore *core = g_engine->getCore();
-	const Common::Path lightsPath = core->findFileNew(getLightsFileName());
+	const Common::Path lightsPath = core->findFile(getLightsFileName());
 	if (Common::File::exists(lightsPath))
 		loadLights(lightsPath);
 
@@ -805,7 +805,7 @@ bool InGameScene::loadXml(const Common::String &zone, const Common::String &scen
 
 	Common::Path xmlpath = _sceneFileNameBase(zone, scene).joinInPlace("Scene")
 												.appendInPlace(scene).appendInPlace(".xml");
-	Common::Path path = g_engine->getCore()->findFileNew(xmlpath);
+	Common::Path path = g_engine->getCore()->findFile(xmlpath);
 	InGameSceneXmlParser parser(this);
 	parser.setAllowText();
 
@@ -855,11 +855,11 @@ bool InGameScene::loadXml(const Common::String &zone, const Common::String &scen
 	_shadowLightNo = -1;
 
 	TeCore *core = g_engine->getCore();
-	const Common::Path lightsPath = core->findFileNew(getLightsFileName());
+	const Common::Path lightsPath = core->findFile(getLightsFileName());
 	if (Common::File::exists(lightsPath))
 		loadLights(lightsPath);
 
-	Common::Path pxmlpath = core->findFileNew(_sceneFileNameBase(zone, scene).joinInPlace("particles.xml"));
+	Common::Path pxmlpath = core->findFile(_sceneFileNameBase(zone, scene).joinInPlace("particles.xml"));
 	if (Common::File::exists(pxmlpath)) {
 		ParticleXmlParser pparser;
 		pparser._scene = this;
@@ -1024,7 +1024,7 @@ bool InGameScene::loadObjectMaterials(const Common::String &name) {
 			continue;
 
 		Common::Path mpath = _loadedPath.join(name).join(obj._name + ".png");
-		if (img.load(core->findFileNew(mpath))) {
+		if (img.load(core->findFile(mpath))) {
 			Te3DTexture *tex = Te3DTexture::makeInstance();
 			tex->load(img);
 			obj._model->meshes()[0]->defaultMaterial(tex);
@@ -1079,7 +1079,7 @@ bool InGameScene::loadPlayerCharacter(const Common::String &name) {
 
 bool InGameScene::loadCurve(const Common::String &name) {
 	TeCore *core = g_engine->getCore();
-	const Common::Path path = core->findFileNew(_sceneFileNameBase().joinInPlace(name).appendInPlace(".bin"));
+	const Common::Path path = core->findFile(_sceneFileNameBase().joinInPlace(name).appendInPlace(".bin"));
 	if (!Common::File::exists(path)) {
 		warning("[InGameScene::loadCurve] Can't open file : %s.", path.toString(Common::Path::kNativeSeparator).c_str());
 		return false;
@@ -1093,8 +1093,8 @@ bool InGameScene::loadCurve(const Common::String &name) {
 bool InGameScene::loadDynamicLightBloc(const Common::String &name, const Common::String &texture, const Common::String &zone, const Common::String &scene) {
 	const Common::Path pdat = _sceneFileNameBase(zone, scene).joinInPlace(name).appendInPlace(".bin");
 	const Common::Path ptex = _sceneFileNameBase(zone, scene).joinInPlace(texture);
-	Common::Path datPath = g_engine->getCore()->findFileNew(pdat);
-	Common::Path texPath = g_engine->getCore()->findFileNew(ptex);
+	Common::Path datPath = g_engine->getCore()->findFile(pdat);
+	Common::Path texPath = g_engine->getCore()->findFile(ptex);
 	if (!Common::File::exists(datPath)) {
 		warning("[InGameScene::loadDynamicLightBloc] Can't open file : %s.", pdat.toString(Common::Path::kNativeSeparator).c_str());
 		return false;
@@ -1151,7 +1151,7 @@ bool InGameScene::loadDynamicLightBloc(const Common::String &name, const Common:
 }
 
 bool InGameScene::loadLight(const Common::String &name, const Common::String &zone, const Common::String &scene) {
-	Common::Path datPath = g_engine->getCore()->findFileNew(_sceneFileNameBase(zone, scene).joinInPlace(name).appendInPlace(".bin"));
+	Common::Path datPath = g_engine->getCore()->findFile(_sceneFileNameBase(zone, scene).joinInPlace(name).appendInPlace(".bin"));
 	if (!Common::File::exists(datPath)) {
 		warning("[InGameScene::loadLight] Can't open file : %s.", datPath.toString(Common::Path::kNativeSeparator).c_str());
 		return false;
@@ -1172,8 +1172,8 @@ bool InGameScene::loadLight(const Common::String &name, const Common::String &zo
 
 bool InGameScene::loadMask(const Common::String &name, const Common::String &texture, const Common::String &zone, const Common::String &scene) {
 	TeCore *core = g_engine->getCore();
-	Common::Path datPath = core->findFileNew(_sceneFileNameBase(zone, scene).joinInPlace(name).appendInPlace(".bin"));
-	Common::Path texPath = core->findFileNew(_sceneFileNameBase(zone, scene).joinInPlace(texture));
+	Common::Path datPath = core->findFile(_sceneFileNameBase(zone, scene).joinInPlace(name).appendInPlace(".bin"));
+	Common::Path texPath = core->findFile(_sceneFileNameBase(zone, scene).joinInPlace(texture));
 	if (!Common::File::exists(datPath)) {
 		warning("[InGameScene::loadMask] Can't open file : %s.", datPath.toString(Common::Path::kNativeSeparator).c_str());
 		return false;
@@ -1221,7 +1221,7 @@ bool InGameScene::loadMask(const Common::String &name, const Common::String &tex
 	}
 
 	file.close();
-	Common::Path texnode = core->findFileNew(texPath);
+	Common::Path texnode = core->findFile(texPath);
 	TeIntrusivePtr<Te3DTexture> tex = Te3DTexture::load2(texnode, !_maskAlpha);
 
 	if (tex) {
@@ -1259,7 +1259,7 @@ bool InGameScene::loadShadowMask(const Common::String &name, const Common::Strin
 }
 
 bool InGameScene::loadShadowReceivingObject(const Common::String &name, const Common::String &zone, const Common::String &scene) {
-	Common::Path datPath = g_engine->getCore()->findFileNew(_sceneFileNameBase(zone, scene).joinInPlace(name).appendInPlace(".bin"));
+	Common::Path datPath = g_engine->getCore()->findFile(_sceneFileNameBase(zone, scene).joinInPlace(name).appendInPlace(".bin"));
 	if (!Common::File::exists(datPath)) {
 		warning("[InGameScene::loadShadowReceivingObject] Can't open file : %s.", datPath.toString(Common::Path::kNativeSeparator).c_str());
 		return false;
@@ -1303,7 +1303,7 @@ bool InGameScene::loadShadowReceivingObject(const Common::String &name, const Co
 }
 
 bool InGameScene::loadZBufferObject(const Common::String &name, const Common::String &zone, const Common::String &scene) {
-	Common::Path datPath = g_engine->getCore()->findFileNew(_sceneFileNameBase(zone, scene).joinInPlace(name).appendInPlace(".bin"));
+	Common::Path datPath = g_engine->getCore()->findFile(_sceneFileNameBase(zone, scene).joinInPlace(name).appendInPlace(".bin"));
 	if (!Common::File::exists(datPath)) {
 		warning("[InGameScene::loadZBufferObject] Can't open file : %s.", datPath.toString(Common::Path::kNativeSeparator).c_str());
 		return false;

--- a/engines/tetraedge/game/in_game_scene.cpp
+++ b/engines/tetraedge/game/in_game_scene.cpp
@@ -205,9 +205,9 @@ Billboard *InGameScene::billboard(const Common::String &name) {
 }
 
 bool InGameScene::changeBackground(const Common::Path &name) {
-	Common::FSNode node = g_engine->getCore()->findFile(name);
-	if (node.isReadable()) {
-		_bgGui.spriteLayoutChecked("root")->load(node);
+	Common::Path path = g_engine->getCore()->findFileNew(name);
+	if (Common::File::exists(path)) {
+		_bgGui.spriteLayoutChecked("root")->load(path);
 		if (g_engine->gameType() == TetraedgeEngine::kSyberia2)
 			_bgGui.spriteLayoutChecked("root")->play();
 		return true;
@@ -678,11 +678,10 @@ bool InGameScene::load(const Common::FSNode &sceneNode) {
 	}
 	_shadowLightNo = -1;
 
-	const Common::Path lightspath = getLightsFileName();
 	TeCore *core = g_engine->getCore();
-	const Common::FSNode lightsNode(core->findFile(lightspath));
-	if (lightsNode.isReadable())
-		loadLights(lightsNode);
+	const Common::Path lightsPath = core->findFileNew(getLightsFileName());
+	if (Common::File::exists(lightsPath))
+		loadLights(lightsPath);
 
 	if (!sceneNode.isReadable())
 		return false;
@@ -806,7 +805,7 @@ bool InGameScene::loadXml(const Common::String &zone, const Common::String &scen
 
 	Common::Path xmlpath = _sceneFileNameBase(zone, scene).joinInPlace("Scene")
 												.appendInPlace(scene).appendInPlace(".xml");
-	Common::FSNode node = g_engine->getCore()->findFile(xmlpath);
+	Common::Path path = g_engine->getCore()->findFileNew(xmlpath);
 	InGameSceneXmlParser parser(this);
 	parser.setAllowText();
 
@@ -818,8 +817,8 @@ bool InGameScene::loadXml(const Common::String &zone, const Common::String &scen
 		// Patch the contents of the file before loading.
 		//
 		Common::File xmlFile;
-		if (!xmlFile.open(node))
-			error("InGameScene::loadXml: Can't open %s", node.getPath().toString(Common::Path::kNativeSeparator).c_str());
+		if (!xmlFile.open(path))
+			error("InGameScene::loadXml: Can't open %s", path.toString(Common::Path::kNativeSeparator).c_str());
 		const int64 bufsize = xmlFile.size();
 		char *buf = new char[bufsize+1];
 		buf[bufsize] = '\0';
@@ -838,12 +837,12 @@ bool InGameScene::loadXml(const Common::String &zone, const Common::String &scen
 		parser.loadBuffer((const byte *)fixedbuf.c_str(), bufsize);
 	} else {
 		// Regular loading.
-		if (!parser.loadFile(node))
-			error("InGameScene::loadXml: Can't load %s", node.getPath().toString(Common::Path::kNativeSeparator).c_str());
+		if (!parser.loadFile(path))
+			error("InGameScene::loadXml: Can't load %s", path.toString(Common::Path::kNativeSeparator).c_str());
 	}
 
 	if (!parser.parse())
-		error("InGameScene::loadXml: Can't parse %s", node.getPath().toString(Common::Path::kNativeSeparator).c_str());
+		error("InGameScene::loadXml: Can't parse %s", path.toString(Common::Path::kNativeSeparator).c_str());
 
 	// loadFlamme and loadSnowCustom are handled by the above.
 
@@ -855,11 +854,10 @@ bool InGameScene::loadXml(const Common::String &zone, const Common::String &scen
 	_lights.clear();
 	_shadowLightNo = -1;
 
-	const Common::Path lightspath = getLightsFileName();
 	TeCore *core = g_engine->getCore();
-	const Common::FSNode lightsNode(core->findFile(lightspath));
-	if (lightsNode.isReadable())
-		loadLights(lightsNode);
+	const Common::Path lightsPath = core->findFileNew(getLightsFileName());
+	if (Common::File::exists(lightsPath))
+		loadLights(lightsPath);
 
 	Common::Path pxmlpath = _sceneFileNameBase(zone, scene).joinInPlace("particles.xml");
 	Common::FSNode pnode = g_engine->getCore()->findFile(pxmlpath);
@@ -947,13 +945,13 @@ bool InGameScene::loadFreeMoveZone(const Common::String &name, TeVector2f32 &gri
 	return true;
 }
 
-bool InGameScene::loadLights(const Common::FSNode &node) {
+bool InGameScene::loadLights(const Common::Path &path) {
 	SceneLightsXmlParser parser(&_lights);
 
-	if (!parser.loadFile(node))
-		error("InGameScene::loadLights: Can't load %s", node.getPath().toString(Common::Path::kNativeSeparator).c_str());
+	if (!parser.loadFile(path))
+		error("InGameScene::loadLights: Can't load %s", path.toString(Common::Path::kNativeSeparator).c_str());
 	if (!parser.parse())
-		error("InGameScene::loadLights: Can't parse %s", node.getPath().toString(Common::Path::kNativeSeparator).c_str());
+		error("InGameScene::loadLights: Can't parse %s", path.toString(Common::Path::kNativeSeparator).c_str());
 
 	_shadowColor = parser.getShadowColor();
 	_shadowLightNo = parser.getShadowLightNo();
@@ -991,8 +989,8 @@ bool InGameScene::loadLights(const Common::FSNode &node) {
 	return true;
 }
 
-void InGameScene::loadMarkers(const Common::FSNode &node) {
-	_markerGui.load(node);
+void InGameScene::loadMarkers(const Common::Path &path) {
+	_markerGui.load(path);
 	TeLayout *bg = _bgGui.layoutChecked("background");
 	TeSpriteLayout *root = Game::findSpriteLayoutByName(bg, "root");
 	bg->setRatioMode(TeILayout::RATIO_MODE_NONE);
@@ -1098,7 +1096,7 @@ bool InGameScene::loadDynamicLightBloc(const Common::String &name, const Common:
 	const Common::Path pdat = _sceneFileNameBase(zone, scene).joinInPlace(name).appendInPlace(".bin");
 	const Common::Path ptex = _sceneFileNameBase(zone, scene).joinInPlace(texture);
 	Common::FSNode datnode = g_engine->getCore()->findFile(pdat);
-	Common::FSNode texnode = g_engine->getCore()->findFile(ptex);
+	Common::Path texPath = g_engine->getCore()->findFileNew(ptex);
 	if (!datnode.isReadable()) {
 		warning("[InGameScene::loadDynamicLightBloc] Can't open file : %s.", pdat.toString(Common::Path::kNativeSeparator).c_str());
 		return false;
@@ -1140,9 +1138,9 @@ bool InGameScene::loadDynamicLightBloc(const Common::String &name, const Common:
 
 	file.close();
 
-	if (texnode.isReadable()) {
+	if (Common::File::exists(texPath)) {
 		TeIntrusivePtr<Te3DTexture> tex = Te3DTexture::makeInstance();
-		tex->load2(texnode, false);
+		tex->load2(g_engine->getCore()->convertPathToFSNode(texPath), false);
 		mesh->defaultMaterial(tex);
 	} else if (texture.size()) {
 		warning("loadDynamicLightBloc: Failed to load texture %s", texture.c_str());
@@ -1177,11 +1175,11 @@ bool InGameScene::loadLight(const Common::String &name, const Common::String &zo
 
 bool InGameScene::loadMask(const Common::String &name, const Common::String &texture, const Common::String &zone, const Common::String &scene) {
 	TeCore *core = g_engine->getCore();
-	Common::Path datpath = _sceneFileNameBase(zone, scene).joinInPlace(name).appendInPlace(".bin");
-	Common::Path texpath = _sceneFileNameBase(zone, scene).joinInPlace(texture);
-	Common::FSNode datnode = core->findFile(datpath);
+	Common::Path datPath = _sceneFileNameBase(zone, scene).joinInPlace(name).appendInPlace(".bin");
+	Common::Path texPath = _sceneFileNameBase(zone, scene).joinInPlace(texture);
+	Common::FSNode datnode = core->findFile(datPath);
 	if (!datnode.isReadable()) {
-		warning("[InGameScene::loadMask] Can't open file : %s.", datpath.toString(Common::Path::kNativeSeparator).c_str());
+		warning("[InGameScene::loadMask] Can't open file : %s.", datPath.toString(Common::Path::kNativeSeparator).c_str());
 		return false;
 	}
 	TeModel *model = new TeModel();
@@ -1227,7 +1225,7 @@ bool InGameScene::loadMask(const Common::String &name, const Common::String &tex
 	}
 
 	file.close();
-	Common::FSNode texnode = core->findFile(texpath);
+	Common::FSNode texnode = core->findFile(texPath);
 	TeIntrusivePtr<Te3DTexture> tex = Te3DTexture::load2(texnode, !_maskAlpha);
 
 	if (tex) {
@@ -1405,9 +1403,9 @@ void InGameScene::loadBlockers() {
 	}
 }
 
-void InGameScene::loadBackground(const Common::FSNode &node) {
+void InGameScene::loadBackground(const Common::Path &path) {
 	_youkiManager.reset();
-	_bgGui.load(node);
+	_bgGui.load(path);
 	TeLayout *bg = _bgGui.layout("background");
 	TeLayout *root = _bgGui.layout("root");
 	bg->setRatioMode(TeILayout::RATIO_MODE_NONE);
@@ -1441,8 +1439,8 @@ bool InGameScene::loadBillboard(const Common::String &name) {
 	}
 }
 
-void InGameScene::loadInteractions(const Common::FSNode &node) {
-	_hitObjectGui.load(node);
+void InGameScene::loadInteractions(const Common::Path &path) {
+	_hitObjectGui.load(path);
 	TeLayout *bgbackground = _bgGui.layoutChecked("background");
 	Game *game = g_engine->getGame();
 	TeSpriteLayout *root = game->findSpriteLayoutByName(bgbackground, "root");

--- a/engines/tetraedge/game/in_game_scene.cpp
+++ b/engines/tetraedge/game/in_game_scene.cpp
@@ -1140,7 +1140,7 @@ bool InGameScene::loadDynamicLightBloc(const Common::String &name, const Common:
 
 	if (Common::File::exists(texPath)) {
 		TeIntrusivePtr<Te3DTexture> tex = Te3DTexture::makeInstance();
-		tex->load2(g_engine->getCore()->convertPathToFSNode(texPath), false);
+		tex->load2(texPath, false);
 		mesh->defaultMaterial(tex);
 	} else if (texture.size()) {
 		warning("loadDynamicLightBloc: Failed to load texture %s", texture.c_str());
@@ -1225,7 +1225,7 @@ bool InGameScene::loadMask(const Common::String &name, const Common::String &tex
 	}
 
 	file.close();
-	Common::FSNode texnode = core->findFile(texPath);
+	Common::Path texnode = core->findFileNew(texPath);
 	TeIntrusivePtr<Te3DTexture> tex = Te3DTexture::load2(texnode, !_maskAlpha);
 
 	if (tex) {

--- a/engines/tetraedge/game/in_game_scene.h
+++ b/engines/tetraedge/game/in_game_scene.h
@@ -141,13 +141,11 @@ public:
 	void addBlockingObject(const Common::String &obj) {
 		_blockingObjects.push_back(obj);
 	}
-	void addCallbackAnimation2D(const Common::String &param_1, const Common::String &param_2, float param_3);
 	bool addMarker(const Common::String &name, const Common::Path &imgPath, float x, float y, const Common::String &locType, const Common::String &markerVal, float anchorX, float anchorY);
 	static float angularDistance(float a1, float a2);
 	bool aroundAnchorZone(const AnchorZone *zone);
 	TeLayout *background();
 	Billboard *billboard(const Common::String &name);
-	TeVector2f32 boundLayerSize();
 	bool changeBackground(const Common::Path &name);
 	Character *character(const Common::String &name);
 	virtual void close() override;
@@ -155,7 +153,6 @@ public:
 	void convertPathToMesh(TeFreeMoveZone *zone);
 	TeIntrusivePtr<TeBezierCurve> curve(const Common::String &curveName);
 	void deleteAllCallback();
-	void deleteCallback(const Common::String &key, const Common::String &name, float f);
 	void deleteMarker(const Common::String &markerName);
 	// Original just calls these "deserialize" but that's a fairly vague name
 	// so renamed to be more meaningful.
@@ -182,7 +179,6 @@ public:
 	void initScroll();
 	bool isMarker(const Common::String &name);
 	bool isObjectBlocking(const Common::String &name);
-	bool isVisibleMarker(const Common::String &name);
 	TeVector2f32 layerSize();
 
 	virtual bool load(const Common::FSNode &node) override;
@@ -210,32 +206,24 @@ public:
 	bool loadRBB(const Common::String &fname, const Common::String &zone, const Common::String &scene);
 	bool loadRippleMask(const Common::String &name, const Common::String &texture, const Common::String &zone, const Common::String &scene);
 	bool loadRObject(const Common::String &fname, const Common::String &zone, const Common::String &scene);
-	//bool loadSBB(const Common::String &fname, const Common::String &zone, const Common::String &scene); // Unused?
 	bool loadShadowMask(const Common::String &name, const Common::String &texture, const Common::String &zone, const Common::String &scene);
 	bool loadShadowReceivingObject(const Common::String &fname, const Common::String &zone, const Common::String &scene);
-	//bool loadSnowCone(const Common::String &fname, const Common::String &zone, const Common::String &scene) { return false; } // Unused?
 	//bool loadSnowCustom() // todo: from xml file?
 	bool loadXml(const Common::String &zone, const Common::String &scene);
 	bool loadZBufferObject(const Common::String &fname, const Common::String &zone, const Common::String &scene);
 
 	void moveCharacterTo(const Common::String &charName, const Common::String &curveName, float curveOffset, float curveEnd);
-	int object(const Common::String &oname);
 	Object3D *object3D(const Common::String &oname);
 	void onMainWindowSizeChanged();
 	TeFreeMoveZone *pathZone(const Common::String &zname);
 	void playVerticalScrolling(float time);
-	TeVector3f32 positionMarker(const Common::String &mname);
-	void removeBlockingObject(const Common::String &oname);
 
 	void reset();
 	void setImagePathMarker(const Common::String &markerName, const Common::Path &path);
 	void setPositionCharacter(const Common::String &charName, const Common::String &freeMoveZoneName, const TeVector3f32 &position);
-	void setPositionMarker(const Common::String &name, const TeVector3f32 &vec);
 	void setStep(const Common::String &scene, const Common::String &step1, const Common::String &step2);
 	void setVisibleMarker(const Common::String &markerName, bool val);
 	TeLight *shadowLight();
-	bool showAllObjects(const Common::String &name);
-	void unloadAllObjects();
 	void unloadCharacter(const Common::String &name);
 	void unloadObject(const Common::String &name);
 	void unloadSpriteLayouts();

--- a/engines/tetraedge/game/in_game_scene.h
+++ b/engines/tetraedge/game/in_game_scene.h
@@ -186,13 +186,13 @@ public:
 	TeVector2f32 layerSize();
 
 	virtual bool load(const Common::FSNode &node) override;
-	void loadBackground(const Common::FSNode &node);
+	void loadBackground(const Common::Path &node);
 	bool loadBillboard(const Common::String &name);
 	void loadBlockers();
 	bool loadCharacter(const Common::String &name);
-	void loadInteractions(const Common::FSNode &node);
-	bool loadLights(const Common::FSNode &node);
-	void loadMarkers(const Common::FSNode &node);
+	void loadInteractions(const Common::Path &path);
+	bool loadLights(const Common::Path &path);
+	void loadMarkers(const Common::Path &path);
 	bool loadObject(const Common::String &oname);
 	bool loadObjectMaterials(const Common::String &name);
 	bool loadObjectMaterials(const Common::Path &path, const Common::String &name);

--- a/engines/tetraedge/game/in_game_scene.h
+++ b/engines/tetraedge/game/in_game_scene.h
@@ -181,7 +181,7 @@ public:
 	bool isObjectBlocking(const Common::String &name);
 	TeVector2f32 layerSize();
 
-	virtual bool load(const Common::FSNode &node) override;
+	virtual bool load(const Common::Path &path) override;
 	void loadBackground(const Common::Path &node);
 	bool loadBillboard(const Common::String &name);
 	void loadBlockers();

--- a/engines/tetraedge/game/loc_file.cpp
+++ b/engines/tetraedge/game/loc_file.cpp
@@ -36,7 +36,7 @@ void LocFile::load(const Common::Path &path) {
 	const Common::String xmlHeader("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
 	Common::File locFile;
 	if (!locFile.open(path))
-		error("LocFile::load: failed to open %s.", path.getLastComponent().toString().c_str());
+		error("LocFile::load: failed to open %s.", path.baseName().c_str());
 
 	int64 fileLen = locFile.size();
 	char *buf = new char[fileLen + 1];
@@ -46,10 +46,10 @@ void LocFile::load(const Common::Path &path) {
 	delete [] buf;
 	locFile.close();
 	if (!parser.loadBuffer((const byte *)xmlContents.c_str(), xmlContents.size()))
-		error("LocFile::load: failed to load %s.", path.getLastComponent().toString().c_str());
+		error("LocFile::load: failed to load %s.", path.baseName().c_str());
 
 	if (!parser.parse())
-		error("LocFile::load: failed to parse %s.", path.getLastComponent().toString().c_str());
+		error("LocFile::load: failed to parse %s.", path.baseName().c_str());
 
 	_map = parser.getMap();
 }

--- a/engines/tetraedge/game/loc_file.cpp
+++ b/engines/tetraedge/game/loc_file.cpp
@@ -31,13 +31,12 @@ namespace Tetraedge {
 LocFile::LocFile() {
 }
 
-void LocFile::load(const Common::FSNode &fsnode) {
+void LocFile::load(const Common::Path &path) {
 	TeNameValXmlParser parser;
 	const Common::String xmlHeader("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
 	Common::File locFile;
-	const Common::String path = fsnode.getName();
-	if (!locFile.open(fsnode))
-		error("LocFile::load: failed to open %s.", path.c_str());
+	if (!locFile.open(path))
+		error("LocFile::load: failed to open %s.", path.getLastComponent().toString().c_str());
 
 	int64 fileLen = locFile.size();
 	char *buf = new char[fileLen + 1];
@@ -47,10 +46,10 @@ void LocFile::load(const Common::FSNode &fsnode) {
 	delete [] buf;
 	locFile.close();
 	if (!parser.loadBuffer((const byte *)xmlContents.c_str(), xmlContents.size()))
-		error("LocFile::load: failed to load %s.", path.c_str());
+		error("LocFile::load: failed to load %s.", path.getLastComponent().toString().c_str());
 
 	if (!parser.parse())
-		error("LocFile::load: failed to parse %s.", path.c_str());
+		error("LocFile::load: failed to parse %s.", path.getLastComponent().toString().c_str());
 
 	_map = parser.getMap();
 }

--- a/engines/tetraedge/game/loc_file.h
+++ b/engines/tetraedge/game/loc_file.h
@@ -33,8 +33,7 @@ class LocFile : public TeILoc {
 public:
 	LocFile();
 
-	//const Common::String *avatar(const Common::String &key);
-	void load(const Common::FSNode &fsnode);
+	void load(const Common::Path &path);
 	const Common::String *value(const Common::String &key) const;
 
 };

--- a/engines/tetraedge/game/main_menu.cpp
+++ b/engines/tetraedge/game/main_menu.cpp
@@ -295,7 +295,10 @@ bool MainMenu::onNewGameButtonValidated() {
 bool MainMenu::onNewGameConfirmed() {
 	// Note: Original game deletes saves here.  Don't do that..
 	_confirmingTuto = true;
-	_tutoConfirm.enter("menus/confirm/confirmTuto.lua", "");
+	if (!g_engine->gameIsAmerzone())
+		_tutoConfirm.enter("menus/confirm/confirmTuto.lua", "");
+	else
+		_tutoConfirm.enter("GUI/ConfirmNewGame.lua", "");
 	onContinueGameButtonValidated();
 	return false;
 }

--- a/engines/tetraedge/game/options_menu.cpp
+++ b/engines/tetraedge/game/options_menu.cpp
@@ -44,8 +44,15 @@ void OptionsMenu::enter() {
 		app->appSpriteLayout().load("menus/menu.ogv");
 		app->appSpriteLayout().play();
 	}
-	load("menus/options/optionsMenu.lua");
-	_gui2.load("menus/options/tuto.lua");
+
+	if (!g_engine->gameIsAmerzone()) {
+		load("menus/options/optionsMenu.lua");
+		_gui2.load("menus/options/tuto.lua");
+	} else {
+		load("GUI/OptionsMenu.lua");
+		_gui2.load("menus/options/tuto.lua");	// TODO: This is wrong
+	}
+
 	app->frontLayout().addChild(layoutChecked("menu2"));
 	app->frontLayout().addChild(_gui2.buttonLayoutChecked("tuto"));
 	_gui2.buttonLayoutChecked("tuto")->setVisible(false);

--- a/engines/tetraedge/game/question2.cpp
+++ b/engines/tetraedge/game/question2.cpp
@@ -74,7 +74,10 @@ void Question2::load() {
 	setSizeType(RELATIVE_TO_PARENT);
 	const TeVector3f32 usersz = userSize();
 	setSize(TeVector3f32(1.0, 1.0, usersz.z()));
-	_gui.load("menus/answer.lua");
+	if (!g_engine->gameIsAmerzone())
+		_gui.load("menus/answer.lua");
+	else
+		_gui.load("GUI/answer.lua");
 
 	TeButtonLayout *backgroundButton = _gui.buttonLayout("background");
 	if (backgroundButton) {

--- a/engines/tetraedge/game/splash_screens.cpp
+++ b/engines/tetraedge/game/splash_screens.cpp
@@ -40,9 +40,9 @@ void SplashScreens::enter()	{
 		_entered = true;
 		_splashNo = 0;
 		const char *scriptStr = g_engine->gameIsAmerzone() ? "GUI/PC-MacOSX/Splash0.lua" : "menus/splashes/splash0.lua";
-		Common::FSNode node = g_engine->getCore()->findFile(scriptStr);
-		if (node.exists()) {
-			load(node);
+		Common::Path path = g_engine->getCore()->findFileNew(scriptStr);
+		if (Common::File::exists(path)) {
+			load(path);
 			Application *app = g_engine->getApplication();
 			TeLayout *splash = layoutChecked("splash");
 
@@ -72,11 +72,11 @@ bool SplashScreens::onAlarm() {
 		return true;
 	}
 
-	Common::FSNode node = g_engine->getCore()->findFile(scriptName);
-	if (!node.exists()) {
+	Common::Path path = g_engine->getCore()->findFileNew(scriptName);
+	if (!Common::File::exists(path)) {
 		onQuitSplash();
 	} else {
-		load(node);
+		load(path);
 
 		TeButtonLayout *splash = buttonLayoutChecked("splash");
 		splash->onMouseClickValidated().add(this, &SplashScreens::onQuitSplash);

--- a/engines/tetraedge/game/splash_screens.cpp
+++ b/engines/tetraedge/game/splash_screens.cpp
@@ -40,7 +40,7 @@ void SplashScreens::enter()	{
 		_entered = true;
 		_splashNo = 0;
 		const char *scriptStr = g_engine->gameIsAmerzone() ? "GUI/PC-MacOSX/Splash0.lua" : "menus/splashes/splash0.lua";
-		Common::Path path = g_engine->getCore()->findFileNew(scriptStr);
+		Common::Path path = g_engine->getCore()->findFile(scriptStr);
 		if (Common::File::exists(path)) {
 			load(path);
 			Application *app = g_engine->getApplication();
@@ -72,7 +72,7 @@ bool SplashScreens::onAlarm() {
 		return true;
 	}
 
-	Common::Path path = g_engine->getCore()->findFileNew(scriptName);
+	Common::Path path = g_engine->getCore()->findFile(scriptName);
 	if (!Common::File::exists(path)) {
 		onQuitSplash();
 	} else {

--- a/engines/tetraedge/game/syberia_game.cpp
+++ b/engines/tetraedge/game/syberia_game.cpp
@@ -503,7 +503,7 @@ bool SyberiaGame::initWarp(const Common::String &zone, const Common::String &sce
 	geomPath = core->findFile(geomPath);
 	if (Common::File::exists(geomPath)) {
 		// Syberia 1, load geom bin
-		_scene.load(core->convertPathToFSNode(geomPath));
+		_scene.load(geomPath);
 	} else {
 		// Syberia 2, load from xml
 		_scene.loadXml(zone, scene);

--- a/engines/tetraedge/game/syberia_game.cpp
+++ b/engines/tetraedge/game/syberia_game.cpp
@@ -492,9 +492,9 @@ bool SyberiaGame::initWarp(const Common::String &zone, const Common::String &sce
 	if (logicLuaExists) {
 		_luaContext.addBindings(LuaBinds::LuaOpenBinds);
 		_luaScript.attachToContext(&_luaContext);
-		_luaScript.load(core->findFile("menus/help/help.lua"));
+		_luaScript.load(core->findFileNew("menus/help/help.lua"));
 		_luaScript.execute();
-		_luaScript.load(core->convertPathToFSNode(logicLuaPath));
+		_luaScript.load(logicLuaPath);
 	}
 
 	if (_forGui.loaded())
@@ -514,7 +514,7 @@ bool SyberiaGame::initWarp(const Common::String &zone, const Common::String &sce
 		// Syberia 2, load from xml
 		_scene.loadXml(zone, scene);
 	}
-	_scene.loadBackground(core->convertPathToFSNode(setLuaPath));
+	_scene.loadBackground(setLuaPath);
 
 	Application *app = g_engine->getApplication();
 	if (forLuaExists) {
@@ -531,7 +531,7 @@ bool SyberiaGame::initWarp(const Common::String &zone, const Common::String &sce
 	}
 
 	if (intLuaExists) {
-		_scene.loadInteractions(core->convertPathToFSNode(intLuaPath));
+		_scene.loadInteractions(intLuaPath);
 		TeLuaGUI::StringMap<TeButtonLayout *> &blayouts = _scene.hitObjectGui().buttonLayouts();
 		for (auto &entry : blayouts) {
 			HitObject *hobj = new HitObject();
@@ -803,7 +803,7 @@ bool SyberiaGame::loadPlayerCharacter(const Common::String &name) {
 
 bool SyberiaGame::loadScene(const Common::String &name) {
 	TeCore *core = g_engine->getCore();
-	_gameEnterScript.load(core->findFile("scenes/OnGameEnter.lua"));
+	_gameEnterScript.load(core->findFileNew("scenes/OnGameEnter.lua"));
 	_gameEnterScript.execute();
 	Character *character = _scene._character;
 	if (character && character->_model->visible()) {

--- a/engines/tetraedge/game/syberia_game.cpp
+++ b/engines/tetraedge/game/syberia_game.cpp
@@ -462,23 +462,23 @@ bool SyberiaGame::initWarp(const Common::String &zone, const Common::String &sce
 
 	TeCore *core = g_engine->getCore();
 
-	const Common::FSNode intLuaNode = core->findFile(scenePath.join(Common::String::format("Int%s.lua", scene.c_str())));
-	const Common::FSNode logicLuaNode = core->findFile(scenePath.join(Common::String::format("Logic%s.lua", scene.c_str())));
-	const Common::FSNode setLuaNode = core->findFile(scenePath.join(Common::String::format("Set%s.lua", scene.c_str())));
-	Common::FSNode forLuaNode = core->findFile(scenePath.join(Common::String::format("For%s.lua", scene.c_str())));
-	const Common::FSNode markerLuaNode = core->findFile(scenePath.join(Common::String::format("Marker%s.lua", scene.c_str())));
+	const Common::Path intLuaPath = core->findFileNew(scenePath.join(Common::String::format("Int%s.lua", scene.c_str())));
+	const Common::Path logicLuaPath = core->findFileNew(scenePath.join(Common::String::format("Logic%s.lua", scene.c_str())));
+	const Common::Path setLuaPath = core->findFileNew(scenePath.join(Common::String::format("Set%s.lua", scene.c_str())));
+	Common::Path forLuaPath = core->findFileNew(scenePath.join(Common::String::format("For%s.lua", scene.c_str())));
+	const Common::Path markerLuaPath = core->findFileNew(scenePath.join(Common::String::format("Marker%s.lua", scene.c_str())));
 
-	bool intLuaExists = intLuaNode.exists();
-	bool logicLuaExists = logicLuaNode.exists();
-	bool setLuaExists = setLuaNode.exists();
-	bool forLuaExists = forLuaNode.exists();
+	bool intLuaExists = Common::File::exists(intLuaPath);
+	bool logicLuaExists = Common::File::exists(logicLuaPath);
+	bool setLuaExists = Common::File::exists(setLuaPath);
+	bool forLuaExists = Common::File::exists(forLuaPath);
 	if (!forLuaExists) {
 		// slight hack.. try an alternate For lua path.
-		forLuaNode = core->findFile(scenePath.join("Android-MacOSX").join(Common::String::format("For%s.lua", scene.c_str())));
-		forLuaExists = forLuaNode.exists();
-		debug("searched for %s", forLuaNode.getName().c_str());
+		forLuaPath = core->findFileNew(scenePath.join("Android-MacOSX").join(Common::String::format("For%s.lua", scene.c_str())));
+		forLuaExists = Common::File::exists(forLuaPath);
+		debug("searched for %s", forLuaPath.getLastComponent().toString().c_str());
 	}
-	bool markerLuaExists = markerLuaNode.exists();
+	bool markerLuaExists = Common::File::exists(markerLuaPath);
 
 	if (!intLuaExists && !logicLuaExists && !setLuaExists && !forLuaExists && !markerLuaExists) {
 		debug("No lua scripts for scene %s zone %s", scene.c_str(), zone.c_str());
@@ -494,7 +494,7 @@ bool SyberiaGame::initWarp(const Common::String &zone, const Common::String &sce
 		_luaScript.attachToContext(&_luaContext);
 		_luaScript.load(core->findFile("menus/help/help.lua"));
 		_luaScript.execute();
-		_luaScript.load(logicLuaNode);
+		_luaScript.load(core->convertPathToFSNode(logicLuaPath));
 	}
 
 	if (_forGui.loaded())
@@ -514,11 +514,11 @@ bool SyberiaGame::initWarp(const Common::String &zone, const Common::String &sce
 		// Syberia 2, load from xml
 		_scene.loadXml(zone, scene);
 	}
-	_scene.loadBackground(setLuaNode);
+	_scene.loadBackground(core->convertPathToFSNode(setLuaPath));
 
 	Application *app = g_engine->getApplication();
 	if (forLuaExists) {
-		_forGui.load(forLuaNode);
+		_forGui.load(forLuaPath);
 		TeLayout *bg = _forGui.layoutChecked("background");
 		bg->setRatioMode(TeILayout::RATIO_MODE_NONE);
 		app->frontLayout().addChild(bg);
@@ -531,7 +531,7 @@ bool SyberiaGame::initWarp(const Common::String &zone, const Common::String &sce
 	}
 
 	if (intLuaExists) {
-		_scene.loadInteractions(intLuaNode);
+		_scene.loadInteractions(core->convertPathToFSNode(intLuaPath));
 		TeLuaGUI::StringMap<TeButtonLayout *> &blayouts = _scene.hitObjectGui().buttonLayouts();
 		for (auto &entry : blayouts) {
 			HitObject *hobj = new HitObject();

--- a/engines/tetraedge/game/syberia_game.cpp
+++ b/engines/tetraedge/game/syberia_game.cpp
@@ -465,19 +465,13 @@ bool SyberiaGame::initWarp(const Common::String &zone, const Common::String &sce
 	const Common::Path intLuaPath = core->findFileNew(scenePath.join(Common::String::format("Int%s.lua", scene.c_str())));
 	const Common::Path logicLuaPath = core->findFileNew(scenePath.join(Common::String::format("Logic%s.lua", scene.c_str())));
 	const Common::Path setLuaPath = core->findFileNew(scenePath.join(Common::String::format("Set%s.lua", scene.c_str())));
-	Common::Path forLuaPath = core->findFileNew(scenePath.join(Common::String::format("For%s.lua", scene.c_str())));
+	const Common::Path forLuaPath = core->findFileNew(scenePath.join(Common::String::format("For%s.lua", scene.c_str())));
 	const Common::Path markerLuaPath = core->findFileNew(scenePath.join(Common::String::format("Marker%s.lua", scene.c_str())));
 
 	bool intLuaExists = Common::File::exists(intLuaPath);
 	bool logicLuaExists = Common::File::exists(logicLuaPath);
 	bool setLuaExists = Common::File::exists(setLuaPath);
 	bool forLuaExists = Common::File::exists(forLuaPath);
-	if (!forLuaExists) {
-		// slight hack.. try an alternate For lua path.
-		forLuaPath = core->findFileNew(scenePath.join("Android-MacOSX").join(Common::String::format("For%s.lua", scene.c_str())));
-		forLuaExists = Common::File::exists(forLuaPath);
-		debug("searched for %s", forLuaPath.getLastComponent().toString().c_str());
-	}
 	bool markerLuaExists = Common::File::exists(markerLuaPath);
 
 	if (!intLuaExists && !logicLuaExists && !setLuaExists && !forLuaExists && !markerLuaExists) {

--- a/engines/tetraedge/game/syberia_game.cpp
+++ b/engines/tetraedge/game/syberia_game.cpp
@@ -224,7 +224,7 @@ bool SyberiaGame::changeWarp2(const Common::String &zone, const Common::String &
 	luapath.appendInPlace(scene);
 	luapath.appendInPlace(".lua");
 
-	if (Common::File::exists(g_engine->getCore()->findFileNew(luapath))) {
+	if (Common::File::exists(g_engine->getCore()->findFile(luapath))) {
 		_luaScript.execute("OnLeave");
 		_luaContext.removeGlobal("On");
 		_luaContext.removeGlobal("OnEnter");
@@ -462,11 +462,11 @@ bool SyberiaGame::initWarp(const Common::String &zone, const Common::String &sce
 
 	TeCore *core = g_engine->getCore();
 
-	const Common::Path intLuaPath = core->findFileNew(scenePath.join(Common::String::format("Int%s.lua", scene.c_str())));
-	const Common::Path logicLuaPath = core->findFileNew(scenePath.join(Common::String::format("Logic%s.lua", scene.c_str())));
-	const Common::Path setLuaPath = core->findFileNew(scenePath.join(Common::String::format("Set%s.lua", scene.c_str())));
-	const Common::Path forLuaPath = core->findFileNew(scenePath.join(Common::String::format("For%s.lua", scene.c_str())));
-	const Common::Path markerLuaPath = core->findFileNew(scenePath.join(Common::String::format("Marker%s.lua", scene.c_str())));
+	const Common::Path intLuaPath = core->findFile(scenePath.join(Common::String::format("Int%s.lua", scene.c_str())));
+	const Common::Path logicLuaPath = core->findFile(scenePath.join(Common::String::format("Logic%s.lua", scene.c_str())));
+	const Common::Path setLuaPath = core->findFile(scenePath.join(Common::String::format("Set%s.lua", scene.c_str())));
+	const Common::Path forLuaPath = core->findFile(scenePath.join(Common::String::format("For%s.lua", scene.c_str())));
+	const Common::Path markerLuaPath = core->findFile(scenePath.join(Common::String::format("Marker%s.lua", scene.c_str())));
 
 	bool intLuaExists = Common::File::exists(intLuaPath);
 	bool logicLuaExists = Common::File::exists(logicLuaPath);
@@ -486,7 +486,7 @@ bool SyberiaGame::initWarp(const Common::String &zone, const Common::String &sce
 	if (logicLuaExists) {
 		_luaContext.addBindings(LuaBinds::LuaOpenBinds);
 		_luaScript.attachToContext(&_luaContext);
-		_luaScript.load(core->findFileNew("menus/help/help.lua"));
+		_luaScript.load(core->findFile("menus/help/help.lua"));
 		_luaScript.execute();
 		_luaScript.load(logicLuaPath);
 	}
@@ -500,7 +500,7 @@ bool SyberiaGame::initWarp(const Common::String &zone, const Common::String &sce
 	_scene.hitObjectGui().unload();
 	Common::Path geomPath(Common::String::format("scenes/%s/Geometry%s.bin",
 												 zone.c_str(), zone.c_str()));
-	geomPath = core->findFileNew(geomPath);
+	geomPath = core->findFile(geomPath);
 	if (Common::File::exists(geomPath)) {
 		// Syberia 1, load geom bin
 		_scene.load(core->convertPathToFSNode(geomPath));
@@ -797,7 +797,7 @@ bool SyberiaGame::loadPlayerCharacter(const Common::String &name) {
 
 bool SyberiaGame::loadScene(const Common::String &name) {
 	TeCore *core = g_engine->getCore();
-	_gameEnterScript.load(core->findFileNew("scenes/OnGameEnter.lua"));
+	_gameEnterScript.load(core->findFile("scenes/OnGameEnter.lua"));
 	_gameEnterScript.execute();
 	Character *character = _scene._character;
 	if (character && character->_model->visible()) {

--- a/engines/tetraedge/game/syberia_game.cpp
+++ b/engines/tetraedge/game/syberia_game.cpp
@@ -224,7 +224,7 @@ bool SyberiaGame::changeWarp2(const Common::String &zone, const Common::String &
 	luapath.appendInPlace(scene);
 	luapath.appendInPlace(".lua");
 
-	if (g_engine->getCore()->findFile(luapath).exists()) {
+	if (Common::File::exists(g_engine->getCore()->findFileNew(luapath))) {
 		_luaScript.execute("OnLeave");
 		_luaContext.removeGlobal("On");
 		_luaContext.removeGlobal("OnEnter");
@@ -500,10 +500,10 @@ bool SyberiaGame::initWarp(const Common::String &zone, const Common::String &sce
 	_scene.hitObjectGui().unload();
 	Common::Path geomPath(Common::String::format("scenes/%s/Geometry%s.bin",
 												 zone.c_str(), zone.c_str()));
-	Common::FSNode geomFile = core->findFile(geomPath);
-	if (geomFile.isReadable()) {
+	geomPath = core->findFileNew(geomPath);
+	if (Common::File::exists(geomPath)) {
 		// Syberia 1, load geom bin
-		_scene.load(geomFile);
+		_scene.load(core->convertPathToFSNode(geomPath));
 	} else {
 		// Syberia 2, load from xml
 		_scene.loadXml(zone, scene);

--- a/engines/tetraedge/te/te_3d_texture.cpp
+++ b/engines/tetraedge/te/te_3d_texture.cpp
@@ -44,20 +44,20 @@ bool Te3DTexture::hasAlpha() const {
 }
 
 /*static*/
-TeIntrusivePtr<Te3DTexture> Te3DTexture::load2(const Common::FSNode &node, bool alphaOnly) {
-	const Common::Path fullPath = node.getPath().append(".3dtex");
+TeIntrusivePtr<Te3DTexture> Te3DTexture::load2(const Common::Path &path, bool alphaOnly) {
+	const Common::Path fullPath = path.append(".3dtex");
 
 	TeResourceManager *resMgr = g_engine->getResourceManager();
 	if (!resMgr->exists(fullPath)) {
 		TeIntrusivePtr<Te3DTexture> retval(makeInstance());
-		if (!node.isReadable())
-			warning("Request to load unreadable texture %s", node.getPath().toString(Common::Path::kNativeSeparator).c_str());
+		if (!Common::File::exists(path))
+			warning("Request to load unreadable texture %s", path.toString(Common::Path::kNativeSeparator).c_str());
 		if (alphaOnly)
 			retval->setLoadAlphaOnly();
 
-		bool result = retval->load(node);
+		bool result = retval->load(path);
 		if (!result)
-			warning("Failed loading texture %s", node.getPath().toString(Common::Path::kNativeSeparator).c_str());
+			warning("Failed loading texture %s", path.toString(Common::Path::kNativeSeparator).c_str());
 
 		retval->setAccessName(fullPath);
 		resMgr->addResource(retval.get());
@@ -67,11 +67,11 @@ TeIntrusivePtr<Te3DTexture> Te3DTexture::load2(const Common::FSNode &node, bool 
 	}
 }
 
-bool Te3DTexture::load(const Common::FSNode &node) {
+bool Te3DTexture::load(const Common::Path &path) {
 	TeResourceManager *resmgr = g_engine->getResourceManager();
-	TeIntrusivePtr<TeImage> img = resmgr->getResource<TeImage>(node);
+	TeIntrusivePtr<TeImage> img = resmgr->getResource<TeImage>(g_engine->getCore()->convertPathToFSNode(path));
 	bool result = load(*img);
-	setAccessName(node.getPath().append(".3dtex"));
+	setAccessName(path.append(".3dtex"));
 	return result;
 }
 

--- a/engines/tetraedge/te/te_3d_texture.cpp
+++ b/engines/tetraedge/te/te_3d_texture.cpp
@@ -69,7 +69,7 @@ TeIntrusivePtr<Te3DTexture> Te3DTexture::load2(const Common::Path &path, bool al
 
 bool Te3DTexture::load(const Common::Path &path) {
 	TeResourceManager *resmgr = g_engine->getResourceManager();
-	TeIntrusivePtr<TeImage> img = resmgr->getResource<TeImage>(g_engine->getCore()->convertPathToFSNode(path));
+	TeIntrusivePtr<TeImage> img = resmgr->getResource<TeImage>(path);
 	bool result = load(*img);
 	setAccessName(path.append(".3dtex"));
 	return result;

--- a/engines/tetraedge/te/te_3d_texture.h
+++ b/engines/tetraedge/te/te_3d_texture.h
@@ -48,11 +48,11 @@ public:
 	TeImage::Format getFormat() const { return _format; }
 	bool hasAlpha() const;
 
-	bool load(const Common::FSNode &path);
+	bool load(const Common::Path &path);
 	virtual bool load(const TeImage &img) = 0;
 	// The original passes a GL enum param, but it's only ever GL_INVALID or GL_ALPHA.
 	// Simplify to avoid leaking gl types.
-	static TeIntrusivePtr<Te3DTexture> load2(const Common::FSNode &node, bool alphaOnly);
+	static TeIntrusivePtr<Te3DTexture> load2(const Common::Path &path, bool alphaOnly);
 
 	static TeVector2s32 optimisedSize(const TeVector2s32 &size);
 

--- a/engines/tetraedge/te/te_bezier_curve.cpp
+++ b/engines/tetraedge/te/te_bezier_curve.cpp
@@ -208,10 +208,10 @@ void TeBezierCurve::deserialize(Common::ReadStream &stream, TeBezierCurve &curve
 	}
 }
 
-void TeBezierCurve::loadBin(Common::FSNode &node) {
+void TeBezierCurve::loadBin(const Common::Path &path) {
 	Common::File file;
-	file.open(node);
-	Common::String fname = node.getName();
+	file.open(path);
+	Common::String fname = path.baseName();
 	if (fname.size() < 4)
 		error("TeBezierCurve::loadBin fname %s is too short", fname.c_str());
 	setName(fname.substr(0, fname.size() - 4));

--- a/engines/tetraedge/te/te_bezier_curve.h
+++ b/engines/tetraedge/te/te_bezier_curve.h
@@ -50,7 +50,7 @@ public:
 
 	static void serialize(Common::WriteStream &stream, const TeBezierCurve &curve);
 	static void deserialize(Common::ReadStream &stream, TeBezierCurve &curve);
-	void loadBin(Common::FSNode &node);
+	void loadBin(const Common::Path &path);
 
 	const Common::Array<TeVector3f32> &controlPoints() { return _controlPoints; }
 	uint numIterations() const { return _numIterations; }

--- a/engines/tetraedge/te/te_camera.cpp
+++ b/engines/tetraedge/te/te_camera.cpp
@@ -169,7 +169,7 @@ void TeCamera::loadXml(const Common::Path &path) {
 	setName(path.baseName());
 	_projectionMatrixType = 3;
 	TeCore *core = g_engine->getCore();
-	Common::Path cameraPath = core->findFileNew(path);
+	Common::Path cameraPath = core->findFile(path);
 	if (!Common::File::exists(cameraPath)) {
 		//
 		// WORKAROUND: scenes/A3_Village/34015 has Camera34010, not 34015
@@ -179,7 +179,7 @@ void TeCamera::loadXml(const Common::Path &path) {
 		if (pos != Common::String::npos) {
 			spath.replace(pos + 4, 1, "0");
 		}
-		cameraPath = core->findFileNew(Common::Path(spath, '/'));
+		cameraPath = core->findFile(Common::Path(spath, '/'));
 	}
 	if (!Common::File::exists(cameraPath)) {
 		warning("Can't open camera data %s", path.toString(Common::Path::kNativeSeparator).c_str());

--- a/engines/tetraedge/te/te_camera.cpp
+++ b/engines/tetraedge/te/te_camera.cpp
@@ -19,6 +19,7 @@
  *
  */
 
+#include "common/file.h"
 #include "math/ray.h"
 
 #include "tetraedge/tetraedge.h"
@@ -168,8 +169,8 @@ void TeCamera::loadXml(const Common::Path &path) {
 	setName(path.baseName());
 	_projectionMatrixType = 3;
 	TeCore *core = g_engine->getCore();
-	Common::FSNode node = core->findFile(path);
-	if (!node.isReadable()) {
+	Common::Path cameraPath = core->findFileNew(path);
+	if (!Common::File::exists(cameraPath)) {
 		//
 		// WORKAROUND: scenes/A3_Village/34015 has Camera34010, not 34015
 		//
@@ -178,28 +179,18 @@ void TeCamera::loadXml(const Common::Path &path) {
 		if (pos != Common::String::npos) {
 			spath.replace(pos + 4, 1, "0");
 		}
-		node = core->findFile(Common::Path(spath, '/'));
+		cameraPath = core->findFileNew(Common::Path(spath, '/'));
 	}
-	if (!node.isReadable()) {
+	if (!Common::File::exists(cameraPath)) {
 		warning("Can't open camera data %s", path.toString(Common::Path::kNativeSeparator).c_str());
 	}
 	TeCameraXmlParser parser;
 	parser._cam = this;
-	if (!parser.loadFile(node))
-		error("TeCamera::loadXml: can't load file %s", node.getPath().toString(Common::Path::kNativeSeparator).c_str());
+	if (!parser.loadFile(cameraPath))
+		error("TeCamera::loadXml: can't load file %s", cameraPath.toString(Common::Path::kNativeSeparator).c_str());
 	if (!parser.parse())
-		error("TeCamera::loadXml: error parsing %s", node.getPath().toString(Common::Path::kNativeSeparator).c_str());
+		error("TeCamera::loadXml: error parsing %s", cameraPath.toString(Common::Path::kNativeSeparator).c_str());
 }
-
-/*
-void TeCamera::loadBin(const Common::Path &path) {
-	error("TODO: Implement TeCamera::loadBin");
-}
-
-void TeCamera::loadBin(const Common::ReadStream &stream) {
-	error("TODO: Implement TeCamera::loadBin");
-}
-*/
 
 void TeCamera::orthogonalParams(float left, float right, float top, float bottom) {
 	_orthogonalParamL = left;

--- a/engines/tetraedge/te/te_camera.h
+++ b/engines/tetraedge/te/te_camera.h
@@ -54,12 +54,6 @@ public:
 	// We just have a separate function.
 	void loadXml(const Common::Path &path);
 
-	// Unused in Syberia 1.
-	//void loadBin(const Common::Path &path);
-	//void loadBin(const Common::ReadStream &stream);
-
-	//void lookAt(const TeVector3f32 &point) {} // empty and unused?
-
 	void orthogonalParams(float f1, float f2, float f3, float f4);
 	TeMatrix4x4 projectionMatrix();
 
@@ -106,7 +100,6 @@ private:
 	uint _viewportH;
 
 	int _transformA;
-	//int _transformB; // never used?
 
 	float _orthogonalParamL;
 	float _orthogonalParamR;

--- a/engines/tetraedge/te/te_core.cpp
+++ b/engines/tetraedge/te/te_core.cpp
@@ -164,6 +164,7 @@ Common::Path TeCore::findFileNew(const Common::Path &path) const {
 		"PC-MacOSX-MacOSXAppStore-Android-iPhone-iPad",
 		"PC-MacOSX-MacOSXAppStore-Xbox360-Android-iPad-iPhone",
 		"Android-iPhone-iPad-PC-MacOSX",
+		"Android-MacOSX",
 		"Full",
 		"Part1-Full",
 		"Part2-Full-Part1",

--- a/engines/tetraedge/te/te_core.cpp
+++ b/engines/tetraedge/te/te_core.cpp
@@ -136,7 +136,7 @@ Common::FSNode TeCore::convertPathToFSNode(const Common::Path &path) const {
 	return Common::FSNode(gameRoot.getChild("Resources").getPath().joinInPlace(path));
 }
 
-Common::Path TeCore::findFileNew(const Common::Path &path) const {
+Common::Path TeCore::findFile(const Common::Path &path) const {
 	if (Common::File::exists(path))
 		return path;
 

--- a/engines/tetraedge/te/te_core.cpp
+++ b/engines/tetraedge/te/te_core.cpp
@@ -136,10 +136,6 @@ Common::FSNode TeCore::convertPathToFSNode(const Common::Path &path) const {
 	return Common::FSNode(gameRoot.getChild("Resources").getPath().joinInPlace(path));
 }
 
-Common::FSNode TeCore::findFile(const Common::Path &path) const {
-	return convertPathToFSNode(findFileNew(path));
-}
-
 Common::Path TeCore::findFileNew(const Common::Path &path) const {
 	if (Common::File::exists(path))
 		return path;

--- a/engines/tetraedge/te/te_core.cpp
+++ b/engines/tetraedge/te/te_core.cpp
@@ -131,11 +131,6 @@ bool TeCore::onActivityTrackingAlarm() {
 	error("TODO: Implement TeCore::onActivityTrackingAlarm");
 }
 
-Common::FSNode TeCore::convertPathToFSNode(const Common::Path &path) const {
-	const Common::FSNode gameRoot(ConfMan.getPath("path"));
-	return Common::FSNode(gameRoot.getChild("Resources").getPath().joinInPlace(path));
-}
-
 Common::Path TeCore::findFile(const Common::Path &path) const {
 	if (Common::File::exists(path))
 		return path;

--- a/engines/tetraedge/te/te_core.cpp
+++ b/engines/tetraedge/te/te_core.cpp
@@ -38,7 +38,7 @@
 
 namespace Tetraedge {
 
-TeCore::TeCore() : _loc(nullptr), _coreNotReady(true) {
+TeCore::TeCore() : _loc(nullptr), _coreNotReady(true), _resourcesRoot("") {
 	create();
 }
 
@@ -61,6 +61,21 @@ void TeCore::create() {
 	_coreNotReady = false;
 	_activityTrackingTimer.alarmSignal().add(this, &TeCore::onActivityTrackingAlarm);
 	warning("TODO: TeCore::create: Finish implementing me.");
+
+	const Common::FSNode gameRoot(ConfMan.getPath("path"));
+	if (!gameRoot.isDirectory())
+		error("Game directory should be a directory");
+	const Common::FSNode resNode = (g_engine->getGamePlatform() == Common::kPlatformMacintosh
+										? gameRoot.getChild("Resources")
+										: gameRoot);
+	if (!resNode.isDirectory())
+		error("Resources directory should exist in game");
+
+	_resourcesRoot = Common::FSDirectory(resNode, 5, false, false, true);
+}
+
+Common::FSNode TeCore::getFSNode(const Common::Path &path) const {
+	return Common::FSNode(Common::Path(_resourcesRoot.getFSNode().getPath()).join(path));
 }
 
 TeICodec *TeCore::createVideoCodec(const Common::String &extn) {

--- a/engines/tetraedge/te/te_core.h
+++ b/engines/tetraedge/te/te_core.h
@@ -56,13 +56,13 @@ public:
 	TeILoc *loc() { return _loc; }
 
 	bool onActivityTrackingAlarm();
-	void enableActivityTracking(bool enable);
-	void setActivityTrackingFolder(const Common::Path &path);
 
 	// Note: this is not in the original, but it's not clear how the original
 	// adds things like "PC-MacOSX" to the path, and there is not clear logic
 	// to them, so here we are.
+	Common::Path findFileNew(const Common::Path &path) const;
 	Common::FSNode findFile(const Common::Path &path) const;
+	Common::FSNode convertPathToFSNode(const Common::Path &path) const;
 
 	bool _coreNotReady;
 

--- a/engines/tetraedge/te/te_core.h
+++ b/engines/tetraedge/te/te_core.h
@@ -60,7 +60,7 @@ public:
 	// Note: this is not in the original, but it's not clear how the original
 	// adds things like "PC-MacOSX" to the path, and there is not clear logic
 	// to them, so here we are.
-	Common::Path findFileNew(const Common::Path &path) const;
+	Common::Path findFile(const Common::Path &path) const;
 	Common::FSNode convertPathToFSNode(const Common::Path &path) const;
 
 	bool _coreNotReady;

--- a/engines/tetraedge/te/te_core.h
+++ b/engines/tetraedge/te/te_core.h
@@ -39,7 +39,6 @@ public:
 	TeCore();
 
 	void addLoc(TeILoc *loc);
-	//void args(int argc, char **argv); // Probably not needed
 	void create();
 	TeICodec *createVideoCodec(const Common::Path &path);
 	TeICodec *createVideoCodec(const Common::String &extn);
@@ -48,7 +47,6 @@ public:
 	Common::Array<Common::String> fileFlagSystemPossibleFlags();
 	bool fileFlagSystemPossibleFlagsContains(const Common::String &name) const;
 	void fileFlagSystemSetFlag(const Common::String &name, const Common::String &val);
-	void fileFlagSystemSetPossibleFlags(const Common::String &name, const Common::Array<Common::String> &vals);
 
 	const Common::String &language() const;
 	void language(const Common::String &val);
@@ -61,7 +59,6 @@ public:
 	// adds things like "PC-MacOSX" to the path, and there is not clear logic
 	// to them, so here we are.
 	Common::Path findFile(const Common::Path &path) const;
-	Common::FSNode convertPathToFSNode(const Common::Path &path) const;
 
 	bool _coreNotReady;
 

--- a/engines/tetraedge/te/te_core.h
+++ b/engines/tetraedge/te/te_core.h
@@ -59,6 +59,7 @@ public:
 	// adds things like "PC-MacOSX" to the path, and there is not clear logic
 	// to them, so here we are.
 	Common::Path findFile(const Common::Path &path) const;
+	Common::FSNode getFSNode(const Common::Path &path) const;
 
 	bool _coreNotReady;
 
@@ -66,6 +67,7 @@ private:
 	TeILoc *_loc;
 
 	Common::HashMap<Common::String, Common::String, Common::CaseSensitiveString_Hash, Common::CaseSensitiveString_EqualTo> _fileSystemFlags;
+	Common::FSDirectory _resourcesRoot;
 
 	TeTimer _activityTrackingTimer;
 };

--- a/engines/tetraedge/te/te_core.h
+++ b/engines/tetraedge/te/te_core.h
@@ -61,7 +61,6 @@ public:
 	// adds things like "PC-MacOSX" to the path, and there is not clear logic
 	// to them, so here we are.
 	Common::Path findFileNew(const Common::Path &path) const;
-	Common::FSNode findFile(const Common::Path &path) const;
 	Common::FSNode convertPathToFSNode(const Common::Path &path) const;
 
 	bool _coreNotReady;

--- a/engines/tetraedge/te/te_font2.cpp
+++ b/engines/tetraedge/te/te_font2.cpp
@@ -42,24 +42,19 @@ bool TeFont2::load(const Common::Path &path) {
 		return true; // already open
 
 	TeCore *core = g_engine->getCore();
-	Common::FSNode node = core->findFile(path);
-	return load(node);
-}
-
-bool TeFont2::load(const Common::FSNode &node) {
-	const Common::Path path = node.getPath();
+	Common::Path fontPath = core->findFileNew(path);
 
 	unload();
 	setAccessName(path);
 	_loadedPath = path;
 
-	if (!node.isReadable()) {
+	if (!Common::File::exists(fontPath)) {
 		warning("TeFont2::load: Can't read from %s", path.toString(Common::Path::kNativeSeparator).c_str());
 		return false;
 	}
 
 	Common::File file;
-	file.open(node);
+	file.open(fontPath);
 
 	if (!Te3DObject2::loadAndCheckFourCC(file, "TESF")) {
 		warning("TeFont2::load: Invalid magic in %s", path.toString(Common::Path::kNativeSeparator).c_str());

--- a/engines/tetraedge/te/te_font2.cpp
+++ b/engines/tetraedge/te/te_font2.cpp
@@ -42,7 +42,7 @@ bool TeFont2::load(const Common::Path &path) {
 		return true; // already open
 
 	TeCore *core = g_engine->getCore();
-	Common::Path fontPath = core->findFileNew(path);
+	Common::Path fontPath = core->findFile(path);
 
 	unload();
 	setAccessName(path);

--- a/engines/tetraedge/te/te_font2.h
+++ b/engines/tetraedge/te/te_font2.h
@@ -71,7 +71,6 @@ public:
 	virtual ~TeFont2();
 
 	bool load(const Common::Path &path);
-	bool load(const Common::FSNode &node);
 	void unload();
 
 	Graphics::Font *getAtSize(uint size) override;

--- a/engines/tetraedge/te/te_font3.cpp
+++ b/engines/tetraedge/te/te_font3.cpp
@@ -56,7 +56,7 @@ Graphics::Font *TeFont3::getAtSize(uint size) {
 
 bool TeFont3::load(const Common::Path &path) {
 	TeCore *core = g_engine->getCore();
-	const Common::Path fontPath = core->findFileNew(path);
+	const Common::Path fontPath = core->findFile(path);
 	if (_loadedPath == fontPath && _fontFile.isOpen())
 		return true; // already open
 

--- a/engines/tetraedge/te/te_font3.cpp
+++ b/engines/tetraedge/te/te_font3.cpp
@@ -55,31 +55,23 @@ Graphics::Font *TeFont3::getAtSize(uint size) {
 }
 
 bool TeFont3::load(const Common::Path &path) {
-	if (_loadedPath == path && _fontFile.isOpen())
-		return true; // already open
-
 	TeCore *core = g_engine->getCore();
-	Common::FSNode node = core->findFile(path);
-	return load(node);
-}
-
-bool TeFont3::load(const Common::FSNode &node) {
-	const Common::Path path = node.getPath();
-	if (_loadedPath == path && _fontFile.isOpen())
+	const Common::Path fontPath = core->findFileNew(path);
+	if (_loadedPath == fontPath && _fontFile.isOpen())
 		return true; // already open
 
-	setAccessName(path);
-	_loadedPath = path;
+	setAccessName(fontPath);
+	_loadedPath = fontPath;
 
-	if (!node.isReadable()) {
-		warning("TeFont3::load: Can't read from %s", path.toString(Common::Path::kNativeSeparator).c_str());
+	if (!Common::File::exists(fontPath)) {
+		warning("TeFont3::load: Can't find %s", path.toString(Common::Path::kNativeSeparator).c_str());
 		return false;
 	}
 
 	if (_fontFile.isOpen())
 		_fontFile.close();
 
-	if (!_fontFile.open(node)) {
+	if (!_fontFile.open(fontPath)) {
 		warning("TeFont3::load: can't open %s", path.toString(Common::Path::kNativeSeparator).c_str());
 		return false;
 	}

--- a/engines/tetraedge/te/te_font3.h
+++ b/engines/tetraedge/te/te_font3.h
@@ -52,7 +52,6 @@ public:
 	virtual ~TeFont3();
 
 	bool load(const Common::Path &path);
-	bool load(const Common::FSNode &node);
 	void unload();
 
 private:

--- a/engines/tetraedge/te/te_free_move_zone.cpp
+++ b/engines/tetraedge/te/te_free_move_zone.cpp
@@ -182,7 +182,7 @@ void TeFreeMoveZone::buildAStar() {
 }
 
 bool TeFreeMoveZone::loadAStar(const Common::Path &path, const TeVector2s32 &size) {
-	Common::Path aStarPath = g_engine->getCore()->findFileNew(path);
+	Common::Path aStarPath = g_engine->getCore()->findFile(path);
 	Common::File file;
 	if (!file.open(aStarPath)) {
 		warning("[TeFreeMoveZone::loadAStar] Can't open file : %s.", path.toString(Common::Path::kNativeSeparator).c_str());
@@ -608,7 +608,7 @@ TeActZone *TeFreeMoveZone::isInZone(const TeVector3f32 &pt) {
 bool TeFreeMoveZone::loadBin(const Common::Path &path, const Common::Array<TeBlocker> *blockers,
 		const Common::Array<TeRectBlocker> *rectblockers, const Common::Array<TeActZone> *actzones,
 		const TeVector2f32 &gridSize) {
-	Common::Path binPath = g_engine->getCore()->findFileNew(path);
+	Common::Path binPath = g_engine->getCore()->findFile(path);
 	if (!Common::File::exists(binPath)) {
 		warning("[TeFreeMoveZone::loadBin] Can't open file : %s.", binPath.baseName().c_str());
 		return false;

--- a/engines/tetraedge/te/te_free_move_zone.cpp
+++ b/engines/tetraedge/te/te_free_move_zone.cpp
@@ -182,9 +182,9 @@ void TeFreeMoveZone::buildAStar() {
 }
 
 bool TeFreeMoveZone::loadAStar(const Common::Path &path, const TeVector2s32 &size) {
-	Common::FSNode node = g_engine->getCore()->findFile(path);
+	Common::Path aStarPath = g_engine->getCore()->findFileNew(path);
 	Common::File file;
-	if (!node.isReadable() || !file.open(node)) {
+	if (!file.open(aStarPath)) {
 		warning("[TeFreeMoveZone::loadAStar] Can't open file : %s.", path.toString(Common::Path::kNativeSeparator).c_str());
 		return false;
 	}
@@ -608,14 +608,14 @@ TeActZone *TeFreeMoveZone::isInZone(const TeVector3f32 &pt) {
 bool TeFreeMoveZone::loadBin(const Common::Path &path, const Common::Array<TeBlocker> *blockers,
 		const Common::Array<TeRectBlocker> *rectblockers, const Common::Array<TeActZone> *actzones,
 		const TeVector2f32 &gridSize) {
-	Common::FSNode node = g_engine->getCore()->findFile(path);
-	if (!node.isReadable()) {
-		warning("[TeFreeMoveZone::loadBin] Can't open file : %s.", node.getName().c_str());
+	Common::Path binPath = g_engine->getCore()->findFileNew(path);
+	if (!Common::File::exists(binPath)) {
+		warning("[TeFreeMoveZone::loadBin] Can't open file : %s.", binPath.baseName().c_str());
 		return false;
 	}
 	_aszGridPath = path.append(".aszgrid");
 	Common::File file;
-	file.open(node);
+	file.open(binPath);
 	return loadBin(file, blockers, rectblockers, actzones, gridSize);
 }
 

--- a/engines/tetraedge/te/te_i_codec.h
+++ b/engines/tetraedge/te/te_i_codec.h
@@ -36,7 +36,7 @@ public:
 	TeICodec() {};
 
 	virtual ~TeICodec() {};
-	virtual bool load(const Common::FSNode &node) = 0;
+	virtual bool load(const Common::Path &path) = 0;
 	virtual uint width() = 0;
 	virtual uint height() = 0;
 	virtual int nbFrames() = 0;

--- a/engines/tetraedge/te/te_image.cpp
+++ b/engines/tetraedge/te/te_image.cpp
@@ -22,6 +22,7 @@
 #include "tetraedge/tetraedge.h"
 
 #include "common/endian.h"
+#include "common/file.h"
 #include "common/rect.h"
 #include "tetraedge/te/te_core.h"
 #include "tetraedge/te/te_image.h"
@@ -100,11 +101,11 @@ bool TeImage::isExtensionSupported(const Common::Path &path) {
 	error("TODO: Implement TeImage::isExtensionSupported");
 }
 
-bool TeImage::load(const Common::FSNode &node) {
+bool TeImage::load(const Common::Path &path) {
 	TeCore *core = g_engine->getCore();
-	TeICodec *codec = core->createVideoCodec(node.getPath());
-	if (!node.isReadable() || !codec->load(node)) {
-		warning("TeImage::load: Failed to load %s.", node.getPath().toString(Common::Path::kNativeSeparator).c_str());
+	TeICodec *codec = core->createVideoCodec(path);
+	if (!Common::File::exists(path) || !codec->load(core->convertPathToFSNode(path))) {
+		warning("TeImage::load: Failed to load %s.", path.toString(Common::Path::kNativeSeparator).c_str());
 		delete codec;
 		return false;
 	}
@@ -113,7 +114,7 @@ bool TeImage::load(const Common::FSNode &node) {
 	createImg(codec->width(), codec->height(), nullpal, codec->imageFormat(), codec->width(), codec->height());
 
 	if (!codec->update(0, *this)) {
-		error("TeImage::load: Failed to update from %s.", node.getPath().toString(Common::Path::kNativeSeparator).c_str());
+		error("TeImage::load: Failed to update from %s.", path.toString(Common::Path::kNativeSeparator).c_str());
 	}
 	delete codec;
 	return true;

--- a/engines/tetraedge/te/te_image.cpp
+++ b/engines/tetraedge/te/te_image.cpp
@@ -104,7 +104,7 @@ bool TeImage::isExtensionSupported(const Common::Path &path) {
 bool TeImage::load(const Common::Path &path) {
 	TeCore *core = g_engine->getCore();
 	TeICodec *codec = core->createVideoCodec(path);
-	if (!Common::File::exists(path) || !codec->load(core->convertPathToFSNode(path))) {
+	if (!Common::File::exists(path) || !codec->load(path)) {
 		warning("TeImage::load: Failed to load %s.", path.toString(Common::Path::kNativeSeparator).c_str());
 		delete codec;
 		return false;

--- a/engines/tetraedge/te/te_image.h
+++ b/engines/tetraedge/te/te_image.h
@@ -75,7 +75,7 @@ public:
 	void fill(byte r, byte g, byte b, byte a);
 	void getBuff(uint x, uint y, byte *pout, uint w, uint h);
 	bool isExtensionSupported(const Common::Path &path);
-	bool load(const Common::FSNode &node);
+	bool load(const Common::Path &path);
 	bool load(Common::SeekableReadStream &stream, const Common::String &type);
 	bool save(const Common::Path &path, enum SaveType type);
 	int serialize(Common::WriteStream &stream);

--- a/engines/tetraedge/te/te_images_sequence.cpp
+++ b/engines/tetraedge/te/te_images_sequence.cpp
@@ -20,11 +20,12 @@
  */
 
 #include "common/file.h"
-#include "common/config-manager.h"
 #include "image/png.h"
 #include "graphics/surface.h"
 #include "graphics/managed_surface.h"
 
+#include "tetraedge/tetraedge.h"
+#include "tetraedge/te/te_core.h"
 #include "tetraedge/te/te_images_sequence.h"
 
 namespace Tetraedge {
@@ -49,8 +50,7 @@ static bool compareNodes(const Common::FSNode &left, const Common::FSNode &right
 }
 
 bool TeImagesSequence::load(const Common::Path &directory) {
-	const Common::FSNode gameRoot(ConfMan.getPath("path"));
-	Common::FSNode dir(gameRoot.getChild("Resources").getPath().joinInPlace(directory));
+	Common::FSNode dir = g_engine->getCore()->getFSNode(directory);
 
 	const Common::String path = directory.toString('/');
 	if (!dir.isDirectory()) {

--- a/engines/tetraedge/te/te_images_sequence.cpp
+++ b/engines/tetraedge/te/te_images_sequence.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "common/file.h"
+#include "common/config-manager.h"
 #include "image/png.h"
 #include "graphics/surface.h"
 #include "graphics/managed_surface.h"
@@ -47,16 +48,19 @@ static bool compareNodes(const Common::FSNode &left, const Common::FSNode &right
 	return left.getPath().toString('/') < right.getPath().toString('/');
 }
 
-bool TeImagesSequence::load(const Common::FSNode &directory) {
-	const Common::String path = directory.getPath().toString('/');
-	if (!directory.isDirectory()) {
-		warning("TeImagesSequence::load:: not a directory %s", directory.getPath().toString(Common::Path::kNativeSeparator).c_str());
+bool TeImagesSequence::load(const Common::Path &directory) {
+	const Common::FSNode gameRoot(ConfMan.getPath("path"));
+	Common::FSNode dir(gameRoot.getChild("Resources").getPath().joinInPlace(directory));
+
+	const Common::String path = directory.toString('/');
+	if (!dir.isDirectory()) {
+		warning("TeImagesSequence::load:: not a directory %s", directory.toString(Common::Path::kNativeSeparator).c_str());
 		return false;
 	}
 
 	Common::FSList children;
-	if (!directory.getChildren(children, Common::FSNode::kListFilesOnly) || children.empty()) {
-		warning("TeImagesSequence::load:: couldn't get children of %s", directory.getPath().toString(Common::Path::kNativeSeparator).c_str());
+	if (!dir.getChildren(children, Common::FSNode::kListFilesOnly) || children.empty()) {
+		warning("TeImagesSequence::load:: couldn't get children of %s", directory.toString(Common::Path::kNativeSeparator).c_str());
 		return false;
 	}
 

--- a/engines/tetraedge/te/te_images_sequence.h
+++ b/engines/tetraedge/te/te_images_sequence.h
@@ -37,7 +37,7 @@ public:
 	TeImagesSequence();
 	virtual ~TeImagesSequence();
 
-	virtual bool load(const Common::FSNode &node) override;
+	virtual bool load(const Common::Path &path) override;
 	virtual uint width() override { return _width; }
 	virtual uint height() override { return _height; }
 	virtual int nbFrames() override { return _files.size(); }

--- a/engines/tetraedge/te/te_interpolation.cpp
+++ b/engines/tetraedge/te/te_interpolation.cpp
@@ -37,10 +37,10 @@ void TeInterpolation::load(Common::ReadStream &stream) {
 		_array[i] = stream.readFloatLE();
 }
 
-void TeInterpolation::load(Common::FSNode &node) {
+void TeInterpolation::load(Common::Path &path) {
 	Common::File f;
-	if (!f.open(node))
-		error("Couldn't open %s", node.getPath().toString(Common::Path::kNativeSeparator).c_str());
+	if (!f.open(path))
+		error("Couldn't open %s", path.toString(Common::Path::kNativeSeparator).c_str());
 
 	load(f);
 }

--- a/engines/tetraedge/te/te_interpolation.h
+++ b/engines/tetraedge/te/te_interpolation.h
@@ -33,7 +33,7 @@ public:
 	TeInterpolation();
 
 	void load(Common::ReadStream &stream);
-	void load(Common::FSNode &node);
+	void load(Common::Path &path);
 
 	// Note: this function is not in the original but simplifies
 	// the code for TeCurveAnim2 a lot.

--- a/engines/tetraedge/te/te_lua_context.cpp
+++ b/engines/tetraedge/te/te_lua_context.cpp
@@ -142,7 +142,7 @@ enum TeLuaSaveVarType {
 	String = 4
 };
 
-#define TETRAEDGE_LUA_DEBUG_SAVELOAD
+//#define TETRAEDGE_LUA_DEBUG_SAVELOAD
 
 Common::Error TeLuaContext::syncState(Common::Serializer &s) {
 	// Save/Load globals.  The format of saving is:

--- a/engines/tetraedge/te/te_lua_gui.cpp
+++ b/engines/tetraedge/te/te_lua_gui.cpp
@@ -181,7 +181,7 @@ bool TeLuaGUI::load(const Common::Path &subPath) {
 	TeCore *core = g_engine->getCore();
 
 	unload();
-	_scriptPath = core->findFileNew(subPath);
+	_scriptPath = core->findFile(subPath);
 	// Not the same as original, we abstract the search logic a bit.
 	_luaContext.setGlobal("Pixel", 0);
 	_luaContext.setGlobal("Percent", 1);

--- a/engines/tetraedge/te/te_lua_gui.cpp
+++ b/engines/tetraedge/te/te_lua_gui.cpp
@@ -179,12 +179,9 @@ TeSpriteLayout *TeLuaGUI::spriteLayoutChecked(const Common::String &name) {
 
 bool TeLuaGUI::load(const Common::Path &subPath) {
 	TeCore *core = g_engine->getCore();
-	return load(core->findFile(subPath));
-}
 
-bool TeLuaGUI::load(const Common::FSNode &node) {
 	unload();
-	_scriptPath = node.getPath();
+	_scriptPath = core->findFileNew(subPath);
 	// Not the same as original, we abstract the search logic a bit.
 	_luaContext.setGlobal("Pixel", 0);
 	_luaContext.setGlobal("Percent", 1);
@@ -213,7 +210,7 @@ bool TeLuaGUI::load(const Common::FSNode &node) {
 	_luaContext.registerCFunction("TeVideoLayout", spriteLayoutBindings);
 	_luaContext.setInRegistry("__TeLuaGUIThis", this);
 	_luaScript.attachToContext(&_luaContext);
-	_luaScript.load(node);
+	_luaScript.load(_scriptPath);
 	_luaScript.execute();
 	_luaScript.unload();
 	_loaded = true;

--- a/engines/tetraedge/te/te_lua_gui.h
+++ b/engines/tetraedge/te/te_lua_gui.h
@@ -78,7 +78,6 @@ public:
 	TeSpriteLayout *spriteLayoutChecked(const Common::String &name);
 
 	bool load(const Common::Path &subPath);
-	bool load(const Common::FSNode &node);
 	void unload();
 
 	TeVariant value(const Common::String &key);

--- a/engines/tetraedge/te/te_lua_script.cpp
+++ b/engines/tetraedge/te/te_lua_script.cpp
@@ -82,13 +82,13 @@ void TeLuaScript::execute(const Common::String &fname, const TeVariant &p1, cons
 	}
 }
 
-void TeLuaScript::load(const Common::FSNode &node) {
+void TeLuaScript::load(const Common::Path &node) {
 	_started = false;
 	_scriptNode = node;
 }
 
 void TeLuaScript::unload() {
-	_scriptNode = Common::FSNode();
+	_scriptNode = Common::Path();
 	_started = false;
 }
 

--- a/engines/tetraedge/te/te_lua_script.h
+++ b/engines/tetraedge/te/te_lua_script.h
@@ -42,13 +42,13 @@ public:
 	void execute(const Common::String &fname, const TeVariant &p1, const TeVariant &p2);
 	void execute(const Common::String &fname, const TeVariant &p1, const TeVariant &p2, const TeVariant &p3);
 
-	void load(const Common::FSNode &node);
+	void load(const Common::Path &node);
 	void unload();
 
 private:
 	TeLuaContext *_luaContext;
 
-	Common::FSNode _scriptNode;
+	Common::Path _scriptNode;
 	bool _started;
 };
 

--- a/engines/tetraedge/te/te_lua_thread.cpp
+++ b/engines/tetraedge/te/te_lua_thread.cpp
@@ -254,10 +254,10 @@ void TeLuaThread::applyScriptWorkarounds(char *buf, const Common::String &fileNa
 	}
 }
 
-void TeLuaThread::executeFile(const Common::FSNode &node) {
+void TeLuaThread::executeFile(const Common::Path &node) {
 	Common::File scriptFile;
 	if (!scriptFile.open(node)) {
-		warning("TeLuaThread::executeFile: File %s can't be opened", node.getName().c_str());
+		warning("TeLuaThread::executeFile: File %s can't be opened", node.getLastComponent().toString().c_str());
 		return;
 	}
 
@@ -271,9 +271,9 @@ void TeLuaThread::executeFile(const Common::FSNode &node) {
 	buf[fileLen] = 0;
 	scriptFile.close();
 
-	applyScriptWorkarounds(buf, node.getName());
+	applyScriptWorkarounds(buf, node.getLastComponent().toString());
 
-	_lastResumeResult = luaL_loadbuffer(_luaThread, buf, fileLen, node.getPath().toString(Common::Path::kNativeSeparator).c_str());
+	_lastResumeResult = luaL_loadbuffer(_luaThread, buf, fileLen, node.toString(Common::Path::kNativeSeparator).c_str());
 	if (_lastResumeResult) {
 		const char *msg = lua_tostring(_luaThread, -1);
 		warning("TeLuaThread::executeFile: %s", msg);

--- a/engines/tetraedge/te/te_lua_thread.cpp
+++ b/engines/tetraedge/te/te_lua_thread.cpp
@@ -257,7 +257,7 @@ void TeLuaThread::applyScriptWorkarounds(char *buf, const Common::String &fileNa
 void TeLuaThread::executeFile(const Common::Path &node) {
 	Common::File scriptFile;
 	if (!scriptFile.open(node)) {
-		warning("TeLuaThread::executeFile: File %s can't be opened", node.getLastComponent().toString().c_str());
+		warning("TeLuaThread::executeFile: File %s can't be opened", node.baseName().c_str());
 		return;
 	}
 
@@ -271,7 +271,7 @@ void TeLuaThread::executeFile(const Common::Path &node) {
 	buf[fileLen] = 0;
 	scriptFile.close();
 
-	applyScriptWorkarounds(buf, node.getLastComponent().toString());
+	applyScriptWorkarounds(buf, node.baseName());
 
 	_lastResumeResult = luaL_loadbuffer(_luaThread, buf, fileLen, node.toString(Common::Path::kNativeSeparator).c_str());
 	if (_lastResumeResult) {

--- a/engines/tetraedge/te/te_lua_thread.h
+++ b/engines/tetraedge/te/te_lua_thread.h
@@ -46,7 +46,7 @@ public:
 	void execute(const Common::String &str, const TeVariant &p1, const TeVariant &p2);
 	void execute(const Common::String &str, const TeVariant &p1, const TeVariant &p2, const TeVariant &p3);
 
-	void executeFile(const Common::FSNode &node);
+	void executeFile(const Common::Path &node);
 	void pushValue(const TeVariant &val);
 
 	void release();

--- a/engines/tetraedge/te/te_material.cpp
+++ b/engines/tetraedge/te/te_material.cpp
@@ -97,10 +97,10 @@ void TeMaterial::deserialize(Common::SeekableReadStream &stream, TeMaterial &mat
 
 	if (nameStr.size()) {
 		TeCore *core = g_engine->getCore();
-		Common::FSNode texNode = core->findFile(texPath.join(nameStr));
-		material._texture = Te3DTexture::load2(texNode, false);
+		Common::Path matPath = core->findFileNew(texPath.join(nameStr));
+		material._texture = Te3DTexture::load2(matPath, false);
 		if (!material._texture)
-			warning("failed to load texture %s (texpath %s)", nameStr.c_str(), texPath.toString(Common::Path::kNativeSeparator).c_str());
+			warning("failed to load texture %s (texpath %s)", nameStr.c_str(), matPath.toString(Common::Path::kNativeSeparator).c_str());
 	}
 
 	material._ambientColor.deserialize(stream);

--- a/engines/tetraedge/te/te_material.cpp
+++ b/engines/tetraedge/te/te_material.cpp
@@ -97,7 +97,7 @@ void TeMaterial::deserialize(Common::SeekableReadStream &stream, TeMaterial &mat
 
 	if (nameStr.size()) {
 		TeCore *core = g_engine->getCore();
-		Common::Path matPath = core->findFileNew(texPath.join(nameStr));
+		Common::Path matPath = core->findFile(texPath.join(nameStr));
 		material._texture = Te3DTexture::load2(matPath, false);
 		if (!material._texture)
 			warning("failed to load texture %s (texpath %s)", nameStr.c_str(), matPath.toString(Common::Path::kNativeSeparator).c_str());

--- a/engines/tetraedge/te/te_model.h
+++ b/engines/tetraedge/te/te_model.h
@@ -139,7 +139,6 @@ public:
 
 protected:
 	TeMatrix4x4 lerpElementsMatrix(uint weightNum, const Common::Array<TeMatrix4x4> &matricies);
-	void optimize();
 
 	Common::Path _texturePath;
 	TeIntrusivePtr<TeTiledTexture> _tiledTexture;

--- a/engines/tetraedge/te/te_model_animation.cpp
+++ b/engines/tetraedge/te/te_model_animation.cpp
@@ -181,7 +181,7 @@ int TeModelAnimation::lastFrame() const {
 }
 
 bool TeModelAnimation::load(const Common::Path &path) {
-	Common::FSNode foundFile = g_engine->getCore()->findFile(path);
+	Common::Path foundFile = g_engine->getCore()->findFileNew(path);
 	Common::File modelFile;
 	if (!modelFile.open(foundFile)) {
 		warning("[TeModel::load] Can't open file : %s.", path.toString(Common::Path::kNativeSeparator).c_str());

--- a/engines/tetraedge/te/te_model_animation.cpp
+++ b/engines/tetraedge/te/te_model_animation.cpp
@@ -181,7 +181,7 @@ int TeModelAnimation::lastFrame() const {
 }
 
 bool TeModelAnimation::load(const Common::Path &path) {
-	Common::Path foundFile = g_engine->getCore()->findFileNew(path);
+	Common::Path foundFile = g_engine->getCore()->findFile(path);
 	Common::File modelFile;
 	if (!modelFile.open(foundFile)) {
 		warning("[TeModel::load] Can't open file : %s.", path.toString(Common::Path::kNativeSeparator).c_str());

--- a/engines/tetraedge/te/te_music.cpp
+++ b/engines/tetraedge/te/te_music.cpp
@@ -60,11 +60,11 @@ void TeMusic::pause() {
 bool TeMusic::play() {
 	if (isPlaying())
 		return true;
-	if (!_fileNode.exists())
+	if (!Common::File::exists(_filePath))
 		return false;
 
 	Common::File *streamfile = new Common::File();
-	if (!streamfile->open(_fileNode)) {
+	if (!streamfile->open(_filePath)) {
 		delete streamfile;
 		return false;
 	}
@@ -191,7 +191,7 @@ void TeMusic::setFilePath(const Common::Path &name) {
 	_rawPath = name;
 	TeCore *core = g_engine->getCore();
 	// Note: original search logic here abstracted away in our version..
-	_fileNode = core->findFile(name);
+	_filePath = core->findFileNew(name);
 }
 
 void TeMusic::update() {

--- a/engines/tetraedge/te/te_music.cpp
+++ b/engines/tetraedge/te/te_music.cpp
@@ -191,7 +191,7 @@ void TeMusic::setFilePath(const Common::Path &name) {
 	_rawPath = name;
 	TeCore *core = g_engine->getCore();
 	// Note: original search logic here abstracted away in our version..
-	_filePath = core->findFileNew(name);
+	_filePath = core->findFile(name);
 }
 
 void TeMusic::update() {

--- a/engines/tetraedge/te/te_music.h
+++ b/engines/tetraedge/te/te_music.h
@@ -74,7 +74,7 @@ public:
 
 private:
 	Common::Path _rawPath; // Plain name of file requested
-	Common::FSNode _fileNode; // file after finding it
+	Common::Path _filePath; // file after finding it
 	Common::String _channelName;
 
 	bool _repeat;

--- a/engines/tetraedge/te/te_particle.cpp
+++ b/engines/tetraedge/te/te_particle.cpp
@@ -52,9 +52,7 @@ bool TeParticle::loadTexture(const Common::String &filename) {
 	// Path for these textures includes '/' so convert to Path object first.
 	const Common::Path path(filename);
 	_texture = Te3DTexture::makeInstance();
-	TeCore *core = g_engine->getCore();
-	Common::FSNode texnode = core->findFile(path);
-	return _texture->load(texnode);
+	return _texture->load(g_engine->getCore()->findFileNew(path));
 }
 
 void TeParticle::setOrientation(const TeVector3f32 &orientation) {

--- a/engines/tetraedge/te/te_particle.cpp
+++ b/engines/tetraedge/te/te_particle.cpp
@@ -52,7 +52,7 @@ bool TeParticle::loadTexture(const Common::String &filename) {
 	// Path for these textures includes '/' so convert to Path object first.
 	const Common::Path path(filename);
 	_texture = Te3DTexture::makeInstance();
-	return _texture->load(g_engine->getCore()->findFileNew(path));
+	return _texture->load(g_engine->getCore()->findFile(path));
 }
 
 void TeParticle::setOrientation(const TeVector3f32 &orientation) {

--- a/engines/tetraedge/te/te_png.cpp
+++ b/engines/tetraedge/te/te_png.cpp
@@ -44,8 +44,8 @@ bool TePng::matchExtension(const Common::String &extn) {
 	return extn == "png" || extn == "png#anim";
 }
 
-bool TePng::load(const Common::FSNode &node) {
-	if (!TeScummvmCodec::load(node))
+bool TePng::load(const Common::Path &path) {
+	if (!TeScummvmCodec::load(path))
 		return false;
 
 	_height = _loadedSurface->h / _nbFrames;

--- a/engines/tetraedge/te/te_png.h
+++ b/engines/tetraedge/te/te_png.h
@@ -36,7 +36,7 @@ public:
 	TePng(const Common::String &extn);
 	virtual ~TePng();
 
-	virtual bool load(const Common::FSNode &node) override;
+	virtual bool load(const Common::Path &path) override;
 	virtual bool load(Common::SeekableReadStream &stream) override;
 
 	TeImage::Format imageFormat() override;

--- a/engines/tetraedge/te/te_resource_manager.h
+++ b/engines/tetraedge/te/te_resource_manager.h
@@ -79,6 +79,25 @@ public:
 		return retval;
 	}
 
+	template<class T>
+	TeIntrusivePtr<T> getResource(const Common::Path &path) {
+		for (TeIntrusivePtr<TeResource> &resource : this->_resources) {
+			if (resource->getAccessName() == path) {
+				return TeIntrusivePtr<T>(dynamic_cast<T *>(resource.get()));
+			}
+		}
+
+		TeIntrusivePtr<T> retval = new T();
+
+		if (retval.get()) {
+			if (!Common::File::exists(path))
+				warning("getResource: asked to fetch unreadable resource %s", path.toString(Common::Path::kNativeSeparator).c_str());
+			retval->load(path);
+			addResource(retval.get());
+		}
+		return retval;
+	}
+
 	template<class T> TeIntrusivePtr<T> getResourceOrMakeInstance(const Common::FSNode &node) {
 		Common::Path path = node.getPath();
 		for (TeIntrusivePtr<TeResource> &resource : this->_resources) {

--- a/engines/tetraedge/te/te_resource_manager.h
+++ b/engines/tetraedge/te/te_resource_manager.h
@@ -59,26 +59,6 @@ public:
 		return TeIntrusivePtr<T>();
 	}
 
-	template<class T> TeIntrusivePtr<T> getResource(const Common::FSNode &node) {
-		Common::Path path = node.getPath();
-		for (TeIntrusivePtr<TeResource> &resource : this->_resources) {
-			if (resource->getAccessName() == path) {
-				return TeIntrusivePtr<T>(dynamic_cast<T *>(resource.get()));
-			}
-		}
-
-		TeIntrusivePtr<T> retval;
-		retval = new T();
-
-		if (retval.get()) {
-			if (!node.isReadable())
-				warning("getResource: asked to fetch unreadable resource %s", node.getPath().toString(Common::Path::kNativeSeparator).c_str());
-			retval->load(node);
-			addResource(retval.get());
-		}
-		return retval;
-	}
-
 	template<class T>
 	TeIntrusivePtr<T> getResource(const Common::Path &path) {
 		for (TeIntrusivePtr<TeResource> &resource : this->_resources) {
@@ -93,26 +73,6 @@ public:
 			if (!Common::File::exists(path))
 				warning("getResource: asked to fetch unreadable resource %s", path.toString(Common::Path::kNativeSeparator).c_str());
 			retval->load(path);
-			addResource(retval.get());
-		}
-		return retval;
-	}
-
-	template<class T> TeIntrusivePtr<T> getResourceOrMakeInstance(const Common::FSNode &node) {
-		Common::Path path = node.getPath();
-		for (TeIntrusivePtr<TeResource> &resource : this->_resources) {
-			if (resource->getAccessName() == path) {
-				return TeIntrusivePtr<T>(dynamic_cast<T *>(resource.get()));
-			}
-		}
-
-		TeIntrusivePtr<T> retval;
-		retval = T::makeInstance();
-
-		if (retval.get()) {
-			if (!node.isReadable())
-				warning("getResourceOrMakeInstance: asked to fetch unreadable resource %s", node.getPath().toString(Common::Path::kNativeSeparator).c_str());
-			retval->load(node);
 			addResource(retval.get());
 		}
 		return retval;

--- a/engines/tetraedge/te/te_scene.h
+++ b/engines/tetraedge/te/te_scene.h
@@ -47,7 +47,7 @@ public:
 	Common::String currentCameraName() const;
 
 	virtual void draw();
-	virtual bool load(const Common::FSNode &node) { return false; };
+	virtual bool load(const Common::Path &path) { return false; };
 
 	void removeModel(const Common::String &mname);
 	void setCurrentCamera(const Common::String &cname);

--- a/engines/tetraedge/te/te_scene_warp.cpp
+++ b/engines/tetraedge/te/te_scene_warp.cpp
@@ -77,8 +77,8 @@ bool TeSceneWarp::load(const Common::Path &name, TeWarp *warp, bool flag) {
 
 	TeSceneWarpXmlParser parser(this, flag);
 	TeCore *core = g_engine->getCore();
-	Common::FSNode node = core->findFile(name);
-	if (!parser.loadFile(node))
+	Common::Path path = core->findFileNew(name);
+	if (!parser.loadFile(path))
 		error("TeSceneWarp::load: failed to load data from %s", name.toString(Common::Path::kNativeSeparator).c_str());
 	if (!parser.parse())
 		error("TeSceneWarp::load: failed to parse data from %s", name.toString(Common::Path::kNativeSeparator).c_str());

--- a/engines/tetraedge/te/te_scene_warp.cpp
+++ b/engines/tetraedge/te/te_scene_warp.cpp
@@ -77,7 +77,7 @@ bool TeSceneWarp::load(const Common::Path &name, TeWarp *warp, bool flag) {
 
 	TeSceneWarpXmlParser parser(this, flag);
 	TeCore *core = g_engine->getCore();
-	Common::Path path = core->findFileNew(name);
+	Common::Path path = core->findFile(name);
 	if (!parser.loadFile(path))
 		error("TeSceneWarp::load: failed to load data from %s", name.toString(Common::Path::kNativeSeparator).c_str());
 	if (!parser.parse())

--- a/engines/tetraedge/te/te_scummvm_codec.cpp
+++ b/engines/tetraedge/te/te_scummvm_codec.cpp
@@ -38,10 +38,10 @@ TeScummvmCodec::~TeScummvmCodec() {
 	}
 }
 
-bool TeScummvmCodec::load(const Common::FSNode &node) {
+bool TeScummvmCodec::load(const Common::Path &path) {
 	Common::File file;
-	if (file.open(node) && load(static_cast<Common::SeekableReadStream&>(file))) {
-		_loadedPath = node.getPath();
+	if (file.open(path) && load(static_cast<Common::SeekableReadStream &>(file))) {
+		_loadedPath = path;
 		return true;
 	}
 	return false;

--- a/engines/tetraedge/te/te_scummvm_codec.h
+++ b/engines/tetraedge/te/te_scummvm_codec.h
@@ -32,7 +32,7 @@ public:
 	TeScummvmCodec();
 	virtual ~TeScummvmCodec();
 
-	virtual bool load(const Common::FSNode &node) override;
+	virtual bool load(const Common::Path &path) override;
 	virtual bool load(Common::SeekableReadStream &stream) = 0;
 	virtual uint width() override;
 	virtual uint height() override;

--- a/engines/tetraedge/te/te_sound_manager.cpp
+++ b/engines/tetraedge/te/te_sound_manager.cpp
@@ -43,7 +43,7 @@ void TeSoundManager::playFreeSound(const Common::Path &path) {
 
 void TeSoundManager::playFreeSound(const Common::Path &path, float vol, const Common::String &channel) {
 	TeCore *core = g_engine->getCore();
-	Common::Path sndPath = core->findFileNew(path);
+	Common::Path sndPath = core->findFile(path);
 
 	Common::File *streamfile = new Common::File();
 	if (!streamfile->open(sndPath)) {

--- a/engines/tetraedge/te/te_sound_manager.cpp
+++ b/engines/tetraedge/te/te_sound_manager.cpp
@@ -43,11 +43,11 @@ void TeSoundManager::playFreeSound(const Common::Path &path) {
 
 void TeSoundManager::playFreeSound(const Common::Path &path, float vol, const Common::String &channel) {
 	TeCore *core = g_engine->getCore();
-	Common::FSNode sndNode = core->findFile(path);
+	Common::Path sndPath = core->findFileNew(path);
 
 	Common::File *streamfile = new Common::File();
-	if (!sndNode.isReadable() || !streamfile->open(sndNode)) {
-		warning("TeSoundManager::playFreeSound: couldn't open %s", sndNode.getPath().toString(Common::Path::kNativeSeparator).c_str());
+	if (!streamfile->open(sndPath)) {
+		warning("TeSoundManager::playFreeSound: couldn't open %s", sndPath.toString(Common::Path::kNativeSeparator).c_str());
 		delete streamfile;
 		return;
 	}

--- a/engines/tetraedge/te/te_sprite_layout.cpp
+++ b/engines/tetraedge/te/te_sprite_layout.cpp
@@ -19,6 +19,8 @@
  *
  */
 
+#include "common/file.h"
+
 #include "tetraedge/tetraedge.h"
 #include "tetraedge/te/te_core.h"
 #include "tetraedge/te/te_matrix4x4.h"
@@ -80,14 +82,10 @@ bool TeSpriteLayout::load(const Common::Path &path) {
 	}
 
 	TeCore *core = g_engine->getCore();
-	Common::FSNode node = core->findFile(path);
-	if (!load(node, &path))
-		return false;
-	return true;
-}
+	Common::Path spritePath = core->findFileNew(path);
+	Common::FSNode spriteNode = core->findFile(path);
 
-bool TeSpriteLayout::load(const Common::FSNode &node, const Common::Path *forcePath) {
-	if (!node.exists()) {
+	if (!Common::File::exists(spritePath) && !spriteNode.exists()) {
 		_tiledSurfacePtr->unload();
 		return false;
 	}
@@ -95,8 +93,8 @@ bool TeSpriteLayout::load(const Common::FSNode &node, const Common::Path *forceP
 	stop();
 	unload();
 
-	_tiledSurfacePtr->setLoadedPath(forcePath ? *forcePath : Common::Path());
-	if (_tiledSurfacePtr->load(node)) {
+	_tiledSurfacePtr->setLoadedPath(path);
+	if (_tiledSurfacePtr->load(spritePath)) {
 		const TeVector2s32 texSize = _tiledSurfacePtr->tiledTexture()->totalSize();
 		if (texSize._y <= 0) {
 			setRatio(1.0);
@@ -108,7 +106,7 @@ bool TeSpriteLayout::load(const Common::FSNode &node, const Common::Path *forceP
 		}
 		updateMesh();
 	} else {
-		debug("Failed to load TeSpriteLayout %s", node.getPath().toString(Common::Path::kNativeSeparator).c_str());
+		debug("Failed to load TeSpriteLayout %s", path.toString(Common::Path::kNativeSeparator).c_str());
 		_tiledSurfacePtr->setLoadedPath("");
 	}
 	return true;

--- a/engines/tetraedge/te/te_sprite_layout.cpp
+++ b/engines/tetraedge/te/te_sprite_layout.cpp
@@ -82,7 +82,7 @@ bool TeSpriteLayout::load(const Common::Path &path) {
 	}
 
 	TeCore *core = g_engine->getCore();
-	Common::Path spritePath = core->findFileNew(path);
+	Common::Path spritePath = core->findFile(path);
 	Common::FSNode spriteNode = core->convertPathToFSNode(spritePath);
 
 	// The path can point to a single file, or a folder with files

--- a/engines/tetraedge/te/te_sprite_layout.cpp
+++ b/engines/tetraedge/te/te_sprite_layout.cpp
@@ -19,7 +19,6 @@
  *
  */
 
-#include "common/config-manager.h"
 #include "common/file.h"
 
 #include "tetraedge/tetraedge.h"
@@ -83,8 +82,7 @@ bool TeSpriteLayout::load(const Common::Path &path) {
 	}
 
 	TeCore *core = g_engine->getCore();
-	const Common::FSNode gameRoot(ConfMan.getPath("path"));
-	Common::FSNode spriteNode(gameRoot.getChild("Resources").getPath().joinInPlace(path));
+	Common::FSNode spriteNode = core->getFSNode(path);
 	Common::Path spritePath(path);
 
 	// The path can point to a single file, or a folder with files

--- a/engines/tetraedge/te/te_sprite_layout.cpp
+++ b/engines/tetraedge/te/te_sprite_layout.cpp
@@ -83,8 +83,9 @@ bool TeSpriteLayout::load(const Common::Path &path) {
 
 	TeCore *core = g_engine->getCore();
 	Common::Path spritePath = core->findFileNew(path);
-	Common::FSNode spriteNode = core->findFile(path);
+	Common::FSNode spriteNode = core->convertPathToFSNode(spritePath);
 
+	// The path can point to a single file, or a folder with files
 	if (!Common::File::exists(spritePath) && !spriteNode.exists()) {
 		_tiledSurfacePtr->unload();
 		return false;

--- a/engines/tetraedge/te/te_sprite_layout.cpp
+++ b/engines/tetraedge/te/te_sprite_layout.cpp
@@ -19,6 +19,7 @@
  *
  */
 
+#include "common/config-manager.h"
 #include "common/file.h"
 
 #include "tetraedge/tetraedge.h"
@@ -82,13 +83,22 @@ bool TeSpriteLayout::load(const Common::Path &path) {
 	}
 
 	TeCore *core = g_engine->getCore();
-	Common::Path spritePath = core->findFile(path);
-	Common::FSNode spriteNode = core->convertPathToFSNode(spritePath);
+	const Common::FSNode gameRoot(ConfMan.getPath("path"));
+	Common::FSNode spriteNode(gameRoot.getChild("Resources").getPath().joinInPlace(path));
+	Common::Path spritePath(path);
 
 	// The path can point to a single file, or a folder with files
-	if (!Common::File::exists(spritePath) && !spriteNode.exists()) {
-		_tiledSurfacePtr->unload();
-		return false;
+	if (spriteNode.isDirectory()) {
+		if (!spriteNode.exists()) {
+			_tiledSurfacePtr->unload();
+			return false;
+		}
+	} else {
+		spritePath = core->findFile(path);
+		if (!Common::File::exists(spritePath)) {
+			_tiledSurfacePtr->unload();
+			return false;
+		}
 	}
 
 	stop();

--- a/engines/tetraedge/te/te_sprite_layout.h
+++ b/engines/tetraedge/te/te_sprite_layout.h
@@ -38,7 +38,6 @@ public:
 	virtual bool onParentWorldColorChanged() override;
 
 	bool load(const Common::Path &path);
-	bool load(const Common::FSNode &node, const Common::Path *forcePath = nullptr);
 	bool load(TeImage &img);
 	bool load(TeIntrusivePtr<Te3DTexture> &texture);
 

--- a/engines/tetraedge/te/te_text_layout.cpp
+++ b/engines/tetraedge/te/te_text_layout.cpp
@@ -119,7 +119,7 @@ void TeTextLayout::setText(const Common::String &val) {
 		_baseFontSize = parser.fontSize();
 
 	if (!parser.fontFile().empty()) {
-		Common::Path fontPath(g_engine->getCore()->findFileNew(Common::Path(parser.fontFile())));
+		Common::Path fontPath(g_engine->getCore()->findFile(Common::Path(parser.fontFile())));
 		TeIntrusivePtr<TeIFont> font;
 		if (parser.fontFile().hasSuffixIgnoreCase(".ttf"))
 			font = g_engine->getResourceManager()->getResource<TeFont3>(fontPath).get();

--- a/engines/tetraedge/te/te_text_layout.cpp
+++ b/engines/tetraedge/te/te_text_layout.cpp
@@ -119,14 +119,12 @@ void TeTextLayout::setText(const Common::String &val) {
 		_baseFontSize = parser.fontSize();
 
 	if (!parser.fontFile().empty()) {
-		Common::Path fontPath(parser.fontFile());
-		Common::FSNode fontNode = g_engine->getCore()->findFile(fontPath);
+		Common::Path fontPath(g_engine->getCore()->findFileNew(Common::Path(parser.fontFile())));
 		TeIntrusivePtr<TeIFont> font;
 		if (parser.fontFile().hasSuffixIgnoreCase(".ttf"))
-			font = g_engine->getResourceManager()->getResource<TeFont3>(fontNode).get();
+			font = g_engine->getResourceManager()->getResource<TeFont3>(fontPath).get();
 		else
-			font = g_engine->getResourceManager()->getResource<TeFont2>(fontNode).get();
-		//font->load(fontPath); // lazy load this later.
+			font = g_engine->getResourceManager()->getResource<TeFont2>(fontPath).get();
 		_base.setFont(0, font);
 	}
 	if (parser.style().size())

--- a/engines/tetraedge/te/te_theora.h
+++ b/engines/tetraedge/te/te_theora.h
@@ -36,7 +36,7 @@ public:
 	TeTheora();
 	virtual ~TeTheora();
 
-	virtual bool load(const Common::FSNode &node) override;
+	virtual bool load(const Common::Path &path) override;
 	virtual uint width() override;
 	virtual uint height() override;
 	virtual int nbFrames() override;
@@ -61,7 +61,7 @@ public:
 private:
 	Video::TheoraDecoder *_decoder;
 
-	Common::FSNode _loadedNode;
+	Common::Path _loadedPath;
 	bool _hitEnd;
 
 };

--- a/engines/tetraedge/te/te_tiled_surface.cpp
+++ b/engines/tetraedge/te/te_tiled_surface.cpp
@@ -82,7 +82,7 @@ bool TeTiledSurface::load(const Common::Path &path) {
 
 		texture = new TeTiledTexture();
 
-		if (_codec->load(core->convertPathToFSNode(path))) {
+		if (_codec->load(path)) {
 			texture->setAccessName(ttPath);
 			resmgr->addResource(texture.get());
 			_imgFormat = _codec->imageFormat();

--- a/engines/tetraedge/te/te_tiled_surface.cpp
+++ b/engines/tetraedge/te/te_tiled_surface.cpp
@@ -60,12 +60,12 @@ byte TeTiledSurface::isLoaded() {
 	return _tiledTexture && _tiledTexture->isLoaded();
 }
 
-bool TeTiledSurface::load(const Common::FSNode &node) {
+bool TeTiledSurface::load(const Common::Path &path) {
 	unload();
 
 	TeResourceManager *resmgr = g_engine->getResourceManager();
 	if (_loadedPath.empty())
-		_loadedPath = node.getPath();
+		_loadedPath = path;
 
 	Common::Path ttPath(_loadedPath.append(".tt"));
 	TeIntrusivePtr<TeTiledTexture> texture;
@@ -82,7 +82,7 @@ bool TeTiledSurface::load(const Common::FSNode &node) {
 
 		texture = new TeTiledTexture();
 
-		if (_codec->load(node)) {
+		if (_codec->load(core->convertPathToFSNode(path))) {
 			texture->setAccessName(ttPath);
 			resmgr->addResource(texture.get());
 			_imgFormat = _codec->imageFormat();

--- a/engines/tetraedge/te/te_tiled_surface.h
+++ b/engines/tetraedge/te/te_tiled_surface.h
@@ -45,7 +45,7 @@ public:
 	void draw() override;
 	virtual void entry() {};
 	byte isLoaded();
-	bool load(const Common::FSNode &node);
+	bool load(const Common::Path &path);
 	bool load(const TeImage &image);
 	bool load(const TeIntrusivePtr<Te3DTexture> &texture);
 

--- a/engines/tetraedge/te/te_tiled_texture.cpp
+++ b/engines/tetraedge/te/te_tiled_texture.cpp
@@ -50,7 +50,7 @@ bool TeTiledTexture::load(const Common::Path &path) {
 	} else {
 		img = new TeImage();
 		TeCore *core = g_engine->getCore();
-		if (!img->load(core->findFile(path)))
+		if (!img->load(core->findFileNew(path)))
 			return false;
 	}
 	load(*img);

--- a/engines/tetraedge/te/te_tiled_texture.cpp
+++ b/engines/tetraedge/te/te_tiled_texture.cpp
@@ -50,7 +50,7 @@ bool TeTiledTexture::load(const Common::Path &path) {
 	} else {
 		img = new TeImage();
 		TeCore *core = g_engine->getCore();
-		if (!img->load(core->findFileNew(path)))
+		if (!img->load(core->findFile(path)))
 			return false;
 	}
 	load(*img);

--- a/engines/tetraedge/te/te_warp.cpp
+++ b/engines/tetraedge/te/te_warp.cpp
@@ -243,14 +243,14 @@ void TeWarp::load(const Common::Path &path, bool flag) {
 		error("Empty TeWarp path!");
 
 	TeCore *core = g_engine->getCore();
-	Common::FSNode node = core->findFile(_warpPath);
-	if (!node.isReadable()) {
+	Common::Path warpPath = core->findFileNew(_warpPath);
+	if (!Common::File::exists(warpPath)) {
 		error("Couldn't find TeWarp path data '%s'", _warpPath.toString(Common::Path::kNativeSeparator).c_str());
 	}
 
 	if (_preloaded)
 		error("TODO: Support preloading in TeWarp::load");
-	_file.open(node);
+	_file.open(warpPath);
 	char header[7];
 	header[6] = '\0';
 	_file.read(header, 6);

--- a/engines/tetraedge/te/te_warp.cpp
+++ b/engines/tetraedge/te/te_warp.cpp
@@ -243,7 +243,7 @@ void TeWarp::load(const Common::Path &path, bool flag) {
 		error("Empty TeWarp path!");
 
 	TeCore *core = g_engine->getCore();
-	Common::Path warpPath = core->findFileNew(_warpPath);
+	Common::Path warpPath = core->findFile(_warpPath);
 	if (!Common::File::exists(warpPath)) {
 		error("Couldn't find TeWarp path data '%s'", _warpPath.toString(Common::Path::kNativeSeparator).c_str());
 	}

--- a/engines/tetraedge/tetraedge.cpp
+++ b/engines/tetraedge/tetraedge.cpp
@@ -208,7 +208,7 @@ void TetraedgeEngine::closeGameDialogs() {
 void TetraedgeEngine::configureSearchPaths() {
 	const Common::FSNode gameDataDir(ConfMan.getPath("path"));
 	if (_gameDescription->platform != Common::kPlatformIOS)
-		SearchMan.addSubDirectoryMatching(gameDataDir, "Resources", 0, 5);
+		SearchMan.addSubDirectoryMatching(gameDataDir, "Resources", 0, 6);
 }
 
 int TetraedgeEngine::getDefaultScreenWidth() const {


### PR DESCRIPTION
In this engine, there is excessive usage of Common::FSNode, the results of which aren't cached.

This PR aims to switch almost all of the usages of Common::FSNode to Common::Path, the results of which are cached.
Syberia 1 and 2 have been tested, and nothing seems to be broken.
**Edit:** Also tested with Amerzone

For the remaining 2 cases where Common::FSNode is used, @andrewglass's code from PR #5714 has been incorporated, in order to cache Common::FSNode lookups. Thus, this PR supersedes PR #5714.

Since all of the file access code in the engine has been modified, I've tried to split the changes into smaller chunks, to make it easier to monitor the overall changes and check for any possible regressions. Intermediate functions have been added and removed to help with the migration.

Any comments are welcome :)