### PR TITLE
SDL: EMSCRIPTEN: SDL3 bug fixes and use SDL3 for emscripten backend

### DIFF
--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -236,7 +236,11 @@ protected:
 	};
 
 	struct TouchFinger {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		SDL_FingerID id = 0; // 0: no touch
+#else 
 		int id = -1; // -1: no touch
+#endif
 		uint32 timeLastDown = 0;
 		int lastX = 0; // last known screen coordinates
 		int lastY = 0; // last known screen coordinates

--- a/backends/plugins/sdl/sdl-provider.cpp
+++ b/backends/plugins/sdl/sdl-provider.cpp
@@ -32,10 +32,19 @@
 
 class SDLPlugin : public DynamicPlugin {
 protected:
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	SDL_SharedObject *_dlHandle;
+#else
 	void *_dlHandle;
+#endif
 
 	virtual VoidFunc findSymbol(const char *symbol) {
-		void *func = SDL_LoadFunction(_dlHandle, symbol);
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+		SDL_FunctionPointer func;
+#else
+		void *func ;
+#endif
+		func = SDL_LoadFunction(_dlHandle, symbol);
 		if (!func)
 			warning("Failed loading symbol '%s' from plugin '%s' (%s)", symbol, _filename.toString(Common::Path::kNativeSeparator).c_str(), SDL_GetError());
 

--- a/configure
+++ b/configure
@@ -3275,9 +3275,21 @@ EOF
 			append_var LDFLAGS "-O3"
 		fi
 
-		# activate emscripten-ports
-		if test "$_sdl" != no; then # we enable SDL2 by default
-			append_var LDFLAGS "-s USE_SDL=2 "
+		# enable SDL3 and set it up correctly
+		if test "$_dynamic_modules" = "yes" ; then
+			embuilder build sdl3 --pic 
+		else
+			embuilder build sdl3
+		fi
+		_pkg_config=yes
+		PKG_CONFIG_LIBDIR="$EMSDK/upstream/emscripten/cache/sysroot/local/lib/pkgconfig:$EMSDK/upstream/emscripten/cache/sysroot/lib/pkgconfig"
+		_sdlconfig="pkg-config sdl3"
+		_sdlversion=`$_sdlconfig --modversion`
+		append_var SDL_CFLAGS "`$_sdlconfig --cflags | sed 's/[[:space:]]*-Dmain=SDL_main//g'`"
+		if test "$_static_build" = yes ; then
+			append_var SDL_LIBS "`$_sdlconfig --static-libs`"
+		else
+			append_var SDL_LIBS "`$_sdlconfig --libs`"
 		fi
 
 		# We explicitly disable optional libraries if not enabled. "auto" would depend
@@ -3630,7 +3642,7 @@ if test -n "$_host"; then
 			_strip=$_host-strip
 			;;
 		wasm*-emscripten)
-			_backend="sdl"
+			_backend="emscripten"
 			# Disable cloud and SDL_Net as this is handled in the browser
 			_cloud=no
 			_sdlnet=no
@@ -4122,6 +4134,10 @@ case $_backend in
 		;;
 	ds)
 		append_var INCLUDES '-I$(srcdir)/backends/platform/ds'
+		;;
+	emscripten)
+		_sdl=yes
+		append_var MODULES "backends/platform/sdl"
 		;;
 	ios7)
 		append_var LIBS "-lobjc -framework UIKit -framework CoreGraphics -framework OpenGLES"
@@ -4658,7 +4674,7 @@ fi
 # Enable 16bit support only for backends which support it
 #
 case $_backend in
-	3ds | android | dc | ds | ios7 | kolibrios | maemo | null | opendingux | miyoomini | miyoo | openpandora | psp | psp2 | sailfish | samsungtv | sdl | switch | wii)
+	3ds | android | dc | ds | emscripten |ios7 | kolibrios | maemo | null | opendingux | miyoomini | miyoo | openpandora | psp | psp2 | sailfish | samsungtv | sdl | switch | wii)
 		if test "$_16bit" = auto ; then
 			_16bit=yes
 		else
@@ -4694,7 +4710,7 @@ esac
 # Enable Event Recorder only for backends that support it
 #
 case $_backend in
-	sdl)
+	sdl | emscripten)
 		;;
 	*)
 		_eventrec=no
@@ -6499,6 +6515,11 @@ if test "$_opengl_mode" != none ; then
 			_opengl_mode=gles2
 			_opengl_glad=yes
 			;;
+		emscripten)
+			_opengl_mode=gles2
+			_opengl_glad=no # https://github.com/Dav1dde/glad-web/issues/12
+			append_var OPENGL_LIBS "-s FULL_ES2=1 -s MAX_WEBGL_VERSION=1"
+			;;
 		ios7)
 			_opengl_mode=gles2
 			_opengl_glad=yes
@@ -6526,11 +6547,6 @@ if test "$_opengl_mode" != none ; then
 					case $_host_os in
 						darwin*)
 							_opengl_mode=gl
-							;;
-						emscripten)
-							_opengl_mode=gles2
-							_opengl_glad=no # https://github.com/Dav1dde/glad-web/issues/12
-							append_var OPENGL_LIBS "-s FULL_ES2=1 -s MAX_WEBGL_VERSION=1"
 							;;
 						*)
 							# As SDL2 supports everything, let the user choose if he wants to
@@ -6935,7 +6951,7 @@ echocheck "ImGui"
 if test "$_imgui" != no ; then
 	if test "$_freetype2" = yes ; then
 		case $_backend in
-			sdl | sailfish)
+			sdl | sailfish | emscripten)
 				if test "$_sdlMajorVersionNumber" -ge 3 ; then
 					cat > $TMPC << EOF
 #include <SDL3/SDL.h>


### PR DESCRIPTION
This changes four things:

- Add emscripten backend to configure (to setup SDL3 manually)
- Fix `SDLPlugin` by using the correct types (doesn't compile currently with SDL3)
- Touch Events: Converting `SDL_FingerID` to `int` (in SDL2 it was signed, in SDL3 it's unsigned) to avoid an issue where on iOS devices the `id` turned negative (which we use to indicate that a finger isn't down anymore)
- Touch Events: Converting SDL3 nanosecond timestamps to milliseconds as that's what scummvm uses everywhere. This resolves an issue where simulated keypresses where not triggered as a difference between a (truncated from 64bit) uint32 and uint64 timestamp was calculated to determine the duration of a tap, as well as double clicks not being detected correctly either.