### PR TITLE
I18N: Miscellaneous fixes

### DIFF
--- a/gui/themes/residualvm/remastered_gfx.stx
+++ b/gui/themes/residualvm/remastered_gfx.stx
@@ -144,7 +144,8 @@
 				<!-- Add these in order of priority. First match is used -->
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Bold.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Bold.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Bold.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Bold.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Bold.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Bold.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Bold.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSansBold.ttf'/>
@@ -154,7 +155,8 @@
 				point_size = '11'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Regular.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Regular.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Regular.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Regular.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Regular.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Regular.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Regular.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSans.ttf'/>
@@ -164,7 +166,8 @@
 				file = 'helvb12.bdf'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Bold.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Bold.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Bold.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Bold.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Bold.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Bold.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Bold.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSansBold.ttf'/>
@@ -174,7 +177,8 @@
 				point_size = '11'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Regular.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Regular.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Regular.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Regular.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Regular.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Regular.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Regular.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSans.ttf'/>
@@ -184,7 +188,8 @@
 				file = 'helvb12.bdf'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Regular.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Regular.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Regular.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Regular.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Regular.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Regular.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Regular.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSans.ttf'/>
@@ -194,7 +199,8 @@
 				point_size = '11'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Regular.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Regular.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Regular.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Regular.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Regular.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Regular.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Regular.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSans.ttf'/>
@@ -204,7 +210,8 @@
 				point_size = '11'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Regular.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Regular.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Regular.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Regular.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Regular.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Regular.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Regular.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSans.ttf'/>

--- a/gui/themes/scummmodern/scummmodern_gfx.stx
+++ b/gui/themes/scummmodern/scummmodern_gfx.stx
@@ -142,7 +142,8 @@
 				file = 'helvb12.bdf'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Bold.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Bold.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Bold.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Bold.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Bold.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Bold.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Bold.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSansBold.ttf'/>
@@ -152,7 +153,8 @@
 				point_size = '11'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Regular.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Regular.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Regular.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansTC-Regular.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansSC-Regular.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Regular.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Regular.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSans.ttf'/>
@@ -162,7 +164,8 @@
 				file = 'helvb12.bdf'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Bold.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Bold.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Bold.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Bold.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Bold.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Bold.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Bold.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSansBold.ttf'/>
@@ -172,7 +175,8 @@
 				point_size = '11'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Regular.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Regular.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Regular.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Regular.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Regular.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Regular.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Regular.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSans.ttf'/>
@@ -182,7 +186,8 @@
 				file = 'helvb12.bdf'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Regular.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Regular.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Regular.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Regular.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Regular.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Regular.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Regular.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSans.ttf'/>
@@ -192,7 +197,8 @@
 				point_size = '11'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Regular.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Regular.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Regular.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Regular.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Regular.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Regular.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Regular.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSans.ttf'/>
@@ -202,7 +208,8 @@
 				point_size = '8'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Regular.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Regular.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Regular.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Regular.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Regular.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Regular.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Regular.ttf'/>
 				<language id = '*'   scalable_file = 'FreeMonoBold.ttf'/>

--- a/gui/themes/scummremastered/remastered_gfx.stx
+++ b/gui/themes/scummremastered/remastered_gfx.stx
@@ -144,7 +144,8 @@
 				<!-- Add these in order of priority. First match is used -->
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Bold.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Bold.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Bold.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Bold.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Bold.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Bold.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Bold.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSansBold.ttf'/>
@@ -154,7 +155,8 @@
 				point_size = '11'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Regular.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Regular.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Regular.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Regular.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Regular.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Regular.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Regular.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSans.ttf'/>
@@ -164,7 +166,8 @@
 				file = 'helvb12.bdf'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Bold.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Bold.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Bold.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Bold.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Bold.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Bold.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Bold.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Regular.ttf'/>
@@ -175,7 +178,8 @@
 				point_size = '11'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Regular.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Regular.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Regular.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Regular.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Regular.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Regular.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Regular.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSans.ttf'/>
@@ -185,7 +189,8 @@
 				file = 'helvb12.bdf'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Regular.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Regular.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Regular.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Regular.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Regular.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Regular.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Regular.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSans.ttf'/>
@@ -195,7 +200,8 @@
 				point_size = '11'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Regular.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Regular.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Regular.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Regular.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Regular.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Regular.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Regular.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSans.ttf'/>
@@ -205,7 +211,8 @@
 				point_size = '11'>
 				<language id = 'ja'  scalable_file = 'NotoSansJP-Regular.otf'/>
 				<language id = 'ko'  scalable_file = 'NotoSansKR-Regular.otf'/>
-				<language id = 'zh*' scalable_file = 'NotoSansTC-Regular.otf'/>
+				<language id = 'zh_Hans' scalable_file = 'NotoSansSC-Regular.otf'/>
+				<language id = 'zh_Hant' scalable_file = 'NotoSansTC-Regular.otf'/>
 				<language id = 'hi'  scalable_file = 'NotoSans-Regular.ttf'/>
 				<language id = 'ar'  scalable_file = 'NotoNaskhArabic-Regular.ttf'/>
 				<language id = '*'   scalable_file = 'FreeSans.ttf'/>

--- a/po/ka.po
+++ b/po/ka.po
@@ -18,6 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.7.2\n"
+"X-Language-name: Georgian\n"
 
 #: audio/mac_plugin.cpp:30
 msgid "Apple Macintosh Audio"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -18,6 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.7.2\n"
+"X-Language-name: Chinese (Simplified)\n"
 
 #: audio/mac_plugin.cpp:30
 msgid "Apple Macintosh Audio"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -15,6 +15,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Language-name: Chinese (Traditional)\n"
 
 #: audio/mac_plugin.cpp:30
 msgid "Apple Macintosh Audio"


### PR DESCRIPTION
This is complicated by the fact that there appear to be two Traditional Chinese translations - one that's empty but has a more descriptive language ID, and one that's 20% complete but is broken by the first commit which uses zh_Hant as the language ID in the theme files.

I'm also not sure if the second commit should have been done via Weblate instead, but I couldn't spot an easy way of doing it.