### PR TITLE
NANCY: Don't pop from empty newlineTokens list

### DIFF
--- a/engines/nancy/misc/hypertext.cpp
+++ b/engines/nancy/misc/hypertext.cpp
@@ -243,8 +243,13 @@ void HypertextParser::drawAllText(const Common::Rect &textBounds, uint leftOffse
 			Common::String &line = wrappedLines[lineNumber];
 			horizontalOffset = 0;
 			newLineStart = false;
+
 			// Draw images
-			if (newlineTokens.front() <= totalCharsDrawn) {
+			if (newlineTokens.empty()) {
+				warning("HypertextParser::drawAllText():: newlineTokens list was empty at line %u out of %u wrapped lines", lineNumber+1, wrappedLines.size());
+			}
+
+			if (!newlineTokens.empty() && newlineTokens.front() <= totalCharsDrawn) {
 				newlineTokens.pop();
 				newLineStart = true;
 


### PR DESCRIPTION
Fixes assertion fail for Nancy Drew 2 when calling Dwayne Powers (late into the game)

This bug was reported here: https://bugs.scummvm.org/ticket/16112


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
