### PR TITLE
DGDS: fix compiler warning for ads.cpp

### DIFF
--- a/engines/dgds/ads.cpp
+++ b/engines/dgds/ads.cpp
@@ -752,7 +752,7 @@ int16 ADSInterpreter::getStateForSceneOp(uint16 segnum) {
 	if (idx < 0)
 		return 0;
 	if (!(_adsData->_state[idx] & 4)) {
-		for (const Common::SharedPtr<TTMSeq> seq: _adsData->_usedSeqs[idx]) {
+		for (const Common::SharedPtr<TTMSeq>& seq: _adsData->_usedSeqs[idx]) {
 			if (!seq)
 				return 0;
 			if (seq->_runFlag != kRunTypeStopped && !seq->_selfLoop)


### PR DESCRIPTION
    C++      engines/dgds/ads.o
engines/dgds/ads.cpp: In member function ‘int16 Dgds::ADSInterpreter::getStateForSceneOp(uint16)’:
engines/dgds/ads.cpp:755:54: warning: loop variable ‘seq’ creates a copy from type ‘const Common::SharedPtr<Dgds::TTMSeq>’ [-Wrange-loop-construct]
  755 |                 for (const Common::SharedPtr<TTMSeq> seq: _adsData->_usedSeqs[idx]) {
      |                                                      ^~~
engines/dgds/ads.cpp:755:54: note: use reference type to prevent copying
  755 |                 for (const Common::SharedPtr<TTMSeq> seq: _adsData->_usedSeqs[idx]) {

Or is there an better solution to fix the compiler warning while compiling DGDS engine?
Suggestions are welcome :)
