### PR TITLE
BACKENDS: FS: Use stat() fallback for all unexpected dirent d_type values

### DIFF
--- a/backends/audiocd/macosx/macosx-audiocd.cpp
+++ b/backends/audiocd/macosx/macosx-audiocd.cpp
@@ -267,7 +267,7 @@ bool MacOSXAudioCDManager::findTrackNames(const Common::Path &drivePath) {
 	}
 
 	Common::FSList children;
-	if (!directory.getChildren(children, Common::FSNode::kListFilesOnly)) {
+	if (!directory.getChildren(children, Common::FSNode::kListFilesOnly) || children.empty()) {
 		warning("Failed to find children for '%s'", drivePath.toString(Common::Path::kNativeSeparator).c_str());
 		return false;
 	}


### PR DESCRIPTION
## Problem

On OSX Tiger, playing Indy3 FM-TOWNS from its original CD (which has both an ISO-9660 layer and a Redbook layer) produced no music.

## Explanation

It looks like that's because we rely on dirent's `d_type` (on systems where it's available). Thing is, this field is not guaranteed to be meaningful for all filesystems (even on Linux; as seen in its `readdir(3)` manual page).

In OSX Tiger in particular, dirent returns completely bogus `d_type` values for the files being part of the CDDAFS volumes (used by MacOSXAudioCDManager). I'd get `DT_CHR` for the AIFF files, and `3` (which has no `DT_*` value name!) for the TOC file. (It looks like this is because their `cddafs` module, up until cddafs-240.0.9 in 2008, [uses improper constants](https://github.com/apple-oss-distributions/cddafs/commit/d7f85707277ac630e7ac10439e6a112c39411184#diff-7724b510894676a7136bafd8f5ef1f4e43f8a9d59174a9e230bd262488dda185L811) for `d_type`. This was fixed in cddafs-242.0.1, apparently part of macOS 10.6.2.).

The `posix-fs.cpp` code would then flag all the `.aiff` files as invalid, and then MacOSXAudioCDManager had nothing left to play.

If you `stat()` those files, though, you do get proper file type values. But the current `posix-fs.cpp` code only falls back to `stat()` for `DT_UNKNOWN` values.

## Suggested fix

Fall back to `stat()` for _all_ unexpected values (that is, anything different from: `DT_DIR`, `DT_REG`, `DT_LNK`), and not just `DT_UNKNOWN`.

This makes our `d_type` usage a bit more robust on more limited implementations. It also effectively unbreaks Indy3 TOWNS on OSX Tiger.

Still, this code is shared by many things, so we may need a careful review of the possible side effects of this change.

**EDIT:** FreeBSD also documents this `d_type` behavior ([`[1]`](https://man.freebsd.org/cgi/man.cgi?query=dirent&apropos=0&sektion=0&manpath=FreeBSD+14.2-RELEASE+and+Ports&arch=default&format=html#end), [`[2]`](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=11645)) for some filesystems.