### PR TITLE
SCI: Suppress GCC warnings on release builds

### DIFF
--- a/engines/sci/engine/vm_types.h
+++ b/engines/sci/engine/vm_types.h
@@ -191,6 +191,12 @@ private:
 #endif
 };
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+// setSegment and setOffset together set all the bits without leaving
+// uninitialized parts, so this is not a real problem.
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 static inline reg_t make_reg(SegmentId segment, uint16 offset) {
 	reg_t r;
 	r.setSegment(segment);
@@ -204,6 +210,9 @@ static inline reg_t make_reg32(SegmentId segment, uint32 offset) {
 	r.setOffset(offset);
 	return r;
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #define PRINT_REG(r) (kSegmentMask) & (unsigned) (r).getSegment(), (unsigned) (r).getOffset()
 


### PR DESCRIPTION
```
In member function 'void Sci::reg_t::setSegment(Sci::SegmentId)',
    inlined from 'void Sci::reg_t::setSegment(Sci::SegmentId)' at engines/sci/engine/vm_types.cpp:39:6,
    inlined from 'Sci::reg_t Sci::make_reg(SegmentId, uint16)' at engines/sci/engine/vm_types.h:196:14,
    inlined from 'Sci::reg_t Sci::reg_t::operator+(Sci::reg_t) const' at engines/sci/engine/vm_types.cpp:70:19:
engines/sci/engine/vm_types.cpp:44:38: warning: 'r.Sci::reg_t::_segment' may be used uninitialized [-Wmaybe-uninitialized]
   44 |                 _segment = (_segment & 0xC000) | (segment & 0x3FFF);
      |                            ~~~~~~~~~~^~~~~~~~~
In file included from engines/sci/sci.h:29,
                 from engines/sci/engine/vm_types.cpp:22:
engines/sci/engine/vm_types.h: In member function 'Sci::reg_t Sci::reg_t::operator+(Sci::reg_t) const':
engines/sci/engine/vm_types.h:195:15: note: 'r.Sci::reg_t::_segment' was declared here
  195 |         reg_t r;
      |               ^
```

setSegment and setOffset together set all the bits without leaving uninitialized parts, so this is not a real problem.