### PR TITLE
GUI: Fix leak in widgets/grid.cpp

### DIFF
--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -1070,8 +1070,7 @@ void GridWidget::reflowLayout() {
 		_platformIconsAlpha.clear();
 		_languageIconsAlpha.clear();
 		_extraIconsAlpha.clear();
-		if (_disabledIconOverlay)
-			_disabledIconOverlay->free();
+		delete _disabledIconOverlay;
 		reloadThumbnails();
 		loadFlagIcons();
 		loadPlatformIcons();
@@ -1080,10 +1079,7 @@ void GridWidget::reflowLayout() {
 		Graphics::ManagedSurface *gfx = new Graphics::ManagedSurface(_thumbnailWidth, _thumbnailHeight, g_system->getOverlayFormat());
 		uint32 disabledThumbnailColor = gfx->format.ARGBToColor(153, 0, 0, 0);  // 60% opacity black
 		gfx->fillRect(Common::Rect(0, 0, _thumbnailWidth, _thumbnailHeight), disabledThumbnailColor);
-		if (gfx)
-			_disabledIconOverlay = gfx;
-		else
-			_disabledIconOverlay = nullptr;
+		_disabledIconOverlay = gfx;
 	}
 
 	_trayHeight = kLineHeight * 3;


### PR DESCRIPTION
`_disabledIconOverlay`, a `ManagedSurface` regularly re-instantiated e.g. when the window is resized, should be deleted rather than merely have its `free()` method called.

While here, remove an if() which is guaranteed true lest scummvm segfault at `gfx->fillRect()`.

If I may I would ask @tag2015 for review.

Addresses `ERROR: LeakSanitizer: detected memory leaks`:
```
Direct leak of 224 byte(s) in 2 object(s) allocated from:
    #0 0x7f4c796b94c8 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x5562ef20fa29 in GUI::GridWidget::reflowLayout() gui/widgets/grid.cpp:1080
    #2 0x5562eef1c366 in GUI::Dialog::reflowLayout() gui/dialog.cpp:116
    #3 0x5562eef56ca3 in GUI::LauncherDialog::reflowLayout() gui/launcher.cpp:918
    #4 0x5562eef30a97 in GUI::GuiManager::screenChange() gui/gui-manager.cpp:829
    #5 0x5562eef30f18 in GUI::GuiManager::checkScreenChange() gui/gui-manager.cpp:806
[...]
Direct leak of 112 byte(s) in 1 object(s) allocated from:
    #0 0x7f4c796b94c8 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x5562ef20fa29 in GUI::GridWidget::reflowLayout() gui/widgets/grid.cpp:1080
    #2 0x5562eef1c366 in GUI::Dialog::reflowLayout() gui/dialog.cpp:116
    #3 0x5562eef56ca3 in GUI::LauncherDialog::reflowLayout() gui/launcher.cpp:918
    #4 0x5562eef31397 in GUI::GuiManager::openDialog(GUI::Dialog*) gui/gui-manager.cpp:747
[...]
Direct leak of 112 byte(s) in 1 object(s) allocated from:
    #0 0x7f4c796b94c8 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x5562ef20fa29 in GUI::GridWidget::reflowLayout() gui/widgets/grid.cpp:1080
    #2 0x5562eef1c366 in GUI::Dialog::reflowLayout() gui/dialog.cpp:116
    #3 0x5562eef56ca3 in GUI::LauncherDialog::reflowLayout() gui/launcher.cpp:918
    #4 0x5562eef30a97 in GUI::GuiManager::screenChange() gui/gui-manager.cpp:829
    #5 0x5562eef34632 in GUI::GuiManager::processEvent(Common::Event const&, GUI::Dialog*) gui/gui-manager.cpp:901
[...]
```
