### PR TITLE
GRAPHICS: Fix deprecation warning

### DIFF
--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -41,7 +41,7 @@ ManagedSurface::ManagedSurface(const ManagedSurface &surf) :
 		w(_innerSurface.w), h(_innerSurface.h), pitch(_innerSurface.pitch), format(_innerSurface.format),
 		_disposeAfterUse(DisposeAfterUse::NO), _owner(nullptr),
 		_transparentColor(0), _transparentColorSet(false), _palette(nullptr) {
-	*this = surf;
+	copyFrom(surf);
 }
 
 ManagedSurface::ManagedSurface(ManagedSurface &&surf) :


### PR DESCRIPTION
```
graphics/managed_surface.cpp: In copy constructor 'Graphics::ManagedSurface::ManagedSurface(const Graphics::ManagedSurface&)': graphics/managed_surface.cpp:44:17: warning: 'Graphics::ManagedSurface& Graphics::ManagedSurface::operator=(const Graphics::ManagedSurface&)' is deprecated: Use copyFrom() or a move constructor instead [-Wdeprecated-declarations]
   44 |         *this = surf;
      |                 ^~~~
```