### PR TITLE
TINYGL: Expose TinyGL API for scissor test

### DIFF
--- a/engines/freescape/gfx_tinygl.cpp
+++ b/engines/freescape/gfx_tinygl.cpp
@@ -85,11 +85,14 @@ void TinyGLRenderer::init() {
 	_lastColorSet0 = 0;
 	_lastColorSet1 = 0;
 	_stippleTexture = nullptr;
+
+	tglEnable(TGL_SCISSOR_TEST);
 }
 
 void TinyGLRenderer::setViewport(const Common::Rect &rect) {
 	_viewport = rect;
 	tglViewport(rect.left, g_system->getHeight() - rect.bottom, rect.width(), rect.height());
+	tglScissor(rect.left, g_system->getHeight() - rect.bottom, rect.width(), rect.height());
 }
 
 void TinyGLRenderer::drawTexturedRect2D(const Common::Rect &screenRect, const Common::Rect &textureRect, Texture *texture) {
@@ -533,46 +536,12 @@ void TinyGLRenderer::useColor(uint8 r, uint8 g, uint8 b) {
 }
 
 void TinyGLRenderer::clear(uint8 r, uint8 g, uint8 b, bool ignoreViewport) {
-	tglClear(TGL_DEPTH_BUFFER_BIT | TGL_STENCIL_BITS);
-	if (ignoreViewport) {
-		tglClearColor(r / 255., g / 255., b / 255., 1.0);
-		tglClear(TGL_COLOR_BUFFER_BIT);
-	} else {
-		// Create a viewport sized quad and color it
-		useColor(r, g, b);
-
-		tglMatrixMode(TGL_PROJECTION);
-		tglPushMatrix();
-		tglLoadIdentity();
-
-		tglOrtho(0, _viewport.width(), _viewport.height(), 0, 0, 1);
-		tglMatrixMode(TGL_MODELVIEW);
-		tglPushMatrix();
-		tglLoadIdentity();
-
-		tglDisable(TGL_DEPTH_TEST);
-		tglDepthMask(TGL_FALSE);
-
-		tglEnableClientState(TGL_VERTEX_ARRAY);
-		copyToVertexArray(0, Math::Vector3d(0, 0, 0));
-		copyToVertexArray(1, Math::Vector3d(0, _viewport.height(), 0));
-		copyToVertexArray(2, Math::Vector3d(_viewport.width(), _viewport.height(), 0));
-
-		copyToVertexArray(3, Math::Vector3d(0, 0, 0));
-		copyToVertexArray(4, Math::Vector3d(_viewport.width(), 0, 0));
-		copyToVertexArray(5, Math::Vector3d(_viewport.width(), _viewport.height(), 0));
-
-		tglVertexPointer(3, TGL_FLOAT, 0, _verts);
-		tglDrawArrays(TGL_TRIANGLES, 0, 6);
-		tglDisableClientState(TGL_VERTEX_ARRAY);
-
-		tglEnable(TGL_DEPTH_TEST);
-		tglDepthMask(TGL_TRUE);
-
-		tglPopMatrix();
-		tglMatrixMode(TGL_PROJECTION);
-		tglPopMatrix();
-	}
+	if (ignoreViewport)
+ 		tglDisable(TGL_SCISSOR_TEST);
+ 	tglClearColor(r / 255., g / 255., b / 255., 1.0);
+ 	tglClear(TGL_COLOR_BUFFER_BIT | TGL_DEPTH_BUFFER_BIT | TGL_STENCIL_BUFFER_BIT);
+ 	if (ignoreViewport)
+ 		tglEnable(TGL_SCISSOR_TEST);
 }
 
 void TinyGLRenderer::drawFloor(uint8 color) {

--- a/graphics/tinygl/api.cpp
+++ b/graphics/tinygl/api.cpp
@@ -670,6 +670,19 @@ void tglFlush() {
 	// nothing to do
 }
 
+void tglScissor(TGLint x, TGLint y, TGLsizei width, TGLsizei height) {
+	TinyGL::GLContext *c = TinyGL::gl_get_context();
+	TinyGL::GLParam p[5];
+
+	p[0].op = TinyGL::OP_Scissor;
+	p[1].i = x;
+	p[2].i = y;
+	p[3].i = width;
+	p[4].i = height;
+
+	c->gl_add_op(p);
+}
+
 void tglHint(TGLenum target, TGLenum mode) {
 	TinyGL::GLContext *c = TinyGL::gl_get_context();
 	TinyGL::GLParam p[3];

--- a/graphics/tinygl/get.cpp
+++ b/graphics/tinygl/get.cpp
@@ -674,7 +674,9 @@ void GLContext::gl_get_pname(TGLenum pname, union uglValue *data, eDataType &dat
 	case TGL_SCISSOR_BOX:
 		// fall through
 	case TGL_SCISSOR_TEST:
-		error("gl_get_pname: TGL_SCISSOR_x option not implemented");
+		// error("gl_get_pname: TGL_SCISSOR_x option not implemented");
+		data->_int = (TGLint)scissor_test_enabled;
+		dataType = kIntType;
 		break;
 	case TGL_SELECTION_BUFFER_SIZE:
 		error("gl_get_pname: TGL_SELECTION_BUFFER_SIZE option not implemented");

--- a/graphics/tinygl/get.cpp
+++ b/graphics/tinygl/get.cpp
@@ -672,9 +672,9 @@ void GLContext::gl_get_pname(TGLenum pname, union uglValue *data, eDataType &dat
 		dataType = kIntType;
 		break;
 	case TGL_SCISSOR_BOX:
-		// fall through
+		error("gl_get_pname: TGL_SCISSOR_BOX option not implemented");
+		break;
 	case TGL_SCISSOR_TEST:
-		// error("gl_get_pname: TGL_SCISSOR_x option not implemented");
 		data->_int = (TGLint)scissor_test_enabled;
 		dataType = kIntType;
 		break;

--- a/graphics/tinygl/init.cpp
+++ b/graphics/tinygl/init.cpp
@@ -358,6 +358,9 @@ void GLContext::init(int screenW, int screenH, Graphics::PixelFormat pixelFormat
 	_debugRectsEnabled = false;
 	_profilingEnabled = false;
 
+	// scissor test
+	scissor_test_enabled = false;
+
 	TinyGL::Internal::tglBlitResetScissorRect();
 }
 

--- a/graphics/tinygl/misc.cpp
+++ b/graphics/tinygl/misc.cpp
@@ -102,6 +102,9 @@ void GLContext::glopEnableDisable(GLParam *p) {
 	case TGL_BLEND:
 		blending_enabled = v != 0;
 		break;
+	case TGL_SCISSOR_TEST:
+		scissor_test_enabled = v != 0;
+		break;
 	case TGL_POLYGON_OFFSET_FILL:
 		if (v)
 			offset_states |= TGL_OFFSET_FILL;
@@ -198,6 +201,16 @@ void GLContext::glopPolygonMode(GLParam *p) {
 	default:
 		assert(0);
 	}
+}
+
+void GLContext::glopScissor(GLParam *p) {
+	// top left corner
+	_scissorTestRect.top = p[2].i;
+	_scissorTestRect.left = p[1].i;
+
+	// bottom right corner
+	_scissorTestRect.bottom = p[4].i;
+	_scissorTestRect.right = p[3].i;
 }
 
 void GLContext::glopHint(GLParam *) {

--- a/graphics/tinygl/opinfo.h
+++ b/graphics/tinygl/opinfo.h
@@ -56,6 +56,8 @@ ADD_OP(ColorMaterial, 2, "%C %C")
 ADD_OP(Light, 6, "%C %C %f %f %f %f")
 ADD_OP(LightModel, 5, "%C %f %f %f %f")
 
+ADD_OP(Scissor, 4, "%d %d %d %d")
+
 ADD_OP(Clear, 1, "%d")
 ADD_OP(ClearColor, 4, "%f %f %f %f")
 ADD_OP(ClearDepth, 1, "%f")

--- a/graphics/tinygl/zbuffer.h
+++ b/graphics/tinygl/zbuffer.h
@@ -107,6 +107,14 @@ struct FrameBuffer {
 	FrameBuffer(int width, int height, const Graphics::PixelFormat &format, bool enableStencilBuffer);
 	~FrameBuffer();
 
+	bool getScissorTestEnabled() {
+		return _enableScissorTest;
+	}
+
+	Common::Rect getScissorTestRectangle() {
+		return _scissorTestRectangle;
+	}
+
 	Graphics::PixelFormat getPixelFormat() {
 		return _pbufFormat;
 	}
@@ -620,6 +628,14 @@ public:
 		_polygonStippleEnabled = enable;
 	}
 
+	void enableScissorTest(bool enable) {
+		_enableScissorTest = enable;
+	}
+
+	void setScissorTestRectangle(Common::Rect rect) {
+		_scissorTestRectangle = rect;
+	}
+
 	void setPolygonStipplePattern(const byte *stipple) {
 		_polygonStipplePattern = stipple;
 	}
@@ -769,8 +785,13 @@ private:
 	int _textureSize;
 	int _textureSizeMask;
 
+	// used by internal implementation
 	Common::Rect _clipRectangle;
 	bool _enableScissor;
+
+	// scissor test set by API
+	Common::Rect _scissorTestRectangle;
+	bool _enableScissorTest;
 
 	const TexelBuffer *_currentTexture;
 	uint _wrapS, _wrapT;

--- a/graphics/tinygl/zbuffer.h
+++ b/graphics/tinygl/zbuffer.h
@@ -396,7 +396,10 @@ private:
 	}
 
 	FORCEINLINE bool scissorPixel(int x, int y) {
-		return !_clipRectangle.contains(x, y);
+		Common::Rect r = _clipRectangle;
+	    if(_enableScissorTest) r = _scissorTestRectangle.findIntersectingRect(_clipRectangle);
+
+		return !r.contains(x, y);
 	}
 
 public:

--- a/graphics/tinygl/zdirtyrect.cpp
+++ b/graphics/tinygl/zdirtyrect.cpp
@@ -560,10 +560,7 @@ void RasterizationDrawCall::applyState(const RasterizationDrawCall::Rasterizatio
 
 void RasterizationDrawCall::execute(const Common::Rect &clippingRectangle, bool restoreState) const {
 	TinyGL::GLContext *c = gl_get_context();
-
-	// set scissor rectangle here
-	c->fb->setScissorRectangle(c->fb->getScissorTestEnabled() ? c->fb->getScissorTestRectangle() : clippingRectangle);
-
+	c->fb->setScissorRectangle(clippingRectangle);
 	execute(restoreState);
 	c->fb->resetScissorRectangle();
 }

--- a/graphics/tinygl/zdirtyrect.h
+++ b/graphics/tinygl/zdirtyrect.h
@@ -130,6 +130,11 @@ private:
 		bool alphaTestEnabled;
 		int alphaFunc;
 		int alphaRefValue;
+
+		// scissor test
+		bool scissorTestEnabled;
+		Common::Rect scissorRect;
+
 		bool stencilTestEnabled;
 		int stencilTestFunc;
 		int stencilValue;
@@ -191,6 +196,8 @@ private:
 		bool alphaTest;
 		int alphaFunc, alphaRefValue;
 		int depthTestEnabled;
+		bool scissorTestEnabled;
+		Common::Rect scissorRect;
 
 		bool operator==(const BlittingState &other) const {
 			return
@@ -200,7 +207,10 @@ private:
 				alphaTest == other.alphaTest &&
 				alphaFunc == other.alphaFunc &&
 				alphaRefValue == other.alphaRefValue &&
-				depthTestEnabled == other.depthTestEnabled;
+				depthTestEnabled == other.depthTestEnabled &&
+				// should scissor test be compared here?
+				scissorTestEnabled == other.scissorTestEnabled &&
+				scissorRect == other.scissorRect;
 		}
 	};
 

--- a/graphics/tinygl/zgl.h
+++ b/graphics/tinygl/zgl.h
@@ -448,7 +448,12 @@ struct GLContext {
 	float fog_start;
 	float fog_end;
 
+	// implementation uses and modifies _scissorRect. See `tglBlitSetScissorRect`
 	Common::Rect _scissorRect;
+
+	// set by API
+	bool scissor_test_enabled;
+	Common::Rect _scissorTestRect;
 
 	bool _enableDirtyRectangles;
 


### PR DESCRIPTION
This PR exposes TinyGL's API for `tglScissor()` and `tglEnable/Disable(TGL_SCISSOR_TEST)`. I have currently tested the commit on freescape's total eclipse demo. The commit works for rasterization, however scissor test for clearing (screen clear color) and blitting needs to be fixed. I have added comments to the sections of the code where clearing and blitting occur. The relevant caller to these functions is [here](https://github.com/scummvm/scummvm/blob/master/graphics/tinygl/zdirtyrect.cpp#L200). This will require some inspection of the clear and blitting code.

Example rasterized output when using a half viewport sized scissor:

![Pasted image 20250125235641](https://github.com/user-attachments/assets/af55e462-8e13-4c0e-aa1f-bfd8ad09c172)

Output of the Freescape Total Eclipse demo with commits applied (scissor for clear color needs to be implemented):

![Pasted image 20250126010318](https://github.com/user-attachments/assets/f27c8406-aff3-41a1-9d67-e59967c2bba9)

Expected Output (current Freescape TinyGL implementation uses a hack for clearing color by coloring a viewport sized quad):

![image](https://github.com/user-attachments/assets/97b63fe6-eff5-40e9-8462-39b571e4b507)

Additionally, the implementation should decide whether to provide a default scissor rectangle in case `tglEnable(TGL_SCISSOR_TEST)` is called but `tglScissor` is never called (need to check from OpenGL documentation). Currently, this will lead to no output drawn, since `Common::Rect` will have no dimensions by default.