### PR TITLE
COMMON: Improve Gentee Installer loader to support Schizm Japanese version

### DIFF
--- a/common/compression/gentee_installer.cpp
+++ b/common/compression/gentee_installer.cpp
@@ -835,9 +835,10 @@ bool PackageArchive::loadPAK(const char *prefix) {
 
 			debug(3, "GenteeInstaller: Detected %s item '%s' size %u at pos %u .. %u", (isCompressed ? "compressed" : "stored"), fileName.c_str(), static_cast<uint>(decompressedSize), static_cast<uint>(dataStart), static_cast<uint>(dataEnd));
 
+			fileName.replace('\\', '/');
+
 			if (fileName.hasPrefix(prefix)) {
 				fileName = fileName.substr(strlen(prefix));
-				fileName.replace('\\', '/');
 				Common::Path path(fileName, '/');
 
 				Common::SharedPtr<ArchiveItem> item(new ArchiveItem(_stream, getGuardMutex(), path, dataStart, static_cast<uint>(dataEnd - dataStart), decompressedSize, isCompressed));

--- a/common/compression/gentee_installer.h
+++ b/common/compression/gentee_installer.h
@@ -52,13 +52,16 @@ namespace Common {
  * other compression methods like PPMd.  This version uses LZ77 with adaptive Huffman coding.
  *
  * @param stream          Data stream to load
+ * @param embedded        If true, load an embedded package from an installer executable, otherwise load
+ *                        a stand-alone package file.
  * @param prefixToRemove  Specifies the prefix of extract directives to include, and removes the prefix
- *                        If you pass an empty string or null, all directives will be included
+ *                        If you pass an empty string or null, all directives will be included.
+ *                        File path separators will be normalized to '/' before checking the prefix.
  * @param threadSafe      If true, all read operations will be wrapped in a mutex-guarded substream
  *
  * @return                The Gentee Installer package archive
  */
-Common::Archive *createGenteeInstallerArchive(Common::SeekableReadStream *stream, const char *prefixToRemove, bool threadSafe);
+Common::Archive *createGenteeInstallerArchive(Common::SeekableReadStream *stream, const char *prefixToRemove, bool embedded, bool threadSafe);
 
 } // End of namespace Common
 

--- a/engines/vcruise/vcruise.cpp
+++ b/engines/vcruise/vcruise.cpp
@@ -125,7 +125,7 @@ Common::Error VCruiseEngine::run() {
 		if (!f->open(_gameDescription->desc.filesDescriptions[0].fileName))
 			error("Couldn't open installer package '%s'", _gameDescription->desc.filesDescriptions[0].fileName);
 
-		Common::Archive *installerPackageArchive = Common::createGenteeInstallerArchive(f, "#setuppath#\\", true);
+		Common::Archive *installerPackageArchive = Common::createGenteeInstallerArchive(f, "#setuppath#/", false, true);
 		if (!installerPackageArchive)
 			error("Couldn't load installer package '%s'", _gameDescription->desc.filesDescriptions[0].fileName);
 


### PR DESCRIPTION
This adds a few features necessary to support the Schizm Japanese version installer:

Adds support for loading PAKs embedded in the installer executable, both by adding the necessary functionality and by fixing the PAK header EOF location being misread as the PAK size.

Adjusts path handling to deal with the path separator at the end of the prefix being inconsistent in the unpack commands.