### PR TITLE
CONFIGURE: Added possibility to define engine components

### DIFF
--- a/configure
+++ b/configure
@@ -298,18 +298,18 @@ add_feature bink "Bink" "_bink"
 add_feature cloud "cloud" "_cloud"
 add_feature faad "libfaad" "_faad"
 add_feature flac "FLAC" "_flac"
+add_feature fribidi "FriBidi" "_fribidi"
 add_feature freetype2 "FreeType2" "_freetype2"
+add_feature gif "GIF" "_gif"
 add_feature highres "high resolution" "_highres"
-add_feature mad "MAD" "_mad"
 add_feature jpeg "JPEG" "_jpeg"
+add_feature mad "MAD" "_mad"
 add_feature mpeg2 "mpeg2" "_mpeg2"
 add_feature opengl_game_classic "OpenGL (classic)" "_opengl_game_classic"
 add_feature opengl_game_shaders "OpenGL with shaders" "_opengl_game_shaders"
 add_feature png "PNG" "_png"
-add_feature gif "GIF" "_gif"
 add_feature vorbis "Vorbis file support" "_vorbis _tremor"
 add_feature zlib "zlib" "_zlib"
-add_feature fribidi "FriBidi" "_fribidi"
 add_feature test_cxx11 "Test C++11" "_test_cxx11"
 
 # Components are features which may be disabled if unused by the engines
@@ -319,6 +319,21 @@ add_component vpx "libvpx" "_vpx" "USE_VPX"
 add_component theoradec "libtheoradec" "_theoradec" "USE_THEORADEC"
 add_component mt32emu "mt32emu" "_mt32emu" "USE_MT32EMU"
 add_component tinygl "TinyGL" "_tinygl" "USE_TINYGL"
+
+# The following list of features cannot be declared as components
+# because they are used in the common code:
+# 16bit: used by the GUI
+# 3d: not a real feature
+# cloud: used by the GUI
+# flac: used by DefaultAudioCDManager
+# fribidi: used by the GUI
+# freetype2: used by the GUI
+# highres: not a real feature
+# mad: used by DefaultAudioCDManager
+# png: used by the GUI
+# vorbis: used by DefaultAudioCDManager
+# zlib: used by the GUI
+# test_cxx11: used by the build system
 
 # Directories for installing ScummVM.
 # This list is closely based on what GNU autoconf does,

--- a/configure
+++ b/configure
@@ -198,6 +198,7 @@ _verbose_build=no
 _werror_build=no
 _text_console=no
 _mt32emu=yes
+_lua=yes
 _build_scalers=yes
 _build_hq_scalers=yes
 _build_edge_scalers=yes
@@ -310,6 +311,7 @@ add_feature tinygl "TinyGL" "_tinygl"
 add_feature vpx "libvpx" "_vpx"
 add_feature vorbis "Vorbis file support" "_vorbis _tremor"
 add_feature zlib "zlib" "_zlib"
+add_feature lua "lua" "_lua"
 add_feature fribidi "FriBidi" "_fribidi"
 add_feature test_cxx11 "Test C++11" "_test_cxx11"
 add_feature imgui "imgui" "_imgui"
@@ -956,6 +958,7 @@ Optional Features:
   --enable-plugins         enable the support for dynamic plugins
   --default-dynamic        make plugins dynamic by default
   --disable-mt32emu        don't enable the integrated MT-32 emulator
+  --disable-lua            don't enable Lua support
   --disable-nuked-opl      don't build Nuked OPL driver
   --disable-16bit          don't enable 16bit color support
   --disable-highres        don't enable support for high resolution engines >320x240
@@ -1319,6 +1322,8 @@ for ac_option in $@; do
 	--default-dynamic)           _plugins_default=dynamic;;
 	--enable-mt32emu)            _mt32emu=yes            ;;
 	--disable-mt32emu)           _mt32emu=no             ;;
+	--enable-lua)                _lua=yes                ;;
+	--disable-lua)               _lua=no                 ;;
 	--enable-nuked-opl)          _nuked_opl=yes          ;;
 	--disable-nuked-opl)         _nuked_opl=no           ;;
 	--enable-translation)        _translation=yes        ;;
@@ -3610,6 +3615,7 @@ if test -n "$_host"; then
 			_nuked_opl=no
 			_tinygl=no
 			_bink=no
+			_lua=no
 			_png=no
 			_freetype2=no
 			_port_mk="backends/platform/ds/ds.mk"
@@ -4989,6 +4995,11 @@ echo "$_detection_features_full"
 # Check whether integrated MT-32 emulator support is requested
 #
 define_in_config_if_yes "$_mt32emu" 'USE_MT32EMU'
+
+#
+# Check whether Lua support is requested
+#
+define_in_config_if_yes "$_lua" 'USE_LUA'
 
 #
 # Check whether Nuked OPL emulator support is disabled
@@ -7171,6 +7182,10 @@ fi
 
 if test "$_mt32emu" = yes ; then
 	echo_n ", MT-32 emulator"
+fi
+
+if test "$_lua" = yes ; then
+	echo_n ", Lua"
 fi
 
 if test "$_nuked_opl" = yes ; then

--- a/configure
+++ b/configure
@@ -5014,11 +5014,6 @@ echo "$_detection_features_full"
 define_in_config_if_yes "$_mt32emu" 'USE_MT32EMU'
 
 #
-# Check whether Lua support is requested
-#
-define_in_config_if_yes "$_lua" 'USE_LUA'
-
-#
 # Check whether Nuked OPL emulator support is disabled
 #
 define_in_config_if_no "$_nuked_opl" 'DISABLE_NUKED_OPL'
@@ -5417,7 +5412,7 @@ if test "$_theoradec" = yes ; then
 	append_var LIBS "$THEORADEC_LIBS"
 	append_var INCLUDES "$THEORADEC_CFLAGS"
 fi
-define_in_config_if_yes "$_theoradec" 'USE_THEORADEC'
+
 if test ! "$_theoradec" = notsupported ; then
 	echo "$_theoradec"
 fi
@@ -5467,7 +5462,7 @@ if test "$_vpx" = yes ; then
 	append_var LIBS "$VPX_LIBS -lvpx"
 	append_var INCLUDES "$VPX_CFLAGS"
 fi
-define_in_config_if_yes "$_vpx" 'USE_VPX'
+
 if test ! "$_vpx" = notsupported ; then
 	echo "$_vpx"
 fi

--- a/configure
+++ b/configure
@@ -311,9 +311,9 @@ add_feature vorbis "Vorbis file support" "_vorbis _tremor"
 add_feature zlib "zlib" "_zlib"
 add_feature fribidi "FriBidi" "_fribidi"
 add_feature test_cxx11 "Test C++11" "_test_cxx11"
-add_feature imgui "imgui" "_imgui"
 
 # Components are features which may be disabled if unused by the engines
+add_component imgui "ImGui" "_imgui" "USE_IMGUI"
 add_component lua "lua" "_lua" "USE_LUA"
 add_component vpx "libvpx" "_vpx" "USE_VPX"
 add_component theoradec "libtheoradec" "_theoradec" "USE_THEORADEC"
@@ -6804,7 +6804,6 @@ EOF
 else
 	echo "$_imgui"
 fi
-define_in_config_if_yes "$_imgui" 'USE_IMGUI'
 
 #
 # Enable vkeybd / event recorder

--- a/configure
+++ b/configure
@@ -129,8 +129,7 @@ add_component() {
 
 	set_var _components "$(get_var _components) ${1}"
 
-	set_var _component_${1}_name "${2}"
-	set_var _component_${1}_settings "${4}"
+	set_var _component_${1}_define "${4}"
 }
 
 _srcdir=`dirname $0`

--- a/configure
+++ b/configure
@@ -108,6 +108,7 @@ add_engine() {
 	set_var _engine_${1}_subengines "${4}"
 	set_var _engine_${1}_base "${5}"
 	set_var _engine_${1}_deps "${6}"
+	set_var _engine_${1}_components "${7}"
 	for sub in ${4}; do
 		set_var _engine_${sub}_sub "yes"
 		set_var _engine_${sub}_parent "${1}"
@@ -120,6 +121,14 @@ add_feature() {
 	# This is a list of settings, where one must be "yes" for the feature to
 	# be enabled
 	set_var _feature_${1}_settings "${3}"
+}
+
+# Add a component: id name settings-list
+add_component() {
+	_components="${_components} ${1}"
+
+	set_var _component_${1}_name "${2}"
+	set_var _component_${1}_settings "${3}"
 }
 
 _srcdir=`dirname $0`
@@ -189,7 +198,6 @@ _verbose_build=no
 _werror_build=no
 _text_console=no
 _mt32emu=yes
-_lua=yes
 _build_scalers=yes
 _build_hq_scalers=yes
 _build_edge_scalers=yes
@@ -302,10 +310,11 @@ add_feature tinygl "TinyGL" "_tinygl"
 add_feature vpx "libvpx" "_vpx"
 add_feature vorbis "Vorbis file support" "_vorbis _tremor"
 add_feature zlib "zlib" "_zlib"
-add_feature lua "lua" "_lua"
 add_feature fribidi "FriBidi" "_fribidi"
 add_feature test_cxx11 "Test C++11" "_test_cxx11"
 add_feature imgui "imgui" "_imgui"
+
+add_component lua "lua" "USE_LUA"
 
 # Directories for installing ScummVM.
 # This list is closely based on what GNU autoconf does,
@@ -947,7 +956,6 @@ Optional Features:
   --enable-plugins         enable the support for dynamic plugins
   --default-dynamic        make plugins dynamic by default
   --disable-mt32emu        don't enable the integrated MT-32 emulator
-  --disable-lua            don't enable Lua support
   --disable-nuked-opl      don't build Nuked OPL driver
   --disable-16bit          don't enable 16bit color support
   --disable-highres        don't enable support for high resolution engines >320x240
@@ -1311,8 +1319,6 @@ for ac_option in $@; do
 	--default-dynamic)           _plugins_default=dynamic;;
 	--enable-mt32emu)            _mt32emu=yes            ;;
 	--disable-mt32emu)           _mt32emu=no             ;;
-	--enable-lua)                _lua=yes                ;;
-	--disable-lua)               _lua=no                 ;;
 	--enable-nuked-opl)          _nuked_opl=yes          ;;
 	--disable-nuked-opl)         _nuked_opl=no           ;;
 	--enable-translation)        _translation=yes        ;;
@@ -3604,7 +3610,6 @@ if test -n "$_host"; then
 			_nuked_opl=no
 			_tinygl=no
 			_bink=no
-			_lua=no
 			_png=no
 			_freetype2=no
 			_port_mk="backends/platform/ds/ds.mk"
@@ -4984,11 +4989,6 @@ echo "$_detection_features_full"
 # Check whether integrated MT-32 emulator support is requested
 #
 define_in_config_if_yes "$_mt32emu" 'USE_MT32EMU'
-
-#
-# Check whether Lua support is requested
-#
-define_in_config_if_yes "$_lua" 'USE_LUA'
 
 #
 # Check whether Nuked OPL emulator support is disabled
@@ -7171,10 +7171,6 @@ fi
 
 if test "$_mt32emu" = yes ; then
 	echo_n ", MT-32 emulator"
-fi
-
-if test "$_lua" = yes ; then
-	echo_n ", Lua"
 fi
 
 if test "$_nuked_opl" = yes ; then

--- a/configure
+++ b/configure
@@ -318,6 +318,7 @@ add_feature imgui "imgui" "_imgui"
 
 add_component lua "lua" "USE_LUA"
 add_component vpx "libvpx" "USE_VPX"
+add_component theoradec "libtheoradec" "USE_THEORADEC"
 
 # Directories for installing ScummVM.
 # This list is closely based on what GNU autoconf does,

--- a/configure
+++ b/configure
@@ -125,7 +125,7 @@ add_feature() {
 
 # Add a component: id name settings-list
 add_component() {
-	_components="${_components} ${1}"
+	set_var _components "$(get_var _components) ${1}"
 
 	set_var _component_${1}_name "${2}"
 	set_var _component_${1}_settings "${3}"
@@ -317,6 +317,7 @@ add_feature test_cxx11 "Test C++11" "_test_cxx11"
 add_feature imgui "imgui" "_imgui"
 
 add_component lua "lua" "USE_LUA"
+add_component vpx "libvpx" "USE_VPX"
 
 # Directories for installing ScummVM.
 # This list is closely based on what GNU autoconf does,
@@ -4154,7 +4155,6 @@ echo "...check complete"
 eval "`. engines.awk.out`"
 
 for f in $_features_disabled; do
-    echo $f  # XXXX
     set_var $(get_var _feature_${f}_settings) "no"
 done
 

--- a/configure
+++ b/configure
@@ -321,6 +321,7 @@ add_component lua "lua" "USE_LUA"
 add_component vpx "libvpx" "USE_VPX"
 add_component theoradec "libtheoradec" "USE_THEORADEC"
 add_component mt32emu "mt32emu" "USE_MT32EMU"
+add_component tinygl "TinyGL" "USE_TINYGL"
 
 # Directories for installing ScummVM.
 # This list is closely based on what GNU autoconf does,
@@ -6942,7 +6943,6 @@ echo_n "Building TinyGL support... "
 if test "$_16bit" = "no"; then
 	_tinygl=no
 fi
-define_in_config_if_yes $_tinygl 'USE_TINYGL'
 echo "$_tinygl"
 
 echo_n "Building any 3D game... "

--- a/configure
+++ b/configure
@@ -4149,11 +4149,10 @@ append_var MODULES "backends/platform/$_backend"
 # Check if specific components are not used by enabled engines and disable them
 #
 echo "Checking for unused components..."
-rm -f engines.awk.out
 awk -f "$_srcdir/engines.awk" -v _pass=pass1 < /dev/null
 echo "...check complete"
 
-eval "`. engines.awk.out`"
+. ./engines.awk.out
 
 for f in $_features_disabled; do
     set_var $(get_var _feature_${f}_settings) "no"

--- a/configure
+++ b/configure
@@ -4144,6 +4144,13 @@ esac
 append_var MODULES "backends/platform/$_backend"
 
 #
+# Check if specific components are not used by enabled engines and disable them
+#
+echo "Checking for unused components..."
+awk -f "$_srcdir/engines.awk" -v _pass=pass1 < /dev/null
+echo "...check complete"
+
+#
 # Check for pkg-config
 #
 echocheck "pkg-config"
@@ -7387,7 +7394,7 @@ _engines_built_static=""
 _engines_built_dynamic=""
 _engines_skipped=""
 
-awk -f "$_srcdir/engines.awk" < /dev/null
+awk -f "$_srcdir/engines.awk" -v _pass=pass2 < /dev/null
 
 echo "Creating config.h"
 cat > config.h.new << EOF

--- a/configure
+++ b/configure
@@ -302,6 +302,7 @@ add_feature highres "high resolution" "_highres"
 add_feature mad "MAD" "_mad"
 add_feature jpeg "JPEG" "_jpeg"
 add_feature mpeg2 "mpeg2" "_mpeg2"
+add_feature mt32emu "mt32emu" "_mt32emu"
 add_feature opengl_game_classic "OpenGL (classic)" "_opengl_game_classic"
 add_feature opengl_game_shaders "OpenGL with shaders" "_opengl_game_shaders"
 add_feature png "PNG" "_png"
@@ -319,6 +320,7 @@ add_feature imgui "imgui" "_imgui"
 add_component lua "lua" "USE_LUA"
 add_component vpx "libvpx" "USE_VPX"
 add_component theoradec "libtheoradec" "USE_THEORADEC"
+add_component mt32emu "mt32emu" "USE_MT32EMU"
 
 # Directories for installing ScummVM.
 # This list is closely based on what GNU autoconf does,
@@ -5007,11 +5009,6 @@ echo "$_detection_features_static"
 define_in_config_if_yes "$_detection_features_full" "DETECTION_FULL"
 echo_n "Checking if building detection features for all engines... "
 echo "$_detection_features_full"
-
-#
-# Check whether integrated MT-32 emulator support is requested
-#
-define_in_config_if_yes "$_mt32emu" 'USE_MT32EMU'
 
 #
 # Check whether Nuked OPL emulator support is disabled

--- a/configure
+++ b/configure
@@ -4147,8 +4147,18 @@ append_var MODULES "backends/platform/$_backend"
 # Check if specific components are not used by enabled engines and disable them
 #
 echo "Checking for unused components..."
+rm -f engines.awk.out
 awk -f "$_srcdir/engines.awk" -v _pass=pass1 < /dev/null
 echo "...check complete"
+
+eval "`. engines.awk.out`"
+
+for f in $_features_disabled; do
+    echo $f  # XXXX
+    set_var $(get_var _feature_${f}_settings) "no"
+done
+
+rm -f engines.awk.out
 
 #
 # Check for pkg-config

--- a/configure
+++ b/configure
@@ -123,12 +123,14 @@ add_feature() {
 	set_var _feature_${1}_settings "${3}"
 }
 
-# Add a component: id name settings-list
+# Add a component: id name settings-list use-define
 add_component() {
+	add_feature "$1" "$2" "$3"
+
 	set_var _components "$(get_var _components) ${1}"
 
 	set_var _component_${1}_name "${2}"
-	set_var _component_${1}_settings "${3}"
+	set_var _component_${1}_settings "${4}"
 }
 
 _srcdir=`dirname $0`
@@ -302,26 +304,22 @@ add_feature highres "high resolution" "_highres"
 add_feature mad "MAD" "_mad"
 add_feature jpeg "JPEG" "_jpeg"
 add_feature mpeg2 "mpeg2" "_mpeg2"
-add_feature mt32emu "mt32emu" "_mt32emu"
 add_feature opengl_game_classic "OpenGL (classic)" "_opengl_game_classic"
 add_feature opengl_game_shaders "OpenGL with shaders" "_opengl_game_shaders"
 add_feature png "PNG" "_png"
 add_feature gif "GIF" "_gif"
-add_feature theoradec "libtheoradec" "_theoradec"
-add_feature tinygl "TinyGL" "_tinygl"
-add_feature vpx "libvpx" "_vpx"
 add_feature vorbis "Vorbis file support" "_vorbis _tremor"
 add_feature zlib "zlib" "_zlib"
-add_feature lua "lua" "_lua"
 add_feature fribidi "FriBidi" "_fribidi"
 add_feature test_cxx11 "Test C++11" "_test_cxx11"
 add_feature imgui "imgui" "_imgui"
 
-add_component lua "lua" "USE_LUA"
-add_component vpx "libvpx" "USE_VPX"
-add_component theoradec "libtheoradec" "USE_THEORADEC"
-add_component mt32emu "mt32emu" "USE_MT32EMU"
-add_component tinygl "TinyGL" "USE_TINYGL"
+# Components are features which may be disabled if unused by the engines
+add_component lua "lua" "_lua" "USE_LUA"
+add_component vpx "libvpx" "_vpx" "USE_VPX"
+add_component theoradec "libtheoradec" "_theoradec" "USE_THEORADEC"
+add_component mt32emu "mt32emu" "_mt32emu" "USE_MT32EMU"
+add_component tinygl "TinyGL" "_tinygl" "USE_TINYGL"
 
 # Directories for installing ScummVM.
 # This list is closely based on what GNU autoconf does,

--- a/devtools/create_engine/files/configure.engine
+++ b/devtools/create_engine/files/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine xyzzy "Xyzzy" no "" "" ""
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
+add_engine xyzzy "Xyzzy" no "" "" "" ""

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -2570,10 +2570,10 @@ bool BuildSetup::featureEnabled(const std::string &feature) const {
 }
 
 Feature BuildSetup::getFeature(const std::string &feature) const {
-	for (FeatureList::const_iterator itr = features.begin(); itr != features.end(); ++itr) {
-		if (itr->name != feature)
-			continue;
-		return *itr;
+	FeatureList::const_iterator itr = std::find(features.begin(), features.end(), feature);
+	if (itr == features.end()) {
+		error("invalid feature request: " + feature);
 	}
-	error("invalid feature request: " + feature);
+
+	return *itr;
 }

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1156,6 +1156,7 @@ const Feature s_features[] = {
 	{                 "3d",                              "", false, true,  "3D rendering" },
 	{            "highres",                   "USE_HIGHRES", false, true,  "high resolution" },
 	{              "imgui",                     "USE_IMGUI", false, true,  "Dear ImGui based debugger" },
+	{                "lua",                       "USE_LUA", false, true,  "Lua" },
 	{            "mt32emu",                   "USE_MT32EMU", false, true,  "integrated MT-32 emulator" },
 	{               "nasm",                      "USE_NASM", false, true,  "IA-32 assembly support" }, // This feature is special in the regard, that it needs additional handling.
 	{             "tinygl",                    "USE_TINYGL", false, true,  "TinyGL support" },

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1310,9 +1310,16 @@ ComponentList getAllComponents(const std::string &srcDir, FeatureList &features)
 }
 
 void disableComponents(const ComponentList &components) {
+	bool disabled = false;
 	for (ComponentList::const_iterator i = components.begin(); i != components.end(); ++i) {
-		if (!i->needed)
+		if (!i->needed) {
 			i->feature.enable = false;
+			disabled = true;
+			std::cout << "Feature " << i->feature.description << " is disabled as unused by enabled engines\n";
+		}
+	}
+	if (disabled) {
+		std::cout << "\n";
 	}
 }
 

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -98,6 +98,11 @@ struct EngineDesc {
 	StringList requiredFeatures;
 
 	/**
+	 * Components wished for this engine.
+	 */
+	StringList wishedComponents;
+
+	/**
 	 * A list of all available sub engine names. Sub engines are engines
 	 * which are built on top of an existing engines and can be only
 	 * enabled when the parten engine is enabled.
@@ -175,6 +180,22 @@ struct Feature {
 };
 typedef std::list<Feature> FeatureList;
 
+struct Component {
+	std::string name;   ///< Name of the component
+	std::string define; ///< Define of the component
+
+	Feature &feature; ///< Associated feature
+
+	std::string description; ///< Human readable description of the component
+
+	bool needed;
+
+	bool operator==(const std::string &n) const {
+		return (name == n);
+	}
+};
+typedef std::list<Component> ComponentList;
+
 struct Tool {
 	const char *name; ///< Name of the tools
 	bool enable;      ///< Whether the tools is enabled or not
@@ -188,7 +209,22 @@ typedef std::list<Tool> ToolList;
  */
 FeatureList getAllFeatures();
 
-StringList getAllComponents(const std::string &srcDir);
+/**
+ * Creates a list of all components.
+ *
+ * @param srcDir The source directory containing the configure script
+ * @param features The features list used to link the component to its feature
+ *
+ * @return A list including all components available linked to its features.
+ */
+ComponentList getAllComponents(const std::string &srcDir, FeatureList &features);
+
+/**
+ * Disable the features for the unused components.
+ *
+ * @param components List of components for the build
+ */
+void disableComponents(const ComponentList &components);
 
 /**
  * Returns a list of all defines, according to the feature set
@@ -240,7 +276,7 @@ struct BuildSetup {
 	EngineDescList engines; ///< Engine list for the build (this may contain engines, which are *not* enabled!).
 	FeatureList features;   ///< Feature list for the build (this may contain features, which are *not* enabled!).
 
-	StringList components;
+	ComponentList components;
 
 	StringList defines;   ///< List of all defines for the build.
 	StringList testDirs;  ///< List of all folders containing tests

--- a/devtools/create_project/create_project.h
+++ b/devtools/create_project/create_project.h
@@ -188,6 +188,8 @@ typedef std::list<Tool> ToolList;
  */
 FeatureList getAllFeatures();
 
+StringList getAllComponents(const std::string &srcDir);
+
 /**
  * Returns a list of all defines, according to the feature set
  * passed.
@@ -237,6 +239,8 @@ struct BuildSetup {
 
 	EngineDescList engines; ///< Engine list for the build (this may contain engines, which are *not* enabled!).
 	FeatureList features;   ///< Feature list for the build (this may contain features, which are *not* enabled!).
+
+	StringList components;
 
 	StringList defines;   ///< List of all defines for the build.
 	StringList testDirs;  ///< List of all folders containing tests

--- a/engines.awk
+++ b/engines.awk
@@ -173,7 +173,8 @@ function check_engine_components(engine) {
 		# Collect components
 		compcount = get_engine_components(engine, components)
 		for (c = 1; c <= compcount; c++) {
-			enable_component(components[c])
+			if (get_feature_state(components[c]) != "no")
+				enable_component(components[c])
 		}
 
 		# And collect those features that also declared as components

--- a/engines.awk
+++ b/engines.awk
@@ -53,7 +53,7 @@ function get_feature_name(feature) {
 function get_feature_state(feature) {
 	get_values("_feature_" feature "_settings", settings)
 	for (i in settings) {
-		if (ENVIRON[settings[i]] == "yes")
+		if (ENVIRON[settings[i]] == "yes" || ENVIRON[settings[i]] == "auto")
 			return "yes"
 	}
 	return "no"
@@ -372,7 +372,7 @@ END {
 		for (c = 1; c <= components_count; c++) {
 			if (get_component_enabled(components[c]) != "yes") {
 				if (have_feature(components[c])) {
-					if (get_feature_state(components[c]) == "yes") {
+					if (get_feature_state(components[c]) == "yes" || get_feature_state(components[c]) == "auto") {
 						disable_feature(components[c])
 						print("   Feature '" components[c] "' is disabled as unused by enabled engines")
 					}
@@ -380,7 +380,7 @@ END {
 			}
 		}
 
-		print("#!/bin/sh\necho _features_disabled='" _features_disabled "'") >> "engines.awk.out"
+		print("#!/bin/sh\necho '_features_disabled=\"" _features_disabled "\"'") >> "engines.awk.out"
 
 		exit 0
 	}

--- a/engines.awk
+++ b/engines.awk
@@ -136,12 +136,12 @@ function get_component_enabled(comp) {
 	return ENVIRON["_component_" comp "_enabled"]
 }
 
-function get_component_settings(comp) {
-	return ENVIRON["_component_" comp "_settings"]
+function get_component_define(comp) {
+	return ENVIRON["_component_" comp "_define"]
 }
 
 function have_component(comp) {
-	if (length(ENVIRON["_component_" comp "_settings"]) == 0)
+	if (length(ENVIRON["_component_" comp "_define"]) == 0)
 		return "no"
 
 	return "yes"
@@ -439,14 +439,14 @@ END {
 	comp_enabled = ""
 	comp_disabled = ""
 	for (c = 1; c <= components_count; c++) {
-		setting = get_component_settings(components[c])
-		add_to_config_h_if_yes(get_component_enabled(components[c]), "#define " setting)
+		define = get_component_define(components[c])
+		add_to_config_h_if_yes(get_component_enabled(components[c]), "#define " define)
 
 		if (get_component_enabled(components[c]) == "yes") {
-			add_line_to_config_mk(setting "=1")
+			add_line_to_config_mk(define "=1")
 			comp_enabled = comp_enabled components[c] " "
 		} else {
-			add_line_to_config_mk("# " setting)
+			add_line_to_config_mk("# " define)
 			comp_disabled = comp_disabled components[c] " "
 		}
 	}

--- a/engines.awk
+++ b/engines.awk
@@ -140,6 +140,13 @@ function get_component_settings(comp) {
 	return ENVIRON["_component_" comp "_settings"]
 }
 
+function have_component(comp) {
+	if (length(ENVIRON["_component_" comp "_settings"]) == 0)
+		return "no"
+
+	return "yes"
+}
+
 function check_engine_deps(engine) {
 	unmet_deps = ""
 
@@ -167,6 +174,13 @@ function check_engine_components(engine) {
 		compcount = get_engine_components(engine, components)
 		for (c = 1; c <= compcount; c++) {
 			enable_component(components[c])
+		}
+
+		# And collect those features that also declared as components
+		depcount = get_engine_dependencies(engine, deps)
+		for (d = 1; d <= depcount; d++) {
+			if (have_component(deps[d]) == "yes")
+				enable_component(deps[d])
 		}
 	}
 }

--- a/engines.awk
+++ b/engines.awk
@@ -436,6 +436,7 @@ END {
 	add_line_to_config_mk("\n# components")
 	components_count = get_values("_components", components)
 	comp_enabled = ""
+	comp_disabled = ""
 	for (c = 1; c <= components_count; c++) {
 		setting = get_component_settings(components[c])
 		add_to_config_h_if_yes(get_component_enabled(components[c]), "#define " setting)
@@ -445,6 +446,7 @@ END {
 			comp_enabled = comp_enabled components[c] " "
 		} else {
 			add_line_to_config_mk("# " setting)
+			comp_disabled = comp_disabled components[c] " "
 		}
 	}
 	add_line_to_config_h("/* end of components */")
@@ -460,6 +462,7 @@ END {
 	if (comp_enabled == "")
 		comp_enabled = "<none>"
 	print("\nComponents Enabled: " comp_enabled)
+	print("Components Disabled: " comp_disabled)
 
 	# Ensure engines folder exists prior to trying to generate
 	# files into it (used for out-of-tree-builds)

--- a/engines.awk
+++ b/engines.awk
@@ -69,7 +69,7 @@ function have_feature(feature) {
 function disable_feature(feature) {
 	ENVIRON["_feature_" feature "_settings"] = "no"
 
-	ENVIRON["_features_disabled"] = ENVIRON["_features_disabled"] feature " "
+	_features_disabled = _features_disabled feature " "
 }
 
 #
@@ -374,11 +374,13 @@ END {
 				if (have_feature(components[c])) {
 					if (get_feature_state(components[c]) == "yes") {
 						disable_feature(components[c])
-						print("   Feature '" components[c] "' is disabled as unused")
+						print("   Feature '" components[c] "' is disabled as unused by enabled engines")
 					}
 				}
 			}
 		}
+
+		print("#!/bin/sh\necho _features_disabled='" _features_disabled "'") >> "engines.awk.out"
 
 		exit 0
 	}

--- a/engines.awk
+++ b/engines.awk
@@ -380,7 +380,7 @@ END {
 			}
 		}
 
-		print("#!/bin/sh\necho '_features_disabled=\"" _features_disabled "\"'") >> "engines.awk.out"
+		print("_features_disabled=\"" _features_disabled "\"") > "engines.awk.out"
 
 		exit 0
 	}

--- a/engines.awk
+++ b/engines.awk
@@ -313,6 +313,14 @@ function print_engines(headline, engines, count) {
 		print("    " engines[e])
 }
 
+function print_components(headline, components, count) {
+	if (!count)
+		return
+	print("\n" headline)
+	for (c = 1; c <= count; c++)
+		print("    " get_feature_name(components[c]))
+}
+
 BEGIN {
 	config_mk = "config.mk.engines"
 	config_h = "config.h.engines"
@@ -389,7 +397,7 @@ END {
 				if (have_feature(components[c])) {
 					if (get_feature_state(components[c]) == "yes" || get_feature_state(components[c]) == "auto") {
 						disable_feature(components[c])
-						print("   Feature '" components[c] "' is disabled as unused by enabled engines")
+						print("   Feature " get_feature_name(components[c]) " is disabled as unused by enabled engines")
 					}
 				}
 			}
@@ -436,18 +444,16 @@ END {
 	add_line_to_config_h("\n/* components */")
 	add_line_to_config_mk("\n# components")
 	components_count = get_values("_components", components)
-	comp_enabled = ""
-	comp_disabled = ""
 	for (c = 1; c <= components_count; c++) {
 		define = get_component_define(components[c])
 		add_to_config_h_if_yes(get_component_enabled(components[c]), "#define " define)
 
 		if (get_component_enabled(components[c]) == "yes") {
 			add_line_to_config_mk(define "=1")
-			comp_enabled = comp_enabled components[c] " "
+			_comp_enabled[++_comp_enabled_count] = components[c]
 		} else {
 			add_line_to_config_mk("# " define)
-			comp_disabled = comp_disabled components[c] " "
+			_comp_disabled[++_comp_disabled_count] = components[c]
 		}
 	}
 	add_line_to_config_h("/* end of components */")
@@ -460,10 +466,8 @@ END {
 	print_engines("Engines Skipped:", _engines_skipped, _skipped)
 	print_engines("WARNING: This ScummVM build contains the following UNSTABLE engines:", _engines_built_wip, _wip)
 
-	if (comp_enabled == "")
-		comp_enabled = "<none>"
-	print("\nComponents Enabled: " comp_enabled)
-	print("Components Disabled: " comp_disabled)
+	print_components("Components Enabled: ", _comp_enabled, _comp_enabled_count)
+	print_components("Components Disabled: ", _comp_disabled, _comp_disabled_count)
 
 	# Ensure engines folder exists prior to trying to generate
 	# files into it (used for out-of-tree-builds)

--- a/engines/access/configure.engine
+++ b/engines/access/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine access "Access" yes
+add_engine access "Access" yes "" "" "" "mt32emu"

--- a/engines/access/configure.engine
+++ b/engines/access/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine access "Access" yes

--- a/engines/adl/configure.engine
+++ b/engines/adl/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine adl "ADL" yes "" "" "16bit highres"

--- a/engines/agi/configure.engine
+++ b/engines/agi/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine agi "AGI" yes

--- a/engines/agi/configure.engine
+++ b/engines/agi/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine agi "AGI" yes
+add_engine agi "AGI" yes "" "" "" "mt32emu"

--- a/engines/agos/configure.engine
+++ b/engines/agos/configure.engine
@@ -1,4 +1,4 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine agos "AGOS" yes "agos2" "AGOS 1 games"
+add_engine agos "AGOS" yes "agos2" "AGOS 1 games" "" "mt32emu"
 add_engine agos2 "AGOS 2 games" yes "" "" "highres"

--- a/engines/agos/configure.engine
+++ b/engines/agos/configure.engine
@@ -1,4 +1,4 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine agos "AGOS" yes "agos2" "AGOS 1 games"
 add_engine agos2 "AGOS 2 games" yes "" "" "highres"

--- a/engines/ags/configure.engine
+++ b/engines/ags/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine ags "Adventure Game Studio" yes "" "" "16bit mad"
+add_engine ags "Adventure Game Studio" yes "" "" "16bit mad" "theoradec"

--- a/engines/ags/configure.engine
+++ b/engines/ags/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine ags "Adventure Game Studio" yes "" "" "16bit mad"

--- a/engines/ags/configure.engine
+++ b/engines/ags/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine ags "Adventure Game Studio" yes "" "" "16bit mad" "theoradec"
+add_engine ags "Adventure Game Studio" yes "" "" "16bit mad" "theoradec mt32emu"

--- a/engines/asylum/configure.engine
+++ b/engines/asylum/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine asylum "Sanitarium" yes "" "" "highres"

--- a/engines/asylum/configure.engine
+++ b/engines/asylum/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine asylum "Sanitarium" yes "" "" "highres"
+add_engine asylum "Sanitarium" yes "" "" "highres" "theoradec"

--- a/engines/avalanche/configure.engine
+++ b/engines/avalanche/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine avalanche "Lord Avalot d'Argent" no "" "" "highres"

--- a/engines/bagel/configure.engine
+++ b/engines/bagel/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine bagel "BAGEL" yes "" "" "16bit highres freetype2"

--- a/engines/bagel/configure.engine
+++ b/engines/bagel/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine bagel "BAGEL" yes "" "" "16bit highres freetype2"
+add_engine bagel "BAGEL" yes "" "" "16bit highres freetype2" "mt32emu"

--- a/engines/bbvs/configure.engine
+++ b/engines/bbvs/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine bbvs "Beavis and Butthead in Virtual Stupidity" yes

--- a/engines/bladerunner/configure.engine
+++ b/engines/bladerunner/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine bladerunner "Blade Runner" yes "" "" "16bit highres"

--- a/engines/bladerunner/configure.engine
+++ b/engines/bladerunner/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine bladerunner "Blade Runner" yes "" "" "16bit highres mt32emu"
+add_engine bladerunner "Blade Runner" yes "" "" "16bit highres"

--- a/engines/bladerunner/configure.engine
+++ b/engines/bladerunner/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine bladerunner "Blade Runner" yes "" "" "16bit highres"
+add_engine bladerunner "Blade Runner" yes "" "" "16bit highres mt32emu"

--- a/engines/buried/configure.engine
+++ b/engines/buried/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine buried "The Journeyman Project 2: Buried in Time" yes "" "" "highres freetype2"

--- a/engines/cge/configure.engine
+++ b/engines/cge/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine cge "CGE" yes

--- a/engines/cge/configure.engine
+++ b/engines/cge/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine cge "CGE" yes
+add_engine cge "CGE" yes "" "" "" "mt32emu"

--- a/engines/cge2/configure.engine
+++ b/engines/cge2/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine cge2 "CGE2" yes
+add_engine cge2 "CGE2" yes "" "" "" "mt32emu"

--- a/engines/cge2/configure.engine
+++ b/engines/cge2/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine cge2 "CGE2" yes

--- a/engines/chamber/configure.engine
+++ b/engines/chamber/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine chamber "Chamber" no

--- a/engines/chewy/configure.engine
+++ b/engines/chewy/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine chewy "Chewy: Esc from F5" yes

--- a/engines/cine/configure.engine
+++ b/engines/cine/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine cine "Cinematique evo 1" yes

--- a/engines/cine/configure.engine
+++ b/engines/cine/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine cine "Cinematique evo 1" yes
+add_engine cine "Cinematique evo 1" yes "" "" "" "mt32emu"

--- a/engines/composer/configure.engine
+++ b/engines/composer/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine composer "Magic Composer" yes "" "" "highres"

--- a/engines/crab/configure.engine
+++ b/engines/crab/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine crab "CRAB" yes "" "" "16bit highres png freetype2 vorbis"

--- a/engines/cruise/configure.engine
+++ b/engines/cruise/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine cruise "Cinematique evo 2" yes

--- a/engines/cryo/configure.engine
+++ b/engines/cryo/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine cryo "Lost Eden" no "" "" ""

--- a/engines/cryomni3d/configure.engine
+++ b/engines/cryomni3d/configure.engine
@@ -1,4 +1,4 @@
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine cryomni3d "Cryo Omni3D games" yes "versailles" "" "highres"
 add_engine versailles "Versailles 1685" yes
 

--- a/engines/darkseed/configure.engine
+++ b/engines/darkseed/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine darkseed "Darkseed" yes "" "" "highres"

--- a/engines/darkseed/configure.engine
+++ b/engines/darkseed/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine darkseed "Darkseed" yes "" "" "highres"
+add_engine darkseed "Darkseed" yes "" "" "highres" "mt32emu"

--- a/engines/dgds/configure.engine
+++ b/engines/dgds/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine dgds "Dynamix Game Development System" yes
+add_engine dgds "Dynamix Game Development System" yes "" "" "" "mt32emu"

--- a/engines/dgds/configure.engine
+++ b/engines/dgds/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine dgds "Dynamix Game Development System" yes

--- a/engines/director/configure.engine
+++ b/engines/director/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine director "Macromedia Director" yes "" "" "highres"

--- a/engines/director/configure.engine
+++ b/engines/director/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine director "Macromedia Director" yes "" "" "highres"
+add_engine director "Macromedia Director" yes "" "" "highres" "imgui"

--- a/engines/dm/configure.engine
+++ b/engines/dm/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine dm "Dungeon Master" no

--- a/engines/draci/configure.engine
+++ b/engines/draci/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine draci "Dragon History" yes
+add_engine draci "Dragon History" yes "" "" "" "mt32emu"

--- a/engines/draci/configure.engine
+++ b/engines/draci/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine draci "Dragon History" yes

--- a/engines/dragons/configure.engine
+++ b/engines/dragons/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine dragons "Blazing Dragons" yes "" "" "16bit"
+add_engine dragons "Blazing Dragons" yes "" "" "16bit" "mt32emu"

--- a/engines/dragons/configure.engine
+++ b/engines/dragons/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine dragons "Blazing Dragons" yes "" "" "16bit" "mt32emu"
+add_engine dragons "Blazing Dragons" yes "" "" "16bit" ""

--- a/engines/dragons/configure.engine
+++ b/engines/dragons/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine dragons "Blazing Dragons" yes "" "" "16bit"

--- a/engines/drascula/configure.engine
+++ b/engines/drascula/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine drascula "Drascula: The Vampire Strikes Back" yes

--- a/engines/dreamweb/configure.engine
+++ b/engines/dreamweb/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine dreamweb "Dreamweb" yes

--- a/engines/efh/configure.engine
+++ b/engines/efh/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine efh "Escape From Hell" yes

--- a/engines/freescape/configure.engine
+++ b/engines/freescape/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine freescape "Freescape" yes "" "" "highres 16bit 3d"
+add_engine freescape "Freescape" yes "" "" "highres 16bit 3d" "tinygl"

--- a/engines/freescape/configure.engine
+++ b/engines/freescape/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine freescape "Freescape" yes "" "" "highres 16bit 3d"

--- a/engines/glk/configure.engine
+++ b/engines/glk/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine glk "Glk Interactive Fiction games" yes "" "" "16bit freetype2 jpeg png"

--- a/engines/gnap/configure.engine
+++ b/engines/gnap/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine gnap "UFOs" yes "" "" "highres 16bit"

--- a/engines/gnap/configure.engine
+++ b/engines/gnap/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine gnap "UFOs" yes "" "" "highres 16bit"
+add_engine gnap "UFOs" yes "" "" "highres 16bit" "mt32emu"

--- a/engines/gob/configure.engine
+++ b/engines/gob/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine gob "Gobli*ns" yes

--- a/engines/gob/configure.engine
+++ b/engines/gob/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine gob "Gobli*ns" yes
+add_engine gob "Gobli*ns" yes "" "" "" "mt32emu"

--- a/engines/griffon/configure.engine
+++ b/engines/griffon/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine griffon "The Griffon Legend" yes "" "" "16bit"

--- a/engines/grim/configure.engine
+++ b/engines/grim/configure.engine
@@ -1,4 +1,4 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine grim "Grim" yes "monkey4" "Grim Fandango" "16bit 3d highres"
 add_engine monkey4 "Escape from Monkey Island" no "" "" "bink"

--- a/engines/grim/configure.engine
+++ b/engines/grim/configure.engine
@@ -1,4 +1,4 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine grim "Grim" yes "monkey4" "Grim Fandango" "16bit 3d highres" "theoradec"
+add_engine grim "Grim" yes "monkey4" "Grim Fandango" "16bit 3d highres" "theoradec tinygl"
 add_engine monkey4 "Escape from Monkey Island" no "" "" "bink"

--- a/engines/grim/configure.engine
+++ b/engines/grim/configure.engine
@@ -1,4 +1,4 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine grim "Grim" yes "monkey4" "Grim Fandango" "16bit 3d highres"
+add_engine grim "Grim" yes "monkey4" "Grim Fandango" "16bit 3d highres" "theoradec"
 add_engine monkey4 "Escape from Monkey Island" no "" "" "bink"

--- a/engines/groovie/configure.engine
+++ b/engines/groovie/configure.engine
@@ -1,4 +1,4 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine groovie "Groovie" yes "groovie2" "7th Guest" "highres"
 add_engine groovie2 "Groovie 2 games" yes "" "" "jpeg 16bit"

--- a/engines/groovie/configure.engine
+++ b/engines/groovie/configure.engine
@@ -1,4 +1,4 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine groovie "Groovie" yes "groovie2" "7th Guest" "highres"
-add_engine groovie2 "Groovie 2 games" yes "" "" "jpeg 16bit"
+add_engine groovie2 "Groovie 2 games" yes "" "" "jpeg 16bit" "mt32emu"

--- a/engines/hadesch/configure.engine
+++ b/engines/hadesch/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine hadesch "Hades Challenge" yes "" "" "highres"

--- a/engines/hdb/configure.engine
+++ b/engines/hdb/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine hdb "Hyperspace Delivery Boy!" yes "" "" "16bit highres lua"
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
+add_engine hdb "Hyperspace Delivery Boy!" yes "" "" "16bit highres" "lua"

--- a/engines/hdb/configure.engine
+++ b/engines/hdb/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine hdb "Hyperspace Delivery Boy!" yes "" "" "16bit highres" "lua"
+add_engine hdb "Hyperspace Delivery Boy!" yes "" "" "16bit highres lua" ""

--- a/engines/hopkins/configure.engine
+++ b/engines/hopkins/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine hopkins "Hopkins FBI" yes "" "" "16bit highres"

--- a/engines/hpl1/configure.engine
+++ b/engines/hpl1/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine hpl1 "Hpl1" no "" "" "16bit 3d highres jpeg gif png opengl_game_shaders"

--- a/engines/hpl1/configure.engine
+++ b/engines/hpl1/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine hpl1 "Hpl1" no "" "" "16bit 3d highres jpeg gif png opengl_game_shaders"
+add_engine hpl1 "Hpl1" no "" "" "16bit 3d highres jpeg gif png opengl_game_shaders" "tinygl"

--- a/engines/hugo/configure.engine
+++ b/engines/hugo/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine hugo "Hugo Trilogy" yes
+add_engine hugo "Hugo Trilogy" yes "" "" "" "mt32emu"

--- a/engines/hugo/configure.engine
+++ b/engines/hugo/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine hugo "Hugo Trilogy" yes

--- a/engines/hypno/configure.engine
+++ b/engines/hypno/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine hypno "Hypnotix Inc." yes "" "" ""

--- a/engines/icb/configure.engine
+++ b/engines/icb/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine icb "In Cold Blood" no "" "" "16bit highres bink"

--- a/engines/illusions/configure.engine
+++ b/engines/illusions/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine illusions "Illusions Engine" yes
+add_engine illusions "Illusions Engine" yes "" "" "" "mt32emu"

--- a/engines/illusions/configure.engine
+++ b/engines/illusions/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine illusions "Illusions Engine" yes

--- a/engines/immortal/configure.engine
+++ b/engines/immortal/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine immortal "The Immortal" no "" "" ""

--- a/engines/kingdom/configure.engine
+++ b/engines/kingdom/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine kingdom "Kingdom: The Far Reaches" yes "" "" ""

--- a/engines/kyra/configure.engine
+++ b/engines/kyra/configure.engine
@@ -1,5 +1,5 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine kyra "Kyra" yes "lol eob" "Legend of Kyrandia 1-3"
+add_engine kyra "Kyra" yes "lol eob" "Legend of Kyrandia 1-3" "" "mt32emu"
 add_engine lol "Lands of Lore" yes
 add_engine eob "Eye of the Beholder" yes

--- a/engines/kyra/configure.engine
+++ b/engines/kyra/configure.engine
@@ -1,5 +1,5 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine kyra "Kyra" yes "lol eob" "Legend of Kyrandia 1-3"
 add_engine lol "Lands of Lore" yes
 add_engine eob "Eye of the Beholder" yes

--- a/engines/lab/configure.engine
+++ b/engines/lab/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine lab "Labyrinth of Time" yes

--- a/engines/lastexpress/configure.engine
+++ b/engines/lastexpress/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine lastexpress "The Last Express" no "" "" "16bit highres"

--- a/engines/lilliput/configure.engine
+++ b/engines/lilliput/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine lilliput "Lilliput" no
+add_engine lilliput "Lilliput" no "" "" "" "mt32emu"

--- a/engines/lilliput/configure.engine
+++ b/engines/lilliput/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine lilliput "Lilliput" no

--- a/engines/lure/configure.engine
+++ b/engines/lure/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine lure "Lure of the Temptress" yes

--- a/engines/lure/configure.engine
+++ b/engines/lure/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine lure "Lure of the Temptress" yes
+add_engine lure "Lure of the Temptress" yes "" "" "" "mt32emu"

--- a/engines/m4/configure.engine
+++ b/engines/m4/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine m4 "M4" yes "" "" "highres"

--- a/engines/m4/configure.engine
+++ b/engines/m4/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine m4 "M4" yes "" "" "highres"
+add_engine m4 "M4" yes "" "" "highres" "mt32emu"

--- a/engines/macventure/configure.engine
+++ b/engines/macventure/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine macventure "MacVenture" no "" "" "highres"

--- a/engines/made/configure.engine
+++ b/engines/made/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine made "MADE" yes
+add_engine made "MADE" yes "" "" "" "mt32emu"

--- a/engines/made/configure.engine
+++ b/engines/made/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine made "MADE" yes

--- a/engines/mads/configure.engine
+++ b/engines/mads/configure.engine
@@ -1,4 +1,4 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine mads "MADS" yes "madsv2" "Rex Nebular"
 add_engine madsv2 "MADS V2" no "" "Return of the Phantom, Dragonsphere"

--- a/engines/mm/configure.engine
+++ b/engines/mm/configure.engine
@@ -1,5 +1,5 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine mm "Might and Magic" yes "mm1 xeen"
+add_engine mm "Might and Magic" yes "mm1 xeen" "" "mt32emu"
 add_engine mm1 "Might and Magic 1" yes
 add_engine xeen "Might and Magic Xeen" yes

--- a/engines/mm/configure.engine
+++ b/engines/mm/configure.engine
@@ -1,5 +1,5 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine mm "Might and Magic" yes "mm1 xeen"
 add_engine mm1 "Might and Magic 1" yes
 add_engine xeen "Might and Magic Xeen" yes

--- a/engines/mohawk/configure.engine
+++ b/engines/mohawk/configure.engine
@@ -1,6 +1,6 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine mohawk "Mohawk" yes "cstime myst mystme riven" "Living Books" "highres"
+add_engine mohawk "Mohawk" yes "cstime myst mystme riven" "Living Books" "highres" "mt32emu"
 add_engine cstime "Where in Time is Carmen Sandiego?" no
 add_engine riven "Riven: The Sequel to Myst" yes "" "" "16bit"
 add_engine myst "Myst" yes

--- a/engines/mohawk/configure.engine
+++ b/engines/mohawk/configure.engine
@@ -1,5 +1,5 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine mohawk "Mohawk" yes "cstime myst mystme riven" "Living Books" "highres"
 add_engine cstime "Where in Time is Carmen Sandiego?" no
 add_engine riven "Riven: The Sequel to Myst" yes "" "" "16bit"

--- a/engines/mohawk/configure.engine
+++ b/engines/mohawk/configure.engine
@@ -1,6 +1,6 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine mohawk "Mohawk" yes "cstime myst mystme riven" "Living Books" "highres" "mt32emu"
+add_engine mohawk "Mohawk" yes "cstime myst mystme riven" "Living Books" "highres" ""
 add_engine cstime "Where in Time is Carmen Sandiego?" no
 add_engine riven "Riven: The Sequel to Myst" yes "" "" "16bit"
 add_engine myst "Myst" yes

--- a/engines/mortevielle/configure.engine
+++ b/engines/mortevielle/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine mortevielle "Mortevielle" yes "" "" "highres"

--- a/engines/mtropolis/configure.engine
+++ b/engines/mtropolis/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine mtropolis "mTropolis" yes "" "" "16bit highres"

--- a/engines/mtropolis/configure.engine
+++ b/engines/mtropolis/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine mtropolis "mTropolis" yes "" "" "16bit highres"
+add_engine mtropolis "mTropolis" yes "" "" "16bit highres" "mt32emu"

--- a/engines/mutationofjb/configure.engine
+++ b/engines/mutationofjb/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine mutationofjb "Mutation of JB" no

--- a/engines/myst3/configure.engine
+++ b/engines/myst3/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine myst3 "Myst 3" yes "" "" "16bit 3d highres jpeg bink"

--- a/engines/myst3/configure.engine
+++ b/engines/myst3/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine myst3 "Myst 3" yes "" "" "16bit 3d highres jpeg bink"
+add_engine myst3 "Myst 3" yes "" "" "16bit 3d highres jpeg bink" "tinygl"

--- a/engines/nancy/configure.engine
+++ b/engines/nancy/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine nancy "Nancy Drew" yes "" "" "16bit highres vorbis bink"

--- a/engines/neverhood/configure.engine
+++ b/engines/neverhood/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine neverhood "Neverhood" yes "" "" "highres"

--- a/engines/ngi/configure.engine
+++ b/engines/ngi/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine ngi "Nikita Game Interface" yes "" "" "16bit highres"

--- a/engines/parallaction/configure.engine
+++ b/engines/parallaction/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine parallaction "Parallaction" yes

--- a/engines/parallaction/configure.engine
+++ b/engines/parallaction/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine parallaction "Parallaction" yes
+add_engine parallaction "Parallaction" yes "" "" "" "mt32emu"

--- a/engines/pegasus/configure.engine
+++ b/engines/pegasus/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine pegasus "The Journeyman Project: Pegasus Prime" yes "" "" "16bit highres"
+add_engine pegasus "The Journeyman Project: Pegasus Prime" yes "" "" "16bit highres" "theoradec"

--- a/engines/pegasus/configure.engine
+++ b/engines/pegasus/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine pegasus "The Journeyman Project: Pegasus Prime" yes "" "" "16bit highres"

--- a/engines/petka/configure.engine
+++ b/engines/petka/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine petka "Red Comrades" yes "" "" "highres 16bit freetype2"

--- a/engines/pink/configure.engine
+++ b/engines/pink/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine pink "Pink Panther" yes "" "" "highres"

--- a/engines/playground3d/configure.engine
+++ b/engines/playground3d/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine playground3d "Playground 3d: the testing and playground environment for 3d renderers" no "" "" "16bit 3d highres"

--- a/engines/playground3d/configure.engine
+++ b/engines/playground3d/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine playground3d "Playground 3d: the testing and playground environment for 3d renderers" no "" "" "16bit 3d highres"
+add_engine playground3d "Playground 3D: the testing and playground environment for 3d renderers" no "" "" "16bit 3d highres" "tinygl"

--- a/engines/plumbers/configure.engine
+++ b/engines/plumbers/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine plumbers "Plumbers Don't Wear Ties" yes

--- a/engines/prince/configure.engine
+++ b/engines/prince/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine prince "The Prince and The Coward" yes "" "" "highres"

--- a/engines/prince/configure.engine
+++ b/engines/prince/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine prince "The Prince and The Coward" yes "" "" "highres"
+add_engine prince "The Prince and The Coward" yes "" "" "highres" "mt32emu"

--- a/engines/private/configure.engine
+++ b/engines/private/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine private "Private Eye" yes "" "" "highres"

--- a/engines/qdengine/configure.engine
+++ b/engines/qdengine/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine qdengine "QD Engine" yes "" "" "vorbis 16bit highres mpeg2"

--- a/engines/qdengine/configure.engine
+++ b/engines/qdengine/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine qdengine "QD Engine" yes "" "" "vorbis 16bit highres mpeg2"
+add_engine qdengine "QD Engine" yes "" "" "vorbis 16bit highres mpeg2" "imgui"

--- a/engines/queen/configure.engine
+++ b/engines/queen/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine queen "Flight of the Amazon Queen" yes
+add_engine queen "Flight of the Amazon Queen" yes "" "" "" "mt32emu"

--- a/engines/queen/configure.engine
+++ b/engines/queen/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine queen "Flight of the Amazon Queen" yes

--- a/engines/saga/configure.engine
+++ b/engines/saga/configure.engine
@@ -1,4 +1,4 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine saga "SAGA" yes "ihnm" "ITE"
+add_engine saga "SAGA" yes "ihnm" "ITE" "" "mt32emu"
 add_engine ihnm "IHNM" yes "" "" "highres"

--- a/engines/saga/configure.engine
+++ b/engines/saga/configure.engine
@@ -1,4 +1,4 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine saga "SAGA" yes "ihnm" "ITE"
 add_engine ihnm "IHNM" yes "" "" "highres"

--- a/engines/saga2/configure.engine
+++ b/engines/saga2/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine saga2 "SAGA2" yes "" "" "highres"
+add_engine saga2 "SAGA2" yes "" "" "highres" "mt32emu"

--- a/engines/saga2/configure.engine
+++ b/engines/saga2/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine saga2 "SAGA2" yes "" "" "highres"

--- a/engines/sci/configure.engine
+++ b/engines/sci/configure.engine
@@ -1,4 +1,4 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine sci "SCI" yes "sci32" "SCI 0-1.1 games"
 add_engine sci32 "SCI32 games" yes "" "" "highres"

--- a/engines/sci/configure.engine
+++ b/engines/sci/configure.engine
@@ -1,4 +1,4 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine sci "SCI" yes "sci32" "SCI 0-1.1 games"
+add_engine sci "SCI" yes "sci32" "SCI 0-1.1 games" "" "mt32emu"
 add_engine sci32 "SCI32 games" yes "" "" "highres"

--- a/engines/scumm/configure.engine
+++ b/engines/scumm/configure.engine
@@ -1,5 +1,5 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine scumm "SCUMM" yes "scumm_7_8 he" "v0-v6 games"
 add_engine scumm_7_8 "v7 & v8 games" yes
 add_engine he "HE71+ games" yes "" "" "highres bink"

--- a/engines/scumm/configure.engine
+++ b/engines/scumm/configure.engine
@@ -1,5 +1,5 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine scumm "SCUMM" yes "scumm_7_8 he" "v0-v6 games"
+add_engine scumm "SCUMM" yes "scumm_7_8 he" "v0-v6 games" "" "mt32emu"
 add_engine scumm_7_8 "v7 & v8 games" yes
 add_engine he "HE71+ games" yes "" "" "highres bink"

--- a/engines/sherlock/configure.engine
+++ b/engines/sherlock/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine sherlock "The Lost Files of Sherlock Holmes" yes

--- a/engines/sherlock/configure.engine
+++ b/engines/sherlock/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine sherlock "The Lost Files of Sherlock Holmes" yes
+add_engine sherlock "The Lost Files of Sherlock Holmes" yes "" "" "" "mt32emu"

--- a/engines/sky/configure.engine
+++ b/engines/sky/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine sky "Beneath a Steel Sky" yes
+add_engine sky "Beneath a Steel Sky" yes "" "" "" "mt32emu"

--- a/engines/sky/configure.engine
+++ b/engines/sky/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine sky "Beneath a Steel Sky" yes

--- a/engines/sludge/configure.engine
+++ b/engines/sludge/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine sludge "Sludge" no "" "" "16bit png"
+add_engine sludge "Sludge" no "" "" "16bit png" "vpx"

--- a/engines/sludge/configure.engine
+++ b/engines/sludge/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine sludge "Sludge" no "" "" "16bit png"

--- a/engines/stark/configure.engine
+++ b/engines/stark/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine stark "The Longest Journey" yes "" "" "16bit 3d highres freetype2 vorbis bink"
+add_engine stark "The Longest Journey" yes "" "" "16bit 3d highres freetype2 vorbis bink" "tinygl"

--- a/engines/stark/configure.engine
+++ b/engines/stark/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine stark "The Longest Journey" yes "" "" "16bit 3d highres freetype2 vorbis bink"

--- a/engines/startrek/configure.engine
+++ b/engines/startrek/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine startrek "Star Trek 25th Anniversary/Judgment Rites" no

--- a/engines/startrek/configure.engine
+++ b/engines/startrek/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine startrek "Star Trek 25th Anniversary/Judgment Rites" no
+add_engine startrek "Star Trek 25th Anniversary/Judgment Rites" no "" "" "" "mt32emu"

--- a/engines/supernova/configure.engine
+++ b/engines/supernova/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine supernova "Mission Supernova" yes

--- a/engines/sword1/configure.engine
+++ b/engines/sword1/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine sword1 "Broken Sword" yes "" "" "highres"

--- a/engines/sword2/configure.engine
+++ b/engines/sword2/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine sword2 "Broken Sword II" yes "" "" "highres"

--- a/engines/sword25/configure.engine
+++ b/engines/sword25/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine sword25 "Broken Sword 2.5" yes "" "" "png 16bit highres theoradec" "lua"
+add_engine sword25 "Broken Sword 2.5" yes "" "" "png 16bit highres theoradec" "lua theoradec"

--- a/engines/sword25/configure.engine
+++ b/engines/sword25/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine sword25 "Broken Sword 2.5" yes "" "" "png 16bit highres lua theoradec"
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
+add_engine sword25 "Broken Sword 2.5" yes "" "" "png 16bit highres theoradec" "lua"

--- a/engines/sword25/configure.engine
+++ b/engines/sword25/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine sword25 "Broken Sword 2.5" yes "" "" "png 16bit highres theoradec" "lua theoradec"
+add_engine sword25 "Broken Sword 2.5" yes "" "" "png 16bit highres theoradec lua" ""

--- a/engines/teenagent/configure.engine
+++ b/engines/teenagent/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine teenagent "Teen Agent" yes

--- a/engines/testbed/configure.engine
+++ b/engines/testbed/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine testbed "TestBed: the Testing framework" no
+add_engine testbed "TestBed: the Testing framework" no "" "" "" "mt32emu"

--- a/engines/testbed/configure.engine
+++ b/engines/testbed/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine testbed "TestBed: the Testing framework" no

--- a/engines/testbed/configure.engine
+++ b/engines/testbed/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine testbed "TestBed: the Testing framework" no "" "" "" "mt32emu"
+add_engine testbed "TestBed: the Testing framework" no "" "" "" "imgui mt32emu"

--- a/engines/tetraedge/configure.engine
+++ b/engines/tetraedge/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine tetraedge "Tetraedge" yes "" "" "highres 3d freetype2 vorbis png jpeg lua theoradec" ""
+add_engine tetraedge "Tetraedge" yes "" "" "highres 3d freetype2 vorbis png jpeg lua theoradec" "tinygl"

--- a/engines/tetraedge/configure.engine
+++ b/engines/tetraedge/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine tetraedge "Tetraedge" yes "" "" "highres 3d freetype2 vorbis png jpeg lua theoradec"
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
+add_engine tetraedge "Tetraedge" yes "" "" "highres 3d freetype2 vorbis png jpeg theoradec" "lua"

--- a/engines/tetraedge/configure.engine
+++ b/engines/tetraedge/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine tetraedge "Tetraedge" yes "" "" "highres 3d freetype2 vorbis png jpeg theoradec" "lua"
+add_engine tetraedge "Tetraedge" yes "" "" "highres 3d freetype2 vorbis png jpeg theoradec" "lua theoradec"

--- a/engines/tetraedge/configure.engine
+++ b/engines/tetraedge/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine tetraedge "Tetraedge" yes "" "" "highres 3d freetype2 vorbis png jpeg theoradec" "lua theoradec"
+add_engine tetraedge "Tetraedge" yes "" "" "highres 3d freetype2 vorbis png jpeg lua theoradec" ""

--- a/engines/tinsel/configure.engine
+++ b/engines/tinsel/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine tinsel "Tinsel" yes "" "" "" "mt32emu"
+add_engine tinsel "Tinsel" yes "" "" "" "mt32emu tinygl"

--- a/engines/tinsel/configure.engine
+++ b/engines/tinsel/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine tinsel "Tinsel" yes
+add_engine tinsel "Tinsel" yes "" "" "" "mt32emu"

--- a/engines/tinsel/configure.engine
+++ b/engines/tinsel/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine tinsel "Tinsel" yes

--- a/engines/titanic/configure.engine
+++ b/engines/titanic/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine titanic "Starship Titanic" yes "" "" "16bit jpeg highres mad"

--- a/engines/toltecs/configure.engine
+++ b/engines/toltecs/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine toltecs "3 Skulls of the Toltecs" yes "" "" "highres"

--- a/engines/toltecs/configure.engine
+++ b/engines/toltecs/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine toltecs "3 Skulls of the Toltecs" yes "" "" "highres"
+add_engine toltecs "3 Skulls of the Toltecs" yes "" "" "highres" "mt32emu"

--- a/engines/tony/configure.engine
+++ b/engines/tony/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine tony "Tony Tough and the Night of Roasted Moths" yes "" "" "16bit highres"

--- a/engines/toon/configure.engine
+++ b/engines/toon/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine toon "Toonstruck" yes "" "" "highres"

--- a/engines/touche/configure.engine
+++ b/engines/touche/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine touche "Touche: The Adventures of the Fifth Musketeer" yes "" "" "highres"
+add_engine touche "Touche: The Adventures of the Fifth Musketeer" yes "" "" "highres" "mt32emu"

--- a/engines/touche/configure.engine
+++ b/engines/touche/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine touche "Touche: The Adventures of the Fifth Musketeer" yes "" "" "highres"

--- a/engines/trecision/configure.engine
+++ b/engines/trecision/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine trecision "Trecision Adventure Module" yes "" "" "highres 16bit"

--- a/engines/tsage/configure.engine
+++ b/engines/tsage/configure.engine
@@ -1,5 +1,5 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine tsage "TsAGE" yes "ringworld blueforce ringworld2"
 add_engine ringworld "Ringworld: Revenge of the Patriarch" yes
 add_engine blueforce "Blue Force" yes

--- a/engines/tucker/configure.engine
+++ b/engines/tucker/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine tucker "Bud Tucker in Double Trouble" yes

--- a/engines/twine/configure.engine
+++ b/engines/twine/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine twine "Little Big Adventure" yes "" "" "highres"

--- a/engines/twine/configure.engine
+++ b/engines/twine/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine twine "Little Big Adventure" yes "" "" "highres"
+add_engine twine "Little Big Adventure" yes "" "" "highres" "mt32emu"

--- a/engines/twine/configure.engine
+++ b/engines/twine/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine twine "Little Big Adventure" yes "" "" "highres" "mt32emu"
+add_engine twine "Little Big Adventure" yes "" "" "highres" "imgui mt32emu"

--- a/engines/twp/configure.engine
+++ b/engines/twp/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine twp "Thimbleweed Park" yes "" "" "16bit 3d highres vorbis png opengl_game_shaders"

--- a/engines/twp/configure.engine
+++ b/engines/twp/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine twp "Thimbleweed Park" yes "" "" "16bit 3d highres vorbis png opengl_game_shaders"
+add_engine twp "Thimbleweed Park" yes "" "" "16bit 3d highres vorbis png opengl_game_shaders" "imgui"

--- a/engines/ultima/configure.engine
+++ b/engines/ultima/configure.engine
@@ -1,7 +1,7 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine ultima "Ultima" yes "ultima1 ultima4 ultima6 ultima8"
-add_engine ultima1 "Ultima I - The First Age of Darkness" no "" "" ""	
+add_engine ultima1 "Ultima I - The First Age of Darkness" no "" "" ""
 add_engine ultima4 "Ultima IV - Quest of the Avatar" yes "" "" "16bit"
-add_engine ultima6 "Ultima VI = The False Prophet" yes "" "" "highres 16bit lua"
+add_engine ultima6 "Ultima VI = The False Prophet" yes "" "" "highres 16bit" "lua"
 add_engine ultima8 "Ultima VIII - Pagan" yes "" "" "highres 16bit"

--- a/engines/ultima/configure.engine
+++ b/engines/ultima/configure.engine
@@ -1,6 +1,6 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine ultima "Ultima" yes "ultima1 ultima4 ultima6 ultima8"
+add_engine ultima "Ultima" yes "ultima1 ultima4 ultima6 ultima8" "" "mt32emu"
 add_engine ultima1 "Ultima I - The First Age of Darkness" no "" "" ""
 add_engine ultima4 "Ultima IV - Quest of the Avatar" yes "" "" "16bit"
 add_engine ultima6 "Ultima VI = The False Prophet" yes "" "" "highres 16bit" "lua"

--- a/engines/ultima/configure.engine
+++ b/engines/ultima/configure.engine
@@ -3,5 +3,5 @@
 add_engine ultima "Ultima" yes "ultima1 ultima4 ultima6 ultima8" "" "mt32emu"
 add_engine ultima1 "Ultima I - The First Age of Darkness" no "" "" ""
 add_engine ultima4 "Ultima IV - Quest of the Avatar" yes "" "" "16bit"
-add_engine ultima6 "Ultima VI = The False Prophet" yes "" "" "highres 16bit" "lua"
+add_engine ultima6 "Ultima VI = The False Prophet" yes "" "" "highres 16bit lua"
 add_engine ultima8 "Ultima VIII - Pagan" yes "" "" "highres 16bit"

--- a/engines/vcruise/configure.engine
+++ b/engines/vcruise/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine vcruise "V-Cruise" yes "" "" "16bit highres"

--- a/engines/vcruise/configure.engine
+++ b/engines/vcruise/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine vcruise "V-Cruise" yes "" "" "16bit highres"
+add_engine vcruise "V-Cruise" yes "" "" "16bit highres" "mt32emu"

--- a/engines/voyeur/configure.engine
+++ b/engines/voyeur/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine voyeur "Voyeur" yes

--- a/engines/wage/configure.engine
+++ b/engines/wage/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine wage "WAGE" no "" "" "highres"

--- a/engines/watchmaker/configure.engine
+++ b/engines/watchmaker/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine watchmaker "The Watchmaker" no "" "" "highres 16bit 3d opengl_game_classic"

--- a/engines/wintermute/configure.engine
+++ b/engines/wintermute/configure.engine
@@ -1,6 +1,6 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine wintermute "Wintermute" yes "foxtail herocraft wme3d" "" "16bit highres jpeg png"
+add_engine wintermute "Wintermute" yes "foxtail herocraft wme3d" "" "16bit highres jpeg png" "theoradec"
 add_engine wme3d "Wintermute3D" no "" "" "3d"
 add_engine foxtail "FoxTail" yes
 add_engine herocraft "HeroCraft" yes

--- a/engines/wintermute/configure.engine
+++ b/engines/wintermute/configure.engine
@@ -1,5 +1,5 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine wintermute "Wintermute" yes "foxtail herocraft wme3d" "" "16bit highres jpeg png"
 add_engine wme3d "Wintermute3D" no "" "" "3d"
 add_engine foxtail "FoxTail" yes

--- a/engines/zvision/configure.engine
+++ b/engines/zvision/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
-# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
+# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
 add_engine zvision "Z-Vision" yes "" "" "freetype2 16bit highres"

--- a/engines/zvision/configure.engine
+++ b/engines/zvision/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine zvision "Z-Vision" yes "" "" "freetype2 16bit highres"
+add_engine zvision "Z-Vision" yes "" "" "freetype2 16bit highres" "mt32emu"


### PR DESCRIPTION
It is an idea to build certain ScummVM components only when the relevant engines are enabled.

This is the first RFC. Things to do:

- [x] Add more components, like MKV
- [x] Add support to create_project
- [x] Modify `confgure.engine` for all engines for consistency
- [x] Modify create_engine
- [x] Implement the possibility of disabling features via components. E.g., `theoradec` is compiled only when `theoradec` component is enabled
- [x] If the matching feature is disabled, disable the component

The idea is to add another optional list to `configure.engine` (here it is `lua`):
```make
# This file is included from the main "configure" script
# add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
add_engine sword25 "Broken Sword 2.5" yes "" "" "png 16bit highres theoradec" "lua"
```

and in `configure` script:
```sh
add_component lua "lua" "USE_LUA"
```

This results in the addition of `#define USE_LUA` in `config.h` and `USE_LUA=1` in `config.mk` files.

Your comments are welcome.