### PR TITLE
GLOBAL: Bulk MSVC warning cleanup (Update)

### DIFF
--- a/backends/networking/curl/socket.cpp
+++ b/backends/networking/curl/socket.cpp
@@ -123,7 +123,7 @@ bool CurlSocket::connect(const Common::String &url) {
 
 size_t CurlSocket::send(const char *data, int len) {
 	if (!_socket)
-		return -1;
+		return (size_t)-1;
 
 	size_t nsent_total = 0, left = len;
 	CURLcode res = CURLE_AGAIN;

--- a/common/util.h
+++ b/common/util.h
@@ -55,7 +55,7 @@
 #endif
 
 /** Template method to return the absolute value of @p x. */
-template<typename T> inline T ABS(T x)		{ return (x >= 0) ? x : -x; }
+template<typename T> inline T ABS(T x)		{ return (x >= 0) ? x : 0 - (T)x; } // 0 - (T)x is used instead of -x to silence MSVC C4146
 
 /** Template method to return the smallest of its parameters. */
 template<typename T> inline T MIN(T a, T b)	{ return (a < b) ? a : b; }

--- a/engines/freescape/unpack.cpp
+++ b/engines/freescape/unpack.cpp
@@ -109,6 +109,7 @@ void unpack_data(unsigned char *unpacked_data, unsigned char *buf, unsigned int 
 	unsigned char *save_buf = NULL;
 	unsigned char *save_unp = NULL;
 	unsigned int cur_unpacked_data_size = 0x00;
+	unsigned int data_left = 0x00;
 
 	save_buf = buf;
 	save_unp = unpacked_data;
@@ -141,16 +142,17 @@ void unpack_data(unsigned char *unpacked_data, unsigned char *buf, unsigned int 
 		if ((opcode & 1) == 1) {
 			break;
 		}
-		if (buf - save_buf >= packed_data_len) {
+		data_left = (unsigned int)(buf - save_buf);
+		if (data_left >= packed_data_len) {
 			break;
 		}
 	}
-	if (buf - save_buf < packed_data_len) {
-		if ((packed_data_len - (buf - save_buf)) > (*unpacked_data_size - (unpacked_data - save_unp))) {
+	if (data_left < packed_data_len) {
+		if ((packed_data_len - data_left) > (*unpacked_data_size - (unpacked_data - save_unp))) {
 			debug("Data left are too large!");
 		}
-		memcpy(unpacked_data, buf, packed_data_len - (buf - save_buf));
-		cur_unpacked_data_size += packed_data_len - (buf - save_buf);
+		memcpy(unpacked_data, buf, packed_data_len - data_left);
+		cur_unpacked_data_size += packed_data_len - data_left;
 	}
 	*unpacked_data_size = cur_unpacked_data_size;
 }

--- a/engines/glk/scott/hulk.cpp
+++ b/engines/glk/scott/hulk.cpp
@@ -421,7 +421,7 @@ int tryLoadingHulk(GameInfo info, int dictStart) {
 		_G(_hulkItemImageOffsets) = 0x2731;
 		_G(_hulkLookImageOffsets) = 0x2761;
 		_G(_hulkSpecialImageOffsets) = 0x2781;
-		_G(_hulkImageOffset) = -0x7ff;
+		_G(_hulkImageOffset) = (size_t)-0x7ff;
 	}
 
 	return 1;


### PR DESCRIPTION
This PR builds on the work by elasota in https://github.com/scummvm/scummvm/pull/5128.

The fixes are broken up into multiple commits for clarity, but the summary is:
 - MULTIPLE: Add casts to prevent signed/unsigned conversion and mismatch warnings
 - IMGUI: Use an existing pattern to prevent redefinition of ARRAYSIZE when windows.h is included directly.
 - DIRECTOR,HYPNO,PRIVATE: Remove limit macros from flex skeleton to fix MSVC redefinition warnings
 A fix was checked into flex to fix this issue, but it has not been included in a public release yet. It will be in 2.6.5 whenever that is released. The macros in question are not used in the skeleton and the fix prevents their inclusion. They may be removed them from the generated code with zero impact.
 - DIRECTOR: Fix format warning/remove MSVC-specific
In VS 2015, support was added for the %zX standard to support size_t in printf formats. The MSVC-specific code may be removed as it is no longer needed.
 - SAGA: Fixed a switch statement that can contain no case statements due to code inclusion/exclusion.
 - NANCY,COMMON: Fixed unary minus MSVC warnings
 - LUA: Fixed 32-bit/64-bit shift warning (MSVC)
 - FREESPACE: Fixed mismatch and eliminated instance where same calculation was done multiple times.

Remaining warnings (x64):
engines\tinsel\noir\spriter.cpp(376,11): warning C4146: unary minus operator applied to unsigned type, result still unsigned [...\dists\msvc\tinsel.vcxproj]
engines\tinsel\noir\spriter.cpp(380,11): warning C4146: unary minus operator applied to unsigned type, result still unsigned [...\dists\msvc\tinsel.vcxproj]
common\lua\ldo.cpp(141,3): warning C4611: interaction between '_setjmp' and C++ object destruction is non-portable [...\dists\msvc\scummvm.vcxproj]

Remaining warnings (Win32):
engines\mtropolis\boot.cpp(62,43): warning C4121: 'MTropolis::Boot::Game': alignment of a member was sensitive to packing [...\dists\msvc\mtropolis.vcxproj]
engines\tinsel\noir\spriter.cpp(376,11): warning C4146: unary minus operator applied to unsigned type, result still unsigned [...\dists\msvc\tinsel.vcxproj]
engines\tinsel\noir\spriter.cpp(380,11): warning C4146: unary minus operator applied to unsigned type, result still unsigned [...\dists\msvc\tinsel.vcxproj]
engines\twp\squirrel\sqcompiler.cpp(174,12): warning C4611: interaction between '_setjmp' and C++ object destruction is non-portable [...\dists\msvc\twp.vcxproj]
engines\twp\squirrel\sqstdrex.cpp(568,8): warning C4611: interaction between '_setjmp' and C++ object destruction is non-portable [...\dists\msvc\twp.vcxproj]
engines\twp\syslib.cpp(899,27): warning C4309: 'argument': truncation of constant value [...\dists\msvc\twp.vcxproj]
engines\ultima\ultima4\game\item.h(50,20): warning C4121: 'Ultima::Ultima4::ItemLocation': alignment of a member was sensitive to packing [...\dists\msvc\ultima.vcxproj]
