### PR TITLE
SDL: Add a dedicated graphics manager for the SDL2 render API

### DIFF
--- a/backends/graphics/rendersdl/rendersdl-graphics.cpp
+++ b/backends/graphics/rendersdl/rendersdl-graphics.cpp
@@ -57,8 +57,6 @@
 
 // SDL surface flags which got removed in SDL2.
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-#define SDL_SRCCOLORKEY 0
-#define SDL_SRCALPHA    0
 #define SDL_FULLSCREEN  0x40000000
 #endif
 
@@ -180,7 +178,7 @@ RenderSdlGraphicsManager::RenderSdlGraphicsManager(SdlEventSource *sdlEventSourc
 	_useOldSrc(false), _isHwPalette(false),
 	_overlayscreen(nullptr), _tmpscreen2(nullptr),
 	_screenChangeCount(0),
-	_mouseSurface(nullptr), _mouseScaler(nullptr),
+	_mouseTexture(nullptr), _mouseScaler(nullptr), _mouseSurface(nullptr),
 	_mouseOrigSurface(nullptr), _cursorDontScale(false), _cursorPaletteDisabled(true),
 	_currentShakeXOffset(0), _currentShakeYOffset(0),
 	_paletteDirtyStart(0), _paletteDirtyEnd(0),
@@ -192,7 +190,6 @@ RenderSdlGraphicsManager::RenderSdlGraphicsManager(SdlEventSource *sdlEventSourc
 	_transactionMode(kTransactionNone),
 	_scalerPlugins(ScalerMan.getPlugins()), _scalerPlugin(nullptr), _scaler(nullptr),
 	_needRestoreAfterOverlay(false), _isInOverlayPalette(false), _isDoubleBuf(false), _prevForceRedraw(false), _numPrevDirtyRects(0),
-	_prevCursorNeedsRedraw(false),
 	_mouseKeyColor(0), _disableMouseKeyColor(false) {
 
 	// allocate palette storage
@@ -209,9 +206,6 @@ RenderSdlGraphicsManager::RenderSdlGraphicsManager(SdlEventSource *sdlEventSourc
 		_overlayPalette[i].a = 0xff;
 #endif
 	}
-
-	_mouseLastRect.x = _mouseLastRect.y = _mouseLastRect.w = _mouseLastRect.h = 0;
-	_mouseNextRect.x = _mouseNextRect.y = _mouseNextRect.w = _mouseNextRect.h = 0;
 
 #ifdef USE_SDL_DEBUG_FOCUSRECT
 	if (ConfMan.hasKey("use_sdl_debug_focusrect"))
@@ -501,8 +495,10 @@ OSystem::TransactionError RenderSdlGraphicsManager::endGFXTransaction() {
 			_screenChangeCount++;
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-			if (_transactionDetails.needDisplayResize)
+			if (_transactionDetails.needDisplayResize) {
 				recalculateDisplayAreas();
+				recalculateCursorScaling();
+			}
 #endif
 			if (_transactionDetails.needUpdatescreen)
 				internUpdateScreen();
@@ -511,15 +507,19 @@ OSystem::TransactionError RenderSdlGraphicsManager::endGFXTransaction() {
 	} else if (_transactionDetails.needTextureUpdate) {
 		setGraphicsModeIntern();
 		recreateScreenTexture();
-		if (_transactionDetails.needDisplayResize)
+		if (_transactionDetails.needDisplayResize) {
 			recalculateDisplayAreas();
+			recalculateCursorScaling();
+		}
 		internUpdateScreen();
 #endif
 	} else if (_transactionDetails.needUpdatescreen) {
 		setGraphicsModeIntern();
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-		if (_transactionDetails.needDisplayResize)
+		if (_transactionDetails.needDisplayResize) {
 			recalculateDisplayAreas();
+			recalculateCursorScaling();
+		}
 #endif
 		internUpdateScreen();
 	}
@@ -1100,6 +1100,11 @@ void RenderSdlGraphicsManager::unloadGFXMode() {
 	}
 #endif
 
+	if (_mouseTexture) {
+		SDL_DestroyTexture(_mouseTexture);
+		_mouseTexture = nullptr;
+	}
+
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	deinitializeRenderer();
 #endif
@@ -1210,18 +1215,11 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 	if (debugger)
 		debugger->onFrame();
 
-	bool curCursorNeedsRedraw = _cursorNeedsRedraw;
-	if (_prevCursorNeedsRedraw && _isDoubleBuf) {
-		_cursorNeedsRedraw = true;
-	}
-	_prevCursorNeedsRedraw = curCursorNeedsRedraw;
-
 #if !SDL_VERSION_ATLEAST(2, 0, 0)
 	// If the shake position changed, fill the dirty area with blackness
 	// When building with SDL2, the shake offset is added to the active rect instead,
 	// so this isn't needed there.
-	if (_currentShakeXOffset != _gameScreenShakeXOffset ||
-		(_cursorNeedsRedraw && _mouseLastRect.x <= _currentShakeXOffset)) {
+	if (_currentShakeXOffset != _gameScreenShakeXOffset) {
 		SDL_Rect blackrect = {0, 0, (Uint16)(_videoMode.screenWidth * _videoMode.scaleFactor), (Uint16)(_videoMode.screenHeight * _videoMode.scaleFactor)};
 
 		if (_gameScreenShakeXOffset >= 0)
@@ -1241,8 +1239,7 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 
 		_forceRedraw = true;
 	}
-	if (_currentShakeYOffset != _gameScreenShakeYOffset ||
-		(_cursorNeedsRedraw && _mouseLastRect.y <= _currentShakeYOffset)) {
+	if (_currentShakeYOffset != _gameScreenShakeYOffset) {
 		SDL_Rect blackrect = {0, 0, (Uint16)(_videoMode.screenWidth * _videoMode.scaleFactor), (Uint16)(_videoMode.screenHeight * _videoMode.scaleFactor)};
 
 		if (_gameScreenShakeYOffset >= 0)
@@ -1314,13 +1311,6 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 		_needRestoreAfterOverlay = _useOldSrc;
 	}
 
-	// Add the area covered by the mouse cursor to the list of dirty rects if
-	// we have to redraw the mouse, or if the cursor is alpha-blended since
-	// alpha-blended cursors will happily blend into themselves if the surface
-	// under the cursor is not reset first
-	if (_cursorNeedsRedraw || _cursorFormat.aBits() > 1)
-		undrawMouse();
-
 #ifdef USE_OSD
 	updateOSD();
 #endif
@@ -1366,7 +1356,7 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 	}
 
 	// Only draw anything if necessary
-	if (actualDirtyRects > 0 || _cursorNeedsRedraw) {
+	if (actualDirtyRects > 0) {
 		SDL_Rect *r;
 		SDL_Rect dst;
 		uint32 bpp, srcPitch, dstPitch;
@@ -1465,8 +1455,6 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 			_dirtyRectList[0].h = _videoMode.hardwareHeight;
 		}
 
-		drawMouse();
-
 #ifdef USE_SDL_DEBUG_FOCUSRECT
 		// We draw the focus rectangle on top of everything, to assure it's easily visible.
 		// Of course when the GUI overlay is visible we do not show it, since it is only for game
@@ -1564,6 +1552,7 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 
 	SDL_RenderClear(_renderer);
 	drawScreen();
+	drawMouse();
 #ifdef USE_OSD
 	drawOSD();
 #endif
@@ -2256,6 +2245,11 @@ void RenderSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, i
 			_mouseSurface = nullptr;
 		}
 
+		if (formatChanged && _mouseTexture) {
+			SDL_DestroyTexture(_mouseTexture);
+			_mouseTexture = nullptr;
+		}
+
 		if (!w || !h) {
 			return;
 		}
@@ -2288,6 +2282,11 @@ void RenderSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, i
 			error("Allocating _mouseOrigSurface failed");
 		}
 
+		if (_mouseOrigSurface->format->Aloss < 8)
+			SDL_SetSurfaceBlendMode(_mouseOrigSurface, SDL_BLENDMODE_BLEND);
+		else
+			SDL_SetSurfaceRLE(_mouseOrigSurface, SDL_TRUE);
+
 #ifdef USE_SCALERS
 		if (_mouseScaler != nullptr) {
 			delete _mouseScaler;
@@ -2304,11 +2303,10 @@ void RenderSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, i
 
 	if (keycolorChanged) {
 #if SDL_VERSION_ATLEAST(3, 0, 0)
-		uint32 flags = _disableMouseKeyColor ? 0 : SDL_SRCCOLORKEY | SDL_SRCALPHA;
+		uint32 flags = _disableMouseKeyColor ? SDL_FALSE : SDL_TRUE;
 		SDL_SetSurfaceColorKey(_mouseOrigSurface, flags, _mouseKeyColor);
-		SDL_SetSurfaceRLE(_mouseOrigSurface, !_disableMouseKeyColor);
 #else
-		uint32 flags = _disableMouseKeyColor ? 0 : SDL_RLEACCEL | SDL_SRCCOLORKEY | SDL_SRCALPHA;
+		uint32 flags = _disableMouseKeyColor ? SDL_FALSE : SDL_TRUE;
 		SDL_SetColorKey(_mouseOrigSurface, flags, _mouseKeyColor);
 #endif
 	}
@@ -2352,7 +2350,9 @@ void RenderSdlGraphicsManager::blitCursor() {
 		return;
 	}
 
-	_cursorNeedsRedraw = true;
+	if (!_mouseOrigSurface) {
+		return;
+	}
 
 	int cursorScale;
 	if (_cursorDontScale) {
@@ -2394,6 +2394,11 @@ void RenderSdlGraphicsManager::blitCursor() {
 	}
 
 	if (sizeChanged || !_mouseSurface) {
+		if (_mouseTexture) {
+			SDL_DestroyTexture(_mouseTexture);
+			_mouseTexture = nullptr;
+		}
+
 		if (_mouseSurface)
 			destroySurface(_mouseSurface);
 
@@ -2423,15 +2428,19 @@ void RenderSdlGraphicsManager::blitCursor() {
 
 		if (_mouseSurface == nullptr)
 			error("Allocating _mouseSurface failed");
+
+		if (_mouseSurface->format->Aloss < 8)
+			SDL_SetSurfaceBlendMode(_mouseSurface, SDL_BLENDMODE_BLEND);
+		else
+			SDL_SetSurfaceRLE(_mouseSurface, SDL_TRUE);
 	}
 
 	SDL_SetColors(_mouseSurface, _cursorPaletteDisabled ? _currentPalette : _cursorPalette, 0, 256);
 #if SDL_VERSION_ATLEAST(3, 0, 0)
-	uint32 flags = _disableMouseKeyColor ? 0 : SDL_SRCCOLORKEY | SDL_SRCALPHA;
+	uint32 flags = _disableMouseKeyColor ? SDL_FALSE : SDL_TRUE;
 	SDL_SetSurfaceColorKey(_mouseSurface, flags, _mouseKeyColor);
-	SDL_SetSurfaceRLE(_mouseSurface, !_disableMouseKeyColor);
 #else
-	uint32 flags = _disableMouseKeyColor ? 0 : SDL_RLEACCEL | SDL_SRCCOLORKEY | SDL_SRCALPHA;
+	uint32 flags = _disableMouseKeyColor ? SDL_FALSE : SDL_TRUE;
 	SDL_SetColorKey(_mouseSurface, flags, _mouseKeyColor);
 #endif
 
@@ -2505,80 +2514,126 @@ void RenderSdlGraphicsManager::blitCursor() {
 
 	SDL_UnlockSurface(_mouseSurface);
 	SDL_UnlockSurface(_mouseOrigSurface);
-}
 
-void RenderSdlGraphicsManager::undrawMouse() {
-	_mouseLastRect = _mouseNextRect;
+	if (!_mouseTexture) {
+		// TODO: Pick a better pixel format?
+		_mouseTexture = SDL_CreateTexture(_renderer,
+						SDL_PIXELFORMAT_RGBA32,
+						SDL_TEXTUREACCESS_STREAMING,
+						_mouseSurface->w,
+						_mouseSurface->h);
 
-	const Common::Point virtualCursor = convertWindowToVirtual(_cursorX, _cursorY);
+		if (_mouseTexture == nullptr)
+			error("Creating _mouseTexture failed");
 
-	// The offsets must be applied, since the call to convertWindowToVirtual()
-	// counteracts the move of the view port.
-
-	_mouseNextRect.x = virtualCursor.x + _gameScreenShakeXOffset;
-	_mouseNextRect.y = virtualCursor.y + _gameScreenShakeYOffset;
-
-	if (!_overlayInGUI) {
-		_mouseNextRect.w = _mouseCurState.vW;
-		_mouseNextRect.h = _mouseCurState.vH;
-		_mouseNextRect.x -= _mouseCurState.vHotX;
-		_mouseNextRect.y -= _mouseCurState.vHotY;
-	} else {
-		_mouseNextRect.w = _mouseCurState.rW;
-		_mouseNextRect.h = _mouseCurState.rH;
-		_mouseNextRect.x -= _mouseCurState.rHotX;
-		_mouseNextRect.y -= _mouseCurState.rHotY;
+		SDL_SetTextureBlendMode(_mouseTexture, SDL_BLENDMODE_BLEND);
 	}
 
-	if (!_cursorVisible || !_mouseSurface) {
-		_mouseNextRect.x = _mouseNextRect.y = _mouseNextRect.w = _mouseNextRect.h = 0;
+	SDL_Surface *tmp;
+	if (SDL_LockTextureToSurface(_mouseTexture, nullptr, &tmp) >= 0) {
+		SDL_FillRect(tmp, nullptr, 0);
+		SDL_BlitSurface(_mouseSurface, nullptr, tmp, nullptr);
+		SDL_UnlockTexture(_mouseTexture);
 	}
 
-	// Add the area covered by the mouse cursor to the list of dirty rects if
-	// we have to redraw the mouse, or if the cursor is alpha-blended since
-	// alpha-blended cursors will happily blend into themselves if the surface
-	// under the cursor is not reset first
-	//
-	// The mouse is undrawn using virtual coordinates, i.e. they may be
-	// scaled and aspect-ratio corrected.
-
-	if (_mouseLastRect.w != 0 && _mouseLastRect.h != 0)
-		addDirtyRect(_mouseLastRect.x, _mouseLastRect.y, _mouseLastRect.w, _mouseLastRect.h, _overlayInGUI);
-
-	if (_mouseNextRect.w != 0 && _mouseNextRect.h != 0)
-		addDirtyRect(_mouseNextRect.x, _mouseNextRect.y, _mouseNextRect.w, _mouseNextRect.h, _overlayInGUI);
+	recalculateCursorScaling();
 }
 
 void RenderSdlGraphicsManager::drawMouse() {
-	if (!_cursorVisible || !_mouseSurface || !_mouseCurState.w || !_mouseCurState.h) {
+	if (!_cursorVisible || !_mouseTexture || !_mouseCurState.w || !_mouseCurState.h) {
 		return;
 	}
 
 	SDL_Rect dst;
 
+	// The offsets must be applied, since the call to convertWindowToVirtual()
+	// counteracts the move of the view port.
+
+	dst.x = _cursorX - _mouseCurState.vHotX + _gameScreenShakeXOffset;
+	dst.y = _cursorY - _mouseCurState.vHotY + _gameScreenShakeYOffset;
+	dst.w = _mouseCurState.vW;
+	dst.h = _mouseCurState.vH;
+
 	// We draw the pre-scaled cursor image, so now we need to adjust for
 	// scaling, shake position and aspect ratio correction manually.
-
-	dst.x = _mouseNextRect.x;
-	dst.y = _mouseNextRect.y;
-	dst.w = _mouseNextRect.w;
-	dst.h = _mouseNextRect.h;
 
 	if (_videoMode.aspectRatioCorrection && !_overlayInGUI)
 		dst.y = real2Aspect(dst.y);
 
-	if (!_overlayInGUI) {
-		dst.x *= _videoMode.scaleFactor;
-		dst.y *= _videoMode.scaleFactor;
+	switch (_rotationMode) {
+	case Common::kRotationNormal:
+	case Common::kRotation180:
+		break;
+	case Common::kRotation90:
+	case Common::kRotation270: {
+//		SWAP(dst.w, dst.h);
+		break;
 	}
-	dst.w = _mouseCurState.rW;
-	dst.h = _mouseCurState.rH;
+	}
 
-	// Note that SDL_BlitSurface() and addDirtyRect() will both perform any
-	// clipping necessary
+	// TODO: Handle clipping?
 
-	if (!blitSurface(_mouseSurface, nullptr, _hwScreen, &dst))
-		error("SDL_BlitSurface failed: %s", SDL_GetError());
+	assert(_mouseTexture);
+	if (_rotationMode != 0) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		const SDL_FPoint center = { 0, 0 };
+		SDL_FRect dstF;
+		SDL_RectToFRect(&dst, &dstF);
+		if (!SDL_RenderTextureRotated(_renderer, _mouseTexture, nullptr, &dstF, _rotationMode, &center, SDL_FLIP_NONE))
+			error("SDL_RenderTextureRotated failed: %s", SDL_GetError());
+#else
+		const SDL_Point center = { 0, 0 };
+		if (SDL_RenderCopyEx(_renderer, _mouseTexture, nullptr, &dst, _rotationMode, &center, SDL_FLIP_NONE) != 0)
+			error("SDL_RenderCopyEx failed: %s", SDL_GetError());
+#endif
+	} else {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		SDL_FRect dstF;
+		SDL_RectToFRect(&dst, &dstF);
+		if (!SDL_RenderTexture(_renderer, _mouseTexture, nullptr, &dstF))
+			error("SDL_RenderTexture failed: %s", SDL_GetError());
+#else
+		if (SDL_RenderCopy(_renderer, _mouseTexture, nullptr, &dst) != 0)
+			error("SDL_RenderCopy failed: %s", SDL_GetError());
+#endif
+	}
+}
+
+void RenderSdlGraphicsManager::recalculateCursorScaling() {
+	if (!_mouseTexture) {
+		return;
+	}
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	float cursorWidth, cursorHeight;
+	SDL_GetTextureSize(_mouseTexture, &cursorWidth, &cursorHeight);
+#else
+	int cursorWidth, cursorHeight;
+	SDL_QueryTexture(_mouseTexture, nullptr, nullptr, &cursorWidth, &cursorHeight);
+#endif
+
+	// By default we use the unscaled versions.
+	_mouseCurState.vHotX = _mouseCurState.rHotX;
+	_mouseCurState.vHotY = _mouseCurState.rHotY;
+	_mouseCurState.vW    = cursorWidth;
+	_mouseCurState.vH    = cursorHeight;
+
+	if (_rotationMode == Common::kRotation90 || _rotationMode == Common::kRotation270) {
+		SWAP(cursorWidth, cursorHeight);
+	}
+
+	// In case scaling is actually enabled we will scale the cursor according
+	// to the game screen.
+	/* if (!_cursorDontScale) */ {
+		const frac_t screenScaleFactorX = intToFrac(_gameDrawRect.width()) / _hwScreen->w;
+		const frac_t screenScaleFactorY = intToFrac(_gameDrawRect.height()) / _hwScreen->h;
+
+		_mouseCurState.vHotX = fracToInt(_mouseCurState.rHotX * screenScaleFactorX);
+		_mouseCurState.vW    = fracToInt(cursorWidth          * screenScaleFactorX);
+
+		_mouseCurState.vHotY = fracToInt(_mouseCurState.rHotY * screenScaleFactorY);
+		_mouseCurState.vH    = fracToInt(cursorHeight         * screenScaleFactorY);
+	}
 }
 
 #pragma mark -
@@ -2877,6 +2932,7 @@ void RenderSdlGraphicsManager::drawScreen() {
 void RenderSdlGraphicsManager::handleResizeImpl(const int width, const int height) {
 	SdlGraphicsManager::handleResizeImpl(width, height);
 	recalculateDisplayAreas();
+	recalculateCursorScaling();
 }
 
 void RenderSdlGraphicsManager::handleScalerHotkeys(uint mode, int factor) {
@@ -3041,6 +3097,10 @@ void RenderSdlGraphicsManager::deinitializeRenderer() {
 	if (_screenTexture)
 		SDL_DestroyTexture(_screenTexture);
 	_screenTexture = nullptr;
+
+	if (_mouseTexture)
+		SDL_DestroyTexture(_mouseTexture);
+	_mouseTexture = nullptr;
 
 	if (_renderer)
 		SDL_DestroyRenderer(_renderer);
@@ -3226,14 +3286,6 @@ int RenderSdlGraphicsManager::SDL_SetAlpha(SDL_Surface *surface, Uint32 flag, Ui
 
 
 	return 0;
-}
-
-int RenderSdlGraphicsManager::SDL_SetColorKey(SDL_Surface *surface, Uint32 flag, Uint32 key) {
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-	return SDL_SetSurfaceColorKey(surface, flag, key) ? -1 : 0;
-#else
-	return ::SDL_SetColorKey(surface, flag ? SDL_TRUE : SDL_FALSE, key) ? -1 : 0;
-#endif
 }
 
 #if defined(USE_IMGUI) && (defined(USE_IMGUI_SDLRENDERER2) || defined(USE_IMGUI_SDLRENDERER3))

--- a/backends/graphics/rendersdl/rendersdl-graphics.cpp
+++ b/backends/graphics/rendersdl/rendersdl-graphics.cpp
@@ -492,20 +492,48 @@ Common::List<Graphics::PixelFormat> RenderSdlGraphicsManager::getSupportedFormat
 	return _supportedFormats;
 }
 
+static void maskToBitCount(Uint32 mask, uint8 &numBits, uint8 &shift) {
+	numBits = 0;
+	shift = 32;
+	for (int i = 0; i < 32; ++i) {
+		if (mask & 1) {
+			if (i < shift) {
+				shift = i;
+			}
+			++numBits;
+		}
+		mask >>= 1;
+	}
+}
+
 void RenderSdlGraphicsManager::detectSupportedFormats() {
 	_supportedFormats.clear();
 
-	Graphics::PixelFormat format = Graphics::PixelFormat::createFormatCLUT8();
+	SDL_RendererInfo info;
+	if (SDL_GetRendererInfo(_renderer, &info) < 0)
+		error("SDL_GetRendererInfo failed: %s", SDL_GetError());
 
-	if (_hwScreen) {
-		// Get our currently set hardware format
-		Graphics::PixelFormat hwFormat = convertSDLPixelFormat(_hwScreen->format);
+	// Enumerate all pixel formats supported by the renderer
+	for (Uint32 i = 0; i < info.num_texture_formats; i++) {
+		if (!SDL_ISPIXELFORMAT_PACKED(info.texture_formats[i]))
+			continue;
 
-		// This is the first supported format to prevent pixel format conversion
-		// on blitting. This gives us a lot more performance on low perf hardware.
-		_supportedFormats.push_back(hwFormat);
+		int bpp;
+		Uint32 rMask, gMask, bMask, aMask;
+		if (SDL_PixelFormatEnumToMasks(info.texture_formats[i], &bpp, &rMask, &gMask, &bMask, &aMask) != SDL_TRUE) {
+			error("Could not convert system pixel format %s to masks", SDL_GetPixelFormatName(info.texture_formats[i]));
+		}
 
-		format = hwFormat;
+		const uint8 bytesPerPixel = SDL_BYTESPERPIXEL(info.texture_formats[i]);
+		uint8 rBits, rShift, gBits, gShift, bBits, bShift, aBits, aShift;
+		maskToBitCount(rMask, rBits, rShift);
+		maskToBitCount(gMask, gBits, gShift);
+		maskToBitCount(bMask, bBits, bShift);
+		maskToBitCount(aMask, aBits, aShift);
+
+		Graphics::PixelFormat format(bytesPerPixel, rBits, gBits, bBits, aBits, rShift, gShift, bShift, aShift);
+
+		_supportedFormats.push_back(format);
 	}
 
 	// Some tables with standard formats that we always list
@@ -547,18 +575,12 @@ void RenderSdlGraphicsManager::detectSupportedFormats() {
 
 	// Push some RGB formats
 	for (i = 0; i < ARRAYSIZE(RGBList); i++) {
-		if (_hwScreen && (RGBList[i].bytesPerPixel > format.bytesPerPixel))
-			continue;
-		if (RGBList[i] != format)
-			_supportedFormats.push_back(RGBList[i]);
+		_supportedFormats.push_back(RGBList[i]);
 	}
 
 	// Push some BGR formats
 	for (i = 0; i < ARRAYSIZE(BGRList); i++) {
-		if (_hwScreen && (BGRList[i].bytesPerPixel > format.bytesPerPixel))
-			continue;
-		if (BGRList[i] != format)
-			_supportedFormats.push_back(BGRList[i]);
+		_supportedFormats.push_back(BGRList[i]);
 	}
 
 	// Finally, we always supposed 8 bit palette graphics
@@ -866,14 +888,32 @@ bool RenderSdlGraphicsManager::loadGFXMode() {
 
 		SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, _videoMode.filtering ? "linear" : "nearest");
 
-		Uint32 screenFormat = SDL_PIXELFORMAT_RGB565;
+		_screenTexFormat = SDL_PIXELFORMAT_UNKNOWN;
+		if (!_screenFormat.isCLUT8())
+			_screenTexFormat = SDL_MasksToPixelFormatEnum(_screenFormat.bytesPerPixel * 8, rMask, gMask, bMask, aMask);
+		if (_screenTexFormat == SDL_PIXELFORMAT_UNKNOWN) {
+			// Pick the best pixel format for the screen based on what the
+			// renderer supports.
+			SDL_RendererInfo info;
+			if (SDL_GetRendererInfo(_renderer, &info) < 0)
+				error("SDL_GetRendererInfo failed: %s", SDL_GetError());
 
-		_screenTexture = SDL_CreateTexture(_renderer, screenFormat, SDL_TEXTUREACCESS_STREAMING, _videoMode.hardwareWidth, _videoMode.hardwareHeight);
+			for (Uint32 i = 0; i < info.num_texture_formats; i++) {
+				if (!SDL_ISPIXELFORMAT_PACKED(info.texture_formats[i]))
+					continue;
+				_screenTexFormat = info.texture_formats[i];
+				break;
+			}
+		}
+		if (_screenTexFormat == SDL_PIXELFORMAT_UNKNOWN)
+			_screenTexFormat = SDL_PIXELFORMAT_RGBA32;
+
+		_screenTexture = SDL_CreateTexture(_renderer, _screenTexFormat, SDL_TEXTUREACCESS_STREAMING, _videoMode.hardwareWidth, _videoMode.hardwareHeight);
 		if (!_screenTexture) {
 			error("Failed to create texture: %s", SDL_GetError());
 		}
 
-		_hwScreen = SDL_CreateRGBSurfaceWithFormat(SDL_SWSURFACE, _videoMode.hardwareWidth, _videoMode.hardwareHeight, SDL_BITSPERPIXEL(screenFormat), screenFormat);
+		_hwScreen = SDL_CreateRGBSurfaceWithFormat(SDL_SWSURFACE, _videoMode.hardwareWidth, _videoMode.hardwareHeight, SDL_BITSPERPIXEL(_screenTexFormat), _screenTexFormat);
 	}
 
 
@@ -2694,7 +2734,7 @@ void RenderSdlGraphicsManager::recreateScreenTexture() {
 #endif
 
 	SDL_Texture *oldTexture = _screenTexture;
-	_screenTexture = SDL_CreateTexture(_renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_STREAMING, _videoMode.hardwareWidth, _videoMode.hardwareHeight);
+	_screenTexture = SDL_CreateTexture(_renderer, _screenTexFormat, SDL_TEXTUREACCESS_STREAMING, _videoMode.hardwareWidth, _videoMode.hardwareHeight);
 	if (_screenTexture) {
 		SDL_DestroyTexture(oldTexture);
 #if SDL_VERSION_ATLEAST(3, 0, 0)

--- a/backends/graphics/rendersdl/rendersdl-graphics.cpp
+++ b/backends/graphics/rendersdl/rendersdl-graphics.cpp
@@ -1,0 +1,3285 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/scummsys.h"
+
+#if defined(SDL_BACKEND)
+#include "backends/graphics/rendersdl/rendersdl-graphics.h"
+#include "backends/events/sdl/sdl-events.h"
+#include "common/config-manager.h"
+#include "common/mutex.h"
+#include "common/textconsole.h"
+#include "common/translation.h"
+#include "common/util.h"
+#include "common/file.h"
+#include "common/frac.h"
+#ifdef USE_RGB_COLOR
+#include "common/list.h"
+#endif
+#include "graphics/blit.h"
+#include "graphics/font.h"
+#include "graphics/fontman.h"
+#include "graphics/scaler.h"
+#include "graphics/scaler/aspect.h"
+#include "graphics/surface.h"
+#include "gui/debugger.h"
+#include "gui/EventRecorder.h"
+#ifdef USE_PNG
+#include "image/png.h"
+#else
+#include "image/bmp.h"
+#endif
+#include "common/text-to-speech.h"
+
+#ifdef USE_OSD
+#if defined(MACOSX)
+#include "backends/platform/sdl/macosx/macosx-touchbar.h"
+#endif
+#endif
+
+// SDL surface flags which got removed in SDL2.
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+#define SDL_SRCCOLORKEY 0
+#define SDL_SRCALPHA    0
+#define SDL_FULLSCREEN  0x40000000
+#endif
+
+static void destroySurface(SDL_Surface *surface) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	SDL_DestroySurface(surface);
+#else
+	SDL_FreeSurface(surface);
+#endif
+}
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+static bool blitSurface(SDL_Surface *src, const SDL_Rect *srcrect, SDL_Surface *dst, const SDL_Rect *dstrect) {
+	return SDL_BlitSurface(src, srcrect, dst, dstrect);
+}
+#elif SDL_VERSION_ATLEAST(2, 0, 0)
+static bool blitSurface(SDL_Surface * src, const SDL_Rect * srcrect, SDL_Surface * dst, SDL_Rect * dstrect) {
+	return SDL_BlitSurface(src, srcrect, dst, dstrect) != -1;
+}
+#else
+static bool blitSurface(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst, SDL_Rect *dstrect) {
+	return SDL_BlitSurface(src, srcrect, dst, dstrect) != -1;
+}
+#endif
+
+
+static bool lockSurface(SDL_Surface *surface) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	return SDL_LockSurface(surface);
+#else
+	return SDL_LockSurface(surface) != -1;
+#endif
+}
+
+static SDL_Surface *createSurface(int width, int height, SDL_Surface *surface) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	const SDL_PixelFormatDetails *pixelFormatDetails = SDL_GetPixelFormatDetails(surface->format);
+	if (pixelFormatDetails == nullptr)
+		error("getting pixel format details failed");
+	return SDL_CreateSurface(width, height,
+					SDL_GetPixelFormatForMasks(
+						pixelFormatDetails->bits_per_pixel,
+						pixelFormatDetails->Rmask,
+						pixelFormatDetails->Gmask,
+						pixelFormatDetails->Bmask,
+						pixelFormatDetails->Amask));
+#else
+	return SDL_CreateRGBSurface(SDL_SWSURFACE,
+					width,
+					height,
+					surface->format->BitsPerPixel,
+					surface->format->Rmask,
+					surface->format->Gmask,
+					surface->format->Bmask,
+					surface->format->Amask);
+#endif
+}
+
+static const OSystem::GraphicsMode s_supportedGraphicsModes[] = {
+	{"rendersdl", _s("SDL Renderer"), GFX_RENDERSDL},
+	{nullptr, nullptr, 0}
+};
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+const OSystem::GraphicsMode s_supportedStretchModes[] = {
+	{"center", _s("Center"), STRETCH_CENTER},
+	{"pixel-perfect", _s("Pixel-perfect scaling"), STRETCH_INTEGRAL},
+	{"fit", _s("Fit to window"), STRETCH_FIT},
+	{"stretch", _s("Stretch to window"), STRETCH_STRETCH},
+	{"fit_force_aspect", _s("Fit to window (4:3)"), STRETCH_FIT_FORCE_ASPECT},
+	{nullptr, nullptr, 0}
+};
+#endif
+
+RenderSdlGraphicsManager::AspectRatio::AspectRatio(int w, int h) {
+	// TODO : Validation and so on...
+	// Currently, we just ensure the program don't instantiate non-supported aspect ratios
+	_kw = w;
+	_kh = h;
+}
+
+#if defined(USE_ASPECT)
+RenderSdlGraphicsManager::AspectRatio RenderSdlGraphicsManager::getDesiredAspectRatio() {
+	const size_t AR_COUNT = 4;
+	const char *desiredAspectRatioAsStrings[AR_COUNT] = {	"auto",				"4/3",				"16/9",				"16/10" };
+	const AspectRatio desiredAspectRatios[AR_COUNT] = {		AspectRatio(0, 0),	AspectRatio(4,3),	AspectRatio(16,9),	AspectRatio(16,10) };
+
+	//TODO : We could parse an arbitrary string, if we code enough proper validation
+	Common::String desiredAspectRatio = ConfMan.get("desired_screen_aspect_ratio");
+
+	for (size_t i = 0; i < AR_COUNT; i++) {
+		assert(desiredAspectRatioAsStrings[i] != nullptr);
+
+		if (!scumm_stricmp(desiredAspectRatio.c_str(), desiredAspectRatioAsStrings[i])) {
+			return desiredAspectRatios[i];
+		}
+	}
+	// TODO : Report a warning
+	return AspectRatio(0, 0);
+}
+#endif
+
+RenderSdlGraphicsManager::RenderSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window)
+	:
+	SdlGraphicsManager(sdlEventSource, window),
+#ifdef USE_OSD
+	_osdMessageSurface(nullptr), _osdMessageAlpha(SDL_ALPHA_TRANSPARENT), _osdMessageFadeStartTime(0),
+	_osdIconSurface(nullptr),
+#endif
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	_renderer(nullptr), _screenTexture(nullptr),
+#endif
+#if defined(WIN32) && !SDL_VERSION_ATLEAST(2, 0, 0)
+	_originalBitsPerPixel(0),
+#endif
+	_screen(nullptr), _tmpscreen(nullptr),
+	_screenFormat(Graphics::PixelFormat::createFormatCLUT8()),
+	_cursorFormat(Graphics::PixelFormat::createFormatCLUT8()),
+	_useOldSrc(false), _isHwPalette(false),
+	_overlayscreen(nullptr), _tmpscreen2(nullptr),
+	_screenChangeCount(0),
+	_mouseSurface(nullptr), _mouseScaler(nullptr),
+	_mouseOrigSurface(nullptr), _cursorDontScale(false), _cursorPaletteDisabled(true),
+	_currentShakeXOffset(0), _currentShakeYOffset(0),
+	_paletteDirtyStart(0), _paletteDirtyEnd(0),
+	_screenIsLocked(false),
+	_displayDisabled(false),
+#ifdef USE_SDL_DEBUG_FOCUSRECT
+	_enableFocusRectDebugCode(false), _enableFocusRect(false), _focusRect(),
+#endif
+	_transactionMode(kTransactionNone),
+	_scalerPlugins(ScalerMan.getPlugins()), _scalerPlugin(nullptr), _scaler(nullptr),
+	_needRestoreAfterOverlay(false), _isInOverlayPalette(false), _isDoubleBuf(false), _prevForceRedraw(false), _numPrevDirtyRects(0),
+	_prevCursorNeedsRedraw(false),
+	_mouseKeyColor(0), _disableMouseKeyColor(false) {
+
+	// allocate palette storage
+	_currentPalette = (SDL_Color *)calloc(256, sizeof(SDL_Color));
+	_overlayPalette = (SDL_Color *)calloc(256, sizeof(SDL_Color));
+	_cursorPalette = (SDL_Color *)calloc(256, sizeof(SDL_Color));
+
+	// Generate RGB332 palette for overlay
+	for (uint i = 0; i < 256; i++) {
+		_overlayPalette[i].r = ((i >> 5) & 7) << 5;
+		_overlayPalette[i].g = ((i >> 2) & 7) << 5;
+		_overlayPalette[i].b = (i & 3) << 6;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		_overlayPalette[i].a = 0xff;
+#endif
+	}
+
+	_mouseLastRect.x = _mouseLastRect.y = _mouseLastRect.w = _mouseLastRect.h = 0;
+	_mouseNextRect.x = _mouseNextRect.y = _mouseNextRect.w = _mouseNextRect.h = 0;
+
+#ifdef USE_SDL_DEBUG_FOCUSRECT
+	if (ConfMan.hasKey("use_sdl_debug_focusrect"))
+		_enableFocusRectDebugCode = ConfMan.getBool("use_sdl_debug_focusrect");
+#endif
+
+#if defined(USE_ASPECT)
+	_videoMode.aspectRatioCorrection = ConfMan.getBool("aspect_ratio");
+	_videoMode.desiredAspectRatio = getDesiredAspectRatio();
+#else // for small screen platforms
+	_videoMode.aspectRatioCorrection = false;
+#endif
+
+	_scaler = nullptr;
+	_maxExtraPixels = ScalerMan.getMaxExtraPixels();
+
+	_videoMode.fullscreen = ConfMan.getBool("fullscreen");
+	_videoMode.filtering = ConfMan.getBool("filtering");
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	_videoMode.stretchMode = STRETCH_FIT;
+#endif
+	_videoMode.vsync = ConfMan.getBool("vsync");
+
+	_videoMode.scalerIndex = getDefaultScaler();
+	_videoMode.scaleFactor = getDefaultScaleFactor();
+}
+
+RenderSdlGraphicsManager::~RenderSdlGraphicsManager() {
+	unloadGFXMode();
+	delete _scaler;
+	delete _mouseScaler;
+	if (_mouseOrigSurface) {
+		destroySurface(_mouseOrigSurface);
+		if (_mouseOrigSurface == _mouseSurface) {
+			_mouseSurface = nullptr;
+		}
+	}
+	if (_mouseSurface) {
+		destroySurface(_mouseSurface);
+	}
+	free(_currentPalette);
+	free(_overlayPalette);
+	free(_cursorPalette);
+}
+
+bool RenderSdlGraphicsManager::hasFeature(OSystem::Feature f) const {
+	return
+		(f == OSystem::kFeatureFullscreenMode) ||
+#ifdef USE_SCALERS
+		(f == OSystem::kFeatureScalers) ||
+#endif
+#ifdef USE_ASPECT
+		(f == OSystem::kFeatureAspectRatioCorrection) ||
+#endif
+		(f == OSystem::kFeatureFilteringMode) ||
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		(f == OSystem::kFeatureStretchMode) ||
+		(f == OSystem::kFeatureRotationMode) ||
+		(f == OSystem::kFeatureVSync) ||
+#endif
+		(f == OSystem::kFeatureCursorPalette) ||
+		(f == OSystem::kFeatureCursorAlpha && !_isHwPalette) ||
+		(f == OSystem::kFeatureIconifyWindow) ||
+		(f == OSystem::kFeatureCursorMask);
+}
+
+void RenderSdlGraphicsManager::setFeatureState(OSystem::Feature f, bool enable) {
+	switch (f) {
+	case OSystem::kFeatureFullscreenMode:
+		setFullscreenMode(enable);
+		break;
+#ifdef USE_ASPECT
+	case OSystem::kFeatureAspectRatioCorrection:
+		setAspectRatioCorrection(enable);
+		break;
+#endif
+	case OSystem::kFeatureFilteringMode:
+		setFilteringMode(enable);
+		break;
+	case OSystem::kFeatureVSync:
+		setVSync(enable);
+		break;
+	case OSystem::kFeatureCursorPalette:
+		_cursorPaletteDisabled = !enable;
+		blitCursor();
+		break;
+	case OSystem::kFeatureIconifyWindow:
+		if (enable)
+			_window->iconifyWindow();
+		break;
+	default:
+		break;
+	}
+}
+
+bool RenderSdlGraphicsManager::getFeatureState(OSystem::Feature f) const {
+	// We need to allow this to be called from within a transaction, since we
+	// currently use it to retrieve the graphics state, when switching from
+	// SDL->OpenGL mode for example.
+	//assert(_transactionMode == kTransactionNone);
+
+	switch (f) {
+	case OSystem::kFeatureFullscreenMode:
+		return _videoMode.fullscreen;
+#ifdef USE_ASPECT
+	case OSystem::kFeatureAspectRatioCorrection:
+		return _videoMode.aspectRatioCorrection;
+#endif
+	case OSystem::kFeatureVSync:
+		return _videoMode.vsync;
+	case OSystem::kFeatureFilteringMode:
+		return _videoMode.filtering;
+	case OSystem::kFeatureCursorPalette:
+		return !_cursorPaletteDisabled;
+	default:
+		return false;
+	}
+}
+
+const OSystem::GraphicsMode *RenderSdlGraphicsManager::getSupportedGraphicsModes() const {
+	return s_supportedGraphicsModes;
+}
+
+int RenderSdlGraphicsManager::getDefaultGraphicsMode() const {
+	return GFX_RENDERSDL;
+}
+
+bool RenderSdlGraphicsManager::setGraphicsMode(int mode, uint flags) {
+	Common::StackLock lock(_graphicsMutex);
+
+	assert(_transactionMode == kTransactionActive);
+
+	if (_oldVideoMode.setup && _oldVideoMode.mode == mode)
+		return true;
+
+	// Check this is a valid mode
+	const OSystem::GraphicsMode *sm = getSupportedGraphicsModes();
+	bool found = false;
+	while (sm->name) {
+		if (sm->id == mode) {
+			found = true;
+			break;
+		}
+		sm++;
+	}
+	if (!found) {
+		warning("unknown mode %d", mode);
+		return false;
+	}
+
+	_transactionDetails.needUpdatescreen = true;
+
+	_videoMode.mode = mode;
+
+	return true;
+}
+
+int RenderSdlGraphicsManager::getGraphicsMode() const {
+	return _videoMode.mode;
+}
+
+void RenderSdlGraphicsManager::beginGFXTransaction() {
+	assert(_transactionMode == kTransactionNone);
+
+	_transactionMode = kTransactionActive;
+
+	_transactionDetails.sizeChanged = false;
+
+	_transactionDetails.needHotswap = false;
+	_transactionDetails.needUpdatescreen = false;
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	_transactionDetails.needDisplayResize = false;
+	_transactionDetails.needTextureUpdate = false;
+#endif
+	_transactionDetails.formatChanged = false;
+
+	_oldVideoMode = _videoMode;
+}
+
+OSystem::TransactionError RenderSdlGraphicsManager::endGFXTransaction() {
+	int errors = OSystem::kTransactionSuccess;
+
+	assert(_transactionMode != kTransactionNone);
+
+	if (_transactionMode == kTransactionRollback) {
+		if (_videoMode.mode != _oldVideoMode.mode) {
+			errors |= OSystem::kTransactionModeSwitchFailed;
+
+			_videoMode.mode = _oldVideoMode.mode;
+		}
+
+		if (_videoMode.fullscreen != _oldVideoMode.fullscreen) {
+			errors |= OSystem::kTransactionFullscreenFailed;
+
+			_videoMode.fullscreen = _oldVideoMode.fullscreen;
+		}
+
+		if (_videoMode.aspectRatioCorrection != _oldVideoMode.aspectRatioCorrection) {
+			errors |= OSystem::kTransactionAspectRatioFailed;
+
+			_videoMode.aspectRatioCorrection = _oldVideoMode.aspectRatioCorrection;
+		}
+
+		if (_videoMode.scalerIndex != _oldVideoMode.scalerIndex) {
+			errors |= OSystem::kTransactionModeSwitchFailed;
+
+			_videoMode.scalerIndex = _oldVideoMode.scalerIndex;
+			_videoMode.scaleFactor = _oldVideoMode.scaleFactor;
+		}
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		if (_videoMode.stretchMode != _oldVideoMode.stretchMode) {
+			errors |= OSystem::kTransactionStretchModeSwitchFailed;
+
+			_videoMode.stretchMode = _oldVideoMode.stretchMode;
+		}
+#endif
+		if (_videoMode.vsync != _oldVideoMode.vsync) {
+			errors |= OSystem::kTransactionVSyncFailed;
+
+			_videoMode.vsync = _oldVideoMode.vsync;
+		}
+
+		if (_videoMode.filtering != _oldVideoMode.filtering) {
+			errors |= OSystem::kTransactionFilteringFailed;
+
+			_videoMode.filtering = _oldVideoMode.filtering;
+		}
+
+		if (_videoMode.format != _oldVideoMode.format) {
+			errors |= OSystem::kTransactionFormatNotSupported;
+
+			_videoMode.format = _oldVideoMode.format;
+			_screenFormat = _videoMode.format;
+		}
+
+		if (_videoMode.screenWidth != _oldVideoMode.screenWidth || _videoMode.screenHeight != _oldVideoMode.screenHeight) {
+			errors |= OSystem::kTransactionSizeChangeFailed;
+
+			_videoMode.screenWidth = _oldVideoMode.screenWidth;
+			_videoMode.screenHeight = _oldVideoMode.screenHeight;
+			_videoMode.overlayWidth = _oldVideoMode.overlayWidth;
+			_videoMode.overlayHeight = _oldVideoMode.overlayHeight;
+		}
+
+		// Our new video mode would now be exactly the same as the
+		// old one. Since we still can not assume SDL_SetVideoMode
+		// to be working fine, we need to invalidate the old video
+		// mode, so loadGFXMode would error out properly.
+		_oldVideoMode.setup = false;
+	}
+
+	if (_transactionDetails.sizeChanged || _transactionDetails.formatChanged) {
+		unloadGFXMode();
+		if (!loadGFXMode()) {
+			if (_oldVideoMode.setup) {
+				_transactionMode = kTransactionRollback;
+				errors |= endGFXTransaction();
+			}
+		} else {
+			setGraphicsModeIntern();
+			clearOverlay();
+
+			_videoMode.setup = true;
+			// OSystem_SDL::pollEvent used to update the screen change count,
+			// but actually it gives problems when a video mode was changed
+			// but OSystem_SDL::pollEvent was not called. This for example
+			// caused a crash under certain circumstances when returning to launcher.
+			// To fix this issue we update the screen change count right here.
+			_screenChangeCount++;
+		}
+	} else if (_transactionDetails.needHotswap) {
+		setGraphicsModeIntern();
+		if (!hotswapGFXMode()) {
+			if (_oldVideoMode.setup) {
+				_transactionMode = kTransactionRollback;
+				errors |= endGFXTransaction();
+			}
+		} else {
+			_videoMode.setup = true;
+			// OSystem_SDL::pollEvent used to update the screen change count,
+			// but actually it gives problems when a video mode was changed
+			// but OSystem_SDL::pollEvent was not called. This for example
+			// caused a crash under certain circumstances when returning to launcher.
+			// To fix this issue we update the screen change count right here.
+			_screenChangeCount++;
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+			if (_transactionDetails.needDisplayResize)
+				recalculateDisplayAreas();
+#endif
+			if (_transactionDetails.needUpdatescreen)
+				internUpdateScreen();
+		}
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	} else if (_transactionDetails.needTextureUpdate) {
+		setGraphicsModeIntern();
+		recreateScreenTexture();
+		if (_transactionDetails.needDisplayResize)
+			recalculateDisplayAreas();
+		internUpdateScreen();
+#endif
+	} else if (_transactionDetails.needUpdatescreen) {
+		setGraphicsModeIntern();
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		if (_transactionDetails.needDisplayResize)
+			recalculateDisplayAreas();
+#endif
+		internUpdateScreen();
+	}
+
+	_transactionMode = kTransactionNone;
+	return (OSystem::TransactionError)errors;
+}
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+Graphics::PixelFormat RenderSdlGraphicsManager::convertSDLPixelFormat(SDL_PixelFormat format) const {
+	const SDL_PixelFormatDetails *in = SDL_GetPixelFormatDetails(format);
+	assert(in);
+	if (in->bytes_per_pixel == 1 && (
+		    (in->Rmask == 0xff && in->Gmask == 0xff && in->Bmask == 0xff) ||
+		    (in->Rmask == 0 && in->Gmask == 0 && in->Bmask == 0)
+		    ))
+		return Graphics::PixelFormat::createFormatCLUT8();
+	Graphics::PixelFormat out(in->bytes_per_pixel,
+		in->Rbits, in->Gbits,
+		in->Bbits, in->Abits,
+		in->Rshift, in->Gshift,
+		in->Bshift, in->Ashift);
+
+	// Workaround to SDL not providing an accurate Aloss value on some platforms.
+	if (in->Amask == 0)
+		out.aLoss = 8;
+
+	return out;
+}
+#else
+Graphics::PixelFormat RenderSdlGraphicsManager::convertSDLPixelFormat(SDL_PixelFormat *in) const {
+	if (in->BytesPerPixel == 1 && (
+		    (in->Rmask == 0xff && in->Gmask == 0xff && in->Bmask == 0xff) ||
+		    (in->Rmask == 0 && in->Gmask == 0 && in->Bmask == 0)
+		    ))
+		return Graphics::PixelFormat::createFormatCLUT8();
+	Graphics::PixelFormat out(in->BytesPerPixel,
+		8 - in->Rloss, 8 - in->Gloss,
+		8 - in->Bloss, 8 - in->Aloss,
+		in->Rshift, in->Gshift,
+		in->Bshift, in->Ashift);
+
+	// Workaround to SDL not providing an accurate Aloss value on some platforms.
+	if (in->Amask == 0)
+		out.aLoss = 8;
+
+	return out;
+}
+#endif
+
+#ifdef USE_RGB_COLOR
+Common::List<Graphics::PixelFormat> RenderSdlGraphicsManager::getSupportedFormats() const {
+	assert(!_supportedFormats.empty());
+	return _supportedFormats;
+}
+
+void RenderSdlGraphicsManager::detectSupportedFormats() {
+	_supportedFormats.clear();
+
+	Graphics::PixelFormat format = Graphics::PixelFormat::createFormatCLUT8();
+
+	if (_hwScreen) {
+		// Get our currently set hardware format
+		Graphics::PixelFormat hwFormat = convertSDLPixelFormat(_hwScreen->format);
+
+		// This is the first supported format to prevent pixel format conversion
+		// on blitting. This gives us a lot more performance on low perf hardware.
+		_supportedFormats.push_back(hwFormat);
+
+		format = hwFormat;
+	}
+
+	if (!_isHwPalette) {
+		// Some tables with standard formats that we always list
+		// as "supported". If frontend code tries to use one of
+		// these, we will perform the necessary format
+		// conversion in the background. Of course this incurs a
+		// performance hit, but on desktop ports this should not
+		// matter. We still push the currently active format to
+		// the front, so if frontend code just uses the first
+		// available format, it will get one that is "cheap" to
+		// use.
+		const Graphics::PixelFormat RGBList[] = {
+			// RGBA8888, ARGB8888, RGB888
+			Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0),
+			Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24),
+			Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0),
+			// RGB565, XRGB1555, RGB555, RGBA4444, ARGB4444
+			Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0),
+			Graphics::PixelFormat(2, 5, 5, 5, 1, 10, 5, 0, 15),
+			Graphics::PixelFormat(2, 5, 5, 5, 0, 10, 5, 0, 0),
+			Graphics::PixelFormat(2, 4, 4, 4, 4, 12, 8, 4, 0),
+			Graphics::PixelFormat(2, 4, 4, 4, 4, 8, 4, 0, 12)
+		};
+		const Graphics::PixelFormat BGRList[] = {
+			// ABGR8888, BGRA8888, BGR888
+			Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24),
+			Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0),
+			Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0),
+			// BGR565, XBGR1555, BGR555, ABGR4444, BGRA4444
+			Graphics::PixelFormat(2, 5, 6, 5, 0, 0, 5, 11, 0),
+			Graphics::PixelFormat(2, 5, 5, 5, 1, 0, 5, 10, 15),
+			Graphics::PixelFormat(2, 5, 5, 5, 0, 0, 5, 10, 0),
+			Graphics::PixelFormat(2, 4, 4, 4, 4, 0, 4, 8, 12),
+			Graphics::PixelFormat(2, 4, 4, 4, 4, 4, 8, 12, 0)
+		};
+
+		// TODO: prioritize matching alpha masks
+		int i;
+
+		// Push some RGB formats
+		for (i = 0; i < ARRAYSIZE(RGBList); i++) {
+			if (_hwScreen && (RGBList[i].bytesPerPixel > format.bytesPerPixel))
+				continue;
+			if (RGBList[i] != format)
+				_supportedFormats.push_back(RGBList[i]);
+		}
+
+		// Push some BGR formats
+		for (i = 0; i < ARRAYSIZE(BGRList); i++) {
+			if (_hwScreen && (BGRList[i].bytesPerPixel > format.bytesPerPixel))
+				continue;
+			if (BGRList[i] != format)
+				_supportedFormats.push_back(BGRList[i]);
+		}
+	}
+
+	// Finally, we always supposed 8 bit palette graphics
+	_supportedFormats.push_back(Graphics::PixelFormat::createFormatCLUT8());
+}
+#endif
+
+uint RenderSdlGraphicsManager::getDefaultScaler() const {
+	return ScalerMan.findScalerPluginIndex("normal");
+}
+
+uint RenderSdlGraphicsManager::getDefaultScaleFactor() const {
+#if defined (USE_SCALERS)
+	return 2;
+#else
+	return 1;
+#endif
+}
+
+bool RenderSdlGraphicsManager::setScaler(uint mode, int factor) {
+	Common::StackLock lock(_graphicsMutex);
+
+	assert(_transactionMode == kTransactionActive);
+
+	if (_oldVideoMode.setup && _oldVideoMode.scalerIndex == mode && _oldVideoMode.scaleFactor == factor)
+		return true;
+
+	int newFactor;
+	if (factor == -1)
+		newFactor = getDefaultScaleFactor();
+	else if (_scalerPlugins[mode]->get<ScalerPluginObject>().hasFactor(factor))
+		newFactor = factor;
+	else if (_scalerPlugins[mode]->get<ScalerPluginObject>().hasFactor(_oldVideoMode.scaleFactor))
+		newFactor = _oldVideoMode.scaleFactor;
+	else
+		newFactor = _scalerPlugins[mode]->get<ScalerPluginObject>().getDefaultFactor();
+
+	if (_oldVideoMode.setup && _oldVideoMode.scaleFactor != newFactor)
+		_transactionDetails.needHotswap = true;
+
+	_transactionDetails.needUpdatescreen = true;
+
+	_videoMode.scalerIndex = mode;
+	_videoMode.scaleFactor = newFactor;
+
+	return true;
+}
+
+void RenderSdlGraphicsManager::setGraphicsModeIntern() {
+	Common::StackLock lock(_graphicsMutex);
+
+	if (!_screen || !_hwScreen)
+		return;
+
+
+	// If the scalerIndex has changed, change scaler plugins
+	if (&_scalerPlugins[_videoMode.scalerIndex]->get<ScalerPluginObject>() != _scalerPlugin
+		|| _transactionDetails.formatChanged) {
+		Graphics::PixelFormat format = convertSDLPixelFormat(_hwScreen->format);
+		delete _scaler;
+
+		_scalerPlugin = &_scalerPlugins[_videoMode.scalerIndex]->get<ScalerPluginObject>();
+		_scaler = _scalerPlugin->createInstance(format);
+
+		if (_mouseScaler != nullptr) {
+			delete _mouseScaler;
+			_mouseScaler = _scalerPlugin->createInstance(_cursorFormat);
+		}
+	}
+
+	_scaler->setFactor(_videoMode.scaleFactor);
+	_extraPixels = _scalerPlugin->extraPixels();
+	_useOldSrc = _scalerPlugin->useOldSource();
+	if (_useOldSrc) {
+		_scaler->enableSource(true);
+		_scaler->setSource((byte *)_tmpscreen->pixels, _tmpscreen->pitch,
+									_videoMode.screenWidth, _videoMode.screenHeight, _maxExtraPixels);
+	}
+
+	// Blit everything to the screen
+	_forceRedraw = true;
+
+	// Even if the old and new scale factors are the same, we may have a
+	// different scaler for the cursor now.
+	blitCursor();
+}
+
+uint RenderSdlGraphicsManager::getScaler() const {
+	assert(_transactionMode == kTransactionNone);
+	return _videoMode.scalerIndex;
+}
+
+uint RenderSdlGraphicsManager::getScaleFactor() const {
+	assert(_transactionMode == kTransactionNone);
+	return _videoMode.scaleFactor;
+}
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+const OSystem::GraphicsMode *RenderSdlGraphicsManager::getSupportedStretchModes() const {
+	return s_supportedStretchModes;
+}
+
+int RenderSdlGraphicsManager::getDefaultStretchMode() const {
+	return STRETCH_FIT;
+}
+
+bool RenderSdlGraphicsManager::setStretchMode(int mode) {
+	Common::StackLock lock(_graphicsMutex);
+
+	assert(_transactionMode == kTransactionActive);
+
+	if (_oldVideoMode.setup && _oldVideoMode.stretchMode == mode)
+		return true;
+
+	// Check this is a valid mode
+	const OSystem::GraphicsMode *sm = s_supportedStretchModes;
+	bool found = false;
+	while (sm->name) {
+		if (sm->id == mode) {
+			found = true;
+			break;
+		}
+		sm++;
+	}
+	if (!found) {
+		warning("unknown stretch mode %d", mode);
+		return false;
+	}
+
+	_transactionDetails.needUpdatescreen = true;
+	_transactionDetails.needDisplayResize = true;
+
+	_videoMode.stretchMode = mode;
+
+	return true;
+}
+
+int RenderSdlGraphicsManager::getStretchMode() const {
+	return _videoMode.stretchMode;
+}
+#endif
+
+void RenderSdlGraphicsManager::getDefaultResolution(uint &w, uint &h) {
+	w = 320;
+	h = 200;
+}
+
+void RenderSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFormat *format) {
+	assert(_transactionMode == kTransactionActive);
+
+	_gameScreenShakeXOffset = 0;
+	_gameScreenShakeYOffset = 0;
+
+	if (w == 0) {
+		getDefaultResolution(w, h);
+	}
+
+	//avoid redundant format changes
+	Graphics::PixelFormat newFormat;
+	if (!format)
+		newFormat = Graphics::PixelFormat::createFormatCLUT8();
+	else
+		newFormat = *format;
+
+	assert(newFormat.bytesPerPixel > 0);
+
+	if (newFormat != _videoMode.format) {
+		_videoMode.format = newFormat;
+		_transactionDetails.formatChanged = true;
+		_screenFormat = newFormat;
+	}
+
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
+	// Avoid redundant res changes, only in SDL1. In SDL2, redundancies may not
+	// actually be redundant if ScummVM is switching between game engines and
+	// the screen dimensions are being reinitialized, since window resizing is
+	// supposed to reset when this happens
+	if ((int)w == _videoMode.screenWidth && (int)h == _videoMode.screenHeight)
+		return;
+#endif
+
+	if ((int)w != _videoMode.screenWidth || (int)h != _videoMode.screenHeight) {
+		const bool useDefault = defaultGraphicsModeConfig();
+		int scaleFactor = ConfMan.getInt("scale_factor");
+		if (scaleFactor == -1)
+			scaleFactor = getDefaultScaleFactor();
+		int mode = _videoMode.scalerIndex;
+		if (useDefault && w > 320) {
+			// The default scaler is assumed to be for low
+			// resolution games. For high resolution games, pick
+			// the largest scale factor that gives at most the
+			// same window width.
+			scaleFactor = MAX<uint>(1, (scaleFactor * 320) / w);
+
+			// Check that the current scaler is available at the
+			// new scale factor. If not, the normal scaler is
+			// assumed to be available at any reasonable factor,
+			// and is - of course -the only one that has a 1x mode.
+			const Common::Array<uint> &factors = _scalerPlugins[mode]->get<ScalerPluginObject>().getFactors();
+			if (Common::find(factors.begin(), factors.end(), (uint)scaleFactor) == factors.end()) {
+				mode = ScalerMan.findScalerPluginIndex("normal");
+			}
+		}
+		setScaler(mode, scaleFactor);
+	}
+
+	_videoMode.screenWidth = w;
+	_videoMode.screenHeight = h;
+
+	_transactionDetails.sizeChanged = true;
+}
+
+void RenderSdlGraphicsManager::fixupResolutionForAspectRatio(AspectRatio desiredAspectRatio, int &width, int &height) const {
+	assert(&width != &height);
+
+	if (desiredAspectRatio.isAuto())
+		return;
+
+	int kw = desiredAspectRatio.kw();
+	int kh = desiredAspectRatio.kh();
+
+	const int w = width;
+	const int h = height;
+
+	int bestW = 0, bestH = 0;
+	uint bestMetric = (uint)-1; // Metric is wasted space
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	int numModes;
+	const int display = _window->getDisplayIndex();
+	SDL_DisplayMode** modes = SDL_GetFullscreenDisplayModes(display, &numModes);
+	for (int i = 0; i < numModes; ++i) {
+		SDL_DisplayMode* mode = modes[i];
+#elif SDL_VERSION_ATLEAST(2, 0, 0)
+	const int display = _window->getDisplayIndex();
+	const int numModes = SDL_GetNumDisplayModes(display);
+	SDL_DisplayMode modeData, *mode = &modeData;
+	for (int i = 0; i < numModes; ++i) {
+		if (SDL_GetDisplayMode(display, i, &modeData)) {
+			continue;
+		}
+#else
+	SDL_Rect const* const*availableModes = SDL_ListModes(NULL, SDL_FULLSCREEN|SDL_SWSURFACE); //TODO : Maybe specify a pixel format
+	assert(availableModes);
+
+	while (const SDL_Rect *mode = *availableModes++) {
+#endif
+		if (mode->w < w)
+			continue;
+		if (mode->h < h)
+			continue;
+		if (mode->h * kw != mode->w * kh)
+			continue;
+
+		uint metric = mode->w * mode->h - w * h;
+		if (metric > bestMetric)
+			continue;
+
+		bestMetric = metric;
+		bestW = mode->w;
+		bestH = mode->h;
+
+	// Make editors a bit more happy by having the same amount of closing as
+	// opening curley braces.
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	}
+	SDL_free(modes);
+#elif SDL_VERSION_ATLEAST(2, 0, 0)
+	}
+#else
+	}
+#endif
+
+	if (!bestW || !bestH) {
+		warning("Unable to enforce the desired aspect ratio");
+		return;
+	}
+	width = bestW;
+	height = bestH;
+}
+
+void RenderSdlGraphicsManager::setupHardwareSize() {
+	_videoMode.overlayWidth = _videoMode.screenWidth * _videoMode.scaleFactor;
+	_videoMode.overlayHeight = _videoMode.screenHeight * _videoMode.scaleFactor;
+
+	if (_videoMode.screenHeight != 200 && _videoMode.screenHeight != 400)
+		_videoMode.aspectRatioCorrection = false;
+
+	_videoMode.hardwareWidth = _videoMode.screenWidth * _videoMode.scaleFactor;
+	_videoMode.hardwareHeight = _videoMode.screenHeight * _videoMode.scaleFactor;
+
+	if (_videoMode.aspectRatioCorrection) {
+		_videoMode.overlayHeight = real2Aspect(_videoMode.overlayHeight);
+		_videoMode.hardwareHeight = real2Aspect(_videoMode.hardwareHeight);
+	}
+}
+
+void RenderSdlGraphicsManager::initGraphicsSurface() {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	Uint32 flags = 0;
+#else
+	Uint32 flags = SDL_SWSURFACE;
+#endif
+	if (_videoMode.fullscreen)
+		flags |= SDL_FULLSCREEN;
+
+	_hwScreen = SDL_SetVideoMode(_videoMode.hardwareWidth, _videoMode.hardwareHeight, 16, flags);
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	_isDoubleBuf = false;
+	_isHwPalette = false;
+#else
+	_isDoubleBuf = flags & SDL_DOUBLEBUF;
+	_isHwPalette = flags & SDL_HWPALETTE;
+#endif
+}
+
+bool RenderSdlGraphicsManager::loadGFXMode() {
+	_forceRedraw = true;
+
+	setupHardwareSize();
+
+	//
+	// Create the surface that contains the game data
+	//
+
+	const Graphics::PixelFormat &format = _screenFormat;
+	const Uint32 rMask = ((0xFF >> format.rLoss) << format.rShift);
+	const Uint32 gMask = ((0xFF >> format.gLoss) << format.gShift);
+	const Uint32 bMask = ((0xFF >> format.bLoss) << format.bShift);
+	const Uint32 aMask = ((0xFF >> format.aLoss) << format.aShift);
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	_screen = SDL_CreateSurface(_videoMode.screenWidth, _videoMode.screenHeight,
+						SDL_GetPixelFormatForMasks(_screenFormat.bytesPerPixel * 8, rMask, gMask, bMask, aMask));
+#else
+	_screen = SDL_CreateRGBSurface(SDL_SWSURFACE, _videoMode.screenWidth, _videoMode.screenHeight,
+						_screenFormat.bytesPerPixel * 8, rMask, gMask, bMask, aMask);
+#endif
+	if (_screen == nullptr)
+		error("allocating _screen failed");
+
+	// Avoid having SDL_SRCALPHA set even if we supplied an alpha-channel in the format.
+	SDL_SetAlpha(_screen, 0, 255);
+
+	// SDL 1.2 palettes default to all black,
+	// SDL 1.3 palettes default to all white,
+	// Thus set our own default palette to all black.
+	// SDL_SetColors does nothing for non indexed surfaces.
+	SDL_SetColors(_screen, _currentPalette, 0, 256);
+
+	//
+	// Create the surface that contains the scaled graphics in 16 bit mode
+	//
+
+	if (_videoMode.fullscreen) {
+		fixupResolutionForAspectRatio(_videoMode.desiredAspectRatio, _videoMode.hardwareWidth, _videoMode.hardwareHeight);
+	}
+
+
+#ifdef ENABLE_EVENTRECORDER
+	_displayDisabled = ConfMan.getBool("disable_display");
+
+	if (_displayDisabled) {
+		_hwScreen = g_eventRec.getSurface(_videoMode.hardwareWidth, _videoMode.hardwareHeight);
+	} else
+#endif
+	{
+#if defined(WIN32) && !SDL_VERSION_ATLEAST(2, 0, 0)
+		// Save the original bpp to be able to restore the video mode on
+		// unload. See _originalBitsPerPixel documentation.
+		if (_originalBitsPerPixel == 0) {
+			const SDL_VideoInfo *videoInfo = SDL_GetVideoInfo();
+			_originalBitsPerPixel = videoInfo->vfmt->BitsPerPixel;
+		}
+#endif
+
+		initGraphicsSurface();
+	}
+
+#ifdef USE_RGB_COLOR
+	detectSupportedFormats();
+#endif
+
+	if (_hwScreen == nullptr) {
+		// DON'T use error(), as this tries to bring up the debug
+		// console, which WON'T WORK now that _hwScreen is hosed.
+
+		if (!_oldVideoMode.setup) {
+			warning("SDL_SetVideoMode says we can't switch to that mode (%s)", SDL_GetError());
+			g_system->quit();
+		} else {
+			return false;
+		}
+	}
+
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
+	handleResize(_videoMode.hardwareWidth, _videoMode.hardwareHeight);
+#endif
+
+	//
+	// Create the surface used for the graphics in 16 bit before scaling, and also the overlay
+	//
+
+	// Need some extra bytes around when using 2xSaI
+	_tmpscreen = createSurface(_videoMode.screenWidth + _maxExtraPixels * 2, _videoMode.screenHeight + _maxExtraPixels * 2, _hwScreen);
+	if (_tmpscreen == nullptr)
+		error("allocating _tmpscreen failed");
+
+	if (_useOldSrc) {
+		// Create surface containing previous frame's data to pass to scaler
+		_scaler->setSource((byte *)_tmpscreen->pixels, _tmpscreen->pitch,
+									_videoMode.screenWidth, _videoMode.screenHeight, _maxExtraPixels);
+	}
+
+	_overlayscreen = createSurface(_videoMode.overlayWidth, _videoMode.overlayHeight, _hwScreen);
+	if (_overlayscreen == nullptr)
+		error("allocating _overlayscreen failed");
+
+	_overlayFormat = convertSDLPixelFormat(_overlayscreen->format);
+	// Overlay uses RGB332 palette
+	if (_overlayFormat.bytesPerPixel == 1 && _overlayFormat.rBits() == 0)
+		_overlayFormat = Graphics::PixelFormat(1, 3, 3, 2, 0, 5, 2, 0, 0);
+
+	_tmpscreen2 = createSurface(_videoMode.overlayWidth + _maxExtraPixels * 2, _videoMode.overlayHeight + _maxExtraPixels * 2, _hwScreen);
+	if (_tmpscreen2 == nullptr)
+		error("allocating _tmpscreen2 failed");
+
+	if (_isHwPalette) {
+		if (!_screenFormat.isCLUT8())
+			return false;
+
+		SDL_SetColors(_tmpscreen2, _overlayPalette, 0, 256);
+		SDL_SetColors(_overlayscreen, _overlayPalette, 0, 256);
+	}
+
+	return true;
+}
+
+void RenderSdlGraphicsManager::unloadGFXMode() {
+	if (_screen) {
+		destroySurface(_screen);
+		_screen = nullptr;
+	}
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	deinitializeRenderer();
+#endif
+
+	if (_hwScreen) {
+		destroySurface(_hwScreen);
+		_hwScreen = nullptr;
+	}
+
+	if (_tmpscreen) {
+		destroySurface(_tmpscreen);
+		_tmpscreen = nullptr;
+	}
+
+	if (_tmpscreen2) {
+		destroySurface(_tmpscreen2);
+		_tmpscreen2 = nullptr;
+	}
+
+	if (_overlayscreen) {
+		destroySurface(_overlayscreen);
+		_overlayscreen = nullptr;
+	}
+
+#ifdef USE_OSD
+	if (_osdMessageSurface) {
+		destroySurface(_osdMessageSurface);
+		_osdMessageSurface = nullptr;
+	}
+
+	if (_osdIconSurface) {
+		destroySurface(_osdIconSurface);
+		_osdIconSurface = nullptr;
+	}
+#endif
+
+#if defined(WIN32) && !SDL_VERSION_ATLEAST(2, 0, 0)
+	// Reset video mode to original.
+	// This will ensure that any new graphic manager will use the initial BPP
+	// when listing available modes. See _originalBitsPerPixel documentation.
+	if (_originalBitsPerPixel != 0)
+		SDL_SetVideoMode(_videoMode.screenWidth, _videoMode.screenHeight, _originalBitsPerPixel, _videoMode.fullscreen ? (SDL_FULLSCREEN | SDL_SWSURFACE) : SDL_SWSURFACE);
+#endif
+}
+
+bool RenderSdlGraphicsManager::hotswapGFXMode() {
+	if (!_screen)
+		return false;
+
+	// Keep around the old _screen & _overlayscreen so we can restore the screen data
+	// after the mode switch.
+	SDL_Surface *old_screen = _screen;
+	_screen = nullptr;
+	SDL_Surface *old_overlayscreen = _overlayscreen;
+	_overlayscreen = nullptr;
+
+	// Release the HW screen surface
+	if (_hwScreen) {
+		destroySurface(_hwScreen);
+		_hwScreen = nullptr;
+	}
+	if (_tmpscreen) {
+		destroySurface(_tmpscreen);
+		_tmpscreen = nullptr;
+	}
+	if (_tmpscreen2) {
+		destroySurface(_tmpscreen2);
+		_tmpscreen2 = nullptr;
+	}
+
+	// Setup the new GFX mode
+	if (!loadGFXMode()) {
+		unloadGFXMode();
+
+		_screen = old_screen;
+		_overlayscreen = old_overlayscreen;
+
+		return false;
+	}
+
+	// reset palette
+	SDL_SetColors(_screen, _currentPalette, 0, 256);
+
+	// Restore old screen content
+	SDL_BlitSurface(old_screen, nullptr, _screen, nullptr);
+	SDL_BlitSurface(old_overlayscreen, nullptr, _overlayscreen, nullptr);
+
+	// Free the old surfaces
+	destroySurface(old_screen);
+	destroySurface(old_overlayscreen);
+
+	// Update cursor to new scale
+	blitCursor();
+
+	// Blit everything to the screen
+	internUpdateScreen();
+
+	return true;
+}
+
+void RenderSdlGraphicsManager::updateScreen() {
+	assert(_transactionMode == kTransactionNone);
+
+	Common::StackLock lock(_graphicsMutex);	// Lock the mutex until this function ends
+
+	internUpdateScreen();
+}
+
+void RenderSdlGraphicsManager::updateScreen(SDL_Rect *dirtyRectList, int actualDirtyRects) {
+	SDL_UpdateRects(_hwScreen, actualDirtyRects, dirtyRectList);
+}
+
+void RenderSdlGraphicsManager::internUpdateScreen() {
+	SDL_Surface *srcSurf, *origSurf;
+	int height, width;
+	int scale1;
+
+	// If there's an active debugger, update it
+	GUI::Debugger *debugger = g_engine ? g_engine->getDebugger() : nullptr;
+	if (debugger)
+		debugger->onFrame();
+
+	bool curCursorNeedsRedraw = _cursorNeedsRedraw;
+	if (_prevCursorNeedsRedraw && _isDoubleBuf) {
+		_cursorNeedsRedraw = true;
+	}
+	_prevCursorNeedsRedraw = curCursorNeedsRedraw;
+
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
+	// If the shake position changed, fill the dirty area with blackness
+	// When building with SDL2, the shake offset is added to the active rect instead,
+	// so this isn't needed there.
+	if (_currentShakeXOffset != _gameScreenShakeXOffset ||
+		(_cursorNeedsRedraw && _mouseLastRect.x <= _currentShakeXOffset)) {
+		SDL_Rect blackrect = {0, 0, (Uint16)(_videoMode.screenWidth * _videoMode.scaleFactor), (Uint16)(_videoMode.screenHeight * _videoMode.scaleFactor)};
+
+		if (_gameScreenShakeXOffset >= 0)
+			blackrect.w = (Uint16)(_gameScreenShakeXOffset * _videoMode.scaleFactor);
+		else {
+			blackrect.w = ((-_gameScreenShakeXOffset) * _videoMode.scaleFactor);
+			blackrect.x = ((_videoMode.screenWidth + _gameScreenShakeXOffset) * _videoMode.scaleFactor);
+		}
+
+		if (_videoMode.aspectRatioCorrection && !_overlayVisible) {
+			blackrect.h = real2Aspect(blackrect.h - 1) + 1;
+		}
+
+		SDL_FillRect(_hwScreen, &blackrect, 0);
+
+		_currentShakeXOffset = _gameScreenShakeXOffset;
+
+		_forceRedraw = true;
+	}
+	if (_currentShakeYOffset != _gameScreenShakeYOffset ||
+		(_cursorNeedsRedraw && _mouseLastRect.y <= _currentShakeYOffset)) {
+		SDL_Rect blackrect = {0, 0, (Uint16)(_videoMode.screenWidth * _videoMode.scaleFactor), (Uint16)(_videoMode.screenHeight * _videoMode.scaleFactor)};
+
+		if (_gameScreenShakeYOffset >= 0)
+			blackrect.h = (Uint16)(_gameScreenShakeYOffset * _videoMode.scaleFactor);
+		else {
+			blackrect.h = ((-_gameScreenShakeYOffset) * _videoMode.scaleFactor);
+			blackrect.y = ((_videoMode.screenHeight + _gameScreenShakeYOffset) * _videoMode.scaleFactor);
+		}
+
+		if (_videoMode.aspectRatioCorrection && !_overlayVisible) {
+			blackrect.y = real2Aspect(blackrect.y);
+			blackrect.h = real2Aspect(blackrect.h + blackrect.y - 1) - blackrect.y + 1;
+		}
+
+		SDL_FillRect(_hwScreen, &blackrect, 0);
+
+		_currentShakeYOffset = _gameScreenShakeYOffset;
+
+		_forceRedraw = true;
+	}
+#endif
+
+	// Check whether the palette was changed in the meantime and update the
+	// screen surface accordingly.
+	if (_screen && _paletteDirtyEnd != 0) {
+		SDL_SetColors(_screen, _currentPalette + _paletteDirtyStart,
+			_paletteDirtyStart,
+			_paletteDirtyEnd - _paletteDirtyStart);
+		if (_isHwPalette)
+			SDL_SetColors(_tmpscreen, _currentPalette + _paletteDirtyStart,
+				      _paletteDirtyStart,
+				      _paletteDirtyEnd - _paletteDirtyStart);
+		if (_isHwPalette && !_isInOverlayPalette)
+			SDL_SetColors(_hwScreen, _currentPalette + _paletteDirtyStart,
+				       _paletteDirtyStart,
+				       _paletteDirtyEnd - _paletteDirtyStart);
+
+		_paletteDirtyEnd = 0;
+
+		_forceRedraw = true;
+	}
+
+	int oldScaleFactor;
+
+	if (!_overlayVisible) {
+		if (_needRestoreAfterOverlay) {
+			// This is needed for the Edge scaler which seems to be the only scaler to use the "_useOldSrc" feature.
+			// Otherwise the screen will not be properly restored after removing the overlay. We need to trigger a
+			// regeneration of SourceScaler::_bufferedOutput. The call to _scaler->setFactor() down below could
+			// do that in theory, but it won't unless the factor actually changes (which it doesn't). Now, the code
+			// in SourceScaler::setSource() looks a bit fishy, e. g. the *src argument isn't even used. But otherwise
+			// it does what we want here at least...
+			_scaler->setSource(nullptr, _tmpscreen->pitch, _videoMode.screenWidth, _videoMode.screenHeight, _maxExtraPixels);
+		}
+
+		origSurf = _screen;
+		srcSurf = _tmpscreen;
+		width = _videoMode.screenWidth;
+		height = _videoMode.screenHeight;
+		oldScaleFactor = scale1 = _videoMode.scaleFactor;
+		_needRestoreAfterOverlay = false;
+	} else {
+		origSurf = _overlayscreen;
+		srcSurf = _tmpscreen2;
+		width = _videoMode.overlayWidth;
+		height = _videoMode.overlayHeight;
+		scale1 = 1;
+		oldScaleFactor = _scaler->setFactor(1);
+		_needRestoreAfterOverlay = _useOldSrc;
+	}
+
+	// Add the area covered by the mouse cursor to the list of dirty rects if
+	// we have to redraw the mouse, or if the cursor is alpha-blended since
+	// alpha-blended cursors will happily blend into themselves if the surface
+	// under the cursor is not reset first
+	if (_cursorNeedsRedraw || _cursorFormat.aBits() > 1)
+		undrawMouse();
+
+#ifdef USE_OSD
+	updateOSD();
+#endif
+
+	if (_isHwPalette && _isInOverlayPalette != _overlayVisible) {
+		SDL_SetColors(_hwScreen, _overlayVisible ? _overlayPalette : _currentPalette, 0, 256);
+		_forceRedraw = true;
+		_isInOverlayPalette = _overlayVisible;
+	}
+
+	// In case of double buferring partially good version may be on another page,
+	// so we need to fully redraw
+	if (_isDoubleBuf && _numDirtyRects)
+		_forceRedraw = true;
+
+#if defined(USE_IMGUI) && (defined(USE_IMGUI_SDLRENDERER2) || defined(USE_IMGUI_SDLRENDERER3))
+	if (_imGuiCallbacks.render) {
+		_forceRedraw = true;
+	}
+#endif
+
+	bool doRedraw = _forceRedraw || (_prevForceRedraw && _isDoubleBuf);
+	int actualDirtyRects = _numDirtyRects;
+	if (_isDoubleBuf && _numPrevDirtyRects > 0) {
+		memcpy(_dirtyRectList + _numDirtyRects, _prevDirtyRectList, _numPrevDirtyRects * sizeof(_dirtyRectList[0]));
+		actualDirtyRects += _numPrevDirtyRects;
+	}
+
+	// Force a full redraw if requested.
+	// If _useOldSrc, the scaler will do its own partial updates.
+	if (doRedraw) {
+		actualDirtyRects = 1;
+		_dirtyRectList[0].x = 0;
+		_dirtyRectList[0].y = 0;
+		_dirtyRectList[0].w = width;
+		_dirtyRectList[0].h = height;
+	}
+
+	_prevForceRedraw = _forceRedraw;
+	if (!_prevForceRedraw && _numDirtyRects && _isDoubleBuf) {
+		memcpy(_prevDirtyRectList, _dirtyRectList, _numDirtyRects * sizeof(_dirtyRectList[0]));
+		_numPrevDirtyRects = _numDirtyRects;
+	}
+
+	// Only draw anything if necessary
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	bool doPresent = false;
+#endif
+	if (actualDirtyRects > 0 || _cursorNeedsRedraw) {
+		SDL_Rect *r;
+		SDL_Rect dst;
+		uint32 bpp, srcPitch, dstPitch;
+		SDL_Rect *lastRect = _dirtyRectList + actualDirtyRects;
+
+		for (r = _dirtyRectList; r != lastRect; ++r) {
+			dst = *r;
+			dst.x += _maxExtraPixels;	// Shift rect since some scalers need to access the data around
+			dst.y += _maxExtraPixels;	// any pixel to scale it, and we want to avoid mem access crashes.
+
+			if (!blitSurface(origSurf, r, srcSurf, &dst))
+				error("SDL_BlitSurface failed: %s", SDL_GetError());
+		}
+
+		SDL_LockSurface(srcSurf);
+		SDL_LockSurface(_hwScreen);
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		const SDL_PixelFormatDetails *pixelFormatDetails = SDL_GetPixelFormatDetails(_hwScreen->format);
+		if (!pixelFormatDetails)
+			error("SDL_GetPixelFormatDetails failed: %s", SDL_GetError());
+		bpp = pixelFormatDetails->bytes_per_pixel;
+#else
+		bpp = _hwScreen->format->BytesPerPixel;
+#endif
+		srcPitch = srcSurf->pitch;
+		dstPitch = _hwScreen->pitch;
+
+		for (r = _dirtyRectList; r != lastRect; ++r) {
+			int src_x = r->x;
+			int src_y = r->y;
+			int dst_x = r->x;
+			int dst_y = r->y;
+			int dst_w = r->w;
+			int dst_h = r->h;
+#ifdef USE_ASPECT
+			int orig_dst_y = 0;
+#endif
+			dst_x += _currentShakeXOffset;
+			if (dst_x < 0) {
+				src_x -= dst_x;
+				dst_w += dst_x;
+				dst_x = 0;
+			}
+
+			dst_y += _currentShakeYOffset;
+			if (dst_y < 0) {
+				src_y -= dst_y;
+				dst_h += dst_y;
+				dst_y = 0;
+			}
+
+			if (dst_x < width && dst_y < height && dst_w > 0 && dst_h > 0) {
+				if (dst_w > width - dst_x)
+					dst_w = width - dst_x;
+				if (dst_w > width - src_x)
+					dst_w = width - src_x;
+
+				if (dst_h > height - dst_y)
+					dst_h = height - dst_y;
+				if (dst_h > height - src_y)
+					dst_h = height - src_y;
+
+#ifdef USE_ASPECT
+				orig_dst_y = dst_y;
+#endif
+				dst_x *= scale1;
+				dst_y *= scale1;
+
+				if (_videoMode.aspectRatioCorrection && !_overlayVisible)
+					dst_y = real2Aspect(dst_y);
+
+				_scaler->scale((byte *)srcSurf->pixels + (src_x + _maxExtraPixels) * bpp + (src_y + _maxExtraPixels) * srcPitch, srcPitch,
+						(byte *)_hwScreen->pixels + dst_x * bpp + dst_y * dstPitch, dstPitch, dst_w, dst_h, src_x, src_y);
+
+				r->x = dst_x;
+				r->y = dst_y;
+				r->w = dst_w * scale1;
+				r->h = dst_h * scale1;
+
+#ifdef USE_ASPECT
+				if (_videoMode.aspectRatioCorrection && orig_dst_y < height && !_overlayVisible)
+					r->h = stretch200To240((uint8 *) _hwScreen->pixels, dstPitch, r->w, r->h, r->x, r->y, orig_dst_y * scale1, _videoMode.filtering, 	convertSDLPixelFormat(_hwScreen->format));
+#endif
+			}
+		}
+		SDL_UnlockSurface(srcSurf);
+		SDL_UnlockSurface(_hwScreen);
+
+		// Readjust the dirty rect list in case we are doing a full update.
+		// This is necessary if shaking is active.
+		if (_forceRedraw) {
+			_dirtyRectList[0].x = 0;
+			_dirtyRectList[0].y = 0;
+			_dirtyRectList[0].w = _videoMode.hardwareWidth;
+			_dirtyRectList[0].h = _videoMode.hardwareHeight;
+		}
+
+		drawMouse();
+
+#ifdef USE_OSD
+		drawOSD();
+#endif
+
+#ifdef USE_SDL_DEBUG_FOCUSRECT
+		// We draw the focus rectangle on top of everything, to assure it's easily visible.
+		// Of course when the GUI overlay is visible we do not show it, since it is only for game
+		// specific focus.
+		if (_enableFocusRect && !_overlayInGUI) {
+			int x = _focusRect.left + _currentShakeXOffset;
+			int y = _focusRect.top + _currentShakeYOffset;
+
+			if (x < width && y < height) {
+				int w = _focusRect.width();
+				if (w > width - x)
+					w = width - x;
+
+				int h = _focusRect.height();
+				if (h > height - y)
+					h = height - y;
+
+				x *= scale1;
+				y *= scale1;
+				w *= scale1;
+				h *= scale1;
+
+				if (_videoMode.aspectRatioCorrection && !_overlayVisible)
+					y = real2Aspect(y);
+
+				if (h > 0 && w > 0) {
+					SDL_LockSurface(_hwScreen);
+
+					// Use white as color for now.
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+					Uint32 rectColor = SDL_MapSurfaceRGB(_hwScreen, 0xFF, 0xFF, 0xFF);
+#else
+					Uint32 rectColor = SDL_MapRGB(_hwScreen->format, 0xFF, 0xFF, 0xFF);
+#endif
+
+					// First draw the top and bottom lines
+					// then draw the left and right lines
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+					if (pixelFormatDetails->bytes_per_pixel == 2) {
+#else
+					if (_hwScreen->format->BytesPerPixel == 2) {
+#endif
+						uint16 *top = (uint16 *)((byte *)_hwScreen->pixels + y * _hwScreen->pitch + x * 2);
+						uint16 *bottom = (uint16 *)((byte *)_hwScreen->pixels + (y + h) * _hwScreen->pitch + x * 2);
+						byte *left = ((byte *)_hwScreen->pixels + y * _hwScreen->pitch + x * 2);
+						byte *right = ((byte *)_hwScreen->pixels + y * _hwScreen->pitch + (x + w - 1) * 2);
+
+						while (w--) {
+							*top++ = rectColor;
+							*bottom++ = rectColor;
+						}
+
+						while (h--) {
+							*(uint16 *)left = rectColor;
+							*(uint16 *)right = rectColor;
+
+							left += _hwScreen->pitch;
+							right += _hwScreen->pitch;
+						}
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+					} else if (pixelFormatDetails->bytes_per_pixel == 4) {
+#else
+					} else if (_hwScreen->format->BytesPerPixel == 4) {
+#endif
+						uint32 *top = (uint32 *)((byte *)_hwScreen->pixels + y * _hwScreen->pitch + x * 4);
+						uint32 *bottom = (uint32 *)((byte *)_hwScreen->pixels + (y + h) * _hwScreen->pitch + x * 4);
+						byte *left = ((byte *)_hwScreen->pixels + y * _hwScreen->pitch + x * 4);
+						byte *right = ((byte *)_hwScreen->pixels + y * _hwScreen->pitch + (x + w - 1) * 4);
+
+						while (w--) {
+							*top++ = rectColor;
+							*bottom++ = rectColor;
+						}
+
+						while (h--) {
+							*(uint32 *)left = rectColor;
+							*(uint32 *)right = rectColor;
+
+							left += _hwScreen->pitch;
+							right += _hwScreen->pitch;
+						}
+					}
+
+					SDL_UnlockSurface(_hwScreen);
+				}
+			}
+		}
+#endif
+
+		// Finally, blit all our changes to the screen
+		if (!_displayDisabled) {
+			updateScreen(_dirtyRectList, actualDirtyRects);
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+			doPresent = true;
+#endif
+		}
+	}
+
+	// Set up the old scale factor
+	if (_scaler)
+		_scaler->setFactor(oldScaleFactor);
+
+	_numDirtyRects = 0;
+	_forceRedraw = false;
+	_cursorNeedsRedraw = false;
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+
+#if defined(USE_IMGUI) && (defined(USE_IMGUI_SDLRENDERER2) || defined(USE_IMGUI_SDLRENDERER3))
+	renderImGui();
+#endif
+
+	if (doPresent) {
+		SDL_RenderPresent(_renderer);
+	}
+#else
+	if (_isDoubleBuf)
+		SDL_Flip(_hwScreen);
+#endif
+}
+
+bool RenderSdlGraphicsManager::saveScreenshot(const Common::Path &filename) const {
+	assert(_hwScreen != nullptr);
+
+	Common::StackLock lock(_graphicsMutex);
+
+	Common::DumpFile out;
+	if (!out.open(filename)) {
+		return false;
+	}
+
+	if (!lockSurface(_hwScreen)) {
+		warning("Could not lock RGB surface");
+		return false;
+	}
+
+	Graphics::PixelFormat format = convertSDLPixelFormat(_hwScreen->format);
+	Graphics::Surface data;
+	data.init(_hwScreen->w, _hwScreen->h, _hwScreen->pitch, _hwScreen->pixels, format);
+
+	bool success;
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	SDL_Palette *sdlPalette = SDL_CreateSurfacePalette(_hwScreen);
+#else
+	SDL_Palette *sdlPalette = _hwScreen->format->palette;
+#endif
+	if (sdlPalette) {
+		byte palette[256 * 3];
+		for (int i = 0; i < sdlPalette->ncolors; i++) {
+			palette[(i * 3) + 0] = sdlPalette->colors[i].r;
+			palette[(i * 3) + 1] = sdlPalette->colors[i].g;
+			palette[(i * 3) + 2] = sdlPalette->colors[i].b;
+		}
+
+#ifdef USE_PNG
+		success = Image::writePNG(out, data, palette);
+#else
+		success = Image::writeBMP(out, data, palette);
+#endif
+	} else {
+#ifdef USE_PNG
+		success = Image::writePNG(out, data);
+#else
+		success = Image::writeBMP(out, data);
+#endif
+	}
+
+	SDL_UnlockSurface(_hwScreen);
+
+	return success;
+}
+
+void RenderSdlGraphicsManager::setFullscreenMode(bool enable) {
+	Common::StackLock lock(_graphicsMutex);
+
+	if (!g_system->hasFeature(OSystem::kFeatureFullscreenMode))
+		return;
+
+	if (_oldVideoMode.setup && _oldVideoMode.fullscreen == enable)
+		return;
+
+	if (_transactionMode == kTransactionActive) {
+		_videoMode.fullscreen = enable;
+		_transactionDetails.needHotswap = true;
+	}
+}
+
+void RenderSdlGraphicsManager::setVSync(bool enable) {
+	Common::StackLock lock(_graphicsMutex);
+
+	if (!g_system->hasFeature(OSystem::kFeatureVSync))
+		return;
+
+	if (_oldVideoMode.setup && _oldVideoMode.vsync == enable)
+		return;
+
+	if (_transactionMode == kTransactionActive) {
+		_videoMode.vsync = enable;
+		_transactionDetails.needHotswap = true;
+	}
+}
+
+void RenderSdlGraphicsManager::setAspectRatioCorrection(bool enable) {
+	Common::StackLock lock(_graphicsMutex);
+
+	if (_oldVideoMode.setup && _oldVideoMode.aspectRatioCorrection == enable)
+		return;
+
+	if (_transactionMode == kTransactionActive) {
+		_videoMode.aspectRatioCorrection = enable;
+		_transactionDetails.needHotswap = true;
+	}
+}
+
+void RenderSdlGraphicsManager::setFilteringMode(bool enable) {
+	Common::StackLock lock(_graphicsMutex);
+
+	if (_oldVideoMode.setup && _oldVideoMode.filtering == enable)
+		return;
+
+	if (_transactionMode == kTransactionActive) {
+		_videoMode.filtering = enable;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		_transactionDetails.needTextureUpdate = true;
+#endif
+	}
+}
+
+void RenderSdlGraphicsManager::copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) {
+	assert(_transactionMode == kTransactionNone);
+	assert(buf);
+
+	if (_screen == nullptr) {
+		warning("RenderSdlGraphicsManager::copyRectToScreen: _screen == NULL");
+		return;
+	}
+
+	Common::StackLock lock(_graphicsMutex);	// Lock the mutex until this function ends
+
+	assert(x >= 0 && x < _videoMode.screenWidth);
+	assert(y >= 0 && y < _videoMode.screenHeight);
+	assert(h > 0 && y + h <= _videoMode.screenHeight);
+	assert(w > 0 && x + w <= _videoMode.screenWidth);
+
+	addDirtyRect(x, y, w, h, false);
+
+	// Try to lock the screen surface
+	if (!lockSurface(_screen))
+		error("SDL_LockSurface failed: %s", SDL_GetError());
+
+	byte *dst = (byte *)_screen->pixels + y * _screen->pitch + x * _screenFormat.bytesPerPixel;
+	if (_videoMode.screenWidth == w && pitch == _screen->pitch) {
+		memcpy(dst, buf, h*pitch);
+	} else {
+		const byte *src = (const byte *)buf;
+		do {
+			memcpy(dst, src, w * _screenFormat.bytesPerPixel);
+			src += pitch;
+			dst += _screen->pitch;
+		} while (--h);
+	}
+
+	// Unlock the screen surface
+	SDL_UnlockSurface(_screen);
+}
+
+Graphics::Surface *RenderSdlGraphicsManager::lockScreen() {
+	assert(_transactionMode == kTransactionNone);
+
+	// Lock the graphics mutex
+	_graphicsMutex.lock();
+
+	// paranoia check
+	assert(!_screenIsLocked);
+	_screenIsLocked = true;
+
+	// Try to lock the screen surface
+	if (!lockSurface(_screen))
+		error("SDL_LockSurface failed: %s", SDL_GetError());
+
+	_framebuffer.init(_screen->w, _screen->h, _screen->pitch, _screen->pixels, _screenFormat);
+
+	return &_framebuffer;
+}
+
+void RenderSdlGraphicsManager::unlockScreen() {
+	assert(_transactionMode == kTransactionNone);
+
+	// paranoia check
+	assert(_screenIsLocked);
+	_screenIsLocked = false;
+
+	// Unlock the screen surface
+	SDL_UnlockSurface(_screen);
+
+	// Trigger a full screen update
+	_forceRedraw = true;
+
+	// Finally unlock the graphics mutex
+	_graphicsMutex.unlock();
+}
+
+void RenderSdlGraphicsManager::fillScreen(uint32 col) {
+	Graphics::Surface *screen = lockScreen();
+	if (screen)
+		screen->fillRect(Common::Rect(screen->w, screen->h), col);
+	unlockScreen();
+}
+
+void RenderSdlGraphicsManager::fillScreen(const Common::Rect &r, uint32 col) {
+	Graphics::Surface *screen = lockScreen();
+	if (screen)
+		screen->fillRect(r, col);
+	unlockScreen();
+}
+
+void RenderSdlGraphicsManager::addDirtyRect(int x, int y, int w, int h, bool inOverlay, bool realCoordinates) {
+	if (_forceRedraw)
+		return;
+
+	if (_numDirtyRects == NUM_DIRTY_RECT) {
+		_forceRedraw = true;
+		return;
+	}
+
+	int height, width;
+
+	if (!inOverlay && !realCoordinates) {
+		width = _videoMode.screenWidth;
+		height = _videoMode.screenHeight;
+	} else {
+		width = _videoMode.overlayWidth;
+		height = _videoMode.overlayHeight;
+	}
+
+	// Extend the dirty region for scalers
+	// that "smear" the screen, e.g. 2xSAI
+	if (!realCoordinates) {
+		// Aspect ratio correction requires this to be at least one
+		int adjust = MAX(_extraPixels, (uint)1);
+		x -= adjust;
+		y -= adjust;
+		w += adjust * 2;
+		h += adjust * 2;
+	}
+
+	// clip
+	if (x < 0) {
+		w += x;
+		x = 0;
+	}
+
+	if (y < 0) {
+		h += y;
+		y = 0;
+	}
+
+	if (w > width - x) {
+		w = width - x;
+	}
+
+	if (h > height - y) {
+		h = height - y;
+	}
+
+#ifdef USE_ASPECT
+	if (_videoMode.aspectRatioCorrection && !inOverlay && !realCoordinates)
+		makeRectStretchable(x, y, w, h, _videoMode.filtering);
+#endif
+
+	if (w == width && h == height) {
+		_forceRedraw = true;
+		return;
+	}
+
+	if (w > 0 && h > 0) {
+		SDL_Rect *r = &_dirtyRectList[_numDirtyRects++];
+
+		r->x = x;
+		r->y = y;
+		r->w = w;
+		r->h = h;
+	}
+}
+
+int16 RenderSdlGraphicsManager::getHeight() const {
+	return _videoMode.screenHeight;
+}
+
+int16 RenderSdlGraphicsManager::getWidth() const {
+	return _videoMode.screenWidth;
+}
+
+void RenderSdlGraphicsManager::setPalette(const byte *colors, uint start, uint num) {
+	assert(colors);
+	assert(_screenFormat.bytesPerPixel == 1);
+
+	// Setting the palette before _screen is created is allowed - for now -
+	// since we don't actually set the palette until the screen is updated.
+	// But it could indicate a programming error, so let's warn about it.
+
+	if (!_screen)
+		warning("RenderSdlGraphicsManager::setPalette: _screen == NULL");
+
+	const byte *b = colors;
+	uint i;
+	SDL_Color *base = _currentPalette + start;
+	for (i = 0; i < num; i++, b += 3) {
+		base[i].r = b[0];
+		base[i].g = b[1];
+		base[i].b = b[2];
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		base[i].a = 255;
+#endif
+	}
+
+	if (start < _paletteDirtyStart)
+		_paletteDirtyStart = start;
+
+	if (start + num > _paletteDirtyEnd)
+		_paletteDirtyEnd = start + num;
+
+	// Some games blink cursors with palette
+	if (_cursorPaletteDisabled)
+		blitCursor();
+}
+
+void RenderSdlGraphicsManager::grabPalette(byte *colors, uint start, uint num) const {
+	assert(colors);
+	assert(_screenFormat.bytesPerPixel == 1);
+
+	const SDL_Color *base = _currentPalette + start;
+
+	for (uint i = 0; i < num; ++i) {
+		colors[i * 3] = base[i].r;
+		colors[i * 3 + 1] = base[i].g;
+		colors[i * 3 + 2] = base[i].b;
+	}
+}
+
+void RenderSdlGraphicsManager::setCursorPalette(const byte *colors, uint start, uint num) {
+	assert(colors);
+	const byte *b = colors;
+	uint i;
+	SDL_Color *base = _cursorPalette + start;
+	for (i = 0; i < num; i++, b += 3) {
+		base[i].r = b[0];
+		base[i].g = b[1];
+		base[i].b = b[2];
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		base[i].a = 255;
+#endif
+	}
+
+	_cursorPaletteDisabled = false;
+	blitCursor();
+}
+
+void RenderSdlGraphicsManager::setFocusRectangle(const Common::Rect &rect) {
+#ifdef USE_SDL_DEBUG_FOCUSRECT
+	// Only enable focus rectangle debug code, when the user wants it
+	if (!_enableFocusRectDebugCode)
+		return;
+
+	_enableFocusRect = true;
+	_focusRect = rect;
+
+	if (rect.left < 0 || rect.top < 0 || rect.right > _videoMode.screenWidth || rect.bottom > _videoMode.screenHeight)
+		warning("RenderSdlGraphicsManager::setFocusRectangle: Got a rect which does not fit inside the screen bounds: %d,%d,%d,%d", rect.left, rect.top, rect.right, rect.bottom);
+
+	// It's gross but we actually sometimes get rects, which are not inside the screen bounds,
+	// thus we need to clip the rect here...
+	_focusRect.clip(_videoMode.screenWidth, _videoMode.screenHeight);
+
+	// We just fake this as a dirty rect for now, to easily force a screen update whenever
+	// the rect changes.
+	addDirtyRect(_focusRect.left, _focusRect.top, _focusRect.width(), _focusRect.height(), false);
+#endif
+}
+
+void RenderSdlGraphicsManager::clearFocusRectangle() {
+#ifdef USE_SDL_DEBUG_FOCUSRECT
+	// Only enable focus rectangle debug code, when the user wants it
+	if (!_enableFocusRectDebugCode)
+		return;
+
+	_enableFocusRect = false;
+
+	// We just fake this as a dirty rect for now, to easily force a screen update whenever
+	// the rect changes.
+	addDirtyRect(_focusRect.left, _focusRect.top, _focusRect.width(), _focusRect.height(), false);
+#endif
+}
+
+#pragma mark -
+#pragma mark --- Overlays ---
+#pragma mark -
+
+void RenderSdlGraphicsManager::clearOverlay() {
+	Common::StackLock lock(_graphicsMutex);	// Lock the mutex until this function ends
+
+	if (!_overlayVisible)
+		return;
+
+	// Clear the overlay by making the game screen "look through" everywhere.
+	SDL_Rect src, dst;
+	src.x = src.y = 0;
+	dst.x = dst.y = _maxExtraPixels;
+	src.w = dst.w = _videoMode.screenWidth;
+	src.h = dst.h = _videoMode.screenHeight;
+	if (!blitSurface(_screen, &src, _tmpscreen, &dst))
+		error("SDL_BlitSurface failed: %s", SDL_GetError());
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	const SDL_PixelFormatDetails *pixelFormatDetails = SDL_GetPixelFormatDetails(_tmpscreen->format);
+	if (!pixelFormatDetails)
+		error("SDL_GetPixelFormatDetails failed: %s", SDL_GetError());
+#endif
+
+	SDL_LockSurface(_tmpscreen);
+	SDL_LockSurface(_overlayscreen);
+
+	// Transpose from game palette to RGB332 (overlay palette)
+	if (_isHwPalette) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		byte *p = (byte *)(_tmpscreen->pixels) + _maxExtraPixels * _tmpscreen->pitch + _maxExtraPixels * pixelFormatDetails->bytes_per_pixel;
+#else
+		byte *p = (byte *)(_tmpscreen->pixels) + _maxExtraPixels * _tmpscreen->pitch + _maxExtraPixels * _tmpscreen->format->BytesPerPixel;
+#endif
+		int pitchSkip = _tmpscreen->pitch - _videoMode.screenWidth;
+		for (int y = 0; y < _videoMode.screenHeight; y++) {
+			for (int x = 0; x < _videoMode.screenWidth; x++, p++) {
+				const SDL_Color &col = _currentPalette[*p];
+				*p = (col.r & 0xe0) | ((col.g >> 3) & 0x1c) | ((col.b >> 6) & 0x03);
+			}
+			p += pitchSkip;
+		}
+	}
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	_scaler->scale((byte *)(_tmpscreen->pixels) + _maxExtraPixels * _tmpscreen->pitch + _maxExtraPixels * pixelFormatDetails->bytes_per_pixel, _tmpscreen->pitch,
+#else
+	_scaler->scale((byte *)(_tmpscreen->pixels) + _maxExtraPixels * _tmpscreen->pitch + _maxExtraPixels * _tmpscreen->format->BytesPerPixel, _tmpscreen->pitch,
+#endif
+	(byte *)_overlayscreen->pixels, _overlayscreen->pitch, _videoMode.screenWidth, _videoMode.screenHeight, 0, 0);
+
+#ifdef USE_ASPECT
+	if (_videoMode.aspectRatioCorrection)
+		stretch200To240((uint8 *)_overlayscreen->pixels, _overlayscreen->pitch,
+						_videoMode.overlayWidth, _videoMode.screenHeight * _videoMode.scaleFactor, 0, 0, 0,
+						_videoMode.filtering, _overlayFormat);
+#endif
+	SDL_UnlockSurface(_tmpscreen);
+	SDL_UnlockSurface(_overlayscreen);
+
+	_forceRedraw = true;
+}
+
+void RenderSdlGraphicsManager::grabOverlay(Graphics::Surface &surface) const {
+	assert(_transactionMode == kTransactionNone);
+
+	if (_overlayscreen == nullptr)
+		return;
+
+	if (!lockSurface(_overlayscreen))
+		error("SDL_LockSurface failed: %s", SDL_GetError());
+
+	assert(surface.w >= _videoMode.overlayWidth);
+	assert(surface.h >= _videoMode.overlayHeight);
+	assert(surface.format.bytesPerPixel == _overlayFormat.bytesPerPixel);
+
+	byte *src = (byte *)_overlayscreen->pixels;
+	byte *dst = (byte *)surface.getPixels();
+	Graphics::copyBlit(dst, src, surface.pitch, _overlayscreen->pitch,
+		_videoMode.overlayWidth, _videoMode.overlayHeight, _overlayFormat.bytesPerPixel);
+
+	SDL_UnlockSurface(_overlayscreen);
+}
+
+void RenderSdlGraphicsManager::copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) {
+	assert(_transactionMode == kTransactionNone);
+
+	if (_overlayscreen == nullptr)
+		return;
+
+	const byte *src = (const byte *)buf;
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	const SDL_PixelFormatDetails *pixelFormatDetails = SDL_GetPixelFormatDetails(_overlayscreen->format);
+	if (!pixelFormatDetails)
+		error("SDL_GetPixelFormatDetails failed: %s", SDL_GetError());
+	uint bpp = pixelFormatDetails->bytes_per_pixel;
+#else
+	uint bpp = _overlayscreen->format->BytesPerPixel;
+#endif
+
+	// Clip the coordinates
+	if (x < 0) {
+		w += x;
+		src -= x * bpp;
+		x = 0;
+	}
+
+	if (y < 0) {
+		h += y;
+		src -= y * pitch;
+		y = 0;
+	}
+
+	if (w > _videoMode.overlayWidth - x) {
+		w = _videoMode.overlayWidth - x;
+	}
+
+	if (h > _videoMode.overlayHeight - y) {
+		h = _videoMode.overlayHeight - y;
+	}
+
+	if (w <= 0 || h <= 0)
+		return;
+
+	// Mark the modified region as dirty
+	addDirtyRect(x, y, w, h, true);
+
+	if (!lockSurface(_overlayscreen))
+		error("SDL_LockSurface failed: %s", SDL_GetError());
+
+	byte *dst = (byte *)_overlayscreen->pixels + y * _overlayscreen->pitch + x * bpp;
+	do {
+		memcpy(dst, src, w * bpp);
+		dst += _overlayscreen->pitch;
+		src += pitch;
+	} while (--h);
+
+	SDL_UnlockSurface(_overlayscreen);
+}
+
+
+#pragma mark -
+#pragma mark --- Mouse ---
+#pragma mark -
+
+void RenderSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keyColor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask, bool disableKeyColor) {
+
+	if (mask && (!format || format->bytesPerPixel == 1)) {
+		// 8-bit masked cursor, RenderSdl has no alpha mask support so we must convert this to color key
+		const byte *bufBytes = static_cast<const byte *>(buf);
+
+		uint numPixelUsingColor[256];
+		for (uint i = 0; i < 256; i++)
+			numPixelUsingColor[i] = 0;
+
+		uint numPixels = w * h;
+
+		for (uint i = 0; i < numPixels; i++) {
+			if (mask[i] == kCursorMaskOpaque)
+				numPixelUsingColor[bufBytes[i]]++;
+		}
+
+		uint bestColorNumPixels = 0xffffffffu;
+		uint bestKey = 0;
+		for (uint i = 0; i < 256; i++) {
+			if (numPixelUsingColor[i] < bestColorNumPixels) {
+				bestColorNumPixels = numPixelUsingColor[i];
+				bestKey = i;
+				if (bestColorNumPixels == 0)
+					break;
+			}
+		}
+
+		if (bestColorNumPixels != 0)
+			warning("RenderSdlGraphicsManager::setMouseCursor: A mask was specified for an 8-bit cursor but the cursor couldn't be converted to color key");
+
+		Common::Array<byte> maskedImage;
+		maskedImage.resize(w * h);
+		for (uint i = 0; i < numPixels; i++) {
+			if (mask[i] == kCursorMaskOpaque)
+				maskedImage[i] = bufBytes[i];
+			else
+				maskedImage[i] = static_cast<byte>(bestKey);
+		}
+
+		setMouseCursor(&maskedImage[0], w, h, hotspotX, hotspotY, bestKey, dontScale, format, nullptr, disableKeyColor);
+		return;
+	}
+
+	if (mask && format && format->bytesPerPixel > 1 && !_isHwPalette) {
+		const uint numPixels = w * h;
+		const uint inBPP = format->bytesPerPixel;
+
+		Graphics::PixelFormat formatWithAlpha = Graphics::createPixelFormat<8888>();
+
+		// Use the existing format if it already has alpha
+		if (format->aBits() > 0)
+			formatWithAlpha = *format;
+
+		const uint outBPP = formatWithAlpha.bytesPerPixel;
+
+		Common::Array<byte> maskedImage;
+		maskedImage.resize(numPixels * outBPP);
+
+		uint32 inColor = 0;
+		byte *inColorPtr = reinterpret_cast<byte *>(&inColor);
+#ifdef SCUMM_BIG_ENDIAN
+		inColorPtr += 4 - inBPP;
+#endif
+
+		uint32 outColor = 0;
+		byte *outColorPtr = reinterpret_cast<byte *>(&outColor);
+#ifdef SCUMM_BIG_ENDIAN
+		outColorPtr += 4 - inBPP;
+#endif
+
+		for (uint i = 0; i < numPixels; i++) {
+			if (mask[i] != kCursorMaskOpaque)
+				outColor = 0;
+			else {
+				memcpy(inColorPtr, static_cast<const byte *>(buf) + i * inBPP, inBPP);
+
+				uint8 r = 0;
+				uint8 g = 0;
+				uint8 b = 0;
+				uint8 a = 0;
+				format->colorToARGB(inColor, a, r, g, b);
+				if (a == 0)
+					outColor = 0;
+				else
+					outColor = formatWithAlpha.ARGBToColor(a, r, g, b);
+			}
+			memcpy(&maskedImage[i * outBPP], outColorPtr, outBPP);
+		}
+
+		// Disable the key color because SDL_SetColorKey ignores the alpha channel, which would make 0xFF000000 transparent
+		setMouseCursor(&maskedImage[0], w, h, hotspotX, hotspotY, 0, dontScale, &formatWithAlpha, nullptr, true);
+		return;
+	}
+
+	bool formatChanged = false;
+
+	if (format) {
+		assert(format->bytesPerPixel == 1 || !_isHwPalette);
+
+		if (format->bytesPerPixel != _cursorFormat.bytesPerPixel) {
+			formatChanged = true;
+		}
+		_cursorFormat = *format;
+	} else {
+		if (_cursorFormat.bytesPerPixel != 1) {
+			formatChanged = true;
+		}
+		_cursorFormat = Graphics::PixelFormat::createFormatCLUT8();
+	}
+
+	if (_cursorFormat.bytesPerPixel < 4) {
+		assert(keyColor < 1U << (_cursorFormat.bytesPerPixel * 8));
+	}
+
+	_mouseCurState.hotX = hotspotX;
+	_mouseCurState.hotY = hotspotY;
+
+	bool keycolorChanged = false;
+
+	if (_mouseKeyColor != keyColor || _disableMouseKeyColor != disableKeyColor) {
+		_mouseKeyColor = keyColor;
+		_disableMouseKeyColor = disableKeyColor;
+		keycolorChanged = true;
+	}
+
+	_cursorDontScale = dontScale;
+
+	if (_mouseCurState.w != (int)w || _mouseCurState.h != (int)h || formatChanged || !_mouseOrigSurface) {
+		_mouseCurState.w = w;
+		_mouseCurState.h = h;
+
+		if (_mouseOrigSurface) {
+			destroySurface(_mouseOrigSurface);
+
+			if (_mouseSurface == _mouseOrigSurface) {
+				_mouseSurface = nullptr;
+			}
+
+			_mouseOrigSurface = nullptr;
+		}
+
+		if (formatChanged && _mouseSurface) {
+			destroySurface(_mouseSurface);
+			_mouseSurface = nullptr;
+		}
+
+		if (!w || !h) {
+			return;
+		}
+
+		assert(!_mouseOrigSurface);
+
+		// Allocate bigger surface because scalers will read past the boudaries.
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		_mouseOrigSurface = SDL_CreateSurface(
+						_mouseCurState.w + _maxExtraPixels * 2,
+						_mouseCurState.h + _maxExtraPixels * 2,
+						SDL_GetPixelFormatForMasks(
+							_cursorFormat.bytesPerPixel * 8,
+							((0xFF >> _cursorFormat.rLoss) << _cursorFormat.rShift),
+							((0xFF >> _cursorFormat.gLoss) << _cursorFormat.gShift),
+							((0xFF >> _cursorFormat.bLoss) << _cursorFormat.bShift),
+							((0xFF >> _cursorFormat.aLoss) << _cursorFormat.aShift)));
+#else
+		_mouseOrigSurface = SDL_CreateRGBSurface(SDL_SWSURFACE,
+						_mouseCurState.w + _maxExtraPixels * 2,
+						_mouseCurState.h + _maxExtraPixels * 2,
+						_cursorFormat.bytesPerPixel * 8,
+						((0xFF >> _cursorFormat.rLoss) << _cursorFormat.rShift),
+						((0xFF >> _cursorFormat.gLoss) << _cursorFormat.gShift),
+						((0xFF >> _cursorFormat.bLoss) << _cursorFormat.bShift),
+						((0xFF >> _cursorFormat.aLoss) << _cursorFormat.aShift));
+#endif
+
+		if (_mouseOrigSurface == nullptr) {
+			error("Allocating _mouseOrigSurface failed");
+		}
+
+#ifdef USE_SCALERS
+		if (_mouseScaler != nullptr) {
+			delete _mouseScaler;
+			_mouseScaler = nullptr;
+		}
+		if (_scalerPlugin) {
+			_mouseScaler = _scalerPlugin->createInstance(_cursorFormat);
+		}
+#endif
+
+		// Force setup of border
+		keycolorChanged = true;
+	}
+
+	if (keycolorChanged) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		uint32 flags = _disableMouseKeyColor ? 0 : SDL_SRCCOLORKEY | SDL_SRCALPHA;
+		SDL_SetSurfaceColorKey(_mouseOrigSurface, flags, _mouseKeyColor);
+		SDL_SetSurfaceRLE(_mouseOrigSurface, !_disableMouseKeyColor);
+#else
+		uint32 flags = _disableMouseKeyColor ? 0 : SDL_RLEACCEL | SDL_SRCCOLORKEY | SDL_SRCALPHA;
+		SDL_SetColorKey(_mouseOrigSurface, flags, _mouseKeyColor);
+#endif
+	}
+
+	SDL_LockSurface(_mouseOrigSurface);
+
+	if (keycolorChanged && _mouseScaler && _maxExtraPixels > 0 && _cursorFormat.aBits() == 0) {
+		// We have extra pixels and no alpha channel, we must use color key on the borders
+		Graphics::Surface cursorSurface;
+		Common::Rect border(0, 0, _mouseCurState.w + _maxExtraPixels * 2, _mouseCurState.h + _maxExtraPixels * 2);
+		cursorSurface.init(border.width(), border.height(), border.width() * _cursorFormat.bytesPerPixel,
+				_mouseOrigSurface->pixels, _cursorFormat);
+		for(unsigned int i = 0; i < _maxExtraPixels; i++) {
+			cursorSurface.frameRect(border, _mouseKeyColor);
+			border.grow(-1);
+		}
+	}
+
+	// Draw from [_maxExtraPixels,_maxExtraPixels] since scalers will read past boudaries
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	Graphics::copyBlit((byte *)_mouseOrigSurface->pixels + _mouseOrigSurface->pitch * _maxExtraPixels + _maxExtraPixels * _cursorFormat.bytesPerPixel,
+	                   (const byte *)buf, _mouseOrigSurface->pitch, w * _cursorFormat.bytesPerPixel, w, h, _cursorFormat.bytesPerPixel);
+#else
+	Graphics::copyBlit((byte *)_mouseOrigSurface->pixels + _mouseOrigSurface->pitch * _maxExtraPixels + _maxExtraPixels * _mouseOrigSurface->format->BytesPerPixel,
+	                   (const byte *)buf, _mouseOrigSurface->pitch, w * _cursorFormat.bytesPerPixel, w, h, _cursorFormat.bytesPerPixel);
+#endif
+	SDL_UnlockSurface(_mouseOrigSurface);
+
+	blitCursor();
+}
+
+void RenderSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keyColor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
+	setMouseCursor(buf, w, h, hotspotX, hotspotY, keyColor, dontScale, format, mask, false);
+}
+
+void RenderSdlGraphicsManager::blitCursor() {
+	const int w = _mouseCurState.w;
+	const int h = _mouseCurState.h;
+
+	if (!w || !h || !_mouseOrigSurface) {
+		return;
+	}
+
+	_cursorNeedsRedraw = true;
+
+	int cursorScale;
+	if (_cursorDontScale) {
+		// Don't scale the cursor at all if the user requests this behavior.
+		cursorScale = 1;
+	} else {
+		// Scale the cursor with the game screen scale factor.
+		cursorScale = _videoMode.scaleFactor;
+	}
+
+	// Adapt the real hotspot according to the scale factor.
+	int rW = w * cursorScale;
+	int rH = h * cursorScale;
+	_mouseCurState.rHotX = _mouseCurState.hotX * cursorScale;
+	_mouseCurState.rHotY = _mouseCurState.hotY * cursorScale;
+
+	// The virtual dimensions will be the same as the original.
+
+	_mouseCurState.vW = w;
+	_mouseCurState.vH = h;
+	_mouseCurState.vHotX = _mouseCurState.hotX;
+	_mouseCurState.vHotY = _mouseCurState.hotY;
+
+#ifdef USE_ASPECT
+	// store original to pass to aspect-correction function later
+	const int rH1 = rH;
+#endif
+
+	if (!_cursorDontScale && _videoMode.aspectRatioCorrection) {
+		rH = real2Aspect(rH - 1) + 1;
+		_mouseCurState.rHotY = real2Aspect(_mouseCurState.rHotY);
+	}
+
+	bool sizeChanged = false;
+	if (_mouseCurState.rW != rW || _mouseCurState.rH != rH) {
+		_mouseCurState.rW = rW;
+		_mouseCurState.rH = rH;
+		sizeChanged = true;
+	}
+
+	if (sizeChanged || !_mouseSurface) {
+		if (_mouseSurface)
+			destroySurface(_mouseSurface);
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		const SDL_PixelFormatDetails *pixelFormatDetails = SDL_GetPixelFormatDetails(_mouseOrigSurface->format);
+		if (pixelFormatDetails == nullptr)
+			error("getting pixel format details failed");
+		_mouseSurface = SDL_CreateSurface(
+			_mouseCurState.rW,
+			_mouseCurState.rH,
+			SDL_GetPixelFormatForMasks(
+				pixelFormatDetails->bits_per_pixel,
+				pixelFormatDetails->Rmask,
+				pixelFormatDetails->Gmask,
+				pixelFormatDetails->Bmask,
+				pixelFormatDetails->Amask));
+#else
+		_mouseSurface = SDL_CreateRGBSurface(SDL_SWSURFACE,
+						_mouseCurState.rW,
+						_mouseCurState.rH,
+						_mouseOrigSurface->format->BitsPerPixel,
+						_mouseOrigSurface->format->Rmask,
+						_mouseOrigSurface->format->Gmask,
+						_mouseOrigSurface->format->Bmask,
+						_mouseOrigSurface->format->Amask);
+#endif
+
+		if (_mouseSurface == nullptr)
+			error("Allocating _mouseSurface failed");
+	}
+
+	SDL_SetColors(_mouseSurface, _cursorPaletteDisabled ? _currentPalette : _cursorPalette, 0, 256);
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	uint32 flags = _disableMouseKeyColor ? 0 : SDL_SRCCOLORKEY | SDL_SRCALPHA;
+	SDL_SetSurfaceColorKey(_mouseSurface, flags, _mouseKeyColor);
+	SDL_SetSurfaceRLE(_mouseSurface, !_disableMouseKeyColor);
+#else
+	uint32 flags = _disableMouseKeyColor ? 0 : SDL_RLEACCEL | SDL_SRCCOLORKEY | SDL_SRCALPHA;
+	SDL_SetColorKey(_mouseSurface, flags, _mouseKeyColor);
+#endif
+
+	SDL_LockSurface(_mouseOrigSurface);
+	SDL_LockSurface(_mouseSurface);
+
+	// If possible, use the same scaler for the cursor as for the rest of
+	// the game. This only works well with the non-blurring scalers so we
+	// otherwise use the Normal scaler
+	if (!_cursorDontScale) {
+#ifdef USE_SCALERS
+		// HACK: AdvMame4x requires a height of at least 4 pixels, so we
+		// fall back on the Normal scaler when a smaller cursor is supplied.
+		if (_mouseScaler && _scalerPlugin->canDrawCursor() && (uint)_mouseCurState.h >= _extraPixels) {
+			_mouseScaler->setFactor(_videoMode.scaleFactor);
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+			const SDL_PixelFormatDetails *pixelFormatDetails = SDL_GetPixelFormatDetails(_mouseOrigSurface->format);
+			if (pixelFormatDetails == nullptr)
+				error("getting pixel format details failed");
+			_mouseScaler->scale(
+					(byte *)_mouseOrigSurface->pixels + _mouseOrigSurface->pitch * _maxExtraPixels + _maxExtraPixels * pixelFormatDetails->bytes_per_pixel,
+					_mouseOrigSurface->pitch, (byte *)_mouseSurface->pixels, _mouseSurface->pitch,
+					_mouseCurState.w, _mouseCurState.h, 0, 0);
+#else
+			_mouseScaler->scale(
+					(byte *)_mouseOrigSurface->pixels + _mouseOrigSurface->pitch * _maxExtraPixels + _maxExtraPixels * _mouseOrigSurface->format->BytesPerPixel,
+					_mouseOrigSurface->pitch, (byte *)_mouseSurface->pixels, _mouseSurface->pitch,
+					_mouseCurState.w, _mouseCurState.h, 0, 0);
+#endif
+		} else
+#endif
+		{
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+			const SDL_PixelFormatDetails *pixelFormatDetails = SDL_GetPixelFormatDetails(_mouseOrigSurface->format);
+			if (pixelFormatDetails == nullptr)
+				error("getting pixel format details failed");
+			Graphics::scaleBlit((byte *)_mouseSurface->pixels, (const byte *)_mouseOrigSurface->pixels + _mouseOrigSurface->pitch * _maxExtraPixels + _maxExtraPixels * pixelFormatDetails->bytes_per_pixel,
+			                    _mouseSurface->pitch, _mouseOrigSurface->pitch,
+				                _mouseCurState.w * _videoMode.scaleFactor, _mouseCurState.h * _videoMode.scaleFactor,
+			                    _mouseCurState.w, _mouseCurState.h, convertSDLPixelFormat(_mouseSurface->format));
+#else
+			Graphics::scaleBlit((byte *)_mouseSurface->pixels, (const byte *)_mouseOrigSurface->pixels + _mouseOrigSurface->pitch * _maxExtraPixels + _maxExtraPixels * _mouseOrigSurface->format->BytesPerPixel,
+			                    _mouseSurface->pitch, _mouseOrigSurface->pitch,
+				                _mouseCurState.w * _videoMode.scaleFactor, _mouseCurState.h * _videoMode.scaleFactor,
+			                    _mouseCurState.w, _mouseCurState.h, convertSDLPixelFormat(_mouseSurface->format));
+#endif
+
+		}
+	} else {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		const SDL_PixelFormatDetails *srcPixelFormatDetails = SDL_GetPixelFormatDetails(_mouseOrigSurface->format);
+		if (srcPixelFormatDetails == nullptr)
+			error("getting pixel format details failed");
+		const SDL_PixelFormatDetails *dstPixelFormatDetails = SDL_GetPixelFormatDetails(_mouseSurface->format);
+		if (dstPixelFormatDetails == nullptr)
+			error("getting pixel format details failed");
+		Graphics::copyBlit((byte *)_mouseSurface->pixels, (const byte *)_mouseOrigSurface->pixels + _mouseOrigSurface->pitch * _maxExtraPixels + _maxExtraPixels * srcPixelFormatDetails->bytes_per_pixel,
+		                   _mouseSurface->pitch, _mouseOrigSurface->pitch,
+		                   _mouseCurState.w, _mouseCurState.h, dstPixelFormatDetails->bytes_per_pixel);
+#else
+		Graphics::copyBlit((byte *)_mouseSurface->pixels, (const byte *)_mouseOrigSurface->pixels + _mouseOrigSurface->pitch * _maxExtraPixels + _maxExtraPixels * _mouseOrigSurface->format->BytesPerPixel,
+		                   _mouseSurface->pitch, _mouseOrigSurface->pitch,
+		                   _mouseCurState.w, _mouseCurState.h, _mouseSurface->format->BytesPerPixel);
+#endif
+	}
+
+#ifdef USE_ASPECT
+	if (!_cursorDontScale && _videoMode.aspectRatioCorrection)
+		stretch200To240Nearest((uint8 *)_mouseSurface->pixels, _mouseSurface->pitch, rW, rH1, 0, 0, 0, convertSDLPixelFormat(_mouseSurface->format));
+#endif
+
+	SDL_UnlockSurface(_mouseSurface);
+	SDL_UnlockSurface(_mouseOrigSurface);
+}
+
+void RenderSdlGraphicsManager::undrawMouse() {
+	_mouseLastRect = _mouseNextRect;
+
+	const Common::Point virtualCursor = convertWindowToVirtual(_cursorX, _cursorY);
+
+	// The offsets must be applied, since the call to convertWindowToVirtual()
+	// counteracts the move of the view port.
+
+	_mouseNextRect.x = virtualCursor.x + _gameScreenShakeXOffset;
+	_mouseNextRect.y = virtualCursor.y + _gameScreenShakeYOffset;
+
+	if (!_overlayInGUI) {
+		_mouseNextRect.w = _mouseCurState.vW;
+		_mouseNextRect.h = _mouseCurState.vH;
+		_mouseNextRect.x -= _mouseCurState.vHotX;
+		_mouseNextRect.y -= _mouseCurState.vHotY;
+	} else {
+		_mouseNextRect.w = _mouseCurState.rW;
+		_mouseNextRect.h = _mouseCurState.rH;
+		_mouseNextRect.x -= _mouseCurState.rHotX;
+		_mouseNextRect.y -= _mouseCurState.rHotY;
+	}
+
+	if (!_cursorVisible || !_mouseSurface) {
+		_mouseNextRect.x = _mouseNextRect.y = _mouseNextRect.w = _mouseNextRect.h = 0;
+	}
+
+	// Add the area covered by the mouse cursor to the list of dirty rects if
+	// we have to redraw the mouse, or if the cursor is alpha-blended since
+	// alpha-blended cursors will happily blend into themselves if the surface
+	// under the cursor is not reset first
+	//
+	// The mouse is undrawn using virtual coordinates, i.e. they may be
+	// scaled and aspect-ratio corrected.
+
+	if (_mouseLastRect.w != 0 && _mouseLastRect.h != 0)
+		addDirtyRect(_mouseLastRect.x, _mouseLastRect.y, _mouseLastRect.w, _mouseLastRect.h, _overlayInGUI);
+
+	if (_mouseNextRect.w != 0 && _mouseNextRect.h != 0)
+		addDirtyRect(_mouseNextRect.x, _mouseNextRect.y, _mouseNextRect.w, _mouseNextRect.h, _overlayInGUI);
+}
+
+void RenderSdlGraphicsManager::drawMouse() {
+	if (!_cursorVisible || !_mouseSurface || !_mouseCurState.w || !_mouseCurState.h) {
+		return;
+	}
+
+	SDL_Rect dst;
+
+	// We draw the pre-scaled cursor image, so now we need to adjust for
+	// scaling, shake position and aspect ratio correction manually.
+
+	dst.x = _mouseNextRect.x;
+	dst.y = _mouseNextRect.y;
+	dst.w = _mouseNextRect.w;
+	dst.h = _mouseNextRect.h;
+
+	if (_videoMode.aspectRatioCorrection && !_overlayInGUI)
+		dst.y = real2Aspect(dst.y);
+
+	if (!_overlayInGUI) {
+		dst.x *= _videoMode.scaleFactor;
+		dst.y *= _videoMode.scaleFactor;
+	}
+	dst.w = _mouseCurState.rW;
+	dst.h = _mouseCurState.rH;
+
+	// Note that SDL_BlitSurface() and addDirtyRect() will both perform any
+	// clipping necessary
+
+	if (!blitSurface(_mouseSurface, nullptr, _hwScreen, &dst))
+		error("SDL_BlitSurface failed: %s", SDL_GetError());
+}
+
+#pragma mark -
+#pragma mark --- On Screen Display ---
+#pragma mark -
+
+#ifdef USE_OSD
+void RenderSdlGraphicsManager::displayMessageOnOSD(const Common::U32String &msg) {
+	assert(_transactionMode == kTransactionNone);
+	assert(!msg.empty());
+	Common::U32String textToSay = msg;
+
+	Common::StackLock lock(_graphicsMutex);	// Lock the mutex until this function ends
+
+	removeOSDMessage();
+
+	// The font we are going to use:
+	const Graphics::Font *font = FontMan.getFontByUsage(Graphics::FontManager::kLocalizedFont);
+
+	// Split the message into separate lines.
+	Common::Array<Common::U32String> lines;
+	Common::U32String::const_iterator strLineItrBegin = msg.begin();
+
+	for (const auto &itr : msg) {
+		if (itr == '\n') {
+			lines.push_back(Common::U32String(strLineItrBegin, itr));
+			strLineItrBegin = &itr + 1;
+		}
+	}
+	if (strLineItrBegin != msg.end())
+		lines.push_back(Common::U32String(strLineItrBegin, msg.end()));
+
+	// Determine a rect which would contain the message string (clipped to the
+	// screen dimensions).
+	const int vOffset = 6;
+	const int lineSpacing = 1;
+	const int lineHeight = font->getFontHeight() + 2 * lineSpacing;
+	int width = 0;
+	int height = lineHeight * lines.size() + 2 * vOffset;
+	uint i;
+	for (i = 0; i < lines.size(); i++) {
+		width = MAX(width, font->getStringWidth(lines[i]) + 14);
+	}
+
+	// Clip the rect
+	if (width > _hwScreen->w)
+		width = _hwScreen->w;
+	if (height > _hwScreen->h)
+		height = _hwScreen->h;
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	const SDL_PixelFormatDetails *pixelFormatDetails = SDL_GetPixelFormatDetails(_hwScreen->format);
+	if (pixelFormatDetails == nullptr)
+		error("getting pixel format details failed");
+	_osdMessageSurface = SDL_CreateSurface(
+		width, height,
+		SDL_GetPixelFormatForMasks(pixelFormatDetails->bits_per_pixel, pixelFormatDetails->Rmask, pixelFormatDetails->Gmask, pixelFormatDetails->Bmask, pixelFormatDetails->Amask));
+#else
+	_osdMessageSurface = SDL_CreateRGBSurface(
+		SDL_SWSURFACE,
+		width, height, _hwScreen->format->BitsPerPixel, _hwScreen->format->Rmask, _hwScreen->format->Gmask, _hwScreen->format->Bmask, _hwScreen->format->Amask
+	);
+#endif
+
+	// Lock the surface
+	if (!lockSurface(_osdMessageSurface))
+		error("displayMessageOnOSD: SDL_LockSurface failed: %s", SDL_GetError());
+
+	// Draw a dark gray rect
+	// TODO: Rounded corners ? Border?
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	SDL_FillSurfaceRect(_osdMessageSurface, nullptr, SDL_MapSurfaceRGB(_osdMessageSurface, 64, 64, 64));
+#else
+	SDL_FillRect(_osdMessageSurface, nullptr, SDL_MapRGB(_osdMessageSurface->format, 64, 64, 64));
+#endif
+
+	Graphics::Surface dst;
+	dst.init(_osdMessageSurface->w, _osdMessageSurface->h, _osdMessageSurface->pitch, _osdMessageSurface->pixels,
+		convertSDLPixelFormat(_osdMessageSurface->format));
+
+	// Render the message, centered, and in white
+	for (i = 0; i < lines.size(); i++) {
+		font->drawString(&dst, lines[i],
+			0, 0 + i * lineHeight + vOffset + lineSpacing, width,
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+			SDL_MapSurfaceRGB(_osdMessageSurface, 255, 255, 255),
+#else
+			SDL_MapRGB(_osdMessageSurface->format, 255, 255, 255),
+#endif
+			Graphics::kTextAlignCenter, 0, true);
+	}
+
+	// Finished drawing, so unlock the OSD message surface
+	SDL_UnlockSurface(_osdMessageSurface);
+
+	// Init the OSD display parameters, and the fade out
+	_osdMessageAlpha = SDL_ALPHA_TRANSPARENT + kOSDInitialAlpha * (SDL_ALPHA_OPAQUE - SDL_ALPHA_TRANSPARENT) / 100;
+	_osdMessageFadeStartTime = SDL_GetTicks() + kOSDFadeOutDelay;
+	// Enable alpha blending
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	SDL_SetAlpha(_osdMessageSurface, SDL_SRCALPHA, _osdMessageAlpha);
+	SDL_SetSurfaceRLE(_osdMessageSurface, true);
+#else
+	SDL_SetAlpha(_osdMessageSurface, SDL_RLEACCEL | SDL_SRCALPHA, _osdMessageAlpha);
+#endif
+
+#if defined(MACOSX)
+	macOSTouchbarUpdate(msg.encode().c_str());
+#endif
+	// Ensure a full redraw takes place next time the screen is updated
+	_forceRedraw = true;
+	if (ConfMan.hasKey("tts_enabled", "scummvm") &&
+			ConfMan.getBool("tts_enabled", "scummvm")) {
+		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+		if (ttsMan)
+			ttsMan->say(textToSay);
+	}
+}
+
+SDL_Rect RenderSdlGraphicsManager::getOSDMessageRect() const {
+	SDL_Rect rect;
+	rect.x = (_hwScreen->w - _osdMessageSurface->w) / 2;
+	rect.y = (_hwScreen->h - _osdMessageSurface->h) / 2;
+	rect.w = _osdMessageSurface->w;
+	rect.h = _osdMessageSurface->h;
+	return rect;
+}
+
+void RenderSdlGraphicsManager::displayActivityIconOnOSD(const Graphics::Surface *icon) {
+	assert(_transactionMode == kTransactionNone);
+
+	Common::StackLock lock(_graphicsMutex);	// Lock the mutex until this function ends
+
+	if (_osdIconSurface && !icon) {
+		// Force a redraw to clear the icon on the next update
+		_forceRedraw = true;
+	}
+
+	if (_osdIconSurface) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		SDL_DestroySurface(_osdIconSurface);
+#else
+		SDL_FreeSurface(_osdIconSurface);
+#endif
+		_osdIconSurface = nullptr;
+	}
+
+	if (icon) {
+		const Graphics::PixelFormat &iconFormat = icon->format;
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		_osdIconSurface = SDL_CreateSurface(
+				icon->w, icon->h,
+				SDL_GetPixelFormatForMasks(
+					iconFormat.bytesPerPixel * 8,
+					((0xFF >> iconFormat.rLoss) << iconFormat.rShift),
+					((0xFF >> iconFormat.gLoss) << iconFormat.gShift),
+					((0xFF >> iconFormat.bLoss) << iconFormat.bShift),
+					((0xFF >> iconFormat.aLoss) << iconFormat.aShift))
+		);
+#else
+		_osdIconSurface = SDL_CreateRGBSurface(
+				SDL_SWSURFACE,
+				icon->w, icon->h, iconFormat.bytesPerPixel * 8,
+				((0xFF >> iconFormat.rLoss) << iconFormat.rShift),
+				((0xFF >> iconFormat.gLoss) << iconFormat.gShift),
+				((0xFF >> iconFormat.bLoss) << iconFormat.bShift),
+				((0xFF >> iconFormat.aLoss) << iconFormat.aShift)
+		);
+#endif
+
+		// Lock the surface
+		if (!lockSurface(_osdIconSurface))
+			error("displayActivityIconOnOSD: SDL_LockSurface failed: %s", SDL_GetError());
+
+		byte *dst = (byte *) _osdIconSurface->pixels;
+		const byte *src = (const byte *) icon->getPixels();
+		for (int y = 0; y < icon->h; y++) {
+			memcpy(dst, src, icon->w * iconFormat.bytesPerPixel);
+			src += icon->pitch;
+			dst += _osdIconSurface->pitch;
+		}
+
+		// Finished drawing, so unlock the OSD icon surface
+		SDL_UnlockSurface(_osdIconSurface);
+	}
+}
+
+SDL_Rect RenderSdlGraphicsManager::getOSDIconRect() const {
+	SDL_Rect dstRect;
+	dstRect.x = _hwScreen->w - _osdIconSurface->w - 10;
+	dstRect.y = 10;
+	dstRect.w = _osdIconSurface->w;
+	dstRect.h = _osdIconSurface->h;
+	return dstRect;
+}
+
+void RenderSdlGraphicsManager::removeOSDMessage() {
+	// Remove the previous message
+	if (_osdMessageSurface) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		SDL_DestroySurface(_osdMessageSurface);
+#else
+		SDL_FreeSurface(_osdMessageSurface);
+#endif
+		_forceRedraw = true;
+	}
+
+	_osdMessageSurface = nullptr;
+	_osdMessageAlpha = SDL_ALPHA_TRANSPARENT;
+
+#if defined(MACOSX)
+	macOSTouchbarUpdate(nullptr);
+#endif
+}
+
+void RenderSdlGraphicsManager::updateOSD() {
+	// OSD message visible (i.e. non-transparent)?
+	if (_osdMessageAlpha != SDL_ALPHA_TRANSPARENT) {
+		// Updated alpha value
+		const int diff = SDL_GetTicks() - _osdMessageFadeStartTime;
+		if (diff > 0) {
+			if (diff >= kOSDFadeOutDuration) {
+				// Back to full transparency
+				_osdMessageAlpha = SDL_ALPHA_TRANSPARENT;
+			} else {
+				// Do a linear fade out...
+				const int startAlpha = SDL_ALPHA_TRANSPARENT + kOSDInitialAlpha * (SDL_ALPHA_OPAQUE - SDL_ALPHA_TRANSPARENT) / 100;
+				_osdMessageAlpha = startAlpha + diff * (SDL_ALPHA_TRANSPARENT - startAlpha) / kOSDFadeOutDuration;
+			}
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+			SDL_SetAlpha(_osdMessageSurface, SDL_SRCALPHA, _osdMessageAlpha);
+			SDL_SetSurfaceRLE(_osdMessageSurface, true);
+#else
+			SDL_SetAlpha(_osdMessageSurface, SDL_RLEACCEL | SDL_SRCALPHA, _osdMessageAlpha);
+#endif
+		}
+
+		if (_osdMessageAlpha == SDL_ALPHA_TRANSPARENT) {
+			removeOSDMessage();
+		}
+	}
+
+	if (_osdIconSurface || _osdMessageSurface) {
+		// Redraw the area below the icon and message for the transparent blit to give correct results.
+		_forceRedraw = true;
+	}
+}
+
+void RenderSdlGraphicsManager::drawOSD() {
+	if (_osdMessageSurface) {
+		SDL_Rect dstRect = getOSDMessageRect();
+		SDL_BlitSurface(_osdMessageSurface, nullptr, _hwScreen, &dstRect);
+	}
+
+	if (_osdIconSurface) {
+		SDL_Rect dstRect = getOSDIconRect();
+		SDL_BlitSurface(_osdIconSurface, nullptr, _hwScreen, &dstRect);
+	}
+}
+
+#endif
+
+void RenderSdlGraphicsManager::handleResizeImpl(const int width, const int height) {
+	SdlGraphicsManager::handleResizeImpl(width, height);
+	recalculateDisplayAreas();
+}
+
+void RenderSdlGraphicsManager::handleScalerHotkeys(uint mode, int factor) {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	bool sizeChanged = _videoMode.scaleFactor != factor;
+#endif
+
+	beginGFXTransaction();
+		setScaler(mode, factor);
+	endGFXTransaction();
+#ifdef USE_OSD
+	const char *newScalerName = _scalerPlugin->getPrettyName();
+	if (newScalerName) {
+		const Common::U32String message = Common::U32String::format(
+			"%S %s%d\n%d x %d -> %d x %d",
+			_("Active graphics filter:").c_str(),
+			newScalerName,
+			_scaler->getFactor(),
+			_videoMode.screenWidth, _videoMode.screenHeight,
+			_hwScreen->w, _hwScreen->h);
+		displayMessageOnOSD(message);
+	}
+#endif
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (sizeChanged) {
+		// Forcibly resizing the window here since a user switching scaler
+		// size will not normally cause the window to update
+		_window->createOrUpdateWindow(_hwScreen->w, _hwScreen->h, _window->getWindowFlags());
+	}
+#endif
+
+	internUpdateScreen();
+}
+
+bool RenderSdlGraphicsManager::notifyEvent(const Common::Event &event) {
+	if (event.type != Common::EVENT_CUSTOM_BACKEND_ACTION_START) {
+		return SdlGraphicsManager::notifyEvent(event);
+	}
+
+	switch ((CustomEventAction) event.customType) {
+	case kActionToggleAspectRatioCorrection: {
+		beginGFXTransaction();
+			setFeatureState(OSystem::kFeatureAspectRatioCorrection, !_videoMode.aspectRatioCorrection);
+		endGFXTransaction();
+#ifdef USE_OSD
+		Common::U32String message;
+		if (_videoMode.aspectRatioCorrection)
+			message = Common::U32String::format("%S\n%d x %d -> %d x %d",
+			                                    _("Enabled aspect ratio correction").c_str(),
+			                                    _videoMode.screenWidth, _videoMode.screenHeight,
+			                                    _hwScreen->w, _hwScreen->h
+			          );
+		else
+			message = Common::U32String::format("%S\n%d x %d -> %d x %d",
+			                                    _("Disabled aspect ratio correction").c_str(),
+			                                    _videoMode.screenWidth, _videoMode.screenHeight,
+			                                    _hwScreen->w, _hwScreen->h
+			          );
+		displayMessageOnOSD(message);
+#endif
+		internUpdateScreen();
+		return true;
+	}
+
+	case kActionToggleFilteredScaling:
+		beginGFXTransaction();
+			setFeatureState(OSystem::kFeatureFilteringMode, !_videoMode.filtering);
+		endGFXTransaction();
+#ifdef USE_OSD
+		if (getFeatureState(OSystem::kFeatureFilteringMode)) {
+			displayMessageOnOSD(_("Filtering enabled"));
+		} else {
+			displayMessageOnOSD(_("Filtering disabled"));
+		}
+#endif
+		_forceRedraw = true;
+		internUpdateScreen();
+		return true;
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	case kActionCycleStretchMode: {
+		int index = 0;
+		const OSystem::GraphicsMode *sm = s_supportedStretchModes;
+		while (sm->name) {
+			if (sm->id == _videoMode.stretchMode)
+				break;
+			sm++;
+			index++;
+		}
+		index++;
+		if (!s_supportedStretchModes[index].name)
+			index = 0;
+
+		beginGFXTransaction();
+			setStretchMode(s_supportedStretchModes[index].id);
+		endGFXTransaction();
+
+#ifdef USE_OSD
+		Common::U32String message = Common::U32String::format("%S: %S",
+		                                                      _("Stretch mode").c_str(),
+		                                                      _(s_supportedStretchModes[index].description).c_str()
+		                            );
+		displayMessageOnOSD(message);
+#endif
+		_forceRedraw = true;
+		internUpdateScreen();
+		return true;
+	}
+#endif
+
+	case kActionIncreaseScaleFactor:
+		handleScalerHotkeys(_videoMode.scalerIndex, _scaler->increaseFactor());
+		return true;
+
+	case kActionDecreaseScaleFactor:
+		handleScalerHotkeys(_videoMode.scalerIndex, _scaler->decreaseFactor());
+		return true;
+
+	case kActionNextScaleFilter: {
+		uint scalerIndex =  _videoMode.scalerIndex + 1;
+		if (scalerIndex >= _scalerPlugins.size()) {
+			scalerIndex = 0;
+		}
+
+		handleScalerHotkeys(scalerIndex, _scaler->getFactor());
+		return true;
+	}
+
+	case kActionPreviousScaleFilter: {
+		uint scalerIndex =  _videoMode.scalerIndex;
+		if (scalerIndex == 0) {
+			scalerIndex = _scalerPlugins.size();
+		}
+		scalerIndex--;
+
+		handleScalerHotkeys(scalerIndex, _scaler->getFactor());
+		return true;
+	}
+
+	default:
+		return SdlGraphicsManager::notifyEvent(event);
+	}
+}
+
+void RenderSdlGraphicsManager::notifyVideoExpose() {
+	_forceRedraw = true;
+}
+
+void RenderSdlGraphicsManager::notifyResize(const int width, const int height) {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	handleResize(width, height);
+#endif
+}
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+void RenderSdlGraphicsManager::deinitializeRenderer() {
+#if defined(USE_IMGUI) && (defined(USE_IMGUI_SDLRENDERER2) || defined(USE_IMGUI_SDLRENDERER3))
+	destroyImGui();
+#endif
+
+	if (_screenTexture)
+		SDL_DestroyTexture(_screenTexture);
+	_screenTexture = nullptr;
+
+	if (_renderer)
+		SDL_DestroyRenderer(_renderer);
+	_renderer = nullptr;
+}
+
+void RenderSdlGraphicsManager::recreateScreenTexture() {
+	if (!_renderer)
+		return;
+
+#if !SDL_VERSION_ATLEAST(3, 0, 0)
+	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, _videoMode.filtering ? "linear" : "nearest");
+#endif
+
+	SDL_Texture *oldTexture = _screenTexture;
+	_screenTexture = SDL_CreateTexture(_renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_STREAMING, _videoMode.hardwareWidth, _videoMode.hardwareHeight);
+	if (_screenTexture) {
+		SDL_DestroyTexture(oldTexture);
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		SDL_SetTextureScaleMode(_screenTexture, _videoMode.filtering ? SDL_SCALEMODE_LINEAR : SDL_SCALEMODE_NEAREST);
+#endif
+	}
+	else
+		_screenTexture = oldTexture;
+}
+
+SDL_Surface *RenderSdlGraphicsManager::SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags) {
+	deinitializeRenderer();
+
+	uint32 createWindowFlags = SDL_WINDOW_RESIZABLE;
+	if ((flags & SDL_FULLSCREEN) != 0) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		createWindowFlags |= SDL_WINDOW_FULLSCREEN;
+#else
+		createWindowFlags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+#endif
+	}
+
+	if (!createOrUpdateWindow(width, height, createWindowFlags)) {
+		return nullptr;
+	}
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	if ((flags & SDL_FULLSCREEN) != 0) {
+		if (!SDL_SetWindowFullscreenMode(_window->getSDLWindow(), NULL))
+			warning("SDL_SetWindowFullscreenMode failed (%s)", SDL_GetError());
+		if (!SDL_SyncWindow(_window->getSDLWindow()))
+			warning("SDL_SyncWindow failed (%s)", SDL_GetError());
+	}
+#endif
+
+#if defined(MACOSX) && SDL_VERSION_ATLEAST(2, 0, 10)
+	// WORKAROUND: Bug #11430: "macOS: blurry content on Retina displays"
+	// Since SDL 2.0.10, Metal takes priority over OpenGL rendering on macOS,
+	// but this causes blurriness issues on Retina displays. Just switch
+	// back to OpenGL for now.
+	SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
+#endif
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	SDL_PropertiesID props = SDL_CreateProperties();
+	SDL_SetPointerProperty(props, SDL_PROP_RENDERER_CREATE_WINDOW_POINTER, _window->getSDLWindow());
+	SDL_SetNumberProperty(props, SDL_PROP_RENDERER_CREATE_PRESENT_VSYNC_NUMBER, _videoMode.vsync ? 1 : 0);
+	_renderer = SDL_CreateRendererWithProperties(props);
+	SDL_DestroyProperties(props);
+#else
+	uint32 rendererFlags = 0;
+	if (_videoMode.vsync) {
+		rendererFlags |= SDL_RENDERER_PRESENTVSYNC;
+	}
+	_renderer = SDL_CreateRenderer(_window->getSDLWindow(), -1, rendererFlags);
+#endif
+	if (!_renderer) {
+		if (_videoMode.vsync) {
+			// VSYNC might not be available, so retry without VSYNC
+			warning("SDL_SetVideoMode: SDL_CreateRenderer() failed with VSYNC option, retrying without it...");
+			_videoMode.vsync = false;
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+			props = SDL_CreateProperties();
+			SDL_SetPointerProperty(props, SDL_PROP_RENDERER_CREATE_WINDOW_POINTER, _window->getSDLWindow());
+			SDL_SetNumberProperty(props, SDL_PROP_RENDERER_CREATE_PRESENT_VSYNC_NUMBER, 0);
+			_renderer = SDL_CreateRendererWithProperties(props);
+			SDL_DestroyProperties(props);
+#else
+			rendererFlags &= ~SDL_RENDERER_PRESENTVSYNC;
+			_renderer = SDL_CreateRenderer(_window->getSDLWindow(), -1, rendererFlags);
+#endif
+		}
+		if (!_renderer) {
+			deinitializeRenderer();
+			return nullptr;
+		}
+	}
+
+	getWindowSizeFromSdl(&_windowWidth, &_windowHeight);
+	handleResize(_windowWidth, _windowHeight);
+
+#if !SDL_VERSION_ATLEAST(3, 0, 0)
+	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, _videoMode.filtering ? "linear" : "nearest");
+#endif
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	SDL_PixelFormat format = SDL_PIXELFORMAT_RGB565;
+#else
+	Uint32 format = SDL_PIXELFORMAT_RGB565;
+#endif
+
+	_screenTexture = SDL_CreateTexture(_renderer, format, SDL_TEXTUREACCESS_STREAMING, width, height);
+	if (!_screenTexture) {
+		deinitializeRenderer();
+		return nullptr;
+	}
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	SDL_SetTextureScaleMode(_screenTexture, _videoMode.filtering ? SDL_SCALEMODE_LINEAR : SDL_SCALEMODE_NEAREST);
+#endif
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	SDL_Surface *screen = SDL_CreateSurface(width, height, format);
+#else
+	SDL_Surface *screen = SDL_CreateRGBSurfaceWithFormat(0, width, height, SDL_BITSPERPIXEL(format), format);
+#endif
+	if (!screen) {
+		deinitializeRenderer();
+		return nullptr;
+	}
+
+#if defined(USE_IMGUI) && (defined(USE_IMGUI_SDLRENDERER2) || defined(USE_IMGUI_SDLRENDERER3))
+	// Setup Dear ImGui
+	initImGui(_renderer, nullptr);
+#endif
+
+	return screen;
+}
+
+void RenderSdlGraphicsManager::SDL_UpdateRects(SDL_Surface *screen, int numrects, SDL_Rect *rects) {
+	SDL_UpdateTexture(_screenTexture, nullptr, screen->pixels, screen->pitch);
+
+	SDL_Rect viewport;
+
+	Common::Rect &drawRect = (_overlayVisible) ? _overlayDrawRect : _gameDrawRect;
+
+	/* Destination rectangle represents the texture before rotation */
+	if (_rotationMode == Common::kRotation90 || _rotationMode == Common::kRotation270) {
+		viewport.w = drawRect.height();
+		viewport.h = drawRect.width();
+		int delta = (viewport.w - viewport.h) / 2;
+		viewport.x = drawRect.left - delta;
+		viewport.y = drawRect.top + delta;
+	} else {
+		viewport.w = drawRect.width();
+		viewport.h = drawRect.height();
+		viewport.x = drawRect.left;
+		viewport.y = drawRect.top;
+	}
+
+	int rotangle = (int)_rotationMode;
+
+	SDL_RenderClear(_renderer);
+
+	if (rotangle != 0) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		SDL_FRect fViewport;
+		SDL_RectToFRect(&viewport, &fViewport);
+		SDL_RenderTextureRotated(_renderer, _screenTexture, nullptr, &fViewport, rotangle, nullptr, SDL_FLIP_NONE);
+#else
+		SDL_RenderCopyEx(_renderer, _screenTexture, nullptr, &viewport, rotangle, nullptr, SDL_FLIP_NONE);
+#endif
+	} else {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		SDL_FRect fViewport;
+		SDL_RectToFRect(&viewport, &fViewport);
+		SDL_RenderTexture(_renderer, _screenTexture, nullptr, &fViewport);
+#else
+		SDL_RenderCopy(_renderer, _screenTexture, nullptr, &viewport);
+#endif
+	}
+}
+
+int RenderSdlGraphicsManager::SDL_SetColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	SDL_Palette *palette = SDL_CreateSurfacePalette(surface);
+	if (palette) {
+		return !SDL_SetPaletteColors(palette, colors, firstcolor, ncolors) ? 1 : 0;
+	}
+#else
+	if (surface->format->palette) {
+		return !SDL_SetPaletteColors(surface->format->palette, colors, firstcolor, ncolors) ? 1 : 0;
+	}
+#endif
+	return 0;
+}
+
+int RenderSdlGraphicsManager::SDL_SetAlpha(SDL_Surface *surface, Uint32 flag, Uint8 alpha) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	if (!SDL_SetSurfaceAlphaMod(surface, alpha)) {
+		return -1;
+	}
+
+	if (alpha == 255 || !flag) {
+		if (!SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_NONE)) {
+			return -1;
+		}
+	} else {
+		if (!SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_BLEND)) {
+			return -1;
+		}
+	}
+#else
+	if (SDL_SetSurfaceAlphaMod(surface, alpha)) {
+		return -1;
+	}
+
+	if (alpha == 255 || !flag) {
+		if (SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_NONE)) {
+			return -1;
+		}
+	} else {
+		if (SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_BLEND)) {
+			return -1;
+		}
+	}
+#endif
+
+
+	return 0;
+}
+
+int RenderSdlGraphicsManager::SDL_SetColorKey(SDL_Surface *surface, Uint32 flag, Uint32 key) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	return SDL_SetSurfaceColorKey(surface, flag, key) ? -1 : 0;
+#else
+	return ::SDL_SetColorKey(surface, flag ? SDL_TRUE : SDL_FALSE, key) ? -1 : 0;
+#endif
+}
+
+#if defined(USE_IMGUI) && (defined(USE_IMGUI_SDLRENDERER2) || defined(USE_IMGUI_SDLRENDERER3))
+void *RenderSdlGraphicsManager::getImGuiTexture(const Graphics::Surface &image, const byte *palette, int palCount) {
+
+	// Upload pixels into texture
+	SDL_Texture *texture = SDL_CreateTexture(_renderer, SDL_PIXELFORMAT_RGBA32, SDL_TEXTUREACCESS_STATIC, image.w, image.h);
+	if (texture == nullptr) {
+		error("getImGuiTexture: errror creating tetxure: %s", SDL_GetError());
+		return nullptr;
+	}
+
+	Graphics::Surface *s = image.convertTo(Graphics::PixelFormat::createFormatRGBA32(), palette, palCount);
+	SDL_UpdateTexture(texture, nullptr, s->getPixels(), s->pitch);
+	SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
+#ifdef USE_IMGUI_SDLRENDERER3
+	SDL_SetTextureScaleMode(texture, SDL_SCALEMODE_NEAREST);
+#elif defined(USE_IMGUI_SDLRENDERER2)
+	SDL_SetTextureScaleMode(texture, SDL_ScaleModeNearest);
+#endif
+
+	s->free();
+	delete s;
+
+	return (void *)texture;
+}
+
+void RenderSdlGraphicsManager::freeImGuiTexture(void *texture) {
+	SDL_DestroyTexture((SDL_Texture *) texture);
+}
+#endif // defined(USE_IMGUI) && (defined(USE_IMGUI_SDLRENDERER2) || defined(USE_IMGUI_SDLRENDERER3))
+
+#endif // SDL_VERSION_ATLEAST(2, 0, 0)
+
+#endif

--- a/backends/graphics/rendersdl/rendersdl-graphics.cpp
+++ b/backends/graphics/rendersdl/rendersdl-graphics.cpp
@@ -54,11 +54,6 @@
 #endif
 #endif
 
-// SDL surface flags which got removed in SDL2.
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-#define SDL_FULLSCREEN  0x40000000
-#endif
-
 static void destroySurface(SDL_Surface *surface) {
 #if SDL_VERSION_ATLEAST(3, 0, 0)
 	SDL_DestroySurface(surface);
@@ -119,7 +114,6 @@ static const OSystem::GraphicsMode s_supportedGraphicsModes[] = {
 	{nullptr, nullptr, 0}
 };
 
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 const OSystem::GraphicsMode s_supportedStretchModes[] = {
 	{"center", _s("Center"), STRETCH_CENTER},
 	{"pixel-perfect", _s("Pixel-perfect scaling"), STRETCH_INTEGRAL},
@@ -128,7 +122,6 @@ const OSystem::GraphicsMode s_supportedStretchModes[] = {
 	{"fit_force_aspect", _s("Fit to window (4:3)"), STRETCH_FIT_FORCE_ASPECT},
 	{nullptr, nullptr, 0}
 };
-#endif
 
 RenderSdlGraphicsManager::RenderSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window)
 	:
@@ -137,12 +130,7 @@ RenderSdlGraphicsManager::RenderSdlGraphicsManager(SdlEventSource *sdlEventSourc
 	_osdMessageTexture(nullptr), _osdMessageAlpha(SDL_ALPHA_TRANSPARENT), _osdMessageFadeStartTime(0),
 	_osdIconTexture(nullptr),
 #endif
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 	_renderer(nullptr), _screenTexture(nullptr),
-#endif
-#if defined(WIN32) && !SDL_VERSION_ATLEAST(2, 0, 0)
-	_originalBitsPerPixel(0),
-#endif
 	_screen(nullptr), _tmpscreen(nullptr),
 	_screenFormat(Graphics::PixelFormat::createFormatCLUT8()),
 	_cursorFormat(Graphics::PixelFormat::createFormatCLUT8()),
@@ -170,9 +158,7 @@ RenderSdlGraphicsManager::RenderSdlGraphicsManager(SdlEventSource *sdlEventSourc
 
 	_videoMode.fullscreen = ConfMan.getBool("fullscreen");
 	_videoMode.filtering = ConfMan.getBool("filtering");
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 	_videoMode.stretchMode = STRETCH_FIT;
-#endif
 	_videoMode.vsync = ConfMan.getBool("vsync");
 
 	_videoMode.scalerIndex = getDefaultScaler();
@@ -207,11 +193,9 @@ bool RenderSdlGraphicsManager::hasFeature(OSystem::Feature f) const {
 #endif
 		(f == OSystem::kFeatureAspectRatioCorrection) ||
 		(f == OSystem::kFeatureFilteringMode) ||
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 		(f == OSystem::kFeatureStretchMode) ||
 		(f == OSystem::kFeatureRotationMode) ||
 		(f == OSystem::kFeatureVSync) ||
-#endif
 		(f == OSystem::kFeatureCursorPalette) ||
 		(f == OSystem::kFeatureCursorAlpha) ||
 		(f == OSystem::kFeatureIconifyWindow) ||
@@ -319,10 +303,8 @@ void RenderSdlGraphicsManager::beginGFXTransaction() {
 	_transactionDetails.needHotswap = false;
 	_transactionDetails.needUpdatescreen = false;
 
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 	_transactionDetails.needDisplayResize = false;
 	_transactionDetails.needTextureUpdate = false;
-#endif
 	_transactionDetails.formatChanged = false;
 
 	_oldVideoMode = _videoMode;
@@ -359,13 +341,12 @@ OSystem::TransactionError RenderSdlGraphicsManager::endGFXTransaction() {
 			_videoMode.scaleFactor = _oldVideoMode.scaleFactor;
 		}
 
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 		if (_videoMode.stretchMode != _oldVideoMode.stretchMode) {
 			errors |= OSystem::kTransactionStretchModeSwitchFailed;
 
 			_videoMode.stretchMode = _oldVideoMode.stretchMode;
 		}
-#endif
+
 		if (_videoMode.vsync != _oldVideoMode.vsync) {
 			errors |= OSystem::kTransactionVSyncFailed;
 
@@ -434,16 +415,14 @@ OSystem::TransactionError RenderSdlGraphicsManager::endGFXTransaction() {
 			// To fix this issue we update the screen change count right here.
 			_screenChangeCount++;
 
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 			if (_transactionDetails.needDisplayResize) {
 				recalculateDisplayAreas();
 				recalculateCursorScaling();
 			}
-#endif
+
 			if (_transactionDetails.needUpdatescreen)
 				internUpdateScreen();
 		}
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 	} else if (_transactionDetails.needTextureUpdate) {
 		setGraphicsModeIntern();
 		recreateScreenTexture();
@@ -452,15 +431,12 @@ OSystem::TransactionError RenderSdlGraphicsManager::endGFXTransaction() {
 			recalculateCursorScaling();
 		}
 		internUpdateScreen();
-#endif
 	} else if (_transactionDetails.needUpdatescreen) {
 		setGraphicsModeIntern();
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 		if (_transactionDetails.needDisplayResize) {
 			recalculateDisplayAreas();
 			recalculateCursorScaling();
 		}
-#endif
 		internUpdateScreen();
 	}
 
@@ -680,7 +656,6 @@ uint RenderSdlGraphicsManager::getScaleFactor() const {
 	return _videoMode.scaleFactor;
 }
 
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 const OSystem::GraphicsMode *RenderSdlGraphicsManager::getSupportedStretchModes() const {
 	return s_supportedStretchModes;
 }
@@ -723,7 +698,6 @@ bool RenderSdlGraphicsManager::setStretchMode(int mode) {
 int RenderSdlGraphicsManager::getStretchMode() const {
 	return _videoMode.stretchMode;
 }
-#endif
 
 void RenderSdlGraphicsManager::getDefaultResolution(uint &w, uint &h) {
 	w = 320;
@@ -754,15 +728,6 @@ void RenderSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFor
 		_transactionDetails.formatChanged = true;
 		_screenFormat = newFormat;
 	}
-
-#if !SDL_VERSION_ATLEAST(2, 0, 0)
-	// Avoid redundant res changes, only in SDL1. In SDL2, redundancies may not
-	// actually be redundant if ScummVM is switching between game engines and
-	// the screen dimensions are being reinitialized, since window resizing is
-	// supposed to reset when this happens
-	if ((int)w == _videoMode.screenWidth && (int)h == _videoMode.screenHeight)
-		return;
-#endif
 
 	if ((int)w != _videoMode.screenWidth || (int)h != _videoMode.screenHeight) {
 		const bool useDefault = defaultGraphicsModeConfig();
@@ -814,18 +779,6 @@ void RenderSdlGraphicsManager::setupHardwareSize() {
 	_videoMode.hardwareHeight = _videoMode.screenHeight * _videoMode.scaleFactor;
 }
 
-void RenderSdlGraphicsManager::initGraphicsSurface() {
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-	Uint32 flags = 0;
-#else
-	Uint32 flags = SDL_SWSURFACE;
-#endif
-	if (_videoMode.fullscreen)
-		flags |= SDL_FULLSCREEN;
-
-	_hwScreen = SDL_SetVideoMode(_videoMode.hardwareWidth, _videoMode.hardwareHeight, 16, flags);
-}
-
 bool RenderSdlGraphicsManager::loadGFXMode() {
 	_forceRedraw = true;
 
@@ -850,14 +803,14 @@ bool RenderSdlGraphicsManager::loadGFXMode() {
 	if (_screen == nullptr)
 		error("allocating _screen failed");
 
-	// Avoid having SDL_SRCALPHA set even if we supplied an alpha-channel in the format.
-	SDL_SetAlpha(_screen, 0, 255);
+	// Avoid having the blend mode set even if we supplied an alpha-channel in the format.
+	SDL_SetSurfaceBlendMode(_screen, SDL_BLENDMODE_NONE);
 
 	// SDL 1.2 palettes default to all black,
 	// SDL 1.3 palettes default to all white,
 	// Thus set our own default palette to all black.
-	// SDL_SetColors does nothing for non indexed surfaces.
-	SDL_SetColors(_screen, _currentPalette, 0, 256);
+	if (_screen->format->palette)
+		SDL_SetPaletteColors(_screen->format->palette, _currentPalette, 0, 256);
 
 	//
 	// Create the surface that contains the scaled graphics in 16 bit mode
@@ -871,17 +824,58 @@ bool RenderSdlGraphicsManager::loadGFXMode() {
 	} else
 #endif
 	{
-#if defined(WIN32) && !SDL_VERSION_ATLEAST(2, 0, 0)
-		// Save the original bpp to be able to restore the video mode on
-		// unload. See _originalBitsPerPixel documentation.
-		if (_originalBitsPerPixel == 0) {
-			const SDL_VideoInfo *videoInfo = SDL_GetVideoInfo();
-			_originalBitsPerPixel = videoInfo->vfmt->BitsPerPixel;
+
+		uint32 createWindowFlags = SDL_WINDOW_RESIZABLE;
+		uint32 rendererFlags = 0;
+
+		if (_videoMode.fullscreen)
+			createWindowFlags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+
+		if (!createOrUpdateWindow(_videoMode.hardwareWidth, _videoMode.hardwareHeight, createWindowFlags)) {
+			error("Failed to create window: %s", SDL_GetError());
 		}
+
+#if defined(MACOSX) && SDL_VERSION_ATLEAST(2, 0, 10)
+		// WORKAROUND: Bug #11430: "macOS: blurry content on Retina displays"
+		// Since SDL 2.0.10, Metal takes priority over OpenGL rendering on macOS,
+		// but this causes blurriness issues on Retina displays. Just switch
+		// back to OpenGL for now.
+		SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
 #endif
 
-		initGraphicsSurface();
+		if (_videoMode.vsync) {
+			rendererFlags |= SDL_RENDERER_PRESENTVSYNC;
+		}
+
+		_renderer = SDL_CreateRenderer(_window->getSDLWindow(), -1, rendererFlags);
+		if (!_renderer) {
+			if (_videoMode.vsync) {
+				// VSYNC might not be available, so retry without VSYNC
+				warning("SDL_SetVideoMode: SDL_CreateRenderer() failed with VSYNC option, retrying without it...");
+				_videoMode.vsync = false;
+				rendererFlags &= ~SDL_RENDERER_PRESENTVSYNC;
+				_renderer = SDL_CreateRenderer(_window->getSDLWindow(), -1, rendererFlags);
+			}
+			if (!_renderer) {
+				error("Failed to create renderer: %s", SDL_GetError());
+			}
+		}
+
+		getWindowSizeFromSdl(&_windowWidth, &_windowHeight);
+		handleResize(_windowWidth, _windowHeight);
+
+		SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, _videoMode.filtering ? "linear" : "nearest");
+
+		Uint32 screenFormat = SDL_PIXELFORMAT_RGB565;
+
+		_screenTexture = SDL_CreateTexture(_renderer, screenFormat, SDL_TEXTUREACCESS_STREAMING, _videoMode.hardwareWidth, _videoMode.hardwareHeight);
+		if (!_screenTexture) {
+			error("Failed to create texture: %s", SDL_GetError());
+		}
+
+		_hwScreen = SDL_CreateRGBSurfaceWithFormat(SDL_SWSURFACE, _videoMode.hardwareWidth, _videoMode.hardwareHeight, SDL_BITSPERPIXEL(screenFormat), screenFormat);
 	}
+
 
 #ifdef USE_RGB_COLOR
 	detectSupportedFormats();
@@ -899,10 +893,6 @@ bool RenderSdlGraphicsManager::loadGFXMode() {
 		}
 	}
 
-#if !SDL_VERSION_ATLEAST(2, 0, 0)
-	handleResize(_videoMode.hardwareWidth, _videoMode.hardwareHeight);
-#endif
-
 	//
 	// Create the surface used for the graphics in 16 bit before scaling, and also the overlay
 	//
@@ -918,10 +908,19 @@ bool RenderSdlGraphicsManager::loadGFXMode() {
 									_videoMode.screenWidth, _videoMode.screenHeight, _maxExtraPixels);
 	}
 
+#if defined(USE_IMGUI) && defined(USE_IMGUI_SDLRENDERER2)
+	// Setup Dear ImGui
+	initImGui(_renderer, nullptr);
+#endif
+
 	return true;
 }
 
 void RenderSdlGraphicsManager::unloadGFXMode() {
+#if defined(USE_IMGUI) && defined(USE_IMGUI_SDLRENDERER2)
+	destroyImGui();
+#endif
+
 	if (_screen) {
 		destroySurface(_screen);
 		_screen = nullptr;
@@ -954,9 +953,10 @@ void RenderSdlGraphicsManager::unloadGFXMode() {
 		_overlaySurface = nullptr;
 	}
 
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	deinitializeRenderer();
-#endif
+	if (_screenTexture) {
+		SDL_DestroyTexture(_screenTexture);
+		_screenTexture = nullptr;
+	}
 
 	if (_hwScreen) {
 		destroySurface(_hwScreen);
@@ -968,13 +968,10 @@ void RenderSdlGraphicsManager::unloadGFXMode() {
 		_tmpscreen = nullptr;
 	}
 
-#if defined(WIN32) && !SDL_VERSION_ATLEAST(2, 0, 0)
-	// Reset video mode to original.
-	// This will ensure that any new graphic manager will use the initial BPP
-	// when listing available modes. See _originalBitsPerPixel documentation.
-	if (_originalBitsPerPixel != 0)
-		SDL_SetVideoMode(_videoMode.screenWidth, _videoMode.screenHeight, _originalBitsPerPixel, _videoMode.fullscreen ? (SDL_FULLSCREEN | SDL_SWSURFACE) : SDL_SWSURFACE);
-#endif
+	if (_renderer) {
+		SDL_DestroyRenderer(_renderer);
+		_renderer = nullptr;
+	}
 }
 
 bool RenderSdlGraphicsManager::hotswapGFXMode() {
@@ -1006,7 +1003,8 @@ bool RenderSdlGraphicsManager::hotswapGFXMode() {
 	}
 
 	// reset palette
-	SDL_SetColors(_screen, _currentPalette, 0, 256);
+	if (_screen->format->palette)
+		SDL_SetPaletteColors(_screen->format->palette, _currentPalette, 0, 256);
 
 	// Restore old screen content
 	SDL_BlitSurface(old_screen, nullptr, _screen, nullptr);
@@ -1032,7 +1030,7 @@ void RenderSdlGraphicsManager::updateScreen() {
 }
 
 void RenderSdlGraphicsManager::updateScreen(SDL_Rect *dirtyRectList, int actualDirtyRects) {
-	SDL_UpdateRects(_hwScreen, actualDirtyRects, dirtyRectList);
+	SDL_UpdateTexture(_screenTexture, nullptr, _hwScreen->pixels, _hwScreen->pitch);
 }
 
 void RenderSdlGraphicsManager::internUpdateScreen() {
@@ -1045,50 +1043,14 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 	if (debugger)
 		debugger->onFrame();
 
-#if !SDL_VERSION_ATLEAST(2, 0, 0)
-	// If the shake position changed, fill the dirty area with blackness
-	// When building with SDL2, the shake offset is added to the active rect instead,
-	// so this isn't needed there.
-	if (_currentShakeXOffset != _gameScreenShakeXOffset) {
-		SDL_Rect blackrect = {0, 0, (Uint16)(_videoMode.screenWidth * _videoMode.scaleFactor), (Uint16)(_videoMode.screenHeight * _videoMode.scaleFactor)};
-
-		if (_gameScreenShakeXOffset >= 0)
-			blackrect.w = (Uint16)(_gameScreenShakeXOffset * _videoMode.scaleFactor);
-		else {
-			blackrect.w = ((-_gameScreenShakeXOffset) * _videoMode.scaleFactor);
-			blackrect.x = ((_videoMode.screenWidth + _gameScreenShakeXOffset) * _videoMode.scaleFactor);
-		}
-
-		SDL_FillRect(_hwScreen, &blackrect, 0);
-
-		_currentShakeXOffset = _gameScreenShakeXOffset;
-
-		_forceRedraw = true;
-	}
-	if (_currentShakeYOffset != _gameScreenShakeYOffset) {
-		SDL_Rect blackrect = {0, 0, (Uint16)(_videoMode.screenWidth * _videoMode.scaleFactor), (Uint16)(_videoMode.screenHeight * _videoMode.scaleFactor)};
-
-		if (_gameScreenShakeYOffset >= 0)
-			blackrect.h = (Uint16)(_gameScreenShakeYOffset * _videoMode.scaleFactor);
-		else {
-			blackrect.h = ((-_gameScreenShakeYOffset) * _videoMode.scaleFactor);
-			blackrect.y = ((_videoMode.screenHeight + _gameScreenShakeYOffset) * _videoMode.scaleFactor);
-		}
-
-		SDL_FillRect(_hwScreen, &blackrect, 0);
-
-		_currentShakeYOffset = _gameScreenShakeYOffset;
-
-		_forceRedraw = true;
-	}
-#endif
-
 	// Check whether the palette was changed in the meantime and update the
 	// screen surface accordingly.
 	if (_screen && _paletteDirtyEnd != 0) {
-		SDL_SetColors(_screen, _currentPalette + _paletteDirtyStart,
-			_paletteDirtyStart,
-			_paletteDirtyEnd - _paletteDirtyStart);
+		if (_screen->format->palette)
+			SDL_SetPaletteColors(_screen->format->palette,
+				_currentPalette + _paletteDirtyStart,
+				_paletteDirtyStart,
+				_paletteDirtyEnd - _paletteDirtyStart);
 
 		_paletteDirtyEnd = 0;
 
@@ -1232,14 +1194,11 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 	_forceRedraw = false;
 	_cursorNeedsRedraw = false;
 
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-
 #if defined(USE_IMGUI) && (defined(USE_IMGUI_SDLRENDERER2) || defined(USE_IMGUI_SDLRENDERER3))
 	renderImGui();
 #endif
 
 	SDL_RenderPresent(_renderer);
-#endif
 }
 
 bool RenderSdlGraphicsManager::saveScreenshot(const Common::Path &filename) const {
@@ -1323,9 +1282,7 @@ void RenderSdlGraphicsManager::setFilteringMode(bool enable) {
 
 	if (_transactionMode == kTransactionActive) {
 		_videoMode.filtering = enable;
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 		_transactionDetails.needTextureUpdate = true;
-#endif
 	}
 }
 
@@ -1498,9 +1455,7 @@ void RenderSdlGraphicsManager::setPalette(const byte *colors, uint start, uint n
 		base[i].r = b[0];
 		base[i].g = b[1];
 		base[i].b = b[2];
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 		base[i].a = 255;
-#endif
 	}
 
 	if (start < _paletteDirtyStart)
@@ -1536,9 +1491,7 @@ void RenderSdlGraphicsManager::setCursorPalette(const byte *colors, uint start, 
 		base[i].r = b[0];
 		base[i].g = b[1];
 		base[i].b = b[2];
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 		base[i].a = 255;
-#endif
 	}
 
 	_cursorPaletteDisabled = false;
@@ -2097,7 +2050,9 @@ void RenderSdlGraphicsManager::blitCursor() {
 			SDL_SetSurfaceRLE(_mouseSurface, SDL_TRUE);
 	}
 
-	SDL_SetColors(_mouseSurface, _cursorPaletteDisabled ? _currentPalette : _cursorPalette, 0, 256);
+	if (_mouseSurface->format->palette)
+		SDL_SetPaletteColors(_mouseSurface->format->palette,
+			_cursorPaletteDisabled ? _currentPalette : _cursorPalette, 0, 256);
 #if SDL_VERSION_ATLEAST(3, 0, 0)
 	uint32 flags = _disableMouseKeyColor ? SDL_FALSE : SDL_TRUE;
 	SDL_SetSurfaceColorKey(_mouseSurface, flags, _mouseKeyColor);
@@ -2595,9 +2550,7 @@ void RenderSdlGraphicsManager::handleResizeImpl(const int width, const int heigh
 }
 
 void RenderSdlGraphicsManager::handleScalerHotkeys(uint mode, int factor) {
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 	bool sizeChanged = _videoMode.scaleFactor != factor;
-#endif
 
 	beginGFXTransaction();
 		setScaler(mode, factor);
@@ -2616,13 +2569,11 @@ void RenderSdlGraphicsManager::handleScalerHotkeys(uint mode, int factor) {
 	}
 #endif
 
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 	if (sizeChanged) {
 		// Forcibly resizing the window here since a user switching scaler
 		// size will not normally cause the window to update
 		_window->createOrUpdateWindow(_hwScreen->w, _hwScreen->h, _window->getWindowFlags());
 	}
-#endif
 
 	internUpdateScreen();
 }
@@ -2663,7 +2614,6 @@ bool RenderSdlGraphicsManager::notifyEvent(const Common::Event &event) {
 		internUpdateScreen();
 		return true;
 
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 	case kActionCycleStretchMode: {
 		int index = 0;
 		const OSystem::GraphicsMode *sm = s_supportedStretchModes;
@@ -2692,7 +2642,6 @@ bool RenderSdlGraphicsManager::notifyEvent(const Common::Event &event) {
 		internUpdateScreen();
 		return true;
 	}
-#endif
 
 	case kActionIncreaseScaleFactor:
 		handleScalerHotkeys(_videoMode.scalerIndex, _scaler->increaseFactor());
@@ -2733,28 +2682,7 @@ void RenderSdlGraphicsManager::notifyVideoExpose() {
 }
 
 void RenderSdlGraphicsManager::notifyResize(const int width, const int height) {
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 	handleResize(width, height);
-#endif
-}
-
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-void RenderSdlGraphicsManager::deinitializeRenderer() {
-#if defined(USE_IMGUI) && (defined(USE_IMGUI_SDLRENDERER2) || defined(USE_IMGUI_SDLRENDERER3))
-	destroyImGui();
-#endif
-
-	if (_screenTexture)
-		SDL_DestroyTexture(_screenTexture);
-	_screenTexture = nullptr;
-
-	if (_mouseTexture)
-		SDL_DestroyTexture(_mouseTexture);
-	_mouseTexture = nullptr;
-
-	if (_renderer)
-		SDL_DestroyRenderer(_renderer);
-	_renderer = nullptr;
 }
 
 void RenderSdlGraphicsManager::recreateScreenTexture() {
@@ -2775,167 +2703,6 @@ void RenderSdlGraphicsManager::recreateScreenTexture() {
 	}
 	else
 		_screenTexture = oldTexture;
-}
-
-SDL_Surface *RenderSdlGraphicsManager::SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags) {
-	deinitializeRenderer();
-
-	uint32 createWindowFlags = SDL_WINDOW_RESIZABLE;
-	if ((flags & SDL_FULLSCREEN) != 0) {
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-		createWindowFlags |= SDL_WINDOW_FULLSCREEN;
-#else
-		createWindowFlags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
-#endif
-	}
-
-	if (!createOrUpdateWindow(width, height, createWindowFlags)) {
-		return nullptr;
-	}
-
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-	if ((flags & SDL_FULLSCREEN) != 0) {
-		if (!SDL_SetWindowFullscreenMode(_window->getSDLWindow(), NULL))
-			warning("SDL_SetWindowFullscreenMode failed (%s)", SDL_GetError());
-		if (!SDL_SyncWindow(_window->getSDLWindow()))
-			warning("SDL_SyncWindow failed (%s)", SDL_GetError());
-	}
-#endif
-
-#if defined(MACOSX) && SDL_VERSION_ATLEAST(2, 0, 10)
-	// WORKAROUND: Bug #11430: "macOS: blurry content on Retina displays"
-	// Since SDL 2.0.10, Metal takes priority over OpenGL rendering on macOS,
-	// but this causes blurriness issues on Retina displays. Just switch
-	// back to OpenGL for now.
-	SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
-#endif
-
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-	SDL_PropertiesID props = SDL_CreateProperties();
-	SDL_SetPointerProperty(props, SDL_PROP_RENDERER_CREATE_WINDOW_POINTER, _window->getSDLWindow());
-	SDL_SetNumberProperty(props, SDL_PROP_RENDERER_CREATE_PRESENT_VSYNC_NUMBER, _videoMode.vsync ? 1 : 0);
-	_renderer = SDL_CreateRendererWithProperties(props);
-	SDL_DestroyProperties(props);
-#else
-	uint32 rendererFlags = 0;
-	if (_videoMode.vsync) {
-		rendererFlags |= SDL_RENDERER_PRESENTVSYNC;
-	}
-	_renderer = SDL_CreateRenderer(_window->getSDLWindow(), -1, rendererFlags);
-#endif
-	if (!_renderer) {
-		if (_videoMode.vsync) {
-			// VSYNC might not be available, so retry without VSYNC
-			warning("SDL_SetVideoMode: SDL_CreateRenderer() failed with VSYNC option, retrying without it...");
-			_videoMode.vsync = false;
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-			props = SDL_CreateProperties();
-			SDL_SetPointerProperty(props, SDL_PROP_RENDERER_CREATE_WINDOW_POINTER, _window->getSDLWindow());
-			SDL_SetNumberProperty(props, SDL_PROP_RENDERER_CREATE_PRESENT_VSYNC_NUMBER, 0);
-			_renderer = SDL_CreateRendererWithProperties(props);
-			SDL_DestroyProperties(props);
-#else
-			rendererFlags &= ~SDL_RENDERER_PRESENTVSYNC;
-			_renderer = SDL_CreateRenderer(_window->getSDLWindow(), -1, rendererFlags);
-#endif
-		}
-		if (!_renderer) {
-			deinitializeRenderer();
-			return nullptr;
-		}
-	}
-
-	getWindowSizeFromSdl(&_windowWidth, &_windowHeight);
-	handleResize(_windowWidth, _windowHeight);
-
-#if !SDL_VERSION_ATLEAST(3, 0, 0)
-	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, _videoMode.filtering ? "linear" : "nearest");
-#endif
-
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-	SDL_PixelFormat format = SDL_PIXELFORMAT_RGB565;
-#else
-	Uint32 format = SDL_PIXELFORMAT_RGB565;
-#endif
-
-	_screenTexture = SDL_CreateTexture(_renderer, format, SDL_TEXTUREACCESS_STREAMING, width, height);
-	if (!_screenTexture) {
-		deinitializeRenderer();
-		return nullptr;
-	}
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-	SDL_SetTextureScaleMode(_screenTexture, _videoMode.filtering ? SDL_SCALEMODE_LINEAR : SDL_SCALEMODE_NEAREST);
-#endif
-
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-	SDL_Surface *screen = SDL_CreateSurface(width, height, format);
-#else
-	SDL_Surface *screen = SDL_CreateRGBSurfaceWithFormat(0, width, height, SDL_BITSPERPIXEL(format), format);
-#endif
-	if (!screen) {
-		deinitializeRenderer();
-		return nullptr;
-	}
-
-#if defined(USE_IMGUI) && (defined(USE_IMGUI_SDLRENDERER2) || defined(USE_IMGUI_SDLRENDERER3))
-	// Setup Dear ImGui
-	initImGui(_renderer, nullptr);
-#endif
-
-	return screen;
-}
-
-void RenderSdlGraphicsManager::SDL_UpdateRects(SDL_Surface *screen, int numrects, SDL_Rect *rects) {
-	SDL_UpdateTexture(_screenTexture, nullptr, screen->pixels, screen->pitch);
-}
-
-int RenderSdlGraphicsManager::SDL_SetColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors) {
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-	SDL_Palette *palette = SDL_CreateSurfacePalette(surface);
-	if (palette) {
-		return !SDL_SetPaletteColors(palette, colors, firstcolor, ncolors) ? 1 : 0;
-	}
-#else
-	if (surface->format->palette) {
-		return !SDL_SetPaletteColors(surface->format->palette, colors, firstcolor, ncolors) ? 1 : 0;
-	}
-#endif
-	return 0;
-}
-
-int RenderSdlGraphicsManager::SDL_SetAlpha(SDL_Surface *surface, Uint32 flag, Uint8 alpha) {
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-	if (!SDL_SetSurfaceAlphaMod(surface, alpha)) {
-		return -1;
-	}
-
-	if (alpha == 255 || !flag) {
-		if (!SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_NONE)) {
-			return -1;
-		}
-	} else {
-		if (!SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_BLEND)) {
-			return -1;
-		}
-	}
-#else
-	if (SDL_SetSurfaceAlphaMod(surface, alpha)) {
-		return -1;
-	}
-
-	if (alpha == 255 || !flag) {
-		if (SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_NONE)) {
-			return -1;
-		}
-	} else {
-		if (SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_BLEND)) {
-			return -1;
-		}
-	}
-#endif
-
-
-	return 0;
 }
 
 #if defined(USE_IMGUI) && (defined(USE_IMGUI_SDLRENDERER2) || defined(USE_IMGUI_SDLRENDERER3))
@@ -2967,7 +2734,5 @@ void RenderSdlGraphicsManager::freeImGuiTexture(void *texture) {
 	SDL_DestroyTexture((SDL_Texture *) texture);
 }
 #endif // defined(USE_IMGUI) && (defined(USE_IMGUI_SDLRENDERER2) || defined(USE_IMGUI_SDLRENDERER3))
-
-#endif // SDL_VERSION_ATLEAST(2, 0, 0)
 
 #endif

--- a/backends/graphics/rendersdl/rendersdl-graphics.cpp
+++ b/backends/graphics/rendersdl/rendersdl-graphics.cpp
@@ -165,8 +165,8 @@ RenderSdlGraphicsManager::RenderSdlGraphicsManager(SdlEventSource *sdlEventSourc
 	:
 	SdlGraphicsManager(sdlEventSource, window),
 #ifdef USE_OSD
-	_osdMessageSurface(nullptr), _osdMessageAlpha(SDL_ALPHA_TRANSPARENT), _osdMessageFadeStartTime(0),
-	_osdIconSurface(nullptr),
+	_osdMessageTexture(nullptr), _osdMessageAlpha(SDL_ALPHA_TRANSPARENT), _osdMessageFadeStartTime(0),
+	_osdIconTexture(nullptr),
 #endif
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	_renderer(nullptr), _screenTexture(nullptr),
@@ -1088,6 +1088,18 @@ void RenderSdlGraphicsManager::unloadGFXMode() {
 		_screen = nullptr;
 	}
 
+#ifdef USE_OSD
+	if (_osdMessageTexture) {
+		SDL_DestroyTexture(_osdMessageTexture);
+		_osdMessageTexture = nullptr;
+	}
+
+	if (_osdIconTexture) {
+		SDL_DestroyTexture(_osdIconTexture);
+		_osdIconTexture = nullptr;
+	}
+#endif
+
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	deinitializeRenderer();
 #endif
@@ -1111,18 +1123,6 @@ void RenderSdlGraphicsManager::unloadGFXMode() {
 		destroySurface(_overlayscreen);
 		_overlayscreen = nullptr;
 	}
-
-#ifdef USE_OSD
-	if (_osdMessageSurface) {
-		destroySurface(_osdMessageSurface);
-		_osdMessageSurface = nullptr;
-	}
-
-	if (_osdIconSurface) {
-		destroySurface(_osdIconSurface);
-		_osdIconSurface = nullptr;
-	}
-#endif
 
 #if defined(WIN32) && !SDL_VERSION_ATLEAST(2, 0, 0)
 	// Reset video mode to original.
@@ -1366,9 +1366,6 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 	}
 
 	// Only draw anything if necessary
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	bool doPresent = false;
-#endif
 	if (actualDirtyRects > 0 || _cursorNeedsRedraw) {
 		SDL_Rect *r;
 		SDL_Rect dst;
@@ -1470,10 +1467,6 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 
 		drawMouse();
 
-#ifdef USE_OSD
-		drawOSD();
-#endif
-
 #ifdef USE_SDL_DEBUG_FOCUSRECT
 		// We draw the focus rectangle on top of everything, to assure it's easily visible.
 		// Of course when the GUI overlay is visible we do not show it, since it is only for game
@@ -1566,11 +1559,14 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 		// Finally, blit all our changes to the screen
 		if (!_displayDisabled) {
 			updateScreen(_dirtyRectList, actualDirtyRects);
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-			doPresent = true;
-#endif
 		}
 	}
+
+	SDL_RenderClear(_renderer);
+	drawScreen();
+#ifdef USE_OSD
+	drawOSD();
+#endif
 
 	// Set up the old scale factor
 	if (_scaler)
@@ -1586,9 +1582,7 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 	renderImGui();
 #endif
 
-	if (doPresent) {
-		SDL_RenderPresent(_renderer);
-	}
+	SDL_RenderPresent(_renderer);
 #else
 	if (_isDoubleBuf)
 		SDL_Flip(_hwScreen);
@@ -2639,57 +2633,59 @@ void RenderSdlGraphicsManager::displayMessageOnOSD(const Common::U32String &msg)
 	const SDL_PixelFormatDetails *pixelFormatDetails = SDL_GetPixelFormatDetails(_hwScreen->format);
 	if (pixelFormatDetails == nullptr)
 		error("getting pixel format details failed");
-	_osdMessageSurface = SDL_CreateSurface(
+	SDL_Surface *osdMessageSurface = SDL_CreateSurface(
 		width, height,
 		SDL_GetPixelFormatForMasks(pixelFormatDetails->bits_per_pixel, pixelFormatDetails->Rmask, pixelFormatDetails->Gmask, pixelFormatDetails->Bmask, pixelFormatDetails->Amask));
 #else
-	_osdMessageSurface = SDL_CreateRGBSurface(
+	SDL_Surface *osdMessageSurface = SDL_CreateRGBSurface(
 		SDL_SWSURFACE,
 		width, height, _hwScreen->format->BitsPerPixel, _hwScreen->format->Rmask, _hwScreen->format->Gmask, _hwScreen->format->Bmask, _hwScreen->format->Amask
 	);
 #endif
 
 	// Lock the surface
-	if (!lockSurface(_osdMessageSurface))
+	if (!lockSurface(osdMessageSurface))
 		error("displayMessageOnOSD: SDL_LockSurface failed: %s", SDL_GetError());
 
 	// Draw a dark gray rect
 	// TODO: Rounded corners ? Border?
 #if SDL_VERSION_ATLEAST(3, 0, 0)
-	SDL_FillSurfaceRect(_osdMessageSurface, nullptr, SDL_MapSurfaceRGB(_osdMessageSurface, 64, 64, 64));
+	SDL_FillSurfaceRect(osdMessageSurface, nullptr, SDL_MapSurfaceRGB(osdMessageSurface, 64, 64, 64));
 #else
-	SDL_FillRect(_osdMessageSurface, nullptr, SDL_MapRGB(_osdMessageSurface->format, 64, 64, 64));
+	SDL_FillRect(osdMessageSurface, nullptr, SDL_MapRGB(osdMessageSurface->format, 64, 64, 64));
 #endif
 
 	Graphics::Surface dst;
-	dst.init(_osdMessageSurface->w, _osdMessageSurface->h, _osdMessageSurface->pitch, _osdMessageSurface->pixels,
-		convertSDLPixelFormat(_osdMessageSurface->format));
+	dst.init(osdMessageSurface->w, osdMessageSurface->h, osdMessageSurface->pitch, osdMessageSurface->pixels,
+		convertSDLPixelFormat(osdMessageSurface->format));
 
 	// Render the message, centered, and in white
 	for (i = 0; i < lines.size(); i++) {
 		font->drawString(&dst, lines[i],
 			0, 0 + i * lineHeight + vOffset + lineSpacing, width,
 #if SDL_VERSION_ATLEAST(3, 0, 0)
-			SDL_MapSurfaceRGB(_osdMessageSurface, 255, 255, 255),
+			SDL_MapSurfaceRGB(osdMessageSurface, 255, 255, 255),
 #else
-			SDL_MapRGB(_osdMessageSurface->format, 255, 255, 255),
+			SDL_MapRGB(osdMessageSurface->format, 255, 255, 255),
 #endif
 			Graphics::kTextAlignCenter, 0, true);
 	}
 
 	// Finished drawing, so unlock the OSD message surface
-	SDL_UnlockSurface(_osdMessageSurface);
+	SDL_UnlockSurface(osdMessageSurface);
+
+	// Create a new texture from the surface
+	_osdMessageTexture = SDL_CreateTextureFromSurface(_renderer, osdMessageSurface);
+
+	// We don't need the surface any more
+	SDL_FreeSurface(osdMessageSurface);
 
 	// Init the OSD display parameters, and the fade out
 	_osdMessageAlpha = SDL_ALPHA_TRANSPARENT + kOSDInitialAlpha * (SDL_ALPHA_OPAQUE - SDL_ALPHA_TRANSPARENT) / 100;
 	_osdMessageFadeStartTime = SDL_GetTicks() + kOSDFadeOutDelay;
 	// Enable alpha blending
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-	SDL_SetAlpha(_osdMessageSurface, SDL_SRCALPHA, _osdMessageAlpha);
-	SDL_SetSurfaceRLE(_osdMessageSurface, true);
-#else
-	SDL_SetAlpha(_osdMessageSurface, SDL_RLEACCEL | SDL_SRCALPHA, _osdMessageAlpha);
-#endif
+	SDL_SetTextureBlendMode(_osdMessageTexture, SDL_BLENDMODE_BLEND);
+	SDL_SetTextureAlphaMod(_osdMessageTexture, _osdMessageAlpha);
 
 #if defined(MACOSX)
 	macOSTouchbarUpdate(msg.encode().c_str());
@@ -2705,11 +2701,14 @@ void RenderSdlGraphicsManager::displayMessageOnOSD(const Common::U32String &msg)
 }
 
 SDL_Rect RenderSdlGraphicsManager::getOSDMessageRect() const {
+	int w, h;
+	SDL_QueryTexture(_osdMessageTexture, nullptr, nullptr, &w, &h);
+
 	SDL_Rect rect;
-	rect.x = (_hwScreen->w - _osdMessageSurface->w) / 2;
-	rect.y = (_hwScreen->h - _osdMessageSurface->h) / 2;
-	rect.w = _osdMessageSurface->w;
-	rect.h = _osdMessageSurface->h;
+	rect.x = (_windowWidth - w) / 2;
+	rect.y = (_windowHeight - h) / 2;
+	rect.w = w;
+	rect.h = h;
 	return rect;
 }
 
@@ -2718,37 +2717,29 @@ void RenderSdlGraphicsManager::displayActivityIconOnOSD(const Graphics::Surface 
 
 	Common::StackLock lock(_graphicsMutex);	// Lock the mutex until this function ends
 
-	if (_osdIconSurface && !icon) {
-		// Force a redraw to clear the icon on the next update
-		_forceRedraw = true;
-	}
-
-	if (_osdIconSurface) {
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-		SDL_DestroySurface(_osdIconSurface);
-#else
-		SDL_FreeSurface(_osdIconSurface);
-#endif
-		_osdIconSurface = nullptr;
+	if (_osdIconTexture) {
+		SDL_DestroyTexture(_osdIconTexture);
+		_osdIconTexture = nullptr;
 	}
 
 	if (icon) {
 		const Graphics::PixelFormat &iconFormat = icon->format;
 
 #if SDL_VERSION_ATLEAST(3, 0, 0)
-		_osdIconSurface = SDL_CreateSurface(
+		SDL_Surface *osdIconSurface = SDL_CreateSurfaceFrom(
 				icon->w, icon->h,
 				SDL_GetPixelFormatForMasks(
 					iconFormat.bytesPerPixel * 8,
 					((0xFF >> iconFormat.rLoss) << iconFormat.rShift),
 					((0xFF >> iconFormat.gLoss) << iconFormat.gShift),
 					((0xFF >> iconFormat.bLoss) << iconFormat.bShift),
-					((0xFF >> iconFormat.aLoss) << iconFormat.aShift))
+					((0xFF >> iconFormat.aLoss) << iconFormat.aShift)),
+				const_cast<void *>(icon->getPixels()),
+				icon->pitch
 		);
 #else
-		_osdIconSurface = SDL_CreateRGBSurface(
-				SDL_SWSURFACE,
-				icon->w, icon->h, iconFormat.bytesPerPixel * 8,
+		SDL_Surface *osdIconSurface = SDL_CreateRGBSurfaceFrom(const_cast<void *>(icon->getPixels()),
+				icon->w, icon->h, iconFormat.bytesPerPixel * 8, icon->pitch,
 				((0xFF >> iconFormat.rLoss) << iconFormat.rShift),
 				((0xFF >> iconFormat.gLoss) << iconFormat.gShift),
 				((0xFF >> iconFormat.bLoss) << iconFormat.bShift),
@@ -2756,44 +2747,37 @@ void RenderSdlGraphicsManager::displayActivityIconOnOSD(const Graphics::Surface 
 		);
 #endif
 
-		// Lock the surface
-		if (!lockSurface(_osdIconSurface))
-			error("displayActivityIconOnOSD: SDL_LockSurface failed: %s", SDL_GetError());
+		// Create a new texture from the surface
+		_osdIconTexture = SDL_CreateTextureFromSurface(_renderer, osdIconSurface);
 
-		byte *dst = (byte *) _osdIconSurface->pixels;
-		const byte *src = (const byte *) icon->getPixels();
-		for (int y = 0; y < icon->h; y++) {
-			memcpy(dst, src, icon->w * iconFormat.bytesPerPixel);
-			src += icon->pitch;
-			dst += _osdIconSurface->pitch;
-		}
+		// We don't need the surface any more
+		SDL_FreeSurface(osdIconSurface);
 
-		// Finished drawing, so unlock the OSD icon surface
-		SDL_UnlockSurface(_osdIconSurface);
+		// Enable alpha blending
+		SDL_SetTextureBlendMode(_osdIconTexture, SDL_BLENDMODE_BLEND);
 	}
 }
 
 SDL_Rect RenderSdlGraphicsManager::getOSDIconRect() const {
+	int w, h;
+	SDL_QueryTexture(_osdIconTexture, nullptr, nullptr, &w, &h);
+
 	SDL_Rect dstRect;
-	dstRect.x = _hwScreen->w - _osdIconSurface->w - 10;
+	dstRect.x = _windowWidth - w - 10;
 	dstRect.y = 10;
-	dstRect.w = _osdIconSurface->w;
-	dstRect.h = _osdIconSurface->h;
+	dstRect.w = w;
+	dstRect.h = h;
 	return dstRect;
 }
 
 void RenderSdlGraphicsManager::removeOSDMessage() {
 	// Remove the previous message
-	if (_osdMessageSurface) {
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-		SDL_DestroySurface(_osdMessageSurface);
-#else
-		SDL_FreeSurface(_osdMessageSurface);
-#endif
+	if (_osdMessageTexture) {
+		SDL_DestroyTexture(_osdMessageTexture);
 		_forceRedraw = true;
 	}
 
-	_osdMessageSurface = nullptr;
+	_osdMessageTexture = nullptr;
 	_osdMessageAlpha = SDL_ALPHA_TRANSPARENT;
 
 #if defined(MACOSX)
@@ -2815,38 +2799,80 @@ void RenderSdlGraphicsManager::updateOSD() {
 				const int startAlpha = SDL_ALPHA_TRANSPARENT + kOSDInitialAlpha * (SDL_ALPHA_OPAQUE - SDL_ALPHA_TRANSPARENT) / 100;
 				_osdMessageAlpha = startAlpha + diff * (SDL_ALPHA_TRANSPARENT - startAlpha) / kOSDFadeOutDuration;
 			}
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-			SDL_SetAlpha(_osdMessageSurface, SDL_SRCALPHA, _osdMessageAlpha);
-			SDL_SetSurfaceRLE(_osdMessageSurface, true);
-#else
-			SDL_SetAlpha(_osdMessageSurface, SDL_RLEACCEL | SDL_SRCALPHA, _osdMessageAlpha);
-#endif
+			SDL_SetTextureAlphaMod(_osdMessageTexture, _osdMessageAlpha);
 		}
 
 		if (_osdMessageAlpha == SDL_ALPHA_TRANSPARENT) {
 			removeOSDMessage();
 		}
 	}
-
-	if (_osdIconSurface || _osdMessageSurface) {
-		// Redraw the area below the icon and message for the transparent blit to give correct results.
-		_forceRedraw = true;
-	}
 }
 
 void RenderSdlGraphicsManager::drawOSD() {
-	if (_osdMessageSurface) {
+	if (_osdMessageTexture) {
 		SDL_Rect dstRect = getOSDMessageRect();
-		SDL_BlitSurface(_osdMessageSurface, nullptr, _hwScreen, &dstRect);
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		SDL_FRect dstRectF;
+		SDL_RectToFRect(&dstRect, &dstRectF);
+		SDL_RenderTexture(_renderer, _osdMessageTexture, nullptr, &dstRectF);
+#else
+		SDL_RenderCopy(_renderer, _osdMessageTexture, nullptr, &dstRect);
+#endif
 	}
 
-	if (_osdIconSurface) {
+	if (_osdIconTexture) {
 		SDL_Rect dstRect = getOSDIconRect();
-		SDL_BlitSurface(_osdIconSurface, nullptr, _hwScreen, &dstRect);
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		SDL_FRect dstRectF;
+		SDL_RectToFRect(&dstRect, &dstRectF);
+		SDL_RenderTexture(_renderer, _osdIconTexture, nullptr, &dstRectF);
+#else
+		SDL_RenderCopy(_renderer, _osdIconTexture, nullptr, &dstRect);
+#endif
 	}
 }
 
 #endif
+
+void RenderSdlGraphicsManager::drawScreen() {
+	SDL_Rect viewport;
+
+	Common::Rect &drawRect = (_overlayVisible) ? _overlayDrawRect : _gameDrawRect;
+
+	/* Destination rectangle represents the texture before rotation */
+	if (_rotationMode == Common::kRotation90 || _rotationMode == Common::kRotation270) {
+		viewport.w = drawRect.height();
+		viewport.h = drawRect.width();
+		int delta = (viewport.w - viewport.h) / 2;
+		viewport.x = drawRect.left - delta;
+		viewport.y = drawRect.top + delta;
+	} else {
+		viewport.w = drawRect.width();
+		viewport.h = drawRect.height();
+		viewport.x = drawRect.left;
+		viewport.y = drawRect.top;
+	}
+
+	int rotangle = (int)_rotationMode;
+
+	if (rotangle != 0) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		SDL_FRect fViewport;
+		SDL_RectToFRect(&viewport, &fViewport);
+		SDL_RenderTextureRotated(_renderer, _screenTexture, nullptr, &fViewport, rotangle, nullptr, SDL_FLIP_NONE);
+#else
+		SDL_RenderCopyEx(_renderer, _screenTexture, nullptr, &viewport, rotangle, nullptr, SDL_FLIP_NONE);
+#endif
+	} else {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		SDL_FRect fViewport;
+		SDL_RectToFRect(&viewport, &fViewport);
+		SDL_RenderTexture(_renderer, _screenTexture, nullptr, &fViewport);
+#else
+		SDL_RenderCopy(_renderer, _screenTexture, nullptr, &viewport);
+#endif
+	}
+}
 
 void RenderSdlGraphicsManager::handleResizeImpl(const int width, const int height) {
 	SdlGraphicsManager::handleResizeImpl(width, height);
@@ -3151,46 +3177,6 @@ SDL_Surface *RenderSdlGraphicsManager::SDL_SetVideoMode(int width, int height, i
 
 void RenderSdlGraphicsManager::SDL_UpdateRects(SDL_Surface *screen, int numrects, SDL_Rect *rects) {
 	SDL_UpdateTexture(_screenTexture, nullptr, screen->pixels, screen->pitch);
-
-	SDL_Rect viewport;
-
-	Common::Rect &drawRect = (_overlayVisible) ? _overlayDrawRect : _gameDrawRect;
-
-	/* Destination rectangle represents the texture before rotation */
-	if (_rotationMode == Common::kRotation90 || _rotationMode == Common::kRotation270) {
-		viewport.w = drawRect.height();
-		viewport.h = drawRect.width();
-		int delta = (viewport.w - viewport.h) / 2;
-		viewport.x = drawRect.left - delta;
-		viewport.y = drawRect.top + delta;
-	} else {
-		viewport.w = drawRect.width();
-		viewport.h = drawRect.height();
-		viewport.x = drawRect.left;
-		viewport.y = drawRect.top;
-	}
-
-	int rotangle = (int)_rotationMode;
-
-	SDL_RenderClear(_renderer);
-
-	if (rotangle != 0) {
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-		SDL_FRect fViewport;
-		SDL_RectToFRect(&viewport, &fViewport);
-		SDL_RenderTextureRotated(_renderer, _screenTexture, nullptr, &fViewport, rotangle, nullptr, SDL_FLIP_NONE);
-#else
-		SDL_RenderCopyEx(_renderer, _screenTexture, nullptr, &viewport, rotangle, nullptr, SDL_FLIP_NONE);
-#endif
-	} else {
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-		SDL_FRect fViewport;
-		SDL_RectToFRect(&viewport, &fViewport);
-		SDL_RenderTexture(_renderer, _screenTexture, nullptr, &fViewport);
-#else
-		SDL_RenderCopy(_renderer, _screenTexture, nullptr, &viewport);
-#endif
-	}
 }
 
 int RenderSdlGraphicsManager::SDL_SetColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors) {

--- a/backends/graphics/rendersdl/rendersdl-graphics.cpp
+++ b/backends/graphics/rendersdl/rendersdl-graphics.cpp
@@ -184,9 +184,6 @@ RenderSdlGraphicsManager::RenderSdlGraphicsManager(SdlEventSource *sdlEventSourc
 	_paletteDirtyStart(0), _paletteDirtyEnd(0),
 	_screenIsLocked(false),
 	_displayDisabled(false),
-#ifdef USE_SDL_DEBUG_FOCUSRECT
-	_enableFocusRectDebugCode(false), _enableFocusRect(false), _focusRect(),
-#endif
 	_transactionMode(kTransactionNone),
 	_scalerPlugins(ScalerMan.getPlugins()), _scalerPlugin(nullptr), _scaler(nullptr),
 	_isDoubleBuf(false), _prevForceRedraw(false), _numPrevDirtyRects(0),
@@ -195,11 +192,6 @@ RenderSdlGraphicsManager::RenderSdlGraphicsManager(SdlEventSource *sdlEventSourc
 	// allocate palette storage
 	_currentPalette = (SDL_Color *)calloc(256, sizeof(SDL_Color));
 	_cursorPalette = (SDL_Color *)calloc(256, sizeof(SDL_Color));
-
-#ifdef USE_SDL_DEBUG_FOCUSRECT
-	if (ConfMan.hasKey("use_sdl_debug_focusrect"))
-		_enableFocusRectDebugCode = ConfMan.getBool("use_sdl_debug_focusrect");
-#endif
 
 #if defined(USE_ASPECT)
 	_videoMode.aspectRatioCorrection = ConfMan.getBool("aspect_ratio");
@@ -1383,95 +1375,6 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 			_dirtyRectList[0].h = _videoMode.hardwareHeight;
 		}
 
-#ifdef USE_SDL_DEBUG_FOCUSRECT
-		// We draw the focus rectangle on top of everything, to assure it's easily visible.
-		// Of course when the GUI overlay is visible we do not show it, since it is only for game
-		// specific focus.
-		if (_enableFocusRect && !_overlayInGUI) {
-			int x = _focusRect.left + _currentShakeXOffset;
-			int y = _focusRect.top + _currentShakeYOffset;
-
-			if (x < width && y < height) {
-				int w = _focusRect.width();
-				if (w > width - x)
-					w = width - x;
-
-				int h = _focusRect.height();
-				if (h > height - y)
-					h = height - y;
-
-				x *= scale1;
-				y *= scale1;
-				w *= scale1;
-				h *= scale1;
-
-				if (_videoMode.aspectRatioCorrection && !_overlayVisible)
-					y = real2Aspect(y);
-
-				if (h > 0 && w > 0) {
-					SDL_LockSurface(_hwScreen);
-
-					// Use white as color for now.
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-					Uint32 rectColor = SDL_MapSurfaceRGB(_hwScreen, 0xFF, 0xFF, 0xFF);
-#else
-					Uint32 rectColor = SDL_MapRGB(_hwScreen->format, 0xFF, 0xFF, 0xFF);
-#endif
-
-					// First draw the top and bottom lines
-					// then draw the left and right lines
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-					if (pixelFormatDetails->bytes_per_pixel == 2) {
-#else
-					if (_hwScreen->format->BytesPerPixel == 2) {
-#endif
-						uint16 *top = (uint16 *)((byte *)_hwScreen->pixels + y * _hwScreen->pitch + x * 2);
-						uint16 *bottom = (uint16 *)((byte *)_hwScreen->pixels + (y + h) * _hwScreen->pitch + x * 2);
-						byte *left = ((byte *)_hwScreen->pixels + y * _hwScreen->pitch + x * 2);
-						byte *right = ((byte *)_hwScreen->pixels + y * _hwScreen->pitch + (x + w - 1) * 2);
-
-						while (w--) {
-							*top++ = rectColor;
-							*bottom++ = rectColor;
-						}
-
-						while (h--) {
-							*(uint16 *)left = rectColor;
-							*(uint16 *)right = rectColor;
-
-							left += _hwScreen->pitch;
-							right += _hwScreen->pitch;
-						}
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-					} else if (pixelFormatDetails->bytes_per_pixel == 4) {
-#else
-					} else if (_hwScreen->format->BytesPerPixel == 4) {
-#endif
-						uint32 *top = (uint32 *)((byte *)_hwScreen->pixels + y * _hwScreen->pitch + x * 4);
-						uint32 *bottom = (uint32 *)((byte *)_hwScreen->pixels + (y + h) * _hwScreen->pitch + x * 4);
-						byte *left = ((byte *)_hwScreen->pixels + y * _hwScreen->pitch + x * 4);
-						byte *right = ((byte *)_hwScreen->pixels + y * _hwScreen->pitch + (x + w - 1) * 4);
-
-						while (w--) {
-							*top++ = rectColor;
-							*bottom++ = rectColor;
-						}
-
-						while (h--) {
-							*(uint32 *)left = rectColor;
-							*(uint32 *)right = rectColor;
-
-							left += _hwScreen->pitch;
-							right += _hwScreen->pitch;
-						}
-					}
-
-					SDL_UnlockSurface(_hwScreen);
-				}
-			}
-		}
-#endif
-
 		// Finally, blit all our changes to the screen
 		if (!_displayDisabled) {
 			updateScreen(_dirtyRectList, actualDirtyRects);
@@ -1812,42 +1715,6 @@ void RenderSdlGraphicsManager::setCursorPalette(const byte *colors, uint start, 
 
 	_cursorPaletteDisabled = false;
 	blitCursor();
-}
-
-void RenderSdlGraphicsManager::setFocusRectangle(const Common::Rect &rect) {
-#ifdef USE_SDL_DEBUG_FOCUSRECT
-	// Only enable focus rectangle debug code, when the user wants it
-	if (!_enableFocusRectDebugCode)
-		return;
-
-	_enableFocusRect = true;
-	_focusRect = rect;
-
-	if (rect.left < 0 || rect.top < 0 || rect.right > _videoMode.screenWidth || rect.bottom > _videoMode.screenHeight)
-		warning("RenderSdlGraphicsManager::setFocusRectangle: Got a rect which does not fit inside the screen bounds: %d,%d,%d,%d", rect.left, rect.top, rect.right, rect.bottom);
-
-	// It's gross but we actually sometimes get rects, which are not inside the screen bounds,
-	// thus we need to clip the rect here...
-	_focusRect.clip(_videoMode.screenWidth, _videoMode.screenHeight);
-
-	// We just fake this as a dirty rect for now, to easily force a screen update whenever
-	// the rect changes.
-	addDirtyRect(_focusRect.left, _focusRect.top, _focusRect.width(), _focusRect.height());
-#endif
-}
-
-void RenderSdlGraphicsManager::clearFocusRectangle() {
-#ifdef USE_SDL_DEBUG_FOCUSRECT
-	// Only enable focus rectangle debug code, when the user wants it
-	if (!_enableFocusRectDebugCode)
-		return;
-
-	_enableFocusRect = false;
-
-	// We just fake this as a dirty rect for now, to easily force a screen update whenever
-	// the rect changes.
-	addDirtyRect(_focusRect.left, _focusRect.top, _focusRect.width(), _focusRect.height());
-#endif
 }
 
 #pragma mark -

--- a/backends/graphics/rendersdl/rendersdl-graphics.cpp
+++ b/backends/graphics/rendersdl/rendersdl-graphics.cpp
@@ -176,7 +176,7 @@ RenderSdlGraphicsManager::RenderSdlGraphicsManager(SdlEventSource *sdlEventSourc
 	_screenFormat(Graphics::PixelFormat::createFormatCLUT8()),
 	_cursorFormat(Graphics::PixelFormat::createFormatCLUT8()),
 	_useOldSrc(false), _isHwPalette(false),
-	_overlayscreen(nullptr), _tmpscreen2(nullptr),
+	_overlayTexture(nullptr), _overlaySurface(nullptr),
 	_screenChangeCount(0),
 	_mouseTexture(nullptr), _mouseScaler(nullptr), _mouseSurface(nullptr),
 	_mouseOrigSurface(nullptr), _cursorDontScale(false), _cursorPaletteDisabled(true),
@@ -189,23 +189,12 @@ RenderSdlGraphicsManager::RenderSdlGraphicsManager(SdlEventSource *sdlEventSourc
 #endif
 	_transactionMode(kTransactionNone),
 	_scalerPlugins(ScalerMan.getPlugins()), _scalerPlugin(nullptr), _scaler(nullptr),
-	_needRestoreAfterOverlay(false), _isInOverlayPalette(false), _isDoubleBuf(false), _prevForceRedraw(false), _numPrevDirtyRects(0),
+	_isDoubleBuf(false), _prevForceRedraw(false), _numPrevDirtyRects(0),
 	_mouseKeyColor(0), _disableMouseKeyColor(false) {
 
 	// allocate palette storage
 	_currentPalette = (SDL_Color *)calloc(256, sizeof(SDL_Color));
-	_overlayPalette = (SDL_Color *)calloc(256, sizeof(SDL_Color));
 	_cursorPalette = (SDL_Color *)calloc(256, sizeof(SDL_Color));
-
-	// Generate RGB332 palette for overlay
-	for (uint i = 0; i < 256; i++) {
-		_overlayPalette[i].r = ((i >> 5) & 7) << 5;
-		_overlayPalette[i].g = ((i >> 2) & 7) << 5;
-		_overlayPalette[i].b = (i & 3) << 6;
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-		_overlayPalette[i].a = 0xff;
-#endif
-	}
 
 #ifdef USE_SDL_DEBUG_FOCUSRECT
 	if (ConfMan.hasKey("use_sdl_debug_focusrect"))
@@ -247,11 +236,13 @@ RenderSdlGraphicsManager::~RenderSdlGraphicsManager() {
 		destroySurface(_mouseSurface);
 	}
 	free(_currentPalette);
-	free(_overlayPalette);
 	free(_cursorPalette);
 }
 
 bool RenderSdlGraphicsManager::hasFeature(OSystem::Feature f) const {
+	if (f == OSystem::kFeatureOverlaySupportsAlpha)
+		return _overlayFormat.aBits() > 3;
+
 	return
 		(f == OSystem::kFeatureFullscreenMode) ||
 #ifdef USE_SCALERS
@@ -448,8 +439,6 @@ OSystem::TransactionError RenderSdlGraphicsManager::endGFXTransaction() {
 
 			_videoMode.screenWidth = _oldVideoMode.screenWidth;
 			_videoMode.screenHeight = _oldVideoMode.screenHeight;
-			_videoMode.overlayWidth = _oldVideoMode.overlayWidth;
-			_videoMode.overlayHeight = _oldVideoMode.overlayHeight;
 		}
 
 		// Our new video mode would now be exactly the same as the
@@ -927,9 +916,6 @@ void RenderSdlGraphicsManager::fixupResolutionForAspectRatio(AspectRatio desired
 }
 
 void RenderSdlGraphicsManager::setupHardwareSize() {
-	_videoMode.overlayWidth = _videoMode.screenWidth * _videoMode.scaleFactor;
-	_videoMode.overlayHeight = _videoMode.screenHeight * _videoMode.scaleFactor;
-
 	if (_videoMode.screenHeight != 200 && _videoMode.screenHeight != 400)
 		_videoMode.aspectRatioCorrection = false;
 
@@ -937,7 +923,6 @@ void RenderSdlGraphicsManager::setupHardwareSize() {
 	_videoMode.hardwareHeight = _videoMode.screenHeight * _videoMode.scaleFactor;
 
 	if (_videoMode.aspectRatioCorrection) {
-		_videoMode.overlayHeight = real2Aspect(_videoMode.overlayHeight);
 		_videoMode.hardwareHeight = real2Aspect(_videoMode.hardwareHeight);
 	}
 }
@@ -1058,27 +1043,6 @@ bool RenderSdlGraphicsManager::loadGFXMode() {
 									_videoMode.screenWidth, _videoMode.screenHeight, _maxExtraPixels);
 	}
 
-	_overlayscreen = createSurface(_videoMode.overlayWidth, _videoMode.overlayHeight, _hwScreen);
-	if (_overlayscreen == nullptr)
-		error("allocating _overlayscreen failed");
-
-	_overlayFormat = convertSDLPixelFormat(_overlayscreen->format);
-	// Overlay uses RGB332 palette
-	if (_overlayFormat.bytesPerPixel == 1 && _overlayFormat.rBits() == 0)
-		_overlayFormat = Graphics::PixelFormat(1, 3, 3, 2, 0, 5, 2, 0, 0);
-
-	_tmpscreen2 = createSurface(_videoMode.overlayWidth + _maxExtraPixels * 2, _videoMode.overlayHeight + _maxExtraPixels * 2, _hwScreen);
-	if (_tmpscreen2 == nullptr)
-		error("allocating _tmpscreen2 failed");
-
-	if (_isHwPalette) {
-		if (!_screenFormat.isCLUT8())
-			return false;
-
-		SDL_SetColors(_tmpscreen2, _overlayPalette, 0, 256);
-		SDL_SetColors(_overlayscreen, _overlayPalette, 0, 256);
-	}
-
 	return true;
 }
 
@@ -1105,6 +1069,16 @@ void RenderSdlGraphicsManager::unloadGFXMode() {
 		_mouseTexture = nullptr;
 	}
 
+	if (_overlayTexture) {
+		SDL_DestroyTexture(_overlayTexture);
+		_overlayTexture = nullptr;
+	}
+
+	if (_overlaySurface) {
+		SDL_FreeSurface(_overlaySurface);
+		_overlaySurface = nullptr;
+	}
+
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	deinitializeRenderer();
 #endif
@@ -1117,16 +1091,6 @@ void RenderSdlGraphicsManager::unloadGFXMode() {
 	if (_tmpscreen) {
 		destroySurface(_tmpscreen);
 		_tmpscreen = nullptr;
-	}
-
-	if (_tmpscreen2) {
-		destroySurface(_tmpscreen2);
-		_tmpscreen2 = nullptr;
-	}
-
-	if (_overlayscreen) {
-		destroySurface(_overlayscreen);
-		_overlayscreen = nullptr;
 	}
 
 #if defined(WIN32) && !SDL_VERSION_ATLEAST(2, 0, 0)
@@ -1142,12 +1106,10 @@ bool RenderSdlGraphicsManager::hotswapGFXMode() {
 	if (!_screen)
 		return false;
 
-	// Keep around the old _screen & _overlayscreen so we can restore the screen data
+	// Keep around the old _screen so we can restore the screen data
 	// after the mode switch.
 	SDL_Surface *old_screen = _screen;
 	_screen = nullptr;
-	SDL_Surface *old_overlayscreen = _overlayscreen;
-	_overlayscreen = nullptr;
 
 	// Release the HW screen surface
 	if (_hwScreen) {
@@ -1158,17 +1120,12 @@ bool RenderSdlGraphicsManager::hotswapGFXMode() {
 		destroySurface(_tmpscreen);
 		_tmpscreen = nullptr;
 	}
-	if (_tmpscreen2) {
-		destroySurface(_tmpscreen2);
-		_tmpscreen2 = nullptr;
-	}
 
 	// Setup the new GFX mode
 	if (!loadGFXMode()) {
 		unloadGFXMode();
 
 		_screen = old_screen;
-		_overlayscreen = old_overlayscreen;
 
 		return false;
 	}
@@ -1178,11 +1135,9 @@ bool RenderSdlGraphicsManager::hotswapGFXMode() {
 
 	// Restore old screen content
 	SDL_BlitSurface(old_screen, nullptr, _screen, nullptr);
-	SDL_BlitSurface(old_overlayscreen, nullptr, _overlayscreen, nullptr);
 
 	// Free the old surfaces
 	destroySurface(old_screen);
-	destroySurface(old_overlayscreen);
 
 	// Update cursor to new scale
 	blitCursor();
@@ -1272,7 +1227,7 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 			SDL_SetColors(_tmpscreen, _currentPalette + _paletteDirtyStart,
 				      _paletteDirtyStart,
 				      _paletteDirtyEnd - _paletteDirtyStart);
-		if (_isHwPalette && !_isInOverlayPalette)
+		if (_isHwPalette)
 			SDL_SetColors(_hwScreen, _currentPalette + _paletteDirtyStart,
 				       _paletteDirtyStart,
 				       _paletteDirtyEnd - _paletteDirtyStart);
@@ -1284,42 +1239,15 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 
 	int oldScaleFactor;
 
-	if (!_overlayVisible) {
-		if (_needRestoreAfterOverlay) {
-			// This is needed for the Edge scaler which seems to be the only scaler to use the "_useOldSrc" feature.
-			// Otherwise the screen will not be properly restored after removing the overlay. We need to trigger a
-			// regeneration of SourceScaler::_bufferedOutput. The call to _scaler->setFactor() down below could
-			// do that in theory, but it won't unless the factor actually changes (which it doesn't). Now, the code
-			// in SourceScaler::setSource() looks a bit fishy, e. g. the *src argument isn't even used. But otherwise
-			// it does what we want here at least...
-			_scaler->setSource(nullptr, _tmpscreen->pitch, _videoMode.screenWidth, _videoMode.screenHeight, _maxExtraPixels);
-		}
-
-		origSurf = _screen;
-		srcSurf = _tmpscreen;
-		width = _videoMode.screenWidth;
-		height = _videoMode.screenHeight;
-		oldScaleFactor = scale1 = _videoMode.scaleFactor;
-		_needRestoreAfterOverlay = false;
-	} else {
-		origSurf = _overlayscreen;
-		srcSurf = _tmpscreen2;
-		width = _videoMode.overlayWidth;
-		height = _videoMode.overlayHeight;
-		scale1 = 1;
-		oldScaleFactor = _scaler->setFactor(1);
-		_needRestoreAfterOverlay = _useOldSrc;
-	}
+	origSurf = _screen;
+	srcSurf = _tmpscreen;
+	width = _videoMode.screenWidth;
+	height = _videoMode.screenHeight;
+	oldScaleFactor = scale1 = _videoMode.scaleFactor;
 
 #ifdef USE_OSD
 	updateOSD();
 #endif
-
-	if (_isHwPalette && _isInOverlayPalette != _overlayVisible) {
-		SDL_SetColors(_hwScreen, _overlayVisible ? _overlayPalette : _currentPalette, 0, 256);
-		_forceRedraw = true;
-		_isInOverlayPalette = _overlayVisible;
-	}
 
 	// In case of double buferring partially good version may be on another page,
 	// so we need to fully redraw
@@ -1552,6 +1480,7 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 
 	SDL_RenderClear(_renderer);
 	drawScreen();
+	drawOverlay();
 	drawMouse();
 #ifdef USE_OSD
 	drawOSD();
@@ -1702,7 +1631,7 @@ void RenderSdlGraphicsManager::copyRectToScreen(const void *buf, int pitch, int 
 	assert(h > 0 && y + h <= _videoMode.screenHeight);
 	assert(w > 0 && x + w <= _videoMode.screenWidth);
 
-	addDirtyRect(x, y, w, h, false);
+	addDirtyRect(x, y, w, h);
 
 	// Try to lock the screen surface
 	if (!lockSurface(_screen))
@@ -1774,7 +1703,7 @@ void RenderSdlGraphicsManager::fillScreen(const Common::Rect &r, uint32 col) {
 	unlockScreen();
 }
 
-void RenderSdlGraphicsManager::addDirtyRect(int x, int y, int w, int h, bool inOverlay, bool realCoordinates) {
+void RenderSdlGraphicsManager::addDirtyRect(int x, int y, int w, int h) {
 	if (_forceRedraw)
 		return;
 
@@ -1783,26 +1712,17 @@ void RenderSdlGraphicsManager::addDirtyRect(int x, int y, int w, int h, bool inO
 		return;
 	}
 
-	int height, width;
-
-	if (!inOverlay && !realCoordinates) {
-		width = _videoMode.screenWidth;
-		height = _videoMode.screenHeight;
-	} else {
-		width = _videoMode.overlayWidth;
-		height = _videoMode.overlayHeight;
-	}
+	int width = _videoMode.screenWidth;
+	int height = _videoMode.screenHeight;
 
 	// Extend the dirty region for scalers
 	// that "smear" the screen, e.g. 2xSAI
-	if (!realCoordinates) {
-		// Aspect ratio correction requires this to be at least one
-		int adjust = MAX(_extraPixels, (uint)1);
-		x -= adjust;
-		y -= adjust;
-		w += adjust * 2;
-		h += adjust * 2;
-	}
+	// Aspect ratio correction requires this to be at least one
+	int adjust = MAX(_extraPixels, (uint)1);
+	x -= adjust;
+	y -= adjust;
+	w += adjust * 2;
+	h += adjust * 2;
 
 	// clip
 	if (x < 0) {
@@ -1824,7 +1744,7 @@ void RenderSdlGraphicsManager::addDirtyRect(int x, int y, int w, int h, bool inO
 	}
 
 #ifdef USE_ASPECT
-	if (_videoMode.aspectRatioCorrection && !inOverlay && !realCoordinates)
+	if (_videoMode.aspectRatioCorrection)
 		makeRectStretchable(x, y, w, h, _videoMode.filtering);
 #endif
 
@@ -1934,7 +1854,7 @@ void RenderSdlGraphicsManager::setFocusRectangle(const Common::Rect &rect) {
 
 	// We just fake this as a dirty rect for now, to easily force a screen update whenever
 	// the rect changes.
-	addDirtyRect(_focusRect.left, _focusRect.top, _focusRect.width(), _focusRect.height(), false);
+	addDirtyRect(_focusRect.left, _focusRect.top, _focusRect.width(), _focusRect.height());
 #endif
 }
 
@@ -1948,7 +1868,7 @@ void RenderSdlGraphicsManager::clearFocusRectangle() {
 
 	// We just fake this as a dirty rect for now, to easily force a screen update whenever
 	// the rect changes.
-	addDirtyRect(_focusRect.left, _focusRect.top, _focusRect.width(), _focusRect.height(), false);
+	addDirtyRect(_focusRect.left, _focusRect.top, _focusRect.width(), _focusRect.height());
 #endif
 }
 
@@ -1962,95 +1882,47 @@ void RenderSdlGraphicsManager::clearOverlay() {
 	if (!_overlayVisible)
 		return;
 
-	// Clear the overlay by making the game screen "look through" everywhere.
-	SDL_Rect src, dst;
-	src.x = src.y = 0;
-	dst.x = dst.y = _maxExtraPixels;
-	src.w = dst.w = _videoMode.screenWidth;
-	src.h = dst.h = _videoMode.screenHeight;
-	if (!blitSurface(_screen, &src, _tmpscreen, &dst))
-		error("SDL_BlitSurface failed: %s", SDL_GetError());
+	if (SDL_FillRect(_overlaySurface, NULL, 0) != 0)
+		error("SDL_FillRect failed: %s", SDL_GetError());
 
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-	const SDL_PixelFormatDetails *pixelFormatDetails = SDL_GetPixelFormatDetails(_tmpscreen->format);
-	if (!pixelFormatDetails)
-		error("SDL_GetPixelFormatDetails failed: %s", SDL_GetError());
-#endif
-
-	SDL_LockSurface(_tmpscreen);
-	SDL_LockSurface(_overlayscreen);
-
-	// Transpose from game palette to RGB332 (overlay palette)
-	if (_isHwPalette) {
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-		byte *p = (byte *)(_tmpscreen->pixels) + _maxExtraPixels * _tmpscreen->pitch + _maxExtraPixels * pixelFormatDetails->bytes_per_pixel;
-#else
-		byte *p = (byte *)(_tmpscreen->pixels) + _maxExtraPixels * _tmpscreen->pitch + _maxExtraPixels * _tmpscreen->format->BytesPerPixel;
-#endif
-		int pitchSkip = _tmpscreen->pitch - _videoMode.screenWidth;
-		for (int y = 0; y < _videoMode.screenHeight; y++) {
-			for (int x = 0; x < _videoMode.screenWidth; x++, p++) {
-				const SDL_Color &col = _currentPalette[*p];
-				*p = (col.r & 0xe0) | ((col.g >> 3) & 0x1c) | ((col.b >> 6) & 0x03);
-			}
-			p += pitchSkip;
-		}
-	}
-
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-	_scaler->scale((byte *)(_tmpscreen->pixels) + _maxExtraPixels * _tmpscreen->pitch + _maxExtraPixels * pixelFormatDetails->bytes_per_pixel, _tmpscreen->pitch,
-#else
-	_scaler->scale((byte *)(_tmpscreen->pixels) + _maxExtraPixels * _tmpscreen->pitch + _maxExtraPixels * _tmpscreen->format->BytesPerPixel, _tmpscreen->pitch,
-#endif
-	(byte *)_overlayscreen->pixels, _overlayscreen->pitch, _videoMode.screenWidth, _videoMode.screenHeight, 0, 0);
-
-#ifdef USE_ASPECT
-	if (_videoMode.aspectRatioCorrection)
-		stretch200To240((uint8 *)_overlayscreen->pixels, _overlayscreen->pitch,
-						_videoMode.overlayWidth, _videoMode.screenHeight * _videoMode.scaleFactor, 0, 0, 0,
-						_videoMode.filtering, _overlayFormat);
-#endif
-	SDL_UnlockSurface(_tmpscreen);
-	SDL_UnlockSurface(_overlayscreen);
-
-	_forceRedraw = true;
+	_overlayDirty = true;
 }
 
 void RenderSdlGraphicsManager::grabOverlay(Graphics::Surface &surface) const {
 	assert(_transactionMode == kTransactionNone);
 
-	if (_overlayscreen == nullptr)
+	if (_overlaySurface == nullptr)
 		return;
 
-	if (!lockSurface(_overlayscreen))
+	if (!lockSurface(_overlaySurface))
 		error("SDL_LockSurface failed: %s", SDL_GetError());
 
-	assert(surface.w >= _videoMode.overlayWidth);
-	assert(surface.h >= _videoMode.overlayHeight);
+	assert(surface.w >= _overlaySurface->w);
+	assert(surface.h >= _overlaySurface->h);
 	assert(surface.format.bytesPerPixel == _overlayFormat.bytesPerPixel);
 
-	byte *src = (byte *)_overlayscreen->pixels;
+	byte *src = (byte *)_overlaySurface->pixels;
 	byte *dst = (byte *)surface.getPixels();
-	Graphics::copyBlit(dst, src, surface.pitch, _overlayscreen->pitch,
-		_videoMode.overlayWidth, _videoMode.overlayHeight, _overlayFormat.bytesPerPixel);
+	Graphics::copyBlit(dst, src, surface.pitch, _overlaySurface->pitch,
+		_overlaySurface->w, _overlaySurface->h, _overlayFormat.bytesPerPixel);
 
-	SDL_UnlockSurface(_overlayscreen);
+	SDL_UnlockSurface(_overlaySurface);
 }
 
 void RenderSdlGraphicsManager::copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) {
 	assert(_transactionMode == kTransactionNone);
 
-	if (_overlayscreen == nullptr)
+	if (_overlaySurface == nullptr)
 		return;
 
 	const byte *src = (const byte *)buf;
 #if SDL_VERSION_ATLEAST(3, 0, 0)
-	const SDL_PixelFormatDetails *pixelFormatDetails = SDL_GetPixelFormatDetails(_overlayscreen->format);
+	const SDL_PixelFormatDetails *pixelFormatDetails = SDL_GetPixelFormatDetails(_overlaySurface->format);
 	if (!pixelFormatDetails)
 		error("SDL_GetPixelFormatDetails failed: %s", SDL_GetError());
 	uint bpp = pixelFormatDetails->bytes_per_pixel;
 #else
-	uint bpp = _overlayscreen->format->BytesPerPixel;
+	uint bpp = _overlaySurface->format->BytesPerPixel;
 #endif
 
 	// Clip the coordinates
@@ -2066,33 +1938,162 @@ void RenderSdlGraphicsManager::copyRectToOverlay(const void *buf, int pitch, int
 		y = 0;
 	}
 
-	if (w > _videoMode.overlayWidth - x) {
-		w = _videoMode.overlayWidth - x;
+	if (w > _overlaySurface->w - x) {
+		w = _overlaySurface->w - x;
 	}
 
-	if (h > _videoMode.overlayHeight - y) {
-		h = _videoMode.overlayHeight - y;
+	if (h > _overlaySurface->h - y) {
+		h = _overlaySurface->h - y;
 	}
 
 	if (w <= 0 || h <= 0)
 		return;
 
-	// Mark the modified region as dirty
-	addDirtyRect(x, y, w, h, true);
+	// Mark the overlay as dirty
+	_overlayDirty = true;
 
-	if (!lockSurface(_overlayscreen))
+	if (!lockSurface(_overlaySurface))
 		error("SDL_LockSurface failed: %s", SDL_GetError());
 
-	byte *dst = (byte *)_overlayscreen->pixels + y * _overlayscreen->pitch + x * bpp;
-	do {
-		memcpy(dst, src, w * bpp);
-		dst += _overlayscreen->pitch;
-		src += pitch;
-	} while (--h);
+	byte *dst = (byte *)_overlaySurface->pixels + y * _overlaySurface->pitch + x * bpp;
+	Graphics::copyBlit(dst, src, _overlaySurface->pitch, pitch, w, h, bpp);
 
-	SDL_UnlockSurface(_overlayscreen);
+	SDL_UnlockSurface(_overlaySurface);
 }
 
+void RenderSdlGraphicsManager::drawOverlay() {
+	if (!_overlayTexture || !_overlaySurface || !_overlayVisible)
+		return;
+
+	if (_overlayDirty) {
+		SDL_UpdateTexture(_overlayTexture, NULL, _overlaySurface->pixels, _overlaySurface->pitch);
+		_overlayDirty = false;
+	}
+
+	SDL_Rect viewport;
+
+	Common::Rect &drawRect = _overlayDrawRect;
+
+	/* Destination rectangle represents the texture before rotation */
+	if (_rotationMode == Common::kRotation90 || _rotationMode == Common::kRotation270) {
+		viewport.w = drawRect.height();
+		viewport.h = drawRect.width();
+		int delta = (viewport.w - viewport.h) / 2;
+		viewport.x = drawRect.left - delta;
+		viewport.y = drawRect.top + delta;
+	} else {
+		viewport.w = drawRect.width();
+		viewport.h = drawRect.height();
+		viewport.x = drawRect.left;
+		viewport.y = drawRect.top;
+	}
+
+	if (_rotationMode != 0) {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		SDL_FRect fViewport;
+		SDL_RectToFRect(&viewport, &fViewport);
+		SDL_RenderTextureRotated(_renderer, _overlayTexture, nullptr, &fViewport, _rotationMode, nullptr, SDL_FLIP_NONE);
+#else
+		SDL_RenderCopyEx(_renderer, _overlayTexture, nullptr, &viewport, _rotationMode, nullptr, SDL_FLIP_NONE);
+#endif
+	} else {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		SDL_FRect fViewport;
+		SDL_RectToFRect(&viewport, &fViewport);
+		SDL_RenderTexture(_renderer, _overlayTexture, nullptr, &fViewport);
+#else
+		SDL_RenderCopy(_renderer, _overlayTexture, nullptr, &viewport);
+#endif
+	}
+}
+
+void RenderSdlGraphicsManager::recreateOverlay(const int width, const int height) {
+
+	SDL_RendererInfo info;
+	if (SDL_GetRendererInfo(_renderer, &info) < 0)
+		error("SDL_GetRendererInfo failed: %s", SDL_GetError());
+
+	uint overlayWidth = width;
+	uint overlayHeight = height;
+	Uint32 overlayFormat = SDL_PIXELFORMAT_UNKNOWN;
+
+	Common::RotationMode rotation = _rotationMode;
+	if (rotation == Common::kRotation90 || rotation == Common::kRotation270) {
+		overlayWidth = height;
+		overlayHeight = width;
+	}
+
+	// WORKAROUND: We can only support surfaces up to the maximum supported
+	// texture size. Thus, in case we encounter a physical size bigger than
+	// this maximum texture size we will simply use an overlay as big as
+	// possible and then scale it to the physical display size. This sounds
+	// bad but actually all recent chips should support full HD resolution
+	// anyway. Thus, it should not be a real issue for modern hardware.
+	if (   overlayWidth  > (uint)info.max_texture_width
+	    || overlayHeight > (uint)info.max_texture_height) {
+		const frac_t outputAspect = intToFrac(_windowWidth) / _windowHeight;
+
+		if (outputAspect > (frac_t)FRAC_ONE) {
+			overlayWidth  = info.max_texture_width;
+			overlayHeight = intToFrac(overlayWidth) / outputAspect;
+		} else {
+			overlayHeight = info.max_texture_height;
+			overlayWidth  = fracToInt(overlayHeight * outputAspect);
+		}
+	}
+
+	// HACK: We limit the minimal overlay size to 256x200, which is the
+	// minimum of the dimensions of the two resolutions 256x240 (NES) and
+	// 320x200 (many DOS games use this). This hopefully assure that our
+	// GUI has working layouts.
+	overlayWidth = MAX<uint>(overlayWidth, 256);
+	overlayHeight = MAX<uint>(overlayHeight, 200);
+
+	// Pick the best pixel format for the overlay based on what the
+	// renderer supports - prefer ones with alpha and higher bit depths.
+	for (Uint32 i = 0; i < info.num_texture_formats; i++) {
+		if (!SDL_ISPIXELFORMAT_PACKED(info.texture_formats[i]))
+			continue;
+
+		if (SDL_BITSPERPIXEL(info.texture_formats[i]) > SDL_BITSPERPIXEL(overlayFormat) &&
+		   !SDL_ISPIXELFORMAT_ALPHA(overlayFormat)) {
+			overlayFormat = info.texture_formats[i];
+			continue;
+		}
+
+		if (SDL_BITSPERPIXEL(info.texture_formats[i]) > SDL_BITSPERPIXEL(overlayFormat) &&
+		    SDL_ISPIXELFORMAT_ALPHA(info.texture_formats[i])) {
+			overlayFormat = info.texture_formats[i];
+			continue;
+		}
+	}
+	if (overlayFormat == SDL_PIXELFORMAT_UNKNOWN)
+		overlayFormat = SDL_PIXELFORMAT_RGBA32;
+
+	// Recreate the overlay surface and texture with the new information.
+
+	if (_overlaySurface) {
+		SDL_FreeSurface(_overlaySurface);
+	}
+	_overlaySurface = SDL_CreateRGBSurfaceWithFormat(SDL_SWSURFACE, overlayWidth, overlayHeight,
+						SDL_BITSPERPIXEL(overlayFormat), overlayFormat);
+
+	if (_overlaySurface == nullptr)
+		error("allocating _overlaySurface failed");
+
+	_overlayFormat = convertSDLPixelFormat(_overlaySurface->format);
+
+	if (_overlayTexture) {
+		SDL_DestroyTexture(_overlayTexture);
+	}
+	_overlayTexture = SDL_CreateTexture(_renderer, _overlaySurface->format->format, SDL_TEXTUREACCESS_STREAMING,
+						_overlaySurface->w, _overlaySurface->h);
+
+	if (_overlayTexture == nullptr)
+		error("allocating _overlayTexture failed");
+
+	SDL_SetTextureBlendMode(_overlayTexture, SDL_BLENDMODE_BLEND);
+}
 
 #pragma mark -
 #pragma mark --- Mouse ---
@@ -2624,7 +2625,7 @@ void RenderSdlGraphicsManager::recalculateCursorScaling() {
 
 	// In case scaling is actually enabled we will scale the cursor according
 	// to the game screen.
-	/* if (!_cursorDontScale) */ {
+	if (!_cursorDontScale) {
 		const frac_t screenScaleFactorX = intToFrac(_gameDrawRect.width()) / _hwScreen->w;
 		const frac_t screenScaleFactorY = intToFrac(_gameDrawRect.height()) / _hwScreen->h;
 
@@ -2892,7 +2893,7 @@ void RenderSdlGraphicsManager::drawOSD() {
 void RenderSdlGraphicsManager::drawScreen() {
 	SDL_Rect viewport;
 
-	Common::Rect &drawRect = (_overlayVisible) ? _overlayDrawRect : _gameDrawRect;
+	Common::Rect &drawRect = _gameDrawRect;
 
 	/* Destination rectangle represents the texture before rotation */
 	if (_rotationMode == Common::kRotation90 || _rotationMode == Common::kRotation270) {
@@ -2931,8 +2932,13 @@ void RenderSdlGraphicsManager::drawScreen() {
 
 void RenderSdlGraphicsManager::handleResizeImpl(const int width, const int height) {
 	SdlGraphicsManager::handleResizeImpl(width, height);
+
+	recreateOverlay(width, height);
 	recalculateDisplayAreas();
 	recalculateCursorScaling();
+
+	// Something changed, so update the screen change ID.
+	_screenChangeCount++;
 }
 
 void RenderSdlGraphicsManager::handleScalerHotkeys(uint mode, int factor) {

--- a/backends/graphics/rendersdl/rendersdl-graphics.cpp
+++ b/backends/graphics/rendersdl/rendersdl-graphics.cpp
@@ -1517,44 +1517,22 @@ bool RenderSdlGraphicsManager::saveScreenshot(const Common::Path &filename) cons
 		return false;
 	}
 
-	if (!lockSurface(_hwScreen)) {
-		warning("Could not lock RGB surface");
+	Graphics::Surface data;
+	data.create(_windowWidth, _windowHeight, Graphics::PixelFormat::createFormatRGB24());
+
+	if (SDL_RenderReadPixels(_renderer, NULL, SDL_PIXELFORMAT_RGB24, data.getPixels(), data.pitch) < 0) {
+		warning("Could not create screenshot: %s", SDL_GetError());
+		data.free();
 		return false;
 	}
 
-	Graphics::PixelFormat format = convertSDLPixelFormat(_hwScreen->format);
-	Graphics::Surface data;
-	data.init(_hwScreen->w, _hwScreen->h, _hwScreen->pitch, _hwScreen->pixels, format);
-
-	bool success;
-
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-	SDL_Palette *sdlPalette = SDL_CreateSurfacePalette(_hwScreen);
-#else
-	SDL_Palette *sdlPalette = _hwScreen->format->palette;
-#endif
-	if (sdlPalette) {
-		byte palette[256 * 3];
-		for (int i = 0; i < sdlPalette->ncolors; i++) {
-			palette[(i * 3) + 0] = sdlPalette->colors[i].r;
-			palette[(i * 3) + 1] = sdlPalette->colors[i].g;
-			palette[(i * 3) + 2] = sdlPalette->colors[i].b;
-		}
-
 #ifdef USE_PNG
-		success = Image::writePNG(out, data, palette);
+	const bool success = Image::writePNG(out, data);
 #else
-		success = Image::writeBMP(out, data, palette);
+	const bool success = Image::writeBMP(out, data);
 #endif
-	} else {
-#ifdef USE_PNG
-		success = Image::writePNG(out, data);
-#else
-		success = Image::writeBMP(out, data);
-#endif
-	}
 
-	SDL_UnlockSurface(_hwScreen);
+	data.free();
 
 	return success;
 }

--- a/backends/graphics/rendersdl/rendersdl-graphics.cpp
+++ b/backends/graphics/rendersdl/rendersdl-graphics.cpp
@@ -146,7 +146,7 @@ RenderSdlGraphicsManager::RenderSdlGraphicsManager(SdlEventSource *sdlEventSourc
 	_screen(nullptr), _tmpscreen(nullptr),
 	_screenFormat(Graphics::PixelFormat::createFormatCLUT8()),
 	_cursorFormat(Graphics::PixelFormat::createFormatCLUT8()),
-	_useOldSrc(false), _isHwPalette(false),
+	_useOldSrc(false),
 	_overlayTexture(nullptr), _overlaySurface(nullptr),
 	_screenChangeCount(0),
 	_mouseTexture(nullptr), _mouseScaler(nullptr), _mouseSurface(nullptr),
@@ -157,7 +157,6 @@ RenderSdlGraphicsManager::RenderSdlGraphicsManager(SdlEventSource *sdlEventSourc
 	_displayDisabled(false),
 	_transactionMode(kTransactionNone),
 	_scalerPlugins(ScalerMan.getPlugins()), _scalerPlugin(nullptr), _scaler(nullptr),
-	_isDoubleBuf(false), _prevForceRedraw(false), _numPrevDirtyRects(0),
 	_mouseKeyColor(0), _disableMouseKeyColor(false) {
 
 	// allocate palette storage
@@ -214,7 +213,7 @@ bool RenderSdlGraphicsManager::hasFeature(OSystem::Feature f) const {
 		(f == OSystem::kFeatureVSync) ||
 #endif
 		(f == OSystem::kFeatureCursorPalette) ||
-		(f == OSystem::kFeatureCursorAlpha && !_isHwPalette) ||
+		(f == OSystem::kFeatureCursorAlpha) ||
 		(f == OSystem::kFeatureIconifyWindow) ||
 		(f == OSystem::kFeatureCursorMask);
 }
@@ -533,59 +532,57 @@ void RenderSdlGraphicsManager::detectSupportedFormats() {
 		format = hwFormat;
 	}
 
-	if (!_isHwPalette) {
-		// Some tables with standard formats that we always list
-		// as "supported". If frontend code tries to use one of
-		// these, we will perform the necessary format
-		// conversion in the background. Of course this incurs a
-		// performance hit, but on desktop ports this should not
-		// matter. We still push the currently active format to
-		// the front, so if frontend code just uses the first
-		// available format, it will get one that is "cheap" to
-		// use.
-		const Graphics::PixelFormat RGBList[] = {
-			// RGBA8888, ARGB8888, RGB888
-			Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0),
-			Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24),
-			Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0),
-			// RGB565, XRGB1555, RGB555, RGBA4444, ARGB4444
-			Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0),
-			Graphics::PixelFormat(2, 5, 5, 5, 1, 10, 5, 0, 15),
-			Graphics::PixelFormat(2, 5, 5, 5, 0, 10, 5, 0, 0),
-			Graphics::PixelFormat(2, 4, 4, 4, 4, 12, 8, 4, 0),
-			Graphics::PixelFormat(2, 4, 4, 4, 4, 8, 4, 0, 12)
-		};
-		const Graphics::PixelFormat BGRList[] = {
-			// ABGR8888, BGRA8888, BGR888
-			Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24),
-			Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0),
-			Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0),
-			// BGR565, XBGR1555, BGR555, ABGR4444, BGRA4444
-			Graphics::PixelFormat(2, 5, 6, 5, 0, 0, 5, 11, 0),
-			Graphics::PixelFormat(2, 5, 5, 5, 1, 0, 5, 10, 15),
-			Graphics::PixelFormat(2, 5, 5, 5, 0, 0, 5, 10, 0),
-			Graphics::PixelFormat(2, 4, 4, 4, 4, 0, 4, 8, 12),
-			Graphics::PixelFormat(2, 4, 4, 4, 4, 4, 8, 12, 0)
-		};
+	// Some tables with standard formats that we always list
+	// as "supported". If frontend code tries to use one of
+	// these, we will perform the necessary format
+	// conversion in the background. Of course this incurs a
+	// performance hit, but on desktop ports this should not
+	// matter. We still push the currently active format to
+	// the front, so if frontend code just uses the first
+	// available format, it will get one that is "cheap" to
+	// use.
+	const Graphics::PixelFormat RGBList[] = {
+		// RGBA8888, ARGB8888, RGB888
+		Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0),
+		Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24),
+		Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0),
+		// RGB565, XRGB1555, RGB555, RGBA4444, ARGB4444
+		Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0),
+		Graphics::PixelFormat(2, 5, 5, 5, 1, 10, 5, 0, 15),
+		Graphics::PixelFormat(2, 5, 5, 5, 0, 10, 5, 0, 0),
+		Graphics::PixelFormat(2, 4, 4, 4, 4, 12, 8, 4, 0),
+		Graphics::PixelFormat(2, 4, 4, 4, 4, 8, 4, 0, 12)
+	};
+	const Graphics::PixelFormat BGRList[] = {
+		// ABGR8888, BGRA8888, BGR888
+		Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24),
+		Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0),
+		Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0),
+		// BGR565, XBGR1555, BGR555, ABGR4444, BGRA4444
+		Graphics::PixelFormat(2, 5, 6, 5, 0, 0, 5, 11, 0),
+		Graphics::PixelFormat(2, 5, 5, 5, 1, 0, 5, 10, 15),
+		Graphics::PixelFormat(2, 5, 5, 5, 0, 0, 5, 10, 0),
+		Graphics::PixelFormat(2, 4, 4, 4, 4, 0, 4, 8, 12),
+		Graphics::PixelFormat(2, 4, 4, 4, 4, 4, 8, 12, 0)
+	};
 
-		// TODO: prioritize matching alpha masks
-		int i;
+	// TODO: prioritize matching alpha masks
+	int i;
 
-		// Push some RGB formats
-		for (i = 0; i < ARRAYSIZE(RGBList); i++) {
-			if (_hwScreen && (RGBList[i].bytesPerPixel > format.bytesPerPixel))
-				continue;
-			if (RGBList[i] != format)
-				_supportedFormats.push_back(RGBList[i]);
-		}
+	// Push some RGB formats
+	for (i = 0; i < ARRAYSIZE(RGBList); i++) {
+		if (_hwScreen && (RGBList[i].bytesPerPixel > format.bytesPerPixel))
+			continue;
+		if (RGBList[i] != format)
+			_supportedFormats.push_back(RGBList[i]);
+	}
 
-		// Push some BGR formats
-		for (i = 0; i < ARRAYSIZE(BGRList); i++) {
-			if (_hwScreen && (BGRList[i].bytesPerPixel > format.bytesPerPixel))
-				continue;
-			if (BGRList[i] != format)
-				_supportedFormats.push_back(BGRList[i]);
-		}
+	// Push some BGR formats
+	for (i = 0; i < ARRAYSIZE(BGRList); i++) {
+		if (_hwScreen && (BGRList[i].bytesPerPixel > format.bytesPerPixel))
+			continue;
+		if (BGRList[i] != format)
+			_supportedFormats.push_back(BGRList[i]);
 	}
 
 	// Finally, we always supposed 8 bit palette graphics
@@ -827,13 +824,6 @@ void RenderSdlGraphicsManager::initGraphicsSurface() {
 		flags |= SDL_FULLSCREEN;
 
 	_hwScreen = SDL_SetVideoMode(_videoMode.hardwareWidth, _videoMode.hardwareHeight, 16, flags);
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	_isDoubleBuf = false;
-	_isHwPalette = false;
-#else
-	_isDoubleBuf = flags & SDL_DOUBLEBUF;
-	_isHwPalette = flags & SDL_HWPALETTE;
-#endif
 }
 
 bool RenderSdlGraphicsManager::loadGFXMode() {
@@ -1099,14 +1089,6 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 		SDL_SetColors(_screen, _currentPalette + _paletteDirtyStart,
 			_paletteDirtyStart,
 			_paletteDirtyEnd - _paletteDirtyStart);
-		if (_isHwPalette)
-			SDL_SetColors(_tmpscreen, _currentPalette + _paletteDirtyStart,
-				      _paletteDirtyStart,
-				      _paletteDirtyEnd - _paletteDirtyStart);
-		if (_isHwPalette)
-			SDL_SetColors(_hwScreen, _currentPalette + _paletteDirtyStart,
-				       _paletteDirtyStart,
-				       _paletteDirtyEnd - _paletteDirtyStart);
 
 		_paletteDirtyEnd = 0;
 
@@ -1125,46 +1107,28 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 	updateOSD();
 #endif
 
-	// In case of double buferring partially good version may be on another page,
-	// so we need to fully redraw
-	if (_isDoubleBuf && _numDirtyRects)
-		_forceRedraw = true;
-
 #if defined(USE_IMGUI) && (defined(USE_IMGUI_SDLRENDERER2) || defined(USE_IMGUI_SDLRENDERER3))
 	if (_imGuiCallbacks.render) {
 		_forceRedraw = true;
 	}
 #endif
 
-	bool doRedraw = _forceRedraw || (_prevForceRedraw && _isDoubleBuf);
-	int actualDirtyRects = _numDirtyRects;
-	if (_isDoubleBuf && _numPrevDirtyRects > 0) {
-		memcpy(_dirtyRectList + _numDirtyRects, _prevDirtyRectList, _numPrevDirtyRects * sizeof(_dirtyRectList[0]));
-		actualDirtyRects += _numPrevDirtyRects;
-	}
-
 	// Force a full redraw if requested.
 	// If _useOldSrc, the scaler will do its own partial updates.
-	if (doRedraw) {
-		actualDirtyRects = 1;
+	if (_forceRedraw) {
+		_numDirtyRects = 1;
 		_dirtyRectList[0].x = 0;
 		_dirtyRectList[0].y = 0;
 		_dirtyRectList[0].w = width;
 		_dirtyRectList[0].h = height;
 	}
 
-	_prevForceRedraw = _forceRedraw;
-	if (!_prevForceRedraw && _numDirtyRects && _isDoubleBuf) {
-		memcpy(_prevDirtyRectList, _dirtyRectList, _numDirtyRects * sizeof(_dirtyRectList[0]));
-		_numPrevDirtyRects = _numDirtyRects;
-	}
-
 	// Only draw anything if necessary
-	if (actualDirtyRects > 0) {
+	if (_numDirtyRects > 0) {
 		SDL_Rect *r;
 		SDL_Rect dst;
 		uint32 bpp, srcPitch, dstPitch;
-		SDL_Rect *lastRect = _dirtyRectList + actualDirtyRects;
+		SDL_Rect *lastRect = _dirtyRectList + _numDirtyRects;
 
 		for (r = _dirtyRectList; r != lastRect; ++r) {
 			dst = *r;
@@ -1248,7 +1212,7 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 
 		// Finally, blit all our changes to the screen
 		if (!_displayDisabled) {
-			updateScreen(_dirtyRectList, actualDirtyRects);
+			updateScreen(_dirtyRectList, _numDirtyRects);
 		}
 	}
 
@@ -1275,9 +1239,6 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 #endif
 
 	SDL_RenderPresent(_renderer);
-#else
-	if (_isDoubleBuf)
-		SDL_Flip(_hwScreen);
 #endif
 }
 
@@ -1855,7 +1816,7 @@ void RenderSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, i
 		return;
 	}
 
-	if (mask && format && format->bytesPerPixel > 1 && !_isHwPalette) {
+	if (mask && format && format->bytesPerPixel > 1) {
 		const uint numPixels = w * h;
 		const uint inBPP = format->bytesPerPixel;
 
@@ -1909,8 +1870,6 @@ void RenderSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, i
 	bool formatChanged = false;
 
 	if (format) {
-		assert(format->bytesPerPixel == 1 || !_isHwPalette);
-
 		if (format->bytesPerPixel != _cursorFormat.bytesPerPixel) {
 			formatChanged = true;
 		}

--- a/backends/graphics/rendersdl/rendersdl-graphics.cpp
+++ b/backends/graphics/rendersdl/rendersdl-graphics.cpp
@@ -38,7 +38,6 @@
 #include "graphics/font.h"
 #include "graphics/fontman.h"
 #include "graphics/scaler.h"
-#include "graphics/scaler/aspect.h"
 #include "graphics/surface.h"
 #include "gui/debugger.h"
 #include "gui/EventRecorder.h"
@@ -131,34 +130,6 @@ const OSystem::GraphicsMode s_supportedStretchModes[] = {
 };
 #endif
 
-RenderSdlGraphicsManager::AspectRatio::AspectRatio(int w, int h) {
-	// TODO : Validation and so on...
-	// Currently, we just ensure the program don't instantiate non-supported aspect ratios
-	_kw = w;
-	_kh = h;
-}
-
-#if defined(USE_ASPECT)
-RenderSdlGraphicsManager::AspectRatio RenderSdlGraphicsManager::getDesiredAspectRatio() {
-	const size_t AR_COUNT = 4;
-	const char *desiredAspectRatioAsStrings[AR_COUNT] = {	"auto",				"4/3",				"16/9",				"16/10" };
-	const AspectRatio desiredAspectRatios[AR_COUNT] = {		AspectRatio(0, 0),	AspectRatio(4,3),	AspectRatio(16,9),	AspectRatio(16,10) };
-
-	//TODO : We could parse an arbitrary string, if we code enough proper validation
-	Common::String desiredAspectRatio = ConfMan.get("desired_screen_aspect_ratio");
-
-	for (size_t i = 0; i < AR_COUNT; i++) {
-		assert(desiredAspectRatioAsStrings[i] != nullptr);
-
-		if (!scumm_stricmp(desiredAspectRatio.c_str(), desiredAspectRatioAsStrings[i])) {
-			return desiredAspectRatios[i];
-		}
-	}
-	// TODO : Report a warning
-	return AspectRatio(0, 0);
-}
-#endif
-
 RenderSdlGraphicsManager::RenderSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window)
 	:
 	SdlGraphicsManager(sdlEventSource, window),
@@ -193,12 +164,7 @@ RenderSdlGraphicsManager::RenderSdlGraphicsManager(SdlEventSource *sdlEventSourc
 	_currentPalette = (SDL_Color *)calloc(256, sizeof(SDL_Color));
 	_cursorPalette = (SDL_Color *)calloc(256, sizeof(SDL_Color));
 
-#if defined(USE_ASPECT)
 	_videoMode.aspectRatioCorrection = ConfMan.getBool("aspect_ratio");
-	_videoMode.desiredAspectRatio = getDesiredAspectRatio();
-#else // for small screen platforms
-	_videoMode.aspectRatioCorrection = false;
-#endif
 
 	_scaler = nullptr;
 	_maxExtraPixels = ScalerMan.getMaxExtraPixels();
@@ -240,9 +206,7 @@ bool RenderSdlGraphicsManager::hasFeature(OSystem::Feature f) const {
 #ifdef USE_SCALERS
 		(f == OSystem::kFeatureScalers) ||
 #endif
-#ifdef USE_ASPECT
 		(f == OSystem::kFeatureAspectRatioCorrection) ||
-#endif
 		(f == OSystem::kFeatureFilteringMode) ||
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 		(f == OSystem::kFeatureStretchMode) ||
@@ -260,11 +224,9 @@ void RenderSdlGraphicsManager::setFeatureState(OSystem::Feature f, bool enable) 
 	case OSystem::kFeatureFullscreenMode:
 		setFullscreenMode(enable);
 		break;
-#ifdef USE_ASPECT
 	case OSystem::kFeatureAspectRatioCorrection:
 		setAspectRatioCorrection(enable);
 		break;
-#endif
 	case OSystem::kFeatureFilteringMode:
 		setFilteringMode(enable);
 		break;
@@ -293,10 +255,8 @@ bool RenderSdlGraphicsManager::getFeatureState(OSystem::Feature f) const {
 	switch (f) {
 	case OSystem::kFeatureFullscreenMode:
 		return _videoMode.fullscreen;
-#ifdef USE_ASPECT
 	case OSystem::kFeatureAspectRatioCorrection:
 		return _videoMode.aspectRatioCorrection;
-#endif
 	case OSystem::kFeatureVSync:
 		return _videoMode.vsync;
 	case OSystem::kFeatureFilteringMode:
@@ -838,85 +798,23 @@ void RenderSdlGraphicsManager::initSize(uint w, uint h, const Graphics::PixelFor
 	_transactionDetails.sizeChanged = true;
 }
 
-void RenderSdlGraphicsManager::fixupResolutionForAspectRatio(AspectRatio desiredAspectRatio, int &width, int &height) const {
-	assert(&width != &height);
+bool RenderSdlGraphicsManager::gameNeedsAspectRatioCorrection() const {
+	if (_videoMode.aspectRatioCorrection) {
+		const uint width = getWidth();
+		const uint height = getHeight();
 
-	if (desiredAspectRatio.isAuto())
-		return;
-
-	int kw = desiredAspectRatio.kw();
-	int kh = desiredAspectRatio.kh();
-
-	const int w = width;
-	const int h = height;
-
-	int bestW = 0, bestH = 0;
-	uint bestMetric = (uint)-1; // Metric is wasted space
-
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-	int numModes;
-	const int display = _window->getDisplayIndex();
-	SDL_DisplayMode** modes = SDL_GetFullscreenDisplayModes(display, &numModes);
-	for (int i = 0; i < numModes; ++i) {
-		SDL_DisplayMode* mode = modes[i];
-#elif SDL_VERSION_ATLEAST(2, 0, 0)
-	const int display = _window->getDisplayIndex();
-	const int numModes = SDL_GetNumDisplayModes(display);
-	SDL_DisplayMode modeData, *mode = &modeData;
-	for (int i = 0; i < numModes; ++i) {
-		if (SDL_GetDisplayMode(display, i, &modeData)) {
-			continue;
-		}
-#else
-	SDL_Rect const* const*availableModes = SDL_ListModes(NULL, SDL_FULLSCREEN|SDL_SWSURFACE); //TODO : Maybe specify a pixel format
-	assert(availableModes);
-
-	while (const SDL_Rect *mode = *availableModes++) {
-#endif
-		if (mode->w < w)
-			continue;
-		if (mode->h < h)
-			continue;
-		if (mode->h * kw != mode->w * kh)
-			continue;
-
-		uint metric = mode->w * mode->h - w * h;
-		if (metric > bestMetric)
-			continue;
-
-		bestMetric = metric;
-		bestW = mode->w;
-		bestH = mode->h;
-
-	// Make editors a bit more happy by having the same amount of closing as
-	// opening curley braces.
-#if SDL_VERSION_ATLEAST(3, 0, 0)
+		// In case we enable aspect ratio correction we force a 4/3 ratio.
+		// But just for 320x200 and 640x400 games, since other games do not need
+		// this.
+		return (width == 320 && height == 200) || (width == 640 && height == 400);
 	}
-	SDL_free(modes);
-#elif SDL_VERSION_ATLEAST(2, 0, 0)
-	}
-#else
-	}
-#endif
 
-	if (!bestW || !bestH) {
-		warning("Unable to enforce the desired aspect ratio");
-		return;
-	}
-	width = bestW;
-	height = bestH;
+	return false;
 }
 
 void RenderSdlGraphicsManager::setupHardwareSize() {
-	if (_videoMode.screenHeight != 200 && _videoMode.screenHeight != 400)
-		_videoMode.aspectRatioCorrection = false;
-
 	_videoMode.hardwareWidth = _videoMode.screenWidth * _videoMode.scaleFactor;
 	_videoMode.hardwareHeight = _videoMode.screenHeight * _videoMode.scaleFactor;
-
-	if (_videoMode.aspectRatioCorrection) {
-		_videoMode.hardwareHeight = real2Aspect(_videoMode.hardwareHeight);
-	}
 }
 
 void RenderSdlGraphicsManager::initGraphicsSurface() {
@@ -974,11 +872,6 @@ bool RenderSdlGraphicsManager::loadGFXMode() {
 	//
 	// Create the surface that contains the scaled graphics in 16 bit mode
 	//
-
-	if (_videoMode.fullscreen) {
-		fixupResolutionForAspectRatio(_videoMode.desiredAspectRatio, _videoMode.hardwareWidth, _videoMode.hardwareHeight);
-	}
-
 
 #ifdef ENABLE_EVENTRECORDER
 	_displayDisabled = ConfMan.getBool("disable_display");
@@ -1176,10 +1069,6 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 			blackrect.x = ((_videoMode.screenWidth + _gameScreenShakeXOffset) * _videoMode.scaleFactor);
 		}
 
-		if (_videoMode.aspectRatioCorrection && !_overlayVisible) {
-			blackrect.h = real2Aspect(blackrect.h - 1) + 1;
-		}
-
 		SDL_FillRect(_hwScreen, &blackrect, 0);
 
 		_currentShakeXOffset = _gameScreenShakeXOffset;
@@ -1194,11 +1083,6 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 		else {
 			blackrect.h = ((-_gameScreenShakeYOffset) * _videoMode.scaleFactor);
 			blackrect.y = ((_videoMode.screenHeight + _gameScreenShakeYOffset) * _videoMode.scaleFactor);
-		}
-
-		if (_videoMode.aspectRatioCorrection && !_overlayVisible) {
-			blackrect.y = real2Aspect(blackrect.y);
-			blackrect.h = real2Aspect(blackrect.h + blackrect.y - 1) - blackrect.y + 1;
 		}
 
 		SDL_FillRect(_hwScreen, &blackrect, 0);
@@ -1312,9 +1196,7 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 			int dst_y = r->y;
 			int dst_w = r->w;
 			int dst_h = r->h;
-#ifdef USE_ASPECT
-			int orig_dst_y = 0;
-#endif
+
 			dst_x += _currentShakeXOffset;
 			if (dst_x < 0) {
 				src_x -= dst_x;
@@ -1340,14 +1222,8 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 				if (dst_h > height - src_y)
 					dst_h = height - src_y;
 
-#ifdef USE_ASPECT
-				orig_dst_y = dst_y;
-#endif
 				dst_x *= scale1;
 				dst_y *= scale1;
-
-				if (_videoMode.aspectRatioCorrection && !_overlayVisible)
-					dst_y = real2Aspect(dst_y);
 
 				_scaler->scale((byte *)srcSurf->pixels + (src_x + _maxExtraPixels) * bpp + (src_y + _maxExtraPixels) * srcPitch, srcPitch,
 						(byte *)_hwScreen->pixels + dst_x * bpp + dst_y * dstPitch, dstPitch, dst_w, dst_h, src_x, src_y);
@@ -1356,11 +1232,6 @@ void RenderSdlGraphicsManager::internUpdateScreen() {
 				r->y = dst_y;
 				r->w = dst_w * scale1;
 				r->h = dst_h * scale1;
-
-#ifdef USE_ASPECT
-				if (_videoMode.aspectRatioCorrection && orig_dst_y < height && !_overlayVisible)
-					r->h = stretch200To240((uint8 *) _hwScreen->pixels, dstPitch, r->w, r->h, r->x, r->y, orig_dst_y * scale1, _videoMode.filtering, 	convertSDLPixelFormat(_hwScreen->format));
-#endif
 			}
 		}
 		SDL_UnlockSurface(srcSurf);
@@ -1478,7 +1349,8 @@ void RenderSdlGraphicsManager::setAspectRatioCorrection(bool enable) {
 
 	if (_transactionMode == kTransactionActive) {
 		_videoMode.aspectRatioCorrection = enable;
-		_transactionDetails.needHotswap = true;
+		_transactionDetails.needUpdatescreen = true;
+		_transactionDetails.needDisplayResize = true;
 	}
 }
 
@@ -1623,11 +1495,6 @@ void RenderSdlGraphicsManager::addDirtyRect(int x, int y, int w, int h) {
 	if (h > height - y) {
 		h = height - y;
 	}
-
-#ifdef USE_ASPECT
-	if (_videoMode.aspectRatioCorrection)
-		makeRectStretchable(x, y, w, h, _videoMode.filtering);
-#endif
 
 	if (w == width && h == height) {
 		_forceRedraw = true;
@@ -2222,16 +2089,6 @@ void RenderSdlGraphicsManager::blitCursor() {
 	_mouseCurState.vHotX = _mouseCurState.hotX;
 	_mouseCurState.vHotY = _mouseCurState.hotY;
 
-#ifdef USE_ASPECT
-	// store original to pass to aspect-correction function later
-	const int rH1 = rH;
-#endif
-
-	if (!_cursorDontScale && _videoMode.aspectRatioCorrection) {
-		rH = real2Aspect(rH - 1) + 1;
-		_mouseCurState.rHotY = real2Aspect(_mouseCurState.rHotY);
-	}
-
 	bool sizeChanged = false;
 	if (_mouseCurState.rW != rW || _mouseCurState.rH != rH) {
 		_mouseCurState.rW = rW;
@@ -2353,11 +2210,6 @@ void RenderSdlGraphicsManager::blitCursor() {
 #endif
 	}
 
-#ifdef USE_ASPECT
-	if (!_cursorDontScale && _videoMode.aspectRatioCorrection)
-		stretch200To240Nearest((uint8 *)_mouseSurface->pixels, _mouseSurface->pitch, rW, rH1, 0, 0, 0, convertSDLPixelFormat(_mouseSurface->format));
-#endif
-
 	SDL_UnlockSurface(_mouseSurface);
 	SDL_UnlockSurface(_mouseOrigSurface);
 
@@ -2401,10 +2253,7 @@ void RenderSdlGraphicsManager::drawMouse() {
 	dst.h = _mouseCurState.vH;
 
 	// We draw the pre-scaled cursor image, so now we need to adjust for
-	// scaling, shake position and aspect ratio correction manually.
-
-	if (_videoMode.aspectRatioCorrection && !_overlayInGUI)
-		dst.y = real2Aspect(dst.y);
+	// scaling and shake position manually.
 
 	switch (_rotationMode) {
 	case Common::kRotationNormal:
@@ -2471,8 +2320,8 @@ void RenderSdlGraphicsManager::recalculateCursorScaling() {
 	// In case scaling is actually enabled we will scale the cursor according
 	// to the game screen.
 	if (!_cursorDontScale) {
-		const frac_t screenScaleFactorX = intToFrac(_gameDrawRect.width()) / _hwScreen->w;
-		const frac_t screenScaleFactorY = intToFrac(_gameDrawRect.height()) / _hwScreen->h;
+		const frac_t screenScaleFactorX = intToFrac(_gameDrawRect.width()) / _windowWidth;
+		const frac_t screenScaleFactorY = intToFrac(_gameDrawRect.height()) / _windowHeight;
 
 		_mouseCurState.vHotX = fracToInt(_mouseCurState.rHotX * screenScaleFactorX);
 		_mouseCurState.vW    = fracToInt(cursorWidth          * screenScaleFactorX);
@@ -2830,21 +2679,12 @@ bool RenderSdlGraphicsManager::notifyEvent(const Common::Event &event) {
 			setFeatureState(OSystem::kFeatureAspectRatioCorrection, !_videoMode.aspectRatioCorrection);
 		endGFXTransaction();
 #ifdef USE_OSD
-		Common::U32String message;
-		if (_videoMode.aspectRatioCorrection)
-			message = Common::U32String::format("%S\n%d x %d -> %d x %d",
-			                                    _("Enabled aspect ratio correction").c_str(),
-			                                    _videoMode.screenWidth, _videoMode.screenHeight,
-			                                    _hwScreen->w, _hwScreen->h
-			          );
+		if (getFeatureState(OSystem::kFeatureAspectRatioCorrection))
+			displayMessageOnOSD(_("Enabled aspect ratio correction"));
 		else
-			message = Common::U32String::format("%S\n%d x %d -> %d x %d",
-			                                    _("Disabled aspect ratio correction").c_str(),
-			                                    _videoMode.screenWidth, _videoMode.screenHeight,
-			                                    _hwScreen->w, _hwScreen->h
-			          );
-		displayMessageOnOSD(message);
+			displayMessageOnOSD(_("Disabled aspect ratio correction"));
 #endif
+		_forceRedraw = true;
 		internUpdateScreen();
 		return true;
 	}

--- a/backends/graphics/rendersdl/rendersdl-graphics.h
+++ b/backends/graphics/rendersdl/rendersdl-graphics.h
@@ -141,7 +141,7 @@ public:
 protected:
 #ifdef USE_OSD
 	/** Surface containing the OSD message */
-	SDL_Surface *_osdMessageSurface;
+	SDL_Texture *_osdMessageTexture;
 	/** Transparency level of the OSD message */
 	uint8 _osdMessageAlpha;
 	/** When to start the fade out */
@@ -157,13 +157,15 @@ protected:
 	/** Clear the currently displayed OSD message if any */
 	void removeOSDMessage();
 	/** Surface containing the OSD background activity icon */
-	SDL_Surface *_osdIconSurface;
+	SDL_Texture *_osdIconTexture;
 	/** Screen rectangle where the OSD background activity icon is drawn */
 	SDL_Rect getOSDIconRect() const;
 
 	void updateOSD();
 	void drawOSD();
 #endif
+
+	void drawScreen();
 
 	class AspectRatio {
 		int _kw, _kh;

--- a/backends/graphics/rendersdl/rendersdl-graphics.h
+++ b/backends/graphics/rendersdl/rendersdl-graphics.h
@@ -173,6 +173,7 @@ protected:
 
 	SDL_Renderer *_renderer;
 	SDL_Texture *_screenTexture;
+	Uint32 _screenTexFormat;
 	void recreateScreenTexture();
 
 	/** Unseen game screen */

--- a/backends/graphics/rendersdl/rendersdl-graphics.h
+++ b/backends/graphics/rendersdl/rendersdl-graphics.h
@@ -64,12 +64,10 @@ public:
 	Graphics::PixelFormat getScreenFormat() const override { return _screenFormat; }
 	Common::List<Graphics::PixelFormat> getSupportedFormats() const override;
 #endif
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 	const OSystem::GraphicsMode *getSupportedStretchModes() const override;
 	int getDefaultStretchMode() const override;
 	bool setStretchMode(int mode) override;
 	int getStretchMode() const override;
-#endif
 	void initSize(uint w, uint h, const Graphics::PixelFormat *format = NULL) override;
 	int getScreenChangeID() const override { return _screenChangeCount; }
 
@@ -83,7 +81,6 @@ protected:
 	// PaletteManager API
 	void setPalette(const byte *colors, uint start, uint num) override;
 	void grabPalette(byte *colors, uint start, uint num) const override;
-	virtual void initGraphicsSurface();
 
 	/**
 	 * Convert from the SDL pixel format to Graphics::PixelFormat
@@ -174,19 +171,9 @@ protected:
 
 	virtual void setupHardwareSize();
 
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	/* SDL2 features a different API for 2D graphics. We create a wrapper
-	 * around this API to keep the code paths as close as possible. */
 	SDL_Renderer *_renderer;
 	SDL_Texture *_screenTexture;
-	void deinitializeRenderer();
 	void recreateScreenTexture();
-
-	virtual SDL_Surface *SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags);
-	virtual void SDL_UpdateRects(SDL_Surface *screen, int numrects, SDL_Rect *rects);
-	int SDL_SetColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors);
-	int SDL_SetAlpha(SDL_Surface *surface, Uint32 flag, Uint8 alpha);
-#endif
 
 	/** Unseen game screen */
 	SDL_Surface *_screen;
@@ -221,10 +208,8 @@ protected:
 		bool sizeChanged;
 		bool needHotswap;
 		bool needUpdatescreen;
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 		bool needTextureUpdate;
 		bool needDisplayResize;
-#endif
 		bool formatChanged;
 
 		TransactionDetails() {
@@ -232,10 +217,8 @@ protected:
 			needHotswap = false;
 			needUpdatescreen = false;
 
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 			needTextureUpdate = false;
 			needDisplayResize = false;
-#endif
 			formatChanged = false;
 		}
 	};
@@ -249,9 +232,7 @@ protected:
 		bool filtering;
 
 		int mode;
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 		int stretchMode;
-#endif
 		bool vsync;
 
 		uint scalerIndex;
@@ -268,9 +249,7 @@ protected:
 			filtering = false;
 
 			mode = GFX_RENDERSDL;
-#if SDL_VERSION_ATLEAST(2, 0, 0)
 			stretchMode = 0;
-#endif
 			vsync = false;
 
 			scalerIndex = 0;
@@ -284,23 +263,6 @@ protected:
 		}
 	};
 	VideoState _videoMode, _oldVideoMode;
-
-#if defined(WIN32) && !SDL_VERSION_ATLEAST(2, 0, 0)
-	/**
-	 * Original BPP to restore the video mode on unload.
-	 *
-	 * This is required to make listing video modes for the OpenGL output work
-	 * on Windows 8+. On these systems OpenGL modes are only available for
-	 * 32bit formats. However, we setup a 16bit format and thus mode listings
-	 * for OpenGL will return an empty list afterwards.
-	 *
-	 * In theory we might require this behavior on non-Win32 platforms too.
-	 * However, SDL sometimes gives us invalid pixel formats for X11 outputs
-	 * causing crashes when trying to setup the original pixel format.
-	 * See bug #7038 "IRIX: X BadMatch when trying to start any 640x480 game".
-	 */
-	uint8 _originalBitsPerPixel;
-#endif
 
 	int _transactionMode;
 

--- a/backends/graphics/rendersdl/rendersdl-graphics.h
+++ b/backends/graphics/rendersdl/rendersdl-graphics.h
@@ -34,11 +34,6 @@
 
 #include "backends/platform/sdl/sdl-sys.h"
 
-#ifndef RELEASE_BUILD
-// Define this to allow for focus rectangle debugging
-#define USE_SDL_DEBUG_FOCUSRECT
-#endif
-
 enum {
 	GFX_RENDERSDL = 0
 };
@@ -107,8 +102,8 @@ public:
 	void fillScreen(uint32 col) override;
 	void fillScreen(const Common::Rect &r, uint32 col) override;
 	void updateScreen() override;
-	void setFocusRectangle(const Common::Rect& rect) override;
-	void clearFocusRectangle() override;
+	void setFocusRectangle(const Common::Rect& rect) override {}
+	void clearFocusRectangle() override {}
 
 	Graphics::PixelFormat getOverlayFormat() const override { return _overlayFormat; }
 	void clearOverlay() override;
@@ -407,12 +402,6 @@ protected:
 	 * when accessing the screen.
 	 */
 	Common::Mutex _graphicsMutex;
-
-#ifdef USE_SDL_DEBUG_FOCUSRECT
-	bool _enableFocusRectDebugCode;
-	bool _enableFocusRect;
-	Common::Rect _focusRect;
-#endif
 
 	virtual void addDirtyRect(int x, int y, int w, int h);
 

--- a/backends/graphics/rendersdl/rendersdl-graphics.h
+++ b/backends/graphics/rendersdl/rendersdl-graphics.h
@@ -1,0 +1,484 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef BACKENDS_GRAPHICS_RENDERSDL_GRAPHICS_H
+#define BACKENDS_GRAPHICS_RENDERSDL_GRAPHICS_H
+
+#include "backends/graphics/graphics.h"
+#include "backends/graphics/sdl/sdl-graphics.h"
+#include "graphics/pixelformat.h"
+#include "graphics/scaler.h"
+#include "graphics/scalerplugin.h"
+#include "common/events.h"
+#include "common/mutex.h"
+
+#include "backends/events/sdl/sdl-events.h"
+
+#include "backends/platform/sdl/sdl-sys.h"
+
+#ifndef RELEASE_BUILD
+// Define this to allow for focus rectangle debugging
+#define USE_SDL_DEBUG_FOCUSRECT
+#endif
+
+enum {
+	GFX_RENDERSDL = 0
+};
+
+
+/**
+ * SDL2 graphics manager
+ */
+class RenderSdlGraphicsManager : public SdlGraphicsManager {
+public:
+	RenderSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
+	virtual ~RenderSdlGraphicsManager();
+
+	bool hasFeature(OSystem::Feature f) const override;
+	void setFeatureState(OSystem::Feature f, bool enable) override;
+	bool getFeatureState(OSystem::Feature f) const override;
+
+	const OSystem::GraphicsMode *getSupportedGraphicsModes() const override;
+	int getDefaultGraphicsMode() const override;
+	bool setGraphicsMode(int mode, uint flags = OSystem::kGfxModeNoFlags) override;
+	int getGraphicsMode() const override;
+	uint getDefaultScaler() const override;
+	uint getDefaultScaleFactor() const override;
+	bool setScaler(uint mode, int factor) override;
+	uint getScaler() const override;
+	uint getScaleFactor() const override;
+#ifdef USE_RGB_COLOR
+	Graphics::PixelFormat getScreenFormat() const override { return _screenFormat; }
+	Common::List<Graphics::PixelFormat> getSupportedFormats() const override;
+#endif
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	const OSystem::GraphicsMode *getSupportedStretchModes() const override;
+	int getDefaultStretchMode() const override;
+	bool setStretchMode(int mode) override;
+	int getStretchMode() const override;
+#endif
+	void initSize(uint w, uint h, const Graphics::PixelFormat *format = NULL) override;
+	int getScreenChangeID() const override { return _screenChangeCount; }
+
+	void beginGFXTransaction() override;
+	OSystem::TransactionError endGFXTransaction() override;
+
+	int16 getHeight() const override;
+	int16 getWidth() const override;
+
+protected:
+	// PaletteManager API
+	void setPalette(const byte *colors, uint start, uint num) override;
+	void grabPalette(byte *colors, uint start, uint num) const override;
+	virtual void initGraphicsSurface();
+
+	/**
+	 * Convert from the SDL pixel format to Graphics::PixelFormat
+	 * @param in    The SDL pixel format to convert
+	 * @param out   A pixel format to be written to
+	 */
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	Graphics::PixelFormat convertSDLPixelFormat(SDL_PixelFormat in) const;
+#else
+	Graphics::PixelFormat convertSDLPixelFormat(SDL_PixelFormat *in) const;
+#endif
+public:
+	void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) override;
+	Graphics::Surface *lockScreen() override;
+	void unlockScreen() override;
+	void fillScreen(uint32 col) override;
+	void fillScreen(const Common::Rect &r, uint32 col) override;
+	void updateScreen() override;
+	void setFocusRectangle(const Common::Rect& rect) override;
+	void clearFocusRectangle() override;
+
+	Graphics::PixelFormat getOverlayFormat() const override { return _overlayFormat; }
+	void clearOverlay() override;
+	void grabOverlay(Graphics::Surface &surface) const override;
+	void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) override;
+	int16 getOverlayHeight() const override { return _videoMode.overlayHeight; }
+	int16 getOverlayWidth() const override { return _videoMode.overlayWidth; }
+
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override;
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask, bool disableKeyColor);
+	void setCursorPalette(const byte *colors, uint start, uint num) override;
+
+#ifdef USE_OSD
+	void displayMessageOnOSD(const Common::U32String &msg) override;
+	void displayActivityIconOnOSD(const Graphics::Surface *icon) override;
+#endif
+
+	// Override from Common::EventObserver
+	bool notifyEvent(const Common::Event &event) override;
+
+	// SdlGraphicsManager interface
+	void notifyVideoExpose() override;
+	void notifyResize(const int width, const int height) override;
+
+#if defined(USE_IMGUI) && (defined(USE_IMGUI_SDLRENDERER2) || defined(USE_IMGUI_SDLRENDERER3))
+	void *getImGuiTexture(const Graphics::Surface &image, const byte *palette, int palCount) override;
+	void freeImGuiTexture(void *texture) override;
+#endif
+
+protected:
+#ifdef USE_OSD
+	/** Surface containing the OSD message */
+	SDL_Surface *_osdMessageSurface;
+	/** Transparency level of the OSD message */
+	uint8 _osdMessageAlpha;
+	/** When to start the fade out */
+	uint32 _osdMessageFadeStartTime;
+	/** Enum with OSD options */
+	enum {
+		kOSDFadeOutDelay = 2 * 1000,	/** < Delay before the OSD is faded out (in milliseconds) */
+		kOSDFadeOutDuration = 500,		/** < Duration of the OSD fade out (in milliseconds) */
+		kOSDInitialAlpha = 80			/** < Initial alpha level, in percent */
+	};
+	/** Screen rectangle where the OSD message is drawn */
+	SDL_Rect getOSDMessageRect() const;
+	/** Clear the currently displayed OSD message if any */
+	void removeOSDMessage();
+	/** Surface containing the OSD background activity icon */
+	SDL_Surface *_osdIconSurface;
+	/** Screen rectangle where the OSD background activity icon is drawn */
+	SDL_Rect getOSDIconRect() const;
+
+	void updateOSD();
+	void drawOSD();
+#endif
+
+	class AspectRatio {
+		int _kw, _kh;
+	public:
+		AspectRatio() { _kw = _kh = 0; }
+		AspectRatio(int w, int h);
+
+		bool isAuto() const { return (_kw | _kh) == 0; }
+
+		int kw() const { return _kw; }
+		int kh() const { return _kh; }
+	};
+
+	static AspectRatio getDesiredAspectRatio();
+
+	bool gameNeedsAspectRatioCorrection() const override {
+		return _videoMode.aspectRatioCorrection;
+	}
+	int getGameRenderScale() const override {
+		return _videoMode.scaleFactor;
+	}
+
+	void handleResizeImpl(const int width, const int height) override;
+
+	virtual void setupHardwareSize();
+
+	void fixupResolutionForAspectRatio(AspectRatio desiredAspectRatio, int &width, int &height) const;
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	/* SDL2 features a different API for 2D graphics. We create a wrapper
+	 * around this API to keep the code paths as close as possible. */
+	SDL_Renderer *_renderer;
+	SDL_Texture *_screenTexture;
+	void deinitializeRenderer();
+	void recreateScreenTexture();
+
+	virtual SDL_Surface *SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags);
+	virtual void SDL_UpdateRects(SDL_Surface *screen, int numrects, SDL_Rect *rects);
+	int SDL_SetColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors);
+	int SDL_SetAlpha(SDL_Surface *surface, Uint32 flag, Uint8 alpha);
+	int SDL_SetColorKey(SDL_Surface *surface, Uint32 flag, Uint32 key);
+#endif
+
+	/** Unseen game screen */
+	SDL_Surface *_screen;
+	Graphics::PixelFormat _screenFormat;
+	Graphics::PixelFormat _cursorFormat;
+#ifdef USE_RGB_COLOR
+	Common::List<Graphics::PixelFormat> _supportedFormats;
+
+	/**
+	 * Update the list of supported pixel formats.
+	 * This method is invoked by loadGFXMode().
+	 */
+	void detectSupportedFormats();
+#endif
+
+	/** Temporary screen (for scalers) */
+	SDL_Surface *_tmpscreen;
+	/** Temporary screen (for scalers) */
+	SDL_Surface *_tmpscreen2;
+
+	SDL_Surface *_overlayscreen;
+	bool _useOldSrc;
+	Graphics::PixelFormat _overlayFormat;
+	bool _isDoubleBuf, _isHwPalette;
+
+	enum {
+		kTransactionNone = 0,
+		kTransactionActive = 1,
+		kTransactionRollback = 2
+	};
+
+	struct TransactionDetails {
+		bool sizeChanged;
+		bool needHotswap;
+		bool needUpdatescreen;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		bool needTextureUpdate;
+		bool needDisplayResize;
+#endif
+		bool formatChanged;
+
+		TransactionDetails() {
+			sizeChanged = false;
+			needHotswap = false;
+			needUpdatescreen = false;
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+			needTextureUpdate = false;
+			needDisplayResize = false;
+#endif
+			formatChanged = false;
+		}
+	};
+	TransactionDetails _transactionDetails;
+
+	struct VideoState {
+		bool setup;
+
+		bool fullscreen;
+		bool aspectRatioCorrection;
+		AspectRatio desiredAspectRatio;
+		bool filtering;
+
+		int mode;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		int stretchMode;
+#endif
+		bool vsync;
+
+		uint scalerIndex;
+		int scaleFactor;
+
+		int screenWidth, screenHeight;
+		int overlayWidth, overlayHeight;
+		int hardwareWidth, hardwareHeight;
+		Graphics::PixelFormat format;
+
+		VideoState() {
+			setup = false;
+			fullscreen = false;
+			aspectRatioCorrection = false;
+			// desiredAspectRatio set to (0, 0) by AspectRatio constructor
+			filtering = false;
+
+			mode = GFX_RENDERSDL;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+			stretchMode = 0;
+#endif
+			vsync = false;
+
+			scalerIndex = 0;
+			scaleFactor = 0;
+
+			screenWidth = 0;
+			screenHeight = 0;
+			overlayWidth = 0;
+			overlayHeight = 0;
+			hardwareWidth = 0;
+			hardwareHeight = 0;
+			// format set to 0 values by Graphics::PixelFormat constructor
+		}
+	};
+	VideoState _videoMode, _oldVideoMode;
+
+#if defined(WIN32) && !SDL_VERSION_ATLEAST(2, 0, 0)
+	/**
+	 * Original BPP to restore the video mode on unload.
+	 *
+	 * This is required to make listing video modes for the OpenGL output work
+	 * on Windows 8+. On these systems OpenGL modes are only available for
+	 * 32bit formats. However, we setup a 16bit format and thus mode listings
+	 * for OpenGL will return an empty list afterwards.
+	 *
+	 * In theory we might require this behavior on non-Win32 platforms too.
+	 * However, SDL sometimes gives us invalid pixel formats for X11 outputs
+	 * causing crashes when trying to setup the original pixel format.
+	 * See bug #7038 "IRIX: X BadMatch when trying to start any 640x480 game".
+	 */
+	uint8 _originalBitsPerPixel;
+#endif
+
+	int _transactionMode;
+
+	// Indicates whether it is needed to free _hwSurface in destructor
+	bool _displayDisabled;
+
+	const PluginList &_scalerPlugins;
+	ScalerPluginObject *_scalerPlugin;
+	Scaler *_scaler, *_mouseScaler;
+	uint _maxExtraPixels;
+	uint _extraPixels;
+
+	bool _screenIsLocked;
+	Graphics::Surface _framebuffer;
+
+	int _screenChangeCount;
+
+	enum {
+		NUM_DIRTY_RECT = 100,
+		MAX_SCALING = 3
+	};
+
+	// Dirty rect management
+	// When double-buffering we need to redraw both updates from
+	// current frame and previous frame. For convenience we copy
+	// them here before traversing the list.
+	SDL_Rect _dirtyRectList[2 * NUM_DIRTY_RECT];
+	int _numDirtyRects;
+
+	SDL_Rect _prevDirtyRectList[NUM_DIRTY_RECT];
+	int _numPrevDirtyRects;
+
+	struct MousePos {
+		// The size and hotspot of the original cursor image.
+		int16 w, h;
+		int16 hotX, hotY;
+
+		// The size and hotspot of the pre-scaled cursor image, in real
+		// coordinates.
+		int16 rW, rH;
+		int16 rHotX, rHotY;
+
+		// The size and hotspot of the pre-scaled cursor image, in game
+		// coordinates.
+		int16 vW, vH;
+		int16 vHotX, vHotY;
+
+		MousePos() : w(0), h(0), hotX(0), hotY(0),
+					rW(0), rH(0), rHotX(0), rHotY(0), vW(0), vH(0),
+					vHotX(0), vHotY(0)
+			{ }
+	};
+
+	SDL_Rect _mouseLastRect, _mouseNextRect;
+	MousePos _mouseCurState;
+	uint32 _mouseKeyColor;
+	bool _disableMouseKeyColor;
+	byte _mappedMouseKeyColor;
+	bool _cursorDontScale;
+	bool _cursorPaletteDisabled;
+	SDL_Surface *_mouseOrigSurface;
+	SDL_Surface *_mouseSurface;
+
+	// Shake mode
+	// This is always set to 0 when building with SDL2.
+	int _currentShakeXOffset;
+	int _currentShakeYOffset;
+
+	// Palette data
+	SDL_Color *_currentPalette;
+	uint _paletteDirtyStart, _paletteDirtyEnd;
+
+	SDL_Color *_overlayPalette;
+	bool _isInOverlayPalette;
+
+	// Cursor palette data
+	SDL_Color *_cursorPalette;
+
+	/**
+	 * Mutex which prevents multiple threads from interfering with each other
+	 * when accessing the screen.
+	 */
+	Common::Mutex _graphicsMutex;
+
+#ifdef USE_SDL_DEBUG_FOCUSRECT
+	bool _enableFocusRectDebugCode;
+	bool _enableFocusRect;
+	Common::Rect _focusRect;
+#endif
+
+	virtual void addDirtyRect(int x, int y, int w, int h, bool inOverlay, bool realCoordinates = false);
+
+	virtual void drawMouse();
+	virtual void undrawMouse();
+	virtual void blitCursor();
+
+	virtual void internUpdateScreen();
+	virtual void updateScreen(SDL_Rect *dirtyRectList, int actualDirtyRects);
+
+	virtual bool loadGFXMode();
+	virtual void unloadGFXMode();
+	virtual bool hotswapGFXMode();
+
+	virtual void setAspectRatioCorrection(bool enable);
+	void setFilteringMode(bool enable);
+	void setVSync(bool enable);
+
+	bool saveScreenshot(const Common::Path &filename) const override;
+	virtual void setGraphicsModeIntern();
+	virtual void getDefaultResolution(uint &w, uint &h);
+
+	// In RenderSDL mode we never render in 3D and can always switch the fullscreen state
+	bool canSwitchFullscreen() const override { return true; }
+
+private:
+	void setFullscreenMode(bool enable);
+	void handleScalerHotkeys(uint mode, int factor);
+
+	/**
+	 * Converts the given point from the overlay's coordinate space to the
+	 * game's coordinate space.
+	 */
+	Common::Point convertOverlayToGame(const int x, const int y) const {
+		if (getOverlayWidth() == 0 || getOverlayHeight() == 0) {
+			error("convertOverlayToGame called without a valid overlay");
+		}
+
+		return Common::Point(x * getWidth() / getOverlayWidth(),
+							 y * getHeight() / getOverlayHeight());
+	}
+
+	/**
+	 * Converts the given point from the game's coordinate space to the
+	 * overlay's coordinate space.
+	 */
+	Common::Point convertGameToOverlay(const int x, const int y) const {
+		if (getWidth() == 0 || getHeight() == 0) {
+			error("convertGameToOverlay called without a valid overlay");
+		}
+
+		return Common::Point(x * getOverlayWidth() / getWidth(),
+							 y * getOverlayHeight() / getHeight());
+	}
+
+	/**
+	 * Special case for scalers that use the useOldSrc feature (currently
+	 * only the Edge scalers). The variable is checked after closing the
+	 * overlay, so that the creation of a new output buffer for the scaler
+	 * can be triggered.
+	 */
+	bool _needRestoreAfterOverlay;
+	bool _prevForceRedraw;
+	bool _prevCursorNeedsRedraw;
+};
+
+#endif

--- a/backends/graphics/rendersdl/rendersdl-graphics.h
+++ b/backends/graphics/rendersdl/rendersdl-graphics.h
@@ -165,23 +165,7 @@ protected:
 	void drawOverlay();
 	void recreateOverlay(const int width, const int height);
 
-	class AspectRatio {
-		int _kw, _kh;
-	public:
-		AspectRatio() { _kw = _kh = 0; }
-		AspectRatio(int w, int h);
-
-		bool isAuto() const { return (_kw | _kh) == 0; }
-
-		int kw() const { return _kw; }
-		int kh() const { return _kh; }
-	};
-
-	static AspectRatio getDesiredAspectRatio();
-
-	bool gameNeedsAspectRatioCorrection() const override {
-		return _videoMode.aspectRatioCorrection;
-	}
+	bool gameNeedsAspectRatioCorrection() const override;
 	int getGameRenderScale() const override {
 		return _videoMode.scaleFactor;
 	}
@@ -189,8 +173,6 @@ protected:
 	void handleResizeImpl(const int width, const int height) override;
 
 	virtual void setupHardwareSize();
-
-	void fixupResolutionForAspectRatio(AspectRatio desiredAspectRatio, int &width, int &height) const;
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	/* SDL2 features a different API for 2D graphics. We create a wrapper
@@ -265,7 +247,6 @@ protected:
 
 		bool fullscreen;
 		bool aspectRatioCorrection;
-		AspectRatio desiredAspectRatio;
 		bool filtering;
 
 		int mode;
@@ -285,7 +266,6 @@ protected:
 			setup = false;
 			fullscreen = false;
 			aspectRatioCorrection = false;
-			// desiredAspectRatio set to (0, 0) by AspectRatio constructor
 			filtering = false;
 
 			mode = GFX_RENDERSDL;

--- a/backends/graphics/rendersdl/rendersdl-graphics.h
+++ b/backends/graphics/rendersdl/rendersdl-graphics.h
@@ -210,7 +210,6 @@ protected:
 	bool _overlayDirty;
 	bool _useOldSrc;
 	Graphics::PixelFormat _overlayFormat;
-	bool _isDoubleBuf, _isHwPalette;
 
 	enum {
 		kTransactionNone = 0,
@@ -325,14 +324,8 @@ protected:
 	};
 
 	// Dirty rect management
-	// When double-buffering we need to redraw both updates from
-	// current frame and previous frame. For convenience we copy
-	// them here before traversing the list.
-	SDL_Rect _dirtyRectList[2 * NUM_DIRTY_RECT];
+	SDL_Rect _dirtyRectList[NUM_DIRTY_RECT];
 	int _numDirtyRects;
-
-	SDL_Rect _prevDirtyRectList[NUM_DIRTY_RECT];
-	int _numPrevDirtyRects;
 
 	struct MousePos {
 		// The size and hotspot of the original cursor image.
@@ -411,8 +404,6 @@ private:
 	void handleScalerHotkeys(uint mode, int factor);
 
 	void recalculateCursorScaling();
-
-	bool _prevForceRedraw;
 };
 
 #endif

--- a/backends/graphics/rendersdl/rendersdl-graphics.h
+++ b/backends/graphics/rendersdl/rendersdl-graphics.h
@@ -206,7 +206,6 @@ protected:
 	virtual void SDL_UpdateRects(SDL_Surface *screen, int numrects, SDL_Rect *rects);
 	int SDL_SetColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors);
 	int SDL_SetAlpha(SDL_Surface *surface, Uint32 flag, Uint8 alpha);
-	int SDL_SetColorKey(SDL_Surface *surface, Uint32 flag, Uint32 key);
 #endif
 
 	/** Unseen game screen */
@@ -381,7 +380,6 @@ protected:
 			{ }
 	};
 
-	SDL_Rect _mouseLastRect, _mouseNextRect;
 	MousePos _mouseCurState;
 	uint32 _mouseKeyColor;
 	bool _disableMouseKeyColor;
@@ -390,6 +388,7 @@ protected:
 	bool _cursorPaletteDisabled;
 	SDL_Surface *_mouseOrigSurface;
 	SDL_Surface *_mouseSurface;
+	SDL_Texture *_mouseTexture;
 
 	// Shake mode
 	// This is always set to 0 when building with SDL2.
@@ -421,7 +420,6 @@ protected:
 	virtual void addDirtyRect(int x, int y, int w, int h, bool inOverlay, bool realCoordinates = false);
 
 	virtual void drawMouse();
-	virtual void undrawMouse();
 	virtual void blitCursor();
 
 	virtual void internUpdateScreen();
@@ -445,6 +443,8 @@ protected:
 private:
 	void setFullscreenMode(bool enable);
 	void handleScalerHotkeys(uint mode, int factor);
+
+	void recalculateCursorScaling();
 
 	/**
 	 * Converts the given point from the overlay's coordinate space to the
@@ -480,7 +480,6 @@ private:
 	 */
 	bool _needRestoreAfterOverlay;
 	bool _prevForceRedraw;
-	bool _prevCursorNeedsRedraw;
 };
 
 #endif

--- a/backends/graphics/rendersdl/rendersdl-graphics.h
+++ b/backends/graphics/rendersdl/rendersdl-graphics.h
@@ -114,8 +114,8 @@ public:
 	void clearOverlay() override;
 	void grabOverlay(Graphics::Surface &surface) const override;
 	void copyRectToOverlay(const void *buf, int pitch, int x, int y, int w, int h) override;
-	int16 getOverlayHeight() const override { return _videoMode.overlayHeight; }
-	int16 getOverlayWidth() const override { return _videoMode.overlayWidth; }
+	int16 getOverlayHeight() const override { return _overlaySurface ? _overlaySurface->h : 0; }
+	int16 getOverlayWidth() const override { return _overlaySurface ? _overlaySurface->w : 0; }
 
 	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override;
 	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask, bool disableKeyColor);
@@ -166,6 +166,9 @@ protected:
 #endif
 
 	void drawScreen();
+
+	void drawOverlay();
+	void recreateOverlay(const int width, const int height);
 
 	class AspectRatio {
 		int _kw, _kh;
@@ -224,10 +227,10 @@ protected:
 
 	/** Temporary screen (for scalers) */
 	SDL_Surface *_tmpscreen;
-	/** Temporary screen (for scalers) */
-	SDL_Surface *_tmpscreen2;
 
-	SDL_Surface *_overlayscreen;
+	SDL_Texture *_overlayTexture;
+	SDL_Surface *_overlaySurface;
+	bool _overlayDirty;
 	bool _useOldSrc;
 	Graphics::PixelFormat _overlayFormat;
 	bool _isDoubleBuf, _isHwPalette;
@@ -280,7 +283,6 @@ protected:
 		int scaleFactor;
 
 		int screenWidth, screenHeight;
-		int overlayWidth, overlayHeight;
 		int hardwareWidth, hardwareHeight;
 		Graphics::PixelFormat format;
 
@@ -302,8 +304,6 @@ protected:
 
 			screenWidth = 0;
 			screenHeight = 0;
-			overlayWidth = 0;
-			overlayHeight = 0;
 			hardwareWidth = 0;
 			hardwareHeight = 0;
 			// format set to 0 values by Graphics::PixelFormat constructor
@@ -399,9 +399,6 @@ protected:
 	SDL_Color *_currentPalette;
 	uint _paletteDirtyStart, _paletteDirtyEnd;
 
-	SDL_Color *_overlayPalette;
-	bool _isInOverlayPalette;
-
 	// Cursor palette data
 	SDL_Color *_cursorPalette;
 
@@ -417,7 +414,7 @@ protected:
 	Common::Rect _focusRect;
 #endif
 
-	virtual void addDirtyRect(int x, int y, int w, int h, bool inOverlay, bool realCoordinates = false);
+	virtual void addDirtyRect(int x, int y, int w, int h);
 
 	virtual void drawMouse();
 	virtual void blitCursor();
@@ -446,39 +443,6 @@ private:
 
 	void recalculateCursorScaling();
 
-	/**
-	 * Converts the given point from the overlay's coordinate space to the
-	 * game's coordinate space.
-	 */
-	Common::Point convertOverlayToGame(const int x, const int y) const {
-		if (getOverlayWidth() == 0 || getOverlayHeight() == 0) {
-			error("convertOverlayToGame called without a valid overlay");
-		}
-
-		return Common::Point(x * getWidth() / getOverlayWidth(),
-							 y * getHeight() / getOverlayHeight());
-	}
-
-	/**
-	 * Converts the given point from the game's coordinate space to the
-	 * overlay's coordinate space.
-	 */
-	Common::Point convertGameToOverlay(const int x, const int y) const {
-		if (getWidth() == 0 || getHeight() == 0) {
-			error("convertGameToOverlay called without a valid overlay");
-		}
-
-		return Common::Point(x * getOverlayWidth() / getWidth(),
-							 y * getOverlayHeight() / getHeight());
-	}
-
-	/**
-	 * Special case for scalers that use the useOldSrc feature (currently
-	 * only the Edge scalers). The variable is checked after closing the
-	 * overlay, so that the creation of a new output buffer for the scaler
-	 * can be triggered.
-	 */
-	bool _needRestoreAfterOverlay;
 	bool _prevForceRedraw;
 };
 

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -248,8 +248,11 @@ endif
 endif
 endif
 
+ifdef USE_SDL2
+MODULE_OBJS += \
+	graphics/rendersdl/rendersdl-graphics.o
+else
 # SDL 2 removed audio CD support
-ifndef USE_SDL2
 MODULE_OBJS += \
 	audiocd/sdl/sdl-audiocd.o
 endif

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -48,6 +48,9 @@
 #include "backends/mutex/sdl/sdl-mutex.h"
 #include "backends/timer/sdl/sdl-timer.h"
 #include "backends/graphics/surfacesdl/surfacesdl-graphics.h"
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+#include "backends/graphics/rendersdl/rendersdl-graphics.h"
+#endif
 #ifdef USE_OPENGL
 #include "backends/graphics/openglsdl/openglsdl-graphics.h"
 #endif
@@ -960,7 +963,11 @@ Common::Path OSystem_SDL::getScreenshotsPath() {
 #ifdef USE_MULTIPLE_RENDERERS
 
 OSystem_SDL::GraphicsManagerType OSystem_SDL::getDefaultGraphicsManager() const {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	return GraphicsManagerRenderSDL;
+#else
 	return GraphicsManagerSurfaceSDL;
+#endif
 }
 
 SdlGraphicsManager *OSystem_SDL::createGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window, GraphicsManagerType type) {
@@ -968,11 +975,19 @@ SdlGraphicsManager *OSystem_SDL::createGraphicsManager(SdlEventSource *sdlEventS
 	case GraphicsManagerSurfaceSDL:
 		debug(1, "creating SurfaceSDL graphics manager");
 		return new SurfaceSdlGraphicsManager(sdlEventSource, window);
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	case GraphicsManagerRenderSDL:
+		debug(1, "creating RenderSDL graphics manager");
+		return new RenderSdlGraphicsManager(sdlEventSource, window);
+#endif
+
 #ifdef USE_OPENGL
 	case GraphicsManagerOpenGL:
 		debug(1, "creating OpenGL graphics manager");
 		return new OpenGLSdlGraphicsManager(sdlEventSource, window);
 #endif
+
 	default:
 		assert(0);
 		return NULL;

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -32,7 +32,7 @@
 
 #include "common/array.h"
 
-#ifdef USE_OPENGL
+#if SDL_VERSION_ATLEAST(2, 0, 0) || defined(USE_OPENGL)
 #define USE_MULTIPLE_RENDERERS
 #endif
 
@@ -171,6 +171,9 @@ protected:
 #ifdef USE_MULTIPLE_RENDERERS
 	enum GraphicsManagerType {
 		GraphicsManagerSurfaceSDL,
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		GraphicsManagerRenderSDL,
+#endif
 #ifdef USE_OPENGL
 		GraphicsManagerOpenGL,
 #endif


### PR DESCRIPTION
Having this will allow making better use of hardware scaling on systems with SDL2 while reducing the complexity of SurfaceSdlGraphicsManager for platforms with SDL 1.2 or software rendering.

TODO:
- [x] Remove the unneeded SDL 1.2 ifdefs from SDL2 only code.
- [ ] Reduce the amount of memory copying done when scaling is not needed.
- [x] Improve support for texture formats other than `SDL_PIXELFORMAT_RGB565`.
- [ ] Simplify the mouse rendering code.
- [ ] Ensure that rotation works correctly.
- [ ] Ensure that the window size is calculated correctly.
- [ ] Support building with SDL3
