### PR TITLE
SCUMM: Add small helpers for shorter/safer/clearer enhancement checks

### DIFF
--- a/engines/scumm/he/script_v72he.cpp
+++ b/engines/scumm/he/script_v72he.cpp
@@ -175,7 +175,7 @@ int ScummEngine_v72he::readArray(int array, int idx2, int idx1) {
 		if (_game.id == GID_BASEBALL2001 &&
 			_currentRoom == 3 && vm.slot[_currentScript].number == 2076 &&  // This is the script that handles basepath clicks
 			readVar(399) == 1 &&  // This checks that we're playing online
-			readVar(0x8000 + 11) == 1 &&  // The ball is a pop-up
+			readVar(ROOM_VAL(11)) == 1 &&  // The ball is a pop-up
 			readVar(291) < 2 &&  // Less than two outs
 			// This is the array of baserunner status info, and the value in position 8 specifies whether the runner is forced
 			array == 295 && idx1 == 8) {

--- a/engines/scumm/he/script_v72he.cpp
+++ b/engines/scumm/he/script_v72he.cpp
@@ -173,7 +173,7 @@ int ScummEngine_v72he::readArray(int array, int idx2, int idx1) {
 		// and if they are then basepath clicks to turn them around have no effect.
 		// Here we return 0 (false) under certain conditions, so these clicks now have the desired effect.
 		if (_game.id == GID_BASEBALL2001 &&
-			_currentRoom == 3 && vm.slot[_currentScript].number == 2076 &&  // This is the script that handles basepath clicks
+			_currentRoom == 3 && currentScriptSlotIs(2076) &&  // This is the script that handles basepath clicks
 			readVar(399) == 1 &&  // This checks that we're playing online
 			readVar(ROOM_VAL(11)) == 1 &&  // The ball is a pop-up
 			readVar(291) < 2 &&  // Less than two outs

--- a/engines/scumm/input.cpp
+++ b/engines/scumm/input.cpp
@@ -603,7 +603,7 @@ void ScummEngine_v7::processKeyboard(Common::KeyState lastKeyHit) {
 			// rest of the game.
 			// This fix produces the intended behaviour from the original interpreter.
 			if (_game.id == GID_FT && _currentRoom == 6
-				&& (vm.slot[_currentScript].number == 65 || vm.slot[_currentScript].number == 64)) {
+				&& (currentScriptSlotIs(65) || currentScriptSlotIs(64))) {
 				_skipVideo = false;
 			} else {
 				_skipVideo = true;

--- a/engines/scumm/object.cpp
+++ b/engines/scumm/object.cpp
@@ -112,7 +112,7 @@ void ScummEngine::setOwnerOf(int obj, int owner) {
 	// This would then trigger the assert() below.
 	//
 	// Note that the original interpreter did NOT produce an error, here.
-	if (_game.id == GID_PASS && obj == 0 && vm.slot[_currentScript].number == 94 && enhancementEnabled(kEnhGameBreakingBugFixes))
+	if (_game.id == GID_PASS && obj == 0 && currentScriptSlotIs(94) && enhancementEnabled(kEnhGameBreakingBugFixes))
 		return;
 
 	// WORKAROUND for bug #6802: assert() was triggered in freddi2.
@@ -121,7 +121,7 @@ void ScummEngine::setOwnerOf(int obj, int owner) {
 	// case, it is obj 0. That means two setOwnerOf calls are made with obj 0.
 	// The correct setOwnerOf calls are made afterwards, so just ignoring this
 	// seems to work just fine.
-	if (_game.id == GID_HEGAME && obj == 0 && _currentRoom == 39 && vm.slot[_currentScript].number == 10)
+	if (_game.id == GID_HEGAME && obj == 0 && _currentRoom == 39 && currentScriptSlotIs(10))
 		return;
 
 	// TODO: Should the following assert(), and the ScummEngine::clearOwnerOf()

--- a/engines/scumm/room.cpp
+++ b/engines/scumm/room.cpp
@@ -507,7 +507,7 @@ void ScummEngine::setupRoomSubBlocks() {
 	//
 	// Using `kEnhGameBreakingBugFixes`, since leaving the room too quickly
 	// would just make this puzzle impossible to complete.
-	if (_game.id == GID_TENTACLE && _roomResource == 26 && readVar(0x8000 + 69)
+	if (_game.id == GID_TENTACLE && _roomResource == 26 && readVar(ROOM_VAL(69))
 			&& getClass(182, kObjectClassUntouchable)
 			&& enhancementEnabled(kEnhGameBreakingBugFixes)) {
 		putClass(182, kObjectClassUntouchable, 0);

--- a/engines/scumm/saveload.cpp
+++ b/engines/scumm/saveload.cpp
@@ -132,7 +132,7 @@ bool ScummEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 		}
 
 		// Also deny persistence operations while the script opening the save menu is running...
-		isOriginalMenuActive = _currentRoom == saveRoom || (_currentScript != 0xFF && vm.slot[_currentScript].number == saveMenuScript);
+		isOriginalMenuActive = _currentRoom == saveRoom || currentScriptSlotIs(saveMenuScript);
 	}
 
 	return (VAR_MAINMENU_KEY == 0xFF || VAR(VAR_MAINMENU_KEY) != 0) && !isOriginalMenuActive;
@@ -207,7 +207,7 @@ bool ScummEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 		}
 
 		// Also deny persistence operations while the script opening the save menu is running...
-		isOriginalMenuActive = _currentRoom == saveRoom || (_currentScript != 0xFF && vm.slot[_currentScript].number == saveMenuScript);
+		isOriginalMenuActive = _currentRoom == saveRoom || currentScriptSlotIs(saveMenuScript);
 	}
 
 	// SCUMM v4+ doesn't allow saving in room 0 or if
@@ -2113,7 +2113,7 @@ void ScummEngine::saveLoadWithSerializer(Common::Serializer &s) {
 			static const char wmsg2[] = "%d bytes, savegame has %d bytes";
 			// For SegaCD, we don't need a warning, since nothing can glitch there. We have to compensate
 			// for the fact that there are old savegames that have an unused imuse state inside of them.
-			// But fixing that will not lead to glitches or other surprises. 
+			// But fixing that will not lead to glitches or other surprises.
 			if (_game.platform == Common::kPlatformSegaCD) {
 				Common::String msg = s.err() ? Common::String::format(wmsg1, sndDataBlockSize) : Common::String::format(wmsg2, (int)(now - before), sndDataBlockSize);
 				warning("Savegame sound data mismatch (sound engine tried to read %s). \r\nAdjusting file read position. Sound might start up with glitches...", msg.c_str());

--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -984,7 +984,7 @@ void ScummEngine::runExitScript() {
 	if (_EXCD_offs) {
 		int slot = getScriptSlot();
 		vm.slot[slot].status = ssRunning;
-		vm.slot[slot].number = 10001;
+		vm.slot[slot].number = kScriptNumEXCD;
 		vm.slot[slot].where = WIO_ROOM;
 		vm.slot[slot].offs = _EXCD_offs;
 		vm.slot[slot].freezeResistant = false;
@@ -1035,7 +1035,7 @@ void ScummEngine::runEntryScript() {
 	if (_ENCD_offs) {
 		int slot = getScriptSlot();
 		vm.slot[slot].status = ssRunning;
-		vm.slot[slot].number = 10002;
+		vm.slot[slot].number = kScriptNumENCD;
 		vm.slot[slot].where = WIO_ROOM;
 		vm.slot[slot].offs = _ENCD_offs;
 		vm.slot[slot].freezeResistant = false;

--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -606,13 +606,13 @@ int ScummEngine::readVar(uint var) {
 			// successfully fetched custom teams, and we're not in one of the three scripts
 			// that cause bugs if 263 is returned here, return 263.
 			if (_game.id == GID_BASEBALL2001 && var == 586 && readVar(399) == 1 && readVar(747) == 1 &&
-				!(_currentRoom == 4 && (vm.slot[_currentScript].number == 2150 || vm.slot[_currentScript].number == 2208 || vm.slot[_currentScript].number == 2210))) {
+				!(_currentRoom == 4 && (currentScriptSlotIs(2150) || currentScriptSlotIs(2208) || currentScriptSlotIs(2210)))) {
 				return 263;
 			}
 			// Mod for Backyard Baseball 2001 online competitive play: allow random bounces
 			// Normally they only happen offline; this script checks var399, here we tell this
 			// script that we're not in online play even if we are
-			if (_game.id == GID_BASEBALL2001 && vm.slot[_currentScript].number == 39 && var == 399) {
+			if (_game.id == GID_BASEBALL2001 && currentScriptSlotIs(39) && var == 399) {
 				return 0;
 			}
 		}
@@ -631,7 +631,7 @@ int ScummEngine::readVar(uint var) {
 				// Mod for Backyard Baseball 2001 online competitive play: don't give powerups for double plays
 				// Return true for this variable, which dictates whether powerups are disabled, but only in this script
 				// that detects double plays (among other things)
-				if (_game.id == GID_BASEBALL2001 && _currentRoom == 3 && vm.slot[_currentScript].number == 2099 && var == 32 && readVar(399) == 1) {
+				if (_game.id == GID_BASEBALL2001 && _currentRoom == 3 && currentScriptSlotIs(2099) && var == 32 && readVar(399) == 1) {
 					return 1;
 				}
 			}
@@ -682,7 +682,7 @@ int ScummEngine::readVar(uint var) {
 		// batter's power stat on hit power
 		if (_enableHECompetitiveOnlineMods) {
 			if (_game.id == GID_BASEBALL2001 &&
-				_currentRoom == 4 && vm.slot[_currentScript].number == 2090  // The script that calculates hit power
+				_currentRoom == 4 && currentScriptSlotIs(2090)  // The script that calculates hit power
 				&& readVar(399) == 1  // Check that we're playing online
 				&& var == 2  // Local var for batter's hitting power stat
 			) {
@@ -718,14 +718,14 @@ void ScummEngine::writeVar(uint var, int value) {
 
 		if (VAR_SUBTITLES != 0xFF && var == VAR_SUBTITLES) {
 			// Ignore default setting in HE72-74 games
-			if (_game.heversion <= 74 && vm.slot[_currentScript].number == 1)
+			if (_game.heversion <= 74 && currentScriptSlotIs(1))
 				return;
 			assert(value == 0 || value == 1);
 			ConfMan.setBool("subtitles", (value != 0));
 		}
 		if (VAR_NOSUBTITLES != 0xFF && var == VAR_NOSUBTITLES) {
 			// Ignore default setting in HE60-71 games
-			if (_game.heversion >= 60 && vm.slot[_currentScript].number == 1)
+			if (_game.heversion >= 60 && currentScriptSlotIs(1))
 				return;
 			assert(value == 0 || value == 1);
 			ConfMan.setBool("subtitles", !value);
@@ -755,7 +755,7 @@ void ScummEngine::writeVar(uint var, int value) {
 		// Any modifications here depend on knowing if the script will
 		// set the timer value back to something sensible afterwards.
 
-		if (_game.id == GID_SAMNMAX && _currentScript != 0xFF && vm.slot[_currentScript].number == 65 && var == VAR_TIMER_NEXT && enhancementEnabled(kEnhTimingChanges)) {
+		if (_game.id == GID_SAMNMAX && currentScriptSlotIs(65) && var == VAR_TIMER_NEXT && enhancementEnabled(kEnhTimingChanges)) {
 			// "Wirst Du brutzeln, wie eine grobe Bratwurst!"
 			if (value == 1 && _language == Common::DE_DEU)
 				value = 4;
@@ -775,7 +775,7 @@ void ScummEngine::writeVar(uint var, int value) {
 		// throughout the intro. This does not apply to the VGA talkie
 		// version, because there the fire isn't animated.
 
-		else if (_game.id == GID_LOOM && !(_game.features & GF_DEMO) && _game.version < 4 && vm.slot[_currentScript].number == 44 && var == VAR_TIMER_NEXT && enhancementEnabled(kEnhTimingChanges)) {
+		if (_game.id == GID_LOOM && !(_game.features & GF_DEMO) && _game.version < 4 && currentScriptSlotIs(44) && var == VAR_TIMER_NEXT && enhancementEnabled(kEnhTimingChanges)) {
 			Actor *a = derefActorSafe(4, "writeVar");
 			if (a) {
 				a->setAnimSpeed((value == 0) ? 6 : 0);
@@ -1632,9 +1632,10 @@ void ScummEngine::endCutscene() {
 		// script bug (with UNZ, DREAMM or TOWNSEMU), and decide which
 		// Enhancement setting should be used in this case.
 		if (_game.id == GID_ZAK && _game.platform == Common::kPlatformFMTowns &&
-			vm.slot[_currentScript].number == 205 && _currentRoom == 185) {
+			currentScriptSlotIs(205) && _currentRoom == 185) {
 			return;
 		}
+
 		error("Cutscene stack underflow");
 	}
 	vm.cutSceneStackPointer--;

--- a/engines/scumm/script.h
+++ b/engines/scumm/script.h
@@ -117,6 +117,11 @@ enum {
 	kMaxScriptNestingHE = 40
 };
 
+enum {
+	kScriptNumEXCD = 10001,
+	kScriptNumENCD = 10002
+};
+
 struct VirtualMachineState {
 	uint32 cutScenePtr[kMaxCutsceneNum];
 	byte cutSceneScript[kMaxCutsceneNum];

--- a/engines/scumm/script.h
+++ b/engines/scumm/script.h
@@ -122,6 +122,9 @@ enum {
 	kScriptNumENCD = 10002
 };
 
+/** Small helper to avoid `readVar(0x8000 + var)` repetition. */
+#define ROOM_VAL(val)	(0x8000 + (val))
+
 struct VirtualMachineState {
 	uint32 cutScenePtr[kMaxCutsceneNum];
 	byte cutSceneScript[kMaxCutsceneNum];

--- a/engines/scumm/script_v2.cpp
+++ b/engines/scumm/script_v2.cpp
@@ -1089,7 +1089,7 @@ void ScummEngine_v2::o2_walkActorTo() {
 	// WORKAROUND bug #2110: crash when trying to fly back to San Francisco.
 	// walkActorTo() is called with an invalid actor number by script 115,
 	// after the room is loaded. The original DOS interpreter probably let
-	// this slip by (TODO: confirm this? and chose an Enhancement class).
+	// this slip by (TODO: confirm this? and choose an Enhancement class).
 	if (_game.id == GID_ZAK && _game.version == 1 && vm.slot[_currentScript].number == 115 && act == 249) {
 		act = VAR(VAR_EGO);
 	}
@@ -1198,10 +1198,10 @@ void ScummEngine_v2::stopScriptCommon(int script) {
 		}
 	}
 
-	if (_game.id == GID_MANIAC && _roomResource == 26 && vm.slot[_currentScript].number == 10001) {
 	// FIXME: Nasty hack for bug #1529
 	// Don't let the exit script for room 26 stop the script (116), when
 	// switching to the dungeon (script 89)
+	if (_game.id == GID_MANIAC && _roomResource == 26 && vm.slot[_currentScript].number == kScriptNumEXCD) {
 		if (script == MM_SCRIPT(111) && isScriptRunning(MM_SCRIPT(84)))
 			return;
 	}

--- a/engines/scumm/script_v2.cpp
+++ b/engines/scumm/script_v2.cpp
@@ -30,9 +30,9 @@
 
 namespace Scumm {
 
-	// Helper functions for ManiacMansion workarounds
-#define MM_SCRIPT(script)  (script + (_game.version == 0 ? 0 : 5))
-#define MM_VALUE(v0,v1)    (_game.version == 0 ? v0 : v1)
+// Helper functions for Maniac Mansion workarounds
+#define MM_SCRIPT(script)  ((script) + (_game.version == 0 ? 0 : 5))
+#define MM_VALUE(v0,v1)    (_game.version == 0 ? (v0) : (v1))
 
 #define OPCODE(i, x)	_opcodes[i]._OPCODE(ScummEngine_v2, x)
 
@@ -407,7 +407,7 @@ void ScummEngine_v2::decodeParseString() {
 	//
 	// (Using `kEnhGameBreakingBugFixes`, because some users could be really confused
 	// by the game hanging and they may not know about the Esc key.)
-	if (_game.id == GID_MANIAC && _game.platform != Common::kPlatformNES && _language == Common::FR_FRA && _currentScript != 0xFF && vm.slot[_currentScript].number == 155 && _roomResource == 31 && _actorToPrintStrFor == 9 && enhancementEnabled(kEnhGameBreakingBugFixes)) {
+	if (_game.id == GID_MANIAC && _game.platform != Common::kPlatformNES && _language == Common::FR_FRA && currentScriptSlotIs(155) && _roomResource == 31 && _actorToPrintStrFor == 9 && enhancementEnabled(kEnhGameBreakingBugFixes)) {
 		while (ptr - buffer < 100) {
 			*ptr++ = ' ';
 		}
@@ -417,10 +417,10 @@ void ScummEngine_v2::decodeParseString() {
 	// WORKAROUND: There is a typo in Syd's biography ("tring" instead of
 	// "trying") in the English DOS version of Maniac Mansion (v1). As far
 	// as I know, this is the only version with the typo.
-	else if (_game.id == GID_MANIAC && _game.version == 1
+	if (_game.id == GID_MANIAC && _game.version == 1
 		&& _game.platform == Common::kPlatformDOS
-		&& !(_game.features & GF_DEMO) && _language == Common::EN_ANY && _currentScript != 0xFF
-		&& vm.slot[_currentScript].number == 260 && enhancementEnabled(kEnhTextLocFixes)
+		&& !(_game.features & GF_DEMO) && _language == Common::EN_ANY
+		&& currentScriptSlotIs(260) && enhancementEnabled(kEnhTextLocFixes)
 		&& strncmp((char *)buffer + 26, " tring ", 7) == 0) {
 		for (byte *p = ptr; p >= buffer + 29; p--)
 			*(p + 1) = *p;
@@ -479,7 +479,7 @@ void ScummEngine_v2::writeVar(uint var, int value) {
 
 	if (_game.id == GID_MANIAC && (_game.version == 1 || _game.version == 2)
 			&& _game.platform != Common::kPlatformNES
-			&& vm.slot[_currentScript].number == 4
+			&& currentScriptSlotIs(4)
 			&& VAR(VAR_CLICK_AREA) == kSentenceClickArea
 			&& var == 34 && value == 0 && enhancementEnabled(kEnhRestoredContent)) {
 		value = 1;
@@ -813,7 +813,7 @@ void ScummEngine_v2::o2_resourceRoutines() {
 		return;
 
 	// HACK V2 Maniac Mansion tries to load an invalid sound resource in demo script.
-	if (_game.id == GID_MANIAC && _game.version == 2 && _currentScript != 0xFF && vm.slot[_currentScript].number == 9 && type == rtSound && resid == 1)
+	if (_game.id == GID_MANIAC && _game.version == 2 && currentScriptSlotIs(9) && type == rtSound && resid == 1)
 		return;
 
 	if ((opcode & 0x0f) == 1) {
@@ -1090,7 +1090,7 @@ void ScummEngine_v2::o2_walkActorTo() {
 	// walkActorTo() is called with an invalid actor number by script 115,
 	// after the room is loaded. The original DOS interpreter probably let
 	// this slip by (TODO: confirm this? and choose an Enhancement class).
-	if (_game.id == GID_ZAK && _game.version == 1 && vm.slot[_currentScript].number == 115 && act == 249) {
+	if (_game.id == GID_ZAK && _game.version == 1 && currentScriptSlotIs(115) && act == 249) {
 		act = VAR(VAR_EGO);
 	}
 
@@ -1187,11 +1187,8 @@ void ScummEngine_v2::stopScriptCommon(int script) {
 	// back on. This fix forces the power on, when the player enters the lab,
 	// if the script which turned it off is running
 	if (_game.id == GID_MANIAC && _roomResource == 4 && isScriptRunning(MM_SCRIPT(138))) {
-
-		if (vm.slot[_currentScript].number == MM_VALUE(130, 163)) {
-
+		if (currentScriptSlotIs(MM_VALUE(130, 163))) {
 			if (script == MM_SCRIPT(138)) {
-
 				int obj = MM_VALUE(124, 157);
 				putState(obj, getState(obj) & ~kObjectStateIntrinsic);
 			}
@@ -1201,7 +1198,7 @@ void ScummEngine_v2::stopScriptCommon(int script) {
 	// FIXME: Nasty hack for bug #1529
 	// Don't let the exit script for room 26 stop the script (116), when
 	// switching to the dungeon (script 89)
-	if (_game.id == GID_MANIAC && _roomResource == 26 && vm.slot[_currentScript].number == kScriptNumEXCD) {
+	if (_game.id == GID_MANIAC && _roomResource == 26 && currentScriptSlotIs(kScriptNumEXCD)) {
 		if (script == MM_SCRIPT(111) && isScriptRunning(MM_SCRIPT(84)))
 			return;
 	}

--- a/engines/scumm/script_v4.cpp
+++ b/engines/scumm/script_v4.cpp
@@ -76,9 +76,8 @@ void ScummEngine_v4::o4_ifState() {
 	// This workaround is meant to address that.
 	//
 	// See also the similar ScummEngine_v5::o5_startScript() workaround.
-	if (_game.id == GID_INDY3 && a == 367 && _currentScript != 0xFF &&
-	    vm.slot[_currentScript].number == 363 && _currentRoom == 25 &&
-	    enhancementEnabled(kEnhMinorBugFixes)) {
+	if (_game.id == GID_INDY3 && a == 367 && currentScriptSlotIs(363) &&
+	    _currentRoom == 25 && enhancementEnabled(kEnhMinorBugFixes)) {
 		// Buggy script compares it with '1'
 		b = 0;
 	}

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -1065,7 +1065,7 @@ void ScummEngine_v5::o5_drawObject() {
 	// be called if Bit[129] is set in that script, so if it does happen, it means
 	// the check was missing, and so we ignore the next 32 bytes of Dread's reaction.
 	if (_game.id == GID_MONKEY2 && !(_game.features & GF_ULTIMATE_TALKIE) && _currentRoom == 22 && _currentScript != 0xFF && vm.slot[_currentScript].number == 201 && obj == 237 &&
-		state == 1 && readVar(0x8000 + 129) == 1 && enhancementEnabled(kEnhMinorBugFixes)) {
+		state == 1 && readVar(ROOM_VAL(129)) == 1 && enhancementEnabled(kEnhMinorBugFixes)) {
 		_scriptPointer += 32;
 		return;
 	}
@@ -1599,7 +1599,7 @@ void ScummEngine_v5::o5_isEqual() {
 		a == b && (b == 7 || b == 13)) {
 		// No need to skip any line if playing in always-prefer-original-text
 		// mode (Bit[588]) where silent lines are expected, or if speech is muted.
-		if (readVar(0x8000 + 588) == 1 && !ConfMan.getBool("speech_mute")) {
+		if (readVar(ROOM_VAL(588)) == 1 && !ConfMan.getBool("speech_mute")) {
 			// Only skip the line when we can detect one and it has no sound prologue.
 			if (memcmp(_scriptPointer + 2, "\x27\x01\x1D", 3) == 0 && memcmp(_scriptPointer + 5, "\xFF\x0A", 2) != 0) {
 				// Cheat and use the next recorded line, but do it in a way so that it
@@ -1710,16 +1710,16 @@ void ScummEngine_v5::o5_notEqualZero() {
 		//
 		// Note that fixing this unveils the script error causing the possible
 		// dead-end described above.
-		if (!(_game.features & GF_ULTIMATE_TALKIE) && var == 0x8000 + 70 && a == 0 && getOwner(519) == VAR(VAR_EGO) && enhancementEnabled(kEnhRestoredContent)) {
+		if (!(_game.features & GF_ULTIMATE_TALKIE) && var == ROOM_VAL(70) && a == 0 && getOwner(519) == VAR(VAR_EGO) && enhancementEnabled(kEnhRestoredContent)) {
 			a = 1;
 		}
 
 		// [Back to the previous "dead-end" workaround.]
 		// If you've got the four map pieces and the script is checking this...
-		else if (var == 0x8000 + 69 && a == 1 && getOwner(519) == VAR(VAR_EGO) && readVar(0x8000 + 55) == 1 && readVar(0x8000 + 366) == 1) {
+		else if (var == ROOM_VAL(69) && a == 1 && getOwner(519) == VAR(VAR_EGO) && readVar(ROOM_VAL(55)) == 1 && readVar(ROOM_VAL(366)) == 1) {
 			// ...but you don't have the lens and you never gave it to Wally...
 			// (and you're not playing the Lite mode, where this doesn't matter)
-			if (getOwner(295) != VAR(VAR_EGO) && readVar(0x8000 + 67) != 0 && readVar(0x8000 + 567) == 0) {
+			if (getOwner(295) != VAR(VAR_EGO) && readVar(ROOM_VAL(67)) != 0 && readVar(ROOM_VAL(567)) == 0) {
 				// ...then short-circuit this condition, so that you can still go back
 				// to Phatt Island to pick up the lens, as in the original game.
 				a = 0;
@@ -1741,7 +1741,7 @@ void ScummEngine_v5::o5_notEqualZero() {
 			int var = fetchScriptWord();
 			a = readVar(var);
 
-			if (var == 0x8000 + 321 && enhancementEnabled(kEnhRestoredContent))
+			if (var == ROOM_VAL(321) && enhancementEnabled(kEnhRestoredContent))
 				a = !a;
 		} else {
 			a = getVar();

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -653,7 +653,7 @@ void ScummEngine_v5::o5_setClass() {
 		// are taken from the Ultimate Talkie Edition.
 		if (_game.id == GID_MONKEY && _game.platform != Common::kPlatformFMTowns &&
 		    _game.platform != Common::kPlatformSegaCD && _roomResource == 59 &&
-			_currentScript != 0xFF && vm.slot[_currentScript].number == 10002 &&
+			_currentScript != 0xFF && vm.slot[_currentScript].number == kScriptNumENCD &&
 			obj == 915 && cls == 6 && _currentPalette[251 * 3] == 0 &&
 			enhancementEnabled(kEnhVisualChanges) && !(_game.features & GF_ULTIMATE_TALKIE)) {
 			// True as long as Guybrush isn't done with the voodoo recipe on the
@@ -1091,7 +1091,7 @@ void ScummEngine_v5::o5_drawObject() {
 	// been officially fixed in some '1.2' releases (e.g. French DOS/EGA) and
 	// all later versions; this smaller workaround appears to be enough.
 	if (_game.id == GID_LOOM && _game.version == 3 && !(_game.features & GF_OLD256) && _roomResource == 32 &&
-		vm.slot[_currentScript].number == 10002 && obj == 540 && state == 1 && xpos == 255 && ypos == 255 &&
+		vm.slot[_currentScript].number == kScriptNumENCD && obj == 540 && state == 1 && xpos == 255 && ypos == 255 &&
 		enhancementEnabled(kEnhMinorBugFixes)) {
 		if (getState(541) == 1) {
 			putState(obj, state);
@@ -1691,7 +1691,7 @@ void ScummEngine_v5::o5_notEqualZero() {
 	// stuck on Scabb Island with no way of going back to the Phatt Island
 	// Library, since Dread's ship is gone.
 	if (_game.id == GID_MONKEY2 && ((_roomResource == 22 && vm.slot[_currentScript].number == 202) ||
-		(_roomResource == 2 && vm.slot[_currentScript].number == 10002) ||
+		(_roomResource == 2 && vm.slot[_currentScript].number == kScriptNumENCD) ||
 		vm.slot[_currentScript].number == 97) && enhancementEnabled(kEnhGameBreakingBugFixes)) {
 		int var = fetchScriptWord();
 		a = readVar(var);
@@ -1734,7 +1734,7 @@ void ScummEngine_v5::o5_notEqualZero() {
 		// Ron Gilbert commented on this: "Not sure I'd call that a
 		// coding error. The lines were just cut. But what do I know."
 
-		if ((_game.id == GID_MONKEY || _game.id == GID_MONKEY_VGA || _game.id == GID_MONKEY_EGA) && _roomResource == 8 && vm.slot[_currentScript].number == 10002) {
+		if ((_game.id == GID_MONKEY || _game.id == GID_MONKEY_VGA || _game.id == GID_MONKEY_EGA) && _roomResource == 8 && vm.slot[_currentScript].number == kScriptNumENCD) {
 			// A local getVar(), where the var number can be examined.
 			// Taking care to limit this to Monkey1, so that the proper getVar()
 			// implementation still gets called for v2 and below.
@@ -2176,7 +2176,7 @@ void ScummEngine_v5::o5_putActorInRoom() {
 	// really have been that under-powered?
 
 	if (_game.id == GID_MONKEY2 && _game.platform == Common::kPlatformMacintosh &&
-		_currentRoom == 7 && vm.slot[_currentScript].number == 10002 &&
+		_currentRoom == 7 && vm.slot[_currentScript].number == kScriptNumENCD &&
 		a->_number == 11 && room == 0 && enhancementEnabled(kEnhRestoredContent)) {
 		room = _currentRoom;
 		a->animateActor(250);
@@ -2841,11 +2841,11 @@ void ScummEngine_v5::o5_stopSound() {
 	// they keep playing like they do in the Special Edition. (Though there
 	// the background makes it more obvious.)
 	//
-	// The sound is stopped by the exit script, which always has number
-	// 10001 regardless of which room it is. We figure out which one by
-	// looking at which rooms we're moving between.
+	// The sound is stopped by the exit script kScriptNumEXCD, which always
+	// has the same value regardless of which room it is. We figure out
+	// which one by looking at which rooms we're moving between.
 
-	if (_game.id == GID_MONKEY && (_game.features & GF_AUDIOTRACKS) && sound == 126 && vm.slot[_currentScript].number == 10001 && VAR(VAR_ROOM) == 43 && VAR(VAR_NEW_ROOM) == 76 && enhancementEnabled(kEnhAudioChanges)) {
+	if (_game.id == GID_MONKEY && (_game.features & GF_AUDIOTRACKS) && sound == 126 && vm.slot[_currentScript].number == kScriptNumEXCD && VAR(VAR_ROOM) == 43 && VAR(VAR_NEW_ROOM) == 76 && enhancementEnabled(kEnhAudioChanges)) {
 		return;
 	}
 
@@ -3330,7 +3330,7 @@ void ScummEngine_v5::o5_walkActorTo() {
 	//
 	// Intentionally using `kEnhGameBreakingBugFixes`, since you can get
 	// completely stuck.
-	if (_game.id == GID_INDY4 && _currentScript != 0xFF && vm.slot[_currentScript].number == 10002 &&
+	if (_game.id == GID_INDY4 && _currentScript != 0xFF && vm.slot[_currentScript].number == kScriptNumENCD &&
 		_currentRoom == (_game.platform == Common::kPlatformAmiga ? 58 : 60) &&
 		VAR(224) == 140 && a->_number == VAR(VAR_EGO) && x == 45 && y == 137 &&
 		enhancementEnabled(kEnhGameBreakingBugFixes)) {
@@ -3844,7 +3844,7 @@ bool ScummEngine_v5::workaroundMonkey1JollyRoger(byte callerOpcode, int arg) {
 	// also need to remove the flag from the room, once it's been shown for the first time.
 	// We fix both issues.
 	if ((_game.id == GID_MONKEY_EGA || _game.id == GID_MONKEY_VGA || (_game.id == GID_MONKEY && !(_game.features & GF_ULTIMATE_TALKIE))) &&
-		_roomResource == 87 && _currentScript != 0xFF && vm.slot[_currentScript].number == 10002 &&
+		_roomResource == 87 && _currentScript != 0xFF && vm.slot[_currentScript].number == kScriptNumENCD &&
 		enhancementEnabled(kEnhVisualChanges)) {
 		// The script that's only run the first time the flag is shown
 		const int defaultExpectedScriptNr = (_game.version == 5) ? 122 : 119;

--- a/engines/scumm/script_v5.cpp
+++ b/engines/scumm/script_v5.cpp
@@ -431,7 +431,7 @@ void ScummEngine_v5::o5_actorOps() {
 	// hadn't been implemented", but it appears to work nonetheless, which is what they
 	// also observed when doing the QA for the PC version.
 	if (_game.id == GID_MONKEY2 && _game.platform == Common::kPlatformFMTowns &&
-		vm.slot[_currentScript].number == 45 && _currentRoom == 45 &&
+		currentScriptSlotIs(45) && _currentRoom == 45 &&
 		(_scriptPointer - _scriptOrgPointer == 0xA9) && enhancementEnabled(kEnhRestoredContent)) {
 		_scriptPointer += 0xCF - 0xA1;
 		writeVar(32811, 0); // clear bit 43
@@ -653,7 +653,7 @@ void ScummEngine_v5::o5_setClass() {
 		// are taken from the Ultimate Talkie Edition.
 		if (_game.id == GID_MONKEY && _game.platform != Common::kPlatformFMTowns &&
 		    _game.platform != Common::kPlatformSegaCD && _roomResource == 59 &&
-			_currentScript != 0xFF && vm.slot[_currentScript].number == kScriptNumENCD &&
+			currentScriptSlotIs(kScriptNumENCD) &&
 			obj == 915 && cls == 6 && _currentPalette[251 * 3] == 0 &&
 			enhancementEnabled(kEnhVisualChanges) && !(_game.features & GF_ULTIMATE_TALKIE)) {
 			// True as long as Guybrush isn't done with the voodoo recipe on the
@@ -672,7 +672,7 @@ void ScummEngine_v5::o5_setClass() {
 		// door (object 465) of the of the Hostel on Mars), when opening the
 		// Hostel door from the outside.
 		if (_game.id == GID_ZAK && _game.platform == Common::kPlatformFMTowns &&
-		    vm.slot[_currentScript].number == 205 && _currentRoom == 185 &&
+		    currentScriptSlotIs(205) && _currentRoom == 185 &&
 		    (cls == 0 || cls == 1)) {
 			putState(obj, cls);
 		} else if (cls == 0) {
@@ -701,8 +701,6 @@ void ScummEngine_v5::o5_add() {
 	// We fix this by changing Var[229] += 8 to Var[229] += 1.
 
 	if (_game.id == GID_MONKEY && _game.platform == Common::kPlatformSegaCD && _language == Common::EN_ANY && _resultVarNumber == 229 && a == 8 && enhancementEnabled(kEnhSubFmtCntChanges)) {
-		int scriptNr = vm.slot[_currentScript].number;
-
 		// Room 35 - Talking to the Men of Low Moral Fiber (pirates),
 		// telling them that the governor has been kidnapped. Two of
 		// the conversation options are off-screen.
@@ -710,8 +708,8 @@ void ScummEngine_v5::o5_add() {
 		// Room 19 - Talking to your crew aboard the ship. The last
 		// conversation option is off-screen.
 
-		if ((scriptNr == 216 && _currentRoom == 35) ||
-		    (scriptNr == 204 && _currentRoom == 19))
+		if ((currentScriptSlotIs(216) && _currentRoom == 35) ||
+		    (currentScriptSlotIs(204) && _currentRoom == 19))
 			a = 1;
 	}
 
@@ -719,7 +717,7 @@ void ScummEngine_v5::o5_add() {
 	// understand the reasoning behind this, compare script 210 and 218 in
 	// room 20. Apparently they made a mistake when converting the absolute
 	// delays into relative ones.
-	if (_game.id == GID_LOOM && _game.version == 4 && vm.slot[_currentScript].number == 210 && _currentRoom == 20 && _resultVarNumber == 0x4000) {
+	if (_game.id == GID_LOOM && _game.version == 4 && currentScriptSlotIs(210) && _currentRoom == 20 && _resultVarNumber == 0x4000) {
 		switch (a) {
 		// Fix for the Var[250] == 11 case
 		case 138:
@@ -771,7 +769,7 @@ void ScummEngine_v5::o5_add() {
 	// We restore the old behavior by adding 0, not 1, to the second
 	// variable when examining the clock tower.
 
-	if (_game.id == GID_MONKEY && vm.slot[_currentScript].number == 210 && _currentRoom == 35 && _resultVarNumber == 248 && a == 1 && enhancementEnabled(kEnhRestoredContent)) {
+	if (_game.id == GID_MONKEY && currentScriptSlotIs(210) && _currentRoom == 35 && _resultVarNumber == 248 && a == 1 && enhancementEnabled(kEnhRestoredContent)) {
 		a = 0;
 	}
 
@@ -805,8 +803,8 @@ void ScummEngine_v5::o5_animateActor() {
 	// safety (from where you came). The following hack works around this by
 	// ignoring that particular turn command.
 	if (_game.id == GID_ZAK && _currentRoom == 182 && anim == 246 &&
-			((_game.version < 3 && vm.slot[_currentScript].number == 82)
-			|| (_game.version == 3 && vm.slot[_currentScript].number == 131))) {
+			((_game.version < 3 && currentScriptSlotIs(82))
+			|| (_game.version == 3 && currentScriptSlotIs(131)))) {
 		return;
 	}
 
@@ -824,7 +822,7 @@ void ScummEngine_v5::o5_breakHere() {
 	// least intrusive way of adding the delay. The script calls it a number
 	// of times, but only once from room 69.
 
-	if (_game.id == GID_LOOM && _game.platform == Common::kPlatformPCEngine && _language == Common::EN_ANY && _currentScript != 0xFF && vm.slot[_currentScript].number == 44 && _currentRoom == 69) {
+	if (_game.id == GID_LOOM && _game.platform == Common::kPlatformPCEngine && _language == Common::EN_ANY && currentScriptSlotIs(44) && _currentRoom == 69) {
 		vm.slot[_currentScript].delay = 120;
 		vm.slot[_currentScript].status = ssPaused;
 	}
@@ -947,7 +945,7 @@ void ScummEngine_v5::o5_cutscene() {
 	// from the zeppelin with the biplane is missing the `[1]` parameter
 	// which disables the verb interface. For some reason, this only causes
 	// a problem on the FM-TOWNS version, though... also happens under UNZ.
-	if (_game.id == GID_INDY3 && _game.platform == Common::kPlatformFMTowns && _currentRoom == 80 && _currentScript != 0xFF && vm.slot[_currentScript].number == 201 && args[0] == 0 && enhancementEnabled(kEnhVisualChanges)) {
+	if (_game.id == GID_INDY3 && _game.platform == Common::kPlatformFMTowns && _currentRoom == 80 && currentScriptSlotIs(201) && args[0] == 0 && enhancementEnabled(kEnhVisualChanges)) {
 		args[0] = 1;
 	}
 
@@ -1064,7 +1062,7 @@ void ScummEngine_v5::o5_drawObject() {
 	// face Guybrush even if he's already looking at him.  drawObject() should never
 	// be called if Bit[129] is set in that script, so if it does happen, it means
 	// the check was missing, and so we ignore the next 32 bytes of Dread's reaction.
-	if (_game.id == GID_MONKEY2 && !(_game.features & GF_ULTIMATE_TALKIE) && _currentRoom == 22 && _currentScript != 0xFF && vm.slot[_currentScript].number == 201 && obj == 237 &&
+	if (_game.id == GID_MONKEY2 && !(_game.features & GF_ULTIMATE_TALKIE) && _currentRoom == 22 && currentScriptSlotIs(201) && obj == 237 &&
 		state == 1 && readVar(ROOM_VAL(129)) == 1 && enhancementEnabled(kEnhMinorBugFixes)) {
 		_scriptPointer += 32;
 		return;
@@ -1076,7 +1074,7 @@ void ScummEngine_v5::o5_drawObject() {
 	// picked up the real Grail. This was probably done as a way to unconditionally
 	// reset the animation if it's already been played, but we can just do an
 	// unconditional reset of all previous frames instead, restoring the first one.
-	if (_game.id == GID_INDY3 && _roomResource == 87 && _currentScript != 0xFF && vm.slot[_currentScript].number == 200 && obj == 899 && state == 1 && VAR(VAR_TIMER_NEXT) != 12 && enhancementEnabled(kEnhRestoredContent)) {
+	if (_game.id == GID_INDY3 && _roomResource == 87 && currentScriptSlotIs(200) && obj == 899 && state == 1 && VAR(VAR_TIMER_NEXT) != 12 && enhancementEnabled(kEnhRestoredContent)) {
 		i = _numLocalObjects - 1;
 		do {
 			if (_objs[i].obj_nr)
@@ -1091,7 +1089,7 @@ void ScummEngine_v5::o5_drawObject() {
 	// been officially fixed in some '1.2' releases (e.g. French DOS/EGA) and
 	// all later versions; this smaller workaround appears to be enough.
 	if (_game.id == GID_LOOM && _game.version == 3 && !(_game.features & GF_OLD256) && _roomResource == 32 &&
-		vm.slot[_currentScript].number == kScriptNumENCD && obj == 540 && state == 1 && xpos == 255 && ypos == 255 &&
+		currentScriptSlotIs(kScriptNumENCD) && obj == 540 && state == 1 && xpos == 255 && ypos == 255 &&
 		enhancementEnabled(kEnhMinorBugFixes)) {
 		if (getState(541) == 1) {
 			putState(obj, state);
@@ -1463,7 +1461,7 @@ void ScummEngine_v5::o5_isScriptRunning() {
 	// (AFAICS) no error. Fixing this would be nice as well (as a `kEnhMinorBugFixes` fix)
 	// but it would require a different workaround in a different place, since the script
 	// is a bit different.
-	if (_game.id == GID_MONKEY && _currentScript != 0xFF && vm.slot[_currentScript].number == 204 && _currentRoom == 25 &&
+	if (_game.id == GID_MONKEY && currentScriptSlotIs(204) && _currentRoom == 25 &&
 		enhancementEnabled(kEnhGameBreakingBugFixes)) {
 		ScriptSlot *ss = vm.slot;
 		for (int i = 0; i < NUM_SCRIPT_SLOT; i++, ss++) {
@@ -1503,7 +1501,7 @@ void ScummEngine_v5::o5_ifClassOfIs() {
 		// TODO: check the behavior of the original interpreter against ours,
 		// in this particular case.
 		if (_game.id == GID_ZAK && _game.platform == Common::kPlatformFMTowns &&
-		    vm.slot[_currentScript].number == 205 && _currentRoom == 185 &&
+		    currentScriptSlotIs(205) && _currentRoom == 185 &&
 		    obj == 465 && cls == 0 && enhancementEnabled(kEnhGameBreakingBugFixes)) {
 			cond = (getState(obj) == 0);
 		} else {
@@ -1545,8 +1543,8 @@ void ScummEngine_v5::o5_isEqual() {
 	// backport this fix to the floppy EGA/VGA releases.
 	//
 	// (It looks like the (or some?) Amiga releases already have this
-	// fix, but it's written in a way so that it can't hurt.)
-	if ((_game.id == GID_MONKEY_EGA || _game.id == GID_MONKEY_VGA) && _currentScript != 0xFF && vm.slot[_currentScript].number == 120 && var == VAR_ROOM && b == 29) {
+	// fix, but the following's written in a way so that it can't hurt.)
+	if ((_game.id == GID_MONKEY_EGA || _game.id == GID_MONKEY_VGA) && currentScriptSlotIs(120) && var == VAR_ROOM && b == 29) {
 		// In Meathook's house; check is missing from both EGA and VGA SCUMMv4
 		// releases. It can cause a fatal "ERROR: (63:49:0x14A): Local script 207
 		// is not in room 63!" error, if one looks at the map instead of using
@@ -1574,7 +1572,7 @@ void ScummEngine_v5::o5_isEqual() {
 	//
 	// Not using enhancementEnabled, since this small oversight only
 	// exists in this fan-made edition which was made for enhancements.
-	if (_game.id == GID_MONKEY2 && (_game.features & GF_ULTIMATE_TALKIE) && _roomResource == 48 && _currentScript != 0xFF && vm.slot[_currentScript].number == 215 && a == vm.localvar[_currentScript][0]) {
+	if (_game.id == GID_MONKEY2 && (_game.features & GF_ULTIMATE_TALKIE) && _roomResource == 48 && currentScriptSlotIs(215) && a == vm.localvar[_currentScript][0]) {
 		if (a == 550 && b == 530)
 			b = a;
 		else if (a == 549 && b == 529)
@@ -1594,7 +1592,7 @@ void ScummEngine_v5::o5_isEqual() {
 	//
 	// Intentionally not using enhancementEnabled for this version.
 	if (_game.id == GID_MONKEY2 && (_game.features & GF_ULTIMATE_TALKIE) &&
-		_roomResource == 47 && vm.slot[_currentScript].number == 218 &&
+		_roomResource == 47 && currentScriptSlotIs(218) &&
 		var == 0x4000 + 1 && a == vm.localvar[_currentScript][1] &&
 		a == b && (b == 7 || b == 13)) {
 		// No need to skip any line if playing in always-prefer-original-text
@@ -1650,7 +1648,7 @@ void ScummEngine_v5::o5_isLessEqual() {
 	// Since the biplane is unplayable without this, we use
 	// `kEnhGameBreakingBugFixes`.
 	if (_game.id == GID_INDY3 && (_game.platform == Common::kPlatformFMTowns) &&
-	    (vm.slot[_currentScript].number == 200 || vm.slot[_currentScript].number == 203) &&
+	    (currentScriptSlotIs(200) || currentScriptSlotIs(203)) &&
 	    _currentRoom == 70 && b == -256 && enhancementEnabled(kEnhGameBreakingBugFixes)) {
 		o5_jumpRelative();
 		return;
@@ -1662,7 +1660,7 @@ void ScummEngine_v5::o5_isLessEqual() {
 	// together that they look like one. This adjusts the timing of the
 	// second one.
 
-	if (_game.id == GID_LOOM && _game.version >= 4 && _language == Common::EN_ANY && vm.slot[_currentScript].number == 95 && var == VAR_MUSIC_TIMER && b == 1708 && enhancementEnabled(kEnhVisualChanges)) {
+	if (_game.id == GID_LOOM && _game.version >= 4 && _language == Common::EN_ANY && currentScriptSlotIs(95) && var == VAR_MUSIC_TIMER && b == 1708 && enhancementEnabled(kEnhVisualChanges)) {
 		b = 1815;
 	}
 
@@ -1690,9 +1688,9 @@ void ScummEngine_v5::o5_notEqualZero() {
 	// otherwise Wally won't be able to read the map, and you'll be completely
 	// stuck on Scabb Island with no way of going back to the Phatt Island
 	// Library, since Dread's ship is gone.
-	if (_game.id == GID_MONKEY2 && ((_roomResource == 22 && vm.slot[_currentScript].number == 202) ||
-		(_roomResource == 2 && vm.slot[_currentScript].number == kScriptNumENCD) ||
-		vm.slot[_currentScript].number == 97) && enhancementEnabled(kEnhGameBreakingBugFixes)) {
+	if (_game.id == GID_MONKEY2 && ((_roomResource == 22 && currentScriptSlotIs(202)) ||
+		(_roomResource == 2 && currentScriptSlotIs(kScriptNumENCD)) ||
+		currentScriptSlotIs(97)) && enhancementEnabled(kEnhGameBreakingBugFixes)) {
 		int var = fetchScriptWord();
 		a = readVar(var);
 
@@ -1734,7 +1732,7 @@ void ScummEngine_v5::o5_notEqualZero() {
 		// Ron Gilbert commented on this: "Not sure I'd call that a
 		// coding error. The lines were just cut. But what do I know."
 
-		if ((_game.id == GID_MONKEY || _game.id == GID_MONKEY_VGA || _game.id == GID_MONKEY_EGA) && _roomResource == 8 && vm.slot[_currentScript].number == kScriptNumENCD) {
+		if ((_game.id == GID_MONKEY || _game.id == GID_MONKEY_VGA || _game.id == GID_MONKEY_EGA) && _roomResource == 8 && currentScriptSlotIs(kScriptNumENCD)) {
 			// A local getVar(), where the var number can be examined.
 			// Taking care to limit this to Monkey1, so that the proper getVar()
 			// implementation still gets called for v2 and below.
@@ -1771,7 +1769,7 @@ void ScummEngine_v5::o5_equalZero() {
 	// If the bit has been set, we simulate a WaitForMessage() instruction
 	// here, so that the script pauses until the "Wow!" message is gone.
 
-	if (_game.id == GID_LOOM && _game.platform == Common::kPlatformPCEngine && vm.slot[_currentScript].number == 109 &&
+	if (_game.id == GID_LOOM && _game.platform == Common::kPlatformPCEngine && currentScriptSlotIs(109) &&
 		enhancementEnabled(kEnhMinorBugFixes)) {
 		int var = fetchScriptWord();
 		a = readVar(var);
@@ -1829,7 +1827,7 @@ void ScummEngine_v5::o5_loadRoom() {
 	// you will always get the close-up where he's wearing his own clothes.
 
 	if (_game.id == GID_LOOM && _game.version == 3 && room == 29 &&
-		vm.slot[_currentScript].number == 112 && enhancementEnabled(kEnhVisualChanges)) {
+		currentScriptSlotIs(112) && enhancementEnabled(kEnhVisualChanges)) {
 		Actor *a = derefActorSafe(VAR(VAR_EGO), "o5_loadRoom");
 
 		// Bobbin's normal costume is number 1. If he's wearing anything
@@ -2062,7 +2060,7 @@ void ScummEngine_v5::o5_print() {
 	//
 	// The workaround is deliberately not marked as an enhancement, since
 	// this version makes so many changes of its own.
-	if (_game.id == GID_MONKEY && (_game.features & GF_ULTIMATE_TALKIE) && _currentRoom == 25 && vm.slot[_currentScript].number == 205 && VAR(VAR_HAVE_MSG)) {
+	if (_game.id == GID_MONKEY && (_game.features & GF_ULTIMATE_TALKIE) && _currentRoom == 25 && currentScriptSlotIs(205) && VAR(VAR_HAVE_MSG)) {
 		_scriptPointer--;
 		o5_breakHere();
 		return;
@@ -2114,12 +2112,14 @@ void ScummEngine_v5::o5_putActor() {
 		} else if (x == 176 && y == 78) {
 			x = 172;
 		}
-	} else if (_game.id == GID_ZAK && _game.platform == Common::kPlatformFMTowns && _currentRoom == 42 && vm.slot[_currentScript].number == 201 && act == 6 && x == 136 && y == 0 && enhancementEnabled(kEnhVisualChanges)) {
-		// WORKAROUND: bug #2762: When switching back to Zak after using the blue
-		// crystal on the bird in Lima, the bird will disappear, come back and
-		// disappear again. This is really strange and only happens with the
-		// FM-TOWNS version, which adds an unconditional putActor(6,136,0) sequence
-		// that will always negate the getActorX()/getActorY() checks that follow.
+	}
+
+	// WORKAROUND: bug #2762: When switching back to Zak after using the blue
+	// crystal on the bird in Lima, the bird will disappear, come back and
+	// disappear again. This is really strange and only happens with the
+	// FM-TOWNS version, which adds an unconditional putActor(6,136,0) sequence
+	// that would always negate the getActorX()/getActorY() checks that follow.
+	if (_game.id == GID_ZAK && _game.platform == Common::kPlatformFMTowns && _currentRoom == 42 && currentScriptSlotIs(201) && act == 6 && x == 136 && y == 0 && enhancementEnabled(kEnhVisualChanges)) {
 		return;
 	}
 
@@ -2147,7 +2147,7 @@ void ScummEngine_v5::o5_putActorAtObject() {
 		// is a bug in the original game, and we work around it by
 		// adjusting the elevation immediately.
 
-		if (_game.id == GID_MONKEY2 && a->_number == 1 && vm.slot[_currentScript].number == 58 && enhancementEnabled(kEnhMinorBugFixes)) {
+		if (_game.id == GID_MONKEY2 && a->_number == 1 && currentScriptSlotIs(58) && enhancementEnabled(kEnhMinorBugFixes)) {
 			a->setElevation(99);
 		}
 	}
@@ -2176,7 +2176,7 @@ void ScummEngine_v5::o5_putActorInRoom() {
 	// really have been that under-powered?
 
 	if (_game.id == GID_MONKEY2 && _game.platform == Common::kPlatformMacintosh &&
-		_currentRoom == 7 && vm.slot[_currentScript].number == kScriptNumENCD &&
+		_currentRoom == 7 && currentScriptSlotIs(kScriptNumENCD) &&
 		a->_number == 11 && room == 0 && enhancementEnabled(kEnhRestoredContent)) {
 		room = _currentRoom;
 		a->animateActor(250);
@@ -2703,7 +2703,7 @@ void ScummEngine_v5::o5_setObjectName() {
 	//
 	// (The original interpreter would print a fatal "Object xxx stopped with active
 	// cutscene/override" error.)
-	if (_game.id == GID_MONKEY && vm.slot[_currentScript].number == 68 && enhancementEnabled(kEnhGameBreakingBugFixes)) {
+	if (_game.id == GID_MONKEY && currentScriptSlotIs(68) && enhancementEnabled(kEnhGameBreakingBugFixes)) {
 		ScriptSlot *ss = vm.slot;
 		for (int i = 0; i < NUM_SCRIPT_SLOT; i++, ss++) {
 			if (ss->status != ssDead && ss->where == WIO_INVENTORY && ss->cutsceneOverride) {
@@ -2735,7 +2735,7 @@ void ScummEngine_v5::o5_setState() {
 	// doll on Largo. Script 13-213 triggers the same action without any glitch,
 	// though, since it properly resets the state of the (invisible) laundry claim
 	// ticket part of the door, so we just reuse its setState and setClass calls.
-	if (_game.id == GID_MONKEY2 && _currentRoom == 13 && vm.slot[_currentScript].number == 200 &&
+	if (_game.id == GID_MONKEY2 && _currentRoom == 13 && currentScriptSlotIs(200) &&
 		obj == 108 && state == 1 && getState(100) != 1 && getState(111) != 2 && enhancementEnabled(kEnhMinorBugFixes)) {
 		putState(111, 2);
 		markObjectRectAsDirty(111);
@@ -2845,7 +2845,7 @@ void ScummEngine_v5::o5_stopSound() {
 	// has the same value regardless of which room it is. We figure out
 	// which one by looking at which rooms we're moving between.
 
-	if (_game.id == GID_MONKEY && (_game.features & GF_AUDIOTRACKS) && sound == 126 && vm.slot[_currentScript].number == kScriptNumEXCD && VAR(VAR_ROOM) == 43 && VAR(VAR_NEW_ROOM) == 76 && enhancementEnabled(kEnhAudioChanges)) {
+	if (_game.id == GID_MONKEY && (_game.features & GF_AUDIOTRACKS) && sound == 126 && currentScriptSlotIs(kScriptNumEXCD) && VAR(VAR_ROOM) == 43 && VAR(VAR_NEW_ROOM) == 76 && enhancementEnabled(kEnhAudioChanges)) {
 		return;
 	}
 
@@ -2853,7 +2853,7 @@ void ScummEngine_v5::o5_stopSound() {
 	// music status variable when you stop it. Wendy's music would then
 	// resume when leaving some rooms (such as room 3 with the chandelier),
 	// even though her CD player was off.
-	if (_game.id == GID_MANIAC && _game.platform == Common::kPlatformNES && sound == 75 && vm.slot[_currentScript].number == 50 && VAR(VAR_EGO) == 6 && VAR(224) == sound && enhancementEnabled(kEnhAudioChanges)) {
+	if (_game.id == GID_MANIAC && _game.platform == Common::kPlatformNES && sound == 75 && currentScriptSlotIs(50) && VAR(VAR_EGO) == 6 && VAR(224) == sound && enhancementEnabled(kEnhAudioChanges)) {
 		VAR(224) = 0;
 	}
 
@@ -2922,7 +2922,7 @@ void ScummEngine_v5::o5_startScript() {
 	// This workaround is meant to address that.
 	//
 	// See also the similar ScummEngine_v4::o4_ifState() workaround.
-	if (_game.id == GID_INDY3 && _currentScript != 0xFF && vm.slot[_currentScript].number == 106 && script == 125 && VAR(115) != 2 &&
+	if (_game.id == GID_INDY3 && currentScriptSlotIs(106) && script == 125 && VAR(115) != 2 &&
 		enhancementEnabled(kEnhMinorBugFixes)) {
 		// If Var[115] != 2, then:
 		// Correct: startScript(125,[29,10]);
@@ -3017,8 +3017,8 @@ void ScummEngine_v5::o5_stopScript() {
 
 	script = getVarOrDirectByte(PARAM_1);
 
-	if (_game.id == GID_INDY4 && script == 164 && _roomResource == 50 && _currentScript != 0xFF &&
-		vm.slot[_currentScript].number == 213 && VAR(VAR_HAVE_MSG) &&
+	if (_game.id == GID_INDY4 && script == 164 && _roomResource == 50 &&
+		currentScriptSlotIs(213) && VAR(VAR_HAVE_MSG) &&
 		getOwner(933) == VAR(VAR_EGO) && getClass(933, 146) && enhancementEnabled(kEnhRestoredContent)) {
 		// WORKAROUND bug #2215: Due to a script bug, a line of text is skipped
 		// which Indy is supposed to speak when he finds Orichalcum in some old
@@ -3311,7 +3311,7 @@ void ScummEngine_v5::o5_walkActorTo() {
 	// the script which closes the door *before* he starts walking away from
 	// it, as in the other releases. Another v5 bug fixed on SegaCD, though!
 	if (_game.id == GID_MONKEY && !(_game.features & GF_ULTIMATE_TALKIE) && _game.platform != Common::kPlatformSegaCD &&
-		_currentRoom == 30 && _currentScript != 0xFF && vm.slot[_currentScript].number == 207 && a->_number == 11 &&
+		_currentRoom == 30 && currentScriptSlotIs(207) && a->_number == 11 &&
 		x == 232 && y == 141 && enhancementEnabled(kEnhVisualChanges)) {
 		if (whereIsObject(387) == WIO_ROOM && getState(387) == 1 && getState(437) == 1) {
 			int args[NUM_SCRIPT_LOCAL];
@@ -3330,7 +3330,7 @@ void ScummEngine_v5::o5_walkActorTo() {
 	//
 	// Intentionally using `kEnhGameBreakingBugFixes`, since you can get
 	// completely stuck.
-	if (_game.id == GID_INDY4 && _currentScript != 0xFF && vm.slot[_currentScript].number == kScriptNumENCD &&
+	if (_game.id == GID_INDY4 && currentScriptSlotIs(kScriptNumENCD) &&
 		_currentRoom == (_game.platform == Common::kPlatformAmiga ? 58 : 60) &&
 		VAR(224) == 140 && a->_number == VAR(VAR_EGO) && x == 45 && y == 137 &&
 		enhancementEnabled(kEnhGameBreakingBugFixes)) {
@@ -3462,7 +3462,7 @@ void ScummEngine_v5::decodeParseString() {
 			// with a shadow, but in a Mac emulator the text is
 			// drawn in light gray with a shadow instead. Very
 			// strange.
-			if (_game.id == GID_INDY3 && _game.platform == Common::kPlatformMacintosh && _currentScript != 0xFF && vm.slot[_currentScript].number == 134 && color == 0x8F)
+			if (_game.id == GID_INDY3 && _game.platform == Common::kPlatformMacintosh && currentScriptSlotIs(134) && color == 0x8F)
 				color = 0x87;
 
 			// WORKAROUND: In the CD version of MI1, the text in
@@ -3485,7 +3485,7 @@ void ScummEngine_v5::decodeParseString() {
 					_game.platform != Common::kPlatformFMTowns &&
 					_game.platform != Common::kPlatformMacintosh &&
 					_currentRoom == 36 &&
-					vm.slot[_currentScript].number == 201 &&
+					currentScriptSlotIs(201) &&
 					color == 2 &&
 					enhancementEnabled(kEnhVisualChanges)) {
 				color = findClosestPaletteColor(_currentPalette, 256, 0, 171, 0);
@@ -3568,20 +3568,20 @@ void ScummEngine_v5::decodeParseStringTextString(int textSlot) {
 	const int len = resStrLen(_scriptPointer);
 
 	if (_game.id == GID_LOOM && _game.version == 4 && _language == Common::EN_ANY &&
-		_currentScript != 0xFF && vm.slot[_currentScript].number == 95 && enhancementEnabled(kEnhTextLocFixes) &&
+		currentScriptSlotIs(95) && enhancementEnabled(kEnhTextLocFixes) &&
 			strcmp((const char *)_scriptPointer, "I am Choas.") == 0) {
 		// WORKAROUND: This happens when Chaos introduces
 		// herself to bishop Mandible. Of all the places to put
 		// a typo...
 		printString(textSlot, (const byte *)"I am Chaos.");
 	} else if (_game.id == GID_LOOM && _game.version == 4 && _roomResource == 90 &&
-		_currentScript != 0xFF && vm.slot[_currentScript].number == 203 && _string[textSlot].color == 0x0F && enhancementEnabled(kEnhSubFmtCntChanges)) {
+		currentScriptSlotIs(203) && _string[textSlot].color == 0x0F && enhancementEnabled(kEnhSubFmtCntChanges)) {
 		// WORKAROUND: When Mandible speaks with Goodmold, his second
 		// speech line is missing its color parameter.
 		_string[textSlot].color = 0x0A;
 		printString(textSlot, _scriptPointer);
 	} else if (_game.id == GID_INDY3 && _game.platform == Common::kPlatformFMTowns && _roomResource == 80 &&
-		_currentScript != 0xFF && vm.slot[_currentScript].number == 201 && enhancementEnabled(kEnhSubFmtCntChanges)) {
+		currentScriptSlotIs(201) && enhancementEnabled(kEnhSubFmtCntChanges)) {
 		// WORKAROUND: When Indy and his father escape the zeppelin
 		// with the biplane in the FM-TOWNS version, they share the
 		// same text color. Indeed, they're not given any explicit
@@ -3597,7 +3597,7 @@ void ScummEngine_v5::decodeParseStringTextString(int textSlot) {
 		else
 			_string[textSlot].color = 0x0E;
 		printString(textSlot, _scriptPointer);
-	} else if (_game.id == GID_INDY4 && _roomResource == 23 && _currentScript != 0xFF && vm.slot[_currentScript].number == 167 &&
+	} else if (_game.id == GID_INDY4 && _roomResource == 23 && currentScriptSlotIs(167) &&
 		len == 24 && enhancementEnabled(kEnhTextLocFixes) && memcmp(_scriptPointer+16, "pregod", 6) == 0) {
 		// WORKAROUND for bug #2961: At the end of Indy4, if Ubermann is told
 		// to use 20 orichalcum beads, he'll count "pregod8" and "pregod9"
@@ -3614,7 +3614,7 @@ void ScummEngine_v5::decodeParseStringTextString(int textSlot) {
 			Common::strlcpy((char *)tmpBuf+16, "^19^", sizeof(tmpBuf) - 16);
 		printString(textSlot, tmpBuf);
 	} else if (_game.id == GID_INDY4 && _language == Common::EN_ANY && _roomResource == 10 &&
-		_currentScript != 0xFF && vm.slot[_currentScript].number == 209 && _actorToPrintStrFor == 4 && len == 81 &&
+		currentScriptSlotIs(209) && _actorToPrintStrFor == 4 && len == 81 &&
 			strcmp(_game.variant, "Floppy") != 0 && enhancementEnabled(kEnhSubFmtCntChanges)) {
 		// WORKAROUND: The English Talkie version of Indy4 changed Kerner's
 		// lines when he uses the phone booth in New York, but the text doesn't
@@ -3631,7 +3631,7 @@ void ScummEngine_v5::decodeParseStringTextString(int textSlot) {
 		} else {
 			printString(textSlot, _scriptPointer);
 		}
-	} else if (_game.id == GID_INDY4 && _currentScript != 0xFF && vm.slot[_currentScript].number == 161 && _actorToPrintStrFor == 2 &&
+	} else if (_game.id == GID_INDY4 && currentScriptSlotIs(161) && _actorToPrintStrFor == 2 &&
 		_game.platform != Common::kPlatformAmiga && strcmp(_game.variant, "Floppy") != 0 &&
 			enhancementEnabled(kEnhAudioChanges)) {
 		// WORKAROUND: In Indy 4, if one plays as Sophia and looks at Indy, then
@@ -3649,7 +3649,7 @@ void ScummEngine_v5::decodeParseStringTextString(int textSlot) {
 		} else {
 			printString(textSlot, _scriptPointer);
 		}
-	} else if (_game.id == GID_MONKEY_EGA && _roomResource == 30 && _currentScript != 0xFF && vm.slot[_currentScript].number == 411 &&
+	} else if (_game.id == GID_MONKEY_EGA && _roomResource == 30 && currentScriptSlotIs(411) &&
 		enhancementEnabled(kEnhTextLocFixes) &&
 		strstr((const char *)_scriptPointer, "NCREDIT-NOTE-AMOUNT")) {
 		// WORKAROUND for bug #4886 (MI1EGA German: Credit text incorrect)
@@ -3663,8 +3663,8 @@ void ScummEngine_v5::decodeParseStringTextString(int textSlot) {
 		printString(textSlot, (byte *)tmpBuf);
 	} else if (_game.id == GID_MONKEY && !(_game.features & GF_ULTIMATE_TALKIE) &&
 		_game.platform != Common::kPlatformSegaCD &&
-			_currentScript != 0xFF && ((_roomResource == 78 && vm.slot[_currentScript].number == 201) ||
-			(_roomResource == 45 && vm.slot[_currentScript].number == 200 &&
+			_currentScript != 0xFF && ((_roomResource == 78 && currentScriptSlotIs(201)) ||
+			(_roomResource == 45 && currentScriptSlotIs(200) &&
 			isValidActor(10) && _actors[10]->isInCurrentRoom())) &&
 			_actorToPrintStrFor == 255 && _string[textSlot].color != 0x0F &&
 			enhancementEnabled(kEnhSubFmtCntChanges)) {
@@ -3677,7 +3677,7 @@ void ScummEngine_v5::decodeParseStringTextString(int textSlot) {
 		printString(textSlot, _scriptPointer);
 	} else if (_game.id == GID_MONKEY && !(_game.features & GF_ULTIMATE_TALKIE) &&
 			_game.platform != Common::kPlatformSegaCD && _currentScript != 0xFF &&
-			(vm.slot[_currentScript].number == 140 || vm.slot[_currentScript].number == 294) &&
+			(currentScriptSlotIs(140) || currentScriptSlotIs(294)) &&
 			_actorToPrintStrFor == 255 && _string[textSlot].color == 0x06 &&
 			enhancementEnabled(kEnhSubFmtCntChanges)) {
 		// WORKAROUND: In MI1 CD, the colors when the navigator head speaks are
@@ -3689,7 +3689,7 @@ void ScummEngine_v5::decodeParseStringTextString(int textSlot) {
 		// different releases and scenes, so we don't know the original intent.
 		_string[textSlot].color = (_game.platform == Common::kPlatformFMTowns) ? 0x0C : 0xEA;
 		printString(textSlot, _scriptPointer);
-	} else if (_game.id == GID_MONKEY && _roomResource == 25 && _currentScript != 0xFF && vm.slot[_currentScript].number == 205) {
+	} else if (_game.id == GID_MONKEY && _roomResource == 25 && currentScriptSlotIs(205)) {
 		printPatchedMI1CannibalString(textSlot, _scriptPointer);
 	} else {
 		printString(textSlot, _scriptPointer);
@@ -3756,7 +3756,7 @@ void ScummEngine_v5::workaroundIndy3TownsMissingLightningCastle(int sound) {
 	// Japanese release on the same CD does show it (it also has some other
 	// script/resource fixes over the English one). Backport this script fix.
 	if (_game.id == GID_INDY3 && _game.platform == Common::kPlatformFMTowns && _language != Common::JA_JPN &&
-		_currentRoom == 12 && _currentScript != 0xFF && vm.slot[_currentScript].number == 132 &&
+		_currentRoom == 12 && currentScriptSlotIs(132) &&
 		enhancementEnabled(kEnhVisualChanges)) {
 		// Thunder sound
 		const int expectedSoundId = 58;
@@ -3811,11 +3811,11 @@ void ScummEngine_v5::workaroundLoomHetchelDoubleHead(Actor *a, int act) {
 	// The problem is known to exist in (at least) the EGA 1.0, 1.1 and Macintosh
 	// releases. The fix is taken from the official French EGA 1.2 release; the
 	// TG16 and all later 256-color releases appear to be fixed by default as well.
-	if (_game.id == GID_LOOM && _game.version == 3 && !(_game.features & GF_OLD256) && _currentScript != 0xFF &&
+	if (_game.id == GID_LOOM && _game.version == 3 && !(_game.features & GF_OLD256) &&
 		(act == 11 || act == 12) && enhancementEnabled(kEnhMinorBugFixes)) {
 		// Hetchel looks at and then flies to the forge; TalkAnimNr() options were
 		// added to some ActorOps() calls in EGA 1.2 script 34-88.
-		if (vm.slot[_currentScript].number == 88 && _roomResource == 34) {
+		if (currentScriptSlotIs(88) && _roomResource == 34) {
 			if (a->_walkFrame == 6 && a->_standFrame == 6) {
 				a->_talkStartFrame = a->_talkStopFrame = 6;
 			} else if (a->_walkFrame == 2 && a->_standFrame == 3 && act == 11) {
@@ -3826,7 +3826,7 @@ void ScummEngine_v5::workaroundLoomHetchelDoubleHead(Actor *a, int act) {
 
 		// Hetchel goes into the forge chimney to get Bobbin's distaff;
 		// TalkAnimNr(6,6) option was added to ActorOps(12) in script 38-087.
-		if (vm.slot[_currentScript].number == 87 && _roomResource >= 38 && _roomResource <= 40) {
+		if (currentScriptSlotIs(87) && _roomResource >= 38 && _roomResource <= 40) {
 			if (a->_walkFrame == 6 && a->_standFrame == 6 && act == 12)
 				a->_talkStartFrame = a->_talkStopFrame = 6;
 		}
@@ -3844,7 +3844,7 @@ bool ScummEngine_v5::workaroundMonkey1JollyRoger(byte callerOpcode, int arg) {
 	// also need to remove the flag from the room, once it's been shown for the first time.
 	// We fix both issues.
 	if ((_game.id == GID_MONKEY_EGA || _game.id == GID_MONKEY_VGA || (_game.id == GID_MONKEY && !(_game.features & GF_ULTIMATE_TALKIE))) &&
-		_roomResource == 87 && _currentScript != 0xFF && vm.slot[_currentScript].number == kScriptNumENCD &&
+		_roomResource == 87 && currentScriptSlotIs(kScriptNumENCD) &&
 		enhancementEnabled(kEnhVisualChanges)) {
 		// The script that's only run the first time the flag is shown
 		const int defaultExpectedScriptNr = (_game.version == 5) ? 122 : 119;

--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -408,7 +408,7 @@ int ScummEngine_v6::readArray(int array, int idx, int base) {
 	// the array. Ouch.
 	//
 	// TODO: what did the original interpreter precisely do in this case?
-	if (_game.id == GID_FT && array == 447 && _currentRoom == 95 && vm.slot[_currentScript].number == 2010 && idx == -1 && base == -1 &&
+	if (_game.id == GID_FT && array == 447 && _currentRoom == 95 && currentScriptSlotIs(2010) && idx == -1 && base == -1 &&
 		enhancementEnabled(kEnhGameBreakingBugFixes)) {
 		return 0;
 	}
@@ -504,7 +504,7 @@ void ScummEngine_v6::o6_pushWordVar() {
 	if (_enableHECompetitiveOnlineMods) {
 		// Sprinting in competitive Backyard Baseball is considered too weak in its current state. This will increase how effective
 		// it is, limiting the highest speed characters enough to where they cannot go TOO fast.
-		if (_game.id == GID_BASEBALL2001 && _currentRoom == 3 && vm.slot[_currentScript].number == 2095 && readVar(399) == 1) {
+		if (_game.id == GID_BASEBALL2001 && _currentRoom == 3 && currentScriptSlotIs(2095) && readVar(399) == 1) {
 			int offset = _scriptPointer - _scriptOrgPointer;
 			int sprintCounter = readArray(344, vm.localvar[_currentScript][0], 1);
 			int sprintGain = vm.localvar[_currentScript][4];
@@ -534,7 +534,7 @@ void ScummEngine_v6::o6_pushWordVar() {
 		}
 
 		// This code will change the velocity of the hit based on the pitch thrown, and the location of the pitch itself.
-		if (_game.id == GID_BASEBALL2001 && _currentRoom == 4 && vm.slot[_currentScript].number == 2090 && readVar(399) == 1) {
+		if (_game.id == GID_BASEBALL2001 && _currentRoom == 4 && currentScriptSlotIs(2090) && readVar(399) == 1) {
 			int offset = _scriptPointer - _scriptOrgPointer;
 			int powerAdjustment = vm.localvar[_currentScript][4];
 			int pitchSelected = readVar(ROOM_VAL(10));
@@ -562,12 +562,12 @@ void ScummEngine_v6::o6_pushWordVar() {
 		}
 
 		// Remember the previous pitch thrown and the previous pitch "zone location", then set those two values to the "remembered" values for later use.
-		if (_game.id == GID_BASEBALL2001 && _currentRoom == 4 && vm.slot[_currentScript].number == 2201 && readVar(399) == 1) {
+		if (_game.id == GID_BASEBALL2001 && _currentRoom == 4 && currentScriptSlotIs(2201) && readVar(399) == 1) {
 			writeArray(346, 1, 0, readArray(346, 0, 0));
 			writeArray(346, 1, 1, readArray(346, 0, 1));
 		}
 		// This sets the base cost of a slow ball to 2. Previously it costed the least of every pitch to throw, which resulted in people only using that pitch.
-		if (_game.id == GID_BASEBALL2001 && _currentRoom == 4 && vm.slot[_currentScript].number == 2057 && readVar(399) == 1) {
+		if (_game.id == GID_BASEBALL2001 && _currentRoom == 4 && currentScriptSlotIs(2057) && readVar(399) == 1) {
 			if (readVar(0x4000 + 1) == 15) {
 				writeVar(0x4000 + 2, 2);
 			}
@@ -589,7 +589,7 @@ void ScummEngine_v6::o6_wordArrayRead() {
 	if (_enableHECompetitiveOnlineMods) {
 		// If we're pulling from the randomly selected teams for online play
 		// at Prince Rupert, read from variables 748 and 749 instead
-		if (_game.id == GID_BASEBALL2001 && _currentRoom == 6 && vm.slot[_currentScript].number == 2071 &&
+		if (_game.id == GID_BASEBALL2001 && _currentRoom == 6 && currentScriptSlotIs(2071) &&
 			readVar(399) == 1 &&  // We're online and in the team name select screen
 			readVar(747) == 1) {  // We successfully got team arrays the host and opponent
 			switch (array) {
@@ -641,7 +641,7 @@ void ScummEngine_v6::o6_eq() {
 	// version of players' stats, leading to unfair play and potential desyncs. This hack ensures the away team's game doesn't
 	// exit the script before applying these stat adjustments. The script checks whether the game is being played online before
 	// this, such that this code doesn't execute for offline play.
-	if (_game.id == GID_BASEBALL2001 && _currentRoom == 27 && vm.slot[_currentScript].number == 2346) {
+	if (_game.id == GID_BASEBALL2001 && _currentRoom == 27 && currentScriptSlotIs(2346)) {
 		int offset = _scriptPointer - _scriptOrgPointer;
 		if (offset == 196137) {
 			push(0);
@@ -664,7 +664,7 @@ void ScummEngine_v6::o6_eq() {
 		// b. at least 2 pixels lower than the top of the zone/at least 3 pixels above the bottom of the zone
 		// If either of these are true AND the x value is less than or equal to 279 OR greater than or equal to 354, make the game read as a ball.
 		// The strike zone should be much more lenient in the corners, as well as removing the small advantage of throwing to the farthest right side of the zone.
-		if (_game.id == GID_BASEBALL2001 && _currentRoom == 4 && (vm.slot[_currentScript].number == 2202 || vm.slot[_currentScript].number == 2192) && readVar(399) == 1) {
+		if (_game.id == GID_BASEBALL2001 && _currentRoom == 4 && (currentScriptSlotIs(2202) || currentScriptSlotIs(2192)) && readVar(399) == 1) {
 			if (((pitchYValue <= strikeZoneTop + 2 || pitchYValue >= strikeZoneBottom - 3) && pitchXValue <= 279) ||
 				((pitchYValue <= strikeZoneTop + 2 || pitchYValue >= strikeZoneBottom - 3) && pitchXValue >= 354)) {
 				writeVar(ROOM_VAL(16), 2);
@@ -679,7 +679,7 @@ void ScummEngine_v6::o6_eq() {
 		// This change affects the angle adjustment for each batting stance when timing your swing. There are complaints that
 		// the game does not give you enough control when batting, resulting in a lot of hits going to the same area. This should
 		// give players more agency on where they want to hit the ball, which will also increase the skill ceiling.
-		if (_game.id == GID_BASEBALL2001 && _currentRoom == 4 && vm.slot[_currentScript].number == 2087 && readVar(399) == 1) {
+		if (_game.id == GID_BASEBALL2001 && _currentRoom == 4 && currentScriptSlotIs(2087) && readVar(399) == 1) {
 			int offset = _scriptPointer - _scriptOrgPointer;
 			// OPEN STANCE ADJUSTMENTS (1 being earliest, 5 being latest)
 			if (offset == 101898 && readVar(447) == 1) {
@@ -745,7 +745,7 @@ void ScummEngine_v6::o6_eq() {
 
 		// This code makes it so that generic players (and Mr. Clanky) play pro player music when hitting home runs.
 		// This is a purely aesthetic change, as they have no home run music by default.
-		if (_game.id == GID_BASEBALL2001 && _currentRoom == 3 && vm.slot[_currentScript].number == 11 && vm.localvar[_currentScript][0] > 61 && readVar(399) == 1) {
+		if (_game.id == GID_BASEBALL2001 && _currentRoom == 3 && currentScriptSlotIs(11) && vm.localvar[_currentScript][0] > 61 && readVar(399) == 1) {
 			// this local variable checks for player ID
 			writeVar(0x4000 + 0, 60);
 		}
@@ -758,7 +758,7 @@ void ScummEngine_v6::o6_eq() {
 	// are incorrect.  They were set to "3 innings" and "no swing spot" respectively, while they were supposed to be set to
 	// "no special rules" and "3 innings".  This is a script bug which assumed to be fixed in later post-retail updates, but
 	// since we don't have access to any of those, this workaround will have to do.
-	if (_game.id == GID_BASEBALL2001 && vm.slot[_currentScript].number == 419 && ((a == 9 && b == 9) || (a == 8 && b == 8))) {
+	if (_game.id == GID_BASEBALL2001 && currentScriptSlotIs(419) && ((a == 9 && b == 9) || (a == 8 && b == 8))) {
 		switch (a) {
 		case 9:
 			// Mountain Aire (No special rules)
@@ -779,30 +779,30 @@ void ScummEngine_v6::o6_eq() {
 	// field's value is 5 (SCD's number) and incrementing/decrementing if it is. To allow SCD to be used, we return 0
 	// for those checks.
 	} else if (_enableHECompetitiveOnlineMods && _game.id == GID_BASEBALL2001 && _currentRoom == 40 &&
-		vm.slot[_currentScript].number == 2106 && a == 5 && (offset == 16754 || offset == 16791)) {
+		currentScriptSlotIs(2106) && a == 5 && (offset == 16754 || offset == 16791)) {
 		push(0);
 
 	// WORKAROUND: Online play is disabled in the Macintosh versions of Backyard Football and Backyard Baseball 2001
 	// because the original U32 makes use of DirectPlay, a Windows exclusive API; we now have our own implementation
 	// which is cross-platform compatible.  We get around that by tricking those checks that we are playing on
 	// the Windows version. These scripts check VAR_PLATFORM (b) against the value (2) of the Macintosh platform (a).
-	} else if (_game.id == GID_FOOTBALL && _currentRoom == 2 && (vm.slot[_currentScript].number == 2049 || vm.slot[_currentScript].number == 2050 ||
+	} else if (_game.id == GID_FOOTBALL && _currentRoom == 2 && (currentScriptSlotIs(2049) || currentScriptSlotIs(2050) ||
 #else
-	if (_game.id == GID_FOOTBALL && _currentRoom == 2 && (vm.slot[_currentScript].number == 2049 || vm.slot[_currentScript].number == 2050 ||
+	if (_game.id == GID_FOOTBALL && _currentRoom == 2 && (currentScriptSlotIs(2049) || currentScriptSlotIs(2050) ||
 #endif
-		vm.slot[_currentScript].number == 498) && a == 2 && b == 2) {
+		currentScriptSlotIs(498)) && a == 2 && b == 2) {
 		push(0);
-	} else if (_game.id == GID_BASEBALL2001 && _currentRoom == 2 && (vm.slot[_currentScript].number == kScriptNumENCD || vm.slot[_currentScript].number == 2050) &&
+	} else if (_game.id == GID_BASEBALL2001 && _currentRoom == 2 && (currentScriptSlotIs(kScriptNumENCD) || currentScriptSlotIs(2050)) &&
 		a == 2 && b == 2) {
 		push(0);
-	} else if (_game.id == GID_FOOTBALL2002 && _currentRoom == 3 && vm.slot[_currentScript].number == 2079 &&
+	} else if (_game.id == GID_FOOTBALL2002 && _currentRoom == 3 && currentScriptSlotIs(2079) &&
 		a == 2 && b == 2) {
 		push(0);
 
 	// WORKAROUND: Forces the game version string set via script 1 to be used in both Macintosh and Windows versions,
 	// when checking for save game compatibility. Allows saved games to be shared between Macintosh and Windows versions.
 	// The scripts check VAR_PLATFORM (b) against the value (2) of the Macintosh platform (a).
-	} else if (_game.id == GID_BASEBALL2001 && (vm.slot[_currentScript].number == 291 || vm.slot[_currentScript].number == 292) &&
+	} else if (_game.id == GID_BASEBALL2001 && (currentScriptSlotIs(291) || currentScriptSlotIs(292)) &&
 		a == 2 && b == 1) {
 		push(1);
 	} else {
@@ -835,7 +835,7 @@ void ScummEngine_v6::o6_gt() {
 	// they please; we do not want them to go through the whole setup again after the timeout
 	// so let's just make unreachable, allowing the session to be hosted indefinitely until
 	// they cancel it out.
-	if (_game.id == GID_FOOTBALL2002 && _currentRoom == 3 && vm.slot[_currentScript].number == 2052) {
+	if (_game.id == GID_FOOTBALL2002 && _currentRoom == 3 && currentScriptSlotIs(2052)) {
 		push(0);
 		return;
 	}
@@ -860,7 +860,7 @@ void ScummEngine_v6::o6_ge() {
 	// Mod for Backyard Baseball 2001 online competitive play: Reduce sprints
 	// required to reach top speed
 	if (_enableHECompetitiveOnlineMods && _game.id == GID_BASEBALL2001 &&
-		_currentRoom == 3 && vm.slot[_currentScript].number == 2095 && readVar(399) == 1) {
+		_currentRoom == 3 && currentScriptSlotIs(2095) && readVar(399) == 1) {
 		a -= 1;  // If sprint counter (b) is higher than a, runner gets 1 extra speed
 	}
 #endif
@@ -891,7 +891,7 @@ void ScummEngine_v6::o6_div() {
 	// Mod for Backyard Baseball 2001 online competitive play: Allow full sprinting while
 	// running half-speed on a popup
 	if (_enableHECompetitiveOnlineMods && _game.id == GID_BASEBALL2001 && _currentRoom == 3 &&
-		vm.slot[_currentScript].number == 2095 && readVar(399) == 1 && a == 2) {
+		currentScriptSlotIs(2095) && readVar(399) == 1 && a == 2) {
 		// Normally divides speed by two here
 		int runnerIdx = readVar(0x4000);
 		int runnerReSprint = readArray(344, runnerIdx, 1);
@@ -913,7 +913,7 @@ void ScummEngine_v6::o6_land() {
 	// showing the coach list.  var133 is set 1 somewhere but var134
 	// is always set at 0. I am going to assume this is a script bug,
 	// so let's skip the 5 second wait.
-	if (_game.id == GID_BASEBALL2001 && _currentRoom == 40 && vm.slot[_currentScript].number == 2122)
+	if (_game.id == GID_BASEBALL2001 && _currentRoom == 40 && currentScriptSlotIs(2122))
 		push(1);
 	else
 		push(b && a);
@@ -1034,9 +1034,9 @@ void ScummEngine_v6::o6_jump() {
 	// will cause the raft to disappear. This is a script bug in the
 	// original game and affects several versions.
 	if (_game.id == GID_PUTTZOO) {
-		if (_game.heversion == 73 && vm.slot[_currentScript].number == 206 && offset == 176 && !isScriptRunning(202))
+		if (_game.heversion == 73 && currentScriptSlotIs(206) && offset == 176 && !isScriptRunning(202))
 			_scummVars[244] = 35;
-		if (_game.features & GF_HE_985 && vm.slot[_currentScript].number == 2054 && offset == 178 && !isScriptRunning(2050))
+		if (_game.features & GF_HE_985 && currentScriptSlotIs(2054) && offset == 178 && !isScriptRunning(2050))
 			_scummVars[202] = 35;
 	}
 
@@ -1047,7 +1047,7 @@ void ScummEngine_v6::o6_jump() {
 	//
 	// Intentionally using `kEnhGameBreakingBugFixes`, since having the game hang
 	// is not useful to anyone.
-	if (_game.id == GID_SAMNMAX && vm.slot[_currentScript].number == 101 && readVar(ROOM_VAL(97)) == 1 && offset == 1 &&
+	if (_game.id == GID_SAMNMAX && currentScriptSlotIs(101) && readVar(ROOM_VAL(97)) == 1 && offset == 1 &&
 		enhancementEnabled(kEnhGameBreakingBugFixes)) {
 		offset = -18;
 	}
@@ -1058,8 +1058,8 @@ void ScummEngine_v6::o6_jump() {
 	// the popuation.  Not only this may slow down the game a bit, it sends quite a bit of bandwidth
 	// considering we're outside the game.  So let's break the script for 5 seconds
 	// before jumping back to the beginning.
-	if ((_game.id == GID_BASEBALL2001 && _currentRoom == 39 && vm.slot[_currentScript].number == 2090 && offset == -904) ||
-		(_game.id == GID_BASEBALL2001 && _currentRoom == 40 && vm.slot[_currentScript].number == 2101 && offset == -128)) {
+	if ((_game.id == GID_BASEBALL2001 && _currentRoom == 39 && currentScriptSlotIs(2090) && offset == -904) ||
+		(_game.id == GID_BASEBALL2001 && _currentRoom == 40 && currentScriptSlotIs(2101) && offset == -128)) {
 		vm.slot[_currentScript].delay = 5 * 60; // 5 seconds
 		vm.slot[_currentScript].status = ssPaused;
 		o6_breakHere();
@@ -1084,7 +1084,7 @@ void ScummEngine_v6::o6_startScript() {
 	// differently when it's just been lit, but then the idea was dropped?).
 	// This also happens with the original interpreters and with the remaster.
 	if (_game.id == GID_TENTACLE && _roomResource == 13 &&
-		vm.slot[_currentScript].number == 21 && script == 106 &&
+		currentScriptSlotIs(21) && script == 106 &&
 		args[0] == 91 && enhancementEnabled(kEnhRestoredContent)) {
 		return;
 	}
@@ -1103,7 +1103,7 @@ void ScummEngine_v6::o6_startScript() {
 	// This fix checks for this situation happening (and only this one), and makes a call
 	// to a soundKludge operation like script 29 would have done.
 	if (_game.id == GID_CMI && _currentRoom == 19 &&
-		vm.slot[_currentScript].number == 168 && script == 118 && enhancementEnabled(kEnhAudioChanges)) {
+		currentScriptSlotIs(168) && script == 118 && enhancementEnabled(kEnhAudioChanges)) {
 		int list[16] = { 4096, 1278, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 		_sound->soundKludge(list, 2);
 	}
@@ -1113,7 +1113,7 @@ void ScummEngine_v6::o6_startScript() {
 	// stopping and starting their speech. This was a script bug in the original
 	// game, which would also block the "That was informative" reaction from Sam.
 	if (_game.id == GID_SAMNMAX && _roomResource == 59 &&
-		vm.slot[_currentScript].number == 201 && script == 48 && enhancementEnabled(kEnhRestoredContent)) {
+		currentScriptSlotIs(201) && script == 48 && enhancementEnabled(kEnhRestoredContent)) {
 		o6_breakHere();
 	}
 
@@ -1246,7 +1246,7 @@ void ScummEngine_v6::o6_drawObjectAt() {
 	// WORKAROUND bug #3487 : Adjust x and y position of
 	// objects in credits sequence, to match other ports
 	if (_game.id == GID_PUTTMOON && _game.platform == Common::kPlatform3DO &&
-		_roomResource == 38 && vm.slot[_currentScript].number == 206) {
+		_roomResource == 38 && currentScriptSlotIs(206)) {
 		x = y = -1;
 	}
 
@@ -1498,7 +1498,7 @@ void ScummEngine_v6::o6_loadRoom() {
 	// WORKAROUND bug #13378: During Sam's reactions to Max beating up the
 	// scientist in the intro, we sometimes have to slow down animations
 	// artificially. This is where we speed them back up again.
-	if (_game.id == GID_SAMNMAX && vm.slot[_currentScript].number == 65 && room == 6 && enhancementEnabled(kEnhTimingChanges)) {
+	if (_game.id == GID_SAMNMAX && currentScriptSlotIs(65) && room == 6 && enhancementEnabled(kEnhTimingChanges)) {
 		int actors[] = { 2, 3, 10 };
 
 		for (int i = 0; i < ARRAYSIZE(actors); i++) {
@@ -1623,7 +1623,7 @@ void ScummEngine_v6::o6_animateActor() {
 	int anim = pop();
 	int act = pop();
 
-	if (_game.id == GID_SAMNMAX && _roomResource == 35 && vm.slot[_currentScript].number == 202 &&
+	if (_game.id == GID_SAMNMAX && _roomResource == 35 && currentScriptSlotIs(202) &&
 		act == 4 && anim == 14 && enhancementEnabled(kEnhMinorBugFixes)) {
 		// WORKAROUND bug #2068 (Animation glitch at World of Fish).
 		// Before starting animation 14 of the fisherman, make sure he isn't
@@ -1635,7 +1635,7 @@ void ScummEngine_v6::o6_animateActor() {
 		}
 	}
 
-	if (_game.id == GID_SAMNMAX && _roomResource == 47 && vm.slot[_currentScript].number == 202 &&
+	if (_game.id == GID_SAMNMAX && _roomResource == 47 && currentScriptSlotIs(202) &&
 		act == 2 && anim == 249 && enhancementEnabled(kEnhMinorBugFixes)) {
 		// WORKAROUND for bug #3832: parts of Bruno are left on the screen when he
 		// escapes Bumpusville with Trixie. Bruno (act. 11) and Trixie (act. 12) are
@@ -1740,7 +1740,7 @@ void ScummEngine_v6::o6_getRandomNumberRange() {
 	if (_enableHECompetitiveOnlineMods) {
 		// For using predefined teams in Prince Rupert, instead of choosing player IDs randomly
 		// let's pull from the variables that contain the teams
-		if (_game.id == GID_BASEBALL2001 && vm.slot[_currentScript].number == 298 &&
+		if (_game.id == GID_BASEBALL2001 && currentScriptSlotIs(298) &&
 			readVar(399) == 1 && readVar(747) == 1) {
 			int offset = _scriptPointer - _scriptOrgPointer;
 			if (offset == 117) {
@@ -1754,7 +1754,7 @@ void ScummEngine_v6::o6_getRandomNumberRange() {
 		// Mod for Backyard Football online competitive play: allow all 38 backyard kids and pros
 		// to be drafted in an online game. This controls how many kids are shown in the bleachers
 		// when drafting. Without this mod, a random selection of between 31 and 35 kids are shown.
-		if (_game.id == GID_FOOTBALL && readVar(465) == 1 && _currentRoom == 5 && vm.slot[_currentScript].number == 2107) {
+		if (_game.id == GID_FOOTBALL && readVar(465) == 1 && _currentRoom == 5 && currentScriptSlotIs(2107)) {
 			rnd = 38;
 		}
 	}
@@ -1858,7 +1858,7 @@ void ScummEngine_v6::o6_getAnimateVariable() {
 	// regardless if the ball's foul or not.
 	if ((_game.id == GID_BASEBALL2001 || _game.id == GID_BASEBALL2003) && \
 			_currentRoom == ((_game.id == GID_BASEBALL2001) ? 4 : 3) && \
-			vm.slot[_currentScript].number == 2105 && \
+			currentScriptSlotIs(2105) && \
 			a->_costume == ((_game.id == GID_BASEBALL2001) ? 107 : 99) && \
 			// Room variable 5 to ensure this workaround executes only once at
 			// the beginning of the script and room variable 22 to check if we
@@ -1923,7 +1923,7 @@ void ScummEngine_v6::o6_beginOverride() {
 	//
 	// To amend this, we intercept this exact script override and we force the playback of sound 2277,
 	// which is the iMUSE sequence which would have been played after the dialogue.
-	if (enhancementEnabled(kEnhAudioChanges) && _game.id == GID_CMI && _currentRoom == 37 && vm.slot[_currentScript].number == 251 &&
+	if (enhancementEnabled(kEnhAudioChanges) && _game.id == GID_CMI && _currentRoom == 37 && currentScriptSlotIs(251) &&
 		_sound->isSoundRunning(2275) != 0 && (_scriptPointer - _scriptOrgPointer) == 0x1A) {
 		int list[16] = {0x1001, 2277, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 		_sound->soundKludge(list, 2);
@@ -2198,7 +2198,7 @@ void ScummEngine_v6::o6_roomOps() {
 		// so we have two ways to perform it: the accurate one, and our
 		// improved one...
 		if (_game.id == GID_SAMNMAX && enhancementEnabled(kEnhMinorBugFixes) &&
-			_currentScript != 0xFF && vm.slot[_currentScript].number == 64) {
+			currentScriptSlotIs(64)) {
 			setDirtyColors(0, 255);
 		} else {
 			setCurrentPalette(a);
@@ -2232,7 +2232,7 @@ void ScummEngine_v6::o6_actorOps() {
 		// makes Washington leave the room can only exist if he's wearing the
 		// chattering teeth, but yet when he comes back he's not wearing them
 		// during this cutscene.
-		if (_game.id == GID_TENTACLE && _currentRoom == 13 && vm.slot[_currentScript].number == 211 &&
+		if (_game.id == GID_TENTACLE && _currentRoom == 13 && currentScriptSlotIs(211) &&
 			a->_number == 8 && i == 53 && enhancementEnabled(kEnhVisualChanges)) {
 			i = 69;
 		}
@@ -2717,10 +2717,11 @@ void ScummEngine_v6::o6_soundKludge() {
 	// the best of circumstances, this will cause the game to hang briefly.
 	// On platforms where threading is cooperative, it will cause the game
 	// to hang indefinitely (hence the use of `kEnhGameBreakingBugFixes`).
+	//
 	// We identify the buggy part of the script by looking for a
 	// soundKludge() opcode immediately followed by a jump.
 
-	if (_game.id == GID_CMI && _roomResource == 11 && vm.slot[_currentScript].number == 2016 && *_scriptPointer == 0x66 &&
+	if (_game.id == GID_CMI && _roomResource == 11 && currentScriptSlotIs(2016) && *_scriptPointer == 0x66 &&
 		enhancementEnabled(kEnhGameBreakingBugFixes)) {
 		debug(3, "Working around script bug in room-11-2016");
 		o6_breakHere();
@@ -2784,7 +2785,7 @@ void ScummEngine_v6::o6_delaySeconds() {
 	// [004E] (4F) localvar3++
 	// [0051] (B1) delaySeconds(1)
 	// [0054] (5D) unless ((var135 || (localvar3 > localvar2))) jump 4e
-	if (!(_game.id == GID_BASEBALL2001 && vm.slot[_currentScript].number == 414)) {
+	if (!(_game.id == GID_BASEBALL2001 && currentScriptSlotIs(414))) {
 		delay = delay * 60;
 	}
 	vm.slot[_currentScript].delay = delay;
@@ -2856,7 +2857,7 @@ void ScummEngine_v6::o6_talkActor() {
 	// This call can't just be inserted after Max's line; it needs to be done
 	// just before the employee's line, otherwise the timing with Sam's moves
 	// will feel off -- so we can't use the _forcedWaitForMessage trick.
-	if (_game.id == GID_SAMNMAX && _roomResource == 11 && vm.slot[_currentScript].number == 67
+	if (_game.id == GID_SAMNMAX && _roomResource == 11 && currentScriptSlotIs(67)
 		&& getOwner(70) != 2 && !readVar(ROOM_VAL(67)) && !readVar(ROOM_VAL(39)) && readVar(ROOM_VAL(12)) == 1
 		&& !getClass(126, 6) && enhancementEnabled(kEnhRestoredContent)) {
 		if (VAR(VAR_HAVE_MSG)) {
@@ -2871,7 +2872,7 @@ void ScummEngine_v6::o6_talkActor() {
 	// WORKAROUND for bug #3803: "DOTT: Bernard impersonating LaVerne"
 	// Original script did not check for VAR_EGO == 2 before executing
 	// a talkActor opcode.
-	if (_game.id == GID_TENTACLE && vm.slot[_currentScript].number == 307
+	if (_game.id == GID_TENTACLE && currentScriptSlotIs(307)
 			&& VAR(VAR_EGO) != 2 && _actorToPrintStrFor == 2
 			&& enhancementEnabled(kEnhMinorBugFixes)) {
 		_scriptPointer += resStrLen(_scriptPointer) + 1;
@@ -2883,7 +2884,7 @@ void ScummEngine_v6::o6_talkActor() {
 	// above the piano in the bar. Probably an original placeholder which
 	// hasn't been properly replaced... Fixed in the 2017 remaster, though.
 	if (_game.id == GID_FT && _language == Common::FR_FRA
-		&& _roomResource == 7 && vm.slot[_currentScript].number == 77
+		&& _roomResource == 7 && currentScriptSlotIs(77)
 		&& _actorToPrintStrFor == 1 && enhancementEnabled(kEnhTextLocFixes)) {
 		const int len = resStrLen(_scriptPointer) + 1;
 		if (len == 93 && memcmp(_scriptPointer + 16 + 18, "piano-low-kick", 14) == 0) {
@@ -2909,7 +2910,7 @@ void ScummEngine_v6::o6_talkActor() {
 	// triggering Dr Fred's lines in this part of the script, since there is
 	// no stable offset for all the floppy, CD and translated versions, and
 	// no easy way to only target the impacted lines.
-	if (_game.id == GID_TENTACLE && vm.slot[_currentScript].number == 9
+	if (_game.id == GID_TENTACLE && currentScriptSlotIs(9)
 		&& vm.localvar[_currentScript][0] == 216 && _actorToPrintStrFor == 4 && enhancementEnabled(kEnhRestoredContent)) {
 		_forcedWaitForMessage = true;
 		_scriptPointer--;
@@ -2928,7 +2929,7 @@ void ScummEngine_v6::o6_talkActor() {
 	// [0166] (73)   } else {
 	//
 	// Here we simulate that opcode.
-	if (_game.id == GID_DIG && vm.slot[_currentScript].number == 88 && enhancementEnabled(kEnhRestoredContent)) {
+	if (_game.id == GID_DIG && currentScriptSlotIs(88) && enhancementEnabled(kEnhRestoredContent)) {
 		if (offset == 0x158 || offset == 0x214 || offset == 0x231 || offset == 0x278) {
 			_forcedWaitForMessage = true;
 			_scriptPointer--;
@@ -2944,7 +2945,7 @@ void ScummEngine_v6::o6_talkActor() {
 	// animation was lost and he would just glide over the floor. Having him
 	// wait before he moves is less disturbing, since that's something he
 	// already does in the game.
-	if (_game.id == GID_DIG && _roomResource == 58 && vm.slot[_currentScript].number == 402
+	if (_game.id == GID_DIG && _roomResource == 58 && currentScriptSlotIs(402)
 		&& _actorToPrintStrFor == 3 && vm.localvar[_currentScript][0] == 0
 		&& readVar(ROOM_VAL(94)) && readVar(ROOM_VAL(78)) && !readVar(ROOM_VAL(97))
 		&& _scummVars[269] == 3 && getState(388) == 2 && enhancementEnabled(kEnhRestoredContent)) {
@@ -3429,8 +3430,8 @@ void ScummEngine_v6::o6_delayFrames() {
 	//
 	// WORKAROUND:  On Baseball 2001, there is a 10 frame pause before sending the login information
 	// to the server.  This is rather a pointless break, so let's skip that.
-	if ((_game.id == GID_MOONBASE && vm.slot[_currentScript].number == 69) ||
-		(_game.id == GID_BASEBALL2001 && _currentRoom == 37 && vm.slot[_currentScript].number == 2068)) {
+	if ((_game.id == GID_MOONBASE && currentScriptSlotIs(69)) ||
+		(_game.id == GID_BASEBALL2001 && _currentRoom == 37 && currentScriptSlotIs(2068))) {
 		pop();
 		return;
 	}

--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -537,7 +537,7 @@ void ScummEngine_v6::o6_pushWordVar() {
 		if (_game.id == GID_BASEBALL2001 && _currentRoom == 4 && vm.slot[_currentScript].number == 2090 && readVar(399) == 1) {
 			int offset = _scriptPointer - _scriptOrgPointer;
 			int powerAdjustment = vm.localvar[_currentScript][4];
-			int pitchSelected = readVar(0x8000 + 10);
+			int pitchSelected = readVar(ROOM_VAL(10));
 
 			// Checks if the swing is either Power or Line Drive
 			if (offset == 102789 && (readVar(387) == 1||readVar(387) == 2)) {
@@ -650,10 +650,10 @@ void ScummEngine_v6::o6_eq() {
 	}
 
 	if (_enableHECompetitiveOnlineMods) {
-		int pitchXValue = readVar(0x8000 + 11);
-		int pitchYValue = readVar(0x8000 + 12);
-		int strikeZoneTop = readVar(0x8000 + 29);
-		int strikeZoneBottom = readVar(0x8000 + 30);
+		int pitchXValue = readVar(ROOM_VAL(11));
+		int pitchYValue = readVar(ROOM_VAL(12));
+		int strikeZoneTop = readVar(ROOM_VAL(29));
+		int strikeZoneBottom = readVar(ROOM_VAL(30));
 
 		// People have been complaining about strikes being visually unclear during online games. This is because the strike zone's visual is not
 		// equal length compared to the actual range in which a strike can be called. These changes should fix that, with some extra leniency in
@@ -667,12 +667,12 @@ void ScummEngine_v6::o6_eq() {
 		if (_game.id == GID_BASEBALL2001 && _currentRoom == 4 && (vm.slot[_currentScript].number == 2202 || vm.slot[_currentScript].number == 2192) && readVar(399) == 1) {
 			if (((pitchYValue <= strikeZoneTop + 2 || pitchYValue >= strikeZoneBottom - 3) && pitchXValue <= 279) ||
 				((pitchYValue <= strikeZoneTop + 2 || pitchYValue >= strikeZoneBottom - 3) && pitchXValue >= 354)) {
-				writeVar(0x8000 + 16, 2);
+				writeVar(ROOM_VAL(16), 2);
 			}
 			// if the ball's y location is 1 pixel higher than the bottom of the zone, then it will be a ball.
 			// This removes the small advantage of throwing at the very bottom of the zone.
 			if (pitchYValue > strikeZoneBottom - 1) {
-				writeVar(0x8000 + 16, 2);
+				writeVar(ROOM_VAL(16), 2);
 			}
 		}
 
@@ -683,7 +683,7 @@ void ScummEngine_v6::o6_eq() {
 			int offset = _scriptPointer - _scriptOrgPointer;
 			// OPEN STANCE ADJUSTMENTS (1 being earliest, 5 being latest)
 			if (offset == 101898 && readVar(447) == 1) {
-				switch (readVar(0x8000 + 1)) {
+				switch (readVar(ROOM_VAL(1))) {
 				case 1:
 					writeVar(0x4000 + 0, -13);
 					break;
@@ -703,7 +703,7 @@ void ScummEngine_v6::o6_eq() {
 			}
 			// SQUARED STANCE ADJUSTMENTS (1 being earliest, 5 being latest)
 			if (offset == 101898 && readVar(447) == 2) {
-				switch (readVar(0x8000 + 1)) {
+				switch (readVar(ROOM_VAL(1))) {
 				case 1:
 					writeVar(0x4000 + 0, -30);
 					break;
@@ -723,7 +723,7 @@ void ScummEngine_v6::o6_eq() {
 			}
 			// CLOSED STANCE ADJUSTMENTS (1 being earliest, 5 being latest)
 			if (offset == 101898 && readVar(447) == 3) {
-				switch (readVar(0x8000 + 1)) {
+				switch (readVar(ROOM_VAL(1))) {
 				case 1:
 					writeVar(0x4000 + 0, -47);
 					break;
@@ -1047,7 +1047,7 @@ void ScummEngine_v6::o6_jump() {
 	//
 	// Intentionally using `kEnhGameBreakingBugFixes`, since having the game hang
 	// is not useful to anyone.
-	if (_game.id == GID_SAMNMAX && vm.slot[_currentScript].number == 101 && readVar(0x8000 + 97) == 1 && offset == 1 &&
+	if (_game.id == GID_SAMNMAX && vm.slot[_currentScript].number == 101 && readVar(ROOM_VAL(97)) == 1 && offset == 1 &&
 		enhancementEnabled(kEnhGameBreakingBugFixes)) {
 		offset = -18;
 	}
@@ -1863,7 +1863,7 @@ void ScummEngine_v6::o6_getAnimateVariable() {
 			// Room variable 5 to ensure this workaround executes only once at
 			// the beginning of the script and room variable 22 to check if we
 			// are bunting.
-			readVar(0x8000 + 5) != 0 && readVar(0x8000 + 22) == 4)
+			readVar(ROOM_VAL(5)) != 0 && readVar(ROOM_VAL(22)) == 4)
 		push(1);
 	else
 		push(a->getAnimVar(var));
@@ -2857,7 +2857,7 @@ void ScummEngine_v6::o6_talkActor() {
 	// just before the employee's line, otherwise the timing with Sam's moves
 	// will feel off -- so we can't use the _forcedWaitForMessage trick.
 	if (_game.id == GID_SAMNMAX && _roomResource == 11 && vm.slot[_currentScript].number == 67
-		&& getOwner(70) != 2 && !readVar(0x8000 + 67) && !readVar(0x8000 + 39) && readVar(0x8000 + 12) == 1
+		&& getOwner(70) != 2 && !readVar(ROOM_VAL(67)) && !readVar(ROOM_VAL(39)) && readVar(ROOM_VAL(12)) == 1
 		&& !getClass(126, 6) && enhancementEnabled(kEnhRestoredContent)) {
 		if (VAR(VAR_HAVE_MSG)) {
 			_scriptPointer--;
@@ -2946,7 +2946,7 @@ void ScummEngine_v6::o6_talkActor() {
 	// already does in the game.
 	if (_game.id == GID_DIG && _roomResource == 58 && vm.slot[_currentScript].number == 402
 		&& _actorToPrintStrFor == 3 && vm.localvar[_currentScript][0] == 0
-		&& readVar(0x8000 + 94) && readVar(0x8000 + 78) && !readVar(0x8000 + 97)
+		&& readVar(ROOM_VAL(94)) && readVar(ROOM_VAL(78)) && !readVar(ROOM_VAL(97))
 		&& _scummVars[269] == 3 && getState(388) == 2 && enhancementEnabled(kEnhRestoredContent)) {
 		_forcedWaitForMessage = true;
 		_scriptPointer--;

--- a/engines/scumm/script_v6.cpp
+++ b/engines/scumm/script_v6.cpp
@@ -792,7 +792,7 @@ void ScummEngine_v6::o6_eq() {
 #endif
 		vm.slot[_currentScript].number == 498) && a == 2 && b == 2) {
 		push(0);
-	} else if (_game.id == GID_BASEBALL2001 && _currentRoom == 2 && (vm.slot[_currentScript].number == 10002 || vm.slot[_currentScript].number == 2050) &&
+	} else if (_game.id == GID_BASEBALL2001 && _currentRoom == 2 && (vm.slot[_currentScript].number == kScriptNumENCD || vm.slot[_currentScript].number == 2050) &&
 		a == 2 && b == 2) {
 		push(0);
 	} else if (_game.id == GID_FOOTBALL2002 && _currentRoom == 3 && vm.slot[_currentScript].number == 2079 &&

--- a/engines/scumm/script_v8.cpp
+++ b/engines/scumm/script_v8.cpp
@@ -266,7 +266,7 @@ int ScummEngine_v8::readVar(uint var) {
 	// which was disabled for international releases, if the user decides so.
 	if (_enableCOMISong &&
 		VAR_LANGUAGE != 0xFF && var == VAR_LANGUAGE &&
-		vm.slot[_currentScript].number == 319 && _currentRoom == 52)
+		currentScriptSlotIs(319) && _currentRoom == 52)
 		return 0;
 
 	if (!(var & 0xF0000000)) {

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -978,6 +978,14 @@ protected:
 
 	OpcodeEntry _opcodes[256];
 
+	/**
+	 * Small helper to avoid checking `_currentScript != 0xFF` before every
+	 * `vm.slot[_currentScript].number` use that would require so.
+	 */
+	bool currentScriptSlotIs(uint16 script) const {
+		return _currentScript != 0xFF && vm.slot[_currentScript].number == script;
+	}
+
 	virtual void setupOpcodes() = 0;
 	void executeOpcode(byte i);
 	const char *getOpcodeDesc(byte i);

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -1524,7 +1524,7 @@ int ScummEngine::convertMessageToString(const byte *msg, byte *dst, int dstSize)
 					// German releases use `startAnim(8)` while the English release correctly
 					// uses `startAnim(7)` for this.
 					if (_game.id == GID_SAMNMAX && _currentRoom == 52 && vm.slot[_currentScript].number == 102 &&
-						chr == 9 && readVar(0x8000 + 95) != 0 && (VAR(171) == 997 || VAR(171) == 998) &&
+						chr == 9 && readVar(ROOM_VAL(95)) != 0 && (VAR(171) == 997 || VAR(171) == 998) &&
 						dst[-2] == 8 && enhancementEnabled(kEnhMinorBugFixes)) {
 						dst[-2] = 7;
 					}

--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -68,7 +68,7 @@ void ScummEngine::printString(int m, const byte *msg) {
 		// We have to do it here, because we don't want to delay the
 		// animation of Rapp turning back to Ashes.
 		if (_game.id == GID_MONKEY2 && _roomResource == 19 &&
-			vm.slot[_currentScript].number == 203 &&
+			currentScriptSlotIs(203) &&
 			_actorToPrintStrFor == 255 && strcmp((const char *)msg, " ") == 0 &&
 			getOwner(200) == VAR(VAR_EGO) && VAR(VAR_HAVE_MSG) &&
 			enhancementEnabled(kEnhMinorBugFixes)) {
@@ -83,7 +83,7 @@ void ScummEngine::printString(int m, const byte *msg) {
 		// In the italian CD version, the whole scene is sped up to
 		// keep up with Sam's speech. We compensate for this by slowing
 		// down the other animations.
-		if (_game.id == GID_SAMNMAX && vm.slot[_currentScript].number == 65 && enhancementEnabled(kEnhTimingChanges)) {
+		if (_game.id == GID_SAMNMAX && currentScriptSlotIs(65) && enhancementEnabled(kEnhTimingChanges)) {
 			Actor *a;
 
 			if (_language == Common::DE_DEU && strcmp(_game.variant, "Floppy") != 0) {
@@ -1523,7 +1523,7 @@ int ScummEngine::convertMessageToString(const byte *msg, byte *dst, int dstSize)
 					// though Sam is the one actually speaking. For example, the French and
 					// German releases use `startAnim(8)` while the English release correctly
 					// uses `startAnim(7)` for this.
-					if (_game.id == GID_SAMNMAX && _currentRoom == 52 && vm.slot[_currentScript].number == 102 &&
+					if (_game.id == GID_SAMNMAX && _currentRoom == 52 && currentScriptSlotIs(102) &&
 						chr == 9 && readVar(ROOM_VAL(95)) != 0 && (VAR(171) == 997 || VAR(171) == 998) &&
 						dst[-2] == 8 && enhancementEnabled(kEnhMinorBugFixes)) {
 						dst[-2] = 7;
@@ -1555,7 +1555,7 @@ int ScummEngine::convertMessageToString(const byte *msg, byte *dst, int dstSize)
 
 	// WORKAROUND bug #12249 (occurs also in original): Missing actor animation in German versions of SAMNMAX
 	// Adding the missing startAnim(14) animation escape sequence while copying the text fixes it.
-	if (_game.id == GID_SAMNMAX && _currentRoom == 56 && vm.slot[_currentScript].number == 200 &&
+	if (_game.id == GID_SAMNMAX && _currentRoom == 56 && currentScriptSlotIs(200) &&
 		_language == Common::DE_DEU && enhancementEnabled(kEnhMinorBugFixes)) {
 		// 0xE5E6 is the CD version, 0xE373 is for the floppy version
 		if (vm.slot[_currentScript].offs == 0xE5E6 || vm.slot[_currentScript].offs == 0xE373) {


### PR DESCRIPTION
This is based on some words from @eriktorbjorn and @athrxx regarding some common patterns used for SCUMM enhancements.

The PR is cut in 3 commits:

1. Introduce `kScriptNumENCD` and `kScriptNumEXCD`, to some repetition for the "magical" `10002` and `10001` values for SCUMM entry/exit (ENCD/EXCD) numbers.
2. Introduce a `ROOM_VAL()`, to avoid the same magical `0x8000 + number` pattern, quite often used to access room vars.
3. Add a new `safeCurrentScriptSlotIs()` helper, that takes care of doing the `_currentScript != 0xFF` that we often miss before doing our many `vm.slot[_currentScript].number` checks (when building with UBSan, one can see that there are many cases where `_currentScript` is `0xFF`

(and some tiny adjustments here and there)

Some remarks:

* `ROOM_VAL()` is a macro because it looks good-enough, and there are no callers that could currently trigger the possible bad side effects inherent to macros. But maybe me want a real, inline function instead, to be sure it can't be misused?
* For `safeCurrentScriptSlotIs()`, the safety check only excludes `_currentScript == 0xFF`. I wonder whether it's a good idea to look for values above `NUM_SCRIPT_SLOT`? Or maybe it's just overkill/a bad idea/can't happen? I can't say.

*Note:* DON'T squash the commits when merging

Thoughts/remarks? 🙃 