### PR TITLE
AWE: Enable EGA/VGA renderer selection for DOS version

### DIFF
--- a/engines/awe/awe.cpp
+++ b/engines/awe/awe.cpp
@@ -21,6 +21,7 @@
 
 #include "audio/mixer.h"
 #include "common/config-manager.h"
+#include "common/rendermode.h"
 #include "common/stream.h"
 #include "awe/awe.h"
 #include "awe/engine.h"
@@ -105,7 +106,12 @@ AweEngine::AweEngine(OSystem *syst, const Awe::AweGameDescription *gameDesc)
 
 	Gfx::_is1991 = false;
 	Gfx::_format = Graphics::PixelFormat::createFormatCLUT8();
-	Video::_useEGA = false;
+
+	if (ConfMan.hasKey("render_mode") && !ConfMan.get("render_mode").empty())
+		Video::_useEGA = (Common::parseRenderMode(ConfMan.get("render_mode")) == Common::kRenderEGA) ? true : false;
+	else
+		Video::_useEGA = false;
+
 	Script::_difficulty = DIFFICULTY_NORMAL;
 	Script::_useRemasteredAudio = true;
 }

--- a/engines/awe/detection_tables.h
+++ b/engines/awe/detection_tables.h
@@ -37,7 +37,7 @@ const AweGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_TESTING,
-			GUIO1(GAMEOPTION_COPY_PROTECTION)
+			GUIO3(GUIO_RENDEREGA, GUIO_RENDERVGA, GAMEOPTION_COPY_PROTECTION)
 		},
 		DT_DOS
 	},
@@ -49,7 +49,7 @@ const AweGameDescription gameDescriptions[] = {
 			Common::FR_FRA,
 			Common::kPlatformDOS,
 			ADGF_TESTING,
-			GUIO1(GAMEOPTION_COPY_PROTECTION)
+			GUIO3(GUIO_RENDEREGA, GUIO_RENDERVGA, GAMEOPTION_COPY_PROTECTION)
 		},
 		DT_DOS
 	},
@@ -64,7 +64,7 @@ const AweGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_TESTING,
-			GUIO1(GAMEOPTION_COPY_PROTECTION)
+			GUIO3(GUIO_RENDEREGA, GUIO_RENDERVGA, GAMEOPTION_COPY_PROTECTION)
 		},
 		DT_DOS
 	},
@@ -78,7 +78,7 @@ const AweGameDescription gameDescriptions[] = {
 			Common::EN_USA,
 			Common::kPlatformDOS,
 			ADGF_TESTING,
-			GUIO1(GAMEOPTION_COPY_PROTECTION)
+			GUIO3(GUIO_RENDEREGA, GUIO_RENDERVGA, GAMEOPTION_COPY_PROTECTION)
 		},
 		DT_DOS
 	},
@@ -92,7 +92,7 @@ const AweGameDescription gameDescriptions[] = {
 			Common::EN_USA,
 			Common::kPlatformDOS,
 			ADGF_TESTING,
-			GUIO1(GAMEOPTION_COPY_PROTECTION)
+			GUIO3(GUIO_RENDEREGA, GUIO_RENDERVGA, GAMEOPTION_COPY_PROTECTION)
 		},
 		DT_DOS
 	},
@@ -105,7 +105,7 @@ const AweGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_DEMO | ADGF_TESTING,
-			GUIO1(GAMEOPTION_COPY_PROTECTION)
+			GUIO3(GUIO_RENDEREGA, GUIO_RENDERVGA, GAMEOPTION_COPY_PROTECTION)
 		},
 		DT_DOS
 	},


### PR DESCRIPTION
The DOS version can be played in VGA or EGA mode, and that is already supported by the engine.
This PR simply enables the Renderer combobox in the GUI, with the EGA and VGA options (VGA by default)


![scummvm-anotherworld-1-00000](https://github.com/user-attachments/assets/43fb0731-e720-49c1-b9e3-01c2edb4f941)



![scummvm-anotherworld-1-00003](https://github.com/user-attachments/assets/be5e3680-4ed0-4c01-8e77-f54c46456e23)
<!---

Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
