### PR TITLE
NANCY: PeepholePuzzle: Always show hotspot cursor on buttons

### DIFF
--- a/engines/nancy/action/puzzle/peepholepuzzle.cpp
+++ b/engines/nancy/action/puzzle/peepholepuzzle.cpp
@@ -117,10 +117,7 @@ void PeepholePuzzle::handleInput(NancyInput &input) {
 		if (input.input & NancyInput::kLeftMouseButtonHeld) {
 			// Player is still holding the left button, check if mouse has moved outside bounds
 			if (NancySceneState.getViewport().convertViewportToScreen(_buttonDests[_pressedButton]).contains(input.mousePos)) {
-				if (!_disabledButtons[_pressedButton]) {
-					// Do not show hover cursor on disabled button
-					g_nancy->_cursor->setCursorType(CursorManager::kHotspot);
-				}
+				g_nancy->_cursor->setCursorType(CursorManager::kHotspot);
 
 				if (_pressStart == 0) {
 					// Mouse was out of bounds but still held, and is now back in bounds, continue moving
@@ -135,7 +132,7 @@ void PeepholePuzzle::handleInput(NancyInput &input) {
 			// Player released mouse button
 
 			// Avoid single frame with non-highlighted cursor
-			if (NancySceneState.getViewport().convertViewportToScreen(_buttonDests[_pressedButton]).contains(input.mousePos) && !_disabledButtons[_pressedButton]) {
+			if (NancySceneState.getViewport().convertViewportToScreen(_buttonDests[_pressedButton]).contains(input.mousePos)) {
 				g_nancy->_cursor->setCursorType(CursorManager::kHotspot);
 			}
 
@@ -146,16 +143,14 @@ void PeepholePuzzle::handleInput(NancyInput &input) {
 	} else {
 		// Mouse is not currently pressing button, check all buttons
 		for (uint i = 0; i < 4; ++i) {
-			if (!_disabledButtons[i]) {
-				if (NancySceneState.getViewport().convertViewportToScreen(_buttonDests[i]).contains(input.mousePos)) {
-					g_nancy->_cursor->setCursorType(CursorManager::kHotspot);
+			if (NancySceneState.getViewport().convertViewportToScreen(_buttonDests[i]).contains(input.mousePos)) {
+				g_nancy->_cursor->setCursorType(CursorManager::kHotspot);
 
-					if (input.input & NancyInput::kLeftMouseButtonDown) {
-						if (_pressedButton == -1) {
-							// Just pressed
-							_pressedButton = i;
-							_pressStart = g_nancy->getTotalPlayTime();
-						}
+				if (!_disabledButtons[i] && input.input & NancyInput::kLeftMouseButtonDown) {
+					if (_pressedButton == -1) {
+						// Just pressed
+						_pressedButton = i;
+						_pressStart = g_nancy->getTotalPlayTime();
 					}
 				}
 			}


### PR DESCRIPTION
regardless of their disabled status, like original games. (e.g. scroll buttons in nancy6 temple computer activity instructions, nancy7 PDA & ranger station computer, nancy8 laptop todo, ...)

@fracturehill - if current behaviour is an intentional enhancement (it does make more sense of course ;) ), please go ahead and close! (But then I wonder if there should be a comment indicating that in the code.)


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
