### PR TITLE
PSP: Fix PNG loading and improve it

### DIFF
--- a/backends/platform/psp/png_loader.cpp
+++ b/backends/platform/psp/png_loader.cpp
@@ -33,6 +33,13 @@
 
 #include "backends/platform/psp/trace.h"
 
+PngLoader::~PngLoader() {
+	if (!_pngPtr) {
+		return;
+	}
+	png_destroy_read_struct(&_pngPtr, &_infoPtr, nullptr);
+}
+
 PngLoader::Status PngLoader::allocate() {
 	DEBUG_ENTER_FUNC();
 
@@ -76,9 +83,8 @@ PngLoader::Status PngLoader::allocate() {
 
 bool PngLoader::load() {
 	DEBUG_ENTER_FUNC();
-	// Try to load the image
-	_file.seek(0);	// Go back to start
 
+	// Try to really load the image
 	if (!loadImageIntoBuffer()) {
 		PSP_DEBUG_PRINT("failed to load image\n");
 		return false;
@@ -121,15 +127,11 @@ bool PngLoader::basicImageLoad() {
 
 	_infoPtr = png_create_info_struct(_pngPtr);
 	if (!_infoPtr) {
-		png_destroy_read_struct(&_pngPtr, nullptr, nullptr);
 		return false;
 	}
 	// Set the png lib to use our read function
 	png_set_read_fn(_pngPtr, &_file, libReadFunc);
 
-	unsigned int sig_read = 0;
-
-	png_set_sig_bytes(_pngPtr, sig_read);
 	png_read_info(_pngPtr, _infoPtr);
 	int interlaceType;
 	png_get_IHDR(_pngPtr, _infoPtr, (png_uint_32 *)&_width, (png_uint_32 *)&_height, &_bitDepth,
@@ -154,7 +156,6 @@ bool PngLoader::findImageDimensions() {
 	bool status = basicImageLoad();
 
 	PSP_DEBUG_PRINT("width[%d], height[%d], paletteSize[%d], bitDepth[%d], channels[%d], rowBytes[%d]\n", _width, _height, _paletteSize, _bitDepth, _channels, png_get_rowbytes(_pngPtr, _infoPtr));
-	png_destroy_read_struct(&_pngPtr, &_infoPtr, nullptr);
 	return status;
 }
 
@@ -164,10 +165,9 @@ bool PngLoader::findImageDimensions() {
 bool PngLoader::loadImageIntoBuffer() {
 	DEBUG_ENTER_FUNC();
 
-	if (!basicImageLoad()) {
-		png_destroy_read_struct(&_pngPtr, &_infoPtr, nullptr);
-		return false;
-	}
+	// Everything has already been set up in allocate
+	assert(_pngPtr);
+
 	png_set_strip_16(_pngPtr);		// Strip off 16 bit channels in case they occur
 
 	if (_paletteSize) {
@@ -206,7 +206,6 @@ bool PngLoader::loadImageIntoBuffer() {
 
 	unsigned char *line = (unsigned char*) malloc(rowBytes);
 	if (!line) {
-		png_destroy_read_struct(&_pngPtr, nullptr, nullptr);
 		PSP_ERROR("Couldn't allocate line\n");
 		return false;
 	}
@@ -217,7 +216,6 @@ bool PngLoader::loadImageIntoBuffer() {
 	}
 	free(line);
 	png_read_end(_pngPtr, _infoPtr);
-	png_destroy_read_struct(&_pngPtr, &_infoPtr, nullptr);
 
 	return true;
 }

--- a/backends/platform/psp/png_loader.cpp
+++ b/backends/platform/psp/png_loader.cpp
@@ -129,8 +129,10 @@ bool PngLoader::basicImageLoad() {
 	_channels = png_get_channels(_pngPtr, _infoPtr);
 
 	if (_colorType & PNG_COLOR_MASK_PALETTE) {
-		int paletteSize;
-		png_get_PLTE(_pngPtr, _infoPtr, nullptr, &paletteSize);
+		int paletteSize = 0;
+		png_colorp palettePtr = nullptr;
+		png_uint_32 ret = png_get_PLTE(_pngPtr, _infoPtr, &palettePtr, &paletteSize);
+		assert(ret == PNG_INFO_PLTE);
 		_paletteSize = paletteSize;
 	}
 

--- a/backends/platform/psp/png_loader.cpp
+++ b/backends/platform/psp/png_loader.cpp
@@ -93,6 +93,13 @@ bool PngLoader::load() {
 
 void PngLoader::warningFn(png_structp png_ptr, png_const_charp warning_msg) {
 	// ignore PNG warnings
+	PSP_ERROR("Got PNG warning: %s\n", warning_msg);
+}
+
+void PngLoader::errorFn(png_structp png_ptr, png_const_charp error_msg) {
+	// ignore PNG warnings
+	PSP_ERROR("Got PNG error: %s\n", error_msg);
+	abort();
 }
 
 // Read function for png library to be able to read from our SeekableReadStream
@@ -100,7 +107,8 @@ void PngLoader::warningFn(png_structp png_ptr, png_const_charp warning_msg) {
 void PngLoader::libReadFunc(png_structp pngPtr, png_bytep data, png_size_t length) {
 	Common::SeekableReadStream &file = *(Common::SeekableReadStream *)png_get_io_ptr(pngPtr);
 
-	file.read(data, length);
+	uint32 ret = file.read(data, length);
+	assert(ret == length);
 }
 
 bool PngLoader::basicImageLoad() {
@@ -109,7 +117,7 @@ bool PngLoader::basicImageLoad() {
 	if (!_pngPtr)
 		return false;
 
-	png_set_error_fn(_pngPtr, (png_voidp) nullptr, (png_error_ptr) nullptr, warningFn);
+	png_set_error_fn(_pngPtr, (png_voidp) nullptr, (png_error_ptr) errorFn, warningFn);
 
 	_infoPtr = png_create_info_struct(_pngPtr);
 	if (!_infoPtr) {

--- a/backends/platform/psp/png_loader.h
+++ b/backends/platform/psp/png_loader.h
@@ -63,6 +63,7 @@ public:
 			_width(0), _height(0), _paletteSize(0),
 			_bitDepth(0), _sizeBy(sizeBy), _pngPtr(0),
 			_infoPtr(0), _colorType(0), _channels(0) {}
+	~PngLoader();
 
 	PngLoader::Status allocate();
 	bool load();

--- a/backends/platform/psp/png_loader.h
+++ b/backends/platform/psp/png_loader.h
@@ -31,6 +31,7 @@ private:
 	bool loadImageIntoBuffer();
 
 	static void warningFn(png_structp png_ptr, png_const_charp warning_msg);
+	static void errorFn(png_structp png_ptr, png_const_charp warning_msg);
 	static void libReadFunc(png_structp pngPtr, png_bytep data, png_size_t length);
 
 	Common::SeekableReadStream &_file;

--- a/configure
+++ b/configure
@@ -3377,7 +3377,7 @@ EOF
 		add_line_to_config_h "#define PREFIX \"${prefix}\""
 		;;
 	psp)
-		_optimization_level=-O1
+		_optimization_level=-O2
 		_freetypepath="$PSPDEV/psp/bin"
 		append_var CXXFLAGS "-I$PSPSDK/include"
 		# FIXME: Why is the following in CXXFLAGS and not in DEFINES? Change or document this.


### PR DESCRIPTION
This PR allows to revert back the -O1 flag switch.

It also improves the decoding by avoiding rewinding the stream.