### PR TITLE
MADE: Split up the music player class to support other platforms

### DIFF
--- a/engines/made/made.cpp
+++ b/engines/made/made.cpp
@@ -111,7 +111,8 @@ MadeEngine::~MadeEngine() {
 void MadeEngine::syncSoundSettings() {
 	Engine::syncSoundSettings();
 
-	_music->syncSoundSettings();
+	if (_music)
+		_music->syncSoundSettings();
 }
 
 int16 MadeEngine::getTicks() {
@@ -249,7 +250,10 @@ void MadeEngine::handleEvents() {
 }
 
 Common::Error MadeEngine::run() {
-	_music = new MusicPlayer(this, getGameID() == GID_RTZ);
+	if (getPlatform() == Common::kPlatformMacintosh)
+		_music = nullptr; // TODO: Macintosh music player
+	else
+		_music = new DOSMusicPlayer(this, getGameID() == GID_RTZ);
 	syncSoundSettings();
 
 	// Initialize backend
@@ -308,7 +312,8 @@ Common::Error MadeEngine::run() {
 	_script->runScript(_dat->getMainCodeObjectIndex());
 #endif
 
-	_music->close();
+	if (_music)
+		_music->close();
 
 	return Common::kNoError;
 }

--- a/engines/made/music.h
+++ b/engines/made/music.h
@@ -37,23 +37,39 @@ namespace Made {
 class GenericResource;
 
 class MusicPlayer {
+public:
+	virtual ~MusicPlayer() {}
+
+	virtual void close() = 0;
+
+	virtual bool load(int16 musicNum) = 0;
+	virtual void play(int16 musicNum) = 0;
+	virtual void stop() = 0;
+	virtual void pause() = 0;
+	virtual void resume() = 0;
+
+	virtual bool isPlaying() = 0;
+	virtual void syncSoundSettings() = 0;
+};
+
+class DOSMusicPlayer : public MusicPlayer {
 private:
 	static const uint8 MT32_GOODBYE_MSG[MidiDriver_MT32GM::MT32_DISPLAY_NUM_CHARS];
 
 public:
-	MusicPlayer(MadeEngine *vm, bool milesAudio);
-	~MusicPlayer();
+	DOSMusicPlayer(MadeEngine *vm, bool milesAudio);
+	~DOSMusicPlayer();
 
-	void close();
+	void close() override;
 
-	void playXMIDI(GenericResource *midiResource);
-	void playSMF(GenericResource *midiResource);
-	void stop();
-	void pause();
-	void resume();
+	bool load(int16 musicNum) override;
+	void play(int16 musicNum) override;
+	void stop() override;
+	void pause() override;
+	void resume() override;
 
-	bool isPlaying();
-	void syncSoundSettings();
+	bool isPlaying() override;
+	void syncSoundSettings() override;
 
 private:
 	MadeEngine *_vm;
@@ -61,6 +77,11 @@ private:
 	MidiDriver_Multisource *_driver;
 
 	MusicType _driverType;
+
+	GenericResource *_musicRes;
+
+	void playXMIDI(GenericResource *midiResource);
+	void playSMF(GenericResource *midiResource);
 
 	static void timerCallback(void *refCon);
 	void onTimer();

--- a/engines/made/scriptfuncs.cpp
+++ b/engines/made/scriptfuncs.cpp
@@ -42,7 +42,6 @@ ScriptFunctions::ScriptFunctions(MadeEngine *vm) : _vm(vm), _soundStarted(false)
 	_vm->_system->getMixer()->playStream(Audio::Mixer::kMusicSoundType, &_pcSpeakerHandle1, _pcSpeaker1);
 	_vm->_system->getMixer()->playStream(Audio::Mixer::kMusicSoundType, &_pcSpeakerHandle2, _pcSpeaker2);
 	_soundResource = nullptr;
-	_musicRes = nullptr;
 }
 
 ScriptFunctions::~ScriptFunctions() {
@@ -271,41 +270,21 @@ int16 ScriptFunctions::sfPlayMusic(int16 argc, int16 *argv) {
 
 	_vm->_musicBeatStart = _vm->_system->getMillis();
 
-	if (_vm->getGameID() == GID_RTZ) {
-		if (musicNum > 0) {
-			_musicRes = _vm->_res->getXmidi(musicNum);
-			if (_musicRes)
-				_vm->_music->playXMIDI(_musicRes);
-		}
-	} else {
-		// HACK: music number 2 in LGOP2 is file MT32SET.TON, which
-		// is used to set the MT32 instruments. This is not loaded
-		// correctly and the game freezes, and since we don't support
-		// MT32 music yet, we ignore it here
-		// FIXME: Remove this hack and handle this file properly
-		if (_vm->getGameID() == GID_LGOP2 && musicNum == 2)
-			return 0;
-		if (musicNum > 0) {
-			_musicRes = _vm->_res->getMidi(musicNum);
-			if (_musicRes)
-				_vm->_music->playSMF(_musicRes);
-		}
-	}
+	if (_vm->_music)
+		_vm->_music->play(musicNum);
 
 	return 0;
 }
 
 int16 ScriptFunctions::sfStopMusic(int16 argc, int16 *argv) {
-	if (_vm->_music->isPlaying() && _musicRes) {
+	if (_vm->_music && _vm->_music->isPlaying()) {
 		_vm->_music->stop();
-		_vm->_res->freeResource(_musicRes);
-		_musicRes = nullptr;
 	}
 	return 0;
 }
 
 int16 ScriptFunctions::sfIsMusicPlaying(int16 argc, int16 *argv) {
-	if (_vm->_music->isPlaying())
+	if (_vm->_music && _vm->_music->isPlaying())
 		return 1;
 	else
 		return 0;
@@ -782,12 +761,10 @@ int16 ScriptFunctions::sfLoadSound(int16 argc, int16 *argv) {
 }
 
 int16 ScriptFunctions::sfLoadMusic(int16 argc, int16 *argv) {
-	GenericResource *xmidi = _vm->_res->getXmidi(argv[0]);
-	if (xmidi) {
-		_vm->_res->freeResource(xmidi);
+	if (_vm->_music && _vm->_music->load(argv[0]))
 		return 1;
-	}
-	return 0;
+	else
+		return 0;
 }
 
 int16 ScriptFunctions::sfLoadPicture(int16 argc, int16 *argv) {

--- a/engines/made/scriptfuncs.h
+++ b/engines/made/scriptfuncs.h
@@ -74,7 +74,6 @@ protected:
 
 	Common::Array<const ExternalFunc *> _externalFuncs;
 	Common::Array<const char *> _externalFuncNames;
-	GenericResource *_musicRes;
 
 	int16 sfSystemCall(int16 argc, int16 *argv);
 	int16 sfInitGraf(int16 argc, int16 *argv);


### PR DESCRIPTION
Macintosh music hasn't been implemented yet, but it should be relatively simple to reuse the Halestorm driver from the Kyra engine.