### PR TITLE
TESTBED: Allow video test to handle more decoders

### DIFF
--- a/engines/testbed/video.cpp
+++ b/engines/testbed/video.cpp
@@ -172,25 +172,21 @@ Common::Error Videotests::videoTest(Common::SeekableReadStream *stream, const Co
 				if (Common::isMouseEvent(event))
 					mouse = event.mouse;
 
-				if (mouse.x >= x && mouse.x < x + mw &&
+				if (qtVideo && mouse.x >= x && mouse.x < x + mw &&
 						mouse.y >= y && mouse.y < y + mh) {
 					switch (event.type) {
 					case Common::EVENT_LBUTTONDOWN:
-						if (qtVideo)
-							qtVideo->handleMouseButton(true, event.mouse.x - x, event.mouse.y - y);
+						qtVideo->handleMouseButton(true, event.mouse.x - x, event.mouse.y - y);
 						break;
 					case Common::EVENT_LBUTTONUP:
-						if (qtVideo)
-							qtVideo->handleMouseButton(false, event.mouse.x - x, event.mouse.y - y);
+						qtVideo->handleMouseButton(false, event.mouse.x - x, event.mouse.y - y);
 						break;
 					case Common::EVENT_MOUSEMOVE:
-						if (qtVideo)
-							qtVideo->handleMouseMove(event.mouse.x - x, event.mouse.y - y);
+						qtVideo->handleMouseMove(event.mouse.x - x, event.mouse.y - y);
 						break;
 					case Common::EVENT_KEYUP:
 					case Common::EVENT_KEYDOWN:
-						if (qtVideo)
-							qtVideo->handleKey(event.kbd, event.type == Common::EVENT_KEYDOWN);
+						qtVideo->handleKey(event.kbd, event.type == Common::EVENT_KEYDOWN);
 						break;
 					default:
 						break;

--- a/video/mve_decoder.cpp
+++ b/video/mve_decoder.cpp
@@ -503,15 +503,15 @@ bool MveDecoder::MveVideoTrack::endOfTrack() const {
 }
 
 uint16 MveDecoder::MveVideoTrack::getWidth() const {
-	return _decoder->getWidth();
+	return _decoder->_width;
 }
 
 uint16 MveDecoder::MveVideoTrack::getHeight() const {
-	return _decoder->getHeight();
+	return _decoder->_height;
 }
 
 Graphics::PixelFormat MveDecoder::MveVideoTrack::getPixelFormat() const {
-	return _decoder->getPixelFormat();
+	return _decoder->_pixelFormat;
 }
 
 int MveDecoder::MveVideoTrack::getCurFrame() const {


### PR DESCRIPTION
The decoders for avi, dxa, flc, mve, and smk are selected based on file extension.

The MVE video width, height, and pixel format getters were causing infinite recursion due to the video decoder asking its tracks for the width, height, and pixel format by the same methods