### PR TITLE
AUDIO: Fix order of Macintosh music types

### DIFF
--- a/audio/mididrv.cpp
+++ b/audio/mididrv.cpp
@@ -353,6 +353,9 @@ MidiDriver::DeviceHandle MidiDriver::detectDevice(int flags) {
 		} else if (flags & MDT_SEGACD) {
 			tp = MT_SEGACD;
 			flags &= ~MDT_SEGACD;
+		} else if (flags & MDT_MACINTOSH) {
+			tp = MT_MACINTOSH;
+			flags &= ~MDT_MACINTOSH;
 		} else if (flags & MDT_ADLIB) {
 			tp = MT_ADLIB;
 			flags &= ~MDT_ADLIB;
@@ -371,9 +374,6 @@ MidiDriver::DeviceHandle MidiDriver::detectDevice(int flags) {
 		} else if (flags & MDT_APPLEIIGS) {
 			tp = MT_APPLEIIGS;
 			flags &= ~MDT_APPLEIIGS;
-		} else if (flags & MDT_MACINTOSH) {
-			tp = MT_MACINTOSH;
-			flags &= ~MDT_MACINTOSH;
 		} else if (flags & MDT_MIDI) {
 			// If we haven't tried to find a MIDI device yet we do this now.
 			skipMidi = false;

--- a/audio/mididrv.h
+++ b/audio/mididrv.h
@@ -55,12 +55,14 @@ enum MusicType {
 	MT_TOWNS,			// FM-TOWNS
 	MT_PC98,			// PC98
 	MT_SEGACD,			// SegaCD
+	MT_MACINTOSH,		// Apple Macintosh
+
+	// All devices after this one are treated as MIDI devices
 	MT_GM,				// General MIDI
 	MT_MT32,			// MT-32
 	MT_GS,				// Roland GS
 	MT_MT540,			// Casio MT-540
-	MT_CT460,			// Casio CT-460 / CSM-1
-	MT_MACINTOSH		// Apple Macintosh
+	MT_CT460			// Casio CT-460 / CSM-1
 };
 
 /**


### PR DESCRIPTION
This stops "Apple Macintosh Audio" from being listed as a general purpose MIDI device, and ensures that it gets prioritised over DOS music types when available.