### PR TITLE
COMMON: Remove MemoryReadStream::seek() assertion

### DIFF
--- a/common/stream.cpp
+++ b/common/stream.cpp
@@ -145,8 +145,10 @@ bool MemoryReadStream::seek(int64 offs, int whence) {
 		_pos += offs;
 		break;
 	}
-	// Post-Condition
-	assert(_pos <= _size);
+	
+	if (!(_pos <= _size)) {
+		_pos = _size;
+	}
 
 	// Reset end-of-stream flag on a successful seek
 	_eos = false;


### PR DESCRIPTION
Removes an abstraction-breaking assertion in `MemoryReadStream::seek()`. 

`MemoryReadStream::seek()` fails an assertion (crashes) when requested to seek out of bounds. Expected behavior is to not crash on an invalid seek, but to return false and not reset eos. Currently it always returns true.

Passing a `MemoryReadStream` as a `Stream` is currently unsafe, because any code that seeks, reads, and tests `eos()` (a common pattern) becomes a fatal error. This is blocking an AGI feature I'm working on.

In my case, parsing code takes a `SeekableReadStream`. This used to always be a `Common::File`, but now it can be a `MemoryReadStream`, so it crashes. This is detection/parsing code, so it will routinely encounter files it can't parse. That's good and expected; that's what the `seek()` return value and `eos()` are for. This assertion crashes the program before those can be used.

The pre-condition assertion in `MemoryReadStream::seek()` can stay, as long as `_pos` is clipped to `_size` in the `seek()` error handling, which is what I've done. Otherwise, a second `seek()` will crash, even when the current position is irrelevant.
 
`SeekableSubReadStream::seek()` looks like it has the same problem, but I don't know anything about that class so I'm not touching it.