### PR TITLE
GRIM: Refresh screen on a regular basis on hardware renderer

### DIFF
--- a/engines/grim/gfx_base.h
+++ b/engines/grim/gfx_base.h
@@ -109,8 +109,10 @@ public:
 
 	/**
 	 *  Swap the buffers, making the drawn screen visible
+	 *
+	 *  @param opportunistic True when the flip can be avoided to spare CPU
 	 */
-	virtual void flipBuffer() = 0;
+	virtual void flipBuffer(bool opportunistic = false) = 0;
 
 	/**
 	 * FIXME: The implementations of these functions (for Grim and EMI, respectively)

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -259,7 +259,18 @@ void GfxOpenGL::clearDepthBuffer() {
 	glClear(GL_DEPTH_BUFFER_BIT);
 }
 
-void GfxOpenGL::flipBuffer() {
+void GfxOpenGL::flipBuffer(bool opportunistic) {
+	if (opportunistic) {
+		GLint fbo = 0;
+		glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &fbo);
+		if (fbo == 0) {
+			// Don't flip if we are not rendering on FBO
+			// Flipping without any draw is undefined
+			// When using an FBO, the older texture will be used
+			return;
+		}
+	}
+
 	g_system->updateScreen();
 }
 

--- a/engines/grim/gfx_opengl.h
+++ b/engines/grim/gfx_opengl.h
@@ -52,7 +52,7 @@ public:
 
 	void clearScreen() override;
 	void clearDepthBuffer() override;
-	void flipBuffer() override;
+	void flipBuffer(bool opportunistic = false) override;
 
 	bool isHardwareAccelerated() override;
 	bool supportsShaders() override;

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -514,7 +514,18 @@ void GfxOpenGLS::clearDepthBuffer() {
 	glClear(GL_DEPTH_BUFFER_BIT);
 }
 
-void GfxOpenGLS::flipBuffer() {
+void GfxOpenGLS::flipBuffer(bool opportunistic) {
+	if (opportunistic) {
+		GLint fbo = 0;
+		glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &fbo);
+		if (fbo == 0) {
+			// Don't flip if we are not rendering on FBO
+			// Flipping without any draw is undefined
+			// When using an FBO, the older texture will be used
+			return;
+		}
+	}
+
 	g_system->updateScreen();
 }
 

--- a/engines/grim/gfx_opengl_shaders.h
+++ b/engines/grim/gfx_opengl_shaders.h
@@ -65,7 +65,7 @@ public:
 	/**
 	 * Swap the buffers, making the drawn screen visible
 	 */
-	void flipBuffer() override;
+	void flipBuffer(bool opportunistic = false) override;
 
 	void getScreenBoundingBox(const Mesh *mesh, int *x1, int *y1, int *x2, int *y2) override;
 	void getScreenBoundingBox(const EMIModel *model, int *x1, int *y1, int *x2, int *y2) override;

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -175,7 +175,12 @@ void GfxTinyGL::clearDepthBuffer() {
 	tglClear(TGL_DEPTH_BUFFER_BIT);
 }
 
-void GfxTinyGL::flipBuffer() {
+void GfxTinyGL::flipBuffer(bool opportunistic) {
+	if (opportunistic) {
+		g_system->updateScreen();
+		return;
+	}
+
 	Common::List<Common::Rect> dirtyAreas;
 	TinyGL::presentBuffer(dirtyAreas);
 

--- a/engines/grim/gfx_tinygl.h
+++ b/engines/grim/gfx_tinygl.h
@@ -54,7 +54,7 @@ public:
 
 	void clearScreen() override;
 	void clearDepthBuffer() override;
-	void flipBuffer() override;
+	void flipBuffer(bool opportunistic = false) override;
 
 	bool isHardwareAccelerated() override;
 	bool supportsShaders() override;

--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -653,9 +653,7 @@ void GrimEngine::playAspyrLogo() {
 		uint32 startTime = g_system->getMillis();
 
 		updateDisplayScene();
-		if (_doFlip) {
-			doFlip();
-		}
+		doFlip();
 		// Process events to allow the user to skip the logo.
 		Common::Event event;
 		while (g_system->getEventManager()->pollEvent(event)) {
@@ -957,7 +955,11 @@ void GrimEngine::drawNormalMode() {
 
 void GrimEngine::doFlip() {
 	_frameCounter++;
-	if (!_doFlip) {
+	// When possible, flip the buffer
+	// This makes sure the screen is refreshed on a regular basis
+	// The image is properly resized if needed and backend overlays are displayed
+	if (!_doFlip || (_mode == PauseMode)) {
+		g_driver->flipBuffer(true);
 		return;
 	}
 
@@ -1131,9 +1133,7 @@ void GrimEngine::mainLoop() {
 			updateDisplayScene();
 		}
 
-		if (_mode != PauseMode) {
-			doFlip();
-		}
+		doFlip();
 
 		// We do not want the scripts to update while a movie is playing in the PS2-version.
 		if (!(getGamePlatform() == Common::kPlatformPS2 && _mode == SmushMode)) {


### PR DESCRIPTION
This fix is needed to properly display the gamepad overlay on Android when in menus.

The `_doFlip` flag has been added by @eriktorbjorn in 24bcd2bd25d5 in order to reduce CPU usage while playing Smush videos.
The main problem is that it blocks redraws to take into account external events (for example screen resize) and I am almost sure that it would have cause black screen if a window would have gone over ScummVM one.

I am not completely sure it's valid because I may need to force some draw before.