### PR TITLE
SCUMM: MACGUI: Fall back on using no Mac GUI for unrecognized versions

### DIFF
--- a/engines/scumm/macgui/macgui.cpp
+++ b/engines/scumm/macgui/macgui.cpp
@@ -60,8 +60,8 @@ int MacGui::getNumColors() const {
 	return _impl->getNumColors();
 }
 
-void MacGui::initialize() {
-	_impl->initialize();
+bool MacGui::initialize() {
+	return _impl->initialize();
 }
 
 void MacGui::reset() {

--- a/engines/scumm/macgui/macgui.h
+++ b/engines/scumm/macgui/macgui.h
@@ -48,7 +48,7 @@ public:
 
 	int getNumColors() const;
 
-	void initialize();
+	bool initialize();
 	void reset();
 	void update(int delta);
 	void updateWindowManager();

--- a/engines/scumm/macgui/macgui_impl.cpp
+++ b/engines/scumm/macgui/macgui_impl.cpp
@@ -163,7 +163,10 @@ void MacGuiImpl::menuCallback(int id, Common::String &name, void *data) {
 	}
 }
 
-void MacGuiImpl::initialize() {
+bool MacGuiImpl::initialize() {
+	if (!readStrings())
+		return false;
+
 	uint32 menuMode = Graphics::kWMModeNoDesktop | Graphics::kWMModeAutohideMenu |
 		Graphics::kWMModalMenuMode | Graphics::kWMModeNoCursorOverride | Graphics::kWMModeForceMacFonts;
 
@@ -286,6 +289,8 @@ void MacGuiImpl::initialize() {
 			break;
 		}
 	}
+
+	return true;
 }
 
 bool MacGuiImpl::handleMenu(int id, Common::String &name) {

--- a/engines/scumm/macgui/macgui_impl.h
+++ b/engines/scumm/macgui/macgui_impl.h
@@ -226,7 +226,7 @@ protected:
 
 	bool runOkCancelDialog(Common::String text);
 
-	void readStrings();
+	bool readStrings();
 	void parseSTRSBlock(uint8 *strsData, MacSTRSParsingEntry *parsingTable, int parsingTableSize);
 
 	// These are non interactable, no point in having them as widgets for now...
@@ -708,7 +708,7 @@ public:
 	virtual bool handleEvent(Common::Event event);
 
 	static void menuCallback(int id, Common::String &name, void *data);
-	virtual void initialize();
+	virtual bool initialize();
 	void updateWindowManager();
 
 	const Graphics::Font *getFont(FontId fontId);

--- a/engines/scumm/macgui/macgui_indy3.cpp
+++ b/engines/scumm/macgui/macgui_indy3.cpp
@@ -928,8 +928,6 @@ MacIndy3Gui::MacIndy3Gui(ScummEngine *vm, const Common::Path &resourceFile) :
 
 	_dirtyRects.clear();
 	_textArea.create(448, 47, Graphics::PixelFormat::createFormatCLUT8());
-
-	readStrings();
 }
 
 MacIndy3Gui::~MacIndy3Gui() {

--- a/engines/scumm/macgui/macgui_loom.cpp
+++ b/engines/scumm/macgui/macgui_loom.cpp
@@ -50,7 +50,6 @@ MacLoomGui::MacLoomGui(ScummEngine *vm, const Common::Path &resourceFile) : MacG
 	// a large screen, and it's not saved.
 
 	_practiceBoxPos = Common::Point(215, 376 + 2 * _vm->_macScreenDrawOffset);
-	readStrings();
 }
 
 MacLoomGui::~MacLoomGui() {

--- a/engines/scumm/macgui/macgui_strings.cpp
+++ b/engines/scumm/macgui/macgui_strings.cpp
@@ -602,13 +602,13 @@ static MacGuiImpl::MacSTRSParsingEntry strsIndy4FloppyVariant2Table[] = {
 #undef SKIP_C
 #undef SKIP_P
 
-void MacGuiImpl::readStrings() {
+bool MacGuiImpl::readStrings() {
 	Common::MacResManager resource;
 	resource.open(_resourceFile);
 	uint32 strsLen = resource.getResLength(MKTAG('S', 'T', 'R', 'S'), 0);
 
 	if (strsLen <= 0)
-		return;
+		return false;
 
 	Common::SeekableReadStream *strsStream = resource.getResource(MKTAG('S', 'T', 'R', 'S'), 0);
 	uint8 *strsBlock = (uint8 *)malloc(strsLen);
@@ -676,8 +676,6 @@ void MacGuiImpl::readStrings() {
 			parsingTableSize = ARRAYSIZE(strsIndy4CDVariant2Table);
 			break;
 		}
-	} else {
-		error("MacGuiImpl::readStrings(): String parsing table not defined for this game");
 	}
 
 	if (parsingTable)
@@ -687,6 +685,8 @@ void MacGuiImpl::readStrings() {
 
 	free(strsBlock);
 	delete strsStream;
+
+	return parsingTable != nullptr;
 }
 
 void MacGuiImpl::parseSTRSBlock(uint8 *strsData, MacSTRSParsingEntry *parsingTable, int parsingTableSize) {

--- a/engines/scumm/macgui/macgui_v5.cpp
+++ b/engines/scumm/macgui/macgui_v5.cpp
@@ -45,7 +45,6 @@ namespace Scumm {
 // ===========================================================================
 
 MacV5Gui::MacV5Gui(ScummEngine *vm, const Common::Path &resourceFile) : MacGuiImpl(vm, resourceFile) {
-	readStrings();
 }
 
 const Graphics::Font *MacV5Gui::getFontByScummId(int32 id) {

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -1335,8 +1335,12 @@ Common::Error ScummEngine::init() {
 
 		memset(_completeScreenBuffer, 0, 320 * 200);
 
-		if (_macGui)
-			_macGui->initialize();
+		if (_macGui) {
+			if (!_macGui->initialize()) {
+				delete _macGui;
+				_macGui = nullptr;
+			}
+		}
 	}
 
 	// Initialize backend


### PR DESCRIPTION
This arose out of https://bugs.scummvm.org/ticket/15482

While there are currently no known unsupported versions, this patch allows the game to still run albeit without the Mac GUI.

It moves the string reading from the constructor into the initialize() method, which now returns true or false. I think that should be safe.

I hope disabling the Mac GUI like this is safe.

There should probably be a nice dialog telling the user what happened. I didn't add that, and it seems pretty close to a release to add new strings to translate.

