### PR TITLE
AGS: Fix displaying thumbnails in the ScummVM GUI

### DIFF
--- a/engines/ags/metaengine.cpp
+++ b/engines/ags/metaengine.cpp
@@ -126,18 +126,16 @@ SaveStateDescriptor AGSMetaEngine::querySaveMetaInfos(const char *target, int sl
 				Image::BitmapDecoder decoder;
 				if (decoder.loadStream(thumbStream)) {
 					const Graphics::Surface *src = decoder.getSurface();
+					const Graphics::Palette &pal = decoder.getPalette();
 					Graphics::Surface *dest;
 
 					if (src->w == 160 && src->h == 100) {
-						dest = new Graphics::Surface();
-						dest->copyFrom(*src);
+						dest = src->convertTo(g_system->getOverlayFormat(), pal.data(), pal.size());
 					} else {
-						Graphics::ManagedSurface temp(160, 100, src->format);
-						temp.blitFrom(*src, Common::Rect(0, 0, src->w, src->h),
-							Common::Rect(0, 0, 160, 100));
-
-						dest = new Graphics::Surface();
-						dest->copyFrom(temp);
+						Graphics::Surface *temp = src->convertTo(g_system->getOverlayFormat(), pal.data(), pal.size());
+						dest = temp->scale(160, 100);
+						temp->free();
+						delete temp;
 					}
 
 					desc.setThumbnail(dest);

--- a/engines/ags/shared/gfx/allegro_bitmap.cpp
+++ b/engines/ags/shared/gfx/allegro_bitmap.cpp
@@ -146,7 +146,7 @@ bool Bitmap::LoadFromFile(PACKFILE *pf) {
 }
 
 bool Bitmap::SaveToFile(Common::WriteStream &out, const void *palette) {
-	return save_bitmap(out, _alBitmap, (const RGB *)palette) == 0;
+	return save_bitmap(out, _alBitmap, (const RGB *)palette);
 }
 
 bool Bitmap::SaveToFile(const char *filename, const void *palette) {

--- a/engines/ags/shared/gfx/image.h
+++ b/engines/ags/shared/gfx/image.h
@@ -35,7 +35,7 @@ extern BITMAP *load_lbm(const char *filename, color *pal);
 extern BITMAP *load_pcx(const char *filename, color *pal);
 extern BITMAP *load_tga(const char *filename, color *pal);
 
-extern int save_bitmap(Common::WriteStream &out, BITMAP *bmp, const RGB *pal);
+extern bool save_bitmap(Common::WriteStream &out, BITMAP *bmp, const RGB *pal);
 
 } // namespace AGS3
 


### PR DESCRIPTION
In addition, `Image::writeBMP()` is now used for creating thumbnails.