### PR TITLE
GUI: Fixes and cleanup when removing games

### DIFF
--- a/gui/launcher.h
+++ b/gui/launcher.h
@@ -166,7 +166,7 @@ protected:
 	 */
 	virtual void updateListing(int selPos = -1) = 0;
 
-	virtual int getNextPos(int item) = 0;
+	virtual int getItemPos(int item) = 0;
 
 	virtual void updateButtons() = 0;
 
@@ -242,7 +242,7 @@ public:
 
 protected:
 	void updateListing(int selPos = -1) override;
-	int getNextPos(int item) override;
+	int getItemPos(int item) override;
 	void groupEntries(const Common::Array<LauncherEntry> &metadata);
 	void updateButtons() override;
 	void selectTarget(const Common::String &target) override;

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -888,12 +888,11 @@ void GridWidget::assignEntriesToItems() {
 	}
 }
 
-int GridWidget::getNextPos(int oldSel) {
+int GridWidget::getItemPos(int item) {
 	int pos = 0;
 
-	// Find the next item in the grid
 	for (uint i = 0; i < _sortedEntryList.size(); i++) {
-		if (_sortedEntryList[i]->entryID == oldSel) {
+		if (_sortedEntryList[i]->entryID == item) {
 			return pos;
 		} else if (!_sortedEntryList[i]->isHeader) {
 			pos++;

--- a/gui/widgets/grid.h
+++ b/gui/widgets/grid.h
@@ -210,7 +210,7 @@ public:
 	void scrollToEntry(int id, bool forceToTop);
 	void assignEntriesToItems();
 
-	int getNextPos(int oldSel);
+	int getItemPos(int item);
 	int getNewSel(int index);
 	int getScrollPos() const { return _scrollPos; }
 	int getSelected() const { return ((_selectedEntry == nullptr) ? -1 : _selectedEntry->entryID); }

--- a/gui/widgets/groupedlist.cpp
+++ b/gui/widgets/groupedlist.cpp
@@ -229,8 +229,11 @@ void GroupedListWidget::setSelected(int item) {
 		// Notify clients that the selection changed.
 		sendCommand(kListSelectionChangedCmd, _selectedItem);
 
-		_currentPos = _selectedItem - _entriesPerPage / 2;
-		scrollToCurrent();
+		if (!isItemVisible(_selectedItem)) {
+			// scroll selected item to center if possible
+			_currentPos = _selectedItem - _entriesPerPage / 2;
+			scrollToCurrent();
+		}
 		markAsDirty();
 	}
 }

--- a/gui/widgets/groupedlist.cpp
+++ b/gui/widgets/groupedlist.cpp
@@ -304,7 +304,7 @@ int GroupedListWidget::getNextPos(int oldSel) {
 	for (uint i = 0; i < _listIndex.size(); i++) {
 		if (_listIndex[i] == oldSel) {
 			return pos;
-		} else if (_listIndex[i] > 0) {
+		} else if (_listIndex[i] >= 0) { // skip headers
 			pos++;
 		}
 	}

--- a/gui/widgets/groupedlist.cpp
+++ b/gui/widgets/groupedlist.cpp
@@ -297,12 +297,11 @@ void GroupedListWidget::handleCommand(CommandSender *sender, uint32 cmd, uint32 
 	}
 }
 
-int GroupedListWidget::getNextPos(int oldSel) {
+int GroupedListWidget::getItemPos(int item) {
 	int pos = 0;
 
-	// Find the position of the new selection in the list. 
 	for (uint i = 0; i < _listIndex.size(); i++) {
-		if (_listIndex[i] == oldSel) {
+		if (_listIndex[i] == item) {
 			return pos;
 		} else if (_listIndex[i] >= 0) { // skip headers
 			pos++;

--- a/gui/widgets/groupedlist.h
+++ b/gui/widgets/groupedlist.h
@@ -67,7 +67,7 @@ public:
 
 	void setGroupsVisibility(bool val) { _groupsVisible = val; }
 
-	int getNextPos(int oldSel);
+	int getItemPos(int item);
 	int getNewSel(int index);
 
 	void startEditMode() override { error("Edit mode is not supported for Grouped Lists"); }

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -183,8 +183,11 @@ void ListWidget::setSelected(int item) {
 		// Notify clients that the selection changed.
 		sendCommand(kListSelectionChangedCmd, _selectedItem);
 
-		_currentPos = _selectedItem - _entriesPerPage / 2;
-		scrollToCurrent();
+		if (!isItemVisible(_selectedItem)) {
+			// scroll selected item to center if possible
+			_currentPos = _selectedItem - _entriesPerPage / 2;
+			scrollToCurrent();
+		}
 		markAsDirty();
 	}
 }
@@ -315,8 +318,7 @@ void ListWidget::handleMouseLeft(int button) {
 int ListWidget::findItem(int x, int y) const {
 	if (y < _topPadding) return -1;
 	int item = (y - _topPadding) / kLineHeight + _currentPos;
-	if (item >= _currentPos && item < _currentPos + _entriesPerPage &&
-		item < (int)_list.size())
+	if (isItemVisible(item) && item < (int)_list.size())
 		return item;
 	else
 		return -1;

--- a/gui/widgets/list.h
+++ b/gui/widgets/list.h
@@ -121,6 +121,7 @@ public:
 	void scrollTo(int item);
 	void scrollToEnd();
 	int getCurrentScrollPos() const { return _currentPos; }
+	bool isItemVisible(int item) const { return _currentPos <= item && item < _currentPos + _entriesPerPage; }
 
 	void enableQuickSelect(bool enable) 		{ _quickSelect = enable; }
 	Common::String getQuickSelectString() const { return _quickSelectStr; }


### PR DESCRIPTION
This PR fixes the launcher unnecessarily scrolling the list when removing a game. For a user such as myself with more than a full screen of games, this caused the list to confusingly jump around unpredictably. Now scrolling only occurs when setting a selection if the item isn't already visible, instead of always trying to re-scroll the newly selected item to the center.

While testing the scroll change, I found that list item selection doesn't work when grouping is enabled due an off-by-one bug from last year in da3c3d097c4a6e71a6385c8ad1c6736d6825c205, so that's fixed too.

This took a while to figure out because many supporting functions were named `getNextPos`, but there was nothing "next" about them, so I've renamed them.