### PR TITLE
SWORD1/SWORD2: Detect availability of RGB colour support at runtime

### DIFF
--- a/engines/asylum/views/video.cpp
+++ b/engines/asylum/views/video.cpp
@@ -191,8 +191,7 @@ void VideoPlayer::play(const Common::Path &filename, bool showSubtitles) {
 	int32 currentSubtitle = 0;
 
 	if (_vm->checkGameVersion("Steam") || _vm->isAltDemo()) {
-		Graphics::PixelFormat bestFormat = g_system->getSupportedFormats().front();
-		_decoder->setOutputPixelFormat(bestFormat);
+		_decoder->setOutputPixelFormats(g_system->getSupportedFormats());
 
 		Graphics::PixelFormat decoderFormat = _decoder->getPixelFormat();
 		initGraphics(640, 480, &decoderFormat);

--- a/engines/sword1/animation.h
+++ b/engines/sword1/animation.h
@@ -62,7 +62,7 @@ class MoviePlayer {
 public:
 	MoviePlayer(SwordEngine *vm, Text *textMan, ResMan *resMan, Sound *sound, OSystem *system, Video::VideoDecoder *decoder, DecoderType decoderType);
 	virtual ~MoviePlayer();
-	bool load(uint32 id);
+	Common::Error load(uint32 id);
 	void play();
 
 protected:
@@ -77,6 +77,7 @@ protected:
 	uint32 _black;
 	uint32 _c1Color, _c2Color, _c3Color, _c4Color;
 	DecoderType _decoderType;
+	bool _modeChange;
 
 	Video::VideoDecoder *_decoder;
 

--- a/engines/sword1/logic.cpp
+++ b/engines/sword1/logic.cpp
@@ -39,6 +39,7 @@
 
 #include "sword1/debug.h"
 
+#include "gui/error.h"
 #include "gui/message.h"
 
 namespace Sword1 {
@@ -1014,9 +1015,14 @@ int Logic::fnPlaySequence(Object *cpt, int32 id, int32 sequenceId, int32 d, int3
 	} else {
 		MoviePlayer *player = makeMoviePlayer(sequenceId, _vm, _textMan, _resMan, _sound, _system);
 		if (player) {
+			Common::Error err;
+
 			_screen->clearScreen();
-			if (player->load(sequenceId))
+			err = player->load(sequenceId);
+			if (err.getCode() == Common::kNoError)
 				player->play();
+			else
+				GUI::displayErrorDialog(err);
 			delete player;
 
 			// In some instances, when you start a video when the palette is still fading

--- a/engines/sword2/animation.h
+++ b/engines/sword2/animation.h
@@ -64,7 +64,7 @@ public:
 	MoviePlayer(Sword2Engine *vm, OSystem *system, Video::VideoDecoder *decoder, DecoderType decoderType);
 	virtual ~MoviePlayer();
 
-	bool load(const char *name);
+	Common::Error load(const char *name);
 	void play(MovieText *movieTexts, uint32 numMovieTexts, uint32 leadIn, uint32 leadOut);
 
 protected:
@@ -77,6 +77,7 @@ protected:
 	int _textX, _textY;
 	byte _white, _black;
 	DecoderType _decoderType;
+	bool _modeChange;
 
 	Video::VideoDecoder *_decoder;
 

--- a/engines/sword2/function.cpp
+++ b/engines/sword2/function.cpp
@@ -40,6 +40,8 @@
 #include "sword2/sound.h"
 #include "sword2/animation.h"
 
+#include "gui/error.h"
+
 namespace Sword2 {
 
 int32 Logic::fnTestFunction(int32 *params) {
@@ -2143,8 +2145,12 @@ int32 Logic::fnPlaySequence(int32 *params) {
 
 	_moviePlayer = makeMoviePlayer(filename, _vm, _vm->_system, frameCount);
 
-	if (_moviePlayer && _moviePlayer->load(filename)) {
-		_moviePlayer->play(_sequenceTextList, _sequenceTextLines, _smackerLeadIn, _smackerLeadOut);
+	if (_moviePlayer) {
+		Common::Error err = _moviePlayer->load(filename);
+		if (err.getCode() == Common::kNoError)
+			_moviePlayer->play(_sequenceTextList, _sequenceTextLines, _smackerLeadIn, _smackerLeadOut);
+		else
+			GUI::displayErrorDialog(err);
 	}
 
 	_sequenceTextLines = 0;

--- a/image/codecs/cinepak.cpp
+++ b/image/codecs/cinepak.cpp
@@ -651,6 +651,9 @@ bool CinepakDecoder::setOutputPixelFormat(const Graphics::PixelFormat &format) {
 	if (_bitsPerPixel == 8)
 		return false;
 
+	if (format.bytesPerPixel != 2 && format.bytesPerPixel != 4)
+		return false;
+
 	_pixelFormat = format;
 	return true;
 }

--- a/image/codecs/indeo/indeo.h
+++ b/image/codecs/indeo/indeo.h
@@ -540,7 +540,12 @@ protected:
 	 * Select the preferred format to use, for codecs where this is faster than converting
 	 * the image afterwards. Returns true if supported, and false otherwise.
 	 */
-	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override { _pixelFormat = format; return true; }
+	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override {
+		if (format.bytesPerPixel != 2 && format.bytesPerPixel != 4)
+			return false;
+		_pixelFormat = format;
+		return true;
+	}
 
 	/**
 	 * Decode the Indeo picture header.

--- a/image/codecs/indeo3.h
+++ b/image/codecs/indeo3.h
@@ -50,7 +50,12 @@ public:
 
 	const Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream) override;
 	Graphics::PixelFormat getPixelFormat() const override;
-	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override { _pixelFormat = format; return true; }
+	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override {
+		if (format.bytesPerPixel != 2 && format.bytesPerPixel != 4)
+			return false;
+		_pixelFormat = format;
+		return true;
+	}
 
 	static bool isIndeo3(Common::SeekableReadStream &stream);
 

--- a/image/codecs/mjpeg.h
+++ b/image/codecs/mjpeg.h
@@ -48,7 +48,12 @@ public:
 	const Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream) override;
 	void setCodecAccuracy(CodecAccuracy accuracy) override;
 	Graphics::PixelFormat getPixelFormat() const override { return _pixelFormat; }
-	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override { _pixelFormat = format; return true; }
+	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override {
+		if (format.isCLUT8())
+			return false;
+		_pixelFormat = format;
+		return true;
+	}
 
 private:
 	Graphics::PixelFormat _pixelFormat;

--- a/image/codecs/mpeg.h
+++ b/image/codecs/mpeg.h
@@ -53,7 +53,12 @@ public:
 	// Codec interface
 	const Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream) override;
 	Graphics::PixelFormat getPixelFormat() const override { return _pixelFormat; }
-	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override { _pixelFormat = format; return true; }
+	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override {
+		if (format.bytesPerPixel != 2 && format.bytesPerPixel != 4)
+			return false;
+		_pixelFormat = format;
+		return true;
+	}
 
 	// MPEGPSDecoder call
 	bool decodePacket(Common::SeekableReadStream &packet, uint32 &framePeriod, Graphics::Surface *dst = 0);

--- a/image/codecs/svq1.h
+++ b/image/codecs/svq1.h
@@ -45,7 +45,12 @@ public:
 
 	const Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream) override;
 	Graphics::PixelFormat getPixelFormat() const override { return _pixelFormat; }
-	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override { _pixelFormat = format; return true; }
+	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override {
+		if (format.bytesPerPixel != 2 && format.bytesPerPixel != 4)
+			return false;
+		_pixelFormat = format;
+		return true;
+	}
 
 private:
 	Graphics::PixelFormat _pixelFormat;

--- a/image/codecs/xan.h
+++ b/image/codecs/xan.h
@@ -47,7 +47,12 @@ public:
 
 	const Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream) override;
 	Graphics::PixelFormat getPixelFormat() const override { return _pixelFormat; }
-	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override { _pixelFormat = format; return true; }
+	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override {
+		if (format.bytesPerPixel != 2 && format.bytesPerPixel != 4)
+			return false;
+		_pixelFormat = format;
+		return true;
+	}
 
 private:
 	void decodeFrameType0(Common::SeekableReadStream &stream);

--- a/image/jpeg.h
+++ b/image/jpeg.h
@@ -60,7 +60,12 @@ public:
 	const Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream) override;
 	void setCodecAccuracy(CodecAccuracy accuracy) override;
 	Graphics::PixelFormat getPixelFormat() const override;
-	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override { _requestedPixelFormat = format; return true; }
+	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override {
+		if (format.isCLUT8())
+			return false;
+		_requestedPixelFormat = format;
+		return true;
+	}
 
 	// Special API for JPEG
 	enum ColorSpace {

--- a/video/bink_decoder.h
+++ b/video/bink_decoder.h
@@ -153,7 +153,13 @@ private:
 		uint16 getWidth() const override { return _width; }
 		uint16 getHeight() const  override{ return _height; }
 		Graphics::PixelFormat getPixelFormat() const override { return _pixelFormat; }
-		bool setOutputPixelFormat(const Graphics::PixelFormat &format) override { _pixelFormat = format; return true; }
+		bool setOutputPixelFormat(const Graphics::PixelFormat &format) override {
+			if (format.bytesPerPixel != 2 && format.bytesPerPixel != 4)
+				return false;
+			_pixelFormat = format;
+			return true;
+		}
+
 		int getCurFrame() const override { return _curFrame; }
 		int getFrameCount() const override { return _frameCount; }
 		const Graphics::Surface *decodeNextFrame() override { return _surface; }

--- a/video/mkv_decoder.h
+++ b/video/mkv_decoder.h
@@ -95,7 +95,13 @@ private:
 		uint16 getWidth() const { return _width; }
 		uint16 getHeight() const { return _height; }
 		Graphics::PixelFormat getPixelFormat() const { return _pixelFormat; }
-		bool setOutputPixelFormat(const Graphics::PixelFormat &format) { _pixelFormat = format; return true; }
+		bool setOutputPixelFormat(const Graphics::PixelFormat &format) {
+			if (format.bytesPerPixel != 2 && format.bytesPerPixel != 4)
+				return false;
+			_pixelFormat = format;
+			return true;
+		}
+
 		int getCurFrame() const { return _curFrame; }
 		uint32 getNextFrameStartTime() const { return (uint32)(_nextFrameStartTime * 1000); }
 		const Graphics::Surface *decodeNextFrame();

--- a/video/mpegps_decoder.cpp
+++ b/video/mpegps_decoder.cpp
@@ -622,6 +622,8 @@ Graphics::PixelFormat MPEGPSDecoder::MPEGVideoTrack::getPixelFormat() const {
 }
 
 bool MPEGPSDecoder::MPEGVideoTrack::setOutputPixelFormat(const Graphics::PixelFormat &format) {
+	if (format.bytesPerPixel != 2 && format.bytesPerPixel != 4)
+		return false;
 	_pixelFormat = format;
 	return true;
 }

--- a/video/psx_decoder.h
+++ b/video/psx_decoder.h
@@ -84,6 +84,8 @@ private:
 		uint16 getHeight() const override { return _height; }
 		Graphics::PixelFormat getPixelFormat() const override { return _pixelFormat; }
 		bool setOutputPixelFormat(const Graphics::PixelFormat &format) override {
+			if (format.bytesPerPixel != 2 && format.bytesPerPixel != 4)
+				return false;
 			_pixelFormat = format;
 			return true;
 		}

--- a/video/theora_decoder.h
+++ b/video/theora_decoder.h
@@ -86,7 +86,13 @@ private:
 		uint16 getWidth() const { return _width; }
 		uint16 getHeight() const { return _height; }
 		Graphics::PixelFormat getPixelFormat() const { return _pixelFormat; }
-		bool setOutputPixelFormat(const Graphics::PixelFormat &format) { _pixelFormat = format; return true; }
+		bool setOutputPixelFormat(const Graphics::PixelFormat &format) {
+			if (format.bytesPerPixel != 2 && format.bytesPerPixel != 4)
+				return false;
+			_pixelFormat = format;
+			return true;
+		}
+
 		int getCurFrame() const { return _curFrame; }
 		const Common::Rational &getFrameRate() const { return _frameRate; }
 		uint32 getNextFrameStartTime() const { return (uint32)(_nextFrameStartTime * 1000); }

--- a/video/video_decoder.cpp
+++ b/video/video_decoder.cpp
@@ -568,6 +568,14 @@ bool VideoDecoder::setOutputPixelFormat(const Graphics::PixelFormat &format) {
 	return result;
 }
 
+bool VideoDecoder::setOutputPixelFormats(const Common::List<Graphics::PixelFormat> &formatList) {
+	for (Common::List<Graphics::PixelFormat>::const_iterator i = formatList.begin(); i != formatList.end(); ++i) {
+		if (setOutputPixelFormat(*i))
+			return true;
+	}
+	return false;
+}
+
 void VideoDecoder::setVideoCodecAccuracy(Image::CodecAccuracy accuracy) {
 	_videoCodecAccuracy = accuracy;
 

--- a/video/video_decoder.h
+++ b/video/video_decoder.h
@@ -408,6 +408,18 @@ public:
 	bool setOutputPixelFormat(const Graphics::PixelFormat &format);
 
 	/**
+	 * Pick the default high color format from a list for videos that convert
+	 * from YUV.
+	 *
+	 * This should be called after loadStream(), but before a decodeNextFrame()
+	 * call. This is enforced.
+	 *
+	 * @param format The preferred output pixel format
+	 * @return true on success, false otherwise
+	 */
+	bool setOutputPixelFormats(const Common::List<Graphics::PixelFormat> &formatList);
+
+	/**
 	 * Set the accuracy of the video decoder
 	 */
 	virtual void setVideoCodecAccuracy(Image::CodecAccuracy accuracy);


### PR DESCRIPTION
This is currently a draft because it uncovers a bug in the PSX video decoder - `setOutputPixelFormats` needs to be called after `loadFile()` and before the first frame is decoded, however the PSX decoder decodes the first frame within the load function, meaning that it's not possible to override the default format.