### PR TITLE
GRAPHICS: Add wrapping mode that ignores trailing space

### DIFF
--- a/graphics/font.cpp
+++ b/graphics/font.cpp
@@ -265,7 +265,9 @@ int wordWrapTextImpl(const Font &font, const StringType &str, int maxWidth, Comm
 			const int currentCharWidth = font.getCharWidth(c);
 			const int w = currentCharWidth + font.getKerningOffset(last, c);
 			last = c;
-			const bool wouldExceedWidth = (lineWidth + tmpWidth + w > targetMaxLineWidth);
+			const bool wouldExceedWidth =
+				(lineWidth + tmpWidth + w > targetMaxLineWidth) &&
+				!(mode & kWordWrapAllowTrailingWhitespace && Common::isSpace(c));
 
 			// If this char is a whitespace, then it represents a potential
 			// 'wrap point' where wrapping could take place. Everything that

--- a/graphics/font.h
+++ b/graphics/font.h
@@ -56,9 +56,10 @@ enum TextAlign {
 
 /** Word wrapping modes. */
 enum WordWrapMode {
-	kWordWrapDefault			= 0,		///< Default wrapping mode.
-	kWordWrapEvenWidthLines 	= 1 << 0,	///< Make the resulting line segments close to the same width.
-	kWordWrapOnExplicitNewLines	= 1 << 1	///< Text is wrapped on new lines. Otherwise, treats them as single whitespace.
+	kWordWrapDefault				 = 0,		///< Default wrapping mode.
+	kWordWrapEvenWidthLines 		 = 1 << 0,	///< Make the resulting line segments close to the same width.
+	kWordWrapOnExplicitNewLines		 = 1 << 1,	///< Text is wrapped on new lines. Otherwise, treats them as single whitespace.
+	kWordWrapAllowTrailingWhitespace = 1 << 2 	///< Allow any amount of trailing whitespace before wrapping as it won't be drawn.
 };
 
 /**


### PR DESCRIPTION
Creating a PR for this as it's common code and I want to check my change makes sense.

The DGDS engine word wrapping algorithm appends any amount of whitepsace on the end of the line before wrapping, allowing the nominal line length to go beyond the limit specified. The drawn length will still be within the limit.

Add a WordWrapMode flag that does the same.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
