### PR TITLE
GRAPHICS: Set hwFormat as first supported format in surfacesdl

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -613,52 +613,8 @@ void SurfaceSdlGraphicsManager::detectSupportedFormats() {
 		// on blitting. This gives us a lot more performance on low perf hardware.
 		_supportedFormats.push_back(hwFormat);
 
-#if !SDL_VERSION_ATLEAST(2, 0, 0)
 		format = hwFormat;
-#endif
 	}
-
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	{
-#if SDL_VERSION_ATLEAST(3, 0, 0)
-		const SDL_DisplayMode* pDefaultMode = SDL_GetDesktopDisplayMode(_window->getDisplayIndex());
-		if (!pDefaultMode) {
-			error("Could not get default system display mode");
-		}
-
-		int bpp;
-		Uint32 rMask, gMask, bMask, aMask;
-		if (!SDL_GetMasksForPixelFormat(pDefaultMode->format, &bpp, &rMask, &gMask, &bMask, &aMask)) {
-			error("Could not convert system pixel format %s to masks", SDL_GetPixelFormatName(pDefaultMode->format));
-		}
-
-		const uint8 bytesPerPixel = SDL_BYTESPERPIXEL(pDefaultMode->format);
-#else
-		SDL_DisplayMode defaultMode;
-		if (SDL_GetDesktopDisplayMode(_window->getDisplayIndex(), &defaultMode) != 0) {
-			error("Could not get default system display mode");
-		}
-
-		int bpp;
-		Uint32 rMask, gMask, bMask, aMask;
-		if (SDL_PixelFormatEnumToMasks(defaultMode.format, &bpp, &rMask, &gMask, &bMask, &aMask) != SDL_TRUE) {
-			error("Could not convert system pixel format %s to masks", SDL_GetPixelFormatName(defaultMode.format));
-		}
-
-		const uint8 bytesPerPixel = SDL_BYTESPERPIXEL(defaultMode.format);
-#endif
-
-		uint8 rBits, rShift, gBits, gShift, bBits, bShift, aBits, aShift;
-		maskToBitCount(rMask, rBits, rShift);
-		maskToBitCount(gMask, gBits, gShift);
-		maskToBitCount(bMask, bBits, bShift);
-		maskToBitCount(aMask, aBits, aShift);
-
-		format = Graphics::PixelFormat(bytesPerPixel, rBits, gBits, bBits, aBits, rShift, gShift, bShift, aShift);
-
-		_supportedFormats.push_back(format);
-	}
-#endif
 
 	if (!_isHwPalette) {
 		// Some tables with standard formats that we always list

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -605,6 +605,19 @@ void SurfaceSdlGraphicsManager::detectSupportedFormats() {
 
 	Graphics::PixelFormat format = Graphics::PixelFormat::createFormatCLUT8();
 
+	if (_hwScreen) {
+		// Get our currently set hardware format
+		Graphics::PixelFormat hwFormat = convertSDLPixelFormat(_hwScreen->format);
+
+		// This is the first supported format to prevent pixel format conversion
+		// on blitting. This gives us a lot more performance on low perf hardware.
+		_supportedFormats.push_back(hwFormat);
+
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
+		format = hwFormat;
+#endif
+	}
+
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	{
 #if SDL_VERSION_ATLEAST(3, 0, 0)
@@ -646,17 +659,6 @@ void SurfaceSdlGraphicsManager::detectSupportedFormats() {
 		_supportedFormats.push_back(format);
 	}
 #endif
-
-	if (_hwScreen) {
-		// Get our currently set hardware format
-		Graphics::PixelFormat hwFormat = convertSDLPixelFormat(_hwScreen->format);
-
-		_supportedFormats.push_back(hwFormat);
-
-#if !SDL_VERSION_ATLEAST(2, 0, 0)
-		format = hwFormat;
-#endif
-	}
 
 	if (!_isHwPalette) {
 		// Some tables with standard formats that we always list


### PR DESCRIPTION
surfacesdl forces RGB565 pixel format for the hardware screen but the first supported format returned by detectSupportedFormats() may be very different (RGB565 VS ABGR8888 on PSP2 for example) thus a pixel format conversion is done at each blitting when calling SDL_BlitSurface().
On PSP2 with BladeRunner this conversion + blitting takes ~60ms. By moving the hardware screen format first on the
detectSupportedFormats() we will use RGB565 for all surfaces. By removing the format conversion on PSP2 we go down to ~2-3ms per frame.

This makes BladeRunner very playable on PSP2.

It may have a performance (positive) impact on other sdlsurface-based platforms.