### PR TITLE
GUI: Restrict platform selection based on GUIOptions

### DIFF
--- a/common/gui_options.cpp
+++ b/common/gui_options.cpp
@@ -22,6 +22,7 @@
 #include "common/gui_options.h"
 
 #include "common/config-manager.h"
+#include "common/platform.h"
 #include "common/str.h"
 
 namespace Common {
@@ -167,6 +168,8 @@ String parseGameGUIOptions(const String &str) {
 		}
 	}
 
+	res += parseGameGUIOptionsPlatforms(str);
+
 	return res;
 }
 
@@ -177,13 +180,15 @@ const String getGameGUIOptionsDescription(const String &options) {
 		if (options.contains(g_gameOptions[i].option[0]))
 			res += String(g_gameOptions[i].desc) + " ";
 
+	res += getGameGUIOptionsDescriptionPlatforms(options);
 	res.trim();
 
 	return res;
 }
 
-void updateGameGUIOptions(const String &options, const String &langOption) {
-	const String newOptionString = getGameGUIOptionsDescription(options) + " " + langOption;
+void updateGameGUIOptions(const String &options, const String &langOption, const String &platOption) {
+	const String newOptionString = getGameGUIOptionsDescription(options) + " " + langOption + " " + platOption;
+
 	ConfMan.setAndFlush("guioptions", newOptionString);
 }
 

--- a/common/gui_options.h
+++ b/common/gui_options.h
@@ -81,6 +81,47 @@
 
 #define GUIO_NOLANG          "\x33"
 
+// Defines to be used for additional platforms
+#define GUIO_PLAT_APPLE2GS "\x40"
+#define GUIO_PLAT_APPLE2 "\x41"
+#define GUIO_PLAT_3DO "\x42"
+#define GUIO_PLAT_ACORN "\x43"
+#define GUIO_PLAT_AMIGA "\x44"
+#define GUIO_PLAT_ATARI8BIT "\x45"
+#define GUIO_PLAT_ATARIST "\x46"
+#define GUIO_PLAT_C64 "\x47"
+#define GUIO_PLAT_AMSTRADCPC "\x48"
+#define GUIO_PLAT_DOS "\x49"
+#define GUIO_PLAT_PC98 "\x4A"
+#define GUIO_PLAT_WII "\x4B"
+#define GUIO_PLAT_COCO "\x4C"
+#define GUIO_PLAT_COCO3 "\x4D"
+#define GUIO_PLAT_FMTOWNS "\x4E"
+#define GUIO_PLAT_LINUX "\x4F"
+#define GUIO_PLAT_MACINTOSH "\x50"
+#define GUIO_PLAT_PCENGINE "\x51"
+#define GUIO_PLAT_NES "\x52"
+#define GUIO_PLAT_SEGACD "\x53"
+#define GUIO_PLAT_WINDOWS "\x54"
+#define GUIO_PLAT_PSX "\x55"
+#define GUIO_PLAT_PS2 "\x56"
+#define GUIO_PLAT_PS3 "\x57"
+#define GUIO_PLAT_XBOX "\x58"
+#define GUIO_PLAT_CDI "\x59"
+#define GUIO_PLAT_IOS "\x5A"
+#define GUIO_PLAT_ANDROID "\x5B"
+#define GUIO_PLAT_OS2 "\x5C"
+#define GUIO_PLAT_BEOS "\x5D"
+#define GUIO_PLAT_POCKETPC "\x5E"
+#define GUIO_PLAT_MEGADRIVE "\x5F"
+#define GUIO_PLAT_SATURN "\x60"
+#define GUIO_PLAT_PIPPIN "\x61"
+#define GUIO_PLAT_MACINTOSHII "\x62"
+#define GUIO_PLAT_SHOCKWAVE "\x63"
+#define GUIO_PLAT_ZX "\x64"
+#define GUIO_PLAT_TI994 "\x65"
+#define GUIO_PLAT_NINTENDOSWITCH "\x66"
+
 // Special GUIO flags for the AdvancedDetector's caching of game specific
 // options.
 // Putting them to the end of the range so less renumerations required
@@ -153,7 +194,7 @@ const String getGameGUIOptionsDescription(const String &options);
  * domain when they differ to the ones passed as
  * parameter.
  */
-void updateGameGUIOptions(const String &options, const String &langOption);
+void updateGameGUIOptions(const String &options, const String &langOption, const String &platOption);
 
 /** @} */
 

--- a/common/gui_options.h
+++ b/common/gui_options.h
@@ -185,8 +185,19 @@ namespace Common {
 
 class String;
 
+/**
+* Check if given option exists in a string
+*/
 bool checkGameGUIOption(const String &option, const String &str);
+
+/**
+* Parse GUIOptions string to GUIO literals defined in this file
+*/
 String parseGameGUIOptions(const String &str);
+
+/**
+* Return string containing gui options description based on GUIO literals
+*/
 const String getGameGUIOptionsDescription(const String &options);
 
 /**

--- a/common/platform.cpp
+++ b/common/platform.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "common/platform.h"
-#include "common/array.h"
 #include "common/gui_options.h"
 #include "common/str.h"
 #include "common/algorithm.h"

--- a/common/platform.cpp
+++ b/common/platform.cpp
@@ -20,58 +20,58 @@
  */
 
 #include "common/platform.h"
+#include "common/array.h"
+#include "common/gui_options.h"
 #include "common/str.h"
 #include "common/algorithm.h"
 
 namespace Common {
 
 const PlatformDescription g_platforms[] = {
-	{ "2gs", "2gs", "2gs", "Apple IIgs", kPlatformApple2GS },
-	{ "apple2", "apple2", "apple2", "Apple II", kPlatformApple2 },
-	{ "3do", "3do", "3do", "3DO", kPlatform3DO },
-	{ "acorn", "acorn", "acorn", "Acorn", kPlatformAcorn },
-	{ "amiga", "ami", "amiga", "Amiga", kPlatformAmiga },
-	{ "atari8", "atari8", "atari8", "Atari 8-bit", kPlatformAtari8Bit },
-	{ "atari", "atari-st", "st", "Atari ST", kPlatformAtariST },
-	{ "c64", "c64", "c64", "Commodore 64", kPlatformC64 },
-	{ "cpc", "cpc", "cpc", "Amstrad CPC", kPlatformAmstradCPC },
-	{ "pc", "dos", "ibm", "DOS", kPlatformDOS },
-	{ "pc98", "pc98", "pc98", "PC-98", kPlatformPC98 },
-	{ "wii", "wii", "wii", "Nintendo Wii", kPlatformWii },
-	{ "coco", "coco", "coco", "CoCo", kPlatformCoCo },		// CoCo 1/2
-	{ "coco3", "coco3", "coco3", "CoCo3", kPlatformCoCo3 },	// CoCo 3 only
-
+	{ GUIO_PLAT_APPLE2GS, "2gs", "2gs", "2gs", "Apple IIgs", kPlatformApple2GS },
+	{ GUIO_PLAT_APPLE2, "apple2", "apple2", "apple2", "Apple II", kPlatformApple2 },
+	{ GUIO_PLAT_3DO, "3do", "3do", "3do", "3DO", kPlatform3DO },
+	{ GUIO_PLAT_ACORN, "acorn", "acorn", "acorn", "Acorn", kPlatformAcorn },
+	{ GUIO_PLAT_AMIGA, "amiga", "ami", "amiga", "Amiga", kPlatformAmiga },
+	{ GUIO_PLAT_ATARI8BIT, "atari8", "atari8", "atari8", "Atari 8-bit", kPlatformAtari8Bit },
+	{ GUIO_PLAT_ATARIST, "atari", "atari-st", "st", "Atari ST", kPlatformAtariST },
+	{ GUIO_PLAT_C64, "c64", "c64", "c64", "Commodore 64", kPlatformC64 },
+	{ GUIO_PLAT_AMSTRADCPC, "cpc", "cpc", "cpc", "Amstrad CPC", kPlatformAmstradCPC },
+	{ GUIO_PLAT_DOS, "pc", "dos", "ibm", "DOS", kPlatformDOS },
+	{ GUIO_PLAT_PC98, "pc98", "pc98", "pc98", "PC-98", kPlatformPC98 },
+	{ GUIO_PLAT_WII, "wii", "wii", "wii", "Nintendo Wii", kPlatformWii },
+	{ GUIO_PLAT_COCO, "coco", "coco", "coco", "CoCo", kPlatformCoCo },		// CoCo 1/2
+	{ GUIO_PLAT_COCO3, "coco3", "coco3", "coco3", "CoCo3", kPlatformCoCo3 },	// CoCo 3 only
 	// The 'official' spelling seems to be "FM-TOWNS" (e.g. in the Indy4 demo).
 	// However, on the net many variations can be seen, like "FMTOWNS",
 	// "FM TOWNS", "FmTowns", etc.
-	{ "fmtowns", "towns", "fm", "FM-TOWNS", kPlatformFMTowns },
+	{ GUIO_PLAT_FMTOWNS, "fmtowns", "towns", "fm", "FM-TOWNS", kPlatformFMTowns },
+	{ GUIO_PLAT_LINUX, "linux", "linux", "linux", "Linux", kPlatformLinux },
+	{ GUIO_PLAT_MACINTOSH, "macintosh", "mac", "mac", "Macintosh", kPlatformMacintosh },
+	{ GUIO_PLAT_PCENGINE, "pce", "pce", "pce", "PC-Engine", kPlatformPCEngine },
+	{ GUIO_PLAT_NES, "nes", "nes", "nes", "NES", kPlatformNES },
+	{ GUIO_PLAT_SEGACD, "segacd", "segacd", "sega", "SegaCD", kPlatformSegaCD },
+	{ GUIO_PLAT_WINDOWS, "windows", "win", "win", "Windows", kPlatformWindows },
+	{ GUIO_PLAT_PSX, "playstation", "psx", "psx", "Sony PlayStation", kPlatformPSX },
+	{ GUIO_PLAT_PS2, "playstation2", "ps2", "ps2", "Sony PlayStation 2", kPlatformPS2 },
+	{ GUIO_PLAT_PS3, "playstation3", "ps3", "ps3", "Sony PlayStation 3", kPlatformPS3 },
+	{ GUIO_PLAT_XBOX, "xbox", "xbox", "xbox", "Microsoft Xbox", kPlatformXbox },
+	{ GUIO_PLAT_CDI, "cdi", "cdi", "cdi", "Philips CD-i", kPlatformCDi },
+	{ GUIO_PLAT_IOS, "ios", "ios", "ios", "Apple iOS", kPlatformIOS },
+	{ GUIO_PLAT_ANDROID, "android", "android", "android", "Android", kPlatformAndroid },
+	{ GUIO_PLAT_OS2, "os2", "os2", "os2", "OS/2", kPlatformOS2 },
+	{ GUIO_PLAT_BEOS, "beos", "beos", "beos", "BeOS", kPlatformBeOS },
+	{ GUIO_PLAT_POCKETPC, "ppc", "ppc", "ppc", "PocketPC", kPlatformPocketPC },
+	{ GUIO_PLAT_MEGADRIVE, "megadrive", "genesis", "md", "Mega Drive/Genesis", kPlatformMegaDrive },
+	{ GUIO_PLAT_SATURN, "saturn", "saturn", "saturn", "Sega Saturn", kPlatformSaturn },
+	{ GUIO_PLAT_PIPPIN, "pippin", "pippin", "pippin", "Pippin", kPlatformPippin },
+	{ GUIO_PLAT_MACINTOSHII, "macintosh2", "macintosh2", "mac2", "Macintosh II", kPlatformMacintoshII },
+	{ GUIO_PLAT_SHOCKWAVE, "shockwave", "shockwave", "shock", "Shockwave", kPlatformShockwave },
+	{ GUIO_PLAT_ZX, "zx", "zx", "zx", "ZX Spectrum", kPlatformZX },
+	{ GUIO_PLAT_TI994, "ti994", "ti994", "ti994", "TI-99/4A", kPlatformTI994 },
+	{ GUIO_PLAT_NINTENDOSWITCH, "switch", "switch", "switch", "Nintendo Switch", kPlatformNintendoSwitch },
 
-	{ "linux", "linux", "linux", "Linux", kPlatformLinux },
-	{ "macintosh", "mac", "mac", "Macintosh", kPlatformMacintosh },
-	{ "pce", "pce", "pce", "PC-Engine", kPlatformPCEngine },
-	{ "nes", "nes", "nes", "NES", kPlatformNES },
-	{ "segacd", "segacd", "sega", "SegaCD", kPlatformSegaCD },
-	{ "windows", "win", "win", "Windows", kPlatformWindows },
-	{ "playstation", "psx", "psx", "Sony PlayStation", kPlatformPSX },
-	{ "playstation2", "ps2", "ps2", "Sony PlayStation 2", kPlatformPS2 },
-	{ "playstation3", "ps3", "ps3", "Sony PlayStation 3", kPlatformPS3 },
-	{ "xbox", "xbox", "xbox", "Microsoft Xbox", kPlatformXbox },
-	{ "cdi", "cdi", "cdi", "Philips CD-i", kPlatformCDi },
-	{ "ios", "ios", "ios", "Apple iOS", kPlatformIOS },
-	{ "android", "android", "android", "Android", kPlatformAndroid },
-	{ "os2", "os2", "os2", "OS/2", kPlatformOS2 },
-	{ "beos", "beos", "beos", "BeOS", kPlatformBeOS },
-	{ "ppc", "ppc", "ppc", "PocketPC", kPlatformPocketPC },
-	{ "megadrive", "genesis", "md", "Mega Drive/Genesis", kPlatformMegaDrive },
-	{ "saturn", "saturn", "saturn", "Sega Saturn", kPlatformSaturn },
-	{ "pippin", "pippin", "pippin", "Pippin", kPlatformPippin },
-	{ "macintosh2", "macintosh2", "mac2", "Macintosh II", kPlatformMacintoshII },
-	{ "shockwave", "shockwave", "shock", "Shockwave", kPlatformShockwave },
-	{ "zx", "zx", "zx", "ZX Spectrum", kPlatformZX },
-	{ "ti994", "ti994", "ti994", "TI-99/4A", kPlatformTI994 },
-	{ "switch", "switch", "switch", "Nintendo Switch", kPlatformNintendoSwitch },
-
-	{ nullptr, nullptr, nullptr, "Default", kPlatformUnknown }
+	{ nullptr, nullptr, nullptr, nullptr, "Default", kPlatformUnknown }
 };
 
 Platform parsePlatform(const String &str) {
@@ -134,11 +134,34 @@ bool checkGameGUIOptionPlatform(Platform plat, const String &str) {
 	return false;
 }
 
+const String parseGameGUIOptionsPlatforms(const String &str) {
+	String res;
+
+	for (int i = 0; g_platforms[i].code; i++)
+		if (str.contains("plat_" + String(g_platforms[i].code)))
+			res += String(g_platforms[i].GUIOption);
+
+	return res;
+}
+
+const String getGameGUIOptionsDescriptionPlatforms(const String &str) {
+	String res;
+
+	for (int i = 0; g_platforms[i].GUIOption; i++)
+		if (str.contains(g_platforms[i].GUIOption))
+			res += "plat_" + String(g_platforms[i].code) + " ";
+
+	res.trim();
+
+	return res;
+}
+
 const String getGameGUIOptionsDescriptionPlatform(Platform plat) {
 	if (plat == kPlatformUnknown)
 		return "";
 
-	return String("plat_") + getPlatformDescription(plat);
+	// Using platform code as description for GUI options to avoid spaces in the name
+	return String("plat_") + getPlatformCode(plat);
 }
 
 List<String> getPlatformList() {

--- a/common/platform.cpp
+++ b/common/platform.cpp
@@ -124,6 +124,23 @@ const char *getPlatformDescription(Platform id) {
 	return l->description;
 }
 
+bool checkGameGUIOptionPlatform(Platform plat, const String &str) {
+	if (!str.contains("plat_")) // If no platforms are specified
+		return true;
+
+	if (str.contains(getGameGUIOptionsDescriptionPlatform(plat)))
+		return true;
+
+	return false;
+}
+
+const String getGameGUIOptionsDescriptionPlatform(Platform plat) {
+	if (plat == kPlatformUnknown)
+		return "";
+
+	return String("plat_") + getPlatformDescription(plat);
+}
+
 List<String> getPlatformList() {
 	List<String> list;
 

--- a/common/platform.h
+++ b/common/platform.h
@@ -102,6 +102,8 @@ extern Platform parsePlatform(const String &str);
 extern const char *getPlatformCode(Platform id);
 extern const char *getPlatformAbbrev(Platform id);
 extern const char *getPlatformDescription(Platform id);
+extern const String getGameGUIOptionsDescriptionPlatform(Platform plat);
+extern bool checkGameGUIOptionPlatform(Platform plat, const String &str);
 
 List<String> getPlatformList();
 

--- a/common/platform.h
+++ b/common/platform.h
@@ -103,9 +103,25 @@ extern Platform parsePlatform(const String &str);
 extern const char *getPlatformCode(Platform id);
 extern const char *getPlatformAbbrev(Platform id);
 extern const char *getPlatformDescription(Platform id);
+
+/**
+* Return string containing platform description based on platform enum
+*/
 const String getGameGUIOptionsDescriptionPlatform(Platform plat);
+
+/**
+* Check if given platform option is present in a string
+*/
 bool checkGameGUIOptionPlatform(Platform plat, const String &str);
+
+/**
+* Parse gui options string to GUIO platform literals
+*/
 const String parseGameGUIOptionsPlatforms(const String &str);
+
+/**
+* Return string containing platform(s) description based on gui options string
+*/
 const String getGameGUIOptionsDescriptionPlatforms(const String &str);
 
 List<String> getPlatformList();

--- a/common/platform.h
+++ b/common/platform.h
@@ -88,6 +88,7 @@ enum Platform : int8 {
 };
 
 struct PlatformDescription {
+	const char *GUIOption;
 	const char *code;
 	const char *code2;
 	const char *abbrev;
@@ -102,8 +103,10 @@ extern Platform parsePlatform(const String &str);
 extern const char *getPlatformCode(Platform id);
 extern const char *getPlatformAbbrev(Platform id);
 extern const char *getPlatformDescription(Platform id);
-extern const String getGameGUIOptionsDescriptionPlatform(Platform plat);
-extern bool checkGameGUIOptionPlatform(Platform plat, const String &str);
+const String getGameGUIOptionsDescriptionPlatform(Platform plat);
+bool checkGameGUIOptionPlatform(Platform plat, const String &str);
+const String parseGameGUIOptionsPlatforms(const String &str);
+const String getGameGUIOptionsDescriptionPlatforms(const String &str);
 
 List<String> getPlatformList();
 

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -210,7 +210,7 @@ DetectedGame AdvancedMetaEngineDetectionBase::toDetectedGame(const ADDetectedGam
 
 	game.setGUIOptions(desc->guiOptions + _guiOptions);
 	game.appendGUIOptions(getGameGUIOptionsDescriptionLanguage(desc->language));
-	game.appendGUIOptions(getGameGUIOptionsDescriptionPlatform(desc->platform));
+	game.appendGUIOptions(Common::getGameGUIOptionsDescriptionPlatform(desc->platform));
 
 	if (desc->flags & ADGF_ADDENGLISH)
 		game.appendGUIOptions(getGameGUIOptionsDescriptionLanguage(Common::EN_ANY));

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -210,6 +210,7 @@ DetectedGame AdvancedMetaEngineDetectionBase::toDetectedGame(const ADDetectedGam
 
 	game.setGUIOptions(desc->guiOptions + _guiOptions);
 	game.appendGUIOptions(getGameGUIOptionsDescriptionLanguage(desc->language));
+	game.appendGUIOptions(getGameGUIOptionsDescriptionPlatform(desc->platform));
 
 	if (desc->flags & ADGF_ADDENGLISH)
 		game.appendGUIOptions(getGameGUIOptionsDescriptionLanguage(Common::EN_ANY));

--- a/engines/sci/detection.cpp
+++ b/engines/sci/detection.cpp
@@ -233,6 +233,8 @@ DetectedGames SciMetaEngineDetection::detectGames(const Common::FSList &fslist, 
 		}
 		game.setGUIOptions(customizeGuiOptions(fslist.begin()->getParent().getPath(), parseGameGUIOptions(game.getGUIOptions()), game.platform, g->gameidStr, g->version));
 		game.appendGUIOptions(getGameGUIOptionsDescriptionLanguage(game.language));
+		game.appendGUIOptions(getGameGUIOptionsDescriptionPlatform(game.platform));
+
 	}
 
 	return games;

--- a/engines/sci/detection.cpp
+++ b/engines/sci/detection.cpp
@@ -231,10 +231,9 @@ DetectedGames SciMetaEngineDetection::detectGames(const Common::FSList &fslist, 
 			if (game.gameId.equals(g->gameidStr))
 				break;
 		}
+
 		game.setGUIOptions(customizeGuiOptions(fslist.begin()->getParent().getPath(), parseGameGUIOptions(game.getGUIOptions()), game.platform, g->gameidStr, g->version));
 		game.appendGUIOptions(getGameGUIOptionsDescriptionLanguage(game.language));
-		game.appendGUIOptions(getGameGUIOptionsDescriptionPlatform(game.platform));
-
 	}
 
 	return games;

--- a/engines/sci/detection_tables.h
+++ b/engines/sci/detection_tables.h
@@ -19,6 +19,7 @@
  *
  */
 
+#include "common/gui_options.h"
 #include "common/translation.h"
 
 namespace Sci {
@@ -907,17 +908,19 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 							  GAMEOPTION_ORIGINAL_SAVELOAD, \
 							  GAMEOPTION_TTS, \
 							  GAMEOPTION_ENABLE_GMM_SAVE)
-#define GUIO_GK1_CD_DOS GUIO6(GUIO_LINKSPEECHTOSFX, \
+#define GUIO_GK1_CD_DOS GUIO7(GUIO_LINKSPEECHTOSFX, \
 							  GAMEOPTION_ORIGINAL_SAVELOAD, \
 							  GAMEOPTION_HIGH_RESOLUTION_GRAPHICS, \
 							  GAMEOPTION_HQ_VIDEO, \
 							  GAMEOPTION_ENABLE_GMM_SAVE, \
-							  GAMEOPTION_GK1_ENABLE_AUDIO_POPFIX)
-#define GUIO_GK1_CD_WIN GUIO5(GUIO_LINKSPEECHTOSFX, \
+							  GAMEOPTION_GK1_ENABLE_AUDIO_POPFIX, \
+							  GUIO_PLAT_WINDOWS)
+#define GUIO_GK1_CD_WIN GUIO6(GUIO_LINKSPEECHTOSFX, \
 							  GAMEOPTION_ORIGINAL_SAVELOAD, \
 							  GAMEOPTION_HQ_VIDEO, \
 							  GAMEOPTION_ENABLE_GMM_SAVE, \
-							  GAMEOPTION_GK1_ENABLE_AUDIO_POPFIX)
+							  GAMEOPTION_GK1_ENABLE_AUDIO_POPFIX, \
+							  GUIO_PLAT_DOS)
 #define GUIO_GK1_MAC    GUIO3(GUIO_NOSPEECH, \
 							  GAMEOPTION_TTS, \
 							  GAMEOPTION_ENABLE_GMM_SAVE)
@@ -5902,7 +5905,7 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		{"resource.004", 0, "0d8dfe42683b46f3131823233a91ce6a", 787066},
 		AD_LISTEND},
 		Common::EN_ANY, Common::kPlatformMacintosh, ADGF_UNSTABLE, GUIO_STD16_MAC_PALETTEMODS	},
-		
+
 	// Space Quest 3 - Hebrew DOS (from the Space Quest Collection)
 	// Executable scanning reports "0.000.685", VERSION file reports "1.018"
 	// This translation is still a work in progress
@@ -5914,7 +5917,7 @@ static const struct ADGameDescription SciGameDescriptions[] = {
 		{"PATCHES/font.000", 0, "6fab182f1c071d1ed47be27776964baf", 3334},
 		AD_LISTEND},
 		Common::HE_ISR, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_STD16_PALETTEMODS },
-		
+
 	// Space Quest 3 - Spanish fan translation. VERSION file reports "06/03/2002"
 	{ "sq3", "", {
 		{"resource.map", 0, "9ba042c797b62dd46d8979caeed61116", 3726},

--- a/engines/sci/metaengine.cpp
+++ b/engines/sci/metaengine.cpp
@@ -215,7 +215,9 @@ Common::Error SciMetaEngine::createInstance(OSystem *syst, Engine **engine, cons
 			*engine = new SciEngine(syst, desc, g->gameidEnum);
 
 			// If the GUI options were updated, we catch this here and update them in the users config file transparently.
-			Common::updateGameGUIOptions(customizeGuiOptions(ConfMan.getPath("path"), desc->guiOptions, desc->platform, g->gameidStr, g->version), getGameGUIOptionsDescriptionLanguage(desc->language));
+			Common::updateGameGUIOptions(customizeGuiOptions(ConfMan.getPath("path"), desc->guiOptions, desc->platform, g->gameidStr, g->version),
+										 getGameGUIOptionsDescriptionLanguage(desc->language),
+										 getGameGUIOptionsDescriptionPlatform(desc->platform));
 
 			return Common::kNoError;
 		}

--- a/engines/scumm/detection.cpp
+++ b/engines/scumm/detection.cpp
@@ -217,6 +217,8 @@ DetectedGames ScummMetaEngineDetection::detectGames(const Common::FSList &fslist
 
 		game.setGUIOptions(customizeGuiOptions(*x));
 		game.appendGUIOptions(getGameGUIOptionsDescriptionLanguage(x->language));
+		game.appendGUIOptions(getGameGUIOptionsDescriptionPlatform(x->game.platform));
+
 
 		detectedGames.push_back(game);
 	}

--- a/engines/scumm/metaengine.cpp
+++ b/engines/scumm/metaengine.cpp
@@ -420,7 +420,7 @@ Common::Error ScummMetaEngine::createInstance(OSystem *syst, Engine **engine,
 
 	// If the GUI options were updated, we catch this here and update them in the users config
 	// file transparently.
-	Common::updateGameGUIOptions(customizeGuiOptions(res), getGameGUIOptionsDescriptionLanguage(res.language));
+	Common::updateGameGUIOptions(customizeGuiOptions(res), getGameGUIOptionsDescriptionLanguage(res.language), getGameGUIOptionsDescriptionPlatform(res.game.platform));
 
 	// If the game was added really long ago, it may be missing its "extra"
 	// field. When adding game-specific options, it may be our only way of

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -381,7 +381,8 @@ void EditGameDialog::addGameControls(GuiObject *boss, const Common::String &pref
 	_platformPopUp->appendEntry("");
 	const Common::PlatformDescription *p = Common::g_platforms;
 	for (; p->code; ++p) {
-		_platformPopUp->appendEntry(p->description, p->id);
+		if (checkGameGUIOptionPlatform(p->id, _guioptionsString))
+			_platformPopUp->appendEntry(p->description, p->id);
 	}
 }
 
@@ -393,7 +394,6 @@ void EditGameDialog::setupGraphicsTab() {
 void EditGameDialog::open() {
 	OptionsDialog::open();
 
-	int sel, i;
 	bool e;
 
 	// En-/disable dialog items depending on whether overrides are active or not.
@@ -462,14 +462,21 @@ void EditGameDialog::open() {
 		_engineOptions->load();
 	}
 
-	const Common::PlatformDescription *p = Common::g_platforms;
 	const Common::Platform platform = Common::parsePlatform(ConfMan.get("platform", _domain));
-	sel = 0;
-	for (i = 0; p->code; ++p, ++i) {
-		if (platform == p->id)
-			sel = i + 2;
+
+	if (ConfMan.hasKey("platform", _domain)) {
+		_platformPopUp->setSelectedTag(platform);
+	} else {
+		_platformPopUp->setSelectedTag((uint32)Common::kPlatformUnknown);
 	}
-	_platformPopUp->setSelected(sel);
+
+	// First entry is <default>
+	// Second entry is ""
+	// So from third entry onwards are actual platforms - same logic as for language
+	if (_platformPopUp->numEntries() <= 3) {
+		_platformPopUpDesc->setEnabled(false);
+		_platformPopUp->setEnabled(false);
+	}
 }
 
 void EditGameDialog::close() {


### PR DESCRIPTION
The logic for restriction is as follows:
1. If platform for a game in the detection tables is Common::kPlatformUnknown - nothing will change and all platforms will be available for selection.
2. If platform is anything else and no GUIO_PLAT_* was added to the game gui options - platform selection will be grayed out.
3. If platform is anything else and some GUIO_PLAT_* was added to the game gui options - only these platforms will be available for selection. 

Cases 1 and 2 are basically the same as for language.

Sadly I did not find a way to avoid adding all GUIO_PLAT_ defines, but they are coupled with g_platforms global so if something will be changed there it should be clear that some define should be added or modified. 

I've updated Gabriel Knight entries in detection tables as they seem to support changing platforms after detection, but I am not sure how to find all games that support this behavior.

![Platform_selection](https://github.com/user-attachments/assets/eeb8864a-590b-42e1-8cd0-cb76da3bdcef)

I was thinking about changing the name of the game after it was started with new platform (so it can be flushed by the ConfMan), but it will probably just be confusing.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
