### PR TITLE
QDENGINE: Various fixes around older game versions 

### DIFF
--- a/engines/qdengine/qdcore/qd_camera.cpp
+++ b/engines/qdengine/qdcore/qd_camera.cpp
@@ -1300,7 +1300,7 @@ bool qdCamera::is_walkable(const Vect2s &center_pos, const Vect2s &size, bool ig
 	debugC(3, kDebugMovement, "qdCamera::is_walkable(): attr: %d [%d, %d] size: [%d, %d], ignore_personages: %d", cells->attributes(), x0, y0, size.x, size.y, ignore_personages);
 
 	int attr = sGridCell::CELL_IMPASSABLE | sGridCell::CELL_OCCUPIED;
-	if (!ignore_personages) {
+	if (g_engine->_gameVersion > 20031206 && !ignore_personages) {
 		attr |= sGridCell::CELL_PERSONAGE_OCCUPIED;
 	 }
 

--- a/engines/qdengine/qdcore/qd_contour.cpp
+++ b/engines/qdengine/qdcore/qd_contour.cpp
@@ -190,52 +190,62 @@ bool qdContour::is_inside(const Vect2s &pos) const {
 			return true;
 		break;
 	case CONTOUR_POLYGON: {
-		Vect2s p = pos;
-		int intersections_lt0 = 0;
-		int intersections_gt0 = 0;
-		int intersections_lt1 = 0;
-		int intersections_gt1 = 0;
-		for (uint i = 0; i < _contour.size(); i ++) {
-			Vect2s p0 = _contour[i];
-			Vect2s p1 = (i < _contour.size() - 1) ? _contour[i + 1] : _contour[0];
-			if (p0.y != p1.y) {
-				if ((p0.y < p.y && p1.y >= p.y) || (p0.y >= p.y && p1.y < p.y)) {
-					if (p0.x < p.x && p1.x < p.x)
-						intersections_lt0++;
-					else if (p0.x > p.x && p1.x > p.x)
-						intersections_gt0++;
-					else {
-						int x = (p.y - p0.y) * (p1.x - p0.x) / (p1.y - p0.y) + p0.x;
-
-						if (x == p.x)
-							return true;
-						else if (x > p.x)
-							intersections_gt0++;
-						else
+		if (g_engine->_gameVersion > 20050101) {
+			Vect2s p = pos;
+			int intersections_lt0 = 0;
+			int intersections_gt0 = 0;
+			int intersections_lt1 = 0;
+			int intersections_gt1 = 0;
+			for (uint i = 0; i < _contour.size(); i ++) {
+				Vect2s p0 = _contour[i];
+				Vect2s p1 = (i < _contour.size() - 1) ? _contour[i + 1] : _contour[0];
+				if (p0.y != p1.y) {
+					if ((p0.y < p.y && p1.y >= p.y) || (p0.y >= p.y && p1.y < p.y)) {
+						if (p0.x < p.x && p1.x < p.x)
 							intersections_lt0++;
-					}
-				}
-				if ((p0.y <= p.y && p1.y > p.y) || (p0.y > p.y && p1.y <= p.y)) {
-					if (p0.x < p.x && p1.x < p.x)
-						intersections_lt1++;
-					else if (p0.x > p.x && p1.x > p.x)
-						intersections_gt1++;
-					else {
-						int x = (p.y - p0.y) * (p1.x - p0.x) / (p1.y - p0.y) + p0.x;
+						else if (p0.x > p.x && p1.x > p.x)
+							intersections_gt0++;
+						else {
+							int x = (p.y - p0.y) * (p1.x - p0.x) / (p1.y - p0.y) + p0.x;
 
-						if (x == p.x)
-							return true;
-						else if (x > p.x)
-							intersections_gt1++;
-						else
+							if (x == p.x)
+								return true;
+							else if (x > p.x)
+								intersections_gt0++;
+							else
+								intersections_lt0++;
+						}
+					}
+					if ((p0.y <= p.y && p1.y > p.y) || (p0.y > p.y && p1.y <= p.y)) {
+						if (p0.x < p.x && p1.x < p.x)
 							intersections_lt1++;
+						else if (p0.x > p.x && p1.x > p.x)
+							intersections_gt1++;
+						else {
+							int x = (p.y - p0.y) * (p1.x - p0.x) / (p1.y - p0.y) + p0.x;
+
+							if (x == p.x)
+								return true;
+							else if (x > p.x)
+								intersections_gt1++;
+							else
+								intersections_lt1++;
+						}
 					}
 				}
 			}
-		}
 
-		return ((intersections_lt0 & 1) && intersections_gt0 != 0) ||
-		       ((intersections_lt1 & 1) && intersections_gt1 != 0);
+			return ((intersections_lt0 & 1) && intersections_gt0 != 0) ||
+				   ((intersections_lt1 & 1) && intersections_gt1 != 0);
+		} else {
+			Vect2s p = pos - _mask_pos;
+			p.x += _size.x / 2;
+			p.y += _size.y / 2;
+			if (p.x >= 0 && p.x < _size.x && p.y >= 0 && p.y < _size.y) {
+				if (_mask[p.x + p.y * _size.x])
+					return true;
+			}
+		}
 		break;
 	}
 }

--- a/engines/qdengine/qdcore/qd_contour.h
+++ b/engines/qdengine/qdcore/qd_contour.h
@@ -111,6 +111,12 @@ public:
 		return _contour[pos];
 	}
 
+	void createMaskOld(int x0, int y0, int x1, int y1);
+
+	const byte *maskData() const {
+		return &*_mask.begin();
+	}
+
 	//! Возвращает размеры маски.
 	const Vect2s &mask_size() const {
 		return _size;
@@ -152,6 +158,8 @@ private:
 	Vect2s _size;
 
 	Vect2s _mask_pos;
+
+	Std::vector<byte> _mask;
 
 	//! Контур.
 	/**

--- a/engines/qdengine/qdcore/qd_game_dispatcher.cpp
+++ b/engines/qdengine/qdcore/qd_game_dispatcher.cpp
@@ -2392,7 +2392,7 @@ bool qdGameDispatcher::keyboard_handler(Common::KeyCode vkey, bool event) {
 	}
 
 	if (event) {
-		if (_interface_dispatcher.keyboard_handler(vkey))
+		if (g_engine->_gameVersion > 20060715 && _interface_dispatcher.keyboard_handler(vkey))
 			return true;
 
 		switch (vkey) {

--- a/engines/qdengine/qdcore/qd_game_dispatcher.cpp
+++ b/engines/qdengine/qdcore/qd_game_dispatcher.cpp
@@ -2049,7 +2049,8 @@ bool qdGameDispatcher::toggle_inventory(bool state) {
 		}
 	}
 
-	_cur_inventory = NULL;
+	if (g_engine->_gameVersion > 20031206 || !state)
+		_cur_inventory = NULL;
 	update_ingame_interface();
 	return true;
 }

--- a/engines/qdengine/qdcore/qd_game_object_moving.cpp
+++ b/engines/qdengine/qdcore/qd_game_object_moving.cpp
@@ -79,7 +79,7 @@ qdGameObjectMoving::qdGameObjectMoving() :
 	_is_selected = false;
 	set_flag(QD_OBJ_HAS_BOUND_FLAG);
 
-	if (g_engine->_gameVersion <= 20030919)
+	if (g_engine->_gameVersion <= 20060129)
 		_movement_mode = MOVEMENT_MODE_NONE_EARLY;
 	else
 		_movement_mode = MOVEMENT_MODE_STOP;
@@ -121,7 +121,7 @@ qdGameObjectMoving::qdGameObjectMoving(const qdGameObjectMoving &obj) : qdGameOb
 	_is_selected = false;
 	set_flag(QD_OBJ_HAS_BOUND_FLAG);
 
-	if (g_engine->_gameVersion <= 20030919)
+	if (g_engine->_gameVersion <= 20060129)
 		_movement_mode = MOVEMENT_MODE_NONE_EARLY;
 	else
 		_movement_mode = MOVEMENT_MODE_STOP;
@@ -532,7 +532,7 @@ bool qdGameObjectMoving::stop_movement() {
 		if (cur_state() == -1) return true;
 
 		qdGameObjectState *st = get_state(cur_state());
-		if (g_engine->_gameVersion <= 20030919) {
+		if (g_engine->_gameVersion <= 20060129) {
 			if (st->state_type() == qdGameObjectState::STATE_WALK) {
 				set_animation_info(static_cast<qdGameObjectStateWalk *>(st)->static_animation_info(_direction_angle));
 				st->stop_sound();
@@ -734,7 +734,7 @@ Vect3f qdGameObjectMoving::get_future_r(float dt, bool &end_movement, bool real_
 			}
 		}
 		return R();
-	case MOVEMENT_MODE_NONE_EARLY: // _gameVersion <= 20030919
+	case MOVEMENT_MODE_NONE_EARLY: // _gameVersion <= 20060129
 	default:
 		break;
 	}
@@ -877,7 +877,7 @@ void qdGameObjectMoving::quant(float dt) {
 		start_auto_move();
 
 	if (check_flag(QD_OBJ_MOVING_FLAG)) {
-		if (g_engine->_gameVersion <= 20030919 || future_pos_correct(dt)) {
+		if (g_engine->_gameVersion <= 20041201 || future_pos_correct(dt)) {
 			bool end_movement = false;
 			Vect3f r = get_future_r(dt, end_movement, true);
 
@@ -895,7 +895,7 @@ void qdGameObjectMoving::quant(float dt) {
 					if (_target_angle >= 0.0f)
 						_direction_angle = _target_angle;
 
-					if (g_engine->_gameVersion <= 20030919) {
+					if (g_engine->_gameVersion <= 20060129) {
 						drop_flag(QD_OBJ_MOVING_FLAG);
 						set_direction(_direction_angle);
 
@@ -1082,7 +1082,7 @@ bool qdGameObjectMoving::update_screen_pos() {
 				case MOVEMENT_MODE_END:
 					offs_type = qdGameObjectStateWalk::OFFSET_END;
 					break;
-				case MOVEMENT_MODE_NONE_EARLY: // _gameVersion <= 20030919
+				case MOVEMENT_MODE_NONE_EARLY: // _gameVersion <= 20060129
 					if (!check_flag(QD_OBJ_MOVING_FLAG))
 						offs_type = qdGameObjectStateWalk::OFFSET_STATIC;
 				}
@@ -2042,7 +2042,7 @@ bool qdGameObjectMoving::set_walk_animation() {
 				}
 			}
 			break;
-		case MOVEMENT_MODE_NONE_EARLY: // _gameVersion <= 20030919
+		case MOVEMENT_MODE_NONE_EARLY: // _gameVersion <= 20060129
 		default:
 			break;
 		}
@@ -2089,7 +2089,7 @@ bool qdGameObjectMoving::movement_impulse() {
 	_impulse_direction = -1.0f;
 	_target_angle = -1.0f;
 
-	if (g_engine->_gameVersion <= 20030919)
+	if (g_engine->_gameVersion <= 20060129)
 		set_walk_animation();
 
 	if (_movement_mode == MOVEMENT_MODE_STOP || _movement_mode == MOVEMENT_MODE_END)

--- a/engines/qdengine/qdcore/qd_game_object_moving.cpp
+++ b/engines/qdengine/qdcore/qd_game_object_moving.cpp
@@ -493,7 +493,7 @@ bool qdGameObjectMoving::find_path(const Vect3f target, bool lock_target) {
 	debugC(3, kDebugLog, "Optimised Path");
 	dump_vect(path_vect);
 
-	if (path_vect.size() >= 2 && (movement_type() == qdGameObjectStateWalk::MOVEMENT_FOUR_DIRS || movement_type() == qdGameObjectStateWalk::MOVEMENT_EIGHT_DIRS)) {
+	if (g_engine->_gameVersion > 20041201 && path_vect.size() >= 2 && (movement_type() == qdGameObjectStateWalk::MOVEMENT_FOUR_DIRS || movement_type() == qdGameObjectStateWalk::MOVEMENT_EIGHT_DIRS)) {
 		Std::vector<Vect3f> final_path;
 		finalize_path(R(), trg, path_vect, final_path);
 
@@ -510,10 +510,13 @@ bool qdGameObjectMoving::find_path(const Vect3f target, bool lock_target) {
 			_path[idx] = qdCamera::current_camera()->get_cell_coords(it->x, it->y);
 			idx ++;
 		}
-		_path[idx - 1] = trg;
+		if (g_engine->_gameVersion <= 20041201)
+			_path[idx] = trg;
+		else
+			_path[idx - 1] = trg;
 	}
 
-	_cur_path_index = (idx > 1) ? 1 : 0;
+	_cur_path_index = (g_engine->_gameVersion <= 20041201 || idx > 1) ? 1 : 0;
 	_path_length = idx;
 	move2position(_path[_cur_path_index++]);
 

--- a/engines/qdengine/qdcore/qd_grid_zone.cpp
+++ b/engines/qdengine/qdcore/qd_grid_zone.cpp
@@ -192,14 +192,13 @@ bool qdGridZone::apply_zone() const {
 	pos.x -= mask_size().x / 2;
 	pos.y -= mask_size().y / 2;
 
-//	const byte* mask_ptr = mask_data();
+	const byte* mask_ptr = maskData();
 
 	if (_state) {
 		for (int y = 0; y < mask_size().y; y++) {
 			for (int x = 0; x < mask_size().x; x++) {
-				if (is_inside(pos + Vect2s(x, y))) {
-//				if(*mask_ptr++){
-					if (sGridCell * p = camera->get_cell(pos + Vect2s(x, y))) {
+				if ((g_engine->_gameVersion <= 20050101 && *mask_ptr++) || is_inside(pos + Vect2s(x, y))) {
+					if (sGridCell *p = camera->get_cell(pos + Vect2s(x, y))) {
 						p->make_walkable();
 						p->set_height(_height);
 					}
@@ -209,8 +208,7 @@ bool qdGridZone::apply_zone() const {
 	} else {
 		for (int y = 0; y < mask_size().y; y++) {
 			for (int x = 0; x < mask_size().x; x++) {
-				if (is_inside(pos + Vect2s(x, y))) {
-//				if(*mask_ptr++){
+				if ((g_engine->_gameVersion <= 20050101 && *mask_ptr++) || is_inside(pos + Vect2s(x, y))) {
 					if (sGridCell * p = camera->get_cell(pos + Vect2s(x, y))) {
 						p->make_impassable();
 						p->set_height(0);
@@ -248,14 +246,13 @@ bool qdGridZone::select(qdCamera *camera, bool bSelect) const {
 	pos.x -= mask_size().x / 2;
 	pos.y -= mask_size().y / 2;
 
-//	const byte* mask_ptr = mask_data();
+	const byte* mask_ptr = maskData();
 
 	if (bSelect) {
 		for (int y = 0; y < mask_size().y; y++) {
 			for (int x = 0; x < mask_size().x; x++) {
-				if (is_inside(pos + Vect2s(x, y))) {
-//				if(*mask_ptr++){
-					if (sGridCell * p = camera->get_cell(pos + Vect2s(x, y)))
+				if ((g_engine->_gameVersion <= 20050101 && *mask_ptr++) || is_inside(pos + Vect2s(x, y))) {
+					if (sGridCell *p = camera->get_cell(pos + Vect2s(x, y)))
 						p->select();
 				}
 			}
@@ -263,8 +260,7 @@ bool qdGridZone::select(qdCamera *camera, bool bSelect) const {
 	} else {
 		for (int y = 0; y < mask_size().y; y++) {
 			for (int x = 0; x < mask_size().x; x++) {
-				if (is_inside(pos + Vect2s(x, y))) {
-//				if(*mask_ptr++){
+				if ((g_engine->_gameVersion <= 20050101 && *mask_ptr++) || is_inside(pos + Vect2s(x, y))) {
 					if (sGridCell * p = camera->get_cell(pos + Vect2s(x, y)))
 						p->deselect();
 				}


### PR DESCRIPTION
- Fix inventory being empty in one scene in karliknos
- Fix zigzag pattern in generated paths for pilots3
- Fix impassable grid issue by bringing back the old mask-based implementation
- Fix inventory being drawn when switching to main menu