### PR TITLE
CREATE_PROJECT: Use /diagnostics:caret for clearer MSVC warnings

### DIFF
--- a/devtools/create_project/msbuild.cpp
+++ b/devtools/create_project/msbuild.cpp
@@ -387,6 +387,10 @@ void MSBuildProvider::outputGlobalPropFile(const BuildSetup &setup, std::ofstrea
 	properties << "\t\t\t<RuntimeTypeInfo>false</RuntimeTypeInfo>\n";
 #endif
 
+	// Print a bit more context for warnings, like modern GCC/Clang do
+	if (_msvcVersion.version >= 15)
+		properties << "\t\t\t<DiagnosticsFormat>Caret</DiagnosticsFormat>\n";
+
 	properties << "\t\t\t<WarningLevel>Level4</WarningLevel>\n"
 	           << "\t\t\t<TreatWarningAsError>false</TreatWarningAsError>\n"
 	           << "\t\t\t<CompileAs>Default</CompileAs>\n"


### PR DESCRIPTION
I'm just looking for some MSVC users for some feedback on this, although I don't think it's controversial.

So, summoning @sluicebox (our MSVC 2015 Lord), @SupSuper, @elasota, and any possible MSVC user out there.

i.e. this PR changes this warning output:

```
path\to\engines\tinsel\detection.cpp(153,17): warning C4245: '=': conversion from 'int' to 'unsigned int', signed/unsigned mismatch [D:\a\scummvm\scummvm\build-scummvm\scummvm-detection.vcxproj]
```

to this:
```
path\to\engines\tinsel\detection.cpp(153,17): warning C4245: '=': conversion from 'int' to 'unsigned int', signed/unsigned mismatch [D:\a\scummvm\scummvm\build-scummvm\scummvm-detection.vcxproj]
  					tmp.size = -1;
  					           ^
```

giving a bit more context, more in line with what modern GCC/Clang do. Quite cool in the CI output, too, I think.

It looks like the `caret` option was added in some VS2017 update, but I couldn't find any changelog mentioning it. So I just enable on (what I think is) VS2019 and later.

Tested through GitHub Actions, and VS2022.