### PR TITLE
DIRECTOR: Disable Movie Events while Alert is being shown

### DIFF
--- a/engines/director/events.cpp
+++ b/engines/director/events.cpp
@@ -121,6 +121,12 @@ bool Window::processEvent(Common::Event &event) {
 }
 
 bool Movie::processEvent(Common::Event &event) {
+	// When in GUI message box is being shown, movie may record clicking on the message box as a movie event
+	// Make sure that these events (mouseUp, mouseDown) are not recorded in the movie
+	if (_inGuiMessageBox) {
+		return false;
+	}
+
 	Score *sc = getScore();
 	if (sc->getCurrentFrameNum() > sc->getFramesNum()) {
 		warning("processEvents: request to access frame %d of %d", sc->getCurrentFrameNum(), sc->getFramesNum());

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -2128,6 +2128,12 @@ void LB::b_voidP(int nargs) {
 // Misc
 ///////////////////
 void LB::b_alert(int nargs) {
+	// Let the movie know not to record mouse and key events
+	// While there is an GUI alert box being shown
+	// It may happen the user clicks on the button on the GUI message and
+	// due to it getting recorded as a movie event, causes unpredictable changes
+	g_director->getCurrentMovie()->_inGuiMessageBox = true;
+
 	Datum d = g_lingo->pop();
 
 	Common::String alert = d.asString();
@@ -2144,6 +2150,9 @@ void LB::b_alert(int nargs) {
 		GUI::MessageDialog dialog(alert.c_str(), _("OK"));
 		dialog.runModal();
 	}
+
+	// Movie can process events as normal now
+	g_director->getCurrentMovie()->_inGuiMessageBox = false;
 }
 
 void LB::b_clearGlobals(int nargs) {

--- a/engines/director/movie.h
+++ b/engines/director/movie.h
@@ -194,6 +194,11 @@ public:
 
 	Common::String _script;
 
+	// A flag to disable the event processing in the Movie
+	// This flag will be set when the user's interaction (mouse and key events like mouseUp, keyUp)  
+	// shouldn't be recorded as movie event, which may cause undesirable change in the lingo script
+	bool _inGuiMessageBox = false;
+
 private:
 	Window *_window;
 	DirectorEngine *_vm;


### PR DESCRIPTION
Alerts and Message are shown on the screen by ScummVM using 
GUI dialog boxes. They may have clickable buttons on them.
In Director, it may happen that the event of clicking or pressing the 
button on the GUI dialog box (mouseUp, keyUp) get recorded as a movie 
event, which may cause unpredictable change in the lingo script.

An example of this: in Testbed.dir, if you try to open a file that doesn't 
exist director engine throws a dialog box error with an "OK" button 
However, pressing the button triggers  a movie event `mouseUp` which 
causes the button to reappear.

The following video shows a demonstration of that
https://github.com/user-attachments/assets/24bd81cd-082f-4a50-9cc1-c7d86aa869e1

Prevent this by disabling all event processing in the Director movie using 
a flag _inGuiMessageBox, which is set by the function that calls the alert 
or dialog box and cleared once the dialog box disappears In this case that 
is the `b_alert()` function This prevents any event being triggered in movie 
but still gets registered in the window class making it disappear without 
re-triggering the dialog box.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
