### PR TITLE
CONFIGURE: Remove needless condition for GCC version

### DIFF
--- a/configure
+++ b/configure
@@ -2395,9 +2395,7 @@ if test "$have_gcc" = yes; then
 				fi
 
 				# Many false positives with Common::Serializer
-				if test $_cxx_minor -le 9; then
-					append_var CXXFLAGS "-Wno-maybe-uninitialized"
-				fi
+				append_var CXXFLAGS "-Wno-maybe-uninitialized"
 			fi
 		fi
 	fi


### PR DESCRIPTION
The last version for GCC 4.x is 4.9.x, so testing for <=9 is redundant.