### PR TITLE
PLAYGROUND3D: Make various improvements

### DIFF
--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -1121,6 +1121,10 @@ XcodeProvider::ValueList& XcodeProvider::getResourceFiles(const BuildSetup &setu
 			files.push_back("engines/playground3d/shaders/playground3d_cube.vertex");
 			files.push_back("engines/playground3d/shaders/playground3d_fade.fragment");
 			files.push_back("engines/playground3d/shaders/playground3d_fade.vertex");
+			files.push_back("engines/playground3d/shaders/playground3d_offset.fragment");
+			files.push_back("engines/playground3d/shaders/playground3d_offset.vertex");
+			files.push_back("engines/playground3d/shaders/playground3d_viewport.fragment");
+			files.push_back("engines/playground3d/shaders/playground3d_viewport.vertex");
 		}
 		if (CONTAINS_DEFINE(setup.defines, "ENABLE_STARK")) {
 			files.push_back("engines/stark/shaders/stark_actor.fragment");

--- a/dists/scummvm.rc
+++ b/dists/scummvm.rc
@@ -126,6 +126,10 @@ shaders/playground3d_cube.fragment      FILE    "engines/playground3d/shaders/pl
 shaders/playground3d_cube.vertex        FILE    "engines/playground3d/shaders/playground3d_cube.vertex"
 shaders/playground3d_fade.fragment      FILE    "engines/playground3d/shaders/playground3d_fade.fragment"
 shaders/playground3d_fade.vertex        FILE    "engines/playground3d/shaders/playground3d_fade.vertex"
+shaders/playground3d_offset.fragment    FILE    "engines/playground3d/shaders/playground3d_offset.fragment"
+shaders/playground3d_offset.vertex      FILE    "engines/playground3d/shaders/playground3d_offset.vertex"
+shaders/playground3d_viewport.fragment  FILE    "engines/playground3d/shaders/playground3d_viewport.fragment"
+shaders/playground3d_viewport.vertex    FILE    "engines/playground3d/shaders/playground3d_viewport.vertex"
 #endif
 #if PLUGIN_ENABLED_STATIC(HPL1)
 shaders/hpl1_Ambient_Color.fragment                    FILE   "engines/hpl1/engine/impl/shaders/hpl1_Ambient_Color.fragment"

--- a/engines/playground3d/gfx_opengl.cpp
+++ b/engines/playground3d/gfx_opengl.cpp
@@ -283,9 +283,9 @@ void OpenGLRenderer::drawInViewport() {
 	glPushMatrix();
 	_pos.x() += 0.01f;
 	_pos.y() += 0.01f;
-	if (_pos.x() >= 1.0f) {
-		_pos.x() = -1.0f;
-		_pos.y() = -1.0f;
+	if (_pos.x() >= 1.1f) {
+		_pos.x() = -1.1f;
+		_pos.y() = -1.1f;
 	}
 	glTranslatef(_pos.x(), _pos.y(), 0);
 

--- a/engines/playground3d/gfx_opengl.cpp
+++ b/engines/playground3d/gfx_opengl.cpp
@@ -176,6 +176,12 @@ void OpenGLRenderer::drawCube(const Math::Vector3d &pos, const Math::Vector3d &r
 	glMatrixMode(GL_MODELVIEW);
 	glLoadMatrixf(_modelViewMatrix.getData());
 
+	glDisable(GL_BLEND);
+	glBlendFunc(GL_ONE, GL_ZERO);
+	glEnable(GL_DEPTH_TEST);
+	glDepthMask(GL_TRUE);
+	glDisable(GL_TEXTURE_2D);
+
 	glTranslatef(pos.x(), pos.y(), pos.z());
 	glRotatef(roll.x(), 1.0f, 0.0f, 0.0f);
 	glRotatef(roll.y(), 0.0f, 1.0f, 0.0f);
@@ -192,6 +198,12 @@ void OpenGLRenderer::drawPolyOffsetTest(const Math::Vector3d &pos, const Math::V
 
 	glMatrixMode(GL_MODELVIEW);
 	glLoadMatrixf(_modelViewMatrix.getData());
+
+	glDisable(GL_BLEND);
+	glBlendFunc(GL_ONE, GL_ZERO);
+	glEnable(GL_DEPTH_TEST);
+	glDepthMask(GL_TRUE);
+	glDisable(GL_TEXTURE_2D);
 
 	glTranslatef(pos.x(), pos.y(), pos.z());
 	glRotatef(roll.y(), 0.0f, 1.0f, 0.0f);

--- a/engines/playground3d/gfx_opengl_shaders.cpp
+++ b/engines/playground3d/gfx_opengl_shaders.cpp
@@ -84,8 +84,6 @@ void ShaderRenderer::init() {
 
 	computeScreenViewport();
 
-	glEnable(GL_DEPTH_TEST);
-
 	static const char *cubeAttributes[] = { "position", "normal", "color", "texcoord", nullptr };
 	_cubeShader = OpenGL::Shader::fromFiles("playground3d_cube", cubeAttributes);
 	_cubeVBO = OpenGL::Shader::createBuffer(GL_ARRAY_BUFFER, sizeof(cubeVertices), cubeVertices);
@@ -172,6 +170,12 @@ void ShaderRenderer::enableFog(const Math::Vector4d &fogColor) {
 }
 
 void ShaderRenderer::drawCube(const Math::Vector3d &pos, const Math::Vector3d &roll) {
+	glDisable(GL_BLEND);
+	glBlendFunc(GL_ONE, GL_ZERO);
+	glEnable(GL_DEPTH_TEST);
+	glDepthMask(GL_TRUE);
+	glDisable(GL_TEXTURE_2D);
+
 	auto rotateMatrix = (Math::Quaternion::fromEuler(roll.x(), roll.y(), roll.z(), Math::EO_XYZ)).inverse().toMatrix();
 	_cubeShader->use();
 	_cubeShader->setUniform("textured", false);

--- a/engines/playground3d/gfx_opengl_shaders.cpp
+++ b/engines/playground3d/gfx_opengl_shaders.cpp
@@ -285,9 +285,9 @@ void ShaderRenderer::drawInViewport() {
 
 	_pos.setX(_pos.getX() + 0.01f);
 	_pos.setY(_pos.getY() + 0.01f);
-	if (_pos.getX() >= 1.0f) {
-		_pos.setX(-1.0f);
-		_pos.setY(-1.0f);
+	if (_pos.getX() >= 1.1f) {
+		_pos.setX(-1.1f);
+		_pos.setY(-1.1f);
 	}
 
 	_viewportShader->setUniform("offset", _pos);

--- a/engines/playground3d/gfx_opengl_shaders.h
+++ b/engines/playground3d/gfx_opengl_shaders.h
@@ -59,14 +59,19 @@ public:
 
 private:
 	OpenGL::Shader *_cubeShader;
+	OpenGL::Shader *_offsetShader;
 	OpenGL::Shader *_fadeShader;
+	OpenGL::Shader *_viewportShader;
 	OpenGL::Shader *_bitmapShader;
 
 	GLuint _cubeVBO;
+	GLuint _offsetVBO;
 	GLuint _fadeVBO;
+	GLuint _viewportVBO;
 	GLuint _bitmapVBO;
 
 	Common::Rect _currentViewport;
+	Math::Vector2d _pos;
 	GLuint _textureRgbaId[5];
 	GLuint _textureRgbId[5];
 	GLuint _textureRgb565Id[2];

--- a/engines/playground3d/gfx_tinygl.cpp
+++ b/engines/playground3d/gfx_tinygl.cpp
@@ -329,9 +329,9 @@ void TinyGLRenderer::drawInViewport() {
 	tglPushMatrix();
 	_pos.x() += 0.01f;
 	_pos.y() += 0.01f;
-	if (_pos.x() >= 1.0f) {
-		_pos.x() = -1.0;
-		_pos.y() = -1.0;
+	if (_pos.x() >= 1.1f) {
+		_pos.x() = -1.1;
+		_pos.y() = -1.1;
 	}
 	tglTranslatef(_pos.x(), _pos.y(), 0);
 

--- a/engines/playground3d/gfx_tinygl.cpp
+++ b/engines/playground3d/gfx_tinygl.cpp
@@ -206,6 +206,12 @@ void TinyGLRenderer::drawCube(const Math::Vector3d &pos, const Math::Vector3d &r
 	tglMatrixMode(TGL_MODELVIEW);
 	tglLoadMatrixf(_modelViewMatrix.getData());
 
+	tglDisable(TGL_BLEND);
+	tglBlendFunc(TGL_ONE, TGL_ZERO);
+	tglEnable(TGL_DEPTH_TEST);
+	tglDepthMask(TGL_TRUE);
+	tglDisable(TGL_TEXTURE_2D);
+
 	tglTranslatef(pos.x(), pos.y(), pos.z());
 	tglRotatef(roll.x(), 1.0f, 0.0f, 0.0f);
 	tglRotatef(roll.y(), 0.0f, 1.0f, 0.0f);
@@ -222,6 +228,12 @@ void TinyGLRenderer::drawPolyOffsetTest(const Math::Vector3d &pos, const Math::V
 
 	tglMatrixMode(TGL_MODELVIEW);
 	tglLoadMatrixf(_modelViewMatrix.getData());
+
+	tglDisable(TGL_BLEND);
+	tglBlendFunc(TGL_ONE, TGL_ZERO);
+	tglEnable(TGL_DEPTH_TEST);
+	tglDepthMask(TGL_TRUE);
+	tglDisable(TGL_TEXTURE_2D);
 
 	tglTranslatef(pos.x(), pos.y(), pos.z());
 	tglRotatef(roll.y(), 0.0f, 1.0f, 0.0f);

--- a/engines/playground3d/playground3d.cpp
+++ b/engines/playground3d/playground3d.cpp
@@ -54,6 +54,26 @@ bool Playground3dEngine::hasFeature(EngineFeature f) const {
 		(f == kSupportsArbitraryResolutions && !softRenderer);
 }
 
+void Playground3dEngine::genTextures() {
+#if defined(SCUMM_LITTLE_ENDIAN)
+	Graphics::PixelFormat pixelFormatRGBA(4, 8, 8, 8, 8, 0, 8, 16, 24);
+	Graphics::PixelFormat pixelFormatRGB(3, 8, 8, 8, 0, 0, 8, 16, 0);
+#else
+	Graphics::PixelFormat pixelFormatRGBA(4, 8, 8, 8, 8, 24, 16, 8, 0);
+	Graphics::PixelFormat pixelFormatRGB(3, 8, 8, 8, 0, 16, 8, 0, 0);
+#endif
+	Graphics::PixelFormat pixelFormatRGB565(2, 5, 6, 5, 0, 11, 5, 0, 0);
+	Graphics::PixelFormat pixelFormatRGB5551(2, 5, 5, 5, 1, 11, 6, 1, 0);
+	Graphics::PixelFormat pixelFormatRGB4444(2, 4, 4, 4, 4, 12, 8, 4, 0);
+	_rgbaTexture = generateRgbaTexture(120, 120, pixelFormatRGBA);
+	_rgbTexture = _rgbaTexture->convertTo(pixelFormatRGB);
+	_rgb565Texture = generateRgbaTexture(120, 120, pixelFormatRGB565);
+	_rgba5551Texture = generateRgbaTexture(120, 120, pixelFormatRGB5551);
+	_rgba4444Texture = generateRgbaTexture(120, 120, pixelFormatRGB4444);
+}
+
+static int testId;
+static bool texturesGenerated;
 Playground3dEngine::Playground3dEngine(OSystem *syst)
 		: Engine(syst), _system(syst), _gfx(nullptr), _frameLimiter(nullptr),
 		_rotateAngleX(0), _rotateAngleY(0), _rotateAngleZ(0), _fogEnable(false),
@@ -76,12 +96,14 @@ Common::Error Playground3dEngine::run() {
 
 	_system->showMouse(true);
 
+	texturesGenerated = false;
+
 	// 1 - rotated colorfull cube
 	// 2 - rotated two triangles with depth offset
 	// 3 - fade in/out
 	// 4 - moving filled rectangle in viewport
 	// 5 - drawing RGBA pattern texture to check endian correctness
-	int testId = 1;
+	testId = 1;
 	_fogEnable = false;
 
 	if (_fogEnable) {
@@ -104,21 +126,8 @@ Common::Error Playground3dEngine::run() {
 			break;
 		case 5: {
 			_clearColor = Math::Vector4d(0.5f, 0.5f, 0.5f, 1.0f);
-#if defined(SCUMM_LITTLE_ENDIAN)
-			Graphics::PixelFormat pixelFormatRGBA(4, 8, 8, 8, 8, 0, 8, 16, 24);
-			Graphics::PixelFormat pixelFormatRGB(3, 8, 8, 8, 0, 0, 8, 16, 0);
-#else
-			Graphics::PixelFormat pixelFormatRGBA(4, 8, 8, 8, 8, 24, 16, 8, 0);
-			Graphics::PixelFormat pixelFormatRGB(3, 8, 8, 8, 0, 16, 8, 0, 0);
-#endif
-			Graphics::PixelFormat pixelFormatRGB565(2, 5, 6, 5, 0, 11, 5, 0, 0);
-			Graphics::PixelFormat pixelFormatRGB5551(2, 5, 5, 5, 1, 11, 6, 1, 0);
-			Graphics::PixelFormat pixelFormatRGB4444(2, 4, 4, 4, 4, 12, 8, 4, 0);
-			_rgbaTexture = generateRgbaTexture(120, 120, pixelFormatRGBA);
-			_rgbTexture = _rgbaTexture->convertTo(pixelFormatRGB);
-			_rgb565Texture = generateRgbaTexture(120, 120, pixelFormatRGB565);
-			_rgba5551Texture = generateRgbaTexture(120, 120, pixelFormatRGB5551);
-			_rgba4444Texture = generateRgbaTexture(120, 120, pixelFormatRGB4444);
+			genTextures();
+			texturesGenerated = true;
 			break;
 		}
 		default:
@@ -147,6 +156,36 @@ void Playground3dEngine::processInput() {
 	while (getEventManager()->pollEvent(event)) {
 		if (event.type == Common::EVENT_SCREEN_CHANGED) {
 			_gfx->computeScreenViewport();
+		}
+		if (event.type == Common::EVENT_LBUTTONUP) {
+			testId++;
+			if (testId > 5)
+				testId = 1;
+			switch (testId) {
+				case 1:
+					_clearColor = Math::Vector4d(0.5f, 0.5f, 0.5f, 1.0f);
+					_rotateAngleX = 45, _rotateAngleY = 45, _rotateAngleZ = 10;
+					break;
+				case 2:
+					_clearColor = Math::Vector4d(0.5f, 0.5f, 0.5f, 1.0f);
+					break;
+				case 3:
+					_clearColor = Math::Vector4d(1.0f, 0.0f, 0.0f, 1.0f);
+					break;
+				case 4:
+					_clearColor = Math::Vector4d(0.5f, 0.5f, 0.5f, 1.0f);
+					break;
+				case 5: {
+					_clearColor = Math::Vector4d(0.5f, 0.5f, 0.5f, 1.0f);
+					if (!texturesGenerated) {
+						genTextures();
+						texturesGenerated = true;
+					}
+					break;
+				}
+				default:
+					assert(false);
+			}
 		}
 	}
 }
@@ -218,7 +257,7 @@ void Playground3dEngine::drawRgbaTexture() {
 	_gfx->drawRgbaTexture();
 }
 
-void Playground3dEngine::drawFrame(int testId) {
+void Playground3dEngine::drawFrame(int id) {
 	_gfx->clear(_clearColor);
 
 	float pitch = 0.0f;
@@ -229,7 +268,7 @@ void Playground3dEngine::drawFrame(int testId) {
 	Common::Rect vp = _gfx->viewport();
 	_gfx->setupViewport(vp.left, _system->getHeight() - vp.top - vp.height(), vp.width(), vp.height());
 
-	switch (testId) {
+	switch (id) {
 		case 1:
 			if (_fogEnable) {
 				_gfx->enableFog(_fogColor);

--- a/engines/playground3d/playground3d.h
+++ b/engines/playground3d/playground3d.h
@@ -41,6 +41,8 @@ public:
 
 	bool hasFeature(EngineFeature f) const override;
 
+	void genTextures();
+
 	void processInput();
 
 	void drawFrame(int testId);

--- a/engines/playground3d/shaders/playground3d_offset.fragment
+++ b/engines/playground3d/shaders/playground3d_offset.fragment
@@ -1,0 +1,8 @@
+
+OUTPUT
+
+uniform vec3 triColor;
+
+void main() {
+	outColor = vec4(triColor, 1.0);
+}

--- a/engines/playground3d/shaders/playground3d_offset.vertex
+++ b/engines/playground3d/shaders/playground3d_offset.vertex
@@ -1,0 +1,12 @@
+in vec2 position;
+
+uniform mat4 mvpMatrix;
+uniform mat4 projMatrix;
+uniform mat4 modelMatrix;
+uniform mat4 rotateMatrix;
+uniform vec3 modelPos;
+
+void main() {
+	vec4 pos = rotateMatrix * vec4(position, 0.0, 1.0);
+	gl_Position = mvpMatrix * (pos + vec4(modelPos, 1.0));
+}

--- a/engines/playground3d/shaders/playground3d_viewport.fragment
+++ b/engines/playground3d/shaders/playground3d_viewport.fragment
@@ -1,0 +1,8 @@
+
+OUTPUT
+
+uniform vec3 color;
+
+void main() {
+	outColor = vec4(color, 1.0);
+}

--- a/engines/playground3d/shaders/playground3d_viewport.vertex
+++ b/engines/playground3d/shaders/playground3d_viewport.vertex
@@ -1,0 +1,7 @@
+in vec2 position;
+
+uniform vec2 offset;
+
+void main() {
+	gl_Position = vec4(position + offset, 0.0, 1.0);
+}


### PR DESCRIPTION
* Implement Tests 2 and 4 in the OpenGL Shaders renderer
* In Test 4, make sure the red square is completely out of view before it is warped from the top-right corner to the bottom-left corner.
* Left-clicking the screen starts the next test. For example, left-clicking when Test 1 is running will start Test 2; if Test 5 is the current test, the cycle will loop back to Test 1. This eliminates the need to recompile every time you want to do a different test.