### PR TITLE
DRAGONS: Clean up and reorganize includes

### DIFF
--- a/engines/dragons/actor.cpp
+++ b/engines/dragons/actor.cpp
@@ -18,11 +18,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "common/debug.h"
+#include "dragons/actor.h"
+#include "dragons/actorresource.h"
 #include "dragons/dragons.h"
 #include "dragons/dragonini.h"
-#include "dragons/actorresource.h"
-#include "dragons/actor.h"
 #include "dragons/scene.h"
 #include "dragons/screen.h"
 

--- a/engines/dragons/actor.h
+++ b/engines/dragons/actor.h
@@ -21,7 +21,9 @@
 #ifndef DRAGONS_ACTOR_H
 #define DRAGONS_ACTOR_H
 
-#include "common/system.h"
+#include "common/array.h"
+#include "common/scummsys.h"
+#include "graphics/surface.h"
 
 namespace Dragons {
 class Actor;

--- a/engines/dragons/actorresource.h
+++ b/engines/dragons/actorresource.h
@@ -21,7 +21,9 @@
 #ifndef DRAGONS_ACTORRESOURCE_H
 #define DRAGONS_ACTORRESOURCE_H
 
-#include "common/system.h"
+#include "common/scummsys.h"
+#include "graphics/surface.h"
+#include "common/stream.h"
 
 namespace Dragons {
 

--- a/engines/dragons/credits.cpp
+++ b/engines/dragons/credits.cpp
@@ -18,9 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "dragons/credits.h"
 
-#include "common/system.h"
+#include "dragons/credits.h"
 #include "dragons/bigfile.h"
 #include "dragons/dragons.h"
 #include "dragons/screen.h"

--- a/engines/dragons/cursor.h
+++ b/engines/dragons/cursor.h
@@ -21,7 +21,6 @@
 #ifndef DRAGONS_CURSOR_H
 #define DRAGONS_CURSOR_H
 
-#include "common/system.h"
 #include "dragons/scriptopcodes.h"
 
 namespace Dragons {

--- a/engines/dragons/cutscene.h
+++ b/engines/dragons/cutscene.h
@@ -21,7 +21,7 @@
 #ifndef DRAGONS_CUTSCENE_H
 #define DRAGONS_CUTSCENE_H
 
-#include "common/system.h"
+#include "common/scummsys.h"
 
 namespace Dragons {
 

--- a/engines/dragons/dragonflg.h
+++ b/engines/dragons/dragonflg.h
@@ -22,7 +22,6 @@
 #define DRAGONS_DRAGONFLG_H
 
 #include "common/stream.h"
-#include "common/system.h"
 
 namespace Dragons {
 

--- a/engines/dragons/dragonimg.h
+++ b/engines/dragons/dragonimg.h
@@ -21,8 +21,6 @@
 #ifndef DRAGONS_DRAGONImg_H
 #define DRAGONS_DRAGONImg_H
 
-#include "common/system.h"
-
 namespace Dragons {
 
 struct Img {

--- a/engines/dragons/dragonini.h
+++ b/engines/dragons/dragonini.h
@@ -21,7 +21,6 @@
 #ifndef DRAGONS_DRAGONINI_H
 #define DRAGONS_DRAGONINI_H
 
-#include "common/system.h"
 #include "dragons/bigfile.h"
 
 namespace Dragons {

--- a/engines/dragons/dragonobd.h
+++ b/engines/dragons/dragonobd.h
@@ -21,8 +21,6 @@
 #ifndef DRAGONS_DRAGONOBD_H
 #define DRAGONS_DRAGONOBD_H
 
-#include "common/system.h"
-
 namespace Dragons {
 
 class BigfileArchive;

--- a/engines/dragons/dragonrms.h
+++ b/engines/dragons/dragonrms.h
@@ -21,8 +21,6 @@
 #ifndef DRAGONS_DRAGONRMS_H
 #define DRAGONS_DRAGONRMS_H
 
-#include "common/system.h"
-
 namespace Dragons {
 
 struct RMS {

--- a/engines/dragons/dragons.cpp
+++ b/engines/dragons/dragons.cpp
@@ -18,14 +18,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "gui/message.h"
 #include "common/config-manager.h"
 #include "common/keyboard.h"
 #include "common/language.h"
 #include "common/translation.h"
+#include "common/error.h"
+#include "common/events.h"
+#include "common/scummsys.h"
+#include "common/system.h"
 #include "engines/util.h"
 #include "graphics/thumbnail.h"
-#include "common/error.h"
+#include "gui/message.h"
 #include "dragons/actor.h"
 #include "dragons/actorresource.h"
 #include "dragons/background.h"

--- a/engines/dragons/dragons.h
+++ b/engines/dragons/dragons.h
@@ -21,10 +21,9 @@
 #ifndef DRAGONS_DRAGONS_H
 #define DRAGONS_DRAGONS_H
 
-#include "gui/EventRecorder.h"
 #include "engines/engine.h"
-#include "dragons/specialopcodes.h"
 #include "dragons/detection.h"
+#include "common/rect.h"
 
 namespace Dragons {
 

--- a/engines/dragons/dragonvar.h
+++ b/engines/dragons/dragonvar.h
@@ -21,7 +21,7 @@
 #ifndef DRAGONS_DRAGONVAR_H
 #define DRAGONS_DRAGONVAR_H
 
-#include "common/system.h"
+#include "common/scummsys.h"
 
 namespace Dragons {
 

--- a/engines/dragons/font.h
+++ b/engines/dragons/font.h
@@ -24,7 +24,6 @@
 #include "common/scummsys.h"
 #include "common/stream.h"
 #include "graphics/surface.h"
-#include "common/rect.h"
 
 namespace Dragons {
 

--- a/engines/dragons/inventory.h
+++ b/engines/dragons/inventory.h
@@ -22,8 +22,6 @@
 #ifndef DRAGONS_INVENTORY_H
 #define DRAGONS_INVENTORY_H
 
-#include "common/system.h"
-
 namespace Dragons {
 
 class Actor;

--- a/engines/dragons/metaengine.cpp
+++ b/engines/dragons/metaengine.cpp
@@ -28,7 +28,6 @@
 #include "backends/keymapper/keymapper.h"
 #include "backends/keymapper/standard-actions.h"
 #include "base/plugins.h"
-#include "graphics/thumbnail.h"
 
 class DragonsMetaEngine : public AdvancedMetaEngine<Dragons::DragonsGameDescription> {
 public:

--- a/engines/dragons/midimusicplayer.h
+++ b/engines/dragons/midimusicplayer.h
@@ -22,8 +22,8 @@
 #define DRAGONS_MIDIMUSICPLAYER_H
 
 #include "audio/midiplayer.h"
-#include "vabsound.h"
-#include "bigfile.h"
+#include "dragons/vabsound.h"
+#include "dragons/bigfile.h"
 
 namespace Dragons {
 

--- a/engines/dragons/minigame1.h
+++ b/engines/dragons/minigame1.h
@@ -21,8 +21,6 @@
 #ifndef DRAGONS_MINIGAME1_H
 #define DRAGONS_MINIGAME1_H
 
-#include "common/system.h"
-
 namespace Dragons {
 
 class DragonsEngine;

--- a/engines/dragons/minigame2.cpp
+++ b/engines/dragons/minigame2.cpp
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#include "common/scummsys.h"
 #include "dragons/minigame2.h"
 #include "dragons/actor.h"
 #include "dragons/actorresource.h"

--- a/engines/dragons/minigame2.h
+++ b/engines/dragons/minigame2.h
@@ -21,8 +21,6 @@
 #ifndef DRAGONS_MINIGAME2_H
 #define DRAGONS_MINIGAME2_H
 
-#include "common/system.h"
-
 namespace Dragons {
 
 class DragonsEngine;

--- a/engines/dragons/minigame4.cpp
+++ b/engines/dragons/minigame4.cpp
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#include "common/scummsys.h"
 #include "dragons/minigame4.h"
 #include "dragons/actor.h"
 #include "dragons/dragons.h"

--- a/engines/dragons/minigame4.h
+++ b/engines/dragons/minigame4.h
@@ -21,8 +21,6 @@
 #ifndef DRAGONS_MINIGAME4_H
 #define DRAGONS_MINIGAME4_H
 
-#include "common/system.h"
-
 namespace Dragons {
 
 class DragonsEngine;

--- a/engines/dragons/minigame5.cpp
+++ b/engines/dragons/minigame5.cpp
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#include "common/scummsys.h"
 #include "dragons/minigame5.h"
 #include "dragons/actor.h"
 #include "dragons/dragons.h"

--- a/engines/dragons/minigame5.h
+++ b/engines/dragons/minigame5.h
@@ -21,8 +21,6 @@
 #ifndef DRAGONS_MINIGAME5_H
 #define DRAGONS_MINIGAME5_H
 
-#include "common/system.h"
-
 namespace Dragons {
 
 class DragonsEngine;

--- a/engines/dragons/sound.h
+++ b/engines/dragons/sound.h
@@ -24,7 +24,7 @@
 #include "common/scummsys.h"
 #include "audio/mixer.h"
 #include "audio/audiostream.h"
-#include "midimusicplayer.h"
+#include "dragons/midimusicplayer.h"
 
 
 namespace Dragons {

--- a/engines/dragons/strplayer.cpp
+++ b/engines/dragons/strplayer.cpp
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#include "common/events.h"
 #include "video/psx_decoder.h"
 #include "dragons/dragons.h"
 #include "dragons/screen.h"


### PR DESCRIPTION
This avoids the inclusion of large system headers in all files (e.g. system.h), and fixes compilation with MSVC, which would not compile this engine without enabling language extensions, as system headers were included in the wrong order

Creating this as a PR to check that the engine still builds correctly in all builders
