### PR TITLE
MTROPOLIS: add specific boot functions for numerous games

### DIFF
--- a/engines/mtropolis/boot.cpp
+++ b/engines/mtropolis/boot.cpp
@@ -1118,6 +1118,32 @@ public:
 	void bootMTIRetailWinRu();
 	void bootSPQRMac();
 	void bootSPQRWin();
+	void bootPurpleMoonWin();
+	void bootDilbertWin();
+	void bootEasyBakeWin();
+	void bootC9SamplerWin();
+	void bootFTTSWin();
+	void bootArchitectureWin();
+	void bootDrawMarvelWin();
+	void bootDinosaurFinderWin();
+	void bootAnimalDoctorWin();
+	void bootIvoclarWin();
+	void bootBeatrixWin();
+	void bootPoserWin();
+	void bootRWCWin();
+	void bootAngelicaWin();
+	void bootAlbertWin();
+	void bootWhitetailWin();
+	void bootNotebookWin();
+	void bootMsbAnimalWin();
+	void bootMsbBugsWin();
+	void bootMsbConcertWin();
+	void bootMsbFlightWin();
+	void bootMsbMarsWin();
+	void bootMsbVolcanoWin();
+	void bootMsbWhalesWin();
+
+
 	void bootGeneric();
 	void bootUsingBootScript();
 
@@ -1412,6 +1438,149 @@ void BootScriptContext::bootSPQRMac() {
 
 void BootScriptContext::bootSPQRWin() {
 	addPlugIn(kPlugInStandard);
+}
+
+void BootScriptContext::bootPurpleMoonWin() {
+	addPlugIn(kPlugInStandard);
+	setMainSegmentFile("workspace/0Sampler.mpl");
+}
+
+void BootScriptContext::bootDilbertWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInKnowWonder);
+	addPlugIn(kPlugInThereware);
+	addPlugIn(kPlugInAxLogic);
+	addPlugIn(kPlugInHoologic);
+	setMainSegmentFile("workspace/HIJINKS/Hijinks1.mpl");
+}
+
+void BootScriptContext::bootEasyBakeWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInKnowWonder);
+	setMainSegmentFile("workspace/EB/INTRO.MFX");
+}
+
+void BootScriptContext::bootC9SamplerWin() {
+	addPlugIn(kPlugInStandard);
+	setRuntimeVersion(RuntimeVersion::kRuntimeVersion100);
+	setMainSegmentFile("workspace/RUNSAMP.C9A");
+}
+
+void BootScriptContext::bootFTTSWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInFTTS);
+	addPlugIn(kPlugInHoologic);
+}
+
+void BootScriptContext::bootArchitectureWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInHoologic);
+}
+
+void BootScriptContext::bootDrawMarvelWin() {
+	addPlugIn(kPlugInStandard);
+	setRuntimeVersion(RuntimeVersion::kRuntimeVersion100);
+	setMainSegmentFile("workspace/MDRAW.C9A");
+}
+
+void BootScriptContext::bootDinosaurFinderWin() {
+	addPlugIn(kPlugInStandard);
+	setRuntimeVersion(RuntimeVersion::kRuntimeVersion100);
+	setMainSegmentFile("workspace/WBDFR1.C9A");
+}
+
+void BootScriptContext::bootAnimalDoctorWin() {
+	addPlugIn(kPlugInStandard);
+	setRuntimeVersion(RuntimeVersion::kRuntimeVersion100);
+	setMainSegmentFile("workspace/VET.C9A");
+}
+
+void BootScriptContext::bootIvoclarWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInMLine);
+}
+
+void BootScriptContext::bootBeatrixWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInHoologic);
+	//Force V112 mode for PlugInModifier::load
+	//Autodetected V100 causes error there
+	setRuntimeVersion(RuntimeVersion::kRuntimeVersion112);
+}
+
+void BootScriptContext::bootPoserWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInThereware);
+}
+
+void BootScriptContext::bootRWCWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInThereware);
+	addPlugIn(kPlugInRWC);
+}
+
+void BootScriptContext::bootAngelicaWin() {
+	addPlugIn(kPlugInStandard);
+	setMainSegmentFile("workspace/mfx/Splash.mfx");
+}
+
+void BootScriptContext::bootAlbertWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInHoologic);
+	addPlugIn(kPlugInThereware);
+}
+
+void BootScriptContext::bootWhitetailWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInThereware);
+}
+
+void BootScriptContext::bootNotebookWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInKnowWonder);
+	setMainSegmentFile("workspace/YN/Hallway.mfx");
+}
+
+void BootScriptContext::bootMsbAnimalWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInKnowWonder);
+	setMainSegmentFile("workspace/MSB/Startup.mfw");
+}
+
+void BootScriptContext::bootMsbBugsWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInKnowWonder);
+	setMainSegmentFile("workspace/MSB/SignIn.mfx");
+}
+
+void BootScriptContext::bootMsbConcertWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInKnowWonder);
+	setMainSegmentFile("workspace/MSB/SignInC.mfx");
+}
+
+void BootScriptContext::bootMsbFlightWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInKnowWonder);
+	setMainSegmentFile("workspace/MSB/SignInF.mfx");
+}
+
+void BootScriptContext::bootMsbMarsWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInKnowWonder);
+	setMainSegmentFile("workspace/MSB/SignInM.mfx");
+}
+
+void BootScriptContext::bootMsbVolcanoWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInKnowWonder);
+	setMainSegmentFile("workspace/MSB/SignInV.mfx");
+}
+
+void BootScriptContext::bootMsbWhalesWin() {
+	addPlugIn(kPlugInStandard);
+	addPlugIn(kPlugInKnowWonder);
+	setMainSegmentFile("workspace/MSB/SignInW.mfx");
 }
 
 void BootScriptContext::bootGeneric() {
@@ -1771,67 +1940,67 @@ const Game games[] = {
 	// Uncle Albert's Magical Album - German - Windows
 	{
 		MTBOOT_ALBERT1_WIN_DE,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootAlbertWin
 	},
 	// Uncle Albert's Magical Album - English - Windows
 	{
 		MTBOOT_ALBERT1_WIN_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootAlbertWin
 	},
 	// Uncle Albert's Magical Album - French - Windows
 	{
 		MTBOOT_ALBERT1_WIN_FR,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootAlbertWin
 	},
 	// Uncle Albert's Magical Album - Dutch - Windows
 	{
 		MTBOOT_ALBERT1_WIN_NL,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootAlbertWin
 	},
 	// Uncle Albert's Fabulous Voyage - German - Windows
 	{
 		MTBOOT_ALBERT2_WIN_DE,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootAlbertWin
 	},
 	// Uncle Albert's Fabulous Voyage - English - Windows
 	{
 		MTBOOT_ALBERT2_WIN_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootAlbertWin
 	},
 	// Uncle Albert's Fabulous Voyage - English - Windows
 	{
 		MTBOOT_ALBERT2_WIN_FR,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootAlbertWin
 	},
 	// Uncle Albert's Fabulous Voyage - Dutch - Windows
 	{
 		MTBOOT_ALBERT2_WIN_NL,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootAlbertWin
 	},
 	// Uncle Albert's Mysterious Island - German - Windows
 	{
 		MTBOOT_ALBERT3_WIN_DE,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootAlbertWin
 	},
 	// Uncle Albert's Mysterious Island - English - Windows
 	{
 		MTBOOT_ALBERT3_WIN_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootAlbertWin
 	},
 	// Uncle Albert's Mysterious Island - French - Windows
 	{
 		MTBOOT_ALBERT3_WIN_FR,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootAlbertWin
 	},
 	// Uncle Albert's Mysterious Island - Dutch - Windows
 	{
 		MTBOOT_ALBERT3_WIN_NL,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootAlbertWin
 	},
 	// Uncle Albert's Mysterious Island - Catalan - Windows
 	{
 		MTBOOT_ALBERT3_WIN_CA,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootAlbertWin
 	},
 	// SPQR: The Empire's Darkest Hour - Retail - Windows - English
 	{
@@ -1871,22 +2040,22 @@ const Game games[] = {
 	// Fun With Architecture - Windows - English
 	{
 		MTBOOT_ARCHITECTURE_EN,
-	 	&BootScriptContext::bootGeneric
+	 	&BootScriptContext::bootArchitectureWin
 	},
 	// The Magic World of Beatrix Potter - Windows - English
 	{
 		MTBOOT_BEATRIX_EN,
-	 	&BootScriptContext::bootGeneric
+	 	&BootScriptContext::bootBeatrixWin
 	},
 	// The Magic World of Beatrix Potter - Demo - Windows - English
 	{
 		MTBOOT_BEATRIX_DEMO_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootBeatrixWin
 	},
 	// Whitetail Impact - Windows - English
 	{
 		MTBOOT_WT_IMPACT_EN,
-	 	&BootScriptContext::bootGeneric
+	 	&BootScriptContext::bootWhitetailWin
 	},
 	// The Day The World Broke - Windows - English
 	{
@@ -1896,7 +2065,7 @@ const Game games[] = {
 	// The Totally Techie World of Young Dilbert: Hi-Tech Hijinks - Windows - English
 	{
 		MTBOOT_DILBERT_WIN_EN,
-	 	&BootScriptContext::bootGeneric
+	 	&BootScriptContext::bootDilbertWin
 	},
 	// Free Willy Activity Center - Windows - English
 	{
@@ -1911,27 +2080,27 @@ const Game games[] = {
 	// I Can Be a Dinosaur Finder - Retail - Windows - English
 	{
 		MTBOOT_IDINO_RETAIL_EN,
-	 	&BootScriptContext::bootGeneric
+	 	&BootScriptContext::bootDinosaurFinderWin
 	},
 	// I Can Be an Animal Doctor - Retail - Windows - English
 	{
 		MTBOOT_IDOCTOR_RETAIL_EN,
-	 	&BootScriptContext::bootGeneric
+	 	&BootScriptContext::bootAnimalDoctorWin
 	},
 	// How to Draw the Marvel Way - Windows - English
 	{
 		MTBOOT_DRAWMARVELWAY_WIN_EN,
-		&BootScriptContext::bootGeneric,
+		&BootScriptContext::bootDrawMarvelWin,
 	},
 	// FairyTale: A True Story - Activity Center - Windows - English
 	{
 		MTBOOT_FTTS_WIN_EN,
-	 	&BootScriptContext::bootGeneric
+	 	&BootScriptContext::bootFTTSWin
 	},
 	// Purple Moon Sampler - Demo - Windows - English
 	{
 		MTBOOT_PURPLEMOON_WIN_EN,
-	 	&BootScriptContext::bootGeneric
+	 	&BootScriptContext::bootPurpleMoonWin
 	},
 	// Chomp! The Video Game - Retail - Windows - English
 	{
@@ -1951,12 +2120,12 @@ const Game games[] = {
 	// IVOCLAR - Windows - English
 	{
 		MTBOOT_IVOCLAR_WIN_EN,
-	 	&BootScriptContext::bootGeneric
+	 	&BootScriptContext::bootIvoclarWin
 	},
 	// Real Wild Child! Australian Rock Music 1950s-90s - Windows - English
 	{
 		MTBOOT_REALWILD_WIN_EN,
-	 	&BootScriptContext::bootGeneric
+		&BootScriptContext::bootRWCWin
 	},
 	// How to Build a Telemedicine Program - Windows - English
 	{
@@ -1966,7 +2135,7 @@ const Game games[] = {
 	// Rugrats: Totally Angelica Boredom Buster - Windows - English
 	{
 		MTBOOT_ANGELICA_WIN_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootAngelicaWin
 	},
 	// Babe and Friends: Animated Early Reader - Windows - English
 	{
@@ -1981,7 +2150,7 @@ const Game games[] = {
 	// Easy-Bake Kitchen - Windows - English
 	{
 		MTBOOT_EASYBAKE_WIN_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootEasyBakeWin
 	},
 	// The Forgotten: It Begins - Windows - English
 	{
@@ -2016,37 +2185,37 @@ const Game games[] = {
 	// The Magic School Bus Explores the World of Animals - Windows - English
 	{
 		MTBOOT_MSB_ANIMAL_WIN_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootMsbAnimalWin
 	},
 	// The Magic School Bus Explores Bugs - Windows - English
 	{
 		MTBOOT_MSB_BUGS_WIN_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootMsbBugsWin
 	},
 	// The Magic School Bus In Concert - Windows - English
 	{
 		MTBOOT_MSB_CONCERT_WIN_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootMsbConcertWin
 	},
 	// The Magic School Bus Discovers Flight - Windows - English
 	{
 		MTBOOT_MSB_FLIGHT_WIN_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootMsbFlightWin
 	},
 	// The Magic School Bus Lands on Mars - Windows - English
 	{
 		MTBOOT_MSB_MARS_WIN_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootMsbMarsWin
 	},
 	// The Magic School Bus Volcano Adventure - Windows - English
 	{
 		MTBOOT_MSB_VOLCANO_WIN_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootMsbVolcanoWin
 	},
 	// The Magic School Bus Whales & Dolphins - Windows - English
 	{
 		MTBOOT_MSB_WHALES_WIN_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootMsbWhalesWin
 	},
 	// Mykropolis Planet der Roboter - Windows - German
 	{
@@ -2056,7 +2225,7 @@ const Game games[] = {
 	// Your Notebook (with help from Amelia) - Windows - English
 	{
 		MTBOOT_NOTEBOOK_WIN_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootNotebookWin
 	},
 	// Pferd & Pony Lass uns reiten	- Windows - English
 	{
@@ -2076,22 +2245,22 @@ const Game games[] = {
 	// Poser 3 Content Sampler - Windows - English
 	{
 		MTBOOT_POSER3_SAMPLER_ZYGOTE_WIN_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootPoserWin
 	},
 	// Another Poser 3 content sampler - Windows - English
 	{
 		MTBOOT_POSER3_ZYGOTE_WIN_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootPoserWin
 	},
 	// Whitetail Extreme - Windows - English
 	{
 		MTBOOT_WT_EXTREME_WIN_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootWhitetailWin
 	},
 	// Cloud 9 CD Sampler Volume 2 - Windows - English
 	{
 		MTBOOT_C9SAMPLER_WIN_EN,
-		&BootScriptContext::bootGeneric
+		&BootScriptContext::bootC9SamplerWin
 	},
 	// Adobe 24 Hours Tools Sampler - Windows - English
 	{


### PR DESCRIPTION
Add specific boot scripts for numerous mTropolis games, configuring plugins and explicitly stating the main segment file where necessary.