### PR TITLE
WINTERMUTE: Set pixels matching the colour key to black in the the 2D renderer

### DIFF
--- a/engines/wintermute/base/gfx/osystem/base_surface_osystem.cpp
+++ b/engines/wintermute/base/gfx/osystem/base_surface_osystem.cpp
@@ -154,7 +154,9 @@ bool BaseSurfaceOSystem::finishLoad() {
 	}
 
 	if (needsColorKey) {
-		_surface->applyColorKey(_ckRed, _ckGreen, _ckBlue, replaceAlpha);
+		// We set the pixel color to transparent black,
+		// like D3DX, if it matches the color key.
+		_surface->applyColorKey(_ckRed, _ckGreen, _ckBlue, replaceAlpha, 0, 0, 0);
 	}
 
 	_alphaType = _surface->detectAlpha();


### PR DESCRIPTION
This matches the OpenGL renderer, and fixes scaling artefacts when filtering is enabled.