### PR TITLE
JANITORIAL: IMMORTAL: Fix typos in comments *and one file name*

### DIFF
--- a/engines/immortal/compression.cpp
+++ b/engines/immortal/compression.cpp
@@ -23,7 +23,7 @@
 
 /* Decompression:
  * This decompression algorithm follows the source assembly very closely,
- * which is itself a modification to LZW (a derivitive of LZ78).
+ * which is itself a modification to LZW (a derivative of LZ78).
  * In: Source data as File, size of data
  * Out: Pointer to uncompressed data as SeekableReadStream
  */

--- a/engines/immortal/cycle.cpp
+++ b/engines/immortal/cycle.cpp
@@ -78,7 +78,7 @@ bool Room::cycleAdvance(int c) {
 }
 
 int Room::cycleGetFrame(int c) {
-	/* The source version of this is facinating. It is basically:
+	/* The source version of this is fascinating. It is basically:
 	 * in: cycList, Index
 	 * index -> tmp
 	 * Load the value of cycPtrs + cycList (returns address of start of cyc)

--- a/engines/immortal/immortal.h
+++ b/engines/immortal/immortal.h
@@ -22,14 +22,14 @@
 #ifndef IMMORTAL_H
 #define IMMORTAL_H
 
-// Audio is only handled in kernal, therefore it is only needed here
+// Audio is only handled in kernel, therefore it is only needed here
 #include "audio/mixer.h"
 
 // Immortal.h is the engine, so it needs the engine headers
 #include "engines/engine.h"
 #include "engines/savestate.h"
 
-// Theorectically, all graphics should be handled through driver, which is part of kernal, which is in immortal.h
+// Theorectically, all graphics should be handled through driver, which is part of kernel, which is in immortal.h
 #include "graphics/screen.h"
 #include "graphics/surface.h"
 
@@ -56,7 +56,7 @@
 
 namespace Immortal {
 
-// Needed by kernal for input
+// Needed by kernel for input
 enum InputAction {
 	kActionNothing,
 	kActionKey,
@@ -79,13 +79,13 @@ enum InputDirection {
 	kDirectionRight
 };
 
-// Needed by kernal for text
+// Needed by kernel for text
 enum FadeType {
 	kTextFadeIn,
 	kTextDontFadeIn
 };
 
-// Needed by kernal for music
+// Needed by kernel for music
 enum Song {
 	kSongNothing,
 	kSongMaze,
@@ -343,7 +343,7 @@ public:
 	int _roomCellX       = 0;
 	int _roomCellY       = 0;
 	Room *_rooms[kMaxRooms];                            // Rooms within the level
-	Common::Array<SFlame> _allFlames[kMaxRooms];        // The level needs it's own set of flames so that the flames can be turned on/off permenantly. This is technically more like a hashmap in the source, but it could also be seen as a 2d array, just hashed together in the source
+	Common::Array<SFlame> _allFlames[kMaxRooms];        // The level needs it's own set of flames so that the flames can be turned on/off permanently. This is technically more like a hashmap in the source, but it could also be seen as a 2d array, just hashed together in the source
 
 	// Door members
 	Common::Array<Door> _doors;
@@ -454,7 +454,7 @@ public:
 	 */
 
 	/*
-	 * [Kernal.cpp] Functions from Kernal.gs and Driver.gs
+	 * [Kernel.cpp] Functions from Kernel.gs and Driver.gs
 	 */
 
 	// Screen
@@ -523,7 +523,7 @@ public:
 	void makeBlisters(int povX, int povY);              // Turns the unmodified CNM/CBM/LCNM etc into the modified ones to actually be used for drawing the game
 	void loadFont();                                    // Gets the font.spr file, and centers the sprite
 	void clearSprites();                                // Clears all sprites before drawing the current frame
-	void loadSprites();                                 // Loads all the sprite files and centers their sprites (in spritelist, but called from kernal)
+	void loadSprites();                                 // Loads all the sprite files and centers their sprites (in spritelist, but called from kernel)
 
 	// Input
 	void userIO();                                      // Get input

--- a/engines/immortal/kernal.cpp
+++ b/engines/immortal/kernal.cpp
@@ -19,10 +19,10 @@
  *
  */
 
-/* This file covers both Kernal.GS and Driver.GS.
+/* This file covers both Kernel.GS and Driver.GS.
  * This is because most of Driver.GS is hardware specific,
  * and what is not (the slightly abstracted aspects), is
- * directly connected to kernal, and might as well be
+ * directly connected to kernel, and might as well be
  * considered part of the same process.
  */
 
@@ -440,7 +440,7 @@ void ImmortalEngine::printChr(char c) {
 		_penX -= 2;
 	}
 
-	// If the letter was a captial T, the next letter should be a little closer
+	// If the letter was a capital T, the next letter should be a little closer
 	if (c == 'T') {
 		_penX -= 2;
 	}
@@ -592,7 +592,7 @@ void ImmortalEngine::loadSprites() {
 	 * ie. file_pointer[file_index]+((sprite_num<<3)+4) = center_x.
 	 * We aren't going to have the sprite properties inside the file data, so instead
 	 * we have an array of all game sprites _dataSprites which is indexed
-	 * soley by a sprite number now. This also means that a sprite itself has a reference to
+	 * solely by a sprite number now. This also means that a sprite itself has a reference to
 	 * a datasprite, instead of the sprite index and separately the file pointer. Datasprite
 	 * is what needs the file, so that's where the pointer is. The index isn't used by
 	 * the sprite or datasprite themselves, so it isn't a member of either of them.
@@ -975,7 +975,7 @@ void ImmortalEngine::waitKey() {
 	}
 }
 
-// This was originally in Motives, which is weird since it seems more like an engine level function, so it's in kernal now
+// This was originally in Motives, which is weird since it seems more like an engine level function, so it's in kernel now
 void ImmortalEngine::waitClick() {
 	bool wait = true;
 	while (wait == true) {

--- a/engines/immortal/module.mk
+++ b/engines/immortal/module.mk
@@ -8,7 +8,7 @@ MODULE_OBJS = \
 	drawChr.o \
 	flameSet.o \
 	immortal.o \
-	kernal.o \
+	kernel.o \
 	level.o \
 	logic.o \
 	metaengine.o \

--- a/engines/immortal/module.mk
+++ b/engines/immortal/module.mk
@@ -8,7 +8,7 @@ MODULE_OBJS = \
 	drawChr.o \
 	flameSet.o \
 	immortal.o \
-	kernel.o \
+	kernal.o \
 	level.o \
 	logic.o \
 	metaengine.o \

--- a/engines/immortal/room.h
+++ b/engines/immortal/room.h
@@ -174,7 +174,7 @@ public:
 	bool cycleAdvance(int c);
 	CycID getCycList(int c);
 
-	/* Unneccessary cycle functions
+	/* Unnecessary cycle functions
 	void cycleInit();
 	void cycleFree();
 	void cycleGetNumFrames();
@@ -184,7 +184,7 @@ public:
 	 * [flameSet.cpp] Functions from flameSet.GS
 	 */
 
-	//void flameNew() does not need to exist, because we create the duplicate SFlame in Level, and the array in immortal.h is not accessable from here
+	//void flameNew() does not need to exist, because we create the duplicate SFlame in Level, and the array in immortal.h is not accessible from here
 	void flameInit();
 	void flameDrawAll(uint16 vX, uint16 vY);
 	bool roomLighted();

--- a/engines/immortal/sprite_list.h
+++ b/engines/immortal/sprite_list.h
@@ -24,7 +24,7 @@
 
 namespace Immortal {
 
-// We need a few two-dimentional vectors, and writing them out in full each time is tedious
+// We need a few two-dimensional vectors, and writing them out in full each time is tedious
 template<class T> using CArray2D = Common::Array<Common::Array<T>>;
 
 struct Image {


### PR DESCRIPTION
If this is accepted, someone has to rename
*kernal.cpp* to *kernel.cpp*
otherwise this PR will always fail.

I have no idea how to do that from the web interface or without stomping the change history of that file.

Thank you and sorry for the additional workl