### PR TITLE
GLK: AGT: Fix unintended comparison for digits in debugout()

### DIFF
--- a/engines/glk/agt/interface.cpp
+++ b/engines/glk/agt/interface.cpp
@@ -173,7 +173,7 @@ void debugout(const char *s) {
 				lp = 0;
 			} else if (*s == '\t') {
 				for (i = 0; i < 3; i++) linebuff[lp++] = ' ';
-			} else if (*s >= 0 && *s <= 9) linebuff[lp++] = ' ';
+			} else if (*s >= '0' && *s <= '9') linebuff[lp++] = ' ';
 			else linebuff[lp++] = *s;
 		}
 		linebuff[lp] = 0;


### PR DESCRIPTION
This was caught by the OSX PPC build, where `-funsigned-char` is the default:

```
warning: comparison is always true due to limited range of data type [-Wtype-limits]
    } else if (*s >= 0 && *s <= 9) linebuff[lp++] = ' ';
                     ^
```

but I think this warning is just a happy accident; and that instead of showing a type limit problem, it showed a part of the code which probably intended to check for the digits '0' to '9', and not the 10 first characters of the ASCII table?

Still, I'm asking @dreammaster to double check this, since I'm not sure about the intent of this code. But it appears to be likely :)