### PR TITLE
COMMON: Avoid punycoding paths in configuration for Win32

### DIFF
--- a/backends/platform/sdl/win32/win32.cpp
+++ b/backends/platform/sdl/win32/win32.cpp
@@ -289,7 +289,7 @@ Common::Path OSystem_Win32::getDefaultDLCsPath() {
 		CreateDirectory(dlcsPath, nullptr);
 	}
 
-	return Common::Path(Win32::tcharToString(dlcsPath));
+	return Common::Path(Win32::tcharToString(dlcsPath), Common::Path::kNativeSeparator);
 }
 
 Common::Path OSystem_Win32::getScreenshotsPath() {

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -856,12 +856,13 @@ Common::String parseCommandLine(Common::StringMap &settings, int argc, const cha
 			END_OPTION
 
 			DO_LONG_OPTION("soundfont")
-				Common::FSNode path(Common::Path::fromConfig(option));
+				Common::FSNode path(Common::Path::fromCommandLine(option));
 				if (!path.exists()) {
 					usage("Non-existent soundfont path '%s'", option);
 				} else if (!path.isReadable()) {
 					usage("Non-readable soundfont path '%s'", option);
 				}
+				settings["soundfont"] = path.getPath().toConfig();
 			END_OPTION
 
 #ifdef SDL_BACKEND

--- a/common/path.cpp
+++ b/common/path.cpp
@@ -1025,6 +1025,18 @@ Path Path::punycodeEncode() const {
 		}, tmp);
 }
 
+bool Path::punycodeNeedsEncode() const {
+	bool tmp;
+	return reduceComponents<bool &>(
+		[](bool &result, const String &in, bool last) -> bool & {
+			// If we already need encode, we still need it
+			if (result) return result;
+
+			result = punycode_needEncode(in);
+			return result;
+		}, tmp);
+}
+
 // For a path component creates a string with following property:
 // if 2 files have the same case-insensitive
 // identifier string then and only then we treat them as

--- a/common/path.cpp
+++ b/common/path.cpp
@@ -1152,6 +1152,54 @@ Path Path::fromConfig(const String &value) {
 	return Path(value, '/').punycodeDecode();
 }
 
+String Path::toConfig() const {
+#if defined(WIN32)
+	if (!isEscaped()) {
+		// If we are escaped, we have forbidden characters (slash or pipe) which must be encoded
+		// This can't happen on real Win32 paths
+#if defined(UNICODE)
+		// With UNICODE every path is encoded by the backend to UTF-8 strings all the configuration
+		// Except for (strange) cases where we would like to store paths containing backslashes,
+		// there is no need for escaping
+		if (strchr(_str.c_str(), Path::kNativeSeparator) == nullptr) {
+			return toString(Path::kNativeSeparator);
+		}
+#else
+		// Under WIN32 we try to store paths without punycoding the ':' for drives
+		// and using \ to keep the file simple.
+		// This also allows the configuration file to be backwards compatible for simple cases.
+		// Having non-ASCII characters in the path makes it punycoded anyway.
+		const char *start = nullptr;
+
+		// Check for DOS, Win32 device namespace and Win32 file name namespace style paths
+		// The checks are done from less costly to more
+		if (_str.size() >= 2 && _str[1] == ':' && Common::isAlpha(_str[0])) {
+			// This looks like a DOS drive specifier,
+			start = _str.c_str() + 2;
+		} else if (_str.size() >= 4 &&
+			_str[0] == SEPARATOR &&
+			_str[1] == SEPARATOR &&
+			_str[3] == SEPARATOR && (
+				_str[2] == '?' ||
+				_str[2] == '.')) {
+			// This looks like a Win32 device or drive namespaces specifier...
+			start = _str.c_str() + 4;
+			if (_str.size() >= 6 && _str[5] == ':' && Common::isAlpha(_str[4])) {
+				// ...which contains a drive specifier
+				start += 2;
+			}
+		}
+		// with some luck we don't need to punycode the path
+		if (start && !extract(start).punycodeNeedsEncode()) {
+			return toString(Path::kNativeSeparator);
+		}
+#endif
+	}
+#endif
+
+	return punycodeEncode().toString('/');
+}
+
 Path Path::fromCommandLine(const String &value) {
 	if (value.empty()) {
 		return Path();

--- a/common/path.h
+++ b/common/path.h
@@ -164,9 +164,6 @@ private:
 	 */
 	bool compareComponents(bool (*comparator)(const String &x, const String &y), const Path &other) const;
 
-	static Path &punycode_decodefilename_helper(Path &path, const String &in, bool last);
-	static Path &punycode_encodefilename_helper(Path &path, const String &in, bool last);
-
 	/**
 	 * Determines if the path is escaped
 	 */

--- a/common/path.h
+++ b/common/path.h
@@ -499,6 +499,11 @@ public:
 	Path punycodeEncode() const;
 
 	/**
+	 * Returns whether the path will need to be Punycoded
+	 */
+	bool punycodeNeedsEncode() const;
+
+	/**
 	 * Convert all characters in the path to lowercase.
 	 *
 	 * Be aware that this only affects the case of ASCII characters. All

--- a/common/path.h
+++ b/common/path.h
@@ -561,10 +561,10 @@ public:
 	/**
 	 * Use by ConfigManager to store a path in a protected fashion
 	 * All components are punyencoded and / is used as a delimiter for all platforms
+	 * Under Windows don't encode when it's not needed and make use of \ separator
+	 * in this case
 	 */
-	String toConfig() const {
-		return punycodeEncode().toString('/');
-	}
+	String toConfig() const;
 
 	/**
 	 * Used by ConfigManager to parse a configuration value in a backwards compatible way

--- a/common/punycode.cpp
+++ b/common/punycode.cpp
@@ -210,6 +210,11 @@ bool punycode_needEncode(const String &src) {
 	if (!src.size())
 		return false;
 
+	// If name begins with xn-- this could become ambiguous
+	if (src.size() > 4 && src[0] == 'x' && src[1] == 'n' &&
+		src[2] == '-' && src[3] == '-')
+		return true;
+
 	for (uint si = 0; si < src.size(); si++) {
 		if (src[si] & 0x80 || src[si] < 0x20 || strchr(SPECIAL_SYMBOLS, src[si])) {
 			return true;


### PR DESCRIPTION
Under Win32 paths use colons and dots with a special meaning.
These are puny-encoded and the paths in configuration file are not quite readable anymore.

For such paths, don't puny-encode and return them using the traditional backslash path separator.

I only do it for absolute paths to avoid unplanned consequences with path not absolute (not sure if we have any).

I also fix a `fromConfig` leftover coming from before the introduction of `fromCommandLine`