### PR TITLE
IMAGE: Fix dithering 8bpp images when the container owns the palette

### DIFF
--- a/image/codecs/dither.cpp
+++ b/image/codecs/dither.cpp
@@ -51,7 +51,7 @@ inline uint16 makeQuickTimeDitherColor(byte r, byte g, byte b) {
 
 DitherCodec::DitherCodec(Codec *codec, DisposeAfterUse::Flag disposeAfterUse)
   : _codec(codec), _disposeAfterUse(disposeAfterUse), _dirtyPalette(false),
-    _forcedDitherPalette(0), _ditherTable(0), _ditherFrame(0) {
+    _forcedDitherPalette(0), _ditherTable(0), _ditherFrame(0), _srcPalette(nullptr) {
 }
 
 DitherCodec::~DitherCodec() {
@@ -114,8 +114,7 @@ const Graphics::Surface *DitherCodec::decodeFrame(Common::SeekableReadStream &st
 	if (!frame || _forcedDitherPalette.empty())
 		return frame;
 
-	// TODO: Handle palettes that are owned by the container instead of the codec
-	const byte *curPalette = _codec->getPalette();
+	const byte *curPalette = _codec->containsPalette() ? _codec->getPalette() : _srcPalette;
 
 	if (frame->format.isCLUT8() && curPalette) {
 		// This should always be true, but this is for sanity

--- a/image/codecs/dither.h
+++ b/image/codecs/dither.h
@@ -46,6 +46,11 @@ public:
 	void setCodecAccuracy(CodecAccuracy accuracy) override;
 
 	/**
+	 * Specify the source palette when dithering from CLUT8 to CLUT8.
+	 */
+	void setPalette(const byte *palette) { _srcPalette = palette; }
+
+	/**
 	 * Create a dither table, as used by QuickTime codecs.
 	 */
 	static byte *createQuickTimeDitherTable(const byte *palette, uint colorCount);
@@ -53,6 +58,7 @@ public:
 private:
 	DisposeAfterUse::Flag _disposeAfterUse;
 	Codec *_codec;
+	const byte *_srcPalette;
 
 	Graphics::Surface *_ditherFrame;
 	Graphics::Palette _forcedDitherPalette;

--- a/video/qt_decoder.h
+++ b/video/qt_decoder.h
@@ -345,7 +345,7 @@ private:
 		const Graphics::Surface *decodeNextFrame();
 		Audio::Timestamp getFrameTime(uint frame) const;
 		const byte *getPalette() const;
-		bool hasDirtyPalette() const { return _curPalette; }
+		bool hasDirtyPalette() const { return _dirtyPalette; }
 		bool setReverse(bool reverse);
 		bool isReversed() const { return _reversed; }
 		bool canDither() const;


### PR DESCRIPTION
This fixes displaying two QTRLE videos in the Windows demo of Frankenstein: Through the Eyes of the Monster.