### PR TITLE
CONFIGURE: Add -ffat-lto-objects to the endianness check for LTO builds

### DIFF
--- a/configure
+++ b/configure
@@ -2650,8 +2650,8 @@ if $_strings $TMPO$HOSTEXEEXT 2>> "$TMPLOG"| grep BIGenDianSyS >/dev/null; then
 elif $_strings $TMPO$HOSTEXEEXT 2>> "$TMPLOG" | grep LiTTleEnDian >/dev/null; then
 	_endian=little
 fi
-echo $_endian;
-cc_check_clean tmp_endianness_check.cpp $TMPO-tmp_endianness_check.dwo
+echo $_endian
+cc_check_clean tmp_endianness_check.cpp $TMPO-tmp_endianness_check.dwo tmp_endianness_check.dwo
 
 case $_endian in
 	big)

--- a/configure
+++ b/configure
@@ -2641,7 +2641,10 @@ __attribute__ ((used)) unsigned short ebcdic_mm[] = { 0xC2C9, 0xC785, 0x95C4, 0x
 const char * _ebcdic() { char* s = (char*) ebcdic_mm; s = (char*) ebcdic_ii; return s; }
 int main() { _ascii (); _ebcdic (); return 0; }
 EOF
-$CXX $LDFLAGS $CXXFLAGS -o $TMPO$HOSTEXEEXT tmp_endianness_check.cpp >> "$TMPLOG" 2>&1
+# Make sure that this particular object always has regular machine code content,
+# so that the checks below can be done, even with LTO on.
+test "$have_gcc" = yes && no_lto_regular_machine_code_removal=-ffat-lto-objects
+$CXX $LDFLAGS $CXXFLAGS $no_lto_regular_machine_code_removal -o $TMPO$HOSTEXEEXT tmp_endianness_check.cpp >> "$TMPLOG" 2>&1
 if $_strings $TMPO$HOSTEXEEXT 2>> "$TMPLOG"| grep BIGenDianSyS >/dev/null; then
 	_endian=big
 elif $_strings $TMPO$HOSTEXEEXT 2>> "$TMPLOG" | grep LiTTleEnDian >/dev/null; then


### PR DESCRIPTION
Some Linux distributions (Fedora, Gentoo…) are using LTO builds more and more. The following `configure` change comes [from Fedora](https://src.fedoraproject.org/rpms/scummvm-tools/blob/rawhide/f/configure.patch), which hit an issue with our endianness check when they build with LTO.

We already have the first part (explicit `__attribute__ ((used))` so that the compiler doesn't remove the objects we search later on with `strings`), but not the second part, that is [`-ffat-lto-objects`](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-ffat-lto-objects). It forces the compiler to produce both machine code and intermediate representation objects in the resulting file. Otherwise (as far as I understand), in some cases you could end up with the IR part alone, and/or a `strings` binary which can't properly parse the objects we look for (i.e. `BIGenDianSyS` or `LiTTleEnDian`) if it's not LTO-aware.

This flag was added in GCC 4.7 (and equivalent Clang version, at least Clang 3 appears to have it, looking at Godbolt), which is *our de facto* minimum C++11 compiler, AFAIK (used for RISC OS). So we can just always enable *for this particular check* on all GCC-compatible compilers, I believe.

It's a no-op if LTO isn't enabled.

(The second commit removes the `tmp_endianness_check.dwo` leftover file I'm seeing with GCC 5.5.0 on the [reference VM](https://wiki.scummvm.org/index.php/HOWTO-Debug-Endian-Issues) we use for big-endian testing.)

Any objection? This is part of a pass of merging some changes that Linux distributions tend to do. Having this by default also means that we reduce the possibility of end-users hitting the problem with their LTO-enabled-by-default system compiler (e.g. I suspect that the error reported in https://bugs.scummvm.org/ticket/10695 was possibly related to this, since this user was using Fedora)