### PR TITLE
SWORD25: Add internal debugger launch flag

### DIFF
--- a/engines/sword25/detection.cpp
+++ b/engines/sword25/detection.cpp
@@ -34,6 +34,7 @@ static const PlainGameDescriptor sword25Game[] = {
 static const DebugChannelDef debugFlagList[] = {
 	{Sword25::kDebugScript, "Script", "Script debug level"},
 	{Sword25::kDebugSound, "Sound", "Sound debug level"},
+	{Sword25::kDebugInternalDebugger, "Internaldebugger", "Internal debugger level"}, 
 	DEBUG_CHANNEL_END
 };
 

--- a/engines/sword25/package/packagemanager.cpp
+++ b/engines/sword25/package/packagemanager.cpp
@@ -198,6 +198,21 @@ byte *PackageManager::getFile(const Common::String &fileName, uint *fileSizePtr)
 	int bytesRead = in->read(buffer, in->size());
 	delete in;
 
+	// Modify the buffer to enable internal debugger if needed
+	if (debugChannelSet(-1, kDebugInternalDebugger) && fileName.matchString("/system/internal_config.lua")) {
+		const int sentenceLen = 27;
+		byte oldSentence[sentenceLen + 1] = "ENGINE_RELEASE_TYPE = 'pub'";
+		byte newSentence[sentenceLen + 1] = "ENGINE_RELEASE_TYPE = 'dev'";
+		byte *pos = buffer;
+		while (*pos) {
+			if (memcmp(pos, oldSentence, sentenceLen) == 0) {
+				memcpy(pos, newSentence, sentenceLen);
+				break;
+			}
+			pos++;
+		}
+	}
+
 	if (!bytesRead) {
 		delete[] buffer;
 		return NULL;

--- a/engines/sword25/sword25.h
+++ b/engines/sword25/sword25.h
@@ -55,6 +55,7 @@ enum {
 enum {
 	kDebugScript = 1,
 	kDebugSound,
+	kDebugInternalDebugger,
 	kDebugResource,
 };
 


### PR DESCRIPTION
Run ScummVM with `./scummvm --debugflags=internaldebugger sword25` to enable the internal debugger.

![image](https://github.com/user-attachments/assets/88413200-898f-4d1c-8317-481dde7c4425)
