### PR TITLE
GRAPHICS: MACGUI: Fix color palette used in nine-patch bitmap for disabling border

### DIFF
--- a/graphics/macgui/macwindowborder.cpp
+++ b/graphics/macgui/macwindowborder.cpp
@@ -82,12 +82,13 @@ bool MacWindowBorder::hasBorder(uint32 flags) {
 void MacWindowBorder::disableBorder() {
 	const byte palette[] = {
 		255, 0,   255,
-		0,   0,   0
+		0,   0,   0,
+		255, 255, 255,
 	};
 
 	Graphics::ManagedSurface *noborder = new Graphics::ManagedSurface();
 	noborder->create(3, 3, Graphics::PixelFormat::createFormatCLUT8());
-	noborder->setPalette(palette, 0, 2);
+	noborder->setPalette(palette, 0, 3);
 	noborder->setTransparentColor(0);
 
 	for (int y = 0; y < 3; y++)


### PR DESCRIPTION
A `NinePatchBitmap` type requires a white color in the color palette otherwise it throws a warning `WARNING: NinePatchBitmap::NinePatchBitmap(): Bad bitmap!`. The bitmap is created [here](https://github.com/scummvm/scummvm/blob/master/graphics/macgui/macwindowborder.cpp#L112)