### PR TITLE
GRAPHICS: Disable filtering when scaling image to its original size

### DIFF
--- a/graphics/image-archive.cpp
+++ b/graphics/image-archive.cpp
@@ -101,7 +101,14 @@ const Surface *ImageArchive::getImageSurface(const Common::Path &fname, int w, i
 	}
 
 	const Graphics::Surface *surf = decoder.getSurface();
-	_imageCache[fname] = surf->scale(w ? w : surf->w, h ? h : surf->h, true);
+
+	// Disable filtering when surface dimensions are not changed to improve performance
+	if (w && h) {
+		_imageCache[fname] = surf->scale(w, h, true);
+	}
+	else {
+		_imageCache[fname] = surf->scale(surf->w, surf->h, false);
+	}
 
 	return _imageCache[fname];
 #endif // USE_PNG


### PR DESCRIPTION
Followup to https://github.com/scummvm/scummvm/pull/6561.

I tried different approach to this issue in https://github.com/scummvm/scummvm/pull/6649 but after discussion with @OMGPizzaGuy it turned out that simply disabling filtering when scaling the image to its original size, the performance gains are the same while requiring much less code changes. We can also discus different/further scaling optimizations.  

Please note that currently there is a issue (introduced in https://github.com/scummvm/scummvm/commit/b96a8dd7039d01dffb76dd3d6cb322483164ac14 ) in Help Menu where clicking on links doesn't work, and clicking anywhere sometimes causes application to crash. 

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
