### PR TITLE
BASE: Show error description when game fails to run

### DIFF
--- a/base/main.cpp
+++ b/base/main.cpp
@@ -870,7 +870,7 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 		} else {
 			DebugMan.removeAllDebugChannels();
 
-			GUI::displayErrorDialog(_("Could not find any engine capable of running the selected game"));
+			GUI::displayErrorDialog(result, _("Error running game:"));
 
 			// Clear the active domain
 			ConfMan.setActiveDomain("");


### PR DESCRIPTION
The previous "not...any engine" message was appropriate in the past ([circa 1a93895](https://github.com/scummvm/scummvm/blob/1a938956ec00247794151bb2b72f088f68581857/base/main.cpp)), but with changes over time it began appearing even for other error conditions (e.g. some game data files missing); thus it is sometimes incorrect.

Instead, show a message like we already do around line 824.

When I first tried this, I saw a lot of "Unknown error", hence #6665 :-)

Wretched PR number ✞

By the way, if this isn't an acceptable change, shall we consider adjusting the translated string to be the same as the almost identical one currently near gui/launcher.cpp:562, "ScummVM could not find any engine capable of running the selected game!"? (But I think we should change it: if game files are missing, it isn't right to say there is no capable engine.)


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
