### PR TITLE
SCUMM: Fix MI1 storekeeper line being skipped (original script error)

### DIFF
--- a/engines/scumm/scumm_v5.h
+++ b/engines/scumm/scumm_v5.h
@@ -96,6 +96,7 @@ protected:
 	void workaroundIndy3TownsMissingLightningCastle(int sound);
 	void workaroundLoomHetchelDoubleHead(Actor *a, int act);
 	bool workaroundMonkey1JollyRoger(byte callerOpcode, int arg);
+	bool workaroundMonkey1StorekeeperWaitTablesLine();
 
 	/**
 	 * Fetch the next script word, then if cond is *false*, perform a relative jump.


### PR DESCRIPTION
When Guybrush needs to get a credit note from the storekeeper, he may pretend having various jobs; one of the options is him saying he's "waiting tables at the Scumm Bar".

But then, one of the storekeeper's lines was cut, because of a missing `WaitForMessage()` call before `endCutscene()`, in script 30-11.

So this PR tries to restore this missing call, looking at some `Var`/`Bit` context to be sure (script 30-11 is quite long and deals with various storekeeper interactions in Part 1, so I really want to avoid any bad side effect).

Releases I've tested:

- [x] EGA French
- [x] CD/DOS French
- [x] Floppy VGA/DOS English
- [x] Amiga English 1.2
- [x] Sega CD English
- [x] Macintosh English
- [x] Special Edition (the line's voiced)

Releases I've haven't tested or don't own:

- [x] FM-TOWNS
- [ ] Atari
- [ ] Amiga releases different from 1.2
- [ ] testing _all_ interactions with the storekeeper (not just the credit ones) to be sure nothing broke because of this change.

How to test, with the "Restore content" enhancement setting on:

* have a nearby save, after Elaine's been kidnapped
* OR use boot param `666`, pick the fish, go at Stan's (give the fish to the troll on the way), ask for a ship and credit, go back to the storekeeper, ask for credit, say you're "waiting tables"

Fixed by LogicDeluxe in the Ultimate Talkie version, back in 2010. Yeah, I'm not telling you which line's missing, because it's quite a cool one and, if you have to figure it out yourself, it makes a new PR test ;)