### PR TITLE
GUI/ALL: Display message when deleting a save fails

### DIFF
--- a/engines/access/metaengine.cpp
+++ b/engines/access/metaengine.cpp
@@ -79,7 +79,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
@@ -149,9 +149,9 @@ int AccessMetaEngine::getMaximumSaveSlot() const {
 	return MAX_SAVES;
 }
 
-void AccessMetaEngine::removeSaveState(const char *target, int slot) const {
+bool AccessMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String filename = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 SaveStateDescriptor AccessMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/adl/metaengine.cpp
+++ b/engines/adl/metaengine.cpp
@@ -166,7 +166,7 @@ public:
 	int getAutosaveSlot() const override { return 15; }
 	int getMaximumSaveSlot() const override { return 15; }
 	SaveStateList listSaves(const char *target) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 
 	Common::Error createInstance(OSystem *syst, Engine **engine, const AdlGameDescription *adlGd) const override;
 	Common::KeymapArray initKeymaps(const char *target) const override;
@@ -285,9 +285,9 @@ SaveStateList AdlMetaEngine::listSaves(const char *target) const {
 	return saveList;
 }
 
-void AdlMetaEngine::removeSaveState(const char *target, int slot) const {
+bool AdlMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String fileName = Common::String::format("%s.s%02d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	return g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
 Engine *HiRes1Engine_create(OSystem *syst, const AdlGameDescription *gd);

--- a/engines/agi/metaengine.cpp
+++ b/engines/agi/metaengine.cpp
@@ -208,7 +208,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
 	bool hasFeature(MetaEngineFeature f) const override;
@@ -306,9 +306,9 @@ SaveStateList AgiMetaEngine::listSaves(const char *target) const {
 	return saveList;
 }
 
-void AgiMetaEngine::removeSaveState(const char *target, int slot) const {
+bool AgiMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String fileName = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	return g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
 int AgiMetaEngine::getMaximumSaveSlot() const { return 999; }

--- a/engines/ags/metaengine.cpp
+++ b/engines/ags/metaengine.cpp
@@ -151,8 +151,8 @@ SaveStateDescriptor AGSMetaEngine::querySaveMetaInfos(const char *target, int sl
 	return SaveStateDescriptor();
 }
 
-void AGSMetaEngine::removeSaveState(const char *target, int slot) const {
-	g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
+bool AGSMetaEngine::removeSaveState(const char *target, int slot) const {
+	return g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 }
 
 int AGSMetaEngine::getAutosaveSlot() const {

--- a/engines/ags/metaengine.h
+++ b/engines/ags/metaengine.h
@@ -77,7 +77,7 @@ public:
 	 * @param target  Name of a config manager target.
 	 * @param slot    Slot number of the save state to be removed.
 	 */
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 
 	const Common::AchievementDescriptionList *getAchievementDescriptionList() const override;
 

--- a/engines/avalanche/metaengine.cpp
+++ b/engines/avalanche/metaengine.cpp
@@ -64,7 +64,7 @@ public:
 
 	int getMaximumSaveSlot() const override { return 99; }
 	SaveStateList listSaves(const char *target) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
@@ -137,9 +137,9 @@ SaveStateList AvalancheMetaEngine::listSaves(const char *target) const {
 	return saveList;
 }
 
-void AvalancheMetaEngine::removeSaveState(const char *target, int slot) const {
+bool AvalancheMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String fileName = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	return g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
 SaveStateDescriptor AvalancheMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/bbvs/metaengine.cpp
+++ b/engines/bbvs/metaengine.cpp
@@ -61,7 +61,7 @@ public:
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 
 	// Disable autosave (see mirrored method in bbvs.h for detailed explanation)
 	int getAutosaveSlot() const override { return -1; }
@@ -80,9 +80,9 @@ bool BbvsMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSimpleSavesNames);
 }
 
-void BbvsMetaEngine::removeSaveState(const char *target, int slot) const {
+bool BbvsMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String fileName = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	return g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
 Common::KeymapArray BbvsMetaEngine::initKeymaps(const char *target) const {

--- a/engines/bladerunner/metaengine.cpp
+++ b/engines/bladerunner/metaengine.cpp
@@ -135,7 +135,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	// Disable autosave (see mirrored method in bladerunner.h for detailed explanation)
 	int getAutosaveSlot() const override { return -1; }
@@ -393,8 +393,8 @@ int BladeRunnerMetaEngine::getMaximumSaveSlot() const {
 	return 999;
 }
 
-void BladeRunnerMetaEngine::removeSaveState(const char *target, int slot) const {
-	BladeRunner::SaveFileManager::remove(target, slot);
+bool BladeRunnerMetaEngine::removeSaveState(const char *target, int slot) const {
+	return BladeRunner::SaveFileManager::remove(target, slot);
 }
 
 SaveStateDescriptor BladeRunnerMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/bladerunner/savefile.cpp
+++ b/engines/bladerunner/savefile.cpp
@@ -92,9 +92,9 @@ Common::OutSaveFile *SaveFileManager::openForSaving(const Common::String &target
 	return g_system->getSavefileManager()->openForSaving(filename);
 }
 
-void SaveFileManager::remove(const Common::String &target, int slot) {
+bool SaveFileManager::remove(const Common::String &target, int slot) {
 	Common::String filename = Common::String::format("%s.%03d", target.c_str(), slot);
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 bool SaveFileManager::readHeader(Common::SeekableReadStream &in, SaveFileHeader &header, bool skipThumbnail) {

--- a/engines/bladerunner/savefile.h
+++ b/engines/bladerunner/savefile.h
@@ -78,7 +78,7 @@ public:
 	static Common::InSaveFile *openForLoading(const Common::String &target, int slot);
 	static Common::OutSaveFile *openForSaving(const Common::String &target, int slot);
 
-	static void remove(const Common::String &target, int slot);
+	static bool remove(const Common::String &target, int slot);
 
 	static bool readHeader(Common::SeekableReadStream &in, SaveFileHeader &header, bool skipThumbnail = true);
 	static bool writeHeader(Common::WriteStream &out, SaveFileHeader &header);

--- a/engines/cge/metaengine.cpp
+++ b/engines/cge/metaengine.cpp
@@ -83,7 +83,7 @@ public:
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	Common::KeymapArray initKeymaps(const char *target) const override;
 };
 
@@ -99,9 +99,9 @@ bool CGEMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSimpleSavesNames);
 }
 
-void CGEMetaEngine::removeSaveState(const char *target, int slot) const {
+bool CGEMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String fileName = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	return g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
 int CGEMetaEngine::getMaximumSaveSlot() const {

--- a/engines/cge2/metaengine.cpp
+++ b/engines/cge2/metaengine.cpp
@@ -96,7 +96,7 @@ public:
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	Common::KeymapArray initKeymaps(const char *target) const override;
 };
 
@@ -201,9 +201,9 @@ SaveStateDescriptor CGE2MetaEngine::querySaveMetaInfos(const char *target, int s
 	return SaveStateDescriptor();
 }
 
-void CGE2MetaEngine::removeSaveState(const char *target, int slot) const {
+bool CGE2MetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String fileName = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	return g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
 Common::KeymapArray CGE2MetaEngine::initKeymaps(const char *target) const {

--- a/engines/cine/metaengine.cpp
+++ b/engines/cine/metaengine.cpp
@@ -93,7 +93,7 @@ public:
 	bool hasFeature(MetaEngineFeature f) const override;
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	Common::String getSavegameFile(int saveGameIdx, const char *target = nullptr) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	
@@ -435,9 +435,9 @@ Common::KeymapArray CineMetaEngine::initKeymaps(const char *target) const {
 	return keymaps;
 }
 
-void CineMetaEngine::removeSaveState(const char *target, int slot) const {
+bool CineMetaEngine::removeSaveState(const char *target, int slot) const {
 	if (slot < 0 || slot >= MAX_SAVEGAMES) {
-		return;
+		return false;
 	}
 
 	// Load savegame descriptions from index file
@@ -453,7 +453,7 @@ void CineMetaEngine::removeSaveState(const char *target, int slot) const {
 	in = g_system->getSavefileManager()->openForLoading(Common::String::format("%s.dir", target));
 
 	if (!in)
-		return;
+		return false;
 
 	in->read(saveNames, SAVELIST_SIZE);
 	delete in;
@@ -468,7 +468,7 @@ void CineMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::OutSaveFile *out = g_system->getSavefileManager()->openForSaving(indexFile);
 	if (!out) {
 		warning("Unable to open file %s for saving", indexFile.c_str());
-		return;
+		return false;
 	}
 
 	out->write(saveNames, SAVELIST_SIZE);
@@ -477,7 +477,7 @@ void CineMetaEngine::removeSaveState(const char *target, int slot) const {
 	// Delete save file
 	Common::String saveFileName = getSavegameFile(slot, target);
 
-	g_system->getSavefileManager()->removeSavefile(saveFileName);
+	return g_system->getSavefileManager()->removeSavefile(saveFileName);
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(CINE)

--- a/engines/cruise/metaengine.cpp
+++ b/engines/cruise/metaengine.cpp
@@ -59,7 +59,7 @@ public:
 	int getMaximumSaveSlot() const override { return 99; }
 
 	SaveStateList listSaves(const char *target) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	Common::Error createInstance(OSystem *syst, Engine **engine, const Cruise::CRUISEGameDescription *desc) const override;
 
@@ -103,8 +103,8 @@ SaveStateList CruiseMetaEngine::listSaves(const char *target) const {
 	return saveList;
 }
 
-void CruiseMetaEngine::removeSaveState(const char *target, int slot) const {
-	g_system->getSavefileManager()->removeSavefile(Cruise::CruiseEngine::getSavegameFile(slot));
+bool CruiseMetaEngine::removeSaveState(const char *target, int slot) const {
+	return g_system->getSavefileManager()->removeSavefile(Cruise::CruiseEngine::getSavegameFile(slot));
 }
 
 SaveStateDescriptor CruiseMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/cryomni3d/metaengine.cpp
+++ b/engines/cryomni3d/metaengine.cpp
@@ -77,7 +77,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override { return 999; }
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (!target)
 			target = getName();
@@ -128,8 +128,8 @@ SaveStateList CryOmni3DMetaEngine::listSaves(const char *target) const {
 	return saveList;
 }
 
-void CryOmni3DMetaEngine::removeSaveState(const char *target, int slot) const {
-	g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
+bool CryOmni3DMetaEngine::removeSaveState(const char *target, int slot) const {
+	return g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 }
 
 Common::Error CryOmni3DMetaEngine::createInstance(OSystem *syst, Engine **engine,

--- a/engines/dm/metaengine.cpp
+++ b/engines/dm/metaengine.cpp
@@ -108,7 +108,7 @@ public:
 		return SaveStateDescriptor();
 	}
 
-	void removeSaveState(const char *target, int slot) const override {}
+	bool removeSaveState(const char *target, int slot) const override { return false; }
 
 };
 

--- a/engines/draci/metaengine.cpp
+++ b/engines/draci/metaengine.cpp
@@ -41,7 +41,7 @@ public:
 	bool hasFeature(MetaEngineFeature f) const override;
 	int getMaximumSaveSlot() const override { return 99; }
 	SaveStateList listSaves(const char *target) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
@@ -88,8 +88,8 @@ SaveStateList DraciMetaEngine::listSaves(const char *target) const {
 	return saveList;
 }
 
-void DraciMetaEngine::removeSaveState(const char *target, int slot) const {
-	g_system->getSavefileManager()->removeSavefile(Draci::DraciEngine::getSavegameFile(slot));
+bool DraciMetaEngine::removeSaveState(const char *target, int slot) const {
+	return g_system->getSavefileManager()->removeSavefile(Draci::DraciEngine::getSavegameFile(slot));
 }
 
 SaveStateDescriptor DraciMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/dragons/metaengine.cpp
+++ b/engines/dragons/metaengine.cpp
@@ -41,7 +41,7 @@ public:
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	Common::KeymapArray initKeymaps(const char *target) const override;
 };
 
@@ -56,9 +56,9 @@ bool DragonsMetaEngine::hasFeature(MetaEngineFeature f) const {
 			(f == kSavesSupportCreationDate);
 }
 
-void DragonsMetaEngine::removeSaveState(const char *target, int slot) const {
+bool DragonsMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String fileName = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	return g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
 int DragonsMetaEngine::getMaximumSaveSlot() const {

--- a/engines/drascula/metaengine.cpp
+++ b/engines/drascula/metaengine.cpp
@@ -89,7 +89,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
@@ -167,9 +167,9 @@ SaveStateDescriptor DrasculaMetaEngine::querySaveMetaInfos(const char *target, i
 
 int DrasculaMetaEngine::getMaximumSaveSlot() const { return 999; }
 
-void DrasculaMetaEngine::removeSaveState(const char *target, int slot) const {
+bool DrasculaMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String fileName = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	return g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
 Common::Error DrasculaMetaEngine::createInstance(OSystem *syst, Engine **engine, const Drascula::DrasculaGameDescription *desc) const {

--- a/engines/dreamweb/metaengine.cpp
+++ b/engines/dreamweb/metaengine.cpp
@@ -111,7 +111,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (saveGameIdx == kSavegameFilePattern)
@@ -179,9 +179,9 @@ SaveStateList DreamWebMetaEngine::listSaves(const char *target) const {
 
 int DreamWebMetaEngine::getMaximumSaveSlot() const { return 99; }
 
-void DreamWebMetaEngine::removeSaveState(const char *target, int slot) const {
+bool DreamWebMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String fileName = Common::String::format("DREAMWEB.D%02d", slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	return g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
 SaveStateDescriptor DreamWebMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/efh/metaengine.cpp
+++ b/engines/efh/metaengine.cpp
@@ -69,7 +69,7 @@ public:
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 };
 
 Common::Error EfhMetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const {
@@ -187,9 +187,9 @@ SaveStateDescriptor EfhMetaEngine::querySaveMetaInfos(const char *target, int sl
 	return SaveStateDescriptor();
 }
 
-void EfhMetaEngine::removeSaveState(const char *target, int slot) const {
+bool EfhMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String fileName = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	return g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
 } // End of namespace Efh

--- a/engines/glk/metaengine.cpp
+++ b/engines/glk/metaengine.cpp
@@ -86,7 +86,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
@@ -246,9 +246,9 @@ int GlkMetaEngine::getMaximumSaveSlot() const {
 	return MAX_SAVES;
 }
 
-void GlkMetaEngine::removeSaveState(const char *target, int slot) const {
+bool GlkMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String filename = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 SaveStateDescriptor GlkMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/gnap/metaengine.cpp
+++ b/engines/gnap/metaengine.cpp
@@ -40,7 +40,7 @@ public:
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 };
 
 bool GnapMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -61,9 +61,9 @@ bool Gnap::GnapEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsSavingDuringRuntime);
 }
 
-void GnapMetaEngine::removeSaveState(const char *target, int slot) const {
+bool GnapMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String fileName = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	return g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
 int GnapMetaEngine::getMaximumSaveSlot() const { return 99; }

--- a/engines/groovie/metaengine.cpp
+++ b/engines/groovie/metaengine.cpp
@@ -137,7 +137,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	int getAutosaveSlot() const override;
 
@@ -171,14 +171,14 @@ int GroovieMetaEngine::getMaximumSaveSlot() const {
 	return SaveLoad::getMaximumSlot();
 }
 
-void GroovieMetaEngine::removeSaveState(const char *target, int slot) const {
+bool GroovieMetaEngine::removeSaveState(const char *target, int slot) const {
 	if (!SaveLoad::isSlotValid(slot)) {
 		// Invalid slot, do nothing
-		return;
+		return false;
 	}
 
 	Common::String filename = SaveLoad::getSlotSaveName(target, slot);
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 SaveStateDescriptor GroovieMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/hdb/metaengine.cpp
+++ b/engines/hdb/metaengine.cpp
@@ -91,7 +91,7 @@ public:
 	bool hasFeature(MetaEngineFeature f) const override;
 	int getMaximumSaveSlot() const override;
 
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	Common::KeymapArray initKeymaps(const char *target) const override;
@@ -115,9 +115,9 @@ bool HDB::HDBGame::hasFeature(Engine::EngineFeature f) const {
 		   (f == kSupportsSavingDuringRuntime);
 }
 
-void HDBMetaEngine::removeSaveState(const char *target, int slot) const {
+bool HDBMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String fileName = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	return g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
 int HDBMetaEngine::getMaximumSaveSlot() const { return 99; }

--- a/engines/hopkins/metaengine.cpp
+++ b/engines/hopkins/metaengine.cpp
@@ -105,7 +105,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
 	Common::KeymapArray initKeymaps(const char *target) const override;
@@ -170,9 +170,9 @@ int HopkinsMetaEngine::getMaximumSaveSlot() const {
 	return MAX_SAVES;
 }
 
-void HopkinsMetaEngine::removeSaveState(const char *target, int slot) const {
+bool HopkinsMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String filename = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 SaveStateDescriptor HopkinsMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/hugo/metaengine.cpp
+++ b/engines/hugo/metaengine.cpp
@@ -58,7 +58,7 @@ public:
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (!target)
 			target = getName();
@@ -335,8 +335,8 @@ SaveStateDescriptor HugoMetaEngine::querySaveMetaInfos(const char *target, int s
 	return desc;
 }
 
-void HugoMetaEngine::removeSaveState(const char *target, int slot) const {
-	g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
+bool HugoMetaEngine::removeSaveState(const char *target, int slot) const {
+	return g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 }
 
 } // End of namespace Hugo

--- a/engines/illusions/metaengine.cpp
+++ b/engines/illusions/metaengine.cpp
@@ -61,7 +61,7 @@ public:
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 
 	Common::KeymapArray initKeymaps(const char *target) const override;
 };
@@ -77,9 +77,9 @@ bool IllusionsMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportCreationDate);
 }
 
-void IllusionsMetaEngine::removeSaveState(const char *target, int slot) const {
+bool IllusionsMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String fileName = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	return g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
 Common::KeymapArray IllusionsMetaEngine::initKeymaps(const char *target) const {

--- a/engines/kingdom/metaengine.cpp
+++ b/engines/kingdom/metaengine.cpp
@@ -48,7 +48,7 @@ public:
 
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
@@ -108,9 +108,9 @@ SaveStateList KingdomMetaEngine::listSaves(const char *target) const {
 	return saveList;
 }
 
-void KingdomMetaEngine::removeSaveState(const char *target, int slot) const {
+bool KingdomMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String filename = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 SaveStateDescriptor KingdomMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/kyra/metaengine.cpp
+++ b/engines/kyra/metaengine.cpp
@@ -183,7 +183,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	int getAutosaveSlot() const override { return 999; }
 
@@ -312,16 +312,16 @@ int KyraMetaEngine::getMaximumSaveSlot() const {
 	return 999;
 }
 
-void KyraMetaEngine::removeSaveState(const char *target, int slot) const {
+bool KyraMetaEngine::removeSaveState(const char *target, int slot) const {
 	// In Kyra games slot 0 can't be deleted, it's for restarting the game(s).
 	// An exception makes Lands of Lore here, it does not have any way to restart the
 	// game except via its main menu.
 	const Common::String gameId = ConfMan.getDomain(target)->getVal("gameid");
 	if (slot == 0 && !gameId.equalsIgnoreCase("lol") && !gameId.equalsIgnoreCase("eob") && !gameId.equalsIgnoreCase("eob2"))
-		return;
+		return false;
 
 	Common::String filename = Kyra::KyraEngine_v1::getSavegameFilename(target, slot);
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 SaveStateDescriptor KyraMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/lab/metaengine.cpp
+++ b/engines/lab/metaengine.cpp
@@ -56,7 +56,7 @@ public:
 	bool hasFeature(MetaEngineFeature f) const override;
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
@@ -113,9 +113,9 @@ int LabMetaEngine::getMaximumSaveSlot() const {
 	return 999;
 }
 
-void LabMetaEngine::removeSaveState(const char *target, int slot) const {
+bool LabMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
-	saveFileMan->removeSavefile(Common::String::format("%s.%03u", target, slot));
+	return saveFileMan->removeSavefile(Common::String::format("%s.%03u", target, slot));
 }
 
 SaveStateDescriptor LabMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/lastexpress/game/savegame.cpp
+++ b/engines/lastexpress/game/savegame.cpp
@@ -945,9 +945,9 @@ Common::OutSaveFile *SaveLoad::openForSaving(const Common::String &target, GameI
 	return save;
 }
 
-void SaveLoad::remove(const Common::String &target, GameId id) {
+bool SaveLoad::remove(const Common::String &target, GameId id) {
 	Common::String filename = getFilename(target, id);
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 } // End of namespace LastExpress

--- a/engines/lastexpress/game/savegame.h
+++ b/engines/lastexpress/game/savegame.h
@@ -167,7 +167,7 @@ public:
 	void saveVolumeBrightness();
 
 	static SaveStateList list(const MetaEngine *metaEngine, const Common::String &target);
-	static void remove(const Common::String &target, GameId slot);
+	static bool remove(const Common::String &target, GameId slot);
 
 	// Opening save files
 	static Common::String getFilename(const Common::String &target, GameId slot);

--- a/engines/lastexpress/metaengine.cpp
+++ b/engines/lastexpress/metaengine.cpp
@@ -35,7 +35,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 
 protected:
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
@@ -64,8 +64,8 @@ int LastExpressMetaEngine::getMaximumSaveSlot() const {
 	return LastExpress::SaveLoad::kMaximumSaveSlots - 1;
 }
 
-void LastExpressMetaEngine::removeSaveState(const char *target, int slot) const {
-	LastExpress::SaveLoad::remove(target, (LastExpress::GameId)slot);
+bool LastExpressMetaEngine::removeSaveState(const char *target, int slot) const {
+	return LastExpress::SaveLoad::remove(target, (LastExpress::GameId)slot);
 }
 
 } // End of namespace LastExpress

--- a/engines/lilliput/metaengine.cpp
+++ b/engines/lilliput/metaengine.cpp
@@ -55,7 +55,7 @@ public:
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (!target)
 			target = getName();
@@ -182,8 +182,8 @@ SaveStateDescriptor LilliputMetaEngine::querySaveMetaInfos(const char *target, i
 	return SaveStateDescriptor();
 }
 
-void LilliputMetaEngine::removeSaveState(const char *target, int slot) const {
-	g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
+bool LilliputMetaEngine::removeSaveState(const char *target, int slot) const {
+	return g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 }
 
 } // End of namespace Lilliput

--- a/engines/lure/metaengine.cpp
+++ b/engines/lure/metaengine.cpp
@@ -99,7 +99,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 
 	Common::KeymapArray initKeymaps(const char *target) const override;
 };
@@ -154,11 +154,11 @@ SaveStateList LureMetaEngine::listSaves(const char *target) const {
 
 int LureMetaEngine::getMaximumSaveSlot() const { return 999; }
 
-void LureMetaEngine::removeSaveState(const char *target, int slot) const {
+bool LureMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String filename = target;
 	filename += Common::String::format(".%03d", slot);
 
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 Common::KeymapArray LureMetaEngine::initKeymaps(const char *target) const {

--- a/engines/macventure/metaengine.cpp
+++ b/engines/macventure/metaengine.cpp
@@ -50,7 +50,7 @@ protected:
 	bool hasFeature(MetaEngineFeature f) const override;
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
 };
@@ -113,8 +113,8 @@ Common::Error MacVentureMetaEngine::createInstance(OSystem *syst, Engine **engin
 	return Common::kNoError;
 }
 
-void MacVentureMetaEngine::removeSaveState(const char *target, int slot) const {
-	g_system->getSavefileManager()->removeSavefile(Common::String::format("%s.%03d", target, slot));
+bool MacVentureMetaEngine::removeSaveState(const char *target, int slot) const {
+	return g_system->getSavefileManager()->removeSavefile(Common::String::format("%s.%03d", target, slot));
 }
 
 

--- a/engines/mads/metaengine.cpp
+++ b/engines/mads/metaengine.cpp
@@ -175,7 +175,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
 	Common::KeymapArray initKeymaps(const char *target) const override;
@@ -237,9 +237,9 @@ int MADSMetaEngine::getMaximumSaveSlot() const {
 	return MAX_SAVES;
 }
 
-void MADSMetaEngine::removeSaveState(const char *target, int slot) const {
+bool MADSMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String filename = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 SaveStateDescriptor MADSMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -442,11 +442,11 @@ GUI::OptionsContainerWidget *MetaEngine::buildEngineOptionsWidget(GUI::GuiObject
 	return new GUI::ExtraGuiOptionsWidget(boss, name, target, engineOptions);
 }
 
-void MetaEngine::removeSaveState(const char *target, int slot) const {
+bool MetaEngine::removeSaveState(const char *target, int slot) const {
 	if (!hasFeature(kSavesUseExtendedFormat))
-		return;
+		return false;
 
-	g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
+	return g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 }
 
 SaveStateDescriptor MetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -345,7 +345,7 @@ public:
 	 * @param target  Name of a config manager target.
 	 * @param slot    Slot number of the save state to be removed.
 	 */
-	virtual void removeSaveState(const char *target, int slot) const;
+	virtual bool removeSaveState(const char *target, int slot) const;
 
 	/**
 	 * Return meta information from the specified save state.

--- a/engines/mohawk/metaengine.cpp
+++ b/engines/mohawk/metaengine.cpp
@@ -133,7 +133,7 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateList listSavesForPrefix(const char *prefix, const char *extension) const;
 	int getMaximumSaveSlot() const override { return 999; }
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
 	Common::KeymapArray initKeymaps(const char *target) const override;
@@ -229,20 +229,21 @@ SaveStateList MohawkMetaEngine::listSaves(const char *target) const {
 	return saveList;
 }
 
-void MohawkMetaEngine::removeSaveState(const char *target, int slot) const {
+bool MohawkMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String gameId = ConfMan.get("gameid", target);
 
 	// Removing saved games is only supported in Myst/Riven currently.
 #ifdef ENABLE_MYST
 	if (gameId == "myst") {
-		Mohawk::MystGameState::deleteSave(slot);
+		return Mohawk::MystGameState::deleteSave(slot);
 	}
 #endif
 #ifdef ENABLE_RIVEN
 	if (gameId == "riven") {
-		Mohawk::RivenSaveLoad::deleteSave(slot);
+		return Mohawk::RivenSaveLoad::deleteSave(slot);
 	}
 #endif
+	return false;
 }
 
 SaveStateDescriptor MohawkMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/mohawk/myst_state.cpp
+++ b/engines/mohawk/myst_state.cpp
@@ -514,14 +514,16 @@ void MystGameState::syncGameState(Common::Serializer &s, bool isME) {
 		warning("Unexpected File Position 0x%03X At End of Save/Load", s.bytesSynced());
 }
 
-void MystGameState::deleteSave(int slot) {
+bool MystGameState::deleteSave(int slot) {
 	Common::String filename = buildSaveFilename(slot);
 	Common::String metadataFilename = buildMetadataFilename(slot);
 
 	debugC(kDebugSaveLoad, "Deleting save file \'%s\'", filename.c_str());
 
-	g_system->getSavefileManager()->removeSavefile(filename);
-	g_system->getSavefileManager()->removeSavefile(metadataFilename);
+	bool success = true;
+	success &= g_system->getSavefileManager()->removeSavefile(filename);
+	success &= g_system->getSavefileManager()->removeSavefile(metadataFilename);
+	return success;
 }
 
 void MystGameState::addZipDest(MystStack stack, uint16 view) {

--- a/engines/mohawk/myst_state.h
+++ b/engines/mohawk/myst_state.h
@@ -110,7 +110,7 @@ public:
 	void reset();
 	bool load(int slot);
 	bool save(int slot, const Common::String &desc, const Graphics::Surface *thumbnail, bool autosave);
-	static void deleteSave(int slot);
+	static bool deleteSave(int slot);
 
 	void addZipDest(MystStack stack, uint16 view);
 	bool isReachableZipDest(MystStack stack, uint16 view);

--- a/engines/mohawk/riven_saveload.cpp
+++ b/engines/mohawk/riven_saveload.cpp
@@ -591,11 +591,11 @@ Common::Error RivenSaveLoad::saveGame(const int slot, const Common::String &desc
 	return Common::kNoError;
 }
 
-void RivenSaveLoad::deleteSave(const int slot) {
+bool RivenSaveLoad::deleteSave(const int slot) {
 	Common::String filename = buildSaveFilename(slot);
 
 	debug (0, "Deleting save file \'%s\'", filename.c_str());
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 } // End of namespace Mohawk

--- a/engines/mohawk/riven_saveload.h
+++ b/engines/mohawk/riven_saveload.h
@@ -64,7 +64,7 @@ public:
 	Common::Error loadGame(const int slot);
 	Common::Error saveGame(const int slot, const Common::String &description,
 	                       const Graphics::Surface *thumbnail, bool autoSave);
-	static void deleteSave(const int slot);
+	static bool deleteSave(const int slot);
 
 	static SaveStateDescriptor querySaveMetaInfos(const int slot);
 	static Common::String querySaveDescription(const int slot);

--- a/engines/myst3/metaengine.cpp
+++ b/engines/myst3/metaengine.cpp
@@ -143,9 +143,9 @@ public:
 		return saveInfos;
 	}
 
-	void removeSaveState(const char *target, int slot) const override {
+	bool removeSaveState(const char *target, int slot) const override {
 		SaveStateDescriptor saveInfos = getSaveDescription(target, slot);
-		g_system->getSavefileManager()->removeSavefile(saveInfos.getDescription());
+		return g_system->getSavefileManager()->removeSavefile(saveInfos.getDescription());
 	}
 
 	int getMaximumSaveSlot() const override {

--- a/engines/neverhood/metaengine.cpp
+++ b/engines/neverhood/metaengine.cpp
@@ -71,7 +71,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
@@ -132,10 +132,10 @@ int NeverhoodMetaEngine::getMaximumSaveSlot() const {
 	return 999;
 }
 
-void NeverhoodMetaEngine::removeSaveState(const char *target, int slot) const {
+bool NeverhoodMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
 	Common::String filename = Neverhood::NeverhoodEngine::getSavegameFilename(target, slot);
-	saveFileMan->removeSavefile(filename.c_str());
+	return saveFileMan->removeSavefile(filename.c_str());
 }
 
 SaveStateDescriptor NeverhoodMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/parallaction/metaengine.cpp
+++ b/engines/parallaction/metaengine.cpp
@@ -55,7 +55,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (!target)
 			target = getName();
@@ -183,8 +183,8 @@ SaveStateList ParallactionMetaEngine::listSaves(const char *target) const {
 
 int ParallactionMetaEngine::getMaximumSaveSlot() const { return 99; }
 
-void ParallactionMetaEngine::removeSaveState(const char *target, int slot) const {
-	g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
+bool ParallactionMetaEngine::removeSaveState(const char *target, int slot) const {
+	return g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(PARALLACTION)

--- a/engines/pegasus/metaengine.cpp
+++ b/engines/pegasus/metaengine.cpp
@@ -75,7 +75,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override { return 999; }
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	Common::KeymapArray initKeymaps(const char *target) const override;
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (saveGameIdx == kSavegameFilePattern)
@@ -117,10 +117,10 @@ SaveStateList PegasusMetaEngine::listSaves(const char *target) const {
 	return saveList;
 }
 
-void PegasusMetaEngine::removeSaveState(const char *target, int slot) const {
+bool PegasusMetaEngine::removeSaveState(const char *target, int slot) const {
 	// See listSaves() for info on the pattern
 	Common::StringArray fileNames = Pegasus::PegasusEngine::listSaveFiles();
-	g_system->getSavefileManager()->removeSavefile(fileNames[slot].c_str());
+	return g_system->getSavefileManager()->removeSavefile(fileNames[slot].c_str());
 }
 
 Common::KeymapArray PegasusMetaEngine::initKeymaps(const char *target) const {

--- a/engines/petka/metaengine.cpp
+++ b/engines/petka/metaengine.cpp
@@ -35,7 +35,7 @@ public:
 	bool hasFeature(MetaEngineFeature f) const override;
 	int getMaximumSaveSlot() const override { return 17; }
 	SaveStateList listSaves(const char *target) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 };
@@ -76,8 +76,8 @@ SaveStateList PetkaMetaEngine::listSaves(const char *target) const {
 	return saveList;
 }
 
-void PetkaMetaEngine::removeSaveState(const char *target, int slot) const {
-	g_system->getSavefileManager()->removeSavefile(Petka::generateSaveName(slot, target));
+bool PetkaMetaEngine::removeSaveState(const char *target, int slot) const {
+	return g_system->getSavefileManager()->removeSavefile(Petka::generateSaveName(slot, target));
 }
 
 SaveStateDescriptor PetkaMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/pink/metaengine.cpp
+++ b/engines/pink/metaengine.cpp
@@ -43,7 +43,7 @@ public:
 
 	int getMaximumSaveSlot() const override { return 99; }
 	SaveStateList listSaves(const char *target) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
@@ -85,8 +85,8 @@ SaveStateList PinkMetaEngine::listSaves(const char *target) const {
 	return saveList;
 }
 
-void PinkMetaEngine::removeSaveState(const char *target, int slot) const {
-	g_system->getSavefileManager()->removeSavefile(Pink::generateSaveName(slot, target));
+bool PinkMetaEngine::removeSaveState(const char *target, int slot) const {
+	return g_system->getSavefileManager()->removeSavefile(Pink::generateSaveName(slot, target));
 }
 
 SaveStateDescriptor PinkMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/prince/metaengine.cpp
+++ b/engines/prince/metaengine.cpp
@@ -55,7 +55,7 @@ public:
 	int getMaximumSaveSlot() const override { return 99; }
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 };
 
 bool PrinceMetaEngine::hasFeature(MetaEngineFeature f) const {
@@ -153,9 +153,9 @@ SaveStateDescriptor PrinceMetaEngine::querySaveMetaInfos(const char *target, int
 	return SaveStateDescriptor();
 }
 
-void PrinceMetaEngine::removeSaveState(const char *target, int slot) const {
+bool PrinceMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String fileName = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	return g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
 Common::Error PrinceMetaEngine::createInstance(OSystem *syst, Engine **engine, const Prince::PrinceGameDescription *desc) const {

--- a/engines/queen/metaengine.cpp
+++ b/engines/queen/metaengine.cpp
@@ -70,7 +70,7 @@ public:
 	Common::Error createInstance(OSystem *syst, Engine **engine, const Queen::QueenGameDescription *desc) const override;
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override { return 99; }
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	int getAutosaveSlot() const override { return 99; }
 };
 
@@ -111,10 +111,10 @@ SaveStateList QueenMetaEngine::listSaves(const char *target) const {
 	return saveList;
 }
 
-void QueenMetaEngine::removeSaveState(const char *target, int slot) const {
+bool QueenMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String filename = Common::String::format("queen.s%02d", slot);
 
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 Common::Error QueenMetaEngine::createInstance(OSystem *syst, Engine **engine, const Queen::QueenGameDescription *desc) const {

--- a/engines/saga/metaengine.cpp
+++ b/engines/saga/metaengine.cpp
@@ -106,7 +106,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
 	Common::KeymapArray initKeymaps(const char *target) const override;
@@ -179,11 +179,11 @@ SaveStateList SagaMetaEngine::listSaves(const char *target) const {
 
 int SagaMetaEngine::getMaximumSaveSlot() const { return MAX_SAVES - 1; }
 
-void SagaMetaEngine::removeSaveState(const char *target, int slot) const {
+bool SagaMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String filename = target;
 	filename += Common::String::format(".s%02d", slot);
 
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 SaveStateDescriptor SagaMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/sci/metaengine.cpp
+++ b/engines/sci/metaengine.cpp
@@ -190,7 +190,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	// Disable autosave (see mirrored method in sci.h for detailed explanation)
 	int getAutosaveSlot() const override { return -1; }
@@ -345,9 +345,9 @@ SaveStateDescriptor SciMetaEngine::querySaveMetaInfos(const char *target, int sl
 
 int SciMetaEngine::getMaximumSaveSlot() const { return 99; }
 
-void SciMetaEngine::removeSaveState(const char *target, int slot) const {
+bool SciMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String fileName = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	return g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
 Common::Error SciEngine::loadGameState(int slot) {

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -540,9 +540,9 @@ SaveStateList ScummMetaEngine::listSaves(const char *target) const {
 	return saveList;
 }
 
-void ScummMetaEngine::removeSaveState(const char *target, int slot) const {
+bool ScummMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String filename = ScummEngine::makeSavegameName(target, slot, false);
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 SaveStateDescriptor ScummMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/scumm/metaengine.h
+++ b/engines/scumm/metaengine.h
@@ -34,7 +34,7 @@ class ScummMetaEngine : public MetaEngine {
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
 	const ExtraGuiOptions getExtraGuiOptions(const Common::String &target) const override;

--- a/engines/sherlock/metaengine.cpp
+++ b/engines/sherlock/metaengine.cpp
@@ -169,7 +169,7 @@ public:
 	/**
 	 * Deletes a savegame in the specified slot
 	 */
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 
 	/**
 	 * Given a specified savegame slot, returns extended information for the save
@@ -222,9 +222,9 @@ int SherlockMetaEngine::getMaximumSaveSlot() const {
 	return MAX_SAVEGAME_SLOTS;
 }
 
-void SherlockMetaEngine::removeSaveState(const char *target, int slot) const {
+bool SherlockMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String filename = Sherlock::SaveManager(nullptr, target).generateSaveName(slot);
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 SaveStateDescriptor SherlockMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/sky/metaengine.cpp
+++ b/engines/sky/metaengine.cpp
@@ -51,7 +51,7 @@ class SkyMetaEngine : public MetaEngine {
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
 	Common::KeymapArray initKeymaps(const char *target) const override;
@@ -227,7 +227,7 @@ SaveStateList SkyMetaEngine::listSaves(const char *target) const {
 
 int SkyMetaEngine::getMaximumSaveSlot() const { return MAX_SAVE_GAMES; }
 
-void SkyMetaEngine::removeSaveState(const char *target, int slot) const {
+bool SkyMetaEngine::removeSaveState(const char *target, int slot) const {
 	if (slot == 0)	{
 		// Do not delete the auto save
 		// Note: Setting the autosave slot as write protected (with setWriteProtectedFlag())
@@ -235,7 +235,7 @@ void SkyMetaEngine::removeSaveState(const char *target, int slot) const {
 		const Common::U32String message = _("WARNING: Deleting the autosave slot is not supported by this engine");
 		GUI::MessageDialog warn(message);
 		warn.runModal();
-		return;
+		return false;
 	}
 
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
@@ -279,6 +279,7 @@ void SkyMetaEngine::removeSaveState(const char *target, int slot) const {
 	}
 	if (ioFailed)
 		warning("Unable to store Savegame names to file SKY-VM.SAV. (%s)", saveFileMan->popErrorDesc().c_str());
+	return !ioFailed;
 }
 
 SaveStateDescriptor SkyMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/stark/metaengine.cpp
+++ b/engines/stark/metaengine.cpp
@@ -157,9 +157,9 @@ public:
 		return descriptor;
 	}
 
-	void removeSaveState(const char *target, int slot) const override {
+	bool removeSaveState(const char *target, int slot) const override {
 		Common::String filename = StarkEngine::formatSaveName(target, slot);
-		g_system->getSavefileManager()->removeSavefile(filename);
+		return g_system->getSavefileManager()->removeSavefile(filename);
 	}
 
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override {

--- a/engines/startrek/metaengine.cpp
+++ b/engines/startrek/metaengine.cpp
@@ -64,7 +64,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
@@ -132,9 +132,9 @@ int StarTrekMetaEngine::getMaximumSaveSlot() const {
 	return 999;
 }
 
-void StarTrekMetaEngine::removeSaveState(const char *target, int slot) const {
+bool StarTrekMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String fileName = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	return g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
 SaveStateDescriptor StarTrekMetaEngine::querySaveMetaInfos(const char *target, int slotNr) const {

--- a/engines/supernova/metaengine.cpp
+++ b/engines/supernova/metaengine.cpp
@@ -72,7 +72,7 @@ public:
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 
 	SaveStateList listSaves(const char *target) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	int getMaximumSaveSlot() const override {
 		return 99;
 	}
@@ -144,8 +144,8 @@ SaveStateList SupernovaMetaEngine::listSaves(const char *target) const {
 	return saveFileList;
 }
 
-void SupernovaMetaEngine::removeSaveState(const char *target, int slot) const {
-	g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
+bool SupernovaMetaEngine::removeSaveState(const char *target, int slot) const {
+	return g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 }
 
 SaveStateDescriptor SupernovaMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/sword1/metaengine.cpp
+++ b/engines/sword1/metaengine.cpp
@@ -215,7 +215,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 
 	GUI::OptionsContainerWidget *buildEngineOptionsWidget(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const override;
@@ -341,8 +341,8 @@ SaveStateList SwordMetaEngine::listSaves(const char *target) const {
 
 int SwordMetaEngine::getMaximumSaveSlot() const { return 999; }
 
-void SwordMetaEngine::removeSaveState(const char *target, int slot) const {
-	g_system->getSavefileManager()->removeSavefile(Common::String::format("sword1.%03d", slot));
+bool SwordMetaEngine::removeSaveState(const char *target, int slot) const {
+	return g_system->getSavefileManager()->removeSavefile(Common::String::format("sword1.%03d", slot));
 }
 
 SaveStateDescriptor SwordMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/sword2/metaengine.cpp
+++ b/engines/sword2/metaengine.cpp
@@ -67,7 +67,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 };
@@ -120,11 +120,11 @@ SaveStateList Sword2MetaEngine::listSaves(const char *target) const {
 
 int Sword2MetaEngine::getMaximumSaveSlot() const { return 999; }
 
-void Sword2MetaEngine::removeSaveState(const char *target, int slot) const {
+bool Sword2MetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String filename = target;
 	filename += Common::String::format(".%03d", slot);
 
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 Common::Error Sword2MetaEngine::createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const {

--- a/engines/teenagent/metaengine.cpp
+++ b/engines/teenagent/metaengine.cpp
@@ -97,8 +97,8 @@ public:
 		return MAX_SAVES - 1;
 	}
 
-	void removeSaveState(const char *target, int slot) const override {
-		g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
+	bool removeSaveState(const char *target, int slot) const override {
+		return g_system->getSavefileManager()->removeSavefile(getSavegameFile(slot, target));
 	}
 
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override {

--- a/engines/tinsel/metaengine.cpp
+++ b/engines/tinsel/metaengine.cpp
@@ -95,7 +95,7 @@ public:
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 
 	// TODO: Add getSavegameFile(). See comments in loadGameState and removeSaveState
 	
@@ -203,7 +203,7 @@ Common::Error TinselMetaEngine::createInstance(OSystem *syst, Engine **engine, c
 
 int TinselMetaEngine::getMaximumSaveSlot() const { return 99; }
 
-void TinselMetaEngine::removeSaveState(const char *target, int slot) const {
+bool TinselMetaEngine::removeSaveState(const char *target, int slot) const {
 	Tinsel::setNeedLoad();
 	// Same issue here as with loadGameState(): we need the physical savegame
 	// slot. Refer to bug #5819.
@@ -219,9 +219,10 @@ void TinselMetaEngine::removeSaveState(const char *target, int slot) const {
 		}
 	}
 
-	g_system->getSavefileManager()->removeSavefile(Tinsel::ListEntry(listSlot, Tinsel::LE_NAME));
+	bool success = g_system->getSavefileManager()->removeSavefile(Tinsel::ListEntry(listSlot, Tinsel::LE_NAME));
 	Tinsel::setNeedLoad();
 	Tinsel::getList(g_system->getSavefileManager(), target);
+	return success;
 }
 
 void TinselMetaEngine::registerDefaultSettings(const Common::String &target) const {

--- a/engines/titanic/metaengine.cpp
+++ b/engines/titanic/metaengine.cpp
@@ -55,7 +55,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
@@ -121,9 +121,9 @@ int TitanicMetaEngine::getMaximumSaveSlot() const {
 	return MAX_SAVES;
 }
 
-void TitanicMetaEngine::removeSaveState(const char *target, int slot) const {
+bool TitanicMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String filename = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 SaveStateDescriptor TitanicMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/toltecs/metaengine.cpp
+++ b/engines/toltecs/metaengine.cpp
@@ -73,7 +73,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
@@ -135,11 +135,11 @@ int ToltecsMetaEngine::getMaximumSaveSlot() const {
 	return 999;
 }
 
-void ToltecsMetaEngine::removeSaveState(const char *target, int slot) const {
+bool ToltecsMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
 	Common::String filename = Toltecs::ToltecsEngine::getSavegameFilename(target, slot);
 
-	saveFileMan->removeSavefile(filename.c_str());
+	bool success = saveFileMan->removeSavefile(filename.c_str());
 
 	Common::StringArray filenames;
 	Common::String pattern = target;
@@ -157,6 +157,8 @@ void ToltecsMetaEngine::removeSaveState(const char *target, int slot) const {
 			filename = Toltecs::ToltecsEngine::getSavegameFilename(target, ++slot);
 		}
 	}
+
+	return success;
 }
 
 SaveStateDescriptor ToltecsMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/tony/metaengine.cpp
+++ b/engines/tony/metaengine.cpp
@@ -61,7 +61,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
@@ -121,10 +121,10 @@ int TonyMetaEngine::getMaximumSaveSlot() const {
 	return 99;
 }
 
-void TonyMetaEngine::removeSaveState(const char *target, int slot) const {
+bool TonyMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String filename = Tony::TonyEngine::getSaveStateFileName(slot);
 
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 SaveStateDescriptor TonyMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/toon/metaengine.cpp
+++ b/engines/toon/metaengine.cpp
@@ -52,7 +52,7 @@ public:
 	int getMaximumSaveSlot() const override;
 	SaveStateList listSaves(const char *target) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 
 	Common::KeymapArray initKeymaps(const char *target) const override;
 };
@@ -69,9 +69,9 @@ bool ToonMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSimpleSavesNames);
 }
 
-void ToonMetaEngine::removeSaveState(const char *target, int slot) const {
+bool ToonMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String fileName = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(fileName);
+	return g_system->getSavefileManager()->removeSavefile(fileName);
 }
 
 Common::KeymapArray ToonMetaEngine::initKeymaps(const char *target) const {

--- a/engines/touche/metaengine.cpp
+++ b/engines/touche/metaengine.cpp
@@ -43,7 +43,7 @@ public:
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *desc) const override;
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	Common::String getSavegameFile(int saveGameIdx, const char *target) const override {
 		if (!target)
 			target = getName();
@@ -106,9 +106,9 @@ int ToucheMetaEngine::getMaximumSaveSlot() const {
 	return Touche::kMaxSaveStates - 1;
 }
 
-void ToucheMetaEngine::removeSaveState(const char *target, int slot) const {
+bool ToucheMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String filename = Touche::generateGameStateFileName(target, slot);
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 Common::KeymapArray ToucheMetaEngine::initKeymaps(const char *target) const {

--- a/engines/tsage/metaengine.cpp
+++ b/engines/tsage/metaengine.cpp
@@ -123,9 +123,9 @@ public:
 		return MAX_SAVES - 1;
 	}
 
-	void removeSaveState(const char *target, int slot) const override {
+	bool removeSaveState(const char *target, int slot) const override {
 		Common::String filename = Common::String::format("%s.%03d", target, slot);
-		g_system->getSavefileManager()->removeSavefile(filename);
+		return g_system->getSavefileManager()->removeSavefile(filename);
 	}
 
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override {

--- a/engines/tucker/metaengine.cpp
+++ b/engines/tucker/metaengine.cpp
@@ -94,9 +94,9 @@ public:
 		return Tucker::kAutoSaveSlot;
 	}
 
-	void removeSaveState(const char *target, int slot) const override {
+	bool removeSaveState(const char *target, int slot) const override {
 		Common::String filename = Tucker::generateGameStateFileName(target, slot);
-		g_system->getSavefileManager()->removeSavefile(filename);
+		return g_system->getSavefileManager()->removeSavefile(filename);
 	}
 
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override {

--- a/engines/voyeur/metaengine.cpp
+++ b/engines/voyeur/metaengine.cpp
@@ -83,7 +83,7 @@ public:
 	Common::Error createInstance(OSystem *syst, Engine **engine, const Voyeur::VoyeurGameDescription *desc) const override;
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
@@ -145,9 +145,9 @@ int VoyeurMetaEngine::getMaximumSaveSlot() const {
 	return MAX_SAVES;
 }
 
-void VoyeurMetaEngine::removeSaveState(const char *target, int slot) const {
+bool VoyeurMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::String filename = Common::String::format("%s.%03d", target, slot);
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 SaveStateDescriptor VoyeurMetaEngine::querySaveMetaInfos(const char *target, int slot) const {

--- a/engines/wintermute/base/base_persistence_manager.cpp
+++ b/engines/wintermute/base/base_persistence_manager.cpp
@@ -190,9 +190,9 @@ void BasePersistenceManager::getSaveStateDesc(int slot, SaveStateDescriptor &des
 	desc.setPlayTime(0);
 }
 
-void BasePersistenceManager::deleteSaveSlot(int slot) {
+bool BasePersistenceManager::deleteSaveSlot(int slot) {
 	Common::String filename = getFilenameForSlot(slot);
-	g_system->getSavefileManager()->removeSavefile(filename);
+	return g_system->getSavefileManager()->removeSavefile(filename);
 }
 
 uint32 BasePersistenceManager::getMaxUsedSlot() {

--- a/engines/wintermute/base/base_persistence_manager.h
+++ b/engines/wintermute/base/base_persistence_manager.h
@@ -70,7 +70,7 @@ public:
 	void putDouble(double val);
 	void cleanup();
 	void getSaveStateDesc(int slot, SaveStateDescriptor &desc);
-	void deleteSaveSlot(int slot);
+	bool deleteSaveSlot(int slot);
 	uint32 getMaxUsedSlot();
 	bool getSaveExists(int slot);
 	bool initLoad(const Common::String &filename);

--- a/engines/wintermute/metaengine.cpp
+++ b/engines/wintermute/metaengine.cpp
@@ -159,9 +159,9 @@ public:
 		return 100;
 	}
 
-	void removeSaveState(const char *target, int slot) const override {
+	bool removeSaveState(const char *target, int slot) const override {
 		Wintermute::BasePersistenceManager pm(target, true);
-		pm.deleteSaveSlot(slot);
+		return pm.deleteSaveSlot(slot);
 	}
 
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override {

--- a/engines/zvision/metaengine.cpp
+++ b/engines/zvision/metaengine.cpp
@@ -131,7 +131,7 @@ public:
 
 	SaveStateList listSaves(const char *target) const override;
 	int getMaximumSaveSlot() const override;
-	void removeSaveState(const char *target, int slot) const override;
+	bool removeSaveState(const char *target, int slot) const override;
 	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 };
 
@@ -344,9 +344,9 @@ int ZVisionMetaEngine::getMaximumSaveSlot() const {
 	return 999;
 }
 
-void ZVisionMetaEngine::removeSaveState(const char *target, int slot) const {
+bool ZVisionMetaEngine::removeSaveState(const char *target, int slot) const {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
-	saveFileMan->removeSavefile(Common::String::format("%s.%03u", target, slot));
+	return saveFileMan->removeSavefile(Common::String::format("%s.%03u", target, slot));
 }
 
 SaveStateDescriptor ZVisionMetaEngine::querySaveMetaInfos(const char *target, int slot) const {


### PR DESCRIPTION
This PR adds a GUI message and logs a warning when an attempt to delete a save fails. The other day I discovered that the Windows UNICODE builds have been failing for years to delete saves when interesting characters are in the path (such as someone's username) and was surprised that this error didn't reach the GUI or logs. ( 9eab979bfb6d4abeb3b38d97f67ebf8d576e6237 )

The `SaveFileManager::removeSavefile` implementations already detect errors, translate them to error codes, build and store descriptions, and return success or failure. But the `MetaEngine::removeSaveState` implementations don't pass this along.

Now the metaengines pass along the return value, the GUI displays a message on failure, and the details are logged.