### PR TITLE
SCI: [RFC] Fix PCjr music volume

### DIFF
--- a/engines/sci/sound/drivers/pcjr.cpp
+++ b/engines/sci/sound/drivers/pcjr.cpp
@@ -235,7 +235,15 @@ public:
 	byte getPlayId() const override;
 	int getPolyphony() const override { return 3; }
 	bool hasRhythmChannel() const override { return false; }
-	void setVolume(byte volume) override { static_cast<MidiDriver_PCJr *>(_driver)->_global_volume = volume; }
+
+	void setVolume(byte volume) override {
+		byte volTable[16] = {
+			0, 5, 6, 8, 10, 12, 15, 20,
+			25, 31, 40, 50, 64, 80, 100, 127
+		};
+
+		static_cast<MidiDriver_PCJr *>(_driver)->_global_volume = volTable[CLIP<byte>(volume, 0, 15)];
+	}
 };
 
 byte MidiPlayer_PCJr::getPlayId() const {


### PR DESCRIPTION
It was pointed out in bug #15208 that the PCjr music for SCI games is played at very low volume. On investigation, it seems like the other audio drivers expect the volume to be in the 0-15 range, but the PCjr one has 100 as default, so it probably uses 0-127.

I'm basing the volume table on https://www.smspower.org/Development/SN76489 and its statement that the volume is attenuated "by 2dB for each step in the volume register". But is that the right way to do it? This will have to be one of those "I don't know if I'm doing it right, but the current behavior is clearly wrong" kind of pull requests...