### PR TITLE
GUI: Remove RTL hack

### DIFF
--- a/gui/ThemeLayout.cpp
+++ b/gui/ThemeLayout.cpp
@@ -243,19 +243,7 @@ void ThemeLayoutMain::reflowLayout(Widget *widgetChain) {
 			_w = g_gui.getGUIWidth()  * 8 / 10 * g_gui.getScaleFactor();
 			_h = g_gui.getGUIHeight() * 8 / 10 * g_gui.getScaleFactor();
 		}
-	}
 
-	if (g_gui.useRTL()) {
-		if (this->_name == "GameOptions" || this->_name == "GlobalOptions" || this->_name == "Browser") {
-			/** The dialogs named above are the stacked dialogs for which the left+right paddings need to be adjusted for RTL.
-				Whenever a stacked dialog is opened, the below code sets the left and right paddings and enables widgets to be
-				shifted by that amount. If any new stacked and padded dialogs are added in the future,
-				add them here and in Widget::draw() to enable RTL support for that particular dialog
-			*/
-			int oldX = _x;
-			_x = g_gui.getGUIWidth() * g_gui.getScaleFactor() - _w - _x;
-			g_gui.setDialogPaddings(oldX, _x);
-		}
 	}
 
 	if (_x >= 0) _x += _inset * g_gui.getScaleFactor();

--- a/gui/Tooltip.cpp
+++ b/gui/Tooltip.cpp
@@ -58,9 +58,6 @@ void Tooltip::setup(Dialog *parent, Widget *widget, int x, int y) {
 	_x = MIN<int16>(parent->_x + x + _xdelta + _xpadding, g_system->getOverlayWidth() - _w - _xpadding * 2);
 	_y = MIN<int16>(parent->_y + y + _ydelta + _ypadding, g_system->getOverlayHeight() - _h - _ypadding * 2);
 
-	if (g_gui.useRTL())
-		_x = g_system->getOverlayWidth() - _w - _x + g_gui.getOverlayOffset();
-
 	if (ConfMan.hasKey("tts_enabled", "scummvm") &&
 			ConfMan.getBool("tts_enabled", "scummvm")) {
 		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
@@ -76,7 +73,11 @@ void Tooltip::drawDialog(DrawLayer layerToDraw) {
 
 	Dialog::drawDialog(layerToDraw);
 
-	int16 textX = g_gui.useRTL() ? _x - 1 - _xpadding : _x + 1 + _xpadding;
+	int16 textX = _x + 1 + _xpadding;
+	if (g_gui.useRTL()) {
+		textX = g_system->getOverlayWidth() - _w - textX;
+	}
+
 	int16 textY = _y + 1 + _ypadding;
 
 	Graphics::TextAlign textAlignment = g_gui.useRTL() ? Graphics::kTextAlignRight : Graphics::kTextAlignLeft;

--- a/gui/dialog.cpp
+++ b/gui/dialog.cpp
@@ -170,7 +170,11 @@ void Dialog::drawDialog(DrawLayer layerToDraw) {
 
 	g_gui.theme()->disableClipRect();
 	g_gui.theme()->_layerToDraw = layerToDraw;
-	g_gui.theme()->drawDialogBackground(Common::Rect(_x, _y, _x + _w, _y + _h), _backgroundType);
+	int16 x = _x;
+	if (g_gui.useRTL()) {
+		x = g_system->getOverlayWidth() - _x - _w;
+	}
+	g_gui.theme()->drawDialogBackground(Common::Rect(x, _y, x + _w, _y + _h), _backgroundType);
 
 	markWidgetsAsDirty();
 

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -69,9 +69,6 @@ GuiManager::GuiManager() : CommandSender(nullptr), _redrawStatus(kRedrawDisabled
 
 	_iconsSetChanged = false;
 
-	_topDialogLeftPadding = 0;
-	_topDialogRightPadding = 0;
-
 	_displayTopDialogOnly = false;
 
 	// Clear the cursor
@@ -477,11 +474,6 @@ void GuiManager::redraw() {
 	if (_dialogStack.empty())
 		return;
 
-	// Reset any custom RTL paddings set by stacked dialogs when we go back to the top
-	if (useRTL() && _dialogStack.size() == 1) {
-		setDialogPaddings(0, 0);
-	}
-
 	if (_displayTopDialogOnly) {
 		redrawInternalTopDialogOnly();
 	} else {
@@ -842,9 +834,11 @@ void GuiManager::processEvent(const Common::Event &event, Dialog *const activeDi
 		return;
 	int button;
 	uint32 time;
+	int16 screenW;
 	Common::Point mouse(event.mouse.x - activeDialog->_x, event.mouse.y - activeDialog->_y);
 	if (g_gui.useRTL()) {
-		mouse.x = g_system->getOverlayWidth() - event.mouse.x - activeDialog->_x + g_gui.getOverlayOffset();
+		screenW = g_system->getOverlayWidth();
+		mouse.x = screenW - event.mouse.x - activeDialog->_x;
 	}
 	switch (event.type) {
 	case Common::EVENT_KEYDOWN:
@@ -855,7 +849,7 @@ void GuiManager::processEvent(const Common::Event &event, Dialog *const activeDi
 		break;
 	case Common::EVENT_MOUSEMOVE:
 		if (g_gui.useRTL()) {
-			_globalMousePosition.x = g_system->getOverlayWidth() - event.mouse.x + g_gui.getOverlayOffset();
+			_globalMousePosition.x = screenW - event.mouse.x;
 		} else {
 			_globalMousePosition.x = event.mouse.x;
 		}
@@ -946,11 +940,6 @@ void GuiManager::setLanguageRTL() {
 #endif // USE_TRANSLATION
 
 	_useRTL = false;
-}
-
-void GuiManager::setDialogPaddings(int l, int r) {
-	_topDialogLeftPadding = l;
-	_topDialogRightPadding = r;
 }
 
 void GuiManager::initTextToSpeech() {

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -122,9 +122,6 @@ public:
 	bool useRTL() const { return _useRTL; }
 	void setLanguageRTL();
 
-	void setDialogPaddings(int l, int r);
-	int getOverlayOffset() { return _topDialogRightPadding - _topDialogLeftPadding; }
-
 	const Graphics::Font &getFont(ThemeEngine::FontStyle style = ThemeEngine::kFontStyleBold) const { return *(_theme->getFont(style)); }
 	int getFontHeight(ThemeEngine::FontStyle style = ThemeEngine::kFontStyleBold) const { return _theme->getFontHeight(style); }
 	int getStringWidth(const Common::String &str, ThemeEngine::FontStyle style = ThemeEngine::kFontStyleBold) const { return _theme->getStringWidth(str, style); }
@@ -183,9 +180,6 @@ protected:
 	bool		_useStdCursor;
 
 	bool		_useRTL;
-
-	int			_topDialogLeftPadding;
-	int			_topDialogRightPadding;
 
 	bool		_displayTopDialogOnly;
 

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -113,13 +113,6 @@ void Widget::draw() {
 		if (g_gui.useRTL()) {
 			_x = g_system->getOverlayWidth() - _x - _w;
 
-			if (this->_name.contains("GameOptions") || this->_name.contains("GlobalOptions") || this->_name.contains("Browser") || this->_name.empty()) {
-				/** The dialogs named above are the stacked dialogs for which the left+right paddings need to be adjusted for RTL.
-					The _name is empty for some special widgets - like RemapWidgets, NavBars, ScrollBars and they need to be adjusted too.
-				*/
-				_x = _x + g_gui.getOverlayOffset();
-			}
-
 			clip.moveTo(_x, clip.top);
 			g_gui.theme()->swapClipRect(clip);
 		}

--- a/gui/widgets/editable.cpp
+++ b/gui/widgets/editable.cpp
@@ -571,7 +571,7 @@ int EditableWidget::getSelectionCarretOffset() const {
 		return;
 
 	if (g_gui.useRTL())
-		x += g_system->getOverlayWidth() - _w - xOff + g_gui.getOverlayOffset();
+		x += g_system->getOverlayWidth() - _w - xOff;
 	else
 		x += xOff;
 	y += yOff;

--- a/gui/widgets/popup.cpp
+++ b/gui/widgets/popup.cpp
@@ -131,12 +131,13 @@ void PopUpDialog::reflowLayout() {
 void PopUpDialog::drawDialog(DrawLayer layerToDraw) {
 	Dialog::drawDialog(layerToDraw);
 
+	int16 x = _x;
 	if (g_gui.useRTL()) {
-		_x = g_system->getOverlayWidth() - _x - _w + g_gui.getOverlayOffset();
+		x = g_system->getOverlayWidth() - _x - _w;
 	}
 
 	// Draw the menu border
-	g_gui.theme()->drawWidgetBackground(Common::Rect(_x, _y, _x + _w, _y + _h), ThemeEngine::kWidgetBackgroundPlain);
+	g_gui.theme()->drawWidgetBackground(Common::Rect(x, _y, x + _w, _y + _h), ThemeEngine::kWidgetBackgroundPlain);
 
 	/*if (_twoColumns)
 		g_gui.vLine(_x + _w / 2, _y, _y + _h - 2, g_gui._color);*/
@@ -405,11 +406,10 @@ void PopUpDialog::drawMenuEntry(int entry, bool hilite) {
 	int pad = _leftPadding;
 
 	if (g_gui.useRTL()) {
-		if (_twoColumns) {
-			r1.translate(this->getWidth() - w, 0);		// Shift the line-separator to the "first" col of RTL popup
-		}
-
-		r2.left = g_system->getOverlayWidth() - r2.left - w + g_gui.getOverlayOffset();
+		const int16 screenW = g_system->getOverlayWidth();
+		r1.left = screenW - r1.left - w;
+		r1.right = r1.left + w;
+		r2.left = screenW - r2.left - w;
 		r2.right = r2.left + w;
 
 		alignment = Graphics::kTextAlignRight;


### PR DESCRIPTION
The hack was here because the RTL aware code was incomplete.

Fix everything and remove useless code.

I still see a small bug, in the launcher in list grouped view, the collapsing arrows are not drawn except when rendering the option dialog. In which case, they are misplaced like if they were not RTL.

I hope to have time to fix it soon.

Tested with the guiRTL option set to true.