### PR TITLE
WINTERMUTE: Support invalidating surfaces with the 2D renderer

### DIFF
--- a/engines/wintermute/base/base_sub_frame.cpp
+++ b/engines/wintermute/base/base_sub_frame.cpp
@@ -463,9 +463,14 @@ bool BaseSubFrame::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisS
 		int x = stack->pop()->getInt();
 		int y = stack->pop()->getInt();
 		byte r, g, b, a;
-		if (_surface && _surface->getPixel(x, y, &r, &g, &b, &a)) {
-			uint32 pixel = BYTETORGBA(r, g, b, a);
-			stack->pushInt(pixel);
+		if (_surface && _surface->startPixelOp()) {
+			if (_surface->getPixel(x, y, &r, &g, &b, &a)) {
+				uint32 pixel = BYTETORGBA(r, g, b, a);
+				stack->pushInt(pixel);
+			} else {
+				stack->pushNULL();
+			}
+			_surface->endPixelOp();
 		} else {
 			stack->pushNULL();
 		}

--- a/engines/wintermute/base/font/base_font_truetype.cpp
+++ b/engines/wintermute/base/font/base_font_truetype.cpp
@@ -287,6 +287,7 @@ BaseSurface *BaseFontTT::renderTextToTexture(const WideString &text, int width, 
 	}
 
 	BaseSurface *retSurface = _gameRef->_renderer->createSurface();
+	retSurface->create(surface->w, surface->h);
 	retSurface->putSurface(*surface, true);
 	surface->free();
 	delete surface;

--- a/engines/wintermute/base/gfx/base_surface.cpp
+++ b/engines/wintermute/base/gfx/base_surface.cpp
@@ -39,8 +39,6 @@ BaseSurface::BaseSurface(BaseGame *inGame) : BaseClass(inGame) {
 
 	_filename = "";
 
-	_pixelOpReady = false;
-
 	_ckDefault = true;
 	_ckRed = _ckGreen = _ckBlue = 0;
 	_lifeTime = 0;
@@ -52,9 +50,6 @@ BaseSurface::BaseSurface(BaseGame *inGame) : BaseClass(inGame) {
 
 //////////////////////////////////////////////////////////////////////
 BaseSurface::~BaseSurface() {
-	if (_pixelOpReady) {
-		endPixelOp();
-	}
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -64,7 +59,13 @@ bool BaseSurface::restore() {
 
 //////////////////////////////////////////////////////////////////////
 bool BaseSurface::isTransparentAt(int x, int y) {
-	return false;
+	if (startPixelOp()) {
+		bool retval = isTransparentAtLite(x, y);
+		endPixelOp();
+		return retval;
+	} else {
+		return false;
+	}
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -75,36 +76,6 @@ bool BaseSurface::displayHalfTrans(int x, int y, Rect32 rect) {
 //////////////////////////////////////////////////////////////////////////
 bool BaseSurface::create(int width, int height) {
 	return STATUS_FAILED;
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool BaseSurface::startPixelOp() {
-	return STATUS_FAILED;
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool BaseSurface::endPixelOp() {
-	return STATUS_FAILED;
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool BaseSurface::getPixel(int x, int y, byte *r, byte *g, byte *b, byte *a) {
-	return STATUS_FAILED;
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool BaseSurface::putPixel(int x, int y, byte r, byte g, byte b, int a) {
-	return STATUS_FAILED;
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool BaseSurface::comparePixel(int x, int y, byte r, byte g, byte b, int a) {
-	return false;
-}
-
-//////////////////////////////////////////////////////////////////////
-bool BaseSurface::isTransparentAtLite(int x, int y) {
-	return false;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/engines/wintermute/base/gfx/base_surface.h
+++ b/engines/wintermute/base/gfx/base_surface.h
@@ -43,7 +43,6 @@ public:
 	bool _valid;
 	int32 _lifeTime;
 
-	bool _pixelOpReady;
 	BaseSurface(BaseGame *inGame);
 	~BaseSurface() override;
 
@@ -63,12 +62,10 @@ public:
 	virtual bool putSurface(const Graphics::Surface &surface, bool hasAlpha = false) {
 		return STATUS_FAILED;
 	}
-	virtual bool putPixel(int x, int y, byte r, byte g, byte b, int a = -1);
-	virtual bool getPixel(int x, int y, byte *r, byte *g, byte *b, byte *a = nullptr);
-	virtual bool comparePixel(int x, int y, byte r, byte g, byte b, int a = -1);
-	virtual bool startPixelOp();
-	virtual bool endPixelOp();
-	virtual bool isTransparentAtLite(int x, int y);
+	virtual bool startPixelOp() = 0;
+	virtual bool endPixelOp() = 0;
+	virtual bool getPixel(int x, int y, byte *r, byte *g, byte *b, byte *a = nullptr) const = 0;
+	virtual bool isTransparentAtLite(int x, int y) const = 0;
 	void setSize(int width, int height);
 
 	int _referenceCount;

--- a/engines/wintermute/base/gfx/opengl/base_surface_opengl3d.h
+++ b/engines/wintermute/base/gfx/opengl/base_surface_opengl3d.h
@@ -40,7 +40,6 @@ public:
 
 	bool invalidate() override;
 
-	bool isTransparentAt(int x, int y) override;
 	bool displayTransRotate(int x, int y, float rotate, int32 hotspotX, int32 hotspotY, Rect32 rect, float zoomX, float zoomY, uint32 alpha = 0xFFFFFFFF, Graphics::TSpriteBlendMode blendMode = Graphics::BLEND_NORMAL, bool mirrorX = false, bool mirrorY = false) override;
 	bool displayTransZoom(int x, int y, Rect32 rect, float zoomX, float zoomY, uint32 alpha = 0xFFFFFFFF, Graphics::TSpriteBlendMode blendMode = Graphics::BLEND_NORMAL, bool mirrorX = false, bool mirrorY = false) override;
 	bool displayTrans(int x, int y, Rect32 rect, uint32 alpha = 0xFFFFFFFF, Graphics::TSpriteBlendMode blendMode = Graphics::BLEND_NORMAL, bool mirrorX = false, bool mirrorY = false, int offsetX = 0, int offsetY = 0) override;
@@ -50,10 +49,10 @@ public:
 	bool create(int width, int height) override;
 	bool setAlphaImage(const Common::String &filename) override;
 	bool putSurface(const Graphics::Surface &surface, bool hasAlpha = false) override;
-	bool getPixel(int x, int y, byte *r, byte *g, byte *b, byte *a = nullptr) override;
+	bool getPixel(int x, int y, byte *r, byte *g, byte *b, byte *a = nullptr) const override;
 	bool startPixelOp() override;
 	bool endPixelOp() override;
-	bool isTransparentAtLite(int x, int y) override;
+	bool isTransparentAtLite(int x, int y) const override;
 
 	void setTexture();
 
@@ -76,6 +75,7 @@ private:
 	Graphics::Surface *_maskData;
 	uint _texWidth;
 	uint _texHeight;
+	bool _pixelOpReady;
 
 	void writeAlpha(Graphics::Surface *surface, const Graphics::Surface *mask);
 };

--- a/engines/wintermute/base/gfx/osystem/base_surface_osystem.h
+++ b/engines/wintermute/base/gfx/osystem/base_surface_osystem.h
@@ -47,6 +47,8 @@ public:
 
 	bool setAlphaImage(const Common::String &filename) override;
 
+	bool invalidate() override;
+
 	bool isTransparentAtLite(int x, int y) const override;
 	bool startPixelOp() override;
 	bool endPixelOp() override;
@@ -58,20 +60,14 @@ public:
 	bool displayTiled(int x, int y, Rect32 rect, int numTimesX, int numTimesY) override;
 	bool putSurface(const Graphics::Surface &surface, bool hasAlpha = false) override;
 	int getWidth() override {
-		if (!_loaded) {
+		if (_width == 0) {
 			finishLoad();
-		}
-		if (_surface) {
-			return _surface->w;
 		}
 		return _width;
 	}
 	int getHeight() override {
-		if (!_loaded) {
+		if (_height == 0) {
 			finishLoad();
-		}
-		if (_surface) {
-			return _surface->h;
 		}
 		return _height;
 	}
@@ -90,7 +86,6 @@ public:
 	Graphics::AlphaType getAlphaType() const { return _alphaType; }
 private:
 	Graphics::Surface *_surface;
-	bool _loaded;
 	bool finishLoad();
 	bool drawSprite(int x, int y, Rect32 *rect, Rect32 *newRect, Graphics::TransformStruct transformStruct);
 	void writeAlpha(Graphics::Surface *surface, const Graphics::Surface *mask);

--- a/engines/wintermute/base/gfx/osystem/base_surface_osystem.h
+++ b/engines/wintermute/base/gfx/osystem/base_surface_osystem.h
@@ -47,9 +47,7 @@ public:
 
 	bool setAlphaImage(const Common::String &filename) override;
 
-	bool isTransparentAt(int x, int y) override;
-	bool isTransparentAtLite(int x, int y) override;
-
+	bool isTransparentAtLite(int x, int y) const override;
 	bool startPixelOp() override;
 	bool endPixelOp() override;
 
@@ -77,9 +75,9 @@ public:
 		}
 		return _height;
 	}
-	bool getPixel(int x, int y, byte *r, byte *g, byte *b, byte *a) override {
-		if (!_loaded) {
-			finishLoad();
+	bool getPixel(int x, int y, byte *r, byte *g, byte *b, byte *a) const override {
+		if (!_pixelOpReady) {
+			return STATUS_FAILED;
 		}
 		if (_surface) {
 			uint32 pixel = _surface->getPixel(x, y);
@@ -97,10 +95,9 @@ private:
 	bool drawSprite(int x, int y, Rect32 *rect, Rect32 *newRect, Graphics::TransformStruct transformStruct);
 	void writeAlpha(Graphics::Surface *surface, const Graphics::Surface *mask);
 
+	bool _pixelOpReady;
 	float _rotation;
 	Graphics::AlphaType _alphaType;
-	void *_lockPixels;
-	int _lockPitch;
 	Graphics::Surface *_alphaMask;
 	Graphics::AlphaType _alphaMaskType;
 };

--- a/engines/wintermute/ext/wme_vlink.cpp
+++ b/engines/wintermute/ext/wme_vlink.cpp
@@ -127,9 +127,7 @@ bool SXVlink::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisStack,
 					if (_updateNeeded) {
 						{
 							Common::StackLock lock(_frameMutex);
-							texture->startPixelOp();
 							texture->putSurface(_surface, false);
-							texture->endPixelOp();
 						}
 						texture->display(0, 0, Rect32(texture->getWidth(), texture->getHeight()));
 						_updateNeeded = false;

--- a/engines/wintermute/video/video_theora_player.cpp
+++ b/engines/wintermute/video/video_theora_player.cpp
@@ -346,12 +346,9 @@ bool VideoTheoraPlayer::writeVideo(const Graphics::Surface *decodedFrame) {
 		return STATUS_FAILED;
 	}
 
-	_texture->startPixelOp();
-
 	_texture->putSurface(*decodedFrame, false);
 	//RenderFrame(_texture, &yuv);
 
-	_texture->endPixelOp();
 	_videoFrameReady = true;
 	return STATUS_OK;
 }


### PR DESCRIPTION
This was previously only supported by the OpenGL renderer. Some changes have also been made to `getPixel` and `isTransparentAt` to ensure that the surface exists when those functions are called.