### PR TITLE
NDEBUG usage adaptation to RELEASE_BUILD

### DIFF
--- a/common/hashmap.h
+++ b/common/hashmap.h
@@ -451,7 +451,7 @@ template<class Key, class Val, class HashFunc, class EqualFunc>
 void HashMap<Key, Val, HashFunc, EqualFunc>::expandStorage(size_type newCapacity) {
 	assert(newCapacity > _mask + 1);
 
-#ifndef NDEBUG
+#ifndef RELEASE_BUILD
 	const size_type old_size = _size;
 #endif
 	const size_type old_mask = _mask;
@@ -484,9 +484,11 @@ void HashMap<Key, Val, HashFunc, EqualFunc>::expandStorage(size_type newCapacity
 		_size++;
 	}
 
+#ifndef RELEASE_BUILD
 	// Perform a sanity check: Old number of elements should match the new one!
 	// This check will fail if some previous operation corrupted this hashmap.
 	assert(_size == old_size);
+#endif
 
 	delete[] old_storage;
 

--- a/devtools/create_mm/create_xeen/hashmap.h
+++ b/devtools/create_mm/create_xeen/hashmap.h
@@ -407,7 +407,7 @@ template<class Key, class Val, class HashFunc, class EqualFunc>
 void HashMap<Key, Val, HashFunc, EqualFunc>::expandStorage(size_type newCapacity) {
 	assert(newCapacity > _mask+1);
 
-#ifndef NDEBUG
+#ifndef RELEASE_BUILD
 	const size_type old_size = _size;
 #endif
 	const size_type old_mask = _mask;
@@ -440,9 +440,11 @@ void HashMap<Key, Val, HashFunc, EqualFunc>::expandStorage(size_type newCapacity
 		_size++;
 	}
 
+#ifndef RELEASE_BUILD
 	// Perform a sanity check: Old number of elements should match the new one!
 	// This check will fail if some previous operation corrupted this hashmap.
 	assert(_size == old_size);
+#endif
 
 	delete[] old_storage;
 

--- a/devtools/create_titanic/hashmap.h
+++ b/devtools/create_titanic/hashmap.h
@@ -407,7 +407,7 @@ template<class Key, class Val, class HashFunc, class EqualFunc>
 void HashMap<Key, Val, HashFunc, EqualFunc>::expandStorage(size_type newCapacity) {
 	assert(newCapacity > _mask+1);
 
-#ifndef NDEBUG
+#ifndef RELEASE_BUILD
 	const size_type old_size = _size;
 #endif
 	const size_type old_mask = _mask;
@@ -440,9 +440,11 @@ void HashMap<Key, Val, HashFunc, EqualFunc>::expandStorage(size_type newCapacity
 		_size++;
 	}
 
+#ifndef RELEASE_BUILD
 	// Perform a sanity check: Old number of elements should match the new one!
 	// This check will fail if some previous operation corrupted this hashmap.
 	assert(_size == old_size);
+#endif
 
 	delete[] old_storage;
 

--- a/engines/sci/graphics/celobj32.cpp
+++ b/engines/sci/graphics/celobj32.cpp
@@ -105,7 +105,7 @@ void CelObj::deinit() {
 
 template<bool FLIP, typename READER>
 struct SCALER_NoScale {
-#ifndef NDEBUG
+#ifndef RELEASE_BUILD
 	const byte *_rowEdge;
 #endif
 	const byte *_row;
@@ -125,13 +125,13 @@ struct SCALER_NoScale {
 		_row = _reader.getRow(y - _sourceY);
 
 		if (FLIP) {
-#ifndef NDEBUG
+#ifndef RELEASE_BUILD
 			_rowEdge = _row - 1;
 #endif
 			_row += _lastIndex - (x - _sourceX);
 			assert(_row > _rowEdge);
 		} else {
-#ifndef NDEBUG
+#ifndef RELEASE_BUILD
 			_rowEdge = _row + _lastIndex + 1;
 #endif
 			_row += x - _sourceX;
@@ -152,7 +152,7 @@ struct SCALER_NoScale {
 
 template<bool FLIP, typename READER>
 struct SCALER_Scale {
-#ifndef NDEBUG
+#ifndef RELEASE_BUILD
 	int16 _minX;
 	int16 _maxX;
 #endif
@@ -167,7 +167,7 @@ struct SCALER_Scale {
 
 	SCALER_Scale(const CelObj &celObj, const Common::Rect &targetRect, const Common::Point &scaledPosition, const Ratio scaleX, const Ratio scaleY) :
 	_row(nullptr),
-#ifndef NDEBUG
+#ifndef RELEASE_BUILD
 	_minX(targetRect.left),
 	_maxX(targetRect.right - 1),
 #endif
@@ -176,7 +176,7 @@ struct SCALER_Scale {
 	// decompress an entire line of source data when scaling
 	_reader(celObj, celObj._width),
 	_sourceBuffer() {
-#ifndef NDEBUG
+#ifndef RELEASE_BUILD
 		assert(_minX <= _maxX);
 #endif
 
@@ -316,7 +316,7 @@ int16 SCALER_Scale<FLIP, READER>::_valuesY[kCelScalerTableSize];
 
 struct READER_Uncompressed {
 private:
-#ifndef NDEBUG
+#ifndef RELEASE_BUILD
 	int16 _sourceHeight;
 #endif
 	const byte *_pixels;
@@ -324,7 +324,7 @@ private:
 
 public:
 	READER_Uncompressed(const CelObj &celObj, const int16) :
-#ifndef NDEBUG
+#ifndef RELEASE_BUILD
 	_sourceHeight(celObj._height),
 #endif
 	_sourceWidth(celObj._width) {
@@ -334,7 +334,7 @@ public:
 
 		if (numPixels < celObj._width * celObj._height) {
 			warning("%s is truncated", celObj._info.toString().c_str());
-#ifndef NDEBUG
+#ifndef RELEASE_BUILD
 			_sourceHeight = numPixels / celObj._width;
 #endif
 		}


### PR DESCRIPTION
<strike>Remove the usage of NDEBUG

We don't define NDEBUG in release builds, but we have other means
of debugging in our common code, via debug levels</strike>

**Update:** This has been changed so that all the remaining usage of NDEBUG is replaced with RELEASE_BUILD

This is a follow-up to PR #2486 