### PR TITLE
ENGINES: Replace glColor3*/glColorPointer calls with OpenGL ES compatible calls

### DIFF
--- a/engines/freescape/gfx_opengl.cpp
+++ b/engines/freescape/gfx_opengl.cpp
@@ -228,7 +228,7 @@ void OpenGLRenderer::positionCamera(const Math::Vector3d &pos, const Math::Vecto
 void OpenGLRenderer::renderSensorShoot(byte color, const Math::Vector3d sensor, const Math::Vector3d target, const Common::Rect &viewArea) {
 	glEnable(GL_BLEND);
 	glBlendFunc(GL_ONE_MINUS_DST_COLOR, GL_ZERO);
-	glColor3ub(255, 255, 255);
+	glColor4ub(255, 255, 255, 255);
 
 	glLineWidth(20);
 	glEnableClientState(GL_VERTEX_ARRAY);
@@ -301,7 +301,7 @@ void OpenGLRenderer::renderPlayerShootRay(byte color, const Common::Point &posit
 	glDisable(GL_DEPTH_TEST);
 	glDepthMask(GL_FALSE);
 
-	glColor3ub(r, g, b);
+	glColor4ub(r, g, b, 255);
 
 	glLineWidth(5); // It will not work in every OpenGL implementation since the
 	                // spec doesn't require support for line widths other than 1
@@ -417,7 +417,7 @@ void OpenGLRenderer::renderPlayerShootBall(byte color, const Common::Point &posi
 	glDisable(GL_DEPTH_TEST);
 	glDepthMask(GL_FALSE);
 
-	glColor3ub(r, g, b);
+	glColor4ub(r, g, b, 255);
 	int triangleAmount = 20;
 	float twicePi = (float)(2.0 * M_PI);
 	float coef = (9 - frame) / 9.0;
@@ -531,7 +531,7 @@ void OpenGLRenderer::useStipple(bool enabled) {
 }
 
 void OpenGLRenderer::useColor(uint8 r, uint8 g, uint8 b) {
-	glColor3ub(r, g, b);
+	glColor4ub(r, g, b, 255);
 }
 
 void OpenGLRenderer::clear(uint8 r, uint8 g, uint8 b, bool ignoreViewport) {
@@ -547,7 +547,7 @@ void OpenGLRenderer::drawFloor(uint8 color) {
 	uint8 r1, g1, b1, r2, g2, b2;
 	byte *stipple;
 	assert(getRGBAt(color, 0, r1, g1, b1, r2, g2, b2, stipple)); // TODO: move check inside this function
-	glColor3ub(r1, g1, b1);
+	glColor4ub(r1, g1, b1, 255);
 
 	glEnableClientState(GL_VERTEX_ARRAY);
 	copyToVertexArray(0, Math::Vector3d(-100000.0, 0.0, -100000.0));

--- a/engines/freescape/gfx_opengl_shaders.cpp
+++ b/engines/freescape/gfx_opengl_shaders.cpp
@@ -558,7 +558,7 @@ void OpenGLShaderRenderer::drawFloor(uint8 color) {
 	/*uint8 r1, g1, b1, r2, g2, b2;
 	byte *stipple;
 	assert(getRGBAt(color, r1, g1, b1, r2, g2, b2, stipple)); // TODO: move check inside this function
-	glColor3ub(r1, g1, b1);
+	glColor4ub(r1, g1, b1, 255);
 
 	glEnableClientState(GL_VERTEX_ARRAY);
 	copyToVertexArray(0, Math::Vector3d(-100000.0, 0.0, -100000.0));

--- a/engines/freescape/gfx_tinygl.cpp
+++ b/engines/freescape/gfx_tinygl.cpp
@@ -175,7 +175,7 @@ void TinyGLRenderer::positionCamera(const Math::Vector3d &pos, const Math::Vecto
 void TinyGLRenderer::renderSensorShoot(byte color, const Math::Vector3d sensor, const Math::Vector3d player, const Common::Rect &viewArea) {
 	tglEnable(TGL_BLEND);
 	tglBlendFunc(TGL_ONE_MINUS_DST_COLOR, TGL_ZERO);
-	tglColor3ub(255, 255, 255);
+	tglColor4ub(255, 255, 255, 255);
 	polygonOffset(true);
 	tglEnableClientState(TGL_VERTEX_ARRAY);
 	copyToVertexArray(0, player);
@@ -206,7 +206,7 @@ void TinyGLRenderer::renderPlayerShootBall(byte color, const Common::Point &posi
 	tglDisable(TGL_DEPTH_TEST);
 	tglDepthMask(TGL_FALSE);
 
-	tglColor3ub(r, g, b);
+	tglColor4ub(r, g, b, 255);
 	int triangleAmount = 20;
 	float twicePi = (float)(2.0 * M_PI);
 	float coef = (9 - frame) / 9.0;
@@ -255,7 +255,7 @@ void TinyGLRenderer::renderPlayerShootRay(byte color, const Common::Point &posit
 	tglDisable(TGL_DEPTH_TEST);
 	tglDepthMask(TGL_FALSE);
 
-	tglColor3ub(r, g, b);
+	tglColor4ub(r, g, b, 255);
 
 	int viewPort[4];
 	tglGetIntegerv(TGL_VIEWPORT, viewPort);
@@ -535,7 +535,7 @@ void TinyGLRenderer::polygonOffset(bool enabled) {
 void TinyGLRenderer::useColor(uint8 r, uint8 g, uint8 b) {
 	_lastColorSet1 = _lastColorSet0;
 	_lastColorSet0 = _texturePixelFormat.RGBToColor(r, g, b);
-	tglColor3ub(r, g, b);
+	tglColor4ub(r, g, b, 255);
 }
 
 void TinyGLRenderer::clear(uint8 r, uint8 g, uint8 b, bool ignoreViewport) {
@@ -551,7 +551,7 @@ void TinyGLRenderer::drawFloor(uint8 color) {
 	uint8 r1, g1, b1, r2, g2, b2;
 	byte *stipple = nullptr;
 	assert(getRGBAt(color, 0, r1, g1, b1, r2, g2, b2, stipple)); // TODO: move check inside this function
-	tglColor3ub(r1, g1, b1);
+	tglColor4ub(r1, g1, b1, 255);
 
 	tglEnableClientState(TGL_VERTEX_ARRAY);
 	copyToVertexArray(0, Math::Vector3d(-100000.0, 0.0, -100000.0));

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -555,11 +555,11 @@ void GfxOpenGL::startActorDraw(const Actor *actor) {
 		glDisable(GL_LIGHTING);
 		glDisable(GL_TEXTURE_2D);
 		if (g_grim->getGameType() == GType_GRIM) {
-			glColor3ub(_shadowColorR, _shadowColorG, _shadowColorB);
+			glColor4ub(_shadowColorR, _shadowColorG, _shadowColorB, 255);
 		} else {
-			glColor3ub(_currentShadowArray->color.getRed(), _currentShadowArray->color.getGreen(), _currentShadowArray->color.getBlue());
+			glColor4ub(_currentShadowArray->color.getRed(), _currentShadowArray->color.getGreen(), _currentShadowArray->color.getBlue(), 255);
 		}
-		//glColor3f(0.0f, 1.0f, 0.0f); // debug draw color
+		//glColor4f(0.0f, 1.0f, 0.0f, 1.0f); // debug draw color
 		shadowProjection(_currentShadowArray->pos, shadowSector->getVertices()[0], shadowSector->getNormal(), _currentShadowArray->dontNegate);
 	}
 
@@ -621,7 +621,7 @@ void GfxOpenGL::finishActorDraw() {
 
 	if (_currentShadowArray) {
 		glEnable(GL_LIGHTING);
-		glColor3f(1.0f, 1.0f, 1.0f);
+		glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 		glDisable(GL_POLYGON_OFFSET_FILL);
 	}
 
@@ -633,7 +633,7 @@ void GfxOpenGL::finishActorDraw() {
 }
 
 void GfxOpenGL::drawShadowPlanes() {
-/*	glColor3f(1.0f, 1.0f, 1.0f);
+/*	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 	_currentShadowArray->planeList.begin();
 	for (SectorListType::iterator i = _currentShadowArray->planeList.begin(); i != _currentShadowArray->planeList.end(); i++) {
 		Sector *shadowSector = i->sector;
@@ -755,7 +755,7 @@ void GfxOpenGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 	glEnd();
 
 	if (!_currentShadowArray) {
-		glColor3f(1.0f, 1.0f, 1.0f);
+		glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 	}
 
 	glEnable(GL_TEXTURE_2D);
@@ -1176,7 +1176,7 @@ void GfxOpenGL::drawBitmap(const Bitmap *bitmap, int dx, int dy, uint32 layer) {
 		glDisable(GL_DEPTH_TEST);
 		glDepthMask(GL_FALSE);
 
-		glColor3f(1.0f, 1.0f, 1.0f);
+		glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 		BitmapData *data = bitmap->_data;
 		GLuint *textures = (GLuint *)bitmap->getTexIds();
@@ -1196,7 +1196,7 @@ void GfxOpenGL::drawBitmap(const Bitmap *bitmap, int dx, int dy, uint32 layer) {
 			glEnd();
 		}
 
-		glColor3f(1.0f, 1.0f, 1.0f);
+		glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 		glDisable(GL_BLEND);
 		glDisable(GL_TEXTURE_2D);
@@ -1473,7 +1473,7 @@ void GfxOpenGL::drawTextObject(const TextObject *text) {
 	const Color &color = text->getFGColor();
 	const Font *f = text->getFont();
 
-	glColor3ub(color.getRed(), color.getGreen(), color.getBlue());
+	glColor4ub(color.getRed(), color.getGreen(), color.getBlue(), 255);
 	if (!f->is8Bit()) {
 		const TextObjectUserData *ud = (const TextObjectUserData *)text->getUserData();
 
@@ -1512,7 +1512,7 @@ void GfxOpenGL::drawTextObject(const TextObject *text) {
 			glEnd();
 		}
 
-		glColor3f(1, 1, 1);
+		glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 		glDisable(GL_TEXTURE_2D);
 		glDisable(GL_BLEND);
@@ -1561,7 +1561,7 @@ void GfxOpenGL::drawTextObject(const TextObject *text) {
 		}
 	}
 
-	glColor3f(1, 1, 1);
+	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 	glDisable(GL_TEXTURE_2D);
 	glDisable(GL_BLEND);
@@ -1856,7 +1856,7 @@ void GfxOpenGL::drawEmergString(int x, int y, const char *text, const Color &fgC
 	glDisable(GL_LIGHTING);
 
 	glRasterPos2i(x, y);
-	glColor3f(1.0f, 1.0f, 1.0f);
+	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 	glListBase(_emergFont);
 
@@ -2035,7 +2035,7 @@ void GfxOpenGL::irisAroundRegion(int x1, int y1, int x2, int y2) {
 	glDisable(GL_LIGHTING);
 	glDepthMask(GL_FALSE);
 
-	glColor3f(0.0f, 0.0f, 0.0f);
+	glColor4f(0.0f, 0.0f, 0.0f, 1.0f);
 
 	// Explicitly cast to avoid problems with C++11
 	float fx1 = x1;
@@ -2063,7 +2063,7 @@ void GfxOpenGL::irisAroundRegion(int x1, int y1, int x2, int y2) {
 	}
 	glEnd();
 
-	glColor3f(1.0f, 1.0f, 1.0f);
+	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 	glEnable(GL_DEPTH_TEST);
 	glEnable(GL_LIGHTING);
 	glDepthMask(GL_TRUE);
@@ -2086,7 +2086,7 @@ void GfxOpenGL::drawRectangle(const PrimitiveObject *primitive) {
 	glDisable(GL_DEPTH_TEST);
 	glDepthMask(GL_FALSE);
 
-	glColor3ub(color.getRed(), color.getGreen(), color.getBlue());
+	glColor4ub(color.getRed(), color.getGreen(), color.getBlue(), 255);
 
 	if (primitive->isFilled()) {
 		glBegin(GL_QUADS);
@@ -2105,7 +2105,7 @@ void GfxOpenGL::drawRectangle(const PrimitiveObject *primitive) {
 		glEnd();
 	}
 
-	glColor3f(1.0f, 1.0f, 1.0f);
+	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 	glDepthMask(GL_TRUE);
 	glEnable(GL_DEPTH_TEST);
@@ -2130,7 +2130,7 @@ void GfxOpenGL::drawLine(const PrimitiveObject *primitive) {
 	glDisable(GL_DEPTH_TEST);
 	glDepthMask(GL_FALSE);
 
-	glColor3ub(color.getRed(), color.getGreen(), color.getBlue());
+	glColor4ub(color.getRed(), color.getGreen(), color.getBlue(), 255);
 
 	glLineWidth(_scaleW);
 
@@ -2139,7 +2139,7 @@ void GfxOpenGL::drawLine(const PrimitiveObject *primitive) {
 	glVertex2f(x2, y2);
 	glEnd();
 
-	glColor3f(1.0f, 1.0f, 1.0f);
+	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 	glDepthMask(GL_TRUE);
 	glEnable(GL_DEPTH_TEST);
@@ -2205,7 +2205,7 @@ void GfxOpenGL::drawPolygon(const PrimitiveObject *primitive) {
 	glDisable(GL_DEPTH_TEST);
 	glDepthMask(GL_FALSE);
 
-	glColor3ub(color.getRed(), color.getGreen(), color.getBlue());
+	glColor4ub(color.getRed(), color.getGreen(), color.getBlue(), 255);
 
 	glBegin(GL_LINES);
 	glVertex2f(x1, y1);
@@ -2214,7 +2214,7 @@ void GfxOpenGL::drawPolygon(const PrimitiveObject *primitive) {
 	glVertex2f(x4 + 1, y4);
 	glEnd();
 
-	glColor3f(1.0f, 1.0f, 1.0f);
+	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 	glDepthMask(GL_TRUE);
 	glEnable(GL_DEPTH_TEST);

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -478,11 +478,11 @@ void GfxTinyGL::startActorDraw(const Actor *actor) {
 		tglDisable(TGL_LIGHTING);
 		tglDisable(TGL_TEXTURE_2D);
 		if (g_grim->getGameType() == GType_GRIM) {
-			tglColor3ub(_shadowColorR, _shadowColorG, _shadowColorB);
+			tglColor4ub(_shadowColorR, _shadowColorG, _shadowColorB, 255);
 		} else {
-			tglColor3ub(_currentShadowArray->color.getRed(), _currentShadowArray->color.getGreen(), _currentShadowArray->color.getBlue());
+			tglColor4ub(_currentShadowArray->color.getRed(), _currentShadowArray->color.getGreen(), _currentShadowArray->color.getBlue(), 255);
 		}
-		//tglColor3f(0.0f, 1.0f, 0.0f); // debug draw color
+		//tglColor4f(0.0f, 1.0f, 0.0f, 1.0f); // debug draw color
 		shadowProjection(_currentShadowArray->pos, shadowSector->getVertices()[0], shadowSector->getNormal(), _currentShadowArray->dontNegate);
 	}
 
@@ -544,7 +544,7 @@ void GfxTinyGL::finishActorDraw() {
 
 	if (_currentShadowArray) {
 		tglEnable(TGL_LIGHTING);
-		tglColor3f(1.0f, 1.0f, 1.0f);
+		tglColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 		tglDisable(TGL_POLYGON_OFFSET_FILL);
 	}
 
@@ -556,7 +556,7 @@ void GfxTinyGL::finishActorDraw() {
 }
 
 void GfxTinyGL::drawShadowPlanes() {
-/*	tglColor3f(1.0f, 1.0f, 1.0f);
+/*	tglColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 	_currentShadowArray->planeList.begin();
 	for (SectorListType::iterator i = _currentShadowArray->planeList.begin(); i != _currentShadowArray->planeList.end(); i++) {
 		Sector *shadowSector = i->sector;
@@ -678,7 +678,7 @@ void GfxTinyGL::drawEMIModelFace(const EMIModel *model, const EMIMeshFace *face)
 	tglEnd();
 
 	if (!_currentShadowArray) {
-		tglColor3f(1.0f, 1.0f, 1.0f);
+		tglColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 	}
 
 	tglEnable(TGL_TEXTURE_2D);
@@ -939,7 +939,7 @@ void GfxTinyGL::drawBitmap(const Bitmap *bitmap, int x, int y, uint32 layer) {
 	if (g_grim->getGameType() == GType_MONKEY4 && bitmap->_data && bitmap->_data->_texc) {
 		tglEnable(TGL_BLEND);
 		tglBlendFunc(TGL_SRC_ALPHA, TGL_ONE_MINUS_SRC_ALPHA);
-		tglColor3f(1.0f, 1.0f, 1.0f);
+		tglColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 		BitmapData *data = bitmap->_data;
 		float *texc = data->_texc;
@@ -1257,7 +1257,7 @@ void GfxTinyGL::dimRegion(int x, int y, int w, int h, float level) {
 	tglVertex2f(x, y + h);
 	tglEnd();
 
-	tglColor3f(1.0f, 1.0f, 1.0f);
+	tglColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 	tglDisable(TGL_BLEND);
 	tglDepthMask(TGL_TRUE);
@@ -1278,7 +1278,7 @@ void GfxTinyGL::irisAroundRegion(int x1, int y1, int x2, int y2) {
 	tglDisable(TGL_LIGHTING);
 	tglDepthMask(TGL_FALSE);
 
-	tglColor3f(0.0f, 0.0f, 0.0f);
+	tglColor4f(0.0f, 0.0f, 0.0f, 1.0f);
 
 	// Explicitly cast to avoid problems with C++11
 	float fx1 = x1;
@@ -1305,7 +1305,7 @@ void GfxTinyGL::irisAroundRegion(int x1, int y1, int x2, int y2) {
 	tglDrawArrays(TGL_TRIANGLE_STRIP, 0, 10);
 	tglDisableClientState(TGL_VERTEX_ARRAY);
 
-	tglColor3f(1.0f, 1.0f, 1.0f);
+	tglColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 	tglEnable(TGL_DEPTH_TEST);
 	tglEnable(TGL_LIGHTING);
 	tglDepthMask(TGL_TRUE);
@@ -1328,7 +1328,7 @@ void GfxTinyGL::drawRectangle(const PrimitiveObject *primitive) {
 	tglDisable(TGL_DEPTH_TEST);
 	tglDepthMask(TGL_FALSE);
 
-	tglColor3ub(color.getRed(), color.getGreen(), color.getBlue());
+	tglColor4ub(color.getRed(), color.getGreen(), color.getBlue(), 255);
 
 	if (primitive->isFilled()) {
 		tglBegin(TGL_QUADS);
@@ -1347,7 +1347,7 @@ void GfxTinyGL::drawRectangle(const PrimitiveObject *primitive) {
 		tglEnd();
 	}
 
-	tglColor3f(1.0f, 1.0f, 1.0f);
+	tglColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 	tglDepthMask(TGL_TRUE);
 	tglEnable(TGL_DEPTH_TEST);
@@ -1372,7 +1372,7 @@ void GfxTinyGL::drawLine(const PrimitiveObject *primitive) {
 	tglDisable(TGL_DEPTH_TEST);
 	tglDepthMask(TGL_FALSE);
 
-	tglColor3ub(color.getRed(), color.getGreen(), color.getBlue());
+	tglColor4ub(color.getRed(), color.getGreen(), color.getBlue(), 255);
 
 	//tglLineWidth(_scaleW); // Not implemented in TinyGL
 
@@ -1381,7 +1381,7 @@ void GfxTinyGL::drawLine(const PrimitiveObject *primitive) {
 	tglVertex2f(x2, y2);
 	tglEnd();
 
-	tglColor3f(1.0f, 1.0f, 1.0f);
+	tglColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 	tglDepthMask(TGL_TRUE);
 	tglEnable(TGL_DEPTH_TEST);
@@ -1443,7 +1443,7 @@ void GfxTinyGL::drawPolygon(const PrimitiveObject *primitive) {
 	tglDisable(TGL_DEPTH_TEST);
 	tglDepthMask(TGL_FALSE);
 
-	tglColor3ub(color.getRed(), color.getGreen(), color.getBlue());
+	tglColor4ub(color.getRed(), color.getGreen(), color.getBlue(), 255);
 
 	tglBegin(TGL_LINES);
 	tglVertex2f(x1, y1);
@@ -1452,7 +1452,7 @@ void GfxTinyGL::drawPolygon(const PrimitiveObject *primitive) {
 	tglVertex2f(x4 + 1, y4);
 	tglEnd();
 
-	tglColor3f(1.0f, 1.0f, 1.0f);
+	tglColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 	tglDepthMask(TGL_TRUE);
 	tglEnable(TGL_DEPTH_TEST);

--- a/engines/myst3/gfx_opengl.cpp
+++ b/engines/myst3/gfx_opengl.cpp
@@ -72,7 +72,7 @@ void OpenGLRenderer::init() {
 void OpenGLRenderer::clear() {
 	glClearColor(0.f, 0.f, 0.f, 1.f); // Solid black
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-	glColor3f(1.0f, 1.0f, 1.0f);
+	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 }
 
 void OpenGLRenderer::selectTargetWindow(Window *window, bool is3D, bool scaled) {
@@ -208,7 +208,7 @@ void OpenGLRenderer::draw2DText(const Common::String &text, const Common::Point 
 	glEnable(GL_TEXTURE_2D);
 	glDepthMask(GL_FALSE);
 
-	glColor3f(1.0f, 1.0f, 1.0f);
+	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 	glBindTexture(GL_TEXTURE_2D, glFont->id);
 
 	int x = position.x;

--- a/engines/myst3/gfx_tinygl.cpp
+++ b/engines/myst3/gfx_tinygl.cpp
@@ -76,7 +76,7 @@ void TinyGLRenderer::init() {
 void TinyGLRenderer::clear() {
 	tglClearColor(0.f, 0.f, 0.f, 1.f); // Solid black
 	tglClear(TGL_COLOR_BUFFER_BIT | TGL_DEPTH_BUFFER_BIT);
-	tglColor3f(1.0f, 1.0f, 1.0f);
+	tglColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 }
 
 void TinyGLRenderer::selectTargetWindow(Window *window, bool is3D, bool scaled) {
@@ -191,7 +191,7 @@ void TinyGLRenderer::draw2DText(const Common::String &text, const Common::Point 
 	tglEnable(TGL_TEXTURE_2D);
 	tglDepthMask(TGL_FALSE);
 
-	tglColor3f(1.0f, 1.0f, 1.0f);
+	tglColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 	int x = position.x;
 	int y = position.y;

--- a/engines/playground3d/gfx_opengl.cpp
+++ b/engines/playground3d/gfx_opengl.cpp
@@ -175,7 +175,7 @@ void OpenGLRenderer::disableScissor() {
 void OpenGLRenderer::drawFace(uint face) {
 	glBegin(GL_TRIANGLE_STRIP);
 	for (uint i = 0; i < 4; i++) {
-		glColor3f(cubeVertices[11 * (4 * face + i) + 8], cubeVertices[11 * (4 * face + i) + 9], cubeVertices[11 * (4 * face + i) + 10]);
+		glColor4f(cubeVertices[11 * (4 * face + i) + 8], cubeVertices[11 * (4 * face + i) + 9], cubeVertices[11 * (4 * face + i) + 10], 1.0f);
 		glVertex3f(cubeVertices[11 * (4 * face + i) + 2], cubeVertices[11 * (4 * face + i) + 3], cubeVertices[11 * (4 * face + i) + 4]);
 		glNormal3f(cubeVertices[11 * (4 * face + i) + 5], cubeVertices[11 * (4 * face + i) + 6], cubeVertices[11 * (4 * face + i) + 7]);
 	}
@@ -221,7 +221,7 @@ void OpenGLRenderer::drawPolyOffsetTest(const Math::Vector3d &pos, const Math::V
 	glTranslatef(pos.x(), pos.y(), pos.z());
 	glRotatef(roll.y(), 0.0f, 1.0f, 0.0f);
 
-	glColor3f(0.0f, 1.0f, 0.0f);
+	glColor4f(0.0f, 1.0f, 0.0f, 1.0f);
 	glBegin(GL_TRIANGLES);
 	glVertex3f(-1.0f,  1.0, 0.0f);
 	glVertex3f( 1.0f,  1.0, 0.0f);
@@ -230,7 +230,7 @@ void OpenGLRenderer::drawPolyOffsetTest(const Math::Vector3d &pos, const Math::V
 
 	glPolygonOffset(-1.0f, 0.0f);
 	glEnable(GL_POLYGON_OFFSET_FILL);
-	glColor3f(1.0f, 1.0f, 1.0f);
+	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 	glBegin(GL_TRIANGLES);
 	glVertex3f(-0.5f,  0.5, 0.0f);
 	glVertex3f( 0.5f,  0.5, 0.0f);

--- a/engines/playground3d/gfx_tinygl.cpp
+++ b/engines/playground3d/gfx_tinygl.cpp
@@ -205,7 +205,7 @@ void TinyGLRenderer::disableScissor() {
 void TinyGLRenderer::drawFace(uint face) {
 	tglBegin(TGL_TRIANGLE_STRIP);
 	for (uint i = 0; i < 4; i++) {
-		tglColor3f(cubeVertices[11 * (4 * face + i) + 8], cubeVertices[11 * (4 * face + i) + 9], cubeVertices[11 * (4 * face + i) + 10]);
+		tglColor4f(cubeVertices[11 * (4 * face + i) + 8], cubeVertices[11 * (4 * face + i) + 9], cubeVertices[11 * (4 * face + i) + 10], 1.0f);
 		tglVertex3f(cubeVertices[11 * (4 * face + i) + 2], cubeVertices[11 * (4 * face + i) + 3], cubeVertices[11 * (4 * face + i) + 4]);
 		tglNormal3f(cubeVertices[11 * (4 * face + i) + 5], cubeVertices[11 * (4 * face + i) + 6], cubeVertices[11 * (4 * face + i) + 7]);
 	}
@@ -251,7 +251,7 @@ void TinyGLRenderer::drawPolyOffsetTest(const Math::Vector3d &pos, const Math::V
 	tglTranslatef(pos.x(), pos.y(), pos.z());
 	tglRotatef(roll.y(), 0.0f, 1.0f, 0.0f);
 
-	tglColor3f(0.0f, 1.0f, 0.0f);
+	tglColor4f(0.0f, 1.0f, 0.0f, 1.0f);
 	tglBegin(TGL_TRIANGLES);
 	tglVertex3f(-1.0f,  1.0, 0.0f);
 	tglVertex3f( 1.0f,  1.0, 0.0f);
@@ -260,7 +260,7 @@ void TinyGLRenderer::drawPolyOffsetTest(const Math::Vector3d &pos, const Math::V
 
 	tglPolygonOffset(-1.0f, 0.0f);
 	tglEnable(TGL_POLYGON_OFFSET_FILL);
-	tglColor3f(1.0f, 1.0f, 1.0f);
+	tglColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 	tglBegin(TGL_TRIANGLES);
 	tglVertex3f(-0.5f,  0.5, 0.0f);
 	tglVertex3f( 0.5f,  0.5, 0.0f);

--- a/engines/stark/gfx/openglactor.cpp
+++ b/engines/stark/gfx/openglactor.cpp
@@ -252,6 +252,7 @@ void OpenGLActorRenderer::render(const Math::Vector3d &position, float direction
 				vertex.r = color.x();
 				vertex.g = color.y();
 				vertex.b = color.z();
+				vertex.a = 1.0f; /* needed for compatibility with OpenGL ES 1.x */
 			}
 
 			_faceVBO[index] = vertex;
@@ -269,7 +270,7 @@ void OpenGLActorRenderer::render(const Math::Vector3d &position, float direction
 			glTexCoordPointer(2, GL_FLOAT, sizeof(ActorVertex), &_faceVBO[0].texS);
 		glNormalPointer(GL_FLOAT, sizeof(ActorVertex), &_faceVBO[0].nx);
 		if (_gfx->computeLightsEnabled())
-			glColorPointer(3, GL_FLOAT, sizeof(ActorVertex), &_faceVBO[0].r);
+			glColorPointer(4, GL_FLOAT, sizeof(ActorVertex), &_faceVBO[0].r);
 
 		glDrawElements(GL_TRIANGLES, numVertexIndices, GL_UNSIGNED_INT, vertexIndices);
 

--- a/engines/stark/gfx/openglactor.cpp
+++ b/engines/stark/gfx/openglactor.cpp
@@ -127,12 +127,12 @@ void OpenGLActorRenderer::render(const Math::Vector3d &position, float direction
 				if (_gfx->computeLightsEnabled())
 					color = Math::Vector3d(1.0f, 1.0f, 1.0f);
 				else
-					glColor3f(1.0f, 1.0f, 1.0f);
+					glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 			} else {
 				if (_gfx->computeLightsEnabled())
 					color = Math::Vector3d(material->r, material->g, material->b);
 				else
-					glColor3f(material->r, material->g, material->b);
+					glColor4f(material->r, material->g, material->b, 1.0f);
 			}
 			uint32 index = vertexIndices[i];
 			auto vertex = _faceVBO[index];

--- a/engines/stark/gfx/openglactor.h
+++ b/engines/stark/gfx/openglactor.h
@@ -65,6 +65,7 @@ struct _ActorVertex {
 	float r;
 	float g;
 	float b;
+	float a;
 };
 typedef _ActorVertex ActorVertex;
 

--- a/engines/stark/gfx/openglprop.cpp
+++ b/engines/stark/gfx/openglprop.cpp
@@ -183,6 +183,7 @@ void OpenGLPropRenderer::render(const Math::Vector3d &position, float direction,
 				vertex.r = color.x();
 				vertex.g = color.y();
 				vertex.b = color.z();
+				vertex.a = 1.0f; /* needed for compatibility with OpenGL ES 1.x */
 			}
 			_faceVBO[index] = vertex;
 		}
@@ -199,7 +200,7 @@ void OpenGLPropRenderer::render(const Math::Vector3d &position, float direction,
 			glTexCoordPointer(2, GL_FLOAT, sizeof(PropVertex), &_faceVBO[0].texS);
 		glNormalPointer(GL_FLOAT, sizeof(PropVertex), &_faceVBO[0].nx);
 		if (_gfx->computeLightsEnabled())
-			glColorPointer(3, GL_FLOAT, sizeof(PropVertex), &_faceVBO[0].r);
+			glColorPointer(4, GL_FLOAT, sizeof(PropVertex), &_faceVBO[0].r);
 
 		glDrawElements(GL_TRIANGLES, face->vertexIndices.size(), GL_UNSIGNED_INT, vertexIndices);
 

--- a/engines/stark/gfx/openglprop.cpp
+++ b/engines/stark/gfx/openglprop.cpp
@@ -107,7 +107,7 @@ void OpenGLPropRenderer::render(const Math::Vector3d &position, float direction,
 				if (_gfx->computeLightsEnabled())
 					color = Math::Vector3d(1.0f, 1.0f, 1.0f);
 				else
-					glColor3f(1.0f, 1.0f, 1.0f);
+					glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 				if (material.doubleSided) {
 					vertex.texS = vertex.stexS;
 					vertex.texT = 1.0f - vertex.stexT;
@@ -119,7 +119,7 @@ void OpenGLPropRenderer::render(const Math::Vector3d &position, float direction,
 				if (_gfx->computeLightsEnabled())
 					color = Math::Vector3d(material.r, material.g, material.b);
 				else
-					glColor3f(material.r, material.g, material.b);
+					glColor4f(material.r, material.g, material.b, 1.0f);
 			}
 
 			if (_gfx->computeLightsEnabled()) {

--- a/engines/stark/gfx/openglprop.h
+++ b/engines/stark/gfx/openglprop.h
@@ -53,6 +53,7 @@ struct _PropVertex {
 	float r;
 	float g;
 	float b;
+	float a;
 };
 typedef _PropVertex PropVertex;
 

--- a/engines/stark/gfx/openglsurface.cpp
+++ b/engines/stark/gfx/openglsurface.cpp
@@ -72,7 +72,7 @@ void OpenGLSurfaceRenderer::render(const Bitmap *bitmap, const Common::Point &de
 
 	glVertexPointer(2, GL_FLOAT, sizeof(SurfaceVertex), &vertices[0].x);
 	glTexCoordPointer(2, GL_FLOAT, 2 * sizeof(float), textCords);
-	glColor3f(1.0f - _fadeLevel, 1.0f - _fadeLevel, 1.0f - _fadeLevel);
+	glColor4f(1.0f - _fadeLevel, 1.0f - _fadeLevel, 1.0f - _fadeLevel, 1.0f);
 
 	bitmap->bind();
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);

--- a/engines/tinsel/noir/spriter.cpp
+++ b/engines/tinsel/noir/spriter.cpp
@@ -995,7 +995,7 @@ void Spriter::RenderMeshPartColor(MeshPart& part, Vectors& vertices, Vectors &no
 		TGLubyte g = (prim.color >> 8) & 0xff;
 		TGLubyte b = (prim.color >> 16) & 0xff;
 
-		tglColor3ub(r, g, b);
+		tglColor4ub(r, g, b, 255);
 
 		if (part.numVertices == 4) {
 			tglBegin(TGL_QUADS);
@@ -1024,7 +1024,7 @@ void Spriter::RenderMeshPartTexture(MeshPart& part, Vectors& vertices, Vectors &
 	}
 
 	tglEnable(TGL_TEXTURE_2D);
-	tglColor3f(1.0f, 1.0f, 1.0f);
+	tglColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 	for (auto& prim : part.primitives) {
 		tglBindTexture(TGL_TEXTURE_2D, _texture[prim.texture]);

--- a/engines/watchmaker/3d/render/opengl_2d.cpp
+++ b/engines/watchmaker/3d/render/opengl_2d.cpp
@@ -167,7 +167,7 @@ void renderTexture(WGame &game, gTexture &bitmap, Common::Rect srcRect, Common::
 	float rightDst = ((dstRect.right == 0 ? 0 : ((double)dstRect.right) / viewport.width()) * 2.0) - 1.0;
 
 	glBegin(GL_QUADS);
-	glColor3f(1.0, 1.0, 1.0);
+	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 
 	glTexCoord2f(leftSrc, bottomSrc); // Bottom Left
 	glVertex3f(leftDst, bottomDst, 0.0f);

--- a/engines/watchmaker/3d/render/opengl_renderer.cpp
+++ b/engines/watchmaker/3d/render/opengl_renderer.cpp
@@ -66,8 +66,8 @@ void OpenGLRenderer::drawIndexedPrimitivesVBO(PrimitiveType primitiveType, Commo
 		assert(index <= VBO->_buffer.size());
 		auto &vertex = VBO->_buffer[index];
 		//warning("%d/%d %d: [%f, %f, %f], [%f, %f], [%f, %f]", i, numFaces, index, vertex.x, vertex.y, vertex.z, vertex.u1, vertex.v1, vertex.u2, vertex.v2);
-		//glColor3f((float)i/numFaces, 1.0, 0.0);
-		glColor3f(1.0f, 1.0f, 1.0f);
+		//glColor4f((float)i/numFaces, 1.0f, 0.0f, 1.0f);
+		glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 		glTexCoord2f(vertex.u1, vertex.v1);
 		glVertex3f(vertex.x, vertex.y, -vertex.z);
 	}
@@ -85,7 +85,7 @@ void OpenGLRenderer::drawPrimitives(PrimitiveType primitiveType, Vertex *vertice
 	glBegin(GL_TRIANGLES);
 	for (int i = 0; i < numPrimitives; i++) {
 		auto &vertex = vertices[i];
-		glColor3f(1.0, 1.0, 1.0);
+		glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 		glVertex3f(vertex.sx, vertex.sy, -vertex.sz);
 	}
 	glEnd();


### PR DESCRIPTION
This is split out from PR #4633, and expanded to cover engines other than Stark.