### PR TITLE
HYPNO: Fix playing music during cutscenes

### DIFF
--- a/engines/hypno/actions.cpp
+++ b/engines/hypno/actions.cpp
@@ -136,7 +136,6 @@ void HypnoEngine::runIntro(Intro *a) {
 void HypnoEngine::runCutscene(Cutscene *a) {
 	stopSound();
 	defaultCursor();
-	_music.clear();
 	MVideo v(a->path, Common::Point(0, 0), false, true, false);
 	disableCursor();
 	runIntro(v);

--- a/engines/hypno/arcade.cpp
+++ b/engines/hypno/arcade.cpp
@@ -550,11 +550,8 @@ void HypnoEngine::runArcade(ArcadeShooting *arc) {
 			}
 		}
 
-		if (_music.empty() && !arc->music.empty()) {
-			_music = _soundPath + arc->music;
-			_musicRate = arc->musicRate;
-			_musicStereo = arc->musicStereo;
-			playSound(_music, 0, _musicRate, _musicStereo); // music loop forever
+		if (!isMusicActive() && !arc->music.empty()) {
+			playMusic(_soundPath + arc->music, arc->musicRate, arc->musicStereo);
 		}
 
 		if (needsUpdate) {
@@ -609,7 +606,7 @@ void HypnoEngine::runArcade(ArcadeShooting *arc) {
 	_timerStarted = false;
 	removeTimers();
 	stopSound();
-	_music.clear();
+	stopMusic();
 }
 
 Common::Point HypnoEngine::computeTargetPosition(const Common::Point &mousePos) {
@@ -720,8 +717,6 @@ bool HypnoEngine::shoot(const Common::Point &mousePos, ArcadeShooting *arc, bool
 				_background->decoder->pauseVideo(false);
 				updateScreen(*_background);
 				drawScreen();
-				if (!_music.empty())
-					playSound(_music, 0, _musicRate, _musicStereo); // restore music
 			} else if (_objIdx == 1 && !arc->hitBoss2Video.empty()) {
 				_background->decoder->pauseVideo(true);
 				MVideo video(arc->hitBoss2Video, Common::Point(0, 0), false, true, false);
@@ -732,8 +727,6 @@ bool HypnoEngine::shoot(const Common::Point &mousePos, ArcadeShooting *arc, bool
 				updateScreen(*_background);
 				drawScreen();
 				drawCursorArcade(mousePos);
-				if (!_music.empty())
-					playSound(_music, 0, _musicRate, _musicStereo); // restore music
 			}
 			byte p[3] = {0x00, 0x00, 0x00}; // Always black?
 			assert(_shoots[i].paletteSize == 1 || _shoots[i].paletteSize == 0);

--- a/engines/hypno/boyz/arcade.cpp
+++ b/engines/hypno/boyz/arcade.cpp
@@ -390,8 +390,6 @@ bool BoyzEngine::checkTransition(ArcadeTransitions &transitions, ArcadeShooting 
 
 			_background->decoder->pauseVideo(false);
 			_masks->decoder->pauseVideo(false);
-			if (!_music.empty())
-				playSound(_music, 0, _musicRate, _musicStereo); // restore music
 			drawPlayer();
 			updateScreen(*_background);
 			drawScreen();
@@ -639,8 +637,6 @@ bool BoyzEngine::shoot(const Common::Point &mousePos, ArcadeShooting *arc, bool 
 					_shootsDestroyed[_shoots[i].name] = true;
 					updateScreen(*_background);
 					drawScreen();
-					if (!_music.empty())
-						playSound(_music, 0, _musicRate, _musicStereo); // restore music
 				}
 			} else if (_shoots[i].interactionFrame > 0) {
 				incFriendliesEncountered();
@@ -685,9 +681,6 @@ bool BoyzEngine::shoot(const Common::Point &mousePos, ArcadeShooting *arc, bool 
 				_background->decoder->pauseVideo(false);
 				updateScreen(*_background);
 				drawScreen();
-				if (!_music.empty())
-					playSound(_music, 0, _musicRate, _musicStereo); // restore music
-
 				hitPlayer();
 			}
 			if (_shoots[i].explosionFrames.size() == 0)

--- a/engines/hypno/hypno.h
+++ b/engines/hypno/hypno.h
@@ -37,6 +37,10 @@
 #include "hypno/grammar.h"
 #include "hypno/libfile.h"
 
+namespace Audio {
+class SeekableAudioStream;
+}
+
 namespace Image {
 class ImageDecoder;
 }
@@ -148,7 +152,7 @@ public:
 	bool _unlockAllLevels;
 	bool _restoredContentEnabled;
 
-	Audio::SoundHandle _soundHandle;
+	Audio::SoundHandle _soundHandle, _musicHandle;
 	Common::InstallShieldV3 _installerArchive;
 	Common::List<LibFile*> _archive;
 
@@ -289,12 +293,12 @@ public:
 
 	// Sounds
 	Filename _soundPath;
-	Filename _music;
-	int _musicRate;
-	bool _musicStereo;
-	bool _doNotStopSounds;
+	Audio::SeekableAudioStream *loadAudioStream(const Filename &filename, uint32 sampleRate = 22050, bool stereo = false);
 	void playSound(const Filename &filename, uint32 loops, uint32 sampleRate = 22050, bool stereo = false);
+	void playMusic(const Filename &filename, uint32 sampleRate = 22050, bool stereo = false);
 	void stopSound();
+	void stopMusic();
+	bool isMusicActive();
 
 	// Arcade
 	Common::String _arcadeMode;

--- a/engines/hypno/scene.cpp
+++ b/engines/hypno/scene.cpp
@@ -509,11 +509,6 @@ void HypnoEngine::runScene(Scene *scene) {
 			}
 		}
 
-		if (_music.empty() && !scene->music.empty() && _videosPlaying.empty() && _nextSequentialVideoToPlay.empty()) {
-			_music = scene->music;
-			playSound(_music, 0, scene->musicRate);
-		}
-
 		if (!_videosPlaying.empty() || !_videosLooping.empty() || !_nextSequentialVideoToPlay.empty()) {
 			drawScreen();
 			continue;
@@ -531,6 +526,10 @@ void HypnoEngine::runScene(Scene *scene) {
 			runMenu(stack.back());
 			_nextHotsToAdd = nullptr;
 			drawScreen();
+		}
+
+		if (!isMusicActive() && !scene->music.empty()) {
+			playMusic(scene->music, scene->musicRate);
 		}
 
 		g_system->updateScreen();

--- a/engines/hypno/spider/spider.cpp
+++ b/engines/hypno/spider/spider.cpp
@@ -1202,6 +1202,7 @@ void SpiderEngine::loadGame(const Common::String &nextLevel, int score, int puzz
 
 	// We don't want to continue with any sound from a previous game
 	stopSound();
+	stopMusic();
 	_sceneState["GS_PUZZLELEVEL"] = puzzleDifficulty;
 	_sceneState["GS_COMBATLEVEL"] = combatDifficulty;
 	_score = score;

--- a/engines/hypno/spider/talk.cpp
+++ b/engines/hypno/spider/talk.cpp
@@ -135,7 +135,6 @@ void SpiderEngine::showConversation() {
 		}
 
 		endConversation();
-		_music.clear();
 
 		if (shouldEscape) {
 			runIntros(_escapeSequentialVideoToPlay);

--- a/engines/hypno/wet/arcade.cpp
+++ b/engines/hypno/wet/arcade.cpp
@@ -390,8 +390,6 @@ bool WetEngine::checkTransition(ArcadeTransitions &transitions, ArcadeShooting *
 			updateScreen(*_background);
 			drawScreen();
 			drawCursorArcade(g_system->getEventManager()->getMousePos());
-			if (!_music.empty())
-				playSound(_music, 0, _musicRate); // restore music
 		} else
 			error ("Invalid transition at %d", ttime);
 
@@ -740,8 +738,6 @@ void WetEngine::pressedKey(const int keycode) {
 		_background->decoder->pauseVideo(false);
 		updateScreen(*_background);
 		drawScreen();
-		if (!_music.empty())
-			playSound(_music, 0, _musicRate); // restore music
 	} else if (keycode == kActionSkipLevel) { // Added for testing
 		_skipLevel = true;
 	} else if (keycode == kActionKillPlayer) { // Added for testing
@@ -904,8 +900,6 @@ void WetEngine::missNoTarget(ArcadeShooting *arc) {
 			_background->decoder->pauseVideo(false);
 			updateScreen(*_background);
 			drawScreen();
-			if (!_music.empty())
-				playSound(_music, 0, _musicRate); // restore music
 			break;
 		} else if (it->name == "SP_BOSS2" && !arc->missBoss2Video.empty()) {
 			_background->decoder->pauseVideo(true);
@@ -917,8 +911,6 @@ void WetEngine::missNoTarget(ArcadeShooting *arc) {
 			_background->decoder->pauseVideo(false);
 			updateScreen(*_background);
 			drawScreen();
-			if (!_music.empty())
-				playSound(_music, 0, _musicRate); // restore music
 			break;
 		}
 	}

--- a/engines/hypno/wet/hard.cpp
+++ b/engines/hypno/wet/hard.cpp
@@ -86,6 +86,7 @@ void WetEngine::runLevelMenu(Code *code) {
 	loadPalette((byte *) &lime, 192+currentLevel, 1);
 	drawImage(*menu, 0, 0, false);
 	bool cont = true;
+	// TODO: Should this be played as music instead?
 	playSound("sound/bub01.raw", 0, 22050);
 
 	Common::Keymapper *keymapper = g_system->getEventManager()->getKeymapper();


### PR DESCRIPTION
This fixes [Trac #13268](https://bugs.scummvm.org/ticket/13268), although there are still a number of missing sound effects. Only tested with the demo of Spider-Man: The Sinister Six.