### PR TITLE
GOB: Distgunish newer coktel games with CD1 file

### DIFF
--- a/engines/gob/detection/tables_adiboudchou.h
+++ b/engines/gob/detection/tables_adiboudchou.h
@@ -54,7 +54,8 @@
 	{ // Supplied by BJNFNE
 		"adiboudchoumer",
 		MetaEngineDetection::GAME_NOT_IMPLEMENTED, // Addy Buschu am Meer 1.01 (Engine: DEV7 version unknown)
-		AD_ENTRY1s("adbc_envir_obc.stk", "46b7db9f7e77a077d9ac8506130ba9a2", 2830950),
+		AD_ENTRY2s("adbc_envir_obc.stk", "46b7db9f7e77a077d9ac8506130ba9a2", 2830950,
+				   "DMDCD101.CD1", "d41d8cd98f00b204e9800998ecf8427e", 0),
 		DE_DEU,
 		kPlatformWindows,
 		ADGF_UNSUPPORTED,
@@ -68,7 +69,8 @@
 
 		"adiboudchoubanquise",
 		MetaEngineDetection::GAME_NOT_IMPLEMENTED, // Addy Buschu Schnee & Eis 1.00 (Engine: DEV7 version 1.0.0.0)
-		AD_ENTRY1s("adbc_envir_obc.stk", "fde006186b93b4f33486f021826f88a0", 5199806),
+		AD_ENTRY2s("adbc_envir_obc.stk", "fde006186b93b4f33486f021826f88a0", 5199806,
+				   "DNDCD100.CD1", "d41d8cd98f00b204e9800998ecf8427e", 0),
 		DE_DEU,
 		kPlatformWindows,
 		ADGF_UNSUPPORTED,
@@ -81,7 +83,8 @@
 	{ // Supplied by BJNFNE
 		"adiboudchoucampagne",
 		MetaEngineDetection::GAME_NOT_IMPLEMENTED, // Addy Buschu auf dem Land 1.00 (Engine: DEV7 version unknown)
-		AD_ENTRY1s("adbc_envir_obc.stk", "4b43d3d1a8bc908d80e729069c5bb59f", 2831471),
+		AD_ENTRY2s("adbc_envir_obc.stk", "4b43d3d1a8bc908d80e729069c5bb59f", 2831471,
+				   "DCDCD100.CD1", "d41d8cd98f00b204e9800998ecf8427e", 0),
 		DE_DEU,
 		kPlatformWindows,
 		ADGF_UNSUPPORTED,
@@ -94,7 +97,8 @@
 	{ // Supplied by BJNFNE
 		"adiboudchoujunglesavane",
 		MetaEngineDetection::GAME_NOT_IMPLEMENTED, // Addy Buschu Die bunte Tierwelt 1.00 (Engine: DEV7 version 1.0.0.0)
-		AD_ENTRY1s("adbc_envir_obc.stk", "7f33561f295030cbe64a21f941ef1efc", 3188852),
+		AD_ENTRY2s("adbc_envir_obc.stk", "7f33561f295030cbe64a21f941ef1efc", 3188852,
+				   "djdcd100.cd1", "d41d8cd98f00b204e9800998ecf8427e", 0),
 		DE_DEU,
 		kPlatformWindows,
 		ADGF_UNSUPPORTED,
@@ -110,7 +114,8 @@
 	{
 		"adiboudchoucampagne",
 		MetaEngineDetection::GAME_NOT_IMPLEMENTED, // Антошка. В гостях у друзей 1.00 (Engine: DEV7 version 1.0.0.0)
-		AD_ENTRY1s("adbc_envir_obc.stk", "1b65643b2aa794f38f3b18efb9e68b92", 3210008),
+		AD_ENTRY2s("adbc_envir_obc.stk", "1b65643b2aa794f38f3b18efb9e68b92", 3210008,
+				   "DCDCF100.CD1", "d41d8cd98f00b204e9800998ecf8427e" ,0),
 		RU_RUS,
 		kPlatformWindows,
 		ADGF_UNSUPPORTED,

--- a/engines/gob/detection/tables_adiboupresente.h
+++ b/engines/gob/detection/tables_adiboupresente.h
@@ -37,7 +37,8 @@
 	{ // Supplied by BJNFNE
 		"adiboudessin",
 		MetaEngineDetection::GAME_NOT_IMPLEMENTED, // Adibou présente Dessin 1.00 (Engine: DEV7 version 1.10a)
-		AD_ENTRY1s("adibou.stk", "14e3f8e9c237d4236d93e08c60b784bc", 217172),
+		AD_ENTRY2s("adibou.stk", "14e3f8e9c237d4236d93e08c60b781bc", 217172,
+				   "PD47F100.CD1", "d41d8cd98f00b204e9800998ecf8427e", 0),
 		FR_FRA,
 		kPlatformWindows,
 		ADGF_UNSUPPORTED,
@@ -53,7 +54,8 @@
 	{ // Supplied by BJNFNE
 		"adiboucuisine",
 		MetaEngineDetection::GAME_NOT_IMPLEMENTED, // Adibou présente Cuisine 1.00 (Engine: DEV7 version 1.0.0.0)
-		AD_ENTRY1s("adibou.stk", "cb2d576f6d546485af7693d4eaf1142b", 174027),
+		AD_ENTRY2s("adibou.stk", "cb2d576f6d546485af7693d4eaf1142b", 174027,
+				   "PC47F100.CD1", "d41d8cd98f00b204e9800998ecf8427e", 0),
 		FR_FRA,
 		kPlatformWindows,
 		ADGF_UNSUPPORTED,
@@ -70,7 +72,7 @@
 		"adiboumagie",
 		MetaEngineDetection::GAME_NOT_IMPLEMENTED, // Adibou présente Magie 1.00 (Engine: DEV7 version 1.0.0.0)
 		AD_ENTRY2s("adibou.stk", "977d2449d398f3df23238d718fca35b5", 61097,
-				   "magic.stk", "9776765dead3e338a32c43bf344b5819", 302664),
+				   "Pm47f100.cd1", "3389dae361af79b04c9c8e7057f60cc6", 1),
 		FR_FRA,
 		kPlatformWindows,
 		ADGF_UNSUPPORTED,

--- a/engines/gob/detection/tables_nathanvacances.h
+++ b/engines/gob/detection/tables_nathanvacances.h
@@ -37,7 +37,8 @@
 	{
 		"nathanvacances",
 		MetaEngineDetection::GAME_NOT_IMPLEMENTED, // CM1/CE2 1.00 (DEV7 version 1.20a)
-		AD_ENTRY1s("common.stk", "344185d17c593122a548122df63b70cf", 1851672),
+		AD_ENTRY2s("common.stk", "344185d17c593122a548122df63b70cf", 1851672,
+				   "ah88f100.cd1", "d41d8cd98f00b204e9800998ecf8427e", 0),
 		FR_FRA,
 		kPlatformWindows,
 		ADGF_UNSUPPORTED,


### PR DESCRIPTION
CD1 files defines name of the game and version number

This is better to distgunish the games itself and also avoid incorrect detection regarding different games.