### PR TITLE
M4: Fix for case-sensitive file systems

### DIFF
--- a/engines/m4/m4.cpp
+++ b/engines/m4/m4.cpp
@@ -55,8 +55,8 @@ M4Engine::~M4Engine() {
 
 void M4Engine::initializePath(const Common::FSNode &gamePath) {
 	Engine::initializePath(gamePath);
-	SearchMan.addDirectory(gamePath.getChild("goodstuf"));
-	SearchMan.addDirectory(gamePath.getChild("resource"), 0, 2);
+	SearchMan.addSubDirectoryMatching(gamePath, "goodstuf");
+	SearchMan.addSubDirectoryMatching(gamePath, "resource");
 }
 
 uint32 M4Engine::getFeatures() const {

--- a/engines/m4/riddle/riddle.cpp
+++ b/engines/m4/riddle/riddle.cpp
@@ -47,7 +47,7 @@ RiddleEngine::RiddleEngine(OSystem *syst, const M4GameDescription *gameDesc) :
 
 void RiddleEngine::initializePath(const Common::FSNode &gamePath) {
 	M4Engine::initializePath(gamePath);
-	SearchMan.addDirectory(gamePath.getChild("option1"));
+	SearchMan.addSubDirectoryMatching(gamePath, "option1");
 }
 
 M4::Vars *RiddleEngine::createVars() {


### PR DESCRIPTION
I noticed that the https://downloads.scummvm.org/frs/demos/m4/  don't work on case-sensitive file systems anymore. The directory names in code are all in lower case, while the actual files are named upper case. 

This was not an issue before 7f959eca7efa79a9a4014d2d2896a212933b63d0, and this commit partially reverts that. `SearchMan.addSubDirectoryMatching` works case insensitive (as do the later `File::open` usages), but  `SearchMan.addDirectory` is case sensitive. 

I'm not 100% sure if this is the correct fix, or whether we should:
- use upper-case folder names in code (are they always upper case for all version? presumably, but I don't own the full versions)
- add the relative subdirectory names to the paths when calling `File::open`  (since that is case insensitive)
- Fix `SearchMan.addDirectory` to work case insensitive.
