### PR TITLE
SCUMM: Add enhancement for missing message when entering ship's hold

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -1738,7 +1738,17 @@ void ScummEngine_v5::o5_notEqualZero() {
 			}
 		}
 	} else {
-		a = getVar();
+		int var = fetchScriptWord();
+		a = readVar(var);
+
+		// WORKAROUND: There is a message for when Guybrush first
+		// enters the hold where he remarks that the whole thing reeks
+		// of monkeys. But the way it's scripted, the message is only
+		// shown if it has already been shown.
+
+		if ((_game.id == GID_MONKEY || _game.id == GID_MONKEY_VGA || _game.id == GID_MONKEY_EGA) && _roomResource == 8 && vm.slot[_currentScript].number == 10002 && var == 0x8000 + 321 && enhancementEnabled(kEnhRestoredContent)) {
+			a = !a;
+		}
 	}
 
 	jumpRelative(a != 0);


### PR DESCRIPTION
The first time Guybrush enters the ship's hold, there is a message where he remarks that the whole thing reeks of monkeys. But the way it's scripted, it's only shown if it has already been shown. Here's how Nutcracker renders the script:

```
	enter { ; ENCD LECF_0001/LFLF_0008/ROOM/ENCD
		start-script bak 200 ()
		break-here
		if (B.321) {
			B.321 = 1
			say-line "Yech!!!\\xFF\\x03The unmistakable stench of Monkeys!!!\\xFF\\x03This whole ship smells like hot, sweaty primates.\\xFF\\x03I knew I should have taken it for a test sail."
		}
		end-object
	}
```

I assume that variables are automatically initialized to 0, because these are the only references I can find to `B.321`. We can enable the message by inverting the check:

![scummvm-monkey-2-00002](https://github.com/user-attachments/assets/26b0dd85-e89c-4737-b744-ce73ad8f1aba)

In most versions, you should be able to reach the scene easily by using boot param 2222. Alternatively, you can teleport to room 9 and walk down into the hold.

I have tested this with:

- English VGA CD version.
- English VGA floppy version.
- English Mac version (two different ones).
- English Sega CD version.
- English Special Edition. (The lines are voiced there.)

Theoretically it could also apply to the "Ultimate Talkie" version, but we don't expose the enhancement settings to that version because of how many script changes it already includes.

But I could really use some help in testing it for the other versions and translations.