### PR TITLE
SCUMM: "Fix" the bright graphics in the Sega CD version of MI1

### DIFF
--- a/engines/scumm/dialogs.h
+++ b/engines/scumm/dialogs.h
@@ -240,6 +240,7 @@ protected:
 	GUI::ThemeEval &addEnhancementsLayout(GUI::ThemeEval &layouts) const;
 	GUI::CheckboxWidget *createOriginalGUICheckbox(GuiObject *boss, const Common::String &name);
 	GUI::CheckboxWidget *createGammaCorrectionCheckbox(GuiObject *boss, const Common::String &name);
+	GUI::CheckboxWidget *createSegaShadowModeCheckbox(GuiObject *boss, const Common::String &name);
 	GUI::CheckboxWidget *createCopyProtectionCheckbox(GuiObject *boss, const Common::String &name);
 	void updateAdjustmentSlider(GUI::SliderWidget *slider, GUI::StaticTextWidget *value);
 
@@ -374,6 +375,7 @@ private:
 	void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) override;
 
 	GUI::CheckboxWidget *_enableOriginalGUICheckbox = nullptr;
+	GUI::CheckboxWidget *_enableSegaShadowModeCheckbox = nullptr;
 
 	GUI::SliderWidget *_introAdjustmentSlider = nullptr;
 	GUI::StaticTextWidget *_introAdjustmentValue = nullptr;

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -619,10 +619,10 @@ GUI::OptionsContainerWidget *ScummMetaEngine::buildMI1OptionsWidget(GUI::GuiObje
 	if (platform == Common::kPlatformMacintosh && extra != "Steam")
 		return new Scumm::MacGameOptionsWidget(boss, name, target, GID_MONKEY, extra);
 
-	if (extra != "CD" && extra != "FM-TOWNS" && extra != "SEGA")
-		return nullptr;
+	if (extra == "CD" || platform == Common::kPlatformFMTowns || platform == Common::kPlatformSegaCD)
+		return new Scumm::MI1CdGameOptionsWidget(boss, name, target);
 
-	return new Scumm::MI1CdGameOptionsWidget(boss, name, target);
+	return nullptr;
 }
 
 

--- a/engines/scumm/palette.cpp
+++ b/engines/scumm/palette.cpp
@@ -1730,18 +1730,26 @@ void ScummEngine::updatePalette() {
 		for (int i = 0; i < 3 * num; ++i)
 			paletteColors[i] = _macGammaCorrectionLookUp[paletteColors[i]];
 	} else if (_game.platform == Common::kPlatformSegaCD && _game.id == GID_MONKEY && _enableSegaShadowMode) {
-		// This works on the assumption that the original interpreter
-		// used just the three most significant bits of each color
-		// component. Furthermore, the graphcis were drawn in "shadow
-		// mode" (possibly by accident), halving the color intensity.
-		// Without access to a proper Sega CD emulator, this is the
-		// best I can do at the moment.
+		// Apparently the Sega had only 15 levels of intensity for each
+		// color component. You might think there would be 16, but the
+		// palette uses only three bits per color. These can then be
+		// rendered as normal, shadow, or highlight mode, and that comes
+		// out to 15 possible levels.
+
+		// These color levels come from the BlastEm emulator.
+
+		const byte levels[] = { 0, 27, 49, 71, 87, 103, 119, 130, 146, 157, 174, 190, 206, 228, 255 };
+
+		// For reasons unknown, the orignal interpreter rendered
+		// everything in shadow mode. We could easily emulate the other
+		// two modes as well:
 		//
-		// You can tell the developers were aware that the graphics
-		// were dark, becaues they made the SCUMM Bar sign brighter
-		// than in other versions.
+		// Normal: idx = (paletteColors[i] >> 4) & 0x0E;
+		// Shadow: idx = (paletteColors[i] >> 5) & 0x07;
+		// Hilite: idx = ((paletteColors[i] >> 5) & 0x07) + 7;
+
 		for (int i = 0; i < 3 * num; ++i)
-			paletteColors[i] = (paletteColors[i] & 0xE0) >> 1;
+			paletteColors[i] = levels[(paletteColors[i] >> 5) & 0x07];
 	}
 
 	_system->getPaletteManager()->setPalette(paletteColors, first, num);

--- a/engines/scumm/palette.cpp
+++ b/engines/scumm/palette.cpp
@@ -1729,6 +1729,19 @@ void ScummEngine::updatePalette() {
 	if (_game.platform == Common::kPlatformMacintosh && _game.heversion == 0 && _useGammaCorrection) {
 		for (int i = 0; i < 3 * num; ++i)
 			paletteColors[i] = _macGammaCorrectionLookUp[paletteColors[i]];
+	} else if (_game.platform == Common::kPlatformSegaCD && _game.id == GID_MONKEY && !enhancementEnabled(kEnhVisualChanges)) {
+		// This works on the assumption that the original interpreter
+		// used just the three most significant bits of each color
+		// component. Furthermore, the graphcis were drawn in "shadow
+		// mode" (possibly by accident), halving the color intensity.
+		// Without access to a proper Sega CD emulator, this is the
+		// best I can do at the moment.
+		//
+		// You can tell the developers were aware that the graphics
+		// were dark, becaues they made the SCUMM Bar sign brighter
+		// than in other versions.
+		for (int i = 0; i < 3 * num; ++i)
+			paletteColors[i] = (paletteColors[i] & 0xE0) >> 1;
 	}
 
 	_system->getPaletteManager()->setPalette(paletteColors, first, num);

--- a/engines/scumm/palette.cpp
+++ b/engines/scumm/palette.cpp
@@ -1729,7 +1729,7 @@ void ScummEngine::updatePalette() {
 	if (_game.platform == Common::kPlatformMacintosh && _game.heversion == 0 && _useGammaCorrection) {
 		for (int i = 0; i < 3 * num; ++i)
 			paletteColors[i] = _macGammaCorrectionLookUp[paletteColors[i]];
-	} else if (_game.platform == Common::kPlatformSegaCD && _game.id == GID_MONKEY && !enhancementEnabled(kEnhVisualChanges)) {
+	} else if (_game.platform == Common::kPlatformSegaCD && _game.id == GID_MONKEY && _enableSegaShadowMode) {
 		// This works on the assumption that the original interpreter
 		// used just the three most significant bits of each color
 		// component. Furthermore, the graphcis were drawn in "shadow

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -201,6 +201,13 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 		}
 	}
 
+	if (_game.platform == Common::kPlatformSegaCD) {
+		ConfMan.registerDefault("enable_sega_shadow_mode", false);
+		if (ConfMan.hasKey("enable_sega_shadow_mode", _targetName)) {
+			_enableSegaShadowMode = ConfMan.getBool("enable_sega_shadow_mode");
+		}
+	}
+
 	if (ConfMan.hasKey("gamma_correction", _targetName)) {
 		_useGammaCorrection = ConfMan.getBool("gamma_correction");
 	}
@@ -279,8 +286,6 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 		else
 			_voiceMode = ConfMan.getBool("subtitles");
 	}
-
-	_enableSegaShadowMode = ConfMan.getBool("enable_sega_shadow_mode");
 
 	if (ConfMan.hasKey("render_mode")) {
 		_renderMode = Common::parseRenderMode(ConfMan.get("render_mode"));

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -280,6 +280,8 @@ ScummEngine::ScummEngine(OSystem *syst, const DetectorResult &dr)
 			_voiceMode = ConfMan.getBool("subtitles");
 	}
 
+	_enableSegaShadowMode = ConfMan.getBool("enable_sega_shadow_mode");
+
 	if (ConfMan.hasKey("render_mode")) {
 		_renderMode = Common::parseRenderMode(ConfMan.get("render_mode"));
 	} else {

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -1425,6 +1425,7 @@ protected:
 	byte *_hercCGAScaleBuf = nullptr;
 	bool _enableEGADithering = false;
 	bool _supportsEGADithering = false;
+	bool _enableSegaShadowMode = false;
 
 	virtual void drawDirtyScreenParts();
 	void updateDirtyScreen(VirtScreenNumber slot);


### PR DESCRIPTION
As can be seen on MobyGames, the Sega CD version of MI1 is really quite dark: https://www.mobygames.com/game/141074/the-secret-of-monkey-island/screenshots/sega-cd/

This attempts to implement that in ScummVM, while at the same time making it en enhancement ("Audio-visual improvements") to use the colors provided by the game data files. Though without access to a proper Sega CD emulator, this is just a guess. it seems to match the screenshots I've seen pretty well.

Before:

![image](https://github.com/user-attachments/assets/935d3cc1-8168-41c9-af30-c37fd31f50b3)

After:

![image](https://github.com/user-attachments/assets/2a6da348-c834-429b-8de0-b041d62744b7)

I don't know if the dark graphics (apparently everything is drawn in "shadow mode") were deliberate or not. But you can tell that the developers were at least aware, because they made the SCUMM Bar sign a lot brighter than in other versions, making it stand out even with the darker colors:

![image](https://github.com/user-attachments/assets/9332017c-1984-42c7-8fc0-c5b928ec25b8)
