### PR TITLE
SCUMM: Fix out-of-bounds charset error with some v0.13.x saves (Trac#15931)

### DIFF
--- a/engines/scumm/charset.cpp
+++ b/engines/scumm/charset.cpp
@@ -1056,6 +1056,13 @@ void CharsetRenderer::saveLoadWithSerializer(Common::Serializer &ser) {
 	ser.syncAsByte(_color, VER(73));
 
 	if (ser.isLoading()) {
+		// Some old v0.13.x saves have bogus values, for some reason (see
+		// bug #15931). When detecting such weird values made before the
+		// v1.0.0 release (VER(80)) that followed it, reinitialize the id
+		// using a, hopefully, sane value.
+		if (ser.getVersion() < VER(80) && _curId > _vm->_numCharsets - 1)
+			_curId = _vm->_string[0]._default.charset;
+
 		setCurID(_curId);
 		setColor(_color);
 	}
@@ -1687,7 +1694,7 @@ CharsetRendererMac::~CharsetRendererMac() {
 }
 
 void CharsetRendererMac::setCurID(int32 id) {
-	if  (id == -1)
+	if (id == -1)
 		return;
 
 	// This should only happen, if it happens at all, with older savegames.


### PR DESCRIPTION
Most context is in [Trac#15931](https://bugs.scummvm.org/ticket/15931), including old saves.

Basically, it looks like, just before ScummVM 1.0.0, we had a bug (present in ScummVM 0.13.x) that could write bogus `_curId` data in the save files, for some reason (possible reasons given in the previous link). So, modern ScummVM isn't happy with that.

And, well, I have many ScummVM saves, some of them going back to (at least) 2004-2005, so then I sometimes find stuff like this 😁 

Anyway, this fix is inspired by what done in commit bd67214c96c1bb1b194cfc31abf05a08afc9cf64, back in 2007.

Putting this into a PR, so that my peers can tell if I got it right ;)

How to reproduce: load the Trac save above. (I have many more, if necessary.)