### PR TITLE
SCI: Improve reg_t initialization sequence

### DIFF
--- a/engines/sci/engine/vm_types.cpp
+++ b/engines/sci/engine/vm_types.cpp
@@ -27,6 +27,18 @@
 
 namespace Sci {
 
+reg_t::reg_t(SegmentId segment, uint32 offset)
+{
+	if (getSciVersion() < SCI_VERSION_3) {
+		_segment = segment;
+		_offset = offset;
+	} else {
+		// Set the lower 14 bits of the segment, and preserve the upper 2 ones for the offset
+		_segment = ((offset & 0x30000) >> 2) | (segment & 0x3FFF);
+		_offset = offset & 0xFFFF;
+	}
+}
+
 SegmentId reg_t::getSegment() const {
 	if (getSciVersion() < SCI_VERSION_3) {
 		return _segment;

--- a/engines/sci/engine/vm_types.h
+++ b/engines/sci/engine/vm_types.h
@@ -41,6 +41,9 @@ struct reg_t {
 	SegmentId _segment;
 	uint16 _offset;
 
+	reg_t() = default;
+	reg_t(SegmentId segment, uint32 offset);
+
 	SegmentId getSegment() const;
 	void setSegment(SegmentId segment);
 
@@ -191,28 +194,13 @@ private:
 #endif
 };
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-// setSegment and setOffset together set all the bits without leaving
-// uninitialized parts, so this is not a real problem.
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
 static inline reg_t make_reg(SegmentId segment, uint16 offset) {
-	reg_t r;
-	r.setSegment(segment);
-	r.setOffset(offset);
-	return r;
+	return reg_t(segment, offset);
 }
 
 static inline reg_t make_reg32(SegmentId segment, uint32 offset) {
-	reg_t r;
-	r.setSegment(segment);
-	r.setOffset(offset);
-	return r;
+	return reg_t(segment, offset);
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 #define PRINT_REG(r) (kSegmentMask) & (unsigned) (r).getSegment(), (unsigned) (r).getOffset()
 


### PR DESCRIPTION
* A single function instead of call to setSegment and inline setOffset.
* Checks SCI version only once.
* Initializes _segment directly with both values instead of twice.
* Fixes -Wmaybe-uninitialized GCC warning.

This reverts commit 33643c7cc32b84dd6e2ce16a2dd7f500219ccfd9.
