### PR TITLE
XEEN: Support rendering Traditional Chinese characters

### DIFF
--- a/engines/mm/xeen/font.h
+++ b/engines/mm/xeen/font.h
@@ -24,6 +24,7 @@
 
 #include "common/language.h"
 #include "mm/shared/xeen/xsurface.h"
+#include "graphics/big5.h"
 
 namespace MM {
 namespace Xeen {
@@ -41,12 +42,14 @@ struct FontData {
 	static byte _bgColor;
 	static bool _fontReduced;
 	static Justify _fontJustify;
+	static Graphics::Big5Font *_big5Font;
 };
 
 class FontSurface: public Shared::Xeen::XSurface, public FontData {
 private:
 	const char *_displayString;
 	bool _msgWraps;
+	bool _isBig5;
 
 	Common::Language lang;
 	/**
@@ -64,7 +67,7 @@ private:
 	/**
 	 * Return the next pending character to display
 	 */
-	char getNextChar();
+	uint16_t getNextChar();
 
 	/**
 	 * Return the width of a given character
@@ -89,7 +92,7 @@ private:
 	/**
 	 * Wrie a character to the surface
 	 */
-	void writeChar(char c, const Common::Rect &clipRect);
+	void writeChar(uint16_t c, const Common::Rect &clipRect);
 public:
 	Common::Point &_writePos;
 public:
@@ -118,7 +121,7 @@ public:
 	 * @param c			Character
 	 * @param clipRect	Window bounds to display string within
 	 */
-	void writeCharacter(char c, const Common::Rect &clipRect);
+	void writeCharacter(uint16_t c, const Common::Rect &clipRect);
 };
 
 } // End of namespace Xeen

--- a/engines/mm/xeen/window.cpp
+++ b/engines/mm/xeen/window.cpp
@@ -84,6 +84,18 @@ Windows::Windows() {
 	};
 
 	_windows = Common::Array<Window>(windows, 42);
+
+	Common::File pat;
+	if (pat.open("TEXTPAT.FNT")) {
+		_big5Font = new Graphics::Big5Font();
+		_big5Font->loadPrefixedRaw(pat, 14);
+	} else if (pat.open("CMM4.PAT")) {
+		_big5Font = new Graphics::Big5Font();
+		_big5Font->loadPrefixedRaw(pat, 15);
+	} else if (g_vm->getLanguage() == Common::ZH_TWN) {
+		error("Unable to find TEXTPAT.FNT or CMM4.PAT for Chinese version");
+	}	
+
 }
 
 Windows::~Windows() {


### PR DESCRIPTION
Note: this isn't full Chinese support, only font rendering

Tested with "Might and Magic V: Darkside of Xeen"


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
