### PR TITLE
SCUMM: [RFC, WIP] Fix Valgrind warnings when saving

### DIFF
--- a/engines/scumm/actor.h
+++ b/engines/scumm/actor.h
@@ -67,9 +67,9 @@ struct CostumeData {
 	uint16 frame[16];
 
 	/* HE specific */
-	uint16 heJumpOffsetTable[16];
-	uint16 heJumpCountTable[16];
-	uint32 heCondMaskTable[16];
+	uint16 heJumpOffsetTable[16] = {};
+	uint16 heJumpCountTable[16] = {};
+	uint32 heCondMaskTable[16] = {};
 
 	void reset() {
 		animCounter = 0;

--- a/engines/scumm/gfx_gui.cpp
+++ b/engines/scumm/gfx_gui.cpp
@@ -39,6 +39,8 @@
 namespace Scumm {
 
 void ScummEngine::initBanners() {
+	memset(_bannerColors, 0, sizeof(_bannerColors));
+
 	setPalColor(7, 0x5A, 0x5A, 0x5A);
 	setPalColor(8, 0x46, 0x46, 0x46);
 	setPalColor(15, 0x8C, 0x8C, 0x8C);

--- a/engines/scumm/imuse_digi/dimuse_fades.cpp
+++ b/engines/scumm/imuse_digi/dimuse_fades.cpp
@@ -155,6 +155,14 @@ void IMuseDigiFadesHandler::clearAllFades() {
 	for (int l = 0; l < DIMUSE_MAX_FADES; l++) {
 		_fades[l].status = 0;
 		_fades[l].sound = 0;
+		_fades[l].param = 0;
+		_fades[l].currentVal = 0;
+		_fades[l].counter = 0;
+		_fades[l].length = 0;
+		_fades[l].slope = 0;
+		_fades[l].slopeMod = 0;
+		_fades[l].modOvfloCounter = 0;
+		_fades[l].nudge = 0;
 	}
 	_fadesOn = 0;
 }

--- a/engines/scumm/imuse_digi/dimuse_files.h
+++ b/engines/scumm/imuse_digi/dimuse_files.h
@@ -42,7 +42,7 @@ private:
 	IMuseDigiSndBuffer _soundBuffers[4];
 	char _currentSpeechFilename[60] = {};
 	ScummFile *_ftSpeechFile;
-	char _ftSpeechFilename[160];
+	char _ftSpeechFilename[160] = {};
 	int _ftSpeechSubFileOffset;
 	int _ftSpeechFileSize;
 	int _ftSpeechFileCurPos;

--- a/engines/scumm/imuse_digi/dimuse_files.h
+++ b/engines/scumm/imuse_digi/dimuse_files.h
@@ -40,7 +40,7 @@ private:
 	ScummEngine_v7 *_vm;
 	Common::Mutex _mutex;
 	IMuseDigiSndBuffer _soundBuffers[4];
-	char _currentSpeechFilename[60];
+	char _currentSpeechFilename[60] = {};
 	ScummFile *_ftSpeechFile;
 	char _ftSpeechFilename[160];
 	int _ftSpeechSubFileOffset;

--- a/engines/scumm/imuse_digi/dimuse_tracks.cpp
+++ b/engines/scumm/imuse_digi/dimuse_tracks.cpp
@@ -49,6 +49,17 @@ int IMuseDigital::tracksInit() {
 		_tracks[l].dispatchPtr = dispatchGetDispatchByTrackId(l);
 		_tracks[l].dispatchPtr->trackPtr = &_tracks[l];
 		_tracks[l].soundId = 0;
+		_tracks[l].group = 0;
+		_tracks[l].marker = 0;
+		_tracks[l].priority = 0;
+		_tracks[l].vol = 0;
+		_tracks[l].effVol = 0;
+		_tracks[l].pan = 0;
+		_tracks[l].detune = 0;
+		_tracks[l].transpose = 0;
+		_tracks[l].pitchShift = 0;
+		_tracks[l].mailbox = 0;
+		_tracks[l].jumpHook = 0;
 		_tracks[l].syncSize_0 = 0;
 		_tracks[l].syncSize_1 = 0;
 		_tracks[l].syncSize_2 = 0;

--- a/engines/scumm/imuse_digi/dimuse_triggers.cpp
+++ b/engines/scumm/imuse_digi/dimuse_triggers.cpp
@@ -42,8 +42,34 @@ int IMuseDigiTriggersHandler::deinit() {
 int IMuseDigiTriggersHandler::clearAllTriggers() {
 	for (int l = 0; l < DIMUSE_MAX_TRIGGERS; l++) {
 		_trigs[l].sound = 0;
+		memset(_trigs[l].text, 0, sizeof(_trigs[l].text));
+		_trigs[l].opcode = 0;
+		_trigs[l].a = 0;
+		_trigs[l].b = 0;
+		_trigs[l].c = 0;
+		_trigs[l].d = 0;
+		_trigs[l].e = 0;
+		_trigs[l].f = 0;
+		_trigs[l].g = 0;
+		_trigs[l].h = 0;
+		_trigs[l].i = 0;
+		_trigs[l].j = 0;
 		_trigs[l].clearLater = 0;
+	}
+
+	for (int l = 0; l < DIMUSE_MAX_DEFERS; l++) {
 		_defers[l].counter = 0;
+		_defers[l].opcode = 0;
+		_defers[l].a = 0;
+		_defers[l].b = 0;
+		_defers[l].c = 0;
+		_defers[l].d = 0;
+		_defers[l].e = 0;
+		_defers[l].f = 0;
+		_defers[l].g = 0;
+		_defers[l].h = 0;
+		_defers[l].i = 0;
+		_defers[l].j = 0;
 	}
 	_defersOn = 0;
 	_midProcessing = 0;

--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -53,7 +53,7 @@ struct SaveGameHeader {
 	uint32 type;
 	uint32 size;
 	uint32 ver;
-	char name[32];
+	char name[32] = {};
 };
 
 struct SaveInfoSection {


### PR DESCRIPTION
Currently, ScummVM will print a lot of Valgrind warnings when saving, at least in The Dig, Full Throttle and The Curse of Monkey Island. This is my attempt at fixing some of these. Most of the warnings I've seen so far are caused by uninitialized data in Digital iMUSE, and while these warnings are _probably_ harmless they do potentially obscure more serious ones. (E.g. there's a warning in the thumbnail code when saving in Curse of Monkey Island.)

This isn't complete by any means. Full Throttle in particular has lots of warnings about data that looks like it should already be initialized to me, so I guess it's then overwritten with uninitialized data?

I don't know if this is important enough to go into 2.9.0 or not. I welcome any help. (I haven't even tried the earlier games, nor the HE ones yet.)