### PR TITLE
JANITORIAL: PINK: Fix recepient typos in code

### DIFF
--- a/engines/pink/objects/actors/lead_actor.cpp
+++ b/engines/pink/objects/actors/lead_actor.cpp
@@ -59,9 +59,9 @@ void LeadActor::loadState(Archive &archive) {
 	_stateBeforeInventory = (State)archive.readByte();
 	_stateBeforePDA = (State)archive.readByte();
 	_isHaveItem = archive.readByte();
-	Common::String recepient = archive.readString();
-	if (!recepient.empty())
-		_recipient = _page->findActor(recepient);
+	Common::String recipient = archive.readString();
+	if (!recipient.empty())
+		_recipient = _page->findActor(recipient);
 	else
 		_recipient = nullptr;
 	_sequencer->loadState(archive);

--- a/engines/pink/objects/handlers/handler.cpp
+++ b/engines/pink/objects/handlers/handler.cpp
@@ -110,11 +110,11 @@ void HandlerLeftClick::toConsole() const {
 void HandlerUseClick::deserialize(Archive &archive) {
 	HandlerSequences::deserialize(archive);
 	_inventoryItem = archive.readString();
-	_recepient = archive.readString();
+	_recipient = archive.readString();
 }
 
 void HandlerUseClick::toConsole() const {
-	debugC(6, kPinkDebugLoadingObjects, "HandlerUseClick: _inventoryItem=%s, _recepient=%s", _inventoryItem.c_str(), _recepient.c_str());
+	debugC(6, kPinkDebugLoadingObjects, "HandlerUseClick: _inventoryItem=%s, _recipient=%s", _inventoryItem.c_str(), _recipient.c_str());
 	debugC(6, kPinkDebugLoadingObjects, "\tSideEffects:");
 	for (uint i = 0; i < _sideEffects.size(); ++i) {
 		_sideEffects[i]->toConsole();

--- a/engines/pink/objects/handlers/handler.h
+++ b/engines/pink/objects/handlers/handler.h
@@ -81,7 +81,7 @@ public:
 
 private:
 	Common::String _inventoryItem;
-	Common::String _recepient;
+	Common::String _recipient;
 };
 
 class HandlerTimerActions : public Handler {

--- a/engines/pink/objects/handlers/handler.h
+++ b/engines/pink/objects/handlers/handler.h
@@ -77,7 +77,7 @@ public:
 	void toConsole() const override;
 
 	const Common::String &getInventoryItem() const { return _inventoryItem; }
-	const Common::String &getRecepient() const { return _recepient; }
+	const Common::String &getRecipient() const { return _recipient; }
 
 private:
 	Common::String _inventoryItem;

--- a/engines/pink/objects/handlers/handler_mgr.cpp
+++ b/engines/pink/objects/handlers/handler_mgr.cpp
@@ -61,8 +61,8 @@ void HandlerMgr::onLeftClickMessage(Actor *actor) {
 void HandlerMgr::onUseClickMessage(Actor *actor, InventoryItem *item, InventoryMgr *mgr) {
 	HandlerUseClick *handler = findSuitableHandlerUseClick(actor, item->getName());
 	assert(handler);
-	if (!handler->getRecepient().empty())
-		mgr->setItemOwner(handler->getRecepient(), item);
+	if (!handler->getRecipient().empty())
+		mgr->setItemOwner(handler->getRecipient(), item);
 	handler->handle(actor);
 }
 


### PR DESCRIPTION
Need a little help here, since it could be intended

in lead_actor.cpp, line 64 _recipient is spelled correctly ONCE...all of the other instances are misspelled.

Was that an oversight?
Intended?
How did that piece of code even work? :-)
Or is that "if else" loop extremely unlikely to trigger?

Thank you