### PR TITLE
TINYGL: Fix TGL_TRIANGLE_FAN rendering

### DIFF
--- a/graphics/tinygl/zdirtyrect.cpp
+++ b/graphics/tinygl/zdirtyrect.cpp
@@ -392,7 +392,7 @@ void RasterizationDrawCall::execute(bool restoreState) const {
 		}
 		break;
 	case TGL_TRIANGLE_FAN:
-		for(int i = 1; i < cnt; i++) {
+		for(int i = 1; i < cnt - 1; i++) {
 			c->gl_draw_triangle(&c->vertex[0], &c->vertex[i], &c->vertex[i + 1]);
 		}
 		break;

--- a/graphics/tinygl/zdirtyrect.cpp
+++ b/graphics/tinygl/zdirtyrect.cpp
@@ -392,7 +392,7 @@ void RasterizationDrawCall::execute(bool restoreState) const {
 		}
 		break;
 	case TGL_TRIANGLE_FAN:
-		for(int i = 1; i < cnt; i += 2) {
+		for(int i = 1; i < cnt; i++) {
 			c->gl_draw_triangle(&c->vertex[0], &c->vertex[i], &c->vertex[i + 1]);
 		}
 		break;


### PR DESCRIPTION
TGL_TRIANGLE_FAN was found to be causing an access violation error while drawing pixels due to a bad value which emerged when attempting to render celestial bodies in Total Eclipse. When the access violation was forestalled by some means, you would see the sun and moon rendered as disconnected triangles which looked like rays rather than a true triangle fan. The first issue was because the loop which draws the vertices was stepping one vertex too far, and the rendering issue was due the loop not reusing a vertex from the previous triangle for the next one, causing the skipped triangle rendering.