### PR TITLE
SCUMM: MANIAC NES: Add WIP loading for NES title screens. Not drawing them yet.

### DIFF
--- a/engines/scumm/file_nes.h
+++ b/engines/scumm/file_nes.h
@@ -59,7 +59,8 @@ public:
 		NES_SPROFFS,
 		NES_SPRDATA,
 		NES_CHARSET,
-		NES_PREPLIST
+		NES_PREPLIST,
+        NES_TITLES
 	};
 
 


### PR DESCRIPTION
Adds resource parsing for the NES title screens, currently I'm sticking these at the end of LFL 54, though I'm not quite sure exactly where or how to load them.
