### PR TITLE
MYST3: Fix incorrectly constructed sanity check

### DIFF
--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -1517,7 +1517,8 @@ Common::Error Myst3Engine::loadGameState(int slot) {
 	// Slots are assigned consecutively, starting from slot 1
 	// Get the Save List index for the selected slot
 	int listIndex = (slot == 0) ? slot : slot - 1;
-	if (!listIndex < filenames.size()) {
+	// Sanity check
+	if (listIndex >= filenames.size()) {
 		return Common::kReadingFailed;
 	}
 


### PR DESCRIPTION
Thanks to @eriktorbjorn  and @criezy for reviewing my code in [44fc331](https://github.com/scummvm/scummvm/commit/44fc3315a4461c1a98a50b53f333ccb182034dfa), and identifying that my sanity check isn't properly constructed, and for providing the correct solution.

 