### PR TITLE
SCI: Merge and cleanup LZW decompressors

### DIFF
--- a/engines/sci/resource/decompressor.h
+++ b/engines/sci/resource/decompressor.h
@@ -142,26 +142,15 @@ protected:
 };
 
 /**
- * LZW-like decompressor for SCI01/SCI1.
- * TODO: Needs clean-up of post-processing fncs
+ * LZW decompressor for SCI0/01/1
+ * TODO: Clean-up post-processing functions
  */
 class DecompressorLZW : public Decompressor {
 public:
-	DecompressorLZW(int nCompression) : _numbits(0), _curtoken(0), _endtoken(0) {
-		_compression = nCompression;
-	}
-	void init(Common::ReadStream *src, byte *dest, uint32 nPacked, uint32 nUnpacked) override;
+	DecompressorLZW(ResourceCompression compression) : _compression(compression) {}
 	int unpack(Common::ReadStream *src, byte *dest, uint32 nPacked, uint32 nUnpacked) override;
 
 protected:
-	enum {
-		PIC_OPX_EMBEDDED_VIEW = 1,
-		PIC_OPX_SET_PALETTE = 2,
-		PIC_OP_OPX = 0xfe
-	};
-	// unpacking procedures
-	// TODO: unpackLZW and unpackLZW1 are similar and should be merged
-	int unpackLZW1(Common::ReadStream *src, byte *dest, uint32 nPacked, uint32 nUnpacked);
 	int unpackLZW(Common::ReadStream *src, byte *dest, uint32 nPacked, uint32 nUnpacked);
 
 	// functions to post-process view and pic resources
@@ -171,14 +160,7 @@ protected:
 	int getRLEsize(byte *rledata, int dsize);
 	void buildCelHeaders(byte **seeker, byte **writer, int celindex, int *cc_lengths, int max);
 
-	// decompressor data
-	struct Tokenlist {
-		byte data;
-		uint16 next;
-	};
-	uint16 _numbits;
-	uint16 _curtoken, _endtoken;
-	int _compression;
+	ResourceCompression _compression;
 };
 
 /**


### PR DESCRIPTION
This PR ports the [LZW decompressor](https://github.com/sluicebox/sci-tools/blob/main/SCI/Resource/Decompressors/LzwDecompressor.cs) from my SCI tools to ScummVM. This replaces two FreeSCI-era decompressors with one small documented one.

That's right, we're compressing the decompressors.

SCI has two LZW compression formats. They only have two minor differences. The first is the bit order, the second is an off-by-one bug. The bug is so common in LZW implementations that it has a name and made the [LZW wiki page](https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Welch): "early change".

I don't think it's known to the SCI community that the formats only differ by these two things. I learned it the hard way when developing my decompressors. I think what usually happens is that the FreeSCI code for the second algorithm just gets ported around. It works, but it's based on disassembly and not very comprehensible. (As the [FreeSCI comments](https://github.com/wjp/freesci-archive/blob/master/doc/misc/decrypt.c) acknowledged.)

This decompressor helps generate my sci-scripts repository, where it gets run on every script in almost every game/version, so it's well used. I've also ran it against every LZW-compressed resource in my corpus.

This affects all SCI0-SCI1 games, but it shouldn't change any behavior unless I've messed something up =)
