### PR TITLE
SCUMM: MANIAC (Apple II): add note separation when playing music

### DIFF
--- a/engines/scumm/players/player_apple2.cpp
+++ b/engines/scumm/players/player_apple2.cpp
@@ -244,8 +244,10 @@ private:
 			_speakerShiftReg ^= _bitmask1;
 		}
 
-		if (_speakerShiftReg & 0x1)
-			_player->speakerToggle();
+		if (_count < 0xff80) { // add a note separation towards the end of the note, otherwise, play the note
+			if (_speakerShiftReg & 0x1)
+				_player->speakerToggle();
+		}
 		_speakerShiftReg >>= 1;
 		_player->generateSamples(42); /* actually 42.5 */
 


### PR DESCRIPTION
This change adds a separation between notes when Sid/Razor play the piano or when the demo tape is played.   This change prevents a note that was meant to be played multiple times consecutively from sounding like the note being only once for an extended time.
