### PR TITLE
IMAGE: Use palette class in Cinepak decoder.

### DIFF
--- a/graphics/palette.cpp
+++ b/graphics/palette.cpp
@@ -110,6 +110,21 @@ byte Palette::findBestColor(byte cr, byte cg, byte cb, ColorDistanceMethod metho
 
 	switch (method)
 	{
+	case kColorDistanceEuclidean:
+		for (int i = 0; i < _size; i++) {
+			int r = _data[3 * i + 0] - cr;
+			int g = _data[3 * i + 1] - cg;
+			int b = _data[3 * i + 2] - cb;
+			if (r == 0 && g == 0 && b == 0)
+				return i;
+
+			uint32 distSquared =  r * r + g * g + b * b;
+			if (distSquared < min) {
+				bestColor = i;
+				min = distSquared;
+			}
+		}
+	break;
 	case kColorDistanceNaive:
 		for (uint i = 0; i < _size; i++) {
 			int r = _data[3 * i + 0] - cr;

--- a/graphics/palette.h
+++ b/graphics/palette.h
@@ -27,8 +27,9 @@
 namespace Graphics {
 
 enum ColorDistanceMethod {
-	kColorDistanceNaive,	///< Weighted red 30%, green 50%, blue 20%
-	kColorDistanceRedmean,	///< Common low-cost approximation
+	kColorDistanceEuclidean, ///< Non-Weighted distance
+	kColorDistanceNaive,	 ///< Weighted red 30%, green 50%, blue 20%
+	kColorDistanceRedmean,	 ///< Common low-cost approximation
 };
 
 /**

--- a/image/codecs/cinepak.h
+++ b/image/codecs/cinepak.h
@@ -25,6 +25,7 @@
 #include "common/scummsys.h"
 #include "common/rect.h"
 #include "graphics/pixelformat.h"
+#include "graphics/palette.h"
 
 #include "image/codecs/codec.h"
 
@@ -77,7 +78,7 @@ public:
 	bool setOutputPixelFormat(const Graphics::PixelFormat &format) override;
 
 	bool containsPalette() const override { return _ditherPalette != 0; }
-	const byte *getPalette() override { _dirtyPalette = false; return _ditherPalette; }
+	const byte *getPalette() override { _dirtyPalette = false; return _ditherPalette.data(); }
 	bool hasDirtyPalette() const override { return _dirtyPalette; }
 	bool canDither(DitherType type) const override;
 	void setDither(DitherType type, const byte *palette) override;
@@ -89,7 +90,7 @@ private:
 	Graphics::PixelFormat _pixelFormat;
 	byte *_clipTable, *_clipTableBuf;
 
-	byte *_ditherPalette;
+	Graphics::Palette _ditherPalette;
 	bool _dirtyPalette;
 	byte *_colorMap;
 	DitherType _ditherType;


### PR DESCRIPTION
The Cinepak decoder had an unweighted euclidean color distance calculation for palette matching. This was moved and rewritten to a color distance method on the palette class.

Tested with Myst demo for quicktime usage and Journeyman Project 2 demo for AVI / Video for Windows dithering usage.
