### PR TITLE
CI: Fix libmpeg2 vcpkg source

### DIFF
--- a/.github/vcpkg-ports/libmpeg2/0001-Add-naive-MSVC-support-to-sources.patch
+++ b/.github/vcpkg-ports/libmpeg2/0001-Add-naive-MSVC-support-to-sources.patch
@@ -1,0 +1,146 @@
+From ed3b6e4bca1fe5211e3d7ca06bbbf9b161c8bc19 Mon Sep 17 00:00:00 2001
+From: Michal Janiszewski <janisozaur@gmail.com>
+Date: Sat, 2 Nov 2019 14:50:53 -0700
+Subject: [PATCH] Add naive MSVC support to sources
+
+---
+ libmpeg2/convert/rgb.c | 2 +-
+ libmpeg2/cpu_accel.c   | 4 ++--
+ libmpeg2/cpu_state.c   | 4 ++--
+ libmpeg2/idct.c        | 2 +-
+ libmpeg2/motion_comp.c | 2 +-
+ libvo/video_out_dx.c   | 6 +++---
+ vc++/config.h          | 2 ++
+ 7 files changed, 12 insertions(+), 10 deletions(-)
+
+diff --git a/libmpeg2/convert/rgb.c b/libmpeg2/convert/rgb.c
+index 8863b0b..db6f4e3 100644
+--- a/libmpeg2/convert/rgb.c
++++ b/libmpeg2/convert/rgb.c
+@@ -499,7 +499,7 @@ static int rgb_internal (mpeg2convert_rgb_order_t order, unsigned int bpp,
+     int convert420 = 0;
+     int rgb_stride_min = ((bpp + 7) >> 3) * seq->width;
+ 
+-#ifdef ARCH_X86
++#if !defined(_MSC_VER) && defined(ARCH_X86)
+     if (!copy && (accel & MPEG2_ACCEL_X86_MMXEXT)) {
+ 	convert420 = 0;
+ 	copy = mpeg2convert_rgb_mmxext (order, bpp, seq);
+diff --git a/libmpeg2/cpu_accel.c b/libmpeg2/cpu_accel.c
+index 9b24610..a922df1 100644
+--- a/libmpeg2/cpu_accel.c
++++ b/libmpeg2/cpu_accel.c
+@@ -29,7 +29,7 @@
+ #include "attributes.h"
+ #include "mpeg2_internal.h"
+ 
+-#if defined(ARCH_X86) || defined(ARCH_X86_64)
++#if !defined(_MSC_VER) && (defined(ARCH_X86) || defined(ARCH_X86_64))
+ static inline uint32_t arch_accel (uint32_t accel)
+ {
+     if (accel & (MPEG2_ACCEL_X86_3DNOW | MPEG2_ACCEL_X86_MMXEXT))
+@@ -253,7 +253,7 @@ static inline uint32_t arch_accel (uint32_t accel)
+ 
+ uint32_t mpeg2_detect_accel (uint32_t accel)
+ {
+-#if defined (ARCH_X86) || defined (ARCH_X86_64) || defined (ARCH_PPC) || defined (ARCH_ALPHA) || defined (ARCH_SPARC)
++#if !defined(_MSC_VER) && (defined (ARCH_X86) || defined (ARCH_X86_64) || defined (ARCH_PPC) || defined (ARCH_ALPHA) || defined (ARCH_SPARC))
+     accel = arch_accel (accel);
+ #endif
+     return accel;
+diff --git a/libmpeg2/cpu_state.c b/libmpeg2/cpu_state.c
+index 2f2f64a..f4966c1 100644
+--- a/libmpeg2/cpu_state.c
++++ b/libmpeg2/cpu_state.c
+@@ -36,7 +36,7 @@
+ void (* mpeg2_cpu_state_save) (cpu_state_t * state) = NULL;
+ void (* mpeg2_cpu_state_restore) (cpu_state_t * state) = NULL;
+ 
+-#if defined(ARCH_X86) || defined(ARCH_X86_64)
++#if !defined(_MSC_VER) && (defined(ARCH_X86) || defined(ARCH_X86_64))
+ static void state_restore_mmx (cpu_state_t * state)
+ {
+     emms ();
+@@ -115,7 +115,7 @@ static void state_restore_altivec (cpu_state_t * state)
+ 
+ void mpeg2_cpu_state_init (uint32_t accel)
+ {
+-#if defined(ARCH_X86) || defined(ARCH_X86_64)
++#if !defined(_MSC_VER) && (defined(ARCH_X86) || defined(ARCH_X86_64))
+     if (accel & MPEG2_ACCEL_X86_MMX) {
+ 	mpeg2_cpu_state_restore = state_restore_mmx;
+     }
+diff --git a/libmpeg2/idct.c b/libmpeg2/idct.c
+index 81c57e0..a057bf7 100644
+--- a/libmpeg2/idct.c
++++ b/libmpeg2/idct.c
+@@ -235,7 +235,7 @@ static void mpeg2_idct_add_c (const int last, int16_t * block,
+ 
+ void mpeg2_idct_init (uint32_t accel)
+ {
+-#ifdef ARCH_X86
++#if !defined(_MSC_VER) && defined(ARCH_X86)
+     if (accel & MPEG2_ACCEL_X86_SSE2) {
+ 	mpeg2_idct_copy = mpeg2_idct_copy_sse2;
+ 	mpeg2_idct_add = mpeg2_idct_add_sse2;
+diff --git a/libmpeg2/motion_comp.c b/libmpeg2/motion_comp.c
+index 7aed113..b00a32d 100644
+--- a/libmpeg2/motion_comp.c
++++ b/libmpeg2/motion_comp.c
+@@ -33,7 +33,7 @@ mpeg2_mc_t mpeg2_mc;
+ 
+ void mpeg2_mc_init (uint32_t accel)
+ {
+-#ifdef ARCH_X86
++#if !defined(_MSC_VER) && defined(ARCH_X86)
+     if (accel & MPEG2_ACCEL_X86_MMXEXT)
+ 	mpeg2_mc = mpeg2_mc_mmxext;
+     else if (accel & MPEG2_ACCEL_X86_3DNOW)
+diff --git a/libvo/video_out_dx.c b/libvo/video_out_dx.c
+index 36de68a..0797cdc 100644
+--- a/libvo/video_out_dx.c
++++ b/libvo/video_out_dx.c
+@@ -82,7 +82,7 @@ static void update_overlay (dx_instance_t * instance)
+ 				       dwFlags, &ddofx);
+ }
+ 
+-static long FAR PASCAL event_procedure (HWND hwnd, UINT message,
++static LRESULT FAR PASCAL event_procedure (HWND hwnd, UINT message,
+ 					WPARAM wParam, LPARAM lParam)
+ {
+     RECT rect_window;
+@@ -92,7 +92,7 @@ static long FAR PASCAL event_procedure (HWND hwnd, UINT message,
+     switch (message) {
+ 
+     case WM_WINDOWPOSCHANGED:
+-	instance = (dx_instance_t *) GetWindowLong (hwnd, GWL_USERDATA);
++	instance = (dx_instance_t *) GetWindowLongPtr (hwnd, GWLP_USERDATA);
+ 
+ 	/* update the window position and size */
+ 	point_window.x = 0;
+@@ -173,7 +173,7 @@ static int create_window (dx_instance_t * instance)
+     /* store a directx_instance pointer into the window local storage
+      * (for later use in event_handler).
+      * We need to use SetWindowLongPtr when it is available in mingw */
+-    SetWindowLong (instance->window, GWL_USERDATA, (LONG) instance);
++    SetWindowLongPtr (instance->window, GWLP_USERDATA, (LONG_PTR) instance);
+ 
+     ShowWindow (instance->window, SW_SHOW);
+ 
+diff --git a/vc++/config.h b/vc++/config.h
+index 93719f0..a03cce6 100644
+--- a/vc++/config.h
++++ b/vc++/config.h
+@@ -16,7 +16,9 @@
+ /* #undef ARCH_SPARC */
+ 
+ /* x86 architecture */
++#if defined(_M_AMD64) || defined(_M_IX86)
+ #define ARCH_X86
++#endif
+ 
+ /* maximum supported data alignment */
+ /* #undef ATTRIBUTE_ALIGNED_MAX */
+-- 
+2.25.0
+

--- a/.github/vcpkg-ports/libmpeg2/CMakeLists.txt
+++ b/.github/vcpkg-ports/libmpeg2/CMakeLists.txt
@@ -1,0 +1,108 @@
+cmake_minimum_required(VERSION 3.2)
+project(libmpeg2)
+
+option(TOOLS "Build libmpeg2 tools" OFF)
+
+set(MPEG2_SOURCE_FILES
+    libmpeg2/alloc.c
+    libmpeg2/cpu_accel.c
+    libmpeg2/cpu_state.c
+    libmpeg2/decode.c
+    libmpeg2/header.c
+    libmpeg2/idct.c
+    libmpeg2/idct_alpha.c
+    libmpeg2/idct_altivec.c
+    #libmpeg2/idct_mmx.c
+    libmpeg2/motion_comp.c
+    libmpeg2/motion_comp_alpha.c
+    libmpeg2/motion_comp_altivec.c
+    libmpeg2/motion_comp_arm.c
+    #libmpeg2/motion_comp_mmx.c
+    libmpeg2/motion_comp_vis.c
+    libmpeg2/slice.c
+    )
+set(VO_SOURCE_FILES
+    libvo/video_out.c
+    libvo/video_out_dx.c
+    libvo/video_out_null.c
+    libvo/video_out_pgm.c
+    libvo/video_out_sdl.c
+    libvo/video_out_x11.c
+    )
+set(MPEG2_CONVERT_SOURCES
+    libmpeg2/convert/rgb.c
+    #libmpeg2/convert/rgb_mmx.c
+    libmpeg2/convert/rgb_vis.c
+    libmpeg2/convert/uyvy.c
+    )
+set(GETOPT_FILES
+    src/getopt.c
+    )
+set(HEADERS
+    include/mpeg2.h
+    include/mpeg2convert.h
+    )
+
+add_library(mpeg2 ${MPEG2_SOURCE_FILES})
+add_library(mpeg2convert ${MPEG2_CONVERT_SOURCES})
+add_library(getopt STATIC ${GETOPT_FILES})
+add_library(vo STATIC ${VO_SOURCE_FILES})
+
+target_include_directories(mpeg2convert PUBLIC
+    "${CMAKE_SOURCE_DIR}/vc++"
+    "${CMAKE_SOURCE_DIR}/include"
+    )
+target_include_directories(getopt PUBLIC
+    "${CMAKE_SOURCE_DIR}/vc++"
+    "${CMAKE_SOURCE_DIR}/include"
+    )
+target_include_directories(vo PUBLIC
+    "${CMAKE_SOURCE_DIR}/vc++"
+    "${CMAKE_SOURCE_DIR}/include"
+    )
+target_include_directories(mpeg2 PUBLIC
+    "${CMAKE_SOURCE_DIR}/vc++"
+    "${CMAKE_SOURCE_DIR}/include"
+    )
+target_include_directories(mpeg2 INTERFACE
+    "${CMAKE_SOURCE_DIR}/include"
+    )
+
+target_compile_definitions(getopt PUBLIC HAVE_CONFIG_H)
+target_link_libraries(vo mpeg2convert)
+
+if (TOOLS)
+    add_executable(mpeg2dec src/mpeg2dec.c src/dump_state.c src/gettimeofday.c)
+    add_executable(extract_mpeg2 src/extract_mpeg2.c)
+    add_executable(corrupt_mpeg2 src/corrupt_mpeg2.c)
+
+    target_compile_definitions(extract_mpeg2 PUBLIC HAVE_CONFIG_H)
+    target_compile_definitions(corrupt_mpeg2 PUBLIC HAVE_CONFIG_H)
+
+    target_link_libraries(mpeg2dec PRIVATE getopt vo mpeg2convert mpeg2 gdi32)
+    target_link_libraries(extract_mpeg2 PRIVATE getopt)
+    target_link_libraries(corrupt_mpeg2 PRIVATE getopt)
+
+    target_include_directories(mpeg2dec PUBLIC
+        "${CMAKE_SOURCE_DIR}/vc++"
+        "${CMAKE_SOURCE_DIR}/include"
+        "${CMAKE_SOURCE_DIR}/src"
+        )
+    target_include_directories(extract_mpeg2 PUBLIC
+        "${CMAKE_SOURCE_DIR}/vc++"
+        "${CMAKE_SOURCE_DIR}/include"
+        "${CMAKE_SOURCE_DIR}/src"
+        )
+    target_include_directories(corrupt_mpeg2 PUBLIC
+        "${CMAKE_SOURCE_DIR}/vc++"
+        "${CMAKE_SOURCE_DIR}/include"
+        "${CMAKE_SOURCE_DIR}/src"
+        )
+endif (TOOLS)
+
+install(TARGETS mpeg2
+    EXPORT libmpeg2
+    LIBRARY DESTINATION lib
+)
+
+install(FILES ${HEADERS} DESTINATION "include/mpeg2dec")

--- a/.github/vcpkg-ports/libmpeg2/portfile.cmake
+++ b/.github/vcpkg-ports/libmpeg2/portfile.cmake
@@ -1,0 +1,36 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+# There is archived version of releases available at https://github.com/janisozaur/libmpeg2
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://libmpeg2.sourceforge.net/files/libmpeg2-0.5.1.tar.gz"
+    FILENAME "libmpeg2-0.5.1.tar.gz"
+    SHA512 3648a2b3d7e2056d5adb328acd2fb983a1fa9a05ccb6f9388cc686c819445421811f42e8439418a0491a13080977f074a0d8bf8fa6bc101ff245ddea65a46fbc
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        0001-Add-naive-MSVC-support-to-sources.patch
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    tools   TOOLS
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+# # Handle copyright
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_copy_pdbs()

--- a/.github/vcpkg-ports/libmpeg2/portfile.cmake
+++ b/.github/vcpkg-ports/libmpeg2/portfile.cmake
@@ -1,15 +1,10 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 # There is archived version of releases available at https://github.com/janisozaur/libmpeg2
-vcpkg_download_distfile(ARCHIVE
-    URLS "http://libmpeg2.sourceforge.net/files/libmpeg2-0.5.1.tar.gz"
-    FILENAME "libmpeg2-0.5.1.tar.gz"
-    SHA512 3648a2b3d7e2056d5adb328acd2fb983a1fa9a05ccb6f9388cc686c819445421811f42e8439418a0491a13080977f074a0d8bf8fa6bc101ff245ddea65a46fbc
-)
-
-vcpkg_extract_source_archive(
-    SOURCE_PATH
-    ARCHIVE "${ARCHIVE}"
+vcpkg_from_git(
+    OUT_SOURCE_PATH SOURCE_PATH
+    URL https://code.videolan.org/videolan/libmpeg2.git
+    REF 946bf4b518aacc224f845e73708f99e394744499  # Use a pinned commit hash
     PATCHES
         0001-Add-naive-MSVC-support-to-sources.patch
 )

--- a/.github/vcpkg-ports/libmpeg2/vcpkg.json
+++ b/.github/vcpkg-ports/libmpeg2/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "libmpeg2",
+  "version": "0.5.1",
+  "port-version": 3,
+  "description": "a free MPEG-2 video stream decoder",
+  "homepage": "http://libmpeg2.sourceforge.net/",
+  "supports": "!(linux | osx | uwp)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ],
+  "features": {
+    "tools": {
+      "description": "Build tools provided with libmpeg2"
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
       VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg_installed
       VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg_cache,readwrite
+      VCPKG_OVERLAY_PORTS: ${{ github.workspace }}/.github/vcpkg-ports
       GIT_VCPKG_COMMIT: ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0
     permissions:
       contents: write # For dependencygraph


### PR DESCRIPTION
Change the upstream URL for libmpeg2 to VideoLAN

The original libmpeg2 source archive is gone from SF.NET, so use the
patched libmpeg2 sources from the VideoLAN git repo instead.

Opening as a PR to check that Github actions compile the Windows builds correctly