### PR TITLE
GRAPHICS: Add palette constructor for ownership of data

### DIFF
--- a/engines/mm/mm1/gfx/gfx.cpp
+++ b/engines/mm/mm1/gfx/gfx.cpp
@@ -33,7 +33,7 @@ namespace Gfx {
 byte EGA_INDEXES[EGA_PALETTE_COUNT];
 
 void GFX::setEgaPalette() {
-	Graphics::Palette ega = Graphics::Palette::createEGAPalette();
+	const Graphics::Palette ega = Graphics::Palette::createEGAPalette();
 	g_system->getPaletteManager()->setPalette(ega);
 
 	uint32 c = 0xffffffff;
@@ -45,7 +45,7 @@ void GFX::setEgaPalette() {
 }
 
 void GFX::findPalette(const byte palette[256 * 3]) {
-	Graphics::Palette ega = Graphics::Palette::createEGAPalette();
+	const Graphics::Palette ega = Graphics::Palette::createEGAPalette();
 	const byte *data = ega.data();
 
 	for (int col = 0; col < 16; ++col) {

--- a/graphics/palette.h
+++ b/graphics/palette.h
@@ -23,6 +23,7 @@
 #define GRAPHICS_PALETTE_H
 
 #include "common/hashmap.h"
+#include "common/types.h"
 
 namespace Graphics {
 
@@ -51,6 +52,7 @@ constexpr int PALETTE_SIZE = (256 * 3);
 class Palette {
 	byte *_data;
 	uint16 _size;
+	DisposeAfterUse::Flag _disposeAfterUse;
 
 public:
 	static const uint16 npos = 0xFFFF;
@@ -63,12 +65,21 @@ public:
 	Palette(uint size);
 
 	/**
-	 * @brief Construct a new Palette object
+	 * @brief Construct a new Palette object with a copy of the palette data
 	 *
 	 * @param data   the palette data, in interleaved RGB format
 	 * @param size   the number of palette entries
 	 */
 	Palette(const byte *data, uint size);
+
+	/**
+	 * @brief Construct a new Palette object taking ownership of the palette data
+	 *
+	 * @param data   the palette data, in interleaved RGB format
+	 * @param size   the number of palette entries
+	 * @param disposeAfterUse    a flag indicating whether to dispose of the palette data
+	 */
+	Palette(byte *data, uint size, DisposeAfterUse::Flag disposeAfterUse);
 
 	Palette(const Palette &p);
 
@@ -77,7 +88,7 @@ public:
 	/**
 	 * Constructs a new palette containing the standarad EGA palette
 	 */
-	static Palette createEGAPalette();
+	static const Palette createEGAPalette();
 
 	Palette &operator=(const Palette &rhs);
 	bool operator==(const Palette &rhs) const { return equals(rhs); }


### PR DESCRIPTION
One roadblock to expanded use of the palette class is my desire to not make extra memory copies the static palette data used in a number of classes. This new constructor with the use of DisposeAfterUse::NO and a const qualifier could be an answer to that problem.

Does this seem like a good path forward or are there alternate ideas?
Is this a silly concern and a small memory copy not a big enough deal to warrant a change?