### PR TITLE
COMMON: set EVENT_MAX for EventType to force size

### DIFF
--- a/common/events.h
+++ b/common/events.h
@@ -115,7 +115,18 @@ enum EventType {
 
 	/** ScummVM has gained or lost focus. */
 	EVENT_FOCUS_GAINED = 36,
-	EVENT_FOCUS_LOST = 37
+	EVENT_FOCUS_LOST = 37,
+
+	/**
+	 * We reserve some event ids for custom events.
+	 * 
+	 * This is used for example by Asylum and Bagel engines.
+	 * Your custom event ids must be in this range.
+	 * This also prevents compiler from using a too short datatype
+	 *  for storing this enum on some platforms.
+	 */
+	EVENT_USER_FIRST_AVAILABLE = 1000,
+	EVENT_USER_LAST_AVAILABLE = 9999
 };
 
 const int16 JOYAXIS_MIN = -32768;

--- a/engines/asylum/eventhandler.h
+++ b/engines/asylum/eventhandler.h
@@ -28,7 +28,7 @@
 namespace Asylum {
 
 enum AsylumEventType {
-	EVENT_ASYLUM_MIDI     = 953,
+	EVENT_ASYLUM_MIDI     = 1053,
 	EVENT_ASYLUM_CHANGECD = 5120,
 	EVENT_ASYLUM_INIT     = 5122,
 	EVENT_ASYLUM_UPDATE   = 5121,
@@ -37,7 +37,7 @@ enum AsylumEventType {
 	EVENT_ASYLUM_SUBTITLE = 5125,
 	EVENT_ASYLUM_MUSIC    = 5376,
 
-	EVENT_ASYLUM_ACTIVATE = 0xFFF0
+	EVENT_ASYLUM_ACTIVATE = 6000
 };
 
 struct AsylumEvent : public Common::Event {


### PR DESCRIPTION
This was the root cause of a black screen with ASYLUM engine (Sanitarium) on PSP2
Fixes https://bugs.scummvm.org/ticket/15115

A casting was made in AsylumEvent() that expects 32 bits, but before this patch the cast would change the event type value thus breaking the ASYLUM engine.