### PR TITLE
GOB: remove usage translation.h include from DEV7 entries

### DIFF
--- a/engines/gob/detection/tables.h
+++ b/engines/gob/detection/tables.h
@@ -29,7 +29,6 @@
 #define GOB_DETECTION_TABLES_H
 
 // Struct "GOBGameDescription"
-#include "common/translation.h"
 #include "gob/detection/detection.h"
 
 using namespace Common;

--- a/engines/gob/detection/tables_adi5.h
+++ b/engines/gob/detection/tables_adi5.h
@@ -32,8 +32,6 @@
 #ifndef GOB_DETECTION_TABLES_ADI5_H
 #define GOB_DETECTION_TABLES_ADI5_H
 
-//#include "common/translation.h"  // Make release checker happy
-
 // -- French: Adi 5 --
 
 {

--- a/engines/gob/detection/tables_adibou3.h
+++ b/engines/gob/detection/tables_adibou3.h
@@ -32,8 +32,6 @@
 #ifndef GOB_DETECTION_TABLES_ADIBOU3_H
 #define GOB_DETECTION_TABLES_ADIBOU3_H
 
-//#include "common/translation.h"  // Make release checker happy
-
 // -- French: Adibou 3 --
 
 {

--- a/engines/gob/detection/tables_adiboudchou.h
+++ b/engines/gob/detection/tables_adiboudchou.h
@@ -32,8 +32,6 @@
 #ifndef GOB_DETECTION_TABLES_ADIBOUDCHOU_H
 #define GOB_DETECTION_TABLES_ADIBOUDCHOU_H
 
-//#include "common/translation.h"  // Make release checker happy
-
 // -- French: Adiboud'chou series --
 
 {

--- a/engines/gob/detection/tables_adiboupresente.h
+++ b/engines/gob/detection/tables_adiboupresente.h
@@ -31,8 +31,6 @@
 #ifndef GOB_DETECTION_TABLES_ADIBOUPRESENTE_H
 #define GOB_DETECTION_TABLES_ADIBOUPRESENTE_H
 
-//#include "common/translation.h"  // Make release checker happy
-
 // -- French: Adibou présente Dessin --
 
 {

--- a/engines/gob/detection/tables_nathanvacances.h
+++ b/engines/gob/detection/tables_nathanvacances.h
@@ -31,8 +31,6 @@
 #ifndef GOB_DETECTION_TABLES_NATHANVACANCES_H
 #define GOB_DETECTION_TABLES_NATHANVACANCES_H
 
-//#include "common/translation.h"  // Make release checker happy
-
 // -- French: Nathan Vacances --
 
 {

--- a/engines/gob/detection/tables_pierresmagiques.h
+++ b/engines/gob/detection/tables_pierresmagiques.h
@@ -31,8 +31,6 @@
 #ifndef GOB_DETECTION_TABLES_PIERRESMAGIQUES_H
 #define GOB_DETECTION_TABLES_PIERRESMAGIQUES_H
 
-//#include "common/translation.h"  // Make release checker happy
-
 // -- French: Le pays des Pierres Magiques --
 
 {


### PR DESCRIPTION
We no longer need the include of translation.h due to we replaced it with the MetaEngine code.