### PR TITLE
[RFC] HYPNO: Cache Smacker cursors to address bug #15347

### DIFF
--- a/engines/hypno/cursors.cpp
+++ b/engines/hypno/cursors.cpp
@@ -154,7 +154,7 @@ Graphics::Surface *CursorCache::getCursor(const Common::String &cursor, uint32 n
 		return _surface;
 	}
 
-	delete(_palette);
+	free(_palette);
 	_palette = nullptr;
 
 	if (_surface) {

--- a/engines/hypno/cursors.cpp
+++ b/engines/hypno/cursors.cpp
@@ -148,16 +148,35 @@ void HypnoEngine::changeCursor(const Common::String &cursor) {
 	CursorMan.showMouse(true);
 }
 
+Graphics::Surface *CursorCache::getCursor(const Common::String &cursor, uint32 n, byte **palette) {
+	if (cursor == _filename && n == _frame) {
+		*palette = _palette;
+		return _surface;
+	}
+
+	delete(_palette);
+	_palette = nullptr;
+
+	if (_surface) {
+		_surface->free();
+		delete _surface;
+		_surface = nullptr;
+	}
+
+	_filename = cursor;
+	_frame = n;
+	_surface = _vm->decodeFrame(cursor, n, &_palette);
+	*palette = _palette;
+	return _surface;
+}
+
 void HypnoEngine::changeCursor(const Common::String &cursor, uint32 n, bool centerCursor) {
 	byte *palette;
-	Graphics::Surface *entry = decodeFrame(cursor, n, &palette);
+	Graphics::Surface *entry = _cursorCache->getCursor(cursor, n, &palette);
 	uint32 hotspotX = centerCursor ? entry->w / 2 : 0;
 	uint32 hotspotY = centerCursor ? entry->h / 2 : 0;
 	CursorMan.replaceCursor(*entry, hotspotX, hotspotY, 0, false);
 	CursorMan.replaceCursorPalette(palette, 0, 256);
-	entry->free();
-	delete entry;
-	free(palette);
 	CursorMan.showMouse(true);
 }
 

--- a/engines/hypno/hypno.cpp
+++ b/engines/hypno/hypno.cpp
@@ -63,6 +63,8 @@ HypnoEngine::HypnoEngine(OSystem *syst, const ADGameDescription *gd)
 	_rnd = new Common::RandomSource("hypno");
 	_checkpoint = "";
 
+	_cursorCache = new CursorCache(this);
+
 	if (gd->extra)
 		_variant = gd->extra;
 	else
@@ -109,6 +111,7 @@ HypnoEngine::~HypnoEngine() {
 	// }
 
 	delete _rnd;
+	delete _cursorCache;
 	_compositeSurface->free();
 	delete _compositeSurface;
 

--- a/engines/hypno/hypno.h
+++ b/engines/hypno/hypno.h
@@ -78,6 +78,29 @@ enum SpiderColors {
 	kSpiderColorBlue = 252,
 };
 
+class HypnoEngine;
+
+class CursorCache {
+private:
+	HypnoEngine *_vm;
+	Common::String _filename;
+	uint32 _frame;
+	byte *_palette;
+	Graphics::Surface *_surface;
+
+public:
+	CursorCache(HypnoEngine *vm) : _vm(vm), _filename(""), _frame(0), _palette(nullptr), _surface(nullptr) {}
+
+	~CursorCache() {
+		if (_surface) {
+			_surface->free();
+			delete _surface;
+		}
+		free(_palette);
+	}
+
+	Graphics::Surface *getCursor(const Common::String &cursor, uint32 n, byte **palette);
+};
 
 class HypnoEngine : public Engine {
 private:
@@ -164,6 +187,7 @@ public:
 	// Cursors
 	Common::String _defaultCursor;
 	uint32 _defaultCursorIdx;
+	CursorCache *_cursorCache;
 	void disableCursor();
 	void defaultCursor();
 	virtual void changeCursor(const Common::String &cursor, uint32 n, bool centerCursor = false);


### PR DESCRIPTION
This is my attempt at fixing bug #15347, "HYPNO: Bad performance under Android in menu of Spider Man: Sinister Six".

Since this is apparently caused by the engine reading and decoding a Smacker frame every time the mouse moves, even though the cursor doesn't actually change, I have added a cursor cache to remember the previous decoded frame.

Another approach would have been to not update the cursor unless necessary, but I don't know the engine well enough for that. Since it looks like 2.9.0 may be approaching, I'm submitting this for discussion. But please don't merge it blindly, because it may be the wrong approach! (I also have no way of testing it on Android.)