### PR TITLE
CGE/CGE2: Rewrite keymapper and add joystick support - bugs 15187,15188

### DIFF
--- a/engines/cge/cge.h
+++ b/engines/cge/cge.h
@@ -79,6 +79,29 @@ class Talk;
 
 #define kSayTheEnd  41
 
+enum CGEAction {
+	kActionNone,
+	kActionInfo,
+	kActionEscape,
+	kActionSave,
+	kActionLoad,
+	kActionQuit,
+	kActionInv1,
+	kActionInv2,
+	kActionInv3,
+	kActionInv4,
+	kActionInv5,
+	kActionInv6,
+	kActionInv7,
+	kActionInv8,
+	kActionAltDice,
+	kActionLevel0,
+	kActionLevel1,
+	kActionLevel2,
+	kActionLevel3,
+	kActionLevel4
+};
+
 // our engine debug channels
 enum {
 	kCGEDebugBitmap = 1 << 0,

--- a/engines/cge/cge_main.cpp
+++ b/engines/cge/cge_main.cpp
@@ -533,8 +533,8 @@ Square::Square(CGEEngine *vm) : Sprite(vm, nullptr), _vm(vm) {
 	setShapeList(MB);
 }
 
-void Square::touch(uint16 mask, int x, int y, Common::KeyCode keyCode) {
-	Sprite::touch(mask, x, y, keyCode);
+void Square::touch(uint16 mask, int x, int y) {
+	Sprite::touch(mask, x, y);
 	if (mask & kMouseLeftUp) {
 		_vm->XZ(_x + x, _y + y).cell() = 0;
 		_vm->_commandHandlerTurbo->addCommand(kCmdKill, -1, 0, this);
@@ -772,18 +772,16 @@ void System::funTouch() {
 		_funDel = n;
 }
 
-void System::touch(uint16 mask, int x, int y, Common::KeyCode keyCode) {
+void System::touch(uint16 mask, int x, int y) {
 	funTouch();
 
-	if (mask & kEventKeyb) {
-		if (keyCode == Common::KEYCODE_ESCAPE) {
-			// The original was calling keyClick()
-			// The sound is uselessly annoying and noisy, so it has been removed
-			_vm->killText();
-			if (_vm->_startupMode == 1) {
-				_vm->_commandHandler->addCommand(kCmdClear, -1, 0, nullptr);
-				return;
-			}
+	if (mask & kEventEsc) {
+		// The original was calling keyClick()
+		// The sound is uselessly annoying and noisy, so it has been removed
+		_vm->killText();
+		if (_vm->_startupMode == 1) {
+			_vm->_commandHandler->addCommand(kCmdClear, -1, 0, nullptr);
+			return;
 		}
 	} else {
 		if (_vm->_startupMode)
@@ -942,7 +940,7 @@ void CGEEngine::optionTouch(int opt, uint16 mask) {
 }
 
 #pragma argsused
-void Sprite::touch(uint16 mask, int x, int y, Common::KeyCode keyCode) {
+void Sprite::touch(uint16 mask, int x, int y) {
 	_vm->_sys->funTouch();
 
 	if ((mask & kEventAttn) != 0)

--- a/engines/cge/cge_main.h
+++ b/engines/cge/cge_main.h
@@ -91,7 +91,7 @@ public:
 
 	void setPal();
 	void funTouch();
-	void touch(uint16 mask, int x, int y, Common::KeyCode keyCode) override;
+	void touch(uint16 mask, int x, int y) override;
 	void tick() override;
 private:
 	CGEEngine *_vm;
@@ -100,7 +100,7 @@ private:
 class Square : public Sprite {
 public:
 	Square(CGEEngine *vm);
-	void touch(uint16 mask, int x, int y, Common::KeyCode keyCode) override;
+	void touch(uint16 mask, int x, int y) override;
 private:
 	CGEEngine *_vm;
 };

--- a/engines/cge/events.h
+++ b/engines/cge/events.h
@@ -45,18 +45,17 @@ enum EventMask {
 	kMouseRightDown = 1 << 3,
 	kMouseRightUp   = 1 << 4,
 	kEventAttn      = 1 << 5,
-	kEventKeyb      = 1 << 7
+	kEventEsc       = 1 << 7
 };
 
 class Keyboard {
 private:
-	bool getKey(Common::Event &event);
 	CGEEngine *_vm;
 public:
 	Sprite *_client;
 	bool _keyAlt;
 
-	void newKeyboard(Common::Event &event);
+	void handleAction(Common::Event &event);
 	Sprite *setClient(Sprite *spr);
 
 	Keyboard(CGEEngine *vm);
@@ -69,7 +68,6 @@ struct CGEEvent {
 	uint16 _mask;
 	uint16 _x;
 	uint16 _y;
-	Common::KeyCode _keyCode;
 	Sprite *_spritePtr;
 };
 

--- a/engines/cge/metaengine.cpp
+++ b/engines/cge/metaengine.cpp
@@ -200,96 +200,129 @@ Common::KeymapArray CGEMetaEngine::initKeymaps(const char *target) const {
 
 	Action *act;
 
+	act = new Action(kStandardActionLeftClick, _("Left click"));
+	act->setLeftClickEvent();
+	act->addDefaultInputMapping("MOUSE_LEFT");
+	act->addDefaultInputMapping("JOY_A");
+	keymap->addAction(act);
+
+	act = new Action(kStandardActionRightClick, _("Right click"));
+	act->setRightClickEvent();
+	act->addDefaultInputMapping("MOUSE_RIGHT");
+	act->addDefaultInputMapping("JOY_B");
+	keymap->addAction(act);
+
+	act = new Action(kStandardActionSkip, _("Exit/Skip"));
+	act->setCustomEngineActionEvent(kActionEscape);
+	act->addDefaultInputMapping("ESCAPE");
+	act->addDefaultInputMapping("JOY_X");
+	keymap->addAction(act);
+
+	act = new Action(kStandardActionSave, _("Save game"));
+	act->setCustomEngineActionEvent(kActionSave);
+	act->addDefaultInputMapping("F5");
+	act->addDefaultInputMapping("JOY_LEFT_SHOULDER");
+	keymap->addAction(act);
+
+	act = new Action(kStandardActionLoad, _("Load game"));
+	act->setCustomEngineActionEvent(kActionLoad);
+	act->addDefaultInputMapping("F7");
+	act->addDefaultInputMapping("JOY_RIGHT_SHOULDER");
+	keymap->addAction(act);
+
 	// I18N: 3-4 dialogs of game version info, (translation) credits, etc.
-	act = new Action("Game Info", _("Game Info"));
-	act->setKeyEvent(KEYCODE_F1);
+	act = new Action("INFO", _("Game Info"));
+	act->setCustomEngineActionEvent(kActionInfo);
 	act->addDefaultInputMapping("F1");
+	act->addDefaultInputMapping("JOY_LEFT_TRIGGER");
 	keymap->addAction(act);
 
 	// I18N: This opens a Quit Prompt where you have to choose
 	// [Confirm] or [Continue Playing] lines with Left Click.
-	act = new Action("Quit Prompt", _("Quit Prompt"));
-	act->setKeyEvent(KeyState(KEYCODE_x, 0, KBD_ALT));
+	act = new Action("QUIT", _("Quit Prompt"));
+	act->setCustomEngineActionEvent(kActionQuit);
 	act->addDefaultInputMapping("A+x");
+	act->addDefaultInputMapping("JOY_RIGHT_TRIGGER");
 	keymap->addAction(act);
 
 	// I18N: Here ALTered Item refers to the dice that has been altered/changed.
 	// In order to escape the dice game loop press Right/Left Alt
-	act = new Action("ALTered Item", _("ALTered Item"));
-	act->setKeyEvent(KEYCODE_LALT);
+	act = new Action("ALTITEM", _("ALTered Item"));
+	act->setCustomEngineActionEvent(kActionAltDice);
 	act->addDefaultInputMapping("LALT");
 	act->addDefaultInputMapping("RALT");
+	act->addDefaultInputMapping("JOY_Y");
 	keymap->addAction(act);
 
-	act = new Action("Inventory Item 1 (Select/Deselect)", _("Inventory Item 1 (Select/Deselect)"));
-	act->setKeyEvent(KEYCODE_1);
+	act = new Action("INV1", _("Inventory Item 1 (Select/Deselect)"));
+	act->setCustomEngineActionEvent(kActionInv1);
 	act->addDefaultInputMapping("1");
 	keymap->addAction(act);
 
-	act = new Action("Inventory Item 2 (Select/Deselect)", _("Inventory Item 2 (Select/Deselect)"));
-	act->setKeyEvent(KEYCODE_2);
+	act = new Action("INV2", _("Inventory Item 2 (Select/Deselect)"));
+	act->setCustomEngineActionEvent(kActionInv2);
 	act->addDefaultInputMapping("2");
 	keymap->addAction(act);
 
-	act = new Action("Inventory Item 3 (Select/Deselect)", _("Inventory Item 3 (Select/Deselect)"));
-	act->setKeyEvent(KEYCODE_3);
+	act = new Action("INV3", _("Inventory Item 3 (Select/Deselect)"));
+	act->setCustomEngineActionEvent(kActionInv3);
 	act->addDefaultInputMapping("3");
 	keymap->addAction(act);
 
-	act = new Action("Inventory Item 4 (Select/Deselect)", _("Inventory Item 4 (Select/Deselect)"));
-	act->setKeyEvent(KEYCODE_4);
+	act = new Action("INV4", _("Inventory Item 4 (Select/Deselect)"));
+	act->setCustomEngineActionEvent(kActionInv4);
 	act->addDefaultInputMapping("4");
 	keymap->addAction(act);
 
-	act = new Action("Inventory Item 5 (Select/Deselect)", _("Inventory Item 5 (Select/Deselect)"));
-	act->setKeyEvent(KEYCODE_5);
+	act = new Action("INV5", _("Inventory Item 5 (Select/Deselect)"));
+	act->setCustomEngineActionEvent(kActionInv5);
 	act->addDefaultInputMapping("5");
 	keymap->addAction(act);
 
-	act = new Action("Inventory Item 6 (Select/Deselect)", _("Inventory Item 6 (Select/Deselect)"));
-	act->setKeyEvent(KEYCODE_6);
+	act = new Action("INV6", _("Inventory Item 6 (Select/Deselect)"));
+	act->setCustomEngineActionEvent(kActionInv6);
 	act->addDefaultInputMapping("6");
 	keymap->addAction(act);
 
-	act = new Action("Inventory Item 7 (Select/Deselect)", _("Inventory Item 7 (Select/Deselect)"));
-	act->setKeyEvent(KEYCODE_7);
+	act = new Action("INV7", _("Inventory Item 7 (Select/Deselect)"));
+	act->setCustomEngineActionEvent(kActionInv7);
 	act->addDefaultInputMapping("7");
 	keymap->addAction(act);
 
-	act = new Action("Inventory Item 8 (Select/Deselect)", _("Inventory Item 8 (Select/Deselect)"));
-	act->setKeyEvent(KEYCODE_8);
+	act = new Action("INV8", _("Inventory Item 8 (Select/Deselect)"));
+	act->setCustomEngineActionEvent(kActionInv8);
 	act->addDefaultInputMapping("8");
 	keymap->addAction(act);
 
 	// I18N: There are 24 single-room/screen locations in the game.
 	// You switch between them from numbered buttons on interface.
 	// Sets the current access to only the first Location
-	act = new Action("DEBUG: Access to Location 1", _("DEBUG: Access to Location 1"));
-	act->setKeyEvent(KeyState(KEYCODE_0, 0, KBD_ALT));
+	act = new Action("DEBUGLOC1", _("DEBUG: Access to Location 1"));
+	act->setCustomEngineActionEvent(kActionLevel0);
 	act->addDefaultInputMapping("A+0");
 	keymap->addAction(act);
 
 	// I18N: Sets the current access to Locations 1 to 8.
-	act = new Action("DEBUG: Access to Locations 1-8", _("DEBUG: Access to Locations 1-8"));
-	act->setKeyEvent(KeyState(KEYCODE_1, 0, KBD_ALT));
+	act = new Action("DEBUGLOC18", _("DEBUG: Access to Locations 1-8"));
+	act->setCustomEngineActionEvent(kActionLevel1);
 	act->addDefaultInputMapping("A+1");
 	keymap->addAction(act);
 
 	// I18N: Sets the current access to Locations 1 to 16.
-	act = new Action("DEBUG: Access to Locations 1-16", _("DEBUG: Access to Locations 1-16"));
-	act->setKeyEvent(KeyState(KEYCODE_2, 0, KBD_ALT));
+	act = new Action("DEBUGLOC116", _("DEBUG: Access to Locations 1-16"));
+	act->setCustomEngineActionEvent(kActionLevel2);
 	act->addDefaultInputMapping("A+2");
 	keymap->addAction(act);
 
 	// I18N: Sets the current access to Locations 1 to 23.
-	act = new Action("DEBUG: Access to Locations 1-23", _("DEBUG: Access to Locations 1-23"));
-	act->setKeyEvent(KeyState(KEYCODE_3, 0, KBD_ALT));
+	act = new Action("DEBUGLOC123", _("DEBUG: Access to Locations 1-23"));
+	act->setCustomEngineActionEvent(kActionLevel3);
 	act->addDefaultInputMapping("A+3");
 	keymap->addAction(act);
 
 	// I18N: Sets the current access to Locations 1 to 24.
-	act = new Action("DEBUG: Access to Locations 1-24", _("DEBUG: Access to Locations 1-24"));
-	act->setKeyEvent(KeyState(KEYCODE_4, 0, KBD_ALT));
+	act = new Action("DEBUGLOC124", _("DEBUG: Access to Locations 1-24"));
+	act->setCustomEngineActionEvent(kActionLevel4);
 	act->addDefaultInputMapping("A+4");
 	keymap->addAction(act);
 

--- a/engines/cge/vga13h.h
+++ b/engines/cge/vga13h.h
@@ -146,7 +146,7 @@ public:
 	void step(int nr = -1);
 	Seq *setSeq(Seq *seq);
 	CommandHandler::Command *snList(SnList type);
-	virtual void touch(uint16 mask, int x, int y, Common::KeyCode keyCode);
+	virtual void touch(uint16 mask, int x, int y);
 	virtual void tick();
 	void sync(Common::Serializer &s);
 private:

--- a/engines/cge/vmenu.cpp
+++ b/engines/cge/vmenu.cpp
@@ -87,11 +87,11 @@ Vmenu::~Vmenu() {
 
 #define CALL_MEMBER_FN(object,ptrToMember)  ((object).*(ptrToMember))
 
-void Vmenu::touch(uint16 mask, int x, int y, Common::KeyCode keyCode) {
+void Vmenu::touch(uint16 mask, int x, int y) {
 	if (!_items)
 		return;
 
-	Sprite::touch(mask, x, y, keyCode);
+	Sprite::touch(mask, x, y);
 
 	y -= kTextVMargin - 1;
 	int n = 0;

--- a/engines/cge/vmenu.h
+++ b/engines/cge/vmenu.h
@@ -57,7 +57,7 @@ public:
 	MenuBar *_bar;
 	Vmenu(CGEEngine *vm, Choice *list, int x, int y);
 	~Vmenu() override;
-	void touch(uint16 mask, int x, int y, Common::KeyCode keyCode) override;
+	void touch(uint16 mask, int x, int y) override;
 private:
 	char *_vmgt;
 	CGEEngine *_vm;

--- a/engines/cge2/cge2.h
+++ b/engines/cge2/cge2.h
@@ -111,6 +111,15 @@ struct SavegameHeader;
 
 #define kColorNum           6
 
+enum CGEAction {
+	kActionNone,
+	kActionInfo,
+	kActionEscape,
+	kActionSave,
+	kActionLoad,
+	kActionQuit
+};
+
 struct SavegameHeader {
 	uint8 version;
 	Common::String saveName;

--- a/engines/cge2/cge2_main.cpp
+++ b/engines/cge2/cge2_main.cpp
@@ -42,16 +42,14 @@ System::System(CGE2Engine *vm) : Sprite(vm), _vm(vm) {
 	tick();
 }
 
-void System::touch(uint16 mask, V2D pos, Common::KeyCode keyCode) {
-	if (mask & kEventKeyb) {
-		if (keyCode == Common::KEYCODE_ESCAPE) {
-			// The original was calling keyClick()
-			// The sound is uselessly annoying and noisy, so it has been removed
-			_vm->killText();
-			if (_vm->_gamePhase == kPhaseIntro) {
-				_vm->_commandHandler->addCommand(kCmdClear, -1, 0, nullptr);
-				return;
-			}
+void System::touch(uint16 mask, V2D pos) {
+	if (mask & kEventEsc) {
+		// The original was calling keyClick()
+		// The sound is uselessly annoying and noisy, so it has been removed
+		_vm->killText();
+		if (_vm->_gamePhase == kPhaseIntro) {
+			_vm->_commandHandler->addCommand(kCmdClear, -1, 0, nullptr);
+			return;
 		}
 	} else {
 		if (_vm->_gamePhase != kPhaseInGame)
@@ -844,7 +842,7 @@ void CGE2Engine::switchHero(int sex) {
 		_commandHandler->addCommand(kCmdSeq, -1, 1, face);
 }
 
-void Sprite::touch(uint16 mask, V2D pos, Common::KeyCode keyCode) {
+void Sprite::touch(uint16 mask, V2D pos) {
 	if ((mask & kEventAttn) != 0)
 		return;
 

--- a/engines/cge2/cge2_main.h
+++ b/engines/cge2/cge2_main.h
@@ -40,7 +40,7 @@ public:
 
 	System(CGE2Engine *vm);
 
-	void touch(uint16 mask, V2D pos, Common::KeyCode keyCode) override;
+	void touch(uint16 mask, V2D pos) override;
 	void tick() override;
 private:
 	CGE2Engine *_vm;

--- a/engines/cge2/events.cpp
+++ b/engines/cge2/events.cpp
@@ -46,51 +46,33 @@ Sprite *Keyboard::setClient(Sprite *spr) {
 	return spr;
 }
 
-bool Keyboard::getKey(Common::Event &event) {
-	Common::KeyCode keycode = event.kbd.keycode;
-
-	switch (keycode) {
-	case Common::KEYCODE_F1:
-		if (event.type == Common::EVENT_KEYUP)
-			return false;
+void Keyboard::handleAction(Common::Event &event) {
+	switch (event.customType) {
+	case kActionInfo:
 		// Display ScummVM version and translation strings
 		for (int i = 0; i < 3; i++)
 			_vm->_commandHandler->addCommand(kCmdInf, 1, kShowScummVMVersion + i, nullptr);
-		return false;
-	case Common::KEYCODE_F5:
+		break;
+	case kActionSave:
 		_vm->saveGameDialog();
-		return false;
-	case Common::KEYCODE_F7:
+		break;
+	case kActionLoad:
 		_vm->loadGameDialog();
-		return false;
-	case Common::KEYCODE_x:
-		if (event.kbd.flags & Common::KBD_ALT) {
-			_vm->quit();
-			return false;
+		break;
+	case kActionQuit:
+		_vm->quit();
+		break;
+	case kActionEscape:
+		if (_client) {
+			CGE2Event &evt = _vm->_eventManager->getNextEvent();
+			evt._x = 0;
+			evt._y = 0;
+			evt._mask = kEventEsc;    // Event mask
+			evt._spritePtr = _client; // Sprite pointer
 		}
 		break;
-	case Common::KEYCODE_F10:
-		if (_vm->_commandHandler->idle())
-			_vm->switchScene(-1); // Exits the game.
-		return false;
 	default:
 		break;
-	}
-
-	return true;
-}
-
-void Keyboard::newKeyboard(Common::Event &event) {
-	if (!getKey(event))
-		return;
-
-	if ((event.type == Common::EVENT_KEYDOWN) && _client) {
-		CGE2Event &evt = _vm->_eventManager->getNextEvent();
-		evt._x = 0;
-		evt._y = 0;
-		evt._keyCode = event.kbd.keycode;   // Keycode
-		evt._mask = kEventKeyb;             // Event mask
-		evt._spritePtr = _client;           // Sprite pointer
 	}
 }
 
@@ -149,7 +131,6 @@ void Mouse::newMouse(Common::Event &event) {
 	CGE2Event &evt = _vm->_eventManager->getNextEvent();
 	evt._x = event.mouse.x;
 	evt._y = event.mouse.y;
-	evt._keyCode = Common::KEYCODE_INVALID;
 	evt._spritePtr = _vm->spriteAt(V2D(_vm, evt._x, evt._y));
 
 	switch (event.type) {
@@ -197,10 +178,9 @@ void EventManager::poll() {
 	while (g_system->getEventManager()->pollEvent(_event)) {
 		_event.mouse.y = kWorldHeight - _event.mouse.y;
 		switch (_event.type) {
-		case Common::EVENT_KEYDOWN:
-		case Common::EVENT_KEYUP:
+		case Common::EVENT_CUSTOM_ENGINE_ACTION_START:
 			// Handle keyboard events
-			_vm->_keyboard->newKeyboard(_event);
+			_vm->_keyboard->handleAction(_event);
 			handleEvents();
 			break;
 		case Common::EVENT_MOUSEMOVE:
@@ -229,7 +209,7 @@ void EventManager::handleEvents() {
 				e._y -= _vm->_mouse->_siz.y;
 				if (_vm->_mouse->_hold && (e._spritePtr != _vm->_mouse->_hold)) {
 					_vm->_mouse->_hold->touch(e._mask | kEventAttn,
-						V2D(_vm, e._x - _vm->_mouse->_hold->_pos2D.x, e._y - _vm->_mouse->_hold->_pos2D.y), e._keyCode);
+						V2D(_vm, e._x - _vm->_mouse->_hold->_pos2D.x, e._y - _vm->_mouse->_hold->_pos2D.y));
 				}
 				// update mouse cursor position
 				if (e._mask & kMouseRoll)
@@ -238,12 +218,9 @@ void EventManager::handleEvents() {
 
 			// activate current touched SPRITE
 			if (e._spritePtr) {
-				if (e._mask & kEventKeyb)
-					e._spritePtr->touch(e._mask, _vm->_mouse->_point, e._keyCode);
-				else
-					e._spritePtr->touch(e._mask, _vm->_mouse->_point - e._spritePtr->_pos2D, e._keyCode);
+				e._spritePtr->touch(e._mask, _vm->_mouse->_point - e._spritePtr->_pos2D);
 			} else if (_vm->_sys)
-				_vm->_sys->touch(e._mask, _vm->_mouse->_point, e._keyCode);
+				_vm->_sys->touch(e._mask, _vm->_mouse->_point);
 
 			// discard Text if button released
 			if (e._mask & (kMouseLeftUp | kMouseRightUp))

--- a/engines/cge2/events.h
+++ b/engines/cge2/events.h
@@ -45,17 +45,16 @@ enum EventMask {
 	kMouseRightUp = 1 << 4,
 	kEventAttn = 1 << 5,
 	kMouseMask = (kMouseRoll | kMouseLeftDown | kMouseLeftUp |	kMouseRightDown | kMouseRightUp),
-	kEventKeyb = 1 << 7
+	kEventEsc = 1 << 7
 };
 
 class Keyboard {
 private:
-	bool getKey(Common::Event &event);
 	CGE2Engine *_vm;
 public:
 	Sprite *_client;
 
-	void newKeyboard(Common::Event &event);
+	void handleAction(Common::Event &event);
 	Sprite *setClient(Sprite *spr);
 
 	Keyboard(CGE2Engine *vm);
@@ -68,7 +67,6 @@ struct CGE2Event {
 	uint16 _mask;
 	uint16 _x;
 	uint16 _y;
-	Common::KeyCode _keyCode;
 	Sprite *_spritePtr;
 };
 

--- a/engines/cge2/metaengine.cpp
+++ b/engines/cge2/metaengine.cpp
@@ -213,38 +213,50 @@ Common::KeymapArray CGE2MetaEngine::initKeymaps(const char *target) const {
 
 	Common::Action *act;
 
-	act = new Common::Action("Game Info", _("Game Info"));
-	act->setKeyEvent(KEYCODE_F1);
-	act->addDefaultInputMapping("F1");
+	act = new Common::Action(kStandardActionLeftClick, _("Left click"));
+	act->setLeftClickEvent();
+	act->addDefaultInputMapping("MOUSE_LEFT");
+	act->addDefaultInputMapping("JOY_A");
 	keymap->addAction(act);
 
-	act = new Common::Action("Save Game", _("Save Game"));
-	act->setKeyEvent(KEYCODE_F5);
+	act = new Common::Action(kStandardActionRightClick, _("Right click"));
+	act->setRightClickEvent();
+	act->addDefaultInputMapping("MOUSE_RIGHT");
+	act->addDefaultInputMapping("JOY_B");
+	keymap->addAction(act);
+
+	// I18N: This closes the Dialogue/text box.
+	act = new Common::Action("CLOSEBOX", _("Close the Dialogue box"));
+	act->setCustomEngineActionEvent(kActionEscape);
+	act->addDefaultInputMapping("ESCAPE");
+	act->addDefaultInputMapping("JOY_X");
+	keymap->addAction(act);
+
+	act = new Common::Action(kStandardActionSave, _("Save game"));
+	act->setCustomEngineActionEvent(kActionSave);
 	act->addDefaultInputMapping("F5");
+	act->addDefaultInputMapping("JOY_LEFT_SHOULDER");
 	keymap->addAction(act);
 
-	act = new Common::Action("Load Game", _("Load Game"));
-	act->setKeyEvent(KEYCODE_F7);
+	act = new Common::Action(kStandardActionLoad, _("Load game"));
+	act->setCustomEngineActionEvent(kActionLoad);
 	act->addDefaultInputMapping("F7");
+	act->addDefaultInputMapping("JOY_RIGHT_SHOULDER");
+	keymap->addAction(act);
+
+	// I18N: 3-4 dialogs of game version info, (translation) credits, etc.
+	act = new Common::Action("INFO", _("Game Info"));
+	act->setCustomEngineActionEvent(kActionInfo);
+	act->addDefaultInputMapping("F1");
+	act->addDefaultInputMapping("JOY_LEFT_TRIGGER");
 	keymap->addAction(act);
 
 	// I18N: This opens a Quit Prompt where you have to choose
 	// [Confirm] or [Continue Playing] lines with Left Click.
-	act = new Common::Action("Quit Prompt", _("Quit Prompt"));
-	act->setKeyEvent(KeyState(KEYCODE_x, 0, KBD_ALT));
+	act = new Common::Action("QUIT", _("Quit Prompt"));
+	act->setCustomEngineActionEvent(kActionQuit);
 	act->addDefaultInputMapping("A+x");
-	keymap->addAction(act);
-
-	// I18N: This directly quits the game.
-	act = new Common::Action("Quit", _("Quit"));
-	act->setKeyEvent(KEYCODE_F10);
-	act->addDefaultInputMapping("F10");
-	keymap->addAction(act);
-
-	// I18N: This closes the Dialogue/text box.
-	act = new Common::Action("Close the box", _("Close the Dialogue box"));
-	act->setKeyEvent(KEYCODE_ESCAPE);
-	act->addDefaultInputMapping("ESCAPE");
+	act->addDefaultInputMapping("JOY_RIGHT_TRIGGER");
 	keymap->addAction(act);
 
 	return Keymap::arrayOf(keymap);

--- a/engines/cge2/vga13h.h
+++ b/engines/cge2/vga13h.h
@@ -224,7 +224,7 @@ public:
 	void step(int nr = -1);
 	Seq *setSeq(Seq *seq);
 	CommandHandler::Command *snList(Action type);
-	virtual void touch(uint16 mask, V2D pos, Common::KeyCode keyCode);
+	virtual void touch(uint16 mask, V2D pos);
 	virtual void tick();
 	virtual void setScene(int c);
 	void clrHide() { if (_ext) _ext->_b0 = nullptr; }

--- a/engines/cge2/vmenu.cpp
+++ b/engines/cge2/vmenu.cpp
@@ -135,9 +135,9 @@ VMenu::~VMenu() {
 	}
 }
 
-void VMenu::touch(uint16 mask, V2D pos, Common::KeyCode keyCode) {
+void VMenu::touch(uint16 mask, V2D pos) {
 	if (_items) {
-		Sprite::touch(mask, pos, keyCode);
+		Sprite::touch(mask, pos);
 
 		int n = 0;
 		bool ok = false;

--- a/engines/cge2/vmenu.h
+++ b/engines/cge2/vmenu.h
@@ -80,7 +80,7 @@ public:
 
 	VMenu(CGE2Engine *vm, Common::Array<Choice *> list, V2D pos, ColorBank col);
 	~VMenu() override;
-	void touch(uint16 mask, V2D pos, Common::KeyCode keyCode) override;
+	void touch(uint16 mask, V2D pos) override;
 	char *vmGather(Common::Array<Choice *> list);
 };
 


### PR DESCRIPTION
This adds keymaps for joystick buttons for CGE, and cleans up the keyboard input code
Fixes bug 15187: https://bugs.scummvm.org/ticket/15187

Edit: Added the same changes for CGE2, as the input code is basically the same as CGE
Fixes bug 15188: https://bugs.scummvm.org/ticket/15188