### PR TITLE
LASTEXPRESS: Add InstallShield archive reader

### DIFF
--- a/engines/lastexpress/detection.cpp
+++ b/engines/lastexpress/detection.cpp
@@ -102,6 +102,23 @@ static const ADGameDescription gameDescriptions[] = {
 		GUIO2(GUIO_NOASPECT, GUIO_NOMIDI)
 	},
 
+	{
+		"lastexpress",
+		"Interplay Release",
+		{
+			{"CD1.HPF", 0, "8c86db47304033fcff32c69fddd5a920", 525522944},
+			{"CD2.HPF", 0, "58aa26e782d10ec5d2231e539d2fe6a2", 669581312},
+			{"CD3.HPF", 0, "00554fbf78a2ad391d98578fbbbe1c48", 641128448},
+			{"data1.cab", 0, "895ba6eec49346245e468553ba7a64fb", 42775756},
+			{"is:data1.cab:HD.HPF", 0, "A:bcc32d977f92bb52c060a0b4e8589cac", 30715904},
+			AD_LISTEND
+		},
+		Common::EN_ANY,
+		Common::kPlatformUnknown,
+		ADGF_TESTING | GF_COMPRESSED,
+		GUIO2(GUIO_NOASPECT, GUIO_NOMIDI)
+	},
+
 	// The Last Express (Demo - English) - Broderbund
 	//   expressw.exe 1997-08-14 14:09:42
 	//   express.exe  1997-08-14 14:19:34

--- a/engines/lastexpress/lastexpress.cpp
+++ b/engines/lastexpress/lastexpress.cpp
@@ -38,6 +38,7 @@
 #include "common/error.h"
 #include "common/fs.h"
 #include "common/timer.h"
+#include "common/compression/installshield_cab.h"
 
 #include "engines/util.h"
 #include "engines/advancedDetector.h"
@@ -136,6 +137,14 @@ void LastExpressEngine::soundTimerHandler(void *refCon) {
 }
 
 Common::Error LastExpressEngine::run() {
+	// Allow HD.HPF to be read directly from the InstallShield archive
+	if (isCompressed()) {
+		Common::Archive *cabinet = Common::makeInstallShieldArchive("data");
+		if (cabinet) {
+			SearchMan.add("data1.cab", cabinet);
+		}
+	}
+
 	// Initialize the graphics
 	const Graphics::PixelFormat dataPixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0);
 	initGraphics(640, 480, &dataPixelFormat);

--- a/engines/lastexpress/lastexpress.h
+++ b/engines/lastexpress/lastexpress.h
@@ -94,6 +94,10 @@ class VCR;
 
 struct Extent;
 
+enum {
+	GF_COMPRESSED = 1 << 0
+};
+
 typedef struct Item {
 	uint8 mnum;
 	uint16 closeUp;
@@ -551,6 +555,7 @@ public:
 
 	bool isDemo() const;
 	bool isGoldEdition() const;
+	bool isCompressed() const;
 
 	Common::String getTargetName() const;
 

--- a/engines/lastexpress/metaengine.cpp
+++ b/engines/lastexpress/metaengine.cpp
@@ -50,6 +50,10 @@ bool LastExpressEngine::isGoldEdition() const {
 	return (Common::String(_gameDescription->extra) == "Gold Edition");
 }
 
+bool LastExpressEngine::isCompressed() const {
+	return (bool)(_gameDescription->flags & GF_COMPRESSED);
+}
+
 bool LastExpressMetaEngine::hasFeature(MetaEngineFeature f) const {
 	return f == kSupportsListSaves
 	    || f == kSupportsDeleteSave;


### PR DESCRIPTION
The Interplay release of the game - my copy, at least - puts HD.HPF in an InstallShield archive. This pull request adapts some code from the Nancy engine to allow the game to be played without unpacking that. Instead of HD.HPF, copy the data1.cab and data1.hdr files instead.

I've only played the very beginning of the game, but didn't notice any problems that far at least.

It does print a "WARNING: File::open: node does not exist!" but as far as I can tell that's harmless.