### PR TITLE
AGI: PREAGI: Handle carriage return characters

### DIFF
--- a/engines/agi/preagi/preagi.cpp
+++ b/engines/agi/preagi/preagi.cpp
@@ -112,6 +112,7 @@ void PreAgiEngine::drawStr(int row, int col, int attr, const char *buffer) {
 
 		switch (code) {
 		case '\n':
+		case '\r': // winnie
 		case 0x8D:
 			if (++row == 200 / 8) return;
 			col = 0;


### PR DESCRIPTION
Fixes newlines in Winnie the Pooh. Tested in DOS, Amiga, and Apple II versions.

To test, start the game and go north until reaching the north pole, then read the sign.

I'm doing this as a PR because I'm new to preagi. This change would only be a problem if one of the other two games used character 13 for something special. (Troll's tale or Mickey's Space Adventure)

@bluegr for reference, you first added the character handling code in: 2182d758d07432d990b0e18beb569d539b901e00

Before:
![scummvm-winnie-00001](https://github.com/user-attachments/assets/235e7269-cdd3-4c02-9949-ce3f7e3c2e59)

After:
![scummvm-winnie-00002](https://github.com/user-attachments/assets/177f7eae-99cf-4a93-88ad-2bbbda31f675)
