### PR TITLE
ENGINES: Fix unknown games report punycoding

### DIFF
--- a/common/path.cpp
+++ b/common/path.cpp
@@ -1083,6 +1083,18 @@ bool Path::punycodeNeedsEncode() const {
 		}, tmp);
 }
 
+bool Path::punycodeIsEncoded() const {
+	bool tmp = false;
+	return reduceComponents<bool &>(
+		[](bool &result, const String &in, bool last) -> bool & {
+			// If we already are encoded, we still are
+			if (result) return result;
+
+			result = punycode_hasprefix(in);
+			return result;
+		}, tmp);
+}
+
 // For a path component creates a string with following property:
 // if 2 files have the same case-insensitive
 // identifier string then and only then we treat them as

--- a/common/path.h
+++ b/common/path.h
@@ -514,6 +514,14 @@ public:
 	bool punycodeNeedsEncode() const;
 
 	/**
+	 * Returns whether the path is already Punycoded
+	 *
+	 * Only the prefix is checked and not the Punycode correctness.
+	 * Use this function only with known Punycoded paths.
+	 */
+	bool punycodeIsEncoded() const;
+
+	/**
 	 * Convert all characters in the path to lowercase.
 	 *
 	 * Be aware that this only affects the case of ASCII characters. All

--- a/engines/game.cpp
+++ b/engines/game.cpp
@@ -239,7 +239,12 @@ Common::U32String generateUnknownGameReport(const DetectedGames &detectedGames, 
 
 		// Consolidate matched files across all engines and detection entries
 		for (const auto &file : game.matchedFiles) {
-			Common::String key = Common::String::format("%s:%s", md5PropToCachePrefix(file._value.md5prop).c_str(), file._key.punycodeEncode().toString('/').c_str());
+			Common::Path filename = file._key;
+			// Avoid double encoding of punycoded files
+			if (!filename.punycodeIsEncoded()) {
+				filename = filename.punycodeEncode();
+			}
+			Common::String key = Common::String::format("%s:%s", md5PropToCachePrefix(file._value.md5prop).c_str(), filename.toString('/').c_str());
 			matchedFiles.setVal(key, file._value);
 		}
 	}
@@ -271,7 +276,7 @@ Common::U32String generateUnknownGameReport(const DetectedGames &detectedGames, 
 		// Skip the md5 prefix and since we could have full paths, take it into account
 		Common::Path filepath(strchr(filenames[i].c_str(), ':') + 1);
 		report += Common::String::format("  {\"%s\", 0, \"%s%s\", %lld},\n",
-			filepath.punycodeEncode().toString().c_str(),
+			filepath.toString().c_str(),
 			md5Prefix.c_str(), file.md5.c_str(), (long long)file.size);
 	}
 


### PR DESCRIPTION
This fixes the triple Punycoding which can be witnessed with unknown variants of games having Punycoded file entries.

As our entries come are properly punycoded or not punycoded at all, it's safe to just check the prefix.

This has been tested with Wage engine (and PR #6801) by making some game entries not matching and running the detection code on the files dumped by the Dumper-Companion (Unicode and non-Unicode modes).