### PR TITLE
AGI: Fix PREAGI pictures

### DIFF
--- a/engines/agi/agi.h
+++ b/engines/agi/agi.h
@@ -153,13 +153,14 @@ enum kDebugLevels {
 	kDebugLevelMain =      1 << 0,
 	kDebugLevelResources = 1 << 1,
 	kDebugLevelSprites =   1 << 2,
-	kDebugLevelInventory = 1 << 3,
-	kDebugLevelInput =     1 << 4,
-	kDebugLevelMenu =      1 << 5,
-	kDebugLevelScripts =   1 << 6,
-	kDebugLevelSound =     1 << 7,
-	kDebugLevelText =      1 << 8,
-	kDebugLevelSavegame =  1 << 9
+	kDebugLevelPictures =  1 << 3,
+	kDebugLevelInventory = 1 << 4,
+	kDebugLevelInput =     1 << 5,
+	kDebugLevelMenu =      1 << 6,
+	kDebugLevelScripts =   1 << 7,
+	kDebugLevelSound =     1 << 8,
+	kDebugLevelText =      1 << 9,
+	kDebugLevelSavegame =  1 << 10
 };
 
 /**

--- a/engines/agi/detection.cpp
+++ b/engines/agi/detection.cpp
@@ -37,6 +37,7 @@
 static const DebugChannelDef debugFlagList[] = {
 	{Agi::kDebugLevelMain, "Main", "Generic debug level"},
 	{Agi::kDebugLevelResources, "Resources", "Resources debugging"},
+	{Agi::kDebugLevelPictures, "Pictures", "Pictures debugging"},
 	{Agi::kDebugLevelSprites, "Sprites", "Sprites debugging"},
 	{Agi::kDebugLevelInventory, "Inventory", "Inventory debugging"},
 	{Agi::kDebugLevelInput, "Input", "Input events debugging"},

--- a/engines/agi/picture.cpp
+++ b/engines/agi/picture.cpp
@@ -386,7 +386,7 @@ void PictureMgr::drawPicture() {
 }
 
 void PictureMgr::drawPictureC64() {
-	debugC(8, kDebugLevelMain, "Drawing Apple II / C64 / CoCo picture");
+	debugC(kDebugLevelPictures, "Drawing Apple II / C64 / CoCo picture");
 
 	_scrColor = 0;
 
@@ -431,7 +431,7 @@ void PictureMgr::drawPictureC64() {
 }
 
 void PictureMgr::drawPictureV1() {
-	debugC(8, kDebugLevelMain, "Drawing V1 picture");
+	debugC(kDebugLevelPictures, "Drawing V1 picture");
 
 	while (_dataOffset < _dataSize) {
 		byte curByte = getNextByte();
@@ -473,7 +473,7 @@ void PictureMgr::drawPictureV1() {
 }
 
 void PictureMgr::drawPictureV15() {
-	debugC(8, kDebugLevelMain, "Drawing V1.5 picture");
+	debugC(kDebugLevelPictures, "Drawing V1.5 picture");
 
 	while (_dataOffset < _dataSize) {
 		byte curByte = getNextByte();
@@ -520,7 +520,7 @@ void PictureMgr::drawPictureV15() {
 }
 
 void PictureMgr::drawPicturePreAGI() {
-	debugC(8, kDebugLevelMain, "Drawing PreAGI picture");
+	debugC(kDebugLevelPictures, "Drawing PreAGI picture");
 
 	int step = 0;
 	while (_dataOffset < _dataSize) {
@@ -569,7 +569,7 @@ void PictureMgr::drawPicturePreAGI() {
 }
 
 void PictureMgr::drawPictureV2() {
-	debugC(8, kDebugLevelMain, "Drawing V2/V3 picture");
+	debugC(kDebugLevelPictures, "Drawing V2/V3 picture");
 
 	// AGIv3 nibble parameters are indicated by a flag in the picture's directory entry
 	bool nibbleMode = (_vm->_game.dirPic[_resourceNr].flags & RES_PICTURE_V3_NIBBLE_PARM) != 0;
@@ -637,7 +637,7 @@ void PictureMgr::drawPictureAGI256() {
 	byte *dataPtr = _data;
 	byte *dataEndPtr = _data + _dataSize;
 
-	debugC(8, kDebugLevelMain, "Drawing AGI256 picture");
+	debugC(kDebugLevelPictures, "Drawing AGI256 picture");
 
 	while (dataPtr < dataEndPtr) {
 		byte color = *dataPtr++;
@@ -968,7 +968,7 @@ void PictureMgr::decodePictureFromBuffer(byte *data, uint32 length, bool clearSc
 }
 
 void PictureMgr::showPicture(int16 x, int16 y, int16 width, int16 height) {
-	debugC(8, kDebugLevelMain, "Show picture");
+	debugC(kDebugLevelPictures, "Show picture");
 
 	_gfx->render_Block(x, y, width, height);
 }
@@ -977,7 +977,7 @@ void PictureMgr::showPictureWithTransition() {
 	_width = SCRIPT_WIDTH;
 	_height = SCRIPT_HEIGHT;
 
-	debugC(8, kDebugLevelMain, "Show picture");
+	debugC(kDebugLevelPictures, "Show picture");
 
 	if (!_vm->_game.automaticRestoreGame) {
 		// only do transitions when we are not restoring a saved game

--- a/engines/agi/picture.cpp
+++ b/engines/agi/picture.cpp
@@ -578,9 +578,15 @@ void PictureMgr::drawPicturePreAGI() {
 		case 0xf7:
 			draw_LineShort();
 			break;
-		case 0xf8:
+		case 0xf8: {
+			// The screen-on flag does not prevent PreAGI flood fills.
+			// Winnie picture 7 (Roo) contains F1 before several fills.
+			byte prevScrOn = _scrOn;
+			_scrOn = true;
 			draw_Fill();
+			_scrOn = prevScrOn;
 			break;
+		}
 		case 0xf9:
 			plotBrush_PreAGI();
 			break;

--- a/engines/agi/picture.cpp
+++ b/engines/agi/picture.cpp
@@ -379,7 +379,6 @@ void PictureMgr::drawPictureC64() {
 			_scrOn = true;
 			break;
 		case 0xe6:  // plot brush
-			// TODO: should this be getNextParamByte()?
 			_patCode = getNextByte();
 			plotBrush();
 			break;
@@ -419,6 +418,11 @@ void PictureMgr::drawPictureV1() {
 			break;
 		case 0xfb:
 			draw_LineShort();
+			break;
+		case 0xfc:
+			draw_SetColor();
+			draw_SetPriority();
+			draw_Fill();
 			break;
 		case 0xff: // end of data
 			return;
@@ -525,7 +529,6 @@ void PictureMgr::drawPictureV2() {
 			draw_Fill();
 			break;
 		case 0xf9:
-			// TODO: should this be getNextParamByte()?
 			_patCode = getNextByte();
 
 			if (_vm->getGameType() == GType_PreAGI)
@@ -533,14 +536,6 @@ void PictureMgr::drawPictureV2() {
 			break;
 		case 0xfa:
 			plotBrush();
-			break;
-		// FIXME: There is no opcode FC. A refactor in 2016 moved it to this
-		//        function and removed the comment that it was for V1 or V1.5.
-		//        Determine where this should go (if anywhere) before removing.
-		case 0xfc:
-			draw_SetColor();
-			draw_SetPriority();
-			draw_Fill();
 			break;
 		case 0xff: // end of data
 			return;
@@ -597,8 +592,7 @@ void PictureMgr::drawPictureAGI256() {
 }
 
 void PictureMgr::draw_SetColor() {
-	if (!getNextParamByte(_scrColor))
-		return;
+	_scrColor = getNextByte();
 
 	// For CGA, replace the color with its mixture color
 	if (_vm->_renderMode == Common::kRenderCGA) {
@@ -607,7 +601,7 @@ void PictureMgr::draw_SetColor() {
 }
 
 void PictureMgr::draw_SetPriority() {
-	getNextParamByte(_priColor);
+	_priColor = getNextByte();
 }
 
 // this gets a nibble instead of a full byte

--- a/engines/agi/picture.cpp
+++ b/engines/agi/picture.cpp
@@ -62,6 +62,12 @@ void PictureMgr::putVirtPixel(int x, int y) {
 	x += _xOffset;
 	y += _yOffset;
 
+	// validate coordinate after applying preagi offset.
+	// winnie objects go past the bottom of the screen.
+	if (x >= SCRIPT_WIDTH || y >= SCRIPT_HEIGHT) {
+		return;
+	}
+
 	byte drawMask= 0;
 	if (_priOn)
 		drawMask |= GFX_SCREEN_MASK_PRIORITY;
@@ -949,6 +955,12 @@ bool PictureMgr::draw_FillCheck(int16 x, int16 y) {
 
 	x += _xOffset;
 	y += _yOffset;
+
+	// validate coordinate after applying preagi offset.
+	// winnie objects go past the bottom of the screen.
+	if (x >= SCRIPT_WIDTH || y >= SCRIPT_HEIGHT) {
+		return false;
+	}
 
 	byte screenColor = _gfx->getColor(x, y);
 	byte screenPriority = _gfx->getPriority(x, y);

--- a/engines/agi/picture.h
+++ b/engines/agi/picture.h
@@ -52,9 +52,8 @@ enum AgiPictureVersion {
 
 enum AgiPictureFlags {
 	kPicFNone      = (1 << 0),
-	kPicFCircle    = (1 << 1), // Mickey, spaceship lights (not drawn accurately)
-	kPicFf3Stop    = (1 << 2), // Troll, certain pictures
-	kPicFTrollMode = (1 << 3)  // Troll, drawing the Troll
+	kPicFf3Stop    = (1 << 1), // Troll, certain pictures
+	kPicFTrollMode = (1 << 2)  // Troll, drawing the Troll
 };
 
 class AgiBase;
@@ -75,6 +74,8 @@ private:
 	void yCorner(bool skipOtherCoords = false);
 	void plotPattern(int x, int y);
 	void plotBrush();
+	void plotPattern_PreAGI(byte x, byte y);
+	void plotBrush_PreAGI();
 
 	byte getNextByte();
 	bool getNextParamByte(byte &b);

--- a/engines/agi/picture.h
+++ b/engines/agi/picture.h
@@ -81,6 +81,10 @@ private:
 	bool getNextParamByte(byte &b);
 	byte getNextNibble();
 
+	bool getNextXCoordinate(byte &x);
+	bool getNextYCoordinate(byte &y);
+	bool getNextCoordinates(byte &x, byte &y);
+
 public:
 	void decodePicture(int16 resourceNr, bool clearScreen, bool agi256 = false, int16 width = _DEFAULT_WIDTH, int16 height = _DEFAULT_HEIGHT);
 	void decodePictureFromBuffer(byte *data, uint32 length, bool clearScreen, int16 width = _DEFAULT_WIDTH, int16 height = _DEFAULT_HEIGHT);

--- a/engines/agi/picture.h
+++ b/engines/agi/picture.h
@@ -46,7 +46,8 @@ enum AgiPictureVersion {
 	AGIPIC_C64,     // Winnie (Apple II, C64, CoCo)
 	AGIPIC_V1,      // Currently unused
 	AGIPIC_V15,     // Troll (DOS)
-	AGIPIC_V2       // AGIv2, AGIv3, Winnie (DOS, Amiga), Mickey (DOS)
+	AGIPIC_PREAGI,  // Winnie (DOS, Amiga), Mickey (DOS)
+	AGIPIC_V2       // AGIv2, AGIv3
 };
 
 enum AgiPictureFlags {
@@ -88,6 +89,7 @@ private:
 	void drawPictureC64();
 	void drawPictureV1();
 	void drawPictureV15();
+	void drawPicturePreAGI();
 	void drawPictureV2();
 	void drawPictureAGI256();
 

--- a/engines/agi/preagi/mickey.cpp
+++ b/engines/agi/preagi/mickey.cpp
@@ -2275,6 +2275,8 @@ void MickeyEngine::init() {
 #endif
 
 	setFlag(VM_FLAG_SOUND_ON, true); // enable sound
+
+	_picture->setPictureVersion(AGIPIC_PREAGI);
 }
 
 Common::Error MickeyEngine::go() {

--- a/engines/agi/preagi/mickey.cpp
+++ b/engines/agi/preagi/mickey.cpp
@@ -762,7 +762,7 @@ void MickeyEngine::drawRoomAnimation() {
 		// draw blinking ship lights
 		uint8 lightPicture[] = {
 			0xF0, 1,          // Set Color: 1
-			0xF9, 2, 43, 45,  // Set Pattern: 2, plot at 43,45
+			0xF9, 2, 44, 45,  // Set Pattern: 2, plot at 44,45
 			0xFF              // End
 		};
 
@@ -777,7 +777,6 @@ void MickeyEngine::drawRoomAnimation() {
 			lightPicture[1] = iColor; // change light color
 			lightPicture[4] += 7;     // increase x coordinate
 
-			_picture->setPictureFlags(kPicFCircle);
 			_picture->setMaxStep(0);
 			_picture->setOffset(IDI_MSA_PIC_X0, IDI_MSA_PIC_Y0);
 			_picture->decodePictureFromBuffer(lightPicture, sizeof(lightPicture), false, IDI_MSA_PIC_WIDTH, IDI_MSA_PIC_HEIGHT);

--- a/engines/agi/preagi/winnie.cpp
+++ b/engines/agi/preagi/winnie.cpp
@@ -1526,6 +1526,7 @@ void WinnieEngine::init() {
 		_picture->setPictureVersion(AGIPIC_C64);
 		break;
 	default:
+		_picture->setPictureVersion(AGIPIC_PREAGI);
 		break;
 	}
 


### PR DESCRIPTION
This PR fixes picture inaccuracies and bugs in Winnie the Pooh and Mickey's Space Adventure:

- Circles not being drawn correctly
- Coordinates not being clipped
- Flood fills not being drawn
- Flood fills escaping due to the other bugs
- Frequent memory corruption
- https://bugs.scummvm.org/ticket/5730 (14 years old)
- https://bugs.scummvm.org/ticket/14549

Some of these bugs were TODOs in TrollVM (2004). Some were regressions from TrollVM being merged in 2007. Some were regressions from a 2016 refactor.

This is part of an ongoing effort to get our AGI picture code under control so that we can keep building on it. Right now it's tricky: some code is from Sarien, some code is from NAGI, some code is from TrollVM, some code has never executed and never will, much has been lost in translation, and none of this is documented. Only now that I have Curt Coder's thoroughly documented TrollVM source from 2004 do I understand our code, and even that was a challenge because TrollVM has been practically wiped from the internet.

Reverse engineering the executables was hard, but it was nothing compared to reverse engineering the 20+ years that led to `picture.cpp` =)

### Examples:

#### Missing flood fills in lower left, balloon circle pattern is wrong allowing flood fill to escape, balloon corrupts memory because it goes off screen, flood fills run wild through process memory.
![1a](https://github.com/user-attachments/assets/0429dc63-d0d8-4d75-853d-7ff11e7ed158)
![1b](https://github.com/user-attachments/assets/4984243d-db64-479b-bbcd-64c4d5d0e3e1)

#### Missing green flood fills due to inaccurate screen-on flag handling, the pink coat's circle pattern is wrong allowing flood fill to escape.
![2a](https://github.com/user-attachments/assets/2bee5e8c-fa6d-4d59-ae25-b4cc6946b107)
![2b](https://github.com/user-attachments/assets/2386aa8a-cc6d-4734-ab90-ec2696346140)

#### Water should have been blue, rain cloud circle patterns are wrong allowing flood fill to escape.
![3a](https://github.com/user-attachments/assets/6fa2c84e-0ff9-42df-a8df-3c34ceab7a68)
![3b](https://github.com/user-attachments/assets/b6d0b510-f092-4aa0-815c-7b7563db250a)

#### Spaceship lights are wrong shape, despite undocumented hacks (now removed)
![4a](https://github.com/user-attachments/assets/4dcd1a42-700f-4a81-ae60-dce14f8684fd)
![4b](https://github.com/user-attachments/assets/7b278d8b-75c5-43c0-af98-b76a8791ac07)

#### Planets and sun are wrong shape and not solid (there is no texture in PreAGI)
![5a](https://github.com/user-attachments/assets/2060e02b-352b-4721-b90f-607966889bea)
![5b](https://github.com/user-attachments/assets/f2e44f21-78ac-4ec4-a331-525ee9476412)
