### PR TITLE
VIDEO: QTVR: Fix hard coded maximum zoom value

### DIFF
--- a/video/qtvr_decoder.cpp
+++ b/video/qtvr_decoder.cpp
@@ -118,10 +118,10 @@ Common::QuickTimeParser::SampleDesc *QuickTimeDecoder::readPanoSampleDesc(Common
 	entry->_hotSpotColorDepth = _fd->readSint16BE(); // must be 8
 
 	if (entry->_minimumZoom == 0.0)
-		entry->_minimumZoom = 5.0;
+		entry->_minimumZoom = 2.0;
 
 	if (entry->_maximumZoom == 0.0)
-		entry->_maximumZoom = 65.0;
+		entry->_maximumZoom = abs(entry->_vPanTop - entry->_vPanBottom);
 
 	debugC(2, kDebugLevelGVideo, "    version: %d.%d sceneTrackID: %d loResSceneTrackID: %d hotSpotTrackID: %d",
 		entry->_majorVersion, entry->_minorVersion, entry->_sceneTrackID, entry->_loResSceneTrackID, entry->_hotSpotTrackID);


### PR DESCRIPTION
While reading the Panorama sample description, if the maximum zoom
and minimum zoom values are not present, ScummVM Director assigns
hard coded values of 65 degrees (for maximum zoom) and 5 degrees
(for minimum zoom). However, for panorama movies smaller tilting range,
that may get out of bounds. So, instead we should decide maximum zoom
based on its vertical panning range.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
