### PR TITLE
JANITORIAL: WATCHMAKER: Fix enviroment typos

### DIFF
--- a/engines/watchmaker/3d/geometry.cpp
+++ b/engines/watchmaker/3d/geometry.cpp
@@ -2320,7 +2320,7 @@ void t3dSetFaceVisibility(t3dMESH *mesh, t3dCAMERA *cam) {
 		} else
 			T2 = -1;
 
-		if (Material->hasFlag(T3D_MATERIAL_ENVIROMENT)) {                                        // se ha l'enviroment
+		if (Material->hasFlag(T3D_MATERIAL_ENVIRONMENT)) {                                       // se ha l'environnement
 			t3dM3X3F    m;
 			t3dMatMul(&m, &mesh->Matrix, &t3dCurViewMatrix);
 

--- a/engines/watchmaker/render.h
+++ b/engines/watchmaker/render.h
@@ -36,7 +36,7 @@ namespace Watchmaker {
 #define T3D_MATERIAL_ADDITIVE           (1<<2)          // additive (25-49)
 #define T3D_MATERIAL_GLASS              (1<<3)          // glass (50-74)
 #define T3D_MATERIAL_BOTTLE             (1<<4)          // bottle (75-100)
-#define T3D_MATERIAL_ENVIROMENT         (1<<5)          // enviroment
+#define T3D_MATERIAL_ENVIRONMENT        (1<<5)          // environment
 #define T3D_MATERIAL_SKY                (1<<6)          // sky
 #define T3D_MATERIAL_NOLIGHTMAP         (1<<7)          // no lightmap
 #define T3D_MATERIAL_MOVIE              (1<<8)          // with movie


### PR DESCRIPTION
Mostly for consistency.

enviroment is clearly wrong

even l'enviroment is wrong, it has to be l'environnement (fixed that too)

Just two lines, but it touches code, so...