### PR TITLE
ENGINES: Use LiberationSans for subtitles instead of FreeSans

### DIFF
--- a/engines/agos/animation.cpp
+++ b/engines/agos/animation.cpp
@@ -421,7 +421,7 @@ MoviePlayerSMK::MoviePlayerSMK(AGOSEngine_Feeble *vm, const char *name)
 
 	_subtitles.setBBox(Common::Rect(20, h - 120, g_system->getOverlayWidth() - 20, h - 20));
 	_subtitles.setColor(0xff, 0xff, 0xff);
-	_subtitles.setFont("FreeSans.ttf");
+	_subtitles.setFont("LiberationSans-Regular.ttf");
 }
 
 bool MoviePlayerSMK::load() {

--- a/engines/groovie/video/player.cpp
+++ b/engines/groovie/video/player.cpp
@@ -39,7 +39,7 @@ VideoPlayer::VideoPlayer(GroovieEngine *vm) :
 
 	_subtitles.setBBox(Common::Rect(20, h - 120, g_system->getOverlayWidth() - 20, h - 20));
 	_subtitles.setColor(0xff, 0xff, 0xff);
-	_subtitles.setFont("FreeSans.ttf");
+	_subtitles.setFont("LiberationSans-Regular.ttf");
 }
 
 bool VideoPlayer::load(Common::SeekableReadStream *file, uint16 flags) {

--- a/engines/mohawk/video.cpp
+++ b/engines/mohawk/video.cpp
@@ -135,7 +135,7 @@ void VideoEntry::start() {
 			        w = g_system->getOverlayWidth();
 		_subtitles.setBBox(Common::Rect(20, h - 120, w - 20, h - 20));
 		_subtitles.setColor(0xff, 0xff, 0xff);
-		_subtitles.setFont("FreeSans.ttf");
+		_subtitles.setFont("LiberationSans-Regular.ttf");
 
 		g_system->showOverlay(false);
 		g_system->clearOverlay();

--- a/engines/sci/graphics/video32.cpp
+++ b/engines/sci/graphics/video32.cpp
@@ -149,7 +149,7 @@ VideoPlayer::EventFlags VideoPlayer::playUntilEvent(const EventFlags flags, cons
 	if (_subtitles.isLoaded()) {
 		setSubtitlePosition();
 		_subtitles.setColor(0xff, 0xff, 0xff);
-		_subtitles.setFont("FreeSans.ttf");
+		_subtitles.setFont("LiberationSans-Regular.ttf");
 
 		g_system->clearOverlay();
 		g_system->showOverlay(false);


### PR DESCRIPTION
Unfortunately, I don't know how to test this.