### PR TITLE
ENGINES: remove usage of translation.h include

### DIFF
--- a/engines/cge/detection.cpp
+++ b/engines/cge/detection.cpp
@@ -23,8 +23,6 @@
 
 #include "engines/advancedDetector.h"
 
-#include "common/translation.h"
-
 #include "cge/fileio.h"
 #include "cge/cge.h"
 #include "cge/detection.h"

--- a/engines/groovie/detection.cpp
+++ b/engines/groovie/detection.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "common/system.h"
-#include "common/translation.h"
 
 #include "engines/advancedDetector.h"
 #include "groovie/detection.h"

--- a/engines/lure/detection.cpp
+++ b/engines/lure/detection.cpp
@@ -23,8 +23,6 @@
 
 #include "engines/advancedDetector.h"
 
-#include "common/translation.h"
-
 #include "lure/detection.h"
 #include "lure/lure.h"
 

--- a/engines/mohawk/detection_tables.h
+++ b/engines/mohawk/detection_tables.h
@@ -19,8 +19,6 @@
  *
  */
 
-#include "common/translation.h"
-
 namespace Mohawk {
 
 #define GUI_OPTIONS_MYST                   GUIO4(GUIO_NOASPECT, GUIO_NOSUBTITLES, GUIO_NOSPEECH, GUIO_NOMIDI)

--- a/engines/mtropolis/detection_tables.h
+++ b/engines/mtropolis/detection_tables.h
@@ -26,8 +26,6 @@
 
 #include "mtropolis/detection.h"
 
-#include "common/translation.h"
-
 namespace MTropolis {
 
 static const MTropolisGameDescription gameDescriptions[] = {

--- a/engines/stark/detection.cpp
+++ b/engines/stark/detection.cpp
@@ -21,8 +21,6 @@
 
 #include "engines/advancedDetector.h"
 
-#include "common/translation.h"
-
 #include "stark/detection.h"
 #include "stark/debug.h"
 

--- a/engines/teenagent/detection.cpp
+++ b/engines/teenagent/detection.cpp
@@ -22,7 +22,6 @@
 #include "common/algorithm.h"
 
 #include "base/plugins.h"
-#include "common/translation.h"
 
 #include "engines/advancedDetector.h"
 #include "teenagent/teenagent.h"

--- a/engines/toltecs/detection.cpp
+++ b/engines/toltecs/detection.cpp
@@ -24,7 +24,6 @@
 #include "engines/advancedDetector.h"
 
 #include "common/config-manager.h"
-#include "common/translation.h"
 #include "common/savefile.h"
 #include "common/str-array.h"
 #include "common/system.h"

--- a/engines/trecision/detection.cpp
+++ b/engines/trecision/detection.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "base/plugins.h"
-#include "common/translation.h"
 #include "engines/advancedDetector.h"
 
 #include "trecision/detection.h"


### PR DESCRIPTION
Since the translation code has been replaced with the MetaEngine code the include of translation.h is no longer needed.