### PR TITLE
TSAGE: BLUEFORCE: Fix submitting password text

### DIFF
--- a/engines/tsage/blue_force/blueforce_scenes5.cpp
+++ b/engines/tsage/blue_force/blueforce_scenes5.cpp
@@ -1644,6 +1644,20 @@ void Scene570::PasswordEntry::process(Event &event) {
 	case EVENT_BUTTON_DOWN:
 		event.handled = true;
 		break;
+	case EVENT_CUSTOM_ACTIONSTART:
+		// Custom action to submit a password text.
+		// The code handling this custom action is identical
+		// to the code for handling event type EVENT_KEYPRESS
+		// when event.kdb.keycode == Common::KEYCODE_RETURN.
+		if (event.customType == kActionReturn)  {
+			// Finished entering password
+			_passwordText.remove();
+			_entryText.remove();
+
+			checkPassword();
+			remove();
+		}
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
Adds a case for handling the EVENT_CUSTOM_ACTIONSTART of type kActionReturn when in password input mode

This will make the key mapped to the "return" action (by default being the ENTER key) work for submitting the password. If the ENTER key is not mapped to some (other) action it can also be used to submit the password. There is still the issue of ScummVM setting letter keys (w for walk, l for look, u for use, t for talk) as default keymaps for "verb" in-game actions, which will not allow the player to enter those letters unless the player remaps the relevant keymaps. These letters are not used in the valid password.

This is a quick fix for issue https://bugs.scummvm.org/ticket/15917

A complementary fix would be to use non-letter keys for the default keymaps to the verb actions to free up the "l", "w", "u" and "t", but then the default keymaps for those won't be as intuitive.

An alternative fix would be disabling and re-enabling the keymapper for the "game-shortcuts" group but that comes with more potential issues:
- When should it be re-enabled to avoid inconsistent state if loading/saving within/outside the password input mode?
- Should the keymaps be re-organized to have a group with only the ScummVM-exclusive keymaps for verb actions (ie. which do not exist in the original game), so that we could isolate disabling and enabling those only, since the original game does allow other hotkey actions to be performed in the computer "scene" (including password input mode) like F1 (for the "help" popup) and the keys for save, load, restart, quit, pause, sound?
- The player could potentially still map letter keys to keymapper actions (enabled in the password mode), which would still be conflicting with the intended free typing mode for the password input.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
