### PR TITLE
AGI: PREAGI: Fix Winnie the Pooh game loop

### DIFF
--- a/engines/agi/preagi/winnie.cpp
+++ b/engines/agi/preagi/winnie.cpp
@@ -1047,10 +1047,12 @@ void WinnieEngine::gameLoop() {
 
 		if (decodePhase == 3) {
 			for (iBlock = 0; iBlock < IDI_WTP_MAX_BLOCK; iBlock++) {
-				if (parser(hdr.ofsBlock[iBlock] - _roomOffset, iBlock, roomdata) == IDI_WTP_PAR_GOTO) {
+				int result = parser(hdr.ofsBlock[iBlock] - _roomOffset, iBlock, roomdata);
+				if (result == IDI_WTP_PAR_GOTO) {
 					decodePhase = 0;
 					break;
-				} else if (parser(hdr.ofsBlock[iBlock] - _roomOffset, iBlock, roomdata) == IDI_WTP_PAR_BACK) {
+				}
+				if (result == IDI_WTP_PAR_BACK) {
 					decodePhase = 2;
 					break;
 				}


### PR DESCRIPTION
When trying to play this game (to test AGI picture code), it would randomly behave unexpectedly. Prompts were repeated, or selections were ignored, or the game would think it was in a different room than the picture on the screen. All of this was inconsistent, but frequent. Then I found a consistent example where an Eeyore menu always repeats: https://bugs.scummvm.org/ticket/15472

The problem is that the game loop attempts to test the return value of the `parser` function against two values ("goto" or "back") but instead it runs `parser` for each comparison. This causes unpredictable behavior depending on which `parser` call you happen to land on, as each call ignores one of the possible return values. With this change, I haven't had any of these problems.