### PR TITLE
PARALLACTION: Add text-to-speech (TTS)

### DIFF
--- a/engines/parallaction/balloons.cpp
+++ b/engines/parallaction/balloons.cpp
@@ -334,6 +334,8 @@ int BalloonManager_ns::setSingleBalloon(const Common::String &text, uint16 x, ui
 	w = _se.width() + 14;
 	h = _se.height() + 20;
 
+	_vm->sayText(text, Common::TextToSpeechManager::INTERRUPT);
+
 	int id = createBalloon(w+5, h, winding, 1);
 	Balloon *balloon = &_intBalloons[id];
 
@@ -379,6 +381,10 @@ int BalloonManager_ns::setDialogueBalloon(const Common::String &text, uint16 win
 void BalloonManager_ns::setBalloonText(uint id, const Common::String &text, TextColor textColor) {
 	Balloon *balloon = getBalloon(id);
 	balloon->surface->fillRect(balloon->innerBox, 1);
+
+	if (textColor != kUnselectedColor && !text.contains("%P")) {
+		_vm->sayText(text, Common::TextToSpeechManager::INTERRUPT);
+	}
 
 	_sw.write(text, MAX_BALLOON_WIDTH, _textColors[textColor], balloon->surface);
 }
@@ -426,6 +432,10 @@ void BalloonManager_ns::reset() {
 		_intBalloons[i].surface = nullptr;	// no need to delete surface, since it is done by Gfx
 	}
 	_numBalloons = 0;
+
+	if (_vm->_password.size() == 0) {
+		_vm->stopTextToSpeech();
+	}
 }
 
 
@@ -585,6 +595,8 @@ Graphics::Surface *BalloonManager_br::expandBalloon(Frames *data, int frameNum) 
 int BalloonManager_br::setSingleBalloon(const Common::String &text, uint16 x, uint16 y, uint16 winding, TextColor textColor) {
 	cacheAnims();
 
+	_vm->sayText(text, Common::TextToSpeechManager::INTERRUPT);
+
 	int id = _numBalloons;
 	Frames *src = nullptr;
 	int srcFrame = 0;
@@ -657,6 +669,11 @@ int BalloonManager_br::setDialogueBalloon(const Common::String &text, uint16 win
 
 void BalloonManager_br::setBalloonText(uint id, const Common::String &text, TextColor textColor) {
 	Balloon *balloon = getBalloon(id);
+
+	if (textColor != kUnselectedColor) {
+		_vm->sayText(text, Common::TextToSpeechManager::INTERRUPT);
+	}
+
 	_sw.write(text, 216, _textColors[textColor], balloon->surface);
 }
 
@@ -713,6 +730,8 @@ void BalloonManager_br::reset() {
 	}
 
 	_numBalloons = 0;
+
+	_vm->stopTextToSpeech();
 }
 
 void BalloonManager_br::cacheAnims() {

--- a/engines/parallaction/callables_ns.cpp
+++ b/engines/parallaction/callables_ns.cpp
@@ -413,6 +413,23 @@ void Parallaction_ns::_c_testResult(void *parm) {
 	_gfx->showLabel(_testResultLabels[0], CENTER_LABEL_HORIZONTAL, 38);
 	_gfx->showLabel(_testResultLabels[1], CENTER_LABEL_HORIZONTAL, 58);
 
+	const char *charName = nullptr;
+	switch (_characterVoiceID) {
+	case kDoug:
+		charName = "Doug Nuts";
+		break;
+	case kDonna:
+		charName = "Donna Fatale";
+		break;
+	case kDino:
+		charName = "Dino Fagioli";
+		break;
+	}
+	
+	if (charName != nullptr) {
+		sayText(charName, Common::TextToSpeechManager::QUEUE);
+	}
+
 	return;
 }
 

--- a/engines/parallaction/detection.cpp
+++ b/engines/parallaction/detection.cpp
@@ -70,7 +70,7 @@ static const PARALLACTIONGameDescription gameDescriptions[] = {
 			Common::UNK_LANG,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_TTS)
 		},
 		GType_Nippon,
 		GF_LANG_EN | GF_LANG_FR | GF_LANG_DE | GF_LANG_IT | GF_LANG_MULT,
@@ -96,7 +96,7 @@ static const PARALLACTIONGameDescription gameDescriptions[] = {
 			Common::UNK_LANG,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_TTS)
 		},
 		GType_Nippon,
 		GF_LANG_EN | GF_LANG_FR | GF_LANG_DE | GF_LANG_IT | GF_LANG_MULT,
@@ -120,7 +120,7 @@ static const PARALLACTIONGameDescription gameDescriptions[] = {
 			Common::UNK_LANG,
 			Common::kPlatformAmiga,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_TTS)
 		},
 		GType_Nippon,
 		GF_LANG_EN | GF_LANG_FR | GF_LANG_DE | GF_LANG_MULT,
@@ -135,7 +135,7 @@ static const PARALLACTIONGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformAmiga,
 			ADGF_DEMO,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_TTS)
 		},
 		GType_Nippon,
 		GF_LANG_EN | GF_DEMO,
@@ -158,7 +158,7 @@ static const PARALLACTIONGameDescription gameDescriptions[] = {
 			Common::IT_ITA,
 			Common::kPlatformAmiga,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_TTS)
 		},
 		GType_Nippon,
 		GF_LANG_IT,
@@ -173,7 +173,7 @@ static const PARALLACTIONGameDescription gameDescriptions[] = {
 			Common::UNK_LANG,
 			Common::kPlatformDOS,
 			ADGF_UNSTABLE,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_TTS)
 		},
 		GType_BRA,
 		GF_LANG_EN | GF_LANG_FR | GF_LANG_DE | GF_LANG_IT | GF_LANG_MULT,
@@ -187,7 +187,7 @@ static const PARALLACTIONGameDescription gameDescriptions[] = {
 			Common::UNK_LANG,
 			Common::kPlatformDOS,
 			ADGF_DEMO | ADGF_UNSTABLE,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_TTS)
 		},
 		GType_BRA,
 		GF_LANG_EN | GF_DEMO,
@@ -201,7 +201,7 @@ static const PARALLACTIONGameDescription gameDescriptions[] = {
 			Common::UNK_LANG,
 			Common::kPlatformAmiga,
 			ADGF_UNSTABLE,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_TTS)
 		},
 		GType_BRA,
 		GF_LANG_EN | GF_LANG_FR | GF_LANG_DE | GF_LANG_MULT,
@@ -215,7 +215,7 @@ static const PARALLACTIONGameDescription gameDescriptions[] = {
 			Common::UNK_LANG,
 			Common::kPlatformAmiga,
 			ADGF_DEMO | ADGF_UNSTABLE,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_TTS)
 		},
 		GType_BRA,
 		GF_LANG_EN | GF_DEMO,

--- a/engines/parallaction/detection.h
+++ b/engines/parallaction/detection.h
@@ -49,6 +49,8 @@ struct PARALLACTIONGameDescription {
 	uint32 features;
 };
 
+#define GAMEOPTION_TTS                    GUIO_GAMEOPTIONS1
+
 } // End of namespace Parallaction
 
 #endif // PARALLACTION_DETECTION_H

--- a/engines/parallaction/exec.h
+++ b/engines/parallaction/exec.h
@@ -202,6 +202,8 @@ public:
 
 class ProgramExec_ns : public ProgramExec {
 protected:
+	int _currentCredit;
+
 	Parallaction_ns *_vm;
 
 	DECLARE_UNQUALIFIED_INSTRUCTION_OPCODE(invalid);

--- a/engines/parallaction/exec_ns.cpp
+++ b/engines/parallaction/exec_ns.cpp
@@ -24,9 +24,200 @@
 #include "parallaction/parallaction.h"
 #include "parallaction/sound.h"
 
+#include "common/config-manager.h"
 #include "common/textconsole.h"
 
 namespace Parallaction {
+
+#ifdef USE_TTS
+
+// Transcribed for TTS; only English is translated in-game
+static const char *openingCreditsSecondLine[] = {
+	"Grafica Totale: Max M.",		// Italian
+	"Graphiques Totaux: Max M.",	// French
+	"Total Graphics: Max M.",		// English
+	"Gesamtgrafik: Max M."			// German
+};
+
+static const char *openingCreditsThirdLine[] = {
+	"Design del Gioco: Mr. Tzutzumi",	// Italian
+	"Conception de Jeux: Mr. Tzutzumi",	// French
+	"Game Design: Mr. Tzutzumi",		// English
+	"Spieldesign: Mr. Tzutzumi"			// German
+};
+
+// Transcribed for TTS; only Italian is translated in-game
+static const char *endCreditsItalian[] = {
+	"La Cassiera",
+	"La Segretaria",
+	"Il Taxista",
+	"Il Giornalaio",
+	"Passante",
+	"Il Segretario",
+	"L'Uccello",
+	"L'Inserviente",
+	"Il Priore",
+	"Il Suicida",
+	"Il Direttore",
+	"Passante",
+	"Fratello Shinpui",
+	"Apollo il Gorilla",
+	"Il Portiere",
+	"Il Guru",
+	"Fratello Baka",
+	"Josko il Barman",
+	"Figaro L' Estetista",
+	"Il Guardiano del Museo",
+	"Passante",
+	"Il Losco Max",
+	"Mister Y",
+	"Il Punk",
+	"Passante",
+	"Il Signor Bemutsu",
+	"L' Annunciatore",
+	"La Punkina",
+	"L' Imperatore",
+	"Il Dottor Ki",
+	"Il Cuoco",
+	"Il Punk",
+	"Passante",
+	"Il Losco Figuro",
+	"Chan L'Onesto",
+	"",
+	"La Geisha",
+	"Kos 'O Professore",
+	"Il Giocatore di Pacinko"
+};
+
+static const char *endCreditsFrench[] = {
+	"La Cassi\350re",
+	"La Secr\351taire",
+	"Le Chaffeur de Taxi",
+	"Le Marchand de Journaux",
+	"La Pi\351tonne",
+	"Le Secr\351taire",
+	"La Corneille",
+	"Le Oshiya",
+	"Le Prieur",
+	"Le Candidat au Suicide",
+	"Le Directeur",
+	"La Pi\351tonne",
+	"Fr\350re Shinpui",
+	"Apollo le Garde du Corps",
+	"Le Concierge",
+	"Le Guru",
+	"Fr\350re Baka",
+	"Josko le Barman",
+	"Figaro L'esth\351ticien",
+	"Le Gardien du Mus\351e",
+	"La Pi\351tonne",
+	"Le Ombrag\351e Max",
+	"Monsieur Y",
+	"Le Punk",
+	"La Pi\351tonne",
+	"Monsieur Bemutsu",
+	"Le Annonceur",
+	"Le Punk",
+	"L'Empereur",
+	"Le Docteur Ki",
+	"Le Chef",
+	"Le Punk",
+	"Le Pi\351ton",
+	"Le Louche Personnage",
+	"Honest Chan",
+	"",
+	"La Geisha",
+	"Professeur Kos",
+	"Le Joueur de Pachinko"
+};
+
+static const char *endCreditsEnglish[] = {
+	"Cashier",
+	"Secretary",
+	"Taxi-driver",
+	"Newspaper Seller",
+	"Pedestrian",
+	"Secretary",
+	"Grackle",
+	"Oshiya",
+	"Prior",
+	"Suicidal Man",
+	"Governor",
+	"Pedestrian",
+	"Brother Shinpui",
+	"Apollo the Bodyguard",
+	"Door-keeper",
+	"Guru",
+	"Brother Baka",
+	"Josko the Barman",
+	"Figaro the Beautician",
+	"Museum Custodian",
+	"Pedestrian",
+	"Sullen Max",
+	"Mister Y",
+	"Punk",
+	"Pedestrian",
+	"Mister Bemutsu",
+	"Announcer",
+	"Punk",
+	"Emperor",
+	"Doctor Ki",
+	"Cook",
+	"Punk",
+	"Pedestrian",
+	"Shady Type",
+	"Honest Chan",
+	"",
+	"Geisha",
+	"Professor Kos",
+	"Pachinko Player"
+};
+
+static const char *endCreditsGerman[] = {
+	"Die Kassiererin",
+	"Die Sekret\344rin",
+	"Der Taxifahrer",
+	"Der Zeitungsverk\344ufer",
+	"Die Passantin",
+	"Der Sekret\344r",
+	"Des Grakula",
+	"Der Oshiya",
+	"Der Prior",
+	"Der Selbstm\366rder",
+	"Der Direktor",
+	"Die Passantin",
+	"Bruder Shinpui",
+	"Apollo der Bodyguard",
+	"Der Portier",
+	"Der Guru",
+	"Bruder Baka",
+	"Josko der Barman",
+	"Figaro, der Kosmetiker",
+	"Der Museumsw\344rter",
+	"Die Passantin",
+	"Schattig Max",
+	"Herr Y",
+	"Der Punker",
+	"Die Passantin",
+	"Herr Bemutsu",
+	"Der Ansager",
+	"Der Punker",
+	"Der Kaiser",
+	"Doktor Ki",
+	"Der Koch",
+	"Der Punker",
+	"Der Passant",
+	"Der Dunkler Typ",
+	"Honest Chan",
+	"",
+	"Die Geisha",
+	"Professor Kos",
+	"Der Pachinko-Spieler"
+};
+
+static const int kNumberOfCredits = ARRAYSIZE(endCreditsItalian);
+
+#endif
 
 #define INST_ON							1
 #define INST_OFF						2
@@ -68,6 +259,16 @@ DECLARE_INSTRUCTION_OPCODE(on) {
 
 	inst->_a->_flags |= kFlagsActive;
 	inst->_a->_flags &= ~kFlagsRemove;
+
+#ifdef USE_TTS
+	if (scumm_stricmp(inst->_a->_name, "telo3") == 0) {
+		_vm->setTTSVoice(kNarratorVoiceID);
+		_vm->sayText(openingCreditsSecondLine[_vm->getInternLanguage()], Common::TextToSpeechManager::INTERRUPT);
+	} else if (scumm_stricmp(inst->_a->_name, "game") == 0) {
+		_vm->setTTSVoice(kNarratorVoiceID);
+		_vm->sayText(openingCreditsThirdLine[_vm->getInternLanguage()], Common::TextToSpeechManager::INTERRUPT);
+	}
+#endif
 }
 
 
@@ -85,6 +286,21 @@ DECLARE_INSTRUCTION_OPCODE(loop) {
 
 
 DECLARE_INSTRUCTION_OPCODE(endloop) {
+	if (ctxt._program->_loopStart == 11 && scumm_stricmp(_vm->_location._name, "test") == 0) {
+		// Delay moving on from test results until TTS is done or the player clicks, 
+		// so the TTS system can speak them fully
+		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+		if (ttsMan != nullptr && ConfMan.getBool("tts_enabled") && ttsMan->isSpeaking()) {
+			ctxt._program->_loopCounter = 2;
+			int event = _vm->_input->getLastButtonEvent();
+
+			if (event == kMouseLeftUp) {
+				ttsMan->stop();
+				ctxt._program->_loopCounter = 0;
+			}
+		}
+	}
+
 	if (--ctxt._program->_loopCounter > 0) {
 		ctxt._ip = ctxt._program->_loopStart;
 	}
@@ -104,6 +320,33 @@ DECLARE_INSTRUCTION_OPCODE(inc) {
 	int16 lvalue = inst->_opA.getValue();
 
 	if (inst->_index == INST_INC) {
+#ifdef USE_TTS
+		if (_vm->_endCredits && ctxt._anim->_name[0] == 's' && _currentCredit < kNumberOfCredits) {
+			const char **credits;
+
+			switch (_vm->getInternLanguage()) {
+			case kItalian:
+				credits = endCreditsItalian;
+				break;
+			case kFrench:
+				credits = endCreditsFrench;
+				break;
+			case kEnglish:
+				credits = endCreditsEnglish;
+				break;
+			case kGerman:
+				credits = endCreditsGerman;
+				break;
+			default:
+				credits = endCreditsItalian;
+				break;
+			}
+
+			_vm->sayText(credits[_currentCredit], Common::TextToSpeechManager::QUEUE);
+			_currentCredit++;
+		}
+#endif
+
 		lvalue += _si;
 	} else {
 		lvalue -= _si;
@@ -314,6 +557,8 @@ CommandExec_ns::CommandExec_ns(Parallaction_ns* vm) : CommandExec(vm), _vm(vm) {
 }
 
 ProgramExec_ns::ProgramExec_ns(Parallaction_ns *vm) : _vm(vm) {
+	_currentCredit = 0;
+
 	_instructionNames = _instructionNamesRes_ns;
 
 	ProgramOpcodeSet *table = nullptr;

--- a/engines/parallaction/graphics.cpp
+++ b/engines/parallaction/graphics.cpp
@@ -551,6 +551,7 @@ GfxObj *Gfx::renderFloatingLabel(Font *font, char *text) {
 	GfxObj *obj = new GfxObj(kGfxObjTypeLabel, new SurfaceToFrames(cnv), "floatingLabel");
 	obj->transparentKey = LABEL_TRANSPARENT_COLOR;
 	obj->layer = LAYER_FOREGROUND;
+	obj->_text = text;
 
 	return obj;
 }
@@ -559,6 +560,8 @@ void Gfx::showFloatingLabel(GfxObj *label) {
 	hideFloatingLabel();
 
 	if (label) {
+		_vm->sayText(label->_text, Common::TextToSpeechManager::INTERRUPT);
+
 		label->x = -1000;
 		label->y = -1000;
 		label->setFlags(kGfxObjVisible);
@@ -648,11 +651,13 @@ GfxObj *Gfx::createLabel(Font *font, const char *text, byte color) {
 	GfxObj *obj = new GfxObj(kGfxObjTypeLabel, new SurfaceToFrames(cnv), "label");
 	obj->transparentKey = LABEL_TRANSPARENT_COLOR;
 	obj->layer = LAYER_FOREGROUND;
+	obj->_text = text;
+	obj->_text.replace('@', ' ');
 
 	return obj;
 }
 
-void Gfx::showLabel(GfxObj *label, int16 x, int16 y) {
+void Gfx::showLabel(GfxObj *label, int16 x, int16 y, bool queueTTS, bool voiceText) {
 	if (!label) {
 		return;
 	}
@@ -672,6 +677,20 @@ void Gfx::showLabel(GfxObj *label, int16 x, int16 y) {
 
 	label->x = x;
 	label->y = y;
+
+	if (voiceText) {
+		_vm->setTTSVoice(kNarratorVoiceID);
+
+		Common::TextToSpeechManager::Action action;
+
+		if (queueTTS) {
+			action = Common::TextToSpeechManager::QUEUE;
+		} else {
+			action = Common::TextToSpeechManager::INTERRUPT;
+		}
+
+		_vm->sayText(label->_text, action);
+	}
 
 	_labels.push_back(label);
 }

--- a/engines/parallaction/graphics.h
+++ b/engines/parallaction/graphics.h
@@ -320,6 +320,8 @@ public:
 	int _pathId;
 	bool _hasPath;
 
+	Common::String _text;
+
 
 	GfxObj(uint type, Frames *frames, const char *name = NULL);
 	virtual ~GfxObj();
@@ -457,7 +459,7 @@ public:
 
 	GfxObj *renderFloatingLabel(Font *font, char *text);
 	GfxObj *createLabel(Font *font, const char *text, byte color);
-	void showLabel(GfxObj *label, int16 x, int16 y);
+	void showLabel(GfxObj *label, int16 x, int16 y, bool queueTTS = true, bool voiceText = true);
 	void hideLabel(GfxObj *label);
 	void freeLabels();
 	void unregisterLabel(GfxObj *label);

--- a/engines/parallaction/metaengine.cpp
+++ b/engines/parallaction/metaengine.cpp
@@ -43,11 +43,37 @@ Common::Platform Parallaction::getPlatform() const { return _gameDescription->de
 
 } // End of namespace Parallaction
 
+#ifdef USE_TTS
+
+static const ADExtraGuiOptionsMap optionsList[] = {
+	{
+		GAMEOPTION_TTS,
+		{
+			_s("Enable Text to Speech"),
+			_s("Use TTS to read the descriptions (if TTS is available)"),
+			"tts_enabled",
+			false,
+			0,
+			0
+		}
+	},
+	
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR
+};
+
+#endif
+
 class ParallactionMetaEngine : public AdvancedMetaEngine<Parallaction::PARALLACTIONGameDescription> {
 public:
 	const char *getName() const override {
 		return "parallaction";
 	}
+
+#ifdef USE_TTS
+	const ADExtraGuiOptionsMap *getAdvancedExtraGuiOptions() const override {
+		return optionsList;
+	}
+#endif
 
 	bool hasFeature(MetaEngineFeature f) const override;
 	Common::Error createInstance(OSystem *syst, Engine **engine, const Parallaction::PARALLACTIONGameDescription *desc) const override;

--- a/engines/parallaction/parallaction.h
+++ b/engines/parallaction/parallaction.h
@@ -29,6 +29,7 @@
 #include "common/random.h"
 #include "common/savefile.h"
 #include "common/textconsole.h"
+#include "common/text-to-speech.h"
 
 #include "engines/engine.h"
 
@@ -84,6 +85,12 @@ enum {
 	kEvIngameMenu   = 8000
 };
 
+enum LanguageIndex {
+	kItalian = 0,
+	kFrench = 1,
+	kEnglish = 2,
+	kGerman = 3
+};
 
 
 
@@ -219,6 +226,92 @@ public:
 	bool dummy() const;
 };
 
+#ifdef USE_TTS
+
+struct CharacterVoiceData {
+	const char *characterName;
+	uint8 voiceID;
+	bool male;
+};
+
+static const CharacterVoiceData characterVoiceDatas[] = {
+	{ nullptr, 0, true },		// Used as the narrator for cutscene text
+	{ "dough", 1, true },
+	{ "donna", 0, false },
+	{ "dino", 2, true },
+	{ "drki", 3, true },
+	{ "ddd.talk", 1, true },
+	{ nullptr, 0, false },	// Donna in ddd.talk
+	{ nullptr, 2, true },	// Dino in ddd.talk
+	{ "police.talk", 4, true },
+	{ "vecchio.talk", 5, true },
+	{ "karaoke.talk", 6, true },
+	{ "suicida.talk", 7, true },
+	{ "direttore.talk", 8, true },
+	{ "guardiano.talk", 9, true },
+	{ "sento.talk", 10, true },
+	{ "giocatore.talk", 11, true },
+	{ "mona.talk", 12, true },
+	{ "monaco2.talk", 13, true },
+	{ "uccello.talk", 14, true },
+	{ "guru.talk", 15, true },
+	{ "monaco1.talk", 16, true },
+	{ "segretario.talk", 17, true },
+	{ "imperatore.talk", 18, true },
+	{ "secondo.talk", 19, true },
+	{ "taxista.talk", 20, true },
+	{ "bemutsu.talk", 21, true },
+	{ "negro.talk", 22, true },
+	{ "punk.talk", 23, true },
+	{ "chan.talk", 24, true },
+	{ "donna0.talk", 0, false },
+	{ "maxkos.talk", 25, true },
+	{ nullptr, 26, true },		// Second person in the maxkos.talk dialogue
+	{ "drki.talk", 3, true },
+	{ "barman.talk", 27, true },
+	{ "losco.talk", 28, true },
+	{ "mitsu.talk", 29, true },
+	{ "autoradio.talk", 30, true },
+	{ "passa1.talk", 31, true },
+	{ "passa2.talk", 1, false },
+	{ "passa3.talk", 32, true },
+	{ "giornalaio.talk", 33, true },
+	{ "pazza1.talk", 2, false },
+	{ "pazza2.talk", 3, false },
+	{ "pazza3.talk", 4, false },
+	{ "citofono.talk", 34, true },
+	{ "perdelook.talk", 0, false },
+	{ "tele.talk", 35, true },
+	{ "dough.talk", 1, true },
+	{ "donna.talk", 0, false },
+	{ "guanti.talk", 36, true },
+	{ "cuoco.talk", 37, true },
+	{ "punks.talk", 38, true },
+	{ nullptr, 39, true },		// Second person in the punks.talk dialogue
+	{ "punko.talk", 40, true },
+	{ "hotdog.talk", 41, true },
+	{ "cameriera.talk", 5, false },
+	{ "rice1.talk", 42, true },
+	{ nullptr, 43, true },		// Second person in the rice1.talk dialogue
+	{ "segretaria.talk", 6, false },
+	{ "robot.talk", 44, true },
+	{ "portiere.talk", 45, true },
+	{ "figaro.talk", 46, true },
+	{ "ominos.talk", 47, true },
+	{ "cassiera.talk", 7, false },
+	{ "dino.talk", 2, true }
+};
+
+#endif
+
+enum PlayableCharacterVoiceID {
+	kDoug = 1,
+	kDonna = 2,
+	kDino = 3,
+	kDrki = 4
+};
+
+static const int kNarratorVoiceID = 0;
 
 class SaveLoad;
 
@@ -301,6 +394,7 @@ public:
 	Location		_location;
 	ZonePtr			_activeZone;
 	char			_characterName1[50];	// only used in changeCharacter
+	int				_characterVoiceID;
 	ZonePtr			_zoneTrap;
 	ZonePtr			_commentZone;
 	Common::String  _newLocationName;
@@ -359,6 +453,9 @@ public:
 	int16		getInventoryItemIndex(int16 pos);
 	void		openInventory();
 	void		closeInventory();
+	void		sayText(const Common::String &text, Common::TextToSpeechManager::Action action) const;
+	void		setTTSVoice(int id) const;
+	void		stopTextToSpeech() const;
 
 	virtual void parseLocation(const char* name) = 0;
 	virtual void changeLocation() = 0;
@@ -388,6 +485,8 @@ public:
 
 	uint16			_score;
 	Common::String	_password;
+
+	bool _endCredits;
 
 
 public:


### PR DESCRIPTION
Adds a toggle for text-to-speech to the game options.
Adds text-to-speech for the following:
- Opening and end credits
- Slides
- Objects when hovered over
- Dialogue and dialogue options
- Location comments

Currently only tested with Nippon Safes, Inc.
The following hardcoded translations need verification:
- Opening credits, mouse click prompts, and intro messages in Italian, French, and German
- End credits in French and German (English translation may also need to be checked for mistranslations from the original text, which is in Italian)