### PR TITLE
GUI: restrict platform selection via guioptions

### DIFF
--- a/common/gui_options.cpp
+++ b/common/gui_options.cpp
@@ -166,6 +166,12 @@ String parseGameGUIOptions(const String &str) {
 			ii = c_end;
 		}
 	}
+	// Check for Additional Platforms
+	for (int i = 0; i < str.size(); ++i) {
+		if (str[i] == '\x34') {
+			res += String(str[i]) + String(str[i + 1]);
+		}
+	}
 
 	return res;
 }
@@ -176,6 +182,13 @@ const String getGameGUIOptionsDescription(const String &options) {
 	for (int i = 0; g_gameOptions[i].desc; i++)
 		if (options.contains(g_gameOptions[i].option[0]))
 			res += String(g_gameOptions[i].desc) + " ";
+
+	// Check for Additional Platforms
+	for (int i = 0; i < options.size(); ++i) {
+		if (options[i] == '\x34') {
+			res += String(options[i]) + String(options[i + 1]) + " ";
+		}
+	}
 
 	res.trim();
 

--- a/common/gui_options.h
+++ b/common/gui_options.h
@@ -131,6 +131,8 @@
 #define GUIO11(a,b,c,d,e,f,g,h,i,j,k) (a b c d e f g h i j k)
 #define GUIO12(a,b,c,d,e,f,g,h,i,j,k,l) (a b c d e f g h i j k l)
 
+#define GUIO_PLATFORM(a) (Common::getGameGUIOptionsPlatformCode(a))
+
 namespace Common {
 
 /**

--- a/common/platform.cpp
+++ b/common/platform.cpp
@@ -96,6 +96,91 @@ Platform parsePlatform(const String &str) {
 	return kPlatformUnknown;
 }
 
+const char *getGameGUIOptionsPlatformCode(Platform platform) {
+	switch (platform) {
+	case kPlatformDOS:
+		return "\x34\x01";
+	case kPlatformAmiga:
+		return "\x34\x02";
+	case kPlatformAmstradCPC:
+		return "\x34\x03";
+	case kPlatformAtari8Bit:
+		return "\x34\x04";
+	case kPlatformAtariST:
+		return "\x34\x05";
+	case kPlatformMacintosh:
+		return "\x34\x06";
+	case kPlatformFMTowns:
+		return "\x34\x07";
+	case kPlatformWindows:
+		return "\x34\x08";
+	case kPlatformNES:
+		return "\x34\x09";
+	case kPlatformC64:
+		return "\x34\x0A";
+	case kPlatformCoCo:
+		return "\x34\x0B";
+	case kPlatformCoCo3:
+		return "\x34\x0C";
+	case kPlatformLinux:
+		return "\x34\x0D";
+	case kPlatformAcorn:
+		return "\x34\x0E";
+	case kPlatformSegaCD:
+		return "\x34\x0F";
+	case kPlatform3DO:
+		return "\x34\x10";
+	case kPlatformPCEngine:
+		return "\x34\x11";
+	case kPlatformApple2:
+		return "\x34\x12";
+	case kPlatformApple2GS:
+		return "\x34\x13";
+	case kPlatformPC98:
+		return "\x34\x14";
+	case kPlatformWii:
+		return "\x34\x15";
+	case kPlatformPSX:
+		return "\x34\x16";
+	case kPlatformPS2:
+		return "\x34\x17";
+	case kPlatformPS3:
+		return "\x34\x18";
+	case kPlatformXbox:
+		return "\x34\x19";
+	case kPlatformCDi:
+		return "\x34\x1A";
+	case kPlatformIOS:
+		return "\x34\x1B";
+	case kPlatformAndroid:
+		return "\x34\x1C";
+	case kPlatformOS2:
+		return "\x34\x1D";
+	case kPlatformBeOS:
+		return "\x34\x1E";
+	case kPlatformPocketPC:
+		return "\x34\x1F";
+	case kPlatformMegaDrive:
+		return "\x34\x21";
+	case kPlatformSaturn:
+		return "\x34\x22";
+	case kPlatformPippin:
+		return "\x34\x23";
+	case kPlatformMacintoshII:
+		return "\x34\x24";
+	case kPlatformShockwave:
+		return "\x34\x25";
+	case kPlatformZX:
+		return "\x34\x26";
+	case kPlatformTI994:
+		return "\x34\x27";
+	case kPlatformNintendoSwitch:
+		return "\x34\x28";
+	default:
+		return "\x34\x7E"; // Unknown
+	}
+}
+
 
 const char *getPlatformCode(Platform id) {
 	const PlatformDescription *l = g_platforms;
@@ -122,6 +207,16 @@ const char *getPlatformDescription(Platform id) {
 			return l->description;
 	}
 	return l->description;
+}
+
+bool checkGameGUIOptionPlatform(Platform plat, const String &str) {
+	if (!str.contains("\x34")) // If no platforms are specified
+		return true;
+
+	if (str.contains(getGameGUIOptionsPlatformCode(plat)))
+		return true;
+
+	return false;
 }
 
 List<String> getPlatformList() {

--- a/common/platform.h
+++ b/common/platform.h
@@ -102,8 +102,10 @@ extern Platform parsePlatform(const String &str);
 extern const char *getPlatformCode(Platform id);
 extern const char *getPlatformAbbrev(Platform id);
 extern const char *getPlatformDescription(Platform id);
+extern const char *getGameGUIOptionsPlatformCode(Platform platform);
 
-List<String> getPlatformList();
+bool checkGameGUIOptionPlatform(Platform plat, const String &str);
+	List<String> getPlatformList();
 
 /** @} */
 

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -210,6 +210,8 @@ DetectedGame AdvancedMetaEngineDetectionBase::toDetectedGame(const ADDetectedGam
 
 	game.setGUIOptions(desc->guiOptions + _guiOptions);
 	game.appendGUIOptions(getGameGUIOptionsDescriptionLanguage(desc->language));
+	game.appendGUIOptions(getGameGUIOptionsPlatformCode(desc->platform));
+
 
 	if (desc->flags & ADGF_ADDENGLISH)
 		game.appendGUIOptions(getGameGUIOptionsDescriptionLanguage(Common::EN_ANY));

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -381,7 +381,8 @@ void EditGameDialog::addGameControls(GuiObject *boss, const Common::String &pref
 	_platformPopUp->appendEntry("");
 	const Common::PlatformDescription *p = Common::g_platforms;
 	for (; p->code; ++p) {
-		_platformPopUp->appendEntry(p->description, p->id);
+		if (checkGameGUIOptionPlatform(p->id, _guioptionsString))
+			_platformPopUp->appendEntry(p->description, p->id);
 	}
 }
 
@@ -393,7 +394,7 @@ void EditGameDialog::setupGraphicsTab() {
 void EditGameDialog::open() {
 	OptionsDialog::open();
 
-	int sel, i;
+	int i;
 	bool e;
 
 	// En-/disable dialog items depending on whether overrides are active or not.
@@ -462,14 +463,18 @@ void EditGameDialog::open() {
 		_engineOptions->load();
 	}
 
-	const Common::PlatformDescription *p = Common::g_platforms;
 	const Common::Platform platform = Common::parsePlatform(ConfMan.get("platform", _domain));
-	sel = 0;
-	for (i = 0; p->code; ++p, ++i) {
-		if (platform == p->id)
-			sel = i + 2;
+
+	if (ConfMan.hasKey("platform", _domain)) {
+		_platformPopUp->setSelectedTag(platform);
+	} else {
+		_platformPopUp->setSelectedTag((uint32)Common::kPlatformUnknown);
 	}
-	_platformPopUp->setSelected(sel);
+
+	if (_platformPopUp->numEntries() <= 3) { // If only one platform is available
+		_platformPopUpDesc->setEnabled(false);
+		_platformPopUp->setEnabled(false);
+	}
 }
 
 void EditGameDialog::close() {


### PR DESCRIPTION
Added logic for platform detection:

- adds changes to GUIoptions class to check for platforms
- changes in editgamedialog to only view supported platforms for each game
- restricted platform selection for games having only 1 platform