### PR TITLE
DIRECTOR: Fix MSVC warnings

### DIFF
--- a/engines/director/debugger/imgui_memory_editor.h
+++ b/engines/director/debugger/imgui_memory_editor.h
@@ -54,10 +54,8 @@
 #include <stdint.h>     // uint8_t, etc.
 
 #ifdef _MSC_VER
-#define _PRISizeT   "I"
 #define ImSnprintf  _snprintf
 #else
-#define _PRISizeT   "z"
 #define ImSnprintf  snprintf
 #endif
 
@@ -265,8 +263,8 @@ struct MemoryEditor
         const ImU32 color_text = ImGui::GetColorU32(ImGuiCol_Text);
         const ImU32 color_disabled = OptGreyOutZeroes ? ImGui::GetColorU32(ImGuiCol_TextDisabled) : color_text;
 
-        const char* format_address = OptUpperCaseHex ? "%0*" _PRISizeT "X: " : "%0*" _PRISizeT "x: ";
-        const char* format_data = OptUpperCaseHex ? "%0*" _PRISizeT "X" : "%0*" _PRISizeT "x";
+        const char* format_address = OptUpperCaseHex ? "%0*zX: " : "%0*zx: ";
+        const char* format_data = OptUpperCaseHex ? "%0*zX" : "%0*zx";
         const char* format_byte = OptUpperCaseHex ? "%02X" : "%02x";
         const char* format_byte_space = OptUpperCaseHex ? "%02X " : "%02x ";
 
@@ -455,7 +453,7 @@ struct MemoryEditor
     {
         IM_UNUSED(mem_data);
         ImGuiStyle& style = ImGui::GetStyle();
-        const char* format_range = OptUpperCaseHex ? "Range %0*" _PRISizeT "X..%0*" _PRISizeT "X" : "Range %0*" _PRISizeT "x..%0*" _PRISizeT "x";
+        const char* format_range = OptUpperCaseHex ? "Range %0*zX..%0*zX" : "Range %0*zx..%0*zx";
 
         // Options menu
         if (ImGui::Button("Options"))
@@ -480,7 +478,7 @@ struct MemoryEditor
         if (ImGui::InputText("##addr", AddrInputBuf, IM_ARRAYSIZE(AddrInputBuf), ImGuiInputTextFlags_CharsHexadecimal | ImGuiInputTextFlags_EnterReturnsTrue))
         {
             size_t goto_addr;
-            if (sscanf(AddrInputBuf, "%" _PRISizeT "X", &goto_addr) == 1)
+            if (sscanf(AddrInputBuf, "%zX", &goto_addr) == 1)
             {
                 GotoAddr = goto_addr - base_display_addr;
                 HighlightMin = HighlightMax = (size_t)-1;
@@ -733,7 +731,6 @@ struct MemoryEditor
     }
 };
 
-#undef _PRISizeT
 #undef ImSnprintf
 
 #ifdef _MSC_VER

--- a/engines/director/lingo/lingodec/ast.h
+++ b/engines/director/lingo/lingodec/ast.h
@@ -149,7 +149,7 @@ struct BlockNode : Node {
 	uint32 endPos;
 	CaseLabelNode *currentCaseLabel = nullptr;
 
-	explicit BlockNode(uint32 offset) : Node(kBlockNode, offset), endPos(-1) {}
+	explicit BlockNode(uint32 offset) : Node(kBlockNode, offset), endPos(Common::String::npos) {}
 	void addChild(Common::SharedPtr<Node> child);
 	void accept(NodeVisitor &visitor) const override;
 };

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -1343,7 +1343,7 @@ bool Score::checkShotSimilarity(const Graphics::Surface *oldSurface, const Graph
 				absolute_pixel_differences++;
 
 				for (int c = 0; c < 4; c++) {
-					if (ABS((newColor & 0xFF) - (oldColor & 0xFF)) > kShotColorDiffThreshold) {
+					if (ABS<int32>((newColor & 0xFF) - (oldColor & 0xFF)) > kShotColorDiffThreshold) {
 						different_pixel_count++;
 						break;
 					}


### PR DESCRIPTION
This PR aims to fix most of the warnings in the `director` engine, which are thrown by MSVC.

Opening as a PR to get feedback on the changes, mostly the one about signed integers in file offsets, plus to check if everything builds OK.

@sev-, @moralrecordings, @rvanlaar, any feedback is welcome :)