### PR TITLE
BACKENDS: SDL: Never make window smaller in OpenGL mode when starting a game

### DIFF
--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -353,10 +353,10 @@ bool SdlGraphicsManager::createOrUpdateWindow(int width, int height, const Uint3
 		const bool fullscreen = (flags & (SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP)) != 0;
 		const bool maximized = (flags & SDL_WINDOW_MAXIMIZED);
 		if (!fullscreen && !maximized) {
-			if (_hintedWidth) {
+			if (_hintedWidth > width) {
 				width = _hintedWidth;
 			}
-			if (_hintedHeight) {
+			if (_hintedHeight > height) {
 				height = _hintedHeight;
 			}
 		}


### PR DESCRIPTION
Normally when using the OpenGL mode the window is not resized when starting a game, unless the game requires a window bigger than the current window size. However this was not the case if the engine called `initSizeHint()` with sizes smaller than the current window size, as in this case the window was forcibly resized to the bigger of those provided sizes.

This can be seen for example with the Goblins games or Dreamweb. When using OpenGL graphics mode with scaler of 1x, and starting Gobliiins the window is resized to 320x240 (or 320x200 with AR correction). For Dreamweb it is resized to 640x480. This does not happen with engines that do not call `initSizeHint()` (which means it only happens with engines that have games that use multiple resolutions).

The initSizeHint() function was added for engines that use multiple resolutions to indicate when starting the engine that it may use multiple resolutions and thus may need a bigger window later than when the game starts. This allows getting the bigger size from the start and prevent window resize during gameplay. But this function was not meant to make the window smaller if the graphics backend request an even bigger size, which may be the case of the OpenGLSDL graphics backend as it tries to preserve the current window size.

This commit changes the code to only use the size hint if it is bigger than the size requested by the graphics backend.