### PR TITLE
HPL1: Add detection entries for Mac Steam release

### DIFF
--- a/engines/hpl1/detection_tables.h
+++ b/engines/hpl1/detection_tables.h
@@ -62,6 +62,17 @@ const ADGameDescription GAME_DESCRIPTIONS[] = {
 		GUIO0()
 	},
 
+	// Penumbra: Overture (Steam v1.1.1 - Mac Intel only)
+	{
+		"penumbraoverture",
+		nullptr,
+		AD_ENTRY1s("Penumbra.app/Contents/MacOS/Penumbra", "18d91c220e3461f2f7cf257009068416", 8468352),
+		Common::Language::EN_ANY,
+		Common::Platform::kPlatformMacintosh,
+		ADGF_TESTING,
+		GUIO0()
+	},
+
 	// Penumbra: Overture (v1.0.3 - Mac PPC + Intel)
 	{
 		"penumbraoverture",


### PR DESCRIPTION
This commit expands detection for version 1.1.1 of the mac release by adding the Steam version's info.

This builds off of the work of pull request #6916.

Note that I have not personally tested this. 
