### PR TITLE
BACKENDS: Use DefaultPaletteManager for all backends

### DIFF
--- a/backends/graphics/atari/atari-graphics.cpp
+++ b/backends/graphics/atari/atari-graphics.cpp
@@ -509,7 +509,7 @@ OSystem::TransactionError AtariGraphicsManager::endGFXTransaction() {
 	return OSystem::kTransactionSuccess;
 }
 
-void AtariGraphicsManager::setPalette(const byte *colors, uint start, uint num) {
+void AtariGraphicsManager::setPaletteIntern(const byte *colors, uint start, uint num) {
 	//atari_debug("setPalette: %d, %d", start, num);
 
 	if (_tt) {
@@ -531,28 +531,6 @@ void AtariGraphicsManager::setPalette(const byte *colors, uint start, uint num) 
 	}
 
 	_pendingScreenChanges.queuePalette();
-}
-
-void AtariGraphicsManager::grabPalette(byte *colors, uint start, uint num) const {
-	//atari_debug("grabPalette: %d, %d", start, num);
-
-	if (_tt) {
-		const uint16 *pal = &_palette.tt[start];
-		for (uint i = 0; i < num; ++i) {
-			// Bits 15-12    Bits 11-8     Bits 7-4      Bits 3-0
-			// Reserved      Red           Green         Blue
-			*colors++ = ((pal[i] >> 8) & 0x0f) << 4;
-			*colors++ = ((pal[i] >> 4) & 0x0f) << 4;
-			*colors++ = ((pal[i]     ) & 0x0f) << 4;
-		}
-	} else {
-		const _RGB *pal = &_palette.falcon[start];
-		for (uint i = 0; i < num; ++i) {
-			*colors++ = pal[i].red;
-			*colors++ = pal[i].green;
-			*colors++ = pal[i].blue;
-		}
-	}
 }
 
 void AtariGraphicsManager::copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) {
@@ -976,7 +954,7 @@ void AtariGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int h
 	}
 }
 
-void AtariGraphicsManager::setCursorPalette(const byte *colors, uint start, uint num) {
+void AtariGraphicsManager::setCursorPaletteIntern(const byte *colors, uint start, uint num) {
 	atari_debug("setCursorPalette: %d, %d", start, num);
 
 	// cursor palette is supported only in the overlay

--- a/backends/graphics/atari/atari-graphics.h
+++ b/backends/graphics/atari/atari-graphics.h
@@ -23,6 +23,7 @@
 #define BACKENDS_GRAPHICS_ATARI_H
 
 #include "backends/graphics/graphics.h"
+#include "backends/graphics/default-palette.h"
 #include "common/events.h"
 
 #include <mint/osbind.h>
@@ -38,7 +39,7 @@
 #define MAX_HZ_SHAKE 16 // Falcon only
 #define MAX_V_SHAKE  16
 
-class AtariGraphicsManager : public GraphicsManager, public PaletteManager, Common::EventObserver {
+class AtariGraphicsManager : public GraphicsManager, public DefaultPaletteManager, Common::EventObserver {
 	friend class Cursor;
 	friend class PendingScreenChanges;
 	friend class Screen;
@@ -73,9 +74,6 @@ public:
 
 	int16 getHeight() const override { return _currentState.height; }
 	int16 getWidth() const override { return _currentState.width; }
-	PaletteManager *getPaletteManager() override { return this; }
-	void setPalette(const byte *colors, uint start, uint num) override;
-	void grabPalette(byte *colors, uint start, uint num) const override;
 	void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) override;
 	Graphics::Surface *lockScreen() override;
 	void unlockScreen() override;
@@ -100,8 +98,14 @@ public:
 	void warpMouse(int x, int y) override;
 	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor,
 						bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override;
-	void setCursorPalette(const byte *colors, uint start, uint num) override;
 
+	PaletteManager *getPaletteManager() override { return this; }
+protected:
+	// DefaultPaletteManager interface
+	void setPaletteIntern(const byte *colors, uint start, uint num) override;
+	void setCursorPaletteIntern(const byte *colors, uint start, uint num) override;
+
+public:
 	Common::Point getMousePosition() const {
 		if (isOverlayVisible()) {
 			return _screen[kOverlayBuffer]->cursor.getPosition();

--- a/backends/graphics/atari/atari-graphics.h
+++ b/backends/graphics/atari/atari-graphics.h
@@ -38,7 +38,7 @@
 #define MAX_HZ_SHAKE 16 // Falcon only
 #define MAX_V_SHAKE  16
 
-class AtariGraphicsManager : public GraphicsManager, Common::EventObserver {
+class AtariGraphicsManager : public GraphicsManager, public PaletteManager, Common::EventObserver {
 	friend class Cursor;
 	friend class PendingScreenChanges;
 	friend class Screen;
@@ -73,6 +73,7 @@ public:
 
 	int16 getHeight() const override { return _currentState.height; }
 	int16 getWidth() const override { return _currentState.width; }
+	PaletteManager *getPaletteManager() override { return this; }
 	void setPalette(const byte *colors, uint start, uint num) override;
 	void grabPalette(byte *colors, uint start, uint num) const override;
 	void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) override;

--- a/backends/graphics/default-palette.h
+++ b/backends/graphics/default-palette.h
@@ -37,22 +37,27 @@ protected:
 	byte _palette[3 * 256];
 
 	/**
-	 * Subclasses should only implement this method and none of the others.
+	 * Subclasses should only implement these methods and none of the others.
 	 * Its semantics are like that of setPalette, only that it does not need
 	 * to worry about making it possible to query the palette values once they
 	 * have been set.
 	 */
 	virtual void setPaletteIntern(const byte *colors, uint start, uint num) = 0;
+	virtual void setCursorPaletteIntern(const byte *colors, uint start, uint num) {}
 
 public:
-	void setPalette(const byte *colors, uint start, uint num) {
+	void setPalette(const byte *colors, uint start, uint num) override final {
 		assert(start + num <= 256);
 		memcpy(_palette + 3 * start, colors, 3 * num);
 		setPaletteIntern(colors, start, num);
 	}
-	void grabPalette(byte *colors, uint start, uint num) const {
+	void grabPalette(byte *colors, uint start, uint num) const override final {
 		assert(start + num <= 256);
 		memcpy(colors, _palette + 3 * start, 3 * num);
+	}
+	void setCursorPalette(const byte *colors, uint start, uint num) override final {
+		assert(start + num <= 256);
+		setCursorPaletteIntern(colors, start, num);
 	}
 };
 

--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -108,7 +108,6 @@ public:
 	virtual bool showMouse(bool visible) = 0;
 	virtual void warpMouse(int x, int y) = 0;
 	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = nullptr, const byte *mask = nullptr) = 0;
-	virtual void setCursorPalette(const byte *colors, uint start, uint num) = 0;
 
 	virtual void displayMessageOnOSD(const Common::U32String &msg) {}
 	virtual void displayActivityIconOnOSD(const Graphics::Surface *icon) {}
@@ -117,6 +116,7 @@ public:
 	// Graphics::PaletteManager interface
 	//virtual void setPalette(const byte *colors, uint start, uint num) = 0;
 	//virtual void grabPalette(byte *colors, uint start, uint num) const = 0;
+	//virtual void setCursorPalette(const byte *colors, uint start, uint num) = 0;
 
 	virtual void saveScreenshot() {}
 	virtual bool lockMouse(bool lock) { return false; }

--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -34,7 +34,7 @@
  * Abstract class for graphics manager. Subclasses
  * implement the real functionality.
  */
-class GraphicsManager : public PaletteManager {
+class GraphicsManager {
 public:
 	virtual ~GraphicsManager() {}
 
@@ -82,8 +82,6 @@ public:
 
 	virtual int16 getHeight() const = 0;
 	virtual int16 getWidth() const = 0;
-	virtual void setPalette(const byte *colors, uint start, uint num) = 0;
-	virtual void grabPalette(byte *colors, uint start, uint num) const = 0;
 	virtual void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) = 0;
 	virtual Graphics::Surface *lockScreen() = 0;
 	virtual void unlockScreen() = 0;
@@ -112,11 +110,7 @@ public:
 	virtual void displayMessageOnOSD(const Common::U32String &msg) {}
 	virtual void displayActivityIconOnOSD(const Graphics::Surface *icon) {}
 
-
-	// Graphics::PaletteManager interface
-	//virtual void setPalette(const byte *colors, uint start, uint num) = 0;
-	//virtual void grabPalette(byte *colors, uint start, uint num) const = 0;
-	//virtual void setCursorPalette(const byte *colors, uint start, uint num) = 0;
+	virtual PaletteManager *getPaletteManager() = 0;
 
 	virtual void saveScreenshot() {}
 	virtual bool lockMouse(bool lock) { return false; }

--- a/backends/graphics/null/null-graphics.h
+++ b/backends/graphics/null/null-graphics.h
@@ -23,8 +23,9 @@
 #define BACKENDS_GRAPHICS_NULL_H
 
 #include "backends/graphics/graphics.h"
+#include "backends/graphics/default-palette.h"
 
-class NullGraphicsManager : public GraphicsManager, public PaletteManager {
+class NullGraphicsManager : public GraphicsManager, public DefaultPaletteManager {
 public:
 	virtual ~NullGraphicsManager() {}
 
@@ -62,9 +63,6 @@ public:
 
 	int16 getHeight() const override { return _height; }
 	int16 getWidth() const override { return _width; }
-	PaletteManager *getPaletteManager() override { return this; }
-	void setPalette(const byte *colors, uint start, uint num) override {}
-	void grabPalette(byte *colors, uint start, uint num) const override {}
 	void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) override {}
 	Graphics::Surface *lockScreen() override { return NULL; }
 	void unlockScreen() override {}
@@ -88,7 +86,12 @@ public:
 	bool showMouse(bool visible) override { return !visible; }
 	void warpMouse(int x, int y) override {}
 	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override {}
-	void setCursorPalette(const byte *colors, uint start, uint num) override {}
+
+	PaletteManager *getPaletteManager() override { return this; }
+protected:
+	// DefaultPaletteManager interface
+	void setPaletteIntern(const byte *colors, uint start, uint num) override {}
+	void setCursorPaletteIntern(const byte *colors, uint start, uint num) override {}
 
 private:
 	uint _width, _height;

--- a/backends/graphics/null/null-graphics.h
+++ b/backends/graphics/null/null-graphics.h
@@ -24,7 +24,7 @@
 
 #include "backends/graphics/graphics.h"
 
-class NullGraphicsManager : public GraphicsManager {
+class NullGraphicsManager : public GraphicsManager, public PaletteManager {
 public:
 	virtual ~NullGraphicsManager() {}
 
@@ -62,6 +62,7 @@ public:
 
 	int16 getHeight() const override { return _height; }
 	int16 getWidth() const override { return _width; }
+	PaletteManager *getPaletteManager() override { return this; }
 	void setPalette(const byte *colors, uint start, uint num) override {}
 	void grabPalette(byte *colors, uint start, uint num) const override {}
 	void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) override {}

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -1125,7 +1125,7 @@ void OpenGLGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int 
 	recalculateCursorScaling();
 }
 
-void OpenGLGraphicsManager::setCursorPalette(const byte *colors, uint start, uint num) {
+void OpenGLGraphicsManager::setCursorPaletteIntern(const byte *colors, uint start, uint num) {
 	// FIXME: For some reason client code assumes that usage of this function
 	// automatically enables the cursor palette.
 	_cursorPaletteEnabled = true;
@@ -1250,7 +1250,7 @@ void OpenGLGraphicsManager::displayActivityIconOnOSD(const Graphics::Surface *ic
 #endif
 }
 
-void OpenGLGraphicsManager::setPalette(const byte *colors, uint start, uint num) {
+void OpenGLGraphicsManager::setPaletteIntern(const byte *colors, uint start, uint num) {
 	assert(_gameScreen->hasPalette());
 
 	memcpy(_gamePalette + start * 3, colors, num * 3);
@@ -1258,12 +1258,6 @@ void OpenGLGraphicsManager::setPalette(const byte *colors, uint start, uint num)
 
 	// We might need to update the cursor palette here.
 	updateCursorPalette();
-}
-
-void OpenGLGraphicsManager::grabPalette(byte *colors, uint start, uint num) const {
-	assert(_gameScreen->hasPalette());
-
-	memcpy(colors, _gamePalette + start * 3, num * 3);
 }
 
 void OpenGLGraphicsManager::handleResizeImpl(const int width, const int height) {

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -23,6 +23,7 @@
 #define BACKENDS_GRAPHICS_OPENGL_OPENGL_GRAPHICS_H
 
 #include "backends/graphics/opengl/framebuffer.h"
+#include "backends/graphics/default-palette.h"
 #include "backends/graphics/windowed.h"
 
 #include "base/plugins.h"
@@ -54,7 +55,7 @@ enum {
 	GFX_OPENGL = 0
 };
 
-class OpenGLGraphicsManager : virtual public WindowedGraphicsManager, public PaletteManager {
+class OpenGLGraphicsManager : virtual public WindowedGraphicsManager, public DefaultPaletteManager {
 public:
 	OpenGLGraphicsManager();
 	virtual ~OpenGLGraphicsManager();
@@ -123,15 +124,15 @@ public:
 	void grabOverlay(Graphics::Surface &surface) const override;
 
 	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) override;
-	void setCursorPalette(const byte *colors, uint start, uint num) override;
 
 	void displayMessageOnOSD(const Common::U32String &msg) override;
 	void displayActivityIconOnOSD(const Graphics::Surface *icon) override;
 
-	// PaletteManager interface
 	PaletteManager *getPaletteManager() override { return this; }
-	void setPalette(const byte *colors, uint start, uint num) override;
-	void grabPalette(byte *colors, uint start, uint num) const override;
+protected:
+	// DefaultPaletteManager interface
+	void setPaletteIntern(const byte *colors, uint start, uint num) override;
+	void setCursorPaletteIntern(const byte *colors, uint start, uint num) override;
 
 protected:
 	void renderCursor();

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -54,7 +54,7 @@ enum {
 	GFX_OPENGL = 0
 };
 
-class OpenGLGraphicsManager : virtual public WindowedGraphicsManager {
+class OpenGLGraphicsManager : virtual public WindowedGraphicsManager, public PaletteManager {
 public:
 	OpenGLGraphicsManager();
 	virtual ~OpenGLGraphicsManager();
@@ -129,6 +129,7 @@ public:
 	void displayActivityIconOnOSD(const Graphics::Surface *icon) override;
 
 	// PaletteManager interface
+	PaletteManager *getPaletteManager() override { return this; }
 	void setPalette(const byte *colors, uint start, uint num) override;
 	void grabPalette(byte *colors, uint start, uint num) const override;
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -1938,7 +1938,7 @@ int16 SurfaceSdlGraphicsManager::getWidth() const {
 	return _videoMode.screenWidth;
 }
 
-void SurfaceSdlGraphicsManager::setPalette(const byte *colors, uint start, uint num) {
+void SurfaceSdlGraphicsManager::setPaletteIntern(const byte *colors, uint start, uint num) {
 	assert(colors);
 	assert(_screenFormat.bytesPerPixel == 1);
 
@@ -1972,20 +1972,7 @@ void SurfaceSdlGraphicsManager::setPalette(const byte *colors, uint start, uint 
 		blitCursor();
 }
 
-void SurfaceSdlGraphicsManager::grabPalette(byte *colors, uint start, uint num) const {
-	assert(colors);
-	assert(_screenFormat.bytesPerPixel == 1);
-
-	const SDL_Color *base = _currentPalette + start;
-
-	for (uint i = 0; i < num; ++i) {
-		colors[i * 3] = base[i].r;
-		colors[i * 3 + 1] = base[i].g;
-		colors[i * 3 + 2] = base[i].b;
-	}
-}
-
-void SurfaceSdlGraphicsManager::setCursorPalette(const byte *colors, uint start, uint num) {
+void SurfaceSdlGraphicsManager::setCursorPaletteIntern(const byte *colors, uint start, uint num) {
 	assert(colors);
 	const byte *b = colors;
 	uint i;

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -47,7 +47,7 @@ enum {
 /**
  * SDL graphics manager
  */
-class SurfaceSdlGraphicsManager : public SdlGraphicsManager {
+class SurfaceSdlGraphicsManager : public SdlGraphicsManager, public PaletteManager {
 public:
 	SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
 	virtual ~SurfaceSdlGraphicsManager();
@@ -86,8 +86,10 @@ public:
 
 protected:
 	// PaletteManager API
+	PaletteManager *getPaletteManager() override { return this; }
 	void setPalette(const byte *colors, uint start, uint num) override;
 	void grabPalette(byte *colors, uint start, uint num) const override;
+
 	virtual void initGraphicsSurface();
 
 	/**

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -23,6 +23,7 @@
 #define BACKENDS_GRAPHICS_SURFACESDL_GRAPHICS_H
 
 #include "backends/graphics/graphics.h"
+#include "backends/graphics/default-palette.h"
 #include "backends/graphics/sdl/sdl-graphics.h"
 #include "graphics/pixelformat.h"
 #include "graphics/scaler.h"
@@ -47,7 +48,7 @@ enum {
 /**
  * SDL graphics manager
  */
-class SurfaceSdlGraphicsManager : public SdlGraphicsManager, public PaletteManager {
+class SurfaceSdlGraphicsManager : public SdlGraphicsManager, public DefaultPaletteManager {
 public:
 	SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSource, SdlWindow *window);
 	virtual ~SurfaceSdlGraphicsManager();
@@ -84,11 +85,11 @@ public:
 	int16 getHeight() const override;
 	int16 getWidth() const override;
 
-protected:
-	// PaletteManager API
 	PaletteManager *getPaletteManager() override { return this; }
-	void setPalette(const byte *colors, uint start, uint num) override;
-	void grabPalette(byte *colors, uint start, uint num) const override;
+protected:
+	// DefaultPaletteManager API
+	void setPaletteIntern(const byte *colors, uint start, uint num) override;
+	void setCursorPaletteIntern(const byte *colors, uint start, uint num) override;
 
 	virtual void initGraphicsSurface();
 
@@ -121,7 +122,6 @@ public:
 
 	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override;
 	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask, bool disableKeyColor);
-	void setCursorPalette(const byte *colors, uint start, uint num) override;
 
 #ifdef USE_OSD
 	void displayMessageOnOSD(const Common::U32String &msg) override;

--- a/backends/graphics3d/android/android-graphics3d.cpp
+++ b/backends/graphics3d/android/android-graphics3d.cpp
@@ -668,12 +668,7 @@ int16 AndroidGraphics3dManager::getWidth() const {
 		return _overlay_texture->width();
 }
 
-void AndroidGraphics3dManager::setPalette(const byte *colors, uint start, uint num) {
-	// We should never end up here in 3D
-	assert(false);
-}
-
-void AndroidGraphics3dManager::grabPalette(byte *colors, uint start, uint num) const {
+void AndroidGraphics3dManager::setPaletteIntern(const byte *colors, uint start, uint num) {
 	// We should never end up here in 3D
 	assert(false);
 }
@@ -915,7 +910,7 @@ void AndroidGraphics3dManager::setMouseCursor(const void *buf, uint w, uint h,
 	updateCursorScaling();
 }
 
-void AndroidGraphics3dManager::setCursorPalette(const byte *colors,
+void AndroidGraphics3dManager::setCursorPaletteIntern(const byte *colors,
         uint start, uint num) {
 	ENTER("%p, %u, %u", colors, start, num);
 

--- a/backends/graphics3d/android/android-graphics3d.h
+++ b/backends/graphics3d/android/android-graphics3d.h
@@ -86,10 +86,6 @@ public:
 	virtual int16 getHeight() const override;
 	virtual int16 getWidth() const override;
 
-	// PaletteManager API
-	PaletteManager *getPaletteManager() override { return this; }
-	virtual void setPalette(const byte *colors, uint start, uint num) override;
-	virtual void grabPalette(byte *colors, uint start, uint num) const override;
 	virtual void copyRectToScreen(const void *buf, int pitch, int x, int y,
 	                              int w, int h) override;
 	virtual Graphics::Surface *lockScreen() override;
@@ -112,10 +108,16 @@ public:
 	                            int hotspotY, uint32 keycolor,
 	                            bool dontScale,
 	                            const Graphics::PixelFormat *format, const byte *mask) override;
-	virtual void setCursorPalette(const byte *colors, uint start, uint num) override;
 
 	float getHiDPIScreenFactor() const override;
 
+	PaletteManager *getPaletteManager() override { return this; }
+protected:
+	// DefaultPaletteManager API
+	void setPaletteIntern(const byte *colors, uint start, uint num) override;
+	void setCursorPaletteIntern(const byte *colors, uint start, uint num) override;
+
+public:
 #ifdef USE_RGB_COLOR
 	virtual Graphics::PixelFormat getScreenFormat() const override;
 	virtual Common::List<Graphics::PixelFormat> getSupportedFormats() const override;

--- a/backends/graphics3d/android/android-graphics3d.h
+++ b/backends/graphics3d/android/android-graphics3d.h
@@ -31,7 +31,7 @@
 #include "backends/platform/android/touchcontrols.h"
 
 class AndroidGraphics3dManager :
-	public GraphicsManager, public AndroidCommonGraphics, public TouchControlsDrawer {
+	public GraphicsManager, public PaletteManager, public AndroidCommonGraphics, public TouchControlsDrawer {
 public:
 	AndroidGraphics3dManager();
 	virtual ~AndroidGraphics3dManager();
@@ -87,6 +87,7 @@ public:
 	virtual int16 getWidth() const override;
 
 	// PaletteManager API
+	PaletteManager *getPaletteManager() override { return this; }
 	virtual void setPalette(const byte *colors, uint start, uint num) override;
 	virtual void grabPalette(byte *colors, uint start, uint num) const override;
 	virtual void copyRectToScreen(const void *buf, int pitch, int x, int y,

--- a/backends/graphics3d/android/texture.cpp
+++ b/backends/graphics3d/android/texture.cpp
@@ -521,14 +521,6 @@ void GLESFakePalette16Texture::setPalette(const byte *colors, uint start, uint n
 	}
 }
 
-void GLESFakePalette16Texture::grabPalette(byte *colors, uint start, uint num) const {
-        const uint16 *p = _palette + start;
-
-        for (uint i = 0; i < num; ++i, colors += 3, ++p) {
-                _palettePixelFormat.colorToRGB(*p, colors[0], colors[1], colors[2]);
-        }
-}
-
 GLESFakePalette565Texture::GLESFakePalette565Texture() :
 	GLESFakePalette16Texture(GL_RGB, GL_UNSIGNED_SHORT_5_6_5,
 	                         GLES565Texture::pixelFormat()) {
@@ -599,10 +591,6 @@ void GLESFakePalette888Texture::setPalette(const byte *colors, uint start, uint 
 	memcpy(_palette + start * 3, colors, num * 3);
 }
 
-void GLESFakePalette888Texture::grabPalette(byte *colors, uint start, uint num) const {
-	memcpy(colors, _palette + start * 3, num * 3);
-}
-
 GLESFakePalette8888Texture::GLESFakePalette8888Texture() :
 	GLESFakePaletteTexture(GL_RGBA, GL_UNSIGNED_BYTE,
 	                       GLES8888Texture::pixelFormat()),
@@ -667,14 +655,4 @@ void GLESFakePalette8888Texture::setKeycolor(byte color) {
 
 	p = (byte *)(_palette + _keycolor);
 	p[3] = 0;
-}
-
-void GLESFakePalette8888Texture::grabPalette(byte *colors, uint start, uint num) const {
-	const byte *p = (byte *)(_palette + start);
-
-        for (uint i = 0; i < num; ++i, colors += 3, p += 4) {
-		colors[0] = p[0];
-		colors[1] = p[1];
-		colors[2] = p[2];
-        }
 }

--- a/backends/graphics3d/android/texture.h
+++ b/backends/graphics3d/android/texture.h
@@ -130,7 +130,6 @@ public:
 
 	virtual void setPalette(const byte *colors, uint start, uint num) = 0;
 	virtual void setKeycolor(byte color) = 0;
-	virtual void grabPalette(byte *colors, uint start, uint num) const = 0;
 
 	inline bool hasPalette() const {
 		return _palettePixelFormat.bytesPerPixel > 0;
@@ -236,7 +235,6 @@ public:
 
 	void setPalette(const byte *colors, uint start, uint num) override {}
 	void setKeycolor(byte color) override {};
-	void grabPalette(byte *colors, uint start, uint num) const override {}
 
 	void readPixels();
 
@@ -332,7 +330,6 @@ public:
 	void allocBuffer(GLuint w, GLuint h) override;
 
 	void setPalette(const byte *colors, uint start, uint num) override;
-	void grabPalette(byte *colors, uint start, uint num) const override;
 
 protected:
 	void *prepareTextureBuffer(const Common::Rect &rect) override;
@@ -369,7 +366,6 @@ public:
 
 	void setPalette(const byte *colors, uint start, uint num) override;
 	void setKeycolor(byte color) override {};
-	void grabPalette(byte *colors, uint start, uint num) const override;
 
 protected:
 	void *prepareTextureBuffer(const Common::Rect &rect) override;
@@ -387,7 +383,6 @@ public:
 
 	void setPalette(const byte *colors, uint start, uint num) override;
 	void setKeycolor(byte color) override;
-	void grabPalette(byte *colors, uint start, uint num) const override;
 
 protected:
 	void *prepareTextureBuffer(const Common::Rect &rect) override;

--- a/backends/graphics3d/ios/ios-graphics3d.h
+++ b/backends/graphics3d/ios/ios-graphics3d.h
@@ -27,12 +27,13 @@
 #include "common/scummsys.h"
 
 #include "backends/graphics/windowed.h"
+#include "backends/graphics/default-palette.h"
 #include "backends/graphics/ios/ios-graphics.h"
 #include "backends/graphics3d/opengl/framebuffer.h"
 #include "backends/graphics3d/opengl/tiledsurface.h"
 #include "backends/graphics3d/opengl/surfacerenderer.h"
 
-class iOSGraphics3dManager : virtual public WindowedGraphicsManager, public PaletteManager, public iOSCommonGraphics {
+class iOSGraphics3dManager : virtual public WindowedGraphicsManager, public DefaultPaletteManager, public iOSCommonGraphics {
 public:
 	iOSGraphics3dManager();
 	virtual ~iOSGraphics3dManager();
@@ -87,9 +88,6 @@ public:
 	// GraphicsManager API - Draw methods
 	void updateScreen() override;
 	// Following methods are not used by 3D graphics managers
-	PaletteManager *getPaletteManager() override { return this; }
-	void setPalette(const byte *colors, uint start, uint num) override {}
-	void grabPalette(byte *colors, uint start, uint num) const override {}
 	void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) override {}
 	Graphics::Surface *lockScreen() override { return nullptr; }
 	void unlockScreen() override {}
@@ -116,7 +114,13 @@ public:
 	// GraphicsManager API - Mouse
 	bool showMouse(bool visible) override;
 	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override;
-	void setCursorPalette(const byte *colors, uint start, uint num) override {}
+
+	// GraphicsManager API - Palette
+	PaletteManager *getPaletteManager() override { return this; }
+protected:
+	// DefaultPaletteManager interface
+	void setPaletteIntern(const byte *colors, uint start, uint num) override {}
+	void setCursorPaletteIntern(const byte *colors, uint start, uint num) override {}
 
 protected:
 	void updateCursorScaling();

--- a/backends/graphics3d/ios/ios-graphics3d.h
+++ b/backends/graphics3d/ios/ios-graphics3d.h
@@ -32,7 +32,7 @@
 #include "backends/graphics3d/opengl/tiledsurface.h"
 #include "backends/graphics3d/opengl/surfacerenderer.h"
 
-class iOSGraphics3dManager : virtual public WindowedGraphicsManager, public iOSCommonGraphics {
+class iOSGraphics3dManager : virtual public WindowedGraphicsManager, public PaletteManager, public iOSCommonGraphics {
 public:
 	iOSGraphics3dManager();
 	virtual ~iOSGraphics3dManager();
@@ -87,6 +87,7 @@ public:
 	// GraphicsManager API - Draw methods
 	void updateScreen() override;
 	// Following methods are not used by 3D graphics managers
+	PaletteManager *getPaletteManager() override { return this; }
 	void setPalette(const byte *colors, uint start, uint num) override {}
 	void grabPalette(byte *colors, uint start, uint num) const override {}
 	void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) override {}

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
@@ -23,6 +23,7 @@
 #define BACKENDS_GRAPHICS3D_OPENGLSDL_GRAPHICS3D_H
 
 #include "backends/graphics/sdl/sdl-graphics.h"
+#include "backends/graphics/default-palette.h"
 
 #include "math/rect2d.h"
 
@@ -41,7 +42,7 @@ namespace OpenGL {
  *
  * Used when rendering games with OpenGL
  */
-class OpenGLSdlGraphics3dManager : public SdlGraphicsManager, public PaletteManager {
+class OpenGLSdlGraphics3dManager : public SdlGraphicsManager, public DefaultPaletteManager {
 public:
 	OpenGLSdlGraphics3dManager(SdlEventSource *eventSource, SdlWindow *window, bool supportsFrameBuffer);
 	virtual ~OpenGLSdlGraphics3dManager();
@@ -80,9 +81,6 @@ public:
 	// GraphicsManager API - Draw methods
 	void updateScreen() override;
 	// Following methods are not used by 3D graphics managers
-	PaletteManager *getPaletteManager() override { return this; }
-	void setPalette(const byte *colors, uint start, uint num) override {}
-	void grabPalette(byte *colors, uint start, uint num) const override {}
 	void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) override {}
 	Graphics::Surface *lockScreen() override { return nullptr; }
 	void unlockScreen() override {}
@@ -105,8 +103,15 @@ public:
 	// GraphicsManager API - Mouse
 	bool showMouse(bool visible) override;
 	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override {}
-	void setCursorPalette(const byte *colors, uint start, uint num) override {}
 
+	// GraphicsManager API - Palette
+	PaletteManager *getPaletteManager() override { return this; }
+protected:
+	// DefaultPaletteManager interface
+	void setPaletteIntern(const byte *colors, uint start, uint num) override {}
+	void setCursorPaletteIntern(const byte *colors, uint start, uint num) override {}
+
+public:
 	// SdlGraphicsManager API
 	void notifyVideoExpose() override {};
 	void notifyResize(const int width, const int height) override;

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.h
@@ -41,7 +41,7 @@ namespace OpenGL {
  *
  * Used when rendering games with OpenGL
  */
-class OpenGLSdlGraphics3dManager : public SdlGraphicsManager {
+class OpenGLSdlGraphics3dManager : public SdlGraphicsManager, public PaletteManager {
 public:
 	OpenGLSdlGraphics3dManager(SdlEventSource *eventSource, SdlWindow *window, bool supportsFrameBuffer);
 	virtual ~OpenGLSdlGraphics3dManager();
@@ -80,6 +80,7 @@ public:
 	// GraphicsManager API - Draw methods
 	void updateScreen() override;
 	// Following methods are not used by 3D graphics managers
+	PaletteManager *getPaletteManager() override { return this; }
 	void setPalette(const byte *colors, uint start, uint num) override {}
 	void grabPalette(byte *colors, uint start, uint num) const override {}
 	void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) override {}

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -280,10 +280,6 @@ void ModularGraphicsBackend::setMouseCursor(const void *buf, uint w, uint h, int
 	_graphicsManager->setMouseCursor(buf, w, h, hotspotX, hotspotY, keycolor, dontScale, format, mask);
 }
 
-void ModularGraphicsBackend::setCursorPalette(const byte *colors, uint start, uint num) {
-	_graphicsManager->setCursorPalette(colors, start, num);
-}
-
 void ModularGraphicsBackend::displayMessageOnOSD(const Common::U32String &msg) {
 	_graphicsManager->displayMessageOnOSD(msg);
 }

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -166,7 +166,7 @@ int16 ModularGraphicsBackend::getWidth() {
 }
 
 PaletteManager *ModularGraphicsBackend::getPaletteManager() {
-	return _graphicsManager;
+	return _graphicsManager->getPaletteManager();
 }
 
 void ModularGraphicsBackend::copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) {

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -122,7 +122,6 @@ public:
 	bool showMouse(bool visible) override final;
 	void warpMouse(int x, int y) override final;
 	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override final;
-	void setCursorPalette(const byte *colors, uint start, uint num) override final;
 	bool lockMouse(bool lock) override final;
 
 	//@}

--- a/backends/platform/3ds/osystem-graphics.cpp
+++ b/backends/platform/3ds/osystem-graphics.cpp
@@ -353,16 +353,11 @@ float OSystem_3DS::getScaleRatio() const {
 	}
 }
 
-void OSystem_3DS::setPalette(const byte *colors, uint start, uint num) {
+void OSystem_3DS::setPaletteIntern(const byte *colors, uint start, uint num) {
 	assert(start + num <= 256);
 	memcpy(_palette + 3 * start, colors, 3 * num);
 	Graphics::convertPaletteToMap(_paletteMap + start, colors, num, _modeCLUT8.surfaceFormat);
 	_gameTextureDirty = true;
-}
-
-void OSystem_3DS::grabPalette(byte *colors, uint start, uint num) const {
-	assert(start + num <= 256);
-	memcpy(colors, _palette + 3 * start, 3 * num);
 }
 
 static void copyRect555To5551(const Graphics::Surface &srcSurface, Graphics::Surface &destSurface, uint16 destX, uint16 destY, const Common::Rect &srcRect) {
@@ -819,7 +814,7 @@ void OSystem_3DS::setMouseCursor(const void *buf, uint w, uint h,
 	}
 }
 
-void OSystem_3DS::setCursorPalette(const byte *colors, uint start, uint num) {
+void OSystem_3DS::setCursorPaletteIntern(const byte *colors, uint start, uint num) {
 	assert(start + num <= 256);
 	memcpy(_cursorPalette + 3 * start, colors, 3 * num);
 	_cursorPaletteEnabled = true;

--- a/backends/platform/3ds/osystem.h
+++ b/backends/platform/3ds/osystem.h
@@ -25,10 +25,10 @@
 #define FORBIDDEN_SYMBOL_EXCEPTION_time_h
 
 #include "backends/base-backend.h"
-#include "graphics/paletteman.h"
 #include "base/main.h"
 #include "audio/mixer_intern.h"
 #include "backends/graphics/graphics.h"
+#include "backends/graphics/default-palette.h"
 #include "backends/log/log.h"
 #include "backends/platform/3ds/sprite.h"
 #include "common/rect.h"
@@ -99,7 +99,7 @@ struct GfxState {
 };
 
 
-class OSystem_3DS : public EventsBaseBackend, public PaletteManager, public Common::EventObserver {
+class OSystem_3DS : public EventsBaseBackend, public DefaultPaletteManager, public Common::EventObserver {
 public:
 	OSystem_3DS();
 	virtual ~OSystem_3DS();
@@ -132,7 +132,6 @@ public:
 	virtual void logMessage(LogMessageType::Type type, const char *message);
 
 	virtual Audio::Mixer *getMixer();
-	virtual PaletteManager *getPaletteManager() { return this; }
 	virtual Common::String getSystemLanguage() const;
 	virtual void fatalError();
 	virtual void quit();
@@ -154,8 +153,6 @@ public:
 	int16 getHeight(){ return _gameHeight; }
 	int16 getWidth(){ return _gameWidth; }
 	float getScaleRatio() const;
-	void setPalette(const byte *colors, uint start, uint num);
-	void grabPalette(byte *colors, uint start, uint num) const;
 	void copyRectToScreen(const void *buf, int pitch, int x, int y, int w,
 	                      int h);
 	Graphics::Surface *lockScreen();
@@ -182,8 +179,14 @@ public:
 	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX,
 	                    int hotspotY, uint32 keycolor, bool dontScale = false,
 	                    const Graphics::PixelFormat *format = NULL, const byte *mask = NULL);
-	void setCursorPalette(const byte *colors, uint start, uint num);
 
+	PaletteManager *getPaletteManager() override { return this; }
+protected:
+	// DefaultPaletteManager interface
+	void setPaletteIntern(const byte *colors, uint start, uint num) override;
+	void setCursorPaletteIntern(const byte *colors, uint start, uint num) override;
+
+public:
 	// Transform point from touchscreen coords into gamescreen coords
 	void transformPoint(touchPosition &point);
 	// Clip point to gamescreen coords

--- a/backends/platform/dc/dc.h
+++ b/backends/platform/dc/dc.h
@@ -21,8 +21,8 @@
 
 #include "backends/base-backend.h"
 #include <graphics/surface.h>
-#include <graphics/paletteman.h>
 #include <ronin/soundcommon.h>
+#include "backends/graphics/default-palette.h"
 #include "backends/timer/default/default-timer.h"
 #include "backends/audiocd/default/default-audiocd.h"
 #include "backends/fs/fs-factory.h"
@@ -68,7 +68,7 @@ public:
 	void stop() override;
 };
 
-class OSystem_Dreamcast : private DCHardware, public EventsBaseBackend, public PaletteManager, public FilesystemFactory
+class OSystem_Dreamcast : private DCHardware, public EventsBaseBackend, public DefaultPaletteManager, public FilesystemFactory
 #ifdef DYNAMIC_MODULES
   , public FilePluginProvider
 #endif
@@ -88,12 +88,11 @@ class OSystem_Dreamcast : private DCHardware, public EventsBaseBackend, public P
   // Query the state of the specified feature.
   bool getFeatureState(Feature f);
 
-  // Set colors of the palette
-  PaletteManager *getPaletteManager() { return this; }
+  PaletteManager *getPaletteManager() override { return this; }
 protected:
-	// PaletteManager API
-  void setPalette(const byte *colors, uint start, uint num);
-  void grabPalette(byte *colors, uint start, uint num) const;
+  // DefaultPaletteManager API
+  void setPaletteIntern(const byte *colors, uint start, uint num) override;
+  void setCursorPaletteIntern(const byte *colors, uint start, uint num) override;
 
 public:
 
@@ -127,9 +126,6 @@ public:
 
   // Set the bitmap that's used when drawing the cursor.
   void setMouseCursor(const void *buf, uint w, uint h, int hotspot_x, int hotspot_y, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask);
-
-  // Replace the specified range of cursor the palette with new colors.
-  void setCursorPalette(const byte *colors, uint start, uint num);
 
   // Shaking is used in SCUMM. Set current shake position.
   void setShakePos(int shake_x_pos, int shake_y_pos);

--- a/backends/platform/dc/display.cpp
+++ b/backends/platform/dc/display.cpp
@@ -146,7 +146,7 @@ void commit_dummy_transpoly()
 }
 
 
-void OSystem_Dreamcast::setPalette(const byte *colors, uint start, uint num)
+void OSystem_Dreamcast::setPaletteIntern(const byte *colors, uint start, uint num)
 {
   unsigned short *dst = palette + start;
   if (num>0)
@@ -159,7 +159,7 @@ void OSystem_Dreamcast::setPalette(const byte *colors, uint start, uint num)
   _screen_dirty = true;
 }
 
-void OSystem_Dreamcast::setCursorPalette(const byte *colors, uint start, uint num)
+void OSystem_Dreamcast::setCursorPaletteIntern(const byte *colors, uint start, uint num)
 {
   unsigned short *dst = cursor_palette + start;
   if (num>0)
@@ -170,19 +170,6 @@ void OSystem_Dreamcast::setCursorPalette(const byte *colors, uint start, uint nu
 	  colors += 3;
 	}
   _enable_cursor_palette = true;
-}
-
-void OSystem_Dreamcast::grabPalette(byte *colors, uint start, uint num) const
-{
-  const unsigned short *src = palette + start;
-  if (num>0)
-	while ( num-- ) {
-	  unsigned short p = *src++;
-	  colors[0] = ((p&0x7c00)>>7)|((p&0x7000)>>12);
-	  colors[1] = ((p&0x03e0)>>2)|((p&0x0380)>>7);
-	  colors[2] = ((p&0x001f)<<3)|((p&0x001c)>>2);
-	  colors += 3;
-	}
 }
 
 Graphics::PixelFormat OSystem_Dreamcast::getScreenFormat() const

--- a/backends/platform/ds/ds-graphics.cpp
+++ b/backends/platform/ds/ds-graphics.cpp
@@ -400,7 +400,7 @@ int16 OSystem_DS::getWidth() {
 	return _framebuffer.w;
 }
 
-void OSystem_DS::setPalette(const byte *colors, uint start, uint num) {
+void OSystem_DS::setPaletteIntern(const byte *colors, uint start, uint num) {
 	for (unsigned int r = start; r < start + num; r++) {
 		int red = *colors;
 		int green = *(colors + 1);
@@ -415,7 +415,7 @@ void OSystem_DS::setPalette(const byte *colors, uint start, uint num) {
 		_cursorDirty = true;
 }
 
-void OSystem_DS::setCursorPalette(const byte *colors, uint start, uint num) {
+void OSystem_DS::setCursorPaletteIntern(const byte *colors, uint start, uint num) {
 
 	for (unsigned int r = start; r < start + num; r++) {
 		int red = *colors;
@@ -428,14 +428,6 @@ void OSystem_DS::setCursorPalette(const byte *colors, uint start, uint num) {
 
 	_disableCursorPalette = false;
 	_cursorDirty = true;
-}
-
-void OSystem_DS::grabPalette(unsigned char *colors, uint start, uint num) const {
-	for (unsigned int r = start; r < start + num; r++) {
-		*colors++ = (_palette[r] & 0x001F) << 3;
-		*colors++ = (_palette[r] & 0x03E0) >> 5 << 3;
-		*colors++ = (_palette[r] & 0x7C00) >> 10 << 3;
-	}
 }
 
 void OSystem_DS::copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) {

--- a/backends/platform/ds/osystem_ds.h
+++ b/backends/platform/ds/osystem_ds.h
@@ -25,11 +25,11 @@
 
 #include "backends/modular-backend.h"
 #include "backends/events/ds/ds-events.h"
+#include "backends/graphics/default-palette.h"
 #include "backends/mixer/mixer.h"
 #include "backends/platform/ds/background.h"
 #include "backends/platform/ds/keyboard.h"
 #include "graphics/surface.h"
-#include "graphics/paletteman.h"
 
 enum {
 	GFX_NOSCALE = 0,
@@ -37,7 +37,7 @@ enum {
 	GFX_SWSCALE = 2
 };
 
-class OSystem_DS : public ModularMixerBackend, public PaletteManager {
+class OSystem_DS : public ModularMixerBackend, public DefaultPaletteManager {
 protected:
 	Graphics::Surface _framebuffer, _overlay;
 	DS::Background *_screen, *_overlayScreen;
@@ -101,11 +101,11 @@ public:
 	virtual int16 getHeight();
 	virtual int16 getWidth();
 
-	virtual PaletteManager *getPaletteManager() { return this; }
+	PaletteManager *getPaletteManager() override { return this; }
 protected:
-	// PaletteManager API
-	virtual void setPalette(const byte *colors, uint start, uint num);
-	virtual void grabPalette(byte *colors, uint start, uint num) const;
+	// DefaultPaletteManager API
+	void setPaletteIntern(const byte *colors, uint start, uint num) override;
+	void setCursorPaletteIntern(const byte *colors, uint start, uint num) override;
 
 public:
 	virtual void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h);
@@ -152,8 +152,6 @@ public:
 
 	virtual Graphics::Surface *lockScreen();
 	virtual void unlockScreen();
-
-	virtual void setCursorPalette(const byte *colors, uint start, uint num);
 
 	void setSwapLCDs(bool swap);
 

--- a/backends/platform/libretro/include/libretro-graphics-surface.h
+++ b/backends/platform/libretro/include/libretro-graphics-surface.h
@@ -20,9 +20,10 @@
 #include "common/system.h"
 #include "graphics/palette.h"
 #include "graphics/managed_surface.h"
+#include "backends/graphics/default-palette.h"
 #include "backends/graphics/windowed.h"
 
-class LibretroGraphics : public WindowedGraphicsManager, public PaletteManager {
+class LibretroGraphics : public WindowedGraphicsManager, public DefaultPaletteManager {
 
 public:
 	Graphics::ManagedSurface _screen;
@@ -65,7 +66,6 @@ public:
 	const Graphics::ManagedSurface *getScreen(void);
 	void warpMouse(int x, int y) override;
 	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor = 255, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = nullptr) override;
-	void setCursorPalette(const byte *colors, uint start, uint num) override;
 	bool isOverlayInGUI(void);
 
 	bool hasFeature(OSystem::Feature f) const override;
@@ -107,8 +107,9 @@ public:
 
 	PaletteManager *getPaletteManager() override { return this; }
 protected:
-	void setPalette(const byte *colors, uint start, uint num) override;
-	void grabPalette(byte *colors, uint start, uint num) const override;
+	// DefaultPaletteManager interface
+	void setPaletteIntern(const byte *colors, uint start, uint num) override;
+	void setCursorPaletteIntern(const byte *colors, uint start, uint num) override;
 private:
 	void overrideCursorScaling();
 };

--- a/backends/platform/libretro/include/libretro-graphics-surface.h
+++ b/backends/platform/libretro/include/libretro-graphics-surface.h
@@ -22,7 +22,7 @@
 #include "graphics/managed_surface.h"
 #include "backends/graphics/windowed.h"
 
-class LibretroGraphics : public WindowedGraphicsManager {
+class LibretroGraphics : public WindowedGraphicsManager, public PaletteManager {
 
 public:
 	Graphics::ManagedSurface _screen;
@@ -105,6 +105,7 @@ public:
 
 	void displayMessageOnOSD(const Common::U32String &msg) override;
 
+	PaletteManager *getPaletteManager() override { return this; }
 protected:
 	void setPalette(const byte *colors, uint start, uint num) override;
 	void grabPalette(byte *colors, uint start, uint num) const override;

--- a/backends/platform/libretro/src/libretro-graphics-surface.cpp
+++ b/backends/platform/libretro/src/libretro-graphics-surface.cpp
@@ -206,7 +206,7 @@ void LibretroGraphics::handleResizeImpl(const int width, const int height) {
 	overrideCursorScaling();
 }
 
-void LibretroGraphics::setCursorPalette(const byte *colors, uint start, uint num) {
+void LibretroGraphics::setCursorPaletteIntern(const byte *colors, uint start, uint num) {
 	_cursorPalette.set(colors, start, num);
 	_cursorPaletteEnabled = true;
 }
@@ -219,12 +219,8 @@ const Graphics::ManagedSurface *LibretroGraphics::getScreen() {
 	return &_screen;
 }
 
-void LibretroGraphics::setPalette(const byte *colors, uint start, uint num) {
+void LibretroGraphics::setPaletteIntern(const byte *colors, uint start, uint num) {
 	_gamePalette.set(colors, start, num);
-}
-
-void LibretroGraphics::grabPalette(byte *colors, uint start, uint num) const {
-	_gamePalette.grab(colors, start, num);
 }
 
 bool LibretroGraphics::hasFeature(OSystem::Feature f) const {

--- a/backends/platform/n64/osys_n64.h
+++ b/backends/platform/n64/osys_n64.h
@@ -26,11 +26,11 @@
 #include "common/config-manager.h"
 
 #include "backends/base-backend.h"
+#include "backends/graphics/default-palette.h"
 
 #include "base/main.h"
 
 #include "graphics/surface.h"
-#include "graphics/paletteman.h"
 #include "graphics/pixelformat.h"
 
 #include "audio/mixer_intern.h"
@@ -69,7 +69,7 @@ enum GraphicModeID {
 	OVERS_MPAL_340X240
 };
 
-class OSystem_N64 : public EventsBaseBackend, public PaletteManager {
+class OSystem_N64 : public EventsBaseBackend, public DefaultPaletteManager {
 protected:
 	Audio::MixerImpl *_mixer;
 
@@ -82,10 +82,6 @@ protected:
 	uint16 *_overlayBuffer; // Offscreen for the overlay (16 bit)
 
 	uint16 *_screenPalette; // Array for palette entries (256 colors max)
-
-#ifndef N64_EXTREME_MEMORY_SAVING
-	uint8 *_screenExactPalette; // Array for palette entries, as received by setPalette(), no precision loss
-#endif
 	uint16 _cursorPalette[256]; // Palette entries for the cursor
 
 	int _graphicMode; // Graphic mode
@@ -152,11 +148,11 @@ public:
 	virtual int16 getHeight();
 	virtual int16 getWidth();
 
-	virtual PaletteManager *getPaletteManager() { return this; }
+	PaletteManager *getPaletteManager() override { return this; }
 protected:
-	// PaletteManager API
-	virtual void setPalette(const byte *colors, uint start, uint num);
-	virtual void grabPalette(byte *colors, uint start, uint num) const;
+	// DefaultPaletteManager API
+	void setPaletteIntern(const byte *colors, uint start, uint num) override;
+	void setCursorPaletteIntern(const byte *colors, uint start, uint num) override;
 
 public:
 	virtual void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h);
@@ -181,7 +177,6 @@ public:
 
 	virtual void warpMouse(int x, int y);
 	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask);
-	virtual void setCursorPalette(const byte *colors, uint start, uint num);
 
 	virtual bool pollEvent(Common::Event &event);
 	virtual uint32 getMillis(bool skipRecord = false);

--- a/backends/platform/n64/osys_n64_base.cpp
+++ b/backends/platform/n64/osys_n64_base.cpp
@@ -118,10 +118,6 @@ OSystem_N64::OSystem_N64() {
 
 	// Clear palette array
 	_screenPalette = (uint16 *)memalign(8, 256 * sizeof(uint16));
-#ifndef N64_EXTREME_MEMORY_SAVING
-	_screenExactPalette = (uint8 *)memalign(8, 256 * 3);
-	memset(_screenExactPalette, 0, 256 * 3);
-#endif
 	memset(_screenPalette, 0, 256 * sizeof(uint16));
 	memset(_cursorPalette, 0, 256 * sizeof(uint16));
 
@@ -341,11 +337,7 @@ int16 OSystem_N64::getWidth() {
 	return _screenWidth;
 }
 
-void OSystem_N64::setPalette(const byte *colors, uint start, uint num) {
-#ifndef N64_EXTREME_MEMORY_SAVING
-	memcpy(_screenExactPalette + start * 3, colors, num * 3);
-#endif
-
+void OSystem_N64::setPaletteIntern(const byte *colors, uint start, uint num) {
 	for (uint i = 0; i < num; ++i) {
 		_screenPalette[start + i] = colRGB888toBGR555(colors[2], colors[1], colors[0]);
 		colors += 3;
@@ -394,27 +386,7 @@ void OSystem_N64::rebuildOffscreenMouseBuffer(void) {
 	}
 }
 
-void OSystem_N64::grabPalette(byte *colors, uint start, uint num) const {
-#ifdef N64_EXTREME_MEMORY_SAVING  // This way loses precisions
-	uint32 i;
-	uint16 color;
-
-	for (i = start; i < start + num; i++) {
-		color = _screenPalette[i];
-
-		// Color format on the n64 is RGB - 1555
-		*colors++ = ((color & 0x1F) << 3);
-		*colors++ = (((color >> 5) & 0x1F) << 3);
-		*colors++ = (((color >> 10) & 0x1F) << 3);
-	}
-#else
-	memcpy(colors, _screenExactPalette + start * 3, num * 3);
-#endif
-
-	return;
-}
-
-void OSystem_N64::setCursorPalette(const byte *colors, uint start, uint num) {
+void OSystem_N64::setCursorPaletteIntern(const byte *colors, uint start, uint num) {
 	for (uint i = 0; i < num; ++i) {
 		_cursorPalette[start + i] = colRGB888toBGR555(colors[2], colors[1], colors[0]);
 		colors += 3;

--- a/backends/platform/psp/default_display_client.h
+++ b/backends/platform/psp/default_display_client.h
@@ -42,9 +42,6 @@ public:
 	uint32 getWidth() const { return _buffer.getSourceWidth(); }
 	uint32 getHeight() const { return _buffer.getSourceHeight(); }
 	void setPartialPalette(const byte *colors, uint start, uint num) { setDirty(); return _palette.setPartial(colors, start, num); }
-	void getPartialPalette(byte *colors, uint start, uint num) const {
-		return _palette.getPartial(colors, start, num);
-	}
 	void copyFromRect(const byte *buf, int pitch, int destX, int destY, int recWidth, int recHeight);
 	void copyToArray(byte *dst, int pitch);
 	void setDirty() { _dirty = true; }

--- a/backends/platform/psp/display_client.cpp
+++ b/backends/platform/psp/display_client.cpp
@@ -201,46 +201,6 @@ void Palette::deallocate() {
 	_numOfEntries = 0;
 }
 
-// Copy some of the palette to an array of colors
-//
-void Palette::getPartial(byte *colors, uint start, uint num) const {
-	DEBUG_ENTER_FUNC();
-
-	assert(_values);
-	assert(_numOfEntries);
-
-	uint32 r, g, b, a;
-
-	if (start + num > _numOfEntries)	// Check boundary
-		num = _numOfEntries - start;
-
-	if (_pixelFormat.bitsPerPixel == 16) {
-		uint16 *palette = (uint16 *)_values;
-		palette += start;
-
-		for (uint32 i = start; i < start + num; i++) {
-			_pixelFormat.colorToRgba(*palette, r, g, b, a);
-
-			*colors++ = (byte)r;
-			*colors++ = (byte)g;
-			*colors++ = (byte)b;
-			palette++;
-		}
-	} else if (_pixelFormat.bitsPerPixel == 32) {
-		uint32 *palette = (uint32 *)_values;
-		palette += start;
-
-		for (uint32 i = start; i < start + num; i++) {
-			_pixelFormat.colorToRgba(*palette, r, g, b, a);
-
-			*colors++ = (byte)r;
-			*colors++ = (byte)g;
-			*colors++ = (byte)b;
-			palette++;
-		}
-	}
-}
-
 void Palette::setSingleColorRGBA(uint32 num, byte r, byte g, byte b, byte a) {
 	// DEBUG_ENTER_FUNC();
 	uint16 *shortValues;

--- a/backends/platform/psp/display_client.h
+++ b/backends/platform/psp/display_client.h
@@ -88,7 +88,6 @@ public:
 	uint32 getSizeInBytes() const { return _pixelFormat.pixelsToBytes(_numOfEntries); }
 	void set(byte *values) { setPartial(values, 0, _numOfEntries); }
 	void setPartial(const byte *colors, uint start, uint num, bool supportsAlpha = false);
-	void getPartial(byte *colors, uint start, uint num) const;
 	uint32 getRawColorAt(uint32 position) const;
 	uint32 getRGBAColorAt(uint32 position) const;
 	void setSingleColorRGBA(uint32 num, byte r, byte g, byte b, byte a);

--- a/backends/platform/psp/osys_psp.cpp
+++ b/backends/platform/psp/osys_psp.cpp
@@ -178,7 +178,7 @@ int16 OSystem_PSP::getHeight() {
 	return (int16)_screen.getHeight();
 }
 
-void OSystem_PSP::setPalette(const byte *colors, uint start, uint num) {
+void OSystem_PSP::setPaletteIntern(const byte *colors, uint start, uint num) {
 	DEBUG_ENTER_FUNC();
 	_displayManager.waitUntilRenderFinished();
 	_pendingUpdate = false;
@@ -187,7 +187,7 @@ void OSystem_PSP::setPalette(const byte *colors, uint start, uint num) {
 	_cursor.clearKeyColor();
 }
 
-void OSystem_PSP::setCursorPalette(const byte *colors, uint start, uint num) {
+void OSystem_PSP::setCursorPaletteIntern(const byte *colors, uint start, uint num) {
 	DEBUG_ENTER_FUNC();
 	_displayManager.waitUntilRenderFinished();
 	_pendingUpdate = false;
@@ -280,11 +280,6 @@ int16 OSystem_PSP::getOverlayWidth() {
 
 int16 OSystem_PSP::getOverlayHeight() {
 	return (int16)_overlay.getHeight();
-}
-
-void OSystem_PSP::grabPalette(byte *colors, uint start, uint num) const {
-	DEBUG_ENTER_FUNC();
-	_screen.getPartialPalette(colors, start, num);
 }
 
 bool OSystem_PSP::showMouse(bool v) {

--- a/backends/platform/psp/osys_psp.h
+++ b/backends/platform/psp/osys_psp.h
@@ -24,10 +24,10 @@
 
 #include "common/scummsys.h"
 #include "graphics/surface.h"
-#include "graphics/paletteman.h"
 #include "audio/mixer_intern.h"
 #include "backends/base-backend.h"
 #include "backends/fs/psp/psp-fs-factory.h"
+#include "backends/graphics/default-palette.h"
 
 #include "backends/platform/psp/display_client.h"
 #include "backends/platform/psp/default_display_client.h"
@@ -39,7 +39,7 @@
 #include "backends/platform/psp/audio.h"
 #include "backends/platform/psp/thread.h"
 
-class OSystem_PSP : public EventsBaseBackend, public PaletteManager {
+class OSystem_PSP : public EventsBaseBackend, public DefaultPaletteManager {
 private:
 
 	Audio::MixerImpl *_mixer;
@@ -85,14 +85,13 @@ public:
 	int16 getHeight();
 
 	// Palette related
-	PaletteManager *getPaletteManager() { return this; }
+	PaletteManager *getPaletteManager() override { return this; }
 protected:
-	// PaletteManager API
-	void setPalette(const byte *colors, uint start, uint num);
-	void grabPalette(byte *colors, uint start, uint num) const;
-public:
-	void setCursorPalette(const byte *colors, uint start, uint num);
+	// DefaultPaletteManager API
+	void setPaletteIntern(const byte *colors, uint start, uint num) override;
+	void setCursorPaletteIntern(const byte *colors, uint start, uint num) override;
 
+public:
 	// Screen related
 	void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h);
 	Graphics::Surface *lockScreen();

--- a/backends/platform/wii/osystem.h
+++ b/backends/platform/wii/osystem.h
@@ -32,7 +32,7 @@
 #include "common/rect.h"
 #include "common/events.h"
 #include "backends/base-backend.h"
-#include "graphics/paletteman.h"
+#include "backends/graphics/default-palette.h"
 #include "graphics/surface.h"
 #include "audio/mixer_intern.h"
 
@@ -51,7 +51,7 @@ extern void wii_memstats(void);
 }
 #endif
 
-class OSystem_Wii final : public EventsBaseBackend, public PaletteManager {
+class OSystem_Wii final : public EventsBaseBackend, public DefaultPaletteManager {
 private:
 	s64 _startup_time;
 
@@ -164,10 +164,11 @@ public:
 
 	PaletteManager *getPaletteManager() override { return this; }
 protected:
-	void setPalette(const byte *colors, uint start, uint num) override;
-	void grabPalette(byte *colors, uint start, uint num) const override;
+	// DefaultPaletteManager API
+	void setPaletteIntern(const byte *colors, uint start, uint num) override;
+	void setCursorPaletteIntern(const byte *colors, uint start, uint num) override;
+
 public:
-	void setCursorPalette(const byte *colors, uint start, uint num) override;
 	virtual void copyRectToScreen(const void *buf, int pitch, int x, int y,
 									int w, int h) override;
 	void updateScreen() override;

--- a/backends/platform/wii/osystem_gfx.cpp
+++ b/backends/platform/wii/osystem_gfx.cpp
@@ -351,7 +351,7 @@ void OSystem_Wii::updateMousePalette() {
 	}
 }
 
-void OSystem_Wii::setPalette(const byte *colors, uint start, uint num) {
+void OSystem_Wii::setPaletteIntern(const byte *colors, uint start, uint num) {
 #ifdef PLATFORM_WII_OSYSTEM_GFX_DEBUG
 	printf("%s(%p, %d, %d) _cursorPaletteDisabled:%d\n", __func__, colors, start, num, _cursorPaletteDisabled);
 #endif
@@ -371,24 +371,7 @@ void OSystem_Wii::setPalette(const byte *colors, uint start, uint num) {
 	updateMousePalette();
 }
 
-void OSystem_Wii::grabPalette(byte *colors, uint start, uint num) const {
-#ifdef USE_RGB_COLOR
-	assert(_pfGame.bytesPerPixel == 1);
-#endif
-
-	u16 *s = _texGame.palette;
-	byte *d = colors;
-
-	u8 r, g, b;
-	for (uint i = 0; i < num; ++i, d += 3) {
-		_pfRGB565.colorToRGB(s[start + i], r, g, b);
-		d[0] = r;
-		d[1] = g;
-		d[2] = b;
-	}
-}
-
-void OSystem_Wii::setCursorPalette(const byte *colors, uint start, uint num) {
+void OSystem_Wii::setCursorPaletteIntern(const byte *colors, uint start, uint num) {
 #ifdef PLATFORM_WII_OSYSTEM_GFX_DEBUG
 	printf("%s(%p,%u,%u) _cursorPaletteDisabled:%d\n", __func__, colors, start, num, _cursorPaletteDisabled);
 #endif

--- a/common/system.h
+++ b/common/system.h
@@ -1492,19 +1492,6 @@ public:
 	 */
 	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = nullptr, const byte *mask = nullptr) = 0;
 
-	/**
-	 * Replace the specified range of cursor palette with new colors.
-	 *
-	 * The palette entries from 'start' till (start+num-1) will be replaced - so
-	 * a full palette update is accomplished via start=0, num=256.
-	 *
-	 * Backends which implement this should have the kFeatureCursorPalette flag set.
-	 *
-	 * @see setPalette
-	 * @see kFeatureCursorPalette
-	 */
-	virtual void setCursorPalette(const byte *colors, uint start, uint num) {}
-
 
 
 	/**

--- a/engines/chamber/cga.cpp
+++ b/engines/chamber/cga.cpp
@@ -142,7 +142,7 @@ void cga_ColorSelect(byte csel) {
 		pal = PALETTE_CGA2;
 
 	g_system->getPaletteManager()->setPalette(pal, 0, 4);
-	g_system->setCursorPalette(pal, 0, 4);
+	g_system->getPaletteManager()->setCursorPalette(pal, 0, 4);
 }
 
 void cga_blitToScreen(int16 dx, int16 dy, int16 w, int16 h) {

--- a/engines/testbed/graphics.cpp
+++ b/engines/testbed/graphics.cpp
@@ -912,7 +912,7 @@ TestExitStatus GFXtests::maskedCursors() {
 		g_system->getPaletteManager()->setPalette(newPalette, 0, 4);
 
 		if (haveCursorPalettes)
-			g_system->setCursorPalette(newPalette, 0, 4);
+			g_system->getPaletteManager()->setCursorPalette(newPalette, 0, 4);
 
 		CursorMan.replaceCursor(cursorData, 16, 16, 1, 1, 0, false, nullptr, maskData);
 		CursorMan.showMouse(true);

--- a/graphics/cursorman.cpp
+++ b/graphics/cursorman.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "graphics/cursorman.h"
+#include "graphics/paletteman.h"
 
 #include "common/rect.h"
 #include "common/system.h"
@@ -239,7 +240,7 @@ void CursorManager::pushCursorPalette(const byte *colors, uint start, uint num) 
 	_cursorPaletteStack.push(pal);
 
 	if (num)
-		g_system->setCursorPalette(colors, start, num);
+		g_system->getPaletteManager()->setCursorPalette(colors, start, num);
 	else
 		g_system->setFeatureState(OSystem::kFeatureCursorPalette, false);
 }
@@ -262,7 +263,7 @@ void CursorManager::popCursorPalette() {
 	pal = _cursorPaletteStack.top();
 
 	if (pal->_num && !pal->_disabled)
-		g_system->setCursorPalette(pal->_data, pal->_start, pal->_num);
+		g_system->getPaletteManager()->setCursorPalette(pal->_data, pal->_start, pal->_num);
 	else
 		g_system->setFeatureState(OSystem::kFeatureCursorPalette, false);
 }
@@ -291,7 +292,7 @@ void CursorManager::replaceCursorPalette(const byte *colors, uint start, uint nu
 
 	if (num) {
 		memcpy(pal->_data, colors, size);
-		g_system->setCursorPalette(pal->_data, pal->_start, pal->_num);
+		g_system->getPaletteManager()->setCursorPalette(pal->_data, pal->_start, pal->_num);
 	} else {
 		g_system->setFeatureState(OSystem::kFeatureCursorPalette, false);
 	}

--- a/graphics/paletteman.h
+++ b/graphics/paletteman.h
@@ -116,6 +116,23 @@ public:
 		grabPalette(tmp, start, num);
 		return Graphics::Palette(tmp, num);
 	}
+
+	/**
+	 * Replace the specified range of cursor palette with new colors.
+	 *
+	 * The palette entries from 'start' till (start+num-1) will be replaced - so
+	 * a full palette update is accomplished via start=0, num=256.
+	 *
+	 * Backends which implement this should have the kFeatureCursorPalette flag set.
+	 *
+	 * @see setPalette
+	 * @see kFeatureCursorPalette
+	 */
+	virtual void setCursorPalette(const byte *colors, uint start, uint num) {}
+
+	void setCursorPalette(const Graphics::Palette &pal, uint start = 0) {
+		setCursorPalette(pal.data(), start, pal.size());
+	}
 };
  /** @} */
 


### PR DESCRIPTION
By having a common base class that manages the palette, it becomes easier to extend it with new features. It also ensures that all implementations follow the specified behaviour for `grabPalette()` ("This should return exactly the same RGB data as was setup via previous setPalette calls.").
