### PR TITLE
IMAGE: Replace palette byte arrays with Palette class

### DIFF
--- a/engines/hopkins/graphics.h
+++ b/engines/hopkins/graphics.h
@@ -31,10 +31,10 @@
 
 namespace Hopkins {
 
-#define DIRTY_RECTS_SIZE 250
-#define PALETTE_SIZE 256
-#define PALETTE_BLOCK_SIZE (PALETTE_SIZE * 3)
-#define PALETTE_EXT_BLOCK_SIZE 800
+constexpr int DIRTY_RECTS_SIZE = 250;
+constexpr int PALETTE_SIZE = 256;
+constexpr int PALETTE_BLOCK_SIZE = (PALETTE_SIZE * 3);
+constexpr int PALETTE_EXT_BLOCK_SIZE = 800;
 static const byte kSetOffset = 251;
 static const byte kByteStop = 252;
 static const byte k8bVal = 253;

--- a/graphics/palette.cpp
+++ b/graphics/palette.cpp
@@ -83,6 +83,27 @@ bool Palette::contains(const Palette& p) const {
 	return p._size <= _size && !memcmp(_data, p._data, p._size * 3);
 }
 
+void Palette::clear() {
+	delete[] _data;
+	_data = nullptr;
+	_size = 0;
+}
+
+void Palette::resize(uint newSize, bool preserve) {
+	if (newSize > _size) {
+		byte *newData = nullptr;
+		if (newSize > 0) {
+			newData = new byte[newSize * 3]();
+			if (_size > 0 && preserve)
+				memcpy(newData, _data, _size * 3);
+		}
+
+		delete[] _data;
+		_data = newData;
+	}
+	_size = newSize;
+}
+
 byte Palette::findBestColor(byte cr, byte cg, byte cb, ColorDistanceMethod method) const {
 	uint bestColor = 0;
 	uint32 min = 0xFFFFFFFF;
@@ -125,11 +146,6 @@ byte Palette::findBestColor(byte cr, byte cg, byte cb, ColorDistanceMethod metho
 	}
 
 	return bestColor;
-}
-
-void Palette::clear() {
-	if (_size > 0)
-		memset(_data, 0, _size);
 }
 
 void Palette::set(const byte *colors, uint start, uint num) {

--- a/graphics/palette.h
+++ b/graphics/palette.h
@@ -88,6 +88,19 @@ public:
 
 	const byte *data() const { return _data; }
 	uint size() const { return _size; }
+	
+	/**
+	 * Clears the palette of all entries and resets the size to zero.
+	 */
+	void clear();
+
+	/**
+	 * Changes the number of palette entries.
+	 * 
+	 * @param newSize the new number of palette entries
+	 * @param preserve indicates the existing entry values should be preserved
+	 */
+	void resize(uint newSize, bool preserve);
 
 	void set(uint entry, byte r, byte g, byte b) {
 		assert(entry < _size);
@@ -124,8 +137,6 @@ public:
 	 * @return the palette index
 	 */
 	byte findBestColor(byte r, byte g, byte b, ColorDistanceMethod method = kColorDistanceRedmean) const;
-
-	void clear();
 
 	/**
 	 * Replace the specified range of the palette with new colors.

--- a/image/bmp.cpp
+++ b/image/bmp.cpp
@@ -36,11 +36,7 @@
 
 namespace Image {
 
-BitmapDecoder::BitmapDecoder() {
-	_surface = 0;
-	_palette = 0;
-	_paletteColorCount = 0;
-	_codec = 0;
+BitmapDecoder::BitmapDecoder(): _codec(nullptr), _surface(nullptr), _palette(0) {
 }
 
 BitmapDecoder::~BitmapDecoder() {
@@ -48,15 +44,11 @@ BitmapDecoder::~BitmapDecoder() {
 }
 
 void BitmapDecoder::destroy() {
-	_surface = 0;
-
-	delete[] _palette;
-	_palette = 0;
-
-	_paletteColorCount = 0;
-
 	delete _codec;
-	_codec = 0;
+	_codec = nullptr;
+
+	_surface = nullptr;
+	_palette.clear();
 }
 
 bool BitmapDecoder::loadStream(Common::SeekableReadStream &stream) {
@@ -111,22 +103,24 @@ bool BitmapDecoder::loadStream(Common::SeekableReadStream &stream) {
 	uint32 imageSize = stream.readUint32LE();
 	/* uint32 pixelsPerMeterX = */ stream.readUint32LE();
 	/* uint32 pixelsPerMeterY = */ stream.readUint32LE();
-	_paletteColorCount = stream.readUint32LE();
+	uint32 paletteColorCount = stream.readUint32LE();
 	/* uint32 colorsImportant = */ stream.readUint32LE();
 
 	stream.seek(infoSize - 40, SEEK_CUR);
 
 	if (bitsPerPixel == 4 || bitsPerPixel == 8) {
-		if (_paletteColorCount == 0)
-			_paletteColorCount = bitsPerPixel == 8 ? 256 : 16;
+		if (paletteColorCount == 0)
+			paletteColorCount = bitsPerPixel == 8 ? 256 : 16;
 
 		// Read the palette
-		_palette = new byte[_paletteColorCount * 3];
-		for (uint16 i = 0; i < _paletteColorCount; i++) {
-			_palette[i * 3 + 2] = stream.readByte();
-			_palette[i * 3 + 1] = stream.readByte();
-			_palette[i * 3 + 0] = stream.readByte();
+		_palette.resize(paletteColorCount, false);
+		for (uint16 i = 0; i < paletteColorCount; i++) {
+			byte b = stream.readByte();
+			byte g = stream.readByte();
+			byte r = stream.readByte();
 			stream.readByte();
+
+			_palette.set(i, r, g, b);
 		}
 	}
 

--- a/image/bmp.h
+++ b/image/bmp.h
@@ -34,6 +34,7 @@
 
 #include "common/scummsys.h"
 #include "common/str.h"
+#include "graphics/palette.h"
 #include "image/image_decoder.h"
 
 namespace Common {
@@ -74,14 +75,13 @@ public:
 	void destroy();
 	virtual bool loadStream(Common::SeekableReadStream &stream);
 	virtual const Graphics::Surface *getSurface() const { return _surface; }
-	const byte *getPalette() const { return _palette; }
-	uint16 getPaletteColorCount() const { return _paletteColorCount; }
+	const byte *getPalette() const { return _palette.data(); }
+	uint16 getPaletteColorCount() const { return _palette.size(); }
 
 private:
 	Codec *_codec;
 	const Graphics::Surface *_surface;
-	byte *_palette;
-	uint16 _paletteColorCount;
+	Graphics::Palette _palette;
 };
 
 /**

--- a/image/cel_3do.cpp
+++ b/image/cel_3do.cpp
@@ -36,10 +36,7 @@ enum CCBFlags {
 	kCCBNoPre0 = 1 << 22
 };
 
-Cel3DODecoder::Cel3DODecoder() {
-	_surface = 0;
-	_palette = 0;
-	_paletteColorCount = 0;
+Cel3DODecoder::Cel3DODecoder(): _surface(nullptr), _palette(0) {
 }
 
 Cel3DODecoder::~Cel3DODecoder() {
@@ -47,12 +44,8 @@ Cel3DODecoder::~Cel3DODecoder() {
 }
 
 void Cel3DODecoder::destroy() {
-	_surface = 0;
-
-	delete[] _palette;
-	_palette = 0;
-
-	_paletteColorCount = 0;
+	_surface = nullptr;
+	_palette.clear();
 }
 
 bool Cel3DODecoder::loadStream(Common::SeekableReadStream &stream) {

--- a/image/cel_3do.h
+++ b/image/cel_3do.h
@@ -24,6 +24,7 @@
 
 #include "common/scummsys.h"
 #include "common/str.h"
+#include "graphics/palette.h"
 #include "image/image_decoder.h"
 
 namespace Common {
@@ -56,13 +57,12 @@ public:
 	void destroy();
 	virtual bool loadStream(Common::SeekableReadStream &stream);
 	virtual const Graphics::Surface *getSurface() const { return _surface; }
-	const byte *getPalette() const { return _palette; }
-	uint16 getPaletteColorCount() const { return _paletteColorCount; }
+	const byte *getPalette() const { return _palette.data(); }
+	uint16 getPaletteColorCount() const { return _palette.size(); }
 
 private:
 	const Graphics::Surface *_surface;
-	byte *_palette;
-	uint16 _paletteColorCount;
+	Graphics::Palette _palette;
 };
 /** @} */
 } // End of namespace Image

--- a/image/cicn.cpp
+++ b/image/cicn.cpp
@@ -29,11 +29,7 @@
 
 namespace Image {
 
-CicnDecoder::CicnDecoder() {
-	_surface = nullptr;
-	_palette = nullptr;
-	_paletteColorCount = 0;
-	_mask = nullptr;
+CicnDecoder::CicnDecoder(): _surface(nullptr), _palette(0), _mask(nullptr) {
 }
 
 CicnDecoder::~CicnDecoder() {
@@ -46,11 +42,8 @@ void CicnDecoder::destroy() {
 		delete _surface;
 		_surface = nullptr;
 	}
-
-	delete[] _palette;
-	_palette = nullptr;
-	_paletteColorCount = 0;
-
+	
+	_palette.clear();
 	if (_mask) {
 		_mask->free();
 		delete _mask;
@@ -106,17 +99,16 @@ bool CicnDecoder::loadStream(Common::SeekableReadStream &stream) {
 
 	// Palette
 	stream.skip(6);
-	_paletteColorCount = stream.readUint16BE() + 1;
+	uint16 paletteColorCount = stream.readUint16BE() + 1;
 
-	_palette = new byte[3 * _paletteColorCount];
+	_palette.resize(paletteColorCount, false);
 
-	byte *p = _palette;
-
-	for (uint i = 0; i < _paletteColorCount; i++) {
+	for (uint i = 0; i < paletteColorCount; i++) {
 		stream.skip(2);
-		*p++ = stream.readUint16BE() >> 8;
-		*p++ = stream.readUint16BE() >> 8;
-		*p++ = stream.readUint16BE() >> 8;
+		byte r = stream.readUint16BE() >> 8;
+		byte g = stream.readUint16BE() >> 8;
+		byte b = stream.readUint16BE() >> 8;
+		_palette.set(i, r, g, b);
 	}
 
 	_surface = new Graphics::Surface();

--- a/image/cicn.h
+++ b/image/cicn.h
@@ -22,6 +22,7 @@
 #ifndef IMAGE_CICN_H
 #define IMAGE_CICN_H
 
+#include "graphics/palette.h"
 #include "image/image_decoder.h"
 
 namespace Image {
@@ -46,14 +47,13 @@ public:
 	void destroy() override;
 	bool loadStream(Common::SeekableReadStream &stream) override;
 	const Graphics::Surface *getSurface() const override { return _surface; }
-	const byte *getPalette() const override { return _palette; }
-	uint16 getPaletteColorCount() const override { return _paletteColorCount; }
+	const byte *getPalette() const override { return _palette.data(); }
+	uint16 getPaletteColorCount() const override { return _palette.size(); }
 	const Graphics::Surface *getMask() const override { return _mask; }
 
 private:
 	Graphics::Surface *_surface;
-	byte *_palette;
-	uint16 _paletteColorCount;
+	Graphics::Palette _palette;
 	Graphics::Surface *_mask;
 };
 

--- a/image/gif.cpp
+++ b/image/gif.cpp
@@ -32,7 +32,7 @@
 
 namespace Image {
 
-GIFDecoder::GIFDecoder() : _outputSurface(0), _palette(0), _colorCount(0) {
+GIFDecoder::GIFDecoder() : _outputSurface(nullptr), _palette(0) {
 }
 
 GIFDecoder::~GIFDecoder() {
@@ -89,15 +89,15 @@ bool GIFDecoder::loadStream(Common::SeekableReadStream &stream) {
 		}
 	}
 
-	_colorCount = colorMap->ColorCount;
+	int colorCount = colorMap->ColorCount;
 	_outputSurface = new Graphics::Surface();
-	_palette = new uint8[_colorCount * 3];
+	_palette.resize(colorCount, false);
 
 	const Graphics::PixelFormat format = Graphics::PixelFormat::createFormatCLUT8();
-	for (int i = 0; i < _colorCount; ++i) {
-		_palette[(i * 3) + 0] = colorMap->Colors[i].Red;
-		_palette[(i * 3) + 1] = colorMap->Colors[i].Green;
-		_palette[(i * 3) + 2] = colorMap->Colors[i].Blue;
+	for (int i = 0; i < colorCount; ++i) {
+		_palette.set(i, colorMap->Colors[i].Red,
+						colorMap->Colors[i].Green,
+						colorMap->Colors[i].Blue);
 	}
 
 	// TODO: support transparency
@@ -128,10 +128,7 @@ void GIFDecoder::destroy() {
 		delete _outputSurface;
 		_outputSurface = 0;
 	}
-	if (_palette) {
-		delete[] _palette;
-		_palette = 0;
-	}
+	_palette.clear();
 }
 
 } // End of namespace Image

--- a/image/gif.h
+++ b/image/gif.h
@@ -22,6 +22,7 @@
 #ifndef IMAGE_GIF_H
 #define IMAGE_GIF_H
 
+#include "graphics/palette.h"
 #include "image/image_decoder.h"
 
 #ifdef USE_GIF
@@ -55,15 +56,14 @@ public:
 
 	bool loadStream(Common::SeekableReadStream &stream) override;
 	void destroy() override;
-	const byte *getPalette() const override { return _palette; }
-	uint16 getPaletteColorCount() const override { return _colorCount; }
+	const byte *getPalette() const override { return _palette.data(); }
+	uint16 getPaletteColorCount() const override { return _palette.size(); }
 	const Graphics::Surface *getSurface() const override { return _outputSurface; }
 	bool hasTransparentColor() const override { return _hasTransparentColor; }
 	uint32 getTransparentColor() const override { return _transparentColor; }
 private:
 	Graphics::Surface *_outputSurface;
-	uint8 *_palette;
-	uint16 _colorCount;
+	Graphics::Palette _palette;
 	bool _hasTransparentColor;
 	uint32 _transparentColor;
 };

--- a/image/iff.cpp
+++ b/image/iff.cpp
@@ -27,10 +27,7 @@
 
 namespace Image {
 
-IFFDecoder::IFFDecoder() {
-	_surface = 0;
-	_palette = 0;
-
+IFFDecoder::IFFDecoder(): _surface(nullptr), _palette(0) {
 	// these 2 properties are not reset by destroy(), so the default is set here.
 	_numRelevantPlanes = 8;
 	_pixelPacking = false;
@@ -46,18 +43,14 @@ void IFFDecoder::destroy() {
 	if (_surface) {
 		_surface->free();
 		delete _surface;
-		_surface = 0;
+		_surface = nullptr;
 	}
 
-	if (_palette) {
-		delete[] _palette;
-		_palette = 0;
-	}
+	_palette.clear();
 
 	memset(&_header, 0, sizeof(Header));
 	_paletteRanges.clear();
 	_type = TYPE_UNKNOWN;
-	_paletteColorCount = 0;
 }
 
 bool IFFDecoder::loadStream(Common::SeekableReadStream &stream) {
@@ -152,9 +145,14 @@ void IFFDecoder::loadHeader(Common::SeekableReadStream &stream) {
 }
 
 void IFFDecoder::loadPalette(Common::SeekableReadStream &stream, const uint32 size) {
-	_palette = new byte[size];
-	stream.read(_palette, size);
-	_paletteColorCount = size / 3;
+	_palette.resize(size / 3, false);
+	for (uint i = 0; i < _palette.size(); i++) {
+		byte r = stream.readByte();
+		byte g = stream.readByte();
+		byte b = stream.readByte();
+
+		_palette.set(i, r, g, b);
+	}
 }
 
 void IFFDecoder::loadPaletteRange(Common::SeekableReadStream &stream, const uint32 size) {

--- a/image/iff.h
+++ b/image/iff.h
@@ -24,6 +24,7 @@
 
 #include "common/array.h"
 #include "common/endian.h"
+#include "graphics/palette.h"
 #include "graphics/surface.h"
 
 #include "image/image_decoder.h"
@@ -85,9 +86,9 @@ public:
 	bool loadStream(Common::SeekableReadStream &stream);
 	const Header *getHeader() const { return &_header; }
 	const Graphics::Surface *getSurface() const { return _surface; }
-	const byte *getPalette() const { return _palette; }
+	const byte *getPalette() const { return _palette.data(); }
 	const Common::Array<PaletteRange> &getPaletteRanges() const { return _paletteRanges; }
-	uint16 getPaletteColorCount() const { return _paletteColorCount; }
+	uint16 getPaletteColorCount() const { return _palette.size(); }
 
 	/**
 	* The number of planes to decode, also determines the pixel packing if _packPixels is true.
@@ -111,10 +112,9 @@ private:
 
 	Header _header;
 	Graphics::Surface *_surface;
-	byte *_palette;
+	Graphics::Palette _palette;
 	Common::Array<PaletteRange> _paletteRanges;
 	Type _type;
-	uint16 _paletteColorCount;
 	uint8 _numRelevantPlanes;
 	bool _pixelPacking;
 

--- a/image/pcx.cpp
+++ b/image/pcx.cpp
@@ -35,10 +35,7 @@
 
 namespace Image {
 
-PCXDecoder::PCXDecoder() {
-	_surface = 0;
-	_palette = 0;
-	_paletteColorCount = 0;
+PCXDecoder::PCXDecoder(): _surface(nullptr), _palette(0) {
 }
 
 PCXDecoder::~PCXDecoder() {
@@ -49,12 +46,10 @@ void PCXDecoder::destroy() {
 	if (_surface) {
 		_surface->free();
 		delete _surface;
-		_surface = 0;
+		_surface = nullptr;
 	}
 
-	delete[] _palette;
-	_palette = 0;
-	_paletteColorCount = 0;
+	_palette.clear();
 }
 
 bool PCXDecoder::loadStream(Common::SeekableReadStream &stream) {
@@ -87,11 +82,12 @@ bool PCXDecoder::loadStream(Common::SeekableReadStream &stream) {
 	stream.skip(4);	// HDpi, VDpi
 
 	// Read the EGA palette (colormap)
-	_palette = new byte[16 * 3];
+	_palette.resize(16, false);
 	for (uint16 i = 0; i < 16; i++) {
-		_palette[i * 3 + 0] = stream.readByte();
-		_palette[i * 3 + 1] = stream.readByte();
-		_palette[i * 3 + 2] = stream.readByte();
+		byte r = stream.readByte();
+		byte g = stream.readByte();
+		byte b = stream.readByte();
+		_palette.set(i, r, g, b);
 	}
 
 	if (stream.readByte() != 0)	// reserved, should be set to 0
@@ -118,7 +114,7 @@ bool PCXDecoder::loadStream(Common::SeekableReadStream &stream) {
 		Graphics::PixelFormat format = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
 		_surface->create(width, height, format);
 		dst = (byte *)_surface->getPixels();
-		_paletteColorCount = 0;
+		_palette.clear();
 
 		for (y = 0; y < height; y++) {
 			decodeRLE(stream, scanLine, bytesPerscanLine, compressed);
@@ -136,7 +132,7 @@ bool PCXDecoder::loadStream(Common::SeekableReadStream &stream) {
 	} else if (nPlanes == 1 && bitsPerPixel == 8) {	// 8bpp indexed
 		_surface->create(width, height, Graphics::PixelFormat::createFormatCLUT8());
 		dst = (byte *)_surface->getPixels();
-		_paletteColorCount = 16;
+		_palette.resize(16, true);
 
 		for (y = 0; y < height; y++, dst += _surface->pitch) {
 			decodeRLE(stream, scanLine, bytesPerscanLine, compressed);
@@ -151,20 +147,18 @@ bool PCXDecoder::loadStream(Common::SeekableReadStream &stream) {
 			}
 
 			// Read the VGA palette
-			delete[] _palette;
-			_palette = new byte[256 * 3];
+			_palette.resize(256, false);
 			for (uint16 i = 0; i < 256; i++) {
-				_palette[i * 3 + 0] = stream.readByte();
-				_palette[i * 3 + 1] = stream.readByte();
-				_palette[i * 3 + 2] = stream.readByte();
+				byte r = stream.readByte();
+				byte g = stream.readByte();
+				byte b = stream.readByte();
+				_palette.set(i, r, g, b);
 			}
-
-			_paletteColorCount = 256;
 		}
 	} else if ((nPlanes == 2 || nPlanes == 3 || nPlanes == 4) && bitsPerPixel == 1) {	// planar, 4, 8 or 16 colors
 		_surface->create(width, height, Graphics::PixelFormat::createFormatCLUT8());
 		dst = (byte *)_surface->getPixels();
-		_paletteColorCount = 16;
+		_palette.resize(16, true);
 
 		for (y = 0; y < height; y++, dst += _surface->pitch) {
 			decodeRLE(stream, scanLine, bytesPerscanLine, compressed);

--- a/image/pcx.h
+++ b/image/pcx.h
@@ -24,6 +24,7 @@
 
 #include "common/scummsys.h"
 #include "common/str.h"
+#include "graphics/palette.h"
 #include "image/image_decoder.h"
 
 namespace Common{
@@ -56,15 +57,14 @@ public:
 	void destroy();
 	virtual bool loadStream(Common::SeekableReadStream &stream);
 	virtual const Graphics::Surface *getSurface() const { return _surface; }
-	const byte *getPalette() const { return _palette; }
-	uint16 getPaletteColorCount() const { return _paletteColorCount; }
+	const byte *getPalette() const { return _palette.data(); }
+	uint16 getPaletteColorCount() const { return _palette.size(); }
 
 private:
 	void decodeRLE(Common::SeekableReadStream &stream, byte *dst, uint32 bytesPerScanline, bool compressed);
 
 	Graphics::Surface *_surface;
-	byte *_palette;
-	uint16 _paletteColorCount;
+	Graphics::Palette _palette;
 };
 /** @} */
 } // End of namespace Image

--- a/image/pict.cpp
+++ b/image/pict.cpp
@@ -37,10 +37,7 @@ namespace Image {
 // https://developer.apple.com/library/archive/documentation/mac/QuickDraw/QuickDraw-461.html
 // https://developer.apple.com/library/archive/documentation/mac/QuickDraw/QuickDraw-269.html
 
-PICTDecoder::PICTDecoder() {
-	_outputSurface = 0;
-	_paletteColorCount = 0;
-	_version = 2;
+PICTDecoder::PICTDecoder() : _outputSurface(nullptr), _palette(0), _version(2) {
 }
 
 PICTDecoder::~PICTDecoder() {
@@ -51,10 +48,10 @@ void PICTDecoder::destroy() {
 	if (_outputSurface) {
 		_outputSurface->free();
 		delete _outputSurface;
-		_outputSurface = 0;
+		_outputSurface = nullptr;
 	}
 
-	_paletteColorCount = 0;
+	_palette.clear();
 }
 
 #define OPCODE(a, b, c) _opcodes.push_back(PICTOpcode(a, &PICTDecoder::b, c))
@@ -320,7 +317,7 @@ bool PICTDecoder::loadStream(Common::SeekableReadStream &stream) {
 	setupOpcodesNormal();
 
 	_continueParsing = true;
-	memset(_palette, 0, sizeof(_palette));
+	_palette.clear();
 
 	uint16 fileSize = stream.readUint16BE();
 
@@ -435,13 +432,15 @@ void PICTDecoder::unpackBitsRect(Common::SeekableReadStream &stream, bool withPa
 		// See https://developer.apple.com/library/archive/documentation/mac/QuickDraw/QuickDraw-267.html
 		stream.readUint32BE(); // seed
 		stream.readUint16BE(); // flags
-		_paletteColorCount = stream.readUint16BE() + 1;
+		uint16 paletteColorCount = stream.readUint16BE() + 1;
 
-		for (uint32 i = 0; i < _paletteColorCount; i++) {
+		_palette.resize(paletteColorCount, false);
+		for (uint16 i = 0; i < paletteColorCount; i++) {
 			stream.readUint16BE();
-			_palette[i * 3] = stream.readUint16BE() >> 8;
-			_palette[i * 3 + 1] = stream.readUint16BE() >> 8;
-			_palette[i * 3 + 2] = stream.readUint16BE() >> 8;
+			byte r = stream.readUint16BE() >> 8;
+			byte g = stream.readUint16BE() >> 8;
+			byte b = stream.readUint16BE() >> 8;
+			_palette.set(i, r, g, b);
 		}
 	}
 

--- a/image/pict.h
+++ b/image/pict.h
@@ -25,6 +25,7 @@
 #include "common/array.h"
 #include "common/rect.h"
 #include "common/scummsys.h"
+#include "graphics/palette.h"
 
 #include "image/image_decoder.h"
 
@@ -62,9 +63,9 @@ public:
 	bool loadStream(Common::SeekableReadStream &stream);
 	void destroy();
 	const Graphics::Surface *getSurface() const { return _outputSurface; }
-	const byte *getPalette() const { return _palette; }
+	const byte *getPalette() const { return _palette.data(); }
 	int getPaletteSize() const { return 256; }
-	uint16 getPaletteColorCount() const { return _paletteColorCount; }
+	uint16 getPaletteColorCount() const { return _palette.size(); }
 
 	struct PixMap {
 		uint32 baseAddr;
@@ -89,8 +90,7 @@ public:
 
 private:
 	Common::Rect _imageRect;
-	byte _palette[256 * 3];
-	uint16 _paletteColorCount;
+	Graphics::Palette _palette;
 	byte _penPattern[8];
 	Common::Point _currentPenPosition;
 	Graphics::Surface *_outputSurface;

--- a/image/png.h
+++ b/image/png.h
@@ -24,6 +24,7 @@
 
 #include "common/scummsys.h"
 #include "common/textconsole.h"
+#include "graphics/palette.h"
 #include "graphics/pixelformat.h"
 #include "image/image_decoder.h"
 
@@ -61,8 +62,8 @@ public:
 	bool loadStream(Common::SeekableReadStream &stream) override;
 	void destroy() override;
 	const Graphics::Surface *getSurface() const override { return _outputSurface; }
-	const byte *getPalette() const override { return _palette; }
-	uint16 getPaletteColorCount() const override { return _paletteColorCount; }
+	const byte *getPalette() const override { return _palette.data(); }
+	uint16 getPaletteColorCount() const override { return _palette.size(); }
 	bool hasTransparentColor() const override { return _hasTransparentColor; }
 	uint32 getTransparentColor() const override { return _transparentColor; }
 	void setSkipSignature(bool skip) { _skipSignature = skip; }
@@ -70,8 +71,7 @@ public:
 private:
 	Graphics::PixelFormat getByteOrderRgbaPixelFormat(bool isAlpha) const;
 
-	byte *_palette;
-	uint16 _paletteColorCount;
+	Graphics::Palette _palette;
 
 	// flag to skip the png signature check for headless png files
 	bool _skipSignature;

--- a/image/tga.cpp
+++ b/image/tga.cpp
@@ -33,12 +33,11 @@
 
 namespace Image {
 
-TGADecoder::TGADecoder() {
+TGADecoder::TGADecoder() : _colorMap(0) {
 	_colorMapSize = 0;
 	_colorMapOrigin = 0;
 	_colorMapLength = 0;
 	_colorMapEntryLength = 0;
-	_colorMap = NULL;
 }
 
 TGADecoder::~TGADecoder() {
@@ -47,7 +46,7 @@ TGADecoder::~TGADecoder() {
 
 void TGADecoder::destroy() {
 	_surface.free();
-	delete[] _colorMap;
+	_colorMap.clear();
 }
 
 bool TGADecoder::loadStream(Common::SeekableReadStream &tga) {
@@ -182,8 +181,8 @@ bool TGADecoder::readHeader(Common::SeekableReadStream &tga, byte &imageType, by
 }
 
 bool TGADecoder::readColorMap(Common::SeekableReadStream &tga, byte imageType, byte pixelDepth) {
-	_colorMap = new byte[3 * _colorMapLength];
-	for (int i = 0; i < _colorMapLength * 3; i += 3) {
+	_colorMap.resize(_colorMapLength, false);
+	for (int i = 0; i < _colorMapLength; i++) {
 		byte r, g, b;
 		if (_colorMapEntryLength == 32) {
 			b = tga.readByte();
@@ -203,9 +202,7 @@ bool TGADecoder::readColorMap(Common::SeekableReadStream &tga, byte imageType, b
 			warning("Unsupported image type: %d", imageType);
 			r = g = b = 0;
 		}
-		_colorMap[i] = r;
-		_colorMap[i + 1] = g;
-		_colorMap[i + 2] = b;
+		_colorMap.set(i, r, g, b);
 	}
 	return true;
 }

--- a/image/tga.h
+++ b/image/tga.h
@@ -33,6 +33,7 @@
 #ifndef IMAGE_TGA_H
 #define IMAGE_TGA_H
 
+#include "graphics/palette.h"
 #include "graphics/surface.h"
 #include "image/image_decoder.h"
 
@@ -68,8 +69,8 @@ public:
 	virtual ~TGADecoder();
 	virtual void destroy();
 	virtual const Graphics::Surface *getSurface() const { return &_surface; }
-	virtual const byte *getPalette() const { return _colorMap; }
-	virtual uint16 getPaletteColorCount() const { return _colorMapLength; }
+	virtual const byte *getPalette() const { return _colorMap.data(); }
+	virtual uint16 getPaletteColorCount() const { return _colorMap.size(); }
 	virtual bool loadStream(Common::SeekableReadStream &stream);
 private:
 	// Format-spec from:
@@ -85,7 +86,7 @@ private:
 
 	// Color-map:
 	bool _colorMapSize;
-	byte *_colorMap;
+	Graphics::Palette _colorMap;
 	int16 _colorMapOrigin;
 	int16 _colorMapLength;
 	byte _colorMapEntryLength;


### PR DESCRIPTION
These changes expand use of the Graphics::Palette class to the internals for many of the ImageDecoder classes.
The palette clear method is changed from zeroing out the entries to deleting them. I do not believe this method previously in use.
The NeoDecoder was not changed due to more complex uses of a passed in palette variable.
The XBMDecoder was not changed due to the use of a static const palette.

Do we have good method to test these changes? I was able to test BMP with testbed, but I am unsure what other paletted images I can check with.