### PR TITLE
IOS7: Migrate to the UIKit scene-based life cycle 

### DIFF
--- a/backends/platform/ios7/ios7_app_delegate.h
+++ b/backends/platform/ios7/ios7_app_delegate.h
@@ -34,6 +34,7 @@
 
 #if TARGET_OS_IOS
 + (UIInterfaceOrientation)currentOrientation;
++ (void)setKeyWindow:(UIWindow *)window;
 #endif
 
 @end

--- a/backends/platform/ios7/ios7_app_delegate.mm
+++ b/backends/platform/ios7/ios7_app_delegate.mm
@@ -61,7 +61,12 @@
 #endif
 	_controller.view = _view;
 
-	[iOS7AppDelegate setKeyWindow:[[UIWindow alloc] initWithFrame:rect]];
+	if (@available(iOS 13.0, *)) {
+		// iOS13 and later uses of UIScene.
+		// The keyWindow is setup by iOS7SceneDelegate
+	} else {
+		[iOS7AppDelegate setKeyWindow:[[UIWindow alloc] initWithFrame:rect]];
+	}
 
 	// Force creation of the shared instance on the main thread
 	iOS7_buildSharedOSystemInstance();
@@ -114,6 +119,21 @@
 
 - (BOOL)application:(UIApplication *)application shouldRestoreSecureApplicationState:(NSCoder *)coder {
 	return YES;
+}
+#endif
+
+#ifdef __IPHONE_13_0
+- (UISceneConfiguration *)application:(UIApplication *)application configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession options:(UISceneConnectionOptions *)options API_AVAILABLE(ios(13.0)) {
+	// Called when a new scene session is being created.
+	UISceneConfiguration *config = [[UISceneConfiguration alloc] initWithName:@"ScummVM Scene Configuration" sessionRole:connectingSceneSession.role];
+	[config setDelegateClass:NSClassFromString(@"iOS7SceneDelegate")];
+	return config;
+}
+
+- (void)application:(UIApplication *)application didDiscardSceneSessions:(NSSet<UISceneSession *> *)sceneSessions API_AVAILABLE(ios(13.0)) {
+	// Called when the user discards a scene session.
+	// Use this method to release any resources that were
+	// specific to the discarded scenes, as they will not return.
 }
 #endif
 

--- a/backends/platform/ios7/ios7_app_delegate.mm
+++ b/backends/platform/ios7/ios7_app_delegate.mm
@@ -51,9 +51,6 @@
 		[fm createDirectoryAtPath:savePath withIntermediateDirectories:YES attributes:nil error:nil];
 	}
 
-	_window = [[UIWindow alloc] initWithFrame:rect];
-	[_window retain];
-
 	_controller = [[iOS7ScummVMViewController alloc] init];
 
 	_view = [[iPhoneView alloc] initWithFrame:rect];
@@ -64,8 +61,7 @@
 #endif
 	_controller.view = _view;
 
-	[_window setRootViewController:_controller];
-	[_window makeKeyAndVisible];
+	[iOS7AppDelegate setKeyWindow:[[UIWindow alloc] initWithFrame:rect]];
 
 	// Force creation of the shared instance on the main thread
 	iOS7_buildSharedOSystemInstance();
@@ -148,6 +144,14 @@
 + (UIInterfaceOrientation)currentOrientation {
 	iOS7AppDelegate *appDelegate = [self iOS7AppDelegate];
 	return [appDelegate->_controller currentOrientation];
+}
+
++ (void)setKeyWindow:(UIWindow *)window {
+	iOS7AppDelegate *appDelegate = [self iOS7AppDelegate];
+	appDelegate->_window = window;
+	[appDelegate->_window retain];
+	[appDelegate->_window setRootViewController:appDelegate->_controller];
+	[appDelegate->_window makeKeyAndVisible];
 }
 #endif
 

--- a/backends/platform/ios7/ios7_scene_delegate.h
+++ b/backends/platform/ios7/ios7_scene_delegate.h
@@ -1,0 +1,32 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef BACKENDS_PLATFORM_IOS7_IOS7_SCENE_DELEGATE_H
+#define BACKENDS_PLATFORM_IOS7_IOS7_SCENE_DELEGATE_H
+
+#include <UIKit/UIKit.h>
+
+API_AVAILABLE(ios(13.0))
+@interface iOS7SceneDelegate : NSObject<UIWindowSceneDelegate>
+
+@end
+
+#endif

--- a/backends/platform/ios7/ios7_scene_delegate.mm
+++ b/backends/platform/ios7/ios7_scene_delegate.mm
@@ -1,0 +1,58 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "backends/platform/ios7/ios7_scene_delegate.h"
+#include "backends/platform/ios7/ios7_app_delegate.h"
+#include "backends/platform/ios7/ios7_video.h"
+
+API_AVAILABLE(ios(13.0))
+@implementation iOS7SceneDelegate
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions {
+
+	UIWindowScene *windowScene = (UIWindowScene *)scene;
+	[iOS7AppDelegate setKeyWindow:[[UIWindow alloc] initWithWindowScene:windowScene]];
+}
+
+- (void)sceneDidDisconnect:(UIScene *)scene {
+}
+
+- (void)sceneDidBecomeActive:(UIScene *)scene {
+	[[iOS7AppDelegate iPhoneView] applicationResume];
+}
+
+- (void)sceneWillResignActive:(UIScene *)scene {
+	[[iOS7AppDelegate iPhoneView] applicationSuspend];
+}
+
+- (void)sceneDidEnterBackground:(UIScene *)scene {
+	// Start the background task before sending the application entered background event.
+	// This is because this event will be handled in a separate thread and it will likely
+	// no be started before we return from this function.
+	[[iOS7AppDelegate iPhoneView] beginBackgroundSaveStateTask];
+
+	[[iOS7AppDelegate iPhoneView] saveApplicationState];
+}
+
+- (void)sceneWillEnterForeground:(UIScene *)scene {
+}
+
+@end

--- a/backends/platform/ios7/module.mk
+++ b/backends/platform/ios7/module.mk
@@ -16,7 +16,8 @@ MODULE_OBJS := \
 	ios7_game_controller.o \
 	ios7_touch_controller.o \
 	ios7_mouse_controller.o \
-	ios7_gamepad_controller.o
+	ios7_gamepad_controller.o \
+	ios7_scene_delegate.o
 
 # We don't use rules.mk but rather manually update OBJS and MODULE_DIRS.
 MODULE_OBJS := $(addprefix $(MODULE)/, $(MODULE_OBJS))


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
    UIScene is Apple's solution to support multiple windows for an iOS
    application. A scene represents an instance of the applications UI.

    ScummVM is a single window application and does not make use of the
    scene concept. It is however mandatory to implement it since the next
    major release following iOS 26 will require it.
    https://developer.apple.com/documentation/technotes/tn3187-migrating-to-the-uikit-scene-based-life-cycle

    The application life cycle delegate functions are handled as following
    by the iOS versions::
    version < iOS 13
    applicationDidBecomeActive(_:)
    applicationWillResignActive(_:)
    applicationDidEnterBackground(_:)
    applicationWillEnterForeground(_:)

    version >= iOS 13
    UISceneDelegate
    sceneDidBecomeActive(_:)
    sceneWillResignActive(_:)
    sceneDidEnterBackground(_:)
    sceneWillEnterForeground(_:)

    Implement the scene-based life cycle in the class iOS7SceneDelegate.
    This fulfills the requirements from Apple.