### PR TITLE
JANITORIAL: Silence Compiler Warnings

### DIFF
--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -58,7 +58,7 @@ static bool sdlSetSwapInterval(int interval) {
 static bool sdlGetAttribute(SDL_GLAttr attr, int *value) {
 	return SDL_GL_GetAttribute(attr, value);
 }
-#else
+#elif !USE_FORCED_GL && !USE_FORCED_GLES && !USE_FORCED_GLES2
 static bool sdlGetAttribute(SDL_GLattr attr, int *value) {
 	return SDL_GL_GetAttribute(attr, value) == 0;
 }

--- a/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
+++ b/backends/graphics3d/openglsdl/openglsdl-graphics3d.cpp
@@ -50,7 +50,7 @@
 static bool sdlGetAttribute(SDL_GLAttr attr, int *value) {
 	return SDL_GL_GetAttribute(attr, value);
 }
-#else
+#elif !USE_FORCED_GLES2
 static bool sdlGetAttribute(SDL_GLattr attr, int *value) {
 	return SDL_GL_GetAttribute(attr, value) == 0;
 }

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -83,7 +83,7 @@
 static bool sdlGetAttribute(SDL_GLAttr attr, int *value) {
 	return SDL_GL_GetAttribute(attr, value);
 }
-#elif SDL_VERSION_ATLEAST(2, 0, 0)
+#elif SDL_VERSION_ATLEAST(2, 0, 0) && !USE_FORCED_GLES2
 static bool sdlGetAttribute(SDL_GLattr attr, int *value) {
 	return SDL_GL_GetAttribute(attr, value) == 0;
 }

--- a/common/archive.h
+++ b/common/archive.h
@@ -317,7 +317,6 @@ private:
 
 	mutable HashMap<CacheKey, SharedArchiveContents, CacheKey_Hash, CacheKey_EqualTo> _cache;
 	uint32 _maxStronglyCachedSize;
-	char _separator = '\0';
 };
 
 /**

--- a/image/jpeg.h
+++ b/image/jpeg.h
@@ -105,7 +105,7 @@ public:
 	void setOutputColorSpace(ColorSpace outSpace) { _colorSpace = outSpace; }
 
 private:
-	// TODO: Avoid inheriting from multiple superclasses that have identically functions.
+	// TODO: Avoid inheriting from multiple superclasses that have identical member functions.
 	using Codec::getPalette;
 	Graphics::Surface _surface;
 	Graphics::Palette _palette;

--- a/image/jpeg.h
+++ b/image/jpeg.h
@@ -105,6 +105,8 @@ public:
 	void setOutputColorSpace(ColorSpace outSpace) { _colorSpace = outSpace; }
 
 private:
+	// TODO: Avoid inheriting from multiple superclasses that have identically functions.
+	using Codec::getPalette;
 	Graphics::Surface _surface;
 	Graphics::Palette _palette;
 	ColorSpace _colorSpace;


### PR DESCRIPTION
This fixes some recently added compiler warnings ( I tried to git blame them to ensure I understood the code):

- warning "'Image::JPEGDecoder::getPalette' hides overloaded virtual function" in `jpeg.h` - I think introduced with https://github.com/scummvm/scummvm/pull/6535/commits/4c4a94cf18dc48c8b483a2ebd9550f868b429314 / #6535
- warning "unused variable" in `archive.h` - I think introduced with https://github.com/scummvm/scummvm/commit/78859312f8e2d70002abe1001f10dbe99f6209f0
- SDL: warning "unused function 'sdlGetAttribute'" - I think introduced with https://github.com/scummvm/scummvm/commit/8afb2c1f62f518fa5872eefbd5a951b29e6ceb32

~Edit: Looks like the "sdlGetAttribute" change isn't working on all platforms. I'll have another look at it.~ _fixed_