### PR TITLE
JANITORIAL: MTROPOLIS: resolve various typos

### DIFF
--- a/engines/mtropolis/boot.cpp
+++ b/engines/mtropolis/boot.cpp
@@ -743,7 +743,7 @@ bool BootScriptParser::parseNumber(char firstChar, Common::String &outToken) {
 		}
 
 		if (isAlpha(ch)) {
-			warning("Invalid floating point constantin boot script");
+			warning("Invalid floating point constant in boot script");
 			return false;
 		}
 

--- a/engines/mtropolis/coroutine_manager.cpp
+++ b/engines/mtropolis/coroutine_manager.cpp
@@ -521,7 +521,7 @@ void CoroutineCompiler::compileOne(CompiledCoroutine *compiledCoro, CoroutineCom
 							chainEndInstr[chainID] = (uint)-1;
 							break;
 						} else if (instrJumpRoot[traceInstr] == 0) {
-							// Propgate jump chain
+							// Propagate jump chain
 							instrJumpRoot[traceInstr] = jumpRootID;
 							traceInstr = instr._value;
 						} else {

--- a/engines/mtropolis/elements.cpp
+++ b/engines/mtropolis/elements.cpp
@@ -1826,7 +1826,7 @@ MiniscriptInstructionOutcome MToonElement::scriptSetCel(MiniscriptThread *thread
 
 	int32 maxCel = _metadata->frames.size();
 
-	// Intentially ignore play range.  The cel may be set to an out-of-range cel here and will
+	// Intentionally ignore play range.  The cel may be set to an out-of-range cel here and will
 	// in fact play from that cel even if it's out of range.  The mariachi hint room near the
 	// Bureau booths in Obsidian depends on this behavior, since it sets the mToon cel and then
 	// sets the range based on the cel value.

--- a/engines/mtropolis/hacks.cpp
+++ b/engines/mtropolis/hacks.cpp
@@ -1124,7 +1124,7 @@ void addMTIQuirks(const MTropolisGameDescription &desc, Hacks &hacks) {
 	hacks.mtiVariableReferencesHack = true;
 
 	// MTI returns from the menu by transitioning to a "return" scene that sends a return message to the target
-	// scene, which is supposed to activate a scene transtion modifier in the scene that transitions to itself.
+	// scene, which is supposed to activate a scene transition modifier in the scene that transitions to itself.
 	// This doesn't work because the modifier is gone when the scene is unloaded.
 	hacks.mtiSceneReturnHack = true;
 

--- a/engines/mtropolis/plugin/ftts_data.h
+++ b/engines/mtropolis/plugin/ftts_data.h
@@ -32,7 +32,7 @@ namespace FTTS {
 
 // Known Fairy Tale: A True Story - Activity Center custom modifiers:
 // - Motion
-// - Sparke
+// - Sparkle
 
 
 struct MotionModifier : public PlugInModifierData {

--- a/engines/mtropolis/plugin/hoologic_data.h
+++ b/engines/mtropolis/plugin/hoologic_data.h
@@ -36,7 +36,7 @@ namespace Hoologic {
 // - hlCaptureBitmap: captures a screen image into a bitmap
 // - hlPrintBitmap: print a bitmap
 // - hlSaveBitmap: saves a bitmap as a PICT/BMP file
-// - hlImportBitamp: load a bitmap from a PICT/BMP file
+// - hlImportBitmap: load a bitmap from a PICT/BMP file
 // - hlDisplayBitmap: display a bitmap
 // - hlScaleBitmap: scale a bitmap
 //

--- a/engines/mtropolis/plugin/standard.cpp
+++ b/engines/mtropolis/plugin/standard.cpp
@@ -1765,6 +1765,6 @@ Common::SharedPtr<PlugIn> createStandard() {
 	return Common::SharedPtr<PlugIn>(new Standard::StandardPlugIn());
 }
 
-} // End of namespace MTropolis
+} // End of namespace PlugIns
 
 } // End of namespace MTropolis

--- a/engines/mtropolis/plugin/thereware_data.h
+++ b/engines/mtropolis/plugin/thereware_data.h
@@ -54,7 +54,7 @@ namespace Thereware {
 // - EasyScroller: various detail controls for scrolling behavior
 //
 // * Quick Kit:
-// - Flasher: Lets objects blinko on the screen
+// - Flasher: Lets objects blink on the screen
 // - Snapper: Creates an invisible grid that elements can snap onto when dragged
 // - Conductor: Forward messages to all the children of an element
 // - Randomizer: Use random numbers without Miniscript

--- a/engines/mtropolis/runtime.cpp
+++ b/engines/mtropolis/runtime.cpp
@@ -2412,7 +2412,7 @@ void MessengerSendSpec::resolveDestination(Runtime *runtime, Modifier *sender, R
 
 void MessengerSendSpec::resolveVariableObjectType(RuntimeObject *obj, Common::WeakPtr<Structural> &outStructuralDest, Common::WeakPtr<Modifier> &outModifierDest) {
 	if (!obj) {
-		warning("Couldn't resolve mesenger destination");
+		warning("Couldn't resolve messenger destination");
 		return;
 	}
 
@@ -4471,7 +4471,7 @@ Palette::Palette() {
 }
 
 void Palette::initDefaultPalette(int version) {
-	// NOTE: The "V2" pallete is correct for Unit: Rebooted.
+	// NOTE: The "V2" palette is correct for Unit: Rebooted.
 	// Is it correct for all V2 apps?
 	assert(version == 1 || version == 2);
 	int outColorIndex = 0;
@@ -5320,7 +5320,7 @@ void Runtime::executeCloneObject(RuntimeObject *object) {
 		if (container)
 			container->appendModifier(modifierRef);
 		else
-			error("Internal error: Cloned a modifier, but the parent isn't a modifeir container");
+			error("Internal error: Cloned a modifier, but the parent isn't a modifier container");
 
 		{
 			Common::SharedPtr<MessageProperties> msgProps(new MessageProperties(Event(EventIDs::kClone, 0), DynamicValue(), modifierRef));
@@ -10228,7 +10228,7 @@ bool Modifier::respondsToEvent(const Event &evt) const {
 }
 
 VThreadState Modifier::consumeMessage(Runtime *runtime, const Common::SharedPtr<MessageProperties> &msg) {
-	// If you're here, a message type was reported as responsive by respondsToEvent but consumeMessage wasn't overrided
+	// If you're here, a message type was reported as responsive by respondsToEvent but consumeMessage wasn't overridden
 	assert(false);
 	return kVThreadError;
 }

--- a/engines/mtropolis/saveload.cpp
+++ b/engines/mtropolis/saveload.cpp
@@ -79,7 +79,7 @@ bool MTropolisEngine::promptSave(ISaveWriter *writer, const Graphics::Surface *s
 	desc = dialog->getResultString();
 
 	if (desc.empty()) {
-		// create our own description for the saved game, the user didnt enter it
+		// create our own description for the saved game, the user didn't enter it
 		desc = dialog->createDefaultSaveDescription(slot);
 	}
 


### PR DESCRIPTION
Resolve various typos and an error in a comment in the mTropolis engine code.