### PR TITLE
SCUMM: V0/V1 - Workaround for original blocker bug in V0/V1 Zak that prevented Annie from picking up the crystal shard from the statue in Mexico.

### DIFF
--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -49,7 +49,16 @@ void ScummEngine::runScript(int script, bool freezeResistant, bool recursive, in
 	if (enhancementEnabled(kEnhGameBreakingBugFixes) && _game.id == GID_MANIAC &&
 		_game.version == 0 && (_game.features & GF_DEMO) && script == 43)
 		return;
-
+    
+    // WORKAROUND for bug in v0/v1 Zak McKracken:
+    // Picking up the yellow shard in the Mexican Temple while playing as Annie was not possible.
+    // This was fixed in v2.
+    if (enhancementEnabled(kEnhGameBreakingBugFixes) && _game.id == GID_ZAK &&
+        _game.version < 2 && script == 119 && VAR(VAR_EGO) == 2) {
+        addObjectToInventory(56, 14);
+        putOwner(56, VAR(VAR_EGO));
+    }
+    
  	if (!script)
 		return;
 


### PR DESCRIPTION
During a recent livestream with David Fox and Matthew Kane, a bug was discovered in Zak McKracken, it appears to be an original game bug and not a ScummVM issue.

The issue can be seen to occur here, https://youtu.be/HJ5CpEy4sio?t=5473 
Note, Annie has a crystal shard in her inventory and when trying to pick up the shard from the statue, the inventory still only has one shard.

If the player took Annie to the Mexican temple and tried to pick up the yellow crystal shard from the statue, the object was not added to the inventory.

I took a look at the V1 and V2 scripts in descumm, it looks like V2 fixes this issue by moving a pickupObject call outside of a check for the current actor.

Script 119 is the script in question, it does a check against the current actor and in V1 it only runs pickupObject() if we aren't actor 2(Annie)

V2 fixes this by moving the pickupObject() call outside of the actor check.

See the following descumm output, with v1 on the left and v2 on the right:
<img width="1833" alt="Screenshot 2024-08-27 at 15 21 48" src="https://github.com/user-attachments/assets/4a94121c-455a-4124-aceb-8e173b78836d">
