### PR TITLE
CLOUD: fix #15337

### DIFF
--- a/backends/cloud/onedrive/onedrivetokenrefresher.cpp
+++ b/backends/cloud/onedrive/onedrivetokenrefresher.cpp
@@ -97,8 +97,8 @@ void OneDriveTokenRefresher::finishJson(const Common::JSONValue *json) {
 				irrecoverable = false;
 
 			if (irrecoverable) {
-				Common::String errorContents = "<irrecoverable> " + json->stringify(true);
-				finishError(Networking::ErrorResponse(this, false, true, errorContents, httpResponseCode));
+				Common::String errorContents = json->stringify(true);
+				finishErrorIrrecoverable(Networking::ErrorResponse(this, false, true, errorContents, httpResponseCode));
 				delete json;
 				return;
 			}
@@ -134,7 +134,12 @@ void OneDriveTokenRefresher::finishError(const Networking::ErrorResponse &error,
 		}
 	}
 
-	Request::finishError(error); //call closest base class's method
+	Request::finishError(error, state); //call closest base class's method
+}
+
+void OneDriveTokenRefresher::finishErrorIrrecoverable(const Networking::ErrorResponse &error, Networking::RequestState state) {
+	// don't try to fix JSON as this is irrecoverable version
+	Request::finishError(error, state); // call closest base class's method
 }
 
 void OneDriveTokenRefresher::setHeaders(const Common::Array<Common::String> &headers) {

--- a/backends/cloud/onedrive/onedrivetokenrefresher.h
+++ b/backends/cloud/onedrive/onedrivetokenrefresher.h
@@ -38,6 +38,8 @@ class OneDriveTokenRefresher: public Networking::CurlJsonRequest {
 
 	void finishJson(const Common::JSONValue *json) override;
 	void finishError(const Networking::ErrorResponse &error, Networking::RequestState state = Networking::FINISHED) override;
+	void finishErrorIrrecoverable(const Networking::ErrorResponse &error, Networking::RequestState state = Networking::FINISHED);
+
 public:
 	OneDriveTokenRefresher(OneDriveStorage *parent, Networking::JsonCallback callback, Networking::ErrorCallback ecb, const char *url);
 	~OneDriveTokenRefresher() override;


### PR DESCRIPTION
Fixes OneDrive sync by handling list of unexisting "saves" subdirectory.

Previously, code that worked with JSON didn't trigger, because string was intentionally malformed. If it wasn't, `OneDriveTokenRefresher::finishError()` would've treated it as JSON parse failure, tried to fix it, and call `finishJson()` instead of `finishError()`. Now, there's a separate method that doesn't try to fix JSON parse failure, and that method is called in case we're sure this is not a parse failure and `finishError()` should be called indeed.