### PR TITLE
BUILD: Drop WinCE remnants and old hacks

### DIFF
--- a/audio/decoders/raw.cpp
+++ b/audio/decoders/raw.cpp
@@ -178,11 +178,14 @@ bool RawStream<bytesPerSample, isUnsigned, isLE>::seek(const Timestamp &where) {
 
 /* In the following, we use preprocessor / macro tricks to simplify the code
  * which instantiates the input streams. We used to use template functions for
- * this, but MSVC6 / EVC 3-4 (used for WinCE builds) are extremely buggy when it
- * comes to this feature of C++... so as a compromise we use macros to cut down
+ * this, but MSVC6 / EVC 3-4 (used for WinCE builds) were extremely buggy when it
+ * came to this feature of C++... so as a compromise we used macros to cut down
  * on the (source) code duplication a bit.
  * So while normally macro tricks are said to make maintenance harder, in this
  * particular case it should actually help it :-)
+ *
+ * TODO: WinCE and ancient MSVC releases are not supported anymore. Should the
+ * macro tricks introduced in commit c55652d be reverted now?
  */
 
 #define MAKE_RAW_STREAM(UNSIGNED) \

--- a/audio/decoders/vorbis.cpp
+++ b/audio/decoders/vorbis.cpp
@@ -36,11 +36,7 @@
 #include "audio/audiostream.h"
 
 #ifdef USE_TREMOR
-#ifdef USE_TREMOLO
-#include <tremolo/ivorbisfile.h>
-#else
 #include <tremor/ivorbisfile.h>
-#endif
 #else
 #define OV_EXCLUDE_STATIC_CALLBACKS
 #include <vorbis/vorbisfile.h>

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -54,6 +54,8 @@
 #include "backends/platform/sdl/sdl-sys.h"
 #endif
 
+#include <errno.h> // For strtol result check
+
 namespace Base {
 
 #ifndef DISABLE_COMMAND_LINE
@@ -551,12 +553,12 @@ bool ensureAccessibleDirectoryForPathOption(Common::FSNode &node,
 	if (!option) usage("Option '%s' requires an argument", argv[isLongCmd ? i : i-1]);
 
 // Use this for options which have a required integer value
-// (we don't check ERANGE because WinCE doesn't support errno, so we're stuck just rejecting LONG_MAX/LONG_MIN..)
 #define DO_OPTION_INT(shortCmd, longCmd) \
 	DO_OPTION(shortCmd, longCmd) \
 	char *endptr; \
+	errno = 0; \
 	long int retval = strtol(option, &endptr, 0); \
-	if (*endptr != '\0' || retval == LONG_MAX || retval == LONG_MIN) \
+	if (*endptr != '\0' || (errno == ERANGE && (retval == LONG_MAX || retval == LONG_MIN))) \
 		usage("--%s: Invalid number '%s'", longCmd, option);
 
 // Use this for boolean options; this distinguishes between "-x" and "-X",

--- a/base/version.cpp
+++ b/base/version.cpp
@@ -85,12 +85,7 @@ const char gScummVMFeatures[] = ""
 #endif
 
 #ifdef USE_TREMOR
-#  ifdef USE_TREMOLO
-	// libTremolo is used on WinCE for better ogg performance
-	"Tremolo "
-#  else
 	"Tremor "
-#  endif
 #elif defined(USE_VORBIS)
 	"Vorbis "
 #endif

--- a/common/scummsys.h
+++ b/common/scummsys.h
@@ -124,11 +124,10 @@
 	#include <assert.h>
 	#include <ctype.h>
 
-	// The C++11 standard removed the C99 requirement that some <inttypes.h>
-	// features should only be available when the following macros are defined.
-	// But on some systems (such as RISC OS or macOS < 10.7), the system headers
-	// are not necessarily up to date with this change. So, continue defining
-	// them, in order to avoid build failures on some environments.
+	// In C99, the following macros were necessary to get some <inttypes.h>
+	// features we want. The C++11 standard removed this requirement, but in
+	// practice, some systems (such as RISC OS or macOS < 10.7) are not fully
+	// compliant, and still require the old defines.
 	#define __STDC_CONSTANT_MACROS
 	#define __STDC_FORMAT_MACROS
 	#define __STDC_LIMIT_MACROS
@@ -145,6 +144,7 @@
 	#endif
 
 	#include <limits.h>
+
 	// MSVC does not define M_PI, M_SQRT2 and other math defines by default.
 	// _USE_MATH_DEFINES must be defined in order to have these defined, thus
 	// we enable it here. For more information, check:

--- a/configure
+++ b/configure
@@ -150,7 +150,6 @@ _sdlnet=auto
 _libcurl=auto
 _enet=yes
 _tremor=auto
-_tremolo=no
 _flac=auto
 _mad=auto
 _opl2lpt=no
@@ -5291,10 +5290,6 @@ echo "$_vorbis"
 # Check for Tremor
 #
 echocheck "Tremor"
-if test "$_tremolo" = yes ; then
-	_tremor=yes
-fi
-
 if test "$_tremor" = auto ; then
 	_tremor=no
 	cat > $TMPC << EOF
@@ -5312,12 +5307,7 @@ fi
 if test "$_tremor" = yes && test "$_vorbis" = no; then
 	add_line_to_config_h '#define USE_TREMOR'
 	add_line_to_config_h '#define USE_VORBIS'
-	if test "$_tremolo" = yes ; then
-		add_line_to_config_h '#define USE_TREMOLO'
-		append_var LIBS "$TREMOR_LIBS -ltremolo"
-	else
-		append_var LIBS "$TREMOR_LIBS -lvorbisidec"
-	fi
+	append_var LIBS "$TREMOR_LIBS -lvorbisidec"
 	append_var INCLUDES "$TREMOR_CFLAGS"
 else
 	if test "$_vorbis" = yes; then


### PR DESCRIPTION
The WinCE port was removed in PR #1931, but we still had some old hacks for it.

This PR consists in 3 changes:

1. Drop [Tremolo](http://wss.co.uk/pinknoise/tremolo/) support (= an old Tremor fork with some ARM optimizations).
    * AFAICS, it was only used by the WinCE port, and it has no other consumer.
    * **Possible objection:** maybe some old ARM port could still benefit from it? 
2. There's an old macro hack in `audio/decoders/raw.cpp` that was introduced [more than 20 years ago](https://github.com/scummvm/scummvm/commit/c55652d4a60ee51dde381417c590fff9a59ecb0d), for the ancient compilers used by the earliest WinCE builds.
    * My commit just adds a `// TODO` mentioning that the macro hack could maybe be removed in favour of the original template usage. I'm not adding such template use myself, as I'm not confortable with that.
    * **Possible objection:** maybe the macro is just OK as it is. I could then just drop the comment around it. Opinions welcome 😁 
3. When checking for proper integer options in `base/commandLine.cpp`, the `strtol()` check was [intentionally limited at some point](https://github.com/scummvm/scummvm/commit/1b6453dff4dde1e293b62f7fb4ade02507fd31bb), as WinCE didn't have proper `errno` support.
    * `errno` seems to be present in all the current ports, so restoring the full [and recommended check](https://man.openbsd.org/strtol.3#EXAMPLES) along the way just feels right (but note that we have many improper checks for it in the full codebase, see below).

=> So I'm looking for some feedback on that one (e.g. @lephilousophe?).

## Regarding strtol()/atoi() usage

I gave a quick look at our many `strto*l*()`/`atoi()` uses, and in general they look fragile, because we often don't apply the [recommended checks](https://man.openbsd.org/strtol.3#EXAMPLES) for it. Maybe we should have a helper function Common that would take care of that. The BSDs have introduced [`strtonum(3)`](https://man.netbsd.org/strtonum.3) as a better API, but then a "better better API" (as you'd expect) was added in NetBSD with [`strtoi(3)`](https://man.netbsd.org/strtoi.3). Maybe it'd make sense to import it, the way Common has `strlcpy()`/`strlcat()`?