### PR TITLE
ENGINES: Set boolean uniforms using integer calls for AmigaOS 4

### DIFF
--- a/engines/stark/gfx/openglssurface.cpp
+++ b/engines/stark/gfx/openglssurface.cpp
@@ -54,7 +54,7 @@ void OpenGLSSurfaceRenderer::render(const Bitmap *bitmap, const Common::Point &d
 
 	_shader->use();
 	_shader->setUniform1f("fadeLevel", _fadeLevel);
-	_shader->setUniform1f("snapToGrid", _snapToGrid);
+	_shader->setUniform("snapToGrid", _snapToGrid ? 1 : 0);
 	_shader->setUniform("verOffsetXY", normalizeOriginalCoordinates(dest.x, dest.y));
 	if (_noScalingOverride) {
 		_shader->setUniform("verSizeWH", normalizeCurrentCoordinates(width, height));
@@ -78,7 +78,7 @@ void OpenGLSSurfaceRenderer::fill(const Color &color, const Common::Point &dest,
 
 	_shaderFill->use();
 	_shaderFill->setUniform1f("fadeLevel", _fadeLevel);
-	_shaderFill->setUniform1f("snapToGrid", _snapToGrid);
+	_shaderFill->setUniform("snapToGrid", _snapToGrid ? 1 : 0);
 	_shaderFill->setUniform("verOffsetXY", normalizeOriginalCoordinates(dest.x, dest.y));
 	if (_noScalingOverride) {
 		_shaderFill->setUniform("verSizeWH", normalizeCurrentCoordinates(width, height));

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
@@ -1127,9 +1127,9 @@ void BaseRenderOpenGL3DShader::postfilter() {
 		glUniform1i(_postfilterShader->getUniformLocation("tex"), 0);
 
 		if (_postFilterMode == kPostFilterSepia) {
-			_postfilterShader->setUniform1f("sepiaMode", true);
+			_postfilterShader->setUniform("sepiaMode", true);
 		} else {
-			_postfilterShader->setUniform1f("sepiaMode", false);
+			_postfilterShader->setUniform("sepiaMode", false);
 		}
 
 		g_system->presentBuffer();


### PR DESCRIPTION
The documentation for `glUniform` says that "Either the i, ui or f variants may be used to provide values for uniform variables of type bool, bvec2, bvec3, bvec4, or arrays of these", however Amiga OS 4 is using int instead of bool, which makes it necessary to use the i variant for boolean variables.

This should fix [Trac #15053](https://bugs.scummvm.org/ticket/15053), but has not been tested.