### PR TITLE
SCUMM: MACGUI: Trying to get save/load to work in Mac Maniac Mansion

### DIFF
--- a/engines/scumm/macgui/macgui.cpp
+++ b/engines/scumm/macgui/macgui.cpp
@@ -125,6 +125,14 @@ bool MacGui::runRestartDialog() {
 	return _impl->runRestartDialog();
 }
 
+bool MacGui::runOpenDialog(int &saveSlotToUse) {
+	return _impl->runOpenDialog(saveSlotToUse);
+}
+
+bool MacGui::runSaveDialog(int &saveSlotToUse, Common::String &saveName) {
+	return _impl->runSaveDialog(saveSlotToUse, saveName);
+}
+
 void MacGui::runDraftsInventory() {
 	((MacLoomGui *)_impl)->runDraftsInventory();
 }

--- a/engines/scumm/macgui/macgui.h
+++ b/engines/scumm/macgui/macgui.h
@@ -67,6 +67,8 @@ public:
 
 	bool runQuitDialog();
 	bool runRestartDialog();
+	bool runOpenDialog(int &saveSlotToHandle);
+	bool runSaveDialog(int &saveSlotToHandle, Common::String &saveName);
 
 	// Indiana Jones and the Last Crusade
 	bool isVerbGuiActive() const;

--- a/engines/scumm/macgui/macgui_impl.h
+++ b/engines/scumm/macgui/macgui_impl.h
@@ -227,8 +227,6 @@ protected:
 	virtual void restoreScreen() {}
 
 	virtual void runAboutDialog() = 0;
-	virtual bool runOpenDialog(int &saveSlotToHandle);
-	virtual bool runSaveDialog(int &saveSlotToHandle, Common::String &saveName);
 	virtual bool runOptionsDialog() = 0;
 	void prepareSaveLoad(Common::StringArray &savegameNames, bool *availSlots, int *slotIds, int size);
 
@@ -821,6 +819,8 @@ public:
 
 	virtual bool runQuitDialog();
 	virtual bool runRestartDialog();
+	virtual bool runOpenDialog(int &saveSlotToHandle);
+	virtual bool runSaveDialog(int &saveSlotToHandle, Common::String &saveName);
 
 	virtual void setupCursor(int &width, int &height, int &hotspotX, int &hotspotY, int &animate) = 0;
 

--- a/engines/scumm/macgui/macgui_indy3.h
+++ b/engines/scumm/macgui/macgui_indy3.h
@@ -75,14 +75,15 @@ public:
 	void update(int delta) override;
 	bool handleEvent(Common::Event event) override;
 
+	bool runOpenDialog(int &saveSlotToHandle) override;
+	bool runSaveDialog(int &saveSlotToHandle, Common::String &saveName) override;
+
 protected:
 	bool getFontParams(FontId fontId, int &id, int &size, int &slant) const override;
 
 	bool handleMenu(int id, Common::String &name) override;
 
 	void runAboutDialog() override;
-	bool runOpenDialog(int &saveSlotToHandle) override;
-	bool runSaveDialog(int &saveSlotToHandle, Common::String &saveName) override;
 	bool runOptionsDialog() override;
 	bool runIqPointsDialog();
 

--- a/engines/scumm/macgui/macgui_v6.cpp
+++ b/engines/scumm/macgui/macgui_v6.cpp
@@ -34,6 +34,7 @@
 #include "graphics/paletteman.h"
 #include "graphics/macgui/macwindowmanager.h"
 #include "graphics/surface.h"
+#include "graphics/thumbnail.h"
 
 #include "scumm/scumm.h"
 #include "scumm/detection.h"
@@ -41,6 +42,7 @@
 #include "scumm/imuse_digi/dimuse_engine.h"
 #include "scumm/macgui/macgui_impl.h"
 #include "scumm/macgui/macgui_v6.h"
+#include "scumm/verbs.h"
 
 namespace Scumm {
 
@@ -161,6 +163,12 @@ bool MacV6Gui::handleMenu(int id, Common::String &name) {
 	// handled trivially.
 	if (id == 0)
 		return true;
+
+	if (_vm->_game.id == GID_MANIAC && (id == 200 || id == 201)) {
+		_vm->VAR(_vm->VAR_KEYPRESS) = 5;
+		_vm->runInputScript(kKeyClickArea, 319, 1);
+		return true;
+	}
 
 	// This is how we keep the menu bar visible.
 	Graphics::MacMenu *menu = _windowManager->getMenu();

--- a/engines/scumm/macgui/macgui_v6.h
+++ b/engines/scumm/macgui/macgui_v6.h
@@ -55,6 +55,9 @@ public:
 
 	bool handleEvent(Common::Event event) override;
 
+	bool runOpenDialog(int &saveSlotToHandle) override;
+	bool runSaveDialog(int &saveSlotToHandle, Common::String &saveName) override;
+
 	const Graphics::Font *getFontByScummId(int32 id) override;
 
 	void setupCursor(int &width, int &height, int &hotspotX, int &hotspotY, int &animate) override;
@@ -82,8 +85,6 @@ protected:
 	void setVolume(int type, int volume);
 
 	void runAboutDialog() override;
-	bool runOpenDialog(int &saveSlotToHandle) override;
-	bool runSaveDialog(int &saveSlotToHandle, Common::String &saveName) override;
 	bool runOptionsDialog() override;
 	bool runQuitDialog() override;
 	bool runRestartDialog() override;

--- a/engines/scumm/script_v4.cpp
+++ b/engines/scumm/script_v4.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "scumm/scumm_v4.h"
+#include "scumm/macgui/macgui.h"
 #include "scumm/object.h"
 
 namespace Scumm {
@@ -473,6 +474,14 @@ void ScummEngine_v4::o4_saveLoadGame() {
 			}
 		}
 
+		if (_game.id == GID_MANIAC && _macGui && _currentRoom == saveRoom) {
+			int loadSlot;
+
+			if (!_macGui->runOpenDialog(loadSlot) || loadSlot < 0)
+				return;
+			slot = loadSlot;
+		}
+
 		if (loadState(slot, false))
 			result = 3; // Success
 		else
@@ -496,7 +505,20 @@ void ScummEngine_v4::o4_saveLoadGame() {
 		_lastLoadedRoom = -1;
 		if (_game.version <= 3) {
 			char name[32];
-			if (_game.version <= 2) {
+			if (_game.id == GID_MANIAC && _macGui && _currentRoom == saveRoom) {
+				int saveSlot;
+				bool ok;
+
+				beginTextInput();
+				ok = _macGui->runSaveDialog(saveSlot, dummyName);
+				endTextInput();
+
+				if (!ok || saveSlot < 0)
+					return;
+
+				slot = saveSlot;
+				Common::strlcpy(name, dummyName.c_str(), sizeof(name));
+			} else if (_game.version <= 2) {
 				// V2 and below use a hardcoded name for savestates
 				Common::sprintf_s(name, "Game %c", 'A' + slot - 1);
 			} else {


### PR DESCRIPTION
I don't know if I'll ever be able to complete this by myself...

Maniac Mansion on the Mac handles saving/loading differently, not just than the DOS version but also differently than the other Mac games. Both menu items bring up the original save/load screen, and clicking the save/load buttons there bring up the Mac dialogs. This almost works, with a few caveats:

- The savegame does not get the appropriate thumbnail image. (This is only visible when loading from the ScummVM load dialog.)
- Using the -x command line option to load a saved game immediately brings up the Mac save dialog. Was the game saved in mid-saving, perhaps?

I don't know yet what to do about these, and I don't know if I'm taking the correct approach with the rest either.