### PR TITLE
COMMON: Move file search in current working directory to backends

### DIFF
--- a/backends/platform/3ds/osystem.cpp
+++ b/backends/platform/3ds/osystem.cpp
@@ -194,6 +194,9 @@ Common::Path OSystem_3DS::getDefaultLogFileName() {
 
 void OSystem_3DS::addSysArchivesToSearchSet(Common::SearchSet &s, int priority) {
 	s.add("RomFS", new Common::FSDirectory(DATA_PATH"/"), priority);
+	// Add the current dir as a very last resort (cf. bug #3984).
+	// TODO: check if it's really needed
+	s.addDirectory(".", ".", priority - 1);
 }
 
 uint32 OSystem_3DS::getMillis(bool skipRecord) {

--- a/backends/platform/atari/osystem_atari.cpp
+++ b/backends/platform/atari/osystem_atari.cpp
@@ -466,6 +466,9 @@ void OSystem_Atari::addSysArchivesToSearchSet(Common::SearchSet &s, int priority
 		}
 	}
 #endif
+	// Add the current dir as a very last resort (cf. bug #3984).
+	// TODO: check if it's really needed
+	s.addDirectory(".", ".", priority - 1);
 }
 
 Common::Path OSystem_Atari::getDefaultConfigFileName() {

--- a/backends/platform/ds/osystem_ds.cpp
+++ b/backends/platform/ds/osystem_ds.cpp
@@ -100,6 +100,9 @@ void OSystem_DS::initBackend() {
 
 void OSystem_DS::addSysArchivesToSearchSet(Common::SearchSet &s, int priority) {
 	s.add("nitro:/", new Common::FSDirectory("nitro:/"), priority);
+	// Add the current dir as a very last resort (cf. bug #3984).
+	// TODO: check if it's really needed
+	s.addDirectory(".", ".", priority - 1);
 }
 
 uint32 OSystem_DS::getMillis(bool skipRecord) {

--- a/backends/platform/ios7/ios7_osys_main.cpp
+++ b/backends/platform/ios7/ios7_osys_main.cpp
@@ -402,6 +402,9 @@ void OSystem_iOS7::addSysArchivesToSearchSet(Common::SearchSet &s, int priority)
 		}
 		CFRelease(fileUrl);
 	}
+	// Add the current dir as a very last resort (cf. bug #3984).
+	// TODO: check if it's really needed
+	s.addDirectory(".", ".", priority - 1);
 }
 
 void iOS7_buildSharedOSystemInstance() {

--- a/backends/platform/libretro/src/libretro-os-utils.cpp
+++ b/backends/platform/libretro/src/libretro-os-utils.cpp
@@ -280,4 +280,7 @@ Common::String OSystem_libretro::getSaveDir(void) {
 void OSystem_libretro::addSysArchivesToSearchSet(Common::SearchSet &s, int priority) {
 	if (!s_systemDir.empty())
 		s.add("systemDir", new Common::FSDirectory(Common::FSNode(Common::Path(s_systemDir))), priority);
+	// Add the current dir as a very last resort (cf. bug #3984).
+	// TODO: check if it's really needed
+	s.addDirectory(".", ".", priority - 1);
 }

--- a/backends/platform/null/null.cpp
+++ b/backends/platform/null/null.cpp
@@ -249,6 +249,9 @@ void OSystem_NULL::logMessage(LogMessageType::Type type, const char *message) {
 void OSystem_NULL::addSysArchivesToSearchSet(Common::SearchSet &s, int priority) {
 	s.add("test/engine-data", new Common::FSDirectory("test/engine-data", 4), priority);
 	s.add("gui/themes", new Common::FSDirectory("gui/themes", 4), priority);
+	// Add the current dir as a very last resort (cf. bug #3984).
+	// TODO: check if it's really needed
+	s.addDirectory(".", ".", priority - 1);
 }
 
 OSystem *OSystem_NULL_create(bool silenceLogs) {

--- a/backends/platform/openpandora/op-backend.cpp
+++ b/backends/platform/openpandora/op-backend.cpp
@@ -173,6 +173,10 @@ void OSystem_OP::addSysArchivesToSearchSet(Common::SearchSet &s, int priority) {
 	if (engineNode.exists() && engineNode.isDirectory()) {
 		s.add("__OP_ENGDATA__", new Common::FSDirectory(enginedataPath), priority);
 	}
+
+	// Add the current dir as a very last resort (cf. bug #3984).
+	// TODO: check if it's really needed
+	s.addDirectory(".", ".", priority - 1);
 }
 
 void OSystem_OP::quit() {

--- a/backends/platform/sdl/kolibrios/kolibrios.cpp
+++ b/backends/platform/sdl/kolibrios/kolibrios.cpp
@@ -62,6 +62,9 @@ void OSystem_KolibriOS::init() {
 void OSystem_KolibriOS::addSysArchivesToSearchSet(Common::SearchSet &s, int priority) {
 	Common::FSNode dataNode(_exePath);
 	s.add("exePath", new Common::FSDirectory(dataNode, 4), priority);
+	// Add the current dir as a very last resort (cf. bug #3984).
+	// TODO: check if it's really needed
+	s.addDirectory(".", ".", priority - 1);
 }
 
 void OSystem_KolibriOS::initBackend() {

--- a/backends/platform/sdl/psp2/psp2.cpp
+++ b/backends/platform/sdl/psp2/psp2.cpp
@@ -164,6 +164,19 @@ Common::Path OSystem_PSP2::getDefaultLogFileName() {
 	return "ux0:data/scummvm/scummvm.log";
 }
 
+void OSystem_PSP2::addSysArchivesToSearchSet(Common::SearchSet &s, int priority) {
+#ifdef DATA_PATH
+	// Add the global DATA_PATH to the directory search list
+	// FIXME: We use depth = 4 for now, to match the old code. May want to change that
+	Common::FSNode dataNode(DATA_PATH);
+	if (dataNode.exists() && dataNode.isDirectory()) {
+		s.add(DATA_PATH, new Common::FSDirectory(dataNode, 4), priority);
+	}
+#endif
+
+	// Don't add current working directory: there is none
+}
+
 Common::HardwareInputSet *OSystem_PSP2::getHardwareInputSet() {
 	using namespace Common;
 

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -647,6 +647,9 @@ void OSystem_SDL::addSysArchivesToSearchSet(Common::SearchSet &s, int priority) 
 	}
 #endif
 
+	// Add the current dir as a very last resort (cf. bug #3984).
+	// TODO: check if it's really needed
+	s.addDirectory(".", ".", priority - 1);
 }
 
 void OSystem_SDL::setWindowCaption(const Common::U32String &caption) {

--- a/common/archive.cpp
+++ b/common/archive.cpp
@@ -632,13 +632,6 @@ void SearchManager::clear() {
 	// so that archives added by client code are searched first.
 	if (g_system)
 		g_system->addSysArchivesToSearchSet(*this, -1);
-
-#if !defined(__ANDROID__) && !defined(PSP2)
-	// Add the current dir as a very last resort.
-	// See also bug #3984.
-	// But don't do this for Android platform, since it may lead to crashes
-	addDirectory(".", ".", -2);
-#endif
 }
 
 DECLARE_SINGLETON(SearchManager);

--- a/common/system.cpp
+++ b/common/system.cpp
@@ -241,6 +241,12 @@ FilesystemFactory *OSystem::getFilesystemFactory() {
 	return _fsFactory;
 }
 
+void OSystem::addSysArchivesToSearchSet(Common::SearchSet &s, int priority) {
+	// Add the current dir as a very last resort (cf. bug #3984).
+	// TODO: check if it's really needed
+	s.addDirectory(".", ".", priority - 1);
+}
+
 Common::SeekableReadStream *OSystem::createConfigReadStream() {
 	Common::FSNode file(getDefaultConfigFileName());
 	return file.createReadStream();

--- a/common/system.h
+++ b/common/system.h
@@ -1834,7 +1834,7 @@ public:
 	 * @param s         SearchSet to which the system-specific dirs, if any, are added.
 	 * @param priority	Priority with which those dirs are added.
 	 */
-	virtual void addSysArchivesToSearchSet(Common::SearchSet &s, int priority = 0) {}
+	virtual void addSysArchivesToSearchSet(Common::SearchSet &s, int priority);
 
 	/**
 	 * Open the default config file for reading by returning a suitable


### PR DESCRIPTION
The current working directory doesn't always exist on the platforms. Some platform are then exempted from searching in it.

This is a followup of #6838.
As indicated in this PR, relying on current working directory doesn't look right but that's a workaround for bug [#3984](https://bugs.scummvm.org/ticket/3984).
The other solution is to just remove the code and hope there is no bug anymore.
