### PR TITLE
VIDEO: Use palette class in video decoders (Part 2)

### DIFF
--- a/engines/chewy/video/cfo_decoder.cpp
+++ b/engines/chewy/video/cfo_decoder.cpp
@@ -326,16 +326,19 @@ void CfoDecoder::CfoVideoTrack::handleCustomFrame() {
 void CfoDecoder::CfoVideoTrack::fadeOut() {
 	for (int j = 0; j < 64; j++) {
 		for (int i = 0; i < 256; i++) {
-			if (_palette[i * 3 + 0] > 0)
-				--_palette[i * 3 + 0];
-			if (_palette[i * 3 + 1] > 0)
-				--_palette[i * 3 + 1];
-			if (_palette[i * 3 + 2] > 0)
-				--_palette[i * 3 + 2];
+			byte r, g, b;
+			_palette.get(i, r, g, b);
+			if (r > 0)
+				--r;
+			if (g > 0)
+				--g;
+			if (b > 0)
+				--b;
+			_palette.set(i, r, g, b);
 		}
 
 		//setScummVMPalette(_palette, 0, 256);
-		g_system->getPaletteManager()->setPalette(_palette, 0, 256);
+		g_system->getPaletteManager()->setPalette(_palette, 0);
 		g_system->updateScreen();
 		g_system->delayMillis(10);
 	}

--- a/video/coktel_decoder.h
+++ b/video/coktel_decoder.h
@@ -40,6 +40,7 @@
 #include "common/rational.h"
 #include "common/str.h"
 
+#include "graphics/palette.h"
 #include "graphics/surface.h"
 
 #include "video/video_decoder.h"
@@ -236,7 +237,7 @@ protected:
 
 	uint32 _startTime;
 
-	byte _palette[768];
+	Graphics::Palette _palette;
 	bool _paletteDirty;
 
 	bool _isDouble;

--- a/video/dxa_decoder.cpp
+++ b/video/dxa_decoder.cpp
@@ -73,13 +73,12 @@ void DXADecoder::readSoundData(Common::SeekableReadStream *stream) {
 	}
 }
 
-DXADecoder::DXAVideoTrack::DXAVideoTrack(Common::SeekableReadStream *stream) {
+DXADecoder::DXAVideoTrack::DXAVideoTrack(Common::SeekableReadStream *stream) : _palette(256) {
 	_fileStream = stream;
 	_curFrame = -1;
 	_frameStartOffset = 0;
 	_decompBuffer = 0;
 	_inBuffer = 0;
-	memset(_palette, 0, 256 * 3);
 
 	uint8 flags = _fileStream->readByte();
 	_frameCount = _fileStream->readUint16BE();
@@ -465,7 +464,13 @@ void DXADecoder::DXAVideoTrack::decode13(int size) {
 const Graphics::Surface *DXADecoder::DXAVideoTrack::decodeNextFrame() {
 	uint32 tag = _fileStream->readUint32BE();
 	if (tag == MKTAG('C','M','A','P')) {
-		_fileStream->read(_palette, 256 * 3);
+		for (int i = 0; i < 256; i++) {
+			byte r = _fileStream->readByte();
+			byte g = _fileStream->readByte();
+			byte b = _fileStream->readByte();
+			_palette.set(i, r, g, b);
+		}
+
 		_dirtyPalette = true;
 	}
 

--- a/video/dxa_decoder.h
+++ b/video/dxa_decoder.h
@@ -23,6 +23,7 @@
 #define VIDEO_DXA_DECODER_H
 
 #include "common/rational.h"
+#include "graphics/palette.h"
 #include "graphics/pixelformat.h"
 #include "video/video_decoder.h"
 
@@ -68,7 +69,7 @@ private:
 		int getCurFrame() const { return _curFrame; }
 		int getFrameCount() const { return _frameCount; }
 		const Graphics::Surface *decodeNextFrame();
-		const byte *getPalette() const { _dirtyPalette = false; return _palette; }
+		const byte *getPalette() const { _dirtyPalette = false; return _palette.data(); }
 		bool hasDirtyPalette() const { return _dirtyPalette; }
 
 		void setFrameStartPos();
@@ -103,7 +104,7 @@ private:
 		uint16 _width, _height;
 		uint32 _frameRate;
 		uint32 _frameCount;
-		byte _palette[256 * 3];
+		Graphics::Palette _palette;
 		mutable bool _dirtyPalette;
 		int _curFrame;
 		uint32 _frameStartOffset;

--- a/video/flic_decoder.cpp
+++ b/video/flic_decoder.cpp
@@ -84,13 +84,12 @@ void FlicDecoder::copyDirtyRectsToBuffer(uint8 *dst, uint pitch) {
 		((FlicVideoTrack *)track)->copyDirtyRectsToBuffer(dst, pitch);
 }
 
-FlicDecoder::FlicVideoTrack::FlicVideoTrack(Common::SeekableReadStream *stream, uint16 frameCount, uint16 width, uint16 height, bool skipHeader) {
+FlicDecoder::FlicVideoTrack::FlicVideoTrack(Common::SeekableReadStream *stream, uint16 frameCount, uint16 width, uint16 height, bool skipHeader) : _palette(256) {
 	_fileStream = stream;
 	_frameCount = frameCount;
 
 	_surface = new Graphics::Surface();
 	_surface->create(width, height, Graphics::PixelFormat::createFormatCLUT8());
-	_palette = new byte[3 * 256]();
 	_dirtyPalette = false;
 
 	_curFrame = -1;
@@ -103,7 +102,6 @@ FlicDecoder::FlicVideoTrack::FlicVideoTrack(Common::SeekableReadStream *stream, 
 
 FlicDecoder::FlicVideoTrack::~FlicVideoTrack() {
 	delete _fileStream;
-	delete[] _palette;
 
 	_surface->free();
 	delete _surface;
@@ -363,7 +361,10 @@ void FlicDecoder::FlicVideoTrack::unpackPalette(uint8 *data) {
 	if (0 == READ_LE_UINT16(data)) { //special case
 		data += 2;
 		for (int i = 0; i < 256; ++i) {
-			memcpy(_palette + i * 3, data + i * 3, 3);
+			byte r = data[i * 3];
+			byte g = data[i * 3 + 1];
+			byte b = data[i * 3 + 2];
+			_palette.set(i, r, g, b);
 		}
 	} else {
 		uint8 palPos = 0;
@@ -373,7 +374,10 @@ void FlicDecoder::FlicVideoTrack::unpackPalette(uint8 *data) {
 			uint8 change = *data++;
 
 			for (int i = 0; i < change; ++i) {
-				memcpy(_palette + (palPos + i) * 3, data + i * 3, 3);
+				byte r = data[i * 3];
+				byte g = data[i * 3 + 1];
+				byte b = data[i * 3 + 2];
+				_palette.set(palPos + i, r, g, b);
 			}
 
 			palPos += change;

--- a/video/flic_decoder.h
+++ b/video/flic_decoder.h
@@ -25,6 +25,7 @@
 #include "video/video_decoder.h"
 #include "common/list.h"
 #include "common/rect.h"
+#include "graphics/palette.h"
 
 namespace Common {
 class SeekableReadStream;
@@ -77,7 +78,7 @@ protected:
 		uint32 getNextFrameStartTime() const { return _nextFrameStartTime; }
 		virtual const Graphics::Surface *decodeNextFrame();
 		virtual void handleFrame();
-		const byte *getPalette() const { _dirtyPalette = false; return _palette; }
+		const byte *getPalette() const { _dirtyPalette = false; return _palette.data(); }
 		bool hasDirtyPalette() const { return _dirtyPalette; }
 
 		const Common::List<Common::Rect> *getDirtyRects() const { return &_dirtyRects; }
@@ -93,7 +94,7 @@ protected:
 
 		uint32 _offsetFrame1;
 		uint32 _offsetFrame2;
-		byte *_palette;
+		Graphics::Palette _palette;
 		mutable bool _dirtyPalette;
 
 		uint32 _frameCount;

--- a/video/mve_decoder.cpp
+++ b/video/mve_decoder.cpp
@@ -40,6 +40,7 @@ MveDecoder::MveDecoder()
 	: _done(false),
 	  _s(nullptr),
 	  _dirtyPalette(false),
+	  _palette(256),
 	  _skipMapSize(0),
 	  _skipMap(nullptr),
 	  _decodingMapSize(0),
@@ -50,8 +51,6 @@ MveDecoder::MveDecoder()
 	  _audioTrack(0),
 	  _audioStream(nullptr)
 {
-	for (int i = 0; i < 0x300; ++i)
-		_palette[i] = 0;
 }
 
 MveDecoder::~MveDecoder() {
@@ -97,7 +96,7 @@ void MveDecoder::setAudioTrack(int track) {
 }
 
 void MveDecoder::applyPalette(PaletteManager *paletteManager) {
-	paletteManager->setPalette(_palette + 3 * _palStart, _palStart, _palCount);
+	paletteManager->setPalette(_palette.data() + 3 * _palStart, _palStart, _palCount);
 }
 
 void MveDecoder::copyBlock_8bit(Graphics::Surface &dst, Common::MemoryReadStream &s, int block) {
@@ -443,9 +442,7 @@ void MveDecoder::readNextPacket() {
 					byte g = _s->readByte();
 					byte b = _s->readByte();
 
-					_palette[3*i+0] = (r << 2) | (r >> 4);
-					_palette[3*i+1] = (g << 2) | (g >> 4);
-					_palette[3*i+2] = (b << 2) | (b >> 4);
+					_palette.set(i, (r << 2) | (r >> 4), (g << 2) | (g >> 4), (b << 2) | (b >> 4));
 				}
 				if (palCount & 1) {
 					_s->skip(1);
@@ -523,7 +520,7 @@ const Graphics::Surface *MveDecoder::MveVideoTrack::decodeNextFrame() {
 }
 
 const byte *MveDecoder::MveVideoTrack::getPalette() const {
-	return _decoder->_palette;
+	return _decoder->_palette.data();
 }
 
 bool MveDecoder::MveVideoTrack::hasDirtyPalette() const {

--- a/video/mve_decoder.h
+++ b/video/mve_decoder.h
@@ -24,6 +24,7 @@
 
 #include "audio/audiostream.h"
 #include "video/video_decoder.h"
+#include "graphics/palette.h"
 #include "graphics/surface.h"
 #include "common/list.h"
 #include "common/rect.h"
@@ -72,7 +73,7 @@ class MveDecoder : public VideoDecoder {
 	bool      _dirtyPalette;
 	uint16    _palStart;
 	uint16    _palCount;
-	byte      _palette[0x300];
+	Graphics::Palette _palette;
 
 	uint16    _skipMapSize;
 	byte     *_skipMap;

--- a/video/paco_decoder.cpp
+++ b/video/paco_decoder.cpp
@@ -171,18 +171,18 @@ const byte* PacoDecoder::getPalette(){
 
 const byte* PacoDecoder::PacoVideoTrack::getPalette() const {
 	_dirtyPalette = false;
-	return _palette;
+	return _palette.data();
 }
 
 PacoDecoder::PacoVideoTrack::PacoVideoTrack(
-	uint16 frameRate, uint16 frameCount, uint16 width, uint16 height) {
+	uint16 frameRate, uint16 frameCount, uint16 width, uint16 height) : _palette(256) {
 	_curFrame = 0;
 	_frameRate = frameRate;
 	_frameCount = frameCount;
 
 	_surface = new Graphics::Surface();
 	_surface->create(width, height, Graphics::PixelFormat::createFormatCLUT8());
-	_palette = const_cast<byte *>(quickTimeDefaultPalette256);
+	_palette.set(quickTimeDefaultPalette256, 0, 256);
 	_dirtyPalette = true;
 }
 
@@ -260,12 +260,14 @@ const Graphics::Surface *PacoDecoder::PacoVideoTrack::decodeNextFrame() {
 void PacoDecoder::PacoVideoTrack::handlePalette(Common::SeekableReadStream *fileStream) {
 	uint32 header = fileStream->readUint32BE();
 	if (header == 0x30000000) { // default quicktime palette
-		_palette = const_cast<byte *>(quickTimeDefaultPalette256);
+		_palette.set(quickTimeDefaultPalette256, 0, 256);
 	} else {
 		fileStream->readUint32BE(); // 4 bytes of 00
-		_palette = new byte[256 * 3]();
-		for (int i = 0; i < 256 * 3; i++){
-			_palette[i] = fileStream->readByte();
+		for (int i = 0; i < 256; i++){
+			byte r = fileStream->readByte();
+			byte g = fileStream->readByte();
+			byte b = fileStream->readByte();
+			_palette.set(i, r, g, b);
 		}
 	}
 	_dirtyPalette = true;

--- a/video/paco_decoder.h
+++ b/video/paco_decoder.h
@@ -25,6 +25,7 @@
 #include "audio/audiostream.h"
 #include "common/list.h"
 #include "common/rect.h"
+#include "graphics/palette.h"
 #include "video/video_decoder.h"
 
 namespace Common {
@@ -88,8 +89,7 @@ protected:
 
 	protected:
 		Graphics::Surface *_surface;
-
-		byte *_palette;
+		Graphics::Palette _palette;
 
 		mutable bool _dirtyPalette;
 


### PR DESCRIPTION
Coktel video decoders were tested with various game demos. 
DXA, FLIC, and MVE tested with Testbed video alterations in #6473
PACo still needs a test case but appeared to be potentially leaking memory in prior code.