### PR TITLE
ACCESS: enable savestate metadata (timestamp & playtime)

### DIFF
--- a/engines/access/access.cpp
+++ b/engines/access/access.cpp
@@ -192,6 +192,7 @@ void AccessEngine::initialize() {
 	_video = new VideoPlayer(this);
 
 	syncSoundSettings();
+	setTotalPlayTime(0);
 
 	setDebugger(Debugger::init(this));
 	_buffer1.create(g_system->getWidth() + TILE_WIDTH, g_system->getHeight());
@@ -506,6 +507,9 @@ Common::Error AccessEngine::loadGameState(int slot) {
 	synchronize(s);
 	delete saveFile;
 
+	// Set total playTime (ms) from header
+	setTotalPlayTime(header._totalPlayTime * 1000);
+
 	// Set extra post-load state
 	_room->_function = FN_CLEAR1;
 	_timers._timersSavedFlag = false;
@@ -568,8 +572,14 @@ WARN_UNUSED_RESULT bool AccessEngine::readSavegameHeader(Common::InSaveFile *in,
 	header._day = in->readSint16LE();
 	header._hour = in->readSint16LE();
 	header._minute = in->readSint16LE();
+
+	// Read Totalframes
 	header._totalFrames = in->readUint32LE();
 
+	// Read the Total PlayTime (if available)
+	if (header._version > 1)
+		header._totalPlayTime = in->readUint32LE();	
+	
 	return true;
 }
 
@@ -601,6 +611,9 @@ void AccessEngine::writeSavegameHeader(Common::OutSaveFile *out, AccessSavegameH
 	out->writeSint16LE(td.tm_hour);
 	out->writeSint16LE(td.tm_min);
 	out->writeUint32LE(_events->getFrameCounter());
+
+	// Write the total PlayTime (ms)
+	out->writeUint32LE(g_engine->getTotalPlayTime() / 1000);
 }
 
 bool AccessEngine::shouldQuitOrRestart() {

--- a/engines/access/access.cpp
+++ b/engines/access/access.cpp
@@ -471,6 +471,33 @@ void AccessEngine::syncSoundSettings() {
 	_sound->syncVolume();
 }
 
+Common::Error AccessEngine::saveGameStream(Common::WriteStream *stream, bool isAutosave) {
+	stream->writeByte(ACCESS_SAVEGAME_VERSION);
+	Common::Serializer s(nullptr, stream);
+	s.setVersion(ACCESS_SAVEGAME_VERSION);
+
+	return synchronize(s);
+}
+
+Common::Error AccessEngine::loadGameStream(Common::SeekableReadStream *stream) {
+	byte version = stream->readByte();
+	if (version != ACCESS_SAVEGAME_VERSION)
+		error("Invalid savegame version");
+
+	Common::Serializer s(stream, nullptr);
+	s.setVersion(version);
+
+	Common::Error result = synchronize(s);
+
+	// Set extra post-load state
+	_room->_function = FN_CLEAR1;
+	_timers._timersSavedFlag = false;
+	_events->clearEvents();
+
+	return result;
+}
+
+/*
 Common::Error AccessEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
 	Common::OutSaveFile *out = g_system->getSavefileManager()->openForSaving(
 		getSaveStateName(slot));
@@ -517,6 +544,7 @@ Common::Error AccessEngine::loadGameState(int slot) {
 
 	return Common::kNoError;
 }
+*/
 
 bool AccessEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return _canSaveLoad;
@@ -526,7 +554,7 @@ bool AccessEngine::canSaveGameStateCurrently(Common::U32String *msg) {
 	return _canSaveLoad;
 }
 
-void AccessEngine::synchronize(Common::Serializer &s) {
+Common::Error AccessEngine::synchronize(Common::Serializer &s) {
 	s.syncAsUint16LE(_conversation);
 	s.syncAsUint16LE(_currentMan);
 	s.syncAsUint32LE(_newTime);
@@ -541,11 +569,14 @@ void AccessEngine::synchronize(Common::Serializer &s) {
 	_timers.synchronize(s);
 	_inventory->synchronize(s);
 	_player->synchronize(s);
+
+	return Common::kNoError;
 }
 
 const char *const SAVEGAME_STR = "ACCESS";
 #define SAVEGAME_STR_SIZE 6
 
+/*
 WARN_UNUSED_RESULT bool AccessEngine::readSavegameHeader(Common::InSaveFile *in, AccessSavegameHeader &header, bool skipThumbnail) {
 	char saveIdentBuffer[SAVEGAME_STR_SIZE + 1];
 
@@ -615,6 +646,7 @@ void AccessEngine::writeSavegameHeader(Common::OutSaveFile *out, AccessSavegameH
 	// Write the total PlayTime (ms)
 	out->writeUint32LE(g_engine->getTotalPlayTime() / 1000);
 }
+*/
 
 bool AccessEngine::shouldQuitOrRestart() {
 	return shouldQuit() || _restartFl;

--- a/engines/access/access.cpp
+++ b/engines/access/access.cpp
@@ -472,21 +472,12 @@ void AccessEngine::syncSoundSettings() {
 }
 
 Common::Error AccessEngine::saveGameStream(Common::WriteStream *stream, bool isAutosave) {
-	stream->writeByte(ACCESS_SAVEGAME_VERSION);
 	Common::Serializer s(nullptr, stream);
-	s.setVersion(ACCESS_SAVEGAME_VERSION);
-
 	return synchronize(s);
 }
 
-Common::Error AccessEngine::loadGameStream(Common::SeekableReadStream *stream) {
-	byte version = stream->readByte();
-	if (version != ACCESS_SAVEGAME_VERSION)
-		error("Invalid savegame version");
-
-	Common::Serializer s(stream, nullptr);
-	s.setVersion(version);
-
+Common::Error AccessEngine::loadGameStream(Common::SeekableReadStream *stream) {	
+	Common::Serializer s(stream, nullptr);	
 	Common::Error result = synchronize(s);
 
 	// Set extra post-load state
@@ -495,26 +486,6 @@ Common::Error AccessEngine::loadGameStream(Common::SeekableReadStream *stream) {
 	_events->clearEvents();
 
 	return result;
-}
-
-/*
-Common::Error AccessEngine::saveGameState(int slot, const Common::String &desc, bool isAutosave) {
-	Common::OutSaveFile *out = g_system->getSavefileManager()->openForSaving(
-		getSaveStateName(slot));
-	if (!out)
-		return Common::kCreatingFileFailed;
-
-	AccessSavegameHeader header;
-	header._saveName = desc;
-	writeSavegameHeader(out, header);
-
-	Common::Serializer s(nullptr, out);
-	synchronize(s);
-
-	out->finalize();
-	delete out;
-
-	return Common::kNoError;
 }
 
 Common::Error AccessEngine::loadGameState(int slot) {
@@ -527,9 +498,11 @@ Common::Error AccessEngine::loadGameState(int slot) {
 
 	// Load the savaegame header
 	AccessSavegameHeader header;
-	if (!readSavegameHeader(saveFile, header))
-		error("Invalid savegame");
-
+	if (!readSavegameHeader(saveFile, header)) {
+		delete saveFile;
+		return Engine::loadGameState(slot);
+	}
+		
 	// Load most of the savegame data
 	synchronize(s);
 	delete saveFile;
@@ -544,7 +517,7 @@ Common::Error AccessEngine::loadGameState(int slot) {
 
 	return Common::kNoError;
 }
-*/
+
 
 bool AccessEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return _canSaveLoad;
@@ -576,8 +549,8 @@ Common::Error AccessEngine::synchronize(Common::Serializer &s) {
 const char *const SAVEGAME_STR = "ACCESS";
 #define SAVEGAME_STR_SIZE 6
 
-/*
-WARN_UNUSED_RESULT bool AccessEngine::readSavegameHeader(Common::InSaveFile *in, AccessSavegameHeader &header, bool skipThumbnail) {
+
+bool AccessEngine::readSavegameHeader(Common::InSaveFile *in, AccessSavegameHeader &header, bool skipThumbnail) {
 	char saveIdentBuffer[SAVEGAME_STR_SIZE + 1];
 
 	// Validate the header Id
@@ -613,40 +586,6 @@ WARN_UNUSED_RESULT bool AccessEngine::readSavegameHeader(Common::InSaveFile *in,
 	
 	return true;
 }
-
-void AccessEngine::writeSavegameHeader(Common::OutSaveFile *out, AccessSavegameHeader &header) {
-	// Write out a savegame header
-	out->write(SAVEGAME_STR, SAVEGAME_STR_SIZE + 1);
-
-	out->writeByte(ACCESS_SAVEGAME_VERSION);
-
-	// Write savegame name
-	out->writeString(header._saveName);
-	out->writeByte('\0');
-
-	// Write a thumbnail of the screen
-	uint8 thumbPalette[Graphics::PALETTE_SIZE];
-	_screen->getPalette(thumbPalette);
-	Graphics::Surface saveThumb;
-	::createThumbnail(&saveThumb, (const byte *)_screen->getPixels(),
-		_screen->w, _screen->h, thumbPalette);
-	Graphics::saveThumbnail(*out, saveThumb);
-	saveThumb.free();
-
-	// Write out the save date/time
-	TimeDate td;
-	g_system->getTimeAndDate(td);
-	out->writeSint16LE(td.tm_year + 1900);
-	out->writeSint16LE(td.tm_mon + 1);
-	out->writeSint16LE(td.tm_mday);
-	out->writeSint16LE(td.tm_hour);
-	out->writeSint16LE(td.tm_min);
-	out->writeUint32LE(_events->getFrameCounter());
-
-	// Write the total PlayTime (ms)
-	out->writeUint32LE(g_engine->getTotalPlayTime() / 1000);
-}
-*/
 
 bool AccessEngine::shouldQuitOrRestart() {
 	return shouldQuit() || _restartFl;

--- a/engines/access/access.h
+++ b/engines/access/access.h
@@ -126,7 +126,7 @@ static const AccessActionCode MARTIAN_ACTION_CODES[] = {
 	{ kActionNone, -1 },
 };
 
-#define ACCESS_SAVEGAME_VERSION 1
+#define ACCESS_SAVEGAME_VERSION 2
 
 struct AccessSavegameHeader {
 	uint8 _version;
@@ -135,6 +135,7 @@ struct AccessSavegameHeader {
 	int _year, _month, _day;
 	int _hour, _minute;
 	int _totalFrames;
+	int _totalPlayTime;
 };
 
 class AccessEngine : public Engine {

--- a/engines/access/access.h
+++ b/engines/access/access.h
@@ -184,7 +184,6 @@ protected:
 	/**
 	* Synchronize savegame data
 	*/
-	//virtual void synchronize(Common::Serializer &s);
 	virtual Common::Error synchronize(Common::Serializer &s);
 
 public:
@@ -344,7 +343,6 @@ public:
 	 * Save the game
 	 */
 	Common::Error saveGameStream(Common::WriteStream *stream, bool isAutosave = false) override;
-	
 	/**
 	 * Returns true if a savegame can currently be loaded
 	 */

--- a/engines/access/access.h
+++ b/engines/access/access.h
@@ -184,7 +184,9 @@ protected:
 	/**
 	* Synchronize savegame data
 	*/
-	virtual void synchronize(Common::Serializer &s);
+	//virtual void synchronize(Common::Serializer &s);
+	virtual Common::Error synchronize(Common::Serializer &s);
+
 public:
 	AnimationManager *_animation;
 	BubbleBox *_bubbleBox;
@@ -335,13 +337,15 @@ public:
 	/**
 	 * Load a savegame
 	 */
-	Common::Error loadGameState(int slot) override;
+	//Common::Error loadGameState(int slot) override;
+	Common::Error loadGameStream(Common::SeekableReadStream *stream) override;
 
 	/**
 	 * Save the game
 	 */
-	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
-
+	//Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
+	Common::Error saveGameStream(Common::WriteStream *stream, bool isAutosave = false) override;
+	
 	/**
 	 * Returns true if a savegame can currently be loaded
 	 */

--- a/engines/access/access.h
+++ b/engines/access/access.h
@@ -126,7 +126,7 @@ static const AccessActionCode MARTIAN_ACTION_CODES[] = {
 	{ kActionNone, -1 },
 };
 
-#define ACCESS_SAVEGAME_VERSION 2
+#define ACCESS_SAVEGAME_VERSION 1
 
 struct AccessSavegameHeader {
 	uint8 _version;
@@ -337,13 +337,12 @@ public:
 	/**
 	 * Load a savegame
 	 */
-	//Common::Error loadGameState(int slot) override;
+	Common::Error loadGameState(int slot) override;
 	Common::Error loadGameStream(Common::SeekableReadStream *stream) override;
 
 	/**
 	 * Save the game
 	 */
-	//Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
 	Common::Error saveGameStream(Common::WriteStream *stream, bool isAutosave = false) override;
 	
 	/**
@@ -359,12 +358,7 @@ public:
 	/**
 	 * Read in a savegame header
 	 */
-	WARN_UNUSED_RESULT static bool readSavegameHeader(Common::InSaveFile *in, AccessSavegameHeader &header, bool skipThumbnail = true);
-
-	/**
-	 * Write out a savegame header
-	 */
-	void writeSavegameHeader(Common::OutSaveFile *out, AccessSavegameHeader &header);
+	static bool readSavegameHeader(Common::InSaveFile *in, AccessSavegameHeader &header, bool skipThumbnail = true);
 
 	bool playMovie(const Common::Path &filename, const Common::Point &pos);
 };

--- a/engines/access/amazon/amazon_game.cpp
+++ b/engines/access/amazon/amazon_game.cpp
@@ -769,7 +769,7 @@ void AmazonEngine::dead(int deathId) {
 	}
 }
 
-void AmazonEngine::synchronize(Common::Serializer &s) {
+Common::Error AmazonEngine::synchronize(Common::Serializer &s) {
 	AccessEngine::synchronize(s);
 
 	s.syncAsSint16LE(_chapter);
@@ -785,6 +785,8 @@ void AmazonEngine::synchronize(Common::Serializer &s) {
 
 	_river->synchronize(s);
 	_ant->synchronize(s);
+
+	return Common::kNoError;
 }
 
 } // End of namespace Amazon

--- a/engines/access/amazon/amazon_game.h
+++ b/engines/access/amazon/amazon_game.h
@@ -63,7 +63,9 @@ protected:
 	/**
 	* Synchronize savegame data
 	*/
-	void synchronize(Common::Serializer &s) override;
+	//void synchronize(Common::Serializer &s) override;
+	Common::Error synchronize(Common::Serializer &s) override;
+
 public:
 	InactivePlayer _inactive;
 	bool _charSegSwitch;

--- a/engines/access/amazon/amazon_game.h
+++ b/engines/access/amazon/amazon_game.h
@@ -63,7 +63,6 @@ protected:
 	/**
 	* Synchronize savegame data
 	*/
-	//void synchronize(Common::Serializer &s) override;
 	Common::Error synchronize(Common::Serializer &s) override;
 
 public:

--- a/engines/access/martian/martian_game.cpp
+++ b/engines/access/martian/martian_game.cpp
@@ -393,7 +393,7 @@ void MartianEngine::establish(int estabIndex, int sub) {
 	_events->showCursor();
 }
 
-void MartianEngine::synchronize(Common::Serializer &s) {
+Common::Error MartianEngine::synchronize(Common::Serializer &s) {
 	AccessEngine::synchronize(s);
 
 	for (int i = 0; i < ARRAYSIZE(_travel); i++) {
@@ -419,6 +419,8 @@ void MartianEngine::synchronize(Common::Serializer &s) {
 	_boxSelectYOld
 	_numLines
 	*/
+
+	return Common::kNoError;
 }
 
 

--- a/engines/access/martian/martian_game.h
+++ b/engines/access/martian/martian_game.h
@@ -70,7 +70,8 @@ public:
 	/**
 	* Synchronize savegame data
 	*/
-	void synchronize(Common::Serializer &s) override;
+	//void synchronize(Common::Serializer &s) override;
+	Common::Error synchronize(Common::Serializer &s) override;
 };
 
 } // End of namespace Martian

--- a/engines/access/martian/martian_game.h
+++ b/engines/access/martian/martian_game.h
@@ -70,7 +70,6 @@ public:
 	/**
 	* Synchronize savegame data
 	*/
-	//void synchronize(Common::Serializer &s) override;
 	Common::Error synchronize(Common::Serializer &s) override;
 };
 

--- a/engines/access/metaengine.cpp
+++ b/engines/access/metaengine.cpp
@@ -83,14 +83,15 @@ public:
 
 	Common::Error createInstance(OSystem *syst, Engine **engine, const Access::AccessGameDescription *desc) const override;
 
-	SaveStateList listSaves(const char *target) const override;
-	int getMaximumSaveSlot() const override;
-	bool removeSaveState(const char *target, int slot) const override;
-	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
+	//SaveStateList listSaves(const char *target) const override;
+	//int getMaximumSaveSlot() const override;
+	//bool removeSaveState(const char *target, int slot) const override;
+	//SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
 	Common::KeymapArray initKeymaps(const char *target) const override;
 };
 
 bool AccessMetaEngine::hasFeature(MetaEngineFeature f) const {
+<<<<<<< Updated upstream
 	return
 	    (f == kSupportsListSaves) ||
 		(f == kSupportsLoadingDuringStartup) ||
@@ -100,6 +101,10 @@ bool AccessMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSavesSupportCreationDate) ||
 		(f == kSavesSupportPlayTime) ||
 		(f == kSimpleSavesNames);
+=======
+	return checkExtendedSaves(f) ||
+		   (f == kSupportsLoadingDuringStartup);
+>>>>>>> Stashed changes
 }
 
 bool Access::AccessEngine::hasFeature(EngineFeature f) const {
@@ -123,6 +128,7 @@ Common::Error AccessMetaEngine::createInstance(OSystem *syst, Engine **engine, c
 	return Common::kNoError;
 }
 
+/*
 SaveStateList AccessMetaEngine::listSaves(const char *target) const {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
 	Common::String saveDesc;
@@ -190,6 +196,7 @@ SaveStateDescriptor AccessMetaEngine::querySaveMetaInfos(const char *target, int
 
 	return SaveStateDescriptor();
 }
+*/
 
 Common::KeymapArray AccessMetaEngine::initKeymaps(const char *target) const {
 	using namespace Common;

--- a/engines/access/metaengine.cpp
+++ b/engines/access/metaengine.cpp
@@ -97,6 +97,8 @@ bool AccessMetaEngine::hasFeature(MetaEngineFeature f) const {
 		(f == kSupportsDeleteSave) ||
 		(f == kSavesSupportMetaInfo) ||
 		(f == kSavesSupportThumbnail) ||
+		(f == kSavesSupportCreationDate) ||
+		(f == kSavesSupportPlayTime) ||
 		(f == kSimpleSavesNames);
 }
 
@@ -177,8 +179,12 @@ SaveStateDescriptor AccessMetaEngine::querySaveMetaInfos(const char *target, int
 		desc.setThumbnail(header._thumbnail);
 		desc.setSaveDate(header._year, header._month, header._day);
 		desc.setSaveTime(header._hour, header._minute);
-		desc.setPlayTime(header._totalFrames * GAME_FRAME_TIME);
 
+		if (header._version >= 2)
+			desc.setPlayTime(header._totalPlayTime * 1000);
+		else
+			desc.setPlayTime(0);
+				
 		return desc;
 	}
 

--- a/engines/access/metaengine.cpp
+++ b/engines/access/metaengine.cpp
@@ -83,28 +83,15 @@ public:
 
 	Common::Error createInstance(OSystem *syst, Engine **engine, const Access::AccessGameDescription *desc) const override;
 
-	//SaveStateList listSaves(const char *target) const override;
-	//int getMaximumSaveSlot() const override;
-	//bool removeSaveState(const char *target, int slot) const override;
-	//SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
+	SaveStateList listSaves(const char *target) const override;
+	SaveStateDescriptor querySaveMetaInfos(const char *target, int slot) const override;
+
 	Common::KeymapArray initKeymaps(const char *target) const override;
 };
 
 bool AccessMetaEngine::hasFeature(MetaEngineFeature f) const {
-<<<<<<< Updated upstream
-	return
-	    (f == kSupportsListSaves) ||
-		(f == kSupportsLoadingDuringStartup) ||
-		(f == kSupportsDeleteSave) ||
-		(f == kSavesSupportMetaInfo) ||
-		(f == kSavesSupportThumbnail) ||
-		(f == kSavesSupportCreationDate) ||
-		(f == kSavesSupportPlayTime) ||
-		(f == kSimpleSavesNames);
-=======
 	return checkExtendedSaves(f) ||
 		   (f == kSupportsLoadingDuringStartup);
->>>>>>> Stashed changes
 }
 
 bool Access::AccessEngine::hasFeature(EngineFeature f) const {
@@ -128,7 +115,6 @@ Common::Error AccessMetaEngine::createInstance(OSystem *syst, Engine **engine, c
 	return Common::kNoError;
 }
 
-/*
 SaveStateList AccessMetaEngine::listSaves(const char *target) const {
 	Common::SaveFileManager *saveFileMan = g_system->getSavefileManager();
 	Common::String saveDesc;
@@ -147,7 +133,11 @@ SaveStateList AccessMetaEngine::listSaves(const char *target) const {
 			if (in) {
 				if (Access::AccessEngine::readSavegameHeader(in, header))
 					saveList.push_back(SaveStateDescriptor(this, slot, header._saveName));
-
+				else {
+					ExtendedSavegameHeader eHeader;
+					if (MetaEngine::readSavegameHeader(in, &eHeader))
+						saveList.push_back(SaveStateDescriptor(this, slot, eHeader.description));
+				}
 				delete in;
 			}
 		}
@@ -158,45 +148,55 @@ SaveStateList AccessMetaEngine::listSaves(const char *target) const {
 	return saveList;
 }
 
-int AccessMetaEngine::getMaximumSaveSlot() const {
-	return MAX_SAVES;
-}
-
-bool AccessMetaEngine::removeSaveState(const char *target, int slot) const {
-	Common::String filename = Common::String::format("%s.%03d", target, slot);
-	return g_system->getSavefileManager()->removeSavefile(filename);
-}
-
 SaveStateDescriptor AccessMetaEngine::querySaveMetaInfos(const char *target, int slot) const {
 	Common::String filename = Common::String::format("%s.%03d", target, slot);
 	Common::InSaveFile *f = g_system->getSavefileManager()->openForLoading(filename);
 
 	if (f) {
-		Access::AccessSavegameHeader header;
-		if (!Access::AccessEngine::readSavegameHeader(f, header, false)) {
+
+		ExtendedSavegameHeader eHeader;
+		if (MetaEngine::readSavegameHeader(f, &eHeader, false)) {
 			delete f;
-			return SaveStateDescriptor();
+
+			SaveStateDescriptor desc(this, slot, eHeader.description);
+			desc.setThumbnail(eHeader.thumbnail);
+
+			uint16 year;
+			uint8 month;
+			uint8 day;
+
+			decodeSavegameDate(&eHeader, year, month, day);
+			desc.setSaveDate(year,month,day);
+
+			uint8 hour;
+			uint8 minute;
+
+			decodeSavegameTime(&eHeader, hour, minute);
+			desc.setSaveTime(hour, minute);
+
+			desc.setPlayTime(eHeader.playtime);
+			return desc;
+		}
+			
+		Access::AccessSavegameHeader header;
+		if (Access::AccessEngine::readSavegameHeader(f, header, false)) {
+			delete f;
+			SaveStateDescriptor desc(this, slot, header._saveName);
+			desc.setThumbnail(header._thumbnail);
+			desc.setSaveDate(header._year, header._month, header._day);
+			desc.setSaveTime(header._hour, header._minute);
+
+			return desc;
 		}
 
 		delete f;
 
-		// Create the return descriptor
-		SaveStateDescriptor desc(this, slot, header._saveName);
-		desc.setThumbnail(header._thumbnail);
-		desc.setSaveDate(header._year, header._month, header._day);
-		desc.setSaveTime(header._hour, header._minute);
-
-		if (header._version >= 2)
-			desc.setPlayTime(header._totalPlayTime * 1000);
-		else
-			desc.setPlayTime(0);
-				
-		return desc;
+		return SaveStateDescriptor();				
 	}
 
 	return SaveStateDescriptor();
 }
-*/
+
 
 Common::KeymapArray AccessMetaEngine::initKeymaps(const char *target) const {
 	using namespace Common;


### PR DESCRIPTION
 - make savegame handling meta engine mechanism 

- remove obsolete methods

 - add fallback detection for legacy savegames