### PR TITLE
MTROPOLIS: Promote three titles to Unstable

### DIFF
--- a/engines/mtropolis/detection_tables.h
+++ b/engines/mtropolis/detection_tables.h
@@ -1067,7 +1067,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 	  // Published by The Voyager Company, 1997
 		{
 			"architecture",
-			MetaEngineDetection::GAME_NOT_IMPLEMENTED,
+			"",
 			{
 				{ "MTPLAY95.EXE", 0, "0e513dac9d2a0d7cfcdc670cab2a9bda", 757760 },
 			 	{ "FWA1041.MPL", 0, "cb108fec620eff4108f194b1a730ec16", 50695771 },
@@ -1075,7 +1075,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 			},
 			Common::EN_ANY,
 			Common::kPlatformWindows,
-			ADGF_UNSUPPORTED,
+			ADGF_UNSTABLE,
 			GUIO0()
 		},
 		GID_ARCHITECTURE,
@@ -1087,7 +1087,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 	  // Published by Europress Software, 1997
 		{
 			"beatrix",
-			MetaEngineDetection::GAME_NOT_IMPLEMENTED,
+			"",
 			{
 				{ "POTTER95.EXE", 0, "0e513dac9d2a0d7cfcdc670cab2a9bda", 757760 },
 			 	{ "DATA.MPL", 0, "1dc4d2bf656ebb5a89e5f4a750a8cec0", 259660228 },
@@ -1095,7 +1095,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 			},
 			Common::EN_ANY,
 			Common::kPlatformWindows,
-			ADGF_UNSUPPORTED,
+			ADGF_UNSTABLE,
 			GUIO0()
 		},
 		GID_BEATRIX,
@@ -1115,7 +1115,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 			},
 			Common::EN_ANY,
 			Common::kPlatformWindows,
-			ADGF_UNSUPPORTED | ADGF_DEMO,
+			ADGF_UNSTABLE | ADGF_DEMO,
 			GUIO0()
 		},
 		GID_BEATRIX,
@@ -1459,7 +1459,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 	{ // How to Build a Telemedicine Program (English, Windows)
 		{
 			"telemed",
-			MetaEngineDetection::GAME_NOT_IMPLEMENTED,
+			"",
 			{
 		 		{ "TELEMED.EXE", 0, "0e513dac9d2a0d7cfcdc670cab2a9bda", 757760 },
 				{ "TELEMED.MPL", 0, "cd73ec482fb21508a34daeff6773623c", 44022984 },
@@ -1467,7 +1467,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 			},
 		 	Common::EN_ANY,
 		 	Common::kPlatformWindows,
-		 	ADGF_UNSUPPORTED,
+		 	ADGF_UNSTABLE,
 		 	GUIO0()
 		},
 	 	GID_TELEMED,


### PR DESCRIPTION
I would like to suggest to promote three mTropolis titles from Unsupported to Unstable. The mTropolis engine implementation is far enough that these titles can do something useful when run with ScummVM. 

### How to Build a Telemedicine Program 
HTBATP offers lectures on the titular subject which consist of audio talks combined with slide shows, but not actual video.
There is also a bit of general informational text to read.

<img width="647" alt="image" src="https://github.com/user-attachments/assets/98383da2-9de9-45ec-8755-e4d5c2a0bac8">
<img width="647" alt="image" src="https://github.com/user-attachments/assets/48c2c2ee-2ea4-46cb-a431-6f9a55f8856b">
<img width="647" alt="image" src="https://github.com/user-attachments/assets/4886a6d8-b7fe-4834-998d-81e0c0721839">
<img width="647" alt="image" src="https://github.com/user-attachments/assets/d60b9690-0a8b-43b2-b4fc-8ce43eda30a9">

#### Current State
ScummVM will play the audio lectures. But while the audio plays the app window freezes in the sense that it is not refreshed or repainted. When the lecture ends it unfreezes.

The text can be read.

### Fun With Architecture
FWA was originally a physical toy consisting of rubber stamps in various shapes that could be layed into buildings and printed onto paper with an inkpad. It also came with a booklet explaining some architectural design and offering templates/inspiration for the rubber stamps.

The CD version consists of a digital version of the booklet (I presume, as I haven't read the original) and a painting/construction activity based around shape-laying. Some of the example buildings from the book activity can be opened directly in the painting tool to be modified.

<img width="493" alt="image" src="https://github.com/user-attachments/assets/e32b05a5-6d99-4f44-bd59-94fe95f92400">

<img width="493" alt="image" src="https://github.com/user-attachments/assets/8b3b678a-c4b1-4b44-9aee-b35fff13cbb4">

#### Current State
The ebook can be read, but the rendering quality is very poor.

<img width="647" alt="image" src="https://github.com/user-attachments/assets/e3bb293e-20e1-4dff-85fa-b01731a3ba31">

The painting activity will open, but it cannot load pictures or let you place shapes.

### The Magic World of Beatrix Potter
Beatrix Potter was an author of children's books. This multimedia CD contains various content about Beatrix herself, her work and her tales.

#### Current State
We will break it down by each content item:
<img width="647" alt="image" src="https://github.com/user-attachments/assets/061c3a79-1aa6-4c00-8cc7-566105aada2c">

 - Family: Image gallery. Images do no show.
 - Photo Album: Image gallery with voiceover. Images do not show, voiceover plays.
 - Art: Image Gallery of paintings and other artwork by Beatrix, with voiceover explanations. Images and voiceover do work. 
<img width="647" alt="image" src="https://github.com/user-attachments/assets/104201b0-88af-4043-af0f-4b39ff631dd0">

 - 23 Tales: Tales by Beatrix in a shortened/summarized form, read aloud over a slideshow of illustrations. Also includes some background info on those tales. Slideshow images and voiceover do work. 
<img width="647" alt="image" src="https://github.com/user-attachments/assets/b06c4eac-ac71-4d9e-832e-99945534436d">

 - Miniature Letters: Letters to be found as collectibles within the other content. I think this is broken.
 - Tom Kitten Film: Animated short of one of the tales. Video playback works.
<img width="647" alt="image" src="https://github.com/user-attachments/assets/edee2a70-76f8-4a07-9d4c-12ddfbbaed4d">

 - Activities: Various activities to print out. Printing, or its lesser ScummVM implementation as saving to a file, does not work.
<img width="647" alt="image" src="https://github.com/user-attachments/assets/8ffbcecd-88c0-494a-888d-f74fe55b3626">

 - Games:
 
<img width="647" alt="image" src="https://github.com/user-attachments/assets/73e24a74-3cba-4550-a75b-7bb57598245e">

   - Mazes: Works with limitations. Minor graphical glitches, keyboard controls are partially broken, but mouse controls work.
 
<img width="647" alt="image" src="https://github.com/user-attachments/assets/f8ba7f1f-aea0-48e0-9a54-6d944d04b4db">

   - Dot-Dot: Broken 
 
<img width="647" alt="image" src="https://github.com/user-attachments/assets/6a6b94b6-3af4-4962-906c-0e1af75b3d4b">

<img width="647" alt="image" src="https://github.com/user-attachments/assets/d4a93b5c-6f59-4dda-994c-842f2e5ce4ef">

   - Jigsaw: Works, but behavior is glitchy
<img width="647" alt="image" src="https://github.com/user-attachments/assets/70a2a92c-8f34-4c76-8dc1-880a5520a1b1">

   - Colouring: Will error out because of unimplemented plugin data loading.
<img width="647" alt="image" src="https://github.com/user-attachments/assets/f8dec368-eb79-4b38-a617-3ab1b510e5a3">
