### PR TITLE
GRAPHICS: Fix parameter documentation for BlendBlit

### DIFF
--- a/graphics/blit.h
+++ b/graphics/blit.h
@@ -385,8 +385,8 @@ public:
 	 * @param srcPitch source pitch
 	 * @param posX where src will be blitted to (onto dest)
 	 * @param posY where src will be blitted to (onto dest)
-	 * @param width width of the input surface
-	 * @param height height of the input surface
+	 * @param width width of the destination area
+	 * @param height height of the destination area
 	 * @param scaleX scale factor to use when blitting (src / dst) (0.5 for 2x scale) use BlendBlit::SCALE_THRESHOLD
 	 * @param scaleY scale factor to use when blitting (src / dst) (0.5 for 2x scale) use BlendBlit::SCALE_THRESHOLD
 	 * @param scaleXsrcOff since you can only offset the *src pointer to effectivly
@@ -413,8 +413,8 @@ public:
 	 * NOTE: Can only be used with BlendBlit::getSupportedPixelFormat format
 	 * @param dst a pointer to the destination buffer (can be offseted by pixels)
 	 * @param dstPitch destination pitch
-	 * @param width width of the input surface
-	 * @param height height of the input surface
+	 * @param width width of the destination area
+	 * @param height height of the destination area
 	 * @param colorMod the color to multiply by. (0xffffffff does no multiplication and has 0 overhead usually)
 	 * @param blendMode the blending mode to be used
 	 */


### PR DESCRIPTION
`width` and `height` are currently documented as "[width/height] of the input surface", but this is not correct. As one can see in the implementation e.g. in `blitGeneric`

https://github.com/scummvm/scummvm/blob/74e55525875deb65ecd08a27b1256bdbba706ae1/graphics/blit/blit-generic.cpp#L56-L67

it is the *output* pointers that are incremented per loop over width/height, while the input pointers are incremented with the scaled step values.

---

Also in `ManagedSurface::blendBlitTo`, the destination area rectangle is passed to `BlendBlit::blit` instead of the source rectangle:

https://github.com/scummvm/scummvm/blob/74e55525875deb65ecd08a27b1256bdbba706ae1/graphics/managed_surface.cpp#L1099-L1104