### PR TITLE
WINTERMUTE: WME3D: fix missing condition

### DIFF
--- a/engines/wintermute/ad/ad_game.cpp
+++ b/engines/wintermute/ad/ad_game.cpp
@@ -2342,9 +2342,11 @@ char *AdGame::findSpeechFile(char *stringID) {
 
 //////////////////////////////////////////////////////////////////////////
 bool AdGame::renderShadowGeometry() {
+#ifdef ENABLE_WME3D
 	if (_scene && _scene->_geom)
 		return _scene->_geom->renderShadowGeometry();
 	else
+#endif
 		return true;
 }
 


### PR DESCRIPTION
If `ENABLE_WME3D` is undefined, the engine won't build, as `_geom` for `Wintermute::AdScene` is not defined in this case.
This will fix the build, though I'm not sure if the returned value is correct from the point of view of the engine functionality.