### PR TITLE
BLADERUNNER: Fix various leaks

### DIFF
--- a/engines/bladerunner/slice_animations.h
+++ b/engines/bladerunner/slice_animations.h
@@ -58,8 +58,11 @@ class SliceAnimations {
 	struct Page {
 		void   *_data;
 		uint32 _lastAccess;
+		// Use a doubly linked list to sort pages by access time
+		Page   *_prevPage;
+		Page   *_nextPage;
 
-		Page() : _data(nullptr), _lastAccess(0) {}
+		Page() : _data(nullptr), _lastAccess(0), _prevPage(nullptr), _nextPage(nullptr) {}
 	};
 
 	struct PageFile {
@@ -86,9 +89,13 @@ class SliceAnimations {
 	Common::Array<Palette>      _palettes;
 	Common::Array<Animation>    _animations;
 	Common::Array<Page>         _pages;
+	Page                       *_lastUsedPage;
 
 	PageFile _coreAnimPageFile;
 	PageFile _framesPageFile;
+
+	void updatePagesList(Page &page, bool newPage);
+	void cleanupOutdatedPages();
 
 public:
 	SliceAnimations(BladeRunnerEngine *vm)
@@ -98,7 +105,8 @@ public:
 		, _timestamp(0)
 		, _pageSize(0)
 		, _pageCount(0)
-		, _paletteCount(0) {}
+		, _paletteCount(0)
+		, _lastUsedPage(nullptr) {}
 	~SliceAnimations();
 
 	bool open(const Common::String &name);

--- a/engines/bladerunner/slice_renderer.cpp
+++ b/engines/bladerunner/slice_renderer.cpp
@@ -732,8 +732,10 @@ void SliceRenderer::drawShadowPolygon(int transparency, Graphics::Surface &surfa
 			if (z >= zMin) {
 				int index = (x & 3) + ((y & 3) << 2);
 				if (transparency - ditheringFactor[index] <= 0) {
+					uint32 color;
 					uint8 r, g, b;
-					surface.format.colorToRGB(READ_UINT32(pixel), r, g, b);
+					getPixel(surface, pixel, color);
+					surface.format.colorToRGB(color, r, g, b);
 					r *= 0.75f;
 					g *= 0.75f;
 					b *= 0.75f;

--- a/engines/bladerunner/vqa_decoder.cpp
+++ b/engines/bladerunner/vqa_decoder.cpp
@@ -148,17 +148,32 @@ VQADecoder::VQADecoder() {
 }
 
 VQADecoder::~VQADecoder() {
+	close();
+}
+
+void VQADecoder::close() {
 	for (uint i = _codebooks.size(); i != 0; --i) {
 		delete[] _codebooks[i - 1].data;
 	}
+	_codebooks.clear();
+
 	delete _audioTrack;
+	_audioTrack = nullptr;
+
 	delete _videoTrack;
+	_videoTrack = nullptr;
+
 	delete[] _frameInfo;
+	_frameInfo = nullptr;
+
+	_loopInfo.close();
+
 	deleteVQPTable();
 }
 
 bool VQADecoder::loadStream(Common::SeekableReadStream *s) {
-	// close();
+	close();
+
 	_s = s;
 
 	IFFChunkHeader chd;

--- a/engines/bladerunner/vqa_decoder.h
+++ b/engines/bladerunner/vqa_decoder.h
@@ -64,6 +64,7 @@ public:
 	~VQADecoder();
 
 	bool loadStream(Common::SeekableReadStream *s);
+	void close();
 
 	void readFrame(int frame, uint readFlags = kVQAReadAll);
 
@@ -135,7 +136,14 @@ public:
 
 		LoopInfo() : loopCount(0), loops(nullptr), flags(0) {}
 		~LoopInfo() {
+			close();
+		}
+
+		void close() {
 			delete[] loops;
+			loops = nullptr;
+			loopCount = 0;
+			flags = 0;
 		}
 	};
 

--- a/engines/bladerunner/vqa_player.cpp
+++ b/engines/bladerunner/vqa_player.cpp
@@ -36,6 +36,8 @@
 namespace BladeRunner {
 
 bool VQAPlayer::open() {
+	close();
+
 	_s = _vm->getResourceStream(_vm->_enhancedEdition ? ("video/" + _name) : _name);
 	if (!_s) {
 		return false;
@@ -109,6 +111,7 @@ bool VQAPlayer::open() {
 }
 
 void VQAPlayer::close() {
+	_decoder.close();
 	_vm->_mixer->stopHandle(_soundHandle);
 	delete _s;
 	_s = nullptr;


### PR DESCRIPTION
This is the result of my investigation on the bugs [#11376](https://bugs.scummvm.org/ticket/11376) and [#13660](https://bugs.scummvm.org/ticket/13660).
After some debugging, it appears that these bugs occur because of an OOM situation.
When using new, the failed allocation triggers a brutal abort without any information.
When using malloc, nullptr is returned but it doesn't seem to trigger a fault on the Wii to dereference it.
This causes random errors and assertion faults.

As I ran the engine using ASan on Linux using a 16bpp pixel format, it also uncovered two other bugs.

First commit avoids to read out of bound in 16bpp surfaces.

The second commit plugs a leak in overlays, when Overlays::play is called twice for the same loaded video.
In this case, the VQAPlayer::open function is called on an already open player and a cascade of memory leaks happens inside the decoder.

The third commit is what, I believe, should fix the two aforementioned bugs.
It prevents the pages array to fill indefinitely by adding a time based garbage collector.
I postulate that if a block has not been used after 60 seconds, it can be discarded (and it will be reloaded later if needed).
It seems safe as these pages seem to only be used by the slice renderer and one at a time.
The GC is implemented using a doubly circular linked list in addition of the existing array.

This last commit drastically reduces the memory consumption on the Wii and should avoid the OOM situation.