### PR TITLE
BACKENDS: OPENGL: Fix rendering issues in 3D games when antialiasing is enabled

### DIFF
--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -90,6 +90,7 @@ public:
 	virtual void fillScreen(uint32 col) = 0;
 	virtual void fillScreen(const Common::Rect &r, uint32 col) = 0;
 	virtual void updateScreen() = 0;
+	virtual void presentBuffer() {}
 	virtual void setShakePos(int shakeXOffset, int shakeYOffset) = 0;
 	virtual void setFocusRectangle(const Common::Rect& rect) = 0;
 	virtual void clearFocusRectangle() = 0;

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -929,6 +929,14 @@ void OpenGLGraphicsManager::updateScreen() {
 #endif
 }
 
+void OpenGLGraphicsManager::presentBuffer() {
+#if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
+	assert(_renderer3d);
+
+	_renderer3d->presentBuffer();
+#endif
+}
+
 Graphics::Surface *OpenGLGraphicsManager::lockScreen() {
 	assert(_gameScreen);
 	return _gameScreen->getSurface();

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -109,6 +109,7 @@ public:
 	void fillScreen(const Common::Rect &r, uint32 col) override;
 
 	void updateScreen() override;
+	void presentBuffer() override;
 
 	Graphics::Surface *lockScreen() override;
 	void unlockScreen() override;

--- a/backends/graphics/opengl/renderer3d.cpp
+++ b/backends/graphics/opengl/renderer3d.cpp
@@ -393,6 +393,32 @@ void Renderer3D::enter3D() {
 	}
 }
 
+void Renderer3D::presentBuffer() {
+	if (!_frameBuffers[1]) {
+		// We are not using multisampling: contents are readily available
+		// The engine just has to read from the FBO or the backbuffer
+		return;
+	}
+
+	assert(_stackLevel == 0);
+	bool saveScissorTest = glIsEnabled(GL_SCISSOR_TEST);
+
+	// Frambuffer blit is impacted by scissor test, disable it
+	glDisable(GL_SCISSOR_TEST);
+	// Swap the framebuffers and blit
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, _frameBuffers[0]);
+	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, _frameBuffers[1]);
+	const uint w = _texture.getLogicalWidth();
+	const uint h = _texture.getLogicalHeight();
+	glBlitFramebuffer(0, 0, w, h, 0, 0, w, h, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+
+	// Put back things as they were before
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, _frameBuffers[1]);
+	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, _frameBuffers[0]);
+
+	saveScissorTest ? glEnable(GL_SCISSOR_TEST) : glDisable(GL_SCISSOR_TEST);
+}
+
 void Renderer3D::showOverlay(uint w, uint h) {
 	_inOverlay = true;
 

--- a/backends/graphics/opengl/renderer3d.h
+++ b/backends/graphics/opengl/renderer3d.h
@@ -42,6 +42,7 @@ public:
 
 	void leave3D();
 	void enter3D();
+	void presentBuffer();
 
 	void showOverlay(uint w, uint h);
 	void hideOverlay();

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -198,6 +198,10 @@ void ModularGraphicsBackend::updateScreen() {
 #endif
 }
 
+void ModularGraphicsBackend::presentBuffer() {
+	_graphicsManager->presentBuffer();
+}
+
 void ModularGraphicsBackend::setShakePos(int shakeXOffset, int shakeYOffset) {
 	_graphicsManager->setShakePos(shakeXOffset, shakeYOffset);
 }

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -103,6 +103,7 @@ public:
 	void fillScreen(uint32 col) override final;
 	void fillScreen(const Common::Rect &r, uint32 col) override final;
 	void updateScreen() override final;
+	void presentBuffer() override final;
 	void setShakePos(int shakeXOffset, int shakeYOffset) override final;
 	void setFocusRectangle(const Common::Rect& rect) override final;
 	void clearFocusRectangle() override final;

--- a/common/system.h
+++ b/common/system.h
@@ -1272,6 +1272,11 @@ public:
 	virtual void updateScreen() = 0;
 
 	/**
+	 * When in 3D mode, forces a rendering pass to let the engine read back pixels.
+	 */
+	virtual void presentBuffer() {}
+
+	/**
 	 * Set current shake position, a feature needed for screen effects in some
 	 * engines.
 	 *

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -262,7 +262,7 @@ void GfxOpenGL::clearDepthBuffer() {
 void GfxOpenGL::flipBuffer(bool opportunistic) {
 	if (opportunistic) {
 		GLint fbo = 0;
-		glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &fbo);
+		glGetIntegerv(GL_FRAMEBUFFER_BINDING, &fbo);
 		if (fbo == 0) {
 			// Don't flip if we are not rendering on FBO
 			// Flipping without any draw is undefined

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -1879,6 +1879,7 @@ Bitmap *GfxOpenGL::getScreenshot(int w, int h, bool useStored) {
 	if (useStored) {
 		memcpy(src.getPixels(), _storedDisplay, _screenWidth * _screenHeight * 4);
 	} else {
+		g_system->presentBuffer();
 		glReadPixels(0, 0, _screenWidth, _screenHeight, GL_RGBA, GL_UNSIGNED_BYTE, src.getPixels());
 	}
 	Bitmap *bmp = createScreenshotBitmap(&src, w, h, false);
@@ -1887,6 +1888,7 @@ Bitmap *GfxOpenGL::getScreenshot(int w, int h, bool useStored) {
 }
 
 void GfxOpenGL::storeDisplay() {
+	g_system->presentBuffer();
 	glReadPixels(0, 0, _screenWidth, _screenHeight, GL_RGBA, GL_UNSIGNED_BYTE, _storedDisplay);
 }
 
@@ -1942,6 +1944,7 @@ void GfxOpenGL::dimRegion(int x, int yReal, int w, int h, float level) {
 		glViewport(0, 0, _screenWidth, _screenHeight);
 
 		// copy the data over to the texture
+		g_system->presentBuffer();
 		glBindTexture(GL_TEXTURE_2D, texture);
 		glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, x, y, w, h, 0);
 
@@ -1989,6 +1992,7 @@ void GfxOpenGL::dimRegion(int x, int yReal, int w, int h, float level) {
 	y = _screenHeight - yReal;
 
 	// collect the requested area and generate the dimmed version
+	g_system->presentBuffer();
 	glReadPixels(x, y - h, w, h, GL_RGBA, GL_UNSIGNED_BYTE, data);
 	for (int ly = 0; ly < h; ly++) {
 		for (int lx = 0; lx < w; lx++) {
@@ -2233,6 +2237,7 @@ void GfxOpenGL::readPixels(int x, int y, int width, int height, uint8 *buffer) {
 }
 
 void GfxOpenGL::createSpecialtyTextureFromScreen(uint id, uint8 *data, int x, int y, int width, int height) {
+	g_system->presentBuffer();
 	readPixels(x, y, width, height, data);
 	createSpecialtyTexture(id, data, width, height);
 }

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -1790,6 +1790,7 @@ void GfxOpenGLS::dimRegion(int xin, int yReal, int w, int h, float level) {
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
+	g_system->presentBuffer();
 	glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, xin, yin, w, h, 0);
 
 	glBindBuffer(GL_ARRAY_BUFFER, _dimRegionVBO);
@@ -2255,6 +2256,7 @@ Bitmap *GfxOpenGLS::getScreenshot(int w, int h, bool useStored) {
 #endif
 		}
 	} else {
+		g_system->presentBuffer();
 		readPixels(0, 0, _screenWidth, _screenHeight, (uint8 *)src.getPixels());
 	}
 	bmp = createScreenshotBitmap(&src, w, h, true);
@@ -2263,6 +2265,7 @@ Bitmap *GfxOpenGLS::getScreenshot(int w, int h, bool useStored) {
 }
 
 void GfxOpenGLS::createSpecialtyTextureFromScreen(uint id, uint8 *data, int x, int y, int width, int height) {
+	g_system->presentBuffer();
 	readPixels(x, y, width, height, data);
 	createSpecialtyTexture(id, data, width, height);
 }

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -517,7 +517,7 @@ void GfxOpenGLS::clearDepthBuffer() {
 void GfxOpenGLS::flipBuffer(bool opportunistic) {
 	if (opportunistic) {
 		GLint fbo = 0;
-		glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &fbo);
+		glGetIntegerv(GL_FRAMEBUFFER_BINDING, &fbo);
 		if (fbo == 0) {
 			// Don't flip if we are not rendering on FBO
 			// Flipping without any draw is undefined

--- a/engines/hpl1/engine/impl/LowLevelGraphicsSDL.cpp
+++ b/engines/hpl1/engine/impl/LowLevelGraphicsSDL.cpp
@@ -1361,6 +1361,7 @@ void cLowLevelGraphicsSDL::CopyContextToTexure(iTexture *apTex, const cVector2l 
 	// Log("ScreenOffset: %d %d (h: %d s: %d p: %d)\n",avPos.x,lScreenY,mvScreenSize.y,
 	//												avSize.y,avPos.y);
 
+	g_system->presentBuffer();
 	SetTexture(0, apTex);
 	GL_CHECK(glCopyTexSubImage2D(GetGLTextureTargetEnum(apTex->GetTarget()), 0,
 								 avTexOffset.x, lTexY, avPos.x, lScreenY, avSize.x, avSize.y));

--- a/engines/myst3/transition.cpp
+++ b/engines/myst3/transition.cpp
@@ -80,6 +80,7 @@ void Transition::draw(TransitionType type) {
 
 	// Capture a screenshot of the destination node
 	_vm->drawFrame(true);
+	g_system->presentBuffer();
 	Texture *targetScreenshot = _vm->_gfx->copyScreenshotToTexture();
 
 	// Compute the start and end frames for the animation

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
@@ -1020,7 +1020,7 @@ void BaseRenderOpenGL3D::postfilter() {
 		glEnable(GL_TEXTURE_2D);
 		glBindTexture(GL_TEXTURE_2D, _postfilterTexture);
 
-
+		g_system->presentBuffer();
 		glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 0, 0, _width, _height, 0);
 
 		glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE);
@@ -1040,6 +1040,7 @@ void BaseRenderOpenGL3D::postfilter() {
 		glDisableClientState(GL_VERTEX_ARRAY);
 		glDisableClientState(GL_TEXTURE_COORD_ARRAY);
 
+		g_system->presentBuffer();
 		glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 0, 0, _width, _height, 0);
 
 		glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE);
@@ -1059,6 +1060,7 @@ void BaseRenderOpenGL3D::postfilter() {
 		glDisableClientState(GL_VERTEX_ARRAY);
 		glDisableClientState(GL_TEXTURE_COORD_ARRAY);
 
+		g_system->presentBuffer();
 		glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 0, 0, _width, _height, 0);
 		
 		glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE);
@@ -1079,6 +1081,7 @@ void BaseRenderOpenGL3D::postfilter() {
 		glDisableClientState(GL_TEXTURE_COORD_ARRAY);
 
 		if (_postFilterMode == kPostFilterSepia) {
+			g_system->presentBuffer();
 			glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 0, 0, _width, _height, 0);
 
 			glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE);

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
@@ -1110,6 +1110,7 @@ void BaseRenderOpenGL3DShader::postfilter() {
 			_postfilterShader->setUniform1f("sepiaMode", false);
 		}
 
+		g_system->presentBuffer();
 		glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 0, 0, _width, _height, 0);
 
 		glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);


### PR DESCRIPTION
When 3D backends have been merged, I took the decision to use multisampling FBO to get AA rendering instead of relying on the OpenGL context having it.
This has allowed to add antialiasing to Android and iOS and avoids OpenGL context switches when a new setting is requested.

The main problem it introduces is that now, there are two distinct FBOs: one for reading and one for drawing and some engines expect to read what they just drew without issuing an updateScreen call first (to avoid polluting the display).
This PR adds a new presentBuffer call which does this offscreen rendering letting the engines read back what they have just rendered.

This has been tested with WME (fixing post filters), Grim (fixing save screenshots) and Myst III (fixing transitions).