### PR TITLE
AGS: Fix volume modifier not being respected

### DIFF
--- a/engines/ags/engine/media/audio/sound_clip.cpp
+++ b/engines/ags/engine/media/audio/sound_clip.cpp
@@ -274,7 +274,7 @@ void SoundClipWaveBase::set_speed(int new_speed) {
 }
 
 void SoundClipWaveBase::adjust_volume() {
-	_mixer->setChannelVolume(_soundHandle, _vol255);
+	_mixer->setChannelVolume(_soundHandle, get_final_volume());
 }
 
 } // namespace AGS3


### PR DESCRIPTION
This is a fix for https://bugs.scummvm.org/ticket/15761 and https://bugs.scummvm.org/ticket/15307. 
Some games (namely Blackwell Legacy and Blackwell Unbound but there are probably more) have volume modifiers associated with the sound clips. The code for detecting and calculating the final volume was already present but it was not used.
