### PR TITLE
Fix: AGI PCjr sound "choppy" on fast notes

### DIFF
--- a/engines/agi/sound_pcjr.cpp
+++ b/engines/agi/sound_pcjr.cpp
@@ -273,8 +273,8 @@ int SoundGenPCJr::getNextNote_v2(int ch) {
 			break;
 		}
 
-		_tchannel[ch].genTypePrev = -1;
-		_tchannel[ch].freqCountPrev = -1;
+		tpcm->genTypePrev = tpcm->genType;
+		tpcm->freqCountPrev = tpcm->freqCount;
 
 		// only tone channels dissolve
 		if ((ch != 3) && (_dissolveMethod != 0))    // != noise??
@@ -481,7 +481,7 @@ int SoundGenPCJr::fillSquare(ToneChan *t, int16 *buf, int len) {
 	if (t->freqCount != t->freqCountPrev) {
 		//t->scale = (int)( (double)t->samp->freq*t->freqCount/FREQ_DIV * MULT + 0.5);
 		t->scale = (SAMPLE_RATE / 2) * t->freqCount;
-		t->count = t->scale;
+		//t->count = t->scale;
 		t->freqCountPrev = t->freqCount;
 	}
 


### PR DESCRIPTION
Due to the PCjr code enforcing a square wave sign change on every
new note, fast note sequences caused a choppy or rasping sound to
be heard.

The original SN76496 chip doesn't reset either the sign or its square
wave counters on a frequency change, so this commit prevents that
from happening by properly handling "previous" frequencies and
modes when the sign and counters are reset.

Demonstration:
Before: https://vimeo.com/1094121036
After: https://vimeo.com/1094121870
