### PR TITLE
KEYMAPPER: Add keymap option for allowing patial matching.

### DIFF
--- a/backends/keymapper/keymap.cpp
+++ b/backends/keymapper/keymap.cpp
@@ -36,6 +36,7 @@ Keymap::Keymap(KeymapType type, const String &id, const U32String &description) 
 		_type(type),
 		_id(id),
 		_description(description),
+		_partialMatchAllowed(true),
 		_enabled(true),
 		_configDomain(nullptr),
 		_hardwareInputSet(nullptr),
@@ -47,6 +48,7 @@ Keymap::Keymap(KeymapType type, const String &id, const String &description) :
 		_type(type),
 		_id(id),
 		_description(U32String(description)),
+		_partialMatchAllowed(true),
 		_enabled(true),
 		_configDomain(nullptr),
 		_hardwareInputSet(nullptr),
@@ -145,7 +147,7 @@ Keymap::KeymapMatch Keymap::getMappedActions(const Event &event, ActionArray &ac
 			return kKeymapMatchExact;
 		}
 
-		if (normalizedKeystate.flags & KBD_NON_STICKY) {
+		if (_partialMatchAllowed && normalizedKeystate.flags & KBD_NON_STICKY) {
 			// If no matching actions and non-sticky keyboard modifiers are down,
 			// check again for matches without the exact keyboard modifiers
 			for (const auto &itInput : _hwActionMap) {

--- a/backends/keymapper/keymap.h
+++ b/backends/keymapper/keymap.h
@@ -158,6 +158,9 @@ public:
 	const U32String &getDescription() const { return _description; }
 	KeymapType getType() const { return _type; }
 
+	bool isPartialMatchAllowed() const { return _partialMatchAllowed; }
+	void setPartialMatchAllowed(bool partialMatchAllowed) { _partialMatchAllowed = partialMatchAllowed; }
+
 	/**
 	 * Defines if the keymap is considered when mapping events
 	 */
@@ -181,7 +184,7 @@ private:
 	KeymapType _type;
 	String _id;
 	U32String _description;
-
+	bool _partialMatchAllowed;
 	bool _enabled;
 
 	ActionArray _actions;

--- a/engines/metaengine.cpp
+++ b/engines/metaengine.cpp
@@ -74,6 +74,9 @@ Common::KeymapArray MetaEngine::initKeymaps(const char *target) const {
 
 	Keymap *engineKeyMap = new Keymap(Keymap::kKeymapTypeGame, "engine-default", _("Default game keymap"));
 
+	// Default keymap for engines should not match partial as it may hide intended input handling.
+	engineKeyMap->setPartialMatchAllowed(false);
+
 	Action *act;
 
 	act = new Action(kStandardActionLeftClick, _("Left click"));


### PR DESCRIPTION
In previous code partial match would always be allowed, but this hides intended inputs for engines that neither define their own keymaps nor disable them on text input. The fallback engine-default keymap will no longer match partial inputs.

Tested with Space Quest 3, I mapped "Skip line" to semicolon, which produces period as the input. An input of 3 semicolons and 3 colons ("Shift + ;" on my keyboard) produced different results. Fix on left, previous behavior on right:
<img width="1311" height="589" alt="Screenshot 2025-07-13 120718" src="https://github.com/user-attachments/assets/c1d23bb7-42ad-41a1-a595-d985716ec73d" />

I proposed this on individual keymaps, and keeping partial match allowed on global and GUI keymaps as their default keys use Control or Alt modifiers.

Alternatively, we could make the entire keymapper have a single flag for this or make the default value for _partialMatchAllowed false and force devs to specify true when needed.

This is a proposed fix for https://bugs.scummvm.org/ticket/12410

Partial matches originally implemented in https://github.com/scummvm/scummvm/pull/2281