### PR TITLE
HPL1: Add a new detection entry for Penumbra: Overture

### DIFF
--- a/engines/hpl1/detection_tables.h
+++ b/engines/hpl1/detection_tables.h
@@ -63,6 +63,17 @@ const ADGameDescription GAME_DESCRIPTIONS[] = {
 		GUIO0()
 	},
 
+	// Penumbra: Overture (Steam)
+	{
+		"penumbraoverture",
+		nullptr,
+		AD_ENTRY1s("Penumbra.exe", "384e33ddc55f51debca07b6538087e75", 3104768),
+		Common::Language::EN_ANY,
+		Common::kPlatformWindows,
+		ADGF_UNSTABLE,
+		GUIO0()
+	},
+
 	// Penumbra: Black Plague (GOG v1.0)
 	{
 		"penumbrablackplague",


### PR DESCRIPTION
Add a new detection entry for Penumbra: Overture bought from Steam.