### PR TITLE
3DS: Avoid extra screen copies when no conversion is needed

### DIFF
--- a/backends/platform/3ds/osystem.h
+++ b/backends/platform/3ds/osystem.h
@@ -53,7 +53,6 @@ enum InputMode {
 enum GraphicsModeID {
 	RGBA8,
 	RGB565,
-	RGB555,
 	RGB5A1,
 	RGBA4,
 	CLUT8


### PR DESCRIPTION
It should be noted that with this PR, the surface returned by `lockScreen()` may have a pitch larger than `width * bpp`, so it may be necessary to fix up certain engines that make assumptions about this.
