### PR TITLE
GRAPHICS: Add helper functions for creating endian-independent formats

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -1702,11 +1702,7 @@ Surface *OpenGLGraphicsManager::createSurface(const Graphics::PixelFormat &forma
 		// hope for this to change anytime soon) we use pixel format
 		// conversion to a supported texture format.
 		return new TextureSurfaceRGB555();
-#ifdef SCUMM_LITTLE_ENDIAN
-	} else if (format == Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0)) { // RGBA8888
-#else
-	} else if (format == Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24)) { // ABGR8888
-#endif
+	} else if (format == Graphics::PixelFormat::createFormatABGR32()) {
 		return new TextureSurfaceRGBA8888Swap();
 	} else {
 		return new FakeTextureSurface(GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, OpenGL::Texture::getRGBAPixelFormat(), format);

--- a/backends/graphics/opengl/texture.cpp
+++ b/backends/graphics/opengl/texture.cpp
@@ -368,11 +368,7 @@ void TextureSurfaceRGB555::updateGLTexture() {
 }
 
 TextureSurfaceRGBA8888Swap::TextureSurfaceRGBA8888Swap()
-#ifdef SCUMM_LITTLE_ENDIAN
-	: FakeTextureSurface(GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, OpenGL::Texture::getRGBAPixelFormat(), Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0)) // RGBA8888 -> ABGR8888
-#else
-	: FakeTextureSurface(GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, OpenGL::Texture::getRGBAPixelFormat(), Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24)) // ABGR8888 -> RGBA8888
-#endif
+	: FakeTextureSurface(GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, OpenGL::Texture::getRGBAPixelFormat(), Graphics::PixelFormat::createFormatABGR32())
 	  {
 }
 

--- a/engines/ags/shared/gfx/image.cpp
+++ b/engines/ags/shared/gfx/image.cpp
@@ -133,11 +133,7 @@ BITMAP *load_bitmap(PACKFILE *pf, color *pal) {
 }
 
 int save_bitmap(Common::WriteStream &out, BITMAP *bmp, const RGB *pal) {
-#ifdef SCUMM_LITTLE_ENDIAN
-	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 16, 8, 0, 0);
-#else
-	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 0, 8, 16, 0);
-#endif
+	const Graphics::PixelFormat requiredFormat_3byte = Graphics::PixelFormat::createFormatBGR24();
 	Graphics::ManagedSurface surface(bmp->w, bmp->h, requiredFormat_3byte);
 
 	Graphics::ManagedSurface &src = bmp->getSurface();

--- a/engines/freescape/gfx.cpp
+++ b/engines/freescape/gfx.cpp
@@ -46,7 +46,6 @@ Renderer::Renderer(int screenW, int screenH, Common::RenderMode renderMode, bool
 	_screenW = screenW;
 	_screenH = screenH;
 	_currentPixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-	_palettePixelFormat = Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0);
 	_keyColor = -1;
 	_inkColor = -1;
 	_paperColor = -1;

--- a/engines/freescape/gfx.cpp
+++ b/engines/freescape/gfx.cpp
@@ -35,11 +35,7 @@
 namespace Freescape {
 
 const Graphics::PixelFormat getRGBAPixelFormat() {
-#ifdef SCUMM_BIG_ENDIAN
-	return Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-	return Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+	return Graphics::PixelFormat::createFormatRGBA32();
 }
 
 Renderer::Renderer(int screenW, int screenH, Common::RenderMode renderMode, bool authenticGraphics) {

--- a/engines/freescape/gfx.h
+++ b/engines/freescape/gfx.h
@@ -63,7 +63,6 @@ public:
 	virtual ~Renderer();
 
 	Graphics::PixelFormat _currentPixelFormat;
-	Graphics::PixelFormat _palettePixelFormat;
 	Graphics::PixelFormat _texturePixelFormat;
 	bool _isAccelerated;
 	bool _authenticGraphics;

--- a/engines/gnap/gnap.cpp
+++ b/engines/gnap/gnap.cpp
@@ -194,12 +194,8 @@ GnapEngine::~GnapEngine() {
 }
 
 Common::Error GnapEngine::run() {
-	// Initialize the graphics mode to RGBA8888
-#if defined(SCUMM_BIG_ENDIAN)
-	Graphics::PixelFormat format = Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#else
-	Graphics::PixelFormat format = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#endif
+	// Initialize the graphics mode to ABGR32
+	Graphics::PixelFormat format = Graphics::PixelFormat::createFormatABGR32();
 	initGraphics(800, 600, &format);
 
 	// We do not support color conversion yet

--- a/engines/grim/bitmap.cpp
+++ b/engines/grim/bitmap.cpp
@@ -309,11 +309,7 @@ bool BitmapData::loadTile(Common::SeekableReadStream *o) {
 	_data = new Graphics::Surface[_numImages];
 
 	Graphics::PixelFormat format_16bpp = Graphics::PixelFormat(2, 5, 5, 5, 1, 0, 5, 10, 15);
-#ifdef SCUMM_BIG_ENDIAN
-	Graphics::PixelFormat format_32bpp = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-	Graphics::PixelFormat format_32bpp = Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+	Graphics::PixelFormat format_32bpp = Graphics::PixelFormat::createFormatRGBA32();
 
 	int width = 256;
 	int height = 256;

--- a/engines/grim/emi/lua_v2.cpp
+++ b/engines/grim/emi/lua_v2.cpp
@@ -503,11 +503,7 @@ void Lua_V2::ThumbnailFromFile() {
 		return;
 	}
 
-#ifdef SCUMM_BIG_ENDIAN
-	screenshot->_data->convertToColorFormat(Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
-#else
-	screenshot->_data->convertToColorFormat(Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
-#endif
+	screenshot->_data->convertToColorFormat(Graphics::PixelFormat::createFormatRGBA32());
 	g_driver->createSpecialtyTexture(index, (const uint8 *)screenshot->getData(0).getPixels(), width, height);
 	delete screenshot;
 	delete[] data;

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -1088,11 +1088,7 @@ void GfxOpenGL::createBitmap(BitmapData *bitmap) {
 		glPixelStorei(GL_UNPACK_ROW_LENGTH, bitmap->_width);
 
 		const Graphics::PixelFormat format_16bpp(2, 5, 6, 5, 0, 11, 5, 0, 0);
-#ifdef SCUMM_BIG_ENDIAN
-		const Graphics::PixelFormat format_32bpp(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-		const Graphics::PixelFormat format_32bpp(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+		const Graphics::PixelFormat format_32bpp = Graphics::PixelFormat::createFormatRGBA32();
 
 		for (int pic = 0; pic < bitmap->_numImages; pic++) {
 			const Graphics::Surface &imageData = bitmap->getImageData(pic);
@@ -1679,11 +1675,7 @@ void GfxOpenGL::drawDepthBitmap(int x, int y, int w, int h, const char *data) {
 }
 
 const Graphics::PixelFormat GfxOpenGL::getMovieFormat() const {
-#ifdef SCUMM_BIG_ENDIAN
-	return Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-	return Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+	return Graphics::PixelFormat::createFormatRGBA32();
 }
 
 void GfxOpenGL::prepareMovieFrame(Graphics::Surface *frame) {
@@ -1871,11 +1863,7 @@ void GfxOpenGL::drawEmergString(int x, int y, const char *text, const Color &fgC
 
 Bitmap *GfxOpenGL::getScreenshot(int w, int h, bool useStored) {
 	Graphics::Surface src;
-#ifdef SCUMM_BIG_ENDIAN
-	src.create(_screenWidth, _screenHeight, Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
-#else
-	src.create(_screenWidth, _screenHeight, Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
-#endif
+	src.create(_screenWidth, _screenHeight, Graphics::PixelFormat::createFormatRGBA32());
 	if (useStored) {
 		memcpy(src.getPixels(), _storedDisplay, _screenWidth * _screenHeight * 4);
 	} else {

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -1360,11 +1360,7 @@ void GfxOpenGLS::createBitmap(BitmapData *bitmap) {
 		glPixelStorei(GL_UNPACK_ALIGNMENT, bytes);
 
 		const Graphics::PixelFormat format_16bpp(2, 5, 6, 5, 0, 11, 5, 0, 0);
-#ifdef SCUMM_BIG_ENDIAN
-		const Graphics::PixelFormat format_32bpp(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-		const Graphics::PixelFormat format_32bpp(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+		const Graphics::PixelFormat format_32bpp = Graphics::PixelFormat::createFormatRGBA32();
 
 		for (int pic = 0; pic < bitmap->_numImages; pic++) {
 			const Graphics::Surface &imageData = bitmap->getImageData(pic);
@@ -2001,11 +1997,7 @@ void GfxOpenGLS::drawPolygon(const PrimitiveObject *primitive) {
 }
 
 const Graphics::PixelFormat GfxOpenGLS::getMovieFormat() const {
-#ifdef SCUMM_BIG_ENDIAN
-	return Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-	return Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+	return Graphics::PixelFormat::createFormatRGBA32();
 }
 
 void GfxOpenGLS::prepareMovieFrame(Graphics::Surface* frame) {
@@ -2224,11 +2216,7 @@ static void readPixels(int x, int y, int width, int height, byte *buffer) {
 
 Bitmap *GfxOpenGLS::getScreenshot(int w, int h, bool useStored) {
 	Graphics::Surface src;
-#ifdef SCUMM_BIG_ENDIAN
-	src.create(_screenWidth, _screenHeight, Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
-#else
-	src.create(_screenWidth, _screenHeight, Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
-#endif
+	src.create(_screenWidth, _screenHeight, Graphics::PixelFormat::createFormatRGBA32());
 	Bitmap *bmp;
 
 	if (useStored) {

--- a/engines/grim/material.cpp
+++ b/engines/grim/material.cpp
@@ -50,11 +50,10 @@ MaterialData::MaterialData(const Common::String &filename, Common::SeekableReadS
 }
 
 static void loadImage(Image::ImageDecoder *decoder, Texture *t) {
+	const Graphics::PixelFormat format_3bpp = Graphics::PixelFormat::createFormatRGB24();
 #ifdef SCUMM_BIG_ENDIAN
-	const Graphics::PixelFormat format_3bpp(3, 8, 8, 8, 0, 16, 8,  0, 0);
 	const Graphics::PixelFormat format_4bpp(4, 8, 8, 8, 8, 24, 16, 8, 0);
 #else
-	const Graphics::PixelFormat format_3bpp(3, 8, 8, 8, 0, 0, 8, 16, 0);
 	const Graphics::PixelFormat format_4bpp(4, 8, 8, 8, 8, 0, 8, 16, 24);
 #endif
 

--- a/engines/grim/material.cpp
+++ b/engines/grim/material.cpp
@@ -51,11 +51,7 @@ MaterialData::MaterialData(const Common::String &filename, Common::SeekableReadS
 
 static void loadImage(Image::ImageDecoder *decoder, Texture *t) {
 	const Graphics::PixelFormat format_3bpp = Graphics::PixelFormat::createFormatRGB24();
-#ifdef SCUMM_BIG_ENDIAN
-	const Graphics::PixelFormat format_4bpp(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-	const Graphics::PixelFormat format_4bpp(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+	const Graphics::PixelFormat format_4bpp = Graphics::PixelFormat::createFormatRGBA32();
 
 	const Graphics::Surface *surface = decoder->getSurface();
 

--- a/engines/hpl1/engine/graphics/bitmap2D.cpp
+++ b/engines/hpl1/engine/graphics/bitmap2D.cpp
@@ -41,11 +41,7 @@ static Image::ImageDecoder *loadImage(const tString &filepath, Image::ImageDecod
 }
 
 Image::JPEGDecoder *setupJPEGDecoder(Image::JPEGDecoder *jpeg) {
-#ifdef SCUMM_BIG_ENDIAN
-	jpeg->setOutputPixelFormat(Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
-#else
-	jpeg->setOutputPixelFormat(Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
-#endif
+	jpeg->setOutputPixelFormat(Graphics::PixelFormat::createFormatRGBA32());
 	return jpeg;
 }
 

--- a/engines/hpl1/engine/impl/LowLevelGraphicsSDL.cpp
+++ b/engines/hpl1/engine/impl/LowLevelGraphicsSDL.cpp
@@ -96,11 +96,7 @@ cLowLevelGraphicsSDL::cLowLevelGraphicsSDL() {
 	mvVirtualSize.y = 600;
 	mfGammaCorrection = 1.0;
 	mpRenderTarget = nullptr;
-#ifdef SCUMM_BIG_ENDIAN
-	mpPixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-	mpPixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+	mpPixelFormat = Graphics::PixelFormat::createFormatRGBA32();
 
 	Common::fill(mpCurrentTexture, mpCurrentTexture + MAX_TEXTUREUNITS, nullptr);
 

--- a/engines/hpl1/engine/impl/low_level_graphics_tgl.cpp
+++ b/engines/hpl1/engine/impl/low_level_graphics_tgl.cpp
@@ -312,11 +312,7 @@ LowLevelGraphicsTGL::LowLevelGraphicsTGL() {
 	mvVirtualSize.y = 600;
 	mfGammaCorrection = 1.0;
 	mpRenderTarget = nullptr;
-#ifdef SCUMM_BIG_ENDIAN
-	mpPixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-	mpPixelFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+	mpPixelFormat = Graphics::PixelFormat::createFormatRGBA32();
 
 	Common::fill(mpCurrentTexture, mpCurrentTexture + MAX_TEXTUREUNITS, nullptr);
 

--- a/engines/hpl1/opengl.cpp
+++ b/engines/hpl1/opengl.cpp
@@ -54,11 +54,7 @@ static Common::Rect getGLViewport() {
 }
 
 static Graphics::PixelFormat getRGBAPixelFormat() {
-#ifdef SCUMM_BIG_ENDIAN
-	return Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-	return Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+	return Graphics::PixelFormat::createFormatRGBA32();
 }
 
 Common::ScopedPtr<Graphics::Surface> createGLViewportScreenshot() {

--- a/engines/myst3/gfx.cpp
+++ b/engines/myst3/gfx.cpp
@@ -300,11 +300,7 @@ Common::Point Window::scalePoint(const Common::Point &screen) const {
 }
 
 const Graphics::PixelFormat Texture::getRGBAPixelFormat() {
-#ifdef SCUMM_BIG_ENDIAN
-	return Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-	return Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+	return Graphics::PixelFormat::createFormatRGBA32();
 }
 
 } // End of namespace Myst3

--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -1423,11 +1423,7 @@ Graphics::Surface *Myst3Engine::loadTexture(uint16 id) {
 	data->readUint32LE(); // unk 2
 	data->readUint32LE(); // unk 3
 
-#ifdef SCUMM_BIG_ENDIAN
-	Graphics::PixelFormat onDiskFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24);
-#else
-	Graphics::PixelFormat onDiskFormat = Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0);
-#endif
+	Graphics::PixelFormat onDiskFormat = Graphics::PixelFormat::createFormatARGB32();
 
 	Graphics::Surface *s = new Graphics::Surface();
 	s->create(width, height, onDiskFormat);

--- a/engines/myst3/state.cpp
+++ b/engines/myst3/state.cpp
@@ -479,11 +479,7 @@ Common::Error GameState::StateData::syncWithSaveGame(Common::Serializer &s) {
 }
 
 const Graphics::PixelFormat GameState::getThumbnailSavePixelFormat() {
-#ifdef SCUMM_BIG_ENDIAN
-	return Graphics::PixelFormat(4, 8, 8, 8, 0, 8, 16, 24, 0);
-#else
-	return Graphics::PixelFormat(4, 8, 8, 8, 0, 16, 8, 0, 24);
-#endif
+	return Graphics::PixelFormat::createFormatBGRA32(false);
 }
 
 Graphics::Surface *GameState::readThumbnail(Common::ReadStream *inStream) {

--- a/engines/playground3d/playground3d.cpp
+++ b/engines/playground3d/playground3d.cpp
@@ -56,11 +56,7 @@ bool Playground3dEngine::hasFeature(EngineFeature f) const {
 }
 
 void Playground3dEngine::genTextures() {
-#if defined(SCUMM_LITTLE_ENDIAN)
-	Graphics::PixelFormat pixelFormatRGBA(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#else
-	Graphics::PixelFormat pixelFormatRGBA(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#endif
+	Graphics::PixelFormat pixelFormatRGBA = Graphics::PixelFormat::createFormatRGBA32();
 	Graphics::PixelFormat pixelFormatRGB = Graphics::PixelFormat::createFormatRGB24();
 	Graphics::PixelFormat pixelFormatRGB565(2, 5, 6, 5, 0, 11, 5, 0, 0);
 	Graphics::PixelFormat pixelFormatRGB5551(2, 5, 5, 5, 1, 11, 6, 1, 0);

--- a/engines/playground3d/playground3d.cpp
+++ b/engines/playground3d/playground3d.cpp
@@ -58,11 +58,10 @@ bool Playground3dEngine::hasFeature(EngineFeature f) const {
 void Playground3dEngine::genTextures() {
 #if defined(SCUMM_LITTLE_ENDIAN)
 	Graphics::PixelFormat pixelFormatRGBA(4, 8, 8, 8, 8, 0, 8, 16, 24);
-	Graphics::PixelFormat pixelFormatRGB(3, 8, 8, 8, 0, 0, 8, 16, 0);
 #else
 	Graphics::PixelFormat pixelFormatRGBA(4, 8, 8, 8, 8, 24, 16, 8, 0);
-	Graphics::PixelFormat pixelFormatRGB(3, 8, 8, 8, 0, 16, 8, 0, 0);
 #endif
+	Graphics::PixelFormat pixelFormatRGB = Graphics::PixelFormat::createFormatRGB24();
 	Graphics::PixelFormat pixelFormatRGB565(2, 5, 6, 5, 0, 11, 5, 0, 0);
 	Graphics::PixelFormat pixelFormatRGB5551(2, 5, 5, 5, 1, 11, 6, 1, 0);
 	Graphics::PixelFormat pixelFormatRGB4444(2, 4, 4, 4, 4, 12, 8, 4, 0);

--- a/engines/stark/formats/dds.cpp
+++ b/engines/stark/formats/dds.cpp
@@ -169,11 +169,7 @@ bool DDS::detectFormat(const DDSPixelFormat &format) {
 	           (format.bitCount == 32) &&
 	           (format.rBitMask == 0x00FF0000) && (format.gBitMask == 0x0000FF00) &&
 	           (format.bBitMask == 0x000000FF) && (format.aBitMask == 0xFF000000)) {
-#ifdef SCUMM_BIG_ENDIAN
-		_format = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 0, 8, 16);
-#else
-		_format = Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24);
-#endif
+		_format = Graphics::PixelFormat::createFormatBGRA32();
 		return true;
 	} else if (!(format.flags & kPixelFlagsHasAlpha) &&
 	           (format.bitCount == 24) &&

--- a/engines/stark/formats/dds.cpp
+++ b/engines/stark/formats/dds.cpp
@@ -179,11 +179,7 @@ bool DDS::detectFormat(const DDSPixelFormat &format) {
 	           (format.bitCount == 24) &&
 	           (format.rBitMask == 0x00FF0000) && (format.gBitMask == 0x0000FF00) &&
 	           (format.bBitMask == 0x000000FF)) {
-#ifdef SCUMM_BIG_ENDIAN
-		_format = Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0);
-#else
-		_format = Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0);
-#endif
+		_format = Graphics::PixelFormat::createFormatBGR24();
 		return true;
 	} else {
 		warning("Unsupported pixel format (%X, %X, %d, %X, %X, %X, %X) for %s",

--- a/engines/stark/gfx/driver.cpp
+++ b/engines/stark/gfx/driver.cpp
@@ -83,11 +83,7 @@ Driver *Driver::create() {
 }
 
 const Graphics::PixelFormat Driver::getRGBAPixelFormat() {
-#ifdef SCUMM_BIG_ENDIAN
-	return Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-	return Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+	return Graphics::PixelFormat::createFormatRGBA32();
 }
 
 bool Driver::computeScreenViewport() {

--- a/engines/ultima/ultima4/gfx/imageloader.cpp
+++ b/engines/ultima/ultima4/gfx/imageloader.cpp
@@ -96,13 +96,8 @@ Graphics::PixelFormat U4ImageDecoder::getPixelFormatForBpp() const {
 		return Graphics::PixelFormat::createFormatCLUT8();
 	case 24:
 		return Graphics::PixelFormat::createFormatRGB24();
-#ifdef SCUMM_LITTLE_ENDIAN
 	case 32:
-		return Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#else
-	case 32:
-		return Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#endif
+		return Graphics::PixelFormat::createFormatRGBA32();
 	default:
 		error("invalid bits-per-pixel (bpp): %d", _bpp);
 	}

--- a/engines/ultima/ultima4/gfx/imageloader.cpp
+++ b/engines/ultima/ultima4/gfx/imageloader.cpp
@@ -94,14 +94,12 @@ Graphics::PixelFormat U4ImageDecoder::getPixelFormatForBpp() const {
 	case 4:
 	case 8:
 		return Graphics::PixelFormat::createFormatCLUT8();
-#ifdef SCUMM_LITTLE_ENDIAN
 	case 24:
-		return Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0);
+		return Graphics::PixelFormat::createFormatRGB24();
+#ifdef SCUMM_LITTLE_ENDIAN
 	case 32:
 		return Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
 #else
-	case 24:
-		return Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0);
 	case 32:
 		return Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
 #endif

--- a/engines/wintermute/base/gfx/base_renderer3d.cpp
+++ b/engines/wintermute/base/gfx/base_renderer3d.cpp
@@ -132,11 +132,7 @@ DXViewport BaseRenderer3D::getViewPort() {
 }
 
 Graphics::PixelFormat BaseRenderer3D::getPixelFormat() const {
-#ifdef SCUMM_BIG_ENDIAN
-	return Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-	return Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+	return Graphics::PixelFormat::createFormatRGBA32();
 }
 
 bool BaseRenderer3D::flip() {

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
@@ -636,11 +636,7 @@ void BaseRenderOpenGL3D::fadeToColor(byte r, byte g, byte b, byte a) {
 BaseImage *BaseRenderOpenGL3D::takeScreenshot(int newWidth, int newHeight) {
 	BaseImage *screenshot = new BaseImage();
 	Graphics::Surface *surface = new Graphics::Surface();
-#ifdef SCUMM_BIG_ENDIAN
-	Graphics::PixelFormat format(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-	Graphics::PixelFormat format(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+	Graphics::PixelFormat format = Graphics::PixelFormat::createFormatRGBA32();
 	surface->create(_viewportRect.width(), _viewportRect.height(), format);
 
 	glReadPixels(_viewportRect.left, _viewportRect.height() - _viewportRect.bottom,

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
@@ -734,11 +734,7 @@ void BaseRenderOpenGL3DShader::fadeToColor(byte r, byte g, byte b, byte a) {
 BaseImage *BaseRenderOpenGL3DShader::takeScreenshot(int newWidth, int newHeight) {
 	BaseImage *screenshot = new BaseImage();
 	Graphics::Surface *surface = new Graphics::Surface();
-#ifdef SCUMM_BIG_ENDIAN
-	Graphics::PixelFormat format(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-	Graphics::PixelFormat format(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+	Graphics::PixelFormat format = Graphics::PixelFormat::createFormatRGBA32();
 	surface->create(_viewportRect.width(), _viewportRect.height(), format);
 
 	glReadPixels(_viewportRect.left, _viewportRect.height() - _viewportRect.bottom,

--- a/engines/wintermute/base/gfx/opengl/base_surface_opengl3d.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_surface_opengl3d.cpp
@@ -155,11 +155,7 @@ bool BaseSurfaceOpenGL3D::create(const Common::String &filename, bool defaultCK,
 		_imageData = nullptr;
 	}
 
-#ifdef SCUMM_BIG_ENDIAN
-	_imageData = img.getSurface()->convertTo(Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0), img.getPalette(), img.getPaletteCount());
-#else
-	_imageData = img.getSurface()->convertTo(Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24), img.getPalette(), img.getPaletteCount());
-#endif
+	_imageData = img.getSurface()->convertTo(Graphics::PixelFormat::createFormatRGBA32(), img.getPalette(), img.getPaletteCount());
 
 	if (_filename.matchString("savegame:*g", true)) {
 		uint8 r, g, b, a;
@@ -338,11 +334,7 @@ bool BaseSurfaceOpenGL3D::setAlphaImage(const Common::String &filename) {
 
 	Graphics::AlphaType type = alphaImage->getSurface()->detectAlpha();
 	if (type != Graphics::ALPHA_OPAQUE) {
-#ifdef SCUMM_BIG_ENDIAN
-		_maskData = alphaImage->getSurface()->convertTo(Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
-#else
-		_maskData = alphaImage->getSurface()->convertTo(Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
-#endif
+		_maskData = alphaImage->getSurface()->convertTo(Graphics::PixelFormat::createFormatRGBA32());
 	}
 
 	delete alphaImage;

--- a/graphics/opengl/texture.h
+++ b/graphics/opengl/texture.h
@@ -163,11 +163,7 @@ public:
 	GLuint getGLTexture() const { return _glTexture; }
 
 	static inline const Graphics::PixelFormat getRGBPixelFormat() {
-#ifdef SCUMM_BIG_ENDIAN
-		return Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0);
-#else
-		return Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0);
-#endif
+		return Graphics::PixelFormat::createFormatRGB24();
 	}
 
 	static inline const Graphics::PixelFormat getRGBAPixelFormat() {

--- a/graphics/opengl/texture.h
+++ b/graphics/opengl/texture.h
@@ -167,19 +167,11 @@ public:
 	}
 
 	static inline const Graphics::PixelFormat getRGBAPixelFormat() {
-#ifdef SCUMM_BIG_ENDIAN
-		return Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#else
-		return Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#endif
+		return Graphics::PixelFormat::createFormatRGBA32();
 	}
 
 	static inline const Graphics::PixelFormat getBGRAPixelFormat() {
-#ifdef SCUMM_BIG_ENDIAN
-		return Graphics::PixelFormat(4, 8, 8, 8, 8, 8, 16, 24, 0);
-#else
-		return Graphics::PixelFormat(4, 8, 8, 8, 8, 16, 8, 0, 24);
-#endif
+		return Graphics::PixelFormat::createFormatBGRA32();
 	}
 
 protected:

--- a/graphics/pixelformat.h
+++ b/graphics/pixelformat.h
@@ -203,6 +203,42 @@ struct PixelFormat {
 #endif
 	}
 
+	/** Define an endian-aware RGBA32 pixel format. */
+	static inline PixelFormat createFormatRGBA32(bool alpha = true) {
+#ifdef SCUMM_BIG_ENDIAN
+		return Graphics::PixelFormat(4, 8, 8, 8, alpha ? 8 : 0, 24, 16, 8, 0);
+#else
+		return Graphics::PixelFormat(4, 8, 8, 8, alpha ? 8 : 0, 0, 8, 16, 24);
+#endif
+	}
+
+	/** Define an endian-aware BGRA32 pixel format. */
+	static inline PixelFormat createFormatBGRA32(bool alpha = true) {
+#ifdef SCUMM_BIG_ENDIAN
+		return Graphics::PixelFormat(4, 8, 8, 8, alpha ? 8 : 0, 8, 16, 24, 0);
+#else
+		return Graphics::PixelFormat(4, 8, 8, 8, alpha ? 8 : 0, 16, 8, 0, 24);
+#endif
+	}
+
+	/** Define an endian-aware ABGR32 pixel format. */
+	static inline PixelFormat createFormatABGR32(bool alpha = true) {
+#ifdef SCUMM_BIG_ENDIAN
+		return Graphics::PixelFormat(4, 8, 8, 8, alpha ? 8 : 0, 0, 8, 16, 24);
+#else
+		return Graphics::PixelFormat(4, 8, 8, 8, alpha ? 8 : 0, 24, 16, 8, 0);
+#endif
+	}
+
+	/** Define an endian-aware ARGB32 pixel format. */
+	static inline PixelFormat createFormatARGB32(bool alpha = true) {
+#ifdef SCUMM_BIG_ENDIAN
+		return Graphics::PixelFormat(4, 8, 8, 8, alpha ? 8 : 0, 16, 8, 0, 24);
+#else
+		return Graphics::PixelFormat(4, 8, 8, 8, alpha ? 8 : 0, 8, 16, 24, 0);
+#endif
+	}
+
 	/** Check if two pixel formats are the same */
 	inline bool operator==(const PixelFormat &fmt) const {
 		return bytesPerPixel == fmt.bytesPerPixel &&

--- a/graphics/pixelformat.h
+++ b/graphics/pixelformat.h
@@ -185,6 +185,24 @@ struct PixelFormat {
 		return PixelFormat(1, 0, 0, 0, 0, 0, 0, 0, 0);
 	}
 
+	/** Define an endian-aware RGB24 pixel format. */
+	static inline PixelFormat createFormatRGB24() {
+#ifdef SCUMM_BIG_ENDIAN
+		return Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0);
+#else
+		return Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0);
+#endif
+	}
+
+	/** Define an endian-aware BGR24 pixel format. */
+	static inline PixelFormat createFormatBGR24() {
+#ifdef SCUMM_BIG_ENDIAN
+		return Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0);
+#else
+		return Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0);
+#endif
+	}
+
 	/** Check if two pixel formats are the same */
 	inline bool operator==(const PixelFormat &fmt) const {
 		return bytesPerPixel == fmt.bytesPerPixel &&

--- a/graphics/svg.cpp
+++ b/graphics/svg.cpp
@@ -29,11 +29,7 @@
 #define NANOSVGRAST_IMPLEMENTATION
 #include "graphics/nanosvg/nanosvgrast.h"
 
-#ifdef SCUMM_BIG_ENDIAN
-#define PIXELFORMAT Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0)
-#else
-#define PIXELFORMAT Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24)
-#endif
+#define PIXELFORMAT Graphics::PixelFormat::createFormatRGBA32()
 
 namespace Graphics {
 

--- a/graphics/tinygl/init.cpp
+++ b/graphics/tinygl/init.cpp
@@ -237,11 +237,7 @@ void GLContext::init(int screenW, int screenH, Graphics::PixelFormat pixelFormat
 	maxTextureName = 0;
 	texture_mag_filter = TGL_LINEAR;
 	texture_min_filter = TGL_NEAREST_MIPMAP_LINEAR;
-#if defined(SCUMM_LITTLE_ENDIAN)
-	colorAssociationList.push_back({Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24), TGL_RGBA, TGL_UNSIGNED_BYTE});
-#else
-	colorAssociationList.push_back({Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0), TGL_RGBA, TGL_UNSIGNED_BYTE});
-#endif
+	colorAssociationList.push_back({Graphics::PixelFormat::createFormatRGBA32(),        TGL_RGBA, TGL_UNSIGNED_BYTE});
 	colorAssociationList.push_back({Graphics::PixelFormat::createFormatRGB24(),         TGL_RGB,  TGL_UNSIGNED_BYTE});
 	colorAssociationList.push_back({Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0),  TGL_RGB,  TGL_UNSIGNED_SHORT_5_6_5});
 	colorAssociationList.push_back({Graphics::PixelFormat(2, 5, 5, 5, 1, 11, 6, 1, 0),  TGL_RGBA, TGL_UNSIGNED_SHORT_5_5_5_1});

--- a/graphics/tinygl/init.cpp
+++ b/graphics/tinygl/init.cpp
@@ -239,11 +239,10 @@ void GLContext::init(int screenW, int screenH, Graphics::PixelFormat pixelFormat
 	texture_min_filter = TGL_NEAREST_MIPMAP_LINEAR;
 #if defined(SCUMM_LITTLE_ENDIAN)
 	colorAssociationList.push_back({Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24), TGL_RGBA, TGL_UNSIGNED_BYTE});
-	colorAssociationList.push_back({Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0),  TGL_RGB,  TGL_UNSIGNED_BYTE});
 #else
 	colorAssociationList.push_back({Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0), TGL_RGBA, TGL_UNSIGNED_BYTE});
-	colorAssociationList.push_back({Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0),  TGL_RGB,  TGL_UNSIGNED_BYTE});
 #endif
+	colorAssociationList.push_back({Graphics::PixelFormat::createFormatRGB24(),         TGL_RGB,  TGL_UNSIGNED_BYTE});
 	colorAssociationList.push_back({Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0),  TGL_RGB,  TGL_UNSIGNED_SHORT_5_6_5});
 	colorAssociationList.push_back({Graphics::PixelFormat(2, 5, 5, 5, 1, 11, 6, 1, 0),  TGL_RGBA, TGL_UNSIGNED_SHORT_5_5_5_1});
 	colorAssociationList.push_back({Graphics::PixelFormat(2, 4, 4, 4, 4, 12, 8, 4, 0),  TGL_RGBA, TGL_UNSIGNED_SHORT_4_4_4_4});

--- a/image/bmp.cpp
+++ b/image/bmp.cpp
@@ -148,11 +148,7 @@ bool BitmapDecoder::loadStream(Common::SeekableReadStream &stream) {
 }
 
 bool writeBMP(Common::WriteStream &out, const Graphics::Surface &input, const byte *palette) {
-#ifdef SCUMM_LITTLE_ENDIAN
-	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 16, 8, 0, 0);
-#else
-	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 0, 8, 16, 0);
-#endif
+	const Graphics::PixelFormat requiredFormat_3byte = Graphics::PixelFormat::createFormatBGR24();
 
 	Graphics::Surface *tmp = NULL;
 	const Graphics::Surface *surface;

--- a/image/codecs/bmp_raw.cpp
+++ b/image/codecs/bmp_raw.cpp
@@ -129,14 +129,12 @@ Graphics::PixelFormat BitmapRawDecoder::getPixelFormat() const {
 		return Graphics::PixelFormat::createFormatCLUT8();
 	case 16:
 		return Graphics::PixelFormat(2, 5, 5, 5, 0, 10, 5, 0, 0);
-#ifdef SCUMM_LITTLE_ENDIAN
 	case 24:
-		return Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0);
+		return Graphics::PixelFormat::createFormatBGR24();
+#ifdef SCUMM_LITTLE_ENDIAN
 	case 32:
 		return Graphics::PixelFormat(4, 8, 8, 8, _ignoreAlpha ? 0 : 8, 16, 8, 0, 24);
 #else
-	case 24:
-		return Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0);
 	case 32:
 		return Graphics::PixelFormat(4, 8, 8, 8, _ignoreAlpha ? 0 : 8, 8, 16, 24, 0);
 #endif

--- a/image/codecs/bmp_raw.cpp
+++ b/image/codecs/bmp_raw.cpp
@@ -131,13 +131,8 @@ Graphics::PixelFormat BitmapRawDecoder::getPixelFormat() const {
 		return Graphics::PixelFormat(2, 5, 5, 5, 0, 10, 5, 0, 0);
 	case 24:
 		return Graphics::PixelFormat::createFormatBGR24();
-#ifdef SCUMM_LITTLE_ENDIAN
 	case 32:
-		return Graphics::PixelFormat(4, 8, 8, 8, _ignoreAlpha ? 0 : 8, 16, 8, 0, 24);
-#else
-	case 32:
-		return Graphics::PixelFormat(4, 8, 8, 8, _ignoreAlpha ? 0 : 8, 8, 16, 24, 0);
-#endif
+		return Graphics::PixelFormat::createFormatBGRA32(!_ignoreAlpha);
 	default:
 		break;
 	}

--- a/image/jpeg.cpp
+++ b/image/jpeg.cpp
@@ -57,11 +57,7 @@ JPEGDecoder::~JPEGDecoder() {
 }
 
 Graphics::PixelFormat JPEGDecoder::getByteOrderRgbPixelFormat() const {
-#ifdef SCUMM_BIG_ENDIAN
-	return Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0);
-#else
-	return Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0);
-#endif
+	return Graphics::PixelFormat::createFormatRGB24();
 }
 
 const Graphics::Surface *JPEGDecoder::getSurface() const {

--- a/image/png.cpp
+++ b/image/png.cpp
@@ -299,11 +299,10 @@ bool PNGDecoder::loadStream(Common::SeekableReadStream &stream) {
 
 bool writePNG(Common::WriteStream &out, const Graphics::Surface &input, const byte *palette) {
 #ifdef USE_PNG
+	const Graphics::PixelFormat requiredFormat_3byte = Graphics::PixelFormat::createFormatRGB24();
 #ifdef SCUMM_LITTLE_ENDIAN
-	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 0, 8, 16, 0);
 	const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 0, 8, 16, 24);
 #else
-	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 16, 8, 0, 0);
 	const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 24, 16, 8, 0);
 #endif
 

--- a/image/png.cpp
+++ b/image/png.cpp
@@ -63,11 +63,7 @@ void PNGDecoder::destroy() {
 }
 
 Graphics::PixelFormat PNGDecoder::getByteOrderRgbaPixelFormat(bool isAlpha) const {
-#ifdef SCUMM_BIG_ENDIAN
-	return Graphics::PixelFormat(4, 8, 8, 8, isAlpha ? 8 : 0, 24, 16, 8, 0);
-#else
-	return Graphics::PixelFormat(4, 8, 8, 8, isAlpha ? 8 : 0, 0, 8, 16, 24);
-#endif
+	return Graphics::PixelFormat::createFormatRGBA32(isAlpha);
 }
 
 #ifdef USE_PNG
@@ -300,11 +296,7 @@ bool PNGDecoder::loadStream(Common::SeekableReadStream &stream) {
 bool writePNG(Common::WriteStream &out, const Graphics::Surface &input, const byte *palette) {
 #ifdef USE_PNG
 	const Graphics::PixelFormat requiredFormat_3byte = Graphics::PixelFormat::createFormatRGB24();
-#ifdef SCUMM_LITTLE_ENDIAN
-	const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 0, 8, 16, 24);
-#else
-	const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 24, 16, 8, 0);
-#endif
+	const Graphics::PixelFormat requiredFormat_4byte = Graphics::PixelFormat::createFormatRGBA32();
 
 	int colorType;
 	Graphics::Surface *tmp = NULL;

--- a/test/image/blending.h
+++ b/test/image/blending.h
@@ -749,11 +749,7 @@ OldTransparentSurface *OldTransparentSurface::scale(int16 newWidth, int16 newHei
 static int save_bitmap(const char *path, const Graphics::ManagedSurface *surf) {
 	Common::FSNode fileNode(path);
 	Common::SeekableWriteStream *out = fileNode.createWriteStream();
-#ifdef SCUMM_LITTLE_ENDIAN
-	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 16, 8, 0, 0);
-#else
-	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 0, 8, 16, 0);
-#endif
+	const Graphics::PixelFormat requiredFormat_3byte = Graphics::PixelFormat::createFormatBGR24();
 	Graphics::ManagedSurface surface(surf->w, surf->h, requiredFormat_3byte);
 
 	// Copy from the source surface without alpha transparency


### PR DESCRIPTION
These are normally used by OpenGL and TinyGL, as well as when loading and saving image files with minimal conversion.