### PR TITLE
CHAMBER: HGA Text Rendering Fixes

### DIFF
--- a/engines/chamber/script.cpp
+++ b/engines/chamber/script.cpp
@@ -874,6 +874,13 @@ uint16 SCR_D_DrawPortraitDotEffect(void) {
 	cur_image_end = width * height;
 	int16 count = 0;
 
+	if (g_vm->_videoMode == Common::RenderMode::kRenderHercG) {
+		const int START_X = (HGA_WIDTH / 8 - (2 * CGA_WIDTH) / 8) / 2;
+		const int START_Y = (HGA_HEIGHT - CGA_HEIGHT) / 2;
+		x += START_X;
+		y += START_Y;
+	}
+
 	for (offs = 0; offs != cur_image_end;) {
 		target[CalcXY_p(x + offs % cur_image_size_w, y + offs / cur_image_size_w)] = cur_image_pixels[offs]; // TODO check this
 

--- a/engines/chamber/script.cpp
+++ b/engines/chamber/script.cpp
@@ -885,7 +885,7 @@ uint16 SCR_D_DrawPortraitDotEffect(void) {
 		target[CalcXY_p(x + offs % cur_image_size_w, y + offs / cur_image_size_w)] = cur_image_pixels[offs]; // TODO check this
 
 		if (count % 5 == 0)
-			cga_blitToScreen(offs, 4, 1);
+			cga_blitToScreen(offs, g_vm->_screenPPB, 1);
 
 		offs += step;
 		if (offs > cur_image_end)


### PR DESCRIPTION
The PR includes following changes

- Adjust portrait rendering position for HGA mode.
- Add HGA support to ```cga_PrintChar()```.
- Fix crash in ```cga_blitToScreen()``` due to division by zero. A hard-coded value of 4 was being passed in ```SCR_D_DrawPortraitDotEffect()```.
