### PR TITLE
BACKENDS: SDL: Let the user prevent resizing of the window

### DIFF
--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -483,6 +483,10 @@ bool SdlGraphicsManager::notifyEvent(const Common::Event &event) {
 		getWindow()->grabMouse(!getWindow()->mouseIsGrabbed());
 		return true;
 
+	case kActionToggleResizableWindow:
+		getWindow()->setResizable(!getWindow()->resizable());
+		return true;
+
 	case kActionToggleFullscreen:
 		toggleFullScreen();
 		return true;
@@ -536,6 +540,11 @@ Common::Keymap *SdlGraphicsManager::getKeymap() {
 	act = new Action("CAPT", _("Toggle mouse capture"));
 	act->addDefaultInputMapping("C+m");
 	act->setCustomBackendActionEvent(kActionToggleMouseCapture);
+	keymap->addAction(act);
+
+	act = new Action("RSZW", _("Toggle resizable window"));
+	act->addDefaultInputMapping("C+r");
+	act->setCustomBackendActionEvent(kActionToggleResizableWindow);
 	keymap->addAction(act);
 
 	act = new Action("SCRS", _("Save screenshot"));

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -141,6 +141,7 @@ protected:
 	enum CustomEventAction {
 		kActionToggleFullscreen = 100,
 		kActionToggleMouseCapture,
+		kActionToggleResizableWindow,
 		kActionSaveScreenshot,
 		kActionToggleAspectRatioCorrection,
 		kActionToggleFilteredScaling,

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -45,6 +45,13 @@ public:
 	void setWindowCaption(const Common::String &caption);
 
 	/**
+	 * Allows the window to be resized or not
+	 *
+	 * @param resizable Whether the window can be resizable or not.
+	 */
+	void setResizable(bool resizable);
+
+	/**
 	 * Grab or ungrab the mouse cursor. This decides whether the cursor can leave
 	 * the window or not.
 	 */
@@ -110,6 +117,15 @@ public:
 	 */
 	virtual float getDpiScalingFactor() const;
 
+	bool resizable() const {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		if (_window) {
+			return SDL_GetWindowFlags(_window) & SDL_WINDOW_RESIZABLE;
+		}
+#endif
+		return _resizable;
+	}
+
 	bool mouseIsGrabbed() const {
 #if SDL_VERSION_ATLEAST(3, 0, 0)
 		if (_window) {
@@ -135,6 +151,7 @@ public:
 
 private:
 	Common::Rect _desktopRes;
+	bool _resizable;
 	bool _inputGrabState, _inputLockState;
 	SDL_Rect grabRect;
 


### PR DESCRIPTION
This adds a new shortcut (Ctrl+R) which toggles the resizable state of the window and allows the user to lock the window size and prevents resizing.

Closes [bug:15124](https://bugs.scummvm.org/ticket/15124).

This PR replaces #6423.
