### PR TITLE
NANCY: Fix reset sound in SafeDialPuzzle 

### DIFF
--- a/engines/nancy/action/puzzle/safedialpuzzle.cpp
+++ b/engines/nancy/action/puzzle/safedialpuzzle.cpp
@@ -296,7 +296,6 @@ void SafeDialPuzzle::handleInput(NancyInput &input) {
 }
 
 void SafeDialPuzzle::drawDialFrame(uint frame) {
-	debug("%u", frame);
 	if (frame >= _dialSrcs.size() / 2 && !_imageName2.empty()) {
 		_drawSurface.blitFrom(_image2, _dialSrcs[frame], _dialDest);
 	} else {

--- a/engines/nancy/action/puzzle/safedialpuzzle.cpp
+++ b/engines/nancy/action/puzzle/safedialpuzzle.cpp
@@ -283,7 +283,7 @@ void SafeDialPuzzle::handleInput(NancyInput &input) {
 
 		if (!g_nancy->_sound->isSoundPlaying(_resetSound) && input.input & NancyInput::kLeftMouseButtonUp) {
 			_drawSurface.blitFrom(_image1, _resetSrc, _resetDest);
-			g_nancy->_sound->playSound(_resetSound);
+			g_nancy->_sound->playSound(_selectSound);
 			_animState = kReset;
 			_nextAnim = g_nancy->getTotalPlayTime() + 500; // hardcoded
 			_current = 0;


### PR DESCRIPTION
The select sound should play before the reset sound, instead of the reset sound twice (the first interrupted). Verified in nancy3 MHM (scene 3333) and nancy7 DOG (scene 2299).

(The actual reset sound is played in updateGraphics(). At first that seemed bad but it does not look trivial to move it elsewhere, given the kResetAnim transitions.)

Meanwhile in this PR I remove the frame number debug statement which I guess was accidentally left in. It could instead be decorated a bit and given a debug level so it doesn't always print--it's a bit noisy.

(By the way, the reset animation appears to run way too long at first, but a comment explains that we run it at ~60fps (and it does look beautiful) and in roughly the duration of the reset sound in MHM. The original game runs it at ... about 590 frames per second in my VM!?!? nice. I guess this isn't an issue until speedrunners say it is. But it seems like speedrunners with different machine performances simply play the originals at different speeds, while ScummVM is more fair to everyone and might perhaps become the better way to play!)


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
