### PR TITLE
SCUMM: HE: Fix leak in mixer

### DIFF
--- a/engines/scumm/he/mixer_he.cpp
+++ b/engines/scumm/he/mixer_he.cpp
@@ -541,7 +541,7 @@ bool HEMixer::mixerStartChannel(
 	}
 
 	bool hasCallbackData = false;
-	if (flags & CHANNEL_CALLBACK_EARLY) {
+	if ((flags & CHANNEL_CALLBACK_EARLY) && !(_mixerChannels[channel].flags & CHANNEL_LOOPING)) {
 		va_start(params, flags);
 		_mixerChannels[channel].endSampleAdjustment = va_arg(params, int);
 		va_end(params);


### PR DESCRIPTION
`HEMixerChannel.residualData` could be allocated but not used and freed, for example during Pelican Sam Airlines intro scene in Freddi 3. This patch moves its allocation to just before its use.
Please do not commit this until @AndywinXp can review it.

```
ERROR: LeakSanitizer: detected memory leaks

Direct leak of 26 byte(s) in 1 object(s) allocated from:
    #0 0x7f6ada8b89cf in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x560f1255a081 in Scumm::HEMixer::mixerStartChannel(int, int, int, unsigned int, int, int, int, int, unsigned int, ...) engines/scumm/he/mixer_he.cpp:555
    #2 0x560f1255c30a in Scumm::HEMixer::startChannel(int, int, int, unsigned int, int, int, int, int, int, ...) engines/scumm/he/mixer_he.cpp:159
[...]```