### PR TITLE
DIRECTOR: Fix cast duplication for multiple casts

### DIFF
--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -533,9 +533,9 @@ bool Movie::eraseCastMember(CastMemberID memberID) {
 bool Movie::duplicateCastMember(CastMemberID source, CastMemberID target) {
 	Cast *sourceCast = nullptr;
 	Cast *targetCast = nullptr;
-	if (_casts.contains(target.castLib)) {
-		if (_casts[target.castLib]->getCastMember(source.member)) {
-			sourceCast = _casts[target.castLib];
+	if (_casts.contains(source.castLib)) {
+		if (_casts[source.castLib]->getCastMember(source.member)) {
+			sourceCast = _casts[source.castLib];
 		} else if (_sharedCast && _sharedCast->getCastMember(source.member)) {
 			sourceCast = _sharedCast;
 		}


### PR DESCRIPTION
When duplicating a cast member, where the cast member being duplicated (source)
is from one cast and the position at which the cast member is to be duplicated (target)
is from a different cast, we have a bug where we try to search for the source cast member
in the target cast:
```c++
bool Movie::duplicateCastMember(CastMemberID source, CastMemberID target) {
	Cast *sourceCast = nullptr;
	Cast *targetCast = nullptr;
	if (_casts.contains(target.castLib)) {
		if (_casts[target.castLib]->getCastMember(source.member)) {
			sourceCast = _casts[target.castLib];
		} else if (_sharedCast && _sharedCast->getCastMember(source.member)) {
			sourceCast = _sharedCast;
		}
	}
```
Here instead of getting the source cast member from the source cast we have
`sourceCast = _casts[target.castLib`
This causes the following bug:
I made a simple movie in the original director, with two different bitmaps in two different casts
with different colors to indicate their cast.
Here red bitmap is from cast 1 (internal cast) and the black bitmap is from cast 2 (Second cast)
<img width="1920" height="1080" alt="Screenshot_20250726_154345" src="https://github.com/user-attachments/assets/2a14e7ff-30c2-42a5-96b2-75576ea9695c" />

When I try to duplicate the red bitmap (from cast 1) it works perfectly, because the target
cast member and the source cast member are from the same cast (cast 1):
https://github.com/user-attachments/assets/ec9b9b00-13f0-463f-be4b-ffc96ea152ee

However, when I try to duplicate the black bitmap (from cast 2) it doesn't work because it searches
for the black bitmap in the target cast (cast 1) which is not the same as source cast (cast 2)

https://github.com/user-attachments/assets/a2fc900f-bd08-4924-8429-da6cccd7e74b


So, we should look for the source cast member in the source cast (cast 1) 
`sourceCast = _casts[source.castLib];`
which works perfectly:
https://github.com/user-attachments/assets/c4f4bb14-ce9c-4a82-ac41-a77fb7854dbb

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
