### PR TITLE
SCI: (SQ4/CD/Windows) - make use of windows gfx drivers

### DIFF
--- a/engines/sci/detection_internal.cpp
+++ b/engines/sci/detection_internal.cpp
@@ -130,11 +130,15 @@ Common::String customizeGuiOptions(Common::Path gamePath, Common::String guiOpti
 		{ SCI_VERSION_01,		SCI_VERSION_01,				"9801VID.DRV",		GUIO_RENDERPC98_16C },
 		{ SCI_VERSION_1_LATE,	SCI_VERSION_1_LATE,			"9801V8.DRV",		GUIO_RENDERPC98_8C },
 		{ SCI_VERSION_01,		SCI_VERSION_01,				"9801V8M.DRV",		GUIO_RENDERPC98_8C },
-		{ SCI_VERSION_01,		SCI_VERSION_01,				"9801VID.DRV",		GUIO_RENDERPC98_8C }
+		{ SCI_VERSION_01,		SCI_VERSION_01,				"9801VID.DRV",		GUIO_RENDERPC98_8C },
+		{ SCI_VERSION_1_1,		SCI_VERSION_1_1,			"SCIWV.EXE",		GUIO_RENDERWIN_16C }
 	};
 
-	if (idStr.equals("kq6") && platform == Common::kPlatformWindows)
-		return guiOptions + GUIO_RENDERWIN_256C + GUIO_RENDERWIN_16C;
+	bool isWindows = false;
+	if ((idStr.equals("kq6") || idStr.equals("sq4")) && platform == Common::kPlatformWindows) {
+		guiOptions += GUIO_RENDERWIN_256C;
+		isWindows = true;
+	}
 
 	Common::FSNode node(gamePath);
 	Common::FSList files;
@@ -147,7 +151,10 @@ Common::String customizeGuiOptions(Common::Path gamePath, Common::String guiOpti
 		for (int ii = 0; ii < ARRAYSIZE(rmodes); ii++) {
 			if (version == SCI_VERSION_NONE || (rmodes[ii].min <= version && version <= rmodes[ii].max)) {
 				if (i->getFileName().equalsIgnoreCase(rmodes[ii].gfxDriverName)) {
-					guiOptions += rmodes[ii].guio;
+					// Make sure that the Windows 16 colors mode is only ever added to the above mentioned
+					// windows versions and the other modes only get added to the other versions.
+					if (isWindows != (strncmp(rmodes[ii].guio, GUIO_RENDERWIN_16C, 1) != 0))
+						guiOptions += rmodes[ii].guio;
 				}
 			}
 		}

--- a/engines/sci/graphics/gfxdrivers.h
+++ b/engines/sci/graphics/gfxdrivers.h
@@ -235,13 +235,13 @@ protected:
 	uint16 _vScaleMult, _vScaleDiv;
 	const byte *_egaMatchTable;
 	byte *_egaColorPatterns;
+	uint8 _colAdjust;
 	byte *_compositeBuffer;
 	byte *_currentPalette;
 private:
 	virtual void loadData();
 	virtual void renderBitmap(byte *dst, const byte *src, int pitch, int y, int w, int h, const byte *patterns, const byte *palette, uint16 &realWidth, uint16 &realHeight);
 	byte *_currentBitmap;
-	uint8 _colAdjust;
 	const byte *_internalPalette;
 	const bool _requestRGBMode;
 	static const char *_driverFile;
@@ -283,10 +283,10 @@ private:
 	bool _needCursorBuffer;
 };
 
-class KQ6WinGfxDriver final : public UpscaledGfxDriver {
+class WindowsGfx256ColorsDriver final : public UpscaledGfxDriver {
 public:
-	KQ6WinGfxDriver(bool dosStyleCursors, bool smallWindow, bool rgbRendering);
-	~KQ6WinGfxDriver() override {}
+	WindowsGfx256ColorsDriver(bool coloredDosStyleCursors, bool smallWindow, bool rgbRendering);
+	~WindowsGfx256ColorsDriver() override {}
 	void initScreen(const Graphics::PixelFormat *format) override;
 	void copyRectToScreen(const byte *src, int srcX, int srcY, int pitch, int destX, int destY, int w, int h, const PaletteMod *palMods, const byte *palModMapping) override;
 	void replaceCursor(const void *cursor, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor) override;
@@ -309,22 +309,22 @@ private:
 	uint16 _vScaleMult2;
 };
 
-class KQ6WinGfx16ColorsDriver final : public SCI1_EGADriver {
+class WindowsGfx16ColorsDriver final : public SCI1_EGADriver {
 public:
 	// The original does not take into account the extra lines required for the 200->440 vertical scaling. There is a noticeable dithering glitch every 11th line, as the
 	// two pixels of the checkerbox pattern appear in the wrong order. I have implemented a fix for this which can be activated with the fixDithering parameter.
-	KQ6WinGfx16ColorsDriver(bool fixDithering, bool rgbRendering);
-	~KQ6WinGfx16ColorsDriver() override;
+	WindowsGfx16ColorsDriver(bool fixDithering, bool rgbRendering);
+	~WindowsGfx16ColorsDriver() override {}
 	void initScreen(const Graphics::PixelFormat *format) override;
 	void replaceCursor(const void *cursor, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor) override;
 	Common::Point getRealCoords(Common::Point &pos) const override;
-	static bool validateMode(Common::Platform p) { return (p == Common::kPlatformDOS || p == Common::kPlatformWindows); }
+	static bool validateMode(Common::Platform p) { return (p == Common::kPlatformWindows && checkDriver(&_driverFile, 1)); }
 private:
 	void loadData() override;
 	void renderBitmap(byte *dst, const byte *src, int pitch, int y, int w, int h, const byte *patterns, const byte *palette, uint16 &realWidth, uint16 &realHeight) override;
 	LineProc _renderLine2;
 	const bool _enhancedDithering;
-	static const byte _win16ColorsDitherPatterns[512];
+	static const char *_driverFile;
 };
 
 class PC98Gfx16ColorsDriver final : public UpscaledGfxDriver {

--- a/engines/sci/graphics/maciconbar.cpp
+++ b/engines/sci/graphics/maciconbar.cpp
@@ -44,7 +44,7 @@ GfxMacIconBar::GfxMacIconBar(ResourceManager *resMan, EventManager *eventMan, Se
 
 	_inventoryIcon = nullptr;
 	_allDisabled = true;
-	
+
 	_isUpscaled = (_screen->getUpscaledHires() == GFX_SCREEN_UPSCALED_640x400);
 }
 

--- a/engines/sci/graphics/paint16.cpp
+++ b/engines/sci/graphics/paint16.cpp
@@ -323,7 +323,7 @@ void GfxPaint16::bitsShow(const Common::Rect &rect) {
 
 	// WORKAROUND, see comment above. Normally, the call to _ports->offsetRect(workerRect) would be unconditional here.
 	if (!triggeredWorkaround)
-		_ports->offsetRect(workerRect);	
+		_ports->offsetRect(workerRect);
 
 	// We adjust the left/right coordinates to even coordinates
 	workerRect.left &= 0xFFFE; // round down

--- a/engines/sci/graphics/picture.cpp
+++ b/engines/sci/graphics/picture.cpp
@@ -47,7 +47,7 @@ GfxPicture::GfxPicture(ResourceManager *resMan, GfxCoordAdjuster16 *coordAdjuste
 	_EGApaletteNo(0),
 	_priority(0),
 	_EGAdrawingVisualize(EGAdrawingVisualize) {
-	
+
 	assert(resourceId != -1);
 	initData(resourceId);
 }

--- a/engines/sci/graphics/screen.cpp
+++ b/engines/sci/graphics/screen.cpp
@@ -128,7 +128,7 @@ GfxScreen::GfxScreen(ResourceManager *resMan, Common::RenderMode renderMode) : _
 		// We add 2 to the height of the icon bar to add a buffer between the screen and the
 		// icon bar (as did the original interpreter).
 		switch (g_sci->getGameId()) {
-		case GID_KQ6: 
+		case GID_KQ6:
 			extraHeight = 26 + 2;
 			break;
 		case GID_FREDDYPHARKAS:
@@ -166,7 +166,7 @@ GfxScreen::GfxScreen(ResourceManager *resMan, Common::RenderMode renderMode) : _
 		_gfxDrv = new SCI1_VGAGreyScaleDriver(requestRGB);
 		break;
 	case Common::kRenderWin16c:
-		_gfxDrv = new KQ6WinGfx16ColorsDriver(true, requestRGB);
+		_gfxDrv = new WindowsGfx16ColorsDriver(true, requestRGB);
 		break;
 	case Common::kRenderPC98_8c:
 		if (g_sci->getGameId() == GID_PQ2)
@@ -203,12 +203,13 @@ GfxScreen::GfxScreen(ResourceManager *resMan, Common::RenderMode renderMode) : _
 		case Common::kPlatformWindows:
 		case Common::kPlatformDOS:
 			// King's Quest 6 has hires content in the Windows version which we also allow to be optionally enabled in the DOS version
-			// and which we also optionally allow to be disabled in the Windows version (the Windows version has support in the original
-			// interpreter code for a small 320 x 240 window on desktops with resolutions of less than 640 x 480, but I haven't managed
-			// to produce it in a Win95 VM; the windows setting don't seem to allow less than 640 x 480, so I don't know if it is actually
-			// possible to set it up).
-			if (g_sci->getGameId() == GID_KQ6 && (g_sci->getPlatform() == Common::kPlatformWindows || g_sci->useHiresGraphics())) {
-				_gfxDrv = new KQ6WinGfxDriver(ConfMan.getBool("windows_cursors") == false, !g_sci->useHiresGraphics(), requestRGB);
+			// and which we also optionally allow to be disabled in the Windows version. Also, the Windows versions of King's Quest 6
+			// and Space Quest 4 have support in the original interpreter code for a small 320 x 240 window on desktops with resolutions
+			// of less than 640 x 480, but I haven't managed to produce it in a Win95 VM; the windows setting don't seem to allow less
+			// than 640 x 480, so I don't know if it is actually possible to set it up. Anyway, we can use it here, for the configs that
+			// do not require hires support.
+			if ((g_sci->getGameId() == GID_KQ6 || g_sci->getGameId() == GID_SQ4) && (g_sci->getPlatform() == Common::kPlatformWindows || g_sci->useHiresGraphics())) {
+				_gfxDrv = new WindowsGfx256ColorsDriver(!ConfMan.getBool("windows_cursors"), !g_sci->useHiresGraphics(), requestRGB);
 				break;
 			}
 			// fallthrough
@@ -233,7 +234,7 @@ GfxScreen::GfxScreen(ResourceManager *resMan, Common::RenderMode renderMode) : _
 	_priorityScreen = (byte *)calloc(_pixels, 1);
 	_controlScreen = (byte *)calloc(_pixels, 1);
 	_displayScreen = (byte *)calloc(_displayPixels, 1);
-	
+
 	// Create a Surface for _displayPixels so that we can draw to it from interfaces
 	// that only draw to Surfaces. Currently that's just Graphics::Font.
 	Graphics::PixelFormat format8 = Graphics::PixelFormat::createFormatCLUT8();
@@ -982,7 +983,7 @@ void GfxScreen::grabPalette(byte *buffer, uint start, uint num) const {
 
 void GfxScreen::setPalette(const byte *buffer, uint start, uint num, bool update) {
 	assert(start + num <= 256);
-	_gfxDrv->setPalette(buffer, start, num, update, _paletteModsEnabled ? _paletteMods : nullptr, _paletteMapScreen);	
+	_gfxDrv->setPalette(buffer, start, num, update, _paletteModsEnabled ? _paletteMods : nullptr, _paletteMapScreen);
 }
 
 

--- a/engines/sci/graphics/text16.cpp
+++ b/engines/sci/graphics/text16.cpp
@@ -838,7 +838,7 @@ void GfxText16::macTextSize(const Common::String &text, GuiResourceId sciFontId,
 	// Default max width is 193, otherwise increment the specified max
 	maxWidth = (maxWidth == 0) ? 193 : (maxWidth + 1);
 
-	// Build lists of lines and widths and calculate the largest line width. 
+	// Build lists of lines and widths and calculate the largest line width.
 	// The Mac interpreter did this by creating a hidden TEdit, settings its width
 	// and text, and then querying TEdit's internal structures to count the lines
 	// and find the largest. This means that Mac's own text wrapping algorithm
@@ -889,7 +889,7 @@ void GfxText16::macTextSize(const Common::String &text, GuiResourceId sciFontId,
 	// Leading can be zero for fonts that have spacing embedded in their glyphs.
 	*textHeight = lineCount * (font->getFontHeight() + font->getFontLeading());
 
-	if (_macFontManager->usesSystemFonts() && 
+	if (_macFontManager->usesSystemFonts() &&
 		_screen->getUpscaledHires() == GFX_SCREEN_UPSCALED_640x400) {
 		// QFG1VGA and LSL6 make this adjustment when the large font is used.
 		*textHeight -= (lineCount + 1);

--- a/engines/sci/graphics/video32.h
+++ b/engines/sci/graphics/video32.h
@@ -170,7 +170,7 @@ protected:
 
 	/**
 	 * Sets the subtitle position according to the draw rect and overlay size.
-	 * 
+	 *
 	 */
 	void setSubtitlePosition() const;
 

--- a/engines/sci/sci.cpp
+++ b/engines/sci/sci.cpp
@@ -336,7 +336,7 @@ Common::Error SciEngine::run() {
 			((renderMode == Common::kRenderHercA || renderMode == Common::kRenderHercG) && !SCI0_HerculesDriver::validateMode(p)) ||
 			(renderMode == Common::kRenderPC98_8c && ((getSciVersion() <= SCI_VERSION_01 && !SCI0_PC98Gfx8ColorsDriver::validateMode(p)) ||
 			(getSciVersion() > SCI_VERSION_01 && !SCI1_PC98Gfx8ColorsDriver::validateMode(p)))) ||
-			(getSciVersion() > SCI_VERSION_1_LATE && !KQ6WinGfx16ColorsDriver::validateMode(p)) ||
+			(renderMode == Common::kRenderWin16c && getSciVersion() >= SCI_VERSION_1_1 && !WindowsGfx16ColorsDriver::validateMode(p)) ||
 			(renderMode == Common::kRenderPC98_16c && undither) ||
 			(getLanguage() == Common::KO_KOR)) // No extra modes supported for the Korean fan-patched games
 				renderMode = Common::kRenderDefault;


### PR DESCRIPTION
SQ4/CD/Windows uses a similar interpreter to the KQ6 one, minus the hires graphics support. It has the same upscaling to 640x440 (or 320x220 for small windows) and also supports the same 16 colors mode.

I have attached the SQ4 Windows version to the gfx drivers I made for KQ6. The 16 colors mode now requires the SCIWV.EXE executable, though. I had hard coded the 512 bytes color pattern table for KQ6, since I thought it would remain the only one necessary. But SQ4 has a different table. So I now load them from the executable.

There might be more Windows games like that, I just currently don't know about it (probably other SCI_VERSION_1_1 titles). Adding support would be super easy. But it will not work right out of the box, since I explicitly check the game IDs in customizeGuiOptions(), to avoid any nonsense to happen.

