### PR TITLE
ANDROID: Upgrade the NDK to version 23

### DIFF
--- a/configure
+++ b/configure
@@ -2126,13 +2126,13 @@ if test "$_host_os" = android; then
 	esac
 
 	# These values can get overriden below by environments variables
-	_ar="$_android_toolchain/bin/$_ar"
-	_as="$_android_toolchain/bin/$_as"
-	_dwp="$_android_toolchain/bin/$_dwp"
-	_ranlib="$_android_toolchain/bin/$_ranlib"
-	_strip="$_android_toolchain/bin/$_strip"
+	_ar="$_android_toolchain/bin/llvm-ar cr"
+	_as="$_android_toolchain/bin/llvm-as"
+	_dwp="$_android_toolchain/bin/llvm-dwp"
+	_ranlib="$_android_toolchain/bin/llvm-ranlib"
+	_strip="$_android_toolchain/bin/llvm-strip"
 	if test -z "$STRINGS"; then
-		STRINGS="$_android_toolchain/bin/$_host_alias-strings"
+		STRINGS="$_android_toolchain/bin/llvm-strings"
 	fi
 	if test -z "$PKG_CONFIG_LIBDIR"; then
 		PKG_CONFIG_LIBDIR="$_android_toolchain/sysroot/usr/lib/$_host_alias/$_android_version/pkgconfig"
@@ -7343,10 +7343,7 @@ case $_host_os in
 			esac
 		done
 
-		# -lgcc is carefully placed here - we want to catch
-		# all toolchain symbols in *our* libraries rather
-		# than pick up anything unhygienic from the Android libs.
-		LIBS="-Wl,-Bstatic $static_libs -Wl,-Bdynamic -lgcc $system_libs -llog -landroid -ljnigraphics -lEGL"
+		LIBS="-Wl,-Bstatic $static_libs -Wl,-Bdynamic $system_libs -llog -landroid -ljnigraphics -lEGL"
 		;;
 	ds)
 		# Moved -Wl,--gc-sections here to avoid it interfering with the library checks

--- a/dists/android/build.gradle
+++ b/dists/android/build.gradle
@@ -31,7 +31,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdk 34
-    ndkVersion "21.3.6528147"
+    ndkVersion "23.2.8568313"
 
     namespace "org.scummvm.scummvm"
 


### PR DESCRIPTION
This version is the last one to support API level 17 (Jelly Bean).
It also gets rid of all remnants from the old binutils/GCC toolchain.
This also migrates from LLVM 9 to LLVM 12.

I have a Docker toolchain update ready for these changes.

This PR must be merged synchronously with a docker image update to keep the Buildbot happy.
Produced packages still need to be tested on various Android phones before merging.