### PR TITLE
MTROPOLIS: iterate over childen in default shared scene search

### DIFF
--- a/engines/mtropolis/hacks.cpp
+++ b/engines/mtropolis/hacks.cpp
@@ -46,6 +46,7 @@ Hacks::Hacks() {
 	mtiSceneReturnHack = false;
 	mtiHispaniolaDamagedStringHack = false;
 	ignoreSceneUnloads = false;
+	alternativeDefaultSharedSceneSearch = false;
 }
 
 Hacks::~Hacks() {
@@ -1136,6 +1137,11 @@ void addMTIQuirks(const MTropolisGameDescription &desc, Hacks &hacks) {
 
 	hacks.defaultStructuralHooks.reset(new MTIStructuralHooks(molassesHandler));
 	hacks.addSceneTransitionHooks(Common::SharedPtr<SceneTransitionHooks>(new MTIMolassesSceneTransitionHooks(molassesHandler)));
+}
+
+void addTDTWBQuirks(const MTropolisGameDescription &desc, Hacks &hacks) {
+	//The default code path would cause a nullptr segfault
+	hacks.alternativeDefaultSharedSceneSearch = true;
 }
 
 } // End of namespace HackSuites

--- a/engines/mtropolis/hacks.cpp
+++ b/engines/mtropolis/hacks.cpp
@@ -1140,7 +1140,7 @@ void addMTIQuirks(const MTropolisGameDescription &desc, Hacks &hacks) {
 }
 
 void addTDTWBQuirks(const MTropolisGameDescription &desc, Hacks &hacks) {
-	//The default code path would cause a nullptr segfault
+	// The default code path would cause a nullptr segfault
 	hacks.alternativeDefaultSharedSceneSearch = true;
 }
 

--- a/engines/mtropolis/hacks.h
+++ b/engines/mtropolis/hacks.h
@@ -56,6 +56,8 @@ struct Hacks {
 	bool mtiSceneReturnHack;
 	bool mtiHispaniolaDamagedStringHack;
 
+	bool alternativeDefaultSharedSceneSearch;
+
 	bool ignoreSceneUnloads;
 
 	uint midiVolumeScale;	// 256 = 1.0
@@ -83,6 +85,8 @@ void addObsidianSaveMechanism(const MTropolisGameDescription &desc, Hacks &hacks
 void addObsidianImprovedWidescreen(const MTropolisGameDescription &desc, Hacks &hacks);
 
 void addMTIQuirks(const MTropolisGameDescription &desc, Hacks &hacks);
+
+void addTDTWBQuirks(const MTropolisGameDescription &desc, Hacks &hacks);
 
 } // End of namespace HackSuites
 

--- a/engines/mtropolis/mtropolis.cpp
+++ b/engines/mtropolis/mtropolis.cpp
@@ -332,6 +332,8 @@ Common::Error MTropolisEngine::run() {
 		Palette pal;
 		pal.initDefaultPalette(2);
 		_runtime->setGlobalPalette(pal);
+	} else if (_gameDescription->gameID == GID_WORLDBROKE) {
+		HackSuites::addTDTWBQuirks(*_gameDescription, _runtime->getHacks());
 	}
 
 

--- a/engines/mtropolis/runtime.cpp
+++ b/engines/mtropolis/runtime.cpp
@@ -5127,14 +5127,22 @@ Common::SharedPtr<Structural> Runtime::findDefaultSharedSceneForScene(Structural
 	Structural *subsection = scene->getParent();
 
 	const Common::Array<Common::SharedPtr<Structural> > &children = subsection->getChildren();
-	if (children.size() == 0)
-		return Common::SharedPtr<Structural>();
+	if (getHacks().alternativeDefaultSharedSceneSearch) {
+		// This code path is for The Day The World Broke
+		// to bypass a nullptr segfault that would occur otherwise.
+		// But seemingly this path does no harm in other titles.
 
-	if (children[0].get() == scene) {
-		// This case occurs in The Day The World Broke
-		if (children.size() > 1)
-			return children[1];
-		else
+		if (children.size() == 0)
+			return Common::SharedPtr<Structural>();
+
+		if (children[0].get() == scene) {
+			if (children.size() > 1)
+				return children[1];
+			else
+				return Common::SharedPtr<Structural>();
+		}
+	} else {
+		if (children.size() == 0 || children[0].get() == scene)
 			return Common::SharedPtr<Structural>();
 	}
 

--- a/engines/mtropolis/runtime.cpp
+++ b/engines/mtropolis/runtime.cpp
@@ -5127,8 +5127,16 @@ Common::SharedPtr<Structural> Runtime::findDefaultSharedSceneForScene(Structural
 	Structural *subsection = scene->getParent();
 
 	const Common::Array<Common::SharedPtr<Structural> > &children = subsection->getChildren();
-	if (children.size() == 0 || children[0].get() == scene)
+	if (children.size() == 0)
 		return Common::SharedPtr<Structural>();
+
+	if (children[0].get() == scene) {
+		// This case occurs in The Day The World Broke
+		if (children.size() > 1)
+			return children[1];
+		else
+			return Common::SharedPtr<Structural>();
+	}
 
 	return children[0];
 }

--- a/engines/mtropolis/runtime.h
+++ b/engines/mtropolis/runtime.h
@@ -1833,7 +1833,7 @@ private:
 		Common::Rect absRect;
 	};
 
-	static Common::SharedPtr<Structural> findDefaultSharedSceneForScene(Structural *scene);
+	Common::SharedPtr<Structural> findDefaultSharedSceneForScene(Structural *scene);
 	void executeTeardown(const Teardown &teardown);
 	void executeLowLevelSceneStateTransition(const LowLevelSceneStateTransitionAction &transitionAction);
 	void executeHighLevelSceneReturn();


### PR DESCRIPTION
Return the second child instead of ``nullptr`` in case the first child is to be rejected.
Otherwise the returned ``nullptr`` would cause a segfault later. This happens in The Day The World Broke.

Stacktrace for the segfault:
```
scummvm.exe!Common::WeakPtr<MTropolis::RuntimeObject>::reset<MTropolis::RuntimeObject>(const Common::WeakPtr<MTropolis::RuntimeObject> & r) Line 536
scummvm.exe!Common::WeakPtr<MTropolis::RuntimeObject>::operator=(const Common::WeakPtr<MTropolis::RuntimeObject> & r) Line 487
scummvm.exe!MTropolis::MessageDispatch::MessageDispatch(const Common::SharedPtr<MTropolis::MessageProperties> & msgProps, MTropolis::Structural * root, bool cascade, bool relay, bool couldBeCommand) Line 4170
scummvm.exe!MTropolis::Runtime::queueEventAsLowLevelSceneStateTransitionAction(const MTropolis::Event & evt, MTropolis::Structural * root, bool cascade, bool relay) Line 5833
scummvm.exe!MTropolis::Runtime::executeHighLevelSceneTransition(const MTropolis::HighLevelSceneTransition & transition) Line 5588
scummvm.exe!MTropolis::Runtime::runFrame() Line 4870
scummvm.exe!MTropolis::MTropolisEngine::run() Line 341
scummvm.exe!runGame(const Plugin * enginePlugin, OSystem & system, const DetectedGame & game, const void * meDescriptor) Line 311
scummvm.exe!scummvm_main(int argc, const char * const * argv) Line 796
scummvm.exe!SDL_main(int argc, char * * argv) Line 75
scummvm.exe!WinMain(HINSTANCE__ * __formal, HINSTANCE__ * __formal, char * __formal, int __formal) Line 56
```
Here the problematic call to ``findDefaultSharedSceneForScene`` occurs earlier in ``executeHighLevelSceneTransition``.