### PR TITLE
QDENGINE: Fix sound related issues

### DIFF
--- a/engines/qdengine/system/sound/snd_dispatcher.cpp
+++ b/engines/qdengine/system/sound/snd_dispatcher.cpp
@@ -94,7 +94,7 @@ bool sndDispatcher::play_sound(const sndSound *snd, bool loop, int vol) {
 		if (loop)
 			p.toggle_looping();
 
-		int snd_volume = (vol == 255) ? volume_dB() : convert_volume_to_dB((volume() * vol) >> 8);
+		int snd_volume = vol * volume() / 256;
 
 		if (!p.create_sound_buffer())
 			return false;
@@ -161,7 +161,7 @@ sndSound::status_t sndDispatcher::sound_status(const sndSound *snd) const {
 
 bool sndDispatcher::update_volume() {
 	for (sound_list_t::iterator it = _sounds.begin(); it != _sounds.end(); ++it)
-		it->set_volume(volume_dB());
+		it->set_volume(volume());
 
 	return true;
 }

--- a/engines/qdengine/system/sound/snd_sound.cpp
+++ b/engines/qdengine/system/sound/snd_sound.cpp
@@ -91,6 +91,7 @@ void sndSound::pause() {
 void sndSound::resume() {
 	debugC(5, kDebugSound, "sndSound::resume(). this: %p",  (void *)this);
 
+	_flags &= ~SOUND_FLAG_PAUSED;
 	g_system->getMixer()->pauseHandle(_audHandle, false);
 }
 

--- a/engines/qdengine/system/sound/snd_sound.cpp
+++ b/engines/qdengine/system/sound/snd_sound.cpp
@@ -61,9 +61,9 @@ bool sndSound::play() {
 
 	if (_flags & SOUND_FLAG_LOOPING) {
 		Audio::AudioStream *audio = new Audio::LoopingAudioStream(_sound->_audioStream, 0, DisposeAfterUse::NO);
-		g_system->getMixer()->playStream(Audio::Mixer::kSFXSoundType, &_audHandle, audio, -1, Audio::Mixer::kMaxChannelVolume, 0,  DisposeAfterUse::NO);
+		g_system->getMixer()->playStream(Audio::Mixer::kSFXSoundType, &_audHandle, audio, -1, _volume, 0,  DisposeAfterUse::NO);
 	} else {
-		g_system->getMixer()->playStream(Audio::Mixer::kSFXSoundType, &_audHandle, _sound->_audioStream, -1, Audio::Mixer::kMaxChannelVolume, 0,  DisposeAfterUse::NO);
+		g_system->getMixer()->playStream(Audio::Mixer::kSFXSoundType, &_audHandle, _sound->_audioStream, -1, _volume, 0,  DisposeAfterUse::NO);
 	}
 
 	return true;
@@ -119,6 +119,7 @@ bool sndSound::is_stopped() const {
 }
 
 bool sndSound::set_volume(int vol) {
+	_volume = vol;
 	g_system->getMixer()->setChannelVolume(_audHandle, vol);
 	return true;
 }

--- a/engines/qdengine/system/sound/snd_sound.h
+++ b/engines/qdengine/system/sound/snd_sound.h
@@ -121,6 +121,8 @@ private:
 
 	Audio::SoundHandle _audHandle;
 
+	byte _volume = 255;
+
 	bool _isStopped = false;
 };
 


### PR DESCRIPTION
- Implemented resuming a sound correctly
- Adjusted the methods for updating the volume, playing the sound so that the sound volume control actually affects the volume value. Also used the _volume instead of _volume_dB so that the volume range is in [0, 255] instead of [-10000, 0]. 