### PR TITLE
AWE: Add detection entry for Amiga version

### DIFF
--- a/engines/awe/detection_tables.h
+++ b/engines/awe/detection_tables.h
@@ -105,6 +105,20 @@ const AweGameDescription gameDescriptions[] = {
 		},
 		DT_20TH_EDITION
 	},
+	// This Amiga version is included as a bonus on both GOG and Steam.
+	{
+		{
+			"anotherworld",
+			nullptr,
+			AD_ENTRY2s("bank01", "8cec5badf5bea89bff3a550daff79861", 244868,
+					   "bank03", "2ef3440fd6205634b257d56b0bc3ea51", 127846),
+			Common::EN_ANY,
+			Common::kPlatformAmiga,
+			ADGF_UNSTABLE,
+			GUIO1(GUIO_NONE)
+		},
+		DT_AMIGA
+	},
 
 	{ AD_TABLE_END_MARKER, 0 }
 };

--- a/engines/awe/resource.cpp
+++ b/engines/awe/resource.cpp
@@ -43,7 +43,7 @@ static const int MEMLIST_BMP[] = {
 
 Resource::Resource(Video *vid, DataType dataType) :
 		_vid(vid), _dataType(dataType) {
-	if (_dataType == DT_ATARI) {
+	if (_dataType == DT_AMIGA || _dataType == DT_ATARI) {
 		_amigaMemList = detectAmigaAtari();
 	} else
 		_amigaMemList = nullptr;


### PR DESCRIPTION
Since the Amiga version is included as a bonus both with the GOG and the Steam version of the game, it would be nice if ScummVM would support it too.

This pull request adds a detection entry for it (I've made sure that it includes one file from Disk A and another from Disk B), and makes a tiny adjustment to the resource manager to ensure that 'detectAmigaAtari()` gets called for the Amiga version as well, and not just the Atari one.

I've played through the first mission, and it worked just fine. Except I can't find a way to skip the intro, which is a bit annoying.