### PR TITLE
IMAGE: Use palette class in more codecs

### DIFF
--- a/image/codecs/cdtoons.cpp
+++ b/image/codecs/cdtoons.cpp
@@ -47,14 +47,13 @@ static Common::Rect readRect(Common::SeekableReadStream &stream) {
 	return rect;
 }
 
-CDToonsDecoder::CDToonsDecoder(uint16 width, uint16 height) {
+CDToonsDecoder::CDToonsDecoder(uint16 width, uint16 height) : _palette(256) {
 	debugN(5, "CDToons: width %d, height %d\n", width, height);
 
 	_surface = new Graphics::Surface();
 	_surface->create(width, height, Graphics::PixelFormat::createFormatCLUT8());
 
 	_currentPaletteId = 0;
-	memset(_palette, 0, 256 * 3);
 	_dirtyPalette = false;
 }
 
@@ -435,13 +434,11 @@ void CDToonsDecoder::setPalette(byte *data) {
 
 	// A lovely QuickTime palette
 	for (uint i = 0; i < 256; i++) {
-		_palette[i * 3]     = *data;
-		_palette[i * 3 + 1] = *(data + 2);
-		_palette[i * 3 + 2] = *(data + 4);
+		_palette.set(i, *data, *(data + 2), *(data + 4));
 		data += 6;
 	}
 
-	_palette[0] = _palette[1] = _palette[2] = 0;
+	_palette.set(0, 0, 0, 0);
 }
 
 } // End of namespace Image

--- a/image/codecs/cdtoons.h
+++ b/image/codecs/cdtoons.h
@@ -25,6 +25,7 @@
 #include "image/codecs/codec.h"
 
 #include "common/hashmap.h"
+#include "graphics/palette.h"
 
 namespace Image {
 
@@ -50,12 +51,12 @@ public:
 	Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream) override;
 	Graphics::PixelFormat getPixelFormat() const override { return Graphics::PixelFormat::createFormatCLUT8(); }
 	bool containsPalette() const override { return true; }
-	const byte *getPalette() override { _dirtyPalette = false; return _palette; }
+	const byte *getPalette() override { _dirtyPalette = false; return _palette.data(); }
 	bool hasDirtyPalette() const override { return _dirtyPalette; }
 
 private:
 	Graphics::Surface *_surface;
-	byte _palette[256 * 3];
+	Graphics::Palette _palette;
 	bool _dirtyPalette;
 	uint16 _currentPaletteId;
 

--- a/image/codecs/qtrle.h
+++ b/image/codecs/qtrle.h
@@ -23,6 +23,7 @@
 #define IMAGE_CODECS_QTRLE_H
 
 #include "graphics/pixelformat.h"
+#include "graphics/palette.h"
 #include "image/codecs/codec.h"
 
 namespace Image {
@@ -41,7 +42,7 @@ public:
 	Graphics::PixelFormat getPixelFormat() const override;
 
 	bool containsPalette() const override { return _ditherPalette != 0; }
-	const byte *getPalette() override { _dirtyPalette = false; return _ditherPalette; }
+	const byte *getPalette() override { _dirtyPalette = false; return _ditherPalette.data(); }
 	bool hasDirtyPalette() const override { return _dirtyPalette; }
 	bool canDither(DitherType type) const override;
 	void setDither(DitherType type, const byte *palette) override;
@@ -51,7 +52,7 @@ private:
 	Graphics::Surface *_surface;
 	uint16 _width, _height;
 	uint32 _paddedWidth;
-	byte *_ditherPalette;
+	Graphics::Palette _ditherPalette;
 	bool _dirtyPalette;
 	byte *_colorMap;
 

--- a/image/codecs/rpza.cpp
+++ b/image/codecs/rpza.cpp
@@ -30,9 +30,8 @@
 
 namespace Image {
 
-RPZADecoder::RPZADecoder(uint16 width, uint16 height) : Codec() {
+RPZADecoder::RPZADecoder(uint16 width, uint16 height) : Codec(), _ditherPalette(0) {
 	_format = Graphics::PixelFormat(2, 5, 5, 5, 0, 10, 5, 0, 0);
-	_ditherPalette = 0;
 	_dirtyPalette = false;
 	_colorMap = 0;
 	_width = width;
@@ -48,7 +47,6 @@ RPZADecoder::~RPZADecoder() {
 		delete _surface;
 	}
 
-	delete[] _ditherPalette;
 	delete[] _colorMap;
 }
 
@@ -353,8 +351,8 @@ bool RPZADecoder::canDither(DitherType type) const {
 void RPZADecoder::setDither(DitherType type, const byte *palette) {
 	assert(canDither(type));
 
-	_ditherPalette = new byte[256 * 3];
-	memcpy(_ditherPalette, palette, 256 * 3);
+	_ditherPalette.resize(256, false);
+	_ditherPalette.set(palette, 0, 256);
 
 	_dirtyPalette = true;
 	_format = Graphics::PixelFormat::createFormatCLUT8();

--- a/image/codecs/rpza.h
+++ b/image/codecs/rpza.h
@@ -23,6 +23,7 @@
 #define IMAGE_CODECS_RPZA_H
 
 #include "graphics/pixelformat.h"
+#include "graphics/palette.h"
 #include "image/codecs/codec.h"
 
 namespace Image {
@@ -41,7 +42,7 @@ public:
 	Graphics::PixelFormat getPixelFormat() const override { return _format; }
 
 	bool containsPalette() const override { return _ditherPalette != 0; }
-	const byte *getPalette() override { _dirtyPalette = false; return _ditherPalette; }
+	const byte *getPalette() override { _dirtyPalette = false; return _ditherPalette.data(); }
 	bool hasDirtyPalette() const override { return _dirtyPalette; }
 	bool canDither(DitherType type) const override;
 	void setDither(DitherType type, const byte *palette) override;
@@ -49,7 +50,7 @@ public:
 private:
 	Graphics::PixelFormat _format;
 	Graphics::Surface *_surface;
-	byte *_ditherPalette;
+	Graphics::Palette _ditherPalette;
 	bool _dirtyPalette;
 	byte *_colorMap;
 	uint16 _width, _height;


### PR DESCRIPTION
These changes are simple, but not all of it is tested. I am having difficulty finding examples demos with videos using these codecs.

Currently tested:
CDToons - Testbed video with Where in the USA is Carmen Sandiego? (Windows Demo)