### PR TITLE
GRAPHICS: MACGUI: Make it possible to disable menus

### DIFF
--- a/graphics/macgui/macmenu.cpp
+++ b/graphics/macgui/macmenu.cpp
@@ -1237,7 +1237,7 @@ void MacMenu::renderSubmenu(MacMenuSubMenu *menu, bool recursive) {
 		y += _menuDropdownItemHeight;
 	}
 
-	if (recursive && menu->highlight != -1 && menu->items[menu->highlight]->submenu != nullptr)
+	if (recursive && menu->highlight != -1 && _items[_activeItem]->enabled && menu->items[menu->highlight]->enabled && menu->items[menu->highlight]->submenu != nullptr)
 		renderSubmenu(menu->items[menu->highlight]->submenu, false);
 
 	if (_wm->_mode & kWMModalMenuMode) {
@@ -1337,7 +1337,7 @@ static void scrollCallback(void *data) {
 }
 
 bool MacMenu::mouseClick(int x, int y) {
-	if (!_isModal &&_bbox.contains(x, y)) {
+	if (!_isModal && _bbox.contains(x, y)) {
 		for (uint i = 0; i < _items.size(); i++) {
 			if (_items[i]->bbox.contains(x, y)) {
 				if ((uint)_activeItem == i)
@@ -1383,7 +1383,7 @@ bool MacMenu::mouseClick(int x, int y) {
 
 		if (numSubItem != _activeSubItem) {
 			if (_wm->_mode & kWMModalMenuMode) {
-				if (_activeSubItem == -1 || menu->items[_activeSubItem]->submenu != nullptr)
+				if (_activeSubItem == -1 || (_items[_activeItem]->enabled && menu->items[_activeSubItem]->enabled && menu->items[_activeSubItem]->submenu != nullptr))
 					g_system->copyRectToScreen(_wm->_screenCopy->getPixels(), _wm->_screenCopy->pitch, 0, 0, _wm->_screenCopy->w, _wm->_screenCopy->h);
 			}
 
@@ -1435,9 +1435,11 @@ bool MacMenu::mouseClick(int x, int y) {
 		}
 	}
 
-	if (_activeSubItem != -1 && _menustack.back()->items[_activeSubItem]->submenu != nullptr) {
-		if (_menustack.back()->items[_activeSubItem]->submenu->bbox.contains(x, y)) {
-			_menustack.push_back(_menustack.back()->items[_activeSubItem]->submenu);
+	if (_activeSubItem != -1 && _items[_activeItem]->enabled) {
+		Graphics::MacMenuItem *subitem = _menustack.back()->items[_activeSubItem];
+
+		if (subitem->submenu != nullptr && subitem->enabled && subitem->submenu->bbox.contains(x, y)) {
+			_menustack.push_back(subitem->submenu);
 
 			_activeSubItem = 0;
 			_contentIsDirty = true;

--- a/graphics/macgui/macmenu.cpp
+++ b/graphics/macgui/macmenu.cpp
@@ -1603,7 +1603,7 @@ bool MacMenu::processMenuShortCut(uint16 ascii) {
 	ascii = tolower(ascii);
 
 	for (uint i = 0; i < _items.size(); i++) {
-		if (_items[i]->submenu != nullptr) {
+		if (_items[i]->enabled && _items[i]->submenu != nullptr) {
 			for (uint j = 0; j < _items[i]->submenu->items.size(); j++) {
 				if (_items[i]->submenu->items[j]->enabled && tolower(_items[i]->submenu->items[j]->shortcut) == ascii) {
 					if (_items[i]->submenu->items[j]->unicode) {

--- a/graphics/macgui/macmenu.cpp
+++ b/graphics/macgui/macmenu.cpp
@@ -1186,6 +1186,7 @@ void MacMenu::renderSubmenu(MacMenuSubMenu *menu, bool recursive) {
 				tx = 0;
 				ty = 0;
 				accelX -= x;
+				arrowX -= x;
 
 				_tempSurface.clear(_wm->_colorGreen);
 			}


### PR DESCRIPTION
On a real Macintosh, you can disable entire menus. They will show up as grayed out in the menu bar, everything in them will be grayed out, and you cannot open submenus. As seen in this screenshot from an emulator:

![image](https://github.com/user-attachments/assets/49d83e7b-809d-44ab-a04a-082d301fe6e6)

This is an initial attempt at implementing this in ScummVM. What I have so far:

- Disabled menus are rendered as grayed out in the menu bar.
- Keyboard shortcuts are not available for disabled menus.
- Disabled submenus now still get their (grayed out) submenu arrow glyph.
- Unlike top-level menus, disabled submenus do not open.

I'm definitely going to need help with testing it, because it's easy to miss things. (I almost missed the keyboard shortcuts.)

Here is a preview of what I intend to use it for. In v6 and v7 games, the Edit menu is disabled. (In earlier games, it's not.) And in Maniac Mansion (which uses the same kind of Mac GUI), the Sound menu is also disabled.

![image](https://github.com/user-attachments/assets/e41ad308-f535-4729-82c0-76828fea418e)

I guess this also opens the door - just a crack - to keeping the menus active during dialogs. (In the original, this allows you to use the Edit menu during the Save dialog, though all other menus are grayed out.) But that appears to be quite tricky.