### PR TITLE
MOHAWK: Fix sound discontinuity.

### DIFF
--- a/engines/mohawk/dialogs.cpp
+++ b/engines/mohawk/dialogs.cpp
@@ -449,4 +449,33 @@ bool RivenOptionsWidget::save() {
 
 #endif
 
+MohawkDefaultOptionsWidget::MohawkDefaultOptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain) :
+	OptionsContainerWidget(boss, name, "MohawkEngineOptionsDialog", domain) {
+
+	_audioPopFixCheckbox = new GUI::CheckboxWidget(widgetsBoss(), "MohawkEngineOptionsDialog.AudioDiscontinuityFix",
+		_("Fix audio pops/clicks"),
+		_("Reduces audible pops at the end of some sound effects (Non Myst/Riven only)."));
+}
+
+MohawkDefaultOptionsWidget::~MohawkDefaultOptionsWidget() {
+}
+
+void MohawkDefaultOptionsWidget::defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const {
+	layouts.addDialog(layoutName, overlayedLayout)
+		.addLayout(GUI::ThemeLayout::kLayoutVertical)
+			.addPadding(0, 0, 0, 0)
+			.addWidget("AudioDiscontinuityFix", "Checkbox")
+		.closeLayout()
+	.closeDialog();
+}
+
+void MohawkDefaultOptionsWidget::load() {
+	_audioPopFixCheckbox->setState(ConfMan.getBool("fix_audio_pops", _domain));
+}
+
+bool MohawkDefaultOptionsWidget::save() {
+	ConfMan.setBool("fix_audio_pops", _audioPopFixCheckbox->getState(), _domain);
+	return true;
+}
+
 } // End of namespace Mohawk

--- a/engines/mohawk/dialogs.h
+++ b/engines/mohawk/dialogs.h
@@ -143,6 +143,22 @@ private:
 
 #endif
 
+class MohawkDefaultOptionsWidget : public GUI::OptionsContainerWidget {
+public:
+	MohawkDefaultOptionsWidget(GuiObject *boss, const Common::String &name, const Common::String &domain);
+	~MohawkDefaultOptionsWidget() override;
+
+	// OptionsContainerWidget API
+	void load() override;
+	bool save() override;
+
+private:
+	// OptionsContainerWidget API
+	void defineLayout(GUI::ThemeEval &layouts, const Common::String &layoutName, const Common::String &overlayedLayout) const override;
+
+	GUI::CheckboxWidget *_audioPopFixCheckbox;
+};
+
 } // End of namespace Mohawk
 
 #endif

--- a/engines/mohawk/metaengine.cpp
+++ b/engines/mohawk/metaengine.cpp
@@ -334,6 +334,14 @@ void MohawkMetaEngine::registerDefaultSettings(const Common::String &target) con
 		return Mohawk::MohawkMetaEngine_Riven::registerDefaultSettings();
 	}
 
+	// Rest of the Mohawk games.
+	ConfMan.registerDefault("fix_audio_pops", true);
+
+	if (!ConfMan.hasKey("fix_audio_pops", target)) {
+		ConfMan.setBool("fix_audio_pops", true, target);
+		ConfMan.flushToDisk();
+	}
+
 	return MetaEngine::registerDefaultSettings(target);
 }
 
@@ -351,7 +359,7 @@ GUI::OptionsContainerWidget *MohawkMetaEngine::buildEngineOptionsWidget(GUI::Gui
 	}
 #endif
 
-	return MetaEngine::buildEngineOptionsWidget(boss, name, target);
+	return new Mohawk::MohawkDefaultOptionsWidget(boss, name, target);
 }
 
 #if PLUGIN_ENABLED_DYNAMIC(MOHAWK)

--- a/engines/mohawk/sound.cpp
+++ b/engines/mohawk/sound.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "common/debug.h"
+#include "common/config-manager.h"
 
 #include "audio/mididrv.h"
 #include "audio/midiparser.h"
@@ -198,7 +199,12 @@ Audio::RewindableAudioStream *makeMohawkWaveStream(Common::SeekableReadStream *s
 
 			// For unsigned 8-bit PCM, check for and fix a potential pop/click at the end of the sample.
 			if (dataChunk.encoding == kCodecRaw && dataChunk.bitsPerSample == 8 && dataChunk.sampleCount >= 4) {
-				scanAndFixAudioPops(dataChunk, dataSize, stream);
+				MohawkEngine *mohawkEngine = static_cast<MohawkEngine *>(g_engine);
+				const char *gameId = mohawkEngine->getGameId();
+				// Myst does not have pops and Riven does not have unsigned 8-bit PCM and so is ignored.
+				if (strcmp(gameId, "myst") != 0 && strcmp(gameId, "riven") != 0 && ConfMan.getBool("fix_audio_pops")) {
+					scanAndFixAudioPops(dataChunk, dataSize, stream);
+				}
 			}
 
 				// NOTE: We currently ignore all of the loop parameters here. Myst uses the


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
This addresses the popping noise heard near the end of certain 8-bit unsigned PCM sounds. This issue appears to be caused by sound discontinuity present in the original game assets.

To resolve this, this patch introduces a balanced heuristic to detect and prevent the artifact before the audio is passed to the mixer. The logic is applied within the ID_DATA chunk processing for raw 8-bit audio streams.

The heuristic works as follows:

1. It peeks at the last four samples of the audio stream.  
2. It then determines if the ending is "safe" by checking two paths:  
   * **Path 1: Sustained Quietness.** The ending is considered safe if all four samples are very close to the 8-bit unsigned silence value (0x80). This assumes any minor fluctuation is inaudible.  
   * **Path 2: Consistent Fade-Out.** If not quiet, the ending is still considered safe if the samples show a clear and consistent trend of fading towards silence.  
3. If the ending is neither stable nor fading consistently, the heuristic assumes a pop will occur. It then truncates the final sample by decrementing both the sampleCount and dataSize. If the sound is a loop, loopEnd is also updated to match the new sample count.

[Original.](https://0x0.st/s/2Y6ie2w06FLj1ltwyQ6dag/KrHz.mp4)
[After.](https://0x0.st/s/iXI395k0mDX3AT-8mnRCHg/KrHi.mp4)