### PR TITLE
SCUMM: MACGUI: Don't display the 'rough' GUI warning when using original_gui=false

### DIFF
--- a/engines/scumm/macgui/macgui_v5.cpp
+++ b/engines/scumm/macgui/macgui_v5.cpp
@@ -940,7 +940,7 @@ bool MacV5Gui::handleEvent(Common::Event event) {
 			_roughProgress++;
 			if (_roughProgress >= strlen(rough)) {
 				_roughProgress = 0;
-				if (_vm->_useMacGraphicsSmoothing && !_roughWarned) {
+				if (_vm->isUsingOriginalGUI() && _vm->_useMacGraphicsSmoothing && !_roughWarned) {
 					_roughWarned = true;
 
 					Common::String msg = _strsStrings[kMSIRoughCommandMsg];


### PR DESCRIPTION
This fixes [Trac#15487](https://bugs.scummvm.org/ticket/15487), i.e. trying to type `rough` in-game, in a SCUMM Macintosh title, when using `original_gui=false`.

If the user chose not to enable the original GUI, then we can't show them any original warning (since it requires the original GUI). So we should still disable the GFX effect, but silently.

Otherwise, it would just segfault, anyway.

OK?

**Backport:** To be cherry-picked to the (new) 2.9.0 branch as well