### PR TITLE
SCI: add setShakePos() function to gfx drivers

### DIFF
--- a/engines/sci/graphics/gfxdrivers.cpp
+++ b/engines/sci/graphics/gfxdrivers.cpp
@@ -45,6 +45,10 @@ void GfxDriver::setMousePos(const Common::Point &pos) const {
 	g_system->warpMouse(pos.x, pos.y);
 }
 
+void GfxDriver::setShakePos(int shakeXOffset, int shakeYOffset) const {
+	g_system->setShakePos(shakeXOffset, shakeYOffset);
+}
+
 void GfxDriver::clearRect(const Common::Rect &r) const {
 	GFXDRV_ASSERT_READY;
 	g_system->fillScreen(r, 0);
@@ -690,6 +694,10 @@ void SCI0_CGABWDriver::setMousePos(const Common::Point &pos) const {
 	g_system->warpMouse(pos.x << 1, pos.y << 1);
 }
 
+void SCI0_CGABWDriver::setShakePos(int shakeXOffset, int shakeYOffset) const {
+	g_system->setShakePos(shakeXOffset << 1, shakeYOffset << 1);
+}
+
 void SCI0_CGABWDriver::clearRect(const Common::Rect &r) const {
 	Common::Rect r2(r.left << 1, r.top << 1, r.right << 1, r.bottom << 1);
 	GfxDriver::clearRect(r2);
@@ -849,6 +857,10 @@ Common::Point SCI0_HerculesDriver::getMousePos() const {
 
 void SCI0_HerculesDriver::setMousePos(const Common::Point &pos) const {
 	g_system->warpMouse((pos.x << 1) + _centerX, (pos.y & ~1) * 3 / 2 + (pos.y & 1) + _centerY);
+}
+
+void SCI0_HerculesDriver::setShakePos(int shakeXOffset, int shakeYOffset) const {
+	g_system->setShakePos(shakeXOffset << 1, (shakeYOffset & ~1) * 3 / 2 + (shakeYOffset & 1));
 }
 
 void SCI0_HerculesDriver::clearRect(const Common::Rect &r) const {
@@ -1148,6 +1160,10 @@ void SCI1_EGADriver::setMousePos(const Common::Point &pos) const {
 	g_system->warpMouse(pos.x << 1, pos.y << 1);
 }
 
+void SCI1_EGADriver::setShakePos(int shakeXOffset, int shakeYOffset) const {
+	g_system->setShakePos(shakeXOffset << 1, shakeYOffset << 1);
+}
+
 void SCI1_EGADriver::clearRect(const Common::Rect &r) const {
 	Common::Rect r2(r.left << 1, r.top << 1, r.right << 1, r.bottom << 1);
 	GfxDriver::clearRect(r2);
@@ -1256,6 +1272,10 @@ Common::Point UpscaledGfxDriver::getMousePos() const {
 
 void UpscaledGfxDriver::setMousePos(const Common::Point &pos) const {
 	g_system->warpMouse(pos.x << 1, pos.y << 1);
+}
+
+void UpscaledGfxDriver::setShakePos(int shakeXOffset, int shakeYOffset) const {
+	g_system->setShakePos(shakeXOffset << 1, shakeYOffset << 1);
 }
 
 void UpscaledGfxDriver::clearRect(const Common::Rect &r) const {

--- a/engines/sci/graphics/gfxdrivers.h
+++ b/engines/sci/graphics/gfxdrivers.h
@@ -45,6 +45,7 @@ public:
 	virtual void replaceMacCursor(const Graphics::Cursor *cursor) = 0;
 	virtual Common::Point getMousePos() const;
 	virtual void setMousePos(const Common::Point &pos) const;
+	virtual void setShakePos(int shakeXOffset, int shakeYOffset) const;
 	virtual void clearRect(const Common::Rect &r) const;
 	virtual void copyCurrentBitmap(byte *dest, uint32 size) const = 0;
 	virtual void copyCurrentPalette(byte *dest, int start, int num) const;
@@ -145,6 +146,7 @@ public:
 	void replaceCursor(const void *cursor, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor) override;
 	Common::Point getMousePos() const override;
 	void setMousePos(const Common::Point &pos) const override;
+	void setShakePos(int shakeXOffset, int shakeYOffset) const override;
 	void clearRect(const Common::Rect &r) const override;
 	static bool validateMode(Common::Platform p) { return (p == Common::kPlatformDOS) && checkDriver(_driverFiles, 2); }
 private:
@@ -165,6 +167,7 @@ public:
 	void replaceCursor(const void *cursor, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor) override;
 	Common::Point getMousePos() const override;
 	void setMousePos(const Common::Point &pos) const override;
+	void setShakePos(int shakeXOffset, int shakeYOffset) const override;
 	void clearRect(const Common::Rect &r) const override;
 	static bool validateMode(Common::Platform p) { return (p == Common::kPlatformDOS) && checkDriver(&_driverFile, 1); }
 private:
@@ -203,6 +206,7 @@ public:
 	void drawTextFontGlyph(const byte*, int, int, int, int, int, int, const PaletteMod*, const byte*) override; // Only for HiRes fonts. Not implemented here.
 	Common::Point getMousePos() const override;
 	void setMousePos(const Common::Point &pos) const override;
+	void setShakePos(int shakeXOffset, int shakeYOffset) const override;
 	void clearRect(const Common::Rect &r) const override;
 	bool supportsPalIntensity() const override { return false; }
 	bool driverBasedTextRendering() const override { return false; }
@@ -231,6 +235,7 @@ public:
 	void replaceCursor(const void *cursor, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor) override;
 	Common::Point getMousePos() const override;
 	void setMousePos(const Common::Point &pos) const override;
+	void setShakePos(int shakeXOffset, int shakeYOffset) const override;
 	void clearRect(const Common::Rect &r) const override;
 	void drawTextFontGlyph(const byte *src, int pitch, int hiresDestX, int hiresDestY, int hiresW, int hiresH, int transpColor, const PaletteMod *palMods, const byte *palModMapping) override; // For HiRes fonts. PC-98 versions bypass the video driver for this and render directly on top of the vram.
 	bool driverBasedTextRendering() const override { return true; }

--- a/engines/sci/graphics/screen.cpp
+++ b/engines/sci/graphics/screen.cpp
@@ -758,7 +758,7 @@ void GfxScreen::bitsRestoreDisplayScreen(Common::Rect rect, const byte *&memoryP
 
 void GfxScreen::setShakePos(uint16 shakeXOffset, uint16 shakeYOffset) {
 	if (!_upscaledHires)
-		g_system->setShakePos(shakeXOffset, shakeYOffset);
+		_gfxDrv->setShakePos(shakeXOffset, shakeYOffset);
 	else
 		g_system->setShakePos(_upscaledWidthMapping[shakeXOffset], _upscaledHeightMapping[shakeYOffset]);
 }


### PR DESCRIPTION
Currently the screen shakes will not be scaled to the driver's screen resolution. This patch fixes that.

Now, this isn't exactly the original behaviour. The screen shaking was a hardware feature that only EGA and VGA adapters had. Therefore, the screen shake function is only implemented in the drivers for these devices. For all other graphics hardware the drivers have an empty dummy function for the screen shake (at least from what I have seen). But we needn't be strict here, we can shake everything...
