### PR TITLE
GUI: Fix Rotation mode option

### DIFF
--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -400,6 +400,7 @@ void EditGameDialog::open() {
 
 	e = ConfMan.hasKey("gfx_mode", _domain) ||
 		ConfMan.hasKey("render_mode", _domain) ||
+		ConfMan.hasKey("rotation_mode", _domain) ||
 		ConfMan.hasKey("stretch_mode", _domain) ||
 		ConfMan.hasKey("scaler", _domain) ||
 		ConfMan.hasKey("scale_factor", _domain) ||

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -681,11 +681,18 @@ void OptionsDialog::apply() {
 			if (g_system->hasFeature(OSystem::kFeatureRotationMode)) {
 				if ((int32)_rotationModePopUp->getSelectedTag() >= 0) {
 					int rotationModeCode = ((Common::RotationMode)_rotationModePopUp->getSelectedTag());
-					if (_rotationModePopUp->getSelectedTag() == 0 || ConfMan.getInt("rotation_mode", _domain) != rotationModeCode) {
+					if (!ConfMan.hasKey("rotation_mode", _domain) ||
+						ConfMan.getInt("rotation_mode", _domain) != rotationModeCode) {
 						ConfMan.setInt("rotation_mode", rotationModeCode, _domain);
 						_rotationModePopUpDesc->setFontColor(ThemeEngine::FontColor::kFontColorNormal);
+						graphicsModeChanged = true;
 					}
-					g_system->setFeatureState(OSystem::kFeatureRotationMode, true);
+				} else {
+					// default selected
+					if (ConfMan.hasKey("rotation_mode", _domain)) {
+						ConfMan.removeKey("rotation_mode", _domain);
+						graphicsModeChanged = true;
+					}
 				}
 			}
 
@@ -775,6 +782,7 @@ void OptionsDialog::apply() {
 			ConfMan.removeKey("scaler", _domain);
 			ConfMan.removeKey("scale_factor", _domain);
 			ConfMan.removeKey("render_mode", _domain);
+			ConfMan.removeKey("rotation_mode", _domain);
 			ConfMan.removeKey("renderer", _domain);
 			ConfMan.removeKey("antialiasing", _domain);
 			ConfMan.removeKey("vsync", _domain);
@@ -825,6 +833,10 @@ void OptionsDialog::apply() {
 			g_system->setFeatureState(OSystem::kFeatureFilteringMode, ConfMan.getBool("filtering", _domain));
 		if (ConfMan.hasKey("vsync"))
 			g_system->setFeatureState(OSystem::kFeatureVSync, ConfMan.getBool("vsync", _domain));
+
+		if (g_system->hasFeature(OSystem::kFeatureRotationMode)) {
+			g_system->setFeatureState(OSystem::kFeatureRotationMode, ConfMan.hasKey("rotation_mode", _domain));
+		}
 
 		OSystem::TransactionError gfxError = g_system->endGFXTransaction();
 


### PR DESCRIPTION
- Changing rotation back to `<default>` had no effect
- Unchecking "Override" checkbox did not change rotation
- "Override" checkbox initialization was not affected by rotation

It looks like part of happened is that the GUI code for `rotation_mode` was cloned from the code for `render_mode`, but that can't work because `render_mode` has a sentinel zero value/enum for default and `rotation_mode` does not.

This is how I learned we had a rotation mode; yesterday I misclicked it instead of the render mode, and then I was trapped and had to turn my head like this: =)