### PR TITLE
ENGINES: Make more use of endian-safe pixel formats

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -3326,13 +3326,13 @@ int SurfaceSdlGraphicsManager::SDL_SetColorKey(SDL_Surface *surface, Uint32 flag
 void *SurfaceSdlGraphicsManager::getImGuiTexture(const Graphics::Surface &image, const byte *palette, int palCount) {
 
 	// Upload pixels into texture
-	SDL_Texture *texture = SDL_CreateTexture(_renderer, SDL_PIXELFORMAT_ABGR8888, SDL_TEXTUREACCESS_STATIC, image.w, image.h);
+	SDL_Texture *texture = SDL_CreateTexture(_renderer, SDL_PIXELFORMAT_RGBA32, SDL_TEXTUREACCESS_STATIC, image.w, image.h);
 	if (texture == nullptr) {
 		error("getImGuiTexture: errror creating tetxure: %s", SDL_GetError());
 		return nullptr;
 	}
 
-	Graphics::Surface *s = image.convertTo(Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24), palette, palCount);
+	Graphics::Surface *s = image.convertTo(Graphics::PixelFormat::createFormatRGBA32(), palette, palCount);
 	SDL_UpdateTexture(texture, nullptr, s->getPixels(), s->pitch);
 	SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
 #ifdef USE_IMGUI_SDLRENDERER3

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -1425,7 +1425,7 @@ void Score::screenShot() {
 #else
 
 	Graphics::Surface rawSurface = _window->getSurface()->rawSurface();
-	const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 0, 8, 16, 24);
+	const Graphics::PixelFormat requiredFormat_4byte = Graphics::PixelFormat::createFormatRGBA32();
 	Graphics::Surface *newSurface = rawSurface.convertTo(requiredFormat_4byte, _vm->getPalette());
 
 	Common::String currentPath = _vm->getCurrentPath().c_str();

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -1417,6 +1417,10 @@ void GfxOpenGL::createTextObject(TextObject *text) {
 	//error("Could not get font userdata");
 	const Font *font = text->getFont();
 
+	const Graphics::PixelFormat format = Graphics::PixelFormat::createFormatRGBA32();
+	const uint32 blackColor = format.RGBToColor(0, 0, 0);
+	const uint32 whiteColor = format.RGBToColor(0xff, 0xff, 0xff);
+
 	if (font->is8Bit())
 		return;
 
@@ -1427,8 +1431,8 @@ void GfxOpenGL::createTextObject(TextObject *text) {
 	for (int i = 0; i < numLines; i++) {
 		Graphics::Surface surface;
 
-		font->render(surface, text->getLines()[i], Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24),
-			     0xFF000000, 0xFFFFFFFF, 0x00000000);
+		font->render(surface, text->getLines()[i], format,
+			     blackColor, whiteColor, 0);
 
 		byte *bitmap = (byte *)surface.getPixels();
 

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -908,7 +908,7 @@ void GfxTinyGL::createBitmap(BitmapData *bitmap) {
 	if (bitmap->_format != 1) {
 		for (int pic = 0; pic < bitmap->_numImages; pic++) {
 			Graphics::Surface buffer;
-			buffer.create(bitmap->_width, bitmap->_height, Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
+			buffer.create(bitmap->_width, bitmap->_height, Graphics::PixelFormat::createFormatRGBA32());
 			uint32 *buf = (uint32 *)buffer.getPixels();
 			const uint16 *bufPtr = (const uint16 *)(bitmap->getImageData(pic).getPixels());
 			for (int i = 0; i < (bitmap->_width * bitmap->_height); i++) {
@@ -1167,7 +1167,7 @@ void GfxTinyGL::releaseMovieFrame() {
 
 void GfxTinyGL::loadEmergFont() {
 	Graphics::Surface characterSurface;
-	Graphics::PixelFormat textureFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
+	Graphics::PixelFormat textureFormat = Graphics::PixelFormat::createFormatRGBA32();
 	characterSurface.create(8, 13, textureFormat);
 	uint32 color = textureFormat.ARGBToColor(255, 255, 255, 255);
 	uint32 colorTransparent = textureFormat.ARGBToColor(0, 255, 255, 255);

--- a/engines/tetraedge/game/characters_shadow_opengl.cpp
+++ b/engines/tetraedge/game/characters_shadow_opengl.cpp
@@ -64,7 +64,7 @@ void CharactersShadowOpenGL::createTextureInternal(InGameScene *scene) {
 
 #ifdef TETRAEDGE_DUMP_SHADOW_RENDER
 	Graphics::Surface tex;
-	tex.create(_texSize, _texSize, Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
+	tex.create(_texSize, _texSize, Graphics::PixelFormat::createFormatRGBA32());
 	glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, tex.getPixels());
 	Common::DumpFile dumpFile;
 	tex.flipVertical(Common::Rect(tex.w, tex.h));

--- a/engines/tetraedge/te/te_3d_texture.cpp
+++ b/engines/tetraedge/te/te_3d_texture.cpp
@@ -28,19 +28,13 @@
 
 namespace Tetraedge {
 
-Te3DTexture::Te3DTexture() : _createdTexture(false), _format(TeImage::INVALID),
+Te3DTexture::Te3DTexture() : _createdTexture(false),
 _loaded(false), _width(0), _height(0), _texHeight(0), _texWidth(0),
 _topBorder(0), _leftBorder(0), _rightBorder(0), _btmBorder(0),
 _flipY(false), _alphaOnly(false) {
 }
 
 Te3DTexture::~Te3DTexture() {
-}
-
-bool Te3DTexture::hasAlpha() const {
-	TeImage::Format format = getFormat();
-	return (format == TeImage::RGBA8 || format == 9
-			|| format == 0xb || format == 1 || format == 0);
 }
 
 /*static*/

--- a/engines/tetraedge/te/te_3d_texture.h
+++ b/engines/tetraedge/te/te_3d_texture.h
@@ -45,8 +45,7 @@ public:
 	virtual void destroy() = 0;
 	virtual void forceTexData(uint gltexture, uint xsize, uint ysize) = 0;
 
-	TeImage::Format getFormat() const { return _format; }
-	bool hasAlpha() const;
+	bool hasAlpha() const { return _hasAlpha; }
 
 	bool load(const TetraedgeFSNode &path);
 	virtual bool load(const TeImage &img) = 0;
@@ -71,11 +70,11 @@ public:
 protected:
 	uint _width;
 	uint _height;
-	TeImage::Format _format;
 	bool _createdTexture;
 	bool _loaded;
 	TeMatrix4x4 _matrix;
 
+	bool _hasAlpha;
 	bool _alphaOnly;
 
 	uint _texWidth;

--- a/engines/tetraedge/te/te_i_codec.h
+++ b/engines/tetraedge/te/te_i_codec.h
@@ -40,7 +40,7 @@ public:
 	virtual uint width() = 0;
 	virtual uint height() = 0;
 	virtual int nbFrames() = 0;
-	virtual TeImage::Format imageFormat() = 0;
+	virtual Graphics::PixelFormat pixelFormat() = 0;
 	virtual void setLeftBorderSize(uint val) = 0;
 	virtual uint leftBorderSize() = 0;
 	virtual void setRightBorderSize(uint val) = 0;

--- a/engines/tetraedge/te/te_i_font.cpp
+++ b/engines/tetraedge/te/te_i_font.cpp
@@ -40,7 +40,7 @@ TeIFont::GlyphData TeIFont::glyph(uint pxSize, uint charcode) {
 	Common::Rect bbox = font->getBoundingBox(charcode);
 	TeImage *img = new TeImage();
 	Common::SharedPtr<TePalette> nullpal;
-	img->createImg(bbox.width(), bbox.height(), nullpal, TeImage::RGBA8);
+	img->createImg(bbox.width(), bbox.height(), nullpal, Graphics::PixelFormat::createFormatRGBA32());
 	font->drawChar(img, charcode, 0, 0, 0xffffffff);
 	GlyphData retval;
 	retval._charcode = charcode;

--- a/engines/tetraedge/te/te_image.cpp
+++ b/engines/tetraedge/te/te_image.cpp
@@ -31,10 +31,10 @@
 
 namespace Tetraedge {
 
-TeImage::TeImage() : ManagedSurface(), _teFormat(INVALID) {
+TeImage::TeImage() : ManagedSurface() {
 }
 
-TeImage::TeImage(const TeImage &other) : ManagedSurface(), _teFormat(other._teFormat) {
+TeImage::TeImage(const TeImage &other) : ManagedSurface() {
 	copyFrom(other);
 	error("TODO: Implement TeImage::TeImage copy constructor");
 }
@@ -54,18 +54,9 @@ void TeImage::create() {
 }*/
 
 void TeImage::createImg(uint xsize, uint ysize, Common::SharedPtr<TePalette> &pal,
-			Format teformat, uint bufxsize, uint bufysize) {
-	_teFormat = teformat;
-#ifdef SCUMM_BIG_ENDIAN
-	Graphics::PixelFormat pxformat = ((teformat == TeImage::RGB8) ?
-									  Graphics::PixelFormat(3, 8, 8, 8, 0, 0, 8, 16, 0) : Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
-#else
-	Graphics::PixelFormat pxformat = ((teformat == TeImage::RGB8) ?
-									  Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0) : Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
-#endif
-
+			const Graphics::PixelFormat &pxformat, uint bufxsize, uint bufysize) {
 	Graphics::ManagedSurface::create(xsize, ysize, pxformat);
-	if (teformat == TeImage::RGBA8)
+	if (pxformat.aBits() > 0)
 		Graphics::ManagedSurface::fillRect(Common::Rect(0, 0, xsize, ysize), 0);
 }
 
@@ -75,7 +66,6 @@ void TeImage::deserialize(Common::ReadStream &stream) {
 
 void TeImage::destroy() {
 	Graphics::ManagedSurface::free();
-	_teFormat = INVALID;
 }
 
 void TeImage::drawPlot(void *outbuf, int x, int y, const TeVector2s32 &bufsize, const TeColor &col) {
@@ -111,7 +101,7 @@ bool TeImage::load(const TetraedgeFSNode &node) {
 	}
 
 	Common::SharedPtr<TePalette> nullpal;
-	createImg(codec->width(), codec->height(), nullpal, codec->imageFormat(), codec->width(), codec->height());
+	createImg(codec->width(), codec->height(), nullpal, codec->pixelFormat(), codec->width(), codec->height());
 
 	if (!codec->update(0, *this)) {
 		error("TeImage::load: Failed to update from %s.", node.toString().c_str());
@@ -130,7 +120,7 @@ bool TeImage::load(Common::SeekableReadStream &stream, const Common::String &typ
 	}
 
 	Common::SharedPtr<TePalette> nullpal;
-	createImg(codec->width(), codec->height(), nullpal, codec->imageFormat(), codec->width(), codec->height());
+	createImg(codec->width(), codec->height(), nullpal, codec->pixelFormat(), codec->width(), codec->height());
 
 	if (!codec->update(0, *this)) {
 		error("TeImage::load: Failed to update from stream");

--- a/engines/tetraedge/te/te_image.h
+++ b/engines/tetraedge/te/te_image.h
@@ -48,12 +48,6 @@ public:
 		destroy();
 	};
 
-	enum Format {
-		RGB8 = 5,
-		RGBA8 = 6,
-		// GREY8 = 0xd,
-		INVALID = 0xe
-	};
 	enum SaveType {
 		PNG
 	};
@@ -62,11 +56,11 @@ public:
 			  const TeVector2s32 &vec3) const;
 	uint64 countPixelsOfColor(const TeColor &col) const;
 	// void create(); // never used?
-	void createImg(uint xsize, uint ysize, Common::SharedPtr<TePalette> &palette, Format newformat) {
+	void createImg(uint xsize, uint ysize, Common::SharedPtr<TePalette> &palette, const Graphics::PixelFormat &newformat) {
 		createImg(xsize, ysize, palette, newformat, xsize, ysize);
 	}
 	void createImg(uint xsize, uint ysize, Common::SharedPtr<TePalette> &pal,
-				Format format, uint bufxsize, uint bufysize);
+				const Graphics::PixelFormat &format, uint bufxsize, uint bufysize);
 	void deserialize(Common::ReadStream &stream);
 	void destroy();
 	void drawPlot(int x, int y, const TeColor &col) {
@@ -84,10 +78,6 @@ public:
 	TeVector2s32 bufSize() const {
 		return TeVector2s32(pitch / format.bytesPerPixel, h);
 	}
-	Format teFormat() const { return _teFormat; }
-
-private:
-	Format _teFormat;
 };
 
 } // end namespace Tetraedge

--- a/engines/tetraedge/te/te_images_sequence.cpp
+++ b/engines/tetraedge/te/te_images_sequence.cpp
@@ -162,8 +162,8 @@ bool TeImagesSequence::isAtEnd() {
 	return _curFrame >= _files.size();
 }
 
-TeImage::Format TeImagesSequence::imageFormat() {
-	return TeImage::RGBA8;
+Graphics::PixelFormat TeImagesSequence::pixelFormat() {
+	return Graphics::PixelFormat::createFormatRGBA32();
 }
 
 } // end namespace Tetraedge

--- a/engines/tetraedge/te/te_images_sequence.h
+++ b/engines/tetraedge/te/te_images_sequence.h
@@ -49,7 +49,7 @@ public:
 	virtual uint bottomBorderSize() override { return 0; }
 	virtual void setTopBorderSize(uint val) override  { }
 	virtual uint topBorderSize() override { return 0; }
-	virtual TeImage::Format imageFormat() override;
+	virtual Graphics::PixelFormat pixelFormat() override;
 	virtual float frameRate() override { return _frameRate; }
 	virtual bool update(uint i, TeImage &imgout) override;
 	virtual bool isAtEnd() override;

--- a/engines/tetraedge/te/te_jpeg.cpp
+++ b/engines/tetraedge/te/te_jpeg.cpp
@@ -46,11 +46,11 @@ bool TeJpeg::load(Common::SeekableReadStream &stream) {
 		delete _loadedSurface;
 	_loadedSurface = nullptr;
 
-	jpg.setOutputPixelFormat(Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
+	jpg.setOutputPixelFormat(Graphics::PixelFormat::createFormatRGBA32());
 	if (!jpg.loadStream(stream))
 		return false;
 
-	_loadedSurface = jpg.getSurface()->convertTo(Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
+	_loadedSurface = jpg.getSurface()->convertTo(Graphics::PixelFormat::createFormatRGBA32());
 	return true;
 }
 

--- a/engines/tetraedge/te/te_png.cpp
+++ b/engines/tetraedge/te/te_png.cpp
@@ -62,7 +62,7 @@ bool TePng::load(Common::SeekableReadStream &stream) {
 	if (!png.loadStream(stream))
 		return false;
 
-	_loadedSurface = png.getSurface()->convertTo(Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
+	_loadedSurface = png.getSurface()->convertTo(Graphics::PixelFormat::createFormatRGBA32());
 
 	_height = _loadedSurface->h;
 
@@ -90,16 +90,6 @@ bool TePng::update(uint i, TeImage &imgout) {
 // TODO: should this return true if last frame was 7?
 bool TePng::isAtEnd() {
 	return false;
-}
-
-TeImage::Format TePng::imageFormat() {
-	if (_loadedSurface) {
-		if (_loadedSurface->format == Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24))
-			return TeImage::RGBA8;
-		else if (_loadedSurface->format == Graphics::PixelFormat(3, 8, 8, 8, 0, 16, 8, 0, 0))
-			return TeImage::RGB8;
-	}
-	return TeImage::INVALID;
 }
 
 } // end namespace Tetraedge

--- a/engines/tetraedge/te/te_png.h
+++ b/engines/tetraedge/te/te_png.h
@@ -39,8 +39,6 @@ public:
 	virtual bool load(const TetraedgeFSNode &node) override;
 	virtual bool load(Common::SeekableReadStream &stream) override;
 
-	TeImage::Format imageFormat() override;
-
 	// We support "animated" PNGs which contain 8
 	// frames stacked vertically.
 	virtual int nbFrames() override { return _nbFrames; }

--- a/engines/tetraedge/te/te_scummvm_codec.cpp
+++ b/engines/tetraedge/te/te_scummvm_codec.cpp
@@ -59,8 +59,10 @@ uint TeScummvmCodec::height() {
 	return 0;
 }
 
-TeImage::Format TeScummvmCodec::imageFormat() {
-	return TeImage::RGBA8;
+Graphics::PixelFormat TeScummvmCodec::pixelFormat() {
+	if (_loadedSurface)
+		return _loadedSurface->format;
+	return Graphics::PixelFormat();
 }
 
 bool TeScummvmCodec::update(uint i, TeImage &imgout) {

--- a/engines/tetraedge/te/te_scummvm_codec.h
+++ b/engines/tetraedge/te/te_scummvm_codec.h
@@ -37,7 +37,7 @@ public:
 	virtual uint width() override;
 	virtual uint height() override;
 	virtual int nbFrames() override { return 1; }
-	virtual TeImage::Format imageFormat() override;
+	virtual Graphics::PixelFormat pixelFormat() override;
 	virtual void setLeftBorderSize(uint val) override;
 	virtual uint leftBorderSize() override { return 0; }
 	virtual void setRightBorderSize(uint val) override;

--- a/engines/tetraedge/te/te_text_base2.cpp
+++ b/engines/tetraedge/te/te_text_base2.cpp
@@ -97,7 +97,7 @@ void TeTextBase2::build() {
 
 	TeImage img;
 	Common::SharedPtr<TePalette> nullpal;
-	img.createImg(_size._x, _size._y, nullpal, TeImage::RGBA8);
+	img.createImg(_size._x, _size._y, nullpal, Graphics::PixelFormat::createFormatRGBA32());
 	// fill with global color, alpha 0 so that the font anti-aliasing blends
 	// to the right color (see eg, the cellphone display)
 	img.fill(_globalColor.r(), _globalColor.g(), _globalColor.b(), 0);

--- a/engines/tetraedge/te/te_tga.cpp
+++ b/engines/tetraedge/te/te_tga.cpp
@@ -46,7 +46,7 @@ bool TeTga::load(Common::SeekableReadStream &stream) {
 	if (!tga.loadStream(stream))
 		return false;
 
-	_loadedSurface = tga.getSurface()->convertTo(Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
+	_loadedSurface = tga.getSurface()->convertTo(Graphics::PixelFormat::createFormatRGBA32());
 
 	return true;
 }

--- a/engines/tetraedge/te/te_theora.cpp
+++ b/engines/tetraedge/te/te_theora.cpp
@@ -44,7 +44,7 @@ bool TeTheora::load(const TetraedgeFSNode &node) {
 	_loadedNode = node;
 	if (!_decoder->loadStream(node.createReadStream()))
 		return false;
-	_decoder->setOutputPixelFormat(Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24));
+	_decoder->setOutputPixelFormat(Graphics::PixelFormat::createFormatRGBA32());
 	return true;
 }
 
@@ -60,10 +60,8 @@ int TeTheora::nbFrames() {
 	return _decoder->getFrameCount();
 }
 
-TeImage::Format TeTheora::imageFormat() {
-	//const Graphics::PixelFormat format = _decoder->getPixelFormat();
-	// TODO: use format?
-	return TeImage::RGBA8;
+Graphics::PixelFormat TeTheora::pixelFormat() {
+	return _decoder->getPixelFormat();
 }
 
 void TeTheora::setLeftBorderSize(uint val) {

--- a/engines/tetraedge/te/te_theora.h
+++ b/engines/tetraedge/te/te_theora.h
@@ -40,7 +40,7 @@ public:
 	virtual uint width() override;
 	virtual uint height() override;
 	virtual int nbFrames() override;
-	virtual TeImage::Format imageFormat() override;
+	virtual Graphics::PixelFormat pixelFormat() override;
 	virtual void setLeftBorderSize(uint val) override;
 	virtual uint leftBorderSize() override;
 	virtual void setRightBorderSize(uint val) override;

--- a/engines/tetraedge/te/te_tiled_surface.cpp
+++ b/engines/tetraedge/te/te_tiled_surface.cpp
@@ -39,7 +39,7 @@ static void getRangeIntersection(float start1, float end1, float start2, float e
 }
 
 TeTiledSurface::TeTiledSurface() : _shouldDraw(true), _codec(nullptr), _colorKeyActive(false), _colorKeyTolerence(0),
-_bottomCrop(0), _topCrop(0), _leftCrop(0), _rightCrop(0), _imgFormat(TeImage::INVALID) {
+_bottomCrop(0), _topCrop(0), _leftCrop(0), _rightCrop(0), _imgFormat() {
 	_frameAnim.frameChangedSignal().add(this, &TeTiledSurface::onFrameAnimCurrentFrameChanged);
 }
 
@@ -85,9 +85,9 @@ bool TeTiledSurface::load(const TetraedgeFSNode &node) {
 		if (_codec->load(node)) {
 			texture->setAccessName(ttPath);
 			resmgr->addResource(texture.get());
-			_imgFormat = _codec->imageFormat();
+			_imgFormat = _codec->pixelFormat();
 
-			if (_imgFormat == TeImage::INVALID) {
+			if (_imgFormat == Graphics::PixelFormat()) {
 				warning("TeTiledSurface::load: Wrong image format on file %s", _loadedPath.toString(Common::Path::kNativeSeparator).c_str());
 				delete _codec;
 				_codec = nullptr;
@@ -159,7 +159,7 @@ bool TeTiledSurface::onFrameAnimCurrentFrameChanged() {
 	if (!_codec)
 		return false;
 
-	if (_imgFormat == TeImage::INVALID) {
+	if (_imgFormat == Graphics::PixelFormat()) {
 		warning("TeTiledSurface::load: Wrong image format on file %s", _loadedPath.toString(Common::Path::kNativeSeparator).c_str());
 		return false;
 	}

--- a/engines/tetraedge/te/te_tiled_surface.h
+++ b/engines/tetraedge/te/te_tiled_surface.h
@@ -104,7 +104,7 @@ private:
 
 	bool _shouldDraw;
 
-	TeImage::Format _imgFormat;
+	Graphics::PixelFormat _imgFormat;
 
 	Common::Path _loadedPath;
 

--- a/engines/tetraedge/te/te_tiled_texture.cpp
+++ b/engines/tetraedge/te/te_tiled_texture.cpp
@@ -30,12 +30,6 @@ namespace Tetraedge {
 TeTiledTexture::TeTiledTexture() : _tileSize(0x800, 0x800), _skipBlank(false) {
 }
 
-uint TeTiledTexture::imageFormat() {
-	if (!_tileArray.empty())
-		return _tileArray[0]._texture->getFormat();
-	return TeImage::INVALID;
-}
-
 bool TeTiledTexture::isLoaded() {
 	return !_tileArray.empty();
 }
@@ -84,7 +78,7 @@ bool TeTiledTexture::load(const TeImage &img) {
 
 			const TeImage *tileimage;
 			if (newTileSize != _totalSize) {
-				TeImage *optimizedimg = optimisedTileImage(imgArray, newTileSize, Common::SharedPtr<TePalette>(), img.teFormat());
+				TeImage *optimizedimg = optimisedTileImage(imgArray, newTileSize, Common::SharedPtr<TePalette>(), img.format);
 				img.copy(*optimizedimg, TeVector2s32(0, 0), TeVector2s32(_tileSize._x * row, _tileSize._y * col), newTileSize);
 				//optimizedimg->_flipY = img._flipY;
 				Common::String accessName = Common::String::format("%s.Tile%dx%d", img.getAccessName().toString('/').c_str(), row, col);
@@ -144,9 +138,9 @@ uint32 TeTiledTexture::numberOfRow() const {
 
 /*static*/
 TeImage *TeTiledTexture::optimisedTileImage(Common::Array<TeImage> &images, const TeVector2s32 &size,
-							const Common::SharedPtr<TePalette> &pal, enum TeImage::Format format) {
+							const Common::SharedPtr<TePalette> &pal, const Graphics::PixelFormat &format) {
 	for (TeImage &image : images) {
-		if (image.w == size._x && image.h == size._y && image.teFormat() == format) {
+		if (image.w == size._x && image.h == size._y && image.format == format) {
 			return &image;
 		}
 	}

--- a/engines/tetraedge/te/te_tiled_texture.h
+++ b/engines/tetraedge/te/te_tiled_texture.h
@@ -44,7 +44,6 @@ public:
 		TeIntrusivePtr<Te3DTexture> _texture;
 	} Tile;
 
-	uint imageFormat();
 	bool isLoaded();
 	bool load(const Common::Path &path);
 	bool load(const TeImage &image);
@@ -53,7 +52,7 @@ public:
 	uint32 numberOfRow() const;
 
 	TeImage *optimisedTileImage(Common::Array<TeImage> &images, const TeVector2s32 &size,
-								const Common::SharedPtr<TePalette> &pal, enum TeImage::Format format);
+								const Common::SharedPtr<TePalette> &pal, const Graphics::PixelFormat &format);
 
 	void release();
 	void save() {};

--- a/engines/tetraedge/te/te_visual_fade.cpp
+++ b/engines/tetraedge/te/te_visual_fade.cpp
@@ -128,7 +128,7 @@ void TeVisualFade::init() {
 	Common::SharedPtr<TePalette> nullpal;
 	_image.destroy();
 	const TeVector3f32 winSize = g_engine->getApplication()->getMainWindow().size();
-	_image.createImg((int)winSize.x(), (int)winSize.y(), nullpal, TeImage::RGBA8);
+	_image.createImg((int)winSize.x(), (int)winSize.y(), nullpal, Graphics::PixelFormat::createFormatRGBA32());
 	_texturePtr->load(_image);
 	g_engine->getRenderer()->enableTexture();
 	_texturePtr->load(_image);

--- a/engines/twp/gfx.cpp
+++ b/engines/twp/gfx.cpp
@@ -187,12 +187,11 @@ void Shader::setUniform4(const char *name, Color value) {
 }
 
 void Gfx::init() {
-	Graphics::PixelFormat fmt(4, 8, 8, 8, 8, 0, 8, 16, 24);
 	byte pixels[] = {0xFF, 0xFF, 0xFF, 0xFF};
 	Graphics::Surface empty;
 	empty.w = 1;
 	empty.h = 1;
-	empty.format = fmt;
+	empty.format = Graphics::PixelFormat::createFormatRGBA32();
 	empty.setPixels(pixels);
 	_emptyTexture.load(empty);
 

--- a/engines/twp/twp.cpp
+++ b/engines/twp/twp.cpp
@@ -2112,7 +2112,7 @@ void TwpEngine::capture(Graphics::Surface &surface, int width, int height) {
 	rt.capture(data);
 
 	// flip it (due to opengl) and scale it to the desired size
-	Graphics::PixelFormat fmt(4, 8, 8, 8, 8, 0, 8, 16, 24);
+	const Graphics::PixelFormat fmt = Graphics::PixelFormat::createFormatRGBA32();
 	Graphics::Surface s;
 	s.init(SCREEN_WIDTH, SCREEN_HEIGHT, 4 * SCREEN_WIDTH, data.data(), fmt);
 	s.flipVertical(Common::Rect(s.w, s.h));

--- a/engines/watchmaker/3d/render/opengl_2d.cpp
+++ b/engines/watchmaker/3d/render/opengl_2d.cpp
@@ -323,7 +323,7 @@ int rLoadBitmapImage(WGame &game, const char *TextName, unsigned char flags) {
 		return -1;
 	}
 
-	Graphics::PixelFormat RGBA8888(4, 8, 8, 8, 8, 0, 8, 16, 24);
+	const Graphics::PixelFormat RGBA32 = Graphics::PixelFormat::createFormatRGBA32();
 
 	unsigned int pos = game._renderer->_bitmapList.acquirePosition();
 	if (pos == 0) {
@@ -333,7 +333,7 @@ int rLoadBitmapImage(WGame &game, const char *TextName, unsigned char flags) {
 	gTexture *Texture = &game._renderer->_bitmapList.bitmaps[pos];
 	*Texture = gTexture();
 	Texture->Flags = CurLoaderFlags;
-	auto surface = ReadTgaImage(TextName, *stream, RGBA8888, Texture->Flags);
+	auto surface = ReadTgaImage(TextName, *stream, RGBA32, Texture->Flags);
 	applyColorKey(*surface, 0, 0, 0, false);
 	auto texData = createTextureFromSurface(*surface, GL_RGBA);
 	Texture->_texture = createGLTexture();

--- a/engines/watchmaker/3d/render/opengl_3d.cpp
+++ b/engines/watchmaker/3d/render/opengl_3d.cpp
@@ -690,7 +690,7 @@ gTexture *gLoadTexture(WorkDirs &workDirs, const char *TextName, unsigned int _L
 		stream = nullptr;
 	} else { // TGA
 		auto stream = workDirs.resolveFile(TextName);
-		auto image = ReadTgaImage(TextName, *stream, Graphics::PixelFormat(4, 8, 8, 8, 8, 0, 8, 16, 24), 0); // TODO Flags
+		auto image = ReadTgaImage(TextName, *stream, Graphics::PixelFormat::createFormatRGBA32(), 0); // TODO Flags
 		SurfaceBackedTextureData texData(image);
 
 		texture->_texture->assignData(texData);

--- a/graphics/tinygl/zblit.cpp
+++ b/graphics/tinygl/zblit.cpp
@@ -69,7 +69,7 @@ public:
 
 			_binaryTransparent = false;
 		} else {
-			const Graphics::PixelFormat textureFormat(4, 8, 8, 8, 8, 0, 8, 16, 24);
+			const Graphics::PixelFormat textureFormat = Graphics::PixelFormat::createFormatRGBA32();
 			_surface.convertFrom(surface, textureFormat);
 
 			Graphics::PixelBuffer dataBuffer(textureFormat, (byte *)const_cast<void *>(_surface.getPixels()));


### PR DESCRIPTION
Most of these are cases where `createFormatRGBA32()` is used to match the format of `GL_RGBA`/`GL_UNSIGNED_BYTE`, however the Director engine has also been modified to ensure that matching formats are used when comparing screenshots.

The Tetraedge engine has also been modified to replace the `TeImage::Format` enum with `Graphics::PixelFormat`, since having both makes it easy to mix up formats. In the future, it should be possible to extend it to prefer other formats with different renderers, such as when using TinyGL's blit images.

This has currently only been tested on little endian.

There are still five engine that use ABGR8888 (even on big endian where it's less generally available), which should be relatively easy to adapt to use a different pixel format that can be guaranteed to be available and/or fast:
- AGS (only used if ABGR8888 is supported and ARGB8888 isn't)
- Crab (required for the screen)
- Gnap (required for the screen on big endian)
- mTropolis (used for asset loading, no alpha component)
- Ultima 6 (used for .bmp loading, no alpha component)