### PR TITLE
SCUMM: Add option for gamma correction (for the Macintosh games)

### DIFF
--- a/engines/scumm/dialogs.cpp
+++ b/engines/scumm/dialogs.cpp
@@ -1183,6 +1183,13 @@ GUI::CheckboxWidget *ScummOptionsContainerWidget::createOriginalGUICheckbox(GuiO
 	);
 }
 
+GUI::CheckboxWidget *ScummOptionsContainerWidget::createGammaCorrectionCheckbox(GuiObject *boss, const Common::String &name) {
+	return new GUI::CheckboxWidget(boss, name,
+		_("Enable gamma correction"),
+		_("Brighten the graphics to simulate a Macintosh monitor.")
+	);
+}
+
 GUI::CheckboxWidget *ScummOptionsContainerWidget::createCopyProtectionCheckbox(GuiObject *boss, const Common::String &name) {
 	return new GUI::CheckboxWidget(boss, name,
 		_("Enable copy protection"),
@@ -1207,9 +1214,7 @@ void ScummOptionsContainerWidget::updateAdjustmentSlider(GUI::SliderWidget *slid
 // SCUMM game settings
 
 ScummGameOptionsWidget::ScummGameOptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain, const ExtraGuiOptions &options) :
-		ScummOptionsContainerWidget(boss, name, "ScummGameOptionsDialog", domain),
-		_options(options), _smoothScrollCheckbox(nullptr),
-		_semiSmoothScrollCheckbox(nullptr) {
+		ScummOptionsContainerWidget(boss, name, "ScummGameOptionsDialog", domain), _options(options) {
 	for (uint i = 0; i < _options.size(); i++) {
 		GUI::CheckboxWidget *checkbox = nullptr;
 		if (strcmp(_options[i].configOption, "enhancements") == 0) {
@@ -1387,7 +1392,7 @@ void LoomEgaGameOptionsWidget::updateOvertureTicksValue() {
 
 // Options for various Mac games
 MacGameOptionsWidget::MacGameOptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain, int gameId, const Common::String &extra) :
-	ScummOptionsContainerWidget(boss, name, "MacGameOptionsWidget", domain), _sndQualitySlider(nullptr), _sndQualityValue(nullptr), _enableOriginalGUICheckbox(nullptr), _enableCopyProtectionCheckbox(nullptr), _quality(0) {
+	ScummOptionsContainerWidget(boss, name, "MacGameOptionsWidget", domain) {
 	GUI::StaticTextWidget *text = new GUI::StaticTextWidget(widgetsBoss(), "MacGameOptionsWidget.SndQualityLabel", _("Music Quality:"));
 	text->setAlign(Graphics::TextAlign::kTextAlignEnd);
 
@@ -1402,6 +1407,7 @@ MacGameOptionsWidget::MacGameOptionsWidget(GuiObject *boss, const Common::String
 	updateQualitySlider();
 	createEnhancementsWidget(widgetsBoss(), "MacGameOptionsWidget");
 	_enableOriginalGUICheckbox = createOriginalGUICheckbox(widgetsBoss(), "MacGameOptionsWidget.EnableOriginalGUI");
+	_enableGammaCorrectionCheckbox = createGammaCorrectionCheckbox(widgetsBoss(), "MacGameOptionsWidget.EnableGammaCorrection");
 
 	if (gameId == GID_MONKEY || gameId == GID_MONKEY2 || (gameId == GID_INDY4 && extra == "Floppy"))
 		_enableCopyProtectionCheckbox = createCopyProtectionCheckbox(widgetsBoss(), "MacGameOptionsWidget.EnableCopyProtection");
@@ -1425,6 +1431,7 @@ void MacGameOptionsWidget::load() {
 	_sndQualitySlider->setValue(_quality);
 	updateQualitySlider();
 	_enableOriginalGUICheckbox->setState(ConfMan.getBool("original_gui", _domain));
+	_enableGammaCorrectionCheckbox->setState(ConfMan.getBool("gamma_correction", _domain));
 
 	if (_enableCopyProtectionCheckbox)
 		_enableCopyProtectionCheckbox->setState(ConfMan.getBool("copy_protection", _domain));
@@ -1434,6 +1441,7 @@ bool MacGameOptionsWidget::save() {
 	bool res = ScummOptionsContainerWidget::save();
 	ConfMan.setInt("mac_snd_quality", _quality, _domain);
 	ConfMan.setBool("original_gui", _enableOriginalGUICheckbox->getState(), _domain);
+	ConfMan.setBool("gamma_correction", _enableGammaCorrectionCheckbox->getState(), _domain);
 
 	if (_enableCopyProtectionCheckbox)
 		ConfMan.setBool("copy_protection", _enableCopyProtectionCheckbox->getState(), _domain);
@@ -1447,7 +1455,8 @@ void MacGameOptionsWidget::defineLayout(GUI::ThemeEval &layouts, const Common::S
 			.addPadding(0, 0, 0, 0)
 			.addLayout(GUI::ThemeLayout::kLayoutVertical, 4)
 				.addPadding(0, 0, 10, 0)
-				.addWidget("EnableOriginalGUI", "Checkbox");
+				.addWidget("EnableOriginalGUI", "Checkbox")
+				.addWidget("EnableGammaCorrection", "Checkbox");
 
 	if (_enableCopyProtectionCheckbox)
 		layouts.addWidget("EnableCopyProtection", "Checkbox");

--- a/engines/scumm/dialogs.h
+++ b/engines/scumm/dialogs.h
@@ -239,11 +239,11 @@ protected:
 	void createEnhancementsWidget(GuiObject *boss, const Common::String &name);
 	GUI::ThemeEval &addEnhancementsLayout(GUI::ThemeEval &layouts) const;
 	GUI::CheckboxWidget *createOriginalGUICheckbox(GuiObject *boss, const Common::String &name);
+	GUI::CheckboxWidget *createGammaCorrectionCheckbox(GuiObject *boss, const Common::String &name);
 	GUI::CheckboxWidget *createCopyProtectionCheckbox(GuiObject *boss, const Common::String &name);
 	void updateAdjustmentSlider(GUI::SliderWidget *slider, GUI::StaticTextWidget *value);
 
 	Common::Array<GUI::CheckboxWidget *> _enhancementsCheckboxes;
-
 };
 
 /**
@@ -262,8 +262,8 @@ private:
 		kSmoothScrollCmd = 'SMSC'
 	};
 
-	GUI::CheckboxWidget *_smoothScrollCheckbox;
-	GUI::CheckboxWidget *_semiSmoothScrollCheckbox;
+	GUI::CheckboxWidget *_smoothScrollCheckbox = nullptr;
+	GUI::CheckboxWidget *_semiSmoothScrollCheckbox = nullptr;
 
 	void defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const override;
 	void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) override;
@@ -291,11 +291,11 @@ private:
 	void defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const override;
 	void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) override;
 
-	GUI::CheckboxWidget *_enableOriginalGUICheckbox;
-	GUI::CheckboxWidget *_enableCopyProtectionCheckbox;
+	GUI::CheckboxWidget *_enableOriginalGUICheckbox = nullptr;
+	GUI::CheckboxWidget *_enableCopyProtectionCheckbox = nullptr;
 
-	GUI::SliderWidget *_overtureTicksSlider;
-	GUI::StaticTextWidget *_overtureTicksValue;
+	GUI::SliderWidget *_overtureTicksSlider = nullptr;
+	GUI::StaticTextWidget *_overtureTicksValue = nullptr;
 
 	void updateOvertureTicksValue();
 };
@@ -318,11 +318,12 @@ private:
 	void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) override;
 	void updateQualitySlider();
 
-	GUI::CheckboxWidget *_enableOriginalGUICheckbox;
-	GUI::CheckboxWidget *_enableCopyProtectionCheckbox;
-	GUI::SliderWidget *_sndQualitySlider;
-	GUI::StaticTextWidget *_sndQualityValue;
-	int _quality;
+	GUI::CheckboxWidget *_enableOriginalGUICheckbox = nullptr;
+	GUI::CheckboxWidget *_enableGammaCorrectionCheckbox = nullptr;
+	GUI::CheckboxWidget *_enableCopyProtectionCheckbox = nullptr;
+	GUI::SliderWidget *_sndQualitySlider = nullptr;
+	GUI::StaticTextWidget *_sndQualityValue = nullptr;
+	int _quality = 0;
 };
 
 /**
@@ -344,10 +345,10 @@ private:
 	void defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const override;
 	void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) override;
 
-	GUI::CheckboxWidget *_enableOriginalGUICheckbox;
+	GUI::CheckboxWidget *_enableOriginalGUICheckbox = nullptr;
 
-	GUI::SliderWidget *_playbackAdjustmentSlider;
-	GUI::StaticTextWidget *_playbackAdjustmentValue;
+	GUI::SliderWidget *_playbackAdjustmentSlider = nullptr;
+	GUI::StaticTextWidget *_playbackAdjustmentValue = nullptr;
 
 	void updatePlaybackAdjustmentValue();
 };
@@ -372,12 +373,12 @@ private:
 	void defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const override;
 	void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) override;
 
-	GUI::CheckboxWidget *_enableOriginalGUICheckbox;
+	GUI::CheckboxWidget *_enableOriginalGUICheckbox = nullptr;
 
-	GUI::SliderWidget *_introAdjustmentSlider;
-	GUI::StaticTextWidget *_introAdjustmentValue;
-	GUI::SliderWidget *_outlookAdjustmentSlider;
-	GUI::StaticTextWidget *_outlookAdjustmentValue;
+	GUI::SliderWidget *_introAdjustmentSlider = nullptr;
+	GUI::StaticTextWidget *_introAdjustmentValue = nullptr;
+	GUI::SliderWidget *_outlookAdjustmentSlider = nullptr;
+	GUI::StaticTextWidget *_outlookAdjustmentValue = nullptr;
 
 	void updateIntroAdjustmentValue();
 	void updateOutlookAdjustmentValue();
@@ -408,24 +409,24 @@ private:
 	void defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const override;
 	void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) override;
 
-	GUI::CheckboxWidget *_audioOverride;
+	GUI::CheckboxWidget *_audioOverride = nullptr;
 
-	GUI::CheckboxWidget *_enableSessionServer;
+	GUI::CheckboxWidget *_enableSessionServer = nullptr;
 
-	GUI::EditTextWidget *_sessionServerAddr;
-	GUI::ButtonWidget *_serverResetButton;
+	GUI::EditTextWidget *_sessionServerAddr = nullptr;
+	GUI::ButtonWidget *_serverResetButton = nullptr;
 
-	GUI::CheckboxWidget *_enableLANBroadcast;
+	GUI::CheckboxWidget *_enableLANBroadcast = nullptr;
 
-	GUI::CheckboxWidget *_generateRandomMaps;
+	GUI::CheckboxWidget *_generateRandomMaps = nullptr;
 
-	GUI::EditTextWidget *_lobbyServerAddr;
+	GUI::EditTextWidget *_lobbyServerAddr = nullptr;
 
 #ifdef USE_LIBCURL
-	GUI::CheckboxWidget *_enableCompetitiveMods;
+	GUI::CheckboxWidget *_enableCompetitiveMods = nullptr;
 #endif
 
-	GUI::StaticTextWidget *_networkVersion;
+	GUI::StaticTextWidget *_networkVersion = nullptr;
 };
 #endif
 

--- a/engines/scumm/macgui/macgui_impl.cpp
+++ b/engines/scumm/macgui/macgui_impl.cpp
@@ -868,14 +868,16 @@ MacGuiImpl::MacDialogWindow *MacGuiImpl::createDialog(int dialogId, Common::Rect
 
 		_windowManager->passPalette(palette.data(), 256);
 
-		for (int i = 0; i < 256; i++) {
-			byte r, g, b;
+		if (_vm->_useGammaCorrection) {
+			for (int i = 0; i < 256; i++) {
+				byte r, g, b;
 
-			palette.get(i, r, g, b);
-			r = _vm->_macGammaCorrectionLookUp[r];
-			g = _vm->_macGammaCorrectionLookUp[g];
-			b = _vm->_macGammaCorrectionLookUp[b];
-			palette.set(i, r, g, b);
+				palette.get(i, r, g, b);
+				r = _vm->_macGammaCorrectionLookUp[r];
+				g = _vm->_macGammaCorrectionLookUp[g];
+				b = _vm->_macGammaCorrectionLookUp[b];
+				palette.set(i, r, g, b);
+			}
 		}
 
 		_system->getPaletteManager()->setPalette(palette);

--- a/engines/scumm/macgui/macgui_v6.cpp
+++ b/engines/scumm/macgui/macgui_v6.cpp
@@ -355,14 +355,16 @@ void MacV6Gui::saveScreen() {
 
 		_windowManager->passPalette(palette.data(), 256);
 
-		for (int i = 0; i < 256; i++) {
-			byte r, g, b;
+		if (_vm->_useGammaCorrection) {
+			for (int i = 0; i < 256; i++) {
+				byte r, g, b;
 
-			palette.get(i, r, g, b);
-			r = _vm->_macGammaCorrectionLookUp[r];
-			g = _vm->_macGammaCorrectionLookUp[g];
-			b = _vm->_macGammaCorrectionLookUp[b];
-			palette.set(i, r, g, b);
+				palette.get(i, r, g, b);
+				r = _vm->_macGammaCorrectionLookUp[r];
+				g = _vm->_macGammaCorrectionLookUp[g];
+				b = _vm->_macGammaCorrectionLookUp[b];
+				palette.set(i, r, g, b);
+			}
 		}
 
 		screen->fillRect(Common::Rect(screen->w, screen->h), getBlack());
@@ -556,9 +558,11 @@ void MacV6Gui::runAboutDialog() {
 		if (r == 0 && g == 0 && b == 0)
 			black = i;
 
-		r = _vm->_macGammaCorrectionLookUp[r];
-		g = _vm->_macGammaCorrectionLookUp[g];
-		b = _vm->_macGammaCorrectionLookUp[b];
+		if (_vm->_useGammaCorrection) {
+			r = _vm->_macGammaCorrectionLookUp[r];
+			g = _vm->_macGammaCorrectionLookUp[g];
+			b = _vm->_macGammaCorrectionLookUp[b];
+		}
 
 		palette.set(i, r, g, b);
 	}

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -752,6 +752,15 @@ static const ExtraGuiOption enableOriginalGUI = {
 	0
 };
 
+static const ExtraGuiOption enableMacintoshGamma = {
+	_s("Enable gamma correction"),
+	_s("Brighten the graphics to simulate a Macintosh monitor."),
+	"gamma_correction",
+	true,
+	0,
+	0
+};
+
 static const ExtraGuiOption enableLowLatencyAudio = {
 	_s("Enable low latency audio mode"),
 	_s("Allows the game to use low latency audio, at the cost of sound accuracy. "
@@ -811,6 +820,10 @@ const ExtraGuiOptions ScummMetaEngine::getExtraGuiOptions(const Common::String &
 
 	if (target.empty() || guiOptions.contains(GAMEOPTION_ORIGINALGUI)) {
 		options.push_back(enableOriginalGUI);
+
+		if (platform == Common::kPlatformMacintosh) {
+			options.push_back(enableMacintoshGamma);
+		}
 	}
 	if (target.empty() || guiOptions.contains(GAMEOPTION_COPY_PROTECTION)) {
 		options.push_back(enableCopyProtection);
@@ -881,6 +894,7 @@ void ScummMetaEngine::registerDefaultSettings(const Common::String &) const {
 		else
 			ConfMan.registerDefault(engineOptions[i].configOption, engineOptions[i].defaultState);
 	}
+	ConfMan.registerDefault("gamma_correction", true);
 }
 
 Common::KeymapArray ScummMetaEngine::initKeymaps(const char *target) const {

--- a/engines/scumm/palette.cpp
+++ b/engines/scumm/palette.cpp
@@ -1726,7 +1726,7 @@ void ScummEngine::updatePalette() {
 #endif
 #endif
 
-	if (_game.platform == Common::kPlatformMacintosh && _game.heversion == 0) {
+	if (_game.platform == Common::kPlatformMacintosh && _game.heversion == 0 && _useGammaCorrection) {
 		for (int i = 0; i < 3 * num; ++i)
 			paletteColors[i] = _macGammaCorrectionLookUp[paletteColors[i]];
 	}

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -195,9 +195,14 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 
 	if (_game.platform == Common::kPlatformMacintosh) {
 		ConfMan.registerDefault("mac_graphics_smoothing", true);
+		ConfMan.registerDefault("gamma_correction", true);
 		if (ConfMan.hasKey("mac_graphics_smoothing", _targetName)) {
 			_useMacGraphicsSmoothing = ConfMan.getBool("mac_graphics_smoothing");
 		}
+	}
+
+	if (ConfMan.hasKey("gamma_correction", _targetName)) {
+		_useGammaCorrection = ConfMan.getBool("gamma_correction");
 	}
 
 	setTimerAndShakeFrequency();

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -1614,6 +1614,8 @@ public:
 	Graphics::Surface _textSurface;
 	int _textSurfaceMultiplier = 0;
 
+	bool _useGammaCorrection = true;
+
 	Graphics::Surface *_macScreen = nullptr;
 	MacGui *_macGui = nullptr;
 	bool _useMacGraphicsSmoothing = true;

--- a/engines/scumm/smush/smush_player.cpp
+++ b/engines/scumm/smush/smush_player.cpp
@@ -1288,8 +1288,11 @@ void SmushPlayer::play(const char *filename, int32 speed, int32 offset, int32 st
 				if (_vm->_macScreen) {
 					byte palette[768];
 					memcpy(palette, _pal, 768);
-					for (int i = 0; i < ARRAYSIZE(palette); i++) {
-						palette[i] = _vm->_macGammaCorrectionLookUp[_pal[i]];
+
+					if (_vm->_useGammaCorrection) {
+						for (int i = 0; i < ARRAYSIZE(palette); i++) {
+							palette[i] = _vm->_macGammaCorrectionLookUp[_pal[i]];
+						}
 					}
 
 					_vm->_system->getPaletteManager()->setPalette(palette + _palDirtyMin * 3, _palDirtyMin, _palDirtyMax - _palDirtyMin + 1);


### PR DESCRIPTION
This adds a checkbox to the options dialog for the Macintosh games that use gamma correction. I haven't had the time to test it much (I haven't looked at what it does to the Humongous Entertainment games at all), but what I've tried seems to work.