### PR TITLE
fixed the GUI filter when the game is removed

### DIFF
--- a/gui/game_list.cpp
+++ b/gui/game_list.cpp
@@ -1,17 +1,19 @@
-#include <algorithm>
-#include <cctype> // For tolower()
-#include <string>
-#include <vector>
+#include "common/algorithm.h"
+#include "common/array.h"
+#include "common/str.h"
 
-using String = std::string;
+using String = Common::String;
+using string = Common::String;
 
 class GameListWidget {
 public:
 	void removeGame(const String &gameId);
 	void applyFilter(const String &filter);
 
-private:
+	std::vector<String> _gameList;
+	std::vector<String> _filteredGameList;
 	Common::Array<String> _gameList;
+	Common::Array<String> _filteredGameList;
 	Common::Array<String> _filteredGameList;
 	String _currentFilter;
 	String _selectedGameId; // To track currently selected game
@@ -24,7 +26,8 @@ private:
 };
 
 // Finds the index of a game in the filtered list, or -1 if not found
-int GameListWidget::findFilteredGameIndex(const String &gameId) const {
+auto it = std::find(_filteredGameList.begin(), _filteredGameList.end(), gameId);
+{
 	auto it = Common::find(_filteredGameList.begin(), _filteredGameList.end(), gameId);
 	if (it != _filteredGameList.end()) {
 		return static_cast<int>(std::distance(_filteredGameList.begin(), it));
@@ -73,10 +76,9 @@ void GameListWidget::refreshGameList() {
 }
 
 // Existing implementations...
-
-void GameListWidget::removeGame(const String &gameId) {
-	int removedIndex = findFilteredGameIndex(gameId);
-	_gameList.erase(std::remove(_gameList.begin(), _gameList.end(), gameId), _gameList.end());
+{
+	int newIndex = std::min(removedIndex, static_cast<int>(_filteredGameList.size()) - 1);
+	int newIndex = MIN(removedIndex, static_cast<int>(_filteredGameList.size()) - 1);
 	applyFilter(_currentFilter);
 
 	if (!_filteredGameList.empty()) {

--- a/gui/game_list.cpp
+++ b/gui/game_list.cpp
@@ -11,8 +11,8 @@ public:
 	void applyFilter(const String &filter);
 
 private:
-	std::vector<String> _gameList;
-	std::vector<String> _filteredGameList;
+	Common::Array<String> _gameList;
+	Common::Array<String> _filteredGameList;
 	String _currentFilter;
 	String _selectedGameId; // To track currently selected game
 

--- a/gui/game_list.cpp
+++ b/gui/game_list.cpp
@@ -80,7 +80,7 @@ void GameListWidget::removeGame(const String &gameId) {
 	applyFilter(_currentFilter);
 
 	if (!_filteredGameList.empty()) {
-		int newIndex = std::min(removedIndex, static_cast<int>(_filteredGameList.size()) - 1);
+		int newIndex = MIN(removedIndex, static_cast<int>(_filteredGameList.size()) - 1);
 		setSelectedGame(_filteredGameList[newIndex]);
 	} else {
 		clearSelection();

--- a/gui/game_list.cpp
+++ b/gui/game_list.cpp
@@ -1,6 +1,7 @@
-#include "common/algorithm.h"
-#include "common/array.h"
-#include "common/str.h"
+#include Common::Algorithm.h
+#include Common::String.toLowercase()
+#include Common::Array.h
+#include Common::String.h
 
 using String = Common::String;
 using string = Common::String;

--- a/gui/game_list.cpp
+++ b/gui/game_list.cpp
@@ -25,7 +25,7 @@ private:
 
 // Finds the index of a game in the filtered list, or -1 if not found
 int GameListWidget::findFilteredGameIndex(const String &gameId) const {
-	auto it = std::find(_filteredGameList.begin(), _filteredGameList.end(), gameId);
+	auto it = Common::find(_filteredGameList.begin(), _filteredGameList.end(), gameId);
 	if (it != _filteredGameList.end()) {
 		return static_cast<int>(std::distance(_filteredGameList.begin(), it));
 	}

--- a/gui/game_list.cpp
+++ b/gui/game_list.cpp
@@ -1,0 +1,100 @@
+#include <algorithm>
+#include <cctype> // For tolower()
+#include <string>
+#include <vector>
+
+using String = std::string;
+
+class GameListWidget {
+public:
+	void removeGame(const String &gameId);
+	void applyFilter(const String &filter);
+
+private:
+	std::vector<String> _gameList;
+	std::vector<String> _filteredGameList;
+	String _currentFilter;
+	String _selectedGameId; // To track currently selected game
+
+	int findFilteredGameIndex(const String &gameId) const;
+	bool gameMatchesFilter(const String &game, const String &filter) const;
+	void setSelectedGame(const String &gameId);
+	void clearSelection();
+	void refreshGameList();
+};
+
+// Finds the index of a game in the filtered list, or -1 if not found
+int GameListWidget::findFilteredGameIndex(const String &gameId) const {
+	auto it = std::find(_filteredGameList.begin(), _filteredGameList.end(), gameId);
+	if (it != _filteredGameList.end()) {
+		return static_cast<int>(std::distance(_filteredGameList.begin(), it));
+	}
+	return -1;
+}
+
+// Case-insensitive check if game matches filter
+bool GameListWidget::gameMatchesFilter(const String &game, const String &filter) const {
+	if (filter.empty())
+		return true;
+
+	auto containsCaseInsensitive = [](const String &str, const String &sub) {
+		auto it = std::search(
+			str.begin(), str.end(),
+			sub.begin(), sub.end(),
+			[](char ch1, char ch2) {
+				return std::tolower(ch1) == std::tolower(ch2);
+			});
+		return it != str.end();
+	};
+
+	return containsCaseInsensitive(game, filter);
+}
+
+// Sets the currently selected game
+void GameListWidget::setSelectedGame(const String &gameId) {
+	_selectedGameId = gameId;
+	// In a real implementation, you would also update the UI here
+}
+
+// Clears the current selection
+void GameListWidget::clearSelection() {
+	_selectedGameId.clear();
+	// In a real implementation, you would also update the UI here
+}
+
+// Refreshes the game list display
+void GameListWidget::refreshGameList() {
+	// In a real implementation, this would update the UI widget
+	// to reflect the current state of _filteredGameList
+	// This might involve:
+	// 1. Clearing the current display
+	// 2. Repopulating with items from _filteredGameList
+	// 3. Restoring selection if needed
+}
+
+// Existing implementations...
+
+void GameListWidget::removeGame(const String &gameId) {
+	int removedIndex = findFilteredGameIndex(gameId);
+	_gameList.erase(std::remove(_gameList.begin(), _gameList.end(), gameId), _gameList.end());
+	applyFilter(_currentFilter);
+
+	if (!_filteredGameList.empty()) {
+		int newIndex = std::min(removedIndex, static_cast<int>(_filteredGameList.size()) - 1);
+		setSelectedGame(_filteredGameList[newIndex]);
+	} else {
+		clearSelection();
+	}
+	refreshGameList();
+}
+
+void GameListWidget::applyFilter(const String &filter) {
+	_currentFilter = filter;
+	_filteredGameList.clear();
+
+	for (const auto &game : _gameList) {
+		if (gameMatchesFilter(game, filter)) {
+			_filteredGameList.push_back(game);
+		}
+	}
+}

--- a/gui/game_list.h
+++ b/gui/game_list.h
@@ -1,0 +1,27 @@
+// ...existing code...
+
+#include <string>
+#include <vector>
+
+// Assuming Game is a class or struct defined elsewhere
+class Game {
+	// Placeholder definition for Game
+public:
+	std::string id;
+};
+
+class GameListWidget {
+	// ...existing code...
+
+private:
+	std::string _currentFilter;          // Stores the current filter
+	std::vector<Game> _filteredGameList; // Stores the filtered list of games
+
+	void applyFilter(const std::string &filter);
+	int findFilteredGameIndex(const std::string &gameId);
+	void setSelectedGame(const Game &game);
+	void clearSelection();
+	void refreshGameList();
+
+	// ...existing code...
+};


### PR DESCRIPTION
Some of the main key changes made:-
findFilteredGameIndex:
Used std::find to locate the game in _filteredGameList
Returns the index or -1 if not found
Made constant as it doesn't modify the object

gameMatchesFilter:
Implements case-insensitive substring matching.
Returns true if filter is empty (show all games)
Used std::search with a custom comparator for case-insensitive comparison.

setSelectedGame:
Stores the selected game ID
In a real UI framework, this would also update the visual selection.

clearSelection:
Clears the stored selection
Would update UI in a real implementation

refreshGameList:
Placeholder for UI update logic
In practice, this would redraw the list widget with the current filtered items

Additional improvements:
Added _selectedGameId member to track selection state
Made helper functions const where necessary to it
Improved the case-insensitive matching in gameMatchesFilter
Consistent code style throughout.