### PR TITLE
HPL1: Fix build with GLES(2) without GLAD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Call configure
         run: |
-          dists/emscripten/build.sh configure --enable-all-engines --disable-engines=hpl1 ${{ matrix.configFlags }}
+          dists/emscripten/build.sh configure --enable-all-engines ${{ matrix.configFlags }}
       - name: Build cache
         uses: hendrikmuhs/ccache-action@v1.2
         with:

--- a/engines/hpl1/engine/game/low_level_game_setup.cpp
+++ b/engines/hpl1/engine/game/low_level_game_setup.cpp
@@ -32,7 +32,7 @@
 namespace hpl {
 
 static iLowLevelGraphics *createLowLevelGfx() {
-#ifdef USE_OPENGL
+#ifdef HPL1_USE_OPENGL
 	if (Hpl1::useOpenGL())
 		return hplNew(cLowLevelGraphicsSDL, ());
 #endif

--- a/engines/hpl1/engine/impl/CGProgram.cpp
+++ b/engines/hpl1/engine/impl/CGProgram.cpp
@@ -27,7 +27,7 @@
 
 #include "hpl1/engine/impl/CGProgram.h"
 
-#ifdef USE_OPENGL
+#ifdef HPL1_USE_OPENGL
 
 #include "hpl1/engine/impl/SDLTexture.h"
 #include "hpl1/engine/system/low_level_system.h"
@@ -38,7 +38,6 @@
 #include "common/array.h"
 #include "common/str.h"
 #include "hpl1/debug.h"
-#include "hpl1/opengl.h"
 #include "math/matrix4.h"
 
 namespace hpl {
@@ -154,4 +153,4 @@ bool cCGProgram::SetMatrixf(const tString &asName, eGpuProgramMatrix mType,
 
 } // namespace hpl
 
-#endif // USE_OPENGL
+#endif // HPL1_USE_OPENGL

--- a/engines/hpl1/engine/impl/CGProgram.h
+++ b/engines/hpl1/engine/impl/CGProgram.h
@@ -32,8 +32,9 @@
 #include "hpl1/engine/graphics/GPUProgram.h"
 #include "hpl1/engine/math/MathTypes.h"
 #include "hpl1/engine/system/SystemTypes.h"
+#include "hpl1/opengl.h"
 
-#ifdef USE_OPENGL
+#ifdef HPL1_USE_OPENGL
 
 #include "graphics/opengl/shader.h"
 
@@ -72,5 +73,5 @@ private:
 
 } // namespace hpl
 
-#endif // USE_OPENGL
+#endif // HPL1_USE_OPENGL
 #endif // HPL_CGPROGRAM_H

--- a/engines/hpl1/engine/impl/LowLevelGraphicsSDL.cpp
+++ b/engines/hpl1/engine/impl/LowLevelGraphicsSDL.cpp
@@ -271,7 +271,7 @@ int cLowLevelGraphicsSDL::GetCaps(eGraphicCaps type) const {
 		return 1; // gl 1.4
 
 	case eGraphicCaps_GL_MultiTexture:
-		return GLAD_GL_ARB_multitexture; // gl 1.4
+		return 1; // gl 1.2.1
 
 	default:
 		break;

--- a/engines/hpl1/engine/impl/LowLevelGraphicsSDL.cpp
+++ b/engines/hpl1/engine/impl/LowLevelGraphicsSDL.cpp
@@ -43,9 +43,8 @@
 #include "hpl1/debug.h"
 #include "hpl1/engine/impl/OcclusionQueryOGL.h"
 #include "hpl1/graphics.h"
-#include "hpl1/opengl.h"
 
-#ifdef USE_OPENGL
+#ifdef HPL1_USE_OPENGL
 
 namespace hpl {
 
@@ -1808,4 +1807,4 @@ void cLowLevelGraphicsSDL::SetMatrixMode(eMatrix type) {
 
 } // namespace hpl
 
-#endif // USE_OPENGL
+#endif // HPL1_USE_OPENGL

--- a/engines/hpl1/engine/impl/LowLevelGraphicsSDL.h
+++ b/engines/hpl1/engine/impl/LowLevelGraphicsSDL.h
@@ -35,7 +35,7 @@
 #include "hpl1/engine/math/MathTypes.h"
 #include "hpl1/opengl.h"
 
-#ifdef USE_OPENGL
+#ifdef HPL1_USE_OPENGL
 
 namespace hpl {
 
@@ -313,5 +313,5 @@ private:
 
 } // namespace hpl
 
-#endif // USE_OPENGL
+#endif // HPL1_USE_OPENGL
 #endif // HPL_LOWLEVELGRAPHICS_SDL_H

--- a/engines/hpl1/engine/impl/OcclusionQueryOGL.cpp
+++ b/engines/hpl1/engine/impl/OcclusionQueryOGL.cpp
@@ -26,9 +26,8 @@
  */
 
 #include "hpl1/engine/impl/OcclusionQueryOGL.h"
-#include "hpl1/opengl.h"
 
-#ifdef USE_OPENGL
+#ifdef HPL1_USE_OPENGL
 
 namespace hpl {
 
@@ -82,4 +81,4 @@ unsigned int cOcclusionQueryOGL::GetSampleCount() {
 //-----------------------------------------------------------------------
 } // namespace hpl
 
-#endif // USE_OPENGL
+#endif // HL1_USE_OPENGL

--- a/engines/hpl1/engine/impl/OcclusionQueryOGL.h
+++ b/engines/hpl1/engine/impl/OcclusionQueryOGL.h
@@ -30,8 +30,9 @@
 
 #include "common/scummsys.h"
 #include "hpl1/engine/graphics/OcclusionQuery.h"
+#include "hpl1/opengl.h"
 
-#ifdef USE_OPENGL
+#ifdef HPL1_USE_OPENGL
 
 namespace hpl {
 
@@ -52,5 +53,5 @@ public:
 
 } // namespace hpl
 
-#endif // USE_OPENGL
+#endif // HPL1_USE_OPENGL
 #endif // HPL_OCCLUSION_QUERY_H

--- a/engines/hpl1/engine/impl/SDLTexture.cpp
+++ b/engines/hpl1/engine/impl/SDLTexture.cpp
@@ -33,9 +33,8 @@
 #include "hpl1/debug.h"
 #include "hpl1/engine/math/Math.h"
 #include "hpl1/engine/system/low_level_system.h"
-#include "hpl1/opengl.h"
 
-#ifdef USE_OPENGL
+#ifdef HPL1_USE_OPENGL
 
 namespace hpl {
 
@@ -654,4 +653,4 @@ GLenum cSDLTexture::GetGLWrap(eTextureWrap aMode) {
 
 } // namespace hpl
 
-#endif // USE_OPENGL
+#endif // HPL1_USE_OPENGL

--- a/engines/hpl1/engine/impl/SDLTexture.h
+++ b/engines/hpl1/engine/impl/SDLTexture.h
@@ -32,8 +32,9 @@
 #include "hpl1/engine/graphics/Texture.h"
 #include "hpl1/engine/graphics/bitmap2D.h"
 #include "hpl1/engine/impl/LowLevelGraphicsSDL.h"
+#include "hpl1/opengl.h"
 
-#ifdef USE_OPENGL
+#ifdef HPL1_USE_OPENGL
 
 namespace hpl {
 
@@ -101,5 +102,5 @@ private:
 
 } // namespace hpl
 
-#endif // USE_OPENGL
+#endif // HPL1_USE_OPENGL
 #endif // HPL_SDL_TEXTURE_H

--- a/engines/hpl1/engine/impl/VertexBufferOGL.cpp
+++ b/engines/hpl1/engine/impl/VertexBufferOGL.cpp
@@ -30,7 +30,7 @@
 #include "hpl1/engine/math/Math.h"
 #include "hpl1/engine/system/low_level_system.h"
 
-#ifdef USE_OPENGL
+#ifdef HPL1_USE_OPENGL
 
 namespace hpl {
 
@@ -507,4 +507,4 @@ void cVertexBufferOGL::SetVertexStates(tVertexFlag aFlags) {
 
 } // namespace hpl
 
-#endif // USE_OPENGL
+#endif // HPL1_USE_OPENGL

--- a/engines/hpl1/engine/impl/VertexBufferOGL.h
+++ b/engines/hpl1/engine/impl/VertexBufferOGL.h
@@ -30,8 +30,9 @@
 
 #include "common/scummsys.h"
 #include "hpl1/engine/graphics/VertexBuffer.h"
+#include "hpl1/opengl.h"
 
-#ifdef USE_OPENGL
+#ifdef HPL1_USE_OPENGL
 
 namespace hpl {
 
@@ -92,5 +93,5 @@ private:
 
 } // namespace hpl
 
-#endif // USE_OPENGL
+#endif // HPL1_USE_OPENGL
 #endif // HPL_RENDERER3D_OGL_H

--- a/engines/hpl1/engine/impl/VertexBufferVBO.cpp
+++ b/engines/hpl1/engine/impl/VertexBufferVBO.cpp
@@ -28,9 +28,8 @@
 #include "hpl1/engine/impl/VertexBufferVBO.h"
 #include "hpl1/engine/math/Math.h"
 #include "hpl1/engine/system/low_level_system.h"
-#include "hpl1/opengl.h"
 
-#ifdef USE_OPENGL
+#ifdef HPL1_USE_OPENGL
 
 namespace hpl {
 
@@ -683,4 +682,4 @@ Log("\n");
 }
 }*/
 
-#endif // USE_OPENGL
+#endif // HPL1_USE_OPENGL

--- a/engines/hpl1/engine/impl/VertexBufferVBO.h
+++ b/engines/hpl1/engine/impl/VertexBufferVBO.h
@@ -30,8 +30,9 @@
 
 #include "common/scummsys.h"
 #include "hpl1/engine/graphics/VertexBuffer.h"
+#include "hpl1/opengl.h"
 
-#ifdef USE_OPENGL
+#ifdef HPL1_USE_OPENGL
 
 namespace hpl {
 
@@ -99,5 +100,5 @@ private:
 
 } // namespace hpl
 
-#endif // USE_OPENGL
+#endif // HPL1_USE_OPENGL
 #endif // HPL_RENDERER3D_VBO_H

--- a/engines/hpl1/graphics.cpp
+++ b/engines/hpl1/graphics.cpp
@@ -28,6 +28,7 @@
 
 namespace Hpl1 {
 
+#ifdef HPL1_USE_OPENGL
 static Graphics::RendererType getBestRendererType() {
 	Common::String renderConfig = ConfMan.get("renderer");
 	Graphics::RendererType desiredRendererType = Graphics::Renderer::parseTypeCode(renderConfig);
@@ -37,13 +38,18 @@ static Graphics::RendererType getBestRendererType() {
 	return Graphics::Renderer::getBestMatchingType(
 		desiredRendererType, availableRendererTypes);
 }
+#endif
 
 bool areShadersAvailable() {
+#ifdef HPL1_USE_OPENGL
 	return getBestRendererType() == Graphics::kRendererTypeOpenGLShaders;
+#else
+	return false;
+#endif
 }
 
 Common::ScopedPtr<Graphics::Surface> createViewportScreenshot() {
-#ifdef USE_OPENGL
+#ifdef HPL1_USE_OPENGL
 	return createGLViewportScreenshot();
 #else
 	return nullptr;
@@ -51,9 +57,13 @@ Common::ScopedPtr<Graphics::Surface> createViewportScreenshot() {
 }
 
 bool useOpenGL() {
+#ifdef HPL1_USE_OPENGL
 	Graphics::RendererType bestRendererType = getBestRendererType();
 	return bestRendererType == Graphics::kRendererTypeOpenGL ||
 	       bestRendererType == Graphics::kRendererTypeOpenGLShaders;
+#else
+	return false;
+#endif
 }
 
 } // namespace Hpl1

--- a/engines/hpl1/opengl.cpp
+++ b/engines/hpl1/opengl.cpp
@@ -25,7 +25,7 @@
 #include "graphics/surface.h"
 #include "hpl1/debug.h"
 
-#ifdef USE_OPENGL
+#ifdef HPL1_USE_OPENGL
 
 namespace Hpl1 {
 
@@ -68,4 +68,4 @@ Common::ScopedPtr<Graphics::Surface> createGLViewportScreenshot() {
 
 } // End of namespace Hpl1
 
-#endif // USE_OPENGL
+#endif // HPL1_USE_OPENGL

--- a/engines/hpl1/opengl.h
+++ b/engines/hpl1/opengl.h
@@ -27,7 +27,9 @@
 #include "graphics/opengl/context.h"
 #include "graphics/opengl/system_headers.h"
 
-#ifdef USE_OPENGL
+#if defined(USE_OPENGL) && !USE_FORCED_GLES2 && !USE_FORCED_GLES
+
+#define HPL1_USE_OPENGL
 
 namespace Graphics {
 
@@ -51,5 +53,5 @@ Common::ScopedPtr<Graphics::Surface> createGLViewportScreenshot();
 #define GL_CHECK_FN() \
 	{ ::Hpl1::checkOGLErrors(__func__, __FILE__, __LINE__); }
 
-#endif // USE_OPENGL
+#endif // defined(USE_OPENGL) && !USE_FORCED_GLES2 && !USE_FORCED_GLES
 #endif // HPL1_OPENGL_H

--- a/graphics/opengl/system_headers.h
+++ b/graphics/opengl/system_headers.h
@@ -82,6 +82,13 @@
 	#endif
 	#undef GL_GLEXT_PROTOTYPES
 
+#else
+
+#define GL_GLEXT_PROTOTYPES
+#include <GL/gl.h>
+#include <GL/glext.h>
+#undef GL_GLEXT_PROTOTYPES
+
 #endif
 #endif
 


### PR DESCRIPTION
Disable the OpenGL case when GLES or GLES2 are forced as the code is not (yet?) compatible.
It fails to build when used without GLAD and it is useless anyway.

Also, don't fail to build when GLAD is disabled (by patching the configure script) and OpenGL mode is selected.

This PR is mostly to check for CI status.