### PR TITLE
DIRECTOR: Read `castId` in `Scripts::read()` as 16bit and dump scripts with correct names

### DIFF
--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -1626,12 +1626,14 @@ void Cast::loadLingoContext(Common::SeekableReadStreamEndian &stream) {
 		if (ConfMan.getBool("dump_scripts")) {
 			for (auto it = _lingodec->scripts.begin(); it != _lingodec->scripts.end(); ++it) {
 				Common::DumpFile out;
-				ScriptType scriptType = kMovieScript;
+				ScriptType scriptType = kNoneScript;
 
 				if (_loadedCast->contains(it->second->castID)) {
 					CastMember *member = _loadedCast->getVal(it->second->castID);
 					if (member && member->_type == kCastLingoScript) {
 						scriptType = ((ScriptCastMember *)member)->_scriptType;
+					} else {
+						scriptType = kCastScript;
 					}
 				}
 

--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -1635,11 +1635,11 @@ void Cast::loadLingoContext(Common::SeekableReadStreamEndian &stream) {
 					}
 				}
 
-				// FIXME: castID is set incorrectly for D5+
-				Common::Path lingoPath(dumpScriptName(encodePathForDump(_macName).c_str(), scriptType, it->second->castID, "lingo"));
+				Common::String filename = encodePathForDump(_macName);
+				Common::Path lingoPath(dumpScriptName(filename.c_str(), scriptType, it->second->castID, "lingo"));
 
 				if (out.open(lingoPath, true)) {
-					Common::String decompiled = it->second->scriptText("\n", true);
+					Common::String decompiled = it->second->scriptText("\n", false);
 					out.writeString(decompiled);
 					out.flush();
 					out.close();

--- a/engines/director/lingo/lingodec/script.cpp
+++ b/engines/director/lingo/lingodec/script.cpp
@@ -36,7 +36,8 @@ void Script::read(Common::SeekableReadStream &stream) {
 	stream.seek(38);
 	/* 38 */ scriptFlags = stream.readUint32BE();
 	/* 42 */ unk42 = stream.readSint16BE();
-	/* 44 */ castID = stream.readSint32BE();
+	/* 44 */ unk43 = stream.readSint16BE();
+	/* 46 */ castID = stream.readSint16BE();
 	/* 48 */ factoryNameID = stream.readSint16BE();
 	/* 50 */ handlerVectorsCount = stream.readUint16BE();
 	/* 52 */ handlerVectorsOffset = stream.readUint32BE();

--- a/engines/director/lingo/lingodec/script.h
+++ b/engines/director/lingo/lingodec/script.h
@@ -45,7 +45,8 @@ struct Script {
 
 	/* 38 */ uint32 scriptFlags;
 	/* 42 */ int16 unk42;
-	/* 44 */ int32 castID;
+	/* 44 */ int16 unk43;
+	/* 46 */ int16 castID;
 	/* 48 */ int16 factoryNameID;
 	/* 50 */ uint16 handlerVectorsCount;
 	/* 52 */ uint32 handlerVectorsOffset;

--- a/engines/director/util.cpp
+++ b/engines/director/util.cpp
@@ -1152,22 +1152,22 @@ Common::Path dumpScriptName(const char *prefix, int type, int id, const char *ex
 
 	switch (type) {
 	case kNoneScript:
-		typeName = "unknown";
+		typeName = "UnknownScript";
 		break;
 	case kMovieScript:
-		typeName = "movie";
+		typeName = "MovieScript";
 		break;
 	case kCastScript:
-		typeName = "cast";
+		typeName = "CastScript";
 		break;
 	case kEventScript:
-		typeName = "event";
+		typeName = "EventScript";
 		break;
 	case kScoreScript:
-		typeName = "score";
+		typeName = "ScoreScript";
 		break;
 	case kParentScript:
-		typeName = "parent";
+		typeName = "ParentScript";
 		break;
 	default:
 		error("dumpScriptName(): Incorrect call (type %d)", type);


### PR DESCRIPTION
While checking why the names of the lingo scripts being dumped for D5+
movies are incorrect, I realized the `castId` was being read incorrectly.
Instead of 1 we had 65537 (65536 (2^16)+1), instead of 2 we had 
65538 (65536 (2^16) + 2).  
In the hex dump of the movies I found that, the castId was a 16 bit-entry 
rather than 32-bit. The 16 bits before that were unknown and observed to 
be 0x0 for Director 4 movies and 0x1 for Director 5 movies (see screenshots below).
In each screenshot, the highlighted 32 bits are read previously as `castId`

D4 movies:
<img width="901" height="237" alt="Screenshot_20250728_224222" src="https://github.com/user-attachments/assets/cef50d93-53a9-4a25-aa99-ede935623b86" />
<img width="964" height="237" alt="Screenshot_20250728_224449" src="https://github.com/user-attachments/assets/5232d4ba-9b25-4fd0-b157-5b6bd6e7f1ad" />

D5 movies:
<img width="891" height="205" alt="Screenshot_20250728_223730" src="https://github.com/user-attachments/assets/5b17b0d4-540a-4ab1-b458-74eeb18c10a8" />
<img width="887" height="240" alt="Screenshot_20250728_223929" src="https://github.com/user-attachments/assets/d7dbbde3-3bf2-4aa8-b85f-6e9c839b734a" />
<img width="902" height="208" alt="Screenshot_20250728_223949" src="https://github.com/user-attachments/assets/ed615d99-44fb-4a28-8816-a211fe430d7f" />

Also fix the script type being written in the filename of the dumped lingo scripts.
The script must be associated with a cast member. If the cast member is `ScriptCastMember` 
the script type is given by `ScriptCastMember::_scriptType` (kMovieScript, kScoreScript, kParentScript, etc) 
If the cast member is not a `ScriptCastMember`
its a script linked to a `CastMember` (not ScriptCastMember)
If none of these, then its a `kNoneScript`

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
