### PR TITLE
CLOUD: Fix missing separator in local path for folder download

### DIFF
--- a/backends/cloud/folderdownloadrequest.cpp
+++ b/backends/cloud/folderdownloadrequest.cpp
@@ -138,7 +138,7 @@ void FolderDownloadRequest::downloadNextFile() {
 	}
 	Common::Path localPath(localPathStr);
 	if (!_localDirectoryPath.empty()) {
-		localPath = _localDirectoryPath.append(localPath);
+		localPath = _localDirectoryPath.join(localPath);
 	}
 	debug(9, "FolderDownloadRequest: %s -> %s", remotePath.c_str(), localPath.toString(Common::Path::kNativeSeparator).c_str());
 	_workingRequest = _storage->downloadById(


### PR DESCRIPTION
In the 2.9.0 and 2.9.1 releases downloading games from the cloud does not work properly. Instead of downloading the game older with files inside, it downloads the files with the folder name prepended to the file name. This causes the game detection to fail. This was reported on Discord for iOS, and I reproduced both on iOS and macOS.

Debug print:
```
FolderDownloadRequest: /games/king's quest i/kq1vga.exe -> /Applications/Games/ScummVM/test/king's quest ikq1vga.exe
```

<img width="856" height="896" alt="image" src="https://github.com/user-attachments/assets/35c0b598-873c-4234-9ada-77d9cb15513b" />

This appears to be a regression from commit 460be93

The fix seems simple enough, but since I am not familiar with this code another pair of eyes would be welcome.
With it the debug print now looks like this:
```
FolderDownloadRequest: /games/king's quest i/kq1vga.exe -> /Applications/Games/ScummVM/test/king's quest i/kq1vga.exe
```
And the result is as shown below and the game is properly detected after being downloaded:
<img width="856" height="930" alt="image" src="https://github.com/user-attachments/assets/ffbf092a-5c32-4072-9877-5dd3a39b56a8" />
