### PR TITLE
FREESCAPE: Fix for #15486 TINYGL: triangles always override zbuffer from lines

### DIFF
--- a/engines/freescape/area.cpp
+++ b/engines/freescape/area.cpp
@@ -359,10 +359,6 @@ void Area::draw(Freescape::Renderer *gfx, uint32 animationTicks, Math::Vector3d 
 		}
 	}
 
-	// In theory, the ordering of the rendering should not matter,
-	// however, it seems that rendering the planar objects first
-	// triggers a bug in TinyGL where certain objects such as lines,
-	// are not rendered correctly. This is a workaround for that issue.
 	for (auto &obj : nonPlanarObjects) {
 		obj->draw(gfx);
 	}

--- a/graphics/tinygl/zbuffer.h
+++ b/graphics/tinygl/zbuffer.h
@@ -419,7 +419,7 @@ private:
 
 	template <bool kEnableAlphaTest, bool kBlendingEnabled, bool kDepthWrite>
 	FORCEINLINE void writePixel(int pixel, byte aSrc, byte rSrc, byte gSrc, byte bSrc, uint z) {
-		writePixel<kEnableAlphaTest, kBlendingEnabled, false, false>(pixel, aSrc, rSrc, gSrc, bSrc, z, 0.0f, 0, 0, 0);
+		writePixel<kEnableAlphaTest, kBlendingEnabled, kDepthWrite, false>(pixel, aSrc, rSrc, gSrc, bSrc, z, 0.0f, 0, 0, 0);
 	}
 
 	template <bool kEnableAlphaTest, bool kBlendingEnabled, bool kDepthWrite, bool kFogMode>


### PR DESCRIPTION
Fix incorrect depth buffer writing in render pipeline of TGL_LINES 
- Add `kDepthWrite` parameter to control depth updates
- Modify the the affected code to render first planar, then non-planar objects