### PR TITLE
Disable load button in Launcher when no savegame is available for the selected game

### DIFF
--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -1369,8 +1369,29 @@ void LauncherSimple::updateButtons() {
 	int item = _list->getSelected();
 	bool en = enable;
 
-	if (item >= 0)
+	if (item >= 0) {
+		// Check load from launcher is supported
 		en = !(Common::checkGameGUIOption(GUIO_NOLAUNCHLOAD, ConfMan.get("guioptions", _domains[item])));
+		// Check savegames are available
+		if (en) {
+			Common::String target = _domains[item];
+			target.toLowercase();
+			EngineMan.upgradeTargetIfNecessary(target);
+			QualifiedGameDescriptor game = EngineMan.findTarget(target);
+#if defined(UNCACHED_PLUGINS) && defined(DYNAMIC_MODULES) && !defined(DETECTION_STATIC)
+			// Unload all MetaEnginesDetection if we're using uncached plugins to save extra memory.
+			PluginMan.unloadDetectionPlugin();
+#endif
+			const Plugin *enginePlugin = PluginMan.findEnginePlugin(game.engineId);
+			if (enginePlugin) {
+				const MetaEngine &metaEngine = enginePlugin->get<MetaEngine>();
+				if (metaEngine.hasFeature(MetaEngine::kSupportsListSaves)) {
+					SaveStateList saveList = metaEngine.listSaves(target.c_str());
+					en = !saveList.empty();
+				}
+			}
+		}
+	}
 
 	_loadButton->setEnabled(en);
 }

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -1679,7 +1679,7 @@ void LauncherGrid::build() {
 	_gridItemSizeLabel->setValue(ConfMan.getInt("grid_items_per_row"));
 
 	// Add list with game titles
-	_grid = new GridWidget(this, "LauncherGrid.IconArea");
+	_grid = new GridWidget(this, "LauncherGrid.IconArea", this);
 	// Populate the list
 	updateListing();
 

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -446,6 +446,30 @@ Common::String LauncherDialog::getGameConfig(int item, Common::String key) {
 	return "";
 }
 
+bool LauncherDialog::canLoadSavegames(int item) const {
+	// Check load from launcher is supported
+	if (Common::checkGameGUIOption(GUIO_NOLAUNCHLOAD, ConfMan.get("guioptions", _domains[item])))
+		return false;
+
+	// Check savegames are available
+	Common::String target = _domains[item];
+	target.toLowercase();
+	EngineMan.upgradeTargetIfNecessary(target);
+	QualifiedGameDescriptor game = EngineMan.findTarget(target);
+#if defined(UNCACHED_PLUGINS) && defined(DYNAMIC_MODULES) && !defined(DETECTION_STATIC)
+	// Unload all MetaEnginesDetection if we're using uncached plugins to save extra memory.
+	PluginMan.unloadDetectionPlugin();
+#endif
+	const Plugin *enginePlugin = PluginMan.findEnginePlugin(game.engineId);
+	if (!enginePlugin)
+		return false;
+	const MetaEngine &metaEngine = enginePlugin->get<MetaEngine>();
+	if (!metaEngine.hasFeature(MetaEngine::kSupportsListSaves))
+		return false;
+	SaveStateList saveList = metaEngine.listSaves(target.c_str());
+	return !saveList.empty();
+}
+
 void LauncherDialog::removeGame(int item) {
 	MessageDialog alert(_("Do you really want to remove this game configuration?"), _("Yes"), _("No"));
 
@@ -1369,29 +1393,8 @@ void LauncherSimple::updateButtons() {
 	int item = _list->getSelected();
 	bool en = enable;
 
-	if (item >= 0) {
-		// Check load from launcher is supported
-		en = !(Common::checkGameGUIOption(GUIO_NOLAUNCHLOAD, ConfMan.get("guioptions", _domains[item])));
-		// Check savegames are available
-		if (en) {
-			Common::String target = _domains[item];
-			target.toLowercase();
-			EngineMan.upgradeTargetIfNecessary(target);
-			QualifiedGameDescriptor game = EngineMan.findTarget(target);
-#if defined(UNCACHED_PLUGINS) && defined(DYNAMIC_MODULES) && !defined(DETECTION_STATIC)
-			// Unload all MetaEnginesDetection if we're using uncached plugins to save extra memory.
-			PluginMan.unloadDetectionPlugin();
-#endif
-			const Plugin *enginePlugin = PluginMan.findEnginePlugin(game.engineId);
-			if (enginePlugin) {
-				const MetaEngine &metaEngine = enginePlugin->get<MetaEngine>();
-				if (metaEngine.hasFeature(MetaEngine::kSupportsListSaves)) {
-					SaveStateList saveList = metaEngine.listSaves(target.c_str());
-					en = !saveList.empty();
-				}
-			}
-		}
-	}
+	if (item >= 0)
+		en = canLoadSavegames(item);
 
 	_loadButton->setEnabled(en);
 }

--- a/gui/launcher.h
+++ b/gui/launcher.h
@@ -122,6 +122,7 @@ public:
 	void handleOtherEvent(const Common::Event &evt) override;
 	bool doGameDetection(const Common::Path &path);
 	Common::String getGameConfig(int item, Common::String key);
+	bool canLoadSavegames(int item) const;
 protected:
 	EditTextWidget  *_searchWidget;
 #ifndef DISABLE_FANCY_THEMES

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -28,6 +28,7 @@
 
 #include "gui/gui-manager.h"
 #include "gui/widgets/grid.h"
+#include "gui/launcher.h"
 
 #include "gui/ThemeEval.h"
 
@@ -264,7 +265,7 @@ void GridItemWidget::handleMouseDown(int x, int y, int button, int clickCount) {
 
 #pragma mark -
 
-GridItemTray::GridItemTray(GuiObject *boss, int x, int y, int w, int h, int entryID, GridWidget *grid)
+GridItemTray::GridItemTray(GuiObject *boss, int x, int y, int w, int h, int entryID, GridWidget *grid, LauncherDialog *launcher)
 	: Dialog(x, y, w, h), CommandSender(boss) {
 
 	_entryID = entryID;
@@ -286,6 +287,8 @@ GridItemTray::GridItemTray(GuiObject *boss, int x, int y, int w, int h, int entr
 	_loadButton = new PicButtonWidget(this, trayPaddingX, trayPaddingY + buttonHeight + buttonSpacingY,
 									  buttonWidth, buttonHeight,
 									  _("Saves"), kLoadButtonCmd);
+	if (launcher)
+		_loadButton->setEnabled(launcher->canLoadSavegames(entryID));
 	_editButton = new PicButtonWidget(this, trayPaddingX + buttonWidth + buttonSpacingX, trayPaddingY + buttonHeight + buttonSpacingY,
 									  buttonWidth, buttonHeight,
 									  _("Edit"), kEditButtonCmd);
@@ -400,9 +403,10 @@ Graphics::ManagedSurface *loadSurfaceFromFile(const Common::String &name, int re
 
 #pragma mark -
 
-GridWidget::GridWidget(GuiObject *boss, const Common::String &name)
+GridWidget::GridWidget(GuiObject *boss, const Common::String &name, LauncherDialog *launcher)
 	: ContainerWidget(boss, name), CommandSender(boss) {
 
+	_launcher = launcher;
 	_thumbnailHeight = 0;
 	_thumbnailWidth = 0;
 	_flagIconHeight = 0;
@@ -1115,7 +1119,7 @@ void GridWidget::reflowLayout() {
 void GridWidget::openTrayAtSelected() {
 	if (_selectedEntry) {
 		GridItemTray *tray = new GridItemTray(this, _x + _selectedEntry->x - _gridXSpacing / 3, _y + _selectedEntry->y + _selectedEntry->h - _scrollPos,
-								_gridItemWidth + 2 * (_gridXSpacing / 3), _trayHeight, _selectedEntry->entryID, this);
+											  _gridItemWidth + 2 * (_gridXSpacing / 3), _trayHeight, _selectedEntry->entryID, this, _launcher);
 		tray->runModal();
 		delete tray;
 	}

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -1112,12 +1112,6 @@ void GridWidget::reflowLayout() {
 	markAsDirty();
 }
 
-void GridWidget::openTray(int x, int y, int entryId) {
-	GridItemTray *tray = new GridItemTray(this, x - _gridXSpacing / 3, y, _gridItemWidth + 2 * (_gridXSpacing / 3), _trayHeight, entryId, this);
-	tray->runModal();
-	delete tray;
-}
-
 void GridWidget::openTrayAtSelected() {
 	if (_selectedEntry) {
 		GridItemTray *tray = new GridItemTray(this, _x + _selectedEntry->x - _gridXSpacing / 3, _y + _selectedEntry->y + _selectedEntry->h - _scrollPos,

--- a/gui/widgets/grid.h
+++ b/gui/widgets/grid.h
@@ -223,7 +223,6 @@ public:
 
 	bool wantsFocus() override { return true; }
 
-	void openTray(int x, int y, int entryID);
 	void openTrayAtSelected();
 	void scrollBarRecalc();
 

--- a/gui/widgets/grid.h
+++ b/gui/widgets/grid.h
@@ -35,6 +35,7 @@ namespace GUI {
 class ScrollBarWidget;
 class GridItemWidget;
 class GridWidget;
+class LauncherDialog;
 
 enum {
 	kPlayButtonCmd = 'PLAY',
@@ -84,7 +85,7 @@ class GridItemTray: public Dialog, public CommandSender {
 	PicButtonWidget	*_loadButton;
 	PicButtonWidget	*_editButton;
 public:
-	GridItemTray(GuiObject *boss, int x, int y, int w, int h, int entryID, GridWidget *grid);
+	GridItemTray(GuiObject *boss, int x, int y, int w, int h, int entryID, GridWidget *grid, LauncherDialog *launcher);
 
 	void reflowLayout() override;
 
@@ -126,6 +127,7 @@ protected:
 	Common::Array<GridItemWidget *>		_gridItems;
 
 	ScrollBarWidget *_scrollBar;
+	LauncherDialog *_launcher;
 
 	int				_scrollBarWidth;
 	int				_scrollWindowHeight;
@@ -169,7 +171,7 @@ public:
 
 	Common::U32String	_filter;
 
-	GridWidget(GuiObject *boss, const Common::String &name);
+	GridWidget(GuiObject *boss, const Common::String &name, LauncherDialog *launcher);
 	~GridWidget();
 
 	template<typename T>


### PR DESCRIPTION
In the List Launcher, the Load button was disabled for engines that do not support loading from the launcher, but was otherwise always enabled. With this pull request it is also disabled if no savegame exists for the selected game.

In the Grid Launcher, the Load button in the tray was always enabled. This pull requests adds the same check as for the List Launcher to only enable the Load button if supported by the engine and if savegames are available.