### PR TITLE
WINTERMUTE: Replace drawLine() with fillRect() for drawing indicators

### DIFF
--- a/engines/wintermute/ad/ad_game.cpp
+++ b/engines/wintermute/ad/ad_game.cpp
@@ -2064,8 +2064,8 @@ bool AdGame::displayContent(bool doUpdate, bool displayAll) {
 		initLoop();
 	}
 
-	// fill black
-	_renderer->fill(0, 0, 0);
+	// clear screen
+	_renderer->clear();
 	if (!_editorMode) {
 		_renderer->setScreenViewport();
 	}

--- a/engines/wintermute/base/base_game.cpp
+++ b/engines/wintermute/base/base_game.cpp
@@ -4296,8 +4296,8 @@ bool BaseGame::displayContent(bool doUpdate, bool displayAll) {
 
 //////////////////////////////////////////////////////////////////////////
 bool BaseGame::displayContentSimple() {
-	// fill black
-	_renderer->fill(0, 0, 0);
+	// clear screen
+	_renderer->clear();
 	_renderer->displayIndicator();
 
 	return STATUS_OK;

--- a/engines/wintermute/base/gfx/base_renderer.cpp
+++ b/engines/wintermute/base/gfx/base_renderer.cpp
@@ -368,7 +368,7 @@ bool BaseRenderer::displayIndicator() {
 #ifdef ENABLE_FOXTAIL
 	if (BaseEngine::instance().isFoxTail()) {
 		_hasDrawnSaveLoadImage = false;
-		fill(0, 0, 0);
+		clear();
 		displaySaveloadLines();
 		displaySaveloadImage();
 		forcedFlip();

--- a/engines/wintermute/base/gfx/base_renderer.cpp
+++ b/engines/wintermute/base/gfx/base_renderer.cpp
@@ -269,25 +269,8 @@ bool BaseRenderer::setup3D(Camera3D *camera, bool force) {
 #endif
 
 //////////////////////////////////////////////////////////////////////////
-bool BaseRenderer::setupLines() {
+bool BaseRenderer::fillRect(int x, int y, int w, int h, uint32 color) {
 	return STATUS_FAILED;
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool BaseRenderer::drawLine(int x1, int y1, int x2, int y2, uint32 color) {
-	return STATUS_FAILED;
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool BaseRenderer::drawRect(int x1, int y1, int x2, int y2, uint32 color, int width) {
-	for (int i = 0; i < width; i++) {
-		drawLine(x1 + i, y1 + i, x2 - i,     y1 + i, color); // up
-		drawLine(x1 + i, y2 - i, x2 - i + 1, y2 - i, color); // down
-
-		drawLine(x1 + i, y1 + i, x1 + i, y2 - i,     color); // left
-		drawLine(x2 - i, y1 + i, x2 - i, y2 - i + 1, color); // right
-	}
-	return STATUS_OK;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -369,7 +352,7 @@ bool BaseRenderer::displayIndicator() {
 	if (BaseEngine::instance().isFoxTail()) {
 		_hasDrawnSaveLoadImage = false;
 		clear();
-		displaySaveloadLines();
+		displaySaveloadRect();
 		displaySaveloadImage();
 		forcedFlip();
 		return STATUS_OK;
@@ -377,7 +360,7 @@ bool BaseRenderer::displayIndicator() {
 #endif
 
 	displaySaveloadImage();
-	displaySaveloadLines();
+	displaySaveloadRect();
 	indicatorFlip();
 	return STATUS_OK;
 }
@@ -400,17 +383,12 @@ bool BaseRenderer::displaySaveloadImage() {
 }
 
 //////////////////////////////////////////////////////////////////////////
-bool BaseRenderer::displaySaveloadLines() {
+bool BaseRenderer::displaySaveloadRect() {
 	if ((!_indicatorDisplay && _indicatorWidth <= 0) || _indicatorHeight <= 0) {
 		return STATUS_OK;
 	}
-	setupLines();
 	int curWidth = (int)(_indicatorWidth * (float)((float)_indicatorProgress / 100.0f));
-	for (int i = 0; i < _indicatorHeight; i++) {
-		drawLine(_indicatorX, _indicatorY + i, _indicatorX + curWidth, _indicatorY + i, _indicatorColor);
-	}
-
-	setup2D();
+	fillRect(_indicatorX, _indicatorY, curWidth, _indicatorHeight, _indicatorColor);
 	_indicatorWidthDrawn = curWidth;
 	return STATUS_OK;
 }

--- a/engines/wintermute/base/gfx/base_renderer.h
+++ b/engines/wintermute/base/gfx/base_renderer.h
@@ -87,8 +87,7 @@ public:
 	 */
 	virtual void fadeToColor(byte r, byte g, byte b, byte a) = 0;
 
-	virtual bool drawLine(int x1, int y1, int x2, int y2, uint32 color); // Unused outside indicator-display
-	virtual bool drawRect(int x1, int y1, int x2, int y2, uint32 color, int width = 1); // Unused outside indicator-display
+	virtual bool fillRect(int x, int y, int w, int h, uint32 color); // Unused outside indicator-display
 	BaseRenderer(BaseGame *inGame = nullptr);
 	~BaseRenderer() override;
 	virtual bool setProjection() {
@@ -120,7 +119,6 @@ public:
 #ifdef ENABLE_WME3D
 	virtual bool setup3D(Camera3D *camera = nullptr, bool force = false);
 #endif
-	virtual bool setupLines();
 
 	/**
 	 * Get the name of the current renderer
@@ -226,7 +224,7 @@ protected:
 private:
 	Common::Array<BaseActiveRect *> _rectList;
 	bool displaySaveloadImage();
-	bool displaySaveloadLines();
+	bool displaySaveloadRect();
 };
 
 BaseRenderer *makeOSystemRenderer(BaseGame *inGame); // Implemented in BRenderSDL.cpp

--- a/engines/wintermute/base/gfx/base_renderer.h
+++ b/engines/wintermute/base/gfx/base_renderer.h
@@ -97,13 +97,9 @@ public:
 
 	virtual bool windowedBlt();
 	/**
-	 * Fill a portion of the screen with a specified color
-	 *
-	 * @param r the red component to fill with.
-	 * @param g the green component to fill with.
-	 * @param b the blue component to fill with.
+	 * Clear the screen
 	 */
-	virtual bool fill(byte r, byte g, byte b, Common::Rect *rect = nullptr) = 0;
+	virtual bool clear() = 0;
 	virtual void onWindowChange();
 	virtual bool initRenderer(int width, int height, bool windowed);
 	/**

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
@@ -580,6 +580,16 @@ bool BaseRenderOpenGL3D::drawLine(int x1, int y1, int x2, int y2, uint32 color) 
 	return true;
 }
 
+bool BaseRenderOpenGL3D::fillRect(int x, int y, int w, int h, uint32 color) {
+	// TODO: Use a simplified method for drawing rectangles with OpenGL
+	setupLines();
+	for (int i = 0; i < h; i++) {
+		drawLine(x, y + i, x + w, y + i, color);
+	}
+	setup2D();
+	return true;
+}
+
 void BaseRenderOpenGL3D::fadeToColor(byte r, byte g, byte b, byte a) {
 	float left, right, bottom, top;
 

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
@@ -159,11 +159,11 @@ bool BaseRenderOpenGL3D::flip() {
 	return true;
 }
 
-bool BaseRenderOpenGL3D::fill(byte r, byte g, byte b, Common::Rect *rect) {
+bool BaseRenderOpenGL3D::clear() {
 	if(!_gameRef->_editorMode) {
 		glViewport(0, _height, _width, _height);
 	}
-	glClearColor(r / 255.0f, g / 255.0f, b / 255.0f, 1.0f);
+	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 	return true;
 }

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d.h
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d.h
@@ -105,7 +105,7 @@ public:
 	bool clear() override;
 
 	bool setViewport(int left, int top, int right, int bottom) override;
-	bool drawLine(int x1, int y1, int x2, int y2, uint32 color) override;
+	bool fillRect(int x, int y, int w, int h, uint32 color) override;
 
 	DXMatrix *buildMatrix(DXMatrix* out, const DXVector2 *centre, const DXVector2 *scaling, float angle);
 	void transformVertices(struct SpriteVertex *vertices, const DXVector2 *centre, const DXVector2 *scaling, float angle);
@@ -119,7 +119,6 @@ public:
 	bool initRenderer(int width, int height, bool windowed) override;
 	bool setup2D(bool force = false) override;
 	bool setup3D(Camera3D *camera, bool force = false) override;
-	bool setupLines() override;
 
 	Common::String getName() const override {
 		return "OpenGL 3D renderer";
@@ -161,6 +160,9 @@ public:
 	void setPostfilter(PostFilter postFilter) override { _postFilterMode = postFilter; };
 
 private:
+	bool setupLines();
+	bool drawLine(int x1, int y1, int x2, int y2, uint32 color);
+
 	void displaySimpleShadow(BaseObject *object) override;
 
 	SimpleShadowVertex _simpleShadow[4];

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d.h
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d.h
@@ -102,7 +102,7 @@ public:
 	void fadeToColor(byte r, byte g, byte b, byte a) override;
 
 	bool flip() override;
-	bool fill(byte r, byte g, byte b, Common::Rect *rect = nullptr) override;
+	bool clear() override;
 
 	bool setViewport(int left, int top, int right, int bottom) override;
 	bool drawLine(int x1, int y1, int x2, int y2, uint32 color) override;

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
@@ -237,11 +237,11 @@ bool BaseRenderOpenGL3DShader::flip() {
 	return true;
 }
 
-bool BaseRenderOpenGL3DShader::fill(byte r, byte g, byte b, Common::Rect *rect) {
+bool BaseRenderOpenGL3DShader::clear() {
 	if(!_gameRef->_editorMode) {
 		glViewport(0, _height, _width, _height);
 	}
-	glClearColor(r / 255.0f, g / 255.0f, b / 255.0f, 1.0f);
+	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 	return true;
 }

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
@@ -675,6 +675,16 @@ bool BaseRenderOpenGL3DShader::drawLine(int x1, int y1, int x2, int y2, uint32 c
 	return true;
 }
 
+bool BaseRenderOpenGL3DShader::fillRect(int x, int y, int w, int h, uint32 color) {
+	// TODO: Use a simplified method for drawing rectangles with OpenGL
+	setupLines();
+	for (int i = 0; i < h; i++) {
+		drawLine(x, y + i, x + w, y + i, color);
+	}
+	setup2D();
+	return true;
+}
+
 void BaseRenderOpenGL3DShader::fadeToColor(byte r, byte g, byte b, byte a) {
 	float left, right, bottom, top;
 

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.h
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.h
@@ -103,7 +103,7 @@ public:
 	BaseImage *takeScreenshot(int newWidth = 0, int newHeight = 0) override;
 	void fadeToColor(byte r, byte g, byte b, byte a) override;
 	bool flip() override;
-	bool fill(byte r, byte g, byte b, Common::Rect *rect = nullptr) override;
+	bool clear() override;
 
 	bool setViewport(int left, int top, int right, int bottom) override;
 	bool drawLine(int x1, int y1, int x2, int y2, uint32 color) override;

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.h
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.h
@@ -106,7 +106,7 @@ public:
 	bool clear() override;
 
 	bool setViewport(int left, int top, int right, int bottom) override;
-	bool drawLine(int x1, int y1, int x2, int y2, uint32 color) override;
+	bool fillRect(int x, int y, int w, int h, uint32 color) override;
 
 	DXMatrix *buildMatrix(DXMatrix* out, const DXVector2 *centre, const DXVector2 *scaling, float angle);
 	void transformVertices(struct SpriteVertex *vertices, const DXVector2 *centre, const DXVector2 *scaling, float angle);
@@ -120,7 +120,6 @@ public:
 	bool initRenderer(int width, int height, bool windowed) override;
 	bool setup2D(bool force = false) override;
 	bool setup3D(Camera3D *camera, bool force = false) override;
-	bool setupLines() override;
 
 	Common::String getName() const override {
 		return "OpenGL 3D renderer";
@@ -164,6 +163,9 @@ public:
 	OpenGL::Shader *_shadowMaskShader;
 
 private:
+	bool setupLines();
+	bool drawLine(int x1, int y1, int x2, int y2, uint32 color);
+
 	void displaySimpleShadow(BaseObject *object) override;
 
 	SimpleShadowVertex _simpleShadow[4];

--- a/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
+++ b/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
@@ -213,16 +213,12 @@ void BaseRenderOSystem::setWindowed(bool windowed) {
 }
 
 //////////////////////////////////////////////////////////////////////////
-bool BaseRenderOSystem::fill(byte r, byte g, byte b, Common::Rect *rect) {
-	_clearColor = _renderSurface->format.ARGBToColor(0xFF, r, g, b);
+bool BaseRenderOSystem::clear() {
 	if (!_disableDirtyRects) {
 		return STATUS_OK;
 	}
-	if (!rect) {
-		rect = &_renderRect;
-	}
 	// TODO: This doesn't work with dirty rects
-	_renderSurface->fillRect(*rect, _clearColor);
+	_renderSurface->fillRect(_renderRect, _clearColor);
 
 	return STATUS_OK;
 }

--- a/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
+++ b/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
@@ -453,11 +453,11 @@ void BaseRenderOSystem::drawFromSurface(RenderTicket *ticket, Common::Rect *dstR
 }
 
 //////////////////////////////////////////////////////////////////////////
-bool BaseRenderOSystem::drawLine(int x1, int y1, int x2, int y2, uint32 color) {
+bool BaseRenderOSystem::fillRect(int x, int y, int w, int h, uint32 color) {
 	// This function isn't used outside of indicator-displaying, and thus quite unused in
 	// BaseRenderOSystem when dirty-rects are enabled.
 	if (!_disableDirtyRects && !_indicatorDisplay) {
-		error("BaseRenderOSystem::DrawLine - doesn't work for dirty rects yet");
+		error("BaseRenderOSystem::fillRect - doesn't work for dirty rects yet");
 	}
 
 	byte r = RGBCOLGetR(color);
@@ -467,17 +467,11 @@ bool BaseRenderOSystem::drawLine(int x1, int y1, int x2, int y2, uint32 color) {
 
 	//SDL_SetRenderDrawBlendMode(_renderer, SDL_BLENDMODE_BLEND);
 
-	Point32 point1, point2;
-	point1.x = x1;
-	point1.y = y1;
-	pointToScreen(&point1);
-
-	point2.x = x2;
-	point2.y = y2;
-	pointToScreen(&point2);
+	Common::Rect fillRect(x, y, x + w, y + w);
+	modTargetRect(&fillRect);
 
 	uint32 colorVal = _renderSurface->format.ARGBToColor(a, r, g, b);
-	_renderSurface->drawLine(point1.x, point1.y, point2.x, point2.y, colorVal);
+	_renderSurface->fillRect(fillRect, colorVal);
 	return STATUS_OK;
 }
 

--- a/engines/wintermute/base/gfx/osystem/base_render_osystem.h
+++ b/engines/wintermute/base/gfx/osystem/base_render_osystem.h
@@ -76,7 +76,7 @@ public:
 	void fade(uint16 alpha) override;
 	void fadeToColor(byte r, byte g, byte b, byte a) override;
 
-	bool drawLine(int x1, int y1, int x2, int y2, uint32 color) override;
+	bool fillRect(int x, int y, int w, int h, uint32 color) override;
 
 	BaseImage *takeScreenshot(int newWidth = 0, int newHeight = 0) override;
 	void onWindowChange() override;

--- a/engines/wintermute/base/gfx/osystem/base_render_osystem.h
+++ b/engines/wintermute/base/gfx/osystem/base_render_osystem.h
@@ -71,7 +71,7 @@ public:
 	bool flip() override;
 	bool indicatorFlip() override;
 	bool forcedFlip() override;
-	bool fill(byte r, byte g, byte b, Common::Rect *rect = nullptr) override;
+	bool clear() override;
 	Graphics::PixelFormat getPixelFormat() const override;
 	void fade(uint16 alpha) override;
 	void fadeToColor(byte r, byte g, byte b, byte a) override;


### PR DESCRIPTION
The `drawLine()` function was only being used for drawing filled rectangles one line at a time, so it should be simpler and faster for the individual renderers to use alternative methods. Only the 2D renderer has been updated, but it should be possible to simplify the OpenGL renderers as well.