### PR TITLE
ALCACHOFA: Use ScummVM GUI dialogs instead of OS message boxes

### DIFF
--- a/engines/alcachofa/POTFILES
+++ b/engines/alcachofa/POTFILES
@@ -1,1 +1,2 @@
+engines/alcachofa/graphics-opengl.cpp
 engines/alcachofa/metaengine.cpp

--- a/engines/alcachofa/graphics-opengl.cpp
+++ b/engines/alcachofa/graphics-opengl.cpp
@@ -24,9 +24,11 @@
 #include "alcachofa/graphics-opengl.h"
 
 #include "common/system.h"
+#include "common/translation.h"
 #include "common/config-manager.h"
 #include "engines/util.h"
 #include "graphics/renderer.h"
+#include "gui/error.h"
 
 using namespace Common;
 using namespace Math;
@@ -125,7 +127,7 @@ OpenGLRenderer::OpenGLRenderer(Point resolution) : _resolution(resolution) {
 	GL_CALL(glDepthMask(GL_FALSE));
 
 	if (!OpenGLContext.NPOTSupported || !OpenGLContext.textureMirrorRepeatSupported) {
-		g_system->messageBox(LogMessageType::kWarning, "Old OpenGL detected, some graphical errors will occur.");
+		GUI::displayErrorDialog(_("Old OpenGL detected, some graphical errors will occur."));
 	}
 }
 


### PR DESCRIPTION
`OSystem::messageBox` isn't implemented on many platforms, and is only really meant to be a last resort in case the GUI wasn't able to handle an error that would cause ScummVM to exit.

The error message string has also been marked as translatable.