### PR TITLE
MACGUI: Fix clicking on links in helpmenu

### DIFF
--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -384,7 +384,7 @@ void MacText::setMaxWidth(int maxWidth) {
 		absoluteCharOffset -= lineWidth;
 		++_cursorRow;
 	}
-	
+
 	int ppos = 0;
 	if (absoluteCharOffset > _canvas.getLineCharWidth(_cursorRow, true))
 		ppos = _canvas.getLineCharWidth(_cursorRow, true);
@@ -1718,7 +1718,7 @@ Common::U32String MacText::getMouseLink(int x, int y) {
 	y += _scrollPos;
 
 	int row, chunk;
-	getLineCharacter(x, y, nullptr, nullptr, &row, nullptr, &chunk);
+	getRowCol(x, y, nullptr, nullptr, &row, nullptr, &chunk);
 
 	if (chunk < 0)
 		return Common::U32String();


### PR DESCRIPTION
Recent change replaced getRowCol in MacText::getMouseLink with getLineCharacter. This commits reverts it because getLineCharacter counts lines by paragraph not by rendered rows, which causes issues with clicking on links in help menu due to long text in said menu.

WIP!
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
