### PR TITLE
BLADERUNNER: Wait with framelimiter in OuttakePlayer::play()

### DIFF
--- a/engines/bladerunner/outtake.cpp
+++ b/engines/bladerunner/outtake.cpp
@@ -30,6 +30,7 @@
 #include "bladerunner/audio_player.h"
 #include "bladerunner/game_constants.h"
 #include "bladerunner/game_info.h"
+#include "bladerunner/framelimiter.h"
 
 #include "common/debug.h"
 #include "common/events.h"
@@ -160,6 +161,8 @@ void OuttakePlayer::play(const Common::String &name, bool noLocalization, int co
 					break;
 				}
 			}
+		} else {
+			_vm->_framelimiter->wait();
 		}
 	}
 


### PR DESCRIPTION
There was a really high CPU usage when starting BladeRunner for the first time. There was in fact no frame rate limitation when playing videos. This caused a lot of calls to _vm->handleEvents(); Just call the wait() method
of FrameLimiter to prevent this.