### PR TITLE
SCUMM: INDY3: Backport FM-TOWNS lightning effect from Japanese release

### DIFF
--- a/engines/scumm/scumm_v5.h
+++ b/engines/scumm/scumm_v5.h
@@ -93,6 +93,7 @@ protected:
 
 	void injectMISESpeech();
 
+	void workaroundIndy3TownsMissingLightningCastle(int sound);
 	void workaroundLoomHetchelDoubleHead(Actor *a, int act);
 	bool workaroundMonkey1JollyRoger(byte callerOpcode, int arg);
 


### PR DESCRIPTION
It's been known for many years that Indy3 FM-TOWNS has some script/resource oversights (the PC VGA one also has its own set). We already fix some, and I hope to add more.

What's less known is that the Japanese release on the same CD *does* fix a good chunk of these issues.

So, after playing the full Japanese release from my own CD (which was… quite challenging as I can't read Japanese at all), I had a look at the script differences between the two FM-TOWNS releases, and the following was easy-enough to backport.

Basically, the English script (no. 12-132) does this:

```c
[0000] (16) Local[11] = getRandomNr(90);
[0004] (2B) delayVariable(Local[11]);
[0007] (1A) Local[12] = 0;
[000C] (9A) Local[8] = Local[7 + Local[12]];
[0013] (2B) delayVariable(Local[8]);
[0016] (16) VAR_RESULT = getRandomNr(1);
[001A] (A8) if (VAR_RESULT) {
[001F] (1C)   startSound(58);
[0021] (18) } else {
[0024] (1C)   startSound(58);
[0026] (**) }
[0026] (46) Local[12]++;
[0029] (C4) unless (Local[12] > Local[0]) goto 000C;
[0030] (A0) stopObjectCode();
END
```

and the Japanese one does this:

```c
[0000] (16) Local[11] = getRandomNr(90);
[0004] (2B) delayVariable(Local[11]);
[0007] (1A) Local[12] = 0;
[000C] (9A) Local[8] = Local[7 + Local[12]];
[0013] (2B) delayVariable(Local[8]);
[0016] (16) VAR_RESULT = getRandomNr(1);
[001A] (A8) if (VAR_RESULT) {
[001F] (1C)   startSound(58);
[0021] (18) } else {
[0024] (1C)   startSound(58);
[0026] (**) }
[0026] (07) setState(947,1);   // <== NEW
[002A] (80) breakHere();       // <== NEW
[002B] (07) setState(947,0);   // <== NEW
[002F] (80) breakHere();       // <== NEW
[0030] (46) Local[12]++;
[0033] (C4) unless (Local[12] > Local[0]) goto 000C;
[003A] (A0) stopObjectCode();
END
```

i.e. it switches the image of the castle (no. 947) to the "illuminated" one (state 1), and then goes back to the default "dark" one (state 0).

If I replicate as-is, though, it doesn't work. It looks like we can't rely on `breakHere()` causing the intended effect, when inserting it at this stage, through a workaround (it was discussed a bit on Discord with erik).

So I just do it a bit differently, making sure not to stop on a "perpetually illuminated castle", if the last round of thunder (a random value) stopped on that.

To test:

* start any Indy3 FM-TOWNS release (except for the Japanese one)
* use `room 12` in the debugger to be in front of the castle