### PR TITLE
BUILD: Use -Werror=return-type (and MSVC equivalent)

### DIFF
--- a/configure
+++ b/configure
@@ -196,7 +196,7 @@ _debug_build=auto
 _release_build=auto
 _optimizations=auto
 _verbose_build=no
-_werror_build=no
+_werror_build=auto
 _text_console=no
 _mt32emu=yes
 _lua=yes
@@ -984,7 +984,8 @@ Optional Features:
   --enable-detection-dynamic build detection features into a library
   --disable-detection-full add detection only for the engines which were enabled
   --disable-debug          disable building with debugging symbols
-  --enable-Werror          treat warnings as errors
+  --enable-Werror          treat all warnings as errors
+  --disable-Werror         disable default promotion of some warnings to errors
   --enable-release         enable building in release mode (this activates
                            optimizations)
   --enable-release-mode    enable building in release mode (without optimizations)
@@ -1542,6 +1543,9 @@ for ac_option in $@; do
 		;;
 	--enable-Werror)
 		_werror_build=yes
+		;;
+	--disable-Werror)
+		_werror_build=no
 		;;
 	--enable-release-mode)
 		_release_build=yes
@@ -7544,12 +7548,20 @@ case $_host_os in
 		;;
 esac
 
-
+# Promote any warning to an error, only if explicitly asked
 if test "$_werror_build" = yes; then
 	# --enable-Werror shouldn't be applied before being done testing all system
 	# features and libraries. Otherwise, some of them could just end up being silently
 	# disabled, when any small warning appears in a test.
 	append_var CXXFLAGS "-Werror"
+fi
+
+# Promote some selected warnings to errors, by default
+#
+# Some warnings can reveal some serious issues that shouldn't remain
+# unnoticed. Flags added here shouldn't trigger false positives, though.
+if test "$_werror_build" != no; then
+	append_var CXXFLAGS "-Werror=return-type"
 fi
 
 #

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -678,6 +678,9 @@ int main(int argc, char *argv[]) {
 		globalErrors.push_back("4305"); // truncation of double to float or int to bool
 		globalErrors.push_back("4366"); // address taken of unaligned field
 		globalErrors.push_back("4315"); // unaligned field has constructor that expects to be aligned
+		globalErrors.push_back("4715"); // not all control paths return a value
+		globalErrors.push_back("4716"); // function must return a value
+
 
 		projectWarnings["agi"].push_back("4510");
 		projectWarnings["agi"].push_back("4610");

--- a/devtools/create_project/xcode.cpp
+++ b/devtools/create_project/xcode.cpp
@@ -1342,6 +1342,7 @@ void XcodeProvider::setupBuildConfiguration(const BuildSetup &setup) {
 	scummvm_WarningCFlags.push_back("-Wno-undefined-var-template");
 	scummvm_WarningCFlags.push_back("-Wno-pragma-pack");
 	scummvm_WarningCFlags.push_back("-Wc++11-extensions");
+	scummvm_WarningCFlags.push_back("-Werror=return-type");
 	ADD_SETTING_LIST(scummvm_Debug, "WARNING_CFLAGS", scummvm_WarningCFlags, kSettingsQuoteVariable | kSettingsAsList, 5);
 	ValueList scummvm_defines(_defines);
 	REMOVE_DEFINE(scummvm_defines, "MACOSX");


### PR DESCRIPTION
Based on @sluicebox's comment on commit 599fbc290a25ef671f844cada1705219c735042b, where a missing `return` statement was caught by a fatal error in MSVC (thanks to previous PR #4561) but not in the GCC/Clang builds.

This PR now makes the three main builders (`configure`, MSVC, Xcode) have such a behavior, for this specific case.

## `configure` changes

For the `configure` scripts, the new flag is set by default, but one can turn it off with `--disable-Werror`, if some situation requires it (e.g. some Linux distributions having a good reason to do so, some future compiler upgrade introducing a stricter/buggier `-Wreturn-type`…).

(Regarding `CXXFLAGS`: I'm not using `set_flag_if_supported`, since `-Werror=flag-name` was introduced before GCC 4.7, which is our minimal C++11 requirement.)

Of course, turning a *specific* warning into a fatal error should only be done when it reveals a dangerous pattern where we want to fail early (to be sure to catch it), and if the compilers don't create frequent false positives for it.

## False positives?

Regarding false positives, @lephilousophe mentioned https://github.com/godotengine/godot/issues/58747.

I also saw https://reviews.llvm.org/D98224 mentioning that _"some versions of gcc can emit `-Wreturn-type` warnings on functions that have exhaustive switches over enums"_ (this seems to be related to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87950, where `__builtin_unreachable()` is also mentioned).

Anyway, I did some `--enable-all-engines` tests with:

* GitHub Actions (Clang, MSVC, GCC 13, GCC 4.8)
* `./devtools/docker.sh toolchains/riscos` (our de-facto oldest toolchain? GCC 4.7)
* `./devtools/docker.sh toolchains/windows-9x`
* `./devtools/docker.sh toolchains/ps3`
* `./devtools/docker.sh toolchains/windows-9x` 

and I couldn't find any false-positive case.