### PR TITLE
TINYGL: Implement scissor test

### DIFF
--- a/engines/playground3d/gfx.h
+++ b/engines/playground3d/gfx.h
@@ -72,6 +72,9 @@ public:
 	virtual void enableFog(const Math::Vector4d &fogColor) = 0;
 	virtual void disableFog() = 0;
 
+	virtual void enableScissor(int x, int y, int width, int height) = 0;
+	virtual void disableScissor() = 0;
+
 protected:
 	OSystem *_system;
 

--- a/engines/playground3d/gfx.h
+++ b/engines/playground3d/gfx.h
@@ -70,6 +70,7 @@ public:
 	virtual void drawRgbaTexture() = 0;
 
 	virtual void enableFog(const Math::Vector4d &fogColor) = 0;
+	virtual void disableFog() = 0;
 
 protected:
 	OSystem *_system;

--- a/engines/playground3d/gfx_opengl.cpp
+++ b/engines/playground3d/gfx_opengl.cpp
@@ -163,6 +163,15 @@ void OpenGLRenderer::disableFog() {
 	glDisable(GL_FOG);
 }
 
+void OpenGLRenderer::enableScissor(int x, int y, int width, int height) {
+	glScissor(x, y, width, height);
+	glEnable(GL_SCISSOR_TEST);
+}
+
+void OpenGLRenderer::disableScissor() {
+	glDisable(GL_SCISSOR_TEST);
+}
+
 void OpenGLRenderer::drawFace(uint face) {
 	glBegin(GL_TRIANGLE_STRIP);
 	for (uint i = 0; i < 4; i++) {

--- a/engines/playground3d/gfx_opengl.cpp
+++ b/engines/playground3d/gfx_opengl.cpp
@@ -159,6 +159,10 @@ void OpenGLRenderer::enableFog(const Math::Vector4d &fogColor) {
 	glEnable(GL_FOG);
 }
 
+void OpenGLRenderer::disableFog() {
+	glDisable(GL_FOG);
+}
+
 void OpenGLRenderer::drawFace(uint face) {
 	glBegin(GL_TRIANGLE_STRIP);
 	for (uint i = 0; i < 4; i++) {

--- a/engines/playground3d/gfx_opengl.h
+++ b/engines/playground3d/gfx_opengl.h
@@ -56,6 +56,7 @@ public:
 	void drawRgbaTexture() override;
 
 	void enableFog(const Math::Vector4d &fogColor) override;
+	void disableFog() override;
 
 private:
 	Math::Vector3d _pos;

--- a/engines/playground3d/gfx_opengl.h
+++ b/engines/playground3d/gfx_opengl.h
@@ -58,6 +58,9 @@ public:
 	void enableFog(const Math::Vector4d &fogColor) override;
 	void disableFog() override;
 
+	void enableScissor(int x, int y, int width, int height) override;
+	void disableScissor() override;
+
 private:
 	Math::Vector3d _pos;
 	GLuint _textureRgbaId[5];

--- a/engines/playground3d/gfx_opengl_shaders.cpp
+++ b/engines/playground3d/gfx_opengl_shaders.cpp
@@ -213,6 +213,9 @@ void ShaderRenderer::setupViewport(int x, int y, int width, int height) {
 void ShaderRenderer::enableFog(const Math::Vector4d &fogColor) {
 }
 
+void ShaderRenderer::disableFog() {
+}
+
 void ShaderRenderer::drawCube(const Math::Vector3d &pos, const Math::Vector3d &roll) {
 	glDisable(GL_BLEND);
 	glBlendFunc(GL_ONE, GL_ZERO);

--- a/engines/playground3d/gfx_opengl_shaders.cpp
+++ b/engines/playground3d/gfx_opengl_shaders.cpp
@@ -216,6 +216,15 @@ void ShaderRenderer::enableFog(const Math::Vector4d &fogColor) {
 void ShaderRenderer::disableFog() {
 }
 
+void ShaderRenderer::enableScissor(int x, int y, int width, int height) {
+	glScissor(x, y, width, height);
+	glEnable(GL_SCISSOR_TEST);
+}
+
+void ShaderRenderer::disableScissor() {
+	glDisable(GL_SCISSOR_TEST);
+}
+
 void ShaderRenderer::drawCube(const Math::Vector3d &pos, const Math::Vector3d &roll) {
 	glDisable(GL_BLEND);
 	glBlendFunc(GL_ONE, GL_ZERO);

--- a/engines/playground3d/gfx_opengl_shaders.h
+++ b/engines/playground3d/gfx_opengl_shaders.h
@@ -56,6 +56,7 @@ public:
 	void drawRgbaTexture() override;
 
 	void enableFog(const Math::Vector4d &fogColor) override;
+	void disableFog() override;
 
 private:
 	OpenGL::Shader *_cubeShader;

--- a/engines/playground3d/gfx_opengl_shaders.h
+++ b/engines/playground3d/gfx_opengl_shaders.h
@@ -58,6 +58,9 @@ public:
 	void enableFog(const Math::Vector4d &fogColor) override;
 	void disableFog() override;
 
+	void enableScissor(int x, int y, int width, int height) override;
+	void disableScissor() override;
+
 private:
 	OpenGL::Shader *_cubeShader;
 	OpenGL::Shader *_offsetShader;

--- a/engines/playground3d/gfx_tinygl.cpp
+++ b/engines/playground3d/gfx_tinygl.cpp
@@ -189,6 +189,10 @@ void TinyGLRenderer::enableFog(const Math::Vector4d &fogColor) {
 	tglEnable(TGL_FOG);
 }
 
+void TinyGLRenderer::disableFog() {
+	tglDisable(TGL_FOG);
+}
+
 void TinyGLRenderer::drawFace(uint face) {
 	tglBegin(TGL_TRIANGLE_STRIP);
 	for (uint i = 0; i < 4; i++) {

--- a/engines/playground3d/gfx_tinygl.cpp
+++ b/engines/playground3d/gfx_tinygl.cpp
@@ -193,6 +193,12 @@ void TinyGLRenderer::disableFog() {
 	tglDisable(TGL_FOG);
 }
 
+void TinyGLRenderer::enableScissor(int x, int y, int width, int height) {
+}
+
+void TinyGLRenderer::disableScissor() {
+}
+
 void TinyGLRenderer::drawFace(uint face) {
 	tglBegin(TGL_TRIANGLE_STRIP);
 	for (uint i = 0; i < 4; i++) {

--- a/engines/playground3d/gfx_tinygl.cpp
+++ b/engines/playground3d/gfx_tinygl.cpp
@@ -194,9 +194,12 @@ void TinyGLRenderer::disableFog() {
 }
 
 void TinyGLRenderer::enableScissor(int x, int y, int width, int height) {
+	tglScissor(x, y, width, height);
+	tglEnable(TGL_SCISSOR_TEST);
 }
 
 void TinyGLRenderer::disableScissor() {
+	tglDisable(TGL_SCISSOR_TEST);
 }
 
 void TinyGLRenderer::drawFace(uint face) {

--- a/engines/playground3d/gfx_tinygl.h
+++ b/engines/playground3d/gfx_tinygl.h
@@ -56,6 +56,7 @@ public:
 	void drawRgbaTexture() override;
 
 	void enableFog(const Math::Vector4d &fogColor) override;
+	void disableFog() override;
 
 	void flipBuffer() override;
 

--- a/engines/playground3d/gfx_tinygl.h
+++ b/engines/playground3d/gfx_tinygl.h
@@ -58,6 +58,9 @@ public:
 	void enableFog(const Math::Vector4d &fogColor) override;
 	void disableFog() override;
 
+	void enableScissor(int x, int y, int width, int height) override;
+	void disableScissor() override;
+
 	void flipBuffer() override;
 
 private:

--- a/engines/playground3d/metaengine.cpp
+++ b/engines/playground3d/metaengine.cpp
@@ -22,6 +22,11 @@
 #include "base/plugins.h"
 
 #include "common/system.h"
+#include "common/translation.h"
+
+#include "backends/keymapper/action.h"
+#include "backends/keymapper/keymapper.h"
+#include "backends/keymapper/standard-actions.h"
 
 #include "engines/advancedDetector.h"
 
@@ -40,6 +45,27 @@ public:
 
 	bool hasFeature(MetaEngineFeature f) const override {
 		return false;
+	}
+
+	Common::KeymapArray initKeymaps(const char *target) const override {
+		Common::Keymap *keymap = new Common::Keymap(Common::Keymap::kKeymapTypeGame, "playground3d", _("Default keymappings"));
+
+		Common::Action *act;
+
+		act = new Common::Action(Common::kStandardActionLeftClick, _("Switch test"));
+		act->setCustomEngineActionEvent(Playground3d::kActionSwitchTest);
+		act->addDefaultInputMapping("MOUSE_LEFT");
+		act->addDefaultInputMapping("JOY_A");
+		keymap->addAction(act);
+
+		act = new Common::Action("FOG", _("Enable/Disable fog"));
+		act->setCustomEngineActionEvent(Playground3d::kActionEnableFog);
+		act->addDefaultInputMapping("f");
+		act->addDefaultInputMapping("JOY_X");
+		keymap->addAction(act);
+
+		Common::KeymapArray keymaps = { keymap };
+		return keymaps;
 	}
 };
 

--- a/engines/playground3d/metaengine.cpp
+++ b/engines/playground3d/metaengine.cpp
@@ -64,6 +64,12 @@ public:
 		act->addDefaultInputMapping("JOY_X");
 		keymap->addAction(act);
 
+		act = new Common::Action("SCISSOR", _("Enable/Disable scissor"));
+		act->setCustomEngineActionEvent(Playground3d::kActionEnableScissor);
+		act->addDefaultInputMapping("s");
+		act->addDefaultInputMapping("JOY_Y");
+		keymap->addAction(act);
+
 		Common::KeymapArray keymaps = { keymap };
 		return keymaps;
 	}

--- a/engines/playground3d/playground3d.cpp
+++ b/engines/playground3d/playground3d.cpp
@@ -268,6 +268,8 @@ void Playground3dEngine::drawFrame(int id) {
 	Common::Rect vp = _gfx->viewport();
 	_gfx->setupViewport(vp.left, _system->getHeight() - vp.top - vp.height(), vp.width(), vp.height());
 
+	_gfx->disableFog();
+
 	switch (id) {
 		case 1:
 			if (_fogEnable) {

--- a/engines/playground3d/playground3d.cpp
+++ b/engines/playground3d/playground3d.cpp
@@ -157,7 +157,12 @@ void Playground3dEngine::processInput() {
 		if (event.type == Common::EVENT_SCREEN_CHANGED) {
 			_gfx->computeScreenViewport();
 		}
-		if (event.type == Common::EVENT_LBUTTONUP) {
+		if (event.type != Common::EVENT_CUSTOM_ENGINE_ACTION_START)	{
+			continue;
+		}
+
+		switch (event.customType) {
+		case kActionSwitchTest:
 			testId++;
 			if (testId > 5)
 				testId = 1;
@@ -186,6 +191,10 @@ void Playground3dEngine::processInput() {
 				default:
 					assert(false);
 			}
+			break;
+		case kActionEnableFog:
+			_fogEnable = !_fogEnable;
+			break;
 		}
 	}
 }

--- a/engines/playground3d/playground3d.cpp
+++ b/engines/playground3d/playground3d.cpp
@@ -78,7 +78,7 @@ Playground3dEngine::Playground3dEngine(OSystem *syst)
 		: Engine(syst), _system(syst), _gfx(nullptr), _frameLimiter(nullptr),
 		_rotateAngleX(0), _rotateAngleY(0), _rotateAngleZ(0), _fogEnable(false),
 		_clearColor(0.0f, 0.0f, 0.0f, 1.0f), _fogColor(0.0f, 0.0f, 0.0f, 1.0f),
-        _fade(1.0f), _fadeIn(false),
+		_fade(1.0f), _fadeIn(false), _scissorEnable(false),
 		_rgbaTexture(nullptr), _rgbTexture(nullptr), _rgb565Texture(nullptr),
 		_rgba5551Texture(nullptr), _rgba4444Texture(nullptr) {
 }
@@ -105,6 +105,7 @@ Common::Error Playground3dEngine::run() {
 	// 5 - drawing RGBA pattern texture to check endian correctness
 	testId = 1;
 	_fogEnable = false;
+	_scissorEnable = false;
 
 	if (_fogEnable) {
 		_fogColor = Math::Vector4d(1.0f, 1.0f, 1.0f, 1.0f);
@@ -195,6 +196,9 @@ void Playground3dEngine::processInput() {
 		case kActionEnableFog:
 			_fogEnable = !_fogEnable;
 			break;
+		case kActionEnableScissor:
+			_scissorEnable = !_scissorEnable;
+			break;
 		}
 	}
 }
@@ -277,6 +281,10 @@ void Playground3dEngine::drawFrame(int id) {
 	Common::Rect vp = _gfx->viewport();
 	_gfx->setupViewport(vp.left, _system->getHeight() - vp.top - vp.height(), vp.width(), vp.height());
 
+	if (_scissorEnable) {
+		_gfx->enableScissor(vp.left + vp.width() / 4, _system->getHeight() - vp.top - (vp.height() * 3) / 4, vp.width() / 2, vp.height() / 2);
+	}
+
 	_gfx->disableFog();
 
 	switch (id) {
@@ -306,6 +314,10 @@ void Playground3dEngine::drawFrame(int id) {
 			break;
 		default:
 			assert(false);
+	}
+
+	if (_scissorEnable) {
+		_gfx->disableScissor();
 	}
 
 	_gfx->flipBuffer();

--- a/engines/playground3d/playground3d.h
+++ b/engines/playground3d/playground3d.h
@@ -34,7 +34,8 @@ namespace Playground3d {
 
 enum Actions {
 	kActionSwitchTest,
-	kActionEnableFog
+	kActionEnableFog,
+	kActionEnableScissor
 };
 
 class Playground3dEngine : public Engine {
@@ -61,6 +62,7 @@ private:
 	float _fade;
 	bool _fadeIn;
 	bool _fogEnable;
+	bool _scissorEnable;
 	Graphics::Surface *_rgbaTexture;
 	Graphics::Surface *_rgbTexture;
 	Graphics::Surface *_rgb565Texture;

--- a/engines/playground3d/playground3d.h
+++ b/engines/playground3d/playground3d.h
@@ -32,6 +32,11 @@
 
 namespace Playground3d {
 
+enum Actions {
+	kActionSwitchTest,
+	kActionEnableFog
+};
+
 class Playground3dEngine : public Engine {
 public:
 	Playground3dEngine(OSystem *syst);

--- a/graphics/tinygl/api.cpp
+++ b/graphics/tinygl/api.cpp
@@ -464,6 +464,19 @@ void tglViewport(TGLint x, TGLint y, TGLsizei width, TGLsizei height) {
 	c->gl_add_op(p);
 }
 
+void tglScissor(TGLint x, TGLint y, TGLsizei width, TGLsizei height) {
+	TinyGL::GLContext *c = TinyGL::gl_get_context();
+	TinyGL::GLParam p[5];
+
+	p[0].op = TinyGL::OP_Scissor;
+	p[1].i = x;
+	p[2].i = y;
+	p[3].i = width;
+	p[4].i = height;
+
+	c->gl_add_op(p);
+}
+
 void tglFrustumf(TGLfloat left, TGLfloat right, TGLfloat bottom, TGLfloat top, TGLfloat nearv, TGLfloat farv) {
 	TinyGL::GLContext *c = TinyGL::gl_get_context();
 	TinyGL::GLParam p[7];

--- a/graphics/tinygl/get.cpp
+++ b/graphics/tinygl/get.cpp
@@ -672,9 +672,15 @@ void GLContext::gl_get_pname(TGLenum pname, union uglValue *data, eDataType &dat
 		dataType = kIntType;
 		break;
 	case TGL_SCISSOR_BOX:
-		// fall through
+		data->_int4[0] = scissor[0];
+		data->_int4[1] = scissor[1];
+		data->_int4[2] = scissor[2];
+		data->_int4[3] = scissor[3];
+		dataType = kInt4Type;
+		break;
 	case TGL_SCISSOR_TEST:
-		error("gl_get_pname: TGL_SCISSOR_x option not implemented");
+		data->_int = (TGLint)scissor_test_enabled;
+		dataType = kIntType;
 		break;
 	case TGL_SELECTION_BUFFER_SIZE:
 		error("gl_get_pname: TGL_SELECTION_BUFFER_SIZE option not implemented");

--- a/graphics/tinygl/init.cpp
+++ b/graphics/tinygl/init.cpp
@@ -357,8 +357,6 @@ void GLContext::init(int screenW, int screenH, Graphics::PixelFormat pixelFormat
 	_drawCallAllocator[1].initialize(drawCallMemorySize);
 	_debugRectsEnabled = false;
 	_profilingEnabled = false;
-
-	TinyGL::Internal::tglBlitResetScissorRect();
 }
 
 void GLContext::deinit() {

--- a/graphics/tinygl/init.cpp
+++ b/graphics/tinygl/init.cpp
@@ -265,6 +265,12 @@ void GLContext::init(int screenW, int screenH, Graphics::PixelFormat pixelFormat
 	current_shade_model = TGL_SMOOTH;
 	cull_face_enabled = 0;
 
+	// scissor
+	scissor_test_enabled = false;
+	scissor[0] = scissor[1] = 0;
+	scissor[2] = screenW;
+	scissor[3] = screenH;
+
 	// fog
 	fog_enabled = false;
 	fog_mode = TGL_EXP;

--- a/graphics/tinygl/misc.cpp
+++ b/graphics/tinygl/misc.cpp
@@ -64,6 +64,13 @@ void GLContext::glopViewport(GLParam *p) {
 	}
 }
 
+void GLContext::glopScissor(GLParam *p) {
+	scissor[0] = p[1].i;
+	scissor[1] = p[2].i;
+	scissor[2] = p[3].i;
+	scissor[3] = p[4].i;
+}
+
 void GLContext::glopEnableDisable(GLParam *p) {
 	int code = p[1].i;
 	int v = p[2].i;
@@ -98,6 +105,9 @@ void GLContext::glopEnableDisable(GLParam *p) {
 		break;
 	case TGL_STENCIL_TEST:
 		stencil_test_enabled = v != 0;
+		break;
+	case TGL_SCISSOR_TEST:
+		scissor_test_enabled = v != 0;
 		break;
 	case TGL_BLEND:
 		blending_enabled = v != 0;

--- a/graphics/tinygl/opinfo.h
+++ b/graphics/tinygl/opinfo.h
@@ -48,6 +48,7 @@ ADD_OP(Translate, 3, "%f %f %f")
 ADD_OP(Scale, 3, "%f %f %f")
 ADD_OP(Ortho, 6, "%f %f %f %f %f %f")
 
+ADD_OP(Scissor, 4, "%d %d %d %d")
 ADD_OP(Viewport, 4, "%d %d %d %d")
 ADD_OP(Frustum, 6, "%f %f %f %f %f %f")
 

--- a/graphics/tinygl/zblit.cpp
+++ b/graphics/tinygl/zblit.cpp
@@ -174,37 +174,39 @@ public:
 			height = srcHeight;
 		}
 
-		if (dstX >= c->_scissorRect.right || dstY >= c->_scissorRect.bottom)
+		const Common::Rect &clippingRect = c->fb->getClippingRectangle();
+
+		if (dstX >= clippingRect.right || dstY >= clippingRect.bottom)
 			return false;
 
-		if (dstX + width < c->_scissorRect.left || dstY + height < c->_scissorRect.top) {
+		if (dstX + width < clippingRect.left || dstY + height < clippingRect.top) {
 			return false;
 		}
 
-		if (dstX < c->_scissorRect.left) {
-			srcX += (c->_scissorRect.left - dstX);
-			width -= (c->_scissorRect.left - dstX);
-			dstX = c->_scissorRect.left;
+		if (dstX < clippingRect.left) {
+			srcX += (clippingRect.left - dstX);
+			width -= (clippingRect.left - dstX);
+			dstX = clippingRect.left;
 		}
 
-		if (dstY < c->_scissorRect.top) {
-			srcY += (c->_scissorRect.top - dstY);
-			height -= (c->_scissorRect.top - dstY);
-			dstY = c->_scissorRect.top;
+		if (dstY < clippingRect.top) {
+			srcY += (clippingRect.top - dstY);
+			height -= (clippingRect.top - dstY);
+			dstY = clippingRect.top;
 		}
 
 		if (width < 0 || height < 0) {
 			return false;
 		}
 
-		if (dstX + width >= c->_scissorRect.right) {
-			clampWidth = c->_scissorRect.right - dstX;
+		if (dstX + width >= clippingRect.right) {
+			clampWidth = clippingRect.right - dstX;
 		} else {
 			clampWidth = width;
 		}
 
-		if (dstY + height >= c->_scissorRect.bottom) {
-			clampHeight = c->_scissorRect.bottom - dstY;
+		if (dstY + height >= clippingRect.bottom) {
+			clampHeight = clippingRect.bottom - dstY;
 		} else {
 			clampHeight = height;
 		}
@@ -804,15 +806,6 @@ void tglCleanupImages() {
 			++it;
 		}
 	}
-}
-
-void tglBlitSetScissorRect(const Common::Rect &rect) {
-	gl_get_context()->_scissorRect = rect;
-}
-
-void tglBlitResetScissorRect() {
-	GLContext *c = gl_get_context();
-	c->_scissorRect = c->renderRect;
 }
 
 } // end of namespace Internal

--- a/graphics/tinygl/zblit.h
+++ b/graphics/tinygl/zblit.h
@@ -45,11 +45,6 @@ namespace Internal {
 
 	void tglBlitZBuffer(BlitImage *blitImage, int x, int y);
 
-	/**
-	@brief Sets up a scissor rectangle for blit calls: every blit call is affected by this rectangle.
-	*/
-	void tglBlitSetScissorRect(const Common::Rect &rect);
-	void tglBlitResetScissorRect();
 } // end of namespace Internal
 
 } // end of namespace TinyGL

--- a/graphics/tinygl/zbuffer.cpp
+++ b/graphics/tinygl/zbuffer.cpp
@@ -55,7 +55,7 @@ FrameBuffer::FrameBuffer(int width, int height, const Graphics::PixelFormat &for
 
 	_currentTexture = nullptr;
 
-	_enableScissor = false;
+	_clippingEnabled = false;
 }
 
 FrameBuffer::~FrameBuffer() {

--- a/graphics/tinygl/zbuffer.cpp
+++ b/graphics/tinygl/zbuffer.cpp
@@ -80,6 +80,12 @@ void FrameBuffer::delOffscreenBuffer(Buffer *buf) {
 
 void FrameBuffer::clear(int clearZ, int z, int clearColor, int r, int g, int b,
                         bool clearStencil, int stencilValue) {
+	if (_clippingEnabled) {
+		clearRegion(_clipRectangle.left, _clipRectangle.top,
+				_clipRectangle.width(), _clipRectangle.height(),
+				clearZ, z, clearColor, r, g, b, clearStencil, stencilValue);
+		return;
+	}
 	if (clearZ) {
 		const uint8 *zc = (const uint8 *)&z;
 		uint i;

--- a/graphics/tinygl/zbuffer.h
+++ b/graphics/tinygl/zbuffer.h
@@ -569,13 +569,22 @@ public:
 	void clearRegion(int x, int y, int w, int h, bool clearZ, int z,
 	                 bool clearColor, int r, int g, int b, bool clearStencil, int stencilValue);
 
-	void setScissorRectangle(const Common::Rect &rect) {
+	void setClippingRectangle(const Common::Rect &rect) {
 		_clipRectangle = rect;
-		_enableScissor = true;
+		_clippingEnabled = true;
 	}
 
-	void resetScissorRectangle() {
-		_enableScissor = false;
+	void resetClippingRectangle() {
+		_clippingEnabled = false;
+		// Mark it as invalid to fix it when it is fetched
+		_clipRectangle.left = -1;
+	}
+
+	Common::Rect &getClippingRectangle() {
+		if (!_clippingEnabled && _clipRectangle.left != 0) {
+			_clipRectangle = Common::Rect(0, 0, _pbufWidth, _pbufHeight);
+		}
+		return _clipRectangle;
 	}
 
 	void enableBlending(bool enable) {
@@ -770,7 +779,7 @@ private:
 	int _textureSizeMask;
 
 	Common::Rect _clipRectangle;
-	bool _enableScissor;
+	bool _clippingEnabled;
 
 	const TexelBuffer *_currentTexture;
 	uint _wrapS, _wrapT;

--- a/graphics/tinygl/zbuffer.h
+++ b/graphics/tinygl/zbuffer.h
@@ -569,22 +569,32 @@ public:
 	void clearRegion(int x, int y, int w, int h, bool clearZ, int z,
 	                 bool clearColor, int r, int g, int b, bool clearStencil, int stencilValue);
 
-	void setClippingRectangle(const Common::Rect &rect) {
-		_clipRectangle = rect;
-		_clippingEnabled = true;
+	const Common::Rect &getClippingRectangle() const {
+		return _clipRectangle;
 	}
 
-	void resetClippingRectangle() {
-		_clippingEnabled = false;
-		// Mark it as invalid to fix it when it is fetched
-		_clipRectangle.left = -1;
-	}
+	void setupScissor(bool enable, const int (&scissor)[4], const Common::Rect *clippingRectangle) {
+		_clippingEnabled = enable || clippingRectangle;
 
-	Common::Rect &getClippingRectangle() {
-		if (!_clippingEnabled && _clipRectangle.left != 0) {
+		if (enable && clippingRectangle) {
+			_clipRectangle = clippingRectangle->findIntersectingRect(Common::Rect(
+					scissor[0],
+					// all viewport calculations are already flipped upside down
+					_pbufHeight - scissor[1] - scissor[3],
+					scissor[0] + scissor[2],
+					_pbufHeight - scissor[1]));
+		} else if (enable) {
+			_clipRectangle = Common::Rect(
+					scissor[0],
+					// all viewport calculations are already flipped upside down
+					_pbufHeight - scissor[1] - scissor[3],
+					scissor[0] + scissor[2],
+					_pbufHeight - scissor[1]);
+		} else if (clippingRectangle) {
+			_clipRectangle = *clippingRectangle;
+		} else {
 			_clipRectangle = Common::Rect(0, 0, _pbufWidth, _pbufHeight);
 		}
-		return _clipRectangle;
 	}
 
 	void enableBlending(bool enable) {

--- a/graphics/tinygl/zdirtyrect.cpp
+++ b/graphics/tinygl/zdirtyrect.cpp
@@ -548,9 +548,9 @@ void RasterizationDrawCall::applyState(const RasterizationDrawCall::Rasterizatio
 
 void RasterizationDrawCall::execute(const Common::Rect &clippingRectangle, bool restoreState) const {
 	TinyGL::GLContext *c = gl_get_context();
-	c->fb->setScissorRectangle(clippingRectangle);
+	c->fb->setClippingRectangle(clippingRectangle);
 	execute(restoreState);
-	c->fb->resetScissorRectangle();
+	c->fb->resetClippingRectangle();
 }
 
 bool RasterizationDrawCall::operator==(const RasterizationDrawCall &other) const {
@@ -608,9 +608,10 @@ void BlittingDrawCall::execute(bool restoreState) const {
 }
 
 void BlittingDrawCall::execute(const Common::Rect &clippingRectangle, bool restoreState) const {
-	Internal::tglBlitSetScissorRect(clippingRectangle);
+	TinyGL::GLContext *c = gl_get_context();
+	c->fb->setClippingRectangle(clippingRectangle);
 	execute(restoreState);
-	Internal::tglBlitResetScissorRect();
+	c->fb->resetClippingRectangle();
 }
 
 BlittingDrawCall::BlittingState BlittingDrawCall::captureState() const {

--- a/graphics/tinygl/zdirtyrect.cpp
+++ b/graphics/tinygl/zdirtyrect.cpp
@@ -196,7 +196,7 @@ void GLContext::presentBufferDirtyRects(Common::List<Common::Rect> &dirtyAreas) 
 			for (auto &rect : rectangles) {
 				Common::Rect dirtyRegion = rect.rectangle;
 				if (dirtyRegion.intersects(drawCallRegion)) {
-					drawCall->execute(dirtyRegion, true);
+					drawCall->execute(true, &dirtyRegion);
 				}
 			}
 		}
@@ -329,14 +329,14 @@ void RasterizationDrawCall::computeDirtyRegion() {
 	}
 }
 
-void RasterizationDrawCall::execute(bool restoreState) const {
+void RasterizationDrawCall::execute(bool restoreState, const Common::Rect *clippingRectangle) const {
 	GLContext *c = gl_get_context();
 
 	RasterizationDrawCall::RasterizationState backupState;
 	if (restoreState) {
 		backupState = captureState();
 	}
-	applyState(_state);
+	applyState(_state, clippingRectangle);
 
 	GLVertex *prevVertex = c->vertex;
 	int prevVertexCount = c->vertex_cnt;
@@ -425,13 +425,14 @@ void RasterizationDrawCall::execute(bool restoreState) const {
 	c->vertex_cnt = prevVertexCount;
 
 	if (restoreState) {
-		applyState(backupState);
+		applyState(backupState, nullptr);
 	}
 }
 
 RasterizationDrawCall::RasterizationState RasterizationDrawCall::captureState() const {
 	RasterizationState state;
 	GLContext *c = gl_get_context();
+	state.enableScissor = c->scissor_test_enabled;
 	state.enableBlending = c->blending_enabled;
 	state.sfactor = c->source_blending_factor;
 	state.dfactor = c->destination_blending_factor;
@@ -475,6 +476,7 @@ RasterizationDrawCall::RasterizationState RasterizationDrawCall::captureState() 
 	state.fogColorG = c->fog_color.Y;
 	state.fogColorB = c->fog_color.Z;
 
+	memcpy(state.scissor, c->scissor, sizeof(state.scissor));
 	memcpy(state.viewportScaling, c->viewport.scale._v, sizeof(c->viewport.scale._v));
 	memcpy(state.viewportTranslation, c->viewport.trans._v, sizeof(c->viewport.trans._v));
 	memcpy(state.polygonStipplePattern, c->polygon_stipple_pattern, sizeof(c->polygon_stipple_pattern));
@@ -482,8 +484,9 @@ RasterizationDrawCall::RasterizationState RasterizationDrawCall::captureState() 
 	return state;
 }
 
-void RasterizationDrawCall::applyState(const RasterizationDrawCall::RasterizationState &state) const {
+void RasterizationDrawCall::applyState(const RasterizationDrawCall::RasterizationState &state, const Common::Rect *clippingRectangle) const {
 	GLContext *c = gl_get_context();
+	c->fb->setupScissor(state.enableScissor, state.scissor, clippingRectangle);
 	c->fb->enableBlending(state.enableBlending);
 	c->fb->setBlendingFactors(state.sfactor, state.dfactor);
 	c->fb->enableAlphaTest(state.alphaTestEnabled);
@@ -503,6 +506,7 @@ void RasterizationDrawCall::applyState(const RasterizationDrawCall::Rasterizatio
 	c->fb->setPolygonStipplePattern(state.polygonStipplePattern);
 	c->fb->enablePolygonStipple(state.polygonStippleEnabled);
 
+	c->scissor_test_enabled = state.enableScissor;
 	c->blending_enabled = state.enableBlending;
 	c->source_blending_factor = state.sfactor;
 	c->destination_blending_factor = state.dfactor;
@@ -542,15 +546,9 @@ void RasterizationDrawCall::applyState(const RasterizationDrawCall::Rasterizatio
 	c->fog_enabled = state.fogEnabled;
 	c->fog_color = Vector4(state.fogColorR, state.fogColorG, state.fogColorB, 1.0f);
 
+	memcpy(c->scissor, state.scissor, sizeof(c->scissor));
 	memcpy(c->viewport.scale._v, state.viewportScaling, sizeof(c->viewport.scale._v));
 	memcpy(c->viewport.trans._v, state.viewportTranslation, sizeof(c->viewport.trans._v));
-}
-
-void RasterizationDrawCall::execute(const Common::Rect &clippingRectangle, bool restoreState) const {
-	TinyGL::GLContext *c = gl_get_context();
-	c->fb->setClippingRectangle(clippingRectangle);
-	execute(restoreState);
-	c->fb->resetClippingRectangle();
 }
 
 bool RasterizationDrawCall::operator==(const RasterizationDrawCall &other) const {
@@ -582,12 +580,12 @@ BlittingDrawCall::~BlittingDrawCall() {
 	tglDeleteBlitImage(_image);
 }
 
-void BlittingDrawCall::execute(bool restoreState) const {
+void BlittingDrawCall::execute(bool restoreState, const Common::Rect *clippingRectangle) const {
 	BlittingState backupState;
 	if (restoreState) {
 		backupState = captureState();
 	}
-	applyState(_blitState);
+	applyState(_blitState, clippingRectangle);
 
 	switch (_mode) {
 	case BlittingDrawCall::BlitMode_Regular:
@@ -603,20 +601,14 @@ void BlittingDrawCall::execute(bool restoreState) const {
 		break;
 	}
 	if (restoreState) {
-		applyState(backupState);
+		applyState(backupState, nullptr);
 	}
-}
-
-void BlittingDrawCall::execute(const Common::Rect &clippingRectangle, bool restoreState) const {
-	TinyGL::GLContext *c = gl_get_context();
-	c->fb->setClippingRectangle(clippingRectangle);
-	execute(restoreState);
-	c->fb->resetClippingRectangle();
 }
 
 BlittingDrawCall::BlittingState BlittingDrawCall::captureState() const {
 	BlittingState state;
 	TinyGL::GLContext *c = gl_get_context();
+	state.enableScissor = c->scissor_test_enabled;
 	state.enableBlending = c->blending_enabled;
 	state.sfactor = c->source_blending_factor;
 	state.dfactor = c->destination_blending_factor;
@@ -624,17 +616,21 @@ BlittingDrawCall::BlittingState BlittingDrawCall::captureState() const {
 	state.alphaFunc = c->alpha_test_func;
 	state.alphaRefValue = c->alpha_test_ref_val;
 	state.depthTestEnabled = c->depth_test_enabled;
+
+	memcpy(state.scissor, c->scissor, sizeof(state.scissor));
 	return state;
 }
 
-void BlittingDrawCall::applyState(const BlittingState &state) const {
+void BlittingDrawCall::applyState(const BlittingState &state, const Common::Rect *clippingRectangle) const {
 	TinyGL::GLContext *c = gl_get_context();
+	c->fb->setupScissor(state.enableScissor, state.scissor, clippingRectangle);
 	c->fb->enableBlending(state.enableBlending);
 	c->fb->setBlendingFactors(state.sfactor, state.dfactor);
 	c->fb->enableAlphaTest(state.alphaTest);
 	c->fb->setAlphaTestFunc(state.alphaFunc, state.alphaRefValue);
 	c->fb->enableDepthTest(state.depthTestEnabled);
 
+	c->scissor_test_enabled = state.enableScissor;
 	c->blending_enabled = state.enableBlending;
 	c->source_blending_factor = state.sfactor;
 	c->destination_blending_factor = state.dfactor;
@@ -642,6 +638,8 @@ void BlittingDrawCall::applyState(const BlittingState &state) const {
 	c->alpha_test_func = state.alphaFunc;
 	c->alpha_test_ref_val = state.alphaRefValue;
 	c->depth_test_enabled = state.depthTestEnabled;
+
+	memcpy(c->scissor, state.scissor, sizeof(c->scissor));
 }
 
 void BlittingDrawCall::computeDirtyRegion() {
@@ -690,23 +688,42 @@ ClearBufferDrawCall::ClearBufferDrawCall(bool clearZBuffer, int zValue,
 	: _clearZBuffer(clearZBuffer), _clearColorBuffer(clearColorBuffer), _zValue(zValue),
 	  _rValue(rValue), _gValue(gValue), _bValue(bValue), _clearStencilBuffer(clearStencilBuffer),
 	  _stencilValue(stencilValue), DrawCall(DrawCall_Clear) {
+	_clearState = captureState();
 	TinyGL::GLContext *c = gl_get_context();
 	if (c->_enableDirtyRectangles) {
 		_dirtyRegion = c->renderRect;
 	}
 }
 
-void ClearBufferDrawCall::execute(bool restoreState) const {
+void ClearBufferDrawCall::execute(bool restoreState, const Common::Rect *clippingRectangle) const {
+	ClearBufferState backupState;
+	if (restoreState) {
+		backupState = captureState();
+	}
+	applyState(_clearState, clippingRectangle);
+
 	TinyGL::GLContext *c = gl_get_context();
 	c->fb->clear(_clearZBuffer, _zValue, _clearColorBuffer, _rValue, _gValue, _bValue, _clearStencilBuffer, _stencilValue);
+
+	if (restoreState) {
+		applyState(backupState, nullptr);
+	}
 }
 
-void ClearBufferDrawCall::execute(const Common::Rect &clippingRectangle, bool restoreState) const {
+ClearBufferDrawCall::ClearBufferState ClearBufferDrawCall::captureState() const {
+	ClearBufferState state;
 	TinyGL::GLContext *c = gl_get_context();
-	Common::Rect clearRect = clippingRectangle.findIntersectingRect(getDirtyRegion());
-	c->fb->clearRegion(clearRect.left, clearRect.top, clearRect.width(), clearRect.height(),
-	                   _clearZBuffer, _zValue, _clearColorBuffer, _rValue, _gValue, _bValue,
-	                   _clearStencilBuffer, _stencilValue);
+	state.enableScissor = c->scissor_test_enabled;
+	memcpy(state.scissor, c->scissor, sizeof(state.scissor));
+	return state;
+}
+
+void ClearBufferDrawCall::applyState(const ClearBufferState &state, const Common::Rect *clippingRectangle) const {
+	TinyGL::GLContext *c = gl_get_context();
+	c->fb->setupScissor(state.enableScissor, state.scissor, clippingRectangle);
+
+	c->scissor_test_enabled = state.enableScissor;
+	memcpy(c->scissor, state.scissor, sizeof(c->scissor));
 }
 
 bool ClearBufferDrawCall::operator==(const ClearBufferDrawCall &other) const {
@@ -718,12 +735,14 @@ bool ClearBufferDrawCall::operator==(const ClearBufferDrawCall &other) const {
 		_gValue == other._gValue &&
 		_bValue == other._bValue &&
 		_zValue == other._zValue &&
-		_stencilValue == other._stencilValue;
+		_stencilValue == other._stencilValue &&
+		_clearState == other._clearState;
 }
 
 
 bool RasterizationDrawCall::RasterizationState::operator==(const RasterizationState &other) const {
 	return
+		enableScissor == other.enableScissor &&
 		enableBlending == other.enableBlending &&
 		sfactor == other.sfactor &&
 		dfactor == other.dfactor &&
@@ -762,6 +781,10 @@ bool RasterizationDrawCall::RasterizationState::operator==(const RasterizationSt
 		fogColorR == other.fogColorR &&
 		fogColorG == other.fogColorG &&
 		fogColorB == other.fogColorB &&
+		scissor[0] == other.scissor[0] &&
+		scissor[1] == other.scissor[1] &&
+		scissor[2] == other.scissor[2] &&
+		scissor[3] == other.scissor[3] &&
 		viewportTranslation[0] == other.viewportTranslation[0] &&
 		viewportTranslation[1] == other.viewportTranslation[1] &&
 		viewportTranslation[2] == other.viewportTranslation[2] &&

--- a/graphics/tinygl/zgl.h
+++ b/graphics/tinygl/zgl.h
@@ -285,6 +285,10 @@ struct GLContext {
 	FrameBuffer *fb;
 	Common::Rect renderRect;
 
+	// scissor
+	bool scissor_test_enabled;
+	int scissor[4];
+
 	// blending
 	bool blending_enabled;
 	int source_blending_factor;

--- a/graphics/tinygl/zgl.h
+++ b/graphics/tinygl/zgl.h
@@ -448,8 +448,6 @@ struct GLContext {
 	float fog_start;
 	float fog_end;
 
-	Common::Rect _scissorRect;
-
 	bool _enableDirtyRectangles;
 
 	// stipple

--- a/graphics/tinygl/zline.cpp
+++ b/graphics/tinygl/zline.cpp
@@ -31,7 +31,7 @@ namespace TinyGL {
 
 template <bool kDepthWrite>
 FORCEINLINE void FrameBuffer::putPixel(uint pixelOffset, int color, int x, int y, uint z) {
-	if (_enableScissor)
+	if (_clippingEnabled)
 		putPixel<kDepthWrite, true>(pixelOffset, color, x, y, z);
 	else
 		putPixel<kDepthWrite, false>(pixelOffset, color, x, y, z);
@@ -58,7 +58,7 @@ FORCEINLINE void FrameBuffer::putPixel(uint pixelOffset, int color, int x, int y
 
 template <bool kInterpRGB, bool kInterpZ, bool kDepthWrite>
 void FrameBuffer::drawLine(const ZBufferPoint *p1, const ZBufferPoint *p2) {
-	if (_enableScissor)
+	if (_clippingEnabled)
 		drawLine<kInterpRGB, kInterpZ, kDepthWrite, true>(p1, p2);
 	else
 		drawLine<kInterpRGB, kInterpZ, kDepthWrite, false>(p1, p2);

--- a/graphics/tinygl/ztriangle.cpp
+++ b/graphics/tinygl/ztriangle.cpp
@@ -51,18 +51,18 @@ void FrameBuffer::putPixelNoTexture(int fbOffset, uint *pz, byte *ps, int _a,
                                     int &dzdx, int &drdx, int &dgdx, int &dbdx, uint dadx,
                                     uint &fog, int fog_r, int fog_g, int fog_b, int &dfdx) {
 	if (kEnableScissor && scissorPixel(x + _a, y)) {
-		return;
+		goto end;
 	}
 
 	if (kStippleEnabled && !applyStipplePattern(x + _a, y, _polygonStipplePattern)) {
-		return;
+		goto end;
 	}
 
 	if (kStencilEnabled) {
 		bool stencilResult = stencilTest(ps[_a]);
 		if (!stencilResult) {
 			stencilOp(false, true, ps + _a);
-			return;
+			goto end;
 		}
 	}
 	bool depthTestResult;
@@ -79,6 +79,7 @@ void FrameBuffer::putPixelNoTexture(int fbOffset, uint *pz, byte *ps, int _a,
 		          (fbOffset + _a, a >> (ZB_POINT_ALPHA_BITS - 8), r >> (ZB_POINT_RED_BITS - 8), g >> (ZB_POINT_GREEN_BITS - 8), b >> (ZB_POINT_BLUE_BITS - 8),
 		          z, fog, fog_r, fog_g, fog_b);
 	}
+end:
 	z += dzdx;
 	if (kFogMode) {
 		fog += dfdx;
@@ -99,14 +100,14 @@ void FrameBuffer::putPixelTexture(int fbOffset, const TexelBuffer *texture,
                                   int &dzdx, int &dsdx, int &dtdx, int &drdx, int &dgdx, int &dbdx, uint dadx,
                                   uint &fog, int fog_r, int fog_g, int fog_b, int &dfdx) {
 	if (kEnableScissor && scissorPixel(x + _a, y)) {
-		return;
+		goto end;
 	}
 
 	if (kStencilEnabled) {
 		bool stencilResult = stencilTest(ps[_a]);
 		if (!stencilResult) {
 			stencilOp(false, true, ps + _a);
-			return;
+			goto end;
 		}
 	}
 	bool depthTestResult;
@@ -133,6 +134,7 @@ void FrameBuffer::putPixelTexture(int fbOffset, const TexelBuffer *texture,
 		}
 		writePixel<kEnableAlphaTest, kEnableBlending, kDepthWrite, kFogMode>(fbOffset + _a, c_a, c_r, c_g, c_b, z, fog, fog_r, fog_g, fog_b);
 	}
+end:
 	z += dzdx;
 	s += dsdx;
 	t += dtdx;
@@ -150,7 +152,7 @@ void FrameBuffer::putPixelTexture(int fbOffset, const TexelBuffer *texture,
 template <bool kDepthWrite, bool kEnableScissor, bool kStencilEnabled, bool kStippleEnabled, bool kDepthTestEnabled>
 void FrameBuffer::putPixelDepth(uint *pz, byte *ps, int _a, int x, int y, uint &z, int &dzdx) {
 	if (kEnableScissor && scissorPixel(x + _a, y)) {
-		return;
+		goto end;
 	}
 
 	/*if (kStippleEnabled && !applyStipplePattern(x + _a, y, _polygonStipplePattern)) {
@@ -161,7 +163,7 @@ void FrameBuffer::putPixelDepth(uint *pz, byte *ps, int _a, int x, int y, uint &
 		bool stencilResult = stencilTest(ps[_a]);
 		if (!stencilResult) {
 			stencilOp(false, true, ps + _a);
-			return;
+			goto end;
 		}
 	}
 	bool depthTestResult;
@@ -176,6 +178,7 @@ void FrameBuffer::putPixelDepth(uint *pz, byte *ps, int _a, int x, int y, uint &
 	if (kDepthWrite && depthTestResult) {
 		pz[_a] = z;
 	}
+end:
 	z += dzdx;
 }
 

--- a/graphics/tinygl/ztriangle.cpp
+++ b/graphics/tinygl/ztriangle.cpp
@@ -720,7 +720,7 @@ void FrameBuffer::fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint 
 
 template <bool kInterpRGB, bool kInterpZ, bool kInterpST, bool kInterpSTZ, bool kSmoothMode, bool kDepthWrite, bool kFogMode, bool kEnableAlphaTest>
 void FrameBuffer::fillTriangle(ZBufferPoint *p0, ZBufferPoint *p1, ZBufferPoint *p2) {
-	if (_enableScissor) {
+	if (_clippingEnabled) {
 		fillTriangle<kInterpRGB, kInterpZ, kInterpST, kInterpSTZ, kSmoothMode, kDepthWrite, kFogMode, kEnableAlphaTest, true>(p0, p1, p2);
 	} else {
 		fillTriangle<kInterpRGB, kInterpZ, kInterpST, kInterpSTZ, kSmoothMode, kDepthWrite, kFogMode, kEnableAlphaTest, false>(p0, p1, p2);


### PR DESCRIPTION
This is a followup of #6412.

I implemented a test case in Playground3D (after enabling the keymapper for all tests) and, then, I managed to merge the already in-place clipping with the missing pieces to have a working scissor test.

Finally, a bug is fixed in the various pixel writing function where the update of the z, fog and color was not done.

@neuromancer you may want to test this with Freescape.