### PR TITLE
LASTEXPRESS: Rename PAGE_SIZE macro

### DIFF
--- a/engines/lastexpress/data/archive.cpp
+++ b/engines/lastexpress/data/archive.cpp
@@ -243,13 +243,13 @@ HPF *ArchiveManager::openHPF(const char *filename) {
 void ArchiveManager::readHD(void *dstBuf, int offset, uint32 size) {
 	if (_hdFilePointer && _hdFilePointer->isOpen()) {
 		if (offset != _hdFilePosition) {	
-			if (!_hdFilePointer->seek(offset * PAGE_SIZE, SEEK_SET)) {
+			if (!_hdFilePointer->seek(offset * MEM_PAGE_SIZE, SEEK_SET)) {
 				error("Error seeking in file \"%s\"", "HD cache file");
 			}
 		}
 
-		uint32 readSize = _hdFilePointer->read(dstBuf, size * PAGE_SIZE);
-		if (readSize != size * PAGE_SIZE) {
+		uint32 readSize = _hdFilePointer->read(dstBuf, size * MEM_PAGE_SIZE);
+		if (readSize != size * MEM_PAGE_SIZE) {
 			error("Error reading from file \"%s\"", "HD cache file");
 		}
 
@@ -260,13 +260,13 @@ void ArchiveManager::readHD(void *dstBuf, int offset, uint32 size) {
 void ArchiveManager::readCD(void *dstBuf, int offset, uint32 size) {
 	if (_cdFilePointer && _cdFilePointer->isOpen()) {
 		if (offset != _cdFilePosition) {
-			if (!_cdFilePointer->seek(offset * PAGE_SIZE, SEEK_SET)) {
+			if (!_cdFilePointer->seek(offset * MEM_PAGE_SIZE, SEEK_SET)) {
 				error("Error seeking in file \"%s\"", "CD cache file");
 			}
 		}
 
-		uint32 readSize = _cdFilePointer->read(dstBuf, size * PAGE_SIZE);
-		if (readSize != size * PAGE_SIZE) {
+		uint32 readSize = _cdFilePointer->read(dstBuf, size * MEM_PAGE_SIZE);
+		if (readSize != size * MEM_PAGE_SIZE) {
 			error("Error reading from file \"%s\"", "CD cache file");
 		}
 
@@ -448,7 +448,7 @@ Seq *ArchiveManager::loadSeq(const char *filename, uint8 ticksToWaitUntilCycleRe
 	if (!archive)
 		return nullptr;
 
-	byte *seqDataRaw = (byte *)_engine->getMemoryManager()->allocMem(PAGE_SIZE * archive->size, filename, character);
+	byte *seqDataRaw = (byte *)_engine->getMemoryManager()->allocMem(MEM_PAGE_SIZE * archive->size, filename, character);
 	if (!seqDataRaw)
 		return nullptr;
 
@@ -458,7 +458,7 @@ Seq *ArchiveManager::loadSeq(const char *filename, uint8 ticksToWaitUntilCycleRe
 		_engine->getSoundManager()->soundThread();
 		_engine->getSubtitleManager()->subThread();
 		readHPF(archive, seqDataRawCur, 8);
-		seqDataRawCur += (PAGE_SIZE * 8);
+		seqDataRawCur += (MEM_PAGE_SIZE * 8);
 	}
 
 	readHPF(archive, seqDataRawCur, i);
@@ -469,7 +469,7 @@ Seq *ArchiveManager::loadSeq(const char *filename, uint8 ticksToWaitUntilCycleRe
 	// Again, there is no such thing in the original...
 	seq->rawSeqData = seqDataRaw;
 
-	Common::SeekableReadStream *seqDataStream = new Common::MemoryReadStream(seqDataRaw, PAGE_SIZE * archive->size, DisposeAfterUse::NO);
+	Common::SeekableReadStream *seqDataStream = new Common::MemoryReadStream(seqDataRaw, MEM_PAGE_SIZE * archive->size, DisposeAfterUse::NO);
 
 	seq->numFrames = seqDataStream->readUint32LE();
 	seqDataStream->readUint32LE(); // Empty sprite pointer

--- a/engines/lastexpress/data/gold_archive.cpp
+++ b/engines/lastexpress/data/gold_archive.cpp
@@ -118,7 +118,7 @@ HPF *GoldArchiveManager::openHPF(const char *filename) {
 
 	Common::strcpy_s(result->name, filename);
 	int64 archiveSize = archiveItem.get()->createReadStream()->size();
-	result->size = (uint16)((archiveSize / PAGE_SIZE) + ((archiveSize % PAGE_SIZE) > 0 ? 1 : 0));
+	result->size = (uint16)((archiveSize / MEM_PAGE_SIZE) + ((archiveSize % MEM_PAGE_SIZE) > 0 ? 1 : 0));
 	result->status |= kHPFFileIsLoaded;
 	result->currentPos = 0;
 	result->archiveName = archiveItem.get()->getPathInArchive().toString();
@@ -144,8 +144,8 @@ void GoldArchiveManager::readHPF(HPF *archive, void *dstBuf, uint32 size) {
 
 			Common::SeekableReadStream *readStream = archivePtr->createReadStream();
 
-			readStream->seek((archive->currentPos + archive->offset) * PAGE_SIZE, SEEK_SET);
-			readStream->read(dstBuf, effSize * PAGE_SIZE);
+			readStream->seek((archive->currentPos + archive->offset) * MEM_PAGE_SIZE, SEEK_SET);
+			readStream->read(dstBuf, effSize * MEM_PAGE_SIZE);
 
 			delete readStream;
 
@@ -193,10 +193,10 @@ int GoldArchiveManager::loadBG(const char *filename) {
 		// All these fields are 32-bit LE.
 
 		Image::JPEGDecoder *dec = new Image::JPEGDecoder();
-		byte *backgroundCompBuffer = (byte *)malloc(archive->size * PAGE_SIZE);
+		byte *backgroundCompBuffer = (byte *)malloc(archive->size * MEM_PAGE_SIZE);
 		assert(backgroundCompBuffer);
 		readHPF(archive, backgroundCompBuffer, archive->size);
-		Common::SeekableReadStream *seqDataStream = new Common::MemoryReadStream(backgroundCompBuffer, PAGE_SIZE * archive->size, DisposeAfterUse::YES);
+		Common::SeekableReadStream *seqDataStream = new Common::MemoryReadStream(backgroundCompBuffer, MEM_PAGE_SIZE * archive->size, DisposeAfterUse::YES);
 
 		_engine->getGraphicsManager()->_renderBox1.x = seqDataStream->readUint32LE();
 		_engine->getGraphicsManager()->_renderBox1.y = seqDataStream->readUint32LE();

--- a/engines/lastexpress/game/credits.cpp
+++ b/engines/lastexpress/game/credits.cpp
@@ -388,7 +388,7 @@ int32 LastExpressEngine::readTGAIntoMemory(const char *filename, TGAHeader *tgaH
 	}
 
 	if (_doCredits) {
-		fileSize = archive->size * PAGE_SIZE;
+		fileSize = archive->size * MEM_PAGE_SIZE;
 
 		byte *tgaRawData = (byte *)malloc(fileSize);
 

--- a/engines/lastexpress/game/navigation.cpp
+++ b/engines/lastexpress/game/navigation.cpp
@@ -61,12 +61,12 @@ void LogicManager::loadTrain(int cd) {
 			// fix-ups on it. Since this is not portable we use a more reliable
 			// system.
 
-			byte *trainDataRaw = (byte *)malloc(PAGE_SIZE * archive->size);
+			byte *trainDataRaw = (byte *)malloc(MEM_PAGE_SIZE * archive->size);
 			if (trainDataRaw) {
 				_engine->getArchiveManager()->readHPF(archive, trainDataRaw, archive->size);
 				_engine->getArchiveManager()->closeHPF(archive);
 
-				Common::SeekableReadStream *trainDataStream = new Common::MemoryReadStream(trainDataRaw, PAGE_SIZE * archive->size, DisposeAfterUse::YES);
+				Common::SeekableReadStream *trainDataStream = new Common::MemoryReadStream(trainDataRaw, MEM_PAGE_SIZE * archive->size, DisposeAfterUse::YES);
 
 				// First node
 				trainDataStream->read(_trainData[0].sceneFilename, sizeof(_trainData[0].sceneFilename));

--- a/engines/lastexpress/game/nis.cpp
+++ b/engines/lastexpress/game/nis.cpp
@@ -153,7 +153,7 @@ void NISManager::loadSnd(int32 size) {
 }
 
 int NISManager::loadChunk(int32 size) {
-	int32 sizeToLoad = _totalStreamPages - ((_remainingStreamBytes + 2047) / PAGE_SIZE);
+	int32 sizeToLoad = _totalStreamPages - ((_remainingStreamBytes + 2047) / MEM_PAGE_SIZE);
 
 	if (!_archive || (_archive->status & 2) == 0)
 		return 0;
@@ -184,10 +184,10 @@ int NISManager::loadChunk(int32 size) {
 	if (sizeToLoad + _currentStreamPage >= _totalStreamPages)
 		sizeToLoad = _totalStreamPages - _currentStreamPage;
 
-	_engine->getArchiveManager()->readHPF(_archive, ((byte *)_backgroundSurface + (_currentStreamPage * PAGE_SIZE)), sizeToLoad);
+	_engine->getArchiveManager()->readHPF(_archive, ((byte *)_backgroundSurface + (_currentStreamPage * MEM_PAGE_SIZE)), sizeToLoad);
 
 	_currentStreamPage += sizeToLoad;
-	_remainingStreamBytes += sizeToLoad * PAGE_SIZE;
+	_remainingStreamBytes += sizeToLoad * MEM_PAGE_SIZE;
 
 	if (_currentStreamPage >= _totalStreamPages)
 		_currentStreamPage -= _totalStreamPages;
@@ -214,7 +214,7 @@ bool NISManager::initNIS(const char *filename, int32 flags) {
 	_currentStreamPage = 0;
 	_streamCurrentPosition = 0;
 	_remainingStreamBytes = 0;
-	_streamBufferSize = 1530 * PAGE_SIZE;
+	_streamBufferSize = 1530 * MEM_PAGE_SIZE;
 	_originalBackgroundSurface = _engine->getGraphicsManager()->_frontBuffer;
 	_totalBackgroundPages = 1530;
 	_totalStreamPages = 1530;
@@ -226,7 +226,7 @@ bool NISManager::initNIS(const char *filename, int32 flags) {
 		return false;
 	}
 
-	_engine->getMemoryManager()->lockSeqMem((_totalBackgroundPages - 300) * PAGE_SIZE);
+	_engine->getMemoryManager()->lockSeqMem((_totalBackgroundPages - 300) * MEM_PAGE_SIZE);
 	getStream((byte *)&_eventsCount, 4);
 
 	_eventsCount = READ_LE_INT32(&_eventsCount);
@@ -247,8 +247,8 @@ bool NISManager::initNIS(const char *filename, int32 flags) {
 	_waneSpriteByteStream = (byte *)((byte *)_backgroundSurface + _streamBufferSize);
 	_streamBufferSize -= 8 * _eventsCount;
 	_eventsByteStream = (byte *)((byte *)_backgroundSurface + _streamBufferSize);
-	_totalStreamPages = (_streamBufferSize / PAGE_SIZE);
-	_streamBufferSize = (_streamBufferSize / PAGE_SIZE) * PAGE_SIZE;
+	_totalStreamPages = (_streamBufferSize / MEM_PAGE_SIZE);
+	_streamBufferSize = (_streamBufferSize / MEM_PAGE_SIZE) * MEM_PAGE_SIZE;
 
 	chunkSizeRead = loadChunk(32);
 
@@ -267,7 +267,7 @@ bool NISManager::initNIS(const char *filename, int32 flags) {
 		if (!_events[4].eventSize)
 			break;
 
-		chunkSizeRead = loadChunk(32) * PAGE_SIZE;
+		chunkSizeRead = loadChunk(32) * MEM_PAGE_SIZE;
 
 		if (!chunkSizeRead)
 			break;
@@ -958,9 +958,9 @@ void NISManager::getNISSlot() {
 
 	slot->setCurrentBufferPtr(slot->getSoundBuffer());
 	slot->setDataStart(slot->getSoundBuffer());
-	slot->setDataEnd(slot->getSoundBuffer() + (44 * PAGE_SIZE));
+	slot->setDataEnd(slot->getSoundBuffer() + (44 * MEM_PAGE_SIZE));
 	slot->setCurrentDataPtr(slot->getDataStart() + 6);
-	slot->setSize(44 * PAGE_SIZE);
+	slot->setSize(44 * MEM_PAGE_SIZE);
 }
 
 Slot *NISManager::getChainedSound() {

--- a/engines/lastexpress/lastexpress.h
+++ b/engines/lastexpress/lastexpress.h
@@ -514,7 +514,7 @@ typedef struct NisEvents {
 	}
 } NisEvents;
 
-#define PAGE_SIZE  0x800
+#define MEM_PAGE_SIZE  0x800
 
 #define DEMO_TIMEOUT 2700
 

--- a/engines/lastexpress/memory.cpp
+++ b/engines/lastexpress/memory.cpp
@@ -50,18 +50,18 @@ void MemoryManager::initMem() {
 	// | via allocMem                              |
 	// +-------------------------------------------+
 	//
-	// Each page weighs PAGE_SIZE bytes (0x800 = 2048 bytes = 2 KB).
+	// Each page weighs MEM_PAGE_SIZE bytes (0x800 = 2048 bytes = 2 KB).
 
-	_engine->_globalMemoryPool = (byte *)malloc(1800 * PAGE_SIZE);
-	memset(_engine->_globalMemoryPool, 0, 1800 * PAGE_SIZE);
+	_engine->_globalMemoryPool = (byte *)malloc(1800 * MEM_PAGE_SIZE);
+	memset(_engine->_globalMemoryPool, 0, 1800 * MEM_PAGE_SIZE);
 
 	_engine->getGraphicsManager()->_backBuffer = (PixMap *)malloc(640 * 480 * sizeof(PixMap));
 	_engine->getLogicManager()->_trainData = (Node *)malloc(2048 * sizeof(Node));
-	_engine->_cursorsMemoryPool = (byte *)malloc(49 * PAGE_SIZE);
+	_engine->_cursorsMemoryPool = (byte *)malloc(49 * MEM_PAGE_SIZE);
 	_engine->_characters = new Characters();
 	_engine->getSubtitleManager()->_font = new FontData();
 	_engine->getSubtitleManager()->_subtitlesData = (uint16 *)malloc(0x4400 * sizeof(uint16));
-	_engine->getGraphicsManager()->_backgroundCompBuffer = (byte *)malloc(8 * PAGE_SIZE);
+	_engine->getGraphicsManager()->_backgroundCompBuffer = (byte *)malloc(8 * MEM_PAGE_SIZE);
 	_engine->getLogicManager()->_items = (Item *)malloc(32 * sizeof(Item));
 	_engine->getLogicManager()->_doors = (Door *)malloc(128 * sizeof(Door));
 	_engine->getLogicManager()->_blockedViews = (int32 *)malloc(1000 * sizeof(int32));
@@ -91,14 +91,14 @@ void MemoryManager::initMem() {
 	_engine->getGraphicsManager()->_cursorsDataHeader = (CursorHeader *)_engine->_cursorsMemoryPool;
 	_engine->getGraphicsManager()->_iconsBitmapData = (PixMap *)(_engine->_cursorsMemoryPool + sizeof(CursorHeader) * kCursorMAX);
 	_engine->_soundMemoryPool = _engine->_globalMemoryPool;
-	_engine->getGraphicsManager()->_frontBuffer = (PixMap *)(_engine->_globalMemoryPool + (270 * PAGE_SIZE));
+	_engine->getGraphicsManager()->_frontBuffer = (PixMap *)(_engine->_globalMemoryPool + (270 * MEM_PAGE_SIZE));
 
-	_memoryPages[0].memPageSize = 1230 * PAGE_SIZE;
-	_memoryPages[0].memPagePtr = _engine->_globalMemoryPool + (570 * PAGE_SIZE);
+	_memoryPages[0].memPageSize = 1230 * MEM_PAGE_SIZE;
+	_memoryPages[0].memPagePtr = _engine->_globalMemoryPool + (570 * MEM_PAGE_SIZE);
 	_memoryPages[0].allocatedFlag = 0;
 
 	_nisSeqMemFlag = kMemoryFlagSeqFree | kMemoryFlagInit;
-	_nisSeqMemAvailForLocking = 1230 * PAGE_SIZE;
+	_nisSeqMemAvailForLocking = 1230 * MEM_PAGE_SIZE;
 }
 
 void *MemoryManager::allocMem(uint32 size, const char *name, int character) {
@@ -180,8 +180,8 @@ void MemoryManager::releaseMemory() {
 void MemoryManager::freeFX() {
 	if ((_nisSeqMemFlag & kMemoryFlagFXFree) == 0) {
 		_nisSeqMemFlag |= kMemoryFlagFXFree;
-		_memoryPages[_numAllocatedMemPages - 1].memPageSize += (300 * PAGE_SIZE);
-		_memoryPages[_numAllocatedMemPages - 1].memPagePtr = (byte *)_memoryPages[_numAllocatedMemPages - 1].memPagePtr - (300 * PAGE_SIZE);
+		_memoryPages[_numAllocatedMemPages - 1].memPageSize += (300 * MEM_PAGE_SIZE);
+		_memoryPages[_numAllocatedMemPages - 1].memPagePtr = (byte *)_memoryPages[_numAllocatedMemPages - 1].memPagePtr - (300 * MEM_PAGE_SIZE);
 		_nisSeqMemAvailForLocking += 614400;
 	}
 }
@@ -189,9 +189,9 @@ void MemoryManager::freeFX() {
 void MemoryManager::lockFX() {
 	if ((_nisSeqMemFlag & kMemoryFlagFXFree) != 0) {
 		_nisSeqMemFlag &= ~kMemoryFlagFXFree;
-		_memoryPages[_numAllocatedMemPages - 1].memPageSize -= (300 * PAGE_SIZE);
-		_memoryPages[_numAllocatedMemPages - 1].memPagePtr = (byte *)_memoryPages[_numAllocatedMemPages - 1].memPagePtr + (300 * PAGE_SIZE);
-		_nisSeqMemAvailForLocking -= (300 * PAGE_SIZE);
+		_memoryPages[_numAllocatedMemPages - 1].memPageSize -= (300 * MEM_PAGE_SIZE);
+		_memoryPages[_numAllocatedMemPages - 1].memPagePtr = (byte *)_memoryPages[_numAllocatedMemPages - 1].memPagePtr + (300 * MEM_PAGE_SIZE);
+		_nisSeqMemAvailForLocking -= (300 * MEM_PAGE_SIZE);
 	}
 }
 

--- a/engines/lastexpress/sound/slot.cpp
+++ b/engines/lastexpress/sound/slot.cpp
@@ -518,16 +518,16 @@ void Slot::devirtualize() {
 				_size = 0x16000;
 				_currentDataPtr = &_dataStart[chunkSize & 0x7FF];
 				_loadedBytes = chunkSize & 0xFFFF800;
-				diff = (_archive->size * PAGE_SIZE) - (chunkSize & 0xFFFF800);
+				diff = (_archive->size * MEM_PAGE_SIZE) - (chunkSize & 0xFFFF800);
 
 				if (diff <= 0x15800) {
-					pagesToRead = (diff + 2047) / PAGE_SIZE;
+					pagesToRead = (diff + 2047) / MEM_PAGE_SIZE;
 				} else {
 					pagesToRead = 43;
 					_statusFlags |= (kSoundFlagCyclicBuffer | kSoundFlagHasUnreadData);
 				}
 
-				_engine->getArchiveManager()->seekHPF(_archive, chunkSize / PAGE_SIZE);
+				_engine->getArchiveManager()->seekHPF(_archive, chunkSize / MEM_PAGE_SIZE);
 				_engine->getArchiveManager()->readHPF(_archive, _soundBuffer, pagesToRead);
 				if (_archive->size <= _archive->currentPos) {
 					_engine->getArchiveManager()->closeHPF(_archive);
@@ -536,8 +536,8 @@ void Slot::devirtualize() {
 					_loadedBytes = 4;
 				}
 
-				_loadedBytes += pagesToRead * PAGE_SIZE;
-				_currentBufferPtr = &_soundBuffer[pagesToRead * PAGE_SIZE];
+				_loadedBytes += pagesToRead * MEM_PAGE_SIZE;
+				_currentBufferPtr = &_soundBuffer[pagesToRead * MEM_PAGE_SIZE];
 				_statusFlags &= ~(kSoundFlagMute | kSoundFlagPaused | kSoundFlagPauseRequested);
 			} else {
 				for (i = _soundMan->_soundCache; i; i = i->_next) {
@@ -582,7 +582,7 @@ bool Slot::load(const char *filename) {
 					_dataEnd = _dataStart + 0x16000;
 				} else {
 					_engine->getArchiveManager()->readHPF(_archive, _soundBuffer, _archive->size);
-					_loadedBytes = _archive->size * PAGE_SIZE;
+					_loadedBytes = _archive->size * MEM_PAGE_SIZE;
 					_engine->getArchiveManager()->closeHPF(_archive);
 					_archive = nullptr;
 					_loadedBytes = 6;
@@ -598,7 +598,7 @@ bool Slot::load(const char *filename) {
 
 				return true;
 			} else {
-				_size = _archive->size * PAGE_SIZE;
+				_size = _archive->size * MEM_PAGE_SIZE;
 				if (_size > 0x16000)
 					_statusFlags |= (kSoundFlagCyclicBuffer | kSoundFlagHasUnreadData);
 
@@ -632,7 +632,7 @@ void Slot::stream() {
 					if (numPages > _size)
 						numPages = 0;
 
-					numBytes = numPages / PAGE_SIZE;
+					numBytes = numPages / MEM_PAGE_SIZE;
 
 					if (numBytes > 16) {
 						if (_archive->size - _archive->currentPos <= numBytes) {

--- a/engines/lastexpress/sound/subtitle.cpp
+++ b/engines/lastexpress/sound/subtitle.cpp
@@ -110,7 +110,7 @@ void Subtitle::load() {
 		_engine->getArchiveManager()->readHPF(archive, _engine->getSubtitleManager()->_subtitlesData, archive->size);
 		_engine->getArchiveManager()->closeHPF(archive);
 
-		for (int i = 0; i < (archive->size * PAGE_SIZE) / 2; i++) {
+		for (int i = 0; i < (archive->size * MEM_PAGE_SIZE) / 2; i++) {
 			_engine->getSubtitleManager()->_subtitlesData[i] = READ_LE_UINT16(&_engine->getSubtitleManager()->_subtitlesData[i]);
 		}
 
@@ -194,13 +194,13 @@ void SubtitleManager::initSubtitles() {
 			_font->fontData = nullptr;
 		}
 
-		byte *fontData = (byte *)malloc(PAGE_SIZE * archive->size);
+		byte *fontData = (byte *)malloc(MEM_PAGE_SIZE * archive->size);
 
 		if (fontData) {
 			_engine->getArchiveManager()->readHPF(archive, fontData, archive->size);
 			_engine->getArchiveManager()->closeHPF(archive);
 
-			Common::MemoryReadStream *fontStream = new Common::MemoryReadStream(fontData, PAGE_SIZE * archive->size, DisposeAfterUse::YES);
+			Common::MemoryReadStream *fontStream = new Common::MemoryReadStream(fontData, MEM_PAGE_SIZE * archive->size, DisposeAfterUse::YES);
 
 			for (int i = 0; i < 16; i++) {
 				_font->palette[i] = fontStream->readUint16LE();
@@ -214,7 +214,7 @@ void SubtitleManager::initSubtitles() {
 				_font->charKerning[i] = fontStream->readByte();
 			}
 
-			uint32 sizeOfData = PAGE_SIZE * archive->size - (16 * sizeof(uint16) + 256 + 256);
+			uint32 sizeOfData = MEM_PAGE_SIZE * archive->size - (16 * sizeof(uint16) + 256 + 256);
 			_font->fontData = (byte *)malloc(sizeOfData);
 
 			assert(_font->fontData);


### PR DESCRIPTION
This renames `PAGE_SIZE` to `LASTEXPRESS_PAGE_SIZE` to resolve a compiler warning.

`PAGE_SIZE` is already defined by 
- c standard libraries (some? most? at least [musl](https://github.com/kraj/musl/blob/0784374d561435f7c787a555aeab8ede699ed298/include/limits.h#L97) does which is how I discovered this)
- linux kernel headers as well, but that's probably not an issue here

Generally not a huge issue (as we don't use this macro in any backend), but I thought it might be nice to resolve. This is currently the only warning I get when building emscripten with `--disable-all-engines`. 