### PR TITLE
COMMON: ARCHIVE: Fix crash in SearchSet::addDirectory on PSP2

### DIFF
--- a/common/archive.cpp
+++ b/common/archive.cpp
@@ -629,7 +629,7 @@ void SearchManager::clear() {
 	if (g_system)
 		g_system->addSysArchivesToSearchSet(*this, -1);
 
-#ifndef __ANDROID__
+#if !defined(__ANDROID__) && !defined(PSP2)
 	// Add the current dir as a very last resort.
 	// See also bug #3984.
 	// But don't do this for Android platform, since it may lead to crashes


### PR DESCRIPTION
Following commit : 95440c2
"ZVISION: Rework engine to use standard SearchMan functionality." an error is now raised in SearchSet::addDirectory() while it was ignored before.
The culprit is a call inside SearchManager::clear() which tries to add the directory "." that is not really a valid directory on PSP2. Just prevent calling addDirectory() with "." like we do on Android. Also tested on Linux but it works fine. Maybe some other platforms are affected ?
