### PR TITLE
QDENGINE: Convert engine to rgba8888 pixel format

### DIFF
--- a/engines/qdengine/qdcore/qd_camera.cpp
+++ b/engines/qdengine/qdcore/qd_camera.cpp
@@ -677,14 +677,14 @@ bool qdCamera::draw_grid() const {
 			if (_grid[cnt].height() || _grid[cnt].attributes()) {
 				color = 0;
 				if (_grid[cnt].attributes() & sGridCell::CELL_IMPASSABLE)
-					color = grDispatcher::make_rgb565u(0xff, 0x00, 0x00);
+					color = grDispatcher::make_rgb888(0xff, 0x00, 0x00);
 				else if (_grid[cnt].attributes() & sGridCell::CELL_PERSONAGE_OCCUPIED)
-					color = grDispatcher::make_rgb565u(0xff, 0xff, 0x00);
+					color = grDispatcher::make_rgb888(0xff, 0xff, 0x00);
 				else if (_grid[cnt].height())
-					color = grDispatcher::make_rgb565u(0xff, 0xff, 0xff);
+					color = grDispatcher::make_rgb888(0xff, 0xff, 0xff);
 
 				if (_grid[cnt].attributes() & sGridCell::CELL_OCCUPIED)
-					color = grDispatcher::make_rgb565u(0x00, 0x00, 0xff);
+					color = grDispatcher::make_rgb888(0x00, 0x00, 0xff);
 				if (_grid[cnt].attributes() & sGridCell::CELL_PERSONAGE_PATH)
 					warning("path");
 

--- a/engines/qdengine/qdcore/qd_game_dispatcher.cpp
+++ b/engines/qdengine/qdcore/qd_game_dispatcher.cpp
@@ -2831,16 +2831,16 @@ bool qdGameDispatcher::game_screenshot(Graphics::Surface &thumb) const {
 	int w = g_engine->_screenW;
 	int h = g_engine->_screenH;
 
-	thumb.create(w, h, Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0));
+	thumb.create(w, h, Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
 
 	if (qdGameScene *sp = get_active_scene()) {
-		qdSprite sprite(w, h, GR_RGB565);
+		qdSprite sprite(w, h, GR_RGB888);
 
 		sp->redraw();
 
-		uint16 col;
+		uint32 col;
 		for (int i = 0; i < h; i++) {
-			uint16 *dst = (uint16 *)thumb.getBasePtr(0, i);
+			uint32 *dst = (uint32 *)thumb.getBasePtr(0, i);
 			for (int j = 0; j < w; j++) {
 				grDispatcher::instance()->getPixel(j, i, col);
 				*dst = col;

--- a/engines/qdengine/qdcore/qd_sprite.cpp
+++ b/engines/qdengine/qdcore/qd_sprite.cpp
@@ -224,18 +224,34 @@ bool qdSprite::load() {
 			float rx = static_cast<float>(g_engine->_screenW) / g_engine->_thumbSizeX;
 			float ry = static_cast<float>(g_engine->_screenH) / g_engine->_thumbSizeY;
 
-			for (int i = 0; i < _size.y; i++) {
-				byte *dst = (byte *)&_data[3 * _size.x * i];
-				for (int j = 0; j < _size.x; j++) {
-					uint16 col = *(uint16 *)saveHeader.thumbnail->getBasePtr(rx * j, ry * i);
-					byte r, g, b;
-					grDispatcher::split_rgb565u(col, r, g, b);
+			if (saveHeader.thumbnail->format.bytesPerPixel == 2) {
+				for (int i = 0; i < _size.y; i++) {
+					byte *dst = (byte *)&_data[3 * _size.x * i];
+					for (int j = 0; j < _size.x; j++) {
+						uint16 col = *(uint16 *)saveHeader.thumbnail->getBasePtr(rx * j, ry * i);
+						byte r, g, b;
+						grDispatcher::split_rgb565u(col, r, g, b);
 
-					dst[0] = b;
-					dst[1] = g;
-					dst[2] = r;
+						dst[0] = b;
+						dst[1] = g;
+						dst[2] = r;
 
-					dst += 3;
+						dst += 3;
+					}
+				}
+			} else {
+				// bytes per pixel is 4
+				for (int i = 0; i < _size.y; i++) {
+					byte *dst = (byte *)&_data[3 * _size.x * i];
+					for (int j = 0; j < _size.x; j++) {
+						byte *col_buf = (byte *)saveHeader.thumbnail->getBasePtr(rx * j, ry * i);
+
+						dst[0] = col_buf[1];
+						dst[1] = col_buf[2];
+						dst[2] = col_buf[3];
+
+						dst += 3;
+					}
 				}
 			}
 		}

--- a/engines/qdengine/qdcore/qd_sprite.cpp
+++ b/engines/qdengine/qdcore/qd_sprite.cpp
@@ -216,18 +216,26 @@ bool qdSprite::load() {
 			_size = _picture_size = Vect2i(g_engine->_thumbSizeX, g_engine->_thumbSizeY);
 			_picture_offset = Vect2i(0, 0);
 
-			_format = GR_RGB565;
+			_format = GR_RGB888;
 
-			_data = new byte[_size.x * _size.y * 2];
+			_data = new byte[_size.x * _size.y * 3];
 
 			// Scale image down
 			float rx = static_cast<float>(g_engine->_screenW) / g_engine->_thumbSizeX;
 			float ry = static_cast<float>(g_engine->_screenH) / g_engine->_thumbSizeY;
 
 			for (int i = 0; i < _size.y; i++) {
-				uint16 *dst = (uint16 *)&_data[2 * _size.x * i];
+				byte *dst = (byte *)&_data[3 * _size.x * i];
 				for (int j = 0; j < _size.x; j++) {
-					*dst++ = *(uint16 *)saveHeader.thumbnail->getBasePtr(rx * j, ry * i);
+					uint16 col = *(uint16 *)saveHeader.thumbnail->getBasePtr(rx * j, ry * i);
+					byte r, g, b;
+					grDispatcher::split_rgb565u(col, r, g, b);
+
+					dst[0] = b;
+					dst[1] = g;
+					dst[2] = r;
+
+					dst += 3;
 				}
 			}
 		}

--- a/engines/qdengine/qdengine.cpp
+++ b/engines/qdengine/qdengine.cpp
@@ -72,7 +72,7 @@ static void qd_show_load_progress(int percents_loaded, void *p);
 QDEngineEngine::QDEngineEngine(OSystem *syst, const ADGameDescription *gameDesc) : Engine(syst),
 	_gameDescription(gameDesc), _randomSource("QDEngine") {
 	g_engine = this;
-	_pixelformat = Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0);
+	_pixelformat = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
 
 	_screenW = 640;
 	_screenH = 480;
@@ -467,7 +467,7 @@ void QDEngineEngine::init_graphics() {
 
 	grDispatcher::set_instance(_grD);
 
-	grDispatcher::instance()->init(g_engine->_screenW, g_engine->_screenH, GR_RGB565);
+	grDispatcher::instance()->init(g_engine->_screenW, g_engine->_screenH, GR_ARGB8888);
 
 	grDispatcher::instance()->setClip();
 	grDispatcher::instance()->setClipMode(1);

--- a/engines/qdengine/system/graphics/gr_dispatcher.cpp
+++ b/engines/qdengine/system/graphics/gr_dispatcher.cpp
@@ -315,23 +315,24 @@ void grDispatcher::rectangleAlpha(int x, int y, int sx, int sy, uint32 color, in
 	int psy = sy;
 
 	if (!clip_rectangle(x, y, px, py, psx, psy)) return;
-	int dx = 1;
+	int dx = 4;
 	int dy = 1;
 
-	byte mr, mg, mb;
-	split_rgb565u(color, mr, mg, mb);
+	uint32 mr, mg, mb;
+	split_rgb888(color, mr, mg, mb);
 
 	mr = (mr * (255 - alpha)) >> 8;
 	mg = (mg * (255 - alpha)) >> 8;
 	mb = (mb * (255 - alpha)) >> 8;
 
-	uint32 mcl = make_rgb565u(mr, mg, mb);
-
 	for (int i = 0; i < psy; i++) {
-		uint16 *scr_buf = reinterpret_cast<uint16 *>(_screenBuf->getBasePtr(x, y));
+		byte *scr_buf = reinterpret_cast<byte *>(_screenBuf->getBasePtr(x,y));
 
 		for (int j = 0; j < psx; j++) {
-			*scr_buf = alpha_blend_565(mcl, *scr_buf, alpha);
+			scr_buf[3] = mr + ((alpha * scr_buf[3]) >> 8);
+			scr_buf[2] = mg + ((alpha * scr_buf[2]) >> 8);
+			scr_buf[1] = mb + ((alpha * scr_buf[1]) >> 8);
+
 			scr_buf += dx;
 		}
 
@@ -359,25 +360,38 @@ void grDispatcher::resetSurfaceOverride() {
 void grDispatcher::setPixel(int x, int y, int col) {
 	if (_clipMode && !clipCheck(x, y)) return;
 
-	uint16 *p = (uint16 *)(_screenBuf->getBasePtr(x, y));
+	uint32 *p = (uint32 *)(_screenBuf->getBasePtr(x, y));
 	*p = col;
 }
 
 void grDispatcher::setPixelFast(int x, int y, int col) {
-	uint16 *p = (uint16 *)(_screenBuf->getBasePtr(x, y));
-	*p = col;
+	byte *cp = (byte *)(&col);
+	byte *p = (byte *)(_screenBuf->getBasePtr(x, y));
+
+	p[1] = cp[2];
+	p[2] = cp[1];
+	p[3] = cp[0];
 }
 
 void grDispatcher::setPixelFast(int x, int y, int r, int g, int b) {
-	uint16 *p = (uint16 *)(_screenBuf->getBasePtr(x, y));
-	*p = (((r >> 3) << 11) + ((g >> 2) << 5) + ((b >> 3) << 0));
+	byte *p = (byte *)(_screenBuf->getBasePtr(x, y));
+
+	p[1] = b;
+	p[2] = g;
+	p[3] = r;
 }
 
 void grDispatcher::setPixel(int x, int y, int r, int g, int b) {
 	if (_clipMode && !clipCheck(x, y)) return;
 
-	uint16 *p = (uint16 *)(_screenBuf->getBasePtr(x * 2, y));
-	*p = (((r >> 3) << 11) + ((g >> 2) << 5) + ((b >> 3) << 0));
+	byte *p = (byte *)(_screenBuf->getBasePtr(x, y));
+	p[1] = b;
+	p[2] = g;
+	p[3] = r;
+}
+
+void grDispatcher::getPixel(int x, int y, uint32 &col) {
+	col = *(uint32 *)(_screenBuf->getBasePtr(x, y));
 }
 
 void grDispatcher::getPixel(int x, int y, uint16 &col) {
@@ -385,8 +399,11 @@ void grDispatcher::getPixel(int x, int y, uint16 &col) {
 }
 
 void grDispatcher::getPixel(int x, int y, byte &r, byte &g, byte &b) {
-	uint16 col = *(uint16 *)(_screenBuf->getBasePtr(x, y));
-	split_rgb565u(col, r, g, b);
+	byte *p = (byte *)(_screenBuf->getBasePtr(x, y));
+
+	r = p[3];
+	g = p[2];
+	b = p[1];
 }
 
 bool grDispatcher::clip_line(int &x0, int &y0, int &x1, int &y1) const {

--- a/engines/qdengine/system/graphics/gr_dispatcher.h
+++ b/engines/qdengine/system/graphics/gr_dispatcher.h
@@ -241,6 +241,7 @@ public:
 	void surfaceOverride(Graphics::ManagedSurface *target);
 	void resetSurfaceOverride();
 
+	void getPixel(int x, int y, uint32 &col);
 	void getPixel(int x, int y, uint16 &col);
 	void getPixel(int x, int y, byte &r, byte &g, byte &b);
 

--- a/engines/qdengine/system/graphics/gr_draw_sprite.cpp
+++ b/engines/qdengine/system/graphics/gr_draw_sprite.cpp
@@ -71,16 +71,18 @@ void grDispatcher::putSpr_a(int x, int y, int sx, int sy, const byte *p, int mod
 		fx = (1 << 15);
 
 		for (j = x0; j != x1; j += ix) {
-			const byte *src_data = line_src + (fx >> 16) * 4;
-			uint32 a = src_data[3];
+			int idx = (fx >> 16) << 2;
+			uint32 a = line_src[idx + 3];
 
 			if (a != 255 && clipCheck(x + j, y + i)) {
-				if (a) {
-					uint16 sc;
-					getPixel(x + j, y + i, sc);
-					setPixel(x + j, y + i, alpha_blend_565(make_rgb565u(src_data[2], src_data[1], src_data[0]), sc, a));
-				} else
-					setPixel(x + j, y + i, make_rgb565u(src_data[2], src_data[1], src_data[0]));
+				byte sr, sg, sb;
+				getPixel(x + j, y + i, sr, sg, sb);
+
+				uint32 r = line_src[idx + 2] + ((a * sr) >> 8);
+				uint32 g = line_src[idx + 1] + ((a * sg) >> 8);
+				uint32 b = line_src[idx + 0] + ((a * sb) >> 8);
+
+				setPixel(x + j, y + i, r, g, b);
 			}
 			fx += dx;
 		}
@@ -119,18 +121,23 @@ void grDispatcher::putSpr(int x, int y, int sx, int sy, const byte *p, int mode,
 		x1 = 0;
 		ix = -1;
 	}
-	const uint16 *src = reinterpret_cast<const uint16 *>(p);
-
+	sx *= 3;
 	for (int i = y0; i != y1; i += iy) {
-		const uint16 *line_src = src + ((fy >> 16) * sx);
+		const byte *line_src = p + ((fy >> 16) * sx);
 
 		fy += dy;
 		fx = (1 << 15);
 
 		for (int j = x0; j != x1; j += ix) {
-			uint32 cl = line_src[fx >> 16];
-			if (cl)
-				setPixel(x + j, y + i, cl);
+			int idx = (fx >> 16) * 3;
+
+			uint32 r = line_src[idx + 2];
+			uint32 g = line_src[idx + 1];
+			uint32 b = line_src[idx + 0];
+
+			if (r || g || b)
+				setPixel(x + j, y + i, r, g, b);
+
 			fx += dx;
 		}
 	}
@@ -147,14 +154,14 @@ void grDispatcher::putSpr_a(int x, int y, int sx, int sy, const byte *p, int mod
 	int psy = sy;
 
 	if (!clip_rectangle(x, y, px, py, psx, psy)) return;
-	int dx = -1;
+	int dx = -4;
 	int dy = -1;
 
 	if (mode & GR_FLIP_HORIZONTAL) {
 		x += psx - 1;
 		px = sx - px - psx;
 	} else
-		dx = 1;
+		dx = 4;
 
 	if (mode & GR_FLIP_VERTICAL) {
 		y += psy - 1;
@@ -167,16 +174,21 @@ void grDispatcher::putSpr_a(int x, int y, int sx, int sy, const byte *p, int mod
 
 	const byte *data_ptr = p + py * sx;
 	for (int i = 0; i < psy; i++) {
-		uint16 *scr_buf = reinterpret_cast<uint16 *>(_screenBuf->getBasePtr(x, y));
+		byte *scr_buf = reinterpret_cast<byte *>(_screenBuf->getBasePtr(x, y));
 		const byte *data_line = data_ptr + px;
 
 		for (int j = 0; j < psx; j++) {
 			uint32 a = data_line[3];
 			if (a != 255) {
-				if (a)
-					*scr_buf = alpha_blend_565(make_rgb565u(data_line[2], data_line[1], data_line[0]), *scr_buf, a);
-				else
-					*scr_buf = make_rgb565u(data_line[2], data_line[1], data_line[0]);
+				if (a) {
+					scr_buf[1] = data_line[0] + ((a * scr_buf[1]) >> 8);
+					scr_buf[2] = data_line[1] + ((a * scr_buf[2]) >> 8);
+					scr_buf[3] = data_line[2] + ((a * scr_buf[3]) >> 8);
+				} else {
+					scr_buf[1] = data_line[0];
+					scr_buf[2] = data_line[1];
+					scr_buf[3] = data_line[2];
+				}
 			}
 
 			scr_buf += dx;
@@ -607,14 +619,14 @@ void grDispatcher::putSpr(int x, int y, int sx, int sy, const byte *p, int mode,
 	int psy = sy;
 
 	if (!clip_rectangle(x, y, px, py, psx, psy)) return;
-	int dx = -1;
+	int dx = -4;
 	int dy = -1;
 
 	if (mode & GR_FLIP_HORIZONTAL) {
 		x += psx - 1;
 		px = sx - px - psx;
 	} else
-		dx = 1;
+		dx = 4;
 
 	if (mode & GR_FLIP_VERTICAL) {
 		y += psy - 1;
@@ -629,12 +641,15 @@ void grDispatcher::putSpr(int x, int y, int sx, int sy, const byte *p, int mode,
 		const byte *data_ptr = p + py * sx;
 
 		for (int i = 0; i < psy; i++) {
-			uint16 *scr_buf = reinterpret_cast<uint16 *>(_screenBuf->getBasePtr(x, y));
+			byte *scr_buf = reinterpret_cast<byte *>(_screenBuf->getBasePtr(x, y));
 			const byte *data_line = data_ptr + px;
 
 			for (int j = 0; j < psx; j++) {
-				if (data_line[0] || data_line[1] || data_line[2])
-					*scr_buf = make_rgb565u(data_line[2], data_line[1], data_line[0]);
+				if (data_line[0] || data_line[1] || data_line[2]) {
+					scr_buf[1] = data_line[0];
+					scr_buf[2] = data_line[1];
+					scr_buf[3] = data_line[2];
+				}
 				scr_buf += dx;
 				data_line += 3;
 			}
@@ -649,12 +664,19 @@ void grDispatcher::putSpr(int x, int y, int sx, int sy, const byte *p, int mode,
 		const byte *data_ptr = p + py * sx;
 
 		for (int i = 0; i < psy; i++) {
-			uint16 *scr_buf = reinterpret_cast<uint16 *>(_screenBuf->getBasePtr(x, y));
+			byte *scr_buf = reinterpret_cast<byte *>(_screenBuf->getBasePtr(x, y));
 			const byte *data_line = data_ptr + px;
 
 			for (int j = 0; j < psx; j++) {
-				if (*data_line)
-					*scr_buf = *(const uint16 *)data_line;
+				uint16 dataCol = *(const uint16 *)data_line;
+				if (data_line[0] || data_line[1]) {
+					byte sr, sg, sb;
+					split_rgb565u(dataCol, sr, sg, sb);
+
+					scr_buf[1] = sb;
+					scr_buf[2] = sg;
+					scr_buf[3] = sr;
+				}
 				scr_buf += dx;
 				data_line += 2;
 			}
@@ -987,23 +1009,27 @@ void grDispatcher::putChar(int x, int y, uint32 color, int font_sx, int font_sy,
 
 	color = make_rgb(color);
 
+	uint32 r = ((byte *)(&color))[2];
+	uint32 g = ((byte *)(&color))[1];
+	uint32 b = ((byte *)(&color))[0];
+
 	for (int i = 0; i < psy; i++, y++) {
-		uint16 *scr_buf = reinterpret_cast<uint16 *>(_screenBuf->getBasePtr(x, y));
+		byte *scr_buf = reinterpret_cast<byte *>(_screenBuf->getBasePtr(x, y));
 		for (int j = 0; j < psx; j++) {
 			uint32 a = alpha_buf[j];
 			uint32 a1 = 255 - a;
 			if (a) {
 				if (a != 255) {
-					uint32 scr_col = *scr_buf;
-					*scr_buf++ = (((((color & mask_565_r) * a) >> 8) & mask_565_r) |
-									((((color & mask_565_g) * a) >> 8) & mask_565_g) |
-									((((color & mask_565_b) * a) >> 8) & mask_565_b)) +
-									(((((scr_col & mask_565_r) * a1) >> 8) & mask_565_r) |
-									((((scr_col & mask_565_g) * a1) >> 8) & mask_565_g) |
-									((((scr_col & mask_565_b) * a1) >> 8) & mask_565_b));
-				} else
-					*scr_buf++ = color;
-			} else scr_buf++;
+					scr_buf[1] = ((r * a) >> 8) + ((a1 * scr_buf[1]) >> 8);
+					scr_buf[2] = ((g * a) >> 8) + ((a1 * scr_buf[2]) >> 8);
+					scr_buf[3] = ((b * a) >> 8) + ((a1 * scr_buf[3]) >> 8);
+				} else {
+					scr_buf[1] = r;
+					scr_buf[2] = g;
+					scr_buf[3] = b;
+				}
+			}
+			scr_buf += 4;
 		}
 		alpha_buf += font_sx;
 	}
@@ -1138,14 +1164,14 @@ void grDispatcher::putSprMask_a(int x, int y, int sx, int sy, const byte *p, uin
 	int psy = sy;
 
 	if (!clip_rectangle(x, y, px, py, psx, psy)) return;
-	int dx = -1;
+	int dx = -4;
 	int dy = -1;
 
 	if (mode & GR_FLIP_HORIZONTAL) {
 		x += psx - 1;
 		px = sx - px - psx;
 	} else
-		dx = 1;
+		dx = 4;
 
 	if (mode & GR_FLIP_VERTICAL) {
 		y += psy - 1;
@@ -1156,14 +1182,14 @@ void grDispatcher::putSprMask_a(int x, int y, int sx, int sy, const byte *p, uin
 	sx <<= 2;
 	px <<= 2;
 
-	const byte *data_ptr = p + py * sx + px;
+	const byte *data_ptr = p + py * sx;
 
-	byte mr, mg, mb;
-	split_rgb565u(mask_color, mr, mg, mb);
+	uint32 mr, mg, mb;
+	split_rgb888(mask_color, mr, mg, mb);
 
 	for (int i = 0; i < psy; i++) {
-		uint16 *scr_buf = (uint16 *)(_screenBuf->getBasePtr(x, y));
-		const byte *data_line = data_ptr;
+		byte *scr_buf = (byte *)(_screenBuf->getBasePtr(x, y));
+		const byte *data_line = data_ptr + px;
 
 		for (int j = 0; j < psx; j++) {
 			uint32 a = data_line[3];
@@ -1171,13 +1197,9 @@ void grDispatcher::putSprMask_a(int x, int y, int sx, int sy, const byte *p, uin
 			if (a != 255) {
 				a = mask_alpha + ((a * (255 - mask_alpha)) >> 8);
 
-				uint32 r = (mr * (255 - a)) >> 8;
-				uint32 g = (mg * (255 - a)) >> 8;
-				uint32 b = (mb * (255 - a)) >> 8;
-
-				uint32 cl = make_rgb565u(r, g, b);
-
-				*scr_buf = alpha_blend_565(cl, *scr_buf, a);
+				scr_buf[1] = ((mb * (255 - a)) >> 8) + ((a * scr_buf[1]) >> 8);
+				scr_buf[2] = ((mg * (255 - a)) >> 8) + ((a * scr_buf[2]) >> 8);
+				scr_buf[3] = ((mr * (255 - a)) >> 8) + ((a * scr_buf[3]) >> 8);
 			}
 			scr_buf += dx;
 			data_line += 4;
@@ -1223,8 +1245,8 @@ void grDispatcher::putSprMask_a(int x, int y, int sx, int sy, const byte *p, uin
 	}
 
 	sx <<= 2;
-	byte mr, mg, mb;
-	split_rgb565u(mask_color, mr, mg, mb);
+	uint32 mr, mg, mb;
+	split_rgb888(mask_color, mr, mg, mb);
 
 	for (i = y0; i != y1; i += iy) {
 		const byte *line_src = p + ((fy >> 16) * sx);
@@ -1233,22 +1255,19 @@ void grDispatcher::putSprMask_a(int x, int y, int sx, int sy, const byte *p, uin
 		fx = (1 << 15);
 
 		for (j = x0; j != x1; j += ix) {
-			const byte *src_data = line_src + (fx >> 16) * 4;
-			uint32 a = src_data[3];
-
+			int idx = (fx >> 16) << 2;
+			uint32 a = line_src[idx + 3];
 			if (a != 255 && clipCheck(x + j, y + i)) {
-				uint16 sc;
-				getPixel(x + j, y + i, sc);
+				byte sr, sg, sb;
+				getPixel(x + j, y + i, sr, sg, sb);
 
 				a = mask_alpha + ((a * (255 - mask_alpha)) >> 8);
 
-				uint32 r = (mr * (255 - a)) >> 8;
-				uint32 g = (mg * (255 - a)) >> 8;
-				uint32 b = (mb * (255 - a)) >> 8;
+				uint32 r = ((mr * (255 - a)) >> 8) + ((a * sr) >> 8);
+				uint32 g = ((mg * (255 - a)) >> 8) + ((a * sg) >> 8);
+				uint32 b = ((mb * (255 - a)) >> 8) + ((a * sb) >> 8);
 
-				uint32 cl = make_rgb565u(r, g, b);
-
-				setPixel(x + j, y + i, alpha_blend_565(cl, sc, a));
+				setPixel(x + j, y + i, r, g, b);
 			}
 			fx += dx;
 		}

--- a/engines/qdengine/system/graphics/gr_draw_sprite.cpp
+++ b/engines/qdengine/system/graphics/gr_draw_sprite.cpp
@@ -242,6 +242,8 @@ void grDispatcher::putSpr_rot(const Vect2i &pos, const Vect2i &size, const byte 
 	int sin_a = round(sn * float(1 << F_PREC));
 	int cos_a = round(cs * float(1 << F_PREC));
 
+	warning("STUB: grDispatcher::putSpr_rot");
+
 	if (has_alpha) {
 		for (int y = 0; y <= sy; y++) {
 			uint16 *screen_ptr = (uint16 *)_screenBuf->getBasePtr(x0, y + y0);
@@ -333,6 +335,8 @@ void grDispatcher::putSpr_rot(const Vect2i &pos, const Vect2i &size, const byte 
 	Vect2i iscale = Vect2i(scale.x * float(1 << F_PREC), scale.y * float(1 << F_PREC));
 	Vect2i scaled_size = Vect2i(iscale.x * size.x, iscale.y * size.y);
 
+	warning("STUB: grDispatcher::putSpr_rot (scaled)");
+
 	if (has_alpha) {
 		for (int y = 0; y <= sy; y++) {
 			uint16 *screen_ptr = (uint16 *)_screenBuf->getBasePtr(x0, y + y0);
@@ -419,6 +423,8 @@ void grDispatcher::putSprMask_rot(const Vect2i &pos, const Vect2i &size, const b
 
 	int sin_a = round(sn * float(1 << F_PREC));
 	int cos_a = round(cs * float(1 << F_PREC));
+
+	warning("STUB: grDispatcher::putSprMask_rot");
 
 	if (has_alpha) {
 		byte mr, mg, mb;
@@ -529,6 +535,8 @@ void grDispatcher::putSprMask_rot(const Vect2i &pos, const Vect2i &size, const b
 
 	Vect2i iscale = Vect2i(scale.x * float(1 << F_PREC), scale.y * float(1 << F_PREC));
 	Vect2i scaled_size = Vect2i(iscale.x * size.x, iscale.y * size.y);
+
+	warning("STUB: grDispatcher::putSprMask_rot (scaled)");
 
 	if (has_alpha) {
 		byte mr, mg, mb;
@@ -1112,6 +1120,8 @@ void grDispatcher::putSprMask(int x, int y, int sx, int sy, const byte *p, uint3
 	int y0 = 0;
 	int y1 = sy_dest;
 	int iy = 1;
+
+	warning("STUB: grDispatcher::putSprMask (scaled)");
 
 	if (mode & GR_FLIP_VERTICAL) {
 		y0 = sy_dest,

--- a/engines/qdengine/system/graphics/gr_draw_sprite_rle.cpp
+++ b/engines/qdengine/system/graphics/gr_draw_sprite_rle.cpp
@@ -40,14 +40,14 @@ void grDispatcher::putSpr_rle(int x, int y, int sx, int sy, const class RLEBuffe
 	int psy = sy;
 
 	if (!clip_rectangle(x, y, px, py, psx, psy)) return;
-	int dx = -1;
+	int dx = -4;
 	int dy = -1;
 
 	if (mode & GR_FLIP_HORIZONTAL) {
 		x += (psx - 1);
 		px = sx - px - psx;
 	} else
-		dx = 1;
+		dx = 4;
 
 	psx += px;
 
@@ -58,7 +58,7 @@ void grDispatcher::putSpr_rle(int x, int y, int sx, int sy, const class RLEBuffe
 		dy = 1;
 
 	for (int i = 0; i < psy; i++) {
-		uint16 *scr_buf = reinterpret_cast<uint16 *>(_screenBuf->getBasePtr(x, y));
+		byte *scr_buf = reinterpret_cast<byte *>(_screenBuf->getBasePtr(x, y));
 
 		const int8 *rle_header = p->header_ptr(py + i);
 		const uint32 *rle_data = p->data_ptr(py + i);
@@ -95,8 +95,9 @@ void grDispatcher::putSpr_rle(int x, int y, int sx, int sy, const class RLEBuffe
 					while (count && j < psx) {
 						if (*rle_data) {
 							const byte *rle_buf = (const byte *)rle_data;
-							uint32 cl = make_rgb565u(rle_buf[2], rle_buf[1], rle_buf[0]);
-							*scr_buf = cl;
+							scr_buf[1] = rle_buf[0];
+							scr_buf[2] = rle_buf[1];
+							scr_buf[3] = rle_buf[2];
 						}
 						scr_buf += dx;
 						count--;
@@ -109,8 +110,9 @@ void grDispatcher::putSpr_rle(int x, int y, int sx, int sy, const class RLEBuffe
 						while (count && j < psx) {
 							if (*rle_data) {
 								const byte *rle_buf = (const byte *)rle_data;
-								uint32 cl = make_rgb565u(rle_buf[2], rle_buf[1], rle_buf[0]);
-								*scr_buf = cl;
+								scr_buf[1] = rle_buf[0];
+								scr_buf[2] = rle_buf[1];
+								scr_buf[3] = rle_buf[2];
 							}
 							scr_buf += dx;
 							rle_data++;
@@ -127,7 +129,11 @@ void grDispatcher::putSpr_rle(int x, int y, int sx, int sy, const class RLEBuffe
 					while (count && j < psx) {
 						const byte *rle_buf = (const byte *)rle_data;
 						uint32 a = rle_buf[3];
-						*scr_buf = alpha_blend_565(make_rgb565u(rle_buf[2], rle_buf[1], rle_buf[0]), *scr_buf, a);
+						if (a != 255) {
+							scr_buf[1] = rle_buf[0] + ((a * scr_buf[1]) >> 8);
+							scr_buf[2] = rle_buf[1] + ((a * scr_buf[2]) >> 8);
+							scr_buf[3] = rle_buf[2] + ((a * scr_buf[3]) >> 8);
+						}
 						scr_buf += dx;
 						count--;
 						j++;
@@ -139,7 +145,11 @@ void grDispatcher::putSpr_rle(int x, int y, int sx, int sy, const class RLEBuffe
 						while (count && j < psx) {
 							const byte *rle_buf = (const byte *)rle_data;
 							uint32 a = rle_buf[3];
-							*scr_buf = alpha_blend_565(make_rgb565u(rle_buf[2], rle_buf[1], rle_buf[0]), *scr_buf, a);
+							if (a != 255) {
+								scr_buf[1] = rle_buf[0] + ((a * scr_buf[1]) >> 8);
+								scr_buf[2] = rle_buf[1] + ((a * scr_buf[2]) >> 8);
+								scr_buf[3] = rle_buf[2] + ((a * scr_buf[3]) >> 8);
+							}
 							scr_buf += dx;
 							rle_data++;
 							count--;
@@ -196,9 +206,14 @@ void grDispatcher::putSpr_rle(int x, int y, int sx, int sy, const class RLEBuffe
 
 			for (int j = x0; j != x1; j += ix) {
 				if (clipCheck(x + j, y + i)) {
-					const byte *src_data = line_src + (fx >> 16) * 3;
-					if (src_data[0] || src_data[1] || src_data[2])
-						setPixelFast(x + j, y + i, make_rgb565u(src_data[2], src_data[1], src_data[0]));
+					int idx = (fx >> 16) << 2;
+
+					uint32 r = line_src[idx + 2];
+					uint32 g = line_src[idx + 1];
+					uint32 b = line_src[idx + 0];
+
+					if (r || g || b)
+						setPixelFast(x + j, y + i, r, g, b);
 				}
 				fx += dx;
 			}
@@ -213,19 +228,18 @@ void grDispatcher::putSpr_rle(int x, int y, int sx, int sy, const class RLEBuffe
 
 			for (int j = x0; j != x1; j += ix) {
 				if (clipCheck(x + j, y + i)) {
-					const byte *src_data = line_src + ((fx >> 16) << 2);
+					int idx = (fx >> 16) << 2;
 
-					uint32 a = src_data[3];
+					uint32 a = line_src[idx + 3];
 					if (a != 255) {
-						uint32 cl = make_rgb565u(src_data[2], src_data[1], src_data[0]);
+						byte sr, sg, sb;
+						getPixel(x + j, y + i, sr, sg, sb);
 
-						if (a) {
-							uint16 scl;
-							getPixel(x + j, y + i, scl);
+						uint32 r = line_src[idx + 2] + ((a * sr) >> 8);
+						uint32 g = line_src[idx + 1] + ((a * sg) >> 8);
+						uint32 b = line_src[idx + 0] + ((a * sb) >> 8);
 
-							setPixelFast(x + j, y + i, alpha_blend_565(cl, scl, a));
-						} else
-							setPixelFast(x + j, y + i, cl);
+						setPixelFast(x + j, y + i, r, g, b);
 					}
 				}
 				fx += dx;
@@ -245,14 +259,14 @@ void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const RLEBuffer 
 
 	if (!clip_rectangle(x, y, px, py, psx, psy)) return;
 
-	int dx = -1;
+	int dx = -4;
 	int dy = -1;
 
 	if (mode & GR_FLIP_HORIZONTAL) {
-		x += (psx - 1) * 2;
+		x += (psx - 1);
 		px = sx - px - psx;
 	} else
-		dx = 1;
+		dx = 4;
 
 	psx += px;
 
@@ -263,7 +277,7 @@ void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const RLEBuffer 
 		dy = 1;
 
 	for (int i = 0; i < psy; i++) {
-		uint16 *scr_buf = reinterpret_cast<uint16 *>(_screenBuf->getBasePtr(x, y));
+		byte *scr_buf = reinterpret_cast<byte *>(_screenBuf->getBasePtr(x, y));
 
 		const int8 *rle_header = p->header_ptr(py + i);
 		const uint32 *rle_data = p->data_ptr(py + i);
@@ -293,21 +307,17 @@ void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const RLEBuffer 
 				}
 			}
 		}
-		byte mr, mg, mb;
-		split_rgb565u(mask_color, mr, mg, mb);
-
-		mr = (mr * (255 - mask_alpha)) >> 8;
-		mg = (mg * (255 - mask_alpha)) >> 8;
-		mb = (mb * (255 - mask_alpha)) >> 8;
-
-		uint32 cl = make_rgb565u(mr, mg, mb);
+		uint32 mr, mg, mb;
+		split_rgb888(mask_color, mr, mg, mb);
 
 		if (!alpha_flag) {
 			while (j < psx) {
 				if (count > 0) {
 					while (count && j < psx) {
 						if (*rle_data) {
-							*scr_buf = cl;
+							scr_buf[1] = ((mb * (255 - mask_alpha)) >> 8) + ((mask_alpha * scr_buf[1]) >> 8);
+							scr_buf[2] = ((mg * (255 - mask_alpha)) >> 8) + ((mask_alpha * scr_buf[2]) >> 8);
+							scr_buf[3] = ((mr * (255 - mask_alpha)) >> 8) + ((mask_alpha * scr_buf[3]) >> 8);
 						}
 						scr_buf += dx;
 						count--;
@@ -319,7 +329,9 @@ void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const RLEBuffer 
 						count = -count;
 						while (count && j < psx) {
 							if (*rle_data) {
-								*scr_buf = cl;
+								scr_buf[1] = ((mb * (255 - mask_alpha)) >> 8) + ((mask_alpha * scr_buf[1]) >> 8);
+								scr_buf[2] = ((mg * (255 - mask_alpha)) >> 8) + ((mask_alpha * scr_buf[2]) >> 8);
+								scr_buf[3] = ((mr * (255 - mask_alpha)) >> 8) + ((mask_alpha * scr_buf[3]) >> 8);
 							}
 							scr_buf += dx;
 							rle_data++;
@@ -340,12 +352,9 @@ void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const RLEBuffer 
 						if (a != 255) {
 							a = mask_alpha + ((a * (255 - mask_alpha)) >> 8);
 
-							uint32 r = (mr * (255 - a)) >> 8;
-							uint32 g = (mg * (255 - a)) >> 8;
-							uint32 b = (mb * (255 - a)) >> 8;
-
-							cl = make_rgb565u(r, g, b);
-							*scr_buf = alpha_blend_565(cl, *scr_buf, a);
+							scr_buf[1] = ((mb * (255 - a)) >> 8) + ((a * scr_buf[1]) >> 8);
+							scr_buf[2] = ((mg * (255 - a)) >> 8) + ((a * scr_buf[2]) >> 8);
+							scr_buf[3] = ((mr * (255 - a)) >> 8) + ((a * scr_buf[3]) >> 8);
 						}
 
 						scr_buf += dx;
@@ -363,12 +372,9 @@ void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const RLEBuffer 
 							if (a != 255) {
 								a = mask_alpha + ((a * (255 - mask_alpha)) >> 8);
 
-								uint32 r = (mr * (255 - a)) >> 8;
-								uint32 g = (mg * (255 - a)) >> 8;
-								uint32 b = (mb * (255 - a)) >> 8;
-
-								cl = make_rgb565u(r, g, b);
-								*scr_buf = alpha_blend_565(cl, *scr_buf, a);
+								scr_buf[1] = ((mb * (255 - a)) >> 8) + ((a * scr_buf[1]) >> 8);
+								scr_buf[2] = ((mg * (255 - a)) >> 8) + ((a * scr_buf[2]) >> 8);
+								scr_buf[3] = ((mr * (255 - a)) >> 8) + ((a * scr_buf[3]) >> 8);
 							}
 
 							scr_buf += dx;
@@ -418,14 +424,8 @@ void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const RLEBuffer 
 		ix = -1;
 	}
 	if (!alpha_flag) {
-		byte mr, mg, mb;
-		split_rgb565u(mask_color, mr, mg, mb);
-
-		mr = (mr * (255 - mask_alpha)) >> 8;
-		mg = (mg * (255 - mask_alpha)) >> 8;
-		mb = (mb * (255 - mask_alpha)) >> 8;
-
-		uint32 mcl = (_pixel_format == GR_RGB565) ? make_rgb565u(mr, mg, mb) : make_rgb555u(mr, mg, mb);
+		uint32 mr, mg, mb;
+		split_rgb888(mask_color, mr, mg, mb);
 
 		const byte *line_src = RLEBuffer::get_buffer(0);
 
@@ -437,11 +437,17 @@ void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const RLEBuffer 
 
 			for (int j = x0; j != x1; j += ix) {
 				if (clipCheck(x + j, y + i)) {
-					const byte *src_buf = line_src + ((fx >> 16) << 2);
-					if (src_buf[0] || src_buf[1] || src_buf[2]) {
-						uint16 scl;
-						getPixel(x + j, y + i, scl);
-						setPixelFast(x + j, y + i, alpha_blend_565(mcl, scl, mask_alpha));
+					int idx = (fx >> 16) << 2;
+
+					if (line_src[idx + 2] || line_src[idx + 1] || line_src[idx + 0]) {
+						byte sr, sg, sb;
+						getPixel(x + j, y + i, sr, sg, sb);
+
+						uint32 r = ((mr * (255 - mask_alpha)) >> 8) + ((mask_alpha * sr) >> 8);
+						uint32 g = ((mg * (255 - mask_alpha)) >> 8) + ((mask_alpha * sg) >> 8);
+						uint32 b = ((mb * (255 - mask_alpha)) >> 8) + ((mask_alpha * sb) >> 8);
+
+						setPixelFast(x + j, y + i, r, g, b);
 					}
 				}
 				fx += dx;
@@ -449,8 +455,8 @@ void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const RLEBuffer 
 		}
 	} else {
 		const byte *line_src = RLEBuffer::get_buffer(0);
-		byte mr, mg, mb;
-		split_rgb565u(mask_color, mr, mg, mb);
+		uint32 mr, mg, mb;
+		split_rgb888(mask_color, mr, mg, mb);
 
 		for (int i = y0; i != y1; i += iy) {
 			p->decode_line(fy >> 16);
@@ -460,23 +466,23 @@ void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const RLEBuffer 
 
 			for (int j = x0; j != x1; j += ix) {
 				if (clipCheck(x + j, y + i)) {
-					const byte *src_buf = line_src + ((fx >> 16) << 2);
-					uint32 a = src_buf[3];
+					int idx = (fx >> 16) << 2;
+
+					uint32 a = line_src[idx + 3];
 					if (a != 255) {
-						uint16 scl;
-						getPixel(x + j, y + i, scl);
+						byte sr, sg, sb;
+						getPixel(x + j, y + i, sr, sg, sb);
 
 						a = mask_alpha + ((a * (255 - mask_alpha)) >> 8);
 
-						uint32 r = (mr * (255 - a)) >> 8;
-						uint32 g = (mg * (255 - a)) >> 8;
-						uint32 b = (mb * (255 - a)) >> 8;
+						uint32 r = ((mr * (255 - a)) >> 8) + ((a * sr) >> 8);
+						uint32 g = ((mg * (255 - a)) >> 8) + ((a * sg) >> 8);
+						uint32 b = ((mb * (255 - a)) >> 8) + ((a * sb) >> 8);
 
-						uint32 cl = make_rgb565u(r, g, b);
-
-						setPixelFast(x + j, y + i, alpha_blend_565(cl, scl, a));
+						setPixelFast(x + j, y + i, r, g, b);
 					}
 				}
+
 				fx += dx;
 			}
 		}

--- a/engines/qdengine/system/graphics/gr_tile_animation.cpp
+++ b/engines/qdengine/system/graphics/gr_tile_animation.cpp
@@ -624,10 +624,11 @@ Graphics::ManagedSurface *grTileAnimation::dumpFrameTiles(int frame_index, float
 			const byte *src = (const byte *)getTile(_frameIndex[idx++]).data();
 
 			for (int yy = 0; yy < GR_TILE_SPRITE_SIZE_Y; yy++) {
-				uint16 *dst = (uint16 *)dstSurf->getBasePtr(j * (GR_TILE_SPRITE_SIZE_X + 1), i * (GR_TILE_SPRITE_SIZE_Y + 1) + yy);
+				uint32 *dst = (uint32 *)dstSurf->getBasePtr(j * (GR_TILE_SPRITE_SIZE_X + 1), i * (GR_TILE_SPRITE_SIZE_Y + 1) + yy);
 
 				for (int xx = 0; xx < GR_TILE_SPRITE_SIZE_X; xx++) {
-					*dst = grDispatcher::instance()->make_rgb565u(src[2], src[1], src[0]);
+					uint32 col = (src[2] << 24) | (src[1] << 16) | (src[0] << 8);
+					*dst = col;
 					dst++;
 					src += 4;
 				}

--- a/engines/qdengine/system/graphics/gr_tile_sprite.cpp
+++ b/engines/qdengine/system/graphics/gr_tile_sprite.cpp
@@ -106,14 +106,14 @@ void grDispatcher::putTileSpr(int x, int y, const grTileSprite &sprite, bool has
 	if (clip && !clip_rectangle(x, y, px, py, psx, psy))
 		return;
 
-	int dx = -1;
+	int dx = -4;
 	int dy = -1;
 
 	if (mode & GR_FLIP_HORIZONTAL) {
 		x += psx - 1;
 		px = GR_TILE_SPRITE_SIZE_X - px - psx;
 	} else
-		dx = 1;
+		dx = 4;
 
 	if (mode & GR_FLIP_VERTICAL) {
 		y += psy - 1;
@@ -124,19 +124,24 @@ void grDispatcher::putTileSpr(int x, int y, const grTileSprite &sprite, bool has
 	if (!surf)
 		surf = _screenBuf;
 
-	const byte *data_ptr = (const byte *)(sprite.data() + px + py * GR_TILE_SPRITE_SIZE_X);
+	const byte *data_ptr = (const byte *)sprite.data() + px * 4 + py * GR_TILE_SPRITE_SIZE_X * 4;
 
 	for (int i = 0; i < psy; i++) {
-		uint16 *scr_buf = reinterpret_cast<uint16 *>(surf->getBasePtr(x, y));
+		byte *scr_buf = reinterpret_cast<byte *>(surf->getBasePtr(x, y));
 		const byte *data_line = data_ptr;
 
 		for (int j = 0; j < psx; j++) {
 			uint32 a = data_line[3];
 			if (a != 255) {
-				if (a)
-					*scr_buf = alpha_blend_565(make_rgb565u(data_line[2], data_line[1], data_line[0]), *scr_buf, a);
-				else
-					*scr_buf = make_rgb565u(data_line[2], data_line[1], data_line[0]);
+				if (a) {
+					scr_buf[1] = data_line[0] + ((a * scr_buf[1]) >> 8);
+					scr_buf[2] = data_line[1] + ((a * scr_buf[2]) >> 8);
+					scr_buf[3] = data_line[2] + ((a * scr_buf[3]) >> 8);
+				} else {
+					scr_buf[1] = data_line[0];
+					scr_buf[2] = data_line[1];
+					scr_buf[3] = data_line[2];
+				}
 			}
 			scr_buf += dx;
 			data_line += 4;


### PR DESCRIPTION
This PR attempts to switch engine's pixel format from rgb565 to rgba8888. Changes have been made to every drawing function, except for putSprMask and putSprMask_rot methods. So far during playtesting I haven't seen these methods being called, so I put STUBs to them for the moment.