### PR TITLE
BACKENDS: FS: Atomic write of files

### DIFF
--- a/backends/fs/posix-drives/posix-drives-fs.cpp
+++ b/backends/fs/posix-drives/posix-drives-fs.cpp
@@ -69,7 +69,7 @@ void DrivePOSIXFilesystemNode::configureStream(StdioStream *stream) {
 }
 
 Common::SeekableReadStream *DrivePOSIXFilesystemNode::createReadStream() {
-	PosixIoStream *readStream = PosixIoStream::makeFromPath(getPath(), false);
+	StdioStream *readStream = PosixIoStream::makeFromPath(getPath(), false);
 
 	configureStream(readStream);
 
@@ -82,7 +82,7 @@ Common::SeekableReadStream *DrivePOSIXFilesystemNode::createReadStream() {
 }
 
 Common::SeekableWriteStream *DrivePOSIXFilesystemNode::createWriteStream() {
-	PosixIoStream *writeStream = PosixIoStream::makeFromPath(getPath(), true);
+	StdioStream *writeStream = PosixIoStream::makeFromPath(getPath(), true);
 
 	configureStream(writeStream);
 

--- a/backends/fs/posix/posix-iostream.cpp
+++ b/backends/fs/posix/posix-iostream.cpp
@@ -25,20 +25,6 @@
 
 #include <sys/stat.h>
 
-PosixIoStream *PosixIoStream::makeFromPath(const Common::String &path, bool writeMode) {
-#if defined(HAS_FOPEN64)
-	FILE *handle = fopen64(path.c_str(), writeMode ? "wb" : "rb");
-#else
-	FILE *handle = fopen(path.c_str(), writeMode ? "wb" : "rb");
-#endif
-
-	if (handle)
-		return new PosixIoStream(handle);
-
-	return nullptr;
-}
-
-
 PosixIoStream::PosixIoStream(void *handle) :
 		StdioStream(handle) {
 }

--- a/backends/fs/posix/posix-iostream.h
+++ b/backends/fs/posix/posix-iostream.h
@@ -29,7 +29,11 @@
  */
 class PosixIoStream final : public StdioStream {
 public:
-	static PosixIoStream *makeFromPath(const Common::String &path, bool writeMode);
+	static StdioStream *makeFromPath(const Common::String &path, bool writeMode) {
+		return StdioStream::makeFromPathHelper(path, writeMode, [](void *handle) -> StdioStream * {
+			return new PosixIoStream(handle);
+		});
+	}
 	PosixIoStream(void *handle);
 
 	int64 size() const override;

--- a/backends/fs/stdiostream.cpp
+++ b/backends/fs/stdiostream.cpp
@@ -124,7 +124,8 @@ bool StdioStream::flush() {
 	return fflush((FILE *)_handle) == 0;
 }
 
-StdioStream *StdioStream::makeFromPath(const Common::String &path, bool writeMode) {
+StdioStream *StdioStream::makeFromPathHelper(const Common::String &path, bool writeMode,
+		StdioStream *(*factory)(void *handle)) {
 #if defined(WIN32) && defined(UNICODE)
 	wchar_t *wPath = Win32::stringToTchar(path);
 	FILE *handle = _wfopen(wPath, writeMode ? L"wb" : L"rb");
@@ -136,7 +137,7 @@ StdioStream *StdioStream::makeFromPath(const Common::String &path, bool writeMod
 #endif
 
 	if (handle)
-		return new StdioStream(handle);
+		return new factory(handle);
 	return nullptr;
 }
 

--- a/backends/fs/stdiostream.h
+++ b/backends/fs/stdiostream.h
@@ -32,12 +32,19 @@ protected:
 	/** File handle to the actual file. */
 	void *_handle;
 
+	static StdioStream *makeFromPathHelper(const Common::String &path, bool writeMode,
+			StdioStream *(*factory)(void *handle));
+
 public:
 	/**
 	 * Given a path, invokes fopen on that path and wrap the result in a
 	 * StdioStream instance.
 	 */
-	static StdioStream *makeFromPath(const Common::String &path, bool writeMode);
+	static StdioStream *makeFromPath(const Common::String &path, bool writeMode) {
+		return makeFromPathHelper(path, writeMode, [](void *handle) {
+			return new StdioStream(handle);
+		});
+	}
 
 	StdioStream(void *handle);
 	~StdioStream() override;

--- a/backends/fs/stdiostream.h
+++ b/backends/fs/stdiostream.h
@@ -31,6 +31,7 @@ class StdioStream : public Common::SeekableReadStream, public Common::SeekableWr
 protected:
 	/** File handle to the actual file. */
 	void *_handle;
+	Common::String *_path;
 
 	static StdioStream *makeFromPathHelper(const Common::String &path, bool writeMode,
 			StdioStream *(*factory)(void *handle));

--- a/backends/log/log.cpp
+++ b/backends/log/log.cpp
@@ -56,8 +56,11 @@ void Log::close() {
 		// Output a message to indicate that the log was closed successfully
 		print("--- Log closed successfully.\n");
 
-		delete _stream;
+		// This avoids a segfault if a warning is issued when deleting the stream
+		Common::WriteStream *stream = _stream;
 		_stream = nullptr;
+
+		delete stream;
 	}
 }
 


### PR DESCRIPTION
A temporary file is used to write the data and the file is renamed when it is closed.
The string containing the destination path is a stored as a pointer to limit the size of the object (which is already doubled) as in majority of the streams the path will never be used.

This implementation is done in StdioStream to cover most of the backends.
The PosixIoStream code is adapted to avoid code duplication.

This should fix problems of configuration file corruptions which can happen on mobile platforms ~or on concurrent writes~.
EDIT: concurrent writes are not fixed as we use the same file in both processes.
Customizing using the PID would help but in case of a crash it would leave a dangling file which would be never cleaned up.