### PR TITLE
GUI: Take out all the trash (fix memory leak)

### DIFF
--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -607,15 +607,7 @@ void GuiManager::runLoop() {
 		}
 
 		// Delete GuiObject that have been added to the trash for a delayed deletion
-		Common::List<GuiObjectTrashItem>::iterator it = _guiObjectTrash.begin();
-		while (it != _guiObjectTrash.end()) {
-			if ((*it).parent == nullptr || (*it).parent == activeDialog) {
-				debug(7, "Delayed deletion of Gui Object %p", (void *)(*it).object);
-				delete (*it).object;
-				it = _guiObjectTrash.erase(it);
-			} else
-				++it;
-		}
+		emptyTrash(activeDialog);
 
 		// Handle tooltip for the widget under the mouse cursor.
 		// 1. Only try to show a tooltip if the mouse cursor was actually moved
@@ -997,6 +989,18 @@ Graphics::MacWindowManager *GuiManager::getWM() {
 	_wm = new Graphics::MacWindowManager(wmMode);
 
 	return _wm;
+}
+
+void GuiManager::emptyTrash(Dialog *const activeDialog) {
+	Common::List<GuiObjectTrashItem>::iterator it = _guiObjectTrash.begin();
+	while (it != _guiObjectTrash.end()) {
+		if ((*it).parent == nullptr || (*it).parent == activeDialog) {
+			debug(7, "Delayed deletion of Gui Object %p", (void *)(*it).object);
+			delete (*it).object;
+			it = _guiObjectTrash.erase(it);
+		} else
+			++it;
+	}
 }
 
 } // End of namespace GUI

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -675,8 +675,10 @@ void GuiManager::runLoop() {
 	// it will never be removed. Since we can have multiple run loops being
 	// called we cannot rely on catching EVENT_QUIT in the event loop above,
 	// since it would only catch it for the top run loop.
-	if ((eventMan->shouldQuit() || (g_engine && eventMan->shouldReturnToLauncher())) && activeDialog == getTopDialog())
+	if ((eventMan->shouldQuit() || (g_engine && eventMan->shouldReturnToLauncher())) && activeDialog == getTopDialog()) {
 		getTopDialog()->close();
+		emptyTrash(activeDialog);
+	}
 
 	if (didSaveState) {
 		_theme->disable();

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -244,6 +244,8 @@ protected:
 
 	void giveFocusToDialog(Dialog *dialog);
 	void setLastMousePos(int16 x, int16 y);
+
+	void emptyTrash(Dialog *const activeDialog);
 };
 
 } // End of namespace GUI


### PR DESCRIPTION
Objects could remain in the trash (unfreed) during quit. For example, hit the X or press Ctrl+C during:

![image](https://github.com/user-attachments/assets/4fd2c2b8-82b0-4846-badd-28dbdebfae53)

Attempts to fix:

```
==77365==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 1048 byte(s) in 1 object(s) allocated from:
    #0 in operator new(unsigned long) (scummvm+0xefcd4d) (BuildId: f8e86a9b42db40e7)
    #1 in GUI::LauncherDialog::createSwitchButton(Common::String const&, Common::U32String const&, Common::U32String const&, char const*, unsigned int) gui/launcher.cpp:947:12
    #2 in GUI::LauncherDialog::addLayoutChooserButtons() gui/launcher.cpp:938:16
    #3 in GUI::LauncherDialog::LauncherDialog(Common::String const&) gui/launcher.cpp:195:2
    #4 in GUI::LauncherSimple::LauncherSimple(Common::String const&) gui/launcher.cpp:1053:4
    #5 in GUI::LauncherChooser::selectLauncher() gui/launcher.cpp:1028:16
    #6 in launcherDialog() base/main.cpp:116:7
...

Direct leak of 1048 byte(s) in 1 object(s) allocated from:
    #0 in operator new(unsigned long) (scummvm+0xefcd4d) (BuildId: f8e86a9b42db40e7)
    #1 in GUI::LauncherDialog::createSwitchButton(Common::String const&, Common::U32String const&, Common::U32String const&, char const*, unsigned int) gui/launcher.cpp:947:12
    #2 in GUI::LauncherDialog::addLayoutChooserButtons() gui/launcher.cpp:939:16
    #3 in GUI::LauncherDialog::LauncherDialog(Common::String const&) gui/launcher.cpp:195:2
    #4 in GUI::LauncherSimple::LauncherSimple(Common::String const&) gui/launcher.cpp:1053:4
    #5 in GUI::LauncherChooser::selectLauncher() gui/launcher.cpp:1028:16
    #6 in launcherDialog() base/main.cpp:116:7
...

Direct leak of 1048 byte(s) in 1 object(s) allocated from:
    #0 in operator new(unsigned long) (scummvm+0xefcd4d) (BuildId: f8e86a9b42db40e7)
    #1 in GUI::addClearButton(GUI::GuiObject*, Common::String const&, unsigned int, int, int, int, int, bool) gui/widget.cpp
    #2 in GUI::LauncherDialog::build() gui/launcher.cpp:309:23
    #3 in GUI::LauncherSimple::build() gui/launcher.cpp:1078:18
    #4 in GUI::LauncherChooser::selectLauncher() gui/launcher.cpp:1028:16
    #5 in launcherDialog() base/main.cpp:116:7
...

Indirect leak of 40 byte(s) in 1 object(s) allocated from:
    #0 in operator new[](unsigned long) (scummvm+0xefce5d) (BuildId: f8e86a9b42db40e7)
    #1 in Common::BaseString<char>::ensureCapacity(unsigned int, bool) common/str-base.cpp:160:16
    #2 in Common::BaseString<char>::assignAppend(char const*) common/str-base.cpp:1066:3
    #3 in Common::String::operator+=(char const*) common/str.cpp:60:2
    #4 in Common::operator+(Common::String const&, char const*) common/str.cpp:323:7
    #5 in GUI::LauncherDialog::build() gui/launcher.cpp:309:51
    #6 in GUI::LauncherSimple::build() gui/launcher.cpp:1078:18
    #7 in GUI::LauncherChooser::selectLauncher() gui/launcher.cpp:1028:16
    #8 in launcherDialog() base/main.cpp:116:7
...

SUMMARY: AddressSanitizer: 3184 byte(s) leaked in 4 allocation(s).

```