### PR TITLE
JANITORIAL: HPL1: Fix typos in code

### DIFF
--- a/engines/hpl1/engine/graphics/LowLevelGraphics.h
+++ b/engines/hpl1/engine/graphics/LowLevelGraphics.h
@@ -93,7 +93,7 @@ enum eTextureFunc {
 	eTextureFunc_Modulate,
 	eTextureFunc_Replace,
 	eTextureFunc_Add,
-	eTextureFunc_Substract,
+	eTextureFunc_Subtract,
 	eTextureFunc_AddSigned,
 	eTextureFunc_Interpolate,
 	eTextureFunc_Dot3RGB,

--- a/engines/hpl1/engine/impl/LowLevelGraphicsSDL.cpp
+++ b/engines/hpl1/engine/impl/LowLevelGraphicsSDL.cpp
@@ -1665,7 +1665,7 @@ GLenum cLowLevelGraphicsSDL::GetGLTextureFuncEnum(eTextureFunc type) {
 		return GL_REPLACE;
 	case eTextureFunc_Add:
 		return GL_ADD;
-	case eTextureFunc_Substract:
+	case eTextureFunc_Subtract:
 		return GL_SUBTRACT;
 	case eTextureFunc_AddSigned:
 		return GL_ADD_SIGNED;

--- a/engines/hpl1/engine/impl/MeshLoaderCollada.cpp
+++ b/engines/hpl1/engine/impl/MeshLoaderCollada.cpp
@@ -214,7 +214,7 @@ static cColladaNode *GetNodeFromController(const tString &asGeomId,
 				asGeomId.c_str(), sControlId.c_str());
 
 	if (sControlId == "") {
-		Warning("No controller refered to the geometry!\n");
+		Warning("No controller referred to the geometry!\n");
 		return NULL;
 	}
 

--- a/engines/hpl1/engine/impl/low_level_graphics_tgl.cpp
+++ b/engines/hpl1/engine/impl/low_level_graphics_tgl.cpp
@@ -166,7 +166,7 @@ TGLenum GetGLTextureFuncEnum(eTextureFunc type) {
 	case eTextureFunc_Add:
 		return TGL_ADD;
 
-	case eTextureFunc_Substract:
+	case eTextureFunc_Subtract:
 	case eTextureFunc_AddSigned:
 	case eTextureFunc_Interpolate:
 	case eTextureFunc_Dot3RGB:

--- a/engines/hpl1/engine/math/Math.cpp
+++ b/engines/hpl1/engine/math/Math.cpp
@@ -1488,7 +1488,7 @@ bool cMath::CreateEdges(tTriEdgeVec &avEdges,
 		// If vertex already exist just add the index
 		if (it != mapVtxIndices.end()) {
 			if (bLog)
-				Log("Allready added, appending.!\n");
+				Log("Already added, appending.!\n");
 			it->second.mlstIndices.push_back(idx);
 		}
 		// if vertex is not added create new vertex and add.

--- a/engines/hpl1/engine/resources/FontManager.cpp
+++ b/engines/hpl1/engine/resources/FontManager.cpp
@@ -98,7 +98,7 @@ FontData *cFontManager::CreateFontData(const tString &asName, int alSize, unsign
 				return NULL;
 			}
 		} else {
-			Error("Font '%s' has an unkown extension!\n", asName.c_str());
+			Error("Font '%s' has an unknown extension!\n", asName.c_str());
 			hplDelete(pFont);
 			EndLoad();
 			return NULL;

--- a/engines/hpl1/engine/scene/MeshEntity.cpp
+++ b/engines/hpl1/engine/scene/MeshEntity.cpp
@@ -353,7 +353,7 @@ cMeshEntity::cMeshEntity(const tString asName, cMesh *apMesh, cMaterialManager *
 cMeshEntity::~cMeshEntity() {
 	for (tEntity3DListIt it = mlstAttachedEntities.begin(); it != mlstAttachedEntities.end(); ++it) {
 		// iEntity3D *pEntity = *it;
-		//  TODO: if(mpWorld) mpWorld->DestroyUnkownEntity(pEntity);
+		//  TODO: if(mpWorld) mpWorld->DestroyUnknownEntity(pEntity);
 	}
 
 	for (int i = 0; i < (int)mvSubMeshes.size(); i++) {

--- a/engines/hpl1/penumbra-overture/GameEnemy_Worm.cpp
+++ b/engines/hpl1/penumbra-overture/GameEnemy_Worm.cpp
@@ -472,7 +472,7 @@ cGameEnemy_Worm::cGameEnemy_Worm(cInit *apInit, const tString &asName, TiXmlElem
 	// Internal variables
 	mvLastForward = cVector3f(0, 0, 1);
 
-	mlMaxSegmentPostions = 20;
+	mlMaxSegmentPositions = 20;
 	mfTurnSpeed = cMath::ToRad(160.0f);
 }
 
@@ -675,7 +675,7 @@ void cGameEnemy_Worm::OnUpdate(float afTimeStep) {
 	} else
 		mlstRootPositions.push_back(pCharBody->GetPosition());
 
-	if ((int)mlstRootPositions.size() > mlMaxSegmentPostions)
+	if ((int)mlstRootPositions.size() > mlMaxSegmentPositions)
 		mlstRootPositions.pop_front();
 
 	// Get smooth position
@@ -739,9 +739,9 @@ void cGameEnemy_Worm::OnUpdate(float afTimeStep) {
 		// Change postion of segment
 
 		// Get add newer pos and smooth all the previuos
-		cVector3f vPrevPos = pSegment->mvPostion;
+		cVector3f vPrevPos = pSegment->mvPosition;
 		pSegment->mlstPositions.push_back(vSegBackPos);
-		if ((int)pSegment->mlstPositions.size() > mlMaxSegmentPostions) {
+		if ((int)pSegment->mlstPositions.size() > mlMaxSegmentPositions) {
 			pSegment->mlstPositions.pop_front();
 		}
 		pSegment->mvPostion = 0;
@@ -753,7 +753,7 @@ void cGameEnemy_Worm::OnUpdate(float afTimeStep) {
 
 		/////////////////////////////////////////////
 		// Get the movement vector
-		cVector3f vSegMovement = pSegment->mvPostion - vPrevPos;
+		cVector3f vSegMovement = pSegment->mvPosition - vPrevPos;
 
 		/////////////////////////////////////////////
 		// Update body position
@@ -824,8 +824,8 @@ void cGameEnemy_Worm::ExtraPostSceneDraw() {
 
 		pLowLevelGfx->DrawSphere(pSegment->mvPostion, 0.3f, cColor(1, 1));
 
-		pLowLevelGfx->DrawLine(pSegment->mvPostion,
-							   pSegment->mvPostion + pSegment->mvForward * 0.5f,
+		pLowLevelGfx->DrawLine(pSegment->mvPosition,
+							   pSegment->mvPosition + pSegment->mvForward * 0.5f,
 							   cColor(1, 0, 1, 1));
 
 		cVector3f vForward = cMath::MatrixMul(cMatrixf::Identity, pSegment->mvForward);

--- a/engines/hpl1/penumbra-overture/GameEnemy_Worm.cpp
+++ b/engines/hpl1/penumbra-overture/GameEnemy_Worm.cpp
@@ -738,7 +738,7 @@ void cGameEnemy_Worm::OnUpdate(float afTimeStep) {
 		//////////////////////////////////
 		// Change postion of segment
 
-		// Get add newer pos and smooth all the previuos
+		// Get add newer pos and smooth all the previous
 		cVector3f vPrevPos = pSegment->mvPosition;
 		pSegment->mlstPositions.push_back(vSegBackPos);
 		if ((int)pSegment->mlstPositions.size() > mlMaxSegmentPositions) {

--- a/engines/hpl1/penumbra-overture/GameEnemy_Worm.cpp
+++ b/engines/hpl1/penumbra-overture/GameEnemy_Worm.cpp
@@ -563,7 +563,7 @@ void cGameEnemy_Worm_MeshCallback::AfterAnimationUpdate(cMeshEntity *apMeshEntit
 
 		////////////////////////////////////////
 		// Set world matrix of bone
-		mtxTrans.SetTranslation(pSegment->mvPostion);
+		mtxTrans.SetTranslation(pSegment->mvPosition);
 		pSegment->mpBone->SetWorldMatrix(mtxTrans);
 	}
 }
@@ -744,12 +744,12 @@ void cGameEnemy_Worm::OnUpdate(float afTimeStep) {
 		if ((int)pSegment->mlstPositions.size() > mlMaxSegmentPositions) {
 			pSegment->mlstPositions.pop_front();
 		}
-		pSegment->mvPostion = 0;
+		pSegment->mvPosition = 0;
 		Common::List<cVector3f>::iterator posIt2 = pSegment->mlstPositions.begin();
 		for (; posIt2 != pSegment->mlstPositions.end(); ++posIt2) {
-			pSegment->mvPostion += *posIt2;
+			pSegment->mvPosition += *posIt2;
 		}
-		pSegment->mvPostion = pSegment->mvPostion / (float)pSegment->mlstPositions.size();
+		pSegment->mvPosition = pSegment->mvPosition / (float)pSegment->mlstPositions.size();
 
 		/////////////////////////////////////////////
 		// Get the movement vector
@@ -757,7 +757,7 @@ void cGameEnemy_Worm::OnUpdate(float afTimeStep) {
 
 		/////////////////////////////////////////////
 		// Update body position
-		pSegment->mpBody->SetPosition(pSegment->mvPostion);
+		pSegment->mpBody->SetPosition(pSegment->mvPosition);
 
 		//////////////////////////////////////////////
 		// Get the direction vector of the segment
@@ -796,7 +796,7 @@ void cGameEnemy_Worm::OnUpdate(float afTimeStep) {
 		////////////////////////////////////////
 		// Set the New back pos
 		if (i < mvTailSegments.size() - 1) {
-			vSegBackPos = pSegment->mvPostion +
+			vSegBackPos = pSegment->mvPosition +
 						  pSegment->mvForward * -mvTailSegments[i + 1]->mfDistToFront;
 		}
 	}
@@ -822,7 +822,7 @@ void cGameEnemy_Worm::ExtraPostSceneDraw() {
 	for (size_t i = 0; i < mvTailSegments.size(); ++i) {
 		cWormTailSegment *pSegment = mvTailSegments[i];
 
-		pLowLevelGfx->DrawSphere(pSegment->mvPostion, 0.3f, cColor(1, 1));
+		pLowLevelGfx->DrawSphere(pSegment->mvPosition, 0.3f, cColor(1, 1));
 
 		pLowLevelGfx->DrawLine(pSegment->mvPosition,
 							   pSegment->mvPosition + pSegment->mvForward * 0.5f,
@@ -922,7 +922,7 @@ void cGameEnemy_Worm::SetupTail() {
 		pSegment->mpBone->SetActive(false);
 
 		// Start Position,forward and rotation
-		pSegment->mvPostion = pSegment->mpBone->GetWorldPosition();
+		pSegment->mvPosition = pSegment->mpBone->GetWorldPosition();
 
 		pSegment->mvForward = mpMover->GetCharBody()->GetForward();
 		pSegment->mvUp = mpMover->GetCharBody()->GetUp();
@@ -938,7 +938,7 @@ void cGameEnemy_Worm::SetupTail() {
 		iCollideShape *pShape = pPhysicsWorld->CreateSphereShape(pCharBody->GetSize().x / 2.0f, NULL);
 		pSegment->mpBody = pPhysicsWorld->CreateBody("Tail0" + cString::ToString(i + 1), pShape);
 		pSegment->mpBody->SetMass(0);
-		pSegment->mpBody->SetPosition(pSegment->mvPostion);
+		pSegment->mpBody->SetPosition(pSegment->mvPosition);
 		pSegment->mpBody->SetIsCharacter(true);
 		pSegment->mpBody->SetActive(IsActive());
 

--- a/engines/hpl1/penumbra-overture/GameEnemy_Worm.h
+++ b/engines/hpl1/penumbra-overture/GameEnemy_Worm.h
@@ -259,7 +259,7 @@ private:
 
 	cVector3f mvLastForward;
 
-	int mlMaxSegmentPostions;
+	int mlMaxSegmentPositions;
 	float mfTurnSpeed;
 
 	bool mbFirstUpdate;

--- a/engines/hpl1/penumbra-overture/GameEnemy_Worm.h
+++ b/engines/hpl1/penumbra-overture/GameEnemy_Worm.h
@@ -136,7 +136,7 @@ public:
 	}
 
 	Common::List<cVector3f> mlstPositions;
-	cVector3f mvPostion;
+	cVector3f mvPosition;
 
 	cVector3f mvGoalForward;
 

--- a/engines/hpl1/penumbra-overture/GameEntity.cpp
+++ b/engines/hpl1/penumbra-overture/GameEntity.cpp
@@ -64,7 +64,7 @@ iGameEntity::iGameEntity(cInit *apInit, const tString &asName) {
 
 	mpCharBody = NULL;
 
-	mType = eGameEntityType_Unkown;
+	mType = eGameEntityType_Unknown;
 
 	msDescription = _W("");
 	msGameName = _W("");

--- a/engines/hpl1/penumbra-overture/GameTypes.h
+++ b/engines/hpl1/penumbra-overture/GameTypes.h
@@ -131,7 +131,7 @@ enum eGameDifficulty {
 //---------------------------------
 
 enum eGameEntityType {
-	eGameEntityType_Unkown,
+	eGameEntityType_Unknown,
 	eGameEntityType_Object,
 	eGameEntityType_Door,
 	eGameEntityType_DoorPanel,

--- a/engines/hpl1/penumbra-overture/HudModel_Weapon.cpp
+++ b/engines/hpl1/penumbra-overture/HudModel_Weapon.cpp
@@ -490,7 +490,7 @@ void cHudModel_WeaponMelee::Attack() {
 	cWorld3D *pWorld = mpInit->mpGame->GetScene()->GetWorld3D();
 	iPhysicsWorld *pPhysicsWorld = pWorld->GetPhysicsWorld();
 
-	tVector3fList lstPostions;
+	tVector3fList lstPositions;
 
 	////////////////////////////////
 	// Iterate Enemies
@@ -512,7 +512,7 @@ void cHudModel_WeaponMelee::Attack() {
 			}*/
 			if (pEnemy->GetMeshEntity()->CheckColliderShapeCollision(pPhysicsWorld,
 																	 mvAttacks[mlCurrentAttack].mpCollider,
-																	 mtxDamage, &lstPostions, NULL) == false) {
+																	 mtxDamage, &lstPositions, NULL) == false) {
 				continue;
 			}
 
@@ -549,7 +549,7 @@ void cHudModel_WeaponMelee::Attack() {
 			// Get closest position
 			float fClosestDist = 9999.0f;
 			cVector3f vClosestPostion = vCenter;
-			for (tVector3fListIt it = lstPostions.begin(); it != lstPostions.end(); ++it) {
+			for (tVector3fListIt it = lstPositions.begin(); it != lstPositions.end(); ++it) {
 				cVector3f &vPos = *it;
 
 				float fDist = cMath::Vector3DistSqr(pCamera->GetPosition(), vPos);
@@ -565,7 +565,7 @@ void cHudModel_WeaponMelee::Attack() {
 											 cMath::MatrixTranslate(vClosestPostion));
 			}
 
-			lstPostions.clear();
+			lstPositions.clear();
 
 			bHit = true;
 		}

--- a/engines/hpl1/penumbra-overture/PlayerHands.cpp
+++ b/engines/hpl1/penumbra-overture/PlayerHands.cpp
@@ -251,7 +251,7 @@ void cPlayerHands::OnStart() {
 //-----------------------------------------------------------------------
 
 void cPlayerHands::Update(float afTimeStep) {
-	UpdatePrevPostions();
+	UpdatePrevPositions();
 
 	///////////////////////////////////
 	// Get the camera properties
@@ -589,7 +589,7 @@ void cPlayerHands::OnWorldLoad() {
 //////////////////////////////////////////////////////////////////////////
 
 //-----------------------------------------------------------------------
-void cPlayerHands::UpdatePrevPostions() {
+void cPlayerHands::UpdatePrevPositions() {
 	///////////////////////////////////
 	// Get current position
 	cCamera3D *pCam = mpInit->mpPlayer->GetCamera();

--- a/engines/hpl1/penumbra-overture/PlayerHands.h
+++ b/engines/hpl1/penumbra-overture/PlayerHands.h
@@ -178,7 +178,7 @@ public:
 	iHudModel *GetCurrentModel(int alNum) { return mvCurrentHudModels[alNum]; }
 
 private:
-	void UpdatePrevPostions();
+	void UpdatePrevPositions();
 
 	cInit *mpInit;
 	cMeshManager *mpMeshManager;


### PR DESCRIPTION
Separate PR since it touches code

QUESTION, please:

Angelscript, Newton and TinyXML are upstream libraries (iiuc)
Are typo fixes for those desirable in-tree?
Or should i drag them to their up-stream versions (not sure if all of them are still maintained, though)?

Thank you