### PR TITLE
GOB2: fix missing footsteps sounds for CD-Rom version

### DIFF
--- a/engines/gob/sound/pcspeaker.cpp
+++ b/engines/gob/sound/pcspeaker.cpp
@@ -47,7 +47,10 @@ void PCSpeaker::speakerOn(int16 frequency, int32 length) {
 }
 
 void PCSpeaker::speakerOff() {
-	_stream->stop();
+	// Allow the last samples to be run before turning off the speaker
+	// BUGSTORY: #15341
+	// https://bugs.scummvm.org/ticket/15341
+	_stream->stop(1);
 }
 
 void PCSpeaker::onUpdate(uint32 millis) {


### PR DESCRIPTION
We found that footsteps in CD-Rom version of Gobliins 2 where not played.
After checking why we noticed that sounds where not played because they were stopped before played.
Then, we decided to stop the footsteps sound 1 ms **after** playing it.

Solves the issue 15341 from the ScummVM Bug Tickets: https://bugs.scummvm.org/ticket/15341