### PR TITLE
GRAPHICS: AGS: Fix ODR problems in AGS and add Clang support

### DIFF
--- a/configure
+++ b/configure
@@ -7122,10 +7122,6 @@ case $_host_cpu in
 		if test "$_ext_neon" = auto ; then
 			_ext_neon=no
 		fi
-		if test "$_ext_neon" = yes ; then
-			# -mfpu=neon doesn't work with aarch64 but neon is available
-			add_line_to_config_mk 'NEON_CXXFLAGS = -mfpu=neon'
-		fi
 		_ext_sse2=no
 		_ext_avx2=no
 		;;

--- a/configure
+++ b/configure
@@ -2282,6 +2282,9 @@ if test "$have_gcc" = yes; then
 		cxx_version="`echo "${cxx_version}" | sed -e 's/"\([^ ]*\) .*/\1/'`"
 		cxx_version="clang $cxx_version, ok"
 
+		_clang_major=`gcc_get_define __clang_major__`
+		_clang_minor=`gcc_get_define __clang_minor__`
+
 		append_var CXXFLAGS "-Wshadow"
 	else
 		cxx_version="GCC $cxx_version, ok"
@@ -7132,7 +7135,35 @@ case $_host_cpu in
 		;;
 esac
 
-if test "$have_gcc" = yes; then
+if test "$have_clang" = yes; then
+	# Clang has variable support to target gating of intrinsics
+	case $_host_cpu in
+	i[3-6]86)
+		# SSE2 and AVX2 has been target gated since LLVM 5.0
+		if (test $_clang_major -lt 5) || (test $_clang_major -eq 5 && test $_clang_minor -lt 0); then
+			_ext_sse2=no
+			_ext_avx2=no
+		fi
+		;;
+	arm*)
+		# NEON has been target gated since LLVM 19.1
+		if (test $_clang_major -lt 19) || (test $_clang_major -eq 19 && test $_clang_minor -lt 1); then
+			# But several platforms enables it globally...
+			if ! echo "$CXXFLAGS" | grep -q -e -mfpu=neon; then
+				_ext_neon=no
+			fi
+		fi
+		;;
+	x86_64 | amd64)
+		# AVX2 has been target gated since LLVM 5.0
+		# x86_64 always supports SSE2, no need of gating
+		if (test $_clang_major -lt 5) || (test $_clang_major -eq 5 && test $_clang_minor -lt 0); then
+			_ext_avx2=no
+		fi
+		;;
+	# aarch64 always supports NEON, no need of gating
+	esac
+elif test "$have_gcc" = yes; then
 	# Need 4.9 for pragma target
 	if (test $_cxx_major -lt 4) || (test $_cxx_major -eq 4 && test $_cxx_minor -lt 9); then
 		_ext_sse2=no

--- a/configure
+++ b/configure
@@ -7104,6 +7104,12 @@ case $_host_cpu in
 			_ext_avx2=yes
 		fi
 		_ext_neon=no
+		# SSE2 is always available on x86_64
+		if !(test "$have_clang" = yes && (test $_clang_major -gt 5) || (test $_clang_major -eq 5 && test $_clang_minor -gt 0)) &&
+		   !(test "$have_gcc" = yes && (test $_cxx_major -gt 4) || (test $_cxx_major -eq 4 && test $_cxx_minor -gt 9)); then
+			# Need GCC 4.9+ or Clang 5.0+ for target pragma
+			_ext_avx2=no
+		fi
 		;;
 	i[3-6]86)
 		if test "$_ext_sse2" = auto ; then
@@ -7113,6 +7119,12 @@ case $_host_cpu in
 			_ext_avx2=no
 		fi
 		_ext_neon=no
+		if !(test "$have_clang" = yes && (test $_clang_major -gt 5) || (test $_clang_major -eq 5 && test $_clang_minor -gt 0)) &&
+		   !(test "$have_gcc" = yes && (test $_cxx_major -gt 4) || (test $_cxx_major -eq 4 && test $_cxx_minor -gt 9)); then
+			# Need GCC 4.9+ or Clang 5.0+ for target pragma
+			_ext_sse2=no
+			_ext_avx2=no
+		fi
 		;;
 	aarch64)
 		if test "$_ext_neon" = auto ; then
@@ -7120,6 +7132,7 @@ case $_host_cpu in
 		fi
 		_ext_sse2=no
 		_ext_avx2=no
+		# On aarch64 neon is always available and doesn't need a target pragma
 		;;
 	arm*)
 		if test "$_ext_neon" = auto ; then
@@ -7127,6 +7140,11 @@ case $_host_cpu in
 		fi
 		_ext_sse2=no
 		_ext_avx2=no
+		if !(test "$have_clang" = yes && (test $_clang_major -gt 19) || (test $_clang_major -eq 19 && test $_clang_minor -gt 1)) &&
+		   !(test "$have_gcc" = yes && (test $_cxx_major -gt 4) || (test $_cxx_major -eq 4 && test $_cxx_minor -gt 9)); then
+			# Need GCC 4.9+ or Clang 19.1+ for target pragma
+			_ext_neon=no
+		fi
 		;;
 	*)
 		_ext_sse2=no
@@ -7134,43 +7152,6 @@ case $_host_cpu in
 		_ext_neon=no
 		;;
 esac
-
-if test "$have_clang" = yes; then
-	# Clang has variable support to target gating of intrinsics
-	case $_host_cpu in
-	i[3-6]86)
-		# SSE2 and AVX2 has been target gated since LLVM 5.0
-		if (test $_clang_major -lt 5) || (test $_clang_major -eq 5 && test $_clang_minor -lt 0); then
-			_ext_sse2=no
-			_ext_avx2=no
-		fi
-		;;
-	arm*)
-		# NEON has been target gated since LLVM 19.1
-		if (test $_clang_major -lt 19) || (test $_clang_major -eq 19 && test $_clang_minor -lt 1); then
-			# But several platforms enables it globally...
-			if ! echo "$CXXFLAGS" | grep -q -e -mfpu=neon; then
-				_ext_neon=no
-			fi
-		fi
-		;;
-	x86_64 | amd64)
-		# AVX2 has been target gated since LLVM 5.0
-		# x86_64 always supports SSE2, no need of gating
-		if (test $_clang_major -lt 5) || (test $_clang_major -eq 5 && test $_clang_minor -lt 0); then
-			_ext_avx2=no
-		fi
-		;;
-	# aarch64 always supports NEON, no need of gating
-	esac
-elif test "$have_gcc" = yes; then
-	# Need 4.9 for pragma target
-	if (test $_cxx_major -lt 4) || (test $_cxx_major -eq 4 && test $_cxx_minor -lt 9); then
-		_ext_sse2=no
-		_ext_avx2=no
-		_ext_neon=no
-	fi
-fi
 
 define_in_config_if_yes "$_ext_sse2" 'SCUMMVM_SSE2'
 echo_n "Enabling x86/amd64 SSE2... "

--- a/engines/ags/lib/allegro/surface_avx2.cpp
+++ b/engines/ags/lib/allegro/surface_avx2.cpp
@@ -19,7 +19,6 @@
  *
  */
 
-#include <immintrin.h>
 #include "ags/lib/allegro/gfx.h"
 #include "ags/lib/allegro/color.h"
 #include "ags/lib/allegro/flood.h"
@@ -27,6 +26,13 @@
 #include "ags/globals.h"
 #include "common/textconsole.h"
 #include "graphics/screen.h"
+
+#include <immintrin.h>
+
+#ifdef __GNUC__
+#pragma GCC push_options
+#pragma GCC target("avx2")
+#endif
 
 namespace AGS3 {
 
@@ -1003,3 +1009,7 @@ template void BITMAP::drawAVX2<false>(DrawInnerArgs &);
 template void BITMAP::drawAVX2<true>(DrawInnerArgs &);
 
 } // namespace AGS3
+
+#ifdef __GNUC__
+#pragma GCC pop_options
+#endif

--- a/engines/ags/lib/allegro/surface_avx2.cpp
+++ b/engines/ags/lib/allegro/surface_avx2.cpp
@@ -29,7 +29,9 @@
 
 #include <immintrin.h>
 
-#ifdef __GNUC__
+#if defined(__clang__)
+#pragma clang attribute push (__attribute__((target("avx2"))), apply_to=function)
+#elif defined(__GNUC__)
 #pragma GCC push_options
 #pragma GCC target("avx2")
 #endif
@@ -1010,6 +1012,8 @@ template void BITMAP::drawAVX2<true>(DrawInnerArgs &);
 
 } // namespace AGS3
 
-#ifdef __GNUC__
+#if defined(__clang__)
+#pragma clang attribute pop
+#elif defined(__GNUC__)
 #pragma GCC pop_options
 #endif

--- a/engines/ags/lib/allegro/surface_neon.cpp
+++ b/engines/ags/lib/allegro/surface_neon.cpp
@@ -24,13 +24,23 @@
 // Without this ifdef the iOS backend breaks, please do not remove
 #ifdef SCUMMVM_NEON
 
-#include <arm_neon.h>
 #include "ags/globals.h"
 #include "ags/lib/allegro/color.h"
 #include "ags/lib/allegro/flood.h"
 #include "ags/lib/allegro/gfx.h"
 #include "common/textconsole.h"
 #include "graphics/screen.h"
+
+#include <arm_neon.h>
+
+#ifdef __GNUC__
+#pragma GCC push_options
+
+#if !defined(__aarch64__)
+#pragma GCC target("fpu=neon")
+#endif // !defined(__aarch64__)
+
+#endif // __GNUC__
 
 namespace AGS3 {
 
@@ -963,5 +973,9 @@ template void BITMAP::drawNEON<false>(DrawInnerArgs &);
 template void BITMAP::drawNEON<true>(DrawInnerArgs &);
 
 } // namespace AGS3
+
+#ifdef __GNUC__
+#pragma GCC pop_options
+#endif
 
 #endif // SCUMMVM_NEON

--- a/engines/ags/lib/allegro/surface_neon.cpp
+++ b/engines/ags/lib/allegro/surface_neon.cpp
@@ -33,14 +33,16 @@
 
 #include <arm_neon.h>
 
-#ifdef __GNUC__
-#pragma GCC push_options
-
 #if !defined(__aarch64__)
-#pragma GCC target("fpu=neon")
-#endif // !defined(__aarch64__)
 
-#endif // __GNUC__
+#if defined(__clang__)
+#pragma clang attribute push (__attribute__((target("neon"))), apply_to=function)
+#elif defined(__GNUC__)
+#pragma GCC push_options
+#pragma GCC target("fpu=neon")
+#endif
+
+#endif // !defined(__aarch64__)
 
 namespace AGS3 {
 
@@ -974,8 +976,14 @@ template void BITMAP::drawNEON<true>(DrawInnerArgs &);
 
 } // namespace AGS3
 
-#ifdef __GNUC__
+#if !defined(__aarch64__)
+
+#if defined(__clang__)
+#pragma clang attribute pop
+#elif defined(__GNUC__)
 #pragma GCC pop_options
 #endif
+
+#endif // !defined(__aarch64__)
 
 #endif // SCUMMVM_NEON

--- a/engines/ags/lib/allegro/surface_sse2.cpp
+++ b/engines/ags/lib/allegro/surface_sse2.cpp
@@ -19,7 +19,6 @@
  *
  */
 
-#include <emmintrin.h>
 #include "ags/ags.h"
 #include "ags/globals.h"
 #include "ags/lib/allegro/color.h"
@@ -27,6 +26,17 @@
 #include "ags/lib/allegro/gfx.h"
 #include "common/textconsole.h"
 #include "graphics/screen.h"
+
+#include <emmintrin.h>
+
+#ifdef __GNUC__
+#pragma GCC push_options
+
+#ifndef __x86_64__
+#pragma GCC target("sse2")
+#endif
+
+#endif
 
 namespace AGS3 {
 
@@ -990,3 +1000,7 @@ template void BITMAP::drawSSE2<false>(DrawInnerArgs &);
 template void BITMAP::drawSSE2<true>(DrawInnerArgs &);
 
 } // namespace AGS3
+
+#ifdef __GNUC__
+#pragma GCC pop_options
+#endif

--- a/engines/ags/lib/allegro/surface_sse2.cpp
+++ b/engines/ags/lib/allegro/surface_sse2.cpp
@@ -29,14 +29,16 @@
 
 #include <emmintrin.h>
 
-#ifdef __GNUC__
-#pragma GCC push_options
+#if !defined(__x86_64__)
 
-#ifndef __x86_64__
+#if defined(__clang__)
+#pragma clang attribute push (__attribute__((target("sse2"))), apply_to=function)
+#elif defined(__GNUC__)
+#pragma GCC push_options
 #pragma GCC target("sse2")
 #endif
 
-#endif
+#endif // !defined(__x86_64__)
 
 namespace AGS3 {
 
@@ -1001,6 +1003,12 @@ template void BITMAP::drawSSE2<true>(DrawInnerArgs &);
 
 } // namespace AGS3
 
-#ifdef __GNUC__
+#if !defined(__x86_64__)
+
+#if defined(__clang__)
+#pragma clang attribute pop
+#elif defined(__GNUC__)
 #pragma GCC pop_options
 #endif
+
+#endif // !defined(__x86_64__)

--- a/engines/ags/module.mk
+++ b/engines/ags/module.mk
@@ -391,17 +391,14 @@ endif
 ifdef SCUMMVM_NEON
 MODULE_OBJS += \
 	lib/allegro/surface_neon.o
-$(MODULE)/lib/allegro/surface_neon.o: CXXFLAGS += $(NEON_CXXFLAGS)
 endif
 ifdef SCUMMVM_SSE2
 MODULE_OBJS += \
 	lib/allegro/surface_sse2.o
-$(MODULE)/lib/allegro/surface_sse2.o: CXXFLAGS += -msse2
 endif
 ifdef SCUMMVM_AVX2
 MODULE_OBJS += \
 	lib/allegro/surface_avx2.o
-$(MODULE)/lib/allegro/surface_avx2.o: CXXFLAGS += -mavx2 -mavx -msse2
 endif
 
 # This module can be built as a plugin

--- a/graphics/blit/blit-avx2.cpp
+++ b/graphics/blit/blit-avx2.cpp
@@ -26,7 +26,9 @@
 
 #include <immintrin.h>
 
-#ifdef __GNUC__
+#if defined(__clang__)
+#pragma clang attribute push (__attribute__((target("avx2"))), apply_to=function)
+#elif defined(__GNUC__)
 #pragma GCC push_options
 #pragma GCC target("avx2")
 #endif
@@ -307,6 +309,8 @@ void BlendBlit::blitAVX2(Args &args, const TSpriteBlendMode &blendMode, const Al
 
 } // End of namespace Graphics
 
-#ifdef __GNUC__
+#if defined(__clang__)
+#pragma clang attribute pop
+#elif defined(__GNUC__)
 #pragma GCC pop_options
 #endif

--- a/graphics/blit/blit-neon.cpp
+++ b/graphics/blit/blit-neon.cpp
@@ -28,14 +28,16 @@
 
 #include <arm_neon.h>
 
-#ifdef __GNUC__
-#pragma GCC push_options
-
 #if !defined(__aarch64__)
-#pragma GCC target("fpu=neon")
-#endif // !defined(__aarch64__)
 
-#endif // __GNUC__
+#if defined(__clang__)
+#pragma clang attribute push (__attribute__((target("neon"))), apply_to=function)
+#elif defined(__GNUC__)
+#pragma GCC push_options
+#pragma GCC target("fpu=neon")
+#endif
+
+#endif // !defined(__aarch64__)
 
 namespace Graphics {
 
@@ -310,8 +312,14 @@ void BlendBlit::blitNEON(Args &args, const TSpriteBlendMode &blendMode, const Al
 
 } // end of namespace Graphics
 
-#ifdef __GNUC__
+#if !defined(__aarch64__)
+
+#if defined(__clang__)
+#pragma clang attribute pop
+#elif defined(__GNUC__)
 #pragma GCC pop_options
 #endif
+
+#endif // !defined(__aarch64__)
 
 #endif // SCUMMVM_NEON

--- a/graphics/blit/blit-sse2.cpp
+++ b/graphics/blit/blit-sse2.cpp
@@ -26,15 +26,16 @@
 
 #include <emmintrin.h>
 
-#ifdef __GNUC__
-#pragma GCC push_options
+#if !defined(__x86_64__)
 
-#ifndef __x86_64__
+#if defined(__clang__)
+#pragma clang attribute push (__attribute__((target("sse2"))), apply_to=function)
+#elif defined(__GNUC__)
+#pragma GCC push_options
 #pragma GCC target("sse2")
 #endif
 
-#endif
-
+#endif // !defined(__x86_64__)
 
 namespace Graphics {
 
@@ -313,7 +314,12 @@ void BlendBlit::blitSSE2(Args &args, const TSpriteBlendMode &blendMode, const Al
 
 } // End of namespace Graphics
 
-#ifdef __GNUC__
+#if !defined(__x86_64__)
+
+#if defined(__clang__)
+#pragma clang attribute pop
+#elif defined(__GNUC__)
 #pragma GCC pop_options
 #endif
 
+#endif // !defined(__x86_64__)


### PR DESCRIPTION
This PR fixes leftovers following the PR #5581 where AGS code was not touched to apply the same recipe.
Then, the support for Clang is added with proper version checks.
Finally the checks for GCC and Clang version are relaxed for architecture which do not need such checks (ARMv8 for NEON and x86_64 for SSE2).

This is not perfect as old Android ARM cannot benefit from the SIMD code but it allows to widen the support to Android ARM64 and all MacOS platforms at least.