### PR TITLE
OPENGL: Add support for more pixel formats

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -224,24 +224,17 @@ Common::List<Graphics::PixelFormat> OpenGLGraphicsManager::getSupportedFormats()
 
 	// ABGR8888/RGBA8888
 	formats.push_back(OpenGL::Texture::getRGBAPixelFormat());
+
+	// TODO: Limit these formats to implementations that support them -
+	// currently the Kyra, SCUMM and Trecision engines expect at least
+	// one 16bpp format in this list.
+
 	// RGB565
 	formats.push_back(Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0));
 	// RGBA5551
 	formats.push_back(Graphics::PixelFormat(2, 5, 5, 5, 1, 11, 6, 1, 0));
 	// RGBA4444
 	formats.push_back(Graphics::PixelFormat(2, 4, 4, 4, 4, 12, 8, 4, 0));
-
-	// These formats are not natively supported by OpenGL ES implementations,
-	// we convert the pixel format internally.
-#ifdef SCUMM_LITTLE_ENDIAN
-	// RGBA8888
-	formats.push_back(Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
-#else
-	// ABGR8888
-	formats.push_back(Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
-#endif
-	// RGB555, this is used by SCUMM HE 16 bit games.
-	formats.push_back(Graphics::PixelFormat(2, 5, 5, 5, 0, 10, 5, 0, 0));
 
 	formats.push_back(Graphics::PixelFormat::createFormatCLUT8());
 
@@ -397,14 +390,6 @@ OSystem::TransactionError OpenGLGraphicsManager::endGFXTransaction() {
 #ifdef USE_RGB_COLOR
 	if (_oldState.gameFormat != _currentState.gameFormat) {
 		setupNewGameScreen = true;
-	}
-
-	// Check whether the requested format can actually be used.
-	Common::List<Graphics::PixelFormat> supportedFormats = getSupportedFormats();
-	// In case the requested format is not usable we will fall back to CLUT8.
-	if (Common::find(supportedFormats.begin(), supportedFormats.end(), _currentState.gameFormat) == supportedFormats.end()) {
-		_currentState.gameFormat = Graphics::PixelFormat::createFormatCLUT8();
-		transactionError |= OSystem::kTransactionFormatNotSupported;
 	}
 #endif
 

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -225,6 +225,11 @@ Common::List<Graphics::PixelFormat> OpenGLGraphicsManager::getSupportedFormats()
 	// ABGR8888/RGBA8888
 	formats.push_back(OpenGL::Texture::getRGBAPixelFormat());
 
+	if (OpenGLContext.bgraSupported) {
+		// ARGB8888/BGRA8888
+		formats.push_back(OpenGL::Texture::getBGRAPixelFormat());
+	}
+
 	// TODO: Limit these formats to implementations that support them -
 	// currently the Kyra, SCUMM and Trecision engines expect at least
 	// one 16bpp format in this list.
@@ -235,6 +240,37 @@ Common::List<Graphics::PixelFormat> OpenGLGraphicsManager::getSupportedFormats()
 	formats.push_back(Graphics::PixelFormat(2, 5, 5, 5, 1, 11, 6, 1, 0));
 	// RGBA4444
 	formats.push_back(Graphics::PixelFormat(2, 4, 4, 4, 4, 12, 8, 4, 0));
+
+#if !USE_FORCED_GLES && !USE_FORCED_GLES2
+	if (OpenGLContext.packedPixelsSupported && !isGLESContext()) {
+#ifdef SCUMM_LITTLE_ENDIAN
+		// RGBA8888
+		formats.push_back(Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
+		// BGRA8888
+		formats.push_back(Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0));
+#endif
+#ifdef SCUMM_BIG_ENDIAN
+		// ABGR8888
+		formats.push_back(Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
+		// ARGB8888
+		formats.push_back(Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24));
+#endif
+		// BGR565
+		formats.push_back(Graphics::PixelFormat(2, 5, 6, 5, 0, 0, 5, 11, 0));
+		// ABGR1555
+		formats.push_back(Graphics::PixelFormat(2, 5, 5, 5, 1, 10, 5, 0, 15));
+		// ARGB1555
+		formats.push_back(Graphics::PixelFormat(2, 5, 5, 5, 1, 10, 5, 0, 15));
+		// BGRA5551
+		formats.push_back(Graphics::PixelFormat(2, 5, 5, 5, 1, 1, 6, 11, 0));
+		// ABGR4444
+		formats.push_back(Graphics::PixelFormat(2, 4, 4, 4, 4, 0, 4, 8, 12));
+		// ARGB4444
+		formats.push_back(Graphics::PixelFormat(2, 4, 4, 4, 4, 8, 4, 0, 12));
+		// BGRA4444
+		formats.push_back(Graphics::PixelFormat(2, 4, 4, 4, 4, 4, 8, 12, 0));
+	}
+#endif // !USE_FORCED_GLES && !USE_FORCED_GLES2
 
 	formats.push_back(Graphics::PixelFormat::createFormatCLUT8());
 
@@ -1524,6 +1560,11 @@ bool OpenGLGraphicsManager::getGLPixelFormat(const Graphics::PixelFormat &pixelF
 		glFormat = GL_RGB;
 		glType = GL_UNSIGNED_BYTE;
 		return true;
+	} else if (OpenGLContext.bgraSupported && pixelFormat == OpenGL::Texture::getBGRAPixelFormat()) { // ARGB8888 / BGRA8888
+		glIntFormat = isGLESContext() ? GL_BGRA : GL_RGBA;
+		glFormat = GL_BGRA;
+		glType = GL_UNSIGNED_BYTE;
+		return true;
 	} else if (!OpenGLContext.packedPixelsSupported) {
 		return false;
 	} else if (pixelFormat == Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0)) { // RGB565
@@ -1552,33 +1593,38 @@ bool OpenGLGraphicsManager::getGLPixelFormat(const Graphics::PixelFormat &pixelF
 		glFormat = GL_RGBA;
 		glType = GL_UNSIGNED_INT_8_8_8_8;
 		return true;
-#endif
-	} else if (pixelFormat == Graphics::PixelFormat(2, 5, 5, 5, 0, 10, 5, 0, 0)) { // RGB555
-		glIntFormat = GL_RGB;
-		glFormat = GL_BGRA;
-		glType = GL_UNSIGNED_SHORT_1_5_5_5_REV;
-		return true;
-	} else if (pixelFormat == Graphics::PixelFormat(2, 4, 4, 4, 4, 8, 4, 0, 12)) { // ARGB4444
+	} else if (pixelFormat == Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0)) { // BGRA8888
 		glIntFormat = GL_RGBA;
 		glFormat = GL_BGRA;
-		glType = GL_UNSIGNED_SHORT_4_4_4_4_REV;
+		glType = GL_UNSIGNED_INT_8_8_8_8;
 		return true;
+#endif
 #ifdef SCUMM_BIG_ENDIAN
 	} else if (pixelFormat == Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24)) { // ABGR8888
 		glIntFormat = GL_RGBA;
 		glFormat = GL_RGBA;
 		glType = GL_UNSIGNED_INT_8_8_8_8_REV;
 		return true;
-#endif
-	} else if (pixelFormat == Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0)) { // BGRA8888
+	} else if (pixelFormat == Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24)) { // ARGB8888
 		glIntFormat = GL_RGBA;
 		glFormat = GL_BGRA;
-		glType = GL_UNSIGNED_INT_8_8_8_8;
+		glType = GL_UNSIGNED_INT_8_8_8_8_REV;
 		return true;
+#endif
 	} else if (pixelFormat == Graphics::PixelFormat(2, 5, 6, 5, 0, 0, 5, 11, 0)) { // BGR565
 		glIntFormat = GL_RGB;
 		glFormat = GL_RGB;
 		glType = GL_UNSIGNED_SHORT_5_6_5_REV;
+		return true;
+	} else if (pixelFormat == Graphics::PixelFormat(2, 5, 5, 5, 1, 10, 5, 0, 15)) { // ABGR1555
+		glIntFormat = GL_RGB;
+		glFormat = GL_RGBA;
+		glType = GL_UNSIGNED_SHORT_1_5_5_5_REV;
+		return true;
+	} else if (pixelFormat == Graphics::PixelFormat(2, 5, 5, 5, 1, 10, 5, 0, 15)) { // ARGB1555
+		glIntFormat = GL_RGB;
+		glFormat = GL_BGRA;
+		glType = GL_UNSIGNED_SHORT_1_5_5_5_REV;
 		return true;
 	} else if (pixelFormat == Graphics::PixelFormat(2, 5, 5, 5, 1, 1, 6, 11, 0)) { // BGRA5551
 		glIntFormat = GL_RGBA;
@@ -1588,6 +1634,11 @@ bool OpenGLGraphicsManager::getGLPixelFormat(const Graphics::PixelFormat &pixelF
 	} else if (pixelFormat == Graphics::PixelFormat(2, 4, 4, 4, 4, 0, 4, 8, 12)) { // ABGR4444
 		glIntFormat = GL_RGBA;
 		glFormat = GL_RGBA;
+		glType = GL_UNSIGNED_SHORT_4_4_4_4_REV;
+		return true;
+	} else if (pixelFormat == Graphics::PixelFormat(2, 4, 4, 4, 4, 8, 4, 0, 12)) { // ARGB4444
+		glIntFormat = GL_RGBA;
+		glFormat = GL_BGRA;
 		glType = GL_UNSIGNED_SHORT_4_4_4_4_REV;
 		return true;
 	} else if (pixelFormat == Graphics::PixelFormat(2, 4, 4, 4, 4, 4, 8, 12, 0)) { // BGRA4444

--- a/graphics/opengl/context.cpp
+++ b/graphics/opengl/context.cpp
@@ -70,6 +70,7 @@ void Context::reset() {
 	framebufferObjectSupported = false;
 	framebufferObjectMultisampleSupported = false;
 	multisampleMaxSamples = -1;
+	bgraSupported = false;
 	packedPixelsSupported = false;
 	packedDepthStencilSupported = false;
 	unpackSubImageSupported = false;
@@ -179,6 +180,8 @@ void Context::initialize(ContextType contextType) {
 			multitextureSupported = true;
 		} else if (token == "GL_ARB_framebuffer_object") {
 			framebufferObjectSupported = true;
+		} else if (token == "GL_EXT_bgra" || token == "GL_EXT_texture_format_BGRA8888") {
+			bgraSupported = true;
 		} else if (token == "GL_EXT_packed_pixels" || token == "GL_APPLE_packed_pixels") {
 			packedPixelsSupported = true;
 		} else if (token == "GL_EXT_packed_depth_stencil" || token == "GL_OES_packed_depth_stencil") {
@@ -278,6 +281,7 @@ void Context::initialize(ContextType contextType) {
 
 		// OpenGL 1.2 and later always has packed pixels, texture edge clamp and texture max level support
 		if (isGLVersionOrHigher(1, 2)) {
+			bgraSupported = true;
 			packedPixelsSupported = true;
 			textureEdgeClampSupported = true;
 			textureMaxLevelSupported = true;
@@ -320,6 +324,7 @@ void Context::initialize(ContextType contextType) {
 	debug(5, "OpenGL: FBO support: %d", framebufferObjectSupported);
 	debug(5, "OpenGL: Multisample FBO support: %d", framebufferObjectMultisampleSupported);
 	debug(5, "OpenGL: Multisample max number: %d", multisampleMaxSamples);
+	debug(5, "OpenGL: BGRA support: %d", bgraSupported);
 	debug(5, "OpenGL: Packed pixels support: %d", packedPixelsSupported);
 	debug(5, "OpenGL: Packed depth stencil support: %d", packedDepthStencilSupported);
 	debug(5, "OpenGL: Unpack subimage support: %d", unpackSubImageSupported);

--- a/graphics/opengl/context.h
+++ b/graphics/opengl/context.h
@@ -96,6 +96,9 @@ public:
 	 */
 	int multisampleMaxSamples;
 
+	/** Whether BGRA support is available or not. */
+	bool bgraSupported;
+
 	/** Whether packed pixels support is available or not. */
 	bool packedPixelsSupported;
 

--- a/graphics/opengl/texture.h
+++ b/graphics/opengl/texture.h
@@ -161,6 +161,14 @@ public:
 #endif
 	}
 
+	static inline const Graphics::PixelFormat getBGRAPixelFormat() {
+#ifdef SCUMM_BIG_ENDIAN
+		return Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0);
+#else
+		return Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24);
+#endif
+	}
+
 protected:
 	const GLenum _glIntFormat;
 	const GLenum _glFormat;


### PR DESCRIPTION
The main addition here is support for ARGB8888, which is the preferred format for AGS in 32-bit mode, but some other formats have also been added/changed for consistency.

~TODO: Test with OpenGL ES implementations that support `GL_EXT_texture_format_BGRA8888`.~ Confirmed working on Android.
