### PR TITLE
GUI: Initialize PicButtonWidget _alphaType

### DIFF
--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -618,7 +618,7 @@ const Graphics::ManagedSurface *scaleGfx(const Graphics::ManagedSurface *gfx, in
 
 PicButtonWidget::PicButtonWidget(GuiObject *boss, int x, int y, int w, int h, bool scale, const Common::U32String &tooltip, uint32 cmd, uint8 hotkey)
 	: ButtonWidget(boss, x, y, w, h, scale, Common::U32String(), tooltip, cmd, hotkey),
-	  _showButton(true) {
+	  _showButton(true), _alphaType({Graphics::ALPHA_OPAQUE}) {
 
 	setFlags(WIDGET_ENABLED/* | WIDGET_BORDER*/ | WIDGET_CLEARBG);
 	_type = kButtonWidget;
@@ -630,7 +630,7 @@ PicButtonWidget::PicButtonWidget(GuiObject *boss, int x, int y, int w, int h, co
 
 PicButtonWidget::PicButtonWidget(GuiObject *boss, const Common::String &name, const Common::U32String &tooltip, uint32 cmd, uint8 hotkey)
 	: ButtonWidget(boss, name, Common::U32String(), tooltip, cmd, hotkey),
-	  _showButton(true) {
+	  _showButton(true), _alphaType({Graphics::ALPHA_OPAQUE}) {
 	setFlags(WIDGET_ENABLED/* | WIDGET_BORDER*/ | WIDGET_CLEARBG);
 	_type = kButtonWidget;
 }


### PR DESCRIPTION
Uninitialized `PicButtonWidget._alphaType[]` was read. Reproduce by hovering over the 'X' button beside the search bar when ScummVM starts, or some savegame thumbs. (Consider `--enable-ubsan`)
Don't know what an appropriate initial value would be (for any or all of the four); mimicking `GraphicsWidget`...

@ccawley2011 ok?

```
gui/widget.cpp:712:13: runtime error: load of value 3200171710, which is not a valid value for type 'AlphaType'
gui/widget.cpp:715:13: runtime error: load of value 3200171710, which is not a valid value for type 'AlphaType'
gui/widget.cpp:718:13: runtime error: load of value 3200171710, which is not a valid value for type 'AlphaType'

    (gdb) print _alphaType
    $4 = {Graphics::ALPHA_FULL, (Graphics::ALPHA_FULL | unknown: 0xbebebebc), (Graphics::ALPHA_FULL | unknown: 0xbebebebc), 
    (Graphics::ALPHA_FULL | unknown: 0xbebebebc)}
```

(Honourable mention PVS-Studio V730; however, that's not how I identified this.)