### PR TITLE
DIRECTOR: add nocursor debug flag

### DIFF
--- a/engines/director/cursor.cpp
+++ b/engines/director/cursor.cpp
@@ -36,7 +36,11 @@ Cursor::Cursor() {
 	_keyColor = 0xff;
 
 	_cursorResId = Datum(0);
-	_cursorType = Graphics::kMacCursorArrow;
+	if (debugChannelSet(-1, kDebugNoCursor)) {
+		_cursorType = Graphics::kMacCursorOff;
+	} else {
+		_cursorType = Graphics::kMacCursorArrow;
+	}
 
 	_usePalette = false;
 }

--- a/engines/director/detection.cpp
+++ b/engines/director/detection.cpp
@@ -67,6 +67,7 @@ static const DebugChannelDef debugFlagList[] = {
 	{Director::kDebugLingoStrict, "lingostrict", "Drop into debugger on Lingo error"},
 	{Director::kDebugLoading, "loading", "Loading"},
 	{Director::kDebugNoBytecode, "nobytecode", "Do not execute Lscr bytecode"},
+	{Director::kDebugNoCursor, "nocursor", "Default to a blank cursor instead of a pointer"},
 	{Director::kDebugNoLoop, "noloop", "Do not loop the playback"},
 	{Director::kDebugParse, "parse", "Lingo code parsing"},
 	{Director::kDebugPreprocess, "preprocess", "Lingo preprocessing"},

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -75,6 +75,7 @@ enum {
 	kDebugFast,
 	kDebugNoLoop,
 	kDebugNoBytecode,
+	kDebugNoCursor,
 	kDebugFewFramesOnly,
 	kDebugPreprocess,
 	kDebugScreenshot,


### PR DESCRIPTION
This flag causes games to boot to a blank cursor by default instead of a pointer. It's useful when booting noninteractive animations in order to get a clearer screen.