### PR TITLE
COMMON: Implement Pause feature

### DIFF
--- a/backends/events/default/default-events.cpp
+++ b/backends/events/default/default-events.cpp
@@ -144,6 +144,14 @@ bool DefaultEventManager::pollEvent(Common::Event &event) {
 		_buttonState &= ~RBUTTON;
 		break;
 
+	case Common::EVENT_PAUSE_TOGGLE:
+		if (_pauseToken.isActive()) {
+			_pauseToken.clear();
+		} else if (g_engine) {
+			_pauseToken = g_engine->pauseEngine();
+		}
+		break;
+
 	case Common::EVENT_MAINMENU:
 		if (g_engine && !g_engine->isPaused())
 			g_engine->openMainMenuDialog();
@@ -220,6 +228,9 @@ bool DefaultEventManager::pollEvent(Common::Event &event) {
 			_confirmExitDialogActive = false;
 		} else {
 			_shouldQuit = true;
+		}
+		if (_shouldQuit) {
+			_pauseToken.clear();
 		}
 		break;
 
@@ -332,6 +343,11 @@ Common::Keymap *DefaultEventManager::getGlobalKeymap() {
 	Keymap *globalKeymap = new Keymap(Keymap::kKeymapTypeGlobal, kGlobalKeymapName, _("Global"));
 
 	Action *act;
+	act = new Action("PAUSE", _("Toggle pause"));
+	act->addDefaultInputMapping("C+S+p");
+	act->setEvent(EVENT_PAUSE_TOGGLE);
+	globalKeymap->addAction(act);
+
 	act = new Action("MENU", _("Global Main Menu"));
 	act->addDefaultInputMapping("C+F5");
 	act->addDefaultInputMapping("JOY_START");

--- a/backends/events/default/default-events.h
+++ b/backends/events/default/default-events.h
@@ -24,6 +24,7 @@
 
 #include "common/events.h"
 #include "common/queue.h"
+#include "engines/engine.h"
 
 namespace Common {
 class Keymapper;
@@ -57,6 +58,7 @@ class DefaultEventManager : public Common::EventManager, Common::EventObserver {
 	bool _shouldQuit;
 	bool _shouldReturnToLauncher;
 	bool _confirmExitDialogActive;
+	PauseToken _pauseToken;
 
 public:
 	DefaultEventManager(Common::EventSource *boss);

--- a/common/events.h
+++ b/common/events.h
@@ -115,7 +115,9 @@ enum EventType {
 
 	/** ScummVM has gained or lost focus. */
 	EVENT_FOCUS_GAINED = 36,
-	EVENT_FOCUS_LOST = 37
+	EVENT_FOCUS_LOST = 37,
+
+	EVENT_PAUSE_TOGGLE = 38,
 };
 
 const int16 JOYAXIS_MIN = -32768;


### PR DESCRIPTION
Any game can be stopped and resumed using Ctrl+Shift+P shortcut; this can be handy if one would like to learn foreign words from ScummVM games, for example.