### PR TITLE
DIRECTOR: XTRA: Set origin for the QTVR decoder in QTVR Xtra

### DIFF
--- a/engines/director/lingo/xtras/qtvrxtra.cpp
+++ b/engines/director/lingo/xtras/qtvrxtra.cpp
@@ -382,6 +382,7 @@ void QtvrxtraXtra::m_QTVROpen(int nargs) {
 	}
 
 	me->_video->setTargetSize(me->_rect.width(), me->_rect.height());
+	me->_video->setOrigin(me->_rect.left, me->_rect.top);
 
 	me->_widget = new QtvrxtraWidget(me, g_director->getCurrentWindow(),
 			me->_rect.left, me->_rect.top, me->_rect.width(), me->_rect.height(),


### PR DESCRIPTION
Please refer to the pull request
https://github.com/scummvm/scummvm/pull/6548

Set the corner origin point in the QTVR decoder from QTVR Xtra
in order to make sure during the swing transition the QTVR video
decoder blits the panorama at the correct position


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
