### PR TITLE
AUDIO: Create a wrapper around the PCSpeaker emulator that handles the mixer stream

### DIFF
--- a/engines/agi/preagi/preagi.cpp
+++ b/engines/agi/preagi/preagi.cpp
@@ -37,8 +37,6 @@ PreAgiEngine::PreAgiEngine(OSystem *syst, const AGIGameDescription *gameDesc) : 
 	syncSoundSettings();
 
 	memset(&_debug, 0, sizeof(struct AgiDebug));
-
-	_speakerHandle = new Audio::SoundHandle();
 }
 
 void PreAgiEngine::initialize() {
@@ -57,9 +55,8 @@ void PreAgiEngine::initialize() {
 
 	_gfx->initVideo();
 
-	_speakerStream = new Audio::PCSpeaker(_mixer->getOutputRate());
-	_mixer->playStream(Audio::Mixer::kSFXSoundType, _speakerHandle,
-	                   _speakerStream, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO, true);
+	_speaker = new Audio::PCSpeaker();
+	_speaker->init();
 
 	debugC(2, kDebugLevelMain, "Detect game");
 
@@ -73,9 +70,7 @@ void PreAgiEngine::initialize() {
 }
 
 PreAgiEngine::~PreAgiEngine() {
-	_mixer->stopHandle(*_speakerHandle);
-	delete _speakerStream;
-	delete _speakerHandle;
+	delete _speaker;
 
 	delete _gfx;
 	delete _font;
@@ -288,7 +283,7 @@ int PreAgiEngine::getSelection(SelectionTypes type) {
 bool PreAgiEngine::playSpeakerNote(int16 frequency, int32 length, WaitOptions options) {
 	// play note, unless this is a pause
 	if (frequency != 0) {
-		_speakerStream->play(Audio::PCSpeaker::kWaveFormSquare, frequency, length);
+		_speaker->play(Audio::PCSpeaker::kWaveFormSquare, frequency, length);
 	}
 
 	// wait for note length
@@ -297,7 +292,7 @@ bool PreAgiEngine::playSpeakerNote(int16 frequency, int32 length, WaitOptions op
 	// stop note if the wait was interrupted
 	if (!completed) {
 		if (frequency != 0) {
-			_speakerStream->stop();
+			_speaker->stop();
 		}
 	}
 

--- a/engines/agi/preagi/preagi.h
+++ b/engines/agi/preagi/preagi.h
@@ -25,7 +25,6 @@
 #include "agi/agi.h"
 
 namespace Audio {
-class SoundHandle;
 class PCSpeaker;
 }
 
@@ -112,8 +111,7 @@ protected:
 private:
 	int _defaultColor;
 
-	Audio::PCSpeaker *_speakerStream;
-	Audio::SoundHandle *_speakerHandle;
+	Audio::PCSpeaker *_speaker;
 };
 
 } // End of namespace Agi

--- a/engines/agi/sound_a2.h
+++ b/engines/agi/sound_a2.h
@@ -52,7 +52,7 @@ public:
 private:
 	Common::Mutex _mutex;
 	bool _isPlaying;
-	Audio::PCSpeaker _speaker;
+	Audio::PCSpeakerStream _speaker;
 };
 
 } // End of namespace Agi

--- a/engines/agi/sound_coco3.h
+++ b/engines/agi/sound_coco3.h
@@ -52,7 +52,7 @@ public:
 private:
 	Common::Mutex _mutex;
 	bool _isPlaying;
-	Audio::PCSpeaker _speaker;
+	Audio::PCSpeakerStream _speaker;
 };
 
 } // End of namespace Agi

--- a/engines/avalanche/sound.cpp
+++ b/engines/avalanche/sound.cpp
@@ -29,13 +29,12 @@ namespace Avalanche {
 
 SoundHandler::SoundHandler(AvalancheEngine *vm) : _vm(vm) {
 	_soundFl = true;
-	_speakerStream = new Audio::PCSpeaker(_vm->_mixer->getOutputRate());
-	_vm->_mixer->playStream(Audio::Mixer::kSFXSoundType, &_speakerHandle,
-						_speakerStream, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::YES, true);
+	_speaker = new Audio::PCSpeaker();
+	_speaker->init();
 }
 
 SoundHandler::~SoundHandler() {
-	_vm->_mixer->stopHandle(_speakerHandle);
+	delete _speaker;
 }
 
 /**
@@ -70,7 +69,7 @@ void SoundHandler::playNote(int freq, int length) {
 		return;
 
 	// Start a note playing (we will stop it when the timer expires).
-	_speakerStream->play(Audio::PCSpeaker::kWaveFormSquare, freq, length);
+	_speaker->play(Audio::PCSpeaker::kWaveFormSquare, freq, length);
 }
 
 void SoundHandler::click() {

--- a/engines/avalanche/sound.h
+++ b/engines/avalanche/sound.h
@@ -46,8 +46,7 @@ public:
 
 private:
 	AvalancheEngine *_vm;
-	Audio::PCSpeaker *_speakerStream;
-	Audio::SoundHandle _speakerHandle;
+	Audio::PCSpeaker *_speaker;
 };
 
 } // End of namespace Avalanche

--- a/engines/chamber/chamber.cpp
+++ b/engines/chamber/chamber.cpp
@@ -55,11 +55,6 @@ ChamberEngine::ChamberEngine(OSystem *syst, const ADGameDescription *desc)
 	_videoMode = Common::kRenderCGA;
 	_screenH = _screenW = _screenBits = _screenBPL = _screenPPB = 0;
 	_line_offset = _line_offset2 = _fontHeight = _fontWidth = 0;
-
-
-
-	_speakerHandle = NULL;
-	_speakerStream = NULL;
 }
 
 ChamberEngine::~ChamberEngine() {

--- a/engines/chamber/chamber.h
+++ b/engines/chamber/chamber.h
@@ -85,8 +85,7 @@ public:
 	uint8 _fontWidth; ///< Font height
 
 
-	Audio::PCSpeaker *_speakerStream;
-	Audio::SoundHandle *_speakerHandle;
+	Audio::PCSpeaker *_speaker;
 
 private:
 	const ADGameDescription *_gameDescription;

--- a/engines/chamber/sound.cpp
+++ b/engines/chamber/sound.cpp
@@ -70,8 +70,8 @@ static void speakerPlay(pcsample_t *sample) {
 		uint32 delayOff = delay1 * 16; // Around 335 ticks per second
 		uint32 delayOn = delay2 * 16;
 
-		g_vm->_speakerStream->playQueue(Audio::PCSpeaker::kWaveFormSilence, frequency, delayOff);
-		g_vm->_speakerStream->playQueue(Audio::PCSpeaker::kWaveFormSquare, frequency, delayOn);
+		g_vm->_speaker->playQueue(Audio::PCSpeaker::kWaveFormSilence, frequency, delayOff);
+		g_vm->_speaker->playQueue(Audio::PCSpeaker::kWaveFormSquare, frequency, delayOn);
 
 		if (sample->delay1sweep & 0xF000)
 			delay1 -= sample->delay1sweep & 0xFFF;
@@ -126,16 +126,12 @@ void ChamberEngine::initSound() {
 	// Setup mixer
 	syncSoundSettings();
 
-	_speakerHandle = new Audio::SoundHandle();
-	_speakerStream = new Audio::PCSpeaker(_mixer->getOutputRate());
-	_mixer->playStream(Audio::Mixer::kSFXSoundType, _speakerHandle,
-		_speakerStream, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO, true);
+	_speaker = new Audio::PCSpeaker();
+	_speaker->init();
 }
 
 void ChamberEngine::deinitSound() {
-	_mixer->stopHandle(*_speakerHandle);
-	delete g_vm->_speakerHandle;
-	delete g_vm->_speakerStream;
+	delete g_vm->_speaker;
 }
 
 } // End of namespace Chamber

--- a/engines/director/sound.cpp
+++ b/engines/director/sound.cpp
@@ -54,8 +54,7 @@ DirectorSound::DirectorSound(Window *window) : _window(window) {
 	_mixer = g_system->getMixer();
 
 	_speaker = new Audio::PCSpeaker();
-	_mixer->playStream(Audio::Mixer::kSFXSoundType,
-		&_pcSpeakerHandle, _speaker, -1, 50, 0, DisposeAfterUse::NO, true);
+	_speaker->init();
 
 	_enable = true;
 }
@@ -521,7 +520,7 @@ void DirectorSound::stopSound() {
 	}
 
 	_mixer->stopHandle(_scriptSound);
-	_mixer->stopHandle(_pcSpeakerHandle);
+	_speaker->quit();
 }
 
 void DirectorSound::systemBeep() {

--- a/engines/director/sound.h
+++ b/engines/director/sound.h
@@ -162,7 +162,6 @@ private:
 	Audio::SoundHandle _scriptSound;
 	Audio::Mixer *_mixer;
 	Audio::PCSpeaker *_speaker;
-	Audio::SoundHandle _pcSpeakerHandle;
 
 	// these two were used in fplay xobj
 	Common::Queue<Common::String> _fplayQueue;

--- a/engines/efh/efh.h
+++ b/engines/efh/efh.h
@@ -640,8 +640,7 @@ private:
 
 	int16 _regenCounter;
 
-	Audio::PCSpeaker *_speakerStream;
-	Audio::SoundHandle _speakerHandle;
+	Audio::PCSpeaker *_speaker;
 };
 
 } // End of namespace Efh

--- a/engines/efh/init.cpp
+++ b/engines/efh/init.cpp
@@ -394,8 +394,6 @@ EfhEngine::EfhEngine(OSystem *syst, const ADGameDescription *gd) : Engine(syst),
 	_loadSaveSlot = -1;
 	_saveAuthorized = false;
 
-	_speakerStream = nullptr;
-
 	if (ConfMan.hasKey("save_slot")) {
 		int saveSlot = ConfMan.getInt("save_slot");
 		if (saveSlot >= 0 && saveSlot <= 999)

--- a/engines/efh/sound.cpp
+++ b/engines/efh/sound.cpp
@@ -36,9 +36,9 @@ void EfhEngine::songDelay(int delay) {
 void EfhEngine::playNote(int frequencyIndex, int totalDelay) {
 	debugC(3, kDebugEngine, "playNote %d %d", frequencyIndex, totalDelay);
 	if (frequencyIndex > 0 && frequencyIndex < 72) {
-		_speakerStream->play(Audio::PCSpeaker::kWaveFormSquare, 0x1234DD / kSoundFrequency[frequencyIndex], -1);
+		_speaker->play(Audio::PCSpeaker::kWaveFormSquare, 0x1234DD / kSoundFrequency[frequencyIndex], -1);
 		songDelay(totalDelay);
-		_speakerStream->stop();
+		_speaker->stop();
 	} else {
 		warning("playNote - Skip note with frequency index %d", frequencyIndex);
 	}
@@ -47,9 +47,8 @@ void EfhEngine::playNote(int frequencyIndex, int totalDelay) {
 Common::KeyCode EfhEngine::playSong(uint8 *buffer) {
 	debugC(3, kDebugEngine, "playSong");
 
-	_speakerStream = new Audio::PCSpeaker(_mixer->getOutputRate());
-	_mixer->playStream(Audio::Mixer::kSFXSoundType, &_speakerHandle,
-					   _speakerStream, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO, true);
+	_speaker = new Audio::PCSpeaker();
+	_speaker->init();
 
 	Common::KeyCode inputChar = Common::KEYCODE_INVALID;
 	int totalDelay = 0;
@@ -92,9 +91,8 @@ Common::KeyCode EfhEngine::playSong(uint8 *buffer) {
 		}
 	} while (stopFl != 0 && !shouldQuit());
 
-	_mixer->stopHandle(_speakerHandle);
-	delete _speakerStream;
-	_speakerStream = nullptr;
+	delete _speaker;
+	_speaker = nullptr;
 
 	return inputChar;
 }
@@ -111,28 +109,25 @@ void EfhEngine::generateSound1(int lowFreq, int highFreq, int duration) {
 	uint16 var2 = 0;
 	duration /= 20;
 
-	_speakerStream = new Audio::PCSpeaker(_mixer->getOutputRate());
-	_mixer->playStream(Audio::Mixer::kSFXSoundType, &_speakerHandle,
-					   _speakerStream, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO, true);
+	_speaker = new Audio::PCSpeaker();
+	_speaker->init();
 
-	_speakerStream->play(Audio::PCSpeaker::kWaveFormSquare, highFreq, -1);
+	_speaker->play(Audio::PCSpeaker::kWaveFormSquare, highFreq, -1);
 	songDelay(10);
-	_speakerStream->stop();
+	_speaker->stop();
 
 
 	for (int i = 0; i < duration; ++i) {
 		var2 = ROR(var2 + 0x9248, 3);
 		int val = (var2 * (highFreq - lowFreq)) >> 16;
 
-		_speakerStream->play(Audio::PCSpeaker::kWaveFormSquare, lowFreq + val, -1);
+		_speaker->play(Audio::PCSpeaker::kWaveFormSquare, lowFreq + val, -1);
 		songDelay(10);
-		_speakerStream->stop();
+		_speaker->stop();
 	}
 
-
-	_mixer->stopHandle(_speakerHandle);
-	delete _speakerStream;
-	_speakerStream = nullptr;
+	delete _speaker;
+	_speaker = nullptr;
 }
 
 void EfhEngine::generateSound2(int startFreq, int endFreq, int speed) {
@@ -151,42 +146,38 @@ void EfhEngine::generateSound2(int startFreq, int endFreq, int speed) {
 	else
 		delta = 50;
 
-	_speakerStream = new Audio::PCSpeaker(_mixer->getOutputRate());
-	_mixer->playStream(Audio::Mixer::kSFXSoundType, &_speakerHandle,
-					   _speakerStream, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO, true);
+	_speaker = new Audio::PCSpeaker();
+	_speaker->init();
 
 	int curFreq = startFreq;
 
 	do {
-		_speakerStream->play(Audio::PCSpeaker::kWaveFormSquare, curFreq, -1);
+		_speaker->play(Audio::PCSpeaker::kWaveFormSquare, curFreq, -1);
 		// The original is just looping, making the sound improperly timed as the length of a loop is directly related to the speed of the CPU
 		// Dividing by 10 is just a guess based on how it sounds. I suspect it may be still too much
 		songDelay(speed);
-		_speakerStream->stop();
+		_speaker->stop();
 		curFreq += delta;
 	} while (curFreq < endFreq && !shouldQuit());
 
 
-	_mixer->stopHandle(_speakerHandle);
-	delete _speakerStream;
-	_speakerStream = nullptr;
+	delete _speaker;
+	_speaker = nullptr;
 
 }
 
 void EfhEngine::generateSound3() {
 	debugC(3, kDebugEngine, "generateSound3");
-	_speakerStream = new Audio::PCSpeaker(_mixer->getOutputRate());
-	_mixer->playStream(Audio::Mixer::kSFXSoundType, &_speakerHandle,
-					   _speakerStream, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO, true);
+	_speaker = new Audio::PCSpeaker();
+	_speaker->init();
 
-	_speakerStream->play(Audio::PCSpeaker::kWaveFormSquare, 88, -1);
+	_speaker->play(Audio::PCSpeaker::kWaveFormSquare, 88, -1);
 	// The original makes me think the delay is so short it's not possible to hear. So that delay is guessed (and short)
 	songDelay(30);
-	_speakerStream->stop();
+	_speaker->stop();
 
-	_mixer->stopHandle(_speakerHandle);
-	delete _speakerStream;
-	_speakerStream = nullptr;
+	delete _speaker;
+	_speaker = nullptr;
 }
 
 void EfhEngine::generateSound4(int repeat) {

--- a/engines/freescape/sound.h
+++ b/engines/freescape/sound.h
@@ -51,7 +51,7 @@ struct soundSpeakerFx {
 	Common::Array<struct soundSpeakerFx *>additionalSteps;
 };
 
-class SizedPCSpeaker : public Audio::PCSpeaker {
+class SizedPCSpeaker : public Audio::PCSpeakerStream {
 public:
 	bool endOfStream() const override { return !isPlaying(); }
 };

--- a/engines/glk/glk.cpp
+++ b/engines/glk/glk.cpp
@@ -82,7 +82,7 @@ void GlkEngine::initialize() {
 	_screen->initialize();
 	_clipboard = new Clipboard();
 	_events = new Events();
-	_pcSpeaker = new PCSpeaker(_mixer);
+	_pcSpeaker = new PCSpeaker();
 	_pictures = new Pictures();
 	_selection = new Selection();
 	_sounds = new Sounds();

--- a/engines/glk/pc_speaker.cpp
+++ b/engines/glk/pc_speaker.cpp
@@ -24,28 +24,26 @@
 
 namespace Glk {
 
-PCSpeaker::PCSpeaker(Audio::Mixer *mixer) : _mixer(mixer) {
-	_stream = new Audio::PCSpeaker(_mixer->getOutputRate());
-	_mixer->playStream(Audio::Mixer::kSFXSoundType,
-			&_handle, _stream, -1, 50, 0, DisposeAfterUse::NO, true);
+PCSpeaker::PCSpeaker() {
+	_speaker = new Audio::PCSpeaker();
+	_speaker->init();
 }
 
 PCSpeaker::~PCSpeaker() {
-	_mixer->stopHandle(_handle);
-	delete _stream;
+	delete _speaker;
 }
 
 void PCSpeaker::speakerOn(int16 frequency, int32 length) {
-	_stream->play(Audio::PCSpeaker::kWaveFormSquare, frequency, length);
+	_speaker->play(Audio::PCSpeaker::kWaveFormSquare, frequency, length);
 }
 
 void PCSpeaker::speakerOff() {
-	_stream->stop();
+	_speaker->stop();
 }
 
 void PCSpeaker::onUpdate(uint32 millis) {
-	if (_stream->isPlaying())
-		_stream->stop(millis);
+	if (_speaker->isPlaying())
+		_speaker->stop(millis);
 }
 
 } // End of namespace Glk

--- a/engines/glk/pc_speaker.h
+++ b/engines/glk/pc_speaker.h
@@ -22,7 +22,7 @@
 #ifndef GLK_PC_SPEAKER_H
 #define GLK_PC_SPEAKER_H
 
-#include "audio/mixer.h"
+#include "common/scummsys.h"
 
 namespace Audio {
 class PCSpeaker;
@@ -32,11 +32,9 @@ namespace Glk {
 
 class PCSpeaker {
 private:
-	Audio::Mixer *_mixer;
-	Audio::PCSpeaker *_stream;
-	Audio::SoundHandle _handle;
+	Audio::PCSpeaker *_speaker;
 public:
-	PCSpeaker(Audio::Mixer *mixer);
+	PCSpeaker();
 	~PCSpeaker();
 
 	void speakerOn(int16 frequency, int32 length = -1);

--- a/engines/gob/sound/pcspeaker.cpp
+++ b/engines/gob/sound/pcspeaker.cpp
@@ -30,29 +30,26 @@
 
 namespace Gob {
 
-PCSpeaker::PCSpeaker(Audio::Mixer &mixer) : _mixer(&mixer) {
-
-	_stream = new Audio::PCSpeaker(_mixer->getOutputRate());
-	_mixer->playStream(Audio::Mixer::kSFXSoundType,
-			&_handle, _stream, -1, 50, 0, DisposeAfterUse::NO, true);
+PCSpeaker::PCSpeaker() {
+	_speaker = new Audio::PCSpeaker();
+	_speaker->init();
 }
 
 PCSpeaker::~PCSpeaker() {
-	_mixer->stopHandle(_handle);
-	delete _stream;
+	delete _speaker;
 }
 
 void PCSpeaker::speakerOn(int16 frequency, int32 length) {
-	_stream->play(Audio::PCSpeaker::kWaveFormSquare, frequency, length);
+	_speaker->play(Audio::PCSpeaker::kWaveFormSquare, frequency, length);
 }
 
 void PCSpeaker::speakerOff() {
-	_stream->stop();
+	_speaker->stop();
 }
 
 void PCSpeaker::onUpdate(uint32 millis) {
-	if (_stream->isPlaying())
-		_stream->stop(millis);
+	if (_speaker->isPlaying())
+		_speaker->stop(millis);
 }
 
 } // End of namespace Gob

--- a/engines/gob/sound/pcspeaker.h
+++ b/engines/gob/sound/pcspeaker.h
@@ -28,7 +28,7 @@
 #ifndef GOB_SOUND_PCSPEAKER_H
 #define GOB_SOUND_PCSPEAKER_H
 
-#include "audio/mixer.h"
+#include "common/scummsys.h"
 
 namespace Audio {
 class PCSpeaker;
@@ -38,7 +38,7 @@ namespace Gob {
 
 class PCSpeaker {
 public:
-	PCSpeaker(Audio::Mixer &mixer);
+	PCSpeaker();
 	~PCSpeaker();
 
 	void speakerOn(int16 frequency, int32 length = -1);
@@ -46,10 +46,7 @@ public:
 	void onUpdate(uint32 millis);
 
 private:
-	Audio::Mixer *_mixer;
-
-	Audio::PCSpeaker *_stream;
-	Audio::SoundHandle _handle;
+	Audio::PCSpeaker *_speaker;
 };
 
 } // End of namespace Gob

--- a/engines/gob/sound/sound.cpp
+++ b/engines/gob/sound/sound.cpp
@@ -45,7 +45,7 @@
 namespace Gob {
 
 Sound::Sound(GobEngine *vm) : _vm(vm) {
-	_pcspeaker = new PCSpeaker(*_vm->_mixer);
+	_pcspeaker = new PCSpeaker();
 	_blaster = new SoundBlaster(*_vm->_mixer);
 
 	_adlPlayer = nullptr;

--- a/engines/hugo/sound.h
+++ b/engines/hugo/sound.h
@@ -94,8 +94,7 @@ private:
 	HugoEngine *_vm;
 	Audio::SoundHandle _soundHandle;
 	MidiPlayer *_midiPlayer;
-	Audio::PCSpeaker *_speakerStream;
-	Audio::SoundHandle _speakerHandle;
+	Audio::PCSpeaker *_speaker;
 
 	void stopSound();
 	void stopMusic();

--- a/engines/kyra/sound/drivers/pcspeaker_v2.cpp
+++ b/engines/kyra/sound/drivers/pcspeaker_v2.cpp
@@ -35,7 +35,7 @@ MidiDriver_PCSpeaker::MidiDriver_PCSpeaker(Audio::Mixer *mixer)
 	for (int i = 0; i < 2; ++i)
 		_note[i].hardwareChannel = 0xFF;
 
-	_speaker = new Audio::PCSpeaker(_rate);
+	_speaker = new Audio::PCSpeakerStream(_rate);
 	assert(_speaker);
 	_mixer->playStream(Audio::Mixer::kMusicSoundType, &_mixerSoundHandle, this, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO, true);
 

--- a/engines/kyra/sound/sound_intern.h
+++ b/engines/kyra/sound/sound_intern.h
@@ -37,7 +37,7 @@ class EuphonyPlayer;
 class TownsPC98_AudioDriver;
 
 namespace Audio {
-class PCSpeaker;
+class PCSpeakerStream;
 class MaxTrax;
 } // End of namespace Audio
 
@@ -265,7 +265,7 @@ public:
 	int getRate() const override { return _rate; }
 private:
 	Common::Mutex _mutex;
-	Audio::PCSpeaker *_speaker;
+	Audio::PCSpeakerStream *_speaker;
 	int _rate;
 
 	struct Channel {

--- a/engines/made/scriptfuncs.cpp
+++ b/engines/made/scriptfuncs.cpp
@@ -39,8 +39,8 @@ ScriptFunctions::ScriptFunctions(MadeEngine *vm) : _vm(vm), _soundStarted(false)
 	// Initialize the two tone generators
 	_pcSpeaker1 = new Audio::PCSpeaker();
 	_pcSpeaker2 = new Audio::PCSpeaker();
-	_vm->_system->getMixer()->playStream(Audio::Mixer::kMusicSoundType, &_pcSpeakerHandle1, _pcSpeaker1);
-	_vm->_system->getMixer()->playStream(Audio::Mixer::kMusicSoundType, &_pcSpeakerHandle2, _pcSpeaker2);
+	_pcSpeaker1->init();
+	_pcSpeaker2->init();
 	_soundResource = nullptr;
 }
 

--- a/engines/scumm/imuse/drivers/pcspk.h
+++ b/engines/scumm/imuse/drivers/pcspk.h
@@ -47,7 +47,7 @@ protected:
 	void onTimer() override;
 
 private:
-	Audio::PCSpeaker _pcSpk;
+	Audio::PCSpeakerStream _pcSpk;
 	int _effectTimer;
 	uint8 _randBase;
 

--- a/engines/testbed/sound.cpp
+++ b/engines/testbed/sound.cpp
@@ -55,9 +55,9 @@ SoundSubsystemDialog::SoundSubsystemDialog() : TestbedInteractionDialog(80, 60, 
 	_mixer = g_system->getMixer();
 
 	// the three streams to be mixed
-	Audio::PCSpeaker *s1 = new Audio::PCSpeaker();
-	Audio::PCSpeaker *s2 = new Audio::PCSpeaker();
-	Audio::PCSpeaker *s3 = new Audio::PCSpeaker();
+	Audio::PCSpeakerStream *s1 = new Audio::PCSpeakerStream();
+	Audio::PCSpeakerStream *s2 = new Audio::PCSpeakerStream();
+	Audio::PCSpeakerStream *s3 = new Audio::PCSpeakerStream();
 
 	s1->play(Audio::PCSpeaker::kWaveFormSine, 1000, -1);
 	s2->play(Audio::PCSpeaker::kWaveFormSine, 1200, -1);
@@ -125,7 +125,7 @@ TestExitStatus SoundSubsystem::playBeeps() {
 		return kTestSkipped;
 	}
 
-	Audio::PCSpeaker *speaker = new Audio::PCSpeaker();
+	Audio::PCSpeakerStream *speaker = new Audio::PCSpeakerStream();
 	Audio::Mixer *mixer = g_system->getMixer();
 	Audio::SoundHandle handle;
 	mixer->playStream(Audio::Mixer::kPlainSoundType, &handle, speaker);
@@ -306,11 +306,11 @@ TestExitStatus SoundSubsystem::sampleRates() {
 	TestExitStatus passed = kTestPassed;
 	Audio::Mixer *mixer = g_system->getMixer();
 
-	Audio::PCSpeaker *s1 = new Audio::PCSpeaker();
+	Audio::PCSpeakerStream *s1 = new Audio::PCSpeakerStream();
 	// Stream at half sampling rate
-	Audio::PCSpeaker *s2 = new Audio::PCSpeaker(s1->getRate() - 10000);
+	Audio::PCSpeakerStream *s2 = new Audio::PCSpeakerStream(s1->getRate() - 10000);
 	// Stream at twice sampling rate
-	Audio::PCSpeaker *s3 = new Audio::PCSpeaker(s1->getRate() + 10000);
+	Audio::PCSpeakerStream *s3 = new Audio::PCSpeakerStream(s1->getRate() + 10000);
 
 	s1->play(Audio::PCSpeaker::kWaveFormSine, 1000, -1);
 	s2->play(Audio::PCSpeaker::kWaveFormSine, 1000, -1);


### PR DESCRIPTION
This should hopefully make it easier to add `Audio::Chip` support for PC Speaker in the future. 

Notes:
* The AGI, Freescape, Kyra, SCUMM and Testbed engines still directly use the audio stream.
* How should the volume and sound type be handled?
* MADE and Testbed create multiple PC Speaker objects and are the only engines to use non-square wave forms. For MADE, how did the original executable implement the relevant functionality (the piano and telephone in The Manhole EGA/NE)?