### PR TITLE
BUILD: enable ARM NEON on PSP2

### DIFF
--- a/configure
+++ b/configure
@@ -3436,6 +3436,7 @@ EOF
 		_freetypepath="$VITASDK/arm-vita-eabi/bin"
 		_freetype2=yes
 		_libcurlpath="$VITASDK/arm-vita-eabi/bin"
+		_ext_neon=yes
 		append_var CXXFLAGS "--sysroot=$VITASDK/arm-vita-eabi"
 		append_var LDFLAGS "--sysroot=$VITASDK/arm-vita-eabi"
 		append_var DEFINES "-DPSP2 -DSYSTEM_NOT_SUPPORTING_D_TYPE"


### PR DESCRIPTION
Although PSP2 was compiled with neon fpu parameter, SCUMMVM_NEON was not defined.
It in turn did not enabled neon paths.