### PR TITLE
SCUMM: Add workaround for MI1 Sega CD clobbering bit variables

### DIFF
--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -359,7 +359,7 @@ void ScummEngine_v5::setupOpcodes() {
 	OPCODE(0xfe, o5_walkActorTo);
 	OPCODE(0xff, o5_drawBox);
 
-	if (_game.id == GID_MONKEY && _game.platform == Common::kPlatformSegaCD && enhancementEnabled(kEnhMinorBugFixes)) {
+	if (_game.id == GID_MONKEY && _game.platform == Common::kPlatformSegaCD && _language == Common::EN_ANY && enhancementEnabled(kEnhMinorBugFixes)) {
 		OPCODE(0x1a, o5_move_segafix);
 	}
 }

--- a/engines/scumm/scumm_v5.h
+++ b/engines/scumm/scumm_v5.h
@@ -163,6 +163,7 @@ protected:
 	void o5_loadRoomWithEgo();
 	void o5_matrixOps();
 	void o5_move();
+	void o5_move_segafix();
 	void o5_multiply();
 	void o5_notEqualZero();
 	void o5_or();


### PR DESCRIPTION
Here's a scary one!

Any conversation in the Sega CD version of MI1 is likely - perhaps even guaranteed - to set one or more bit variables that are intended for other things. Luckily none of them appear to be game breaking, but still...

Since this is a global bug, I've been relying on NUTCracker for dissecting the scripts. While I'm a bit fuzzy on some of the details, MI1 uses nine bit flags numbered 384 through 392. They are set when conversation options are presented. In the DOS CD version it can look like this:

```
	V.100 = ((120 + 1) - 1)
	verb V.100 at 2,V.229 name "So what was your name, anyway?" on key V.230
	V.229 += 8
	V.100 -= 120
	++V.230
	B.384[V.100] = 1
```

And then the script that handles conversation trees test and clears these variables. (They're cleared manually in some cases too.) The conversation tree handling in the Sega version is different, and doesn't use these variables but still clears them.

It also sets them, and that's where the bug comes in. Because here's the corresponding code from the Sega version:

```
	V.100 = ((120 + 1) - 1)
	V.435 = (V.229 * V.452)
	V.435 += 145
	verb V.100 at 8,V.435 name "So what was your name, anyway?" off key V.230
	V.412[V.432] = V.100
	++V.432
	++V.229
	++V.230
	B.384[V.100] = 1
```

The `V.100 -= 120` line is missing. So the Sega version will set bits 504 through 512 instead. And they're used for completely different things throughout the game. I didn't notice until I got to the cannibals, and found that when they asked if they could do anything for them I couldn't ask them for a ship or for money. But the easiest one to reproduce is with Cobb: Guybrush will never say "Geeze, what an obvious sales pitch." to him:

```
	if (!B.504) {
		B.504 = 1
		V.100 = ((120 + 4) - 1)
		V.435 = (V.229 * V.452)
		V.435 += 145
		verb V.100 at 8,V.435 name "Geeze, what an obvious sales pitch." off key V.230
		V.412[V.432] = V.100
		++V.432
		++V.229
		++V.230
		B.384[V.100] = 1
```

The good news is that the pattern `B.384[V.100] = 1` only appears in these buggy conversation scripts. We can detect and correct that pattern. The bad news is that it appears more than 500 times, so testing them all is not reasonable.