### PR TITLE
MTROPOLIS: declare Star Trek: The Game Show demo as unsupported

### DIFF
--- a/engines/mtropolis/detection_tables.h
+++ b/engines/mtropolis/detection_tables.h
@@ -974,7 +974,7 @@ static const MTropolisGameDescription gameDescriptions[] = {
 			},
 			Common::EN_ANY,
 			Common::kPlatformWindows,
-			ADGF_DEMO | ADGF_UNSTABLE,
+			ADGF_DEMO | ADGF_UNSUPPORTED,
 			GUIO0()
 		},
 		GID_STTGS,


### PR DESCRIPTION
After the criteria for a game's status were clarified in PR #6128, Star Trek: The Game Show demo should be demoted from unstable to unsupported.

After the start screen, STTGS demo runs into an error about being unable to load a data object of the unknown type 0xc5.
So while it can boot, it cannot do anything useful.

The retail version of STTGS suffers the exact same error, but is already listed as unsupported.