### PR TITLE
NANCY: Fixup RippedLetterPuzzle fix

### DIFF
--- a/engines/nancy/action/puzzle/rippedletterpuzzle.cpp
+++ b/engines/nancy/action/puzzle/rippedletterpuzzle.cpp
@@ -361,6 +361,7 @@ void RippedLetterPuzzle::handleInput(NancyInput &input) {
 						if (_puzzleState->order[i] == -1) {
 							// No, hide the picked up piece graphic
 							_pickedUpPiece.setVisible(false);
+							_puzzleState->_pickedUpPieceLastPos = -1;
 						} else {
 							// Yes, change the picked piece graphic
 							if (!_useCustomPickUpTile) {
@@ -374,7 +375,6 @@ void RippedLetterPuzzle::handleInput(NancyInput &input) {
 
 						SWAP<int8>(_puzzleState->order[i], _puzzleState->_pickedUpPieceID);
 						SWAP<byte>(_puzzleState->rotations[i], _puzzleState->_pickedUpPieceRot);
-						_puzzleState->_pickedUpPieceLastPos = -1;
 
 						// Draw the newly placed piece
 						drawPiece(i, _puzzleState->rotations[i], _puzzleState->order[i]);


### PR DESCRIPTION
If a piece is swapped with another piece, the LastPos is forgotten too soon; after viewing an inventory item with the new piece in hand, that piece can't be put down.

```
scummvm: ./common/array.h:274: T& Common::Array<T>::operator[](size_type) [with T = signed char; size_type = unsigned int]: Assertion `idx < _size' failed.
```

AFAICT, does not affect nancy2 (in ScummVM 2.9) which has no viewable inventory items (and which re-initializes the puzzle on loading save game).

For @fracturehill's review