### PR TITLE
STARK: Check for GL_MIRRORED_REPEAT before using it

### DIFF
--- a/engines/stark/gfx/opengltexture.cpp
+++ b/engines/stark/gfx/opengltexture.cpp
@@ -83,8 +83,11 @@ void OpenGlTexture::setLevelCount(uint32 count) {
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 		}
 
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_MIRRORED_REPEAT);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_MIRRORED_REPEAT);
+		// TODO: Provide a fallback if this isn't available.
+		if (OpenGLContext.textureMirrorRepeatSupported) {
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_MIRRORED_REPEAT);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_MIRRORED_REPEAT);
+		}
 	}
 }
 

--- a/graphics/opengl/system_headers.h
+++ b/graphics/opengl/system_headers.h
@@ -115,6 +115,10 @@
 	#define GL_CLAMP_TO_BORDER 0x812D
 #endif
 
+#if !defined(GL_MIRRORED_REPEAT)
+	#define GL_MIRRORED_REPEAT 0x8370
+#endif
+
 #if !defined(GL_DRAW_FRAMEBUFFER_BINDING)
 	#define GL_DRAW_FRAMEBUFFER_BINDING 0x8CA6
 #endif

--- a/graphics/opengl/texture.cpp
+++ b/graphics/opengl/texture.cpp
@@ -84,12 +84,10 @@ void Texture::setWrapMode(WrapMode wrapMode) {
 				break;
 			}
 		case kWrapModeMirroredRepeat:
-#if !USE_FORCED_GLES
 			if (OpenGLContext.textureMirrorRepeatSupported) {
 				glwrapMode = GL_MIRRORED_REPEAT;
 				break;
 			}
-#endif
 		// fall through
 		case kWrapModeRepeat:
 		default:


### PR DESCRIPTION
This is split out from PR #4633.