### PR TITLE
MACOS: Change default savepath to use the Application Support folder

### DIFF
--- a/backends/platform/sdl/macosx/macosx.cpp
+++ b/backends/platform/sdl/macosx/macosx.cpp
@@ -117,6 +117,20 @@ void OSystem_MacOSX::initBackend() {
 	_textToSpeechManager = new MacOSXTextToSpeechManager();
 #endif
 
+	// Migrate savepath.
+	// It used to be in ~/Documents/ScummVM Savegames/, but was changed to use the application support
+	// directory. To migrate old config files we use a flag to indicate if the config file was migrated.
+	// This allows detecting old config files. If the flag is not set we:
+	// 1. Set the flag
+	// 2. If the config file has no custom savepath and has some games, we set the savepath to the old default.
+	if (!ConfMan.hasKey("macos_savepath_migrated", Common::ConfigManager::kApplicationDomain)) {
+		if (!ConfMan.hasKey("savepath", Common::ConfigManager::kApplicationDomain) && !ConfMan.getGameDomains().empty()) {
+			ConfMan.set("savepath", getDocumentsPathMacOSX() + "/ScummVM Savegames", Common::ConfigManager::kApplicationDomain);
+		}
+		ConfMan.setBool("macos_savepath_migrated", true, Common::ConfigManager::kApplicationDomain);
+		ConfMan.flushToDisk();
+	}
+
 	// Invoke parent implementation of this method
 	OSystem_POSIX::initBackend();
 }

--- a/backends/platform/sdl/macosx/macosx_wrapper.h
+++ b/backends/platform/sdl/macosx/macosx_wrapper.h
@@ -25,6 +25,7 @@
 #include <common/str.h>
 
 Common::String getDesktopPathMacOSX();
+Common::String getDocumentsPathMacOSX();
 Common::String getResourceAppBundlePathMacOSX();
 Common::String getAppSupportPathMacOSX();
 Common::String getMacBundleName();

--- a/backends/platform/sdl/macosx/macosx_wrapper.mm
+++ b/backends/platform/sdl/macosx/macosx_wrapper.mm
@@ -46,6 +46,17 @@ Common::String getDesktopPathMacOSX() {
 	return Common::String([path fileSystemRepresentation]);
 }
 
+Common::String getDocumentsPathMacOSX() {
+	// See comment in getDesktopPathMacOSX()
+	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+	if ([paths count] == 0)
+		return Common::String();
+	NSString *path = [paths objectAtIndex:0];
+	if (path == nil)
+		return Common::String();
+	return Common::String([path fileSystemRepresentation]);
+}
+
 Common::String getResourceAppBundlePathMacOSX() {
 	NSString *bundlePath = [[NSBundle mainBundle] resourcePath];
 	if (bundlePath == nil)

--- a/backends/saves/posix/posix-saves.cpp
+++ b/backends/saves/posix/posix-saves.cpp
@@ -32,6 +32,9 @@
 
 #include "backends/saves/posix/posix-saves.h"
 #include "backends/fs/posix/posix-fs.h"
+#if defined(MACOSX)
+#include "backends/platform/sdl/macosx/macosx_wrapper.h"
+#endif
 
 #include "common/config-manager.h"
 #include "common/savefile.h"
@@ -44,14 +47,11 @@ POSIXSaveFileManager::POSIXSaveFileManager() {
 	Common::Path savePath;
 
 #if defined(MACOSX)
-	const char *home = getenv("HOME");
-	if (home && *home && strlen(home) < MAXPATHLEN) {
-		savePath = home;
-		savePath.joinInPlace("Documents/ScummVM Savegames");
-
+	savePath = getAppSupportPathMacOSX();
+	if (!savePath.empty()) {
+		savePath.joinInPlace("Savegames");
 		ConfMan.registerDefault("savepath", savePath);
 	}
-
 #else
 	const char *envVar;
 

--- a/dists/macosx/Info.plist
+++ b/dists/macosx/Info.plist
@@ -78,8 +78,6 @@
 	<string>scummvm.docktileplugin</string>
 	<key>NSRequiresAquaSystemAppearance</key>
 	<false/>
-	<key>NSDocumentsFolderUsageDescription</key>
-	<string>ScummVM saves and loads savegames in the Documents folder by default.</string>
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
 	<key>NSHighResolutionCapable</key>

--- a/dists/macosx/Info.plist.in
+++ b/dists/macosx/Info.plist.in
@@ -78,8 +78,6 @@
 	<string>scummvm.docktileplugin</string>
 	<key>NSRequiresAquaSystemAppearance</key>
 	<false/>
-	<key>NSDocumentsFolderUsageDescription</key>
-	<string>ScummVM saves and loads savegames in the Documents folder by default.</string>
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
 	<key>NSHighResolutionCapable</key>

--- a/doc/cz/PrectiMe
+++ b/doc/cz/PrectiMe
@@ -1352,7 +1352,7 @@ Uložené hry jsou na některých platformách standardně umístěny do součas
 
 Platformy, které v současnosti mají jiné výchozí složky jsou:
     macOS:
-    $HOME/Documents/ScummVM Savegames/
+    $HOME/Library/Application Support/ScummVM/Savegames/
 
     Jiné unixy:
     Řídíme se specifikacemi základního adresáře XDG. To znamená, že nastavení lze nalézt v:

--- a/doc/de/LIESMICH
+++ b/doc/de/LIESMICH
@@ -2017,7 +2017,7 @@ Sehen Sie sich das Beispiel weiter unten in dieser Liesmich-Datei an.
 
 Die folgenden Plattformen haben ein anderes Standard-Verzeichnis:
     macOS:
-    $HOME/Documents/ScummVM Savegames/
+    $HOME/Library/Application Support/ScummVM/Savegames/
 
     Andere UNIX-Systeme:
     Wir befolgen die Spezifikation XDG Base Directory. Dies bedeutet, dass

--- a/doc/docportal/use_scummvm/save_load_games.rst
+++ b/doc/docportal/use_scummvm/save_load_games.rst
@@ -60,7 +60,7 @@ Default saved game paths are shown below.
 
     .. tab-item:: macOS
 
-        ``~/Documents/ScummVM Savegames/``
+        ``~/Library/Application Support/ScummVM/Savegames/`` (with versions of ScummVM prior to 2.9 it was in ``~/Documents/ScummVM Savegames/``).
 
 
     .. tab-item:: Linux/Unix

--- a/doc/se/LasMig
+++ b/doc/se/LasMig
@@ -1031,7 +1031,7 @@ Spardata lagras som standard i den aktiva katalogen på vissa plattformar och i 
 
 Plattformar som för närvarande har annorlunda standardkataloger:
     macOS:
-    $HOME/Documents/ScummVM Savegames/
+    $HOME/Library/Application Support/ScummVM/Savegames/
 
     Övriga unix-system:
     $HOME/.scummvm/


### PR DESCRIPTION
The default savepath on macOS used to be in the user Document folder. However ScummVM requires special permission to access that folder, and if the user denied it, this caused various issues. This implement [ticket #11428](https://bugs.scummvm.org/ticket/11428).

The change should not be controversial. But I am interested in getting feedback on the migration method I implemented in `OSystem_MacOSX::initBackend()`. The idea I had was to:
- Have a `macos_savepath_migrated` setting in the config file that indicate it has been migrated.
- If the setting is not yet set, we set it. And if the config has games (i.e. it is an old config file), and if the savepath setting is not set (i.e. the default is used) then it explicitly set it to the old default.

That means that for existing users it will not change the savepath, and the new default will only be used for new users (or for old users who remove their custom savepath and manually move their save games.

I have tested that this seems to work. But please comment here if you see a scenario where that might not work or if you have a better idea.