### PR TITLE
GRIM: Fix failed assertion on font rendering with TinyGL

### DIFF
--- a/engines/grim/font.cpp
+++ b/engines/grim/font.cpp
@@ -300,9 +300,11 @@ int BitmapFont::getKernedStringLength(const Common::String &text) const {
 
 int BitmapFont::getBitmapStringLength(const Common::String &text) const {
 	int result = 0;
-	for (uint32 i = 0; i < text.size(); ) {
-		uint32 ch = getNextChar(text, i);
-		result += getCharKernedWidth(ch) + getCharStartingCol(ch);
+	const uint size = text.size();
+	for (uint32 i = 0; i < size; ) {
+		const uint32 ch = getNextChar(text, i);
+		result += getCharStartingCol(ch);
+		result += (i >= size) ? getCharBitmapWidth(ch) : getCharKernedWidth(ch);
 	}
 	return result;
 }


### PR DESCRIPTION
Opening the menu (F1) in a debug build triggers a crash due to an assertion failure in surface.h:
```
assert(x >= 0 && x < w && y >= 0 && y < h).
```

This problem occurs because `setPixel` is called with x equal to w. It's especially noticeable when rendering a single "Q" character, where the kerned width is 12, but the bitmap width is 14 pixels.

`getBitmapStringLength` returns the sum of character advance widths Kerning applies to spacing between glyphs not bitmap widths.

Since no subsequent glyph follows the final character, kerning is unused. Therefore the final character's bitmap width must be used This prevents `setPixel` from receiving x coordinates equal to w.
