### PR TITLE
GRAPHICS: Remove overrideColor from ManagedSurface::transBlitFrom

### DIFF
--- a/backends/platform/libretro/src/libretro-graphics-surface.cpp
+++ b/backends/platform/libretro/src/libretro-graphics-surface.cpp
@@ -132,7 +132,7 @@ void LibretroGraphics::realUpdateScreen(void) {
 
 	if (_cursorVisible && _cursor.w && _cursor.h) {
 		Common::Point topLeft(_cursorX - _cursorHotspotXScaled, _cursorY - _cursorHotspotYScaled);
-		_screen.transBlitFrom(_cursor, Common::Rect(_cursor.w, _cursor.h), Common::Rect(topLeft, topLeft + Common::Point(_cursorWidthScaled, _cursorHeightScaled)),  _cursorKeyColor, false, 0, 0xff, nullptr, false,  _cursorPaletteEnabled ? &_cursorPalette : &_gamePalette);
+		_screen.transBlitFrom(_cursor, Common::Rect(_cursor.w, _cursor.h), Common::Rect(topLeft, topLeft + Common::Point(_cursorWidthScaled, _cursorHeightScaled)),  _cursorKeyColor, false, 0xff, nullptr, false,  _cursorPaletteEnabled ? &_cursorPalette : &_gamePalette);
 	}
 	_screenUpdatePending = false;
 }

--- a/engines/hdb/gfx.cpp
+++ b/engines/hdb/gfx.cpp
@@ -1385,7 +1385,7 @@ int Picture::draw(int x, int y) {
 }
 
 int Picture::drawMasked(int x, int y, int alpha) {
-	g_hdb->_gfx->_globalSurface.transBlitFrom(_surface, Common::Point(x, y), 0xf81f, false, 0, alpha & 0xff);
+	g_hdb->_gfx->_globalSurface.transBlitFrom(_surface, Common::Point(x, y), 0xf81f, false, alpha & 0xff);
 
 	Common::Rect clip(_surface.getBounds());
 	clip.moveTo(x, y);
@@ -1447,7 +1447,7 @@ int Tile::draw(int x, int y) {
 }
 
 int Tile::drawMasked(int x, int y, int alpha) {
-	g_hdb->_gfx->_globalSurface.transBlitFrom(_surface, Common::Point(x, y), 0xf81f, false, 0, alpha & 0xff);
+	g_hdb->_gfx->_globalSurface.transBlitFrom(_surface, Common::Point(x, y), 0xf81f, false, alpha & 0xff);
 
 	Common::Rect clip(_surface.getBounds());
 	clip.moveTo(x, y);

--- a/engines/mtropolis/elements.cpp
+++ b/engines/mtropolis/elements.cpp
@@ -1304,7 +1304,7 @@ void ImageElement::render(Window *window) {
 			if (transColor == 0)
 				transColor = optimized->format.ARGBToColor(255, transColorRGB8.r, transColorRGB8.g, transColorRGB8.b);
 
-			window->getSurface()->transBlitFrom(*optimized, srcRect, destRect, transColor, false, 0, alpha);
+			window->getSurface()->transBlitFrom(*optimized, srcRect, destRect, transColor, false, alpha);
 		} else if (inkMode == VisualElementRenderProperties::kInkModeDefault || inkMode == VisualElementRenderProperties::kInkModeCopy) {
 			if (alpha != 255) {
 				warning("Alpha fade was applied to a default or copy image, this isn't supported yet");

--- a/engines/nancy/graphics.cpp
+++ b/engines/nancy/graphics.cpp
@@ -385,7 +385,7 @@ void GraphicsManager::rotateBlit(const Graphics::ManagedSurface &src, Graphics::
 void GraphicsManager::crossDissolve(const Graphics::ManagedSurface &from, const Graphics::ManagedSurface &to, byte alpha, const Common::Rect rect, Graphics::ManagedSurface &inResult) {
 	assert(from.getBounds() == to.getBounds());
 	inResult.blitFrom(from, rect, Common::Point());
-	inResult.transBlitFrom(to, rect, Common::Point(), (uint32)-1, false, 0, alpha);
+	inResult.transBlitFrom(to, rect, Common::Point(), (uint32)-1, false, alpha);
 }
 
 void GraphicsManager::debugDrawToScreen(const Graphics::ManagedSurface &surf) {

--- a/engines/sherlock/fonts.cpp
+++ b/engines/sherlock/fonts.cpp
@@ -318,7 +318,11 @@ void Fonts::writeString(BaseSurface *surface, const Common::String &str,
 
 		if (curChar < _charCount) {
 			ImageFrame &frame = (*_font)[curChar];
-			surface->SHtransBlitFrom(frame, Common::Point(charPos.x, charPos.y + _yOffsets[curChar]), false, overrideColor);
+			if (overrideColor) {
+				surface->SHoverrideBlitFrom(frame, Common::Point(charPos.x, charPos.y + _yOffsets[curChar]), overrideColor);
+			} else {
+				surface->SHtransBlitFrom(frame, Common::Point(charPos.x, charPos.y + _yOffsets[curChar]));
+			}
 			charPos.x += frame._frame.w + 1;
 		} else {
 			warning("Invalid character encountered - %d", (int)curChar);

--- a/engines/sherlock/scalpel/3do/scalpel_3do_screen.cpp
+++ b/engines/sherlock/scalpel/3do/scalpel_3do_screen.cpp
@@ -123,14 +123,14 @@ void Scalpel3DOScreen::SHfillRect(const Common::Rect &r, uint color) {
 }
 
 void Scalpel3DOScreen::SHtransBlitFrom(const ImageFrame &src, const Common::Point &pt,
-		bool flipped, int overrideColor, int scaleVal) {
-	ScalpelScreen::SHtransBlitFrom(src, pt, flipped, overrideColor,
+		bool flipped, int scaleVal) {
+	ScalpelScreen::SHtransBlitFrom(src, pt, flipped,
 		_vm->_isScreenDoubled ? scaleVal / 2 : scaleVal);
 }
 
 void Scalpel3DOScreen::SHtransBlitFrom(const Graphics::Surface &src, const Common::Point &pt,
-		bool flipped, int overrideColor, int scaleVal) {
-	ScalpelScreen::SHtransBlitFrom(src, pt, flipped, overrideColor,
+		bool flipped, int scaleVal) {
+	ScalpelScreen::SHtransBlitFrom(src, pt, flipped,
 		_vm->_isScreenDoubled ? scaleVal / 2 : scaleVal);
 }
 

--- a/engines/sherlock/scalpel/3do/scalpel_3do_screen.h
+++ b/engines/sherlock/scalpel/3do/scalpel_3do_screen.h
@@ -72,13 +72,13 @@ public:
 	 * Draws an image frame at a given position within this surface with transparency
 	 */
 	void SHtransBlitFrom(const ImageFrame &src, const Common::Point &pt,
-		bool flipped = false, int overrideColor = 0, int scaleVal = SCALE_THRESHOLD) override;
+		bool flipped = false, int scaleVal = SCALE_THRESHOLD) override;
 
 	/**
 	 * Draws an image frame at a given position within this surface with transparency
 	 */
 	void SHtransBlitFrom(const Graphics::Surface &src, const Common::Point &pt,
-		bool flipped = false, int overrideColor = 0, int scaleVal = SCALE_THRESHOLD) override;
+		bool flipped = false, int scaleVal = SCALE_THRESHOLD) override;
 
 	/**
 	 * Fill a given area of the surface with a given color

--- a/engines/sherlock/scalpel/scalpel.cpp
+++ b/engines/sherlock/scalpel/scalpel.cpp
@@ -650,9 +650,9 @@ bool ScalpelEngine::scrollCredits() {
 
 		// Write the text appropriate for the next frame
 		if (idx < 400)
-			_screen->SHtransBlitFrom(creditsImages[0], Common::Point(10, 200 - idx), false, 0);
+			_screen->SHtransBlitFrom(creditsImages[0], Common::Point(10, 200 - idx), false);
 		if (idx > 200)
-			_screen->SHtransBlitFrom(creditsImages[1], Common::Point(10, 400 - idx), false, 0);
+			_screen->SHtransBlitFrom(creditsImages[1], Common::Point(10, 400 - idx), false);
 
 		// Don't show credit text on the top and bottom ten rows of the screen
 		_screen->SHblitFrom(_screen->_backBuffer1, Common::Point(0, 0), Common::Rect(0, 0, _screen->width(), 10));

--- a/engines/sherlock/surface.cpp
+++ b/engines/sherlock/surface.cpp
@@ -55,19 +55,43 @@ void BaseSurface::writeFancyString(const Common::String &str, const Common::Poin
 }
 
 void BaseSurface::SHtransBlitFrom(const ImageFrame &src, const Common::Point &pt,
-		bool flipped, int overrideColor, int scaleVal) {
+		bool flipped, int scaleVal) {
 	Common::Point drawPt(pt.x + src.sDrawXOffset(scaleVal), pt.y + src.sDrawYOffset(scaleVal));
-	SHtransBlitFrom(src._frame, drawPt, flipped, overrideColor, scaleVal);
+	SHtransBlitFrom(src._frame, drawPt, flipped, scaleVal);
 }
 
 void BaseSurface::SHtransBlitFrom(const Graphics::Surface &src, const Common::Point &pt,
-		bool flipped, int overrideColor, int scaleVal) {
+		bool flipped, int scaleVal) {
 	Common::Rect srcRect(0, 0, src.w, src.h);
 	Common::Rect destRect(pt.x, pt.y, pt.x + src.w * SCALE_THRESHOLD / scaleVal,
 		pt.y + src.h * SCALE_THRESHOLD / scaleVal);
 
 	Graphics::Screen::transBlitFrom(src, srcRect, destRect, IS_3DO ? 0 : TRANSPARENCY,
-		flipped, overrideColor);
+		flipped);
+}
+
+void BaseSurface::SHoverrideBlitFrom(const ImageFrame &src, const Common::Point &pt,
+		int overrideColor) {
+	Common::Point drawPt(pt.x + src.sDrawXOffset(SCALE_THRESHOLD), pt.y + src.sDrawYOffset(SCALE_THRESHOLD));
+	SHoverrideBlitFrom(src._frame, drawPt, overrideColor);
+}
+
+void BaseSurface::SHoverrideBlitFrom(const Graphics::Surface &src, const Common::Point &pt,
+		int overrideColor) {
+	Common::Rect srcRect(0, 0, src.w, src.h);
+	Common::Rect destRect(pt.x, pt.y, pt.x + src.w, pt.y + src.h);
+	clip(srcRect, destRect);
+
+	const uint32 transColor = IS_3DO ? 0 : TRANSPARENCY;
+
+	for (uint y = 0; y < destRect.height(); y++) {
+		for (uint x = 0; x < destRect.width(); x++) {
+			const uint8 srcVal = src.getPixel(srcRect.left + x, srcRect.top + y);
+			if (srcVal == transColor)
+				continue;
+			setPixel(destRect.left + x, destRect.top + y, overrideColor);
+		}
+	}
 }
 
 void BaseSurface::SHbitmapBlitFrom(const byte *src, int widthSrc, int heightSrc, int pitchSrc, const Common::Point &pt,

--- a/engines/sherlock/surface.h
+++ b/engines/sherlock/surface.h
@@ -79,13 +79,25 @@ public:
 	 * Draws an image frame at a given position within this surface with transparency
 	 */
 	virtual void SHtransBlitFrom(const ImageFrame &src, const Common::Point &pt,
-		bool flipped = false, int overrideColor = 0, int scaleVal = SCALE_THRESHOLD);
+		bool flipped = false, int scaleVal = SCALE_THRESHOLD);
 
 	/**
 	 * Draws an image frame at a given position within this surface with transparency
 	 */
 	virtual void SHtransBlitFrom(const Graphics::Surface &src, const Common::Point &pt,
-		bool flipped = false, int overrideColor = 0, int scaleVal = SCALE_THRESHOLD);
+		bool flipped = false, int scaleVal = SCALE_THRESHOLD);
+
+	/**
+	 * Draws an image frame at a given position within this surface with transparency
+	 */
+	virtual void SHoverrideBlitFrom(const ImageFrame &src, const Common::Point &pt,
+		int overrideColor);
+
+	/**
+	 * Draws an image frame at a given position within this surface with transparency
+	 */
+	virtual void SHoverrideBlitFrom(const Graphics::Surface &src, const Common::Point &pt,
+		int overrideColor);
 
 	/**
 	 * Fill a given area of the surface with a given color

--- a/engines/sherlock/tattoo/tattoo_map.cpp
+++ b/engines/sherlock/tattoo/tattoo_map.cpp
@@ -405,7 +405,7 @@ void TattooMap::showCloseUp(int closeUpNum) {
 			screen._currentScroll.y + closeUp.y / 100 - picSize.y / 2);
 
 		restoreArea(oldBounds);
-		screen._backBuffer1.SHtransBlitFrom(pic[0], pt, false, 0, scaleVal);
+		screen._backBuffer1.SHtransBlitFrom(pic[0], pt, false, scaleVal);
 
 		screen.slamRect(oldBounds);
 		screen.slamArea(pt.x, pt.y, picSize.x, picSize.y);

--- a/engines/sherlock/tattoo/tattoo_scene.cpp
+++ b/engines/sherlock/tattoo/tattoo_scene.cpp
@@ -142,14 +142,14 @@ void TattooScene::drawAllShapes() {
 			if (obj._quickDraw && obj._scaleVal == SCALE_THRESHOLD)
 				screen._backBuffer1.SHblitFrom(*obj._imageFrame, obj._position);
 			else
-				screen._backBuffer1.SHtransBlitFrom(*obj._imageFrame, obj._position, obj._flags & OBJ_FLIPPED, 0, obj._scaleVal);
+				screen._backBuffer1.SHtransBlitFrom(*obj._imageFrame, obj._position, obj._flags & OBJ_FLIPPED, obj._scaleVal);
 		}
 	}
 
 	// Draw the animation if it is behind the person
 	if (_activeCAnim.active() && _activeCAnim._zPlacement == BEHIND)
 		screen._backBuffer1.SHtransBlitFrom(_activeCAnim._imageFrame, _activeCAnim._position,
-			(_activeCAnim._flags & 4) >> 1, 0, _activeCAnim._scaleVal);
+			(_activeCAnim._flags & 4) >> 1, _activeCAnim._scaleVal);
 
 	screen.resetDisplayBounds();
 
@@ -196,11 +196,11 @@ void TattooScene::drawAllShapes() {
 				screen._backBuffer1.SHblitFrom(*se._shape->_imageFrame, se._shape->_position);
 			else
 				screen._backBuffer1.SHtransBlitFrom(*se._shape->_imageFrame, se._shape->_position,
-					se._shape->_flags & OBJ_FLIPPED, 0, se._shape->_scaleVal);
+					se._shape->_flags & OBJ_FLIPPED, se._shape->_scaleVal);
 		} else if (se._isAnimation) {
 			// It's an active animation
 			screen._backBuffer1.SHtransBlitFrom(_activeCAnim._imageFrame, _activeCAnim._position,
-				(_activeCAnim._flags & 4) >> 1, 0, _activeCAnim._scaleVal);
+				(_activeCAnim._flags & 4) >> 1, _activeCAnim._scaleVal);
 		} else {
 			// Drawing person
 			TattooPerson &p = *se._person;
@@ -212,7 +212,7 @@ void TattooScene::drawAllShapes() {
 			if (p._tempScaleVal == SCALE_THRESHOLD) {
 				p._tempX += adjust.x;
 				screen._backBuffer1.SHtransBlitFrom(*p._imageFrame, Common::Point(p._tempX, p._position.y / FIXED_INT_MULTIPLIER
-					- p.frameHeight() - adjust.y), p._walkSequences[p._sequenceNumber]._horizFlip, 0, p._tempScaleVal);
+					- p.frameHeight() - adjust.y), p._walkSequences[p._sequenceNumber]._horizFlip, p._tempScaleVal);
 			} else {
 				if (adjust.x) {
 					if (!p._tempScaleVal)
@@ -242,7 +242,7 @@ void TattooScene::drawAllShapes() {
 				}
 
 				screen._backBuffer1.SHtransBlitFrom(*p._imageFrame, Common::Point(p._tempX, p._position.y / FIXED_INT_MULTIPLIER
-					- p._imageFrame->sDrawYSize(p._tempScaleVal) - adjust.y), p._walkSequences[p._sequenceNumber]._horizFlip, 0, p._tempScaleVal);
+					- p._imageFrame->sDrawYSize(p._tempScaleVal) - adjust.y), p._walkSequences[p._sequenceNumber]._horizFlip, p._tempScaleVal);
 			}
 		}
 	}
@@ -256,13 +256,13 @@ void TattooScene::drawAllShapes() {
 			if (obj._quickDraw && obj._scaleVal == SCALE_THRESHOLD)
 				screen._backBuffer1.SHblitFrom(*obj._imageFrame, obj._position);
 			else
-				screen._backBuffer1.SHtransBlitFrom(*obj._imageFrame, obj._position, obj._flags & OBJ_FLIPPED, 0, obj._scaleVal);
+				screen._backBuffer1.SHtransBlitFrom(*obj._imageFrame, obj._position, obj._flags & OBJ_FLIPPED, obj._scaleVal);
 		}
 	}
 
 	// Draw the canimation if it is set as FORWARD
 	if (_activeCAnim.active() && _activeCAnim._zPlacement == FORWARD)
-		screen._backBuffer1.SHtransBlitFrom(_activeCAnim._imageFrame, _activeCAnim._position, (_activeCAnim._flags & 4) >> 1, 0, _activeCAnim._scaleVal);
+		screen._backBuffer1.SHtransBlitFrom(_activeCAnim._imageFrame, _activeCAnim._position, (_activeCAnim._flags & 4) >> 1, _activeCAnim._scaleVal);
 
 	// Draw all NO_SHAPE shapes which have their flag bits clear
 	for (uint idx = 0; idx < _bgShapes.size(); ++idx) {

--- a/engines/twine/movies.cpp
+++ b/engines/twine/movies.cpp
@@ -312,7 +312,7 @@ void Movies::prepareGIF(int index) {
 	_engine->setPalette(0, decoder.getPaletteColorCount(), decoder.getPalette());
 	Graphics::ManagedSurface& target = _engine->_frontVideoBuffer;
 	const Common::Rect surfaceBounds(0, 0, surface->w, surface->h);
-	target.transBlitFrom(*surface, surfaceBounds, target.getBounds(), 0, false, 0, 0xff, nullptr, true);
+	target.transBlitFrom(*surface, surfaceBounds, target.getBounds(), 0, false, 0xff, nullptr, true);
 	debugC(1, TwinE::kDebugMovies, "Show gif with id %i from %s", index, Resources::HQR_FLAGIF_FILE);
 	delete stream;
 	_engine->delaySkip(5000);
@@ -540,7 +540,7 @@ bool Movies::playSmkMovie(const char *name, int index) {
 
 			Graphics::ManagedSurface& target = _engine->_frontVideoBuffer;
 			const Common::Rect frameBounds(0, 0, frameSurf->w, frameSurf->h);
-			target.transBlitFrom(*frameSurf, frameBounds, target.getBounds(), 0, false, 0, 0xff, nullptr, true);
+			target.transBlitFrom(*frameSurf, frameBounds, target.getBounds(), 0, false, 0xff, nullptr, true);
 		}
 	}
 

--- a/engines/twine/renderer/screens.cpp
+++ b/engines/twine/renderer/screens.cpp
@@ -82,7 +82,7 @@ void Screens::loadImage(TwineImage image, bool fadeIn) {
 	}
 	debugC(1, TwinE::kDebugResources, "Load image: %i", image.image.index);
 	Graphics::ManagedSurface& target = _engine->_frontVideoBuffer;
-	target.transBlitFrom(src, src.getBounds(), target.getBounds(), 0, false, 0, 0xff, nullptr, true);
+	target.transBlitFrom(src, src.getBounds(), target.getBounds(), 0, false, 0xff, nullptr, true);
 	const Graphics::Palette *pal = &_ptrPal;
 	if (image.palette.index != -1) {
 		loadCustomPalette(image.palette);
@@ -133,7 +133,7 @@ static bool loadImageDelayViaDecoder(TwinEEngine *engine, const Common::Path &fi
 		delete source;
 	} else {
 		engine->setPalette(0, decoder.getPaletteColorCount(), decoder.getPalette());
-		target.transBlitFrom(*src, rect, target.getBounds(), 0, false, 0, 0xff, nullptr, true);
+		target.transBlitFrom(*src, rect, target.getBounds(), 0, false, 0xff, nullptr, true);
 	}
 	if (engine->delaySkip(1000 * seconds)) {
 		return true;

--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -632,81 +632,81 @@ void ManagedSurface::blitFromInner(const Surface &src, const Common::Rect &srcRe
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, uint32 transColor, bool flipped,
-		uint32 overrideColor, uint32 srcAlpha, const Palette *srcPalette) {
+		uint32 srcAlpha, const Palette *srcPalette) {
 	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(0, 0, this->w, this->h),
-		transColor, flipped, overrideColor, srcAlpha, nullptr, false, srcPalette);
+		transColor, flipped, srcAlpha, nullptr, false, srcPalette);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Point &destPos,
-		uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha, const Palette *srcPalette) {
+		uint32 transColor, bool flipped, uint32 srcAlpha, const Palette *srcPalette) {
 	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(destPos.x, destPos.y,
-		destPos.x + src.w, destPos.y + src.h), transColor, flipped, overrideColor, srcAlpha, nullptr, false, srcPalette);
+		destPos.x + src.w, destPos.y + src.h), transColor, flipped, srcAlpha, nullptr, false, srcPalette);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Point &destPos,
 		const ManagedSurface &mask, const Palette *srcPalette) {
 	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(destPos.x, destPos.y,
-		destPos.x + src.w, destPos.y + src.h), 0, false, 0, 0xff, &mask._innerSurface, true, srcPalette);
+		destPos.x + src.w, destPos.y + src.h), 0, false, 0xff, &mask._innerSurface, true, srcPalette);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Point &destPos,
 		const Surface &mask, const Palette *srcPalette) {
 	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(destPos.x, destPos.y,
-		destPos.x + src.w, destPos.y + src.h), 0, false, 0, 0xff, &mask, true, srcPalette);
+		destPos.x + src.w, destPos.y + src.h), 0, false, 0xff, &mask, true, srcPalette);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Rect &srcRect,
-		const Common::Point &destPos, uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha, const Palette *srcPalette) {
+		const Common::Point &destPos, uint32 transColor, bool flipped, uint32 srcAlpha, const Palette *srcPalette) {
 	transBlitFrom(src, srcRect, Common::Rect(destPos.x, destPos.y,
-		destPos.x + srcRect.width(), destPos.y + srcRect.height()), transColor, flipped, overrideColor, srcAlpha, nullptr, false, srcPalette);
+		destPos.x + srcRect.width(), destPos.y + srcRect.height()), transColor, flipped, srcAlpha, nullptr, false, srcPalette);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Rect &srcRect, const Common::Rect &destRect, const Palette *srcPalette) {
-	transBlitFrom(src, srcRect, destRect, 0, false, 0, 0xff, nullptr, false, srcPalette);
+	transBlitFrom(src, srcRect, destRect, 0, false, 0xff, nullptr, false, srcPalette);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Rect &srcRect,
-		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha,
+		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 srcAlpha,
 		const Surface *mask, bool maskOnly, const Palette *srcPalette) {
-	transBlitFromInner(src, srcRect, destRect, transColor, flipped, overrideColor, srcAlpha,
+	transBlitFromInner(src, srcRect, destRect, transColor, flipped, srcAlpha,
 		srcPalette, nullptr, mask, maskOnly);
 }
 
 void ManagedSurface::transBlitFrom(const ManagedSurface &src, uint32 transColor, bool flipped,
-		uint32 overrideColor, uint32 srcAlpha) {
+		uint32 srcAlpha) {
 	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(0, 0, this->w, this->h),
-		transColor, flipped, overrideColor, srcAlpha);
+		transColor, flipped, srcAlpha);
 }
 
 void ManagedSurface::transBlitFrom(const ManagedSurface &src, const Common::Point &destPos,
-		uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha) {
+		uint32 transColor, bool flipped, uint32 srcAlpha) {
 	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(destPos.x, destPos.y,
-		destPos.x + src.w, destPos.y + src.h), transColor, flipped, overrideColor, srcAlpha);
+		destPos.x + src.w, destPos.y + src.h), transColor, flipped, srcAlpha);
 }
 
 void ManagedSurface::transBlitFrom(const ManagedSurface &src, const Common::Point &destPos,
 		const ManagedSurface &mask) {
 	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(destPos.x, destPos.y,
-		destPos.x + src.w, destPos.y + src.h), 0, false, 0, 0xff, &mask._innerSurface, true);
+		destPos.x + src.w, destPos.y + src.h), 0, false, 0xff, &mask._innerSurface, true);
 }
 
 void ManagedSurface::transBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect,
-		const Common::Point &destPos, uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha) {
+		const Common::Point &destPos, uint32 transColor, bool flipped, uint32 srcAlpha) {
 	uint32 tColor = !transColor && src._transparentColorSet ? src._transparentColor : transColor;
 
 	transBlitFrom(src, srcRect, Common::Rect(destPos.x, destPos.y, destPos.x + srcRect.width(),
-		destPos.y + srcRect.height()), tColor, flipped, overrideColor, srcAlpha);
+		destPos.y + srcRect.height()), tColor, flipped, srcAlpha);
 }
 
 void ManagedSurface::transBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect,
-		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha,
+		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 srcAlpha,
 		const Surface *mask, bool maskOnly) {
 	if (transColor == (uint32)-1 && src._transparentColorSet)
 		transColor = src._transparentColor;
 	const Palette *srcPalette = src._palette;
 	const Palette *dstPalette = _palette;
 
-	transBlitFromInner(src._innerSurface, srcRect, destRect, transColor, flipped, overrideColor,
+	transBlitFromInner(src._innerSurface, srcRect, destRect, transColor, flipped,
 		srcAlpha, srcPalette, dstPalette, mask, maskOnly);
 }
 
@@ -736,7 +736,7 @@ static byte *createPaletteLookup(const Palette *srcPalette, const Palette *dstPa
 
 template<typename TSRC, typename TDEST>
 void transBlitPixel(TSRC srcVal, TDEST &destVal, const Graphics::PixelFormat &srcFormat, const Graphics::PixelFormat &destFormat,
-		uint32 overrideColor, uint32 srcAlpha, const Palette *srcPalette, const byte *lookup) {
+		uint32 srcAlpha, const Palette *srcPalette, const byte *lookup) {
 	// Decode and re-encode each pixel
 	byte aSrc, rSrc, gSrc, bSrc;
 	if (srcFormat.isCLUT8()) {
@@ -780,13 +780,13 @@ void transBlitPixel(TSRC srcVal, TDEST &destVal, const Graphics::PixelFormat &sr
 
 template<>
 void transBlitPixel<byte, byte>(byte srcVal, byte &destVal, const Graphics::PixelFormat &srcFormat, const Graphics::PixelFormat &destFormat,
-		uint32 overrideColor, uint32 srcAlpha, const Palette *srcPalette, const byte *lookup) {
+		uint32 srcAlpha, const Palette *srcPalette, const byte *lookup) {
 	if (srcAlpha == 0) {
 		// Completely transparent, so skip
 		return;
 	}
 
-	destVal = overrideColor ? overrideColor : srcVal;
+	destVal = srcVal;
 
 	if (lookup)
 		destVal = lookup[destVal];
@@ -794,7 +794,7 @@ void transBlitPixel<byte, byte>(byte srcVal, byte &destVal, const Graphics::Pixe
 
 template<typename TSRC, typename TDEST>
 void transBlit(const Surface &src, const Common::Rect &srcRect, ManagedSurface &dest, const Common::Rect &destRect,
-		TSRC transColor, bool flipped, uint32 overrideColor, uint32 srcAlpha, const Palette *srcPalette,
+		TSRC transColor, bool flipped, uint32 srcAlpha, const Palette *srcPalette,
 		const Palette *dstPalette, const Surface *mask, bool maskOnly) {
 	int scaleX = SCALE_THRESHOLD * srcRect.width() / destRect.width();
 	int scaleY = SCALE_THRESHOLD * srcRect.height() / destRect.height();
@@ -865,13 +865,13 @@ void transBlit(const Surface &src, const Common::Rect &srcRect, ManagedSurface &
 					// Remove transparent color on dest so it isn't alpha blended
 					destVal = 0;
 
-				transBlitPixel<TSRC, TDEST>(srcVal, destVal, src.format, dest.format, overrideColor, mskVal, srcPalette, lookup);
+				transBlitPixel<TSRC, TDEST>(srcVal, destVal, src.format, dest.format, mskVal, srcPalette, lookup);
 			} else {
 				if (isDestPixelTrans)
 					// Remove transparent color on dest so it isn't alpha blended
 					destVal = 0;
 
-				transBlitPixel<TSRC, TDEST>(srcVal, destVal, src.format, dest.format, overrideColor, srcAlpha, srcPalette, lookup);
+				transBlitPixel<TSRC, TDEST>(srcVal, destVal, src.format, dest.format, srcAlpha, srcPalette, lookup);
 			}
 		}
 	}
@@ -881,11 +881,11 @@ void transBlit(const Surface &src, const Common::Rect &srcRect, ManagedSurface &
 
 #define HANDLE_BLIT(SRC_BYTES, DEST_BYTES, SRC_TYPE, DEST_TYPE) \
 	if (src.format.bytesPerPixel == SRC_BYTES && format.bytesPerPixel == DEST_BYTES) \
-		transBlit<SRC_TYPE, DEST_TYPE>(src, srcRect, *this, destRect, transColor, flipped, overrideColor, srcAlpha, srcPalette, dstPalette, mask, maskOnly); \
+		transBlit<SRC_TYPE, DEST_TYPE>(src, srcRect, *this, destRect, transColor, flipped, srcAlpha, srcPalette, dstPalette, mask, maskOnly); \
 	else
 
 void ManagedSurface::transBlitFromInner(const Surface &src, const Common::Rect &srcRect,
-		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 overrideColor,
+		const Common::Rect &destRect, uint32 transColor, bool flipped,
 		uint32 srcAlpha, const Palette *srcPalette, const Palette *dstPalette, const Surface *mask, bool maskOnly) {
 	if (src.w == 0 || src.h == 0 || destRect.width() == 0 || destRect.height() == 0)
 		return;

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -102,8 +102,8 @@ protected:
 	 * Inner method for copying another surface into this one at a given destination position.
 	 */
 	void transBlitFromInner(const Surface &src, const Common::Rect &srcRect,
-		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 overrideColor,
-		uint32 srcAlpha, const Palette *srcPalette, const Palette *dstPalette,
+		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 srcAlpha,
+		const Palette *srcPalette, const Palette *dstPalette,
 		const Surface *mask, bool maskOnly);
 public:
 	/**
@@ -409,13 +409,11 @@ public:
 	 * @param src			Source surface.
 	 * @param transColor	Transparency color to ignore copying of.
 	 * @param flipped		Whether to horizontally flip the image.
-	 * @param overrideColor	Optional color to use instead of non-transparent pixels from
-	 *						the source surface.
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
 	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
 	 */
 	void transBlitFrom(const Surface &src, uint32 transColor = 0, bool flipped = false,
-		uint32 overrideColor = 0, uint32 srcAlpha = 0xff, const Palette *srcPalette = nullptr);
+		uint32 srcAlpha = 0xff, const Palette *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -424,13 +422,11 @@ public:
 	 * @param destPos		Destination position to draw the surface.
 	 * @param transColor	Transparency color to ignore copying of.
 	 * @param flipped		Whether to horizontally flip the image.
-	 * @param overrideColor	Optional color to use instead of non-transparent pixels from
-	 *						the source surface.
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
 	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
 	 */
 	void transBlitFrom(const Surface &src, const Common::Point &destPos,
-		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff, const Palette *srcPalette = nullptr);
+		uint32 transColor = 0, bool flipped = false, uint32 srcAlpha = 0xff, const Palette *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -462,13 +458,11 @@ public:
 	 * @param destPos		Destination position to draw the surface.
 	 * @param transColor	Transparency color to ignore copying of.
 	 * @param flipped		Specifies whether to horizontally flip the image.
-	 * @param overrideColor	Optional color to use instead of non-transparent pixels from
-	 *						the source surface.
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
 	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
 	 */
 	void transBlitFrom(const Surface &src, const Common::Rect &srcRect, const Common::Point &destPos,
-		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff, const Palette *srcPalette = nullptr);
+		uint32 transColor = 0, bool flipped = false, uint32 srcAlpha = 0xff, const Palette *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -490,15 +484,13 @@ public:
 	 *						then @p srcRect, allowing for arbitrary scaling of the image.
 	 * @param transColor	Transparency color to ignore copying of.
 	 * @param flipped		Whether to horizontally flip the image.
-	 * @param overrideColor	Optional color to use instead of non-transparent pixels from
-	 *						the source surface.
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
 	 * @param mask			Optional parameter with mask definition.
 	 * @param maskOnly		Optional parameter for using mask over @p transColor.
 	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
 	 */
 	void transBlitFrom(const Surface &src, const Common::Rect &srcRect, const Common::Rect &destRect,
-		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff,
+		uint32 transColor = 0, bool flipped = false, uint32 srcAlpha = 0xff,
 		const Surface *mask = nullptr, bool maskOnly = false, const Palette *srcPalette = nullptr);
 
 	/**
@@ -507,12 +499,10 @@ public:
 	 * @param src			Source surface.
 	 * @param transColor	Transparency color to ignore copying of.
 	 * @param flipped		Whether to horizontally flip the image.
-	 * @param overrideColor	Optional color to use instead of non-transparent pixels from
-	 *						the source surface.
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
 	 */
 	void transBlitFrom(const ManagedSurface &src, uint32 transColor = 0, bool flipped = false,
-		uint32 overrideColor = 0, uint32 srcAlpha = 0xff);
+		uint32 srcAlpha = 0xff);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -521,12 +511,10 @@ public:
 	 * @param destPos		Destination position to draw the surface.
 	 * @param transColor	Transparency color to ignore copying of.
 	 * @param flipped		Whether to horizontally flip the image.
-	 * @param overrideColor	Optional color to use instead of non-transparent pixels from
-	 *						the source surface.
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
 	 */
 	void transBlitFrom(const ManagedSurface &src, const Common::Point &destPos,
-		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff);
+		uint32 transColor = 0, bool flipped = false, uint32 srcAlpha = 0xff);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -546,12 +534,10 @@ public:
 	 * @param destPos		Destination position to draw the surface.
 	 * @param transColor	Transparency color to ignore copying of.
 	 * @param flipped		Whether to horizontally flip the image.
-	 * @param overrideColor	Optional color to use instead of non-transparent pixels from
-	 *						the source surface.
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
 	 */
 	void transBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect, const Common::Point &destPos,
-		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff);
+		uint32 transColor = 0, bool flipped = false, uint32 srcAlpha = 0xff);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -562,14 +548,12 @@ public:
 	 *						then @p srcRect, allowing for arbitrary scaling of the image.
 	 * @param transColor	Transparency color to ignore copying of.
 	 * @param flipped		Whether to horizontally flip the image.
-	 * @param overrideColor	Optional color to use instead of non-transparent pixels from
-	 *						the source surface.
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
 	 * @param mask			Optional parameter with mask definition.
 	 * @param maskOnly		Optional parameter for using mask over @p transColor.
 	 */
 	void transBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect, const Common::Rect &destRect,
-		uint32 transColor = 0, bool flipped = false, uint32 overrideColor = 0, uint32 srcAlpha = 0xff,
+		uint32 transColor = 0, bool flipped = false, uint32 srcAlpha = 0xff,
 		const Surface *mask = nullptr, bool maskOnly = false);
 
 	/**


### PR DESCRIPTION
The Sherlock engine was the only user of this feature, and it was only implemented for paletted surfaces. Removing it allows the ManagedSurface blitting code to be simplified a bit.