### PR TITLE
MADE: Add text-to-speech (TTS)

### DIFF
--- a/engines/made/detection.cpp
+++ b/engines/made/detection.cpp
@@ -39,6 +39,7 @@ static const PlainGameDescriptor madeGames[] = {
 class MadeMetaEngineDetection : public AdvancedMetaEngineDetection<Made::MadeGameDescription> {
 public:
 	MadeMetaEngineDetection() : AdvancedMetaEngineDetection(Made::gameDescriptions, madeGames) {
+		_guiOptions = GUIO1(GAMEOPTION_TTS);
 	}
 
 	const char *getName() const override {

--- a/engines/made/detection.h
+++ b/engines/made/detection.h
@@ -52,6 +52,7 @@ struct MadeGameDescription {
 };
 
 #define GAMEOPTION_INTRO_MUSIC_DIGITAL GUIO_GAMEOPTIONS1
+#define GAMEOPTION_TTS                 GUIO_GAMEOPTIONS2
 
 } // End of namespace Made
 

--- a/engines/made/made.cpp
+++ b/engines/made/made.cpp
@@ -77,6 +77,22 @@ MadeEngine::MadeEngine(OSystem *syst, const MadeGameDescription *gameDesc) : Eng
 
 	_soundRate = 0;
 
+	_saveLoadScreenOpen = false;
+	_openingCreditsOpen = true;
+	_tapeRecorderOpen = false;
+	_previousRect = -1;
+	_previousTextBox = -1;
+	_voiceText = true;
+	_forceVoiceText = false;
+	_forceQueueText = false;
+
+#ifdef USE_TTS
+	_rtzSaveLoadIndex = ARRAYSIZE(_rtzSaveLoadButtonText);
+	_rtzFirstSaveSlot = 0;
+	_tapeRecorderIndex = 0;
+	_playOMaticButtonIndex = ARRAYSIZE(_playOMaticButtonText);
+#endif
+
 	// Set default sound frequency
 	switch (getGameID()) {
 	case GID_RODNEY:
@@ -120,9 +136,14 @@ int16 MadeEngine::getTicks() {
 }
 
 int16 MadeEngine::getTimer(int16 timerNum) {
-	if (timerNum > 0 && timerNum <= ARRAYSIZE(_timers) && _timers[timerNum - 1] != -1)
+	if (timerNum > 0 && timerNum <= ARRAYSIZE(_timers) && _timers[timerNum - 1] != -1) {
+		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+		if (getGameID() == GID_LGOP2 && ttsMan && ttsMan->isSpeaking()) {
+			return 1;
+		}
+
 		return (getTicks() - _timers[timerNum - 1]);
-	else
+	} else
 		return 32000;
 }
 
@@ -156,6 +177,104 @@ void MadeEngine::resetAllTimers() {
 		_timers[i] = -1;
 }
 
+void MadeEngine::sayText(const Common::String &text, Common::TextToSpeechManager::Action action) const {
+	if (text.empty()) {
+		return;
+	}
+
+	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+	if (ttsMan != nullptr && ConfMan.getBool("tts_enabled")) {
+		ttsMan->say(text, action, _ttsTextEncoding);
+	}
+}
+
+void MadeEngine::stopTextToSpeech() const {
+	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+	if (ttsMan != nullptr && ConfMan.getBool("tts_enabled") && ttsMan->isSpeaking()) {
+		ttsMan->stop();
+	}
+}
+
+#ifdef USE_TTS
+
+void MadeEngine::checkHoveringSaveLoadScreen() {
+	static const Common::Rect rtzSaveLoadScreenButtons[] = {
+		Common::Rect(184, 174, 241, 189),	// Cancel button
+		Common::Rect(109, 174, 166, 189),	// Save/load button
+		Common::Rect(25, 20, 297, 158)		// Text entry box
+	};
+
+	static const uint8 kRtzSaveLoadButtonCount = ARRAYSIZE(rtzSaveLoadScreenButtons);
+	static const uint8 kRtzSaveBoxHeight = 14;
+
+	enum RtzSaveLoadScreenIndex {
+		kCancel = 0,
+		kSaveOrLoad = 1,
+		kTextBox = 2
+	};
+
+	if (_saveLoadScreenOpen && getGameID() == GID_RTZ) {
+		bool hoveringOverButton = false;
+		for (uint8 i = 0; i < kRtzSaveLoadButtonCount; ++i) {
+			if (rtzSaveLoadScreenButtons[i].contains(_eventMouseX, _eventMouseY)) {
+				if (_previousRect != i) {
+					if (i == kTextBox) {
+						int index = MIN((_eventMouseY - 20) / kRtzSaveBoxHeight, 9);
+
+						if (index != _previousTextBox) {
+							sayText(Common::String::format("%d", _rtzFirstSaveSlot + index));
+							_previousTextBox = index;
+						}
+					} else {
+						sayText(_rtzSaveLoadButtonText[i]);
+						_previousRect = i;
+					}
+				}
+
+				hoveringOverButton = true;
+				break;
+			}
+		}
+
+		if (!hoveringOverButton) {
+			_previousRect = -1;
+			_previousTextBox = -1;
+		}
+	}
+}
+
+void MadeEngine::checkHoveringPlayOMatic(int16 spriteY) {
+	static const Common::Rect lgop2PlayOMaticButtons[] = {
+		Common::Rect(105, 102, 225, 122),
+		Common::Rect(105, 127, 225, 147),
+		Common::Rect(105, 152, 225, 172),
+		Common::Rect(105, 177, 225, 197)
+	};
+
+	static const uint8 kLgop2PlayOMaticButtonCount = ARRAYSIZE(lgop2PlayOMaticButtons);
+
+	if (_saveLoadScreenOpen && getGameID() == GID_LGOP2) {
+		bool hoveringOverButton = false;
+		for (uint8 i = 0; i < kLgop2PlayOMaticButtonCount; ++i) {
+			if (lgop2PlayOMaticButtons[i].contains(_eventMouseX, _eventMouseY) || spriteY == lgop2PlayOMaticButtons[i].top) {
+				if (_previousRect != i || spriteY != -1) {
+					sayText(_playOMaticButtonText[i], Common::TextToSpeechManager::INTERRUPT);
+					_previousRect = i;
+				}
+
+				hoveringOverButton = true;
+				break;
+			}
+		}
+
+		if (!hoveringOverButton) {
+			_previousRect = -1;
+		}
+	}
+}
+
+#endif
+
 Common::String MadeEngine::getSavegameFilename(int16 saveNum) {
 	return Common::String::format("%s.%03d", getTargetName().c_str(), saveNum);
 }
@@ -173,10 +292,22 @@ void MadeEngine::handleEvents() {
 		case Common::EVENT_MOUSEMOVE:
 			_eventMouseX = event.mouse.x;
 			_eventMouseY = event.mouse.y;
+
+#ifdef USE_TTS
+			checkHoveringSaveLoadScreen();
+			checkHoveringPlayOMatic();
+#endif
+
 			break;
 
 		case Common::EVENT_LBUTTONDOWN:
 			_eventNum = 2;
+
+			if (_openingCreditsOpen) {
+				_openingCreditsOpen = false;
+				stopTextToSpeech();
+			}
+
 			break;
 
 		case Common::EVENT_LBUTTONUP:
@@ -260,6 +391,23 @@ Common::Error MadeEngine::run() {
 	initGraphics(320, 200);
 
 	resetAllTimers();
+
+	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+	if (ttsMan != nullptr) {
+		ttsMan->enable(ConfMan.getBool("tts_enabled"));
+
+		if (getLanguage() == Common::KO_KOR) {	// Korean version doesn't translate any text
+			ttsMan->setLanguage("en");
+		} else {
+			ttsMan->setLanguage(ConfMan.get("language"));
+		}
+
+		if (getLanguage() == Common::JA_JPN) {
+			_ttsTextEncoding = Common::CodePage::kWindows932;
+		} else {
+			_ttsTextEncoding = Common::CodePage::kDos850;
+		}
+	}
 
 	if (getGameID() == GID_RTZ) {
 		if (getFeatures() & GF_DEMO) {

--- a/engines/made/made.h
+++ b/engines/made/made.h
@@ -28,6 +28,7 @@
 #include "engines/engine.h"
 
 #include "common/random.h"
+#include "common/text-to-speech.h"
 
 /**
  * This is the namespace of the Made engine.
@@ -84,6 +85,7 @@ public:
 	uint32 getFeatures() const;
 	uint16 getVersion() const;
 	Common::Platform getPlatform() const;
+	Common::Language getLanguage() const;
 
 public:
 	PmvPlayer *_pmvPlayer;
@@ -106,6 +108,29 @@ public:
 	uint32 _cdTimeStart;
 	bool _introMusicDigital;
 
+	Common::CodePage _ttsTextEncoding;
+	int _previousRect;
+	int _previousTextBox;
+	bool _saveLoadScreenOpen;
+	bool _openingCreditsOpen;
+	bool _tapeRecorderOpen;
+
+	bool _voiceText;
+	bool _forceVoiceText;
+	bool _forceQueueText;
+
+#ifdef USE_TTS
+	Common::String _rtzSaveLoadButtonText[2];
+	uint8 _rtzFirstSaveSlot;
+	uint8 _rtzSaveLoadIndex;
+
+	Common::String _tapeRecorderText[4];
+	uint8 _tapeRecorderIndex;
+
+	Common::String _playOMaticButtonText[4];
+	uint8 _playOMaticButtonIndex;
+#endif
+
 	int32 _timers[50];
 	int16 getTicks();
 	int16 getTimer(int16 timerNum);
@@ -114,6 +139,13 @@ public:
 	int16 allocTimer();
 	void freeTimer(int16 timerNum);
 	void resetAllTimers();
+
+	void sayText(const Common::String &text, Common::TextToSpeechManager::Action action = Common::TextToSpeechManager::INTERRUPT) const;
+	void stopTextToSpeech() const;
+#ifdef USE_TTS
+	void checkHoveringSaveLoadScreen();
+	void checkHoveringPlayOMatic(int16 spriteY = -1);
+#endif
 
 	const Common::String getTargetName() { return _targetName; }
 	Common::String getSavegameFilename(int16 saveNum);

--- a/engines/made/metaengine.cpp
+++ b/engines/made/metaengine.cpp
@@ -43,6 +43,21 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 			0
 		}
 	},
+
+#ifdef USE_TTS
+	{
+		GAMEOPTION_TTS,
+		{
+			_s("Enable Text to Speech"),
+			_s("Use TTS to read text in the game (if TTS is available)"),
+			"tts_enabled",
+			false,
+			0,
+			0
+		}
+	},
+#endif
+
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };
 
@@ -60,6 +75,10 @@ Common::Platform MadeEngine::getPlatform() const {
 
 uint16 MadeEngine::getVersion() const {
 	return _gameDescription->version;
+}
+
+Common::Language MadeEngine::getLanguage() const {
+	return _gameDescription->desc.language;
 }
 
 } // End of namespace Made

--- a/engines/made/screen.h
+++ b/engines/made/screen.h
@@ -37,6 +37,7 @@ struct SpriteChannel {
 	int16 textColor, outlineColor;
 	int16 frameNum;
 	int16 mask;
+	Common::String previousText;
 };
 
 struct ClipInfo {
@@ -129,6 +130,9 @@ public:
 		_textY = _textRect.top;
 	}
 
+	void setQueueNextText(bool value) { _queueNextText = value; }
+	void setVoiceTimeText(bool value) { _voiceTimeText = value; }
+
 	uint16 updateChannel(uint16 channelIndex);
 	void deleteChannel(uint16 channelIndex);
 	int16 getChannelType(uint16 channelIndex);
@@ -160,6 +164,9 @@ public:
 	int16 getAnimFrame(uint16 channelIndex);
 
 	uint16 placeText(uint16 channelIndex, uint16 textObjectIndex, int16 x, int16 y, uint16 fontNum, int16 textColor, int16 outlineColor);
+#ifdef USE_TTS
+	void voiceChannelText(const char *text, uint16 channelIndex);
+#endif
 
 	void show();
 	void flash(int count);
@@ -215,6 +222,9 @@ protected:
 
 	uint16 _channelsUsedCount;
 	SpriteChannel _channels[100];
+
+	bool _queueNextText;
+	bool _voiceTimeText;
 
 	Common::Array<SpriteListItem> _spriteList;
 

--- a/engines/made/scriptfuncs.cpp
+++ b/engines/made/scriptfuncs.cpp
@@ -30,6 +30,8 @@
 
 #include "backends/audiocd/audiocd.h"
 
+#include "common/config-manager.h"
+
 #include "graphics/cursorman.h"
 #include "graphics/surface.h"
 
@@ -42,6 +44,7 @@ ScriptFunctions::ScriptFunctions(MadeEngine *vm) : _vm(vm), _soundStarted(false)
 	_vm->_system->getMixer()->playStream(Audio::Mixer::kMusicSoundType, &_pcSpeakerHandle1, _pcSpeaker1);
 	_vm->_system->getMixer()->playStream(Audio::Mixer::kMusicSoundType, &_pcSpeakerHandle2, _pcSpeaker2);
 	_soundResource = nullptr;
+	_soundWasPlaying = false;
 }
 
 ScriptFunctions::~ScriptFunctions() {
@@ -195,6 +198,10 @@ int16 ScriptFunctions::sfDrawPicture(int16 argc, int16 *argv) {
 }
 
 int16 ScriptFunctions::sfClearScreen(int16 argc, int16 *argv) {
+	if (_vm->getGameID() == GID_LGOP2) {
+		_vm->stopTextToSpeech();
+	}
+
 	if (_vm->_screen->isScreenLocked())
 		return 0;
 	if (_vm->_autoStopSound) {
@@ -248,6 +255,7 @@ int16 ScriptFunctions::sfPlaySound(int16 argc, int16 *argv) {
 		soundNum = argv[1];
 		_vm->_autoStopSound = (argv[0] == 1);
 	}
+	_soundWasPlaying = true;
 	if (soundNum > 0) {
 		SoundResource *soundRes = _vm->_res->getSound(soundNum);
 		_vm->_mixer->playStream(Audio::Mixer::kSFXSoundType, &_audioStreamHandle,
@@ -390,6 +398,15 @@ int16 ScriptFunctions::sfShowMouseCursor(int16 argc, int16 *argv) {
 }
 
 int16 ScriptFunctions::sfGetMusicBeat(int16 argc, int16 *argv) {
+	// Delay the opening credits when TTS is enabled until TTS is done speaking,
+	// as they move too fast otherwise
+	if (_vm->getGameID() == GID_RTZ && _vm->_openingCreditsOpen) {
+		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+		if (ttsMan != nullptr && ConfMan.getBool("tts_enabled") && ttsMan->isSpeaking()) {
+			return 0;
+		}
+	}
+
 	// This is used as timer in some games
 	return (_vm->_system->getMillis() - _vm->_musicBeatStart) / 360;
 }
@@ -425,6 +442,17 @@ int16 ScriptFunctions::sfDrawSprite(int16 argc, int16 *argv) {
 		SpriteListItem item = _vm->_screen->getFromSpriteList(argv[2]);
 		int16 channelIndex = _vm->_screen->drawSprite(item.index, argv[1] - item.xofs, argv[0] - item.yofs);
 		_vm->_screen->setChannelUseMask(channelIndex);
+
+		if (_vm->getGameID() == GID_LGOP2) {
+			// Postcard examine, which displays several pieces of text immediately, resulting in only the last being
+			// voiced unless the text is queued
+			if (item.index == 687) {
+				_vm->_forceQueueText = true;
+			} else {
+				_vm->_forceQueueText = false;
+			}
+		}
+
 		return 0;
 	} else {
 		return 0;
@@ -507,6 +535,45 @@ int16 ScriptFunctions::sfDrawText(int16 argc, int16 *argv) {
 			break;
 		}
 		_vm->_screen->printText(finalText.c_str());
+
+#ifdef USE_TTS
+		if (_vm->getGameID() == GID_LGOP2) {
+			if (_vm->_playOMaticButtonIndex < ARRAYSIZE(_vm->_playOMaticButtonText)) {
+				_vm->_playOMaticButtonText[_vm->_playOMaticButtonIndex] = finalText;
+				_vm->_playOMaticButtonIndex++;
+			} else {
+				finalText.replace('\x09', '\n');	// Replace tabs with newlines
+				if (_vm->_voiceText) {
+					if (_vm->_forceQueueText) {
+						_vm->sayText(finalText, Common::TextToSpeechManager::QUEUE);
+					} else {
+						_vm->sayText(finalText);
+					}
+				} else if (_vm->_forceVoiceText) {
+					_vm->sayText(finalText, Common::TextToSpeechManager::QUEUE);
+					_vm->_forceVoiceText = false;
+				} else {
+					_vm->stopTextToSpeech();
+				}
+			}
+		} else if (_vm->getGameID() == GID_RTZ) {
+			if (_vm->_saveLoadScreenOpen) {
+				if (_vm->_rtzFirstSaveSlot == 0) {
+					_vm->_rtzFirstSaveSlot = atoi(finalText.c_str());
+				}
+			} else if (_vm->_tapeRecorderOpen) {
+				if (_vm->_tapeRecorderIndex < ARRAYSIZE(_vm->_tapeRecorderText)) {
+					_vm->_tapeRecorderText[_vm->_tapeRecorderIndex] = finalText;
+					_vm->_tapeRecorderIndex++;
+				}
+			} else {
+				_vm->sayText(finalText, Common::TextToSpeechManager::QUEUE);
+				_vm->_screen->setQueueNextText(true);
+			}
+		} else {
+			_vm->sayText(finalText);
+		}
+#endif
 	}
 
 	return 0;
@@ -544,6 +611,15 @@ int16 ScriptFunctions::sfSetFontDropShadow(int16 argc, int16 *argv) {
 }
 
 int16 ScriptFunctions::sfSetFontColor(int16 argc, int16 *argv) {
+	if (_vm->getGameID() == GID_LGOP2) {
+		// White text usually has a voiceover, so it shouldn't be voiced by TTS, while text of other colors should be
+		if (argv[0] == 255) {
+			_vm->_voiceText = false;
+		} else {
+			_vm->_voiceText = true;
+		}
+	}
+
 	_vm->_screen->setTextColor(argv[0]);
 	return 0;
 }
@@ -598,8 +674,16 @@ int16 ScriptFunctions::sfSetSpriteMask(int16 argc, int16 *argv) {
 
 int16 ScriptFunctions::sfSoundPlaying(int16 argc, int16 *argv) {
 	if (_vm->getGameID() == GID_RTZ) {
-		if (!_vm->_mixer->isSoundHandleActive(_audioStreamHandle))
+		if (!_vm->_mixer->isSoundHandleActive(_audioStreamHandle)) {
+			if (_soundWasPlaying) {
+				_vm->_screen->setVoiceTimeText(true);
+				_soundWasPlaying = false;
+			}
+			
 			return 0;
+		}
+
+		_vm->_screen->setVoiceTimeText(false);
 
 		// For looping sounds the game script regularly checks if the sound has
 		// finished playing, then plays it again. This works in the original
@@ -930,8 +1014,24 @@ int16 ScriptFunctions::sfDrawMenu(int16 argc, int16 *argv) {
 	MenuResource *menu = _vm->_res->getMenu(menuIndex);
 	if (menu) {
 		const char *text = menu->getString(textIndex);
-		if (text)
+		if (text) {
 			_vm->_screen->printText(text);
+
+#ifdef USE_TTS
+			if (_vm->_saveLoadScreenOpen) {
+				if (_vm->_rtzSaveLoadIndex < ARRAYSIZE(_vm->_rtzSaveLoadButtonText)) {
+					_vm->_rtzSaveLoadButtonText[_vm->_rtzSaveLoadIndex] = text;
+					_vm->_rtzSaveLoadIndex++;
+				}
+			} else {
+				if (_vm->_openingCreditsOpen) {
+					_vm->sayText(text, Common::TextToSpeechManager::QUEUE);
+				} else {
+					_vm->sayText(text);
+				}
+			}
+#endif
+		}
 
 		_vm->_res->freeResource(menu);
 	}

--- a/engines/made/scriptfuncs.h
+++ b/engines/made/scriptfuncs.h
@@ -62,6 +62,7 @@ protected:
 	Audio::SoundHandle _voiceStreamHandle;
 	SoundResource* _soundResource;
 	bool _soundStarted;
+	bool _soundWasPlaying;
 	// The sound length in milliseconds for purpose of checking if the sound is
 	// still playing.
 	int _soundCheckLength;


### PR DESCRIPTION
Adds a toggle for text-to-speech to the game options.
Adds text-to-speech for the following:
- Opening credits
- Objects when hovered over
- Menus
- Tool use (map, photos, and tape recorder)
- Location names
- Notifications

Currently only tested with the Return to Zork DOS demos.
Translations for the opening credits (in `pmvplayer.cpp`) need verification.