### PR TITLE
GRAPHICS, BLADERUNNER: add ARM NEON blitting and use it for VQADecoder

### DIFF
--- a/graphics/blit.h
+++ b/graphics/blit.h
@@ -212,6 +212,11 @@ bool crossMaskBlitMap(byte *dst, const byte *src, const byte *mask,
 
 typedef void (*FastBlitFunc)(byte *, const byte *, const uint, const uint, const uint, const uint);
 
+#ifdef SCUMMVM_NEON
+// Fast blit functions for ARM NEON
+void fastBlitNEON_XRGB1555_RGB565(byte *, const byte *, const uint, const uint, const uint, const uint);
+#endif
+
 /**
  * Look up optimised routines for converting between pixel formats.
  *

--- a/graphics/blit/blit.cpp
+++ b/graphics/blit/blit.cpp
@@ -322,7 +322,7 @@ bool crossBlit(byte *dst, const byte *src,
 	}
 
 	// Attempt to use a faster method if possible
-	FastBlitFunc blitFunc = getFastBlitFunc(dstFmt, dstFmt);
+	FastBlitFunc blitFunc = getFastBlitFunc(dstFmt, srcFmt);
 	if (blitFunc) {
 		blitFunc(dst, src, dstPitch, srcPitch, w, h);
 		return true;


### PR DESCRIPTION
On ARM devices with low compute power like the PSP2 we can drastically improve performance by using ARM NEON instructions.