### PR TITLE
WAGE: Make combat less broken (bug #16194)

### DIFF
--- a/engines/wage/combat.cpp
+++ b/engines/wage/combat.cpp
@@ -296,20 +296,20 @@ bool WageEngine::attackHit(Chr *attacker, Chr *victim, Obj *weapon, int targetIn
 	}
 
 	if (causesPhysicalDamage) {
-		victim->_context._userVariables[PHYS_HIT_CUR] -= weapon->_damage;
+		victim->_context._statVariables[PHYS_HIT_CUR] -= weapon->_damage;
 
 		/* Do it here to get the right order of messages in case of death. */
 		decrementUses(weapon);
 		usesDecremented = true;
 
-		if (victim->_context._userVariables[PHYS_HIT_CUR] < 0) {
+		if (victim->_context._statVariables[PHYS_HIT_CUR] < 0) {
 			playSound(victim->_dyingSound);
 			appendText(victim->_dyingWords.c_str());
 			snprintf(buf, 512, "%s%s is dead!", victim->getDefiniteArticle(true), victim->_name.c_str());
 			appendText(buf);
 
 			attacker->_context._kills++;
-			attacker->_context._experience += victim->_context._userVariables[SPIR_HIT_CUR] + victim->_context._userVariables[PHYS_HIT_CUR];
+			attacker->_context._experience += victim->_context._statVariables[SPIR_HIT_CUR] + victim->_context._statVariables[PHYS_HIT_CUR];
 
 			if (!victim->_playerCharacter && !victim->_inventory.empty()) {
 				Scene *currentScene = victim->_currentScene;
@@ -324,8 +324,8 @@ bool WageEngine::attackHit(Chr *attacker, Chr *victim, Obj *weapon, int targetIn
 			}
 			_world->move(victim, _world->_storageScene);
 		} else if (attacker->_playerCharacter && !receivedHitTextPrinted) {
-			double physicalPercent = (double)victim->_context._userVariables[SPIR_HIT_CUR] /
-					victim->_context._userVariables[SPIR_HIT_BAS];
+			double physicalPercent = (double)victim->_context._statVariables[SPIR_HIT_CUR] /
+					victim->_context._statVariables[SPIR_HIT_BAS];
 			snprintf(buf, 512, "%s%s's condition appears to be %s.",
 				victim->getDefiniteArticle(true), victim->_name.c_str(),
 				getPercentMessage(physicalPercent));


### PR DESCRIPTION
Currently, combat in the World Builder games appears to be quite broken, and this is a central game mechanic in many of them:

- I have yet to see a fight that didn't end as soon as either you or your opponent lands a hit.
- On winning a fight, your experience goes down instead of up.

I think the problem is a simple mix-up. The `Context` class has two sets of variables:

```
	int16 _userVariables[26 * 9];
	int16 _statVariables[18];
```

The `StatVariabe` enum has 18 values from 0 through 17. It seems reasonable to assume that they should only be used as indexes into `_statVariables`, so I've changed the few cases where they were used with `_userVariables` instead. Doing that seems to fix both issues. Note that there are still a number of "TODO" comments in combat.cpp, but I have no idea how to fix those properly.