### PR TITLE
NANCY: Fix leak in scene.cpp

### DIFF
--- a/engines/nancy/state/scene.cpp
+++ b/engines/nancy/state/scene.cpp
@@ -102,7 +102,7 @@ void Scene::SceneSummary::read(Common::SeekableReadStream &stream) {
 }
 
 void Scene::SceneSummary::readTerse(Common::SeekableReadStream &stream) {
-	char *buf = new char[0x32];
+	char buf[0x32];
 	stream.read(buf, 0x32);
 	description = buf;
 	readFilename(stream, videoFile);


### PR DESCRIPTION
`buf` wasn't freed.
The assignment to `description` copies the string; no need for heap here.

```
LeakSanitizer: detected memory leaks
Direct leak of 100 byte(s) in 2 object(s) allocated from:
    #0 0x7f57a56b9628 in operator new[](unsigned long)
    #1 0x5592ac6abb5c in Nancy::State::Scene::SceneSummary::readTerse(Common::SeekableReadStream&) engines/nancy/state/scene.cpp:105
    #2 0x5592ac6c8fe0 in Nancy::State::Scene::load(bool) engines/nancy/state/scene.cpp:905
    #3 0x5592ac6dc737 in Nancy::State::Scene::process() engines/nancy/state/scene.cpp:159
    #4 0x5592ac253dba in Nancy::NancyEngine::run() engines/nancy/nancy.cpp:308
    #5 0x5592ab7a5b6a in runGame base/main.cpp:311
```

@fracturehill for review

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
