### PR TITLE
FREESCAPE: Implement skybox for opengl with shaders

### DIFF
--- a/engines/freescape/gfx.h
+++ b/engines/freescape/gfx.h
@@ -238,6 +238,20 @@ public:
 		{ 81280.0f, -8128.0f, -81280.0f },//4
 	};
 
+	unsigned int _skyIndices[24] = {
+		0, 1, 2, 	// front
+		0, 2, 3,
+
+		4, 5, 6, 	// back
+		4, 6, 7,
+
+		8, 9, 10, 	// left
+		8, 10, 11,
+
+		12, 13, 14, // right
+		12, 14, 15,
+	};
+
 	byte *_palette;
 	void setColorMap(ColorMap *colorMap_);
 	ColorMap *_colorMap;

--- a/engines/freescape/gfx_opengl_shaders.h
+++ b/engines/freescape/gfx_opengl_shaders.h
@@ -60,8 +60,12 @@ public:
 
 	OpenGL::Shader *_triangleShader;
 	OpenGL::Shader *_bitmapShader;
+	OpenGL::Shader *_cubemapShader;
 	GLuint _triangleVBO;
 	GLuint _bitmapVBO;
+	GLuint _cubemapVertVBO;
+	GLuint _cubemapTexCoordVBO;
+	GLuint _cubemapEBO;
 
 	int _defaultShaderStippleArray[128];
 	int _variableStippleArray[128];
@@ -88,6 +92,7 @@ public:
 	virtual void renderPlayerShootBall(byte color, const Common::Point position, int frame, const Common::Rect viewPort) override;
 	virtual void renderPlayerShootRay(byte color, const Common::Point position, const Common::Rect viewPort) override;
 	void drawCelestialBody(Math::Vector3d position, float radius, uint8 color) override;
+	void drawSkybox(Texture *texture, Math::Vector3d camera) override;
 
 	virtual void renderCrossair(const Common::Point crossairPosition) override;
 

--- a/engines/freescape/shaders/freescape_cubemap.fragment
+++ b/engines/freescape/shaders/freescape_cubemap.fragment
@@ -1,0 +1,10 @@
+in vec2 TexCoord;
+
+OUTPUT
+
+uniform sampler2D skyTexture;
+
+void main()
+{
+	outColor = texture(skyTexture, TexCoord);
+}

--- a/engines/freescape/shaders/freescape_cubemap.vertex
+++ b/engines/freescape/shaders/freescape_cubemap.vertex
@@ -1,0 +1,11 @@
+in vec3 position;
+in vec2 texcoord;
+
+uniform mat4 mvpMatrix;
+out vec2 TexCoord;
+
+void main()
+{
+	TexCoord = texcoord;
+    gl_Position = mvpMatrix * vec4(position, 1.0);
+}


### PR DESCRIPTION
Currently, Freescape does not draw a skybox when using opengl with shaders to run Castle Master. I have defined `OpenGLShaderRenderer::drawSkybox` and used seperate cubemap shaders for the rendering.  Only Castle Master will be affected by this.