### PR TITLE
NUVIE: Allow loading custom tiles from game dir mods/custom_tiles.bmp

### DIFF
--- a/engines/ultima/nuvie/actors/actor_manager.cpp
+++ b/engines/ultima/nuvie/actors/actor_manager.cpp
@@ -1073,10 +1073,6 @@ void ActorManager::set_combat_movement(bool c) {
 }
 
 bool ActorManager::loadCustomTiles(nuvie_game_t game_type) {
-	if (obj_manager->use_custom_actor_tiles() == false) {
-		return false;
-	}
-
 	Common::Path datadir = "images";
 	Common::Path path;
 
@@ -1087,19 +1083,22 @@ bool ActorManager::loadCustomTiles(nuvie_game_t game_type) {
 
 	tile_manager->freeCustomTiles(); //FIXME this might need to change if we start using custom tiles outside of ActorManager. eg custom map/object tilesets
 
-	loadCustomBaseTiles(datadir);
-	loadAvatarTiles(datadir);
-	loadNPCTiles(datadir);
+	loadCustomBaseTiles();
+	if (obj_manager->use_custom_actor_tiles()) {
+		loadAvatarTiles(datadir);
+		loadNPCTiles(datadir);
+	}
 
 	return true;
 }
 
-void ActorManager::loadCustomBaseTiles(const Common::Path &datadir) {
+void ActorManager::loadCustomBaseTiles() {
+	Common::Path datadir = "mods";
 	Common::Path imagefile;
 	build_path(datadir, "custom_tiles.bmp", imagefile);
 
 	//attempt to load custom base tiles if the file exists.
-	tile_manager->loadCustomTiles(Game::get_game()->get_data_file_path(imagefile), true, true, 0);
+	tile_manager->loadCustomTiles(imagefile, true, true, 0);
 }
 
 void ActorManager::loadAvatarTiles(const Common::Path &datadir) {

--- a/engines/ultima/nuvie/actors/actor_manager.h
+++ b/engines/ultima/nuvie/actors/actor_manager.h
@@ -163,7 +163,7 @@ private:
 	bool loadCustomTiles(nuvie_game_t game_type);
 	void loadNPCTiles(const Common::Path &datadir);
 	void loadAvatarTiles(const Common::Path &datadir);
-	void loadCustomBaseTiles(const Common::Path &datadir);
+	void loadCustomBaseTiles();
 	Std::set<Std::string> getCustomTileFilenames(const Common::Path &datadir, const Std::string &filenamePrefix);
 };
 

--- a/engines/ultima/nuvie/conf/configuration.h
+++ b/engines/ultima/nuvie/conf/configuration.h
@@ -44,7 +44,7 @@ class ConfigNode;
  * Configuration values are stored in one of two ways -either as a standalone
  * nuvie.cfg file, or otherwise from the ScummVM domain for the added game.
  *
- * WHen the nuvie.cfg file is present, it's contents are stored as an XML tree
+ * When the nuvie.cfg file is present, it's contents are stored as an XML tree
  * (or a forest, technically). All values are stored as strings, but access
  * functions for ints and bools are provided
  * You should only store values in leaf nodes. (This isn't enforced everywhere,


### PR DESCRIPTION
This PR allows loading the `custom_tiles.bmp` file from the ultima6 game directory. In a subdirectory called `mods/`

It also decouples loading custom base tiles from the custom actor tiles config setting.
```
[ultima6]
ultima6/custom_actor_tiles=yes
```
Here is the brown dirt custom tileset in action! The bmp file can be found at [https://ultimacodex.com/2017/06/nuvie-support-for-exporting-and-importing-tilesets-added/](https://ultimacodex.com/2017/06/nuvie-support-for-exporting-and-importing-tilesets-added/)
![image](https://github.com/user-attachments/assets/70b36010-756a-4b61-aedf-c2717be03a70)

