### PR TITLE
CONFIGURE: Don't use the Gold linker on i386/ppc (unless using --enable-gold)

### DIFF
--- a/configure
+++ b/configure
@@ -206,7 +206,7 @@ _pandoc=no
 _curl=yes
 _lld=no
 _mold=no
-_gold=yes
+_gold=auto
 # Default vkeybd/eventrec options
 _vkeybd=no
 _eventrec=no
@@ -2507,6 +2507,17 @@ else
 	define_in_config_if_yes yes 'NO_CXX11_ALIGNAS'
 fi
 
+# The Gold linker had known issues on at least i386 and ppc32, in some cases.
+# Since this linker is not very maintained anymore, and since alternative exist,
+# avoid using it on such archs unless --enable-gold was explicitly given.
+if test "$_gold" = auto; then
+	case $_host_cpu in
+		i[3-6]86 | powerpc* | ppc*)
+			_gold=no
+		;;
+	esac
+fi
+
 #
 # Determine extra build flags for debug and/or release builds
 #
@@ -2542,7 +2553,7 @@ if test "$_debug_build" != no; then
 			append_var LDFLAGS "-fuse-ld=mold"
 			append_var LDFLAGS "-Wl,--gdb-index"
 			echo_n -- " + Mold"
-		elif test "$_gold" = yes && cc_check_no_clean $debug_mode -gsplit-dwarf -fuse-ld=gold -Wl,--gdb-index; then
+		elif test "$_gold" != no && cc_check_no_clean $debug_mode -gsplit-dwarf -fuse-ld=gold -Wl,--gdb-index; then
 			append_var LDFLAGS "-fuse-ld=gold"
 			append_var LDFLAGS "-Wl,--gdb-index"
 			echo_n -- " + Gold"


### PR DESCRIPTION
Debian and Fedora have been building their official ScummVM packages with `--disable-gold` for a while, because of build failures on (at least) i386: [`[1]`](https://salsa.debian.org/games-team/scummvm/-/commit/a6afd58cf8cb8bb39ee1b1fd764ff1721b1001f4), [`[2]`](https://src.fedoraproject.org/rpms/scummvm/c/e737fe0c41f2c9cff8400defaab10908b553db18?branch=rawhide).

I saw a similar issue with Gold and the [ppc32 QEMU VM](https://wiki.scummvm.org/index.php?title=HOWTO-Debug-Endian-Issues) myself (`internal error in relocate, at ../../gold/powerpc.cc:6773` when doing a full build with all engines), and both Gentoo and Fedora think of Gold as a deprecated linker nowadays, anyway: [`[1]`](https://wiki.gentoo.org/wiki/Gold), [`[2]`](https://www.phoronix.com/news/GNU-Gold-Stagnate-F31), [`[3]`](https://fedoraproject.org/wiki/Changes/BINUTILS_GOLD).

So this PR disables the Gold linker on i386 and ppc. People really wanting to use it there can still use it with an explicit `--enable-gold`.

Alternative linkers exist (`mold`, `lld`...) and are already supported, and otherwise `ld.bfd` often is a safe default (and AFAICS it's not as slow at it used to be).

Any objection to this? The idea is to take care, by default, of the build issues that Fedora and Debian have been having with Gold. It looks like (at least) the `master-debian-i686` buildbot will be impacted by this change. (By the way, since it appears that this buildbot target never had an issue wild Gold, maybe we could disable its usage for older Gold releases only. But I can't say where to draw the line. Fedora/Debian hit the bug in 2020/2021, and Gold didn't receive many commits since then.)