### PR TITLE
TINSEL: Add detection for unsupported DW2 demos

### DIFF
--- a/engines/tinsel/detection_tables.h
+++ b/engines/tinsel/detection_tables.h
@@ -645,15 +645,50 @@ static const TinselGameDescription gameDescriptions[] = {
 	// Note: All Discworld 2 versions are CD only, therefore we don't add the ADGF_CD flag
 #define DISCWORLD2_GUIOPTIONS GUIO2(GUIO_NOASPECT, GAMEOPTION_CROP_HEIGHT_480_TO_432)
 
-	{	// English Discworld 2 demo
+	{	// English Discworld 2 demo (dw2-win-demo-en)
 		{
 			"dw2",
 			"Demo",
 			AD_ENTRY2s("dw2.scn",		"853ab998f5136b69bc586991175d6eeb", 4231121,
 					   "english.smp",	"b5660a0e031cb4710bcb0ef5629ea61d", 28562357),
 			Common::EN_ANY,
-			Common::kPlatformDOS,
+			Common::kPlatformWindows,
 			ADGF_DEMO,
+			DISCWORLD2_GUIOPTIONS
+		},
+		GID_DW2,
+		0,
+		GF_SCNFILES,
+		TINSEL_V2,
+	},
+
+	{	// English Discworld 2 demo (second Windows demo: dw2-win-demo-2-en)
+		{
+			"dw2",
+			"",
+			AD_ENTRY3s("dw2.scn",     "3f24abb61a058f8faeac7c0768cf21fc", 4224921,
+					   "english.smp", "b5660a0e031cb4710bcb0ef5629ea61d", 31360342,
+					   "english.txt", "f17e10eccac0fb2d1fea489a951da266", 283144),
+			Common::EN_ANY,
+			Common::kPlatformWindows,
+			ADGF_UNSUPPORTED | ADGF_DEMO,
+			DISCWORLD2_GUIOPTIONS
+		},
+		GID_DW2,
+		0,
+		GF_SCNFILES,
+		TINSEL_V2,
+	},
+
+	{	// English (US) Discworld 2 demo (DOS demo: dw2-dos-demo-en)
+		{
+			"dw2",
+			"",
+			AD_ENTRY2s("dw2.scn",     "05beafadd26562d708f68194d337b2cb", 103221,
+					   "us.smp",      "b5660a0e031cb4710bcb0ef5629ea61d", 28320582),
+			Common::EN_USA,
+			Common::kPlatformDOS,
+			ADGF_UNSUPPORTED | ADGF_DEMO,
 			DISCWORLD2_GUIOPTIONS
 		},
 		GID_DW2,


### PR DESCRIPTION
This adds detection for the DOS demo and second windows demo that are on the ScummVM website

Both of these demos are added as UNSUPPORTED since they both crash to the debugger at launch. I have also replaced the "demo" string with an empty string "" for both of the detection entries, since otherwise the error message when launching these games (after the detection is added) was a confusing "This game is unsupported for the following reason demo".

It also changes the platform for the one detected demo to be Windows to match with how it is presented on the ScummVM demos page. I am unsure though if this change is correct, or if the description on the demos page is wrong.

This does not add detection for the PSX demo offered on the ScummVM demos page, as it's not clear to me how that could be added.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
