### PR TITLE
Fix ImGui related segfault

### DIFF
--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -552,6 +552,26 @@ Common::Keymap *SdlGraphicsManager::getKeymap() {
 }
 
 #if defined(USE_IMGUI) && SDL_VERSION_ATLEAST(2, 0, 0)
+void SdlGraphicsManager::setImGuiCallbacks(const ImGuiCallbacks &callbacks) {
+	if (_imGuiInited) {
+		if (_imGuiCallbacks.cleanup) {
+			_imGuiCallbacks.cleanup();
+		}
+		_imGuiInited = false;
+	}
+
+	_imGuiCallbacks = callbacks;
+
+	if (!_imGuiReady) {
+		return;
+	}
+
+	if (_imGuiCallbacks.init) {
+		_imGuiCallbacks.init();
+	}
+	_imGuiInited = true;
+}
+
 void SdlGraphicsManager::initImGui(SDL_Renderer *renderer, void *glContext) {
 	assert(!_imGuiReady);
 	_imGuiInited = false;
@@ -613,8 +633,8 @@ void SdlGraphicsManager::initImGui(SDL_Renderer *renderer, void *glContext) {
 
 	if (_imGuiCallbacks.init) {
 		_imGuiCallbacks.init();
-		_imGuiInited = true;
 	}
+	_imGuiInited = true;
 }
 
 void SdlGraphicsManager::renderImGui() {

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -210,7 +210,7 @@ private:
 
 #if defined(USE_IMGUI) && SDL_VERSION_ATLEAST(2, 0, 0)
 public:
-	void setImGuiCallbacks(const ImGuiCallbacks &callbacks) override { _imGuiCallbacks = callbacks; }
+	void setImGuiCallbacks(const ImGuiCallbacks &callbacks) override;
 
 protected:
 	ImGuiCallbacks _imGuiCallbacks;

--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -332,6 +332,10 @@ Common::Error DirectorEngine::run() {
 #endif
 	}
 
+#ifdef USE_IMGUI
+	_system->setImGuiCallbacks(ImGuiCallbacks());
+#endif
+
 	return Common::kNoError;
 }
 

--- a/engines/qdengine/qdengine.cpp
+++ b/engines/qdengine/qdengine.cpp
@@ -324,6 +324,10 @@ Common::Error QDEngineEngine::run() {
 		g_system->delayMillis(10);
 	}
 
+#ifdef USE_IMGUI
+	_system->setImGuiCallbacks(ImGuiCallbacks());
+#endif
+
 	delete _gameD;
 
 	grDispatcher::instance()->finit();

--- a/engines/twine/twine.cpp
+++ b/engines/twine/twine.cpp
@@ -337,6 +337,10 @@ Common::Error TwinEEngine::run() {
 		if (saveSlot >= 0 && saveSlot <= 999) {
 			Common::Error state = loadGameState(saveSlot);
 			if (state.getCode() != Common::kNoError) {
+#ifdef USE_IMGUI
+				_system->setImGuiCallbacks(ImGuiCallbacks());
+#endif
+
 				return state;
 			}
 		}
@@ -415,6 +419,11 @@ Common::Error TwinEEngine::run() {
 
 	_sound->stopSamples();
 	_music->stopMusic();
+
+#ifdef USE_IMGUI
+	_system->setImGuiCallbacks(ImGuiCallbacks());
+#endif
+
 	return Common::kNoError;
 }
 

--- a/engines/twp/twp.cpp
+++ b/engines/twp/twp.cpp
@@ -1320,6 +1320,10 @@ Common::Error TwpEngine::run() {
 		}
 	}
 
+#ifdef USE_IMGUI
+	_system->setImGuiCallbacks(ImGuiCallbacks());
+#endif
+
 	return Common::kNoError;
 }
 


### PR DESCRIPTION
This segfault happens when discarding the engine with plugins.
Without this, the cleanup function is called too late (after the engine class is destroyed) and the code may not be present anymore.

Let's wait for build to finish before merging: I didn't build all the engines, only Twine, which works flawlessly under ASan.

EDIT: I thought about resetting the callbacks directly in Engine::~Engine() but it could make calls to code inside the subclass while it has just been destroyed. So I put the call directly in the run() function of every engine.