### PR TITLE
GOB: Fix missing background tracks in Gobliiins 1

### DIFF
--- a/engines/gob/sound/sound.cpp
+++ b/engines/gob/sound/sound.cpp
@@ -55,7 +55,9 @@ Sound::Sound(GobEngine *vm) : _vm(vm) {
 	_cdrom = nullptr;
 	_bgatmos = nullptr;
 
-	_hasAdLibBg = _hasAdLib = (!_vm->_noMusic && _vm->hasAdLib());
+	_hasAdLib = (!_vm->_noMusic && _vm->hasAdLib());
+
+	_hasAdLibBg = _hasAdLib;
 
 	if (!_vm->_noMusic && (_vm->getPlatform() == Common::kPlatformAmiga)) {
 		_infogrames = new Infogrames(*_vm->_mixer);

--- a/engines/gob/sound/sound.cpp
+++ b/engines/gob/sound/sound.cpp
@@ -55,9 +55,7 @@ Sound::Sound(GobEngine *vm) : _vm(vm) {
 	_cdrom = nullptr;
 	_bgatmos = nullptr;
 
-	_hasAdLib = (!_vm->_noMusic && _vm->hasAdLib());
-
-	_hasAdLibBg = _hasAdLib;
+	_hasAdLibBg = _hasAdLib = (!_vm->_noMusic && _vm->hasAdLib());
 
 	if (!_vm->_noMusic && (_vm->getPlatform() == Common::kPlatformAmiga)) {
 		_infogrames = new Infogrames(*_vm->_mixer);
@@ -337,7 +335,7 @@ void Sound::adlibPlayTrack(const char *trackname) {
 }
 
 void Sound::adlibPlayBgMusic() {
-	if (!_hasAdLib || _hasAdLibBg)
+	if (!_hasAdLib || !_hasAdLibBg) // If one of those is disabled, then stop there 
 		return;
 
 	createADLPlayer();

--- a/engines/gob/sound/sound.h
+++ b/engines/gob/sound/sound.h
@@ -154,8 +154,8 @@ public:
 private:
 	GobEngine *_vm;
 
-	bool _hasAdLib   = false;
-	bool _hasAdLibBg = false;
+	bool _hasAdLib;
+	bool _hasAdLibBg;
 
 	SoundDesc _sounds[kSoundsCount];
 

--- a/engines/gob/sound/sound.h
+++ b/engines/gob/sound/sound.h
@@ -154,8 +154,8 @@ public:
 private:
 	GobEngine *_vm;
 
-	bool _hasAdLib;
-	bool _hasAdLibBg;
+	bool _hasAdLib   = false;
+	bool _hasAdLibBg = false;
 
 	SoundDesc _sounds[kSoundsCount];
 


### PR DESCRIPTION
We found that some tracks where not played in Gobliiins 1, in the 
Windows version.
After a quick check we noticed that the boolean flag was always false, 
and the code was never executed to play a background track.