### PR TITLE
DOCS: Fix some typos and style

### DIFF
--- a/doc/QuickStart
+++ b/doc/QuickStart
@@ -135,7 +135,7 @@ our website for that game, to ensure the issue is not already known:
   https://www.scummvm.org/compatibility/
 
 Please do not report bugs for games that are not listed as being
-completeable in the 'Supported Games' section, or compatibility list. We
+completable in the 'Supported Games' section, or compatibility list. We
 -know- those games have bugs.
 
 Please include the following information:

--- a/doc/cz/PrectiMe
+++ b/doc/cz/PrectiMe
@@ -2097,7 +2097,7 @@ Na Windows můžete určit USE_WINDBG a připojit WinDbg pro procházení ladíc
       Přečtěte si prosím:
       <https://wiki.scummvm.org/index.php/Compiling_ScummVM/Dreamcast>
 
-   Sony Playstation:
+   Sony PlayStation:
    * Sony PlayStation 2
       Přečtěte si prosím:
       <https://wiki.scummvm.org/index.php/Compiling_ScummVM/PlayStation_2>

--- a/doc/cz/PrectiMe
+++ b/doc/cz/PrectiMe
@@ -1098,7 +1098,7 @@ Beneath a Steel Sky
     it  - Italština
     pt  - Portugalština
     es  - Španělština
-    se  - Švédština
+    sv  - Švédština
 
 Broken Sword
     en  - Angličtina (výchozí)
@@ -1863,7 +1863,7 @@ Jsou rozpoznávána následující klíčová slova:
     gameid             řetězec  Skutečné id hry. Užitečné, pokud máte několik verzí stejné hry a chcete pro ně různé přezdívky. Viz příklad.
     description        řetězec  Popis hry jak se zobrazí ve spouštěči.
     language           řetězec  Určí jazyk (en, us, de, fr, it, pt, es,
-                                jp, zh, kr, se, gb, hb, cz, ru)
+                                jp, zh, kr, sv, gb, hb, cz, ru)
     speech_mute        boolean  Pokud true, řeč je ztlumena
     subtitles          boolean  Pokud true jsou titulky zapnuty.
     talkspeed          číslo    Zpoždění textu v hrách SCUMM, nebo rychlost textu v jiných hrách.

--- a/doc/de/LIESMICH
+++ b/doc/de/LIESMICH
@@ -3148,7 +3148,7 @@ https://wiki.scummvm.org/index.php/Compiling_ScummVM/Mac_OS_X_Crosscompiling
       Weiterführende Informationen finden Sie unter:
       https://wiki.scummvm.org/index.php/Compiling_ScummVM/Dreamcast
 
-   Sony Playstation:
+   Sony PlayStation:
    * Sony PlayStation 2
       Weiterführende Informationen finden Sie unter:
       https://wiki.scummvm.org/index.php/Compiling_ScummVM/PlayStation_2

--- a/doc/de/LIESMICH
+++ b/doc/de/LIESMICH
@@ -1997,7 +1997,7 @@ Beneath a Steel Sky
     it  - Italienisch
     pt  - Portugiesisch
     es  - Spanisch
-    se  - Schwedisch
+    sv  - Schwedisch
 
 Baphomets Fluch
     en  - Englisch (Standard)
@@ -2782,7 +2782,7 @@ Die folgenden Schlüsselwörter werden erkannt:
                                 erscheinen wird
 
     language           Text     Legt Sprache fest (de, en, us, fr, it, pt, es,
-                                jp, zh, kr, se, gb, hb, cz, ru).
+                                jp, zh, kr, sv, gb, hb, cz, ru).
     speech_mute        Bool     Falls „true“, wird Sprachausgabe unterdrückt.
     subtitles          Bool     Belegung mit „true“ aktiviert Untertitel.
     talkspeed          Zahl     Textverzögerung in SCUMM-Spielen oder Texttempo

--- a/doc/docportal/advanced_topics/command_line.rst
+++ b/doc/docportal/advanced_topics/command_line.rst
@@ -176,7 +176,7 @@ Short options are listed where they are available.
         ``--iconspath=PATH``,,":ref:`Path to additional icons for the launcher grid view <iconspath>`",
         ``--initial-cfg=FILE``,``-i``,"Loads an initial configuration file if no configuration file has been saved yet.",
         ``--joystick=NUM``,,"Enables joystick input.",0
-        ``--language``,``-q``,":ref:`Selects language <lang>`. Allowed values: en, de, fr, it, pt, es, jp, zh, kr, se, gb, hb, ru, cz",en
+        ``--language``,``-q``,":ref:`Selects language <lang>`. Allowed values: en, de, fr, it, pt, es, jp, zh, kr, sv, gb, hb, ru, cz",en
         ``--list-all-debugflags``,,"Lists all debug flags",
         ``--list-all-engines``,,"Lists all detection engines, then exits",
         ``--list-audio-devices``,,"Lists all available audio devices",

--- a/doc/docportal/advanced_topics/command_line.rst
+++ b/doc/docportal/advanced_topics/command_line.rst
@@ -191,7 +191,7 @@ Short options are listed where they are available.
         ``--md5``,,"Shows MD5 hash of the file given by ``--md5-path=PATH``. If ``--md5-length=NUM`` is passed then it shows the MD5 hash of the first or last ``NUM`` bytes of the file given by ``PATH``. If ``--md5-engine=ENGINE_ID`` option is passed then it auto-calculates the required bytes and its hash, overriding ``--md5-length``",
         ``--md5mac``,,"Shows MD5 hash for both the resource fork and data fork of the file given by ``--md5-path=PATH``. If ``--md5-length=NUM`` is passed then it shows the MD5 hash of the first or last``NUM`` bytes of each fork.",
         ``--md5-engine=ENGINE_ID``,,"Used with ``--md5`` to specify the engine for which number of bytes to be hashed must be calculated. This option overrides ``--md5-length`` if used along with it. Use ``--list-engines`` to find all engine IDs.",
-        ``--md5-length=NUM``,,"Used with ``--md5`` or ``--md5mac`` to specify the number of bytes to be hashed.If ``NUM`` is 0, MD5 hash of the whole file is calculated. If ``NUM`` is negative, the MD5 hash is calculated from the tail. Is overriden if passed with ``--md5-engine`` option",0
+        ``--md5-length=NUM``,,"Used with ``--md5`` or ``--md5mac`` to specify the number of bytes to be hashed. If ``NUM`` is 0, MD5 hash of the whole file is calculated. If ``NUM`` is negative, the MD5 hash is calculated from the tail. Is overridden if passed with ``--md5-engine`` option",0
         ``--md5-path=PATH``,,"Used with ``--md5`` or ``--md5mac`` to specify path of file to calculate MD5 hash of", ./scummvm
         ``--midi-gain=NUM``,,":ref:`Sets the gain for MIDI playback <gain>` Only supported by some MIDI drivers. 0-1000",100
         ``--multi-midi``,,":ref:`Enables combination AdLib and native MIDI <multi>`",false
@@ -262,7 +262,7 @@ Short options are listed where they are available.
         ``--screenshot-period=NUM``,,"When recording, triggers a screenshot every NUM milliseconds.(`Event Recorder <https://wiki.scummvm.org/index.php/Event_Recorder>`_)",60000
         ``--sfx-volume=NUM``,``-s``,":ref:`Sets the sfx volume <sfx>`, 0-255",192
     	``--show-fps``,,Turns on frames-per-second information in 3D games,false
-        ``--soundfont=FILE``,,":ref:`Selects the SoundFont for MIDI playback. <soundfont>`. Only supported bysome MIDI drivers.",
+        ``--soundfont=FILE``,,":ref:`Selects the SoundFont for MIDI playback. <soundfont>`. Only supported by some MIDI drivers.",
         ``--speech-volume=NUM``,``-r``,":ref:`Sets the speech volume <speechvol>`, 0-255",192
         ``--start-movie=NAME@NUM``,,"Starts Director movie at specified frame. Either can be specified without the other.",
         ``--stretch-mode=MODE``,, "Selects stretch mode.

--- a/doc/docportal/advanced_topics/configuration_file.rst
+++ b/doc/docportal/advanced_topics/configuration_file.rst
@@ -97,9 +97,9 @@ Example of a configuration file
 Default configuration file option
 =====================================
 
-An initial (default) configuration file can be specified via the :doc:`command line <../advanced_topics/command_line>` using the ``--i`` or ``--initial-cfg`` option. ScummVM uses this default file if the configuration file is missing from its usual location, such as after initial install, or if the user deletes their configuration file. 
+An initial (default) configuration file can be specified via the :doc:`command line <../advanced_topics/command_line>` using the ``--i`` or ``--initial-cfg`` option. ScummVM uses this default file if the configuration file is missing from its usual location, such as after initial install, or if the user deletes their configuration file.
 
-Setting an initial configuration file in this way allows default settings to easily be bundled with a game. The alternatives are to use the command line for all settings, which has fewer options and in some cases means the user can't change settings, or to install a default configuration file to a writable location and using the ``--config`` option, which is harder to deploy, and leaves the user with no way to restore default settings except re-installing the game. 
+Setting an initial configuration file in this way allows default settings to easily be bundled with a game. The alternatives are to use the command line for all settings, which has fewer options and in some cases means the user can't change settings, or to install a default configuration file to a writable location and using the ``--config`` option, which is harder to deploy, and leaves the user with no way to restore default settings except re-installing the game.
 
 
 .. _configuration_keys:

--- a/doc/docportal/advanced_topics/configuration_file.rst
+++ b/doc/docportal/advanced_topics/configuration_file.rst
@@ -107,7 +107,7 @@ Setting an initial configuration file in this way allows default settings to eas
 Configuration keys
 =====================
 
-There are many recognized configuration keys. In the table below, each key is either linked to an explanatory description in the Settings pages, or has further information in the **Decription/Options** column.
+There are many recognized configuration keys. In the table below, each key is either linked to an explanatory description in the Settings pages, or has further information in the **Description/Options** column.
 
 .. csv-table::
   	:header-rows: 1
@@ -250,7 +250,7 @@ There are many recognized configuration keys. In the table below, each key is ei
 	- timidity"
 		":ref:`gui_browser_native <guibrowser>`", boolean, true
 		gui_browser_show_hidden,boolean,false, Shows hidden files/folders in the ScummVM file browser.
-		gui_list_max_scan_entries,integer,-1, "Specifies the threshold for scanning directories in the Launcher. If the number of game entires exceeds the specified number, then scanning is skipped."
+		gui_list_max_scan_entries,integer,-1, "Specifies the threshold for scanning directories in the Launcher. If the number of game entries exceeds the specified number, then scanning is skipped."
 		":ref:`gui_return_to_launcher_at_exit <guireturn>`",boolean,false,
 		gui_saveload_chooser,string,grid,"- list
 	- grid"
@@ -395,7 +395,7 @@ There are many recognized configuration keys. In the table below, each key is ei
 	- 44100"
 		":ref:`palette_mods <palette>`",boolean,false,
 		":ref:`platform <platform>`",string,,
-		":ref:`portaits_on <portraits>`",boolean,true,
+		":ref:`portraits_on <portraits>`",boolean,true,
 		":ref:`prefer_digitalsfx <dsfx>`",boolean,true,
 		":ref:`prerecorded_sounds <prerecorded>`",boolean,true,
 		":ref:`renderer <renderer>`",string,default,"

--- a/doc/docportal/advanced_topics/understand_audio.rst
+++ b/doc/docportal/advanced_topics/understand_audio.rst
@@ -133,7 +133,7 @@ If you select an option that does not match the actual device, this might have u
 
 
 
-macOS/Mac OSX
+macOS/Mac OS X
 ***************
 
 Mac has a built-in MIDI synthesizer; Apple DLS software synthesizer. It uses the Mac's built-in sounds (which are based on Roland GS).

--- a/doc/docportal/advanced_topics/understand_search_box.rst
+++ b/doc/docportal/advanced_topics/understand_search_box.rst
@@ -60,7 +60,7 @@ Here are some more examples:
 - ``guioptions:noLang`` - games without displayed language
 - ``keymap_engine-default_LCLK:MOUSE_RIGHT`` - games with right mouse button remapped to left mouse button
 
-Abbrevating configuration keys
+Abbreviating configuration keys
 *******************************************
 
 To abbreviate the 6 most common configuration keys, just type any prefix instead of full strings for those keys:
@@ -102,7 +102,7 @@ To abbreviate the 6 most common configuration keys, just type any prefix instead
 
 .. note::
 
-	The ``platform`` key can't be abbrevated to ``p``, since ``p`` is already used for ``path``.
+	The ``platform`` key can't be abbreviated to ``p``, since ``p`` is already used for ``path``.
 
 
 Inverting the search pattern
@@ -111,7 +111,7 @@ ___________________________________________
 To invert the search result, prefix the search pattern with the`!` character. For example:
 
 - ``!GOG`` - games that don't contain "GOG" substring in description
-- ``!lang=ru`` - games not in Russian languange
+- ``!lang=ru`` - games not in Russian language
 - ``!p:demo`` - games that don't have "demo" substring in game path
 - ``!engine~sword#`` - games not made with "sword1" and "sword2" engines (but "sword25" is fine)
 

--- a/doc/docportal/help/report_bugs.rst
+++ b/doc/docportal/help/report_bugs.rst
@@ -5,7 +5,7 @@ Report a bug
 
 To report a bug, go to the ScummVM `Issue Tracker <https://bugs.scummvm.org/>`_ and log in with your GitHub account.
 
-Please make sure the bug is reproducible, and still occurs in the latest git/Daily build version. Also check the `compatibility list <https://www.scummvm.org/compatibility/>`_ for that game, to ensure the issue is not already known. Please do not report bugs for games that are not listed as completeable on the `Supported Games <https://wiki.scummvm.org/index.php?title=Category:Supported_Games>`_ wiki page, or on the compatibility list. We already know those games have bugs!
+Please make sure the bug is reproducible, and still occurs in the latest git/Daily build version. Also check the `compatibility list <https://www.scummvm.org/compatibility/>`_ for that game, to ensure the issue is not already known. Please do not report bugs for games that are not listed as completable  on the `Supported Games <https://wiki.scummvm.org/index.php?title=Category:Supported_Games>`_ wiki page, or on the compatibility list. We already know those games have bugs!
 
 Please include the following information in the bug report:
 

--- a/doc/docportal/other_platforms/amigaos_4.rst
+++ b/doc/docportal/other_platforms/amigaos_4.rst
@@ -22,7 +22,7 @@ Optional: Run the extracted ``ScummVM_Install`` script. This installer guides yo
 
     The ScummVM installer.
 
-Note: AmiUpdate is already aware of ScummVM and will automatically keep ScummVM up to date through it's ``Autoinstall`` script.
+Note: AmiUpdate is already aware of ScummVM and will automatically keep ScummVM up to date through its ``Autoinstall`` script.
 
 
 Transferring game files

--- a/doc/docportal/other_platforms/ios.rst
+++ b/doc/docportal/other_platforms/ios.rst
@@ -90,7 +90,7 @@ For a two finger double tap, hold one finger down and then double tap with a sec
 Keyboard
 ^^^^^^^^^^^^^^^^^^^^
 
-If no external keyboard is connected, the pinch gesture shows and hides the onscreen keyboard. When an external keyboard is connected the inputs from the external keyboard is enaled by default.
+If no external keyboard is connected, the pinch gesture shows and hides the onscreen keyboard. When an external keyboard is connected, input from the external keyboard is enabled by default.
 External keyboards are supported and from iOS 13.4 most of the special keys, e.g. function keys, Home and End, are mapped.
 For external keyboards missing the special keys, e.g. the Apple Magic Keyboard for iPads, the special keys can be triggered using the following key combinations:
 
@@ -136,6 +136,6 @@ Known issues
 ===============
 
 - If ScummVM is uninstalled or downgraded, its internal and external app spaces are fully deleted. If you want to keep saved games use ScummVM's :doc:`cloud <../use_scummvm/connect_cloud>` or LAN functionality to keep those files. Alternatively, change the saved game path to a shared location such as an SD card.
-- If closing the ScummVM application (background mode) and then killing the application (by swiping the application upwards) there is a risk that the ScummVM configuration file becomes corrupted. Make sure not to kill the application to soon after ptting it to background.
-- In rare cases the ScummVM folder is not created in the "Files" application after installing ScummVM. Make sure the ScummVM folder shows up after installation. If not, uninstall the ScummVM, restart the iOS device and reinstall ScummVM.
-- In rare cases the system mouse pointer on iPadOS is not hidden so both the ScummVM arrow mouse pointer and the iPadOS system pointer are seen in parallell. It's usually fixed when restartarting the iPad.
+- If closing the ScummVM application (background mode) and then killing the application (by swiping the application upwards) there is a risk that the ScummVM configuration file becomes corrupted. Make sure not to kill the application too soon after putting it in the background.
+- In rare cases the ScummVM folder is not created in the "Files" application after installing ScummVM. Make sure the ScummVM folder shows up after installation. If not, uninstall ScummVM, restart the iOS device, and reinstall ScummVM.
+- In rare cases the system mouse pointer on iPadOS is not hidden so both the ScummVM arrow pointer and the iPadOS system pointer are seen at the same time. It's usually fixed by restarting the iPad.

--- a/doc/docportal/other_platforms/ios.rst
+++ b/doc/docportal/other_platforms/ios.rst
@@ -57,7 +57,7 @@ Controls
         Apple Pencil control, Action
         Touch, Left mouse click
         Touch & hold for >0.5s, "Left mouse button hold and drag, such as for selection from action wheel in Curse of Monkey Island"
-        3 quick touches, Right mouse click 
+        3 quick touches, Right mouse click
         3 quick touches & hold for >0.5s, "Right mouse button hold and drag, such as for selection from action wheel in Tony Tough"
 
 

--- a/doc/docportal/other_platforms/nintendo_3ds.rst
+++ b/doc/docportal/other_platforms/nintendo_3ds.rst
@@ -80,7 +80,7 @@ Simulates the click and release of the mouse buttons every time you touch and re
 
 Magnify mode
 ****************
-Due to the low resolutions of the 3DS screens (400x240 for the top, and 320x240 for the bottom), games that run at a higher resolution will inevitably lose some visual detail from being scaled down. This can result in situations where essential information, such as text, is indiscernable.
+Due to the low resolutions of the 3DS screens (400x240 for the top, and 320x240 for the bottom), games that run at a higher resolution will inevitably lose some visual detail from being scaled down. This can result in situations where essential information, such as text, is indiscernible.
 
 Magnify mode increases the scale factor of the top screen back to 1, but the bottom screen remains unchanged. The touchscreen can then be used to change which part of the game display is being magnified. This can be done even in situations where the cursor is disabled, such as during full-motion video segments.
 

--- a/doc/docportal/other_platforms/playstation_3.rst
+++ b/doc/docportal/other_platforms/playstation_3.rst
@@ -7,14 +7,14 @@ This page contains all the information you need to get ScummVM up and running on
 What you'll need
 ===================
 
-- A Homebrew enabled Playstation 3 console. How to enable homebrew is outside the scope of this documentation.
+- A homebrew-enabled PlayStation 3 console. How to enable homebrew is outside the scope of this documentation.
 - A USB drive
 - A computer
 
 Installing ScummVM
 =====================================
 
-Download the Playstation 3 package from the `ScummVM Downloads page <https://www.scummvm.org/downloads/>`_. Copy the ``.pkg`` file to a USB drive.
+Download the PlayStation 3 package from the `ScummVM Downloads page <https://www.scummvm.org/downloads/>`_. Copy the ``.pkg`` file to a USB drive.
 
 Plug the USB drive into the PS3.  Go to the XMB, then go to **Games > Install Package** to install the ScummVM package.
 

--- a/doc/docportal/other_platforms/playstation_vita.rst
+++ b/doc/docportal/other_platforms/playstation_vita.rst
@@ -105,11 +105,11 @@ These controls can also be manually configured in the :doc:`Keymaps tab <../sett
 Keyboard and mouse support
 ****************************
 
-Real bluetooth mice and keyboards work on the Vita and are supported by ScummVM. Go to **Settings > Devices** on the Vita home screen to pair your devices.
+Real Bluetooth mice and keyboards work on the Vita and are supported by ScummVM. Go to **Settings > Devices** on the Vita home screen to pair your devices.
 
 .. note::
 
-    Not all bluetooth keyboards or mice pair successfully with the Vita. The ScummVM team tested the Jelly Bean BT keyboard and mouse combo (ASIN:B06Y56BBYP) and with the standalone Jelly Comb Bluetooth Wireless Mouse (ASIN:B075HBDWCF).
+    Not all Bluetooth keyboards and mice pair successfully with the Vita. The ScummVM team tested the Jelly Bean BT keyboard and mouse combo (ASIN:B06Y56BBYP) and the standalone Jelly Comb Bluetooth Wireless Mouse (ASIN:B075HBDWCF).
 
 Touch support
 ****************

--- a/doc/docportal/settings/audio.rst
+++ b/doc/docportal/settings/audio.rst
@@ -300,7 +300,7 @@ MT-32 Device
 .. _nativemt32:
 
 **True Roland MT-32 (disable GM emulation)**
-	Tells ScummVM that the MIDI device is an actual Roland MT-32, LAPC-I, CM-64, CM-32L, CM-500 or other MT-32 device. Note that this cannot be used in conjuntion with the Roland GS device option.
+	Tells ScummVM that the MIDI device is an actual Roland MT-32, LAPC-I, CM-64, CM-32L, CM-500 or other MT-32 device. Note that this cannot be used in conjunction with the Roland GS device option.
 
 	*native_mt32*
 

--- a/doc/docportal/use_scummvm/add_play_games.rst
+++ b/doc/docportal/use_scummvm/add_play_games.rst
@@ -69,7 +69,7 @@ If you are adding an unknown version of a game, ScummVM is not able to add the g
 
    The **Game Options** window does not open when **Mass Add** is used.
 
-5. Games are now ready to play! To play, either double-click on the game in the games list, or highlight the game by clicking on it, and then click **Start**. In grid view, either double-click on a game to start it, or select the game and click the play icon in the pop-up window. 
+5. Games are now ready to play! To play, either double-click on the game in the games list, or highlight the game by clicking on it, and then click **Start**. In grid view, either double-click on a game to start it, or select the game and click the play icon in the pop-up window.
 
 .. image:: ../images/Launcher/start_game.png
    :class: with-shadow

--- a/doc/docportal/use_scummvm/add_play_games.rst
+++ b/doc/docportal/use_scummvm/add_play_games.rst
@@ -79,7 +79,7 @@ Games can also be launched directly from the command line. For more information,
 A note about copyright
 ==============================
 
-ScummVM has a strict anti-piracy stance and the team wil not tolerate discussions around pirated games in any part of the project, including on the Forum or on Discord.
+ScummVM has a strict anti-piracy stance and the team will not tolerate discussions around pirated games in any part of the project, including on the Forum or on Discord.
 
 Copy protection screen
 ************************

--- a/doc/docportal/use_scummvm/mac_game_files.rst
+++ b/doc/docportal/use_scummvm/mac_game_files.rst
@@ -215,7 +215,7 @@ Install machfs, and xattr if using macOS:
 Use
 ****
 
-The dumper companion supports three modes: ISO, DIR and MAC. The MAC mode is specific to macOS. There's also a STR mode that is used test drive the punyencode parts. For more info see its help section.
+The dumper companion supports three modes: ISO, DIR and MAC. The MAC mode is specific to macOS. There's also a STR mode that is used to test drive the punyencode parts. For more info see its help section.
 
 .. note::
 
@@ -306,7 +306,7 @@ There are other ways to access HFS and HFS+ media on Windows, macOS, and Linux. 
            1. Install hfsplus using the software manager. On Debian-based distributions, use ``sudo apt install hfsplus``.
            2. Find the game disc by running ``sudo fdisk -l`` and finding the one with type ``Apple HFS/HFS+``. In this example, this is ``/dev/fd0``.
            3. Create a mount point, for example: ``sudo mkdir /media/macgamedrive``
-           4. Mount the device to that moint point: ``sudo mount -t hfsplus /dev/fd0 /media/macgamedrive``
+           4. Mount the device to that mount point: ``sudo mount -t hfsplus /dev/fd0 /media/macgamedrive``
            5. Access the device at ``/media/macgamedrive``. To copy files you can use ``hpcopy``. It takes options to indicate if the files should be converted to macbinary (``-m``) or copied as a raw file (``-r``).
 
         Access HFS drives using ``hfsutils``. To use hfsutils, use the command line:

--- a/doc/docportal/use_scummvm/mac_game_files.rst
+++ b/doc/docportal/use_scummvm/mac_game_files.rst
@@ -36,7 +36,7 @@ Files that contain prohibited characters are always puny-encoded.
 
 .. note::
 
-    Windows, MacOS and Linux can store these files and do not need punycode enabled.
+    Windows, macOS and Linux can store these files and do not need punycode enabled.
 
 For more information, see the `Windows naming conventions <https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions>`_ for a list of prohibited characters.
 

--- a/doc/docportal/use_scummvm/save_load_games.rst
+++ b/doc/docportal/use_scummvm/save_load_games.rst
@@ -28,7 +28,7 @@ In tile view, click on the **New Save** tile. Enter a description for the game, 
 
 .. figure:: ../images/Launcher/save_game_grid_desc.png
 
-	Save game decription, grid view.
+	Save game description, grid view.
 
 In list view, click on a slot to save the game to that slot. Enter a description for the game, then click **Save**.
 

--- a/doc/docportal/use_scummvm/taskbar_integration.rst
+++ b/doc/docportal/use_scummvm/taskbar_integration.rst
@@ -13,7 +13,7 @@ The taskbar integration has several features:
 Setting up the icon overlay
 ================================
 
-Currently the taskbar cannot yet use the icons .dat files that can be downloaded from the **Global Options**. This means the icons need to be downloaded manually from our `Github repository <https://github.com/scummvm/scummvm-icons>`. Either place these in the default :ref:`Icon Path <iconspath>` or change the Icon Path to point to the folder containing the icons.
+Currently the taskbar cannot yet use the icon .dat files that can be downloaded from the **Global Options**. This means the icons need to be downloaded manually from our `GitHub repository <https://github.com/scummvm/scummvm-icons>`. Either place these in the default :ref:`Icon Path <iconspath>` or change the Icon Path to point to the folder containing the icons.
 
 The icon files must be ICO files for Windows, or PNG files for macOS. They must follow one of these naming conventions, where xxx is the file extension:
 

--- a/doc/docportal/use_scummvm/taskbar_integration.rst
+++ b/doc/docportal/use_scummvm/taskbar_integration.rst
@@ -5,9 +5,9 @@ Taskbar integration
 The taskbar integration has several features:
 
     - Adds an overlay icon in the taskbar/dock when running a game (Windows and macOS)
-    -  Updates a list of recently played games that can be started from the taskbar/dock (Windows and macOS).
-    -  Shows a progress bar when doing a mass add of games, and shows the number of games found at the end (Windows, macOS and Linux).
-    -  Shows an error state in the taskbar if an error occurs when running a game (Windows only).
+    - Updates a list of recently played games that can be started from the taskbar/dock (Windows and macOS).
+    - Shows a progress bar when doing a mass add of games, and shows the number of games found at the end (Windows, macOS and Linux).
+    - Shows an error state in the taskbar if an error occurs when running a game (Windows only).
 
 
 Setting up the icon overlay

--- a/doc/docportal/use_scummvm/taskbar_integration.rst
+++ b/doc/docportal/use_scummvm/taskbar_integration.rst
@@ -13,7 +13,7 @@ The taskbar integration has several features:
 Setting up the icon overlay
 ================================
 
-Currently the taskbar cannot yet use the icons .dat files that can be dowloaded from the **Global Options**. This means the icons need to be downloaded manually from our `Github repository <https://github.com/scummvm/scummvm-icons>`__. Either place these in the default :ref:`Icon Path <iconspath>` or change the Icon Path to point to the folder containing the icons.
+Currently the taskbar cannot yet use the icons .dat files that can be downloaded from the **Global Options**. This means the icons need to be downloaded manually from our `Github repository <https://github.com/scummvm/scummvm-icons>`. Either place these in the default :ref:`Icon Path <iconspath>` or change the Icon Path to point to the folder containing the icons.
 
 The icon files must be ICO files for Windows, or PNG files for macOS. They must follow one of these naming conventions, where xxx is the file extension:
 

--- a/doc/doxygen/scummvm.doxyfile
+++ b/doc/doxygen/scummvm.doxyfile
@@ -1258,7 +1258,7 @@ HTML_INDEX_NUM_ENTRIES = 100
 # If the GENERATE_DOCSET tag is set to YES, additional index files will be
 # generated that can be used as input for Apple's Xcode 3 integrated development
 # environment (see: https://developer.apple.com/tools/xcode/), introduced with
-# OSX 10.5 (Leopard). To create a documentation set, doxygen will generate a
+# OS X 10.5 (Leopard). To create a documentation set, doxygen will generate a
 # Makefile in the HTML output directory. Running make will produce the docset in
 # that directory and running make install will install the docset in
 # ~/Library/Developer/Shared/Documentation/DocSets so that Xcode will find it at

--- a/doc/sv/LasMig
+++ b/doc/sv/LasMig
@@ -787,7 +787,7 @@ Beneath a Steel Sky
     it  - Italienska
     pt  - Portugisiska
     es  - Spanska
-    se  - Svenska
+    sv  - Svenska
 
 Broken Sword
     en  - Engelska (standard)
@@ -1535,7 +1535,7 @@ Följande nyckelord kan användas:
     description        string   Beskrivningen av spelet enligt launchern.
 
     language           string   Bestäm språk (en, us, de, fr, it, pt, es,
-                                jp, zh, kr, se, gb, hb, cz, ru)
+                                jp, zh, kr, sv, gb, hb, cz, ru)
     speech_mute        bool     Ställ in till “true” för att
                                 stänga av röster
     subtitles          bool     Ställ in till “true” för att


### PR DESCRIPTION
First I had commits for individual files, but that spammed the log; let me know if they should be exploded again in some way.

I tried not to use my own opinion for style, but rather to use what we already see elsewhere, sometimes within the same file. (e.g. "homebrew-enabled"; "PlayStation"; ...)