### PR TITLE
SCI: fix kernel sub function mapping for certain builds

### DIFF
--- a/engines/sci/engine/kernel.cpp
+++ b/engines/sci/engine/kernel.cpp
@@ -681,7 +681,7 @@ void Kernel::mapFunctions(GameFeatures *features) {
 									while (kernelSubLeft) {
 										kernelSubLeft--;
 										kernelSubMapBack--;
-										if (kernelSubMapBack->name == kernelSubMap->name) {
+										if (!strcmp(kernelSubMapBack->name, kernelSubMap->name)) {
 											if (kernelSubMapBack->signature) {
 												subFunctions[subId].signature = parseKernelSignature(kernelSubMap->name, kernelSubMapBack->signature);
 												break;


### PR DESCRIPTION
I had issues to run any SCI1 game with MSVC ASan builds. Debug and release builds worked though. The ASan builds always failed to start up with a 'DoSoundMasterVolume: no previous signatures' error. When I recently had that issue (which I quickly discussed with digitall on discord) I got it fixed by simply doing a full rebuild. But now it failed again and couldn't be repaired like that. So I looked into it deeper. And I find it quite surprising that it usually works in 99,9% of all cases, since it does a comparison of two pointers that are meant to point to different strings. In the kDoSound_subops table, each entry gets its own string. My only explanation is that these string repetitions get optimized away (but apparently not or not always for the MSVC ASan build). I have replaced it with a strcmp which seems to work fine.

