### PR TITLE
MACVENTURE: Add title screens

### DIFF
--- a/engines/macventure/gui.cpp
+++ b/engines/macventure/gui.cpp
@@ -229,9 +229,11 @@ bool Gui::decodeStartupScreen() {
 }
 
 bool Gui::decodeTitleScreen() {
+	Common::MacResManager resMan;
 	Common::Path titlePath = _engine->getFilePath(kTitlePathID);
-	if (_resourceManager->open(titlePath)) {
-		Common::SeekableReadStream *stream = _resourceManager->getResource(MKTAG('P', 'P', 'I', 'C'), 0);
+
+	if (resMan.open(titlePath)) {
+		Common::SeekableReadStream *stream = resMan.getResource(MKTAG('P', 'P', 'I', 'C'), 0);
 
 		if (stream) {
 			// New PPICT title screen

--- a/engines/macventure/gui.h
+++ b/engines/macventure/gui.h
@@ -177,6 +177,10 @@ public:
 
 	void createInnerSurface(Graphics::ManagedSurface *innerSurface, Graphics::ManagedSurface *outerSurface, const BorderBounds &borders);
 
+private:
+	bool decodeStartupScreen();
+	bool decodeTitleScreen();
+	bool displayTitleScreenAndWait(uint32 ms);
 
 private: // Attributes
 

--- a/engines/macventure/image.cpp
+++ b/engines/macventure/image.cpp
@@ -116,7 +116,7 @@ ImageAsset::~ImageAsset() {
 }
 
 void ImageAsset::decodePPIC(Common::SeekableReadStream *baseStream, Common::Array<byte> &data, uint &bitHeight, uint &bitWidth, uint &rowBytes) {
-	Common::BitStream32BEMSB stream(baseStream);
+	Common::BitStream8MSB stream(baseStream);
 
 	uint8 mode = stream.getBits<3>();
 	int w, h;
@@ -179,7 +179,7 @@ void ImageAsset::decodePPIC(ObjID id, Common::Array<byte> &data, uint &bitHeight
 	decodePPIC(baseStream, data, bitHeight, bitWidth, rowBytes);
 }
 
-void ImageAsset::decodePPIC0(Common::BitStream32BEMSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes) {
+void ImageAsset::decodePPIC0(Common::BitStream8MSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes) {
 	uint words = bitWidth >> 4;
 	uint bytes = bitWidth & 0xF;
 	uint v = 0;
@@ -201,15 +201,15 @@ void ImageAsset::decodePPIC0(Common::BitStream32BEMSB &stream, Common::Array<byt
 
 }
 
-void ImageAsset::decodePPIC1(Common::BitStream32BEMSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes) {
+void ImageAsset::decodePPIC1(Common::BitStream8MSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes) {
 	decodeHuffGraphic(PPIC1Huff, stream, data, bitHeight, bitWidth, rowBytes);
 }
 
-void ImageAsset::decodePPIC2(Common::BitStream32BEMSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes) {
+void ImageAsset::decodePPIC2(Common::BitStream8MSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes) {
 	decodeHuffGraphic(PPIC2Huff, stream, data, bitHeight, bitWidth, rowBytes);
 }
 
-void ImageAsset::decodePPIC3(Common::BitStream32BEMSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes) {
+void ImageAsset::decodePPIC3(Common::BitStream8MSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes) {
 	// We need to load the huffman from the PPIC itself
 	PPICHuff huff;
 	uint16 v, bits;
@@ -261,7 +261,7 @@ void ImageAsset::decodePPIC3(Common::BitStream32BEMSB &stream, Common::Array<byt
 	decodeHuffGraphic(huff, stream, data, bitHeight, bitWidth, rowBytes);
 }
 
-void ImageAsset::decodeHuffGraphic(const PPICHuff &huff, Common::BitStream32BEMSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes) {
+void ImageAsset::decodeHuffGraphic(const PPICHuff &huff, Common::BitStream8MSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes) {
 	byte flags = 0;
 	_walkRepeat = 0;
 	_walkLast = 0;
@@ -356,7 +356,7 @@ void ImageAsset::decodeHuffGraphic(const PPICHuff &huff, Common::BitStream32BEMS
 	}
 }
 
-byte ImageAsset::walkHuff(const PPICHuff &huff, Common::BitStream32BEMSB &stream) {
+byte ImageAsset::walkHuff(const PPICHuff &huff, Common::BitStream8MSB &stream) {
 	if (_walkRepeat) {
 		_walkRepeat--;
 		_walkLast = ((_walkLast << 8) & 0xFF00) | (_walkLast >> 8);

--- a/engines/macventure/image.h
+++ b/engines/macventure/image.h
@@ -78,13 +78,13 @@ private:
 	void decodePPIC(Common::SeekableReadStream *baseStream, Common::Array<byte> &data, uint &bitHeight, uint &bitWidth, uint &rowBytes);
 	void decodePPIC(ObjID id, Common::Array<byte> &data, uint &bitHeight, uint &bitWidth, uint &rowBytes);
 
-	void decodePPIC0(Common::BitStream32BEMSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes);
-	void decodePPIC1(Common::BitStream32BEMSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes);
-	void decodePPIC2(Common::BitStream32BEMSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes);
-	void decodePPIC3(Common::BitStream32BEMSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes);
+	void decodePPIC0(Common::BitStream8MSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes);
+	void decodePPIC1(Common::BitStream8MSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes);
+	void decodePPIC2(Common::BitStream8MSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes);
+	void decodePPIC3(Common::BitStream8MSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes);
 
-	void decodeHuffGraphic(const PPICHuff &huff, Common::BitStream32BEMSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes);
-	byte walkHuff(const PPICHuff &huff, Common::BitStream32BEMSB &stream);
+	void decodeHuffGraphic(const PPICHuff &huff, Common::BitStream8MSB &stream, Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes);
+	byte walkHuff(const PPICHuff &huff, Common::BitStream8MSB &stream);
 
 	void blitDirect(Graphics::ManagedSurface *target, int ox, int oy, const Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes);
 	void blitBIC(Graphics::ManagedSurface *target, int ox, int oy, const Common::Array<byte> &data, uint bitHeight, uint bitWidth, uint rowBytes);

--- a/engines/macventure/macventure.cpp
+++ b/engines/macventure/macventure.cpp
@@ -156,6 +156,7 @@ Common::Error MacVentureEngine::run() {
 		}
 	} else {
 		setNewGameState();
+		_gui->drawTitle();
 	}
 	selectControl(kStartOrResume);
 


### PR DESCRIPTION
This adds support for the MacVenture title screens, both StartupScreen (which would originally be shown when booting the computer from the game floppy) and the actual title screen. Deja Vu II only has the latter. I have tested this with the Zojoi re-releases. There is code for handling the older PACK format as well, but someone else will have to test and fix that if needed.

I had to change the 32-bit bit reader to an 8-bit one, because the length of the title screen PPIC isn't a multiple of 4.

How long the title screens should be displayed is debatable. You can skip them with ESC, but I think they set a nice mood. Though now I can't unsee how sloppily they painted over their old address for Uninvited...

<img width="256" height="171" alt="scummvm-deja_vu-00003" src="https://github.com/user-attachments/assets/eab16785-f708-4534-9d9b-c4d503b8d9c7" />
<img width="256" height="171" alt="scummvm-deja_vu-00004" src="https://github.com/user-attachments/assets/be3133cd-d3a8-4002-9735-e617566146ef" />
<img width="256" height="171" alt="scummvm-uninvited-00001" src="https://github.com/user-attachments/assets/1a748cfc-08bc-476b-9fba-52edf5eb0285" />
<img width="256" height="171" alt="scummvm-uninvited-00002" src="https://github.com/user-attachments/assets/99f0598f-f00f-4534-b7b1-26a16823da2e" />
<img width="256" height="171" alt="scummvm-shadowgate-00000" src="https://github.com/user-attachments/assets/4e95aaef-486c-44a3-b9eb-c3b9f473111d" />
<img width="256" height="171" alt="scummvm-shadowgate-00001" src="https://github.com/user-attachments/assets/169e0255-d602-4349-bdb1-18d8be5cf533" />
<img width="256" height="171" alt="scummvm-deja_vu2-00000" src="https://github.com/user-attachments/assets/d9146325-3d91-433c-bbfc-523cb10173c1" />


