### PR TITLE
JANITORIAL: Add missing references to const function parameters

### DIFF
--- a/audio/soundfont/vgmitem.cpp
+++ b/audio/soundfont/vgmitem.cpp
@@ -32,7 +32,7 @@ using namespace std;
 
 VGMItem::VGMItem() : _dwOffset(0), _unLength(0), _vgmfile(nullptr) {}
 
-VGMItem::VGMItem(VGMFile *thevgmfile, uint32 theOffset, uint32 theLength, const Common::String theName)
+VGMItem::VGMItem(VGMFile *thevgmfile, uint32 theOffset, uint32 theLength, const Common::String &theName)
 		: _vgmfile(thevgmfile),
 		  _name(theName),
 		  _dwOffset(theOffset),
@@ -66,7 +66,7 @@ VGMContainerItem::VGMContainerItem() : VGMItem() {
 }
 
 VGMContainerItem::VGMContainerItem(VGMFile *thevgmfile, uint32 theOffset, uint32 theLength,
-								   const Common::String theName)
+								   const Common::String &theName)
 		: VGMItem(thevgmfile, theOffset, theLength, theName) {
 	AddContainer(_headers);
 	AddContainer(_localitems);

--- a/audio/soundfont/vgmitem.h
+++ b/audio/soundfont/vgmitem.h
@@ -43,7 +43,7 @@ class VGMItem {
 public:
 	VGMItem();
 	VGMItem(VGMFile *thevgmfile, uint32 theOffset, uint32 theLength = 0,
-			const Common::String theName = "");
+			const Common::String &theName = "");
 	virtual ~VGMItem(void);
 
 public:
@@ -66,7 +66,7 @@ class VGMContainerItem : public VGMItem {
 public:
 	VGMContainerItem();
 	VGMContainerItem(VGMFile *thevgmfile, uint32 theOffset, uint32 theLength = 0,
-					 const Common::String theName = "");
+					 const Common::String &theName = "");
 	virtual ~VGMContainerItem(void);
 
 	VGMHeader *AddHeader(uint32 offset, uint32 length, const Common::String &name = "Header");

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -710,7 +710,7 @@ static void addPathToConf(const Common::String &key, const Common::Path &value, 
 		ConfMan.setPath(key, value, domain);
 }
 
-Common::String EngineManager::generateUniqueDomain(const Common::String gameId) {
+Common::String EngineManager::generateUniqueDomain(const Common::String &gameId) {
 	Common::String domainName(gameId);
 	int suffixN = 1;
 	while (ConfMan.hasGameDomain(domainName)) {

--- a/common/unicode-bidi.cpp
+++ b/common/unicode-bidi.cpp
@@ -50,7 +50,7 @@ UnicodeBiDiText::UnicodeBiDiText(const Common::U32String &str, BiDiParagraph dir
 	initWithU32String(str);
 }
 
-UnicodeBiDiText::UnicodeBiDiText(const Common::String &str, const Common::CodePage page,
+UnicodeBiDiText::UnicodeBiDiText(const Common::String &str, const Common::CodePage &page,
 		uint32 *pbase_dir) : logical(str), _log_to_vis_index(nullptr), _vis_to_log_index(nullptr) {
 	_pbase_dir = *pbase_dir;
 	initWithU32String(str.decode(page));
@@ -127,12 +127,12 @@ Common::String bidiByLineHelper(Common::String line, va_list args) {
 	return UnicodeBiDiText(line, page, pbase_dir).visual.encode(page);
 }
 
-String convertBiDiStringByLines(const String &input, const Common::CodePage page, BiDiParagraph dir) {
+String convertBiDiStringByLines(const String &input, const Common::CodePage &page, BiDiParagraph dir) {
 	uint32 pbase_dir = GetFriBiDiParType(dir);
 	return input.forEachLine(bidiByLineHelper, page, &pbase_dir);
 }
 
-String convertBiDiString(const String &input, const Common::Language lang, BiDiParagraph dir) {
+String convertBiDiString(const String &input, const Common::Language &lang, BiDiParagraph dir) {
 	if (lang == Common::HE_ISR) {
 		return Common::convertBiDiString(input, kWindows1255, dir);
 	} else if (lang == Common::FA_IRN) {
@@ -142,7 +142,7 @@ String convertBiDiString(const String &input, const Common::Language lang, BiDiP
 	}
 }
 
-String convertBiDiString(const String &input, const Common::CodePage page, BiDiParagraph dir) {
+String convertBiDiString(const String &input, const Common::CodePage &page, BiDiParagraph dir) {
 	return convertBiDiU32String(input.decode(page), dir).visual.encode(page);
 }
 

--- a/common/unicode-bidi.h
+++ b/common/unicode-bidi.h
@@ -50,7 +50,7 @@ public:
 
 	UnicodeBiDiText(const Common::U32String &str, BiDiParagraph dir = BIDI_PAR_ON);
 	/* This constructor shouldn't be used outside of unicode-bidi.cpp file */
-	UnicodeBiDiText(const Common::String &str, const Common::CodePage page, uint32 *pbase_dir);
+	UnicodeBiDiText(const Common::String &str, const Common::CodePage &page, uint32 *pbase_dir);
 	~UnicodeBiDiText();
 
 	/**
@@ -65,11 +65,11 @@ public:
 
 /* just call the constructor for convenience */
 UnicodeBiDiText convertBiDiU32String(const U32String &input, BiDiParagraph dir = BIDI_PAR_ON);
-String convertBiDiString(const String &input, const Common::Language lang, BiDiParagraph dir = BIDI_PAR_ON);
-String convertBiDiString(const String &input, const Common::CodePage page, BiDiParagraph dir = BIDI_PAR_ON);
+String convertBiDiString(const String &input, const Common::Language &lang, BiDiParagraph dir = BIDI_PAR_ON);
+String convertBiDiString(const String &input, const Common::CodePage &page, BiDiParagraph dir = BIDI_PAR_ON);
 
 // calls convertBiDiString for each line in isolation
-String convertBiDiStringByLines(const String &input, const Common::CodePage page, BiDiParagraph dir = BIDI_PAR_ON);
+String convertBiDiStringByLines(const String &input, const Common::CodePage &page, BiDiParagraph dir = BIDI_PAR_ON);
 
 } // End of namespace Common
 

--- a/devtools/create_engine/files_events/events.cpp
+++ b/devtools/create_engine/files_events/events.cpp
@@ -181,7 +181,7 @@ void Events::clearViews() {
 	_views.clear();
 }
 
-void Events::addKeypress(const Common::KeyCode kc) {
+void Events::addKeypress(const Common::KeyCode &kc) {
 	Common::KeyState ks;
 	ks.keycode = kc;
 	if (kc >= Common::KEYCODE_SPACE && kc <= Common::KEYCODE_TILDE)

--- a/devtools/create_engine/files_events/events.h
+++ b/devtools/create_engine/files_events/events.h
@@ -368,7 +368,7 @@ public:
 	/**
 	 * Add a keypress to the event queue
 	 */
-	void addKeypress(const Common::KeyCode kc);
+	void addKeypress(const Common::KeyCode &kc);
 
 	/**
 	 * Events manager doesn't have any intrinsic drawing

--- a/engines/access/amazon/amazon_game.cpp
+++ b/engines/access/amazon/amazon_game.cpp
@@ -473,7 +473,7 @@ void AmazonEngine::drawHelpText(const Common::String &msg) {
 	_events->showCursor();
 }
 
-void AmazonEngine::drawHelp(const Common::String str) {
+void AmazonEngine::drawHelp(const Common::String &str) {
 	_events->hideCursor();
 	if (_useItem == 0) {
 		_buffer2.copyBuffer(_screen);

--- a/engines/access/amazon/amazon_game.h
+++ b/engines/access/amazon/amazon_game.h
@@ -117,7 +117,7 @@ public:
 	*/
 	void freeInactivePlayer();
 
-	void drawHelp(const Common::String str);
+	void drawHelp(const Common::String &str);
 
 	void establish(int esatabIndex, int sub) override;
 

--- a/engines/ags/plugins/ags_waves/ags_waves.h
+++ b/engines/ags/plugins/ags_waves/ags_waves.h
@@ -163,7 +163,7 @@ private:
 	/**
 	 * Loads a ScummVM OGG stream for playback
 	 */
-	Audio::AudioStream *loadOGG(const Common::ArchiveMemberPtr member);
+	Audio::AudioStream *loadOGG(const Common::ArchiveMemberPtr &member);
 
 	void playStream(Audio::Mixer::SoundType type, Audio::SoundHandle *handle, Audio::AudioStream *stream, int repeat);
 

--- a/engines/ags/plugins/ags_waves/sound.cpp
+++ b/engines/ags/plugins/ags_waves/sound.cpp
@@ -181,7 +181,7 @@ void AGSWaves::SFX_Filter(ScriptMethodParams &params) {
 	SFX[sfxNum]._filter = enable;
 }
 
-Audio::AudioStream *AGSWaves::loadOGG(const Common::ArchiveMemberPtr member) {
+Audio::AudioStream *AGSWaves::loadOGG(const Common::ArchiveMemberPtr &member) {
 #ifdef USE_VORBIS
 	if (member) {
 		Audio::AudioStream *stream = Audio::makeVorbisStream(member->createReadStream(), DisposeAfterUse::YES);

--- a/engines/avalanche/graphics.cpp
+++ b/engines/avalanche/graphics.cpp
@@ -335,7 +335,7 @@ void GraphicManager::drawTriangle(Common::Point *p, Color color) {
 	_scrolls.drawLine(p[2].x, p[2].y, p[0].x, p[0].y, color);
 }
 
-void GraphicManager::drawText(Graphics::Surface &surface, const Common::String text, FontType font, byte fontHeight, int16 x, int16 y, Color color) {
+void GraphicManager::drawText(Graphics::Surface &surface, const Common::String &text, FontType font, byte fontHeight, int16 x, int16 y, Color color) {
 	for (uint i = 0; i < text.size(); i++) {
 		for (int j = 0; j < fontHeight; j++) {
 			byte pixel = font[(byte)text[i]][j];
@@ -348,14 +348,14 @@ void GraphicManager::drawText(Graphics::Surface &surface, const Common::String t
 	}
 }
 
-void GraphicManager::drawNormalText(const Common::String text, FontType font, byte fontHeight, int16 x, int16 y, Color color) {
+void GraphicManager::drawNormalText(const Common::String &text, FontType font, byte fontHeight, int16 x, int16 y, Color color) {
 	drawText(_surface, text, font, fontHeight, x, y, color);
 }
 
 /**
  * Draws text double the size of the normal.
  */
-void GraphicManager::drawBigText(Graphics::Surface &surface, const Common::String text, FontType font, byte fontHeight, int16 x, int16 y, Color color) {
+void GraphicManager::drawBigText(Graphics::Surface &surface, const Common::String &text, FontType font, byte fontHeight, int16 x, int16 y, Color color) {
 	for (uint i = 0; i < text.size(); i++) {
 		for (int j = 0; j < fontHeight; j++) {
 			byte pixel = font[(byte)text[i]][j];
@@ -371,7 +371,7 @@ void GraphicManager::drawBigText(Graphics::Surface &surface, const Common::Strin
 	}
 }
 
-void GraphicManager::drawScrollText(const Common::String text, FontType font, byte fontHeight, int16 x, int16 y, Color color) {
+void GraphicManager::drawScrollText(const Common::String &text, FontType font, byte fontHeight, int16 x, int16 y, Color color) {
 	drawText(_scrolls, text, font, fontHeight, x, y, color);
 }
 
@@ -695,7 +695,7 @@ void GraphicManager::helpDrawHighlight(byte which, Color color) {
 	drawRectangle(Common::Rect(466, 38 + which * 27, 556, 63 + which * 27), color);
 }
 
-void GraphicManager::helpDrawBigText(const Common::String text, int16 x, int16 y, Color color) {
+void GraphicManager::helpDrawBigText(const Common::String &text, int16 x, int16 y, Color color) {
 	drawBigText(_surface, text, _vm->_font, 8, x, y, color);
 }
 
@@ -1058,7 +1058,7 @@ void GraphicManager::drawSprite(AnimationType *sprite, byte picnum, int16 x, int
 	}
 }
 
-void GraphicManager::drawPicture(Graphics::Surface &target, const Graphics::Surface picture, uint16 destX, uint16 destY) {
+void GraphicManager::drawPicture(Graphics::Surface &target, const Graphics::Surface &picture, uint16 destX, uint16 destY) {
 	// Copy the picture to the given place on the screen.
 	uint16 maxX = picture.w;
 	uint16 maxY = picture.h;

--- a/engines/avalanche/graphics.h
+++ b/engines/avalanche/graphics.h
@@ -66,8 +66,8 @@ public:
 	Common::Point drawScreenArc(int16 x, int16 y, int16 stAngle, int16 endAngle, uint16 radius, Color color);
 	void drawPieSlice(int16 x, int16 y, int16 stAngle, int16 endAngle, uint16 radius, Color color);
 	void drawTriangle(Common::Point *p, Color color);
-	void drawNormalText(const Common::String text, FontType font, byte fontHeight, int16 x, int16 y, Color color);
-	void drawScrollText(const Common::String text, FontType font, byte fontHeight, int16 x, int16 y, Color color);
+	void drawNormalText(const Common::String &text, FontType font, byte fontHeight, int16 x, int16 y, Color color);
+	void drawScrollText(const Common::String &text, FontType font, byte fontHeight, int16 x, int16 y, Color color);
 	void drawDigit(int index, int x, int y);
 	void drawDirection(int index, int x, int y);
 	void drawScrollShadow(int16 x1, int16 y1, int16 x2, int16 y2);
@@ -104,7 +104,7 @@ public:
 	// Help's function:
 	void helpDrawButton(int y, byte which);
 	void helpDrawHighlight(byte which, Color color);
-	void helpDrawBigText(const Common::String text, int16 x, int16 y, Color color);
+	void helpDrawBigText(const Common::String &text, int16 x, int16 y, Color color);
 
 	// Shoot em' up's functions:
 	void seuDrawTitle();
@@ -196,9 +196,9 @@ private:
 	Graphics::Surface loadPictureGraphic(Common::File &file); // Reads Graphic-planar EGA data.
 	Graphics::Surface loadPictureSign(Common::File &file, uint16 width, uint16 height); // Reads a tricky type of picture used for the "game over"/"about" scrolls and in the mini-game Nim.
 
-	void drawText(Graphics::Surface &surface, const Common::String text, FontType font, byte fontHeight, int16 x, int16 y, Color color);
-	void drawBigText(Graphics::Surface &surface, const Common::String text, FontType font, byte fontHeight, int16 x, int16 y, Color color);
-	void drawPicture(Graphics::Surface &target, const Graphics::Surface picture, uint16 destX, uint16 destY);
+	void drawText(Graphics::Surface &surface, const Common::String &text, FontType font, byte fontHeight, int16 x, int16 y, Color color);
+	void drawBigText(Graphics::Surface &surface, const Common::String &text, FontType font, byte fontHeight, int16 x, int16 y, Color color);
+	void drawPicture(Graphics::Surface &target, const Graphics::Surface &picture, uint16 destX, uint16 destY);
 
 	// Taken from Free Pascal's Procedure InternalEllipseDefault. Used to replace Pascal's procedure arc.
 	// Returns the end point of the arc. (Needed in Clock.)

--- a/engines/cine/pal.cpp
+++ b/engines/cine/pal.cpp
@@ -281,7 +281,7 @@ uint8 Palette::getB(byte index) const {
 	return _colors[index].b;
 }
 
-void Palette::setColorFormat(const Graphics::PixelFormat format) {
+void Palette::setColorFormat(const Graphics::PixelFormat &format) {
 	_format = format;
 }
 
@@ -322,7 +322,7 @@ void Palette::saturatedAddColor(Color &result, const Color &baseColor, signed r,
 	result.b = CLIP<int>(baseColor.b + b, 0, _format.bMax());
 }
 
-Palette::Palette(const Graphics::PixelFormat format, const uint numColors) : _format(format), _colors() {
+Palette::Palette(const Graphics::PixelFormat &format, const uint numColors) : _format(format), _colors() {
 	_colors.resize(numColors);
 	fillWithBlack();
 }
@@ -346,7 +346,7 @@ Palette &Palette::clear() {
 	return *this;
 }
 
-Palette &Palette::load(const byte *buf, const uint size, const Graphics::PixelFormat format, const uint numColors, const EndianType endian) {
+Palette &Palette::load(const byte *buf, const uint size, const Graphics::PixelFormat &format, const uint numColors, const EndianType endian) {
 	assert(format.bytesPerPixel * numColors <= size); // Make sure there's enough input space
 	assert(format.aLoss == 8); // No alpha
 	assert(format.rShift / 8 == (format.rShift + MAX<int>(0, format.rBits() - 1)) / 8); // R must be inside one byte
@@ -376,11 +376,11 @@ byte *Palette::save(byte *buf, const uint size, const EndianType endian) const {
 	return save(buf, size, colorFormat(), colorCount(), endian);
 }
 
-byte *Palette::save(byte *buf, const uint size, const Graphics::PixelFormat format, const EndianType endian) const {
+byte *Palette::save(byte *buf, const uint size, const Graphics::PixelFormat &format, const EndianType endian) const {
 	return save(buf, size, format, colorCount(), endian);
 }
 
-byte *Palette::save(byte *buf, const uint size, const Graphics::PixelFormat format, const uint numColors, const EndianType endian, const byte firstIndex) const {
+byte *Palette::save(byte *buf, const uint size, const Graphics::PixelFormat &format, const uint numColors, const EndianType endian, const byte firstIndex) const {
 	assert(format.bytesPerPixel * numColors <= size); // Make sure there's enough output space
 	assert(format.aLoss == 8); // No alpha
 	assert(format.rShift / 8 == (format.rShift + MAX<int>(0, format.rBits() - 1)) / 8); // R must be inside one byte

--- a/engines/cine/pal.h
+++ b/engines/cine/pal.h
@@ -65,7 +65,7 @@ public:
 	 * @param numColors Number of colors
 	 * @note For the default constructed object (i.e. no parameters given) this will hold: empty() && !isValid()
 	 */
-	Palette(const Graphics::PixelFormat format = Graphics::PixelFormat(), const uint numColors = 0);
+	Palette(const Graphics::PixelFormat &format = Graphics::PixelFormat(), const uint numColors = 0);
 	Palette(const Palette& other);
 	Palette& operator=(const Palette& other);
 
@@ -83,7 +83,7 @@ public:
 	 * @param numColors Number of colors to load
 	 * @param endian The endianness of the colors in the input buffer
 	 */
-	Palette &load(const byte *buf, const uint size, const Graphics::PixelFormat format, const uint numColors, const EndianType endian);
+	Palette &load(const byte *buf, const uint size, const Graphics::PixelFormat &format, const uint numColors, const EndianType endian);
 
 	/**
 	 * Save the whole palette to buffer in original color format using defined endianness.
@@ -100,7 +100,7 @@ public:
 	 * @param format Output color format
 	 * @param endian The endian type to use
 	 */
-	byte *save(byte *buf, const uint size, const Graphics::PixelFormat format, const EndianType endian) const;
+	byte *save(byte *buf, const uint size, const Graphics::PixelFormat &format, const EndianType endian) const;
 
 	/**
 	 * Save (partial) palette to buffer in given color format using defined endianness.
@@ -111,7 +111,7 @@ public:
 	 * @param endian The endian type to use
 	 * @param firstIndex Starting color index (from which onwards to save the colors)
 	 */
-	byte *save(byte *buf, const uint size, const Graphics::PixelFormat format, const uint numColors, const EndianType endian, const byte firstIndex = 0) const;
+	byte *save(byte *buf, const uint size, const Graphics::PixelFormat &format, const uint numColors, const EndianType endian, const byte firstIndex = 0) const;
 
 	/**
 	 * Rotate the palette in color range [firstIndex, lastIndex] to the right by one.
@@ -177,7 +177,7 @@ public:
 private:
 	int findMinBrightnessColorIndex(uint minColorIndex = 1);
 	byte brightness(byte colorIndex);
-	void setColorFormat(const Graphics::PixelFormat format);
+	void setColorFormat(const Graphics::PixelFormat &format);
 	void saturatedAddColor(Color &result, const Color &baseColor, signed r, signed g, signed b) const;
 
 private:

--- a/engines/dragons/screen.cpp
+++ b/engines/dragons/screen.cpp
@@ -64,7 +64,7 @@ void Screen::copyRectToSurface(const Graphics::Surface &srcSurface, int destX, i
 	copyRectToSurface(srcSurface.getBasePtr(0, 0), srcSurface.pitch, srcSurface.w, 0, destX, destY, srcSurface.w, srcSurface.h, false, NONE);
 }
 
-void Screen::copyRectToSurface(const Graphics::Surface &srcSurface, int destX, int destY, const Common::Rect srcRect, bool flipX, AlphaBlendMode alpha) {
+void Screen::copyRectToSurface(const Graphics::Surface &srcSurface, int destX, int destY, const Common::Rect &srcRect, bool flipX, AlphaBlendMode alpha) {
 	Common::Rect clipRect = clipRectToScreen(destX,  destY, srcRect);
 	if (clipRect.width() == 0 || clipRect.height() == 0) {
 		return;
@@ -80,7 +80,7 @@ void Screen::copyRectToSurface(const Graphics::Surface &srcSurface, int destX, i
 	copyRectToSurface(srcSurface.getBasePtr(clipRect.left, clipRect.top), srcSurface.pitch, srcSurface.w, clipRect.left, destX, destY, clipRect.width(), clipRect.height(), flipX, alpha);
 }
 
-void Screen::copyRectToSurface8bpp(const Graphics::Surface &srcSurface, const byte *palette, int destX, int destY, const Common::Rect srcRect, bool flipX, AlphaBlendMode alpha, uint16 scale) {
+void Screen::copyRectToSurface8bpp(const Graphics::Surface &srcSurface, const byte *palette, int destX, int destY, const Common::Rect &srcRect, bool flipX, AlphaBlendMode alpha, uint16 scale) {
 	if (scale != DRAGONS_ENGINE_SPRITE_100_PERCENT_SCALE) {
 		drawScaledSprite(_backSurface, (const byte *)srcSurface.getBasePtr(0, 0),
 				srcRect.width(), srcRect.height(),
@@ -264,11 +264,11 @@ void Screen::drawScaledSprite(Graphics::Surface *destSurface, const byte *source
 	}
 }
 
-Common::Rect Screen::clipRectToScreen(int destX, int destY, const Common::Rect rect) {
+Common::Rect Screen::clipRectToScreen(int destX, int destY, const Common::Rect &rect) {
 	return clipRectToRect(destX, destY, rect, Common::Rect(320, 200));
 }
 
-Common::Rect Screen::clipRectToRect(int destX, int destY, const Common::Rect rect, const Common::Rect containerRect) {
+Common::Rect Screen::clipRectToRect(int destX, int destY, const Common::Rect &rect, const Common::Rect &containerRect) {
 	int16 x, y, w, h;
 	x = rect.left;
 	y = rect.top;
@@ -414,7 +414,7 @@ void Screen::copyRectToSurface8bppWrappedY(const Graphics::Surface &srcSurface, 
 	}
 }
 
-void Screen::copyRectToSurface8bppWrappedX(const Graphics::Surface &srcSurface, const byte *palette, Common::Rect srcRect,
+void Screen::copyRectToSurface8bppWrappedX(const Graphics::Surface &srcSurface, const byte *palette, const Common::Rect &srcRect,
 										   AlphaBlendMode alpha) {
 	// Copy buffer data to internal buffer
 	const byte *src = (const byte *)srcSurface.getBasePtr(0, 0);

--- a/engines/dragons/screen.h
+++ b/engines/dragons/screen.h
@@ -78,9 +78,9 @@ public:
 
 	Graphics::PixelFormat getPixelFormat() { return _pixelFormat; }
 	void copyRectToSurface(const Graphics::Surface &srcSurface, int destX, int destY);
-	void copyRectToSurface(const Graphics::Surface &srcSurface, int destX, int destY, Common::Rect srcRect, bool flipX = false, AlphaBlendMode alpha = NONE);
-	void copyRectToSurface8bpp(const Graphics::Surface &srcSurface, const byte *palette, int destX, int destY, Common::Rect srcRect, bool flipX = false, AlphaBlendMode alpha = NONE, uint16 scale = DRAGONS_ENGINE_SPRITE_100_PERCENT_SCALE);
-	void copyRectToSurface8bppWrappedX(const Graphics::Surface &srcSurface, const byte *palette, Common::Rect srcRect, AlphaBlendMode alpha = NONE);
+	void copyRectToSurface(const Graphics::Surface &srcSurface, int destX, int destY, const Common::Rect &srcRect, bool flipX = false, AlphaBlendMode alpha = NONE);
+	void copyRectToSurface8bpp(const Graphics::Surface &srcSurface, const byte *palette, int destX, int destY, const Common::Rect &srcRect, bool flipX = false, AlphaBlendMode alpha = NONE, uint16 scale = DRAGONS_ENGINE_SPRITE_100_PERCENT_SCALE);
+	void copyRectToSurface8bppWrappedX(const Graphics::Surface &srcSurface, const byte *palette, const Common::Rect &srcRect, AlphaBlendMode alpha = NONE);
 	void updateScreen();
 	void loadPalette(uint16 paletteNum, const byte *palette);
 	byte *getPalette(uint16 paletteNum);
@@ -89,8 +89,8 @@ public:
 	void clearScreen();
 	void drawRect(uint16 colour, Common::Rect rect, int id);
 	void fillRect(uint16 colour, Common::Rect rect);
-	Common::Rect clipRectToScreen(int destX, int destY, const Common::Rect rect);
-	Common::Rect clipRectToRect(int destX, int destY, const Common::Rect rect, const Common::Rect containerRect);
+	Common::Rect clipRectToScreen(int destX, int destY, const Common::Rect &rect);
+	Common::Rect clipRectToRect(int destX, int destY, const Common::Rect &rect, const Common::Rect &containerRect);
 
 	void setScreenShakeOffset(int16 x, int16 y);
 

--- a/engines/engine.cpp
+++ b/engines/engine.cpp
@@ -114,7 +114,7 @@ void ChainedGamesManager::clear() {
 	_chainedGames.clear();
 }
 
-void ChainedGamesManager::push(const Common::String target, const int slot) {
+void ChainedGamesManager::push(const Common::String &target, const int slot) {
 	Game game;
 	game.target = target;
 	game.slot = slot;

--- a/engines/engine.h
+++ b/engines/engine.h
@@ -699,7 +699,7 @@ public:
 	/** Clear the chained games manager of any games. */
 	void clear();
 	/** Load a game into a slot in the chained games manager. */
-	void push(const Common::String target, const int slot = -1);
+	void push(const Common::String &target, const int slot = -1);
 	/** Pop the last game loaded into the chained games manager. */
 	bool pop(Common::String &target, int &slot);
 	/** Returns true if the chained games manager has no elements in the queue. */

--- a/engines/freescape/freescape.cpp
+++ b/engines/freescape/freescape.cpp
@@ -489,14 +489,14 @@ void FreescapeEngine::resetInput() {
 	rotate(0, 0);
 }
 
-Common::Point FreescapeEngine::crossairPosToMousePos(const Common::Point crossairPos) {
+Common::Point FreescapeEngine::crossairPosToMousePos(const Common::Point &crossairPos) {
 	Common::Point mousePos;
 	mousePos.x = g_system->getWidth() * crossairPos.x / _screenW;
 	mousePos.y = g_system->getHeight() * crossairPos.y / _screenH;
 	return mousePos;
 }
 
-Common::Point FreescapeEngine::mousePosToCrossairPos(const Common::Point mousePos) {
+Common::Point FreescapeEngine::mousePosToCrossairPos(const Common::Point &mousePos) {
 	Common::Point crossairPos;
 	crossairPos.x = _screenW * mousePos.x / g_system->getWidth();
 	crossairPos.y = _screenH * mousePos.y / g_system->getHeight();
@@ -1088,7 +1088,7 @@ Common::Error FreescapeEngine::loadGameStreamExtended(Common::SeekableReadStream
 	return Common::kNoError;
 }
 
-void FreescapeEngine::insertTemporaryMessage(const Common::String message, int deadline) {
+void FreescapeEngine::insertTemporaryMessage(const Common::String &message, int deadline) {
 	_temporaryMessages.insert_at(0, message);
 	_temporaryMessageDeadlines.insert_at(0, deadline);
 }

--- a/engines/freescape/freescape.h
+++ b/engines/freescape/freescape.h
@@ -388,8 +388,8 @@ public:
 	int _playerStepIndex;
 	Common::Array<int> _playerSteps;
 
-	Common::Point crossairPosToMousePos(const Common::Point crossairPos);
-	Common::Point mousePosToCrossairPos(const Common::Point mousePos);
+	Common::Point crossairPosToMousePos(const Common::Point &crossairPos);
+	Common::Point mousePosToCrossairPos(const Common::Point &mousePos);
 	void warpMouseToCrossair(void);
 
 	// Effects
@@ -499,7 +499,7 @@ public:
 	float _farClipPlane;
 
 	// Text messages and Fonts
-	void insertTemporaryMessage(const Common::String message, int deadline);
+	void insertTemporaryMessage(const Common::String &message, int deadline);
 	void getLatestMessages(Common::String &message, int &deadline);
 	void clearTemporalMessages();
 	Common::StringArray _temporaryMessages;

--- a/engines/freescape/gfx.h
+++ b/engines/freescape/gfx.h
@@ -85,11 +85,11 @@ public:
 	virtual void freeTexture(Texture *texture) = 0;
 	virtual void drawTexturedRect2D(const Common::Rect &screenRect, const Common::Rect &textureRect, Texture *texture) = 0;
 
-	virtual void renderSensorShoot(byte color, const Math::Vector3d sensor, const Math::Vector3d player, const Common::Rect viewPort) = 0;
-	virtual void renderPlayerShootBall(byte color, const Common::Point position, int frame, const Common::Rect viewPort) = 0;
-	virtual void renderPlayerShootRay(byte color, const Common::Point position, const Common::Rect viewPort) = 0;
+	virtual void renderSensorShoot(byte color, const Math::Vector3d sensor, const Math::Vector3d player, const Common::Rect &viewPort) = 0;
+	virtual void renderPlayerShootBall(byte color, const Common::Point &position, int frame, const Common::Rect &viewPort) = 0;
+	virtual void renderPlayerShootRay(byte color, const Common::Point &position, const Common::Rect &viewPort) = 0;
 
-	virtual void renderCrossair(const Common::Point crossairPosition) = 0;
+	virtual void renderCrossair(const Common::Point &crossairPosition) = 0;
 
 	virtual void renderCube(const Math::Vector3d &position, const Math::Vector3d &size, Common::Array<uint8> *colours, Common::Array<uint8> *ecolours, float offset = 0.0);
 	virtual void renderRectangle(const Math::Vector3d &position, const Math::Vector3d &size, Common::Array<uint8> *colours, Common::Array<uint8> *ecolours, float offset = 0.0);

--- a/engines/freescape/gfx_opengl.cpp
+++ b/engines/freescape/gfx_opengl.cpp
@@ -224,7 +224,7 @@ void OpenGLRenderer::positionCamera(const Math::Vector3d &pos, const Math::Vecto
 	glTranslatef(_shakeOffset.x, _shakeOffset.y, 0);
 }
 
-void OpenGLRenderer::renderSensorShoot(byte color, const Math::Vector3d sensor, const Math::Vector3d target, const Common::Rect viewArea) {
+void OpenGLRenderer::renderSensorShoot(byte color, const Math::Vector3d sensor, const Math::Vector3d target, const Common::Rect &viewArea) {
 	glEnable(GL_BLEND);
 	glBlendFunc(GL_ONE_MINUS_DST_COLOR, GL_ZERO);
 	glColor3ub(255, 255, 255);
@@ -242,7 +242,7 @@ void OpenGLRenderer::renderSensorShoot(byte color, const Math::Vector3d sensor, 
 	glDepthMask(GL_TRUE);
 }
 
-void OpenGLRenderer::renderCrossair(const Common::Point crossairPosition) {
+void OpenGLRenderer::renderCrossair(const Common::Point &crossairPosition) {
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
 	glOrtho(0, _screenW, _screenH, 0, 0, 1);
@@ -281,7 +281,7 @@ void OpenGLRenderer::renderCrossair(const Common::Point crossairPosition) {
 	glDepthMask(GL_TRUE);
 }
 
-void OpenGLRenderer::renderPlayerShootRay(byte color, const Common::Point position, const Common::Rect viewArea) {
+void OpenGLRenderer::renderPlayerShootRay(byte color, const Common::Point &position, const Common::Rect &viewArea) {
 	uint8 r, g, b;
 
 	glMatrixMode(GL_PROJECTION);
@@ -397,7 +397,7 @@ void OpenGLRenderer::drawCelestialBody(Math::Vector3d position, float radius, by
 	glPopMatrix();
 }
 
-void OpenGLRenderer::renderPlayerShootBall(byte color, const Common::Point position, int frame, const Common::Rect viewArea) {
+void OpenGLRenderer::renderPlayerShootBall(byte color, const Common::Point &position, int frame, const Common::Rect &viewArea) {
 	uint8 r, g, b;
 
 	glMatrixMode(GL_PROJECTION);

--- a/engines/freescape/gfx_opengl.h
+++ b/engines/freescape/gfx_opengl.h
@@ -83,10 +83,10 @@ public:
 	void freeTexture(Texture *texture) override;
 	virtual void drawTexturedRect2D(const Common::Rect &screenRect, const Common::Rect &textureRect, Texture *texture) override;
 
-	virtual void renderSensorShoot(byte color, const Math::Vector3d sensor, const Math::Vector3d player, const Common::Rect viewPort) override;
-	virtual void renderPlayerShootBall(byte color, const Common::Point position, int frame, const Common::Rect viewPort) override;
-	virtual void renderPlayerShootRay(byte color, const Common::Point position, const Common::Rect viewPort) override;
-	virtual void renderCrossair(const Common::Point crossairPosition) override;
+	virtual void renderSensorShoot(byte color, const Math::Vector3d sensor, const Math::Vector3d player, const Common::Rect &viewPort) override;
+	virtual void renderPlayerShootBall(byte color, const Common::Point &position, int frame, const Common::Rect &viewPort) override;
+	virtual void renderPlayerShootRay(byte color, const Common::Point &position, const Common::Rect &viewPort) override;
+	virtual void renderCrossair(const Common::Point &crossairPosition) override;
 
 	virtual void renderFace(const Common::Array<Math::Vector3d> &vertices) override;
 

--- a/engines/freescape/gfx_opengl_shaders.cpp
+++ b/engines/freescape/gfx_opengl_shaders.cpp
@@ -220,7 +220,7 @@ void OpenGLShaderRenderer::positionCamera(const Math::Vector3d &pos, const Math:
 	_mvpMatrix = proj * model;
 	_mvpMatrix.transpose();
 }
-void OpenGLShaderRenderer::renderSensorShoot(byte color, const Math::Vector3d sensor, const Math::Vector3d target, const Common::Rect viewArea) {
+void OpenGLShaderRenderer::renderSensorShoot(byte color, const Math::Vector3d sensor, const Math::Vector3d target, const Common::Rect &viewArea) {
 	glEnable(GL_BLEND);
 	glBlendFunc(GL_ONE_MINUS_DST_COLOR, GL_ZERO);
 	useColor(255, 255, 255);
@@ -245,7 +245,7 @@ float remap(float f, float s) {
 	return 2. * f / s - 1;
 }
 
-void OpenGLShaderRenderer::renderPlayerShootBall(byte color, const Common::Point _position, int frame, const Common::Rect viewArea) {
+void OpenGLShaderRenderer::renderPlayerShootBall(byte color, const Common::Point &_position, int frame, const Common::Rect &viewArea) {
 	uint8 r, g, b;
 
 	Math::Matrix4 identity;
@@ -299,7 +299,7 @@ void OpenGLShaderRenderer::renderPlayerShootBall(byte color, const Common::Point
 	glDepthMask(GL_TRUE);
 }
 
-void OpenGLShaderRenderer::renderPlayerShootRay(byte color, const Common::Point position, const Common::Rect viewArea) {
+void OpenGLShaderRenderer::renderPlayerShootRay(byte color, const Common::Point &position, const Common::Rect &viewArea) {
 	uint8 r, g, b;
 
 	Math::Matrix4 identity;
@@ -402,7 +402,7 @@ void OpenGLShaderRenderer::drawCelestialBody(Math::Vector3d position, float radi
 	//_mvpMatrix = mvpMatrix;
 }
 
-void OpenGLShaderRenderer::renderCrossair(const Common::Point crossairPosition) {
+void OpenGLShaderRenderer::renderCrossair(const Common::Point &crossairPosition) {
 	Math::Matrix4 identity;
 	identity(0, 0) = 1.0;
 	identity(1, 1) = 1.0;

--- a/engines/freescape/gfx_opengl_shaders.h
+++ b/engines/freescape/gfx_opengl_shaders.h
@@ -90,13 +90,13 @@ public:
 	void freeTexture(Texture *texture) override;
 	virtual void drawTexturedRect2D(const Common::Rect &screenRect, const Common::Rect &textureRect, Texture *texture) override;
 
-	virtual void renderSensorShoot(byte color, const Math::Vector3d sensor, const Math::Vector3d player, const Common::Rect viewPort) override;
-	virtual void renderPlayerShootBall(byte color, const Common::Point position, int frame, const Common::Rect viewPort) override;
-	virtual void renderPlayerShootRay(byte color, const Common::Point position, const Common::Rect viewPort) override;
+	virtual void renderSensorShoot(byte color, const Math::Vector3d sensor, const Math::Vector3d player, const Common::Rect &viewPort) override;
+	virtual void renderPlayerShootBall(byte color, const Common::Point &position, int frame, const Common::Rect &viewPort) override;
+	virtual void renderPlayerShootRay(byte color, const Common::Point &position, const Common::Rect &viewPort) override;
 	void drawCelestialBody(Math::Vector3d position, float radius, uint8 color) override;
 	void drawSkybox(Texture *texture, Math::Vector3d camera) override;
 
-	virtual void renderCrossair(const Common::Point crossairPosition) override;
+	virtual void renderCrossair(const Common::Point &crossairPosition) override;
 
 	virtual void renderFace(const Common::Array<Math::Vector3d> &vertices) override;
 

--- a/engines/freescape/gfx_tinygl.cpp
+++ b/engines/freescape/gfx_tinygl.cpp
@@ -170,7 +170,7 @@ void TinyGLRenderer::positionCamera(const Math::Vector3d &pos, const Math::Vecto
 	tglTranslatef(-pos.x(), -pos.y(), -pos.z());
 }
 
-void TinyGLRenderer::renderSensorShoot(byte color, const Math::Vector3d sensor, const Math::Vector3d player, const Common::Rect viewArea) {
+void TinyGLRenderer::renderSensorShoot(byte color, const Math::Vector3d sensor, const Math::Vector3d player, const Common::Rect &viewArea) {
 	tglEnable(TGL_BLEND);
 	tglBlendFunc(TGL_ONE_MINUS_DST_COLOR, TGL_ZERO);
 	tglColor3ub(255, 255, 255);
@@ -185,7 +185,7 @@ void TinyGLRenderer::renderSensorShoot(byte color, const Math::Vector3d sensor, 
 	tglDisable(TGL_BLEND);
 }
 
-void TinyGLRenderer::renderPlayerShootBall(byte color, const Common::Point position, int frame, const Common::Rect viewArea) {
+void TinyGLRenderer::renderPlayerShootBall(byte color, const Common::Point &position, int frame, const Common::Rect &viewArea) {
 	/*uint8 r, g, b;
 
 	tglMatrixMode(TGL_PROJECTION);
@@ -232,7 +232,7 @@ void TinyGLRenderer::renderPlayerShootBall(byte color, const Common::Point posit
 }
 
 
-void TinyGLRenderer::renderPlayerShootRay(byte color, const Common::Point position, const Common::Rect viewArea) {
+void TinyGLRenderer::renderPlayerShootRay(byte color, const Common::Point &position, const Common::Rect &viewArea) {
 	uint8 r, g, b;
 	readFromPalette(color, r, g, b); // TODO: should use opposite color
 
@@ -278,7 +278,7 @@ void TinyGLRenderer::renderPlayerShootRay(byte color, const Common::Point positi
 	tglDepthMask(TGL_TRUE);
 }
 
-void TinyGLRenderer::renderCrossair(const Common::Point crossairPosition) {
+void TinyGLRenderer::renderCrossair(const Common::Point &crossairPosition) {
 	tglMatrixMode(TGL_PROJECTION);
 	tglLoadIdentity();
 	tglOrtho(0, _screenW, _screenH, 0, 0, 1);

--- a/engines/freescape/gfx_tinygl.h
+++ b/engines/freescape/gfx_tinygl.h
@@ -85,10 +85,10 @@ public:
 	virtual void drawTexturedRect2D(const Common::Rect &screenRect, const Common::Rect &textureRect, Texture *texture) override;
 	void drawSkybox(Texture *texture, Math::Vector3d camera) override;
 
-	virtual void renderSensorShoot(byte color, const Math::Vector3d sensor, const Math::Vector3d player, const Common::Rect viewPort) override;
-	virtual void renderPlayerShootBall(byte color, const Common::Point position, int frame, const Common::Rect viewPort) override;
-	virtual void renderPlayerShootRay(byte color, const Common::Point position, const Common::Rect viewPort) override;
-	virtual void renderCrossair(const Common::Point crossairPosition) override;
+	virtual void renderSensorShoot(byte color, const Math::Vector3d sensor, const Math::Vector3d player, const Common::Rect &viewPort) override;
+	virtual void renderPlayerShootBall(byte color, const Common::Point &position, int frame, const Common::Rect &viewPort) override;
+	virtual void renderPlayerShootRay(byte color, const Common::Point &position, const Common::Rect &viewPort) override;
+	virtual void renderCrossair(const Common::Point &crossairPosition) override;
 
 	virtual void renderFace(const Common::Array<Math::Vector3d> &vertices) override;
 

--- a/engines/grim/emi/emi_registry.cpp
+++ b/engines/grim/emi/emi_registry.cpp
@@ -115,7 +115,7 @@ uint EmiRegistry::convertSpeechModeFromGUI(bool subtitles, bool speechMute) cons
 	return 1;
 }
 
-bool EmiRegistry::Get(const Common::String key, float &res) const {
+bool EmiRegistry::Get(const Common::String &key, float &res) const {
 	Debug::debug(Debug::Engine, "GetResidualVMPreference(%s)", key.c_str());
 
 	if (!_transMap.contains(key))
@@ -150,7 +150,7 @@ bool EmiRegistry::Get(const Common::String key, float &res) const {
 	return true;
 }
 
-void EmiRegistry::Set(const Common::String key, float &value)  {
+void EmiRegistry::Set(const Common::String &key, float &value)  {
 	Debug::debug(Debug::Engine, "SetResidualVMPreference(%s, %f)", key.c_str(), value);
 
 	if (!_transMap.contains(key))

--- a/engines/grim/emi/emi_registry.h
+++ b/engines/grim/emi/emi_registry.h
@@ -33,8 +33,8 @@ public:
 	EmiRegistry();
 	~EmiRegistry() { }
 
-	bool Get(const Common::String key, float &res) const;
-	void Set(const Common::String key, float &value);
+	bool Get(const Common::String &key, float &res) const;
+	void Set(const Common::String &key, float &value);
 
 private:
 	uint convertVolumeToMixer(uint volume) const;

--- a/engines/grim/emi/sound/emisound.cpp
+++ b/engines/grim/emi/sound/emisound.cpp
@@ -613,7 +613,7 @@ MusicEntry *EMISound::initMusicTableDemo(const Common::String &filename) {
 	return musicTable;
 }
 
-void EMISound::initMusicTableRetail(MusicEntry *musicTable, const Common::String filename) {
+void EMISound::initMusicTableRetail(MusicEntry *musicTable, const Common::String &filename) {
 	Common::SeekableReadStream *data = g_resourceloader->openNewStreamFile(filename);
 
 	// Remember to check, in case we forgot to copy over those files from the CDs.

--- a/engines/grim/emi/sound/emisound.h
+++ b/engines/grim/emi/sound/emisound.h
@@ -136,7 +136,7 @@ private:
 	void saveTrack(SoundTrack *track, SaveGame *savedState);
 	SoundTrack *restoreTrack(SaveGame *savedState);
 	MusicEntry *initMusicTableDemo(const Common::String &filename);
-	void initMusicTableRetail(MusicEntry *table, const Common::String filename);
+	void initMusicTableRetail(MusicEntry *table, const Common::String &filename);
 };
 
 extern EMISound *g_emiSound;

--- a/engines/groovie/video/player.h
+++ b/engines/groovie/video/player.h
@@ -45,7 +45,7 @@ public:
 	virtual void stopAudioStream() = 0;
 	void fastForward();
 	bool isFastForwarding();
-	virtual void drawString(Graphics::Surface *surface, const Common::String text, int posx, int posy, uint32 color, bool blackBackground) {}
+	virtual void drawString(Graphics::Surface *surface, const Common::String &text, int posx, int posy, uint32 color, bool blackBackground) {}
 	virtual void copyfgtobg(uint8 arg) {}
 	void setOverrideSpeed(bool isOverride);
 

--- a/engines/groovie/video/roq.cpp
+++ b/engines/groovie/video/roq.cpp
@@ -321,7 +321,7 @@ void ROQPlayer::redrawRestoreArea(int screenOffset, bool force) {
 	_restoreArea->right = 0;
 }
 
-void writeImage(const Common::String filename, Graphics::Surface &surface) {
+void writeImage(const Common::String &filename, Graphics::Surface &surface) {
 	if (surface.h == 0 || surface.w == 0) {
 		return;
 	}
@@ -345,7 +345,7 @@ void writeImage(const Common::String filename, Graphics::Surface &surface) {
 #endif
 }
 
-void ROQPlayer::dumpAllSurfaces(const Common::String funcname) {
+void ROQPlayer::dumpAllSurfaces(const Common::String &funcname) {
 	TimeDate date;
 	int curMonth;
 	g_system->getTimeAndDate(date, true);
@@ -1039,7 +1039,7 @@ void ROQPlayer::createAudioStream(bool stereo) {
 	g_system->getMixer()->playStream(Audio::Mixer::kSpeechSoundType, &_soundHandle, _audioStream);
 }
 
-void ROQPlayer::drawString(Graphics::Surface *surface, const Common::String text, int posx, int posy, uint32 color, bool blackBackground) {
+void ROQPlayer::drawString(Graphics::Surface *surface, const Common::String &text, int posx, int posy, uint32 color, bool blackBackground) {
 	// TODO: fix redraw
 #if 0
 	int screenOffset = 0;

--- a/engines/groovie/video/roq.h
+++ b/engines/groovie/video/roq.h
@@ -49,7 +49,7 @@ public:
 		return _soundHandle;
 	}
 
-	void drawString(Graphics::Surface *surface, const Common::String text, int posx, int posy, uint32 color, bool blackBackground) override;
+	void drawString(Graphics::Surface *surface, const Common::String &text, int posx, int posy, uint32 color, bool blackBackground) override;
 	void copyfgtobg(uint8 arg) override;
 
 	bool isFileHandled() override { return _isFileHandled; }
@@ -80,7 +80,7 @@ private:
 	bool processBlockAudioContainer(ROQBlockHeader &blockHeader);
 	bool playFirstFrame() { return _flagNoPlay; }; // _alpha && !_flagOverlay; }
 	void clearOverlay();
-	void dumpAllSurfaces(const Common::String funcname);
+	void dumpAllSurfaces(const Common::String &funcname);
 
 	void paint2(byte i, int destx, int desty);
 	void paint4(byte i, int destx, int desty);

--- a/engines/hadesch/hadesch.h
+++ b/engines/hadesch/hadesch.h
@@ -75,7 +75,7 @@ public:
 	virtual bool handleCheat(const Common::String &cheat) {
 		return false;
 	}
-	virtual void handleUnclick(const Common::String &name, Common::Point pnt) {}
+	virtual void handleUnclick(const Common::String &name, const Common::Point &pnt) {}
 	virtual ~Handler() {}
 };
 

--- a/engines/hadesch/rooms/ferry.cpp
+++ b/engines/hadesch/rooms/ferry.cpp
@@ -452,7 +452,7 @@ public:
 */
 	}
 
-	void handleUnclick(const Common::String &name, const Common::Point pnt) override {
+	void handleUnclick(const Common::String &name, const Common::Point &pnt) override {
 		Common::SharedPtr<VideoRoom> room = g_vm->getVideoRoom();
 		if (_clickTimer >= 0) {
 			g_vm->cancelTimer(24012);

--- a/engines/hadesch/rooms/walloffame.cpp
+++ b/engines/hadesch/rooms/walloffame.cpp
@@ -1000,7 +1000,7 @@ private:
 			v += Common::Point(166 * _philWalkPhase, -2 * _philWalkPhase);
 		return v;
 	}
-	void playPhilVideo(const Common::String &name, int callback, const Common::Point videoOffset) {
+	void playPhilVideo(const Common::String &name, int callback, const Common::Point &videoOffset) {
 		Persistent *persistent = g_vm->getPersistent();
 		cancelAllPhils();
 		if (persistent->_quest == kRescuePhilQuest)

--- a/engines/hpl1/metaengine.cpp
+++ b/engines/hpl1/metaengine.cpp
@@ -61,7 +61,7 @@ Common::Action *createKeyBoardAction(const char *id, const Common::U32String &de
 	return act;
 }
 
-Common::Action *createMouseAction(const char *id, const Common::U32String &desc, const char *defaultMap, const Common::EventType type) {
+Common::Action *createMouseAction(const char *id, const Common::U32String &desc, const char *defaultMap, const Common::EventType &type) {
 	Common::Action *act = new Common::Action(id, desc);
 	act->setEvent(type);
 	act->addDefaultInputMapping(defaultMap);

--- a/engines/hypno/hypno.cpp
+++ b/engines/hypno/hypno.cpp
@@ -303,7 +303,7 @@ void HypnoEngine::loadGame(const Common::String &nextLevel, int score, int puzzl
 	error("Function \"%s\" not implemented", __FUNCTION__);
 }
 
-void HypnoEngine::loadFonts(const Common::String prefix) {
+void HypnoEngine::loadFonts(const Common::String &prefix) {
 	Common::File file;
 	Common::Path path = Common::Path(prefix).append("block05.fgx");
 

--- a/engines/hypno/hypno.h
+++ b/engines/hypno/hypno.h
@@ -365,7 +365,7 @@ public:
 	// Fonts
 	Common::BitArray _font05;
 	Common::BitArray _font08;
-	virtual void loadFonts(const Common::String prefix = "");
+	virtual void loadFonts(const Common::String &prefix = "");
 	virtual void drawString(const Filename &name, const Common::String &str, int x, int y, int w, uint32 c);
 
 	// Conversation
@@ -418,7 +418,7 @@ public:
 	void loadAssetsFullGame();
 	void loadAssetsNI();
 
-	void loadFonts(const Common::String prefix = "") override;
+	void loadFonts(const Common::String &prefix = "") override;
 	void drawString(const Filename &name, const Common::String &str, int x, int y, int w, uint32 c) override;
 	void changeCursor(const Common::String &cursor) override;
 
@@ -462,7 +462,7 @@ public:
 	}
 
 private:
-	Common::String getLocalizedString(const Common::String name);
+	Common::String getLocalizedString(const Common::String &name);
 	uint16 getNextChar(const Common::String &str, uint32 &c);
 	void drawGlyph(const Common::BitArray &font, int x, int y, int bitoffset, int width, int height, int pitch, uint32 color, bool invert);
 	void drawKoreanChar(uint16 chr, int &curx, int y, uint32 color);
@@ -523,7 +523,7 @@ public:
 	Common::String findNextLevel(const Common::String &level) override;
 	Common::String findNextLevel(const Transition *trans) override;
 
-	void loadFonts(const Common::String prefix = "") override;
+	void loadFonts(const Common::String &prefix = "") override;
 	void drawString(const Filename &name, const Common::String &str, int x, int y, int w, uint32 c) override;
 
 	void showConversation() override;
@@ -555,7 +555,7 @@ private:
 	void runLock(Code *code);
 	void runFuseBox(Code *code);
 	void runGiveUp();
-	void showScore(const Common::String prefix);
+	void showScore(const Common::String &prefix);
 
 	uint32 _currentPlayerPosition;
 	uint32 _lastPlayerPosition;

--- a/engines/hypno/spider/hard.cpp
+++ b/engines/hypno/spider/hard.cpp
@@ -1175,7 +1175,7 @@ void SpiderEngine::runGiveUp() {
 	_nextLevel = "mainmenu.mi_";
 }
 
-void SpiderEngine::showScore(const Common::String prefix) {
+void SpiderEngine::showScore(const Common::String &prefix) {
 	Common::String fmessage = "%s\nYou finished the ";
 	fmessage = fmessage + (isDemo() ? "demo" : "game") + " with a score of %d points";
 	Common::String message = Common::String::format(fmessage.c_str(), prefix.c_str(), _score);

--- a/engines/hypno/spider/spider.cpp
+++ b/engines/hypno/spider/spider.cpp
@@ -1155,7 +1155,7 @@ Common::String SpiderEngine::findNextLevel(const Transition *trans) {
 	return trans->nextLevel;
 }
 
-void SpiderEngine::loadFonts(const Common::String prefix) {
+void SpiderEngine::loadFonts(const Common::String &prefix) {
 	HypnoEngine::loadFonts(prefix);
 	// Additional fonts
 	_font = FontMan.getFontByUsage(Graphics::FontManager::kConsoleFont);

--- a/engines/hypno/wet/hard.cpp
+++ b/engines/hypno/wet/hard.cpp
@@ -323,7 +323,7 @@ void WetEngine::showDemoScore() {
 	dialog.runModal();
 }
 
-Common::String WetEngine::getLocalizedString(const Common::String name) {
+Common::String WetEngine::getLocalizedString(const Common::String &name) {
 	if (name == "name") {
 		switch (_language) {
 		case Common::FR_FRA:

--- a/engines/hypno/wet/wet.cpp
+++ b/engines/hypno/wet/wet.cpp
@@ -619,7 +619,7 @@ void WetEngine::showCredits() {
 	}
 }
 
-void WetEngine::loadFonts(const Common::String prefix) {
+void WetEngine::loadFonts(const Common::String &prefix) {
 	HypnoEngine::loadFonts(prefix);
 	if (_language == Common::KO_KOR) {
 		Common::File file;

--- a/engines/icb/surface_manager.cpp
+++ b/engines/icb/surface_manager.cpp
@@ -364,7 +364,7 @@ static void copyRectToSurface(void *dstBuffer, const void *srcBuffer, int32 srcP
 }
 
 static void copyRectToSurface(Graphics::Surface *dstSurface, Graphics::Surface *srcSurface,
-							  int32 destX, int32 destY, const Common::Rect subRect,
+							  int32 destX, int32 destY, const Common::Rect &subRect,
 							  bool8 colorKeyEnable, uint32 colorKey) {
 	assert(srcSurface->format == dstSurface->format);
 	assert(srcSurface->format.bytesPerPixel == 4);

--- a/engines/illusions/actor.cpp
+++ b/engines/illusions/actor.cpp
@@ -918,7 +918,7 @@ void Control::getActorFrameDimensions(WidthHeight &dimensions) {
 	dimensions._height = _actor->_surface->h;
 }
 
-void Control::drawActorRect(const Common::Rect r, byte color) {
+void Control::drawActorRect(const Common::Rect &r, byte color) {
 	_vm->_screen->fillSurfaceRect(_actor->_surface, r, color);
 	_actor->_flags |= Illusions::ACTOR_FLAG_4000;
 }

--- a/engines/illusions/actor.h
+++ b/engines/illusions/actor.h
@@ -222,7 +222,7 @@ public:
 	void updateActorMovement(uint32 deltaTime);
 	void refreshSequenceCode();
 	void getActorFrameDimensions(WidthHeight &dimensions);
-	void drawActorRect(const Common::Rect r, byte color);
+	void drawActorRect(const Common::Rect &r, byte color);
 	void fillActor(byte color);
 	bool isPixelCollision(Common::Point &pt);
 public:

--- a/engines/illusions/menusystem.cpp
+++ b/engines/illusions/menusystem.cpp
@@ -35,7 +35,7 @@ namespace Illusions {
 
 // MenuItem
 
-MenuItem::MenuItem(const Common::String text, BaseMenuAction *action)
+MenuItem::MenuItem(const Common::String &text, BaseMenuAction *action)
 	: _text(text), _action(action) {
 }
 
@@ -63,7 +63,7 @@ BaseMenu::~BaseMenu() {
 	}
 }
 
-void BaseMenu::addText(const Common::String text) {
+void BaseMenu::addText(const Common::String &text) {
 	_text.push_back(text);
 }
 

--- a/engines/illusions/menusystem.h
+++ b/engines/illusions/menusystem.h
@@ -42,7 +42,7 @@ const uint kMenuTextSize = 4096;
 
 class MenuItem {
 public:
-	MenuItem(const Common::String text, BaseMenuAction *action);
+	MenuItem(const Common::String &text, BaseMenuAction *action);
 	~MenuItem();
 	void executeAction(const Common::Point &point);
 	const Common::String& getText() const { return _text; }
@@ -59,7 +59,7 @@ public:
 	BaseMenu(BaseMenuSystem *menuSystem, uint32 fontId, byte backgroundColor, byte borderColor, byte textColor, byte fieldE,
 		uint defaultMenuItemIndex);
 	virtual ~BaseMenu();
-	void addText(const Common::String text);
+	void addText(const Common::String &text);
 	void addMenuItem(MenuItem *menuItem);
 	uint getHeaderLinesCount();
 	const Common::String& getHeaderLine(uint index);

--- a/engines/lab/dispman.cpp
+++ b/engines/lab/dispman.cpp
@@ -66,12 +66,12 @@ DisplayMan::~DisplayMan() {
 	delete[] _displayBuffer;
 }
 
-void DisplayMan::loadPict(const Common::String filename) {
+void DisplayMan::loadPict(const Common::String &filename) {
 	freePict();
 	_curBitmap = _vm->_resource->openDataFile(filename, MKTAG('D', 'I', 'F', 'F'));
 }
 
-void DisplayMan::loadBackPict(const Common::String fileName, uint16 *highPal) {
+void DisplayMan::loadBackPict(const Common::String &fileName, uint16 *highPal) {
 	_fadePalette = highPal;
 	_vm->_anim->_noPalChange = true;
 	readPict(fileName);
@@ -85,7 +85,7 @@ void DisplayMan::loadBackPict(const Common::String fileName, uint16 *highPal) {
 	_vm->_anim->_noPalChange = false;
 }
 
-void DisplayMan::readPict(const Common::String filename, bool playOnce, bool onlyDiffData, byte *memoryBuffer) {
+void DisplayMan::readPict(const Common::String &filename, bool playOnce, bool onlyDiffData, byte *memoryBuffer) {
 	_vm->_anim->stopDiff();
 	loadPict(filename);
 	_vm->_anim->setOutputBuffer(memoryBuffer);
@@ -511,7 +511,7 @@ void DisplayMan::freeFont(TextFont **font) {
 	}
 }
 
-uint16 DisplayMan::textLength(TextFont *font, const Common::String text) {
+uint16 DisplayMan::textLength(TextFont *font, const Common::String &text) {
 	uint16 length = 0;
 
 	if (font) {
@@ -528,7 +528,7 @@ uint16 DisplayMan::textHeight(TextFont *tf) {
 	return (tf) ? tf->_height : 0;
 }
 
-void DisplayMan::drawText(TextFont *tf, uint16 x, uint16 y, uint16 color, const Common::String text) {
+void DisplayMan::drawText(TextFont *tf, uint16 x, uint16 y, uint16 color, const Common::String &text) {
 	byte *vgaTop = getCurrentDrawingBuffer();
 	int numChars = text.size();
 
@@ -652,7 +652,7 @@ void DisplayMan::copyPage(uint16 width, uint16 height, uint16 nheight, uint16 st
 	}
 }
 
-void DisplayMan::doScrollWipe(const Common::String filename) {
+void DisplayMan::doScrollWipe(const Common::String &filename) {
 	_vm->_event->mouseHide();
 	uint16 width = _vm->_utils->vgaScaleX(320);
 	uint16 height = _vm->_utils->vgaScaleY(149) + _vm->_utils->svgaCord(2);
@@ -731,7 +731,7 @@ void DisplayMan::doScrollBounce() {
 	_vm->_event->mouseShow();
 }
 
-void DisplayMan::doTransWipe(const Common::String filename) {
+void DisplayMan::doTransWipe(const Common::String &filename) {
 	uint16 lastY, linesLast;
 
 	if (_vm->_isHiRes) {
@@ -816,7 +816,7 @@ void DisplayMan::doTransWipe(const Common::String filename) {
 	// bitMapBuffer will be deleted by the Image destructor
 }
 
-void DisplayMan::doTransition(TransitionType transitionType, const Common::String filename) {
+void DisplayMan::doTransition(TransitionType transitionType, const Common::String &filename) {
 	switch (transitionType) {
 	case kTransitionWipe:
 	case kTransitionTransporter:

--- a/engines/lab/dispman.h
+++ b/engines/lab/dispman.h
@@ -85,7 +85,7 @@ private:
 	/**
 	 * Scrolls the display to a new picture from a black screen.
 	 */
-	void doScrollWipe(const Common::String filename);
+	void doScrollWipe(const Common::String &filename);
 
 	/**
 	 * Does the scroll bounce.  Assumes bitmap already in memory.
@@ -95,7 +95,7 @@ private:
 	/**
 	 * Does the transporter wipe.
 	 */
-	void doTransWipe(const Common::String filename);
+	void doTransWipe(const Common::String &filename);
 
 	/**
 	 * Draws a vertical line.
@@ -110,7 +110,7 @@ private:
 	/**
 	 * Draws the text to the screen.
 	 */
-	void drawText(TextFont *tf, uint16 x, uint16 y, uint16 color, const Common::String text);
+	void drawText(TextFont *tf, uint16 x, uint16 y, uint16 color, const Common::String &text);
 
 	/**
 	 * Gets a line of text for flowText; makes sure that its length is less than
@@ -121,7 +121,7 @@ private:
 	/**
 	 * Returns the length of a text in the specified font.
 	 */
-	uint16 textLength(TextFont *font, const Common::String text);
+	uint16 textLength(TextFont *font, const Common::String &text);
 
 	bool _actionMessageShown;
 	Common::File *_curBitmap;
@@ -132,19 +132,19 @@ public:
 	DisplayMan(LabEngine *lab);
 	virtual ~DisplayMan();
 
-	void loadPict(const Common::String filename);
-	void loadBackPict(const Common::String fileName, uint16 *highPal);
+	void loadPict(const Common::String &filename);
+	void loadBackPict(const Common::String &fileName, uint16 *highPal);
 
 	/**
 	 * Reads in a picture into the display bitmap.
 	 */
-	void readPict(const Common::String filename, bool playOnce = true, bool onlyDiffData = false, byte *memoryBuffer = nullptr);
+	void readPict(const Common::String &filename, bool playOnce = true, bool onlyDiffData = false, byte *memoryBuffer = nullptr);
 	void freePict();
 
 	/**
 	 * Does a certain number of pre-programmed wipes.
 	 */
-	void doTransition(TransitionType transitionType, const Common::String filename);
+	void doTransition(TransitionType transitionType, const Common::String &filename);
 
 	/**
 	 * Changes the front screen to black.

--- a/engines/lab/intro.cpp
+++ b/engines/lab/intro.cpp
@@ -68,7 +68,7 @@ void Intro::introEatMessages() {
 	}
 }
 
-void Intro::doPictText(const Common::String filename, bool isScreen) {
+void Intro::doPictText(const Common::String &filename, bool isScreen) {
 	Common::String path = Common::String("Lab:rooms/Intro/") + filename;
 
 	uint timeDelay = (isScreen) ? 35 : 7;
@@ -191,7 +191,7 @@ void Intro::doPictText(const Common::String filename, bool isScreen) {
 	}	// while(1)
 }
 
-void Intro::nReadPict(const Common::String filename, bool playOnce, bool noPalChange, bool doBlack, int wait) {
+void Intro::nReadPict(const Common::String &filename, bool playOnce, bool noPalChange, bool doBlack, int wait) {
 	Common::String finalFileName = Common::String("P:Intro/") + filename;
 
 	_vm->updateEvents();

--- a/engines/lab/intro.h
+++ b/engines/lab/intro.h
@@ -52,9 +52,9 @@ private:
 	/**
 	 * Reads in a picture.
 	 */
-	void doPictText(const Common::String filename, bool isScreen = false);
+	void doPictText(const Common::String &filename, bool isScreen = false);
 
-	void nReadPict(const Common::String filename, bool playOnce = true, bool noPalChange = false, bool doBlack = false, int wait = 0);
+	void nReadPict(const Common::String &filename, bool playOnce = true, bool noPalChange = false, bool doBlack = false, int wait = 0);
 
 	LabEngine *_vm;
 	bool _quitIntro;

--- a/engines/lab/lab.h
+++ b/engines/lab/lab.h
@@ -281,7 +281,7 @@ private:
 	/**
 	 * Does what's necessary for the monitor.
 	 */
-	void doMonitor(const Common::String background, const Common::String textfile, bool isinteractive, Common::Rect textRect);
+	void doMonitor(const Common::String &background, const Common::String &textfile, bool isinteractive, Common::Rect textRect);
 
 	/**
 	 * Does the things to properly set up the detective notes.
@@ -483,7 +483,7 @@ private:
 	/**
 	 * Writes the game out to disk.
 	 */
-	bool saveGame(int slot, const Common::String desc);
+	bool saveGame(int slot, const Common::String &desc);
 
 	/**
 	 * Reads the game from disk.

--- a/engines/lab/labsets.cpp
+++ b/engines/lab/labsets.cpp
@@ -59,7 +59,7 @@ void LargeSet::exclElement(uint16 element) {
 	_array[(element - 1) >> 4] &= ~(1 << ((element - 1) % 16));
 }
 
-bool LargeSet::readInitialConditions(const Common::String fileName) {
+bool LargeSet::readInitialConditions(const Common::String &fileName) {
 	Common::File *file = _vm->_resource->openDataFile(fileName, MKTAG('C', 'O', 'N', '0'));
 
 	uint16 conditions = file->readUint16LE();

--- a/engines/lab/labsets.h
+++ b/engines/lab/labsets.h
@@ -45,7 +45,7 @@ public:
 	bool in(uint16 element);
 	void inclElement(uint16 element);
 	void exclElement(uint16 element);
-	bool readInitialConditions(const Common::String fileName);
+	bool readInitialConditions(const Common::String &fileName);
 
 private:
 	LabEngine *_vm;

--- a/engines/lab/music.cpp
+++ b/engines/lab/music.cpp
@@ -58,7 +58,7 @@ byte Music::getSoundFlags() {
 	return soundFlags;
 }
 
-void Music::loadSoundEffect(const Common::String filename, bool loop, bool waitTillFinished) {
+void Music::loadSoundEffect(const Common::String &filename, bool loop, bool waitTillFinished) {
 	stopSoundEffect();
 
 	Common::File *file = _vm->_resource->openDataFile(filename, MKTAG('D', 'I', 'F', 'F'));
@@ -131,7 +131,7 @@ bool Music::isSoundEffectActive() const {
 	return _vm->_mixer->isSoundHandleActive(_sfxHandle);
 }
 
-void Music::changeMusic(const Common::String filename, bool storeCurPos, bool seektoStoredPos) {
+void Music::changeMusic(const Common::String &filename, bool storeCurPos, bool seektoStoredPos) {
 	if (storeCurPos)
 		_storedPos = _musicFile->pos();
 

--- a/engines/lab/music.h
+++ b/engines/lab/music.h
@@ -65,7 +65,7 @@ public:
 	/**
 	 * Changes the background music to something else.
 	 */
-	void changeMusic(const Common::String filename, bool storeCurPos, bool seektoStoredPos);
+	void changeMusic(const Common::String &filename, bool storeCurPos, bool seektoStoredPos);
 
 	void resetMusic(bool seekToStoredPos);
 
@@ -85,7 +85,7 @@ public:
 	/**
 	 * Reads in a sound effect file.  Ignores any graphics.
 	 */
-	void loadSoundEffect(const Common::String filename, bool loop, bool waitTillFinished);
+	void loadSoundEffect(const Common::String &filename, bool loop, bool waitTillFinished);
 
 	void stopSoundEffect();
 };

--- a/engines/lab/resource.cpp
+++ b/engines/lab/resource.cpp
@@ -51,7 +51,7 @@ void Resource::readStaticText() {
 	delete labTextFile;
 }
 
-TextFont *Resource::getFont(const Common::String fileName) {
+TextFont *Resource::getFont(const Common::String &fileName) {
 	// TODO: Add support for the font format of the Amiga version
 	Common::File *dataFile = openDataFile(fileName, MKTAG('V', 'G', 'A', 'F'));
 
@@ -73,7 +73,7 @@ TextFont *Resource::getFont(const Common::String fileName) {
 	return textfont;
 }
 
-Common::String Resource::getText(const Common::String fileName) {
+Common::String Resource::getText(const Common::String &fileName) {
 	Common::File *dataFile = openDataFile(fileName);
 
 	uint32 count = dataFile->size();
@@ -92,7 +92,7 @@ Common::String Resource::getText(const Common::String fileName) {
 	return str;
 }
 
-void Resource::readRoomData(const Common::String fileName) {
+void Resource::readRoomData(const Common::String &fileName) {
 	Common::File *dataFile = openDataFile(fileName, MKTAG('D', 'O', 'R', '1'));
 
 	_vm->_manyRooms = dataFile->readUint16LE();
@@ -111,7 +111,7 @@ void Resource::readRoomData(const Common::String fileName) {
 	delete dataFile;
 }
 
-InventoryData *Resource::readInventory(const Common::String fileName) {
+InventoryData *Resource::readInventory(const Common::String &fileName) {
 	Common::File *dataFile = openDataFile(fileName, MKTAG('I', 'N', 'V', '1'));
 
 	_vm->_numInv = dataFile->readUint16LE();
@@ -216,7 +216,7 @@ Common::Path Resource::translateFileName(const Common::String &filename) {
 	return Common::Path(fileNameStrFinal);
 }
 
-Common::File *Resource::openDataFile(const Common::String filename, uint32 fileHeader) {
+Common::File *Resource::openDataFile(const Common::String &filename, uint32 fileHeader) {
 	Common::File *dataFile = new Common::File();
 	dataFile->open(translateFileName(filename));
 

--- a/engines/lab/resource.h
+++ b/engines/lab/resource.h
@@ -96,12 +96,12 @@ public:
 	Resource(LabEngine *vm);
 	~Resource() {}
 
-	Common::File *openDataFile(const Common::String filename, uint32 fileHeader = 0);
-	void readRoomData(const Common::String fileName);
-	InventoryData *readInventory(const Common::String fileName);
+	Common::File *openDataFile(const Common::String &filename, uint32 fileHeader = 0);
+	void readRoomData(const Common::String &fileName);
+	InventoryData *readInventory(const Common::String &fileName);
 	void readViews(uint16 roomNum);
-	TextFont *getFont(const Common::String fileName);
-	Common::String getText(const Common::String fileName);
+	TextFont *getFont(const Common::String &fileName);
+	Common::String getText(const Common::String &fileName);
 	Common::String getStaticText(byte index) const { return _staticText[index]; }
 
 private:

--- a/engines/lab/savegame.cpp
+++ b/engines/lab/savegame.cpp
@@ -124,7 +124,7 @@ WARN_UNUSED_RESULT bool readSaveGameHeader(Common::InSaveFile *in, SaveGameHeade
 	return true;
 }
 
-bool LabEngine::saveGame(int slot, const Common::String desc) {
+bool LabEngine::saveGame(int slot, const Common::String &desc) {
 	Common::String fileName = getSaveStateName(slot);
 	Common::SaveFileManager *saveFileManager = _system->getSavefileManager();
 	Common::OutSaveFile *file = saveFileManager->openForSaving(fileName);

--- a/engines/lab/special.cpp
+++ b/engines/lab/special.cpp
@@ -438,7 +438,7 @@ void LabEngine::processMonitor(const Common::String &ntext, TextFont *monitorFon
 	}	// while
 }
 
-void LabEngine::doMonitor(const Common::String background, const Common::String textfile, bool isinteractive, Common::Rect textRect) {
+void LabEngine::doMonitor(const Common::String &background, const Common::String &textfile, bool isinteractive, Common::Rect textRect) {
 	Common::Rect scaledRect = _utils->vgaRectScale(textRect.left, textRect.top, textRect.right, textRect.bottom);
 	_monitorTextFilename = textfile;
 

--- a/engines/lab/speciallocks.cpp
+++ b/engines/lab/speciallocks.cpp
@@ -235,7 +235,7 @@ void SpecialLocks::doTile(bool showsolution) {
 	}
 }
 
-void SpecialLocks::showTileLock(const Common::String filename, bool showSolution) {
+void SpecialLocks::showTileLock(const Common::String &filename, bool showSolution) {
 	_vm->_anim->_doBlack = true;
 	_vm->_anim->_noPalChange = true;
 	_vm->_graphics->readPict(filename);
@@ -348,7 +348,7 @@ void SpecialLocks::changeCombination(uint16 number) {
 		_vm->_conditions->exclElement(COMBINATIONUNLOCKED);
 }
 
-void SpecialLocks::showCombinationLock(const Common::String filename) {
+void SpecialLocks::showCombinationLock(const Common::String &filename) {
 	_vm->_anim->_doBlack = true;
 	_vm->_anim->_noPalChange = true;
 	_vm->_graphics->readPict(filename);

--- a/engines/lab/speciallocks.h
+++ b/engines/lab/speciallocks.h
@@ -48,14 +48,14 @@ public:
 	SpecialLocks(LabEngine *vm);
 	~SpecialLocks();
 
-	void showTileLock(const Common::String filename, bool showSolution);
+	void showTileLock(const Common::String &filename, bool showSolution);
 
 	/**
 	 * Processes mouse clicks and changes tile positions.
 	 */
 	void tileClick(Common::Point pos);
 
-	void showCombinationLock(const Common::String filename);
+	void showCombinationLock(const Common::String &filename);
 
 	/**
 	 * Processes mouse clicks and changes the door combination.

--- a/engines/lastexpress/game/savepoint.cpp
+++ b/engines/lastexpress/game/savepoint.cpp
@@ -55,7 +55,7 @@ void SavePoints::push(EntityIndex entity2, EntityIndex entity1, ActionIndex acti
 	_savepoints.push_back(point);
 }
 
-void SavePoints::push(EntityIndex entity2, EntityIndex entity1, ActionIndex action, const Common::String param) {
+void SavePoints::push(EntityIndex entity2, EntityIndex entity1, ActionIndex action, const Common::String &param) {
 	if (_savepoints.size() >= _savePointsMaxSize)
 		return;
 
@@ -155,7 +155,7 @@ void SavePoints::call(EntityIndex entity2, EntityIndex entity1, ActionIndex acti
 	}
 }
 
-void SavePoints::call(EntityIndex entity2, EntityIndex entity1, ActionIndex action, const Common::String param) const {
+void SavePoints::call(EntityIndex entity2, EntityIndex entity1, ActionIndex action, const Common::String &param) const {
 	SavePoint point;
 	point.entity1 = entity1;
 	point.action = action;

--- a/engines/lastexpress/game/savepoint.h
+++ b/engines/lastexpress/game/savepoint.h
@@ -101,7 +101,7 @@ public:
 
 	// Savepoints
 	void push(EntityIndex entity2, EntityIndex entity1, ActionIndex action, uint32 param = 0);
-	void push(EntityIndex entity2, EntityIndex entity1, ActionIndex action, const Common::String param);
+	void push(EntityIndex entity2, EntityIndex entity1, ActionIndex action, const Common::String &param);
 	void pushAll(EntityIndex entity, ActionIndex action, uint32 param = 0);
 	void process();
 	void reset();
@@ -113,7 +113,7 @@ public:
 	void setCallback(EntityIndex index, Callback *callback);
 	Callback *getCallback(EntityIndex entity) const;
 	void call(EntityIndex entity2, EntityIndex entity1, ActionIndex action, uint32 param = 0) const;
-	void call(EntityIndex entity2, EntityIndex entity1, ActionIndex action, const Common::String param) const;
+	void call(EntityIndex entity2, EntityIndex entity1, ActionIndex action, const Common::String &param) const;
 	void callAndProcess();
 
 	// Serializable

--- a/engines/macventure/controls.cpp
+++ b/engines/macventure/controls.cpp
@@ -62,7 +62,7 @@ void CommandButton::draw(Graphics::ManagedSurface &surface) const {
 	}
 }
 
-bool CommandButton::isInsideBounds(const Common::Point point) const {
+bool CommandButton::isInsideBounds(const Common::Point &point) const {
 	return _data.bounds.contains(point);
 }
 

--- a/engines/macventure/controls.h
+++ b/engines/macventure/controls.h
@@ -96,7 +96,7 @@ public:
 	~CommandButton() {}
 
 	void draw(Graphics::ManagedSurface &surface) const;
-	bool isInsideBounds(const Common::Point point) const;
+	bool isInsideBounds(const Common::Point &point) const;
 	const ControlData &getData() const;
 	void select();
 	void unselect();

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -632,7 +632,7 @@ public:
 	void upgradeTargetIfNecessary(const Common::String &target) const;
 
 	/** Generate valid, non-repeated domainName for game*/
-	Common::String generateUniqueDomain(const Common::String gameId);
+	Common::String generateUniqueDomain(const Common::String &gameId);
 
 private:
 	/** Find a game across all loaded plugins. */

--- a/engines/mm/mm1/events.cpp
+++ b/engines/mm/mm1/events.cpp
@@ -185,7 +185,7 @@ void Events::clearViews() {
 	_views.clear();
 }
 
-void Events::addKeypress(const Common::KeyCode kc) {
+void Events::addKeypress(const Common::KeyCode &kc) {
 	Common::KeyState ks;
 	ks.keycode = kc;
 	if (kc >= Common::KEYCODE_SPACE && kc <= Common::KEYCODE_TILDE)

--- a/engines/mm/mm1/events.h
+++ b/engines/mm/mm1/events.h
@@ -367,7 +367,7 @@ public:
 	/**
 	 * Add a keypress to the event queue
 	 */
-	void addKeypress(const Common::KeyCode kc);
+	void addKeypress(const Common::KeyCode &kc);
 
 	/**
 	 * Add a action to the event queue

--- a/engines/mtropolis/render.cpp
+++ b/engines/mtropolis/render.cpp
@@ -203,7 +203,7 @@ void Window::onMouseMove(int32 x, int32 y) {
 void Window::onMouseUp(int32 x, int32 y, int mouseButton) {
 }
 
-void Window::onKeyboardEvent(const Common::EventType evtType, bool repeat, const Common::KeyState &keyEvt) {
+void Window::onKeyboardEvent(const Common::EventType &evtType, bool repeat, const Common::KeyState &keyEvt) {
 }
 
 void Window::onAction(Actions::Action action) {
@@ -430,7 +430,7 @@ static void runDissolveTransition(Graphics::ManagedSurface &surface, const Graph
 	}
 }
 
-static void safeCopyRectToSurface(Graphics::ManagedSurface &surface, const Graphics::ManagedSurface &srcSurface, int destX, int destY, const Common::Rect subRect) {
+static void safeCopyRectToSurface(Graphics::ManagedSurface &surface, const Graphics::ManagedSurface &srcSurface, int destX, int destY, const Common::Rect &subRect) {
 	if (subRect.width() == 0 || subRect.height() == 0)
 		return;
 

--- a/engines/mtropolis/render.h
+++ b/engines/mtropolis/render.h
@@ -124,7 +124,7 @@ public:
 	virtual void onMouseDown(int32 x, int32 y, int mouseButton);
 	virtual void onMouseMove(int32 x, int32 y);
 	virtual void onMouseUp(int32 x, int32 y, int mouseButton);
-	virtual void onKeyboardEvent(const Common::EventType evtType, bool repeat, const Common::KeyState &keyEvt);
+	virtual void onKeyboardEvent(const Common::EventType &evtType, bool repeat, const Common::KeyState &keyEvt);
 	virtual void onAction(Actions::Action action);
 
 protected:

--- a/engines/mtropolis/runtime.cpp
+++ b/engines/mtropolis/runtime.cpp
@@ -96,7 +96,7 @@ public:
 	void onMouseDown(int32 x, int32 y, int mouseButton) override;
 	void onMouseMove(int32 x, int32 y) override;
 	void onMouseUp(int32 x, int32 y, int mouseButton) override;
-	void onKeyboardEvent(const Common::EventType evtType, bool repeat, const Common::KeyState &keyEvt) override;
+	void onKeyboardEvent(const Common::EventType &evtType, bool repeat, const Common::KeyState &keyEvt) override;
 	void onAction(MTropolis::Actions::Action action) override;
 
 private:
@@ -132,7 +132,7 @@ void MainWindow::onMouseUp(int32 x, int32 y, int mouseButton) {
 	}
 }
 
-void MainWindow::onKeyboardEvent(const Common::EventType evtType, bool repeat, const Common::KeyState &keyEvt) {
+void MainWindow::onKeyboardEvent(const Common::EventType &evtType, bool repeat, const Common::KeyState &keyEvt) {
 	_runtime->queueOSEvent(Common::SharedPtr<OSEvent>(new KeyboardInputEvent(kOSEventTypeKeyboard, evtType, repeat, keyEvt)));
 }
 
@@ -6699,7 +6699,7 @@ void Runtime::onMouseUp(int32 x, int32 y, Actions::MouseButton mButton) {
 		_mouseFocusWindow.reset();
 }
 
-void Runtime::onKeyboardEvent(const Common::EventType evtType, bool repeat, const Common::KeyState &keyEvt) {
+void Runtime::onKeyboardEvent(const Common::EventType &evtType, bool repeat, const Common::KeyState &keyEvt) {
 	Common::SharedPtr<Window> focusWindow = _keyFocusWindow.lock();
 	if (focusWindow)
 		focusWindow->onKeyboardEvent(evtType, repeat, keyEvt);

--- a/engines/mtropolis/runtime.h
+++ b/engines/mtropolis/runtime.h
@@ -1656,7 +1656,7 @@ public:
 	void onMouseDown(int32 x, int32 y, Actions::MouseButton mButton);
 	void onMouseMove(int32 x, int32 y);
 	void onMouseUp(int32 x, int32 y, Actions::MouseButton mButton);
-	void onKeyboardEvent(const Common::EventType evtType, bool repeat, const Common::KeyState &keyEvt);
+	void onKeyboardEvent(const Common::EventType &evtType, bool repeat, const Common::KeyState &keyEvt);
 	void onAction(MTropolis::Actions::Action action);
 
 	const Common::Point &getCachedMousePosition() const;

--- a/engines/mutationofjb/animationdecoder.cpp
+++ b/engines/mutationofjb/animationdecoder.cpp
@@ -111,7 +111,7 @@ bool AnimationDecoder::decode(AnimationDecoderCallback *callback) {
 	return true;
 }
 
-void AnimationDecoder::setPartialMode(int fromFrame, int toFrame, const Common::Rect area, uint8 threshold) {
+void AnimationDecoder::setPartialMode(int fromFrame, int toFrame, const Common::Rect &area, uint8 threshold) {
 	_fromFrame = fromFrame;
 	_toFrame = toFrame;
 	_area = area;

--- a/engines/mutationofjb/animationdecoder.h
+++ b/engines/mutationofjb/animationdecoder.h
@@ -64,7 +64,7 @@ public:
 	 * @param area Output surface will be confined to this area.
 	 * @param threshold Source pixels with color index above this threshold will not be replaced.
 	 */
-	void setPartialMode(int fromFrame, int toFrame, const Common::Rect area = Common::Rect(), uint8 threshold = 0xFF);
+	void setPartialMode(int fromFrame, int toFrame, const Common::Rect &area = Common::Rect(), uint8 threshold = 0xFF);
 
 private:
 	void loadPalette(Common::SeekableReadStream &stream);

--- a/engines/myst3/database.cpp
+++ b/engines/myst3/database.cpp
@@ -451,7 +451,7 @@ const AgeData Database::_ages[] = {
 	{ 11, 0, 1, roomsLOGO, 0 }
 };
 
-Database::Database(const Common::Platform platform, const Common::Language language, const uint32 localizationType) :
+Database::Database(const Common::Platform &platform, const Common::Language &language, const uint32 localizationType) :
 		_platform(platform),
 		_language(language),
 		_localizationType(localizationType),

--- a/engines/myst3/database.h
+++ b/engines/myst3/database.h
@@ -161,7 +161,7 @@ class Myst3Engine;
 
 class Database {
 public:
-	Database(const Common::Platform platform, const Common::Language language, const uint32 localizationType);
+	Database(const Common::Platform &platform, const Common::Language &language, const uint32 localizationType);
 	~Database();
 
 	/**

--- a/engines/myst3/state.cpp
+++ b/engines/myst3/state.cpp
@@ -80,7 +80,7 @@ GameState::StateData::StateData() {
 	isAutosave = false;
 }
 
-GameState::GameState(const Common::Platform platform, Database *database):
+GameState::GameState(const Common::Platform &platform, Database *database):
 		_platform(platform),
 		_db(database) {
 

--- a/engines/myst3/state.h
+++ b/engines/myst3/state.h
@@ -47,7 +47,7 @@ enum ViewType {
 
 class GameState {
 public:
-	GameState(const Common::Platform platform, Database *database);
+	GameState(const Common::Platform &platform, Database *database);
 	virtual ~GameState();
 
 	void newGame();

--- a/engines/nancy/graphics.cpp
+++ b/engines/nancy/graphics.cpp
@@ -382,7 +382,7 @@ void GraphicsManager::rotateBlit(const Graphics::ManagedSurface &src, Graphics::
 	}
 }
 
-void GraphicsManager::crossDissolve(const Graphics::ManagedSurface &from, const Graphics::ManagedSurface &to, byte alpha, const Common::Rect rect, Graphics::ManagedSurface &inResult) {
+void GraphicsManager::crossDissolve(const Graphics::ManagedSurface &from, const Graphics::ManagedSurface &to, byte alpha, const Common::Rect &rect, Graphics::ManagedSurface &inResult) {
 	assert(from.getBounds() == to.getBounds());
 	inResult.blitFrom(from, rect, Common::Point());
 	inResult.transBlitFrom(to, rect, Common::Point(), (uint32)-1, false, alpha);

--- a/engines/nancy/graphics.h
+++ b/engines/nancy/graphics.h
@@ -70,7 +70,7 @@ public:
 	static void copyToManaged(void *src, Graphics::ManagedSurface &dst, uint srcW, uint srcH, const Graphics::PixelFormat &format, bool verticalFlip = false, bool doubleSize = false);
 
 	static void rotateBlit(const Graphics::ManagedSurface &src, Graphics::ManagedSurface &dest, byte rotation);
-	static void crossDissolve(const Graphics::ManagedSurface &from, const Graphics::ManagedSurface &to, byte alpha, const Common::Rect rect, Graphics::ManagedSurface &inResult);
+	static void crossDissolve(const Graphics::ManagedSurface &from, const Graphics::ManagedSurface &to, byte alpha, const Common::Rect &rect, Graphics::ManagedSurface &inResult);
 
 	// Debug
 	void debugDrawToScreen(const Graphics::ManagedSurface &surf);

--- a/engines/pegasus/hotspot.cpp
+++ b/engines/pegasus/hotspot.cpp
@@ -189,7 +189,7 @@ void Hotspot::moveSpotTo(const CoordType h, const CoordType v) {
 	_spotArea.moveTo(h, v);
 }
 
-void Hotspot::moveSpotTo(const Common::Point pt) {
+void Hotspot::moveSpotTo(const Common::Point &pt) {
 	_spotArea.moveTo(pt);
 }
 
@@ -197,11 +197,11 @@ void Hotspot::moveSpot(const CoordType h, const CoordType v) {
 	_spotArea.translate(h, v);
 }
 
-void Hotspot::moveSpot(const Common::Point pt) {
+void Hotspot::moveSpot(const Common::Point &pt) {
 	_spotArea.translate(pt.x, pt.y);
 }
 
-bool Hotspot::pointInSpot(const Common::Point where) const {
+bool Hotspot::pointInSpot(const Common::Point &where) const {
 	return _spotActive && _spotArea.pointInRegion(where);
 }
 
@@ -223,7 +223,7 @@ void HotspotList::deleteHotspots() {
 	clear();
 }
 
-Hotspot *HotspotList::findHotspot(const Common::Point where) {
+Hotspot *HotspotList::findHotspot(const Common::Point &where) {
 	for (HotspotIterator it = begin(); it != end(); it++)
 		if ((*it)->pointInSpot(where))
 			return *it;
@@ -231,7 +231,7 @@ Hotspot *HotspotList::findHotspot(const Common::Point where) {
 	return nullptr;
 }
 
-HotSpotID HotspotList::findHotspotID(const Common::Point where) {
+HotSpotID HotspotList::findHotspotID(const Common::Point &where) {
 	Hotspot *hotspot = findHotspot(where);
 	return hotspot ? hotspot->getObjectID() : kNoHotSpotID;
 }

--- a/engines/pegasus/hotspot.h
+++ b/engines/pegasus/hotspot.h
@@ -96,11 +96,11 @@ public:
 	void getCenter(CoordType&, CoordType&) const;
 
 	void moveSpotTo(const CoordType, const CoordType);
-	void moveSpotTo(const Common::Point);
+	void moveSpotTo(const Common::Point &);
 	void moveSpot(const CoordType, const CoordType);
-	void moveSpot(const Common::Point);
+	void moveSpot(const Common::Point &);
 
-	bool pointInSpot(const Common::Point) const;
+	bool pointInSpot(const Common::Point &) const;
 
 	void setActive();
 	void setInactive();
@@ -123,8 +123,8 @@ public:
 
 	void deleteHotspots();
 
-	Hotspot *findHotspot(const Common::Point);
-	HotSpotID findHotspotID(const Common::Point);
+	Hotspot *findHotspot(const Common::Point &);
+	HotSpotID findHotspotID(const Common::Point &);
 	Hotspot *findHotspotByID(const HotSpotID);
 	Hotspot *findHotspotByMask(const HotSpotFlags);
 

--- a/engines/pegasus/input.cpp
+++ b/engines/pegasus/input.cpp
@@ -313,7 +313,7 @@ InputBits InputHandler::getClickFilter() {
 	return kFilterNoInput;
 }
 
-void InputHandler::updateCursor(const Common::Point cursorLocation, const Hotspot *cursorSpot) {
+void InputHandler::updateCursor(const Common::Point &cursorLocation, const Hotspot *cursorSpot) {
 	if (_nextHandler)
 		_nextHandler->updateCursor(cursorLocation, cursorSpot);
 }

--- a/engines/pegasus/input.h
+++ b/engines/pegasus/input.h
@@ -427,7 +427,7 @@ public:
 	virtual void clickInHotspot(const Input &, const Hotspot *);
 
 	virtual void activateHotspots();
-	virtual void updateCursor(const Common::Point, const Hotspot *);
+	virtual void updateCursor(const Common::Point &, const Hotspot *);
 	virtual bool isClickInput(const Input &, const Hotspot *);
 	virtual bool wantsCursor();
 

--- a/engines/pegasus/movie.cpp
+++ b/engines/pegasus/movie.cpp
@@ -162,7 +162,7 @@ void Movie::setTime(const TimeValue time, const TimeScale scale) {
 	}
 }
 
-void Movie::setRate(const Common::Rational rate) {
+void Movie::setRate(const Common::Rational &rate) {
 	if (_video) {
 		_video->setRate(rate);
 

--- a/engines/pegasus/movie.h
+++ b/engines/pegasus/movie.h
@@ -53,7 +53,7 @@ public:
 
 	void setTime(const TimeValue, const TimeScale = 0) override;
 
-	void setRate(const Common::Rational) override;
+	void setRate(const Common::Rational &) override;
 
 	void start() override;
 	void stop() override;

--- a/engines/pegasus/neighborhood/caldoria/caldoria.cpp
+++ b/engines/pegasus/neighborhood/caldoria/caldoria.cpp
@@ -2574,7 +2574,7 @@ Common::Path Caldoria::getHintMovie(uint hintNum) {
 	return movieName;
 }
 
-void Caldoria::updateCursor(const Common::Point where, const Hotspot *cursorSpot) {
+void Caldoria::updateCursor(const Common::Point &where, const Hotspot *cursorSpot) {
 	if (cursorSpot) {
 		switch (cursorSpot->getObjectID()) {
 		case kCa4DEnvironCloseSpotID:

--- a/engines/pegasus/neighborhood/caldoria/caldoria.h
+++ b/engines/pegasus/neighborhood/caldoria/caldoria.h
@@ -511,7 +511,7 @@ protected:
 	CanOpenDoorReason canOpenDoor(DoorTable::Entry &) override;
 	void doorOpened() override;
 
-	void updateCursor(const Common::Point, const Hotspot *) override;
+	void updateCursor(const Common::Point &, const Hotspot *) override;
 
 	FlagsArray<uint16, kNumCaldoriaPrivateFlags> _privateFlags;
 

--- a/engines/pegasus/neighborhood/mars/mars.cpp
+++ b/engines/pegasus/neighborhood/mars/mars.cpp
@@ -4207,7 +4207,7 @@ void Mars::decreaseRobotShuttleEnergy(const int delta, Common::Point impactPoint
 	}
 }
 
-void Mars::updateCursor(const Common::Point cursorLocation, const Hotspot *cursorSpot) {
+void Mars::updateCursor(const Common::Point &cursorLocation, const Hotspot *cursorSpot) {
 	if (cursorSpot && cursorSpot->getObjectID() == kShuttleViewSpotID) {
 		if (_weaponSelection != kNoWeapon)
 			_vm->_cursor->setCurrentFrameIndex(6);

--- a/engines/pegasus/neighborhood/mars/mars.h
+++ b/engines/pegasus/neighborhood/mars/mars.h
@@ -194,7 +194,7 @@ protected:
 	void startUpFromSpaceChase();
 	void transportOutFromSpaceChase(bool);
 	void spaceChaseClick(const Input &, const HotSpotID);
-	void updateCursor(const Common::Point, const Hotspot *) override;
+	void updateCursor(const Common::Point &, const Hotspot *) override;
 	void playSpaceAmbient();
 
 	Common::Path getSoundSpotsName() override;

--- a/engines/pegasus/neighborhood/tsa/fulltsa.cpp
+++ b/engines/pegasus/neighborhood/tsa/fulltsa.cpp
@@ -3525,7 +3525,7 @@ void FullTSA::doSolve() {
 	}
 }
 
-void FullTSA::updateCursor(const Common::Point where, const Hotspot *cursorSpot) {
+void FullTSA::updateCursor(const Common::Point &where, const Hotspot *cursorSpot) {
 	if (cursorSpot) {
 		switch (cursorSpot->getObjectID()) {
 		case kTSA0BEastMonitorSpotID:

--- a/engines/pegasus/neighborhood/tsa/fulltsa.h
+++ b/engines/pegasus/neighborhood/tsa/fulltsa.h
@@ -73,7 +73,7 @@ public:
 	bool canSolve() override;
 	void doSolve() override;
 
-	void updateCursor(const Common::Point, const Hotspot *) override;
+	void updateCursor(const Common::Point &, const Hotspot *) override;
 
 protected:
 	enum {

--- a/engines/pegasus/pegasus.cpp
+++ b/engines/pegasus/pegasus.cpp
@@ -1972,7 +1972,7 @@ bool PegasusEngine::wantsCursor() {
 	return _gameMenu == nullptr;
 }
 
-void PegasusEngine::updateCursor(const Common::Point, const Hotspot *cursorSpot) {
+void PegasusEngine::updateCursor(const Common::Point &, const Hotspot *cursorSpot) {
 	if (_itemDragger.isTracking()) {
 		_cursor->setCurrentFrameIndex(5);
 	} else {

--- a/engines/pegasus/pegasus.h
+++ b/engines/pegasus/pegasus.h
@@ -225,7 +225,7 @@ protected:
 	void clickInHotspot(const Input &, const Hotspot *) override;
 	void activateHotspots(void) override;
 
-	void updateCursor(const Common::Point, const Hotspot *) override;
+	void updateCursor(const Common::Point &, const Hotspot *) override;
 	bool wantsCursor() override;
 
 private:

--- a/engines/pegasus/timers.cpp
+++ b/engines/pegasus/timers.cpp
@@ -91,7 +91,7 @@ TimeValue TimeBase::getTime(const TimeScale scale) {
 	return _time.getNumerator() * ((scale == 0) ? _preferredScale : scale) / _time.getDenominator();
 }
 
-void TimeBase::setRate(const Common::Rational rate) {
+void TimeBase::setRate(const Common::Rational &rate) {
 	_rate = rate;
 	_lastMillis = 0;
 

--- a/engines/pegasus/timers.h
+++ b/engines/pegasus/timers.h
@@ -72,7 +72,7 @@ public:
 	virtual void setScale(const TimeScale scale) { _preferredScale = scale; }
 	virtual TimeScale getScale() const { return _preferredScale; }
 
-	virtual void setRate(const Common::Rational);
+	virtual void setRate(const Common::Rational &);
 	virtual Common::Rational getRate() const { return _rate; }
 
 	virtual void start();

--- a/engines/pink/pda_mgr.cpp
+++ b/engines/pink/pda_mgr.cpp
@@ -94,7 +94,7 @@ void PDAMgr::execute(const Command &command) {
 	}
 }
 
-void PDAMgr::goToPage(const Common::String pageName) {
+void PDAMgr::goToPage(const Common::String &pageName) {
 	if (_page && !_page->getName().compareToIgnoreCase(pageName))
 		return;
 

--- a/engines/pink/pda_mgr.h
+++ b/engines/pink/pda_mgr.h
@@ -44,7 +44,7 @@ public:
 	void saveState(Archive &archive);
 
 	void execute(const Command &command);
-	void goToPage(const Common::String pageName);
+	void goToPage(const Common::String &pageName);
 
 	void update() { _cursorMgr.update(); }
 

--- a/engines/pink/pink.cpp
+++ b/engines/pink/pink.cpp
@@ -186,7 +186,7 @@ void PinkEngine::load(Archive &archive) {
 	_modules.deserialize(archive);
 }
 
-void PinkEngine::initModule(const Common::String moduleName, const Common::String pageName, Archive *saveFile) {
+void PinkEngine::initModule(const Common::String &moduleName, const Common::String &pageName, Archive *saveFile) {
 	if (_module)
 		removeModule();
 

--- a/engines/pink/pink.h
+++ b/engines/pink/pink.h
@@ -148,7 +148,7 @@ private:
 
 	bool loadCursors();
 
-	void initModule(const Common::String moduleName, const Common::String pageName, Archive *saveFile);
+	void initModule(const Common::String &moduleName, const Common::String &pageName, Archive *saveFile);
 	void addModule(const Common::String &moduleName);
 	void removeModule();
 

--- a/engines/qdengine/parser/qdscr_parser.cpp
+++ b/engines/qdengine/parser/qdscr_parser.cpp
@@ -370,7 +370,7 @@ const char *qdscr_XML_string(const char *p) {
 	return (const char *)transCyrillic(conv_str.c_str());
 }
 
-const char *qdscr_XML_string(const Common::String s) {
+const char *qdscr_XML_string(const Common::String &s) {
 	return qdscr_XML_string(s.c_str());
 }
 

--- a/engines/qdengine/parser/qdscr_parser.h
+++ b/engines/qdengine/parser/qdscr_parser.h
@@ -708,7 +708,7 @@ const int idTagVersionAll[490] = {
 void cleanup_XML_Parser();
 xml::parser &qdscr_XML_Parser();
 const char *qdscr_XML_string(const char *p);
-const char *qdscr_XML_string(const Common::String s);
+const char *qdscr_XML_string(const Common::String &s);
 
 } // namespace QDEngine
 

--- a/engines/qdengine/qdcore/qd_animation.cpp
+++ b/engines/qdengine/qdcore/qd_animation.cpp
@@ -630,7 +630,7 @@ bool qdAnimation::hit(int x, int y, float scale) const {
 	return false;
 }
 
-bool qdAnimation::qda_load(Common::Path fpath) {
+bool qdAnimation::qda_load(const Common::Path &fpath) {
 	clear_frames();
 
 	debugC(3, kDebugLoad, "qdAnimation::qda_load(%s)", transCyrillic(fpath.toString()));
@@ -711,7 +711,7 @@ bool qdAnimation::qda_load(Common::Path fpath) {
 	return true;
 }
 
-void qdAnimation::qda_set_file(Common::Path fname) {
+void qdAnimation::qda_set_file(const Common::Path &fname) {
 	_qda_file = fname;
 }
 

--- a/engines/qdengine/qdcore/qd_animation.h
+++ b/engines/qdengine/qdcore/qd_animation.h
@@ -176,9 +176,9 @@ public:
 	const Common::Path qda_file() const {
 		return _qda_file;
 	}
-	void qda_set_file(const Common::Path fname);
+	void qda_set_file(const Common::Path &fname);
 
-	bool qda_load(const Common::Path fname);
+	bool qda_load(const Common::Path &fname);
 
 	bool load_resources();
 	void free_resources();
@@ -230,7 +230,7 @@ public:
 	bool load_resource();
 	bool free_resource();
 	//! Устанавливает имя файла, в котором хранятся данные ресурса.
-	void set_resource_file(const Common::Path file_name) {
+	void set_resource_file(const Common::Path &file_name) {
 		qda_set_file(file_name);
 	}
 	//! Возвращает имя файла, в котором хранится анимация.

--- a/engines/qdengine/qdcore/qd_file_manager.cpp
+++ b/engines/qdengine/qdcore/qd_file_manager.cpp
@@ -100,7 +100,7 @@ void qdFileManager::Finit() {
 	delete mgr;
 }
 
-bool qdFileManager::open_file(Common::SeekableReadStream **fh, const Common::Path file_name, bool err_message) {
+bool qdFileManager::open_file(Common::SeekableReadStream **fh, const Common::Path &file_name, bool err_message) {
 	debugC(4, kDebugLoad, "qdFileManager::open_file(%s)", transCyrillic(file_name.toString()));
 
 	if (SearchMan.hasFile((char *)transCyrillic(file_name.toString()))) {

--- a/engines/qdengine/qdcore/qd_file_manager.h
+++ b/engines/qdengine/qdcore/qd_file_manager.h
@@ -70,7 +70,7 @@ public:
 
 	void enable_packages() {}
 
-	bool open_file(Common::SeekableReadStream **fh, const Common::Path file_name, bool err_message = true);
+	bool open_file(Common::SeekableReadStream **fh, const Common::Path &file_name, bool err_message = true);
 
 	int last_CD_id() const {
 		return 1;

--- a/engines/qdengine/qdcore/qd_font_info.h
+++ b/engines/qdengine/qdcore/qd_font_info.h
@@ -60,7 +60,7 @@ public:
 		_type = tp;
 	}
 
-	void set_font_file_name(const Common::Path fname) {
+	void set_font_file_name(const Common::Path &fname) {
 		_font_file_name = fname;
 	}
 	const Common::Path font_file_name() const {

--- a/engines/qdengine/qdcore/qd_game_dispatcher.cpp
+++ b/engines/qdengine/qdcore/qd_game_dispatcher.cpp
@@ -2995,7 +2995,7 @@ void qdGameDispatcher::request_file_package(const qdFileOwner &file_owner) const
 	error("Requested file package is not available");
 }
 
-Common::Path qdGameDispatcher::find_file(const Common::Path file_name, const qdFileOwner &file_owner) const {
+Common::Path qdGameDispatcher::find_file(const Common::Path &file_name, const qdFileOwner &file_owner) const {
 	debugC(4, kDebugLoad, "qdGameDispatcher::find_file(%s)", file_name.toString().c_str());
 
 	return file_name;

--- a/engines/qdengine/qdcore/qd_game_dispatcher.h
+++ b/engines/qdengine/qdcore/qd_game_dispatcher.h
@@ -94,7 +94,7 @@ public:
 	}
 
 	void request_file_package(const qdFileOwner &file_owner) const;
-	Common::Path find_file(const Common::Path file_name, const qdFileOwner &file_owner) const;
+	Common::Path find_file(const Common::Path &file_name, const qdFileOwner &file_owner) const;
 	void startup_check() const;
 
 	qdLoadingProgressFnc set_scene_loading_progress_callback(qdLoadingProgressFnc p, void *dp = 0) {
@@ -491,7 +491,7 @@ public:
 		return _game_title.c_str();
 	}
 
-	void set_texts_database(const Common::Path file_name) {
+	void set_texts_database(const Common::Path &file_name) {
 		_texts_database = file_name;
 	}
 	const Common::Path texts_database() const {

--- a/engines/qdengine/qdcore/qd_interface_background.h
+++ b/engines/qdengine/qdcore/qd_interface_background.h
@@ -58,7 +58,7 @@ public:
 	/**
 	Если надо убрать анимацию - передать NULL в качестве имени файла.
 	*/
-	void set_animation_file(const Common::Path name) {
+	void set_animation_file(const Common::Path &name) {
 		_state.set_animation_file(name);
 	}
 	//! Возвращает имя файла для анимации.

--- a/engines/qdengine/qdcore/qd_interface_dispatcher.cpp
+++ b/engines/qdengine/qdcore/qd_interface_dispatcher.cpp
@@ -186,11 +186,11 @@ bool qdInterfaceDispatcher::select_ingame_screen(bool inventory_state) {
 	return select_screen(NULL);
 }
 
-qdResource *qdInterfaceDispatcher::add_resource(const Common::Path file_name, const qdInterfaceElementState *owner) {
+qdResource *qdInterfaceDispatcher::add_resource(const Common::Path &file_name, const qdInterfaceElementState *owner) {
 	return _resources.add_resource(file_name, owner);
 }
 
-bool qdInterfaceDispatcher::remove_resource(const Common::Path file_name, const qdInterfaceElementState *owner) {
+bool qdInterfaceDispatcher::remove_resource(const Common::Path &file_name, const qdInterfaceElementState *owner) {
 	return _resources.remove_resource(file_name, owner);
 }
 

--- a/engines/qdengine/qdcore/qd_interface_dispatcher.h
+++ b/engines/qdengine/qdcore/qd_interface_dispatcher.h
@@ -96,11 +96,11 @@ public:
 	}
 
 	//! Добавляет ресурс file_name с владельцем owner.
-	qdResource *add_resource(const Common::Path file_name, const qdInterfaceElementState *owner);
+	qdResource *add_resource(const Common::Path &file_name, const qdInterfaceElementState *owner);
 	//! Удаляет ресурс file_name с владельцем owner.
-	bool remove_resource(const Common::Path file_name, const qdInterfaceElementState *owner);
+	bool remove_resource(const Common::Path &file_name, const qdInterfaceElementState *owner);
 	//! Возвращает указатель на ресурс file_name.
-	qdResource *get_resource(const Common::Path file_name) const {
+	qdResource *get_resource(const Common::Path &file_name) const {
 		return _resources.get_resource(file_name);
 	}
 

--- a/engines/qdengine/qdcore/qd_interface_element.cpp
+++ b/engines/qdengine/qdcore/qd_interface_element.cpp
@@ -195,14 +195,14 @@ bool qdInterfaceElement::load_script(const xml::tag *p) {
 	return load_script_body(p);
 }
 
-qdResource *qdInterfaceElement::add_resource(const Common::Path file_name, const qdInterfaceElementState *res_owner) {
+qdResource *qdInterfaceElement::add_resource(const Common::Path &file_name, const qdInterfaceElementState *res_owner) {
 	if (qdInterfaceScreen * p = dynamic_cast<qdInterfaceScreen * >(owner()))
 		return p->add_resource(file_name, res_owner);
 
 	return NULL;
 }
 
-bool qdInterfaceElement::remove_resource(const Common::Path file_name, const qdInterfaceElementState *res_owner) {
+bool qdInterfaceElement::remove_resource(const Common::Path &file_name, const qdInterfaceElementState *res_owner) {
 	if (qdInterfaceScreen * p = dynamic_cast<qdInterfaceScreen * >(owner()))
 		return p->remove_resource(file_name, res_owner);
 

--- a/engines/qdengine/qdcore/qd_interface_element.h
+++ b/engines/qdengine/qdcore/qd_interface_element.h
@@ -188,9 +188,9 @@ public:
 	bool set_state(const qdInterfaceElementState *p);
 
 	//! Добавляет ресурс file_name с владельцем owner.
-	qdResource *add_resource(const Common::Path file_name, const qdInterfaceElementState *res_owner);
+	qdResource *add_resource(const Common::Path &file_name, const qdInterfaceElementState *res_owner);
 	//! Удаляет ресурс file_name с владельцем owner.
-	bool remove_resource(const Common::Path file_name, const qdInterfaceElementState *res_owner);
+	bool remove_resource(const Common::Path &file_name, const qdInterfaceElementState *res_owner);
 
 	//! Возвращает true, если точка с экранными координатами (x,у) попадает в элемент.
 	virtual bool hit_test(int x, int y) const;

--- a/engines/qdengine/qdcore/qd_interface_element_state.cpp
+++ b/engines/qdengine/qdcore/qd_interface_element_state.cpp
@@ -204,7 +204,7 @@ bool qdInterfaceElementState::quant(float dt) {
 	return false;
 }
 
-void qdInterfaceElementState::set_sound_file(const Common::Path str, state_mode_t snd_id) {
+void qdInterfaceElementState::set_sound_file(const Common::Path &str, state_mode_t snd_id) {
 	if (has_sound(snd_id)) {
 		if (qdInterfaceElement * p = dynamic_cast<qdInterfaceElement * >(owner()))
 			p->remove_resource(sound_file(snd_id), this);
@@ -219,7 +219,7 @@ void qdInterfaceElementState::set_sound_file(const Common::Path str, state_mode_
 	}
 }
 
-void qdInterfaceElementState::set_animation_file(const Common::Path name, state_mode_t anm_id) {
+void qdInterfaceElementState::set_animation_file(const Common::Path &name, state_mode_t anm_id) {
 	if (has_animation(anm_id)) {
 		if (qdInterfaceElement * p = dynamic_cast<qdInterfaceElement * >(owner()))
 			p->remove_resource(animation_file(anm_id), this);

--- a/engines/qdengine/qdcore/qd_interface_element_state.h
+++ b/engines/qdengine/qdcore/qd_interface_element_state.h
@@ -180,7 +180,7 @@ public:
 	/**
 	Если надо убрать звук - передать NULL в качестве имени файла.
 	*/
-	void set_sound_file(const Common::Path str, state_mode_t snd_id = DEFAULT_MODE);
+	void set_sound_file(const Common::Path &str, state_mode_t snd_id = DEFAULT_MODE);
 	//! Возвращает имя файла звукового эффекта, привязанного к состоянию.
 	const Common::Path sound_file(state_mode_t snd_id = DEFAULT_MODE) const {
 		return _modes[snd_id].sound_file();
@@ -198,7 +198,7 @@ public:
 	/**
 	Если надо убрать анимацию - передать NULL в качестве имени файла.
 	*/
-	void set_animation_file(const Common::Path name, state_mode_t anm_id = DEFAULT_MODE);
+	void set_animation_file(const Common::Path &name, state_mode_t anm_id = DEFAULT_MODE);
 	//! Возвращает имя файла для анимации.
 	const Common::Path animation_file(state_mode_t anm_id = DEFAULT_MODE) const {
 		return _modes[anm_id].animation_file();

--- a/engines/qdengine/qdcore/qd_interface_element_state_mode.cpp
+++ b/engines/qdengine/qdcore/qd_interface_element_state_mode.cpp
@@ -62,11 +62,11 @@ qdInterfaceElementStateMode &qdInterfaceElementStateMode::operator = (const qdIn
 	return *this;
 }
 
-void qdInterfaceElementStateMode::set_sound_file(const Common::Path name) {
+void qdInterfaceElementStateMode::set_sound_file(const Common::Path &name) {
 	_sound_file = name;
 }
 
-void qdInterfaceElementStateMode::set_animation_file(const Common::Path name) {
+void qdInterfaceElementStateMode::set_animation_file(const Common::Path &name) {
 	_animation_file = name;
 }
 

--- a/engines/qdengine/qdcore/qd_interface_element_state_mode.h
+++ b/engines/qdengine/qdcore/qd_interface_element_state_mode.h
@@ -45,7 +45,7 @@ public:
 	/**
 	Если надо убрать звук - передать NULL в качестве имени файла.
 	*/
-	void set_sound_file(const Common::Path name);
+	void set_sound_file(const Common::Path &name);
 	//! Возвращает имя файла звука.
 	const Common::Path sound_file() const {
 		return _sound_file;
@@ -67,7 +67,7 @@ public:
 	/**
 	Если надо убрать анимацию - передать NULL в качестве имени файла.
 	*/
-	void set_animation_file(const Common::Path name);
+	void set_animation_file(const Common::Path &name);
 	//! Возвращает имя файла для анимации.
 	const Common::Path animation_file() const {
 		return _animation_file;

--- a/engines/qdengine/qdcore/qd_interface_save.h
+++ b/engines/qdengine/qdcore/qd_interface_save.h
@@ -122,7 +122,7 @@ public:
 	/**
 	Если надо убрать анимацию - передать NULL в качестве имени файла.
 	*/
-	void set_frame_animation_file(const Common::Path name, qdInterfaceElementState::state_mode_t mode = qdInterfaceElementState::MOUSE_HOVER_MODE) {
+	void set_frame_animation_file(const Common::Path &name, qdInterfaceElementState::state_mode_t mode = qdInterfaceElementState::MOUSE_HOVER_MODE) {
 		_frame.set_animation_file(name, mode);
 	}
 	//! Возвращает имя файла для анимации.

--- a/engines/qdengine/qdcore/qd_interface_screen.cpp
+++ b/engines/qdengine/qdcore/qd_interface_screen.cpp
@@ -270,7 +270,7 @@ bool qdInterfaceScreen::char_input_handler(int vkey) {
 	return false;
 }
 
-qdResource *qdInterfaceScreen::add_resource(const Common::Path file_name, const qdInterfaceElementState *res_owner) {
+qdResource *qdInterfaceScreen::add_resource(const Common::Path &file_name, const qdInterfaceElementState *res_owner) {
 	if (qdInterfaceDispatcher *dp = dynamic_cast<qdInterfaceDispatcher * >(owner())) {
 		if (qdResource *p = dp->add_resource(file_name, res_owner)) {
 			_resources.register_resource(p, res_owner);
@@ -284,7 +284,7 @@ qdResource *qdInterfaceScreen::add_resource(const Common::Path file_name, const 
 	return NULL;
 }
 
-bool qdInterfaceScreen::remove_resource(const Common::Path file_name, const qdInterfaceElementState *res_owner) {
+bool qdInterfaceScreen::remove_resource(const Common::Path &file_name, const qdInterfaceElementState *res_owner) {
 	if (qdInterfaceDispatcher *dp = dynamic_cast<qdInterfaceDispatcher * >(owner())) {
 		if (qdResource *p = dp->get_resource(file_name)) {
 			_resources.unregister_resource(p, res_owner);

--- a/engines/qdengine/qdcore/qd_interface_screen.h
+++ b/engines/qdengine/qdcore/qd_interface_screen.h
@@ -84,9 +84,9 @@ public:
 	bool char_input_handler(int vkey);
 
 	//! Добавляет ресурс file_name с владельцем owner.
-	qdResource *add_resource(const Common::Path file_name, const qdInterfaceElementState *res_owner);
+	qdResource *add_resource(const Common::Path &file_name, const qdInterfaceElementState *res_owner);
 	//! Удаляет ресурс file_name с владельцем owner.
-	bool remove_resource(const Common::Path file_name, const qdInterfaceElementState *res_owner);
+	bool remove_resource(const Common::Path &file_name, const qdInterfaceElementState *res_owner);
 	//! Возвращает true, если на ресурс есть ссылки.
 	bool has_references(const qdResource *p) const {
 		return _resources.is_registered(p);

--- a/engines/qdengine/qdcore/qd_interface_text_window.h
+++ b/engines/qdengine/qdcore/qd_interface_text_window.h
@@ -82,7 +82,7 @@ public:
 	const Common::Path border_background_file() const {
 		return _border_background.animation_file();
 	}
-	void set_border_background_file(const Common::Path file_name) {
+	void set_border_background_file(const Common::Path &file_name) {
 		_border_background.set_animation_file(file_name);
 	}
 

--- a/engines/qdengine/qdcore/qd_inventory_cell.h
+++ b/engines/qdengine/qdcore/qd_inventory_cell.h
@@ -49,7 +49,7 @@ public:
 		_type = tp;
 	}
 
-	void set_sprite_file(const Common::Path fname) {
+	void set_sprite_file(const Common::Path &fname) {
 		_sprite.set_file(fname);
 	}
 	const Common::Path sprite_file() const {

--- a/engines/qdengine/qdcore/qd_minigame.h
+++ b/engines/qdengine/qdcore/qd_minigame.h
@@ -50,7 +50,7 @@ public:
 	const Common::Path config_file_name() const {
 		return _config_file_name;
 	}
-	void set_config_file_name(const Common::Path file_name) {
+	void set_config_file_name(const Common::Path &file_name) {
 		_config_file_name = file_name;
 	}
 	bool has_config_file() const {

--- a/engines/qdengine/qdcore/qd_minigame_config.cpp
+++ b/engines/qdengine/qdcore/qd_minigame_config.cpp
@@ -92,7 +92,7 @@ bool qdMinigameConfigParameter::validate_data() {
 	return true;
 }
 
-bool qdMinigameConfigParameter::load_ini(const Common::Path ini_file, const char *ini_section) {
+bool qdMinigameConfigParameter::load_ini(const Common::Path &ini_file, const char *ini_section) {
 	set_name(ini_section);
 	Common::String str = getIniKey(ini_file, ini_section, "type");
 	if (!str.empty()) {

--- a/engines/qdengine/qdcore/qd_minigame_config.h
+++ b/engines/qdengine/qdcore/qd_minigame_config.h
@@ -119,7 +119,7 @@ public:
 	bool save_script(Common::WriteStream &fh, int indent = 0) const;
 
 	//! Загрузка данных из .ini файла.
-	bool load_ini(const Common::Path ini_file, const char *ini_section);
+	bool load_ini(const Common::Path &ini_file, const char *ini_section);
 
 private:
 

--- a/engines/qdengine/qdcore/qd_music_track.h
+++ b/engines/qdengine/qdcore/qd_music_track.h
@@ -52,7 +52,7 @@ public:
 		return QD_NAMED_OBJECT_MUSIC_TRACK;
 	}
 
-	void set_file_name(const Common::Path fname) {
+	void set_file_name(const Common::Path &fname) {
 		_file_name = fname;
 	}
 	const Common::Path file_name() const {

--- a/engines/qdengine/qdcore/qd_resource.cpp
+++ b/engines/qdengine/qdcore/qd_resource.cpp
@@ -46,7 +46,7 @@ qdResource &qdResource::operator = (const qdResource &res) {
 qdResource::~qdResource() {
 }
 
-qdResource::file_format_t qdResource::file_format(const Common::Path path) {
+qdResource::file_format_t qdResource::file_format(const Common::Path &path) {
 	Common::String file_name(path.baseName());
 
 	if (file_name.size() < 4)

--- a/engines/qdengine/qdcore/qd_resource.h
+++ b/engines/qdengine/qdcore/qd_resource.h
@@ -57,7 +57,7 @@ public:
 	virtual bool free_resource() = 0;
 
 	//! Устанавливает имя файла, в котором хранятся данные ресурса.
-	virtual void set_resource_file(const Common::Path file_name) = 0;
+	virtual void set_resource_file(const Common::Path &file_name) = 0;
 	//! Возвращает имя файла, в котором хранятся данные ресурса.
 	/**
 	Если оно не задано, должна возвращаеть NULL.
@@ -69,7 +69,7 @@ public:
 		return _is_loaded;
 	}
 
-	static file_format_t file_format(const Common::Path file_name);
+	static file_format_t file_format(const Common::Path &file_name);
 
 #ifdef __QD_DEBUG_ENABLE__
 	virtual uint32 resource_data_size() const = 0;

--- a/engines/qdengine/qdcore/qd_resource_container.h
+++ b/engines/qdengine/qdcore/qd_resource_container.h
@@ -43,19 +43,19 @@ public:
 	virtual ~qdResourceContainer();
 
 	//! Добавляет ресурс из файла file_name и возвращает указатель на него.
-	qdResource *add_resource(const Common::Path file_name, const T *owner);
+	qdResource *add_resource(const Common::Path &file_name, const T *owner);
 
 	//! Удаляет ресурс, если он нужен только для объекта owner.
 	/**
 	Если на данный ресурс есть еще ссылки, то он не будет удален.
 	*/
-	bool remove_resource(const Common::Path file_name, const T *owner);
+	bool remove_resource(const Common::Path &file_name, const T *owner);
 
 	//! Возвращает указатель на ресурс, соответствующий файлу с именем file_name.
 	/**
 	Если такой ресурс не найден, возвращает NULL.
 	*/
-	qdResource *get_resource(const Common::Path file_name) const;
+	qdResource *get_resource(const Common::Path &file_name) const;
 
 	typedef Std::list<qdResource *> resource_list_t;
 	//! Возвращает список ресурсов.
@@ -88,7 +88,7 @@ qdResourceContainer<T>::~qdResourceContainer() {
 }
 
 template<class T>
-qdResource *qdResourceContainer<T>::add_resource(const Common::Path file_name, const T *owner) {
+qdResource *qdResourceContainer<T>::add_resource(const Common::Path &file_name, const T *owner) {
 	typename resource_map_t::iterator it = _resource_map.find(file_name.toString());
 	if (it != _resource_map.end()) {
 		_resource_dispatcher.register_resource(it->_value, owner);
@@ -129,7 +129,7 @@ qdResource *qdResourceContainer<T>::add_resource(const Common::Path file_name, c
 }
 
 template<class T>
-bool qdResourceContainer<T>::remove_resource(const Common::Path file_name, const T *owner) {
+bool qdResourceContainer<T>::remove_resource(const Common::Path &file_name, const T *owner) {
 	typename resource_map_t::iterator it = _resource_map.find(file_name.toString());
 
 	if (it == _resource_map.end()) return false;
@@ -153,7 +153,7 @@ bool qdResourceContainer<T>::remove_resource(const Common::Path file_name, const
 }
 
 template<class T>
-qdResource *qdResourceContainer<T>::get_resource(const Common::Path file_name) const {
+qdResource *qdResourceContainer<T>::get_resource(const Common::Path &file_name) const {
 	if (file_name.empty()) return NULL;
 
 	typename resource_map_t::const_iterator it = _resource_map.find(file_name.toString());

--- a/engines/qdengine/qdcore/qd_setup.cpp
+++ b/engines/qdengine/qdcore/qd_setup.cpp
@@ -26,7 +26,7 @@
 
 namespace QDEngine {
 
-bool enumerateIniSections(const Common::Path fname, Common::INIFile::SectionList &sectionList) {
+bool enumerateIniSections(const Common::Path &fname, Common::INIFile::SectionList &sectionList) {
 
 	Common::INIFile ini;
 	Common::Path iniFilePath(fname);
@@ -42,7 +42,7 @@ bool enumerateIniSections(const Common::Path fname, Common::INIFile::SectionList
 	return true;
 }
 
-const Common::String getIniKey(const Common::Path fname, const char *section, const char *key) {
+const Common::String getIniKey(const Common::Path &fname, const char *section, const char *key) {
 	Common::INIFile ini;
 	Common::String buf;
 

--- a/engines/qdengine/qdcore/qd_setup.h
+++ b/engines/qdengine/qdcore/qd_setup.h
@@ -26,8 +26,8 @@
 
 namespace QDEngine {
 
-const Common::String getIniKey(const Common::Path fname, const char *section, const char *key);
-bool enumerateIniSections(const Common::Path fname, Common::INIFile::SectionList &section_list);
+const Common::String getIniKey(const Common::Path &fname, const char *section, const char *key);
+bool enumerateIniSections(const Common::Path &fname, Common::INIFile::SectionList &section_list);
 
 } // namespace QDEngine
 

--- a/engines/qdengine/qdcore/qd_sound.h
+++ b/engines/qdengine/qdcore/qd_sound.h
@@ -49,7 +49,7 @@ public:
 	bool load_resource();
 	bool free_resource();
 	//! Устанавливает имя файла, в котором хранятся данные ресурса.
-	void set_resource_file(const Common::Path file_name) {
+	void set_resource_file(const Common::Path &file_name) {
 		set_file_name(file_name);
 	}
 	//! Возвращает имя файла, в котором хранится анимация.
@@ -67,7 +67,7 @@ public:
 		return _file_name;
 	}
 	//! Устанавливает имя файла, в котором хранится звук.
-	void set_file_name(const Common::Path fname) {
+	void set_file_name(const Common::Path &fname) {
 		_file_name = fname;
 	}
 

--- a/engines/qdengine/qdcore/qd_sprite.cpp
+++ b/engines/qdengine/qdcore/qd_sprite.cpp
@@ -195,7 +195,7 @@ void qdSprite::free() {
 	drop_flag(ALPHA_FLAG);
 }
 
-bool qdSprite::load(const Common::Path fpath) {
+bool qdSprite::load(const Common::Path &fpath) {
 	set_file(fpath);
 
 	return load();
@@ -316,7 +316,7 @@ bool qdSprite::load() {
 	return true;
 }
 
-void qdSprite::save(const Common::Path fname) {
+void qdSprite::save(const Common::Path &fname) {
 	if (_format != GR_RGB888 && _format != GR_ARGB8888) return;
 
 	const Common::Path out_file = !fname.empty() ? fname : _file;

--- a/engines/qdengine/qdcore/qd_sprite.h
+++ b/engines/qdengine/qdcore/qd_sprite.h
@@ -92,7 +92,7 @@ public:
 	}
 	uint32 data_size() const;
 
-	void set_file(const Common::Path fname) {
+	void set_file(const Common::Path &fname) {
 		_file = fname;
 	}
 	const Common::Path file() const {
@@ -102,9 +102,9 @@ public:
 		return !_file.empty();
 	}
 
-	bool load(const Common::Path fname);
+	bool load(const Common::Path &fname);
 	bool load();
-	void save(const Common::Path fname);
+	void save(const Common::Path &fname);
 	void free();
 
 	virtual void qda_load(Common::SeekableReadStream *fh, int version = 100);
@@ -174,7 +174,7 @@ public:
 	}
 
 	//! Устанавливает имя файла, в котором хранятся данные ресурса.
-	void set_resource_file(const Common::Path filename) {
+	void set_resource_file(const Common::Path &filename) {
 		set_file(filename);
 	}
 	//! Возвращает имя файла, в котором хранятся данные ресурса.

--- a/engines/qdengine/qdcore/qd_video.h
+++ b/engines/qdengine/qdcore/qd_video.h
@@ -58,12 +58,12 @@ public:
 	const Common::Path file_name() const {
 		return _file_name;
 	}
-	void set_file_name(const Common::Path fname) {
+	void set_file_name(const Common::Path &fname) {
 		_file_name = fname;
 	}
 
 	// Фон, на котором будет проигрываться видео
-	void set_background_file_name(const Common::Path fname) {
+	void set_background_file_name(const Common::Path &fname) {
 		_background.set_file(fname);
 	}
 	const Common::Path background_file_name() const {

--- a/engines/qdengine/qdcore/util/WinVideo.cpp
+++ b/engines/qdengine/qdcore/util/WinVideo.cpp
@@ -74,7 +74,7 @@ void winVideo::set_window(int x, int y, int xsize, int ysize) {
 		_tempSurf = new Graphics::ManagedSurface(xsize, ysize, g_engine->_pixelformat);
 }
 
-bool winVideo::open_file(const Common::Path fname) {
+bool winVideo::open_file(const Common::Path &fname) {
 	Common::String filename = (char *)transCyrillic(fname.toString());
 	debugC(3, kDebugLoad, "winVideo::open_file(%s)", filename.c_str());
 

--- a/engines/qdengine/qdcore/util/WinVideo.h
+++ b/engines/qdengine/qdcore/util/WinVideo.h
@@ -52,7 +52,7 @@ public:
 	static bool init(); // initialize DirectShow Lib
 	static bool done(); // uninitialize DirectShow Lib
 
-	bool open_file(const Common::Path fname);
+	bool open_file(const Common::Path &fname);
 	void close_file();
 
 	bool play();

--- a/engines/qdengine/qdcore/util/plaympp_api.cpp
+++ b/engines/qdengine/qdcore/util/plaympp_api.cpp
@@ -43,7 +43,7 @@ mpegPlayer::mpegPlayer() : _is_enabled(true),
 mpegPlayer::~mpegPlayer() {
 }
 
-bool mpegPlayer::play(const Common::Path file, bool loop, int vol) {
+bool mpegPlayer::play(const Common::Path &file, bool loop, int vol) {
 	bool isOGG = file.baseName().hasSuffixIgnoreCase(".ogg");
 
 	debugC(1, kDebugSound, "mpegPlayer::play(%s, %d, %d)", file.toString().c_str(), loop, vol);

--- a/engines/qdengine/qdcore/util/plaympp_api.h
+++ b/engines/qdengine/qdcore/util/plaympp_api.h
@@ -44,7 +44,7 @@ public:
 
 	~mpegPlayer();
 
-	bool play(const Common::Path file, bool loop = false, int vol = 256);
+	bool play(const Common::Path &file, bool loop = false, int vol = 256);
 	bool stop();
 	bool pause();
 	bool resume();

--- a/engines/qdengine/system/graphics/gr_font.cpp
+++ b/engines/qdengine/system/graphics/gr_font.cpp
@@ -43,7 +43,7 @@ grFont::~grFont() {
 	delete[] _alpha_buffer;
 }
 
-bool grFont::load(const Common::Path fname) {
+bool grFont::load(const Common::Path &fname) {
 	Common::String str(fname.toString());
 	str += ".tga";
 

--- a/engines/qdengine/system/graphics/gr_font.h
+++ b/engines/qdengine/system/graphics/gr_font.h
@@ -36,7 +36,7 @@ public:
 	grFont();
 	~grFont();
 
-	bool load(const Common::Path fname);
+	bool load(const Common::Path &fname);
 
 	bool load_index(Common::SeekableReadStream *fh);
 	bool load_alpha(Common::SeekableReadStream *fh);

--- a/engines/qdengine/system/sound/wav_sound.cpp
+++ b/engines/qdengine/system/sound/wav_sound.cpp
@@ -37,7 +37,7 @@ wavSound::wavSound() {}
 
 wavSound::~wavSound() {}
 
-bool wavSound::wav_file_load(const Common::Path fpath) {
+bool wavSound::wav_file_load(const Common::Path &fpath) {
 	debugC(3, kDebugSound, "[%d] Loading Wav: %s", g_system->getMillis(), transCyrillic(fpath.toString()));
 
 	if (fpath.empty()) {

--- a/engines/qdengine/system/sound/wav_sound.h
+++ b/engines/qdengine/system/sound/wav_sound.h
@@ -37,7 +37,7 @@ public:
 	//! Returns sound length in seconds
 	float length() const { return _length; }
 
-	bool wav_file_load(const Common::Path fname);
+	bool wav_file_load(const Common::Path &fname);
 
 	Audio::SeekableAudioStream *_audioStream = nullptr;
 	Common::Path _fname;

--- a/engines/sci/graphics/transitions.cpp
+++ b/engines/sci/graphics/transitions.cpp
@@ -281,7 +281,7 @@ void GfxTransitions::setNewScreen(bool blackoutFlag) {
 	}
 }
 
-void GfxTransitions::copyRectToScreen(const Common::Rect rect, bool blackoutFlag) {
+void GfxTransitions::copyRectToScreen(const Common::Rect &rect, bool blackoutFlag) {
 	if (!blackoutFlag) {
 		_screen->copyRectToScreen(rect);
 	} else {

--- a/engines/sci/graphics/transitions.h
+++ b/engines/sci/graphics/transitions.h
@@ -73,7 +73,7 @@ private:
 	void doTransition(int16 number, bool blackout);
 	void setNewPalette(bool blackoutFlag);
 	void setNewScreen(bool blackoutFlag);
-	void copyRectToScreen(const Common::Rect rect, bool blackoutFlag);
+	void copyRectToScreen(const Common::Rect &rect, bool blackoutFlag);
 	void fadeOut();
 	void fadeIn();
 	void pixelation(bool blackoutFlag);

--- a/engines/sci/resource/resource_patcher.cpp
+++ b/engines/sci/resource/resource_patcher.cpp
@@ -503,7 +503,7 @@ static const GameResourcePatch resourcePatches[] = {
 #pragma mark -
 #pragma mark ResourcePatcher
 
-ResourcePatcher::ResourcePatcher(const SciGameId gameId, const bool isCD, const Common::Platform platform, const Common::Language gameLanguage) :
+ResourcePatcher::ResourcePatcher(const SciGameId gameId, const bool isCD, const Common::Platform &platform, const Common::Language &gameLanguage) :
 	ResourceSource(kSourceScummVM, "-scummvm-") {
 	for (int i = 0; i < ARRAYSIZE(resourcePatches); ++i) {
 		const GameResourcePatch &patch = resourcePatches[i];

--- a/engines/sci/resource/resource_patcher.h
+++ b/engines/sci/resource/resource_patcher.h
@@ -89,7 +89,7 @@ struct GameResourcePatch {
  */
 class ResourcePatcher : public ResourceSource {
 public:
-	ResourcePatcher(const SciGameId gameId, const bool isCD, const Common::Platform platform, const Common::Language gameLanguage);
+	ResourcePatcher(const SciGameId gameId, const bool isCD, const Common::Platform &platform, const Common::Language &gameLanguage);
 
 	~ResourcePatcher() override {}
 

--- a/engines/sludge/savedata.cpp
+++ b/engines/sludge/savedata.cpp
@@ -35,7 +35,7 @@ uint16 CustomSaveHelper::_saveEncoding = false;
 char CustomSaveHelper::_encode1 = 0;
 char CustomSaveHelper::_encode2 = 0;
 
-void CustomSaveHelper::writeStringEncoded(const Common::String checker, Common::WriteStream *stream) {
+void CustomSaveHelper::writeStringEncoded(const Common::String &checker, Common::WriteStream *stream) {
 	int len = checker.size();
 
 	stream->writeUint16BE(len);

--- a/engines/sludge/savedata.h
+++ b/engines/sludge/savedata.h
@@ -38,7 +38,7 @@ private:
 	static char _encode1;
 	static char _encode2;
 
-	static void writeStringEncoded(const Common::String checker, Common::WriteStream *stream);
+	static void writeStringEncoded(const Common::String &checker, Common::WriteStream *stream);
 	static Common::String readStringEncoded(Common::SeekableReadStream *fp);
 	static char *readTextPlain(Common::SeekableReadStream *fp);
 

--- a/engines/stark/ui/dialogbox.cpp
+++ b/engines/stark/ui/dialogbox.cpp
@@ -199,7 +199,7 @@ void DialogBox::onClick(const Common::Point &pos) {
 	}
 }
 
-void DialogBox::onKeyPress(const Common::CustomEventType customType) {
+void DialogBox::onKeyPress(const Common::CustomEventType &customType) {
 	if (customType == kActionSkip) {
 		close();
 	}

--- a/engines/stark/ui/dialogbox.h
+++ b/engines/stark/ui/dialogbox.h
@@ -62,7 +62,7 @@ public:
 	void onScreenChanged();
 
 	/** Called when a keyboard key is pressed and the dialog is active */
-	void onKeyPress(const Common::CustomEventType customType);
+	void onKeyPress(const Common::CustomEventType &customType);
 
 protected:
 	void onRender() override;

--- a/engines/testbed/config.cpp
+++ b/engines/testbed/config.cpp
@@ -170,7 +170,7 @@ void TestbedOptionsDialog::handleCommand(GUI::CommandSender *sender, uint32 cmd,
 	GUI::Dialog::handleCommand(sender, cmd, data);
 }
 
-void TestbedInteractionDialog::addText(uint w, uint h, const Common::String text, Graphics::TextAlign textAlign, uint xOffset, uint yPadding) {
+void TestbedInteractionDialog::addText(uint w, uint h, const Common::String &text, Graphics::TextAlign textAlign, uint xOffset, uint yPadding) {
 	if (!xOffset) {
 		xOffset = _xOffset;
 	}
@@ -179,7 +179,7 @@ void TestbedInteractionDialog::addText(uint w, uint h, const Common::String text
 	_yOffset += h;
 }
 
-void TestbedInteractionDialog::addButton(uint w, uint h, const Common::String name, uint32 cmd, uint xOffset, uint yPadding) {
+void TestbedInteractionDialog::addButton(uint w, uint h, const Common::String &name, uint32 cmd, uint xOffset, uint yPadding) {
 	if (!xOffset) {
 		xOffset = _xOffset;
 	}
@@ -197,7 +197,7 @@ void TestbedInteractionDialog::addList(uint x, uint y, uint w, uint h, const Com
 	_yOffset += h;
 }
 
-void TestbedInteractionDialog::addButtonXY(uint x, uint /*y*/, uint w, uint h, const Common::String name, uint32 cmd) {
+void TestbedInteractionDialog::addButtonXY(uint x, uint /*y*/, uint w, uint h, const Common::String &name, uint32 cmd) {
 	_buttonArray.push_back(new GUI::ButtonWidget(this, x, _yOffset, w, h, true, name, Common::U32String(), cmd));
 }
 

--- a/engines/testbed/config.h
+++ b/engines/testbed/config.h
@@ -46,15 +46,15 @@ enum {
 
 class TestbedConfigManager {
 public:
-	TestbedConfigManager(Common::Array<Testsuite *> &tList, const Common::String fName) : _testsuiteList(tList), _configFileName(fName) {}
+	TestbedConfigManager(Common::Array<Testsuite *> &tList, const Common::String &fName) : _testsuiteList(tList), _configFileName(fName) {}
 	~TestbedConfigManager() {}
 	void selectTestsuites();
-	void setConfigFile(const Common::String fName) { _configFileName = fName; }
+	void setConfigFile(const Common::String &fName) { _configFileName = fName; }
 	Common::SeekableReadStream *getConfigReadStream() const;
 	Common::WriteStream *getConfigWriteStream() const;
 	void writeTestbedConfigToStream(Common::WriteStream *ws);
 	Testsuite *getTestsuiteByName(const Common::String &name);
-	bool stringToBool(const Common::String str) { return str.equalsIgnoreCase("true") ? true : false; }
+	bool stringToBool(const Common::String &str) { return str.equalsIgnoreCase("true") ? true : false; }
 	Common::String boolToString(bool val) { return val ? "true" : "false"; }
 	void initDefaultConfiguration();
 	int getNumSuitesEnabled();
@@ -92,9 +92,9 @@ public:
 	TestbedInteractionDialog(uint x, uint y, uint w, uint h) : GUI::Dialog(x, y, w, h, true), _xOffset(0), _yOffset(0) {}
 	~TestbedInteractionDialog() override {}
 	void handleCommand(GUI::CommandSender *sender, uint32 cmd, uint32 data) override;
-	void addButton(uint w, uint h, const Common::String name, uint32 cmd, uint xOffset = 0, uint yPadding = 8);
-	void addButtonXY(uint x, uint y, uint w, uint h, const Common::String name, uint32 cmd);
-	void addText(uint w, uint h, const Common::String text, Graphics::TextAlign textAlign, uint xOffset, uint yPadding = 8);
+	void addButton(uint w, uint h, const Common::String &name, uint32 cmd, uint xOffset = 0, uint yPadding = 8);
+	void addButtonXY(uint x, uint y, uint w, uint h, const Common::String &name, uint32 cmd);
+	void addText(uint w, uint h, const Common::String &text, Graphics::TextAlign textAlign, uint xOffset, uint yPadding = 8);
 	void addList(uint x, uint y, uint w, uint h, const Common::Array<Common::U32String> &strArray, uint yPadding = 8);
 protected:
 	Common::Array<GUI::ButtonWidget *> _buttonArray;

--- a/engines/tetraedge/te/te_warp_marker.h
+++ b/engines/tetraedge/te/te_warp_marker.h
@@ -38,7 +38,7 @@ public:
 	void marker(TeMarker *marker);
 	bool onMarkerButtonValidated();
 	TeSignal1Param<const Common::String &> &markerButtonSignal() { return _markerButtonSignal; };
-	void setName(const Common::String newName) { _name = newName; }
+	void setName(const Common::String &newName) { _name = newName; }
 
 
 private:

--- a/engines/tsage/core.cpp
+++ b/engines/tsage/core.cpp
@@ -42,7 +42,7 @@ namespace TsAGE {
 
 /*--------------------------------------------------------------------------*/
 
-InvObject::InvObject(int sceneNumber, int rlbNum, int cursorNum, CursorType cursorId, const Common::String description) :
+InvObject::InvObject(int sceneNumber, int rlbNum, int cursorNum, CursorType cursorId, const Common::String &description) :
 		_sceneNumber(sceneNumber), _rlbNum(rlbNum), _cursorNum(cursorNum), _cursorId(cursorId),
 		_description(description) {
 	_displayResNum = 3;

--- a/engines/tsage/core.h
+++ b/engines/tsage/core.h
@@ -59,7 +59,7 @@ public:
 	int _strip;
 	int _frame;
 public:
-	InvObject(int sceneNumber, int rlbNum, int cursorNum, CursorType cursorId, const Common::String description);
+	InvObject(int sceneNumber, int rlbNum, int cursorNum, CursorType cursorId, const Common::String &description);
 	InvObject(int visage, int strip, int frame);
 	InvObject(int visage, int strip);
 

--- a/engines/ultima/shared/conf/xml_node.cpp
+++ b/engines/ultima/shared/conf/xml_node.cpp
@@ -455,7 +455,7 @@ XMLNode *XMLNode::xmlParseFile(XMLTree *tree, const Common::Path &fname) {
 }
 
 bool XMLNode::searchPairs(KeyTypeList &ktl, const Common::String &basekey,
-						  const Common::String currkey, const unsigned int pos) {
+						  const Common::String &currkey, const unsigned int pos) {
 	/* If our 'current key' is longer then the key we're serching for
 	    we've obviously gone too deep in this branch, and we won't find
 	    it here. */
@@ -481,7 +481,7 @@ bool XMLNode::searchPairs(KeyTypeList &ktl, const Common::String &basekey,
 }
 
 /* Just adds every key->value pair under the this node to the ktl */
-void XMLNode::selectPairs(KeyTypeList &ktl, const Common::String currkey) {
+void XMLNode::selectPairs(KeyTypeList &ktl, const Common::String &currkey) {
 	ktl.push_back(KeyType(currkey + _id, currkey));
 
 	for (auto *node : _nodeList) {

--- a/engines/ultima/shared/conf/xml_node.h
+++ b/engines/ultima/shared/conf/xml_node.h
@@ -132,8 +132,8 @@ public:
 	 * Returns true if search is 'finished'
 	 */
 	bool searchPairs(KeyTypeList &ktl, const Common::String &basekey,
-		const Common::String currkey, const unsigned int pos);
-	void selectPairs(KeyTypeList &ktl, const Common::String currkey);
+		const Common::String &currkey, const unsigned int pos);
+	void selectPairs(KeyTypeList &ktl, const Common::String &currkey);
 
 	Common::String dump(int depth = 0);
 

--- a/engines/ultima/ultima1/u1dialogs/combat.cpp
+++ b/engines/ultima/ultima1/u1dialogs/combat.cpp
@@ -35,7 +35,7 @@ BEGIN_MESSAGE_MAP(Combat, Dialog)
 END_MESSAGE_MAP()
 
 Combat::Combat(Ultima1Game *game, Shared::Maps::Direction direction, int weaponType,
-	const Common::String weaponName) : FullScreenDialog(game), _direction(direction) {
+	const Common::String &weaponName) : FullScreenDialog(game), _direction(direction) {
 }
 
 bool Combat::KeypressMsg(CKeypressMsg *msg) {

--- a/engines/ultima/ultima1/u1dialogs/combat.h
+++ b/engines/ultima/ultima1/u1dialogs/combat.h
@@ -56,7 +56,7 @@ public:
 	/**
 	 * Constructor
 	 */
-	Combat(Ultima1Game *game, Shared::Maps::Direction direction, int weaponType, const Common::String weaponName);
+	Combat(Ultima1Game *game, Shared::Maps::Direction direction, int weaponType, const Common::String &weaponName);
 
 	/**
 	 * Draws the visual item on the screen

--- a/engines/wintermute/debugger/listing_providers/blank_listing.cpp
+++ b/engines/wintermute/debugger/listing_providers/blank_listing.cpp
@@ -24,7 +24,7 @@
 
 namespace Wintermute {
 
-BlankListing::BlankListing(const Common::Path filename) : _filename(filename.toString(Common::Path::kNativeSeparator)) {}
+BlankListing::BlankListing(const Common::Path &filename) : _filename(filename.toString(Common::Path::kNativeSeparator)) {}
 
 uint BlankListing::getLength() const { return UINT_MAX_VALUE; }
 

--- a/engines/wintermute/debugger/listing_providers/blank_listing.h
+++ b/engines/wintermute/debugger/listing_providers/blank_listing.h
@@ -29,7 +29,7 @@ namespace Wintermute {
 class BlankListing : public Listing {
 	const Common::String _filename;
 public:
-	BlankListing(const Common::Path filename);
+	BlankListing(const Common::Path &filename);
 	~BlankListing() override;
 	uint getLength() const override;
 	Common::String getLine(uint n) override;

--- a/engines/zvision/graphics/cursors/cursor_manager.cpp
+++ b/engines/zvision/graphics/cursors/cursor_manager.cpp
@@ -44,7 +44,7 @@ const char *CursorManager::_zNemCursorFileNames[NUM_CURSORS] = { "00act", "arrow
 																 "hright", "hup", "00idle", "left", "right", "ssurr", "stilt", "turn", "up"
 															   };
 
-CursorManager::CursorManager(ZVision *engine, const Graphics::PixelFormat pixelFormat)
+CursorManager::CursorManager(ZVision *engine, const Graphics::PixelFormat &pixelFormat)
 	: _engine(engine),
 	  _pixelFormat(pixelFormat),
 	  _cursorIsPushed(false),

--- a/engines/zvision/graphics/cursors/cursor_manager.h
+++ b/engines/zvision/graphics/cursors/cursor_manager.h
@@ -57,7 +57,7 @@ enum CursorIndex {
  */
 class CursorManager {
 public:
-	CursorManager(ZVision *engine, const Graphics::PixelFormat pixelFormat);
+	CursorManager(ZVision *engine, const Graphics::PixelFormat &pixelFormat);
 
 private:
 	static const int NUM_CURSORS = 18;

--- a/engines/zvision/graphics/render_manager.cpp
+++ b/engines/zvision/graphics/render_manager.cpp
@@ -38,7 +38,7 @@
 
 namespace ZVision {
 
-RenderManager::RenderManager(ZVision *engine, uint32 windowWidth, uint32 windowHeight, const Common::Rect workingWindow, const Graphics::PixelFormat pixelFormat, bool doubleFPS)
+RenderManager::RenderManager(ZVision *engine, uint32 windowWidth, uint32 windowHeight, const Common::Rect &workingWindow, const Graphics::PixelFormat &pixelFormat, bool doubleFPS)
 	: _engine(engine),
 	  _system(engine->_system),
 	  _screenCenterX(_workingWindow.width() / 2),
@@ -681,7 +681,7 @@ void RenderManager::renderMenuToScreen() {
 	}
 }
 
-void RenderManager::initSubArea(uint32 windowWidth, uint32 windowHeight, const Common::Rect workingWindow) {
+void RenderManager::initSubArea(uint32 windowWidth, uint32 windowHeight, const Common::Rect &workingWindow) {
 	_workingWindow = workingWindow;
 
 	_subtitleSurface.free();

--- a/engines/zvision/graphics/render_manager.h
+++ b/engines/zvision/graphics/render_manager.h
@@ -47,7 +47,7 @@ namespace ZVision {
 
 class RenderManager {
 public:
-	RenderManager(ZVision *engine, uint32 windowWidth, uint32 windowHeight, const Common::Rect workingWindow, const Graphics::PixelFormat pixelFormat, bool doubleFPS);
+	RenderManager(ZVision *engine, uint32 windowWidth, uint32 windowHeight, const Common::Rect &workingWindow, const Graphics::PixelFormat &pixelFormat, bool doubleFPS);
 	~RenderManager();
 
 private:
@@ -236,7 +236,7 @@ public:
 
 	// Subtitles methods
 
-	void initSubArea(uint32 windowWidth, uint32 windowHeight, const Common::Rect workingWindow);
+	void initSubArea(uint32 windowWidth, uint32 windowHeight, const Common::Rect &workingWindow);
 
 	// Create subtitle area and return ID
 	uint16 createSubArea(const Common::Rect &area);

--- a/engines/zvision/zvision.h
+++ b/engines/zvision/zvision.h
@@ -264,7 +264,7 @@ private:
 	void initialize();
 	void initFonts();
 
-	void parseStrFile(const Common::String fileName);
+	void parseStrFile(const Common::String &fileName);
 
 	/** Called every frame from ZVision::run() to process any events from EventMan */
 	void processEvents();

--- a/graphics/macgui/macfontmanager.cpp
+++ b/graphics/macgui/macfontmanager.cpp
@@ -121,7 +121,7 @@ static const char *const fontStyleSuffixes[] = {
 	"Extend"
 };
 
-int parseSlant(const Common::String fontname) {
+int parseSlant(const Common::String &fontname) {
 	int res = 0;
 
 	for (int i = 1; i < 7; i++)
@@ -131,7 +131,7 @@ int parseSlant(const Common::String fontname) {
 	return res;
 }
 
-Common::String cleanFontName(const Common::String fontname) {
+Common::String cleanFontName(const Common::String &fontname) {
 	const char *pos;
 	Common::String f = fontname;
 	for (int i = 0; i < 7; i++) {

--- a/graphics/managed_surface.h
+++ b/graphics/managed_surface.h
@@ -616,7 +616,7 @@ public:
 	 *
 	 * The pixel format of the buffer must match the pixel format of the surface.
 	 */
-	void copyRectToSurface(const Graphics::Surface &srcSurface, int destX, int destY, const Common::Rect subRect) {
+	void copyRectToSurface(const Graphics::Surface &srcSurface, int destX, int destY, const Common::Rect &subRect) {
 		_innerSurface.copyRectToSurface(srcSurface, destX, destY, subRect);
 		addDirtyRect(Common::Rect(destX, destY, destX + subRect.width(), destY + subRect.height()));
 	}
@@ -636,7 +636,7 @@ public:
 	 *
 	 * The pixel format of the buffer must match the pixel format of the surface.
 	 */
-	void copyRectToSurfaceWithKey(const Graphics::Surface &srcSurface, int destX, int destY, const Common::Rect subRect, uint32 key) {
+	void copyRectToSurfaceWithKey(const Graphics::Surface &srcSurface, int destX, int destY, const Common::Rect &subRect, uint32 key) {
 		_innerSurface.copyRectToSurfaceWithKey(srcSurface, destX, destY, subRect, key);
 		addDirtyRect(Common::Rect(destX, destY, destX + subRect.width(), destY + subRect.height()));
 	}

--- a/graphics/sjis.cpp
+++ b/graphics/sjis.cpp
@@ -34,7 +34,7 @@
 
 namespace Graphics {
 
-FontSJIS *FontSJIS::createFont(const Common::Platform platform) {
+FontSJIS *FontSJIS::createFont(const Common::Platform &platform) {
 	FontSJIS *ret = 0;
 
 	// Try the font ROM of the specified platform
@@ -661,7 +661,7 @@ bool FontPCEngine::hasFeature(int feat) const {
 
 // ScummVM SJIS font
 
-FontSjisSVM::FontSjisSVM(const Common::Platform platform)
+FontSjisSVM::FontSjisSVM(const Common::Platform &platform)
 	: _fontData16x16(0), _fontData16x16Size(0), _fontData8x16(0), _fontData8x16Size(0),
 	  _fontData12x12(0), _fontData12x12Size(0) {
 

--- a/graphics/sjis.h
+++ b/graphics/sjis.h
@@ -76,7 +76,7 @@ public:
 	 *
 	 * The last file tried is ScummVM's SJIS.FNT file.
 	 */
-	static FontSJIS *createFont(const Common::Platform platform = Common::kPlatformUnknown);
+	static FontSJIS *createFont(const Common::Platform &platform = Common::kPlatformUnknown);
 
 	/**
 	 * Load the font data.
@@ -293,7 +293,7 @@ private:
  */
 class FontSjisSVM : public FontSJISBase {
 public:
-	FontSjisSVM(const Common::Platform platform);
+	FontSjisSVM(const Common::Platform &platform);
 	~FontSjisSVM();
 
 	/**

--- a/graphics/surface.cpp
+++ b/graphics/surface.cpp
@@ -251,7 +251,7 @@ void Surface::copyRectToSurface(const void *buffer, int srcPitch, int destX, int
 	copyBlit(dst, src, pitch, srcPitch, width, height, format.bytesPerPixel);
 }
 
-void Surface::copyRectToSurface(const Graphics::Surface &srcSurface, int destX, int destY, const Common::Rect subRect) {
+void Surface::copyRectToSurface(const Graphics::Surface &srcSurface, int destX, int destY, const Common::Rect &subRect) {
 	assert(srcSurface.format == format);
 
 	copyRectToSurface(srcSurface.getBasePtr(subRect.left, subRect.top), srcSurface.pitch, destX, destY, subRect.width(), subRect.height());
@@ -271,7 +271,7 @@ void Surface::copyRectToSurfaceWithKey(const void *buffer, int srcPitch, int des
 	Graphics::keyBlit(dst, src, pitch, srcPitch, width, height, format.bytesPerPixel, key);
 }
 
-void Surface::copyRectToSurfaceWithKey(const Graphics::Surface &srcSurface, int destX, int destY, const Common::Rect subRect, uint32 key) {
+void Surface::copyRectToSurfaceWithKey(const Graphics::Surface &srcSurface, int destX, int destY, const Common::Rect &subRect, uint32 key) {
 	assert(srcSurface.format == format);
 
 	copyRectToSurfaceWithKey(srcSurface.getBasePtr(subRect.left, subRect.top), srcSurface.pitch, destX, destY, subRect.width(), subRect.height(), key);

--- a/graphics/surface.h
+++ b/graphics/surface.h
@@ -314,7 +314,7 @@ public:
 	 * @param destY       The y coordinate of the destination rectangle.
 	 * @param subRect     The subRect of the surface to be blitted.
 	 */
-	void copyRectToSurface(const Graphics::Surface &srcSurface, int destX, int destY, const Common::Rect subRect);
+	void copyRectToSurface(const Graphics::Surface &srcSurface, int destX, int destY, const Common::Rect &subRect);
 
 	/**
 	 * Copy a bitmap to the internal buffer of the surface.
@@ -342,7 +342,7 @@ public:
 	 * @param subRect     The subRect of the surface to be blitted.
 	 * @param key
 	 */
-	void copyRectToSurfaceWithKey(const Graphics::Surface &srcSurface, int destX, int destY, const Common::Rect subRect, uint32 key);
+	void copyRectToSurfaceWithKey(const Graphics::Surface &srcSurface, int destX, int destY, const Common::Rect &subRect, uint32 key);
 
 	/**
 	 * Convert the data to another pixel format.

--- a/graphics/transform_tools.h
+++ b/graphics/transform_tools.h
@@ -34,7 +34,7 @@ namespace Graphics {
 		float y;
 		FloatPoint() : x(0), y(0) {}
 		FloatPoint(float x1, float y1) : x(x1), y(y1) {}
-		FloatPoint(const Common::Point p) : x(p.x), y(p.y) {}
+		FloatPoint(const Common::Point &p) : x(p.x), y(p.y) {}
 		bool operator==(const FloatPoint &p) const { return fabs(x - p.x) < kEpsilon && fabs(y - p.y) < kEpsilon; }
 		bool operator!=(const FloatPoint  &p) const { return fabs(x - p.x) > kEpsilon || fabs(y - p.y) > kEpsilon; }
 		FloatPoint operator+(const FloatPoint &delta) const { return FloatPoint (x + delta.x, y + delta.y);     }

--- a/gui/MetadataParser.h
+++ b/gui/MetadataParser.h
@@ -38,8 +38,8 @@ struct MetadataGame {
 	Common::String series_id;
 
 	MetadataGame() {}
-	MetadataGame(const Common::String i, const Common::String n, const Common::String eid, const Common::String cid,
-		const Common::String mid, const Common::String df, const Common::String sid, const Common::String zid, const Common::String yr)
+	MetadataGame(const Common::String &i, const Common::String &n, const Common::String &eid, const Common::String &cid,
+		const Common::String &mid, const Common::String &df, const Common::String &sid, const Common::String &zid, const Common::String &yr)
 		: id(i), name(n), engine_id(eid), company_id(cid), year(yr), moby_id(mid), datafiles(df), zoom_id(zid), series_id(sid) {}
 };
 
@@ -50,7 +50,7 @@ struct MetadataEngine {
 	bool enabled;
 
 	MetadataEngine() : enabled(false) {}
-	MetadataEngine(const Common::String i, const Common::String n, const Common::String altn, bool e)
+	MetadataEngine(const Common::String &i, const Common::String &n, const Common::String &altn, bool e)
 		: id(i), name(n), alt_name(altn), enabled(e) {}
 };
 
@@ -59,7 +59,7 @@ struct MetadataSeries {
 	Common::String name;
 
 	MetadataSeries() {}
-	MetadataSeries(const Common::String i, const Common::String n) : id(i), name(n) {}
+	MetadataSeries(const Common::String &i, const Common::String &n) : id(i), name(n) {}
 };
 
 struct MetadataCompany {
@@ -68,7 +68,7 @@ struct MetadataCompany {
 	Common::String alt_name;
 
 	MetadataCompany() {}
-	MetadataCompany(const Common::String i, const Common::String n, const Common::String altn)
+	MetadataCompany(const Common::String &i, const Common::String &n, const Common::String &altn)
 		: id(i), name(n), alt_name(altn) {}
 };
 

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -491,7 +491,7 @@ const Graphics::ManagedSurface *GridWidget::platformToSurface(Common::Platform p
 	return _platformIcons[platformCode];
 }
 
-const Graphics::ManagedSurface *GridWidget::demoToSurface(const Common::String extraString, Graphics::AlphaType &alphaType) {
+const Graphics::ManagedSurface *GridWidget::demoToSurface(const Common::String &extraString, Graphics::AlphaType &alphaType) {
 	if (! extraString.contains("Demo") )
 		return nullptr;
 	alphaType = _extraIconsAlpha[0];

--- a/gui/widgets/grid.h
+++ b/gui/widgets/grid.h
@@ -178,7 +178,7 @@ public:
 	const Graphics::ManagedSurface *filenameToSurface(const Common::String &name);
 	const Graphics::ManagedSurface *languageToSurface(Common::Language languageCode, Graphics::AlphaType &alphaType);
 	const Graphics::ManagedSurface *platformToSurface(Common::Platform platformCode, Graphics::AlphaType &alphaType);
-	const Graphics::ManagedSurface *demoToSurface(const Common::String extraString, Graphics::AlphaType &alphaType);
+	const Graphics::ManagedSurface *demoToSurface(const Common::String &extraString, Graphics::AlphaType &alphaType);
 	const Graphics::ManagedSurface *disabledThumbnail();
 
 	/// Update _visibleEntries from _allEntries and returns true if reload is required.

--- a/video/subtitles.cpp
+++ b/video/subtitles.cpp
@@ -280,7 +280,7 @@ void Subtitles::loadSRTFile(const Common::Path &fname) {
 	_loaded = _srtParser.parseFile(fname);
 }
 
-void Subtitles::setBBox(const Common::Rect bbox) {
+void Subtitles::setBBox(const Common::Rect &bbox) {
 	_requestedBBox = bbox;
 
 	Graphics::PixelFormat overlayFormat = g_system->getOverlayFormat();

--- a/video/subtitles.h
+++ b/video/subtitles.h
@@ -66,7 +66,7 @@ public:
 	void loadSRTFile(const Common::Path &fname);
 	void close() { _loaded = false; _subtitle.clear(); _fname.clear(); _srtParser.cleanup(); }
 	void setFont(const char *fontname, int height = 18);
-	void setBBox(const Common::Rect bbox);
+	void setBBox(const Common::Rect &bbox);
 	void setColor(byte r, byte g, byte b);
 	void setPadding(uint16 horizontal, uint16 vertical);
 	bool drawSubtitle(uint32 timestamp, bool force = false) const;


### PR DESCRIPTION
Applied to all `const Common::` and `const Graphics::` instances.

The biggest performance win is surely `Common::String` and `Common::Path`.

It also uncovered a few inconsistencies where a .h had a `const` parameter while its .cpp didn't.