### PR TITLE
TESTBED: Small Improvements & Bugfixes

### DIFF
--- a/engines/testbed/config-params.cpp
+++ b/engines/testbed/config-params.cpp
@@ -53,8 +53,15 @@ void ConfigParams::initLogging(const Common::Path &dirname, const char *filename
 }
 
 void ConfigParams::initLogging(bool enable) {
-	// Default Log Directory is game-data directory and filename is 'testbed.log'.
-	initLogging(ConfMan.getPath("path"), "testbed.log", enable);
+	Common::Path logPath = ConfMan.getPath("path");
+	Common::FSNode logDir(logPath);
+	if (logDir.isWritable()) {
+		// Default Log Directory is game-data directory and filename is 'testbed.log'.
+		initLogging(ConfMan.getPath("path"), "testbed.log", enable);
+	} else {
+		// redirect to savepath if game-data directory is not writable.
+		initLogging(ConfMan.getPath("savepath"), "testbed.log", enable);
+	}
 }
 
 bool ConfigParams::isRerunRequired() {

--- a/engines/testbed/config.cpp
+++ b/engines/testbed/config.cpp
@@ -208,7 +208,8 @@ void TestbedInteractionDialog::handleCommand(GUI::CommandSender *sender, uint32 
 void TestbedConfigManager::initDefaultConfiguration() {
 	// Default Configuration
 	// Add Global configuration Parameters here.
-	_configFileInterface.setKey("isSessionInteractive", "Global", "true");
+	ConfParams.setSessionAsInteractive(ConfMan.getBool("interactive-mode"));
+	_configFileInterface.setKey("isSessionInteractive", "Global", ConfParams.isSessionInteractive() ? "true" : "false");
 }
 
 void TestbedConfigManager::writeTestbedConfigToStream(Common::WriteStream *ws) {

--- a/engines/testbed/detection.cpp
+++ b/engines/testbed/detection.cpp
@@ -23,6 +23,7 @@
 
 #include "base/plugins.h"
 #include "testbed/testbed.h"
+#include "testbed/detection.h"
 
 static const PlainGameDescriptor testbed_setting[] = {
 	{ "testbed", "Testbed: The Backend Testing Framework" },
@@ -52,6 +53,7 @@ class TestbedMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDesc
 public:
 	TestbedMetaEngineDetection() : AdvancedMetaEngineDetection(testbedDescriptions, testbed_setting) {
 		_md5Bytes = 512;
+		_guiOptions = GUIO1(GAMEOPTION_INTERACTIVE_MODE);
 	}
 
 	const char *getName() const override {

--- a/engines/testbed/detection.h
+++ b/engines/testbed/detection.h
@@ -1,0 +1,28 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+ #ifndef TESTBED_DETECTION_H
+ #define TESTBED_DETECTION_H
+ 
+ #define GAMEOPTION_INTERACTIVE_MODE GUIO_GAMEOPTIONS1
+ 
+ #endif
+ 

--- a/engines/testbed/fs.cpp
+++ b/engines/testbed/fs.cpp
@@ -67,10 +67,10 @@ TestExitStatus FStests::testReadFile() {
 
 	if (!gameRoot.getFSNode().exists() || !gameRoot.getFSNode().isDirectory()) {
 		Testsuite::logDetailedPrintf("game Path should be an existing directory");
-		 return kTestFailed;
+		return kTestFailed;
 	}
 
-	const char *dirList[] = {"test1" ,"Test2", "TEST3" , "tEST4", "test5"};
+	const char *dirList[] = {"test1", "Test2", "TEST3", "tEST4", "test5"};
 	const char *file[] = {"file.txt", "File.txt", "FILE.txt", "fILe.txt", "file"};
 
 	for (unsigned int i = 0; i < ARRAYSIZE(dirList); i++) {
@@ -80,7 +80,7 @@ TestExitStatus FStests::testReadFile() {
 
 		if (!directory) {
 			Testsuite::logDetailedPrintf("Failed to open directory %s during FS tests\n", dirName.c_str());
-			 return kTestFailed;
+			return kTestFailed;
 		}
 
 		if (!readDataFromFile(directory, fileName.c_str())) {
@@ -95,7 +95,7 @@ TestExitStatus FStests::testReadFile() {
 
 		if (!directory) {
 			Testsuite::logDetailedPrintf("Failed to open directory %s during FS tests\n", dirName.c_str());
-			 return kTestFailed;
+			return kTestFailed;
 		}
 
 		if (!readDataFromFile(directory, fileName.c_str())) {
@@ -110,7 +110,7 @@ TestExitStatus FStests::testReadFile() {
 
 		if (!directory) {
 			Testsuite::logDetailedPrintf("Failed to open directory %s during FS tests\n", dirName.c_str());
-			 return kTestFailed;
+			return kTestFailed;
 		}
 
 		if (!readDataFromFile(directory, fileName.c_str())) {
@@ -133,21 +133,24 @@ TestExitStatus FStests::testReadFile() {
  * it is same by reading the file again.
  */
 TestExitStatus FStests::testWriteFile() {
-	const Common::Path &path = ConfMan.getPath("path");
-	Common::FSNode gameRoot(path);
-	if (!gameRoot.exists()) {
+	Common::FSNode testDirectory(ConfMan.getPath("path"));
+	if (!testDirectory.isWritable()) {
+		// redirect to savepath if game-data directory is not writable.
+		testDirectory = Common::FSNode(ConfMan.getPath("savepath"));
+	}
+	if (!testDirectory.exists()) {
 		Testsuite::logPrintf("Couldn't open the game data directory %s",
-				path.toString(Common::Path::kNativeSeparator).c_str());
+				testDirectory.getPath().toString(Common::Path::kNativeSeparator).c_str());
 		 return kTestFailed;
 	}
 
-	Common::FSNode fileToWrite = gameRoot.getChild("testbed.out");
+	Common::FSNode fileToWrite = testDirectory.getChild("testbed.out");
 
 	Common::WriteStream *ws = fileToWrite.createWriteStream();
 
 	if (!ws) {
 		Testsuite::logDetailedPrintf("Can't open writable file in game data dir\n");
-		 return kTestFailed;
+		return kTestFailed;
 	}
 
 	ws->writeString("ScummVM Rocks!");
@@ -157,7 +160,7 @@ TestExitStatus FStests::testWriteFile() {
 	Common::SeekableReadStream *rs = fileToWrite.createReadStream();
 	if (!rs) {
 		Testsuite::logDetailedPrintf("Can't open recently written file testbed.out in game data dir\n");
-		 return kTestFailed;
+		return kTestFailed;
 	}
 	Common::String readFromFile = rs->readLine();
 	delete rs;
@@ -165,26 +168,28 @@ TestExitStatus FStests::testWriteFile() {
 	if (readFromFile.equals("ScummVM Rocks!")) {
 		// All good
 		Testsuite::logDetailedPrintf("Data written and read correctly\n");
-		 return kTestPassed;
+		return kTestPassed;
 	}
 
 	return kTestFailed;
 }
 
-
 /**
  * This test creates a directory testbed.dir, and confirms if the directory is created successfully
  */
 TestExitStatus FStests::testCreateDir() {
-	const Common::Path &path = ConfMan.getPath("path");
-	Common::FSNode gameRoot(path);
-	if (!gameRoot.exists()) {
+	Common::FSNode testDirectory(ConfMan.getPath("path"));
+	if (!testDirectory.isWritable()) {
+		// redirect to savepath if game-data directory is not writable.
+		testDirectory = Common::FSNode(ConfMan.getPath("savepath"));
+	}
+	if (!testDirectory.exists()) {
 		Testsuite::logPrintf("Couldn't open the game data directory %s",
-				path.toString(Common::Path::kNativeSeparator).c_str());
+				testDirectory.getPath().toString(Common::Path::kNativeSeparator).c_str());
 		 return kTestFailed;
 	}
 
-	Common::FSNode dirToCreate = gameRoot.getChild("testbed.dir");
+	Common::FSNode dirToCreate = testDirectory.getChild("testbed.dir");
 
 	// TODO: Delete the directory after creating it
 	if (dirToCreate.exists()) {
@@ -200,8 +205,6 @@ TestExitStatus FStests::testCreateDir() {
 	Testsuite::logDetailedPrintf("Directory created successfully\n");
 	return kTestPassed;
 }
-
-
 
 FSTestSuite::FSTestSuite() {
 	// FS tests depend on Game Data files.

--- a/engines/testbed/metaengine.cpp
+++ b/engines/testbed/metaengine.cpp
@@ -25,12 +25,35 @@
 
 #include "engines/advancedDetector.h"
 
+#include "common/translation.h"
 #include "testbed/testbed.h"
+#include "testbed/detection.h"
+
+
+static const ADExtraGuiOptionsMap optionsList[] = {
+
+	{
+		GAMEOPTION_INTERACTIVE_MODE,
+		{
+			_s("Run in interactive mode"),
+			_s("Run in interactive mode"),
+			"interactive-mode",
+			true,
+			0,
+			0
+		}
+	},
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR
+};
 
 class TestbedMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "testbed";
+	}
+
+	const ADExtraGuiOptionsMap *getAdvancedExtraGuiOptions() const override {
+		return optionsList;
 	}
 
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription * /* desc */) const override {

--- a/engines/testbed/midi.cpp
+++ b/engines/testbed/midi.cpp
@@ -54,6 +54,9 @@ void MidiTests::waitForMusicToPlay(MidiParser *parser) {
 
 	CursorMan.showMouse(true);
 	while (!quitLoop) {
+#ifdef EMSCRIPTEN
+		g_system->delayMillis(10);
+#endif
 		while (eventMan->pollEvent(event)) {
 			// Quit if explicitly requested!
 			if (Engine::shouldQuit()) {

--- a/engines/testbed/testbed.h
+++ b/engines/testbed/testbed.h
@@ -37,6 +37,9 @@ enum {
 	kTestbedLogOutput = 1,
 	kTestbedEngineDebug,
 
+#ifdef EMSCRIPTEN
+	kCmdOpenLogfile = 'oplf',
+#endif
 	kCmdRerunTestbed = 'crtb'
 };
 


### PR DESCRIPTION
- **Make Interactive Mode configurable in GUI** I wanted to be able to run testbed in automated mode without adjusting the scummvm.ini - this is now possible:
![Screenshot 2025-05-09 at 21-52-21 ScummVM 2 10 0git (May 8 2025 12 59 31)](https://github.com/user-attachments/assets/39dd3ecf-3dd1-4bb8-9493-cd77174fe50d)

- **Fix file writing if game data directory is read-only**: This is a bug we discussed a while ago on discord: https://discord.com/channels/581224060529148060/711242520415174666/1339720409745981582. If the game directory is read-only the write tests and the filelog are now stored in the savegame location.
- **Support opening logfile in Emscripten**: This is similar to the screenshot export from https://github.com/scummvm/scummvm/pull/5587. I added a button to download the log file:
![Screenshot 2025-05-09 at 21-54-05 Testbed The Backend Testing Framework (DOS_English)](https://github.com/user-attachments/assets/5d438970-1514-45a4-8d29-f27e6457414a)

- **Fix freeze when playing MIDI in Emscripten**: This type of loop needs to yield to the browser regularly in single-threaded Emscripten. 