### PR TITLE
BAGEL: Fix Maze O' Doom Demo

### DIFF
--- a/engines/bagel/hodjnpodj/hodjnpodj.cpp
+++ b/engines/bagel/hodjnpodj/hodjnpodj.cpp
@@ -70,9 +70,6 @@ Common::Error HodjNPodjEngine::run() {
 
 	} else {
 		Metagame::Frame::CTheApp app;
-		app.InitApplication();
-		app.InitInstance();
-		app.setKeybinder(KeybindToKeycode);
 
 		if (getGameId() == "mazeodoom") {
 			app.setStartupMinigame("mazedoom_demo");
@@ -86,6 +83,9 @@ Common::Error HodjNPodjEngine::run() {
 			if (!minigame.empty())
 				app.setStartupMinigame(minigame);
 		}
+		app.InitApplication();
+		app.InitInstance();
+		app.setKeybinder(KeybindToKeycode);
 
 		app.Run();
 	}


### PR DESCRIPTION
The Maze O' Doom Demo currently doesn't start wth the following error: `Could not load hodjpodj.exe!`

From what I understood, this is because the minigame is not selected when calling initApplication. From git blame it seems this was inadvertedly changed in 9d3c783ed2c0317e0613e72fb0f5ef5a8ea90912 when initApplication was moved ahead of the minigame selection when it was in App.run previously (which is called after the minigame selection)