### PR TITLE
DISTS: Add Bash tab completions script for ScummVM

### DIFF
--- a/dists/bash-completions/README
+++ b/dists/bash-completions/README
@@ -14,10 +14,11 @@ something like this:
     #     . /etc/bash_completion
     # fi
 
-Uncomment the last three lines. This will the custom tab completions
-for everthing included in the bash-completion package.
+Uncomment the last three lines. This will enable the custom tab completions
+for everything included in the bash-completion package.
 
 Create ~/.local/share/bash-completions/completions if you don't
 already have it, and copy the tab completion script (scummvm) to it.
 Any newly started Bash shell should now have custom completions for
-ScummVM.
+ScummVM. You can also run "source ~/.bashrc" to update your current
+shell process.

--- a/dists/bash-completions/README
+++ b/dists/bash-completions/README
@@ -1,0 +1,23 @@
+Custom Tab completions for the bash shell. This depends on the
+bash-completion package. Consult the documentation for that for how to
+enable this.
+
+Example for how to enable it for a single user in Debian GNU/Linux:
+
+If your ~/.bashrc was automatically generated, it probably contains
+something like this:
+
+    # enable programmable completion features (you don't need to enable
+    # this, if it's already enabled in /etc/bash.bashrc and /etc/profiles
+    # sources /etc/bash.bashrc).
+    # if [ -f /etc/bash_completion ]; then
+    #     . /etc/bash_completion
+    # fi
+
+Uncomment the last three lines. This will the custom tab completions
+for everthing included in the bash-completion package.
+
+Create ~/.local/share/bash-completions/completions if you don't
+already have it, and copy the tab completion script (scummvm) to it.
+Any newly started Bash shell should now have custom completions for
+ScummVM.

--- a/dists/bash-completions/scummvm
+++ b/dists/bash-completions/scummvm
@@ -47,7 +47,7 @@ _scummvm()
         # Try our old, now downright ancient, configuration path
         scummvm_config=${HOME}/.scummvmrc
 
-	if [[ ! -f ${scummvm_config} ]]; then
+        if [[ ! -f ${scummvm_config} ]]; then
             if [[ -n ${XDG_CONFIG_HOME} ]]; then
                 scummvm_config=${XDG_CONFIG_HOME}/scummvm/scummvm.ini
             elif [[ -n ${HOME} ]]; then

--- a/dists/bash-completions/scummvm
+++ b/dists/bash-completions/scummvm
@@ -1,0 +1,86 @@
+_scummvm()
+{
+    local opt_name
+    _init_completion || return
+
+    # If it's in the middle of a long option, offer completions for that. I'm
+    # adding these as an example until we figure which ones we want.
+
+    if [[ ${cur} == --* ]]; then
+       COMPREPLY=($(compgen -W "--debugflags= --debug-channels-only" -- "${cur}"))
+
+       # If the match ends with "=" we want to continue typing from there
+       # without any space at the end. This seems a bit peculiar to me, because
+       # it will apply to multiple matches, but it's the way that was suggested
+       # to me.
+
+       if [[ ${COMPREPLY[@]} =~ "=" ]]; then
+           compopt -o nospace
+       fi
+       
+       return;
+    fi
+
+    # Handle command line options. Short options are converted into their long
+    # form, and for long options we extract the option being used. At the point
+    # where we can do tab completion on a long option, ${prev} will be "=" so
+    # we have to look further back.
+
+    case ${prev} in
+        -e)
+            opt_name=music-driver
+            ;;
+        =)
+            opt_name=${COMP_WORDS[COMP_CWORD-2]}
+            if [[ ${opt_name} != --* ]]; then
+                return;
+            fi
+            opt_name="${opt_name#--}"
+            ;;
+    esac
+
+    # If it's not an option, try matching a target from the scummvm.init file.
+
+    if [[ -z ${opt_name} ]] && [[ ${cur} != -* ]]; then
+        local scummvm_config
+
+        # Try our old, now downright ancient, configuration path
+        scummvm_config=${HOME}/.scummvmrc
+
+	if [[ ! -f ${scummvm_config} ]]; then
+            if [[ -n ${XDG_CONFIG_HOME} ]]; then
+                scummvm_config=${XDG_CONFIG_HOME}/scummvm/scummvm.ini
+            elif [[ -n ${HOME} ]]; then
+                scummvm_config=${HOME}/.config/scummvm/scummvm.ini
+            else
+                return;
+            fi
+        fi
+
+        if [[ -f ${scummvm_config} ]]; then
+            games=$(sed -n '/^\[scummvm\]/!s/^\[\([^]]*\)\]/\1/p' ${scummvm_config})
+            COMPREPLY=($(compgen -W "${games}" -- "${cur}"))
+        fi
+
+        return;
+    fi
+
+    # Completions for various option values. Not everything, just the ones I
+    # thought were the most useful.
+
+    local opts
+
+    case ${opt_name} in
+        music-driver)
+            opts='fluidsynth mt32 eas null mac towns pc98 segacd adlib core riscos camd sndio seq coremidi stmidi dmedia alsa timidity windows'
+            ;;
+        render-mode)
+            opts='hercGreen hercAmber cga cgaComp cgaBW ega vga amiga fmtowns pc98-256c pc98-16c pc98-8c 2gs atari macintosh macintoshbw cpc zx c64 vgaGrey win256c win16c'
+            ;;
+    esac
+
+    if [[ -n ${opts} ]]; then
+        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
+    fi
+} &&
+    complete -F _scummvm scummvm


### PR DESCRIPTION
This is my attempt at adding a custom tab completions script for ScummVM, using the infrastructure provided by the bash-completions package. It is just an initial version that hopefully contains all the plumbing to easily add what we want.

It's the first time I've tried writing something like this, and I'm not good at Bash scripting to begin with. If it's correct, it's because I've looked at a lot of simple examples. If it's wrong, it's because I still did not understand them.

What I've added examples of so far:

- Some long options are completed. If they end with a "=" the space after the completion is suppressed.
- Some parameters to long and short options alike are completed.
- Domains from the scummvm.ini file are completed, except for "scummvm" itself since that isn't a game.

So basically, everything I personally want from it is there now. Question is, what do others want from it?
