### PR TITLE
WINTERMUTE: Use setOutputPixelFormat when loading JPEG images

### DIFF
--- a/engines/wintermute/base/gfx/base_image.cpp
+++ b/engines/wintermute/base/gfx/base_image.cpp
@@ -26,6 +26,8 @@
  */
 
 #include "engines/wintermute/base/gfx/base_image.h"
+#include "engines/wintermute/base/gfx/base_renderer.h"
+#include "engines/wintermute/base/base_engine.h"
 #include "engines/wintermute/base/base_file_manager.h"
 #include "engines/wintermute/base/file/base_savefile_manager_file.h"
 
@@ -72,7 +74,9 @@ bool BaseImage::loadFile(const Common::String &filename) {
 	} else if (_filename.hasSuffix(".tga")) {
 		_decoder = new Image::TGADecoder();
 	} else if (_filename.hasSuffix(".jpg")) {
-		_decoder = new Image::JPEGDecoder();
+		Image::JPEGDecoder *jpeg = new Image::JPEGDecoder();
+		jpeg->setOutputPixelFormat(BaseEngine::getRenderer()->getPixelFormat());
+		_decoder = jpeg;
 	} else {
 		error("BaseImage::loadFile : Unsupported fileformat %s", filename.c_str());
 	}

--- a/engines/wintermute/base/gfx/opengl/base_surface_opengl3d.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_surface_opengl3d.cpp
@@ -165,6 +165,9 @@ bool BaseSurfaceOpenGL3D::create(const Common::String &filename, bool defaultCK,
 	if (_filename.hasSuffix(".bmp")) {
 		// Ignores alpha channel for BMPs
 		needsColorKey = true;
+	} else if (_filename.hasSuffix(".jpg")) {
+		// Ignores alpha channel for JPEGs
+		needsColorKey = true;
 	} else if (BaseEngine::instance().getTargetExecutable() < WME_LITE) {
 		// WME 1.x always use colorkey, even for images with transparency
 		needsColorKey = true;

--- a/engines/wintermute/base/gfx/osystem/base_surface_osystem.cpp
+++ b/engines/wintermute/base/gfx/osystem/base_surface_osystem.cpp
@@ -151,6 +151,9 @@ bool BaseSurfaceOSystem::finishLoad() {
 	if (_filename.hasSuffix(".bmp")) {
 		// Ignores alpha channel for BMPs
 		needsColorKey = true;
+	} else if (_filename.hasSuffix(".jpg")) {
+		// Ignores alpha channel for JPEGs
+		needsColorKey = true;
 	} else if (BaseEngine::instance().getTargetExecutable() < WME_LITE) {
 		// WME 1.x always use colorkey, even for images with transparency
 		needsColorKey = true;


### PR DESCRIPTION
This avoids needing to convert from RGB24 to RGBA32/RGBA8888, since libjpeg-turbo can directly output those formats.

~TODO: Do JPEG images need colour keys?~ @aquadran suggested on Discord that I should assume they do.