### PR TITLE
MYST3: Optimise autosaving for non-slot-based usage

### DIFF
--- a/engines/myst3/metaengine.cpp
+++ b/engines/myst3/metaengine.cpp
@@ -75,7 +75,9 @@ public:
 
 		SaveStateList saveList;
 		for (uint32 i = 0; i < filenames.size(); i++)
-			saveList.push_back(SaveStateDescriptor(this, i, filenames[i]));
+			// Since slots are ignored when saving, we always return slot 0
+			// as an unused slot to optimise the autosave process
+			saveList.push_back(SaveStateDescriptor(this, i + 1, filenames[i]));
 
 		return saveList;
 	}

--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -1513,7 +1513,15 @@ bool Myst3Engine::canLoadGameStateCurrently(Common::U32String *msg) {
 
 Common::Error Myst3Engine::loadGameState(int slot) {
 	Common::StringArray filenames = Saves::list(_saveFileMan, getPlatform());
-	return loadGameState(filenames[slot], kTransitionNone);
+
+	// Slots are assigned consecutively, starting from slot 1
+	// Get the Save List index for the selected slot
+	int listIndex = (slot == 0) ? slot : slot - 1;
+	if (!listIndex < filenames.size()) {
+		return Common::kReadingFailed;
+	}
+
+	return loadGameState(filenames[listIndex], kTransitionNone);
 }
 
 Common::Error Myst3Engine::loadGameState(Common::String fileName, TransitionType transition) {

--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -1581,8 +1581,14 @@ static bool isValidSaveFileName(const Common::String &desc) {
 Common::Error Myst3Engine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	assert(!desc.empty());
 
+	Common::String saveName = desc;
 	if (!isValidSaveFileName(desc)) {
-		return Common::Error(Common::kCreatingFileFailed, _("Invalid file name for saving"));
+		if (isAutosave) {
+			// Fall back to the expected English translation
+			saveName = "Autosave";
+		} else {
+			return Common::Error(Common::kCreatingFileFailed, _("Invalid file name for saving"));
+		}
 	}
 
 	// If autosaving, get a fresh thumbnail of the game screen
@@ -1593,7 +1599,7 @@ Common::Error Myst3Engine::saveGameState(int slot, const Common::String &desc, b
 	const Graphics::Surface *thumbnail = _menu->borrowSaveThumbnail();
 	assert(thumbnail);
 
-	return saveGameState(desc, thumbnail, isAutosave);
+	return saveGameState(saveName, thumbnail, isAutosave);
 }
 
 Common::Error Myst3Engine::saveGameState(const Common::String &desc, const Graphics::Surface *thumbnail, bool isAutosave) {

--- a/engines/myst3/state.cpp
+++ b/engines/myst3/state.cpp
@@ -840,12 +840,6 @@ Common::StringArray Saves::list(Common::SaveFileManager *saveFileManager, Common
 	// The saves are sorted alphabetically
 	Common::sort(filenames.begin(), filenames.end(), AutosaveFirstComparator());
 
-	// The MetaEngine save system expects the Autosave to be in slot 0
-	// if we don't have an autosave (yet), insert a fake one.
-	if (!filenames.empty() && !filenames[0].hasPrefixIgnoreCase("autosave.")) {
-		filenames.insert_at(0, buildName("Autosave", platform));
-	}
-
 	return filenames;
 }
 


### PR DESCRIPTION
The autosave process isn't set up properly for use with Myst3's non-slot-based save system, particularly when dealing with non-English versions of the game.

This PR seeks to exclude those aspects of the autosave process which are only relevant to engines with slot-based save systems.

Specifically, we exclude the unnecessary testing of the Autosave file before each autosave, and adding a custom dummy autosave to the Save List (whenever the Autosave file is either missing or has a non-English name).

We achieve this by always presenting slot 0 as an unused slot for pre-autosave testing purposes (currently, this is how it's done when the Save List is empty).

Slots are always ignored when saving, so detecting the Autosave file isn't an issue. For example, the English Autosave file is currently assigned slot 0, and any Autosave file with a non-English name is assigned slot 1 or later.

Apart from improving overall efficiency, we also address a potential autosave fail due to an incompatible translation of the autosave name, by allowing affected game versions to revert to the standard English translation.

This restores the autosave process to how it was originally handled before switching to saveAutosaveIfEnabled(), while allowing non-English versions to continue to display a localised save name, if supported.