### PR TITLE
CLOUD: Simplify Setup Wizard

### DIFF
--- a/gui/cloudconnectionwizard.cpp
+++ b/gui/cloudconnectionwizard.cpp
@@ -580,7 +580,7 @@ void CloudConnectionWizard::manualModeStorageConnectionCallback(const Networking
 
 // public
 
-int CloudConnectionWizard::runModal(uint32 selectedStorageIndex) {
+int CloudConnectionWizard::runStorageModal(uint32 selectedStorageIndex) {
 	_selectedStorageIndex = selectedStorageIndex;
 	return Dialog::runModal();
 }

--- a/gui/cloudconnectionwizard.cpp
+++ b/gui/cloudconnectionwizard.cpp
@@ -580,6 +580,11 @@ void CloudConnectionWizard::manualModeStorageConnectionCallback(const Networking
 
 // public
 
+int CloudConnectionWizard::runModal(uint32 selectedStorageIndex) {
+	_selectedStorageIndex = selectedStorageIndex;
+	return Dialog::runModal();
+}
+
 void CloudConnectionWizard::open() {
 	Dialog::open();
 #ifdef USE_SDL_NET
@@ -616,12 +621,31 @@ void CloudConnectionWizard::handleCommand(CommandSender *sender, uint32 cmd, uin
 #endif // USE_SDL_NET
 		break;
 
-	case kCloudConnectionWizardOpenUrlStorageCmd:
-		if (!g_system->openUrl("https://cloud.scummvm.org/")) {
+	case kCloudConnectionWizardOpenUrlStorageCmd: {
+		Common::String url = "https://cloud.scummvm.org/";
+		switch (_selectedStorageIndex) {
+		case Cloud::kStorageDropboxId:
+			url += "dropbox/271?refresh_token=true";
+			break;
+		case Cloud::kStorageOneDriveId:
+			url += "onedrive/271";
+			break;
+		case Cloud::kStorageGoogleDriveId:
+			url += "gdrive/271";
+			break;
+		case Cloud::kStorageBoxId:
+			url += "box/271";
+			break;
+		default:
+			break;
+		}
+
+		if (!g_system->openUrl(url)) {
 			MessageDialog alert(_("Failed to open URL!\nPlease navigate to this page manually."));
 			alert.runModal();
 		}
 		break;
+	}
 
 	case kCloudConnectionWizardPasteCodeCmd:
 		if (g_system->hasTextInClipboard()) {

--- a/gui/cloudconnectionwizard.cpp
+++ b/gui/cloudconnectionwizard.cpp
@@ -77,7 +77,11 @@ CloudConnectionWizard::CloudConnectionWizard() :
 	_manualModeButton = nullptr;
 	_codeBox = nullptr;
 
+#ifdef USE_SDL_NET
 	showStep(Step::MODE_SELECT);
+#else 
+	showStep(Step::MANUAL_MODE_STEP_1);
+#endif
 
 	_callback = new Common::Callback<CloudConnectionWizard, const Networking::ErrorResponse &>(this, &CloudConnectionWizard::storageConnectionCallback);
 }
@@ -316,7 +320,9 @@ void CloudConnectionWizard::hideStepQuickModeSuccess() {
 void CloudConnectionWizard::showStepManualMode1() {
 	_headlineLabel->setLabel(_("Manual Mode: Step 1"));
 	showContainer("ConnectionWizard_ManualModeStep1");
+#ifdef USE_SDL_NET
 	showBackButton();
+#endif
 	showNextButton();
 
 	_label0 = new StaticTextWidget(_container, "ConnectionWizard_ManualModeStep1.Line1", _("Open this link in your browser:"));

--- a/gui/cloudconnectionwizard.h
+++ b/gui/cloudconnectionwizard.h
@@ -34,6 +34,7 @@ class ButtonWidget;
 class EditTextWidget;
 
 class CloudConnectionWizard : public Dialog {
+    using Dialog::runModal;
 	enum class Step {
 		NONE,
 		MODE_SELECT,
@@ -55,6 +56,7 @@ class CloudConnectionWizard : public Dialog {
 	Networking::ErrorCallback _callback;
 	bool _connecting;
 	Common::U32String _errorMessage;
+	uint32 _selectedStorageIndex;
 
 	// common and generic widgets
 	StaticTextWidget *_headlineLabel;
@@ -127,6 +129,7 @@ public:
 	CloudConnectionWizard();
 	~CloudConnectionWizard() override;
 
+	int runModal(uint32 selectedStorageIndex);
 	void open() override;
 	void close() override;
 	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data) override;

--- a/gui/cloudconnectionwizard.h
+++ b/gui/cloudconnectionwizard.h
@@ -34,7 +34,6 @@ class ButtonWidget;
 class EditTextWidget;
 
 class CloudConnectionWizard : public Dialog {
-    using Dialog::runModal;
 	enum class Step {
 		NONE,
 		MODE_SELECT,
@@ -129,7 +128,7 @@ public:
 	CloudConnectionWizard();
 	~CloudConnectionWizard() override;
 
-	int runModal(uint32 selectedStorageIndex);
+	int runStorageModal(uint32 selectedStorageIndex);
 	void open() override;
 	void close() override;
 	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data) override;

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -3467,7 +3467,7 @@ void GlobalOptionsDialog::handleCommand(CommandSender *sender, uint32 cmd, uint3
 	}
 	case kOpenCloudConnectionWizardCmd: {
 		CloudConnectionWizard wizard;
-		wizard.runModal(_selectedStorageIndex);
+		wizard.runStorageModal(_selectedStorageIndex);
 		setupCloudTab();
 		reflowLayout();
 		break;

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -139,7 +139,6 @@ enum {
 	kServerPortClearCmd = 'spcl',
 	kChooseRootDirCmd = 'chrp',
 	kRootPathClearCmd = 'clrp',
-	kOpenUrlStorageCmd = 'OpUr',
 	kDisconnectStorageCmd = 'DcSt',
 	kEnableStorageCmd = 'EnSt'
 };
@@ -3494,31 +3493,6 @@ void GlobalOptionsDialog::handleCommand(CommandSender *sender, uint32 cmd, uint3
 	case kDownloadStorageCmd: {
 		DownloadDialog dialog(_selectedStorageIndex, _launcher);
 		dialog.runModal();
-		break;
-	}
-	case kOpenUrlStorageCmd: {
-		Common::String url = "https://cloud.scummvm.org/";
-		switch (_selectedStorageIndex) {
-		case Cloud::kStorageDropboxId:
-			url += "dropbox?refresh_token=true";
-			break;
-		case Cloud::kStorageOneDriveId:
-			url += "onedrive";
-			break;
-		case Cloud::kStorageGoogleDriveId:
-			url += "gdrive";
-			break;
-		case Cloud::kStorageBoxId:
-			url += "box";
-			break;
-		default:
-			break;
-		}
-
-		if (!g_system->openUrl(url)) {
-			MessageDialog alert(_("Failed to open URL!\nPlease navigate to this page manually."));
-			alert.runModal();
-		}
 		break;
 	}
 	case kDisconnectStorageCmd: {

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -3467,7 +3467,7 @@ void GlobalOptionsDialog::handleCommand(CommandSender *sender, uint32 cmd, uint3
 	}
 	case kOpenCloudConnectionWizardCmd: {
 		CloudConnectionWizard wizard;
-		wizard.runModal();
+		wizard.runModal(_selectedStorageIndex);
 		setupCloudTab();
 		reflowLayout();
 		break;


### PR DESCRIPTION
This simplifies the cloud wizard a bit:

- Skip Mode Select in setup wizard if only manual mode is available (on platforms without SDL_NET / webserver). 
- #4860 has removed the use of `kOpenUrlStorageCmd` but still left it in `options.cpp`.
- #4860 introduced `kCloudConnectionWizardOpenUrlStorageCmd` in `gui/cloudconnectionwizard.cpp` but doesn't consider the selected storage option anymore to construct the URL (despite selecting one still being required in `options.cpp`). This PR now passes the selected storage again to the opened URL as it was before.


UI Flow can also be observed at https://youtu.be/kYechxc5tvE  as discussed at https://discord.com/channels/581224060529148060/581224061091446795/1370153256176713808