### PR TITLE
PSP2: Add PSP2 custom filesystem and power manager

### DIFF
--- a/backends/events/psp2sdl/psp2sdl-events.cpp
+++ b/backends/events/psp2sdl/psp2sdl-events.cpp
@@ -25,9 +25,10 @@
 
 #include <psp2/kernel/processmgr.h>
 #include <psp2/touch.h>
-#include "backends/platform/sdl/psp2/psp2.h"
-#include "backends/events/psp2sdl/psp2sdl-events.h"
 #include "backends/platform/sdl/sdl.h"
+#include "backends/platform/sdl/psp2/psp2.h"
+#include "backends/platform/sdl/psp2/powerman.h"
+#include "backends/events/psp2sdl/psp2sdl-events.h"
 #include "engines/engine.h"
 
 #include "common/util.h"
@@ -43,6 +44,17 @@ void PSP2EventSource::preprocessEvents(SDL_Event *event) {
 	sceKernelPowerTick(SCE_KERNEL_POWER_TICK_DISABLE_OLED_OFF);
 
 	SdlEventSource::preprocessEvents(event);
+}
+
+bool PSP2EventSource::pollEvent(Common::Event &event) {
+
+	// If we're polling for events, we should check for pausing the engine
+	// Pausing the engine is a necessary fix for games that use the timer for music synchronization
+	// 	recovering many hours later causes the game to crash. We're polling without mutexes since it's not critical to
+	//  get it right now.
+	PowerMan.pollPauseEngine();
+
+	return SdlEventSource::pollEvent(event);
 }
 
 bool PSP2EventSource::isTouchPortTouchpadMode(SDL_TouchID port) {

--- a/backends/events/psp2sdl/psp2sdl-events.h
+++ b/backends/events/psp2sdl/psp2sdl-events.h
@@ -30,6 +30,7 @@
 class PSP2EventSource : public SdlEventSource {
 public:
 	PSP2EventSource() {}
+	virtual bool pollEvent(Common::Event &event);
 protected:
 	void preprocessEvents(SDL_Event *event) override;
 	bool isTouchPortTouchpadMode(SDL_TouchID port) override;

--- a/backends/fs/posix-drives/posix-drives-fs-factory.cpp
+++ b/backends/fs/posix-drives/posix-drives-fs-factory.cpp
@@ -19,7 +19,7 @@
  *
  */
 
-#if defined(POSIX) || defined(PSP2) || defined(__DS__)
+#if defined(POSIX) || defined(__DS__)
 
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 
@@ -42,12 +42,8 @@ AbstractFSNode *DrivesPOSIXFilesystemFactory::makeRootFileNode() const {
 }
 
 AbstractFSNode *DrivesPOSIXFilesystemFactory::makeCurrentDirectoryFileNode() const {
-#if defined(PSP2) // The Vita does not have getcwd
-	return makeRootFileNode();
-#else
 	char buf[MAXPATHLEN];
 	return getcwd(buf, MAXPATHLEN) ? new DrivePOSIXFilesystemNode(buf, _config) : makeRootFileNode();
-#endif
 }
 
 AbstractFSNode *DrivesPOSIXFilesystemFactory::makeFileNodePath(const Common::String &path) const {

--- a/backends/fs/posix-drives/posix-drives-fs.cpp
+++ b/backends/fs/posix-drives/posix-drives-fs.cpp
@@ -19,7 +19,7 @@
  *
  */
 
-#if defined(POSIX) || defined(PSP2) || defined(__DS__)
+#if defined(POSIX) || defined(__DS__)
 
 #define FORBIDDEN_SYMBOL_ALLOW_ALL
 

--- a/backends/fs/posix/posix-fs.cpp
+++ b/backends/fs/posix/posix-fs.cpp
@@ -19,7 +19,7 @@
  *
  */
 
-#if defined(POSIX) || defined(PLAYSTATION3) || defined(PSP2) || defined(__DS__)
+#if defined(POSIX) || defined(PLAYSTATION3) || defined(__DS__)
 
 // Re-enable some forbidden symbols to avoid clashes with stat.h and unistd.h.
 // Also with clock() in sys/time.h in some macOS SDKs.

--- a/backends/fs/psp2/psp2-fs-factory.cpp
+++ b/backends/fs/psp2/psp2-fs-factory.cpp
@@ -1,0 +1,71 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#if defined(PSP2)
+
+#define FORBIDDEN_SYMBOL_EXCEPTION_unistd_h
+
+#include "backends/fs/psp2/psp2-fs-factory.h"
+#include "backends/fs/psp2/psp2-fs.h"
+#include "backends/platform/sdl/psp2/powerman.h"
+
+#include <unistd.h>
+
+namespace Common {
+DECLARE_SINGLETON(PSP2FilesystemFactory);
+}
+
+void PSP2FilesystemFactory::addDrive(const Common::String &name) {
+	_config.drives.push_back(Common::normalizePath(name, '/'));
+}
+
+AbstractFSNode *PSP2FilesystemFactory::makeRootFileNode() const {
+	return new PSP2FilesystemNode(_config);
+}
+
+AbstractFSNode *PSP2FilesystemFactory::makeCurrentDirectoryFileNode() const {
+	char buf[MAXPATHLEN];
+	char *ret = 0;
+
+	PowerMan.beginCriticalSection();
+	ret = getcwd(buf, MAXPATHLEN);
+	PowerMan.endCriticalSection();
+
+	return (ret ? new PSP2FilesystemNode(buf, _config, true) : NULL);
+}
+
+AbstractFSNode *PSP2FilesystemFactory::makeFileNodePath(const Common::String &path) const {
+	return new PSP2FilesystemNode(path, _config, true);
+}
+
+bool PSP2FilesystemFactory::StaticDrivesConfig::getDrives(AbstractFSList &list, bool hidden) const {
+	for (uint i = 0; i < drives.size(); i++) {
+		list.push_back(_factory->makeFileNodePath(drives[i]));
+	}
+	return true;
+}
+
+bool PSP2FilesystemFactory::StaticDrivesConfig::isDrive(const Common::String &path) const {
+	DrivesArray::const_iterator drive = Common::find(drives.begin(), drives.end(), path);
+	return drive != drives.end();
+}
+
+#endif

--- a/backends/fs/psp2/psp2-fs-factory.h
+++ b/backends/fs/psp2/psp2-fs-factory.h
@@ -1,0 +1,67 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef PSP2_FILESYSTEM_FACTORY_H
+#define PSP2_FILESYSTEM_FACTORY_H
+
+#include "common/singleton.h"
+#include "backends/fs/fs-factory.h"
+#include "backends/fs/psp2/psp2-fs.h"
+
+/**
+ * Creates PSP2FilesystemNode objects.
+ *
+ * Parts of this class are documented in the base interface class, FilesystemFactory.
+ */
+class PSP2FilesystemFactory final : public FilesystemFactory, public Common::Singleton<PSP2FilesystemFactory> {
+public:
+    PSP2FilesystemFactory() : _config(this) { }
+
+    /**
+     * Add a drive to the top-level directory
+     */
+	void addDrive(const Common::String &name);
+
+protected:
+	AbstractFSNode *makeRootFileNode() const override;
+	AbstractFSNode *makeCurrentDirectoryFileNode() const override;
+	AbstractFSNode *makeFileNodePath(const Common::String &path) const override;
+
+    typedef Common::Array<Common::String> DrivesArray;
+	struct StaticDrivesConfig : public PSP2FilesystemNode::Config {
+		StaticDrivesConfig(const PSP2FilesystemFactory *factory) : _factory(factory) { }
+
+		bool getDrives(AbstractFSList &list, bool hidden) const override;
+		bool isDrive(const Common::String &path) const override;
+
+		DrivesArray drives;
+
+	private:
+		const PSP2FilesystemFactory *_factory;
+	};
+
+	StaticDrivesConfig _config;
+
+private:
+	friend class Common::Singleton<SingletonBaseType>;
+};
+
+#endif /*PSP2_FILESYSTEM_FACTORY_H*/

--- a/backends/fs/psp2/psp2-fs.cpp
+++ b/backends/fs/psp2/psp2-fs.cpp
@@ -1,0 +1,252 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#if defined(PSP2)
+
+#define FORBIDDEN_SYMBOL_EXCEPTION_time_h
+
+#define FORBIDDEN_SYMBOL_EXCEPTION_unistd_h
+
+#define FORBIDDEN_SYMBOL_EXCEPTION_mkdir
+
+#include "backends/fs/psp2/psp2-fs.h"
+#include "backends/fs/psp2/psp2-stream.h"
+#include "common/bufferedstream.h"
+#include "common/debug.h"
+#include "engines/engine.h"
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <psp2/io/dirent.h>
+#include <psp2/io/stat.h>
+
+
+PSP2FilesystemNode::PSP2FilesystemNode(const Common::String &path, const Config &config, bool verify) :
+        _isPseudoRoot(false),
+	    _config(config) {
+
+    _path = path;
+    _displayName = lastPathComponent(_path, '/');
+
+    if (isDrive(path)) {
+        _isDirectory = true;
+        _isValid = true;
+
+        if (!_path.hasSuffix("/")) {
+			_path += "/";
+		}
+
+        debug(8, "path [%s]", _path.c_str());
+
+        if (verify) {
+            struct stat st;
+            if (PowerMan.beginCriticalSection() == PowerManager::Blocked)
+                debug(8, "Suspended");
+            _isValid = (0 == stat(_path.c_str(), &st));
+            PowerMan.endCriticalSection();
+            _isDirectory = S_ISDIR(st.st_mode);
+        }
+    }
+}
+
+PSP2FilesystemNode::PSP2FilesystemNode(const Config &config) :
+		_isPseudoRoot(true),
+		_config(config) {
+	_isDirectory = true;
+	_isValid = false;
+}
+
+bool PSP2FilesystemNode::exists() const {
+	int ret = 0;
+
+	if (PowerMan.beginCriticalSection() == PowerManager::Blocked)
+		debug(8, "Suspended");	// Make sure to block in case of suspend
+
+	debug(8, "path [%s]", _path.c_str());
+
+	ret = access(_path.c_str(), F_OK);
+	PowerMan.endCriticalSection();
+
+	return (ret == 0);
+}
+
+bool PSP2FilesystemNode::isReadable() const {
+	int ret = 0;
+
+	if (PowerMan.beginCriticalSection() == PowerManager::Blocked)
+		debug(8, "Suspended");	// Make sure to block in case of suspend
+
+	debug(8, "path [%s]", _path.c_str());
+
+	ret = access(_path.c_str(), R_OK);
+	PowerMan.endCriticalSection();
+
+	return (ret == 0);
+}
+
+bool PSP2FilesystemNode::isWritable() const {
+	int ret = 0;
+
+	if (PowerMan.beginCriticalSection() == PowerManager::Blocked)
+		debug(8, "Suspended");	// Make sure to block in case of suspend
+
+	debug(8, "path [%s]", _path.c_str());
+
+	ret = access(_path.c_str(), W_OK);
+	PowerMan.endCriticalSection();
+
+	return ret == 0;
+}
+
+
+AbstractFSNode *PSP2FilesystemNode::getChild(const Common::String &n) const {
+	// FIXME: Pretty lame implementation! We do no error checking to speak
+	// of, do not check if this is a special node, etc.
+	assert(_isDirectory);
+
+	Common::String newPath(_path);
+	if (_path.lastChar() != '/')
+		newPath += '/';
+	newPath += n;
+
+	debug(8, "child [%s]", newPath.c_str());
+
+	AbstractFSNode *node = new PSP2FilesystemNode(newPath, _config, true);
+
+	return node;
+}
+
+bool PSP2FilesystemNode::getChildren(AbstractFSList &myList, ListMode mode, bool hidden) const {
+	assert(_isDirectory);
+
+	//TODO: honor the hidden flag
+
+	bool ret = true;
+
+	if (PowerMan.beginCriticalSection() == PowerManager::Blocked)
+		debug(8, "Suspended");	// Make sure to block in case of suspend
+
+	debug(8, "Current path[%s]", _path.c_str());
+
+	int dfd  = sceIoDopen(_path.c_str());
+	if (dfd > 0) {
+		SceIoDirent dir;
+		memset(&dir, 0, sizeof(dir));
+
+		while (sceIoDread(dfd, &dir) > 0) {
+			// Skip 'invisible files
+			if (dir.d_name[0] == '.')
+				continue;
+
+			PSP2FilesystemNode entry(_config);
+
+			entry._isValid = true;
+			entry._displayName = dir.d_name;
+
+			Common::String newPath(_path);
+			if (newPath.lastChar() != '/')
+				newPath += '/';
+			newPath += dir.d_name;
+
+			entry._path = newPath;
+			entry._isDirectory = dir.d_stat.st_attr & SCE_SO_IFDIR;
+
+			debug(8, "Child[%s], %s", entry._path.c_str(), entry._isDirectory ? "dir" : "file");
+
+			// Honor the chosen mode
+			if ((mode == Common::FSNode::kListFilesOnly && entry._isDirectory) ||
+			        (mode == Common::FSNode::kListDirectoriesOnly && !entry._isDirectory))
+				continue;
+
+			myList.push_back(new PSP2FilesystemNode(entry));
+		}
+
+		sceIoDclose(dfd);
+		ret = true;
+	} else { // dfd <= 0
+		ret = false;
+	}
+
+	PowerMan.endCriticalSection();
+
+	return ret;
+}
+
+AbstractFSNode *PSP2FilesystemNode::getParent() const {
+	if (_isPseudoRoot) {
+        return nullptr;
+    }
+
+    if (isDrive(_path)) {
+        return makeNode();
+    }
+
+	debug(8, "current[%s]", _path.c_str());
+
+	const char *start = _path.c_str();
+	const char *end = lastPathComponent(_path, '/');
+
+	AbstractFSNode *node = new PSP2FilesystemNode(Common::String(start, end - start), _config, false);
+
+	return node;
+}
+
+Common::SeekableReadStream *PSP2FilesystemNode::createReadStream() {
+	const uint32 READ_BUFFER_SIZE = 1024;
+
+	Common::SeekableReadStream *stream = Psp2IoStream::makeFromPath(getPath(), false);
+
+	return Common::wrapBufferedSeekableReadStream(stream, READ_BUFFER_SIZE, DisposeAfterUse::YES);
+}
+
+Common::SeekableWriteStream *PSP2FilesystemNode::createWriteStream(bool atomic) {
+	const uint32 WRITE_BUFFER_SIZE = 1024;
+
+	// TODO: Add atomic support if possible
+	Common::SeekableWriteStream *stream = Psp2IoStream::makeFromPath(getPath(), true);
+
+	return Common::wrapBufferedWriteStream(stream, WRITE_BUFFER_SIZE);
+}
+
+bool PSP2FilesystemNode::createDirectory() {
+	if (PowerMan.beginCriticalSection() == PowerManager::Blocked)
+		debug(8, "Suspended");	// Make sure to block in case of suspend
+
+	debug(8, "path [%s]", _path.c_str());
+
+	if (sceIoMkdir(_path.c_str(), 0777) == 0) {
+		struct stat st;
+		_isValid = (0 == stat(_path.c_str(), &st));
+		_isDirectory = S_ISDIR(st.st_mode);
+	}
+
+	PowerMan.endCriticalSection();
+
+	return _isValid && _isDirectory;
+}
+
+bool PSP2FilesystemNode::isDrive(const Common::String &path) const {
+	Common::String normalizedPath = Common::normalizePath(path, '/');
+	return _config.isDrive(normalizedPath);
+}
+
+#endif //#ifdef PSP2

--- a/backends/fs/psp2/psp2-fs.h
+++ b/backends/fs/psp2/psp2-fs.h
@@ -1,0 +1,89 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef PSP2_FILESYSTEM_H
+#define PSP2_FILESYSTEM_H
+
+#include "backends/fs/abstract-fs.h"
+
+/**
+ * Implementation of the ScummVM file system API based on PSPSDK API.
+ *
+ * Parts of this class are documented in the base interface class, AbstractFSNode.
+ */
+class PSP2FilesystemNode : public AbstractFSNode {
+protected:
+	Common::String _displayName;
+	Common::String _path;
+	bool _isDirectory;
+	bool _isValid;
+
+	virtual AbstractFSNode *makeNode() const {
+		return new PSP2FilesystemNode(_config);
+	}
+	AbstractFSNode *makeNode(const Common::String &path) const {
+		return new PSP2FilesystemNode(path, _config, true);
+	}
+
+public:
+	struct Config {
+		Config() { }
+		virtual ~Config() { }
+
+		virtual bool getDrives(AbstractFSList &list, bool hidden) const = 0;
+		virtual bool isDrive(const Common::String &path) const = 0;
+	};
+
+	/**
+	 * Creates a PSP2FilesystemNode with the root node as path.
+	 * 
+	 * @param path Common::String with the path the new node should point to.
+	 * @param config Config of the filesystem.
+	 * @param verify true if the isValid and isDirectory flags should be verified during the construction.
+	 */
+	PSP2FilesystemNode(const Common::String &path, const Config &config, bool verify);
+	PSP2FilesystemNode(const Config &config);
+
+	virtual bool exists() const;
+	virtual Common::U32String getDisplayName() const { return _displayName; }
+	virtual Common::String getName() const { return _displayName; }
+	virtual Common::String getPath() const { return _path; }
+	virtual bool isDirectory() const { return _isDirectory; }
+	virtual bool isReadable() const;
+	virtual bool isWritable() const;
+
+	virtual AbstractFSNode *getChild(const Common::String &n) const;
+	virtual bool getChildren(AbstractFSList &list, ListMode mode, bool hidden) const;
+	virtual AbstractFSNode *getParent() const;
+
+	virtual Common::SeekableReadStream *createReadStream();
+	virtual Common::SeekableWriteStream *createWriteStream(bool atomic);
+	virtual bool createDirectory();
+
+protected:
+	const Config &_config;
+
+private:
+	bool _isPseudoRoot;
+	bool isDrive(const Common::String &path) const;
+};
+
+#endif

--- a/backends/fs/psp2/psp2-stream.cpp
+++ b/backends/fs/psp2/psp2-stream.cpp
@@ -1,0 +1,299 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#ifdef PSP2
+
+#include "backends/fs/psp2/psp2-stream.h"
+#include "common/debug.h"
+
+#include <psp2common/kernel/iofilemgr.h>
+#include <psp2/io/stat.h>
+#include <psp2/io/fcntl.h> 
+
+#define MIN2(a,b) ((a < b) ? a : b)
+#define MIN3(a,b,c) ( (a < b) ? (a < c ? a : c) : (b < c ? b : c) )
+
+
+// Class Psp2IoStream ------------------------------------------------
+
+Psp2IoStream::Psp2IoStream(const Common::String &path, bool writeMode)
+		: _handle(0), _path(path), _fileSize(0), _writeMode(writeMode),
+		  _physicalPos(0), _pos(0), _eos(false),	_error(false),
+		  _errorSuspend(0), _errorSource(0), _errorPos(0), _errorHandle(0), _suspendCount(0) {
+
+	//assert(!path.empty());	// do we need this?
+}
+
+Psp2IoStream::~Psp2IoStream() {
+	if (PowerMan.beginCriticalSection())
+	    debug(8, "suspended");
+
+	PowerMan.unregisterForSuspend(this); 			// Unregister with powermanager to be suspended
+													// Must do this before fclose() or resume() will reopen.
+	sceIoClose(_handle);
+
+	PowerMan.endCriticalSection();
+}
+
+/* Function to open the file pointed to by the path.
+ *
+ */
+SceUID Psp2IoStream::open() {
+	if (PowerMan.beginCriticalSection()) {
+		// No need to open? Just return the _handle resume() already opened
+		debug(8, "suspended");
+	}
+
+	_handle = sceIoOpen(_path.c_str(), _writeMode ? SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC : SCE_O_RDONLY, 0777);
+	if (_handle <= 0) {
+		_error = true;
+		_handle = 0;
+	}
+
+	// Get the file size. This way is much faster than going to the end of the file and back
+	SceIoStat stat;
+	sceIoGetstat(_path.c_str(), &stat);
+	_fileSize = stat.st_size;	// 4GB file (32 bits) is big enough for us
+
+	debug(8, "%s filesize[%d]", _path.c_str(), _fileSize);
+
+	PowerMan.registerForSuspend(this);	 // Register with the powermanager to be suspended
+
+	PowerMan.endCriticalSection();
+
+	return _handle;
+}
+
+bool Psp2IoStream::err() const {
+	if (_error)	// We dump since no printing to screen with suspend callback
+		debug(8, "mem_error[%d], source[%d], suspend error[%d], pos[%d],"
+				  "_errorPos[%d], _errorHandle[%d], suspendCount[%d]",
+		          _error, _errorSource, _errorSuspend, _pos,
+				  _errorPos, _errorHandle, _suspendCount);
+
+	return _error;
+}
+
+void Psp2IoStream::clearErr() {
+	_error = false;
+}
+
+bool Psp2IoStream::eos() const {
+	return _eos;
+}
+
+int64 Psp2IoStream::pos() const {
+	return _pos;
+}
+
+int64 Psp2IoStream::size() const {
+	return _fileSize;
+}
+
+bool Psp2IoStream::physicalSeekFromCur(int32 offset) {
+
+	int ret = sceIoLseek32(_handle, offset, SCE_SEEK_CUR);
+
+	if (ret < 0) {
+		_error = true;
+		debug(8, "failed to seek in file[%s] to [%x]. Error[%x]", _path.c_str(), offset, ret);
+		return false;
+	}
+	_physicalPos += offset;
+	return true;
+}
+
+bool Psp2IoStream::seek(int64 offs, int whence) {
+	debug(8, "offset[0x%llx], whence[%d], _pos[0x%x], _physPos[0x%x]", offs, whence, _pos, _physicalPos);
+	_eos = false;
+
+	int32 posToSearchFor = 0;
+	switch (whence) {
+	case SEEK_CUR:
+		posToSearchFor = _pos;
+		break;
+	case SEEK_END:
+		posToSearchFor = _fileSize;
+		break;
+	}
+	posToSearchFor += offs;
+
+	// Check for bad values
+	if (posToSearchFor < 0) {
+		_error = true;
+		return false;
+	} else if (posToSearchFor > _fileSize) {
+		_error = true;
+		_eos = true;
+		return false;
+	}
+
+	_pos = posToSearchFor;
+
+	return true;
+}
+
+uint32 Psp2IoStream::read(void *ptr, uint32 len) {
+	debug(8, "filename[%s], len[0x%x], ptr[%p], _pos[%x], _physPos[%x]", _path.c_str(), len, ptr, _pos, _physicalPos);
+
+	if (_error || _eos || len <= 0)
+		return 0;
+
+	uint32 lenRemainingInFile = _fileSize - _pos;
+
+	// check for getting EOS
+	if (len > lenRemainingInFile) {
+		len = lenRemainingInFile;
+		_eos = true;
+	}
+
+	if (PowerMan.beginCriticalSection())
+	    debug(8, "suspended");
+
+	// check if we need to seek
+	if (_pos != _physicalPos) {
+		debug(8, "seeking from %x to %x", _physicalPos, _pos);
+		if (!physicalSeekFromCur(_pos - _physicalPos)) {
+			_error = true;
+			return 0;
+		}
+	}
+
+	int ret = sceIoRead(_handle, ptr, len);
+
+	PowerMan.endCriticalSection();
+
+	_physicalPos += ret;	// Update position
+	_pos = _physicalPos;
+
+	if (ret != (int)len) {	// error
+		debug(8, "sceIoRead returned [0x%x] instead of len[0x%x]", ret, len);
+		_error = true;
+		_errorSource = 4;
+	}
+	return ret;
+}
+
+uint32 Psp2IoStream::write(const void *ptr, uint32 len) {
+	debug(8, "filename[%s], len[0x%x], ptr[%p], _pos[%x], _physPos[%x]", _path.c_str(), len, ptr, _pos, _physicalPos);
+
+	if (!len || _error)		// we actually get some calls with len == 0!
+		return 0;
+
+	_eos = false;			// we can't have eos with write
+
+	if (PowerMan.beginCriticalSection())
+	    debug(8, "suspended");
+
+	// check if we need to seek
+	if (_pos != _physicalPos)
+		if (!physicalSeekFromCur(_pos - _physicalPos)) {
+			_error = true;
+			return 0;
+		}
+
+	int ret = sceIoWrite(_handle, ptr, len);
+
+	PowerMan.endCriticalSection();
+
+	if (ret != (int)len) {
+		_error = true;
+		_errorSource = 5;
+		debug(8, "sceIoWrite returned[0x%x] instead of len[0x%x]", ret, len);
+	}
+
+	_physicalPos += ret;
+	_pos = _physicalPos;
+
+	if (_pos > _fileSize)
+		_fileSize = _pos;
+
+	return ret;
+}
+
+bool Psp2IoStream::flush() {
+	return true;
+}
+
+// For the PSP2, since we're building in suspend support, we moved opening
+// the actual file to an open function since we need an actual Psp2IoStream object to suspend.
+//
+Psp2IoStream *Psp2IoStream::makeFromPath(const Common::String &path, bool writeMode) {
+	Psp2IoStream *stream = new Psp2IoStream(path, writeMode);
+
+	if (stream->open() <= 0) {
+		delete stream;
+		stream = 0;
+	}
+
+	return stream;
+}
+
+/*
+ *  Function to suspend the IO stream
+ *  we can have no output here
+ */
+int Psp2IoStream::suspend() {
+	_suspendCount++;
+
+	if (_handle > 0 && _pos < 0) {	/* check for error */
+		_errorSuspend = SuspendError;
+		_errorPos = _pos;
+		_errorHandle = _handle;
+	}
+
+	if (_handle > 0) {
+		sceIoClose(_handle);		// close our file descriptor
+		_handle = 0xFFFFFFFF;		// Set handle to non-null invalid value so makeFromPath doesn't return error
+	}
+
+	return 0;
+}
+
+/*
+ *  Function to resume the IO stream (called by Power Manager)
+ */
+int Psp2IoStream::resume() {
+	int ret = 0;
+	_suspendCount--;
+
+	// We reopen our file descriptor
+	_handle = sceIoOpen(_path.c_str(), _writeMode ? SCE_O_RDWR | SCE_O_CREAT : SCE_O_RDONLY, 0777); 	// open
+	if (_handle <= 0) {
+		_errorSuspend = ResumeError;
+		_errorPos = _pos;
+	}
+
+	// Resume our previous position if needed
+	if (_handle > 0 && _pos > 0) {
+		ret = sceIoLseek32(_handle, _pos, SCE_SEEK_SET);
+
+		_physicalPos = _pos;
+
+		if (ret < 0) {		// Check for problem
+			_errorSuspend = ResumeError;
+			_errorPos = _pos;
+			_errorHandle = _handle;
+		}
+	}
+	return ret;
+}
+
+#endif /* PSP2 */

--- a/backends/fs/psp2/psp2-stream.h
+++ b/backends/fs/psp2/psp2-stream.h
@@ -1,0 +1,90 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef PSP2STREAM_H_
+#define PSP2STREAM_H_
+
+#include <psp2common/types.h> 
+//#include "common/list.h"
+#include "common/noncopyable.h"
+#include "common/stream.h"
+#include "common/str.h"
+#include "backends/platform/sdl/psp2/powerman.h"
+
+/**
+ *  Class to handle special suspend/resume needs of PSP2 IO Streams
+ */
+class Psp2IoStream final : public Common::SeekableReadStream, public Common::SeekableWriteStream, public Common::NonCopyable, public Suspendable {
+protected:
+	SceUID _handle;		// file handle
+	Common::String _path;
+	int _fileSize;
+	bool _writeMode;	// for resuming in the right mode
+	int _physicalPos;	// physical position in file
+	int _pos;			// position. Sometimes virtual
+	bool _eos;			// EOS flag
+
+	enum {
+		SuspendError = 2,
+		ResumeError = 3
+	};
+
+	// debug stuff
+	mutable int _error;		// file error state
+	int _errorSuspend;			// for debugging
+	mutable int _errorSource;
+	int _errorPos;
+	SceUID _errorHandle;
+	int _suspendCount;
+
+	bool physicalSeekFromCur(int32 offset);
+
+public:
+
+	/**
+	 * Given a path, invoke fopen on that path and wrap the result in a
+	 * Psp2IoStream instance.
+	 */
+	static Psp2IoStream *makeFromPath(const Common::String &path, bool writeMode);
+
+	Psp2IoStream(const Common::String &path, bool writeMode);
+	~Psp2IoStream() override;
+
+	SceUID open();		// open the file pointed to by the file path
+
+	bool err() const override;
+	void clearErr() override;
+	bool eos() const override;
+
+	uint32 write(const void *dataPtr, uint32 dataSize) override;
+	bool flush() override;
+
+	int64 pos() const override;
+	int64 size() const override;
+	bool seek(int64 offs, int whence = SEEK_SET) override;
+	uint32 read(void *dataPtr, uint32 dataSize) override;
+
+	// for suspending
+	int suspend() override;		/* Suspendable interface (power manager) */
+	int resume() override;		/* " " */
+};
+
+#endif /* PSP2STREAM_H_ */

--- a/backends/module.mk
+++ b/backends/module.mk
@@ -459,10 +459,9 @@ endif
 
 ifeq ($(BACKEND),psp2)
 MODULE_OBJS += \
-	fs/posix/posix-fs.o \
-	fs/posix/posix-iostream.o \
-	fs/posix-drives/posix-drives-fs.o \
-	fs/posix-drives/posix-drives-fs-factory.o \
+	fs/psp2/psp2-fs.o \
+	fs/psp2/psp2-fs-factory.o \
+	fs/psp2/psp2-stream.o \
 	plugins/psp2/psp2-provider.o \
 	events/psp2sdl/psp2sdl-events.o
 endif

--- a/backends/platform/sdl/module.mk
+++ b/backends/platform/sdl/module.mk
@@ -75,6 +75,8 @@ endif
 ifdef PSP2
 CC=arm-vita-eabi-gcc
 MODULE_OBJS += \
+	psp2/powerman.o \
+	psp2/thread.o \
 	psp2/psp2-main.o \
 	psp2/psp2.o
 endif

--- a/backends/platform/sdl/psp2/powerman.cpp
+++ b/backends/platform/sdl/psp2/powerman.cpp
@@ -1,0 +1,314 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+
+#include "backends/platform/sdl/psp2/powerman.h"
+#include "engines/engine.h"
+#include "common/debug.h"
+
+
+namespace Common {
+DECLARE_SINGLETON(PowerManager);
+}
+
+// Function to debug the Power Manager (we have no output to screen)
+inline void PowerManager::debugPM() {
+	debug(9, "PM status[%d]. Listcount[%d]. CriticalCount[%d]. ThreadId[%x]. Error[%d]\n",
+	                _PMStatus, _listCounter, _criticalCounter, sceKernelGetThreadId(), _error);
+}
+
+
+/*******************************************
+*
+*	Constructor
+*
+********************************************/
+PowerManager::PowerManager() : _pauseFlag(false), _pauseFlagOld(false), _pauseClientState(UNPAUSED),
+								_suspendFlag(false), _flagMutex(true), _listMutex(true),
+								_criticalCounter(0), _listCounter(0), _error(0), _PMStatus(kInitDone) {}
+
+/*******************************************
+*
+*	Function to register to be notified when suspend/resume time comes
+*
+********************************************/
+bool PowerManager::registerForSuspend(Suspendable *item) {
+	// Register in list
+	debugPM();
+
+	_listMutex.lock();
+
+	_suspendList.push_front(item);
+	_listCounter++;
+
+	_listMutex.unlock();
+
+	debugPM();
+
+	return true;
+}
+
+/*******************************************
+*
+*	Function to unregister to be notified when suspend/resume time comes
+*
+********************************************/
+bool PowerManager::unregisterForSuspend(Suspendable *item) {
+	debugPM();
+
+	// Unregister from stream list
+	_listMutex.lock();
+
+	_suspendList.remove(item);
+	_listCounter--;
+
+	_listMutex.unlock();
+
+	debugPM();
+	return true;
+}
+
+/*******************************************
+*
+*	Destructor
+*
+********************************************/
+PowerManager::~PowerManager() {
+	_PMStatus = kDestroyPM;
+}
+
+/*******************************************
+*
+*	Unsafe function to poll for a pause event (first stage of suspending)
+*   Only for pausing the engine, which doesn't need high synchronization ie. we don't care if it misreads
+*   the flag a couple of times since there is NO mutex protection (for performance reasons).
+*   Polling the engine happens regularly.
+*	On the other hand, we don't know if there will be ANY polling which prevents us from using proper events.
+*
+********************************************/
+void PowerManager::pollPauseEngine() {
+	bool pause = _pauseFlag;		// We copy so as not to have multiple values
+
+	if (pause != _pauseFlagOld) {
+		if (g_engine) { // Check to see if we have an engine
+			if (pause && _pauseClientState == UNPAUSED) {
+				_pauseClientState = PAUSING;		// Tell PM we're in the middle of pausing
+				debug(2, "Pausing engine");
+				_pauseToken = g_engine->pauseEngine();
+				_pauseClientState = PAUSED;			// Tell PM we're done pausing
+			} else if (!pause && _pauseClientState == PAUSED) {
+				debug(2, "Unpausing for resume");
+				_pauseToken.clear();
+				_pauseClientState = UNPAUSED;		// Tell PM we're unpaused
+			}
+		}
+		_pauseFlagOld = pause;
+	}
+}
+
+/*******************************************
+*
+*	Function to block on a suspend, then start a non-suspendable critical section
+*   Use this for large or REALLY critical critical-sections.
+*	Make sure to call endCriticalSection or the PSP2 won't suspend.
+*   returns true if blocked, false if not blocked
+********************************************/
+
+bool PowerManager::beginCriticalSection() {
+	bool ret = false;
+
+	_flagMutex.lock();
+
+	// Check the access flag
+	if (_suspendFlag) {
+		ret = true;
+
+		debug(8, "I got blocked. ThreadId[%x]", sceKernelGetThreadId());
+		debugPM();
+
+		_threadSleep.wait(_flagMutex);
+
+		debug(8, "I got released. ThreadId[%x]", sceKernelGetThreadId());
+		debugPM();
+	}
+
+	// Now prevent the PM from suspending until we're done
+	_criticalCounter++;
+
+	_flagMutex.unlock();
+
+	return ret;
+}
+
+// returns success = true
+void PowerManager::endCriticalSection() {
+	_flagMutex.lock();
+
+	// We're done with our critical section
+	_criticalCounter--;
+
+	if (_criticalCounter <= 0) {
+		if (_suspendFlag) {		// If the PM is sleeping, this flag must be set
+				debug(8, "PM is asleep. Waking it up.");
+				debugPM();
+
+				_pmSleep.releaseAll();
+
+				debug(8, "Woke up the PM");
+
+				debugPM();
+		}
+
+		if (_criticalCounter < 0) {	// Check for bad usage of critical sections
+			debug(8, "Critical counter[%d]!!!", _criticalCounter);
+			debugPM();
+		}
+	}
+
+	_flagMutex.unlock();
+}
+
+/*******************************************
+*
+*	Callback function to be called to put every Suspendable to suspend
+*
+********************************************/
+void PowerManager::suspend() {
+	if (_pauseFlag)
+		return;					// Very important - make sure we only suspend once
+
+	// The first stage of suspend is pausing the engine if possible. We don't want to cause files
+	// to block, or we might not get the engine to pause. On the other hand, we might wait for polling
+	// and it'll never happen. We also want to do this w/o mutexes (for speed) which is ok in this case.
+	_pauseFlag = true;
+
+	_PMStatus = kWaitForClientPause;
+
+	// Now we wait, giving the engine thread some time to find our flag.
+	for (int i = 0; i < 10 && _pauseClientState == UNPAUSED; i++)
+		Psp2Thread::delayMicros(50000);	// We wait 50 msec x 10 times = 0.5 seconds
+
+	if (_pauseClientState == PAUSING) {	// Our event has been acknowledged. Let's wait until the client is done.
+		_PMStatus = kWaitForClientToFinishPausing;
+
+		while (_pauseClientState != PAUSED)
+			Psp2Thread::delayMicros(50000);	// We wait 50 msec at a time
+	}
+
+	// It's possible that the polling thread missed our pause event, but there's
+	// nothing we can do about that.
+	// We can't know if there's polling going on or not.
+	// It's usually not a critical thing anyway.
+
+	_PMStatus = kGettingFlagMutexSuspend;
+
+	// Now we set the suspend flag to true to cause reading threads to block
+	_flagMutex.lock();
+
+	_PMStatus = kGotFlagMutexSuspend;
+
+	_suspendFlag = true;
+
+	// Check if anyone is in a critical section. If so, we'll wait for them
+	if (_criticalCounter > 0) {
+		_PMStatus = kWaitCritSectionSuspend;
+
+		_pmSleep.wait(_flagMutex);
+
+		_PMStatus = kDoneWaitingCritSectionSuspend;
+	}
+
+	_flagMutex.unlock();
+
+	_PMStatus = kGettingListMutexSuspend;
+
+	// Loop over list, calling suspend()
+	_listMutex.lock();
+
+	_PMStatus = kIteratingListSuspend;
+	// Iterate
+	Common::List<Suspendable *>::iterator i;
+
+	for (i = _suspendList.begin(); i != _suspendList.end(); ++i) {
+		(*i)->suspend();
+	}
+	_PMStatus = kDoneIteratingListSuspend;
+
+	_listMutex.unlock();
+	_PMStatus = kDoneSuspend;
+
+	_PMStatus = kDonePowerUnlock;
+}
+
+/*******************************************
+*
+*	Callback function to resume every Suspendable
+*
+********************************************/
+void PowerManager::resume() {
+	_PMStatus = kBeginResume;
+
+	_PMStatus = kCheckingPauseFlag;
+
+	if (!_pauseFlag)
+		return;						// Make sure we can only resume once
+
+	_PMStatus = kGettingListMutexResume;
+
+	// First we notify our Suspendables. Loop over list, calling resume()
+	_listMutex.lock();
+
+	_PMStatus = kIteratingListResume;
+
+	// Iterate
+	Common::List<Suspendable *>::iterator i = _suspendList.begin();
+
+	for (; i != _suspendList.end(); ++i) {
+		(*i)->resume();
+	}
+
+	_PMStatus = kDoneIteratingListResume;
+
+	_listMutex.unlock();
+
+	_PMStatus = kGettingFlagMutexResume;
+
+	// Now we set the suspend flag to false
+	_flagMutex.lock();
+
+	_PMStatus = kGotFlagMutexResume;
+
+	_suspendFlag = false;
+
+	_PMStatus = kSignalSuspendedThreadsResume;
+
+	// Signal the threads to wake up
+	_threadSleep.releaseAll();
+
+	_PMStatus = kDoneSignallingSuspendedThreadsResume;
+
+	_flagMutex.unlock();
+
+	_PMStatus = kDoneResume;
+
+	_pauseFlag = false;	// Signal engine to unpause -- no mutex needed
+}

--- a/backends/platform/sdl/psp2/powerman.h
+++ b/backends/platform/sdl/psp2/powerman.h
@@ -1,0 +1,134 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef POWERMAN_H
+#define POWERMAN_H
+
+#include "backends/platform/sdl/psp2/thread.h"
+#include "common/singleton.h"
+#include "common/list.h"
+
+#include "engines/engine.h"  // for PauseToken
+
+/*
+ *  Implement this class (interface) if you want to use PowerManager's suspend callback functionality
+ *
+ */
+class Suspendable {
+public:
+	virtual ~Suspendable() {}
+	virtual int suspend() = 0;
+	virtual int resume() = 0;
+};
+
+/******************************************************************************************************
+*
+*  This class will call a Suspendable when the PSP goes to suspend/resumes. It also provides the ability to block
+*  a thread when the PSP is going to suspend/suspending, and to wake it up when the PSP is resumed.
+*	This ability is very useful for managing the PSPIoStream class, but may be found useful by other classes as well.
+*
+*******************************************************************************************************/
+class PowerManager: public Common::Singleton<PowerManager> {
+
+public:
+	int blockOnSuspend();								/* block if suspending */
+	bool beginCriticalSection();	/* Use a critical section to block (if suspend was already pressed) */
+	void endCriticalSection();							/* and to prevent the PSP from suspending in a particular section */
+	bool registerForSuspend(Suspendable *item);			/* register to be called to suspend/resume */
+	bool unregisterForSuspend(Suspendable *item);		/* remove from suspend/resume list */
+	void suspend();									/* callback to have all items in list suspend */
+	void resume();									/* callback to have all items in list resume */
+	// Functions for pausing the engine
+	void pollPauseEngine();							/* Poll whether the engine should be paused */
+
+	enum {
+		Error = -1,
+		NotBlocked = 0,
+		Blocked = 1
+	};
+
+	enum PauseState {
+		UNPAUSED = 0,
+		PAUSING,
+		PAUSED
+	};
+
+private:
+	friend class Common::Singleton<PowerManager>;
+	PowerManager();
+	~PowerManager();
+
+	Common::List<Suspendable *> _suspendList;		// list to register in
+
+	volatile bool _pauseFlag;						// For pausing, which is before suspending
+	volatile bool _pauseFlagOld;					// Save the last state of the flag while polling
+	volatile PauseState _pauseClientState;			// Pause state of the target
+	PauseToken _pauseToken;
+
+	volatile bool _suspendFlag;						// protected variable
+	Psp2Mutex _flagMutex;							// mutex to access access flag
+	Psp2Mutex _listMutex;							// mutex to access Suspendable list
+	Psp2Condition _threadSleep;						// signal to synchronize accessing threads
+	Psp2Condition _pmSleep;							// signal to wake up the PM from a critical section
+	volatile int _criticalCounter;					// Counter of how many threads are in a critical section
+	int _error;										// error code - PM can't talk to us. For debugging
+	volatile int _PMStatus;							// What the PM is doing. for debugging
+
+	// States for PM to be in (used for debugging)
+	enum PMState {
+		kInitDone = 1,
+		kDestroyPM = 2,
+		kWaitForClientPause = 3,
+		kWaitForClientToFinishPausing = 4,
+		kGettingFlagMutexSuspend = 5,
+		kGotFlagMutexSuspend = 6,
+		kWaitCritSectionSuspend = 7,
+		kDoneWaitingCritSectionSuspend = 8,
+		kGettingListMutexSuspend = 9,
+		kIteratingListSuspend = 10,
+		kDoneIteratingListSuspend = 11,
+		kDoneSuspend = 12,
+		kDonePowerUnlock,
+		kBeginResume,
+		kCheckingPauseFlag,
+		kGettingListMutexResume,
+		kIteratingListResume,
+		kDoneIteratingListResume,
+		kGettingFlagMutexResume,
+		kGotFlagMutexResume,
+		kSignalSuspendedThreadsResume,
+		kDoneSignallingSuspendedThreadsResume,
+		kDoneResume
+	};
+
+	volatile int _listCounter;						/* How many people are in the list - just for debugging */
+
+	void debugPM();									/* print info about the PM */
+
+public:
+	int getPMStatus() const { return _PMStatus; }
+
+};
+
+// For easy access
+#define PowerMan	PowerManager::instance()
+
+#endif /* POWERMAN_H */

--- a/backends/platform/sdl/psp2/psp2.cpp
+++ b/backends/platform/sdl/psp2/psp2.cpp
@@ -29,7 +29,7 @@
 #include "common/translation.h"
 #include "backends/platform/sdl/psp2/psp2.h"
 #include "backends/saves/default/default-saves.h"
-#include "backends/fs/posix-drives/posix-drives-fs-factory.h"
+#include "backends/fs/psp2/psp2-fs-factory.h"
 #include "backends/events/psp2sdl/psp2sdl-events.h"
 #include "backends/keymapper/hardware-input.h"
 #include <sys/stat.h>
@@ -78,7 +78,7 @@ void OSystem_PSP2::init() {
 	sceIoMkdir("ux0:data/scummvm", 0755);
 	sceIoMkdir("ux0:data/scummvm/saves", 0755);
 
-	DrivesPOSIXFilesystemFactory *fsFactory = new DrivesPOSIXFilesystemFactory();
+	PSP2FilesystemFactory *fsFactory = new PSP2FilesystemFactory();
 	fsFactory->addDrive("ux0:");
 	fsFactory->addDrive("uma0:");
 

--- a/backends/platform/sdl/psp2/psp2.h
+++ b/backends/platform/sdl/psp2/psp2.h
@@ -23,6 +23,7 @@
 #define PLATFORM_SDL_PSP2_H
 
 #include "backends/platform/sdl/sdl.h"
+#include "backends/fs/psp2/psp2-fs-factory.h"
 
 class OSystem_PSP2 : public OSystem_SDL {
 public:
@@ -31,6 +32,8 @@ public:
 	bool hasFeature(Feature f) override;
 	void logMessage(LogMessageType::Type type, const char *message) override;
 	Common::HardwareInputSet *getHardwareInputSet() override;
+
+	FilesystemFactory *getFilesystemFactory() { return &PSP2FilesystemFactory::instance(); }
 
 protected:
 	Common::Path getDefaultConfigFileName() override;

--- a/backends/platform/sdl/psp2/thread.cpp
+++ b/backends/platform/sdl/psp2/thread.cpp
@@ -1,0 +1,172 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+
+#include "backends/platform/sdl/psp2/thread.h"
+#include "common/debug.h"
+
+// Psp2Thread class
+// Utilities to access general thread functions
+
+void Psp2Thread::delayMillis(uint32 ms) {
+	sceKernelDelayThread(ms * 1000);
+}
+
+void Psp2Thread::delayMicros(uint32 us) {
+	sceKernelDelayThread(us);
+}
+
+// Class Psp2Semaphore ------------------------------------------------
+
+Psp2Semaphore::Psp2Semaphore(int initialValue, int maxValue/*=255*/) {
+	_handle = 0;
+	_handle = (uint32)sceKernelCreateSema("ScummVM Sema", 0 /* attr */,
+								  initialValue, maxValue,
+								  0 /*option*/);
+	if (!_handle)
+		debug(8, "failed to create semaphore.");
+}
+
+Psp2Semaphore::~Psp2Semaphore() {
+	if (_handle)
+		if (sceKernelDeleteSema((SceUID)_handle) < 0)
+		    debug(8, "failed to delete semaphore.");
+}
+
+int Psp2Semaphore::numOfWaitingThreads() {
+	SceKernelSemaInfo info;
+	info.numWaitThreads = 0;
+
+	if (sceKernelGetSemaInfo((SceUID)_handle, &info) < 0)
+		debug(8, "failed to retrieve semaphore info for handle %d", _handle);
+
+	return info.numWaitThreads;
+}
+
+int Psp2Semaphore::getValue() {
+	SceKernelSemaInfo info;
+	info.currentCount = 0;
+
+	if (sceKernelGetSemaInfo((SceUID)_handle, &info) < 0)
+		debug(8, "failed to retrieve semaphore info for handle %d", _handle);
+
+	return info.currentCount;
+}
+
+bool Psp2Semaphore::pollForValue(int value) {
+	if (sceKernelPollSema((SceUID)_handle, value) < 0)
+		return false;
+
+	return true;
+}
+
+// false: timeout or error
+bool Psp2Semaphore::takeWithTimeOut(uint timeOut) {
+	uint *pTimeOut = 0;
+	if (timeOut)
+		pTimeOut = &timeOut;
+
+	if (sceKernelWaitSema(_handle, 1, pTimeOut) < 0)	// we always wait for 1
+		return false;
+	return true;
+}
+
+bool Psp2Semaphore::give(int num /*=1*/) {
+	if (sceKernelSignalSema((SceUID)_handle, num) < 0)
+		return false;
+	return true;
+}
+
+// Class PspMutex ------------------------------------------------------------
+
+bool Psp2Mutex::lock() {
+	int threadId = sceKernelGetThreadId();
+	bool ret = true;
+
+	if (_ownerId == threadId) {
+		_recursiveCount++;
+	} else {
+		ret = _semaphore.take();
+		_ownerId = threadId;
+		_recursiveCount = 0;
+	}
+	return ret;
+}
+
+bool Psp2Mutex::unlock() {
+	int threadId = sceKernelGetThreadId();
+	bool ret = true;
+
+	if (_ownerId != threadId) {
+		debug(8, "attempt to unlock mutex by thread[%x] as opposed to owner[%x]",
+			threadId, _ownerId);
+		return false;
+	}
+
+	if (_recursiveCount) {
+		_recursiveCount--;
+	} else {
+		_ownerId = 0;
+		ret = _semaphore.give(1);
+	}
+	return ret;
+}
+
+// Class PspCondition -------------------------------------------------
+
+// Release all threads waiting on the condition
+void Psp2Condition::releaseAll() {
+	_mutex.lock();
+	if (_waitingThreads > _signaledThreads) {	// we have signals to issue
+		int numWaiting = _waitingThreads - _signaledThreads;	// threads we haven't signaled
+		_signaledThreads = _waitingThreads;
+
+		_waitSem.give(numWaiting);
+		_mutex.unlock();
+		for (int i=0; i<numWaiting; i++)	// wait for threads to tell us they're awake
+			_doneSem.take();
+	} else {
+		_mutex.unlock();
+	}
+}
+
+// Mutex must be taken before entering wait
+void Psp2Condition::wait(Psp2Mutex &externalMutex) {
+	_mutex.lock();
+	_waitingThreads++;
+	_mutex.unlock();
+
+	externalMutex.unlock();	// must unlock external mutex
+
+	_waitSem.take();	// sleep on the wait semaphore
+
+	// let the signaling thread know we're done
+	_mutex.lock();
+	if (_signaledThreads > 0 ) {
+		_doneSem.give();	// let the thread know
+		_signaledThreads--;
+	}
+	_waitingThreads--;
+	_mutex.unlock();
+
+	externalMutex.lock();		// must lock external mutex here for continuation
+}

--- a/backends/platform/sdl/psp2/thread.h
+++ b/backends/platform/sdl/psp2/thread.h
@@ -1,0 +1,80 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef PSP2_THREAD_H
+#define PSP2_THREAD_H
+
+#include <psp2common/types.h>
+#include <psp2/kernel/processmgr.h>
+
+#include "common/mutex.h"
+
+// class for thread utils
+class Psp2Thread {
+public:
+	// static functions
+	static void delayMillis(uint32 ms);	// delay the current thread
+	static void delayMicros(uint32 us);
+};
+
+class Psp2Semaphore {
+private:
+	uint32 _handle;
+public:
+	Psp2Semaphore(int initialValue, int maxValue=255);
+	~Psp2Semaphore();
+	bool take() { return takeWithTimeOut(0); }
+	bool takeWithTimeOut(uint timeOut);
+	bool give(int num=1);
+	bool pollForValue(int value);	// check for a certain value
+	int numOfWaitingThreads();
+	int getValue();
+};
+
+class Psp2Mutex : public Common::MutexInternal {
+private:
+	Psp2Semaphore _semaphore;
+	int _recursiveCount;
+	int _ownerId;
+public:
+	Psp2Mutex(bool initialValue) : _semaphore(initialValue ? 1 : 0, 255), _recursiveCount(0), _ownerId(0) {}	// initial, max value
+	bool lock();
+	bool unlock();
+	bool poll() { return _semaphore.pollForValue(1); }
+	int numOfWaitingThreads() { return _semaphore.numOfWaitingThreads(); }
+	bool getValue() { return (bool)_semaphore.getValue(); }
+};
+
+class Psp2Condition {
+private:
+	Psp2Mutex _mutex;
+	int _waitingThreads;
+	int _signaledThreads;
+	Psp2Semaphore _waitSem;
+	Psp2Semaphore _doneSem;
+public:
+	Psp2Condition() : _mutex(true), _waitingThreads(0), _signaledThreads(0),
+								_waitSem(0), _doneSem(0) {}
+	void wait(Psp2Mutex &externalMutex);
+	void releaseAll();
+};
+
+#endif /* PSP2_THREADS_H */

--- a/configure
+++ b/configure
@@ -4189,6 +4189,7 @@ case $_backend in
 		append_var LIBS "-lSceNet_stub -lSceNetCtl_stub"
 		append_var LIBS "-lSceAppMgr_stub -lSceAppUtil_stub -lScePgf_stub"
 		append_var LIBS "-lSceTouch_stub -lSceHid_stub -lSceMotion_stub"
+		append_var LIBS "-lSceIofilemgr_stub"
 		_sdl=yes
 		_sdlversion=2.0.0
 		append_var MODULES "backends/platform/sdl"


### PR DESCRIPTION
Before this patch the app crashes when suspending the console or the app while an engine is running.
The crash happens because of open files and audio desync like on the PSP.

To fix this the following things where added (mostly from the PSP code) :
- A power manager to lock/unlock resources when suspend/resume
- A callback called by the system to trigger the power manager
- A custom filesystem factory and node to handle files closed after resume