### PR TITLE
BASE: Fix MetaEngine leak in runGame

### DIFF
--- a/base/main.cpp
+++ b/base/main.cpp
@@ -236,6 +236,8 @@ static Common::Error runGame(const Plugin *enginePlugin, OSystem &system, const 
 			ConfMan.removeGameDomain(target.c_str());
 		}
 
+		metaEngine.deleteInstance(engine, game, meDescriptor);
+
 		return err;
 	}
 


### PR DESCRIPTION
`metaEngine` could have been issued `createInstance` but not `deleteInstance` if an engine failed to instantiate (e.g. if user cancels start of a not-fully-supported game).

![image](https://github.com/user-attachments/assets/720b1055-a5b1-4b63-a174-91a7e6939bf8)

Attempts to fix:
```
=================================================================
==35138==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 496 byte(s) in 1 object(s) allocated from:
    #0 in operator new(unsigned long) (scummvm/scummvm+0x17faead) (BuildId: 7d084231cb059720)
    #1 in AdvancedMetaEngineDetection<Nancy::NancyGameDescription>::identifyGame(DetectedGame&, void const**) scummvm/engines/advancedDetector.h:616:18
    #2 in identifyGame(Common::String const&, Plugin const**, DetectedGame&, void const**) scummvm/base/main.cpp:164:36
    #3 in scummvm_main scummvm/base/main.cpp:748:26
    #4 in main scummvm/backends/platform/sdl/posix/posix-main.cpp:44:12
    #5 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #6 in __libc_start_main csu/../csu/libc-start.c:360:3
    #7 in _start (scummvm/scummvm+0x173d210) (BuildId: 7d084231cb059720)

Indirect leak of 198 byte(s) in 1 object(s) allocated from:
    #0 in operator new[](unsigned long) (scummvm/scummvm+0x17fafbd) (BuildId: 7d084231cb059720)
    #1 in ADDynamicGameDescription<Nancy::NancyGameDescription>::ADDynamicGameDescription(Nancy::NancyGameDescription const*) scummvm/engines/advancedDetector.h:280:13
    #2 in AdvancedMetaEngineDetection<Nancy::NancyGameDescription>::identifyGame(DetectedGame&, void const**) scummvm/engines/advancedDetector.h:616:22
    #3 in identifyGame(Common::String const&, Plugin const**, DetectedGame&, void const**) scummvm/base/main.cpp:164:36
    #4 in scummvm_main scummvm/base/main.cpp:748:26
    #5 in main scummvm/backends/platform/sdl/posix/posix-main.cpp:44:12
    #6 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #7 in __libc_start_main csu/../csu/libc-start.c:360:3
    #8 in _start (scummvm/scummvm+0x173d210) (BuildId: 7d084231cb059720)

SUMMARY: AddressSanitizer: 694 byte(s) leaked in 2 allocation(s).
```


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
