### PR TITLE
GRAPHICS: FONTS: Adds DosFont as a Renderable Font

### DIFF
--- a/graphics/fonts/dosfont.cpp
+++ b/graphics/fonts/dosfont.cpp
@@ -20,8 +20,42 @@
  */
 
 #include "graphics/fonts/dosfont.h"
+#include "graphics/surface.h"
 
 namespace Graphics {
+
+DosFont::DosFont() {}
+
+int DosFont::getFontHeight() const {
+	return 8;
+}
+
+int DosFont::getMaxCharWidth() const {
+	return 8;
+}
+
+int DosFont::getCharWidth(uint32 chr) const {
+	return 8;
+}
+
+void DosFont::drawChar(Graphics::Surface *dst, uint32 chr, int x, int y, uint32 color) const {
+	int srcPixel = chr * 8;
+	for (int sy = 0; sy < 8; sy++) {
+		for (int sx = 0; sx < 8; sx++) {
+			if (Graphics::DosFont::fontData_PCBIOS[srcPixel] & 1 << (7 - sx)) {
+				if (dst->format.bytesPerPixel == 1)
+					*((byte *)dst->getBasePtr(x + sx, y + sy)) = color;
+				else if (dst->format.bytesPerPixel == 2)
+					*((uint16 *)dst->getBasePtr(x + sx, y + sy)) = color;
+				else if (dst->format.bytesPerPixel == 4)
+					*((uint32 *)dst->getBasePtr(x + sx, y + sy)) = color;
+			}
+		}
+		srcPixel++;
+	}
+}
+
+
 // 8x8 font patterns
 
 // this is basically the standard PC BIOS font, taken from Dos-Box, with a few modifications

--- a/graphics/fonts/dosfont.h
+++ b/graphics/fonts/dosfont.h
@@ -26,8 +26,14 @@
 
 namespace Graphics {
 
-// For now just a holder for static data. May become a child of Font if needed.
-class DosFont {
+class DosFont : public Graphics::Font {
+public:
+	DosFont();
+
+	int getFontHeight() const override;
+	int getMaxCharWidth() const override;
+	int getCharWidth(uint32 chr) const override;
+	void drawChar(Graphics::Surface *dst, uint32 chr, int x, int y, uint32 color) const override;
 public:
 // 8x8 font patterns
 


### PR DESCRIPTION
Turns DosFont, previously merely a static binary array, into a renderable font. Code taken from the Trick or Treat engine merge [PR](https://github.com/scummvm/scummvm/pull/6902).

Sample screenshot
<img width="640" height="400" alt="scummvm-tot-es-00002" src="https://github.com/user-attachments/assets/29c7cdcb-b52e-4595-8130-402ce8e5ff02" />
