### PR TITLE
AGS: Remove unused case sensitive file system code

### DIFF
--- a/engines/ags/shared/core/platform.h
+++ b/engines/ags/shared/core/platform.h
@@ -129,14 +129,6 @@ namespace AGS3 {
 #error "No endianness defined"
 #endif
 
-#if defined(_DEBUG)
-#define AGS_PLATFORM_DEBUG  (1)
-#elif ! defined(NDEBUG)
-#define AGS_PLATFORM_DEBUG  (1)
-#else
-#define AGS_PLATFORM_DEBUG  (0)
-#endif
-
 #define AGS_PLATFORM_DESKTOP ((AGS_PLATFORM_OS_WINDOWS) || (AGS_PLATFORM_OS_LINUX) || (AGS_PLATFORM_OS_MACOS))
 
 #define AGS_PLATFORM_MOBILE ((AGS_PLATFORM_OS_ANDROID) || (AGS_PLATFORM_OS_IOS))

--- a/engines/ags/shared/util/file.cpp
+++ b/engines/ags/shared/util/file.cpp
@@ -172,93 +172,11 @@ Stream *File::OpenStderr() {
 }
 
 String File::FindFileCI(const String &dir_name, const String &file_name) {
-#if !defined (AGS_CASE_SENSITIVE_FILESYSTEM)
-	// Simply concat dir and filename paths
 	return Path::ConcatPaths(dir_name, file_name);
-#else
-	// Case insensitive file find - on case sensitive filesystems
-	//
-	// TODO: still not covered: a situation when the file_name contains
-	// nested path -and- the case of at least one path parts does not match
-	// (with all matching case the file will be found by an early check).
-	//
-	struct stat   statbuf;
-	struct dirent *entry = nullptr;
-
-	if (dir_name.IsEmpty() && file_name.IsEmpty())
-		return nullptr;
-
-	String directory;
-	String filename;
-	String buf;
-
-	if (!dir_name.IsEmpty()) {
-		directory = dir_name;
-		Path::FixupPath(directory);
-	}
-	if (!file_name.IsEmpty()) {
-		filename = file_name;
-		Path::FixupPath(filename);
-	}
-
-	if (!filename.IsEmpty()) {
-		// TODO: move this case to ConcatPaths too?
-		if (directory.IsEmpty() && filename[0] == '/')
-			buf = filename;
-		else
-			buf = Path::ConcatPaths(directory.IsEmpty() ? "." : directory, filename);
-
-		if (lstat(buf.GetCStr(), &statbuf) == 0 &&
-			(S_ISREG(statbuf.st_mode) || S_ISLNK(statbuf.st_mode))) {
-			return buf;
-		}
-	}
-
-	if (directory.IsEmpty()) {
-		String match = Path::GetFilename(filename);
-		if (match.IsEmpty())
-			return nullptr;
-		directory = Path::GetParent(filename);
-		filename = match;
-	}
-
-	DIR *rough = nullptr;
-	if ((rough = opendir(directory.GetCStr())) == nullptr) {
-		fprintf(stderr, "ci_find_file: cannot open directory: %s\n", directory.GetCStr());
-		return nullptr;
-	}
-
-	String diamond;
-	while ((entry = readdir(rough)) != nullptr) {
-		if (strcasecmp(filename.GetCStr(), entry->d_name) == 0) {
-			if (lstat(entry->d_name, &statbuf) == 0 &&
-				(S_ISREG(statbuf.st_mode) || S_ISLNK(statbuf.st_mode))) {
-#if AGS_PLATFORM_DEBUG
-				fprintf(stderr, "ci_find_file: Looked for %s in rough %s, found diamond %s.\n",
-					filename.GetCStr(), directory.GetCStr(), entry->d_name);
-#endif // AGS_PLATFORM_DEBUG
-				diamond = Path::ConcatPaths(directory, entry->d_name);
-				break;
-			}
-		}
-	}
-	closedir(rough);
-	return diamond;
-#endif
 }
 
 Stream *File::OpenFileCI(const String &file_name, FileOpenMode open_mode, FileWorkMode work_mode) {
-#if !defined (AGS_CASE_SENSITIVE_FILESYSTEM)
 	return File::OpenFile(file_name, open_mode, work_mode);
-#else
-	String fullpath = FindFileCI(nullptr, file_name);
-	if (!fullpath.IsEmpty())
-		return File::OpenFile(fullpath, open_mode, work_mode);
-	// If the file was not found, and it's Create mode, then open new file
-	if (open_mode != kFile_Open)
-		return File::OpenFile(file_name, open_mode, work_mode);
-	return nullptr;
-#endif
 }
 
 Stream *File::OpenFile(const String &filename, soff_t start_off, soff_t end_off) {

--- a/engines/ags/shared/util/path.cpp
+++ b/engines/ags/shared/util/path.cpp
@@ -81,11 +81,7 @@ int ComparePaths(const String &path1, const String &path2) {
 	fixed_path2.TrimRight('/');
 
 	int cmp_result =
-#if defined AGS_CASE_SENSITIVE_FILESYSTEM
-	    fixed_path1.Compare(fixed_path2);
-#else
 	    fixed_path1.CompareNoCase(fixed_path2);
-#endif // AGS_CASE_SENSITIVE_FILESYSTEM
 	return cmp_result;
 }
 

--- a/engines/ags/shared/util/string.h
+++ b/engines/ags/shared/util/string.h
@@ -94,7 +94,7 @@ public:
 	// Tells if the string is either empty or has only whitespace characters
 	bool IsNullOrSpace() const;
 
-	// Those getters are for tests only, hence if AGS_PLATFORM_DEBUG
+	// Those getters are for tests only, hence if AGS_PLATFORM_TEST
 #if defined(AGS_PLATFORM_TEST) && AGS_PLATFORM_TEST
 	inline const char *GetBuffer() const {
 		return _buf;


### PR DESCRIPTION
Since we're using our common file system code, this functionality does not apply for ScummVM. The defines for this code were never set, so it's definitely unneeded.

This also allows us to remove a case of the NDEBUG define
