### PR TITLE
FREESCAPE: Fix sound-related issues

### DIFF
--- a/engines/freescape/games/dark/dark.cpp
+++ b/engines/freescape/games/dark/dark.cpp
@@ -691,6 +691,7 @@ void DarkEngine::updateTimeVariables() {
 				_gameStateVars[k8bitVariableEnergy]--;
 
 		if (_flyMode && _gameStateVars[k8bitVariableEnergy] == 0) {
+			_mixer->stopHandle(_soundFxHandleJetpack);
 			_flyMode = false;
 			insertTemporaryMessage(_messagesList[13], _countdown - 2);
 		}

--- a/engines/freescape/games/dark/dark.cpp
+++ b/engines/freescape/games/dark/dark.cpp
@@ -666,7 +666,7 @@ void DarkEngine::pressedKey(const int keycode) {
 		} else if (_flyMode) {
 			float hzFreq = 1193180.0f / 0xd537;
 			_speaker->play(Audio::PCSpeaker::kWaveFormSquare, hzFreq, -1);
-			_mixer->playStream(Audio::Mixer::kSFXSoundType, &_soundFxHandle, _speaker, -1, Audio::Mixer::kMaxChannelVolume / 2, 0, DisposeAfterUse::NO);
+			_mixer->playStream(Audio::Mixer::kSFXSoundType, &_soundFxHandleJetpack, _speaker, -1, Audio::Mixer::kMaxChannelVolume / 2, 0, DisposeAfterUse::NO);
 			insertTemporaryMessage(_messagesList[11], _countdown - 2);
 		} else {
 			_speaker->stop();

--- a/engines/freescape/games/dark/dark.h
+++ b/engines/freescape/games/dark/dark.h
@@ -19,6 +19,8 @@
  *
  */
 
+#include "audio/mixer.h"
+
 namespace Freescape {
 
 enum {
@@ -100,6 +102,7 @@ public:
 	Font _fontSmall;
 	int _soundIndexRestoreECD;
 	int _soundIndexDestroyECD;
+	Audio::SoundHandle _soundFxHandleJetpack;
 
 	void drawString(const DarkFontSize size, const Common::String &str, int x, int y, uint32 primaryColor, uint32 secondaryColor, uint32 backColor, Graphics::Surface *surface);
 	void drawInfoMenu() override;


### PR DESCRIPTION
## Changes
- **Fix infinite loop when shooting while flying**  
  - Create a new SFXhandle for jetpack and use it to play it's sound.  
- **Fix jetpack sound not stoping when energy reaches 0**  
  - Stop the jetpack SFXhandle using mixer.  