### PR TITLE
IOS7: Add Apple Pencil Input Support

### DIFF
--- a/backends/platform/ios7/ios7_touch_controller.mm
+++ b/backends/platform/ios7/ios7_touch_controller.mm
@@ -49,10 +49,7 @@
 	// they are required as the Apple TV remote sends touh events
 	// but no mouse events.
 #if TARGET_OS_IOS
-	if (touch.type == UITouchTypePencil) {
-		return YES;
-	}
-	return touch != nil && touch.type == UITouchTypeDirect;
+	return touch != nil && (touch.type == UITouchTypeDirect || touch.type == UITouchTypePencil);
 #else
 	return YES;
 #endif

--- a/backends/platform/ios7/ios7_touch_controller.mm
+++ b/backends/platform/ios7/ios7_touch_controller.mm
@@ -49,6 +49,9 @@
 	// they are required as the Apple TV remote sends touh events
 	// but no mouse events.
 #if TARGET_OS_IOS
+	if (touch.type == UITouchTypePencil) {
+		return YES;
+	}
 	return touch != nil && touch.type == UITouchTypeDirect;
 #else
 	return YES;

--- a/backends/platform/ios7/ios7_video.h
+++ b/backends/platform/ios7/ios7_video.h
@@ -63,6 +63,8 @@ uint getSizeNextPOT(uint size);
 
 @property (nonatomic, assign) BOOL isInGame;
 @property (nonatomic, assign) UIInterfaceOrientationMask supportedScreenOrientations;
+@property (nonatomic) NSTimeInterval pencilTouchGestureStartTime;
+@property (nonatomic) BOOL isLongPencilTouch;
 
 - (id)initWithFrame:(struct CGRect)frame;
 

--- a/backends/platform/ios7/ios7_video.h
+++ b/backends/platform/ios7/ios7_video.h
@@ -63,8 +63,6 @@ uint getSizeNextPOT(uint size);
 
 @property (nonatomic, assign) BOOL isInGame;
 @property (nonatomic, assign) UIInterfaceOrientationMask supportedScreenOrientations;
-@property (nonatomic) NSTimeInterval pencilTouchGestureStartTime;
-@property (nonatomic) BOOL isLongPencilTouch;
 
 - (id)initWithFrame:(struct CGRect)frame;
 

--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -88,10 +88,10 @@ bool iOS7_fetchEvent(InternalEvent *event) {
 	UIButton *_toggleTouchModeButton;
 	UITapGestureRecognizer *oneFingerTapGesture;
 	UITapGestureRecognizer *twoFingerTapGesture;
+	UITapGestureRecognizer *pencilThreeTapGesture;
 	UILongPressGestureRecognizer *oneFingerLongPressGesture;
 	UILongPressGestureRecognizer *twoFingerLongPressGesture;
-	UILongPressGestureRecognizer *pencilTouchGesture;
-	UILongPressGestureRecognizer *pencilThreeTapTouchGesture;
+	UILongPressGestureRecognizer *pencilTwoTapLongTouchGesture;
 	CGPoint touchesBegan;
 #endif
 }
@@ -203,7 +203,7 @@ bool iOS7_fetchEvent(InternalEvent *event) {
 	oneFingerTapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(oneFingerTap:)];
 	[oneFingerTapGesture setNumberOfTapsRequired:1];
 	[oneFingerTapGesture setNumberOfTouchesRequired:1];
-	[oneFingerTapGesture setAllowedTouchTypes:@[@(UITouchTypeDirect)]];
+	[oneFingerTapGesture setAllowedTouchTypes:@[@(UITouchTypeDirect),@(UITouchTypePencil)]];
 	[oneFingerTapGesture setDelaysTouchesBegan:NO];
 	[oneFingerTapGesture setDelaysTouchesEnded:NO];
 
@@ -213,11 +213,18 @@ bool iOS7_fetchEvent(InternalEvent *event) {
 	[twoFingerTapGesture setAllowedTouchTypes:@[@(UITouchTypeDirect)]];
 	[twoFingerTapGesture setDelaysTouchesBegan:NO];
 	[twoFingerTapGesture setDelaysTouchesEnded:NO];
+	
+	pencilThreeTapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(pencilThreeTap:)];
+	[pencilThreeTapGesture setNumberOfTapsRequired:3];
+	[pencilThreeTapGesture setNumberOfTouchesRequired:1];
+	[pencilThreeTapGesture setAllowedTouchTypes:@[@(UITouchTypePencil)]];
+	[pencilThreeTapGesture setDelaysTouchesBegan:NO];
+	[pencilThreeTapGesture setDelaysTouchesEnded:NO];
 
 	// Default long press duration is 0.5 seconds which suits us well
 	oneFingerLongPressGesture = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(oneFingerLongPress:)];
 	[oneFingerLongPressGesture setNumberOfTouchesRequired:1];
-	[oneFingerLongPressGesture setAllowedTouchTypes:@[@(UITouchTypeDirect)]];
+	[oneFingerLongPressGesture setAllowedTouchTypes:@[@(UITouchTypeDirect),@(UITouchTypePencil)]];
 	[oneFingerLongPressGesture setDelaysTouchesBegan:NO];
 	[oneFingerLongPressGesture setDelaysTouchesEnded:NO];
 	[oneFingerLongPressGesture setCancelsTouchesInView:NO];
@@ -231,22 +238,14 @@ bool iOS7_fetchEvent(InternalEvent *event) {
 	[twoFingerLongPressGesture setCancelsTouchesInView:NO];
 	[twoFingerLongPressGesture canPreventGestureRecognizer:twoFingerTapGesture];
 	
-	pencilTouchGesture = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(pencilTouch:)];
-	[pencilTouchGesture setNumberOfTouchesRequired:1];
-	[pencilTouchGesture setAllowedTouchTypes:@[@(UITouchTypePencil)]];
-	[pencilTouchGesture setMinimumPressDuration:0];
-	[pencilTouchGesture setDelaysTouchesBegan:NO];
-	[pencilTouchGesture setDelaysTouchesEnded:NO];
-	[pencilTouchGesture setCancelsTouchesInView:NO];
-	
-	pencilThreeTapTouchGesture = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(pencilThreeTapTouch:)];
-	[pencilThreeTapTouchGesture setNumberOfTouchesRequired:1];
-	[pencilThreeTapTouchGesture setNumberOfTapsRequired:2];
-	[pencilThreeTapTouchGesture setAllowedTouchTypes:@[@(UITouchTypePencil)]];
-	[pencilThreeTapTouchGesture setMinimumPressDuration:0];
-	[pencilThreeTapTouchGesture setDelaysTouchesBegan:NO];
-	[pencilThreeTapTouchGesture setDelaysTouchesEnded:NO];
-	[pencilThreeTapTouchGesture setCancelsTouchesInView:NO];
+	pencilTwoTapLongTouchGesture = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(pencilTwoTapLongTouch:)];
+	[pencilTwoTapLongTouchGesture setNumberOfTouchesRequired:1];
+	[pencilTwoTapLongTouchGesture setNumberOfTapsRequired:2];
+	[pencilTwoTapLongTouchGesture setAllowedTouchTypes:@[@(UITouchTypePencil)]];
+	[pencilTwoTapLongTouchGesture setMinimumPressDuration:0.5];
+	[pencilTwoTapLongTouchGesture setDelaysTouchesBegan:NO];
+	[pencilTwoTapLongTouchGesture setDelaysTouchesEnded:NO];
+	[pencilTwoTapLongTouchGesture setCancelsTouchesInView:NO];
 
 	UIPinchGestureRecognizer *pinchKeyboard = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(keyboardPinch:)];
 
@@ -318,8 +317,8 @@ bool iOS7_fetchEvent(InternalEvent *event) {
 	[self addGestureRecognizer:twoFingerTapGesture];
 	[self addGestureRecognizer:oneFingerLongPressGesture];
 	[self addGestureRecognizer:twoFingerLongPressGesture];
-	[self addGestureRecognizer:pencilTouchGesture];
-	[self addGestureRecognizer:pencilThreeTapTouchGesture];
+	[self addGestureRecognizer:pencilThreeTapGesture];
+	[self addGestureRecognizer:pencilTwoTapLongTouchGesture];
 
 	[pinchKeyboard release];
 	[swipeRight release];
@@ -335,8 +334,8 @@ bool iOS7_fetchEvent(InternalEvent *event) {
 	[twoFingerTapGesture release];
 	[oneFingerLongPressGesture release];
 	[twoFingerLongPressGesture release];
-	[pencilTouchGesture release];
-	[pencilThreeTapTouchGesture release];
+	[pencilThreeTapGesture release];
+	[pencilTwoTapLongTouchGesture release];
 #elif TARGET_OS_TV
 	UITapGestureRecognizer *tapUpGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(threeFingersSwipeUp:)];
 	[tapUpGestureRecognizer setAllowedPressTypes:@[@(UIPressTypeUpArrow)]];
@@ -588,8 +587,8 @@ bool iOS7_fetchEvent(InternalEvent *event) {
 	[twoFingerTapGesture setEnabled:enabled];
 	[oneFingerLongPressGesture setEnabled:enabled];
 	[twoFingerLongPressGesture setEnabled:enabled];
-	[pencilTouchGesture setEnabled:enabled];
-	[pencilThreeTapTouchGesture setEnabled:enabled];
+	[pencilThreeTapGesture setEnabled:enabled];
+	[pencilTwoTapLongTouchGesture setEnabled:enabled];
 }
 #endif
 
@@ -681,9 +680,8 @@ bool iOS7_fetchEvent(InternalEvent *event) {
 			// allows some pixels of movement before invalidating the gesture.
 			if (abs(touchesBegan.x - touchesMoved.x) > allowedPencilMovement ||
 				abs(touchesBegan.y - touchesMoved.y) > allowedPencilMovement) {
-				if (self.isLongPencilTouch == NO) {
-					[pencilTouchGesture setState:UIGestureRecognizerStateCancelled];
-				}
+				[oneFingerTapGesture setState:UIGestureRecognizerStateCancelled];
+				[pencilThreeTapGesture setState:UIGestureRecognizerStateCancelled];
 			}
 			break;
 			
@@ -800,6 +798,13 @@ bool iOS7_fetchEvent(InternalEvent *event) {
 	}
 }
 
+- (void)pencilThreeTap:(UITapGestureRecognizer *)recognizer {
+	if (recognizer.state == UIGestureRecognizerStateEnded) {
+		// Click right mouse
+		[self addEvent:InternalEvent(kInputTap, kUIViewTapSingle, 2)];
+	}
+}
+
 - (void)oneFingerLongPress:(UILongPressGestureRecognizer *)recognizer {
 	if (recognizer.state == UIGestureRecognizerStateBegan) {
 		[self addEvent:InternalEvent(kInputLongPress, UIViewLongPressStarted, 1)];
@@ -816,45 +821,13 @@ bool iOS7_fetchEvent(InternalEvent *event) {
 	}
 }
 
-- (void)pencilTouch:(UILongPressGestureRecognizer *)recognizer {
-	switch (recognizer.state) {
-		case UIGestureRecognizerStateBegan:
-			self.pencilTouchGestureStartTime = [NSDate timeIntervalSinceReferenceDate];
-			self.isLongPencilTouch = NO;
-			break;
-
-		case UIGestureRecognizerStateChanged:
-			if (self.isLongPencilTouch == NO) {
-				double longPressDuration = 0.5; // Seconds
-				double duration = [NSDate timeIntervalSinceReferenceDate] - self.pencilTouchGestureStartTime;
-				if (duration >= longPressDuration) {
-					self.isLongPencilTouch = YES;
-					// Long touch: Hold left mouse
-					[self addEvent:InternalEvent(kInputLongPress, UIViewLongPressStarted, 1)];
-				}
-			}
-			break;
-
-		case UIGestureRecognizerStateEnded:
-			if (self.isLongPencilTouch) {
-				// Long touch: Release left mouse
-				[self addEvent:InternalEvent(kInputLongPress, UIViewLongPressEnded, 1)];
-			}
-			else {
-				// Short touch: Click left mouse
-				[self addEvent:InternalEvent(kInputTap, kUIViewTapSingle, 1)];
-			}
-			break;
-
-		default:
-			break;
-	}
-}
-
-- (void)pencilThreeTapTouch:(UILongPressGestureRecognizer *)recognizer {
+- (void)pencilTwoTapLongTouch:(UITapGestureRecognizer *)recognizer {
 	if (recognizer.state == UIGestureRecognizerStateBegan) {
-		// Mouse right-click
-		[self addEvent:InternalEvent(kInputTap, kUIViewTapSingle, 2)];
+		// Hold right mouse
+		[self addEvent:InternalEvent(kInputLongPress, UIViewLongPressStarted, 2)];
+	} else if (recognizer.state == UIGestureRecognizerStateEnded) {
+		// Release right mouse
+		[self addEvent:InternalEvent(kInputLongPress, UIViewLongPressEnded, 2)];
 	}
 }
 

--- a/doc/docportal/other_platforms/ios.rst
+++ b/doc/docportal/other_platforms/ios.rst
@@ -56,8 +56,9 @@ Controls
 
         Apple Pencil control, Action
         Touch, Left mouse click
-        Touch & hold for 0.5s, "Left mouse button hold and drag, such as for selection from action wheel in Curse of Monkey Island"
-        3 quick taps on screen, Right mouse click 
+        Touch & hold for >0.5s, "Left mouse button hold and drag, such as for selection from action wheel in Curse of Monkey Island"
+        3 quick touches, Right mouse click 
+        3 quick touches & hold for >0.5s, "Right mouse button hold and drag, such as for selection from action wheel in Tony Tough"
 
 
 Touch controls

--- a/doc/docportal/other_platforms/ios.rst
+++ b/doc/docportal/other_platforms/ios.rst
@@ -49,6 +49,16 @@ Controls
         Pinch gesture, Enables/disables keyboard
         Keyboard spacebar, Pause
 
+.. csv-table::
+    :widths: 40 60
+    :header-rows: 1
+    :class: controls
+
+        Apple Pencil control, Action
+        Touch, Left mouse click
+        Touch & hold for 0.5s, "Left mouse button hold and drag, such as for selection from action wheel in Curse of Monkey Island"
+        3 quick taps on screen, Right mouse click 
+
 
 Touch controls
 *******************


### PR DESCRIPTION
Some time ago (~v2.2.0) the iOS version had very basic support for using the Apple Pencil as an input device.  

It seems, as more robust input handling has been implemented since then, that the Pencil now needs its own specific gestures in order to work.

This PR adds basic support so that the Pencil can be used in a similar way to touching the screen.

| Pencil Gesture | Description
| --- | ---
| Touch | Left mouse click
| Touch and hold for 0.5 seconds | Let mouse click and hold (for COMI style games)
| 3 quick taps on screen | Right mouse click

To explain a few choices, the Pencil does not seem to work well with `UITapGestureRecognizer` so I used `UILongPressGestureRecognizer` to detect a basic touch input. Because you don't seem to be able to have two `UILongPressGestureRecognizer` active at once, this makes detecting a "real" long touch a bit trickier so this one gesture will do both a basic touch and the long touch.

I found a three tap gesture worked reasonably well for right-click when you're only using it intermittently, but I wasn't sure it would work as well for a right-click and hold gesture so I haven't implemented that for now. I have been testing with Fate of Atlantis and Curse of Monkey Island neither of which rely on right-click and hold.

This should work with all Pencil variants as I haven't attempted to do anything with hover, taps on the pencil, or pressure sensitivity (which could be interesting to expand on in future to extend how many gestures you could do from the Pencil).

There is an open feature request for this support here: https://bugs.scummvm.org/ticket/14350