### PR TITLE
AUDIO: Make MidiParser more const correct

### DIFF
--- a/audio/adlib_ms.cpp
+++ b/audio/adlib_ms.cpp
@@ -938,7 +938,7 @@ void MidiDriver_ADLIB_Multisource::sysEx(const byte *msg, uint16 length) {
 	}
 }
 
-void MidiDriver_ADLIB_Multisource::metaEvent(int8 source, byte type, byte *data, uint16 length) {
+void MidiDriver_ADLIB_Multisource::metaEvent(int8 source, byte type, const byte *data, uint16 length) {
 	if (type == MIDI_META_END_OF_TRACK && source >= 0)
 		// Stop hanging notes and release resources used by this source.
 		deinitSource(source);

--- a/audio/adlib_ms.h
+++ b/audio/adlib_ms.h
@@ -708,7 +708,7 @@ public:
 	using MidiDriver_Multisource::send;
 	void send(int8 source, uint32 b) override;
 	void sysEx(const byte *msg, uint16 length) override;
-	void metaEvent(int8 source, byte type, byte *data, uint16 length) override;
+	void metaEvent(int8 source, byte type, const byte *data, uint16 length) override;
 	void stopAllNotes(bool stopSustainedNotes = false) override;
 
 	void stopAllNotes(uint8 source, uint8 channel) override;

--- a/audio/casio.cpp
+++ b/audio/casio.cpp
@@ -155,7 +155,7 @@ void MidiDriver_Casio::send(int8 source, uint32 b) {
 	processEvent(source, b, outputChannel);
 }
 
-void MidiDriver_Casio::metaEvent(int8 source, byte type, byte *data, uint16 length) {
+void MidiDriver_Casio::metaEvent(int8 source, byte type, const byte *data, uint16 length) {
 	assert(source < MAXIMUM_SOURCES);
 
 	if (type == 0x2F && source >= 0) // End of Track

--- a/audio/casio.h
+++ b/audio/casio.h
@@ -119,7 +119,7 @@ public:
 
 	using MidiDriver_BASE::send;
 	void send(int8 source, uint32 b) override;
-	void metaEvent(int8 source, byte type, byte *data, uint16 length) override;
+	void metaEvent(int8 source, byte type, const byte *data, uint16 length) override;
 
 	void stopAllNotes(bool stopSustainedNotes = false) override;
 	MidiChannel *allocateChannel() override;

--- a/audio/mididrv.h
+++ b/audio/mididrv.h
@@ -232,14 +232,14 @@ public:
 	virtual uint16 sysExNoDelay(const byte *msg, uint16 length) { sysEx(msg, length); return 0; }
 
 	// TODO: Document this.
-	virtual void metaEvent(byte type, byte *data, uint16 length) { }
+	virtual void metaEvent(byte type, const byte *data, uint16 length) { }
 
 	/**
 	 * Send a meta event from a specific source. If the MIDI driver
 	 * does not support multiple sources, the source parameter is
 	 * ignored.
 	 */
-	virtual void metaEvent(int8 source, byte type, byte *data, uint16 length) { metaEvent(type, data, length); }
+	virtual void metaEvent(int8 source, byte type, const byte *data, uint16 length) { metaEvent(type, data, length); }
 
 	/**
 	 * Stops all currently active notes. Specify stopSustainedNotes if

--- a/audio/midiparser.cpp
+++ b/audio/midiparser.cpp
@@ -94,7 +94,7 @@ void MidiParser::sendToDriver(uint32 b) {
 	}
 }
 
-void MidiParser::sendMetaEventToDriver(byte type, byte *data, uint16 length) {
+void MidiParser::sendMetaEventToDriver(byte type, const byte *data, uint16 length) {
 	if (_source < 0) {
 		_driver->metaEvent(type, data, length);
 	} else {
@@ -109,7 +109,7 @@ void MidiParser::setTempo(uint32 tempo) {
 }
 
 // This is the conventional (i.e. SMF) variable length quantity
-uint32 MidiParser::readVLQ(byte * &data) {
+uint32 MidiParser::readVLQ(const byte * &data) {
 	byte str;
 	uint32 value = 0;
 	int i;

--- a/audio/midiparser.h
+++ b/audio/midiparser.h
@@ -60,7 +60,7 @@ class MidiDriver_BASE;
  */
 struct Tracker {
 	struct SubtrackStatus {
-		byte * _playPos;        ///< A pointer to the next event to be parsed
+		const byte * _playPos;        ///< A pointer to the next event to be parsed
 		uint32 _lastEventTime;  ///< The time, in microseconds, of the last event that was parsed
 		uint32 _lastEventTick;  ///< The tick at which the last parsed event occurs
 		byte   _runningStatus;  ///< Cached MIDI command, for MIDI streams that rely on implied event codes
@@ -133,7 +133,7 @@ struct Tracker {
  * of MidiParser::parseNextEvent() each time another event is needed.
  */
 struct EventInfo {
-	byte * start;    ///< Position in the MIDI stream where the event starts.
+	const byte * start; ///< Position in the MIDI stream where the event starts.
 	                 ///< For delta-based MIDI streams (e.g. SMF and XMIDI), this points to the delta.
 	uint8  subtrack; ///< The subtrack containing this event.
 	uint32 delta;    ///< The number of ticks after the previous event that this event should occur.
@@ -146,7 +146,7 @@ struct EventInfo {
 		} basic;
 		struct {
 			byte   type; ///< For META events, this indicates the META type.
-			byte * data; ///< For META and SysEx events, this points to the start of the data.
+			const byte * data; ///< For META and SysEx events, this points to the start of the data.
 		} ext;
 	};
 	uint32 length; ///< For META and SysEx blocks, this indicates the length of the data.
@@ -373,7 +373,7 @@ protected:
 	bool   _sendSustainOffOnNotesOff;   ///< Send a sustain off on a notes off event, stopping hanging notes
 	bool   _disableAllNotesOffMidiEvents;   ///< Don't send All Notes Off MIDI messages
 	bool   _disableAutoStartPlayback;  ///< Do not automatically start playback after parsing MIDI data or setting the track
-	byte  *_tracks[MAXIMUM_TRACKS][MAXIMUM_SUBTRACKS]; ///< Multi-track MIDI formats are supported, up to 120 tracks with 20 subtracks each.
+	const byte  *_tracks[MAXIMUM_TRACKS][MAXIMUM_SUBTRACKS]; ///< Multi-track MIDI formats are supported, up to 120 tracks with 20 subtracks each.
 	byte   _numTracks;     ///< Count of total tracks for multi-track MIDI formats. 1 for single-track formats.
 	byte   _numSubtracks[MAXIMUM_TRACKS]; ///< The number of subtracks for each track.
 	byte   _activeTrack;   ///< Keeps track of the currently active track, in multi-track formats.
@@ -401,7 +401,7 @@ protected:
 	int8   _source;
 
 protected:
-	static uint32 readVLQ(byte * &data);
+	static uint32 readVLQ(const byte * &data);
 	virtual void resetTracking();
 	virtual void allNotesOff();
 	virtual void parseNextEvent(EventInfo &info) = 0;
@@ -434,7 +434,7 @@ protected:
 	void sendToDriver(byte status, byte firstOp, byte secondOp) {
 		sendToDriver(status | ((uint32)firstOp << 8) | ((uint32)secondOp << 16));
 	}
-	virtual void sendMetaEventToDriver(byte type, byte *data, uint16 length);
+	virtual void sendMetaEventToDriver(byte type, const byte *data, uint16 length);
 
 	/**
 	 * Platform independent BE uint32 read-and-advance.
@@ -442,7 +442,7 @@ protected:
 	 * from a memory pointer, at the same time advancing
 	 * the pointer.
 	 */
-	uint32 read4high(byte * &data) {
+	uint32 read4high(const byte * &data) {
 		uint32 val = READ_BE_UINT32(data);
 		data += 4;
 		return val;
@@ -454,7 +454,7 @@ protected:
 	 * from a memory pointer, at the same time advancing
 	 * the pointer.
 	 */
-	uint16 read2low(byte * &data) {
+	uint16 read2low(const byte * &data) {
 		uint16 val = READ_LE_UINT16(data);
 		data += 2;
 		return val;
@@ -515,7 +515,7 @@ public:
 	MidiParser(int8 source = -1);
 	virtual ~MidiParser() { stopPlaying(); }
 
-	virtual bool loadMusic(byte *data, uint32 size) = 0;
+	virtual bool loadMusic(const byte *data, uint32 size) = 0;
 	virtual void unloadMusic();
 	virtual void property(int prop, int value);
 	/**

--- a/audio/midiparser_qt.cpp
+++ b/audio/midiparser_qt.cpp
@@ -24,7 +24,7 @@
 #include "common/debug.h"
 #include "common/memstream.h"
 
-bool MidiParser_QT::loadMusic(byte *data, uint32 size) {
+bool MidiParser_QT::loadMusic(const byte *data, uint32 size) {
 	if (size < 8)
 		return false;
 
@@ -407,7 +407,7 @@ void MidiParser_QT::sendToDriver(uint32 b) {
 	}
 }
 
-void MidiParser_QT::sendMetaEventToDriver(byte type, byte *data, uint16 length) {
+void MidiParser_QT::sendMetaEventToDriver(byte type, const byte *data, uint16 length) {
 	if (_source < 0) {
 		MidiParser::sendMetaEventToDriver(type, data, length);
 	} else {

--- a/audio/midiparser_qt.h
+++ b/audio/midiparser_qt.h
@@ -58,7 +58,7 @@ public:
 	~MidiParser_QT() {}
 
 	// MidiParser
-	bool loadMusic(byte *data, uint32 size) override;
+	bool loadMusic(const byte *data, uint32 size) override;
 	void unloadMusic() override;
 
 	/**
@@ -82,7 +82,7 @@ protected:
 	void resetTracking() override;
 
 	void sendToDriver(uint32 b) override;
-	void sendMetaEventToDriver(byte type, byte *data, uint16 length) override;
+	void sendMetaEventToDriver(byte type, const byte *data, uint16 length) override;
 
 	// QuickTimeParser
 	SampleDesc *readSampleDesc(Track *track, uint32 format, uint32 descSize) override;

--- a/audio/midiparser_smf.cpp
+++ b/audio/midiparser_smf.cpp
@@ -31,7 +31,7 @@ MidiParser_SMF::MidiParser_SMF(int8 source) : MidiParser(source) {
 
 void MidiParser_SMF::parseNextEvent(EventInfo &info) {
 	uint8 subtrack = info.subtrack;
-	byte *playPos = _position._subtracks[subtrack]._playPos;
+	const byte *playPos = _position._subtracks[subtrack]._playPos;
 	info.start = playPos;
 	info.delta = readVLQ(playPos);
 
@@ -117,13 +117,13 @@ void MidiParser_SMF::parseNextEvent(EventInfo &info) {
 	_position._subtracks[subtrack]._playPos = playPos;
 }
 
-bool MidiParser_SMF::loadMusic(byte *data, uint32 size) {
+bool MidiParser_SMF::loadMusic(const byte *data, uint32 size) {
 	uint32 len;
 	byte midiType;
 	byte numTrackChunks;
 
 	unloadMusic();
-	byte *pos = data;
+	const byte *pos = data;
 
 	if (!memcmp(pos, "RIFF", 4)) {
 		// Skip the outer RIFF header.

--- a/audio/midiparser_smf.h
+++ b/audio/midiparser_smf.h
@@ -47,7 +47,7 @@ protected:
 public:
 	MidiParser_SMF(int8 source = -1);
 
-	bool loadMusic(byte *data, uint32 size) override;
+	bool loadMusic(const byte *data, uint32 size) override;
 
 	int32 determineDataSize(Common::SeekableReadStream *stream) override;
 };

--- a/audio/midiplayer.cpp
+++ b/audio/midiplayer.cpp
@@ -122,7 +122,7 @@ void MidiPlayer::sendToChannel(byte ch, uint32 b) {
 	}
 }
 
-void MidiPlayer::metaEvent(byte type, byte *data, uint16 length) {
+void MidiPlayer::metaEvent(byte type, const byte *data, uint16 length) {
 	switch (type) {
 	case 0x2F:	// End of Track
 		endOfTrack();

--- a/audio/midiplayer.h
+++ b/audio/midiplayer.h
@@ -123,7 +123,7 @@ public:
 
 	// MidiDriver_BASE implementation
 	void send(uint32 b) override;
-	void metaEvent(byte type, byte *data, uint16 length) override;
+	void metaEvent(byte type, const byte *data, uint16 length) override;
 
 protected:
 	/**

--- a/audio/miles_adlib.cpp
+++ b/audio/miles_adlib.cpp
@@ -138,7 +138,7 @@ public:
 	void close() override;
 	void send(uint32 b) override;
 	void send(int8 source, uint32 b) override;
-	void metaEvent(int8 source, byte type, byte *data, uint16 length) override;
+	void metaEvent(int8 source, byte type, const byte *data, uint16 length) override;
 	MidiChannel *allocateChannel() override { return nullptr; }
 	MidiChannel *getPercussionChannel() override { return nullptr; }
 
@@ -1198,7 +1198,7 @@ void MidiDriver_Miles_AdLib::pitchBendChange(byte midiChannel, byte parameter1, 
 	}
 }
 
-void MidiDriver_Miles_AdLib::metaEvent(int8 source, byte type, byte *data, uint16 length) {
+void MidiDriver_Miles_AdLib::metaEvent(int8 source, byte type, const byte *data, uint16 length) {
 	if (type == MIDI_META_END_OF_TRACK && source >= 0)
 		// Stop hanging notes and release resources used by this source.
 		deinitSource(source);

--- a/audio/mt32gm.cpp
+++ b/audio/mt32gm.cpp
@@ -964,7 +964,7 @@ uint16 MidiDriver_MT32GM::sysExMT32(const byte *msg, uint16 length, const uint32
 	return 0;
 }
 
-void MidiDriver_MT32GM::metaEvent(int8 source, byte type, byte *data, uint16 length) {
+void MidiDriver_MT32GM::metaEvent(int8 source, byte type, const byte *data, uint16 length) {
 	assert(source < MAXIMUM_SOURCES);
 
 	if (type == 0x2F && source >= 0) // End of Track

--- a/audio/mt32gm.h
+++ b/audio/mt32gm.h
@@ -296,7 +296,7 @@ public:
 	 * not sent before this time has passed.
 	 */
 	uint16 sysExMT32(const byte *msg, uint16 length, const uint32 targetAddress, bool queue = false, bool delay = true, int8 source = -1);
-	void metaEvent(int8 source, byte type, byte *data, uint16 length) override;
+	void metaEvent(int8 source, byte type, const byte *data, uint16 length) override;
 
 	void stopAllNotes(bool stopSustainedNotes = false) override;
 	/**

--- a/engines/agos/midiparser_gmf.cpp
+++ b/engines/agos/midiparser_gmf.cpp
@@ -30,8 +30,8 @@ MidiParser_GMF::MidiParser_GMF(int8 source, bool useDosTempos) : MidiParser_SMF(
 }
 
 void MidiParser_GMF::parseNextEvent(EventInfo &info) {
-	byte *parsePos = _position._subtracks[0]._playPos;
-	uint8 *start = parsePos;
+	const byte *parsePos = _position._subtracks[0]._playPos;
+	const uint8 *start = parsePos;
 	uint32 delta = readVLQ(parsePos);
 
 	// GMF does not use end of track events, so we have to use the size of the
@@ -42,7 +42,7 @@ void MidiParser_GMF::parseNextEvent(EventInfo &info) {
 	bool containsMoreData = true;
 	if (parsePos > _tracksEndPos[_activeTrack] - 5) {
 		containsMoreData = false;
-		byte *checkPos = parsePos;
+		const byte *checkPos = parsePos;
 		while (checkPos < _tracksEndPos[_activeTrack]) {
 			if (*checkPos != 0) {
 				containsMoreData = true;
@@ -92,7 +92,7 @@ void MidiParser_GMF::parseNextEvent(EventInfo &info) {
 	}
 }
 
-bool MidiParser_GMF::loadMusic(byte *data, uint32 size) {
+bool MidiParser_GMF::loadMusic(const byte *data, uint32 size) {
 	assert(size > 7);
 
 	unloadMusic();
@@ -128,9 +128,9 @@ bool MidiParser_GMF::loadMusic(byte *data, uint32 size) {
 		// A multi-track file starts with a list of 2-byte offsets which
 		// identify the starting position of each track, as well as the end of
 		// the last track.
-		byte *pos = data;
+		const byte *pos = data;
 		// Read the start offset of the first track.
-		byte *trackStart = data + READ_LE_UINT16(pos);
+		const byte *trackStart = data + READ_LE_UINT16(pos);
 		pos += 2;
 		// The number of offsets before the first track indicates the number of
 		// tracks plus 1 because the end offset of the last track is included

--- a/engines/agos/midiparser_gmf.h
+++ b/engines/agos/midiparser_gmf.h
@@ -38,14 +38,14 @@ class MidiParser_GMF : public MidiParser_SMF {
 public:
 	MidiParser_GMF(int8 source = -1, bool useDosTempos = false);
 
-	bool loadMusic(byte *data, uint32 size) override;
+	bool loadMusic(const byte *data, uint32 size) override;
 
 protected:
 	void parseNextEvent(EventInfo &info) override;
 
 	// The end position of each track, exclusive
 	// (i.e. 1 byte past the end of the data).
-	byte *_tracksEndPos[MAXIMUM_TRACKS];
+	const byte *_tracksEndPos[MAXIMUM_TRACKS];
 
 	// True if the music tempos from the DOS version should be used; false if
 	// the tempos from the Windows version should be used.

--- a/engines/agos/midiparser_s1d.cpp
+++ b/engines/agos/midiparser_s1d.cpp
@@ -33,12 +33,12 @@ namespace AGOS {
  */
 class MidiParser_S1D : public MidiParser {
 private:
-	byte *_data;
+	const byte *_data;
 	bool _noDelta;
 
 	struct Loop {
 		uint16 timer;
-		byte *start, *end;
+		const byte *start, *end;
 		bool noDelta;
 	} _loops[16];
 
@@ -57,7 +57,7 @@ private:
 	// be played. If false, all notes of a chord will be sent to the driver.
 	bool _monophonicChords;
 
-	uint32 readVLQ2(byte *&data);
+	uint32 readVLQ2(const byte *&data);
 protected:
 	void parseNextEvent(EventInfo &info) override;
 	bool processEvent(const EventInfo &info, bool fireEvents = true) override;
@@ -71,11 +71,11 @@ protected:
 		Common::fill(_lastPlayedNoteTime, _lastPlayedNoteTime + ARRAYSIZE(_lastPlayedNoteTime), 0);
 	}
 
-	bool loadMusic(byte *data, uint32 size) override;
+	bool loadMusic(const byte *data, uint32 size) override;
 	int32 determineDataSize(Common::SeekableReadStream *stream) override;
 };
 
-uint32 MidiParser_S1D::readVLQ2(byte *&data) {
+uint32 MidiParser_S1D::readVLQ2(const byte *&data) {
 	uint32 delta = 0;
 
 	// LE format VLQ, which is 2 bytes long at max.
@@ -89,7 +89,7 @@ uint32 MidiParser_S1D::readVLQ2(byte *&data) {
 }
 
 void MidiParser_S1D::parseNextEvent(EventInfo &info) {
-	byte *playPos = _position._subtracks[0]._playPos;
+	const byte *playPos = _position._subtracks[0]._playPos;
 	info.start = playPos;
 	info.length = 0;
 	info.delta = _noDelta ? 0 : readVLQ2(playPos);
@@ -220,14 +220,14 @@ bool MidiParser_S1D::processEvent(const EventInfo &info, bool fireEvents) {
 	return MidiParser::processEvent(info, fireEvents);
 }
 
-bool MidiParser_S1D::loadMusic(byte *data, uint32 size) {
+bool MidiParser_S1D::loadMusic(const byte *data, uint32 size) {
 	unloadMusic();
 
 	if (!size)
 		return false;
 
 	// The original actually just ignores the first two bytes.
-	byte *pos = data + 2;
+	const byte *pos = data + 2;
 	if (*pos == 0xFC) {
 		// SysEx found right at the start
 		// this seems to happen since Elvira 2, we ignore it

--- a/engines/agos/midiparser_simonwin.cpp
+++ b/engines/agos/midiparser_simonwin.cpp
@@ -30,8 +30,8 @@ MidiParser_SimonWin::MidiParser_SimonWin(int8 source, bool useDosTempos) :
 	MidiParser_SMF(source), _useDosTempos(useDosTempos) { }
 
 void MidiParser_SimonWin::parseNextEvent(EventInfo &info) {
-	byte *parsePos = _position._subtracks[info.subtrack]._playPos;
-	uint8 *start = parsePos;
+	const byte *parsePos = _position._subtracks[info.subtrack]._playPos;
+	const uint8 *start = parsePos;
 	uint32 delta = readVLQ(parsePos);
 	uint8 event = *(parsePos++);
 
@@ -93,13 +93,13 @@ int32 MidiParser_SimonWin::determineDataSize(Common::SeekableReadStream *stream)
 	return totalSize;
 }
 
-bool MidiParser_SimonWin::loadMusic(byte *data, uint32 size) {
+bool MidiParser_SimonWin::loadMusic(const byte *data, uint32 size) {
 	assert(size > 7);
 
 	unloadMusic();
 
 	// The first byte indicates the number of tracks in the MIDI data.
-	byte *pos = data;
+	const byte *pos = data;
 	_numTracks = *(pos++);
 	if (_numTracks > MAXIMUM_TRACKS) {
 		warning("MidiParser_SimonWin::loadMusic - Can only handle %d tracks but was handed %d", MAXIMUM_TRACKS, _numTracks);

--- a/engines/agos/midiparser_simonwin.h
+++ b/engines/agos/midiparser_simonwin.h
@@ -46,7 +46,7 @@ public:
 
 	void setTempo(uint32 tempo) override;
 
-	bool loadMusic(byte *data, uint32 size) override;
+	bool loadMusic(const byte *data, uint32 size) override;
 
 protected:
 	void parseNextEvent(EventInfo &info) override;

--- a/engines/darkseed/midiparser_sbr.cpp
+++ b/engines/darkseed/midiparser_sbr.cpp
@@ -38,8 +38,8 @@ MidiParser_SBR::MidiParser_SBR(int8 source, bool sfx) : MidiParser_SMF(source), 
 
 void MidiParser_SBR::parseNextEvent(EventInfo &info) {
 	uint8 subtrack = info.subtrack;
-	byte *parsePos = _position._subtracks[subtrack]._playPos;
-	uint8 *start = parsePos;
+	const byte *parsePos = _position._subtracks[subtrack]._playPos;
+	const uint8 *start = parsePos;
 
 	/**
 	 * SBR uses 6 byte structures to represent events:
@@ -215,7 +215,7 @@ void MidiParser_SBR::onTrackStart(uint8 track) {
 	Common::fill(_trackLoopCounter, _trackLoopCounter + ARRAYSIZE(_trackLoopCounter), 0);
 }
 
-bool MidiParser_SBR::loadMusic(byte *data, uint32 size) {
+bool MidiParser_SBR::loadMusic(const byte *data, uint32 size) {
 	assert(size > 0);
 
 	unloadMusic();
@@ -229,7 +229,7 @@ bool MidiParser_SBR::loadMusic(byte *data, uint32 size) {
 	// terminated by a 00 byte.
 	uint16 bytesRead = 0;
 	for (int i = 0; i < endTrack; i++) {
-		byte *startOfTrack = data;
+		const byte *startOfTrack = data;
 		uint16 trackSize = 0;
 
 		bool foundEndOfTrack = false;
@@ -273,7 +273,7 @@ bool MidiParser_SBR::loadMusic(byte *data, uint32 size) {
 			// subtrack indices, terminated by a 00 byte.
 			// (The track is padded with garbage and terminated by another
 			// 00 byte to match the x * 6 byte event format used by all tracks.)
-			uint8 *tracklist = _tracks[i][0] + 1;
+			const uint8 *tracklist = _tracks[i][0] + 1;
 			uint8 subtrackIndex = 0;
 			while (*tracklist != 0) {
 				_tracks[i][subtrackIndex++] = _tracks[*tracklist][0];

--- a/engines/darkseed/midiparser_sbr.h
+++ b/engines/darkseed/midiparser_sbr.h
@@ -33,7 +33,7 @@ class MidiParser_SBR : public MidiParser_SMF {
 public:
 	MidiParser_SBR(int8 source = -1, bool sfx = false);
 
-	bool loadMusic(byte *data, uint32 size) override;
+	bool loadMusic(const byte *data, uint32 size) override;
 
 protected:
 	void parseNextEvent(EventInfo &info) override;

--- a/engines/dgds/sound/midiparser_sci.cpp
+++ b/engines/dgds/sound/midiparser_sci.cpp
@@ -473,7 +473,7 @@ void MidiParser_SCI::trackState(uint32 b) {
 }
 
 void MidiParser_SCI::parseNextEvent(EventInfo &info) {
-	byte *playPos = _position._subtracks[0]._playPos;
+	const byte *playPos = _position._subtracks[0]._playPos;
 
 	info.start = playPos;
 	info.delta = 0;

--- a/engines/dgds/sound/midiparser_sci.h
+++ b/engines/dgds/sound/midiparser_sci.h
@@ -55,7 +55,7 @@ public:
 	void mainThreadEnd();
 
 	bool loadMusic(SoundResource::Track *track, MusicEntry *psnd, int channelFilterMask);
-	bool loadMusic(byte *, uint32) override {
+	bool loadMusic(const byte *, uint32) override {
 		return false;
 	}
 	void initTrack();

--- a/engines/groovie/music.cpp
+++ b/engines/groovie/music.cpp
@@ -325,7 +325,7 @@ uint16 MusicPlayerMidi::sysExNoDelay(const byte *msg, uint16 length) {
 	return _driver ? _driver->sysExNoDelay(msg, length) : 0;
 }
 
-void MusicPlayerMidi::metaEvent(byte type, byte *data, uint16 length) {
+void MusicPlayerMidi::metaEvent(byte type, const byte *data, uint16 length) {
 	switch (type) {
 	case 0x2F:
 		// End of Track, play the background song
@@ -501,7 +501,7 @@ void MusicPlayerXMI::send(int8 source, uint32 b) {
 	_multisourceDriver->send(source, b);
 }
 
-void MusicPlayerXMI::metaEvent(int8 source, byte type, byte *data, uint16 length) {
+void MusicPlayerXMI::metaEvent(int8 source, byte type, const byte *data, uint16 length) {
 	if (type == 0x2F) // End Of Track
 		MusicPlayerMidi::endTrack();
 	_multisourceDriver->metaEvent(source, type, data, length);

--- a/engines/groovie/music.h
+++ b/engines/groovie/music.h
@@ -119,7 +119,7 @@ public:
 	void send(uint32 b) override;
 	void sysEx(const byte* msg, uint16 length) override;
 	uint16 sysExNoDelay(const byte *msg, uint16 length) override;
-	void metaEvent(byte type, byte *data, uint16 length) override;
+	void metaEvent(byte type, const byte *data, uint16 length) override;
 
 	void pause(bool pause) override;
 
@@ -149,7 +149,7 @@ public:
 	using MusicPlayerMidi::send;
 	void send(int8 source, uint32 b) override;
 	using MusicPlayerMidi::metaEvent;
-	void metaEvent(int8 source, byte type, byte *data, uint16 length) override;
+	void metaEvent(int8 source, byte type, const byte *data, uint16 length) override;
 	void stopAllNotes(bool stopSustainedNotes) override;
 	void processXMIDITimbreChunk(const byte *timbreListPtr, uint32 timbreListSize) override {
 		if (_milesXmidiTimbres)

--- a/engines/lure/sound.cpp
+++ b/engines/lure/sound.cpp
@@ -854,11 +854,11 @@ void MidiMusic::send(int8 source, uint32 b) {
 	_driver->send(source, b);
 }
 
-void MidiMusic::metaEvent(byte type, byte *data, uint16 length) {
+void MidiMusic::metaEvent(byte type, const byte *data, uint16 length) {
 	metaEvent(-1, type, data, length);
 }
 
-void MidiMusic::metaEvent(int8 source, byte type, byte *data, uint16 length) {
+void MidiMusic::metaEvent(int8 source, byte type, const byte *data, uint16 length) {
 	if (type == MIDI_META_END_OF_TRACK)
 		stopMusic();
 
@@ -943,7 +943,7 @@ void MidiDriver_ADLIB_Lure::channelAftertouch(uint8 channel, uint8 pressure, uin
 	_activeNotesMutex.unlock();
 }
 
-void MidiDriver_ADLIB_Lure::metaEvent(int8 source, byte type, byte *data, uint16 length) {
+void MidiDriver_ADLIB_Lure::metaEvent(int8 source, byte type, const byte *data, uint16 length) {
 	if (type == MIDI_META_SEQUENCER && length >= 6 &&
 			data[0] == 0x00 && data[1] == 0x00 && data[2] == 0x3F && data[3] == 0x00) {
 		// Custom sequencer meta event

--- a/engines/lure/sound.h
+++ b/engines/lure/sound.h
@@ -83,8 +83,8 @@ public:
 	// MidiDriver_BASE interface implementation
 	void send(uint32 b) override;
 	void send(int8 source, uint32 b) override;
-	void metaEvent(byte type, byte *data, uint16 length) override;
-	void metaEvent(int8 source, byte type, byte *data, uint16 length) override;
+	void metaEvent(byte type, const byte *data, uint16 length) override;
+	void metaEvent(int8 source, byte type, const byte *data, uint16 length) override;
 
 	void onTimer();
 
@@ -176,7 +176,7 @@ public:
 	void channelAftertouch(uint8 channel, uint8 pressure, uint8 source) override;
 	// The MIDI data uses three custom sequencer meta events; the most important
 	// one sets the instrument definition for a channel.
-	void metaEvent(int8 source, byte type, byte *data, uint16 length) override;
+	void metaEvent(int8 source, byte type, const byte *data, uint16 length) override;
 
 protected:
 	InstrumentInfo determineInstrument(uint8 channel, uint8 source, uint8 note)	override;

--- a/engines/parallaction/sound_br.cpp
+++ b/engines/parallaction/sound_br.cpp
@@ -70,9 +70,9 @@ namespace Parallaction {
 class MidiParser_MSC : public MidiParser {
 protected:
 	void parseNextEvent(EventInfo &info) override;
-	bool loadMusic(byte *data, uint32 size) override;
+	bool loadMusic(const byte *data, uint32 size) override;
 
-	uint8  read1(byte *&data) {
+	uint8  read1(const byte *&data) {
 		return *data++;
 	}
 
@@ -82,7 +82,7 @@ protected:
 	bool byte_11C5A;
 	uint8 _beats;
 	uint8 _lastEvent;
-	byte *_trackEnd;
+	const byte *_trackEnd;
 
 public:
 	MidiParser_MSC() : byte_11C5A(false), _beats(0), _lastEvent(0), _trackEnd(nullptr) {
@@ -90,7 +90,7 @@ public:
 };
 
 void MidiParser_MSC::parseMetaEvent(EventInfo &info) {
-	byte *playPos = _position._subtracks[0]._playPos;
+	const byte *playPos = _position._subtracks[0]._playPos;
 
 	uint8 type = read1(playPos);
 	uint8 len = read1(playPos);
@@ -111,7 +111,7 @@ void MidiParser_MSC::parseMetaEvent(EventInfo &info) {
 }
 
 void MidiParser_MSC::parseMidiEvent(EventInfo &info) {
-	byte *playPos = _position._subtracks[0]._playPos;
+	const byte *playPos = _position._subtracks[0]._playPos;
 	uint8 type = info.command();
 
 	switch (type) {
@@ -139,7 +139,7 @@ void MidiParser_MSC::parseMidiEvent(EventInfo &info) {
 }
 
 void MidiParser_MSC::parseNextEvent(EventInfo &info) {
-	byte *playPos = _position._subtracks[0]._playPos;
+	const byte *playPos = _position._subtracks[0]._playPos;
 
 	info.start = playPos;
 
@@ -172,10 +172,10 @@ void MidiParser_MSC::parseNextEvent(EventInfo &info) {
 	_lastEvent = info.event;
 }
 
-bool MidiParser_MSC::loadMusic(byte *data, uint32 size) {
+bool MidiParser_MSC::loadMusic(const byte *data, uint32 size) {
 	unloadMusic();
 
-	byte *pos = data;
+	const byte *pos = data;
 
 	if (memcmp("MSCt", pos, 4)) {
 		warning("Expected header not found in music file");

--- a/engines/queen/midiadlib.cpp
+++ b/engines/queen/midiadlib.cpp
@@ -79,7 +79,7 @@ void AdLibMidiDriver::setVolume(uint32 volume) {
 		adlibSetChannelVolume(i, volume * 64 / 256 + 64);
 }
 
-void AdLibMidiDriver::metaEvent(byte type, byte *data, uint16 length) {
+void AdLibMidiDriver::metaEvent(byte type, const byte *data, uint16 length) {
 	int event = 0;
 	if (length > 4 && READ_BE_UINT32(data) == 0x3F00) {
 		event = data[4];

--- a/engines/queen/midiadlib.h
+++ b/engines/queen/midiadlib.h
@@ -38,7 +38,7 @@ public:
 	int open() override;
 	void close() override;
 	void send(uint32 b) override;
-	void metaEvent(byte type, byte *data, uint16 length) override;
+	void metaEvent(byte type, const byte *data, uint16 length) override;
 	MidiChannel *allocateChannel() override { return 0; }
 	MidiChannel *getPercussionChannel() override { return 0; }
 	void setTimerCallback(void *timerParam, Common::TimerManager::TimerProc timerProc) override;

--- a/engines/queen/music.cpp
+++ b/engines/queen/music.cpp
@@ -191,7 +191,7 @@ void MidiMusic::send(uint32 b) {
 		_channelsTable[channel]->send(b);
 }
 
-void MidiMusic::metaEvent(byte type, byte *data, uint16 length) {
+void MidiMusic::metaEvent(byte type, const byte *data, uint16 length) {
 	switch (type) {
 	case 0x2F: // End of Track
 		if (_isLooping || _songQueue[1]) {

--- a/engines/queen/music.h
+++ b/engines/queen/music.h
@@ -54,7 +54,7 @@ public:
 
 	// MidiDriver_BASE interface implementation
 	void send(uint32 b) override;
-	void metaEvent(byte type, byte *data, uint16 length) override;
+	void metaEvent(byte type, const byte *data, uint16 length) override;
 
 protected:
 

--- a/engines/sci/sound/midiparser_sci.cpp
+++ b/engines/sci/sound/midiparser_sci.cpp
@@ -631,7 +631,7 @@ void MidiParser_SCI::trackState(uint32 b) {
 }
 
 void MidiParser_SCI::parseNextEvent(EventInfo &info) {
-	byte *playPos = _position._subtracks[0]._playPos;
+	const byte *playPos = _position._subtracks[0]._playPos;
 
 	info.start = playPos;
 	info.delta = 0;

--- a/engines/sci/sound/midiparser_sci.h
+++ b/engines/sci/sound/midiparser_sci.h
@@ -56,7 +56,7 @@ public:
 	void mainThreadEnd();
 
 	bool loadMusic(SoundResource::Track *track, MusicEntry *psnd, int channelFilterMask, SciVersion soundVersion);
-	bool loadMusic(byte *, uint32) override {
+	bool loadMusic(const byte *, uint32) override {
 		return false;
 	}
 	void initTrack();

--- a/engines/scumm/imuse/imuse_internal.h
+++ b/engines/scumm/imuse/imuse_internal.h
@@ -302,7 +302,7 @@ public:
 	void send(uint32 b) override;
 	void sysEx(const byte *msg, uint16 length) override;
 	uint16 sysExNoDelay(const byte *msg, uint16 length) override;
-	void metaEvent(byte type, byte *data, uint16 length) override;
+	void metaEvent(byte type, const byte *data, uint16 length) override;
 };
 
 

--- a/engines/scumm/imuse/imuse_player.cpp
+++ b/engines/scumm/imuse/imuse_player.cpp
@@ -1096,7 +1096,7 @@ void Player::fixAfterLoad() {
 	}
 }
 
-void Player::metaEvent(byte type, byte *msg, uint16 len) {
+void Player::metaEvent(byte type, const byte *msg, uint16 len) {
 	if (type == 0x2F)
 		clear();
 }

--- a/engines/scumm/midiparser_ro.cpp
+++ b/engines/scumm/midiparser_ro.cpp
@@ -39,7 +39,7 @@ protected:
 	void parseNextEvent (EventInfo &info) override;
 
 public:
-	bool loadMusic (byte *data, uint32 size) override;
+	bool loadMusic(const byte *data, uint32 size) override;
 	uint32 getTick() override { return (uint32) _markerCount * _ppqn / 2; }
 };
 
@@ -55,7 +55,7 @@ void MidiParser_RO::parseNextEvent (EventInfo &info) {
 	_markerCount += _lastMarkerCount;
 	_lastMarkerCount = 0;
 
-	byte *playPos = _position._subtracks[0]._playPos;
+	const byte *playPos = _position._subtracks[0]._playPos;
 
 	info.delta = 0;
 	do {
@@ -128,9 +128,9 @@ void MidiParser_RO::parseNextEvent (EventInfo &info) {
 	_position._subtracks[0]._playPos = playPos;
 }
 
-bool MidiParser_RO::loadMusic (byte *data, uint32 size) {
+bool MidiParser_RO::loadMusic(const byte *data, uint32 size) {
 	unloadMusic();
-	byte *pos = data;
+	const byte *pos = data;
 
 	if (memcmp (pos, "RO", 2)) {
 		error("'RO' header expected but found '%c%c' instead", pos[0], pos[1]);

--- a/engines/sherlock/music.cpp
+++ b/engines/sherlock/music.cpp
@@ -79,7 +79,7 @@ void MidiParser_SH::parseNextEvent(EventInfo &info) {
 
 //	warning("parseNextEvent");
 
-	byte *playPos = _position._subtracks[0]._playPos;
+	const byte *playPos = _position._subtracks[0]._playPos;
 
 	// there is no delta right at the start of the music data
 	// this order is essential, otherwise notes will get delayed or even go missing
@@ -176,7 +176,7 @@ void MidiParser_SH::parseNextEvent(EventInfo &info) {
 	_position._subtracks[0]._playPos = playPos;
 }
 
-bool MidiParser_SH::loadMusic(byte *musData, uint32 musDataSize) {
+bool MidiParser_SH::loadMusic(const byte *musData, uint32 musDataSize) {
 	Common::StackLock lock(_mutex);
 
 	debugC(kDebugLevelMusic, "Music: loadMusic()");
@@ -185,8 +185,8 @@ bool MidiParser_SH::loadMusic(byte *musData, uint32 musDataSize) {
 	_musData     = musData;
 	_musDataSize = musDataSize;
 
-	byte *headerPtr = _musData + 12; // skip over the already checked SPACE header
-	byte *pos       = headerPtr;
+	const byte *headerPtr = _musData + 12; // skip over the already checked SPACE header
+	const byte *pos       = headerPtr;
 
 	uint16 headerSize = READ_LE_UINT16(headerPtr);
 	assert(headerSize == 0x7F); // Security check

--- a/engines/sherlock/music.h
+++ b/engines/sherlock/music.h
@@ -44,15 +44,15 @@ protected:
 
 	uint8 _beats;
 	uint8 _lastEvent;
-	byte *_data;
-	byte *_trackEnd;
+	const byte *_data;
+	const byte *_trackEnd;
 
 public:
-	bool loadMusic(byte *musData, uint32 musSize) override;
+	bool loadMusic(const byte *musData, uint32 musSize) override;
 	void unloadMusic() override;
 
 private:
-	byte  *_musData;
+	const byte  *_musData;
 	uint32 _musDataSize;
 };
 
@@ -64,7 +64,7 @@ private:
 	MidiDriver *_midiDriver;
 	Audio::SoundHandle _digitalMusicHandle;
 	MusicType _musicType;
-	byte *_midiMusicData;
+	const byte *_midiMusicData;
 
 	/**
 	 * Play the specified music resource

--- a/engines/ultima/nuvie/sound/mididrv_m_adlib.cpp
+++ b/engines/ultima/nuvie/sound/mididrv_m_adlib.cpp
@@ -232,7 +232,7 @@ void MidiDriver_M_AdLib::send(int8 source, uint32 b) {
 	}
 }
 
-void MidiDriver_M_AdLib::metaEvent(int8 source, byte type, byte* data, uint16 length) {
+void MidiDriver_M_AdLib::metaEvent(int8 source, byte type, const byte* data, uint16 length) {
 	if (type == 0x3) {
 		// Load instrument
 		// This loads an OPL instrument definition into the bank. The first 

--- a/engines/ultima/nuvie/sound/mididrv_m_adlib.h
+++ b/engines/ultima/nuvie/sound/mididrv_m_adlib.h
@@ -57,7 +57,7 @@ public:
 
 	using MidiDriver_Multisource::send;
 	void send(int8 source, uint32 b) override;
-	void metaEvent(int8 source, byte type, byte *data, uint16 length) override;
+	void metaEvent(int8 source, byte type, const byte *data, uint16 length) override;
 
 protected:
 	void programChange(uint8 channel, uint8 program, uint8 source) override;

--- a/engines/ultima/nuvie/sound/mididrv_m_mt32.cpp
+++ b/engines/ultima/nuvie/sound/mididrv_m_mt32.cpp
@@ -152,7 +152,7 @@ void MidiDriver_M_MT32::send(int8 source, uint32 b) {
 	}
 }
 
-void MidiDriver_M_MT32::metaEvent(int8 source, byte type, byte *data, uint16 length) {
+void MidiDriver_M_MT32::metaEvent(int8 source, byte type, const byte *data, uint16 length) {
 	// Load instrument is ignored for MT-32; instruments are set using
 	// setInstrumentAssignments.
 }

--- a/engines/ultima/nuvie/sound/mididrv_m_mt32.h
+++ b/engines/ultima/nuvie/sound/mididrv_m_mt32.h
@@ -70,7 +70,7 @@ public:
 
 	using MidiDriver_MT32GM::send;
 	void send(int8 source, uint32 b) override;
-	void metaEvent(int8 source, byte type, byte *data, uint16 length) override;
+	void metaEvent(int8 source, byte type, const byte *data, uint16 length) override;
 
 	/**
 	 * Sets the assignments of the 16 M instruments to the MIDI instruments and

--- a/engines/ultima/nuvie/sound/midiparser_m.cpp
+++ b/engines/ultima/nuvie/sound/midiparser_m.cpp
@@ -41,7 +41,7 @@ MidiParser_M::~MidiParser_M() {
 	delete _loopStack;
 }
 
-bool MidiParser_M::loadMusic(byte* data, uint32 size) {
+bool MidiParser_M::loadMusic(const byte* data, uint32 size) {
 	unloadMusic();
 
 	// M uses only 1 track.
@@ -127,7 +127,7 @@ void MidiParser_M::onTimer() {
 }
 
 bool MidiParser_M::processEvent(const EventInfo& info, bool fireEvents) {
-	byte *playPos = _position._subtracks[0]._playPos;
+	const byte *playPos = _position._subtracks[0]._playPos;
 
 	if (info.command() == 0x8 && info.channel() == 0x1) {
 		// Call subroutine
@@ -177,7 +177,7 @@ bool MidiParser_M::processEvent(const EventInfo& info, bool fireEvents) {
 }
 
 void MidiParser_M::parseNextEvent(EventInfo &info) {
-	byte *playPos = _position._subtracks[0]._playPos;
+	const byte *playPos = _position._subtracks[0]._playPos;
 	assert(playPos >= _tracks[0][0]);
 	assert(playPos - _tracks[0][0] < (int)_trackLength);
 

--- a/engines/ultima/nuvie/sound/midiparser_m.h
+++ b/engines/ultima/nuvie/sound/midiparser_m.h
@@ -47,15 +47,15 @@ class MidiParser_M : public MidiParser {
 protected:
 	struct LoopData {
 		byte numLoops;
-		byte *startPos;
-		byte *returnPos;
+		const byte *startPos;
+		const byte *returnPos;
 	};
 
 public:
 	MidiParser_M(int8 source = -1);
 	~MidiParser_M();
 
-	bool loadMusic(byte *data, uint32 size) override;
+	bool loadMusic(const byte *data, uint32 size) override;
 	void unloadMusic() override;
 	void onTimer() override;
 
@@ -69,7 +69,7 @@ protected:
 
 	// The point in the MIDI data where the global loop (not using the stack)
 	// has started and will return.
-	byte *_loopPoint;
+	const byte *_loopPoint;
 
 	// A stack of nested loops, similar to a call stack. A call command will
 	// specify an offset where the parser should jump to (startPus), plus a


### PR DESCRIPTION
The midi parser interface should take a const byte array so that engines can pass data with more confidence.  This also allows them to be more const correct on their side.

There was one place where the input byte stream was actually being modified by the midi parser to overwrite tempo values.  Pointed to a static byte array for this case.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
