### PR TITLE
SCI: fix global pause counters when using original save/load dialogs (follow up to PR 6074)

### DIFF
--- a/engines/sci/engine/kfile.cpp
+++ b/engines/sci/engine/kfile.cpp
@@ -1286,6 +1286,8 @@ reg_t kRestoreGame(EngineState *s, int argc, reg_t *argv) {
 			g_sci->_soundCmd->pauseAll(false); // unpause music
 		else
 			g_sci->_soundCmd->resetGlobalPauseCounter(); // reset music global pause counter without affecting the individual sounds
+	} else if (s->r_acc.isNull() && g_sci->_soundCmd->isGlobalPauseActive()) {
+		g_sci->_soundCmd->resetGlobalPauseCounter(); // reset music global pause counter without affecting the individual sounds
 	}
 
 	return s->r_acc;


### PR DESCRIPTION
I would have added this to PR 6074, since it is part of the bug fix, but that one has already been merged.

In the bug no. 15336 scenario the global pause counter will be increased by 4 before the save/load dialog is shown. If we don't reset it it will still have that value after loading the savegame. Currently, we reset it only for the ScummVM dialogs but not for the original ones.