### PR TITLE
COMMON: Remove plural of debugChannels

### DIFF
--- a/common/debug.cpp
+++ b/common/debug.cpp
@@ -180,9 +180,9 @@ bool debugLevelSet(int level) {
 	return level <= gDebugLevel;
 }
 
-bool debugChannelSet(int level, uint32 debugChannels) {
+bool debugChannelSet(int level, uint32 debugChannel) {
 	if (gDebugLevel != 11 || level == -1)
-		if ((level != -1 && level > gDebugLevel) || !(DebugMan.isDebugChannelEnabled(debugChannels, level == -1)))
+		if ((level != -1 && level > gDebugLevel) || !(DebugMan.isDebugChannelEnabled(debugChannel, level == -1)))
 			return false;
 
 	return true;
@@ -191,7 +191,7 @@ bool debugChannelSet(int level, uint32 debugChannels) {
 
 #ifndef DISABLE_TEXT_CONSOLE
 
-static void debugHelper(const char *s, va_list va, int level, uint32 debugChannels, bool caret = true) {
+static void debugHelper(const char *s, va_list va, int level, uint32 debugChannel, bool caret = true) {
 	Common::String buf = Common::String::vformat(s, va);
 
 	if (caret)
@@ -199,7 +199,7 @@ static void debugHelper(const char *s, va_list va, int level, uint32 debugChanne
 
 	Common::LogWatcher logWatcher = Common::getLogWatcher();
 	if (logWatcher)
-		(*logWatcher)(LogMessageType::kDebug, level, debugChannels, buf.c_str());
+		(*logWatcher)(LogMessageType::kDebug, level, debugChannel, buf.c_str());
 
 	if (g_system)
 		g_system->logMessage(LogMessageType::kDebug, buf.c_str());
@@ -252,55 +252,55 @@ void debugN(int level, const char *s, ...) {
 	va_end(va);
 }
 
-void debugC(int level, uint32 debugChannels, const char *s, ...) {
+void debugC(int level, uint32 debugChannel, const char *s, ...) {
 	va_list va;
 
 	// Debug level 11 turns on all special debug level messages
 	if (gDebugLevel != 11)
-		if (level > gDebugLevel || !(DebugMan.isDebugChannelEnabled(debugChannels)))
+		if (level > gDebugLevel || !(DebugMan.isDebugChannelEnabled(debugChannel)))
 			return;
 
 	va_start(va, s);
-	debugHelper(s, va, level, debugChannels);
+	debugHelper(s, va, level, debugChannel);
 	va_end(va);
 }
 
-void debugCN(int level, uint32 debugChannels, const char *s, ...) {
+void debugCN(int level, uint32 debugChannel, const char *s, ...) {
 	va_list va;
 
 	// Debug level 11 turns on all special debug level messages
 	if (gDebugLevel != 11)
-		if (level > gDebugLevel || !(DebugMan.isDebugChannelEnabled(debugChannels)))
+		if (level > gDebugLevel || !(DebugMan.isDebugChannelEnabled(debugChannel)))
 			return;
 
 	va_start(va, s);
-	debugHelper(s, va, level, debugChannels, false);
+	debugHelper(s, va, level, debugChannel, false);
 	va_end(va);
 }
 
-void debugC(uint32 debugChannels, const char *s, ...) {
+void debugC(uint32 debugChannel, const char *s, ...) {
 	va_list va;
 
 	// Debug level 11 turns on all special debug level messages
 	if (gDebugLevel != 11)
-		if (!(DebugMan.isDebugChannelEnabled(debugChannels)))
+		if (!(DebugMan.isDebugChannelEnabled(debugChannel)))
 			return;
 
 	va_start(va, s);
-	debugHelper(s, va, 0, debugChannels);
+	debugHelper(s, va, 0, debugChannel);
 	va_end(va);
 }
 
-void debugCN(uint32 debugChannels, const char *s, ...) {
+void debugCN(uint32 debugChannel, const char *s, ...) {
 	va_list va;
 
 	// Debug level 11 turns on all special debug level messages
 	if (gDebugLevel != 11)
-		if (!(DebugMan.isDebugChannelEnabled(debugChannels)))
+		if (!(DebugMan.isDebugChannelEnabled(debugChannel)))
 			return;
 
 	va_start(va, s);
-	debugHelper(s, va, 0, debugChannels, false);
+	debugHelper(s, va, 0, debugChannel, false);
 	va_end(va);
 }
 

--- a/common/debug.h
+++ b/common/debug.h
@@ -30,10 +30,10 @@ inline void debug(const char *s, ...) {}
 inline void debug(int level, const char *s, ...) {}
 inline void debugN(const char *s, ...) {}
 inline void debugN(int level, const char *s, ...) {}
-inline void debugC(int level, uint32 debugChannels, const char *s, ...) {}
-inline void debugC(uint32 debugChannels, const char *s, ...) {}
-inline void debugCN(int level, uint32 debugChannels, const char *s, ...) {}
-inline void debugCN(uint32 debugChannels, const char *s, ...) {}
+inline void debugC(int level, uint32 debugChannel, const char *s, ...) {}
+inline void debugC(uint32 debugChannel, const char *s, ...) {}
+inline void debugCN(int level, uint32 debugChannel, const char *s, ...) {}
+inline void debugCN(uint32 debugChannel, const char *s, ...) {}
 
 #else
 
@@ -82,10 +82,10 @@ void debugN(int level, MSVC_PRINTF const char *s, ...) GCC_PRINTF(2, 3);
  * @see enableDebugChannel
  *
  * @param level         Debug level that must be active for the message to be printed.
- * @param debugChannels Bitfield of channels to check against.
+ * @param debugChannel  Channel to check against.
  * @param s             Message to print.
  */
-void debugC(int level, uint32 debugChannels, MSVC_PRINTF const char *s, ...) GCC_PRINTF(3, 4);
+void debugC(int level, uint32 debugChannel, MSVC_PRINTF const char *s, ...) GCC_PRINTF(3, 4);
 
 /**
  * Print a debug message to the text console (stdout), but only if
@@ -96,11 +96,11 @@ void debugC(int level, uint32 debugChannels, MSVC_PRINTF const char *s, ...) GCC
  * @see enableDebugChannel
  *
  * @param level         Debug level that must be active for the message to be printed.
- * @param debugChannels Bitfield of channels to check against.
+ * @param debugChannel  Channel to check against.
  * @param s             Message to print.
  *
  */
-void debugCN(int level, uint32 debugChannels, MSVC_PRINTF const char *s, ...) GCC_PRINTF(3, 4);
+void debugCN(int level, uint32 debugChannel, MSVC_PRINTF const char *s, ...) GCC_PRINTF(3, 4);
 
 /**
  * Print a debug message to the text console (stdout), but only if
@@ -108,10 +108,10 @@ void debugCN(int level, uint32 debugChannels, MSVC_PRINTF const char *s, ...) GC
  * Automatically appends a newline.
  * @see enableDebugChannel
  *
- * @param debugChannels Bitfield of channels to check against.
+ * @param debugChannel  Channel to check against.
  * @param s             Message to print.
  */
-void debugC(uint32 debugChannels, MSVC_PRINTF const char *s, ...) GCC_PRINTF(2, 3);
+void debugC(uint32 debugChannel, MSVC_PRINTF const char *s, ...) GCC_PRINTF(2, 3);
 
 /**
  * Print a debug message to the text console (stdout), but only if
@@ -119,10 +119,10 @@ void debugC(uint32 debugChannels, MSVC_PRINTF const char *s, ...) GCC_PRINTF(2, 
  * Does not append a newline automatically.
  * @see enableDebugChannel
  *
- * @param debugChannels Bitfield of channels to check against.
+ * @param debugChannel  Channel to check against.
  * @param s             Message to print.
  */
-void debugCN(uint32 debugChannels, MSVC_PRINTF const char *s, ...) GCC_PRINTF(2, 3);
+void debugCN(uint32 debugChannel, MSVC_PRINTF const char *s, ...) GCC_PRINTF(2, 3);
 
 #endif
 
@@ -135,10 +135,10 @@ bool debugLevelSet(int level);
  * Check whether the debug level and channel are active.
  *
  * @param level         Debug level to check against. If set to -1, only channel check is active.
- * @param debugChannels Bitfield of channels to check against.
+ * @param debugChannel  Channel to check against.
  * @see enableDebugChannel
  */
-bool debugChannelSet(int level, uint32 debugChannels);
+bool debugChannelSet(int level, uint32 debugChannel);
 
 /**
  * The debug level. Initially set to -1, indicating that no debug output

--- a/common/log.h
+++ b/common/log.h
@@ -47,7 +47,7 @@ namespace Common {
  * A typical example would be a function that shows a debug
  * console and displays the given message in it.
  */
-typedef void (*LogWatcher)(LogMessageType::Type type, int level, uint32 debugChannels, const char *message);
+typedef void (*LogWatcher)(LogMessageType::Type type, int level, uint32 debugChannel, const char *message);
 
 /**
  * Set the watcher used by debug, error and warning methods.

--- a/common/rect.h
+++ b/common/rect.h
@@ -374,8 +374,8 @@ struct Rect {
 	 /**
 	 * Print debug messages related to this class.
 	 */
-	void debugPrintC(int debuglevel, uint32 debugChannels, const char *caption = "Rect:") const {
-		debugC(debuglevel, debugChannels, "%s %d, %d, %d, %d", caption, left, top, right, bottom);
+	void debugPrintC(int debuglevel, uint32 debugChannel, const char *caption = "Rect:") const {
+		debugC(debuglevel, debugChannel, "%s %d, %d, %d, %d", caption, left, top, right, bottom);
 	}
 
 	/**

--- a/engines/director/debugger/debugtools.cpp
+++ b/engines/director/debugger/debugtools.cpp
@@ -273,7 +273,7 @@ static void showSettings() {
 	ImGui::End();
 }
 
-void onLog(LogMessageType::Type type, int level, uint32 debugChannels, const char *message) {
+void onLog(LogMessageType::Type type, int level, uint32 debugChannel, const char *message) {
 	switch (type) {
 	case LogMessageType::kError:
 		_state->_logger->addLog("[error]%s", message);

--- a/engines/twine/debugger/debugtools.cpp
+++ b/engines/twine/debugger/debugtools.cpp
@@ -136,7 +136,7 @@ static const char *toString(ShapeType type) {
 	}
 }
 
-static void onLog(LogMessageType::Type type, int level, uint32 debugChannels, const char *message) {
+static void onLog(LogMessageType::Type type, int level, uint32 debugChannel, const char *message) {
 	switch (type) {
 	case LogMessageType::kError:
 		_logger->addLog("[error]%s", message);


### PR DESCRIPTION
This variable previously held several channels while it's only used for one channel now.
