### PR TITLE
OPENGL: Use helper functions for endian-specific pixel formats

### DIFF
--- a/backends/graphics/android/android-graphics.cpp
+++ b/backends/graphics/android/android-graphics.cpp
@@ -87,13 +87,8 @@ void AndroidGraphicsManager::initSurface() {
 		// If not 16, this must be 24 or 32 bpp so make use of them
 		notifyContextCreate(OpenGL::kContextGLES2,
 				new OpenGL::Backbuffer(),
-#ifdef SCUMM_BIG_ENDIAN
-				Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0),
-				Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0)
-#else
-				Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0),
-				Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24)
-#endif
+				OpenGL::Texture::getRGBPixelFormat(),
+				OpenGL::Texture::getRGBAPixelFormat()
 		);
 	}
 

--- a/backends/graphics/ios/ios-graphics.cpp
+++ b/backends/graphics/ios/ios-graphics.cpp
@@ -41,15 +41,8 @@ void iOSGraphicsManager::initSurface() {
 
 	notifyContextCreate(OpenGL::kContextGLES2,
 	new OpenGL::RenderbufferTarget(rbo),
-	// Currently iOS runs the ARMs in little-endian mode but prepare if
-	// that is changed in the future.
-#ifdef SCUMM_LITTLE_ENDIAN
-	Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24),
-	Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
-#else
-	Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0),
-	Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
-#endif
+	OpenGL::Texture::getRGBAPixelFormat(),
+	OpenGL::Texture::getRGBAPixelFormat());
 	handleResize(sys->getScreenWidth(), sys->getScreenHeight());
 
 	_old_touch_mode = kTouchModeTouchpad;

--- a/backends/graphics/opengl/pipelines/libretro.cpp
+++ b/backends/graphics/opengl/pipelines/libretro.cpp
@@ -79,13 +79,8 @@ static Graphics::Surface *loadViaImageDecoder(const Common::Path &fileName, Comm
 
 	// Use a cast to resolve ambiguities in JPEGDecoder
 	const Graphics::Palette & palette = static_cast<Image::ImageDecoder &>(decoder).getPalette();
-	return decoder.getSurface()->convertTo(
-#ifdef SCUMM_LITTLE_ENDIAN
-										   Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24),
-#else
-										   Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0),
-#endif
-										   palette.data(), palette.size());
+	return decoder.getSurface()->convertTo(OpenGL::Texture::getRGBAPixelFormat(),
+		palette.data(), palette.size());
 }
 
 struct ImageLoader {

--- a/backends/graphics/opengl/texture.cpp
+++ b/backends/graphics/opengl/texture.cpp
@@ -365,9 +365,9 @@ void TextureSurfaceRGB555::updateGLTexture() {
 
 TextureSurfaceRGBA8888Swap::TextureSurfaceRGBA8888Swap()
 #ifdef SCUMM_LITTLE_ENDIAN
-	: FakeTextureSurface(GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24), Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0)) // RGBA8888 -> ABGR8888
+	: FakeTextureSurface(GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, OpenGL::Texture::getRGBAPixelFormat(), Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0)) // RGBA8888 -> ABGR8888
 #else
-	: FakeTextureSurface(GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0), Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24)) // ABGR8888 -> RGBA8888
+	: FakeTextureSurface(GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, OpenGL::Texture::getRGBAPixelFormat(), Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24)) // ABGR8888 -> RGBA8888
 #endif
 	  {
 }
@@ -653,13 +653,7 @@ void TextureSurfaceCLUT8GPU::updateGLTexture() {
 	// Update palette if necessary.
 	if (_paletteDirty) {
 		Graphics::Surface palSurface;
-		palSurface.init(256, 1, 256, _palette,
-#ifdef SCUMM_LITTLE_ENDIAN
-		                Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24) // ABGR8888
-#else
-		                Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0) // RGBA8888
-#endif
-		               );
+		palSurface.init(256, 1, 256, _palette, OpenGL::Texture::getRGBAPixelFormat());
 
 		_paletteTexture.updateArea(Common::Rect(256, 1), palSurface);
 		_paletteDirty = false;

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -596,12 +596,7 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 	// whether we run on little endian or big endian. However, we can
 	// only safely assume that RGBA8888 in memory layout is supported.
 	// Thus, we chose this one.
-	const Graphics::PixelFormat rgba8888 =
-#ifdef SCUMM_LITTLE_ENDIAN
-	                                       Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#else
-	                                       Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#endif
+	const Graphics::PixelFormat rgba8888 = OpenGL::Texture::getRGBAPixelFormat();
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	if (_glContext) {
@@ -980,7 +975,7 @@ void *OpenGLSdlGraphicsManager::getImGuiTexture(const Graphics::Surface &image, 
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE); // Same
 
 	// Upload pixels into texture
-	Graphics::Surface *s = image.convertTo(Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0), palette, palCount);
+	Graphics::Surface *s = image.convertTo(OpenGL::Texture::getRGBPixelFormat(), palette, palCount);
 	glPixelStorei(GL_UNPACK_ALIGNMENT, s->format.bytesPerPixel);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, s->w, s->h, 0, GL_RGB, GL_UNSIGNED_BYTE, s->getPixels());

--- a/backends/graphics3d/android/texture.h
+++ b/backends/graphics3d/android/texture.h
@@ -286,11 +286,7 @@ public:
 	virtual ~GLES888Texture() {}
 
 	static Graphics::PixelFormat pixelFormat() {
-#ifdef SCUMM_BIG_ENDIAN
-		return Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0);
-#else
-		return Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0);
-#endif
+		return OpenGL::Texture::getRGBPixelFormat();
 	}
 };
 
@@ -300,11 +296,7 @@ public:
 	virtual ~GLES8888Texture() {}
 
 	static Graphics::PixelFormat pixelFormat() {
-#ifdef SCUMM_BIG_ENDIAN
-		return Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-		return Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+		return OpenGL::Texture::getRGBAPixelFormat();
 	}
 };
 

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -888,7 +888,7 @@ bool OpenGLSdlGraphics3dManager::saveScreenshot(const Common::Path &filename) co
 	// The second is an implementation-chosen format. " and the implementation-chosen formats are buggy:
 	// https://github.com/KhronosGroup/WebGL/issues/2747
 	glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, &pixels.front());
-	const Graphics::PixelFormat format(4, 8, 8, 8, 8, 0, 8, 16, 24);
+	const Graphics::PixelFormat format(OpenGL::Texture::getRGBAPixelFormat());
 #else
 
 	if (_frameBuffer) {
@@ -899,11 +899,7 @@ bool OpenGLSdlGraphics3dManager::saveScreenshot(const Common::Path &filename) co
 		_frameBuffer->attach();
 	}
 
-#ifdef SCUMM_LITTLE_ENDIAN
-	const Graphics::PixelFormat format(3, 8, 8, 8, 0, 0, 8, 16, 0);
-#else
-	const Graphics::PixelFormat format(3, 8, 8, 8, 0, 16, 8, 0, 0);
-#endif
+	const Graphics::PixelFormat format(OpenGL::Texture::getRGBPixelFormat());
 #endif
 
 	Graphics::Surface data;
@@ -930,7 +926,7 @@ void *OpenGLSdlGraphics3dManager::getImGuiTexture(const Graphics::Surface &image
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE); // Same
 
 	// Upload pixels into texture
-	Graphics::Surface *s = image.convertTo(Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0));
+	Graphics::Surface *s = image.convertTo(OpenGL::Texture::getRGBPixelFormat());
 	glPixelStorei(GL_UNPACK_ALIGNMENT, s->format.bytesPerPixel);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, s->w, s->h, 0, GL_RGB, GL_UNSIGNED_BYTE, s->getPixels());

--- a/backends/platform/libretro/src/libretro-graphics-opengl.cpp
+++ b/backends/platform/libretro/src/libretro-graphics-opengl.cpp
@@ -112,12 +112,7 @@ void LibretroHWFramebuffer::activateInternal() {
 }
 
 void LibretroOpenGLGraphics::resetContext(OpenGL::ContextType contextType) {
-	const Graphics::PixelFormat rgba8888 =
-#ifdef SCUMM_LITTLE_ENDIAN
-	    Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#else
-	    Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#endif
+	const Graphics::PixelFormat rgba8888 = OpenGL::Texture::getRGBAPixelFormat();
 	notifyContextDestroy();
 	notifyContextCreate(contextType, new LibretroHWFramebuffer(), rgba8888, rgba8888);
 

--- a/graphics/opengl/texture.cpp
+++ b/graphics/opengl/texture.cpp
@@ -214,14 +214,6 @@ void Texture::updateArea(const Common::Rect &area, const Graphics::Surface &src)
 	                       _glFormat, _glType, src.getBasePtr(0, area.top)));
 }
 
-const Graphics::PixelFormat Texture::getRGBAPixelFormat() {
-#ifdef SCUMM_BIG_ENDIAN
-	return Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-	return Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
-}
-
 } // End of namespace OpenGL
 
 #endif

--- a/graphics/opengl/texture.h
+++ b/graphics/opengl/texture.h
@@ -145,7 +145,21 @@ public:
 	 */
 	GLuint getGLTexture() const { return _glTexture; }
 
-	static const Graphics::PixelFormat getRGBAPixelFormat();
+	static inline const Graphics::PixelFormat getRGBPixelFormat() {
+#ifdef SCUMM_BIG_ENDIAN
+		return Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0);
+#else
+		return Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0);
+#endif
+	}
+
+	static inline const Graphics::PixelFormat getRGBAPixelFormat() {
+#ifdef SCUMM_BIG_ENDIAN
+		return Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
+#else
+		return Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
+#endif
+	}
 
 protected:
 	const GLenum _glIntFormat;


### PR DESCRIPTION
This should hopefully be a bit less prone to error.