### PR TITLE
GUI: Fix integrity dialog freeze/update issue

### DIFF
--- a/common/macresman.cpp
+++ b/common/macresman.cpp
@@ -168,7 +168,7 @@ String MacResManager::computeResForkMD5AsString(uint32 length, bool tail) const 
 	return computeStreamMD5AsString(resForkStream, MIN<uint32>(length, _resForkSize));
 }
 
-String MacResManager::computeResForkMD5AsString(uint32 length, bool tail, bool (*progressUpdateCallback)(int)) const {
+String MacResManager::computeResForkMD5AsString(uint32 length, bool tail, ProgressUpdateCallback progressUpdateCallback) const {
 	if (!hasResFork())
 		return String();
 

--- a/common/macresman.cpp
+++ b/common/macresman.cpp
@@ -151,7 +151,7 @@ uint32 MacResManager::getResForkDataSize() const {
 	return _stream->readUint32BE();
 }
 
-String MacResManager::computeResForkMD5AsString(uint32 length, bool tail) const {
+String MacResManager::computeResForkMD5AsString(uint32 length, bool tail, ProgressUpdateCallback progressUpdateCallback, void *callbackParameter) const {
 	if (!hasResFork())
 		return String();
 
@@ -165,29 +165,9 @@ String MacResManager::computeResForkMD5AsString(uint32 length, bool tail) const 
 	if (tail && dataLength > length)
 		resForkStream.seek(-(int64)length, SEEK_END);
 
-	return computeStreamMD5AsString(resForkStream, MIN<uint32>(length, _resForkSize));
+	return computeStreamMD5AsString(resForkStream, MIN<uint32>(length, _resForkSize), progressUpdateCallback, callbackParameter);
 }
 
-String MacResManager::computeResForkMD5AsString(uint32 length, bool tail, ProgressUpdateCallback progressUpdateCallback) const {
-	if (!hasResFork())
-		return String();
-
-	_stream->seek(_resForkOffset);
-	uint32 dataOffset = _stream->readUint32BE() + _resForkOffset;
-	/* uint32 mapOffset = */ _stream->readUint32BE();
-	uint32 dataLength = _stream->readUint32BE();
-
-
-	SeekableSubReadStream resForkStream(_stream, dataOffset, dataOffset + dataLength);
-	if (tail && dataLength > length)
-		resForkStream.seek(-(int64)length, SEEK_END);
-
-	return computeStreamMD5AsString(resForkStream, MIN<uint32>(length, _resForkSize), progressUpdateCallback);
-}
-
-bool MacResManager::open(const Path &fileName) {
-	return open(fileName, SearchMan);
-}
 
 SeekableReadStream *MacResManager::openAppleDoubleWithAppleOrOSXNaming(Archive& archive, const Path &fileName) {
 	SeekableReadStream *stream = archive.createReadStreamForMember(constructAppleDoubleName(fileName));
@@ -244,6 +224,10 @@ SeekableReadStream *MacResManager::openAppleDoubleWithAppleOrOSXNaming(Archive& 
 	}
 
 	return nullptr;
+}
+
+bool MacResManager::open(const Path &fileName) {
+    return open(fileName, SearchMan);
 }
 
 bool MacResManager::open(const Path &fileName, Archive &archive) {

--- a/common/macresman.cpp
+++ b/common/macresman.cpp
@@ -168,6 +168,23 @@ String MacResManager::computeResForkMD5AsString(uint32 length, bool tail) const 
 	return computeStreamMD5AsString(resForkStream, MIN<uint32>(length, _resForkSize));
 }
 
+String MacResManager::computeResForkMD5AsString(uint32 length, bool tail, bool (*progressUpdateCallback)(int)) const {
+	if (!hasResFork())
+		return String();
+
+	_stream->seek(_resForkOffset);
+	uint32 dataOffset = _stream->readUint32BE() + _resForkOffset;
+	/* uint32 mapOffset = */ _stream->readUint32BE();
+	uint32 dataLength = _stream->readUint32BE();
+
+
+	SeekableSubReadStream resForkStream(_stream, dataOffset, dataOffset + dataLength);
+	if (tail && dataLength > length)
+		resForkStream.seek(-(int64)length, SEEK_END);
+
+	return computeStreamMD5AsString(resForkStream, MIN<uint32>(length, _resForkSize), progressUpdateCallback);
+}
+
 bool MacResManager::open(const Path &fileName) {
 	return open(fileName, SearchMan);
 }

--- a/common/macresman.h
+++ b/common/macresman.h
@@ -55,7 +55,7 @@ namespace Common {
 
 typedef Array<uint16> MacResIDArray;
 typedef Array<uint32> MacResTagArray;
-typedef bool (*ProgressUpdateCallback)(int);
+typedef bool (* ProgressUpdateCallback)(void *, int);
 
 /**
  * Class containing the raw data bytes for a Macintosh Finder Info data block.
@@ -267,16 +267,7 @@ public:
 	 * @param tail Calculate length from the tail
 	 * @return The MD5 checksum of the resource fork
 	 */
-	String computeResForkMD5AsString(uint32 length = 0, bool tail = false) const;
-
-	/**
-	 * Overloaded version for callbacks
-	 * Calculate the MD5 checksum of the resource fork
-	 * @param length The maximum length to compute for
-	 * @param tail Calculate length from the tail
-	 * @return The MD5 checksum of the resource fork
-	 */
-	String computeResForkMD5AsString(uint32 length, bool tail, ProgressUpdateCallback progressUpdateCallback) const;
+	String computeResForkMD5AsString(uint32 length = 0, bool tail = false, ProgressUpdateCallback progressUpdateCallback = nullptr, void *callbackParameter = nullptr) const;
 
 	/**
 	 * Get the base file name of the data/resource fork pair

--- a/common/macresman.h
+++ b/common/macresman.h
@@ -55,6 +55,7 @@ namespace Common {
 
 typedef Array<uint16> MacResIDArray;
 typedef Array<uint32> MacResTagArray;
+typedef bool (*ProgressUpdateCallback)(int);
 
 /**
  * Class containing the raw data bytes for a Macintosh Finder Info data block.
@@ -275,7 +276,7 @@ public:
 	 * @param tail Calculate length from the tail
 	 * @return The MD5 checksum of the resource fork
 	 */
-	String computeResForkMD5AsString(uint32 length, bool tail, bool (*progressUpdateCallback)(int)) const;
+	String computeResForkMD5AsString(uint32 length, bool tail, ProgressUpdateCallback progressUpdateCallback) const;
 
 	/**
 	 * Get the base file name of the data/resource fork pair

--- a/common/macresman.h
+++ b/common/macresman.h
@@ -269,6 +269,15 @@ public:
 	String computeResForkMD5AsString(uint32 length = 0, bool tail = false) const;
 
 	/**
+	 * Overloaded version for callbacks
+	 * Calculate the MD5 checksum of the resource fork
+	 * @param length The maximum length to compute for
+	 * @param tail Calculate length from the tail
+	 * @return The MD5 checksum of the resource fork
+	 */
+	String computeResForkMD5AsString(uint32 length, bool tail, bool (*progressUpdateCallback)(int)) const;
+
+	/**
 	 * Get the base file name of the data/resource fork pair
 	 * @return The base file name of the data/resource fork pair
 	 */

--- a/common/md5.cpp
+++ b/common/md5.cpp
@@ -279,10 +279,65 @@ bool computeStreamMD5(ReadStream &stream, uint8 digest[16], uint32 length) {
 	return true;
 }
 
+
+bool computeStreamMD5(ReadStream &stream, uint8 digest[16], uint32 length, bool (*progressUpdateCallback)(int)) {
+
+#ifdef DISABLE_MD5
+	memset(digest, 0, 16);
+#else
+	md5_context ctx;
+	int i;
+	unsigned char buf[1000];
+	bool restricted = (length != 0);
+	uint32 readlen;
+
+	if (!restricted || sizeof(buf) <= length)
+		readlen = sizeof(buf);
+	else
+		readlen = length;
+
+	md5_starts(&ctx);
+
+	while ((i = stream.read(buf, readlen)) > 0) {
+
+		if (!progressUpdateCallback(i)) {
+			return false;
+		}
+
+		md5_update(&ctx, buf, i);
+
+		if (restricted) {
+			length -= i;
+			if (length == 0)
+				break;
+
+			if (sizeof(buf) > length)
+				readlen = length;
+		}
+	}
+
+	md5_finish(&ctx, digest);
+#endif
+	return true;
+}
+
 String computeStreamMD5AsString(ReadStream &stream, uint32 length) {
 	String md5;
 	uint8 digest[16];
 	if (computeStreamMD5(stream, digest, length)) {
+		for (int i = 0; i < 16; i++) {
+			md5 += String::format("%02x", (int)digest[i]);
+		}
+	}
+
+	return md5;
+}
+
+
+String computeStreamMD5AsString(ReadStream &stream, uint32 length, bool (*progressUpdateCallback)(int)) {
+	String md5;
+	uint8 digest[16];
+	if (computeStreamMD5(stream, digest, length, progressUpdateCallback)) {
 		for (int i = 0; i < 16; i++) {
 			md5 += String::format("%02x", (int)digest[i]);
 		}

--- a/common/md5.cpp
+++ b/common/md5.cpp
@@ -280,7 +280,7 @@ bool computeStreamMD5(ReadStream &stream, uint8 digest[16], uint32 length) {
 }
 
 
-bool computeStreamMD5(ReadStream &stream, uint8 digest[16], uint32 length, bool (*progressUpdateCallback)(int)) {
+bool computeStreamMD5(ReadStream &stream, uint8 digest[16], uint32 length, ProgressUpdateCallback progressUpdateCallback) {
 
 #ifdef DISABLE_MD5
 	memset(digest, 0, 16);
@@ -334,7 +334,7 @@ String computeStreamMD5AsString(ReadStream &stream, uint32 length) {
 }
 
 
-String computeStreamMD5AsString(ReadStream &stream, uint32 length, bool (*progressUpdateCallback)(int)) {
+String computeStreamMD5AsString(ReadStream &stream, uint32 length, ProgressUpdateCallback progressUpdateCallback) {
 	String md5;
 	uint8 digest[16];
 	if (computeStreamMD5(stream, digest, length, progressUpdateCallback)) {

--- a/common/md5.h
+++ b/common/md5.h
@@ -49,6 +49,7 @@ class String;
  * @return true on success, false if an error occurred
  */
 bool computeStreamMD5(ReadStream &stream, uint8 digest[16], uint32 length = 0);
+bool computeStreamMD5(ReadStream &stream, uint8 digest[16], uint32 length, bool (*progressUpdateCallback)(int));
 
 /**
  * Compute the MD5 checksum of the content of the given ReadStream.
@@ -61,6 +62,7 @@ bool computeStreamMD5(ReadStream &stream, uint8 digest[16], uint32 length = 0);
  * @return the MD5 as a hex string on success, and an empty string if an error occurred
  */
 String computeStreamMD5AsString(ReadStream &stream, uint32 length = 0);
+String computeStreamMD5AsString(ReadStream &stream, uint32 length, bool (*progressUpdateCallback)(int));
 
 /** @} */
 

--- a/common/md5.h
+++ b/common/md5.h
@@ -24,6 +24,8 @@
 
 #include "common/scummsys.h"
 
+typedef bool (*ProgressUpdateCallback)(int);
+
 namespace Common {
 
 /**
@@ -49,7 +51,7 @@ class String;
  * @return true on success, false if an error occurred
  */
 bool computeStreamMD5(ReadStream &stream, uint8 digest[16], uint32 length = 0);
-bool computeStreamMD5(ReadStream &stream, uint8 digest[16], uint32 length, bool (*progressUpdateCallback)(int));
+bool computeStreamMD5(ReadStream &stream, uint8 digest[16], uint32 length, ProgressUpdateCallback progressUpdateCallback );
 
 /**
  * Compute the MD5 checksum of the content of the given ReadStream.
@@ -62,7 +64,7 @@ bool computeStreamMD5(ReadStream &stream, uint8 digest[16], uint32 length, bool 
  * @return the MD5 as a hex string on success, and an empty string if an error occurred
  */
 String computeStreamMD5AsString(ReadStream &stream, uint32 length = 0);
-String computeStreamMD5AsString(ReadStream &stream, uint32 length, bool (*progressUpdateCallback)(int));
+String computeStreamMD5AsString(ReadStream &stream, uint32 length, ProgressUpdateCallback progressUpdateCallback);
 
 /** @} */
 

--- a/common/md5.h
+++ b/common/md5.h
@@ -24,7 +24,7 @@
 
 #include "common/scummsys.h"
 
-typedef bool (*ProgressUpdateCallback)(int);
+typedef bool (* ProgressUpdateCallback)(void *, int);
 
 namespace Common {
 
@@ -50,8 +50,7 @@ class String;
  * @param[in] length	the number of bytes for which to compute the checksum; 0 means all
  * @return true on success, false if an error occurred
  */
-bool computeStreamMD5(ReadStream &stream, uint8 digest[16], uint32 length = 0);
-bool computeStreamMD5(ReadStream &stream, uint8 digest[16], uint32 length, ProgressUpdateCallback progressUpdateCallback );
+bool computeStreamMD5(ReadStream &stream, uint8 digest[16], uint32 length = 0, ProgressUpdateCallback progressUpdateCallback = nullptr, void *callbackParameter = nullptr);
 
 /**
  * Compute the MD5 checksum of the content of the given ReadStream.
@@ -63,8 +62,7 @@ bool computeStreamMD5(ReadStream &stream, uint8 digest[16], uint32 length, Progr
  * @param[in] length	the number of bytes for which to compute the checksum; 0 means all
  * @return the MD5 as a hex string on success, and an empty string if an error occurred
  */
-String computeStreamMD5AsString(ReadStream &stream, uint32 length = 0);
-String computeStreamMD5AsString(ReadStream &stream, uint32 length, ProgressUpdateCallback progressUpdateCallback);
+String computeStreamMD5AsString(ReadStream &stream, uint32 length = 0, ProgressUpdateCallback progressUpdateCallback = nullptr, void *callbackParameter = nullptr);
 
 /** @} */
 

--- a/gui/integrity-dialog.cpp
+++ b/gui/integrity-dialog.cpp
@@ -167,8 +167,7 @@ bool IntegrityDialog::progressUpdateCallback(int bytesProcessed) {
 
 void IntegrityDialog::pollEvent(Common::Event &event) {
 	if (g_system->getEventManager()->pollEvent(event)) {
-		static uint32 lastEventPoll = 0;
-
+		lastEventPoll = 0;
 		if (g_system->getMillis() > lastEventPoll + 16) { 
 			lastEventPoll = g_system->getMillis(); 
 			g_gui.processEvent(event, g_checksum_state->dialog);

--- a/gui/integrity-dialog.cpp
+++ b/gui/integrity-dialog.cpp
@@ -146,6 +146,38 @@ IntegrityDialog::IntegrityDialog(Common::String endpoint, Common::String domain)
 IntegrityDialog::~IntegrityDialog() {
 }
 
+
+bool IntegrityDialog::progressUpdateCallback(int bytesProcessed) {
+	if(g_checksum_state->dialog->_close)
+		return false;
+	
+	g_checksum_state->calculatedSize += bytesProcessed;
+
+	if (g_system->getMillis() > g_checksum_state->lastUpdate + 500) {
+		g_checksum_state->lastUpdate = g_system->getMillis(); 
+		g_checksum_state->dialog->sendCommand(kDownloadProgressCmd, 0);
+	}
+
+	Common::Event event;
+	g_checksum_state->dialog->pollEvent(event);
+
+	return true;
+};
+
+
+void IntegrityDialog::pollEvent(Common::Event &event) {
+	if (g_system->getEventManager()->pollEvent(event)) {
+		static uint32 lastEventPoll = 0;
+
+		if (g_system->getMillis() > lastEventPoll + 16) { 
+			lastEventPoll = g_system->getMillis(); 
+			g_gui.processEvent(event, g_checksum_state->dialog);
+			g_system->updateScreen();
+		}
+	}
+}
+
+
 void IntegrityDialog::open() {
 	Dialog::open();
 	reflowLayout();
@@ -341,21 +373,21 @@ Common::Array<Common::StringArray> IntegrityDialog::generateChecksums(Common::Pa
 				// Data fork
 				// Various checksizes
 				for (auto size : {0, 5000, 1024 * 1024}) {
-					fileChecksum.push_back(Common::computeStreamMD5AsString(*dataForkStream, size).c_str());
+					fileChecksum.push_back(Common::computeStreamMD5AsString(*dataForkStream, size, progressUpdateCallback).c_str());
 					dataForkStream->seek(0);
 				}
 				// Tail checksums with checksize 5000
 				dataForkStream->seek(-5000, SEEK_END);
-				fileChecksum.push_back(Common::computeStreamMD5AsString(*dataForkStream).c_str());
+				fileChecksum.push_back(Common::computeStreamMD5AsString(*dataForkStream, 0, progressUpdateCallback).c_str());
 
 				// Resource fork
 				if (macFile.hasResFork()) {
 					// Various checksizes
 					for (auto size : {0, 5000, 1024 * 1024}) {
-						fileChecksum.push_back(macFile.computeResForkMD5AsString(size).c_str());
+						fileChecksum.push_back(macFile.computeResForkMD5AsString(size, false, progressUpdateCallback).c_str());
 					}
 					// Tail checksums with checksize 5000
-					fileChecksum.push_back(macFile.computeResForkMD5AsString(5000, true).c_str());
+					fileChecksum.push_back(macFile.computeResForkMD5AsString(5000, true, progressUpdateCallback).c_str());
 					fileChecksums.push_back(fileChecksum);
 				}
 
@@ -369,19 +401,12 @@ Common::Array<Common::StringArray> IntegrityDialog::generateChecksums(Common::Pa
 			Common::Array<Common::String> fileChecksum = {filename.toString()};
 			// Various checksizes
 			for (auto size : {0, 5000, 1024 * 1024}) {
-				fileChecksum.push_back(Common::computeStreamMD5AsString(file, size).c_str());
+				fileChecksum.push_back(Common::computeStreamMD5AsString(file, size, progressUpdateCallback).c_str());
 				file.seek(0);
 			}
 			// Tail checksums with checksize 5000
 			file.seek(-5000, SEEK_END);
-			fileChecksum.push_back(Common::computeStreamMD5AsString(file).c_str());
-
-			g_checksum_state->calculatedSize += file.size();
-
-			if (g_system->getMillis() > g_checksum_state->lastUpdate + 500) {
-				g_checksum_state->lastUpdate = g_system->getMillis();
-				sendCommand(kDownloadProgressCmd, 0);
-			}
+			fileChecksum.push_back(Common::computeStreamMD5AsString(file, 0, progressUpdateCallback).c_str());
 
 			file.close();
 			fileChecksums.push_back(fileChecksum);

--- a/gui/integrity-dialog.cpp
+++ b/gui/integrity-dialog.cpp
@@ -187,6 +187,13 @@ void IntegrityDialog::open() {
 void IntegrityDialog::close() {
 	if (g_checksum_state)
 		g_checksum_state->dialog = nullptr;
+		delete g_checksum_state;
+		g_checksum_state = nullptr;
+	
+	if (g_result) {
+		delete g_result;
+		g_result = nullptr;
+	}
 
 	Dialog::close();
 }
@@ -240,13 +247,7 @@ void IntegrityDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 da
 		setState(kResponseReceived);
 		break;
 	case kCleanupCmd: {
-		delete g_checksum_state;
-		g_checksum_state = nullptr;
-
-		delete g_result;
-		g_result = nullptr;
-
-		close();
+		_close = true;
 		break;
 	}
 	case kDownloadProgressCmd:
@@ -477,6 +478,9 @@ Common::JSONValue *IntegrityDialog::generateJSONRequest(Common::Path gamePath, C
 }
 
 void IntegrityDialog::checksumResponseCallback(const Common::JSONValue *r) {
+	if (!g_result || !g_checksum_state) {
+        return;
+    }
 	debug(3, "JSON Response: %s", r->stringify().c_str());
 	IntegrityDialog::parseJSON(r);
 
@@ -508,6 +512,9 @@ void IntegrityDialog::sendJSON() {
 }
 
 void IntegrityDialog::parseJSON(const Common::JSONValue *response) {
+	if (!g_result || !g_checksum_state) {
+        return;
+    }
 	Common::JSONObject responseObject = response->asObject();
 	int responseError = responseObject.getVal("error")->asIntegerNumber();
 

--- a/gui/integrity-dialog.h
+++ b/gui/integrity-dialog.h
@@ -62,6 +62,8 @@ class IntegrityDialog : public Dialog, public CommandSender {
 	ButtonWidget *_copyEmailButton;
 
 	bool _close;
+	uint32 lastEventPoll;
+
 
 	Common::U32String getSizeLabelText();
 	void refreshWidgets();

--- a/gui/integrity-dialog.h
+++ b/gui/integrity-dialog.h
@@ -62,7 +62,7 @@ class IntegrityDialog : public Dialog, public CommandSender {
 	ButtonWidget *_copyEmailButton;
 
 	bool _close;
-	uint32 lastEventPoll;
+	uint32 _lastEventPoll;
 
 
 	Common::U32String getSizeLabelText();
@@ -74,15 +74,10 @@ public:
 
 
 	/**
-	 * Callback funtion which updates the progress bar every 500ms
-	 * It also poll events to allow mouse movements/button interactions to avoid freezing when processing large files
+	 * Updates the progress bar every 500ms
+	 * Includes polling to avoid freezing when processing files
 	 */
-	static bool progressUpdateCallback(int bytesProcessed);
-
-	/**
-	 * Poll events during callback
-	 */
-	void pollEvent(Common::Event &event);
+	bool progressUpdate(int bytesProcessed);
 
 	void sendJSON();
 	void checksumResponseCallback(const Common::JSONValue *r);

--- a/gui/integrity-dialog.h
+++ b/gui/integrity-dialog.h
@@ -70,6 +70,18 @@ public:
 	IntegrityDialog(Common::String endpoint, Common::String gameConfig);
 	~IntegrityDialog();
 
+
+	/**
+	 * Callback funtion which updates the progress bar every 500ms
+	 * It also poll events to allow mouse movements/button interactions to avoid freezing when processing large files
+	 */
+	static bool progressUpdateCallback(int bytesProcessed);
+
+	/**
+	 * Poll events during callback
+	 */
+	void pollEvent(Common::Event &event);
+
 	void sendJSON();
 	void checksumResponseCallback(const Common::JSONValue *r);
 	void errorCallback(const Networking::ErrorResponse &error);


### PR DESCRIPTION
* Add callback function that updates the bytes processed during the md5 calculation to display in the progress bar
* Implement event polling to keep UI responsive during operations
* Fix crash when clicking cancel button during checksum calculations

Here is a demo video - 

https://github.com/user-attachments/assets/c902147c-0445-4848-9932-b065dc275c0e

