### PR TITLE
AGS: fix DynamicSprite.Flip() to use CreateTransparentBitmap

### DIFF
--- a/engines/ags/engine/ac/dynamic_sprite.cpp
+++ b/engines/ags/engine/ac/dynamic_sprite.cpp
@@ -123,7 +123,7 @@ void DynamicSprite_Flip(ScriptDynamicSprite *sds, int direction) {
 
 	// resize the sprite to the requested size
 	Bitmap *sprite = _GP(spriteset)[sds->slot];
-	std::unique_ptr<Bitmap> new_pic(BitmapHelper::CreateBitmap(sprite->GetWidth(), sprite->GetHeight(), sprite->GetColorDepth()));
+	std::unique_ptr<Bitmap> new_pic(BitmapHelper::CreateTransparentBitmap(sprite->GetWidth(), sprite->GetHeight(), sprite->GetColorDepth()));
 
 	// AGS script FlipDirection corresponds to internal GraphicFlip
 	new_pic->FlipBlt(sprite, 0, 0, static_cast<GraphicFlip>(direction));


### PR DESCRIPTION
AGS: fix DynamicSprite.Flip() to use CreateTransparentBitmap

DynamicSprite.Flip() is using CreateBitmap instead of CreateTransparentBitmap meaning flipped sprites lose their transparency.

Looks like this creeped in during refactoring here (other methods are OK, just Flip):
https://github.com/scummvm/scummvm/commit/3078b207d33d5e551811b3f26879f45016d6fe33#diff-4093ff4addff2a4251456a23d8da353c260c0dfd217919f3a0b0cfb31bae921bR126

Reference AGS code here:
https://github.com/adventuregamestudio/ags/blob/master/Engine/ac/dynamicsprite.cpp#L125

Test case are mirror reflections in The Crimson Diamond.