### PR TITLE
ALCACHOFA: Reduce pixel format conversion

### DIFF
--- a/engines/alcachofa/alcachofa.cpp
+++ b/engines/alcachofa/alcachofa.cpp
@@ -383,7 +383,7 @@ void AlcachofaEngine::getSavegameThumbnail(Graphics::Surface &thumbnail) {
 	}
 
 	// otherwise we have to rerender
-	thumbnail.create(kBigThumbnailWidth, kBigThumbnailHeight, Graphics::PixelFormat::createFormatRGBA32());
+	thumbnail.create(kBigThumbnailWidth, kBigThumbnailHeight, g_engine->renderer().getPixelFormat());
 	if (g_engine->player().currentRoom() == nullptr)
 		return; // but without a room we would render only black anyway
 

--- a/engines/alcachofa/graphics-opengl-base.h
+++ b/engines/alcachofa/graphics-opengl-base.h
@@ -28,23 +28,6 @@
 
 namespace Alcachofa {
 
-bool isCompatibleFormat(const Graphics::PixelFormat &format);
-
-class OpenGLTextureBase : public ITexture {
-public:
-	OpenGLTextureBase(int32 w, int32 h, bool withMipmaps);
-	~OpenGLTextureBase() override {}
-	void update(const Graphics::Surface &surface) override;
-
-protected:
-	virtual void updateInner(const void *pixels) = 0; ///< expects pixels to be RGBA32
-
-	bool _withMipmaps;
-	bool _mirrorWrap = true;
-	bool _didConvertOnce = false;
-	Graphics::ManagedSurface _tmpSurface;
-};
-
 class OpenGLRendererBase : public virtual IRenderer {
 public:
 	OpenGLRendererBase(Common::Point resolution);

--- a/engines/alcachofa/graphics-opengl.h
+++ b/engines/alcachofa/graphics-opengl.h
@@ -30,17 +30,18 @@
 
 namespace Alcachofa {
 
-class OpenGLTexture : public OpenGLTextureBase {
+class OpenGLTexture : public ITexture {
 public:
 	OpenGLTexture(int32 w, int32 h, bool withMipmaps);
 	~OpenGLTexture() override;
 
 	inline GLuint handle() const { return _handle; }
 	void setMirrorWrap(bool wrap);
+	void update(const Graphics::Surface &surface) override;
 
 protected:
-	void updateInner(const void *pixels) override;
-
+	bool _withMipmaps;
+	bool _mirrorWrap = true;
 	GLuint _handle = 0;
 };
 
@@ -49,6 +50,7 @@ public:
 	OpenGLRenderer(Common::Point resolution);
 
 	Common::ScopedPtr<ITexture> createTexture(int32 w, int32 h, bool withMipmaps) override;
+	Graphics::PixelFormat getPixelFormat() const override;
 	void end() override;
 	void setOutput(Graphics::Surface &output) override;
 

--- a/engines/alcachofa/graphics.h
+++ b/engines/alcachofa/graphics.h
@@ -76,6 +76,7 @@ public:
 	virtual ~IRenderer() {}
 
 	virtual Common::ScopedPtr<ITexture> createTexture(int32 w, int32 h, bool withMipmaps = true) = 0;
+	virtual Graphics::PixelFormat getPixelFormat() const = 0;
 
 	virtual void begin() = 0;
 	virtual void setTexture(ITexture *texture) = 0;

--- a/engines/alcachofa/menu.cpp
+++ b/engines/alcachofa/menu.cpp
@@ -34,12 +34,13 @@ using namespace Graphics;
 namespace Alcachofa {
 
 static void createThumbnail(ManagedSurface &surface) {
-	surface.create(kBigThumbnailWidth, kBigThumbnailHeight, PixelFormat::createFormatRGBA32());
+	surface.create(kBigThumbnailWidth, kBigThumbnailHeight, g_engine->renderer().getPixelFormat());
 }
 
 static void convertToGrayscale(ManagedSurface &surface) {
+	// TODO: Support other pixel formats
+	assert(surface.format.bytesPerPixel == 4);
 	assert(!surface.empty());
-	assert(surface.format == PixelFormat::createFormatRGBA32());
 	uint32 rgbMask = ~(uint32(0xff) << surface.format.aShift);
 
 	for (int y = 0; y < surface.h; y++) {


### PR DESCRIPTION
`BlendBlit::getSupportedPixelFormat()` is only needed when using the blending routines in common code - since the Alcachofa engine doesn't use them, it can instead use a format that's directly supported by the renderer and skip most intermediate conversions.