### PR TITLE
BACKENDS: MACOS: Fix various small warnings in macosx-audiocd.cpp

### DIFF
--- a/backends/audiocd/macosx/macosx-audiocd.cpp
+++ b/backends/audiocd/macosx/macosx-audiocd.cpp
@@ -190,15 +190,14 @@ void MacOSXAudioCDManager::close() {
 	_trackMap.clear();
 }
 
-enum {
-	// Some crazy high number that we'll never actually hit
-	kMaxDriveCount = 256
-};
-
 MacOSXAudioCDManager::DriveList MacOSXAudioCDManager::detectAllDrives() {
+	int foundDrives = getfsstat(nullptr, 0, MNT_WAIT);
+	if (foundDrives <= 0)
+		return DriveList();
+
 	// Fetch the lists of drives
-	struct statfs *driveStats = (struct statfs *)malloc(sizeof(struct statfs) * kMaxDriveCount);
-	int foundDrives = getfsstat(driveStats, sizeof(struct statfs) * kMaxDriveCount, MNT_WAIT);
+	struct statfs *driveStats = (struct statfs *)malloc(sizeof(struct statfs) * foundDrives);
+	foundDrives = getfsstat(driveStats, sizeof(struct statfs) * foundDrives, MNT_NOWAIT);
 	if (foundDrives <= 0) {
 		free(driveStats);
 		return DriveList();


### PR DESCRIPTION
This is for `macosx-audiocd.cpp` (backend code).

* Fix a `-Wframe-larger-than` warning (macOS 13.7.4, Intel x64, Apple Clang 14), by allocating the `statfs` buffer on the heap instead of the stack
* Fix a `-Wsign-compare` warning when comparing with `UINT_MAX` (macOS 10.4.11, ppc32, GCC 7.5.0), with an `unsigned long` cast (since we already check `trackID > 0` just before it)

While there:

* Add a couple more headers for `getfsstat()`, as given by its manual page (although it always built just fine without them).

I can split this into multiple commits if you'd like, but I'm not sure it's worth it here.

Tested on macOS 10.4 (ppc32), 13.7 (Intel x64) and 15.3 (aarch64).

@criezy: Does this look good to you? Thanks :)