### PR TITLE
PSP2: Remove psp2shell dependency

### DIFF
--- a/backends/platform/sdl/psp2/psp2-main.cpp
+++ b/backends/platform/sdl/psp2/psp2-main.cpp
@@ -33,10 +33,6 @@ char boot_params[1024];
 
 int main(int argc, char *argv[]) {
 
-#ifdef __PSP2_DEBUG__
-	psp2shell_init(3333, 10);
-#endif
-
 	scePowerSetArmClockFrequency(444);
 	scePowerSetBusClockFrequency(222);
 	scePowerSetGpuClockFrequency(222);
@@ -98,10 +94,6 @@ int main(int argc, char *argv[]) {
 exit:
 	// Free OSystem
 	g_system->destroy();
-
-#ifdef __PSP2_DEBUG__
-	psp2shell_exit();
-#endif
 
 	return res;
 }

--- a/backends/platform/sdl/psp2/psp2.cpp
+++ b/backends/platform/sdl/psp2/psp2.cpp
@@ -21,6 +21,7 @@
 
 #define FORBIDDEN_SYMBOL_EXCEPTION_mkdir
 #define FORBIDDEN_SYMBOL_EXCEPTION_time_h	// sys/stat.h includes sys/time.h
+#define FORBIDDEN_SYMBOL_EXCEPTION_printf	// used by sceClibPrintf()
 
 #include "common/scummsys.h"
 #include "common/config-manager.h"
@@ -34,10 +35,8 @@
 #include <sys/stat.h>
 
 #include <psp2/io/stat.h>
+#include <psp2/kernel/clib.h>
 
-#ifdef __PSP2_DEBUG__
-#include <psp2shell.h>
-#endif
 
 static const Common::HardwareInputTableEntry psp2JoystickButtons[] = {
 	{ "JOY_A",              Common::JOYSTICK_BUTTON_A,              _s("Cross")       },
@@ -156,7 +155,7 @@ bool OSystem_PSP2::hasFeature(Feature f) {
 
 void OSystem_PSP2::logMessage(LogMessageType::Type type, const char *message) {
 #if __PSP2_DEBUG__
-	psp2shell_print(message);
+	sceClibPrintf(message);
 #endif
 }
 

--- a/backends/platform/sdl/psp2/psp2.h
+++ b/backends/platform/sdl/psp2/psp2.h
@@ -23,9 +23,6 @@
 #define PLATFORM_SDL_PSP2_H
 
 #include "backends/platform/sdl/sdl.h"
-#ifdef __PSP2_DEBUG__
-#include <psp2shell.h>
-#endif
 
 class OSystem_PSP2 : public OSystem_SDL {
 public:

--- a/configure
+++ b/configure
@@ -3466,7 +3466,6 @@ EOF
 		if test "$_debug_build" = yes; then
 			_optimization_level=-O0
 			append_var DEFINES "-D__PSP2_DEBUG__"
-			append_var LIBS "-lpsp2shell"
 		fi
 		add_line_to_config_mk 'PSP2 = 1'
 		add_line_to_config_h "#define PREFIX \"${prefix}\""


### PR DESCRIPTION
psp2shell as a dependency is not needed for debug.
In fact, it does not even work with current code.
We simply need to remove it and use sceClibPrintf.
This standard function will send debug messages to psp2shell if it is installed on the console.

Tested and working for me.