### PR TITLE
CONFIGURE: Add a 3D feature

### DIFF
--- a/configure
+++ b/configure
@@ -269,6 +269,7 @@ _detection_features_static=yes
 _detection_features_full=yes
 # The following variables are automatically detected, and should not
 # be modified otherwise. Consider them read-only.
+_3d=no
 _posix=no
 _has_posix_spawn=no
 _has_fseeko_offt_64=no
@@ -282,6 +283,7 @@ _imgui=yes
 
 # Add (virtual) features
 add_feature 16bit "16bit color" "_16bit"
+add_feature 3d "3D rendering" "_3d"
 add_feature bink "Bink" "_bink"
 add_feature cloud "cloud" "_cloud"
 add_feature faad "libfaad" "_faad"
@@ -6899,6 +6901,14 @@ if test "$_16bit" = "no"; then
 fi
 define_in_config_if_yes $_tinygl 'USE_TINYGL'
 echo "$_tinygl"
+
+echo_n "Building any 3D game... "
+if (test "$_tinygl" = yes || test "$_opengl_game_classic" = yes || test "$_opengl_game_shaders" = yes); then
+	_3d=yes
+else
+	_3d=no
+fi
+echo "$_3d"
 
 #
 # Check whether to build Bink video support

--- a/devtools/create_project/cmake.cpp
+++ b/devtools/create_project/cmake.cpp
@@ -188,6 +188,8 @@ link_directories(/opt/local/lib)
 		if (!feature.enable || featureExcluded(feature.name)) continue;
 
 		writeFeatureLibSearch(setup, workspace, feature.name);
+
+		if (!feature.define || !feature.define[0]) continue;
 		workspace << "add_definitions(-D" << feature.define << ")\n";
 	}
 	workspace << "\n";

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -374,6 +374,12 @@ int main(int argc, char *argv[]) {
 	}
 #endif
 
+	// Calculate 3D feature state
+	setFeatureBuildState("3d", setup.features,
+			getFeatureBuildState("tinygl", setup.features) ||
+			getFeatureBuildState("opengl_game_classic", setup.features) ||
+			getFeatureBuildState("opengl_game_shaders", setup.features));
+
 	// Disable engines for which we are missing dependencies
 	for (EngineDescList::const_iterator i = setup.engines.begin(); i != setup.engines.end(); ++i) {
 		if (i->enable) {
@@ -1138,6 +1144,7 @@ const Feature s_features[] = {
 	{        "edgescalers",              "USE_EDGE_SCALERS", false, true,  "Edge scalers" },
 	{             "aspect",                    "USE_ASPECT", false, true,  "Aspect ratio correction" },
 	{              "16bit",                 "USE_RGB_COLOR", false, true,  "16bit color support" },
+	{                 "3d",                              "", false, true,  "3D rendering" },
 	{            "highres",                   "USE_HIGHRES", false, true,  "high resolution" },
 	{              "imgui",                     "USE_IMGUI", false, true,  "Dear ImGui based debugger" },
 	{            "mt32emu",                   "USE_MT32EMU", false, true,  "integrated MT-32 emulator" },

--- a/engines/freescape/configure.engine
+++ b/engines/freescape/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine freescape "Freescape" yes "" "" "highres 16bit"
+add_engine freescape "Freescape" yes "" "" "highres 16bit 3d"

--- a/engines/grim/configure.engine
+++ b/engines/grim/configure.engine
@@ -1,4 +1,4 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine grim "Grim" yes "monkey4" "Grim Fandango" "16bit highres"
+add_engine grim "Grim" yes "monkey4" "Grim Fandango" "16bit 3d highres"
 add_engine monkey4 "Escape from Monkey Island" no "" "" "bink"

--- a/engines/hpl1/configure.engine
+++ b/engines/hpl1/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine hpl1 "Hpl1" no "" "" "16bit highres jpeg gif png opengl_game_shaders"
+add_engine hpl1 "Hpl1" no "" "" "16bit 3d highres jpeg gif png opengl_game_shaders"

--- a/engines/myst3/configure.engine
+++ b/engines/myst3/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine myst3 "Myst 3" yes "" "" "16bit highres jpeg bink"
+add_engine myst3 "Myst 3" yes "" "" "16bit 3d highres jpeg bink"

--- a/engines/playground3d/configure.engine
+++ b/engines/playground3d/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine playground3d "Playground 3d: the testing and playground environment for 3d renderers" no "" "" "16bit highres"
+add_engine playground3d "Playground 3d: the testing and playground environment for 3d renderers" no "" "" "16bit 3d highres"

--- a/engines/stark/configure.engine
+++ b/engines/stark/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine stark "The Longest Journey" yes "" "" "16bit highres freetype2 vorbis bink"
+add_engine stark "The Longest Journey" yes "" "" "16bit 3d highres freetype2 vorbis bink"

--- a/engines/tetraedge/configure.engine
+++ b/engines/tetraedge/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine tetraedge "Tetraedge" yes "" "" "highres freetype2 vorbis png jpeg lua theoradec"
+add_engine tetraedge "Tetraedge" yes "" "" "highres 3d freetype2 vorbis png jpeg lua theoradec"

--- a/engines/twp/configure.engine
+++ b/engines/twp/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine twp "Thimbleweed Park" yes "" "" "16bit highres vorbis png opengl_game_shaders"
+add_engine twp "Thimbleweed Park" yes "" "" "16bit 3d highres vorbis png opengl_game_shaders"

--- a/engines/watchmaker/configure.engine
+++ b/engines/watchmaker/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine watchmaker "The Watchmaker" no "" "" "highres 16bit opengl_game_classic"
+add_engine watchmaker "The Watchmaker" no "" "" "highres 16bit 3d opengl_game_classic"

--- a/engines/wintermute/configure.engine
+++ b/engines/wintermute/configure.engine
@@ -1,6 +1,6 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
 add_engine wintermute "Wintermute" yes "foxtail herocraft wme3d" "" "16bit highres jpeg png"
-add_engine wme3d "Wintermute3D" no
+add_engine wme3d "Wintermute3D" no "" "" "3d"
 add_engine foxtail "FoxTail" yes
 add_engine herocraft "HeroCraft" yes


### PR DESCRIPTION
This allows to blacklist 3D engines on platforms not supporting 3D.
These platforms don't have OpenGL nor TinyGL enabled.
