### PR TITLE
ULTIMA: NUVIE: Pathfinding fixes

### DIFF
--- a/engines/ultima/nuvie/pathfinder/astar_path.cpp
+++ b/engines/ultima/nuvie/pathfinder/astar_path.cpp
@@ -149,13 +149,13 @@ sint32 AStarPath::step_cost(const MapCoord &c1, const MapCoord &c2) {
 /* Return an item in the list of closed nodes whose location matches `ncmp'.
  */
 astar_node *AStarPath::find_closed_node(astar_node *ncmp) {
-	for (astar_node *n : open_nodes)
+	for (astar_node *n : closed_nodes)
 		if (n->loc == ncmp->loc)
 			return n;
 	return nullptr;
 }
 
-/* Return an item in the list of closed nodes whose location matches `ncmp'.
+/* Return an item in the list of open nodes whose location matches `ncmp'.
  */
 astar_node *AStarPath::find_open_node(astar_node *ncmp) {
 	for (astar_node *n : open_nodes)

--- a/engines/ultima/nuvie/pathfinder/u6_astar_path.cpp
+++ b/engines/ultima/nuvie/pathfinder/u6_astar_path.cpp
@@ -41,14 +41,13 @@ sint32 U6AStarPath::step_cost(const MapCoord &c1, const MapCoord &c2) {
 		return -1;
 	if (!pf->check_loc(c2.x, c2.y, c2.z)) {
 		// check for door
-		Obj *block = game->get_obj_manager()->get_obj(c2.x, c2.y, c2.z);
-		// HACK: check the neighboring tiles for the "real" door
-		Obj *real = game->get_obj_manager()->get_obj(c2.x + 1, c2.y, c2.z);
-		if (!real || !game->get_usecode()->is_unlocked_door(real))
-			real = game->get_obj_manager()->get_obj(c2.x, c2.y + 1, c2.z);
-		if (!block || !game->get_usecode()->is_unlocked_door(block) || real)
+		// Door objects consist of a wall and the actual door tile.
+		// We use get_objBasedAt() here since we are only interested in the latter.
+		Obj *block = game->get_obj_manager()->get_objBasedAt(c2.x, c2.y, c2.z, true, false);
+		if (block && game->get_usecode()->is_unlocked_door(block))
+			c += 2; // cost for opening door
+		else
 			return -1;
-		c += 2;
 	}
 	// add cost of *original* step
 //    c += game->get_game_map()->get_impedance(c1.x, c1.y, c1.z);


### PR DESCRIPTION
- Fix copy-paste error introduced in 4493bdcf5c08e040cb7f5afda029fb748d915cd4 "ULTIMA: NUVIE: Use foreach style loops for cleaner code"
- Fix pathfinding not detecting some doors

Fixes [#15308](https://bugs.scummvm.org/ticket/15308)