### PR TITLE
AGS: Add translation overrides and custom font fallback

### DIFF
--- a/engines/ags/engine/ac/global_translation.cpp
+++ b/engines/ags/engine/ac/global_translation.cpp
@@ -19,18 +19,19 @@
  *
  */
 
-#include "ags/shared/ac/common.h"
+#include "ags/engine/ac/global_translation.h"
 #include "ags/engine/ac/display.h"
 #include "ags/engine/ac/game_state.h"
-#include "ags/engine/ac/global_translation.h"
 #include "ags/engine/ac/string.h"
 #include "ags/engine/ac/translation.h"
 #include "ags/engine/platform/base/ags_platform_driver.h"
+#include "ags/globals.h"
 #include "ags/plugins/ags_plugin_evts.h"
 #include "ags/plugins/plugin_engine.h"
+#include "ags/shared/ac/common.h"
 #include "ags/shared/util/memory.h"
-#include "ags/engine/ac/string.h"
-#include "ags/globals.h"
+
+#include "ags/engine/util/ags_translator.h"
 
 namespace AGS3 {
 
@@ -50,6 +51,11 @@ const char *get_translation(const char *text) {
 		return plResult;
 	}
 #endif
+
+	const char *translated = AgsTranslator::getInstance().getTranslation(text);
+	if (translated != text) {
+		return translated;
+	}
 
 	const auto &transtree = get_translation_tree();
 	const auto it = transtree.find(String::Wrapper(text));

--- a/engines/ags/engine/util/ags_translator.cpp
+++ b/engines/ags/engine/util/ags_translator.cpp
@@ -22,6 +22,7 @@
 #include "ags/engine/util/ags_translator.h"
 
 #include "common/archive.h"
+#include "common/debug.h"
 #include "common/formats/json.h"
 #include "common/memstream.h"
 #include "common/path.h"
@@ -37,92 +38,18 @@ AgsTranslator &AgsTranslator::getInstance() {
 	return t;
 }
 
-static bool readAll(Common::InSaveFile *in, Common::String &out) {
-	out.clear();
-	if (!in)
-		return false;
-
-	while (!in->eos() && !in->err()) {
-		char buf[4096];
-		const uint32 n = in->read(buf, sizeof(buf));
-		if (n == 0)
-			break;
-		out += Common::String(buf, n);
-	}
-	return !in->err();
-}
-
-static bool appendTextToSaveFile(const char *filename, const Common::String &line) {
-	Common::SaveFileManager *sfm = g_system->getSavefileManager();
-	if (!sfm)
-		return false;
-
-	// Read existing content if file exists.
-	Common::String existing;
-	{
-		Common::InSaveFile *in = sfm->openForLoading(filename);
-		if (in) {
-			if (!readAll(in, existing)) {
-				delete in;
-				return false;
-			}
-			delete in;
-		}
-	}
-
-	// Rewrite full content + appended line, without compression (text).
-	Common::OutSaveFile *out = sfm->openForSaving(filename, false);
-	if (!out)
-		return false;
-
-	if (!existing.empty())
-		out->write(existing.c_str(), existing.size());
-
-	out->write(line.c_str(), line.size());
-	out->finalize();
-	delete out;
-	return true;
-}
-
-static Common::String jsonEscape(const Common::String &s) {
-	Common::String esc;
-	for (uint i = 0; i < s.size(); i++) {
-		char c = s[i];
-		if (c == '\\')
-			esc += "\\\\";
-		else if (c == '"')
-			esc += "\\\"";
-		else if (c == '\n')
-			esc += "\\n";
-		else if (c == '\r')
-			esc += "\\r";
-		else if (c == '\t')
-			esc += "\\t";
-		else
-			esc += c;
-	}
-	return esc;
-}
-
 void AgsTranslator::logMissingString(const Common::String &src) {
-	Common::String key = src;
-	key.trim();
-	if (key.empty())
-		return;
-
 	// Don't log the same missing string over and over
-	if (_missingStrings.contains(key))
+	if (_missingStrings.contains(src))
 		return;
-	_missingStrings[key] = true;
+	_missingStrings[src] = true;
 
-	Common::String line = Common::String::format(
-		"{\"%s\":\"\"}\n",
-		jsonEscape(key).c_str());
-
-	// Log untranslated strings to a file to assist fan translators in creating their mapping.
-	if (!appendTextToSaveFile("translation_override_missing.jsonl", line)) {
-		warning("AGS Translator: failed to append missing string");
+	Common::String hexStr;
+	for (uint i = 0; i < src.size(); ++i) {
+		hexStr += Common::String::format("%02X ", (unsigned char)src[i]);
 	}
+
+	debug(0, "AGS Translation Missing: '%s' (Hex: %s)", src.c_str(), hexStr.c_str());
 }
 
 const char *AgsTranslator::getTranslation(const char *src) {
@@ -137,8 +64,22 @@ const char *AgsTranslator::getTranslation(const char *src) {
 	}
 
 	const Common::String key = normalizeKey(Common::String(src));
+
+	// If the exact string is already a target translation value, it means
+	// AGS is re-translating an already translated string (e.g., in UI loops).
+	// We should just return it without parsing it as a missing original string.
+	// NOTE: We don't have a reverse lookup right now, but for simplicity we
+	// can just check values. Since checking all values every frame is O(N),
+	// we will add a reverse cache during JSON load!
 	if (_entries.contains(key)) {
 		return _entries[key].c_str();
+	}
+
+	// If the exact string is already a target translation value, it means
+	// AGS is re-translating an already translated string (e.g., in UI loops).
+	// We should just return it without parsing it as a missing original string.
+	if (_translatedValues.contains(src)) {
+		return src;
 	}
 
 	logMissingString(Common::String(src));
@@ -180,7 +121,9 @@ bool AgsTranslator::loadFromJsonIfPresent(const Common::String &filename) {
 		if (it->_value->isString()) {
 			Common::String key = normalizeKey(it->_key);
 			if (!key.empty()) {
-				_entries[key] = it->_value->asString();
+				Common::String val = it->_value->asString();
+				_entries[key] = val;
+				_translatedValues[val] = true;
 			}
 		}
 	}

--- a/engines/ags/engine/util/ags_translator.cpp
+++ b/engines/ags/engine/util/ags_translator.cpp
@@ -23,7 +23,6 @@
 
 #include "common/archive.h"
 #include "common/debug.h"
-#include "common/formats/json.h"
 #include "common/memstream.h"
 #include "common/path.h"
 #include "common/savefile.h"
@@ -44,16 +43,11 @@ void AgsTranslator::logMissingString(const Common::String &src) {
 		return;
 	_missingStrings[src] = true;
 
-	Common::String hexStr;
-	for (uint i = 0; i < src.size(); ++i) {
-		hexStr += Common::String::format("%02X ", (unsigned char)src[i]);
-	}
-
-	debug(0, "AGS Translation Missing: '%s' (Hex: %s)", src.c_str(), hexStr.c_str());
+	debug(0, "AGS Translation Missing: '%s'", src.c_str());
 }
 
 const char *AgsTranslator::getTranslation(const char *src) {
-	loadFromJsonIfPresent("translation_override.json");
+	loadFromPoIfPresent("translation_override.po");
 
 	if (!src || !*src)
 		return src;
@@ -65,12 +59,7 @@ const char *AgsTranslator::getTranslation(const char *src) {
 
 	const Common::String key = normalizeKey(Common::String(src));
 
-	// If the exact string is already a target translation value, it means
-	// AGS is re-translating an already translated string (e.g., in UI loops).
-	// We should just return it without parsing it as a missing original string.
-	// NOTE: We don't have a reverse lookup right now, but for simplicity we
-	// can just check values. Since checking all values every frame is O(N),
-	// we will add a reverse cache during JSON load!
+	// Check if we have a translation for the normalized original string.
 	if (_entries.contains(key)) {
 		return _entries[key].c_str();
 	}
@@ -86,7 +75,50 @@ const char *AgsTranslator::getTranslation(const char *src) {
 	return src;
 }
 
-bool AgsTranslator::loadFromJsonIfPresent(const Common::String &filename) {
+void AgsTranslator::storePoEntry(const Common::String &msgId, const Common::String &msgStr) {
+	if (!msgId.empty() && !msgStr.empty()) {
+		Common::String key = normalizeKey(msgId);
+		if (!key.empty()) {
+			_entries[key] = msgStr;
+			_translatedValues[msgStr] = true;
+		}
+	}
+}
+
+Common::String AgsTranslator::unescapePoString(const Common::String &s) {
+	Common::String result;
+	int start = 0, end = s.size();
+	if (s.size() >= 2 && s.firstChar() == '"' && s.lastChar() == '"') {
+		start = 1;
+		end = s.size() - 1;
+	}
+
+	for (int i = start; i < end; ++i) {
+		if (s[i] == '\\' && i + 1 < end) {
+			char nextChar = s[i + 1];
+			if (nextChar == 'n')
+				result += '\n';
+			else if (nextChar == 'r')
+				result += '\r';
+			else if (nextChar == 't')
+				result += '\t';
+			else if (nextChar == '\\')
+				result += '\\';
+			else if (nextChar == '"')
+				result += '"';
+			else {
+				result += '\\';
+				result += nextChar;
+			}
+			++i; // skip escaped char
+		} else {
+			result += s[i];
+		}
+	}
+	return result;
+}
+
+bool AgsTranslator::loadFromPoIfPresent(const Common::String &filename) {
 	if (_loaded)
 		return !_entries.empty();
 
@@ -99,36 +131,47 @@ bool AgsTranslator::loadFromJsonIfPresent(const Common::String &filename) {
 		return false;
 	}
 
-	Common::MemoryWriteStreamDynamic buffer(DisposeAfterUse::YES);
-	buffer.writeStream(rs, rs->size());
-	Common::JSON::zeroTerminateContents(buffer);
-	delete rs;
+	Common::String currentMsgId, currentMsgStr;
+	bool inMsgId = false;
+	bool inMsgStr = false;
 
-	Common::JSONValue *json = Common::JSON::parse((const char *)buffer.getData());
-	if (!json) {
-		warning("AGS Translator: failed to parse %s (invalid JSON)", filename.c_str());
-		return false;
-	}
+	while (!rs->eos() && !rs->err()) {
+		Common::String line = rs->readLine();
+		line.trim();
 
-	if (!json->isObject()) {
-		warning("AGS Translator: failed to parse %s (expected JSON object at root)", filename.c_str());
-		delete json;
-		return false;
-	}
+		if (line.empty() || line.hasPrefix("#"))
+			continue;
 
-	const Common::JSONObject &obj = json->asObject();
-	for (Common::JSONObject::const_iterator it = obj.begin(); it != obj.end(); ++it) {
-		if (it->_value->isString()) {
-			Common::String key = normalizeKey(it->_key);
-			if (!key.empty()) {
-				Common::String val = it->_value->asString();
-				_entries[key] = val;
-				_translatedValues[val] = true;
+		if (line.hasPrefix("msgid ")) {
+			// Save previous entry if any
+			if (!currentMsgId.empty() && !currentMsgStr.empty()) {
+				storePoEntry(currentMsgId, currentMsgStr);
+			}
+			inMsgId = true;
+			inMsgStr = false;
+			currentMsgId = unescapePoString(line.c_str() + 6);
+			currentMsgStr.clear();
+		} else if (line.hasPrefix("msgstr ")) {
+			inMsgId = false;
+			inMsgStr = true;
+			currentMsgStr = unescapePoString(line.c_str() + 7);
+		} else if (line.hasPrefix("\"")) {
+			// Multiline string
+			Common::String appendStr = unescapePoString(line);
+			if (inMsgId) {
+				currentMsgId += appendStr;
+			} else if (inMsgStr) {
+				currentMsgStr += appendStr;
 			}
 		}
 	}
 
-	delete json;
+	// Save the last entry
+	if (!currentMsgId.empty() && !currentMsgStr.empty()) {
+		storePoEntry(currentMsgId, currentMsgStr);
+	}
+
+	delete rs;
 	return !_entries.empty();
 }
 

--- a/engines/ags/engine/util/ags_translator.cpp
+++ b/engines/ags/engine/util/ags_translator.cpp
@@ -1,0 +1,230 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ags/engine/util/ags_translator.h"
+
+#include "common/archive.h"
+#include "common/formats/json.h"
+#include "common/memstream.h"
+#include "common/path.h"
+#include "common/savefile.h"
+#include "common/stream.h"
+#include "common/system.h"
+#include "common/textconsole.h"
+
+namespace AGS3 {
+
+AgsTranslator &AgsTranslator::getInstance() {
+	static AgsTranslator t;
+	return t;
+}
+
+static bool readAll(Common::InSaveFile *in, Common::String &out) {
+	out.clear();
+	if (!in)
+		return false;
+
+	while (!in->eos() && !in->err()) {
+		char buf[4096];
+		const uint32 n = in->read(buf, sizeof(buf));
+		if (n == 0)
+			break;
+		out += Common::String(buf, n);
+	}
+	return !in->err();
+}
+
+static bool appendTextToSaveFile(const char *filename, const Common::String &line) {
+	Common::SaveFileManager *sfm = g_system->getSavefileManager();
+	if (!sfm)
+		return false;
+
+	// Read existing content if file exists.
+	Common::String existing;
+	{
+		Common::InSaveFile *in = sfm->openForLoading(filename);
+		if (in) {
+			if (!readAll(in, existing)) {
+				delete in;
+				return false;
+			}
+			delete in;
+		}
+	}
+
+	// Rewrite full content + appended line, without compression (text).
+	Common::OutSaveFile *out = sfm->openForSaving(filename, false);
+	if (!out)
+		return false;
+
+	if (!existing.empty())
+		out->write(existing.c_str(), existing.size());
+
+	out->write(line.c_str(), line.size());
+	out->finalize();
+	delete out;
+	return true;
+}
+
+static Common::String jsonEscape(const Common::String &s) {
+	Common::String esc;
+	for (uint i = 0; i < s.size(); i++) {
+		char c = s[i];
+		if (c == '\\')
+			esc += "\\\\";
+		else if (c == '"')
+			esc += "\\\"";
+		else if (c == '\n')
+			esc += "\\n";
+		else if (c == '\r')
+			esc += "\\r";
+		else if (c == '\t')
+			esc += "\\t";
+		else
+			esc += c;
+	}
+	return esc;
+}
+
+void AgsTranslator::logMissingString(const Common::String &src) {
+	Common::String key = src;
+	key.trim();
+	if (key.empty())
+		return;
+
+	// Don't log the same missing string over and over
+	if (_missingStrings.contains(key))
+		return;
+	_missingStrings[key] = true;
+
+	Common::String line = Common::String::format(
+		"{\"%s\":\"\"}\n",
+		jsonEscape(key).c_str());
+
+	// Log untranslated strings to a file to assist fan translators in creating their mapping.
+	if (!appendTextToSaveFile("translation_override_missing.jsonl", line)) {
+		warning("AGS Translator: failed to append missing string");
+	}
+}
+
+const char *AgsTranslator::getTranslation(const char *src) {
+	loadFromJsonIfPresent("translation_override.json");
+
+	if (!src || !*src)
+		return src;
+
+	if (_entries.empty()) {
+		logMissingString(Common::String(src));
+		return src;
+	}
+
+	const Common::String key = normalizeKey(Common::String(src));
+	if (_entries.contains(key)) {
+		return _entries[key].c_str();
+	}
+
+	logMissingString(Common::String(src));
+	return src;
+}
+
+bool AgsTranslator::loadFromJsonIfPresent(const Common::String &filename) {
+	if (_loaded)
+		return !_entries.empty();
+
+	_loaded = true;
+	_entries.clear();
+
+	Common::SeekableReadStream *rs = SearchMan.createReadStreamForMember(Common::Path(filename));
+	if (!rs) {
+		// Optional file.
+		return false;
+	}
+
+	Common::MemoryWriteStreamDynamic buffer(DisposeAfterUse::YES);
+	buffer.writeStream(rs, rs->size());
+	Common::JSON::zeroTerminateContents(buffer);
+	delete rs;
+
+	Common::JSONValue *json = Common::JSON::parse((const char *)buffer.getData());
+	if (!json) {
+		warning("AGS Translator: failed to parse %s (invalid JSON)", filename.c_str());
+		return false;
+	}
+
+	if (!json->isObject()) {
+		warning("AGS Translator: failed to parse %s (expected JSON object at root)", filename.c_str());
+		delete json;
+		return false;
+	}
+
+	const Common::JSONObject &obj = json->asObject();
+	for (Common::JSONObject::const_iterator it = obj.begin(); it != obj.end(); ++it) {
+		if (it->_value->isString()) {
+			Common::String key = normalizeKey(it->_key);
+			if (!key.empty()) {
+				_entries[key] = it->_value->asString();
+			}
+		}
+	}
+
+	delete json;
+	return !_entries.empty();
+}
+
+bool AgsTranslator::translate(const Common::String &src, Common::String &out) const {
+	if (_entries.empty()) {
+		return false;
+	}
+
+	const Common::String key = normalizeKey(src);
+	if (_entries.contains(key)) {
+		out = _entries[key];
+		return true;
+	}
+
+	return false;
+}
+
+Common::String AgsTranslator::normalizeKey(const Common::String &s) {
+	Common::String r = s;
+	r.trim();
+
+	// Collapse whitespace (space/tab) to single spaces.
+	Common::String out;
+	bool prevSpace = false;
+
+	for (uint i = 0; i < r.size(); i++) {
+		const char ch = r[i];
+		const bool isSpace = (ch == ' ' || ch == '\t');
+		if (isSpace) {
+			if (!prevSpace)
+				out += ' ';
+			prevSpace = true;
+		} else {
+			out += ch;
+			prevSpace = false;
+		}
+	}
+
+	return out;
+}
+
+} // namespace AGS3

--- a/engines/ags/engine/util/ags_translator.h
+++ b/engines/ags/engine/util/ags_translator.h
@@ -1,0 +1,58 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef AGS_ENGINE_UTIL_AGS_TRANSLATOR_H
+#define AGS_ENGINE_UTIL_AGS_TRANSLATOR_H
+
+#include "common/hash-str.h"
+#include "common/hashmap.h"
+#include "common/str.h"
+
+namespace AGS3 {
+
+class AgsTranslator {
+public:
+	static AgsTranslator &getInstance();
+
+	// Loads translations from a UTF-8 JSON file that contains a flat object: { "src": "dst", ... }
+	// This allows users to provide fan-translations or string replacements without modifying game files.
+	// The file is optional; if missing, returns false.
+	bool loadFromJsonIfPresent(const Common::String &filename);
+
+	// Returns true and sets out if translation exists; otherwise false.
+	bool translate(const Common::String &src, Common::String &out) const;
+
+	// Returns the translated c-string, or the original if not found. Logs the initial lookup.
+	const char *getTranslation(const char *src);
+
+private:
+	Common::HashMap<Common::String, Common::String> _entries;
+	Common::HashMap<Common::String, bool> _missingStrings;
+	bool _loaded = false;
+
+	static Common::String normalizeKey(const Common::String &s);
+
+	void logMissingString(const Common::String &src);
+};
+
+} // namespace AGS3
+
+#endif

--- a/engines/ags/engine/util/ags_translator.h
+++ b/engines/ags/engine/util/ags_translator.h
@@ -32,10 +32,10 @@ class AgsTranslator {
 public:
 	static AgsTranslator &getInstance();
 
-	// Loads translations from a UTF-8 JSON file that contains a flat object: { "src": "dst", ... }
+	// Loads translations from a .po file (e.g. translation_override.po).
 	// This allows users to provide fan-translations or string replacements without modifying game files.
 	// The file is optional; if missing, returns false.
-	bool loadFromJsonIfPresent(const Common::String &filename);
+	bool loadFromPoIfPresent(const Common::String &filename);
 
 	// Returns true and sets out if translation exists; otherwise false.
 	bool translate(const Common::String &src, Common::String &out) const;
@@ -50,7 +50,9 @@ private:
 	bool _loaded = false;
 
 	static Common::String normalizeKey(const Common::String &s);
+	static Common::String unescapePoString(const Common::String &s);
 
+	void storePoEntry(const Common::String &msgId, const Common::String &msgStr);
 	void logMissingString(const Common::String &src);
 };
 

--- a/engines/ags/engine/util/ags_translator.h
+++ b/engines/ags/engine/util/ags_translator.h
@@ -40,11 +40,12 @@ public:
 	// Returns true and sets out if translation exists; otherwise false.
 	bool translate(const Common::String &src, Common::String &out) const;
 
-	// Returns the translated c-string, or the original if not found. Logs the initial lookup.
+	// Returns the translated c-string, or the original if not found.
 	const char *getTranslation(const char *src);
 
 private:
 	Common::HashMap<Common::String, Common::String> _entries;
+	Common::HashMap<Common::String, bool> _translatedValues;
 	Common::HashMap<Common::String, bool> _missingStrings;
 	bool _loaded = false;
 

--- a/engines/ags/module.mk
+++ b/engines/ags/module.mk
@@ -278,6 +278,7 @@ MODULE_OBJS = \
 	engine/script/script_api.o \
 	engine/script/script_runtime.o \
 	engine/script/system_imports.o \
+	engine/util/ags_translator.o \
 	plugins/ags_plugin.o \
 	plugins/plugin_base.o \
 	plugins/core/core.o \

--- a/engines/ags/shared/font/ttf_font_renderer.cpp
+++ b/engines/ags/shared/font/ttf_font_renderer.cpp
@@ -20,14 +20,14 @@
  */
 
 #include "ags/shared/font/ttf_font_renderer.h"
-#include "ags/lib/alfont/alfont.h"
-#include "ags/shared/core/platform.h"
-#include "ags/shared/ac/game_version.h"
 #include "ags/globals.h"
-#include "ags/shared/core/asset_manager.h"
-#include "ags/shared/util/stream.h"
+#include "ags/lib/alfont/alfont.h"
 #include "ags/shared/ac/game_struct_defines.h"
+#include "ags/shared/ac/game_version.h"
+#include "ags/shared/core/asset_manager.h"
+#include "ags/shared/core/platform.h"
 #include "ags/shared/font/fonts.h"
+#include "ags/shared/util/stream.h"
 
 namespace AGS3 {
 
@@ -56,7 +56,7 @@ int TTFFontRenderer::GetTextHeight(const char * /*text*/, int fontNumber) {
 }
 
 void TTFFontRenderer::RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour) {
-	if (y > destination->cb)  // optimisation
+	if (y > destination->cb) // optimisation
 		return;
 
 	// Y - 1 because it seems to get drawn down a bit
@@ -94,7 +94,8 @@ static ALFONT_FONT *LoadTTF(const String &filename, int fontSize, int alfont_fla
 		return nullptr;
 
 	const size_t lenof = reader->GetLength();
-	std::vector<char> buf; buf.resize(lenof);
+	std::vector<char> buf;
+	buf.resize(lenof);
 	reader->Read(&buf.front(), lenof);
 	reader.reset();
 
@@ -107,7 +108,7 @@ static ALFONT_FONT *LoadTTF(const String &filename, int fontSize, int alfont_fla
 
 // Fill the FontMetrics struct from the given ALFONT
 static void FillMetrics(ALFONT_FONT *alfptr, FontMetrics *metrics) {
-	metrics->NominalHeight  = alfont_get_font_height(alfptr);
+	metrics->NominalHeight = alfont_get_font_height(alfptr);
 	metrics->RealHeight = alfont_get_font_real_height(alfptr);
 	metrics->CompatHeight = metrics->NominalHeight; // just set to default here
 	alfont_get_font_real_vextent(alfptr, &metrics->VExtent.first, &metrics->VExtent.second);
@@ -118,23 +119,47 @@ static void FillMetrics(ALFONT_FONT *alfptr, FontMetrics *metrics) {
 
 bool TTFFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize, String *src_filename,
 									 const FontRenderParams *params, FontMetrics *metrics) {
-	String filename = String::FromFormat("agsfnt%d.ttf", fontNumber);
+	String baseName = String::FromFormat("agsfnt%d.ttf", fontNumber);
+	String overrideTTF = String::FromFormat("font_override_%d.ttf", fontNumber);
+	String overrideOTF = String::FromFormat("font_override_%d.otf", fontNumber);
+
 	if (fontSize <= 0)
 		fontSize = 8; // compatibility fix
-	assert(params);
+
 	FontRenderParams f_params = params ? *params : FontRenderParams();
 	if (f_params.SizeMultiplier > 1)
 		fontSize *= f_params.SizeMultiplier;
 
-	ALFONT_FONT *alfptr = LoadTTF(filename, fontSize,
-		GetAlfontFlags(f_params.LoadMode));
-	if (!alfptr)
-		return false;
+	const int flags = GetAlfontFlags(f_params.LoadMode);
+
+	ALFONT_FONT *alfptr = nullptr;
+	String usedName;
+
+	// The font loading order is as follows:
+	// 1. font_override_%d.ttf (User-provided TrueType font)
+	// 2. font_override_%d.otf (User-provided OpenType font)
+	// 3. agsfnt%d.ttf (Original game font)
+	alfptr = LoadTTF(overrideTTF, fontSize, flags);
+	if (alfptr) {
+		usedName = overrideTTF;
+	} else {
+		// Then try override OTF
+		alfptr = LoadTTF(overrideOTF, fontSize, flags);
+		if (alfptr) {
+			usedName = overrideOTF;
+		} else {
+			// Fallback to original
+			alfptr = LoadTTF(baseName, fontSize, flags);
+			if (!alfptr)
+				return false;
+			usedName = baseName;
+		}
+	}
 
 	_fontData[fontNumber].AlFont = alfptr;
 	_fontData[fontNumber].Params = f_params;
 	if (src_filename)
-		*src_filename = filename;
+		*src_filename = usedName;
 	if (metrics)
 		FillMetrics(alfptr, metrics);
 	return true;


### PR DESCRIPTION
This change improves fan-translation support in the AGS engine without requiring modifications to original game files.

- Add AgsTranslator helper to load a flat JSON map of {“source_string”:“translated_string”} and resolve translations at
runtime.
- Route GetTranslation() through the translator singleton and cache resolved lookups to reduce repeated work in UI/loop-heavy paths.
- Log missing/unmapped strings to the debug console, including a precise hexadecimal representation to help translators identify problematic character codes.
- Extend TTFFontRenderer font lookup to prefer optional per-font overrides:
  - font_override_%d.ttf / font_override_%d.otf
  - fallback to existing agsfnt%d.ttf

Notes:

- New files: engines/ags/engine/util/ags_translator.{h,cpp} (added to module.mk).
- Updated: engines/ags/engine/ac/global_translation.cpp, engines/ags/shared/font/ttf_font_renderer.cpp.
 
Suggested documentation to include with the PR:
- Brief note in AGS engine docs/README (or relevant wiki page) describing the expected JSON format, where to place the file, and the override font naming convention.

Screenshots:
<img width="1258" height="779" alt="553077072-5ae6fe90-1a50-4d56-9213-488f419479cd" src="https://github.com/user-attachments/assets/fdc95062-195b-47b6-ae49-ca1946fdafa8" />
<img width="1258" height="779" alt="553077074-f036be81-4f28-4071-b3b7-2410e9a91c4c" src="https://github.com/user-attachments/assets/f5b06701-407f-48f7-818b-0305374e9b4d" />