### PR TITLE
GRAPHICS: Remove masks from ManagedSurface::transBlitFrom

### DIFF
--- a/backends/platform/libretro/src/libretro-graphics-surface.cpp
+++ b/backends/platform/libretro/src/libretro-graphics-surface.cpp
@@ -132,7 +132,7 @@ void LibretroGraphics::realUpdateScreen(void) {
 
 	if (_cursorVisible && _cursor.w && _cursor.h) {
 		Common::Point topLeft(_cursorX - _cursorHotspotXScaled, _cursorY - _cursorHotspotYScaled);
-		_screen.transBlitFrom(_cursor, Common::Rect(_cursor.w, _cursor.h), Common::Rect(topLeft, topLeft + Common::Point(_cursorWidthScaled, _cursorHeightScaled)),  _cursorKeyColor, false, 0xff, nullptr, false,  _cursorPaletteEnabled ? &_cursorPalette : &_gamePalette);
+		_screen.transBlitFrom(_cursor, Common::Rect(_cursor.w, _cursor.h), Common::Rect(topLeft, topLeft + Common::Point(_cursorWidthScaled, _cursorHeightScaled)),  _cursorKeyColor, false, 0xff,  _cursorPaletteEnabled ? &_cursorPalette : &_gamePalette);
 	}
 	_screenUpdatePending = false;
 }

--- a/engines/mtropolis/hacks.cpp
+++ b/engines/mtropolis/hacks.cpp
@@ -955,7 +955,7 @@ void MTIMolassesHandler::release() {
 }
 
 void MTIMolassesHandler::renderPostEffect(Graphics::ManagedSurface &surface) const {
-	surface.transBlitFrom(_surf, Common::Point(0, 0), _mask);
+	surface.maskBlitFrom(_surf, _mask);
 }
 
 class MTIMolassesFullscreenHooks : public StructuralHooks {

--- a/engines/twine/movies.cpp
+++ b/engines/twine/movies.cpp
@@ -312,7 +312,7 @@ void Movies::prepareGIF(int index) {
 	_engine->setPalette(0, decoder.getPaletteColorCount(), decoder.getPalette());
 	Graphics::ManagedSurface& target = _engine->_frontVideoBuffer;
 	const Common::Rect surfaceBounds(0, 0, surface->w, surface->h);
-	target.transBlitFrom(*surface, surfaceBounds, target.getBounds(), 0, false, 0xff, nullptr, true);
+	target.blitFrom(*surface, surfaceBounds, target.getBounds());
 	debugC(1, TwinE::kDebugMovies, "Show gif with id %i from %s", index, Resources::HQR_FLAGIF_FILE);
 	delete stream;
 	_engine->delaySkip(5000);
@@ -540,7 +540,7 @@ bool Movies::playSmkMovie(const char *name, int index) {
 
 			Graphics::ManagedSurface& target = _engine->_frontVideoBuffer;
 			const Common::Rect frameBounds(0, 0, frameSurf->w, frameSurf->h);
-			target.transBlitFrom(*frameSurf, frameBounds, target.getBounds(), 0, false, 0xff, nullptr, true);
+			target.blitFrom(*frameSurf, frameBounds, target.getBounds());
 		}
 	}
 

--- a/engines/twine/renderer/screens.cpp
+++ b/engines/twine/renderer/screens.cpp
@@ -82,7 +82,7 @@ void Screens::loadImage(TwineImage image, bool fadeIn) {
 	}
 	debugC(1, TwinE::kDebugResources, "Load image: %i", image.image.index);
 	Graphics::ManagedSurface& target = _engine->_frontVideoBuffer;
-	target.transBlitFrom(src, src.getBounds(), target.getBounds(), 0, false, 0xff, nullptr, true);
+	target.blitFrom(src, src.getBounds(), target.getBounds());
 	const Graphics::Palette *pal = &_ptrPal;
 	if (image.palette.index != -1) {
 		loadCustomPalette(image.palette);
@@ -133,7 +133,7 @@ static bool loadImageDelayViaDecoder(TwinEEngine *engine, const Common::Path &fi
 		delete source;
 	} else {
 		engine->setPalette(0, decoder.getPaletteColorCount(), decoder.getPalette());
-		target.transBlitFrom(*src, rect, target.getBounds(), 0, false, 0xff, nullptr, true);
+		target.blitFrom(*src, rect, target.getBounds());
 	}
 	if (engine->delaySkip(1000 * seconds)) {
 		return true;

--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -696,42 +696,30 @@ void ManagedSurface::blitFromInner(const Surface &src, const Common::Rect &srcRe
 void ManagedSurface::transBlitFrom(const Surface &src, uint32 transColor, bool flipped,
 		uint32 srcAlpha, const Palette *srcPalette) {
 	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(0, 0, this->w, this->h),
-		transColor, flipped, srcAlpha, nullptr, false, srcPalette);
+		transColor, flipped, srcAlpha, srcPalette);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Point &destPos,
 		uint32 transColor, bool flipped, uint32 srcAlpha, const Palette *srcPalette) {
 	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(destPos.x, destPos.y,
-		destPos.x + src.w, destPos.y + src.h), transColor, flipped, srcAlpha, nullptr, false, srcPalette);
-}
-
-void ManagedSurface::transBlitFrom(const Surface &src, const Common::Point &destPos,
-		const ManagedSurface &mask, const Palette *srcPalette) {
-	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(destPos.x, destPos.y,
-		destPos.x + src.w, destPos.y + src.h), 0, false, 0xff, &mask._innerSurface, true, srcPalette);
-}
-
-void ManagedSurface::transBlitFrom(const Surface &src, const Common::Point &destPos,
-		const Surface &mask, const Palette *srcPalette) {
-	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(destPos.x, destPos.y,
-		destPos.x + src.w, destPos.y + src.h), 0, false, 0xff, &mask, true, srcPalette);
+		destPos.x + src.w, destPos.y + src.h), transColor, flipped, srcAlpha, srcPalette);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Rect &srcRect,
 		const Common::Point &destPos, uint32 transColor, bool flipped, uint32 srcAlpha, const Palette *srcPalette) {
 	transBlitFrom(src, srcRect, Common::Rect(destPos.x, destPos.y,
-		destPos.x + srcRect.width(), destPos.y + srcRect.height()), transColor, flipped, srcAlpha, nullptr, false, srcPalette);
+		destPos.x + srcRect.width(), destPos.y + srcRect.height()), transColor, flipped, srcAlpha, srcPalette);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Rect &srcRect, const Common::Rect &destRect, const Palette *srcPalette) {
-	transBlitFrom(src, srcRect, destRect, 0, false, 0xff, nullptr, false, srcPalette);
+	transBlitFrom(src, srcRect, destRect, 0, false, 0xff, srcPalette);
 }
 
 void ManagedSurface::transBlitFrom(const Surface &src, const Common::Rect &srcRect,
 		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 srcAlpha,
-		const Surface *mask, bool maskOnly, const Palette *srcPalette) {
+		const Palette *srcPalette) {
 	transBlitFromInner(src, srcRect, destRect, transColor, flipped, srcAlpha,
-		srcPalette, nullptr, mask, maskOnly);
+		srcPalette, nullptr);
 }
 
 void ManagedSurface::transBlitFrom(const ManagedSurface &src, uint32 transColor, bool flipped,
@@ -746,12 +734,6 @@ void ManagedSurface::transBlitFrom(const ManagedSurface &src, const Common::Poin
 		destPos.x + src.w, destPos.y + src.h), transColor, flipped, srcAlpha);
 }
 
-void ManagedSurface::transBlitFrom(const ManagedSurface &src, const Common::Point &destPos,
-		const ManagedSurface &mask) {
-	transBlitFrom(src, Common::Rect(0, 0, src.w, src.h), Common::Rect(destPos.x, destPos.y,
-		destPos.x + src.w, destPos.y + src.h), 0, false, 0xff, &mask._innerSurface, true);
-}
-
 void ManagedSurface::transBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect,
 		const Common::Point &destPos, uint32 transColor, bool flipped, uint32 srcAlpha) {
 	uint32 tColor = !transColor && src._transparentColorSet ? src._transparentColor : transColor;
@@ -761,15 +743,14 @@ void ManagedSurface::transBlitFrom(const ManagedSurface &src, const Common::Rect
 }
 
 void ManagedSurface::transBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect,
-		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 srcAlpha,
-		const Surface *mask, bool maskOnly) {
+		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 srcAlpha) {
 	if (transColor == (uint32)-1 && src._transparentColorSet)
 		transColor = src._transparentColor;
 	const Palette *srcPalette = src._palette;
 	const Palette *dstPalette = _palette;
 
 	transBlitFromInner(src._innerSurface, srcRect, destRect, transColor, flipped,
-		srcAlpha, srcPalette, dstPalette, mask, maskOnly);
+		srcAlpha, srcPalette, dstPalette);
 }
 
 static byte *createPaletteLookup(const Palette *srcPalette, const Palette *dstPalette) {
@@ -857,7 +838,7 @@ void transBlitPixel<byte, byte>(byte srcVal, byte &destVal, const Graphics::Pixe
 template<typename TSRC, typename TDEST>
 void transBlit(const Surface &src, const Common::Rect &srcRect, ManagedSurface &dest, const Common::Rect &destRect,
 		TSRC transColor, bool flipped, uint32 srcAlpha, const Palette *srcPalette,
-		const Palette *dstPalette, const Surface *mask, bool maskOnly) {
+		const Palette *dstPalette) {
 	int scaleX = SCALE_THRESHOLD * srcRect.width() / destRect.width();
 	int scaleY = SCALE_THRESHOLD * srcRect.height() / destRect.height();
 	byte rst = 0, gst = 0, bst = 0, rdt = 0, gdt = 0, bdt = 0;
@@ -883,11 +864,6 @@ void transBlit(const Surface &src, const Common::Rect &srcRect, ManagedSurface &
 		if (destY < 0 || destY >= dest.h)
 			continue;
 		const TSRC *srcLine = (const TSRC *)src.getBasePtr(srcRect.left, scaleYCtr / SCALE_THRESHOLD + srcRect.top);
-		const TSRC *mskLine = nullptr;
-
-		if (mask)
-			mskLine = (const TSRC *)mask->getBasePtr(srcRect.left, scaleYCtr / SCALE_THRESHOLD + srcRect.top);
-
 		TDEST *destLine = (TDEST *)dest.getBasePtr(destRect.left, destY);
 
 		// Loop through drawing the pixels of the row
@@ -910,31 +886,19 @@ void transBlit(const Surface &src, const Common::Rect &srcRect, ManagedSurface &
 				isDestPixelTrans = destVal == dest.getTransparentColor();
 			}
 
-			if (isSrcTrans32 && !maskOnly) {
+			if (isSrcTrans32) {
 				src.format.colorToRGB(srcVal, r, g, b);
 				if (rst == r && gst == g && bst == b)
 					continue;
 
-			} else if (srcVal == transColor && !maskOnly)
+			} else if (srcVal == transColor)
 				continue;
 
-			if (mask) {
-				TSRC mskVal = mskLine[flipped ? src.w - scaleXCtr / SCALE_THRESHOLD - 1 : scaleXCtr / SCALE_THRESHOLD];
-				if (!mskVal)
-					continue;
+			if (isDestPixelTrans)
+				// Remove transparent color on dest so it isn't alpha blended
+				destVal = 0;
 
-				if (isDestPixelTrans)
-					// Remove transparent color on dest so it isn't alpha blended
-					destVal = 0;
-
-				transBlitPixel<TSRC, TDEST>(srcVal, destVal, src.format, dest.format, mskVal, srcPalette, lookup);
-			} else {
-				if (isDestPixelTrans)
-					// Remove transparent color on dest so it isn't alpha blended
-					destVal = 0;
-
-				transBlitPixel<TSRC, TDEST>(srcVal, destVal, src.format, dest.format, srcAlpha, srcPalette, lookup);
-			}
+			transBlitPixel<TSRC, TDEST>(srcVal, destVal, src.format, dest.format, srcAlpha, srcPalette, lookup);
 		}
 	}
 
@@ -943,19 +907,14 @@ void transBlit(const Surface &src, const Common::Rect &srcRect, ManagedSurface &
 
 #define HANDLE_BLIT(SRC_BYTES, DEST_BYTES, SRC_TYPE, DEST_TYPE) \
 	if (src.format.bytesPerPixel == SRC_BYTES && format.bytesPerPixel == DEST_BYTES) \
-		transBlit<SRC_TYPE, DEST_TYPE>(src, srcRect, *this, destRect, transColor, flipped, srcAlpha, srcPalette, dstPalette, mask, maskOnly); \
+		transBlit<SRC_TYPE, DEST_TYPE>(src, srcRect, *this, destRect, transColor, flipped, srcAlpha, srcPalette, dstPalette); \
 	else
 
 void ManagedSurface::transBlitFromInner(const Surface &src, const Common::Rect &srcRect,
 		const Common::Rect &destRect, uint32 transColor, bool flipped,
-		uint32 srcAlpha, const Palette *srcPalette, const Palette *dstPalette, const Surface *mask, bool maskOnly) {
+		uint32 srcAlpha, const Palette *srcPalette, const Palette *dstPalette) {
 	if (src.w == 0 || src.h == 0 || destRect.width() == 0 || destRect.height() == 0)
 		return;
-
-	if (mask) {
-		if (mask->w != src.w || mask->h != src.h)
-			error("Surface::transBlitFrom: mask dimensions do not match src");
-	}
 
 	HANDLE_BLIT(1, 1, uint8,  uint8)
 	HANDLE_BLIT(1, 2, uint8,  uint16)

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -110,8 +110,7 @@ protected:
 	 */
 	void transBlitFromInner(const Surface &src, const Common::Rect &srcRect,
 		const Common::Rect &destRect, uint32 transColor, bool flipped, uint32 srcAlpha,
-		const Palette *srcPalette, const Palette *dstPalette,
-		const Surface *mask, bool maskOnly);
+		const Palette *srcPalette, const Palette *dstPalette);
 public:
 	/**
 	 * Clip the given source bounds so the passed destBounds will be entirely on-screen.
@@ -471,28 +470,6 @@ public:
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
 	 *
 	 * @param src			Source surface.
-	 * @param destPos		Destination position to draw the surface.
-	 * @param mask			Mask definition.
-	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
-	 */
-	void transBlitFrom(const Surface &src, const Common::Point &destPos,
-		const ManagedSurface &mask, const Palette *srcPalette = nullptr);
-
-	/**
-	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
-	 *
-	 * @param src			Source surface.
-	 * @param destPos		Destination position to draw the surface.
-	 * @param mask			Mask definition.
-	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
-	 */
-	void transBlitFrom(const Surface &src, const Common::Point &destPos,
-		const Surface &mask, const Palette *srcPalette = nullptr);
-
-	/**
-	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
-	 *
-	 * @param src			Source surface.
 	 * @param srcRect		Subsection of the source surface to draw.
 	 * @param destPos		Destination position to draw the surface.
 	 * @param transColor	Transparency color to ignore copying of.
@@ -524,13 +501,11 @@ public:
 	 * @param transColor	Transparency color to ignore copying of.
 	 * @param flipped		Whether to horizontally flip the image.
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
-	 * @param mask			Optional parameter with mask definition.
-	 * @param maskOnly		Optional parameter for using mask over @p transColor.
 	 * @param srcPalette	Optional palette if the @p src surface uses a CLUT8 pixel format.
 	 */
 	void transBlitFrom(const Surface &src, const Common::Rect &srcRect, const Common::Rect &destRect,
 		uint32 transColor = 0, bool flipped = false, uint32 srcAlpha = 0xff,
-		const Surface *mask = nullptr, bool maskOnly = false, const Palette *srcPalette = nullptr);
+		const Palette *srcPalette = nullptr);
 
 	/**
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
@@ -559,16 +534,6 @@ public:
 	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
 	 *
 	 * @param src			Source surface.
-	 * @param destPos		Destination position to draw the surface.
-	 * @param mask			Mask definition.
-	 */
-	void transBlitFrom(const ManagedSurface &src, const Common::Point &destPos,
-		const ManagedSurface &mask);
-
-	/**
-	 * Copy another surface into this one, ignoring pixels of a designated transparent color.
-	 *
-	 * @param src			Source surface.
 	 * @param srcRect		Subsection of the source surface to draw.
 	 * @param destPos		Destination position to draw the surface.
 	 * @param transColor	Transparency color to ignore copying of.
@@ -588,12 +553,9 @@ public:
 	 * @param transColor	Transparency color to ignore copying of.
 	 * @param flipped		Whether to horizontally flip the image.
 	 * @param srcAlpha		Optional additional transparency applied to @p src.
-	 * @param mask			Optional parameter with mask definition.
-	 * @param maskOnly		Optional parameter for using mask over @p transColor.
 	 */
 	void transBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect, const Common::Rect &destRect,
-		uint32 transColor = 0, bool flipped = false, uint32 srcAlpha = 0xff,
-		const Surface *mask = nullptr, bool maskOnly = false);
+		uint32 transColor = 0, bool flipped = false, uint32 srcAlpha = 0xff);
 
 	/**
 	 * Does a blitFrom ignoring any transparency settings

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -93,6 +93,13 @@ protected:
 		bool transparentColorSet, uint transparentColor);
 
 	/**
+	 * Inner method for blitting with a transparent mask.
+	 */
+	void maskBlitFromInner(const Surface &src, const Surface &mask,
+		const Common::Rect &srcRect, const Common::Point &destPos,
+		const Palette *srcPalette);
+
+	/**
 	 * Inner method for blitting.
 	 */
 	void blitFromInner(const Surface &src, const Common::Rect &srcRect,
@@ -358,6 +365,38 @@ public:
 	 */
 	void simpleBlitFrom(const ManagedSurface &src, const Common::Rect &srcRect,
 		const Common::Point &destPos);
+
+	/**
+	 * Copy another surface into this one using a transparency mask.
+	 */
+	void maskBlitFrom(const Surface &src, const Surface &mask, const Palette *srcPalette = nullptr);
+
+	/**
+	 * Copy another surface into this one at a given destination position using a transparency mask.
+	 */
+	void maskBlitFrom(const Surface &src, const Surface &mask, const Common::Point &destPos, const Palette *srcPalette = nullptr);
+
+	/**
+	 * Copy another surface into this one at a given destination position using a transparency mask.
+	 */
+	void maskBlitFrom(const Surface &src, const Surface &mask, const Common::Rect &srcRect,
+		const Common::Point &destPos, const Palette *srcPalette = nullptr);
+
+	/**
+	 * Copy another surface into this one using a transparency mask.
+	 */
+	void maskBlitFrom(const ManagedSurface &src, const ManagedSurface &mask);
+
+	/**
+	 * Copy another surface into this one at a given destination position using a transparency mask.
+	 */
+	void maskBlitFrom(const ManagedSurface &src, const ManagedSurface &mask, const Common::Point &destPos);
+
+	/**
+	 * Copy another surface into this one at a given destination position using a transparency mask.
+	 */
+	void maskBlitFrom(const ManagedSurface &src, const ManagedSurface &mask,
+		const Common::Rect &srcRect, const Common::Point &destPos);
 
 	/**
 	 * Copy another surface into this one.


### PR DESCRIPTION
A new set of functions has been added in its place that wraps around the shared mask code. It should be sufficient to cover the one place that uses it, but I'm not able to test it. Some modifications have been made to the TwinE engine as well, which used the `maskOnly` parameter without actually having a mask, which I think is just to disable the colour key, but those changes are untested as well.