### PR TITLE
VIDEO: Fix audio lag and delayed playback start in MPEG videos

### DIFF
--- a/engines/qdengine/qdcore/util/WinVideo.cpp
+++ b/engines/qdengine/qdcore/util/WinVideo.cpp
@@ -87,6 +87,14 @@ bool winVideo::open_file(const Common::Path &fname) {
 		return false;
 	}
 
+	// WORKAROUND: Fix lagging audio in mng and rybalka
+	// videos by setting specific number of prebuffered packets
+	// for MPEG-PS demuxer.
+	Common::String gameId = g_engine->getGameId();
+	if (gameId == "mng" || gameId == "rybalka") {
+		_decoder->setPrebufferedPackets(600);
+	}
+
 	if (!_decoder->loadStream(_videostream)) {
 		warning("WinVideo::open: Failed to Load Stream for file '%s'", filename.c_str());
 		_videostream = nullptr;

--- a/video/mpegps_decoder.cpp
+++ b/video/mpegps_decoder.cpp
@@ -78,6 +78,10 @@ bool MPEGPSDecoder::loadStream(Common::SeekableReadStream *stream) {
 	return true;
 }
 
+void MPEGPSDecoder::setPrebufferedPackets(int packets) {
+	_demuxer->setPrebufferedPackets(packets);
+}
+
 void MPEGPSDecoder::close() {
 	VideoDecoder::close();
 	_demuxer->close();
@@ -248,7 +252,6 @@ MPEGPSDecoder::PrivateStreamType MPEGPSDecoder::detectPrivateStreamType(Common::
 // should start slightly before the video.
 // --------------------------------------------------------------------------
 
-#define PREBUFFERED_PACKETS 150
 #define AUDIO_THRESHOLD     100
 
 MPEGPSDecoder::MPEGPSDemuxer::MPEGPSDemuxer() {
@@ -286,7 +289,7 @@ bool MPEGPSDecoder::MPEGPSDemuxer::loadStream(Common::SeekableReadStream *stream
 	_stream = stream;
 
 	int queuedPackets = 0;
-	while (queueNextPacket() && queuedPackets < PREBUFFERED_PACKETS) {
+	while (queueNextPacket() && queuedPackets < _prebufferedPackets) {
 		queuedPackets++;
 	}
 

--- a/video/mpegps_decoder.h
+++ b/video/mpegps_decoder.h
@@ -60,6 +60,10 @@ public:
 	bool loadStream(Common::SeekableReadStream *stream);
 	void close();
 
+	// Set the number of prebuffered packets in demuxer
+	// Used only by qdEngine
+	void setPrebufferedPackets(int packets);
+
 protected:
 	void readNextPacket();
 	bool useAudioSync() const { return false; }
@@ -75,6 +79,8 @@ private:
 
 		Common::SeekableReadStream *getFirstVideoPacket(int32 &startCode, uint32 &pts, uint32 &dts);
 		Common::SeekableReadStream *getNextPacket(uint32 currentTime, int32 &startCode, uint32 &pts, uint32 &dts);
+
+		void setPrebufferedPackets(int packets) { _prebufferedPackets = packets; }
 
 	private:
 		class Packet {
@@ -98,6 +104,8 @@ private:
 		Common::Queue<Packet> _audioQueue;
 		// If we come across a non-packetized elementary stream
 		bool _isESStream;
+
+		int _prebufferedPackets = 150;
 	};
 
 	// Base class for handling MPEG streams

--- a/video/mpegps_decoder.h
+++ b/video/mpegps_decoder.h
@@ -105,6 +105,9 @@ private:
 		// If we come across a non-packetized elementary stream
 		bool _isESStream;
 
+		uint32 _firstAudioPacketPts = 0xFFFFFFFF;
+		uint32 _firstVideoPacketPts = 0xFFFFFFFF;
+
 		int _prebufferedPackets = 150;
 	};
 


### PR DESCRIPTION
This PR attempts to fix issues I had with videos in some QdEngine games. In particular, I had two problems:
1. Audio is lagging behind video
2. Videos start with quite noticeable delay

For the 1), I figured that not enough audio packets (in relation to video packets) are being prebuffered, and so the audio can't keep up with video after playback starts. I decided to increase the number of PREBUFFERED_PACKETS.

For the 2), I've analyzed problematic videos with ffprobe, and noticed that the first video packet's pts_time is quite large (1.874 seconds), so that explains the delay. My solution is to offset both audio and video pts values, so that the first pts is zero. I've assumed that there is only 1 audio and 1 video stream per video.

This needs more testing, especially with mtropolis and zvision games.