### PR TITLE
KYRA: (EOB) - Fix projectile weapon damage

### DIFF
--- a/engines/kyra/engine/eobcommon.h
+++ b/engines/kyra/engine/eobcommon.h
@@ -34,6 +34,14 @@ class Keymap;
 
 namespace Kyra {
 
+const int8 ITEM_TYPE_BOW = 0;
+const int8 ITEM_TYPE_LONG_SWORD = 1;
+const int8 ITEM_TYPE_SHORT_SWORD = 2;
+const int8 ITEM_TYPE_SLING = 7;
+const int8 ITEM_TYPE_ARROW = 16;
+const int8 ITEM_TYPE_ROCK= 18;
+const int8 ITEM_TYPE_RATIONS = 31;
+
 #define releaseShpArr(shapes, num) \
 if (shapes) { \
 	for (int iii = 0; iii < num; iii++) { \
@@ -481,7 +489,7 @@ protected:
 	bool checkInventoryForRings(int charIndex, int itemValue);
 	void eatItemInHand(int charIndex);
 
-	bool launchObject(int charIndex, Item item, uint16 startBlock, int startPos, int dir, int type);
+	bool launchObject(int charIndex, Item item, uint16 startBlock, int startPos, int dir, int type, Item projectileWeapon = kItemNone);
 	void launchMagicObject(int charIndex, int type, uint16 startBlock, int startPos, int dir);
 	bool updateObjectFlight(EoBFlyingObject *fo, int block, int pos);
 	bool updateFlyingObjectHitTest(EoBFlyingObject *fo, int block, int pos);
@@ -988,16 +996,21 @@ protected:
 	void useSlotWeapon(int charIndex, int slotIndex, Item item);
 	int closeDistanceAttack(int charIndex, Item item);
 	int thrownAttack(int charIndex, int slotIndex, Item item);
+	int normalizeProjectileWeaponType(int itemType);
 	int projectileWeaponAttack(int charIndex, Item item);
 	virtual void playStrikeAnimation(uint8 pos, Item itm) {}
 
 	void inflictMonsterDamage(EoBMonsterInPlay *m, int damage, bool giveExperience);
-	void calcAndInflictMonsterDamage(EoBMonsterInPlay *m, int times, int pips, int offs, int flags, int savingThrowType, int savingThrowEffect);
-	void calcAndInflictCharacterDamage(int charIndex, int times, int itemOrPips, int useStrModifierOrBase, int flags, int savingThrowType, int savingThrowEffect);
-	int calcCharacterDamage(int charIndex, int times, int itemOrPips, int useStrModifierOrBase, int flags, int savingThrowType, int damageType);
+	void calcAndInflictMonsterDamage(EoBMonsterInPlay *m, int times, int pips, int offs, int flags, int savingThrowType, int savingThrowEffect, Item projectileWeapon = kItemNone);
+	void calcAndInflictCharacterDamage(int charIndex, int times, int itemOrPips, int useStrModifierOrBase, int flags, int savingThrowType, int savingThrowEffect, Item projectileWeapon = kItemNone);
+	int calcCharacterDamage(int charIndex, int times, int itemOrPips, int useStrModifierOrBase, int flags, int savingThrowType, int damageType, Item projectileWeapon = kItemNone);
 	void inflictCharacterDamage(int charIndex, int damage);
 
-	bool characterAttackHitTest(int charIndex, int monsterIndex, int item, int attackType);
+	bool isElf(int charIndex);
+	bool isBow(Item projectileWeapon);
+	bool isSword(Item item);
+
+	bool characterAttackHitTest(int charIndex, int monsterIndex, int item, int attackType, Item projectileWeapon = kItemNone);
 	bool monsterAttackHitTest(EoBMonsterInPlay *m, int charIndex);
 	bool flyingObjectMonsterHit(EoBFlyingObject *fo, int monsterIndex);
 	bool flyingObjectPartyHit(EoBFlyingObject *fo);
@@ -1006,8 +1019,8 @@ protected:
 	void monsterSpellCast(EoBMonsterInPlay *m, int type);
 	void statusAttack(int charIndex, int attackStatusFlags, const char *attackStatusString, int savingThrowType, uint32 effectDuration, int restoreEvent, int noRefresh);
 
-	int calcMonsterDamage(EoBMonsterInPlay *m, int times, int pips, int offs, int flags, int savingThrowType, int savingThrowEffect);
-	int calcDamageModifers(int charIndex, EoBMonsterInPlay *m, int item, int itemType, int useStrModifier);
+	int calcMonsterDamage(EoBMonsterInPlay *m, int times, int pips, int offs, int flags, int savingThrowType, int savingThrowEffect, Item projectileWeapon = kItemNone);
+	int calcDamageModifers(int charIndex, EoBMonsterInPlay *m, int item, int itemType, int useStrModifier, Item projectileWeapon);
 	bool trySavingThrow(void *target, int hpModifier, int level, int type, int race);
 	bool specialAttackSavingThrow(int charIndex, int type);
 	int getSaveThrowModifier(int hpModifier, int level, int type);

--- a/engines/kyra/engine/kyra_rpg.h
+++ b/engines/kyra/engine/kyra_rpg.h
@@ -83,7 +83,7 @@ struct EoBFlyingObject {
 	int8 callBackIndex;
 	uint8 curPos;
 	uint8 flags;
-	uint8 unused;
+	Item projectileWeapon;
 };
 
 struct KyraRpgGUISettings {

--- a/engines/kyra/gui/gui_eob.cpp
+++ b/engines/kyra/gui/gui_eob.cpp
@@ -2255,7 +2255,7 @@ int GUI_EoB::simpleMenu_getMouseItem(int sd) {
 
 	if (column == _menuColumns)
 		return -1;
-	
+
 	int yrelcol = yrel - _menuColumnOffset[column] * lineH;
 
 	if (yrelcol >= 0 && yrelcol < _menuLines[column] * lineH)
@@ -4510,7 +4510,7 @@ void GUI_EoB::displayTextBox(int id, int, bool) {
 	Common::Point txtPos((dm->sx << 3) + 5, dm->sy + 5);
 	if (_vm->game() == GI_EOB2 && _vm->gameFlags().platform == Common::kPlatformPC98) {
 		for (size_t p = tmp.find("  "); p != Common::String::npos; p = tmp.find("  "))
-			tmp.deleteChar(p);		
+			tmp.deleteChar(p);
 		txtPos = Common::Point(dm->sx << 3, (dm->sy + 16) & ~7);
 	}
 

--- a/engines/kyra/gui/saveload.cpp
+++ b/engines/kyra/gui/saveload.cpp
@@ -28,7 +28,7 @@
 #include "graphics/thumbnail.h"
 #include "graphics/surface.h"
 
-#define CURRENT_SAVE_VERSION 22
+#define CURRENT_SAVE_VERSION 23
 
 #define GF_FLOPPY  (1 <<  0)
 #define GF_TALKIE  (1 <<  1)

--- a/engines/kyra/gui/saveload_eob.cpp
+++ b/engines/kyra/gui/saveload_eob.cpp
@@ -262,7 +262,11 @@ Common::Error EoBCoreEngine::loadGameState(int slot) {
 			m->callBackIndex = in.readSByte();
 			m->curPos = in.readByte();
 			m->flags = in.readByte();
-			m->unused = in.readByte();
+			if (header.version >= 23) {
+				m->projectileWeapon = in.readSint16BE();
+			} else {
+				m->projectileWeapon = in.readByte();
+			}
 		}
 
 		for (int ii = 0; ii < 5; ii++) {
@@ -518,7 +522,7 @@ Common::Error EoBCoreEngine::saveGameStateIntern(int slot, const char *saveName,
 			out->writeSByte(m->callBackIndex);
 			out->writeByte(m->curPos);
 			out->writeByte(m->flags);
-			out->writeByte(m->unused);
+			out->writeSint16BE(m->projectileWeapon);
 		}
 
 		for (int ii = 0; ii < 5; ii++) {


### PR DESCRIPTION
**KYRA: (EOB)** - Fix projectile weapon damage

**Note**: All changes of game functionality here are behind the "Faithful AD&D rules" flag.

Fixes a bug in the original games, where projectiles would deal an incorrect amount of damage (always 1d1):

- projectile weapon id is attached to a FlyingObject and checked when FlyingObject hits a monster or the party

- bumps the save format version to add a new field to FlyingObject (the new 16 bit field replaces the existing unused 8 bit field)

- fixes a bug in original code where a projectile weapon thrown into the 3D view would inflict projectile damage (should be 1d1)

- patch EotB 1 Bow and Sling damage according to AD&D 2nd Ed rules

Elves get +1 to hit bonus with bows and swords, according to manual

Patch EotB 1 NPCs Beohram (paladin) and Ileria (female)

@athrxx A couple of notes to you:

- I left a couple of TODOs to double check the original disassembly where I had trouble understanding the disassembled code logic

- a few minor refactorings, to either help implement the projectile weapon damage fix, or to improve code readability, but the main idea is adding a field to FlyingObject, and a new param to some functions (C++ default param values were useful here to help reduce the number of changes)

@athrxx  FYI a few issues I encountered while testing that are unrelated to this PR, but you could help triage:

- There's a rare segfault when attempting to render one of the "Will-o'-wisp" sprites in EotB 2, caused by a null monster shape pointer in `EoBCoreEngine::drawMonsters`

- Missing circling fireball in EotB 2, Azure Tower level 3, 21A

- Imaginary walls not rendering in EotB 2 (it might be that after casting a True Seeing spell, its effect persists longer than intended)