### PR TITLE
TESTBED: Fix broken tests and non-interactive mode

### DIFF
--- a/backends/saves/default/default-saves.cpp
+++ b/backends/saves/default/default-saves.cpp
@@ -115,12 +115,14 @@ Common::InSaveFile *DefaultSaveFileManager::openForLoading(const Common::String 
 
 	for (const auto &lockedFile : _lockedFiles) {
 		if (filename == lockedFile) {
+			setError(Common::kReadingFailed, Common::String::format("Savefile '%s' is locked and cannot be loaded", filename.c_str()));
 			return nullptr; // file is locked, no loading available
 		}
 	}
 
 	SaveFileCache::const_iterator file = _saveFileCache.find(filename);
 	if (file == _saveFileCache.end()) {
+		setError(Common::kPathDoesNotExist, Common::String::format("Savefile '%s' does not exist", filename.c_str()));
 		return nullptr;
 	} else {
 		// Open the file for loading.

--- a/engines/testbed/config.h
+++ b/engines/testbed/config.h
@@ -56,7 +56,6 @@ public:
 	Testsuite *getTestsuiteByName(const Common::String &name);
 	bool stringToBool(const Common::String &str) { return str.equalsIgnoreCase("true") ? true : false; }
 	Common::String boolToString(bool val) { return val ? "true" : "false"; }
-	void initDefaultConfiguration();
 	int getNumSuitesEnabled();
 
 private:

--- a/engines/testbed/fs.cpp
+++ b/engines/testbed/fs.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "common/config-manager.h"
+#include "common/file.h"
 #include "common/stream.h"
 #include "common/util.h"
 
@@ -38,8 +39,17 @@ namespace Testbed {
  */
 bool FStests::readDataFromFile(Common::FSDirectory *directory, const char *file) {
 
-	Common::SeekableReadStream *readStream = directory->createReadStreamForMember(file);
+	if (!SearchMan.isPathDirectory(directory->getFSNode().getPath())) {
+		SearchMan.addDirectory(directory->getFSNode().getPath(), 0, 1, false);
+	}
 
+	Common::ScopedPtr<Common::File> f(new Common::File());
+	if (!f->open(file)) {
+		Testsuite::logDetailedPrintf("Can't open game file\n");
+		return false;
+	}
+	
+	Common::SeekableReadStream *readStream = f.release();
 	if (!readStream) {
 		Testsuite::logDetailedPrintf("Can't open game file for reading\n");
 		return false;

--- a/engines/testbed/sound.cpp
+++ b/engines/testbed/sound.cpp
@@ -354,7 +354,7 @@ SoundSubsystemTestSuite::SoundSubsystemTestSuite() {
 	// Make audio-files discoverable
 	Common::FSNode gameRoot(ConfMan.getPath("path"));
 	if (gameRoot.exists()) {
-		SearchMan.addSubDirectoryMatching(gameRoot, "audiocd-files");
+		SearchMan.addSubDirectoryMatching(gameRoot, "audiocd-files", 0, 2, false);
 		if (SearchMan.hasFile("track01.mp3") && SearchMan.hasFile("track02.mp3") && SearchMan.hasFile("track03.mp3") && SearchMan.hasFile("track04.mp3")) {
 			addTest("AudiocdOutput", &SoundSubsystem::audiocdOutput, true);
 		} else {


### PR DESCRIPTION
This fixes a few issues I encountered recently when working with Testbed:

- https://github.com/scummvm/scummvm/pull/6605 did not correctly handle the new setting to set non-interactive mode. It's not clear how I missed that (probably during cherry-picking for the PR). I also changed the behaviour to always run all (non-interactive) tests in non-interactive mode, as there's no way to select the tests when launching it non-interactive.
- [Trac#15754](https://bugs.scummvm.org/ticket/15754) turned out to be an issue with the test. It's not clear if this ever worked as the handling of trailing dots is in `SearchMan`, not `FSDirectory`. I checked the AGOS engine and it also uses `SearchMan`, so this should now be correct. Maybe this test pre-dates `SearchMan`?
- The `ImageAlbum` test also didn't work. Also a bug in the test itself which should now be fixed (the images are in a subfolder that wasn't added to `SearchMan`).
- There was a correctly failing test in the save game tests, I fixed the issue by properly setting the errors.