### PR TITLE
MYST3: Fix autosave thumbnail displaying incorrect game state

### DIFF
--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -1577,12 +1577,12 @@ Common::Error Myst3Engine::saveGameState(int slot, const Common::String &desc, b
 		return Common::Error(Common::kCreatingFileFailed, _("Invalid file name for saving"));
 	}
 
-	// Try to use an already generated thumbnail
-	const Graphics::Surface *thumbnail = _menu->borrowSaveThumbnail();
-	if (!thumbnail) {
+	// If autosaving, get a fresh thumbnail of the game screen
+	if (isAutosave && !_menu->isOpen()) {
 		_menu->generateSaveThumbnail();
 	}
-	thumbnail = _menu->borrowSaveThumbnail();
+	// Use the currently generated thumbnail
+	const Graphics::Surface *thumbnail = _menu->borrowSaveThumbnail();
 	assert(thumbnail);
 
 	return saveGameState(desc, thumbnail, isAutosave);


### PR DESCRIPTION
When autosaving, an Autosave file is created which often displays a different thumbnail image to the game state saved.

This is a regression from when the engine's tryAutosaving() method was replaced by the global saveAutosaveIfEnabled(), prior to merging ResidualVM with ScummVM.

Currently, a thumbnail of the game screen is generated whenever the user opens a menu, or pauses the game. This  thumbnail is saved to _saveThumbnail, then later copied when writing a save file. Works well for regular saves, but not when autosaving.

In the original tryAutosaving() method, the autosave generated its own thumbnail, immediately before calling saveGameState().

Fixed by modifying saveGameState() to enable an autosave to generate a thumbnail of the current game screen, prior to obtaining it from _saveThumbnail for writing to the Autosave file.

Fixes bug [15296](https://bugs.scummvm.org/ticket/15296).