### PR TITLE
GUI: Fix clicking on PopUpDialog separator

### DIFF
--- a/gui/widgets/popup.cpp
+++ b/gui/widgets/popup.cpp
@@ -162,6 +162,12 @@ void PopUpDialog::handleMouseUp(int x, int y, int button, int clickCount) {
 	int dist = (_clickX - absX) * (_clickX - absX) + (_clickY - absY) * (_clickY - absY);
 	if (dist > 3 * 3 || g_system->getMillis() - _openTime > 300) {
 		int item = findItem(x, y);
+
+		// treat separator item as if no item was clicked
+		if (item >= 0 && _entries[item].size() == 0) {
+			item = -1;
+		}
+
 		setResult(item);
 		close();
 	}
@@ -181,6 +187,7 @@ void PopUpDialog::handleMouseMoved(int x, int y, int button) {
 	// Compute over which item the mouse is...
 	int item = findItem(x, y);
 
+	// treat separator item as if no item was moused over
 	if (item >= 0 && _entries[item].size() == 0)
 		item = -1;
 


### PR DESCRIPTION
Fixes a regression introduced five years ago, where clicking on a separator in a `PopUpDialog` causes an empty selection instead of the real item that's selected.

`PopUpDialog::handleMouseMoved` has the correct logic to handle separator items, but `handleMouseUp` didn't.

![one](https://github.com/user-attachments/assets/b03e4329-8785-47ff-8975-81509d6a1c19)

![two](https://github.com/user-attachments/assets/ad81dcc2-15bf-4cd0-876b-2b7f5121b71e)
