### PR TITLE
NANCY: Fix a crash in Ghost Dogs of Moon Lake

### DIFF
--- a/engines/nancy/state/scene.cpp
+++ b/engines/nancy/state/scene.cpp
@@ -365,6 +365,13 @@ void Scene::setNoHeldItem() {
 }
 
 byte Scene::hasItem(int16 id) const {
+	// ND Ghost dogs of Moon Lake uses larger item id in conditionalDialogue than actually exists.
+	// Specifically when calling the hardy boys.
+	// The specific dialog options are hint prompts so it might be a feature of the hint system.
+	// Checking it here at least makes the game not crash, but may not be fully correct
+	if (static_cast<uint16_t>(id) >= _flags.items.size()) {
+		return g_nancy->_false;
+	}
 	if (getHeldItem() == id) {
 		return g_nancy->_true;
 	} else {


### PR DESCRIPTION
The game uses item IDs that doesn't exist in conversation option checks. The options with these conditions are hint requests so the item ids might be part of the hint system.
This change just returns false when checking if the player has these items avoiding the crash but may not be a full fix.

This is a workaround to a crash, but probably hides some needed functionality.
[Saved games.zip](https://github.com/user-attachments/files/19274018/Saved.games.zip)

Attached save file Hardy Crash should reproduce the error
* Call the Hardy Boys
* Select the second option "I'm convinced that someone is using those 'ghost dogs'...
The faulty hasItem call should then happen and crash the scummvm.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
