### PR TITLE
MADE: Allow using Win16 cursors for Rodney's Funscreen

### DIFF
--- a/engines/made/detection.h
+++ b/engines/made/detection.h
@@ -53,6 +53,7 @@ struct MadeGameDescription {
 
 #define GAMEOPTION_INTRO_MUSIC_DIGITAL GUIO_GAMEOPTIONS1
 #define GAMEOPTION_TTS                 GUIO_GAMEOPTIONS2
+#define GAMEOPTION_WINDOWS_CURSORS     GUIO_GAMEOPTIONS3
 
 } // End of namespace Made
 

--- a/engines/made/detection_tables.h
+++ b/engines/made/detection_tables.h
@@ -22,7 +22,8 @@
 #ifndef MADE_DETECTION_TABLES_H
 #define MADE_DETECTION_TABLES_H
 
-#include "engines/advancedDetector.h"
+#include "made/detection.h"
+
 #include "common/translation.h"
 
 namespace Made {
@@ -615,14 +616,15 @@ static const MadeGameDescription gameDescriptions[] = {
 
 	{
 		// Rodney's Funscreen
+		// MS-DOS, Win16 and Tandy VIS all share the same resource but a different player.
 		{
 			"rodney",
 			"",
-			AD_ENTRY1("rodneys.dat", "a79887dbaa47689facd7c6f09258ba5a"),
+			AD_ENTRY1s("rodneys.dat", "a79887dbaa47689facd7c6f09258ba5a", 92990),
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_NO_FLAGS,
-			GUIO1(GUIO_NOSPEECH)
+			GUIO2(GUIO_NOSPEECH, GAMEOPTION_WINDOWS_CURSORS)
 		},
 		GID_RODNEY,
 		0,

--- a/engines/made/made.h
+++ b/engines/made/made.h
@@ -95,6 +95,8 @@ public:
 	ScriptInterpreter *_script;
 	MusicPlayer *_music;
 
+	bool _useWinCursors;
+
 	uint16 _eventNum;
 	int _eventMouseX, _eventMouseY;
 	uint16 _eventKey;

--- a/engines/made/metaengine.cpp
+++ b/engines/made/metaengine.cpp
@@ -57,6 +57,17 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 		}
 	},
 #endif
+	{
+		GAMEOPTION_WINDOWS_CURSORS,
+		{
+			_s("Use Windows mouse cursors"),
+			_s("If selected, the game will use Windows mouse cursors bundled in the original .exe file. Otherwise, it will use lower resolution cursors from the data files."),
+			"windows_cursors",
+			true,
+			0,
+			0
+		}
+	},
 
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };

--- a/engines/made/screen.cpp
+++ b/engines/made/screen.cpp
@@ -979,6 +979,10 @@ void Screen::clearSpriteList() {
 	_spriteList.clear();
 }
 
+void Screen::setMouseCursor(const Graphics::Cursor *cursor) {
+	CursorMan.replaceCursor(cursor, true);
+}
+
 void Screen::setDefaultMouseCursor() {
 	CursorMan.replaceCursor(defaultMouseCursor, 16, 16, 9, 2, 0);
 }

--- a/engines/made/screen.h
+++ b/engines/made/screen.h
@@ -26,6 +26,8 @@
 
 #include "common/rect.h"
 
+#include "graphics/cursor.h"
+
 namespace Made {
 
 struct SpriteChannel {
@@ -189,6 +191,7 @@ public:
 	SpriteListItem getFromSpriteList(int16 index);
 	void clearSpriteList();
 
+	void setMouseCursor(const Graphics::Cursor *cursor);
 	void setDefaultMouseCursor();
 
 protected:

--- a/engines/made/scriptfuncs.cpp
+++ b/engines/made/scriptfuncs.cpp
@@ -32,6 +32,7 @@
 
 #include "common/config-manager.h"
 
+#include "graphics/wincursor.h"
 #include "graphics/cursorman.h"
 #include "graphics/surface.h"
 
@@ -632,11 +633,16 @@ int16 ScriptFunctions::sfSetFontOutline(int16 argc, int16 *argv) {
 }
 
 int16 ScriptFunctions::sfLoadMouseCursor(int16 argc, int16 *argv) {
-	PictureResource *flex = _vm->_res->getPicture(argv[2]);
-	if (flex) {
-		Graphics::Surface *surf = flex->getPicture();
-		CursorMan.replaceCursor(*surf, argv[1], argv[0], 0);
-		_vm->_res->freeResource(flex);
+
+	if (_vm->_useWinCursors) {
+		debug(4, "sfLoadMouseCursor: Not replacing mouse cursor, hand already active");
+	} else {
+		PictureResource *flex = _vm->_res->getPicture(argv[2]);
+		if (flex) {
+			Graphics::Surface *surf = flex->getPicture();
+			CursorMan.replaceCursor(*surf, argv[1], argv[0], 0);
+			_vm->_res->freeResource(flex);
+		}
 	}
 	return 0;
 }

--- a/graphics/cursorman.cpp
+++ b/graphics/cursorman.cpp
@@ -206,9 +206,9 @@ void CursorManager::replaceCursor(const Surface &surf, int hotspotX, int hotspot
 	g_system->setMouseCursor(cur->_surf.getPixels(), surf.w, surf.h, hotspotX, hotspotY, keycolor, dontScale, &cur->_surf.format, mask);
 }
 
-void CursorManager::replaceCursor(const Graphics::Cursor *cursor) {
+void CursorManager::replaceCursor(const Graphics::Cursor *cursor, bool dontScale) {
 	replaceCursor(cursor->getSurface(), cursor->getWidth(), cursor->getHeight(), cursor->getHotspotX(),
-				  cursor->getHotspotY(), cursor->getKeyColor(), false, nullptr, cursor->getMask());
+				  cursor->getHotspotY(), cursor->getKeyColor(), dontScale, nullptr, cursor->getMask());
 
 	if (cursor->getPalette())
 		replaceCursorPalette(cursor->getPalette(), cursor->getPaletteStartIndex(), cursor->getPaletteCount());

--- a/graphics/cursorman.h
+++ b/graphics/cursorman.h
@@ -166,8 +166,10 @@ public:
 	 * more optimized way of popping the old cursor before pushing the new one.
 	 *
 	 * @param cursor	New cursor.
+	 * @param dontScale	Whether the cursor should never be scaled. An exception are high PPI displays, where the cursor
+	 *                  would be too small to notice otherwise. These are allowed to scale the cursor anyway.
 	 */
-	void replaceCursor(const Graphics::Cursor *cursor);
+	void replaceCursor(const Graphics::Cursor *cursor, bool dontScale = false);
 
 	/**
 	 * Pop all cursors and cursor palettes from their respective stacks.


### PR DESCRIPTION
The Windows port of the MADE engine handles cursors through the usual
Win16 API, unlike the MS-DOS version which provides its own cursor
handling system.  Mouse cursors are stored in the MADE .exe file and
loaded at startup.  For Rodney's Funscreen, this is just the "hand"
cursor in-game, though others (e.g. a lightning bolt) are in the .exe too.

This PR allows using the Windows cursors in place of the lower-resolution
data file MS-DOS cursors, if the .exe is present alongside the data files.
Both the Windows and Tandy VIS executables work for this.

Note also this exposes the `dontScale` flag for `replaceCursor()`
in CursorMan.c - though the default is "false".