### PR TITLE
GOT: Add eyeballs mode for chapter 2 shovel maze

### DIFF
--- a/engines/got/game/back.cpp
+++ b/engines/got/game/back.cpp
@@ -46,6 +46,17 @@ const char *ITEM_NAMES[] = {
 static const char *odinEndMessage;
 
 void showLevel(const int newLevel) {
+	if (newLevel == 105) { // Shovel Maze
+		_G(thorInfo)._armor = 2; // eyeballs mode
+		loadNewThor();
+		_G(eyeballs) = 1;
+	} else if (_G(eyeballs) == 1) {
+		_G(setup).f25 = 0;
+		_G(thorInfo)._armor = 1;
+		loadNewThor();
+		_G(eyeballs) = 0;
+	}
+
 	_G(bossActive) = false;
 	if (!_G(shieldOn))
 		_G(actor[2])._active = false;

--- a/engines/got/game/main.cpp
+++ b/engines/got/game/main.cpp
@@ -22,6 +22,7 @@
 #include "common/memstream.h"
 #include "got/game/back.h"
 #include "got/vars.h"
+#include "got/gfx/image.h" // loadNewThor
 
 namespace Got {
 
@@ -64,6 +65,12 @@ void setupLoad() {
 
 	_G(currentLevel) = _G(newLevel);
 	showLevel(_G(newLevel));
+
+	if (_G(currentLevel) == 105) { // Shovel Maze
+		_G(thorInfo)._armor = 2; // eyeballs mode
+		loadNewThor();
+		_G(eyeballs) = 1;
+	}
 }
 
 void pause(int delay) {

--- a/engines/got/game/move_patterns.cpp
+++ b/engines/got/game/move_patterns.cpp
@@ -789,6 +789,12 @@ int movementZero(Actor *actor) {
 		}
 	}
 
+	if (_G(eyeballs)) {
+		nextFrame(actor);
+		actor->_dir = oldDir;
+		return d;
+	}
+
 	actor->_moveCounter = 5;
 	actor->_nextFrame = 0;
 	actor->_dir = oldDir;

--- a/engines/got/vars.h
+++ b/engines/got/vars.h
@@ -203,6 +203,7 @@ public:
 	int _currentArea = 0;
 	bool _thorSpecialFlag = false;
 	byte _explosionRow = 0;
+	bool _eyeballs = 0;
 };
 
 #define _G(X) (g_vars->_##X)

--- a/engines/got/views/game_content.cpp
+++ b/engines/got/views/game_content.cpp
@@ -207,6 +207,14 @@ bool GameContent::tick() {
 		break;
 	}
 
+	if (_G(eyeballs) == 1) { // eyeballs movement animation
+		if (!_G(setup).f25) {
+			_G(thor)->_dir = 0;
+		} else {
+			_G(thor)->_dir = 1;
+		}
+	}
+
 	checkForAreaChange();
 
 	// Check for end of game area
@@ -499,8 +507,10 @@ void GameContent::thorDies() {
 void GameContent::spinThor() {
 	static const byte DIRS[] = {0, 2, 1, 3};
 
-	_G(thor)->_dir = DIRS[(_deathCtr / SPIN_INTERVAL) % 4];
-	_G(thor)->_lastDir = DIRS[(_deathCtr / SPIN_INTERVAL) % 4];
+	if (!_G(eyeballs)) {
+		_G(thor)->_dir = DIRS[(_deathCtr / SPIN_INTERVAL) % 4];
+		_G(thor)->_lastDir = DIRS[(_deathCtr / SPIN_INTERVAL) % 4];
+	}
 
 	++_deathCtr;
 }


### PR DESCRIPTION
In chapter 2, there is a section where you enter in a pitch dark room and Thor is replaced with eyeballs. This is all you can see while you move around in the invisible maze to find the shovel.

This patch fully implements this mode and also adds these additional related features :
	* bruised eye animation that happens after the shovel is found, with Thor's face.
	* Saving and loading preserves the eyeball effect in the room 105.
	* Thor's spinning animation takes the eyeballs mode in consideration. Although the only way the user can die in that room is to explicitely use the "die" feature/command.

The original code was used as a guideline to implement this feature.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
