### PR TITLE
GRAPHICS: MACGUI: Fix blank characters on forced Win95 mode

### DIFF
--- a/graphics/macgui/macfontmanager.cpp
+++ b/graphics/macgui/macfontmanager.cpp
@@ -534,7 +534,7 @@ const Font *MacFontManager::getFont(MacFont *macFont) {
 				int newId = macFont->getId();
 				int newSlant = macFont->getSlant();
 				int familyId = getFamilyId(newId, newSlant);
-				if (_fontInfo.contains(familyId)) {
+				if (_fontInfo.contains(familyId) && !(_mode & kWMModeForceMacFontsInWin95)) {
 					font = Graphics::loadTTFFontFromArchive(_fontInfo[familyId]->name, macFont->getSize(), Graphics::kTTFSizeModeCharacter, 0, 0, Graphics::kTTFRenderModeMonochrome);
 					_uniFonts[macFont->getSize()] = font;
 				} else {


### PR DESCRIPTION
Fixes regression introduced in https://github.com/scummvm/scummvm/pull/5658
where on hebrew version of Pink Panther the menu characters are blank