### PR TITLE
BACKENDS: MORPHOS: Fix ASL lock on directory

### DIFF
--- a/backends/dialogs/morphos/morphos-dialogs.cpp
+++ b/backends/dialogs/morphos/morphos-dialogs.cpp
@@ -42,7 +42,6 @@ Common::DialogManager::DialogResult MorphosDialogManager::showFileBrowser(const 
 	struct Library *AslBase = OpenLibrary(AslName, 39);
 
 	if (AslBase) {
-
 		struct FileRequester *fr = NULL;
 
 		if (ConfMan.hasKey("browser_lastpath")) {
@@ -50,12 +49,10 @@ Common::DialogManager::DialogResult MorphosDialogManager::showFileBrowser(const 
 		}
 
 		fr = (struct FileRequester *)AllocAslRequestTags(ASL_FileRequest, TAG_DONE);
-
 		if (!fr)
 			return result;
 
 		if (AslRequestTags(fr, ASLFR_TitleText, (IPTR)newTitle.c_str(), ASLFR_RejectIcons, TRUE, ASLFR_InitialDrawer, (IPTR)pathBuffer, ASLFR_DrawersOnly, (isDirBrowser ? TRUE : FALSE), TAG_DONE)) {
-
 			if (strlen(fr->fr_Drawer) < sizeof(pathBuffer)) {
 				strncpy(pathBuffer, fr->fr_Drawer, sizeof(pathBuffer));
 				ConfMan.setPath("browser_lastpath", pathBuffer); // only path
@@ -65,13 +62,10 @@ Common::DialogManager::DialogResult MorphosDialogManager::showFileBrowser(const 
 				choice = Common::FSNode(pathBuffer);
 				result = kDialogOk;
 			}
-			FreeAslRequest((APTR)fr);
 		}
-
+		FreeAslRequest((APTR)fr);
 		CloseLibrary(AslBase);
 	}
-
 	return result;
 }
-
 #endif


### PR DESCRIPTION
Apparently, on MorphOS, if you try to add a game from a directory where no game exists, cancel out of the platforms native ASL requester and quit ScummVM, the lock on said directory is still present, making it impossible to I.e. delete it.

This change is courtesy of @BeWorld2018 as he has tested that patch on his platform, still I'd need confirmation from him that i didn't break something else.

The same fix "would" also work on AmigaOS (at least it doesn't break anything) but is not needed, because the steps to reproduce it on MorphOS doesn't trigger it on AmigaOS, so i leave it be.
Probably because of a more updated ASL?

Also removed some superflous blank lines