### PR TITLE
SCUMM: IMUSE: Implement music volume reduction during speech

### DIFF
--- a/engines/scumm/gfx_gui.cpp
+++ b/engines/scumm/gfx_gui.cpp
@@ -2033,7 +2033,7 @@ void ScummEngine::setMusicVolume(int volume) {
 	ConfMan.flushToDisk();
 
 	if (_game.version < 7)
-		ScummEngine::syncSoundSettings();
+		ScummEngine::syncSoundSettings(); // Immediately update volume for old iMUSE and sound systems
 }
 
 void ScummEngine::setSpeechVolume(int volume) {
@@ -2044,7 +2044,7 @@ void ScummEngine::setSpeechVolume(int volume) {
 	ConfMan.flushToDisk();
 
 	if (_game.version < 7)
-		ScummEngine::syncSoundSettings();
+		ScummEngine::syncSoundSettings(); // Immediately update volume for old iMUSE and sound systems
 }
 
 void ScummEngine::setSFXVolume(int volume) {
@@ -2055,7 +2055,7 @@ void ScummEngine::setSFXVolume(int volume) {
 	ConfMan.flushToDisk();
 
 	if (_game.version < 7)
-		ScummEngine::syncSoundSettings();
+		ScummEngine::syncSoundSettings(); // Immediately update volume for old iMUSE and sound systems
 }
 
 int ScummEngine::getMusicVolume() {

--- a/engines/scumm/gfx_gui.cpp
+++ b/engines/scumm/gfx_gui.cpp
@@ -2031,6 +2031,9 @@ void ScummEngine::setMusicVolume(int volume) {
 		_mixer->setVolumeForSoundType(Audio::Mixer::kMusicSoundType, volume * 2);
 	ConfMan.setInt("music_volume", volume * 2);
 	ConfMan.flushToDisk();
+
+	if (_game.version < 7)
+		ScummEngine::syncSoundSettings();
 }
 
 void ScummEngine::setSpeechVolume(int volume) {
@@ -2039,6 +2042,9 @@ void ScummEngine::setSpeechVolume(int volume) {
 		_mixer->setVolumeForSoundType(Audio::Mixer::kSpeechSoundType, volume * 2);
 	ConfMan.setInt("speech_volume", volume * 2);
 	ConfMan.flushToDisk();
+
+	if (_game.version < 7)
+		ScummEngine::syncSoundSettings();
 }
 
 void ScummEngine::setSFXVolume(int volume) {
@@ -2047,6 +2053,9 @@ void ScummEngine::setSFXVolume(int volume) {
 		_mixer->setVolumeForSoundType(Audio::Mixer::kSFXSoundType, volume * 2);
 	ConfMan.setInt("sfx_volume", volume * 2);
 	ConfMan.flushToDisk();
+
+	if (_game.version < 7)
+		ScummEngine::syncSoundSettings();
 }
 
 int ScummEngine::getMusicVolume() {

--- a/engines/scumm/imuse/imuse.cpp
+++ b/engines/scumm/imuse/imuse.cpp
@@ -1360,8 +1360,8 @@ void IMuseInternal::musicVolumeReduction(MidiDriver *midi) {
 		return;
 
 	_musicVolumeReductionTimer += midi->getBaseTempo();
-	while (_musicVolumeReductionTimer >= 16667) {
-		_musicVolumeReductionTimer -= 16667;
+	while (_musicVolumeReductionTimer >= MUS_REDUCTION_TIMER_TICKS) {
+		_musicVolumeReductionTimer -= MUS_REDUCTION_TIMER_TICKS;
 		curVol = _music_volume / factor;
 
 		if (_vm->_sound->speechIsPlaying())

--- a/engines/scumm/imuse/imuse.cpp
+++ b/engines/scumm/imuse/imuse.cpp
@@ -34,6 +34,7 @@
 #include "scumm/imuse/instrument.h"
 #include "scumm/resource.h"
 #include "scumm/scumm.h"
+#include "scumm/sound.h"
 
 namespace Scumm {
 
@@ -44,6 +45,7 @@ namespace Scumm {
 ////////////////////////////////////////
 
 IMuseInternal::IMuseInternal(ScummEngine *vm, MidiDriverFlags sndType, bool nativeMT32) :
+	_vm(vm),
 	_native_mt32(nativeMT32),
 	_newSystem(vm && vm->_game.id == GID_SAMNMAX),
 	_dynamicChanAllocation(vm && (vm->_game.id != GID_MONKEY2 && vm->_game.id != GID_INDY4)), // For the non-iMuse games that (unfortunately) run on this player we need to pretend we're on the more modern version
@@ -63,6 +65,7 @@ IMuseInternal::IMuseInternal(ScummEngine *vm, MidiDriverFlags sndType, bool nati
 	_queue_cleared(0),
 	_master_volume(0),
 	_music_volume(0),
+	_music_volume_eff(0),
 	_trigger_count(0),
 	_snm_trigger_index(0),
 	_soundType(sndType),
@@ -345,6 +348,8 @@ void IMuseInternal::on_timer(MidiDriver *midi) {
 	if (_paused || !_initialized)
 		return;
 
+	musicVolumeReduction(midi);
+
 	if (midi == _midi_native || !_midi_native)
 		handleDeferredCommands(midi);
 	sequencer_timers(midi);
@@ -354,11 +359,11 @@ void IMuseInternal::pause(bool paused) {
 	Common::StackLock lock(_mutex);
 	if (_paused == paused)
 		return;
-	int vol = _music_volume;
+	int vol = _music_volume_eff;
 	if (paused)
-		_music_volume = 0;
+		_music_volume_eff = 0;
 	update_volumes();
-	_music_volume = vol;
+	_music_volume_eff = vol;
 
 	// Fix for Bug #1263. The MT-32 apparently fails
 	// sometimes to respond to a channel volume message
@@ -512,8 +517,11 @@ void IMuseInternal::setMusicVolume(int vol) {
 		vol = 255;
 	if (_music_volume == vol)
 		return;
+
 	_music_volume = vol;
-	vol = _master_volume * _music_volume / 255;
+	_music_volume_eff = _music_volume;
+
+	vol = _master_volume * _music_volume_eff / 255;
 	for (uint i = 0; i < ARRAYSIZE(_channel_volume); i++) {
 		_channel_volume_eff[i] = _channel_volume[i] * vol / 255;
 	}
@@ -1042,7 +1050,7 @@ void IMuseInternal::handle_marker(uint id, byte data) {
 int IMuseInternal::get_channel_volume(uint a) {
 	if (a < 8)
 		return _channel_volume_eff[a];
-	return (_master_volume * _music_volume / 255) / 2;
+	return (_master_volume * _music_volume_eff / 255) / 2;
 }
 
 Part *IMuseInternal::allocate_part(byte pri, MidiDriver *midi) {
@@ -1202,7 +1210,7 @@ int IMuseInternal::setImuseMasterVolume(uint vol) {
 	if (_master_volume == vol)
 		return 0;
 	_master_volume = vol;
-	vol = _master_volume * _music_volume / 255;
+	vol = _master_volume * _music_volume_eff / 255;
 	for (uint i = 0; i < ARRAYSIZE(_channel_volume); i++) {
 		_channel_volume_eff[i] = _channel_volume[i] * vol / 255;
 	}
@@ -1327,7 +1335,7 @@ int IMuseInternal::set_channel_volume(uint chan, uint vol) {
 		return -1;
 
 	_channel_volume[chan] = vol;
-	_channel_volume_eff[chan] = _master_volume * _music_volume * vol / 255 / 255;
+	_channel_volume_eff[chan] = _master_volume * _music_volume_eff * vol / 255 / 255;
 	update_volumes();
 	return 0;
 }
@@ -1340,6 +1348,40 @@ void IMuseInternal::update_volumes() {
 		if (player->isActive())
 			player->setVolume(player->getVolume());
 	}
+}
+
+void IMuseInternal::musicVolumeReduction(MidiDriver *midi) {
+	int curVol;
+	int curEffVol;
+	int factor = 2; // The music volume variables are 0-255, and we need 0-127
+
+	if (_paused)
+		return;
+
+	_musicVolumeReductionTimer += midi->getBaseTempo();
+	while (_musicVolumeReductionTimer >= 16667) {
+		_musicVolumeReductionTimer -= 16667;
+		curVol = _music_volume / factor;
+
+		if (_vm->_sound->speechIsPlaying())
+			curVol = (90 * curVol) >> 7;
+
+		curEffVol = _music_volume_eff / factor;
+
+		// The reduction curve is pretty slow, but running
+		// the original through a debugger shows the same behavior...
+		if (curEffVol > curVol)
+			_music_volume_eff = (curEffVol - 1) * factor;
+
+		if (curEffVol < curVol)
+			_music_volume_eff = (curEffVol + 1) * factor;
+	}
+
+	for (uint i = 0; i < ARRAYSIZE(_channel_volume); i++) {
+		_channel_volume_eff[i] = _channel_volume[i] * (_master_volume * _music_volume_eff / 255) / 255;
+	}
+
+	update_volumes();
 }
 
 int IMuseInternal::set_volchan_entry(uint a, uint b) {

--- a/engines/scumm/imuse/imuse.cpp
+++ b/engines/scumm/imuse/imuse.cpp
@@ -348,7 +348,8 @@ void IMuseInternal::on_timer(MidiDriver *midi) {
 	if (_paused || !_initialized)
 		return;
 
-	musicVolumeReduction(midi);
+	if (_game_id == GID_SAMNMAX)
+		musicVolumeReduction(midi);
 
 	if (midi == _midi_native || !_midi_native)
 		handleDeferredCommands(midi);

--- a/engines/scumm/imuse/imuse_internal.h
+++ b/engines/scumm/imuse/imuse_internal.h
@@ -59,6 +59,8 @@ class  IMuseSysex_Scumm;
 
 #define MDPG_TAG "MDpg"
 
+#define MUS_REDUCTION_TIMER_TICKS 16667 // 60 Hz
+
 
 ////////////////////////////////////////
 //

--- a/engines/scumm/imuse/imuse_internal.h
+++ b/engines/scumm/imuse/imuse_internal.h
@@ -416,6 +416,7 @@ class IMuseInternal : public IMuse {
 #endif
 
 protected:
+	ScummEngine *_vm;
 	const bool _native_mt32;
 	const bool _newSystem;
 	const bool _dynamicChanAllocation;
@@ -445,13 +446,16 @@ protected:
 	int  _player_limit;       // Limits how many simultaneous music tracks are played
 	bool _recycle_players;    // Can we stop a player in order to start another one?
 
+	int _musicVolumeReductionTimer = 0; // 60 Hz
+
 	uint _queue_end, _queue_pos, _queue_sound;
 	byte _queue_adding;
 
 	byte _queue_marker;
 	byte _queue_cleared;
 	byte _master_volume; // Master volume. 0-255
-	byte _music_volume; // Global music volume. 0-255
+	byte _music_volume; // Music volume which can be reduced during speech. 0-255
+	byte _music_volume_eff; // Global effective music volume. 0-255
 
 	uint16 _trigger_count;
 	ImTrigger _snm_triggers[16]; // Sam & Max triggers
@@ -528,6 +532,7 @@ protected:
 	int set_volchan_entry(uint a, uint b);
 	int set_channel_volume(uint chan, uint vol);
 	void update_volumes();
+	void musicVolumeReduction(MidiDriver *midi);
 
 	int set_volchan(int sound, int volchan);
 

--- a/engines/scumm/sound.cpp
+++ b/engines/scumm/sound.cpp
@@ -1339,6 +1339,10 @@ void Sound::stopSpeechTimer() {
 	_vm->getTimerManager()->removeTimerProc(&speechTimerHandler);
 }
 
+bool Sound::speechIsPlaying() {
+	return _mixer->isSoundHandleActive(*_talkChannelHandle);
+}
+
 static void cdTimerHandler(void *refCon) {
 	Sound *snd = (Sound *)refCon;
 

--- a/engines/scumm/sound.h
+++ b/engines/scumm/sound.h
@@ -146,6 +146,7 @@ public:
 	void resetSpeechTimer();
 	void startSpeechTimer();
 	void stopSpeechTimer();
+	bool speechIsPlaying(); // Used within MIDI iMUSE
 
 	void startCDTimer();
 	void stopCDTimer();


### PR DESCRIPTION
Posting this as a PR because I'm touching code which I'm not comfortable touching 😛 
The reduction algorithm is the one from the SAMNMAX sound drivers.

INDY4 and DOTT apparently use an earlier version of the algorithm, but this is not implemented because:
- I'm not sure if what I found is the algorithm
- If it is, I don't understand it
- My iMUSE disassemblies are heavily unlabeled

EDIT: At the cost of redundancy, please don't merge this until review is through, as any errors in this PR could break flagship games 🙂 