### PR TITLE
I18N: Fixed wrongly translated word in uk_UA.po

### DIFF
--- a/po/uk_UA.po
+++ b/po/uk_UA.po
@@ -119,7 +119,7 @@ msgstr "Вгору"
 #: engines/scumm/he/moonbase/dialog-mapgenerator.cpp:138
 #: engines/sword1/control.cpp:2813 engines/wintermute/wintermute.cpp:182
 msgid "Cancel"
-msgstr "Відміна"
+msgstr "Скасувати"
 
 #: gui/browser.cpp:82 gui/chooser.cpp:46 gui/filebrowser-dialog.cpp:69
 #: gui/remotebrowser.cpp:60 gui/shaderbrowser-dialog.cpp:81


### PR DESCRIPTION
Just fixed the word "Cancel" being translated as "Відміна". Because the former is a verb, and the latter is a noun that means "to change generally or grammatically (as in 'declension')". The correct translation would be "Скасувати", which translates directly as "to cancel something".