### PR TITLE
VIDEO: QTVR: Remove bug in QTVR while changing nodes

### DIFF
--- a/video/qt_decoder.h
+++ b/video/qt_decoder.h
@@ -424,8 +424,10 @@ private:
 		Graphics::Surface *_projectedPano;
 		Graphics::Surface *_planarProjection;
 
-		// Current upscale level (1 or 2) of _upscaledConstructedPanorama compared to _constructedPano
-		// Level 1 means only upscaled height (2x pixels), level 2 means upscaled height and width (4x pixels)
+		// Current upscale level (0 or 1 or 2) of _upscaledConstructedPanorama compared to _constructedPano
+		// level 0 means that constructedPano was just contructed and hasn't been upscaled yet
+		// level 1 means only upscaled height (2x pixels) 
+		// level 2 means upscaled height and width (4x pixels)
 		uint8 _upscaleLevel = 0;
 
 		// Defining these to make the swing transition happen

--- a/video/qtvr_decoder.cpp
+++ b/video/qtvr_decoder.cpp
@@ -901,6 +901,10 @@ void QuickTimeDecoder::PanoTrackHandler::constructPanorama() {
 
 	_constructedPano = constructMosaic(track, desc->_sceneNumFramesX, desc->_sceneNumFramesY, "dumps/pano-full.png");
 
+	// _upscaleLevel = 0 means _contructedPano has just been constructed, hasn't been upscaled yet
+	// or that the upscaledConstructedPanorama has upscaled a different panorama, not the current constructedPano
+	_upscaleLevel = 0;
+
 	track = (VideoTrackHandler *)(_decoder->getTrack(_decoder->Common::QuickTimeParser::_tracks[desc->_hotSpotTrackID - 1]->targetTrack));
 
 	track->seek(Audio::Timestamp(0, timestamp, _decoder->_timeScale));


### PR DESCRIPTION
The previous pull request (merged) https://github.com/scummvm/scummvm/pull/6548
implemented an upscaled panorama for projection in higher quality.
However, it also introduced a bug where if you change the node
(panorama), the `_constructedPano` is now the node you changed to
but the `_upscaledConstructedPano` is still on the previous node
This caused the `projectPanorama()` function to project the wrong panorama when
in high quality mode.

Fix this bug by resetting the  `_upscaleLevel` to 0 when we're constructing 
`_constructedPano` which implies that we have to
upscale the `_constructedPanorama` from scratch during `projectPanorama()`
So whenever the `_constructedPano` is reconstructed, so will be 
`_upscaledConstructedPano` 


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
