### PR TITLE
AGI: fix display method on RTL language and update kq1 Hebrew fan made checksum 

### DIFF
--- a/engines/agi/detection_tables.h
+++ b/engines/agi/detection_tables.h
@@ -379,9 +379,8 @@ static const AGIGameDescription gameDescriptions[] = {
 	// King's Quest 1 (Russian)
 	GAME_LPS("kq1", "", "973f5830ed5e1c919354dfbcd5036c53", 315, Common::RU_RUS, 0x2440, GID_KQ1, Common::kPlatformDOS),
 
-	// King's Quest 1 (Hebrew)
-	// Fan made translation by SegMash, based on the English GoG version
-	GAME_LVFPN("kq1", "", "logdir", "9812020c1ff9b86b97976c3e85e29ec8", 315, Common::HE_ISR, 0x2917, GF_EXTCHAR, GID_KQ1, Common::kPlatformDOS, GType_V2, GAMEOPTIONS_DEFAULT),
+	// King's Quest 1 (Hebrew) [DOS 2.0F 1987]
+	GAME_LVFPN("kq1", "", "logdir", "cf421deebd7378ea35cddc3e7725b68f", 315, Common::HE_ISR, 0x2917, GF_EXTCHAR, GID_KQ1, Common::kPlatformDOS, GType_V2, GAMEOPTIONS_DEFAULT),
 
 	// King's Quest 2 (Apple II) 1.0G [AGI 1.08]
 	A2("kq2", "1.0G", "8e8d562e50233c939112c89bba55d249", 0x1120, GID_KQ2),

--- a/engines/agi/detection_tables.h
+++ b/engines/agi/detection_tables.h
@@ -380,6 +380,7 @@ static const AGIGameDescription gameDescriptions[] = {
 	GAME_LPS("kq1", "", "973f5830ed5e1c919354dfbcd5036c53", 315, Common::RU_RUS, 0x2440, GID_KQ1, Common::kPlatformDOS),
 
 	// King's Quest 1 (Hebrew) [DOS 2.0F 1987]
+	// Fan made translation by SegMash, based on the English GoG version
 	GAME_LVFPN("kq1", "", "logdir", "cf421deebd7378ea35cddc3e7725b68f", 315, Common::HE_ISR, 0x2917, GF_EXTCHAR, GID_KQ1, Common::kPlatformDOS, GType_V2, GAMEOPTIONS_DEFAULT),
 
 	// King's Quest 2 (Apple II) 1.0G [AGI 1.08]

--- a/engines/agi/text.cpp
+++ b/engines/agi/text.cpp
@@ -246,6 +246,12 @@ void TextMgr::display(int16 textNr, int16 textRow, int16 textColumn) {
 
 	if (textNr >= 1 && textNr <= _vm->_game._curLogic->numTexts) {
 		logicTextPtr = _vm->_game._curLogic->texts[textNr - 1];
+		// For RTL languages, adjust the cursor position to right-align text
+		if (_vm->isLanguageRTL() && logicTextPtr) {
+			int textLength = strlen(logicTextPtr);
+			textColumn = MAX < int16>(0, 40 - textColumn - textLength);
+			charPos_Set(textRow, textColumn);
+		}
 		processedTextPtr = stringPrintf(logicTextPtr);
 		processedTextPtr = stringWordWrap(processedTextPtr, 40);
 


### PR DESCRIPTION
I found that RTL is not working as properly in "display" method. In AGI games most of the messages are displayed using "print" method. But in kq1 - there are 2 cases where the game uses "display" method.
The cursor X position is sent by game logic.
I changed the position in RTL to be display frame size (40) minus position, minus text size.

In addition I had to change the game checksum due to small fixes.

Thanks.