### PR TITLE
NEVERHOOD: Fix "puzzle solved" sound sometimes being played twice in the H room

### DIFF
--- a/engines/neverhood/modules/module2200.cpp
+++ b/engines/neverhood/modules/module2200.cpp
@@ -659,7 +659,7 @@ void Scene2202::update() {
 	if (_ssDoneMovingCube) {
 		setSurfacePriority(_ssDoneMovingCube->getSurface(), _surfacePriority);
 		_ssDoneMovingCube = nullptr;
-		if (testIsSolved()) {
+		if (!_isCubeMoving && testIsSolved()) {
 			playSound(0);
 			setGlobalVar(V_TILE_PUZZLE_SOLVED, 1);
 			_isSolved = true;


### PR DESCRIPTION
I've run into this several times before, as I'm used to solving this puzzle quickly. The problem is that clicking on the last cube to make the solution _before_ the previous cube has finished moving will cause the winning condition to run twice. Nothing game-breaking, but the "puzzle solved" sound is repeated! I've added an extra check to prevent this.

[Here](https://github.com/user-attachments/files/18396456/neverhood.zip) is a save file for testing (the puzzle is 2 steps away from being solved).

P.S. not sure if this is present in the original exe (unable to test right now), but even if it does, I don't think it should be kept as it's clearly a bug.
