### PR TITLE
3DS: Fix improper memory freeing (Sprite.vertices)

### DIFF
--- a/backends/platform/3ds/osystem-graphics.cpp
+++ b/backends/platform/3ds/osystem-graphics.cpp
@@ -113,12 +113,7 @@ void OSystem_3DS::init3DSGraphics() {
 
 void OSystem_3DS::destroy3DSGraphics() {
 	_gameScreen.free();
-	_gameTopTexture.free();
-	_gameBottomTexture.free();
 	_cursor.free();
-	_cursorTexture.free();
-	_overlay.free();
-	_activityIcon.free();
 
 	shaderProgramFree(&_program);
 	DVLB_Free(_dvlb);

--- a/backends/platform/3ds/sprite.cpp
+++ b/backends/platform/3ds/sprite.cpp
@@ -45,7 +45,8 @@ Sprite::Sprite()
 }
 
 Sprite::~Sprite() {
-	//
+	free();
+	linearFree(vertices);
 }
 
 void Sprite::create(uint16 width, uint16 height, const GfxMode3DS *mode, bool vram) {
@@ -84,7 +85,6 @@ void Sprite::create(uint16 width, uint16 height, const GfxMode3DS *mode, bool vr
 }
 
 void Sprite::free() {
-	linearFree(vertices);
 	linearFree(pixels);
 	C3D_TexDelete(&texture);
 	pixels = 0;


### PR DESCRIPTION
~~Up to this point, `Graphics::Surface`-derived `Sprite` objects have simply been decalred in the 3DS backend's `osystem.h` file. As such, the `Sprite` class's constructor was not being called, and the chunk of linear memory `Sprite._vertices` is meant to point to wasn't being allocated. This PR rectifies that.~~

~~The fact that the 3DS port has still been working to this point, despite writing into undefined space in main memory, is a happy accident. The undefined behavior only manifested during my efforts to make a framework with which 3DS hardware renderers can be created for 3D engines.~~

`Sprite.vertices` was being freed before it was meant to be freed.