### PR TITLE
COMMON: Replace type detection in configure with aliases for stdint.h types

### DIFF
--- a/backends/platform/ds/portdefs.h
+++ b/backends/platform/ds/portdefs.h
@@ -25,12 +25,6 @@
 // Include ndstypes.h for uint16 etc. typedefs
 #include "nds/ndstypes.h"
 
-typedef unsigned int uint;
-
-// Define SCUMMVM_DONT_DEFINE_TYPES to prevent scummsys.h from trying to
-// re-define those data types.
-#define SCUMMVM_DONT_DEFINE_TYPES
-
 // Include required headers
 #include <stdio.h>
 #include <stdlib.h>

--- a/backends/platform/libretro/include/config.h
+++ b/backends/platform/libretro/include/config.h
@@ -31,30 +31,4 @@
 
 #define SCUMM_NEED_ALIGNMENT
 
-/* Data types */
-#ifndef SCUMMVM_DONT_DEFINE_TYPES
-typedef unsigned char byte;
-typedef unsigned char uint8;
-typedef signed char int8;
-typedef unsigned short uint16;
-typedef signed short int16;
-typedef unsigned int uint32;
-typedef signed int int32;
-typedef unsigned int uint;
-typedef signed long long int64;
-typedef unsigned long long uint64;
-#endif
-
-#if defined(__x86_64__) || defined(_M_X64) || defined(__ppc64__) || defined(__powerpc64__) || defined(__LP64__) || defined(_M_ARM64)
-
-typedef uint64 uintptr;
-typedef int64 intptr;
-
-#else
-
-typedef uint32 uintptr;
-typedef int32 intptr;
-
-#endif
-
 #endif /* CONFIG_H */

--- a/backends/platform/psp/display_client.cpp
+++ b/backends/platform/psp/display_client.cpp
@@ -102,7 +102,7 @@ void Palette::setColorPositionAlpha(uint32 position, bool alpha) {
 
 //	Set some of the palette to color values in array
 //	By default, ScummVm doesn't support alpha values in palettes
-void Palette::setPartial(const byte *colors, uint32 start, uint32 num, bool supportsAlpha /* = false */) {
+void Palette::setPartial(const byte *colors, uint start, uint num, bool supportsAlpha /* = false */) {
 	DEBUG_ENTER_FUNC();
 
 	assert(_values);

--- a/backends/platform/psp/thread.cpp
+++ b/backends/platform/psp/thread.cpp
@@ -131,10 +131,10 @@ bool PspSemaphore::pollForValue(int value) {
 }
 
 // false: timeout or error
-bool PspSemaphore::takeWithTimeOut(uint32 timeOut) {
+bool PspSemaphore::takeWithTimeOut(uint timeOut) {
 	DEBUG_ENTER_FUNC();
 
-	uint32 *pTimeOut = 0;
+	uint *pTimeOut = 0;
 	if (timeOut)
 		pTimeOut = &timeOut;
 

--- a/backends/platform/psp/thread.h
+++ b/backends/platform/psp/thread.h
@@ -52,7 +52,7 @@ public:
 	PspSemaphore(int initialValue, int maxValue=255);
 	~PspSemaphore();
 	bool take() { return takeWithTimeOut(0); }
-	bool takeWithTimeOut(uint32 timeOut);
+	bool takeWithTimeOut(uint timeOut);
 	bool give(int num=1);
 	bool pollForValue(int value);	// check for a certain value
 	int numOfWaitingThreads();

--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -357,27 +357,6 @@
 	#endif
 #endif
 
-//
-// Some more system specific settings.
-// TODO/FIXME: All of these should be moved to backend specific files (such as portdefs.h)
-//
-#if defined(DINGUX)
-
-	// Very BAD hack following, used to avoid triggering an assert in uClibc dingux library
-	// "toupper" when pressing keyboard function keys.
-	#undef toupper
-	#define toupper(c) __extension__ ({ auto _x = ((c) & 0xFF); (_x >= 97 && _x <= 122) ? (_x - 32) : _x; })
-
-#elif defined(__PSP__)
-
-	#include <malloc.h>
-	#include "backends/platform/psp/memory.h"
-
-	/* to make an efficient, inlined memcpy implementation */
-	#define memcpy(dst, src, size)   psp_memcpy(dst, src, size)
-
-#endif
-
 #if defined(USE_TREMOR) && !defined(USE_VORBIS)
 #define USE_VORBIS // make sure this one is defined together with USE_TREMOR!
 #endif
@@ -605,6 +584,27 @@ namespace std {
 #include <initializer_list>
 
 #endif // NO_CXX11_INITIALIZER_LIST
+
+//
+// Some more system specific settings.
+// TODO/FIXME: All of these should be moved to backend specific files (such as portdefs.h)
+//
+#if defined(DINGUX)
+
+	// Very BAD hack following, used to avoid triggering an assert in uClibc dingux library
+	// "toupper" when pressing keyboard function keys.
+	#undef toupper
+	#define toupper(c) __extension__ ({ auto _x = ((c) & 0xFF); (_x >= 97 && _x <= 122) ? (_x - 32) : _x; })
+
+#elif defined(__PSP__)
+
+	#include <malloc.h>
+	#include "backends/platform/psp/memory.h"
+
+	/* to make an efficient, inlined memcpy implementation */
+	#define memcpy(dst, src, size)   psp_memcpy(dst, src, size)
+
+#endif
 
 #include "common/forbidden.h"
 

--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -490,7 +490,14 @@
 	typedef int8_t int8;
 	typedef uint16_t uint16;
 	typedef int16_t int16;
-#if defined(__MORPHOS__) || defined(__amigaos4__)
+#if defined(__3DS__) || defined(__DC__) || defined(__PSP__)
+	/**
+	 * The system headers define uint32_t and int32_t as long while int is enough
+	 * Force use of int to avoid errors on format strings.
+	 */
+	typedef unsigned int uint32;
+	typedef int int32;
+#elif defined(__amigaos4__) || defined(__MORPHOS__)
 	/**
 	 * The system headers define uint32 and int32 as long, so we have to do the same here.
 	 * Without this, we get a conflicting declaration error when this file is included

--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -479,57 +479,33 @@
 
 
 //
-// Typedef our system types unless they have already been defined by config.h,
-// or SCUMMVM_DONT_DEFINE_TYPES is set.
+// Typedef our system types unless SCUMMVM_DONT_DEFINE_TYPES is set.
+// This is usually due to conflicts with the system headers.
 //
-#if !defined(HAVE_CONFIG_H) && !defined(SCUMMVM_DONT_DEFINE_TYPES)
+#ifndef SCUMMVM_DONT_DEFINE_TYPES
 	typedef unsigned char byte;
-	typedef unsigned char uint8;
-	typedef signed char int8;
-	typedef unsigned short uint16;
-	typedef signed short int16;
-	// HACK: Some ports, such as NDS and AmigaOS, are not frequently
-	// tested during development, but cause frequent buildbot failures
-	// because they need to use 'long' for int32. Windows 32-bit
-	// binaries have this nice property of being easy to build, having
-	// a 32-bit 'long' too, *and* being frequently tested (incl. Github
-	// Actions). We want to catch this case as early and frequently
-	// as possible, so Win32 is probably the best candidate for this...
-	#if defined(WIN32) && !defined(_WIN64)
+	typedef unsigned int uint;
+
+	typedef uint8_t uint8;
+	typedef int8_t int8;
+	typedef uint16_t uint16;
+	typedef int16_t int16;
+#if defined(__MORPHOS__) || defined(__amigaos4__)
+	/**
+	 * The system headers define uint32 and int32 as long, so we have to do the same here.
+	 * Without this, we get a conflicting declaration error when this file is included
+	 * along the AmigaOS files.
+	 */
 	typedef unsigned long uint32;
 	typedef signed long int32;
-	#else
-	typedef unsigned int uint32;
-	typedef signed int int32;
-	#endif
-	typedef unsigned int uint;
-	typedef signed long long int64;
-	typedef unsigned long long uint64;
-#endif
-
-//
-// Determine 64 bitness
-// Reference: https://web.archive.org/web/20190413073704/http://nadeausoftware.com/articles/2012/02/c_c_tip_how_detect_processor_type_using_compiler_predefined_macros
-//
-#if !defined(HAVE_CONFIG_H)
-
-#if defined(__x86_64__) || \
-		  defined(_M_X64) || \
-		  defined(__ppc64__) || \
-		  defined(__powerpc64__) || \
-		  defined(__LP64__) || \
-		  defined(_M_ARM64)
-
-typedef int64 intptr;
-typedef uint64 uintptr;
-
 #else
-
-typedef int32 intptr;
-typedef uint32 uintptr;
-
+	typedef uint32_t uint32;
+	typedef int32_t int32;
 #endif
-
+	typedef uint64_t uint64;
+	typedef int64_t int64;
+	typedef uintptr_t uintptr;
+	typedef intptr_t intptr;
 #endif
 
 //

--- a/configure
+++ b/configure
@@ -7325,13 +7325,6 @@ cat > config.h.new << EOF
 $_config_h_data
 $(cat config.h.engines)
 
-/* TODO: What does this do? */
-#if defined(__APPLE__) && !defined(__ppc__)
-#ifndef _UINT64
-#define _UINT64
-#endif
-#endif
-
 #endif /* CONFIG_H */
 EOF
 rm -f config.h.engines

--- a/configure
+++ b/configure
@@ -2626,89 +2626,6 @@ case $_endian in
 esac
 
 #
-# Determine a data type with the given length
-#
-find_type_with_size() {
-	for datatype in int short char long "long long" __int64 "long long int" unknown; do
-		cat > tmp_find_type_with_size.cpp << EOF
-typedef $datatype ac__type_sizeof_;
-int main() {
-	static int test_array [1 - 2 * !(((long int) (sizeof (ac__type_sizeof_))) == $1)];
-	test_array [0] = 0;
-	return 0;
-}
-EOF
-		if $CXX $CXXFLAGS -c -o $TMPO.o tmp_find_type_with_size.cpp >> "$TMPLOG" 2>&1 ; then
-			break
-		else
-			if test "$datatype" = "unknown"; then
-				echo "couldn't find data type with $1 bytes"
-				exit 1
-			fi
-			continue
-		fi
-	done
-	cc_check_clean tmp_find_type_with_size.cpp
-	echo $datatype
-}
-
-#
-# Check whether the system is 32-bit
-#
-pointer_is_32bit() {
-	cat > tmp_pointer_is_32bit.cpp << EOF
-int main() {
-	static int test_array[1 - 2 * !(sizeof(void *) == 4)];
-	test_array[0] = 0;
-	return 0;
-}
-EOF
-	$CXX $CXXFLAGS -c -o $TMPO.o tmp_pointer_is_32bit.cpp >> "$TMPLOG" 2>&1
-	status=$?
-	cc_check_clean tmp_pointer_is_32bit.cpp
-	return $status
-}
-
-echo_n "Checking 64-bitness... "
-pointer_is_32bit
-if test $? -eq 0; then
-	signed_type_ptr=int32
-	unsigned_type_ptr=uint32
-	echo "no"
-else
-	signed_type_ptr=int64
-	unsigned_type_ptr=uint64
-	echo "yes"
-fi
-
-#
-# Determine data type sizes
-#
-echo_n "Type with 1 byte... "
-type_1_byte=`find_type_with_size 1`
-TMPR="$?"
-echo "$type_1_byte"
-test $TMPR -eq 0 || exit 1	# check exit code of subshell
-
-echo_n "Type with 2 bytes... "
-type_2_byte=`find_type_with_size 2`
-TMPR="$?"
-echo "$type_2_byte"
-test $TMPR -eq 0 || exit 1	# check exit code of subshell
-
-echo_n "Type with 4 bytes... "
-type_4_byte=`find_type_with_size 4`
-TMPR="$?"
-echo "$type_4_byte"
-test $TMPR -eq 0 || exit 1	# check exit code of subshell
-
-echo_n "Type with 8 bytes... "
-type_8_byte=`find_type_with_size 8`
-TMPR="$?"
-echo "$type_8_byte"
-test $TMPR -eq 0 || exit 1	# check exit code of subshell
-
-#
 # Check whether memory alignment is required
 #
 # For some CPU types, unaligned memory access is either not supported at
@@ -2882,7 +2799,6 @@ case $_host_os in
 		# already typedefs (u)int32 as (unsigned) long and suppress
 		# those noisy format warnings caused by the 'long' 4 byte
 		append_var CXXFLAGS "-Wno-format"
-		type_4_byte='long'
 		;;
 	android)
 		case $_host in
@@ -3322,9 +3238,6 @@ EOF
 		append_var LDFLAGS "-Wl,--export-dynamic"
 		append_var LDFLAGS "-L/usr/local/lib"
 		append_var CXXFLAGS "-D__MORPHOS_SHAREDLIBS"
-		# We have to use 'long' for our 4 byte typedef because MorphOS already typedefs (u)int32
-		# as (unsigned) long, and consequently we'd get a compiler error otherwise.
-		type_4_byte='long'
 		# Suppress format warnings as the long 4 byte causes noisy warnings.
 		append_var CXXFLAGS "-Wno-format"
 		add_line_to_config_mk 'MORPHOS = 1'
@@ -5599,14 +5512,7 @@ echocheck "libmpeg2 >= 0.4.0"
 if test "$_mpeg2" = auto ; then
 	_mpeg2=no
 	cat > $TMPC << EOF
-typedef signed $type_1_byte int8_t;
-typedef signed $type_2_byte int16_t;
-typedef signed $type_4_byte int32_t;
-
-typedef unsigned $type_1_byte uint8_t;
-typedef unsigned $type_2_byte uint16_t;
-typedef unsigned $type_4_byte uint32_t;
-
+#include <inttypes.h>
 extern "C" {
 #include <mpeg2dec/mpeg2.h>
 }
@@ -5645,14 +5551,7 @@ echocheck "liba52"
 if test "$_a52" = auto ; then
 	_a52=no
 	cat > $TMPC << EOF
-typedef signed $type_1_byte int8_t;
-typedef signed $type_2_byte int16_t;
-typedef signed $type_4_byte int32_t;
-
-typedef unsigned $type_1_byte uint8_t;
-typedef unsigned $type_2_byte uint16_t;
-typedef unsigned $type_4_byte uint32_t;
-
+#include <inttypes.h>
 extern "C" {
 #include <a52dec/a52.h>
 }
@@ -7426,23 +7325,7 @@ cat > config.h.new << EOF
 $_config_h_data
 $(cat config.h.engines)
 
-/* Data types */
-#ifndef SCUMMVM_DONT_DEFINE_TYPES
-typedef unsigned $type_1_byte byte;
-typedef unsigned int uint;
-typedef unsigned $type_1_byte uint8;
-typedef unsigned $type_2_byte uint16;
-typedef unsigned $type_4_byte uint32;
-typedef unsigned $type_8_byte uint64;
-typedef signed $type_1_byte int8;
-typedef signed $type_2_byte int16;
-typedef signed $type_4_byte int32;
-typedef signed $type_8_byte int64;
-#endif
-
-typedef $signed_type_ptr intptr;
-typedef $unsigned_type_ptr uintptr;
-
+/* TODO: What does this do? */
 #if defined(__APPLE__) && !defined(__ppc__)
 #ifndef _UINT64
 #define _UINT64


### PR DESCRIPTION
Now that `inttypes.h` is included on all platforms, we can use those types as aliases for our own types. This avoids the complexity of detecting the sizes of types in `configure` and provides better defaults when using other build systems (`create_project`, libretro, etc.) Platforms where this is an issue can specify alternative types in the backend's `portdefs.h` file.

A workaround has been left in place for AmigaOS and MorphOS, but I'm hoping that both of them use long for `int32_t` and `uint32_t`, which would allow the workaround to be removed. (CC @raziel-, @BeWorld2018).
