### PR TITLE
WAGE: Fix crash due to outdated sound queue timestamps

### DIFF
--- a/engines/wage/combat.cpp
+++ b/engines/wage/combat.cpp
@@ -520,6 +520,7 @@ bool WageEngine::handleMoveCommand(Directions dir, const char *dirName) {
 			if (strlen(msg) > 0) {
 				appendText(msg);
 			}
+			_soundQueue.clear();
 			_world->move(_world->_player, scene);
 			return true;
 		}


### PR DESCRIPTION
Clear `_soundQueue` when re-entering a scene with stale timestamps. Previously, if a player left and later returned to a scene, the sound queue could contain old timestamps. This caused `installTimerProc` to compute a negative delay, triggering an assertion failure (`interval > 0`) in `DefaultTimerManager`.


Tested by re-entering scenes with sound timers and confirming no crashes.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
