### PR TITLE
AUDIO: Remove rate parameter for Mod/XM/S3M and Universal Tracker streams

### DIFF
--- a/audio/mods/mod_xm_s3m.cpp
+++ b/audio/mods/mod_xm_s3m.cpp
@@ -63,8 +63,10 @@
 #include "common/debug.h"
 #include "common/file.h"
 #include "common/memstream.h"
+#include "common/system.h"
 
 #include "audio/audiostream.h"
+#include "audio/mixer.h"
 #include "audio/mods/mod_xm_s3m.h"
 #include "audio/mods/module_mod_xm_s3m.h"
 
@@ -166,7 +168,7 @@ public:
 	int getRate() const override { return _sampleRate; }
 	bool endOfData() const override { return _dataLeft <= 0; }
 
-	ModXmS3mStream(Common::SeekableReadStream *stream, int initialPos, int rate, int interpolation);
+	ModXmS3mStream(Common::SeekableReadStream *stream, int initialPos, int interpolation);
 	~ModXmS3mStream();
 };
 
@@ -178,9 +180,10 @@ const short ModXmS3mStream::sinetable[] = {
 		255, 253, 250, 244, 235, 224, 212, 197, 180, 161, 141, 120,  97,  74,  49,  24
 	};
 
-ModXmS3mStream::ModXmS3mStream(Common::SeekableReadStream *stream, int initialPos, int rate, int interpolation) :
+ModXmS3mStream::ModXmS3mStream(Common::SeekableReadStream *stream, int initialPos, int interpolation) :
 	_rampBuf(nullptr), _playCount(nullptr), _channels(nullptr),
-	_mixBuffer(nullptr), _sampleRate(rate), _interpolation(interpolation),
+	_mixBuffer(nullptr), _interpolation(interpolation),
+	_sampleRate(g_system->getMixer()->getOutputRate()),
 	_seqPos(initialPos), _mixBufferSamples(0), _finished(false) {
 	if (!_module.load(*stream)) {
 		warning("It's not a valid Mod/S3m/Xm sound file");
@@ -1360,8 +1363,8 @@ void ModXmS3mStream::setSequencePos(int pos) {
 
 namespace Audio {
 
-RewindableAudioStream *makeModXmS3mStream(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse, int initialPos, int rate, int interpolation) {
-	Modules::ModXmS3mStream *soundStream = new Modules::ModXmS3mStream(stream, initialPos, rate, interpolation);
+RewindableAudioStream *makeModXmS3mStream(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse, int initialPos, int interpolation) {
+	Modules::ModXmS3mStream *soundStream = new Modules::ModXmS3mStream(stream, initialPos, interpolation);
 
 	if (disposeAfterUse == DisposeAfterUse::YES)
 		delete stream;

--- a/audio/mods/mod_xm_s3m.h
+++ b/audio/mods/mod_xm_s3m.h
@@ -82,13 +82,12 @@ class AudioStream;
  * @param stream			the ReadStream from which to read the tracker sound data
  * @param disposeAfterUse	whether to delete the stream after use
  * @param initialPos		initial track to start playback from
- * @param rate				sample rate
  * @param interpolation		interpolation effect level
  */
 RewindableAudioStream *makeModXmS3mStream(Common::SeekableReadStream *stream,
 		DisposeAfterUse::Flag disposeAfterUse,
 		int initialPos = 0,
-		int rate = 48000, int interpolation = 0);
+		int interpolation = 0);
 
 /**
  * Check if the stream is one of the supported formats

--- a/audio/mods/universaltracker.cpp
+++ b/audio/mods/universaltracker.cpp
@@ -35,10 +35,12 @@
 
 #include "common/ptr.h"
 #include "common/stream.h"
+#include "common/system.h"
 #include "common/textconsole.h"
 #include "common/util.h"
 
 #include "audio/audiostream.h"
+#include "audio/mixer.h"
 #include "audio/decoders/raw.h"
 
 #ifdef USE_OPENMPT
@@ -184,7 +186,7 @@ static long memoryReaderTell(MREADER *reader) {
 namespace Audio {
 class UniversalTrackerMod : public RewindableAudioStream {
 public:
-	UniversalTrackerMod(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse, int rate);
+	UniversalTrackerMod(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse);
 	~UniversalTrackerMod();
 
 	// ImpulseTrackerMod functions
@@ -228,7 +230,7 @@ private:
 	int _sampleRate;
 };
 
-UniversalTrackerMod::UniversalTrackerMod(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse, int rate) {
+UniversalTrackerMod::UniversalTrackerMod(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse) {
 	if (!stream) {
 		warning("UniversalTrackerMod::UniversalTrackerMod(): Input file/stream is invalid.");
 		return;
@@ -239,7 +241,7 @@ UniversalTrackerMod::UniversalTrackerMod(Common::SeekableReadStream *stream, Dis
 
 	_stream = stream;
 	_dispose = disposeAfterUse;
-	_sampleRate = rate;
+	_sampleRate = g_system->getMixer()->getOutputRate();
 
 	openmpt_stream_callbacks stream_callbacks;
 	stream_callbacks.read = &memoryReaderRead;
@@ -275,7 +277,7 @@ UniversalTrackerMod::~UniversalTrackerMod() {
 namespace Audio {
 class UniversalTrackerMod : public RewindableAudioStream {
 public:
-	UniversalTrackerMod(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse, int rate);
+	UniversalTrackerMod(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse);
 	~UniversalTrackerMod();
 
 	// ImpulseTrackerMod functions
@@ -319,13 +321,13 @@ private:
 	int _sampleRate;
 };
 
-UniversalTrackerMod::UniversalTrackerMod(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse, int rate) {
+UniversalTrackerMod::UniversalTrackerMod(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse) {
 	if (!stream) {
 		warning("UniversalTrackerMod::UniversalTrackerMod(): Input file/stream is invalid.");
 		return;
 	}
 
-	_sampleRate = rate;
+	_sampleRate = g_system->getMixer()->getOutputRate();
 
 	MikMod_InitThreads();
 	MikMod_RegisterDriver(&drv_nos);
@@ -381,14 +383,14 @@ UniversalTrackerMod::~UniversalTrackerMod() {
 
 namespace Audio {
 
-RewindableAudioStream *makeUniversalTrackerStream(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse, int rate) {
+RewindableAudioStream *makeUniversalTrackerStream(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse) {
 
 #if !defined(USE_OPENMPT) && !defined(USE_MIKMOD)
 	warning("Modplayer Support not compiled in");
 	return nullptr;
 #else
 
-	UniversalTrackerMod *impulseTrackerMod = new UniversalTrackerMod(stream, disposeAfterUse, rate);
+	UniversalTrackerMod *impulseTrackerMod = new UniversalTrackerMod(stream, disposeAfterUse);
 
 	if (!impulseTrackerMod->isLoaded()) {
 		delete impulseTrackerMod;

--- a/audio/mods/universaltracker.h
+++ b/audio/mods/universaltracker.h
@@ -49,7 +49,7 @@ class RewindableAudioStream;
  * @param disposeAfterUse   whether to delete the stream after use
  * @return  a new AudioStream, or NULL, if an error occurred
  */
-RewindableAudioStream *makeUniversalTrackerStream(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse, int rate = 48000);
+RewindableAudioStream *makeUniversalTrackerStream(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse);
 
 } // End of namespace Audio
 

--- a/engines/sludge/sound.cpp
+++ b/engines/sludge/sound.cpp
@@ -230,7 +230,7 @@ bool SoundManager::playMOD(int f, int a, int fromTrack) {
 		mod = Audio::makeModXmS3mStream(memImage, DisposeAfterUse::NO, fromTrack);
 
 	if (!mod) {
-		mod = Audio::makeUniversalTrackerStream(memImage, DisposeAfterUse::NO, g_sludge->_mixer->getOutputRate());
+		mod = Audio::makeUniversalTrackerStream(memImage, DisposeAfterUse::NO);
 	}
 
 	if (!mod) {


### PR DESCRIPTION
Most engines didn't specify a sample rate and just used the default value of 48000, which introduces additional resampling on most platforms.