### PR TITLE
GOB: Fix DOS EGA game detection following #5868 merge

### DIFF
--- a/engines/gob/detection/tables_gob1.h
+++ b/engines/gob/detection/tables_gob1.h
@@ -608,8 +608,7 @@
 	{
 		"gob1",
 		"",
-		AD_ENTRY2s("intro.stk", "c65e9cc8ba23a38456242e1f2b1caad4", 135561,
-		           "disk1.stk", "6797b5dbdace1518ecf93dc0414970d8", 367110),
+		AD_ENTRY1s("intro.stk", "c65e9cc8ba23a38456242e1f2b1caad4", 135561),
 		UNK_LANG,
 		kPlatformAmiga,
 		ADGF_NO_FLAGS,


### PR DESCRIPTION
This avoids Amiga version being picked over DOS EGA one. They now have the same number of files so the user is prompted which version it owns.

PR #5868 was not fixed as requested before the merge.