### PR TITLE
FREESCAPE: Keep cursor in the middle of the view area when switching to shoot mode

### DIFF
--- a/engines/freescape/freescape.h
+++ b/engines/freescape/freescape.h
@@ -385,6 +385,10 @@ public:
 	int _playerStepIndex;
 	Common::Array<int> _playerSteps;
 
+	Common::Point crossairPosToMousePos(const Common::Point crossairPos);
+	Common::Point mousePosToCrossairPos(const Common::Point mousePos);
+	void warpMouseToCrossair(void);
+
 	// Effects
 	Common::Array<Common::String> _conditionSources;
 	Common::Array<FCLInstructionVector> _conditions;


### PR DESCRIPTION
This change keeps the mouse cursor in the middle of the play area when switching to 'shoot mode' with SPACE. Currently, the cursor jumps to the top left of the view, which feels awkward.