### PR TITLE
AGS: Support for FreeType 2.13.3 changes to FT_Outline struct

### DIFF
--- a/engines/ags/lib/freetype-2.1.3/autohint/ahglyph.cpp
+++ b/engines/ags/lib/freetype-2.1.3/autohint/ahglyph.cpp
@@ -296,7 +296,11 @@ void ah_outline_save(AH_Outline outline, AH_Loader gloader) {
 	AH_Point point = outline->points;
 	AH_Point point_limit = point + outline->num_points;
 	FT_Vector *vec = gloader->current.outline.points;
+#if (FREETYPE_MAJOR * 1000 + FREETYPE_MINOR) * 1000 + FREETYPE_PATCH < 2013003
 	char *tag = gloader->current.outline.tags;
+#else
+	unsigned char *tag = gloader->current.outline.tags;
+#endif
 
 	/* we assume that the glyph loader has already been checked for storage */
 	for (; point < point_limit; point++, vec++, tag++) {
@@ -408,8 +412,11 @@ FT_Error ah_outline_load(AH_Outline outline, FT_Face face) {
 
 		/* compute Bezier flags */
 		{
+#if (FREETYPE_MAJOR * 1000 + FREETYPE_MINOR) * 1000 + FREETYPE_PATCH < 2013003
 			char *tag = source->tags;
-
+#else
+			unsigned char *tag = source->tags;
+#endif
 			for (point = points; point < point_limit; point++, tag++) {
 				switch (FT_CURVE_TAG(*tag)) {
 				case FT_CURVE_TAG_CONIC:
@@ -457,12 +464,17 @@ FT_Error ah_outline_load(AH_Outline outline, FT_Face face) {
 		{
 			AH_Point *contour = outline->contours;
 			AH_Point *contour_limit = contour + outline->num_contours;
+#if (FREETYPE_MAJOR * 1000 + FREETYPE_MINOR) * 1000 + FREETYPE_PATCH < 2013003
 			short *end = source->contours;
 			short idx = 0;
+#else
+			unsigned short *end = source->contours;
+			unsigned short idx = 0;
+#endif
 
 			for (; contour < contour_limit; contour++, end++) {
 				contour[0] = points + idx;
-				idx = (short)(end[0] + 1);
+				idx = end[0] + 1;
 			}
 		}
 


### PR DESCRIPTION
FreeType 2.13.3 changed a few types of the struct members for FT_Outline struct to unsigned

This is the relevant commit from the FreeType source (github): https://github.com/freetype/freetype/commit/2a7bb4596f566a34fd53932af0ef53b956459d25

Note: FreeType 2.13.3 was only very recently released (on Aug 12, 2024, ie. two days ago).
This PR fixes compilation in MSYS2/Mingw-64 (maybe other toolchains as well, but I'm testing on this one), since that one got the updated version of the library yesterday.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
