### PR TITLE
SCUMM: MM - Add option to boot into demo/kiosk mode to the GUI bug #1…

### DIFF
--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -751,6 +751,15 @@ static const ExtraGuiOption enableCopyProtection = {
 	0
 };
 
+static const ExtraGuiOption mmDemoObjectLabelsOption = {
+	_s("Enable demo/kisok mode"),
+	_s("Enable demo/kiosk mode in the full retail version of Maniac Mansion. Beware, not every version supports this."),
+	"enable_demo_mode",
+	false,
+	0,
+	0
+};
+
 const ExtraGuiOptions ScummMetaEngine::getExtraGuiOptions(const Common::String &target) const {
 	ExtraGuiOptions options;
 	// Query the GUI options
@@ -797,7 +806,9 @@ const ExtraGuiOptions ScummMetaEngine::getExtraGuiOptions(const Common::String &
 			options.push_back(fmtownsForceHiResMode);
 #endif
 	}
-
+    if (target.empty() || gameid == "maniac") {
+        options.push_back(mmDemoObjectLabelsOption);
+    }
 	// The Steam Mac versions of Loom and Indy 3 are more akin to the VGA
 	// DOS versions, and that's how ScummVM usually sees them. But that
 	// rebranding does not happen until later.

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -3769,10 +3769,10 @@ void ScummEngine::runBootscript() {
 
 	args[0] = _bootParam;
 
-	if (_game.id == GID_MANIAC && (_game.features & GF_DEMO) && (_game.platform != Common::kPlatformC64))
-		runScript(9, 0, 0, args);
+	if ((_game.id == GID_MANIAC && (_game.features & GF_DEMO) && (_game.platform != Common::kPlatformC64)) || ConfMan.getBool("enable_demo_mode"))
+    	runScript(9, 0, 0, args);
 	else
-		runScript(1, 0, 0, args);
+    	runScript(1, 0, 0, args);
 }
 
 #ifdef ENABLE_HE


### PR DESCRIPTION
Add a GUI checkbox for MM to enable the demo script. This replicates what the --demo-mode command line argument does, by running script 9 instead of script 0.
