### PR TITLE
SCI: Improve KQ6 CD `enable_high_resolution_graphics`

### DIFF
--- a/engines/sci/detection_tables.h
+++ b/engines/sci/detection_tables.h
@@ -2246,10 +2246,9 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 						  GAMEOPTION_MIDI_MODE,                \
 						  GAMEOPTION_RGB_RENDERING)
 
-#define GUIO_KQ6_CD_WINDOWS GUIO7(GUIO_NOASPECT,                       \
+#define GUIO_KQ6_CD_WINDOWS GUIO6(GUIO_NOASPECT,                       \
 								  GAMEOPTION_WINDOWS_CURSORS,          \
-								  GAMEOPTION_HIGH_RESOLUTION_GRAPHICS, \
-						          GAMEOPTION_PREFER_DIGITAL_SFX,       \
+								  GAMEOPTION_PREFER_DIGITAL_SFX,       \
 								  GAMEOPTION_ORIGINAL_SAVELOAD,        \
 								  GAMEOPTION_MIDI_MODE,                \
 								  GAMEOPTION_RGB_RENDERING)

--- a/engines/sci/engine/kernel.cpp
+++ b/engines/sci/engine/kernel.cpp
@@ -771,7 +771,7 @@ void Kernel::loadKernelNames(GameFeatures *features) {
 			// function has been replaced with kPortrait. In KQ6 Mac,
 			// kPlayBack has been replaced by kShowMovie.
 			if ((g_sci->getPlatform() == Common::kPlatformWindows) || 
-				(g_sci->getPlatform() == Common::kPlatformDOS && g_sci->forceHiresGraphics()))
+				(g_sci->getPlatform() == Common::kPlatformDOS && g_sci->useHiresGraphics()))
 				_kernelNames[0x26] = "Portrait";
 			else if (g_sci->getPlatform() == Common::kPlatformMacintosh)
 				_kernelNames[0x84] = "ShowMovie";

--- a/engines/sci/engine/kmisc.cpp
+++ b/engines/sci/engine/kmisc.cpp
@@ -785,9 +785,9 @@ reg_t kPlatform(EngineState *s, int argc, reg_t *argv) {
 		return NULL_REG;
 	}
 
-	// treat DOS with hires graphics as Windows so that hires graphics are enabled
+	// treat KQ6 DOS with hires graphics as Windows so that hires graphics are enabled
 	bool isWindows = (g_sci->getPlatform() == Common::kPlatformWindows) ||
-		             (g_sci->getPlatform() == Common::kPlatformDOS && g_sci->forceHiresGraphics());
+	                 (g_sci->getGameId() == GID_KQ6 && g_sci->getPlatform() == Common::kPlatformDOS && g_sci->useHiresGraphics());
 
 	uint16 operation = argv[0].toUint16();
 	switch (operation) {
@@ -804,7 +804,7 @@ reg_t kPlatform(EngineState *s, int argc, reg_t *argv) {
 		else
 			return make_reg(0, kSciPlatformDOS);
 	case kPlatformUnknown5:
-		// This case needs to return the opposite of case 6 to get hires graphics
+		// KQ6: subop 5 needs to return the opposite of subop 6 to get hires graphics
 		return make_reg(0, !isWindows);
 	case kPlatformIsHiRes:
 	case kPlatformWin311OrHigher:

--- a/engines/sci/engine/savegame.cpp
+++ b/engines/sci/engine/savegame.cpp
@@ -1380,7 +1380,7 @@ void gamestate_afterRestoreFixUp(EngineState *s, int savegameId) {
 			// will result in some graphics being incorrect (lowres).
 			// That's why we are setting the global after restoring a saved game depending on hires/lowres state.
 			// The CD demo of KQ6 does the same and uses the exact same global.
-			if ((g_sci->getPlatform() == Common::kPlatformWindows) || (g_sci->forceHiresGraphics())) {
+			if ((g_sci->getPlatform() == Common::kPlatformWindows) || (g_sci->useHiresGraphics())) {
 				s->variables[VAR_GLOBAL][0xA9].setOffset(1);
 			} else {
 				s->variables[VAR_GLOBAL][0xA9].setOffset(0);

--- a/engines/sci/graphics/screen.cpp
+++ b/engines/sci/graphics/screen.cpp
@@ -58,7 +58,7 @@ GfxScreen::GfxScreen(ResourceManager *resMan, Common::RenderMode renderMode) : _
 	// allow to be optionally enabled in the DOS version.
 	if (g_sci->getGameId() == GID_KQ6) {
 		if ((g_sci->getPlatform() == Common::kPlatformWindows) ||
-			(g_sci->getPlatform() == Common::kPlatformDOS && g_sci->forceHiresGraphics())) {
+			(g_sci->getPlatform() == Common::kPlatformDOS && g_sci->useHiresGraphics())) {
 			_upscaledHires = GFX_SCREEN_UPSCALED_640x440;
 		}
 	}
@@ -71,7 +71,7 @@ GfxScreen::GfxScreen(ResourceManager *resMan, Common::RenderMode renderMode) : _
 			_height = 300; // regular visual, priority and control map are 480x300 (this is different than other upscaled SCI games)
 		} else {
 			// Macintosh SCI1/1.1 games use hi-res native fonts if hi-res graphics are enabled
-			if (g_sci->hasMacFonts() && g_sci->forceHiresGraphics()) {
+			if (g_sci->hasMacFonts() && g_sci->useHiresGraphics()) {
 				_upscaledHires = GFX_SCREEN_UPSCALED_640x400;
 			}
 		}

--- a/engines/sci/metaengine.cpp
+++ b/engines/sci/metaengine.cpp
@@ -671,6 +671,14 @@ void SciMetaEngine::registerDefaultSettings(const Common::String &target) const 
 
 	for (const PopUpOptionsMap *entry = popUpOptionsList; entry->guioFlag; ++entry)
 		ConfMan.registerDefault(entry->configOption, entry->defaultState);
+
+	// enable_high_resolution_graphics is normally enabled by default,
+	// except for KQ6 where it overrides the DOS platform with Windows.
+	// If it were enabled by default for KQ6, then the DOS platform
+	// would produce the Windows experience by default instead of DOS.
+	if (ConfMan.get("gameid", target) == "kq6" && ConfMan.get("platform", target) == "pc") {
+		ConfMan.registerDefault("enable_high_resolution_graphics", false);
+	}
 }
 
 GUI::OptionsContainerWidget *SciMetaEngine::buildEngineOptionsWidget(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const {

--- a/engines/sci/sci.cpp
+++ b/engines/sci/sci.cpp
@@ -136,7 +136,7 @@ SciEngine::SciEngine(OSystem *syst, const ADGameDescription *desc, SciGameId gam
 	_console(nullptr),
 	_tts(nullptr),
 	_rng("sci"),
-	_forceHiresGraphics(false),
+	_useHiresGraphics(false),
 	_inErrorString(false) {
 
 	assert(g_sci == nullptr);
@@ -312,10 +312,10 @@ Common::Error SciEngine::run() {
 		// so read the user option now.
 		// We need to do this, because the option's default is "true", but we don't want "true"
 		// for any game that does not have this option.
-		_forceHiresGraphics = ConfMan.getBool("enable_high_resolution_graphics");
+		_useHiresGraphics = ConfMan.getBool("enable_high_resolution_graphics");
 	} else if (hasMacFonts()) {
 		// Default to using hires Mac fonts if GUI option isn't present, as it was added later.
-		_forceHiresGraphics = true;
+		_useHiresGraphics = true;
 	}
 
 	if (getSciVersion() < SCI_VERSION_2) {
@@ -894,8 +894,8 @@ bool SciEngine::isCD() const {
 	return _gameDescription->flags & ADGF_CD;
 }
 
-bool SciEngine::forceHiresGraphics() const {
-	return _forceHiresGraphics;
+bool SciEngine::useHiresGraphics() const {
+	return _useHiresGraphics;
 }
 
 bool SciEngine::isBE() const{

--- a/engines/sci/sci.h
+++ b/engines/sci/sci.h
@@ -196,7 +196,7 @@ public:
 	Common::Platform getPlatform() const;
 	bool isDemo() const;
 	bool isCD() const;
-	bool forceHiresGraphics() const;
+	bool useHiresGraphics() const;
 
 	/** 
 	 * Returns true if the game's original platform is Macintosh or Amiga.
@@ -421,7 +421,7 @@ private:
 	Console *_console;
 	Common::RandomSource _rng;
 	Common::MacResManager _macExecutable;
-	bool _forceHiresGraphics; // user-option for GK1, KQ6, PQ4
+	bool _useHiresGraphics; // user-option for GK1, KQ6, PQ4
 	bool _inErrorString; /**< Set while `errorString` is executing */
 };
 


### PR DESCRIPTION
This PR improves KQ6 CD with regards to the `enable_high_resolution_graphics` config setting:

1. `enable_high_resolution_graphics` is clarified for how it affects KQ6 CD: it overrides the ScummVM DOS platform setting and replaces it with Windows
2. `enable_high_resolution_graphics` is no longer enabled by default for the DOS platform
3. `enable_high_resolution_graphics` is no longer available for the Windows platform, because it had no effect

This addresses several sources of confusion:

1. When adding KQ6 CD, we prompt users for DOS or Windows, and then deliver the Windows experience regardless of which they choose.
2. The DOS experience is only achievable by first selecting DOS and then unchecking "Enable High Resolution Graphics".
3. Selecting Windows and then unchecking "Enable High Resolution Graphics" has no effect. Nice try, you still get Windows =)

With these changes:

- Adding KQ6 CD and selecting DOS delivers the DOS experience.
- Adding KQ6 CD and selecting Windows still delivers the Windows experience.
- We no longer offer an option that has no effect.
- Users can still select "Enable High Resolution Graphics" on DOS.
- Existing ScummVM configs are unaffected. (Upgrading ScummVM won't change someone's game)

`enable_high_resolution_graphics` affects three games: KQ6, PQ4, and GK1. For PQ4 and GK1, it does what it says, because the DOS versions could run in high or low resolution, and the graphics are of the same art.

For KQ6 CD, it doesn't do what it says. We can't actually enable high-res graphics on the DOS version; the game isn't structured that way, because the high-res graphics were Windows-only. Instead, we lie to the entire game and say that we're Windows. This indirectly causes high-res graphics to be used, but also drags in every other unrelated Windows difference. (AVI movies, room transitions, sound tweaks, anywhere the game queries the platform.) More importantly: resolution is just *one* of the differences between DOS and Windows. The most notable is the actor portraits, which are completely different pieces with wildly different styles. It's a mistake to `enable_high_resolution_graphics` by default on DOS, not because people don't like having more pixels, but because it delivers Windows art to the wrong platform and suppresses DOS art.

I wish we could remove `enable_high_resolution_graphics` from KQ6 CD. It's redundant given that we have the ScummVM platform setting. But too many config files exist after all these years, and too many user expectations have built up. Instead, I'm just changing the default value when adding KQ6, and removing the UI option when it has no effect.

A recent forum post by a user reminded me that I've wanted to sort this out for a while. It confused me in the same ways when I started, and I've seen it consistently come up with new ScummVM users in Sierra communities. More people are familiar with the DOS version, so they select DOS, and then they see movies and pictures they've never seen. Or, ScummVM crashes because they don't have the .AVI files they've never heard of.