### PR TITLE
SCI: Fix GCC warning

### DIFF
--- a/engines/sci/engine/savegame.cpp
+++ b/engines/sci/engine/savegame.cpp
@@ -132,7 +132,7 @@ struct SegmentObjTableEntrySyncer : Common::BinaryFunction<Common::Serializer, t
 			syncWithSerializer(s, *entry.data);
 		} else if (s.isLoading()) {
 			if (s.getVersion() < 37) {
-				typename T::value_type dummy;
+				typename T::value_type dummy{};
 				syncWithSerializer(s, dummy);
 			}
 			entry.data = nullptr;

--- a/engines/sci/engine/segment.h
+++ b/engines/sci/engine/segment.h
@@ -239,15 +239,14 @@ struct SegmentObjTable : public SegmentObj {
 	};
 	enum { HEAPENTRY_INVALID = -1 };
 
-	int first_free; /**< Beginning of a singly linked list for entries */
-	int entries_used; /**< Statistical information */
+	int first_free = HEAPENTRY_INVALID; /**< Beginning of a singly linked list for entries */
+	int entries_used = 0; /**< Statistical information */
 
 	typedef Common::Array<Entry> ArrayType;
 	ArrayType _table;
 
 public:
 	SegmentObjTable(SegmentType type) : SegmentObj(type) {
-		initTable();
 	}
 
 	~SegmentObjTable() override {
@@ -256,12 +255,6 @@ public:
 				freeEntry(i);
 			}
 		}
-	}
-
-	void initTable() {
-		entries_used = 0;
-		first_free = HEAPENTRY_INVALID;
-		_table.clear();
 	}
 
 	int allocEntry() {


### PR DESCRIPTION
Use default initialization for dummy.

```
In file included from engines/sci/engine/savegame.cpp:26:
In member function 'void Common::Serializer::syncAsUint16LE(T&, Version, Version) [with T = short unsigned int]',
    inlined from 'void Common::Serializer::syncAsUint16LE(T&, Version, Version) [with T = short unsigned int]' at common/serializer.h:120:2,
    inlined from 'void Sci::syncWithSerializer(Common::Serializer&, reg_t&)' at engines/sci/engine/savegame.cpp:77:18,
    inlined from 'void Sci::syncWithSerializer(Common::Serializer&, Node&)' at engines/sci/engine/savegame.cpp:96:20,
    inlined from 'void Sci::SegmentObjTableEntrySyncer<T>::operator()(Common::Serializer&, typename T::Entry&, int) const [with T = Sci::NodeTable]' at engines/sci/engine/savegame.cpp:136:23,
    inlined from 'void Sci::ArraySyncer<T, Syncer>::operator()(Common::Serializer&, Common::Array<T>&) const [with T = Sci::SegmentObjTable<Sci::Node>::Entry; Syncer = Sci::SegmentObjTableEntrySyncer<Sci::NodeTable>]' at engines/sci/engine/savegame.cpp:168:8,
    inlined from 'void Sci::syncArray(Common::Serializer&, Common::Array<T>&) [with T = SegmentObjTable<Node>::Entry; Syncer = SegmentObjTableEntrySyncer<NodeTable>]' at engines/sci/engine/savegame.cpp:183:6,
    inlined from 'void Sci::sync_Table(Common::Serializer&, T&) [with T = NodeTable]' at engines/sci/engine/savegame.cpp:499:62,
    inlined from 'virtual void Sci::NodeTable::saveLoadWithSerializer(Common::Serializer&)' at engines/sci/engine/savegame.cpp:507:23:
common/serializer.h:49:30: warning: 'dummy' may be used uninitialized [-Wmaybe-uninitialized]
   49 |                         TYPE tmp = val; \
      |                              ^~~
common/serializer.h:120:9: note: in expansion of macro 'SYNC_AS'
  120 |         SYNC_AS(Uint16LE, uint16, 2)
      |         ^~~~~~~
```