### PR TITLE
WINTERMUTE: Fix shader compilation with OpenGL ES 2

### DIFF
--- a/engines/wintermute/base/gfx/opengl/shaders/wme_postfilter.fragment
+++ b/engines/wintermute/base/gfx/opengl/shaders/wme_postfilter.fragment
@@ -16,6 +16,6 @@ void main() {
 		outColor.b = dot(vec3(r, g, b), vec3(0.272, 0.534, 0.131));
 	} else {
 		float gray = dot(color.rgb, vec3(0.299, 0.587, 0.114));
-		outColor = vec4(vec3(gray), 1.0f);
+		outColor = vec4(vec3(gray), 1.0);
 	}
 }


### PR DESCRIPTION
There are still rendering issues present in 3D games, but this allows games to start. Tested on Android 5.1.1 with a Mali-400 MP GPU.