### PR TITLE
GRAPHICS: Replace use of createPixelFormat for non-ColorMask purposes

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -2163,7 +2163,7 @@ void SurfaceSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, 
 		const uint numPixels = w * h;
 		const uint inBPP = format->bytesPerPixel;
 
-		Graphics::PixelFormat formatWithAlpha = Graphics::createPixelFormat<8888>();
+		Graphics::PixelFormat formatWithAlpha = Graphics::PixelFormat::createFormatRGBA32();
 
 		// Use the existing format if it already has alpha
 		if (format->aBits() > 0)

--- a/engines/gob/inter_v7.cpp
+++ b/engines/gob/inter_v7.cpp
@@ -622,7 +622,7 @@ void Inter_v7::o7_initScreen() {
 
 		// Comment the next line and uncomment the following ones to use the original pixel format (RGB555) for debugging purposes
 		_vm->setTrueColor(trueColor, false, nullptr);
-		// Graphics::PixelFormat format = Graphics::createPixelFormat<555>();
+		// Graphics::PixelFormat format(2, 5, 5, 5, 0, 10, 5, 0, 0);
 		// _vm->setTrueColor(trueColor, false, &format);
 	}
 

--- a/engines/mtropolis/assets.cpp
+++ b/engines/mtropolis/assets.cpp
@@ -1013,6 +1013,10 @@ const Common::SharedPtr<CachedImage> &ImageAsset::loadAndCacheImage(Runtime *run
 		return _imageCache;
 	}
 
+	ImageAsset::ImageFormat imageFormat = getImageFormat();
+	bool bottomUp = (imageFormat == ImageAsset::kImageFormatWindows);
+	bool isBigEndian = (imageFormat == ImageAsset::kImageFormatMac);
+
 	Graphics::PixelFormat pixelFmt;
 	switch (getColorDepth()) {
 	case kColorDepthMode1Bit:
@@ -1033,12 +1037,18 @@ const Common::SharedPtr<CachedImage> &ImageAsset::loadAndCacheImage(Runtime *run
 		break;
 	case kColorDepthMode16Bit:
 		bytesPerRow = (width * 2 + 3) / 4 * 4;
-		pixelFmt = Graphics::createPixelFormat<1555>();
+		pixelFmt = Graphics::PixelFormat(2, 5, 5, 5, 0, 10, 5, 0, 0);
 		break;
 	case kColorDepthMode32Bit:
 		bytesPerRow = width * 4;
-		pixelFmt = Graphics::createPixelFormat<8888>();
-		break;
+		if (imageFormat == ImageAsset::kImageFormatMac) {
+			pixelFmt = Graphics::PixelFormat::createFormatARGB32(false);
+			break;
+		} else if (imageFormat == ImageAsset::kImageFormatWindows) {
+			pixelFmt = Graphics::PixelFormat::createFormatBGRA32(false);
+			break;
+		}
+		// fall through
 	default:
 		warning("Image asset has an unrecognizable pixel format");
 		return _imageCache;
@@ -1046,10 +1056,6 @@ const Common::SharedPtr<CachedImage> &ImageAsset::loadAndCacheImage(Runtime *run
 
 	Common::Array<uint8> rowBuffer;
 	rowBuffer.resize(bytesPerRow);
-
-	ImageAsset::ImageFormat imageFormat = getImageFormat();
-	bool bottomUp = (imageFormat == ImageAsset::kImageFormatWindows);
-	bool isBigEndian = (imageFormat == ImageAsset::kImageFormatMac);
 
 	Common::SharedPtr<Graphics::ManagedSurface> imageSurface;
 	imageSurface.reset(new Graphics::ManagedSurface());
@@ -1089,44 +1095,18 @@ const Common::SharedPtr<CachedImage> &ImageAsset::loadAndCacheImage(Runtime *run
 				if (isBigEndian) {
 					for (int x = 0; x < width; x++) {
 						uint16 packedPixel = inRowBytes[x * 2 + 1] + (inRowBytes[x * 2 + 0] << 8);
-						int r = ((packedPixel >> 10) & 0x1f);
-						int g = ((packedPixel >> 5) & 0x1f);
-						int b = (packedPixel & 0x1f);
-
-						uint16 repacked = (1 << pixelFmt.aShift) | (r << pixelFmt.rShift) | (g << pixelFmt.gShift) | (b << pixelFmt.bShift);
-						static_cast<uint16 *>(outBase)[x] = repacked;
+						static_cast<uint16 *>(outBase)[x] = packedPixel;
 					}
 				} else {
 					for (int x = 0; x < width; x++) {
 						uint16 packedPixel = inRowBytes[x * 2 + 0] + (inRowBytes[x * 2 + 1] << 8);
-						int r = ((packedPixel >> 10) & 0x1f);
-						int g = ((packedPixel >> 5) & 0x1f);
-						int b = (packedPixel & 0x1f);
-
-						uint16 repacked = (1 << pixelFmt.aShift) | (r << pixelFmt.rShift) | (g << pixelFmt.gShift) | (b << pixelFmt.bShift);
-						static_cast<uint16 *>(outBase)[x] = repacked;
+						static_cast<uint16 *>(outBase)[x] = packedPixel;
 					}
 				}
 			} break;
-		case kColorDepthMode32Bit: {
-				if (imageFormat == ImageAsset::kImageFormatMac) {
-					for (int x = 0; x < width; x++) {
-						uint8 r = inRowBytes[x * 4 + 1];
-						uint8 g = inRowBytes[x * 4 + 2];
-						uint8 b = inRowBytes[x * 4 + 3];
-						uint32 repacked = (255 << pixelFmt.aShift) | (r << pixelFmt.rShift) | (g << pixelFmt.gShift) | (b << pixelFmt.bShift);
-						static_cast<uint32 *>(outBase)[x] = repacked;
-					}
-				} else if (imageFormat == ImageAsset::kImageFormatWindows) {
-					for (int x = 0; x < width; x++) {
-						uint8 r = inRowBytes[x * 4 + 2];
-						uint8 g = inRowBytes[x * 4 + 1];
-						uint8 b = inRowBytes[x * 4 + 0];
-						uint32 repacked = (255 << pixelFmt.aShift) | (r << pixelFmt.rShift) | (g << pixelFmt.gShift) | (b << pixelFmt.bShift);
-						static_cast<uint32 *>(outBase)[x] = repacked;
-					}
-				}
-			} break;
+		case kColorDepthMode32Bit:
+			memcpy(outBase, inRowBytes, width * 4);
+			break;
 		default:
 			break;
 		}

--- a/engines/mtropolis/metaengine.cpp
+++ b/engines/mtropolis/metaengine.cpp
@@ -200,7 +200,7 @@ void MTropolisMetaEngine::getSavegameThumbnail(Graphics::Surface &thumb) {
 		}
 
 		Common::SharedPtr<Graphics::ManagedSurface> outSurface(new Graphics::ManagedSurface());
-		outSurface->create(savegameScreenshot->w, savegameScreenshot->h, Graphics::createPixelFormat<888>());
+		outSurface->create(savegameScreenshot->w, savegameScreenshot->h, Graphics::PixelFormat::createFormatRGBA32());
 
 		for (int y = 0; y < savegameScreenshot->h; y++) {
 			for (int x = 0; x < savegameScreenshot->w; x++) {
@@ -212,7 +212,7 @@ void MTropolisMetaEngine::getSavegameThumbnail(Graphics::Surface &thumb) {
 
 		while (outSurface->w >= thumbnailWidth * 2) {
 			Common::SharedPtr<Graphics::ManagedSurface> temp(new Graphics::ManagedSurface());
-			temp->create(outSurface->w / 2, outSurface->h, Graphics::createPixelFormat<888>());
+			temp->create(outSurface->w / 2, outSurface->h, Graphics::PixelFormat::createFormatRGBA32());
 
 			for (int y = 0; y < temp->h; y++) {
 				for (int x = 0; x < temp->w; x++) {
@@ -234,7 +234,7 @@ void MTropolisMetaEngine::getSavegameThumbnail(Graphics::Surface &thumb) {
 
 		while (outSurface->h >= thumbnailHeight * 2) {
 			Common::SharedPtr<Graphics::ManagedSurface> temp(new Graphics::ManagedSurface());
-			temp->create(outSurface->w, outSurface->h / 2, Graphics::createPixelFormat<888>());
+			temp->create(outSurface->w, outSurface->h / 2, Graphics::PixelFormat::createFormatRGBA32());
 
 			for (int y = 0; y < temp->h; y++) {
 				for (int x = 0; x < temp->w; x++) {
@@ -257,7 +257,7 @@ void MTropolisMetaEngine::getSavegameThumbnail(Graphics::Surface &thumb) {
 		// TODO: Fix this for weird sizes
 		Common::SharedPtr<Graphics::ManagedSurface> changeTo16Temp = outSurface;
 		outSurface.reset(new Graphics::ManagedSurface());
-		outSurface->create(changeTo16Temp->w, changeTo16Temp->h, Graphics::createPixelFormat<565>());
+		outSurface->create(changeTo16Temp->w, changeTo16Temp->h, Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0));
 
 		for (int y = 0; y < outSurface->h; y++) {
 			for (int x = 0; x < outSurface->w; x++) {

--- a/engines/mtropolis/subtitles.cpp
+++ b/engines/mtropolis/subtitles.cpp
@@ -569,7 +569,8 @@ void SubtitleRenderer::render() {
 			int surfaceWidth = static_cast<int>(widestLine) + borderWidth * 2 + horizontalPadding * 2;
 			int surfaceHeight = static_cast<int>(itemLines) * _fontHeight + borderWidth * 2 + verticalPadding * 2;
 
-			Graphics::PixelFormat fmt = Graphics::createPixelFormat<8888>();
+			// TODO: Pick a format closer to the screen format
+			Graphics::PixelFormat fmt = Graphics::PixelFormat::createFormatRGBA32();
 			Common::SharedPtr<Graphics::ManagedSurface> surface(new Graphics::ManagedSurface(surfaceWidth, surfaceHeight, fmt));
 
 			surface->fillRect(Common::Rect(0, 0, surfaceWidth, surfaceHeight), fmt.RGBToColor(0, 0, 0));

--- a/engines/testbed/graphics.cpp
+++ b/engines/testbed/graphics.cpp
@@ -964,7 +964,7 @@ TestExitStatus GFXtests::maskedCursors() {
 			if (haveCursorAlpha) {
 				g_system->delayMillis(500);
 
-				Graphics::PixelFormat rgbaFormat = Graphics::createPixelFormat<8888>();
+				Graphics::PixelFormat rgbaFormat = Graphics::PixelFormat::createFormatRGBA32();
 
 				uint32 rgbaCursorData[16 * 16];
 				for (uint i = 0; i < 16 * 16; i++) {

--- a/engines/vcruise/menu.cpp
+++ b/engines/vcruise/menu.cpp
@@ -761,7 +761,7 @@ void ReahSoundMenuPage::addPageContents() {
 
 		Common::Point sliderSize(40, 60);
 
-		_sliderKeyGraphic.reset(new Graphics::ManagedSurface(sliderSize.x, sliderSize.y, Graphics::createPixelFormat<8888>()));
+		_sliderKeyGraphic.reset(new Graphics::ManagedSurface(sliderSize.x, sliderSize.y, Graphics::PixelFormat::createFormatRGBA32()));
 
 		Graphics::PixelFormat srcFormat = soundGraphics->format;
 		Graphics::PixelFormat dstFormat = _sliderKeyGraphic->format;

--- a/graphics/thumbnail.cpp
+++ b/graphics/thumbnail.cpp
@@ -101,7 +101,7 @@ HeaderState loadHeader(Common::SeekableReadStream &in, ThumbnailHeader &header, 
 		header.format.aShift = in.readByte();
 	} else {
 		// Version 1 used a hardcoded RGB565.
-		header.format = createPixelFormat<565>();
+		header.format = PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0);
 	}
 
 	if (in.err() || in.eos()) {


### PR DESCRIPTION
I'm hoping to adjust some of the existing ColorMasks (particularly the 8888 ones) to more closely match the pixel formats used by backends/engines, so this makes sure that code that doesn't otherwise use ColorMasks don't rely on them using a specific order.