### PR TITLE
CRAB: Remove unused function

### DIFF
--- a/engines/crab/image/Image.cpp
+++ b/engines/crab/image/Image.cpp
@@ -44,18 +44,6 @@ using namespace pyrodactyl::image;
 //------------------------------------------------------------------------
 // Purpose: Load a texture
 //------------------------------------------------------------------------
-bool Image::load(Graphics::Surface *surface) {
-	deleteImage();
-
-	_texture = new Graphics::ManagedSurface();
-	_texture->create(surface->w, surface->h, surface->format);
-	_texture->copyFrom(*surface);
-
-	_w = surface->w;
-	_h = surface->h;
-
-	return true;
-}
 
 bool Image::load(Graphics::ManagedSurface *surface) {
 	deleteImage();

--- a/engines/crab/image/Image.h
+++ b/engines/crab/image/Image.h
@@ -100,7 +100,6 @@ public:
 	// Load the image
 	bool load(const Common::Path &path);
 	bool load(rapidxml::xml_node<char> *node, const char *name);
-	bool load(Graphics::Surface *surface);
 	bool load(Graphics::ManagedSurface *surface);
 
 


### PR DESCRIPTION
This follows commit 26938f6 that fixed dereferencing a null pointer. The same issue existed in another `Image::load()` overload (that starts by destroying the _texture and then accesses it). But it seems that that overload is actually not used, so it seems better to remove it rather than fix it. But this may need to be reviewed by developers familiar with that engine to confirm.
