### PR TITLE
GRAPHICS: MACGUI: Fix borders stop being drawn at resize

### DIFF
--- a/graphics/macgui/macwindow.cpp
+++ b/graphics/macgui/macwindow.cpp
@@ -494,8 +494,19 @@ bool MacWindow::processEvent(Common::Event &event) {
 		}
 
 		if (_beingResized) {
-			resize(MAX(_borderWidth * 4, _dims.width()  + event.mouse.x - _draggedX),
-				   MAX(_borderWidth * 4, _dims.height() + event.mouse.y - _draggedY));
+			int minWidth = _borderWidth * 4;
+			int minHeight = minWidth;
+
+			uint32 flags = getBorderFlags();
+			if (_macBorder.hasBorder(flags) && _macBorder.hasOffsets()) {
+				minWidth = MAX(minWidth, _macBorder.getMinWidth(flags));
+				minHeight = MAX(minHeight, _macBorder.getMinHeight(flags));
+			}
+
+			resize(MAX(minWidth, _dims.width()  + event.mouse.x - _draggedX),
+				   MAX(minHeight, _dims.height() + event.mouse.y - _draggedY));
+
+			setTitle(_title);
 
 			_draggedX = event.mouse.x;
 			_draggedY = event.mouse.y;

--- a/graphics/macgui/macwindowborder.h
+++ b/graphics/macgui/macwindowborder.h
@@ -125,6 +125,9 @@ public:
 	BorderOffsets &getOffset();
 	const BorderOffsets &getOffset() const;
 
+	int getMinWidth(uint32 flags) const;
+	int getMinHeight(uint32 flags) const;
+
 	/**
 	 * Blit the desired border (active or inactive) into a destination surface.
 	 * It automatically resizes the border to fit the given surface.
@@ -138,7 +141,7 @@ public:
 
 	void setScroll(int scrollPos, int scrollSize) { _scrollPos = scrollPos, _scrollSize = scrollSize; }
 
-	void drawTitle(ManagedSurface *g, int titleOffset);
+	void drawTitle(ManagedSurface *g, int titleOffset, int minWidth);
 
 	void drawScrollBar(ManagedSurface *g);
 


### PR DESCRIPTION
When working on MacVenture, I noticed that when resizing, specifically, at downsizing borders stopped being shown. The reason was that at resize() we take MAX of _borderWidth (=17) * 4 and the resized window size. However, if the fix size of border is larger than that then it won't be drawn because of the check in `NinePatchBitmap::blit()`.
I added accessor methods for getting minWidth and minHeight to fix this. Also changed `MacWindowBorder::setTitle()` and `MacWindowBorder::drawTitle()` to adhere to the changes. Tested with MacVenture and WAGE.