### PR TITLE
DREAMWEB: Fix index overflow and crash in `deleteExFrame`

### DIFF
--- a/engines/dreamweb/dreamweb.h
+++ b/engines/dreamweb/dreamweb.h
@@ -534,7 +534,7 @@ public:
 	void obPicture();
 	void removeObFromInv();
 	void deleteExObject(uint8 index);
-	void deleteExFrame(uint8 frameNum);
+	void deleteExFrame(uint16 frameNum);
 	void deleteExText(uint8 textNum);
 	void purgeALocation(uint8 index);
 	const uint8 *getObTextStart();

--- a/engines/dreamweb/object.cpp
+++ b/engines/dreamweb/object.cpp
@@ -96,7 +96,7 @@ void DreamWebEngine::obToInv(uint8 index, uint8 flag, uint16 x, uint16 y) {
 void DreamWebEngine::obPicture() {
 	if (_objectType == kSetObjectType1)
 		return;
-	uint8 frame = 3 * _command + 1;
+	uint16 frame = 3 * _command + 1;
 	if (_objectType == kExObjectType)
 		showFrame(_exFrames, 160, 68, frame, 0x80);
 	else
@@ -424,7 +424,8 @@ void DreamWebEngine::setPickup() {
 	workToScreenM();
 }
 
-void DreamWebEngine::deleteExFrame(uint8 frameNum) {
+void DreamWebEngine::deleteExFrame(uint16 frameNum) {
+	assert(frameNum < 346); // see GraphicsFile::getFrameData
 	Frame *frame = &_exFrames._frames[frameNum];
 
 	uint16 frameSize = frame->width * frame->height;

--- a/engines/dreamweb/vgagrafx.cpp
+++ b/engines/dreamweb/vgagrafx.cpp
@@ -304,7 +304,7 @@ void DreamWebEngine::dumpZoom() {
 }
 
 void DreamWebEngine::crosshair() {
-	uint8 frame;
+	uint16 frame;
 	if ((_commandType != 3) && (_commandType < 10)) {
 		frame = 9;
 	} else {


### PR DESCRIPTION
This PR fixes a crash when changing rooms after using a key on a thing: https://bugs.scummvm.org/ticket/15420

I'm unfamiliar with this engine and game, but the bug was easy to reproduce and seems straightforward.

`DreamWebEngine::_exFrames::_frames` is an array of 347 `Frame` objects. `DreamWebEngine::deleteExFrame` takes an index into this array as a parameter, but it was an 8 bit parameter. The caller passed 256, so it became zero, and an assertion failure followed.

I've fixed the parameter size and updated two other places where an 8 bit frame index variable was passed to a 16 bit parameter, for clarity.

This crash started occurring in release 1.6.0 in 2013, so the mystery is how this is the first time it's been reported.
