### PR TITLE
AGS: Maintain valid filename in fallback detection

### DIFF
--- a/engines/ags/detection.cpp
+++ b/engines/ags/detection.cpp
@@ -177,7 +177,9 @@ ADDetectedGame AGSMetaEngineDetection::fallbackDetect(const FileMap &allFiles, c
 
 			AGS::g_fallbackDesc.desc.gameId = _gameid.c_str();
 			AGS::g_fallbackDesc.desc.extra = _extra.c_str();
-			AGS::g_fallbackDesc.desc.filesDescriptions[0].fileName = _filename.toString('/').c_str();
+
+			_filenameStr = _filename.toString('/');
+			AGS::g_fallbackDesc.desc.filesDescriptions[0].fileName = _filenameStr.c_str();
 			AGS::g_fallbackDesc.desc.filesDescriptions[0].fileSize = (f.size() >= 0xffffffff) ? AD_NO_SIZE : f.size();
 			AGS::g_fallbackDesc.desc.filesDescriptions[0].md5 = _md5.c_str();
 

--- a/engines/ags/detection.h
+++ b/engines/ags/detection.h
@@ -67,6 +67,7 @@ class AGSMetaEngineDetection : public AdvancedMetaEngineDetection<AGS::AGSGameDe
 	mutable Common::String _gameid;
 	mutable Common::String _extra;
 	mutable Common::Path _filename;
+	mutable Common::String _filenameStr;
 	mutable Common::String _md5;
 
 	static const DebugChannelDef debugFlagList[];


### PR DESCRIPTION
Currently the desc.filesDescriptions[0].fileName would contain garbage after returing from ADDetectedGame AGSMetaEngineDetection::fallbackDetect()

This would result in error message like the one shown in this bug report:
https://bugs.scummvm.org/ticket/15319#comment:2
"ERROR: Unable to determine game data. Provided game location is not a valid path.
Cwd: D:/Games/KingsQuestIVGA/
Path:"

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
