### PR TITLE
DREAMWEB: Avoid out of bound read with empty strings in printDirect

### DIFF
--- a/engines/dreamweb/print.cpp
+++ b/engines/dreamweb/print.cpp
@@ -138,11 +138,11 @@ uint8 DreamWebEngine::printDirect(const uint8** string, uint16 x, uint16 *y, uin
 		uint16 i = offset;
 		do {
 			uint8 c = (*string)[0];
-			uint8 nextChar = (*string)[1];
-			++(*string);
 			if ((c == 0) || (c == ':')) {
 				return c;
 			}
+			uint8 nextChar = (*string)[1];
+			++(*string);
 			c = modifyChar(c);
 			uint8 width, height;
 			printChar(charSet, &i, *y, c, nextChar, &width, &height);


### PR DESCRIPTION
In the French version of the game, right at the start (in the first scene) there was a crash when moving the mouse around the screen due to an out of bound read with a string of length 1 (empty, with only the '\0' character) in the `DreamWebEngine::printDirect` function. This commit moves reading the next character to after checking that that the character is not '\0' to avoid this out of bound read.

This fixes [bug #15546](https://bugs.scummvm.org/ticket/15546).