### PR TITLE
ZVISION: Support BiDi text in tty

### DIFF
--- a/engines/zvision/scripting/controls/titler_control.cpp
+++ b/engines/zvision/scripting/controls/titler_control.cpp
@@ -98,7 +98,7 @@ void TitlerControl::readStringsFile(const Common::Path &fileName) {
 
 	while (!file.eos()) {
 
-		Common::String line = readWideLine(file);
+		Common::String line = readWideLine(file).encode();
 		_strings.push_back(line);
 	}
 	file.close();

--- a/engines/zvision/scripting/effects/ttytext_effect.cpp
+++ b/engines/zvision/scripting/effects/ttytext_effect.cpp
@@ -30,6 +30,7 @@
 
 #include "common/stream.h"
 #include "common/file.h"
+#include "common/unicode-bidi.h"
 
 namespace ZVision {
 
@@ -42,6 +43,8 @@ ttyTextNode::ttyTextNode(ZVision *engine, uint32 key, const Common::Path &file, 
 	_nexttime = 0;
 	_dx = 0;
 	_dy = 0;
+	_lineStartPos = 0;
+	_startX = 0;
 
 	Common::File *infile = _engine->getSearchManager()->openFile(file);
 	if (infile) {
@@ -55,6 +58,7 @@ ttyTextNode::ttyTextNode(ZVision *engine, uint32 key, const Common::Path &file, 
 
 		delete infile;
 	}
+	_isRTL = Common::convertBiDiU32String(_txtbuf).visual != _txtbuf;
 	_img.create(_r.width(), _r.height(), _engine->_resourcePixelFormat);
 	_state._sharp = true;
 	_state.readAllStyles(_txtbuf.encode());
@@ -96,33 +100,57 @@ bool ttyTextNode::process(uint32 deltaTimeInMillis) {
 					Common::String buf;
 					buf = Common::String::format("%d", _engine->getScriptManager()->getStateValue(_state._statebox));
 
-					for (uint8 j = 0; j < buf.size(); j++)
-						outchar(buf[j]);
+					if (_isRTL) {
+						int16 currDx = _dx + _fnt.getStringWidth(buf);
+						_dx = _r.width() - currDx;
+						_isRTL = false;
+						for (uint8 j = 0; j < buf.size(); j++)
+							outchar(buf[j]);
+						_isRTL = true;
+						_dx = currDx;
+					} else {
+						for (uint8 j = 0; j < buf.size(); j++)
+							outchar(buf[j]);
+					}
 				}
 
 				_txtpos++;
+				_lineStartPos = _txtpos;
+				_startX = _dx;
 			} else {
-				uint16 chr = _txtbuf[_txtpos];
+				uint32 pos = _lineStartPos;
+				int16 dx = _startX;
 
-				if (chr == ' ') {
-					uint32 i = _txtpos + 1;
-					uint16 width = _fnt.getCharWidth(chr);
+				while (pos < _txtbuf.size() && _txtbuf[pos] != '<') {
+					uint16 chr = _txtbuf[pos];
 
-					while (i < _txtbuf.size() && _txtbuf[i] != ' ' && _txtbuf[i] != '<') {
+					if (chr == ' ') {
+						uint32 i = pos + 1;
+						uint16 width = _fnt.getCharWidth(chr);
 
-						uint16 uchr = _txtbuf[i];
+						while (i < _txtbuf.size() && _txtbuf[i] != ' ' && _txtbuf[i] != '<') {
 
-						width += _fnt.getCharWidth(uchr);
+							uint16 uchr = _txtbuf[i];
 
-						i++;
+							width += _fnt.getCharWidth(uchr);
+
+							i++;
+						}
+
+						if (dx + width > _r.width())
+							break;
 					}
+					dx += _fnt.getCharWidth(chr);
+					pos++;
+				}
 
-					if (_dx + width > _r.width())
-						newline();
-					else
-						outchar(chr);
-				} else
-					outchar(chr);
+				Common::U32String lineBuffer = Common::convertBiDiU32String(_txtbuf.substr(_lineStartPos, pos - _lineStartPos)).visual;
+				if (pos == _txtpos)
+					newline();
+				else if (_isRTL)
+					outchar(lineBuffer[pos - _txtpos - 1]);
+				else
+					outchar(lineBuffer[_txtpos - _lineStartPos]);
 
 				_txtpos++;
 			}
@@ -150,6 +178,8 @@ void ttyTextNode::scroll() {
 void ttyTextNode::newline() {
 	_dy += _fnt.getFontHeight();
 	_dx = 0;
+	_lineStartPos = _txtpos + 1;
+	_startX = _dx;
 }
 
 void ttyTextNode::outchar(uint16 chr) {
@@ -161,8 +191,10 @@ void ttyTextNode::outchar(uint16 chr) {
 	if (_dy + _fnt.getFontHeight() >= _r.height())
 		scroll();
 
-	_fnt.drawChar(&_img, chr, _dx, _dy, clr);
-
+	if (_isRTL)
+		_fnt.drawChar(&_img, chr, _r.width() - _dx - _fnt.getCharWidth(chr), _dy, clr);
+	else
+		_fnt.drawChar(&_img, chr, _dx, _dy, clr);
 	_dx += _fnt.getCharWidth(chr);
 }
 

--- a/engines/zvision/scripting/effects/ttytext_effect.h
+++ b/engines/zvision/scripting/effects/ttytext_effect.h
@@ -54,11 +54,14 @@ private:
 	StyledTTFont _fnt;
 	Common::U32String _txtbuf;
 	uint32 _txtpos;
+	uint32 _lineStartPos;
+	bool _isRTL;
 
 	int32 _delay;
 	int32 _nexttime;
 	Graphics::Surface _img;
 	int16 _dx;
+	int16 _startX;
 	int16 _dy;
 private:
 

--- a/engines/zvision/scripting/effects/ttytext_effect.h
+++ b/engines/zvision/scripting/effects/ttytext_effect.h
@@ -52,7 +52,7 @@ private:
 
 	TextStyleState _state;
 	StyledTTFont _fnt;
-	Common::String _txtbuf;
+	Common::U32String _txtbuf;
 	uint32 _txtpos;
 
 	int32 _delay;

--- a/engines/zvision/text/string_manager.cpp
+++ b/engines/zvision/text/string_manager.cpp
@@ -54,7 +54,7 @@ void StringManager::loadStrFile(const Common::Path &fileName) {
 
 	uint lineNumber = 0;
 	while (!file.eos()) {
-		_lines[lineNumber] = readWideLine(file);
+		_lines[lineNumber] = readWideLine(file).encode();
 
 		lineNumber++;
 		assert(lineNumber <= NUM_TEXT_LINES);

--- a/engines/zvision/text/subtitles.cpp
+++ b/engines/zvision/text/subtitles.cpp
@@ -52,7 +52,7 @@ Subtitle::Subtitle(ZVision *engine, const Common::Path &subname, bool upscaleToH
 				Common::File txt;
 				if (_engine->getSearchManager()->openFile(txt, Common::Path(filename))) {
 					while (!txt.eos()) {
-						Common::String txtline = readWideLine(txt);
+						Common::String txtline = readWideLine(txt).encode();
 						sub curSubtitle;
 						curSubtitle.start = -1;
 						curSubtitle.stop = -1;

--- a/engines/zvision/text/text.cpp
+++ b/engines/zvision/text/text.cpp
@@ -504,8 +504,8 @@ void TextRenderer::drawTextWithWordWrapping(const Common::String &text, Graphics
 	}
 }
 
-Common::String readWideLine(Common::SeekableReadStream &stream) {
-	Common::String asciiString;
+Common::U32String readWideLine(Common::SeekableReadStream &stream) {
+	Common::U32String asciiString;
 
 	while (true) {
 		uint32 value = stream.readUint16LE();
@@ -519,58 +519,9 @@ Common::String readWideLine(Common::SeekableReadStream &stream) {
 			break;
 		}
 
-		// Crush each octet pair to a UTF-8 sequence
-		if (value < 0x80) {
-			asciiString += (char)(value & 0x7F);
-		} else if (value >= 0x80 && value < 0x800) {
-			asciiString += (char)(0xC0 | ((value >> 6) & 0x1F));
-			asciiString += (char)(0x80 | (value & 0x3F));
-		} else if (value >= 0x800 && value < 0x10000 && value != 0xCCCC) {
-			asciiString += (char)(0xE0 | ((value >> 12) & 0xF));
-			asciiString += (char)(0x80 | ((value >> 6) & 0x3F));
-			asciiString += (char)(0x80 | (value & 0x3F));
-		} else if (value == 0xCCCC) {
-			// Ignore, this character is used as newline sometimes
-		} else if (value >= 0x10000 && value < 0x200000) {
-			asciiString += (char)(0xF0);
-			asciiString += (char)(0x80 | ((value >> 12) & 0x3F));
-			asciiString += (char)(0x80 | ((value >> 6) & 0x3F));
-			asciiString += (char)(0x80 | (value & 0x3F));
-		}
+		asciiString += value;
 	}
-
 	return asciiString;
-}
-
-int8 getUtf8CharSize(char chr) {
-	if ((chr & 0x80) == 0)
-		return 1;
-	else if ((chr & 0xE0) == 0xC0)
-		return 2;
-	else if ((chr & 0xF0) == 0xE0)
-		return 3;
-	else if ((chr & 0xF8) == 0xF0)
-		return 4;
-	else if ((chr & 0xFC) == 0xF8)
-		return 5;
-	else if ((chr & 0xFE) == 0xFC)
-		return 6;
-
-	return 1;
-}
-
-uint16 readUtf8Char(const char *chr) {
-	uint16 result = 0;
-	if ((chr[0] & 0x80) == 0)
-		result = chr[0];
-	else if ((chr[0] & 0xE0) == 0xC0)
-		result = ((chr[0] & 0x1F) << 6) | (chr[1] & 0x3F);
-	else if ((chr[0] & 0xF0) == 0xE0)
-		result = ((chr[0] & 0x0F) << 12) | ((chr[1] & 0x3F) << 6) | (chr[2] & 0x3F);
-	else
-		result = chr[0];
-
-	return result;
 }
 
 } // End of namespace ZVision

--- a/engines/zvision/text/text.h
+++ b/engines/zvision/text/text.h
@@ -82,9 +82,7 @@ private:
 	ZVision *_engine;
 };
 
-Common::String readWideLine(Common::SeekableReadStream &stream);
-int8 getUtf8CharSize(char chr);
-uint16 readUtf8Char(const char *chr);
+Common::U32String readWideLine(Common::SeekableReadStream &stream);
 
 } // End of namespace ZVision
 

--- a/engines/zvision/text/truetype_font.cpp
+++ b/engines/zvision/text/truetype_font.cpp
@@ -155,7 +155,7 @@ int StyledTTFont::getMaxCharWidth() {
 	return 0;
 }
 
-int StyledTTFont::getCharWidth(byte chr) {
+int StyledTTFont::getCharWidth(uint16 chr) {
 	if (_font)
 		return _font->getCharWidth(chr);
 
@@ -169,7 +169,7 @@ int StyledTTFont::getKerningOffset(byte left, byte right) {
 	return 0;
 }
 
-void StyledTTFont::drawChar(Graphics::Surface *dst, byte chr, int x, int y, uint32 color) {
+void StyledTTFont::drawChar(Graphics::Surface *dst, uint16 chr, int x, int y, uint32 color) {
 	if (_font) {
 		_font->drawChar(dst, chr, x, y, color);
 		if (_style & TTF_STYLE_UNDERLINE) {

--- a/engines/zvision/text/truetype_font.h
+++ b/engines/zvision/text/truetype_font.h
@@ -71,10 +71,10 @@ public:
 
 	int getFontHeight();
 	int getMaxCharWidth();
-	int getCharWidth(byte chr);
+	int getCharWidth(uint16 chr);
 	int getKerningOffset(byte left, byte right);
 
-	void drawChar(Graphics::Surface *dst, byte chr, int x, int y, uint32 color);
+	void drawChar(Graphics::Surface *dst, uint16 chr, int x, int y, uint32 color);
 
 	void drawString(Graphics::Surface *dst, const Common::String &str, int x, int y, int w, uint32 color, Graphics::TextAlign align = Graphics::kTextAlignLeft);
 	int getStringWidth(const Common::String &str);


### PR DESCRIPTION
This adds BiDi/RTL support for the death screens in Zork Grand Inquisitor
for the hebrew fan translation
![screen-cmp-zgi-he-rtl](https://github.com/user-attachments/assets/dbe11872-90e9-4900-a179-1c7dd5688892)
(text itself still needs work)

On unmodified files (e.g. without the hebrew patch) there wouldn't be any change in the death screen
![screen-cmp-zgi](https://github.com/user-attachments/assets/9d40bee2-1a4c-4f97-a926-14bf4749cffd)

The change is divided into 3 commits
- The first fixes implicit casting of 2-bytes character to 1-byte
- The second refactors the tty processing to use UTF-32, which greatly simplify the logic (simple indexing rather than calculating how many bytes is taken by each character)
- The third add BiDi and RTL support for displaying hebrew text

Thanks

