### PR TITLE
IMAGE: Fix 24bpp PCX image decoding.

### DIFF
--- a/image/pcx.cpp
+++ b/image/pcx.cpp
@@ -120,9 +120,9 @@ bool PCXDecoder::loadStream(Common::SeekableReadStream &stream) {
 			decodeRLE(stream, scanLine, bytesPerscanLine, compressed);
 
 			for (x = 0; x < width; x++) {
-				byte b = scanLine[x];
+				byte r = scanLine[x];
 				byte g = scanLine[x +  bytesPerLine];
-				byte r = scanLine[x + (bytesPerLine << 1)];
+				byte b = scanLine[x + (bytesPerLine << 1)];
 				uint32 color = format.RGBToColor(r, g, b);
 
 				*((uint32 *)dst) = color;


### PR DESCRIPTION
The RGB planes were flipped and TESTBED image decoder tests revealed this bug. AGS is the only engine that allows for 24bpp PCX image, but an example game is currently unknown.
