### PR TITLE
SCI: Fix King's Quest IV demo crash

### DIFF
--- a/engines/sci/engine/script_patches.cpp
+++ b/engines/sci/engine/script_patches.cpp
@@ -5730,7 +5730,7 @@ static const SciScriptPatcherEntry kq4Signatures[] = {
 	{  true,    99, "fix speed test overflow",                     1, sci0SpeedTestOverflowSignature,           sci0SpeedTestOverflowPatch },
 	{  true,   994, "restore fix",                                 1, kq4SignatureRestoreFix1,                  kq4PatchRestoreFix1 },
 	{  true,   994, "restore fix",                                 1, kq4SignatureRestoreFix2,                  kq4PatchRestoreFix2 },
-	{  true,   994, "ride unicorn at night",                       1, kq4SignatureUnicornNightRide,             kq4PatchUnicornNightRide },
+	{  false,  994, "ride unicorn at night",                       1, kq4SignatureUnicornNightRide,             kq4PatchUnicornNightRide },
 	SCI_SIGNATUREENTRY_TERMINATOR
 };
 
@@ -26426,6 +26426,9 @@ void ScriptPatcher::processScript(uint16 scriptNr, SciSpan<byte> scriptData) {
 			case GID_KQ4:
 				if (!g_sci->getResMan()->testResource(ResourceId(kResourceTypeView, 653))) {
 					enablePatch(signatureTable, "missing waterfall view");
+				}
+				if (!g_sci->isDemo()) {
+					enablePatch(signatureTable, "ride unicorn at night");
 				}
 				break;
 			case GID_KQ5:


### PR DESCRIPTION
It was reported in https://forums.scummvm.org/viewtopic.php?t=17338 that the King's Quest IV demo (which can be found on the ScummVM demos page) crashes with the following messages:

```
User picked target 'kq4sci-demo' (engine ID 'sci', game ID 'kq4sci')...
Running King's Quest IV: The Perils of Rosella (SCI/Demo/DOS/English)
resource.001: 143e1c14f15ad0fbfc714f648a65f661, 205330 bytes.
resource.map: 992ac7cc31d3717fe53818a9bb6d1dae, 594 bytes.
WARNING: No selector vocabulary found, using a static one!
[kq4sci-demo-ego 699/994 Room699::<noname268> @ 0a11]: Send to invalid selector 0xffff (<noname65535>) of object at 0014:0170!
Debugger started, type 'exit' to return to the game.
Type 'help' to see a little list of commands and variables.
ERROR: [kq4sci-demo-ego 699/994 Room699::<noname268> @ 0a11]: Send to invalid selector 0xffff (<noname65535>) of object at 0014:0170!
```

Bisecting pointed to the "ride unicorn at night" patch. I suspect it has something to do with the "No selector vocabulary found" warning, but that's way beyond my knowledge of SCI. So this pull request simply disables the unicorn patch for the demo. To me that seems like the simplest, most elegant solution.

Note that I have not played the full game to verify that riding the unicorn at night still work as intended. I haven't played this game for many years (before ScummVM supported it), and from a quick glance at a walkthrough it seems I would have to play a substantial part of it to test this? So this should not be merged blindly. I just wanted to make sure that the bug doesn't get lost.

(I could have filed a bug report instead, but how often do I get to make pull requests for the SCI engine, and how cool is that? ;-)