### PR TITLE
AUDIO: Remove obsolete note-to-track mapping and fix mTropolis usage of it

### DIFF
--- a/audio/midiparser_smf.cpp
+++ b/audio/midiparser_smf.cpp
@@ -27,8 +27,6 @@
 #include "common/util.h"
 
 MidiParser_SMF::MidiParser_SMF(int8 source) : MidiParser(source) {
-	for (int i = 0; i < ARRAYSIZE(_noteChannelToTrack); i++)
-		_noteChannelToTrack[i] = -1;
 }
 
 void MidiParser_SMF::parseNextEvent(EventInfo &info) {

--- a/audio/midiparser_smf.h
+++ b/audio/midiparser_smf.h
@@ -28,8 +28,6 @@
  * The Standard MIDI File version of MidiParser.
  */
 class MidiParser_SMF : public MidiParser {
-protected:
-	int8 _noteChannelToTrack[16];
 
 protected:
 	/**

--- a/engines/mtropolis/plugin/midi.cpp
+++ b/engines/mtropolis/plugin/midi.cpp
@@ -129,7 +129,7 @@ void MidiParser_MTropolis::setMutedTracks(uint16 mutedTracks) {
 
 bool MidiParser_MTropolis::processEvent(const EventInfo &info, bool fireEvents) {
 	if ((info.event & 0xf0) == MidiDriver_BASE::MIDI_COMMAND_NOTE_ON) {
-		int track = _noteChannelToTrack[info.event & 0xf];
+		int track = info.subtrack;
 		if (track >= 0 && (_mutedTracks & (1 << track)))
 			return true;
 	}


### PR DESCRIPTION
Commit debe30b25e666a1ef26a2550e6826cd1adba5810 broke the `_noteChannelToTrack` field, which in turn broke the track muting in certain parts of Obsidian.

This updates the mTropolis code to use the new `subtrack` field instead and deletes `_noteChannelToTrack`.