### PR TITLE
AUDIO: Add comparison operators to SoundHandle

### DIFF
--- a/audio/mixer.h
+++ b/audio/mixer.h
@@ -50,6 +50,17 @@ class SoundHandle {
 	friend class Channel;
 	friend class MixerImpl;
 	uint32 _val = 0xffffffff;
+
+public:
+	/**
+	 * Determine whether two handles are the same.
+	 */
+	bool  operator==(const SoundHandle &h)    const { return _val == h._val; }
+
+	/**
+	 * Determine whether two handles are not the same.
+	 */
+	bool  operator!=(const SoundHandle &h)    const { return _val != h._val; }
 };
 
 /**


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->

During engine development I used an own `SoundID` type to wrap audio-internal data behind an opaque type which was just an incrementing integer internally. The proper reasons (mostly binary search) for this were made obsolete so I sought to replace my own `SoundID` with the ScummVM-provided `Audio::SoundHandle`. Unfortunately a blocker for this simplification of engine-code was that it is currently not possible to compare `Audio::SoundHandle` instances.

If there are no technical reasons to *not* be able to compare `Audio::SoundHandle` equality I propose these two simple comparison operators.
