### PR TITLE
IMAGE: Fix TGA color map loading

### DIFF
--- a/engines/wintermute/base/gfx/base_image.cpp
+++ b/engines/wintermute/base/gfx/base_image.cpp
@@ -46,7 +46,6 @@ namespace Wintermute {
 BaseImage::BaseImage() {
 	_fileManager = BaseFileManager::getEngineInstance();
 	_palette = nullptr;
-	_paletteTga = nullptr;
 	_paletteCount = 0;
 	_surface = nullptr;
 	_decoder = nullptr;
@@ -61,8 +60,6 @@ BaseImage::~BaseImage() {
 		_deletableSurface->free();
 	}
 	delete _deletableSurface;
-	delete _paletteTga;
-	_paletteTga = nullptr;
 }
 
 bool BaseImage::loadFile(const Common::String &filename) {
@@ -90,20 +87,6 @@ bool BaseImage::loadFile(const Common::String &filename) {
 	_palette = _decoder->getPalette();
 	_paletteCount = _decoder->getPaletteColorCount();
 	_fileManager->closeFile(file);
-
-	//
-	// W/A: ScummVM TGA decoder interpreting palette as RGB, but TGA format should be as BGR
-	// So, swap R and B color components
-	//
-	if (_filename.hasSuffix(".tga")) {
-		_paletteTga = new byte[_paletteCount * 3];
-		for (uint32 i = 0; i < _paletteCount * 3; i += 3) {
-			_paletteTga[i + 0] = _palette[i + 2];
-			_paletteTga[i + 1] = _palette[i + 1];
-			_paletteTga[i + 2] = _palette[i + 0];
-		}
-		_palette = _paletteTga;
-	}
 
 	return true;
 }

--- a/engines/wintermute/base/gfx/base_image.h
+++ b/engines/wintermute/base/gfx/base_image.h
@@ -70,7 +70,6 @@ private:
 	const Graphics::Surface *_surface;
 	Graphics::Surface *_deletableSurface;
 	const byte *_palette;
-	byte *_paletteTga;
 	uint16 _paletteCount;
 	BaseFileManager *_fileManager;
 };

--- a/image/tga.cpp
+++ b/image/tga.cpp
@@ -186,32 +186,26 @@ bool TGADecoder::readColorMap(Common::SeekableReadStream &tga, byte imageType, b
 	for (int i = 0; i < _colorMapLength * 3; i += 3) {
 		byte r, g, b;
 		if (_colorMapEntryLength == 32) {
-			byte a;
-			Graphics::PixelFormat format(4, 8, 8, 8, 0, 16, 8, 0, 24);
-			uint32 color = tga.readUint32LE();
-			format.colorToARGB(color, a, r, g, b);
-		} else if (_colorMapEntryLength == 24) {
-			r = tga.readByte();
-			g = tga.readByte();
 			b = tga.readByte();
+			g = tga.readByte();
+			r = tga.readByte();
+			tga.readByte(); // for alpha
+		} else if (_colorMapEntryLength == 24) {
+			b = tga.readByte();
+			g = tga.readByte();
+			r = tga.readByte();
 		} else if (_colorMapEntryLength == 16) {
 			byte a;
-			Graphics::PixelFormat format(2, 5, 5, 5, 0, 10, 5, 0, 15);
+			static const Graphics::PixelFormat format(2, 5, 5, 5, 0, 10, 5, 0, 15);
 			uint16 color = tga.readUint16LE();
 			format.colorToARGB(color, a, r, g, b);
 		} else {
 			warning("Unsupported image type: %d", imageType);
 			r = g = b = 0;
 		}
-#ifdef SCUMM_LITTLE_ENDIAN
 		_colorMap[i] = r;
 		_colorMap[i + 1] = g;
 		_colorMap[i + 2] = b;
-#else
-		_colorMap[i] = b;
-		_colorMap[i + 1] = g;
-		_colorMap[i + 2] = r;
-#endif
 	}
 	return true;
 }


### PR DESCRIPTION
Fixes the TGA image loader to comply with requirements about getPalette (should return an RGB interleaved palette).
The requirement has been added in commit c839fd50b5ddfcceada8cbbd3046ce219df248a0 (Sun Aug 12 2012) while the TGA decoder has been introduced by @somaen in PR #263 around the same dates so I suppose things crossed.

This partially reverts the commit 4624dc9116cf77ab83e387f7d95d041511071e3d to remove any workaround due to this bug.

The TGADecoder is used by the following engines:
- AGS (using getPalette without any workaround for TGA)
- Grim (using getPalette without any workaround for TGA)
- HPL1 (not using getPalette)
- QDEngine (not using getPalette)
- Tetraedge (not using getPalette)
- Titanic (not using getPalette)
- Watchmaker (not using getPalette)
- Wintermute (fixed)
- ZVision (not using getPalette)