### PR TITLE
MTROPOLIS: workaround for window freezing in HTBATP

### DIFF
--- a/engines/mtropolis/elements.cpp
+++ b/engines/mtropolis/elements.cpp
@@ -847,8 +847,10 @@ void MovieElement::playMedia(Runtime *runtime, Project *project) {
 		uint32 maxTS = realRange.max;
 		uint32 targetTS = _currentTimestamp;
 
+		bool playInBackgroundHack = runtime->getHacks().telemedMoviePlaybackInBackground;
+
 		int framesDecodedThisFrame = 0;
-		if (_currentPlayState == kMediaStatePlaying) {
+		if (_currentPlayState == kMediaStatePlaying && !playInBackgroundHack) {
 			while (_videoDecoder->needsUpdate()) {
 				if (_playEveryFrame && framesDecodedThisFrame > 0)
 					break;

--- a/engines/mtropolis/hacks.cpp
+++ b/engines/mtropolis/hacks.cpp
@@ -1140,11 +1140,11 @@ void addMTIQuirks(const MTropolisGameDescription &desc, Hacks &hacks) {
 }
 
 void addTelemedQuirks(const MTropolisGameDescription &desc, Hacks &hacks) {
-	//How To Build A Telemedicine Program wants to play MOV files in the background that are only audio, not video.
-	//The engine implementation will try to play the entire media file during the rendering of a single frame.
-	//Thus, the window freezes, is not repainted/refreshed while the media plays and unfreezes when it finishes.
-	//But the media files in question are between eight and forty minutes long.
-	//As a cheap workaround, media video frame decoding is disabled for this title.
+	// How To Build A Telemedicine Program wants to play MOV files in the background that are only audio, not video.
+	// The engine implementation will try to play the entire media file during the rendering of a single frame.
+	// Thus, the window freezes, is not repainted/refreshed while the media plays and unfreezes when it finishes.
+	// But the media files in question are between eight and forty minutes long.
+	// As a cheap workaround, media video frame decoding is disabled for this title.
 
 	hacks.telemedMoviePlaybackInBackground = true;
 }

--- a/engines/mtropolis/hacks.cpp
+++ b/engines/mtropolis/hacks.cpp
@@ -46,6 +46,7 @@ Hacks::Hacks() {
 	mtiSceneReturnHack = false;
 	mtiHispaniolaDamagedStringHack = false;
 	ignoreSceneUnloads = false;
+	telemedMoviePlaybackInBackground = false;
 }
 
 Hacks::~Hacks() {
@@ -1136,6 +1137,16 @@ void addMTIQuirks(const MTropolisGameDescription &desc, Hacks &hacks) {
 
 	hacks.defaultStructuralHooks.reset(new MTIStructuralHooks(molassesHandler));
 	hacks.addSceneTransitionHooks(Common::SharedPtr<SceneTransitionHooks>(new MTIMolassesSceneTransitionHooks(molassesHandler)));
+}
+
+void addTelemedQuirks(const MTropolisGameDescription &desc, Hacks &hacks) {
+	//How To Build A Telemedicine Program wants to play MOV files in the background that are only audio, not video.
+	//The engine implementation will try to play the entire media file during the rendering of a single frame.
+	//Thus, the window freezes, is not repainted/refreshed while the media plays and unfreezes when it finishes.
+	//But the media files in question are between eight and forty minutes long.
+	//As a cheap workaround, media video frame decoding is disabled for this title.
+
+	hacks.telemedMoviePlaybackInBackground = true;
 }
 
 } // End of namespace HackSuites

--- a/engines/mtropolis/hacks.h
+++ b/engines/mtropolis/hacks.h
@@ -55,6 +55,7 @@ struct Hacks {
 	bool mtiVariableReferencesHack;
 	bool mtiSceneReturnHack;
 	bool mtiHispaniolaDamagedStringHack;
+	bool telemedMoviePlaybackInBackground;
 
 	bool ignoreSceneUnloads;
 
@@ -83,6 +84,8 @@ void addObsidianSaveMechanism(const MTropolisGameDescription &desc, Hacks &hacks
 void addObsidianImprovedWidescreen(const MTropolisGameDescription &desc, Hacks &hacks);
 
 void addMTIQuirks(const MTropolisGameDescription &desc, Hacks &hacks);
+
+void addTelemedQuirks(const MTropolisGameDescription &desc, Hacks &hacks);
 
 } // End of namespace HackSuites
 

--- a/engines/mtropolis/mtropolis.cpp
+++ b/engines/mtropolis/mtropolis.cpp
@@ -332,6 +332,8 @@ Common::Error MTropolisEngine::run() {
 		Palette pal;
 		pal.initDefaultPalette(2);
 		_runtime->setGlobalPalette(pal);
+	} else if (_gameDescription->gameID == GID_TELEMED) {
+		HackSuites::addTelemedQuirks(*_gameDescription, _runtime->getHacks());
 	}
 
 


### PR DESCRIPTION
How To Build A Telemedicine Program (HTBATP) wants to play MOV files in the background that contain only audio, not video. A quick check with FFMPEG confirms that there is no video track. (In context, the audio is accompanied by a slideshow.)

The engine implementation will try to play the entire media file during the rendering of a single frame. Thus, the window freezes, is not repainted/refreshed while the media plays and unfreezes when it finishes. But the media files are between eight and forty minutes long - obviously an unacceptable amount of time for unresponsiveness.

As a cheap workaround, media video frame decoding is disabled for HTBATP using the hack subsystem of the engine implementation.