### PR TITLE
ENGINES: Use LiberationSans instead of FreeSans as a fallback

### DIFF
--- a/engines/petka/interfaces/save_load.cpp
+++ b/engines/petka/interfaces/save_load.cpp
@@ -70,7 +70,7 @@ void InterfaceSaveLoad::start(int id) {
 	surf.blitFrom(*bmp);
 
 	// TODO: Which font did the original game use?
-	Common::ScopedPtr<Graphics::Font> font(Graphics::loadTTFFontFromArchive("LiberationSans-Regular.ttf", 20));
+	Common::ScopedPtr<Graphics::Font> font(Graphics::loadTTFFontFromArchive("LiberationSans-Regular.ttf", 18));
 
 	MetaEngine *metaEngine = g_engine->getMetaEngine();
 	for (int i = 0, j = _page * 6; i < 6; ++i, ++j) {

--- a/engines/petka/interfaces/save_load.cpp
+++ b/engines/petka/interfaces/save_load.cpp
@@ -69,7 +69,8 @@ void InterfaceSaveLoad::start(int id) {
 	Graphics::ManagedSurface surf(bmp->w, bmp->h, bmp->format);
 	surf.blitFrom(*bmp);
 
-	Common::ScopedPtr<Graphics::Font> font(Graphics::loadTTFFontFromArchive("FreeSans.ttf", 20));
+	// TODO: Which font did the original game use?
+	Common::ScopedPtr<Graphics::Font> font(Graphics::loadTTFFontFromArchive("LiberationSans-Regular.ttf", 20));
 
 	MetaEngine *metaEngine = g_engine->getMetaEngine();
 	for (int i = 0, j = _page * 6; i < 6; ++i, ++j) {

--- a/engines/petka/petka.cpp
+++ b/engines/petka/petka.cpp
@@ -98,8 +98,9 @@ Common::Error PetkaEngine::run() {
 	_vsys.reset(new VideoSystem(*this));
 	_resMgr.reset(new QManager(*this));
 
-	_textFont.reset(Graphics::loadTTFFontFromArchive("FreeSansBold.ttf", 20, Graphics::kTTFSizeModeCell));
-	_descriptionFont.reset(Graphics::loadTTFFontFromArchive("FreeSansBold.ttf", 16, Graphics::kTTFSizeModeCell));
+	// TODO: Which fonts did the original game use?
+	_textFont.reset(Graphics::loadTTFFontFromArchive("LiberationSans-Bold.ttf", 20, Graphics::kTTFSizeModeCell));
+	_descriptionFont.reset(Graphics::loadTTFFontFromArchive("LiberationSans-Bold.ttf", 16, Graphics::kTTFSizeModeCell));
 
 	loadPart(isDemo() ? 1 : 0);
 

--- a/engines/petka/petka.cpp
+++ b/engines/petka/petka.cpp
@@ -99,8 +99,8 @@ Common::Error PetkaEngine::run() {
 	_resMgr.reset(new QManager(*this));
 
 	// TODO: Which fonts did the original game use?
-	_textFont.reset(Graphics::loadTTFFontFromArchive("LiberationSans-Bold.ttf", 20, Graphics::kTTFSizeModeCell));
-	_descriptionFont.reset(Graphics::loadTTFFontFromArchive("LiberationSans-Bold.ttf", 16, Graphics::kTTFSizeModeCell));
+	_textFont.reset(Graphics::loadTTFFontFromArchive("LiberationSans-Bold.ttf", 18, Graphics::kTTFSizeModeCell));
+	_descriptionFont.reset(Graphics::loadTTFFontFromArchive("LiberationSans-Bold.ttf", 14, Graphics::kTTFSizeModeCell));
 
 	loadPart(isDemo() ? 1 : 0);
 

--- a/engines/wintermute/base/font/base_font_truetype.cpp
+++ b/engines/wintermute/base/font/base_font_truetype.cpp
@@ -578,17 +578,17 @@ bool BaseFontTT::initFont() {
 	// Handle Bold atleast for the fallback-case.
 	// TODO: Handle italic. (Needs a test-case)
 	if (_isBold) {
-		fallbackFilename = "FreeSansBold.ttf";
+		fallbackFilename = "LiberationSans-Bold.ttf";
 	} else {
-		fallbackFilename = "FreeSans.ttf";
+		fallbackFilename = "LiberationSans-Regular.ttf";
 	}
 
 	Common::SeekableReadStream *file = BaseFileManager::getEngineInstance()->openFile(_fontFile, true, false);
 	if (!file) {
 		if (Common::String(_fontFile) != "arial.ttf") {
-			warning("%s has no replacement font yet, using FreeSans for now (if available)", _fontFile);
+			warning("%s has no replacement font yet, using %s for now (if available)", _fontFile, fallbackFilename);
 		}
-		// Fallback1: Try to find FreeSans.ttf
+		// Fallback1: Try to find the LiberationSans font
 		file = SearchMan.createReadStreamForMember(fallbackFilename);
 	}
 
@@ -602,19 +602,11 @@ bool BaseFontTT::initFont() {
 		_deletableFont = Graphics::loadTTFFontFromArchive(fallbackFilename, _fontHeight, Graphics::kTTFSizeModeCharacter, 96); // Use the same dpi as WME (96 vs 72).
 		_font = _deletableFont;
 	}
-
-	// Fallback3: Try to ask FontMan for the FreeSans.ttf ScummModern.zip uses:
-	if (!_font) {
-		// Really not desirable, as we will get a font with dpi-72 then
-		Common::String fontName = Common::String::format("%s-%s@%d", fallbackFilename, "ASCII", _fontHeight);
-		warning("Looking for %s", fontName.c_str());
-		_font = FontMan.getFontByName(fontName);
-	}
 #else
 	warning("BaseFontTT::InitFont - FreeType2-support not compiled in, TTF-fonts will not be loaded");
 #endif // USE_FREETYPE2
 
-	// Fallback4: Just use the Big GUI-font. (REALLY undesirable)
+	// Fallback3: Just use the Big GUI-font. (REALLY undesirable)
 	if (!_font) {
 		_font = _fallbackFont = FontMan.getFontByUsage(Graphics::FontManager::kBigGUIFont);
 		warning("BaseFontTT::InitFont - Couldn't load font: %s", _fontFile);

--- a/engines/zvision/text/truetype_font.cpp
+++ b/engines/zvision/text/truetype_font.cpp
@@ -38,15 +38,15 @@
 namespace ZVision {
 
 const FontStyle systemFonts[] = {
-	{ "*times new roman*",	  "times",   "FreeSerif", "Italic", "LiberationSerif"  },
-	{ "*times*",		  "times",   "FreeSerif", "Italic", "LiberationSerif"  },
-	{ "*century schoolbook*", "censcbk", "FreeSerif", "Italic", "LiberationSerif"  },
-	{ "*garamond*", 	  "gara",    "FreeSerif", "Italic", "LiberationSerif"  },
-	{ "*courier new*",	  "cour",    "FreeMono",  "Oblique", "LiberationMono" },
-	{ "*courier*",		  "cour",    "FreeMono",  "Oblique", "LiberationMono" },
-	{ "*ZorkDeath*",	  "cour",    "FreeMono",  "Oblique", "LiberationMono" },
-	{ "*arial*",		  "arial",   "FreeSans",  "Oblique", "LiberationSans" },
-	{ "*ZorkNormal*",	  "arial",   "FreeSans",  "Oblique", "LiberationSans" }
+	{ "*times new roman*",	  "times",   "LiberationSerif"  },
+	{ "*times*",		  "times",   "LiberationSerif"  },
+	{ "*century schoolbook*", "censcbk", "LiberationSerif"  },
+	{ "*garamond*", 	  "gara",    "LiberationSerif"  },
+	{ "*courier new*",	  "cour",    "LiberationMono" },
+	{ "*courier*",		  "cour",    "LiberationMono" },
+	{ "*ZorkDeath*",	  "cour",    "LiberationMono" },
+	{ "*arial*",		  "arial",   "LiberationSans" },
+	{ "*ZorkNormal*",	  "arial",   "LiberationSans" }
 };
 
 const FontStyle getSystemFont(int fontIndex) {
@@ -74,35 +74,28 @@ bool StyledTTFont::loadFont(const Common::String &fontName, int32 point, uint st
 	_style = style;
 
 	Common::String newFontName;
-	Common::String freeFontName;
 	Common::String liberationFontName;
 
 	for (int i = 0; i < FONT_COUNT; i++) {
 		FontStyle curFont = getSystemFont(i);
 		if (fontName.matchString(curFont.zorkFont, true)) {
 			newFontName = curFont.fontBase;
-			freeFontName = curFont.freeFontBase;
 			liberationFontName = curFont.liberationFontBase;
 
 			if ((_style & TTF_STYLE_BOLD) && (_style & TTF_STYLE_ITALIC)) {
 				newFontName += "bi";
-				freeFontName += "Bold";
-				freeFontName += curFont.freeFontItalicName;
 				liberationFontName += "-BoldItalic";
 			} else if (_style & TTF_STYLE_BOLD) {
 				newFontName += "bd";
-				freeFontName += "Bold";
 				liberationFontName += "-Bold";
 			} else if (_style & TTF_STYLE_ITALIC) {
 				newFontName += "i";
-				freeFontName += curFont.freeFontItalicName;
 				liberationFontName += "-Italic";
 			} else {
 				liberationFontName += "-Regular";
 			}
 
 			newFontName += ".ttf";
-			freeFontName += ".ttf";
 			liberationFontName += ".ttf";
 			break;
 		}
@@ -111,7 +104,6 @@ bool StyledTTFont::loadFont(const Common::String &fontName, int32 point, uint st
 	if (newFontName.empty()) {
 		debug("Could not identify font: %s. Reverting to Arial", fontName.c_str());
 		newFontName = "arial.ttf";
-		freeFontName = "FreeSans.ttf";
 		liberationFontName = "LiberationSans-Regular.ttf";
 	}
 
@@ -120,8 +112,7 @@ bool StyledTTFont::loadFont(const Common::String &fontName, int32 point, uint st
 	Common::File *file = new Common::File();
 	Graphics::Font *newFont;
 	if (!file->open(Common::Path(newFontName)) && !_engine->getSearchManager()->openFile(*file, Common::Path(newFontName)) &&
-		!file->open(Common::Path(liberationFontName)) && !_engine->getSearchManager()->openFile(*file, Common::Path(liberationFontName)) &&
-		!file->open(Common::Path(freeFontName)) && !_engine->getSearchManager()->openFile(*file, Common::Path(freeFontName))) {
+		!file->open(Common::Path(liberationFontName)) && !_engine->getSearchManager()->openFile(*file, Common::Path(liberationFontName))) {
 		newFont = Graphics::loadTTFFontFromArchive(liberationFontName, point, Graphics::kTTFSizeModeCell, 0, 0, (sharp ? Graphics::kTTFRenderModeMonochrome : Graphics::kTTFRenderModeNormal));
 		delete file;
 	} else {

--- a/engines/zvision/text/truetype_font.h
+++ b/engines/zvision/text/truetype_font.h
@@ -36,8 +36,6 @@ namespace ZVision {
 struct FontStyle {
 	const char *zorkFont;
 	const char *fontBase;
-	const char *freeFontBase;
-	const char *freeFontItalicName;
 	const char *liberationFontBase;
 };
 

--- a/engines/zvision/zvision.cpp
+++ b/engines/zvision/zvision.cpp
@@ -263,10 +263,8 @@ Common::Error ZVision::run() {
 	// Before starting, make absolutely sure that the user has copied the needed fonts
 	for (int i = 0; i < FONT_COUNT; i++) {
 		FontStyle curFont = getSystemFont(i);
-		Common::String freeFontBoldItalic = Common::String("Bold") + curFont.freeFontItalicName;
 
 		const char *fontSuffixes[4] = { "", "bd", "i", "bi" };
-		const char *freeFontSuffixes[4] = { "", "Bold", curFont.freeFontItalicName, freeFontBoldItalic.c_str() };
 		const char *liberationFontSuffixes[4] = { "-Regular", "-Bold", "-Italic", "-BoldItalic" };
 
 		for (int j = 0; j < 4; j++) {
@@ -283,17 +281,12 @@ Common::Error ZVision::run() {
 			if (fontName == "garai.ttf")
 				fontName = "garait.ttf";
 
-			Common::String freeFontName = curFont.freeFontBase;
-			freeFontName += freeFontSuffixes[j];
-			freeFontName += ".ttf";
-
 			Common::String liberationFontName = curFont.liberationFontBase;
 			liberationFontName += liberationFontSuffixes[j];
 			liberationFontName += ".ttf";
 
 			if (!Common::File::exists(Common::Path(fontName)) && !_searchManager->hasFile(Common::Path(fontName)) &&
 				!Common::File::exists(Common::Path(liberationFontName)) && !_searchManager->hasFile(Common::Path(liberationFontName)) &&
-				!Common::File::exists(Common::Path(freeFontName)) && !_searchManager->hasFile(Common::Path(freeFontName)) &&
 				!Common::File::exists("fonts.dat") && !_searchManager->hasFile("fonts.dat")) {
 				foundAllFonts = false;
 				break;
@@ -311,10 +304,9 @@ Common::Error ZVision::run() {
 				"On Windows, you'll need the following font files from the Windows "
 				"font directory: Times New Roman, Century Schoolbook, Garamond, "
 				"Courier New and Arial. Alternatively, you can download the "
-				"Liberation Fonts or the GNU FreeFont package. You'll need all the "
-				"fonts from the font package you choose, i.e., LiberationMono, "
-				"LiberationSans and LiberationSerif, or FreeMono, FreeSans and "
-				"FreeSerif respectively."
+				"Liberation Fonts package. You'll need all the fonts from the "
+				"font package you choose, i.e., LiberationMono, LiberationSans "
+				"and LiberationSerif."
 		));
 		dialog.runModal();
 		quitGame();

--- a/graphics/macgui/macfontmanager.cpp
+++ b/graphics/macgui/macfontmanager.cpp
@@ -538,7 +538,7 @@ const Font *MacFontManager::getFont(MacFont *macFont) {
 					font = Graphics::loadTTFFontFromArchive(_fontInfo[familyId]->name, macFont->getSize(), Graphics::kTTFSizeModeCharacter, 0, 0, Graphics::kTTFRenderModeMonochrome);
 					_uniFonts[macFont->getSize()] = font;
 				} else {
-					font = Graphics::loadTTFFontFromArchive("FreeSans.ttf", macFont->getSize(), Graphics::kTTFSizeModeCharacter, 0, 0, Graphics::kTTFRenderModeMonochrome);
+					font = Graphics::loadTTFFontFromArchive("LiberationSans-Regular.ttf", macFont->getSize(), Graphics::kTTFSizeModeCharacter, 0, 0, Graphics::kTTFRenderModeMonochrome);
 					_uniFonts[macFont->getSize()] = font;
 				}
 			}


### PR DESCRIPTION
Previous discussion suggests that the Liberation fonts work better as fallbacks for fonts like Arial that FreeFont does, so this PR switches all engines for games that originally used Windows fonts to use the Liberation fonts for consistency.