### PR TITLE
CONFIGURE: Make --disable-gold the default, now that Binutils deprecated it

### DIFF
--- a/configure
+++ b/configure
@@ -216,7 +216,7 @@ _pandoc=no
 _curl=yes
 _lld=no
 _mold=no
-_gold=auto
+_gold=no
 # Default vkeybd/eventrec options
 _vkeybd=no
 _eventrec=no
@@ -2552,19 +2552,6 @@ else
 	define_in_config_if_yes yes 'NO_CXX11_ALIGNAS'
 fi
 
-# The Gold linker had known issues on at least i386 and ppc32, in some cases.
-# Since this linker is not very maintained anymore, and since alternatives exist,
-# avoid using it on non-mainstream archs, unless --enable-gold was explicitly given.
-if test "$_gold" = auto; then
-	case $_host_cpu in
-		aarch64 | x86_64 | amd64)
-			;;
-		*)
-			_gold=no
-			;;
-	esac
-fi
-
 #
 # Determine extra build flags for debug and/or release builds
 #
@@ -2600,7 +2587,7 @@ if test "$_debug_build" != no; then
 			append_var LDFLAGS "-fuse-ld=mold"
 			append_var LDFLAGS "-Wl,--gdb-index"
 			echo_n -- " + Mold"
-		elif test "$_gold" != no && cc_check_no_clean $debug_mode -gsplit-dwarf -fuse-ld=gold -Wl,--gdb-index; then
+		elif test "$_gold" = yes && cc_check_no_clean $debug_mode -gsplit-dwarf -fuse-ld=gold -Wl,--gdb-index; then
 			append_var LDFLAGS "-fuse-ld=gold"
 			append_var LDFLAGS "-Wl,--gdb-index"
 			echo_n -- " + Gold"
@@ -2626,6 +2613,28 @@ if ! echo "$LDFLAGS" | grep -q -e -fuse-ld; then
 	echo "Using Mold linker... $_mold"
 	if test "$_mold" =  yes ; then
 		append_var LDFLAGS -fuse-ld=mold
+	fi
+fi
+
+if ! echo "$LDFLAGS" | grep -q -e -fuse-ld; then
+	echo "Using Gold linker... $_gold"
+	if test "$_gold" = yes ; then
+		append_var LDFLAGS -fuse-ld=gold
+	fi
+fi
+
+# The Gold linker has known issues on at least i386 and ppc32, in some
+# cases. Since it's mostly unmaintained and now deprecated with GNU
+# Binutils 2.44, avoid using it, unless --enable-gold was explicitly
+# given (and then you're on your own).
+if $LD $LDFLAGS -Wl,--version 2>/dev/null | grep -q -e 'GNU gold'; then
+	# Trying to help systems where Gold may (unwisely) be the default;
+	# thus we only try to provide a GNU LD (BFD) fallback in that case,
+	# since it appears to only impact some (past?) GNU systems anyway.
+	if test "$_gold" != yes && $LD $LDFLAGS -fuse-ld=bfd -Wl,--version >/dev/null 2>&1; then
+		append_var LDFLAGS -fuse-ld=bfd
+	else
+		echo "WARNING: Using deprecated Gold linker; build may fail on some platforms"
 	fi
 fi
 


### PR DESCRIPTION
This is a follow-up to previous PR #6285.

GNU Binutils 2.44 officially deprecated the (mostly unmaintained for some years) Gold linker:

https://lists.gnu.org/archive/html/info-gnu/2025-02/msg00001.html

So, make `--disable-gold` the default, now, since we know that it trigger internal (and unsolved?) linker errors on non-mainstream archs (see previous PR discussion). The previous PR limited this behavior to the non-mainstream archs; but since GNU Binutils itself marked the whole Gold linker as deprecated, and since alternatives exist nowadays (see the existing LLD/Mold integration, and GNU BFD being better than it used to be before Gold.), it just seems wiser to stop triggering its usage.

Users having good reasons to try linking with Gold anyway now need to set an explicit `--enable-gold`, since we'll try to revert to GNU BFD if it's found, and if Gold appears to be the default for some reason. (Maybe we shouldn't bother with fixing this, but well, the previous PR highlighted 3 GNU/Linux distributions where Gold *was* the default linker at some point, so the check I'm adding seems like a simple & good-enough approach to handle this. It also addresses the previous concerns in https://github.com/scummvm/scummvm/pull/6285#issuecomment-2515233588 by doing so.)