### PR TITLE
AGI: Process events while executing commands

### DIFF
--- a/engines/agi/op_cmd.cpp
+++ b/engines/agi/op_cmd.cpp
@@ -2357,6 +2357,8 @@ int AgiEngine::runLogic(int16 logicNr) {
 	_game._curLogic->cIP = _game._curLogic->sIP;
 
 	while (state->_curLogic->cIP < _game.logics[logicNr].size && !(shouldQuit() || _restartGame)) {
+		processScummVMEvents();
+
 		// TODO: old code, needs to be adjusted
 #if 0
 		if (_debug.enabled) {


### PR DESCRIPTION
This has a direct effect in e.g. [Police Quest Apple IIGS demo](https://downloads.scummvm.org/frs/demos/agi/agi-2gs-demo-pack-en.zip) where the script checks the state of MIDI playback. This works fine as long as the playback is executed in another thread but on platforms which depend on regular pollEvent() events it leads to an infinite loop within AgiEngine::runLogic().
