### PR TITLE
SCUMM: LOOM: Fix Hetchel flying with two heads in some EGA releases (Enhancement)

### DIFF
--- a/engines/scumm/scumm_v5.h
+++ b/engines/scumm/scumm_v5.h
@@ -92,6 +92,8 @@ protected:
 
 	void injectMISESpeech();
 
+	void workaroundLoomHetchelDoubleHead(Actor *a, int act);
+
 	/**
 	 * Fetch the next script word, then if cond is *false*, perform a relative jump.
 	 * So this corresponds to a "jne" jump instruction.


### PR DESCRIPTION
## Summary

Some time ago, @eriktorbjorn mentioned on Discord that some EGA releases of Loom have that bug where Hetchel flies with two heads, for a few frames at the forge:

![erik's screenshot for that bug](https://github.com/user-attachments/assets/0ccb4df8-bad3-4e74-9b5f-d30ac6c47e88)

I can reproduce this problem in (at least):

* the original English EGA 1.0 release
* the original English EGA 1.1 release
* the original English Macintosh release

It's been fixed by LEC in (at least) the following EGA releases, though:

* original French EGA 1.2 release
* Hebrew EGA 3.2 release (as sold by LimitedRunGames)

And then I tested the PC-Engine Japanese release, the FM-TOWNS English release, and the talkie CD release, and there the problem never appears.

## Enhancement implementation

Erik suggested this short diff:

```diff
diff --git a/engines/scumm/actor.cpp b/engines/scumm/actor.cpp
index 8784d906255..78fd6fb63ed 100644
--- a/engines/scumm/actor.cpp
+++ b/engines/scumm/actor.cpp
@@ -3541,6 +3541,9 @@ void Actor::runActorTalkScript(int f) {
 
                _vm->runScript(script, 1, 0, args);
        } else {
+               if (_vm->_game.id == GID_LOOM && _number == 11 && _moving && (_vm->_currentRoom == 34 || _vm->_currentRoom == 39))
+                       return;
+
                startAnimActor(f);
        }
 }
```

With a few tweaks (that I can add here if necessary), I'd be OK with it, but since LEC had an official fix for it back then, it's maybe better to just copy their changes?

Here are the script changes between the EGA 1.1 and 1.2 releases, when Hetchel's speaking at the forge:

Script 34-88:
```diff
 (11) animateCostume(11,245);
 (80) breakHere();
 (80) breakHere();
-(13) ActorOps(11,[WalkAnimNr(6),StandAnimNr(6)]);
+(13) ActorOps(11,[WalkAnimNr(6),StandAnimNr(6),TalkAnimNr(6,6)]);
...
-(13) ActorOps(11,[WalkAnimNr(2),StandAnimNr(3)]);
+(13) ActorOps(11,[WalkAnimNr(2),StandAnimNr(3),TalkAnimNr(4,5)]);
 (11) animateCostume(11,3);
 (AE) WaitForCamera();
 (80) breakHere();
...
 (11) animateCostume(11,245);
 (80) breakHere();
 (80) breakHere();
-(13) ActorOps(11,[WalkAnimNr(6),StandAnimNr(6)]);
+(13) ActorOps(11,[WalkAnimNr(6),StandAnimNr(6),TalkAnimNr(6,6)]);
 (11) animateCostume(11,9);
```

Script 38-87:
```diff
 (01) putActor(12,288,60);
 (1E) walkActorTo(12,96,60);
 (AE) WaitForActor(12);
-(13) ActorOps(12,[WalkSpeed(8,4),InitAnimNr(6),WalkAnimNr(6),StandAnimNr(6)]);
+(13) ActorOps(12,[WalkSpeed(8,4),InitAnimNr(6),WalkAnimNr(6),StandAnimNr(6),TalkAnimNr(6,6)]);
 (1E) walkActorTo(12,48,60);
...
```

So, my PR tries to detect these `ActorOps` calls, and add the `TalkAnimNr()` options that LEC added above.

It works just fine with the EGA 1.0/1.1/Macintosh releases mentioned above. It doesn't cause any regression with the 1.2 French/Hebrew releases already having these script changes.

## Screenshots

For reference, here's what the earliest EGA releases of Loom would display, in that case.

![scummvm-loom-ega10-00000](https://github.com/user-attachments/assets/c60f7c5d-09ca-49b8-a2da-7456a625c257)

![scummvm-loom-ega10-00001](https://github.com/user-attachments/assets/b6ba18a8-c54b-4b08-b61c-31652bf5561f)

![scummvm-loom-ega10-00002](https://github.com/user-attachments/assets/28022651-b332-4677-a18e-8a6c29d5c333)

![scummvm-loom-ega10-00003](https://github.com/user-attachments/assets/7c7383a4-9df8-4810-b74d-52dd2d621ce8)

## How to test this PR

1. Start any Loom release, but disable all Enhancements in the game settings
2. Load an early save where you have at least the distaff
3. Then you can cheat and move to that scene by doing:
    * Debugger (Ctrl-D) > `drafts learn`, `drafts` (note the "Sleep" and "Reflection" lines), `room 34`
    * Wake the boy with the Sleep draft (type the notes from right to left, in order to wake him up, instead)
    * Then, use the Reflection draft on him
    * Go to the right and enter the forge, then go to the right of it to meet the guy who'll put you in jail
    * Sleep on the straw
    * Wait for the dragon to appear and kill the boy, then Hetchel appears

**Expected behavior:**
* with Enhancements off, either Hetchel's head glitches as in the screenshots above (and then your release is impacted), or it doesn't and then you have a fixed release
* with Enhancements on: Hetchel's head should not glitch anymore. If it still does, or if you see any other issue, please report it.