### PR TITLE
BAGEL: Disable saving in the demo

### DIFF
--- a/engines/bagel/bagel.cpp
+++ b/engines/bagel/bagel.cpp
@@ -148,11 +148,11 @@ bool BagelEngine::canSaveLoadFromWindow() const {
 }
 
 bool BagelEngine::canLoadGameStateCurrently(Common::U32String *msg) {
-	return canSaveLoadFromWindow();
+	return canSaveLoadFromWindow() && !isDemo();
 }
 
 bool BagelEngine::canSaveGameStateCurrently(Common::U32String *msg) {
-	return canSaveLoadFromWindow();
+	return canSaveLoadFromWindow() && !isDemo();
 }
 
 Common::Error BagelEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {

--- a/engines/bagel/spacebar/spacebar.cpp
+++ b/engines/bagel/spacebar/spacebar.cpp
@@ -113,7 +113,7 @@ ErrorCode SpaceBarEngine::initialize() {
 		if (saveSlot != -1) {
 			bRestart = loadGameState(saveSlot).getCode() != Common::kNoError;
 
-		} else if (savesExist()) {
+		} else if (savesExist() && !isDemo()) {
 			bRestart = false;
 
 			CBagStartDialog cDlg(buildSysDir("START.BMP"), _masterWin);


### PR DESCRIPTION
This fixes a crash on startup if an autosave has been created, since the demo lacks the resources for the start dialog.