### PR TITLE
SCUMM: Optionally restore boat wreck graphics at beginning of Mac MI2

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2047,6 +2047,29 @@ void ScummEngine_v5::o5_putActorInRoom() {
 	if (a->_visible && _currentRoom != room && getTalkingActor() == a->_number) {
 		stopTalk();
 	}
+
+	// WORKAROUND: The boat wreck in the foreground at the entrance to Woodtick
+	// isn't present in the Macintosh version. The instruction to place the
+	// actor is still there, but places it in room 0. The actor is not
+	// initialized, and the scroll script is never set. (It is however still
+	// cleared when you leave the room, so we don't need to worry about that
+	// part of it.)
+	//
+	// This may have been done for performance reasons, though would the Mac II
+	// really have been that under-powered?
+
+	if (_game.id == GID_MONKEY2 && _game.platform == Common::kPlatformMacintosh &&
+		_currentRoom == 7 && vm.slot[_currentScript].number == 10002 &&
+		a->_number == 11 && room == 0 && enhancementEnabled(kEnhRestoredContent)) {
+		room = _currentRoom;
+		a->animateActor(250);
+		a->initActor(0);
+		a->setActorCostume(142);
+		a->_ignoreBoxes = 1;
+		a->_forceClip = 0;
+		VAR(VAR_SCROLL_SCRIPT) = 207;
+	}
+
 	a->_room = room;
 	if (!room)
 		a->putActor(0, 0, 0);


### PR DESCRIPTION
Here's something I just tried for the fun of it, and thought I'd submit for evaluation. I noticed some time ago that the boat wreck in the foreground at the beginning of Monkey Island 2 has been removed in the Macintosh version:

![scummvm-monkey2-mac-00013](https://github.com/user-attachments/assets/c659f2da-db8e-4683-8f15-59a663d19009)

It's possible that this was done for performance reasons. There is parallax scrolling going on here, and it was also remover from the Amiga version. I don't know how low-end color Macs compared to the Amiga, though. This pull request restores the missing graphics as "Restored content":

![scummvm-monkey2-mac-00014](https://github.com/user-attachments/assets/d7852c64-6a43-4cc8-8188-ca964a76c514)

Apparently everything is still there in the resource files: The graphics and the scroll script. It just needs to be set up from the room's entry script. (At this point, we should probably define constants for the script numbers of entry/exit scripts, but that's outside the scope of this pull request.) I believe my modification corresponds closely with the DOS version's script:

```
[0000] (48) if (VAR_VIDEOMODE == 19) {
[0007] (11)   animateCostume(11,250);
[000A] (13)   ActorOps(11,[Init(),Costume(142),IgnoreBoxes(),NeverZClip()]);
[0012] (2D)   putActorInRoom(11,7);
[0015] (01)   putActor(11,0,0);
[001B] (1A)   VAR_SCROLL_SCRIPT = 207;
[0020] (**) }
```

Whereas the Mac version looks like this:

```
[0000] (48) if (VAR_VIDEOMODE == 19) {
[0007] (2D)   putActorInRoom(11,0);
[000A] (01)   putActor(11,0,0);
[0010] (**) }
```

(The rest of the script is identical.)

Though I have absolutely no idea what the `animateCostume(11, 240)` thing is all about.

Another question: Can it also be restored in the Amiga version the same way? I don't have that one.