### PR TITLE
DIRECTOR: add additonal file to heidislide entry

### DIFF
--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -9127,7 +9127,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINGAME1_l("heididentaku2", "", "xn--.exe-uk4cqevgp14zyi5gqs7i", "1799677b9d869c8dc577d931e229ee3b", 2947676, Common::JA_JPN, 702),
 	WINGAME1_l("heididentaku3", "", "xn--.exe-uk4cqevgp14zyi5g0s7i", "1799677b9d869c8dc577d931e229ee3b", 2988876, Common::JA_JPN, 702),
 	WINGAME1_l("heidimail", "",  "HeidiML.exe", "1799677b9d869c8dc577d931e229ee3b", 2662490, Common::JA_JPN, 702),
-	WINGAME1_l("heidislide", "", "Slide.exe",   "1799677b9d869c8dc577d931e229ee3b", 7934640, Common::JA_JPN, 702),
+	WINGAME2_l("heidislide", "", "Slide.exe",   "1799677b9d869c8dc577d931e229ee3b", 7934640,
+				     "data/1024/h001.jpg", "95384ae6174f7e0b4791a4257fdea499", 1188382, Common::JA_JPN, 702),
 
 	MACGAME1t_l("henachocowine2", "", "WineCom", "12b86bfbc7f08195e2d1d72c576a4a90", 79408477, Common::JA_JPN, 702),
 


### PR DESCRIPTION
The additional file is required to not mismatch in the detection with an Inca 2 (GOB) non interactive demo.

SLIDE.EXE on the Inca 2 demo was provided as the interpreter to play the IMD files.

So that we not mismatch as an unknown heidislide variant we add an this additional file
