### PR TITLE
DIRECTOR: Fix UBsan and ASan warnings

### DIFF
--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -512,7 +512,7 @@ bool Cast::loadConfig() {
 		check *= field25 + 25;
 		check += _frameRate + 26;
 		check *= platform + 27;
-		check *= (protection * 0xE06) + 0xFFF450000;
+		check *= (protection * 0xE06) + 0xFF450000u;
 		check ^= MKTAG('r', 'a', 'l', 'f');
 
 		if (check != checksum)

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -304,7 +304,7 @@ void readSpriteDataD2(Common::SeekableReadStreamEndian &stream, Sprite &sprite, 
 				stream.readByte();
 			} else {
 				// Normalize D2 and D3 colors from -128 ... 127 to 0 ... 255.
-				sprite._foreColor = g_director->transformColor((128 + stream.readByte()) & 0xff);
+				sprite._foreColor = g_director->transformColor(stream.readByte() ^ 0x80);
 			}
 			break;
 		case 3:
@@ -312,7 +312,7 @@ void readSpriteDataD2(Common::SeekableReadStreamEndian &stream, Sprite &sprite, 
 				stream.readByte();
 			} else {
 				// Normalize D2 and D3 colors from -128 ... 127 to 0 ... 255.
-				sprite._backColor = g_director->transformColor((128 + stream.readByte()) & 0xff);
+				sprite._backColor = g_director->transformColor(stream.readByte() ^ 0x80);
 			}
 			break;
 		case 4:
@@ -506,8 +506,8 @@ void Frame::readMainChannelsD4(Common::MemoryReadStreamEndian &stream, uint16 of
 			break;
 		case 22:
 			// loop points for color cycling
-			_mainChannels.palette.firstColor = g_director->transformColor(stream.readByte() + 0x80); // 22
-			_mainChannels.palette.lastColor = g_director->transformColor(stream.readByte() + 0x80); // 23
+			_mainChannels.palette.firstColor = g_director->transformColor(stream.readByte() ^ 0x80); // 22
+			_mainChannels.palette.lastColor = g_director->transformColor(stream.readByte() ^ 0x80); // 23
 			break;
 		case 24:
 			_mainChannels.palette.flags = stream.readByte(); // 24
@@ -826,8 +826,8 @@ void Frame::readMainChannelsD5(Common::MemoryReadStreamEndian &stream, uint16 of
 			_mainChannels.palette.overTime = (_mainChannels.palette.flags & 0x04) != 0;
 			break;
 		case 30:
-			_mainChannels.palette.firstColor = g_director->transformColor(stream.readByte() + 0x80); // 30
-			_mainChannels.palette.lastColor = g_director->transformColor(stream.readByte() + 0x80); // 31
+			_mainChannels.palette.firstColor = g_director->transformColor(stream.readByte() ^ 0x80); // 30
+			_mainChannels.palette.lastColor = g_director->transformColor(stream.readByte() ^ 0x80); // 31
 			break;
 		case 32:
 			_mainChannels.palette.frameCount = stream.readUint16(); // 32


### PR DESCRIPTION
When debugging the Dark Eye crash on Android I met these two errors in ASan and UBSan.
First, an out of bound read in transformColor because the color read is added 0x80 but (as the tranformColor argument type is uint32) overflows the engine current palette.

Then, the checksum calculation raises an undefined behaviour error because the constant used for the multiplication was too big.