### PR TITLE
HADESCH: Add pirated Mac version to detection

### DIFF
--- a/engines/hadesch/detection_tables.h
+++ b/engines/hadesch/detection_tables.h
@@ -56,7 +56,6 @@ static const ADGameDescription gameDescriptions[] = {
 		Common::kPlatformMacintosh,
 		ADGF_DROPPLATFORM,
 		GUIO1(GUIO_NOMIDI)
-
 	},
 	{
 		"hadesch",
@@ -114,6 +113,20 @@ static const ADGameDescription gameDescriptions[] = {
 		},
 		Common::EN_ANY,
 		Common::kPlatformWindows,
+		ADGF_DROPPLATFORM | ADGF_PIRATED,
+		GUIO1(GUIO_NOMIDI)
+	},
+	{
+		"hadesch",
+		0,
+		{
+			{"Hades Challenge PPC", 0, "r:0a1dd550e5efe7f36370e689811fac73", 28945},
+			{"WD.POD", 0, "d:be7030fc4229e69e719ee2c756eb6ba1", 7479768},
+			{"ol.pod", 0, "d:6bf95a48f366bdf8af3a198c7b723c77", 5621074},
+			AD_LISTEND
+		},
+		Common::EN_ANY,
+		Common::kPlatformMacintosh,
 		ADGF_DROPPLATFORM | ADGF_PIRATED,
 		GUIO1(GUIO_NOMIDI)
 	},


### PR DESCRIPTION
This is from the Mac partition of an already detected pirated version.
