### PR TITLE
SCUMM: Prevent expiration of music while it's playing

### DIFF
--- a/engines/scumm/sound.cpp
+++ b/engines/scumm/sound.cpp
@@ -1013,17 +1013,19 @@ bool Sound::isSoundInUse(int sound) const {
 	if (sound == _currentCDSound)
 		return pollCD() != 0;
 
+	if (_mixer->isSoundIDActive(sound))
+		return true;
+
 	if (isSoundInQueue(sound))
 		return true;
 
-	if (!_vm->_res->isResourceLoaded(rtSound, sound))
+	if (sound > _vm->_numSounds || !_vm->_res->isResourceLoaded(rtSound, sound))
 		return false;
 
 	if (_vm->_imuse)
 		return _vm->_imuse->get_sound_active(sound);
-
-	if (_mixer->isSoundIDActive(sound))
-		return 1;
+	else if (_vm->_musicEngine)
+		return _vm->_musicEngine->getSoundStatus(sound);
 
 	return false;
 }

--- a/engines/scumm/sound.cpp
+++ b/engines/scumm/sound.cpp
@@ -994,14 +994,20 @@ int Sound::isSoundRunning(int sound) const {
 
 /**
  * Check whether the sound resource with the specified ID is still
- * used. This is invoked by ScummEngine::isResourceInUse, to determine
+ * used. This is invoked by ScummEngine::isResourceInUse(), to determine
  * which resources can be expired from memory.
- * Technically, this works very similar to isSoundRunning, however it
+ * Technically, this works very similar to isSoundRunning(), however it
  * calls IMuse::get_sound_active() instead of IMuse::getSoundStatus().
  * The difference between those two is in how they treat sounds which
  * are being faded out: get_sound_active() returns true even when the
  * sound is being faded out, while getSoundStatus() returns false in
  * that case.
+ *
+ * Another difference is that isSoundRunning() checks if sound is greater
+ * than _numSounds before checking if the resource is loaded. That check is
+ * only for non-HE games. In HE games, a number higher than _numSounds
+ * represents a (streamed) music track. HE games have their own implementation
+ * of isSoundRunning(), while isSoundInUse() is used by all.
  */
 bool Sound::isSoundInUse(int sound) const {
 
@@ -1019,7 +1025,7 @@ bool Sound::isSoundInUse(int sound) const {
 	if (isSoundInQueue(sound))
 		return true;
 
-	if (sound > _vm->_numSounds || !_vm->_res->isResourceLoaded(rtSound, sound))
+	if (!_vm->_res->isResourceLoaded(rtSound, sound))
 		return false;
 
 	if (_vm->_imuse)


### PR DESCRIPTION
The background to this pull request is that I was playing the Mac version of The Secret of Monkey Island to see if recent work on the Mac GUI had caused any regressions. I got to the part where you have to follow the shopkeeper. The game is supposed to play a particular piece of music all the way up until you reach the swordmaster. But when I got to the island overhead map, the music stopped and was replaced by the regular overhead map theme.

What happened was that the engine decided to expire the music resource. The script checks if the shopkeeper theme is playing, but one of the conditions there is that the resource has to be loaded. Otherwise it starts the overhead map theme.

I don't think we can rely on the music engine keeping its own copy of the resource data, so checking that the resource is loaded _is_ almost certainly the right thing to do. But it shouldn't be allowed to expire sounds while they are still being played. The resource manager will check `isSoundInUse()` and that's where things went wrong. Because the music engine said that no, the sound was not playing.

This change brings `isSoundInUse()` and `isSoundRunning()` closer to each other, while still maintaining the documented differences. That's why it's still calling `_imuse`, even though `_imuse` is - as far as I know - always also the `_musicEngine`.