### PR TITLE
COMMON: Fix inttypes.h support on RISC OS

### DIFF
--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -123,7 +123,17 @@
 	#include <stddef.h>
 	#include <assert.h>
 	#include <ctype.h>
+
+	// The C++11 standard removed the C99 requirement that some <inttypes.h>
+	// features should only be available when the following macros are
+	// defined. But on some systems (such as RISC OS), the libc is not
+	// necessarily up to date with this change. So, continue defining them,
+	// in order to avoid build failures on some environments.
+	#define __STDC_CONSTANT_MACROS
+	#define __STDC_FORMAT_MACROS
+	#define __STDC_LIMIT_MACROS
 	#include <inttypes.h>
+
 	#include <limits.h>
 	// MSVC does not define M_PI, M_SQRT2 and other math defines by default.
 	// _USE_MATH_DEFINES must be defined in order to have these defined, thus


### PR DESCRIPTION
Commit d59f66dfe1981688ce7948e3b5cfacb95d214779 introduced more `<inttypes.h>` in the tree (as OK'd by @ccawley2011 and @lephilousophe on Discord), but this caused a new build failure on RISC OS:
https://buildbot.scummvm.org/#/builders/171/builds/6723

i.e. the `PRId64` macro from `<inttypes.h>` was still not available.

Looking at https://sourceware.org/bugzilla/show_bug.cgi?id=15366 or https://en.cppreference.com/w/cpp/types/integer#Notes, this may be because the RISC OS builder uses an earlier C++11 compiler (GCC 4.7.4) or because its libc isn't up-to-date with the removal of the `__STDC_XXX_MACROS` macro definitions in order to have all the features of `<inttypes.h>`, now that C++11 is a requirement for us.

So this PR just unconditionally defines the macros before including inttypes.h. It shouldn't cause any problem, and I think that _not_ limiting this change to RISC OS only could probably help some other platforms where the C++11 compiler is much newer than the header file.

Any objection? 