### PR TITLE
TWP: Thimbleweed Park should not crash if FBO support is missing

### DIFF
--- a/engines/twp/twp.cpp
+++ b/engines/twp/twp.cpp
@@ -1013,10 +1013,14 @@ Common::Error TwpEngine::run() {
 	AchMan.setActiveDomain(getMetaEngine()->getAchievementsInfo(gameTarget));
 
 	if (!g_system->hasFeature(OSystem::kFeatureShadersForGame)) {
-		return Common::Error(Common::kUnknownError, "Thimbleweed Park requires OpenGL with shaders which is not supported on your system");
+		return Common::Error(Common::kUnknownError, _s("This game requires OpenGL with shaders, which is not supported on your system"));
 	}
 
 	initGraphics3d(SCREEN_WIDTH, SCREEN_HEIGHT);
+
+	if (!OpenGLContext.framebufferObjectSupported) {
+		return Common::Error(Common::kUnknownError, _s("This game requires OpenGL Framebuffer Objects, which are not supported on your system"));
+	}
 
 	// Set the engine's debugger console
 	setDebugger(new Console());


### PR DESCRIPTION
See [Trac#15711](https://bugs.scummvm.org/ticket/15711); TWP seems to have a hard requirement for Framebuffer Objects, but the engine didn't check for this feature.

(I've changed the error messages a bit, so that they could be reused for other games in the whole tree if necessary.)

Use of `framebufferObjectSupported` suggested by @lephilousophe ;)