### PR TITLE
ULTIMA8: Error out if required game resources aren't found on startup

### DIFF
--- a/engines/ultima/ultima8/ultima8.cpp
+++ b/engines/ultima/ultima8/ultima8.cpp
@@ -585,7 +585,8 @@ Common::Error Ultima8Engine::startupGame() {
 	if (saveSlot == -1 && ConfMan.hasKey("lastSave"))
 		saveSlot = ConfMan.getInt("lastSave");
 
-	newGame(saveSlot);
+	if (!newGame(saveSlot))
+		return Common::kNoGameDataFoundError;
 
 	debug(1, "-- Game Initialized --");
 	return Common::kNoError;
@@ -1121,7 +1122,8 @@ bool Ultima8Engine::newGame(int saveSlot) {
 
 	setupCoreGumps();
 
-	_game->startGame();
+	if (!_game->startGame())
+		return false;
 
 	debug(1, "Create Camera...");
 	CameraProcess::SetCameraProcess(new CameraProcess(kMainActorId));


### PR DESCRIPTION
This stops the game from running if a required game data file is missing, such as U8SAVE.000. Fixes bug 12790

This is an alternative fix for that bug than the one proposed in PR #6217 