### PR TITLE
MEDIASTATION: Make use of simpleBlitFrom

### DIFF
--- a/engines/mediastation/assets/movie.cpp
+++ b/engines/mediastation/assets/movie.cpp
@@ -287,7 +287,7 @@ bool Movie::drawNextFrame() {
 		return a->zCoordinate() > b->zCoordinate();
 	});
 	for (MovieFrame *frame : framesToDraw) {
-		g_engine->_screen->transBlitFrom(frame->_surface, Common::Point(frame->left(), frame->top()), 0, false);
+		g_engine->_screen->simpleBlitFrom(frame->_surface, Common::Point(frame->left(), frame->top()));
 	}
 
 	uint blitEnd = g_system->getMillis() - _startTime;

--- a/engines/mediastation/assets/sprite.cpp
+++ b/engines/mediastation/assets/sprite.cpp
@@ -208,7 +208,7 @@ void Sprite::drawFrame(SpriteFrame *frame) {
 	uint frameLeft = frame->left() + _header->_boundingBox->left;
 	uint frameTop = frame->top() + _header->_boundingBox->top;
 	debugC(5, kDebugGraphics, "    Sprite frame %d (%d x %d) @ (%d, %d)", frame->index(), frame->width(), frame->height(), frameLeft, frameTop);
-	g_engine->_screen->transBlitFrom(frame->_surface, Common::Point(frameLeft, frameTop), 0, false);
+	g_engine->_screen->simpleBlitFrom(frame->_surface, Common::Point(frameLeft, frameTop));
 }
 
 } // End of namespace MediaStation

--- a/engines/mediastation/bitmap.cpp
+++ b/engines/mediastation/bitmap.cpp
@@ -53,6 +53,7 @@ Bitmap::Bitmap(Chunk &chunk, BitmapHeader *bitmapHeader) :
 	uint16 width = _bitmapHeader->_dimensions->x;
 	uint16 height = _bitmapHeader->_dimensions->y;
 	_surface.create(width, height, Graphics::PixelFormat::createFormatCLUT8());
+	_surface.setTransparentColor(0);
 	uint8 *pixels = (uint8 *)_surface.getPixels();
 	if (_bitmapHeader->isCompressed()) {
 		// DECOMPRESS THE IMAGE.


### PR DESCRIPTION
This should be straight forward since the engine exclusively uses paletted surfaces and doesn't seem to need scaling or palette remapping, but I haven't been able to test it.