### PR TITLE
NANCY: Fix alloc-dealloc-mismatch in tangrampuzzle

### DIFF
--- a/engines/nancy/action/puzzle/tangrampuzzle.cpp
+++ b/engines/nancy/action/puzzle/tangrampuzzle.cpp
@@ -418,7 +418,7 @@ bool TangramPuzzle::checkBuffer(const Tile &tile) const {
 TangramPuzzle::Tile::Tile() : _mask(nullptr), _id(0), _rotation(0), _isHighlighted(false) {}
 
 TangramPuzzle::Tile::~Tile() {
-	delete _mask;
+	delete[] _mask;
 }
 
 void TangramPuzzle::Tile::drawMask() {


### PR DESCRIPTION
```
ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete)
    ...
    #1 0x55907bd0818e in Nancy::Action::TangramPuzzle::Tile::~Tile() engines/nancy/action/puzzle/tangrampuzzle.cpp:421:2
    ...
```