### PR TITLE
GLK: ADVSYS: Fix verb parsing

### DIFF
--- a/engines/glk/advsys/game.cpp
+++ b/engines/glk/advsys/game.cpp
@@ -176,7 +176,7 @@ void Game::loadGameData(Common::ReadStream &rs) {
 
 int Game::findWord(const Common::String &word) const {
 	// Limit the word to the maximum allowable size
-	Common::String w(word.c_str(), word.c_str() + WORD_SIZE);
+	Common::String w(word.c_str(), MIN(word.size(), (uint)WORD_SIZE));
 
 	// Iterate over the dictionary for the word
 	for (int idx = 1; idx <= _wordCount; ++idx) {


### PR DESCRIPTION
Previously Game::findWord() assumed words of fixed length (6)

Games like "one hand" and "pirating" failed to parse correctly most verbs, because the code would only work with words of the max length (6). The issue was mentioned on the ScummVM forums here: https://forums.scummvm.org/viewtopic.php?p=99918#p99918


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
