### PR TITLE
EFH: Add text-to-speech (TTS)

### DIFF
--- a/engines/efh/detection.cpp
+++ b/engines/efh/detection.cpp
@@ -22,6 +22,7 @@
 #include "base/plugins.h"
 #include "engines/advancedDetector.h"
 
+#include "efh/detection.h"
 #include "efh/efh.h"
 
 namespace Efh {
@@ -40,7 +41,7 @@ static const ADGameDescription gameDescriptions[] = {
 		Common::EN_ANY,
 		Common::kPlatformDOS,
 		ADGF_NO_FLAGS,
-		GUIO0()
+		GUIO1(GAMEOPTION_TTS)
 	},
 	// Escape From Hell English
 	{
@@ -48,7 +49,7 @@ static const ADGameDescription gameDescriptions[] = {
 		Common::EN_ANY,
 		Common::kPlatformDOS,
 		ADGF_NO_FLAGS,
-		GUIO0()
+		GUIO1(GAMEOPTION_TTS)
 	},
 	AD_TABLE_END_MARKER
 };

--- a/engines/efh/detection.h
+++ b/engines/efh/detection.h
@@ -1,0 +1,27 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef EFH_DETECTION_H
+#define EFH_DETECTION_H
+
+#define GAMEOPTION_TTS      	    GUIO_GAMEOPTIONS1
+
+#endif // EFH_DETECTION_H

--- a/engines/efh/efh.h
+++ b/engines/efh/efh.h
@@ -28,6 +28,7 @@
 #include "common/rect.h"
 #include "common/events.h"
 #include "common/serializer.h"
+#include "common/text-to-speech.h"
 
 #include "engines/advancedDetector.h"
 #include "engines/engine.h"
@@ -257,6 +258,12 @@ struct TeamMonster {
 	void init();
 };
 
+enum TTSMenuRestriction {
+	kNoRestriction,
+	kLowStatusMenu,
+	kMenu
+};
+
 enum EFHAction {
 	kActionNone,
 	kActionExit,
@@ -480,7 +487,7 @@ private:
 	void displayColoredMenuBox(int16 minX, int16 minY, int16 maxX, int16 maxY, int16 color);
 
 	// Menu
-	int16 displayBoxWithText(const Common::String &str, int16 menuType, int16 displayOption, bool displayTeamWindowFl);
+	int16 displayBoxWithText(const Common::String &str, int16 menuType, int16 displayOption, bool displayTeamWindowFl, bool voiceText = true);
 	bool handleDeathMenu();
 	void displayCombatMenu(int16 charId);
 	void displayMenuItemString(int16 menuBoxId, int16 thisBoxId, int16 minX, int16 maxX, int16 minY, const char *str);
@@ -516,13 +523,15 @@ private:
 	void generateSound5(int repeat);
 	void generateSound(int16 soundType);
 	void genericGenerateSound(int16 soundType, int16 repeatCount);
+	void sayText(const Common::String &text, TTSMenuRestriction menuRestriction, Common::TextToSpeechManager::Action action = Common::TextToSpeechManager::QUEUE) const;
+	void stopTextToSpeech() const;
 
 	// Utils
 	void decryptImpFile(bool techMapFl);
 	void loadImageSet(int16 imageSetId, uint8 *buffer, uint8 **subFilesArray, uint8 *destBuffer);
 	uint32 uncompressBuffer(uint8 *compressedBuf, uint8 *destBuf);
 	int16 getRandom(int16 maxVal);
-	Common::KeyCode getLastCharAfterAnimCount(int16 delay);
+	Common::KeyCode getLastCharAfterAnimCount(int16 delay, bool waitForTTS = true);
 	Common::KeyCode getInput(int16 delay);
 	Common::KeyCode waitForKey();
 	Common::KeyCode handleAndMapInput(bool animFl);
@@ -632,6 +641,10 @@ private:
 	int16 _menuStatItemArr[15];
 	int16 _menuDepth;
 	int16 _menuItemCounter;
+	int16 _selectedMenuBox;
+	bool _sayMenu;
+	bool _sayLowStatusScreen;
+	bool _initiatedTalkByMenu;
 
 	TeamChar _teamChar[3];
 	TeamMonster _teamMonster[5];

--- a/engines/efh/init.cpp
+++ b/engines/efh/init.cpp
@@ -352,6 +352,10 @@ EfhEngine::EfhEngine(OSystem *syst, const ADGameDescription *gd) : Engine(syst),
 	_statusMenuActive = false;
 	_menuDepth = 0;
 	_menuItemCounter = 0;
+	_selectedMenuBox = -1;
+	_sayMenu = true;
+	_sayLowStatusScreen = false;
+	_initiatedTalkByMenu = false;
 
 	for (int i = 0; i < 15; ++i)
 		_menuStatItemArr[i] = 0;

--- a/engines/efh/menu.cpp
+++ b/engines/efh/menu.cpp
@@ -23,7 +23,7 @@
 
 namespace Efh {
 
-int16 EfhEngine::displayBoxWithText(const Common::String &str, int16 menuType, int16 displayOption, bool displayTeamWindowFl) {
+int16 EfhEngine::displayBoxWithText(const Common::String &str, int16 menuType, int16 displayOption, bool displayTeamWindowFl, bool voiceText) {
 	debugC(3, kDebugEngine, "displayBoxWithText %s %d %d %s", str.c_str(), menuType, displayOption, displayTeamWindowFl ? "True" : "False");
 
 	int16 retVal = 0xFF;
@@ -59,6 +59,20 @@ int16 EfhEngine::displayBoxWithText(const Common::String &str, int16 menuType, i
 		maxX = 320;
 		maxY = 200;
 		break;
+	}
+
+	if (voiceText) {
+		Common::String ttsMessage(str);
+
+		// Some messages have a ^ followed by a few numbers at the end
+		uint32 caretPosition = ttsMessage.find('^');
+		if (caretPosition != Common::String::npos) {
+			ttsMessage.erase(caretPosition, Common::String::npos);
+		}
+
+		ttsMessage.replace('|', '\n');
+
+		sayText(ttsMessage, kNoRestriction);
 	}
 
 	drawColoredRect(minX, minY, maxX, maxY, 0);
@@ -99,6 +113,11 @@ bool EfhEngine::handleDeathMenu() {
 	displayAnimFrames(20, true);
 	_imageSetSubFilesIdx = 213;
 	drawScreen();
+
+	sayText("Darkness prevails... death has taken you!", kNoRestriction, Common::TextToSpeechManager::INTERRUPT);
+	sayText("Load last saved game", kNoRestriction);
+	sayText("Restart from beginning", kNoRestriction);
+	sayText("Quit for now", kNoRestriction);
 
 	for (uint counter = 0; counter < 2; ++counter) {
 		clearBottomTextZone(0);
@@ -165,26 +184,31 @@ void EfhEngine::displayCombatMenu(int16 charId) {
 	displayStringAtTextPos("A");
 	setTextColorRed();
 	displayStringAtTextPos("ttack");
+	sayText("Attack", kMenu);
 	setTextPos(195, 79);
 	setTextColorWhite();
 	displayStringAtTextPos("H");
 	setTextColorRed();
 	displayStringAtTextPos("ide");
+	sayText("Hide", kMenu);
 	setTextPos(152, 88);
 	setTextColorWhite();
 	displayStringAtTextPos("D");
 	setTextColorRed();
 	displayStringAtTextPos("efend");
+	sayText("Defend", kMenu);
 	setTextPos(195, 88);
 	setTextColorWhite();
 	displayStringAtTextPos("R");
 	setTextColorRed();
 	displayStringAtTextPos("un");
+	sayText("Run", kMenu);
 	setTextPos(152, 97);
 	setTextColorWhite();
 	displayStringAtTextPos("S");
 	setTextColorRed();
 	displayStringAtTextPos("tatus");
+	sayText("Status", kMenu);
 }
 
 void EfhEngine::displayMenuItemString(int16 menuBoxId, int16 thisBoxId, int16 minX, int16 maxX, int16 minY, const char *str) {
@@ -195,6 +219,11 @@ void EfhEngine::displayMenuItemString(int16 menuBoxId, int16 thisBoxId, int16 mi
 			setTextColorWhite();
 		else
 			setTextColorGrey();
+
+		if (_selectedMenuBox != thisBoxId) {
+			sayText(str, kNoRestriction, Common::TextToSpeechManager::INTERRUPT);
+			_selectedMenuBox = thisBoxId;
+		}
 
 		Common::String buffer = Common::String::format("> %s <", str);
 		displayCenteredString(buffer, minX, maxX, minY);
@@ -275,33 +304,47 @@ void EfhEngine::displayCharacterSummary(int16 curMenuLine, int16 npcId) {
 	setTextColorRed();
 	Common::String buffer1 = _npcBuf[npcId]._name;
 	setTextPos(146, 27);
-	displayStringAtTextPos("Name: ");
+	buffer1 = "Name: " + buffer1;
+	Common::String ttsMessage = buffer1;
 	displayStringAtTextPos(buffer1);
 	buffer1 = Common::String::format("Level: %d", getXPLevel(_npcBuf[npcId]._xp));
+	ttsMessage += '\n' + buffer1;
 	setTextPos(146, 36);
 	displayStringAtTextPos(buffer1);
 	buffer1 = Common::String::format("XP: %u", _npcBuf[npcId]._xp);
+	ttsMessage += '\n' + buffer1;
 	setTextPos(227, 36);
 	displayStringAtTextPos(buffer1);
 	buffer1 = Common::String::format("Speed: %d", _npcBuf[npcId]._speed);
+	ttsMessage += '\n' + buffer1;
 	setTextPos(146, 45);
 	displayStringAtTextPos(buffer1);
 	buffer1 = Common::String::format("Defense: %d", getEquipmentDefense(npcId));
+	ttsMessage += '\n' + buffer1;
 	setTextPos(146, 54);
 	displayStringAtTextPos(buffer1);
 	buffer1 = Common::String::format("Hit Points: %d", _npcBuf[npcId]._hitPoints);
+	ttsMessage += '\n' + buffer1;
 	setTextPos(146, 63);
 	displayStringAtTextPos(buffer1);
 	buffer1 = Common::String::format("Max HP: %d", _npcBuf[npcId]._maxHP);
+	ttsMessage += '\n' + buffer1;
 	setTextPos(227, 63);
 	displayStringAtTextPos(buffer1);
+
+	if (curMenuLine == -1) {
+		sayText(ttsMessage, kMenu);
+	}
+
 	displayCenteredString("Inventory", 144, 310, 72);
+	sayText("Inventory", kMenu);
 
 	if (_menuItemCounter == 0) {
 		if (curMenuLine != -1)
 			setTextColorWhite();
 
 		displayCenteredString("Nothing Carried", 144, 310, 117);
+		sayText("Nothing Carried", kMenu);
 		setTextColorRed();
 		return;
 	}
@@ -319,6 +362,7 @@ void EfhEngine::displayCharacterSummary(int16 curMenuLine, int16 npcId) {
 			if (_npcBuf[npcId]._inventory[_menuStatItemArr[counter]].isEquipped()) {
 				setTextPos(146, textPosY);
 				displayCharAtTextPos('E');
+				sayText("E", kMenu);
 			}
 		}
 
@@ -329,12 +373,14 @@ void EfhEngine::displayCharacterSummary(int16 curMenuLine, int16 npcId) {
 			buffer1 = Common::String::format("%c)", 'A' + counter);
 		}
 		displayStringAtTextPos(buffer1);
+		sayText(buffer1, kMenu);
 
 		if (itemId != 0x7FFF) {
 			setTextPos(168, textPosY);
 			buffer1 = Common::String::format("  %s", _items[itemId]._name);
 			displayStringAtTextPos(buffer1);
 			setTextPos(262, textPosY);
+			sayText(buffer1, kMenu);
 
 			if (_items[itemId]._defense > 0) {
 				int16 curHitPoints = _npcBuf[npcId]._inventory[_menuStatItemArr[counter]]._curHitPoints;
@@ -343,6 +389,7 @@ void EfhEngine::displayCharacterSummary(int16 curMenuLine, int16 npcId) {
 					displayStringAtTextPos(buffer1);
 					setTextPos(286, textPosY);
 					displayStringAtTextPos("Def");
+					sayText(buffer1 + " Defense", kMenu);
 				}
 			} else if (_items[itemId]._uses != 0x7F) {
 				int16 stat1 = _npcBuf[npcId]._inventory[_menuStatItemArr[counter]].getUsesLeft();
@@ -350,10 +397,13 @@ void EfhEngine::displayCharacterSummary(int16 curMenuLine, int16 npcId) {
 					buffer1 = Common::String::format("%d", stat1);
 					displayStringAtTextPos(buffer1);
 					setTextPos(286, textPosY);
-					if (stat1 == 1)
+					if (stat1 == 1) {
 						displayStringAtTextPos("Use");
-					else
+						sayText(buffer1 + " Use", kMenu);
+					} else {
 						displayStringAtTextPos("Uses");
+						sayText(buffer1 + " Uses", kMenu);
+					}
 				}
 			}
 		}
@@ -366,14 +416,20 @@ void EfhEngine::displayCharacterInformationOrSkills(int16 curMenuLine, int16 cha
 
 	setTextColorRed();
 	Common::String buffer = _npcBuf[charId]._name;
+	buffer = "Name: " + buffer;
 	setTextPos(146, 27);
-	displayStringAtTextPos("Name: ");
 	displayStringAtTextPos(buffer);
+	
+	sayText(buffer, kMenu);
+
 	if (_menuItemCounter <= 0) {
 		if (curMenuLine != -1)
 			setTextColorWhite();
 		displayCenteredString("No Skills To Select", 144, 310, 96);
 		setTextColorRed();
+
+		sayText("No Skills To Select", kMenu);
+
 		return;
 	}
 
@@ -389,9 +445,11 @@ void EfhEngine::displayCharacterInformationOrSkills(int16 curMenuLine, int16 cha
 		}
 
 		displayStringAtTextPos(buffer);
+		sayText(buffer, kMenu);
 		setTextPos(163, textPosY);
 		int16 scoreId = _menuStatItemArr[counter];
 		displayStringAtTextPos(kSkillArray[scoreId]);
+		sayText(kSkillArray[scoreId], kMenu);
 		if (scoreId < 15)
 			buffer = Common::String::format("%d", _npcBuf[charId]._activeScore[_menuStatItemArr[counter]]);
 		else if (scoreId < 26)
@@ -400,6 +458,7 @@ void EfhEngine::displayCharacterInformationOrSkills(int16 curMenuLine, int16 cha
 			buffer = Common::String::format("%d", _npcBuf[charId]._infoScore[_menuStatItemArr[counter] - 26]);
 		setTextPos(278, textPosY);
 		displayStringAtTextPos(buffer);
+		sayText(buffer, kMenu);
 		setTextColorRed();
 	}
 }
@@ -413,44 +472,56 @@ void EfhEngine::displayStatusMenuActions(int16 menuId, int16 curMenuLine, int16 
 	switch (menuId) {
 	case kEfhMenuEquip:
 		displayCenteredString("Select Item to Equip", 144, 310, 15);
+		sayText("Select Item to Equip", kMenu);
 		displayCharacterSummary(curMenuLine, npcId);
 		break;
 	case kEfhMenuUse:
 		displayCenteredString("Select Item to Use", 144, 310, 15);
+		sayText("Select Item to Use", kMenu);
 		displayCharacterSummary(curMenuLine, npcId);
 		break;
 	case kEfhMenuGive:
 		displayCenteredString("Select Item to Give", 144, 310, 15);
+		sayText("Select Item to Give", kMenu);
 		displayCharacterSummary(curMenuLine, npcId);
 		break;
 	case kEfhMenuTrade:
 		displayCenteredString("Select Item to Trade", 144, 310, 15);
+		sayText("Select Item to Trade", kMenu);
 		displayCharacterSummary(curMenuLine, npcId);
 		break;
 	case kEfhMenuDrop:
 		displayCenteredString("Select Item to Drop", 144, 310, 15);
+		sayText("Select Item to Drop", kMenu);
 		displayCharacterSummary(curMenuLine, npcId);
 		break;
 	case kEfhMenuInfo:
 		displayCenteredString("Character Information", 144, 310, 15);
+		sayText("Character Information", kMenu);
 		displayCharacterInformationOrSkills(curMenuLine, npcId);
 		break;
 	case kEfhMenuPassive:
 		displayCenteredString("Passive Skills", 144, 310, 15);
+		sayText("Passive Skills", kMenu);
 		displayCharacterInformationOrSkills(curMenuLine, npcId);
 		break;
 	case kEfhMenuActive:
 		displayCenteredString("Active Skills", 144, 310, 15);
+		sayText("Active Skills", kMenu);
 		displayCharacterInformationOrSkills(curMenuLine, npcId);
 		break;
 	case kEfhMenuLeave:
 	case kEfhMenuInvalid:
 		displayCenteredString("Character Summary", 144, 310, 15);
+		sayText("Character Summary", kMenu);
 		displayCharacterSummary(curMenuLine, npcId);
 		break;
 	default:
 		break;
 	}
+
+	sayText("Escape Aborts", kMenu);
+	_sayMenu = false;
 }
 
 void EfhEngine::prepareStatusMenu(int16 windowId, int16 menuId, int16 curMenuLine, int16 charId, bool refreshFl) {
@@ -480,6 +551,7 @@ void EfhEngine::displayWindowAndStatusMenu(int16 charId, int16 windowId, int16 m
 int16 EfhEngine::displayStringInSmallWindowWithBorder(const Common::String &str, bool delayFl, int16 charId, int16 windowId, int16 menuId, int16 curMenuLine) {
 	debugC(3, kDebugEngine, "displayStringInSmallWindowWithBorder %s %s %d %d %d %d", str.c_str(), delayFl ? "True" : "False", charId, windowId, menuId, curMenuLine);
 
+	sayText(str, kNoRestriction);
 	int16 retVal = 0;
 
 	for (uint counter = 0; counter < 2; ++counter) {
@@ -514,6 +586,7 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 	int16 curMenuLine = -1;
 	bool selectionDoneFl = false;
 	bool var2 = false;
+	_selectedMenuBox = 0;
 
 	saveAnimImageSetId();
 
@@ -554,6 +627,7 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 					break;
 				case Common::KEYCODE_ESCAPE:
 				case Common::KEYCODE_l:
+					stopTextToSpeech();
 					windowId = kEfhMenuLeave;
 					input = Common::KEYCODE_RETURN;
 					break;
@@ -572,6 +646,10 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 				default:
 					debugC(9, kDebugEngine, "handleStatusMenu - unhandled keys");
 					break;
+				}
+
+				if (input == Common::KEYCODE_RETURN) {
+					_selectedMenuBox = -1;
 				}
 			} else if (_menuDepth == 1) {
 				// in the sub-menus, only a list of selectable items is displayed
@@ -592,6 +670,7 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 					if (menuId >= kEfhMenuLeave)
 						selectionDoneFl = true;
 					else {
+						_sayMenu = true;
 						_menuDepth = 1;
 						curMenuLine = 0;
 					}
@@ -600,6 +679,7 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 						_menuDepth = 0;
 						curMenuLine = -1;
 						menuId = kEfhMenuInvalid;
+						_sayMenu = true;
 						prepareStatusMenu(windowId, menuId, curMenuLine, charId, true);
 					} else {
 						selectedLine = curMenuLine;
@@ -611,6 +691,8 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 				_menuDepth = 0;
 				curMenuLine = -1;
 				menuId = kEfhMenuInvalid;
+				stopTextToSpeech();
+				_sayMenu = true;
 				prepareStatusMenu(windowId, menuId, curMenuLine, charId, true);
 				break;
 			case Common::KEYCODE_2:
@@ -667,6 +749,7 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 		case kEfhMenuEquip:
 			objectId = _menuStatItemArr[selectedLine];
 			itemId = _npcBuf[charId]._inventory[objectId]._ref; // CHECKME: Useless?
+			sayText(_items[itemId]._name, kNoRestriction, Common::TextToSpeechManager::INTERRUPT);
 			tryToggleEquipped(charId, objectId, windowId, menuId, curMenuLine);
 			if (gameMode == 2) {
 				restoreAnimImageSetId();
@@ -677,6 +760,7 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 		case kEfhMenuUse:
 			objectId = _menuStatItemArr[selectedLine];
 			itemId = _npcBuf[charId]._inventory[objectId]._ref;
+			sayText(_items[itemId]._name, kNoRestriction, Common::TextToSpeechManager::INTERRUPT);
 			if (gameMode == 2) {
 				restoreAnimImageSetId();
 				_statusMenuActive = false;
@@ -693,12 +777,15 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 		case kEfhMenuGive:
 			objectId = _menuStatItemArr[selectedLine];
 			itemId = _npcBuf[charId]._inventory[objectId]._ref;
+			sayText(_items[itemId]._name, kNoRestriction, Common::TextToSpeechManager::INTERRUPT);
+			_initiatedTalkByMenu = true;
 			if (hasObjectEquipped(charId, objectId) && isItemCursed(itemId)) {
 				displayStringInSmallWindowWithBorder("The item is cursed!  IT IS EVIL!!!!!!!!", true, charId, windowId, menuId, curMenuLine);
 			} else if (hasObjectEquipped(charId, objectId)) {
 				displayStringInSmallWindowWithBorder("Item is Equipped!  Give anyway?", false, charId, windowId, menuId, curMenuLine);
 				if (!getValidationFromUser())
 					validationFl = false;
+				stopTextToSpeech();
 				displayWindowAndStatusMenu(charId, windowId, menuId, curMenuLine);
 
 				if (validationFl) {
@@ -718,6 +805,7 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 		case kEfhMenuTrade:
 			objectId = _menuStatItemArr[selectedLine];
 			itemId = _npcBuf[charId]._inventory[objectId]._ref;
+			sayText(_items[itemId]._name, kNoRestriction, Common::TextToSpeechManager::INTERRUPT);
 			if (hasObjectEquipped(charId, objectId) && isItemCursed(itemId)) {
 				displayStringInSmallWindowWithBorder("The item is cursed!  IT IS EVIL!!!!!!!!", true, charId, windowId, menuId, curMenuLine);
 				break;
@@ -727,6 +815,7 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 				displayStringInSmallWindowWithBorder("Item is Equipped!  Trade anyway?", false, charId, windowId, menuId, curMenuLine);
 				if (!getValidationFromUser())
 					validationFl = false;
+				stopTextToSpeech();
 				displayWindowAndStatusMenu(charId, windowId, menuId, curMenuLine);
 			}
 
@@ -737,6 +826,7 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 					if (_teamChar[2]._id != -1) {
 						displayStringInSmallWindowWithBorder("Who will you give the item to?", false, charId, windowId, menuId, curMenuLine);
 						destCharId = selectOtherCharFromTeam();
+						stopTextToSpeech();
 						var2 = false;
 					} else if (_teamChar[1]._id == -1) {
 						destCharId = 0x1A;
@@ -751,6 +841,7 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 
 					if (destCharId != 0x1A && destCharId != 0x1B) {
 						givenFl = giveItemTo(_teamChar[destCharId]._id, objectId, charId);
+						sayText(_npcBuf[_teamChar[destCharId]._id]._name, kNoRestriction);
 						if (!givenFl) {
 							displayStringInSmallWindowWithBorder("That character cannot carry anymore!", false, charId, windowId, menuId, curMenuLine);
 							getLastCharAfterAnimCount(_guessAnimationAmount);
@@ -780,6 +871,7 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 		case kEfhMenuDrop:
 			objectId = _menuStatItemArr[selectedLine];
 			itemId = _npcBuf[charId]._inventory[objectId]._ref;
+			sayText(_items[itemId]._name, kNoRestriction, Common::TextToSpeechManager::INTERRUPT);
 			if (hasObjectEquipped(charId, objectId) && isItemCursed(itemId)) {
 				displayStringInSmallWindowWithBorder("The item is cursed!  IT IS EVIL!!!!!!!!", true, charId, windowId, menuId, curMenuLine);
 			} else if (hasObjectEquipped(charId, objectId)) {
@@ -789,6 +881,8 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 				displayWindowAndStatusMenu(charId, windowId, menuId, curMenuLine);
 
 				if (validationFl) {
+					stopTextToSpeech();
+					_sayMenu = true;
 					removeObject(charId, objectId);
 					if (gameMode == 2) {
 						restoreAnimImageSetId();
@@ -806,7 +900,9 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 		case kEfhMenuInfo:
 		case kEfhMenuPassive:
 		case kEfhMenuActive:
+			stopTextToSpeech();
 			objectId = _menuStatItemArr[selectedLine];
+			sayText(kSkillArray[objectId], kNoRestriction, Common::TextToSpeechManager::INTERRUPT);
 			if (gameMode == 2) {
 				displayStringInSmallWindowWithBorder("Not a Combat Option!", true, charId, windowId, menuId, curMenuLine);
 			} else if (handleInteractionText(_mapPosX, _mapPosY, charId, objectId, 4, -1)) {
@@ -821,6 +917,7 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 		if (menuId != kEfhMenuLeave) {
 			selectionDoneFl = false;
 			_menuDepth = 0;
+			_sayMenu = true;
 			menuId = kEfhMenuInvalid;
 			selectedLine = -1;
 			curMenuLine = -1;
@@ -829,6 +926,7 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 		if (menuId == kEfhMenuLeave) {
 			restoreAnimImageSetId();
 			_statusMenuActive = false;
+			_sayMenu = true;
 			return 0x7FFF;
 		}
 	}

--- a/engines/efh/metaengine.cpp
+++ b/engines/efh/metaengine.cpp
@@ -30,9 +30,30 @@
 #include "graphics/thumbnail.h"
 #include "graphics/surface.h"
 
+#include "efh/detection.h"
 #include "efh/efh.h"
 
 namespace Efh {
+
+#ifdef USE_TTS
+
+static const ADExtraGuiOptionsMap optionsList[] = {
+	{
+		GAMEOPTION_TTS,
+		{
+			_s("Enable Text to Speech"),
+			_s("Use TTS to read text in the game (if TTS is available)"),
+			"tts_enabled",
+			false,
+			0,
+			0
+		}
+	},
+
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR
+};
+
+#endif
 
 uint32 EfhEngine::getFeatures() const {
 	return _gameDescription->flags;
@@ -66,6 +87,12 @@ public:
 	const char *getName() const override {
 		return "efh";
 	}
+
+#ifdef USE_TTS
+	const ADExtraGuiOptionsMap *getAdvancedExtraGuiOptions() const override {
+		return Efh::optionsList;
+	}
+#endif
 
 	Common::Error createInstance(OSystem *syst, Engine **engine, const ADGameDescription *gd) const override;
 	bool hasFeature(MetaEngineFeature f) const override;

--- a/engines/efh/script.cpp
+++ b/engines/efh/script.cpp
@@ -483,6 +483,7 @@ int16 EfhEngine::script_parse(Common::String stringBuffer, int16 posX, int16 pos
 			_teamChar[teamSlot]._id = joiningNpcId;
 		}
 		refreshTeamSize();
+		_sayLowStatusScreen = true;
 	}
 
 	return retVal;

--- a/engines/efh/utils.cpp
+++ b/engines/efh/utils.cpp
@@ -134,7 +134,7 @@ int16 EfhEngine::getRandom(int16 maxVal) {
 	return 1 + _rnd->getRandomNumber(maxVal - 1);
 }
 
-Common::KeyCode EfhEngine::getLastCharAfterAnimCount(int16 delay) {
+Common::KeyCode EfhEngine::getLastCharAfterAnimCount(int16 delay, bool waitForTTS) {
 	debugC(1, kDebugUtils, "getLastCharAfterAnimCount %d", delay);
 	if (delay == 0)
 		return Common::KEYCODE_INVALID;
@@ -143,7 +143,8 @@ Common::KeyCode EfhEngine::getLastCharAfterAnimCount(int16 delay) {
 	_customAction = kActionNone;
 
 	uint32 lastMs = _system->getMillis();
-	while (delay > 0 && lastChar == Common::KEYCODE_INVALID && _customAction == kActionNone && !shouldQuit()) {
+	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+	while ((delay > 0 || (waitForTTS && ttsMan && ttsMan->isSpeaking())) && lastChar == Common::KEYCODE_INVALID && _customAction == kActionNone && !shouldQuit()) {
 		_system->delayMillis(20);
 		uint32 newMs = _system->getMillis();
 
@@ -154,6 +155,10 @@ Common::KeyCode EfhEngine::getLastCharAfterAnimCount(int16 delay) {
 		}
 
 		lastChar = handleAndMapInput(false);
+	}
+
+	if (waitForTTS) {
+		stopTextToSpeech();
 	}
 
 	return lastChar;
@@ -168,7 +173,8 @@ Common::KeyCode EfhEngine::getInput(int16 delay) {
 	Common::KeyCode retVal = Common::KEYCODE_INVALID;
 
 	uint32 lastMs = _system->getMillis();
-	while (delay > 0 && !shouldQuit()) {
+	Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+	while ((delay > 0 || (ttsMan && ttsMan->isSpeaking())) && !shouldQuit()) {
 		_system->delayMillis(20);
 		uint32 newMs = _system->getMillis();
 


### PR DESCRIPTION
Adds a toggle for text-to-speech to the game options.
Adds text-to-speech for the following:
- Introductory cutscene
- Examine text
- Dialogue
- Character status menu
- Lower status menu
- Combat options and log
- Save and load prompts
- Actions and action prompts
- Death screen
- End screen