### PR TITLE
AUDIO: Fix compiler warning on release build

### DIFF
--- a/audio/mods/mod_xm_s3m.cpp
+++ b/audio/mods/mod_xm_s3m.cpp
@@ -118,7 +118,7 @@ private:
 	int calculateMixBufLength() const { return (calculateTickLength() + 65) * 4; }
 
 	int initPlayCount(int8 **playCount);
-	void setSequencePos(int pos);
+	void setSequencePos(uint pos);
 	int tick();
 	void updateRow();
 	int seek(int samplePos);
@@ -221,7 +221,7 @@ ModXmS3mStream::~ModXmS3mStream() {
 
 int ModXmS3mStream::initPlayCount(int8 **playCount) {
 	int len = 0;
-	for (int idx = 0; idx < _module.sequenceLen; ++idx) {
+	for (uint idx = 0; idx < _module.sequenceLen; ++idx) {
 		int pat = _module.sequence[idx];
 		int rows = (pat < _module.numPatterns) ? _module.patterns[pat].numRows : 0;
 		if (playCount) {
@@ -991,14 +991,14 @@ void ModXmS3mStream::updateRow() {
 	}
 	if (_breakPos >= 0) {
 		_finished = false;
-		if (_breakPos >= _module.sequenceLen) {
+		if (_breakPos >= (int)_module.sequenceLen) {
 			// Hit the end.
 			_breakPos = _nextRow = 0;
 			_finished = true;
 		}
 		while (_module.sequence[_breakPos] >= _module.numPatterns) {
 			_breakPos++;
-			if (_breakPos >= _module.sequenceLen) {
+			if (_breakPos >= (int)_module.sequenceLen) {
 				// Hit the end.
 				_breakPos = _nextRow = 0;
 				_finished = true;
@@ -1329,7 +1329,7 @@ int ModXmS3mStream::readBuffer(int16 *buffer, const int numSamples) {
 	return samplesRead;
 }
 
-void ModXmS3mStream::setSequencePos(int pos) {
+void ModXmS3mStream::setSequencePos(uint pos) {
 	if (pos >= _module.sequenceLen) {
 		pos = 0;
 	}

--- a/audio/mods/module_mod_xm_s3m.cpp
+++ b/audio/mods/module_mod_xm_s3m.cpp
@@ -425,7 +425,7 @@ bool ModuleModXmS3m::loadXm(Common::SeekableReadStream &st) {
 	}
 
 	sequence = new byte[sequenceLen];
-	for (int i = 0; i < sequenceLen; ++i) {
+	for (uint i = 0; i < sequenceLen; ++i) {
 		int entry = st.readByte();
 		sequence[i] = entry < numPatterns ? entry : 0;
 	}

--- a/audio/mods/module_mod_xm_s3m.h
+++ b/audio/mods/module_mod_xm_s3m.h
@@ -130,7 +130,7 @@ private:
 public:
 	// sound properties
 	byte name[32];
-	int sequenceLen;
+	uint sequenceLen;
 	int restartPos;
 	byte *sequence;
 


### PR DESCRIPTION
```
audio/mods/mod_xm_s3m.cpp: In member function 'void Modules::ModXmS3mStream::setSequencePos(int)':
audio/mods/mod_xm_s3m.cpp:1350:15: warning: 'void* memset(void*, int, size_t)' specified bound between 18446744056529682432 and 18446744073709551608 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
 1350 |         memset(_playCount, 0, _module.sequenceLen * sizeof(int8 *));
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```