### PR TITLE
GRAPHICS: MACGUI: Extend the font ID enum

### DIFF
--- a/engines/director/tests.cpp
+++ b/engines/director/tests.cpp
@@ -65,7 +65,7 @@ void Window::testFontScaling() {
 
 	Graphics::MacFONTFont::testBlit(font1, &surface, 0xff, x, y + 200, 500);
 
-	Graphics::MacFont bigFont(Graphics::kMacFontChicago, 12);
+	Graphics::MacFont bigFont(Graphics::kMacFontSystem, 12);
 
 	font1 = (const Graphics::MacFONTFont *)_wm->_fontMan->getFont(bigFont);
 

--- a/engines/macventure/gui.cpp
+++ b/engines/macventure/gui.cpp
@@ -289,7 +289,7 @@ const WindowData &Gui::getWindowData(WindowReference reference) {
 }
 
 const Graphics::Font &Gui::getCurrentFont() {
-	return *_wm._fontMan->getFont(Graphics::MacFont(Graphics::kMacFontChicago, 12));
+	return *_wm._fontMan->getFont(Graphics::MacFont(Graphics::kMacFontSystem, 12));
 }
 
 void Gui::bringToFront(WindowReference winID) {

--- a/engines/pink/screen.cpp
+++ b/engines/pink/screen.cpp
@@ -109,7 +109,7 @@ Screen::Screen(PinkEngine *vm)
 	_textFontCleanup = true;
 #ifdef USE_FREETYPE2
 	if (vm->getLanguage() == Common::HE_ISR) {
-		_textFont = _wm->_fontMan->getFont(Graphics::MacFont(Graphics::kMacFontChicago, 12, Graphics::kMacFontRegular));
+		_textFont = _wm->_fontMan->getFont(Graphics::MacFont(Graphics::kMacFontSystem, 12, Graphics::kMacFontRegular));
 		_textFontCleanup = false;
 	} else {
 		_textFont = Graphics::loadTTFFontFromArchive("system.ttf", 16);

--- a/engines/scumm/macgui/macgui_impl.cpp
+++ b/engines/scumm/macgui/macgui_impl.cpp
@@ -525,7 +525,7 @@ const Graphics::Font *MacGuiImpl::getFont(FontId fontId) {
 
 	switch (fontId) {
 	case kSystemFont:
-		id = Graphics::kMacFontChicago;
+		id = Graphics::kMacFontSystem;
 		size = 12;
 		slant = Graphics::kMacFontRegular;
 		break;
@@ -557,7 +557,7 @@ bool MacGuiImpl::getFontParams(FontId fontId, int &id, int &size, int &slant) co
 		return true;
 
 	case kAboutFontRegular:
-		id = Graphics::kMacFontGeneva;
+		id = Graphics::kMacFontApplication;
 		size = 9;
 		slant = Graphics::kMacFontRegular;
 		return true;

--- a/engines/scumm/macgui/macgui_indy3.cpp
+++ b/engines/scumm/macgui/macgui_indy3.cpp
@@ -1000,19 +1000,19 @@ bool MacIndy3Gui::getFontParams(FontId fontId, int &id, int &size, int &slant) c
 		return true;
 
 	case kIndy3VerbFontRegular:
-		id = Graphics::kMacFontGeneva;
+		id = Graphics::kMacFontApplication;
 		size = 9;
 		slant = Graphics::kMacFontRegular;
 		return true;
 
 	case kIndy3VerbFontBold:
-		id = Graphics::kMacFontGeneva;
+		id = Graphics::kMacFontApplication;
 		size = 9;
 		slant = Graphics::kMacFontBold;
 		return true;
 
 	case kIndy3VerbFontOutline:
-		id = Graphics::kMacFontGeneva;
+		id = Graphics::kMacFontApplication;
 		size = 9;
 		slant = Graphics::kMacFontBold | Graphics::kMacFontOutline | Graphics::kMacFontCondense;
 		return true;

--- a/engines/scumm/macgui/macgui_v5.cpp
+++ b/engines/scumm/macgui/macgui_v5.cpp
@@ -55,13 +55,13 @@ const Graphics::Font *MacV5Gui::getFontByScummId(int32 id) {
 bool MacV5Gui::getFontParams(FontId fontId, int &id, int &size, int &slant) const {
 	switch (fontId) {
 	case kAboutFontRegular:
-		id = Graphics::kMacFontGeneva;
+		id = Graphics::kMacFontApplication;
 		size = 9;
 		slant = Graphics::kMacFontRegular;
 		return true;
 
 	case kAboutFontBold:
-		id = Graphics::kMacFontGeneva;
+		id = Graphics::kMacFontApplication;
 		size = 9;
 		slant = Graphics::kMacFontBold;
 		return true;
@@ -82,13 +82,13 @@ bool MacV5Gui::getFontParams(FontId fontId, int &id, int &size, int &slant) cons
 		return true;
 
 	case kAboutFontHeaderSimple1:
-		id = Graphics::kMacFontGeneva;
+		id = Graphics::kMacFontApplication;
 		size = 12;
 		slant = Graphics::kMacFontBold | Graphics::kMacFontItalic | Graphics::kMacFontOutline;
 		return true;
 
 	case kAboutFontHeaderSimple2:
-		id = Graphics::kMacFontChicago;
+		id = Graphics::kMacFontSystem;
 		size = 12;
 		slant = Graphics::kMacFontBold | Graphics::kMacFontItalic | Graphics::kMacFontOutline;
 		return true;

--- a/engines/wage/gui.cpp
+++ b/engines/wage/gui.cpp
@@ -126,7 +126,7 @@ Gui::Gui(WageEngine *engine) {
 	//TODO: Make the font we use here work
 	// (currently MacFontRun::getFont gets called with the fonts being uninitialized,
 	// so it initializes them by itself with default params, and not those here)
-	const Graphics::MacFont *font = new Graphics::MacFont(Graphics::kMacFontChicago, 8);
+	const Graphics::MacFont *font = new Graphics::MacFont(Graphics::kMacFontSystem, 8);
 
 	uint maxWidth = _screen.w;
 

--- a/graphics/macgui/macdialog.cpp
+++ b/graphics/macgui/macdialog.cpp
@@ -95,7 +95,7 @@ MacDialog::~MacDialog() {
 }
 
 const Graphics::Font *MacDialog::getDialogFont() {
-	return _wm->_fontMan->getFont(Graphics::MacFont(Graphics::kMacFontChicago, 12));
+	return _wm->_fontMan->getFont(Graphics::MacFont(Graphics::kMacFontSystem, 12));
 }
 
 void MacDialog::paint() {

--- a/graphics/macgui/macfontmanager.cpp
+++ b/graphics/macgui/macfontmanager.cpp
@@ -40,35 +40,35 @@ static const struct FontProto {
 	Common::CodePage encoding;
 	const char *name;
 } defaultFonts[] = {
-	{ 2,		Common::UNK_LANG,	Common::kMacRoman,	"New York" },
-	{ 3,		Common::UNK_LANG,	Common::kMacRoman,	"Geneva" },
-	{ 4,		Common::UNK_LANG,	Common::kMacRoman,	"Monaco" },
-	{ 5,		Common::UNK_LANG,	Common::kMacRoman,	"Venice" },
-	{ 6,		Common::UNK_LANG,	Common::kMacRoman,	"London" },
-	{ 7,		Common::UNK_LANG,	Common::kMacRoman,	"Athens" },
-	{ 8,		Common::UNK_LANG,	Common::kMacRoman,	"San Francisco" },
-	{ 9,		Common::UNK_LANG,	Common::kMacRoman,	"Toronto" },
-	{ 11,		Common::UNK_LANG,	Common::kMacRoman,	"Cairo" },
-	{ 12,		Common::UNK_LANG,	Common::kMacRoman,	"Los Angeles" },
-	{ 13,		Common::UNK_LANG,	Common::kMacRoman,	"Zapf Dingbats" },
-	{ 14,		Common::UNK_LANG,	Common::kMacRoman,	"Bookman" },
-	{ 15,		Common::UNK_LANG,	Common::kMacRoman,	"Helvetica Narrow" },
-	{ 16,		Common::UNK_LANG,	Common::kMacRoman,	"Palatino" },
-	{ 18,		Common::UNK_LANG,	Common::kMacRoman,	"Zapf Chancery" },
-	{ 20,		Common::UNK_LANG,	Common::kMacRoman,	"Times" },
-	{ 21,		Common::UNK_LANG,	Common::kMacRoman,	"Helvetica" },
-	{ 22,		Common::UNK_LANG,	Common::kMacRoman,	"Courier" },
-	{ 23,		Common::UNK_LANG,	Common::kMacRoman,	"Symbol" },
-	{ 24,		Common::UNK_LANG,	Common::kMacRoman,	"Taliesin" }, // mobile?
-	{ 33,		Common::UNK_LANG,	Common::kMacRoman,	"Avant Garde" },
-	{ 34,		Common::UNK_LANG,	Common::kMacRoman,	"New Century Schoolbook" },
-	{ 16383,	Common::UNK_LANG,	Common::kMacRoman,	"Chicago" },
+	{ kMacFontNewYork,		Common::UNK_LANG,	Common::kMacRoman,	"New York" },
+	{ kMacFontGeneva,		Common::UNK_LANG,	Common::kMacRoman,	"Geneva" },
+	{ kMacFontMonaco,		Common::UNK_LANG,	Common::kMacRoman,	"Monaco" },
+	{ kMacFontVenice,		Common::UNK_LANG,	Common::kMacRoman,	"Venice" },
+	{ kMacFontLondon,		Common::UNK_LANG,	Common::kMacRoman,	"London" },
+	{ kMacFontAthens,		Common::UNK_LANG,	Common::kMacRoman,	"Athens" },
+	{ kMacFontSanFrancisco,		Common::UNK_LANG,	Common::kMacRoman,	"San Francisco" },
+	{ kMacFontToronto,		Common::UNK_LANG,	Common::kMacRoman,	"Toronto" },
+	{ kMacFontCairo,		Common::UNK_LANG,	Common::kMacRoman,	"Cairo" },
+	{ kMacFontLosAngeles,		Common::UNK_LANG,	Common::kMacRoman,	"Los Angeles" },
+	{ kMacFontZapfDingbats,		Common::UNK_LANG,	Common::kMacRoman,	"Zapf Dingbats" },
+	{ kMacFontBookman,		Common::UNK_LANG,	Common::kMacRoman,	"Bookman" },
+	{ kMacFontHelveticaNarrow,	Common::UNK_LANG,	Common::kMacRoman,	"Helvetica Narrow" },
+	{ kMacFontPalatino,		Common::UNK_LANG,	Common::kMacRoman,	"Palatino" },
+	{ kMacFontZapfChancery,		Common::UNK_LANG,	Common::kMacRoman,	"Zapf Chancery" },
+	{ kMacFontTimes,		Common::UNK_LANG,	Common::kMacRoman,	"Times" },
+	{ kMacFontHelvetica,		Common::UNK_LANG,	Common::kMacRoman,	"Helvetica" },
+	{ kMacFontCourier,		Common::UNK_LANG,	Common::kMacRoman,	"Courier" },
+	{ kMacFontSymbol,		Common::UNK_LANG,	Common::kMacRoman,	"Symbol" },
+	{ kMacFontTaliesin,		Common::UNK_LANG,	Common::kMacRoman,	"Taliesin" }, // mobile?
+	{ kMacFontAvantGarde,		Common::UNK_LANG,	Common::kMacRoman,	"Avant Garde" },
+	{ kMacFontNewCenturySchoolbook,	Common::UNK_LANG,	Common::kMacRoman,	"New Century Schoolbook" },
+	{ kMacFontChicago,		Common::UNK_LANG,	Common::kMacRoman,	"Chicago" },
 
 	// Japanese (names are Shift JIS encoded)
-	{ 16384,	Common::JA_JPN,		Common::kUtf8,		"Osaka" },
-	{ 16436,	Common::JA_JPN,		Common::kUtf8,		"Osaka\x81\x7C\x93\x99\x95\x9D" }, // Osaka Mono
+	{ kMacFontOsaka,		Common::JA_JPN,		Common::kUtf8,		"Osaka" },
+	{ kMacFontOsakaMono,		Common::JA_JPN,		Common::kUtf8,		"Osaka\x81\x7C\x93\x99\x95\x9D" },
 
-	{ -1,		Common::UNK_LANG,	Common::kCodePageInvalid,	NULL }
+	{ kMacFontNonStandard,		Common::UNK_LANG,	Common::kCodePageInvalid,	NULL }
 };
 
 struct AliasProto {
@@ -79,32 +79,34 @@ struct AliasProto {
 
 static const AliasProto defaultAliases[] = {
 	// English names for Japanese fonts
-	{ 16436,	16436,	"OsakaMono" },
+	{ kMacFontOsakaMono,		kMacFontOsakaMono,	"OsakaMono" },
 
 	// Missing Japanese fonts
 	// These technically should be separate fonts, not just aliases for Osaka.
 	// However, we don't have a free source for these right now.
-	{ 16396,	16384,	"\x96\x7B\x96\xBE\x92\xA9\x81\x7C\x82\x6C" }, // Book Mincho - M
-	{ 16433,	16436,	"\x93\x99\x95\x9D\x83\x53\x83\x56\x83\x62\x83\x4E" }, // Mono Gothic
-	{ 16435,	16436,	"\x93\x99\x95\x9D\x96\xBE\x92\xA9" }, // Mono Ming
-	{ 16640,	16384,	"\x92\x86\x83\x53\x83\x56\x83\x62\x83\x4E\x91\xCC" }, // Medium Gothic
-	{ 16641,	16384,	"\x8D\xD7\x96\xBE\x92\xA9\x91\xCC" }, // Ming
-	{ 16700,	16384,	"\x95\xBD\x90\xAC\x96\xBE\x92\xA9" }, // Heisei Mincho
-	{ 16701,	16384,	"\x95\xBD\x90\xAC\x8A\x70\x83\x53\x83\x56\x83\x62\x83\x4E" }, // Heisei Kaku Gothic
+	{ kMacFontBookMinchoM,		kMacFontOsaka,		"\x96\x7B\x96\xBE\x92\xA9\x81\x7C\x82\x6C" }, // Book Mincho - M
+	{ kMacFontMonoGothic,		kMacFontOsakaMono,	"\x93\x99\x95\x9D\x83\x53\x83\x56\x83\x62\x83\x4E" }, // Mono Gothic
+	{ kMacFontMonoMing,		kMacFontOsakaMono,	"\x93\x99\x95\x9D\x96\xBE\x92\xA9" }, // Mono Ming
+	{ kMacFontMediumGothic,		kMacFontOsaka,		"\x92\x86\x83\x53\x83\x56\x83\x62\x83\x4E\x91\xCC" }, // Medium Gothic
+	{ kMacFontMing,			kMacFontOsaka,		"\x8D\xD7\x96\xBE\x92\xA9\x91\xCC" }, // Ming
+	{ kMacFontHeiseiMincho,		kMacFontOsaka,		"\x95\xBD\x90\xAC\x96\xBE\x92\xA9" }, // Heisei Mincho
+	{ kMacFontHeiseiKakuGothic,	kMacFontOsaka,		"\x95\xBD\x90\xAC\x8A\x70\x83\x53\x83\x56\x83\x62\x83\x4E" }, // Heisei Kaku Gothic
 
-	{ -1,		-1,		NULL }
+	{ kMacFontNonStandard,		kMacFontNonStandard,	NULL }
 };
 
 static const AliasProto latinModeAliases[] = {
-	{ 0,		16383,	"System" }, // Chicago
-	{ 1,		3,		"Application" }, // Geneva
-	{ -1,		-1,		NULL }
+	{ kMacFontSystem,		kMacFontChicago,	"System" },
+	{ kMacFontApplication,		kMacFontGeneva,		"Application" },
+
+	{ kMacFontNonStandard,		kMacFontNonStandard,	NULL }
 };
 
 static const AliasProto japaneseModeAliases[] = {
-	{ 0,		16384,	"System" }, // Osaka
-	{ 1,		16384,	"Application" }, // Osaka
-	{ -1,		-1,		NULL }
+	{ kMacFontSystem,		kMacFontOsaka,		"System" },
+	{ kMacFontApplication,		kMacFontOsaka,		"Application" },
+
+	{ kMacFontNonStandard,		kMacFontNonStandard,	NULL }
 };
 
 static const char *const fontStyleSuffixes[] = {
@@ -516,7 +518,7 @@ const Font *MacFontManager::getFont(MacFont *macFont) {
 		if (!font) {
 			debugC(1, kDebugLevelMacGUI, "Cannot load font '%s'", macFont->getName().c_str());
 
-			font = FontMan.getFontByName(MacFont(kMacFontChicago, 12).getName());
+			font = FontMan.getFontByName(MacFont(kMacFontSystem, 12).getName());
 		}
 	}
 

--- a/graphics/macgui/macfontmanager.h
+++ b/graphics/macgui/macfontmanager.h
@@ -43,21 +43,42 @@ class MacFontFamily;
 
 enum {
 	kMacFontNonStandard = -1,
-	kMacFontChicago = 0,
-	kMacFontGeneva = 1,
+	kMacFontSystem = 0,
+	kMacFontApplication = 1,
+
 	kMacFontNewYork = 2,
+	kMacFontGeneva = 3,
 	kMacFontMonaco = 4,
 	kMacFontVenice = 5,
 	kMacFontLondon = 6,
 	kMacFontAthens = 7,
 	kMacFontSanFrancisco = 8,
+	kMacFontToronto = 9,
 	kMacFontCairo = 11,
 	kMacFontLosAngeles = 12,
+	kMacFontZapfDingbats = 13,
+	kMacFontBookman = 14,
+	kMacFontHelveticaNarrow = 15,
 	kMacFontPalatino = 16,
+	kMacFontZapfChancery = 18,
 	kMacFontTimes = 20,
 	kMacFontHelvetica = 21,
 	kMacFontCourier = 22,
-	kMacFontSymbol = 23
+	kMacFontSymbol = 23,
+	kMacFontTaliesin = 24,
+	kMacFontAvantGarde = 33,
+	kMacFontNewCenturySchoolbook = 34,
+	kMacFontChicago = 16383,
+
+	kMacFontOsaka = 16384,
+	kMacFontBookMinchoM = 16396,
+	kMacFontMonoGothic = 16433,
+	kMacFontMonoMing = 16435,
+	kMacFontOsakaMono = 16436,
+	kMacFontMediumGothic = 16640,
+	kMacFontMing = 16641,
+	kMacFontHeiseiMincho = 16700,
+	kMacFontHeiseiKakuGothic = 16701
 };
 
 enum {
@@ -84,7 +105,7 @@ struct FontInfo {
 
 class MacFont {
 public:
-	MacFont(int id = kMacFontChicago, int size = 12, int slant = kMacFontRegular) {
+	MacFont(int id = kMacFontSystem, int size = 12, int slant = kMacFontRegular) {
 		_id = id;
 		_size = size ? size : 12;
 		_slant = slant;

--- a/graphics/macgui/macmenu.cpp
+++ b/graphics/macgui/macmenu.cpp
@@ -795,7 +795,7 @@ const Font *MacMenu::getMenuFont(int slant) {
 	}
 #endif
 
-	return _wm->_fontMan->getFont(Graphics::MacFont(kMacFontChicago, 12, slant));
+	return _wm->_fontMan->getFont(Graphics::MacFont(kMacFontSystem, 12, slant));
 }
 
 const Common::String MacMenu::getAcceleratorString(MacMenuItem *item, const char *prefix) {

--- a/graphics/macgui/mactext.h
+++ b/graphics/macgui/mactext.h
@@ -87,8 +87,8 @@ public:
 	void setTextColor(uint32 color, uint32 line);
 	void setTextColor(uint32 color, uint32 start, uint32 end);
 
-	void appendText(const Common::U32String &str, int fontId = kMacFontChicago, int fontSize = 12, int fontSlant = kMacFontRegular, bool skipAdd = false);
-	void appendText(const Common::U32String &str, int fontId = kMacFontChicago, int fontSize = 12, int fontSlant = kMacFontRegular, uint16 r = 0, uint16 g = 0, uint16 b = 0, bool skipAdd = false);
+	void appendText(const Common::U32String &str, int fontId = kMacFontSystem, int fontSize = 12, int fontSlant = kMacFontRegular, bool skipAdd = false);
+	void appendText(const Common::U32String &str, int fontId = kMacFontSystem, int fontSize = 12, int fontSlant = kMacFontRegular, uint16 r = 0, uint16 g = 0, uint16 b = 0, bool skipAdd = false);
 	void appendText(const Common::U32String &str, const Font *font, uint16 r = 0, uint16 g = 0, uint16 b = 0, bool skipAdd = false);
 
 	int getTextFont() { return _defaultFormatting.fontId; }

--- a/graphics/macgui/macwindow.cpp
+++ b/graphics/macgui/macwindow.cpp
@@ -82,7 +82,7 @@ void MacWindow::disableBorder() {
 }
 
 const Font *MacWindow::getTitleFont() {
-	return _wm->_fontMan->getFont(Graphics::MacFont(kMacFontChicago, 12));
+	return _wm->_fontMan->getFont(Graphics::MacFont(kMacFontSystem, 12));
 }
 
 void MacWindow::setActive(bool active) {

--- a/graphics/macgui/macwindowborder.cpp
+++ b/graphics/macgui/macwindowborder.cpp
@@ -148,7 +148,7 @@ const BorderOffsets &MacWindowBorder::getOffset() const {
 
 void MacWindowBorder::setTitle(const Common::String& title, int width, MacWindowManager *wm) {
 	_title = title;
-	const Graphics::Font *font = wm->_fontMan->getFont(Graphics::MacFont(kMacFontChicago, 12));
+	const Graphics::Font *font = wm->_fontMan->getFont(Graphics::MacFont(kMacFontSystem, 12));
 	int sidesWidth = getOffset().left + getOffset().right;
 	int titleWidth = font->getStringWidth(_title) + 8;
 	int maxWidth = MAX<int>(width - sidesWidth - 7, 0);
@@ -185,7 +185,7 @@ void MacWindowBorder::drawScrollBar(ManagedSurface *g, MacWindowManager *wm) {
 }
 
 void MacWindowBorder::drawTitle(ManagedSurface *g, MacWindowManager *wm, int titleOffset) {
-	const Graphics::Font *font = wm->_fontMan->getFont(Graphics::MacFont(kMacFontChicago, 12));
+	const Graphics::Font *font = wm->_fontMan->getFont(Graphics::MacFont(kMacFontSystem, 12));
 	int width = g->w;
 	int titleColor = getOffset().dark ? wm->_colorWhite: wm->_colorBlack;
 	int titleY = getOffset().titleTop;


### PR DESCRIPTION
All previous uses of `kMacFontChicago` and `kMacFontGeneva` have been replaced with `kMacFontSystem` and `kMacFontApplication` to reflect the fact that the internal values have changed.