### PR TITLE
SCUMM: MACGUI: Disable Maniac Mansion Mac GUI while paused

### DIFF
--- a/engines/scumm/gfx_gui.cpp
+++ b/engines/scumm/gfx_gui.cpp
@@ -333,6 +333,8 @@ Common::KeyState ScummEngine::printMessageAndPause(const char *msg, int color, i
 	int pixelYOffset = (_game.platform == Common::kPlatformC64) ? 1 : 0;
 	int pixelXOffset = (_game.platform == Common::kPlatformC64) ? 1 : 0;
 
+	_messageBannerActive = true;
+
 	// Pause the engine
 	PauseToken pt = pauseEngine();
 
@@ -434,6 +436,8 @@ Common::KeyState ScummEngine::printMessageAndPause(const char *msg, int color, i
 	// Finally, resume the engine, clear the input state, and restore the charset.
 	pt.clear();
 	clearClickedStatus();
+
+	_messageBannerActive = false;
 
 	return ks;
 }

--- a/engines/scumm/macgui/macgui_impl.cpp
+++ b/engines/scumm/macgui/macgui_impl.cpp
@@ -115,9 +115,7 @@ bool MacGuiImpl::handleEvent(Common::Event event) {
 	// The situation we're trying to avoid here is the user opening e.g.
 	// the save dialog using keyboard shortcuts while the game is paused.
 
-	// TODO: We need something for Maniac Mansion here
-
-	if (_bannerWindow || _vm->_messageBannerActive)
+	if (_vm->_messageBannerActive)
 		return false;
 
 	return _windowManager->processEvent(event);


### PR DESCRIPTION
The Mac GUI for the SCUMM games does not work well when the game is paused. At least not the way pause/message banners are handled, so the Mac GUI is suppressed while there is one on screen.

When it was just Loom and Indy 3, we just checked if the custom message banner had been created. When other games were added, we also tested the `_messageBannerActive` flag. But this was not set for old style games, and now Maniac Mansion (which was ported to the Mac for the Day of the Tentacle Easter Egg) is in the process of being supported. So this pull request sets the `_messageBannerActive` flag for that case as well. I hope this doesn't break anything, but there was no one around on Discord that I could ask.

(It also turns out that this flag is already set for Loom and Indy 3, so we don't have to check for the custom message banner.)