### PR TITLE
GLK: ADVSYS: Fix "crash" when matching with empty nouns array

### DIFF
--- a/engines/glk/advsys/vm.cpp
+++ b/engines/glk/advsys/vm.cpp
@@ -353,7 +353,11 @@ void VM::opCLASS() {
 
 void VM::opMATCH() {
 	int idx = _stack.pop() - 1;
-	_stack.top() = match(_stack.top(), _nouns[idx]._noun, _nouns[idx]._adjective) ? TRUE : NIL;
+	if (idx < 0 || _nouns.size() == 0) {
+		_stack.top() = NIL;
+	} else {
+		_stack.top() = match(_stack.top(), _nouns[idx]._noun, _nouns[idx]._adjective) ? TRUE : NIL;
+	}
 }
 
 void VM::opPNOUN() {


### PR DESCRIPTION
This fixes the case for "Starship Columbus" IF game

This game seems to call VM::opMATCH() multiple times per line, and very often would cause an assertion fault for out of bounds access to an array (_nouns). Inputs like "open", "inventory","help" would trigger the assertion fault. Debugging shows that in those cases, the idx var in opMATCH would be "-1" and also the _nouns array would be empty. I've added a check for either in an if clause that essentially fails the match and prevents the out of bounds array access attempt.

The issue was first reported on the forums here: https://forums.scummvm.org/viewtopic.php?p=99929&sid=1d010aa5065115367a5dc3a2c4236434#p99929


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
