### PR TITLE
GRIM: Patch saves on the fly

### DIFF
--- a/engines/grim/lua.h
+++ b/engines/grim/lua.h
@@ -59,6 +59,11 @@ class PoolObjectBase;
 	class::static_##func
 
 /**
+ * Patch Lua state after loading a broken Grim save
+ */
+void lua_PatchGrimSave();
+
+/**
  * @brief A list of arguments to be passed to a Lua function.
  *
  * This is a convenience class to pass arguments to a Lua function, using

--- a/engines/grim/lua_grim_patch.cpp
+++ b/engines/grim/lua_grim_patch.cpp
@@ -1,0 +1,49 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define FORBIDDEN_SYMBOL_EXCEPTION_setjmp
+#define FORBIDDEN_SYMBOL_EXCEPTION_longjmp
+
+#include "engines/grim/lua/lstate.h"
+#include "engines/grim/lua/lua.h"
+
+namespace Grim {
+
+void lua_PatchGrimSave() {
+	// Since ResidualVM 0.2.0, a ResidualVM/ScummVM specific patch was provided broken.
+	// We patch here the code to fix all saves containing this invalid code.
+	// cf. bug #13139 and #14987
+	// The patch here doesn't match exactly the fixed patch.
+	// We minimize here the number of bytes to patch with an equivalent result.
+	TProtoFunc *tempProtoFunc = (TProtoFunc *)rootproto.next;
+	while (tempProtoFunc) {
+		if ((tempProtoFunc->lineDefined == 77) &&
+			(strcmp(tempProtoFunc->fileName->str, "Scripts\\vd.lua") == 0) &&
+			(memcmp(tempProtoFunc->code + 210, "\x22\x29\x39\x03\x32\x22\x30\x79\x02", 9) == 0)) {
+			tempProtoFunc->code[211] = 0x33;
+			tempProtoFunc->code[218] = 0x03;
+			break;
+		}
+		tempProtoFunc = (TProtoFunc *)tempProtoFunc->head.next;
+	}
+}
+
+} // end of namespace Grim

--- a/engines/grim/module.mk
+++ b/engines/grim/module.mk
@@ -111,6 +111,7 @@ MODULE_OBJS := \
 	lipsync.o \
 	localize.o \
 	lua.o \
+	lua_grim_patch.o \
 	lua_v1.o \
 	lua_v1_actor.o \
 	lua_v1_graphics.o \


### PR DESCRIPTION
This is a follow up to fix #13139 and #14987.
All saves created with the faulty patch get contaminated so we decontaminate them at load time by applying a minimized fixup.

This will avoid players to restart a game from scratch and any game saved again will get this fix.

This will address comment in #5692.