### PR TITLE
DIRECTOR: Fix Palette Duplication

### DIFF
--- a/engines/director/castmember/palette.cpp
+++ b/engines/director/castmember/palette.cpp
@@ -41,6 +41,21 @@ PaletteCastMember::PaletteCastMember(Cast *cast, uint16 castId, PaletteCastMembe
 	_palette = source._palette ? new PaletteV4(*source._palette) : nullptr;
 }
 
+PaletteCastMember::PaletteCastMember(Cast *cast, uint16 castId, byte *paletteData, PaletteV4 *pal) 
+	: CastMember(cast, castId) {
+	_type = kCastPalette;
+	_palette = new PaletteV4(pal->id, paletteData, pal->length);
+	_loaded = true;
+}
+ 
+// Need to make a deep copy
+CastMember *PaletteCastMember::duplicate(Cast *cast, uint16 castId) {
+	byte *buf = (byte *)malloc(_palette->length);
+	memcpy(buf, _palette, _palette->length);
+
+	return (CastMember *)(new PaletteCastMember(cast, castId, buf, _palette));
+}
+
 PaletteCastMember::~PaletteCastMember() {
 	if (_palette) {
 		delete[] _palette->palette;

--- a/engines/director/castmember/palette.h
+++ b/engines/director/castmember/palette.h
@@ -30,9 +30,10 @@ class PaletteCastMember : public CastMember {
 public:
 	PaletteCastMember(Cast *cast, uint16 castId, Common::SeekableReadStreamEndian &stream, uint16 version);
 	PaletteCastMember(Cast *cast, uint16 castId, PaletteCastMember &source);
+	PaletteCastMember(Cast *cast, uint16 castId, byte *paletteData, PaletteV4 *palette);
 	~PaletteCastMember();
 
-	CastMember *duplicate(Cast *cast, uint16 castId) override { return (CastMember *)(new PaletteCastMember(cast, castId, *this)); }
+	CastMember *duplicate(Cast *cast, uint16 castId) override;
 
 	CastMemberID getPaletteId();
 	void activatePalette();


### PR DESCRIPTION
When duplicating, deep copy of palette should be made
If not it causes the `~PaletteCastMember()` to be called on both 
cast members when cleaning up the movie
If both cast members are pointing to the same palette data
then free is called on the same data twice causing problems

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
