### PR TITLE
BACKENDS: SAVES: WIN32: Use DeleteFile() instead of _tremove()

### DIFF
--- a/backends/saves/windows/windows-saves.cpp
+++ b/backends/saves/windows/windows-saves.cpp
@@ -57,14 +57,18 @@ WindowsSaveFileManager::WindowsSaveFileManager(bool isPortable) {
 
 Common::ErrorCode WindowsSaveFileManager::removeFile(const Common::FSNode &fileNode) {
 	TCHAR *tFile = Win32::stringToTchar(fileNode.getPath().toString(Common::Path::kNativeSeparator));
-	int result = _tremove(tFile);
+	BOOL result = DeleteFile(tFile);
 	free(tFile);
-	if (result == 0)
+	if (result)
 		return Common::kNoError;
-	if (errno == EACCES)
+
+	switch (GetLastError()) {
+	case ERROR_ACCESS_DENIED:
 		return Common::kWritePermissionDenied;
-	if (errno == ENOENT)
+
+	case ERROR_FILE_NOT_FOUND:
 		return Common::kPathDoesNotExist;
+	}
 	return Common::kUnknownError;
 }
 


### PR DESCRIPTION
I suggest to use `DeleteFile()` instead of `_tremove()` inside `backends\saves\windows\windows-saves.cpp`.
Both functions accept `TCHAR` as parameter, so they can be exchanged easily.
For reference, this is the page about `DeleteFile()` from MSDN:

https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-deletefile

Interesting parts of the above page are:
```
BOOL DeleteFile(
  [in] LPCTSTR lpFileName
);
```
```
If the function succeeds, the return value is nonzero.
If the function fails, the return value is zero (0).
To get extended error information, call GetLastError.
```
```
If an application attempts to delete a file that does not exist, the DeleteFile function fails with ERROR_FILE_NOT_FOUND.
If the file is a read-only file, the function fails with ERROR_ACCESS_DENIED.
```
Since this `windows-saves.cpp` is expected to be used only on platforms running Microsoft Windows, there is no need to keep the overhead introduced by `_tremove()`.
