### PR TITLE
BUILD: Suppress stringop-overflow and stringop-truncation GCC warnings

### DIFF
--- a/configure
+++ b/configure
@@ -2383,6 +2383,12 @@ if test "$have_gcc" = yes; then
 
 		if test $_cxx_major -ge 5; then
 			append_var CXXFLAGS "-Wshadow"
+			if test $_cxx_major -ge 7; then
+				append_var CXXFLAGS "-Wno-stringop-overflow"
+				if test $_cxx_major -ge 8; then
+					append_var CXXFLAGS "-Wno-stringop-truncation"
+				fi
+			fi
 		else
 			append_var CXXFLAGS "-Wno-missing-field-initializers"
 

--- a/devtools/create_project/cmake.cpp
+++ b/devtools/create_project/cmake.cpp
@@ -349,8 +349,16 @@ void CMakeProvider::writeWarnings(std::ofstream &output) const {
 		output << ' ' << warning;
 	}
 	output << "\")\n";
-	output << "\tif(CMAKE_CXX_COMPILER_ID STREQUAL \"GNU\" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0)\n";
-	output << "\t\tset(CMAKE_CXX_FLAGS \"${CMAKE_CXX_FLAGS} -Wno-address-of-packed-member\")\n";
+	output << "\tif(CMAKE_CXX_COMPILER_ID STREQUAL \"GNU\")\n";
+	output << "\t\tif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7.1)\n";
+	output << "\t\t\tset(CMAKE_CXX_FLAGS \"${CMAKE_CXX_FLAGS} -Wno-stringop-overflow\")\n";
+	output << "\t\tendif()\n";
+	output << "\t\tif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8.1)\n";
+	output << "\t\t\tset(CMAKE_CXX_FLAGS \"${CMAKE_CXX_FLAGS} -Wno-stringop-truncation\")\n";
+	output << "\t\tendif()\n";
+	output << "\t\tif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0)\n";
+	output << "\t\t\tset(CMAKE_CXX_FLAGS \"${CMAKE_CXX_FLAGS} -Wno-address-of-packed-member\")\n";
+	output << "\t\tendif()\n";
 	output << "\tendif()\n";
 	output << "endif()\n";
 }

--- a/engines/alg/logic/game_bountyhunter.cpp
+++ b/engines/alg/logic/game_bountyhunter.cpp
@@ -30,10 +30,6 @@
 #include "alg/logic/game_bountyhunter.h"
 #include "alg/scene.h"
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
-#endif
-
 namespace Alg {
 
 GameBountyHunter::GameBountyHunter(AlgEngine *vm, const AlgGameDescription *gd) : Game(vm) {

--- a/engines/grim/lua/lstrlib.cpp
+++ b/engines/grim/lua/lstrlib.cpp
@@ -15,18 +15,11 @@
 
 namespace Grim {
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-truncation"
-#endif
 static void addnchar(const char *s, int32 n) {
 	char *b = luaL_openspace(n);
 	strncpy(b, s, n);
 	luaL_addsize(n);
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 static void addstr(const char *s) {
 	addnchar(s, strlen(s));

--- a/engines/scumm/players/player_sid.cpp
+++ b/engines/scumm/players/player_sid.cpp
@@ -26,10 +26,6 @@
 
 #ifdef USE_SID_AUDIO
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
-#endif
-
 namespace Scumm {
 
 /*


### PR DESCRIPTION
Too many false-positives.

This reverts commits c613f2d4794, 03790b13500 and part of fc71b779a5a.
