### PR TITLE
COMMON: Fix DCL IMPLODE name

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1098,7 +1098,7 @@ Other contributions
      Hugues Valois                  - Game selection menu
      Jordi Vilalta                  - Numerous code and website clean-up
                                       patches
-     Petr Vyhnak                    - The DCL-INFLATE algorithm, many Win32
+     Petr Vyhnak                    - The DCL-IMPLODE algorithm, many Win32
                                       improvements
      Bas Zoetekouw                  - Man pages, debian package management,
                                       CVS maintenance

--- a/common/compression/dcl.cpp
+++ b/common/compression/dcl.cpp
@@ -348,7 +348,7 @@ bool DecompressorDCL::unpack(SeekableReadStream *sourceStream, WriteStream *targ
 	byte dictionaryType = getByteLSB();
 
 	if (mode != DCL_BINARY_MODE && mode != DCL_ASCII_MODE) {
-		warning("DCL-INFLATE: Error: Encountered mode %02x, expected 00 or 01", mode);
+		warning("DCL-IMPLODE: Error: Encountered mode %02x, expected 00 or 01", mode);
 		return false;
 	}
 
@@ -366,7 +366,7 @@ bool DecompressorDCL::unpack(SeekableReadStream *sourceStream, WriteStream *targ
 		dictionarySize = 4096;
 		break;
 	default:
-		warning("DCL-INFLATE: Error: unsupported dictionary type %02x", dictionaryType);
+		warning("DCL-IMPLODE: Error: unsupported dictionary type %02x", dictionaryType);
 		return false;
 	}
 	dictionaryMask = dictionarySize - 1;
@@ -397,14 +397,14 @@ bool DecompressorDCL::unpack(SeekableReadStream *sourceStream, WriteStream *targ
 
 			if (_targetFixedSize) {
 				if (tokenLength + _bytesWritten > _targetSize) {
-					warning("DCL-INFLATE Error: Write out of bounds while copying %d bytes (declared unpacked size is %d bytes, current is %d + %d bytes)",
+					warning("DCL-IMPLODE Error: Write out of bounds while copying %d bytes (declared unpacked size is %d bytes, current is %d + %d bytes)",
 							tokenLength, _targetSize, _bytesWritten, tokenLength);
 					return false;
 				}
 			}
 
 			if (_bytesWritten < tokenOffset) {
-				warning("DCL-INFLATE Error: Attempt to copy from before beginning of input stream (declared unpacked size is %d bytes, current is %d bytes)",
+				warning("DCL-IMPLODE Error: Attempt to copy from before beginning of input stream (declared unpacked size is %d bytes, current is %d bytes)",
 						_targetSize, _bytesWritten);
 				return false;
 			}
@@ -449,7 +449,7 @@ bool DecompressorDCL::unpack(SeekableReadStream *sourceStream, WriteStream *targ
 
 	if (_targetFixedSize) {
 		if (_bytesWritten != _targetSize)
-			warning("DCL-INFLATE Error: Inconsistent bytes written (%d) and target buffer size (%d)", _bytesWritten, _targetSize);
+			warning("DCL-IMPLODE Error: Inconsistent bytes written (%d) and target buffer size (%d)", _bytesWritten, _targetSize);
 		return _bytesWritten == _targetSize;
 	}
 	return true; // For targets featuring dynamic size we always succeed

--- a/devtools/credits.pl
+++ b/devtools/credits.pl
@@ -1047,7 +1047,7 @@ begin_credits("Credits");
 				add_person("Sean Terrell", "", "");
 				add_person("Hugues Valois", "", "Game selection menu");
 				add_person("Jordi Vilalta", "", "Numerous code and website clean-up patches");
-				add_person("Petr Vyhnak", "", "The DCL-INFLATE algorithm, many Win32 improvements");
+				add_person("Petr Vyhnak", "", "The DCL-IMPLODE algorithm, many Win32 improvements");
 				add_person("Bas Zoetekouw", "", "Man pages, debian package management, CVS maintenance");
 			end_persons();
 			add_paragraph("Special thanks to Prof. Dr. Gary Nutt ".

--- a/doc/docportal/help/credits.rst
+++ b/doc/docportal/help/credits.rst
@@ -2663,7 +2663,7 @@ FreeSCI Contributors
    * - Jordi Vilalta
      - Numerous code and website clean-up patches
    * - Petr Vyhnak
-     - The DCL-INFLATE algorithm, many Win32 improvements
+     - The DCL-IMPLODE algorithm, many Win32 improvements
    * - Bas Zoetekouw
      - Man pages, debian package management, CVS maintenance
 

--- a/engines/sci/detection.cpp
+++ b/engines/sci/detection.cpp
@@ -51,7 +51,7 @@ static const DebugChannelDef debugFlagList[] = {
 	{Sci::kDebugLevelTime, "Time", "Time debugging"},
 	{Sci::kDebugLevelRoom, "Room", "Room number debugging"},
 	{Sci::kDebugLevelAvoidPath, "Pathfinding", "Pathfinding debugging"},
-	{Sci::kDebugLevelDclInflate, "DCL", "DCL inflate debugging"},
+	{Sci::kDebugLevelDclImplode, "DCL", "DCL implode debugging"},
 	{Sci::kDebugLevelVM, "VM", "VM debugging"},
 	{Sci::kDebugLevelScripts, "Scripts", "Notifies when scripts are unloaded"},
 	{Sci::kDebugLevelPatcher, "Patcher", "Notifies when scripts or resources are patched"},

--- a/engines/sci/sci.h
+++ b/engines/sci/sci.h
@@ -106,7 +106,7 @@ enum kDebugLevels {
 	kDebugLevelTime,
 	kDebugLevelRoom,
 	kDebugLevelAvoidPath,
-	kDebugLevelDclInflate,
+	kDebugLevelDclImplode,
 	kDebugLevelVM,
 	kDebugLevelScripts,
 	kDebugLevelGC,

--- a/gui/credits.h
+++ b/gui/credits.h
@@ -1329,7 +1329,7 @@ static const char *const credits[] = {
 "C0""Jordi Vilalta",
 "C2""Numerous code and website clean-up patches",
 "C0""Petr Vyhnak",
-"C2""The DCL-INFLATE algorithm, many Win32 improvements",
+"C2""The DCL-IMPLODE algorithm, many Win32 improvements",
 "C0""Bas Zoetekouw",
 "C2""Man pages, debian package management, CVS maintenance",
 "C0""Special thanks to Prof. Dr. Gary Nutt for allowing the FreeSCI VM extension as a course project in his Advanced OS course.",


### PR DESCRIPTION
We have mislabeled PKWARE's DCL IMPLODE format as DCL INFLATE in the ScummVM credits and messages.

It's true that PKWARE's Data Compression Library also supported PKWARE's DEFLATE at some point, but that's a completely different format.

The Data Compression Library format we decompress is named IMPLODE. You'd call the `implode` library function to compress with it and `explode` to decompress.

https://support.pkware.com/pkzip/dcl
http://fileformats.archiveteam.org/wiki/PKWARE_DCL_Implode
https://github.com/madler/zlib/blob/master/contrib/blast/blast.c
