### PR TITLE
IMGUI: Fix some GCC const-related warnings

### DIFF
--- a/backends/imgui/imgui.cpp
+++ b/backends/imgui/imgui.cpp
@@ -15234,7 +15234,7 @@ void ImGui::LoadIniSettingsFromMemory(const char* ini_data, size_t ini_size)
             line_end[-1] = 0;
             const char* name_end = line_end - 1;
             const char* type_start = line + 1;
-            char* type_end = (char*)(void*)ImStrchrRange(type_start, name_end, ']');
+            char* type_end = const_cast<char *>(ImStrchrRange(type_start, name_end, ']'));
             const char* name_start = type_end ? ImStrchrRange(type_end + 1, name_end, '[') : NULL;
             if (!type_end || !name_start)
                 continue;
@@ -21345,7 +21345,7 @@ void ImGui::ShowMetricsWindow(bool* p_open)
 
         if (TreeNode("SettingsIniData", "Settings unpacked data (.ini): %d bytes", g.SettingsIniData.size()))
         {
-            InputTextMultiline("##Ini", (char*)(void*)g.SettingsIniData.c_str(), g.SettingsIniData.Buf.Size, ImVec2(-FLT_MIN, GetTextLineHeight() * 20), ImGuiInputTextFlags_ReadOnly);
+            InputTextMultiline("##Ini", const_cast<char *>(g.SettingsIniData.c_str()), g.SettingsIniData.Buf.Size, ImVec2(-FLT_MIN, GetTextLineHeight() * 20), ImGuiInputTextFlags_ReadOnly);
             TreePop();
         }
         TreePop();

--- a/backends/imgui/imgui_demo.cpp
+++ b/backends/imgui/imgui_demo.cpp
@@ -3926,7 +3926,7 @@ static void ShowDemoWindowMultiSelect(ImGuiDemoWindowData* demo_data)
                             ImGui::TableNextColumn();
                             ImGui::SetNextItemWidth(-FLT_MIN);
                             ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
-                            ImGui::InputText("###NoLabel", (char*)(void*)item_category, strlen(item_category), ImGuiInputTextFlags_ReadOnly);
+                            ImGui::InputText("###NoLabel", const_cast<char *>(item_category), strlen(item_category), ImGuiInputTextFlags_ReadOnly);
                             ImGui::PopStyleVar();
                         }
 

--- a/backends/imgui/imgui_draw.cpp
+++ b/backends/imgui/imgui_draw.cpp
@@ -3727,7 +3727,7 @@ bool ImFont::IsGlyphRangeUnused(unsigned int c_begin, unsigned int c_last)
 
 void ImFont::SetGlyphVisible(ImWchar c, bool visible)
 {
-    if (ImFontGlyph* glyph = (ImFontGlyph*)(void*)FindGlyph((ImWchar)c))
+    if (ImFontGlyph* glyph = const_cast<ImFontGlyph *>(FindGlyph((ImWchar)c)))
         glyph->Visible = visible ? 1 : 0;
 }
 


### PR DESCRIPTION
```
imgui_draw.cpp:3730: warning: cast from type 'const ImFontGlyph*' to type 'void*' casts away qualifiers [-Wcast-qual] imgui_draw.cpp: In member function 'void ImFont::SetGlyphVisible(ImWchar, bool)': imgui_draw.cpp:3730:44: warning: cast from type 'const ImFontGlyph*' to type 'void*' casts away qualifiers [-Wcast-qual]
 3730 |     if (ImFontGlyph* glyph = (ImFontGlyph*)(void*)FindGlyph((ImWchar)c))
      |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
