### PR TITLE
CREATE_PROJECT: Fix include order for cmake projects

### DIFF
--- a/devtools/create_project/cmake.cpp
+++ b/devtools/create_project/cmake.cpp
@@ -165,8 +165,10 @@ endfunction()
 	for (const std::string &includeDir : setup.includeDirs)
 		includeDirsList += includeDir + ' ';
 
-	workspace << "include_directories(${" << setup.projectDescription << "_SOURCE_DIR}/" <<  setup.filePrefix << " ${" << setup.projectDescription << "_SOURCE_DIR}/" <<  setup.filePrefix << "/engines "
-			  << includeDirsList << "$ENV{"<<LIBS_DEFINE<<"}/include .)\n\n";
+	workspace << "include_directories(. ${"
+			  << setup.projectDescription << "_SOURCE_DIR}/" <<  setup.filePrefix
+			  << " ${" << setup.projectDescription << "_SOURCE_DIR}/" <<  setup.filePrefix << "/engines "
+			  << includeDirsList << "$ENV{"<<LIBS_DEFINE<<"}/include)\n\n";
 
 	workspace << "# Libraries and features\n\n";
 	writeFeatureLibSearch(setup, workspace, "sdl");


### PR DESCRIPTION
If the engines directory contains plugins_table.h or detection_table.h from an in-source build, when building out-of-source, these files from the source directory were prioritized over build directory versions.

This caused issues when different plugins were enabled across builds.

The revised include order now matches the implementation in Makefile.
