### PR TITLE
SCI: (PC-98) - fix hilite control color

### DIFF
--- a/engines/sci/graphics/controls16.cpp
+++ b/engines/sci/graphics/controls16.cpp
@@ -347,7 +347,9 @@ void GfxControls16::kernelDrawButton(Common::Rect rect, reg_t obj, const char *t
 		}
 	} else {
 		// SCI0early used xor to invert button rectangles resulting in pink/white buttons
-		if (getSciVersion() == SCI_VERSION_0_EARLY)
+		// All PC-98 targets (both SCI_VERSION_01 and SCI_VERSION_1_LATE) also use the
+		// xor method, resulting in a grey color.
+		if (getSciVersion() == SCI_VERSION_0_EARLY || g_sci->getPlatform() == Common::kPlatformPC98)
 			_paint16->invertRectViaXOR(rect);
 		else
 			_paint16->invertRect(rect);
@@ -391,7 +393,13 @@ void GfxControls16::kernelDrawText(Common::Rect rect, reg_t obj, const char *tex
 		if (allowScreenUpdate && !getPicNotValid())
 			_paint16->bitsShow(rect);
 	} else {
-		_paint16->invertRect(rect);
+		// SCI0early used xor to invert button rectangles resulting in pink/white buttons
+		// All PC-98 targets (both SCI_VERSION_01 and SCI_VERSION_1_LATE) also use the
+		// xor method, resulting in a grey color.
+		if (getSciVersion() == SCI_VERSION_0_EARLY || g_sci->getPlatform() == Common::kPlatformPC98)
+			_paint16->invertRectViaXOR(rect);
+		else
+			_paint16->invertRect(rect);
 		_paint16->bitsShow(rect);
 	}
 }
@@ -426,7 +434,13 @@ void GfxControls16::kernelDrawIcon(Common::Rect rect, reg_t obj, GuiResourceId v
 		if (!getPicNotValid())
 			_paint16->bitsShow(rect);
 	} else {
-		_paint16->invertRect(rect);
+		// SCI0early used xor to invert button rectangles resulting in pink/white buttons
+		// All PC-98 targets (both SCI_VERSION_01 and SCI_VERSION_1_LATE) also use the
+		// xor method, resulting in a grey color.
+		if (getSciVersion() == SCI_VERSION_0_EARLY || g_sci->getPlatform() == Common::kPlatformPC98)
+			_paint16->invertRectViaXOR(rect);
+		else
+			_paint16->invertRect(rect);
 		_paint16->bitsShow(rect);
 	}
 }


### PR DESCRIPTION
I noticed that the button hilite colors are incorrect in KQV PC-98.

Turns out that all PC-98 targets use the xoring method for the hilite, like SCI0early.

Also, this has to be applied not only to the button control, but also to the text and icon controls. For SCI0 that might not make a visual difference, but for PC-98 it does...



![Screenshot 2024-08-09 154834](https://github.com/user-attachments/assets/8d79c2ce-2690-40ce-bfc6-35e2ab393304)

![Screenshot 2024-08-09 205555](https://github.com/user-attachments/assets/c4750d61-81e5-4d30-867c-674fea96c60d)
