### PR TITLE
Add emulator category

### DIFF
--- a/dists/org.scummvm.scummvm.desktop
+++ b/dists/org.scummvm.scummvm.desktop
@@ -11,6 +11,6 @@ Exec=scummvm
 Icon=org.scummvm.scummvm
 Terminal=false
 Type=Application
-Categories=Game;AdventureGame;
+Categories=Game;AdventureGame;Emulator;
 StartupNotify=false
 StartupWMClass=scummvm


### PR DESCRIPTION
This changes the desktop file for linux in particular for flathub.

While I understand, that this is not an emulator, I think it makes sense to show it next to/with other emulators.