### PR TITLE
GUI: Improve Tooltip event handling

### DIFF
--- a/gui/Tooltip.cpp
+++ b/gui/Tooltip.cpp
@@ -23,16 +23,13 @@
 #include "gui/widget.h"
 #include "gui/dialog.h"
 #include "gui/gui-manager.h"
-
 #include "gui/Tooltip.h"
 #include "gui/ThemeEval.h"
 
 namespace GUI {
 
-
 Tooltip::Tooltip() :
 	Dialog(-1, -1, -1, -1), _maxWidth(-1), _widget(nullptr), _xdelta(0), _ydelta(0), _xpadding(0), _ypadding(0) {
-
 	_backgroundType = GUI::ThemeEngine::kDialogBackgroundTooltip;
 }
 
@@ -128,4 +125,4 @@ void Tooltip::handleMouseMoved(int x, int y, int button) {
 	_widget->handleMouseMoved(x, y, button);
 }
 
-}
+} // End of namespace GUI

--- a/gui/Tooltip.cpp
+++ b/gui/Tooltip.cpp
@@ -125,6 +125,7 @@ void Tooltip::handleKeyUp(Common::KeyState state) {
 
 void Tooltip::handleMouseMoved(int x, int y, int button) {
 	close();
+	_widget->handleMouseMoved(x, y, button);
 }
 
 }

--- a/gui/Tooltip.cpp
+++ b/gui/Tooltip.cpp
@@ -98,4 +98,33 @@ void Tooltip::drawDialog(DrawLayer layerToDraw) {
 	}
 }
 
+void Tooltip::handleMouseDown(int x, int y, int button, int clickCount) {
+	close();
+	_parent->handleMouseDown(x + (getAbsX() - _parent->getAbsX()), y + (getAbsY() - _parent->getAbsY()), button, clickCount);
+}
+
+void Tooltip::handleMouseUp(int x, int y, int button, int clickCount) {
+	close();
+	_parent->handleMouseUp(x + (getAbsX() - _parent->getAbsX()), y + (getAbsY() - _parent->getAbsY()), button, clickCount);
+}
+
+void Tooltip::handleMouseWheel(int x, int y, int direction) {
+	close();
+	_parent->handleMouseWheel(x + (getAbsX() - _parent->getAbsX()), y + (getAbsX() - _parent->getAbsX()), direction);
+}
+
+void Tooltip::handleKeyDown(Common::KeyState state) {
+	close();
+	_parent->handleKeyDown(state);
+}
+
+void Tooltip::handleKeyUp(Common::KeyState state) {
+	close();
+	_parent->handleKeyUp(state);
+}
+
+void Tooltip::handleMouseMoved(int x, int y, int button) {
+	close();
+}
+
 }

--- a/gui/Tooltip.cpp
+++ b/gui/Tooltip.cpp
@@ -31,7 +31,7 @@ namespace GUI {
 
 
 Tooltip::Tooltip() :
-	Dialog(-1, -1, -1, -1), _maxWidth(-1), _parent(nullptr), _xdelta(0), _ydelta(0), _xpadding(0), _ypadding(0) {
+	Dialog(-1, -1, -1, -1), _maxWidth(-1), _widget(nullptr), _xdelta(0), _ydelta(0), _xpadding(0), _ypadding(0) {
 
 	_backgroundType = GUI::ThemeEngine::kDialogBackgroundTooltip;
 }
@@ -39,7 +39,7 @@ Tooltip::Tooltip() :
 void Tooltip::setup(Dialog *parent, Widget *widget, int x, int y) {
 	assert(widget->hasTooltip());
 
-	_parent = parent;
+	_widget = widget;
 
 	setMouseUpdatedOnFocus(false);
 
@@ -100,27 +100,27 @@ void Tooltip::drawDialog(DrawLayer layerToDraw) {
 
 void Tooltip::handleMouseDown(int x, int y, int button, int clickCount) {
 	close();
-	_parent->handleMouseDown(x + (getAbsX() - _parent->getAbsX()), y + (getAbsY() - _parent->getAbsY()), button, clickCount);
+	_widget->handleMouseDown(x + (getAbsX() - _widget->getAbsX()), y + (getAbsY() - _widget->getAbsY()), button, clickCount);
 }
 
 void Tooltip::handleMouseUp(int x, int y, int button, int clickCount) {
 	close();
-	_parent->handleMouseUp(x + (getAbsX() - _parent->getAbsX()), y + (getAbsY() - _parent->getAbsY()), button, clickCount);
+	_widget->handleMouseUp(x + (getAbsX() - _widget->getAbsX()), y + (getAbsY() - _widget->getAbsY()), button, clickCount);
 }
 
 void Tooltip::handleMouseWheel(int x, int y, int direction) {
 	close();
-	_parent->handleMouseWheel(x + (getAbsX() - _parent->getAbsX()), y + (getAbsX() - _parent->getAbsX()), direction);
+	_widget->handleMouseWheel(x + (getAbsX() - _widget->getAbsX()), y + (getAbsX() - _widget->getAbsX()), direction);
 }
 
 void Tooltip::handleKeyDown(Common::KeyState state) {
 	close();
-	_parent->handleKeyDown(state);
+	_widget->handleKeyDown(state);
 }
 
 void Tooltip::handleKeyUp(Common::KeyState state) {
 	close();
-	_parent->handleKeyUp(state);
+	_widget->handleKeyUp(state);
 }
 
 void Tooltip::handleMouseMoved(int x, int y, int button) {

--- a/gui/Tooltip.h
+++ b/gui/Tooltip.h
@@ -43,29 +43,12 @@ public:
 
 	void receivedFocus(int x = -1, int y = -1) override {}
 protected:
-	void handleMouseDown(int x, int y, int button, int clickCount) override {
-		close();
-		_parent->handleMouseDown(x + (getAbsX() - _parent->getAbsX()), y + (getAbsY() - _parent->getAbsY()), button, clickCount);
-	}
-	void handleMouseUp(int x, int y, int button, int clickCount) override {
-		close();
-		_parent->handleMouseUp(x + (getAbsX() - _parent->getAbsX()), y + (getAbsY() - _parent->getAbsY()), button, clickCount);
-	}
-	void handleMouseWheel(int x, int y, int direction) override {
-		close();
-		_parent->handleMouseWheel(x + (getAbsX() - _parent->getAbsX()), y + (getAbsX() - _parent->getAbsX()), direction);
-	}
-	void handleKeyDown(Common::KeyState state) override {
-		close();
-		_parent->handleKeyDown(state);
-	}
-	void handleKeyUp(Common::KeyState state) override {
-		close();
-		_parent->handleKeyUp(state);
-	}
-	void handleMouseMoved(int x, int y, int button) override {
-		close();
-	}
+	void handleKeyDown(Common::KeyState state) override;
+	void handleKeyUp(Common::KeyState state) override;
+	void handleMouseDown(int x, int y, int button, int clickCount) override;
+	void handleMouseMoved(int x, int y, int button) override;
+	void handleMouseUp(int x, int y, int button, int clickCount) override;
+	void handleMouseWheel(int x, int y, int direction) override;
 
 	int _maxWidth;
 	int _xdelta, _ydelta;

--- a/gui/Tooltip.h
+++ b/gui/Tooltip.h
@@ -32,7 +32,7 @@ class Widget;
 
 class Tooltip : public Dialog {
 private:
-	Dialog *_parent;
+	Widget *_widget;
 
 public:
 	Tooltip();

--- a/gui/Tooltip.h
+++ b/gui/Tooltip.h
@@ -36,12 +36,10 @@ private:
 
 public:
 	Tooltip();
-
 	void setup(Dialog *parent, Widget *widget, int x, int y);
-
 	void drawDialog(DrawLayer layerToDraw) override;
-
 	void receivedFocus(int x = -1, int y = -1) override {}
+
 protected:
 	void handleKeyDown(Common::KeyState state) override;
 	void handleKeyUp(Common::KeyState state) override;


### PR DESCRIPTION
Fix some behaviour like in this recording.
- Adjust shader, then scroll during Render Mode tip: shader changes
- Scroll during Filter tip: tab changes (but scroll in free space of dialog: no tab change...)

https://github.com/user-attachments/assets/702a301e-5486-4a6b-8828-2a831b5daeff




I have a commit which moves some little methods from .h to .cpp. I would appreciate advice on deciding when code should be in .h and when it should be in .cpp. By my understanding it should practically always be in .cpp unless there are performance i.e. inline concerns of some kind, but I still have a lot to learn about C++.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
