### PR TITLE
TOON: Fix very slow Gift-O-Matic animation

### DIFF
--- a/engines/toon/script_func.cpp
+++ b/engines/toon/script_func.cpp
@@ -890,7 +890,7 @@ int32 ScriptFunc::sys_Cmd_Set_Scene_Anim_Wait(EMCState *state) {
 	if (_vm->state()->_currentScene == 24) {
 		if (_vm->getCurrentUpdatingSceneAnimation() == 6) {
 			if (waitTicks == 1) {
-				waitTicks = 10;
+				waitTicks = 2;
 				_vm->setSceneAnimationScriptUpdate(false);
 			}
 		}


### PR DESCRIPTION
Greetings, ScummVM community.

The other day, I decided to replay the wonderful adventure game Toonstruck and was disappointed by the Gift-O-Matic machine sequence. It moved very slowly and was easily passed on the first try. But from my childhood, I remembered being stuck on it for several days. This prompted me to download the ScummVM source code and build it (which turned out to be a separate multi-day quest in itself). (If I manage to improve the build process, I might write a more up-to-date tutorial on the wiki on how to build ScummVM from VS Code). I then started debugging the engine.

Through trial and error, hacking my way through the dense jungle of code (it's starting to feel like Monkey Island in here), I eventually stumbled upon the section that was preventing this puzzle from working correctly (although this challenge is more about dexterity than brains).

It turns out this machine was intentionally slowed down 15 years ago because a contributor found it too fast, as evidenced by the attached comment. Perhaps during this time, the timer's operation was updated or fixed, and now the challenge runs too slowly, which kills all the humor and "challenge" of this part of the game for the player.

After applying my changes, I tried to get every prize from the Gift-O-Matic, and it took me no more than 10 minutes—after all, the developers didn’t add those countdown signals for nothing. I tested this on a Windows PC.

It would be interesting to test it on weaker devices, maybe on Android, but unfortunately, I don't have the capacity to figure out the project build for Android.
Perhaps someone more experienced will be able to help, at least with advice. Maybe I need to add a check to detect the device type and adjust the animation speed based on its capabilities. This would allow the user to get the optimal experience from the game and avoid accidentally creating a soft-lock situation, where the puzzle becomes impossible to complete on some hardware. The goal is to keep it challenging but not break the progression.

Thank you for your attention!