### PR TITLE
GRAPHICS: Use constexpr for palette constants

### DIFF
--- a/engines/access/access.cpp
+++ b/engines/access/access.cpp
@@ -570,7 +570,7 @@ void AccessEngine::writeSavegameHeader(Common::OutSaveFile *out, AccessSavegameH
 	out->writeByte('\0');
 
 	// Write a thumbnail of the screen
-	uint8 thumbPalette[PALETTE_SIZE];
+	uint8 thumbPalette[Graphics::PALETTE_SIZE];
 	_screen->getPalette(thumbPalette);
 	Graphics::Surface saveThumb;
 	::createThumbnail(&saveThumb, (const byte *)_screen->getPixels(),

--- a/engines/access/screen.cpp
+++ b/engines/access/screen.cpp
@@ -43,7 +43,7 @@ ScreenSave::ScreenSave(){
 
 Screen::Screen(AccessEngine *vm) : _vm(vm) {
 	create(320, 200);
-	Common::fill(&_tempPalette[0], &_tempPalette[PALETTE_SIZE], 0);
+	Common::fill(&_tempPalette[0], &_tempPalette[Graphics::PALETTE_SIZE], 0);
 	Common::fill(&_manPal[0], &_manPal[0x60], 0);
 	Common::fill(&_scaleTable1[0], &_scaleTable1[256], 0);
 	Common::fill(&_scaleTable2[0], &_scaleTable2[256], 0);
@@ -113,7 +113,7 @@ void Screen::update() {
 
 void Screen::setInitialPalettte() {
 	Common::copy(&INITIAL_PALETTE[0], &INITIAL_PALETTE[18 * 3], _rawPalette);
-	Common::fill(&_rawPalette[18 * 3], &_rawPalette[PALETTE_SIZE], 0);
+	Common::fill(&_rawPalette[18 * 3], &_rawPalette[Graphics::PALETTE_SIZE], 0);
 
 	g_system->getPaletteManager()->setPalette(INITIAL_PALETTE, 0, 18);
 }
@@ -140,22 +140,22 @@ void Screen::loadPalette(int fileNum, int subfile) {
 }
 
 void Screen::setPalette() {
-	g_system->getPaletteManager()->setPalette(&_rawPalette[0], 0, PALETTE_COUNT);
+	g_system->getPaletteManager()->setPalette(&_rawPalette[0], 0, Graphics::PALETTE_COUNT);
 }
 
 void Screen::loadRawPalette(Common::SeekableReadStream *stream) {
-	stream->read(&_rawPalette[0], PALETTE_SIZE);
-	for (byte *p = &_rawPalette[0]; p < &_rawPalette[PALETTE_SIZE]; ++p)
+	stream->read(&_rawPalette[0], Graphics::PALETTE_SIZE);
+	for (byte *p = &_rawPalette[0]; p < &_rawPalette[Graphics::PALETTE_SIZE]; ++p)
 		*p = VGA_COLOR_TRANS(*p);
 }
 
 void Screen::updatePalette() {
-	g_system->getPaletteManager()->setPalette(&_tempPalette[0], 0, PALETTE_COUNT);
+	g_system->getPaletteManager()->setPalette(&_tempPalette[0], 0, Graphics::PALETTE_COUNT);
 	update();
 }
 
 void Screen::savePalette() {
-	Common::copy(&_rawPalette[0], &_rawPalette[PALETTE_SIZE],
+	Common::copy(&_rawPalette[0], &_rawPalette[Graphics::PALETTE_SIZE],
 		&_savedPalettes[_savedPaletteCount][0]);
 
 	if (++_savedPaletteCount == 2)
@@ -167,7 +167,7 @@ void Screen::restorePalette() {
 		_savedPaletteCount = 0;
 
 	Common::copy(&_savedPalettes[_savedPaletteCount][0],
-		&_savedPalettes[_savedPaletteCount][PALETTE_SIZE], &_rawPalette[0]);
+		&_savedPalettes[_savedPaletteCount][Graphics::PALETTE_SIZE], &_rawPalette[0]);
 }
 
 void Screen::getPalette(byte *pal) {
@@ -182,7 +182,7 @@ void Screen::forceFadeOut() {
 
 	do {
 		repeatFlag = false;
-		for (srcP = &_tempPalette[0], count = 0; count < PALETTE_SIZE; ++count, ++srcP) {
+		for (srcP = &_tempPalette[0], count = 0; count < Graphics::PALETTE_SIZE; ++count, ++srcP) {
 			int v = *srcP;
 			if (v) {
 				repeatFlag = true;
@@ -196,7 +196,7 @@ void Screen::forceFadeOut() {
 }
 
 void Screen::forceFadeIn() {
-	Common::fill(&_tempPalette[0], &_tempPalette[PALETTE_SIZE], 0);
+	Common::fill(&_tempPalette[0], &_tempPalette[Graphics::PALETTE_SIZE], 0);
 
 	const int FADE_AMOUNT = 2;
 	bool repeatFlag;
@@ -205,7 +205,7 @@ void Screen::forceFadeIn() {
 		const byte *srcP = &_rawPalette[0];
 		byte *destP = &_tempPalette[0];
 
-		for (int idx = 0; idx < PALETTE_SIZE; ++idx, ++srcP, ++destP) {
+		for (int idx = 0; idx < Graphics::PALETTE_SIZE; ++idx, ++srcP, ++destP) {
 			if (*destP != *srcP) {
 				repeatFlag = true;
 				*destP = MIN((int)*destP + FADE_AMOUNT, (int)*srcP);

--- a/engines/access/screen.h
+++ b/engines/access/screen.h
@@ -49,9 +49,9 @@ struct ScreenSave {
 class Screen : public BaseSurface {
 private:
 	AccessEngine *_vm;
-	byte _tempPalette[PALETTE_SIZE];
-	byte _rawPalette[PALETTE_SIZE];
-	byte _savedPalettes[2][PALETTE_SIZE];
+	byte _tempPalette[Graphics::PALETTE_SIZE];
+	byte _rawPalette[Graphics::PALETTE_SIZE];
+	byte _savedPalettes[2][Graphics::PALETTE_SIZE];
 	int _savedPaletteCount;
 	int _vesaCurrentWin;
 	int _currentPanel;

--- a/engines/ags/globals.cpp
+++ b/engines/ags/globals.cpp
@@ -200,7 +200,7 @@ Globals::Globals() {
 	_debugConsoleBuffer = new AGS::Shared::Bitmap();
 	_maincoltable = new COLOR_MAP();
 	_palette = new color[256];
-	for (int i = 0; i < PALETTE_COUNT; ++i)
+	for (int i = 0; i < Graphics::PALETTE_COUNT; ++i)
 		_palette[i].clear();
 
 

--- a/engines/ags/lib/allegro/color.cpp
+++ b/engines/ags/lib/allegro/color.cpp
@@ -47,9 +47,9 @@ void color::writeToFile(AGS::Shared::Stream *file) const {
 	file->WriteByte(filler);
 }
 
-static void convertPalette(const PALETTE src, byte dest[PALETTE_SIZE]) {
+static void convertPalette(const PALETTE src, byte dest[Graphics::PALETTE_SIZE]) {
 	const color *cSrc = (const color *)src;
-	for (int i = 0; i < PALETTE_COUNT; ++i, cSrc++, dest += 3) {
+	for (int i = 0; i < Graphics::PALETTE_COUNT; ++i, cSrc++, dest += 3) {
 		dest[0] = VGA_COLOR_TRANS(cSrc->r);
 		dest[1] = VGA_COLOR_TRANS(cSrc->g);
 		dest[2] = VGA_COLOR_TRANS(cSrc->b);
@@ -58,9 +58,9 @@ static void convertPalette(const PALETTE src, byte dest[PALETTE_SIZE]) {
 
 static void applyPalette() {
 	if (g_system->getScreenFormat().bytesPerPixel == 1) {
-		byte pal[PALETTE_SIZE];
+		byte pal[Graphics::PALETTE_SIZE];
 		convertPalette(_G(current_palette), pal);
-		g_system->getPaletteManager()->setPalette(pal, 0, PALETTE_COUNT);
+		g_system->getPaletteManager()->setPalette(pal, 0, Graphics::PALETTE_COUNT);
 	}
 }
 

--- a/engines/bagel/baglib/cursor.cpp
+++ b/engines/bagel/baglib/cursor.cpp
@@ -149,7 +149,7 @@ void CBagCursor::unLoad() {
 
 void CBagCursor::setCurrent() {
 	_currentCursor = this;
-	CursorMan.replaceCursorPalette(_bitmap->getPalette()->getData(), 0, PALETTE_COUNT);
+	CursorMan.replaceCursorPalette(_bitmap->getPalette()->getData(), 0, Graphics::PALETTE_COUNT);
 	CursorMan.replaceCursor(_bitmap->getSurface(), _x, _y, 1);
 }
 

--- a/engines/bagel/boflib/gfx/bitmap.cpp
+++ b/engines/bagel/boflib/gfx/bitmap.cpp
@@ -180,7 +180,7 @@ ErrorCode CBofBitmap::loadBitmap(const char *pszFileName, CBofPalette *pPalette)
 		_bitmap.copyFrom(*decoder.getSurface());
 
 		// Load the bitmap palette
-		_bitmap.setPalette(decoder.getPalette(), 0, PALETTE_COUNT);
+		_bitmap.setPalette(decoder.getPalette(), 0, Graphics::PALETTE_COUNT);
 
 		_nDX = _bitmap.w;
 		_nDY = _bitmap.h;
@@ -599,7 +599,7 @@ ErrorCode CBofBitmap::captureScreen(CBofWindow *pWnd, CBofRect *pSrcRect, CBofRe
 
 		// If we're capturing the screen, we have to convert the format first.
 		if (!_bUseBackdrop || pBackdrop == nullptr) {
-			Graphics::Surface *tmp = pWnd->getSurface()->rawSurface().convertTo(_bitmap.format, nullptr, 0, _pPalette->getData(), PALETTE_COUNT);
+			Graphics::Surface *tmp = pWnd->getSurface()->rawSurface().convertTo(_bitmap.format, nullptr, 0, _pPalette->getData(), Graphics::PALETTE_COUNT);
 			_bitmap.blitFrom(*tmp, cSrcRect, cDestRect);
 			tmp->free();
 			delete tmp;
@@ -625,7 +625,7 @@ void CBofBitmap::setPalette(CBofPalette *pBofPalette, bool bOwnPalette) {
 		_bOwnPalette = bOwnPalette;
 		_pPalette = pBofPalette;
 
-		_bitmap.setPalette(_pPalette->getData(), 0, PALETTE_COUNT);
+		_bitmap.setPalette(_pPalette->getData(), 0, Graphics::PALETTE_COUNT);
 	}
 }
 
@@ -1114,7 +1114,7 @@ Graphics::ManagedSurface CBofBitmap::getSurface() {
 	s.h = _nDY;
 	s.pitch = _nScanDX;
 	s.format = Graphics::PixelFormat::createFormatCLUT8();
-	s.setPalette(_pPalette->getData(), 0, PALETTE_COUNT);
+	s.setPalette(_pPalette->getData(), 0, Graphics::PALETTE_COUNT);
 	s.setPixels(_pBits);
 
 	return s;

--- a/engines/bagel/boflib/gfx/palette.cpp
+++ b/engines/bagel/boflib/gfx/palette.cpp
@@ -33,7 +33,7 @@ CBofPalette *CBofPalette::_pSharedPalette;
 char CBofPalette::_szSharedPalFile[MAX_FNAME];
 
 HPALETTE::HPALETTE(int16 numColors) : _numColors(numColors) {
-	Common::fill(&_data[0], &_data[PALETTE_SIZE], 0);
+	Common::fill(&_data[0], &_data[Graphics::PALETTE_SIZE], 0);
 }
 
 void CBofPalette::initialize() {
@@ -42,11 +42,11 @@ void CBofPalette::initialize() {
 }
 
 CBofPalette::CBofPalette() {
-	Common::fill(&_palette._data[0], &_palette._data[PALETTE_SIZE], 0);
+	Common::fill(&_palette._data[0], &_palette._data[Graphics::PALETTE_SIZE], 0);
 }
 
 CBofPalette::CBofPalette(const char *pszFileName) {
-	Common::fill(&_palette._data[0], &_palette._data[PALETTE_SIZE], 0);
+	Common::fill(&_palette._data[0], &_palette._data[Graphics::PALETTE_SIZE], 0);
 	assert(pszFileName != nullptr);
 
 	loadPalette(pszFileName);
@@ -105,7 +105,7 @@ ErrorCode CBofPalette::loadPalette(const char *pszFileName, uint16 nFlags) {
 }
 
 void CBofPalette::ReleasePalette() {
-	Common::fill(_palette._data, _palette._data + PALETTE_SIZE, 0);
+	Common::fill(_palette._data, _palette._data + Graphics::PALETTE_SIZE, 0);
 }
 
 CBofPalette *CBofPalette::copyPalette() {
@@ -115,7 +115,7 @@ CBofPalette *CBofPalette::copyPalette() {
 }
 
 byte CBofPalette::getNearestIndex(RGBCOLOR stRGB) {
-	Graphics::PaletteLookup lookup(_palette._data, PALETTE_COUNT);
+	Graphics::PaletteLookup lookup(_palette._data, Graphics::PALETTE_COUNT);
 	return lookup.findBestColor(GetRed(stRGB), GetGreen(stRGB), GetBlue(stRGB));
 }
 

--- a/engines/bagel/boflib/gfx/palette.h
+++ b/engines/bagel/boflib/gfx/palette.h
@@ -36,9 +36,9 @@ namespace Bagel {
 
 typedef uint32 RGBCOLOR;
 struct HPALETTE {
-	byte _data[PALETTE_SIZE];
+	byte _data[Graphics::PALETTE_SIZE];
 	int16 _numColors;
-	HPALETTE(int16 numColors = PALETTE_COUNT);
+	HPALETTE(int16 numColors = Graphics::PALETTE_COUNT);
 };
 
 struct PALETTEENTRY {
@@ -124,7 +124,7 @@ public:
 	}
 
 	void setData(const byte* colors) {
-		memcpy(_palette._data, colors, PALETTE_SIZE);
+		memcpy(_palette._data, colors, Graphics::PALETTE_SIZE);
 	}
 
 	virtual ~CBofPalette();

--- a/engines/chewy/mcga_graphics.cpp
+++ b/engines/chewy/mcga_graphics.cpp
@@ -44,7 +44,7 @@ void McgaGraphics::init() {
 }
 
 void setScummVMPalette(const byte *palette, uint start, uint count) {
-	byte tempPal[PALETTE_SIZE];
+	byte tempPal[Graphics::PALETTE_SIZE];
 	byte *dest = &tempPal[0];
 
 	for (uint i = 0; i < count * 3; ++i, ++palette, ++dest)
@@ -64,7 +64,7 @@ void McgaGraphics::setPointer(byte *ptr) {
 void McgaGraphics::setPalette(byte *palette) {
 	for (int16 i = 0; i < 768; i++)
 		_palTable[i] = palette[i];
-	setScummVMPalette(palette, 0, PALETTE_COUNT);
+	setScummVMPalette(palette, 0, Graphics::PALETTE_COUNT);
 }
 
 void McgaGraphics::raster_col(int16 c, int16 r, int16 g, int16 b) {
@@ -92,7 +92,7 @@ void McgaGraphics::fadeIn(byte *palette) {
 				_palTable[k + 2] = b1;
 			k += 3;
 		}
-		setScummVMPalette(_palTable, 0, PALETTE_COUNT);
+		setScummVMPalette(_palTable, 0, Graphics::PALETTE_COUNT);
 	}
 }
 
@@ -111,7 +111,7 @@ void McgaGraphics::fadeOut() {
 			_palTable[k + 2] = b;
 			k += 3;
 		}
-		setScummVMPalette(_palTable, 0, PALETTE_COUNT);
+		setScummVMPalette(_palTable, 0, Graphics::PALETTE_COUNT);
 	}
 }
 

--- a/engines/chewy/mcga_graphics.h
+++ b/engines/chewy/mcga_graphics.h
@@ -75,7 +75,7 @@ private:
 	void clip(byte *&source, byte *&dest, int16 &x, int16 &y);
 	void zoom_set(byte *source, int16 x, int16 y, int16 xDiff, int16 yDiff, int16 scrWidth);
 
-	byte _palTable[PALETTE_SIZE];
+	byte _palTable[Graphics::PALETTE_SIZE];
 	uint8 _einfuegen = 0;
 
 	int _zoomSpriteDeltaX2;

--- a/engines/chewy/memory.cpp
+++ b/engines/chewy/memory.cpp
@@ -33,12 +33,12 @@ TafInfo *Memory::taf_adr(const char *filename) {
 	uint32 size = res->getAllSize() + imageCount * 8 + sizeof(TafInfo);
 	uint32 kgroesse = imageCount * sizeof(byte *);
 
-	byte *tmp1 = (byte *)MALLOC(size + PALETTE_SIZE + kgroesse);
+	byte *tmp1 = (byte *)MALLOC(size + Graphics::PALETTE_SIZE + kgroesse);
 	TafInfo *tinfo = (TafInfo *)tmp1;
 	tinfo->image = (byte **)(tmp1 + sizeof(TafInfo));
 	tinfo->palette = tmp1 + size;
 	tinfo->count = imageCount;
-	memcpy(tinfo->palette, res->getSpritePalette(), PALETTE_SIZE);
+	memcpy(tinfo->palette, res->getSpritePalette(), Graphics::PALETTE_SIZE);
 	byte *imgPtr = tmp1 + sizeof(TafInfo) + kgroesse;
 
 	for (int i = 0; i < imageCount; i++) {

--- a/engines/got/gfx/palette.cpp
+++ b/engines/got/gfx/palette.cpp
@@ -32,10 +32,10 @@ namespace Gfx {
 
 #define FADE_STEPS 10
 
-static byte saved_palette[PALETTE_SIZE];
+static byte saved_palette[Graphics::PALETTE_SIZE];
 
 Palette63::Palette63(const byte *pal) {
-	for (uint i = 0; i < PALETTE_SIZE; ++i)
+	for (uint i = 0; i < Graphics::PALETTE_SIZE; ++i)
 		_pal[i] = pal[i] << 2;
 }
 
@@ -63,12 +63,12 @@ void xSetPal(const byte color, const byte R, const byte G, const byte B) {
 }
 
 void xSetPal(const byte *pal) {
-	g_system->getPaletteManager()->setPalette(pal, 0, PALETTE_COUNT);
+	g_system->getPaletteManager()->setPalette(pal, 0, Graphics::PALETTE_COUNT);
 }
 
 void setPalette(const byte *pal) {
 	xSetPal(pal);
-	Common::copy(pal, pal + PALETTE_SIZE, saved_palette);
+	Common::copy(pal, pal + Graphics::PALETTE_SIZE, saved_palette);
 }
 
 void xGetPal(byte *pal, const int numColors, const int startIndex) {
@@ -76,18 +76,18 @@ void xGetPal(byte *pal, const int numColors, const int startIndex) {
 }
 
 void fadeOut() {
-	byte tempPal[PALETTE_SIZE];
+	byte tempPal[Graphics::PALETTE_SIZE];
 	const byte *srcP;
 	byte *destP;
 	int count;
 	Common::Event evt;
 
-	xGetPal(saved_palette, PALETTE_COUNT, 0);
+	xGetPal(saved_palette, Graphics::PALETTE_COUNT, 0);
 
 	for (int step = FADE_STEPS - 1; step >= 0; --step) {
 		// Set each palette RGB proportionately
 		for (srcP = &saved_palette[0], destP = &tempPal[0], count = 0;
-			 count < PALETTE_SIZE; ++count, ++srcP, ++destP) {
+			 count < Graphics::PALETTE_SIZE; ++count, ++srcP, ++destP) {
 			*destP = *srcP * step / FADE_STEPS;
 		}
 
@@ -106,23 +106,23 @@ void fadeOut() {
 }
 
 void fadeIn(const byte *pal) {
-	byte tempPal[PALETTE_SIZE];
+	byte tempPal[Graphics::PALETTE_SIZE];
 	const byte *srcP;
 	byte *destP;
 	int count;
 	Common::Event evt;
 
 	if (pal)
-		Common::copy(pal, pal + PALETTE_SIZE, saved_palette);
+		Common::copy(pal, pal + Graphics::PALETTE_SIZE, saved_palette);
 
 	// Start with a black palette
-	Common::fill(tempPal, tempPal + PALETTE_SIZE, 0);
+	Common::fill(tempPal, tempPal + Graphics::PALETTE_SIZE, 0);
 	xSetPal(tempPal);
 
 	for (int step = 1; step <= FADE_STEPS; ++step) {
 		// Set each palette RGB proportionately
 		for (srcP = &saved_palette[0], destP = &tempPal[0], count = 0;
-			 count < PALETTE_SIZE; ++count, ++srcP, ++destP) {
+			 count < Graphics::PALETTE_SIZE; ++count, ++srcP, ++destP) {
 			*destP = *srcP * step / FADE_STEPS;
 		}
 

--- a/engines/got/gfx/palette.h
+++ b/engines/got/gfx/palette.h
@@ -28,7 +28,7 @@ namespace Got {
 namespace Gfx {
 
 struct Palette63 {
-	byte _pal[PALETTE_SIZE] = {};
+	byte _pal[Graphics::PALETTE_SIZE] = {};
 	Palette63() {}
 	Palette63(const byte *pal);
 

--- a/engines/got/views/splash_screen.cpp
+++ b/engines/got/views/splash_screen.cpp
@@ -51,8 +51,8 @@ bool SplashScreen::msgFocus(const FocusMessage &msg) {
 	_delayCtr = 0;
 
 	// This is the first screen shown, so start with black, and fade it in
-	byte blackPal[PALETTE_SIZE];
-	Common::fill(blackPal, blackPal + PALETTE_SIZE, 0);
+	byte blackPal[Graphics::PALETTE_SIZE];
+	Common::fill(blackPal, blackPal + Graphics::PALETTE_SIZE, 0);
 	Gfx::xSetPal(blackPal);
 
 	draw();

--- a/engines/got/views/story.cpp
+++ b/engines/got/views/story.cpp
@@ -35,10 +35,10 @@ bool Story::msgFocus(const FocusMessage &msg) {
 		Common::String::format("STORY%d", _G(area));
 	resourceRead(storyName, _G(tmpBuff));
 
-	byte paletteBuffer[PALETTE_SIZE] = {};
+	byte paletteBuffer[Graphics::PALETTE_SIZE] = {};
 	resourceRead("STORYPAL", paletteBuffer);
 
-	for (int i = 0; i < PALETTE_SIZE; ++i)
+	for (int i = 0; i < Graphics::PALETTE_SIZE; ++i)
 		paletteBuffer[i] = ((int)paletteBuffer[i] * 255 + 31) / 63;
 	Gfx::setPalette(paletteBuffer);
 

--- a/engines/m4/m4.cpp
+++ b/engines/m4/m4.cpp
@@ -335,10 +335,10 @@ bool M4Engine::loadSaveThumbnail(int slotNum, M4sprite *thumbnail) const {
 	thumbnail->sourceOffset = 0;
 	thumbnail->data = data;
 
-	byte pal[PALETTE_SIZE];
+	byte pal[Graphics::PALETTE_SIZE];
 	byte r, g, b;
 	int proximity, minProximity;
-	g_system->getPaletteManager()->grabPalette(pal, 0, PALETTE_COUNT);
+	g_system->getPaletteManager()->grabPalette(pal, 0, Graphics::PALETTE_COUNT);
 
 	// Translate the 16-bit thumbnail to paletted
 	for (int y = 0; y < surf->h; ++y) {
@@ -350,7 +350,7 @@ bool M4Engine::loadSaveThumbnail(int slotNum, M4sprite *thumbnail) const {
 			surf->format.colorToRGB(*srcLine, r, g, b);
 
 			const byte *palP = pal;
-			for (int palIdx = 0; palIdx < PALETTE_COUNT; ++palIdx, palP += 3) {
+			for (int palIdx = 0; palIdx < Graphics::PALETTE_COUNT; ++palIdx, palP += 3) {
 				proximity = ABS((int)r - (int)palP[0]) +
 					ABS((int)g - (int)palP[1]) +
 					ABS((int)b - (int)palP[2]);

--- a/engines/mads/palette.h
+++ b/engines/mads/palette.h
@@ -34,9 +34,9 @@ class MADSEngine;
 #define PALETTE_RESERVED_LOW_COUNT 18
 #define PALETTE_RESERVED_HIGH_COUNT 10
 
-#define PALETTE_COUNT 256
-#define RGB_SIZE 3
-#define PALETTE_SIZE (256 * 3)
+constexpr int PALETTE_COUNT = 256;
+constexpr int RGB_SIZE = 3;
+constexpr int PALETTE_SIZE = (256 * 3);
 
 /**
  * Palette mapping options

--- a/engines/mm/mm1/mm1.cpp
+++ b/engines/mm/mm1/mm1.cpp
@@ -124,10 +124,10 @@ bool MM1Engine::setupEnhanced() {
 		error("Could not load palette");
 
 	// Load the Xeen palette
-	byte pal[PALETTE_SIZE];
-	for (int i = 0; i < PALETTE_SIZE; ++i)
+	byte pal[Graphics::PALETTE_SIZE];
+	for (int i = 0; i < Graphics::PALETTE_SIZE; ++i)
 		pal[i] = f.readByte() << 2;
-	g_system->getPaletteManager()->setPalette(pal, 0, PALETTE_COUNT);
+	g_system->getPaletteManager()->setPalette(pal, 0, Graphics::PALETTE_COUNT);
 	Gfx::GFX::findPalette(pal);
 
 	// Show the mouse cursor

--- a/engines/sherlock/image_file.cpp
+++ b/engines/sherlock/image_file.cpp
@@ -48,13 +48,13 @@ ImageFile::ImageFile(const Common::Path &name, bool skipPal, bool animImages) {
 	_name = name;
 	_stream = _vm->_res->load(name);
 
-	Common::fill(&_palette[0], &_palette[PALETTE_SIZE], 0);
+	Common::fill(&_palette[0], &_palette[Graphics::PALETTE_SIZE], 0);
 	load(*_stream, skipPal, animImages);
 }
 
 ImageFile::ImageFile(Common::SeekableReadStream &stream, bool skipPal) {
 	_stream = nullptr;
-	Common::fill(&_palette[0], &_palette[PALETTE_SIZE], 0);
+	Common::fill(&_palette[0], &_palette[Graphics::PALETTE_SIZE], 0);
 	load(stream, skipPal, false);
 }
 
@@ -191,7 +191,7 @@ void ImageFile::loadPalette(Common::SeekableReadStream &stream) {
 		}
 		// Found palette, so read it in
 		stream.seek(8, SEEK_CUR); // Skip over the rest of the signature text "VGA palette"
-		for (int idx = 0; idx < PALETTE_SIZE; ++idx)
+		for (int idx = 0; idx < Graphics::PALETTE_SIZE; ++idx)
 			_palette[idx] = VGA_COLOR_TRANS(stream.readByte());
 	} else {
 		// Not a palette, so rewind to start of frame data for normal frame processing

--- a/engines/sherlock/saveload.cpp
+++ b/engines/sherlock/saveload.cpp
@@ -186,7 +186,7 @@ void SaveManager::createThumbnail() {
 	_saveThumb = new Graphics::Surface();
 
 	if (!IS_3DO) {
-		uint8 thumbPalette[PALETTE_SIZE];
+		uint8 thumbPalette[Graphics::PALETTE_SIZE];
 		_vm->_screen->getPalette(thumbPalette);
 		::createThumbnail(_saveThumb, (const byte *)_vm->_screen->getPixels(), SHERLOCK_SCREEN_WIDTH, SHERLOCK_SCREEN_HEIGHT, thumbPalette);
 	} else {

--- a/engines/sherlock/scalpel/scalpel.cpp
+++ b/engines/sherlock/scalpel/scalpel.cpp
@@ -357,11 +357,11 @@ void ScalpelEngine::showOpening() {
 }
 
 bool ScalpelEngine::showCityCutscene() {
-	byte greyPalette[PALETTE_SIZE];
-	byte palette[PALETTE_SIZE];
+	byte greyPalette[Graphics::PALETTE_SIZE];
+	byte palette[Graphics::PALETTE_SIZE];
 
 	// Demo fades from black into grey and then fades from grey into the scene
-	Common::fill(&greyPalette[0], &greyPalette[PALETTE_SIZE], 142);
+	Common::fill(&greyPalette[0], &greyPalette[Graphics::PALETTE_SIZE], 142);
 	_screen->fadeIn((const byte *)greyPalette, 3);
 
 	_music->loadSong("prolog1");
@@ -475,7 +475,7 @@ bool ScalpelEngine::showCityCutscene() {
 }
 
 bool ScalpelEngine::showAlleyCutscene() {
-	byte palette[PALETTE_SIZE];
+	byte palette[Graphics::PALETTE_SIZE];
 	_music->loadSong("prolog2");
 
 	_animation->_gfxLibraryFilename = "TITLE.LIB";

--- a/engines/sherlock/scalpel/scalpel_journal.cpp
+++ b/engines/sherlock/scalpel/scalpel_journal.cpp
@@ -231,16 +231,16 @@ void ScalpelJournal::loadLocations() {
 void ScalpelJournal::drawFrame() {
 	Resources &res = *_vm->_res;
 	ScalpelScreen &screen = *(ScalpelScreen *)_vm->_screen;
-	byte palette[PALETTE_SIZE];
+	byte palette[Graphics::PALETTE_SIZE];
 
 	// Load in the journal background
 	Common::SeekableReadStream *bg = res.load("journal.lbv");
 	bg->read(screen._backBuffer1.getPixels(), SHERLOCK_SCREEN_WIDTH * SHERLOCK_SCREEN_HEIGHT);
-	bg->read(palette, PALETTE_SIZE);
+	bg->read(palette, Graphics::PALETTE_SIZE);
 	delete bg;
 
 	// Translate the palette for display
-	for (int idx = 0; idx < PALETTE_SIZE; ++idx)
+	for (int idx = 0; idx < Graphics::PALETTE_SIZE; ++idx)
 		palette[idx] = VGA_COLOR_TRANS(palette[idx]);
 
 	// Set the palette and print the title

--- a/engines/sherlock/scalpel/tsage/logo.cpp
+++ b/engines/sherlock/scalpel/tsage/logo.cpp
@@ -440,9 +440,9 @@ Logo::Logo(ScalpelEngine *vm) : _vm(vm), _lib("sf3.rlb") {
 	_vm->_screen->getPalette(_originalPalette);
 
 	// Set up the palettes
-	Common::fill(&_palette1[0], &_palette1[PALETTE_SIZE], 0);
-	Common::fill(&_palette1[0], &_palette2[PALETTE_SIZE], 0);
-	Common::fill(&_palette1[0], &_palette3[PALETTE_SIZE], 0);
+	Common::fill(&_palette1[0], &_palette1[Graphics::PALETTE_SIZE], 0);
+	Common::fill(&_palette1[0], &_palette2[Graphics::PALETTE_SIZE], 0);
+	Common::fill(&_palette1[0], &_palette3[Graphics::PALETTE_SIZE], 0);
 
 	_lib.getPalette(_palette1, 1111);
 	_lib.getPalette(_palette1, 10);
@@ -550,8 +550,8 @@ void Logo::nextFrame() {
 
 	case 4:
 		// Load the new palette
-		byte palette[PALETTE_SIZE];
-		Common::copy(&_palette2[0], &_palette2[PALETTE_SIZE], &palette[0]);
+		byte palette[Graphics::PALETTE_SIZE];
+		Common::copy(&_palette2[0], &_palette2[Graphics::PALETTE_SIZE], &palette[0]);
 		_lib.getPalette(palette, 12);
 		screen.clear();
 		screen.setPalette(palette);
@@ -646,19 +646,19 @@ void Logo::loadBackground() {
 	}
 
 	// Default to a blank palette
-	byte palette[PALETTE_SIZE];
-	Common::fill(&palette[0], &palette[PALETTE_SIZE], 0);
+	byte palette[Graphics::PALETTE_SIZE];
+	Common::fill(&palette[0], &palette[Graphics::PALETTE_SIZE], 0);
 	screen.setPalette(palette);
 
 	// Copy the surface to the screen
 	screen.SHblitFrom(screen._backBuffer1);
 }
 
-void Logo::fade(const byte palette[PALETTE_SIZE], int step) {
+void Logo::fade(const byte palette[Graphics::PALETTE_SIZE], int step) {
 	Events &events = *_vm->_events;
 	Screen &screen = *_vm->_screen;
-	byte startPalette[PALETTE_SIZE];
-	byte tempPalette[PALETTE_SIZE];
+	byte startPalette[Graphics::PALETTE_SIZE];
+	byte tempPalette[Graphics::PALETTE_SIZE];
 
 	screen.getPalette(startPalette);
 

--- a/engines/sherlock/scalpel/tsage/logo.h
+++ b/engines/sherlock/scalpel/tsage/logo.h
@@ -196,10 +196,10 @@ private:
 	TLib _lib;
 	int _counter, _frameCounter;
 	bool _finished;
-	byte _originalPalette[PALETTE_SIZE];
-	byte _palette1[PALETTE_SIZE];
-	byte _palette2[PALETTE_SIZE];
-	byte _palette3[PALETTE_SIZE];
+	byte _originalPalette[Graphics::PALETTE_SIZE];
+	byte _palette1[Graphics::PALETTE_SIZE];
+	byte _palette2[Graphics::PALETTE_SIZE];
+	byte _palette3[Graphics::PALETTE_SIZE];
 	Object _objects[4];
 	uint _waitFrames;
 	uint32 _waitStartFrame;
@@ -237,7 +237,7 @@ private:
 	/**
 	 * Fade from the current palette to a new one
 	 */
-	void fade(const byte palette[PALETTE_SIZE], int step = 6);
+	void fade(const byte palette[Graphics::PALETTE_SIZE], int step = 6);
 public:
 	static bool show(ScalpelEngine *vm);
 };

--- a/engines/sherlock/scalpel/tsage/resources.cpp
+++ b/engines/sherlock/scalpel/tsage/resources.cpp
@@ -294,7 +294,7 @@ void TLib::loadIndex() {
  *
  * @paletteNum Specefies the palette number
  */
-void TLib::getPalette(byte palette[PALETTE_SIZE], int paletteNum) {
+void TLib::getPalette(byte palette[Graphics::PALETTE_SIZE], int paletteNum) {
 	// Get the specified palette
 	Common::SeekableReadStream *stream = getResource(RES_PALETTE, paletteNum, 0, true);
 	if (!stream)

--- a/engines/sherlock/scalpel/tsage/resources.h
+++ b/engines/sherlock/scalpel/tsage/resources.h
@@ -128,7 +128,7 @@ public:
 	Common::SeekableReadStream *getResource(uint16 id, bool suppressErrors = false);
 	Common::SeekableReadStream *getResource(ResourceType resType, uint16 resNum, uint16 rlbNum, bool suppressErrors = false);
 	uint32 getResourceStart(ResourceType resType, uint16 resNum, uint16 rlbNum, ResourceEntry &entry);
-	void getPalette(byte palette[PALETTE_SIZE], int paletteNum);
+	void getPalette(byte palette[Graphics::PALETTE_SIZE], int paletteNum);
 };
 
 } // end of namespace TsAGE

--- a/engines/sherlock/scene.cpp
+++ b/engines/sherlock/scene.cpp
@@ -47,7 +47,7 @@ BgFileHeader::BgFileHeader() {
 	_scrollSize = -1;
 	_bytesWritten = -1;
 	_fadeStyle = -1;
-	Common::fill(&_palette[0], &_palette[PALETTE_SIZE], 0);
+	Common::fill(&_palette[0], &_palette[Graphics::PALETTE_SIZE], 0);
 }
 
 void BgFileHeader::load(Common::SeekableReadStream &s, bool isRoseTattoo) {
@@ -363,7 +363,7 @@ bool Scene::loadScene(const Common::Path &filename) {
 
 				// Handle initializing the palette
 				screen.initPaletteFade(bgHeader._bytesWritten);
-				rrmStream->read(screen._cMap, PALETTE_SIZE);
+				rrmStream->read(screen._cMap, Graphics::PALETTE_SIZE);
 				paletteLoaded();
 				screen.translatePalette(screen._cMap);
 
@@ -636,9 +636,9 @@ bool Scene::loadScene(const Common::Path &filename) {
 				}
 			} else {
 				// Read in palette
-				rrmStream->read(screen._cMap, PALETTE_SIZE);
+				rrmStream->read(screen._cMap, Graphics::PALETTE_SIZE);
 				screen.translatePalette(screen._cMap);
-				Common::copy(screen._cMap, screen._cMap + PALETTE_SIZE, screen._sMap);
+				Common::copy(screen._cMap, screen._cMap + Graphics::PALETTE_SIZE, screen._sMap);
 
 				// Read in the background
 				Common::SeekableReadStream *bgStream = !_compressed ? rrmStream :

--- a/engines/sherlock/scene.h
+++ b/engines/sherlock/scene.h
@@ -51,7 +51,7 @@ struct BgFileHeader {
 	int _scrollSize;
 	int _bytesWritten;				// Size of the main body of the RRM
 	int _fadeStyle;					// Fade style
-	byte _palette[PALETTE_SIZE];	// Palette
+	byte _palette[Graphics::PALETTE_SIZE];	// Palette
 
 
 	BgFileHeader();

--- a/engines/sherlock/screen.cpp
+++ b/engines/sherlock/screen.cpp
@@ -43,9 +43,9 @@ Screen::Screen(SherlockEngine *vm) : BaseSurface(), _vm(vm),
 		_backBuffer2(vm->getGameID() == GType_RoseTattoo ? 640 : 320, vm->getGameID() == GType_RoseTattoo ? 480 : 200) {
 	_transitionSeed = 1;
 	_fadeStyle = false;
-	Common::fill(&_cMap[0], &_cMap[PALETTE_SIZE], 0);
-	Common::fill(&_sMap[0], &_sMap[PALETTE_SIZE], 0);
-	Common::fill(&_tMap[0], &_tMap[PALETTE_SIZE], 0);
+	Common::fill(&_cMap[0], &_cMap[Graphics::PALETTE_SIZE], 0);
+	Common::fill(&_sMap[0], &_sMap[Graphics::PALETTE_SIZE], 0);
+	Common::fill(&_tMap[0], &_tMap[Graphics::PALETTE_SIZE], 0);
 
 	// Set up the initial font
 	setFont(IS_SERRATED_SCALPEL ? 1 : 4);
@@ -71,14 +71,14 @@ void Screen::activateBackBuffer2() {
 	_backBuffer.create(_backBuffer2, _backBuffer2.getBounds());
 }
 
-int Screen::equalizePalette(const byte palette[PALETTE_SIZE]) {
+int Screen::equalizePalette(const byte palette[Graphics::PALETTE_SIZE]) {
 	int total = 0;
-	byte tempPalette[PALETTE_SIZE];
+	byte tempPalette[Graphics::PALETTE_SIZE];
 	getPalette(tempPalette);
 
 	// For any palette component that doesn't already match the given destination
 	// palette, change by 1 towards the reference palette component
-	for (int idx = 0; idx < PALETTE_SIZE; ++idx) {
+	for (int idx = 0; idx < Graphics::PALETTE_SIZE; ++idx) {
 		if (tempPalette[idx] > palette[idx]) {
 			tempPalette[idx] = MAX((int)palette[idx], (int)tempPalette[idx] - 4);
 			++total;
@@ -96,8 +96,8 @@ int Screen::equalizePalette(const byte palette[PALETTE_SIZE]) {
 }
 
 void Screen::fadeToBlack(int speed) {
-	byte tempPalette[PALETTE_SIZE];
-	Common::fill(&tempPalette[0], &tempPalette[PALETTE_SIZE], 0);
+	byte tempPalette[Graphics::PALETTE_SIZE];
+	Common::fill(&tempPalette[0], &tempPalette[Graphics::PALETTE_SIZE], 0);
 
 	while (equalizePalette(tempPalette)) {
 		_vm->_events->delay(15 * speed);
@@ -107,7 +107,7 @@ void Screen::fadeToBlack(int speed) {
 	fillRect(Common::Rect(0, 0, this->w, this->h), 0);
 }
 
-void Screen::fadeIn(const byte palette[PALETTE_SIZE], int speed) {
+void Screen::fadeIn(const byte palette[Graphics::PALETTE_SIZE], int speed) {
 	int count = 50;
 	while (equalizePalette(palette) && --count) {
 		_vm->_events->delay(15 * speed);
@@ -351,8 +351,8 @@ void Screen::synchronize(Serializer &s) {
 }
 
 void Screen::initPaletteFade(int bytesToRead) {
-	Common::copy(&_cMap[0], &_cMap[PALETTE_SIZE], &_sMap[0]);
-	Common::copy(&_cMap[0], &_cMap[PALETTE_SIZE], &_tMap[0]);
+	Common::copy(&_cMap[0], &_cMap[Graphics::PALETTE_SIZE], &_sMap[0]);
+	Common::copy(&_cMap[0], &_cMap[Graphics::PALETTE_SIZE], &_tMap[0]);
 
 	// Set how many bytes need to be read / have been read
 	_fadeBytesRead = 0;
@@ -366,8 +366,8 @@ int Screen::fadeRead(Common::SeekableReadStream &stream, byte *buf, int totalSiz
 	return totalSize;
 }
 
-void Screen::translatePalette(byte palette[PALETTE_SIZE]) {
-	for (int idx = 0; idx < PALETTE_SIZE; ++idx)
+void Screen::translatePalette(byte palette[Graphics::PALETTE_SIZE]) {
+	for (int idx = 0; idx < Graphics::PALETTE_SIZE; ++idx)
 		palette[idx] = VGA_COLOR_TRANS(palette[idx]);
 }
 

--- a/engines/sherlock/screen.h
+++ b/engines/sherlock/screen.h
@@ -51,9 +51,9 @@ protected:
 public:
 	Surface _backBuffer1, _backBuffer2;
 	bool _fadeStyle;
-	byte _cMap[PALETTE_SIZE];
-	byte _sMap[PALETTE_SIZE];
-	byte _tMap[PALETTE_SIZE];
+	byte _cMap[Graphics::PALETTE_SIZE];
+	byte _sMap[Graphics::PALETTE_SIZE];
+	byte _tMap[Graphics::PALETTE_SIZE];
 	bool _flushScreen;
 	Common::Point _currentScroll;
 public:
@@ -79,7 +79,7 @@ public:
 	/**
 	 * Fades from the currently active palette to the passed palette
 	 */
-	int equalizePalette(const byte palette[PALETTE_SIZE]);
+	int equalizePalette(const byte palette[Graphics::PALETTE_SIZE]);
 
 	/**
 	 * Fade out the palette to black
@@ -89,7 +89,7 @@ public:
 	/**
 	 * Fade in a given palette
 	 */
-	void fadeIn(const byte palette[PALETTE_SIZE], int speed = 2);
+	void fadeIn(const byte palette[Graphics::PALETTE_SIZE], int speed = 2);
 
 	/**
 	 * Do a random pixel transition in from _backBuffer surface to the screen
@@ -196,7 +196,7 @@ public:
 	 * Translate a palette from 6-bit RGB values to full 8-bit values suitable for passing
 	 * to the underlying palette manager
 	 */
-	static void translatePalette(byte palette[PALETTE_SIZE]);
+	static void translatePalette(byte palette[Graphics::PALETTE_SIZE]);
 };
 
 } // End of namespace Sherlock

--- a/engines/sherlock/tattoo/tattoo.cpp
+++ b/engines/sherlock/tattoo/tattoo.cpp
@@ -141,7 +141,7 @@ void TattooEngine::startScene() {
 void TattooEngine::loadInitialPalette() {
 	byte palette[768];
 	Common::SeekableReadStream *stream = _res->load("room.pal");
-	stream->read(palette, PALETTE_SIZE);
+	stream->read(palette, Graphics::PALETTE_SIZE);
 	_screen->translatePalette(palette);
 	_screen->setPalette(palette);
 

--- a/engines/sherlock/tattoo/tattoo_darts.cpp
+++ b/engines/sherlock/tattoo/tattoo_darts.cpp
@@ -350,7 +350,7 @@ void Darts::initDarts() {
 void Darts::loadDarts() {
 	Resources &res = *_vm->_res;
 	Screen &screen = *_vm->_screen;
-	byte palette[PALETTE_SIZE];
+	byte palette[Graphics::PALETTE_SIZE];
 
 	// Load images
 	_hand1 = new ImageFile("hand1.vgs");
@@ -362,7 +362,7 @@ void Darts::loadDarts() {
 
 	// Load and set the palette
 	Common::SeekableReadStream *stream = res.load("DartBd.pal");
-	stream->read(palette, PALETTE_SIZE);
+	stream->read(palette, Graphics::PALETTE_SIZE);
 	screen.translatePalette(palette);
 	screen.setPalette(palette);
 	delete stream;

--- a/engines/sherlock/tattoo/tattoo_journal.cpp
+++ b/engines/sherlock/tattoo/tattoo_journal.cpp
@@ -48,7 +48,7 @@ void TattooJournal::show() {
 	Resources &res = *_vm->_res;
 	Screen &screen = *_vm->_screen;
 	TattooUserInterface &ui = *(TattooUserInterface *)_vm->_ui;
-	byte palette[PALETTE_SIZE];
+	byte palette[Graphics::PALETTE_SIZE];
 
 	Common::Point oldScroll = screen._currentScroll;
 	screen._currentScroll = Common::Point(0, 0);
@@ -58,7 +58,7 @@ void TattooJournal::show() {
 
 	// Load palette
 	Common::SeekableReadStream *stream = res.load("journal.pal");
-	stream->read(palette, PALETTE_SIZE);
+	stream->read(palette, Graphics::PALETTE_SIZE);
 	ui.setupBGArea(palette);
 	screen.translatePalette(palette);
 	delete stream;

--- a/engines/sherlock/tattoo/tattoo_map.cpp
+++ b/engines/sherlock/tattoo/tattoo_map.cpp
@@ -97,7 +97,7 @@ int TattooMap::show() {
 
 	// Load the palette
 	Common::SeekableReadStream *stream = res.load("map.pal");
-	stream->read(screen._cMap, PALETTE_SIZE);
+	stream->read(screen._cMap, Graphics::PALETTE_SIZE);
 	screen.translatePalette(screen._cMap);
 	delete stream;
 

--- a/engines/sherlock/tattoo/tattoo_user_interface.cpp
+++ b/engines/sherlock/tattoo/tattoo_user_interface.cpp
@@ -43,8 +43,8 @@ bool WidgetList::contains(const WidgetBase *item) const {
 TattooUserInterface::TattooUserInterface(SherlockEngine *vm): UserInterface(vm),
 		_inventoryWidget(vm), _messageWidget(vm), _textWidget(vm), _tooltipWidget(vm),
 		_verbsWidget(vm), _creditsWidget(vm), _optionsWidget(vm), _quitWidget(vm) {
-	Common::fill(&_lookupTable[0], &_lookupTable[PALETTE_COUNT], 0);
-	Common::fill(&_lookupTable1[0], &_lookupTable1[PALETTE_COUNT], 0);
+	Common::fill(&_lookupTable[0], &_lookupTable[Graphics::PALETTE_COUNT], 0);
+	Common::fill(&_lookupTable1[0], &_lookupTable1[Graphics::PALETTE_COUNT], 0);
 	_scrollSize = 0;
 	_scrollSpeed = 16;
 	_drawMenu = false;
@@ -214,10 +214,10 @@ void TattooUserInterface::doJournal() {
 	TattooJournal &journal = *(TattooJournal *)_vm->_journal;
 	TattooScene &scene = *(TattooScene *)_vm->_scene;
 	Screen &screen = *_vm->_screen;
-	byte lookupTable[PALETTE_COUNT], lookupTable1[PALETTE_COUNT];
+	byte lookupTable[Graphics::PALETTE_COUNT], lookupTable1[Graphics::PALETTE_COUNT];
 
-	Common::copy(&_lookupTable[0], &_lookupTable[PALETTE_COUNT], &lookupTable[0]);
-	Common::copy(&_lookupTable1[0], &_lookupTable1[PALETTE_COUNT], &lookupTable1[0]);
+	Common::copy(&_lookupTable[0], &_lookupTable[Graphics::PALETTE_COUNT], &lookupTable[0]);
+	Common::copy(&_lookupTable1[0], &_lookupTable1[Graphics::PALETTE_COUNT], &lookupTable1[0]);
 	_menuMode = JOURNAL_MODE;
 	journal.show();
 
@@ -228,8 +228,8 @@ void TattooUserInterface::doJournal() {
 	// Restore the old screen palette and greyscale lookup table
 	screen.clear();
 	screen.setPalette(screen._cMap);
-	Common::copy(&lookupTable[0], &lookupTable[PALETTE_COUNT], &_lookupTable[0]);
-	Common::copy(&lookupTable1[0], &lookupTable1[PALETTE_COUNT], &_lookupTable1[0]);
+	Common::copy(&lookupTable[0], &lookupTable[Graphics::PALETTE_COUNT], &_lookupTable[0]);
+	Common::copy(&lookupTable1[0], &lookupTable1[Graphics::PALETTE_COUNT], &_lookupTable1[0]);
 
 	// Restore the scene
 	screen._backBuffer1.SHblitFrom(screen._backBuffer2);
@@ -658,20 +658,20 @@ void TattooUserInterface::putMessage(const char *formatStr, ...) {
 	_messageWidget.summonWindow();
 }
 
-void TattooUserInterface::setupBGArea(const byte cMap[PALETTE_SIZE]) {
+void TattooUserInterface::setupBGArea(const byte cMap[Graphics::PALETTE_SIZE]) {
 	Scene &scene = *_vm->_scene;
 
 	// This requires that there is a 16 grayscale palette sequence in the palette that goes from lighter
 	// to darker as the palette numbers go up. The last palette entry in that run is specified by _bgColor
 	byte *p = &_lookupTable[0];
-	for (int idx = 0; idx < PALETTE_COUNT; ++idx)
+	for (int idx = 0; idx < Graphics::PALETTE_COUNT; ++idx)
 		*p++ = BG_GREYSCALE_RANGE_END - (cMap[idx * 3] * 30 + cMap[idx * 3 + 1] * 59 + cMap[idx * 3 + 2] * 11) / 480;
 
 	// If we're going to a scene with a haze special effect, initialize the translate table to lighten the colors
 	if (_mask != nullptr) {
 		p = &_lookupTable1[0];
 
-		for (int idx = 0; idx < PALETTE_COUNT; ++idx) {
+		for (int idx = 0; idx < Graphics::PALETTE_COUNT; ++idx) {
 			int r, g, b;
 			switch (scene._currentScene) {
 			case 8:
@@ -702,7 +702,7 @@ void TattooUserInterface::setupBGArea(const byte cMap[PALETTE_SIZE]) {
 			byte c = 0xff;
 			int cd = 99999;
 
-			for (int pal = 0; pal < PALETTE_COUNT; ++pal) {
+			for (int pal = 0; pal < Graphics::PALETTE_COUNT; ++pal) {
 				int d = (r - cMap[pal * 3]) * (r - cMap[pal * 3]) + (g - cMap[pal * 3 + 1]) * (g - cMap[pal * 3 + 1]) +
 					(b - cMap[pal * 3 + 2]) * (b - cMap[pal * 3 + 2]);
 

--- a/engines/sherlock/tattoo/tattoo_user_interface.h
+++ b/engines/sherlock/tattoo/tattoo_user_interface.h
@@ -64,8 +64,8 @@ private:
 	WidgetQuit _quitWidget;
 	WidgetList _fixedWidgets;
 	WidgetList _widgets;
-	byte _lookupTable[PALETTE_COUNT];
-	byte _lookupTable1[PALETTE_COUNT];
+	byte _lookupTable[Graphics::PALETTE_COUNT];
+	byte _lookupTable1[Graphics::PALETTE_COUNT];
 private:
 	/**
 	 * Handle any input when we're in standard mode (with no windows open)
@@ -177,7 +177,7 @@ public:
 	/**
 	 * Makes a greyscale translation table for each palette entry in the table
 	 */
-	void setupBGArea(const byte cMap[PALETTE_SIZE]);
+	void setupBGArea(const byte cMap[Graphics::PALETTE_SIZE]);
 
 	/**
 	 * Erase any background as needed before drawing frame

--- a/engines/twine/renderer/screens.cpp
+++ b/engines/twine/renderer/screens.cpp
@@ -125,7 +125,7 @@ static bool loadImageDelayViaDecoder(TwinEEngine *engine, const Common::Path &fi
 	Graphics::ManagedSurface &target = engine->_frontVideoBuffer;
 	Common::Rect rect(src->w, src->h);
 	if (decoder.getPaletteColorCount() == 0) {
-		uint8 pal[PALETTE_SIZE];
+		uint8 pal[Graphics::PALETTE_SIZE];
 		engine->_frontVideoBuffer.getPalette(pal, 0, 256);
 		Graphics::Surface *source = decoder.getSurface()->convertTo(target.format, nullptr, 0, pal, 256);
 		target.blitFrom(*source, rect, target.getBounds());

--- a/engines/ultima/shared/early/game.cpp
+++ b/engines/ultima/shared/early/game.cpp
@@ -98,14 +98,14 @@ void Game::setEGAPalette(const byte *palette) {
 void Game::loadU6Palette() {
 	// Read in the palette
 	File f("u6pal");
-	byte palette[PALETTE_SIZE];
-	f.read(palette, PALETTE_SIZE);
+	byte palette[Graphics::PALETTE_SIZE];
+	f.read(palette, Graphics::PALETTE_SIZE);
 	f.close();
 
 	// Adjust the palette values from 0-63 to 0-255, and set the palette
-	for (int idx = 0; idx < PALETTE_SIZE; ++idx)
+	for (int idx = 0; idx < Graphics::PALETTE_SIZE; ++idx)
 		palette[idx] = VGA_COLOR_TRANS(palette[idx]);
-	g_vm->_screen->setPalette(&palette[0], 0, PALETTE_COUNT);
+	g_vm->_screen->setPalette(&palette[0], 0, Graphics::PALETTE_COUNT);
 
 	// TODO: Set appropriate indexes
 	_edgeColor = 15;

--- a/engines/ultima/ultima4/gfx/image.cpp
+++ b/engines/ultima/ultima4/gfx/image.cpp
@@ -103,9 +103,9 @@ void Image::setPalette(const byte *colors, unsigned n_colors) {
 void Image::setPaletteFromImage(const Image *src) {
 	assertMsg(_paletted && src->_paletted, "imageSetPaletteFromImage called on non-indexed image");
 
-	uint8 srcPal[PALETTE_COUNT * 3];
-	src->_surface->grabPalette(srcPal, 0, PALETTE_COUNT);
-	_surface->setPalette(srcPal, 0, PALETTE_COUNT);
+	uint8 srcPal[Graphics::PALETTE_COUNT * 3];
+	src->_surface->grabPalette(srcPal, 0, Graphics::PALETTE_COUNT);
+	_surface->setPalette(srcPal, 0, Graphics::PALETTE_COUNT);
 }
 
 RGBA Image::getPaletteColor(int index) {

--- a/engines/voyeur/screen.cpp
+++ b/engines/voyeur/screen.cpp
@@ -47,7 +47,7 @@ Screen::Screen(VoyeurEngine *vm) : Graphics::Screen(), _vm(vm), _drawPtr(&_defau
 	_backgroundPage = nullptr;
 	_vPort = nullptr;
 	_fontPtr = nullptr;
-	Common::fill(&_VGAColors[0], &_VGAColors[PALETTE_SIZE], 0);
+	Common::fill(&_VGAColors[0], &_VGAColors[Graphics::PALETTE_SIZE], 0);
 	_fontChar = new PictureResource(DISPFLAG_NONE, 0xff, 0xff, 0, Common::Rect(), 0, nullptr, 0);
 	_backColors = nullptr;
 }
@@ -1070,7 +1070,7 @@ void Screen::drawDot() {
 }
 
 void Screen::synchronize(Common::Serializer &s) {
-	s.syncBytes(&_VGAColors[0], PALETTE_SIZE);
+	s.syncBytes(&_VGAColors[0], Graphics::PALETTE_SIZE);
 }
 
 } // End of namespace Voyeur

--- a/engines/voyeur/screen.h
+++ b/engines/voyeur/screen.h
@@ -58,7 +58,7 @@ typedef void (Screen::*ViewPortRestorePtr)(ViewPortResource *);
 
 class Screen: public Graphics::Screen {
 public:
-	byte _VGAColors[PALETTE_SIZE];
+	byte _VGAColors[Graphics::PALETTE_SIZE];
 	PictureResource *_backgroundPage;
 	int _SVGAMode;
 	ViewPortListResource *_viewPortListPtr;

--- a/graphics/palette.h
+++ b/graphics/palette.h
@@ -34,8 +34,8 @@ enum ColorDistanceMethod {
 /**
  * Constants available for use in paletted code
  */
-#define PALETTE_COUNT 256
-#define PALETTE_SIZE (256 * 3)
+constexpr int PALETTE_COUNT = 256;
+constexpr int PALETTE_SIZE = (256 * 3);
 
 /**
  * @brief Simple class for handling a palette data.

--- a/graphics/paletteman.h
+++ b/graphics/paletteman.h
@@ -112,7 +112,7 @@ public:
 	virtual void grabPalette(byte *colors, uint start, uint num) const = 0;
 
 	Graphics::Palette grabPalette(uint start, uint num) {
-		byte tmp[PALETTE_SIZE];
+		byte tmp[Graphics::PALETTE_SIZE];
 		grabPalette(tmp, start, num);
 		return Graphics::Palette(tmp, num);
 	}


### PR DESCRIPTION
Expanded use of palette code showed warning of PALETTE_SIZE being redefined to a different size in Hopkins.
To avoid this issue the options are to either alter Hopkins to conform to the constants defined in graphics/palette.h or switch to constexpr for palette constants.
This PR uses constexpr, but we can easily go the other route if preferred. 