### PR TITLE
SCUMM: MM - Update list of valid targets for demo checkbox.

### DIFF
--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -817,8 +817,9 @@ const ExtraGuiOptions ScummMetaEngine::getExtraGuiOptions(const Common::String &
 #endif
 	}
     if (target.empty() || gameid == "maniac") {
-		// The kiosk demo is only available on Maniac v1
-		bool isValidTarget = !extra.contains("Demo") && extra.contains("V1");
+		// The kiosk demo script is in V1/V2 DOS, V2 Atari ST and V2 Amiga.
+        bool isValidTarget = !extra.contains("Demo") && (platform == Common::kPlatformDOS ||                                                                                        platform == Common::kPlatformAmiga  || platform == Common::kPlatformAtariST);
+
 		if (isValidTarget)
 			options.push_back(mmDemoObjectLabelsOption);
     }

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -246,7 +246,7 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 		_debugMode = true;
 
 	_copyProtection = ConfMan.getBool("copy_protection");
-	if (ConfMan.getBool("demo_mode"))
+    if (ConfMan.getBool("demo_mode") || ConfMan.getBool("enable_demo_mode"))
 		_game.features |= GF_DEMO;
 	if (ConfMan.hasKey("nosubtitles")) {
 		// We replaced nosubtitles *ages* ago. Just convert it silently


### PR DESCRIPTION
I checked the scripts for each version of MM and found that it was possible to run the demo/kiosk script in:
V1/V2 DOS
Amiga
Atari ST.

Now doing a platform check for these to mark them as valid targets.