### PR TITLE
FREESCAPE: Fix Flying-Mode Related Issues

### DIFF
--- a/engines/freescape/freescape.cpp
+++ b/engines/freescape/freescape.cpp
@@ -868,7 +868,7 @@ bool FreescapeEngine::checkIfGameEnded() {
 		if (!_noShieldMessage.empty())
 			insertTemporaryMessage(_noShieldMessage, _countdown - 2);
 		_gameStateControl = kFreescapeGameStateEnd;
-	} else if (_gameStateVars[k8bitVariableEnergy] == 0) {
+	} else if (_gameStateVars[k8bitVariableEnergy] == 0 && isDriller()) {
 		playSound(_soundIndexNoEnergy, true);
 
 		if (!_noEnergyMessage.empty())


### PR DESCRIPTION
- Fix a condition in `checkIfGameEnded` function, so that the game ending (when energy reaches 0) happens only in Driller Game.