### PR TITLE
BACKENDS: 3DS: Silence "casts away qualifiers" warning.

### DIFF
--- a/backends/platform/3ds/osystem-graphics.cpp
+++ b/backends/platform/3ds/osystem-graphics.cpp
@@ -84,7 +84,7 @@ void OSystem_3DS::init3DSGraphics() {
 	                          DISPLAY_TRANSFER_FLAGS);
 
 	// Load and bind simple default shader (shader.v.pica)
-	_dvlb = DVLB_ParseFile((u32*)shader_shbin, shader_shbin_size);
+	_dvlb = DVLB_ParseFile((u32*)const_cast<u8 *>(shader_shbin), shader_shbin_size);
 	shaderProgramInit(&_program);
 	shaderProgramSetVsh(&_program, &_dvlb->DVLE[0]);
 	C3D_BindProgram(&_program);


### PR DESCRIPTION
`shader_shbin` has the type `const u8 *`, while the first parameter of `DVLB_ParseFile` is of the non-const type `u32 *`. The compiler throws up a "casts away qualifiers" warning when casting directly from `const u8 *` to `u32 *`. Casting away the constness of `shader_shbin` with a `const_cast` before casting it to `u32 *` silences the warning.