### PR TITLE
CI: Update Ubuntu runner from 20.04 to 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
             cxx: ccache g++
             aptPackages: 'liba52-dev libcurl4-openssl-dev libfaad-dev libflac-dev libfluidsynth-dev libfreetype6-dev libfribidi-dev libgif-dev libgtk-3-dev libjpeg-turbo8-dev libmad0-dev libmikmod-dev libmpeg2-4-dev libogg-dev libpng-dev libsdl2-dev libsdl2-net-dev libsndio-dev libspeechd-dev libtheora-dev libunity-dev libvorbis-dev libvpx-dev zlib1g-dev'
             configFlags: --enable-discord --with-discord-prefix=/usr/local
-          - platform: ubuntu-20.04
+          - platform: ubuntu-22.04
             sdlConfig: sdl-config
             cxx: ccache g++-4.8
             aptPackages: 'g++-4.8 liba52-dev libcurl4-openssl-dev libfaad-dev libflac-dev libfluidsynth-dev libfreetype6-dev libfribidi-dev libgif-dev libgtk-3-dev libjpeg-turbo8-dev libmad0-dev libmikmod-dev libmpeg2-4-dev libogg-dev libpng-dev libsdl-net1.2-dev libsdl1.2-dev libsndio-dev libspeechd-dev libtheora-dev libunity-dev libvorbis-dev libvpx-dev zlib1g-dev'
@@ -177,10 +177,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Add Ubuntu Xenial package sources
-        if: matrix.platform == 'ubuntu-20.04'
+        if: matrix.platform == 'ubuntu-22.04'
         run: |
-          sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu/ xenial main'
-          sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu/ xenial universe'
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 40976EAF437D05B5
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 3B4FE6ACC0B21F32
+          sudo apt-add-repository 'deb http://azure.archive.ubuntu.com/ubuntu/ xenial main'
+          sudo apt-add-repository 'deb http://azure.archive.ubuntu.com/ubuntu/ xenial universe'
       - name: Install packages
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Context

In our current CI configuration, we have a second Ubuntu runner, intentionally using an older release and compiler, as a quick (and early) way to catch some portability problems.

(I think GCC 4.7 is the lowest GCC release that will build current ScummVM, as used for RISC OS, but the runner uses GCC 4.8 as a good-enough measure, since that release is relatively easy to install there.)

Anyway, for that we relied on Ubuntu 20.04, but this release is being deprecated by GitHub Actions, with some *brownout* periods due soon.

## PR content

So this PR updates this runner to Ubuntu 22.04 (= the oldest available release supported by GitHub).

* The trick to use the GCC 4.8 packages from Ubuntu 18.04 still works there, but we now need some `apt-key` lines to cover the older GPG stuff they used.

…and that's it. Any objection?
