### PR TITLE
SCUMM: Optinally enable the bats in the Mac MI2 Scabb Island swamp

### DIFF
--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -593,6 +593,13 @@ int ScummEngine::readVar(uint var) {
 			return !ConfMan.getBool("subtitles");
 		}
 
+		// WORKAROUND: The Macintosh version version of MI2 first sets the
+		// machine speed to 2, then immediately to 1, in script 1. This affects
+		// at the very least the number of bats in the Scabb Island swamp.
+		if (_game.id == GID_MONKEY2 && _game.platform == Common::kPlatformMacintosh && var == VAR_MACHINE_SPEED && enhancementEnabled(kEnhRestoredContent)) {
+			return 2;
+		}
+
 #if defined(USE_ENET) && defined(USE_LIBCURL)
 		if (_enableHECompetitiveOnlineMods) {
 			// HACK: If we're reading var586, competitive mods enabled, playing online,

--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -1041,6 +1041,16 @@ void ScummEngine::runEntryScript() {
 	}
 	if (VAR_ENTRY_SCRIPT2 != 0xFF && VAR(VAR_ENTRY_SCRIPT2))
 		runScript(VAR(VAR_ENTRY_SCRIPT2), 0, 0, nullptr);
+
+	// WORKAROUND: The Macintosh version of MI2 doesn't have any bats in the
+	// Scabb Island swamp, because that line has been removed from the entry
+	// script for room 20. We re-insert that call here.
+	if (_game.id == GID_MONKEY2 && _game.platform == Common::kPlatformMacintosh &&
+		_currentRoom == 20 && enhancementEnabled(kEnhRestoredContent)) {
+		int args[NUM_SCRIPT_LOCAL];
+		memset(args, 0, sizeof(args));
+		runScript(215, false, false, args);
+	}
 }
 
 void ScummEngine::runQuitScript() {


### PR DESCRIPTION
This came out of a brief discussion on Discord. I hadn't noticed it myself, but the bats flying around in the Scabb Island swamp are not present in the Mac version of MI2. This is because the call to the script that starts them has been removed from room 20's entry script. This pull request re-inserts that call if the "restored content" setting is enabled.

While testing, I also found that the number of bats is dependent on VAR_MACHINE_SPEED. The DOS version sets it to 2 in script 1, while the Mac version first sets it to 2, then immediately to 1. This pull request makes ScummVM report 2 when "restored content" is enabled. I put this in `readVar()` so that the setting will always have an effect, not just when the game is started.

I don't know what else is affected by the machine speed, so I really should play through the game and investigate every instance I can find. It shouldn't be that hard, just tedious, so if anyone already knows...
