### PR TITLE
SCI: fix  bug no. 15336

### DIFF
--- a/engines/sci/sound/music.cpp
+++ b/engines/sci/sound/music.cpp
@@ -324,8 +324,11 @@ void SciMusic::resetGlobalPauseCounter() {
 	// do anything unpleasant afterwards, either). So this is not
 	// needed there.
 	// I have added an assert, since it is such a special case,
-	// people need to know what they're doing if they call this...
-	assert(_globalPause == 1);
+	// people need to know what they're doing if they call this.
+	// The value can be greater than 1, since the scripts may
+	// already have increased it, before the kRestoreGame() call
+	// happens.
+	assert(_globalPause >= 1);
 	_globalPause = 0;
 }
 


### PR DESCRIPTION
Since I am the one who added the assert that gets triggered here, I have now prepared a fix.

The assumtion that the global pause would always have to be 1 here, is wrong. It can have higher values due to kDoSoundPause() calls from the scripts.