### PR TITLE
GOB: add lost german croustibat translation variant

### DIFF
--- a/engines/gob/detection/tables_crousti.h
+++ b/engines/gob/detection/tables_crousti.h
@@ -60,6 +60,20 @@
 },
 {
 	{	// German Fan Translation by BJNFNE
+		// ??.0?.2023
+		"crousti",
+		"v1.01",
+		AD_ENTRY1s("intro.stk", "d71d49d89295b2f47182c0455a49bf6a", 864728),
+		DE_DEU,
+		kPlatformDOS,
+		ADGF_NO_FLAGS,
+		GUIO2(GUIO_NOSUBTITLES, GUIO_NOSPEECH)
+	},
+	kFeaturesAdLib,
+	0, 0, 0
+},
+{
+	{	// German Fan Translation by BJNFNE
 		// 23.07.2023
 		"crousti",
 		"v1.01",


### PR DESCRIPTION
I found it on my hard drive, Cant remember when i created that specific variant.

The filedate provides info which would be created at 25/05/2025, but since it was an early development build, so it must be done in somewhat of 2023