### PR TITLE
TITANIC: Validate concepts when accessing them in TTparser - bug #15162

### DIFF
--- a/engines/titanic/true_talk/tt_parser.cpp
+++ b/engines/titanic/true_talk/tt_parser.cpp
@@ -1208,7 +1208,7 @@ int TTparser::considerRequests(TTword *word) {
 			break;
 
 		case MKTAG('F', 'A', 'R', 'R'):
-			if (_conceptP->findBy20(0))
+			if (_conceptP && _conceptP->findBy20(0))
 				_conceptP->_field20 = 2;
 			break;
 
@@ -1251,12 +1251,13 @@ int TTparser::considerRequests(TTword *word) {
 			break;
 
 		case MKTAG('N', 'E', 'A', 'R'):
-			if (_conceptP->findBy20(0)) {
+			if (_conceptP && _conceptP->findBy20(0)) {
 				_conceptP->_field20 = 1;
 			} else {
 				TTpicture *newPictP = new TTpicture(TTstring("?"), WC_THING, 0, 0, 0, 0, 0);
 				status = addToConceptList(newPictP);
-				_conceptP->_field20 = 1;
+				if (_conceptP)
+					_conceptP->_field20 = 1;
 				if (!status)
 					delete newPictP;
 			}


### PR DESCRIPTION
This fixes issues like typing "that" in sentences, where the concept will be null, but the engine will try and modify properties of a null pointer. For some reason, MSVC doesn't crash in this case with invalid memory access, which explains why this bug went unnoticed
