### PR TITLE
JANITORIAL: Fix noone typo in catacombs.cpp

### DIFF
--- a/engines/hadesch/rooms/catacombs.cpp
+++ b/engines/hadesch/rooms/catacombs.cpp
@@ -70,7 +70,7 @@ static const TranscribedSound painSounds2[] = {
 
 static const TranscribedSound guardSpeeches[] = {
 	{"T3220wA0", _hs("Do you think we were going to let you just walk into Troy?")},
-	{"T3220wB0", _hs("So sorry, noone is allowed in. So beat it")},
+	{"T3220wB0", _hs("So sorry, no one is allowed in. So beat it")},
 	{"T3220wC0", _hs("Hey, Troy is closed to all visitors. Take a hike")}
 };
 


### PR DESCRIPTION
I have no idea if the talk line is size dependant, also no idea if this typo is meant to be there, since it's a line some character says...

feel free to reject