### PR TITLE
PSP2: Enable hq and edge scalers

### DIFF
--- a/configure
+++ b/configure
@@ -3990,8 +3990,6 @@ if test -n "$_host"; then
 		psp2)
 			_backend="psp2"
 			_vkeybd=yes
-			_build_scalers=yes
-			_build_hq_scalers=no
 			_mt32emu=no
 			_timidity=no
 			_port_mk="backends/platform/sdl/psp2/psp2.mk"


### PR DESCRIPTION
Since commit df88bb2 performance is good enough to enable hq scalers.
Tested on some games at 2x and 3x times the resolution with no issue.