### PR TITLE
ALCACHOFA: Initial engine merge

### DIFF
--- a/engines/alcachofa/alcachofa.cpp
+++ b/engines/alcachofa/alcachofa.cpp
@@ -84,6 +84,7 @@ Common::Error AlcachofaEngine::run() {
 	_globalUI.reset(new GlobalUI());
 	_menu.reset(new Menu());
 	setMillis(0);
+	game().onLoadedGameFiles();
 
 	if (!tryLoadFromLauncher()) {
 		_script->createProcess(MainCharacterKind::None, "CREDITOS_INICIALES");
@@ -131,6 +132,11 @@ Common::Error AlcachofaEngine::run() {
 }
 
 void AlcachofaEngine::playVideo(int32 videoId) {
+	if (game().isKnownBadVideo(videoId)) {
+		warning("Skipping known bad video %d", videoId);
+		return;
+	}
+
 	// Video files are either MPEG PS or AVI
 	FakeLock lock("playVideo", _eventLoopSemaphore);
 	File *file = new File();

--- a/engines/alcachofa/alcachofa.cpp
+++ b/engines/alcachofa/alcachofa.cpp
@@ -213,4 +213,27 @@ Common::Error AlcachofaEngine::syncGame(Common::Serializer &s) {
 	return Common::kNoError;
 }
 
+Config::Config() {
+	loadFromScummVM();
+}
+
+void Config::loadFromScummVM() {
+	_musicVolume = (uint8)CLIP(ConfMan.getInt("music_volume"), 0, 255);
+	_speechVolume = (uint8)CLIP(ConfMan.getInt("speech_volume"), 0, 255);
+	_subtitles = ConfMan.getBool("subtitles");
+	_highQuality = ConfMan.getBool("high_quality");
+	_bits32 = ConfMan.getBool("32_bits");
+}
+
+void Config::saveToScummVM() {
+	ConfMan.setBool("subtitles", _subtitles);
+	ConfMan.setBool("high_quality", _highQuality);
+	ConfMan.setBool("32_bits", _bits32);
+	ConfMan.setInt("music_volume", _musicVolume);
+	ConfMan.setInt("speech_volume", _speechVolume);
+	ConfMan.setInt("sfx_volume", _speechVolume);
+	// ^ a bit unfortunate, that means if you change in-game it overrides.
+	// if you set it in ScummVMs dialog it sticks
+}
+
 } // End of namespace Alcachofa

--- a/engines/alcachofa/alcachofa.cpp
+++ b/engines/alcachofa/alcachofa.cpp
@@ -427,4 +427,33 @@ void Config::saveToScummVM() {
 	// if you set it in ScummVMs dialog it sticks
 }
 
+DelayTask::DelayTask(Process &process, uint32 millis)
+	: Task(process)
+	, _endTime(millis) {}
+
+DelayTask::DelayTask(Process &process, Serializer &s)
+	: Task(process) {
+	syncGame(s);
+}
+
+TaskReturn DelayTask::run() {
+	TASK_BEGIN;
+	_endTime += g_engine->getMillis();
+	while (g_engine->getMillis() < _endTime)
+		TASK_YIELD(1);
+	TASK_END;
+}
+
+void DelayTask::debugPrint() {
+	uint32 remaining = g_engine->getMillis() <= _endTime ? _endTime - g_engine->getMillis() : 0;
+	g_engine->getDebugger()->debugPrintf("Delay for further %ums\n", remaining);
+}
+
+void DelayTask::syncGame(Serializer &s) {
+	Task::syncGame(s);
+	s.syncAsUint32LE(_endTime);
+}
+
+DECLARE_TASK(DelayTask)
+
 } // End of namespace Alcachofa

--- a/engines/alcachofa/alcachofa.cpp
+++ b/engines/alcachofa/alcachofa.cpp
@@ -173,6 +173,7 @@ void AlcachofaEngine::fadeExit() {
 	Graphics::FrameLimiter limiter(g_system, kDefaultFramerate, false);
 	uint32 startTime = g_system->getMillis();
 
+	Room *room = g_engine->player().currentRoom();
 	_renderer->end(); // we were in a frame, let's exit
 	while (g_system->getMillis() - startTime < kFadeOutDuration && !shouldQuit()) {
 		_input.nextFrame();
@@ -184,12 +185,14 @@ void AlcachofaEngine::fadeExit() {
 		_renderer->begin();
 		_drawQueue->clear();
 		float t = ((float)(g_system->getMillis() - startTime)) / kFadeOutDuration;
-		// TODO: Implement cross-fade and add to fadeExit
+		if (room != nullptr)
+			room->draw();
 		_drawQueue->add<FadeDrawRequest>(FadeType::ToBlack, t, -kForegroundOrderCount);
 		_drawQueue->draw();
 		_renderer->end();
 
 		limiter.delayBeforeSwap();
+		g_system->updateScreen();
 		limiter.startFrame();
 	}
 

--- a/engines/alcachofa/alcachofa.cpp
+++ b/engines/alcachofa/alcachofa.cpp
@@ -123,7 +123,7 @@ Common::Error AlcachofaEngine::run() {
 }
 
 void AlcachofaEngine::playVideo(int32 videoId) {
-	FakeLock lock(_eventLoopSemaphore);
+	FakeLock lock("playVideo", _eventLoopSemaphore);
 	Video::MPEGPSDecoder decoder;
 	if (!decoder.loadFile(Common::Path(Common::String::format("Data/DATA%02d.BIN", videoId + 1))))
 		error("Could not find video %d", videoId);
@@ -162,7 +162,7 @@ void AlcachofaEngine::playVideo(int32 videoId) {
 
 void AlcachofaEngine::fadeExit() {
 	constexpr uint kFadeOutDuration = 1000;
-	FakeLock lock(_eventLoopSemaphore);
+	FakeLock lock("fadeExit", _eventLoopSemaphore);
 	Event e;
 	Graphics::FrameLimiter limiter(g_system, kDefaultFramerate, false);
 	uint32 startTime = g_system->getMillis();

--- a/engines/alcachofa/alcachofa.cpp
+++ b/engines/alcachofa/alcachofa.cpp
@@ -164,8 +164,7 @@ void AlcachofaEngine::playVideo(int32 videoId) {
 	Common::Event e;
 	decoder->start();
 	while (!decoder->endOfVideo() && !shouldQuit()) {
-		if (decoder->needsUpdate())
-		{
+		if (decoder->needsUpdate()) {
 			auto surface = decoder->decodeNextFrame();
 			if (surface)
 				texture->update(*surface);
@@ -225,8 +224,7 @@ void AlcachofaEngine::fadeExit() {
 }
 
 void AlcachofaEngine::setDebugMode(DebugMode mode, int32 param) {
-	switch (mode)
-	{
+	switch (mode) {
 	case DebugMode::ClosestFloorPoint:
 		_debugHandler.reset(new ClosestFloorPointDebugHandler(param));
 		break;
@@ -242,7 +240,9 @@ void AlcachofaEngine::setDebugMode(DebugMode mode, int32 param) {
 	case DebugMode::FloorColor:
 		_debugHandler.reset(FloorColorDebugHandler::create(param, true));
 		break;
-	default: _debugHandler.reset(nullptr);
+	default:
+		_debugHandler.reset(nullptr);
+		break;
 	}
 	_input.toggleDebugInput(isDebugModeActive());
 }
@@ -259,8 +259,7 @@ void AlcachofaEngine::setMillis(uint32 newMillis) {
 	if (newMillis > sysMillis) {
 		_timeNegOffset = 0;
 		_timePosOffset = newMillis - sysMillis;
-	}
-	else {
+	} else {
 		_timeNegOffset = sysMillis - newMillis;
 		_timePosOffset = 0;
 	}
@@ -342,13 +341,12 @@ bool AlcachofaEngine::syncThumbnail(MySerializer &s, Graphics::ManagedSurface *t
 	if (s.isLoading()) {
 		auto prevPosition = s.readStream().pos();
 		Image::PNGDecoder pngDecoder;
-		if (pngDecoder.loadStream(s.readStream()) && pngDecoder.getSurface () != nullptr) {
+		if (pngDecoder.loadStream(s.readStream()) && pngDecoder.getSurface() != nullptr) {
 			if (thumbnail != nullptr) {
 				thumbnail->free();
 				thumbnail->copyFrom(*pngDecoder.getSurface());
 			}
-		}
-		else {
+		} else {
 			// If we do not get a thumbnail, maybe we get at least the marker that there is no thumbnail
 			s.readStream().seek(prevPosition, SEEK_SET);
 			uint32 magicValue = s.readStream().readUint32LE();
@@ -357,8 +355,7 @@ bool AlcachofaEngine::syncThumbnail(MySerializer &s, Graphics::ManagedSurface *t
 			else // this is not an error, just a pity
 				warning("No thumbnail stored in in-game savestate");
 		}
-	}
-	else {
+	} else {
 		if (thumbnail == nullptr ||
 			thumbnail->getPixels() == nullptr ||
 			!Image::writePNG(s.writeStream(), *thumbnail)) {

--- a/engines/alcachofa/alcachofa.cpp
+++ b/engines/alcachofa/alcachofa.cpp
@@ -211,10 +211,9 @@ void AlcachofaEngine::fadeExit() {
 		_renderer->begin();
 		_drawQueue->clear();
 		float t = ((float)(g_system->getMillis() - startTime)) / kFadeOutDuration;
-		if (room != nullptr)
-			room->draw();
 		_drawQueue->add<FadeDrawRequest>(FadeType::ToBlack, t, -kForegroundOrderCount);
-		_drawQueue->draw();
+		if (room != nullptr)
+			room->draw(); // this executes the drawQueue as well
 		_renderer->end();
 
 		limiter.delayBeforeSwap();
@@ -390,8 +389,7 @@ void AlcachofaEngine::getSavegameThumbnail(Graphics::Surface &thumbnail) {
 	g_engine->drawQueue().clear();
 	g_engine->renderer().begin();
 	g_engine->renderer().setOutput(thumbnail);
-	g_engine->player().currentRoom()->draw();
-	g_engine->drawQueue().draw();
+	g_engine->player().currentRoom()->draw(); // drawQueue is drawn here as well
 	g_engine->renderer().end();
 
 	// we should be within the event loop. as such it is quite safe to mess with the drawQueue or renderer

--- a/engines/alcachofa/alcachofa.cpp
+++ b/engines/alcachofa/alcachofa.cpp
@@ -19,7 +19,6 @@
  *
  */
 
-#include "common/scummsys.h"
 #include "common/config-manager.h"
 #include "common/debug-channels.h"
 #include "common/events.h"

--- a/engines/alcachofa/alcachofa.cpp
+++ b/engines/alcachofa/alcachofa.cpp
@@ -395,8 +395,7 @@ bool AlcachofaEngine::tryLoadFromLauncher() {
 	int saveSlot = ConfMan.getInt("save_slot");
 	if (!ConfMan.hasKey("save_slot") || saveSlot < 0)
 		return false;
-	auto *saveFileMgr = g_system->getSavefileManager();
-	auto *saveFile = saveFileMgr->openForLoading(getSaveStateName(saveSlot));
+	auto *saveFile = g_system->getSavefileManager()->openForLoading(getSaveStateName(saveSlot));
 	if (saveFile == nullptr)
 		return false;
 	bool result = loadGameStream(saveFile).getCode() == kNoError;

--- a/engines/alcachofa/alcachofa.cpp
+++ b/engines/alcachofa/alcachofa.cpp
@@ -31,6 +31,7 @@
 #include "video/mpegps_decoder.h"
 
 #include "alcachofa.h"
+#include "metaengine.h"
 #include "console.h"
 #include "detection.h"
 #include "player.h"
@@ -94,6 +95,9 @@ Common::Error AlcachofaEngine::run() {
 		while (g_system->getEventManager()->pollEvent(e)) {
 			if (_input.handleEvent(e))
 				continue;
+			if (e.type == EVENT_CUSTOM_ENGINE_ACTION_START &&
+				e.customType == (CustomEventType)EventAction::LoadFromMenu)
+				menu().triggerLoad();
 		}
 
 		_sounds.update();
@@ -246,6 +250,10 @@ bool AlcachofaEngine::canLoadGameStateCurrently(U32String *msg) {
 	return
 		(menu().isOpen() && menu().interactionSemaphore().isReleased()) ||
 		player().isAllowedToOpenMenu();
+}
+
+Common::String AlcachofaEngine::getSaveStatePattern() {
+	return getMetaEngine()->getSavegameFilePattern(_targetName.c_str());
 }
 
 Common::Error AlcachofaEngine::syncGame(Serializer &s) {

--- a/engines/alcachofa/alcachofa.cpp
+++ b/engines/alcachofa/alcachofa.cpp
@@ -33,17 +33,17 @@
 #include "video/avi_decoder.h"
 #include "video/mpegps_decoder.h"
 
-#include "alcachofa.h"
-#include "metaengine.h"
-#include "console.h"
-#include "detection.h"
-#include "player.h"
-#include "rooms.h"
-#include "script.h"
-#include "global-ui.h"
-#include "menu.h"
-#include "debug.h"
-#include "game.h"
+#include "alcachofa/alcachofa.h"
+#include "alcachofa/metaengine.h"
+#include "alcachofa/console.h"
+#include "alcachofa/detection.h"
+#include "alcachofa/player.h"
+#include "alcachofa/rooms.h"
+#include "alcachofa/script.h"
+#include "alcachofa/global-ui.h"
+#include "alcachofa/menu.h"
+#include "alcachofa/debug.h"
+#include "alcachofa/game.h"
 
 using namespace Math;
 

--- a/engines/alcachofa/alcachofa.cpp
+++ b/engines/alcachofa/alcachofa.cpp
@@ -242,18 +242,20 @@ Common::Error AlcachofaEngine::syncGame(Serializer &s) {
 		setMillis(millis);
 
 	/* Some notes about the order:
-	 * 1. The scheduler should come first due to our FakeSemaphore
+	 * 1. The scheduler should prepare due to our FakeSemaphores
 	 *    By destructing all previous processes we also release all locks and
 	 *    can assert that the semaphores are released on loading.
-	 * 2. The player should come last as it changes the room
+	 * 2. The player should come late as it changes the room
+	 * 3. With the room current, the tasks can now better find the referenced objects
 	 */
 
-	//scheduler().syncGame(s);
+	scheduler().prepareSyncGame(s);
 	world().syncGame(s);
 	camera().syncGame(s);
 	script().syncGame(s);
 	globalUI().syncGame(s);
 	player().syncGame(s);
+	scheduler().syncGame(s);
 
 	if (s.isLoading()) {
 		sounds().stopAll();

--- a/engines/alcachofa/alcachofa.cpp
+++ b/engines/alcachofa/alcachofa.cpp
@@ -53,7 +53,6 @@ AlcachofaEngine *g_engine;
 AlcachofaEngine::AlcachofaEngine(OSystem *syst, const ADGameDescription *gameDesc)
 	: Engine(syst)
 	, _gameDescription(gameDesc)
-	, _randomSource("Alcachofa")
 	, _eventLoopSemaphore("engine") {
 	g_engine = this;
 }

--- a/engines/alcachofa/alcachofa.h
+++ b/engines/alcachofa/alcachofa.h
@@ -83,9 +83,6 @@ private:
 };
 
 class AlcachofaEngine : public Engine {
-private:
-	const ADGameDescription *_gameDescription;
-	Common::RandomSource _randomSource;
 protected:
 	// Engine APIs
 	Common::Error run() override;
@@ -117,18 +114,7 @@ public:
 	void setDebugMode(DebugMode debugMode, int32 param);
 
 	uint32 getFeatures() const;
-
-	/**
-	 * Returns the game Id
-	 */
 	Common::String getGameId() const;
-
-	/**
-	 * Gets a random number
-	 */
-	uint32 getRandomNumber(uint maxNum) {
-		return _randomSource.getRandomNumber(maxNum);
-	}
 
 	bool hasFeature(EngineFeature f) const override {
 		return
@@ -156,6 +142,7 @@ public:
 private:
 	bool tryLoadFromLauncher();
 
+	const ADGameDescription *_gameDescription;
 	Console *_console = new Console();
 	Common::ScopedPtr<IDebugHandler> _debugHandler;
 	Common::ScopedPtr<IRenderer> _renderer;

--- a/engines/alcachofa/alcachofa.h
+++ b/engines/alcachofa/alcachofa.h
@@ -51,6 +51,7 @@ class DrawQueue;
 class World;
 class Script;
 class GlobalUI;
+class Menu;
 class Game;
 struct AlcachofaGameDescription;
 
@@ -74,12 +75,14 @@ public:
 	inline World &world() { return *_world; }
 	inline Script &script() { return *_script; }
 	inline GlobalUI &globalUI() { return *_globalUI; }
+	inline Menu &menu() { return *_menu; }
 	inline Scheduler &scheduler() { return _scheduler; }
 	inline Console &console() { return *_console; }
 	inline Game &game() { return *_game; }
 	inline bool isDebugModeActive() const { return _debugHandler != nullptr; }
 
 	void playVideo(int32 videoId);
+	void fadeExit();
 	void setDebugMode(DebugMode debugMode, int32 param);
 
 	uint32 getFeatures() const;
@@ -134,6 +137,7 @@ private:
 	Common::ScopedPtr<Script> _script;
 	Common::ScopedPtr<Player> _player;
 	Common::ScopedPtr<GlobalUI> _globalUI;
+	Common::ScopedPtr<Menu> _menu;
 	Common::ScopedPtr<Game> _game;
 	Camera _camera;
 	Input _input;

--- a/engines/alcachofa/alcachofa.h
+++ b/engines/alcachofa/alcachofa.h
@@ -105,6 +105,9 @@ public:
 	inline Config &config() { return _config; }
 	inline bool isDebugModeActive() const { return _debugHandler != nullptr; }
 
+	uint32 getMillis() const;
+	void setMillis(uint32 newMillis);
+	virtual void pauseEngineIntern(bool pause);
 	void playVideo(int32 videoId);
 	void fadeExit();
 	void setDebugMode(DebugMode debugMode, int32 param);
@@ -168,6 +171,9 @@ private:
 	Sounds _sounds;
 	Scheduler _scheduler;
 	Config _config;
+
+	uint32 _timeNegOffset = 0, _timePosOffset = 0;
+	uint32 _timeBeforePause = 0;
 };
 
 extern AlcachofaEngine *g_engine;

--- a/engines/alcachofa/alcachofa.h
+++ b/engines/alcachofa/alcachofa.h
@@ -55,6 +55,10 @@ class Menu;
 class Game;
 struct AlcachofaGameDescription;
 
+enum class SaveVersion : Common::Serializer::Version {
+	Initial = 0
+};
+
 class Config {
 public:
 	Config();
@@ -140,12 +144,7 @@ public:
 		return true;
 	}
 
-	/**
-	 * Uses a serializer to allow implementing savegame
-	 * loading and saving using a single method
-	 */
 	Common::Error syncGame(Common::Serializer &s);
-
 	Common::Error saveGameStream(Common::WriteStream *stream, bool isAutosave = false) override {
 		Common::Serializer s(nullptr, stream);
 		return syncGame(s);

--- a/engines/alcachofa/alcachofa.h
+++ b/engines/alcachofa/alcachofa.h
@@ -22,7 +22,6 @@
 #ifndef ALCACHOFA_H
 #define ALCACHOFA_H
 
-#include "common/scummsys.h"
 #include "common/system.h"
 #include "common/error.h"
 #include "common/fs.h"

--- a/engines/alcachofa/alcachofa.h
+++ b/engines/alcachofa/alcachofa.h
@@ -112,6 +112,7 @@ public:
 	AlcachofaEngine(OSystem *syst, const ADGameDescription *gameDesc);
 	~AlcachofaEngine() override;
 
+	inline const ADGameDescription &gameDescription() const { return *_gameDescription; }
 	inline IRenderer &renderer() { return *_renderer; }
 	inline DrawQueue &drawQueue() { return *_drawQueue; }
 	inline Camera &camera() { return _camera; }

--- a/engines/alcachofa/alcachofa.h
+++ b/engines/alcachofa/alcachofa.h
@@ -142,6 +142,7 @@ public:
 		return canLoadGameStateCurrently(msg);
 	}
 
+	Common::String getSaveStatePattern();
 	Common::Error syncGame(Common::Serializer &s);
 	Common::Error saveGameStream(Common::WriteStream *stream, bool isAutosave = false) override {
 		Common::Serializer s(nullptr, stream);

--- a/engines/alcachofa/alcachofa.h
+++ b/engines/alcachofa/alcachofa.h
@@ -138,9 +138,11 @@ public:
 	};
 
 	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override {
+		// TODO: Implement
 		return true;
 	}
 	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override {
+		// TODO: Implement
 		return true;
 	}
 
@@ -155,6 +157,8 @@ public:
 	}
 
 private:
+	bool tryLoadFromLauncher();
+
 	Console *_console = new Console();
 	Common::ScopedPtr<IDebugHandler> _debugHandler;
 	Common::ScopedPtr<IRenderer> _renderer;

--- a/engines/alcachofa/alcachofa.h
+++ b/engines/alcachofa/alcachofa.h
@@ -130,7 +130,7 @@ public:
 
 	uint32 getMillis() const;
 	void setMillis(uint32 newMillis);
-	virtual void pauseEngineIntern(bool pause);
+	void pauseEngineIntern(bool pause) override;
 	void playVideo(int32 videoId);
 	void fadeExit();
 	void setDebugMode(DebugMode debugMode, int32 param);

--- a/engines/alcachofa/alcachofa.h
+++ b/engines/alcachofa/alcachofa.h
@@ -55,6 +55,29 @@ class Menu;
 class Game;
 struct AlcachofaGameDescription;
 
+class Config {
+public:
+	Config();
+
+	inline bool &subtitles() { return _subtitles; }
+	inline bool &highQuality() { return _highQuality; }
+	inline bool &bits32() { return _bits32; }
+	inline uint8 &musicVolume() { return _musicVolume; }
+	inline uint8 &speechVolume() { return _speechVolume; }
+
+	void loadFromScummVM();
+	void saveToScummVM();
+
+private:
+	bool
+		_subtitles = true,
+		_highQuality = true,
+		_bits32 = true;
+	uint8
+		_musicVolume = 255,
+		_speechVolume = 255;
+};
+
 class AlcachofaEngine : public Engine {
 private:
 	const ADGameDescription *_gameDescription;
@@ -79,6 +102,7 @@ public:
 	inline Scheduler &scheduler() { return _scheduler; }
 	inline Console &console() { return *_console; }
 	inline Game &game() { return *_game; }
+	inline Config &config() { return _config; }
 	inline bool isDebugModeActive() const { return _debugHandler != nullptr; }
 
 	void playVideo(int32 videoId);
@@ -143,6 +167,7 @@ private:
 	Input _input;
 	Sounds _sounds;
 	Scheduler _scheduler;
+	Config _config;
 };
 
 extern AlcachofaEngine *g_engine;

--- a/engines/alcachofa/alcachofa.h
+++ b/engines/alcachofa/alcachofa.h
@@ -137,13 +137,9 @@ public:
 			(f == kSupportsReturnToLauncher);
 	};
 
-	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override {
-		// TODO: Implement
-		return true;
-	}
+	bool canLoadGameStateCurrently(Common::U32String *msg = nullptr) override;
 	bool canSaveGameStateCurrently(Common::U32String *msg = nullptr) override {
-		// TODO: Implement
-		return true;
+		return canLoadGameStateCurrently(msg);
 	}
 
 	Common::Error syncGame(Common::Serializer &s);
@@ -175,6 +171,7 @@ private:
 	Scheduler _scheduler;
 	Config _config;
 
+	FakeSemaphore _eventLoopSemaphore; // for special states like playVideo and fadeExit
 	uint32 _timeNegOffset = 0, _timePosOffset = 0;
 	uint32 _timeBeforePause = 0;
 };

--- a/engines/alcachofa/camera.cpp
+++ b/engines/alcachofa/camera.cpp
@@ -58,7 +58,7 @@ void Camera::setFollow(WalkingCharacter *target, bool catchUp) {
 }
 
 void Camera::setPosition(Vector2d v) {
-	setPosition({v.getX(), v.getY(), _cur._usedCenter.z()});
+	setPosition({ v.getX(), v.getY(), _cur._usedCenter.z() });
 }
 
 void Camera::setPosition(Vector3d v) {
@@ -156,8 +156,8 @@ Vector3d Camera::transform3Dto2D(Vector3d v3d) const {
 }
 
 Point Camera::transform3Dto2D(Point p3d) const {
-	auto v2d = transform3Dto2D({(float)p3d.x, (float)p3d.y, kBaseScale});
-	return {(int16)v2d.x(), (int16)v2d.y()};
+	auto v2d = transform3Dto2D({ (float)p3d.x, (float)p3d.y, kBaseScale });
+	return { (int16)v2d.x(), (int16)v2d.y() };
 }
 
 void Camera::update() {
@@ -191,7 +191,7 @@ void Camera::updateFollowing(float deltaTime) {
 	Vector3d targetCenter = setAppliedCenter({
 		_shake.getX() + _followTarget->position().x,
 		_shake.getY() + _followTarget->position().y - depthScale * 85,
-		_cur._usedCenter.z()});
+		_cur._usedCenter.z() });
 	targetCenter.y() -= halfHeight;
 	float distanceToTarget = as2D(_cur._usedCenter - targetCenter).getMagnitude();
 	float moveDistance = _followTarget->stepSizeFactor() * _cur._speed * deltaTime;
@@ -461,7 +461,7 @@ struct CamShakeTask final : public CamLerpTask {
 	CamShakeTask(Process &process, Vector2d amplitude, Vector2d frequency, int32 duration)
 		: CamLerpTask(process, duration, EasingType::Linear)
 		, _amplitude(amplitude)
-		, _frequency(frequency) { }
+		, _frequency(frequency) {}
 
 	CamShakeTask(Process &process, Serializer &s)
 		: CamLerpTask(process) {
@@ -547,9 +547,15 @@ struct CamSetInactiveAttributeTask final : public Task {
 
 		auto &state = _camera._backups[0];
 		switch (_attribute) {
-		case kPosZ: state._usedCenter.z() = _value; break;
-		case kScale: state._scale = _value; break;
-		case kRotation: state._rotation = _value; break;
+		case kPosZ:
+			state._usedCenter.z() = _value;
+			break;
+		case kScale:
+			state._scale = _value;
+			break;
+		case kRotation:
+			state._rotation = _value;
+			break;
 		default:
 			g_engine->game().unknownCamSetInactiveAttribute((int)_attribute);
 			break;
@@ -560,10 +566,18 @@ struct CamSetInactiveAttributeTask final : public Task {
 	void debugPrint() override {
 		const char *attributeName;
 		switch (_attribute) {
-		case kPosZ: attributeName = "PosZ"; break;
-		case kScale: attributeName = "Scale"; break;
-		case kRotation: attributeName = "Rotation"; break;
-		default: attributeName = "<unknown>"; break;
+		case kPosZ:
+			attributeName = "PosZ";
+			break;
+		case kScale:
+			attributeName = "Scale";
+			break;
+		case kRotation:
+			attributeName = "Rotation";
+			break;
+		default:
+			attributeName = "<unknown>";
+			break;
 		}
 		g_engine->console().debugPrintf("Set inactive camera %s to %f after %dms\n", attributeName, _value, _delay);
 	}

--- a/engines/alcachofa/camera.cpp
+++ b/engines/alcachofa/camera.cpp
@@ -291,7 +291,7 @@ struct CamLerpTask : public Task {
 		, _duration(duration)
 		, _easingType(easingType) {}
 
-	virtual TaskReturn run() override {
+	TaskReturn run() override {
 		TASK_BEGIN;
 		_startTime = g_engine->getMillis();
 		while (g_engine->getMillis() - _startTime < _duration) {
@@ -303,14 +303,14 @@ struct CamLerpTask : public Task {
 		TASK_END;
 	}
 
-	virtual void debugPrint() override {
+	void debugPrint() override {
 		uint32 remaining = g_engine->getMillis() - _startTime <= _duration
 			? _duration - (g_engine->getMillis() - _startTime)
 			: 0;
 		g_engine->console().debugPrintf("%s camera with %ums remaining\n", taskName(), remaining);
 	}
 
-	virtual void syncGame(Serializer &s) override {
+	void syncGame(Serializer &s) override {
 		Task::syncGame(s);
 		s.syncAsUint32LE(_startTime);
 		s.syncAsUint32LE(_duration);
@@ -336,7 +336,7 @@ struct CamLerpPosTask final : public CamLerpTask {
 		syncGame(s);
 	}
 
-	virtual void syncGame(Serializer &s) override {
+	void syncGame(Serializer &s) override {
 		CamLerpTask::syncGame(s);
 		syncVector(s, _fromPos);
 		syncVector(s, _deltaPos);
@@ -345,7 +345,7 @@ struct CamLerpPosTask final : public CamLerpTask {
 	virtual const char *taskName() const override;
 
 protected:
-	virtual void update(float t) override {
+	void update(float t) override {
 		_camera.setPosition(_fromPos + _deltaPos * t);
 	}
 
@@ -364,7 +364,7 @@ struct CamLerpScaleTask final : public CamLerpTask {
 		syncGame(s);
 	}
 
-	virtual void syncGame(Serializer &s) override {
+	void syncGame(Serializer &s) override {
 		CamLerpTask::syncGame(s);
 		s.syncAsFloatLE(_fromScale);
 		s.syncAsFloatLE(_deltaScale);
@@ -373,7 +373,7 @@ struct CamLerpScaleTask final : public CamLerpTask {
 	virtual const char *taskName() const override;
 
 protected:
-	virtual void update(float t) override {
+	void update(float t) override {
 		_camera._cur._scale = _fromScale + _deltaScale * t;
 	}
 
@@ -399,7 +399,7 @@ struct CamLerpPosScaleTask final : public CamLerpTask {
 		syncGame(s);
 	}
 
-	virtual void syncGame(Serializer &s) override {
+	void syncGame(Serializer &s) override {
 		CamLerpTask::syncGame(s);
 		syncVector(s, _fromPos);
 		syncVector(s, _deltaPos);
@@ -412,7 +412,7 @@ struct CamLerpPosScaleTask final : public CamLerpTask {
 	virtual const char *taskName() const override;
 
 protected:
-	virtual void update(float t) override {
+	void update(float t) override {
 		_camera.setPosition(_fromPos + _deltaPos * ease(t, _moveEasingType));
 		_camera._cur._scale = _fromScale + _deltaScale * ease(t, _scaleEasingType);
 	}
@@ -434,7 +434,7 @@ struct CamLerpRotationTask final : public CamLerpTask {
 		syncGame(s);
 	}
 
-	virtual void syncGame(Serializer &s) override {
+	void syncGame(Serializer &s) override {
 		CamLerpTask::syncGame(s);
 		s.syncAsFloatLE(_fromRotation);
 		s.syncAsFloatLE(_deltaRotation);
@@ -443,7 +443,7 @@ struct CamLerpRotationTask final : public CamLerpTask {
 	virtual const char *taskName() const override;
 
 protected:
-	virtual void update(float t) override {
+	void update(float t) override {
 		_camera._cur._rotation = Angle(_fromRotation + _deltaRotation * t);
 	}
 
@@ -468,7 +468,7 @@ struct CamShakeTask final : public CamLerpTask {
 		syncGame(s);
 	}
 
-	virtual void syncGame(Serializer &s) override {
+	void syncGame(Serializer &s) override {
 		CamLerpTask::syncGame(s);
 		syncVector(s, _amplitude);
 		syncVector(s, _frequency);
@@ -477,7 +477,7 @@ struct CamShakeTask final : public CamLerpTask {
 	virtual const char *taskName() const override;
 
 protected:
-	virtual void update(float t) override {
+	void update(float t) override {
 		const Vector2d phase = _frequency * t * (float)M_PI * 2.0f;
 		const float amplTimeFactor = 1.0f / expf(t * 5.0f); // a curve starting at 1, depreciating towards 0 
 		_camera.shake() = {
@@ -501,13 +501,13 @@ struct CamWaitToStopTask final : public Task {
 		syncGame(s);
 	}
 
-	virtual TaskReturn run() override {
+	TaskReturn run() override {
 		return _camera._isChanging
 			? TaskReturn::yield()
 			: TaskReturn::finish(1);
 	}
 
-	virtual void debugPrint() override {
+	void debugPrint() override {
 		g_engine->console().debugPrintf("Wait for camera to stop moving\n");
 	}
 
@@ -538,7 +538,7 @@ struct CamSetInactiveAttributeTask final : public Task {
 		syncGame(s);
 	}
 
-	virtual TaskReturn run() override {
+	TaskReturn run() override {
 		if (_delay > 0) {
 			uint32 delay = (uint32)_delay;
 			_delay = 0;
@@ -557,7 +557,7 @@ struct CamSetInactiveAttributeTask final : public Task {
 		return TaskReturn::finish(0);
 	}
 
-	virtual void debugPrint() override {
+	void debugPrint() override {
 		const char *attributeName;
 		switch (_attribute) {
 		case kPosZ: attributeName = "PosZ"; break;
@@ -568,7 +568,7 @@ struct CamSetInactiveAttributeTask final : public Task {
 		g_engine->console().debugPrintf("Set inactive camera %s to %f after %dms\n", attributeName, _value, _delay);
 	}
 
-	virtual void syncGame(Serializer &s) override {
+	void syncGame(Serializer &s) override {
 		Task::syncGame(s);
 		syncEnum(s, _attribute);
 		s.syncAsFloatLE(_value);

--- a/engines/alcachofa/camera.cpp
+++ b/engines/alcachofa/camera.cpp
@@ -377,7 +377,7 @@ protected:
 		_camera._cur._scale = _fromScale + _deltaScale * t;
 	}
 
-	float _fromScale, _deltaScale;
+	float _fromScale = 0, _deltaScale = 0;
 };
 DECLARE_TASK(CamLerpScaleTask);
 
@@ -418,8 +418,8 @@ protected:
 	}
 
 	Vector3d _fromPos, _deltaPos;
-	float _fromScale, _deltaScale;
-	EasingType _moveEasingType, _scaleEasingType;
+	float _fromScale = 0, _deltaScale = 0;
+	EasingType _moveEasingType = {}, _scaleEasingType = {};
 };
 DECLARE_TASK(CamLerpPosScaleTask);
 
@@ -447,7 +447,7 @@ protected:
 		_camera._cur._rotation = Angle(_fromRotation + _deltaRotation * t);
 	}
 
-	float _fromRotation, _deltaRotation;
+	float _fromRotation = 0, _deltaRotation = 0;
 };
 DECLARE_TASK(CamLerpRotationTask);
 
@@ -579,9 +579,9 @@ struct CamSetInactiveAttributeTask final : public Task {
 
 private:
 	Camera &_camera;
-	Attribute _attribute;
-	float _value;
-	int32 _delay;
+	Attribute _attribute = {};
+	float _value = 0;
+	int32 _delay = 0;
 };
 DECLARE_TASK(CamSetInactiveAttributeTask);
 

--- a/engines/alcachofa/camera.cpp
+++ b/engines/alcachofa/camera.cpp
@@ -342,7 +342,7 @@ struct CamLerpPosTask final : public CamLerpTask {
 		syncVector(s, _deltaPos);
 	}
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 protected:
 	void update(float t) override {
@@ -370,7 +370,7 @@ struct CamLerpScaleTask final : public CamLerpTask {
 		s.syncAsFloatLE(_deltaScale);
 	}
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 protected:
 	void update(float t) override {
@@ -409,7 +409,7 @@ struct CamLerpPosScaleTask final : public CamLerpTask {
 		syncEnum(s, _scaleEasingType);
 	}
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 protected:
 	void update(float t) override {
@@ -440,7 +440,7 @@ struct CamLerpRotationTask final : public CamLerpTask {
 		s.syncAsFloatLE(_deltaRotation);
 	}
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 protected:
 	void update(float t) override {
@@ -474,7 +474,7 @@ struct CamShakeTask final : public CamLerpTask {
 		syncVector(s, _frequency);
 	}
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 protected:
 	void update(float t) override {
@@ -511,7 +511,7 @@ struct CamWaitToStopTask final : public Task {
 		g_engine->console().debugPrintf("Wait for camera to stop moving\n");
 	}
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 private:
 	Camera &_camera;
@@ -575,7 +575,7 @@ struct CamSetInactiveAttributeTask final : public Task {
 		s.syncAsSint32LE(_delay);
 	}
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 private:
 	Camera &_camera;

--- a/engines/alcachofa/camera.cpp
+++ b/engines/alcachofa/camera.cpp
@@ -351,7 +351,7 @@ protected:
 
 	Vector3d _fromPos, _deltaPos;
 };
-DECLARE_TASK(CamLerpPosTask);
+DECLARE_TASK(CamLerpPosTask)
 
 struct CamLerpScaleTask final : public CamLerpTask {
 	CamLerpScaleTask(Process &process, float targetScale, int32 duration, EasingType easingType)
@@ -379,7 +379,7 @@ protected:
 
 	float _fromScale = 0, _deltaScale = 0;
 };
-DECLARE_TASK(CamLerpScaleTask);
+DECLARE_TASK(CamLerpScaleTask)
 
 struct CamLerpPosScaleTask final : public CamLerpTask {
 	CamLerpPosScaleTask(Process &process,
@@ -421,7 +421,7 @@ protected:
 	float _fromScale = 0, _deltaScale = 0;
 	EasingType _moveEasingType = {}, _scaleEasingType = {};
 };
-DECLARE_TASK(CamLerpPosScaleTask);
+DECLARE_TASK(CamLerpPosScaleTask)
 
 struct CamLerpRotationTask final : public CamLerpTask {
 	CamLerpRotationTask(Process &process, float targetRotation, int32 duration, EasingType easingType)
@@ -449,7 +449,7 @@ protected:
 
 	float _fromRotation = 0, _deltaRotation = 0;
 };
-DECLARE_TASK(CamLerpRotationTask);
+DECLARE_TASK(CamLerpRotationTask)
 
 static void syncVector(Serializer &s, Vector2d &v) {
 	float *data = v.getData();
@@ -488,7 +488,7 @@ protected:
 
 	Vector2d _amplitude, _frequency;
 };
-DECLARE_TASK(CamShakeTask);
+DECLARE_TASK(CamShakeTask)
 
 struct CamWaitToStopTask final : public Task {
 	CamWaitToStopTask(Process &process)
@@ -516,7 +516,7 @@ struct CamWaitToStopTask final : public Task {
 private:
 	Camera &_camera;
 };
-DECLARE_TASK(CamWaitToStopTask);
+DECLARE_TASK(CamWaitToStopTask)
 
 struct CamSetInactiveAttributeTask final : public Task {
 	enum Attribute {
@@ -583,7 +583,7 @@ private:
 	float _value = 0;
 	int32 _delay = 0;
 };
-DECLARE_TASK(CamSetInactiveAttributeTask);
+DECLARE_TASK(CamSetInactiveAttributeTask)
 
 Task *Camera::lerpPos(Process &process,
 					  Vector2d targetPos,

--- a/engines/alcachofa/camera.cpp
+++ b/engines/alcachofa/camera.cpp
@@ -19,9 +19,9 @@
  *
  */
 
-#include "camera.h"
-#include "alcachofa.h"
-#include "script.h"
+#include "alcachofa/camera.h"
+#include "alcachofa/alcachofa.h"
+#include "alcachofa/script.h"
 
 #include "common/system.h"
 #include "math/vector4d.h"

--- a/engines/alcachofa/camera.cpp
+++ b/engines/alcachofa/camera.cpp
@@ -51,7 +51,7 @@ void Camera::setRoomBounds(Point bgSize, int16 bgScale) {
 void Camera::setFollow(WalkingCharacter *target, bool catchUp) {
 	_cur._isFollowingTarget = target != nullptr;
 	_followTarget = target;
-	_lastUpdateTime = g_system->getMillis();
+	_lastUpdateTime = g_engine->getMillis();
 	_catchUp = catchUp;
 	if (target == nullptr)
 		_isChanging = false;
@@ -162,7 +162,7 @@ Point Camera::transform3Dto2D(Point p3d) const {
 
 void Camera::update() {
 	// original would be some smoothing of delta times, let's not.
-	uint32 now = g_system->getMillis();
+	uint32 now = g_engine->getMillis();
 	float deltaTime = (now - _lastUpdateTime) / 1000.0f;
 	deltaTime = MAX(0.001f, MIN(0.5f, deltaTime));
 	_lastUpdateTime = now;
@@ -239,9 +239,9 @@ struct CamLerpTask : public Task {
 
 	virtual TaskReturn run() override {
 		TASK_BEGIN;
-		_startTime = g_system->getMillis();
-		while (g_system->getMillis() - _startTime < _duration) {
-			update(ease((g_system->getMillis() - _startTime) / (float)_duration, _easingType));
+		_startTime = g_engine->getMillis();
+		while (g_engine->getMillis() - _startTime < _duration) {
+			update(ease((g_engine->getMillis() - _startTime) / (float)_duration, _easingType));
 			_camera._isChanging = true;
 			TASK_YIELD;
 		}
@@ -250,8 +250,8 @@ struct CamLerpTask : public Task {
 	}
 
 	virtual void debugPrint() override {
-		uint32 remaining = g_system->getMillis() - _startTime <= _duration
-			? _duration - (g_system->getMillis() - _startTime)
+		uint32 remaining = g_engine->getMillis() - _startTime <= _duration
+			? _duration - (g_engine->getMillis() - _startTime)
 			: 0;
 		g_engine->console().debugPrintf("%s camera with %ums remaining\n", taskName(), remaining);
 	}

--- a/engines/alcachofa/camera.h
+++ b/engines/alcachofa/camera.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef CAMERA_H
-#define CAMERA_H
+#ifndef ALCACHOFA_CAMERA_H
+#define ALCACHOFA_CAMERA_H
 
 #include "common.h"
 #include "math/matrix4.h"
@@ -119,4 +119,4 @@ private:
 
 }
 
-#endif // CAMERA_H
+#endif // ALCACHOFA_CAMERA_H

--- a/engines/alcachofa/camera.h
+++ b/engines/alcachofa/camera.h
@@ -22,7 +22,7 @@
 #ifndef ALCACHOFA_CAMERA_H
 #define ALCACHOFA_CAMERA_H
 
-#include "common.h"
+#include "alcachofa/common.h"
 #include "math/matrix4.h"
 
 namespace Alcachofa {

--- a/engines/alcachofa/camera.h
+++ b/engines/alcachofa/camera.h
@@ -51,6 +51,7 @@ public:
 	void setPosition(Math::Vector3d v);
 	void backup(uint slot);
 	void restore(uint slot);
+	void syncGame(Common::Serializer &s);
 
 	Task *lerpPos(Process &process,
 		Math::Vector2d targetPos,
@@ -95,6 +96,8 @@ private:
 		Math::Angle _rotation;
 		bool _isBraking = false;
 		bool _isFollowingTarget = false;
+
+		void syncGame(Common::Serializer &s);
 	};
 
 	static constexpr uint kStateBackupCount = 2;

--- a/engines/alcachofa/common.cpp
+++ b/engines/alcachofa/common.cpp
@@ -150,7 +150,6 @@ String readVarString(ReadStream &stream) {
 	if (length == 0)
 		return Common::String();
 
-	// TODO: Being able to resize a string would avoid the double-allocation :/
 	char *buffer = new char[length];
 	if (buffer == nullptr)
 		error("Out of memory in readVarString");

--- a/engines/alcachofa/common.cpp
+++ b/engines/alcachofa/common.cpp
@@ -42,6 +42,16 @@ FakeSemaphore::~FakeSemaphore() {
 	assert(_counter == 0);
 }
 
+void FakeSemaphore::sync(Serializer &s, FakeSemaphore &semaphore) {
+	// if we are still holding locks during loading these locks will
+	// try to decrease the counter which will fail, let's find this out already here
+	assert(s.isSaving() || semaphore.isReleased());
+
+	uint semaphoreCounter = semaphore.counter();
+	s.syncAsSint32LE(semaphoreCounter);
+	semaphore = FakeSemaphore(semaphoreCounter);
+}
+
 FakeLock::FakeLock() : _semaphore(nullptr) {}
 
 FakeLock::FakeLock(FakeSemaphore &semaphore) : _semaphore(&semaphore) {

--- a/engines/alcachofa/common.cpp
+++ b/engines/alcachofa/common.cpp
@@ -29,11 +29,16 @@ namespace Alcachofa {
 
 float ease(float t, EasingType type) {
 	switch (type) {
-	case EasingType::Linear: return t;
-	case EasingType::InOut: return (1 - cosf(t * M_PI)) * 0.5f;
-	case EasingType::In: return 1 - cosf(t * M_PI * 0.5f);
-	case EasingType::Out: return sinf(t * M_PI * 0.5f);
-	default: return 0.0f;
+	case EasingType::Linear:
+		return t;
+	case EasingType::InOut:
+		return (1 - cosf(t * M_PI)) * 0.5f;
+	case EasingType::In:
+		return 1 - cosf(t * M_PI * 0.5f);
+	case EasingType::Out:
+		return sinf(t * M_PI * 0.5f);
+	default:
+		return 0.0f;
 	}
 }
 

--- a/engines/alcachofa/common.cpp
+++ b/engines/alcachofa/common.cpp
@@ -19,8 +19,8 @@
  *
  */
 
-#include "common.h"
-#include "detection.h"
+#include "alcachofa/common.h"
+#include "alcachofa/detection.h"
 
 using namespace Common;
 using namespace Math;

--- a/engines/alcachofa/common.cpp
+++ b/engines/alcachofa/common.cpp
@@ -49,7 +49,8 @@ void FakeSemaphore::sync(Serializer &s, FakeSemaphore &semaphore) {
 	// if we are still holding locks during loading these locks will
 	// try to decrease the counter which will fail, let's find this out already here
 	assert(s.isSaving() || semaphore.isReleased());
-	(void)(s, semaphore);
+	(void)s;
+	(void)semaphore;
 
 	// We should not actually serialize the counter, just make sure it is empty
 	// When the locks are loaded, they will increase the counter themselves

--- a/engines/alcachofa/common.h
+++ b/engines/alcachofa/common.h
@@ -83,7 +83,7 @@ static constexpr const Color kDebugLightBlue = { 80, 80, 255, 190 };
  * It is used as a safer option for a simple "isBusy" counter
  */
 struct FakeSemaphore {
-	FakeSemaphore(uint initialCount = 0);
+	FakeSemaphore(const char *name, uint initialCount = 0);
 	~FakeSemaphore();
 
 	inline bool isReleased() const { return _counter == 0; }
@@ -92,6 +92,7 @@ struct FakeSemaphore {
 	static void sync(Common::Serializer &s, FakeSemaphore &semaphore);
 private:
 	friend struct FakeLock;
+	const char *const _name;
 	uint _counter = 0;
 };
 

--- a/engines/alcachofa/common.h
+++ b/engines/alcachofa/common.h
@@ -88,6 +88,8 @@ struct FakeSemaphore {
 
 	inline bool isReleased() const { return _counter == 0; }
 	inline uint counter() const { return _counter; }
+
+	static void sync(Common::Serializer &s, FakeSemaphore &semaphore);
 private:
 	friend struct FakeLock;
 	uint _counter = 0;

--- a/engines/alcachofa/common.h
+++ b/engines/alcachofa/common.h
@@ -103,7 +103,7 @@ struct FakeLock {
 	~FakeLock();
 	void operator = (FakeLock &&other) noexcept;
 	void release();
-	
+
 	inline bool isReleased() const { return _semaphore == nullptr; }
 private:
 	void debug(const char *action);
@@ -143,8 +143,7 @@ inline void syncStack(Common::Serializer &serializer, Common::Stack<T> &stack, v
 			serializeFunction(serializer, value);
 			stack.push(value);
 		}
-	}
-	else {
+	} else {
 		for (uint i = 0; i < size; i++)
 			serializeFunction(serializer, stack[i]);
 	}

--- a/engines/alcachofa/common.h
+++ b/engines/alcachofa/common.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef COMMON_H
-#define COMMON_H
+#ifndef ALCACHOFA_COMMON_H
+#define ALCACHOFA_COMMON_H
 
 #include "common/scummsys.h"
 #include "common/rect.h"

--- a/engines/alcachofa/common.h
+++ b/engines/alcachofa/common.h
@@ -22,7 +22,6 @@
 #ifndef ALCACHOFA_COMMON_H
 #define ALCACHOFA_COMMON_H
 
-#include "common/scummsys.h"
 #include "common/rect.h"
 #include "common/serializer.h"
 #include "common/stream.h"

--- a/engines/alcachofa/common.h
+++ b/engines/alcachofa/common.h
@@ -103,6 +103,8 @@ struct FakeLock {
 	~FakeLock();
 	void operator = (FakeLock &&other) noexcept;
 	void release();
+	
+	inline bool isReleased() const { return _semaphore == nullptr; }
 private:
 	FakeSemaphore *_semaphore = nullptr;
 };

--- a/engines/alcachofa/common.h
+++ b/engines/alcachofa/common.h
@@ -98,7 +98,7 @@ private:
 
 struct FakeLock {
 	FakeLock();
-	FakeLock(FakeSemaphore &semaphore);
+	FakeLock(const char *name, FakeSemaphore &semaphore);
 	FakeLock(const FakeLock &other);
 	FakeLock(FakeLock &&other) noexcept;
 	~FakeLock();
@@ -107,6 +107,9 @@ struct FakeLock {
 	
 	inline bool isReleased() const { return _semaphore == nullptr; }
 private:
+	void debug(const char *action);
+
+	const char *_name = "<uninitialized>";
 	FakeSemaphore *_semaphore = nullptr;
 };
 

--- a/engines/alcachofa/configure.engine
+++ b/engines/alcachofa/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine alcachofa "Alcachofa" no "" "" ""
+add_engine alcachofa "Alcachofa" no "" "" "highres opengl_game_classic mpeg2 3d"

--- a/engines/alcachofa/configure.engine
+++ b/engines/alcachofa/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps]
-add_engine alcachofa "Alcachofa" no "" "" "highres opengl_game_classic mpeg2 3d"
+add_engine alcachofa "Alcachofa" no "" "" "highres opengl_game_classic mpeg2"

--- a/engines/alcachofa/console.cpp
+++ b/engines/alcachofa/console.cpp
@@ -183,9 +183,9 @@ bool Console::cmdItem(int argc, const char **args) {
 	const char *itemName = args[1];
 	if (argc == 3) {
 		itemName = args[2];
-		if (strcmpi(args[1], "mortadelo") == 0 || strcmpi(args[1], "m") == 0)
+		if (scumm_stricmp(args[1], "mortadelo") == 0 || scumm_stricmp(args[1], "m") == 0)
 			active = &mortadelo;
-		else if (strcmpi(args[1], "filemon") == 0 || strcmpi(args[1], "f") == 0)
+		else if (scumm_stricmp(args[1], "filemon") == 0 || scumm_stricmp(args[1], "f") == 0)
 			active = &filemon;
 		else {
 			debugPrintf("Invalid character name \"%s\", has to be either \"mortadelo\" or \"filemon\"\n", args[1]);

--- a/engines/alcachofa/console.cpp
+++ b/engines/alcachofa/console.cpp
@@ -28,6 +28,7 @@ using namespace Common;
 namespace Alcachofa {
 
 Console::Console() : GUI::Debugger() {
+	registerVar("showGraphics", &_showGraphics);
 	registerVar("showInteractables", &_showInteractables);
 	registerVar("showCharacters", &_showCharacters);
 	registerVar("showFloorShape", &_showFloor);
@@ -53,6 +54,7 @@ Console::~Console() {
 bool Console::isAnyDebugDrawingOn() const {
 	return
 		g_engine->isDebugModeActive() ||
+		_showGraphics ||
 		_showInteractables ||
 		_showCharacters ||
 		_showFloor ||

--- a/engines/alcachofa/console.cpp
+++ b/engines/alcachofa/console.cpp
@@ -53,8 +53,7 @@ Console::Console() : GUI::Debugger() {
 	registerCmd("playVideo", WRAP_METHOD(Console, cmdPlayVideo));
 }
 
-Console::~Console() {
-}
+Console::~Console() {}
 
 bool Console::isAnyDebugDrawingOn() const {
 	return
@@ -80,8 +79,7 @@ bool Console::cmdVar(int argc, const char **args) {
 			debugPrintf("Invalid variable name: %s", args[1]);
 		else
 			script.variable(args[1]) = value;
-	}
-	else if (argc == 2) {
+	} else if (argc == 2) {
 		bool hadSomeMatch = false;
 		for (auto it = script.beginVariables(); it != script.endVariables(); it++) {
 			if (matchString(it->_key.c_str(), args[1], true)) {
@@ -112,8 +110,7 @@ bool Console::cmdRoom(int argc, const char **args) {
 			debugPrintf("Player is currently in no room, cannot print details\n");
 			return true;
 		}
-	}
-	else {
+	} else {
 		room = g_engine->world().getRoomByName(args[1]);
 		if (room == nullptr) {
 			debugPrintf("Could not find room with exact name: %s\n", args[1]);
@@ -147,8 +144,7 @@ bool Console::cmdChangeRoom(int argc, const char **args) {
 	else if (argc == 1) {
 		Room *current = g_engine->player().currentRoom();
 		debugPrintf("Current room: %s\n", current == nullptr ? "<null>" : current->name().c_str());
-	}
-	else if (g_engine->world().getRoomByName(args[1]) == nullptr)
+	} else if (g_engine->world().getRoomByName(args[1]) == nullptr)
 		debugPrintf("Invalid room name: %s\n", args[1]);
 	else {
 		g_engine->player().changeRoom(args[1], true);
@@ -284,7 +280,7 @@ bool Console::cmdPlayVideo(int argc, const char **args) {
 			debugPrintf("Video ID can only be an integer\n");
 			return true;
 		}
-		
+
 #ifndef USE_TEXT_CONSOLE_FOR_DEBUGGER
 		// we have to close the console *now* to properly see the video
 		_debuggerDialog->close();
@@ -293,8 +289,7 @@ bool Console::cmdPlayVideo(int argc, const char **args) {
 
 		g_engine->playVideo(videoId);
 		return false;
-	}
-	else
+	} else
 		debugPrintf("usage: playVideo <id>\n");
 	return true;
 }

--- a/engines/alcachofa/console.cpp
+++ b/engines/alcachofa/console.cpp
@@ -23,9 +23,9 @@
 #include "gui/console.h"
 #endif
 
-#include "console.h"
-#include "script.h"
-#include "alcachofa.h"
+#include "alcachofa/console.h"
+#include "alcachofa/script.h"
+#include "alcachofa/alcachofa.h"
 
 using namespace Common;
 

--- a/engines/alcachofa/console.cpp
+++ b/engines/alcachofa/console.cpp
@@ -19,6 +19,10 @@
  *
  */
 
+#ifndef USE_TEXT_CONSOLE_FOR_DEBUGGER
+#include "gui/console.h"
+#endif
+
 #include "console.h"
 #include "script.h"
 #include "alcachofa.h"
@@ -46,6 +50,7 @@ Console::Console() : GUI::Debugger() {
 	registerCmd("debugMode", WRAP_METHOD(Console, cmdDebugMode));
 	registerCmd("tp", WRAP_METHOD(Console, cmdTeleport));
 	registerCmd("toggleRoomFloor", WRAP_METHOD(Console, cmdToggleRoomFloor));
+	registerCmd("playVideo", WRAP_METHOD(Console, cmdPlayVideo));
 }
 
 Console::~Console() {
@@ -223,12 +228,10 @@ bool Console::cmdDebugMode(int argc, const char **args) {
 	}
 
 	int32 param = -1;
-	if (argc > 2)
-	{
+	if (argc > 2) {
 		char *end = nullptr;
 		param = (int32)strtol(args[2], &end, 10);
-		if (end == nullptr || *end != '\0')
-		{
+		if (end == nullptr || *end != '\0') {
 			debugPrintf("Debug mode parameter can only be integers");
 			return true;
 		}
@@ -240,9 +243,8 @@ bool Console::cmdDebugMode(int argc, const char **args) {
 }
 
 bool Console::cmdTeleport(int argc, const char **args) {
-	if (argc < 1 || argc > 2)
-	{
-		debugPrintf("usagge: tp [<character>]\n");
+	if (argc < 1 || argc > 2) {
+		debugPrintf("usage: tp [<character>]\n");
 		debugPrintf("characters:\n");
 		debugPrintf("  0 - Both\n");
 		debugPrintf("  1 - Mortadelo\n");
@@ -250,13 +252,11 @@ bool Console::cmdTeleport(int argc, const char **args) {
 	}
 
 	int32 param = 0;
-	if (argc > 1)
-	{
+	if (argc > 1) {
 		char *end = nullptr;
 		param = (int32)strtol(args[1], &end, 10);
-		if (end == nullptr || *end != '\0')
-		{
-			debugPrintf("Character kind can only be integer\n");
+		if (end == nullptr || *end != '\0') {
+			debugPrintf("Character kind can only be an integer\n");
 			return true;
 		}
 	}
@@ -267,14 +267,36 @@ bool Console::cmdTeleport(int argc, const char **args) {
 
 bool Console::cmdToggleRoomFloor(int argc, const char **args) {
 	auto room = g_engine->player().currentRoom();
-	if (room == nullptr)
-	{
+	if (room == nullptr) {
 		debugPrintf("No room is active");
 		return true;
 	}
 
 	room->toggleActiveFloor();
 	return false;
+}
+
+bool Console::cmdPlayVideo(int argc, const char **args) {
+	if (argc == 2) {
+		char *end = nullptr;
+		int32 videoId = (int32)strtol(args[1], &end, 10);
+		if (end == nullptr || *end != '\0') {
+			debugPrintf("Video ID can only be an integer\n");
+			return true;
+		}
+		
+#ifndef USE_TEXT_CONSOLE_FOR_DEBUGGER
+		// we have to close the console *now* to properly see the video
+		_debuggerDialog->close();
+		g_system->clearOverlay();
+#endif
+
+		g_engine->playVideo(videoId);
+		return false;
+	}
+	else
+		debugPrintf("usage: playVideo <id>\n");
+	return true;
 }
 
 } // End of namespace Alcachofa

--- a/engines/alcachofa/console.h
+++ b/engines/alcachofa/console.h
@@ -41,6 +41,7 @@ public:
 	Console();
 	~Console() override;
 
+	inline bool showGraphics() const { return _showGraphics; }
 	inline bool showInteractables() const { return _showInteractables; }
 	inline bool showCharacters() const { return _showCharacters; }
 	inline bool showFloor() const { return _showFloor; }
@@ -60,6 +61,7 @@ private:
 	bool cmdTeleport(int argc, const char **args);
 	bool cmdToggleRoomFloor(int argc, const char **args);
 
+	bool _showGraphics = false;
 	bool _showInteractables = false;
 	bool _showCharacters = false;
 	bool _showFloor = false;

--- a/engines/alcachofa/console.h
+++ b/engines/alcachofa/console.h
@@ -60,6 +60,7 @@ private:
 	bool cmdDebugMode(int argc, const char **args);
 	bool cmdTeleport(int argc, const char **args);
 	bool cmdToggleRoomFloor(int argc, const char **args);
+	bool cmdPlayVideo(int argc, const char **args);
 
 	bool _showGraphics = false;
 	bool _showInteractables = false;

--- a/engines/alcachofa/debug.h
+++ b/engines/alcachofa/debug.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef DEBUG_H
-#define DEBUG_H
+#ifndef ALCACHOFA_DEBUG_H
+#define ALCACHOFA_DEBUG_H
 
 #include "alcachofa.h"
 
@@ -231,4 +231,4 @@ public:
 
 }
 
-#endif // DEBUG_H
+#endif // ALCACHOFA_DEBUG_H

--- a/engines/alcachofa/debug.h
+++ b/engines/alcachofa/debug.h
@@ -93,7 +93,6 @@ private:
 
 	void drawIntersectionsFor(const Polygon &polygon, IDebugRenderer *renderer) {
 		auto &camera = g_engine->camera();
-		auto mousePos2D = g_engine->input().debugInput().mousePos2D();
 		auto mousePos3D = g_engine->input().debugInput().mousePos3D();
 		for (uint i = 0; i < polygon._points.size(); i++)
 		{

--- a/engines/alcachofa/debug.h
+++ b/engines/alcachofa/debug.h
@@ -81,8 +81,7 @@ public:
 
 		if (_polygonI >= 0 && (uint)_polygonI < floor->polygonCount())
 			drawIntersectionsFor(floor->at((uint)_polygonI), renderer);
-		else
-		{
+		else {
 			for (uint i = 0; i < floor->polygonCount(); i++)
 				drawIntersectionsFor(floor->at(i), renderer);
 		}
@@ -94,8 +93,7 @@ private:
 	void drawIntersectionsFor(const Polygon &polygon, IDebugRenderer *renderer) {
 		auto &camera = g_engine->camera();
 		auto mousePos3D = g_engine->input().debugInput().mousePos3D();
-		for (uint i = 0; i < polygon._points.size(); i++)
-		{
+		for (uint i = 0; i < polygon._points.size(); i++) {
 			if (!polygon.intersectsEdge(i, _fromPos3D, mousePos3D))
 				continue;
 			auto a = camera.transform3Dto2D(polygon._points[i]);
@@ -123,8 +121,7 @@ public:
 		g_engine->drawQueue().draw();
 
 		auto &input = g_engine->input().debugInput();
-		if (input.wasMouseRightPressed())
-		{
+		if (input.wasMouseRightPressed()) {
 			g_engine->setDebugMode(DebugMode::None, 0);
 			return;
 		}
@@ -149,8 +146,7 @@ public:
 private:
 	void teleport(MainCharacter &character, Point position) {
 		auto currentRoom = g_engine->player().currentRoom();
-		if (character.room() != currentRoom)
-		{
+		if (character.room() != currentRoom) {
 			character.resetTalking();
 			character.room() = currentRoom;
 		}
@@ -174,12 +170,12 @@ public:
 		const Room *room = g_engine->player().currentRoom();
 		uint floorCount = 0;
 		for (auto itObject = room->beginObjects(); itObject != room->endObjects(); ++itObject) {
-			FloorColor *floor = dynamic_cast<FloorColor*>(*itObject);
+			FloorColor *floor = dynamic_cast<FloorColor *>(*itObject);
 			if (floor == nullptr)
 				continue;
 			if (objectI <= 0)
 				// dynamic_cast is not possible due to Shape not having virtual methods
-				return new FloorColorDebugHandler(*(FloorColorShape*)(floor->shape()), useColor);
+				return new FloorColorDebugHandler(*(FloorColorShape *)(floor->shape()), useColor);
 			floorCount++;
 			objectI--;
 		}
@@ -200,15 +196,15 @@ public:
 			_isOnFloor = optColor.first;
 			if (!_isOnFloor) {
 				uint8 roomAlpha = (uint)(g_engine->player().currentRoom()->characterAlphaTint() * 255 / 100);
-				optColor.second = Color{ 255, 255, 255, roomAlpha };
+				optColor.second = Color { 255, 255, 255, roomAlpha };
 			}
 
 			_curColor = _useColor
-				? Color{ optColor.second.r, optColor.second.g, optColor.second.b, 255 }
-				: Color{ optColor.second.a, optColor.second.a, optColor.second.a, 255 };
+				? Color { optColor.second.r, optColor.second.g, optColor.second.b, 255 }
+			: Color { optColor.second.a, optColor.second.a, optColor.second.a, 255 };
 			g_engine->world().mortadelo().color() =
 				g_engine->world().filemon().color() =
-				_useColor ? optColor.second : Color{ 255, 255, 255, optColor.second.a };
+				_useColor ? optColor.second : Color { 255, 255, 255, optColor.second.a };
 		}
 
 		snprintf(_buffer, kBufferSize, "r:%3d g:%3d b:%3d a:%3d",

--- a/engines/alcachofa/debug.h
+++ b/engines/alcachofa/debug.h
@@ -22,7 +22,7 @@
 #ifndef ALCACHOFA_DEBUG_H
 #define ALCACHOFA_DEBUG_H
 
-#include "alcachofa.h"
+#include "alcachofa/alcachofa.h"
 
 using namespace Common;
 

--- a/engines/alcachofa/debug.h
+++ b/engines/alcachofa/debug.h
@@ -40,7 +40,7 @@ class ClosestFloorPointDebugHandler final : public IDebugHandler {
 public:
 	ClosestFloorPointDebugHandler(int32 polygonI) : _polygonI(polygonI) {}
 
-	virtual void update() override {
+	void update() override {
 		auto mousePos2D = g_engine->input().debugInput().mousePos2D();
 		auto mousePos3D = g_engine->input().debugInput().mousePos3D();
 		auto floor = g_engine->player().currentRoom()->activeFloor();
@@ -63,7 +63,7 @@ class FloorIntersectionsDebugHandler final : public IDebugHandler {
 public:
 	FloorIntersectionsDebugHandler(int32 polygonI) : _polygonI(polygonI) {}
 
-	virtual void update() override {
+	void update() override {
 		auto floor = g_engine->player().currentRoom()->activeFloor();
 		auto renderer = dynamic_cast<IDebugRenderer *>(&g_engine->renderer());
 		if (floor == nullptr || renderer == nullptr) {
@@ -118,7 +118,7 @@ class TeleportCharacterDebugHandler final : public IDebugHandler {
 public:
 	TeleportCharacterDebugHandler(int32 kindI) : _kind((MainCharacterKind)kindI) {}
 
-	virtual void update() override {
+	void update() override {
 		g_engine->drawQueue().clear();
 		g_engine->player().drawCursor(true);
 		g_engine->drawQueue().draw();
@@ -189,7 +189,7 @@ public:
 		return nullptr;
 	}
 
-	virtual void update() override {
+	void update() override {
 		auto &input = g_engine->input().debugInput();
 		if (input.wasMouseRightPressed()) {
 			g_engine->setDebugMode(DebugMode::None, 0);

--- a/engines/alcachofa/detection.cpp
+++ b/engines/alcachofa/detection.cpp
@@ -34,6 +34,7 @@ const DebugChannelDef AlcachofaMetaEngineDetection::debugFlagList[] = {
 	{ Alcachofa::kDebugScript, "Script", "Enable debug script dump" },
 	{ Alcachofa::kDebugGameplay, "Gameplay", "Gameplay-related tracing" },
 	{ Alcachofa::kDebugSounds, "Sounds", "Sound- and Music-related tracing" },
+	{ Alcachofa::kDebugSemaphores, "Semaphores", "Tracing operations on semaphores" },
 	DEBUG_CHANNEL_END
 };
 

--- a/engines/alcachofa/detection.h
+++ b/engines/alcachofa/detection.h
@@ -31,6 +31,7 @@ enum AlcachofaDebugChannels {
 	kDebugScript,
 	kDebugGameplay,
 	kDebugSounds,
+	kDebugSemaphores
 };
 
 extern const PlainGameDescriptor alcachofaGames[];

--- a/engines/alcachofa/detection.h
+++ b/engines/alcachofa/detection.h
@@ -37,7 +37,8 @@ extern const PlainGameDescriptor alcachofaGames[];
 
 extern const ADGameDescription gameDescriptions[];
 
-#define GAMEOPTION_ORIGINAL_SAVELOAD GUIO_GAMEOPTIONS1
+#define GAMEOPTION_HIGH_QUALITY GUIO_GAMEOPTIONS1 // I should comment what this does, but I don't know
+#define GAMEOPTION_32BITS GUIO_GAMEOPTIONS2
 
 } // End of namespace Alcachofa
 

--- a/engines/alcachofa/detection_tables.h
+++ b/engines/alcachofa/detection_tables.h
@@ -34,7 +34,7 @@ const ADGameDescription gameDescriptions[] = {
 		Common::DE_DEU,
 		Common::kPlatformWindows,
 		ADGF_UNSTABLE,
-		GUIO1(GUIO_NONE)
+		GUIO2(GAMEOPTION_32BITS, GAMEOPTION_HIGH_QUALITY)
 	},
 
 	AD_TABLE_END_MARKER

--- a/engines/alcachofa/detection_tables.h
+++ b/engines/alcachofa/detection_tables.h
@@ -36,7 +36,7 @@ const ADGameDescription gameDescriptions[] = {
 		AD_ENTRY1s("Textos/Objetos.nkr", "a2b1deff5ca7187f2ebf7f2ab20747e9", 17606),
 		Common::DE_DEU,
 		Common::kPlatformWindows,
-		ADGF_UNSTABLE | ADGF_USEEXTRAASTITLE,
+		ADGF_UNSTABLE | ADGF_USEEXTRAASTITLE | ADGF_REMASTERED,
 		GUIO2(GAMEOPTION_32BITS, GAMEOPTION_HIGH_QUALITY)
 	},
 	{
@@ -45,7 +45,7 @@ const ADGameDescription gameDescriptions[] = {
 		AD_ENTRY1s("Textos/Objetos.nkr", "8dce25494470209d4882bf12f1a5ea42", 19208),
 		Common::DE_DEU,
 		Common::kPlatformWindows,
-		ADGF_UNSTABLE | ADGF_USEEXTRAASTITLE | ADGF_DEMO,
+		ADGF_UNSTABLE | ADGF_USEEXTRAASTITLE | ADGF_REMASTERED | ADGF_DEMO,
 		GUIO2(GAMEOPTION_32BITS, GAMEOPTION_HIGH_QUALITY)
 	},
 
@@ -57,7 +57,7 @@ const ADGameDescription gameDescriptions[] = {
 		AD_ENTRY1s("Textos/Objetos.nkr", "ad3cb78ad7a51cfe63ee6f84768c7e66", 15895),
 		Common::EN_ANY,
 		Common::kPlatformWindows,
-		ADGF_UNSTABLE | ADGF_USEEXTRAASTITLE,
+		ADGF_UNSTABLE | ADGF_USEEXTRAASTITLE | ADGF_REMASTERED,
 		GUIO2(GAMEOPTION_32BITS, GAMEOPTION_HIGH_QUALITY)
 	},
 	{
@@ -66,7 +66,7 @@ const ADGameDescription gameDescriptions[] = {
 		AD_ENTRY1s("Textos/Objetos.nkr", "93331e4cc8d2f8f8a0007bfb5140dff5", 16403),
 		Common::ES_ESP,
 		Common::kPlatformWindows,
-		ADGF_UNSTABLE | ADGF_USEEXTRAASTITLE,
+		ADGF_UNSTABLE | ADGF_USEEXTRAASTITLE | ADGF_REMASTERED,
 		GUIO2(GAMEOPTION_32BITS, GAMEOPTION_HIGH_QUALITY)
 	},
 

--- a/engines/alcachofa/detection_tables.h
+++ b/engines/alcachofa/detection_tables.h
@@ -39,6 +39,16 @@ const ADGameDescription gameDescriptions[] = {
 		ADGF_UNSTABLE | ADGF_USEEXTRAASTITLE,
 		GUIO2(GAMEOPTION_32BITS, GAMEOPTION_HIGH_QUALITY)
 	},
+	{
+		"mort_phil_adventura_de_cine",
+		"Clever & Smart - A Movie Adventure",
+		AD_ENTRY1s("Textos/Objetos.nkr", "8dce25494470209d4882bf12f1a5ea42", 19208),
+		Common::DE_DEU,
+		Common::kPlatformWindows,
+		ADGF_UNSTABLE | ADGF_USEEXTRAASTITLE | ADGF_DEMO,
+		GUIO2(GAMEOPTION_32BITS, GAMEOPTION_HIGH_QUALITY)
+	},
+
 
 	// The "english" version is just the spanish version with english subtitles...
 	{

--- a/engines/alcachofa/detection_tables.h
+++ b/engines/alcachofa/detection_tables.h
@@ -22,7 +22,7 @@
 namespace Alcachofa {
 
 const PlainGameDescriptor alcachofaGames[] = {
-	{ "mort_phil_adventura_de_cine", "Mort & Phil: A Movie Adventure" },
+	{ "aventuradecine", "Mort & Phil: A Movie Adventure" },
 	{ 0, 0 }
 };
 
@@ -31,7 +31,7 @@ const ADGameDescription gameDescriptions[] = {
 	// A Movie Adventure
 	//
 	{
-		"mort_phil_adventura_de_cine",
+		"aventuradecine",
 		"Clever & Smart - A Movie Adventure",
 		AD_ENTRY1s("Textos/Objetos.nkr", "a2b1deff5ca7187f2ebf7f2ab20747e9", 17606),
 		Common::DE_DEU,
@@ -40,7 +40,7 @@ const ADGameDescription gameDescriptions[] = {
 		GUIO2(GAMEOPTION_32BITS, GAMEOPTION_HIGH_QUALITY)
 	},
 	{
-		"mort_phil_adventura_de_cine",
+		"aventuradecine",
 		"Clever & Smart - A Movie Adventure",
 		AD_ENTRY1s("Textos/Objetos.nkr", "8dce25494470209d4882bf12f1a5ea42", 19208),
 		Common::DE_DEU,
@@ -52,7 +52,7 @@ const ADGameDescription gameDescriptions[] = {
 
 	// The "english" version is just the spanish version with english subtitles...
 	{
-		"mort_phil_adventura_de_cine",
+		"aventuradecine",
 		"Mortadelo y Filemón: Una Aventura de Cine - Edición Especial",
 		AD_ENTRY1s("Textos/Objetos.nkr", "ad3cb78ad7a51cfe63ee6f84768c7e66", 15895),
 		Common::EN_ANY,
@@ -61,7 +61,7 @@ const ADGameDescription gameDescriptions[] = {
 		GUIO2(GAMEOPTION_32BITS, GAMEOPTION_HIGH_QUALITY)
 	},
 	{
-		"mort_phil_adventura_de_cine",
+		"aventuradecine",
 		"Mortadelo y Filemón: Una Aventura de Cine - Edición Especial",
 		AD_ENTRY1s("Textos/Objetos.nkr", "93331e4cc8d2f8f8a0007bfb5140dff5", 16403),
 		Common::ES_ESP,

--- a/engines/alcachofa/detection_tables.h
+++ b/engines/alcachofa/detection_tables.h
@@ -22,18 +22,41 @@
 namespace Alcachofa {
 
 const PlainGameDescriptor alcachofaGames[] = {
-	{ "mort_phil_adventura_de_cine", "Mort&Phil: A movie adventure" },
+	{ "mort_phil_adventura_de_cine", "Mort & Phil: A Movie Adventure" },
 	{ 0, 0 }
 };
 
 const ADGameDescription gameDescriptions[] = {
+	//
+	// A Movie Adventure
+	//
 	{
 		"mort_phil_adventura_de_cine",
-		nullptr,
+		"Clever & Smart - A Movie Adventure",
 		AD_ENTRY1s("Textos/Objetos.nkr", "a2b1deff5ca7187f2ebf7f2ab20747e9", 17606),
 		Common::DE_DEU,
 		Common::kPlatformWindows,
-		ADGF_UNSTABLE,
+		ADGF_UNSTABLE | ADGF_USEEXTRAASTITLE,
+		GUIO2(GAMEOPTION_32BITS, GAMEOPTION_HIGH_QUALITY)
+	},
+
+	// The "english" version is just the spanish version with english subtitles...
+	{
+		"mort_phil_adventura_de_cine",
+		u8"Mortadelo y Filemón: Una Aventura de Cine - Edición Especial",
+		AD_ENTRY1s("Textos/Objetos.nkr", "ad3cb78ad7a51cfe63ee6f84768c7e66", 15895),
+		Common::EN_ANY,
+		Common::kPlatformWindows,
+		ADGF_UNSTABLE | ADGF_USEEXTRAASTITLE,
+		GUIO2(GAMEOPTION_32BITS, GAMEOPTION_HIGH_QUALITY)
+	},
+	{
+		"mort_phil_adventura_de_cine",
+		u8"Mortadelo y Filemón: Una Aventura de Cine - Edición Especial",
+		AD_ENTRY1s("Textos/Objetos.nkr", "93331e4cc8d2f8f8a0007bfb5140dff5", 16403),
+		Common::ES_ESP,
+		Common::kPlatformWindows,
+		ADGF_UNSTABLE | ADGF_USEEXTRAASTITLE,
 		GUIO2(GAMEOPTION_32BITS, GAMEOPTION_HIGH_QUALITY)
 	},
 

--- a/engines/alcachofa/detection_tables.h
+++ b/engines/alcachofa/detection_tables.h
@@ -53,7 +53,7 @@ const ADGameDescription gameDescriptions[] = {
 	// The "english" version is just the spanish version with english subtitles...
 	{
 		"mort_phil_adventura_de_cine",
-		u8"Mortadelo y Filemón: Una Aventura de Cine - Edición Especial",
+		"Mortadelo y Filemón: Una Aventura de Cine - Edición Especial",
 		AD_ENTRY1s("Textos/Objetos.nkr", "ad3cb78ad7a51cfe63ee6f84768c7e66", 15895),
 		Common::EN_ANY,
 		Common::kPlatformWindows,
@@ -62,7 +62,7 @@ const ADGameDescription gameDescriptions[] = {
 	},
 	{
 		"mort_phil_adventura_de_cine",
-		u8"Mortadelo y Filemón: Una Aventura de Cine - Edición Especial",
+		"Mortadelo y Filemón: Una Aventura de Cine - Edición Especial",
 		AD_ENTRY1s("Textos/Objetos.nkr", "93331e4cc8d2f8f8a0007bfb5140dff5", 16403),
 		Common::ES_ESP,
 		Common::kPlatformWindows,

--- a/engines/alcachofa/game-movie-adventure.cpp
+++ b/engines/alcachofa/game-movie-adventure.cpp
@@ -140,6 +140,14 @@ class GameMovieAdventure : public Game {
 			return;
 		Game::missingSound(fileName);
 	}
+
+	void invalidVideo(int32 videoId, const char *context) override {
+		// for the one, known AVI problem, let's not block development
+		if (videoId == 1 && g_engine->gameDescription().language != DE_DEU)
+			warning("Could not play video %d (%s) (known problem with AVI decoder)", videoId, context);
+		else
+			Game::invalidVideo(videoId, context);
+	}
 };
 
 Game *Game::createForMovieAdventure() {

--- a/engines/alcachofa/game-movie-adventure.cpp
+++ b/engines/alcachofa/game-movie-adventure.cpp
@@ -27,17 +27,17 @@ using namespace Common;
 namespace Alcachofa {
 
 class GameMovieAdventure : public Game {
-	virtual bool doesRoomHaveBackground(const Room *room) override {
+	bool doesRoomHaveBackground(const Room *room) override {
 		return !room->name().equalsIgnoreCase("Global") &&
 			!room->name().equalsIgnoreCase("HABITACION_NEGRA");
 	}
 
-	virtual void invalidDialogLine(uint index) override {
+	void invalidDialogLine(uint index) override {
 		if (index != 4542)
 			Game::invalidDialogLine(index);
 	}
 
-	virtual bool shouldCharacterTrigger(const Character *character, const char *action) override {
+	bool shouldCharacterTrigger(const Character *character, const char *action) override {
 		// An original hack to check that bed sheet is used on the other main character only in the correct room
 		// There *is* another script variable (es_casa_freddy) that should check this
 		// but, I guess, Alcachofa Soft found a corner case where this does not work?
@@ -57,12 +57,12 @@ class GameMovieAdventure : public Game {
 		return Game::shouldTriggerDoor(door);
 	}
 
-	virtual bool hasMortadeloVoice(const Character *character) override {
+	bool hasMortadeloVoice(const Character *character) override {
 		return Game::hasMortadeloVoice(character) ||
 			character->name().equalsIgnoreCase("MORTADELO_TREN"); // an original hard-coded special case
 	}
 
-	virtual void missingAnimation(const String &fileName) override {
+	void missingAnimation(const String &fileName) override {
 		static const char *exemptions[] = {
 			"ANIMACION.AN0",
 			"DESPACHO_SUPER2_OL_SOMBRAS2.AN0",
@@ -82,13 +82,13 @@ class GameMovieAdventure : public Game {
 		Game::missingAnimation(fileName);
 	}
 
-	virtual void unknownAnimateObject(const char *name) override {
+	void unknownAnimateObject(const char *name) override {
 		if (!scumm_stricmp("EXPLOSION DISFRAZ", name))
 			return;
 		Game::unknownAnimateObject(name);
 	}
 
-	virtual PointObject *unknownGoPutTarget(const Process &process, const char *action, const char *name) override {
+	PointObject *unknownGoPutTarget(const Process &process, const char *action, const char *name) override {
 		if (scumm_stricmp(action, "put"))
 			return Game::unknownGoPutTarget(process, action, name);
 
@@ -117,20 +117,20 @@ class GameMovieAdventure : public Game {
 		return Game::unknownGoPutTarget(process, action, name);
 	}
 
-	virtual void unknownSayTextCharacter(const char *name, int32 dialogId) override {
+	void unknownSayTextCharacter(const char *name, int32 dialogId) override {
 		if (!scumm_stricmp(name, "OFELIA") && dialogId == 3737)
 			return;
 		Game::unknownSayTextCharacter(name, dialogId);
 	}
 
-	virtual void unknownAnimateCharacterObject(const char *name) override {
+	void unknownAnimateCharacterObject(const char *name) override {
 		if (!scumm_stricmp(name, "COGE F DCH") || // original bug in MOTEL_ENTRADA
 			!scumm_stricmp(name, "CHIQUITO_IZQ"))
 			return;
 		Game::unknownAnimateCharacterObject(name);
 	}
 
-	virtual void missingSound(const String &fileName) override {
+	void missingSound(const String &fileName) override {
 		if (fileName == "CHAS" || fileName == "517")
 			return;
 		Game::missingSound(fileName);

--- a/engines/alcachofa/game-movie-adventure.cpp
+++ b/engines/alcachofa/game-movie-adventure.cpp
@@ -51,6 +51,7 @@ class GameMovieAdventure : public Game {
 	}
 
 	virtual bool shouldTriggerDoor(const Door *door) {
+		// An invalid door target, the character will go to the door and then ignore it (also in original engine)
 		if (door->targetRoom() == "LABERINTO" && door->targetObject() == "a_LABERINTO_desde_LABERINTO_2")
 			return false;
 		return Game::shouldTriggerDoor(door);

--- a/engines/alcachofa/game-movie-adventure.cpp
+++ b/engines/alcachofa/game-movie-adventure.cpp
@@ -21,6 +21,7 @@
 
 #include "alcachofa.h"
 #include "game.h"
+#include "script.h"
 
 using namespace Common;
 
@@ -55,6 +56,15 @@ class GameMovieAdventure : public Game {
 		if (door->targetRoom() == "LABERINTO" && door->targetObject() == "a_LABERINTO_desde_LABERINTO_2")
 			return false;
 		return Game::shouldTriggerDoor(door);
+	}
+
+	void onUserChangedCharacter() override {
+		// An original bug in room POBLADO_INDIO if filemon is bound and mortadelo enters the room
+		// the door A_PUENTE which was disabled is reenabled to allow mortadelo leaving
+		// However if the user now changes character, the door is still enabled and filemon can
+		// enter a ghost state walking through a couple rooms and softlocking.
+		if (g_engine->player().currentRoom()->name().equalsIgnoreCase("POBLADO_INDIO"))
+			g_engine->script().createProcess(g_engine->player().activeCharacterKind(), "ENTRAR_POBLADO_INDIO");
 	}
 
 	bool hasMortadeloVoice(const Character *character) override {

--- a/engines/alcachofa/game-movie-adventure.cpp
+++ b/engines/alcachofa/game-movie-adventure.cpp
@@ -50,7 +50,7 @@ class GameMovieAdventure : public Game {
 		return Game::shouldCharacterTrigger(character, action);
 	}
 
-	virtual bool shouldTriggerDoor(const Door *door) {
+	bool shouldTriggerDoor(const Door *door) override {
 		// An invalid door target, the character will go to the door and then ignore it (also in original engine)
 		if (door->targetRoom() == "LABERINTO" && door->targetObject() == "a_LABERINTO_desde_LABERINTO_2")
 			return false;

--- a/engines/alcachofa/game-movie-adventure.cpp
+++ b/engines/alcachofa/game-movie-adventure.cpp
@@ -33,11 +33,6 @@ class GameMovieAdventure : public Game {
 			!room->name().equalsIgnoreCase("HABITACION_NEGRA");
 	}
 
-	void invalidDialogLine(uint index) override {
-		if (index != 4542)
-			Game::invalidDialogLine(index);
-	}
-
 	bool shouldCharacterTrigger(const Character *character, const char *action) override {
 		// An original hack to check that bed sheet is used on the other main character only in the correct room
 		// There *is* another script variable (es_casa_freddy) that should check this

--- a/engines/alcachofa/game-movie-adventure.cpp
+++ b/engines/alcachofa/game-movie-adventure.cpp
@@ -19,9 +19,9 @@
  *
  */
 
-#include "alcachofa.h"
-#include "game.h"
-#include "script.h"
+#include "alcachofa/alcachofa.h"
+#include "alcachofa/game.h"
+#include "alcachofa/script.h"
 
 using namespace Common;
 

--- a/engines/alcachofa/game-objects.cpp
+++ b/engines/alcachofa/game-objects.cpp
@@ -19,11 +19,11 @@
  *
  */
 
-#include "objects.h"
-#include "rooms.h"
-#include "script.h"
-#include "global-ui.h"
-#include "alcachofa.h"
+#include "alcachofa/objects.h"
+#include "alcachofa/rooms.h"
+#include "alcachofa/script.h"
+#include "alcachofa/global-ui.h"
+#include "alcachofa/alcachofa.h"
 
 using namespace Common;
 using namespace Math;

--- a/engines/alcachofa/game-objects.cpp
+++ b/engines/alcachofa/game-objects.cpp
@@ -350,7 +350,7 @@ struct SayTextTask final : public Task {
 		s.syncAsSint32LE(_dialogId);
 	}
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 private:
 	Character *_character = nullptr;
@@ -428,7 +428,7 @@ struct AnimateCharacterTask final : public Task {
 		scumm_assert(_graphic != nullptr);
 	}
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 private:
 	Character *_character = nullptr;
@@ -485,7 +485,7 @@ struct LerpLodBiasTask final : public Task {
 		s.syncAsUint32LE(_durationMs);
 	}
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 private:
 	Character *_character = nullptr;
@@ -800,7 +800,7 @@ struct ArriveTask : public Task {
 		syncObjectAsString(s, _character);
 	}
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 private:
 	const WalkingCharacter *_character = nullptr;
 };
@@ -1083,7 +1083,7 @@ struct DialogMenuTask : public Task {
 		s.syncAsUint32LE(_clickedLineI);
 	}
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 private:
 	static constexpr int kTextXOffset = 5;

--- a/engines/alcachofa/game-objects.cpp
+++ b/engines/alcachofa/game-objects.cpp
@@ -301,15 +301,15 @@ struct SayTextTask final : public Task {
 		while (true) {
 			g_engine->player().addLastDialogCharacter(_character);
 
-			if (_soundId == kInvalidSoundID)
+			if (_soundHandle == SoundHandle {})
 			{
 				bool hasMortadeloVoice = g_engine->game().hasMortadeloVoice(_character);					
-				_soundId = g_engine->sounds().playVoice(
+				_soundHandle = g_engine->sounds().playVoice(
 					String::format(hasMortadeloVoice ? "M%04d" : "%04d", _dialogId),
 					0);
 			}
-			isSoundStillPlaying = g_engine->sounds().isAlive(_soundId);
-			g_engine->sounds().setAppropriateVolume(_soundId, process().character(), _character);
+			isSoundStillPlaying = g_engine->sounds().isAlive(_soundHandle);
+			g_engine->sounds().setAppropriateVolume(_soundHandle, process().character(), _character);
 			if (!isSoundStillPlaying || g_engine->input().wasAnyMouseReleased())
 				_character->_isTalking = false;
 
@@ -323,13 +323,13 @@ struct SayTextTask final : public Task {
 			}
 
 			if (!_character->_isTalking) {
-				g_engine->sounds().fadeOut(_soundId, 100);
+				g_engine->sounds().fadeOut(_soundHandle, 100);
 				TASK_WAIT(delay(200));
 				TASK_RETURN(0);
 			}
 
 			_character->isSpeaking() = !isSoundStillPlaying ||
-				g_engine->sounds().isNoisy(_soundId, 80.0f, 150.0f);
+				g_engine->sounds().isNoisy(_soundHandle, 80.0f, 150.0f);
 			TASK_YIELD;
 		}
 		TASK_END;
@@ -342,7 +342,7 @@ struct SayTextTask final : public Task {
 private:
 	Character *_character;
 	int32 _dialogId;
-	SoundID _soundId = kInvalidSoundID;
+	SoundHandle _soundHandle = {};
 };
 
 Task *Character::sayText(Process &process, int32 dialogId) {

--- a/engines/alcachofa/game-objects.cpp
+++ b/engines/alcachofa/game-objects.cpp
@@ -48,7 +48,7 @@ Item::Item(const Item &other)
 void Item::draw() {
 	if (!isEnabled())
 		return;
-	Item* heldItem = g_engine->player().heldItem();
+	Item *heldItem = g_engine->player().heldItem();
 	if (heldItem == nullptr || !heldItem->name().equalsIgnoreCase(name()))
 		GraphicObject::draw();
 }
@@ -61,8 +61,7 @@ void Item::trigger() {
 			player.triggerObject(this, "MIRAR");
 		else
 			heldItem = nullptr;
-	}
-	else if (heldItem == nullptr)
+	} else if (heldItem == nullptr)
 		heldItem = this;
 	else if (g_engine->script().hasProcedure(name(), heldItem->name()) ||
 		!g_engine->script().hasProcedure(heldItem->name(), name()))
@@ -73,8 +72,7 @@ void Item::trigger() {
 
 ITriggerableObject::ITriggerableObject(ReadStream &stream)
 	: _interactionPoint(Shape(stream).firstPoint())
-	, _interactionDirection((Direction)stream.readSint32LE()) {
-}
+	, _interactionDirection((Direction)stream.readSint32LE()) {}
 
 void ITriggerableObject::onClick() {
 	auto heldItem = g_engine->player().heldItem();
@@ -135,11 +133,17 @@ CursorType Door::cursorType() const {
 	if (fromObject != CursorType::Point)
 		return fromObject;
 	switch (_interactionDirection) {
-	case Direction::Up: return CursorType::LeaveUp;
-	case Direction::Right: return CursorType::LeaveRight;
-	case Direction::Down: return CursorType::LeaveDown;
-	case Direction::Left: return CursorType::LeaveLeft;
-	default: assert(false && "Invalid door character direction"); return fromObject;
+	case Direction::Up:
+		return CursorType::LeaveUp;
+	case Direction::Right:
+		return CursorType::LeaveRight;
+	case Direction::Down:
+		return CursorType::LeaveDown;
+	case Direction::Left:
+		return CursorType::LeaveLeft;
+	default:
+		assert(false && "Invalid door character direction");
+		return fromObject;
 	}
 }
 
@@ -182,16 +186,14 @@ void Character::update() {
 	if (animateGraphic != nullptr) {
 		animateGraphic->topLeft() = Point(0, 0);
 		animateGraphic->update();
-	}
-	else if (_isTalking)
+	} else if (_isTalking)
 		updateTalkingAnimation();
 	else if (g_engine->world().somebodyUsing(this)) {
 		Graphic *talkGraphic = graphicOf(_curTalkingObject, &_graphicTalking);
 		talkGraphic->start(true);
 		talkGraphic->pause();
 		talkGraphic->update();
-	}
-	else
+	} else
 		_graphicNormal.update();
 }
 
@@ -289,8 +291,7 @@ struct SayTextTask final : public Task {
 	SayTextTask(Process &process, Character *character, int32 dialogId)
 		: Task(process)
 		, _character(character)
-		, _dialogId(dialogId) {
-	}
+		, _dialogId(dialogId) {}
 
 	SayTextTask(Process &process, Serializer &s)
 		: Task(process) {
@@ -306,9 +307,8 @@ struct SayTextTask final : public Task {
 		while (true) {
 			g_engine->player().addLastDialogCharacter(_character);
 
-			if (_soundHandle == SoundHandle {})
-			{
-				bool hasMortadeloVoice = g_engine->game().hasMortadeloVoice(_character);					
+			if (_soundHandle == SoundHandle {}) {
+				bool hasMortadeloVoice = g_engine->game().hasMortadeloVoice(_character);
 				_soundHandle = g_engine->sounds().playVoice(
 					String::format(hasMortadeloVoice ? "M%04d" : "%04d", _dialogId),
 					0);
@@ -404,8 +404,7 @@ struct AnimateCharacterTask final : public Task {
 		_graphic->start(false);
 		if (_character->room() == g_engine->player().currentRoom())
 			_graphic->update();
-		do
-		{
+		do {
 			TASK_YIELD(2);
 			if (process().isActiveForPlayer() && g_engine->input().wasAnyMouseReleased())
 				_graphic->pause();
@@ -447,8 +446,7 @@ struct LerpLodBiasTask final : public Task {
 		: Task(process)
 		, _character(character)
 		, _targetLodBias(targetLodBias)
-		, _durationMs(durationMs) {
-	}
+		, _durationMs(durationMs) {}
 
 	LerpLodBiasTask(Process &process, Serializer &s)
 		: Task(process) {
@@ -575,8 +573,7 @@ static Direction getDirection(Point from, Point to) {
 		return slope > 1000 ? Direction::Up
 			: slope < -1000 ? Direction::Down
 			: Direction::Right;
-	}
-	else { // from.x > to.x
+	} else { // from.x > to.x
 		int slope = 1000 * delta.y / delta.x;
 		return slope > 1000 ? Direction::Up
 			: slope < -1000 ? Direction::Down
@@ -597,16 +594,14 @@ void WalkingCharacter::updateWalking() {
 	if (_sourcePos == targetPos) {
 		_currentPos = targetPos;
 		_pathPoints.pop();
-	}
-	else {
+	} else {
 		updateWalkingAnimation();
 		const int32 distanceToTarget = (int32)(sqrtf(_sourcePos.sqrDist(targetPos)));
 		if (_walkedDistance < distanceToTarget) {
 			// separated because having only 16 bits and multiplications seems dangerous
 			_currentPos.x = _sourcePos.x + _walkedDistance * (targetPos.x - _sourcePos.x) / distanceToTarget;
 			_currentPos.y = _sourcePos.y + _walkedDistance * (targetPos.y - _sourcePos.y) / distanceToTarget;
-		}
-		else {
+		} else {
 			_sourcePos = _currentPos = targetPos;
 			_pathPoints.pop();
 			_walkedDistance = 1;
@@ -638,8 +633,7 @@ void WalkingCharacter::updateWalkingAnimation() {
 		_lastWalkAnimFrame = expectedFrame;
 		stepFrameFrom = 2 * expectedFrame - 2;
 		stepFrameTo = 2 * expectedFrame;
-	}
-	else {
+	} else {
 		const int32 frameThreshold = _lastWalkAnimFrame <= halfFrameCount - 1
 			? _lastWalkAnimFrame
 			: (_lastWalkAnimFrame - halfFrameCount + 1) % (halfFrameCount - 2) + 1;
@@ -648,8 +642,7 @@ void WalkingCharacter::updateWalkingAnimation() {
 		if (expectedFrame >= frameThreshold) {
 			stepFrameFrom = 2 * expectedFrame - 2;
 			stepFrameTo = 2 * expectedFrame;
-		}
-		else {
+		} else {
 			stepFrameFrom = 2 * (halfFrameCount - 2);
 			stepFrameTo = 2 * halfFrameCount - 2;
 		}
@@ -661,8 +654,7 @@ void WalkingCharacter::updateWalkingAnimation() {
 	_graphicNormal.frameI() = 2 * expectedFrame; // especially this: wtf?
 }
 
-void WalkingCharacter::onArrived() {
-}
+void WalkingCharacter::onArrived() {}
 
 void WalkingCharacter::stopWalking(Direction direction) {
 	// be careful, the original engine had two versions of this method
@@ -778,12 +770,11 @@ void WalkingCharacter::syncGame(Serializer &serializer) {
 struct ArriveTask : public Task {
 	ArriveTask(Process &process, const WalkingCharacter *character)
 		: Task(process)
-		, _character(character) {
-	}
+		, _character(character) {}
 
 	ArriveTask(Process &process, Serializer &s)
 		: Task(process) {
-		syncGame(s);		
+		syncGame(s);
 	}
 
 	TaskReturn run() override {
@@ -891,8 +882,7 @@ void MainCharacter::walkTo(
 		if (!otherCharacter->isBusy()) {
 			if (activeFloor != nullptr && activeFloor->findEvadeTarget(evadeTarget, activeDepthScale, avoidanceDistSqr, evadeTarget))
 				otherCharacter->WalkingCharacter::walkTo(evadeTarget);
-		}
-		else if (!willIBeBusy) {
+		} else if (!willIBeBusy) {
 			if (activeFloor != nullptr)
 				activeFloor->findEvadeTarget(evadeTarget, activeDepthScale, avoidanceDistSqr, target);
 		}
@@ -908,8 +898,7 @@ void MainCharacter::draw() {
 		if (_currentPos.y <= g_engine->world().filemon()._currentPos.y) {
 			g_engine->world().mortadelo().drawInner();
 			g_engine->world().filemon().drawInner();
-		}
-		else {
+		} else {
 			g_engine->world().filemon().drawInner();
 			g_engine->world().mortadelo().drawInner();
 		}
@@ -1040,8 +1029,7 @@ struct DialogMenuTask : public Task {
 	DialogMenuTask(Process &process, MainCharacter *character)
 		: Task(process)
 		, _input(g_engine->input())
-		, _character(character) {
-	}
+		, _character(character) {}
 
 	DialogMenuTask(Process &process, Serializer &s)
 		: Task(process)
@@ -1117,7 +1105,7 @@ private:
 				g_engine->globalUI().dialogFont(),
 				g_engine->world().getDialogLine(itLine._dialogId),
 				Point(kTextXOffset, itLine._yPosition),
-				maxTextWidth(), false, isHovered ? Color{ 255, 255, 128, 255 } : kWhite, -kForegroundOrderCount + 2);
+				maxTextWidth(), false, isHovered ? Color { 255, 255, 128, 255 } : kWhite, -kForegroundOrderCount + 2);
 			isSomethingHovered = isSomethingHovered || isHovered;
 			if (isHovered && _input.wasMouseLeftReleased())
 				return i - 1;
@@ -1169,8 +1157,7 @@ const char *FloorColor::typeName() const { return "FloorColor"; }
 
 FloorColor::FloorColor(Room *room, ReadStream &stream)
 	: ObjectBase(room, stream)
-	, _shape(stream) {
-}
+	, _shape(stream) {}
 
 void FloorColor::update() {
 	auto updateFor = [&] (MainCharacter &character) {

--- a/engines/alcachofa/game-objects.cpp
+++ b/engines/alcachofa/game-objects.cpp
@@ -144,11 +144,11 @@ CursorType Door::cursorType() const {
 }
 
 void Door::onClick() {
-	if (g_system->getMillis() - _lastClickTime < 500 && g_engine->player().activeCharacter()->clearTargetIf(this))
+	if (g_engine->getMillis() - _lastClickTime < 500 && g_engine->player().activeCharacter()->clearTargetIf(this))
 		trigger(nullptr);
 	else {
 		InteractableObject::onClick();
-		_lastClickTime = g_system->getMillis();
+		_lastClickTime = g_engine->getMillis();
 	}
 }
 
@@ -422,11 +422,11 @@ struct LerpLodBiasTask final : public Task {
 
 	virtual TaskReturn run() override {
 		TASK_BEGIN;
-		_startTime = g_system->getMillis();
+		_startTime = g_engine->getMillis();
 		_sourceLodBias = _character->lodBias();
-		while (g_system->getMillis() - _startTime < _durationMs) {
+		while (g_engine->getMillis() - _startTime < _durationMs) {
 			_character->lodBias() = _sourceLodBias + (_targetLodBias - _sourceLodBias) *
-				((g_system->getMillis() - _startTime) / (float)_durationMs);
+				((g_engine->getMillis() - _startTime) / (float)_durationMs);
 			TASK_YIELD;
 		}
 		_character->lodBias() = _targetLodBias;
@@ -434,8 +434,8 @@ struct LerpLodBiasTask final : public Task {
 	}
 
 	virtual void debugPrint() override {
-		uint32 remaining = g_system->getMillis() - _startTime <= _durationMs
-			? _durationMs - (g_system->getMillis() - _startTime)
+		uint32 remaining = g_engine->getMillis() - _startTime <= _durationMs
+			? _durationMs - (g_engine->getMillis() - _startTime)
 			: 0;
 		g_engine->console().debugPrintf("Lerp lod bias of %s to %f with %ums remaining\n",
 			_character->name().c_str(), _targetLodBias, remaining);
@@ -584,7 +584,7 @@ void WalkingCharacter::updateWalkingAnimation() {
 
 	// this is very confusing. Let's see what it does
 	const int32 halfFrameCount = (int32)animation->frameCount() / 2;
-	int32 expectedFrame = (int32)(g_system->getMillis() - _graphicNormal.lastTime()) * 12 / 1000;
+	int32 expectedFrame = (int32)(g_engine->getMillis() - _graphicNormal.lastTime()) * 12 / 1000;
 	const bool isUnexpectedFrame = expectedFrame != _lastWalkAnimFrame;
 	int32 stepFrameFrom, stepFrameTo;
 	if (expectedFrame < halfFrameCount - 1) {

--- a/engines/alcachofa/game-objects.cpp
+++ b/engines/alcachofa/game-objects.cpp
@@ -297,7 +297,7 @@ struct SayTextTask final : public Task {
 		syncGame(s);
 	}
 
-	virtual TaskReturn run() override {
+	TaskReturn run() override {
 		bool isSoundStillPlaying;
 
 		TASK_BEGIN;
@@ -340,11 +340,11 @@ struct SayTextTask final : public Task {
 		TASK_END;
 	}
 
-	virtual void debugPrint() override {
+	void debugPrint() override {
 		g_engine->console().debugPrintf("SayText %s, %d\n", _character->name().c_str(), _dialogId);
 	}
 
-	virtual void syncGame(Serializer &s) override {
+	void syncGame(Serializer &s) override {
 		Task::syncGame(s);
 		syncObjectAsString(s, _character);
 		s.syncAsSint32LE(_dialogId);
@@ -395,7 +395,7 @@ struct AnimateCharacterTask final : public Task {
 		syncGame(s);
 	}
 
-	virtual TaskReturn run() override {
+	TaskReturn run() override {
 		TASK_BEGIN;
 		while (_character->_curAnimateObject != nullptr)
 			TASK_YIELD(1);
@@ -416,11 +416,11 @@ struct AnimateCharacterTask final : public Task {
 		TASK_END;
 	}
 
-	virtual void debugPrint() override {
+	void debugPrint() override {
 		g_engine->console().debugPrintf("AnimateCharacter %s, %s\n", _character->name().c_str(), _animateObject->name().c_str());
 	}
 
-	virtual void syncGame(Serializer &s) override {
+	void syncGame(Serializer &s) override {
 		Task::syncGame(s);
 		syncObjectAsString(s, _character);
 		syncObjectAsString(s, _animateObject);
@@ -455,7 +455,7 @@ struct LerpLodBiasTask final : public Task {
 		syncGame(s);
 	}
 
-	virtual TaskReturn run() override {
+	TaskReturn run() override {
 		TASK_BEGIN;
 		_startTime = g_engine->getMillis();
 		_sourceLodBias = _character->lodBias();
@@ -468,7 +468,7 @@ struct LerpLodBiasTask final : public Task {
 		TASK_END;
 	}
 
-	virtual void debugPrint() override {
+	void debugPrint() override {
 		uint32 remaining = g_engine->getMillis() - _startTime <= _durationMs
 			? _durationMs - (g_engine->getMillis() - _startTime)
 			: 0;
@@ -476,7 +476,7 @@ struct LerpLodBiasTask final : public Task {
 			_character->name().c_str(), _targetLodBias, remaining);
 	}
 
-	virtual void syncGame(Serializer &s) override {
+	void syncGame(Serializer &s) override {
 		Task::syncGame(s);
 		syncObjectAsString(s, _character);
 		s.syncAsFloatLE(_sourceLodBias);
@@ -786,17 +786,17 @@ struct ArriveTask : public Task {
 		syncGame(s);		
 	}
 
-	virtual TaskReturn run() override {
+	TaskReturn run() override {
 		return _character->isWalking()
 			? TaskReturn::yield()
 			: TaskReturn::finish(1);
 	}
 
-	virtual void debugPrint() override {
+	void debugPrint() override {
 		g_engine->getDebugger()->debugPrintf("Wait for %s to arrive", _character->name().c_str());
 	}
 
-	virtual void syncGame(Serializer &s) override {
+	void syncGame(Serializer &s) override {
 		syncObjectAsString(s, _character);
 	}
 
@@ -1048,7 +1048,7 @@ struct DialogMenuTask : public Task {
 		syncGame(s);
 	}
 
-	virtual TaskReturn run() override {
+	TaskReturn run() override {
 		TASK_BEGIN;
 		layoutLines();
 		while (true) {
@@ -1071,12 +1071,12 @@ struct DialogMenuTask : public Task {
 		TASK_END;
 	}
 
-	virtual void debugPrint() override {
+	void debugPrint() override {
 		g_engine->console().debugPrintf("DialogMenu for %s with %u lines\n",
 			_character->name().c_str(), _character->_dialogLines.size());
 	}
 
-	virtual void syncGame(Serializer &s) override {
+	void syncGame(Serializer &s) override {
 		Task::syncGame(s);
 		syncObjectAsString(s, _character);
 		s.syncAsUint32LE(_clickedLineI);

--- a/engines/alcachofa/game-objects.cpp
+++ b/engines/alcachofa/game-objects.cpp
@@ -357,7 +357,7 @@ private:
 	int32 _dialogId = 0;
 	SoundHandle _soundHandle = {};
 };
-DECLARE_TASK(SayTextTask);
+DECLARE_TASK(SayTextTask)
 
 Task *Character::sayText(Process &process, int32 dialogId) {
 	return new SayTextTask(process, this, dialogId);
@@ -435,7 +435,7 @@ private:
 	ObjectBase *_animateObject = nullptr;
 	Graphic *_graphic = nullptr;
 };
-DECLARE_TASK(AnimateCharacterTask);
+DECLARE_TASK(AnimateCharacterTask)
 
 Task *Character::animate(Process &process, ObjectBase *animateObject) {
 	assert(animateObject != nullptr);
@@ -492,7 +492,7 @@ private:
 	float _sourceLodBias = 0, _targetLodBias = 0;
 	uint32 _startTime = 0, _durationMs = 0;
 };
-DECLARE_TASK(LerpLodBiasTask);
+DECLARE_TASK(LerpLodBiasTask)
 
 Task *Character::lerpLodBias(Process &process, float targetLodBias, int32 durationMs) {
 	return new LerpLodBiasTask(process, this, targetLodBias, durationMs);
@@ -804,7 +804,7 @@ struct ArriveTask : public Task {
 private:
 	const WalkingCharacter *_character = nullptr;
 };
-DECLARE_TASK(ArriveTask);
+DECLARE_TASK(ArriveTask)
 
 Task *WalkingCharacter::waitForArrival(Process &process) {
 	return new ArriveTask(process, this);
@@ -1129,7 +1129,7 @@ private:
 	MainCharacter *_character = nullptr;
 	uint _clickedLineI = UINT_MAX;
 };
-DECLARE_TASK(DialogMenuTask);
+DECLARE_TASK(DialogMenuTask)
 
 void MainCharacter::addDialogLine(int32 dialogId) {
 	assert(dialogId >= 0);

--- a/engines/alcachofa/game-objects.cpp
+++ b/engines/alcachofa/game-objects.cpp
@@ -353,8 +353,8 @@ struct SayTextTask final : public Task {
 	virtual const char *taskName() const override;
 
 private:
-	Character *_character;
-	int32 _dialogId;
+	Character *_character = nullptr;
+	int32 _dialogId = 0;
 	SoundHandle _soundHandle = {};
 };
 DECLARE_TASK(SayTextTask);
@@ -431,9 +431,9 @@ struct AnimateCharacterTask final : public Task {
 	virtual const char *taskName() const override;
 
 private:
-	Character *_character;
-	ObjectBase *_animateObject;
-	Graphic *_graphic;
+	Character *_character = nullptr;
+	ObjectBase *_animateObject = nullptr;
+	Graphic *_graphic = nullptr;
 };
 DECLARE_TASK(AnimateCharacterTask);
 
@@ -488,9 +488,9 @@ struct LerpLodBiasTask final : public Task {
 	virtual const char *taskName() const override;
 
 private:
-	Character *_character;
-	float _sourceLodBias = 0, _targetLodBias;
-	uint32 _startTime = 0, _durationMs;
+	Character *_character = nullptr;
+	float _sourceLodBias = 0, _targetLodBias = 0;
+	uint32 _startTime = 0, _durationMs = 0;
 };
 DECLARE_TASK(LerpLodBiasTask);
 
@@ -802,7 +802,7 @@ struct ArriveTask : public Task {
 
 	virtual const char *taskName() const override;
 private:
-	const WalkingCharacter *_character;
+	const WalkingCharacter *_character = nullptr;
 };
 DECLARE_TASK(ArriveTask);
 
@@ -813,7 +813,8 @@ Task *WalkingCharacter::waitForArrival(Process &process) {
 const char *MainCharacter::typeName() const { return "MainCharacter"; }
 
 MainCharacter::MainCharacter(Room *room, ReadStream &stream)
-	: WalkingCharacter(room, stream) {
+	: WalkingCharacter(room, stream)
+	, _semaphore(name().firstChar() == 'M' ? "mortadelo" : "filemon") {
 	stream.readByte(); // unused byte
 	_order = 100;
 
@@ -1125,7 +1126,7 @@ private:
 	}
 
 	Input &_input;
-	MainCharacter *_character;
+	MainCharacter *_character = nullptr;
 	uint _clickedLineI = UINT_MAX;
 };
 DECLARE_TASK(DialogMenuTask);

--- a/engines/alcachofa/game-objects.cpp
+++ b/engines/alcachofa/game-objects.cpp
@@ -313,7 +313,7 @@ struct SayTextTask final : public Task {
 			if (!isSoundStillPlaying || g_engine->input().wasAnyMouseReleased())
 				_character->_isTalking = false;
 
-			if (true && // TODO: Add game option for subtitles
+			if (g_engine->config().subtitles() &&
 				process().isActiveForPlayer()) {
 				g_engine->drawQueue().add<TextDrawRequest>(
 					g_engine->globalUI().dialogFont(),

--- a/engines/alcachofa/game.cpp
+++ b/engines/alcachofa/game.cpp
@@ -94,7 +94,7 @@ void Game::unknownFadeType(int fadeType) {
 }
 
 void Game::unknownSerializedObject(const char *object, const char *owner, const char *room) {
-	// potentially game-breaking for _currentlyUsingObject but should otherwise be just a graphical bug
+	// potentially game-breaking for _currentlyUsingObject but might otherwise be just a graphical bug
 	_message("Invalid object name \"%s\" saved for \"%s\" in \"%s\"", object, owner, room);
 }
 

--- a/engines/alcachofa/game.cpp
+++ b/engines/alcachofa/game.cpp
@@ -79,6 +79,8 @@ bool Game::shouldTriggerDoor(const Door *door) {
 	return true;
 }
 
+void Game::onUserChangedCharacter() { }
+
 bool Game::hasMortadeloVoice(const Character *character) {
 	return character == &g_engine->world().mortadelo();
 }

--- a/engines/alcachofa/game.cpp
+++ b/engines/alcachofa/game.cpp
@@ -193,4 +193,8 @@ void Game::notEnoughObjectDataRead(const char *room, int64 filePos, int64 object
 	_message("Did not read enough data (%dll < %dll) for an object in room %s", filePos, objectEnd, room);
 }
 
+void Game::invalidVideo(int32 videoId, const char *context) {
+	_message("Could not play video %d (%s)", videoId, context);
+}
+
 }

--- a/engines/alcachofa/game.cpp
+++ b/engines/alcachofa/game.cpp
@@ -36,6 +36,8 @@ Game::Game()
 {
 }
 
+void Game::onLoadedGameFiles() {}
+
 bool Game::doesRoomHaveBackground(const Room *room) {
 	return true;
 }
@@ -191,6 +193,10 @@ void Game::notEnoughRoomDataRead(const char *path, int64 filePos, int64 roomEnd)
 
 void Game::notEnoughObjectDataRead(const char *room, int64 filePos, int64 objectEnd) {
 	_message("Did not read enough data (%dll < %dll) for an object in room %s", filePos, objectEnd, room);
+}
+
+bool Game::isKnownBadVideo(int32 videoId) {
+	return false;
 }
 
 void Game::invalidVideo(int32 videoId, const char *context) {

--- a/engines/alcachofa/game.cpp
+++ b/engines/alcachofa/game.cpp
@@ -33,8 +33,7 @@ Game::Game()
 #else // For release builds the game might still work or the user might still be able to save and restart
 	: _message(warning)
 #endif
-{
-}
+{}
 
 void Game::onLoadedGameFiles() {}
 
@@ -81,7 +80,7 @@ bool Game::shouldTriggerDoor(const Door *door) {
 	return true;
 }
 
-void Game::onUserChangedCharacter() { }
+void Game::onUserChangedCharacter() {}
 
 bool Game::hasMortadeloVoice(const Character *character) {
 	return character == &g_engine->world().mortadelo();

--- a/engines/alcachofa/game.cpp
+++ b/engines/alcachofa/game.cpp
@@ -28,7 +28,7 @@ using namespace Common;
 namespace Alcachofa {
 
 Game::Game()
-#ifdef _DEBUG // During development let's check out these errors more carefully
+#ifdef ALCACHOFA_DEBUG // During development let's check out these errors more carefully
 	: _message(error)
 #else // For release builds the game might still work or the user might still be able to save and restart
 	: _message(warning)

--- a/engines/alcachofa/game.cpp
+++ b/engines/alcachofa/game.cpp
@@ -19,9 +19,9 @@
  *
  */
 
-#include "alcachofa.h"
-#include "game.h"
-#include "script.h"
+#include "alcachofa/alcachofa.h"
+#include "alcachofa/game.h"
+#include "alcachofa/script.h"
 
 using namespace Common;
 

--- a/engines/alcachofa/game.h
+++ b/engines/alcachofa/game.h
@@ -1,4 +1,3 @@
-#pragma once
 /* ScummVM - Graphic Adventure Engine
  *
  * ScummVM is the legal property of its developers, whose names

--- a/engines/alcachofa/game.h
+++ b/engines/alcachofa/game.h
@@ -61,6 +61,7 @@ public:
 	virtual bool shouldCharacterTrigger(const Character *character, const char *action);
 	virtual bool shouldTriggerDoor(const Door *door);
 	virtual bool hasMortadeloVoice(const Character *character);
+	virtual void onUserChangedCharacter();
 
 	virtual void unknownCamSetInactiveAttribute(int attribute);
 	virtual void unknownFadeType(int fadeType);

--- a/engines/alcachofa/game.h
+++ b/engines/alcachofa/game.h
@@ -87,6 +87,7 @@ public:
 	virtual void invalidSNDFormat(uint format, uint channels, uint freq, uint bps);
 	virtual void notEnoughRoomDataRead(const char *path, int64 filePos, int64 objectEnd);
 	virtual void notEnoughObjectDataRead(const char *room, int64 filePos, int64 objectEnd);
+	virtual void invalidVideo(int32 videoId, const char *context);
 
 	static Game *createForMovieAdventure();
 

--- a/engines/alcachofa/game.h
+++ b/engines/alcachofa/game.h
@@ -48,6 +48,8 @@ public:
 	Game();
 	virtual ~Game() = default;
 
+	virtual void onLoadedGameFiles();
+
 	virtual bool doesRoomHaveBackground(const Room *room);
 	virtual void unknownRoomObject(const Common::String &type);
 	virtual void unknownRoomType(const Common::String &type);
@@ -87,6 +89,7 @@ public:
 	virtual void invalidSNDFormat(uint format, uint channels, uint freq, uint bps);
 	virtual void notEnoughRoomDataRead(const char *path, int64 filePos, int64 objectEnd);
 	virtual void notEnoughObjectDataRead(const char *room, int64 filePos, int64 objectEnd);
+	virtual bool isKnownBadVideo(int32 videoId);
 	virtual void invalidVideo(int32 videoId, const char *context);
 
 	static Game *createForMovieAdventure();

--- a/engines/alcachofa/game.h
+++ b/engines/alcachofa/game.h
@@ -20,8 +20,8 @@
  *
  */
 
-#ifndef GAME_H
-#define GAME_H
+#ifndef ALCACHOFA_GAME_H
+#define ALCACHOFA_GAME_H
 
 #include "common/textconsole.h"
 #include "common/file.h"
@@ -99,4 +99,4 @@ public:
 
 }
 
-#endif // GAME_H
+#endif // ALCACHOFA_GAME_H

--- a/engines/alcachofa/general-objects.cpp
+++ b/engines/alcachofa/general-objects.cpp
@@ -169,9 +169,9 @@ struct AnimateTask : public Task {
 	virtual const char *taskName() const override;
 
 private:
-	GraphicObject *_object;
-	Graphic *_graphic;
-	uint32 _duration;
+	GraphicObject *_object = nullptr;
+	Graphic *_graphic = nullptr;
+	uint32 _duration = 0;
 };
 DECLARE_TASK(AnimateTask);
 

--- a/engines/alcachofa/general-objects.cpp
+++ b/engines/alcachofa/general-objects.cpp
@@ -66,7 +66,7 @@ void ObjectBase::loadResources() {
 void ObjectBase::freeResources() {
 }
 
-void ObjectBase::serializeSave(Serializer &serializer) {
+void ObjectBase::syncGame(Serializer &serializer) {
 	serializer.syncAsByte(_isEnabled);
 }
 
@@ -120,9 +120,9 @@ void GraphicObject::freeResources() {
 	_graphic.freeResources();
 }
 
-void GraphicObject::serializeSave(Serializer &serializer) {
-	ObjectBase::serializeSave(serializer);
-	_graphic.serializeSave(serializer);
+void GraphicObject::syncGame(Serializer &serializer) {
+	ObjectBase::syncGame(serializer);
+	_graphic.syncGame(serializer);
 }
 
 Graphic *GraphicObject::graphic() {
@@ -207,8 +207,10 @@ void ShapeObject::update() {
 	}
 }
 
-void ShapeObject::serializeSave(Serializer &serializer) {
+void ShapeObject::syncGame(Serializer &serializer) {
 	serializer.syncAsSByte(_order);
+	_isNewlySelected = false;
+	_wasSelected = false;
 }
 
 Shape *ShapeObject::shape() {

--- a/engines/alcachofa/general-objects.cpp
+++ b/engines/alcachofa/general-objects.cpp
@@ -176,7 +176,7 @@ SpecialEffectObject::SpecialEffectObject(Room *room, ReadStream &stream)
 void SpecialEffectObject::draw() {
 	if (!isEnabled()) // TODO: Add high quality check
 		return;
-	const auto texOffset = g_system->getMillis() * 0.001f * _texShift;
+	const auto texOffset = g_engine->getMillis() * 0.001f * _texShift;
 	const BlendMode blendMode = _type == GraphicObjectType::Effect
 		? BlendMode::Additive
 		: BlendMode::AdditiveAlpha;

--- a/engines/alcachofa/general-objects.cpp
+++ b/engines/alcachofa/general-objects.cpp
@@ -144,7 +144,7 @@ struct AnimateTask : public Task {
 		syncGame(s);
 	}
 
-	virtual TaskReturn run() override {
+	TaskReturn run() override {
 		TASK_BEGIN;
 		_object->toggle(true);
 		_graphic->start(false);
@@ -153,11 +153,11 @@ struct AnimateTask : public Task {
 		TASK_END;
 	}
 
-	virtual void debugPrint() override {
+	void debugPrint() override {
 		g_engine->getDebugger()->debugPrintf("Animate \"%s\" for %ums", _object->name().c_str(), _duration);
 	}
 
-	virtual void syncGame(Serializer &s) override {
+	void syncGame(Serializer &s) override {
 		Task::syncGame(s);
 		s.syncAsUint32LE(_duration);
 		syncObjectAsString(s, _object);

--- a/engines/alcachofa/general-objects.cpp
+++ b/engines/alcachofa/general-objects.cpp
@@ -220,7 +220,7 @@ SpecialEffectObject::SpecialEffectObject(Room *room, ReadStream &stream)
 }
 
 void SpecialEffectObject::draw() {
-	if (!isEnabled()) // TODO: Add high quality check
+	if (!isEnabled() || !g_engine->config().highQuality())
 		return;
 	const auto texOffset = g_engine->getMillis() * 0.001f * _texShift;
 	const BlendMode blendMode = _type == GraphicObjectType::Effect

--- a/engines/alcachofa/general-objects.cpp
+++ b/engines/alcachofa/general-objects.cpp
@@ -202,7 +202,7 @@ private:
 	Graphic *_graphic = nullptr;
 	uint32 _duration = 0;
 };
-DECLARE_TASK(AnimateTask);
+DECLARE_TASK(AnimateTask)
 
 Task *GraphicObject::animate(Process &process) {
 	return new AnimateTask(process, this);

--- a/engines/alcachofa/general-objects.cpp
+++ b/engines/alcachofa/general-objects.cpp
@@ -52,20 +52,15 @@ void ObjectBase::toggle(bool isEnabled) {
 	_isEnabled = isEnabled;
 }
 
-void ObjectBase::draw() {
-}
+void ObjectBase::draw() {}
 
-void ObjectBase::drawDebug() {
-}
+void ObjectBase::drawDebug() {}
 
-void ObjectBase::update() {
-}
+void ObjectBase::update() {}
 
-void ObjectBase::loadResources() {
-}
+void ObjectBase::loadResources() {}
 
-void ObjectBase::freeResources() {
-}
+void ObjectBase::freeResources() {}
 
 void ObjectBase::syncGame(Serializer &serializer) {
 	serializer.syncAsByte(_isEnabled);
@@ -99,8 +94,7 @@ GraphicObject::GraphicObject(Room *room, ReadStream &stream)
 GraphicObject::GraphicObject(Room *room, const char *name)
 	: ObjectBase(room, name)
 	, _type(GraphicObjectType::Normal)
-	, _posterizeAlpha(0) {
-}
+	, _posterizeAlpha(0) {}
 
 void GraphicObject::draw() {
 	if (!isEnabled() || !_graphic.hasAnimation())
@@ -127,8 +121,7 @@ void GraphicObject::drawDebug() {
 		topLeftTmp.z() = _graphic.scale();
 		_graphic.animation().outputRect3D(_graphic.frameI(), scale, topLeftTmp, size);
 		topLeft = as2D(topLeftTmp);
-	}
-	else
+	} else
 		_graphic.animation().outputRect2D(_graphic.frameI(), scale, topLeft, size);
 
 	Vector2d points[] = {
@@ -241,8 +234,7 @@ const char *ShapeObject::typeName() const { return "ShapeObject"; }
 ShapeObject::ShapeObject(Room *room, ReadStream &stream)
 	: ObjectBase(room, stream)
 	, _shape(stream)
-	, _cursorType((CursorType)stream.readSint32LE()) {
-}
+	, _cursorType((CursorType)stream.readSint32LE()) {}
 
 void ShapeObject::update() {
 	if (isEnabled())
@@ -272,8 +264,7 @@ void ShapeObject::onHoverStart() {
 	onHoverUpdate();
 }
 
-void ShapeObject::onHoverEnd() {
-}
+void ShapeObject::onHoverEnd() {}
 
 void ShapeObject::onHoverUpdate() {
 	g_engine->drawQueue().add<TextDrawRequest>(
@@ -299,13 +290,11 @@ void ShapeObject::updateSelection() {
 				onClick();
 			else
 				onHoverUpdate();
-		}
-		else {
+		} else {
 			_wasSelected = true;
 			onHoverStart();
 		}
-	}
-	else if (_wasSelected) {
+	} else if (_wasSelected) {
 		_wasSelected = false;
 		onHoverEnd();
 	}

--- a/engines/alcachofa/general-objects.cpp
+++ b/engines/alcachofa/general-objects.cpp
@@ -195,7 +195,7 @@ struct AnimateTask : public Task {
 
 	}
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 private:
 	GraphicObject *_object = nullptr;

--- a/engines/alcachofa/general-objects.cpp
+++ b/engines/alcachofa/general-objects.cpp
@@ -254,6 +254,7 @@ void ShapeObject::update() {
 }
 
 void ShapeObject::syncGame(Serializer &serializer) {
+	ObjectBase::syncGame(serializer);
 	serializer.syncAsSByte(_order);
 	_isNewlySelected = false;
 	_wasSelected = false;

--- a/engines/alcachofa/general-objects.cpp
+++ b/engines/alcachofa/general-objects.cpp
@@ -19,11 +19,11 @@
  *
  */
 
-#include "objects.h"
-#include "rooms.h"
-#include "scheduler.h"
-#include "global-ui.h"
-#include "alcachofa.h"
+#include "alcachofa/objects.h"
+#include "alcachofa/rooms.h"
+#include "alcachofa/scheduler.h"
+#include "alcachofa/global-ui.h"
+#include "alcachofa/alcachofa.h"
 
 #include "common/system.h"
 

--- a/engines/alcachofa/general-objects.cpp
+++ b/engines/alcachofa/general-objects.cpp
@@ -202,7 +202,7 @@ void ShapeObject::update() {
 	if (isEnabled())
 		updateSelection();
 	else {
-		_isSelected = false;
+		_isNewlySelected = false;
 		_wasSelected = false;
 	}
 }
@@ -239,12 +239,12 @@ void ShapeObject::onClick() {
 }
 
 void ShapeObject::markSelected() {
-	_isSelected = true;
+	_isNewlySelected = true;
 }
 
 void ShapeObject::updateSelection() {
-	if (_isSelected) {
-		_isSelected = false;
+	if (_isNewlySelected) {
+		_isNewlySelected = false;
 		if (_wasSelected) {
 			if (g_engine->input().wasAnyMouseReleased() && g_engine->player().selectedObject() == this)
 				onClick();

--- a/engines/alcachofa/global-ui.cpp
+++ b/engines/alcachofa/global-ui.cpp
@@ -19,10 +19,10 @@
  *
  */
 
-#include "global-ui.h"
-#include "menu.h"
-#include "alcachofa.h"
-#include "script.h"
+#include "alcachofa/global-ui.h"
+#include "alcachofa/menu.h"
+#include "alcachofa/alcachofa.h"
+#include "alcachofa/script.h"
 
 using namespace Common;
 

--- a/engines/alcachofa/global-ui.cpp
+++ b/engines/alcachofa/global-ui.cpp
@@ -149,6 +149,7 @@ bool GlobalUI::updateChangingCharacter() {
 	g_engine->camera().setFollow(player.activeCharacter());
 	g_engine->camera().restore(0);
 	player.changeRoom(player.activeCharacter()->room()->name(), false);
+	g_engine->game().onUserChangedCharacter();
 
 	int32 characterJingle = g_engine->script().variable(
 		player.activeCharacterKind() == MainCharacterKind::Mortadelo

--- a/engines/alcachofa/global-ui.cpp
+++ b/engines/alcachofa/global-ui.cpp
@@ -91,14 +91,12 @@ bool GlobalUI::updateOpeningInventory() {
 		if (deltaTime >= 1000) {
 			_isOpeningInventory = false;
 			g_engine->world().inventory().open();
-		}
-		else {
+		} else {
 			deltaTime = MIN<uint32>(300, deltaTime);
 			g_engine->world().inventory().drawAsOverlay((int32)(g_system->getHeight() * (deltaTime * kSpeed - 1)));
 		}
 		return true;
-	}
-	else if (userWantsToOpenInventory) {
+	} else if (userWantsToOpenInventory) {
 		_isClosingInventory = false;
 		_isOpeningInventory = true;
 		_timeForInventory = g_engine->getMillis();
@@ -136,8 +134,7 @@ bool GlobalUI::updateChangingCharacter() {
 
 	if (!isHoveringChangeButton())
 		return false;
-	if (g_engine->input().wasMouseLeftPressed())
-	{
+	if (g_engine->input().wasMouseLeftPressed()) {
 		player.pressedObject() = &_changeButton;
 		return true;
 	}
@@ -174,8 +171,7 @@ void GlobalUI::drawChangingButton() {
 		return;
 
 	auto anim = activeAnimation();
-	if (!_changeButton.hasAnimation() || &_changeButton.animation() != anim)
-	{
+	if (!_changeButton.hasAnimation() || &_changeButton.animation() != anim) {
 		_changeButton.setAnimation(anim);
 		_changeButton.pause();
 		_changeButton.lastTime() = 42 * (anim->frameCount() - 1) + 1;
@@ -184,8 +180,7 @@ void GlobalUI::drawChangingButton() {
 	_changeButton.topLeft() = { (int16)(g_system->getWidth() + 2), -2 };
 	if (isHoveringChangeButton() &&
 		g_engine->input().isMouseLeftDown() &&
-		player.pressedObject() == &_changeButton)
-	{
+		player.pressedObject() == &_changeButton) {
 		_changeButton.topLeft().x -= 2;
 		_changeButton.topLeft().y += 2;
 	}
@@ -199,8 +194,7 @@ struct CenterBottomTextTask : public Task {
 	CenterBottomTextTask(Process &process, int32 dialogId, uint32 durationMs)
 		: Task(process)
 		, _dialogId(dialogId)
-		, _durationMs(durationMs) {
-	}
+		, _durationMs(durationMs) {}
 
 	CenterBottomTextTask(Process &process, Serializer &s)
 		: Task(process) {
@@ -239,7 +233,7 @@ struct CenterBottomTextTask : public Task {
 		s.syncAsSint32LE(_dialogId);
 		s.syncAsUint32LE(_startTime);
 		s.syncAsUint32LE(_durationMs);
-	} 
+	}
 
 	const char *taskName() const override;
 

--- a/engines/alcachofa/global-ui.cpp
+++ b/engines/alcachofa/global-ui.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "global-ui.h"
+#include "menu.h"
 #include "alcachofa.h"
 #include "script.h"
 
@@ -78,7 +79,7 @@ void GlobalUI::updateClosingInventory() {
 
 bool GlobalUI::updateOpeningInventory() {
 	static constexpr float kSpeed = 10 / 3.0f / 1000.0f;
-	if (g_engine->player().isMenuOpen() || !g_engine->player().isGameLoaded())
+	if (g_engine->menu().isOpen() || !g_engine->player().isGameLoaded())
 		return false;
 
 	if (_isOpeningInventory) {
@@ -123,7 +124,7 @@ bool GlobalUI::isHoveringChangeButton() const {
 
 bool GlobalUI::updateChangingCharacter() {
 	auto &player = g_engine->player();
-	if (player.isMenuOpen() ||
+	if (g_engine->menu().isOpen() ||
 		!player.isGameLoaded() ||
 		_isOpeningInventory)
 		return false;
@@ -160,7 +161,7 @@ bool GlobalUI::updateChangingCharacter() {
 
 void GlobalUI::drawChangingButton() {
 	auto &player = g_engine->player();
-	if (player.isMenuOpen() ||
+	if (g_engine->menu().isOpen() ||
 		!player.isGameLoaded() ||
 		!player.semaphore().isReleased() ||
 		_isOpeningInventory ||
@@ -233,7 +234,7 @@ Task *showCenterBottomText(Process &process, int32 dialogId, uint32 durationMs) 
 }
 
 void GlobalUI::drawScreenStates() {
-	if (g_engine->player().isMenuOpen())
+	if (g_engine->menu().isOpen())
 		return;
 
 	auto &drawQueue = g_engine->drawQueue();
@@ -245,31 +246,6 @@ void GlobalUI::drawScreenStates() {
 		drawQueue.add<BorderDrawRequest>(Rect(0, 0, width, borderWidth), kBlack);
 		drawQueue.add<BorderDrawRequest>(Rect(0, height - borderWidth, width, height), kBlack);
 	}
-}
-
-void GlobalUI::updateOpeningMenu() {
-	if (!_openMenuAtNextFrame) {
-		_openMenuAtNextFrame =
-			g_engine->input().wasMenuKeyPressed() &&
-			g_engine->player().isAllowedToOpenMenu();
-		return;
-	}
-	_openMenuAtNextFrame = false;
-
-	g_engine->sounds().pauseAll(true);
-	// TODO: Add game time behaviour on opening menu
-	g_engine->player().isMenuOpen() = true;
-	// TODO: Render thumbnail
-	g_engine->player().changeRoom("MENUPRINCIPAL", true);
-	// TODO: Check original read lastSaveFileFileId and read options.cfg, we do not need that right?
-
-	g_engine->player().heldItem() = nullptr;
-	g_engine->scheduler().backupContext();
-	g_engine->camera().backup(1);
-	g_engine->camera().setPosition(Math::Vector3d(
-		g_system->getWidth() / 2.0f, g_system->getHeight() / 2.0f, 0.0f));
-
-	// TODO: Load thumbnail into capture graphic object
 }
 
 }

--- a/engines/alcachofa/global-ui.cpp
+++ b/engines/alcachofa/global-ui.cpp
@@ -239,8 +239,8 @@ struct CenterBottomTextTask : public Task {
 	virtual const char *taskName() const override;
 
 private:
-	int32 _dialogId;
-	uint32 _startTime = 0, _durationMs;
+	int32 _dialogId = 0;
+	uint32 _startTime = 0, _durationMs = 0;
 };
 DECLARE_TASK(CenterBottomTextTask);
 

--- a/engines/alcachofa/global-ui.cpp
+++ b/engines/alcachofa/global-ui.cpp
@@ -248,4 +248,8 @@ void GlobalUI::drawScreenStates() {
 	}
 }
 
+void GlobalUI::syncGame(Serializer &s) {
+	s.syncAsByte(_isPermanentFaded);
+}
+
 }

--- a/engines/alcachofa/global-ui.cpp
+++ b/engines/alcachofa/global-ui.cpp
@@ -246,7 +246,7 @@ private:
 	int32 _dialogId = 0;
 	uint32 _startTime = 0, _durationMs = 0;
 };
-DECLARE_TASK(CenterBottomTextTask);
+DECLARE_TASK(CenterBottomTextTask)
 
 Task *showCenterBottomText(Process &process, int32 dialogId, uint32 durationMs) {
 	return new CenterBottomTextTask(process, dialogId, durationMs);

--- a/engines/alcachofa/global-ui.cpp
+++ b/engines/alcachofa/global-ui.cpp
@@ -31,7 +31,7 @@ namespace Alcachofa {
 // originally the inventory only reacts to exactly top-left/bottom-right which is fine in
 // fullscreen when you just slam the mouse cursor into the corner.
 // In any other scenario this is cumbersome so I expand this area.
-// And it is still pretty bad, especially in windowed mode so I should add key-based controls for it
+// And it is still pretty bad, especially in windowed mode so there is a key to open/close as well
 static constexpr int16 kInventoryTriggerSize = 10;
 
 Rect openInventoryTriggerBounds() {
@@ -82,6 +82,10 @@ bool GlobalUI::updateOpeningInventory() {
 	if (g_engine->menu().isOpen() || !g_engine->player().isGameLoaded())
 		return false;
 
+	const bool userWantsToOpenInventory =
+		openInventoryTriggerBounds().contains(g_engine->input().mousePos2D()) ||
+		g_engine->input().wasInventoryKeyPressed();
+
 	if (_isOpeningInventory) {
 		uint32 deltaTime = g_engine->getMillis() - _timeForInventory;
 		if (deltaTime >= 1000) {
@@ -94,7 +98,7 @@ bool GlobalUI::updateOpeningInventory() {
 		}
 		return true;
 	}
-	else if (openInventoryTriggerBounds().contains(g_engine->input().mousePos2D())) {
+	else if (userWantsToOpenInventory) {
 		_isClosingInventory = false;
 		_isOpeningInventory = true;
 		_timeForInventory = g_engine->getMillis();

--- a/engines/alcachofa/global-ui.cpp
+++ b/engines/alcachofa/global-ui.cpp
@@ -240,7 +240,7 @@ struct CenterBottomTextTask : public Task {
 		s.syncAsUint32LE(_durationMs);
 	} 
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 private:
 	int32 _dialogId = 0;

--- a/engines/alcachofa/global-ui.cpp
+++ b/engines/alcachofa/global-ui.cpp
@@ -222,14 +222,14 @@ struct CenterBottomTextTask : public Task {
 		TASK_END;
 	}
 
-	virtual void debugPrint() override {
+	void debugPrint() override {
 		uint32 remaining = g_engine->getMillis() - _startTime <= _durationMs
 			? _durationMs - (g_engine->getMillis() - _startTime)
 			: 0;
 		g_engine->console().debugPrintf("CenterBottomText (%d) with %ums remaining\n", _dialogId, remaining);
 	}
 
-	virtual void syncGame(Serializer &s) override {
+	void syncGame(Serializer &s) override {
 		Task::syncGame(s);
 		s.syncAsSint32LE(_dialogId);
 		s.syncAsUint32LE(_startTime);

--- a/engines/alcachofa/global-ui.cpp
+++ b/engines/alcachofa/global-ui.cpp
@@ -220,7 +220,7 @@ struct CenterBottomTextTask : public Task {
 		while (g_engine->getMillis() - _startTime < _durationMs) {
 			if (process().isActiveForPlayer()) {
 				g_engine->drawQueue().add<TextDrawRequest>(
-					font, text, pos, -1, true, kWhite, 1);
+					font, text, pos, -1, true, kWhite, -kForegroundOrderCount + 1);
 			}
 			TASK_YIELD(1);
 		}

--- a/engines/alcachofa/global-ui.cpp
+++ b/engines/alcachofa/global-ui.cpp
@@ -62,7 +62,7 @@ GlobalUI::GlobalUI() {
 void GlobalUI::startClosingInventory() {
 	_isOpeningInventory = false;
 	_isClosingInventory = true;
-	_timeForInventory = g_system->getMillis();
+	_timeForInventory = g_engine->getMillis();
 	updateClosingInventory(); // prevents the first frame of closing to not render the inventory overlay
 }
 
@@ -70,7 +70,7 @@ void GlobalUI::updateClosingInventory() {
 	static constexpr uint32 kDuration = 300;
 	static constexpr float kSpeed = -10 / 3.0f / 1000.0f;
 
-	uint32 deltaTime = g_system->getMillis() - _timeForInventory;
+	uint32 deltaTime = g_engine->getMillis() - _timeForInventory;
 	if (!_isClosingInventory || deltaTime >= kDuration)
 		_isClosingInventory = false;
 	else
@@ -83,7 +83,7 @@ bool GlobalUI::updateOpeningInventory() {
 		return false;
 
 	if (_isOpeningInventory) {
-		uint32 deltaTime = g_system->getMillis() - _timeForInventory;
+		uint32 deltaTime = g_engine->getMillis() - _timeForInventory;
 		if (deltaTime >= 1000) {
 			_isOpeningInventory = false;
 			g_engine->world().inventory().open();
@@ -97,7 +97,7 @@ bool GlobalUI::updateOpeningInventory() {
 	else if (openInventoryTriggerBounds().contains(g_engine->input().mousePos2D())) {
 		_isClosingInventory = false;
 		_isOpeningInventory = true;
-		_timeForInventory = g_system->getMillis();
+		_timeForInventory = g_engine->getMillis();
 		g_engine->player().activeCharacter()->stopWalking();
 		g_engine->world().inventory().updateItemsByActiveCharacter();
 		return true;
@@ -206,8 +206,8 @@ struct CenterBottomTextTask : public Task {
 		);
 
 		TASK_BEGIN;
-		_startTime = g_system->getMillis();
-		while (g_system->getMillis() - _startTime < _durationMs) {
+		_startTime = g_engine->getMillis();
+		while (g_engine->getMillis() - _startTime < _durationMs) {
 			if (process().isActiveForPlayer()) {
 				g_engine->drawQueue().add<TextDrawRequest>(
 					font, text, pos, -1, true, kWhite, 1);
@@ -218,8 +218,8 @@ struct CenterBottomTextTask : public Task {
 	}
 
 	void debugPrint() override {
-		uint32 remaining = g_system->getMillis() - _startTime <= _durationMs
-			? _durationMs - (g_system->getMillis() - _startTime)
+		uint32 remaining = g_engine->getMillis() - _startTime <= _durationMs
+			? _durationMs - (g_engine->getMillis() - _startTime)
 			: 0;
 		g_engine->console().debugPrintf("CenterBottomText (%d) with %ums remaining\n", _dialogId, remaining);
 	}

--- a/engines/alcachofa/global-ui.h
+++ b/engines/alcachofa/global-ui.h
@@ -43,6 +43,7 @@ public:
 	void updateClosingInventory();
 	void startClosingInventory();
 	void drawScreenStates(); // black borders and/or permanent fade
+	void syncGame(Common::Serializer &s);
 
 private:
 	Animation *activeAnimation() const;

--- a/engines/alcachofa/global-ui.h
+++ b/engines/alcachofa/global-ui.h
@@ -42,7 +42,6 @@ public:
 	bool updateOpeningInventory();
 	void updateClosingInventory();
 	void startClosingInventory();
-	void updateOpeningMenu();
 	void drawScreenStates(); // black borders and/or permanent fade
 
 private:
@@ -61,8 +60,7 @@ private:
 	bool
 		_isOpeningInventory = false,
 		_isClosingInventory = false,
-		_isPermanentFaded = false,
-		_openMenuAtNextFrame = false;
+		_isPermanentFaded = false;
 	uint32 _timeForInventory = 0;
 };
 

--- a/engines/alcachofa/global-ui.h
+++ b/engines/alcachofa/global-ui.h
@@ -22,7 +22,7 @@
 #ifndef ALCACHOFA_GLOBAL_UI_H
 #define ALCACHOFA_GLOBAL_UI_H
 
-#include "objects.h"
+#include "alcachofa/objects.h"
 
 namespace Alcachofa {
 

--- a/engines/alcachofa/global-ui.h
+++ b/engines/alcachofa/global-ui.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef GLOBAL_UI_H
-#define GLOBAL_UI_H
+#ifndef ALCACHOFA_GLOBAL_UI_H
+#define ALCACHOFA_GLOBAL_UI_H
 
 #include "objects.h"
 
@@ -70,4 +70,4 @@ Task *showCenterBottomText(Process &process, int32 dialogId, uint32 durationMs);
 }
 
 
-#endif // GLOBAL_UI_H
+#endif // ALCACHOFA_GLOBAL_UI_H

--- a/engines/alcachofa/graphics-opengl-classic.cpp
+++ b/engines/alcachofa/graphics-opengl-classic.cpp
@@ -127,24 +127,10 @@ public:
 		Angle rotation,
 		Vector2d texMin,
 		Vector2d texMax) override {
-		Vector2d positions[] = {
-			topLeft + Vector2d(0,			0),
-			topLeft + Vector2d(0,			+size.getY()),
-			topLeft + Vector2d(+size.getX(), +size.getY()),
-			topLeft + Vector2d(+size.getX(), 0),
-		};
-		if (abs(rotation.getDegrees()) > epsilon) {
-			const Vector2d zero(0, 0);
-			for (int i = 0; i < 4; i++)
-				positions[i].rotateAround(zero, rotation);
-		}
+		Vector2d positions[4], texCoords[4];
+		getQuadPositions(topLeft, size, rotation, positions);
+		getQuadTexCoords(texMin, texMax, texCoords);
 
-		Vector2d texCoords[] = {
-			{ texMin.getX(), texMin.getY() },
-			{ texMin.getX(), texMax.getY() },
-			{ texMax.getX(), texMax.getY() },
-			{ texMax.getX(), texMin.getY() }
-		};
 		if (_currentTexture != nullptr) {
 			// float equality is fine here, if it was calculated it was not a normal graphic
 			_currentTexture->setMirrorWrap(texMin != Vector2d() || texMax != Vector2d(1, 1));
@@ -230,8 +216,8 @@ public:
 	}
 };
 
-IRenderer *IRenderer::createOpenGLRenderer(Point resolution) {
-	initGraphics3d(resolution.x, resolution.y);
+IRenderer *createOpenGLRendererClassic(Point resolution) {
+	debug("Use OpenGL classic renderer");
 	return new OpenGLRendererClassic(resolution);
 }
 

--- a/engines/alcachofa/graphics-opengl-classic.cpp
+++ b/engines/alcachofa/graphics-opengl-classic.cpp
@@ -1,0 +1,238 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "alcachofa/graphics-opengl.h"
+#include "alcachofa/detection.h"
+
+#include "common/system.h"
+#include "engines/util.h"
+
+using namespace Common;
+using namespace Math;
+using namespace Graphics;
+
+namespace Alcachofa {
+
+class OpenGLRendererClassic : public OpenGLRenderer, public virtual IDebugRenderer {
+public:
+	using OpenGLRenderer::OpenGLRenderer;
+
+	void begin() override {
+		GL_CALL(glEnableClientState(GL_VERTEX_ARRAY));
+		GL_CALL(glDisableClientState(GL_INDEX_ARRAY));
+		GL_CALL(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
+		resetState();
+	}
+
+	void setTexture(ITexture *texture) override {
+		if (texture == _currentTexture)
+			return;
+		else if (texture == nullptr) {
+			GL_CALL(glDisable(GL_TEXTURE_2D));
+			GL_CALL(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
+			_currentTexture = nullptr;
+		} else {
+			if (_currentTexture == nullptr) {
+				GL_CALL(glEnable(GL_TEXTURE_2D));
+				GL_CALL(glEnableClientState(GL_TEXTURE_COORD_ARRAY));
+			}
+			auto glTexture = dynamic_cast<OpenGLTexture *>(texture);
+			assert(glTexture != nullptr);
+			GL_CALL(glBindTexture(GL_TEXTURE_2D, glTexture->handle()));
+			_currentTexture = glTexture;
+		}
+	}
+
+	void setBlendMode(BlendMode blendMode) override {
+		if (blendMode == _currentBlendMode)
+			return;
+		setBlendFunc(blendMode);
+
+		GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE));
+		switch (blendMode) {
+		case BlendMode::AdditiveAlpha:
+		case BlendMode::Additive:
+		case BlendMode::Multiply:
+			// TintAlpha * TexColor, TexAlpha
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB, GL_MODULATE));
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ALPHA, GL_REPLACE));
+
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_SRC0_RGB, GL_TEXTURE));
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_RGB, GL_SRC_COLOR));
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_SRC0_ALPHA, GL_TEXTURE));
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_ALPHA, GL_SRC_ALPHA));
+
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_SRC1_RGB, GL_PRIMARY_COLOR));
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND1_RGB, GL_SRC_ALPHA)); // alpha replaces color
+			break;
+		case BlendMode::Alpha:
+			// TexColor, TintAlpha
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB, GL_REPLACE));
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ALPHA, GL_REPLACE));
+
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_SRC0_RGB, GL_TEXTURE));
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_RGB, GL_SRC_COLOR));
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_SRC0_ALPHA, GL_PRIMARY_COLOR));
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_ALPHA, GL_SRC_ALPHA));
+			break;
+		case BlendMode::Tinted:
+			// (TintColor * TintAlpha) * TexColor, TexAlpha
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB, GL_MODULATE));
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ALPHA, GL_REPLACE));
+
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_SRC0_RGB, GL_TEXTURE));
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_RGB, GL_SRC_COLOR));
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_SRC0_ALPHA, GL_TEXTURE));
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_ALPHA, GL_SRC_ALPHA));
+
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_SRC1_RGB, GL_PRIMARY_COLOR));
+			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND1_RGB, GL_SRC_COLOR)); // we have to pre-multiply
+			break;
+		default:
+			assert(false && "Invalid blend mode");
+			break;
+		}
+		_currentBlendMode = blendMode;
+	}
+
+	void setLodBias(float lodBias) override {
+		if (abs(_currentLodBias - lodBias) < epsilon)
+			return;
+		GL_CALL(glTexEnvf(GL_TEXTURE_FILTER_CONTROL, GL_TEXTURE_LOD_BIAS, lodBias));
+		_currentLodBias = lodBias;
+	}
+
+	void quad(
+		Vector2d topLeft,
+		Vector2d size,
+		Color color,
+		Angle rotation,
+		Vector2d texMin,
+		Vector2d texMax) override {
+		Vector2d positions[] = {
+			topLeft + Vector2d(0,			0),
+			topLeft + Vector2d(0,			+size.getY()),
+			topLeft + Vector2d(+size.getX(), +size.getY()),
+			topLeft + Vector2d(+size.getX(), 0),
+		};
+		if (abs(rotation.getDegrees()) > epsilon) {
+			const Vector2d zero(0, 0);
+			for (int i = 0; i < 4; i++)
+				positions[i].rotateAround(zero, rotation);
+		}
+
+		Vector2d texCoords[] = {
+			{ texMin.getX(), texMin.getY() },
+			{ texMin.getX(), texMax.getY() },
+			{ texMax.getX(), texMax.getY() },
+			{ texMax.getX(), texMin.getY() }
+		};
+		if (_currentTexture != nullptr) {
+			// float equality is fine here, if it was calculated it was not a normal graphic
+			_currentTexture->setMirrorWrap(texMin != Vector2d() || texMax != Vector2d(1, 1));
+		}
+
+		float colors[] = { color.r / 255.0f, color.g / 255.0f, color.b / 255.0f, color.a / 255.0f };
+		if (_currentBlendMode == BlendMode::Tinted) {
+			colors[0] *= colors[3];
+			colors[1] *= colors[3];
+			colors[2] *= colors[3];
+		}
+
+		checkFirstDrawCommand();
+		GL_CALL(glColor4fv(colors));
+		GL_CALL(glVertexPointer(2, GL_FLOAT, 0, positions));
+		if (_currentTexture != nullptr)
+			GL_CALL(glTexCoordPointer(2, GL_FLOAT, 0, texCoords));
+		GL_CALL(glDrawArrays(GL_QUADS, 0, 4));
+
+#ifdef ALCACHOFA_DEBUG
+		// make sure we crash instead of someone using our stack arrays
+		GL_CALL(glVertexPointer(2, GL_FLOAT, sizeof(Vector2d), nullptr));
+		GL_CALL(glTexCoordPointer(2, GL_FLOAT, sizeof(Vector2d), nullptr));
+#endif
+	}
+
+	void debugPolygon(
+		Span<Vector2d> points,
+		Color color
+	) override {
+		checkFirstDrawCommand();
+		setTexture(nullptr);
+		setBlendMode(BlendMode::Alpha);
+		GL_CALL(glVertexPointer(2, GL_FLOAT, 0, points.data()));
+		GL_CALL(glLineWidth(4.0f));
+		GL_CALL(glPointSize(8.0f));
+
+		GL_CALL(glColor4ub(color.r, color.g, color.b, color.a));
+		if (points.size() > 2)
+			GL_CALL(glDrawArrays(GL_POLYGON, 0, points.size()));
+
+		color.a = (byte)(MIN(255.0f, color.a * 1.3f));
+		GL_CALL(glColor4ub(color.r, color.g, color.b, color.a));
+		if (points.size() > 1)
+			GL_CALL(glDrawArrays(GL_LINE_LOOP, 0, points.size()));
+
+		color.a = (byte)(MIN(255.0f, color.a * 1.3f));
+		GL_CALL(glColor4ub(color.r, color.g, color.b, color.a));
+		if (points.size() > 0)
+			GL_CALL(glDrawArrays(GL_POINTS, 0, points.size()));
+	}
+
+	void debugPolyline(
+		Span<Vector2d> points,
+		Color color
+	) override {
+		checkFirstDrawCommand();
+		setTexture(nullptr);
+		setBlendMode(BlendMode::Alpha);
+		GL_CALL(glVertexPointer(2, GL_FLOAT, 0, points.data()));
+		GL_CALL(glLineWidth(4.0f));
+		GL_CALL(glPointSize(8.0f));
+
+		GL_CALL(glColor4ub(color.r, color.g, color.b, color.a));
+		if (points.size() > 1)
+			GL_CALL(glDrawArrays(GL_LINE_STRIP, 0, points.size()));
+
+		color.a = (byte)(MIN(255.0f, color.a * 1.3f));
+		GL_CALL(glColor4ub(color.r, color.g, color.b, color.a));
+		if (points.size() > 0)
+			GL_CALL(glDrawArrays(GL_POINTS, 0, points.size()));
+	}
+
+	void setMatrices(bool flipped) override {
+		float bottom = flipped ? _resolution.y : 0.0f;
+		float top = flipped ? 0.0f : _resolution.y;
+
+		GL_CALL(glMatrixMode(GL_PROJECTION));
+		GL_CALL(glLoadIdentity());
+		GL_CALL(glOrtho(0.0f, _resolution.x, bottom, top, -1.0f, 1.0f));
+		GL_CALL(glMatrixMode(GL_MODELVIEW));
+		GL_CALL(glLoadIdentity());
+	}
+};
+
+IRenderer *IRenderer::createOpenGLRenderer(Point resolution) {
+	initGraphics3d(resolution.x, resolution.y);
+	return new OpenGLRendererClassic(resolution);
+}
+
+}

--- a/engines/alcachofa/graphics-opengl-shaders.cpp
+++ b/engines/alcachofa/graphics-opengl-shaders.cpp
@@ -1,0 +1,255 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "alcachofa/graphics-opengl.h"
+#include "alcachofa/detection.h"
+
+#include "common/system.h"
+#include "engines/util.h"
+#include "graphics/opengl/shader.h"
+
+using namespace Common;
+using namespace Math;
+using namespace Graphics;
+using namespace OpenGL;
+
+namespace Alcachofa {
+
+class OpenGLRendererShaders : public OpenGLRenderer {
+	struct Vertex {
+		Vector2d pos;
+		Vector2d uv;
+		Color color;
+	};
+
+	struct VBO {
+		VBO(GLuint bufferId) : _bufferId(bufferId) {}
+		~VBO() {
+			Shader::freeBuffer(_bufferId);
+		}
+
+		GLuint _bufferId;
+		uint _capacity = 0;
+	};
+public:
+	OpenGLRendererShaders(Point resolution)
+		: OpenGLRenderer(resolution) {
+		if (!_shader.loadFromStrings("alcachofa", kVertexShader, kFragmentShader, kAttributes))
+			error("Could not load shader");
+
+		// we use more than one VBO to reduce implicit synchronization
+		for (int i = 0; i < 4; i++)
+			_vbos.emplace_back(Shader::createBuffer(GL_ARRAY_BUFFER, 0, nullptr, GL_STREAM_DRAW));
+
+		_vertices.resize(8 * 6);
+
+		_whiteTexture.reset(new OpenGLTexture(1, 1, false));
+		const byte whiteData[] = { 0xff, 0xff, 0xff, 0xff };
+		GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, whiteData));
+	}
+
+	void begin() override {
+		resetState();
+		_needsNewBatch = true;
+	}
+
+	void end() override {
+		checkFirstDrawCommand();
+		OpenGLRenderer::end();
+	}
+
+	void setTexture(ITexture *texture) override {
+		if (texture == _currentTexture)
+			return;
+		_needsNewBatch = true;
+
+		if (texture == nullptr)
+			_currentTexture = nullptr;
+		else {
+			_currentTexture = dynamic_cast<OpenGLTexture *>(texture);
+			assert(_currentTexture != nullptr);
+		}
+	}
+
+	void setBlendMode(BlendMode blendMode) override {
+		if (blendMode == _currentBlendMode)
+			return;
+		_needsNewBatch = true;
+		_currentBlendMode = blendMode;
+	}
+
+	void setLodBias(float lodBias) override {
+		if (abs(_currentLodBias - lodBias) < epsilon)
+			return;
+		_needsNewBatch = true;
+		_currentLodBias = lodBias;
+	}
+
+	void quad(
+		Vector2d topLeft,
+		Vector2d size,
+		Color color,
+		Angle rotation,
+		Vector2d texMin,
+		Vector2d texMax) override {
+		if (_needsNewBatch) {
+			_needsNewBatch = false;
+			checkFirstDrawCommand();
+		}
+
+		if (_currentTexture != nullptr) {
+			// float equality is fine here, if it was calculated it was not a normal graphic
+			_currentTexture->setMirrorWrap(texMin != Vector2d() || texMax != Vector2d(1, 1));
+		}
+
+		Vector2d positions[4], texCoords[4];
+		getQuadPositions(topLeft, size, rotation, positions);
+		getQuadTexCoords(texMin, texMax, texCoords);
+		_vertices.push_back({ positions[0], texCoords[0], color });
+		_vertices.push_back({ positions[1], texCoords[1], color });
+		_vertices.push_back({ positions[2], texCoords[2], color });
+		_vertices.push_back({ positions[0], texCoords[0], color });
+		_vertices.push_back({ positions[2], texCoords[2], color });
+		_vertices.push_back({ positions[3], texCoords[3], color });
+	}
+
+	void setMatrices(bool flipped) override {
+		// adapted from https://en.wikipedia.org/wiki/Orthographic_projection
+		const float left = 0.0f;
+		const float right = _resolution.x;
+		const float bottom = flipped ? _resolution.y : 0.0f;
+		const float top = flipped ? 0.0f : _resolution.y;
+		const float near = -1.0f;
+		const float far = 1.0f;
+
+		_projection.setToIdentity();
+		_projection(0, 0) = 2.0f / (right - left);
+		_projection(1, 1) = 2.0f / (top - bottom);
+		_projection(2, 2) = -2.0f / (far - near);
+		_projection(3, 0) = -(right + left) / (right - left);
+		_projection(3, 1) = -(top + bottom) / (top - bottom);
+		_projection(3, 2) = -(far + near) / (far - near);
+	}
+
+private:
+	void checkFirstDrawCommand() {
+		OpenGLRenderer::checkFirstDrawCommand();
+
+		// submit batch
+		if (!_vertices.empty()) {
+			auto &vbo = _vbos[_curVBO];
+			_curVBO = (_curVBO + 1) % _vbos.size();
+
+			_shader.enableVertexAttribute("in_pos", vbo._bufferId, 2, GL_FLOAT, false, sizeof(Vertex), offsetof(Vertex, pos));
+			_shader.enableVertexAttribute("in_uv", vbo._bufferId, 2, GL_FLOAT, false, sizeof(Vertex), offsetof(Vertex, uv));
+			_shader.enableVertexAttribute("in_color", vbo._bufferId, 4, GL_UNSIGNED_BYTE, true, sizeof(Vertex), offsetof(Vertex, color));
+			_shader.use(true);
+
+			GL_CALL(glBindTexture(GL_TEXTURE_2D, _batchTexture == nullptr
+				? _whiteTexture->handle()
+				: _batchTexture->handle()));
+			GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, vbo._bufferId));
+			if (vbo._capacity < _vertices.size()) {
+				vbo._capacity = _vertices.size();
+				glBufferData(GL_ARRAY_BUFFER, sizeof(Vertex) * _vertices.size(), _vertices.data(), GL_STREAM_DRAW);
+			} else
+				glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(Vertex) * _vertices.size(), _vertices.data());
+			glDrawArrays(GL_TRIANGLES, 0, _vertices.size());
+			_vertices.clear();
+		}
+
+		// setup next batch
+		setBlendFunc(_currentBlendMode);
+		_shader.setUniform("projection", _projection);
+		_shader.setUniform("blendMode", _currentTexture == nullptr ? 5 : (int)_currentBlendMode);
+		_shader.setUniform1f("lodBias", _currentLodBias);
+		_shader.setUniform("texture", 0);
+		_batchTexture = _currentTexture;
+	}
+
+	Matrix4 _projection;
+	Shader _shader;
+	Array<VBO> _vbos;
+	Array<Vertex> _vertices;
+	uint _curVBO = 0;
+	uint _usedTextureUnits = 0;
+	bool _needsNewBatch = false;
+	OpenGLTexture *_batchTexture = nullptr;
+	ScopedPtr<OpenGLTexture> _whiteTexture;
+
+	static constexpr const char *const kAttributes[] = {
+		"in_pos",
+		"in_uv",
+		"in_color",
+		nullptr
+	};
+
+	static constexpr const char *const kVertexShader = R"(
+		uniform mat4 projection;
+
+		attribute vec2 in_pos;
+		attribute vec2 in_uv;
+		attribute vec4 in_color;
+
+		varying vec2 var_uv;
+		varying vec4 var_color;
+
+		void main() {
+			gl_Position = projection * vec4(in_pos, 0.0, 1.0);
+			var_uv = in_uv;
+			var_color = in_color;
+		})";
+
+	static constexpr const char *const kFragmentShader = R"(
+		#ifdef GL_ES
+			precision mediump float;
+		#endif
+
+		uniform sampler2D texture;
+		uniform int blendMode;
+		uniform float lodBias;
+
+		varying vec2 var_uv;
+		varying vec4 var_color;
+
+		void main() {
+			vec4 tex_color = texture2D(texture, var_uv, lodBias);
+			if (blendMode <= 2) { // AdditiveAlpha, Additive and Multiply
+				gl_FragColor.rgb = tex_color.rgb * var_color.a;
+				gl_FragColor.a = tex_color.a;
+			} else if (blendMode == 3) { // Alpha
+				gl_FragColor.rgb = tex_color.rgb;
+				gl_FragColor.a = var_color.a;
+			} else if (blendMode == 4) { // Tinted
+				gl_FragColor.rgb = var_color.rgb * var_color.a * tex_color.rgb;
+				gl_FragColor.a = tex_color.a;
+			} else { // Disabled texture
+				gl_FragColor = var_color;
+			}
+		})";
+};
+
+IRenderer *createOpenGLRendererShaders(Point resolution) {
+	debug("Use OpenGL shaders renderer");
+	return new OpenGLRendererShaders(resolution);
+}
+
+}

--- a/engines/alcachofa/graphics-opengl-shaders.cpp
+++ b/engines/alcachofa/graphics-opengl-shaders.cpp
@@ -52,6 +52,12 @@ class OpenGLRendererShaders : public OpenGLRenderer {
 public:
 	OpenGLRendererShaders(Point resolution)
 		: OpenGLRenderer(resolution) {
+		static constexpr const char *const kAttributes[] = {
+			"in_pos",
+			"in_uv",
+			"in_color",
+			nullptr
+		};
 		if (!_shader.loadFromStrings("alcachofa", kVertexShader, kFragmentShader, kAttributes))
 			error("Could not load shader");
 
@@ -194,13 +200,6 @@ private:
 	bool _needsNewBatch = false;
 	OpenGLTexture *_batchTexture = nullptr;
 	ScopedPtr<OpenGLTexture> _whiteTexture;
-
-	static constexpr const char *const kAttributes[] = {
-		"in_pos",
-		"in_uv",
-		"in_color",
-		nullptr
-	};
 
 	static constexpr const char *const kVertexShader = R"(
 		uniform mat4 projection;

--- a/engines/alcachofa/graphics-opengl.cpp
+++ b/engines/alcachofa/graphics-opengl.cpp
@@ -177,8 +177,7 @@ public:
 			GL_CALL(glDisable(GL_TEXTURE_2D));
 			GL_CALL(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
 			_currentTexture = nullptr;
-		}
-		else {
+		} else {
 			if (_currentTexture == nullptr) {
 				GL_CALL(glEnable(GL_TEXTURE_2D));
 				GL_CALL(glEnableClientState(GL_TEXTURE_COORD_ARRAY));
@@ -253,7 +252,9 @@ public:
 			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_SRC1_RGB, GL_PRIMARY_COLOR));
 			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND1_RGB, GL_SRC_COLOR)); // we have to pre-multiply
 			break;
-		default: assert(false && "Invalid blend mode"); break;
+		default:
+			assert(false && "Invalid blend mode");
+			break;
 		}
 		_currentBlendMode = blendMode;
 	}
@@ -327,8 +328,7 @@ public:
 		}
 
 		float colors[] = { color.r / 255.0f, color.g / 255.0f, color.b / 255.0f, color.a / 255.0f };
-		if (_currentBlendMode == BlendMode::Tinted)
-		{
+		if (_currentBlendMode == BlendMode::Tinted) {
 			colors[0] *= colors[3];
 			colors[1] *= colors[3];
 			colors[2] *= colors[3];

--- a/engines/alcachofa/graphics-opengl.cpp
+++ b/engines/alcachofa/graphics-opengl.cpp
@@ -146,12 +146,11 @@ public:
 	virtual void begin() override {
 		GL_CALL(glEnableClientState(GL_VERTEX_ARRAY));
 		GL_CALL(glDisableClientState(GL_INDEX_ARRAY));
+		GL_CALL(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
 		_currentLodBias = -1000.0f;
 		_currentTexture = nullptr;
 		_currentBlendMode = (BlendMode)-1;
-
-		GL_CALL(glClearColor(0.0f, 0.0f, 0.0f, 1.0f));
-		GL_CALL(glClear(GL_COLOR_BUFFER_BIT));
+		_isFirstDrawCommand = true;
 	}
 
 	virtual void end() override {
@@ -292,6 +291,7 @@ public:
 			colors[2] *= colors[3];
 		}
 
+		checkFirstDrawCommand();
 		GL_CALL(glColor4fv(colors));
 		GL_CALL(glVertexPointer(2, GL_FLOAT, 0, positions));
 		if (_currentTexture != nullptr)
@@ -309,6 +309,7 @@ public:
 		Span<Vector2d> points,
 		Color color
 	) override {
+		checkFirstDrawCommand();
 		setTexture(nullptr);
 		setBlendMode(BlendMode::Alpha);
 		GL_CALL(glVertexPointer(2, GL_FLOAT, 0, points.data()));
@@ -334,6 +335,7 @@ public:
 		Span<Vector2d> points,
 		Color color
 	) override {
+		checkFirstDrawCommand();
 		setTexture(nullptr);
 		setBlendMode(BlendMode::Alpha);
 		GL_CALL(glVertexPointer(2, GL_FLOAT, 0, points.data()));
@@ -369,10 +371,21 @@ private:
 		GL_CALL(glLoadIdentity());
 	}
 
+	void checkFirstDrawCommand() {
+		// We delay clearing the screen. It is much easier for the game to switch to a
+		// framebuffer before 
+		if (!_isFirstDrawCommand)
+			return;
+		_isFirstDrawCommand = false;
+		GL_CALL(glClearColor(0.0f, 0.0f, 0.0f, 1.0f));
+		GL_CALL(glClear(GL_COLOR_BUFFER_BIT));
+	}
+
 	Point _resolution;
 	OpenGLTexture *_currentTexture = nullptr;
 	BlendMode _currentBlendMode = (BlendMode)-1;
 	float _currentLodBias = 0.0f;
+	bool _isFirstDrawCommand = false;
 };
 
 IRenderer *IRenderer::createOpenGLRenderer(Point resolution) {

--- a/engines/alcachofa/graphics-opengl.cpp
+++ b/engines/alcachofa/graphics-opengl.cpp
@@ -341,7 +341,7 @@ public:
 			GL_CALL(glTexCoordPointer(2, GL_FLOAT, 0, texCoords));
 		GL_CALL(glDrawArrays(GL_QUADS, 0, 4));
 
-#ifdef _DEBUG
+#ifdef ALCACHOFA_DEBUG
 		// make sure we crash instead of someone using our stack arrays
 		GL_CALL(glVertexPointer(2, GL_FLOAT, sizeof(Vector2d), nullptr));
 		GL_CALL(glTexCoordPointer(2, GL_FLOAT, sizeof(Vector2d), nullptr));

--- a/engines/alcachofa/graphics-opengl.cpp
+++ b/engines/alcachofa/graphics-opengl.cpp
@@ -85,7 +85,7 @@ public:
 			GL_CALL(glDeleteTextures(1, &_handle));
 	}
 
-	virtual void update(const Surface &surface) {
+	void update(const Surface &surface) override {
 		OpenGLFormat format = getOpenGLFormatOf(surface.format);
 		assert(surface.w == size().x && surface.h == size().y);
 		assert(format.isValid());
@@ -301,7 +301,7 @@ public:
 		return _currentOutput != nullptr;
 	}
 
-	virtual void quad(
+	void quad(
 		Vector2d topLeft,
 		Vector2d size,
 		Color color,
@@ -353,7 +353,7 @@ public:
 #endif
 	}
 
-	virtual void debugPolygon(
+	void debugPolygon(
 		Span<Vector2d> points,
 		Color color
 	) override {
@@ -379,7 +379,7 @@ public:
 			GL_CALL(glDrawArrays(GL_POINTS, 0, points.size()));
 	}
 
-	virtual void debugPolyline(
+	void debugPolyline(
 		Span<Vector2d> points,
 		Color color
 	) override {

--- a/engines/alcachofa/graphics-opengl.cpp
+++ b/engines/alcachofa/graphics-opengl.cpp
@@ -21,12 +21,10 @@
 
 #include "alcachofa/graphics.h"
 #include "alcachofa/detection.h"
+#include "alcachofa/graphics-opengl.h"
 
 #include "common/system.h"
 #include "engines/util.h"
-#include "graphics/managed_surface.h"
-#include "graphics/opengl/system_headers.h"
-#include "graphics/opengl/debug.h"
 
 using namespace Common;
 using namespace Math;
@@ -34,18 +32,13 @@ using namespace Graphics;
 
 namespace Alcachofa {
 
-struct OpenGLFormat {
-	GLenum _format, _type;
-	inline bool isValid() const { return _format != GL_NONE; }
-};
-
 static bool areComponentsInOrder(const PixelFormat &format, int r, int g, int b, int a) {
 	return format == (a < 0
 		? PixelFormat(3, 8, 8, 8, 0, r * 8, g * 8, b * 8, 0)
 		: PixelFormat(4, 8, 8, 8, 8, r * 8, g * 8, b * 8, a * 8));
 }
 
-static OpenGLFormat getOpenGLFormatOf(const PixelFormat &format) {
+OpenGLFormat getOpenGLFormatOf(const PixelFormat &format) {
 	if (areComponentsInOrder(format, 0, 1, 2, 3))
 		return { GL_RGBA, GL_UNSIGNED_BYTE };
 	else if (areComponentsInOrder(format, 3, 2, 1, 0))
@@ -61,394 +54,177 @@ static OpenGLFormat getOpenGLFormatOf(const PixelFormat &format) {
 		return { GL_NONE, GL_NONE };
 }
 
+OpenGLTexture::OpenGLTexture(int32 w, int32 h, bool withMipmaps)
+	: ITexture({ (int16)w, (int16)h })
+	, _withMipmaps(withMipmaps) {
+	GL_CALL(glEnable(GL_TEXTURE_2D));
+	GL_CALL(glGenTextures(1, &_handle));
+	GL_CALL(glBindTexture(GL_TEXTURE_2D, _handle));
+	GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR));
+	GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
+	setMirrorWrap(false);
+}
 
-class OpenGLTexture : public ITexture {
-public:
-	OpenGLTexture(int32 w, int32 h, bool withMipmaps)
-		: ITexture({ (int16)w, (int16)h })
-		, _withMipmaps(withMipmaps) {
-		GL_CALL(glEnable(GL_TEXTURE_2D));
-		GL_CALL(glGenTextures(1, &_handle));
-		GL_CALL(glBindTexture(GL_TEXTURE_2D, _handle));
-		GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR));
-		GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
-		setMirrorWrap(false);
+OpenGLTexture::~OpenGLTexture() {
+	if (_handle != 0)
+		GL_CALL(glDeleteTextures(1, &_handle));
+}
+
+void OpenGLTexture::update(const Surface &surface) {
+	OpenGLFormat format = getOpenGLFormatOf(surface.format);
+	assert(surface.w == size().x && surface.h == size().y);
+	assert(format.isValid());
+
+	GL_CALL(glEnable(GL_TEXTURE_2D));
+	GL_CALL(glBindTexture(GL_TEXTURE_2D, _handle));
+	GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, surface.w, surface.h, 0, format._format, format._type, surface.getPixels()));
+	if (_withMipmaps)
+		GL_CALL(glGenerateMipmap(GL_TEXTURE_2D));
+	else
+		GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));
+}
+
+void OpenGLTexture::setMirrorWrap(bool wrap) {
+	if (_mirrorWrap == wrap)
+		return;
+	_mirrorWrap = wrap;
+	GLint wrapMode;
+	if (wrap)
+		wrapMode = OpenGLContext.textureMirrorRepeatSupported ? GL_MIRRORED_REPEAT : GL_REPEAT;
+	else
+		wrapMode = OpenGLContext.textureEdgeClampSupported ? GL_CLAMP_TO_EDGE : GL_CLAMP;
+
+	GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrapMode));
+	GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrapMode));
+}
+
+OpenGLRenderer::OpenGLRenderer(Point resolution) : _resolution(resolution) {
+	GL_CALL(glDisable(GL_LIGHTING));
+	GL_CALL(glDisable(GL_DEPTH_TEST));
+	GL_CALL(glDisable(GL_SCISSOR_TEST));
+	GL_CALL(glDisable(GL_STENCIL_TEST));
+	GL_CALL(glDisable(GL_CULL_FACE));
+	GL_CALL(glEnable(GL_BLEND));
+	GL_CALL(glDepthMask(GL_FALSE));
+
+	if (!OpenGLContext.NPOTSupported || !OpenGLContext.textureMirrorRepeatSupported) {
+		g_system->messageBox(LogMessageType::kWarning, "Old OpenGL detected, some graphical errors will occur.");
 	}
+}
 
-	~OpenGLTexture() override {
-		if (_handle != 0)
-			GL_CALL(glDeleteTextures(1, &_handle));
+ScopedPtr<ITexture> OpenGLRenderer::createTexture(int32 w, int32 h, bool withMipmaps) {
+	assert(w >= 0 && h >= 0);
+	return ScopedPtr<ITexture>(new OpenGLTexture(w, h, withMipmaps));
+}
+
+void OpenGLRenderer::resetState() {
+	setViewportToScreen();
+	_currentOutput = nullptr;
+	_currentLodBias = -1000.0f;
+	_currentTexture = nullptr;
+	_currentBlendMode = (BlendMode)-1;
+	_isFirstDrawCommand = true;
+}
+
+void OpenGLRenderer::end() {
+	GL_CALL(glFlush());
+
+	if (_currentOutput != nullptr) {
+		g_system->presentBuffer();
+		auto format = getOpenGLFormatOf(_currentOutput->format);
+		GL_CALL(glReadPixels(
+			0,
+			0,
+			_outputSize.x,
+			_outputSize.y,
+			format._format,
+			format._type,
+			_currentOutput->getPixels()
+		));
 	}
+}
 
-	void update(const Surface &surface) override {
-		OpenGLFormat format = getOpenGLFormatOf(surface.format);
-		assert(surface.w == size().x && surface.h == size().y);
-		assert(format.isValid());
-
-		GL_CALL(glEnable(GL_TEXTURE_2D));
-		GL_CALL(glBindTexture(GL_TEXTURE_2D, _handle));
-		GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, surface.w, surface.h, 0, format._format, format._type, surface.getPixels()));
-		if (_withMipmaps)
-			GL_CALL(glGenerateMipmap(GL_TEXTURE_2D));
-		else
-			GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));
+void OpenGLRenderer::setBlendFunc(BlendMode blendMode) {
+	switch (blendMode) {
+	case BlendMode::AdditiveAlpha:
+		GL_CALL(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
+		break;
+	case BlendMode::Additive:
+		GL_CALL(glBlendFunc(GL_ONE, GL_ONE));
+		break;
+	case BlendMode::Multiply:
+		GL_CALL(glBlendFunc(GL_DST_COLOR, GL_ONE));
+		break;
+	case BlendMode::Alpha:
+		GL_CALL(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
+		break;
+	case BlendMode::Tinted:
+		GL_CALL(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
+		break;
+	default: assert(false && "Invalid blend mode"); break;
 	}
+}
 
-	void setMirrorWrap(bool wrap) {
-		if (_mirrorWrap == wrap)
-			return;
-		_mirrorWrap = wrap;
-		GLint wrapMode;
-		if (wrap)
-			wrapMode = OpenGLContext.textureMirrorRepeatSupported ? GL_MIRRORED_REPEAT : GL_REPEAT;
-		else
-			wrapMode = OpenGLContext.textureEdgeClampSupported ? GL_CLAMP_TO_EDGE : GL_CLAMP;
+void OpenGLRenderer::setOutput(Surface &output) {
+	assert(_isFirstDrawCommand);
+	setViewportToRect(output.w, output.h);
+	_currentOutput = &output;
 
-		GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrapMode));
-		GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrapMode));
-	}
+	// just debug warnings as it will only produce a graphical glitch while
+	// there is some chance the resolution could change from here to ::end
+	// and this is per-frame so maybe don't spam the console with the same message
 
-	inline GLuint handle() const { return _handle; }
+	if (output.w > g_system->getWidth() || output.h > g_system->getHeight())
+		debugC(0, kDebugGraphics, "Output is larger than screen, output will be cropped (%d, %d) > (%d, %d)",
+			output.w, output.h, g_system->getWidth(), g_system->getHeight());
 
-private:
-	GLuint _handle;
-	bool _withMipmaps;
-	bool _mirrorWrap = true;
-};
-
-class OpenGLRenderer : public IDebugRenderer {
-public:
-	OpenGLRenderer(Point resolution)
-		: _resolution(resolution) {
-		setViewportToScreen();
-
-		GL_CALL(glDisable(GL_LIGHTING));
-		GL_CALL(glDisable(GL_DEPTH_TEST));
-		GL_CALL(glDisable(GL_SCISSOR_TEST));
-		GL_CALL(glDisable(GL_STENCIL_TEST));
-		GL_CALL(glDisable(GL_CULL_FACE));
-		GL_CALL(glEnable(GL_BLEND));
-		GL_CALL(glDepthMask(GL_FALSE));
-
-		if (!OpenGLContext.NPOTSupported || !OpenGLContext.textureMirrorRepeatSupported) {
-			g_system->messageBox(LogMessageType::kWarning, "Old OpenGL detected, some graphical errors will occur.");
-		}
-	}
-
-	ScopedPtr<ITexture> createTexture(int32 w, int32 h, bool withMipmaps) override {
-		assert(w >= 0 && h >= 0);
-		return ScopedPtr<ITexture>(new OpenGLTexture(w, h, withMipmaps));
-	}
-
-	void begin() override {
-		GL_CALL(glEnableClientState(GL_VERTEX_ARRAY));
-		GL_CALL(glDisableClientState(GL_INDEX_ARRAY));
-		GL_CALL(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
-		setViewportToScreen();
+	auto format = getOpenGLFormatOf(output.format);
+	if (format._format == GL_NONE) {
+		auto formatString = output.format.toString();
+		debugC(0, kDebugGraphics, "Cannot use pixelformat of given output surface: %s", formatString.c_str());
 		_currentOutput = nullptr;
-		_currentLodBias = -1000.0f;
-		_currentTexture = nullptr;
-		_currentBlendMode = (BlendMode)-1;
-		_isFirstDrawCommand = true;
 	}
 
-	void end() override {
-		GL_CALL(glFlush());
-
-		if (_currentOutput != nullptr) {
-			g_system->presentBuffer();
-			auto format = getOpenGLFormatOf(_currentOutput->format);
-			GL_CALL(glReadPixels(
-				0,
-				0,
-				_outputSize.x,
-				_outputSize.y,
-				format._format,
-				format._type,
-				_currentOutput->getPixels()
-			));
-		}
+	if (output.pitch != output.format.bytesPerPixel * output.w) {
+		// Maybe there would be a way with glPixelStore
+		debugC(0, kDebugGraphics, "Incompatible output surface pitch");
+		_currentOutput = nullptr;
 	}
+}
 
-	void setTexture(ITexture *texture) override {
-		if (texture == _currentTexture)
-			return;
-		else if (texture == nullptr) {
-			GL_CALL(glDisable(GL_TEXTURE_2D));
-			GL_CALL(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
-			_currentTexture = nullptr;
-		} else {
-			if (_currentTexture == nullptr) {
-				GL_CALL(glEnable(GL_TEXTURE_2D));
-				GL_CALL(glEnableClientState(GL_TEXTURE_COORD_ARRAY));
-			}
-			auto glTexture = dynamic_cast<OpenGLTexture *>(texture);
-			assert(glTexture != nullptr);
-			GL_CALL(glBindTexture(GL_TEXTURE_2D, glTexture->handle()));
-			_currentTexture = glTexture;
-		}
-	}
+bool OpenGLRenderer::hasOutput() const {
+	return _currentOutput != nullptr;
+}
 
-	void setBlendMode(BlendMode blendMode) override {
-		if (blendMode == _currentBlendMode)
-			return;
-		// first the blend func
-		switch (blendMode) {
-		case BlendMode::AdditiveAlpha:
-			GL_CALL(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
-			break;
-		case BlendMode::Additive:
-			GL_CALL(glBlendFunc(GL_ONE, GL_ONE));
-			break;
-		case BlendMode::Multiply:
-			GL_CALL(glBlendFunc(GL_DST_COLOR, GL_ONE));
-			break;
-		case BlendMode::Alpha:
-			GL_CALL(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
-			break;
-		case BlendMode::Tinted:
-			GL_CALL(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
-			break;
-		default: assert(false && "Invalid blend mode"); break;
-		}
+void OpenGLRenderer::setViewportToScreen() {
+	int32 screenWidth = g_system->getWidth();
+	int32 screenHeight = g_system->getHeight();
+	Rect viewport(
+		MIN<int32>(screenWidth, screenHeight * (float)_resolution.x / _resolution.y),
+		MIN<int32>(screenHeight, screenWidth * (float)_resolution.y / _resolution.x));
+	viewport.translate(
+		(screenWidth - viewport.width()) / 2,
+		(screenHeight - viewport.height()) / 2);
 
-		GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE));
-		switch (blendMode) {
-		case BlendMode::AdditiveAlpha:
-		case BlendMode::Additive:
-		case BlendMode::Multiply:
-			// TintAlpha * TexColor, TexAlpha
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB, GL_MODULATE));
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ALPHA, GL_REPLACE));
+	GL_CALL(glViewport(viewport.left, viewport.top, viewport.width(), viewport.height()));
+	setMatrices(true);
+}
 
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_SRC0_RGB, GL_TEXTURE));
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_RGB, GL_SRC_COLOR));
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_SRC0_ALPHA, GL_TEXTURE));
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_ALPHA, GL_SRC_ALPHA));
+void OpenGLRenderer::setViewportToRect(int16 outputWidth, int16 outputHeight) {
+	_outputSize.x = MIN(outputWidth, g_system->getWidth());
+	_outputSize.y = MIN(outputHeight, g_system->getHeight());
+	GL_CALL(glViewport(0, 0, _outputSize.x, _outputSize.y));
+	setMatrices(false);
+}
 
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_SRC1_RGB, GL_PRIMARY_COLOR));
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND1_RGB, GL_SRC_ALPHA)); // alpha replaces color
-			break;
-		case BlendMode::Alpha:
-			// TexColor, TintAlpha
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB, GL_REPLACE));
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ALPHA, GL_REPLACE));
-
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_SRC0_RGB, GL_TEXTURE));
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_RGB, GL_SRC_COLOR));
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_SRC0_ALPHA, GL_PRIMARY_COLOR));
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_ALPHA, GL_SRC_ALPHA));
-			break;
-		case BlendMode::Tinted:
-			// (TintColor * TintAlpha) * TexColor, TexAlpha
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB, GL_MODULATE));
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ALPHA, GL_REPLACE));
-
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_SRC0_RGB, GL_TEXTURE));
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_RGB, GL_SRC_COLOR));
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_SRC0_ALPHA, GL_TEXTURE));
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_ALPHA, GL_SRC_ALPHA));
-
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_SRC1_RGB, GL_PRIMARY_COLOR));
-			GL_CALL(glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND1_RGB, GL_SRC_COLOR)); // we have to pre-multiply
-			break;
-		default:
-			assert(false && "Invalid blend mode");
-			break;
-		}
-		_currentBlendMode = blendMode;
-	}
-
-	void setLodBias(float lodBias) override {
-		if (abs(_currentLodBias - lodBias) < epsilon)
-			return;
-		GL_CALL(glTexEnvf(GL_TEXTURE_FILTER_CONTROL, GL_TEXTURE_LOD_BIAS, lodBias));
-		_currentLodBias = lodBias;
-	}
-
-	void setOutput(Surface &output) override {
-		assert(_isFirstDrawCommand);
-		setViewportToRect(output.w, output.h);
-		_currentOutput = &output;
-
-		// just debug warnings as it will only produce a graphical glitch while
-		// there is some chance the resolution could change from here to ::end
-		// and this is per-frame so maybe don't spam the console with the same message
-
-		if (output.w > g_system->getWidth() || output.h > g_system->getHeight())
-			debugC(0, kDebugGraphics, "Output is larger than screen, output will be cropped (%d, %d) > (%d, %d)",
-				output.w, output.h, g_system->getWidth(), g_system->getHeight());
-
-		auto format = getOpenGLFormatOf(output.format);
-		if (format._format == GL_NONE) {
-			auto formatString = output.format.toString();
-			debugC(0, kDebugGraphics, "Cannot use pixelformat of given output surface: %s", formatString.c_str());
-			_currentOutput = nullptr;
-		}
-
-		if (output.pitch != output.format.bytesPerPixel * output.w) {
-			// Maybe there would be a way with glPixelStore
-			debugC(0, kDebugGraphics, "Incompatible output surface pitch");
-			_currentOutput = nullptr;
-		}
-	}
-
-	bool hasOutput() const override {
-		return _currentOutput != nullptr;
-	}
-
-	void quad(
-		Vector2d topLeft,
-		Vector2d size,
-		Color color,
-		Angle rotation,
-		Vector2d texMin,
-		Vector2d texMax) override {
-		Vector2d positions[] = {
-			topLeft + Vector2d(0,			0),
-			topLeft + Vector2d(0,			+size.getY()),
-			topLeft + Vector2d(+size.getX(), +size.getY()),
-			topLeft + Vector2d(+size.getX(), 0),
-		};
-		if (abs(rotation.getDegrees()) > epsilon) {
-			const Vector2d zero(0, 0);
-			for (int i = 0; i < 4; i++)
-				positions[i].rotateAround(zero, rotation);
-		}
-
-		Vector2d texCoords[] = {
-			{ texMin.getX(), texMin.getY() },
-			{ texMin.getX(), texMax.getY() },
-			{ texMax.getX(), texMax.getY() },
-			{ texMax.getX(), texMin.getY() }
-		};
-		if (_currentTexture != nullptr) {
-			// float equality is fine here, if it was calculated it was not a normal graphic
-			_currentTexture->setMirrorWrap(texMin != Vector2d() || texMax != Vector2d(1, 1));
-		}
-
-		float colors[] = { color.r / 255.0f, color.g / 255.0f, color.b / 255.0f, color.a / 255.0f };
-		if (_currentBlendMode == BlendMode::Tinted) {
-			colors[0] *= colors[3];
-			colors[1] *= colors[3];
-			colors[2] *= colors[3];
-		}
-
-		checkFirstDrawCommand();
-		GL_CALL(glColor4fv(colors));
-		GL_CALL(glVertexPointer(2, GL_FLOAT, 0, positions));
-		if (_currentTexture != nullptr)
-			GL_CALL(glTexCoordPointer(2, GL_FLOAT, 0, texCoords));
-		GL_CALL(glDrawArrays(GL_QUADS, 0, 4));
-
-#ifdef ALCACHOFA_DEBUG
-		// make sure we crash instead of someone using our stack arrays
-		GL_CALL(glVertexPointer(2, GL_FLOAT, sizeof(Vector2d), nullptr));
-		GL_CALL(glTexCoordPointer(2, GL_FLOAT, sizeof(Vector2d), nullptr));
-#endif
-	}
-
-	void debugPolygon(
-		Span<Vector2d> points,
-		Color color
-	) override {
-		checkFirstDrawCommand();
-		setTexture(nullptr);
-		setBlendMode(BlendMode::Alpha);
-		GL_CALL(glVertexPointer(2, GL_FLOAT, 0, points.data()));
-		GL_CALL(glLineWidth(4.0f));
-		GL_CALL(glPointSize(8.0f));
-
-		GL_CALL(glColor4ub(color.r, color.g, color.b, color.a));
-		if (points.size() > 2)
-			GL_CALL(glDrawArrays(GL_POLYGON, 0, points.size()));
-
-		color.a = (byte)(MIN(255.0f, color.a * 1.3f));
-		GL_CALL(glColor4ub(color.r, color.g, color.b, color.a));
-		if (points.size() > 1)
-			GL_CALL(glDrawArrays(GL_LINE_LOOP, 0, points.size()));
-
-		color.a = (byte)(MIN(255.0f, color.a * 1.3f));
-		GL_CALL(glColor4ub(color.r, color.g, color.b, color.a));
-		if (points.size() > 0)
-			GL_CALL(glDrawArrays(GL_POINTS, 0, points.size()));
-	}
-
-	void debugPolyline(
-		Span<Vector2d> points,
-		Color color
-	) override {
-		checkFirstDrawCommand();
-		setTexture(nullptr);
-		setBlendMode(BlendMode::Alpha);
-		GL_CALL(glVertexPointer(2, GL_FLOAT, 0, points.data()));
-		GL_CALL(glLineWidth(4.0f));
-		GL_CALL(glPointSize(8.0f));
-
-		GL_CALL(glColor4ub(color.r, color.g, color.b, color.a));
-		if (points.size() > 1)
-			GL_CALL(glDrawArrays(GL_LINE_STRIP, 0, points.size()));
-
-		color.a = (byte)(MIN(255.0f, color.a * 1.3f));
-		GL_CALL(glColor4ub(color.r, color.g, color.b, color.a));
-		if (points.size() > 0)
-			GL_CALL(glDrawArrays(GL_POINTS, 0, points.size()));
-	}
-
-private:
-	void setMatrices(bool flipped) {
-		float bottom = flipped ? _resolution.y : 0.0f;
-		float top = flipped ? 0.0f : _resolution.y;
-
-		GL_CALL(glMatrixMode(GL_PROJECTION));
-		GL_CALL(glLoadIdentity());
-		GL_CALL(glOrtho(0.0f, _resolution.x, bottom, top, -1.0f, 1.0f));
-		GL_CALL(glMatrixMode(GL_MODELVIEW));
-		GL_CALL(glLoadIdentity());
-	}
-
-	void setViewportToScreen() {
-		int32 screenWidth = g_system->getWidth();
-		int32 screenHeight = g_system->getHeight();
-		Rect viewport(
-			MIN<int32>(screenWidth, screenHeight * (float)_resolution.x / _resolution.y),
-			MIN<int32>(screenHeight, screenWidth * (float)_resolution.y / _resolution.x));
-		viewport.translate(
-			(screenWidth - viewport.width()) / 2,
-			(screenHeight - viewport.height()) / 2);
-
-		GL_CALL(glViewport(viewport.left, viewport.top, viewport.width(), viewport.height()));
-		setMatrices(true);
-	}
-
-	void setViewportToRect(int16 outputWidth, int16 outputHeight) {
-		_outputSize.x = MIN(outputWidth, g_system->getWidth());
-		_outputSize.y = MIN(outputHeight, g_system->getHeight());
-		GL_CALL(glViewport(0, 0, _outputSize.x, _outputSize.y));
-		setMatrices(false);
-	}
-
-	void checkFirstDrawCommand() {
-		// We delay clearing the screen. It is much easier for the game
+void OpenGLRenderer::checkFirstDrawCommand() {
+	// We delay clearing the screen. It is much easier for the game
 		// to switch to a framebuffer before
-		if (!_isFirstDrawCommand)
-			return;
-		_isFirstDrawCommand = false;
-		GL_CALL(glClearColor(0.0f, 0.0f, 0.0f, 1.0f));
-		GL_CALL(glClear(GL_COLOR_BUFFER_BIT));
-	}
-
-	Point _resolution, _outputSize;
-	Surface *_currentOutput = nullptr;
-	OpenGLTexture *_currentTexture = nullptr;
-	BlendMode _currentBlendMode = (BlendMode)-1;
-	float _currentLodBias = 0.0f;
-	bool _isFirstDrawCommand = false;
-};
-
-IRenderer *IRenderer::createOpenGLRenderer(Point resolution) {
-	initGraphics3d(resolution.x, resolution.y);
-	return new OpenGLRenderer(resolution);
+	if (!_isFirstDrawCommand)
+		return;
+	_isFirstDrawCommand = false;
+	GL_CALL(glClearColor(0.0f, 0.0f, 0.0f, 1.0f));
+	GL_CALL(glClear(GL_COLOR_BUFFER_BIT));
 }
 
 }

--- a/engines/alcachofa/graphics-opengl.cpp
+++ b/engines/alcachofa/graphics-opengl.cpp
@@ -341,7 +341,7 @@ public:
 			GL_CALL(glTexCoordPointer(2, GL_FLOAT, 0, texCoords));
 		GL_CALL(glDrawArrays(GL_QUADS, 0, 4));
 
-#if _DEBUG
+#ifdef _DEBUG
 		// make sure we crash instead of someone using our stack arrays
 		GL_CALL(glVertexPointer(2, GL_FLOAT, sizeof(Vector2d), nullptr));
 		GL_CALL(glTexCoordPointer(2, GL_FLOAT, sizeof(Vector2d), nullptr));

--- a/engines/alcachofa/graphics-opengl.cpp
+++ b/engines/alcachofa/graphics-opengl.cpp
@@ -26,12 +26,7 @@
 #include "engines/util.h"
 #include "graphics/managed_surface.h"
 #include "graphics/opengl/system_headers.h"
-
-#ifdef ALCACHOFA_DEBUG_OPENGL // clearing OpenGL errors are very slow, so we only activate the debugging wrapper if necessary
 #include "graphics/opengl/debug.h"
-#else
-#define GL_CALL(call) call
-#endif
 
 using namespace Common;
 using namespace Math;

--- a/engines/alcachofa/graphics-opengl.cpp
+++ b/engines/alcachofa/graphics-opengl.cpp
@@ -79,7 +79,7 @@ public:
 		setMirrorWrap(false);
 	}
 
-	virtual ~OpenGLTexture() override {
+	~OpenGLTexture() override {
 		if (_handle != 0)
 			GL_CALL(glDeleteTextures(1, &_handle));
 	}
@@ -138,12 +138,12 @@ public:
 		}
 	}
 
-	virtual ScopedPtr<ITexture> createTexture(int32 w, int32 h, bool withMipmaps) override {
+	ScopedPtr<ITexture> createTexture(int32 w, int32 h, bool withMipmaps) override {
 		assert(w >= 0 && h >= 0);
 		return ScopedPtr<ITexture>(new OpenGLTexture(w, h, withMipmaps));
 	}
 
-	virtual void begin() override {
+	void begin() override {
 		GL_CALL(glEnableClientState(GL_VERTEX_ARRAY));
 		GL_CALL(glDisableClientState(GL_INDEX_ARRAY));
 		GL_CALL(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
@@ -153,12 +153,12 @@ public:
 		_isFirstDrawCommand = true;
 	}
 
-	virtual void end() override {
+	void end() override {
 		GL_CALL(glFlush());
 		g_system->updateScreen();
 	}
 
-	virtual void setTexture(ITexture *texture) override {
+	void setTexture(ITexture *texture) override {
 		if (texture == _currentTexture)
 			return;
 		else if (texture == nullptr) {
@@ -178,7 +178,7 @@ public:
 		}
 	}
 
-	virtual void setBlendMode(BlendMode blendMode) override {
+	void setBlendMode(BlendMode blendMode) override {
 		if (blendMode == _currentBlendMode)
 			return;
 		// first the blend func
@@ -246,7 +246,7 @@ public:
 		_currentBlendMode = blendMode;
 	}
 
-	virtual void setLodBias(float lodBias) override {
+	void setLodBias(float lodBias) override {
 		if (abs(_currentLodBias - lodBias) < epsilon)
 			return;
 		GL_CALL(glTexEnvf(GL_TEXTURE_FILTER_CONTROL, GL_TEXTURE_LOD_BIAS, lodBias));

--- a/engines/alcachofa/graphics-opengl.cpp
+++ b/engines/alcachofa/graphics-opengl.cpp
@@ -19,8 +19,8 @@
  *
  */
 
-#include "graphics.h"
-#include "detection.h"
+#include "alcachofa/graphics.h"
+#include "alcachofa/detection.h"
 
 #include "common/system.h"
 #include "engines/util.h"

--- a/engines/alcachofa/graphics-opengl.cpp
+++ b/engines/alcachofa/graphics-opengl.cpp
@@ -24,7 +24,9 @@
 #include "alcachofa/graphics-opengl.h"
 
 #include "common/system.h"
+#include "common/config-manager.h"
 #include "engines/util.h"
+#include "graphics/renderer.h"
 
 using namespace Common;
 using namespace Math;
@@ -33,31 +35,19 @@ using namespace Graphics;
 namespace Alcachofa {
 
 static bool areComponentsInOrder(const PixelFormat &format, int r, int g, int b, int a) {
-	return format == (a < 0
-		? PixelFormat(3, 8, 8, 8, 0, r * 8, g * 8, b * 8, 0)
-		: PixelFormat(4, 8, 8, 8, 8, r * 8, g * 8, b * 8, a * 8));
+	return format == PixelFormat(4, 8, 8, 8, 8, r * 8, g * 8, b * 8, a * 8);
 }
 
-OpenGLFormat getOpenGLFormatOf(const PixelFormat &format) {
-	if (areComponentsInOrder(format, 0, 1, 2, 3))
-		return { GL_RGBA, GL_UNSIGNED_BYTE };
-	else if (areComponentsInOrder(format, 3, 2, 1, 0))
-		return { GL_RGBA, GL_UNSIGNED_INT_8_8_8_8 };
-	else if (areComponentsInOrder(format, 0, 1, 2, -1))
-		return { GL_RGB, GL_UNSIGNED_BYTE };
-	else if (areComponentsInOrder(format, 2, 1, 0, 3))
-		return { GL_BGRA, GL_UNSIGNED_BYTE };
-	else if (areComponentsInOrder(format, 2, 1, 0, -1))
-		return { GL_BGR, GL_UNSIGNED_BYTE };
-	// we could look for packed formats here as well in the future
-	else
-		return { GL_NONE, GL_NONE };
+static bool isCompatibleFormat(const PixelFormat &format) {
+	return areComponentsInOrder(format, 0, 1, 2, 3) ||
+		areComponentsInOrder(format, 3, 2, 1, 0);
 }
 
 OpenGLTexture::OpenGLTexture(int32 w, int32 h, bool withMipmaps)
 	: ITexture({ (int16)w, (int16)h })
 	, _withMipmaps(withMipmaps) {
-	GL_CALL(glEnable(GL_TEXTURE_2D));
+	glEnable(GL_TEXTURE_2D); // will error on GLES2, but that is okay
+	OpenGL::clearGLError(); // we will just ignore it
 	GL_CALL(glGenTextures(1, &_handle));
 	GL_CALL(glBindTexture(GL_TEXTURE_2D, _handle));
 	GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR));
@@ -71,17 +61,43 @@ OpenGLTexture::~OpenGLTexture() {
 }
 
 void OpenGLTexture::update(const Surface &surface) {
-	OpenGLFormat format = getOpenGLFormatOf(surface.format);
+	assert(isCompatibleFormat(surface.format));
 	assert(surface.w == size().x && surface.h == size().y);
-	assert(format.isValid());
 
-	GL_CALL(glEnable(GL_TEXTURE_2D));
+	// GLES2 only supports GL_RGBA but we need BlendBlit::getSupportedPixelFormat to use blendBlit
+	// We also do not want to keep surface memory for textures that are not updated repeatedly
+	const void *pixels;
+	if (!areComponentsInOrder(surface.format, 0, 1, 2, 3)) {
+		if (_tmpSurface.empty())
+			_tmpSurface.create(surface.w, surface.h, PixelFormat::createFormatRGBA32());
+		crossBlit(
+			(byte *)_tmpSurface.getPixels(),
+			(const byte *)surface.getPixels(),
+			_tmpSurface.pitch,
+			surface.pitch,
+			surface.w,
+			surface.h,
+			_tmpSurface.format,
+			surface.format);
+		pixels = _tmpSurface.getPixels();
+	} else {
+		glEnable(GL_TEXTURE_2D);
+		OpenGL::clearGLError();
+		pixels = surface.getPixels();
+	}
+
 	GL_CALL(glBindTexture(GL_TEXTURE_2D, _handle));
-	GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, surface.w, surface.h, 0, format._format, format._type, surface.getPixels()));
+	GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, surface.w, surface.h, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels));
 	if (_withMipmaps)
 		GL_CALL(glGenerateMipmap(GL_TEXTURE_2D));
 	else
 		GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));
+
+	if (!_tmpSurface.empty()) {
+		if (!_didConvertOnce)
+			_tmpSurface.free();
+		_didConvertOnce = true;
+	}
 }
 
 void OpenGLTexture::setMirrorWrap(bool wrap) {
@@ -94,12 +110,13 @@ void OpenGLTexture::setMirrorWrap(bool wrap) {
 	else
 		wrapMode = OpenGLContext.textureEdgeClampSupported ? GL_CLAMP_TO_EDGE : GL_CLAMP;
 
+	GL_CALL(glBindTexture(GL_TEXTURE_2D, _handle));
 	GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrapMode));
 	GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrapMode));
 }
 
 OpenGLRenderer::OpenGLRenderer(Point resolution) : _resolution(resolution) {
-	GL_CALL(glDisable(GL_LIGHTING));
+	initGraphics3d(resolution.x, resolution.y);
 	GL_CALL(glDisable(GL_DEPTH_TEST));
 	GL_CALL(glDisable(GL_SCISSOR_TEST));
 	GL_CALL(glDisable(GL_STENCIL_TEST));
@@ -131,16 +148,20 @@ void OpenGLRenderer::end() {
 
 	if (_currentOutput != nullptr) {
 		g_system->presentBuffer();
-		auto format = getOpenGLFormatOf(_currentOutput->format);
 		GL_CALL(glReadPixels(
 			0,
 			0,
 			_outputSize.x,
 			_outputSize.y,
-			format._format,
-			format._type,
+			GL_RGBA,
+			GL_UNSIGNED_BYTE,
 			_currentOutput->getPixels()
 		));
+		if (_currentOutput->format != PixelFormat::createFormatRGBA32()) {
+			auto targetFormat = _currentOutput->format;
+			_currentOutput->format = PixelFormat::createFormatRGBA32();
+			_currentOutput->convertToInPlace(targetFormat);
+		}
 	}
 }
 
@@ -178,8 +199,7 @@ void OpenGLRenderer::setOutput(Surface &output) {
 		debugC(0, kDebugGraphics, "Output is larger than screen, output will be cropped (%d, %d) > (%d, %d)",
 			output.w, output.h, g_system->getWidth(), g_system->getHeight());
 
-	auto format = getOpenGLFormatOf(output.format);
-	if (format._format == GL_NONE) {
+	if (!isCompatibleFormat(output.format)) {
 		auto formatString = output.format.toString();
 		debugC(0, kDebugGraphics, "Cannot use pixelformat of given output surface: %s", formatString.c_str());
 		_currentOutput = nullptr;
@@ -226,5 +246,65 @@ void OpenGLRenderer::checkFirstDrawCommand() {
 	GL_CALL(glClearColor(0.0f, 0.0f, 0.0f, 1.0f));
 	GL_CALL(glClear(GL_COLOR_BUFFER_BIT));
 }
+
+void OpenGLRenderer::getQuadPositions(Vector2d topLeft, Vector2d size, Angle rotation, Vector2d positions[]) const {
+	positions[0] = topLeft + Vector2d(0, 0);
+	positions[1] = topLeft + Vector2d(0, +size.getY());
+	positions[2] = topLeft + Vector2d(+size.getX(), +size.getY());
+	positions[3] = topLeft + Vector2d(+size.getX(), 0);
+	if (abs(rotation.getDegrees()) > epsilon) {
+		const Vector2d zero(0, 0);
+		for (int i = 0; i < 4; i++)
+			positions[i].rotateAround(zero, rotation);
+	}
+}
+
+void OpenGLRenderer::getQuadTexCoords(Vector2d texMin, Vector2d texMax, Vector2d texCoords[]) const {
+	texCoords[0] = { texMin.getX(), texMin.getY() };
+	texCoords[1] = { texMin.getX(), texMax.getY() };
+	texCoords[2] = { texMax.getX(), texMax.getY() };
+	texCoords[3] = { texMax.getX(), texMin.getY() };
+}
+
+IRenderer *IRenderer::createOpenGLRenderer(Point resolution) {
+	const auto available = Renderer::getAvailableTypes() & ~kRendererTypeTinyGL;
+	const auto &rendererCode = ConfMan.get("renderer");
+	RendererType rendererType = Renderer::parseTypeCode(rendererCode);
+	rendererType = (RendererType)(rendererType & available);
+
+	IRenderer *renderer = nullptr;
+	switch (rendererType) {
+	case kRendererTypeOpenGLShaders:
+		renderer = createOpenGLRendererShaders(resolution);
+		break;
+	case kRendererTypeOpenGL:
+		renderer = createOpenGLRendererClassic(resolution);
+		break;
+	default:
+		if (available & kRendererTypeOpenGLShaders)
+			renderer = createOpenGLRendererShaders(resolution);
+		else if (available & kRendererTypeOpenGL)
+			renderer = createOpenGLRendererClassic(resolution);
+		break;
+	}
+
+	if (renderer == nullptr)
+		error("Could not create a renderer, GL context type: %d", (int)OpenGLContext.type);
+	return renderer;
+}
+
+#ifndef USE_OPENGL_SHADERS
+IRenderer *createOpenGLRendererShaders(Point _) {
+	(void)_;
+	return nullptr;
+}
+#endif
+
+#ifndef USE_OPENGL_GAME
+IRenderer *createOpenGLRendererClassic(Point _) {
+	(void)_;
+	return nullptr;
+}
+#endif
 
 }

--- a/engines/alcachofa/graphics-opengl.h
+++ b/engines/alcachofa/graphics-opengl.h
@@ -30,13 +30,6 @@
 
 namespace Alcachofa {
 
-struct OpenGLFormat {
-	GLenum _format, _type;
-	inline bool isValid() const { return _format != GL_NONE; }
-};
-
-OpenGLFormat getOpenGLFormatOf(const Graphics::PixelFormat &format);
-
 class OpenGLTexture : public ITexture {
 public:
 	OpenGLTexture(int32 w, int32 h, bool withMipmaps);
@@ -50,6 +43,8 @@ private:
 	GLuint _handle;
 	bool _withMipmaps;
 	bool _mirrorWrap = true;
+	bool _didConvertOnce = false;
+	Graphics::ManagedSurface _tmpSurface;
 };
 
 class OpenGLRenderer : public virtual IRenderer {
@@ -68,6 +63,8 @@ protected:
 	void setViewportToRect(int16 outputWidth, int16 outputHeight);
 	virtual void setMatrices(bool flipped) = 0;
 	void checkFirstDrawCommand();
+	void getQuadPositions(Math::Vector2d topLeft, Math::Vector2d size, Math::Angle rotation, Math::Vector2d positions[]) const;
+	void getQuadTexCoords(Math::Vector2d texMin, Math::Vector2d texMax, Math::Vector2d texCoords[]) const;
 
 	Common::Point _resolution, _outputSize;
 	Graphics::Surface *_currentOutput = nullptr;
@@ -76,6 +73,9 @@ protected:
 	float _currentLodBias = 0.0f;
 	bool _isFirstDrawCommand = false;
 };
+
+IRenderer *createOpenGLRendererClassic(Common::Point resolution);
+IRenderer *createOpenGLRendererShaders(Common::Point resolution);
 
 }
 

--- a/engines/alcachofa/graphics-opengl.h
+++ b/engines/alcachofa/graphics-opengl.h
@@ -1,0 +1,82 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef ALCACHOFA_GRAPHICS_OPENGL_H
+#define ALCACHOFA_GRAPHICS_OPENGL_H
+
+#include "alcachofa/graphics.h"
+
+#include "graphics/managed_surface.h"
+#include "graphics/opengl/system_headers.h"
+#include "graphics/opengl/debug.h"
+
+namespace Alcachofa {
+
+struct OpenGLFormat {
+	GLenum _format, _type;
+	inline bool isValid() const { return _format != GL_NONE; }
+};
+
+OpenGLFormat getOpenGLFormatOf(const Graphics::PixelFormat &format);
+
+class OpenGLTexture : public ITexture {
+public:
+	OpenGLTexture(int32 w, int32 h, bool withMipmaps);
+	~OpenGLTexture() override;
+	void update(const Graphics::Surface &surface) override;
+	void setMirrorWrap(bool wrap);
+
+	inline GLuint handle() const { return _handle; }
+
+private:
+	GLuint _handle;
+	bool _withMipmaps;
+	bool _mirrorWrap = true;
+};
+
+class OpenGLRenderer : public virtual IRenderer {
+public:
+	OpenGLRenderer(Common::Point resolution);
+
+	Common::ScopedPtr<ITexture> createTexture(int32 w, int32 h, bool withMipmaps) override;
+	void end() override;
+	void setOutput(Graphics::Surface &output) override;
+	bool hasOutput() const override;
+
+protected:
+	void resetState();
+	void setBlendFunc(BlendMode blendMode); ///< just the blend-func, not texenv/shader uniform
+	void setViewportToScreen();
+	void setViewportToRect(int16 outputWidth, int16 outputHeight);
+	virtual void setMatrices(bool flipped) = 0;
+	void checkFirstDrawCommand();
+
+	Common::Point _resolution, _outputSize;
+	Graphics::Surface *_currentOutput = nullptr;
+	OpenGLTexture *_currentTexture = nullptr;
+	BlendMode _currentBlendMode = (BlendMode)-1;
+	float _currentLodBias = 0.0f;
+	bool _isFirstDrawCommand = false;
+};
+
+}
+
+#endif // ALCACHOFA_GRAPHICS_OPENGL_H

--- a/engines/alcachofa/graphics.cpp
+++ b/engines/alcachofa/graphics.cpp
@@ -212,7 +212,7 @@ void AnimationBase::fullBlend(const ManagedSurface &source, ManagedSurface &dest
 	assert(offsetX >= 0 && offsetX + source.w <= destination.w);
 	assert(offsetY >= 0 && offsetY + source.h <= destination.h);
 
-	const byte *sourceLine = (byte *)source.getPixels();
+	const byte *sourceLine = (const byte *)source.getPixels();
 	byte *destinationLine = (byte *)destination.getPixels() + offsetY * destination.pitch + offsetX * 4;
 	for (int y = 0; y < source.h; y++) {
 		const byte *sourcePixel = sourceLine;
@@ -624,6 +624,7 @@ AnimationDrawRequest::AnimationDrawRequest(Animation *animation, int32 frameI, V
 }
 
 void AnimationDrawRequest::draw() {
+	g_engine->renderer().setLodBias(_lodBias);
 	if (_is3D)
 		_animation->draw3D(_frameI, _topLeft, _scale * kInvBaseScale, _blendMode, _color);
 	else

--- a/engines/alcachofa/graphics.cpp
+++ b/engines/alcachofa/graphics.cpp
@@ -845,6 +845,7 @@ DrawQueue::DrawQueue(IRenderer *renderer)
 }
 
 void DrawQueue::clear() {
+	_allocator.deallocateAll();
 	memset(_requestsPerOrderCount, 0, sizeof(_requestsPerOrderCount));
 	memset(_lodBiasPerOrder, 0, sizeof(_lodBiasPerOrder));
 }

--- a/engines/alcachofa/graphics.cpp
+++ b/engines/alcachofa/graphics.cpp
@@ -507,7 +507,7 @@ void Graphic::update() {
 	const uint32 totalDuration = _animation->totalDuration();
 	uint32 curTime = _isPaused
 		? _lastTime
-		: g_system->getMillis() - _lastTime;
+		: g_engine->getMillis() - _lastTime;
 	if (curTime > totalDuration) {
 		if (_isLooping && totalDuration > 0)
 			curTime %= totalDuration;
@@ -524,18 +524,18 @@ void Graphic::update() {
 void Graphic::start(bool isLooping) {
 	_isPaused = false;
 	_isLooping = isLooping;
-	_lastTime = g_system->getMillis();
+	_lastTime = g_engine->getMillis();
 }
 
 void Graphic::pause() {
 	_isPaused = true;
 	_isLooping = false;
-	_lastTime = g_system->getMillis() - _lastTime;
+	_lastTime = g_engine->getMillis() - _lastTime;
 }
 
 void Graphic::reset() {
 	_frameI = 0;
-	_lastTime = _isPaused ? 0 : g_system->getMillis();
+	_lastTime = _isPaused ? 0 : g_engine->getMillis();
 }
 
 void Graphic::setAnimation(const Common::String &fileName, AnimationFolder folder) {
@@ -782,9 +782,9 @@ struct FadeTask : public Task {
 		TASK_BEGIN;
 		if (_permanentFadeAction == PermanentFadeAction::UnsetFaded)
 			g_engine->globalUI().isPermanentFaded() = false;
-		_startTime = g_system->getMillis();
-		while (g_system->getMillis() - _startTime < _duration) {
-			draw((g_system->getMillis() - _startTime) / (float)_duration);
+		_startTime = g_engine->getMillis();
+		while (g_engine->getMillis() - _startTime < _duration) {
+			draw((g_engine->getMillis() - _startTime) / (float)_duration);
 			TASK_YIELD;
 		}
 		draw(1.0f); // so that during a loading lag the screen is completly black/white
@@ -794,8 +794,8 @@ struct FadeTask : public Task {
 	}
 
 	virtual void debugPrint() override {
-		uint32 remaining = g_system->getMillis() - _startTime <= _duration
-			? _duration - (g_system->getMillis() - _startTime)
+		uint32 remaining = g_engine->getMillis() - _startTime <= _duration
+			? _duration - (g_engine->getMillis() - _startTime)
 			: 0;
 		g_engine->console().debugPrintf("Fade (%d) from %.2f to %.2f with %ums remaining\n", (int)_fadeType, _from, _to, remaining);
 	}

--- a/engines/alcachofa/graphics.cpp
+++ b/engines/alcachofa/graphics.cpp
@@ -783,7 +783,7 @@ struct FadeTask : public Task {
 		syncGame(s);
 	}
 
-	virtual TaskReturn run() override {
+	TaskReturn run() override {
 		TASK_BEGIN;
 		if (_permanentFadeAction == PermanentFadeAction::UnsetFaded)
 			g_engine->globalUI().isPermanentFaded() = false;
@@ -798,7 +798,7 @@ struct FadeTask : public Task {
 		TASK_END;
 	}
 
-	virtual void debugPrint() override {
+	void debugPrint() override {
 		uint32 remaining = g_engine->getMillis() - _startTime <= _duration
 			? _duration - (g_engine->getMillis() - _startTime)
 			: 0;

--- a/engines/alcachofa/graphics.cpp
+++ b/engines/alcachofa/graphics.cpp
@@ -117,7 +117,7 @@ void AnimationBase::load() {
 		_spriteBases.push_back(stream->readUint32LE());
 		assert(_spriteBases.back() < imageCount);
 	}
-#ifdef _DEBUG
+#ifdef ALCACHOFA_DEBUG
 	for (uint i = spriteCount; i < kMaxSpriteIDs; i++)
 		assert(stream->readSint32LE() == 0);
 #else

--- a/engines/alcachofa/graphics.cpp
+++ b/engines/alcachofa/graphics.cpp
@@ -57,8 +57,7 @@ void IDebugRenderer::debugShape(const Shape &shape, Color color) {
 
 AnimationBase::AnimationBase(String fileName, AnimationFolder folder)
 	: _fileName(move(fileName))
-	, _folder(folder) {
-}
+	, _folder(folder) {}
 
 AnimationBase::~AnimationBase() {
 	freeImages();
@@ -70,10 +69,18 @@ void AnimationBase::load() {
 
 	String fullPath;
 	switch (_folder) {
-	case AnimationFolder::Animations: fullPath = "Animaciones/"; break;
-	case AnimationFolder::Masks: fullPath = "Mascaras/"; break;
-	case AnimationFolder::Backgrounds: fullPath = "Fondos/"; break;
-	default: assert(false && "Invalid AnimationFolder");
+	case AnimationFolder::Animations:
+		fullPath = "Animaciones/";
+		break;
+	case AnimationFolder::Masks:
+		fullPath = "Mascaras/";
+		break;
+	case AnimationFolder::Backgrounds:
+		fullPath = "Fondos/";
+		break;
+	default:
+		assert(false && "Invalid AnimationFolder");
+		break;
 	}
 	if (_fileName.size() < 4 || scumm_strnicmp(_fileName.end() - 4, ".AN0", 4) != 0)
 		_fileName += ".AN0";
@@ -236,8 +243,7 @@ Point AnimationBase::imageSize(int32 imageI) const {
 }
 
 Animation::Animation(String fileName, AnimationFolder folder)
-	: AnimationBase(fileName, folder) {
-}
+	: AnimationBase(fileName, folder) {}
 
 void Animation::load() {
 	if (_isLoaded)
@@ -492,8 +498,7 @@ void Font::drawCharacter(int32 imageI, Point centerPoint, Color color) {
 	renderer.quad(center, size, color, Angle(), _texMins[imageI], _texMaxs[imageI]);
 }
 
-Graphic::Graphic() {
-}
+Graphic::Graphic() {}
 
 Graphic::Graphic(ReadStream &stream) {
 	_topLeft.x = stream.readSint16LE();
@@ -515,8 +520,7 @@ Graphic::Graphic(const Graphic &other)
 	, _isLooping(other._isLooping)
 	, _lastTime(other._lastTime)
 	, _frameI(other._frameI)
-	, _depthScale(other._depthScale) {
-}
+	, _depthScale(other._depthScale) {}
 
 void Graphic::loadResources() {
 	if (_animation != nullptr)
@@ -593,8 +597,7 @@ static int8 shiftAndClampOrder(int8 order) {
 }
 
 IDrawRequest::IDrawRequest(int8 order)
-	: _order(shiftAndClampOrder(order)) {
-}
+	: _order(shiftAndClampOrder(order)) {}
 
 AnimationDrawRequest::AnimationDrawRequest(Graphic &graphic, bool is3D, BlendMode blendMode, float lodBias)
 	: IDrawRequest(graphic._order)
@@ -678,7 +681,7 @@ TextDrawRequest::TextDrawRequest(Font &font, const char *originalText, Point pos
 	// allocate on drawQueue to prevent having destruct it
 	assert(originalText != nullptr);
 	auto textLen = strlen(originalText);
-	char *text = (char*)g_engine->drawQueue().allocator().allocateRaw(textLen + 1, 1);
+	char *text = (char *)g_engine->drawQueue().allocator().allocateRaw(textLen + 1, 1);
 	memcpy(text, originalText, textLen + 1);
 
 	// split into trimmed lines
@@ -705,8 +708,7 @@ TextDrawRequest::TextDrawRequest(Font &font, const char *originalText, Point pos
 			itChar = trimTrailing(itChar, itLine, true) + 1;
 			itLine = trimLeading(itLine, itChar);
 			_allLines[lineCount] = TextLine(itLine, itChar - itLine);
-		}
-		else
+		} else
 			_allLines[lineCount] = TextLine(itLine, itChar - itLine);
 		itChar = trimLeading(itChar, textEnd);
 		lineCount++;
@@ -739,8 +741,7 @@ TextDrawRequest::TextDrawRequest(Font &font, const char *originalText, Point pos
 			pos.x = screenW - _width / 2 - 1;
 		for (auto &linePosX : _posX)
 			linePosX = pos.x - linePosX / 2;
-	}
-	else
+	} else
 		fill(_posX.begin(), _posX.end(), pos.x);
 
 	// setup height and y position
@@ -772,8 +773,7 @@ void TextDrawRequest::draw() {
 FadeDrawRequest::FadeDrawRequest(FadeType type, float value, int8 order)
 	: IDrawRequest(order)
 	, _type(type)
-	, _value(value) {
-}
+	, _value(value) {}
 
 void FadeDrawRequest::draw() {
 	Color color;
@@ -808,8 +808,7 @@ struct FadeTask : public Task {
 		, _duration(duration)
 		, _easingType(easingType)
 		, _order(order)
-		, _permanentFadeAction(permanentFadeAction) {
-	}
+		, _permanentFadeAction(permanentFadeAction) {}
 
 	FadeTask(Process &process, Serializer &s)
 		: Task(process) {
@@ -881,8 +880,7 @@ Task *fade(Process &process, FadeType fadeType,
 BorderDrawRequest::BorderDrawRequest(Rect rect, Color color)
 	: IDrawRequest(-kForegroundOrderCount)
 	, _rect(rect)
-	, _color(color) {
-}
+	, _color(color) {}
 
 void BorderDrawRequest::draw() {
 	auto &renderer = g_engine->renderer();

--- a/engines/alcachofa/graphics.cpp
+++ b/engines/alcachofa/graphics.cpp
@@ -547,7 +547,7 @@ void Graphic::setAnimation(Animation *animation) {
 	_animation = animation;
 }
 
-void Graphic::serializeSave(Serializer &serializer) {
+void Graphic::syncGame(Serializer &serializer) {
 	syncPoint(serializer, _topLeft);
 	serializer.syncAsSint16LE(_scale);
 	serializer.syncAsUint32LE(_lastTime);

--- a/engines/alcachofa/graphics.cpp
+++ b/engines/alcachofa/graphics.cpp
@@ -824,12 +824,12 @@ private:
 		g_engine->drawQueue().add<FadeDrawRequest>(_fadeType, _from + (_to - _from) * ease(t, _easingType), _order);
 	}
 
-	FadeType _fadeType;
-	float _from, _to;
-	uint32 _startTime = 0, _duration;
-	EasingType _easingType;
-	int8 _order;
-	PermanentFadeAction _permanentFadeAction;
+	FadeType _fadeType = {};
+	float _from = 0, _to = 0;
+	uint32 _startTime = 0, _duration = 0;
+	EasingType _easingType = {};
+	int8 _order = 0;
+	PermanentFadeAction _permanentFadeAction = {};
 };
 DECLARE_TASK(FadeTask);
 

--- a/engines/alcachofa/graphics.cpp
+++ b/engines/alcachofa/graphics.cpp
@@ -850,7 +850,7 @@ struct FadeTask : public Task {
 		s.syncAsSByte(_order);
 	}
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 private:
 	void draw(float t) {

--- a/engines/alcachofa/graphics.cpp
+++ b/engines/alcachofa/graphics.cpp
@@ -864,7 +864,7 @@ private:
 	int8 _order = 0;
 	PermanentFadeAction _permanentFadeAction = {};
 };
-DECLARE_TASK(FadeTask);
+DECLARE_TASK(FadeTask)
 
 Task *fade(Process &process, FadeType fadeType,
 	float from, float to,

--- a/engines/alcachofa/graphics.cpp
+++ b/engines/alcachofa/graphics.cpp
@@ -19,10 +19,10 @@
  *
  */
 
-#include "graphics.h"
-#include "alcachofa.h"
-#include "shape.h"
-#include "global-ui.h"
+#include "alcachofa/graphics.h"
+#include "alcachofa/alcachofa.h"
+#include "alcachofa/shape.h"
+#include "alcachofa/global-ui.h"
 
 #include "common/system.h"
 #include "common/file.h"

--- a/engines/alcachofa/graphics.h
+++ b/engines/alcachofa/graphics.h
@@ -277,7 +277,7 @@ public:
 	void reset();
 	void setAnimation(const Common::String &fileName, AnimationFolder folder);
 	void setAnimation(Animation *animation); ///< no memory ownership is given, but for prerendering it has to be mutable
-	void serializeSave(Common::Serializer &serializer);
+	void syncGame(Common::Serializer &serializer);
 
 private:
 	friend class AnimationDrawRequest;

--- a/engines/alcachofa/graphics.h
+++ b/engines/alcachofa/graphics.h
@@ -30,8 +30,8 @@
 #include "math/vector2d.h"
 #include "graphics/managed_surface.h"
 
-#include "camera.h"
-#include "common.h"
+#include "alcachofa/camera.h"
+#include "alcachofa/common.h"
 
 namespace Alcachofa {
 

--- a/engines/alcachofa/graphics.h
+++ b/engines/alcachofa/graphics.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef GRAPHICS_H
-#define GRAPHICS_H
+#ifndef ALCACHOFA_GRAPHICS_H
+#define ALCACHOFA_GRAPHICS_H
 
 #include "common/ptr.h"
 #include "common/stream.h"
@@ -476,4 +476,4 @@ private:
 
 }
 
-#endif
+#endif // ALCACHOFA_ENGINE_H

--- a/engines/alcachofa/graphics.h
+++ b/engines/alcachofa/graphics.h
@@ -469,7 +469,7 @@ private:
 	static constexpr const uint kMaxDrawRequestsPerOrder = 50;
 	IRenderer *const _renderer;
 	BumpAllocator _allocator;
-	IDrawRequest *_requestsPerOrder[kOrderCount][kMaxDrawRequestsPerOrder] = { 0 };
+	IDrawRequest *_requestsPerOrder[kOrderCount][kMaxDrawRequestsPerOrder] = { { 0 } };
 	uint8 _requestsPerOrderCount[kOrderCount] = { 0 };
 	float _lodBiasPerOrder[kOrderCount] = { 0 };
 };

--- a/engines/alcachofa/graphics.h
+++ b/engines/alcachofa/graphics.h
@@ -322,7 +322,7 @@ public:
 		int8 order
 	);
 
-	virtual void draw() override;
+	void draw() override;
 
 private:
 	bool _is3D;
@@ -344,7 +344,7 @@ public:
 		Math::Vector2d texOffset,
 		BlendMode blendMode);
 
-	virtual void draw() override;
+	void draw() override;
 
 private:
 	Animation *_animation;
@@ -368,7 +368,7 @@ public:
 		int8 order);
 
 	inline Common::Point size() const { return { (int16)_width, (int16)_height }; }
-	virtual void draw() override;
+	void draw() override;
 
 private:
 	static constexpr uint kMaxLines = 12;
@@ -399,7 +399,7 @@ class FadeDrawRequest : public IDrawRequest {
 public:
 	FadeDrawRequest(FadeType type, float value, int8 order);
 
-	virtual void draw() override;
+	void draw() override;
 
 private:
 	FadeType _type;
@@ -416,7 +416,7 @@ class BorderDrawRequest : public IDrawRequest {
 public:
 	BorderDrawRequest(Common::Rect rect, Color color);
 
-	virtual void draw() override;
+	void draw() override;
 
 private:
 	Common::Rect _rect;

--- a/engines/alcachofa/graphics.h
+++ b/engines/alcachofa/graphics.h
@@ -195,22 +195,26 @@ public:
 	int32 frameAtTime(uint32 time) const;
 	int32 imageIndex(int32 frameI, int32 spriteI) const;
 	using AnimationBase::imageSize;
+	void outputRect2D(int32 frameI, float scale, Math::Vector2d &topLeft, Math::Vector2d &size) const;
+	void outputRect3D(int32 frameI, float scale, Math::Vector3d &topLeft, Math::Vector2d &size) const;
+
+	void overrideTexture(const Graphics::ManagedSurface &surface);
 
 	void draw2D(
 		int32 frameI,
-		Math::Vector2d center,
+		Math::Vector2d topLeft,
 		float scale,
 		BlendMode blendMode,
 		Color color);
 	void draw3D(
 		int32 frameI,
-		Math::Vector3d center,
+		Math::Vector3d topLeft,
 		float scale,
 		BlendMode blendMode,
 		Color color);
 	void drawEffect(
 		int32 frameI,
-		Math::Vector3d center,
+		Math::Vector3d topLeft,
 		Math::Vector2d tiling,
 		Math::Vector2d texOffset,
 		BlendMode blendMode);

--- a/engines/alcachofa/graphics.h
+++ b/engines/alcachofa/graphics.h
@@ -95,7 +95,7 @@ public:
 	static IRenderer *createOpenGLRenderer(Common::Point resolution);
 };
 
-class IDebugRenderer : public IRenderer {
+class IDebugRenderer : public virtual IRenderer {
 public:
 	virtual void debugPolygon(
 		Common::Span<Math::Vector2d> points,

--- a/engines/alcachofa/graphics.h
+++ b/engines/alcachofa/graphics.h
@@ -476,4 +476,4 @@ private:
 
 }
 
-#endif // ALCACHOFA_ENGINE_H
+#endif // ALCACHOFA_GRAPHICS_H

--- a/engines/alcachofa/graphics.h
+++ b/engines/alcachofa/graphics.h
@@ -81,6 +81,8 @@ public:
 	virtual void setTexture(ITexture *texture) = 0;
 	virtual void setBlendMode(BlendMode blendMode) = 0;
 	virtual void setLodBias(float lodBias) = 0;
+	virtual void setOutput(Graphics::Surface &surface) = 0;
+	virtual bool hasOutput() const = 0;
 	virtual void quad(
 		Math::Vector2d topLeft,
 		Math::Vector2d size,

--- a/engines/alcachofa/input.cpp
+++ b/engines/alcachofa/input.cpp
@@ -36,6 +36,7 @@ void Input::nextFrame() {
 	_wasMouseLeftReleased = false;
 	_wasMouseRightReleased = false;
 	_wasMenuKeyPressed = false;
+	_wasInventoryKeyPressed = false;
 	updateMousePos3D(); // camera transformation might have changed
 }
 
@@ -73,6 +74,9 @@ bool Input::handleEvent(const Common::Event &event) {
 		switch ((EventAction)event.customType) {
 		case EventAction::InputMenu:
 			_wasMenuKeyPressed = true;
+			return true;
+		case EventAction::InputInventory:
+			_wasInventoryKeyPressed = true;
 			return true;
 		}
 	}

--- a/engines/alcachofa/input.cpp
+++ b/engines/alcachofa/input.cpp
@@ -78,6 +78,8 @@ bool Input::handleEvent(const Common::Event &event) {
 		case EventAction::InputInventory:
 			_wasInventoryKeyPressed = true;
 			return true;
+		default:
+			return false;
 		}
 	}
 	default:

--- a/engines/alcachofa/input.cpp
+++ b/engines/alcachofa/input.cpp
@@ -70,8 +70,8 @@ bool Input::handleEvent(const Common::Event &event) {
 		updateMousePos3D();
 		return true;
 	case EVENT_CUSTOM_ENGINE_ACTION_START:
-		switch ((InputAction)event.customType) {
-		case InputAction::Menu:
+		switch ((EventAction)event.customType) {
+		case EventAction::InputMenu:
 			_wasMenuKeyPressed = true;
 			return true;
 		}

--- a/engines/alcachofa/input.cpp
+++ b/engines/alcachofa/input.cpp
@@ -19,9 +19,9 @@
  *
  */
 
-#include "input.h"
-#include "alcachofa.h"
-#include "metaengine.h"
+#include "alcachofa/input.h"
+#include "alcachofa/alcachofa.h"
+#include "alcachofa/metaengine.h"
 
 using namespace Common;
 

--- a/engines/alcachofa/input.cpp
+++ b/engines/alcachofa/input.cpp
@@ -41,8 +41,7 @@ void Input::nextFrame() {
 }
 
 bool Input::handleEvent(const Common::Event &event) {
-	if (_debugInput != nullptr)
-	{
+	if (_debugInput != nullptr) {
 		auto result = _debugInput->handleEvent(event);
 		_mousePos2D = _debugInput->mousePos2D(); // even for debug input we want to e.g. draw a cursor
 		_mousePos3D = _debugInput->mousePos3D();

--- a/engines/alcachofa/input.h
+++ b/engines/alcachofa/input.h
@@ -39,6 +39,7 @@ public:
 	inline bool isMouseRightDown() const { return _isMouseRightDown; }
 	inline bool isAnyMouseDown() const { return _isMouseLeftDown || _isMouseRightDown; }
 	inline bool wasMenuKeyPressed() const { return _wasMenuKeyPressed; }
+	inline bool wasInventoryKeyPressed() const { return _wasInventoryKeyPressed; }
 	inline Common::Point mousePos2D() const { return _mousePos2D; }
 	inline Common::Point mousePos3D() const { return _mousePos3D; }
 	const Input &debugInput() const { scumm_assert(_debugInput != nullptr); return *_debugInput; }
@@ -57,7 +58,8 @@ private:
 		_wasMouseRightReleased = false,
 		_isMouseLeftDown = false,
 		_isMouseRightDown = false,
-		_wasMenuKeyPressed = false;
+		_wasMenuKeyPressed = false,
+		_wasInventoryKeyPressed = false;
 	Common::Point
 		_mousePos2D,
 		_mousePos3D;

--- a/engines/alcachofa/input.h
+++ b/engines/alcachofa/input.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef INPUT_H
-#define INPUT_H
+#ifndef ALCACHOFA_INPUT_H
+#define ALCACHOFA_INPUT_H
 
 #include "common/events.h"
 #include "common/ptr.h"
@@ -68,4 +68,4 @@ private:
 
 }
 
-#endif // INPUT_H
+#endif // ALCACHOFA_INPUT_H

--- a/engines/alcachofa/menu.cpp
+++ b/engines/alcachofa/menu.cpp
@@ -36,7 +36,7 @@ void Menu::updateOpeningMenu() {
 	_openAtNextFrame = false;
 
 	g_engine->sounds().pauseAll(true);
-	// TODO: Add game time behaviour on opening menu
+	_timeBeforeMenu = g_engine->getMillis();
 	_previousRoom = g_engine->player().currentRoom();
 	_isOpen = true;
 	// TODO: Render thumbnail
@@ -60,7 +60,7 @@ void Menu::continueGame() {
 	g_engine->sounds().pauseAll(false);
 	g_engine->camera().restore(1);
 	g_engine->scheduler().restoreContext();
-	// TODO: Reset time on continueing game
+	g_engine->setMillis(_timeBeforeMenu);
 }
 
 void Menu::triggerMainMenuAction(MainMenuAction action) {

--- a/engines/alcachofa/menu.cpp
+++ b/engines/alcachofa/menu.cpp
@@ -1,0 +1,72 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "alcachofa.h"
+#include "menu.h"
+#include "player.h"
+#include "script.h"
+
+namespace Alcachofa {
+
+void Menu::updateOpeningMenu() {
+	if (!_openAtNextFrame) {
+		_openAtNextFrame =
+			g_engine->input().wasMenuKeyPressed() &&
+			g_engine->player().isAllowedToOpenMenu();
+		return;
+	}
+	_openAtNextFrame = false;
+
+	g_engine->sounds().pauseAll(true);
+	// TODO: Add game time behaviour on opening menu
+	_previousRoom = g_engine->player().currentRoom();
+	_isOpen = true;
+	// TODO: Render thumbnail
+	g_engine->player().changeRoom("MENUPRINCIPAL", true);
+	// TODO: Check original read lastSaveFileFileId and read options.cfg, we do not need that right?
+
+	g_engine->player().heldItem() = nullptr;
+	g_engine->scheduler().backupContext();
+	g_engine->camera().backup(1);
+	g_engine->camera().setPosition(Math::Vector3d(
+		g_system->getWidth() / 2.0f, g_system->getHeight() / 2.0f, 0.0f));
+
+	// TODO: Load thumbnail into capture graphic object
+}
+
+void Menu::continueGame() {
+	assert(_previousRoom != nullptr);
+	_isOpen = false;
+	g_engine->input().nextFrame(); // presumably to clear all was* flags
+	g_engine->player().changeRoom(_previousRoom->name(), true);
+	g_engine->sounds().pauseAll(false);
+	g_engine->camera().restore(1);
+	g_engine->scheduler().restoreContext();
+	// TODO: Reset time on continueing game
+}
+
+void Menu::newGame() {
+	// this action might be unused just like the only room it would appear: MENUPRINCIPALINICIO
+	g_engine->player().isGameLoaded() = true;
+	g_engine->script().createProcess(MainCharacterKind::None, g_engine->world().initScriptName());
+}
+
+}

--- a/engines/alcachofa/menu.cpp
+++ b/engines/alcachofa/menu.cpp
@@ -32,7 +32,7 @@ using namespace Common;
 using namespace Graphics;
 
 namespace Alcachofa {
-	
+
 static void createThumbnail(ManagedSurface &surface) {
 	surface.create(kBigThumbnailWidth, kBigThumbnailHeight, PixelFormat::createFormatRGBA32());
 }
@@ -121,15 +121,13 @@ void Menu::updateSelectedSavefile(bool hasJustSaved) {
 	if (hasJustSaved) {
 		// we just saved in-game so we also still have the correct thumbnail in memory
 		_selectedThumbnail.copyFrom(_bigThumbnail);
-	}
-	else if (isOldSavefile) {
+	} else if (isOldSavefile) {
 		if (!tryReadOldSavefile()) {
 			_selectedSavefileDescription = String::format("Savestate %d",
 				parseSavestateSlot(_savefiles[_selectedSavefileI]));
 			createThumbnail(_selectedThumbnail);
 		}
-	}
-	else {
+	} else {
 		// the unsaved gamestate is shown as grayscale
 		_selectedThumbnail.copyFrom(_bigThumbnail);
 		convertToGrayscale(_selectedThumbnail);
@@ -240,8 +238,7 @@ void Menu::triggerSave() {
 	String fileName;
 	if (_selectedSavefileI < _savefiles.size()) {
 		fileName = _savefiles[_selectedSavefileI]; // overwrite a previous save
-	}
-	else {
+	} else {
 		// for a new savefile we figure out the next slot index
 		int nextSlot = _savefiles.empty()
 			? 1 // start at one to keep autosave alone
@@ -260,8 +257,7 @@ void Menu::triggerSave() {
 		g_engine->getMetaEngine()->appendExtendedSave(savefile.get(), g_engine->getTotalPlayTime(), _selectedSavefileDescription, false);
 		_savefiles.push_back(fileName);
 		updateSelectedSavefile(true);
-	}
-	else {
+	} else {
 		GUI::MessageDialog dialog(error.getTranslatedDesc());
 		dialog.runModal();
 	}

--- a/engines/alcachofa/menu.cpp
+++ b/engines/alcachofa/menu.cpp
@@ -26,6 +26,8 @@
 
 namespace Alcachofa {
 
+Menu::Menu() : _interactionSemaphore("menu") {}
+
 void Menu::resetAfterLoad() {
 	_isOpen = false;
 	_openAtNextFrame = false;

--- a/engines/alcachofa/menu.cpp
+++ b/engines/alcachofa/menu.cpp
@@ -19,6 +19,8 @@
  *
  */
 
+#include "gui/message.h"
+
 #include "alcachofa.h"
 #include "metaengine.h"
 #include "menu.h"
@@ -107,9 +109,10 @@ void Menu::triggerMainMenuAction(MainMenuAction action) {
 		ev.customType = (CustomEventType)EventAction::LoadFromMenu;
 		g_system->getEventManager()->pushEvent(ev);
 	}break;
-	case MainMenuAction::InternetMenu:
-		g_system->messageBox(LogMessageType::kWarning, "Multiplayer is not implemented in this ScummVM version.");
-		break;
+	case MainMenuAction::InternetMenu: {
+		GUI::MessageDialog dialog("Multiplayer is not implemented in this ScummVM version.");
+		dialog.runModal();
+	}break;
 	case MainMenuAction::OptionsMenu:
 		g_engine->menu().openOptionsMenu();
 		break;

--- a/engines/alcachofa/menu.cpp
+++ b/engines/alcachofa/menu.cpp
@@ -50,7 +50,7 @@ static void convertToGrayscale(ManagedSurface &surface) {
 		pixel = (uint32 *)surface.getBasePtr(0, y);
 		for (int x = 0; x < surface.w; x++, pixel++) {
 			*pixel &= rgbMask;
-			byte gray = (components[0] + components[1] + components[2] + components[3]) / 3;
+			byte gray = (byte)CLIP(0.29f * components[0] + 0.58f * components[1] + 0.11f * components[2], 0.0f, 255.0f);
 			*pixel =
 				(uint32(gray) << surface.format.rShift) |
 				(uint32(gray) << surface.format.gShift) |

--- a/engines/alcachofa/menu.cpp
+++ b/engines/alcachofa/menu.cpp
@@ -22,11 +22,11 @@
 #include "gui/message.h"
 #include "graphics/thumbnail.h"
 
-#include "alcachofa.h"
-#include "metaengine.h"
-#include "menu.h"
-#include "player.h"
-#include "script.h"
+#include "alcachofa/alcachofa.h"
+#include "alcachofa/metaengine.h"
+#include "alcachofa/menu.h"
+#include "alcachofa/player.h"
+#include "alcachofa/script.h"
 
 using namespace Common;
 using namespace Graphics;

--- a/engines/alcachofa/menu.cpp
+++ b/engines/alcachofa/menu.cpp
@@ -127,7 +127,7 @@ void Menu::updateSelectedSavefile() {
 	}
 	else {
 		_selectedThumbnail.copyFrom(_bigThumbnail);
-		//convertToGrayscale(_selectedThumbnail);
+		convertToGrayscale(_selectedThumbnail);
 	}
 
 	ObjectBase *captureObject = g_engine->player().currentRoom()->getObjectByName("Capture");

--- a/engines/alcachofa/menu.cpp
+++ b/engines/alcachofa/menu.cpp
@@ -112,7 +112,16 @@ void Menu::setOptionsState() {
 	Room *optionsMenu = g_engine->world().getRoomByName("MENUOPCIONES");
 	scumm_assert(optionsMenu != nullptr);
 
-	// TODO: Set music/sound volume
+	auto getSlideButton = [&] (const char *name) {
+		SlideButton *slideButton = dynamic_cast<SlideButton *>(optionsMenu->getObjectByName(name));
+		scumm_assert(slideButton != nullptr);
+		return slideButton;
+	};
+	SlideButton
+		*slideMusicVolume = getSlideButton("Slider Musica"),
+		*slideSpeechVolume = getSlideButton("Slider Sonido");
+	slideMusicVolume->value() = config.musicVolume() / 255.0f;
+	slideSpeechVolume->value() = config.speechVolume() / 255.0f;
 
 	if (!config.bits32())
 		config.highQuality() = false;
@@ -163,7 +172,24 @@ void Menu::triggerOptionsAction(OptionsMenuAction action) {
 		continueMainMenu();
 		break;
 	default:
-		warning("Unknown check box action: %d", (int32)action);
+		warning("Unknown options menu action: %d", (int32)action);
+		break;
+	}
+	setOptionsState();
+}
+
+void Menu::triggerOptionsValue(OptionsMenuValue valueId, float value) {
+	Config &config = g_engine->config();
+	switch (valueId) {
+	case OptionsMenuValue::Music:
+		config.musicVolume() = CLIP<uint8>((uint8)(value * 255), 0, 255);
+		break;
+	case OptionsMenuValue::Speech:
+		config.speechVolume() = CLIP<uint8>((uint8)(value * 255), 0, 255);
+		break;
+	default:
+		warning("Unknown options menu value: %d", (int32)valueId);
+		break;
 	}
 	setOptionsState();
 }

--- a/engines/alcachofa/menu.cpp
+++ b/engines/alcachofa/menu.cpp
@@ -69,4 +69,39 @@ void Menu::newGame() {
 	g_engine->script().createProcess(MainCharacterKind::None, g_engine->world().initScriptName());
 }
 
+void Menu::openOptionsMenu() {
+	setOptionsState();
+	g_engine->player().changeRoom("MENUOPCIONES", true);
+}
+
+void Menu::setOptionsState() {
+	Config &config = g_engine->config();
+	Room *optionsMenu = g_engine->world().getRoomByName("MENUOPCIONES");
+	scumm_assert(optionsMenu != nullptr);
+
+	// TODO: Set music/sound volume
+
+	if (!config.bits32())
+		config.highQuality() = false;
+	auto getCheckBox = [&] (const char *name) {
+		CheckBox *checkBox = dynamic_cast<CheckBox *>(optionsMenu->getObjectByName(name));
+		scumm_assert(checkBox != nullptr);
+		return checkBox;
+	};
+	CheckBox
+		*checkSubtitlesOn = getCheckBox("Boton ON"),
+		*checkSubtitlesOff = getCheckBox("Boton OFF"),
+		*check32Bits = getCheckBox("Boton 32 Bits"),
+		*check16Bits = getCheckBox("Boton 16 Bits"),
+		*checkHighQuality = getCheckBox("Boton Alta"),
+		*checkLowQuality = getCheckBox("Boton Baja");
+	checkSubtitlesOn->isChecked() = config.subtitles();
+	checkSubtitlesOff->isChecked() = !config.subtitles();
+	check32Bits->isChecked() = config.bits32();
+	check16Bits->isChecked() = !config.bits32();
+	checkHighQuality->isChecked() = config.highQuality();
+	checkLowQuality->isChecked() = !config.highQuality();
+	checkHighQuality->toggle(config.bits32());
+}
+
 }

--- a/engines/alcachofa/menu.cpp
+++ b/engines/alcachofa/menu.cpp
@@ -26,6 +26,12 @@
 
 namespace Alcachofa {
 
+void Menu::resetAfterLoad() {
+	_isOpen = false;
+	_openAtNextFrame = false;
+	_previousRoom = nullptr;
+}
+
 void Menu::updateOpeningMenu() {
 	if (!_openAtNextFrame) {
 		_openAtNextFrame =
@@ -36,7 +42,7 @@ void Menu::updateOpeningMenu() {
 	_openAtNextFrame = false;
 
 	g_engine->sounds().pauseAll(true);
-	_timeBeforeMenu = g_engine->getMillis();
+	_millisBeforeMenu = g_engine->getMillis();
 	_previousRoom = g_engine->player().currentRoom();
 	_isOpen = true;
 	// TODO: Render thumbnail
@@ -60,7 +66,7 @@ void Menu::continueGame() {
 	g_engine->sounds().pauseAll(false);
 	g_engine->camera().restore(1);
 	g_engine->scheduler().restoreContext();
-	g_engine->setMillis(_timeBeforeMenu);
+	g_engine->setMillis(_millisBeforeMenu);
 }
 
 void Menu::triggerMainMenuAction(MainMenuAction action) {

--- a/engines/alcachofa/menu.cpp
+++ b/engines/alcachofa/menu.cpp
@@ -63,10 +63,43 @@ void Menu::continueGame() {
 	// TODO: Reset time on continueing game
 }
 
-void Menu::newGame() {
-	// this action might be unused just like the only room it would appear: MENUPRINCIPALINICIO
-	g_engine->player().isGameLoaded() = true;
-	g_engine->script().createProcess(MainCharacterKind::None, g_engine->world().initScriptName());
+void Menu::triggerMainMenuAction(MainMenuAction action) {
+	switch (action) {
+	case MainMenuAction::ContinueGame:
+		g_engine->menu().continueGame();
+		break;
+	case MainMenuAction::Save:
+		warning("STUB: MainMenuAction Save");
+		break;
+	case MainMenuAction::Load:
+		warning("STUB: MainMenuAction Load");
+		break;
+	case MainMenuAction::InternetMenu:
+		g_system->messageBox(LogMessageType::kWarning, "Multiplayer is not implemented in this ScummVM version.");
+		break;
+	case MainMenuAction::OptionsMenu:
+		g_engine->menu().openOptionsMenu();
+		break;
+	case MainMenuAction::Exit:
+	case MainMenuAction::AlsoExit:
+		// implemented in AlcachofaEngine as it has its own event loop
+		g_engine->fadeExit();
+		break;
+	case MainMenuAction::NextSave:
+		warning("STUB: MainMenuAction NextSave");
+		break;
+	case MainMenuAction::PrevSave:
+		warning("STUB: MainMenuAction PrevSave");
+		break;
+	case MainMenuAction::NewGame:
+		// this action might be unused just like the only room it would appear: MENUPRINCIPALINICIO
+		g_engine->player().isGameLoaded() = true;
+		g_engine->script().createProcess(MainCharacterKind::None, g_engine->world().initScriptName());
+		break;
+	default:
+		warning("Unknown main menu action: %d", (int32)action);
+		break;
+	}
 }
 
 void Menu::openOptionsMenu() {
@@ -102,6 +135,47 @@ void Menu::setOptionsState() {
 	checkHighQuality->isChecked() = config.highQuality();
 	checkLowQuality->isChecked() = !config.highQuality();
 	checkHighQuality->toggle(config.bits32());
+}
+
+void Menu::triggerOptionsAction(OptionsMenuAction action) {
+	Config &config = g_engine->config();
+	switch (action) {
+	case OptionsMenuAction::SubtitlesOn:
+		config.subtitles() = true;
+		break;
+	case OptionsMenuAction::SubtitlesOff:
+		config.subtitles() = false;
+		break;
+	case OptionsMenuAction::HighQuality:
+		config.highQuality() = true;
+		break;
+	case OptionsMenuAction::LowQuality:
+		config.highQuality() = false;
+		break;
+	case OptionsMenuAction::Bits32:
+		config.bits32() = true;
+		config.highQuality() = true;
+		break;
+	case OptionsMenuAction::Bits16:
+		config.bits32() = false;
+		break;
+	case OptionsMenuAction::MainMenu:
+		continueMainMenu();
+		break;
+	default:
+		warning("Unknown check box action: %d", (int32)action);
+	}
+	setOptionsState();
+}
+
+void Menu::continueMainMenu() {
+	g_engine->config().saveToScummVM();
+	g_engine->syncSoundSettings();
+	g_engine->player().changeRoom(
+		g_engine->player().isGameLoaded() ? "MENUPRINCIPAL" : "MENUPRINCIPALINICIO",
+		true
+	);
+	// TODO: Update menu state and thumbanil
 }
 
 }

--- a/engines/alcachofa/menu.h
+++ b/engines/alcachofa/menu.h
@@ -28,17 +28,42 @@ namespace Alcachofa {
 
 class Room;
 
+enum class MainMenuAction : int32 {
+	ContinueGame = 0,
+	Save,
+	Load,
+	InternetMenu,
+	OptionsMenu,
+	Exit,
+	NextSave,
+	PrevSave,
+	NewGame,
+	AlsoExit // there seems to be no difference to Exit
+};
+
+enum class OptionsMenuAction : int32 {
+	SubtitlesOn = 0,
+	SubtitlesOff,
+	HighQuality,
+	LowQuality,
+	Bits32,
+	Bits16,
+	MainMenu
+};
+
 class Menu {
 public:
 	inline bool isOpen() const { return _isOpen; }
 
 	void updateOpeningMenu();
-	void continueGame();
-	void newGame();
+	void triggerMainMenuAction(MainMenuAction action);
 
 	void openOptionsMenu();
+	void triggerOptionsAction(OptionsMenuAction action);
 
 private:
+	void continueGame();
+	void continueMainMenu();
 	void setOptionsState();
 
 	bool

--- a/engines/alcachofa/menu.h
+++ b/engines/alcachofa/menu.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef MENU_H
-#define MENU_H
+#ifndef ALCACHOFA_MENU_H
+#define ALCACHOFA_MENU_H
 
 #include "common/scummsys.h"
 #include "common/savefile.h"
@@ -106,4 +106,4 @@ private:
 
 }
 
-#endif // MENU_H
+#endif // ALCACHOFA_MENU_H

--- a/engines/alcachofa/menu.h
+++ b/engines/alcachofa/menu.h
@@ -1,0 +1,49 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MENU_H
+#define MENU_H
+
+#include "common/scummsys.h"
+
+namespace Alcachofa {
+
+class Room;
+
+class Menu {
+public:
+	inline bool isOpen() const { return _isOpen; }
+
+	void updateOpeningMenu();
+	void continueGame();
+	void newGame();
+
+private:
+	bool
+		_isOpen = false,
+		_openAtNextFrame = false;
+
+	Room *_previousRoom = nullptr;
+};
+
+}
+
+#endif // MENU_H

--- a/engines/alcachofa/menu.h
+++ b/engines/alcachofa/menu.h
@@ -23,6 +23,7 @@
 #define MENU_H
 
 #include "common/scummsys.h"
+#include "common/savefile.h"
 
 namespace Alcachofa {
 
@@ -68,12 +69,14 @@ public:
 	void resetAfterLoad();
 	void updateOpeningMenu();
 	void triggerMainMenuAction(MainMenuAction action);
+	void triggerLoad();
 
 	void openOptionsMenu();
 	void triggerOptionsAction(OptionsMenuAction action);
 	void triggerOptionsValue(OptionsMenuValue valueId, float value);
 
 private:
+	void updateSelectedSavefile();
 	void continueGame();
 	void continueMainMenu();
 	void setOptionsState();
@@ -81,9 +84,13 @@ private:
 	bool
 		_isOpen = false,
 		_openAtNextFrame = false;
-	uint32 _millisBeforeMenu = 0;
+	uint32
+		_millisBeforeMenu = 0,
+		_selectedSavefileI = 0;
 	Room *_previousRoom = nullptr;
 	FakeSemaphore _interactionSemaphore; // to prevent ScummVM loading during button clicks
+	Common::Array<Common::String> _savefiles;
+	Common::SaveFileManager *_saveFileMgr;
 };
 
 }

--- a/engines/alcachofa/menu.h
+++ b/engines/alcachofa/menu.h
@@ -59,7 +59,10 @@ enum class OptionsMenuValue : int32 {
 class Menu {
 public:
 	inline bool isOpen() const { return _isOpen; }
+	inline uint32 millisBeforeMenu() const { return _millisBeforeMenu; }
+	inline Room *previousRoom() { return _previousRoom; }
 
+	void resetAfterLoad();
 	void updateOpeningMenu();
 	void triggerMainMenuAction(MainMenuAction action);
 
@@ -75,7 +78,7 @@ private:
 	bool
 		_isOpen = false,
 		_openAtNextFrame = false;
-	uint32 _timeBeforeMenu = 0;
+	uint32 _millisBeforeMenu = 0;
 	Room *_previousRoom = nullptr;
 };
 

--- a/engines/alcachofa/menu.h
+++ b/engines/alcachofa/menu.h
@@ -58,9 +58,12 @@ enum class OptionsMenuValue : int32 {
 
 class Menu {
 public:
+	Menu();
+
 	inline bool isOpen() const { return _isOpen; }
 	inline uint32 millisBeforeMenu() const { return _millisBeforeMenu; }
 	inline Room *previousRoom() { return _previousRoom; }
+	inline FakeSemaphore &interactionSemaphore() { return _interactionSemaphore; }
 
 	void resetAfterLoad();
 	void updateOpeningMenu();
@@ -80,6 +83,7 @@ private:
 		_openAtNextFrame = false;
 	uint32 _millisBeforeMenu = 0;
 	Room *_previousRoom = nullptr;
+	FakeSemaphore _interactionSemaphore; // to prevent ScummVM loading during button clicks
 };
 
 }

--- a/engines/alcachofa/menu.h
+++ b/engines/alcachofa/menu.h
@@ -76,6 +76,7 @@ public:
 	void triggerOptionsValue(OptionsMenuValue valueId, float value);
 
 private:
+	void triggerSave();
 	void updateSelectedSavefile();
 	void continueGame();
 	void continueMainMenu();
@@ -89,6 +90,7 @@ private:
 		_selectedSavefileI = 0;
 	Room *_previousRoom = nullptr;
 	FakeSemaphore _interactionSemaphore; // to prevent ScummVM loading during button clicks
+	Common::String _selectedSavefileDescription = "<unset>";
 	Common::Array<Common::String> _savefiles;
 	Common::SaveFileManager *_saveFileMgr;
 };

--- a/engines/alcachofa/menu.h
+++ b/engines/alcachofa/menu.h
@@ -36,11 +36,14 @@ public:
 	void continueGame();
 	void newGame();
 
+	void openOptionsMenu();
+
 private:
+	void setOptionsState();
+
 	bool
 		_isOpen = false,
 		_openAtNextFrame = false;
-
 	Room *_previousRoom = nullptr;
 };
 

--- a/engines/alcachofa/menu.h
+++ b/engines/alcachofa/menu.h
@@ -82,7 +82,7 @@ public:
 
 private:
 	void triggerSave();
-	void updateSelectedSavefile();
+	void updateSelectedSavefile(bool hasJustSaved);
 	bool tryReadOldSavefile();
 	void continueGame();
 	void continueMainMenu();

--- a/engines/alcachofa/menu.h
+++ b/engines/alcachofa/menu.h
@@ -75,9 +75,15 @@ public:
 	void triggerOptionsAction(OptionsMenuAction action);
 	void triggerOptionsValue(OptionsMenuValue valueId, float value);
 
+	// if we do still have a big thumbnail, any autosaves, ScummVM-saves, ingame-saves
+	// do not have to render themselves, they can just reuse the one we have.
+	// as such - may return nullptr
+	const Graphics::Surface *getBigThumbnail() const;
+
 private:
 	void triggerSave();
 	void updateSelectedSavefile();
+	bool tryReadOldSavefile();
 	void continueGame();
 	void continueMainMenu();
 	void setOptionsState();
@@ -92,6 +98,9 @@ private:
 	FakeSemaphore _interactionSemaphore; // to prevent ScummVM loading during button clicks
 	Common::String _selectedSavefileDescription = "<unset>";
 	Common::Array<Common::String> _savefiles;
+	Graphics::ManagedSurface
+		_bigThumbnail, // big because it is for the in-game menu, not for ScummVM
+		_selectedThumbnail;
 	Common::SaveFileManager *_saveFileMgr;
 };
 

--- a/engines/alcachofa/menu.h
+++ b/engines/alcachofa/menu.h
@@ -75,6 +75,7 @@ private:
 	bool
 		_isOpen = false,
 		_openAtNextFrame = false;
+	uint32 _timeBeforeMenu = 0;
 	Room *_previousRoom = nullptr;
 };
 

--- a/engines/alcachofa/menu.h
+++ b/engines/alcachofa/menu.h
@@ -22,7 +22,6 @@
 #ifndef ALCACHOFA_MENU_H
 #define ALCACHOFA_MENU_H
 
-#include "common/scummsys.h"
 #include "common/savefile.h"
 
 namespace Alcachofa {

--- a/engines/alcachofa/menu.h
+++ b/engines/alcachofa/menu.h
@@ -51,6 +51,11 @@ enum class OptionsMenuAction : int32 {
 	MainMenu
 };
 
+enum class OptionsMenuValue : int32 {
+	Music = 0,
+	Speech = 1
+};
+
 class Menu {
 public:
 	inline bool isOpen() const { return _isOpen; }
@@ -60,6 +65,7 @@ public:
 
 	void openOptionsMenu();
 	void triggerOptionsAction(OptionsMenuAction action);
+	void triggerOptionsValue(OptionsMenuValue valueId, float value);
 
 private:
 	void continueGame();

--- a/engines/alcachofa/metaengine.cpp
+++ b/engines/alcachofa/metaengine.cpp
@@ -34,12 +34,23 @@ namespace Alcachofa {
 
 static const ADExtraGuiOptionsMap optionsList[] = {
 	{
-		GAMEOPTION_ORIGINAL_SAVELOAD, // TODO: Remove, this is not really possible
+		GAMEOPTION_HIGH_QUALITY,
 		{
-			_s("Use original save/load screens"),
-			_s("Use the original save/load screens instead of the ScummVM ones"),
-			"original_menus",
-			false,
+			_s("High Quality"),
+			_s("TODO: Explain what this does"),
+			_s("high_quality"),
+			true,
+			0,
+			0
+		}
+	},
+	{
+		GAMEOPTION_32BITS,
+		{
+			_s("32 Bits"),
+			_s("TODO: Also explain this, and implement it maybe"),
+			_s("32_bits"),
+			true,
 			0,
 			0
 		}

--- a/engines/alcachofa/metaengine.cpp
+++ b/engines/alcachofa/metaengine.cpp
@@ -38,7 +38,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 		GAMEOPTION_HIGH_QUALITY,
 		{
 			_s("High Quality"),
-			_s("TODO: Explain what this does"),
+			_s("Toggles some optional graphical effects"),
 			_s("high_quality"),
 			true,
 			0,
@@ -49,7 +49,7 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 		GAMEOPTION_32BITS,
 		{
 			_s("32 Bits"),
-			_s("TODO: Also explain this, and implement it maybe"),
+			_s("Uses 32bit textures instead of 16bit ones (currently not implemented)"),
 			_s("32_bits"),
 			true,
 			0,
@@ -100,6 +100,12 @@ KeymapArray AlcachofaMetaEngine::initKeymaps(const char *target) const {
 	act->setCustomEngineActionEvent((CustomEventType)EventAction::InputMenu);
 	act->addDefaultInputMapping("ESCAPE");
 	act->addDefaultInputMapping("JOY_START");
+	keymap->addAction(act);
+
+	act = new Action("INVENTORY", _("Inventory"));
+	act->setCustomEngineActionEvent((CustomEventType)EventAction::InputInventory);
+	act->addDefaultInputMapping("SPACE");
+	act->addDefaultInputMapping("JOY_B");
 	keymap->addAction(act);
 
 	return Keymap::arrayOf(keymap);

--- a/engines/alcachofa/metaengine.cpp
+++ b/engines/alcachofa/metaengine.cpp
@@ -97,7 +97,7 @@ KeymapArray AlcachofaMetaEngine::initKeymaps(const char *target) const {
 	keymap->addAction(act);
 
 	act = new Action("MENU", _("Menu"));
-	act->setCustomEngineActionEvent((CustomEventType)InputAction::Menu);
+	act->setCustomEngineActionEvent((CustomEventType)EventAction::InputMenu);
 	act->addDefaultInputMapping("ESCAPE");
 	act->addDefaultInputMapping("JOY_START");
 	keymap->addAction(act);

--- a/engines/alcachofa/metaengine.cpp
+++ b/engines/alcachofa/metaengine.cpp
@@ -106,8 +106,10 @@ KeymapArray AlcachofaMetaEngine::initKeymaps(const char *target) const {
 }
 
 void AlcachofaMetaEngine::getSavegameThumbnail(Surface &surf) {
-	// TODO: Implement
-	surf.create(160, 120, PixelFormat::createFormatRGBA32());
+	if (Alcachofa::g_engine == nullptr)
+		surf.create(160, 120, PixelFormat::createFormatRGBA32());
+	else
+		Alcachofa::g_engine->getSavegameThumbnail(surf);
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(ALCACHOFA)

--- a/engines/alcachofa/metaengine.cpp
+++ b/engines/alcachofa/metaengine.cpp
@@ -28,6 +28,7 @@
 #include "alcachofa/alcachofa.h"
 
 using namespace Common;
+using namespace Graphics;
 using namespace Alcachofa;
 
 namespace Alcachofa {
@@ -102,6 +103,11 @@ KeymapArray AlcachofaMetaEngine::initKeymaps(const char *target) const {
 	keymap->addAction(act);
 
 	return Keymap::arrayOf(keymap);
+}
+
+void AlcachofaMetaEngine::getSavegameThumbnail(Surface &surf) {
+	// TODO: Implement
+	surf.create(160, 120, PixelFormat::createFormatRGBA32());
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(ALCACHOFA)

--- a/engines/alcachofa/metaengine.cpp
+++ b/engines/alcachofa/metaengine.cpp
@@ -106,10 +106,15 @@ KeymapArray AlcachofaMetaEngine::initKeymaps(const char *target) const {
 }
 
 void AlcachofaMetaEngine::getSavegameThumbnail(Surface &surf) {
-	if (Alcachofa::g_engine == nullptr)
-		surf.create(160, 120, PixelFormat::createFormatRGBA32());
-	else
-		Alcachofa::g_engine->getSavegameThumbnail(surf);
+	if (Alcachofa::g_engine != nullptr) {
+		Surface bigThumbnail;
+		Alcachofa::g_engine->getSavegameThumbnail(bigThumbnail);
+		if (bigThumbnail.getPixels() != nullptr) {
+			surf = *bigThumbnail.scale(kSmallThumbnailWidth, kSmallThumbnailHeight, true);
+			bigThumbnail.free();
+		}
+	}
+	// if not, ScummVM will output an appropriate warning
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(ALCACHOFA)

--- a/engines/alcachofa/metaengine.h
+++ b/engines/alcachofa/metaengine.h
@@ -26,8 +26,9 @@
 
 namespace Alcachofa {
 
-enum class InputAction {
-	Menu
+enum class EventAction {
+	LoadFromMenu,
+	InputMenu
 };
 
 }

--- a/engines/alcachofa/metaengine.h
+++ b/engines/alcachofa/metaengine.h
@@ -53,7 +53,7 @@ public:
 
 	void getSavegameThumbnail(Graphics::Surface &thumb) override;
 
-	
+
 };
 
 #endif // ALCACHOFA_METAENGINE_H

--- a/engines/alcachofa/metaengine.h
+++ b/engines/alcachofa/metaengine.h
@@ -49,6 +49,8 @@ public:
 
 	Common::KeymapArray initKeymaps(const char *target) const override;
 
+	void getSavegameThumbnail(Graphics::Surface &thumb) override;
+
 	
 };
 

--- a/engines/alcachofa/metaengine.h
+++ b/engines/alcachofa/metaengine.h
@@ -28,7 +28,8 @@ namespace Alcachofa {
 
 enum class EventAction {
 	LoadFromMenu,
-	InputMenu
+	InputMenu,
+	InputInventory
 };
 
 }

--- a/engines/alcachofa/module.mk
+++ b/engines/alcachofa/module.mk
@@ -2,24 +2,25 @@ MODULE := engines/alcachofa
 
 MODULE_OBJS = \
 	alcachofa.o \
-	camera.cpp \
-	common.cpp \
+	camera.o \
+	common.o \
 	console.o \
-	game.cpp \
-	game-objects.cpp \
-	general-objects.cpp \
-	global-ui.cpp \
-	graphics.cpp \
-	graphics-opengl.cpp \
-	input.cpp \
+	game.o \
+	game-objects.o \
+	general-objects.o \
+	global-ui.o \
+	graphics.o \
+	graphics-opengl.o \
+	input.o \
+	menu.o \
 	metaengine.o \
-	player.cpp \
-	rooms.cpp \
-	scheduler.cpp \
-	script.cpp \
-	shape.cpp \
-	sounds.cpp \
-	ui-objects.cpp \
+	player.o \
+	rooms.o \
+	scheduler.o \
+	script.o \
+	shape.o \
+	sounds.o \
+	ui-objects.o
 
 
 # This module can be built as a plugin

--- a/engines/alcachofa/module.mk
+++ b/engines/alcachofa/module.mk
@@ -6,6 +6,7 @@ MODULE_OBJS = \
 	common.o \
 	console.o \
 	game.o \
+	game-movie-adventure.o \
 	game-objects.o \
 	general-objects.o \
 	global-ui.o \

--- a/engines/alcachofa/module.mk
+++ b/engines/alcachofa/module.mk
@@ -28,6 +28,10 @@ MODULE_OBJS += \
 	graphics-opengl-classic.o
 endif
 
+ifdef USE_OPENGL_SHADERS
+MODULE_OBJS += \
+	graphics-opengl-shaders.o
+endif
 
 # This module can be built as a plugin
 ifeq ($(ENABLE_ALCACHOFA), DYNAMIC_PLUGIN)

--- a/engines/alcachofa/module.mk
+++ b/engines/alcachofa/module.mk
@@ -23,6 +23,11 @@ MODULE_OBJS = \
 	sounds.o \
 	ui-objects.o
 
+ifdef USE_OPENGL_GAME
+MODULE_OBJS += \
+	graphics-opengl-classic.o
+endif
+
 
 # This module can be built as a plugin
 ifeq ($(ENABLE_ALCACHOFA), DYNAMIC_PLUGIN)

--- a/engines/alcachofa/objects.h
+++ b/engines/alcachofa/objects.h
@@ -125,6 +125,7 @@ public:
 	virtual ~ShapeObject() override = default;
 
 	inline int8 order() const { return _order; }
+	inline bool isSelected() const { return _isSelected; }
 
 	virtual void update() override;
 	virtual void serializeSave(Common::Serializer &serializer) override;
@@ -168,8 +169,8 @@ public:
 	virtual void update() override;
 	virtual void loadResources() override;
 	virtual void freeResources() override;
-	virtual void onHoverStart();
-	virtual void onHoverEnd();
+	virtual void onHoverStart() override;
+	virtual void onHoverEnd() override;
 	virtual void onClick() override;
 	virtual void trigger();
 	virtual const char *typeName() const;
@@ -251,25 +252,30 @@ public:
 	CheckBox(Room *room, Common::ReadStream &stream);
 	virtual ~CheckBox() override = default;
 
+	inline bool &isChecked() { return _isChecked; }
+	inline int32 actionId() const { return _actionId; }
+
+	virtual void update() override; // also takes the role of draw for some reason
+	virtual void loadResources() override;
+	virtual void freeResources() override;
+	virtual void onHoverStart() override;
+	virtual void onHoverEnd() override;
+	virtual void onClick() override;
+	virtual void trigger();
 	virtual const char *typeName() const;
 
 private:
-	// TODO: Reverse engineer CheckBox
-	bool b1;
+	bool
+		_isChecked = false,
+		_wasClicked = false,
+		_isHovered = false;
 	Graphic
-		_graph1,
-		_graph2,
-		_graph3,
-		_graph4;
-	int32 _valueId;
-};
-
-class CheckBoxAutoAdjustNoise final : public CheckBox {
-public:
-	static constexpr const char *kClassName = "CCheckBoxAutoAjustarRuido";
-	CheckBoxAutoAdjustNoise(Room *room, Common::ReadStream &stream);
-
-	virtual const char *typeName() const;
+		_graphicUnchecked,
+		_graphicChecked,
+		_graphicHovered,
+		_graphicClicked;
+	int32 _actionId = 0;
+	uint32 _clickTime = 0;
 };
 
 class SlideButton final : public ObjectBase {
@@ -288,6 +294,17 @@ private:
 		_graph1,
 		_graph2,
 		_graph3;
+};
+
+// the next UI elements are only used for the multiplayer menus
+// so are currently not needed
+
+class CheckBoxAutoAdjustNoise final : public CheckBox {
+public:
+	static constexpr const char *kClassName = "CCheckBoxAutoAjustarRuido";
+	CheckBoxAutoAdjustNoise(Room *room, Common::ReadStream &stream);
+
+	virtual const char *typeName() const;
 };
 
 class IRCWindow final : public ObjectBase {
@@ -310,7 +327,6 @@ public:
 	virtual const char *typeName() const;
 
 private:
-	// TODO: Reverse engineer MessageBox
 	Graphic
 		_graph1,
 		_graph2,

--- a/engines/alcachofa/objects.h
+++ b/engines/alcachofa/objects.h
@@ -171,8 +171,8 @@ public:
 	virtual void onHoverStart();
 	virtual void onHoverEnd();
 	virtual void onClick() override;
-	virtual const char *typeName() const;
 	virtual void trigger();
+	virtual const char *typeName() const;
 
 private:
 	bool
@@ -209,6 +209,8 @@ public:
 	static constexpr const char *kClassName = "CBotonMenuPrincipal";
 	MainMenuButton(Room *room, Common::ReadStream &stream);
 
+	virtual void update() override;
+	virtual void trigger() override;
 	virtual const char *typeName() const;
 };
 

--- a/engines/alcachofa/objects.h
+++ b/engines/alcachofa/objects.h
@@ -69,7 +69,7 @@ public:
 
 	inline Common::Point &position() { return _pos; }
 	inline Common::Point position() const { return _pos; }
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 
 private:
 	Common::Point _pos;
@@ -94,7 +94,7 @@ public:
 	void freeResources() override;
 	void syncGame(Common::Serializer &serializer) override;
 	Graphic *graphic() override;
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 
 	Task *animate(Process &process);
 
@@ -112,7 +112,7 @@ public:
 	SpecialEffectObject(Room *room, Common::ReadStream &stream);
 
 	void draw() override;
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 
 private:
 	static constexpr const float kShiftSpeed = 1 / 256.0f;
@@ -137,7 +137,7 @@ public:
 	virtual void onHoverEnd();
 	virtual void onHoverUpdate();
 	virtual void onClick();
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 	void markSelected();
 
 protected:
@@ -155,7 +155,7 @@ private:
 class PhysicalObject : public ShapeObject {
 public:
 	PhysicalObject(Room *room, Common::ReadStream &stream);
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 };
 
 class MenuButton : public PhysicalObject {
@@ -174,7 +174,7 @@ public:
 	void onHoverUpdate() override;
 	void onClick() override;
 	virtual void trigger();
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 
 private:
 	bool
@@ -198,7 +198,7 @@ public:
 	static constexpr const char *kClassName = "CBotonMenuInternet";
 	InternetMenuButton(Room *room, Common::ReadStream &stream);
 
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 };
 
 class OptionsMenuButton final : public MenuButton {
@@ -208,7 +208,7 @@ public:
 
 	void update() override;
 	void trigger() override;
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 };
 
 class MainMenuButton final : public MenuButton {
@@ -218,7 +218,7 @@ public:
 
 	void update() override;
 	void trigger() override;
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 };
 
 class PushButton final : public PhysicalObject {
@@ -226,7 +226,7 @@ public:
 	static constexpr const char *kClassName = "CPushButton";
 	PushButton(Room *room, Common::ReadStream &stream);
 
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 
 private:
 	bool _alwaysVisible;
@@ -239,7 +239,7 @@ public:
 	static constexpr const char *kClassName = "CEditBox";
 	EditBox(Room *room, Common::ReadStream &stream);
 
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 
 private:
 	int32 i1;
@@ -266,7 +266,7 @@ public:
 	void onHoverUpdate() override;
 	void onClick() override;
 	virtual void trigger();
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 
 private:
 	bool
@@ -293,7 +293,7 @@ public:
 	void update() override;
 	void loadResources() override;
 	void freeResources() override;
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 
 private:
 	bool isMouseOver() const;
@@ -312,7 +312,7 @@ public:
 	static constexpr const char *kClassName = "CCheckBoxAutoAjustarRuido";
 	CheckBoxAutoAdjustNoise(Room *room, Common::ReadStream &stream);
 
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 };
 
 class IRCWindow final : public ObjectBase {
@@ -320,7 +320,7 @@ public:
 	static constexpr const char *kClassName = "CVentanaIRC";
 	IRCWindow(Room *room, Common::ReadStream &stream);
 
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 
 private:
 	Common::Point _p1, _p2;
@@ -332,7 +332,7 @@ public:
 	MessageBox(Room *room, Common::ReadStream &stream);
 	~MessageBox() override = default;
 
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 
 private:
 	Graphic
@@ -348,7 +348,7 @@ public:
 	static constexpr const char *kClassName = "CVuMeter";
 	VoiceMeter(Room *room, Common::ReadStream &stream);
 
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 };
 
 class Item : public GraphicObject {
@@ -358,7 +358,7 @@ public:
 	Item(const Item &other);
 
 	void draw() override;
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 	void trigger();
 };
 
@@ -388,7 +388,7 @@ public:
 	void onClick() override;
 	void trigger(const char *action) override;
 	void toggle(bool isEnabled) override;
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 
 private:
 	Common::String _relatedObject;
@@ -406,7 +406,7 @@ public:
 	virtual CursorType cursorType() const override;
 	void onClick() override;
 	void trigger(const char *action) override;
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 
 private:
 	Common::String _targetRoom, _targetObject;
@@ -429,7 +429,7 @@ public:
 	Graphic *graphic() override;
 	void onClick() override;
 	void trigger(const char *action) override;
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 
 	Task *sayText(Process &process, int32 dialogId);
 	void resetTalking();
@@ -480,7 +480,7 @@ public:
 		const char *activateAction = nullptr);
 	void stopWalking(Direction direction = Direction::Invalid);
 	void setPosition(Common::Point target);
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 
 	Task *waitForArrival(Process &process);
 
@@ -541,7 +541,7 @@ public:
 	void update() override;
 	void draw() override;
 	void syncGame(Common::Serializer &serializer) override;
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 	virtual void walkTo(
 		Common::Point target,
 		Direction endDirection = Direction::Invalid,
@@ -581,7 +581,7 @@ private:
 class Background final : public GraphicObject {
 public:
 	Background(Room *room, const Common::String &animationFileName, int16 scale);
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 };
 
 class FloorColor final : public ObjectBase {
@@ -593,7 +593,7 @@ public:
 	void update() override;
 	void drawDebug() override;
 	Shape *shape() override;
-	virtual const char *typeName() const;
+	const char *typeName() const override;
 
 private:
 	FloorColorShape _shape;

--- a/engines/alcachofa/objects.h
+++ b/engines/alcachofa/objects.h
@@ -125,7 +125,8 @@ public:
 	virtual ~ShapeObject() override = default;
 
 	inline int8 order() const { return _order; }
-	inline bool isSelected() const { return _isSelected; }
+	inline bool isNewlySelected() const { return _isNewlySelected; }
+	inline bool wasSelected() const { return _wasSelected; }
 
 	virtual void update() override;
 	virtual void serializeSave(Common::Serializer &serializer) override;
@@ -146,7 +147,7 @@ protected:
 private:
 	Shape _shape;
 	CursorType _cursorType;
-	bool _isSelected = false,
+	bool _isNewlySelected = false,
 		_wasSelected = false;
 };
 
@@ -169,8 +170,7 @@ public:
 	virtual void update() override;
 	virtual void loadResources() override;
 	virtual void freeResources() override;
-	virtual void onHoverStart() override;
-	virtual void onHoverEnd() override;
+	virtual void onHoverUpdate() override;
 	virtual void onClick() override;
 	virtual void trigger();
 	virtual const char *typeName() const;
@@ -179,7 +179,6 @@ private:
 	bool
 		_isInteractable = true,
 		_isClicked = false,
-		_isHovered = false,
 		_triggerNextFrame = false;
 	int32 _actionId;
 	Graphic
@@ -262,8 +261,7 @@ public:
 	virtual void update() override;
 	virtual void loadResources() override;
 	virtual void freeResources() override;
-	virtual void onHoverStart() override;
-	virtual void onHoverEnd() override;
+	virtual void onHoverUpdate() override;
 	virtual void onClick() override;
 	virtual void trigger();
 	virtual const char *typeName() const;
@@ -271,8 +269,7 @@ public:
 private:
 	bool
 		_isChecked = false,
-		_wasClicked = false,
-		_isHovered = false;
+		_wasClicked = false;
 	Graphic
 		_graphicUnchecked,
 		_graphicChecked,

--- a/engines/alcachofa/objects.h
+++ b/engines/alcachofa/objects.h
@@ -365,6 +365,7 @@ public:
 class ITriggerableObject {
 public:
 	ITriggerableObject(Common::ReadStream &stream);
+	virtual ~ITriggerableObject() = default;
 
 	inline Direction interactionDirection() const { return _interactionDirection; }
 	inline Common::Point interactionPoint() const { return _interactionPoint; }

--- a/engines/alcachofa/objects.h
+++ b/engines/alcachofa/objects.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef OBJECTS_H
-#define OBJECTS_H
+#ifndef ALCACHOFA_OBJECTS_H
+#define ALCACHOFA_OBJECTS_H
 
 #include "shape.h"
 #include "graphics.h"
@@ -602,4 +602,4 @@ private:
 
 }
 
-#endif // OBJECTS_H
+#endif // ALCACHOFA_OBJECTS_H

--- a/engines/alcachofa/objects.h
+++ b/engines/alcachofa/objects.h
@@ -22,8 +22,8 @@
 #ifndef ALCACHOFA_OBJECTS_H
 #define ALCACHOFA_OBJECTS_H
 
-#include "shape.h"
-#include "graphics.h"
+#include "alcachofa/shape.h"
+#include "alcachofa/graphics.h"
 
 #include "common/serializer.h"
 

--- a/engines/alcachofa/objects.h
+++ b/engines/alcachofa/objects.h
@@ -186,6 +186,7 @@ private:
 		_graphicHovered,
 		_graphicClicked,
 		_graphicDisabled;
+	FakeLock _interactionLock;
 };
 
 // some of the UI elements are only used for the multiplayer menus

--- a/engines/alcachofa/objects.h
+++ b/engines/alcachofa/objects.h
@@ -285,16 +285,24 @@ public:
 	SlideButton(Room *room, Common::ReadStream &stream);
 	virtual ~SlideButton() override = default;
 
+	inline float &value() { return _value; }
+
+	virtual void draw() override;
+	virtual void update() override;
+	virtual void loadResources() override;
+	virtual void freeResources() override;
 	virtual const char *typeName() const;
 
 private:
-	// TODO: Reverse engineer SlideButton
-	int32 i1;
-	Common::Point p1, p2;
+	bool isMouseOver() const;
+
+	float _value = 0;
+	int32 _valueId;
+	Common::Point _minPos, _maxPos;
 	Graphic
-		_graph1,
-		_graph2,
-		_graph3;
+		_graphicIdle,
+		_graphicHovered,
+		_graphicClicked;
 };
 
 class CheckBoxAutoAdjustNoise final : public CheckBox {

--- a/engines/alcachofa/objects.h
+++ b/engines/alcachofa/objects.h
@@ -189,6 +189,9 @@ private:
 		_graphicDisabled;
 };
 
+// some of the UI elements are only used for the multiplayer menus
+// so are currently not needed
+
 class InternetMenuButton final : public MenuButton {
 public:
 	static constexpr const char *kClassName = "CBotonMenuInternet";
@@ -202,6 +205,8 @@ public:
 	static constexpr const char *kClassName = "CBotonMenuOpciones";
 	OptionsMenuButton(Room *room, Common::ReadStream &stream);
 
+	virtual void update() override;
+	virtual void trigger() override;
 	virtual const char *typeName() const;
 };
 
@@ -223,7 +228,6 @@ public:
 	virtual const char *typeName() const;
 
 private:
-	// TODO: Reverse engineer PushButton
 	bool _alwaysVisible;
 	Graphic _graphic1, _graphic2;
 	int32 _actionId;
@@ -237,7 +241,6 @@ public:
 	virtual const char *typeName() const;
 
 private:
-	// TODO: Reverse engineer EditBox
 	int32 i1;
 	Common::Point p1;
 	Common::String _labelId;
@@ -255,7 +258,8 @@ public:
 	inline bool &isChecked() { return _isChecked; }
 	inline int32 actionId() const { return _actionId; }
 
-	virtual void update() override; // also takes the role of draw for some reason
+	virtual void draw() override;
+	virtual void update() override;
 	virtual void loadResources() override;
 	virtual void freeResources() override;
 	virtual void onHoverStart() override;
@@ -295,9 +299,6 @@ private:
 		_graph2,
 		_graph3;
 };
-
-// the next UI elements are only used for the multiplayer menus
-// so are currently not needed
 
 class CheckBoxAutoAdjustNoise final : public CheckBox {
 public:

--- a/engines/alcachofa/objects.h
+++ b/engines/alcachofa/objects.h
@@ -89,6 +89,7 @@ public:
 	~GraphicObject() override = default;
 
 	void draw() override;
+	void drawDebug() override;
 	void loadResources() override;
 	void freeResources() override;
 	void syncGame(Common::Serializer &serializer) override;

--- a/engines/alcachofa/objects.h
+++ b/engines/alcachofa/objects.h
@@ -86,13 +86,13 @@ class GraphicObject : public ObjectBase {
 public:
 	static constexpr const char *kClassName = "CObjetoGrafico";
 	GraphicObject(Room *room, Common::ReadStream &stream);
-	virtual ~GraphicObject() override = default;
+	~GraphicObject() override = default;
 
-	virtual void draw() override;
-	virtual void loadResources() override;
-	virtual void freeResources() override;
-	virtual void syncGame(Common::Serializer &serializer) override;
-	virtual Graphic *graphic() override;
+	void draw() override;
+	void loadResources() override;
+	void freeResources() override;
+	void syncGame(Common::Serializer &serializer) override;
+	Graphic *graphic() override;
 	virtual const char *typeName() const;
 
 	Task *animate(Process &process);
@@ -110,7 +110,7 @@ public:
 	static constexpr const char *kClassName = "CObjetoGraficoMuare";
 	SpecialEffectObject(Room *room, Common::ReadStream &stream);
 
-	virtual void draw() override;
+	void draw() override;
 	virtual const char *typeName() const;
 
 private:
@@ -122,15 +122,15 @@ private:
 class ShapeObject : public ObjectBase {
 public:
 	ShapeObject(Room *room, Common::ReadStream &stream);
-	virtual ~ShapeObject() override = default;
+	~ShapeObject() override = default;
 
 	inline int8 order() const { return _order; }
 	inline bool isNewlySelected() const { return _isNewlySelected; }
 	inline bool wasSelected() const { return _wasSelected; }
 
-	virtual void update() override;
-	virtual void syncGame(Common::Serializer &serializer) override;
-	virtual Shape *shape() override;
+	void update() override;
+	void syncGame(Common::Serializer &serializer) override;
+	Shape *shape() override;
 	virtual CursorType cursorType() const;
 	virtual void onHoverStart();
 	virtual void onHoverEnd();
@@ -161,17 +161,17 @@ class MenuButton : public PhysicalObject {
 public:
 	static constexpr const char *kClassName = "CBotonMenu";
 	MenuButton(Room *room, Common::ReadStream &stream);
-	virtual ~MenuButton() override = default;
+	~MenuButton() override = default;
 
 	inline int32 actionId() const { return _actionId; }
 	inline bool &isInteractable() { return _isInteractable; }
 
-	virtual void draw() override;
-	virtual void update() override;
-	virtual void loadResources() override;
-	virtual void freeResources() override;
-	virtual void onHoverUpdate() override;
-	virtual void onClick() override;
+	void draw() override;
+	void update() override;
+	void loadResources() override;
+	void freeResources() override;
+	void onHoverUpdate() override;
+	void onClick() override;
 	virtual void trigger();
 	virtual const char *typeName() const;
 
@@ -204,8 +204,8 @@ public:
 	static constexpr const char *kClassName = "CBotonMenuOpciones";
 	OptionsMenuButton(Room *room, Common::ReadStream &stream);
 
-	virtual void update() override;
-	virtual void trigger() override;
+	void update() override;
+	void trigger() override;
 	virtual const char *typeName() const;
 };
 
@@ -214,8 +214,8 @@ public:
 	static constexpr const char *kClassName = "CBotonMenuPrincipal";
 	MainMenuButton(Room *room, Common::ReadStream &stream);
 
-	virtual void update() override;
-	virtual void trigger() override;
+	void update() override;
+	void trigger() override;
 	virtual const char *typeName() const;
 };
 
@@ -252,17 +252,17 @@ class CheckBox : public PhysicalObject {
 public:
 	static constexpr const char *kClassName = "CCheckBox";
 	CheckBox(Room *room, Common::ReadStream &stream);
-	virtual ~CheckBox() override = default;
+	~CheckBox() override = default;
 
 	inline bool &isChecked() { return _isChecked; }
 	inline int32 actionId() const { return _actionId; }
 
-	virtual void draw() override;
-	virtual void update() override;
-	virtual void loadResources() override;
-	virtual void freeResources() override;
-	virtual void onHoverUpdate() override;
-	virtual void onClick() override;
+	void draw() override;
+	void update() override;
+	void loadResources() override;
+	void freeResources() override;
+	void onHoverUpdate() override;
+	void onClick() override;
 	virtual void trigger();
 	virtual const char *typeName() const;
 
@@ -283,14 +283,14 @@ class SlideButton final : public ObjectBase {
 public:
 	static constexpr const char *kClassName = "CSlideButton";
 	SlideButton(Room *room, Common::ReadStream &stream);
-	virtual ~SlideButton() override = default;
+	~SlideButton() override = default;
 
 	inline float &value() { return _value; }
 
-	virtual void draw() override;
-	virtual void update() override;
-	virtual void loadResources() override;
-	virtual void freeResources() override;
+	void draw() override;
+	void update() override;
+	void loadResources() override;
+	void freeResources() override;
 	virtual const char *typeName() const;
 
 private:
@@ -328,7 +328,7 @@ class MessageBox final : public ObjectBase {
 public:
 	static constexpr const char *kClassName = "CMessageBox";
 	MessageBox(Room *room, Common::ReadStream &stream);
-	virtual ~MessageBox() override = default;
+	~MessageBox() override = default;
 
 	virtual const char *typeName() const;
 
@@ -355,7 +355,7 @@ public:
 	Item(Room *room, Common::ReadStream &stream);
 	Item(const Item &other);
 
-	virtual void draw() override;
+	void draw() override;
 	virtual const char *typeName() const;
 	void trigger();
 };
@@ -380,12 +380,12 @@ class InteractableObject : public PhysicalObject, public ITriggerableObject {
 public:
 	static constexpr const char *kClassName = "CObjetoTipico";
 	InteractableObject(Room *room, Common::ReadStream &stream);
-	virtual ~InteractableObject() override = default;
+	~InteractableObject() override = default;
 
-	virtual void drawDebug() override;
-	virtual void onClick() override;
-	virtual void trigger(const char *action) override;
-	virtual void toggle(bool isEnabled) override;
+	void drawDebug() override;
+	void onClick() override;
+	void trigger(const char *action) override;
+	void toggle(bool isEnabled) override;
 	virtual const char *typeName() const;
 
 private:
@@ -402,8 +402,8 @@ public:
 	inline Direction characterDirection() const { return _characterDirection; }
 
 	virtual CursorType cursorType() const override;
-	virtual void onClick() override;
-	virtual void trigger(const char *action) override;
+	void onClick() override;
+	void trigger(const char *action) override;
 	virtual const char *typeName() const;
 
 private:
@@ -416,17 +416,17 @@ class Character : public ShapeObject, public ITriggerableObject {
 public:
 	static constexpr const char *kClassName = "CPersonaje";
 	Character(Room *room, Common::ReadStream &stream);
-	virtual ~Character() override = default;
+	~Character() override = default;
 
-	virtual void update() override;
-	virtual void draw() override;
-	virtual void drawDebug() override;
-	virtual void loadResources() override;
-	virtual void freeResources() override;
-	virtual void syncGame(Common::Serializer &serializer) override;
-	virtual Graphic *graphic() override;
-	virtual void onClick() override;
-	virtual void trigger(const char *action) override;
+	void update() override;
+	void draw() override;
+	void drawDebug() override;
+	void loadResources() override;
+	void freeResources() override;
+	void syncGame(Common::Serializer &serializer) override;
+	Graphic *graphic() override;
+	void onClick() override;
+	void trigger(const char *action) override;
 	virtual const char *typeName() const;
 
 	Task *sayText(Process &process, int32 dialogId);
@@ -459,18 +459,18 @@ class WalkingCharacter : public Character {
 public:
 	static constexpr const char *kClassName = "CPersonajeAnda";
 	WalkingCharacter(Room *room, Common::ReadStream &stream);
-	virtual ~WalkingCharacter() override = default;
+	~WalkingCharacter() override = default;
 
 	inline bool isWalking() const { return _isWalking; }
 	inline Common::Point position() const { return _currentPos; }
 	inline float stepSizeFactor() const { return _stepSizeFactor; }
 
-	virtual void update() override;
-	virtual void draw() override;
-	virtual void drawDebug() override;
-	virtual void loadResources() override;
-	virtual void freeResources() override;
-	virtual void syncGame(Common::Serializer &serializer) override;
+	void update() override;
+	void draw() override;
+	void drawDebug() override;
+	void loadResources() override;
+	void freeResources() override;
+	void syncGame(Common::Serializer &serializer) override;
 	virtual void walkTo(
 		Common::Point target,
 		Direction endDirection = Direction::Invalid,
@@ -526,7 +526,7 @@ class MainCharacter final : public WalkingCharacter {
 public:
 	static constexpr const char *kClassName = "CPersonajePrincipal";
 	MainCharacter(Room *room, Common::ReadStream &stream);
-	virtual ~MainCharacter() override;
+	~MainCharacter() override;
 
 	inline MainCharacterKind kind() const { return _kind; }
 	inline ObjectBase *&currentlyUsing() { return _currentlyUsingObject; }
@@ -536,9 +536,9 @@ public:
 	inline FakeSemaphore &semaphore() { return _semaphore; }
 	bool isBusy() const;
 
-	virtual void update() override;
-	virtual void draw() override;
-	virtual void syncGame(Common::Serializer &serializer) override;
+	void update() override;
+	void draw() override;
+	void syncGame(Common::Serializer &serializer) override;
 	virtual const char *typeName() const;
 	virtual void walkTo(
 		Common::Point target,
@@ -557,7 +557,7 @@ public:
 	void resetUsingObjectAndDialogMenu();
 
 protected:
-	virtual void onArrived() override;
+	void onArrived() override;
 
 private:
 	friend class Inventory;
@@ -586,11 +586,11 @@ class FloorColor final : public ObjectBase {
 public:
 	static constexpr const char *kClassName = "CSueloColor";
 	FloorColor(Room *room, Common::ReadStream &stream);
-	virtual ~FloorColor() override = default;
+	~FloorColor() override = default;
 
-	virtual void update() override;
-	virtual void drawDebug() override;
-	virtual Shape *shape() override;
+	void update() override;
+	void drawDebug() override;
+	Shape *shape() override;
 	virtual const char *typeName() const;
 
 private:

--- a/engines/alcachofa/objects.h
+++ b/engines/alcachofa/objects.h
@@ -404,7 +404,7 @@ public:
 	inline const Common::String &targetObject() const { return _targetObject; }
 	inline Direction characterDirection() const { return _characterDirection; }
 
-	virtual CursorType cursorType() const override;
+	CursorType cursorType() const override;
 	void onClick() override;
 	void trigger(const char *action) override;
 	const char *typeName() const override;
@@ -543,7 +543,7 @@ public:
 	void draw() override;
 	void syncGame(Common::Serializer &serializer) override;
 	const char *typeName() const override;
-	virtual void walkTo(
+	void walkTo(
 		Common::Point target,
 		Direction endDirection = Direction::Invalid,
 		ITriggerableObject *activateObject = nullptr,

--- a/engines/alcachofa/objects.h
+++ b/engines/alcachofa/objects.h
@@ -51,7 +51,7 @@ public:
 	virtual void update();
 	virtual void loadResources();
 	virtual void freeResources();
-	virtual void serializeSave(Common::Serializer &serializer);
+	virtual void syncGame(Common::Serializer &serializer);
 	virtual Graphic *graphic();
 	virtual Shape *shape();
 	virtual const char *typeName() const;
@@ -91,7 +91,7 @@ public:
 	virtual void draw() override;
 	virtual void loadResources() override;
 	virtual void freeResources() override;
-	virtual void serializeSave(Common::Serializer &serializer) override;
+	virtual void syncGame(Common::Serializer &serializer) override;
 	virtual Graphic *graphic() override;
 	virtual const char *typeName() const;
 
@@ -129,7 +129,7 @@ public:
 	inline bool wasSelected() const { return _wasSelected; }
 
 	virtual void update() override;
-	virtual void serializeSave(Common::Serializer &serializer) override;
+	virtual void syncGame(Common::Serializer &serializer) override;
 	virtual Shape *shape() override;
 	virtual CursorType cursorType() const;
 	virtual void onHoverStart();
@@ -423,7 +423,7 @@ public:
 	virtual void drawDebug() override;
 	virtual void loadResources() override;
 	virtual void freeResources() override;
-	virtual void serializeSave(Common::Serializer &serializer) override;
+	virtual void syncGame(Common::Serializer &serializer) override;
 	virtual Graphic *graphic() override;
 	virtual void onClick() override;
 	virtual void trigger(const char *action) override;
@@ -470,7 +470,7 @@ public:
 	virtual void drawDebug() override;
 	virtual void loadResources() override;
 	virtual void freeResources() override;
-	virtual void serializeSave(Common::Serializer &serializer) override;
+	virtual void syncGame(Common::Serializer &serializer) override;
 	virtual void walkTo(
 		Common::Point target,
 		Direction endDirection = Direction::Invalid,
@@ -538,7 +538,7 @@ public:
 
 	virtual void update() override;
 	virtual void draw() override;
-	virtual void serializeSave(Common::Serializer &serializer) override;
+	virtual void syncGame(Common::Serializer &serializer) override;
 	virtual const char *typeName() const;
 	virtual void walkTo(
 		Common::Point target,

--- a/engines/alcachofa/player.cpp
+++ b/engines/alcachofa/player.cpp
@@ -210,7 +210,7 @@ struct DoorTask : public Task {
 		syncGame(s);
 	}
 
-	virtual TaskReturn run() {
+	TaskReturn run() override {
 		TASK_BEGIN;
 		if (_targetRoom == nullptr || _targetObject == nullptr)
 			return TaskReturn::finish(1);
@@ -240,7 +240,7 @@ struct DoorTask : public Task {
 		TASK_END;
 	}
 
-	virtual void debugPrint() {
+	void debugPrint() override {
 		g_engine->console().debugPrintf("%s\n", process().name().c_str());
 	}
 
@@ -259,7 +259,7 @@ struct DoorTask : public Task {
 		findTarget();
 	}
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 private:
 	void findTarget() {

--- a/engines/alcachofa/player.cpp
+++ b/engines/alcachofa/player.cpp
@@ -22,6 +22,7 @@
 #include "player.h"
 #include "script.h"
 #include "alcachofa.h"
+#include "menu.h"
 
 using namespace Common;
 
@@ -49,7 +50,7 @@ void Player::resetCursor() {
 }
 
 void Player::updateCursor() {
-	if (_isMenuOpen || !_isGameLoaded)
+	if (g_engine->menu().isOpen() || !_isGameLoaded)
 		_cursorFrameI = 0;
 	else if (_selectedObject == nullptr)
 		_cursorFrameI = !g_engine->input().isMouseLeftDown() || _pressedObject != nullptr ? 6 : 7;
@@ -298,7 +299,7 @@ void Player::setActiveCharacter(MainCharacterKind kind) {
 bool Player::isAllowedToOpenMenu() {
 	return
 		isGameLoaded() &&
-		!isMenuOpen() &&
+		!g_engine->menu().isOpen() &&
 		g_engine->sounds().musicSemaphore().isReleased() &&
 		!g_engine->script().variable("prohibirESC");
 }

--- a/engines/alcachofa/player.cpp
+++ b/engines/alcachofa/player.cpp
@@ -58,20 +58,31 @@ void Player::updateCursor() {
 	else {
 		auto type = _selectedObject->cursorType();
 		switch (type) {
-		case CursorType::LeaveUp: _cursorFrameI = 8; break;
-		case CursorType::LeaveRight: _cursorFrameI = 10; break;
-		case CursorType::LeaveDown: _cursorFrameI = 12; break;
-		case CursorType::LeaveLeft: _cursorFrameI = 14; break;
-		case CursorType::WalkTo: _cursorFrameI = 6; break;
+		case CursorType::LeaveUp:
+			_cursorFrameI = 8;
+			break;
+		case CursorType::LeaveRight:
+			_cursorFrameI = 10;
+			break;
+		case CursorType::LeaveDown:
+			_cursorFrameI = 12;
+			break;
+		case CursorType::LeaveLeft:
+			_cursorFrameI = 14;
+			break;
+		case CursorType::WalkTo:
+			_cursorFrameI = 6;
+			break;
 		case CursorType::Point:
-		default: _cursorFrameI = 0; break;
+		default:
+			_cursorFrameI = 0;
+			break;
 		}
 
 		if (_cursorFrameI != 0) {
 			if (g_engine->input().isAnyMouseDown() && _pressedObject == _selectedObject)
 				_cursorFrameI++;
-		}
-		else if (g_engine->input().isMouseLeftDown())
+		} else if (g_engine->input().isMouseLeftDown())
 			_cursorFrameI = 2;
 		else if (g_engine->input().isMouseRightDown())
 			_cursorFrameI = 4;
@@ -84,8 +95,7 @@ void Player::drawCursor(bool forceDefaultCursor) {
 		if (forceDefaultCursor)
 			_cursorFrameI = 0;
 		g_engine->drawQueue().add<AnimationDrawRequest>(_cursorAnimation.get(), _cursorFrameI, as2D(cursorPos), -10);
-	}
-	else {
+	} else {
 		auto itemGraphic = _heldItem->graphic();
 		assert(itemGraphic != nullptr);
 		auto &animation = itemGraphic->animation();
@@ -156,10 +166,15 @@ MainCharacter *Player::inactiveCharacter() const {
 FakeSemaphore &Player::semaphoreFor(MainCharacterKind kind) {
 	static FakeSemaphore dummySemaphore("dummy");
 	switch (kind) {
-	case MainCharacterKind::None: return _semaphore;
-	case MainCharacterKind::Mortadelo: return g_engine->world().mortadelo().semaphore();
-	case MainCharacterKind::Filemon: return g_engine->world().filemon().semaphore();
-	default: assert(false && "Invalid main character kind"); return dummySemaphore;
+	case MainCharacterKind::None:
+		return _semaphore;
+	case MainCharacterKind::Mortadelo:
+		return g_engine->world().mortadelo().semaphore();
+	case MainCharacterKind::Filemon:
+		return g_engine->world().filemon().semaphore();
+	default:
+		assert(false && "Invalid main character kind");
+		return dummySemaphore;
 	}
 }
 
@@ -172,8 +187,7 @@ void Player::triggerObject(ObjectBase *object, const char *action) {
 	if (strcmp(action, "MIRAR") == 0 || inactiveCharacter()->currentlyUsing() == object) {
 		action = "MIRAR";
 		_activeCharacter->currentlyUsing() = nullptr;
-	}
-	else
+	} else
 		_activeCharacter->currentlyUsing() = object;
 
 	auto &script = g_engine->script();
@@ -254,7 +268,7 @@ struct DoorTask : public Task {
 		s.syncAsByte(hasMusicLock);
 		if (s.isLoading() && hasMusicLock)
 			_musicLock = FakeLock("door-music", g_engine->sounds().musicSemaphore());
-		
+
 		_lock = FakeLock("door", _character->semaphore());
 		findTarget();
 	}
@@ -347,7 +361,7 @@ void Player::syncGame(Serializer &s) {
 	}
 
 	FakeSemaphore::sync(s, _semaphore);
-	
+
 	String roomName;
 	if (s.isSaving()) {
 		roomName =

--- a/engines/alcachofa/player.cpp
+++ b/engines/alcachofa/player.cpp
@@ -215,7 +215,7 @@ struct DoorTask : public Task {
 		if (_targetRoom == nullptr || _targetObject == nullptr)
 			return TaskReturn::finish(1);
 
-		_musicLock = FakeLock(g_engine->sounds().musicSemaphore());
+		_musicLock = FakeLock("door-music", g_engine->sounds().musicSemaphore());
 		if (g_engine->sounds().musicID() != _targetRoom->musicID())
 			g_engine->sounds().fadeMusic();
 		TASK_WAIT(1, fade(process(), FadeType::ToBlack, 0, 1, 500, EasingType::Out, -5));
@@ -253,9 +253,9 @@ struct DoorTask : public Task {
 		bool hasMusicLock = !_musicLock.isReleased();
 		s.syncAsByte(hasMusicLock);
 		if (s.isLoading() && hasMusicLock)
-			_musicLock = FakeLock(g_engine->sounds().musicSemaphore());
+			_musicLock = FakeLock("door-music", g_engine->sounds().musicSemaphore());
 		
-		_lock = FakeLock(_character->semaphore());
+		_lock = FakeLock("door", _character->semaphore());
 		findTarget();
 	}
 
@@ -292,7 +292,7 @@ void Player::triggerDoor(const Door *door) {
 	_heldItem = nullptr;
 
 	if (g_engine->game().shouldTriggerDoor(door)) {
-		FakeLock lock(_activeCharacter->semaphore());
+		FakeLock lock("door", _activeCharacter->semaphore());
 		g_engine->scheduler().createProcess<DoorTask>(activeCharacterKind(), door, move(lock));
 	}
 }

--- a/engines/alcachofa/player.cpp
+++ b/engines/alcachofa/player.cpp
@@ -286,7 +286,7 @@ private:
 	MainCharacter *_character = nullptr;
 	Player &_player;
 };
-DECLARE_TASK(DoorTask);
+DECLARE_TASK(DoorTask)
 
 void Player::triggerDoor(const Door *door) {
 	_heldItem = nullptr;

--- a/engines/alcachofa/player.cpp
+++ b/engines/alcachofa/player.cpp
@@ -19,10 +19,10 @@
  *
  */
 
-#include "player.h"
-#include "script.h"
-#include "alcachofa.h"
-#include "menu.h"
+#include "alcachofa/player.h"
+#include "alcachofa/script.h"
+#include "alcachofa/alcachofa.h"
+#include "alcachofa/menu.h"
 
 using namespace Common;
 

--- a/engines/alcachofa/player.h
+++ b/engines/alcachofa/player.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef PLAYER_H
-#define PLAYER_H
+#ifndef ALCACHOFA_PLAYER_H
+#define ALCACHOFA_PLAYER_H
 
 #include "rooms.h"
 
@@ -81,4 +81,4 @@ private:
 
 }
 
-#endif // PLAYER_H
+#endif // ALCACHOFA_PLAYER_H

--- a/engines/alcachofa/player.h
+++ b/engines/alcachofa/player.h
@@ -39,7 +39,6 @@ public:
 	MainCharacter *inactiveCharacter() const;
 	FakeSemaphore &semaphoreFor(MainCharacterKind kind);
 
-	inline bool &isMenuOpen() { return _isMenuOpen; }
 	inline bool &isGameLoaded() { return _isGameLoaded; }
 
 	inline MainCharacterKind activeCharacterKind() const {
@@ -73,7 +72,6 @@ private:
 	Item *_heldItem = nullptr;
 	int32 _cursorFrameI = 0;
 	bool
-		_isMenuOpen = false,
 		_isGameLoaded = true,
 		_didLoadGlobalRooms = false;
 	Character *_lastDialogCharacters[kMaxLastDialogCharacters] = { nullptr };

--- a/engines/alcachofa/player.h
+++ b/engines/alcachofa/player.h
@@ -58,6 +58,7 @@ public:
 	void stopLastDialogCharacters();
 	void setActiveCharacter(MainCharacterKind kind);
 	bool isAllowedToOpenMenu();
+	void syncGame(Common::Serializer &s);
 
 private:
 	static constexpr const int kMaxLastDialogCharacters = 4;

--- a/engines/alcachofa/player.h
+++ b/engines/alcachofa/player.h
@@ -22,7 +22,7 @@
 #ifndef ALCACHOFA_PLAYER_H
 #define ALCACHOFA_PLAYER_H
 
-#include "rooms.h"
+#include "alcachofa/rooms.h"
 
 namespace Alcachofa {
 

--- a/engines/alcachofa/rooms.cpp
+++ b/engines/alcachofa/rooms.cpp
@@ -113,7 +113,7 @@ Room::Room(World *world, SeekableReadStream &stream, bool hasUselessByte)
 			stream.seek(objectEnd, SEEK_SET);
 		}
 		else if (stream.pos() > objectEnd) // this is probably not recoverable
-			error("Read past the object data (%u > %ld) in room %s", objectEnd, stream.pos(), _name.c_str());
+			error("Read past the object data (%u > %lld) in room %s", objectEnd, (long long int)stream.pos(), _name.c_str());
 
 		if (object != nullptr)
 			_objects.push_back(object);

--- a/engines/alcachofa/rooms.cpp
+++ b/engines/alcachofa/rooms.cpp
@@ -23,6 +23,7 @@
 #include "rooms.h"
 #include "script.h"
 #include "global-ui.h"
+#include "menu.h"
 
 #include "common/file.h"
 
@@ -149,7 +150,7 @@ void Room::update() {
 		if (!updateInput())
 			return;
 	}
-	if (!g_engine->player().isMenuOpen() &&
+	if (!g_engine->menu().isOpen() &&
 		g_engine->player().currentRoom() != &g_engine->world().inventory())
 		world().globalRoom().updateObjects();
 	if (g_engine->player().currentRoom() == this)
@@ -183,7 +184,7 @@ bool Room::updateInput() {
 
 	bool canInteract = !player.activeCharacter()->isBusy();
 	// A complicated network condition can prevent interaction at this point
-	if (player.isMenuOpen() || !player.isGameLoaded())
+	if (g_engine->menu().isOpen() || !player.isGameLoaded())
 		canInteract = true;
 	if (canInteract) {
 		player.resetCursor();
@@ -197,7 +198,7 @@ bool Room::updateInput() {
 
 	if (player.currentRoom() == this) {
 		g_engine->globalUI().drawChangingButton();
-		g_engine->globalUI().updateOpeningMenu();
+		g_engine->menu().updateOpeningMenu();
 	}
 
 	return player.currentRoom() == this;

--- a/engines/alcachofa/rooms.cpp
+++ b/engines/alcachofa/rooms.cpp
@@ -356,7 +356,12 @@ bool OptionsMenu::updateInput() {
 void OptionsMenu::loadResources() {
 	Room::loadResources();
 	_lastSelectedObject = nullptr;
+	_currentSlideButton = nullptr;
 	_idleArm = getObjectByName("Brazo");
+}
+
+void OptionsMenu::clearLastSelectedObject() {
+	_lastSelectedObject = nullptr;
 }
 
 ConnectMenu::ConnectMenu(World *world, SeekableReadStream &stream)

--- a/engines/alcachofa/rooms.cpp
+++ b/engines/alcachofa/rooms.cpp
@@ -113,7 +113,7 @@ Room::Room(World *world, SeekableReadStream &stream, bool hasUselessByte)
 			stream.seek(objectEnd, SEEK_SET);
 		}
 		else if (stream.pos() > objectEnd) // this is probably not recoverable
-			error("Read past the object data (%u > %lld) in room %s", objectEnd, stream.pos(), _name.c_str());
+			error("Read past the object data (%u > %ld) in room %s", objectEnd, stream.pos(), _name.c_str());
 
 		if (object != nullptr)
 			_objects.push_back(object);

--- a/engines/alcachofa/rooms.cpp
+++ b/engines/alcachofa/rooms.cpp
@@ -332,6 +332,33 @@ OptionsMenu::OptionsMenu(World *world, SeekableReadStream &stream)
 	: Room(world, stream, true) {
 }
 
+bool OptionsMenu::updateInput() {
+	if (!Room::updateInput())
+		return false;
+
+	auto currentSelectedObject = g_engine->player().selectedObject();
+	if (currentSelectedObject == nullptr) {
+		if (_lastSelectedObject == nullptr) {
+			if (_idleArm != nullptr)
+				_idleArm->toggle(true);
+			return true;
+		}
+
+		_lastSelectedObject->markSelected();
+	}
+	else
+		_lastSelectedObject = currentSelectedObject;
+	if (_idleArm != nullptr)
+		_idleArm->toggle(false);
+	return true;
+}
+
+void OptionsMenu::loadResources() {
+	Room::loadResources();
+	_lastSelectedObject = nullptr;
+	_idleArm = getObjectByName("Brazo");
+}
+
 ConnectMenu::ConnectMenu(World *world, SeekableReadStream &stream)
 	: Room(world, stream, true) {
 }

--- a/engines/alcachofa/rooms.cpp
+++ b/engines/alcachofa/rooms.cpp
@@ -113,7 +113,7 @@ Room::Room(World *world, SeekableReadStream &stream, bool hasUselessByte)
 			stream.seek(objectEnd, SEEK_SET);
 		}
 		else if (stream.pos() > objectEnd) // this is probably not recoverable
-			error("Read past the object data (%u > %dll) in room %s", objectEnd, stream.pos(), _name.c_str());
+			error("Read past the object data (%u > %lld) in room %s", objectEnd, stream.pos(), _name.c_str());
 
 		if (object != nullptr)
 			_objects.push_back(object);
@@ -388,8 +388,8 @@ bool Inventory::updateInput() {
 		player.drawCursor(0);
 
 	if (hoveredItem != nullptr && !player.activeCharacter()->isBusy()) {
-		if (input.wasMouseLeftPressed() && player.heldItem() == nullptr ||
-			input.wasMouseLeftReleased() && player.heldItem() != nullptr ||
+		if ((input.wasMouseLeftPressed() && player.heldItem() == nullptr) ||
+			(input.wasMouseLeftReleased() && player.heldItem() != nullptr) ||
 			input.wasMouseRightReleased()) {
 			hoveredItem->trigger();
 			player.pressedObject() = nullptr;

--- a/engines/alcachofa/rooms.cpp
+++ b/engines/alcachofa/rooms.cpp
@@ -790,7 +790,8 @@ void World::loadDialogLines() {
 			dialogLineEnd--;
 
 		if (cursor >= dialogLineEnd) {
-			g_engine->game().invalidDialogLine(_dialogLines.size());
+			if (cursor > dialogLineEnd)
+				g_engine->game().invalidDialogLine(_dialogLines.size());
 			cursor = lineStart; // store an empty string
 			dialogLineEnd = lineStart + 1;
 		}

--- a/engines/alcachofa/rooms.cpp
+++ b/engines/alcachofa/rooms.cpp
@@ -402,8 +402,12 @@ bool Inventory::updateInput() {
 			-1, true, kWhite, -kForegroundOrderCount + 1);
 	}
 
+	const bool userWantsToCloseInventory =
+		closeInventoryTriggerBounds().contains(input.mousePos2D()) ||
+		input.wasMenuKeyPressed() ||
+		input.wasInventoryKeyPressed();
 	if (!player.activeCharacter()->isBusy() &&
-		closeInventoryTriggerBounds().contains(input.mousePos2D()))
+		userWantsToCloseInventory)
 		close();
 
 	if (!player.activeCharacter()->isBusy() &&

--- a/engines/alcachofa/rooms.cpp
+++ b/engines/alcachofa/rooms.cpp
@@ -558,6 +558,9 @@ MainCharacter &World::getOtherMainCharacterByKind(MainCharacterKind kind) const 
 }
 
 Room *World::getRoomByName(const char *name) const {
+	assert(name != nullptr);
+	if (*name == '\0')
+		return nullptr;
 	for (auto *room : _rooms) {
 		if (room->name().equalsIgnoreCase(name))
 			return room;
@@ -593,6 +596,9 @@ ObjectBase *World::getObjectByName(MainCharacterKind character, const char *name
 }
 
 ObjectBase *World::getObjectByNameFromAnyRoom(const char *name) const {
+	assert(name != nullptr);
+	if (*name == '\0')
+		return nullptr;
 	for (auto *room : _rooms) {
 		ObjectBase *result = room->getObjectByName(name);
 		if (result != nullptr)

--- a/engines/alcachofa/rooms.cpp
+++ b/engines/alcachofa/rooms.cpp
@@ -302,11 +302,10 @@ void Room::freeResources() {
 		object->freeResources();
 }
 
-void Room::serializeSave(Serializer &serializer) {
-	serializer.syncAsSByte(_musicId);
+void Room::syncGame(Serializer &serializer) {
 	serializer.syncAsSByte(_activeFloorI);
 	for (auto *object : _objects)
-		object->serializeSave(serializer);
+		object->syncGame(serializer);
 }
 
 void Room::toggleActiveFloor() {
@@ -758,6 +757,11 @@ void World::loadDialogLines() {
 		_dialogLines.push_back(firstQuote + 1);
 		lineStart = lineEnd + 1;
 	}
+}
+
+void World::syncGame(Serializer &s) {
+	for (Room *room : _rooms)
+		room->syncGame(s);
 }
 
 }

--- a/engines/alcachofa/rooms.cpp
+++ b/engines/alcachofa/rooms.cpp
@@ -31,8 +31,7 @@ using namespace Common;
 
 namespace Alcachofa {
 
-Room::Room(World *world, SeekableReadStream &stream) : Room(world, stream, false) {
-}
+Room::Room(World *world, SeekableReadStream &stream) : Room(world, stream, false) {}
 
 static ObjectBase *readRoomObject(Room *room, const String &type, ReadStream &stream) {
 	if (type == ObjectBase::kClassName)
@@ -100,19 +99,16 @@ Room::Room(World *world, SeekableReadStream &stream, bool hasUselessByte)
 		stream.readByte();
 
 	uint32 objectEnd = stream.readUint32LE();
-	while (objectEnd > 0)
-	{
+	while (objectEnd > 0) {
 		const auto type = readVarString(stream);
 		auto object = readRoomObject(this, type, stream);
 		if (object == nullptr) {
 			g_engine->game().unknownRoomObject(type);
 			stream.seek(objectEnd, SEEK_SET);
-		}
-		else if (stream.pos() < objectEnd) {
+		} else if (stream.pos() < objectEnd) {
 			g_engine->game().notEnoughObjectDataRead(_name.c_str(), stream.pos(), objectEnd);
 			stream.seek(objectEnd, SEEK_SET);
-		}
-		else if (stream.pos() > objectEnd) // this is probably not recoverable
+		} else if (stream.pos() > objectEnd) // this is probably not recoverable
 			error("Read past the object data (%u > %lld) in room %s", objectEnd, (long long int)stream.pos(), _name.c_str());
 
 		if (object != nullptr)
@@ -216,8 +212,7 @@ void Room::updateInteraction() {
 			player.activeCharacter()->walkToMouse();
 			g_engine->camera().setFollow(player.activeCharacter());
 		}
-	}
-	else {
+	} else {
 		player.selectedObject()->markSelected();
 		if (input.wasAnyMousePressed())
 			player.pressedObject() = player.selectedObject();
@@ -270,11 +265,9 @@ void Room::drawDebug() {
 
 	if (g_engine->console().showFloorEdges()) {
 		auto &camera = g_engine->camera();
-		for (uint polygonI = 0; polygonI < floor.polygonCount(); polygonI++)
-		{
+		for (uint polygonI = 0; polygonI < floor.polygonCount(); polygonI++) {
 			auto polygon = floor.at(polygonI);
-			for (uint pointI = 0; pointI < polygon._points.size(); pointI++)
-			{
+			for (uint pointI = 0; pointI < polygon._points.size(); pointI++) {
 				int32 targetI = floor.edgeTarget(polygonI, pointI);
 				if (targetI < 0)
 					continue;
@@ -328,8 +321,7 @@ ShapeObject *Room::getSelectedObject(ShapeObject *best) const {
 }
 
 OptionsMenu::OptionsMenu(World *world, SeekableReadStream &stream)
-	: Room(world, stream, true) {
-}
+	: Room(world, stream, true) {}
 
 bool OptionsMenu::updateInput() {
 	if (!Room::updateInput())
@@ -344,8 +336,7 @@ bool OptionsMenu::updateInput() {
 		}
 
 		_lastSelectedObject->markSelected();
-	}
-	else
+	} else
 		_lastSelectedObject = currentSelectedObject;
 	if (_idleArm != nullptr)
 		_idleArm->toggle(false);
@@ -364,16 +355,13 @@ void OptionsMenu::clearLastSelectedObject() {
 }
 
 ConnectMenu::ConnectMenu(World *world, SeekableReadStream &stream)
-	: Room(world, stream, true) {
-}
+	: Room(world, stream, true) {}
 
 ListenMenu::ListenMenu(World *world, SeekableReadStream &stream)
-	: Room(world, stream, true) {
-}
+	: Room(world, stream, true) {}
 
 Inventory::Inventory(World *world, SeekableReadStream &stream)
-	: Room(world, stream, true) {
-}
+	: Room(world, stream, true) {}
 
 Inventory::~Inventory() {
 	// No need to delete items, they are room objects and thus deleted in Room::~Room
@@ -545,8 +533,10 @@ World::~World() {
 
 MainCharacter &World::getMainCharacterByKind(MainCharacterKind kind) const {
 	switch (kind) {
-	case MainCharacterKind::Mortadelo: return *_mortadelo;
-	case MainCharacterKind::Filemon: return *_filemon;
+	case MainCharacterKind::Mortadelo:
+		return *_mortadelo;
+	case MainCharacterKind::Filemon:
+		return *_filemon;
 	default:
 		error("Invalid character kind given to getMainCharacterByKind");
 	}
@@ -554,8 +544,10 @@ MainCharacter &World::getMainCharacterByKind(MainCharacterKind kind) const {
 
 MainCharacter &World::getOtherMainCharacterByKind(MainCharacterKind kind) const {
 	switch (kind) {
-	case MainCharacterKind::Mortadelo: return *_filemon;
-	case MainCharacterKind::Filemon: return *_mortadelo;
+	case MainCharacterKind::Mortadelo:
+		return *_filemon;
+	case MainCharacterKind::Filemon:
+		return *_mortadelo;
 	default:
 		error("Invalid character kind given to getOtherMainCharacterByKind");
 	}
@@ -691,8 +683,7 @@ bool World::loadWorldFile(const char *path) {
 		if (file.pos() < roomEnd) {
 			g_engine->game().notEnoughRoomDataRead(path, file.pos(), roomEnd);
 			file.seek(roomEnd, SEEK_SET);
-		}
-		else if (file.pos() > roomEnd) // this surely is not recoverable
+		} else if (file.pos() > roomEnd) // this surely is not recoverable
 			error("Read past the room data for world %s", path);
 		roomEnd = file.readUint32LE();
 	}
@@ -770,7 +761,7 @@ void World::loadDialogLines() {
 	 * Name 123, "This is the dialog line\r\n
 	 *     Name     123   This is the dialog line    \r\n
 	 *
-	 * - The ID does not have to be correct, it is ignored by the original engine. 
+	 * - The ID does not have to be correct, it is ignored by the original engine.
 	 * - We only need the dialog line and insert null-terminators where appropriate.
 	 */
 	loadEncryptedFile("Textos/DIALOGOS.nkr", _dialogChunk);

--- a/engines/alcachofa/rooms.cpp
+++ b/engines/alcachofa/rooms.cpp
@@ -19,11 +19,11 @@
  *
  */
 
-#include "alcachofa.h"
-#include "rooms.h"
-#include "script.h"
-#include "global-ui.h"
-#include "menu.h"
+#include "alcachofa/alcachofa.h"
+#include "alcachofa/rooms.h"
+#include "alcachofa/script.h"
+#include "alcachofa/global-ui.h"
+#include "alcachofa/menu.h"
 
 #include "common/file.h"
 

--- a/engines/alcachofa/rooms.h
+++ b/engines/alcachofa/rooms.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef ROOMS_H
-#define ROOMS_H
+#ifndef ALCACHOFA_ROOMS_H
+#define ALCACHOFA_ROOMS_H
 
 #include "objects.h"
 
@@ -211,4 +211,4 @@ private:
 
 }
 
-#endif // ROOMS_H
+#endif // ALCACHOFA_ROOMS_H

--- a/engines/alcachofa/rooms.h
+++ b/engines/alcachofa/rooms.h
@@ -91,6 +91,13 @@ class OptionsMenu final : public Room {
 public:
 	static constexpr const char *kClassName = "CHabitacionMenuOpciones";
 	OptionsMenu(World *world, Common::SeekableReadStream &stream);
+
+	virtual bool updateInput() override;
+	virtual void loadResources() override;
+
+private:
+	ShapeObject *_lastSelectedObject = nullptr;
+	ObjectBase *_idleArm = nullptr;
 };
 
 class ConnectMenu final : public Room {

--- a/engines/alcachofa/rooms.h
+++ b/engines/alcachofa/rooms.h
@@ -59,7 +59,7 @@ public:
 	virtual bool updateInput();
 	virtual void loadResources();
 	virtual void freeResources();
-	virtual void serializeSave(Common::Serializer &serializer);
+	virtual void syncGame(Common::Serializer &serializer);
 	ObjectBase *getObjectByName(const char *name) const;
 	void toggleActiveFloor();
 	void debugPrint(bool withObjects) const;
@@ -183,6 +183,7 @@ public:
 	const char *getDialogLine(int32 dialogId) const;
 
 	void toggleObject(MainCharacterKind character, const char *objName, bool isEnabled);
+	void syncGame(Common::Serializer &s);
 
 private:
 	bool loadWorldFile(const char *path);

--- a/engines/alcachofa/rooms.h
+++ b/engines/alcachofa/rooms.h
@@ -22,7 +22,7 @@
 #ifndef ALCACHOFA_ROOMS_H
 #define ALCACHOFA_ROOMS_H
 
-#include "objects.h"
+#include "alcachofa/objects.h"
 
 namespace Alcachofa {
 

--- a/engines/alcachofa/rooms.h
+++ b/engines/alcachofa/rooms.h
@@ -95,9 +95,13 @@ public:
 	virtual bool updateInput() override;
 	virtual void loadResources() override;
 
+	void clearLastSelectedObject(); // to reset arm animation
+	inline SlideButton *&currentSlideButton() { return _currentSlideButton; }
+
 private:
 	ShapeObject *_lastSelectedObject = nullptr;
 	ObjectBase *_idleArm = nullptr;
+	SlideButton *_currentSlideButton;
 };
 
 class ConnectMenu final : public Room {

--- a/engines/alcachofa/rooms.h
+++ b/engines/alcachofa/rooms.h
@@ -92,8 +92,8 @@ public:
 	static constexpr const char *kClassName = "CHabitacionMenuOpciones";
 	OptionsMenu(World *world, Common::SeekableReadStream &stream);
 
-	virtual bool updateInput() override;
-	virtual void loadResources() override;
+	bool updateInput() override;
+	void loadResources() override;
 
 	void clearLastSelectedObject(); // to reset arm animation
 	inline SlideButton *&currentSlideButton() { return _currentSlideButton; }
@@ -120,9 +120,9 @@ class Inventory final : public Room {
 public:
 	static constexpr const char *kClassName = "CInventario";
 	Inventory(World *world, Common::SeekableReadStream &stream);
-	virtual ~Inventory() override;
+	~Inventory() override;
 
-	virtual bool updateInput() override;
+	bool updateInput() override;
 
 	void initItems();
 	void updateItemsByActiveCharacter();

--- a/engines/alcachofa/scheduler.cpp
+++ b/engines/alcachofa/scheduler.cpp
@@ -87,8 +87,7 @@ void Task::errorForUnexpectedObjectType(const ObjectBase *base) const {
 
 DelayTask::DelayTask(Process &process, uint32 millis)
 	: Task(process)
-	, _endTime(millis) {
-}
+	, _endTime(millis) {}
 
 DelayTask::DelayTask(Process &process, Serializer &s)
 	: Task(process) {
@@ -118,8 +117,7 @@ DECLARE_TASK(DelayTask)
 Process::Process(ProcessId pid, MainCharacterKind characterKind)
 	: _pid(pid)
 	, _character(characterKind)
-	, _name("Unnamed process") {
-}
+	, _name("Unnamed process") {}
 
 Process::Process(Serializer &s) {
 	syncGame(s);
@@ -138,7 +136,8 @@ TaskReturnType Process::run() {
 	while (!_tasks.empty()) {
 		TaskReturn ret = _tasks.top()->run();
 		switch (ret.type()) {
-		case TaskReturnType::Yield: return TaskReturnType::Yield;
+		case TaskReturnType::Yield:
+			return TaskReturnType::Yield;
 		case TaskReturnType::Waiting:
 			_tasks.push(ret.taskToWaitFor());
 			break;
@@ -158,10 +157,18 @@ void Process::debugPrint() {
 	auto *debugger = g_engine->getDebugger();
 	const char *characterName;
 	switch (_character) {
-	case MainCharacterKind::None: characterName = "    <none>"; break;
-	case MainCharacterKind::Filemon: characterName = " Filemon"; break;
-	case MainCharacterKind::Mortadelo: characterName = "Mortadelo"; break;
-	default: characterName = "<invalid>"; break;
+	case MainCharacterKind::None:
+		characterName = "    <none>";
+		break;
+	case MainCharacterKind::Filemon:
+		characterName = " Filemon";
+		break;
+	case MainCharacterKind::Mortadelo:
+		characterName = "Mortadelo";
+		break;
+	default:
+		characterName = "<invalid>";
+		break;
 	}
 	debugger->debugPrintf("pid: %3u char: %s ret: %2d \"%s\"\n", _pid, characterName, _lastReturnValue, _name.c_str());
 
@@ -200,8 +207,7 @@ void Process::syncGame(Serializer &s) {
 		assert(_tasks.empty());
 		for (uint i = 0; i < count; i++)
 			_tasks.push(readTask(*this, s));
-	}
-	else {
+	} else {
 		String taskName;
 		for (uint i = 0; i < count; i++) {
 			taskName = _tasks[i]->taskName();
@@ -363,8 +369,7 @@ void Scheduler::syncGame(Serializer &s) {
 		processes->reserve(count);
 		for (uint32 i = 0; i < count; i++)
 			processes->push_back(new Process(s));
-	}
-	else {
+	} else {
 		for (Process *process : *processes)
 			process->syncGame(s);
 	}

--- a/engines/alcachofa/scheduler.cpp
+++ b/engines/alcachofa/scheduler.cpp
@@ -19,11 +19,11 @@
  *
  */
 
-#include "scheduler.h"
+#include "alcachofa/scheduler.h"
 
 #include "common/system.h"
-#include "alcachofa.h"
-#include "menu.h"
+#include "alcachofa/alcachofa.h"
+#include "alcachofa/menu.h"
 
 using namespace Common;
 
@@ -173,7 +173,7 @@ void Process::debugPrint() {
 
 #define DEFINE_TASK(TaskName) \
 	extern Task *constructTask_##TaskName(Process &process, Serializer &s);
-#include "tasks.h"
+#include "alcachofa/tasks.h"
 
 static Task *readTask(Process &process, Serializer &s) {
 	assert(s.isLoading());
@@ -183,7 +183,7 @@ static Task *readTask(Process &process, Serializer &s) {
 #define DEFINE_TASK(TaskName) \
 	if (taskName == #TaskName) \
 		return constructTask_##TaskName(process, s);
-#include "tasks.h"
+#include "alcachofa/tasks.h"
 
 	error("Invalid task type in savestate: %s", taskName.c_str());
 }

--- a/engines/alcachofa/scheduler.cpp
+++ b/engines/alcachofa/scheduler.cpp
@@ -85,35 +85,6 @@ void Task::errorForUnexpectedObjectType(const ObjectBase *base) const {
 		base->name().c_str(), taskName(), base->typeName());
 }
 
-DelayTask::DelayTask(Process &process, uint32 millis)
-	: Task(process)
-	, _endTime(millis) {}
-
-DelayTask::DelayTask(Process &process, Serializer &s)
-	: Task(process) {
-	syncGame(s);
-}
-
-TaskReturn DelayTask::run() {
-	TASK_BEGIN;
-	_endTime += g_engine->getMillis();
-	while (g_engine->getMillis() < _endTime)
-		TASK_YIELD(1);
-	TASK_END;
-}
-
-void DelayTask::debugPrint() {
-	uint32 remaining = g_engine->getMillis() <= _endTime ? _endTime - g_engine->getMillis() : 0;
-	g_engine->getDebugger()->debugPrintf("Delay for further %ums\n", remaining);
-}
-
-void DelayTask::syncGame(Serializer &s) {
-	Task::syncGame(s);
-	s.syncAsUint32LE(_endTime);
-}
-
-DECLARE_TASK(DelayTask)
-
 Process::Process(ProcessId pid, MainCharacterKind characterKind)
 	: _pid(pid)
 	, _character(characterKind)

--- a/engines/alcachofa/scheduler.cpp
+++ b/engines/alcachofa/scheduler.cpp
@@ -79,6 +79,12 @@ void Task::syncObjectAsString(Serializer &s, ObjectBase *&object, bool optional)
 			objectName.c_str(), roomName.c_str(), taskName());
 }
 
+void Task::errorForUnexpectedObjectType(const ObjectBase *base) const {
+	// Implemented as separate function in order to access ObjectBase methods
+	error("Unexpected type of object %s in savestate for task %s (got a %s)",
+		base->name().c_str(), taskName(), base->typeName());
+}
+
 DelayTask::DelayTask(Process &process, uint32 millis)
 	: Task(process)
 	, _endTime(millis) {

--- a/engines/alcachofa/scheduler.cpp
+++ b/engines/alcachofa/scheduler.cpp
@@ -113,7 +113,7 @@ void DelayTask::syncGame(Serializer &s) {
 	s.syncAsUint32LE(_endTime);
 }
 
-DECLARE_TASK(DelayTask);
+DECLARE_TASK(DelayTask)
 
 Process::Process(ProcessId pid, MainCharacterKind characterKind)
 	: _pid(pid)

--- a/engines/alcachofa/scheduler.cpp
+++ b/engines/alcachofa/scheduler.cpp
@@ -62,14 +62,14 @@ DelayTask::DelayTask(Process &process, uint32 millis)
 
 TaskReturn DelayTask::run() {
 	TASK_BEGIN;
-	_endTime += g_system->getMillis();
-	while (g_system->getMillis() < _endTime)
+	_endTime += g_engine->getMillis();
+	while (g_engine->getMillis() < _endTime)
 		TASK_YIELD;
 	TASK_END;
 }
 
 void DelayTask::debugPrint() {
-	uint32 remaining = g_system->getMillis() <= _endTime ? _endTime - g_system->getMillis() : 0;
+	uint32 remaining = g_engine->getMillis() <= _endTime ? _endTime - g_engine->getMillis() : 0;
 	g_engine->getDebugger()->debugPrintf("Delay for further %ums\n", remaining);
 }
 

--- a/engines/alcachofa/scheduler.h
+++ b/engines/alcachofa/scheduler.h
@@ -113,6 +113,8 @@ private:
 	Process &_process;
 };
 
+// implemented in alcachofa.cpp to prevent a compiler warning when
+// the declaration of the construct function comes after the definition
 struct DelayTask : public Task {
 	DelayTask(Process &process, uint32 millis);
 	DelayTask(Process &process, Common::Serializer &s);

--- a/engines/alcachofa/scheduler.h
+++ b/engines/alcachofa/scheduler.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef SCHEDULER_H
-#define SCHEDULER_H
+#ifndef ALCACHOFA_SCHEDULER_H
+#define ALCACHOFA_SCHEDULER_H
 
 #include "common.h"
 
@@ -222,4 +222,4 @@ private:
 
 }
 
-#endif // SCHEDULER_H
+#endif // ALCACHOFA_SCHEDULER_H

--- a/engines/alcachofa/scheduler.h
+++ b/engines/alcachofa/scheduler.h
@@ -119,7 +119,7 @@ struct DelayTask : public Task {
 	TaskReturn run() override;
 	void debugPrint() override;
 	void syncGame(Common::Serializer &s) override;
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 private:
 	uint32 _endTime = 0;

--- a/engines/alcachofa/scheduler.h
+++ b/engines/alcachofa/scheduler.h
@@ -94,11 +94,11 @@ struct Task {
 protected:
 	Task *delay(uint32 millis);
 
-	void syncObjectAsString(Common::Serializer &s, ObjectBase *&object, bool optional = false);
+	void syncObjectAsString(Common::Serializer &s, ObjectBase *&object, bool optional = false) const;
 	template<class TObject>
-	void syncObjectAsString(Common::Serializer &s, TObject *&object, bool optional = false) {
+	void syncObjectAsString(Common::Serializer &s, TObject *&object, bool optional = false) const {
 		// We could add is_const and therefore true_type, false_type, integral_constant 
-		// or we could just use const_cast and promise that we won't modify
+		// or we could just use const_cast and promise that we won't modify the object itself
 		ObjectBase *base = const_cast<Common::remove_const_t<TObject> *>(object);
 		syncObjectAsString(s, base, optional);
 		object = dynamic_cast<TObject*>(base);
@@ -121,7 +121,7 @@ struct DelayTask : public Task {
 	virtual const char *taskName() const override;
 
 private:
-	uint32 _endTime;
+	uint32 _endTime = 0;
 };
 
 #define DECLARE_TASK(TaskName) \

--- a/engines/alcachofa/scheduler.h
+++ b/engines/alcachofa/scheduler.h
@@ -101,7 +101,7 @@ protected:
 		// or we could just use const_cast and promise that we won't modify the object itself
 		ObjectBase *base = const_cast<Common::remove_const_t<TObject> *>(object);
 		syncObjectAsString(s, base, optional);
-		object = dynamic_cast<TObject*>(base);
+		object = dynamic_cast<TObject *>(base);
 		if (object == nullptr && base != nullptr)
 			errorForUnexpectedObjectType(base);
 	}

--- a/engines/alcachofa/scheduler.h
+++ b/engines/alcachofa/scheduler.h
@@ -103,12 +103,13 @@ protected:
 		syncObjectAsString(s, base, optional);
 		object = dynamic_cast<TObject*>(base);
 		if (object == nullptr && base != nullptr)
-			error("Unexpected type of object %s in savestate for task %s (got a %s)",
-				base->name().c_str(), taskName(), base->typeName());
+			errorForUnexpectedObjectType(base);
 	}
 
 	uint32 _stage = 0;
 private:
+	void errorForUnexpectedObjectType(const ObjectBase *base) const;
+
 	Process &_process;
 };
 
@@ -132,19 +133,12 @@ private:
 		return #TaskName; \
 	}
 
-#if __cplusplus >= 201703L
-#define TASK_BREAK_FALLTHROUGH [[fallthrough]];
-#else
-#define TASK_BREAK_FALLTHROUGH
-#endif
-
 #define TASK_BEGIN \
 	switch(_stage) { \
 	case 0:; \
 
 #define TASK_END \
 	TASK_RETURN(0); \
-	TASK_BREAK_FALLTHROUGH \
 	default: assert(false && "Invalid line in task"); \
 	} return TaskReturn::finish(0)
 
@@ -152,7 +146,6 @@ private:
 	do { \
 		_stage = stage; \
 		return ret; \
-		TASK_BREAK_FALLTHROUGH \
 		case stage:; \
 	} while(0)
 
@@ -161,8 +154,8 @@ private:
 
 #define TASK_RETURN(value) \
 	do { \
-		return TaskReturn::finish(value); \
 		_stage = UINT_MAX; \
+		return TaskReturn::finish(value); \
 	} while(0)
 
 using ProcessId = uint32;

--- a/engines/alcachofa/scheduler.h
+++ b/engines/alcachofa/scheduler.h
@@ -132,7 +132,6 @@ private:
 		return #TaskName; \
 	}
 
-// TODO: This probably should be scummvm common
 #if __cplusplus >= 201703L
 #define TASK_BREAK_FALLTHROUGH [[fallthrough]];
 #else

--- a/engines/alcachofa/scheduler.h
+++ b/engines/alcachofa/scheduler.h
@@ -115,9 +115,9 @@ private:
 struct DelayTask : public Task {
 	DelayTask(Process &process, uint32 millis);
 	DelayTask(Process &process, Common::Serializer &s);
-	virtual TaskReturn run() override;
-	virtual void debugPrint() override;
-	virtual void syncGame(Common::Serializer &s) override;
+	TaskReturn run() override;
+	void debugPrint() override;
+	void syncGame(Common::Serializer &s) override;
 	virtual const char *taskName() const override;
 
 private:

--- a/engines/alcachofa/scheduler.h
+++ b/engines/alcachofa/scheduler.h
@@ -22,7 +22,7 @@
 #ifndef ALCACHOFA_SCHEDULER_H
 #define ALCACHOFA_SCHEDULER_H
 
-#include "common.h"
+#include "alcachofa/common.h"
 
 #include "common/stack.h"
 #include "common/str.h"

--- a/engines/alcachofa/script-debug.h
+++ b/engines/alcachofa/script-debug.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef SCRIPT_DEBUG_H
-#define SCRIPT_DEBUG_H
+#ifndef ALCACHOFA_SCRIPT_DEBUG_H
+#define ALCACHOFA_SCRIPT_DEBUG_H
 
 namespace Alcachofa {
 
@@ -127,4 +127,4 @@ static const char *const KernelCallNames[] = {
 
 }
 
-#endif // SCRIPT_DEBUG_H
+#endif // ALCACHOFA_SCRIPT_DEBUG_H

--- a/engines/alcachofa/script.cpp
+++ b/engines/alcachofa/script.cpp
@@ -804,7 +804,7 @@ private:
 			}
 			return TaskReturn::finish(1);
 
-		// Camera tasks
+			// Camera tasks
 		case ScriptKernelTask::WaitCamStopping:
 			return TaskReturn::waitFor(g_engine->camera().waitToStop(process()));
 		case ScriptKernelTask::CamFollow:

--- a/engines/alcachofa/script.cpp
+++ b/engines/alcachofa/script.cpp
@@ -393,7 +393,7 @@ struct ScriptTask : public Task {
 		bool hasLock = !_lock.isReleased();
 		s.syncAsByte(hasLock);
 		if (s.isLoading() && hasLock)
-			_lock = FakeLock(g_engine->player().semaphoreFor(process().character()));
+			_lock = FakeLock("script", g_engine->player().semaphoreFor(process().character()));
 	}
 
 	virtual const char *taskName() const override;
@@ -593,7 +593,7 @@ private:
 			}
 			process().character() = MainCharacterKind::None;
 			assert(player.semaphore().isReleased());
-			_lock = { player.semaphore() };
+			_lock = FakeLock("script", player.semaphore());
 			return TaskReturn::finish(1);
 		}
 		case ScriptKernelTask::ChangeRoom:
@@ -967,7 +967,7 @@ Process *Script::createProcess(MainCharacterKind character, const String &proced
 	}
 	FakeLock lock;
 	if (!(flags & ScriptFlags::IsBackground))
-		lock = FakeLock(g_engine->player().semaphoreFor(character));
+		lock = FakeLock("script", g_engine->player().semaphoreFor(character));
 	Process *process = g_engine->scheduler().createProcess<ScriptTask>(character, procedure, offset, Common::move(lock));
 	process->name() = procedure;
 	return process;

--- a/engines/alcachofa/script.cpp
+++ b/engines/alcachofa/script.cpp
@@ -19,11 +19,11 @@
  *
  */
 
-#include "script.h"
-#include "rooms.h"
-#include "global-ui.h"
-#include "alcachofa.h"
-#include "script-debug.h"
+#include "alcachofa/script.h"
+#include "alcachofa/rooms.h"
+#include "alcachofa/global-ui.h"
+#include "alcachofa/alcachofa.h"
+#include "alcachofa/script-debug.h"
 
 #include "common/file.h"
 

--- a/engines/alcachofa/script.cpp
+++ b/engines/alcachofa/script.cpp
@@ -168,7 +168,7 @@ struct ScriptTimerTask : public Task {
 		s.syncAsSint32LE(_result);
 	}
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 private:
 	int32 _durationSec = 0;
@@ -367,7 +367,7 @@ struct ScriptTask : public Task {
 		}
 	}
 
-	virtual void debugPrint() {
+	void debugPrint() override {
 		g_engine->getDebugger()->debugPrintf("\"%s\" at %u\n", _name.c_str(), _pc);
 	}
 
@@ -396,7 +396,7 @@ struct ScriptTask : public Task {
 			_lock = FakeLock("script", g_engine->player().semaphoreFor(process().character()));
 	}
 
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 
 private:
 	void setCharacterVariables() {

--- a/engines/alcachofa/script.cpp
+++ b/engines/alcachofa/script.cpp
@@ -597,11 +597,11 @@ private:
 			return TaskReturn::finish(1);
 		}
 		case ScriptKernelTask::ChangeRoom:
-			if (strcmpi(getStringArg(0), "SALIR") == 0) {
+			if (scumm_stricmp(getStringArg(0), "SALIR") == 0) {
 				g_engine->quitGame();
 				g_engine->player().changeRoom("SALIR", true);
 			}
-			else if (strcmpi(getStringArg(0), "MENUPRINCIPALINICIO") == 0)
+			else if (scumm_stricmp(getStringArg(0), "MENUPRINCIPALINICIO") == 0)
 				warning("STUB: change room to MenuPrincipalInicio special case");
 			else {
 				auto targetRoom = g_engine->world().getRoomByName(getStringArg(0));

--- a/engines/alcachofa/script.cpp
+++ b/engines/alcachofa/script.cpp
@@ -920,7 +920,7 @@ void Script::updateCommonVariables() {
 		_scriptTimer = 0;
 
 	variable("EstanAmbos") = g_engine->world().mortadelo().room() == g_engine->world().filemon().room();
-	variable("textoson") = 1; // TODO: Add subtitle option
+	variable("textoson") = g_engine->config().subtitles() ? 1 : 0;
 	variable("modored") = 0; // this is signalling whether a network connection is established
 }
 

--- a/engines/alcachofa/script.cpp
+++ b/engines/alcachofa/script.cpp
@@ -174,7 +174,7 @@ private:
 	int32 _durationSec = 0;
 	int32 _result = 1;
 };
-DECLARE_TASK(ScriptTimerTask);
+DECLARE_TASK(ScriptTimerTask)
 
 enum class StackEntryType {
 	Number,
@@ -950,7 +950,7 @@ private:
 	bool _isFirstExecution = true;
 	FakeLock _lock;
 };
-DECLARE_TASK(ScriptTask);
+DECLARE_TASK(ScriptTask)
 
 Process *Script::createProcess(MainCharacterKind character, const String &behavior, const String &action, ScriptFlags flags) {
 	return createProcess(character, behavior + '/' + action, flags);

--- a/engines/alcachofa/script.cpp
+++ b/engines/alcachofa/script.cpp
@@ -133,7 +133,7 @@ struct ScriptTimerTask : public Task {
 		TASK_BEGIN;
 		{
 			uint32 timeSinceTimer = g_engine->script()._scriptTimer == 0 ? 0
-				: (g_system->getMillis() - g_engine->script()._scriptTimer) / 1000;
+				: (g_engine->getMillis() - g_engine->script()._scriptTimer) / 1000;
 			if (_durationSec >= (int32)timeSinceTimer)
 				_result = g_engine->script().variable("SeHaPulsadoRaton") ? 0 : 2;
 			else
@@ -914,7 +914,7 @@ void Script::updateCommonVariables() {
 
 	if (variable("CalcularTiempoSinPulsarRaton")) {
 		if (_scriptTimer == 0)
-			_scriptTimer = g_system->getMillis();
+			_scriptTimer = g_engine->getMillis();
 	}
 	else
 		_scriptTimer = 0;

--- a/engines/alcachofa/script.cpp
+++ b/engines/alcachofa/script.cpp
@@ -171,7 +171,7 @@ struct ScriptTimerTask : public Task {
 	virtual const char *taskName() const override;
 
 private:
-	int32 _durationSec;
+	int32 _durationSec = 0;
 	int32 _result = 1;
 };
 DECLARE_TASK(ScriptTimerTask);
@@ -392,7 +392,7 @@ struct ScriptTask : public Task {
 
 		bool hasLock = !_lock.isReleased();
 		s.syncAsByte(hasLock);
-		if (hasLock)
+		if (s.isLoading() && hasLock)
 			_lock = FakeLock(g_engine->player().semaphoreFor(process().character()));
 	}
 
@@ -945,7 +945,7 @@ private:
 	Script &_script;
 	Stack<StackEntry> _stack;
 	String _name;
-	uint32 _pc;
+	uint32 _pc = 0;
 	bool _returnsFromKernelCall = false;
 	bool _isFirstExecution = true;
 	FakeLock _lock;

--- a/engines/alcachofa/script.cpp
+++ b/engines/alcachofa/script.cpp
@@ -142,7 +142,7 @@ struct ScriptTimerTask : public Task {
 		syncGame(s);
 	}
 
-	virtual TaskReturn run() override {
+	TaskReturn run() override {
 		TASK_BEGIN;
 		{
 			uint32 timeSinceTimer = g_engine->script()._scriptTimer == 0 ? 0
@@ -158,7 +158,7 @@ struct ScriptTimerTask : public Task {
 		TASK_END;
 	}
 
-	virtual void debugPrint() override {
+	void debugPrint() override {
 		g_engine->getDebugger()->debugPrintf("Check input timer for %dsecs", _durationSec);
 	}
 
@@ -232,7 +232,7 @@ struct ScriptTask : public Task {
 		syncGame(s);
 	}
 
-	virtual TaskReturn run() override {
+	TaskReturn run() override {
 		if (_isFirstExecution || _returnsFromKernelCall)
 			setCharacterVariables();
 		if (_returnsFromKernelCall) {

--- a/engines/alcachofa/script.cpp
+++ b/engines/alcachofa/script.cpp
@@ -98,6 +98,14 @@ Script::Script() {
 		_instructions.push_back(ScriptInstruction(file));
 }
 
+static void syncAsSint32LE(Serializer &s, int32 &value) {
+	s.syncAsSint32LE(value);
+}
+
+void Script::syncGame(Serializer &s) {
+	s.syncArray(_variables.data(), _variables.size(), syncAsSint32LE);
+}
+
 int32 Script::variable(const char *name) const {
 	uint32 index;
 	if (_variableNames.tryGetVal(name, index))

--- a/engines/alcachofa/script.cpp
+++ b/engines/alcachofa/script.cpp
@@ -41,8 +41,7 @@ enum ScriptDebugLevel {
 
 ScriptInstruction::ScriptInstruction(ReadStream &stream)
 	: _op((ScriptOp)stream.readSint32LE())
-	, _arg(stream.readSint32LE()) {
-}
+	, _arg(stream.readSint32LE()) {}
 
 Script::Script() {
 	File file;
@@ -134,8 +133,7 @@ bool Script::hasProcedure(const Common::String &procedure) const {
 struct ScriptTimerTask : public Task {
 	ScriptTimerTask(Process &process, int32 durationSec)
 		: Task(process)
-		, _durationSec(durationSec) {
-	}
+		, _durationSec(durationSec) {}
 
 	ScriptTimerTask(Process &process, Serializer &s)
 		: Task(process) {
@@ -252,11 +250,21 @@ struct ScriptTask : public Task {
 				else {
 					const auto &top = _stack.top();
 					switch (top._type) {
-					case StackEntryType::Number: debug("Number %d", top._number); break;
-					case StackEntryType::Variable: debug("Var %u (%d)", top._index, _script._variables[top._index]); break;
-					case StackEntryType::Instruction: debug("Instr %u", top._index); break;
-					case StackEntryType::String: debug("String %u (\"%s\")", top._index, getStringArg(0)); break;
-					default: debug("INVALID"); break;
+					case StackEntryType::Number:
+						debug("Number %d", top._number);
+						break;
+					case StackEntryType::Variable:
+						debug("Var %u (%d)", top._index, _script._variables[top._index]);
+						break;
+					case StackEntryType::Instruction:
+						debug("Instr %u", top._index);
+						break;
+					case StackEntryType::String:
+						debug("String %u (\"%s\")", top._index, getStringArg(0));
+						break;
+					default:
+						debug("INVALID");
+						break;
 					}
 				}
 			}
@@ -298,8 +306,7 @@ struct ScriptTask : public Task {
 				if (kernelReturn.type() == TaskReturnType::Waiting) {
 					_returnsFromKernelCall = true;
 					return kernelReturn;
-				}
-				else
+				} else
 					handleReturnFromKernelCall(kernelReturn.returnValue());
 			}break;
 			case ScriptOp::JumpIfFalse:
@@ -363,6 +370,7 @@ struct ScriptTask : public Task {
 			}break;
 			default:
 				g_engine->game().unknownInstruction(instruction);
+				break;
 			}
 		}
 	}
@@ -384,8 +392,7 @@ struct ScriptTask : public Task {
 		if (s.isLoading()) {
 			for (uint i = 0; i < count; i++)
 				_stack.push(StackEntry(s));
-		}
-		else {
+		} else {
 			for (uint i = 0; i < count; i++)
 				_stack[i].syncGame(s);
 		}
@@ -600,8 +607,7 @@ private:
 			if (scumm_stricmp(getStringArg(0), "SALIR") == 0) {
 				g_engine->quitGame();
 				g_engine->player().changeRoom("SALIR", true);
-			}
-			else if (scumm_stricmp(getStringArg(0), "MENUPRINCIPALINICIO") == 0)
+			} else if (scumm_stricmp(getStringArg(0), "MENUPRINCIPALINICIO") == 0)
 				warning("STUB: change room to MenuPrincipalInicio special case");
 			else {
 				auto targetRoom = g_engine->world().getRoomByName(getStringArg(0));
@@ -624,8 +630,7 @@ private:
 			if (process().character() == MainCharacterKind::None) {
 				if (g_engine->player().currentRoom() != nullptr)
 					g_engine->player().currentRoom()->toggleActiveFloor();
-			}
-			else
+			} else
 				g_engine->world().getMainCharacterByKind(process().character()).room()->toggleActiveFloor();
 			return TaskReturn::finish(1);
 
@@ -646,8 +651,7 @@ private:
 				graphicObject->toggle(true);
 				graphicObject->graphic()->start(false);
 				return TaskReturn::finish(1);
-			}
-			else
+			} else
 				return TaskReturn::waitFor(graphicObject->animate(process()));
 		}
 
@@ -721,12 +725,10 @@ private:
 			}
 			float targetLodBias = getNumberArg(1) * 0.01f;
 			int32 durationMs = getNumberArg(2);
-			if (durationMs <= 0)
-			{
+			if (durationMs <= 0) {
 				character->lodBias() = targetLodBias;
 				return TaskReturn::finish(1);
-			}
-			else
+			} else
 				return TaskReturn::waitFor(character->lerpLodBias(process(), targetLodBias, durationMs));
 		}
 		case ScriptKernelTask::AnimateCharacter: {
@@ -749,8 +751,7 @@ private:
 				return TaskReturn::finish(1);
 			}
 			ObjectBase *talkObject = getObjectArg(1);
-			if (talkObject == nullptr && *getStringArg(1) != '\0')
-			{
+			if (talkObject == nullptr && *getStringArg(1) != '\0') {
 				g_engine->game().unknownAnimateTalkingObject(getStringArg(1));
 				return TaskReturn::finish(1);
 			}
@@ -798,13 +799,19 @@ private:
 		}
 		case ScriptKernelTask::ClearInventory:
 			switch ((MainCharacterKind)getNumberArg(0)) {
-			case MainCharacterKind::Mortadelo: g_engine->world().mortadelo().clearInventory(); break;
-			case MainCharacterKind::Filemon: g_engine->world().filemon().clearInventory(); break;
-			default: g_engine->game().unknownClearInventoryTarget(getNumberArg(0)); break;
+			case MainCharacterKind::Mortadelo:
+				g_engine->world().mortadelo().clearInventory();
+				break;
+			case MainCharacterKind::Filemon:
+				g_engine->world().filemon().clearInventory();
+				break;
+			default:
+				g_engine->game().unknownClearInventoryTarget(getNumberArg(0));
+				break;
 			}
 			return TaskReturn::finish(1);
 
-			// Camera tasks
+		// Camera tasks
 		case ScriptKernelTask::WaitCamStopping:
 			return TaskReturn::waitFor(g_engine->camera().waitToStop(process()));
 		case ScriptKernelTask::CamFollow:
@@ -980,8 +987,7 @@ void Script::updateCommonVariables() {
 	if (variable("CalcularTiempoSinPulsarRaton")) {
 		if (_scriptTimer == 0)
 			_scriptTimer = g_engine->getMillis();
-	}
-	else
+	} else
 		_scriptTimer = 0;
 
 	variable("EstanAmbos") = g_engine->world().mortadelo().room() == g_engine->world().filemon().room();

--- a/engines/alcachofa/script.h
+++ b/engines/alcachofa/script.h
@@ -156,6 +156,7 @@ class Script {
 public:
 	Script();
 
+	void syncGame(Common::Serializer &s);
 	void updateCommonVariables();
 	int32 variable(const char *name) const;
 	int32 &variable(const char *name);

--- a/engines/alcachofa/script.h
+++ b/engines/alcachofa/script.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef SCRIPT_H
-#define SCRIPT_H
+#ifndef ALCACHOFA_SCRIPT_H
+#define ALCACHOFA_SCRIPT_H
 
 #include "common.h"
 
@@ -190,4 +190,4 @@ private:
 
 }
 
-#endif // SCRIPT_H
+#endif // ALCACHOFA_SCRIPT_H

--- a/engines/alcachofa/script.h
+++ b/engines/alcachofa/script.h
@@ -22,7 +22,7 @@
 #ifndef ALCACHOFA_SCRIPT_H
 #define ALCACHOFA_SCRIPT_H
 
-#include "common.h"
+#include "alcachofa/common.h"
 
 #include "common/hashmap.h"
 #include "common/span.h"

--- a/engines/alcachofa/shape.cpp
+++ b/engines/alcachofa/shape.cpp
@@ -31,7 +31,7 @@ static int sideOfLine(Point a, Point b, Point q) {
 }
 
 static bool lineIntersects(Point a1, Point b1, Point a2, Point b2) {
-	return (sideOfLine(a1, b1, a2) > 0) != (sideOfLine(a1, b1, b2) > 0); 
+	return (sideOfLine(a1, b1, a2) > 0) != (sideOfLine(a1, b1, b2) > 0);
 }
 
 static bool segmentsIntersect(Point a1, Point b1, Point a2, Point b2) {
@@ -43,8 +43,7 @@ static bool segmentsIntersect(Point a1, Point b1, Point a2, Point b2) {
 			return lineIntersects(b1, a1, b2, a2) && lineIntersects(b2, a2, b1, a1);
 		else
 			return lineIntersects(a1, b1, b2, a2) && lineIntersects(b2, a2, a1, b1);
-	}
-	else {
+	} else {
 		if (a1.x > b1.x)
 			return lineIntersects(b1, a1, a2, b2) && lineIntersects(a2, b2, b1, a1);
 		else
@@ -67,9 +66,12 @@ EdgeDistances::EdgeDistances(Point edgeA, Point edgeB, Point query) {
 
 bool Polygon::contains(Point query) const {
 	switch (_points.size()) {
-	case 0: return false;
-	case 1: return query == _points[0];
-	case 2: return edgeDistances(0, query)._toEdge < 2.0f;
+	case 0:
+		return false;
+	case 1:
+		return query == _points[0];
+	case 2:
+		return edgeDistances(0, query)._toEdge < 2.0f;
 	default:
 		// we assume that the polygon is convex
 		for (uint i = 1; i < _points.size(); i++) {
@@ -108,23 +110,18 @@ Point Polygon::closestPointTo(Point query, float &distanceSqr) const {
 	assert(_points.size() > 0);
 	Common::Point bestPoint = {};
 	distanceSqr = std::numeric_limits<float>::infinity();
-	for (uint i = 0; i < _points.size(); i++)
-	{
+	for (uint i = 0; i < _points.size(); i++) {
 		auto edgeDists = edgeDistances(i, query);
-		if (edgeDists._onEdge < 0.0f)
-		{
+		if (edgeDists._onEdge < 0.0f) {
 			float pointDistSqr = as2D(query - _points[i]).getSquareMagnitude();
-			if (pointDistSqr < distanceSqr)
-			{
+			if (pointDistSqr < distanceSqr) {
 				bestPoint = _points[i];
 				distanceSqr = pointDistSqr;
 			}
 		}
-		if (edgeDists._onEdge >= 0.0f && edgeDists._onEdge <= edgeDists._edgeLength)
-		{
+		if (edgeDists._onEdge >= 0.0f && edgeDists._onEdge <= edgeDists._edgeLength) {
 			float edgeDistSqr = powf(edgeDists._toEdge, 2.0f);
-			if (edgeDistSqr < distanceSqr)
-			{
+			if (edgeDistSqr < distanceSqr) {
 				distanceSqr = edgeDistSqr;
 				uint j = (i + 1) % _points.size();
 				bestPoint = _points[i] + (_points[j] - _points[i]) * (edgeDists._onEdge / edgeDists._edgeLength);
@@ -164,9 +161,12 @@ static float depthAtForConvex(const PathFindingPolygon &p, Point q) {
 float PathFindingPolygon::depthAt(Point query) const {
 	switch (_points.size()) {
 	case 0:
-	case 1: return 1.0f;
-	case 2: return depthAtForLine(_points[0], _points[1], query, _pointDepths[0], _pointDepths[1]);
-	default: return depthAtForConvex(*this, query);
+	case 1:
+		return 1.0f;
+	case 2:
+		return depthAtForLine(_points[0], _points[1], query, _pointDepths[0], _pointDepths[1]);
+	default:
+		return depthAtForConvex(*this, query);
 	}
 }
 
@@ -238,10 +238,14 @@ static Color colorAtForConvex(const FloorColorPolygon &p, Point query) {
 
 Color FloorColorPolygon::colorAt(Point query) const {
 	switch (_points.size()) {
-	case 0: return kWhite;
-	case 1: return { 255, 255, 255, _pointColors[0].a };
-	case 2: return colorAtForLine(_points[0], _points[1], query, _pointColors[0], _pointColors[1]);
-	default: return colorAtForConvex(*this, query);
+	case 0:
+		return kWhite;
+	case 1:
+		return { 255, 255, 255, _pointColors[0].a };
+	case 2:
+		return colorAtForLine(_points[0], _points[1], query, _pointColors[0], _pointColors[1]);
+	default:
+		return colorAtForConvex(*this, query);
 	}
 }
 
@@ -310,12 +314,10 @@ Point Shape::closestPointTo(Point query, int32 &polygonI) const {
 	assert(_polygons.size() > 0);
 	float bestDistanceSqr = std::numeric_limits<float>::infinity();
 	Point bestPoint = {};
-	for (uint i = 0; i < _polygons.size(); i++)
-	{
+	for (uint i = 0; i < _polygons.size(); i++) {
 		float curDistanceSqr = std::numeric_limits<float>::infinity();
 		Point curPoint = at(i).closestPointTo(query, curDistanceSqr);
-		if (curDistanceSqr < bestDistanceSqr)
-		{
+		if (curDistanceSqr < bestDistanceSqr) {
 			bestDistanceSqr = curDistanceSqr;
 			bestPoint = curPoint;
 			polygonI = (int32)i;
@@ -486,10 +488,10 @@ void PathFindingShape::initializeFloydWarshall() {
 }
 
 void PathFindingShape::calculateFloydWarshall() {
-	const auto distance = [&](uint a, uint b) -> uint& {
+	const auto distance = [&] (uint a, uint b) -> uint &{
 		return _distanceMatrix[a * _linkPoints.size() + b];
 	};
-	const auto previousTarget = [&](uint a, uint b) -> int32& {
+	const auto previousTarget = [&] (uint a, uint b) -> int32 &{
 		return _previousTarget[a * _linkPoints.size() + b];
 	};
 	for (uint over = 0; over < _linkPoints.size(); over++) {

--- a/engines/alcachofa/shape.cpp
+++ b/engines/alcachofa/shape.cpp
@@ -466,12 +466,12 @@ void PathFindingShape::initializeFloydWarshall() {
 	for (const auto &linkPolygon : _linkIndices) {
 		for (uint i = 0; i < 2 * kPointsPerPolygon; i++) {
 			LinkIndex linkFrom = linkPolygon._points[i / 2];
-			int32 linkFromI = i % 2 ? linkFrom.second : linkFrom.first;
+			int32 linkFromI = (i % 2) ? linkFrom.second : linkFrom.first;
 			if (linkFromI < 0)
 				continue;
 			for (uint j = i + 1; j < 2 * kPointsPerPolygon; j++) {
 				LinkIndex linkTo = linkPolygon._points[j / 2];
-				int32 linkToI = j % 2 ? linkTo.second : linkTo.first;
+				int32 linkToI = (j % 2) ? linkTo.second : linkTo.first;
 				if (linkToI >= 0) {
 					const int32 linkFromFullI = linkFromI * _linkPoints.size() + linkToI;
 					const int32 linkToFullI = linkToI * _linkPoints.size() + linkFromI;
@@ -571,14 +571,14 @@ void PathFindingShape::floydWarshallPath(
 	const auto &toIndices = _linkIndices[toContaining];
 	for (uint i = 0; i < 2 * kPointsPerPolygon; i++) {
 		const auto &curFromPoint = fromIndices._points[i / 2];
-		int32 curFromLink = i % 2 ? curFromPoint.second : curFromPoint.first;
+		int32 curFromLink = (i % 2) ? curFromPoint.second : curFromPoint.first;
 		if (curFromLink < 0)
 			continue;
 		uint curFromDistance = (uint)sqrtf(from.sqrDist(_linkPoints[curFromLink]) + 0.5f);
 
 		for (uint j = 0; j < 2 * kPointsPerPolygon; j++) {
 			const auto &curToPoint = toIndices._points[j / 2];
-			int32 curToLink = j % 2 ? curToPoint.second : curToPoint.first;
+			int32 curToLink = (j % 2) ? curToPoint.second : curToPoint.first;
 			if (curToLink < 0)
 				continue;
 			uint totalDistance =

--- a/engines/alcachofa/shape.cpp
+++ b/engines/alcachofa/shape.cpp
@@ -30,16 +30,14 @@ static int sideOfLine(Point a, Point b, Point q) {
 	return (b.x - a.x) * (q.y - a.y) - (b.y - a.y) * (q.x - a.x);
 }
 
+static bool lineIntersects(Point a1, Point b1, Point a2, Point b2) {
+	return (sideOfLine(a1, b1, a2) > 0) != (sideOfLine(a1, b1, b2) > 0); 
+}
+
 static bool segmentsIntersect(Point a1, Point b1, Point a2, Point b2) {
 	// as there are a number of special cases to consider,
 	// this method is a direct translation of the original engine
-	const auto sideOfLine = [](Point a, Point b, const Point q) {
-		return Alcachofa::sideOfLine(a, b, q) > 0;
-	};
-	const auto lineIntersects = [&](Point a1, Point b1, Point a2, Point b2) {
-		return sideOfLine(a1, b1, a2) != sideOfLine(a1, b1, b2);
-	};
-
+	// rather than using common Math:: code
 	if (a2.x > b2.x) {
 		if (a1.x > b1.x)
 			return lineIntersects(b1, a1, b2, a2) && lineIntersects(b2, a2, b1, a1);
@@ -250,9 +248,9 @@ Color FloorColorPolygon::colorAt(Point query) const {
 Shape::Shape() {}
 
 Shape::Shape(ReadStream &stream) {
-	auto complexity = stream.readByte();
+	byte complexity = stream.readByte();
 	uint8 pointsPerPolygon;
-	if (complexity < 0 || complexity > 3)
+	if (complexity > 3)
 		error("Invalid shape complexity %d", complexity);
 	else if (complexity == 3)
 		pointsPerPolygon = 0; // read in per polygon
@@ -346,10 +344,10 @@ PathFindingShape::PathFindingShape(ReadStream &stream) {
 	_pointDepths.reserve(polygonCount * kPointsPerPolygon);
 
 	for (int i = 0; i < polygonCount; i++) {
-		for (int j = 0; j < kPointsPerPolygon; j++)
+		for (uint j = 0; j < kPointsPerPolygon; j++)
 			_points.push_back(readPoint(stream));
 		_polygonOrders.push_back(stream.readSByte());
-		for (int j = 0; j < kPointsPerPolygon; j++)
+		for (uint j = 0; j < kPointsPerPolygon; j++)
 			_pointDepths.push_back(stream.readByte());
 
 		uint pointCount = addPolygon(kPointsPerPolygon);
@@ -636,16 +634,16 @@ FloorColorShape::FloorColorShape(ReadStream &stream) {
 	_pointColors.reserve(polygonCount * kPointsPerPolygon);
 
 	for (int i = 0; i < polygonCount; i++) {
-		for (int j = 0; j < kPointsPerPolygon; j++)
+		for (uint j = 0; j < kPointsPerPolygon; j++)
 			_points.push_back(readPoint(stream));
 
 		// For the colors the alpha channel is not used so we store the brightness into it instead
 		// Brightness is store 0-100, but we can scale it up here
 		int firstColorI = _pointColors.size();
 		_pointColors.resize(_pointColors.size() + kPointsPerPolygon);
-		for (int j = 0; j < kPointsPerPolygon; j++)
+		for (uint j = 0; j < kPointsPerPolygon; j++)
 			_pointColors[firstColorI + j].a = (uint8)MIN(255, stream.readByte() * 255 / 100);
-		for (int j = 0; j < kPointsPerPolygon; j++) {
+		for (uint j = 0; j < kPointsPerPolygon; j++) {
 			_pointColors[firstColorI + j].r = stream.readByte();
 			_pointColors[firstColorI + j].g = stream.readByte();
 			_pointColors[firstColorI + j].b = stream.readByte();

--- a/engines/alcachofa/shape.cpp
+++ b/engines/alcachofa/shape.cpp
@@ -19,7 +19,7 @@
  *
  */
 
-#include "shape.h"
+#include "alcachofa/shape.h"
 
 using namespace Common;
 using namespace Math;

--- a/engines/alcachofa/shape.h
+++ b/engines/alcachofa/shape.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef SHAPE_H
-#define SHAPE_H
+#ifndef ALCACHOFA_SHAPE_H
+#define ALCACHOFA_SHAPE_H
 
 #include "common/stream.h"
 #include "common/array.h"
@@ -255,4 +255,4 @@ private:
 
 }
 
-#endif // SHAPE_H
+#endif // ALCACHOFA_SHAPE_H

--- a/engines/alcachofa/shape.h
+++ b/engines/alcachofa/shape.h
@@ -30,7 +30,7 @@
 #include "common/util.h"
 #include "math/vector2d.h"
 
-#include "common.h"
+#include "alcachofa/common.h"
 
 namespace Alcachofa {
 

--- a/engines/alcachofa/sounds.cpp
+++ b/engines/alcachofa/sounds.cpp
@@ -183,8 +183,8 @@ SoundHandle Sounds::playSoundInternal(const char *fileName, byte volume, Mixer::
 	_mixer->playStream(type, &playback._handle, stream, -1, volume);
 	playback._type = type;
 	playback._inputRate = stream->getRate();
-	playback._samples = std::move(samples);
-	_playbacks.push_back(std::move(playback));
+	playback._samples = Common::move(samples);
+	_playbacks.push_back(Common::move(playback));
 	return playback._handle;
 }
 

--- a/engines/alcachofa/sounds.cpp
+++ b/engines/alcachofa/sounds.cpp
@@ -133,6 +133,15 @@ static AudioStream *openAudio(const char *fileName) {
 
 SoundHandle Sounds::playSoundInternal(const char *fileName, byte volume, Mixer::SoundType type) {
 	AudioStream *stream = openAudio(fileName);
+	if (stream == nullptr && (type == Mixer::kSpeechSoundType || type == Mixer::kMusicSoundType)) {
+		/* If voice files are missing, the player could still read the subtitle
+		 * For this we return infinite silent audio which the user has to skip
+		 * But only do this for speech as there is no skipping for sound effects
+		 * so those would live on forever and block up mixer channels
+		 * Music is fine as well as we clean up the music playack explicitly
+		 */
+		stream = makeSilentAudioStream(8000, false);
+	}
 	if (stream == nullptr)
 		return {};
 

--- a/engines/alcachofa/sounds.cpp
+++ b/engines/alcachofa/sounds.cpp
@@ -362,7 +362,7 @@ void PlaySoundTask::debugPrint() {
 	g_engine->console().debugPrintf("PlaySound %u\n", _soundHandle);
 }
 
-DECLARE_TASK(PlaySoundTask);
+DECLARE_TASK(PlaySoundTask)
 
 WaitForMusicTask::WaitForMusicTask(Process &process)
 	: Task(process)
@@ -385,6 +385,6 @@ void WaitForMusicTask::debugPrint() {
 	g_engine->console().debugPrintf("WaitForMusic\n");
 }
 
-DECLARE_TASK(WaitForMusicTask);
+DECLARE_TASK(WaitForMusicTask)
 
 }

--- a/engines/alcachofa/sounds.cpp
+++ b/engines/alcachofa/sounds.cpp
@@ -359,7 +359,8 @@ TaskReturn PlaySoundTask::run() {
 }
 
 void PlaySoundTask::debugPrint() {
-	g_engine->console().debugPrintf("PlaySound %u\n", _soundHandle);
+	// unfortunately SoundHandle is not castable to something we could display here safely
+	g_engine->console().debugPrintf("PlaySound\n");
 }
 
 DECLARE_TASK(PlaySoundTask)

--- a/engines/alcachofa/sounds.cpp
+++ b/engines/alcachofa/sounds.cpp
@@ -19,10 +19,10 @@
  *
  */
 
-#include "sounds.h"
-#include "rooms.h"
-#include "alcachofa.h"
-#include "detection.h"
+#include "alcachofa/sounds.h"
+#include "alcachofa/rooms.h"
+#include "alcachofa/alcachofa.h"
+#include "alcachofa/detection.h"
 
 #include "common/file.h"
 #include "common/substream.h"

--- a/engines/alcachofa/sounds.cpp
+++ b/engines/alcachofa/sounds.cpp
@@ -366,11 +366,11 @@ DECLARE_TASK(PlaySoundTask);
 
 WaitForMusicTask::WaitForMusicTask(Process &process)
 	: Task(process)
-	, _lock(g_engine->sounds().musicSemaphore()) {}
+	, _lock("wait-for-music", g_engine->sounds().musicSemaphore()) { }
 
 WaitForMusicTask::WaitForMusicTask(Process &process, Serializer &s)
 	: Task(process)
-	, _lock(g_engine->sounds().musicSemaphore()) {
+	, _lock("wait-for-music", g_engine->sounds().musicSemaphore()) {
 	syncGame(s);
 }
 

--- a/engines/alcachofa/sounds.cpp
+++ b/engines/alcachofa/sounds.cpp
@@ -41,7 +41,9 @@ void Sounds::Playback::fadeOut(uint32 duration) {
 	_fadeDuration = MAX<uint32>(duration, 1);
 }
 
-Sounds::Sounds() : _mixer(g_system->getMixer()) {
+Sounds::Sounds()
+	: _mixer(g_system->getMixer())
+	, _musicSemaphore("music") {
 	assert(_mixer != nullptr);
 }
 

--- a/engines/alcachofa/sounds.cpp
+++ b/engines/alcachofa/sounds.cpp
@@ -73,8 +73,7 @@ void Sounds::update() {
 			if (g_system->getMillis() >= playback._fadeStart + playback._fadeDuration) {
 				_mixer->stopHandle(playback._handle);
 				_playbacks.erase(_playbacks.begin() + i - 1);
-			}
-			else {
+			} else {
 				byte newVolume = (g_system->getMillis() - playback._fadeStart) * Mixer::kMaxChannelVolume / playback._fadeDuration;
 				_mixer->setChannelVolume(playback._handle, Mixer::kMaxChannelVolume - newVolume);
 			}
@@ -157,8 +156,7 @@ SoundHandle Sounds::playSoundInternal(const char *fileName, byte volume, Mixer::
 			if (sampleCount < 0)
 				samples.clear();
 			samples.resize((uint)sampleCount); // we might have gotten less samples
-		}
-		else {
+		} else {
 			// we did not, now it is getting inefficient
 			const int bufferSize = 2048;
 			int16 buffer[bufferSize];
@@ -345,8 +343,7 @@ Task *Sounds::waitForMusicToEnd(Process &process) {
 
 PlaySoundTask::PlaySoundTask(Process &process, SoundHandle SoundHandle)
 	: Task(process)
-	, _soundHandle(SoundHandle) {
-}
+	, _soundHandle(SoundHandle) {}
 
 PlaySoundTask::PlaySoundTask(Process &process, Serializer &s)
 	: Task(process)
@@ -358,12 +355,10 @@ PlaySoundTask::PlaySoundTask(Process &process, Serializer &s)
 
 TaskReturn PlaySoundTask::run() {
 	auto &sounds = g_engine->sounds();
-	if (sounds.isAlive(_soundHandle))
-	{
+	if (sounds.isAlive(_soundHandle)) {
 		sounds.setAppropriateVolume(_soundHandle, process().character(), nullptr);
 		return TaskReturn::yield();
-	}
-	else
+	} else
 		return TaskReturn::finish(1);
 }
 
@@ -376,7 +371,7 @@ DECLARE_TASK(PlaySoundTask)
 
 WaitForMusicTask::WaitForMusicTask(Process &process)
 	: Task(process)
-	, _lock("wait-for-music", g_engine->sounds().musicSemaphore()) { }
+	, _lock("wait-for-music", g_engine->sounds().musicSemaphore()) {}
 
 WaitForMusicTask::WaitForMusicTask(Process &process, Serializer &s)
 	: Task(process)

--- a/engines/alcachofa/sounds.h
+++ b/engines/alcachofa/sounds.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef SOUNDS_H
-#define SOUNDS_H
+#ifndef ALCACHOFA_SOUNDS_H
+#define ALCACHOFA_SOUNDS_H
 
 #include "scheduler.h"
 #include "audio/mixer.h"
@@ -105,4 +105,4 @@ private:
 
 }
 
-#endif // SOUNDS_H
+#endif // ALCACHOFA_SOUNDS_H

--- a/engines/alcachofa/sounds.h
+++ b/engines/alcachofa/sounds.h
@@ -88,7 +88,7 @@ struct PlaySoundTask final : public Task {
 	PlaySoundTask(Process &process, Common::Serializer &s);
 	TaskReturn run() override;
 	void debugPrint() override;
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 private:
 	SoundHandle _soundHandle;
 };
@@ -98,7 +98,7 @@ struct WaitForMusicTask final : public Task {
 	WaitForMusicTask(Process &process, Common::Serializer &s);
 	TaskReturn run() override;
 	void debugPrint() override;
-	virtual const char *taskName() const override;
+	const char *taskName() const override;
 private:
 	FakeLock _lock;
 };

--- a/engines/alcachofa/sounds.h
+++ b/engines/alcachofa/sounds.h
@@ -61,7 +61,7 @@ public:
 	inline FakeSemaphore &musicSemaphore() { return _musicSemaphore; }
 
 private:
-	struct Playback {;
+	struct Playback {
 		void fadeOut(uint32 duration);
 
 		Audio::SoundHandle _handle;

--- a/engines/alcachofa/sounds.h
+++ b/engines/alcachofa/sounds.h
@@ -29,28 +29,27 @@
 namespace Alcachofa {
 
 class Character;
+using ::Audio::SoundHandle;
 
-using SoundID = uint32;
-static constexpr SoundID kInvalidSoundID = 0;
 class Sounds {
 public:
 	Sounds();
 	~Sounds();
 
 	void update();
-	SoundID playVoice(const Common::String &fileName, byte volume = Audio::Mixer::kMaxChannelVolume);
-	SoundID playSFX(const Common::String &fileName, byte volume = Audio::Mixer::kMaxChannelVolume);
+	SoundHandle playVoice(const Common::String &fileName, byte volume = Audio::Mixer::kMaxChannelVolume);
+	SoundHandle playSFX(const Common::String &fileName, byte volume = Audio::Mixer::kMaxChannelVolume);
 	void stopAll();
 	void stopVoice();
 	void pauseAll(bool paused);
-	void fadeOut(SoundID id, uint32 duration);
+	void fadeOut(SoundHandle id, uint32 duration);
 	void fadeOutVoiceAndSFX(uint32 duration);
-	bool isAlive(SoundID id);
-	void setVolume(SoundID id, byte volume);
-	void setAppropriateVolume(SoundID id,
+	bool isAlive(SoundHandle id);
+	void setVolume(SoundHandle id, byte volume);
+	void setAppropriateVolume(SoundHandle id,
 		MainCharacterKind processCharacter,
 		Character *speakingCharacter);
-	bool isNoisy(SoundID id, float windowSize, float minDifferences); ///< used for lip-sync
+	bool isNoisy(SoundHandle id, float windowSize, float minDifferences); ///< used for lip-sync
 
 	void startMusic(int musicId);
 	void queueMusic(int musicId);
@@ -65,7 +64,6 @@ private:
 	struct Playback {;
 		void fadeOut(uint32 duration);
 
-		SoundID _id = 0;
 		Audio::SoundHandle _handle;
 		Audio::Mixer::SoundType _type = Audio::Mixer::SoundType::kPlainSoundType;
 		uint32 _fadeStart = 0,
@@ -73,25 +71,24 @@ private:
 		int _inputRate;
 		Common::Array<int16> _samples; ///< might not be filled, only voice samples are preloaded for lip-sync
 	};
-	Playback *getPlaybackById(SoundID id);
-	SoundID playSoundInternal(const char *fileName, byte volume, Audio::Mixer::SoundType type);
+	Playback *getPlaybackById(SoundHandle id);
+	SoundHandle playSoundInternal(const char *fileName, byte volume, Audio::Mixer::SoundType type);
 
 	Common::Array<Playback> _playbacks;
 	Audio::Mixer *_mixer;
-	SoundID _nextID = 1;
 
-	SoundID _musicSoundID = kInvalidSoundID; // we use another soundID to reuse fading
+	SoundHandle _musicSoundID = {}; // we use another soundID to reuse fading
 	bool _isMusicPlaying = false;
 	int _nextMusicID = -1;
 	FakeSemaphore _musicSemaphore;
 };
 
 struct PlaySoundTask final : public Task {
-	PlaySoundTask(Process &process, SoundID soundID);
+	PlaySoundTask(Process &process, SoundHandle soundHandle);
 	virtual TaskReturn run() override;
 	virtual void debugPrint() override;
 private:
-	SoundID _soundID;
+	SoundHandle _soundHandle;
 };
 
 struct WaitForMusicTask final : public Task {

--- a/engines/alcachofa/sounds.h
+++ b/engines/alcachofa/sounds.h
@@ -85,16 +85,20 @@ private:
 
 struct PlaySoundTask final : public Task {
 	PlaySoundTask(Process &process, SoundHandle soundHandle);
+	PlaySoundTask(Process &process, Common::Serializer &s);
 	virtual TaskReturn run() override;
 	virtual void debugPrint() override;
+	virtual const char *taskName() const override;
 private:
 	SoundHandle _soundHandle;
 };
 
 struct WaitForMusicTask final : public Task {
-	WaitForMusicTask(Process &process, FakeLock &&lock);
+	WaitForMusicTask(Process &process);
+	WaitForMusicTask(Process &process, Common::Serializer &s);
 	virtual TaskReturn run() override;
 	virtual void debugPrint() override;
+	virtual const char *taskName() const override;
 private:
 	FakeLock _lock;
 };

--- a/engines/alcachofa/sounds.h
+++ b/engines/alcachofa/sounds.h
@@ -22,7 +22,7 @@
 #ifndef ALCACHOFA_SOUNDS_H
 #define ALCACHOFA_SOUNDS_H
 
-#include "scheduler.h"
+#include "alcachofa/scheduler.h"
 #include "audio/mixer.h"
 #include "audio/audiostream.h"
 

--- a/engines/alcachofa/sounds.h
+++ b/engines/alcachofa/sounds.h
@@ -86,8 +86,8 @@ private:
 struct PlaySoundTask final : public Task {
 	PlaySoundTask(Process &process, SoundHandle soundHandle);
 	PlaySoundTask(Process &process, Common::Serializer &s);
-	virtual TaskReturn run() override;
-	virtual void debugPrint() override;
+	TaskReturn run() override;
+	void debugPrint() override;
 	virtual const char *taskName() const override;
 private:
 	SoundHandle _soundHandle;
@@ -96,8 +96,8 @@ private:
 struct WaitForMusicTask final : public Task {
 	WaitForMusicTask(Process &process);
 	WaitForMusicTask(Process &process, Common::Serializer &s);
-	virtual TaskReturn run() override;
-	virtual void debugPrint() override;
+	TaskReturn run() override;
+	void debugPrint() override;
 	virtual const char *taskName() const override;
 private:
 	FakeLock _lock;

--- a/engines/alcachofa/tasks.h
+++ b/engines/alcachofa/tasks.h
@@ -47,10 +47,13 @@ DEFINE_TASK(AnimateTask)
 DEFINE_TASK(CenterBottomTextTask)
 DEFINE_TASK(FadeTask)
 DEFINE_TASK(DoorTask)
-DEFINE_TASK(DelayTask)
 DEFINE_TASK(ScriptTimerTask)
 DEFINE_TASK(ScriptTask)
 DEFINE_TASK(PlaySoundTask)
 DEFINE_TASK(WaitForMusicTask)
+
+// this one is special as the implementation is in the same TU as the signature
+// which causes a warning on some pedantic compiler
+//DEFINE_TASK(DelayTask)  
 
 #undef DEFINE_TASK

--- a/engines/alcachofa/tasks.h
+++ b/engines/alcachofa/tasks.h
@@ -51,9 +51,6 @@ DEFINE_TASK(ScriptTimerTask)
 DEFINE_TASK(ScriptTask)
 DEFINE_TASK(PlaySoundTask)
 DEFINE_TASK(WaitForMusicTask)
-
-// this one is special as the implementation is in the same TU as the signature
-// which causes a warning on some pedantic compiler
-//DEFINE_TASK(DelayTask)  
+DEFINE_TASK(DelayTask)  
 
 #undef DEFINE_TASK

--- a/engines/alcachofa/tasks.h
+++ b/engines/alcachofa/tasks.h
@@ -1,0 +1,56 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/* The task loading works as follows:
+ *   - the task has a constructor MyPrivateTask(Process &, Serializer &)
+ *   - DECLARE_TASK implements a global function to call that constructor
+ *     void constructTask_MyPrivateTask(Process &, Serializer
+ *   - in Process::syncGame we first forward-declare that function
+ *   - we go through every task to compare task name and call the factory
+ */
+
+#ifndef DEFINE_TASK
+#define DEFINE_TASK(TaskName)
+#endif
+
+DEFINE_TASK(CamLerpPosTask);
+DEFINE_TASK(CamLerpScaleTask);
+DEFINE_TASK(CamLerpPosScaleTask);
+DEFINE_TASK(CamLerpRotationTask);
+DEFINE_TASK(CamShakeTask);
+DEFINE_TASK(CamWaitToStopTask);
+DEFINE_TASK(CamSetInactiveAttributeTask);
+DEFINE_TASK(SayTextTask);
+DEFINE_TASK(AnimateCharacterTask);
+DEFINE_TASK(LerpLodBiasTask);
+DEFINE_TASK(ArriveTask)
+DEFINE_TASK(DialogMenuTask)
+DEFINE_TASK(AnimateTask)
+DEFINE_TASK(CenterBottomTextTask)
+DEFINE_TASK(FadeTask)
+DEFINE_TASK(DoorTask)
+DEFINE_TASK(DelayTask)
+DEFINE_TASK(ScriptTimerTask)
+DEFINE_TASK(ScriptTask)
+DEFINE_TASK(PlaySoundTask)
+DEFINE_TASK(WaitForMusicTask)
+
+#undef DEFINE_TASK

--- a/engines/alcachofa/tasks.h
+++ b/engines/alcachofa/tasks.h
@@ -31,16 +31,16 @@
 #define DEFINE_TASK(TaskName)
 #endif
 
-DEFINE_TASK(CamLerpPosTask);
-DEFINE_TASK(CamLerpScaleTask);
-DEFINE_TASK(CamLerpPosScaleTask);
-DEFINE_TASK(CamLerpRotationTask);
-DEFINE_TASK(CamShakeTask);
-DEFINE_TASK(CamWaitToStopTask);
-DEFINE_TASK(CamSetInactiveAttributeTask);
-DEFINE_TASK(SayTextTask);
-DEFINE_TASK(AnimateCharacterTask);
-DEFINE_TASK(LerpLodBiasTask);
+DEFINE_TASK(CamLerpPosTask)
+DEFINE_TASK(CamLerpScaleTask)
+DEFINE_TASK(CamLerpPosScaleTask)
+DEFINE_TASK(CamLerpRotationTask)
+DEFINE_TASK(CamShakeTask)
+DEFINE_TASK(CamWaitToStopTask)
+DEFINE_TASK(CamSetInactiveAttributeTask)
+DEFINE_TASK(SayTextTask)
+DEFINE_TASK(AnimateCharacterTask)
+DEFINE_TASK(LerpLodBiasTask)
 DEFINE_TASK(ArriveTask)
 DEFINE_TASK(DialogMenuTask)
 DEFINE_TASK(AnimateTask)

--- a/engines/alcachofa/ui-objects.cpp
+++ b/engines/alcachofa/ui-objects.cpp
@@ -68,6 +68,7 @@ void MenuButton::update() {
 		return;
 	}
 
+	_interactionLock.release();
 	_triggerNextFrame = false;
 	_isClicked = false;
 	trigger();
@@ -90,7 +91,8 @@ void MenuButton::freeResources() {
 void MenuButton::onHoverUpdate() {}
 
 void MenuButton::onClick() {
-	if (_isInteractable) {
+	if (_isInteractable && _interactionLock.isReleased()) {
+		_interactionLock = g_engine->menu().interactionSemaphore();
 		_isClicked = true;
 		_triggerNextFrame = false;
 		_graphicClicked.start(false);

--- a/engines/alcachofa/ui-objects.cpp
+++ b/engines/alcachofa/ui-objects.cpp
@@ -38,8 +38,7 @@ MenuButton::MenuButton(Room *room, ReadStream &stream)
 	, _graphicNormal(stream)
 	, _graphicHovered(stream)
 	, _graphicClicked(stream)
-	, _graphicDisabled(stream) {
-}
+	, _graphicDisabled(stream) {}
 
 void MenuButton::draw() {
 	if (!isEnabled())
@@ -107,14 +106,12 @@ void MenuButton::trigger() {
 const char *InternetMenuButton::typeName() const { return "InternetMenuButton"; }
 
 InternetMenuButton::InternetMenuButton(Room *room, ReadStream &stream)
-	: MenuButton(room, stream) {
-}
+	: MenuButton(room, stream) {}
 
 const char *OptionsMenuButton::typeName() const { return "OptionsMenuButton"; }
 
 OptionsMenuButton::OptionsMenuButton(Room *room, ReadStream &stream)
-	: MenuButton(room, stream) {
-}
+	: MenuButton(room, stream) {}
 
 void OptionsMenuButton::update() {
 	MenuButton::update();
@@ -130,8 +127,7 @@ void OptionsMenuButton::trigger() {
 const char *MainMenuButton::typeName() const { return "MainMenuButton"; }
 
 MainMenuButton::MainMenuButton(Room *room, ReadStream &stream)
-	: MenuButton(room, stream) {
-}
+	: MenuButton(room, stream) {}
 
 void MainMenuButton::update() {
 	MenuButton::update();
@@ -152,8 +148,7 @@ PushButton::PushButton(Room *room, ReadStream &stream)
 	, _alwaysVisible(readBool(stream))
 	, _graphic1(stream)
 	, _graphic2(stream)
-	, _actionId(stream.readSint32LE()) {
-}
+	, _actionId(stream.readSint32LE()) {}
 
 const char *EditBox::typeName() const { return "EditBox"; }
 
@@ -166,8 +161,7 @@ EditBox::EditBox(Room *room, ReadStream &stream)
 	, i3(stream.readSint32LE())
 	, i4(stream.readSint32LE())
 	, i5(stream.readSint32LE())
-	, _fontId(stream.readSint32LE()) {
-}
+	, _fontId(stream.readSint32LE()) {}
 
 const char *CheckBox::typeName() const { return "CheckBox"; }
 
@@ -178,8 +172,7 @@ CheckBox::CheckBox(Room *room, ReadStream &stream)
 	, _graphicChecked(stream)
 	, _graphicHovered(stream)
 	, _graphicClicked(stream)
-	, _actionId(stream.readSint32LE()) {
-}
+	, _actionId(stream.readSint32LE()) {}
 
 void CheckBox::draw() {
 	if (!isEnabled())
@@ -251,8 +244,7 @@ SlideButton::SlideButton(Room *room, ReadStream &stream)
 	, _maxPos(Shape(stream).firstPoint())
 	, _graphicIdle(stream)
 	, _graphicHovered(stream)
-	, _graphicClicked(stream) {
-}
+	, _graphicClicked(stream) {}
 
 void SlideButton::draw() {
 	auto *optionsMenu = dynamic_cast<OptionsMenu *>(room());
@@ -277,14 +269,12 @@ void SlideButton::update() {
 			optionsMenu->currentSlideButton() = nullptr;
 			g_engine->menu().triggerOptionsValue((OptionsMenuValue)_valueId, _value);
 			update(); // to update the position
-		}
-		else {
+		} else {
 			int clippedMousePosY = CLIP(mousePos.y, _minPos.y, _maxPos.y);
 			_value = (_maxPos.y - clippedMousePosY) / (float)(_maxPos.y - _minPos.y);
 			_graphicClicked.topLeft() = Point((_minPos.x + _maxPos.x) / 2, clippedMousePosY);
 		}
-	}
-	else {
+	} else {
 		_graphicIdle.topLeft() = Point(
 			(_minPos.x + _maxPos.x) / 2,
 			(int16)(_maxPos.y - _value * (_maxPos.y - _minPos.y)));
@@ -322,8 +312,7 @@ const char *IRCWindow::typeName() const { return "IRCWindow"; }
 IRCWindow::IRCWindow(Room *room, ReadStream &stream)
 	: ObjectBase(room, stream)
 	, _p1(Shape(stream).firstPoint())
-	, _p2(Shape(stream).firstPoint()) {
-}
+	, _p2(Shape(stream).firstPoint()) {}
 
 const char *MessageBox::typeName() const { return "MessageBox"; }
 

--- a/engines/alcachofa/ui-objects.cpp
+++ b/engines/alcachofa/ui-objects.cpp
@@ -47,7 +47,7 @@ void MenuButton::draw() {
 	Graphic &graphic =
 		!_isInteractable ? _graphicDisabled
 		: _isClicked ? _graphicClicked
-		: _isHovered ? _graphicHovered
+		: wasSelected() ? _graphicHovered
 		: _graphicNormal;
 	graphic.update();
 	g_engine->drawQueue().add<AnimationDrawRequest>(graphic, true, BlendMode::AdditiveAlpha);
@@ -87,15 +87,7 @@ void MenuButton::freeResources() {
 	_graphicDisabled.freeResources();
 }
 
-void MenuButton::onHoverStart() {
-	PhysicalObject::onHoverStart();
-	_isHovered = true;
-}
-
-void MenuButton::onHoverEnd() {
-	PhysicalObject::onHoverEnd();
-	_isHovered = false;
-}
+void MenuButton::onHoverUpdate() {}
 
 void MenuButton::onClick() {
 	if (_isInteractable) {
@@ -194,7 +186,7 @@ void CheckBox::draw() {
 	baseGraphic.update();
 	g_engine->drawQueue().add<AnimationDrawRequest>(baseGraphic, true, BlendMode::AdditiveAlpha);
 
-	if (_isHovered) {
+	if (wasSelected()) {
 		Graphic &hoverGraphic = _wasClicked ? _graphicClicked : _graphicHovered;
 		hoverGraphic.update();
 		g_engine->drawQueue().add<AnimationDrawRequest>(hoverGraphic, true, BlendMode::AdditiveAlpha);
@@ -216,7 +208,7 @@ void CheckBox::update() {
 }
 
 void CheckBox::loadResources() {
-	_wasClicked = _isHovered = false;
+	_wasClicked = false;
 	_graphicUnchecked.loadResources();
 	_graphicChecked.loadResources();
 	_graphicHovered.loadResources();
@@ -230,15 +222,7 @@ void CheckBox::freeResources() {
 	_graphicClicked.freeResources();
 }
 
-void CheckBox::onHoverStart() {
-	PhysicalObject::onHoverStart();
-	_isHovered = true;
-}
-
-void CheckBox::onHoverEnd() {
-	PhysicalObject::onHoverEnd();
-	_isHovered = false;
-}
+void CheckBox::onHoverUpdate() {}
 
 void CheckBox::onClick() {
 	_wasClicked = true;

--- a/engines/alcachofa/ui-objects.cpp
+++ b/engines/alcachofa/ui-objects.cpp
@@ -19,12 +19,12 @@
  *
  */
 
-#include "alcachofa.h"
-#include "script.h"
-#include "global-ui.h"
-#include "menu.h"
-#include "objects.h"
-#include "rooms.h"
+#include "alcachofa/alcachofa.h"
+#include "alcachofa/script.h"
+#include "alcachofa/global-ui.h"
+#include "alcachofa/menu.h"
+#include "alcachofa/objects.h"
+#include "alcachofa/rooms.h"
 
 using namespace Common;
 

--- a/engines/alcachofa/ui-objects.cpp
+++ b/engines/alcachofa/ui-objects.cpp
@@ -20,12 +20,28 @@
  */
 
 #include "alcachofa.h"
+#include "script.h"
+#include "global-ui.h"
+#include "menu.h"
 #include "objects.h"
 #include "rooms.h"
 
 using namespace Common;
 
 namespace Alcachofa {
+
+enum class MainMenuAction : int32 {
+	ContinueGame = 0,
+	Save,
+	Load,
+	InternetMenu,
+	OptionsMenu,
+	Exit,
+	NextSave,
+	PrevSave,
+	NewGame,
+	AlsoExit // there seems to be no difference to Exit
+};
 
 const char *MenuButton::typeName() const { return "MenuButton"; }
 
@@ -123,6 +139,51 @@ const char *MainMenuButton::typeName() const { return "MainMenuButton"; }
 
 MainMenuButton::MainMenuButton(Room *room, ReadStream &stream)
 	: MenuButton(room, stream) {
+}
+
+void MainMenuButton::update() {
+	MenuButton::update();
+	const auto action = (MainMenuAction)actionId();
+	if (g_engine->input().wasMenuKeyPressed() &&
+		(action == MainMenuAction::ContinueGame || action == MainMenuAction::NewGame))
+		onClick();
+}
+
+void MainMenuButton::trigger() {
+	switch ((MainMenuAction)actionId()) {
+	case MainMenuAction::ContinueGame:
+		g_engine->menu().continueGame();
+		break;
+	case MainMenuAction::Save:
+		warning("STUB: MainMenuAction Save");
+		break;
+	case MainMenuAction::Load:
+		warning("STUB: MainMenuAction Load");
+		break;
+	case MainMenuAction::InternetMenu:
+		g_system->messageBox(LogMessageType::kWarning, "Multiplayer is not implemented in this ScummVM version.");
+		break;
+	case MainMenuAction::OptionsMenu:
+		//g_engine->menu().openOptionsMenu();
+		break;
+	case MainMenuAction::Exit:
+	case MainMenuAction::AlsoExit:
+		// implemented in AlcachofaEngine as it has its own event loop
+		g_engine->fadeExit();
+		break;
+	case MainMenuAction::NextSave:
+		warning("STUB: MainMenuAction NextSave");
+		break;
+	case MainMenuAction::PrevSave:
+		warning("STUB: MainMenuAction PrevSave");
+		break;
+	case MainMenuAction::NewGame:
+		g_engine->menu().newGame();
+		break;
+	default:
+		warning("Unknown main menu action: %d", actionId());
+		break;
+	}
 }
 
 const char *PushButton::typeName() const { return "PushButton"; }

--- a/engines/alcachofa/ui-objects.cpp
+++ b/engines/alcachofa/ui-objects.cpp
@@ -196,7 +196,7 @@ void CheckBox::draw() {
 void CheckBox::update() {
 	PhysicalObject::update();
 	if (_wasClicked) {
-		if (g_system->getMillis() - _clickTime > 500) {
+		if (g_engine->getMillis() - _clickTime > 500) {
 			_wasClicked = false;
 			trigger();
 		}
@@ -226,7 +226,7 @@ void CheckBox::onHoverUpdate() {}
 
 void CheckBox::onClick() {
 	_wasClicked = true;
-	_clickTime = g_system->getMillis();
+	_clickTime = g_engine->getMillis();
 }
 
 void CheckBox::trigger() {

--- a/engines/alcachofa/ui-objects.cpp
+++ b/engines/alcachofa/ui-objects.cpp
@@ -92,7 +92,7 @@ void MenuButton::onHoverUpdate() {}
 
 void MenuButton::onClick() {
 	if (_isInteractable && _interactionLock.isReleased()) {
-		_interactionLock = g_engine->menu().interactionSemaphore();
+		_interactionLock = FakeLock("button", g_engine->menu().interactionSemaphore());
 		_isClicked = true;
 		_triggerNextFrame = false;
 		_graphicClicked.start(false);


### PR DESCRIPTION
I briefly talked on the discord about working on this engine used for the Mort & Phil point&click-adventures and it is now in a stage where I could play through the game without many noticeable issues (tested on Windows 10 x64). I kept all variants as `ADGF_UNSTABLE` but if you agree that this warrants more public testing I will change it to `ADGF_TESTING`.
Speaking of variants, this engine currently supports:

  - "Clever & Smart: A Movie Adventure" (german cd release)
  - The demo of above
  - "Mortadelo y Filemón: Una Aventura de Cine - Edición Especial" (spanish steam release)
  -  "Mortadelo y Filemón: Una Aventura de Cine - Edición Especial" ("english" steam release, actually just the spanish version with english subtitles...)

I found images of a russian cd cover, but not much more on that front or other versions of this game. I have summarised the [other potential 9 games here](https://github.com/Helco/scummvm/issues/69).

### Areas worth discussing from my side

<details>
<summary>Video playback</summary>

1. **The MPEG PS playback is laggy.** <br/> Despite low cpu usage and a measured loop and `VideoDecoder::decodeNextFrame` framerate of the proper 25, the actual playback noticeably stutters even in Release builds while playing the video in Windows Media Player or VLC has no such problem. <br/> Additionally I converted the video files to Theora which play fine in ScummVM.
2. **AVI decoder** <br/>The steam releases were published with a single AVI video which fails to load in ScummVM with the output `WARNING: Failed to parse AVI header!`. <br/> A brief debugging showed that the `_tracks` array is empty.
3. **Missing WMV decoder** <br/> The german demo ends by playing the trailer to the full game. This trailer is a WMV file which I understand is not supported in ScummVM at this point.

Maybe a workaround would be to instruct users to convert the affected videos with ffmpeg to Theora and let the engine optionally look for those. 

</details>

<details>
<summary>Graphic modes</summary>

The original game was using D3D8 so translating to OpenGL was the easiest option. While I plan to implement a software renderer as well, the engine currently only supports platforms with classic OpenGL. TinyGL is no substitute here as there are several blend modes that require texture stages which are not supported in TinyGL.

For the software renderer these blend modes are also not implemented in common ScummVM code which means these would have to be custom written for this engine. In fact the engine already has such a function (graphics.cpp:209) as the ScummVM code does not blend the alpha channel alongside the color channels.

</details>

<details>
<summary>Savestate size</summary>

The current savestates are larger than they theoretically could be, reason being the thumbnail included twice (each ~85KiB uncompressed):
  - Once in PNG format 340x256 for the in-game menu (which is what the original engine used)
  - Once in THMB format 160x120 by the ScummVM extended savestates

If there is a good way to let ScummVM reuse the big thumbnail without replacing the ScummVM extended savestate system in the metaengine entirely, please let me know.
</details>

<details>
<summary>Code conventions</summary>

I tried to adhere to any code conventions set out by the wiki, nevertheless I might provoke some additions to the wiki, e.g. in relation to lambdas or the usage of `auto`. I will not choose to die on any hill here, the current code style represents what I consider readable. I am open to requested changes from you on that front.
</details>

I currently do not plan to implement the multiplayer mode of this engine, trying to open the menu will show a GUI dialog with an appropriate message.

~The only change outside of `engines/alcachofa` is the result of running `make updatepot` as instructed by the wiki.~ Apparently done by weblate these days.

I have some C# tools for working with the game files [in this repository](https://github.com/Helco/cus)

That being said I look forward to your review. If need be, I will be also available on the discord (same username) for any questions.