### PR TITLE
SCUMM: Initialize class members

### DIFF
--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -105,11 +105,8 @@ static const byte v0WalkboxSlantedModifier[0x16] = {
 };
 
 Actor::Actor(ScummEngine *scumm, int id) :
-	_vm(scumm), _number(id), _visible(false), _shadowMode(0), _flip(false), _frame(0), _walkbox(0), _talkPosX(0), _talkPosY(0),
-	_talkScript(0), _walkScript(0), _ignoreTurns(false), _drawToBackBuf(false), _layer(0), _heOffsX(0), _heOffsY(0), _heSkipLimbs(false),
-	_heCondMask(0), _hePaletteNum(0), _heShadow(0), _elevation(0), _facing(0), _targetFacing(0), _speedx(0), _speedy(0),
-	_animProgress(0), _animSpeed(0), _costumeNeedsInit(false) {
-		assert(_vm != nullptr);
+	_vm(scumm), _number(id) {
+	assert(_vm != nullptr);
 }
 
 ActorHE::ActorHE(ScummEngine *scumm, int id) : Actor(scumm,id) {

--- a/engines/scumm/actor.h
+++ b/engines/scumm/actor.h
@@ -105,67 +105,67 @@ protected:
 	Common::Point _pos;
 
 public:
-	int _top, _bottom;
-	uint _width;
-	byte _number;
-	uint16 _costume;
-	byte _room;
+	int _top = 0, _bottom = 0;
+	uint _width = 0;
+	byte _number = 0;
+	uint16 _costume = 0;
+	byte _room = 0;
 
 public:
-	byte _talkColor;
-	int _talkFrequency;
-	byte _talkPan;
-	byte _talkVolume;
-	uint16 _boxscale;
-	byte _scalex, _scaley;
-	byte _charset;
-	byte _moving;
-	bool _ignoreBoxes;
-	byte _forceClip;
-	uint16 _lastValidX, _lastValidY;
+	byte _talkColor = 0;
+	int _talkFrequency = 0;
+	byte _talkPan = 0;
+	byte _talkVolume = 0;
+	uint16 _boxscale = 0;
+	byte _scalex = 0, _scaley = 0;
+	byte _charset = 0;
+	byte _moving = 0;
+	bool _ignoreBoxes = false;
+	byte _forceClip = 0;
+	uint16 _lastValidX = 0, _lastValidY = 0;
 
-	byte _initFrame;
-	byte _walkFrame;
-	byte _standFrame;
-	byte _talkStartFrame;
-	byte _talkStopFrame;
+	byte _initFrame = 0;
+	byte _walkFrame = 0;
+	byte _standFrame = 0;
+	byte _talkStartFrame = 0;
+	byte _talkStopFrame = 0;
 
-	bool _needRedraw, _needBgReset, _visible;
-	byte _shadowMode;
-	bool _flip;
-	byte _frame;
-	byte _walkbox;
-	int16 _talkPosX, _talkPosY;
-	uint16 _talkScript, _walkScript;
-	bool _ignoreTurns;
-	bool _drawToBackBuf;
-	int32 _layer;
-	uint16 _sound[32];
+	bool _needRedraw = false, _needBgReset = false, _visible = false;
+	byte _shadowMode = 0;
+	bool _flip = false;
+	byte _frame = 0;
+	byte _walkbox = 0;
+	int16 _talkPosX = 0, _talkPosY = 0;
+	uint16 _talkScript = 0, _walkScript = 0;
+	bool _ignoreTurns = false;
+	bool _drawToBackBuf = false;
+	int32 _layer = 0;
+	uint16 _sound[32] = {};
 	CostumeData _cost;
 
 	/* HE specific */
-	int _heOffsX, _heOffsY;
-	bool _heSkipLimbs;
-	uint32 _heCondMask;
-	uint32 _hePaletteNum;
-	uint32 _heShadow;
+	int _heOffsX = 0, _heOffsY = 0;
+	bool _heSkipLimbs = false;
+	uint32 _heCondMask = 0;
+	uint32 _hePaletteNum = 0;
+	uint32 _heShadow = 0;
 
 protected:
 	struct ActorWalkData {
 		Common::Point dest;           // Final destination point
-		byte destbox;                 // Final destination box
-		int16 destdir;                // Final destination, direction to face at
+		byte destbox = 0;             // Final destination box
+		int16 destdir = 0;            // Final destination, direction to face at
 
 		Common::Point cur;            // Last position
-		byte curbox;                  // Last box
+		byte curbox = 0;              // Last box
 
 		Common::Point next;           // Next position on our way to the destination, i.e. our intermediate destination
 
 		Common::Point point3;
-		int32 deltaXFactor, deltaYFactor;
-		uint16 xfrac, yfrac;
-		uint16 xAdd, yAdd;
-		int16 facing;
+		int32 deltaXFactor = 0, deltaYFactor = 0;
+		uint16 xfrac = 0, yfrac = 0;
+		uint16 xAdd = 0, yAdd = 0;
+		int16 facing = 0;
 
 		void reset() {
 			dest.x = dest.y = 0;
@@ -186,15 +186,15 @@ protected:
 	};
 
 
-	uint16 _palette[256];
-	int _elevation;
-	uint16 _facing;
-	uint16 _targetFacing;
-	uint _speedx, _speedy;
-	byte _animProgress, _animSpeed;
-	bool _costumeNeedsInit;
+	uint16 _palette[256] = {};
+	int _elevation = 0;
+	uint16 _facing = 0;
+	uint16 _targetFacing = 0;
+	uint _speedx = 0, _speedy = 0;
+	byte _animProgress = 0, _animSpeed = 0;
+	bool _costumeNeedsInit = false;
 	ActorWalkData _walkdata;
-	int16 _animVariable[27];
+	int16 _animVariable[27] = {};
 
 public:
 
@@ -417,38 +417,38 @@ public:
 
 	Common::Array<byte> _walkboxHistory;
 
-	byte _walkboxQueue[0x10];
-	byte _walkboxQueueIndex;
+	byte _walkboxQueue[0x10] = {};
+	byte _walkboxQueueIndex = 0;
 
-	byte _costCommandNew;
-	byte _costCommand;
-	byte _miscflags;
-	byte _speaking;
+	byte _costCommandNew = 0;
+	byte _costCommand = 0;
+	byte _miscflags = 0;
+	byte _speaking = 0;
 
-	byte _walkCountModulo;
-	bool _newWalkBoxEntered;
+	byte _walkCountModulo = 0;
+	bool _newWalkBoxEntered = false;
 
-	byte _walkDirX;
-	byte _walkDirY;
+	byte _walkDirX = 0;
+	byte _walkDirY = 0;
 
-	byte _walkYCountGreaterThanXCount;
-	byte _walkXCount;
-	byte _walkXCountInc;
-	byte _walkYCount;
-	byte _walkYCountInc;
+	byte _walkYCountGreaterThanXCount = 0;
+	byte _walkXCount = 0;
+	byte _walkXCountInc = 0;
+	byte _walkYCount = 0;
+	byte _walkYCountInc = 0;
 
-	byte _walkMaxXYCountInc;
+	byte _walkMaxXYCountInc = 0;
 
 	Common::Point _tmp_Pos;
 	Common::Point _tmp_NewPos;
-	byte _tmp_WalkBox;
-	bool _tmp_NewWalkBoxEntered;
+	byte _tmp_WalkBox = 0;
+	bool _tmp_NewWalkBoxEntered = false;
 
-	int8 _animFrameRepeat;
-	int8 _limbFrameRepeatNew[8];
-	int8 _limbFrameRepeat[8];
+	int8 _animFrameRepeat = 0;
+	int8 _limbFrameRepeatNew[8] = {};
+	int8 _limbFrameRepeat[8] = {};
 
-	bool _limb_flipped[8];
+	bool _limb_flipped[8] = {};
 
 private:
 

--- a/engines/scumm/actor.h
+++ b/engines/scumm/actor.h
@@ -67,9 +67,9 @@ struct CostumeData {
 	uint16 frame[16];
 
 	/* HE specific */
-	uint16 heJumpOffsetTable[16];
-	uint16 heJumpCountTable[16];
-	uint32 heCondMaskTable[16];
+	uint16 heJumpOffsetTable[16] = {};
+	uint16 heJumpCountTable[16] = {};
+	uint32 heCondMaskTable[16] = {};
 
 	void reset() {
 		animCounter = 0;

--- a/engines/scumm/actor_he.h
+++ b/engines/scumm/actor_he.h
@@ -89,23 +89,23 @@ public:
 	/** This rect is used to clip actor drawing. */
 	Common::Rect _clipOverride;
 
-	bool _heNoTalkAnimation;
-	bool _heTalking;
-	byte _generalFlags;
+	bool _heNoTalkAnimation = false;
+	bool _heTalking = false;
+	byte _generalFlags = 0;
 
-	int _auxActor;
-	int32 _auxEraseX1, _auxEraseY1, _auxEraseX2, _auxEraseY2;
+	int _auxActor = 0;
+	int32 _auxEraseX1 = 0, _auxEraseY1 = 0, _auxEraseX2 = 0, _auxEraseY2 = 0;
 
 	// 80 is the maximum number of strips that any hi-res HE game is going to have
-	int _screenUpdateTableMin[80];
-	int _screenUpdateTableMax[80];
+	int _screenUpdateTableMin[80] = {};
+	int _screenUpdateTableMax[80] = {};
 
 	struct {
 		int16 posX;
 		int16 posY;
 		int16 color;
 		byte sentence[128];
-	} _heTalkQueue[16];
+	} _heTalkQueue[16] = {};
 
 
 	void prepareDrawActorCostume(BaseCostumeRenderer *bcr) override;

--- a/engines/scumm/akos.h
+++ b/engines/scumm/akos.h
@@ -43,7 +43,7 @@ struct AkosOffset;
 
 class AkosCostumeLoader : public BaseCostumeLoader {
 protected:
-	const byte *_akos;
+	const byte *_akos = nullptr;
 
 public:
 	AkosCostumeLoader(ScummEngine *vm) : BaseCostumeLoader(vm) {}
@@ -64,10 +64,10 @@ protected:
 
 class AkosRenderer : public BaseCostumeRenderer {
 protected:
-	uint16 _codec;
+	uint16 _codec = 0;
 
 	// actor _palette
-	uint16 _palette[256];
+	uint16 _palette[256] = {};
 	bool _useBompPalette;
 
 	// pointer to various parts of the costume resource
@@ -111,9 +111,9 @@ public:
 		_actorHitMode = false;
 	}
 
-	bool _actorHitMode;
-	int16 _actorHitX, _actorHitY;
-	bool _actorHitResult;
+	bool _actorHitMode = false;
+	int16 _actorHitX = 0, _actorHitY = 0;
+	bool _actorHitResult = false;
 
 	void setPalette(uint16 *_palette) override;
 	void setFacing(const Actor *a) override;

--- a/engines/scumm/base-costume.h
+++ b/engines/scumm/base-costume.h
@@ -142,6 +142,8 @@ public:
 		_width = _height = 0;
 		_skipLimbs = false;
 		_paletteNum = 0;
+		_actorDrawVirScr = false;
+		_numBlocks = 0;
 	}
 	virtual ~BaseCostumeRenderer() {}
 

--- a/engines/scumm/charset.h
+++ b/engines/scumm/charset.h
@@ -202,7 +202,7 @@ private:
 
 class CharsetRendererNES : public CharsetRendererCommon {
 protected:
-	byte *_trTable;
+	byte *_trTable = nullptr;
 
 	void drawBits1(Graphics::Surface &dest, int x, int y, const byte *src, int drawTop, int width, int height);
 
@@ -223,7 +223,7 @@ protected:
 	virtual int getDrawHeightIntern(uint16 chr);
 	virtual void setDrawCharIntern(uint16 chr) {}
 
-	const byte *_widthTable;
+	const byte *_widthTable = nullptr;
 
 public:
 	CharsetRendererV3(ScummEngine *vm) : CharsetRendererPC(vm) {}
@@ -285,7 +285,7 @@ public:
 
 class CharsetRendererMac : public CharsetRendererCommon {
 protected:
-	const Graphics::Font *_font;
+	const Graphics::Font *_font = nullptr;
 	bool _useCorrectFontSpacing;
 	bool _pad;
 	int _lastTop;

--- a/engines/scumm/dialogs.h
+++ b/engines/scumm/dialogs.h
@@ -151,11 +151,11 @@ protected:
 		kDisplayDelay = 1500
 	};
 	Common::U32String _label;
-	const int _min, _max;
-	const uint16 _incKey, _decKey;
-	int _percentBarWidth;
-	int _value;
-	uint32 _timer;
+	const int _min = 0, _max = 0;
+	const uint16 _incKey = 0, _decKey = 0;
+	int _percentBarWidth = 0;
+	int _value = 0;
+	uint32 _timer = 0;
 };
 
 /**

--- a/engines/scumm/file.h
+++ b/engines/scumm/file.h
@@ -88,20 +88,20 @@ public:
 class ScummDiskImage : public BaseScummFile {
 private:
 	Common::SeekableReadStream *_stream;
-	byte _roomDisks[59], _roomTracks[59], _roomSectors[59];
+	byte _roomDisks[59] = {}, _roomTracks[59] = {}, _roomSectors[59] = {};
 
-	byte *_buf;
+	byte *_buf = nullptr;
 
 	const GameSettings _game;
 
 	const Common::String _disk1, _disk2;
-	int _openedDisk;
+	int _openedDisk = 0;
 
-	int _numGlobalObjects;
-	int _numRooms;
-	int _numCostumes;
-	int _numScripts;
-	int _numSounds;
+	int _numGlobalObjects = 0;
+	int _numRooms = 0;
+	int _numCostumes = 0;
+	int _numScripts = 0;
+	int _numSounds = 0;
 	const int *_resourcesPerFile;
 
 	bool openDisk(char num);

--- a/engines/scumm/gfx_gui.cpp
+++ b/engines/scumm/gfx_gui.cpp
@@ -39,6 +39,8 @@
 namespace Scumm {
 
 void ScummEngine::initBanners() {
+	memset(_bannerColors, 0, sizeof(_bannerColors));
+
 	setPalColor(7, 0x5A, 0x5A, 0x5A);
 	setPalColor(8, 0x46, 0x46, 0x46);
 	setPalColor(15, 0x8C, 0x8C, 0x8C);

--- a/engines/scumm/he/basketball/court.h
+++ b/engines/scumm/he/basketball/court.h
@@ -77,7 +77,7 @@ public:
 		_backboardIndex[1] = 0;
 	}
 
-	~CBBallCourt() {}
+	~CBBallCourt() = default;
 
 	int getPlayerIndex(int playerID);
 	CCollisionPlayer *getPlayerPtr(int playerID);
@@ -102,7 +102,7 @@ public:
 	Common::Array<CCollisionPlayer> _awayPlayerList;
 	int _objectCount;
 	int _backboardIndex[2];
-	U32Sphere _shotSpot[2];
+	U32Sphere _shotSpot[2] = {};
 };
 
 } // End of namespace Scumm

--- a/engines/scumm/he/cup_player_he.h
+++ b/engines/scumm/he/cup_player_he.h
@@ -83,26 +83,26 @@ protected:
 
 	Common::File _fileStream;
 
-	int _playbackRate;
-	int _width, _height;
+	int _playbackRate = 0;
+	int _width = 0, _height = 0;
 
-	uint8 _paletteData[256 * 3];
-	bool _paletteChanged;
-	uint8 *_offscreenBuffer;
+	uint8 _paletteData[256 * 3] = {};
+	bool _paletteChanged = false;
+	uint8 *_offscreenBuffer = nullptr;
 
-	uint8 *_inLzssBufData;
-	uint32 _inLzssBufSize;
-	uint8 *_outLzssBufData;
-	uint32 _outLzssBufSize;
+	uint8 *_inLzssBufData = nullptr;
+	uint32 _inLzssBufSize = 0;
+	uint8 *_outLzssBufData = nullptr;
+	uint32 _outLzssBufSize = 0;
 
-	uint32 _dataSize;
+	uint32 _dataSize = 0;
 
-	int _sfxCount;
-	uint8 *_sfxBuffer;
-	CUP_SfxChannel _sfxChannels[kSfxChannels];
-	CUP_Sfx _sfxQueue[kSfxQueueSize];
-	int _sfxQueuePos;
-	int _lastSfxChannel;
+	int _sfxCount = 0;
+	uint8 *_sfxBuffer = nullptr;
+	CUP_SfxChannel _sfxChannels[kSfxChannels] = {};
+	CUP_Sfx _sfxQueue[kSfxQueueSize] = {};
+	int _sfxQueuePos = 0;
+	int _lastSfxChannel = 0;
 };
 
 } // End of namespace Scumm

--- a/engines/scumm/he/gfx_comp/aux_comp.cpp
+++ b/engines/scumm/he/gfx_comp/aux_comp.cpp
@@ -1102,13 +1102,11 @@ void Wiz::auxDecompDRLEStream(WizRawPixel *destPtr, const byte *dataStream, WizR
 				background8 += runCount;
 
 				destPtr = (WizRawPixel *)dest8;
-				backgroundPtr = (WizRawPixel *)background8;
 			} else {
 				dest16 += runCount;
 				background16 += runCount;
 
 				destPtr = (WizRawPixel *)dest16;
-				backgroundPtr = (WizRawPixel *)background16;
 			}
 
 			decompAmount -= runCount;
@@ -1127,13 +1125,11 @@ void Wiz::auxDecompDRLEStream(WizRawPixel *destPtr, const byte *dataStream, WizR
 					background8 += runCount;
 
 					destPtr = (WizRawPixel *)dest8;
-					backgroundPtr = (WizRawPixel *)background8;
 				} else {
 					dest16 += runCount;
 					background16 += runCount;
 
 					destPtr = (WizRawPixel *)dest16;
-					backgroundPtr = (WizRawPixel *)background16;
 				}
 			} else {
 				runCount += decompAmount;
@@ -1151,14 +1147,12 @@ void Wiz::auxDecompDRLEStream(WizRawPixel *destPtr, const byte *dataStream, WizR
 					background8 += runCount;
 
 					destPtr = (WizRawPixel *)dest8;
-					backgroundPtr = (WizRawPixel *)background8;
 				} else {
 					memcpy(dest16, background16, runCount * sizeof(WizRawPixel16));
 					dest16 += runCount;
 					background16 += runCount;
 
 					destPtr = (WizRawPixel *)dest16;
-					backgroundPtr = (WizRawPixel *)background16;
 				}
 			} else {
 				runCount += decompAmount;

--- a/engines/scumm/he/intern_he.h
+++ b/engines/scumm/he/intern_he.h
@@ -402,10 +402,10 @@ protected:
 #include "common/pack-end.h"	// END STRUCT PACKING
 
 	int _stringLength = 1;
-	byte _stringBuffer[4096];
+	byte _stringBuffer[4096] = {};
 
-	WizImageCommand _wizImageCommand;
-	FloodFillCommand _floodFillCommand;
+	WizImageCommand _wizImageCommand = {};
+	FloodFillCommand _floodFillCommand = {};
 
 public:
 	ScummEngine_v72he(OSystem *syst, const DetectorResult &dr);

--- a/engines/scumm/he/logic/funshop.cpp
+++ b/engines/scumm/he/logic/funshop.cpp
@@ -67,7 +67,7 @@ int32 LogicHEfunshop::dispatch(int op, int numArgs, int32 *args) {
 void LogicHEfunshop::op_1004(int32 *args) {
 	double data[8], at, sq;
 	int32 x, y;
-	int i=0;
+	int i;
 
 	for (i = 0; i <= 6; i += 2) {
 		data[i] = getFromArray(args[0], 0, 519 + i);

--- a/engines/scumm/he/logic/soccer.cpp
+++ b/engines/scumm/he/logic/soccer.cpp
@@ -61,14 +61,14 @@ private:
 
 	// op_1007 allocates some arrays
 	// they're then filled by op_1019
-	byte _collisionObjIds[4096], _collisionNodeEnabled[585];
+	byte _collisionObjIds[4096] = {}, _collisionNodeEnabled[585] = {};
 
 	// op_1011 has a subfunction
 	void calculateDistances(int32 worldPosArray, int32 a2, int32 closestActorArray, int32 maxDistance);
 
 	// array containing collision detection tree
-	bool _collisionTreeAllocated;
-	uint32 *_collisionTree;
+	bool _collisionTreeAllocated = false;
+	uint32 *_collisionTree = nullptr;
 	int addCollisionTreeChild(int depth, int index, int parent);
 
 	// op_1014 has several subops
@@ -85,11 +85,11 @@ private:
 
 	// op_1014 sets an array optionally based upon
 	// setCollisionOutputData; it is then used by op_1008
-	int _internalCollisionOutData[10];
+	int _internalCollisionOutData[10] = {};
 	Common::List<byte> _collisionObjs;
 
 	// op_1021 can (optionally) set two variables for use in op_1008
-	uint32 _var1021[2];
+	uint32 _var1021[2] = {};
 };
 
 int LogicHEsoccer::versionID() {

--- a/engines/scumm/he/moonbase/ai_weapon.h
+++ b/engines/scumm/he/moonbase/ai_weapon.h
@@ -25,11 +25,10 @@
 namespace Scumm {
 
 class Weapon {
-private:
-	int _typeID;
-	float _damage;
-	int _radius;
-	int _cost;
+	int _typeID = 0;
+	float _damage = 0.0f;
+	int _radius = 0;
+	int _cost = 0;
 
 public:
 	Weapon() {}

--- a/engines/scumm/he/moonbase/map_katton.cpp
+++ b/engines/scumm/he/moonbase/map_katton.cpp
@@ -27,9 +27,6 @@ KattonGenerator::KattonGenerator(int seed) {
 	_seed = seed;
 }
 
-KattonGenerator::~KattonGenerator() {
-}
-
 int KattonGenerator::getRandomNumber() {
 	// This is the exact linear congruential generator
 	// algorithm used on MSVCRT (Windows Visual C++ Runtime), with

--- a/engines/scumm/he/moonbase/map_katton.h
+++ b/engines/scumm/he/moonbase/map_katton.h
@@ -34,18 +34,18 @@ namespace Scumm {
 class KattonGenerator {
 public:
 	KattonGenerator(int seed);
-	~KattonGenerator();
+	~KattonGenerator() = default;
 
 	MapFile *generateMap(int water, int tileSet, int mapSize, int energy, int terrain);
 
 private:
-	int _seed;
+	int _seed = 0;
 
-	int _size; // 32, 40, 48, or 56
-	int _tileset;
-	int _startloc[20][2];
-	int _board[MAX_TILE_COUNT][MAX_TILE_COUNT];
-	int _special[MAX_TILE_COUNT][MAX_TILE_COUNT];
+	int _size = 0; // 32, 40, 48, or 56
+	int _tileset = 0;
+	int _startloc[20][2] = { {}, {} };;
+	int _board[MAX_TILE_COUNT][MAX_TILE_COUNT] = { {}, {} };
+	int _special[MAX_TILE_COUNT][MAX_TILE_COUNT] = { {}, {} };;
 
 	int getRandomNumber();
 

--- a/engines/scumm/he/moonbase/map_mif.h
+++ b/engines/scumm/he/moonbase/map_mif.h
@@ -86,11 +86,11 @@ public:
 
 	void generateMap(MapFile *map);
 
-	int _dimension; // 32 (small), 40 (medium), 48 (large), 56 (huge), 64 (SAI)
-	int _mapType;
-	char _name[17];
-	byte _cornerMap[MAX_TILE_COUNT][MAX_TILE_COUNT];
-	int8 _centerMap[MAX_TILE_COUNT][MAX_TILE_COUNT];
+	int _dimension = 0; // 32 (small), 40 (medium), 48 (large), 56 (huge), 64 (SAI)
+	int _mapType = 0;
+	char _name[17] = {};
+	byte _cornerMap[MAX_TILE_COUNT][MAX_TILE_COUNT] = { {}, {} };
+	int8 _centerMap[MAX_TILE_COUNT][MAX_TILE_COUNT] = { {}, {} };
 private:
 
 	void defineStartLocations(MapFile *map);

--- a/engines/scumm/he/moonbase/map_spiff.cpp
+++ b/engines/scumm/he/moonbase/map_spiff.cpp
@@ -29,9 +29,6 @@ SpiffGenerator::SpiffGenerator(int seed) {
 	_seed = seed;
 }
 
-SpiffGenerator::~SpiffGenerator() {
-}
-
 MapFile *SpiffGenerator::generateMap(int water, int tileset, int mapSize, int energy, int terrain) {
 	_totalMapSizeG = mapSize;
 	_energyAmountG = (2 + energy) * _totalMapSizeG * _totalMapSizeG;

--- a/engines/scumm/he/moonbase/map_spiff.h
+++ b/engines/scumm/he/moonbase/map_spiff.h
@@ -57,28 +57,28 @@ namespace Scumm {
 class SpiffGenerator {
 public:
 	SpiffGenerator(int seed);
-	~SpiffGenerator();
+	~SpiffGenerator() = default;
 
 	MapFile *generateMap(int water, int tileset, int mapSize, int energy, int terrain);
 
 private:
-	int _seed;
+	int _seed = 0;
 
-	int _numPoolsG; // per quadrant
-	int _energyAmountG; // 2048 = min energy on small map, 51200 = max energy on max map, etc.
-	int _cliffAmountG; // amount of cliffs, 10 is min, 70 is max
-	int _waterAmountG; // 0 is min, 30 is max
-	int _totalMapSizeG;
+	int _numPoolsG = 0; // per quadrant
+	int _energyAmountG = 0; // 2048 = min energy on small map, 51200 = max energy on max map, etc.
+	int _cliffAmountG = 0;  // amount of cliffs, 10 is min, 70 is max
+	int _waterAmountG = 0;  // 0 is min, 30 is max
+	int _totalMapSizeG = 0;
 
-	int _terrainSeedFlagG; // disables kElevHigh or kElevLow terrain for the initial elevation when appropriate
-	int _islandsFlagG; // enables islands
-	int _advancedMirrorOK_G; // low terrain roughness can leave too abrupt changes at the edge, so set false to disable some mirroring types
-	int _mirrorTypeG; // what mirroring is used
+	int _terrainSeedFlagG = 0; // disables kElevHigh or kElevLow terrain for the initial elevation when appropriate
+	int _islandsFlagG = 0;     // enables islands
+	int _advancedMirrorOK_G = 0; // low terrain roughness can leave too abrupt changes at the edge, so set false to disable some mirroring types
+	int _mirrorTypeG = 0;        // what mirroring is used
 
-	int _mapCornerMaxG; // size of random section
-	int _mapMiddleMaxG;
-	int _mapCorner[MAXSIZE+1][MAXSIZE+1];
-	int _mapMiddle[MAXSIZE][MAXSIZE];
+	int _mapCornerMaxG = 0; // size of random section
+	int _mapMiddleMaxG = 0;
+	int _mapCorner[MAXSIZE+1][MAXSIZE+1] = { {}, {} };;
+	int _mapMiddle[MAXSIZE][MAXSIZE] = { {}, {} };;
 
 	float getRandomFloat();
 	int spiffRand(int min, int max);

--- a/engines/scumm/he/moonbase/moonbase.h
+++ b/engines/scumm/he/moonbase/moonbase.h
@@ -42,9 +42,6 @@ public:
 	void deallocateArray(int array);
 	int callScummFunction(int scriptNumber, int paramCount,...);
 
-	void blitDistortion(byte *bufferData, const int bufferWidth, const int bufferHeight, const int bufferPitch,
-			const Common::Rect *optionalClippingRect, byte *dataStream, const int x, const int y, byte *altSourceBuffer);
-
 	// FOW Stuff
 	bool isFOW(int resNum, int state, uint32 conditionBits) {
 		return resNum == _fowSentinelImage && state == _fowSentinelState && conditionBits == _fowSentinelConditionBits;

--- a/engines/scumm/he/net/net_lobby.h
+++ b/engines/scumm/he/net/net_lobby.h
@@ -185,10 +185,8 @@ protected:
 	void handleAcceptChallenge();
 
 	void startHostingGame(int playerId);
-	void handleHostGameResp(int resp);
 
 	void handleGameSession(int sessionId);
-	void handleGameRelay(int relayId);
 
 	void gameStarted(int hoster, int player, int playerNameArray);
 	void gameFinished();

--- a/engines/scumm/he/sound_he.cpp
+++ b/engines/scumm/he/sound_he.cpp
@@ -50,10 +50,10 @@ SoundHE::SoundHE(ScummEngine *parent, Audio::Mixer *mixer, Common::Mutex *mutex)
 	:
 	Sound(parent, mixer, false),
 	_vm((ScummEngine_v60he *)parent),
+	_mutex(mutex),
 	_overrideFreq(0),
 	_heSpoolingMusicTable(nullptr),
-	_heSpoolingMusicCount(0),
-	_mutex(mutex) {
+	_heSpoolingMusicCount(0) {
 
 	_createSndId = 0;
 	_createSndLastAppend = 0;

--- a/engines/scumm/he/sprite_he.cpp
+++ b/engines/scumm/he/sprite_he.cpp
@@ -41,7 +41,9 @@ Sprite::Sprite(ScummEngine_v90he *vm)
 	_activeSpriteCount(0),
 	_maxSpriteGroups(0),
 	_maxSprites(0),
-	_maxImageLists(0) {
+	_maxImageLists(0),
+	_imageLists(nullptr),
+	_imageListStack(nullptr) {
 }
 
 Sprite::~Sprite() {

--- a/engines/scumm/he/wiz_he.h
+++ b/engines/scumm/he/wiz_he.h
@@ -631,13 +631,13 @@ public:
 		NUM_IMAGES   = 255
 	};
 
-	WizBufferElement _wizBuffer[NUM_IMAGES];
-	uint16 _wizBufferIndex;
-	WizPolygon _polygons[NUM_POLYGONS];
+	WizBufferElement _wizBuffer[NUM_IMAGES] = {};
+	uint16 _wizBufferIndex = 0;
+	WizPolygon _polygons[NUM_POLYGONS] = {};
 
 	// For collision
-	WizRawPixel _compareBufferA[640];
-	WizRawPixel _compareBufferB[640];
+	WizRawPixel _compareBufferA[640] = {};
+	WizRawPixel _compareBufferB[640] = {};
 
 	Wiz(ScummEngine_v71he *vm);
 	~Wiz() {
@@ -968,7 +968,7 @@ public:
 
 	// TRLE
 	int _trlePutSize = 0;
-	byte _trleBuf[(128 * 2) * sizeof(WizRawPixel)];
+	byte _trleBuf[(128 * 2) * sizeof(WizRawPixel)] = {};
 
 	byte *trlePutDump(byte *dest, int nn);
 	byte *trlePutRun(byte *dest, int nn, int cc, int tcolor);
@@ -977,8 +977,8 @@ public:
 
 	// TRLE FLIP
 	bool _initializeAlphaTable = true;
-	float _alphaTable[256];
-	int _precomputed16bppTable[WIZ_QUANTIZED_ALPHA_COUNT][WIZ_COLOR16_COMPONENT_COUNT][WIZ_COLOR16_COMPONENT_COUNT];
+	float _alphaTable[256] = {};
+	int _precomputed16bppTable[WIZ_QUANTIZED_ALPHA_COUNT][WIZ_COLOR16_COMPONENT_COUNT][WIZ_COLOR16_COMPONENT_COUNT] = { {}, {}, {} };
 
 	void trleFLIPDecompressImage(
 		WizRawPixel *bufferPtr, const byte *compData, int bufferWidth, int bufferHeight,

--- a/engines/scumm/imuse/imuse.cpp
+++ b/engines/scumm/imuse/imuse.cpp
@@ -125,7 +125,7 @@ byte *IMuseInternal::findStartOfSound(int sound, int ct) {
 		return ct == trFlag ? ptr + 4 : nullptr;
 
 	ptr += 4;
-	size = READ_BE_UINT32(ptr);
+	//size = READ_BE_UINT32(ptr);
 	ptr += 4;
 
 	// Okay, we're looking for one of those things: either

--- a/engines/scumm/imuse_digi/dimuse_bndmgr.h
+++ b/engines/scumm/imuse_digi/dimuse_bndmgr.h
@@ -76,22 +76,22 @@ private:
 
 	BundleDirCache *_cache;
 	BundleDirCache::AudioTable *_bundleTable;
-	BundleDirCache::IndexNode *_indexTable;
+	BundleDirCache::IndexNode *_indexTable = nullptr;
 	CompTable *_compTable;
 
-	int _numFiles;
-	int _numCompItems;
-	int _lastBlockDecompressedSize;
-	int _curSampleId;
-	int _curDecompressedFilePos;
+	int _numFiles = 0;
+	int _numCompItems = 0;
+	int _lastBlockDecompressedSize = 0;
+	int _curSampleId = 0;
+	int _curDecompressedFilePos = 0;
 	BaseScummFile *_file;
-	bool _compTableLoaded;
-	bool _isUncompressed;
-	int _fileBundleId;
-	byte _compOutputBuff[0x2000];
-	byte *_compInputBuff;
-	int _outputSize;
-	int _lastBlock;
+	bool _compTableLoaded = 0;
+	bool _isUncompressed = 0;
+	int _fileBundleId = 0;
+	byte _compOutputBuff[0x2000] = {};
+	byte *_compInputBuff = nullptr;
+	int _outputSize = 0;
+	int _lastBlock = 0;
 	bool loadCompTable(int32 index);
 
 public:

--- a/engines/scumm/imuse_digi/dimuse_fades.cpp
+++ b/engines/scumm/imuse_digi/dimuse_fades.cpp
@@ -155,6 +155,14 @@ void IMuseDigiFadesHandler::clearAllFades() {
 	for (int l = 0; l < DIMUSE_MAX_FADES; l++) {
 		_fades[l].status = 0;
 		_fades[l].sound = 0;
+		_fades[l].param = 0;
+		_fades[l].currentVal = 0;
+		_fades[l].counter = 0;
+		_fades[l].length = 0;
+		_fades[l].slope = 0;
+		_fades[l].slopeMod = 0;
+		_fades[l].modOvfloCounter = 0;
+		_fades[l].nudge = 0;
 	}
 	_fadesOn = 0;
 }

--- a/engines/scumm/imuse_digi/dimuse_fades.h
+++ b/engines/scumm/imuse_digi/dimuse_fades.h
@@ -32,8 +32,8 @@ class IMuseDigiFadesHandler {
 
 private:
 	IMuseDigital *_engine;
-	IMuseDigiFade _fades[DIMUSE_MAX_FADES];
-	int _fadesOn;
+	IMuseDigiFade _fades[DIMUSE_MAX_FADES] = {};
+	int _fadesOn = 0;
 
 	void clearAllFades();
 public:

--- a/engines/scumm/imuse_digi/dimuse_files.h
+++ b/engines/scumm/imuse_digi/dimuse_files.h
@@ -42,7 +42,7 @@ private:
 	IMuseDigiSndBuffer _soundBuffers[4];
 	char _currentSpeechFilename[60] = {};
 	ScummFile *_ftSpeechFile;
-	char _ftSpeechFilename[160];
+	char _ftSpeechFilename[160] = {};
 	int _ftSpeechSubFileOffset;
 	int _ftSpeechFileSize;
 	int _ftSpeechFileCurPos;

--- a/engines/scumm/imuse_digi/dimuse_files.h
+++ b/engines/scumm/imuse_digi/dimuse_files.h
@@ -40,7 +40,7 @@ private:
 	ScummEngine_v7 *_vm;
 	Common::Mutex _mutex;
 	IMuseDigiSndBuffer _soundBuffers[4];
-	char _currentSpeechFilename[60];
+	char _currentSpeechFilename[60] = {};
 	ScummFile *_ftSpeechFile;
 	char _ftSpeechFilename[160];
 	int _ftSpeechSubFileOffset;

--- a/engines/scumm/imuse_digi/dimuse_groups.h
+++ b/engines/scumm/imuse_digi/dimuse_groups.h
@@ -35,8 +35,8 @@ class IMuseDigiGroupsHandler {
 
 private:
 	IMuseDigital *_engine;
-	int _effVols[DIMUSE_MAX_GROUPS];
-	int _vols[DIMUSE_MAX_GROUPS];
+	int _effVols[DIMUSE_MAX_GROUPS] = {};
+	int _vols[DIMUSE_MAX_GROUPS] = {};
 public:
 	IMuseDigiGroupsHandler(IMuseDigital *engine);
 	~IMuseDigiGroupsHandler();

--- a/engines/scumm/imuse_digi/dimuse_internalmixer.h
+++ b/engines/scumm/imuse_digi/dimuse_internalmixer.h
@@ -45,23 +45,23 @@ namespace Scumm {
 class IMuseDigiInternalMixer {
 
 private:
-	int32 *_amp8Table;
-	int32 *_amp12Table;
-	int32 *_softLMID;
-	int32 *_softLTable;
+	int32 *_amp8Table = nullptr;
+	int32 *_amp12Table = nullptr;
+	int32 *_softLMID = nullptr;
+	int32 *_softLTable = nullptr;
 
-	uint8 *_mixBuf;
+	uint8 *_mixBuf = nullptr;
 
 	Audio::Mixer *_mixer;
 	Audio::SoundHandle _channelHandle;
-	int _mixBufSize;
-	int _radioChatter;
-	int _outWordSize;
-	int _outChannelCount;
-	int _sampleRate;
-	int _stereoReverseFlag;
-	bool _isEarlyDiMUSE;
-	bool _lowLatencyMode;
+	int _mixBufSize = 0;
+	int _radioChatter = 0;
+	int _outWordSize = 0;
+	int _outChannelCount = 0;
+	int _sampleRate = 0;
+	int _stereoReverseFlag = 0;
+	bool _isEarlyDiMUSE = false;
+	bool _lowLatencyMode = false;
 
 	void mixBits8Mono(uint8 *srcBuf, int32 inFrameCount, int feedSize, int32 mixBufStartIndex, int32 *ampTable, bool ftIs11025Hz);
 	void mixBits12Mono(uint8 *srcBuf, int32 inFrameCount, int feedSize, int32 mixBufStartIndex, int32 *ampTable);

--- a/engines/scumm/imuse_digi/dimuse_tracks.cpp
+++ b/engines/scumm/imuse_digi/dimuse_tracks.cpp
@@ -49,6 +49,17 @@ int IMuseDigital::tracksInit() {
 		_tracks[l].dispatchPtr = dispatchGetDispatchByTrackId(l);
 		_tracks[l].dispatchPtr->trackPtr = &_tracks[l];
 		_tracks[l].soundId = 0;
+		_tracks[l].group = 0;
+		_tracks[l].marker = 0;
+		_tracks[l].priority = 0;
+		_tracks[l].vol = 0;
+		_tracks[l].effVol = 0;
+		_tracks[l].pan = 0;
+		_tracks[l].detune = 0;
+		_tracks[l].transpose = 0;
+		_tracks[l].pitchShift = 0;
+		_tracks[l].mailbox = 0;
+		_tracks[l].jumpHook = 0;
 		_tracks[l].syncSize_0 = 0;
 		_tracks[l].syncSize_1 = 0;
 		_tracks[l].syncSize_2 = 0;

--- a/engines/scumm/imuse_digi/dimuse_triggers.cpp
+++ b/engines/scumm/imuse_digi/dimuse_triggers.cpp
@@ -42,8 +42,34 @@ int IMuseDigiTriggersHandler::deinit() {
 int IMuseDigiTriggersHandler::clearAllTriggers() {
 	for (int l = 0; l < DIMUSE_MAX_TRIGGERS; l++) {
 		_trigs[l].sound = 0;
+		memset(_trigs[l].text, 0, sizeof(_trigs[l].text));
+		_trigs[l].opcode = 0;
+		_trigs[l].a = 0;
+		_trigs[l].b = 0;
+		_trigs[l].c = 0;
+		_trigs[l].d = 0;
+		_trigs[l].e = 0;
+		_trigs[l].f = 0;
+		_trigs[l].g = 0;
+		_trigs[l].h = 0;
+		_trigs[l].i = 0;
+		_trigs[l].j = 0;
 		_trigs[l].clearLater = 0;
+	}
+
+	for (int l = 0; l < DIMUSE_MAX_DEFERS; l++) {
 		_defers[l].counter = 0;
+		_defers[l].opcode = 0;
+		_defers[l].a = 0;
+		_defers[l].b = 0;
+		_defers[l].c = 0;
+		_defers[l].d = 0;
+		_defers[l].e = 0;
+		_defers[l].f = 0;
+		_defers[l].g = 0;
+		_defers[l].h = 0;
+		_defers[l].i = 0;
+		_defers[l].j = 0;
 	}
 	_defersOn = 0;
 	_midProcessing = 0;

--- a/engines/scumm/imuse_digi/dimuse_triggers.h
+++ b/engines/scumm/imuse_digi/dimuse_triggers.h
@@ -33,13 +33,14 @@ class IMuseDigiTriggersHandler {
 
 private:
 	IMuseDigital *_engine;
-	IMuseDigiTrigger _trigs[DIMUSE_MAX_TRIGGERS];
-	IMuseDigiDefer _defers[DIMUSE_MAX_DEFERS];
+	IMuseDigiTrigger _trigs[DIMUSE_MAX_TRIGGERS] = {};
+	IMuseDigiDefer _defers[DIMUSE_MAX_DEFERS] = {};
 
-	int  _defersOn;
-	int  _midProcessing;
-	char _textBuffer[256];
-	char _emptyMarker[1];
+	int  _defersOn = 0;
+	int  _midProcessing = 0;
+	char _textBuffer[256] = {};
+	char _emptyMarker[1] = {};
+
 public:
 	IMuseDigiTriggersHandler(IMuseDigital *engine);
 	~IMuseDigiTriggersHandler();

--- a/engines/scumm/insane/insane.h
+++ b/engines/scumm/insane/insane.h
@@ -395,7 +395,6 @@ class Insane {
 	void prepareScenePropScene(int32 scenePropNum, bool arg_4, bool arg_8);
 	int32 calcBenDamage(bool arg_0, bool arg_4);
 	int32 weaponDamage(int32 actornum);
-	void proc47(int32 actornum, int32 val);
 	bool weaponBenIsEffective();
 	bool actor1StateFlags(int state);
 	bool actor0StateFlags1(int state);

--- a/engines/scumm/macgui/macgui_dialogwindow.cpp
+++ b/engines/scumm/macgui/macgui_dialogwindow.cpp
@@ -408,8 +408,6 @@ int MacGuiImpl::MacDialogWindow::runDialog(Common::Array<int> &deferredActionIds
 	if (!_visible) {
 		show();
 
-		Common::Rect windowBounds(_innerSurface.w, _innerSurface.h);
-
 		for (uint i = 0; i < _widgets.size(); i++) {
 			if (_widgets[i]->isVisible()) {
 				_widgets[i]->setRedraw(true);

--- a/engines/scumm/macgui/macgui_impl.h
+++ b/engines/scumm/macgui/macgui_impl.h
@@ -468,10 +468,10 @@ public:
 	class MacSlider : public MacSliderBase {
 	private:
 		Common::Point _clickPos;
-		uint32 _nextRepeat;
+		uint32 _nextRepeat = 0;
 
-		int _pageSize;
-		int _paging;
+		int _pageSize = 0;
+		int _paging = 0;
 
 		bool _upArrowPressed = false;
 		bool _downArrowPressed = false;

--- a/engines/scumm/macgui/macgui_loom.h
+++ b/engines/scumm/macgui/macgui_loom.h
@@ -60,7 +60,7 @@ protected:
 private:
 	Graphics::Surface *_practiceBox = nullptr;
 	Common::Point _practiceBoxPos;
-	int _practiceBoxNotes;
+	int _practiceBoxNotes = 0;
 };
 
 } // End of namespace Scumm

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -86,7 +86,7 @@ Common::Path ScummEngine::generateFilename(const int room) const {
 
 Common::Path ScummEngine_v60he::generateFilename(const int room) const {
 	Common::String result;
-	char id = 0;
+	char id;
 
 	switch (_filenamePattern.genMethod) {
 	case kGenHEMac:

--- a/engines/scumm/midiparser_ro.cpp
+++ b/engines/scumm/midiparser_ro.cpp
@@ -33,11 +33,9 @@ namespace Scumm {
 
 class MidiParser_RO : public MidiParser {
 protected:
-	int _markerCount;     // Number of markers encountered in stream so far
-	int _lastMarkerCount; // Cache markers until parsed event is actually consumed
+	int _markerCount = 0;     // Number of markers encountered in stream so far
+	int _lastMarkerCount = 0; // Cache markers until parsed event is actually consumed
 
-protected:
-	void compressToType0();
 	void parseNextEvent (EventInfo &info) override;
 
 public:

--- a/engines/scumm/players/player_apple2.cpp
+++ b/engines/scumm/players/player_apple2.cpp
@@ -70,11 +70,11 @@ private:
 	}
 
 protected:
-	int _delta;
-	int _count;
-	byte _interval; // must be unsigned byte ("interval < delta" possible)
-	int _limit;
-	bool _decInterval;
+	int _delta = 0;
+	int _count = 0;
+	byte _interval = 0; // must be unsigned byte ("interval < delta" possible)
+	int _limit = 0;
+	bool _decInterval = false;
 };
 
 /*
@@ -122,8 +122,8 @@ private:
 	}
 
 protected:
-	const byte *_params;
-	int _pos;
+	const byte *_params = 0;
+	int _pos = 0;
 };
 
 /*
@@ -167,8 +167,8 @@ private:
 	}
 
 protected:
-	const byte *_params;
-	int _pos;
+	const byte *_params = nullptr;
+	int _pos = 0;
 };
 
 /*
@@ -256,17 +256,17 @@ private:
 	}
 
 protected:
-	const byte *_params;
+	const byte *_params = nullptr;
 
-	byte _updateRemain1;
-	byte _updateRemain2;
+	byte _updateRemain1 = 0;
+	byte _updateRemain2 = 0;
 
-	uint16 _count;
-	byte _bitmask1;
-	byte _bitmask2;
-	byte _updateInterval1;
-	byte _updateInterval2;
-	byte _speakerShiftReg;
+	uint16 _count = 0;
+	byte _bitmask1 = 0;
+	byte _bitmask2 = 0;
+	byte _updateInterval1 = 0;
+	byte _updateInterval2 = 0;
+	byte _speakerShiftReg = 0;
 };
 
 /*
@@ -324,8 +324,8 @@ private:
 	}
 
 protected:
-	int _index;
-	int _param0;
+	int _index = 0;
+	int _param0 = 0;
 
 private:
 	static const byte _noiseTable[256];

--- a/engines/scumm/players/player_apple2.h
+++ b/engines/scumm/players/player_apple2.h
@@ -231,7 +231,7 @@ public:
 	/* returns true if finished */
 	virtual bool update() = 0;
 protected:
-	Player_AppleII *_player;
+	Player_AppleII *_player = nullptr;
 };
 
 class Player_AppleII : public Audio::AudioStream, public MusicEngine {
@@ -263,28 +263,26 @@ public:
 
 private:
 	// sound number
-	int _soundNr;
+	int _soundNr = 0;
 	// type of sound
-	int _type;
+	int _type = 0;
 	// number of loops left
-	int _loop;
+	int _loop = 0;
 	// global sound param list
-	const byte *_params;
+	const byte *_params = nullptr;
 	// speaker toggle state (0 / 1)
-	byte _speakerState;
+	byte _speakerState = 0;
 	// sound function
 	AppleII_SoundFunction *_soundFunc;
 	// cycle to sample converter
 	SampleConverter _sampleConverter;
 
-private:
 	ScummEngine *_vm;
 	Audio::Mixer *_mixer;
 	Audio::SoundHandle _soundHandle;
-	int _sampleRate;
+	int _sampleRate = 0;
 	Common::Mutex _mutex;
 
-private:
 	void resetState();
 	bool updateSound();
 };

--- a/engines/scumm/players/player_he.cpp
+++ b/engines/scumm/players/player_he.cpp
@@ -31,10 +31,11 @@ namespace Scumm {
 Player_HE::Player_HE(ScummEngine *scumm) :
 	_vm(scumm),
 	_currentMusic(-1),
-	_bank(NULL),
-	_parser(NULL),
-	_midi(NULL),
-	_masterVolume(256) {
+	_bank(nullptr),
+	_parser(nullptr),
+	_midi(nullptr),
+	_masterVolume(256),
+	_bankSize(0) {
 
 	for (int chan = 0; chan < 16; chan++)
 		_channelVolume[chan] = 127;

--- a/engines/scumm/players/player_nes.cpp
+++ b/engines/scumm/players/player_nes.cpp
@@ -89,9 +89,9 @@ static const byte LengthCounts[32] = {
 
 class SoundGen {
 protected:
-	byte wavehold;
-	uint32 freq;	// short
-	uint32 CurD;
+	byte wavehold = 0;
+	uint32 freq = 0;	// short
+	uint32 CurD = 0;
 
 public:
 	byte Timer;
@@ -103,11 +103,11 @@ public:
 
 class Square : public SoundGen {
 protected:
-	byte volume, envelope, duty, swpspeed, swpdir, swpstep, swpenab;
-	byte Vol;
-	byte EnvCtr, Envelope, BendCtr;
-	bool Enabled, ValidFreq, Active;
-	bool EnvClk, SwpClk;
+	byte volume = 0, envelope = 0, duty = 0, swpspeed = 0, swpdir = 0, swpstep = 0, swpenab = 0;
+	byte Vol = 0;
+	byte EnvCtr = 0, Envelope = 0, BendCtr = 0;
+	bool Enabled = 0, ValidFreq = 0, Active = 0;
+	bool EnvClk = 0, SwpClk = 0;
 
 	void CheckActive();
 
@@ -236,10 +236,10 @@ void Square::HalfFrame() {
 
 class Triangle : public SoundGen {
 protected:
-	byte linear;
-	byte LinCtr;
-	bool Enabled, Active;
-	bool LinClk;
+	byte linear = 0;
+	byte LinCtr = 0;
+	bool Enabled = false, Active = false;
+	bool LinClk = false;
 
 	void CheckActive();
 
@@ -341,13 +341,11 @@ void Triangle::HalfFrame() {
 
 class Noise : public SoundGen {
 protected:
-	byte volume, envelope, datatype;
-	byte Vol;
-	byte EnvCtr, Envelope;
-	bool Enabled;
-	bool EnvClk;
-
-	void CheckActive();
+	byte volume = 0, envelope = 0, datatype = 0;
+	byte Vol = 0;
+	byte EnvCtr = 0, Envelope = 0;
+	bool Enabled = false;
+	bool EnvClk = false;
 
 public:
 	void Reset();

--- a/engines/scumm/players/player_nes.h
+++ b/engines/scumm/players/player_nes.h
@@ -63,7 +63,6 @@ private:
 	void sound_play();
 	void playSFX(int nr);
 	void playMusic();
-	byte fetchSoundByte(int nr);
 	void chainCommand(int chan);
 	void checkSilenceChannels(int chan);
 

--- a/engines/scumm/players/player_pce.h
+++ b/engines/scumm/players/player_pce.h
@@ -104,9 +104,6 @@ private:
 	int16* _sampleBuffer;
 	int _sampleBufferCnt;
 
-	void init();
-	bool isPlaying();
-
 	void PSG_Write(int reg, byte data);
 
 	void setupWaveform(byte bank);
@@ -114,15 +111,10 @@ private:
 	void updateSound();
 	void procA731(channel_t *channel);
 	void processSoundData(channel_t *channel);
-	void procA9F3(int x);
 	void procAA62(channel_t *channel, int a);
-	uint16 procAAF6(int x);
 	void procAB7F(channel_t *channel);
 	void procAC24(channel_t *channel);
 	void procACEA(channel_t *channel, int a);
-	void procAD21(int a, int x);
-	void procAD29(int value);
-	void procAD3D(int a, int x);
 };
 
 } // End of namespace Scumm

--- a/engines/scumm/players/player_v1.h
+++ b/engines/scumm/players/player_v1.h
@@ -47,8 +47,6 @@ protected:
 	void generateSpkSamples(int16 *data, uint len) override;
 	void generatePCjrSamples(int16 *data, uint len) override;
 
-	void restartSound();
-
 	void set_mplex(uint mplex);
 	void parseSpeakerChunk();
 	void nextSpeakerCmd();

--- a/engines/scumm/players/player_v2a.cpp
+++ b/engines/scumm/players/player_v2a.cpp
@@ -89,8 +89,8 @@ public:
 		_data = nullptr;
 	}
 protected:
-	const uint16 _offset;
-	const uint16 _size;
+	const uint16 _offset = 0;
+	const uint16 _size = 0;
 
 	char *_data;
 };
@@ -203,16 +203,17 @@ public:
 		_id = 0;
 	}
 private:
-	const uint16 _instoff;
-	const uint16 _voloff;
-	const uint16 _chan1off;
-	const uint16 _chan2off;
-	const uint16 _chan3off;
-	const uint16 _chan4off;
-	const uint16 _sampoff;
-	const bool _looped;
+	const uint16 _instoff = 0;
+	const uint16 _voloff = 0;
+	const uint16 _chan1off = 0;
+	const uint16 _chan2off = 0;
+	const uint16 _chan3off = 0;
+	const uint16 _chan4off = 0;
+	const uint16 _sampoff = 0;
+	const bool _looped = false;
 
-	char *_data;
+	char *_data = nullptr;
+
 	struct tchan {
 		uint16 dataptr_i;
 		uint16 dataptr;
@@ -221,7 +222,7 @@ private:
 		uint16 chan;
 		uint16 dur;
 		uint16 ticks;
-	} _chan[4];
+	} _chan[4] = {};
 };
 
 // plays a single waveform
@@ -247,10 +248,10 @@ public:
 		return true;
 	}
 private:
-	const uint16 _freq;
-	const uint8 _vol;
+	const uint16 _freq = 0;
+	const uint8 _vol = 0;
 
-	int _ticks;
+	int _ticks = 0;
 };
 
 // plays a single looped waveform
@@ -324,9 +325,9 @@ public:
 		return true;
 	}
 private:
-	const uint16 _duration;
+	const uint16 _duration = 0;
 
-	int _ticks;
+	int _ticks = 0;
 };
 
 // plays a single looped waveform which starts at one frequency and bends to another frequency, where it remains until stopped
@@ -361,12 +362,12 @@ public:
 		return true;
 	}
 private:
-	const uint16 _freq1;
-	const uint16 _freq2;
-	const uint8 _vol;
-	const uint16 _step;
+	const uint16 _freq1 = 0;
+	const uint16 _freq2 = 0;
+	const uint8 _vol = 0;
+	const uint16 _step = 0;
 
-	uint16 _curfreq;
+	uint16 _curfreq = 0;
 };
 
 // plays a single looped waveform starting at a specific frequency/volume, dropping in frequency and fading volume to zero
@@ -395,11 +396,11 @@ public:
 		return true;
 	}
 private:
-	const uint16 _freq;
-	const uint8 _vol;
+	const uint16 _freq = 0;
+	const uint8 _vol = 0;
 
-	uint16 _curfreq;
-	uint16 _curvol;
+	uint16 _curfreq = 0;
+	uint16 _curvol = 0;
 };
 
 // plays a single looped waveform, fading the volume from zero to maximum at one rate, then back to zero at another rate
@@ -514,12 +515,12 @@ public:
 		return true;
 	}
 private:
-	const uint16 _freq1;
-	const uint16 _freq2;
-	const uint16 _step;
+	const uint16 _freq1 = 0;
+	const uint16 _freq2 = 0;
+	const uint16 _step = 0;
 
-	uint16 _curfreq;
-	int _curvol;
+	uint16 _curfreq = 0;
+	int _curvol = 0;
 };
 
 // plays a single looped waveform, starting at one frequency, bending down to another frequency, and then back up to the original frequency
@@ -594,11 +595,11 @@ public:
 		return true;
 	}
 private:
-	const uint16 _freq1;
-	const uint16 _freq2;
+	const uint16 _freq1 = 0;
+	const uint16 _freq2 = 0;
 
-	uint16 _curfreq;
-	uint8 _curvol;
+	uint16 _curfreq = 0;
+	uint8 _curvol = 0;
 };
 
 // intermittently plays two looped waveforms for a specific duration
@@ -685,13 +686,13 @@ public:
 		return true;
 	}
 private:
-	const uint16 _freq;
-	const uint8 _vol;
-	const uint8 _loopwidth;
-	const uint8 _numloops;
+	const uint16 _freq = 0;
+	const uint8 _vol = 0;
+	const uint8 _loopwidth = 0;
+	const uint8 _numloops = 0;
 
-	int _loop;
-	int _loopctr;
+	int _loop = 0;
+	int _loopctr = 0;
 
 	void soundon() {
 		char *tmp_data = (char *)malloc(_size);
@@ -732,14 +733,14 @@ public:
 		return true;
 	}
 private:
-	const uint16 _freq;
-	const uint8 _vol;
-	const uint8 _numdurs;
-	const uint8 *_durations;
-	const bool _looped;
+	const uint16 _freq = 0;
+	const uint8 _vol = 0;
+	const uint8 _numdurs = 0;
+	const uint8 *_durations = nullptr;
+	const bool _looped = false;
 
-	int _ticks;
-	int _curdur;
+	int _ticks = 0;
+	int _curdur = 0;
 
 	void soundon() {
 		char *tmp_data = (char *)malloc(_size);
@@ -790,17 +791,17 @@ public:
 		return true;
 	}
 private:
-	const uint16 _offset1;
-	const uint16 _size1;
-	const uint16 _offset2;
-	const uint16 _size2;
-	const uint16 _freq1;
-	const uint16 _freq2;
-	const uint8 _vol;
+	const uint16 _offset1 = 0;
+	const uint16 _size1 = 0;
+	const uint16 _offset2 = 0;
+	const uint16 _size2 = 0;
+	const uint16 _freq1 = 0;
+	const uint16 _freq2 = 0;
+	const uint8 _vol = 0;
 
-	int _curfreq;
-	uint16 _loopnum;
-	uint16 _step;
+	int _curfreq = 0;
+	uint16 _loopnum = 0;
+	uint16 _step = 0;
 
 	void soundon(const char *data, int size) {
 		char *tmp_data1 = (char *)malloc(size);
@@ -858,20 +859,20 @@ public:
 		return true;
 	}
 private:
-	const uint16 _offset1;
-	const uint16 _size1;
-	const uint16 _offset2;
-	const uint16 _size2;
-	const uint8 _vol;
+	const uint16 _offset1 = 0;
+	const uint16 _size1 = 0;
+	const uint16 _offset2 = 0;
+	const uint16 _size2 = 0;
+	const uint8 _vol = 0;
 
-	uint16 _freq1;
-	int16 _step1;
-	uint16 _freq2;
-	int16 _step2;
-	uint16 _freq3;
-	int16 _step3;
-	uint16 _freq4;
-	int16 _step4;
+	uint16 _freq1 = 0;
+	int16 _step1 = 0;
+	uint16 _freq2 = 0;
+	int16 _step2 = 0;
+	uint16 _freq3 = 0;
+	int16 _step3 = 0;
+	uint16 _freq4 = 0;
+	int16 _step4 = 0;
 
 	void updatefreq(uint16 &freq, int16 &step, uint16 min, uint16 max) {
 		freq += step;
@@ -944,9 +945,9 @@ public:
 		return true;
 	}
 private:
-	const uint16 _dur;
+	const uint16 _dur = 0;
 
-	int _ticks;
+	int _ticks = 0;
 };
 
 // plays a single looped waveform and slowly fades volume to zero
@@ -1014,12 +1015,12 @@ public:
 		return true;
 	}
 private:
-	const uint16 _freq1;
-	const uint16 _freq2;
+	const uint16 _freq1 = 0;
+	const uint16 _freq2 = 0;
 
-	uint16 _curfreq;
-	int _curvol;
-	int _ticks;
+	uint16 _curfreq = 0;
+	int _curvol = 0;
+	int _ticks = 0;
 };
 
 // plays 4 looped waveforms, starting at specific frequencies and bending at different rates while fading volume to zero
@@ -1071,14 +1072,14 @@ public:
 		return true;
 	}
 private:
-	const uint16 _offset;
-	const uint16 _size;
+	const uint16 _offset = 0;
+	const uint16 _size = 0;
 
-	uint16 _freq1;
-	uint16 _freq2;
-	uint16 _freq3;
-	uint16 _freq4;
-	uint8 _vol;
+	uint16 _freq1 = 0;
+	uint16 _freq2 = 0;
+	uint16 _freq3 = 0;
+	uint16 _freq4 = 0;
+	uint8 _vol = 0;
 };
 
 // plays a single looped waveform, bending the frequency upward at a varying rate
@@ -1115,14 +1116,14 @@ public:
 		return true;
 	}
 private:
-	const uint16 _freq1;
-	const uint16 _freq2;
-	const uint16 _vol;
+	const uint16 _freq1 = 0;
+	const uint16 _freq2 = 0;
+	const uint16 _vol = 0;
 
-	uint16 _curfreq;
-	uint16 _bendrate;
-	uint16 _bendctr;
-	uint16 _holdctr;
+	uint16 _curfreq = 0;
+	uint16 _bendrate = 0;
+	uint16 _bendctr = 0;
+	uint16 _holdctr = 0;
 };
 
 // plays one waveform, then switches to a different looped waveform and slowly fades volume to zero
@@ -1160,14 +1161,14 @@ public:
 	}
 
 private:
-	const uint16 _offset1;
-	const uint16 _offset2;
-	const uint16 _size1;
-	const uint16 _size2;
-	const uint16 _freq;
+	const uint16 _offset1 = 0;
+	const uint16 _offset2 = 0;
+	const uint16 _size1 = 0;
+	const uint16 _size2 = 0;
+	const uint16 _freq = 0;
 
-	int _vol;
-	int _loop;
+	int _vol = 0;
+	int _loop = 0;
 };
 
 // plays 2 looped waveforms at different frequencies, pulsing at different frequencies and ramping the volume up and down once
@@ -1235,16 +1236,16 @@ public:
 		return true;
 	}
 private:
-	const uint16 _offset1;
-	const uint16 _size1;
-	const uint16 _offset2;
-	const uint16 _size2;
-	const uint16 _freq1;
-	const uint16 _freq2;
+	const uint16 _offset1 = 0;
+	const uint16 _size1 = 0;
+	const uint16 _offset2 = 0;
+	const uint16 _size2 = 0;
+	const uint16 _freq1 = 0;
+	const uint16 _freq2 = 0;
 
-	uint16 _loopnum;
-	uint16 _vol;
-	uint16 _beepcount;
+	uint16 _loopnum = 0;
+	uint16 _vol = 0;
+	uint16 _beepcount = 0;
 };
 
 // plays a stereo siren, sweeping up and down quickly several times before sweeping up slowly, stopping, and then going silent
@@ -1312,14 +1313,14 @@ public:
 		}
 	}
 private:
-	const uint16 _offset1;
-	const uint16 _offset2;
-	const uint16 _size1;
-	const uint16 _size2;
+	const uint16 _offset1 = 0;
+	const uint16 _offset2 = 0;
+	const uint16 _size1 = 0;
+	const uint16 _size2 = 0;
 
-	uint16 _loopnum;
-	int16 _freqmod;
-	uint16 _freq;
+	uint16 _loopnum = 0;
+	int16 _freqmod = 0;
+	uint16 _freq = 0;
 };
 
 // plays a looped waveform, increasing frequency and reducing volume once the frequency reaches a certain point
@@ -1355,10 +1356,10 @@ public:
 			return false;
 	}
 private:
-	const uint16 _offset;
-	const uint16 _size;
+	const uint16 _offset = 0;
+	const uint16 _size = 0;
 
-	uint16 _curfreq;
+	uint16 _curfreq = 0;
 };
 
 // plays a looped waveform, sweeping the frequency up while modulating it (alternating which channel updates) and fading volume out
@@ -1412,11 +1413,11 @@ public:
 		return true;
 	}
 private:
-	const uint16 _offset;
-	const uint16 _size;
+	const uint16 _offset = 0;
+	const uint16 _size = 0;
 
-	uint16 _loop;
-	uint16 _curfreq;
+	uint16 _loop = 0;
+	uint16 _curfreq = 0;
 };
 
 // just like Zak61, but sweeps frequency in the other direction
@@ -1567,15 +1568,15 @@ public:
 		return true;
 	}
 private:
-	const uint16 _offset;
-	const uint16 _size;
+	const uint16 _offset = 0;
+	const uint16 _size = 0;
 
-	uint16 _loop;
-	uint16 _playctr;
-	uint16 _wait1;
-	uint16 _wait2;
-	uint16 _wait3;
-	uint16 _wait4;
+	uint16 _loop = 0;
+	uint16 _playctr = 0;
+	uint16 _wait1 = 0;
+	uint16 _wait2 = 0;
+	uint16 _wait3 = 0;
+	uint16 _wait4 = 0;
 };
 
 // plays a "ding" (volume 0-max-0) followed by a sound sample, a pause, then loops again
@@ -1647,12 +1648,12 @@ public:
 		return true;
 	}
 private:
-	const uint16 _offset;
-	const uint16 _size;
+	const uint16 _offset = 0;
+	const uint16 _size = 0;
 
-	uint16 _mode;
-	uint16 _vol;
-	int16 _volmod;
+	uint16 _mode = 0;
+	uint16 _vol = 0;
+	int16 _volmod = 0;
 };
 
 // modulates volume on 4 samples, frequency on only 2 of them
@@ -1723,13 +1724,13 @@ public:
 		return true;
 	}
 private:
-	const uint16 _offset;
-	const uint16 _size;
+	const uint16 _offset = 0;
+	const uint16 _size = 0;
 
-	uint16 _freq[4];
-	uint16 _vol[4];
-	int16 _freqmod;
-	int16 _volmod[2];
+	uint16 _freq[4] = {};
+	uint16 _vol[4] = {};
+	int16 _freqmod = 0;
+	int16 _volmod[2] = {};
 };
 
 #define CRCToSound(CRC, SOUND) \

--- a/engines/scumm/players/player_v3a.cpp
+++ b/engines/scumm/players/player_v3a.cpp
@@ -53,7 +53,7 @@ Player_V3A::Player_V3A(ScummEngine *scumm, Audio::Mixer *mixer)
 
 bool Player_V3A::init() {
 	byte *ptr;
-	int numInstruments = 0;
+	int numInstruments;
 
 	// Determine which sound resource contains the wavetable data and how large it is
 	// This is hardcoded into each game's executable

--- a/engines/scumm/players/player_v3a.h
+++ b/engines/scumm/players/player_v3a.h
@@ -114,7 +114,6 @@ private:
 	int8 *_wavetableData;
 	InstData *_wavetablePtrs;
 
-	void updateProc();
 	void updateMusicIndy();
 	void updateMusicLoom();
 	void updateSounds();

--- a/engines/scumm/resource_v4.cpp
+++ b/engines/scumm/resource_v4.cpp
@@ -127,7 +127,7 @@ void ScummEngine_v4::readIndexFile() {
 	allocateArrays();
 
 	while (true) {
-		itemsize = _fileHandle->readUint32LE();
+		/*itemsize = */_fileHandle->readUint32LE();
 
 		if (_fileHandle->eos() || _fileHandle->err())
 			break;

--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -53,7 +53,7 @@ struct SaveGameHeader {
 	uint32 type;
 	uint32 size;
 	uint32 ver;
-	char name[32];
+	char name[32] = {};
 };
 
 struct SaveInfoSection {

--- a/engines/scumm/scumm_v0.h
+++ b/engines/scumm/scumm_v0.h
@@ -152,7 +152,6 @@ protected:
 	void o_lights();
 	void o_unlockCostume();
 	void o_unlockScript();
-	void o_decrement();
 	void o_nop();
 	void o_getObjectOwner();
 	void o_getActorBitVar();

--- a/engines/scumm/scumm_v7.h
+++ b/engines/scumm/scumm_v7.h
@@ -44,15 +44,15 @@ public:
 
 
 protected:
-	int _smushFrameRate;
+	int _smushFrameRate = 0;
 
 	/**
 	 * Flag which signals that the SMUSH video playback should end now
 	 * (e.g. because it was aborted by the user or it's simply finished).
 	 */
-	bool _smushVideoShouldFinish;
+	bool _smushVideoShouldFinish = false;
 
-	bool _smushActive;
+	bool _smushActive = false;
 
 	Insane *_insane;
 
@@ -70,15 +70,15 @@ protected:
 	TextRenderer_v7 *_textV7;
 	Common::Rect _defaultTextClipRect;
 	Common::Rect _wrappedTextClipRect;
-	bool _newTextRenderStyle;
+	bool _newTextRenderStyle = false;
 	int _blastTextRectsQueue = 0;
 
-	int _verbLineSpacing;
-	bool _existLanguageFile;
-	char *_languageBuffer;
+	int _verbLineSpacing = 0;
+	bool _existLanguageFile = false;
+	char *_languageBuffer = nullptr;
 	LangIndexNode *_languageIndex;
-	int _languageIndexSize;
-	char _lastStringTag[12+1];
+	int _languageIndexSize = 0;
+	char _lastStringTag[12+1] = {};
 
 	struct SubtitleText : TextObject {
 		void clear() {

--- a/engines/scumm/scumm_v8.h
+++ b/engines/scumm/scumm_v8.h
@@ -176,8 +176,8 @@ protected:
 		char name[40];
 		int id;
 	};
-	int _objectIDMapSize;
-	ObjectNameId *_objectIDMap;
+	int _objectIDMapSize = 0;
+	ObjectNameId *_objectIDMap = nullptr;
 
 	struct StampShot {
 		int slot;
@@ -188,12 +188,12 @@ protected:
 		int brightness;
 	};
 
-	int _savegameThumbnailV8Palette[256];
-	byte _savegameThumbnailV8[160 * 120]; // One fourth of the nominal 640x480 resolution
-	StampShot _stampShots[20];
+	int _savegameThumbnailV8Palette[256] = {};
+	byte _savegameThumbnailV8[160 * 120] = {}; // One fourth of the nominal 640x480 resolution
+	StampShot _stampShots[20] = {};
 	int _stampShotsInQueue = 0;
 
-	int _keyScriptKey, _keyScriptNo;
+	int _keyScriptKey = 0, _keyScriptNo = 0;
 
 public:
 	ScummEngine_v8(OSystem *syst, const DetectorResult &dr);

--- a/engines/scumm/verbs.cpp
+++ b/engines/scumm/verbs.cpp
@@ -329,7 +329,7 @@ void ScummEngine_v2::initNESMouseOver() {
 void ScummEngine_v2::checkV2MouseOver(Common::Point pos) {
 	VirtScreen *vs = &_virtscr[kVerbVirtScreen];
 	Common::Rect rect;
-	byte *ptr, *dst;
+	byte *dst;
 	int i, x, y, new_box = -1;
 
 	// Don't do anything unless the inventory is active
@@ -351,7 +351,7 @@ void ScummEngine_v2::checkV2MouseOver(Common::Point pos) {
 		if (_mouseOverBoxV2 != -1) {
 			rect = _mouseOverBoxesV2[_mouseOverBoxV2].rect;
 
-			dst = ptr = vs->getPixels(rect.left, rect.top);
+			dst = vs->getPixels(rect.left, rect.top);
 
 			// Remove highlight.
 			for (y = rect.height() - 1; y >= 0; y--) {
@@ -368,7 +368,7 @@ void ScummEngine_v2::checkV2MouseOver(Common::Point pos) {
 		if (new_box != -1) {
 			rect = _mouseOverBoxesV2[new_box].rect;
 
-			dst = ptr = vs->getPixels(rect.left, rect.top);
+			dst = vs->getPixels(rect.left, rect.top);
 
 			// Apply highlight
 			for (y = rect.height() - 1; y >= 0; y--) {


### PR DESCRIPTION
After @eriktorbjorn's work on SCUMM class member initialization in PR #6233, I went ahead and used ReSharper to initialize all class members. Some of these initializers are superfluous, as the variables are then initialized in `init()` methods, but there's no harm done in initializing them anyway.

This includes @eriktorbjorn's commits from PR #6233, so this is a superset of that PR.