### PR TITLE
GRAPHICS: Fix memory leaks in image archive

### DIFF
--- a/graphics/image-archive.cpp
+++ b/graphics/image-archive.cpp
@@ -83,7 +83,11 @@ const Surface *ImageArchive::getImageSurface(const Common::Path &fname, int w, i
 	}
 
 	Image::PNGDecoder decoder;
-	if (!decoder.loadStream(*stream)) {
+
+	bool result = decoder.loadStream(*stream);
+	delete stream;
+
+	if (!result) {
 		warning("ImageArchive::getImageSurface(): Cannot load file %s", fname.toString().c_str());
 
 		return _imageCache[fname];
@@ -99,7 +103,6 @@ const Surface *ImageArchive::getImageSurface(const Common::Path &fname, int w, i
 	const Graphics::Surface *surf = decoder.getSurface();
 	_imageCache[fname] = surf->scale(w ? w : surf->w, h ? h : surf->h, true);
 
-	delete stream;
 	return _imageCache[fname];
 #endif // USE_PNG
 }

--- a/graphics/image-archive.cpp
+++ b/graphics/image-archive.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "graphics/image-archive.h"
+#include "common/stream.h"
 #include "graphics/surface.h"
 
 #include "common/archive.h"
@@ -37,8 +38,10 @@ ImageArchive::~ImageArchive() {
 
 void ImageArchive::reset() {
 #ifdef USE_PNG
-	for (auto &i : _imageCache)
+	for (auto &i : _imageCache) {
+		i._value->free();
 		delete i._value;
+	}
 	_imageCache.clear();
 #endif
 }
@@ -87,12 +90,16 @@ const Surface *ImageArchive::getImageSurface(const Common::Path &fname, int w, i
 	}
 
 	if (_imageCache.contains(fname)) {
+		// Surface was created by scale(), it needs to be freed explicitly
+		_imageCache[fname]->free();
 		delete _imageCache[fname];
 		_imageCache.erase(fname);
 	}
 
 	const Graphics::Surface *surf = decoder.getSurface();
 	_imageCache[fname] = surf->scale(w ? w : surf->w, h ? h : surf->h, true);
+
+	delete stream;
 	return _imageCache[fname];
 #endif // USE_PNG
 }


### PR DESCRIPTION
During work on image caching improvements for help menu I noticed memory leaks in image-archive.cpp, this PR fixes them.

1. Surface stored in _imageCache[fname] needs to be explicitly freed as stated in Graphics::Surface *Surface::scale documentation.

2. Common::SeekableReadStream *stream needs to be properly deleted, so additional includes were added.
