### PR TITLE
DS: Support returning errors when switching to unsupported resolutions

### DIFF
--- a/backends/platform/ds/osystem_ds.cpp
+++ b/backends/platform/ds/osystem_ds.cpp
@@ -45,7 +45,8 @@ OSystem_DS *OSystem_DS::_instance = NULL;
 
 OSystem_DS::OSystem_DS()
 	: _eventSource(NULL), _engineRunning(false), _disableCursorPalette(true),
-	_graphicsMode(GFX_HWSCALE), _stretchMode(100),
+	_currentState(), _oldState(), _hiresHack(false), _screenChangeID(0),
+	_transactionMode(kTransactionNone),
 	_paletteDirty(false), _cursorDirty(false), _overlayInGUI(false),
 	_pfCLUT8(Graphics::PixelFormat::createFormatCLUT8()),
 	_pfABGR1555(Graphics::PixelFormat(2, 5, 5, 5, 1, 0, 5, 10, 15)),
@@ -219,8 +220,23 @@ Common::String OSystem_DS::getSystemLanguage() const {
 
 void OSystem_DS::engineInit() {
 	_engineRunning = true;
+
+	const Common::ConfigManager::Domain *activeDomain = ConfMan.getActiveDomain();
+	assert(activeDomain);
+
+	const Common::String engineId = activeDomain->getValOrDefault("engineid");
+	const Common::String gameId = activeDomain->getValOrDefault("gameid");
+
+	if ((engineId == "cine" && gameId == "fw")  ||
+	    (engineId == "gob"  && gameId == "lit") ||
+	     engineId == "supernova") {
+		_hiresHack = true;
+	} else {
+		_hiresHack = false;
+	}
 }
 
 void OSystem_DS::engineDone() {
 	_engineRunning = false;
+	_hiresHack = false;
 }

--- a/engines/dreamweb/titles.cpp
+++ b/engines/dreamweb/titles.cpp
@@ -30,10 +30,8 @@ namespace DreamWeb {
 namespace {
 void initTitlesGfx() {
 	Graphics::ModeWithFormatList modes = {
-#ifdef USE_HIGHRES
 		// First try for a 640x480 mode
 		Graphics::ModeWithFormat(640, 480, Graphics::PixelFormat::createFormatCLUT8()),
-#endif
 		// System doesn't support it, so fall back on 320x240 mode
 		Graphics::ModeWithFormat(320, 240, Graphics::PixelFormat::createFormatCLUT8()),
 	};

--- a/engines/hypno/hypno.cpp
+++ b/engines/hypno/hypno.cpp
@@ -95,6 +95,7 @@ HypnoEngine::HypnoEngine(OSystem *syst, const ADGameDescription *gd)
 	Hotspots hs;
 	hs.push_back(q);
 	quit->hots = hs;
+	quit->resolution = "320x200";
 	_levels["<quit>"] = quit;
 	resetStatistics();
 }


### PR DESCRIPTION
This allows engines like Dreamweb and Plumbers to handle selecting an appropriate resolution at runtime. A couple of issues within individual engines were uncovered by these changes, and the PR contains fixes for them.