### PR TITLE
FREESCAPE: Fix indexing error

### DIFF
--- a/engines/freescape/gfx_tinygl.cpp
+++ b/engines/freescape/gfx_tinygl.cpp
@@ -474,8 +474,8 @@ void TinyGLRenderer::drawCelestialBody(Math::Vector3d position, float radius, by
 	copyToVertexArray(0, position);
 	float adj = 1.25; // Perspective correction
 
-	for (int i = 0; i <= triangleAmount; i++) {
-		copyToVertexArray(i + 1,
+	for (int i = 1; i <= triangleAmount; i++) {
+		copyToVertexArray(i,
 		                  Math::Vector3d(position.x(), position.y() + (radius * cos(i *  twicePi / triangleAmount)),
 		                                 position.z() + (adj * radius * sin(i * twicePi / triangleAmount)))
 		                 );
@@ -492,8 +492,8 @@ void TinyGLRenderer::drawCelestialBody(Math::Vector3d position, float radius, by
 		tglEnableClientState(TGL_VERTEX_ARRAY);
 		copyToVertexArray(0, position);
 
-		for (int i = 0; i <= triangleAmount; i++) {
-			copyToVertexArray(i + 1,
+		for (int i = 1; i <= triangleAmount; i++) {
+			copyToVertexArray(i,
 			                  Math::Vector3d(position.x(), position.y() + (radius * cos(i *  twicePi / triangleAmount)),
 			                                 position.z() + (adj * radius * sin(i * twicePi / triangleAmount)))
 			                 );


### PR DESCRIPTION
The code which creates the triangle fan was pushing the first vertex
outside of the loop and accounting for this by telling TinyGL that each
further vertex was i+1, however the loop itself continued to operate as
if this didn't happen, iterating from 0 to triangleAmount + 1.

This was causing an access violation when compiled with MSVC. Each of the
celestial bodies in the draw call contained 22 vertices and the 22nd
vertex was in each case garbage data.
