### PR TITLE
COMMON: Fix Unicode support in JSON

### DIFF
--- a/backends/networking/curl/curljsonrequest.cpp
+++ b/backends/networking/curl/curljsonrequest.cpp
@@ -49,7 +49,7 @@ void CurlJsonRequest::handle() {
 				warning("CurlJsonRequest: unable to write all the bytes into MemoryWriteStreamDynamic");
 
 		if (_stream->eos()) {
-			char *contents = Common::JSON::untaintContents(_contentsStream);
+			char *contents = Common::JSON::zeroTerminateContents(_contentsStream);
 			Common::JSONValue *json = Common::JSON::parse(contents);
 			if (json) {
 				finishJson(json); //it's JSON even if's not 200 OK? That's fine!..

--- a/backends/networking/sdl_net/handlers/connectcloudhandler.cpp
+++ b/backends/networking/sdl_net/handlers/connectcloudhandler.cpp
@@ -109,7 +109,7 @@ void ConnectCloudClientHandler::handle(Client *client) {
 	if (!client->readContent(&_clientContent))
 		return;
 
-	char *contents = Common::JSON::untaintContents(_clientContent);
+	char *contents = Common::JSON::zeroTerminateContents(_clientContent);
 	Common::JSONValue *json = Common::JSON::parse(contents);
 	if (json == nullptr) {
 		handleError(*client, "Not Acceptable", 406);

--- a/common/formats/json.cpp
+++ b/common/formats/json.cpp
@@ -63,23 +63,11 @@ namespace Common {
 */
 JSON::JSON() {}
 
-char *JSON::untaintContents(Common::MemoryWriteStreamDynamic &stream) {
+char *JSON::zeroTerminateContents(Common::MemoryWriteStreamDynamic &stream) {
 	// write one more byte in the end
 	byte zero[1] = {0};
 	stream.write(zero, 1);
-
-	// replace all "bad" bytes with '.' character
 	byte *result = stream.getData();
-	uint32 size = stream.size();
-	for (uint32 i = 0; i < size; ++i) {
-		if (result[i] == '\n')
-			result[i] = ' '; // yeah, kinda stupid
-		else if (result[i] < 0x20 || result[i] > 0x7f)
-			result[i] = '.';
-	}
-
-	// make it zero-terminated string
-	result[size - 1] = '\0';
 
 	return (char *)result;
 }
@@ -223,7 +211,7 @@ bool JSON::extractString(const char **data, String &str) {
 		}
 
 		// Disallowed char?
-		else if (next_char < ' ' && next_char != '\t') {
+		else if (next_char > 0 && next_char < ' ' && next_char != '\t') {
 			// SPEC Violation: Allow tabs due to real world cases
 			return false;
 		}

--- a/common/formats/json.h
+++ b/common/formats/json.h
@@ -153,7 +153,7 @@ class JSON {
 
 public:
 	/** Prepares raw bytes in a given stream to be parsed with Common::JSON::parse(). */
-	static char *untaintContents(Common::MemoryWriteStreamDynamic &stream);
+	static char *zeroTerminateContents(Common::MemoryWriteStreamDynamic &stream);
 
 	static JSONValue *parse(const char *data);
 	static String stringify(const JSONValue *value);

--- a/gui/cloudconnectionwizard.cpp
+++ b/gui/cloudconnectionwizard.cpp
@@ -520,7 +520,7 @@ void CloudConnectionWizard::manualModeConnect() {
 	// parse JSON and display message if failed
 	Common::MemoryWriteStreamDynamic jsonStream(DisposeAfterUse::YES);
 	jsonStream.write(code.c_str(), code.size());
-	char *contents = Common::JSON::untaintContents(jsonStream);
+	char *contents = Common::JSON::zeroTerminateContents(jsonStream);
 	Common::JSONValue *json = Common::JSON::parse(contents);
 
 	// pass JSON to the manager


### PR DESCRIPTION
JSON allows for keys and string values to be unicode encoded. Currently all non-ASCI characters are stripped by `JSON::untaintContents` and replaced with dots. This breaks access to files in cloud which have a unicode in the path (in my case it was `Ultima IV™`). 

This PR removes `JSON::untaintContents` and replaces it with `JSON::zeroTerminateContents` and fixes a check to ignore `char < 0` (which are all values >255 that overflow in a signed char to negative).

This was discussed also in detail on Discord earlier today: https://discord.com/channels/581224060529148060/711242520415174666/1369945380292395049. With @lephilousophe recommending changing this check instead of moving to unsigned chars.