### PR TITLE
RISCOS: Don't encode path when it's not needed

### DIFF
--- a/backends/fs/stdiostream.cpp
+++ b/backends/fs/stdiostream.cpp
@@ -43,6 +43,10 @@
 // Atari file names must have a 8.3 format, atomic breaks this
 #define STDIOSTREAM_NO_ATOMIC_SUPPORT
 #endif
+#if defined(RISCOS)
+// RISC OS file names are expected to be 10 characters or less, atomic makes this hard to guarantee
+#define STDIOSTREAM_NO_ATOMIC_SUPPORT
+#endif
 
 StdioStream::StdioStream(void *handle) : _handle(handle), _path(nullptr) {
 	assert(handle);

--- a/common/path.cpp
+++ b/common/path.cpp
@@ -1177,13 +1177,21 @@ String Path::toConfig() const {
 			return toString(Path::kNativeSeparator);
 		}
 	}
-#elif defined(__3DS__) || defined(__amigaos4__) || defined(__DS__) || defined(__MORPHOS__) || defined(NINTENDO_SWITCH) || defined(__PSP__) || defined(PSP2) || defined(__WII__) || defined(WIN32)
+#elif defined(__3DS__) || defined(__amigaos4__) || defined(__DS__) || defined(__MORPHOS__) || defined(NINTENDO_SWITCH) || defined(__PSP__) || defined(PSP2) || defined(RISCOS) || defined(__WII__) || defined(WIN32)
 	// For all platforms making use of : as a drive separator, avoid useless punycoding
 	if (!isEscaped()) {
 		// If we are escaped, we have forbidden characters which must be encoded
 		// Try to replace all : by SEPARATOR and check if we need puny encoding: if we don't, we are safe
 		Path tmp(*this);
 		tmp._str.replace(':', SEPARATOR);
+#if defined(RISCOS)
+		// RiscOS uses these characters everywhere
+		tmp._str.replace('$', SEPARATOR);
+		tmp._str.replace('<', SEPARATOR);
+		tmp._str.replace('>', SEPARATOR);
+		// We can get ending dots when we replace $ (.$ suffix)
+		tmp._str.replace('.', SEPARATOR);
+#endif
 #if defined(WIN32)
 		// WIN32 can also make use of ? in Win32 devices namespace
 		tmp._str.replace('?', SEPARATOR);


### PR DESCRIPTION
After some tests, this patch seems to work to avoid puny-encode in cases like `/HostFS::HostFS.$/ScummVM/SC_DEMO` and `/<ScummVM$Dir>/SC_DEMO`.