### PR TITLE
SWORD25: Fix display order of deathscreen

### DIFF
--- a/engines/sword25/package/packagemanager.cpp
+++ b/engines/sword25/package/packagemanager.cpp
@@ -206,6 +206,15 @@ byte *PackageManager::getFile(const Common::String &fileName, uint *fileSizePtr)
 		}
 	}
 
+	// Modify the buffer to properly set the death screen as background 
+	// by changing its z value
+    if (fileName.equals("rooms/tod/scripts/default.lua")) {
+        char *found = strstr((char *)buffer, "self:AddOccluder('/rooms/tod/gfx/rip.png', { X = 0, Y = 80 }, 10)");
+        if (found != nullptr) {
+            memcpy(found + 62, " 8", 2);
+        }
+    }
+
 	if (!bytesRead) {
 		delete[] buffer;
 		return NULL;


### PR DESCRIPTION
Fix death screen appearing behind save/load menu by adjusting its z-value. The issue occurs due to differences in render order between original engine and ScummVM implementation.

The original engine renders based on parent-child relationships, it renders the subtree of a node completely before moving to other nodes. while ScummVM sorts by absolute z-values (parent absolute z + child z).

View `BS_RenderObject::Render` in `renderobject.cpp` in the source code of the original engine and `RenderObject::render` in `renderobject.cpp` in the source code of ScummVM version for more details.

Fixes: https://bugs.scummvm.org/ticket/15426

![before](https://github.com/user-attachments/assets/71ceebf6-e0f3-4cc1-b9ec-510631e3cc9f)
![after](https://github.com/user-attachments/assets/81c7762f-5792-4ac7-a8ea-a43195ab6712)