### PR TITLE
SCUMM: MACGUI: Optimize Mac palette handling (bug #15492)

### DIFF
--- a/engines/scumm/macgui/macgui.cpp
+++ b/engines/scumm/macgui/macgui.cpp
@@ -88,8 +88,8 @@ void MacGui::setupCursor(int &width, int &height, int &hotspotX, int &hotspotY, 
 	_impl->setupCursor(width, height, hotspotX, hotspotY, animate);
 }
 
-void MacGui::setPalette(const byte *palette, uint size) {
-	_impl->setPalette(palette, size);
+void MacGui::setPaletteDirty() {
+	_impl->setPaletteDirty();
 }
 
 const Graphics::Font *MacGui::getFontByScummId(int32 id) {

--- a/engines/scumm/macgui/macgui.h
+++ b/engines/scumm/macgui/macgui.h
@@ -58,7 +58,7 @@ public:
 
 	void setupCursor(int &width, int &height, int &hotspotX, int &hotspotY, int &animate);
 
-	void setPalette(const byte *palette, uint size);
+	void setPaletteDirty();
 
 	const Graphics::Font *getFontByScummId(int32 id);
 

--- a/engines/scumm/macgui/macgui_dialogwindow.cpp
+++ b/engines/scumm/macgui/macgui_dialogwindow.cpp
@@ -40,6 +40,8 @@ namespace Scumm {
 // ---------------------------------------------------------------------------
 
 MacGuiImpl::MacDialogWindow::MacDialogWindow(MacGuiImpl *gui, OSystem *system, Graphics::Surface *from, Common::Rect bounds, MacDialogWindowStyle windowStyle, MacDialogMenuStyle menuStyle) : _gui(gui), _system(system), _from(from), _bounds(bounds) {
+	_gui->updatePalette();
+
 	// Only apply menu style if the menu is open.
 	Graphics::MacMenu *menu = _gui->_windowManager->getMenu();
 

--- a/engines/scumm/macgui/macgui_impl.cpp
+++ b/engines/scumm/macgui/macgui_impl.cpp
@@ -92,8 +92,15 @@ int MacGuiImpl::toMacRoman(int unicode) const {
 	return macRoman;
 }
 
-void MacGuiImpl::setPalette(const byte *palette, uint size) {
-	_windowManager->passPalette(palette, size);
+void MacGuiImpl::setPaletteDirty() {
+	_paletteDirty = true;
+}
+
+void MacGuiImpl::updatePalette() {
+	if (_paletteDirty) {
+		_paletteDirty = false;
+		_windowManager->passPalette(_vm->_currentPalette, getNumColors());
+	}
 }
 
 bool MacGuiImpl::handleEvent(Common::Event event) {
@@ -495,6 +502,10 @@ void MacGuiImpl::updateWindowManager() {
 	}
 
 	_menuIsActive = isActive;
+
+	if (menu->isVisible())
+		updatePalette();
+
 	_windowManager->draw();
 }
 

--- a/engines/scumm/macgui/macgui_impl.h
+++ b/engines/scumm/macgui/macgui_impl.h
@@ -140,6 +140,8 @@ protected:
 
 	Common::Path _resourceFile;
 
+	bool _paletteDirty = false;
+
 	bool _menuIsActive = false;
 	bool _cursorWasVisible = false;
 
@@ -704,7 +706,9 @@ public:
 
 	int toMacRoman(int unicode) const;
 
-	void setPalette(const byte *palette, uint size);
+	void setPaletteDirty();
+	void updatePalette();
+
 	virtual bool handleEvent(Common::Event event);
 
 	static void menuCallback(int id, Common::String &name, void *data);

--- a/engines/scumm/palette.cpp
+++ b/engines/scumm/palette.cpp
@@ -1734,7 +1734,7 @@ void ScummEngine::updatePalette() {
 	_system->getPaletteManager()->setPalette(paletteColors, first, num);
 
 	if (_macGui)
-		_macGui->setPalette(_currentPalette, _macGui->getNumColors());
+		_macGui->setPaletteDirty();
 }
 
 } // End of namespace Scumm

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -994,14 +994,6 @@ void MacWindowManager::draw() {
 		}
 	}
 
-	if (_menuTimer && g_system->getMillis() >= _menuTimer) {
-		if (_menuHotzone.contains(_lastMousePos)) {
-			activateMenu();
-		}
-
-		_menuTimer = 0;
-	}
-
 	// Menu is drawn on top of everything and always
 	if (_menu && !(_mode & kWMModeFullscreen)) {
 		if (_fullRefresh)
@@ -1043,6 +1035,14 @@ bool MacWindowManager::processEvent(Common::Event &event) {
 			if (!_menuTimer && _menuHotzone.contains(event.mouse)) {
 				_menuTimer = g_system->getMillis() + _menuDelay;
 			}
+		}
+
+		if (_menuTimer && g_system->getMillis() >= _menuTimer) {
+			if (_menuHotzone.contains(_lastMousePos)) {
+				activateMenu();
+			}
+
+			_menuTimer = 0;
 		}
 	}
 


### PR DESCRIPTION
This is an attempt at fixing https://bugs.scummvm.org/ticket/15492 but since even my aging computer doesn't see any slowdowns it's hard for me to say if it does.

But assuming that the problem is in the frequent palette updates...

Currently, every palette change in the game gets passed on to the Mac Window Manager, which triggers a bunch of color lookups, and possibly some redrawing as well, which I suppose could be slow. It was fine for the early games, including Monkey Island 1, where palette changes are rare. But later games use a lot of palette animations, so there it can happen at least a couple of times per second.

Now the change palette is only passed to the Mac Window Manager when it's about to draw either a menu or a dialog (since those can be triggered outside of the menu). I had to rearrange some code in graphics/macgui, but I think that's ok. Without that, the menu would get drawn once before the SCUMM Mac GUI could figure out that the menu was visible, causing an ugly color flash.

If this works, and fixes the slowdown, I think it would be nice if it could make it into 2.9.0. But I'm aware that this could cause regressions.