### PR TITLE
AUDIO: Add support for libmpcdec 1.2.6 and older

### DIFF
--- a/configure
+++ b/configure
@@ -5936,7 +5936,27 @@ if test "$_libmpcdec" != "no"; then
 			return 0;
 		}
 EOF
-		cc_check $LIBMPCDEC_CFLAGS $LIBMPCDEC_LIBS && _libmpcdec=yes
+		if cc_check $LIBMPCDEC_CFLAGS $LIBMPCDEC_LIBS; then
+			_libmpcdec=yes
+		else
+			cat > $TMPC << EOF
+			#include <mpcdec/mpcdec.h>
+			int main(void) {
+				mpc_decoder decoder;
+				mpc_reader reader;
+				mpc_streaminfo info;
+
+				mpc_decoder_setup(&decoder, &reader);
+				mpc_decoder_initialize(&decoder, &info);
+
+				return 0;
+			}
+EOF
+			if cc_check $LIBMPCDEC_CFLAGS $LIBMPCDEC_LIBS; then
+				_libmpcdec=yes
+				add_line_to_config_h '#define USE_MPCDEC_OLD_API'
+			fi
+		fi
 	fi
 
 	if test "$_libmpcdec" = "yes"; then

--- a/configure
+++ b/configure
@@ -5917,12 +5917,7 @@ define_in_config_if_yes "$_libmikmod" "USE_MIKMOD"
 echocheck "libmpcdec"
 
 if test "$_libmpcdec" != "no"; then
-	if test "$_pkg_config" = "yes" && $_pkgconfig --exists libmpcdec; then
-		append_var LIBMPCDEC_LIBS "`$_pkgconfig --libs libmpcdec`"
-		append_var LIBMPCDEC_CFLAGS "`$_pkgconfig --cflags libmpcdec`"
-	else
-		append_var LIBMPCDEC_LIBS "-lmpcdec"
-	fi
+	append_var LIBMPCDEC_LIBS "-lmpcdec"
 
 	if test "$_libmpcdec" = "auto"; then
 		_libmpcdec=no

--- a/configure
+++ b/configure
@@ -1350,6 +1350,11 @@ for ac_option in $@; do
 		A52_CFLAGS="-I$arg/include"
 		A52_LIBS="-L$arg/lib"
 		;;
+	--with-mpcdec-prefix=*)
+		arg=`echo $ac_option | cut -d '=' -f 2`
+		LIBMPCDEC_CFLAGS="-I$arg/include"
+		LIBMPCDEC_LIBS="-L$arg/lib"
+		;;
 	--with-alsa-prefix=*)
 		arg=`echo $ac_option | cut -d '=' -f 2`
 		ALSA_CFLAGS="-I$arg/include"


### PR DESCRIPTION
Currently, only the latest libmpcdec is spported by our code.
This adds support for older versions of the API which are still in used in MacPorts and AmigaOS.

I removed the call to pkg-config because the library has no .pc file and I add the missing support for the `--with-mpcdec-prefix` which was already documented.