### PR TITLE
ANDROID: Add ability to build a fat bundle

### DIFF
--- a/backends/platform/android/android.mk
+++ b/backends/platform/android/android.mk
@@ -110,6 +110,7 @@ androiddistrelease: androidrelease
 		sed 's/$$/\r/' < $$i > release/`basename $$i`.txt; \
 	done
 
-.PHONY: androidclean androidrelease androidbundlerelease androidtest androiddistdebug androiddistrelease
+ANDROID_BUILD_RULES := androidrelease androidbundlerelease androidtest androiddistdebug androiddistrelease
+.PHONY: androidclean $(ANDROID_BUILD_RULES)
 
 include $(srcdir)/backends/platform/android/fatbundle.mk

--- a/backends/platform/android/android.mk
+++ b/backends/platform/android/android.mk
@@ -85,8 +85,9 @@ all: $(APK_MAIN)
 
 clean: androidclean
 
+# SUBPATH_BUILDS is set in fatbundle.mk
 androidclean:
-	@$(RM) -rf $(PATH_BUILD) *.apk
+	@$(RM) -rf $(PATH_BUILD) $(SUBPATH_BUILDS) *.apk
 
 androidrelease: $(APK_MAIN_RELEASE)
 androidbundlerelease: $(AAB_MAIN_RELEASE)
@@ -119,3 +120,5 @@ androiddistrelease: androidrelease
 	done
 
 .PHONY: androidrelease androidbundlerelease androidtest $(PATH_BUILD_SRC)
+
+include $(srcdir)/backends/platform/android/fatbundle.mk

--- a/backends/platform/android/android.mk
+++ b/backends/platform/android/android.mk
@@ -81,27 +81,18 @@ $(AAB_MAIN_RELEASE): $(PATH_BUILD_GRADLE) $(PATH_BUILD_ASSETS) $(PATH_BUILD_ASSE
 	(cd $(PATH_BUILD); ./gradlew bundleRelease -PsplitAssets)
 	$(CP) $(PATH_BUILD)/build/outputs/bundle/release/$(AAB_MAIN_RELEASE) $@
 
-all: $(APK_MAIN)
-
 clean: androidclean
 
 # SUBPATH_BUILDS is set in fatbundle.mk
 androidclean:
 	$(RM) -rf $(PATH_BUILD) $(SUBPATH_BUILDS) *.apk *.aab
 
+all: $(APK_MAIN)
+
 androidrelease: $(APK_MAIN_RELEASE)
 androidbundlerelease: $(AAB_MAIN_RELEASE)
 
-androidtestmain: $(APK_MAIN)
-	(cd $(PATH_BUILD); ./gradlew installDebug)
-	# $(ADB) install -g -r $(APK_MAIN)
-	# $(ADB) shell am start -a android.intent.action.MAIN -c android.intent.category.LAUNCHER -n org.scummvm.scummvm/.ScummVMActivity
-
 androidtest: $(APK_MAIN)
-	# @set -e; for apk in $^; do \
-	# 	$(ADB) install -g -r $$apk; \
-	# done
-	# $(ADB) shell am start -a android.intent.action.MAIN -c android.intent.category.LAUNCHER -n org.scummvm.scummvm/.ScummVMActivity
 	(cd $(PATH_BUILD); ./gradlew installDebug)
 
 # used by buildbot!
@@ -119,6 +110,6 @@ androiddistrelease: androidrelease
 		sed 's/$$/\r/' < $$i > release/`basename $$i`.txt; \
 	done
 
-.PHONY: androidrelease androidbundlerelease androidtest $(PATH_BUILD_SRC)
+.PHONY: androidclean androidrelease androidbundlerelease androidtest androiddistdebug androiddistrelease
 
 include $(srcdir)/backends/platform/android/fatbundle.mk

--- a/backends/platform/android/android.mk
+++ b/backends/platform/android/android.mk
@@ -87,7 +87,7 @@ clean: androidclean
 
 # SUBPATH_BUILDS is set in fatbundle.mk
 androidclean:
-	@$(RM) -rf $(PATH_BUILD) $(SUBPATH_BUILDS) *.apk
+	$(RM) -rf $(PATH_BUILD) $(SUBPATH_BUILDS) *.apk *.aab
 
 androidrelease: $(APK_MAIN_RELEASE)
 androidbundlerelease: $(AAB_MAIN_RELEASE)

--- a/backends/platform/android/fatbundle.mk
+++ b/backends/platform/android/fatbundle.mk
@@ -1,0 +1,35 @@
+ALL_ABIS = armeabi-v7a arm64-v8a x86 x86_64
+OTHER_ABIS = $(filter-out $(ABI), $(ALL_ABIS))
+
+PATH_BUILD_LIBSSCUMMVM = $(foreach abi, $(OTHER_ABIS), $(PATH_BUILD)/lib/$(abi)/libscummvm.so)
+
+ANDROID_CONFIGURE_PATH := $(realpath $(srcdir)/configure)
+ANDROID_CONFIGFLAGS := $(filter-out --host=android-%, $(SAVED_CONFIGFLAGS))
+define BUILD_ANDROID
+SUBPATH_BUILD_LIBSCUMMVM_abi := ./build-android$(1)/libscummvm.so
+PATH_BUILD_LIBSCUMMVM_abi := $(PATH_BUILD)/lib/$(1)/libscummvm.so
+
+SUBPATH_BUILDS += ./build-android$(1)
+
+$$(SUBPATH_BUILD_LIBSCUMMVM_abi): SUBPATH_BUILD=./build-android$(1)
+$$(SUBPATH_BUILD_LIBSCUMMVM_abi): config.mk $$(EXECUTABLE)
+	$$(INSTALL) -d "$$(SUBPATH_BUILD)"
+	(cd "$$(SUBPATH_BUILD)" && \
+	$$(foreach VAR,$$(SAVED_ENV_VARS),$$(VAR)="$$(SAVED_$$(VAR))") \
+	"$$(ANDROID_CONFIGURE_PATH)" --host=android-$(1) $$(ANDROID_CONFIGFLAGS))
+	$$(MAKE) -C "$$(SUBPATH_BUILD)" $$(EXECUTABLE)
+
+$$(PATH_BUILD_LIBSCUMMVM_abi): PATH_BUILD_LIB=$(PATH_BUILD)/lib/$(1)
+$$(PATH_BUILD_LIBSCUMMVM_abi): $$(SUBPATH_BUILD_LIBSCUMMVM_abi)
+	$$(INSTALL) -d "$$(PATH_BUILD_LIB)"
+	$$(INSTALL) -c -m 644 "$$<" "$$@"
+
+endef
+
+SUBPATH_BUILDS :=
+$(foreach abi,$(OTHER_ABIS),$(eval $(call BUILD_ANDROID,$(abi))))
+
+androidfatbundlerelease: $(PATH_BUILD_LIBSSCUMMVM)
+	$(MAKE) $(AAB_MAIN_RELEASE)
+
+.PHONY: androidfatbundlerelease

--- a/backends/platform/android/fatbundle.mk
+++ b/backends/platform/android/fatbundle.mk
@@ -29,7 +29,7 @@ endef
 SUBPATH_BUILDS :=
 $(foreach abi,$(OTHER_ABIS),$(eval $(call BUILD_ANDROID,$(abi))))
 
-androidfatbundlerelease: $(PATH_BUILD_LIBSSCUMMVM)
-	$(MAKE) $(AAB_MAIN_RELEASE)
+androidfatall $(subst android,androidfat,$(ANDROID_BUILD_RULES)): androidfat%: $(PATH_BUILD_LIBSSCUMMVM)
+	$(MAKE) $(if $(filter all,$*),$*,android$*)
 
-.PHONY: androidfatbundlerelease
+.PHONY: androidfatall $(subst android,androidfat,$(ANDROID_BUILD_RULES))

--- a/configure
+++ b/configure
@@ -1660,7 +1660,7 @@ case $_host in
 	datadir='${datarootdir}'
 	docdir='${prefix}/doc'
 	;;
-android-arm-v7a | ouya)
+android-arm-v7a | android-armeabi-v7a | ouya)
 	_host_os=android
 	_host_cpu=arm
 	_host_alias=arm-linux-androideabi
@@ -2839,7 +2839,7 @@ case $_host_os in
 		;;
 	android)
 		case $_host in
-			android-arm-v7a)
+			android-arm-v7a | android-armeabi-v7a)
 				# Disable NEON for older devices (like with Tegra 2)
 				append_var CXXFLAGS "-mfpu=vfp"
 				# This is really old CPU but might be still used with android 4.1, it slightly increases code size and decreases performance.
@@ -3456,7 +3456,7 @@ if test -n "$_host"; then
 			_vorbis=no
 			_port_mk="backends/platform/3ds/3ds.mk"
 			;;
-		android-arm-v7a | android-arm64-v8a | android-x86 | android-x86_64 | ouya)
+		android-* | ouya)
 			# __ANDROID__ is defined by Clang in the NDK
 			# we link a .so as default
 			append_var LDFLAGS "-shared"

--- a/dists/android/build.gradle
+++ b/dists/android/build.gradle
@@ -54,10 +54,13 @@ android {
         // (p is patch/bugfix release number)
         // (b is build number, eg. re-release or beta testing was done on Play Store)
         // (a is a number indicating the target architecture (ABI)):
-        //     (1: arm-v7a, 2: arm64-v8a, 3: x86, 4: x86_64)
-        // eg. ScummVM 2.9.0 builds would have version codes: 2090001 - 2090004
+        //     (0: unspecified/fat, 1: arm-v7a, 2: arm64-v8a, 3: x86, 4: x86_64)
+        // eg. ScummVM 2.10.0 builds would have version codes: 2100000 - 2100004
         // --------------
-        // ScummVM 2.8.0:   113 - 116 (arm-v7a, arm64-v8a, x86, x86_64 respectively)
+        // ScummVM 2.9.0:   2090001 - 2090004 (arm-v7a, arm64-v8a, x86, x86_64 respectively)
+        // ScummVM 2.8.1.1: 2081011 - 2081014 (arm-v7a, arm64-v8a, x86, x86_64 respectively) (release on Play Store)
+        // ScummVM 2.8.1:   2081001 - 2081004 (arm-v7a, arm64-v8a, x86, x86_64 respectively) (rejected on Play Store)
+        // ScummVM 2.8.0:   113 - 116 (arm-v7a, arm64-v8a, x86, x86_64 respectively) (release on Play Store)
         // ScummVM 2.7.1:   109 - 112 (arm-v7a, arm64-v8a, x86, x86_64 respectively) (release on Play Store)
         // Historical version codes:
         // ScummVM 2.7.0.5: 105 - 108 (arm-v7a, arm64-v8a, x86, x86_64 respectively) (proper release on Play Store)


### PR DESCRIPTION
This bundle contains all architectures.
To build it, a base architecture must be configured and the build process will invoke the make process for all other architectures in different subfolders.
Then, the bundle will be made with all libraries merged in the base build directory.