### PR TITLE
SCUMM: Fix encoding of some message dialogs with `original_gui=false`

### DIFF
--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -162,7 +162,7 @@ void ScummEngine::showMessageDialog(const byte *msg) {
 		else
 			VAR(VAR_KEYPRESS) = showOldStyleBannerAndPause((const char *)msg, _string[3].color, -1).ascii;
 	} else {
-		InfoDialog dialog(this, Common::U32String((char *)buf));
+		InfoDialog dialog(this, Common::U32String((char *)buf, getDialogCodePage()));
 		VAR(VAR_KEYPRESS) = runDialog(dialog);
 	}
 


### PR DESCRIPTION
This fixes Ctrl-V output with French DOTT, when using `original_gui=false`. The `ç` character was not displayed at all, when using ScummVM's own UI for dialogs.

The `original_gui=true` code path is OK, because it calls `queryResString()`, which takes care of calling `getDialogCodePage()`.

But the `original_gui=false` code path never calls `queryResString()`/`getDialogCodePage()` and so the proper code page decoding was not applied.

I'm not sure this fix is enough, though: maybe the `original_gui=false` path would need more of that stuff being done in the last parts of `queryResString()`? It's not a part I know very well…