### PR TITLE
MTROPOLIS: Handle videos that have no video frames

### DIFF
--- a/engines/mtropolis/elements.cpp
+++ b/engines/mtropolis/elements.cpp
@@ -846,10 +846,11 @@ void MovieElement::playMedia(Runtime *runtime, Project *project) {
 		uint32 minTS = realRange.min;
 		uint32 maxTS = realRange.max;
 		uint32 targetTS = _currentTimestamp;
+		const bool hasFrames = _videoDecoder->getFrameCount() > 0;
 
 		int framesDecodedThisFrame = 0;
 		if (_currentPlayState == kMediaStatePlaying) {
-			while (_videoDecoder->needsUpdate()) {
+			while (_videoDecoder->needsUpdate() && hasFrames) {
 				if (_playEveryFrame && framesDecodedThisFrame > 0)
 					break;
 


### PR DESCRIPTION
In How To Build A Telemedicine Program, all the video files have no video frames, and contain only audio. In this case, the QT player will keep playing the video until the audio is finished. Handle such cases, so that the game's UI is responsive

