### PR TITLE
IMAGE: Get palette class by reference on image decoders

### DIFF
--- a/backends/graphics/opengl/pipelines/libretro.cpp
+++ b/backends/graphics/opengl/pipelines/libretro.cpp
@@ -77,14 +77,15 @@ static Graphics::Surface *loadViaImageDecoder(const Common::Path &fileName, Comm
 		return nullptr;
 	}
 
+	// Use a cast to resolve ambiguities in JPEGDecoder
+	const Graphics::Palette & palette = static_cast<Image::ImageDecoder &>(decoder).getPalette();
 	return decoder.getSurface()->convertTo(
 #ifdef SCUMM_LITTLE_ENDIAN
 										   Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24),
 #else
 										   Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0),
 #endif
-										   // Use a cast to resolve ambiguities in JPEGDecoder
-										   static_cast<Image::ImageDecoder &>(decoder).getPalette());
+										   palette.data(), palette.size());
 }
 
 struct ImageLoader {

--- a/engines/ags/shared/gfx/image.cpp
+++ b/engines/ags/shared/gfx/image.cpp
@@ -52,12 +52,10 @@ BITMAP *decodeImageStream(Common::SeekableReadStream &stream, color *pal) {
 		dest->blitFrom(*src);
 
 		// Copy the palette
-		const byte *palP = decoder.getPalette();
-		if (palP && pal) {
-			for (int idx = 0; idx < 256; ++idx, palP += 3) {
-				pal[idx].r = palP[0];
-				pal[idx].g = palP[1];
-				pal[idx].b = palP[2];
+		const Graphics::Palette &palP = decoder.getPalette();
+		if (pal) {
+			for (uint idx = 0; idx < palP.size(); ++idx) {
+				palP.get(idx, pal[idx].r, pal[idx].g, pal[idx].b);
 				pal[idx].filler = 0xff;
 			}
 		}

--- a/engines/bagel/boflib/gfx/bitmap.cpp
+++ b/engines/bagel/boflib/gfx/bitmap.cpp
@@ -180,7 +180,7 @@ ErrorCode CBofBitmap::loadBitmap(const char *pszFileName, CBofPalette *pPalette)
 		_bitmap.copyFrom(*decoder.getSurface());
 
 		// Load the bitmap palette
-		_bitmap.setPalette(decoder.getPalette(), 0, Graphics::PALETTE_COUNT);
+		_bitmap.setPalette(decoder.getPalette().data(), 0, decoder.getPalette().size());
 
 		_nDX = _bitmap.w;
 		_nDY = _bitmap.h;

--- a/engines/bagel/boflib/gfx/palette.cpp
+++ b/engines/bagel/boflib/gfx/palette.cpp
@@ -91,9 +91,9 @@ ErrorCode CBofPalette::loadPalette(const char *pszFileName, uint16 nFlags) {
 
 	if (f.open(pszFileName) && decoder.loadStream(f)) {
 		// Copy the palette
-		_palette._numColors = decoder.getPaletteColorCount();
-		const byte *src = decoder.getPalette();
-		Common::copy(src, src + _palette._numColors * 3, _palette._data);
+		const Graphics::Palette &pal = decoder.getPalette();
+		_palette._numColors = pal.size();
+		pal.grab(_palette._data, 0, pal.size());
 
 		_errCode = ERR_NONE;
 

--- a/engines/buried/graphics.cpp
+++ b/engines/buried/graphics.cpp
@@ -214,12 +214,12 @@ Graphics::Surface *GraphicsManager::getBitmap(Common::SeekableReadStream *stream
 	// Convert to the screen format, if required
 	if (decoder.getSurface()->format != g_system->getScreenFormat()) {
 		assert(_vm->isTrueColor());
-		return decoder.getSurface()->convertTo(g_system->getScreenFormat(), decoder.getPalette());
+		return decoder.getSurface()->convertTo(g_system->getScreenFormat(), decoder.getPalette().data(), decoder.getPalette().size());
 	}
 
 	// Remap the palette, if required
-	if (!_vm->isTrueColor() && memcmp(decoder.getPalette() + 3, getDefaultPalette() + 3, 256 - 6) != 0)
-		return remapPalettedFrame(decoder.getSurface(), decoder.getPalette());
+	if (!_vm->isTrueColor() && memcmp(decoder.getPalette().data() + 3, getDefaultPalette() + 3, 256 - 6) != 0)
+		return remapPalettedFrame(decoder.getSurface(), decoder.getPalette().data());
 
 	// Just copy the frame
 	Graphics::Surface *surface = new Graphics::Surface();

--- a/engines/cine/cine.cpp
+++ b/engines/cine/cine.cpp
@@ -299,9 +299,8 @@ void CineEngine::showSplashScreen() {
 	if (surface->w == 640 && surface->h == 480) {
 		initGraphics(640, 480);
 
-		const byte *palette = decoder.getPalette();
-		int paletteColorCount = decoder.getPaletteColorCount();
-		g_system->getPaletteManager()->setPalette(palette, 0, paletteColorCount);
+		const Graphics::Palette &palette = decoder.getPalette();
+		g_system->getPaletteManager()->setPalette(palette.data(), 0, palette.size());
 
 		g_system->copyRectToScreen(surface->getPixels(), 640, 0, 0, 640, 480);
 		g_system->updateScreen();

--- a/engines/cryomni3d/cryomni3d.cpp
+++ b/engines/cryomni3d/cryomni3d.cpp
@@ -191,7 +191,7 @@ bool CryOmni3DEngine::displayHLZ(const Common::Path &filepath, uint32 timeout) {
 	}
 
 	if (imageDecoder->hasPalette()) {
-		setPalette(imageDecoder->getPalette(), 0, imageDecoder->getPaletteColorCount());
+		setPalette(imageDecoder->getPalette().data(), 0, imageDecoder->getPalette().size());
 	}
 
 	const Graphics::Surface *frame = imageDecoder->getSurface();

--- a/engines/cryomni3d/fixed_image.cpp
+++ b/engines/cryomni3d/fixed_image.cpp
@@ -23,6 +23,7 @@
 
 #include "common/file.h"
 #include "common/system.h"
+#include "graphics/palette.h"
 #include "graphics/surface.h"
 #include "image/image_decoder.h"
 
@@ -107,8 +108,8 @@ void ZonFixedImage::load(const Common::Path &image, const char *zone) {
 }
 
 void ZonFixedImage::display() const {
-	_engine.setupPalette(_imageDecoder->getPalette(), 0,
-	                     _imageDecoder->getPaletteColorCount());
+	_engine.setupPalette(_imageDecoder->getPalette().data(), 0,
+	                     _imageDecoder->getPalette().size());
 
 	g_system->copyRectToScreen(_imageSurface->getPixels(), _imageSurface->pitch, 0, 0,
 	                           _imageSurface->w, _imageSurface->h);

--- a/engines/cryomni3d/image/hlz.cpp
+++ b/engines/cryomni3d/image/hlz.cpp
@@ -32,9 +32,7 @@
 
 namespace Image {
 
-HLZFileDecoder::HLZFileDecoder() {
-	_surface = nullptr;
-	_codec = nullptr;
+HLZFileDecoder::HLZFileDecoder() : _codec(nullptr), _surface(nullptr), _palette(256) {
 }
 
 HLZFileDecoder::~HLZFileDecoder() {
@@ -50,7 +48,13 @@ void HLZFileDecoder::destroy() {
 bool HLZFileDecoder::loadStream(Common::SeekableReadStream &stream) {
 	destroy();
 
-	stream.read(_palette, sizeof(_palette));
+	for (uint16 i = 0; i < 256; i++) {
+		byte r = stream.readByte();
+		byte g = stream.readByte();
+		byte b = stream.readByte();
+		_palette.set(i, r, g, b);
+	}
+
 	uint16 width = stream.readUint16LE();
 	uint16 height = stream.readUint16LE();
 

--- a/engines/cryomni3d/image/hlz.h
+++ b/engines/cryomni3d/image/hlz.h
@@ -24,6 +24,7 @@
 
 #include "common/scummsys.h"
 #include "common/str.h"
+#include "graphics/palette.h"
 #include "image/image_decoder.h"
 
 namespace Common {
@@ -46,13 +47,12 @@ public:
 	void destroy() override;
 	bool loadStream(Common::SeekableReadStream &stream) override;
 	const Graphics::Surface *getSurface() const override { return _surface; }
-	const byte *getPalette() const override { return _palette; }
-	uint16 getPaletteColorCount() const override { return 256; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 
 private:
 	HLZDecoder *_codec;
 	const Graphics::Surface *_surface;
-	byte _palette[256 * 3];
+	Graphics::Palette _palette;
 };
 
 } // End of namespace Image

--- a/engines/cryomni3d/versailles/documentation.cpp
+++ b/engines/cryomni3d/versailles/documentation.cpp
@@ -326,8 +326,8 @@ Common::String Versailles_Documentation::docAreaHandleSummary() {
 	// No box for 6
 	boxes.setupBox(7, 0, 480 - _sprites->getCursor(225).getHeight(), 640, 480);
 
-	_engine->setupPalette(imageDecoder->getPalette(), 0,
-	                      imageDecoder->getPaletteColorCount());
+	_engine->setupPalette(imageDecoder->getPalette().data(), 0,
+	                      imageDecoder->getPalette().size());
 
 	_engine->setCursor(181);
 	_engine->showMouse(true);
@@ -445,8 +445,8 @@ Common::String Versailles_Documentation::docAreaHandleTimeline() {
 	_fontManager->setCharSpacing(1);
 	_fontManager->setSurface(&docSurface);
 
-	_engine->setupPalette(imageDecoder->getPalette(), 0,
-	                      imageDecoder->getPaletteColorCount());
+	_engine->setupPalette(imageDecoder->getPalette().data(), 0,
+	                      imageDecoder->getPalette().size());
 
 	_fontManager->displayStr(78, 10, (*_messages)[73]);
 	docSurface.hLine(0, 39, 171, 241); // minus 1 because hLine draws inclusive
@@ -956,8 +956,8 @@ Common::String Versailles_Documentation::docAreaHandleGeneralMap() {
 
 	_fontManager->setSurface(&mapSurface);
 
-	_engine->setupPalette(imageDecoder->getPalette(), 0,
-	                      imageDecoder->getPaletteColorCount());
+	_engine->setupPalette(imageDecoder->getPalette().data(), 0,
+	                      imageDecoder->getPalette().size());
 
 	_engine->setCursor(181);
 	_engine->showMouse(true);
@@ -1178,8 +1178,8 @@ Common::String Versailles_Documentation::docAreaHandleCastleMap() {
 
 	_fontManager->setSurface(&mapSurface);
 
-	_engine->setupPalette(imageDecoder->getPalette(), 0,
-	                      imageDecoder->getPaletteColorCount());
+	_engine->setupPalette(imageDecoder->getPalette().data(), 0,
+	                      imageDecoder->getPalette().size());
 
 	_engine->setCursor(181);
 	_engine->showMouse(true);
@@ -1472,8 +1472,8 @@ void Versailles_Documentation::drawRecordData(Graphics::ManagedSurface &surface,
 	Image::ImageDecoder *imageDecoder = _engine->loadHLZ(backgroundPath);
 	const Graphics::Surface *bgFrame = imageDecoder->getSurface();
 
-	_engine->setupPalette(imageDecoder->getPalette(), 0,
-	                      imageDecoder->getPaletteColorCount());
+	_engine->setupPalette(imageDecoder->getPalette().data(), 0,
+	                      imageDecoder->getPalette().size());
 
 	surface.create(bgFrame->w, bgFrame->h, bgFrame->format);
 	surface.blitFrom(*bgFrame);

--- a/engines/cryomni3d/versailles/engine.cpp
+++ b/engines/cryomni3d/versailles/engine.cpp
@@ -643,9 +643,9 @@ void CryOmni3DEngine_Versailles::loadCursorsPalette() {
 		error("Failed to load BMP file");
 	}
 
-	_cursorPalette = new byte[3 * bmpDecoder.getPaletteColorCount()]();
-	memcpy(_cursorPalette, bmpDecoder.getPalette(),
-	       3 * bmpDecoder.getPaletteColorCount());
+	const Graphics::Palette &palette = bmpDecoder.getPalette();
+	_cursorPalette = new byte[3 * palette.size()]();
+	palette.grab(_cursorPalette, 0, palette.size());
 }
 
 void CryOmni3DEngine_Versailles::setupPalette(const byte *palette, uint start, uint num,
@@ -1208,8 +1208,8 @@ void CryOmni3DEngine_Versailles::doPlaceChange() {
 				_currentPlace->setupWarpConstraints(_omni3dMan);
 				_omni3dMan.setSourceSurface(_currentWarpImage->getSurface());
 
-				setupPalette(_currentWarpImage->getPalette(), 0,
-				             _currentWarpImage->getPaletteColorCount(), !_fadedPalette);
+				setupPalette(_currentWarpImage->getPalette().data(), 0,
+				             _currentWarpImage->getPalette().size(), !_fadedPalette);
 
 				setMousePos(Common::Point(320, 240)); // Center of screen
 
@@ -1647,8 +1647,8 @@ void CryOmni3DEngine_Versailles::animateWarpTransition(const Transition *transit
 }
 
 void CryOmni3DEngine_Versailles::redrawWarp() {
-	setupPalette(_currentWarpImage->getPalette(), 0,
-	             _currentWarpImage->getPaletteColorCount(), true);
+	setupPalette(_currentWarpImage->getPalette().data(), 0,
+	             _currentWarpImage->getPalette().size(), true);
 	if (_forceRedrawWarp) {
 		const Graphics::Surface *result = _omni3dMan.getSurface();
 		g_system->copyRectToScreen(result->getPixels(), result->pitch, 0, 0, result->w, result->h);
@@ -1720,8 +1720,8 @@ void CryOmni3DEngine_Versailles::displayObject(const Common::String &imgName,
 
 	if (imageDecoder->hasPalette()) {
 		// We don't need to calculate transparency but it's simpler to call this function
-		setupPalette(imageDecoder->getPalette(), 0,
-		             imageDecoder->getPaletteColorCount());
+		setupPalette(imageDecoder->getPalette().data(), 0,
+		             imageDecoder->getPalette().size());
 	}
 
 	const Graphics::Surface *image = imageDecoder->getSurface();

--- a/engines/cryomni3d/versailles/menus.cpp
+++ b/engines/cryomni3d/versailles/menus.cpp
@@ -143,8 +143,8 @@ uint CryOmni3DEngine_Versailles::displayOptions() {
 
 	while (!shouldAbort() && !end) {
 		if (resetScreen) {
-			setPalette(imageDecoder->getPalette(), 0,
-			           imageDecoder->getPaletteColorCount());
+			setPalette(imageDecoder->getPalette().data(), 0,
+			           imageDecoder->getPalette().size());
 			// _cursorPalette has only 248 colors as 8 last colors are for translucency
 			setPalette(_cursorPalette + 240 * 3, 240, 8);
 
@@ -1011,8 +1011,7 @@ void CryOmni3DEngine_Versailles::displayCredits() {
 	byte palette[256 * 3];
 	memset(palette, 0, 256 * 3);
 	// getPalette returns the first color not index 0
-	memcpy(palette, imageDecoder->getPalette(),
-	       3 * imageDecoder->getPaletteColorCount());
+	imageDecoder->getPalette().grab(palette, 0, imageDecoder->getPalette().size());
 	copySubPalette(palette, _cursorPalette, 240, 8);
 
 	creditsSurface.create(bgFrame->w, bgFrame->h, bgFrame->format);

--- a/engines/director/castmember/bitmap.cpp
+++ b/engines/director/castmember/bitmap.cpp
@@ -619,7 +619,7 @@ void BitmapCastMember::load() {
 						Common::DumpFile bitmapFile;
 
 						bitmapFile.open(Common::Path(filename), true);
-						Image::writePNG(bitmapFile, *decoder->getSurface(), decoder->getPalette());
+						Image::writePNG(bitmapFile, *decoder->getSurface(), decoder->getPalette().data());
 
 						bitmapFile.close();
 					}
@@ -691,7 +691,7 @@ void BitmapCastMember::load() {
 		Common::DumpFile bitmapFile;
 
 		bitmapFile.open(Common::Path(filename), true);
-		Image::writePNG(bitmapFile, *img->getSurface(), img->getPalette());
+		Image::writePNG(bitmapFile, *img->getSurface(), img->getPalette().data());
 
 		bitmapFile.close();
 	}

--- a/engines/director/images.h
+++ b/engines/director/images.h
@@ -22,6 +22,7 @@
 #ifndef DIRECTOR_IMAGES_H
 #define DIRECTOR_IMAGES_H
 
+#include "graphics/palette.h"
 #include "image/image_decoder.h"
 
 namespace Common {
@@ -48,15 +49,13 @@ public:
 	void destroy() override;
 	bool loadStream(Common::SeekableReadStream &stream) override;
 	const Graphics::Surface *getSurface() const override { return _surface; }
-	const byte *getPalette() const override { return _palette; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 	void loadPalette(Common::SeekableReadStream &stream);
-	uint16 getPaletteColorCount() const override { return _paletteColorCount; }
 
 private:
 	Image::Codec *_codec;
 	const Graphics::Surface *_surface;
-	byte *_palette;
-	uint32 _paletteColorCount;
+	Graphics::Palette _palette;
 	uint16 _bitsPerPixel;
 };
 
@@ -69,14 +68,12 @@ public:
 	void destroy() override;
 	bool loadStream(Common::SeekableReadStream &stream) override;
 	const Graphics::Surface *getSurface() const override { return _surface; }
-	const byte *getPalette() const override { return _palette; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 	void loadPalette(Common::SeekableReadStream &stream);
-	uint16 getPaletteColorCount() const override { return _paletteColorCount; }
 
 private:
 	Graphics::Surface *_surface;
-	const byte *_palette;
-	uint8 _paletteColorCount;
+	Graphics::Palette _palette;
 	uint16 _bitsPerPixel;
 	uint16 _version;
 	uint16 _pitch;

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -2414,7 +2414,7 @@ void LB::b_importFileInto(int nargs) {
 	movie->createOrReplaceCastMember(memberID, bitmapCast);
 	bitmapCast->setModified(true);
 	const Graphics::Surface *surf = img->getSurface();
-	bitmapCast->_size = surf->pitch * surf->h + img->getPaletteColorCount() * 3;
+	bitmapCast->_size = surf->pitch * surf->h + img->getPalette().size() * 3;
 	score->refreshPointersForCastMemberID(dst.asMemberID());
 }
 

--- a/engines/director/picture.cpp
+++ b/engines/director/picture.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "common/textconsole.h"
+#include "graphics/palette.h"
 #include "image/image_decoder.h"
 #include "director/picture.h"
 
@@ -27,7 +28,7 @@ namespace Director {
 
 Picture::Picture(Image::ImageDecoder &img) {
 	_surface.copyFrom(*img.getSurface());
-	copyPalette(img.getPalette(), img.getPaletteColorCount());
+	copyPalette(img.getPalette().data(), img.getPalette().size());
 }
 
 Picture::Picture(Picture &picture) {

--- a/engines/director/tests.cpp
+++ b/engines/director/tests.cpp
@@ -119,7 +119,7 @@ void Window::testFontScaling() {
 		Image::PICTDecoder k;
 		k.loadStream(in);
 
-		Graphics::Surface *res = k.getSurface()->convertTo(_wm->_pixelformat, k.getPalette(), k.getPaletteSize(), _wm->getPalette(), _wm->getPaletteSize(), Graphics::kDitherNaive);
+		Graphics::Surface *res = k.getSurface()->convertTo(_wm->_pixelformat, k.getPalette().data(), k.getPalette().size(), _wm->getPalette(), _wm->getPaletteSize(), Graphics::kDitherNaive);
 		surface.blitFrom(*res, Common::Point(400, 280));
 		delete res;
 

--- a/engines/dreamweb/vgagrafx.cpp
+++ b/engines/dreamweb/vgagrafx.cpp
@@ -171,7 +171,7 @@ void DreamWebEngine::showPCX(const Common::String &suffix) {
 	// Read the 16-color palette into the 'maingamepal' buffer. Note that
 	// the color components have to be adjusted from 8 to 6 bits.
 	memset(_mainPal, 0xff, 256 * 3);
-	memcpy(_mainPal, pcx.getPalette(), 48);
+	memcpy(_mainPal, pcx.getPalette().data(), 48);
 	for (int i = 0; i < 48; i++) {
 		_mainPal[i] >>= 2;
 	}

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -321,7 +321,7 @@ void splashScreen() {
 	screen.free();
 
 	// Draw logo
-	Graphics::Surface *logo = bitmap.getSurface()->convertTo(g_system->getOverlayFormat(), bitmap.getPalette());
+	Graphics::Surface *logo = bitmap.getSurface()->convertTo(g_system->getOverlayFormat(), bitmap.getPalette().data(), bitmap.getPalette().size());
 	if (scaleFactor != 1.0f) {
 		Graphics::Surface *tmp = logo->scale(int16(logo->w * scaleFactor), int16(logo->h * scaleFactor), true);
 		logo->free();

--- a/engines/freescape/doodle.cpp
+++ b/engines/freescape/doodle.cpp
@@ -7,9 +7,7 @@
 
 namespace Image {
 
-DoodleDecoder::DoodleDecoder(const byte *palette) : _surface(nullptr), _palette(nullptr) {
-	// Copy the pointer to the provided palette
-	_palette = palette;
+DoodleDecoder::DoodleDecoder(const byte *palette) : _surface(nullptr), _palette(palette, 16) {
 }
 
 DoodleDecoder::~DoodleDecoder() {

--- a/engines/freescape/doodle.h
+++ b/engines/freescape/doodle.h
@@ -3,6 +3,7 @@
 
 #include "image/image_decoder.h"
 #include "common/stream.h"
+#include "graphics/palette.h"
 #include "graphics/surface.h"
 
 namespace Image {
@@ -20,8 +21,7 @@ public:
 	bool loadStream(Common::SeekableReadStream &stream) override;
 	void destroy() override;
 	const Graphics::Surface *getSurface() const override { return _surface; }
-	const byte *getPalette() const override { return _palette; }
-	uint16 getPaletteColorCount() const override { return 16; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 
 	/**
 	 * Load a C64 doodle image from its component streams
@@ -41,7 +41,7 @@ private:
 	static const int kColorDataSize = 1000;  // 40x25 color cells
 
 	Graphics::Surface *_surface;
-	const byte *_palette;
+	Graphics::Palette _palette;
 
 	/**
 	 * Process an 8x8 cell of the image

--- a/engines/freescape/freescape.cpp
+++ b/engines/freescape/freescape.cpp
@@ -1114,7 +1114,7 @@ byte *FreescapeEngine::getPaletteFromNeoImage(Common::SeekableReadStream *stream
 	Image::NeoDecoder decoder;
 	decoder.loadStream(*stream);
 	byte *palette = (byte *)malloc(16 * 3 * sizeof(byte));
-	memcpy(palette, decoder.getPalette(), 16 * 3 * sizeof(byte));
+	decoder.getPalette().grab(palette, 0, 16);
 	return palette;
 }
 
@@ -1124,7 +1124,7 @@ Graphics::ManagedSurface *FreescapeEngine::loadAndConvertNeoImage(Common::Seekab
 	decoder.loadStream(*stream);
 	Graphics::ManagedSurface *surface = new Graphics::ManagedSurface();
 	surface->copyFrom(*decoder.getSurface());
-	surface->convertToInPlace(_gfx->_currentPixelFormat, decoder.getPalette(), decoder.getPaletteColorCount());
+	surface->convertToInPlace(_gfx->_currentPixelFormat, decoder.getPalette().data(), decoder.getPalette().size());
 	return surface;
 }
 
@@ -1133,7 +1133,7 @@ Graphics::ManagedSurface *FreescapeEngine::loadAndConvertDoodleImage(Common::See
 	decoder.loadStreams(*bitmap, *color1, *color2);
 	Graphics::ManagedSurface *surface = new Graphics::ManagedSurface();
 	surface->copyFrom(*decoder.getSurface());
-	surface->convertToInPlace(_gfx->_currentPixelFormat, decoder.getPalette(), decoder.getPaletteColorCount());
+	surface->convertToInPlace(_gfx->_currentPixelFormat, decoder.getPalette().data(), decoder.getPalette().size());
 	return surface;
 }
 

--- a/engines/glk/debugger.cpp
+++ b/engines/glk/debugger.cpp
@@ -108,7 +108,7 @@ void Debugger::saveRawPicture(const RawDecoder &rd, Common::WriteStream &ws) {
 	uint32 transColor = rd.getTransparentColor();
 
 	// If the image doesn't have a palette, we can directly write out the image
-	if (palette.size() == 0) {
+	if (palette.empty()) {
 		Image::writePNG(ws, *surface);
 		return;
 	}

--- a/engines/glk/debugger.cpp
+++ b/engines/glk/debugger.cpp
@@ -102,14 +102,13 @@ bool Debugger::cmdDumpPic(int argc, const char **argv) {
 void Debugger::saveRawPicture(const RawDecoder &rd, Common::WriteStream &ws) {
 #ifdef USE_PNG
 	const Graphics::Surface *surface = rd.getSurface();
-	const byte *palette = rd.getPalette();
-	int paletteCount = rd.getPaletteColorCount();
+	const Graphics::Palette &palette = rd.getPalette();
 	int palStart = 0;
 	bool hasTransColor = rd.hasTransparentColor();
 	uint32 transColor = rd.getTransparentColor();
 
 	// If the image doesn't have a palette, we can directly write out the image
-	if (!palette) {
+	if (palette.size() == 0) {
 		Image::writePNG(ws, *surface);
 		return;
 	}
@@ -126,9 +125,10 @@ void Debugger::saveRawPicture(const RawDecoder &rd, Common::WriteStream &ws) {
 			if ((hasTransColor && (uint32)*srcP == transColor) || (int)*srcP < palStart) {
 				*destP = format.ARGBToColor(0, 0, 0, 0);
 			} else {
-				assert(*srcP < paletteCount);
-				const byte *palP = &palette[*srcP * 3];
-				*destP = format.ARGBToColor(255, palP[0], palP[1], palP[2]);
+				assert(*srcP < palette.size());
+				byte r, g, b;
+				palette.get(*srcP, r, g, b);
+				*destP = format.ARGBToColor(255, r, g, b);
 			}
 		}
 	}

--- a/engines/glk/picture.cpp
+++ b/engines/glk/picture.cpp
@@ -135,8 +135,8 @@ Picture *Pictures::load(const Common::String &name) {
 		png.setKeepTransparencyPaletted(true);
 		png.loadStream(f);
 		img = png.getSurface();
-		palette = png.getPalette();
-		palCount = png.getPaletteColorCount();
+		palette = png.getPalette().data();
+		palCount = png.getPalette().size();
 		hasTransColor = png.hasTransparentColor();
 		transColor = png.getTransparentColor();
 	} else if (
@@ -152,8 +152,8 @@ Picture *Pictures::load(const Common::String &name) {
 			f.open(Common::Path(Common::String::format("pic%s.raw", name.c_str())))) {
 		raw.loadStream(f);
 		img = raw.getSurface();
-		palette = raw.getPalette();
-		palCount = raw.getPaletteColorCount();
+		palette = raw.getPalette().data();
+		palCount = raw.getPalette().size();
 		hasTransColor = raw.hasTransparentColor();
 		transColor = raw.getTransparentColor();
 	} else if (f.open(Common::Path(Common::String::format("pic%s.rect", name.c_str())))) {

--- a/engines/glk/raw_decoder.h
+++ b/engines/glk/raw_decoder.h
@@ -22,6 +22,7 @@
 #ifndef GLK_RAW_DECODER_H
 #define GLK_RAW_DECODER_H
 
+#include "graphics/palette.h"
 #include "graphics/surface.h"
 #include "image/image_decoder.h"
 
@@ -42,8 +43,7 @@ namespace Glk {
 class RawDecoder : public Image::ImageDecoder {
 private:
 	Graphics::Surface _surface;
-	byte *_palette;
-	uint16 _paletteColorCount;
+	Graphics::Palette _palette;
 	uint32 _transColor;
 public:
 	RawDecoder();
@@ -52,8 +52,7 @@ public:
 	bool loadStream(Common::SeekableReadStream &stream) override;
 	void destroy() override;
 	const Graphics::Surface *getSurface() const override { return &_surface; }
-	const byte *getPalette() const override { return _palette; }
-	uint16 getPaletteColorCount() const override { return _paletteColorCount; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 	bool hasTransparentColor() const override { return true; }
 	uint32 getTransparentColor() const override { return _transColor; }
 };

--- a/engines/gob/inter_v7.cpp
+++ b/engines/gob/inter_v7.cpp
@@ -931,12 +931,12 @@ void Inter_v7::o7_loadIFFPalette() {
 
 	Image::IFFDecoder decoder;
 	decoder.loadStream(*iffFile);
-	if (!decoder.getPalette() || decoder.getPaletteColorCount() != 256) {
+	if (decoder.getPalette().size() != 256) {
 		warning("o7_loadIFFPalette(): Failed reading palette from IFF \"%s\"", file.c_str());
 		return;
 	}
 
-	const byte *palette = decoder.getPalette();
+	const byte *palette = decoder.getPalette().data();
 
 	startIndex *= 3;
 	stopIndex  *= 3;

--- a/engines/grim/material.cpp
+++ b/engines/grim/material.cpp
@@ -81,8 +81,8 @@ static void loadImage(Image::ImageDecoder *decoder, Texture *t) {
 	if (decoder->hasPalette()) {
 		uint32 map[256];
 		Graphics::convertPaletteToMap(map,
-		                              decoder->getPalette(),
-		                              decoder->getPaletteColorCount(),
+		                              decoder->getPalette().data(),
+		                              decoder->getPalette().size(),
 		                              format_3bpp);
 		Graphics::crossBlitMap(t->_data, (const byte *)surface->getPixels(),
 		                       t->_width * t->_bpp, surface->pitch,

--- a/engines/hopkins/graphics.cpp
+++ b/engines/hopkins/graphics.cpp
@@ -327,7 +327,7 @@ void GraphicsManager::loadPCX640(byte *surface, const Common::Path &file, byte *
 	Common::copy((const byte *)s->getPixels(), (const byte *)s->getBasePtr(0, s->h), surface);
 
 	// Copy out the palette
-	const byte *palSrc = pcxDecoder.getPalette();
+	const byte *palSrc = pcxDecoder.getPalette().data();
 	Common::copy((const byte *)palSrc, (const byte *)palSrc + PALETTE_BLOCK_SIZE, palette);
 
 	f.close();

--- a/engines/kingdom/kingdom.cpp
+++ b/engines/kingdom/kingdom.cpp
@@ -418,8 +418,8 @@ void KingdomGame::showPic(int reznum) {
 
 	delete stream;
 
-	const byte *palette = decoder.getPalette();
-	int paletteColorCount = decoder.getPaletteColorCount();
+	const byte *palette = decoder.getPalette().data();
+	int paletteColorCount = decoder.getPalette().size();
 	g_system->getPaletteManager()->setPalette(palette, 0, paletteColorCount);
 
 	const Graphics::Surface *surface = decoder.getSurface();

--- a/engines/mm/mm1/gfx/screen_decoder.h
+++ b/engines/mm/mm1/gfx/screen_decoder.h
@@ -24,6 +24,7 @@
 
 #include "image/image_decoder.h"
 #include "graphics/managed_surface.h"
+#include "graphics/palette.h"
 
 namespace MM {
 namespace MM1 {
@@ -32,10 +33,11 @@ namespace Gfx {
 class ScreenDecoder : public Image::ImageDecoder {
 private:
 	Graphics::Surface _surface;
+	Graphics::Palette _palette;
 public:
 	byte _indexes[4] = { 0 };		// EGA palete indexes used
 public:
-	ScreenDecoder() {}
+	ScreenDecoder() : _palette(0) {}
 	~ScreenDecoder() override;
 
 	void destroy() override;
@@ -49,8 +51,7 @@ public:
 	const Graphics::Surface *getSurface() const override {
 		return &_surface;
 	}
-	const byte *getPalette() const override { return nullptr; }
-	uint16 getPaletteColorCount() const override { return 0; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 	void clear() { _surface.free(); }
 };
 

--- a/engines/mohawk/bitmap.cpp
+++ b/engines/mohawk/bitmap.cpp
@@ -669,7 +669,7 @@ MohawkSurface *MystBitmap::decodeImage(Common::SeekableReadStream *stream) {
 	byte *newPal = nullptr;
 
 	if (bitmapDecoder.hasPalette()) {
-		const byte *palette = bitmapDecoder.getPalette();
+		const byte *palette = bitmapDecoder.getPalette().data();
 		newPal = (byte *)malloc(256 * 3);
 		memcpy(newPal, palette, 256 * 3);
 	}

--- a/engines/mtropolis/plugin/standard.cpp
+++ b/engines/mtropolis/plugin/standard.cpp
@@ -1575,7 +1575,7 @@ bool PrintModifierImageSupplier::loadImageSlot(uint slot, const Graphics::Surfac
 	outHasPalette = _decoder->hasPalette();
 
 	if (_decoder->hasPalette())
-		outPalette.set(_decoder->getPalette(), 0, _decoder->getPaletteColorCount());
+		outPalette.set(_decoder->getPalette(), 0, _decoder->getPalette().size());
 
 	outMetadata = GUI::ImageAlbumImageMetadata();
 	outMetadata._orientation = GUI::kImageAlbumImageOrientationLandscape;

--- a/engines/nancy/graphics.cpp
+++ b/engines/nancy/graphics.cpp
@@ -219,7 +219,7 @@ void GraphicsManager::loadSurfacePalette(Graphics::ManagedSurface &inSurf, const
 	if (f.open(paletteFilename.append(".bmp"))) {
 		Image::BitmapDecoder dec;
 		if (dec.loadStream(f)) {
-			inSurf.setPalette(dec.getPalette(), paletteStart, paletteSize);
+			inSurf.setPalette(dec.getPalette().data(), paletteStart, paletteSize);
 		}
 	}
 }

--- a/engines/nancy/resource.cpp
+++ b/engines/nancy/resource.cpp
@@ -77,7 +77,7 @@ bool ResourceManager::loadImage(const Common::Path &name, Graphics::ManagedSurfa
 			Image::BitmapDecoder bmpDec;
 			bmpDec.loadStream(*stream);
 			surf.copyFrom(*bmpDec.getSurface());
-			surf.setPalette(bmpDec.getPalette(), 0, MIN<uint>(256, bmpDec.getPaletteColorCount())); // LOGO.BMP reports 257 colors
+			surf.setPalette(bmpDec.getPalette().data(), 0, MIN<uint>(256, bmpDec.getPalette().size())); // LOGO.BMP reports 257 colors
 		}
 	}
 

--- a/engines/parallaction/disk_br.cpp
+++ b/engines/parallaction/disk_br.cpp
@@ -490,7 +490,7 @@ void AmigaDisk_br::loadBackground(BackgroundInfo& info, const char *filename) {
 	info.height = info.bg.h;
 
 	// Overwrite the first color (transparent key) in the palette
-	p = decoder.getPalette();
+	p = decoder.getPalette().data();
 	info.palette.setEntry(0, p[0] >> 2, p[1] >> 2, p[2] >> 0);
 
 	for (i = 16; i < 32; i++) {

--- a/engines/parallaction/disk_ns.cpp
+++ b/engines/parallaction/disk_ns.cpp
@@ -763,15 +763,11 @@ void AmigaDisk_ns::loadBackground(BackgroundInfo& info, const char *name) {
 	info.width = info.bg.w;
 	info.height = info.bg.h;
 
-	const byte *p = decoder.getPalette();
+	const Graphics::Palette &p = decoder.getPalette();
 	for (uint i = 0; i < 32; i++) {
-		byte r = *p >> 2;
-		p++;
-		byte g = *p >> 2;
-		p++;
-		byte b = *p >> 2;
-		p++;
-		info.palette.setEntry(i, r, g, b);
+		byte r, g, b;
+		p.get(i, r, g, b);
+		info.palette.setEntry(i, r >> 2, g >> 2, b >> 2);
 	}
 
 	const Common::Array<Image::IFFDecoder::PaletteRange> &paletteRanges = decoder.getPaletteRanges();
@@ -803,12 +799,10 @@ void AmigaDisk_ns::loadMask_internal(BackgroundInfo& info, const char *name) {
 	decoder.setPixelPacking(true); // pack 4 2bit pixels into 1 byte
 	decoder.loadStream(*s);
 
-	const byte *p = decoder.getPalette();
-	byte r, g, b;
+	const Graphics::Palette &p = decoder.getPalette();
 	for (uint i = 0; i < 4; i++) {
-		r = p[i*3];
-		g = p[i*3+1];
-		b = p[i*3+2];
+		byte r, g, b;
+		p.get(i, r, g, b);
 		info.layers[i] = (((r << 4) & 0xF00) | (g & 0xF0) | (b >> 4)) & 0xFF;
 	}
 

--- a/engines/pegasus/cursor.cpp
+++ b/engines/pegasus/cursor.cpp
@@ -160,7 +160,7 @@ void Cursor::loadCursorImage(CursorInfo &cursorInfo) {
 		if (!cicn.loadStream(*cicnStream))
 			error("Failed to decode cursor cicn %d", cursorInfo.tag);
 
-		cursorInfo.surface = cicn.getSurface()->convertTo(g_system->getScreenFormat(), cicn.getPalette(), cicn.getPaletteColorCount());
+		cursorInfo.surface = cicn.getSurface()->convertTo(g_system->getScreenFormat(), cicn.getPalette().data(), cicn.getPalette().size());
 		delete cicnStream;
 		return;
 	}

--- a/engines/pegasus/surface.cpp
+++ b/engines/pegasus/surface.cpp
@@ -105,7 +105,7 @@ bool Surface::getImageFromPICTStream(Common::SeekableReadStream *stream) {
 	if (!pict.loadStream(*stream))
 		return false;
 
-	_surface = pict.getSurface()->convertTo(g_system->getScreenFormat(), pict.getPalette());
+	_surface = pict.getSurface()->convertTo(g_system->getScreenFormat(), pict.getPalette().data(), pict.getPalette().size());
 	_ownsSurface = true;
 	_bounds = Common::Rect(0, 0, _surface->w, _surface->h);
 	return true;

--- a/engines/petka/q_manager.cpp
+++ b/engines/petka/q_manager.cpp
@@ -186,7 +186,7 @@ Graphics::Surface *QManager::loadBitmapSurface(Common::SeekableReadStream &strea
 		Image::BitmapDecoder decoder;
 		if (!decoder.loadStream(stream))
 			return nullptr;
-		return decoder.getSurface()->convertTo(g_system->getScreenFormat(), decoder.getPalette());
+		return decoder.getSurface()->convertTo(g_system->getScreenFormat(), decoder.getPalette().data(), decoder.getPalette().size());
 	}
 	else if (bitsPerPixel == 1) {
 		Graphics::Surface *s = new Graphics::Surface;
@@ -218,7 +218,7 @@ Graphics::Surface *QManager::loadBitmapSurface(Common::SeekableReadStream &strea
 	if (!decoder.loadStream(convBmpStream))
 		return nullptr;
 
-	return decoder.getSurface()->convertTo(g_system->getScreenFormat(), decoder.getPalette());
+	return decoder.getSurface()->convertTo(g_system->getScreenFormat(), decoder.getPalette().data(), decoder.getPalette().size());
 }
 
 QManager::QResource::~QResource() {

--- a/engines/plumbers/plumbers.cpp
+++ b/engines/plumbers/plumbers.cpp
@@ -267,8 +267,8 @@ void PlumbersGame::drawScreen() {
 			_showScoreFl = false;
 		}
 
-		if (_image->getPalette() != nullptr)
-			g_system->getPaletteManager()->setPalette(_image->getPalette(), 0, 256);
+		if (_image->hasPalette())
+			g_system->getPaletteManager()->setPalette(_image->getPalette().data(), 0, _image->getPalette().size());
 		g_system->updateScreen();
 	}
 }

--- a/engines/plumbers/windows.cpp
+++ b/engines/plumbers/windows.cpp
@@ -55,7 +55,7 @@ void PlumbersGameWindows::loadImage(const Common::String &name) {
 		_compositeSurface = new Graphics::Surface();
 		const Graphics::Surface *inSurf = _image->getSurface();
 		_compositeSurface->create(_screenW, _screenH, inSurf->format);
-		Graphics::downscaleSurfaceByHalf(_compositeSurface, inSurf, _image->getPalette());
+		Graphics::downscaleSurfaceByHalf(_compositeSurface, inSurf, _image->getPalette().data());
 	}
 }
 

--- a/engines/prince/cursor.cpp
+++ b/engines/prince/cursor.cpp
@@ -85,7 +85,7 @@ void PrinceEngine::changeCursor(uint16 curId) {
 		break;
 	}
 
-	CursorMan.replaceCursorPalette(_roomBmp->getPalette(), 0, 255);
+	CursorMan.replaceCursorPalette(_roomBmp->getPalette().data(), 0, 255);
 	CursorMan.replaceCursor(
 		curSurface->getBasePtr(0, 0),
 		curSurface->w, curSurface->h,

--- a/engines/prince/graphics.cpp
+++ b/engines/prince/graphics.cpp
@@ -373,7 +373,7 @@ byte GraphicsMan::getBlendTableColor(byte pixelColor, byte backgroundPixelColor,
 	if (blendTable[pixelColor] != 255) {
 		currColor = blendTable[pixelColor];
 	} else {
-		const byte *originalPalette = _vm->_roomBmp->getPalette();
+		const byte *originalPalette = _vm->_roomBmp->getPalette().data();
 
 		int redFirstOrg = originalPalette[pixelColor * 3] * _vm->_mst_shadow / 256;
 		redFirstOrg = CLIP(redFirstOrg, 0, 255);
@@ -434,7 +434,7 @@ byte GraphicsMan::getBlendTableColor(byte pixelColor, byte backgroundPixelColor,
 
 void GraphicsMan::makeShadowTable(int brightness, byte *shadowPalette) {
 	int shadow =  brightness * 256 / 100;
-	const byte *originalPalette = _vm->_roomBmp->getPalette();
+	const byte *originalPalette = _vm->_roomBmp->getPalette().data();
 
 	for (int i = 0; i < 256; i++) {
 		int redFirstOrg = originalPalette[3 * i] * shadow / 256;

--- a/engines/prince/mhwanh.cpp
+++ b/engines/prince/mhwanh.cpp
@@ -27,7 +27,7 @@
 
 namespace Prince {
 
-MhwanhDecoder::MhwanhDecoder() : _surface(nullptr), _palette(nullptr) {
+MhwanhDecoder::MhwanhDecoder() : _surface(nullptr), _palette(0) {
 }
 
 MhwanhDecoder::~MhwanhDecoder() {
@@ -40,10 +40,7 @@ void MhwanhDecoder::destroy() {
 		delete _surface;
 		_surface = nullptr;
 	}
-	if (_palette != nullptr) {
-		free(_palette);
-		_palette = nullptr;
-	}
+	_palette.clear();
 }
 
 bool MhwanhDecoder::loadStream(Common::SeekableReadStream &stream) {
@@ -51,11 +48,12 @@ bool MhwanhDecoder::loadStream(Common::SeekableReadStream &stream) {
 	stream.seek(0);
 	stream.skip(0x20);
 	// Read the palette
-	_palette = (byte *)malloc(kPaletteColorCount * 3);
+	_palette.resize(kPaletteColorCount, false);
 	for (uint16 i = 0; i < kPaletteColorCount; i++) {
-		_palette[i * 3] = stream.readByte();
-		_palette[i * 3 + 1] = stream.readByte();
-		_palette[i * 3 + 2] = stream.readByte();
+		byte r = stream.readByte();
+		byte g = stream.readByte();
+		byte b = stream.readByte();
+		_palette.set(i, r, g, b);
 	}
 
 	_surface = new Graphics::Surface();

--- a/engines/prince/mhwanh.h
+++ b/engines/prince/mhwanh.h
@@ -40,13 +40,13 @@ public:
 	void destroy() override;
 	bool loadStream(Common::SeekableReadStream &stream) override;
 	Graphics::Surface *getSurface() const override { return _surface; }
-	const byte *getPalette() const override { return _palette; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 	uint16 getPaletteCount() const { return kPaletteColorCount; }
 	static const uint16 kPaletteColorCount = 256;
 
 private:
 	Graphics::Surface *_surface;
-	byte *_palette;
+	Graphics::Palette _palette;
 };
 
 } // End of namespace Prince

--- a/engines/prince/prince.cpp
+++ b/engines/prince/prince.cpp
@@ -403,7 +403,7 @@ void PrinceEngine::showLogo() {
 		_graph->draw(_graph->_frontScreen, logo.getSurface());
 		_graph->change();
 		_graph->update(_graph->_frontScreen);
-		setPalette(logo.getPalette());
+		setPalette(logo.getPalette().data());
 
 		uint32 logoStart = _system->getMillis();
 		while (_system->getMillis() < logoStart + 5000) {

--- a/engines/prince/script.cpp
+++ b/engines/prince/script.cpp
@@ -602,7 +602,7 @@ void Interpreter::O_BLACKPALETTE() {
 
 void Interpreter::O_SETUPPALETTE() {
 	debugInterpreter("O_SETUPPALETTE");
-	_vm->setPalette(_vm->_roomBmp->getPalette());
+	_vm->setPalette(_vm->_roomBmp->getPalette().data());
 }
 
 void Interpreter::O_INITROOM() {

--- a/engines/private/private.cpp
+++ b/engines/private/private.cpp
@@ -1497,10 +1497,10 @@ Graphics::Surface *PrivateEngine::decodeImage(const Common::String &name, byte *
 	const Graphics::Surface *oldImage = _image->getSurface();
 	Graphics::Surface *newImage;
 
-	const byte *oldPalette = _image->getPalette();
+	const byte *oldPalette = _image->getPalette().data();
 	byte *currentPalette;
 
-	uint16 ncolors = _image->getPaletteColorCount();
+	uint16 ncolors = _image->getPalette().size();
 	if (ncolors < 256 || path.toString('/').hasPrefix("intro")) { // For some reason, requires color remapping
 		currentPalette = (byte *) malloc(3*256);
 		drawScreen();

--- a/engines/qdengine/qdcore/util/splash_screen.cpp
+++ b/engines/qdengine/qdcore/util/splash_screen.cpp
@@ -47,10 +47,10 @@ bool SplashScreen::create(int bitmapResID) {
 		if (stream && decoder.loadStream(*stream)) {
 			_splash = new Graphics::Surface();
 			_splash->copyFrom(*decoder.getSurface());
-			_paletteCount = decoder.getPaletteColorCount();
+			_paletteCount = decoder.getPalette().size();
 			_palette = new byte[_paletteCount * 3];
 
-			memcpy(_palette, decoder.getPalette(), _paletteCount * 3);
+			memcpy(_palette, decoder.getPalette().data(), _paletteCount * 3);
 		}
 	} else {
 		warning("SplashScreen::create(): Cannot load splash screen from file %s", g_engine->getExeName());

--- a/engines/queen/display.cpp
+++ b/engines/queen/display.cpp
@@ -827,7 +827,7 @@ void Display::decodePCX(const uint8 *src, uint32 srcSize, uint8 *dst, uint16 dst
 	*h = pcxSurface->h;
 
 	assert(palStart <= palEnd && palEnd <= 256);
-	memcpy(pal, pcx.getPalette() + palStart * 3, (palEnd - palStart) * 3);
+	memcpy(pal, pcx.getPalette().data() + palStart * 3, (palEnd - palStart) * 3);
 	for (uint16 y = 0; y < pcxSurface->h; y++)
 		memcpy(dst + y * dstPitch, pcxSurface->getBasePtr(0, y), pcxSurface->w);
 }
@@ -844,7 +844,7 @@ void Display::decodeIFF(const uint8 *src, uint32 srcSize, uint8 *dst, uint16 dst
 	*h	= iffSurface->h;
 
 	assert(palStart <= palEnd && palEnd <= 256);
-	memcpy(pal, iff.getPalette() + palStart * 3, (palEnd - palStart) * 3);
+	memcpy(pal, iff.getPalette().data() + palStart * 3, (palEnd - palStart) * 3);
 	for (uint16 y = 0; y < iffSurface->h; y++)
 		for(uint16 x = 0; x < iffSurface->w; x++)
 			dst[(y * dstPitch) + x] = *(const byte *)iffSurface->getBasePtr(x, y) + colorBase;

--- a/engines/saga/scene.cpp
+++ b/engines/saga/scene.cpp
@@ -434,7 +434,6 @@ void Scene::changeScene(int16 sceneNumber, int actorsEntrance, SceneTransitionTy
 	if (_vm->_hasITESceneSubstitutes) {
 		for (int i = 0; i < ARRAYSIZE(sceneSubstitutes); i++) {
 			if (sceneSubstitutes[i].sceneId == sceneNumber) {
-				const byte *pal;
 				Common::File file;
 				Rect rect;
 				PalEntry cPal[PAL_ENTRIES];
@@ -444,14 +443,12 @@ void Scene::changeScene(int16 sceneNumber, int actorsEntrance, SceneTransitionTy
 				if (file.open(sceneSubstitutes[i].image)) {
 					Image::IFFDecoder decoder;
 					decoder.loadStream(file);
-					pal = decoder.getPalette();
+					const Graphics::Palette &pal = decoder.getPalette();
 					rect.setWidth(decoder.getSurface()->w);
 					rect.setHeight(decoder.getSurface()->h);
 					_vm->_gfx->drawRegion(rect, (const byte *)decoder.getSurface()->getPixels());
 					for (int j = 0; j < PAL_ENTRIES; j++) {
-						cPal[j].red = *pal++;
-						cPal[j].green = *pal++;
-						cPal[j].blue = *pal++;
+						pal.get(j, cPal[j].red, cPal[j].green, cPal[j].blue);
 					}
 					_vm->_gfx->setPalette(cPal);
 

--- a/engines/sci/graphics/maciconbar.cpp
+++ b/engines/sci/graphics/maciconbar.cpp
@@ -263,7 +263,7 @@ Graphics::Surface *GfxMacIconBar::loadPict(ResourceId id) {
 
 	Graphics::Surface *surface = new Graphics::Surface();
 	surface->copyFrom(*pictDecoder.getSurface());
-	remapColors(surface, pictDecoder.getPalette());
+	remapColors(surface, pictDecoder.getPalette().data());
 
 	return surface;
 }

--- a/engines/scumm/macgui/macgui_impl.cpp
+++ b/engines/scumm/macgui/macgui_impl.cpp
@@ -628,9 +628,9 @@ bool MacGuiImpl::loadIcon(int id, Graphics::Surface **icon, Graphics::Surface **
 		result = true;
 		const Graphics::Surface *s1 = iconDecoder.getSurface();
 		const Graphics::Surface *s2 = iconDecoder.getMask();
-		const byte *palette = iconDecoder.getPalette();
+		const Graphics::Palette &palette = iconDecoder.getPalette();
 
-		*icon = createRemappedSurface(s1, palette, iconDecoder.getPaletteColorCount());
+		*icon = createRemappedSurface(s1, palette.data(), palette.size());
 		*mask = new Graphics::Surface();
 		(*mask)->copyFrom(*s2);
 	}
@@ -657,9 +657,9 @@ Graphics::Surface *MacGuiImpl::loadPict(int id) {
 
 	if (res && pictDecoder.loadStream(*res)) {
 		const Graphics::Surface *surface = pictDecoder.getSurface();
-		const byte *palette = pictDecoder.getPalette();
+		const Graphics::Palette &palette = pictDecoder.getPalette();
 
-		s = createRemappedSurface(surface, palette, pictDecoder.getPaletteColorCount());
+		s = createRemappedSurface(surface, palette.data(), palette.size());
 	}
 
 	delete res;
@@ -815,9 +815,6 @@ MacGuiImpl::MacDialogWindow *MacGuiImpl::createDialog(int dialogId, Common::Rect
 			Image::PICTDecoder pictDecoder;
 			Image::CicnDecoder iconDecoder;
 
-			const byte *palette = nullptr;
-			int paletteColorCount = 0;
-
 			Common::SeekableReadStream *imageRes = nullptr;
 			Image::ImageDecoder *decoder = nullptr;
 
@@ -838,10 +835,11 @@ MacGuiImpl::MacDialogWindow *MacGuiImpl::createDialog(int dialogId, Common::Rect
 			}
 
 			if (imageRes && decoder->loadStream(*imageRes)) {
-				palette = decoder->getPalette();
-				paletteColorCount = decoder->getPaletteColorCount();
-				for (int j = 0; j < paletteColorCount; j++) {
-					uint32 color = (palette[3 * j] << 16) | (palette[3 * j + 1] << 8) | palette[3 * j + 2];
+				const Graphics::Palette &palette = decoder->getPalette();
+				for (uint j = 0; j < palette.size(); j++) {
+					byte r, g, b;
+					palette.get(j, r, g, b);
+					uint32 color = (r << 16) | (g << 8) | b;
 					if (!paletteMap.contains(color))
 						paletteMap[color] = numWindowColors++;
 				}

--- a/engines/sludge/hsi.cpp
+++ b/engines/sludge/hsi.cpp
@@ -29,7 +29,7 @@
 
 namespace Sludge {
 
-HSIDecoder::HSIDecoder() : _surface(nullptr), _reserve(-1) {
+HSIDecoder::HSIDecoder() : _surface(nullptr), _palette(0), _reserve(-1) {
 }
 
 HSIDecoder::~HSIDecoder() {

--- a/engines/sludge/hsi.h
+++ b/engines/sludge/hsi.h
@@ -21,6 +21,7 @@
 #ifndef SLUDGE_HSI_H
 #define SLUDGE_HSI_H
 
+#include "graphics/palette.h"
 #include "image/image_decoder.h"
 
 namespace Sludge {
@@ -34,10 +35,12 @@ public:
 	void destroy() override;
 	bool loadStream(Common::SeekableReadStream &stream) override;
 	Graphics::Surface *getSurface() const override { return _surface; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 	void setReserve(bool reserve) { _reserve = reserve; }
 
 private:
 	Graphics::Surface *_surface;
+	Graphics::Palette _palette;
 	int _reserve;
 };
 

--- a/engines/sludge/imgloader.cpp
+++ b/engines/sludge/imgloader.cpp
@@ -91,7 +91,7 @@ bool ImgLoader::loadPNGImage(Common::SeekableReadStream *stream, Graphics::Surfa
 	}
 
 	const Graphics::Surface *sourceSurface = png.getSurface();
-	Graphics::Surface *pngSurface = sourceSurface->convertTo(*g_sludge->getScreenPixelFormat(), png.getPalette());
+	Graphics::Surface *pngSurface = sourceSurface->convertTo(*g_sludge->getScreenPixelFormat(), png.getPalette().data(), png.getPalette().size());
 	dest->copyFrom(*pngSurface);
 	pngSurface->free();
 	delete pngSurface;

--- a/engines/stark/ui/dialogbox.cpp
+++ b/engines/stark/ui/dialogbox.cpp
@@ -254,7 +254,7 @@ Gfx::Bitmap *DialogBox::loadBackground(Gfx::Driver *gfx) {
 
 	delete[] bitmapWithHeader;
 
-	return gfx->createBitmap(decoder.getSurface(), decoder.getPalette());
+	return gfx->createBitmap(decoder.getSurface(), decoder.getPalette().data());
 }
 
 void DialogBox::onRender() {

--- a/engines/stark/visual/image.cpp
+++ b/engines/stark/visual/image.cpp
@@ -81,7 +81,7 @@ bool VisualImageXMG::loadPNG(Common::SeekableReadStream *stream) {
 		return false;
 	}
 
-	if (pngDecoder.getPalette()) {
+	if (pngDecoder.hasPalette()) {
 		warning("Indexed colors PNG images are not supported");
 		return false;
 	}

--- a/engines/supernova/graphics.h
+++ b/engines/supernova/graphics.h
@@ -23,6 +23,7 @@
 #define SUPERNOVA_GRAPHICS_H
 
 #include "common/scummsys.h"
+#include "graphics/palette.h"
 #include "image/image_decoder.h"
 #include "supernova/supernova.h"
 
@@ -45,7 +46,7 @@ public:
 	void destroy() override;
 	bool loadStream(Common::SeekableReadStream &stream) override;
 	const Graphics::Surface *getSurface() const override { return _sectionSurfaces[0]; }
-	const byte *getPalette() const override { return _palette; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 
 	bool init(int filenumber);
 
@@ -58,7 +59,7 @@ public:
 	int _numSections;
 	int _numClickFields;
 	Common::Array<Graphics::Surface *> _sectionSurfaces;
-	byte *_palette;
+	Graphics::Palette _palette;
 	byte *_encodedImage;
 
 	struct Section {

--- a/engines/supernova/screen.cpp
+++ b/engines/supernova/screen.cpp
@@ -450,7 +450,7 @@ void Screen::renderImage(int section) {
 
 bool Screen::setCurrentImage(int filenumber) {
 	_currentImage = _resMan->getImage(filenumber);
-	_vm->_system->getPaletteManager()->setPalette(_currentImage->getPalette(), 16, 239);
+	_vm->_system->getPaletteManager()->setPalette(_currentImage->getPalette().data(), 16, 239);
 	paletteBrightness();
 
 	return true;
@@ -638,8 +638,8 @@ void Screen::paletteBrightness() {
 	}
 	for (uint i = 0; i < 717; ++i) {
 		const byte *imagePalette;
-		if (_currentImage && _currentImage->getPalette()) {
-			imagePalette = _currentImage->getPalette();
+		if (_currentImage && _currentImage->hasPalette()) {
+			imagePalette = _currentImage->getPalette().data();
 		} else {
 			imagePalette = palette + 48;
 		}

--- a/engines/sword25/gfx/image/imgloader.cpp
+++ b/engines/sword25/gfx/image/imgloader.cpp
@@ -46,7 +46,7 @@ bool ImgLoader::decodePNGImage(const byte *fileDataPtr, uint fileSize, Graphics:
 		error("Error while reading PNG image");
 
 	const Graphics::Surface *sourceSurface = png.getSurface();
-	Graphics::Surface *pngSurface = sourceSurface->convertTo(Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0), png.getPalette(), png.getPaletteColorCount());
+	Graphics::Surface *pngSurface = sourceSurface->convertTo(Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0), png.getPalette().data(), png.getPalette().size());
 
 	dest->copyFrom(*pngSurface);
 

--- a/engines/testbed/image.cpp
+++ b/engines/testbed/image.cpp
@@ -319,9 +319,8 @@ bool ImageTests::testImageDecoder(Common::Path &filepath, Image::ImageDecoder &d
 	g_system->endGFXTransaction();
 
 	Graphics::Screen screen;
-	if (decoder.getPaletteColorCount() > 0) {
-		Graphics::Palette palette(decoder.getPalette(), decoder.getPaletteColorCount());
-		screen.simpleBlitFrom(*pSurface, &palette);
+	if (decoder.hasPalette()) {
+		screen.simpleBlitFrom(*pSurface, &decoder.getPalette());
 	} else {
 		screen.simpleBlitFrom(*pSurface);
 	}

--- a/engines/testbed/misc.cpp
+++ b/engines/testbed/misc.cpp
@@ -246,7 +246,7 @@ bool ImageAlbumImageSupplier::loadImageSlot(uint slot, const Graphics::Surface *
 	outSurface = fi._decoder->getSurface();
 	outHasPalette = fi._decoder->hasPalette();
 	if (fi._decoder->hasPalette())
-		outPalette.set(fi._decoder->getPalette(), 0, fi._decoder->getPaletteColorCount());
+		outPalette.set(fi._decoder->getPalette(), 0, fi._decoder->getPalette().size());
 	outMetadata = GUI::ImageAlbumImageMetadata();
 
 	return true;

--- a/engines/titanic/support/image.cpp
+++ b/engines/titanic/support/image.cpp
@@ -43,8 +43,8 @@ void Image::loadBitmap(Common::SeekableReadStream &s) {
 		blitFrom(*src);
 	} else {
 		// Convert the loaded surface to the screen surface format
-		const byte *palette = decoder.getPalette();
-		Graphics::Surface *surface = src->convertTo(scrFormat, palette);
+		const Graphics::Palette &palette = decoder.getPalette();
+		Graphics::Surface *surface = src->convertTo(scrFormat, palette.data(), palette.size());
 		create(surface->w, surface->h, scrFormat);
 		blitFrom(*surface);
 

--- a/engines/tucker/resource.cpp
+++ b/engines/tucker/resource.cpp
@@ -323,7 +323,7 @@ void TuckerEngine::loadImage(const char *fname, uint8 *dst, int type) {
 		memcpy(dst + y * 320, pcxSurface->getBasePtr(0, y), pcxSurface->w);
 
 	if (type != 0) {
-		memcpy(_currentPalette, pcx.getPalette(), 3 * 256);
+		pcx.getPalette().grab(_currentPalette, 0, pcx.getPalette().size());
 		setBlackPalette();
 	}
 }

--- a/engines/twine/movies.cpp
+++ b/engines/twine/movies.cpp
@@ -311,7 +311,7 @@ void Movies::prepareGIF(int index) {
 		return;
 	}
 	const Graphics::Surface *surface = decoder.getSurface();
-	_engine->setPalette(0, decoder.getPaletteColorCount(), decoder.getPalette());
+	_engine->setPalette(0, decoder.getPalette().size(), decoder.getPalette().data());
 	Graphics::ManagedSurface& target = _engine->_frontVideoBuffer;
 	const Common::Rect surfaceBounds(0, 0, surface->w, surface->h);
 	target.blitFrom(*surface, surfaceBounds, target.getBounds());

--- a/engines/twine/renderer/screens.cpp
+++ b/engines/twine/renderer/screens.cpp
@@ -124,7 +124,7 @@ static bool loadImageDelayViaDecoder(TwinEEngine *engine, const Common::Path &fi
 	}
 	Graphics::ManagedSurface &target = engine->_frontVideoBuffer;
 	Common::Rect rect(src->w, src->h);
-	if (decoder.getPaletteColorCount() == 0) {
+	if (!decoder.hasPalette()) {
 		uint8 pal[Graphics::PALETTE_SIZE];
 		engine->_frontVideoBuffer.getPalette(pal, 0, 256);
 		Graphics::Surface *source = decoder.getSurface()->convertTo(target.format, nullptr, 0, pal, 256);
@@ -132,7 +132,7 @@ static bool loadImageDelayViaDecoder(TwinEEngine *engine, const Common::Path &fi
 		source->free();
 		delete source;
 	} else {
-		engine->setPalette(0, decoder.getPaletteColorCount(), decoder.getPalette());
+		engine->setPalette(0, decoder.getPalette().size(), decoder.getPalette().data());
 		target.blitFrom(*src, rect, target.getBounds());
 	}
 	if (engine->delaySkip(1000 * seconds)) {

--- a/engines/twine/slideshow.cpp
+++ b/engines/twine/slideshow.cpp
@@ -63,7 +63,7 @@ private:
 		target.blitFrom(*src);
 
 		if (decoder.hasPalette()) {
-			setPalette(decoder.getPalette(), decoder.getPaletteColorCount());
+			setPalette(decoder.getPalette().data(), decoder.getPalette().size());
 		}
 		return true;
 	}

--- a/engines/ultima/nuvie/misc/sdl_compat.cpp
+++ b/engines/ultima/nuvie/misc/sdl_compat.cpp
@@ -72,8 +72,7 @@ Graphics::ManagedSurface *SDL_LoadBMP(const Common::Path &filename) {
 	Graphics::ManagedSurface *const screenSurface = screen->get_sdl_surface();
 	assert(screenSurface);
 	Graphics::ManagedSurface *dest = new Graphics::ManagedSurface(src->w, src->h, screenSurface->format);
-	Graphics::Palette p(decoder.getPalette(), 256);
-	dest->blitFrom(*src, &p);
+	dest->blitFrom(*src, &decoder.getPalette());
 
 	return dest;
 }

--- a/engines/ultima/ultima4/gfx/imageloader.cpp
+++ b/engines/ultima/ultima4/gfx/imageloader.cpp
@@ -28,13 +28,11 @@ namespace Ultima {
 namespace Ultima4 {
 
 /*-------------------------------------------------------------------*/
-U4ImageDecoder::U4ImageDecoder(int width, int height, int bpp) {
+U4ImageDecoder::U4ImageDecoder(int width, int height, int bpp) : _palette(0) {
 	_width = width;
 	_height = height;
 	_bpp = bpp;
 	_surface = nullptr;
-	_palette = nullptr;
-	_paletteColorCount = 0;
 }
 
 U4ImageDecoder::~U4ImageDecoder() {
@@ -48,9 +46,7 @@ void U4ImageDecoder::destroy() {
 		_surface = nullptr;
 	}
 
-	// _palette is owned by U4PaletteLoader
-	_palette = nullptr;
-	_paletteColorCount = 0;
+	_palette.clear();
 }
 
 void U4ImageDecoder::setFromRawData(const byte *rawData) {

--- a/engines/ultima/ultima4/gfx/imageloader.h
+++ b/engines/ultima/ultima4/gfx/imageloader.h
@@ -22,6 +22,7 @@
 #ifndef ULTIMA4_GFX_IMAGELOADER_H
 #define ULTIMA4_GFX_IMAGELOADER_H
 
+#include "graphics/palette.h"
 #include "graphics/pixelformat.h"
 #include "image/image_decoder.h"
 
@@ -43,13 +44,11 @@ public:
 	// ImageDecoder API
 	void destroy() override;
 	const Graphics::Surface *getSurface() const override { return _surface; }
-	const byte *getPalette() const override { return _palette; }
-	uint16 getPaletteColorCount() const override { return _paletteColorCount; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 
 protected:
 	Graphics::Surface *_surface;
-	const byte *_palette;
-	uint16 _paletteColorCount;
+	Graphics::Palette _palette;
 	int _width, _height, _bpp;
 
 	/**

--- a/engines/ultima/ultima4/gfx/imageloader_fmtowns.cpp
+++ b/engines/ultima/ultima4/gfx/imageloader_fmtowns.cpp
@@ -57,8 +57,8 @@ bool FMTOWNSImageDecoder::loadStream(Common::SeekableReadStream &stream) {
 		setFromRawData(raw);
 
 		U4PaletteLoader pal;
-		_palette = pal.loadEgaPalette();
-		_paletteColorCount = 16;
+		_palette.resize(16, false);
+		_palette.set(pal.loadEgaPalette(), 0, 16);
 	}
 
 

--- a/engines/ultima/ultima4/gfx/imageloader_u4.cpp
+++ b/engines/ultima/ultima4/gfx/imageloader_u4.cpp
@@ -62,14 +62,14 @@ bool U4RawImageDecoder::loadStream(Common::SeekableReadStream &stream) {
 
 	U4PaletteLoader paletteLoader;
 	if (_bpp == 8) {
-		_palette = paletteLoader.loadVgaPalette();
-		_paletteColorCount = 256;
+		_palette.resize(256, false);
+		_palette.set(paletteLoader.loadVgaPalette(), 0, 256);
 	} else if (_bpp == 4) {
-		_palette = paletteLoader.loadEgaPalette();
-		_paletteColorCount = 16;
+		_palette.resize(16, false);
+		_palette.set(paletteLoader.loadEgaPalette(), 0, 16);
 	} else if (_bpp == 1) {
-		_palette = paletteLoader.loadBWPalette();
-		_paletteColorCount = 2;
+		_palette.resize(2, false);
+		_palette.set(paletteLoader.loadBWPalette(), 0, 2);
 	}
 
 	setFromRawData(raw);
@@ -109,14 +109,14 @@ bool U4RleImageDecoder::loadStream(Common::SeekableReadStream &stream) {
 
 	U4PaletteLoader paletteLoader;
 	if (_bpp == 8) {
-		_palette = paletteLoader.loadVgaPalette();
-		_paletteColorCount = 256;
+		_palette.resize(256, false);
+		_palette.set(paletteLoader.loadVgaPalette(), 0, 256);
 	} else if (_bpp == 4) {
-		_palette = paletteLoader.loadEgaPalette();
-		_paletteColorCount = 16;
+		_palette.resize(16, false);
+		_palette.set(paletteLoader.loadEgaPalette(), 0, 16);
 	} else if (_bpp == 1) {
-		_palette = paletteLoader.loadBWPalette();
-		_paletteColorCount = 2;
+		_palette.resize(2, false);
+		_palette.set(paletteLoader.loadBWPalette(), 0, 2);
 	}
 
 	setFromRawData(raw);
@@ -156,14 +156,14 @@ bool U4LzwImageDecoder::loadStream(Common::SeekableReadStream &stream) {
 
 	U4PaletteLoader paletteLoader;
 	if (_bpp == 8) {
-		_palette = paletteLoader.loadVgaPalette();
-		_paletteColorCount = 256;
+		_palette.resize(256, false);
+		_palette.set(paletteLoader.loadVgaPalette(), 0, 256);
 	} else if (_bpp == 4) {
-		_palette = paletteLoader.loadEgaPalette();
-		_paletteColorCount = 16;
+		_palette.resize(16, false);
+		_palette.set(paletteLoader.loadEgaPalette(), 0, 16);
 	} else if (_bpp == 1) {
-		_palette = paletteLoader.loadBWPalette();
-		_paletteColorCount = 2;
+		_palette.resize(2, false);
+		_palette.set(paletteLoader.loadBWPalette(), 0, 2);
 	}
 
 	setFromRawData(raw);

--- a/engines/ultima/ultima4/gfx/imagemgr.cpp
+++ b/engines/ultima/ultima4/gfx/imagemgr.cpp
@@ -566,7 +566,7 @@ ImageInfo *ImageMgr::get(const Common::String &name, bool returnUnscaled) {
 				unscaled->blitFrom(*surface);
 
 				const Graphics::Palette &pal = decoder->getPalette();
-				if (pal.size() > 0) {
+				if (!pal.empty()) {
 					unscaled->setPalette(pal.data(), pal.size());
 				}
 

--- a/engines/ultima/ultima4/gfx/imagemgr.cpp
+++ b/engines/ultima/ultima4/gfx/imagemgr.cpp
@@ -565,10 +565,9 @@ ImageInfo *ImageMgr::get(const Common::String &name, bool returnUnscaled) {
 				unscaled = Image::create(surface->w, surface->h, surface->format);
 				unscaled->blitFrom(*surface);
 
-				if (decoder->hasPalette()) {
-					int palCount = decoder->getPaletteColorCount();
-					const byte *pal = decoder->getPalette();
-					unscaled->setPalette(pal, palCount);
+				const Graphics::Palette &pal = decoder->getPalette();
+				if (pal.size() > 0) {
+					unscaled->setPalette(pal.data(), pal.size());
 				}
 
 				if (info->_width == -1) {

--- a/engines/ultima/ultima8/gumps/cru_credits_gump.cpp
+++ b/engines/ultima/ultima8/gumps/cru_credits_gump.cpp
@@ -63,7 +63,7 @@ CruCreditsGump::CruCreditsGump(Common::SeekableReadStream *txtrs,
 		const Graphics::Surface *bmpsurf = decoder.getSurface();
 		Graphics::ManagedSurface ms;
 		ms.copyFrom(*bmpsurf);
-		ms.setPalette(decoder.getPalette(), 0, decoder.getPaletteColorCount());
+		ms.setPalette(decoder.getPalette().data(), 0, decoder.getPalette().size());
 		Common::Rect srcRect(640, 480);
 		_background->Blit(ms, srcRect, 0, 0);
 	} else {

--- a/engines/ultima/ultima8/gumps/cru_demo_gump.cpp
+++ b/engines/ultima/ultima8/gumps/cru_demo_gump.cpp
@@ -54,7 +54,7 @@ CruDemoGump::CruDemoGump(Common::SeekableReadStream *bmprs, uint32 flags, int32 
 		const Graphics::Surface *bmpsurf = decoder.getSurface();
 		Graphics::ManagedSurface ms;
 		ms.copyFrom(*bmpsurf);
-		ms.setPalette(decoder.getPalette(), 0, decoder.getPaletteColorCount());
+		ms.setPalette(decoder.getPalette().data(), 0, decoder.getPalette().size());
 		Common::Rect srcRect(640, 480);
 		_background->Blit(ms, srcRect, 0, 0);
 	} else {

--- a/engines/vcruise/runtime.cpp
+++ b/engines/vcruise/runtime.cpp
@@ -159,7 +159,7 @@ Common::SharedPtr<Graphics::Surface> AD2044Graphics::loadGraphic(const Common::S
 
 	const Graphics::Surface *bmpSurf = decoder.getSurface();
 
-	Common::SharedPtr<Graphics::Surface> surf(bmpSurf->convertTo(_pixFmt, decoder.getPalette(), decoder.getPaletteColorCount()), Graphics::SurfaceDeleter());
+	Common::SharedPtr<Graphics::Surface> surf(bmpSurf->convertTo(_pixFmt, decoder.getPalette().data(), decoder.getPalette().size()), Graphics::SurfaceDeleter());
 	return surf;
 }
 
@@ -6194,7 +6194,7 @@ Common::SharedPtr<Graphics::ManagedSurface> Runtime::loadGraphicFromPath(const C
 	Common::SharedPtr<Graphics::ManagedSurface> surf(new Graphics::ManagedSurface());
 	if (bmpDecoder.hasPalette()) {
 		surf->copyFrom(*bmpDecoder.getSurface());
-		surf->setPalette(bmpDecoder.getPalette(), 0, bmpDecoder.getPaletteColorCount());
+		surf->setPalette(bmpDecoder.getPalette().data(), 0, bmpDecoder.getPalette().size());
 	} else {
 		surf->convertFrom(*bmpDecoder.getSurface(), _system->getScreenFormat());
 	}

--- a/engines/wintermute/base/gfx/base_image.cpp
+++ b/engines/wintermute/base/gfx/base_image.cpp
@@ -84,8 +84,8 @@ bool BaseImage::loadFile(const Common::String &filename) {
 
 	_decoder->loadStream(*file);
 	_surface = _decoder->getSurface();
-	_palette = _decoder->getPalette();
-	_paletteCount = _decoder->getPaletteColorCount();
+	_palette = _decoder->getPalette().data();
+	_paletteCount = _decoder->getPalette().size();
 	_fileManager->closeFile(file);
 
 	return true;

--- a/graphics/macgui/macwindowborder.cpp
+++ b/graphics/macgui/macwindowborder.cpp
@@ -230,18 +230,14 @@ void MacWindowBorder::loadBorder(Common::SeekableReadStream &file, uint32 flags,
 
 	Graphics::ManagedSurface *surface = new Graphics::ManagedSurface();
 	surface->copyFrom(*bmpDecoder.getSurface());
-	surface->setPalette(bmpDecoder.getPalette(), 0,
-	                    bmpDecoder.getPaletteColorCount());
+	surface->setPalette(bmpDecoder.getPalette().data(), 0,
+	                    bmpDecoder.getPalette().size());
 
 	if (surface->format.isCLUT8()) {
-		const byte *palette = bmpDecoder.getPalette();
-		for (int i = 0; i < bmpDecoder.getPaletteColorCount(); i++) {
-			if (palette[0] == 255 && palette[1] == 0 && palette[2] == 255) {
-				surface->setTransparentColor(i);
-				break;
-			}
-			palette += 3;
-		}
+		const Graphics::Palette &palette = bmpDecoder.getPalette();
+		uint i = palette.find(255, 0, 255);
+		if (i < palette.size())
+			surface->setTransparentColor(i);
 	} else {
 		const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 24, 16, 8, 0);
 		surface->convertToInPlace(requiredFormat_4byte);

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -868,7 +868,7 @@ void MacWindowManager::loadDesktop() {
 	bmpDecoder.loadStream(*file);
 
 	const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 24, 16, 8, 0);
-	_desktopBmp = bmpDecoder.getSurface()->convertTo(requiredFormat_4byte, bmpDecoder.getPalette());
+	_desktopBmp = bmpDecoder.getSurface()->convertTo(requiredFormat_4byte, bmpDecoder.getPalette().data(), bmpDecoder.getPalette().size());
 
 	delete file;
 }

--- a/graphics/palette.h
+++ b/graphics/palette.h
@@ -96,6 +96,11 @@ public:
 	void clear();
 
 	/**
+	 * Check whether the palette is empty.
+	 */
+	bool empty() const { return _size == 0; }
+
+	/**
 	 * Changes the number of palette entries.
 	 * 
 	 * @param newSize the new number of palette entries

--- a/image/bmp.h
+++ b/image/bmp.h
@@ -74,9 +74,8 @@ public:
 	// ImageDecoder API
 	void destroy();
 	virtual bool loadStream(Common::SeekableReadStream &stream);
-	virtual const Graphics::Surface *getSurface() const { return _surface; }
-	const byte *getPalette() const { return _palette.data(); }
-	uint16 getPaletteColorCount() const { return _palette.size(); }
+	const Graphics::Surface *getSurface() const override { return _surface; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 
 private:
 	Codec *_codec;

--- a/image/cel_3do.h
+++ b/image/cel_3do.h
@@ -56,9 +56,8 @@ public:
 	// ImageDecoder API
 	void destroy();
 	virtual bool loadStream(Common::SeekableReadStream &stream);
-	virtual const Graphics::Surface *getSurface() const { return _surface; }
-	const byte *getPalette() const { return _palette.data(); }
-	uint16 getPaletteColorCount() const { return _palette.size(); }
+	const Graphics::Surface *getSurface() const override { return _surface; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 
 private:
 	const Graphics::Surface *_surface;

--- a/image/cicn.h
+++ b/image/cicn.h
@@ -47,8 +47,7 @@ public:
 	void destroy() override;
 	bool loadStream(Common::SeekableReadStream &stream) override;
 	const Graphics::Surface *getSurface() const override { return _surface; }
-	const byte *getPalette() const override { return _palette.data(); }
-	uint16 getPaletteColorCount() const override { return _palette.size(); }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 	const Graphics::Surface *getMask() const override { return _mask; }
 
 private:

--- a/image/gif.h
+++ b/image/gif.h
@@ -56,8 +56,7 @@ public:
 
 	bool loadStream(Common::SeekableReadStream &stream) override;
 	void destroy() override;
-	const byte *getPalette() const override { return _palette.data(); }
-	uint16 getPaletteColorCount() const override { return _palette.size(); }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 	const Graphics::Surface *getSurface() const override { return _outputSurface; }
 	bool hasTransparentColor() const override { return _hasTransparentColor; }
 	uint32 getTransparentColor() const override { return _transparentColor; }

--- a/image/iff.h
+++ b/image/iff.h
@@ -85,10 +85,9 @@ public:
 	void destroy();
 	bool loadStream(Common::SeekableReadStream &stream);
 	const Header *getHeader() const { return &_header; }
-	const Graphics::Surface *getSurface() const { return _surface; }
-	const byte *getPalette() const { return _palette.data(); }
+	const Graphics::Surface *getSurface() const override { return _surface; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 	const Common::Array<PaletteRange> &getPaletteRanges() const { return _paletteRanges; }
-	uint16 getPaletteColorCount() const { return _palette.size(); }
 
 	/**
 	* The number of planes to decode, also determines the pixel packing if _packPixels is true.

--- a/image/image_decoder.h
+++ b/image/image_decoder.h
@@ -24,6 +24,7 @@
 
 #include "common/scummsys.h"
 #include "common/str.h"
+#include "graphics/palette.h"
 
 namespace Common {
 class SeekableReadStream;
@@ -94,20 +95,14 @@ public:
 	 * until destroy() or loadStream() is called, or until the destructor of
 	 * this ImageDecoder is called.
 	 *
-	 * The format of the palette is the same as that of the PaletteManager's palette.
-	 * (interleaved RGB values).
-	 *
-	 * @return The decoded palette, or undefined if no palette is present.
+	 * @return The decoded palette, or empty if no palette is present.
 	 */
-	virtual const byte *getPalette() const { return 0; }
+	virtual const Graphics::Palette &getPalette() const = 0;
 
 	/**
 	 * Query whether the decoded image has a palette.
 	 */
-	virtual bool hasPalette() const { return getPaletteColorCount() != 0; }
-
-	/** Return the number of colors in the palette. */
-	virtual uint16 getPaletteColorCount() const { return 0; }
+	virtual bool hasPalette() const { return getPalette().size() != 0; }
 
 	/** Query whether the decoded image has a transparent color. */
 	virtual bool hasTransparentColor() const { return false; }

--- a/image/image_decoder.h
+++ b/image/image_decoder.h
@@ -102,7 +102,7 @@ public:
 	/**
 	 * Query whether the decoded image has a palette.
 	 */
-	virtual bool hasPalette() const { return getPalette().size() != 0; }
+	virtual bool hasPalette() const { return !getPalette().empty(); }
 
 	/** Query whether the decoded image has a transparent color. */
 	virtual bool hasTransparentColor() const { return false; }

--- a/image/jpeg.cpp
+++ b/image/jpeg.cpp
@@ -46,6 +46,7 @@ namespace Image {
 
 JPEGDecoder::JPEGDecoder() :
 		_surface(),
+		_palette(0),
 		_colorSpace(kColorSpaceRGB),
 		_accuracy(CodecAccuracy::Default),
 		_requestedPixelFormat(getByteOrderRgbPixelFormat()) {

--- a/image/jpeg.h
+++ b/image/jpeg.h
@@ -22,6 +22,7 @@
 #ifndef IMAGE_JPEG_H
 #define IMAGE_JPEG_H
 
+#include "graphics/palette.h"
 #include "graphics/surface.h"
 #include "image/image_decoder.h"
 #include "image/codecs/codec.h"
@@ -55,6 +56,7 @@ public:
 	void destroy() override;
 	bool loadStream(Common::SeekableReadStream &str) override;
 	const Graphics::Surface *getSurface() const override;
+	const Graphics::Palette &getPalette() const override { return _palette; }
 
 	// Codec API
 	const Graphics::Surface *decodeFrame(Common::SeekableReadStream &stream) override;
@@ -104,6 +106,7 @@ public:
 
 private:
 	Graphics::Surface _surface;
+	Graphics::Palette _palette;
 	ColorSpace _colorSpace;
 	Graphics::PixelFormat _requestedPixelFormat;
 	CodecAccuracy _accuracy;

--- a/image/neo.cpp
+++ b/image/neo.cpp
@@ -28,11 +28,12 @@
 
 namespace Image {
 
-NeoDecoder::NeoDecoder(byte *palette) {
+NeoDecoder::NeoDecoder(byte *palette) : _palette(0) {
 	_surface = nullptr;
-	_paletteDestroy = palette ? false : true;
-	_palette = palette;
-	_paletteColorCount = 0;
+	if (palette) {
+		_palette.resize(16, false);
+		_palette.set(palette, 0, 16);
+	}
 }
 
 NeoDecoder::~NeoDecoder() {
@@ -46,17 +47,13 @@ void NeoDecoder::destroy() {
 		_surface = nullptr;
 	}
 
-	if (_paletteDestroy) {
-		delete[] _palette;
-		_palette = nullptr;
-	}
-	_paletteColorCount = 0;
+	_palette.clear();
 }
 
 bool NeoDecoder::loadStream(Common::SeekableReadStream &stream) {
 	destroy();
 
-	if (!_palette) {
+	if (_palette.size() == 0) {
 		int start = stream.pos();
 
 		if (stream.readUint16LE() != 0x00)
@@ -65,14 +62,15 @@ bool NeoDecoder::loadStream(Common::SeekableReadStream &stream) {
 		if (stream.readUint16LE() != 0x00)
 			warning("Header check failed for reading neo image");
 
-		_palette = new byte[16 * 3];
+		_palette.resize(16, false);
 		for (int i = 0; i < 16; ++i) {
 			byte v1 = stream.readByte();
 			byte v2 = stream.readByte();
 
-			_palette[i * 3 + 0] = floor((v1 & 0x07) * 255.0 / 7.0);
-			_palette[i * 3 + 1] = floor((v2 & 0x70) * 255.0 / 7.0 / 16.0);
-			_palette[i * 3 + 2] = floor((v2 & 0x07) * 255.0 / 7.0);
+			byte r = floor((v1 & 0x07) * 255.0 / 7.0);
+			byte g = floor((v2 & 0x70) * 255.0 / 7.0 / 16.0);
+			byte b = floor((v2 & 0x07) * 255.0 / 7.0);
+			_palette.set(i, r, g, b);
 		}
 
 		stream.seek(start + 128);
@@ -82,7 +80,6 @@ bool NeoDecoder::loadStream(Common::SeekableReadStream &stream) {
 	int height = 200;
 	_surface = new Graphics::Surface();
 	_surface->create(width, height, Graphics::PixelFormat::createFormatCLUT8());
-	_paletteColorCount = 16;
 
 	// 200 rows of image:
 	for (int y = 0; y < 200; y++) {

--- a/image/neo.cpp
+++ b/image/neo.cpp
@@ -53,7 +53,7 @@ void NeoDecoder::destroy() {
 bool NeoDecoder::loadStream(Common::SeekableReadStream &stream) {
 	destroy();
 
-	if (_palette.size() == 0) {
+	if (_palette.empty()) {
 		int start = stream.pos();
 
 		if (stream.readUint16LE() != 0x00)

--- a/image/neo.h
+++ b/image/neo.h
@@ -22,6 +22,7 @@
 #ifndef IMAGE_NEO_H
 #define IMAGE_NEO_H
 
+#include "graphics/palette.h"
 #include "image/image_decoder.h"
 
 /**
@@ -51,14 +52,12 @@ public:
 	void destroy();
 	virtual bool loadStream(Common::SeekableReadStream &stream);
 	virtual const Graphics::Surface *getSurface() const { return _surface; }
-	const byte *getPalette() const { return _palette; }
-	uint16 getPaletteColorCount() const { return _paletteColorCount; }
+	const Graphics::Palette &getPalette() const { return _palette; }
+	uint16 getPaletteColorCount() const { return _palette.size(); }
 
 private:
 	Graphics::Surface *_surface;
-	bool _paletteDestroy;
-	byte *_palette;
-	uint16 _paletteColorCount;
+	Graphics::Palette _palette;
 };
 } // End of namespace Image
 

--- a/image/pcx.h
+++ b/image/pcx.h
@@ -56,9 +56,8 @@ public:
 	// ImageDecoder API
 	void destroy();
 	virtual bool loadStream(Common::SeekableReadStream &stream);
-	virtual const Graphics::Surface *getSurface() const { return _surface; }
-	const byte *getPalette() const { return _palette.data(); }
-	uint16 getPaletteColorCount() const { return _palette.size(); }
+	const Graphics::Surface *getSurface() const override { return _surface; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 
 private:
 	void decodeRLE(Common::SeekableReadStream &stream, byte *dst, uint32 bytesPerScanline, bool compressed);

--- a/image/pict.h
+++ b/image/pict.h
@@ -62,10 +62,8 @@ public:
 	// ImageDecoder API
 	bool loadStream(Common::SeekableReadStream &stream);
 	void destroy();
-	const Graphics::Surface *getSurface() const { return _outputSurface; }
-	const byte *getPalette() const { return _palette.data(); }
-	int getPaletteSize() const { return 256; }
-	uint16 getPaletteColorCount() const { return _palette.size(); }
+	const Graphics::Surface *getSurface() const override { return _outputSurface; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 
 	struct PixMap {
 		uint32 baseAddr;

--- a/image/png.h
+++ b/image/png.h
@@ -62,8 +62,7 @@ public:
 	bool loadStream(Common::SeekableReadStream &stream) override;
 	void destroy() override;
 	const Graphics::Surface *getSurface() const override { return _outputSurface; }
-	const byte *getPalette() const override { return _palette.data(); }
-	uint16 getPaletteColorCount() const override { return _palette.size(); }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 	bool hasTransparentColor() const override { return _hasTransparentColor; }
 	uint32 getTransparentColor() const override { return _transparentColor; }
 	void setSkipSignature(bool skip) { _skipSignature = skip; }

--- a/image/scr.cpp
+++ b/image/scr.cpp
@@ -28,8 +28,7 @@
 
 namespace Image {
 
-ScrDecoder::ScrDecoder() {
-	_surface = nullptr;
+ScrDecoder::ScrDecoder() : _surface(nullptr), _palette(0) {
 }
 
 ScrDecoder::~ScrDecoder() {

--- a/image/scr.h
+++ b/image/scr.h
@@ -22,6 +22,7 @@
 #ifndef IMAGE_SCR_H
 #define IMAGE_SCR_H
 
+#include "graphics/palette.h"
 #include "image/image_decoder.h"
 
 /**
@@ -52,8 +53,10 @@ public:
 	void destroy();
 	virtual bool loadStream(Common::SeekableReadStream &stream);
 	virtual const Graphics::Surface *getSurface() const { return _surface; }
+	const Graphics::Palette &getPalette() const { return _palette; }
 private:
 	Graphics::Surface *_surface;
+	Graphics::Palette _palette;
 	uint32 getPixelAddress(int x, int y);
 	uint32 getAttributeAddress(int x, int y);
 };

--- a/image/tga.h
+++ b/image/tga.h
@@ -68,9 +68,8 @@ public:
 	TGADecoder();
 	virtual ~TGADecoder();
 	virtual void destroy();
-	virtual const Graphics::Surface *getSurface() const { return &_surface; }
-	virtual const byte *getPalette() const { return _colorMap.data(); }
-	virtual uint16 getPaletteColorCount() const { return _colorMap.size(); }
+	const Graphics::Surface *getSurface() const override { return &_surface; }
+	const Graphics::Palette &getPalette() const override { return _colorMap; }
 	virtual bool loadStream(Common::SeekableReadStream &stream);
 private:
 	// Format-spec from:

--- a/image/xbm.cpp
+++ b/image/xbm.cpp
@@ -27,13 +27,12 @@
 
 namespace Image {
 
-const byte XBMDecoder::_palette[2 * 3] = {
+static const byte xbmPalette[2 * 3] = {
 	0xFF, 0xFF, 0xFF,
 	0x00, 0x00, 0x00
 };
 
-XBMDecoder::XBMDecoder() {
-	_surface = 0;
+XBMDecoder::XBMDecoder() : _surface(nullptr), _palette(xbmPalette, 2) {
 }
 
 XBMDecoder::~XBMDecoder() {

--- a/image/xbm.h
+++ b/image/xbm.h
@@ -22,6 +22,7 @@
 #ifndef IMAGE_XBM_H
 #define IMAGE_XBM_H
 
+#include "graphics/palette.h"
 #include "image/image_decoder.h"
 
 namespace Image {
@@ -46,8 +47,7 @@ public:
 	void destroy() override;
 	bool loadStream(Common::SeekableReadStream &stream) override;
 	const Graphics::Surface *getSurface() const override { return _surface; }
-	const byte *getPalette() const override { return _palette; }
-	uint16 getPaletteColorCount() const override { return 2; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 
 	/**
 	 * Load an image from an embedded XBM file.
@@ -67,7 +67,7 @@ public:
 
 private:
 	Graphics::Surface *_surface;
-	static const byte _palette[2 * 3];
+	Graphics::Palette _palette;
 };
 
 /** @} */


### PR DESCRIPTION
This expands the use of palette class by altering the getPalette() method on ImageDecoder to return a const reference to the palette class. Image decoders without palettes return an empty palette. A few decoder instances now copy palette data rather than retain a pointer.

Thoughts: 
- Should Palette have a default of zero on the size constructor to ease use as a member variable?
- Should Palette have a static const empty palette for references where it will always be empty?