### PR TITLE
DIRECTOR: add carriage return line feed to the TKKG game quirks

### DIFF
--- a/engines/director/game-quirks.cpp
+++ b/engines/director/game-quirks.cpp
@@ -106,22 +106,22 @@ struct CachedFile {
 	{"tkkg1", Common::kPlatformWindows,
 		// TKKG1 checks a file to determine the location of the CD.
 		"PATH.INI",
-		(const byte *)"[cd-path]\r\npath=d:\\", -1
+		(const byte *)"[cd-path]\r\npath=d:\\\r\n", -1
 	},
 	{"tkkg2", Common::kPlatformWindows,
 		// TKKG2 checks a file to determine the location of the CD.
 		"PATH.INI",
-		(const byte *)"[cd-path]\r\npath=d:\\", -1
+		(const byte *)"[cd-path]\r\npath=d:\\\r\n", -1
 	},
 	{"tkkg3", Common::kPlatformWindows,
 		// TKKG3 checks a file to determine the location of the CD.
 		"PATH.INI",
-		(const byte *)"[cd-path]\r\npath=d:\\", -1
+		(const byte *)"[cd-path]\r\npath=d:\\\r\n", -1
 	},
 	{"tkkg4", Common::kPlatformWindows,
 		// TKKG4 checks a file to determine the location of the CD.
 		"PATH.INI",
-		(const byte *)"[cd-path]\r\npath=d:\\", -1
+		(const byte *)"[cd-path]\r\npath=d:\\\r\n", -1
 	},
 
 	// Professor Finkle's Times Table Factory has an installer that copies a bunch of empty files,


### PR DESCRIPTION
TKKG1 constructs the filepath as follows

```    openXLib("fileio.dll")
    if objectp(leseObjekt) then
      leseObjekt(mdispose)
    end if
    set leseObjekt to FileIO(mnew, "read", "Path.ini")
    if not objectp(leseObjekt) then
      exit
    end if
    set temp to leseObjekt(mReadFile)
    set begin to offset("=", temp)
    set ende to the number of chars in temp
    set cdPath to char begin + 1 to ende - 2 of temp
    leseObjekt(mdispose)
    closeXLib("fileio.dll")
    set gTrenn to #\
    go(1, cdPath & "media\intro")
```
since we cut off the last 2 characters the separator between drive and folder gets cut off and we have a broken lookup path for the movie load:

```
[  138]: cb_call "closeXLib"
call:closeXLib("fileio.dll")
[  138]: Stack after: 
Vars after
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d"
    ende - [INT] 19
    temp - [STRING] "[cd-path]

path=d:\"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [VOID] <Void>
    leseObjekt - [OBJECT] object: #FileIO 2 0x55ee3ff809b0

[  141]: Stack before: 
Vars before
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d"
    ende - [INT] 19
    temp - [STRING] "[cd-path]

path=d:\"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [VOID] <Void>
    leseObjekt - [OBJECT] object: #FileIO 2 0x55ee3ff809b0

[  141]: c_namepush "\"
[  141]: Stack after: <#\> 
Vars after
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d"
    ende - [INT] 19
    temp - [STRING] "[cd-path]

path=d:\"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [VOID] <Void>
    leseObjekt - [OBJECT] object: #FileIO 2 0x55ee3ff809b0

[  143]: Stack before: <#\> 
Vars before
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d"
    ende - [INT] 19
    temp - [STRING] "[cd-path]

path=d:\"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [VOID] <Void>
    leseObjekt - [OBJECT] object: #FileIO 2 0x55ee3ff809b0

[  143]: cb_globalassign "gTrenn"
cb_globalassign: assigning to gTrenn
[  143]: Stack after: 
Vars after
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d"
    ende - [INT] 19
    temp - [STRING] "[cd-path]

path=d:\"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [SYMBOL] #\
    leseObjekt - [OBJECT] object: #FileIO 2 0x55ee3ff809b0

[  145]: Stack before: 
Vars before
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d"
    ende - [INT] 19
    temp - [STRING] "[cd-path]

path=d:\"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [SYMBOL] #\
    leseObjekt - [OBJECT] object: #FileIO 2 0x55ee3ff809b0

[  145]: c_intpush 1
[  145]: Stack after: <1> 
Vars after
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d"
    ende - [INT] 19
    temp - [STRING] "[cd-path]

path=d:\"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [SYMBOL] #\
    leseObjekt - [OBJECT] object: #FileIO 2 0x55ee3ff809b0

[  147]: Stack before: <1> 
Vars before
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d"
    ende - [INT] 19
    temp - [STRING] "[cd-path]

path=d:\"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [SYMBOL] #\
    leseObjekt - [OBJECT] object: #FileIO 2 0x55ee3ff809b0

[  147]: cb_varpush "cdPath"
cb_varpush: pushing cdPath to stack
[  147]: Stack after: <1> <"d"> 
Vars after
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d"
    ende - [INT] 19
    temp - [STRING] "[cd-path]

path=d:\"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [SYMBOL] #\
    leseObjekt - [OBJECT] object: #FileIO 2 0x55ee3ff809b0

[  149]: Stack before: <1> <"d"> 
Vars before
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d"
    ende - [INT] 19
    temp - [STRING] "[cd-path]

path=d:\"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [SYMBOL] #\
    leseObjekt - [OBJECT] object: #FileIO 2 0x55ee3ff809b0

[  149]: c_stringpush "media\intro"
[  149]: Stack after: <1> <"d"> <"media\intro"> 
Vars after
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d"
    ende - [INT] 19
    temp - [STRING] "[cd-path]

path=d:\"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [SYMBOL] #\
    leseObjekt - [OBJECT] object: #FileIO 2 0x55ee3ff809b0

[  152]: Stack before: <1> <"d"> <"media\intro"> 
Vars before
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d"
    ende - [INT] 19
    temp - [STRING] "[cd-path]

path=d:\"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [SYMBOL] #\
    leseObjekt - [OBJECT] object: #FileIO 2 0x55ee3ff809b0

[  152]: c_ampersand
[  152]: Stack after: <1> <"dmedia\intro"> 
Vars after
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d"
    ende - [INT] 19
    temp - [STRING] "[cd-path]

path=d:\"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [SYMBOL] #\
    leseObjekt - [OBJECT] object: #FileIO 2 0x55ee3ff809b0

[  153]: Stack before: <1> <"dmedia\intro"> 
Vars before
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d"
    ende - [INT] 19
    temp - [STRING] "[cd-path]

path=d:\"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [SYMBOL] #\
    leseObjekt - [OBJECT] object: #FileIO 2 0x55ee3ff809b0

[  153]: c_argcnoretpush 2
[  153]: Stack after: <1> <"dmedia\intro"> <argcnoret: 2> 
Vars after
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d"
    ende - [INT] 19
    temp - [STRING] "[cd-path]

path=d:\"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [SYMBOL] #\
    leseObjekt - [OBJECT] object: #FileIO 2 0x55ee3ff809b0

[  155]: Stack before: <1> <"dmedia\intro"> <argcnoret: 2> 
Vars before
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d"
    ende - [INT] 19
    temp - [STRING] "[cd-path]

path=d:\"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [SYMBOL] #\
    leseObjekt - [OBJECT] object: #FileIO 2 0x55ee3ff809b0

[  155]: cb_call "go"
call:go(1, "dmedia\intro")
findPath(): beginning search for "dmedia\intro"
resolvePath(): No match found for 
findPath(): searching current folder 
File::open: opening 'dmedia/intro.bin' failed
File::open: opening 'dmedia/._intro' failed
resolvePath(): No match found for dmedia\intro
File::open: opening 'dmedia/intro.DIR.bin' failed
File::open: opening 'dmedia/._intro.DIR' failed
resolvePath(): No match found for dmedia\intro.DIR
File::open: opening 'dmedia/intro.DXR.bin' failed
File::open: opening 'dmedia/._intro.DXR' failed
resolvePath(): No match found for dmedia\intro.DXR
File::open: opening 'dmedia/intro.CST.bin' failed
File::open: opening 'dmedia/._intro.CST' failed
resolvePath(): No match found for dmedia\intro.CST
File::open: opening 'dmedia/intro.CXT.bin' failed
File::open: opening 'dmedia/._intro.CXT' failed
resolvePath(): No match found for dmedia\intro.CXT
File::open: opening 'dmedia/intro.EXE.bin' failed
File::open: opening 'dmedia/._intro.EXE' failed
resolvePath(): No match found for dmedia\intro.EXE
File::open: opening 'intro.bin' failed
File::open: opening '._intro' failed
resolvePath(): No match found for intro
resolvePath(): Found SearchMan match for intro.DIR -> intro.DIR
findPath(): resolved "dmedia\intro" -> "intro.DIR"
FSDirectory::createReadStreamForMember('intro.DIR') -> '/media/user/Volume/Director_5_01_TKKG1/MEDIA/INTRO.dir'
Opening hashed: intro.DIR
Window::setNextMovie: 'dmedia\intro' -> 'dmedia\intro' -> 'intro.DIR'
Lingo::setTheEntity(beepOn, <Void>, #0, 0)
Lingo::setTheEntity(keyDownScript, <Void>, #0, "")
setting primary event handler (keyDown)
Lingo::setTheEntity(mouseDownScript, <Void>, #0, "")
setting primary event handler (mouseDown)
Lingo::setTheEntity(mouseUpScript, <Void>, #0, "")
setting primary event handler (mouseUp)
Lingo::func_goto(): going to movie "dmedia\intro", frame 1
```
and we rely on searchman(ager).

with the fix this looks a lot better 

```  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [SYMBOL] #\
    leseObjekt - [OBJECT] object: #FileIO 2 0x5c0735594dc0

[  153]: Stack before: <1> <"d:\media\intro"> 
Vars before
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d:\"
    ende - [INT] 21
    temp - [STRING] "[cd-path]

path=d:\

"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [SYMBOL] #\
    leseObjekt - [OBJECT] object: #FileIO 2 0x5c0735594dc0

[  153]: c_argcnoretpush 2
[  153]: Stack after: <1> <"d:\media\intro"> <argcnoret: 2> 
Vars after
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d:\"
    ende - [INT] 21
    temp - [STRING] "[cd-path]

path=d:\

"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [SYMBOL] #\
    leseObjekt - [OBJECT] object: #FileIO 2 0x5c0735594dc0

[  155]: Stack before: <1> <"d:\media\intro"> <argcnoret: 2> 
Vars before
  Local vars:
    begin - [INT] 16
    cdPath - [STRING] "d:\"
    ende - [INT] 21
    temp - [STRING] "[cd-path]

path=d:\

"

  Global vars:
    FileIO - [VOID] <Void>
    gOldColor - [VOID] <Void>
    gScorePath - [STRING] "C:\"
    gTrenn - [SYMBOL] #\
    leseObjekt - [OBJECT] object: #FileIO 2 0x5c0735594dc0

[  155]: cb_call "go"
call:go(1, "d:\media\intro")
findPath(): beginning search for "d:\media\intro"
resolvePath(): No match found for 
findAbsolutePath(): searching absolute path
File::open: opening 'media/intro.bin' failed
File::open: opening 'media/._intro' failed
resolvePath(): No match found for d:\media\intro
resolveFSPath(): Found filesystem match for d:\media\intro.DIR -> MEDIA/INTRO.dir
findAbsolutePath(): resolved "d:\media\intro" -> "MEDIA/INTRO.dir"
FSDirectory::createReadStreamForMember('MEDIA/INTRO.dir') -> '/media/user/Volume/Director_5_01_TKKG1/MEDIA/INTRO.dir'
Opening hashed: MEDIA/INTRO.dir
Window::setNextMovie: 'd:\media\intro' -> 'media\intro' -> 'MEDIA/INTRO.dir'
Lingo::setTheEntity(beepOn, <Void>, #0, 0)
Lingo::setTheEntity(keyDownScript, <Void>, #0, "")
setting primary event handler (keyDown)
Lingo::setTheEntity(mouseDownScript, <Void>, #0, "")
setting primary event handler (mouseDown)
Lingo::setTheEntity(mouseUpScript, <Void>, #0, "")
setting primary event handler (mouseUp)
Lingo::func_goto(): going to movie "d:\media\intro", frame 1
```


