### PR TITLE
GRIM: Mark lua_error as noreturn

### DIFF
--- a/engines/grim/lua/lstrlib.cpp
+++ b/engines/grim/lua/lstrlib.cpp
@@ -93,7 +93,7 @@ static void push_captures(Capture *cap) {
 	for (int i = 0; i < cap->level; i++) {
 		int l = cap->capture[i].len;
 		char *buff = luaL_openspace(l+1);
-		if (l == -1)
+		if (l < 0)
 			lua_error("unfinished capture");
 		strncpy(buff, cap->capture[i].init, l);
 		buff[l] = 0;

--- a/engines/grim/lua/lua.h
+++ b/engines/grim/lua/lua.h
@@ -76,7 +76,7 @@ int32 lua_newtag();
 int32 lua_copytagmethods(int32 tagto, int32 tagfrom);
 void lua_settag(int32 tag); // In: object
 
-void lua_error(const char *s);
+void NORETURN_PRE lua_error(const char *s) NORETURN_POST;
 int32 lua_dostring(const char *string); // Out: returns
 int32 lua_dobuffer(const char *buff, int32 size, const char *name);
 int32 lua_callfunction(lua_Object f);


### PR DESCRIPTION
and fix condition to avoid potential negative size passed to strncpy.
