### PR TITLE
FREESCAPE: Support running with any pixel format with TinyGL

### DIFF
--- a/engines/freescape/gfx.cpp
+++ b/engines/freescape/gfx.cpp
@@ -1252,7 +1252,6 @@ Graphics::RendererType determinateRenderType() {
 }
 
 Renderer *createRenderer(int screenW, int screenH, Common::RenderMode renderMode, bool authenticGraphics) {
-	Graphics::PixelFormat pixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
 	Graphics::RendererType rendererType = determinateRenderType();
 
 	bool isAccelerated = rendererType != Graphics::kRendererTypeTinyGL;
@@ -1260,7 +1259,7 @@ Renderer *createRenderer(int screenW, int screenH, Common::RenderMode renderMode
 	if (isAccelerated) {
 		initGraphics3d(screenW, screenH);
 	} else {
-		initGraphics(screenW, screenH, &pixelFormat);
+		initGraphics(screenW, screenH, nullptr);
 	}
 
 	#if defined(USE_OPENGL_GAME) && !defined(USE_GLES2)

--- a/engines/freescape/gfx_tinygl.cpp
+++ b/engines/freescape/gfx_tinygl.cpp
@@ -584,7 +584,7 @@ Graphics::Surface *TinyGLRenderer::getScreenshot() {
 
 	Graphics::Surface *s = new Graphics::Surface();
 	s->create(_screenW, _screenH, getRGBAPixelFormat());
-	s->copyFrom(glBuffer);
+	s->convertFrom(glBuffer, getRGBAPixelFormat());
 
 	return s;
 }


### PR DESCRIPTION
This matches the other engines that use TinyGL, since TinyGL handles most of the differences between formats internally.