### PR TITLE
CONFIGURE: Make SVQ1 and QDM2 optional components

### DIFF
--- a/audio/decoders/qdm2.cpp
+++ b/audio/decoders/qdm2.cpp
@@ -22,10 +22,10 @@
 // Based off ffmpeg's QDM2 decoder
 
 #include "common/scummsys.h"
+
+#ifdef USE_QDM2
+
 #include "audio/decoders/qdm2.h"
-
-#ifdef AUDIO_QDM2_H
-
 #include "audio/audiostream.h"
 #include "audio/decoders/codec.h"
 #include "audio/decoders/qdm2data.h"

--- a/audio/decoders/qdm2.h
+++ b/audio/decoders/qdm2.h
@@ -19,11 +19,13 @@
  *
  */
 
-// Only compile if Mohawk is enabled or if we're building dynamic modules
-#if defined(ENABLE_MOHAWK) || defined(DYNAMIC_MODULES)
 
 #ifndef AUDIO_QDM2_H
 #define AUDIO_QDM2_H
+
+#include "common/scummsys.h"
+
+#ifdef USE_QDM2
 
 #include "common/types.h"
 
@@ -47,5 +49,5 @@ Codec *makeQDM2Decoder(Common::SeekableReadStream *extraData,
 
 } // End of namespace Audio
 
+#endif // USE_QDM2
 #endif // AUDIO_QDM2_H
-#endif // Mohawk/Plugins guard

--- a/audio/decoders/quicktime.cpp
+++ b/audio/decoders/quicktime.cpp
@@ -570,7 +570,7 @@ bool QuickTimeAudioDecoder::AudioSampleDesc::isAudioCodecSupported() const {
 	if (_codecTag == MKTAG('t', 'w', 'o', 's') || _codecTag == MKTAG('r', 'a', 'w', ' ') || _codecTag == MKTAG('i', 'm', 'a', '4'))
 		return true;
 
-#ifdef AUDIO_QDM2_H
+#ifdef USE_QDM2
 	if (_codecTag == MKTAG('Q', 'D', 'M', '2'))
 		return true;
 #endif
@@ -634,7 +634,7 @@ void QuickTimeAudioDecoder::AudioSampleDesc::initCodec() {
 
 	switch (_codecTag) {
 	case MKTAG('Q', 'D', 'M', '2'):
-#ifdef AUDIO_QDM2_H
+#ifdef USE_QDM2
 		_codec = makeQDM2Decoder(_extraData);
 #endif
 		break;

--- a/configure
+++ b/configure
@@ -293,8 +293,10 @@ _imgui=yes
 _indeo3=auto
 _indeo45=auto
 _hnm=auto
+_qdm2=auto
 _fmtowns_pc98_audio=auto
 _sid_audio=auto
+_svq1=auto
 _vgmtrans_audio=auto
 _midi=auto
 _universaltracker=auto
@@ -332,7 +334,9 @@ add_component theoradec "libtheoradec" "_theoradec" "USE_THEORADEC"
 add_component midi "MIDI synthesis" "_midi" "USE_MIDI"
 add_component mpc "MPC" "_libmpcdec" "USE_MPCDEC"
 add_component mpeg2 "mpeg2" "_mpeg2" "USE_MPEG2"
+add_component qdm2 "QDM2" "_qdm2" "USE_QDM2"
 add_component sid_audio "SID audio" "_sid_audio" "USE_SID_AUDIO"
+add_component svq1 "Sorenson Video 1" "_svq1" "USE_SVQ1"
 add_component tinygl "TinyGL" "_tinygl" "USE_TINYGL"
 add_component universaltracker "External Tracker Libraries" "_universaltracker" "USE_UNIVERSALTRACKER"
 add_component vgmtrans_audio "VGMTrans Soundfont audio" "_vgmtrans_audio" "USE_VGMTRANS_AUDIO"

--- a/engines/mohawk/configure.engine
+++ b/engines/mohawk/configure.engine
@@ -4,4 +4,4 @@ add_engine mohawk "Mohawk" yes "cstime myst mystme riven" "Living Books" "highre
 add_engine cstime "Where in Time is Carmen Sandiego?" no
 add_engine riven "Riven: The Sequel to Myst" yes "" "" "16bit"
 add_engine myst "Myst" yes
-add_engine mystme "Myst ME" yes "" "" "jpeg"
+add_engine mystme "Myst ME" yes "" "" "16bit jpeg" "qdm2 svq1"

--- a/engines/testbed/configure.engine
+++ b/engines/testbed/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine testbed "TestBed: the Testing framework" no "" "" "" "imgui midi universaltracker indeo3 indeo45 vpx mpc hnm mpeg2"
+add_engine testbed "TestBed: the Testing framework" no "" "" "" "imgui midi universaltracker indeo3 indeo45 vpx mpc hnm mpeg2 qdm2 svq1"

--- a/image/codecs/codec.cpp
+++ b/image/codecs/codec.cpp
@@ -288,8 +288,13 @@ Codec *createQuickTimeCodec(uint32 tag, int width, int height, int bitsPerPixel)
 		// Apple SMC: Used by some Myst videos.
 		return new SMCDecoder(width, height);
 	case MKTAG('S','V','Q','1'):
+#ifdef USE_SVQ1
 		// Sorenson Video 1: Used by some Myst ME videos.
 		return new SVQ1Decoder(width, height);
+#else
+		warning("createQuickTimeCodec(): Sorenson Video 1 codec is not compiled");
+		return 0;
+#endif
 	case MKTAG('S','V','Q','3'):
 		// Sorenson Video 3: Used by some Myst ME videos.
 		warning("Sorenson Video 3 not yet supported");

--- a/image/codecs/svq1.cpp
+++ b/image/codecs/svq1.cpp
@@ -22,6 +22,10 @@
 // Sorenson Video 1 Codec
 // Based off FFmpeg's SVQ1 decoder (written by Arpi and Nick Kurshev)
 
+#include "common/scummsys.h"
+
+#ifdef USE_SVQ1
+
 #include "image/codecs/svq1.h"
 #include "image/codecs/svq1_cb.h"
 #include "image/codecs/svq1_vlc.h"
@@ -806,3 +810,5 @@ bool SVQ1Decoder::svq1DecodeDeltaBlock(Common::BitStream32BEMSB *ss, byte *curre
 }
 
 } // End of namespace Image
+
+#endif

--- a/image/codecs/svq1.h
+++ b/image/codecs/svq1.h
@@ -22,6 +22,10 @@
 #ifndef IMAGE_CODECS_SVQ1_H
 #define IMAGE_CODECS_SVQ1_H
 
+#include "common/scummsys.h"
+
+#ifdef USE_SVQ1
+
 #include "common/bitstream.h"
 #include "image/codecs/codec.h"
 
@@ -92,5 +96,7 @@ private:
 };
 
 } // End of namespace Image
+
+#endif
 
 #endif


### PR DESCRIPTION
These codecs were introduced in QuickTime 3 and 4 respectively, so are only likely to appear in games released in 1998/1999 or later.