### PR TITLE
JANITORIAL: Fix MSVC macro redefinition warnings

### DIFF
--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -595,6 +595,9 @@ int main(int argc, char *argv[]) {
 		// 4351 (new behavior: elements of array 'array' will be default initialized)
 		//   a change in behavior in Visual Studio 2005. We want the new behavior, so it can be disabled
 		//
+		// 4505 ('function' : unreferenced local function has been removed)
+		//   libvpx triggers this warning a lot. The compiler eliminates the code and that's expected.
+		//
 		// 4512 ('class' : assignment operator could not be generated)
 		//   some classes use const items and the default assignment operator cannot be generated
 		//
@@ -653,6 +656,7 @@ int main(int argc, char *argv[]) {
 		globalWarnings.push_back("4324");
 		globalWarnings.push_back("4345");
 		globalWarnings.push_back("4351");
+		globalWarnings.push_back("4505");
 		globalWarnings.push_back("4512");
 		globalWarnings.push_back("4589");
 		globalWarnings.push_back("4702");

--- a/engines/director/lingo/lingo-lex.cpp
+++ b/engines/director/lingo/lingo-lex.cpp
@@ -1,6 +1,51 @@
-#line 1 "engines/director/lingo/lingo-lex.cpp"
+#line 2 "engines/director/lingo/lingo-lex.cpp"
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
-#line 3 "engines/director/lingo/lingo-lex.cpp"
+#define YY_NO_UNISTD_H
+#define FORBIDDEN_SYMBOL_EXCEPTION_FILE
+#define FORBIDDEN_SYMBOL_EXCEPTION_fprintf
+#define FORBIDDEN_SYMBOL_EXCEPTION_fwrite
+#define FORBIDDEN_SYMBOL_EXCEPTION_fread
+#define FORBIDDEN_SYMBOL_EXCEPTION_stdin
+#define FORBIDDEN_SYMBOL_EXCEPTION_stdout
+#define FORBIDDEN_SYMBOL_EXCEPTION_stderr
+#define FORBIDDEN_SYMBOL_EXCEPTION_exit
+#define FORBIDDEN_SYMBOL_EXCEPTION_getc
+
+#include "common/str.h"
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-ast.h"
+#include "director/lingo/lingo-codegen.h"
+#include "director/lingo/lingo-gr.h"
+#include "director/lingo/lingo-the.h"
+
+using namespace Director;
+
+static const char *inputbuffer;
+static uint inputlen;
+
+#line 49 "engines/director/lingo/lingo-lex.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -758,53 +803,9 @@ int yy_flex_debug = 0;
 #define YY_RESTORE_YY_MORE_OFFSET
 char *yytext;
 #line 1 "engines/director/lingo/lingo-lex.l"
-/* ScummVM - Graphic Adventure Engine
- *
- * ScummVM is the legal property of its developers, whose names
- * are too numerous to list here. Please refer to the COPYRIGHT
- * file distributed with this source distribution.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+
 #define YY_NO_INPUT 1
-#line 31 "engines/director/lingo/lingo-lex.l"
-
-#define YY_NO_UNISTD_H
-#define FORBIDDEN_SYMBOL_EXCEPTION_FILE
-#define FORBIDDEN_SYMBOL_EXCEPTION_fprintf
-#define FORBIDDEN_SYMBOL_EXCEPTION_fwrite
-#define FORBIDDEN_SYMBOL_EXCEPTION_fread
-#define FORBIDDEN_SYMBOL_EXCEPTION_stdin
-#define FORBIDDEN_SYMBOL_EXCEPTION_stdout
-#define FORBIDDEN_SYMBOL_EXCEPTION_stderr
-#define FORBIDDEN_SYMBOL_EXCEPTION_exit
-#define FORBIDDEN_SYMBOL_EXCEPTION_getc
-
-#include "common/str.h"
-
-#include "director/director.h"
-#include "director/lingo/lingo.h"
-#include "director/lingo/lingo-ast.h"
-#include "director/lingo/lingo-codegen.h"
-#include "director/lingo/lingo-gr.h"
-#include "director/lingo/lingo-the.h"
-
-using namespace Director;
-
-static const char *inputbuffer;
-static uint inputlen;
+#line 59 "engines/director/lingo/lingo-lex.l"
 
 // Push lines in stack
 static void pushLine(uint num) {
@@ -903,8 +904,8 @@ static Common::String *readUntilNewline(const char **ptr) {
 	return res;
 }
 
-#line 906 "engines/director/lingo/lingo-lex.cpp"
-#line 907 "engines/director/lingo/lingo-lex.cpp"
+#line 908 "engines/director/lingo/lingo-lex.cpp"
+#line 909 "engines/director/lingo/lingo-lex.cpp"
 
 #define INITIAL 0
 
@@ -1122,10 +1123,10 @@ YY_DECL
 		}
 
 	{
-#line 166 "engines/director/lingo/lingo-lex.l"
+#line 169 "engines/director/lingo/lingo-lex.l"
 
 
-#line 1128 "engines/director/lingo/lingo-lex.cpp"
+#line 1130 "engines/director/lingo/lingo-lex.cpp"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1181,97 +1182,97 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 168 "engines/director/lingo/lingo-lex.l"
+#line 171 "engines/director/lingo/lingo-lex.l"
 { count(); }
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 170 "engines/director/lingo/lingo-lex.l"
+#line 173 "engines/director/lingo/lingo-lex.l"
 { count(); yylval.s = new Common::String(yytext + 1); return tSYMBOL; }	// D3, skip '#'
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 172 "engines/director/lingo/lingo-lex.l"
+#line 175 "engines/director/lingo/lingo-lex.l"
 { count(); return tABBREVIATED; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 173 "engines/director/lingo/lingo-lex.l"
+#line 176 "engines/director/lingo/lingo-lex.l"
 { count(); return tABBREV; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 174 "engines/director/lingo/lingo-lex.l"
+#line 177 "engines/director/lingo/lingo-lex.l"
 { count(); return tABBR; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 175 "engines/director/lingo/lingo-lex.l"
+#line 178 "engines/director/lingo/lingo-lex.l"
 { count(); return tAFTER; }		// D3
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 176 "engines/director/lingo/lingo-lex.l"
+#line 179 "engines/director/lingo/lingo-lex.l"
 { count(); return tAND; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 177 "engines/director/lingo/lingo-lex.l"
+#line 180 "engines/director/lingo/lingo-lex.l"
 { count(); return tBEFORE; }	// D3
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 178 "engines/director/lingo/lingo-lex.l"
+#line 181 "engines/director/lingo/lingo-lex.l"
 { count(); return tCAST; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 179 "engines/director/lingo/lingo-lex.l"
+#line 182 "engines/director/lingo/lingo-lex.l"
 { count(); return tCASTLIB; }	// D5
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 180 "engines/director/lingo/lingo-lex.l"
+#line 183 "engines/director/lingo/lingo-lex.l"
 { count(); return tCASTLIBS; }	// D5
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 181 "engines/director/lingo/lingo-lex.l"
+#line 184 "engines/director/lingo/lingo-lex.l"
 { count(); return tCHAR; }		// D3
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 182 "engines/director/lingo/lingo-lex.l"
+#line 185 "engines/director/lingo/lingo-lex.l"
 { count(); return tCHARS; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 183 "engines/director/lingo/lingo-lex.l"
+#line 186 "engines/director/lingo/lingo-lex.l"
 { count(); return tCONTAINS; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 184 "engines/director/lingo/lingo-lex.l"
+#line 187 "engines/director/lingo/lingo-lex.l"
 { count(); return tDATE; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 185 "engines/director/lingo/lingo-lex.l"
+#line 188 "engines/director/lingo/lingo-lex.l"
 { count(); return tDELETE; }
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 186 "engines/director/lingo/lingo-lex.l"
+#line 189 "engines/director/lingo/lingo-lex.l"
 { count(); return tDOWN; }
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 187 "engines/director/lingo/lingo-lex.l"
+#line 190 "engines/director/lingo/lingo-lex.l"
 { count(); return tELSE; }
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 188 "engines/director/lingo/lingo-lex.l"
+#line 191 "engines/director/lingo/lingo-lex.l"
 {
 		count();
 
@@ -1292,267 +1293,267 @@ YY_RULE_SETUP
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 205 "engines/director/lingo/lingo-lex.l"
+#line 208 "engines/director/lingo/lingo-lex.l"
 { count(); return tEXIT; }
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 206 "engines/director/lingo/lingo-lex.l"
+#line 209 "engines/director/lingo/lingo-lex.l"
 { count(); return tFACTORY; }
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 207 "engines/director/lingo/lingo-lex.l"
+#line 210 "engines/director/lingo/lingo-lex.l"
 { count(); return tFIELD; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 208 "engines/director/lingo/lingo-lex.l"
+#line 211 "engines/director/lingo/lingo-lex.l"
 { count(); return tFRAME; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 209 "engines/director/lingo/lingo-lex.l"
+#line 212 "engines/director/lingo/lingo-lex.l"
 { count(); return tGLOBAL; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 210 "engines/director/lingo/lingo-lex.l"
+#line 213 "engines/director/lingo/lingo-lex.l"
 { count(); return tGO; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 211 "engines/director/lingo/lingo-lex.l"
+#line 214 "engines/director/lingo/lingo-lex.l"
 { count(); return tHILITE; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 212 "engines/director/lingo/lingo-lex.l"
+#line 215 "engines/director/lingo/lingo-lex.l"
 { count(); return tIF; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 213 "engines/director/lingo/lingo-lex.l"
+#line 216 "engines/director/lingo/lingo-lex.l"
 { count(); return tINSTANCE; }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 214 "engines/director/lingo/lingo-lex.l"
+#line 217 "engines/director/lingo/lingo-lex.l"
 { count(); return tINTERSECTS;}
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 215 "engines/director/lingo/lingo-lex.l"
+#line 218 "engines/director/lingo/lingo-lex.l"
 { count(); return tINTO; }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 216 "engines/director/lingo/lingo-lex.l"
+#line 219 "engines/director/lingo/lingo-lex.l"
 { count(); return tIN; }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 217 "engines/director/lingo/lingo-lex.l"
+#line 220 "engines/director/lingo/lingo-lex.l"
 { count(); return tITEM; }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 218 "engines/director/lingo/lingo-lex.l"
+#line 221 "engines/director/lingo/lingo-lex.l"
 { count(); return tITEMS; }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 219 "engines/director/lingo/lingo-lex.l"
+#line 222 "engines/director/lingo/lingo-lex.l"
 { count(); return tLAST; }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 220 "engines/director/lingo/lingo-lex.l"
+#line 223 "engines/director/lingo/lingo-lex.l"
 { count(); return tLINE; }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 221 "engines/director/lingo/lingo-lex.l"
+#line 224 "engines/director/lingo/lingo-lex.l"
 { count(); return tLINES; }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 222 "engines/director/lingo/lingo-lex.l"
+#line 225 "engines/director/lingo/lingo-lex.l"
 { count(); return tLONG; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 223 "engines/director/lingo/lingo-lex.l"
+#line 226 "engines/director/lingo/lingo-lex.l"
 { count(); return tMACRO; }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 224 "engines/director/lingo/lingo-lex.l"
+#line 227 "engines/director/lingo/lingo-lex.l"
 { count(); return tMEMBER; }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 225 "engines/director/lingo/lingo-lex.l"
+#line 228 "engines/director/lingo/lingo-lex.l"
 { count(); return tMENU; }
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 226 "engines/director/lingo/lingo-lex.l"
+#line 229 "engines/director/lingo/lingo-lex.l"
 { count(); return tMENUS; }
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 227 "engines/director/lingo/lingo-lex.l"
+#line 230 "engines/director/lingo/lingo-lex.l"
 { count(); return tMENUITEM;}
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 228 "engines/director/lingo/lingo-lex.l"
+#line 231 "engines/director/lingo/lingo-lex.l"
 { count(); return tMENUITEMS; }
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 229 "engines/director/lingo/lingo-lex.l"
+#line 232 "engines/director/lingo/lingo-lex.l"
 { count(); return tMETHOD; }
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 230 "engines/director/lingo/lingo-lex.l"
+#line 233 "engines/director/lingo/lingo-lex.l"
 { count(); return tMOD;}
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 231 "engines/director/lingo/lingo-lex.l"
+#line 234 "engines/director/lingo/lingo-lex.l"
 { count(); return tMOVIE; }
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
-#line 232 "engines/director/lingo/lingo-lex.l"
+#line 235 "engines/director/lingo/lingo-lex.l"
 { count(); return tNEXT; }
 	YY_BREAK
 case 48:
 YY_RULE_SETUP
-#line 233 "engines/director/lingo/lingo-lex.l"
+#line 236 "engines/director/lingo/lingo-lex.l"
 { count(); return tNOT; }
 	YY_BREAK
 case 49:
 YY_RULE_SETUP
-#line 234 "engines/director/lingo/lingo-lex.l"
+#line 237 "engines/director/lingo/lingo-lex.l"
 { count(); return tNUMBER; }
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 235 "engines/director/lingo/lingo-lex.l"
+#line 238 "engines/director/lingo/lingo-lex.l"
 { count(); return tOF; }
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 236 "engines/director/lingo/lingo-lex.l"
+#line 239 "engines/director/lingo/lingo-lex.l"
 { count(); return tON; }		// D3
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 237 "engines/director/lingo/lingo-lex.l"
+#line 240 "engines/director/lingo/lingo-lex.l"
 { count(); return tOPEN; }
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 238 "engines/director/lingo/lingo-lex.l"
+#line 241 "engines/director/lingo/lingo-lex.l"
 { count(); return tOR; }
 	YY_BREAK
 case 54:
 YY_RULE_SETUP
-#line 239 "engines/director/lingo/lingo-lex.l"
+#line 242 "engines/director/lingo/lingo-lex.l"
 { count(); return tPLAY; }
 	YY_BREAK
 case 55:
 YY_RULE_SETUP
-#line 240 "engines/director/lingo/lingo-lex.l"
+#line 243 "engines/director/lingo/lingo-lex.l"
 { count(); return tPREVIOUS; }
 	YY_BREAK
 case 56:
 YY_RULE_SETUP
-#line 241 "engines/director/lingo/lingo-lex.l"
+#line 244 "engines/director/lingo/lingo-lex.l"
 { count(); return tPROPERTY; }	// D4
 	YY_BREAK
 case 57:
 YY_RULE_SETUP
-#line 242 "engines/director/lingo/lingo-lex.l"
+#line 245 "engines/director/lingo/lingo-lex.l"
 { count(); return tPUT; }
 	YY_BREAK
 case 58:
 YY_RULE_SETUP
-#line 243 "engines/director/lingo/lingo-lex.l"
+#line 246 "engines/director/lingo/lingo-lex.l"
 { count(); return tREPEAT; }
 	YY_BREAK
 case 59:
 YY_RULE_SETUP
-#line 244 "engines/director/lingo/lingo-lex.l"
+#line 247 "engines/director/lingo/lingo-lex.l"
 { count(); return tRETURN; }
 	YY_BREAK
 case 60:
 YY_RULE_SETUP
-#line 245 "engines/director/lingo/lingo-lex.l"
+#line 248 "engines/director/lingo/lingo-lex.l"
 { count(); return tSCRIPT; }
 	YY_BREAK
 case 61:
 YY_RULE_SETUP
-#line 246 "engines/director/lingo/lingo-lex.l"
+#line 249 "engines/director/lingo/lingo-lex.l"
 { count(); return tASSERTERROR; }
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 247 "engines/director/lingo/lingo-lex.l"
+#line 250 "engines/director/lingo/lingo-lex.l"
 { count(); return tSET; }
 	YY_BREAK
 case 63:
 YY_RULE_SETUP
-#line 248 "engines/director/lingo/lingo-lex.l"
+#line 251 "engines/director/lingo/lingo-lex.l"
 { count(); return tSHORT; }
 	YY_BREAK
 case 64:
 YY_RULE_SETUP
-#line 249 "engines/director/lingo/lingo-lex.l"
+#line 252 "engines/director/lingo/lingo-lex.l"
 { count(); return tSOUND; }
 	YY_BREAK
 case 65:
 YY_RULE_SETUP
-#line 250 "engines/director/lingo/lingo-lex.l"
+#line 253 "engines/director/lingo/lingo-lex.l"
 { count(); return tSPRITE; }
 	YY_BREAK
 case 66:
 YY_RULE_SETUP
-#line 251 "engines/director/lingo/lingo-lex.l"
+#line 254 "engines/director/lingo/lingo-lex.l"
 { count(); return tSTARTS; }
 	YY_BREAK
 case 67:
 YY_RULE_SETUP
-#line 252 "engines/director/lingo/lingo-lex.l"
+#line 255 "engines/director/lingo/lingo-lex.l"
 { count(); return tTELL; }
 	YY_BREAK
 case 68:
 YY_RULE_SETUP
-#line 253 "engines/director/lingo/lingo-lex.l"
+#line 256 "engines/director/lingo/lingo-lex.l"
 { count(); return tTHE; }
 	YY_BREAK
 case 69:
 YY_RULE_SETUP
-#line 254 "engines/director/lingo/lingo-lex.l"
+#line 257 "engines/director/lingo/lingo-lex.l"
 { count(); return tTHEN; }
 	YY_BREAK
 case 70:
 YY_RULE_SETUP
-#line 255 "engines/director/lingo/lingo-lex.l"
+#line 258 "engines/director/lingo/lingo-lex.l"
 { count(); return tTIME; }
 	YY_BREAK
 case 71:
 YY_RULE_SETUP
-#line 256 "engines/director/lingo/lingo-lex.l"
+#line 259 "engines/director/lingo/lingo-lex.l"
 { count(); return tTO; }
 	YY_BREAK
 case 72:
 YY_RULE_SETUP
-#line 257 "engines/director/lingo/lingo-lex.l"
+#line 260 "engines/director/lingo/lingo-lex.l"
 {
 		count();
 
@@ -1574,67 +1575,67 @@ YY_RULE_SETUP
 	YY_BREAK
 case 73:
 YY_RULE_SETUP
-#line 275 "engines/director/lingo/lingo-lex.l"
+#line 278 "engines/director/lingo/lingo-lex.l"
 { count(); return tWHILE; }
 	YY_BREAK
 case 74:
 YY_RULE_SETUP
-#line 276 "engines/director/lingo/lingo-lex.l"
+#line 279 "engines/director/lingo/lingo-lex.l"
 { count(); return tWINDOW; }
 	YY_BREAK
 case 75:
 YY_RULE_SETUP
-#line 277 "engines/director/lingo/lingo-lex.l"
+#line 280 "engines/director/lingo/lingo-lex.l"
 { count(); return tWITH; }
 	YY_BREAK
 case 76:
 YY_RULE_SETUP
-#line 278 "engines/director/lingo/lingo-lex.l"
+#line 281 "engines/director/lingo/lingo-lex.l"
 { count(); return tWITHIN; }
 	YY_BREAK
 case 77:
 YY_RULE_SETUP
-#line 279 "engines/director/lingo/lingo-lex.l"
+#line 282 "engines/director/lingo/lingo-lex.l"
 { count(); return tWORD; }
 	YY_BREAK
 case 78:
 YY_RULE_SETUP
-#line 280 "engines/director/lingo/lingo-lex.l"
+#line 283 "engines/director/lingo/lingo-lex.l"
 { count(); return tWORDS; }
 	YY_BREAK
 case 79:
 YY_RULE_SETUP
-#line 281 "engines/director/lingo/lingo-lex.l"
+#line 284 "engines/director/lingo/lingo-lex.l"
 { count(); return tXTRAS; } // D5
 	YY_BREAK
 case 80:
 YY_RULE_SETUP
-#line 283 "engines/director/lingo/lingo-lex.l"
+#line 286 "engines/director/lingo/lingo-lex.l"
 { count(); return tNEQ; }
 	YY_BREAK
 case 81:
 YY_RULE_SETUP
-#line 284 "engines/director/lingo/lingo-lex.l"
+#line 287 "engines/director/lingo/lingo-lex.l"
 { count(); return tGE; }
 	YY_BREAK
 case 82:
 YY_RULE_SETUP
-#line 285 "engines/director/lingo/lingo-lex.l"
+#line 288 "engines/director/lingo/lingo-lex.l"
 { count(); return tLE; }
 	YY_BREAK
 case 83:
 YY_RULE_SETUP
-#line 286 "engines/director/lingo/lingo-lex.l"
+#line 289 "engines/director/lingo/lingo-lex.l"
 { count(); return tCONCAT; }
 	YY_BREAK
 case 84:
 YY_RULE_SETUP
-#line 287 "engines/director/lingo/lingo-lex.l"
+#line 290 "engines/director/lingo/lingo-lex.l"
 { count(); return tEQ; }
 	YY_BREAK
 case 85:
 YY_RULE_SETUP
-#line 289 "engines/director/lingo/lingo-lex.l"
+#line 292 "engines/director/lingo/lingo-lex.l"
 {
 		count();
 		yylval.s = new Common::String(yytext);
@@ -1644,41 +1645,41 @@ YY_RULE_SETUP
 	YY_BREAK
 case 86:
 YY_RULE_SETUP
-#line 295 "engines/director/lingo/lingo-lex.l"
+#line 298 "engines/director/lingo/lingo-lex.l"
 { count(); yylval.f = atof(yytext); return tFLOAT; }
 	YY_BREAK
 case 87:
 YY_RULE_SETUP
-#line 296 "engines/director/lingo/lingo-lex.l"
+#line 299 "engines/director/lingo/lingo-lex.l"
 { count(); yylval.i = strtol(yytext, NULL, 10); return tINT; }
 	YY_BREAK
 case 88:
 YY_RULE_SETUP
-#line 297 "engines/director/lingo/lingo-lex.l"
+#line 300 "engines/director/lingo/lingo-lex.l"
 { count(); return *yytext; }
 	YY_BREAK
 case 89:
 /* rule 89 can match eol */
 YY_RULE_SETUP
-#line 298 "engines/director/lingo/lingo-lex.l"
+#line 301 "engines/director/lingo/lingo-lex.l"
 { count(); return '\n'; }
 	YY_BREAK
 case 90:
 YY_RULE_SETUP
-#line 299 "engines/director/lingo/lingo-lex.l"
+#line 302 "engines/director/lingo/lingo-lex.l"
 { count(); yylval.s = cleanupString(&yytext[1]); yylval.s->deleteLastChar(); return tSTRING; }
 	YY_BREAK
 case 91:
 YY_RULE_SETUP
-#line 300 "engines/director/lingo/lingo-lex.l"
+#line 303 "engines/director/lingo/lingo-lex.l"
 { count(); }
 	YY_BREAK
 case 92:
 YY_RULE_SETUP
-#line 302 "engines/director/lingo/lingo-lex.l"
+#line 305 "engines/director/lingo/lingo-lex.l"
 ECHO;
 	YY_BREAK
-#line 1681 "engines/director/lingo/lingo-lex.cpp"
+#line 1683 "engines/director/lingo/lingo-lex.cpp"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2650,7 +2651,7 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 302 "engines/director/lingo/lingo-lex.l"
+#line 305 "engines/director/lingo/lingo-lex.l"
 
 
 extern int yydebug;

--- a/engines/director/lingo/lingo-lex.l
+++ b/engines/director/lingo/lingo-lex.l
@@ -1,3 +1,4 @@
+%top{
 /* ScummVM - Graphic Adventure Engine
  *
  * ScummVM is the legal property of its developers, whose names
@@ -18,16 +19,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
-%option noyywrap
-%option noinput
-%option nounput
-%option never-interactive
-%option case-insensitive
-
-%option outfile="engines/director/lingo/lingo-lex.cpp"
-
-%{
 
 #define YY_NO_UNISTD_H
 #define FORBIDDEN_SYMBOL_EXCEPTION_FILE
@@ -53,6 +44,18 @@ using namespace Director;
 
 static const char *inputbuffer;
 static uint inputlen;
+
+}
+
+%option noyywrap
+%option noinput
+%option nounput
+%option never-interactive
+%option case-insensitive
+
+%option outfile="engines/director/lingo/lingo-lex.cpp"
+
+%{
 
 // Push lines in stack
 static void pushLine(uint num) {

--- a/engines/hpl1/engine/libraries/newton/core/dgConvexHull4d.cpp
+++ b/engines/hpl1/engine/libraries/newton/core/dgConvexHull4d.cpp
@@ -120,7 +120,7 @@ void dgConvexHull4dTetraherum::Init(const dgHullVector *const points,
 		m_faces[i].m_twin = NULL;
 	}
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 	dgBigVector p1p0(points[v1].Sub4(points[v0]));
 	dgBigVector p2p0(points[v2].Sub4(points[v0]));
 	dgBigVector p3p0(points[v3].Sub4(points[v0]));

--- a/engines/hpl1/engine/libraries/newton/core/dgHeap.h
+++ b/engines/hpl1/engine/libraries/newton/core/dgHeap.h
@@ -231,7 +231,7 @@ template <class OBJECT, class KEY>
 void dgDownHeap<OBJECT, KEY>::Push(OBJECT &obj, KEY key) {
 	dgInt32 i;
 	dgInt32 j;
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 //	NEWTON_ASSERT (m_curCount < m_maxCount);
 	dgInt32 cc = dgHeapBase<OBJECT, KEY>::m_curCount;
 	dgInt32 cm = dgHeapBase<OBJECT, KEY>::m_maxCount;
@@ -401,7 +401,7 @@ void dgUpHeap<OBJECT, KEY>::Push(OBJECT &obj, KEY key) {
 	dgInt32 i;
 	dgInt32 j;
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 	//  NEWTON_ASSERT (m_curCount < m_maxCount);
 	dgInt32 cc = dgHeapBase<OBJECT, KEY>::m_curCount;
 	dgInt32 cm = dgHeapBase<OBJECT, KEY>::m_maxCount;

--- a/engines/hpl1/engine/libraries/newton/core/dgIntersections.cpp
+++ b/engines/hpl1/engine/libraries/newton/core/dgIntersections.cpp
@@ -695,7 +695,7 @@ dgBigVector LineTriangleIntersection(const dgBigVector &p0,
 	dgGoogol sum = t0 + t1 + t2;
 	dgFloat64 den = sum.GetAproximateValue();
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 	dgBigVector testpoint(
 	    A.Scale(val0 / den) + B.Scale(val1 / den) + C.Scale(val2 / den));
 	dgFloat64 volume = ((B - A) * (C - A)) % (testpoint - A);

--- a/engines/hpl1/engine/libraries/newton/core/dgMatrix.cpp
+++ b/engines/hpl1/engine/libraries/newton/core/dgMatrix.cpp
@@ -56,7 +56,7 @@ dgMatrix::dgMatrix(const dgQuaternion &rotation, const dgVector &position) {
 	dgFloat32 y2 = dgFloat32(2.0f) * rotation.m_q2 * rotation.m_q2;
 	dgFloat32 z2 = dgFloat32(2.0f) * rotation.m_q3 * rotation.m_q3;
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 	dgFloat32 w2 = dgFloat32(2.0f) * rotation.m_q0 * rotation.m_q0;
 	NEWTON_ASSERT(dgAbsf(w2 + x2 + y2 + z2 - dgFloat32(2.0f)) < dgFloat32(1.0e-3f));
 #endif
@@ -314,7 +314,7 @@ dgMatrix dgMatrix::Symetric3by3Inverse() const {
 	dgFloat32 x23 = (dgFloat32)(det
 	                            * (mat[0][1] * mat[2][0] - mat[0][0] * mat[2][1]));
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 	dgMatrix matInv(
 	    dgVector(x11, x12, x13, dgFloat32(0.0f)),
 	    dgVector(x12, x22, x23, dgFloat32(0.0f)),
@@ -359,7 +359,7 @@ dgVector dgMatrix::CalcPitchYawRoll() const {
 		pitch = -dgAtan2(matrix[1][0], matrix[1][1]);
 	}
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 	dgMatrix m(dgPitchMatrix(pitch) * dgYawMatrix(yaw) * dgRollMatrix(roll));
 	for (dgInt32 i = 0; i < 3; i++) {
 		for (dgInt32 j = 0; j < 3; j++) {

--- a/engines/hpl1/engine/libraries/newton/core/dgQuaternion.cpp
+++ b/engines/hpl1/engine/libraries/newton/core/dgQuaternion.cpp
@@ -68,7 +68,7 @@ dgQuaternion::dgQuaternion(const dgMatrix &matrix) {
 		ptr[k] = (matrix[i][k] + matrix[k][i]) * trace;
 	}
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 	dgMatrix tmp(*this, matrix.m_posit);
 	dgMatrix unitMatrix(tmp * matrix.Inverse());
 	for (dgInt32 di = 0; di < 4; di++) {
@@ -88,7 +88,7 @@ dgQuaternion::dgQuaternion(const dgVector &unitAxis, dgFloat32 Angle) {
 	m_q0 = dgCos(Angle);
 	sinAng = dgSin(Angle);
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 	if (dgAbsf(Angle) > dgFloat32(dgEPSILON / 10.0f)) {
 		NEWTON_ASSERT(
 		    dgAbsf(dgFloat32(1.0f) - unitAxis % unitAxis) < dgFloat32(dgEPSILON * 10.0f));

--- a/engines/hpl1/engine/libraries/newton/physics/dgBody.cpp
+++ b/engines/hpl1/engine/libraries/newton/physics/dgBody.cpp
@@ -105,7 +105,7 @@ void dgBody::SetMassMatrix(dgFloat32 mass, dgFloat32 Ix, dgFloat32 Iy,
 		masterList.RotateToEnd(m_masterNode);
 	}
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 	dgBodyMasterList &me = *m_world;
 	dgBodyMasterList::dgListNode *refNode;
 	for (refNode = me.GetFirst(); refNode; refNode = refNode->GetNext()) {
@@ -572,7 +572,7 @@ void dgBody::IntegrateVelocity(dgFloat32 timestep) {
 
 	m_matrix.m_posit = m_globalCentreOfMass - m_matrix.RotateVector(m_localCentreOfMass);
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 	for (int i = 0; i < 4; i++) {
 		for (int j = 0; j < 4; j++) {
 			NEWTON_ASSERT(dgCheckFloat(m_matrix[i][j]));

--- a/engines/hpl1/engine/libraries/newton/physics/dgCollisionConvexHull.cpp
+++ b/engines/hpl1/engine/libraries/newton/physics/dgCollisionConvexHull.cpp
@@ -195,7 +195,7 @@ dgBigVector dgCollisionConvexHull::FaceNormal(const dgEdge *face,
 		dgBigVector p2(pool[edge->m_incidentVertex]);
 		dgBigVector e2(p2 - p0);
 		dgBigVector n1(e1 * e2);
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 		dgFloat64 mag = normal % n1;
 		NEWTON_ASSERT(mag >= -dgFloat32(0.1f));
 #endif
@@ -205,7 +205,7 @@ dgBigVector dgCollisionConvexHull::FaceNormal(const dgEdge *face,
 	dgFloat64 den = sqrt(normal % normal) + dgFloat64(1.0e-24f);
 	normal = normal.Scale(dgFloat64(1.0f) / den);
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 	edge = face;
 	dgBigVector e0(
 	    pool[edge->m_incidentVertex] - pool[edge->m_prev->m_incidentVertex]);

--- a/engines/hpl1/engine/libraries/newton/physics/dgCollisionMesh.cpp
+++ b/engines/hpl1/engine/libraries/newton/physics/dgCollisionMesh.cpp
@@ -1089,7 +1089,7 @@ dgInt32 dgCollisionMesh::dgCollisionConvexPolygon::CalculatePlaneIntersectionSim
 		}
 	}
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 	if (count > 1) {
 		dgInt32 j;
 		j = count - 1;
@@ -1134,7 +1134,7 @@ dgInt32 dgCollisionMesh::dgCollisionConvexPolygon::CalculatePlaneIntersection(co
 			count++;
 		}
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 		dgInt32 j = count - 1;
 		for (dgInt32 i = 0; i < count; i++) {
 			dgVector error(contactsOut[i] - contactsOut[j]);
@@ -1241,7 +1241,7 @@ dgInt32 dgCollisionMesh::dgCollisionConvexPolygon::CalculatePlaneIntersection(co
 		}
 	}
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 	if (count > 1) {
 		dgInt32 j = count - 1;
 		for (dgInt32 i = 0; i < count; i++) {

--- a/engines/hpl1/engine/libraries/newton/physics/dgCollisionSphere.cpp
+++ b/engines/hpl1/engine/libraries/newton/physics/dgCollisionSphere.cpp
@@ -105,7 +105,7 @@ void dgCollisionSphere::Init(dgFloat32 radius, dgMemoryAllocator *allocator) {
 
 		polyhedra.BeginFace();
 		for (dgInt32 j = 0; j < count; j += 3) {
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 			dgEdge *const edge = polyhedra.AddFace(indexList[j], indexList[j + 1],
 			                                       indexList[j + 2]);
 			NEWTON_ASSERT(edge);

--- a/engines/hpl1/engine/libraries/newton/physics/dgMeshEffect.cpp
+++ b/engines/hpl1/engine/libraries/newton/physics/dgMeshEffect.cpp
@@ -1185,7 +1185,7 @@ void dgMeshEffect::AddPolygon(dgInt32 count, const dgFloat64 *const vertexList,
 				AddPoint(vertexList + i1 * stride, material);
 				AddPoint(vertexList + i2 * stride, material);
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 				const dgBigVector &p0 = m_points[m_pointCount - 3];
 				const dgBigVector &p1 = m_points[m_pointCount - 2];
 				const dgBigVector &p2 = m_points[m_pointCount - 1];
@@ -1248,7 +1248,7 @@ void dgMeshEffect::EndPolygon(dgFloat64 tol) {
 	dgStack<dgInt32> indexMap(m_pointCount);
 	dgStack<dgInt32> attrIndexMap(m_atribCount);
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 	for (dgInt32 i = 0; i < m_pointCount; i += 3) {
 		dgBigVector p0(m_points[i + 0]);
 		dgBigVector p1(m_points[i + 1]);
@@ -1300,7 +1300,7 @@ void dgMeshEffect::EndPolygon(dgFloat64 tol) {
 
 				m_pointCount += 3;
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 				dgEdge *test = AddFace(3, index, userdata);
 				NEWTON_ASSERT(test);
 #else
@@ -1313,7 +1313,7 @@ void dgMeshEffect::EndPolygon(dgFloat64 tol) {
 
 	RepairTJoints(true);
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 	dgPolyhedra::Iterator iter(*this);
 	for (iter.Begin(); iter; iter++) {
 		dgEdge *const face = &(*iter);
@@ -2667,7 +2667,7 @@ dgMeshEffect::dgVertexAtribute dgMeshEffect::InterpolateVertex(
 
 			dgBigVector p10(q1 - q0);
 			dgBigVector p20(q2 - q0);
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 			dgFloat64 dot = p20 % p10;
 			dgFloat64 mag1 = p10 % p10;
 			dgFloat64 mag2 = p20 % p20;
@@ -2710,7 +2710,7 @@ dgMeshEffect::dgVertexAtribute dgMeshEffect::InterpolateVertex(
 				    attr0.m_normal_z * alpha0 + attr1.m_normal_z * alpha1 + attr2.m_normal_z * alpha2, dgFloat32(0.0f));
 				normal = normal.Scale(dgFloat64(1.0f) / sqrt(normal % normal));
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 				dgBigVector testPoint(
 				    attr0.m_vertex.m_x * alpha0 + attr1.m_vertex.m_x * alpha1 + attr2.m_vertex.m_x * alpha2,
 				    attr0.m_vertex.m_y * alpha0 + attr1.m_vertex.m_y * alpha1 + attr2.m_vertex.m_y * alpha2,
@@ -3958,7 +3958,7 @@ void dgMeshEffect::ClipMesh(const dgMeshEffectSolidTree *const clipper,
 				}
 
 				if (frontCount) {
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 					for (dgList<dgMeshTreeCSGFace *>::dgListNode *node1 =
 					            faceList.GetFirst();
 					        node1; node1 = node1->GetNext()) {
@@ -3970,7 +3970,7 @@ void dgMeshEffect::ClipMesh(const dgMeshEffectSolidTree *const clipper,
 					frontMesh->AddPolygon(count, &facePoints[0].m_vertex.m_x,
 					                      sizeof(dgVertexAtribute), dgFastInt(facePoints[0].m_material));
 				} else {
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 					for (dgList<dgMeshTreeCSGFace *>::dgListNode *dnode1 =
 					            faceList.GetFirst();
 					        dnode1; dnode1 = dnode1->GetNext()) {
@@ -4197,7 +4197,7 @@ void dgMeshEffect::RepairTJoints(bool triangulate) {
 						}
 						NEWTON_ASSERT(firstEdge->m_next->m_next->m_next == firstEdge);
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 						dgEdge *tmp = firstEdge->m_twin;
 						do {
 							NEWTON_ASSERT(tmp->m_incidentFace > 0);
@@ -4241,7 +4241,7 @@ void dgMeshEffect::RepairTJoints(bool triangulate) {
 						}
 						NEWTON_ASSERT(firstEdge->m_next->m_next->m_next == firstEdge);
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 						dgEdge *tmp = firstEdge->m_twin;
 						do {
 							NEWTON_ASSERT(tmp->m_incidentFace > 0);

--- a/engines/hpl1/engine/libraries/newton/physics/dgMinkowskiConv.cpp
+++ b/engines/hpl1/engine/libraries/newton/physics/dgMinkowskiConv.cpp
@@ -744,7 +744,7 @@ class dgContactSolver {
 			dgPerimenterEdge *poly = &subdivision[0];
 			//NEWTON_ASSERT (CheckNormal (poly, shapeNormal));
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 			{
 				dgVector p0;
 				dgVector p1;
@@ -910,7 +910,7 @@ class dgContactSolver {
 
 			NEWTON_ASSERT(poly);
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 			{
 				dgVector p0;
 				dgVector p1;
@@ -1088,7 +1088,7 @@ class dgContactSolver {
 
 			NEWTON_ASSERT(poly);
 
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 			{
 				dgVector p0;
 				dgVector p1;
@@ -2091,7 +2091,7 @@ class dgContactSolver {
 							val = err1 % err1;
 						}
 					} while (val < DG_FALLBACK_SEPARATING_DIST_TOLERANCE);
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 					dgFloat32 test = (m_hullVertex[0] - m_hullVertex[2]) % dir;
 					NEWTON_ASSERT(test >= dgFloat32(-2.0e-1f));
 #endif
@@ -2114,7 +2114,7 @@ class dgContactSolver {
 							val = err1 % err1;
 						}
 					} while (val < DG_FALLBACK_SEPARATING_DIST_TOLERANCE);
-#ifdef _DEBUG
+#if 0 && defined(_DEBUG) // NEWTON_ASSERT is disabled so this whole calculation is useless
 					dgFloat32 test1 = (m_hullVertex[0] - m_hullVertex[3]) % dir;
 					NEWTON_ASSERT(test1 >= dgFloat32(-2.0e-1f));
 #endif

--- a/engines/hypno/lexer_arc.cpp
+++ b/engines/hypno/lexer_arc.cpp
@@ -1,6 +1,42 @@
-#line 1 "engines/hypno/lexer_arc.cpp"
+#line 2 "engines/hypno/lexer_arc.cpp"
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
-#line 3 "engines/hypno/lexer_arc.cpp"
+#define YY_NO_UNISTD_H
+#define FORBIDDEN_SYMBOL_EXCEPTION_FILE
+#define FORBIDDEN_SYMBOL_EXCEPTION_fprintf
+#define FORBIDDEN_SYMBOL_EXCEPTION_fwrite
+#define FORBIDDEN_SYMBOL_EXCEPTION_fread
+#define FORBIDDEN_SYMBOL_EXCEPTION_stdin
+#define FORBIDDEN_SYMBOL_EXCEPTION_stdout
+#define FORBIDDEN_SYMBOL_EXCEPTION_stderr
+#define FORBIDDEN_SYMBOL_EXCEPTION_exit
+#define FORBIDDEN_SYMBOL_EXCEPTION_getc
+#define YYERROR_VERBOSE
+
+#include "hypno/hypno.h"
+#include "hypno/grammar.h"
+#include "hypno/tokens_arc.h"
+
+#line 40 "engines/hypno/lexer_arc.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -841,45 +877,8 @@ int yy_flex_debug = 0;
 #define YY_RESTORE_YY_MORE_OFFSET
 char *yytext;
 #line 1 "engines/hypno/lexer_arc.l"
-/* ScummVM - Graphic Adventure Engine
- *
- * ScummVM is the legal property of its developers, whose names
- * are too numerous to list here. Please refer to the COPYRIGHT
- * file distributed with this source distribution.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+
 #define YY_NO_INPUT 1
-#line 32 "engines/hypno/lexer_arc.l"
-#define YY_NO_UNISTD_H
-#define FORBIDDEN_SYMBOL_EXCEPTION_FILE
-#define FORBIDDEN_SYMBOL_EXCEPTION_fprintf
-#define FORBIDDEN_SYMBOL_EXCEPTION_fwrite
-#define FORBIDDEN_SYMBOL_EXCEPTION_fread
-#define FORBIDDEN_SYMBOL_EXCEPTION_stdin
-#define FORBIDDEN_SYMBOL_EXCEPTION_stdout
-#define FORBIDDEN_SYMBOL_EXCEPTION_stderr
-#define FORBIDDEN_SYMBOL_EXCEPTION_exit
-#define FORBIDDEN_SYMBOL_EXCEPTION_getc
-#define YYERROR_VERBOSE
-
-#include "hypno/hypno.h"
-#include "hypno/grammar.h"
-#include "hypno/tokens_arc.h"
-
-#line 882 "engines/hypno/lexer_arc.cpp"
 #line 883 "engines/hypno/lexer_arc.cpp"
 
 #define INITIAL 0

--- a/engines/hypno/lexer_arc.l
+++ b/engines/hypno/lexer_arc.l
@@ -1,3 +1,4 @@
+%top{
 /* ScummVM - Graphic Adventure Engine
  *
  * ScummVM is the legal property of its developers, whose names
@@ -19,16 +20,6 @@
  *
  */
 
-%option noyywrap
-%option noinput
-%option nounput
-%option yylineno
-%option never-interactive
-
-%option outfile="engines/hypno/lexer_arc.cpp"
-%option prefix="HYPNO_ARC_"
-
-%{
 #define YY_NO_UNISTD_H
 #define FORBIDDEN_SYMBOL_EXCEPTION_FILE
 #define FORBIDDEN_SYMBOL_EXCEPTION_fprintf
@@ -45,7 +36,16 @@
 #include "hypno/grammar.h"
 #include "hypno/tokens_arc.h"
 
-%}
+}
+
+%option noyywrap
+%option noinput
+%option nounput
+%option yylineno
+%option never-interactive
+
+%option outfile="engines/hypno/lexer_arc.cpp"
+%option prefix="HYPNO_ARC_"
 
 %%
 NONE						return NONETOK;

--- a/engines/hypno/lexer_mis.cpp
+++ b/engines/hypno/lexer_mis.cpp
@@ -1,6 +1,41 @@
-#line 1 "engines/hypno/lexer_mis.cpp"
+#line 2 "engines/hypno/lexer_mis.cpp"
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
-#line 3 "engines/hypno/lexer_mis.cpp"
+#define YY_NO_UNISTD_H
+#define FORBIDDEN_SYMBOL_EXCEPTION_FILE
+#define FORBIDDEN_SYMBOL_EXCEPTION_fprintf
+#define FORBIDDEN_SYMBOL_EXCEPTION_fwrite
+#define FORBIDDEN_SYMBOL_EXCEPTION_fread
+#define FORBIDDEN_SYMBOL_EXCEPTION_stdin
+#define FORBIDDEN_SYMBOL_EXCEPTION_stdout
+#define FORBIDDEN_SYMBOL_EXCEPTION_stderr
+#define FORBIDDEN_SYMBOL_EXCEPTION_exit
+#define FORBIDDEN_SYMBOL_EXCEPTION_getc
+
+#include "hypno/hypno.h"
+#include "hypno/grammar.h"
+#include "hypno/tokens_mis.h"
+
+#line 39 "engines/hypno/lexer_mis.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -872,44 +907,8 @@ int yy_flex_debug = 0;
 #define YY_RESTORE_YY_MORE_OFFSET
 char *yytext;
 #line 1 "engines/hypno/lexer_mis.l"
-/* ScummVM - Graphic Adventure Engine
- *
- * ScummVM is the legal property of its developers, whose names
- * are too numerous to list here. Please refer to the COPYRIGHT
- * file distributed with this source distribution.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+
 #define YY_NO_INPUT 1
-#line 32 "engines/hypno/lexer_mis.l"
-#define YY_NO_UNISTD_H
-#define FORBIDDEN_SYMBOL_EXCEPTION_FILE
-#define FORBIDDEN_SYMBOL_EXCEPTION_fprintf
-#define FORBIDDEN_SYMBOL_EXCEPTION_fwrite
-#define FORBIDDEN_SYMBOL_EXCEPTION_fread
-#define FORBIDDEN_SYMBOL_EXCEPTION_stdin
-#define FORBIDDEN_SYMBOL_EXCEPTION_stdout
-#define FORBIDDEN_SYMBOL_EXCEPTION_stderr
-#define FORBIDDEN_SYMBOL_EXCEPTION_exit
-#define FORBIDDEN_SYMBOL_EXCEPTION_getc
-
-#include "hypno/hypno.h"
-#include "hypno/grammar.h"
-#include "hypno/tokens_mis.h"
-
-#line 912 "engines/hypno/lexer_mis.cpp"
 #line 913 "engines/hypno/lexer_mis.cpp"
 
 #define INITIAL 0

--- a/engines/hypno/lexer_mis.l
+++ b/engines/hypno/lexer_mis.l
@@ -1,3 +1,4 @@
+%top{
 /* ScummVM - Graphic Adventure Engine
  *
  * ScummVM is the legal property of its developers, whose names
@@ -19,16 +20,6 @@
  *
  */
 
-%option noyywrap
-%option noinput
-%option nounput
-%option yylineno
-%option never-interactive
-
-%option outfile="engines/hypno/lexer_mis.cpp"
-%option prefix="HYPNO_MIS_"
-
-%{
 #define YY_NO_UNISTD_H
 #define FORBIDDEN_SYMBOL_EXCEPTION_FILE
 #define FORBIDDEN_SYMBOL_EXCEPTION_fprintf
@@ -44,7 +35,16 @@
 #include "hypno/grammar.h"
 #include "hypno/tokens_mis.h"
 
-%}
+}
+
+%option noyywrap
+%option noinput
+%option nounput
+%option yylineno
+%option never-interactive
+
+%option outfile="engines/hypno/lexer_mis.cpp"
+%option prefix="HYPNO_MIS_"
 
 %%
 \;.+						/* return COMMENT; */

--- a/engines/private/lexer.cpp
+++ b/engines/private/lexer.cpp
@@ -1,6 +1,45 @@
-#line 1 "engines/private/lexer.cpp"
+#line 2 "engines/private/lexer.cpp"
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
-#line 3 "engines/private/lexer.cpp"
+#define YY_NO_UNISTD_H
+#define FORBIDDEN_SYMBOL_EXCEPTION_FILE
+#define FORBIDDEN_SYMBOL_EXCEPTION_fprintf
+#define FORBIDDEN_SYMBOL_EXCEPTION_fwrite
+#define FORBIDDEN_SYMBOL_EXCEPTION_fread
+#define FORBIDDEN_SYMBOL_EXCEPTION_stdin
+#define FORBIDDEN_SYMBOL_EXCEPTION_stdout
+#define FORBIDDEN_SYMBOL_EXCEPTION_stderr
+#define FORBIDDEN_SYMBOL_EXCEPTION_exit
+#define FORBIDDEN_SYMBOL_EXCEPTION_getc
+
+#include "private/private.h"
+#include "private/grammar.h"
+#include "private/tokens.h"
+
+using namespace Private;
+using namespace Gen;
+using namespace Settings;
+
+#line 43 "engines/private/lexer.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -773,48 +812,8 @@ int yy_flex_debug = 0;
 #define YY_RESTORE_YY_MORE_OFFSET
 char *yytext;
 #line 1 "engines/private/lexer.l"
-/* ScummVM - Graphic Adventure Engine
- *
- * ScummVM is the legal property of its developers, whose names
- * are too numerous to list here. Please refer to the COPYRIGHT
- * file distributed with this source distribution.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+
 #define YY_NO_INPUT 1
-#line 31 "engines/private/lexer.l"
-#define YY_NO_UNISTD_H
-#define FORBIDDEN_SYMBOL_EXCEPTION_FILE
-#define FORBIDDEN_SYMBOL_EXCEPTION_fprintf
-#define FORBIDDEN_SYMBOL_EXCEPTION_fwrite
-#define FORBIDDEN_SYMBOL_EXCEPTION_fread
-#define FORBIDDEN_SYMBOL_EXCEPTION_stdin
-#define FORBIDDEN_SYMBOL_EXCEPTION_stdout
-#define FORBIDDEN_SYMBOL_EXCEPTION_stderr
-#define FORBIDDEN_SYMBOL_EXCEPTION_exit
-#define FORBIDDEN_SYMBOL_EXCEPTION_getc
-
-#include "private/private.h"
-#include "private/grammar.h"
-#include "private/tokens.h"
-
-using namespace Private;
-using namespace Gen;
-using namespace Settings;
-
-#line 817 "engines/private/lexer.cpp"
 #line 818 "engines/private/lexer.cpp"
 
 #define INITIAL 0

--- a/engines/private/lexer.l
+++ b/engines/private/lexer.l
@@ -1,3 +1,4 @@
+%top{
 /* ScummVM - Graphic Adventure Engine
  *
  * ScummVM is the legal property of its developers, whose names
@@ -19,15 +20,6 @@
  *
  */
 
-%option noyywrap
-%option noinput
-%option nounput
-%option never-interactive
-
-%option outfile="engines/private/lexer.cpp"
-%option prefix="PRIVATE_"
-
-%{
 #define YY_NO_UNISTD_H
 #define FORBIDDEN_SYMBOL_EXCEPTION_FILE
 #define FORBIDDEN_SYMBOL_EXCEPTION_fprintf
@@ -47,7 +39,15 @@ using namespace Private;
 using namespace Gen;
 using namespace Settings;
 
-%}
+}
+
+%option noyywrap
+%option noinput
+%option nounput
+%option never-interactive
+
+%option outfile="engines/private/lexer.cpp"
+%option prefix="PRIVATE_"
 
 %%
 \/\/.*				    /* ignoring the comment */


### PR DESCRIPTION
Our includes must come before flex generated code to avoid macro redefinition of INTx_MIN/MAX macros.
Also make the license appear at the top of the generated file.

This PR is mostly to check MSVC result.