### PR TITLE
ENGINES: Various small -Wunused-but-set-variable/-Wunused-private-field warning fixes

### DIFF
--- a/engines/access/events.h
+++ b/engines/access/events.h
@@ -48,7 +48,6 @@ private:
 	uint32 _priorFrameTime;
 	uint32 _priorTimerTime;
 	Common::KeyCode _keyCode;
-	Common::CustomEventType _customAction;
 
 	Graphics::Surface _invCursor;
 	bool checkForNextFrameCounter();

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -79,8 +79,11 @@ static char dimFragSrc[] =
 
 GfxOpenGL::GfxOpenGL() : _smushNumTex(0),
 		_smushTexIds(nullptr), _smushWidth(0), _smushHeight(0),
-		_useDepthShader(false), _fragmentProgram(0), _useDimShader(0),
-		_dimFragProgram(0), _maxLights(0), _storedDisplay(nullptr),
+		_useDepthShader(false), _useDimShader(0),
+		_maxLights(0), _storedDisplay(nullptr),
+#ifdef GL_ARB_fragment_program
+		_fragmentProgram(0), _dimFragProgram(0),
+#endif
 		_emergFont(0), _alpha(1.f) {
 	type = Graphics::RendererType::kRendererTypeOpenGL;
 	// GL_LEQUAL as glDepthFunc ensures that subsequent drawing attempts for

--- a/engines/grim/gfx_opengl.h
+++ b/engines/grim/gfx_opengl.h
@@ -137,9 +137,11 @@ private:
 	int _smushHeight;
 	byte *_storedDisplay;
 	bool _useDepthShader;
+#ifdef GL_ARB_fragment_program
 	GLuint _fragmentProgram;
-	bool _useDimShader;
 	GLuint _dimFragProgram;
+#endif
+	bool _useDimShader;
 	GLint _maxLights;
 	float _alpha;
 	const Actor *_currentActor;

--- a/engines/icb/options_manager_pc.cpp
+++ b/engines/icb/options_manager_pc.cpp
@@ -6531,7 +6531,7 @@ linesDone:
 	uint32 pitch = surface_manager->Get_pitch(working_buffer_id);
 
 	// Draw the credit lines all nicely formatted
-	for (uint32 count = 0; TRUE8; count++) {
+	while (TRUE8) {
 		// Is this the end of the file
 		if (m_cursor >= (uint32)m_numberOfBytes) {
 			if (m_logoAttached) {

--- a/engines/mm/shared/xeen/sound_driver_mt32.h
+++ b/engines/mm/shared/xeen/sound_driver_mt32.h
@@ -44,7 +44,6 @@ public:
 private:
 	static const uint8 MIDI_NOTE_MAP[24];
 private:
-	MidiChannel *_midiChannels[CHANNEL_COUNT];
 	Common::Queue<MidiValue> _queue;
 	Common::Mutex _driverMutex;
 	const byte *_musInstrumentPtrs[16];

--- a/engines/mortevielle/utils.cpp
+++ b/engines/mortevielle/utils.cpp
@@ -1871,13 +1871,11 @@ Common::String MortevielleEngine::getString(int num) {
 	} else {
 		int hint = _dialogHintArray[num]._hintId;
 		byte point = _dialogHintArray[num]._point;
-		int length = 0;
 		bool endFl = false;
 		char let;
 		do {
 			endFl = decryptNextChar(let, hint, point);
 			wrkStr += let;
-			++length;
 		} while (!endFl);
 	}
 

--- a/engines/prince/hero.cpp
+++ b/engines/prince/hero.cpp
@@ -264,7 +264,6 @@ void Hero::showHeroShadow(Graphics::Surface *screen, DrawNode *drawNode) {
 		int shadWallBitAddr = 0;
 		int shadWallBitMask = 0;
 		byte *shadWallDestAddr = nullptr;
-		int shadWallPosY = 0;
 		int shadWallSkipX = 0;
 		int shadWallModulo = 0;
 
@@ -408,7 +407,6 @@ void Hero::showHeroShadow(Graphics::Surface *screen, DrawNode *drawNode) {
 						shadWallBitAddr = shadBitAddr;
 						shadWallDestAddr = (byte *)screen->getBasePtr(shadDrawX + diffX, shadDrawY + diffY);
 						shadWallBitMask = shadBitMask;
-						shadWallPosY = shadPosY;
 						shadWallSkipX = shadSkipX;
 						shadWallModulo = sprModulo;
 					}
@@ -455,7 +453,6 @@ void Hero::showHeroShadow(Graphics::Surface *screen, DrawNode *drawNode) {
 						//krap2
 						shadWallDestAddr -= PrinceEngine::kNormalWidth;
 						shadWallBitAddr -= PrinceEngine::kMaxPicWidth / 8;
-						shadWallPosY--;
 					}
 				}
 			}

--- a/engines/sherlock/fonts.cpp
+++ b/engines/sherlock/fonts.cpp
@@ -120,11 +120,9 @@ void Fonts::setFont(int fontNum) {
 					byte *frameExclMarkPixels = (byte *)frameExclamationMark._frame.getPixels();
 					byte *frameRevExclMarkPixels = (byte *)frameRevExclamationMark._frame.getPixels();
 
-					uint16 revExclMarkY = frameExclamationMark._height - 1;
 					frameRevExclMarkPixels += frameExclamationMark._width * (frameExclamationMark._height - 1);
 					for (uint16 exclMarkY = 0; exclMarkY < frameExclamationMark._height; exclMarkY++) {
 						memcpy(frameRevExclMarkPixels, frameExclMarkPixels, frameExclamationMark._width);
-						revExclMarkY--;
 						frameRevExclMarkPixels -= frameExclamationMark._width;
 						frameExclMarkPixels += frameExclamationMark._width;
 					}

--- a/engines/startrek/actors.cpp
+++ b/engines/startrek/actors.cpp
@@ -1414,7 +1414,6 @@ void StarTrekEngine::scaleBitmapRow(byte *src, byte *dest, uint16 origWidth, uin
 		uint16 var4 = scaledWidth << 1;
 		uint16 var6 = (scaledWidth - origWidth) << 1;
 		uint16 varE = 0;
-		uint16 varA = 0;
 		uint16 var8 = origWidth;
 		uint16 di = 0;
 
@@ -1437,13 +1436,11 @@ void StarTrekEngine::scaleBitmapRow(byte *src, byte *dest, uint16 origWidth, uin
 			}
 
 			di++;
-			varA++;
 		}
 	} else {
 		int16 var2 = ((origWidth - 1) << 1) - (scaledWidth - 1);
 		uint16 var4 = (origWidth - 1) << 1;
 		uint16 var6 = ((origWidth - 1) - (scaledWidth - 1)) << 1;
-		uint16 varA = 0;
 		uint16 var8 = scaledWidth;
 		uint16 di = 0;
 
@@ -1460,8 +1457,6 @@ void StarTrekEngine::scaleBitmapRow(byte *src, byte *dest, uint16 origWidth, uin
 				var2 += var6;
 				di++;
 			}
-
-			varA++;
 		}
 	}
 }

--- a/engines/toon/toon.cpp
+++ b/engines/toon/toon.cpp
@@ -1839,8 +1839,6 @@ void ToonEngine::fixPaletteEntries(uint8 *palette, int num) {
 
 // adapted from KyraEngine
 void ToonEngine::updateAnimationSceneScripts(int32 timeElapsed) {
-	static int32 numReentrant = 0;
-	++numReentrant;
 	const int startScript = _lastProcessedSceneScript;
 
 	_updatingSceneScriptRunFlag = true;
@@ -1878,7 +1876,6 @@ void ToonEngine::updateAnimationSceneScripts(int32 timeElapsed) {
 	} while (_lastProcessedSceneScript != startScript && !_shouldQuit);
 
 	_updatingSceneScriptRunFlag = false;
-	--numReentrant;
 }
 
 void ToonEngine::loadScene(int32 SceneId, bool forGameLoad) {

--- a/engines/touche/touche.cpp
+++ b/engines/touche/touche.cpp
@@ -2210,7 +2210,7 @@ void ToucheEngine::drawAmountOfMoneyInInventory() {
 
 void ToucheEngine::packInventoryItems(int index) {
 	int16 *p = _inventoryStateTable[index].itemsList;
-	for (int i = 0; *p != -1; ++i, ++p) {
+	for (; *p != -1; ++p) {
 		if (p[0] == 0 && p[1] != -1) {
 			p[0] = p[1];
 			p[1] = 0;
@@ -2241,7 +2241,7 @@ void ToucheEngine::addItemToInventory(int inventory, int16 item) {
 		appendItemToInventoryList(inventory);
 		assert(inventory >= 0 && inventory < 3);
 		int16 *p = _inventoryStateTable[inventory].itemsList;
-		for (int i = 0; *p != -1; ++i, ++p) {
+		for (; *p != -1; ++p) {
 			if (*p == 0) {
 				*p = item;
 				_inventoryItemsInfoTable[item] = inventory | 0x10;
@@ -2260,7 +2260,7 @@ void ToucheEngine::removeItemFromInventory(int inventory, int16 item) {
 	} else {
 		assert(inventory >= 0 && inventory < 3);
 		int16 *p = _inventoryStateTable[inventory].itemsList;
-		for (int i = 0; *p != -1; ++i, ++p) {
+		for (; *p != -1; ++p) {
 			if (*p == item) {
 				*p = 0;
 				packInventoryItems(0);

--- a/engines/vcruise/midi_player.cpp
+++ b/engines/vcruise/midi_player.cpp
@@ -27,7 +27,7 @@
 namespace VCruise {
 
 MidiPlayer::MidiPlayer(MidiDriver *midiDrv, Common::Array<byte> &&musicData, int volume)
-	: _midiDrv(midiDrv), _data(Common::move(musicData)), _volume(-1) {
+	: _midiDrv(midiDrv), _data(Common::move(musicData)) {
 	_parser.reset(MidiParser::createParser_SMF());
 
 	if (_data.size() > 0u && _parser->loadMusic(&_data[0], _data.size())) {

--- a/engines/vcruise/midi_player.h
+++ b/engines/vcruise/midi_player.h
@@ -49,7 +49,6 @@ private:
 	MidiDriver *_midiDrv;
 	Common::SharedPtr<MidiParser> _parser;
 	Common::Array<byte> _data;
-	int _volume;
 };
 
 } // End of namespace VCruise

--- a/engines/vcruise/script.cpp
+++ b/engines/vcruise/script.cpp
@@ -184,7 +184,6 @@ private:
 
 	ScriptDialect _dialect;
 	uint _loadAsRoom;
-	uint _fileRoom;
 
 	const char *_scrToken;
 	const char *_eroomToken;
@@ -228,7 +227,7 @@ private:
 };
 
 ScriptCompiler::ScriptCompiler(TextParser &parser, const Common::Path &blamePath, ScriptDialect dialect, uint loadAsRoom, uint fileRoom, IScriptCompilerGlobalState *gs)
-	: _numberParsingMode(kNumberParsingHex), _parser(parser), _blamePath(blamePath), _dialect(dialect), _loadAsRoom(loadAsRoom), _fileRoom(fileRoom), _gs(gs),
+	: _numberParsingMode(kNumberParsingHex), _parser(parser), _blamePath(blamePath), _dialect(dialect), _loadAsRoom(loadAsRoom), _gs(gs),
 	  _scrToken(nullptr), _eroomToken(nullptr) {
 }
 


### PR DESCRIPTION
Just a bunch of `-Wunused-private-field` and `-Wunused-private-field` warning fixes for various engines.

It should be pretty trivial to review; I'm mostly opening a PR for the CI tests on all compilers

For the GRIM change, it just follow what earlier commit 6d7e92919792 did