### PR TITLE
AGS: Fix use-after-free issue after calling unload_game()

### DIFF
--- a/engines/ags/engine/ac/game.cpp
+++ b/engines/ags/engine/ac/game.cpp
@@ -407,7 +407,7 @@ void unload_game() {
 
 	// Reset all resource caches
 	// IMPORTANT: this is hard reset, including locked items
-	_GP(spriteset).Reset();
+	_GP(spriteset).Reset(_G(game)->SpriteInfos);
 }
 
 const char *Game_GetGlobalStrings(int index) {

--- a/engines/ags/shared/ac/sprite_cache.h
+++ b/engines/ags/shared/ac/sprite_cache.h
@@ -164,6 +164,7 @@ public:
 	void		DisposeAllFreeCached();
 	// Deletes all data and resets cache to the clear state
 	void        Reset();
+	void        Reset(std::vector<SpriteInfo> &sprInfos);
 	// Assigns new sprite for the given index; this sprite won't be auto disposed.
 	// *Deletes* the previous sprite if one was found at the same index.
 	// "flags" are SPF_* constants that define sprite's behavior in game.
@@ -227,7 +228,7 @@ private:
 	};
 
 	// Provided map of sprite infos, to fill in loaded sprite properties
-	std::vector<SpriteInfo> &_sprInfos;
+	std::vector<SpriteInfo> *_sprInfos;
 	// Array of sprite references
 	std::vector<SpriteData> _spriteData;
 	// Placeholder sprite, returned from operator[] for a non-existing sprite


### PR DESCRIPTION
This pull request fixes [bug #16126](https://bugs.scummvm.org/ticket/16126).

I am opening this as a pull request because there are two possible approaches, the one proposed here, and a much simpler one that is also  closer to what upstream AGS is doing.

## Why does it crash?

When calling `unload_game()` we delete the `GameSetupStruct` stored in `Globals::_game` and recreate it. The issue is that the `SpriteCache` holds a reference to one member of the `GameSetupStruct`, and that reference is no longer valid. In normal circumstances this is not an issue as `unload_game()` is called before closing the game. However in 1213 SE, the SE execuable is a launcher for the 3 episodes. When we start an episode it calls `unload_game()` and then proceeds to load the episode. This accessed the reference to the `GameSetupStruct` variable that was deleted and causes a random crash.

## Change proposed here

In `unload_game()`, after we recreate the `GameSetupStruct`, we need to update the reference in the `SpriteCache` to point to the member in the new `GameSetupStruct`. Since we cannot rebound a reference this also means changing it to a pointer.

## Alternative fix

The original AGS engine does not delete the` GameSetupStruct` in `unload_game()`. Instead it resets it (by assigning an empty `GameSetupStruct` to it). So the reference in the `SpriteCache` remains valid.

We could do the same in ScummVM with this simple change, and it indeed also fixes the crashes:

```diff
- delete _G(game);
- _G(game) = new GameSetupStruct();
+  _GP(game) = GameSetupStruct();
```

## Discussion
I don't remember the reason why we deviated from the upstream AGS here, and are deleting and recreating the `GameState()` and `GameSetupStruct()`. If there was no good reason, then maybe the simpler change would be better to keep our code closer to upstream AGS? 
