### PR TITLE
AUDIO: Make the SID emulator a subclass of Audio::Chip

### DIFF
--- a/audio/module.mk
+++ b/audio/module.mk
@@ -24,6 +24,7 @@ MODULE_OBJS := \
 	musicplugin.o \
 	null.o \
 	rate.o \
+	sid.o \
 	timestamp.o \
 	decoders/3do.o \
 	decoders/aac.o \

--- a/audio/sid.cpp
+++ b/audio/sid.cpp
@@ -1,0 +1,51 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "audio/sid.h"
+#include "audio/softsynth/sid.h"
+
+#include "common/textconsole.h"
+
+namespace SID {
+
+SID *Config::create(SidType type) {
+#ifndef DISABLE_SID
+	// For now this is fixed to the ReSID emulator.
+	Resid::SID *sid = new Resid::SID(type);
+	return sid;
+#else
+	return nullptr;
+#endif
+}
+
+bool SID::_hasInstance = false;
+
+SID::SID() {
+	if (_hasInstance)
+		error("There are multiple SID output instances running.");
+	_hasInstance = true;
+}
+
+SID::~SID() {
+	_hasInstance = false;
+}
+
+} // End of namespace SID

--- a/audio/sid.h
+++ b/audio/sid.h
@@ -1,0 +1,75 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef AUDIO_SID_H
+#define AUDIO_SID_H
+
+#include "audio/chip.h"
+
+namespace SID {
+
+class SID;
+
+class Config {
+public:
+	enum SidType {
+		kSidPAL,
+		kSidNTSC
+	};
+
+	/**
+	 * Creates a SID driver.
+	 */
+	static SID *create(SidType type);
+};
+
+class SID : virtual public Audio::Chip {
+private:
+	static bool _hasInstance;
+
+public:
+	SID();
+	virtual ~SID();
+
+	/**
+	 * Initializes the SID emulator.
+	 *
+	 * @return		true on success, false on failure
+	 */
+	virtual bool init() = 0;
+
+	/**
+	 * Reinitializes the SID emulator
+	 */
+	virtual void reset() = 0;
+
+	/**
+	 * Function to directly write to a specific SID register.
+	 *
+	 * @param r		hardware register number to write to
+	 * @param v		value, which will be written
+	 */
+	virtual void writeReg(int r, int v) = 0;
+};
+
+} // End of namespace SID
+
+#endif

--- a/audio/softsynth/sid.cpp
+++ b/audio/softsynth/sid.cpp
@@ -1093,22 +1093,38 @@ void Voice::reset() {
 }
 
 
+struct TimingProps {
+	double clockFreq;
+	int cyclesPerFrame;
+};
+
+static const TimingProps timingProps[2] = {
+	{ 17734472.0 / 18, 312 * 63 }, // PAL:  312*63 cycles/frame @  985248 Hz (~50Hz)
+	{ 14318180.0 / 14, 263 * 65 }  // NTSC: 263*65 cycles/frame @ 1022727 Hz (~60Hz)
+};
+
 /*
  * SID
  */
 
-SID::SID() {
+SID::SID(::SID::Config::SidType videoSystem) : _videoSystem(videoSystem), _cpuCyclesLeft(0) {
 	voice[0].set_sync_source(&voice[2]);
 	voice[1].set_sync_source(&voice[0]);
 	voice[2].set_sync_source(&voice[1]);
 
-	set_sampling_parameters(985248, 44100);
+	set_sampling_parameters(timingProps[videoSystem].clockFreq, getRate());
+	enable_filter(true);
 
 	bus_value = 0;
 	bus_value_ttl = 0;
 }
 
 SID::~SID() {}
+
+bool SID::init() {
+	reset();
+	return true;
+}
 
 void SID::reset() {
 	for (int i = 0; i < 3; i++) {
@@ -1166,7 +1182,7 @@ reg8 SID::read(reg8 offset) {
 	}
 }
 
-void SID::write(reg8 offset, reg8 value) {
+void SID::writeReg(int offset, int value) {
 	bus_value = value;
 	bus_value_ttl = 0x2000;
 
@@ -1420,6 +1436,28 @@ int SID::updateClock(cycle_count& delta_t, short* buf, int n, int interleave) {
 	sample_offset -= delta_t << FIXP_SHIFT;
 	delta_t = 0;
 	return s;
+}
+
+int SID::readBuffer(int16 *buffer, const int numSamples) {
+	int samplesLeft = numSamples;
+
+	while (samplesLeft > 0) {
+		// update SID status after each frame
+		if (_cpuCyclesLeft <= 0) {
+			if (_callback && _callback->isValid())
+				(*_callback)();
+			_cpuCyclesLeft = timingProps[_videoSystem].cyclesPerFrame;
+		}
+		// fetch samples
+		int sampleCount = updateClock(_cpuCyclesLeft, (short *)buffer, samplesLeft);
+		samplesLeft -= sampleCount;
+		buffer += sampleCount;
+	}
+
+	return numSamples;
+}
+
+void SID::generateSamples(int16 *buffer, const int numSamples) {
 }
 
 }

--- a/audio/softsynth/sid.h
+++ b/audio/softsynth/sid.h
@@ -27,7 +27,7 @@
 #ifndef AUDIO_SOFTSYNTH_SID_H
 #define AUDIO_SOFTSYNTH_SID_H
 
-#include "common/scummsys.h"
+#include "audio/sid.h"
 
 // Inlining on/off.
 #define RESID_INLINE inline
@@ -302,9 +302,9 @@ protected:
 };
 
 
-class SID {
+class SID : public ::SID::SID, public Audio::EmulatedChip {
 public:
-	SID();
+	SID(::SID::Config::SidType videoSystem);
 	~SID();
 
 	void enable_filter(bool enable);
@@ -315,16 +315,23 @@ public:
 
 	void updateClock(cycle_count delta_t);
 	int updateClock(cycle_count& delta_t, short* buf, int n, int interleave = 1);
-	void reset();
+
+	bool init() override;
+	void reset() override;
 
 	// Read/write registers.
 	reg8 read(reg8 offset);
-	void write(reg8 offset, reg8 value);
+	void writeReg(int offset, int value) override;
 
 	// 16-bit output (AUDIO OUT).
 	int output();
 
+	bool isStereo() const override { return false; }
+
 protected:
+	void generateSamples(int16 *buffer, int numSamples) override;
+	int readBuffer(int16 *buffer, const int numSamples) override;
+
 	Voice voice[3];
 	Filter filter;
 	ExternalFilter extfilt;
@@ -342,6 +349,9 @@ protected:
 	cycle_count cycles_per_sample;
 	cycle_count sample_offset;
 	short sample_prev;
+
+	::SID::Config::SidType _videoSystem;
+	cycle_count _cpuCyclesLeft;
 };
 
 }

--- a/engines/scumm/players/player_sid.cpp
+++ b/engines/scumm/players/player_sid.cpp
@@ -29,7 +29,7 @@
 namespace Scumm {
 
 /*
- * The player's update() routine is called once per (NTSC/PAL) frame as it is
+ * The player's onTimer() routine is called once per (NTSC/PAL) frame as it is
  * called by the VIC Rasterline interrupt handler which is in turn called
  * approx. 50 (PAL) or 60 (NTSC) times per second.
  * The SCUMM V0/V1 music playback routines or sound data have not been adjusted
@@ -45,16 +45,6 @@ namespace Scumm {
  * - https://riff.2ix.at/c64/print.php?dok=man-vic (German)
  * - http://www.c64-wiki.de/index.php/VIC (German)
  */
-
-struct TimingProps {
-	double clockFreq;
-	int cyclesPerFrame;
-};
-
-static const TimingProps timingProps[2] = {
-	{ 17734472.0 / 18, 312 * 63 }, // PAL:  312*63 cycles/frame @  985248 Hz (~50Hz)
-	{ 14318180.0 / 14, 263 * 65 }  // NTSC: 263*65 cycles/frame @ 1022727 Hz (~60Hz)
-};
 
 static const uint8 BITMASK[7] = {
 	0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40
@@ -265,7 +255,7 @@ void Player_SID::resetSID() { // $48D8
 	resetPlayerState();
 }
 
-void Player_SID::update() { // $481B
+void Player_SID::onTimer() { // $481B
 	if (initializing)
 		return;
 
@@ -1132,7 +1122,7 @@ void Player_SID::unused1() { // $50AF
 
 #define ZEROMEM(a) memset(a, 0, sizeof(a))
 
-Player_SID::Player_SID(ScummEngine *scumm, Audio::Mixer *mixer) {
+Player_SID::Player_SID(ScummEngine *scumm) {
 	/*
 	 * clear memory
 	 */
@@ -1245,26 +1235,17 @@ Player_SID::Player_SID(ScummEngine *scumm, Audio::Mixer *mixer) {
 
 	_music_timer = 0;
 
-	_mixer = mixer;
-	_sampleRate = _mixer->getOutputRate();
 	_vm = scumm;
 
-	// sound speed is slightly different on NTSC and PAL machines
-	// as the SID clock depends on the frame rate.
-	// ScummVM does not distinguish between NTSC and PAL targets
-	// so we use the NTSC timing here as the music was composed for
-	// NTSC systems (music on PAL systems is slower).
-	_videoSystem = NTSC;
-	_cpuCyclesLeft = 0;
 
 	initSID();
 	resetSID();
-
-	_mixer->playStream(Audio::Mixer::kPlainSoundType, &_soundHandle, this, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO, true);
 }
 
 Player_SID::~Player_SID() {
-	_mixer->stopHandle(_soundHandle);
+	Common::StackLock lock(_mutex);
+
+	_sid->stop();
 	delete _sid;
 }
 
@@ -1281,45 +1262,29 @@ uint8 *Player_SID::getResource(int resID) {
 	}
 }
 
-int Player_SID::readBuffer(int16 *buffer, const int numSamples) {
-	int samplesLeft = numSamples;
-
-	Common::StackLock lock(_mutex);
-
-	while (samplesLeft > 0) {
-		// update SID status after each frame
-		if (_cpuCyclesLeft <= 0) {
-			update();
-			_cpuCyclesLeft = timingProps[_videoSystem].cyclesPerFrame;
-		}
-		// fetch samples
-		int sampleCount = _sid->updateClock(_cpuCyclesLeft, (short *)buffer, samplesLeft);
-		samplesLeft -= sampleCount;
-		buffer += sampleCount;
-	}
-
-	return numSamples;
-}
-
 void Player_SID::SID_Write(int reg, uint8 data) {
-	_sid->write(reg, data);
+	_sid->writeReg(reg, data);
 }
 
 void Player_SID::initSID() {
-	_sid = new Resid::SID();
-	_sid->set_sampling_parameters(
-		timingProps[_videoSystem].clockFreq,
-		_sampleRate);
-	_sid->enable_filter(true);
+	// sound speed is slightly different on NTSC and PAL machines
+	// as the SID clock depends on the frame rate.
+	// ScummVM does not distinguish between NTSC and PAL targets
+	// so we use the NTSC timing here as the music was composed for
+	// NTSC systems (music on PAL systems is slower).
+	_sid = SID::Config::create(SID::Config::kSidNTSC);
+	if (!_sid || !_sid->init())
+		error("Failed to initialise SID emulator");
 
-	_sid->reset();
 	// Synchronize the waveform generators (must occur after reset)
-	_sid->write( 4, 0x08);
-	_sid->write(11, 0x08);
-	_sid->write(18, 0x08);
-	_sid->write( 4, 0x00);
-	_sid->write(11, 0x00);
-	_sid->write(18, 0x00);
+	SID_Write( 4, 0x08);
+	SID_Write(11, 0x08);
+	SID_Write(18, 0x08);
+	SID_Write( 4, 0x00);
+	SID_Write(11, 0x00);
+	SID_Write(18, 0x00);
+
+	_sid->start(new Common::Functor0Mem<void, Player_SID>(this, &Player_SID::onTimer), 60);
 }
 
 void Player_SID::startSound(int nr) {

--- a/engines/scumm/players/player_sid.h
+++ b/engines/scumm/players/player_sid.h
@@ -25,9 +25,7 @@
 #include "common/mutex.h"
 #include "common/scummsys.h"
 #include "scumm/music.h"
-#include "audio/audiostream.h"
-#include "audio/mixer.h"
-#include "audio/softsynth/sid.h"
+#include "audio/sid.h"
 
 namespace Scumm {
 
@@ -43,16 +41,11 @@ enum sid_reg_t {
 	PULSE_VOICE3
 };
 
-enum VideoStandard {
-	PAL,
-	NTSC
-};
-
 class ScummEngine;
 
-class Player_SID : public Audio::AudioStream, public MusicEngine {
+class Player_SID : public MusicEngine {
 public:
-	Player_SID(ScummEngine *scumm, Audio::Mixer *mixer);
+	Player_SID(ScummEngine *scumm);
 	~Player_SID() override;
 
 	void setMusicVolume(int vol) override { _maxvol = vol; }
@@ -62,29 +55,15 @@ public:
 	int  getSoundStatus(int sound) const override;
 	int  getMusicTimer() override;
 
-	// AudioStream API
-	int readBuffer(int16 *buffer, const int numSamples) override;
-	bool isStereo() const override { return false; }
-	bool endOfData() const override { return false; }
-	int getRate() const override { return _sampleRate; }
-
 private:
-	Resid::SID *_sid;
+	SID::SID *_sid;
 	void SID_Write(int reg, uint8 data);
 	void initSID();
 	uint8 *getResource(int resID);
 
-	// number of cpu cycles until next frame update
-	Resid::cycle_count _cpuCyclesLeft;
-
 	ScummEngine *_vm;
-	Audio::Mixer *_mixer;
-	Audio::SoundHandle _soundHandle;
-	int _sampleRate;
 	int _maxvol;
 	Common::Mutex _mutex;
-
-	VideoStandard _videoSystem;
 
 	int _music_timer;
 	uint8* _music;
@@ -96,7 +75,7 @@ private:
 	void stopMusic_intern(); // $4CAA
 
 	void resetSID(); // $48D8
-	void update(); // $481B
+	void onTimer(); // $481B
 	void handleMusicBuffer();
 	int setupSongFileData(); // $36cb
 	void func_3674(int channel); // $3674

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2174,7 +2174,7 @@ void ScummEngine::setupMusic(int midi) {
 		_musicEngine = new Player_AppleII(this, _mixer);
 	} else if (_game.platform == Common::kPlatformC64 && _game.version <= 1) {
 #ifndef DISABLE_SID
-		_musicEngine = new Player_SID(this, _mixer);
+		_musicEngine = new Player_SID(this);
 #endif
 	} else if (_game.platform == Common::kPlatformNES && _game.version == 1) {
 #ifndef DISABLE_NES_APU


### PR DESCRIPTION
Unfortunately I don't understand the code well enough to properly implement `generateSamples()`, so I ended up working around it by overriding `readBuffer()` with the version from the SCUMM engine, meaning that the frequency specified by the engine is currently ignored. It's good enough for a proof of concept, but I'll need help doing this properly before it can be merged.