### PR TITLE
BACKENDS: OPENGL: Fix CLUT shader lookup

### DIFF
--- a/backends/graphics/opengl/shader.cpp
+++ b/backends/graphics/opengl/shader.cpp
@@ -71,11 +71,12 @@ const char *const g_lookUpFragmentShader =
 	"uniform sampler2D shaderTexture;\n"
 	"uniform sampler2D palette;\n"
 	"\n"
-	"const float adjustFactor = 255.0 / 256.0 + 1.0 / (2.0 * 256.0);"
+	"const float scaleFactor = 255.0 / 256.0;\n"
+	"const float offsetFactor = 1.0 / (2.0 * 256.0);\n"
 	"\n"
 	"void main(void) {\n"
 	"\tvec4 index = texture2D(shaderTexture, texCoord);\n"
-	"\tgl_FragColor = blendColor * texture2D(palette, vec2(index.a * adjustFactor, 0.0));\n"
+	"\tgl_FragColor = blendColor * texture2D(palette, vec2(index.a * scaleFactor + offsetFactor, 0.0));\n"
 	"}\n";
 
 } // End of anonymous namespace


### PR DESCRIPTION
This should fix [Trac#15860](https://bugs.scummvm.org/ticket/15860).
At least, I hope...

The current code only uses a linear scaling to look at the palette texture.
This means that lookup coordinate is on the form (when stretched to texture size):
0.0, 1.00196, 2.00392 ... 253.49607, 254.49803, 255.5

With the newer code it will be on the form:
0.5, 1.5, 2.5, ... 253.5, 254.5, 255.5

This needs proper testing because this code is used on many backends.
