### PR TITLE
SCUMM HE: BYB01 online play stat buffs fix

### DIFF
--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -636,6 +636,18 @@ void ScummEngine_v6::o6_eq() {
 
 // BACKYARD BASEBALL 2001 ONLINE CHANGES
 #if defined(USE_ENET) && defined(USE_LIBCURL)
+	// The player stat adjustments that should get applied in certain conditions (i.e. when two siblings are on the same team)
+	// don't get applied properly for the away (peer) team in online play. This results in each team's game using a different
+	// version of players' stats, leading to unfair play and potential desyncs. This hack ensures the away team's game doesn't
+	// exit the script before applying these stat adjustments.
+	if (_game.id == GID_BASEBALL2001 && _currentRoom == 27 && vm.slot[_currentScript].number == 2346) {
+		int offset = _scriptPointer - _scriptOrgPointer;
+		if (offset == 196137) {
+			push(0);
+			return;
+		}
+	}
+
 	if (ConfMan.getBool("enable_competitive_mods")) {
 		int pitchXValue = readVar(0x8000 + 11);
 		int pitchYValue = readVar(0x8000 + 12);


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
This PR fixes a bug in Backyard Baseball 2001 online play in which stat adjustments due to things like siblings being on the same team don't get applied correctly for the away team. This results in the two clients showing and using different versions of players' stats, which 1. is unfair and 2. could cause desyncs.

[Here's the script in question.](https://github.com/whatisaphone/baller/blob/756703108fbd3c34c612406f567cef908074a29f/scripts/27/lsc2346.scu#L4) By returning (`push`ing) 0 for that line, the script doesn't early-exit for the away team. I'm unsure why it was written like this originally.