### PR TITLE
TWP: FREESCAPE: Fix non-compliant GLSL

### DIFF
--- a/engines/freescape/shaders/freescape_triangle.fragment
+++ b/engines/freescape/shaders/freescape_triangle.fragment
@@ -20,9 +20,17 @@ void main()
 		int bitIndex = int(mod(float(x), 8.));
 
 		// Get the stipple pattern byte
-		int patternByte = stipple[byteIndex];
+		int patternByte = 0;
+		for (int i = 0; i < 128; i++) {
+			if (i == byteIndex) {
+				patternByte = stipple[i];
+				break;
+			}
+		}
 
-		for (int i = 0; i < 7 - bitIndex; i++) {
+		for (int i = 0; i < 7; i++) {
+			if (i >= 7 - bitIndex)
+				break;
 			patternByte = patternByte / 2;
 		}
 

--- a/engines/twp/lighting.cpp
+++ b/engines/twp/lighting.cpp
@@ -61,7 +61,9 @@ void main(void) {
 	vec2 curPixelPosInLocalSpace = vec2(pixelPos.x, -pixelPos.y);
 
 	vec3 diffuse = vec3(0, 0, 0);
-	for (int i = 0; i < u_numberLights; i++) {
+	for (int i = 0; i < 50; i++) {
+		if (i >= u_numberLights)
+			break;
 		vec2 lightVec = curPixelPosInLocalSpace.xy - u_lightPos[i].xy;
 		float coneValue = dot(normalize(-lightVec), u_coneDirection[i]);
 		if (coneValue >= u_coneCosineHalfConeAngle[i]) {
@@ -127,7 +129,9 @@ void main(void) {
 	vec2 curPixelPosInLocalSpace = vec2(pixelPos.x, -pixelPos.y);
 
 	vec3 diffuse = vec3(0, 0, 0);
-	for (int i = 0; i < u_numberLights; i++) {
+	for (int i = 0; i < 50; i++) {
+		if (i >= u_numberLights)
+			break;
 		vec2 lightVec = curPixelPosInLocalSpace.xy - u_lightPos[i].xy;
 		float coneValue = dot(normalize(-lightVec), u_coneDirection[i]);
 		if (coneValue >= u_coneCosineHalfConeAngle[i]) {


### PR DESCRIPTION
[OpenGLES 2.0 GLSL](https://www.khronos.org/files/opengles_shading_language.pdf) requires:

- Control flow is limited to forward branching and to loops where the maximum number of iterations can easily be determined at compile time. (Appendix A, 4 Control Flow)
- In the fragment shader, support for indexing is only mandated for constant-index-expressions. (Appendix A, 5 Indexing of Arrays, Vectors and Matrices)

Generally this doesn't seem to be a limit enforced on most hardware, but for WebGL, this conformity seems to be [enforced by the ANGLE Compiler](https://www.khronos.org/webgl/public-mailing-list/public_webgl/1012/msg00063.php) used in all major browsers.

This PR, fixes the following two errors when launching TWP or Freescape games:

* ['[]' : Index expression must be constant](https://stackoverflow.com/questions/19529690/index-expression-must-be-constant-webgl-glsl-error)
* ['i' : Loop index cannot be compared with non-constant expression](https://stackoverflow.com/questions/38986208/webgl-loop-index-cannot-be-compared-with-non-constant-expression)

I tried to figure out correct upper boundary for the new iteration limits, but would be good if somebody more knowledgeable could double check.