### PR TITLE
BUILD: Support both $_host-peldd and peldd for mingw builds

### DIFF
--- a/configure
+++ b/configure
@@ -3802,6 +3802,8 @@ if test -n "$_host"; then
 			_strip=$_host-strip
 			if `which $_host-peldd >/dev/null 2>&1`; then
 				_ldd="$_host-peldd -t --ignore-errors"
+			elif `which peldd >/dev/null 2>&1`; then
+				_ldd="peldd -t --ignore-errors"
 			fi
 			;;
 		mips-sgi*)


### PR DESCRIPTION
When using the [`windows-9x` toolchain](https://wiki.scummvm.org/index.php?title=Compiling_ScummVM/Docker), the `make win32dist-mingw DESTDIR=win32dist-mingw` stage would end with this output:

```
...
ldd win32dist-mingw/scummvm.exe | grep -i mingw | cut -d">" -f2 | cut -d" " -f2 | sort -u | xargs -I files cp -vu files win32dist-mingw
	not a dynamic executable
```

i.e. the `peldd` code from previous PR #3196 wasn't called.

Indeed, there is not such prefixed binary in the win9x toolchain:

```
$ ./devtools/docker.sh toolchains/windows-9x
# which mingw32-peldd || echo "not found"
not found
# which peldd || echo "not found"
/opt/toolchains/mingw32/bin/peldd
```

Maybe something needs to be tweaked in the toolchain to have a prefixed version, but in the meantime I think also looking for a plain `peldd` in our build scripts is quite reasonable. 

@lephilousophe: Any objection to this?