### PR TITLE
VIDEO: Correctly handle raw Elementary Stream MPEG Videos

### DIFF
--- a/video/mpegps_decoder.cpp
+++ b/video/mpegps_decoder.cpp
@@ -270,19 +270,16 @@ bool MPEGPSDecoder::MPEGPSDemuxer::loadStream(Common::SeekableReadStream *stream
 	stream->seek(startPosition);
 
 	// If it is a Sequence Header (ES Stream), pass the stream to a Elementary Stream handler.
+	// If it is a Pack Header (PS stream), pass the stream to PS demuxer for demuxing into video and audio packets
+	// Currently not handling other stream types like ES audio stream
+	// Throwing a warning, so that decoding of further streams isn't affected
+	// Unknown stream header types are "handled" (ignored) in the readNextPacketHeader function 
+
 	if (header == kStartCodeSequenceHeader) {
 		_isESStream = true;
-	}
-		
-	// If it is a Pack Header (PS stream), pass the stream to PS demuxer for demuxing into video and audio packets
-	else if (header == kStartCodePack) {
+	} else if (header == kStartCodePack) {
 		_isESStream = false;
-	}
-
-	// Currently not handling other stream types like ES audio stream
-	// Instead of throwing an error, we can throw a warning, so that decoding of further streams isn't affected
-	// Unknown stream header types are "handled" (ignored) in the readNextPacketHeader function 
-	else {
+	} else {
 		warning("Unknown Start Code in the MPEG stream, %d", header);
 		_isESStream = false;
 	}

--- a/video/mpegps_decoder.cpp
+++ b/video/mpegps_decoder.cpp
@@ -265,9 +265,8 @@ bool MPEGPSDecoder::MPEGPSDemuxer::loadStream(Common::SeekableReadStream *stream
 	// Check if the videostream being loaded is an elementary stream (ES) or a program stream (PS)
 	// PS streams start with the Pack Header which has a start code of 0x1ba
 	// ES streams start with the Sequence Header which has a start code of 0x1b3
-	int64 startPosition = stream->pos();
 	uint32 header = stream->readUint32BE();
-	stream->seek(startPosition);
+	stream->seek(-4, SEEK_CUR);
 
 	// If it is a Sequence Header (ES Stream), pass the stream to a Elementary Stream handler.
 	// If it is a Pack Header (PS stream), pass the stream to PS demuxer for demuxing into video and audio packets

--- a/video/mpegps_decoder.cpp
+++ b/video/mpegps_decoder.cpp
@@ -270,18 +270,22 @@ bool MPEGPSDecoder::MPEGPSDemuxer::loadStream(Common::SeekableReadStream *stream
 	stream->seek(startPosition);
 
 	// If it is a Sequence Header (ES Stream), pass the stream to a Elementary Stream handler.
-	if (header == kStartCodeSequenceHeader) 
+	if (header == kStartCodeSequenceHeader) {
 		_isESStream = true;
+	}
 		
 	// If it is a Pack Header (PS stream), pass the stream to PS demuxer for demuxing into video and audio packets
-	else if (header == kStartCodePack) 
+	else if (header == kStartCodePack) {
 		_isESStream = false;
+	}
 
 	// Currently not handling other stream types like ES audio stream
 	// Instead of throwing an error, we can throw a warning, so that decoding of further streams isn't affected
 	// Unknown stream header types are "handled" (ignored) in the readNextPacketHeader function 
-	else 
+	else {
 		warning("Unknown Start Code in the MPEG stream, %d", header);
+		_isESStream = false;
+	}
 	
 	_stream = stream;
 

--- a/video/mpegps_decoder.h
+++ b/video/mpegps_decoder.h
@@ -72,6 +72,8 @@ private:
 
 		bool loadStream(Common::SeekableReadStream *stream);
 		void close();
+		bool getESStream() { return _isESStream; }
+		void setESStream(bool isESStream) { _isESStream = isESStream; }
 
 		Common::SeekableReadStream *getFirstVideoPacket(int32 &startCode, uint32 &pts, uint32 &dts);
 		Common::SeekableReadStream *getNextPacket(uint32 currentTime, int32 &startCode, uint32 &pts, uint32 &dts);
@@ -96,6 +98,8 @@ private:
 		Common::SeekableReadStream *_stream;
 		Common::Queue<Packet> _videoQueue;
 		Common::Queue<Packet> _audioQueue;
+		// If we come across a non-packetized elementary stream
+		bool _isESStream;
 	};
 
 	// Base class for handling MPEG streams

--- a/video/mpegps_decoder.h
+++ b/video/mpegps_decoder.h
@@ -72,8 +72,6 @@ private:
 
 		bool loadStream(Common::SeekableReadStream *stream);
 		void close();
-		bool getESStream() { return _isESStream; }
-		void setESStream(bool isESStream) { _isESStream = isESStream; }
 
 		Common::SeekableReadStream *getFirstVideoPacket(int32 &startCode, uint32 &pts, uint32 &dts);
 		Common::SeekableReadStream *getNextPacket(uint32 currentTime, int32 &startCode, uint32 &pts, uint32 &dts);


### PR DESCRIPTION
Recognize the type of the stream in .mpg files (ES or PS) In case of ES (Elementary Streams) bypass the PES header parsing process and directly feed the MPEG decoder the raw data. Remove warning that appears when opening the ND
logo when opening the game 3mice1-pl

Changes made in how ES stream packets are pushed
in the _demuxer queue for decoding in function queueNextPacket Made sure that the ES stream is handled in
the MPEGPSDecoder::MPEGPSDemuxer class entirely