### PR TITLE
AGOS: Waxworks : Implement hotkey for toggling combat mode

### DIFF
--- a/engines/agos/event.cpp
+++ b/engines/agos/event.cpp
@@ -504,7 +504,6 @@ void AGOSEngine::delay(uint amount) {
 						aboutDialog.runModal();
 					}
 				} else if (event.kbd.keycode == Common::KEYCODE_f && getGameId() == GID_WAXWORKS) {
-
 					// Check if the necessary HitAreas exist.
 					HitArea *fightButton = findBox(117);
 					HitArea *walkButton = findBox(119);

--- a/engines/agos/event.cpp
+++ b/engines/agos/event.cpp
@@ -518,7 +518,7 @@ void AGOSEngine::delay(uint amount) {
 								_needHitAreaRecalc++;
 								ha = findBox(119); // Find a walkable area.
 								if (ha)
-									_lastHitArea = ha;
+									_lastHitArea = ha; // Assign to _lastHitArea.
 							} else {
 								// If not in fighting mode, switch to fighting mode
 								_mouseCursor = 3;
@@ -526,13 +526,27 @@ void AGOSEngine::delay(uint amount) {
 								ha = findBox(117); // Find the fight button's HitArea (ID 117).
 								if (ha)
 									_lastHitArea = ha; // Assign to _lastHitArea.
+
 							}
 						} else {
 							// Hotkey is NOT supported (HitAreas missing)
-							warning("Fighting mode hotkey (F) is not supported for this version of Waxworks (missing HitAreas).");
+							const char *missingHitArea = nullptr;
+							if (!fightButton && !walkButton) {
+								missingHitArea = "HitAreas 117 and 119 are missing.";
+							} else if (!fightButton) {
+								missingHitArea = "HitArea 119 exists but HitArea 117 is missing.";
+							} else if (!walkButton) {
+								missingHitArea = "HitArea 117 exists but HitArea 119 is missing.";
+							}
+
+							warning("Fighting mode hotkey (F) is not supported for this version of Waxworks. "
+									"%s GameID: %d, Language: %d",
+									missingHitArea, getGameId(), getLanguage());
 						}
 					} else {
-						warning("Fighting mode hotkey (F) is not supported for this version/language of Waxworks.");
+						warning("Fighting mode hotkey (F) is not supported for this version/language of Waxworks. "
+								"GameID: %d, Language: %d",
+								getGameId(), getLanguage());
 					}
 				}
 

--- a/engines/agos/event.cpp
+++ b/engines/agos/event.cpp
@@ -504,33 +504,16 @@ void AGOSEngine::delay(uint amount) {
 						aboutDialog.runModal();
 					}
 				} else if (event.kbd.keycode == Common::KEYCODE_f && getGameId() == GID_WAXWORKS) {
-					// Check if the necessary HitAreas exist.
 					HitArea *fightButton = findBox(117);
-					HitArea *walkButton = findBox(119);
 
-					if (fightButton && walkButton) {
-						// Hotkey is supported (HitAreas exist)
+					if (fightButton && !(fightButton->flags & kBFBoxDead)) {
 						_needHitAreaRecalc++;
-
-						if (_mouseCursor == 3) {
-							// If already in fighting mode, switch to a default non-fighting cursor (0)
-							_mouseCursor = 0;
-							_lastHitArea = walkButton;
-						} else {
-							// If not in fighting mode, switch to fighting mode
-							_mouseCursor = 3;
-							_lastHitArea = fightButton;
-						}
-					} else {
-						// Hotkey is NOT supported (HitAreas missing)
-						const char *missingHitArea =
-							(!fightButton && !walkButton) ? "HitAreas 117 and 119 are missing."
-							: (!fightButton)              ? "HitArea 117 is missing."
-														  : "HitArea 119 is missing.";
-
-						warning("Fighting mode hotkey (F) is not supported for this version of Waxworks. "
-								"%s GameID: %d, Language: %d",
-								missingHitArea, getGameId(), getLanguage());
+						_lastHitArea = fightButton;
+						
+						if (_mouseCursor == 3)
+							_mouseCursor = 0; // Switch to default cursor
+						else
+							_mouseCursor = 3;	// Switch to fighting mode
 					}
 				}
 

--- a/engines/agos/event.cpp
+++ b/engines/agos/event.cpp
@@ -505,24 +505,31 @@ void AGOSEngine::delay(uint amount) {
 					}
 				} else if (event.kbd.keycode == Common::KEYCODE_f && getGameId() == GID_WAXWORKS) {
 					if (getLanguage() == Common::EN_ANY) {
+						// Check if the necessary HitAreas exist.
+						HitArea *fightButton = findBox(117);
+						HitArea *walkButton = findBox(119);
 
-						HitArea *ha = nullptr;
-						if (_mouseCursor == 3) {
-							// If already in fighting mode, switch to a default non-fighting cursor (0)
-							_mouseCursor = 0;
-							_verbHitArea = 0;
-							_needHitAreaRecalc++;
-							ha = findBox(119); // Some walkable area.
-							if (ha)
-								_lastHitArea = ha;
+						if (fightButton && walkButton) {
+							// Hotkey is supported (HitAreas exist)
+							HitArea *ha = nullptr;
+							if (_mouseCursor == 3) {
+								// If already in fighting mode, switch to a default non-fighting cursor (0)
+								_mouseCursor = 0;
+								_needHitAreaRecalc++;
+								ha = findBox(119); // Find a walkable area.
+								if (ha)
+									_lastHitArea = ha;
+							} else {
+								// If not in fighting mode, switch to fighting mode
+								_mouseCursor = 3;
+								_needHitAreaRecalc++;
+								ha = findBox(117); // Find the fight button's HitArea (ID 117).
+								if (ha)
+									_lastHitArea = ha; // Assign to _lastHitArea.
+							}
 						} else {
-							// If not in fighting mode, switch to fighting mode
-							_mouseCursor = 3;
-							_verbHitArea = 236;
-							_needHitAreaRecalc++;
-							ha = findBox(117); // Find HitArea for fighting mode (ID 117).
-							if (ha)
-								_lastHitArea = ha; // Assign to _lastHitArea.
+							// Hotkey is NOT supported (HitAreas missing)
+							warning("Fighting mode hotkey (F) is not supported for this version of Waxworks (missing HitAreas).");
 						}
 					} else {
 						warning("Fighting mode hotkey (F) is not supported for this version/language of Waxworks.");

--- a/engines/agos/event.cpp
+++ b/engines/agos/event.cpp
@@ -526,18 +526,13 @@ void AGOSEngine::delay(uint amount) {
 								ha = findBox(117); // Find the fight button's HitArea (ID 117).
 								if (ha)
 									_lastHitArea = ha; // Assign to _lastHitArea.
-
 							}
 						} else {
 							// Hotkey is NOT supported (HitAreas missing)
-							const char *missingHitArea = nullptr;
-							if (!fightButton && !walkButton) {
-								missingHitArea = "HitAreas 117 and 119 are missing.";
-							} else if (!fightButton) {
-								missingHitArea = "HitArea 119 exists but HitArea 117 is missing.";
-							} else if (!walkButton) {
-								missingHitArea = "HitArea 117 exists but HitArea 119 is missing.";
-							}
+							const char *missingHitArea =
+								(!fightButton && !walkButton) ? "HitAreas 117 and 119 are missing."
+								: (!fightButton) ? "HitArea 117 is missing."
+								: "HitArea 119 is missing.";
 
 							warning("Fighting mode hotkey (F) is not supported for this version of Waxworks. "
 									"%s GameID: %d, Language: %d",

--- a/engines/agos/event.cpp
+++ b/engines/agos/event.cpp
@@ -503,24 +503,29 @@ void AGOSEngine::delay(uint amount) {
 						GUI::AboutDialog aboutDialog;
 						aboutDialog.runModal();
 					}
-				} else if (event.kbd.keycode == Common::KEYCODE_f) {
-					HitArea *ha = nullptr;
-					if (_mouseCursor == 3) {
-						// If already in fighting mode, switch to a default non-fighting cursor (0)
-						_mouseCursor = 0;
-						_verbHitArea = 0;
-						_needHitAreaRecalc++;
-						ha = findBox(119); // Some walkable area.
-						if (ha)
-							_lastHitArea = ha;
+				} else if (event.kbd.keycode == Common::KEYCODE_f && getGameId() == GID_WAXWORKS) {
+					if (getLanguage() == Common::EN_ANY) {
+
+						HitArea *ha = nullptr;
+						if (_mouseCursor == 3) {
+							// If already in fighting mode, switch to a default non-fighting cursor (0)
+							_mouseCursor = 0;
+							_verbHitArea = 0;
+							_needHitAreaRecalc++;
+							ha = findBox(119); // Some walkable area.
+							if (ha)
+								_lastHitArea = ha;
+						} else {
+							// If not in fighting mode, switch to fighting mode
+							_mouseCursor = 3;
+							_verbHitArea = 236;
+							_needHitAreaRecalc++;
+							ha = findBox(117); // Find HitArea for fighting mode (ID 117).
+							if (ha)
+								_lastHitArea = ha; // Assign to _lastHitArea.
+						}
 					} else {
-						// If not in fighting mode, switch to fighting mode
-						_mouseCursor = 3;
-						_verbHitArea = 236;
-						_needHitAreaRecalc++;
-						ha = findBox(117); // Find HitArea for fighting mode (ID 117).
-						if (ha)
-							_lastHitArea = ha; // Assign to _lastHitArea.
+						warning("Fighting mode hotkey (F) is not supported for this version/language of Waxworks.");
 					}
 				}
 

--- a/engines/agos/event.cpp
+++ b/engines/agos/event.cpp
@@ -503,6 +503,25 @@ void AGOSEngine::delay(uint amount) {
 						GUI::AboutDialog aboutDialog;
 						aboutDialog.runModal();
 					}
+				} else if (event.kbd.keycode == Common::KEYCODE_f) {
+					HitArea *ha = nullptr;
+					if (_mouseCursor == 3) {
+						// If already in fighting mode, switch to a default non-fighting cursor (0)
+						_mouseCursor = 0;
+						_verbHitArea = 0;
+						_needHitAreaRecalc++;
+						ha = findBox(119); // Some walkable area.
+						if (ha)
+							_lastHitArea = ha;
+					} else {
+						// If not in fighting mode, switch to fighting mode
+						_mouseCursor = 3;
+						_verbHitArea = 236;
+						_needHitAreaRecalc++;
+						ha = findBox(117); // Find HitArea for fighting mode (ID 117).
+						if (ha)
+							_lastHitArea = ha; // Assign to _lastHitArea.
+					}
 				}
 
 				if (getGameType() == GType_PP) {

--- a/engines/agos/event.cpp
+++ b/engines/agos/event.cpp
@@ -504,46 +504,37 @@ void AGOSEngine::delay(uint amount) {
 						aboutDialog.runModal();
 					}
 				} else if (event.kbd.keycode == Common::KEYCODE_f && getGameId() == GID_WAXWORKS) {
-					if (getLanguage() == Common::EN_ANY) {
-						// Check if the necessary HitAreas exist.
-						HitArea *fightButton = findBox(117);
-						HitArea *walkButton = findBox(119);
 
-						if (fightButton && walkButton) {
-							// Hotkey is supported (HitAreas exist)
-							HitArea *ha = nullptr;
-							if (_mouseCursor == 3) {
-								// If already in fighting mode, switch to a default non-fighting cursor (0)
-								_mouseCursor = 0;
-								_needHitAreaRecalc++;
-								ha = findBox(119); // Find a walkable area.
-								if (ha)
-									_lastHitArea = ha; // Assign to _lastHitArea.
-							} else {
-								// If not in fighting mode, switch to fighting mode
-								_mouseCursor = 3;
-								_needHitAreaRecalc++;
-								ha = findBox(117); // Find the fight button's HitArea (ID 117).
-								if (ha)
-									_lastHitArea = ha; // Assign to _lastHitArea.
-							}
+					// Check if the necessary HitAreas exist.
+					HitArea *fightButton = findBox(117);
+					HitArea *walkButton = findBox(119);
+
+					if (fightButton && walkButton) {
+						// Hotkey is supported (HitAreas exist)
+						_needHitAreaRecalc++;
+
+						if (_mouseCursor == 3) {
+							// If already in fighting mode, switch to a default non-fighting cursor (0)
+							_mouseCursor = 0;
+							_lastHitArea = walkButton;
 						} else {
-							// Hotkey is NOT supported (HitAreas missing)
-							const char *missingHitArea =
-								(!fightButton && !walkButton) ? "HitAreas 117 and 119 are missing."
-								: (!fightButton) ? "HitArea 117 is missing."
-								: "HitArea 119 is missing.";
-
-							warning("Fighting mode hotkey (F) is not supported for this version of Waxworks. "
-									"%s GameID: %d, Language: %d",
-									missingHitArea, getGameId(), getLanguage());
+							// If not in fighting mode, switch to fighting mode
+							_mouseCursor = 3;
+							_lastHitArea = fightButton;
 						}
 					} else {
-						warning("Fighting mode hotkey (F) is not supported for this version/language of Waxworks. "
-								"GameID: %d, Language: %d",
-								getGameId(), getLanguage());
+						// Hotkey is NOT supported (HitAreas missing)
+						const char *missingHitArea =
+							(!fightButton && !walkButton) ? "HitAreas 117 and 119 are missing."
+							: (!fightButton)              ? "HitArea 117 is missing."
+														  : "HitArea 119 is missing.";
+
+						warning("Fighting mode hotkey (F) is not supported for this version of Waxworks. "
+								"%s GameID: %d, Language: %d",
+								missingHitArea, getGameId(), getLanguage());
 					}
 				}
+				
 
 				if (getGameType() == GType_PP) {
 					if (event.kbd.hasFlags(Common::KBD_SHIFT))

--- a/engines/agos/event.cpp
+++ b/engines/agos/event.cpp
@@ -533,7 +533,6 @@ void AGOSEngine::delay(uint amount) {
 								missingHitArea, getGameId(), getLanguage());
 					}
 				}
-				
 
 				if (getGameType() == GType_PP) {
 					if (event.kbd.hasFlags(Common::KBD_SHIFT))


### PR DESCRIPTION
This PR implements the 'F' key as a hotkey to toggle between combat and movement modes in the game Waxworks, running on the AGOS engine.

Fix- [#10311](https://bugs.scummvm.org/ticket/10311)