### PR TITLE
ENGINES: Deduplicate escapeString and fix unused-function warnings

### DIFF
--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -668,23 +668,6 @@ static bool getFilePropertiesIntern(uint md5Bytes, const AdvancedMetaEngineBase:
 	return true;
 }
 
-// Add backslash before double quotes (") and backslashes themselves (\)
-Common::String escapeString(const char *string) {
-	if (string == nullptr)
-		return "";
-
-	Common::String res = "";
-
-	for (int i = 0; string[i] != '\0'; i++) {
-		if (string[i] == '"' || string[i] == '\\')
-			res += "\\";
-
-		res += string[i];
-	}
-
-	return res;
-}
-
 void AdvancedMetaEngineDetectionBase::dumpDetectionEntries() const {
 	const byte *descPtr;
 

--- a/engines/glk/detection.cpp
+++ b/engines/glk/detection.cpp
@@ -316,23 +316,6 @@ uint GlkMetaEngineDetection::getMD5Bytes() const {
 	return 5000;
 }
 
-// Add backslash before double quotes (") and backslashes themselves (\)
-static Common::String escapeString(const char *string) {
-	if (string == nullptr)
-		return "";
-
-	Common::String res = "";
-
-	for (int i = 0; string[i] != '\0'; i++) {
-		if (string[i] == '"' || string[i] == '\\')
-			res += "\\";
-
-		res += string[i];
-	}
-
-	return res;
-}
-
 void GlkMetaEngineDetection::dumpDetectionEntries() const {
 #if 0
 	enum class EngineName : uint8 {

--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -38,6 +38,23 @@
 
 const char MetaEngineDetection::GAME_NOT_IMPLEMENTED[] = _s("Game not implemented");
 
+// Add backslash before double quotes (") and backslashes themselves (\)
+Common::String MetaEngineDetection::escapeString(const char *string) {
+	if (string == nullptr)
+		return "";
+
+	Common::String res = "";
+
+	for (int i = 0; string[i] != '\0'; i++) {
+		if (string[i] == '"' || string[i] == '\\')
+			res += "\\";
+
+		res += string[i];
+	}
+
+	return res;
+}
+
 Common::String MetaEngine::getSavegameFile(int saveGameIdx, const char *target) const {
 	if (!target)
 		target = getName();

--- a/engines/metaengine.h
+++ b/engines/metaengine.h
@@ -124,6 +124,12 @@ struct ExtendedSavegameHeader {
  * To instantiate actual Engine objects, see the class @ref MetaEngine.
  */
 class MetaEngineDetection : public PluginObject {
+protected:
+	/** Internal: Add backslash before double quotes (") and backslashes themselves (\)
+	 *  Used for dumping detection entries.
+	 */
+	static Common::String escapeString(const char *string);
+
 public:
 	/**
 	 * This is the message to use in detection tables when

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -107,23 +107,6 @@ PlainGameList ScummMetaEngineDetection::getSupportedGames() const {
 	return PlainGameList(gameDescriptions);
 }
 
-// Add backslash before double quotes (") and backslashes themselves (\)
-static Common::String escapeString(const char *string) {
-	if (string == nullptr)
-		return "";
-
-	Common::String res = "";
-
-	for (int i = 0; string[i] != '\0'; i++) {
-		if (string[i] == '"' || string[i] == '\\')
-			res += "\\";
-
-		res += string[i];
-	}
-
-	return res;
-}
-
 GameFilenamePattern ScummMetaEngineDetection::matchGameFilenamePattern(const MD5Table *entry) const {
 	GameFilenamePattern bestMatch = GameFilenamePattern();
 


### PR DESCRIPTION
The code that uses them in glk and scumm is in #if 0.
