### PR TITLE
HPL1: Add detection entries for some mac releases and demos

### DIFF
--- a/engines/hpl1/detection.cpp
+++ b/engines/hpl1/detection.cpp
@@ -44,6 +44,7 @@ const DebugChannelDef Hpl1MetaEngineDetection::debugFlagList[] = {
 
 Hpl1MetaEngineDetection::Hpl1MetaEngineDetection() : AdvancedMetaEngineDetection(Hpl1::GAME_DESCRIPTIONS,
 																				 Hpl1::GAME_NAMES) {
+	_flags = kADFlagMatchFullPaths;
 }
 
 REGISTER_PLUGIN_STATIC(HPL1_DETECTION, PLUGIN_TYPE_ENGINE_DETECTION, Hpl1MetaEngineDetection);

--- a/engines/hpl1/detection_tables.h
+++ b/engines/hpl1/detection_tables.h
@@ -51,6 +51,50 @@ const ADGameDescription GAME_DESCRIPTIONS[] = {
 		GUIO0()
 	},
 
+	// Penumbra: Overture (GOG v1.1.1 - Mac Intel only)
+	{
+		"penumbraoverture",
+		nullptr,
+		AD_ENTRY1s("Penumbra.app/Contents/MacOS/Penumbra", "e893ccac7b311ab1559890837aa131b0", 8234848),
+		Common::Language::EN_ANY,
+		Common::Platform::kPlatformMacintosh,
+		ADGF_TESTING,
+		GUIO0()
+	},
+
+	// Penumbra: Overture (v1.0.3 - Mac PPC + Intel)
+	{
+		"penumbraoverture",
+		nullptr,
+		AD_ENTRY1s("Penumbra.app/Contents/MacOS/Penumbra", "1fcca1c15ac595c84c49c01692b90c0d", 17446384),
+		Common::Language::EN_ANY,
+		Common::Platform::kPlatformMacintosh,
+		ADGF_TESTING,
+		GUIO0()
+	},
+
+	// Penumbra: Overture (v1.0 - Mac demo)
+	{
+		"penumbraoverture",
+		nullptr,
+		AD_ENTRY1s("PenumbraDemo.app/Contents/MacOS/PenumbraDemo", "656342216967baaaa80eb413d5c93b29", 16203948),
+		Common::Language::EN_ANY,
+		Common::Platform::kPlatformMacintosh,
+		ADGF_TESTING | ADGF_DEMO,
+		GUIO0()
+	},
+
+	// Penumbra: Overture (v1.0.3 - Mac demo)
+	{
+		"penumbraoverture",
+		nullptr,
+		AD_ENTRY1s("PenumbraDemo.app/Contents/MacOS/PenumbraDemo", "c898d408859f80d260dbe0bd312c3acf", 17402172),
+		Common::Language::EN_ANY,
+		Common::Platform::kPlatformMacintosh,
+		ADGF_TESTING | ADGF_DEMO,
+		GUIO0()
+	},
+
 	// Penumbra: Overture (The Penumbra Collection)
 	// TRAC #14674
 	{


### PR DESCRIPTION
This commit adds detection for two versions of the mac release:
- v1.0.3 which supports both Mac PPC and 32 bit Intel
- v1.1.1 which is 32 bit Intel only

It also adds the detection for two mac demos.
I uploaded those demos to https://downloads.scummvm.org/frs/demos/hpl1/

This is proposed as a pull request because there was a question raised in Discord on possibly changing the detection to use other files than the executable. The detections above were added using the executable, and looking for it in the Penumbra.app bundle so that the user does not have to move files around. This required setting the `kADFlagMatchFullPaths` for the detection.

I verified both full game versions and both demos start. But I only played a few minutes of the game with each one.