### PR TITLE
MACGUI: Null pointer and empty chunks tests in mactext , change cursor restoration in getmaxwidth.

### DIFF
--- a/graphics/macgui/mactext-canvas.cpp
+++ b/graphics/macgui/mactext-canvas.cpp
@@ -81,7 +81,6 @@ void MacTextCanvas::chopChunk(const Common::U32String &str, int *curLinePtr, int
 	int w = getLineWidth(curLine, true);
 	D(9, "** chopChunk before wrap \"%s\"", Common::toPrintable(str.encode()).c_str());
 
-	
 	chunk->getFont()->wordWrapText(str, maxWidth, text, lineContinuations, w);
 
 	for (int i = 0; i < (int)text.size(); i++) {
@@ -141,7 +140,6 @@ void MacTextCanvas::chopChunk(const Common::U32String &str, int *curLinePtr, int
 		_text[curLine].indent = indent;
 		_text[curLine].firstLineIndent = 0;
 		_text[curLine].wordContinuation = lineContinuations[i];
-
 
 		D(9, "** chopChunk, added line (firstIndent: %d): \"%s\"", _text[curLine].firstLineIndent, toPrintable(text[i].encode()).c_str());
 	}
@@ -763,6 +761,10 @@ void MacTextCanvas::render(int from, int to) {
 }
 
 int getStringMaxWordWidth(MacFontRun &format, const Common::U32String &str) {
+	if (str.empty()) 
+		return 0;
+	
+
 	if (format.plainByteMode()) {
 		Common::StringTokenizer tok(Common::convertFromU32String(str, format.getEncoding()));
 		int maxW = 0;

--- a/graphics/macgui/mactext-canvas.cpp
+++ b/graphics/macgui/mactext-canvas.cpp
@@ -84,9 +84,7 @@ void MacTextCanvas::chopChunk(const Common::U32String &str, int *curLinePtr, int
 	chunk->getFont()->wordWrapText(str, maxWidth, text, lineContinuations, w);
 
 	for (int i = 0; i < (int)text.size(); i++) {
-
 		D(9, "Line Continuations [%d] : %d", i, lineContinuations[i]);
-
 	}
 
 	if (text.empty()) {
@@ -102,18 +100,14 @@ void MacTextCanvas::chopChunk(const Common::U32String &str, int *curLinePtr, int
 	}
 
 	for (int i = 0; i < (int)text.size(); i++) {
-
 		D(9, "** chopChunk result %d \"%s\"", i, toPrintable(text[i].encode()).c_str());
-
 	}
 
 	chunk->text += text[0];
 
 	//Ensure line continuations is valid before accesing index 0
 	if (!lineContinuations.empty()) {
-
 		_text[curLine].wordContinuation = lineContinuations[0];
-
 	}
 
 	// Recalc dims
@@ -127,7 +121,6 @@ void MacTextCanvas::chopChunk(const Common::U32String &str, int *curLinePtr, int
 
 	// Now add rest of the chunks
 	MacFontRun newchunk = *chunk;
-	
 	for (uint i = 1; i < text.size(); i++) {
 		newchunk.text = text[i];
 
@@ -760,7 +753,6 @@ int getStringMaxWordWidth(MacFontRun &format, const Common::U32String &str) {
 	if (str.empty()) 
 		return 0;
 	
-
 	if (format.plainByteMode()) {
 		Common::StringTokenizer tok(Common::convertFromU32String(str, format.getEncoding()));
 		int maxW = 0;

--- a/graphics/macgui/mactext-canvas.cpp
+++ b/graphics/macgui/mactext-canvas.cpp
@@ -68,7 +68,7 @@ void MacTextCanvas::chopChunk(const Common::U32String &str, int *curLinePtr, int
 		return;
 	}
 
-	 // If maxWidth is not restricted (-1 means possibly invalid width), just append and return
+	// If maxWidth is not restricted (-1 means possibly invalid width), just append and return
 	if (maxWidth == -1) {
 		chunk->text += str;
 
@@ -91,7 +91,7 @@ void MacTextCanvas::chopChunk(const Common::U32String &str, int *curLinePtr, int
 		D(5, "chopChunk: too narrow width, >%d", maxWidth);
 
 		if (w < maxWidth) {
-			chunk->text += str;	//Only append if within bounds
+			chunk->text += str;	// Only append if within bounds
 		}
 		
 		getLineCharWidth(curLine, true);
@@ -105,7 +105,7 @@ void MacTextCanvas::chopChunk(const Common::U32String &str, int *curLinePtr, int
 
 	chunk->text += text[0];
 
-	//Ensure line continuations is valid before accesing index 0
+	// Ensure line continuations is valid before accesing index 0
 	if (!lineContinuations.empty()) {
 		_text[curLine].wordContinuation = lineContinuations[0];
 	}

--- a/graphics/macgui/mactext-canvas.cpp
+++ b/graphics/macgui/mactext-canvas.cpp
@@ -115,7 +115,6 @@ void MacTextCanvas::chopChunk(const Common::U32String &str, int *curLinePtr, int
 		_text[curLine].wordContinuation = lineContinuations[0];
 
 	}
-	
 
 	// Recalc dims
 	getLineWidth(curLine, true);
@@ -129,8 +128,6 @@ void MacTextCanvas::chopChunk(const Common::U32String &str, int *curLinePtr, int
 	// Now add rest of the chunks
 	MacFontRun newchunk = *chunk;
 	
-
-
 	for (uint i = 1; i < text.size(); i++) {
 		newchunk.text = text[i];
 
@@ -263,7 +260,6 @@ const Common::U32String::value_type *MacTextCanvas::splitString(const Common::U3
 	int indentSize = 0;
 	int firstLineIndent = 0;
 	bool inTable = false;
-
 
 	bool lineBreakOnLineEnd = false;
 
@@ -950,7 +946,6 @@ int MacTextCanvas::getLineWidth(int lineNum, bool enforce, int col) {
 
 		height = MAX(height, line->chunks[i].getFont()->getFontHeight());
 	}
-
 
 	line->width = width;
 	line->minWidth = minWidth;

--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -108,7 +108,6 @@ uint MacTextLine::getChunkNum(int *col) {
 
 	if (pos < 0)
 		pos = 0;
-
 	*col = pos;
 
 	return i;
@@ -318,8 +317,6 @@ void MacText::setMaxWidth(int maxWidth) {
 	for (int i = 0; i < _cursorRow; ++i)
 		absoluteCharOffset += _canvas.getLineCharWidth(i);
 	absoluteCharOffset += _cursorCol;
-
-	
 	_canvas.setMaxWidth(maxWidth, _defaultFormatting);
 
 	// restore the cursor pos


### PR DESCRIPTION
- Check for null pointer before handling any operations in getChunkNum function.

- Check for empty chunks to avoid extra operations.

- avoid signed/unsigned issue in chunk position.

- avoid possible overflow in cursor restoration logic