### PR TITLE
GRAPHICS: Fix TTF font caching

### DIFF
--- a/graphics/macgui/macfontmanager.cpp
+++ b/graphics/macgui/macfontmanager.cpp
@@ -568,7 +568,8 @@ const Font *MacFontManager::getFont(MacFont *macFont) {
 		int newSlant = macFont->getSlant();
 		int familyId = getFamilyId(newId, newSlant);
 
-		if ((_mode & kWMModeUnicode) && (_mode & kWMModeForceMacFontsInWin95)) {
+		if ((_mode & kWMModeUnicode) && 
+			(((!_fontInfo.contains(familyId))) || (_mode & kWMModeForceMacFontsInWin95))) {
 			if (macFont->getSize() <= 0) {
 				debugC(1, kDebugLevelMacGUI, "MacFontManager::getFont() - Font size <= 0!");
 			}

--- a/graphics/macgui/macfontmanager.h
+++ b/graphics/macgui/macfontmanager.h
@@ -232,7 +232,7 @@ private:
 	int parseFontSlant(Common::String slant);
 
 	/* Unicode font */
-	Common::HashMap<int, const Graphics::Font *> _uniFonts;
+	Common::HashMap<Common::String, const Graphics::Font *> _uniFontRegistry;
 
 	Common::HashMap<Common::String, Common::SeekableReadStream *> _ttfData;
 };

--- a/gui/helpdialog.cpp
+++ b/gui/helpdialog.cpp
@@ -130,7 +130,7 @@ _s(
 
 void HelpDialog::addTabs(const char * const *tabData) {
 	while (*tabData) {
-		Common::U32String tabName(*tabData++);
+		Common::U32String tabName(_(*tabData++));
 		const char *imagePack = nullptr;
 
 		if (*tabData && **tabData)
@@ -138,7 +138,7 @@ void HelpDialog::addTabs(const char * const *tabData) {
 
 		tabData++;
 
-		Common::U32String tabText(*tabData++);
+		Common::U32String tabText(_(*tabData++));
 
 		_tab->addTab(tabName, "HelpContentDialog");
 

--- a/gui/widgets/richtext.cpp
+++ b/gui/widgets/richtext.cpp
@@ -197,13 +197,8 @@ void RichTextWidget::createWidget() {
 
 	const int fontHeight = g_gui.xmlEval()->getVar("Globals.Font.Height", 25);
 
-#if 1
-	Graphics::MacFont macFont(Graphics::kMacFontNewYork, fontHeight, Graphics::kMacFontRegular);
-	(void)ttfFamily;
-#else
 	int newId = wm->_fontMan->registerTTFFont(ttfFamily);
 	Graphics::MacFont macFont(newId, fontHeight, Graphics::kMacFontRegular);
-#endif
 
 	_txtWnd = new Graphics::MacText(Common::U32String(), wm, &macFont, fg, bg, _textWidth, Graphics::kTextAlignLeft);
 


### PR DESCRIPTION
This is a fix for https://planka.scummvm.org/cards/1245220086541714717 .

- Fixed caching of TTF/unicode fonts.
- Did minor refactor to unify naming with other parts of the code.
- Enabled help menu translations

Did some simple measurements, here is how long it took to create help widget before the fix:
![scummvm_ttf_font_w_translation_wo_caching](https://github.com/user-attachments/assets/a7c90660-fdab-457d-bb6e-46eb4e6735df)

and here is after:
![scummvm_ttf_font_w_translation_w_caching](https://github.com/user-attachments/assets/d833f997-3abc-44a0-a426-c7106bdde030)

