### PR TITLE
AUDIO: Fix linking errors in some setups with older compilers

### DIFF
--- a/audio/adlib_ms.cpp
+++ b/audio/adlib_ms.cpp
@@ -23,6 +23,11 @@
 
 #include "common/debug.h"
 
+// The initialization of the static const integral data members is done in the class definition,
+// but we still need to provide a definition if they are odr-used (e.g. GCC 4.7 wants this).
+const uint8 MidiDriver_ADLIB_Multisource::OPL2_NUM_CHANNELS;
+const uint8 MidiDriver_ADLIB_Multisource::OPL3_NUM_CHANNELS;
+
 bool OplInstrumentOperatorDefinition::isEmpty() const {
 	return freqMultMisc == 0 && level == 0 && decayAttack == 0 &&
 		   releaseSustain == 0 && waveformSelect == 0;

--- a/audio/mt32gm.cpp
+++ b/audio/mt32gm.cpp
@@ -28,11 +28,13 @@
 #include "common/debug.h"
 
 // The initialization of the static const integral data members is done in the class definition,
-// but we still need to provide a definition if they are odr-used.
+// but we still need to provide a definition if they are odr-used (e.g. GCC 4.7 wants this).
 const uint8 MidiDriver_MT32GM::MT32_DEFAULT_CHANNEL_VOLUME;
 const uint8 MidiDriver_MT32GM::GM_DEFAULT_CHANNEL_VOLUME;
 const uint8 MidiDriver_MT32GM::MAXIMUM_MT32_ACTIVE_NOTES;
 const uint8 MidiDriver_MT32GM::MAXIMUM_GM_ACTIVE_NOTES;
+const uint8 MidiDriver_BASE::MT32_PITCH_BEND_SENSITIVITY_DEFAULT;
+const uint8 MidiDriver_BASE::GM_PITCH_BEND_SENSITIVITY_DEFAULT;
 
 // These are the power-on default instruments of the Roland MT-32 family.
 const byte MidiDriver_MT32GM::MT32_DEFAULT_INSTRUMENTS[8] = {


### PR DESCRIPTION
This one is a bit weird…

If one does a RISC OS build this way (note: it uses GCC 4.7):

```
$ ./devtools/docker.sh toolchains/riscos
# ./configure --disable-debug --disable-optimizations --disable-hq-scalers --disable-tinygl --disable-detection-full --disable-all-engines --enable-engine=plumbers --host=arm-unknown-riscos --enable-plugins --default-dynamic
# make -j$(nproc)
```

then you may get this linking error:

```
    LINK     scummvm,e1f
audio/libaudio.a(adlib_ms.o): In function `MidiDriver_ADLIB_Multisource::initOpl()':
adlib_ms.cpp:(.text+0x5a5c): undefined reference to `MidiDriver_ADLIB_Multisource::OPL2_NUM_CHANNELS'
adlib_ms.cpp:(.text+0x5a60): undefined reference to `MidiDriver_ADLIB_Multisource::OPL3_NUM_CHANNELS'
audio/libaudio.a(mt32gm.o): In function `MidiDriver_MT32GM::initControlData()':
mt32gm.cpp:(.text+0xde8): undefined reference to `MidiDriver_BASE::MT32_PITCH_BEND_SENSITIVITY_DEFAULT'
mt32gm.cpp:(.text+0xdec): undefined reference to `MidiDriver_BASE::GM_PITCH_BEND_SENSITIVITY_DEFAULT'
collect2: error: ld returned 1 exit status
make: *** [Makefile.common:132: scummvm,e1f] Error 1
```

(which, for some reason, doesn't show up in full builds, but…)

I remember hitting the same `adlib_ms.cpp` error with GCC 4.2.1, back when C++98 was still supported.

Anyway, commit 7027be781ba39dbe4aa28eec632670dcfb82eb5c fixed a similar thing, a few years ago, and the [comments on that commit page on GitHub](https://github.com/scummvm/scummvm/commit/7027be781ba39dbe4aa28eec632670dcfb82eb5c) describe a bit what's going on.

i.e. I guess it's a matter of GCC 4.7 not being fully C++11 compliant, back then.

But just in case there's something else going on, I made a PR for review.