### PR TITLE
SCI: add warpMouse functionality to gfx drivers

### DIFF
--- a/engines/sci/graphics/cursor.cpp
+++ b/engines/sci/graphics/cursor.cpp
@@ -283,7 +283,6 @@ void GfxCursor::setPosition(Common::Point pos) {
 		_screen->adjustToUpscaledCoordinates(pos.y, pos.x);
 		g_system->warpMouse(pos.x, pos.y);
 	}
-	
 	// WORKAROUNDS for games with windows that are hidden when the mouse cursor
 	// is moved outside them - also check setPositionWorkarounds above.
 	//

--- a/engines/sci/graphics/cursor.cpp
+++ b/engines/sci/graphics/cursor.cpp
@@ -278,12 +278,12 @@ void GfxCursor::setPosition(Common::Point pos) {
 		return;
 
 	if (!_upscaledHires) {
-		g_system->warpMouse(pos.x, pos.y);
+		_screen->gfxDriver()->setMousePos(pos);
 	} else {
 		_screen->adjustToUpscaledCoordinates(pos.y, pos.x);
 		g_system->warpMouse(pos.x, pos.y);
 	}
-
+	
 	// WORKAROUNDS for games with windows that are hidden when the mouse cursor
 	// is moved outside them - also check setPositionWorkarounds above.
 	//

--- a/engines/sci/graphics/gfxdrivers.cpp
+++ b/engines/sci/graphics/gfxdrivers.cpp
@@ -41,6 +41,10 @@ Common::Point GfxDriver::getMousePos() const {
 	return g_system->getEventManager()->getMousePos();
 }
 
+void GfxDriver::setMousePos(const Common::Point &pos) const {
+	g_system->warpMouse(pos.x, pos.y);
+}
+
 void GfxDriver::clearRect(const Common::Rect &r) const {
 	GFXDRV_ASSERT_READY;
 	g_system->fillScreen(r, 0);
@@ -680,6 +684,10 @@ Common::Point SCI0_CGABWDriver::getMousePos() const {
 	return res;
 }
 
+void SCI0_CGABWDriver::setMousePos(const Common::Point &pos) const {
+	g_system->warpMouse(pos.x << 1, pos.y << 1);
+}
+
 void SCI0_CGABWDriver::clearRect(const Common::Rect &r) const {
 	Common::Rect r2(r.left << 1, r.top << 1, r.right << 1, r.bottom << 1);
 	GfxDriver::clearRect(r2);
@@ -837,8 +845,12 @@ Common::Point SCI0_HerculesDriver::getMousePos() const {
 	return res;
 }
 
+void SCI0_HerculesDriver::setMousePos(const Common::Point &pos) const {
+	g_system->warpMouse((pos.x << 1) + _centerX, (pos.y & ~1) * 3 / 2 + (pos.y & 1) + _centerY);
+}
+
 void SCI0_HerculesDriver::clearRect(const Common::Rect &r) const {
-	Common::Rect r2((r.left << 1) + _centerX, (r.top & ~1) * 3 / 2 + (r.top & 1) + _centerY, (r.right << 1) + 40, (r.bottom & ~1) * 3 / 2 + (r.bottom & 1) + 25);
+	Common::Rect r2((r.left << 1) + _centerX, (r.top & ~1) * 3 / 2 + (r.top & 1) + _centerY, (r.right << 1) + 40, (r.bottom & ~1) * 3 / 2 + (r.bottom & 1) + _centerY);
 	GfxDriver::clearRect(r2);
 }
 
@@ -1130,6 +1142,10 @@ Common::Point SCI1_EGADriver::getMousePos() const {
 	return res;
 }
 
+void SCI1_EGADriver::setMousePos(const Common::Point &pos) const {
+	g_system->warpMouse(pos.x << 1, pos.y << 1);
+}
+
 void SCI1_EGADriver::clearRect(const Common::Rect &r) const {
 	Common::Rect r2(r.left << 1, r.top << 1, r.right << 1, r.bottom << 1);
 	GfxDriver::clearRect(r2);
@@ -1234,6 +1250,10 @@ Common::Point UpscaledGfxDriver::getMousePos() const {
 	res.x >>= 1;
 	res.y >>= 1;
 	return res;
+}
+
+void UpscaledGfxDriver::setMousePos(const Common::Point &pos) const {
+	g_system->warpMouse(pos.x << 1, pos.y << 1);
 }
 
 void UpscaledGfxDriver::clearRect(const Common::Rect &r) const {

--- a/engines/sci/graphics/gfxdrivers.h
+++ b/engines/sci/graphics/gfxdrivers.h
@@ -44,6 +44,7 @@ public:
 	virtual void replaceCursor(const void *cursor, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor) = 0;
 	virtual void replaceMacCursor(const Graphics::Cursor *cursor) = 0;
 	virtual Common::Point getMousePos() const;
+	virtual void setMousePos(const Common::Point &pos) const;
 	virtual void clearRect(const Common::Rect &r) const;
 	virtual void copyCurrentBitmap(byte *dest, uint32 size) const = 0;
 	virtual void copyCurrentPalette(byte *dest, int start, int num) const;
@@ -142,6 +143,7 @@ public:
 	void copyRectToScreen(const byte *src, int srcX, int srcY, int pitch, int destX, int destY, int w, int h, const PaletteMod*, const byte*) override;
 	void replaceCursor(const void *cursor, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor) override;
 	Common::Point getMousePos() const override;
+	void setMousePos(const Common::Point &pos) const override;
 	void clearRect(const Common::Rect &r) const override;
 	static bool validateMode(Common::Platform p) { return (p == Common::kPlatformDOS) && checkDriver(_driverFiles, 2); }
 private:
@@ -161,6 +163,7 @@ public:
 	void copyRectToScreen(const byte *src, int srcX, int srcY, int pitch, int destX, int destY, int w, int h, const PaletteMod*, const byte*) override;
 	void replaceCursor(const void *cursor, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor) override;
 	Common::Point getMousePos() const override;
+	void setMousePos(const Common::Point &pos) const override;
 	void clearRect(const Common::Rect &r) const override;
 	static bool validateMode(Common::Platform p) { return (p == Common::kPlatformDOS) && checkDriver(&_driverFile, 1); }
 private:
@@ -198,6 +201,7 @@ public:
 	void copyCurrentPalette(byte *dest, int start, int num) const override;
 	void drawTextFontGlyph(const byte*, int, int, int, int, int, int, const PaletteMod*, const byte*) override; // Only for HiRes fonts. Not implemented here.
 	Common::Point getMousePos() const override;
+	void setMousePos(const Common::Point &pos) const override;
 	void clearRect(const Common::Rect &r) const override;
 	bool supportsPalIntensity() const override { return false; }
 	bool driverBasedTextRendering() const override { return false; }
@@ -225,6 +229,7 @@ public:
 	void copyRectToScreen(const byte *src, int srcX, int srcY, int pitch, int destX, int destY, int w, int h, const PaletteMod *palMods, const byte *palModMapping) override;
 	void replaceCursor(const void *cursor, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor) override;
 	Common::Point getMousePos() const override;
+	void setMousePos(const Common::Point &pos) const override;
 	void clearRect(const Common::Rect &r) const override;
 	void drawTextFontGlyph(const byte *src, int pitch, int hiresDestX, int hiresDestY, int hiresW, int hiresH, int transpColor, const PaletteMod *palMods, const byte *palModMapping) override; // For HiRes fonts. PC-98 versions bypass the video driver for this and render directly on top of the vram.
 	bool driverBasedTextRendering() const override { return true; }

--- a/engines/sci/graphics/screen.cpp
+++ b/engines/sci/graphics/screen.cpp
@@ -209,7 +209,7 @@ GfxScreen::GfxScreen(ResourceManager *resMan, Common::RenderMode renderMode) : _
 				// so the text color is a system color outside the normal 16 colors palette. The original does not even have a
 				// 16 colors mode driver. Only the 8 colors mode, where the colors are identical for text and graphics mode.
 				// But we do want to provide the 16 colors mode, since it is not a big deal (i.e., it does not require data
-				// from a driver file and the fat print is also already there for the SCI1 8 colors mode). So we just make the
+				// from a driver file and the fat print is also already there for the 8 colors mode). So we just make the
 				// necessary adjustments.
 				_gfxDrv = new PC98Gfx16ColorsDriver(8, false, true, PC98Gfx16ColorsDriver::kFontStyleFat, 1, requestRGB, ConfMan.getBool("disable_dithering"));
 			else if (getSciVersion() <= SCI_VERSION_01)
@@ -575,7 +575,7 @@ void GfxScreen::putKanjiChar(Graphics::FontSJIS *commonFont, int16 x, int16 y, u
 	// the right position in the vmem planes. It does not do any bit shifting to fix the x-coordinate. So the text will
 	// be aligned on byte boundaries in vmem which equals 4 pixel boundaries in lowres. We make that bounds adjustment
 	// in the driver, since the layout relies on it. PQ2 on the other hand uses the PC-98 text mode for text print
-	// instead of rendering it in graphics mode (many PC-98 games do that). In an emulator you can see easily recognize
+	// instead of rendering it in graphics mode (many PC-98 games do that). In an emulator you can easily recognize
 	// it, since the mouse cursor will move underneath the text. The use of the text mode has a similiar effect to
 	// x-coordinates as what happens with QFG: In text mode, the coordinates can only be set as text columns and lines,
 	// so the coordinates have to be divided and loose some precision ('& ~3' for x, and '& ~7' for y).


### PR DESCRIPTION
I have noticed (while playing QFG1VGA) that the engine makes use of OSystem::warpMouse() which will not work like that with the drivers that upscale the image.

I have implemented the function for the drivers that need it. It's basically just the reverse of getMousePos().

This wasn't so obvious from disasm, since the original gfx drivers don't need that. The mouse driver will always report coordinates within the 320x200 range there.

Also fixed some of my commments a bit...