### PR TITLE
SCUMM: Add workaround for missing smoke in MI1 VGA floppy lava maze

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -2922,6 +2922,30 @@ void ScummEngine_v5::o5_startScript() {
 	// Save on IQ increment (= script 125 was executed).
 	if (_game.id == GID_INDY3 && script == 125)
 		((ScummEngine_v4 *)this)->updateIQPoints();
+
+	// WORKAROUND: In the CD version of Monkey Island 1, and the EGA
+	// version before it, there is animated smoke in parts of the lava maze
+	// beneath the monkey head. The VGA floppy version still calls the
+	// script to add the smoke, but the script is empty. We repliacte what
+	// the script did manually.
+
+	if (_game.id == GID_MONKEY_VGA && _roomResource == 39 && script == 211 && enhancementEnabled(kEnhRestoredContent)) {
+		Actor *a = derefActorSafe(12, "o5_startScript");
+
+		if (a) {
+			a->initActor(0);
+			a->setActorCostume(76);
+			a->setPalette(3, 8);
+			a->setPalette(2, 12);
+			a->setPalette(9, 4);
+			a->_ignoreBoxes = 1;
+			a->_forceClip = 1;
+			a->animateActor(250);
+			a->_room = _roomResource;
+			a->putActor(data[0], data[1]);
+			a->animateActor(6);
+		}
+	}
 }
 
 void ScummEngine_v5::o5_stopObjectCode() {


### PR DESCRIPTION
While playing through the Sega CD version of the game, I noticed that there was animated smoke in some places in the lava maze. I didn't remember this from earlier playthroughs so I checked with my VGA CD version. And sure enough, there it was:

![scummvm-monkey-3-00039](https://github.com/user-attachments/assets/5564793d-bc25-48a5-b611-17832671410d)

But then I checked my VGA floppy version, and there it wasn't:

![scummvm-monkey-vga-1-00049](https://github.com/user-attachments/assets/e70fa84b-a67d-4982-8a3d-70df055f3142)

After some investigation, I found that room-39-200 and room-39-201 call `startScript(211,[225,93])` and `startScript(211,[477,86])` respectively. Here's what room-39-211 does in the VGA CD version:

```
Script# 211
[0000] (13) ActorOps(12,[Init(),Costume(76),Palette(3,8),Palette(2,12),Palette(9,4),IgnoreBoxes(),SetZClip(1)]);
[0012] (11) animateCostume(12,250);
[0015] (2D) putActorInRoom(12,39);
[0018] (61) putActor(12,Local[0],Local[1]);
[001E] (11) animateCostume(12,6);
[0021] (A0) stopObjectCode();
END
```

And here's what it does in the VGA floppy version:

```
Script# 211
[0000] (A0) stopObjectCode();
END
```

This workaround optionally performs the missing script instructions manually after the script has been called. I'm not sure if *all* floppy versions are affected, but by doing it afterwards we could easily add a check for if the actor is already in the room, if necessary. (It probably isn't.)

I hope I haven't overlooked something obvious. There is a game entry for a VGA demo version that shares the `GID_MONKEY_VGA` id, but I don't know where to find that. But surely we don't need to check the GF_DEMO flag here?