### PR TITLE
EFH: Several bug fixes

### DIFF
--- a/engines/efh/efh.cpp
+++ b/engines/efh/efh.cpp
@@ -906,7 +906,7 @@ int16 EfhEngine::chooseCharacterToReplace() {
 	Common::KeyCode input;
 	for (;;) {
 		input = waitForKey();
-		if (input == Common::KEYCODE_ESCAPE || input == Common::KEYCODE_0 || (input > Common::KEYCODE_1 && input < maxVal))
+		if (input == Common::KEYCODE_ESCAPE || input == Common::KEYCODE_0 || (input > Common::KEYCODE_1 && input <= maxVal))
 			break;
 	}
 

--- a/engines/efh/menu.cpp
+++ b/engines/efh/menu.cpp
@@ -833,6 +833,10 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 			_statusMenuActive = false;
 			return 0x7FFF;
 		}
+
+		if (shouldQuit()) {
+			return 0;
+		}
 	}
 
 	return 0;

--- a/engines/efh/menu.cpp
+++ b/engines/efh/menu.cpp
@@ -695,12 +695,13 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 			itemId = _npcBuf[charId]._inventory[objectId]._ref;
 			if (hasObjectEquipped(charId, objectId) && isItemCursed(itemId)) {
 				displayStringInSmallWindowWithBorder("The item is cursed!  IT IS EVIL!!!!!!!!", true, charId, windowId, menuId, curMenuLine);
-			} else if (hasObjectEquipped(charId, objectId)) {
-				displayStringInSmallWindowWithBorder("Item is Equipped!  Give anyway?", false, charId, windowId, menuId, curMenuLine);
-				if (!getValidationFromUser())
-					validationFl = false;
-				displayWindowAndStatusMenu(charId, windowId, menuId, curMenuLine);
-
+			} else {
+				if (hasObjectEquipped(charId, objectId)) {
+					displayStringInSmallWindowWithBorder("Item is Equipped!  Give anyway?", false, charId, windowId, menuId, curMenuLine);
+					if (!getValidationFromUser())
+						validationFl = false;
+					displayWindowAndStatusMenu(charId, windowId, menuId, curMenuLine);
+				}
 				if (validationFl) {
 					if (gameMode == 2) {
 						displayStringInSmallWindowWithBorder("Not a Combat Option !", true, charId, windowId, menuId, curMenuLine);
@@ -782,12 +783,13 @@ int16 EfhEngine::handleStatusMenu(int16 gameMode, int16 charId) {
 			itemId = _npcBuf[charId]._inventory[objectId]._ref;
 			if (hasObjectEquipped(charId, objectId) && isItemCursed(itemId)) {
 				displayStringInSmallWindowWithBorder("The item is cursed!  IT IS EVIL!!!!!!!!", true, charId, windowId, menuId, curMenuLine);
-			} else if (hasObjectEquipped(charId, objectId)) {
-				displayStringInSmallWindowWithBorder("Item Is Equipped!  Drop Anyway?", false, charId, windowId, menuId, curMenuLine);
-				if (!getValidationFromUser())
-					validationFl = false;
-				displayWindowAndStatusMenu(charId, windowId, menuId, curMenuLine);
-
+			} else {
+				if (hasObjectEquipped(charId, objectId)) {
+					displayStringInSmallWindowWithBorder("Item Is Equipped!  Drop Anyway?", false, charId, windowId, menuId, curMenuLine);
+					if (!getValidationFromUser())
+						validationFl = false;
+					displayWindowAndStatusMenu(charId, windowId, menuId, curMenuLine);
+				}
 				if (validationFl) {
 					removeObject(charId, objectId);
 					if (gameMode == 2) {


### PR DESCRIPTION
Fixes what I think are a few issues that I encountered while working on text-to-speech:
- The "Give" and "Drop" actions currently only work for equipped items, making dropping or giving unequippable items impossible (which therefore locks the player out of events such as recruiting Hamlet).
- Trying to close the game when the status menu is open locks the player in the status menu. No player input is recognized at this point, and the game can only be closed by force quitting.
- When recruiting a new character to replace an existing party member, only 2 can be input, which means that the third party member can't be replaced.