### PR TITLE
SCUMM: HE: Fix alloc-dealloc mismatch in ResExtractor

### DIFF
--- a/engines/scumm/he/resource_he.cpp
+++ b/engines/scumm/he/resource_he.cpp
@@ -49,8 +49,8 @@ ResExtractor::~ResExtractor() {
 	for (int i = 0; i < MAX_CACHED_CURSORS; ++i) {
 		CachedCursor *cc = &_cursorCache[i];
 		if (cc->valid) {
-			free(cc->bitmap);
-			free(cc->palette);
+			delete[] cc->bitmap;
+			delete[] cc->palette;
 		}
 	}
 


### PR DESCRIPTION
CachedCursor->bitmap and palette are allocated via new[] in ::extractResource.

```
ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs free) on 0x619000348080
    #0 0x7fea95eb76a8 in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x55d6c546b996 in Scumm::ResExtractor::~ResExtractor() engines/scumm/he/resource_he.cpp:52
[...]
0x619000348080 is located 0 bytes inside of 1024-byte region [0x619000348080,0x619000348480)
allocated by thread T0 here:
    #0 0x7fea95eb9628 in operator new[](unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:98
    #1 0x55d6c546ce70 in Scumm::Win32ResExtractor::extractResource(int, Scumm::ResExtractor::CachedCursor*) engines/scumm/he/resource_he.cpp:140
[...]
```
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
