### PR TITLE
CONFIGURE: RISCOS: Less false-positive warnings with GCC < 4.8 (and RISC OS)

### DIFF
--- a/configure
+++ b/configure
@@ -2362,6 +2362,14 @@ if test "$have_gcc" = yes ; then
 	openbsd*)
 		pedantic=no
 		;;
+	riscos)
+		# -Wformat complains about '%z' and so on. Don't know if it's related to
+		# the older compiler not being completely C+11-aware, or something else.
+		if test "$have_gcc" = yes && test $_cxx_major -eq 4 && test $_cxx_minor -le 7; then
+			std_variant=gnu++
+			pedantic=no
+		fi
+		;;
 	*)
 		;;
 	esac

--- a/configure
+++ b/configure
@@ -2291,6 +2291,15 @@ if test "$have_gcc" = yes; then
 		else
 			append_var CXXFLAGS "-Wno-missing-field-initializers"
 		fi
+
+		# Many false positives before GCC 4.8, e.g. with templates
+		if test $_cxx_major -eq 4 && test $_cxx_minor -le 7; then
+			append_var CXXFLAGS "-Wno-type-limits"
+			append_var CXXFLAGS "-Wno-uninitialized"
+			append_var CXXFLAGS "-Wno-maybe-uninitialized"
+			append_var CXXFLAGS "-Wno-array-bounds"
+		fi
+
 	fi
 elif test "$have_icc" = yes; then
 	cxx_version="`( $CXX -dumpversion ) 2>/dev/null`"
@@ -4740,10 +4749,17 @@ fi
 # Check whether to enable optimizations
 #
 if test "$_optimizations" = yes ; then
-	# Enable optimizations. This also
-	# makes it possible to use -Wuninitialized, so let's do that.
+	# Enable optimizations
 	append_var CXXFLAGS "$_optimization_level"
-	append_var CXXFLAGS "-Wuninitialized"
+
+	# Optimizations make it possible to use -Wuninitialized, so let's do that
+	# (but only when the compiler has a reliable -Wuninitialized, see the
+	# other _cxx_major/_cxx_minor checks above)
+	if test "$have_gcc" = yes && test $_cxx_major -eq 4 && test $_cxx_minor -le 7; then
+		: nothing
+	else
+		append_var CXXFLAGS "-Wuninitialized"
+	fi
 fi
 
 #


### PR DESCRIPTION
When one looks at [the GCC 4.7 buildbot logs for RISC OS](https://buildbot.scummvm.org/#/builders/171/builds/6737/steps/4/logs/warnings__448_), many warnings show up, but a lot of them are false-positives which won't be printed by a newer compiler.

On the other hand, we have a GCC 4.8 Github Action runner, whose logs are here, for example:
https://github.com/scummvm/scummvm/actions/runs/10340786897/job/28621846127

and indeed many of the GCC 4.7 warnings don't appear in the 4.8 builds.

So, as done in earlier PR #4779, this new PR disables the most unreliable warnings when using this compiler.

In the RISC OS builds in particular (that's our "official" GCC 4.7 user), I'm also suggesting to move to `std_variant=gnu++ pedantic=no` in order to avoid invalid `-Wformat` warnings regarding "GNU extensions". They're aren't, this toolchain just isn't aware of the C++11 requirement changes about this (see PR #6027).

The end result is: less false positives, and so a better view of the compiler warnings on this port.

Assigning this review to @ccawley2011. I don't have any RISC OS system to test this one, I just used the Docker toolchain for it.