### PR TITLE
BACKENDS: OPENGL: Fix getScreenFormat while running in 3D

### DIFF
--- a/backends/graphics/android/android-graphics.cpp
+++ b/backends/graphics/android/android-graphics.cpp
@@ -218,7 +218,7 @@ float AndroidGraphicsManager::getHiDPIScreenFactor() const {
 	return dpi[2] / 1.2f;
 }
 
-bool AndroidGraphicsManager::loadVideoMode(uint requestedWidth, uint requestedHeight, const Graphics::PixelFormat &format, bool resizable, int antialiasing) {
+bool AndroidGraphicsManager::loadVideoMode(uint requestedWidth, uint requestedHeight, bool resizable, int antialiasing) {
 	ENTER("%d, %d, %s", requestedWidth, requestedHeight, format.toString().c_str());
 
 	// As GLES2 provides FBO, OpenGL graphics manager must ask us for a resizable surface

--- a/backends/graphics/android/android-graphics.h
+++ b/backends/graphics/android/android-graphics.h
@@ -61,7 +61,7 @@ protected:
 	void hideOverlay() override;
 
 
-	bool loadVideoMode(uint requestedWidth, uint requestedHeight, const Graphics::PixelFormat &format, bool resizable, int antialiasing) override;
+	bool loadVideoMode(uint requestedWidth, uint requestedHeight, bool resizable, int antialiasing) override;
 
 	void refreshScreen() override;
 

--- a/backends/graphics/ios/ios-graphics.cpp
+++ b/backends/graphics/ios/ios-graphics.cpp
@@ -60,7 +60,7 @@ void iOSGraphicsManager::notifyResize(const int width, const int height) {
 	handleResize(width, height);
 }
 
-bool iOSGraphicsManager::loadVideoMode(uint requestedWidth, uint requestedHeight, const Graphics::PixelFormat &format, bool resizable, int antialiasing) {
+bool iOSGraphicsManager::loadVideoMode(uint requestedWidth, uint requestedHeight, bool resizable, int antialiasing) {
 	// As GLES2 provides FBO, OpenGL graphics manager must ask us for a resizable surface
 	assert(resizable);
 	if (antialiasing != 0) {

--- a/backends/graphics/ios/ios-graphics.h
+++ b/backends/graphics/ios/ios-graphics.h
@@ -46,7 +46,7 @@ public:
 protected:
 	void setSystemMousePosition(const int x, const int y) override {}
 
-	bool loadVideoMode(uint requestedWidth, uint requestedHeight, const Graphics::PixelFormat &format, bool resizable, int antialiasing) override;
+	bool loadVideoMode(uint requestedWidth, uint requestedHeight, bool resizable, int antialiasing) override;
 	void showOverlay(bool inGUI) override;
 	void hideOverlay() override;
 

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -482,21 +482,16 @@ OSystem::TransactionError OpenGLGraphicsManager::endGFXTransaction() {
 		// If loadVideoMode fails, we won't consider that shader was the error
 		bool shaderOK = true;
 
-		if (!loadVideoMode(requestedWidth, requestedHeight,
-#ifdef USE_RGB_COLOR
-		                   _currentState.gameFormat,
-#else
-		                   Graphics::PixelFormat::createFormatCLUT8(),
-#endif
-				  renderToFrameBuffer || engineSupportsArbitraryResolutions,
-		                  renderToFrameBuffer ? 0 : antialiasing)
-			|| !(shaderOK = loadShader(_currentState.shader))
+		if (  !loadVideoMode(requestedWidth, requestedHeight,
+		                     renderToFrameBuffer || engineSupportsArbitraryResolutions,
+		                     renderToFrameBuffer ? 0 : antialiasing)
+		   || !(shaderOK = loadShader(_currentState.shader))
 		   // HACK: This is really nasty but we don't have any guarantees of
 		   // a context existing before, which means we don't know the maximum
 		   // supported texture size before this. Thus, we check whether the
 		   // requested game resolution is supported over here.
 		   || (   _currentState.gameWidth  > (uint)OpenGLContext.maxTextureSize
-		       || _currentState.gameHeight > (uint)OpenGLContext.maxTextureSize)) {
+		   || _currentState.gameHeight > (uint)OpenGLContext.maxTextureSize)) {
 			if (_transactionMode == kTransactionActive) {
 				// If the shader failed, it means that loadVideoMode succeeded
 				// Mark the error and continue without it

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -237,7 +237,11 @@ int OpenGLGraphicsManager::getGraphicsMode() const {
 
 #ifdef USE_RGB_COLOR
 Graphics::PixelFormat OpenGLGraphicsManager::getScreenFormat() const {
-	return _currentState.gameFormat;
+	if (_renderer3d) {
+		return _defaultFormatAlpha;
+	} else {
+		return _currentState.gameFormat;
+	}
 }
 
 Common::List<Graphics::PixelFormat> OpenGLGraphicsManager::getSupportedFormats() const {

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -276,12 +276,11 @@ protected:
 	 *
 	 * @parma requestedWidth  This is the requested actual game screen width.
 	 * @param requestedHeight This is the requested actual game screen height.
-	 * @param format          This is the requested pixel format of the virtual game screen.
 	 * @param resizable       This indicates that the window should not be resized because we can't handle it.
 	 * @param antialiasing    This is the requested antialiasing level.
 	 * @return true on success, false otherwise
 	 */
-	virtual bool loadVideoMode(uint requestedWidth, uint requestedHeight, const Graphics::PixelFormat &format, bool resizable, int antialiasing) = 0;
+	virtual bool loadVideoMode(uint requestedWidth, uint requestedHeight, bool resizable, int antialiasing) = 0;
 
 	bool loadShader(const Common::Path &fileName);
 

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -463,7 +463,7 @@ void OpenGLSdlGraphicsManager::notifyResize(const int width, const int height) {
 #endif
 }
 
-bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requestedHeight, const Graphics::PixelFormat &format, bool resizable, int antialiasing) {
+bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requestedHeight, bool resizable, int antialiasing) {
 	// This function should never be called from notifyResize thus we know
 	// that the requested size came from somewhere else.
 	_gotResize = false;

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -60,7 +60,7 @@ public:
 #endif
 
 protected:
-	bool loadVideoMode(uint requestedWidth, uint requestedHeight, const Graphics::PixelFormat &format, bool resizable, int antialiasing) override;
+	bool loadVideoMode(uint requestedWidth, uint requestedHeight, bool resizable, int antialiasing) override;
 
 	void refreshScreen() override;
 

--- a/backends/platform/libretro/include/libretro-graphics-opengl.h
+++ b/backends/platform/libretro/include/libretro-graphics-opengl.h
@@ -28,7 +28,7 @@ class Surface;
 class LibretroOpenGLGraphics : public OpenGL::OpenGLGraphicsManager {
 public:
 	LibretroOpenGLGraphics(OpenGL::ContextType contextType);
-	bool loadVideoMode(uint requestedWidth, uint requestedHeight, const Graphics::PixelFormat &format, bool resizable, int antialiasing) override {
+	bool loadVideoMode(uint requestedWidth, uint requestedHeight, bool resizable, int antialiasing) override {
 		return true;
 	}
 	void refreshScreen() override;


### PR DESCRIPTION
This is a small fix to allow engines to use the optimum textures when 3D rendering.

I also removed the format argument from loadVideoMode as we were never using it (in 2D and in 3D).