### PR TITLE
BLADERUNNER: Don't allocate the thumbnail before needing it

### DIFF
--- a/engines/bladerunner/savefile.cpp
+++ b/engines/bladerunner/savefile.cpp
@@ -147,8 +147,6 @@ bool SaveFileManager::readHeader(Common::SeekableReadStream &in, SaveFileHeader 
 	}
 
 	if (!skipThumbnail) {
-		header._thumbnail = new Graphics::Surface(); // freed by ScummVM's smartptr
-
 		s.skip(4); //skip size;
 
 		if (header._version >= 4) {
@@ -160,6 +158,7 @@ bool SaveFileManager::readHeader(Common::SeekableReadStream &in, SaveFileHeader 
 				thumbnailData[i] = s.readUint16LE() | alphamask; // We set all pixels to non-transparency
 			}
 
+			header._thumbnail = new Graphics::Surface(); // freed by ScummVM's smartptr
 			header._thumbnail->init(80, 60, 160, thumbnailData, gameDataPixelFormat());
 		}
 


### PR DESCRIPTION
Graphics::loadThumbnail will overwrite it and it creates a memory leak.
