### PR TITLE
SLUDGE: Add an initial Debugger implementation for dumping resources

### DIFF
--- a/engines/sludge/debugger.cpp
+++ b/engines/sludge/debugger.cpp
@@ -1,0 +1,62 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "sludge/debugger.h"
+#include "sludge/sludge.h"
+#include "sludge/fileset.h"
+
+namespace Sludge {
+
+Debugger::Debugger(SludgeEngine *vm) : GUI::Debugger(), _vm(vm) {
+	registerCmd("listResources", WRAP_METHOD(Debugger, Cmd_ListResources));
+	registerCmd("dumpResource", WRAP_METHOD(Debugger, Cmd_DumpResource));
+}
+
+bool Debugger::Cmd_ListResources(int argc, const char **argv) {
+	if (argc != 1 && argc != 2) {
+		debugPrintf("Usage: %s\n", argv[0]);
+		return true;
+	}
+
+	for (int i = 0; i < _vm->_resMan->getResourceNameCount(); i++) {
+		const Common::String name = _vm->_resMan->resourceNameFromNum(i);
+		if (argc == 1 || name.matchString(argv[1]))
+			debugPrintf(" - %s\n", name.c_str());
+	}
+	return true;
+}
+
+bool Debugger::Cmd_DumpResource(int argc, const char **argv) {
+	if (argc != 2) {
+		debugPrintf("Usage: %s\n", argv[0]);
+		return true;
+	}
+
+	if (_vm->_resMan->dumpFileFromName(argv[1])) {
+		debugPrintf("Success\n");
+	} else {
+		debugPrintf("Failure\n");
+	}
+
+	return true;
+}
+
+} // End of namespace Sludge

--- a/engines/sludge/debugger.h
+++ b/engines/sludge/debugger.h
@@ -1,0 +1,46 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SLUDGE_DEBUGGER_H
+#define SLUDGE_DEBUGGER_H
+
+#include "gui/debugger.h"
+
+namespace Sludge {
+
+class SludgeEngine;
+
+class Debugger : public GUI::Debugger {
+private:
+	SludgeEngine *_vm;
+
+public:
+	Debugger(SludgeEngine *vm);
+	~Debugger() override {}
+
+protected:
+	bool Cmd_ListResources(int argc, const char **argv);
+	bool Cmd_DumpResource(int argc, const char **argv);
+};
+
+} // End of namespace Sludge
+
+#endif

--- a/engines/sludge/fileset.cpp
+++ b/engines/sludge/fileset.cpp
@@ -242,6 +242,38 @@ void ResourceManager::dumpFile(int num, const char *pattern) {
 	_bigDataFile->seek(pos);
 }
 
+bool ResourceManager::dumpFileFromName(const char *name) {
+	int num = -1;
+	for (int i = 0; i < getResourceNameCount(); i++) {
+		if (name != resourceNameFromNum(i))
+			continue;
+		num = i;
+		break;
+	}
+	if (num < 0)
+		return false;
+
+	Common::DumpFile dumpFile;
+	dumpFile.open(Common::Path("dumps/").append(name), true);
+	uint32 pos = _bigDataFile->pos();
+
+	_bigDataFile->seek(_startOfDataIndex + (num << 2), 0);
+	_bigDataFile->seek(_bigDataFile->readUint32LE(), 1);
+
+	uint fsize = _bigDataFile->readUint32LE();
+
+	byte *data = (byte *)malloc(fsize);
+
+	_bigDataFile->read(data, fsize);
+	dumpFile.write(data, fsize);
+	dumpFile.close();
+
+	free(data);
+
+	_bigDataFile->seek(pos);
+	return true;
+}
+
 void ResourceManager::readResourceNames(Common::SeekableReadStream *readStream) {
 	int numResourceNames = readStream->readUint16BE();
 	debugC(2, kSludgeDebugDataLoad, "numResourceNames %i", numResourceNames);

--- a/engines/sludge/fileset.h
+++ b/engines/sludge/fileset.h
@@ -50,9 +50,11 @@ public:
 	// Resource names
 	void readResourceNames(Common::SeekableReadStream *readStream);
 	const Common::String resourceNameFromNum(int i);
-	bool hasResourceNames() { return !_allResourceNames.empty(); }
+	bool hasResourceNames() const { return !_allResourceNames.empty(); }
+	int getResourceNameCount() const { return _allResourceNames.size(); }
 
 	void dumpFile(int num, const char *pattern);
+	bool dumpFileFromName(const char *name);
 
 private:
 	bool _sliceBusy;

--- a/engines/sludge/module.mk
+++ b/engines/sludge/module.mk
@@ -5,6 +5,7 @@ MODULE_OBJS := \
 	bg_effects.o \
 	builtin.o \
 	cursors.o \
+	debugger.o \
 	event.o \
 	fileset.o \
 	floor.o \

--- a/engines/sludge/sludge.cpp
+++ b/engines/sludge/sludge.cpp
@@ -27,6 +27,7 @@
 #include "engines/metaengine.h"
 
 #include "sludge/cursors.h"
+#include "sludge/debugger.h"
 #include "sludge/event.h"
 #include "sludge/fileset.h"
 #include "sludge/fonttext.h"
@@ -191,6 +192,8 @@ bool SludgeEngine::hasFeature(EngineFeature f) const {
 Common::Error SludgeEngine::run() {
 	// set global variable
 	g_sludge = this;
+
+	setDebugger(new Debugger(this));
 
 	// debug log
 	main_loop(getGameFile());


### PR DESCRIPTION
Currently only dumping resources by name is supported, which limits this to games that store resource names.