### PR TITLE
SCUMM: GUI (v0-3, v8): Prevent users from overwriting autosave slot

### DIFF
--- a/engines/scumm/gfx_gui.cpp
+++ b/engines/scumm/gfx_gui.cpp
@@ -2220,18 +2220,18 @@ void ScummEngine::fillSavegameLabels() {
 
 	_savegameNames.clear();
 
-	for (int i = 0; i < 9; i++) {
+	for (int i = GUI_CTRL_FIRST_SG; i <= GUI_CTRL_LAST_SG; i++) {
 		curSaveSlot = i + (isLoomVga ? _firstSaveStateOfList : _curDisplayedSaveSlotPage * 9);
-		if (_game.version > 4 || (_game.version == 4 && _game.id == GID_LOOM)) {
+		if (_game.version > 4 || isLoomVga) {
 			if (availSaves[curSaveSlot]) {
 				if (getSavegameName(curSaveSlot, name)) {
-					_savegameNames.push_back(Common::String::format("%2d. %s", curSaveSlot + 1, name.c_str()));
+					_savegameNames.push_back(Common::String::format("%2d. %s", curSaveSlot, name.c_str()));
 				} else {
 					// The original printed "WARNING... old savegame", but we do support old savegames :-)
-					_savegameNames.push_back(Common::String::format("%2d. WARNING: wrong save version", curSaveSlot + 1));
+					_savegameNames.push_back(Common::String::format("%2d. WARNING: wrong save version", curSaveSlot));
 				}
 			} else {
-				_savegameNames.push_back(Common::String::format("%2d. ", curSaveSlot + 1));
+				_savegameNames.push_back(Common::String::format("%2d. ", curSaveSlot));
 			}
 		} else {
 			if (availSaves[curSaveSlot]) {
@@ -2853,7 +2853,7 @@ bool ScummEngine::executeMainMenuOperation(int op, int mouseX, int mouseY, bool 
 					// Temporarily restore the shake effect to save it...
 					setShake(_shakeTempSavedState);
 
-					if (saveState(curSlot - 1, false, dummyString)) {
+					if (saveState(curSlot, false, dummyString)) {
 						setShake(0);
 						saveCursorPreMenu();
 						_saveScriptParam = GAME_PROPER_SAVE;
@@ -2915,7 +2915,7 @@ bool ScummEngine::executeMainMenuOperation(int op, int mouseX, int mouseY, bool 
 				}
 
 				curSlot = _mainMenuSavegameLabel + (isLoomVga ? _firstSaveStateOfList : _curDisplayedSaveSlotPage * 9);
-				if (loadState(curSlot - 1, false)) {
+				if (loadState(curSlot, false)) {
 					hasLoadedState = true;
 
 #ifdef ENABLE_SCUMM_7_8

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -724,8 +724,7 @@ static const ExtraGuiOption audioOverride {
 static const ExtraGuiOption enableOriginalGUI = {
 	_s("Enable the original GUI and Menu"),
 	_s("Allow the game to use the in-engine graphical interface and the original save/load menu. \
-		Use it together with the \"Ask for confirmation on exit\" for a more complete experience. \
-		Autosaving is disabled when this mode is active."),
+		Use it together with the \"Ask for confirmation on exit\" for a more complete experience."),
 	"original_gui",
 	true,
 	0,

--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -139,10 +139,6 @@ bool ScummEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 }
 
 Common::Error ScummEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
-	// Disable autosaving if the original GUI is in place
-	if (isAutosave && isUsingOriginalGUI())
-		return Common::kNoError;
-
 	requestSave(slot, desc);
 	return Common::kNoError;
 }

--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -219,9 +219,6 @@ bool ScummEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return (VAR_MAINMENU_KEY == 0xFF || (VAR(VAR_MAINMENU_KEY) != 0 && _currentRoom != 0)) && !isOriginalMenuActive;
 }
 
-bool ScummEngine::canSaveAutosaveCurrently() {
-	return !isUsingOriginalGUI();
-}
 
 void ScummEngine::requestSave(int slot, const Common::String &name) {
 	_saveLoadSlot = slot;

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -594,7 +594,6 @@ public:
 	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override;
-	bool canSaveAutosaveCurrently() override;
 
 	void pauseEngineIntern(bool pause) override;
 


### PR DESCRIPTION
### What's this?
This is my best bet at fixing the collision between autosaves and savestates made on slot 0 on original menus.
Quoting myself from a comment in this PR:

> In ScummVM 2.7.0, original GUI support was added.
> Unfortunately it came with an issue: in v4-7 games users could
> overwrite autosaves (slot 0). Why? Because I forgot about autosaves :-)
> 
> To amend this from 2.9.0 onwards we check for savegames which are on slot 0
> and are not autosaves (the heuristic is not optimal, but it will have to do),
> and performs a mass rename. Unless the user has used all 99 slots, in which case
> we just bail because there's no easy way to fix that...

Emphasis on "the heuristic is not optimal, but it will have to do": we have no means to see if a savegame is an actual autosave, we can only use its name, which is a translated string anyway.

Furthermore I applied a fix to v4-7 menus, to only show, save, and load onto slots from 1 to 99. 
Previously we also showed slot 0, allowing the user to overwrite the autosave slot.

### Why are you removing the ability for at least loading an autosave from the original menus? 
Because unaffected games (v0-3, v8), using script based menus, already did the correct thing, which is only showing and making available only slots from 1 onwards. We now guarantee consistency across all LEC SCUMM games.
Also, I'm not going to hack scripts to make another slot for autosaves show up on the screen...

This should address https://bugs.scummvm.org/ticket/15063 properly.

