### PR TITLE
BUILD: Restrict -force_cpusubtype_ALL flag to MacOS X PPC

### DIFF
--- a/configure
+++ b/configure
@@ -3075,9 +3075,14 @@ EOF
 				add_line_to_config_mk 'MACOSX_64_BITS_ONLY = 1'
 			fi
 		fi
-		if test "$_host_cpu" = "aarch64" ; then
+		case $_host_cpu in
+		powerpc*)
+			add_line_to_config_mk 'MACOSX_PPC = 1'
+			;;
+		aarch64)
 			add_line_to_config_mk 'MACOSX_ARM64 = 1'
-		fi
+			;;
+		esac
 
 		# Avoid "file has no symbols" noise from ranlib, if it's new enough
 		ranlib_version=`$_ranlib -V 2>/dev/null`

--- a/ports.mk
+++ b/ports.mk
@@ -590,8 +590,12 @@ endif
 # Special target to create a static linked binary for macOS.
 # We use -force_cpusubtype_ALL to ensure the binary runs on every
 # PowerPC machine.
+ifdef MACOSX_PPC
+OSX_STATIC_LD_FLAGS = -force_cpusubtype_ALL
+endif
+
 scummvm-static: $(DETECT_OBJS) $(OBJS)
-	+$(LD) $(LDFLAGS) -force_cpusubtype_ALL -o scummvm-static $(PRE_OBJS_FLAGS) $(DETECT_OBJS) $(OBJS) $(POST_OBJS_FLAGS) \
+	+$(LD) $(LDFLAGS) $(OSX_STATIC_LD_FLAGS) -o scummvm-static $(PRE_OBJS_FLAGS) $(DETECT_OBJS) $(OBJS) $(POST_OBJS_FLAGS) \
 		-framework CoreMIDI \
 		$(OSX_STATIC_LIBS) \
 		$(OSX_ZLIB)


### PR DESCRIPTION
This flag is only needed for PPC builds. Furthermore it is no longer recognized when building with recent Xcode on macOS ARM and causes a link error:
```
ld: unknown options: -force_cpusubtype_ALL 
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
