### PR TITLE
BASE: Fix a crash on exit when the detection plugin is loaded

### DIFF
--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -296,7 +296,8 @@ PluginManagerUncached::~PluginManagerUncached() {
 	}
 	_allEnginePlugins.clear();
 
-	delete _detectionPlugin;
+	// Explicitly unload the detection plugin
+	unloadDetectionPlugin();
 }
 
 /**


### PR DESCRIPTION
The dynamic plugin for detection contains multiple static plugins for each engine, so if the dynamic plugin is deleted first there will be a crash when unloading the static plugins because the code is no longer available/executable.

Fixes [Trac #15517](https://bugs.scummvm.org/ticket/15517). Thanks to @BallM4788 for help with debugging.
