### PR TITLE
AGI: make fallback-detected fanmade games use fanmade options

### DIFF
--- a/engines/agi/detection.cpp
+++ b/engines/agi/detection.cpp
@@ -286,7 +286,7 @@ ADDetectedGame AgiMetaEngineDetection::fallbackDetect(const FileMap &allFilesXXX
 		// is alive (as else the string storage is modified/deleted).
 		g_fallbackDesc.desc.gameId = _gameid.c_str();
 		g_fallbackDesc.desc.extra = _extra.c_str();
-		g_fallbackDesc.desc.guiOptions = GAMEOPTIONS_FANMADE_MOUSE_VGA;
+		g_fallbackDesc.desc.guiOptions = GAMEOPTIONS_FANMADE_MOUSE;
 
 		Common::String fallbackWarning;
 

--- a/engines/agi/detection.cpp
+++ b/engines/agi/detection.cpp
@@ -151,6 +151,7 @@ ADDetectedGame AgiMetaEngineDetection::fallbackDetect(const FileMap &allFilesXXX
 	g_fallbackDesc.desc.language = Common::UNK_LANG;
 	g_fallbackDesc.desc.platform = Common::kPlatformDOS;
 	g_fallbackDesc.desc.flags = ADGF_NO_FLAGS;
+	g_fallbackDesc.desc.guiOptions = GAMEOPTIONS_DEFAULT;
 
 	// Set default values for the fallback descriptor's AGIGameDescription part.
 	g_fallbackDesc.gameID = GID_FANMADE;
@@ -285,6 +286,7 @@ ADDetectedGame AgiMetaEngineDetection::fallbackDetect(const FileMap &allFilesXXX
 		// is alive (as else the string storage is modified/deleted).
 		g_fallbackDesc.desc.gameId = _gameid.c_str();
 		g_fallbackDesc.desc.extra = _extra.c_str();
+		g_fallbackDesc.desc.guiOptions = GAMEOPTIONS_FANMADE_MOUSE_VGA;
 
 		Common::String fallbackWarning;
 


### PR DESCRIPTION
Currently, fallbacked (fellback?) fanmade games will be detected
with "default" GUI options, when there's a perfectly good set of
specialized "fanmade" GUI option flags available. With this
patch, agi-fanmade-fallback games will use
GAMEOPTIONS_FANMADE_VGA for a possibly wide range of
options.
