### PR TITLE
GRAPHICS: Handle seek-only case in TTFLibrary readCallback

### DIFF
--- a/common/stream.cpp
+++ b/common/stream.cpp
@@ -111,6 +111,9 @@ Common::String ReadStream::readPascalString(bool transformCR) {
 }
 
 uint32 MemoryReadStream::read(void *dataPtr, uint32 dataSize) {
+	if(dataPtr == nullptr)
+		return 0;
+
 	// Read at most as many bytes as are still available...
 	if (dataSize > _size - _pos) {
 		dataSize = _size - _pos;

--- a/graphics/fonts/ttf.cpp
+++ b/graphics/fonts/ttf.cpp
@@ -149,7 +149,10 @@ void TTFLibrary::closeFont(FT_Face &face) {
 
 unsigned long TTFLibrary::readCallback(FT_Stream stream, unsigned long offset, unsigned char *buffer, unsigned long count) {
 	Common::SeekableReadStream *ttfFile = (Common::SeekableReadStream *)stream->descriptor.pointer;
-	ttfFile->seek(offset);
+	bool seekSuccess = ttfFile->seek(offset);
+	if (count == 0)
+		// a seek operation was requested: return zero if success else non-zero
+		return !seekSuccess;
 	return ttfFile->read(buffer, count);
 }
 


### PR DESCRIPTION
The [FreeType API Reference](https://freetype.org/freetype2/docs/reference/ft2-system_interface.html#ft_stream_iofunc) explains that a FT_Stream_IoFunc such as our `TTFLibrary::readCallback` should simply perform a seek if `count` is 0 and return a status.

In that case, `buffer` can be nullptr; previously, that was passed to a stream's read(), which in turn gave it to memcpy(). Some argue that memcpy(null, ..., 0) is acceptable, but it's undeniably undefined behaviour.

This PR includes a commit which checks nullptr in `MemoryReadStream::read`. I guess that ought never to be the case, so it may be dropped, but it has happened:

```
common/stream.cpp:119:8: runtime error: null pointer passed as argument 1, which is declared to never be null

#0  Common::MemoryReadStream::read (this=0x60700002dac0, dataPtr=0x0, dataSize=0) at common/stream.cpp:113
#1  0x0000555559c3d3c2 in Common::File::read (this=<optimized out>, ptr=0x0, len=0) at common/file.cpp:142
#2  0x00005555595abfa9 in Graphics::TTFLibrary::readCallback (stream=<optimized out>, offset=<optimized out>, buffer=0x0, count=0)
    at graphics/fonts/ttf.cpp:153
#3  0x00007ffff7570ccb in ?? () from /lib/x86_64-linux-gnu/libfreetype.so.6
[...]
#8  0x00005555595af6ab in Graphics::TTFLibrary::loadFont (this=this@entry=0x603000018070, ttfFile=<optimized out>, 
    stream=stream@entry=0x61800000bc90, face_index=face_index@entry=0, face=@0x61800000bce0: 0x0) at graphics/fonts/ttf.cpp:141
```

...sheesh, I'm switching to plain `-O0`...