### PR TITLE
BACKENDS: Add ImGui support to SurfaceSdlGraphicsManager

### DIFF
--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -513,10 +513,6 @@ void SdlGraphicsManager::initImGui(void *glContext) {
 	assert(!_imGuiReady);
 	_imGuiInited = false;
 
-	if (!glContext) {
-		return;
-	}
-
 	IMGUI_CHECKVERSION();
 	if (!ImGui::CreateContext()) {
 		return;

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -923,6 +923,11 @@ void SurfaceSdlGraphicsManager::initGraphicsSurface() {
 	_isDoubleBuf = flags & SDL_DOUBLEBUF;
 	_isHwPalette = flags & SDL_HWPALETTE;
 #endif
+
+#if defined(USE_IMGUI) && SDL_VERSION_ATLEAST(2, 0, 0)
+	// Setup Dear ImGui
+	initImGui(nullptr);
+#endif
 }
 
 bool SurfaceSdlGraphicsManager::loadGFXMode() {
@@ -1526,6 +1531,11 @@ void SurfaceSdlGraphicsManager::internUpdateScreen() {
 	_numDirtyRects = 0;
 	_forceRedraw = false;
 	_cursorNeedsRedraw = false;
+
+#if defined(USE_IMGUI) && SDL_VERSION_ATLEAST(2, 0, 0)
+	renderImGui();
+#endif
+
 #if !SDL_VERSION_ATLEAST(2, 0, 0)
 	if (_isDoubleBuf)
 		SDL_Flip(_hwScreen);
@@ -2801,6 +2811,10 @@ void SurfaceSdlGraphicsManager::notifyResize(const int width, const int height) 
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 void SurfaceSdlGraphicsManager::deinitializeRenderer() {
+#ifdef USE_IMGUI
+	destroyImGui();
+#endif
+
 	if (_screenTexture)
 		SDL_DestroyTexture(_screenTexture);
 	_screenTexture = nullptr;


### PR DESCRIPTION
This PR adds ImGui support to SdlSurfaceGraphicsMgr, in a similar fashion as other backends. It was tested using "Appartment 3" when ScummVM is launched with "--debugflags=imgui". The base SdlGraphicsMgr class was changed to accept a nullptr glContext which in turns calls ImGui_ImplSDL2_InitForOpenGL with a null context. The internal implementation of ImGui_ImplSDL2_InitForOpenGL allows for this situation, essentially falling back to the appropriate path for us.