### PR TITLE
TETRAEDGE: Don't declare OpenGL with shaders as supported

### DIFF
--- a/engines/tetraedge/tetraedge.cpp
+++ b/engines/tetraedge/tetraedge.cpp
@@ -345,18 +345,12 @@ Graphics::RendererType TetraedgeEngine::preferredRendererType() const {
 #if defined(USE_OPENGL_GAME)
 			Graphics::kRendererTypeOpenGL |
 #endif
-#if defined(USE_OPENGL_SHADERS)
-			Graphics::kRendererTypeOpenGLShaders |
-#endif
 #if defined(USE_TINYGL)
 			Graphics::kRendererTypeTinyGL |
 #endif
 			0;
 
 	Graphics::RendererType matchingRendererType = Graphics::Renderer::getBestMatchingType(desiredRendererType, availableRendererTypes);
-	// Currently no difference between shaders and otherwise for this engine.
-	if (matchingRendererType == Graphics::kRendererTypeOpenGLShaders)
-		matchingRendererType = Graphics::kRendererTypeOpenGL;
 
 	if (matchingRendererType == 0) {
 		error("No supported renderer available.");


### PR DESCRIPTION
And don't try to fallback on classic OpenGL as it's not always available.
This avoids the engine to error out on Android.
Instead, the getBestMatchingType falls back on TinyGL.