### PR TITLE
TEENAGENT: Fix -Wshadow warning for kActionNone appearing in 2 different enums

### DIFF
--- a/engines/teenagent/inventory.cpp
+++ b/engines/teenagent/inventory.cpp
@@ -254,11 +254,11 @@ bool Inventory::processEvent(const Common::Event &event) {
 		return true;
 
 	case Common::EVENT_CUSTOM_ENGINE_ACTION_START:
-		if (_active && event.customType == kActionCloseInventory) {
+		if (_active && event.customType == kActionEventCloseInventory) {
 			activate(false);
 			return true;
 		}
-		if (event.customType == kActionToggleInventory) {
+		if (event.customType == kActionEventToggleInventory) {
 			activate(!_active);
 			return true;
 		}

--- a/engines/teenagent/metaengine.cpp
+++ b/engines/teenagent/metaengine.cpp
@@ -199,7 +199,7 @@ Common::KeymapArray TeenAgentMetaEngine::initKeymaps(const char *target) const {
 	engineKeyMap->addAction(act);
 
 	act = new Common::Action("SKIPDLG", _("Skip dialog"));
-	act->setCustomEngineActionEvent(kActionSkipDialog);
+	act->setCustomEngineActionEvent(kActionEventSkipDialog);
 	act->addDefaultInputMapping("MOUSE_LEFT");
 	act->addDefaultInputMapping("MOUSE_RIGHT");
 	act->addDefaultInputMapping("SPACE");
@@ -207,25 +207,25 @@ Common::KeymapArray TeenAgentMetaEngine::initKeymaps(const char *target) const {
 	engineKeyMap->addAction(act);
 
 	act = new Common::Action("CLOSEINV", _("Close inventory"));
-	act->setCustomEngineActionEvent(kActionCloseInventory);
+	act->setCustomEngineActionEvent(kActionEventCloseInventory);
 	act->addDefaultInputMapping("ESCAPE");
 	engineKeyMap->addAction(act);
 
 	act = new Common::Action("TOGGLEINV", _("Toggle inventory"));
-	act->setCustomEngineActionEvent(kActionToggleInventory);
+	act->setCustomEngineActionEvent(kActionEventToggleInventory);
 	act->addDefaultInputMapping("RETURN");
 	act->addDefaultInputMapping("JOY_X");
 	engineKeyMap->addAction(act);
 
 	act = new Common::Action("SKIPINTRO", _("Skip intro"));
-	act->setCustomEngineActionEvent(kActionSkipIntro);
+	act->setCustomEngineActionEvent(kActionEventSkipIntro);
 	act->addDefaultInputMapping("ESCAPE");
 	act->addDefaultInputMapping("JOY_B");
 	engineKeyMap->addAction(act);
 
 	// I18N: Speeds up the game to twice its normal speed
 	act = new Common::Action("FASTMODE", _("Toggle fast mode"));
-	act->setCustomEngineActionEvent(kActionFastMode);
+	act->setCustomEngineActionEvent(kActionEventFastMode);
 	act->addDefaultInputMapping("C+f");
 	act->addDefaultInputMapping("JOY_UP");
 	engineKeyMap->addAction(act);

--- a/engines/teenagent/scene.cpp
+++ b/engines/teenagent/scene.cpp
@@ -483,7 +483,7 @@ bool Scene::processEvent(const Common::Event &event) {
 	switch (event.type) {
 	case Common::EVENT_CUSTOM_ENGINE_ACTION_START:
 		switch (event.customType) {
-		case kActionSkipIntro:
+		case kActionEventSkipIntro:
 			if (intro) {
 				intro = false;
 				clearMessage();
@@ -500,7 +500,7 @@ bool Scene::processEvent(const Common::Event &event) {
 				return true;
 			}
 			break;
-		case kActionSkipDialog:
+		case kActionEventSkipDialog:
 			if (!message.empty() && messageFirstFrame == 0) {
 				_vm->stopTextToSpeech();
 				clearMessage();

--- a/engines/teenagent/teenagent.cpp
+++ b/engines/teenagent/teenagent.cpp
@@ -655,7 +655,7 @@ Common::Error TeenAgentEngine::run() {
 			debug(5, "event");
 			switch (event.type) {
 			case Common::EVENT_CUSTOM_ENGINE_ACTION_START:
-				if (event.customType == kActionFastMode) {
+				if (event.customType == kActionEventFastMode) {
 					_markDelay = _markDelay == 80 ? 40 : 80;
 					debug(5, "markDelay = %u", _markDelay);
 				}

--- a/engines/teenagent/teenagent.h
+++ b/engines/teenagent/teenagent.h
@@ -80,13 +80,13 @@ enum {
 	kDebugSurface,
 };
 
-enum TEENAGENTActions {
-	kActionNone,
-	kActionSkipIntro,
-	kActionSkipDialog,
-	kActionCloseInventory,
-	kActionToggleInventory,
-	kActionFastMode,
+enum TEENAGENTActionEvents {
+	kActionEventNone,
+	kActionEventSkipIntro,
+	kActionEventSkipDialog,
+	kActionEventCloseInventory,
+	kActionEventToggleInventory,
+	kActionEventFastMode,
 };
 
 const uint16 kScreenWidth = 320;


### PR DESCRIPTION
The title should say it all :) `kActionNone` is defined in two enums in this engine.

I'm seeing this `-Wshadow` warning with Apple clang version 16.0.0. The new enum was introduced in PR #6772.

Opening this as a PR just in case, since the related TTS change was recent. 