### PR TITLE
GRIM: Add French Mac EMI detection entry

### DIFF
--- a/engines/grim/detection_tables.h
+++ b/engines/grim/detection_tables.h
@@ -524,6 +524,20 @@ static const GrimGameDescription gameDescriptions[] = {
 		},
 		GType_MONKEY4
 	},
+	{
+		// Escape from Monkey Island French (Mac)
+		{
+			"monkey4",
+			"",
+			AD_ENTRY2s("artAll.m4b",	 "151af0a694382af873f325fcea293bb1", 18514420,
+					   "Installation de Monkey Island 4", "8b22e2fadb4e72e8041c7bd896f1759d", 9242911),
+			Common::FR_FRA,
+			Common::kPlatformMacintosh,
+			ADGF_UNSTABLE,
+			GUI_OPTIONS_GRIME
+		},
+		GType_MONKEY4
+	},
 
 #if defined(USE_MPEG2)
 	{

--- a/engines/grim/md5check.cpp
+++ b/engines/grim/md5check.cpp
@@ -415,6 +415,7 @@ const char *emid_voice[] = {
 const char *emi_installer[] = {
 	"93a639e3221405862dc46e9706216c00", // German (EFMI Installer)
 	"a42f8aa079a6d23c285fceba191e67a4", // English (Monkey Island 4 Installer)
+	"d54924078bdfc4c449761500873f279c", // French (Installation de Monkey Island 4)
 };
 
 bool MD5Check::_initted = false;
@@ -518,6 +519,9 @@ void MD5Check::init() {
 				if (g_grim->getGameLanguage() == Common::DE_DEU) {
 					// Known to be the correct filename for german
 					MD5SUM("EFMI Installer", emi_installer)
+				} else if (g_grim->getGameLanguage() == Common::FR_FRA) {
+					// Known to be the correct filename for French
+					MD5SUM("Installation de Monkey Island 4", emi_installer)
 				} else {
 					// Known to be the correct filename for english
 					MD5SUM("Monkey Island 4 Installer", emi_installer)
@@ -529,9 +533,10 @@ void MD5Check::init() {
 			MD5SUM("artMel.m4b", emi_artMel)
 			MD5SUM("artMon.m4b", emi_artMon)
 			MD5SUM("lip.m4b", emi_lip)
-			// At least in the English version, this appears to be part of the
-			// installer.
-			if (g_grim->getGameLanguage() != Common::EN_ANY) {
+			// At least in the English and French versions, this appears to be
+			// part of the installer.
+			if (g_grim->getGameLanguage() != Common::EN_ANY
+				&& g_grim->getGameLanguage() != Common::FR_FRA) {
 				MD5SUM("local.m4b", emi_local)
 			}
 			MD5SUM("sfx.m4b", emi_sfx)


### PR DESCRIPTION
From my own French ASPYR CDs. Appears to properly work (just played a few scenes, though), which might not have been the case of the Macintosh English release, judging by commit b59d22dd09e64568daedaa986798f0db5255e906 description.

The Macintosh installer is called `Installation de Monkey Island 4`, there.

Regarding the `MD5SUM("local.m4b", emi_local)`, I've checked both my French Windows and French Macintosh CDs, and it does look like it's part of the MonkeyInstall resources, not the MonkeyData ones.

Submitting it as a PR, in case @aquadran wants to check a few things first.