### PR TITLE
MTROPOLIS: create string union member by constructor

### DIFF
--- a/engines/mtropolis/plugin/standard.cpp
+++ b/engines/mtropolis/plugin/standard.cpp
@@ -337,7 +337,7 @@ bool MediaCueMessengerModifier::load(const PlugInModifierLoaderContext &context,
 		break;
 	case Data::PlugInTypeTaggedValue::kString:
 		_cueSourceType = kCueSourceString;
-		_cueSource.asString = data.executeAt.value.asString;
+		_cueSource.construct<Common::String, &CueSourceUnion::asString>(data.executeAt.value.asString);
 		break;
 	default:
 		return false;


### PR DESCRIPTION
Copy-assignment is called on a string which is a union member, whose constructor was never called. The assignment call leads to an underflow in the reference counting within of the string.
To resolve this, copy-construction is used.

Affects Star Trek: The Game Show (Retail).