### PR TITLE
3DS: Fix top screen not fully rendering in some cases

### DIFF
--- a/backends/platform/3ds/osystem-graphics.cpp
+++ b/backends/platform/3ds/osystem-graphics.cpp
@@ -108,7 +108,7 @@ void OSystem_3DS::init3DSGraphics() {
 	C3D_DepthTest(false, GPU_GEQUAL, GPU_WRITE_ALL);
 	C3D_CullFace(GPU_CULL_NONE);
 
-	_overlay.create(320, 240, &DEFAULT_MODE, true);
+	// _overlay initialized in updateSize()
 }
 
 void OSystem_3DS::destroy3DSGraphics() {
@@ -228,6 +228,18 @@ void OSystem_3DS::initSize(uint width, uint height,
 }
 
 void OSystem_3DS::updateSize() {
+	// Initialize _overlay here so that it can be reinitialized when _screen is changed.
+
+	// Overlay sprite must have a width matching or exceeding that of the screen to
+	//	which it's set to render, otherwise porrtions of the screen will not render.
+	// _screen == kScreenTop
+	//	>>> overlay renders to top screen
+	//	>>> top screen is 400 pixels wide
+	// _screen == (kScreenBottom | kScreenBoth)
+	//	>>> overlay renders to bottom screen
+	//	>>> bottom screen is 320 pixels wide
+	_overlay.create(_screen == kScreenTop ? 400 : 320, 240, &DEFAULT_MODE, true);
+
 	if (_stretchToFit) {
 		_gameTopX = _gameTopY = _gameBottomX = _gameBottomY = 0;
 		_gameTopTexture.setScale(400.f / _gameWidth, 240.f / _gameHeight);

--- a/backends/platform/3ds/osystem-graphics.cpp
+++ b/backends/platform/3ds/osystem-graphics.cpp
@@ -231,7 +231,7 @@ void OSystem_3DS::updateSize() {
 	// Initialize _overlay here so that it can be reinitialized when _screen is changed.
 
 	// Overlay sprite must have a width matching or exceeding that of the screen to
-	//	which it's set to render, otherwise porrtions of the screen will not render.
+	//	which it's set to render, otherwise portions of the screen will not render.
 	// _screen == kScreenTop
 	//	>>> overlay renders to top screen
 	//	>>> top screen is 400 pixels wide


### PR DESCRIPTION
When only the top screen is set to be used, the overlay must have a width of 400; otherwise there's a possibility that not all of the screen will be rendered. This is most notable at the launcher screen, where if only the top screen is set to be used, and `Sprite _overlay` has a width of 320, the right side of the screen will not be rendered.
![2025-04-06_15-27-02 339_top](https://github.com/user-attachments/assets/55a36354-6cdf-452d-a665-8062dd13ad77)

This commit ensures that the overlay sprite has a width of 400 when only the top screen is set to be used. In all other cases, the overlay sprite will have a width of 320.