### PR TITLE
TEENAGENT: Fix Russian TTS encoding

### DIFF
--- a/engines/teenagent/teenagent.h
+++ b/engines/teenagent/teenagent.h
@@ -163,6 +163,8 @@ public:
 	void sayText(const Common::String &text);
 	void stopTextToSpeech();
 	void setTTSVoice(CharacterID characterID) const;
+	Common::U32String convertCyrillic(const Common::String &text) const;
+
 	Common::String _previousSaid;
 	
 private:


### PR DESCRIPTION
Fixes text-to-speech for the Russian translation, which uses a custom encoding.