### PR TITLE
COMPOSER: Fix error when starting games

### DIFF
--- a/engines/composer/composer.cpp
+++ b/engines/composer/composer.cpp
@@ -406,6 +406,7 @@ void ComposerEngine::loadLibrary(uint id) {
 		// bookGroup is the basename of the path.
 		// TODO: tidy this up.
 		_bookGroup.clear();
+		filename = path.toString('/');
 		for (uint i = 0; i < filename.size(); i++) {
 			if (filename[i] == '~' || filename[i] == '/' || filename[i] == ':')
 				continue;


### PR DESCRIPTION
This is a regression from commit bbc4d51.
This was reported in the forum in the call for testing thread: https://forums.scummvm.org/viewtopic.php?p=100132#p100132
This can for example be reproduced with the Windows demo of Baba Yaga from https://downloads.scummvm.org/frs/demos/composer/

The issue was simple. The old correct code (before the regression) did something like this:
```
filename = mangleFilename(filename)
init _bookGroup from filename
```

With the commit above this was changed to:
```
path = mangleFilename(filename)
init _bookGroup from filename
```

Because the result of `mangleFilename` was assigned to a different variable, the `_bookGroup` ended up being initialised from the old `filename` (without mangling).