### PR TITLE
RichText: slow TTF loading, lacking caching

### DIFF
--- a/gui/widgets/richtext.cpp
+++ b/gui/widgets/richtext.cpp
@@ -23,7 +23,7 @@
 #include "common/unicode-bidi.h"
 
 #include "graphics/macgui/mactext.h"
-
+#include "graphics/macgui/macfontmanager.h"
 #include "gui/gui-manager.h"
 
 #include "gui/ThemeEngine.h"

--- a/gui/widgets/richtext.cpp
+++ b/gui/widgets/richtext.cpp
@@ -197,7 +197,7 @@ void RichTextWidget::createWidget() {
 
 	const int fontHeight = g_gui.xmlEval()->getVar("Globals.Font.Height", 25);
 
-#if 1
+#if 0
 	Graphics::MacFont macFont(Graphics::kMacFontNewYork, fontHeight, Graphics::kMacFontRegular);
 	(void)ttfFamily;
 #else


### PR DESCRIPTION
GUI: Add caching support for TTF fonts in RichText

Updated richtext.cpp to use MacFontManager's caching when loading TTF fonts. This helps avoid loading the same font multiple times and speeds up rendering, like in the Help Widget.

Related to Planka task: "RichText: slow TTF loading, lacking caching"
