### PR TITLE
CONFIGURE: Warn if the stack frames are too large

### DIFF
--- a/configure
+++ b/configure
@@ -2639,6 +2639,10 @@ EOF
 
 set_flag_if_supported -Wglobal-constructors
 
+# 307200 is a 640x480 CLUT8 buffer.
+# It's an arbitrary not too large but not too small either value.
+set_flag_if_supported -Wframe-larger-than=307200
+
 # If the compiler supports the -Wundefined-var-template flag, silence that warning.
 # We get this warning a lot with regard to the Singleton class as we explicitly
 # instantiate each specialisation. An alternate way to deal with it would be to

--- a/engines/tony/window.h
+++ b/engines/tony/window.h
@@ -36,9 +36,15 @@ namespace Tony {
 
 class RMSnapshot {
 private:
+	static const int BUFFER_SIZE = RM_SX *RM_SY * 3;
 	// Buffer used to convert to RGB
-	byte _rgb[RM_SX *RM_SY * 3];
+	byte *_rgb;
 public:
+	RMSnapshot() : _rgb(new byte[BUFFER_SIZE]) {}
+	~RMSnapshot() {
+		delete[] _rgb;
+	}
+
 	/**
 	 * Take a screenshot
 	 */

--- a/engines/twp/vm.cpp
+++ b/engines/twp/vm.cpp
@@ -61,10 +61,10 @@ static SQInteger aux_printerror(HSQUIRRELVM v) {
 }
 
 static void printfunc(HSQUIRRELVM, const SQChar *s, ...) {
-	char buf[1024 * 1024];
+	char buf[100 * 1024];
 	va_list vl;
 	va_start(vl, s);
-	vsnprintf(buf, 1024 * 1024, s, vl);
+	vsnprintf(buf, 100 * 1024, s, vl);
 	va_end(vl);
 
 	debug("TWP: %s", buf);


### PR DESCRIPTION
Following the (hard to debug) crash we got on Android due to a stack overflow, I think it could be good to be warned when the functions allocate too much memory on the stack.
In order to not start a huge witch hunt, I propose to begin with an arbitrary value of 300KB (which is a 640x480@8 buffer) and maybe lower this value in the future if there is a need.

This allowed me to detect 3 cases of huge allocations which are fixed in this PR.
For TWP, the buffer size is shrunk as I believe it was generously allocated.
For the other cases, I allocate on the heap the buffer instead.

This would have warned us for the Director case I fixed earlier.

The warning flag is supported since the dawn of time in GCC but on Clang it's more recent (though I could not identify the exact version).