### PR TITLE
GRAPHICS: Apply aspect ratio correction to 16 color VGA 640x350 video…

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -1633,7 +1633,7 @@ bool OpenGLGraphicsManager::gameNeedsAspectRatioCorrection() const {
 		const uint height = getHeight();
 
 		// In case we enable aspect ratio correction we force a 4/3 ratio.
-		// But just for 320x200, 640x400, 640x350 (16 color VGA) and Hercules games, since other
+		// But just for 320x200, 640x400, 640x350 (16 color EGA) and Hercules games, since other
 		// games do not need this.
 		return (width == 320 && height == 200) || (width == 640 && height == 400) ||
 			   (width == 640 && height == 350) ||

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -1633,9 +1633,10 @@ bool OpenGLGraphicsManager::gameNeedsAspectRatioCorrection() const {
 		const uint height = getHeight();
 
 		// In case we enable aspect ratio correction we force a 4/3 ratio.
-		// But just for 320x200, 640x400 and Hercules games, since other
+		// But just for 320x200, 640x400, 640x350 (16 color VGA) and Hercules games, since other
 		// games do not need this.
 		return (width == 320 && height == 200) || (width == 640 && height == 400) ||
+			   (width == 640 && height == 350) ||
 		       (width == 720 && height == 348) || (width == 720 && height == 350);
 	}
 


### PR DESCRIPTION
Darkseed uses an unusual video mode 640x350 16 colors. This should be aspect ratio corrected.
This PR applies the Aspect Ratio Correction setting to this video mode.


![scummvm-darkseed-cd-00013](https://github.com/user-attachments/assets/811d131c-d87c-4608-a27a-43112b667a08)
