### PR TITLE
DIRECTOR: Swedish edutainment games; Krakel ABC game and the Fem Myror demo from Hemglass

### DIFF
--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -202,7 +202,6 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "garage",				"Garage: Bad Dream Adventure" }, // English fan translation
 	{ "garfieldmadcats",	"Garfield: Mad about Cats" },
 	{ "garygadget1",		"Building Cars with Gary Gadget" }, // Sequels list under Swedish
-//	{ "greveholm1",		"The Mystery at Greveholm" },
 	{ "generations",		"Generations" },
 	{ "getaheadmath",		"Math Heads" },
 	{ "getaheadmathcr",		"Math Heads Creator" },
@@ -463,7 +462,6 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "sinkha1",			"Sinkha: Hyleyn" },
 	{ "sinkha2",			"Sinkha: Atmosphere / Planet of the Clouds" },
 	{ "sitfarm",			"Sitting on the Farm" },
-//	{ "skeeto1",			"Skipper & Skeeto: Tales from Paradise Park" },
 	{ "skeeto10",			"Skipper & Skeeto: Fun in the Park" }, // Magnus & Myggen
 	{ "skippy",             "Skippy and the Curse of the Temple of Ock" },
 	{ "skyborg",			"SkyBorg: Into the Vortex" },
@@ -1491,22 +1489,16 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "brspel",				"BR spel" },
 	{ "djuphavsjakten",		"Djuphavsjakten" },
 	{ "ernie",				"Ernie: Broke in Bayonne" },  // aka Ernie: Pank i Bayonne
-//	{ "femmyror1",			"Fem myror är fler än fyra elefanter: Första delen" },
-//	{ "femmyror2",			"Fem myror är fler än fyra elefanter: Andra delen" },
 	{ "femmyrordemo",		"Fem myror är fler än fyra elefanter - Demo" },	//10 games from parts 1 and 2
 	{ "garygadget2",		"Bygg båtar med Mulle Meck" },              // First game listed under English
 	{ "garygadget3",		"Bygg flygplan med Mulle Meck" },
 	{ "garygadget4",		"Bygg hus med Mulle Meck" },
 	{ "garygadget5",		"Upptäck rymden med Mulle Meck" },
-//	{ "greveholm3",		"Mysteriet på Greveholm 3: Den gamla legenden" },	//Greveholm 2 runs on mTropolis, not Director
 	{ "historia",			"Svensk historia: från asatro till frihetskrig år 800-1500" },
 	{ "jonssonligan1",		"Jönssonligan: Jakten på Mjölner" },
 	{ "jonssonligan2",		"Jönssonligan går på djupet" },
 	{ "kosmopolska",		"Kosmopolska" },
-//	{ "krakelstorm",		"Krakels ABC: Storm över Allemansland/Krakel Spektakel" },
 	{ "krakeldamm",		"Krakels ABC: Den galna dammsugaren/Mera Krakel" },
-//	{ "krakelaventyr",		"Krakels ABC: Det magiska äventyret" },
-//	{ "myroribrallan",		"Myror i Brallan" },
 	{ "mumin1",				"Kurragömma med Mumintrollen" },
 	{ "onsalakorv",			"Onsalakorv" },
 	{ "pettson1",			"Pettson o Findus i snickarbon" },
@@ -1518,9 +1510,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "polis1",				"Polis" },
 	{ "polis2",				"Polis 2: Någon ljuger" },
 	{ "polis3",				"Polis 3: Vargspår" },
-//	{ "pussjakten",			"Sune och hans värld: Pussjakten" },
 	{ "requiem",			"Requiem: en mordgåta på 1600-talet" },
-//	{ "rockmanager",		"Rock Manager" },
 	{ "rymdjakten",			"Rymdjakten" },
 	{ "singingbirdbook",	"Jan Lindblad presenterar den sjungande Fågelboken" },
 	{ "sverigejakten",		"Sverigejakten"},
@@ -8287,7 +8277,6 @@ static const DirectorGameDescription gameDescriptions[] = {
 								   "DANE/MAIN.DXR",	"d:98b4f7339e1f8f6628035e6317f78912", 21043440, Common::PL_POL, 650),
 
 	// Krakel Spektakel - Krakels ABC
-	MACGAME1_l("krakeldamm", "Hemglass V1.1", "xn--Icon-ja6e", "sdfökljsdf", 348907, Common:SV_SWE, 602),
 	WINGAME1_l("krakeldamm", "Hemglass V1.1", "DAMMNT.EXE", "518a98696fe1122e08410b0f157f21bf", 1515971, Common::SV_SWE, 602),
 
 
@@ -9031,7 +9020,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 							"JOTO/intro.dxr",		"d:f5a9969070ef59b66aa4474bc8ef684e",	21136, 700),
 
 	// Fem myror är fler än fyra elefanter, Första & Andra delen + Hemglass demo
-	// BreakinBenny: Dedicated to the memory of Magnus, Brasse and Eva!
+	// BreakinBenny: Dedicated to the memory of Magnus Härenstam, Brasse Brännström and Eva Remaeus!
+	MACGAME1_l("femmyrordemo", "Hemglass Demo", "MEDIA/Fem myror 2", "r:0944b962ebb00f4b5d5149d220f8449b", 111222, Common::SV_SWE, 702),
 	WINGAME1_l("femmyrordemo", "Hemglass Demo", "MEDIA/femmyror.exe", "7c18c9a6af2694156bf09ed195c1ab09", 2619547, Common::SV_SWE, 702),
 
 


### PR DESCRIPTION
Most of these like Greveholm are commented out because I don't actually have them, I only looked up that Rock Manager and Pussjakten are on Director, others like PsykakutenTV'll need to the work for these.

I don't understand enough how to check the Macromedia Director version of the Mac versions, I'm unable to use "grep" for the purposes of [this](https://wiki.scummvm.org/index.php?title=Director#Is_my_game_a_Director_Game_and_which_version_is_it.3F) guide.