### PR TITLE
GUI: Improve console selection

### DIFF
--- a/gui/console.cpp
+++ b/gui/console.cpp
@@ -28,6 +28,7 @@
 #include "base/version.h"
 
 #include "common/system.h"
+#include "common/util.h"
 
 #include "graphics/fontman.h"
 
@@ -254,8 +255,12 @@ void ConsoleDialog::handleTickle() {
 	if (_selectionTime < time) {
 		_selectionTime += kDraggingTime;
 		if (_isDragging && _scrollDirection != 0) {
-			_scrollBar->handleMouseWheel(0, 0, -_scrollDirection);
+			handleMouseWheel(0, 0, -_scrollDirection);
 			_selEnd -= kCharsPerLine * _scrollDirection;
+			if (clampSelection(_selEnd))
+				// Scrolled as far as possible. Don't re-execute this block
+				// unnecessarily.
+				_scrollDirection = 0;
 		}
 	}
 	// Perform the "slide animation".
@@ -911,6 +916,7 @@ void ConsoleDialog::handleMouseDown(int x, int y, int button, int clickCount) {
 		int lineNumber = (y - _topPadding) / kConsoleLineHeight;
 		int ind = (x - _leftPadding) / kConsoleCharWidth;
 		_selBegin = (_scrollLine - _linesPerPage + 1 + lineNumber) * kCharsPerLine + ind;
+		clampSelection(_selBegin);
 		_selEnd = _selBegin;
 		_isDragging = true;
 	} else {
@@ -918,6 +924,19 @@ void ConsoleDialog::handleMouseDown(int x, int y, int button, int clickCount) {
 		_selEnd = -1;
 		drawDialog(kDrawLayerForeground);
 	}
+}
+
+bool ConsoleDialog::clampSelection(int &sel) {
+	int oldSel = sel;
+	int lowerBound = 0;
+	int upperBound;
+
+	upperBound = MAX(_promptEndPos, _currentPos);
+	upperBound = MAX(upperBound, _linesPerPage * kCharsPerLine); // at least the whole first page
+	upperBound += kCharsPerLine - (upperBound % kCharsPerLine); // to end of line
+
+	sel = MAX(lowerBound, MIN(upperBound, sel));
+	return sel != oldSel;
 }
 
 void ConsoleDialog::handleMouseMoved(int x, int y, int button) {
@@ -929,6 +948,7 @@ void ConsoleDialog::handleMouseMoved(int x, int y, int button) {
 		lineNumber = MIN(lineNumber, _linesPerPage - 1);
 		int col = (x - _leftPadding) / kConsoleCharWidth;
 		_selEnd = (_scrollLine - _linesPerPage + 1 + lineNumber) * kCharsPerLine + col;
+		clampSelection(_selEnd);
 
 		if (_selEnd == selEndPreviousMove)
 			return;

--- a/gui/console.cpp
+++ b/gui/console.cpp
@@ -910,8 +910,8 @@ void ConsoleDialog::handleMouseDown(int x, int y, int button, int clickCount) {
 
 		w->handleMouseDown(x - (w->getAbsX() - _x), y - (w->getAbsY() - _y), button, clickCount);
 	} else if (_selBegin == -1 || _selEnd == -1) {
-		if (y > _h)
-			return;
+		x = MIN(MAX(x, _leftPadding), kCharsPerLine * kConsoleCharWidth + _leftPadding);
+		y = MIN(MAX(y, _topPadding), (decltype(y))_h - kConsoleLineHeight);
 
 		int lineNumber = (y - _topPadding) / kConsoleLineHeight;
 		int ind = (x - _leftPadding) / kConsoleCharWidth;
@@ -944,6 +944,8 @@ void ConsoleDialog::handleMouseMoved(int x, int y, int button) {
 		Dialog::handleMouseMoved(x, y, button);
 	else {
 		int selEndPreviousMove = _selEnd;
+		x = MIN(MAX(x, _leftPadding), kCharsPerLine * kConsoleCharWidth + _leftPadding);
+		y = MIN(MAX(y, _topPadding), (decltype(y))_h - kConsoleLineHeight);
 		int lineNumber = (y - _topPadding) / kConsoleLineHeight;
 		lineNumber = MIN(lineNumber, _linesPerPage - 1);
 		int col = (x - _leftPadding) / kConsoleCharWidth;

--- a/gui/console.h
+++ b/gui/console.h
@@ -119,9 +119,6 @@ protected:
 	int _historyIndex;
 	int _historyLine;
 
-	void loadHistory();
-	void saveHistory();
-
 	float _widthPercent, _heightPercent;
 
 	int _leftPadding;
@@ -208,6 +205,8 @@ protected:
 	void killLastWord();
 
 	// History
+	void loadHistory();
+	void saveHistory();
 	void addToHistory(const Common::String &str);
 	void historyScroll(int direction);
 };

--- a/gui/console.h
+++ b/gui/console.h
@@ -209,6 +209,11 @@ protected:
 	void saveHistory();
 	void addToHistory(const Common::String &str);
 	void historyScroll(int direction);
+
+	/**
+	 * Returns whether sel was modified
+	 */
+	bool clampSelection(int &sel);
 };
 
 } // End of namespace GUI


### PR DESCRIPTION
`_selEnd` could become negative, so the console buffer could be accessed out of bounds.
Dragging outside the console text area resulted in a slightly strange start and/or end selection anchor.
Edit: I wrote before that there was significant increase in CPU usage while dragging beyond top or bottom of console. That was measured wrongly; it's a really minor difference, sorry. Even so, let's avoid the useless computations.

With ASan, try clicking near coordinate (0,0) in the console (within the margin--the black area), or dragging from anywhere out the top-left corner of the window.

The "Improve selection behaviour" commit was tough to explain; here are quick clips demonstrating.
|before|after|
|-|-|
|<video src=https://github.com/user-attachments/assets/cfbcb081-6d66-4967-b348-e68384aa121e>|<video src=https://github.com/user-attachments/assets/871a8be6-291e-438d-b96b-325dc0935f3b>|


(I gave clampSelection() a return value for a convenient `if(clamp())...` usage, but maybe this could be done better?)

```
gui/console.h:185:35: runtime error: index -128 out of bounds for type 'char [131072]'
ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7fcf3646d688 at pc 0x55f8b1c35422 bp 0x7ffdd6882bb0 sp 0x7ffdd6882ba8
READ of size 1 at 0x7fcf3646d688 thread T0
    #0 0x55f8b1c35421 in GUI::ConsoleDialog::drawLine(int) gui/console.cpp:226
    #1 0x55f8b1c371be in GUI::ConsoleDialog::handleMouseMoved(int, int, int) gui/console.cpp:944
    #2 0x55f8b18b4e14 in GUI::GuiManager::processEvent(Common::Event const&, GUI::Dialog*) gui/gui-manager.cpp:869
    #3 0x55f8b18b76cd in GUI::GuiManager::runLoop() gui/gui-manager.cpp:594
    #4 0x55f8b189c43e in GUI::Dialog::runModal() gui/dialog.cpp:78
    #5 0x55f8b1877e25 in GUI::Debugger::enter() gui/debugger.cpp:250
[...]
0x7fcf3646d688 is located 376 bytes to the left of 132200-byte region [0x7fcf3646d800,0x7fcf3648dc68)
allocated by thread T0 here:
    #0 0x7fcf646b94c8 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x55f8b1883060 in GUI::Debugger::Debugger() gui/debugger.cpp:57
[...]
```

