### PR TITLE
ASYLUM: DO NOT MERGE: Fix crash when cursor is on top of menu screen

### DIFF
--- a/engines/asylum/resources/actor.cpp
+++ b/engines/asylum/resources/actor.cpp
@@ -3656,7 +3656,15 @@ ActorDirection Actor::getAngle(const Common::Point &vec1, const Common::Point &v
 
 	int32 dirAngle = -1;
 
-	if (diffX) {
+	// NOTE The extra condition: diffY < 0x800000
+	// is added to avoid a crash that manifests in optimized builds
+	// (for a couple of platforms/toolchains).
+	// Multiplying the diffY value (when it's >= 0x800000) by 256
+	// produces a value that is too large to fit in a 32-bit signed int.
+	// diffY becomes > 0x80000000 when eg. vec2.y <= 112 ,
+	// which happens when the cursor moves to the top part of the screen
+	// in the in-game menu (given that vec1 is Common::Point(320, 240)).
+	if (diffX && diffY < 0x800000) {
 		uint32 index = (uint32)((diffY * 256) / diffX);
 
 		if (index < 256)


### PR DESCRIPTION
This crash happens in a release build (--enable-release) with --disable-debug on msys2/mingw64

The crash seems to be caused by an overflow for int32 when calculating the index value in the getAngle() method, and diffY value is equal or greater than 0x800000 (ie. 2^23)

The Actor::getAngle() method in the context of the in-game menu (called from Menu::update()) is used for calculating the correct "frame" for the eyes in the center of the screen which are supposed to follow the cursor movement. The getAngle() method is also used elsewhere in the engine (called from Actor::faceTarget()), so this fix should be tested so that it has no side-effects in that part of the code.

This is a potential fix for this bug ticket: https://bugs.scummvm.org/ticket/15658

**Edit: Please do not merge. Currently exploring an alternative fix that will also bring behavior closer to the original**

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
