### PR TITLE
BACKENDS: OPENGL: Don't use HW CLUT8 lookup on low precision devices

### DIFF
--- a/backends/graphics/opengl/shader.cpp
+++ b/backends/graphics/opengl/shader.cpp
@@ -68,7 +68,7 @@ const char *const g_lookUpFragmentShader =
 	"varying vec2 texCoord;\n"
 	"varying vec4 blendColor;\n"
 	"\n"
-	"uniform mediump sampler2D shaderTexture;\n"
+	"uniform sampler2D shaderTexture;\n"
 	"uniform sampler2D palette;\n"
 	"\n"
 	"const float scaleFactor = 255.0 / 256.0;\n"

--- a/backends/graphics/opengl/texture.h
+++ b/backends/graphics/opengl/texture.h
@@ -309,7 +309,9 @@ public:
 	static bool isSupportedByContext() {
 		return OpenGLContext.shadersSupported
 		    && OpenGLContext.multitextureSupported
-		    && OpenGLContext.framebufferObjectSupported;
+		    && OpenGLContext.framebufferObjectSupported
+		    // With 2^-8 precision this is too prone to approximation errors
+		    && OpenGLContext.textureLookupPrecision > 8;
 	}
 private:
 	void lookUpColors();

--- a/graphics/opengl/context.cpp
+++ b/graphics/opengl/context.cpp
@@ -78,6 +78,7 @@ void Context::reset() {
 	textureBorderClampSupported = false;
 	textureMirrorRepeatSupported = false;
 	textureMaxLevelSupported = false;
+	textureLookupPrecision = 0;
 }
 
 void Context::initialize(ContextType contextType) {
@@ -240,6 +241,13 @@ void Context::initialize(ContextType contextType) {
 		if (isGLVersionOrHigher(3, 2)) {
 			textureBorderClampSupported = true;
 		}
+
+		// In GLES2, texture lookup is done using lowp (and mediump is not always available)
+		GLint range[2];
+		GLint precision = 0;
+		glGetShaderPrecisionFormat(GL_FRAGMENT_SHADER, GL_LOW_FLOAT, range, &precision);
+		textureLookupPrecision = precision;
+
 		debug(5, "OpenGL: GLES2 context initialized");
 	} else if (type == kContextGLES) {
 		// GLES doesn't support shaders natively
@@ -251,6 +259,8 @@ void Context::initialize(ContextType contextType) {
 		textureEdgeClampSupported = true;
 		// No border clamping in GLES
 		// No mirror repeat in GLES
+		// Precision is irrelevant (shaders) in GLES
+
 		debug(5, "OpenGL: GLES context initialized");
 	} else if (type == kContextGL) {
 		// Official support of shaders starts with version 110
@@ -280,6 +290,10 @@ void Context::initialize(ContextType contextType) {
 		if (isGLVersionOrHigher(1, 4)) {
 			textureMirrorRepeatSupported = true;
 		}
+
+		// In OpenGL precision is always enough
+		textureLookupPrecision = UINT_MAX;
+
 		debug(5, "OpenGL: GL context initialized");
 	} else {
 		warning("OpenGL: Unknown context initialized");
@@ -314,6 +328,7 @@ void Context::initialize(ContextType contextType) {
 	debug(5, "OpenGL: Texture border clamping support: %d", textureBorderClampSupported);
 	debug(5, "OpenGL: Texture mirror repeat support: %d", textureMirrorRepeatSupported);
 	debug(5, "OpenGL: Texture max level support: %d", textureMaxLevelSupported);
+	debug(5, "OpenGL: Texture lookup precision: %d", textureLookupPrecision);
 }
 
 int Context::getGLSLVersion() const {

--- a/graphics/opengl/context.h
+++ b/graphics/opengl/context.h
@@ -120,6 +120,9 @@ public:
 	/** Whether texture max level is available or not. */
 	bool textureMaxLevelSupported;
 
+	/** Texture lookup result precision. */
+	unsigned int textureLookupPrecision;
+
 private:
 	/**
 	 * Returns the native GLSL version supported by the driver.

--- a/graphics/opengl/shader.cpp
+++ b/graphics/opengl/shader.cpp
@@ -58,7 +58,6 @@ static const char *const compatFragment =
 		"#define outColor gl_FragColor\n"
 		"#define texture texture2D\n"
 	"#elif __VERSION__ < 130\n"
-		"#define mediump\n"
 		"#define in varying\n"
 		"#define OUTPUT\n"
 		"#define outColor gl_FragColor\n"


### PR DESCRIPTION
This also reverts commit 84a31481fa70b56140ca5e62edf9cb287a7d3e7b. This will hopefully fix [Trac#15860](https://bugs.scummvm.org/ticket/15860) for good.
I also hope that nothing else will get broken because of this.

I would like to have the user test this before merging.