### PR TITLE
BACKENDS: FS: Atomic write of files (take 2)

### DIFF
--- a/backends/audiocd/macosx/macosx-audiocd.cpp
+++ b/backends/audiocd/macosx/macosx-audiocd.cpp
@@ -223,7 +223,7 @@ bool MacOSXAudioCDManager::play(int track, int numLoops, int startFrame, int dur
 
 	// Now load the AIFF track from the name
 	Common::Path fileName = _trackMap[track];
-	Common::SeekableReadStream *stream = StdioStream::makeFromPath(fileName.toString(Common::Path::kNativeSeparator).c_str(), false);
+	Common::SeekableReadStream *stream = StdioStream::makeFromPath(fileName.toString(Common::Path::kNativeSeparator).c_str(), StdioStream::WriteMode_Read);
 
 	if (!stream) {
 		warning("Failed to open track '%s'", fileName.toString(Common::Path::kNativeSeparator).c_str());

--- a/backends/fs/abstract-fs.h
+++ b/backends/fs/abstract-fs.h
@@ -197,9 +197,14 @@ public:
 	 * referred by this node. This assumes that the node actually refers
 	 * to a readable file. If this is not the case, 0 is returned.
 	 *
+	 * When an atomic write stream is requested, the backend will write
+	 * the data in a temporary file before moving it to its final destination.
+	 *
+	 * @param atomic Request for an atomic file write when closing.
+	 *
 	 * @return pointer to the stream object, 0 in case of a failure
 	 */
-	virtual Common::SeekableWriteStream *createWriteStream() = 0;
+	virtual Common::SeekableWriteStream *createWriteStream(bool atomic) = 0;
 
 	/**
 	* Creates a directory referred by this node.

--- a/backends/fs/amigaos/amigaos-fs.cpp
+++ b/backends/fs/amigaos/amigaos-fs.cpp
@@ -350,7 +350,7 @@ Common::SeekableReadStream *AmigaOSFilesystemNode::createReadStream() {
 }
 
 
-Common::SeekableWriteStream *AmigaOSFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *AmigaOSFilesystemNode::createWriteStream(bool atomic) {
 	return StdioStream::makeFromPath(getPath(), true);
 }
 

--- a/backends/fs/amigaos/amigaos-fs.cpp
+++ b/backends/fs/amigaos/amigaos-fs.cpp
@@ -346,12 +346,13 @@ AbstractFSList AmigaOSFilesystemNode::listVolumes() const {
 }
 
 Common::SeekableReadStream *AmigaOSFilesystemNode::createReadStream() {
-	return StdioStream::makeFromPath(getPath(), false);
+	return StdioStream::makeFromPath(getPath(), StdioStream::WriteMode_Read);
 }
 
 
 Common::SeekableWriteStream *AmigaOSFilesystemNode::createWriteStream(bool atomic) {
-	return StdioStream::makeFromPath(getPath(), true);
+	return StdioStream::makeFromPath(getPath(), atomic ?
+			StdioStream::WriteMode_WriteAtomic : StdioStream::WriteMode_Write);
 }
 
 bool AmigaOSFilesystemNode::createDirectory() {

--- a/backends/fs/amigaos/amigaos-fs.h
+++ b/backends/fs/amigaos/amigaos-fs.h
@@ -114,7 +114,7 @@ public:
 	AbstractFSNode *getParent() const override;
 
 	Common::SeekableReadStream *createReadStream() override;
-	Common::SeekableWriteStream *createWriteStream() override;
+	Common::SeekableWriteStream *createWriteStream(bool atomic) override;
 	bool createDirectory() override;
 };
 

--- a/backends/fs/android/android-saf-fs.cpp
+++ b/backends/fs/android/android-saf-fs.cpp
@@ -450,7 +450,7 @@ Common::SeekableReadStream *AndroidSAFFilesystemNode::createReadStream() {
 	return new PosixIoStream(f);
 }
 
-Common::SeekableWriteStream *AndroidSAFFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *AndroidSAFFilesystemNode::createWriteStream(bool atomic) {
 	assert(_safTree != nullptr);
 
 	JNIEnv *env = JNI::getEnv();
@@ -459,6 +459,7 @@ Common::SeekableWriteStream *AndroidSAFFilesystemNode::createWriteStream() {
 		assert(_safParent);
 		jstring name = env->NewStringUTF(_newName.c_str());
 
+		// TODO: Add atomic support if possible
 		jobject child = env->CallObjectMethod(_safTree, _MID_createFile, _safParent, name);
 
 		env->DeleteLocalRef(name);

--- a/backends/fs/android/android-saf-fs.h
+++ b/backends/fs/android/android-saf-fs.h
@@ -132,7 +132,7 @@ public:
 	AbstractFSNode *getParent() const override;
 
 	Common::SeekableReadStream *createReadStream() override;
-	Common::SeekableWriteStream *createWriteStream() override;
+	Common::SeekableWriteStream *createWriteStream(bool atomic) override;
 	bool createDirectory() override;
 
 	bool remove() override;
@@ -182,7 +182,7 @@ public:
 	bool isWritable() const override;
 
 	Common::SeekableReadStream *createReadStream() override { return nullptr; }
-	Common::SeekableWriteStream *createWriteStream() override { return nullptr; }
+	Common::SeekableWriteStream *createWriteStream(bool atomic) override { return nullptr; }
 
 	bool createDirectory() override { return false; }
 	bool remove() override { return false; }

--- a/backends/fs/chroot/chroot-fs.cpp
+++ b/backends/fs/chroot/chroot-fs.cpp
@@ -100,8 +100,8 @@ Common::SeekableReadStream *ChRootFilesystemNode::createReadStream() {
 	return _realNode->createReadStream();
 }
 
-Common::SeekableWriteStream *ChRootFilesystemNode::createWriteStream() {
-	return _realNode->createWriteStream();
+Common::SeekableWriteStream *ChRootFilesystemNode::createWriteStream(bool atomic) {
+	return _realNode->createWriteStream(atomic);
 }
 
 bool ChRootFilesystemNode::createDirectory() {

--- a/backends/fs/chroot/chroot-fs.h
+++ b/backends/fs/chroot/chroot-fs.h
@@ -48,7 +48,7 @@ public:
 	AbstractFSNode *getParent() const override;
 
 	Common::SeekableReadStream *createReadStream() override;
-	Common::SeekableWriteStream *createWriteStream() override;
+	Common::SeekableWriteStream *createWriteStream(bool atomic) override;
 	bool createDirectory() override;
 
 private:

--- a/backends/fs/kolibrios/kolibrios-fs.cpp
+++ b/backends/fs/kolibrios/kolibrios-fs.cpp
@@ -218,7 +218,7 @@ Common::SeekableReadStream *KolibriOSFilesystemNode::createReadStream() {
 	return PosixIoStream::makeFromPath(getPath(), false);
 }
 
-Common::SeekableWriteStream *KolibriOSFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *KolibriOSFilesystemNode::createWriteStream(bool atomic) {
 	return PosixIoStream::makeFromPath(getPath(), true);
 }
 

--- a/backends/fs/kolibrios/kolibrios-fs.cpp
+++ b/backends/fs/kolibrios/kolibrios-fs.cpp
@@ -215,11 +215,12 @@ AbstractFSNode *KolibriOSFilesystemNode::getParent() const {
 }
 
 Common::SeekableReadStream *KolibriOSFilesystemNode::createReadStream() {
-	return PosixIoStream::makeFromPath(getPath(), false);
+	return PosixIoStream::makeFromPath(getPath(), StdioStream::WriteMode_Read);
 }
 
 Common::SeekableWriteStream *KolibriOSFilesystemNode::createWriteStream(bool atomic) {
-	return PosixIoStream::makeFromPath(getPath(), true);
+	return PosixIoStream::makeFromPath(getPath(), atomic ?
+			StdioStream::WriteMode_WriteAtomic : StdioStream::WriteMode_Write);
 }
 
 bool KolibriOSFilesystemNode::createDirectory() {

--- a/backends/fs/kolibrios/kolibrios-fs.h
+++ b/backends/fs/kolibrios/kolibrios-fs.h
@@ -52,7 +52,7 @@ public:
 	AbstractFSNode *getParent() const override;
 
 	Common::SeekableReadStream *createReadStream() override;
-	Common::SeekableWriteStream *createWriteStream() override;
+	Common::SeekableWriteStream *createWriteStream(bool atomic) override;
 	bool createDirectory() override;
 
 protected:

--- a/backends/fs/morphos/morphos-fs.cpp
+++ b/backends/fs/morphos/morphos-fs.cpp
@@ -352,7 +352,7 @@ Common::SeekableReadStream *MorphOSFilesystemNode::createReadStream() {
 	return readStream;
 }
 
-Common::SeekableWriteStream *MorphOSFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *MorphOSFilesystemNode::createWriteStream(bool atomic) {
 	return StdioStream::makeFromPath(getPath(), true);
 }
 

--- a/backends/fs/morphos/morphos-fs.cpp
+++ b/backends/fs/morphos/morphos-fs.cpp
@@ -343,7 +343,7 @@ AbstractFSList MorphOSFilesystemNode::listVolumes() const {
 }
 
 Common::SeekableReadStream *MorphOSFilesystemNode::createReadStream() {
-	StdioStream *readStream = StdioStream::makeFromPath(getPath(), false);
+	StdioStream *readStream = StdioStream::makeFromPath(getPath(), StdioStream::WriteMode_Read);
 
 	if (readStream) {
 		readStream->setBufferSize(8192);
@@ -353,7 +353,8 @@ Common::SeekableReadStream *MorphOSFilesystemNode::createReadStream() {
 }
 
 Common::SeekableWriteStream *MorphOSFilesystemNode::createWriteStream(bool atomic) {
-	return StdioStream::makeFromPath(getPath(), true);
+	return StdioStream::makeFromPath(getPath(), atomic ?
+			StdioStream::WriteMode_WriteAtomic : StdioStream::WriteMode_Write);
 }
 
 bool MorphOSFilesystemNode::createDirectory() {

--- a/backends/fs/morphos/morphos-fs.h
+++ b/backends/fs/morphos/morphos-fs.h
@@ -115,7 +115,7 @@ public:
 	AbstractFSNode *getParent() const override;
 
 	Common::SeekableReadStream *createReadStream() override;
-	Common::SeekableWriteStream *createWriteStream() override;
+	Common::SeekableWriteStream *createWriteStream(bool atomic) override;
 	bool createDirectory() override;
 };
 

--- a/backends/fs/n64/n64-fs.cpp
+++ b/backends/fs/n64/n64-fs.cpp
@@ -155,7 +155,8 @@ Common::SeekableReadStream *N64FilesystemNode::createReadStream() {
 	return RomfsStream::makeFromPath(getPath(), false);
 }
 
-Common::SeekableWriteStream *N64FilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *N64FilesystemNode::createWriteStream(bool atomic) {
+	// TODO: Add atomic support if possible
 	return RomfsStream::makeFromPath(getPath(), true);
 }
 

--- a/backends/fs/n64/n64-fs.h
+++ b/backends/fs/n64/n64-fs.h
@@ -71,7 +71,7 @@ public:
 	AbstractFSNode *getParent() const override;
 
 	Common::SeekableReadStream *createReadStream() override;
-	Common::SeekableWriteStream *createWriteStream() override;
+	Common::SeekableWriteStream *createWriteStream(bool atomic) override;
 	bool createDirectory() override;
 };
 

--- a/backends/fs/posix-drives/posix-drives-fs.cpp
+++ b/backends/fs/posix-drives/posix-drives-fs.cpp
@@ -81,7 +81,7 @@ Common::SeekableReadStream *DrivePOSIXFilesystemNode::createReadStream() {
 	return readStream;
 }
 
-Common::SeekableWriteStream *DrivePOSIXFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *DrivePOSIXFilesystemNode::createWriteStream(bool atomic) {
 	StdioStream *writeStream = PosixIoStream::makeFromPath(getPath(), true);
 
 	configureStream(writeStream);

--- a/backends/fs/posix-drives/posix-drives-fs.cpp
+++ b/backends/fs/posix-drives/posix-drives-fs.cpp
@@ -69,7 +69,7 @@ void DrivePOSIXFilesystemNode::configureStream(StdioStream *stream) {
 }
 
 Common::SeekableReadStream *DrivePOSIXFilesystemNode::createReadStream() {
-	StdioStream *readStream = PosixIoStream::makeFromPath(getPath(), false);
+	StdioStream *readStream = PosixIoStream::makeFromPath(getPath(), StdioStream::WriteMode_Read);
 
 	configureStream(readStream);
 
@@ -82,7 +82,8 @@ Common::SeekableReadStream *DrivePOSIXFilesystemNode::createReadStream() {
 }
 
 Common::SeekableWriteStream *DrivePOSIXFilesystemNode::createWriteStream(bool atomic) {
-	StdioStream *writeStream = PosixIoStream::makeFromPath(getPath(), true);
+	StdioStream *writeStream = PosixIoStream::makeFromPath(getPath(), atomic ?
+			StdioStream::WriteMode_WriteAtomic : StdioStream::WriteMode_Write);
 
 	configureStream(writeStream);
 

--- a/backends/fs/posix-drives/posix-drives-fs.h
+++ b/backends/fs/posix-drives/posix-drives-fs.h
@@ -66,7 +66,7 @@ public:
 
 	// AbstractFSNode API
 	Common::SeekableReadStream *createReadStream() override;
-	Common::SeekableWriteStream *createWriteStream() override;
+	Common::SeekableWriteStream *createWriteStream(bool atomic) override;
 	AbstractFSNode *getChild(const Common::String &n) const override;
 	bool getChildren(AbstractFSList &list, ListMode mode, bool hidden) const override;
 	AbstractFSNode *getParent() const override;

--- a/backends/fs/posix/posix-fs.cpp
+++ b/backends/fs/posix/posix-fs.cpp
@@ -280,7 +280,7 @@ Common::SeekableReadStream *POSIXFilesystemNode::createReadStreamForAltStream(Co
 	return nullptr;
 }
 
-Common::SeekableWriteStream *POSIXFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *POSIXFilesystemNode::createWriteStream(bool atomic) {
 	return PosixIoStream::makeFromPath(getPath(), true);
 }
 

--- a/backends/fs/posix/posix-fs.cpp
+++ b/backends/fs/posix/posix-fs.cpp
@@ -266,14 +266,14 @@ AbstractFSNode *POSIXFilesystemNode::getParent() const {
 }
 
 Common::SeekableReadStream *POSIXFilesystemNode::createReadStream() {
-	return PosixIoStream::makeFromPath(getPath(), false);
+	return PosixIoStream::makeFromPath(getPath(), StdioStream::WriteMode_Read);
 }
 
 Common::SeekableReadStream *POSIXFilesystemNode::createReadStreamForAltStream(Common::AltStreamType altStreamType) {
 #ifdef MACOSX
 	if (altStreamType == Common::AltStreamType::MacResourceFork) {
 		// Check the actual fork on a Mac computer
-		return PosixIoStream::makeFromPath(getPath() + "/..namedfork/rsrc", false);
+		return PosixIoStream::makeFromPath(getPath() + "/..namedfork/rsrc", StdioStream::WriteMode_Read);
 	}
 #endif
 
@@ -281,7 +281,8 @@ Common::SeekableReadStream *POSIXFilesystemNode::createReadStreamForAltStream(Co
 }
 
 Common::SeekableWriteStream *POSIXFilesystemNode::createWriteStream(bool atomic) {
-	return PosixIoStream::makeFromPath(getPath(), true);
+	return PosixIoStream::makeFromPath(getPath(), atomic ?
+			StdioStream::WriteMode_WriteAtomic : StdioStream::WriteMode_Write);
 }
 
 bool POSIXFilesystemNode::createDirectory() {

--- a/backends/fs/posix/posix-fs.h
+++ b/backends/fs/posix/posix-fs.h
@@ -67,7 +67,7 @@ public:
 
 	Common::SeekableReadStream *createReadStream() override;
 	Common::SeekableReadStream *createReadStreamForAltStream(Common::AltStreamType altStreamType) override;
-	Common::SeekableWriteStream *createWriteStream() override;
+	Common::SeekableWriteStream *createWriteStream(bool atomic) override;
 	bool createDirectory() override;
 
 protected:

--- a/backends/fs/posix/posix-iostream.h
+++ b/backends/fs/posix/posix-iostream.h
@@ -29,7 +29,7 @@
  */
 class PosixIoStream final : public StdioStream {
 public:
-	static StdioStream *makeFromPath(const Common::String &path, bool writeMode) {
+	static StdioStream *makeFromPath(const Common::String &path, StdioStream::WriteMode writeMode) {
 		return StdioStream::makeFromPathHelper(path, writeMode, [](void *handle) -> StdioStream * {
 			return new PosixIoStream(handle);
 		});

--- a/backends/fs/psp/psp-fs.cpp
+++ b/backends/fs/psp/psp-fs.cpp
@@ -230,9 +230,10 @@ Common::SeekableReadStream *PSPFilesystemNode::createReadStream() {
 	return Common::wrapBufferedSeekableReadStream(stream, READ_BUFFER_SIZE, DisposeAfterUse::YES);
 }
 
-Common::SeekableWriteStream *PSPFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *PSPFilesystemNode::createWriteStream(bool atomic) {
 	const uint32 WRITE_BUFFER_SIZE = 1024;
 
+	// TODO: Add atomic support if possible
 	Common::SeekableWriteStream *stream = PspIoStream::makeFromPath(getPath(), true);
 
 	return Common::wrapBufferedWriteStream(stream, WRITE_BUFFER_SIZE);

--- a/backends/fs/psp/psp-fs.h
+++ b/backends/fs/psp/psp-fs.h
@@ -63,7 +63,7 @@ public:
 	virtual AbstractFSNode *getParent() const;
 
 	virtual Common::SeekableReadStream *createReadStream();
-	virtual Common::SeekableWriteStream *createWriteStream();
+	virtual Common::SeekableWriteStream *createWriteStream(bool atomic);
 	virtual bool createDirectory();
 };
 

--- a/backends/fs/riscos/riscos-fs.cpp
+++ b/backends/fs/riscos/riscos-fs.cpp
@@ -206,11 +206,12 @@ AbstractFSNode *RISCOSFilesystemNode::getParent() const {
 }
 
 Common::SeekableReadStream *RISCOSFilesystemNode::createReadStream() {
-	return StdioStream::makeFromPath(getPath(), false);
+	return StdioStream::makeFromPath(getPath(), StdioStream::WriteMode_Read);
 }
 
 Common::SeekableWriteStream *RISCOSFilesystemNode::createWriteStream(bool atomic) {
-	return StdioStream::makeFromPath(getPath(), true);
+	return StdioStream::makeFromPath(getPath(), atomic ?
+			StdioStream::WriteMode_WriteAtomic : StdioStream::WriteMode_Write);
 }
 
 bool RISCOSFilesystemNode::createDirectory() {

--- a/backends/fs/riscos/riscos-fs.cpp
+++ b/backends/fs/riscos/riscos-fs.cpp
@@ -209,7 +209,7 @@ Common::SeekableReadStream *RISCOSFilesystemNode::createReadStream() {
 	return StdioStream::makeFromPath(getPath(), false);
 }
 
-Common::SeekableWriteStream *RISCOSFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *RISCOSFilesystemNode::createWriteStream(bool atomic) {
 	return StdioStream::makeFromPath(getPath(), true);
 }
 

--- a/backends/fs/riscos/riscos-fs.h
+++ b/backends/fs/riscos/riscos-fs.h
@@ -66,7 +66,7 @@ public:
 	AbstractFSNode *getParent() const override;
 
 	Common::SeekableReadStream *createReadStream() override;
-	Common::SeekableWriteStream *createWriteStream() override;
+	Common::SeekableWriteStream *createWriteStream(bool atomic) override;
 	bool createDirectory() override;
 private:
 	/**

--- a/backends/fs/stdiostream.h
+++ b/backends/fs/stdiostream.h
@@ -27,12 +27,19 @@
 #include "common/stream.h"
 #include "common/str.h"
 
+#if defined(__DC__)
+// libronin doesn't support rename
+#define STDIOSTREAM_NO_ATOMIC_SUPPORT
+#endif
+
 class StdioStream : public Common::SeekableReadStream, public Common::SeekableWriteStream, public Common::NonCopyable {
 public:
 	enum WriteMode {
 		WriteMode_Read = 0,
 		WriteMode_Write = 1,
+#ifndef STDIOSTREAM_NO_ATOMIC_SUPPORT
 		WriteMode_WriteAtomic = 2,
+#endif
 	};
 
 protected:

--- a/backends/fs/stdiostream.h
+++ b/backends/fs/stdiostream.h
@@ -79,6 +79,20 @@ public:
 	 * @return success or failure
 	 */
 	bool setBufferSize(uint32 bufferSize);
+
+private:
+	/**
+	 * Move the file from src to dst.
+	 * This must succeed even if the destination file already exists.
+	 *
+	 * This function cannot be overridden as it's called from the destructor.
+	 *
+	 * @param src The file to move
+	 * @param dst The path where the file is to be moved.
+	 *
+	 * @returns Wether the renaming succeeded or not.
+	 */
+	bool moveFile(const Common::String &src, const Common::String &dst);
 };
 
 #endif

--- a/backends/fs/stdiostream.h
+++ b/backends/fs/stdiostream.h
@@ -28,11 +28,19 @@
 #include "common/str.h"
 
 class StdioStream : public Common::SeekableReadStream, public Common::SeekableWriteStream, public Common::NonCopyable {
+public:
+	enum WriteMode {
+		WriteMode_Read = 0,
+		WriteMode_Write = 1,
+		WriteMode_WriteAtomic = 2,
+	};
+
 protected:
 	/** File handle to the actual file. */
 	void *_handle;
+	Common::String *_path;
 
-	static StdioStream *makeFromPathHelper(const Common::String &path, bool writeMode,
+	static StdioStream *makeFromPathHelper(const Common::String &path, WriteMode writeMode,
 			StdioStream *(*factory)(void *handle));
 
 public:
@@ -40,7 +48,7 @@ public:
 	 * Given a path, invokes fopen on that path and wrap the result in a
 	 * StdioStream instance.
 	 */
-	static StdioStream *makeFromPath(const Common::String &path, bool writeMode) {
+	static StdioStream *makeFromPath(const Common::String &path, WriteMode writeMode) {
 		return makeFromPathHelper(path, writeMode, [](void *handle) {
 			return new StdioStream(handle);
 		});

--- a/backends/fs/wii/wii-fs.cpp
+++ b/backends/fs/wii/wii-fs.cpp
@@ -198,7 +198,7 @@ AbstractFSNode *WiiFilesystemNode::getParent() const {
 }
 
 Common::SeekableReadStream *WiiFilesystemNode::createReadStream() {
-	StdioStream *readStream = StdioStream::makeFromPath(getPath(), false);
+	StdioStream *readStream = StdioStream::makeFromPath(getPath(), StdioStream::WriteMode_Read);
 
 	// disable newlib's buffering, the device libraries handle caching
 	if (readStream) {
@@ -209,7 +209,8 @@ Common::SeekableReadStream *WiiFilesystemNode::createReadStream() {
 }
 
 Common::SeekableWriteStream *WiiFilesystemNode::createWriteStream(bool atomic) {
-	StdioStream *writeStream = StdioStream::makeFromPath(getPath(), true);
+	StdioStream *writeStream = StdioStream::makeFromPath(getPath(), atomic ?
+			StdioStream::WriteMode_WriteAtomic : StdioStream::WriteMode_Write);
 
 	// disable newlib's buffering, the device libraries handle caching
 	if (writeStream) {

--- a/backends/fs/wii/wii-fs.cpp
+++ b/backends/fs/wii/wii-fs.cpp
@@ -208,7 +208,7 @@ Common::SeekableReadStream *WiiFilesystemNode::createReadStream() {
 	return readStream;
 }
 
-Common::SeekableWriteStream *WiiFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *WiiFilesystemNode::createWriteStream(bool atomic) {
 	StdioStream *writeStream = StdioStream::makeFromPath(getPath(), true);
 
 	// disable newlib's buffering, the device libraries handle caching

--- a/backends/fs/wii/wii-fs.h
+++ b/backends/fs/wii/wii-fs.h
@@ -67,7 +67,7 @@ public:
 	AbstractFSNode *getParent() const override;
 
 	Common::SeekableReadStream *createReadStream() override;
-	Common::SeekableWriteStream *createWriteStream() override;
+	Common::SeekableWriteStream *createWriteStream(bool atomic) override;
 	bool createDirectory() override;
 };
 

--- a/backends/fs/windows/windows-fs.cpp
+++ b/backends/fs/windows/windows-fs.cpp
@@ -226,7 +226,7 @@ Common::SeekableReadStream *WindowsFilesystemNode::createReadStream() {
 	return StdioStream::makeFromPath(getPath(), false);
 }
 
-Common::SeekableWriteStream *WindowsFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *WindowsFilesystemNode::createWriteStream(bool atomic) {
 	return StdioStream::makeFromPath(getPath(), true);
 }
 

--- a/backends/fs/windows/windows-fs.cpp
+++ b/backends/fs/windows/windows-fs.cpp
@@ -223,11 +223,12 @@ AbstractFSNode *WindowsFilesystemNode::getParent() const {
 }
 
 Common::SeekableReadStream *WindowsFilesystemNode::createReadStream() {
-	return StdioStream::makeFromPath(getPath(), false);
+	return StdioStream::makeFromPath(getPath(), StdioStream::WriteMode_Read);
 }
 
 Common::SeekableWriteStream *WindowsFilesystemNode::createWriteStream(bool atomic) {
-	return StdioStream::makeFromPath(getPath(), true);
+	return StdioStream::makeFromPath(getPath(), atomic ?
+			StdioStream::WriteMode_WriteAtomic : StdioStream::WriteMode_Write);
 }
 
 bool WindowsFilesystemNode::createDirectory() {

--- a/backends/fs/windows/windows-fs.h
+++ b/backends/fs/windows/windows-fs.h
@@ -78,7 +78,7 @@ public:
 	AbstractFSNode *getParent() const override;
 
 	Common::SeekableReadStream *createReadStream() override;
-	Common::SeekableWriteStream *createWriteStream() override;
+	Common::SeekableWriteStream *createWriteStream(bool atomic) override;
 	bool createDirectory() override;
 
 private:

--- a/backends/log/log.cpp
+++ b/backends/log/log.cpp
@@ -56,8 +56,11 @@ void Log::close() {
 		// Output a message to indicate that the log was closed successfully
 		print("--- Log closed successfully.\n");
 
-		delete _stream;
+		// This avoids a segfault if a warning is issued when deleting the stream
+		Common::WriteStream *stream = _stream;
 		_stream = nullptr;
+
+		delete stream;
 	}
 }
 

--- a/backends/platform/3ds/osystem.cpp
+++ b/backends/platform/3ds/osystem.cpp
@@ -269,7 +269,7 @@ Common::WriteStream *OSystem_3DS::createLogFile() {
 		return nullptr;
 
 	Common::FSNode file(logFile);
-	Common::WriteStream *stream = file.createWriteStream();
+	Common::WriteStream *stream = file.createWriteStream(false);
 	if (stream)
 		_logFilePath = logFile;
 	return stream;

--- a/backends/platform/dc/dc-fs.cpp
+++ b/backends/platform/dc/dc-fs.cpp
@@ -155,7 +155,7 @@ AbstractFSNode *RoninCDFileNode::getParent() const {
 
 
 Common::SeekableReadStream *RoninCDFileNode::createReadStream() {
-	return StdioStream::makeFromPath(getPath().c_str(), false);
+	return StdioStream::makeFromPath(getPath().c_str(), StdioStream::WriteMode_Read);
 }
 
 AbstractFSNode *OSystem_Dreamcast::makeRootFileNode() const {

--- a/backends/platform/dc/dc-fs.cpp
+++ b/backends/platform/dc/dc-fs.cpp
@@ -56,7 +56,7 @@ public:
 	AbstractFSNode *getParent() const override;
 
 	Common::SeekableReadStream *createReadStream() override;
-	Common::SeekableWriteStream *createWriteStream() override { return 0; }
+	Common::SeekableWriteStream *createWriteStream(bool atomic) override { return 0; }
 	bool createDirectory() override { return false; }
 
 	static AbstractFSNode *makeFileNodePath(const Common::String &path);

--- a/backends/platform/libretro/include/libretro-fs.h
+++ b/backends/platform/libretro/include/libretro-fs.h
@@ -85,7 +85,7 @@ public:
 	virtual AbstractFSNode *getParent() const;
 
 	virtual Common::SeekableReadStream *createReadStream();
-	virtual Common::SeekableWriteStream *createWriteStream();
+	virtual Common::SeekableWriteStream *createWriteStream(bool atomic);
 	virtual bool createDirectory();
 
 	static Common::String getHomeDir(void);

--- a/backends/platform/libretro/src/libretro-fs.cpp
+++ b/backends/platform/libretro/src/libretro-fs.cpp
@@ -161,7 +161,7 @@ Common::SeekableReadStream *LibRetroFilesystemNode::createReadStream() {
 	return StdioStream::makeFromPath(getPath(), false);
 }
 
-Common::SeekableWriteStream *LibRetroFilesystemNode::createWriteStream() {
+Common::SeekableWriteStream *LibRetroFilesystemNode::createWriteStream(bool atomic) {
 	return StdioStream::makeFromPath(getPath(), true);
 }
 

--- a/backends/platform/libretro/src/libretro-fs.cpp
+++ b/backends/platform/libretro/src/libretro-fs.cpp
@@ -158,11 +158,12 @@ AbstractFSNode *LibRetroFilesystemNode::getParent() const {
 }
 
 Common::SeekableReadStream *LibRetroFilesystemNode::createReadStream() {
-	return StdioStream::makeFromPath(getPath(), false);
+	return StdioStream::makeFromPath(getPath(), StdioStream::WriteMode_Read);
 }
 
 Common::SeekableWriteStream *LibRetroFilesystemNode::createWriteStream(bool atomic) {
-	return StdioStream::makeFromPath(getPath(), true);
+	return StdioStream::makeFromPath(getPath(), atomic ?
+			StdioStream::WriteMode_WriteAtomic : StdioStream::WriteMode_Write);
 }
 
 bool LibRetroFilesystemNode::createDirectory() {

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -649,7 +649,7 @@ Common::WriteStream *OSystem_SDL::createLogFile() {
 		return nullptr;
 
 	Common::FSNode file(logFile);
-	Common::WriteStream *stream = file.createWriteStream();
+	Common::WriteStream *stream = file.createWriteStream(false);
 	if (stream)
 		_logFilePath = logFile;
 	return stream;

--- a/backends/platform/sdl/win32/win32_wrapper.h
+++ b/backends/platform/sdl/win32/win32_wrapper.h
@@ -63,6 +63,11 @@ void getProcessDirectory(TCHAR *processDirectory, DWORD size);
 bool confirmWindowsVersion(int majorVersion, int minorVersion);
 
 /**
+ * Moves a file within the same volume. Replaces any existing file.
+ */
+bool moveFile(const Common::String &src, const Common::String &dst);
+
+/**
  * Returns true if the drive letter is a CDROM
  *
  * @param driveLetter The drive letter to test

--- a/common/fs.cpp
+++ b/common/fs.cpp
@@ -263,7 +263,7 @@ SeekableReadStream *FSNode::createReadStreamForAltStream(AltStreamType altStream
 	return _realNode->createReadStreamForAltStream(altStreamType);
 }
 
-SeekableWriteStream *FSNode::createWriteStream() const {
+SeekableWriteStream *FSNode::createWriteStream(bool atomic) const {
 	if (_realNode == nullptr)
 		return nullptr;
 
@@ -272,7 +272,7 @@ SeekableWriteStream *FSNode::createWriteStream() const {
 		return nullptr;
 	}
 
-	return _realNode->createWriteStream();
+	return _realNode->createWriteStream(atomic);
 }
 
 bool FSNode::createDirectory() const {

--- a/common/fs.h
+++ b/common/fs.h
@@ -276,9 +276,14 @@ public:
 	 * referred by this node. This assumes that the node actually refers
 	 * to a readable file. If this is not the case, 0 is returned.
 	 *
+	 * When an atomic write stream is requested, the backend will write
+	 * the data in a temporary file before moving it to its final destination.
+	 *
+	 * @param atomic Request for an atomic file write when closing.
+	 *
 	 * @return Pointer to the stream object, 0 in case of a failure.
 	 */
-	SeekableWriteStream *createWriteStream() const;
+	SeekableWriteStream *createWriteStream(bool atomic = true) const;
 
 	/**
 	 * Create a directory referred by this node. This assumes that this

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -1228,7 +1228,7 @@ void Lingo::setTheEntity(int entity, Datum &id, int field, Datum &d) {
 			Common::Path logPath = ConfMan.getPath("path").appendComponent(d.asString());
 			Common::FSNode out(logPath);
 			if (!out.exists())
-				out.createWriteStream();
+				out.createWriteStream(false);
 			if (out.isWritable())
 				g_director->_traceLogFile = logPath;
 			else

--- a/engines/testbed/config-params.cpp
+++ b/engines/testbed/config-params.cpp
@@ -46,7 +46,7 @@ void ConfigParams::initLogging(const Common::Path &dirname, const char *filename
 	setLogDirectory(dirname);
 	setLogFilename(filename);
 	if (enable) {
-		_ws = Common::FSNode(_logDirectory).getChild(_logFilename).createWriteStream();
+		_ws = Common::FSNode(_logDirectory).getChild(_logFilename).createWriteStream(false);
 	} else {
 		_ws = 0;
 	}


### PR DESCRIPTION
After the moderate success (hem!) of my PR #6150 which is now partially reverted, I come back with another design.
First, a new argument is added to `createWriteStream` which allows to request for an atomic write (if supported by the backend). It is enabled by default.
This allows for long running files to be directly available. Thus, log files are not requesting atomic write.

Then, the implementation is recycled from the previous PR with the following tweaks:
- if rename fails, a remove then a rename is tried. This is compliant which what is advised on https://wiki.sei.cmu.edu/confluence/display/c/FIO10-C.+Take+care+when+using+the+rename%28%29+function (section Portable Behavior / Remove Existing Destination File)
- on Win32, MoveFileEx is first tried and then falls back on the rename dance if the function is not implemented.

I checked that MoveFileEx is advertised in include files since the first Windows 95 preliminary development kit.
However, the function returns a failure with error `ERROR_CALL_NOT_IMPLEMENTED` for the whole Windows 9x line.

This code has been tested on Windows 95 and Windows XP.