### PR TITLE
GRIM: LUA: Avoid unnecessary calls for empty string concatenation

### DIFF
--- a/engines/grim/lua/lstrlib.cpp
+++ b/engines/grim/lua/lstrlib.cpp
@@ -29,7 +29,8 @@ static void addnchar(const char *s, int32 n) {
 #endif
 
 static void addstr(const char *s) {
-	addnchar(s, strlen(s));
+	if (*s)
+		addnchar(s, strlen(s));
 }
 
 static void str_len() {


### PR DESCRIPTION
addnchar is effectively no-op for n==0, and it calls strncpy with 0, which is also redundant.
