### PR TITLE
SKY/TINSEL: Fix loading of music on Android

### DIFF
--- a/engines/sky/music/musicbase.cpp
+++ b/engines/sky/music/musicbase.cpp
@@ -53,6 +53,7 @@ void MusicBase::loadSection(uint8 pSection) {
 	_musicTempo0 = 0x78; // init constants taken from idb file, area ~0x1060
 	_musicTempo1 = 0xC0;
 	_onNextPoll.musicToProcess = 0;
+	_onNextPoll.stream = nullptr;
 	_tempo = _aktTime = 0x10001;
 	_numberOfChannels = _currentMusic = 0;
 	setupPointers();
@@ -105,24 +106,14 @@ void MusicBase::loadNewMusic() {
 
 	// Try playing digital audio first (from the Music Enhancement Project).
 	// TODO: This always prefers digital music over the MIDI music types!
-	uint8 section = _currentSection;
-	uint8 song = _currentMusic;
-	// handle duplicates
-	if ((section == 2 && song == 1) || (section == 5 && song == 1)) {
-		section = 1;
-		song = 1;
-	} else if ((section == 2 && song == 4) || (section == 5 && song == 4)) {
-		section = 1;
-		song = 4;
-	} else if (section == 5 && song == 6) {
-		section = 4;
-		song = 4;
-	}
-	Common::Path trackName(Common::String::format("music_%d%02d", section, song));
-	Audio::SeekableAudioStream *stream = Audio::SeekableAudioStream::openStreamFile(trackName);
+	Audio::SeekableAudioStream *stream = _onNextPoll.stream;
 	if (stream) {
+		_onNextPoll.stream = nullptr;
+
 		// not all tracks should loop
 		bool loops = true;
+		uint8 section = _currentSection;
+		uint8 song = _currentMusic;
 		if ((section == 0 && song == 1)
 		 || (section == 1 && song == 1) || (section == 1 && song == 4)
 		 || (section == 2 && song == 1) || (section == 2 && song == 4)
@@ -167,7 +158,32 @@ void MusicBase::pollMusic() {
 }
 
 void MusicBase::startMusic(uint16 param) {
-	_onNextPoll.musicToProcess = param & 0xF;
+	uint8 song = param & 0xF;
+
+	_onNextPoll.musicToProcess = song;
+	delete _onNextPoll.stream;
+	_onNextPoll.stream = nullptr;
+
+	if (song == 0)
+		return;
+
+	// Load digital audio now if available
+	// This avoids doing it in the audio thread
+	uint8 section = _currentSection;
+	// handle duplicates
+	if ((section == 2 && song == 1) || (section == 5 && song == 1)) {
+		section = 1;
+		song = 1;
+	} else if ((section == 2 && song == 4) || (section == 5 && song == 4)) {
+		section = 1;
+		song = 4;
+	} else if (section == 5 && song == 6) {
+		section = 4;
+		song = 4;
+	}
+
+	Common::Path trackName(Common::String::format("music_%d%02d", section, song));
+	_onNextPoll.stream = Audio::SeekableAudioStream::openStreamFile(trackName);
 }
 
 uint8 MusicBase::giveVolume() {

--- a/engines/sky/music/musicbase.h
+++ b/engines/sky/music/musicbase.h
@@ -28,6 +28,10 @@
 
 #include "audio/mixer.h"
 
+namespace Audio {
+class SeekableAudioStream;
+}
+
 namespace Sky {
 
 class Disk;
@@ -36,6 +40,7 @@ class Disk;
 
 typedef struct {
 	uint8 musicToProcess;
+	Audio::SeekableAudioStream *stream;
 } Actions;
 
 class ChannelBase {

--- a/engines/tinsel/music.h
+++ b/engines/tinsel/music.h
@@ -178,6 +178,7 @@ protected:
 	SCNHANDLE _hScript;
 	SCNHANDLE _hSegment;
 	Common::Path _filename;
+	Common::File _file;
 
 	uint8 _volume;
 


### PR DESCRIPTION
Here are two commits which should fix the crash in modern Android.
Instead of modifying Android code (which would have lowered the performance), I fixed the engine code to not attempt to open files from the audio thread.