### PR TITLE
GRAPHICS: Scale images only when rendering

### DIFF
--- a/graphics/image-archive.cpp
+++ b/graphics/image-archive.cpp
@@ -152,4 +152,3 @@ bool ImageArchive::getImageDimensions(const Common::Path &fname, uint16 &wOut, u
 }
 
 } // End of namespace Graphics
-

--- a/graphics/image-archive.h
+++ b/graphics/image-archive.h
@@ -46,9 +46,6 @@ public:
 	bool setImageArchive(const Common::Path &fname);
 
 	/* Retrieve an image from the cache, or load it from the archive if it hasn't been loaded previously. */
-	const Surface *getImageSurface(const Common::Path &fname) {
-		return getImageSurface(fname, 0, 0);
-	}
 	const Surface *getImageSurface(const Common::Path &fname, int w, int h);
 
 	/* Lookup image dimensions from the archive, cache it for later */

--- a/graphics/image-archive.h
+++ b/graphics/image-archive.h
@@ -51,11 +51,21 @@ public:
 	}
 	const Surface *getImageSurface(const Common::Path &fname, int w, int h);
 
+	/* Lookup image dimensions from the archive, cache it for later */
+	bool getImageDimensions(const Common::Path &fname, uint16 &wOut, uint16 &hOut);
+
 private:
 #ifdef USE_PNG
 	Common::HashMap<Common::Path, Surface *, Common::Path::IgnoreCase_Hash, Common::Path::IgnoreCase_EqualTo> _imageCache;
 #endif
 	Common::Archive *_imageArchive = nullptr;
+
+	struct ImageDimensions {
+		uint16 w;
+		uint16 h;
+	};
+
+	Common::HashMap<Common::Path, ImageDimensions, Common::Path::IgnoreCase_Hash, Common::Path::IgnoreCase_EqualTo> _imageDimsCache;
 };
 
 } // End of namespace Graphics

--- a/graphics/macgui/mactext-canvas.cpp
+++ b/graphics/macgui/mactext-canvas.cpp
@@ -94,7 +94,7 @@ void MacTextCanvas::chopChunk(const Common::U32String &str, int *curLinePtr, int
 		if (w < maxWidth) {
 			chunk->text += str;	// Only append if within bounds
 		}
-		
+
 		getLineCharWidth(curLine, true);
 
 		return;
@@ -751,9 +751,9 @@ void MacTextCanvas::render(int from, int to) {
 }
 
 int getStringMaxWordWidth(MacFontRun &format, const Common::U32String &str) {
-	if (str.empty()) 
+	if (str.empty())
 		return 0;
-	
+
 	if (format.plainByteMode()) {
 		Common::StringTokenizer tok(Common::convertFromU32String(str, format.getEncoding()));
 		int maxW = 0;
@@ -874,12 +874,12 @@ int MacTextCanvas::getLineWidth(int lineNum, bool enforce, int col) {
 		return line->width;
 
 	if (!line->picfname.empty()) {
-		const Surface *image = _imageArchive.getImageSurface(line->picfname);
+		uint16 w, h;
 
-		if (image) {
+		bool imageFound = _imageArchive.getImageDimensions(line->picfname, w, h);
+
+		if (imageFound) {
 			line->width = _maxWidth;
-
-			uint16 w = image->w, h = image->h;
 
 			parsePicExt(line->picext, w, h, line->picpercent);
 			line->charwidth = w;


### PR DESCRIPTION
Followup to https://github.com/scummvm/scummvm/pull/6561. 

The main idea is that thee scale() operation performed by ImageArchive::getImageSurface() is very expensive and unnecessary in the context of MacTextCanvas::getLineWidth(). It doesn't need a copy of the whole surface, just the dimensions. The caching in ImageArchive::getImageSurface didn't help with rendering because the image was scaled to it's original size, so when
MacTextCanvas::render calls getImageSurface it needs to perform the scaling again.

There is noticeable speedup on my machine:
![scummvm_richtext_widget_before](https://github.com/user-attachments/assets/40903581-6688-4886-8ea5-21bca46f6abb)
vs
![scummvm_richtext_widget_after](https://github.com/user-attachments/assets/064afe4c-6cae-4342-b049-84a28b09e382)

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
