### PR TITLE
DISTS: EMSCRIPTEN: Cleanup and fix build, add emscripten to Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,31 @@ on: [push, pull_request]
 permissions:
   contents: read
 jobs:
+  emscripten:
+    name: Emscripten
+    runs-on: ubuntu-latest
+    strategy: 
+      fail-fast: false
+      matrix:
+        include:
+          - platform: emscripten
+            configFlags: --enable-gif --enable-jpeg --enable-ogg --enable-png --enable-vorbis --enable-zlib --enable-freetype2
+          - platform: emscripten
+            configFlags: --enable-gif --enable-jpeg --enable-ogg --enable-png --enable-vorbis --enable-zlib  --enable-freetype2 --enable-a52 --enable-faad --enable-mad --enable-mpeg2 --enable-mpeg2 --enable-theoradec
+    steps:
+      - uses: actions/checkout@v4
+      - name: Call configure
+        run: |
+          dists/emscripten/build.sh configure --enable-all-engines --disable-engines=hpl1 ${{ matrix.configFlags }}
+      - name: Build cache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ matrix.platform }}
+          max-size: 1G
+          create-symlink: true
+      - name: Build scummvm
+        run: |
+          dists/emscripten/build.sh make 
   windows:
     name: Windows
     runs-on: windows-latest

--- a/backends/platform/sdl/emscripten/emscripten.cpp
+++ b/backends/platform/sdl/emscripten/emscripten.cpp
@@ -28,6 +28,9 @@
 
 #include "backends/platform/sdl/emscripten/emscripten.h"
 #include "common/file.h"
+#ifdef USE_TTS
+#include "backends/text-to-speech/emscripten/emscripten-text-to-speech.h"
+#endif
 
 // Inline JavaScript, see https://emscripten.org/docs/api_reference/emscripten.h.html#inline-assembly-javascript for details
 EM_JS(bool, isFullscreen, (), {

--- a/configure
+++ b/configure
@@ -3630,6 +3630,9 @@ if test -n "$_host"; then
 			_libcurl=no
 			_curl=no
 			_enet=no
+			_seq_midi=no
+			_timidity=no
+			_sndio=no
 			_ar="emar cr"
 			_ranlib="emranlib"
 			;;

--- a/dists/emscripten/build.sh
+++ b/dists/emscripten/build.sh
@@ -32,7 +32,7 @@ TASKS=()
 CONFIGURE_ARGS=()
 _bundle_games=()
 _verbose=false
-EMSDK_VERSION="3.1.51"
+EMSDK_VERSION="${EMSDK_VERSION:-4.0.10}"
 EMSCRIPTEN_VERSION="$EMSDK_VERSION"
 
 usage="\
@@ -117,7 +117,7 @@ fi
 # Setup Toolchain
 #################################
 
-# Activate Emscripten
+# Download Emscripten
 if [[ ! -d "$DIST_FOLDER/emsdk-$EMSDK_VERSION" ]]; then
   echo "$DIST_FOLDER/emsdk-$EMSDK_VERSION not found. Installing Emscripten"
   cd "$DIST_FOLDER"
@@ -127,7 +127,6 @@ if [[ ! -d "$DIST_FOLDER/emsdk-$EMSDK_VERSION" ]]; then
     wget -nc --content-disposition --no-check-certificate "https://github.com/emscripten-core/emsdk/archive/refs/tags/${EMSDK_VERSION}.tar.gz"
     tar -xf "emsdk-${EMSDK_VERSION}.tar.gz"
   fi
-
 fi
 
 cd "$DIST_FOLDER/emsdk-${EMSDK_VERSION}"
@@ -178,7 +177,6 @@ fi
 #################################
 # Download + Install Libraries (if not part of Emscripten-Ports, these are handled by configure)
 #################################
-
 if [[ ! -d "$LIBS_FOLDER/build" ]]; then
   mkdir -p "$LIBS_FOLDER/build"
 fi
@@ -234,7 +232,7 @@ if [ "$_libmpeg2" = true ]; then
     wget -nc "http://libmpeg2.sourceforge.net/files/libmpeg2-0.5.1.tar.gz"
     tar -xf libmpeg2-0.5.1.tar.gz
     cd "$LIBS_FOLDER/libmpeg2-0.5.1/"
-    CFLAGS="-fPIC -Oz" emconfigure ./configure --host=wasm32-unknown-none --prefix="$LIBS_FOLDER/build/" --disable-sdl
+    CFLAGS="-fPIC -Oz" emconfigure ./configure --build=wasm32-unknown-none --prefix="$LIBS_FOLDER/build/" --disable-sdl
     emmake make -j 5
     emmake make install
   fi
@@ -366,9 +364,5 @@ fi
 if [[ "run" =~ $(echo ^\(${TASKS}\)$) ]]; then
   echo "Run ScummVM"
   cd "${ROOT_FOLDER}/build-emscripten/"
-  # emrun doesn't support range requests. Once it will, we don't need node-static anymore
   emrun --browser=chrome scummvm.html
-
-  # TODO: https://github.com/cloudhead/node-static/issues/241 means node-static doesn't work either.
-  # $EMSDK_NPX -p node-static static .
 fi

--- a/dists/emscripten/build.sh
+++ b/dists/emscripten/build.sh
@@ -185,9 +185,10 @@ if [ "$_liba52" = true ]; then
   if [[ ! -f "$LIBS_FOLDER/build/lib/liba52.a" ]]; then
     echo "building a52dec-0.7.4"
     cd "$LIBS_FOLDER"
-    wget -nc "https://liba52.sourceforge.io/files/a52dec-0.7.4.tar.gz"
-    tar -xf a52dec-0.7.4.tar.gz
-    cd "$LIBS_FOLDER/a52dec-0.7.4/"
+    wget -nc "https://code.videolan.org/videolan/liba52/-/archive/0.7.4/liba52-0.7.4.tar.gz"
+    tar -xf liba52-0.7.4.tar.gz
+    cd "$LIBS_FOLDER/liba52-0.7.4/"
+    autoreconf -i
     CFLAGS="-fPIC -Oz" emconfigure ./configure --host=wasm32-unknown-none --build=wasm32-unknown-none --prefix="$LIBS_FOLDER/build/"
     emmake make -j 5
     emmake make install

--- a/dists/emscripten/build.sh
+++ b/dists/emscripten/build.sh
@@ -227,11 +227,12 @@ fi
 
 if [ "$_libmpeg2" = true ]; then
   if [[ ! -f "$LIBS_FOLDER/build/lib/libmpeg2.a" ]]; then
-    echo "building libmpeg2-0.5.1"
+    echo "building libmpeg2-946bf4b5"
     cd "$LIBS_FOLDER"
-    wget -nc "http://libmpeg2.sourceforge.net/files/libmpeg2-0.5.1.tar.gz"
-    tar -xf libmpeg2-0.5.1.tar.gz
-    cd "$LIBS_FOLDER/libmpeg2-0.5.1/"
+    wget -nc --content-disposition  "https://code.videolan.org/videolan/libmpeg2/-/archive/946bf4b518aacc224f845e73708f99e394744499/libmpeg2-946bf4b518aacc224f845e73708f99e394744499.tar.gz"
+    tar -xf libmpeg2-946bf4b518aacc224f845e73708f99e394744499.tar.gz
+    cd "$LIBS_FOLDER/libmpeg2-946bf4b518aacc224f845e73708f99e394744499/"
+    autoreconf -i
     CFLAGS="-fPIC -Oz" emconfigure ./configure --build=wasm32-unknown-none --prefix="$LIBS_FOLDER/build/" --disable-sdl
     emmake make -j 5
     emmake make install


### PR DESCRIPTION
This is a small set of changes:
- https://github.com/scummvm/scummvm/pull/6636 actually broke the build, I forgot to cherry-pick a include into the build
- add emscripten buld to ci.yml to avoid issues such as the above in the future
- change URLs of a52dec and mpeg2 libs from sourceforce to videolan.org 
- update of Emscripten SDK to 4.0.10 and a few other cleanups