### PR TITLE
BAGEL: Allow using pixel formats other than RGB565

### DIFF
--- a/engines/bagel/spacebar/spacebar.cpp
+++ b/engines/bagel/spacebar/spacebar.cpp
@@ -220,8 +220,7 @@ ErrorCode SpaceBarEngine::ShutDownSoundSystem() {
 
 Common::Error SpaceBarEngine::run() {
 	// Initialize graphics mode
-	Graphics::PixelFormat format(2, 5, 6, 5, 0, 11, 5, 0, 0);
-	initGraphics(640, 480, &format);
+	initGraphics(640, 480, nullptr);
 
 	// Initialize systems
 	_screen = new Graphics::Screen();


### PR DESCRIPTION
This avoids additional conversion when RGB565 isn't supported natively by the backend. Ideally it would be nice to support 256 colour modes as well, but that would require extra work for cases where multiple windows use different palettes.