### PR TITLE
M4: Fix the memory stash code on big endian

### DIFF
--- a/engines/m4/mem/mem.cpp
+++ b/engines/m4/mem/mem.cpp
@@ -86,7 +86,7 @@ void mem_free_to_stash(void *mem, int32 memType) {
 		error_show(FL, 'MSGF');
 
 	b_ptr += index * (_G(sizeMem)[memType] + sizeof(uintptr));
-	*b_ptr = 0;
+	*(uintptr *)b_ptr = 0;
 }
 
 void *mem_get_from_stash(int32 memType, const Common::String &name) {
@@ -94,8 +94,8 @@ void *mem_get_from_stash(int32 memType, const Common::String &name) {
 	int8 *b_ptr = (int8 *)_G(memBlock)[memType];
 
 	for (i = 0; i < _G(requests)[memType]; i++) {
-		if (!*b_ptr) {
-			*(uintptr *)b_ptr = FROM_LE_32(1);
+		if (!*(uintptr *)b_ptr) {
+			*(uintptr *)b_ptr = 1;
 			void *result = (void *)(b_ptr + sizeof(uintptr));
 			Common::fill((byte *)result, (byte *)result + _G(sizeMem)[memType], 0);
 			return result;


### PR DESCRIPTION
This hasn't been tested, but should work correctly on both 32-bit and 64-bit systems.