### PR TITLE
AUDIO: Remove unused interface for OPL reads

### DIFF
--- a/audio/alsa_opl.cpp
+++ b/audio/alsa_opl.cpp
@@ -73,7 +73,6 @@ public:
 	void reset();
 
 	void write(int a, int v);
-	byte read(int a);
 
 	void writeReg(int r, int v);
 };
@@ -232,10 +231,6 @@ void OPL::write(int port, int val) {
 			break;
 		}
 	}
-}
-
-byte OPL::read(int port) {
-	return 0;
 }
 
 void OPL::writeReg(int r, int v) {

--- a/audio/fmopl.h
+++ b/audio/fmopl.h
@@ -140,14 +140,6 @@ public:
 	virtual void write(int a, int v) = 0;
 
 	/**
-	 * Reads a byte from the given I/O port.
-	 *
-	 * @param a		port address
-	 * @return		value read
-	 */
-	virtual byte read(int a) = 0;
-
-	/**
 	 * Function to directly write to a specific OPL register.
 	 * This writes to *both* chips for a Dual OPL2. We allow
 	 * writing to secondary OPL registers by using register

--- a/audio/opl2lpt.cpp
+++ b/audio/opl2lpt.cpp
@@ -69,7 +69,6 @@ public:
 	void reset();
 
 	void write(int a, int v);
-	byte read(int a);
 
 	void writeReg(int r, int v);
 };
@@ -148,11 +147,6 @@ void OPL::write(int port, int val) {
 			break;
 		}
 	}
-}
-
-byte OPL::read(int port) {
-	// No read support for the OPL2LPT
-	return 0;
 }
 
 void OPL::writeReg(int r, int v) {

--- a/audio/rwopl3.cpp
+++ b/audio/rwopl3.cpp
@@ -181,11 +181,6 @@ void OPL::write(int portAddress, int value) {
 	}
 }
 
-byte OPL::read(int portAddress) {
-	// Reads are not supported by the RetroWave OPL3.
-	return 0;
-}
-
 void OPL::writeReg(int reg, int value) {
 	if (emulateDualOpl2OnOpl3(reg, value, _type)) {
 		writeReg(reg, value, false);

--- a/audio/rwopl3.h
+++ b/audio/rwopl3.h
@@ -60,7 +60,6 @@ public:
 	void reset() override;
 
 	void write(int portAddress, int value) override;
-	byte read(int portAddress) override;
 
 	void writeReg(int reg, int value) override;
 

--- a/audio/softsynth/opl/dosbox.cpp
+++ b/audio/softsynth/opl/dosbox.cpp
@@ -235,29 +235,6 @@ void OPL::write(int port, int val) {
 	}
 }
 
-byte OPL::read(int port) {
-	switch (_type) {
-	case Config::kOpl2:
-		if (!(port & 1))
-			//Make sure the low bits are 6 on opl2
-			return _chip[0].read() | 0x6;
-		break;
-	case Config::kOpl3:
-		if (!(port & 1))
-			return _chip[0].read();
-		break;
-	case Config::kDualOpl2:
-		// Only return for the lower ports
-		if (port & 1)
-			return 0xff;
-		// Make sure the low bits are 6 on opl2
-		return _chip[(port >> 1) & 1].read() | 0x6;
-	default:
-		break;
-	}
-	return 0;
-}
-
 void OPL::writeReg(int r, int v) {
 	int tempReg = 0;
 	switch (_type) {

--- a/audio/softsynth/opl/dosbox.h
+++ b/audio/softsynth/opl/dosbox.h
@@ -90,7 +90,6 @@ public:
 	void reset();
 
 	void write(int a, int v);
-	byte read(int a);
 
 	void writeReg(int r, int v);
 

--- a/audio/softsynth/opl/mame.cpp
+++ b/audio/softsynth/opl/mame.cpp
@@ -71,10 +71,6 @@ void OPL::write(int a, int v) {
 	MAME::OPLWrite(_opl, a, v);
 }
 
-byte OPL::read(int a) {
-	return MAME::OPLRead(_opl, a);
-}
-
 void OPL::writeReg(int r, int v) {
 	MAME::OPLWriteReg(_opl, r, v);
 }

--- a/audio/softsynth/opl/mame.h
+++ b/audio/softsynth/opl/mame.h
@@ -184,7 +184,6 @@ public:
 	void reset();
 
 	void write(int a, int v);
-	byte read(int a);
 
 	void writeReg(int r, int v);
 

--- a/audio/softsynth/opl/nuked.cpp
+++ b/audio/softsynth/opl/nuked.cpp
@@ -1642,10 +1642,6 @@ void OPL::dualWrite(uint8 index, uint8 reg, uint8 val) {
 	OPL3_WriteRegBuffered(&chip, (uint16_t)fullReg, (uint8_t)val);
 }
 
-byte OPL::read(int port) {
-	return 0;
-}
-
 void OPL::generateSamples(int16*buffer, int length) {
 	OPL3_GenerateStream(&chip, (int16_t*)buffer, (uint16_t)length / 2);
 }

--- a/audio/softsynth/opl/nuked.h
+++ b/audio/softsynth/opl/nuked.h
@@ -179,7 +179,6 @@ public:
 	void reset();
 
 	void write(int a, int v);
-	byte read(int a);
 
 	void writeReg(int r, int v);
 


### PR DESCRIPTION
In addition to not being used by any engines, it's also not implemented by several of the drivers.