### PR TITLE
AUDIO: MT32: Force MT32 rebuild after configure is run

### DIFF
--- a/audio/softsynth/mt32/module.mk
+++ b/audio/softsynth/mt32/module.mk
@@ -32,3 +32,6 @@ MODULE_OBJS := \
 
 # Include common rules
 include $(srcdir)/rules.mk
+
+# Force rebuild when configuration changed
+$(MODULE_OBJS-$(MODULE)): %.o: config.mk


### PR DESCRIPTION
When configuration flags are changed (ASan enabling for example), force rebuild the MT32 objects.
They were not rebuild because not depending on config.h

I prefer to submit this as a PR because it's a bit hackish and if someone has a better idea, I take it.