### PR TITLE
HUGO: Fix top menu not closing when it should

### DIFF
--- a/engines/hugo/mouse.cpp
+++ b/engines/hugo/mouse.cpp
@@ -325,6 +325,10 @@ void MouseHandler::mouseHandler() {
 	} else {
 		if (cy < 5 && cy > 0) {
 			_vm->_topMenu->runModal();
+			// When the top menu is shown, it eats all the events, including mouse move, which means the
+			// getMouseX() and getMouseY() have not been updated and the topMenu will be shown immediately
+			// again. We do not know where the cursor is currently, but move it outside of the ]0, 5[ range.
+			setMouseY(0);
 		}
 	}
 


### PR DESCRIPTION
While testing TTS for the Hugo engine I was met with an annoying bug. When the mouse moves to the top of the screen it shows a top menu. Clicking outside of this top menu, or pressing escape should close the menu, but this does not work. This was actually already reported several years ago in [bug #12621](https://bugs.scummvm.org/ticket/12621).

The top menu is actually a GUI::Dialog. While it is shown the engines does not receive any event. In particular it does not get the mouse move events. As a result, as soon as the menu is closed, it thinks the mouse cursor is still in the top area, and reopens the top menu immediately (unless there is a pending mouse move event that updates the mouse position before it is checked again).

The solution in this pull request is very simple: when the top menu is closed it also resets the mouse cursor position in the engine to a position that does not trigger the top menu. As far as I know there is no way for the engine to know where the cursor actually is until the next mouse event is received. So it arbitrarily set to the very top.

Another solution I considered was to add a flag to indicate the top menu should not be open again, and reset that flag in the setMouseX() and setMouseY() functions (i.e. when a mouse move event is received). But I did not see a good reason to use that approach over the one here.

Does anybody have a better idea on how this could be fixed, or see potential issues with this change?
I only tested it on the first screen, but it seems to work well there.