### PR TITLE
CONFIGURE: Apply --enable-Werror *after* testing features and libraries

### DIFF
--- a/configure
+++ b/configure
@@ -185,6 +185,7 @@ _debug_build=auto
 _release_build=auto
 _optimizations=auto
 _verbose_build=no
+_werror_build=no
 _text_console=no
 _mt32emu=yes
 _lua=yes
@@ -1474,7 +1475,7 @@ for ac_option in $@; do
 		_debug_build=no
 		;;
 	--enable-Werror)
-		append_var CXXFLAGS "-Werror"
+		_werror_build=yes
 		;;
 	--enable-release-mode)
 		_release_build=yes
@@ -7307,6 +7308,13 @@ case $_host_os in
 		;;
 esac
 
+
+if test "$_werror_build" = yes; then
+	# --enable-Werror shouldn't be applied before being done testing all system
+	# features and libraries. Otherwise, some of them could just end up being silently
+	# disabled, when any small warning appears in a test.
+	append_var CXXFLAGS "-Werror"
+fi
 
 #
 # Engine selection


### PR DESCRIPTION
The `configure` script has this `--enable-Werror` option, when one intentionally wants *any* compiler warning to cause a build failure. Of course, it's not enabled by default.

However, this option currently adds `-Werror` to `CXXFLAGS` at an early stage of the configure script, i.e. `-Werror` gets added to most feature and libraries detection code.

This PR moves the code around, so that `-Werror` only gets enabled as late as possible, i.e. only apply it for ScummVM itself, not for library/feature detection.

## Further reasoning

Here's an issue that the current behavior causes (with G++ 13.2.0 and Glibc 2.39):

```
g++    -Werror -Wshadow -W -Wno-unused-parameter -Wno-empty-body -fno-operator-names -std=c++11 -pedantic -Wglobal-constructors -Wno-undefined-var-template -Wno-pragma-pack -Wno-address-of-packed-member ./scummvm-conf.cpp -o ./scummvm-conf 
./scummvm-conf.cpp:2:40: error: null passed to a callee that requires a non-null argument [-Wnonnull]
    2 | int main(void) { return posix_spawn(0, 0, 0, 0, 0, 0); }
      |                                        ^
./scummvm-conf.cpp:2:49: error: null passed to a callee that requires a non-null argument [-Wnonnull]
    2 | int main(void) { return posix_spawn(0, 0, 0, 0, 0, 0); }
      |          
```

and then:

```
Checking if posix_spawn is supported... no
```

but `posix_spawn()` _is_ there in Glibc systems! Enabling `-Werror` shouldn't change this fact.

This warning/error happens because the prototype for `posix_spawn()` in glibc has GNU attributes which enforce that the 2nd and 5th argument aren't NULL. But for our quick test, we pass 0/NULL values, because it's simpler/shorter for a simple build/link test.

We could fix the `posix_spawn()` test in particular, but we never know what a future GCC upgrade will find when using `-Wall`. So `-Werror` should not be enabled in the system feature detection code. Moreover, the intent of the `--enable-Werror` is to fail on _any_ compiler warning, but just for ScummVM's code itself, not for the system headers and the external libraries that we try to detect (we don't control their code, anyway).