### PR TITLE
QDENGINE: Fix memory leaks when reading files

### DIFF
--- a/engines/qdengine/qdcore/qd_animation.cpp
+++ b/engines/qdengine/qdcore/qd_animation.cpp
@@ -704,6 +704,8 @@ bool qdAnimation::qda_load(Common::Path fpath) {
 		//_tileAnimation->dumpTiles(fpath, 50);
 	}
 
+	delete fh;
+
 	init_size();
 
 	return true;

--- a/engines/qdengine/qdcore/qd_font_info.cpp
+++ b/engines/qdengine/qdcore/qd_font_info.cpp
@@ -113,15 +113,18 @@ bool qdFontInfo::load_font() {
 
 			Common::replace(fpath, tgaExt, idxExt);
 
+			delete fh;
+			fh = nullptr;
+
 			// Открываем .idx и грузим индекс
 			if (qdFileManager::instance().open_file(&fh, Common::Path(fpath), false)) {
 				if (buf_font->load_index(fh))
 					load_fl = true;
 			}
 		}
-	}
 
-	delete fh;
+		delete fh;
+	}
 
 	if (!load_fl) {
 		delete buf_font;

--- a/engines/qdengine/qdcore/qd_sprite.cpp
+++ b/engines/qdengine/qdcore/qd_sprite.cpp
@@ -243,6 +243,8 @@ bool qdSprite::load() {
 
 	Image::TGADecoder tgaDecoder;
 	tgaDecoder.loadStream(*fh);
+	delete fh;
+
 	const Graphics::Surface *tgaSurface = tgaDecoder.getSurface();
 
 	int width = _picture_size.x = tgaSurface->w;	///< width of the sprite. number of pixels in width
@@ -282,8 +284,6 @@ bool qdSprite::load() {
 		memcpy(dataPtr, ptr, widthNB);
 		dataPtr += widthNB;
 	}
-
-	delete fh;
 
 	const byte min_color = 8;
 	if (_format == GR_ARGB8888) {

--- a/engines/qdengine/qdcore/util/plaympp_api.cpp
+++ b/engines/qdengine/qdcore/util/plaympp_api.cpp
@@ -52,19 +52,21 @@ bool mpegPlayer::play(const Common::Path file, bool loop, int vol) {
 
 	stop();
 
-	if (qdFileManager::instance().open_file(&_stream, file, false)) {
+	Common::SeekableReadStream *stream;
+
+	if (qdFileManager::instance().open_file(&stream, file, false)) {
 		Audio::SeekableAudioStream *audiostream;
 
 		if (isOGG) {
 #ifdef USE_VORBIS
-			audiostream = Audio::makeVorbisStream(_stream, DisposeAfterUse::YES);
+			audiostream = Audio::makeVorbisStream(stream, DisposeAfterUse::YES);
 #else
 			warning("mpegPlayer::play(%s, %d, %d): Vorbis support not compiled", file.toString().c_str(), loop, vol);
 			return false;
 #endif
 		} else {
 #ifdef USE_MPCDEC
-			audiostream = Audio::makeMPCStream(_stream, DisposeAfterUse::YES);
+			audiostream = Audio::makeMPCStream(stream, DisposeAfterUse::YES);
 #else
 			warning("mpegPlayer::play(%s, %d, %d): MPC support not compiled", file.toString().c_str(), loop, vol);
 			return false;

--- a/engines/qdengine/qdcore/util/plaympp_api.h
+++ b/engines/qdengine/qdcore/util/plaympp_api.h
@@ -94,8 +94,6 @@ private:
 
 	Audio::SoundHandle _soundHandle;
 
-	Common::SeekableReadStream *_stream = nullptr;
-
 	Common::Path _file;
 };
 

--- a/engines/qdengine/system/sound/wav_sound.cpp
+++ b/engines/qdengine/system/sound/wav_sound.cpp
@@ -51,13 +51,13 @@ bool wavSound::wav_file_load(const Common::Path fpath) {
 	if (qdFileManager::instance().open_file(&stream, fpath.toString().c_str(), false)) {
 		if (_fname.baseName().hasSuffixIgnoreCase(".ogg")) {
 #ifdef USE_VORBIS
-			_audioStream = Audio::makeVorbisStream(stream, DisposeAfterUse::NO);
+			_audioStream = Audio::makeVorbisStream(stream, DisposeAfterUse::YES);
 #else
 			warning("wavSound::wav_file_load(%s): Vorbis support not compiled", fpath.toString().c_str());
 			return false;
 #endif
 		} else {
-			_audioStream = Audio::makeWAVStream(stream, DisposeAfterUse::NO);
+			_audioStream = Audio::makeWAVStream(stream, DisposeAfterUse::YES);
 		}
 
 		_length = (float)_audioStream->getLength().msecs() / 1000.0;


### PR DESCRIPTION
There are still crashes due to running out of memory when testing on RISC OS, but I don't know if that means there are more memory leaks or if it's just a side effect of the `ZipArchive` class decompressing entire files in one go even when the files are quite large.