### PR TITLE
chore: /usr/share/quilt/quilt.make is being removed from Debian

### DIFF
--- a/backends/platform/maemo/debian/rules
+++ b/backends/platform/maemo/debian/rules
@@ -1,7 +1,5 @@
 #!/usr/bin/make -f
 
-#include /usr/share/quilt/quilt.make
-
 build: scummvm
 
 scummvm:


### PR DESCRIPTION
Hi,

Long time no see, only 42911 comits behind.

This one line of text shows up in a Q&A dashboard
where we try to get rid of the old `source 1.0` format

https://trends.debian.net/#source-formats

https://codesearch.debian.net/search?q=%2Fusr%2Fshare%2Fquilt%2Fquilt.make+path%3Adebian%2Frules&literal=1

Please accept this PR as goodwill gesture,
I know it won't make things magicaly better for this Maemo platform.

Greetings

Alexandre

