### PR TITLE
DRASCULA: Add text-to-speech (TTS)

### DIFF
--- a/engines/drascula/animation.cpp
+++ b/engines/drascula/animation.cpp
@@ -21,7 +21,6 @@
 
 #include "drascula/drascula.h"
 
-#include "common/config-manager.h"
 #include "common/text-to-speech.h"
 
 namespace Drascula {
@@ -46,7 +45,6 @@ void DrasculaEngine::updateAnim(int y, int destX, int destY, int width, int heig
 
 void DrasculaEngine::animation_1_1() {
 	debug(4, "animation_1_1()");
-	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 
 	while (term_int == 0 && !shouldQuit()) {
 		playMusic(29);
@@ -80,9 +78,7 @@ void DrasculaEngine::animation_1_1() {
 		color_abc(kColorRed);
 		centerText(_textmisc[1], 160, 100);
 
-		if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
-			ttsMan->say(_textmisc[1], _ttsTextEncoding);
-		}
+		sayText(_textmisc[1], Common::TextToSpeechManager::INTERRUPT);
 
 		updateScreen();
 		if ((term_int == 1) || (getScan() == Common::KEYCODE_ESCAPE) || shouldQuit())
@@ -768,8 +764,6 @@ void DrasculaEngine::animation_16_2() {
 
 	color_abc(kColorDarkGreen);
 
-	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
-
 	for (int i = 1; i <= 4; i++) {
 		if (i < 4)
 			Common::sprintf_s(curPic, "his%i.alg", i);
@@ -778,9 +772,7 @@ void DrasculaEngine::animation_16_2() {
 
 		loadPic(curPic, screenSurface, HALF_PAL);
 
-		if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
-			ttsMan->say(_texthis[i], Common::TextToSpeechManager::QUEUE, _ttsTextEncoding);
-		}
+		sayText(_texthis[i], Common::TextToSpeechManager::QUEUE);
 
 		centerText(_texthis[i], 180, 180);
 		updateScreen();

--- a/engines/drascula/animation.cpp
+++ b/engines/drascula/animation.cpp
@@ -81,7 +81,7 @@ void DrasculaEngine::animation_1_1() {
 		centerText(_textmisc[1], 160, 100);
 
 		if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
-			ttsMan->say(_textmisc[1]);
+			ttsMan->say(_textmisc[1], _ttsTextEncoding);
 		}
 
 		updateScreen();
@@ -779,7 +779,7 @@ void DrasculaEngine::animation_16_2() {
 		loadPic(curPic, screenSurface, HALF_PAL);
 
 		if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
-			ttsMan->say(_texthis[i], Common::TextToSpeechManager::QUEUE);
+			ttsMan->say(_texthis[i], Common::TextToSpeechManager::QUEUE, _ttsTextEncoding);
 		}
 
 		centerText(_texthis[i], 180, 180);

--- a/engines/drascula/animation.cpp
+++ b/engines/drascula/animation.cpp
@@ -21,6 +21,9 @@
 
 #include "drascula/drascula.h"
 
+#include "common/config-manager.h"
+#include "common/text-to-speech.h"
+
 namespace Drascula {
 
 void DrasculaEngine::updateAnim(int y, int destX, int destY, int width, int height, int count, byte* src, int delayVal, bool copyRectangle) {
@@ -43,6 +46,7 @@ void DrasculaEngine::updateAnim(int y, int destX, int destY, int width, int heig
 
 void DrasculaEngine::animation_1_1() {
 	debug(4, "animation_1_1()");
+	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 
 	while (term_int == 0 && !shouldQuit()) {
 		playMusic(29);
@@ -75,6 +79,11 @@ void DrasculaEngine::animation_1_1() {
 			break;
 		color_abc(kColorRed);
 		centerText(_textmisc[1], 160, 100);
+
+		if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
+			ttsMan->say(_textmisc[1]);
+		}
+
 		updateScreen();
 		if ((term_int == 1) || (getScan() == Common::KEYCODE_ESCAPE) || shouldQuit())
 			break;
@@ -759,6 +768,8 @@ void DrasculaEngine::animation_16_2() {
 
 	color_abc(kColorDarkGreen);
 
+	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+
 	for (int i = 1; i <= 4; i++) {
 		if (i < 4)
 			Common::sprintf_s(curPic, "his%i.alg", i);
@@ -766,6 +777,11 @@ void DrasculaEngine::animation_16_2() {
 			Common::strcpy_s(curPic, "his4_2.alg");
 
 		loadPic(curPic, screenSurface, HALF_PAL);
+
+		if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
+			ttsMan->say(_texthis[i], Common::TextToSpeechManager::QUEUE);
+		}
+
 		centerText(_texthis[i], 180, 180);
 		updateScreen();
 

--- a/engines/drascula/converse.cpp
+++ b/engines/drascula/converse.cpp
@@ -23,7 +23,6 @@
 
 #include "drascula/drascula.h"
 
-#include "common/config-manager.h"
 #include "common/text-to-speech.h"
 
 namespace Drascula {
@@ -210,13 +209,10 @@ void DrasculaEngine::converse(int index) {
 		ttsPhrase4.replace('%', ' ');
 	}
 
-	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
-	if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
-		ttsMan->say(ttsPhrase1, Common::TextToSpeechManager::QUEUE, _ttsTextEncoding);
-		ttsMan->say(ttsPhrase2, Common::TextToSpeechManager::QUEUE, _ttsTextEncoding);
-		ttsMan->say(ttsPhrase3, Common::TextToSpeechManager::QUEUE, _ttsTextEncoding);
-		ttsMan->say(ttsPhrase4, Common::TextToSpeechManager::QUEUE, _ttsTextEncoding);
-	}
+	sayText(ttsPhrase1, Common::TextToSpeechManager::QUEUE);
+	sayText(ttsPhrase2, Common::TextToSpeechManager::QUEUE);
+	sayText(ttsPhrase3, Common::TextToSpeechManager::QUEUE);
+	sayText(ttsPhrase4, Common::TextToSpeechManager::QUEUE);
 
 	while (breakOut == 0 && !shouldQuit()) {
 		updateRoom();
@@ -246,10 +242,7 @@ void DrasculaEngine::converse(int index) {
 
 			print_abc_opc(phrase1, 2, kDialogOptionSelected);
 
-			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && ttsPhrase1 != _previousSaid) {
-				_previousSaid = ttsPhrase1;
-				ttsMan->say(ttsPhrase1, _ttsTextEncoding);
-			}
+			sayText(ttsPhrase1, Common::TextToSpeechManager::INTERRUPT);
 
 			if (_leftMouseButton == 1) {
 				delay(100);
@@ -265,10 +258,7 @@ void DrasculaEngine::converse(int index) {
 
 			print_abc_opc(phrase2, phrase1_bottom + 2, kDialogOptionSelected);
 
-			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && ttsPhrase2 != _previousSaid) {
-				_previousSaid = ttsPhrase2;
-				ttsMan->say(ttsPhrase2, _ttsTextEncoding);
-			}
+			sayText(ttsPhrase2, Common::TextToSpeechManager::INTERRUPT);
 
 			if (_leftMouseButton == 1) {
 				delay(100);
@@ -284,10 +274,7 @@ void DrasculaEngine::converse(int index) {
 
 			print_abc_opc(phrase3, phrase2_bottom + 2, kDialogOptionSelected);
 
-			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && ttsPhrase3 != _previousSaid) {
-				_previousSaid = ttsPhrase3;
-				ttsMan->say(ttsPhrase3, _ttsTextEncoding);
-			}
+			sayText(ttsPhrase3, Common::TextToSpeechManager::INTERRUPT);
 
 			if (_leftMouseButton == 1) {
 				delay(100);
@@ -298,10 +285,7 @@ void DrasculaEngine::converse(int index) {
 		} else if (_mouseY > phrase3_bottom && _mouseY < phrase4_bottom) {
 			print_abc_opc(phrase4, phrase3_bottom + 2, kDialogOptionSelected);
 
-			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && ttsPhrase4 != _previousSaid) {
-				_previousSaid = ttsPhrase4;
-				ttsMan->say(ttsPhrase4, _ttsTextEncoding);
-			}
+			sayText(ttsPhrase4, Common::TextToSpeechManager::INTERRUPT);
 
 			if (_leftMouseButton == 1) {
 				delay(100);

--- a/engines/drascula/converse.cpp
+++ b/engines/drascula/converse.cpp
@@ -23,6 +23,9 @@
 
 #include "drascula/drascula.h"
 
+#include "common/config-manager.h"
+#include "common/text-to-speech.h"
+
 namespace Drascula {
 
 void DrasculaEngine::playTalkSequence(int sequence) {
@@ -195,6 +198,14 @@ void DrasculaEngine::converse(int index) {
 	// from 1(top) to 31
 	color_abc(kColorLightGreen);
 
+	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+	if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
+		ttsMan->say(phrase1, Common::TextToSpeechManager::QUEUE);
+		ttsMan->say(phrase2, Common::TextToSpeechManager::QUEUE);
+		ttsMan->say(phrase3, Common::TextToSpeechManager::QUEUE);
+		ttsMan->say(phrase4, Common::TextToSpeechManager::QUEUE);
+	}
+
 	while (breakOut == 0 && !shouldQuit()) {
 		updateRoom();
 
@@ -223,6 +234,11 @@ void DrasculaEngine::converse(int index) {
 
 			print_abc_opc(phrase1, 2, kDialogOptionSelected);
 
+			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && phrase1 != _previousSaid) {
+				_previousSaid = phrase1;
+				ttsMan->say(phrase1);
+			}
+
 			if (_leftMouseButton == 1) {
 				delay(100);
 				game1 = kDialogOptionClicked;
@@ -236,6 +252,11 @@ void DrasculaEngine::converse(int index) {
 				color_abc(kColorLightGreen);
 
 			print_abc_opc(phrase2, phrase1_bottom + 2, kDialogOptionSelected);
+
+			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && phrase2 != _previousSaid) {
+				_previousSaid = phrase2;
+				ttsMan->say(phrase2);
+			}
 
 			if (_leftMouseButton == 1) {
 				delay(100);
@@ -251,6 +272,11 @@ void DrasculaEngine::converse(int index) {
 
 			print_abc_opc(phrase3, phrase2_bottom + 2, kDialogOptionSelected);
 
+			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && phrase3 != _previousSaid) {
+				_previousSaid = phrase3;
+				ttsMan->say(phrase3);
+			}
+
 			if (_leftMouseButton == 1) {
 				delay(100);
 				game3 = kDialogOptionClicked;
@@ -259,6 +285,11 @@ void DrasculaEngine::converse(int index) {
 			}
 		} else if (_mouseY > phrase3_bottom && _mouseY < phrase4_bottom) {
 			print_abc_opc(phrase4, phrase3_bottom + 2, kDialogOptionSelected);
+
+			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && phrase4 != _previousSaid) {
+				_previousSaid = phrase4;
+				ttsMan->say(phrase4);
+			}
 
 			if (_leftMouseButton == 1) {
 				delay(100);

--- a/engines/drascula/converse.cpp
+++ b/engines/drascula/converse.cpp
@@ -198,12 +198,24 @@ void DrasculaEngine::converse(int index) {
 	// from 1(top) to 31
 	color_abc(kColorLightGreen);
 
+	Common::String ttsPhrase1 = phrase1;
+	Common::String ttsPhrase2 = phrase2;
+	Common::String ttsPhrase3 = phrase3;
+	Common::String ttsPhrase4 = phrase4;
+
+	if (_lang == kRussian) {
+		ttsPhrase1.replace('%', ' ');
+		ttsPhrase2.replace('%', ' ');
+		ttsPhrase3.replace('%', ' ');
+		ttsPhrase4.replace('%', ' ');
+	}
+
 	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 	if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
-		ttsMan->say(phrase1, Common::TextToSpeechManager::QUEUE);
-		ttsMan->say(phrase2, Common::TextToSpeechManager::QUEUE);
-		ttsMan->say(phrase3, Common::TextToSpeechManager::QUEUE);
-		ttsMan->say(phrase4, Common::TextToSpeechManager::QUEUE);
+		ttsMan->say(ttsPhrase1, Common::TextToSpeechManager::QUEUE, _ttsTextEncoding);
+		ttsMan->say(ttsPhrase2, Common::TextToSpeechManager::QUEUE, _ttsTextEncoding);
+		ttsMan->say(ttsPhrase3, Common::TextToSpeechManager::QUEUE, _ttsTextEncoding);
+		ttsMan->say(ttsPhrase4, Common::TextToSpeechManager::QUEUE, _ttsTextEncoding);
 	}
 
 	while (breakOut == 0 && !shouldQuit()) {
@@ -234,9 +246,9 @@ void DrasculaEngine::converse(int index) {
 
 			print_abc_opc(phrase1, 2, kDialogOptionSelected);
 
-			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && phrase1 != _previousSaid) {
-				_previousSaid = phrase1;
-				ttsMan->say(phrase1);
+			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && ttsPhrase1 != _previousSaid) {
+				_previousSaid = ttsPhrase1;
+				ttsMan->say(ttsPhrase1, _ttsTextEncoding);
 			}
 
 			if (_leftMouseButton == 1) {
@@ -253,9 +265,9 @@ void DrasculaEngine::converse(int index) {
 
 			print_abc_opc(phrase2, phrase1_bottom + 2, kDialogOptionSelected);
 
-			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && phrase2 != _previousSaid) {
-				_previousSaid = phrase2;
-				ttsMan->say(phrase2);
+			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && ttsPhrase2 != _previousSaid) {
+				_previousSaid = ttsPhrase2;
+				ttsMan->say(ttsPhrase2, _ttsTextEncoding);
 			}
 
 			if (_leftMouseButton == 1) {
@@ -272,9 +284,9 @@ void DrasculaEngine::converse(int index) {
 
 			print_abc_opc(phrase3, phrase2_bottom + 2, kDialogOptionSelected);
 
-			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && phrase3 != _previousSaid) {
-				_previousSaid = phrase3;
-				ttsMan->say(phrase3);
+			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && ttsPhrase3 != _previousSaid) {
+				_previousSaid = ttsPhrase3;
+				ttsMan->say(ttsPhrase3, _ttsTextEncoding);
 			}
 
 			if (_leftMouseButton == 1) {
@@ -286,9 +298,9 @@ void DrasculaEngine::converse(int index) {
 		} else if (_mouseY > phrase3_bottom && _mouseY < phrase4_bottom) {
 			print_abc_opc(phrase4, phrase3_bottom + 2, kDialogOptionSelected);
 
-			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && phrase4 != _previousSaid) {
-				_previousSaid = phrase4;
-				ttsMan->say(phrase4);
+			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && ttsPhrase4 != _previousSaid) {
+				_previousSaid = ttsPhrase4;
+				ttsMan->say(ttsPhrase4, _ttsTextEncoding);
 			}
 
 			if (_leftMouseButton == 1) {
@@ -298,6 +310,8 @@ void DrasculaEngine::converse(int index) {
 			}
 		} else if (_color != kColorLightGreen)
 			color_abc(kColorLightGreen);
+		else
+			_previousSaid.clear();
 
 		_system->delayMillis(10);
 		updateScreen();

--- a/engines/drascula/detection.cpp
+++ b/engines/drascula/detection.cpp
@@ -53,7 +53,7 @@ static const DrasculaGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			GF_PACKED,
-			GUIO1(GUIO_LINKSPEECHTOSFX)
+			GUIO2(GAMEOPTION_TTS, GUIO_LINKSPEECHTOSFX)
 		},
 	},
 
@@ -70,7 +70,7 @@ static const DrasculaGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			GF_PACKED,
-			GUIO1(GUIO_LINKSPEECHTOSFX)
+			GUIO2(GAMEOPTION_TTS, GUIO_LINKSPEECHTOSFX)
 		},
 	},
 
@@ -87,7 +87,7 @@ static const DrasculaGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			GF_PACKED,
-			GUIO1(GUIO_LINKSPEECHTOSFX)
+			GUIO2(GAMEOPTION_TTS, GUIO_LINKSPEECHTOSFX)
 		},
 	},
 
@@ -104,7 +104,7 @@ static const DrasculaGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			GF_PACKED,
-			GUIO1(GUIO_LINKSPEECHTOSFX)
+			GUIO2(GAMEOPTION_TTS, GUIO_LINKSPEECHTOSFX)
 		},
 	},
 
@@ -117,7 +117,7 @@ static const DrasculaGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformDOS,
 			GF_PACKED,
-			GUIO1(GUIO_LINKSPEECHTOSFX)
+			GUIO2(GAMEOPTION_TTS, GUIO_LINKSPEECHTOSFX)
 		},
 	},
 
@@ -134,7 +134,7 @@ static const DrasculaGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformDOS,
 			GF_PACKED,
-			GUIO1(GUIO_LINKSPEECHTOSFX)
+			GUIO2(GAMEOPTION_TTS, GUIO_LINKSPEECHTOSFX)
 		},
 	},
 
@@ -147,7 +147,7 @@ static const DrasculaGameDescription gameDescriptions[] = {
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			GF_PACKED,
-			GUIO1(GUIO_LINKSPEECHTOSFX)
+			GUIO2(GAMEOPTION_TTS, GUIO_LINKSPEECHTOSFX)
 		},
 	},
 
@@ -164,7 +164,7 @@ static const DrasculaGameDescription gameDescriptions[] = {
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			GF_PACKED,
-			GUIO1(GUIO_LINKSPEECHTOSFX)
+			GUIO2(GAMEOPTION_TTS, GUIO_LINKSPEECHTOSFX)
 		},
 	},
 
@@ -181,7 +181,7 @@ static const DrasculaGameDescription gameDescriptions[] = {
 			Common::RU_RUS,
 			Common::kPlatformDOS,
 			GF_PACKED,
-			GUIO1(GUIO_LINKSPEECHTOSFX)
+			GUIO2(GAMEOPTION_TTS, GUIO_LINKSPEECHTOSFX)
 		},
 	},
 
@@ -196,7 +196,7 @@ static const DrasculaGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_LINKSPEECHTOSFX)
+			GUIO2(GAMEOPTION_TTS, GUIO_LINKSPEECHTOSFX)
 		},
 	},
 
@@ -209,7 +209,7 @@ static const DrasculaGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_LINKSPEECHTOSFX)
+			GUIO2(GAMEOPTION_TTS, GUIO_LINKSPEECHTOSFX)
 		},
 	},
 
@@ -222,7 +222,7 @@ static const DrasculaGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_LINKSPEECHTOSFX)
+			GUIO2(GAMEOPTION_TTS, GUIO_LINKSPEECHTOSFX)
 		},
 	},
 
@@ -235,7 +235,7 @@ static const DrasculaGameDescription gameDescriptions[] = {
 			Common::DE_DEU,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_LINKSPEECHTOSFX)
+			GUIO2(GAMEOPTION_TTS, GUIO_LINKSPEECHTOSFX)
 		},
 	},
 
@@ -248,7 +248,7 @@ static const DrasculaGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_LINKSPEECHTOSFX)
+			GUIO2(GAMEOPTION_TTS, GUIO_LINKSPEECHTOSFX)
 		},
 	},
 
@@ -261,7 +261,7 @@ static const DrasculaGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_LINKSPEECHTOSFX)
+			GUIO2(GAMEOPTION_TTS, GUIO_LINKSPEECHTOSFX)
 		},
 	},
 
@@ -274,7 +274,7 @@ static const DrasculaGameDescription gameDescriptions[] = {
 			Common::ES_ESP,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_LINKSPEECHTOSFX)
+			GUIO2(GAMEOPTION_TTS, GUIO_LINKSPEECHTOSFX)
 		},
 	},
 	{
@@ -286,7 +286,7 @@ static const DrasculaGameDescription gameDescriptions[] = {
 			Common::RU_RUS,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_LINKSPEECHTOSFX)
+			GUIO2(GAMEOPTION_TTS, GUIO_LINKSPEECHTOSFX)
 		},
 	},
 

--- a/engines/drascula/detection.h
+++ b/engines/drascula/detection.h
@@ -37,6 +37,7 @@ struct DrasculaGameDescription {
 };
 
 #define GAMEOPTION_ORIGINAL_SAVELOAD      GUIO_GAMEOPTIONS1
+#define GAMEOPTION_TTS                    GUIO_GAMEOPTIONS2
 
 } // End of namespace Drascula
 

--- a/engines/drascula/drascula.cpp
+++ b/engines/drascula/drascula.cpp
@@ -258,7 +258,7 @@ Common::Error DrasculaEngine::run() {
 		if (_lang == kRussian) {
 			_ttsTextEncoding = Common::CodePage::kWindows1251;
 		} else {
-			_ttsTextEncoding = Common::CodePage::kUtf8;
+			_ttsTextEncoding = Common::CodePage::kDos850;
 		}
 	}
 
@@ -702,10 +702,7 @@ bool DrasculaEngine::runCurrentChapter() {
 
 			print_abc(_textsys[2], 96, 86);
 
-			Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
-			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
-				ttsMan->say(_textsys[2], _ttsTextEncoding);
-			}
+			sayText(_textsys[2], Common::TextToSpeechManager::INTERRUPT);
 
 			updateScreen();
 			delay(1410);
@@ -715,10 +712,7 @@ bool DrasculaEngine::runCurrentChapter() {
 
 			print_abc(_textsys[3], 94, 86);
 
-			Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
-			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
-				ttsMan->say(_textsys[3], _ttsTextEncoding);
-			}
+			sayText(_textsys[3], Common::TextToSpeechManager::INTERRUPT);
 
 			updateScreen();
 			delay(1460);
@@ -1166,6 +1160,18 @@ void DrasculaEngine::freeTexts(char **ptr) {
 
 	free(*ptr);
 	free(ptr);
+}
+
+void DrasculaEngine::sayText(const Common::String &text, Common::TextToSpeechManager::Action action) {
+	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+
+	// _previousSaid is used to prevent the TTS from looping when sayText is called inside a loop
+	// (Once the text ends, it will see that there is currently no speech and speak the same text again)
+	// _previousSaid is cleared when appropriate to allow for repeat requests
+	if (ttsMan && ConfMan.getBool("tts_enabled") && _previousSaid != text) {
+		_previousSaid = text;
+		ttsMan->say(text, action, _ttsTextEncoding);
+	}
 }
 
 } // End of namespace Drascula

--- a/engines/drascula/drascula.cpp
+++ b/engines/drascula/drascula.cpp
@@ -1165,8 +1165,9 @@ void DrasculaEngine::freeTexts(char **ptr) {
 void DrasculaEngine::sayText(const Common::String &text, Common::TextToSpeechManager::Action action) {
 	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 
-	// _previousSaid is used to prevent the TTS from looping when sayText is called inside a loop
-	// (Once the text ends, it will see that there is currently no speech and speak the same text again)
+	// _previousSaid is used to prevent the TTS from looping when sayText is called inside a loop,
+	// for example when the cursor stays on a verb icon. Without it when the text ends it would speak
+	// the same text again.
 	// _previousSaid is cleared when appropriate to allow for repeat requests
 	if (ttsMan && ConfMan.getBool("tts_enabled") && _previousSaid != text) {
 		_previousSaid = text;

--- a/engines/drascula/drascula.cpp
+++ b/engines/drascula/drascula.cpp
@@ -254,6 +254,12 @@ Common::Error DrasculaEngine::run() {
 	if (ttsMan != nullptr) {
 		ttsMan->setLanguage(ConfMan.get("language"));
 		ttsMan->enable(ConfMan.getBool("tts_enabled"));
+
+		if (_lang == kRussian) {
+			_ttsTextEncoding = Common::CodePage::kWindows1251;
+		} else {
+			_ttsTextEncoding = Common::CodePage::kUtf8;
+		}
 	}
 
 	setDebugger(new Console(this));
@@ -698,7 +704,7 @@ bool DrasculaEngine::runCurrentChapter() {
 
 			Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
-				ttsMan->say(_textsys[2]);
+				ttsMan->say(_textsys[2], _ttsTextEncoding);
 			}
 
 			updateScreen();
@@ -711,7 +717,7 @@ bool DrasculaEngine::runCurrentChapter() {
 
 			Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
-				ttsMan->say(_textsys[3]);
+				ttsMan->say(_textsys[3], _ttsTextEncoding);
 			}
 
 			updateScreen();

--- a/engines/drascula/drascula.cpp
+++ b/engines/drascula/drascula.cpp
@@ -23,6 +23,7 @@
 #include "common/keyboard.h"
 #include "common/file.h"
 #include "common/config-manager.h"
+#include "common/text-to-speech.h"
 #include "common/textconsole.h"
 #include "common/translation.h"
 
@@ -247,6 +248,12 @@ Common::Error DrasculaEngine::run() {
 	default:
 		warning("Unknown game language. Falling back to English");
 		_lang = kEnglish;
+	}
+
+	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+	if (ttsMan != nullptr) {
+		ttsMan->setLanguage(ConfMan.get("language"));
+		ttsMan->enable(ConfMan.getBool("tts_enabled"));
 	}
 
 	setDebugger(new Console(this));
@@ -688,6 +695,12 @@ bool DrasculaEngine::runCurrentChapter() {
 			ConfMan.setBool("subtitles", !_subtitlesDisabled);
 
 			print_abc(_textsys[2], 96, 86);
+
+			Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
+				ttsMan->say(_textsys[2]);
+			}
+
 			updateScreen();
 			delay(1410);
 		} else if (key == Common::KEYCODE_t) {
@@ -695,6 +708,12 @@ bool DrasculaEngine::runCurrentChapter() {
 			ConfMan.setBool("subtitles", !_subtitlesDisabled);
 
 			print_abc(_textsys[3], 94, 86);
+
+			Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
+				ttsMan->say(_textsys[3]);
+			}
+
 			updateScreen();
 			delay(1460);
 		} else if (key == Common::KEYCODE_ESCAPE) {

--- a/engines/drascula/drascula.h
+++ b/engines/drascula/drascula.h
@@ -776,6 +776,7 @@ private:
 	RoomTalkAction *_roomActions;
 	TalkSequenceCommand *_talkSequences;
 	Common::String _saveNames[10];
+	Common::String _previousSaid;
 
 	char **loadTexts(Common::File &in);
 	void freeTexts(char **ptr);

--- a/engines/drascula/drascula.h
+++ b/engines/drascula/drascula.h
@@ -777,6 +777,7 @@ private:
 	TalkSequenceCommand *_talkSequences;
 	Common::String _saveNames[10];
 	Common::String _previousSaid;
+	Common::CodePage _ttsTextEncoding;
 
 	char **loadTexts(Common::File &in);
 	void freeTexts(char **ptr);

--- a/engines/drascula/drascula.h
+++ b/engines/drascula/drascula.h
@@ -34,6 +34,7 @@
 #include "common/savefile.h"
 #include "common/system.h"
 #include "common/util.h"
+#include "common/text-to-speech.h"
 
 #include "engines/savestate.h"
 
@@ -729,6 +730,8 @@ public:
 	void update_62();
 	void update_62_pre();
 	void update_102();
+	
+	void sayText(const Common::String &text, Common::TextToSpeechManager::Action action);
 
 private:
 	int _lang;

--- a/engines/drascula/graphics.cpp
+++ b/engines/drascula/graphics.cpp
@@ -24,6 +24,8 @@
 
 #include "common/stream.h"
 #include "common/textconsole.h"
+#include "common/config-manager.h"
+#include "common/text-to-speech.h"
 
 namespace Drascula {
 
@@ -80,8 +82,20 @@ void DrasculaEngine::moveCursor() {
 			color_abc(kColorRed);
 	} else if (!_menuScreen && _color != kColorLightGreen)
 		color_abc(kColorLightGreen);
-	if (_hasName && !_menuScreen)
+	if (_hasName && !_menuScreen) {
+		if (_previousSaid != textName) {
+			Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
+				ttsMan->say(textName);
+			}
+
+			_previousSaid = textName;
+		}
+
 		centerText(textName, _mouseX, _mouseY);
+	}
+	else if (!_menuBar && !_menuScreen)
+		_previousSaid.clear();
 	if (_menuScreen)
 		showMenu();
 	else if (_menuBar)

--- a/engines/drascula/graphics.cpp
+++ b/engines/drascula/graphics.cpp
@@ -83,19 +83,20 @@ void DrasculaEngine::moveCursor() {
 	} else if (!_menuScreen && _color != kColorLightGreen)
 		color_abc(kColorLightGreen);
 	if (_hasName && !_menuScreen) {
+		// _previousSaid is used to prevent the speech from looping, since this ttsMan->say() is in a loop
 		if (_previousSaid != textName) {
 			Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
-				ttsMan->say(textName);
+				ttsMan->say(textName, _ttsTextEncoding);
 			}
 
 			_previousSaid = textName;
 		}
 
 		centerText(textName, _mouseX, _mouseY);
-	}
-	else if (!_menuBar && !_menuScreen)
+	} else if (!_menuBar && !_menuScreen)
 		_previousSaid.clear();
+	
 	if (_menuScreen)
 		showMenu();
 	else if (_menuBar)

--- a/engines/drascula/graphics.cpp
+++ b/engines/drascula/graphics.cpp
@@ -24,7 +24,6 @@
 
 #include "common/stream.h"
 #include "common/textconsole.h"
-#include "common/config-manager.h"
 #include "common/text-to-speech.h"
 
 namespace Drascula {
@@ -83,15 +82,7 @@ void DrasculaEngine::moveCursor() {
 	} else if (!_menuScreen && _color != kColorLightGreen)
 		color_abc(kColorLightGreen);
 	if (_hasName && !_menuScreen) {
-		// _previousSaid is used to prevent the speech from looping, since this ttsMan->say() is in a loop
-		if (_previousSaid != textName) {
-			Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
-			if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
-				ttsMan->say(textName, _ttsTextEncoding);
-			}
-
-			_previousSaid = textName;
-		}
+		sayText(textName, Common::TextToSpeechManager::INTERRUPT);
 
 		centerText(textName, _mouseX, _mouseY);
 	} else if (!_menuBar && !_menuScreen)

--- a/engines/drascula/interface.cpp
+++ b/engines/drascula/interface.cpp
@@ -25,7 +25,11 @@
 #include "common/config-manager.h"
 #include "common/text-to-speech.h"
 
-static const char* verbNamesEnglish[] = {
+// The verbs are represented in-game as a picture, thus we are
+// adding transcriptions here
+// While only English, Spanish, Italian, and Russian are translated in-game,
+// they are translated for the TTS system here
+static const char *verbNamesEnglish[] = {
 	"Walk",
 	"Look",
 	"Take",
@@ -35,7 +39,7 @@ static const char* verbNamesEnglish[] = {
 	"Push"
 };
 
-static const char* verbNamesSpanish[] = {
+static const char *verbNamesSpanish[] = {
 	"Ir a",
 	"Mirar",
 	"Coger",
@@ -45,7 +49,7 @@ static const char* verbNamesSpanish[] = {
 	"Mover"
 };
 
-static const char* verbNamesItalian[] = {
+static const char *verbNamesItalian[] = {
 	"Vai",
 	"Guarda",
 	"Prendi",
@@ -54,6 +58,38 @@ static const char* verbNamesItalian[] = {
 	"Parla",
 	"Premi"
 };
+
+static const char *verbNamesFrench[] = {
+	"Marcher",
+	"Regarder",
+	"Ramasser",
+	"Ouvrir",
+	"Fermer",
+	"Parler",
+	"Pousser"
+};
+
+static const char *verbNamesGerman[] = {
+	"Gehe",
+	"Schau",
+	"Nimm",
+	"Oeffne",
+	"Schliesse",
+	"Rede",
+	"Druecke"
+};
+
+static const char *verbNamesRussian[] = {
+	"Идти",
+	"Смотреть",
+	"взять",
+	"Открыть",
+	"Закрыть",
+	"Говорить",
+	"Толкать"
+};
+
+static const int kConfirmExit = 1;
 
 namespace Drascula {
 
@@ -113,6 +149,39 @@ void DrasculaEngine::selectVerb(int verb) {
 	if (verb > 0) {
 		takeObject = 1;
 		pickedObject = verb;
+
+		if (ConfMan.getBool("tts_enabled")) {
+			const char **verbNames;
+
+			switch (_lang) {
+			case kEnglish:
+				verbNames = verbNamesEnglish;
+				break;
+			case kSpanish:
+				verbNames = verbNamesSpanish;
+				break;
+			case kGerman:
+				verbNames = verbNamesGerman;
+				break;
+			case kFrench:
+				verbNames = verbNamesFrench;
+				break;
+			case kItalian:
+				verbNames = verbNamesItalian;
+				break;
+			case kRussian:
+				verbNames = verbNamesRussian;
+				break;
+			default:
+				verbNames = verbNamesEnglish;
+			}
+
+			Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+
+			if (ttsMan != nullptr) {
+				ttsMan->say(verbNames[verb], Common::TextToSpeechManager::INTERRUPT);
+			}
+		}
 	} else {
 		takeObject = 0;
 		_hasName = false;
@@ -129,7 +198,7 @@ bool DrasculaEngine::confirmExit() {
 
 	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 	if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
-		ttsMan->say(_textsys[1]);
+		ttsMan->say(_textsys[kConfirmExit], _ttsTextEncoding);
 	}
 
 	delay(100);
@@ -176,7 +245,7 @@ void DrasculaEngine::showMenu() {
 		if (iconName[x] != _previousSaid) {
 			Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 			if (ConfMan.getBool("tts_enabled") && strlen(iconName[x]) > 0 && ttsMan != nullptr) {
-				ttsMan->say(iconName[x]);
+				ttsMan->say(iconName[x], _ttsTextEncoding);
 			}
 
 			_previousSaid = iconName[x];
@@ -197,13 +266,25 @@ void DrasculaEngine::clearMenu() {
 				const char **verbNames;
 
 				switch (_lang) {
+				case kEnglish:
+					verbNames = verbNamesEnglish;
+					break;
 				case kSpanish:
 					verbNames = verbNamesSpanish;
+					break;
+				case kGerman:
+					verbNames = verbNamesGerman;
+					break;
+				case kFrench:
+					verbNames = verbNamesFrench;
 					break;
 				case kItalian:
 					verbNames = verbNamesItalian;
 					break;
-				default:	// Every other language uses the English verb names in the menu bar
+				case kRussian:
+					verbNames = verbNamesRussian;
+					break;
+				default:
 					verbNames = verbNamesEnglish;
 				}
 	

--- a/engines/drascula/interface.cpp
+++ b/engines/drascula/interface.cpp
@@ -22,7 +22,6 @@
 #include "drascula/drascula.h"
 #include "graphics/cursorman.h"
 
-#include "common/config-manager.h"
 #include "common/text-to-speech.h"
 
 // The verbs are represented in-game as a picture, thus we are
@@ -73,20 +72,20 @@ static const char *verbNamesGerman[] = {
 	"Gehe",
 	"Schau",
 	"Nimm",
-	"Oeffne",
-	"Schliesse",
+	"\231ffne",
+	"Schlie\341e",
 	"Rede",
-	"Druecke"
+	"Dr\201cke"
 };
 
 static const char *verbNamesRussian[] = {
-	"Идти",
-	"Смотреть",
-	"взять",
-	"Открыть",
-	"Закрыть",
-	"Говорить",
-	"Толкать"
+	"\xc8\xe4\xf2\xe8",					// "Идти"
+	"\xd1\xec\xee\xf2\xf0\xe5\xf2\xfc",	// "Смотреть"
+	"\xc2\xe7\xff\xf2\xfc",				// "Взять"
+	"\xce\xf2\xea\xf0\xfb\xf2\xfc",		// "Открыть"
+	"\xc7\xe0\xea\xf0\xfb\xf2\xfc",		// "Закрыть"
+	"\xc3\xee\xe2\xee\xf0\xe8\xf2\xfc",	// "Говорить"
+	"\xd2\xee\xeb\xea\xe0\xf2\xfc"		// "Толкать"
 };
 
 static const int kConfirmExit = 1;
@@ -150,38 +149,32 @@ void DrasculaEngine::selectVerb(int verb) {
 		takeObject = 1;
 		pickedObject = verb;
 
-		if (ConfMan.getBool("tts_enabled")) {
-			const char **verbNames;
+		const char **verbNames;
 
-			switch (_lang) {
-			case kEnglish:
-				verbNames = verbNamesEnglish;
-				break;
-			case kSpanish:
-				verbNames = verbNamesSpanish;
-				break;
-			case kGerman:
-				verbNames = verbNamesGerman;
-				break;
-			case kFrench:
-				verbNames = verbNamesFrench;
-				break;
-			case kItalian:
-				verbNames = verbNamesItalian;
-				break;
-			case kRussian:
-				verbNames = verbNamesRussian;
-				break;
-			default:
-				verbNames = verbNamesEnglish;
-			}
-
-			Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
-
-			if (ttsMan != nullptr) {
-				ttsMan->say(verbNames[verb], Common::TextToSpeechManager::INTERRUPT);
-			}
+		switch (_lang) {
+		case kEnglish:
+			verbNames = verbNamesEnglish;
+			break;
+		case kSpanish:
+			verbNames = verbNamesSpanish;
+			break;
+		case kGerman:
+			verbNames = verbNamesGerman;
+			break;
+		case kFrench:
+			verbNames = verbNamesFrench;
+			break;
+		case kItalian:
+			verbNames = verbNamesItalian;
+			break;
+		case kRussian:
+			verbNames = verbNamesRussian;
+			break;
+		default:
+			verbNames = verbNamesEnglish;
 		}
+
+		sayText(verbNames[verb], Common::TextToSpeechManager::INTERRUPT);
 	} else {
 		takeObject = 0;
 		_hasName = false;
@@ -196,10 +189,7 @@ bool DrasculaEngine::confirmExit() {
 	centerText(_textsys[1], 160, 87);
 	updateScreen();
 
-	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
-	if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
-		ttsMan->say(_textsys[kConfirmExit], _ttsTextEncoding);
-	}
+	sayText(_textsys[kConfirmExit], Common::TextToSpeechManager::INTERRUPT);
 
 	delay(100);
 	while (!shouldQuit()) {
@@ -242,14 +232,7 @@ void DrasculaEngine::showMenu() {
 	}
 
 	if (x < 7) {
-		if (iconName[x] != _previousSaid) {
-			Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
-			if (ConfMan.getBool("tts_enabled") && strlen(iconName[x]) > 0 && ttsMan != nullptr) {
-				ttsMan->say(iconName[x], _ttsTextEncoding);
-			}
-
-			_previousSaid = iconName[x];
-		}
+		sayText(iconName[x], Common::TextToSpeechManager::INTERRUPT);
 
 		print_abc(iconName[x], _itemLocations[x].x - 2, _itemLocations[x].y - 7);
 	}
@@ -262,43 +245,34 @@ void DrasculaEngine::clearMenu() {
 		if (_mouseX > _verbBarX[n] && _mouseX < _verbBarX[n + 1]) {
 			verbActivated = 0;
 
-			if (ConfMan.getBool("tts_enabled")) {
-				const char **verbNames;
+			const char **verbNames;
 
-				switch (_lang) {
-				case kEnglish:
-					verbNames = verbNamesEnglish;
-					break;
-				case kSpanish:
-					verbNames = verbNamesSpanish;
-					break;
-				case kGerman:
-					verbNames = verbNamesGerman;
-					break;
-				case kFrench:
-					verbNames = verbNamesFrench;
-					break;
-				case kItalian:
-					verbNames = verbNamesItalian;
-					break;
-				case kRussian:
-					verbNames = verbNamesRussian;
-					break;
-				default:
-					verbNames = verbNamesEnglish;
-				}
-	
-				if (verbNames[n] != _previousSaid) {
-					Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
-	
-					if (ttsMan != nullptr) {
-						ttsMan->say(verbNames[n]);
-					}
-		
-					_previousSaid = verbNames[n];
-				}
+			switch (_lang) {
+			case kEnglish:
+				verbNames = verbNamesEnglish;
+				break;
+			case kSpanish:
+				verbNames = verbNamesSpanish;
+				break;
+			case kGerman:
+				verbNames = verbNamesGerman;
+				break;
+			case kFrench:
+				verbNames = verbNamesFrench;
+				break;
+			case kItalian:
+				verbNames = verbNamesItalian;
+				break;
+			case kRussian:
+				verbNames = verbNamesRussian;
+				break;
+			default:
+				verbNames = verbNamesEnglish;
 			}
+
+			sayText(verbNames[n], Common::TextToSpeechManager::INTERRUPT);
 		}
+		
 		copyRect(OBJWIDTH * n, OBJHEIGHT * verbActivated, _verbBarX[n], 2,
 						OBJWIDTH, OBJHEIGHT, cursorSurface, screenSurface);
 		verbActivated = 1;

--- a/engines/drascula/metaengine.cpp
+++ b/engines/drascula/metaengine.cpp
@@ -44,6 +44,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 		}
 	},
 
+#ifdef USE_TTS
 	{
 		GAMEOPTION_TTS,
 		{
@@ -55,6 +56,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 			0
 		}
 	},
+#endif
 
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };

--- a/engines/drascula/metaengine.cpp
+++ b/engines/drascula/metaengine.cpp
@@ -43,6 +43,19 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 			0
 		}
 	},
+
+	{
+		GAMEOPTION_TTS,
+		{
+			_s("Enable Text to Speech"),
+			_s("Use TTS to read text in the game (if TTS is available)"),
+			"tts_enabled",
+			false,
+			0,
+			0
+		}
+	},
+
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 

--- a/engines/drascula/saveload.cpp
+++ b/engines/drascula/saveload.cpp
@@ -21,7 +21,6 @@
 
 #include "common/textconsole.h"
 #include "common/translation.h"
-#include "common/config-manager.h"
 #include "common/text-to-speech.h"
 
 #include "engines/savestate.h"
@@ -422,8 +421,6 @@ bool DrasculaEngine::saveLoadScreen() {
 	setCursor(kCursorCrosshair);
 	loadSaveNames();
 
-	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
-
 	while (!shouldQuit()) {
 		copyBackground();
 		for (n = 0; n < NUM_SAVES; n++) {
@@ -431,9 +428,8 @@ bool DrasculaEngine::saveLoadScreen() {
 		}
 		print_abc(selectedName.c_str(), 117, 15);
 
-		if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && _previousSaid != selectedName && selectedName.size() > 0) {
-			ttsMan->say(selectedName.c_str());
-			_previousSaid = selectedName;
+		if (selectedName.size() > 0) {
+			sayText(selectedName.c_str(), Common::TextToSpeechManager::INTERRUPT);
 		}
 
 		updateScreen();
@@ -465,9 +461,7 @@ bool DrasculaEngine::saveLoadScreen() {
 			if (_mouseX > 208 && _mouseY > 123 && _mouseX < 282 && _mouseY < 149) {
 				// "Save" button
 				if (selectedName.empty()) {
-					if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
-						ttsMan->say("Please select a slot");
-					}
+					sayText("Please select a slot", Common::TextToSpeechManager::INTERRUPT);
 
 					print_abc("Please select a slot", 117, 15);
 					updateScreen();
@@ -485,9 +479,7 @@ bool DrasculaEngine::saveLoadScreen() {
 			} else if (_mouseX > 125 && _mouseY > 123 && _mouseX < 199 && _mouseY < 149) {
 				// "Load" button
 				if (selectedName.empty()) {
-					if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
-						ttsMan->say("Please select a slot");
-					}
+					sayText("Please select a slot", Common::TextToSpeechManager::INTERRUPT);
 
 					print_abc("Please select a slot", 117, 15);
 					updateScreen();

--- a/engines/drascula/saveload.cpp
+++ b/engines/drascula/saveload.cpp
@@ -21,6 +21,8 @@
 
 #include "common/textconsole.h"
 #include "common/translation.h"
+#include "common/config-manager.h"
+#include "common/text-to-speech.h"
 
 #include "engines/savestate.h"
 #include "graphics/thumbnail.h"
@@ -420,12 +422,19 @@ bool DrasculaEngine::saveLoadScreen() {
 	setCursor(kCursorCrosshair);
 	loadSaveNames();
 
+	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+
 	while (!shouldQuit()) {
 		copyBackground();
 		for (n = 0; n < NUM_SAVES; n++) {
 			print_abc(_saveNames[n].c_str(), 116, 27 + 9 * n);
 		}
 		print_abc(selectedName.c_str(), 117, 15);
+
+		if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr && _previousSaid != selectedName && selectedName.size() > 0) {
+			ttsMan->say(selectedName.c_str());
+			_previousSaid = selectedName;
+		}
 
 		updateScreen();
 		updateEvents();
@@ -456,6 +465,10 @@ bool DrasculaEngine::saveLoadScreen() {
 			if (_mouseX > 208 && _mouseY > 123 && _mouseX < 282 && _mouseY < 149) {
 				// "Save" button
 				if (selectedName.empty()) {
+					if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
+						ttsMan->say("Please select a slot");
+					}
+
 					print_abc("Please select a slot", 117, 15);
 					updateScreen();
 					delay(200);
@@ -472,6 +485,10 @@ bool DrasculaEngine::saveLoadScreen() {
 			} else if (_mouseX > 125 && _mouseY > 123 && _mouseX < 199 && _mouseY < 149) {
 				// "Load" button
 				if (selectedName.empty()) {
+					if (ConfMan.getBool("tts_enabled") && ttsMan != nullptr) {
+						ttsMan->say("Please select a slot");
+					}
+
 					print_abc("Please select a slot", 117, 15);
 					updateScreen();
 					delay(200);

--- a/engines/drascula/sound.cpp
+++ b/engines/drascula/sound.cpp
@@ -26,10 +26,56 @@
 #include "common/config-manager.h"
 #include "common/textconsole.h"
 #include "common/substream.h"
+#include "common/text-to-speech.h"
 
 #include "backends/audiocd/audiocd.h"
 
 #include "drascula/drascula.h"
+
+// For consistency with the verb names, the English words in the volume controls menu are
+// translated into the game's language for text-to-speech
+static const char *volumeControlsEnglish[] = {
+	"Master",
+	"Voice/FX",
+	"Music"
+};
+
+static const char *volumeControlsSpanish[] = {
+	"Maestro",
+	"Voces/efectos de sonido",
+	"Música"
+};
+
+static const char *volumeControlsItalian[] = {
+	"Principale",
+	"Voci/effetti sonori",
+	"Musica"
+};
+
+static const char *volumeControlsFrench[] = {
+	"Principal",
+	"Voix/effets sonores",
+	"Musique"
+};
+
+static const char *volumeControlsGerman[] = {
+	"Gesamtlautstärke",
+	"Stimmen/Soundeffekte",
+	"Musik"
+};
+
+// The Russian volume controls are translated in-game
+static const char *volumeControlsRussian[] = {
+	"Общий",
+	"голос",
+	"му́зыка"
+};
+
+enum VolumeControlType {
+	kMaster = 0,
+	kSpeechAndSFX = 1,
+	kMusic = 2
+};
 
 namespace Drascula {
 
@@ -154,6 +200,49 @@ void DrasculaEngine::volumeControls() {
 			ConfMan.setInt("music_volume", musicVolume);
 		}
 
+		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+
+		if (ttsMan != nullptr && ConfMan.getBool("tts_enabled")) {
+			const char **controlNames;
+
+			switch (_lang) {
+			case kEnglish:
+				controlNames = volumeControlsEnglish;
+				break;
+			case kSpanish:
+				controlNames = volumeControlsSpanish;
+				break;
+			case kGerman:
+				controlNames = volumeControlsGerman;
+				break;
+			case kFrench:
+				controlNames = volumeControlsFrench;
+				break;
+			case kItalian:
+				controlNames = volumeControlsItalian;
+				break;
+			case kRussian:
+				controlNames = volumeControlsRussian;
+				break;
+			default:
+				controlNames = volumeControlsEnglish;
+			}
+
+			Common::String ttsMessage;
+			if (_mouseX > 80 && _mouseX < 121)
+				ttsMessage = controlNames[kMaster];
+			else if (_mouseX > 136 && _mouseX < 178)
+				ttsMessage = controlNames[kSpeechAndSFX];
+			else if (_mouseX > 192 && _mouseX < 233)
+				ttsMessage = controlNames[kMusic];
+			else
+				_previousSaid.clear();
+
+			if (ttsMessage.size() > 0 && ttsMessage != _previousSaid) {
+				_previousSaid = ttsMessage;
+				ttsMan->say(ttsMessage, Common::TextToSpeechManager::INTERRUPT);
+			}
+		}
 	}
 
 	if (_lang == kSpanish && currentChapter != 6)

--- a/engines/drascula/sound.cpp
+++ b/engines/drascula/sound.cpp
@@ -32,8 +32,8 @@
 
 #include "drascula/drascula.h"
 
-// For consistency with the verb names, the English words in the volume controls menu are
-// translated into the game's language for text-to-speech
+// For consistency with the verb names, the English words in the volume controls menu (which are pictures) 
+// are translated into the game's language for text-to-speech
 static const char *volumeControlsEnglish[] = {
 	"Master",
 	"Voice/FX",
@@ -43,7 +43,7 @@ static const char *volumeControlsEnglish[] = {
 static const char *volumeControlsSpanish[] = {
 	"Maestro",
 	"Voces/efectos de sonido",
-	"Música"
+	"M\243sica"
 };
 
 static const char *volumeControlsItalian[] = {
@@ -59,16 +59,16 @@ static const char *volumeControlsFrench[] = {
 };
 
 static const char *volumeControlsGerman[] = {
-	"Gesamtlautstärke",
+	"Gesamtlautst\204rke",
 	"Stimmen/Soundeffekte",
 	"Musik"
 };
 
 // The Russian volume controls are translated in-game
 static const char *volumeControlsRussian[] = {
-	"Общий",
-	"голос",
-	"му́зыка"
+	"\xce\xe1\xf9\xe8\xe9",		// "Общий"
+	"\xc3\xee\xeb\xee\xf1",		// "Голос"
+	"\xcc\xf3\xe7\xfb\xea\xe0"	// "Музыка"
 };
 
 enum VolumeControlType {
@@ -200,48 +200,43 @@ void DrasculaEngine::volumeControls() {
 			ConfMan.setInt("music_volume", musicVolume);
 		}
 
-		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+		const char **controlNames;
 
-		if (ttsMan != nullptr && ConfMan.getBool("tts_enabled")) {
-			const char **controlNames;
+		switch (_lang) {
+		case kEnglish:
+			controlNames = volumeControlsEnglish;
+			break;
+		case kSpanish:
+			controlNames = volumeControlsSpanish;
+			break;
+		case kGerman:
+			controlNames = volumeControlsGerman;
+			break;
+		case kFrench:
+			controlNames = volumeControlsFrench;
+			break;
+		case kItalian:
+			controlNames = volumeControlsItalian;
+			break;
+		case kRussian:
+			controlNames = volumeControlsRussian;
+			break;
+		default:
+			controlNames = volumeControlsEnglish;
+		}
 
-			switch (_lang) {
-			case kEnglish:
-				controlNames = volumeControlsEnglish;
-				break;
-			case kSpanish:
-				controlNames = volumeControlsSpanish;
-				break;
-			case kGerman:
-				controlNames = volumeControlsGerman;
-				break;
-			case kFrench:
-				controlNames = volumeControlsFrench;
-				break;
-			case kItalian:
-				controlNames = volumeControlsItalian;
-				break;
-			case kRussian:
-				controlNames = volumeControlsRussian;
-				break;
-			default:
-				controlNames = volumeControlsEnglish;
-			}
+		Common::String ttsMessage;
+		if (_mouseX > 80 && _mouseX < 121)
+			ttsMessage = controlNames[kMaster];
+		else if (_mouseX > 136 && _mouseX < 178)
+			ttsMessage = controlNames[kSpeechAndSFX];
+		else if (_mouseX > 192 && _mouseX < 233)
+			ttsMessage = controlNames[kMusic];
+		else
+			_previousSaid.clear();
 
-			Common::String ttsMessage;
-			if (_mouseX > 80 && _mouseX < 121)
-				ttsMessage = controlNames[kMaster];
-			else if (_mouseX > 136 && _mouseX < 178)
-				ttsMessage = controlNames[kSpeechAndSFX];
-			else if (_mouseX > 192 && _mouseX < 233)
-				ttsMessage = controlNames[kMusic];
-			else
-				_previousSaid.clear();
-
-			if (ttsMessage.size() > 0 && ttsMessage != _previousSaid) {
-				_previousSaid = ttsMessage;
-				ttsMan->say(ttsMessage, Common::TextToSpeechManager::INTERRUPT);
-			}
+		if (ttsMessage.size() > 0) {
+			sayText(ttsMessage, Common::TextToSpeechManager::INTERRUPT);
 		}
 	}
 


### PR DESCRIPTION
Adds a toggle for text-to-speech under the game options.
Adds text-to-speech for the following:
- Intro line describing the game's setting
- Dialogue options
- Menu and menu bar actions/verbs
- Names of interactable objects when hovered over
- Messages related to save slots in the original save/load screen
- Lines in the drunkard's cutscene explaining the history of Von Braun
- Subtitles enabled/disabled messages
- Exit confirmation message
- Verb selection with F1 to F6 keys
- Volume controls menu