### PR TITLE
ADL engine fixes

### DIFF
--- a/engines/adl/adl.cpp
+++ b/engines/adl/adl.cpp
@@ -444,6 +444,15 @@ Command &AdlEngine::getCommand(Commands &commands, uint idx) {
 	error("Command %d not found", idx);
 }
 
+void AdlEngine::removeMessage(uint idx) {
+		if (_messages[idx]) {
+			_messages[idx].reset();
+			return;
+		}
+
+		error("Message %d not found", idx);
+}
+
 void AdlEngine::checkInput(byte verb, byte noun) {
 	// Try room-local command list first
 	if (doOneCommand(_roomData.commands, verb, noun))

--- a/engines/adl/adl.h
+++ b/engines/adl/adl.h
@@ -297,6 +297,7 @@ protected:
 	void readCommands(Common::ReadStream &stream, Commands &commands);
 	void removeCommand(Commands &commands, uint idx);
 	Command &getCommand(Commands &commands, uint idx);
+	void removeMessage(uint idx);
 	void checkInput(byte verb, byte noun);
 	virtual bool isInputValid(byte verb, byte noun, bool &is_any);
 	virtual bool isInputValid(const Commands &commands, byte verb, byte noun, bool &is_any);

--- a/engines/adl/adl_v2.cpp
+++ b/engines/adl/adl_v2.cpp
@@ -304,22 +304,27 @@ void AdlEngine_v2::takeItem(byte noun) {
 				return;
 			}
 
+			bool itemIsHere = false;
+
 			if (item->state == IDI_ITEM_DROPPED) {
-				item->room = IDI_ANY;
-				_itemRemoved = true;
-				return;
+				itemIsHere = true;
+			} else {
+				Common::Array<byte>::const_iterator pic;
+				for (pic = item->roomPictures.begin(); pic != item->roomPictures.end(); ++pic) {
+					if (*pic == getCurRoom().curPicture || *pic == IDI_ANY) {
+						itemIsHere = true;
+						break;
+					}
+				}
 			}
 
-			Common::Array<byte>::const_iterator pic;
-			for (pic = item->roomPictures.begin(); pic != item->roomPictures.end(); ++pic) {
-				if (*pic == getCurRoom().curPicture || *pic == IDI_ANY) {
-					if (!isInventoryFull()) {
-						item->room = IDI_ANY;
-						_itemRemoved = true;
-						item->state = IDI_ITEM_DROPPED;
-					}
-					return;
+			if (itemIsHere) {
+				if (!isInventoryFull()) {
+					item->room = IDI_ANY;
+					_itemRemoved = true;
+					item->state = IDI_ITEM_DROPPED;
 				}
+				return;
 			}
 		}
 	}

--- a/engines/adl/adl_v4.cpp
+++ b/engines/adl/adl_v4.cpp
@@ -382,6 +382,17 @@ byte AdlEngine_v4::restoreRoomState(byte room) {
 		return 0;
 	}
 
+	// WORKAROUND: Fix for bug #15379: "ADL: HIRES5: Game unsolvable after
+	// loading savegame. Save state not properly restored?".
+	// There's a problem in the original engine when a picture is set for a
+	// room that hasn't been visited yet. If the user then saves before
+	// visiting that room, the picture change will be ignored when play is
+	// resumed from that savegame.
+	if (backup.picture != 1) {
+		warning("Detected picture change for unvisited room %d in region %d", room, _state.region);
+		getRoom(room).curPicture = getRoom(room).picture = backup.picture;
+	}
+
 	return 1;
 }
 

--- a/engines/adl/detection.cpp
+++ b/engines/adl/detection.cpp
@@ -378,9 +378,35 @@ static const AdlGameDescription gameDiskDescriptions[] = {
 		GAME_TYPE_HIRES4,
 		GAME_VER_NONE
 	},
-	{ // Hi-Res Adventure #5: Time Zone - Apple II - Version 1.1 - Roberta Williams Anthology
+	{ // Hi-Res Adventure #5: Time Zone - Apple II - On-Line Systems - Version 1.1
 		{
-			"hires5", "",
+			"hires5", "On-Line Systems",
+			{
+				{"tzone1a", 2, "6c1f4c9f774dbd9697e3b5b1fe2fb858", 143360},
+				{"tzone1b", 3, "4eaf8d790e3f93097cca9ddbe863df50", 143360},
+				{"tzone2c", 4, "e3aa4f56e727339b1ec00978ce9d435b", 143360},
+				{"tzone2d", 5, "77b8219a380410015c986fa192d4c3bf", 143360},
+				{"tzone3e", 6, "f7acc03edd8d8aecb90711cd5f9e5593", 143360},
+				{"tzone3f", 7, "ed74c056976ecea2eab07448c8a72eb8", 143360},
+				{"tzone4g", 8, "de7bda8a641169fc2dedd8a7b0b7e7de", 143360},
+				{"tzone4h", 9, "21cf76d97505ff09fff5d5e4711bc47c", 143360},
+				{"tzone5i", 10, "d665df374e594cd0978b73c3490e5de2", 143360},
+				{"tzone5j", 11, "5095be23d13201d0897b9169c4e473df", 143360},
+				{"tzone6k", 12, "bef044503f21af5f0a4088e99aa778b1", 143360},
+				{"tzone6l", 13, "84801b7c2ab6c09e62a2a0809b94d16a", 143360},
+				AD_LISTEND
+			},
+			Common::EN_ANY,
+			Common::kPlatformApple2,
+			ADGF_NO_FLAGS,
+			DEFAULT_OPTIONS
+		},
+		GAME_TYPE_HIRES5,
+		GAME_VER_NONE
+	},
+	{ // Hi-Res Adventure #5: Time Zone - Apple II - Roberta Williams Anthology - Version 1.1
+		{
+			"hires5", "Sierra On-Line",
 			{
 				{ "tzone1a", 2, "731844b1d19c2801e3a5bc61d109af54", 143360 },
 				{ "tzone1b", 3, "4eaf8d790e3f93097cca9ddbe863df50", 143360 },

--- a/engines/adl/hires1.cpp
+++ b/engines/adl/hires1.cpp
@@ -253,6 +253,10 @@ void HiRes1Engine::runIntro() {
 	static_cast<Display_A2 *>(_display)->loadFrameBuffer(*stream);
 	_display->renderGraphics();
 
+	// The title screen would normally be visible during loading.
+	// We add a short delay here to simulate that.
+	delay(2000);
+
 	_display->setMode(Display::kModeMixed);
 
 	if (getGameVersion() == GAME_VER_HR1_SIMI) {

--- a/engines/adl/hires5.cpp
+++ b/engines/adl/hires5.cpp
@@ -156,7 +156,7 @@ bool HiRes5Engine::isInventoryFull() {
 	}
 
 	if (weight >= 100) {
-		printString(_gameStrings.carryingTooMuch);
+		_display->printString(_gameStrings.carryingTooMuch);
 		inputString();
 		return true;
 	}

--- a/engines/adl/hires5.cpp
+++ b/engines/adl/hires5.cpp
@@ -371,6 +371,21 @@ void HiRes5Engine::applyRegionWorkarounds() {
 		// of the script.
 		removeCommand(_roomCommands, 0);
 		break;
+	case 32:
+		// This broken message appears right before the game restarts,
+		// and should probably explain that the user fell down some
+		// stairs. We remove the broken message.
+		// TODO: Maybe we could put in a new string?
+		removeMessage(29);
+		break;
+	case 40:
+		// Locking the gate prints a broken message, followed by
+		// "O.K.". Maybe there was supposed to be a more elaborate
+		// message, in the style of the one printed when you unlock
+		// the gate. But "O.K." should be enough, so we remove the
+		// first one.
+		removeMessage(172);
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
This is a set of fixes for the ADL engine, by @waltervn

This addresses the following bugs:
- Bug #[15379](https://bugs.scummvm.org/ticket/15379) - HIRES5: Game unsolvable after loading savegame. Save state not properly restored?
- Bug #[15389](https://bugs.scummvm.org/ticket/15389) - HIRES5: "GET ALL" fails where picking up individual objects doesn't
- Bug #[15382](https://bugs.scummvm.org/ticket/15382) - HIRES5: Crash printing an apparently corrupt string
- Bug #[15301](https://bugs.scummvm.org/ticket/15301) - Mystery House: Barely seen title screen

Creating a PR for review