### PR TITLE
SWORD25: Fix keyboard input

### DIFF
--- a/engines/sword25/input/inputengine.cpp
+++ b/engines/sword25/input/inputengine.cpp
@@ -116,6 +116,10 @@ void InputEngine::update() {
 			break;
 
 		case Common::EVENT_KEYDOWN:
+			if (event.kbd.ascii != 0) {
+				reportCharacter(event.kbd.ascii);
+			}
+			// fall through
 		case Common::EVENT_KEYUP:
 			alterKeyboardState(event.kbd.keycode, (event.type == Common::EVENT_KEYDOWN) ? 0x80 : 0);
 			break;

--- a/engines/sword25/input/inputengine_script.cpp
+++ b/engines/sword25/input/inputengine_script.cpp
@@ -51,7 +51,7 @@ public:
 	Common::String _character;
 
 protected:
-	int PreFunctionInvokation(lua_State *L) {
+	int preFunctionInvokation(lua_State *L) override {
 		lua_pushstring(L, _character.c_str());
 		return 1;
 	}


### PR DESCRIPTION
Add proper reporting of character events to make the debug cheat codes work.
![The "start" cheat code](https://github.com/user-attachments/assets/e2e4a5bf-08af-40b1-a03e-69bdb7a2cc9c)
![The "room" cheat code](https://github.com/user-attachments/assets/3b55049c-4ed1-4fa6-bbd5-b4824a2fa896)
