### PR TITLE
TEST: Fix base64 test on big-endian

### DIFF
--- a/test/common/base64.h
+++ b/test/common/base64.h
@@ -76,11 +76,11 @@ class Base64TestSuite : public CxxTest::TestSuite {
 
 	void test_b64EncodeData() {
 		Base64TestStruct *test = new Base64TestStruct();
-		test->x = 1;
-		test->y = 2;
-		test->z = 3;
-		test->a = 4;
-		test->b = 5;
+		test->x = TO_LE_32(1);
+		test->y =          2;
+		test->z = TO_LE_16(3);
+		test->a = TO_LE_32(4);
+		test->b =          5;
 
 		Common::String encoded = Common::b64EncodeData(test, sizeof(Base64TestStruct));
 		TS_ASSERT_EQUALS(encoded, "AQAAAAIDAAQAAAAF");
@@ -99,7 +99,7 @@ class Base64TestSuite : public CxxTest::TestSuite {
 		for (int i = 0; i < 6; i++) {
 			Common::String encoded = base64_test_encoded[i];
 			Common::MemoryReadStream *stream = Common::b64DecodeStream(encoded, strlen(base64_test_string[i]));
-			TS_ASSERT_EQUALS(stream->size(), strlen(base64_test_string[i]));
+			TS_ASSERT_EQUALS(stream->size(), (int64)strlen(base64_test_string[i]));
 
 			char *data = (char *)malloc(stream->size());
 			stream->read(data, stream->size());
@@ -118,11 +118,11 @@ class Base64TestSuite : public CxxTest::TestSuite {
 		bool success = Common::b64DecodeData(encoded, test);
 		TS_ASSERT_EQUALS(success, true);
 
-		TS_ASSERT_EQUALS(test->x, 1);
-		TS_ASSERT_EQUALS(test->y, 2);
-		TS_ASSERT_EQUALS(test->z, 3);
-		TS_ASSERT_EQUALS(test->a, 4);
-		TS_ASSERT_EQUALS(test->b, 5);
+		TS_ASSERT_EQUALS(FROM_LE_32(test->x), 1u);
+		TS_ASSERT_EQUALS(test->y,             2u);
+		TS_ASSERT_EQUALS(FROM_LE_16(test->z), 3u);
+		TS_ASSERT_EQUALS(FROM_LE_32(test->a), 4u);
+		TS_ASSERT_EQUALS(test->b,             5u);
 		delete test;
 	}
 };


### PR DESCRIPTION
The structure is loaded bytewise from Base64 data and should be compared in a little endian fashion as the Base64 test pattern was generated on a LE machine.

Closes [bug:15738](https://bugs.scummvm.org/ticket/15738).
