### PR TITLE
JANITORIAL: LURE: Fix persistant typos in in code

### DIFF
--- a/engines/lure/debugger.cpp
+++ b/engines/lure/debugger.cpp
@@ -318,7 +318,7 @@ bool Debugger::cmd_hotspot(int argc, const char **argv) {
 
 		if (h != nullptr) {
 			debugPrintf("Frame Number = %d of %d\n", h->frameNumber(), h->numFrames());
-			debugPrintf("Persistent = %s\n", h->persistant() ? "true" : "false");
+			debugPrintf("Persistent = %s\n", h->persistent() ? "true" : "false");
 		}
 
 	} else if (strcmp(argv[2], "actions") == 0) {

--- a/engines/lure/hotspots.cpp
+++ b/engines/lure/hotspots.cpp
@@ -45,7 +45,7 @@ Hotspot::Hotspot(HotspotData *res): _pathFinder(this) {
 	_anim = nullptr;
 	_frames = nullptr;
 	_numFrames = 0;
-	_persistant = false;
+	_persistent = false;
 	_direction = NO_DIRECTION;
 
 	_hotspotId = res->hotspotId;
@@ -96,7 +96,7 @@ Hotspot::Hotspot(Hotspot *character, uint16 objType): _pathFinder(this) {
 	_anim = nullptr;
 	_frames = nullptr;
 	_numFrames = 0;
-	_persistant = false;
+	_persistent = false;
 	_hotspotId = 0xffff;
 	_override = nullptr;
 	_colorOffset = 0;

--- a/engines/lure/hotspots.cpp
+++ b/engines/lure/hotspots.cpp
@@ -141,7 +141,7 @@ Hotspot::Hotspot(Hotspot *character, uint16 objType): _pathFinder(this) {
 		_widthCopy = 19;
 		_heightCopy = 18 + character->heightCopy();
 		_layer = 1;
-		_persistant = false;
+		_persistent = false;
 		_yCorrection = 1;
 		_voiceCtr = CONVERSE_COUNTDOWN_SIZE;
 
@@ -167,7 +167,7 @@ Hotspot::Hotspot(): _pathFinder(nullptr) {
 	_anim = nullptr;
 	_frames = nullptr;
 	_numFrames = 0;
-	_persistant = false;
+	_persistent = false;
 	_hotspotId = 0xffff;
 	_override = nullptr;
 	_colorOffset = 0;
@@ -2355,7 +2355,7 @@ void Hotspot::saveToStream(Common::WriteStream *stream) const {
 	stream->writeUint16LE(_blockedOffset);
 	stream->writeUint16LE(_exitCtr);
 	stream->writeByte(_walkFlag);
-	stream->writeByte(_persistant);
+	stream->writeByte(_persistent);
 	stream->writeUint16LE(_startRoomNumber);
 	stream->writeUint16LE(_supportValue);
 }
@@ -2402,7 +2402,7 @@ void Hotspot::loadFromStream(Common::ReadStream *stream) {
 	_blockedOffset = stream->readUint16LE();
 	_exitCtr = stream->readUint16LE();
 	_walkFlag = stream->readByte() != 0;
-	_persistant = stream->readByte() != 0;
+	_persistent = stream->readByte() != 0;
 	_startRoomNumber = stream->readUint16LE();
 	_supportValue = stream->readUint16LE();
 }

--- a/engines/lure/hotspots.h
+++ b/engines/lure/hotspots.h
@@ -200,7 +200,7 @@ private:
 	uint8 _layer;
 	uint16 _hotspotScriptOffset;
 	uint8 _colorOffset;
-	bool _persistant;
+	bool _persistent;
 	HotspotOverrideData *_override;
 	bool _skipFlag;
 	PathFinder _pathFinder;
@@ -318,8 +318,8 @@ public:
 	uint8 layer() const { return _layer; }
 	bool skipFlag() const { return _skipFlag; }
 	void setTickProc(uint16 newVal);
-	bool persistant() const { return _persistant; }
-	void setPersistant(bool value) { _persistant = value; }
+	bool persistent() const { return _persistent; }
+	void setPersistent(bool value) { _persistent = value; }
 	uint8 colorOffset() const { return _colorOffset; }
 	void setColorOffset(uint8 value) { _colorOffset = value; }
 	void setRoomNumber(uint16 roomNum) {

--- a/engines/lure/res.cpp
+++ b/engines/lure/res.cpp
@@ -614,7 +614,7 @@ Hotspot *Resources::activateHotspot(uint16 hotspotId) {
 			assert(hotspot);
 
 			// Special post-load handling
-			if (res->loadOffset == 3) hotspot->setPersistant(true);
+			if (res->loadOffset == 3) hotspot->setPersistent(true);
 			if (res->loadOffset == 5) hotspot->handleTalkDialog();
 			if (hotspotId == CASTLE_SKORL_ID) {
 				// The Castle skorl has a default room #99, so it needs to be adjusted dynamically

--- a/engines/lure/room.cpp
+++ b/engines/lure/room.cpp
@@ -138,7 +138,7 @@ void Room::leaveRoom() {
 	HotspotList::iterator i = list.begin();
 	while (i != list.end()) {
 		Hotspot const &h = **i;
-		if (!h.persistant()) {
+		if (!h.persistent()) {
 			i = list.erase(i);
 		} else {
 			++i;


### PR DESCRIPTION
Separate PR, since it touches code


The one fix in debugger.cpp will probably stumble over the big bunch of typo fixes, since the warning message has been fixed there...so either we wait for that to get merged first or fix this PR later???