### PR TITLE
GUI: Fix cursor jump in GroupedList after game removal

### DIFF
--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -461,6 +461,10 @@ void LauncherDialog::removeGame(int item) {
 		// This will be used to select the next item.
 		// If grouping method is None then updateListing() will
 		// ignore selPos and use the current selection instead.
+		int selPos = -1;
+		if (_groupBy != kGroupByNone) {
+			selPos = getItemPos(item);
+		}
 
 		// Remove the currently selected game from the list
 		assert(item >= 0);
@@ -478,7 +482,7 @@ void LauncherDialog::removeGame(int item) {
 		ConfMan.flushToDisk();
 
 		// Update the ListWidget/GridWidget and force a redraw
-		updateListing();
+		updateListing(selPos);
 		g_gui.scheduleTopDialogRedraw();
 	}
 }
@@ -1241,11 +1245,17 @@ void LauncherSimple::updateListing(int selPos) {
 	}
 
 	const int oldSel = _list->getSelected();
+
+	// Preserve the current collapsed groups before rebuilding the grouped list
+	if (_groupBy != kGroupByNone) {
+		_list->saveClosedGroups(Common::U32String(groupingModes[_groupBy].name));
+	}
+
 	_list->setList(l);
 
 	groupEntries(domainList);
 
-	// Close groups that the user closed earlier
+	// Restore collapsed groups after rebuilding
 	_list->loadClosedGroups(Common::U32String(groupingModes[_groupBy].name));
 
 	// Update the filter settings, those are lost when "setList"
@@ -1839,14 +1849,9 @@ void LauncherDialog::confirmRemoveGames(const Common::Array<bool> &selectedItems
 
 	// Use standard message box if only one item is selected
 	if (selectedCount == 1) {
-		for (int i = 0; i < (int)selectedItems.size(); ++i) {
-			if (selectedItems[i]) {
-				removeGame(i);
-				return;
-			}
-		}
+		removeGame(getSelected());
+		return;
 	}
-
 	// Build the confirmation message with count
 	Common::U32String message = Common::U32String::format(
 		_("Do you really want to remove the following %d game configurations?\n\n"),

--- a/gui/widgets/groupedlist.cpp
+++ b/gui/widgets/groupedlist.cpp
@@ -296,40 +296,40 @@ void GroupedListWidget::handleCommand(CommandSender *sender, uint32 cmd, uint32 
 }
 
 int GroupedListWidget::getItemPos(int item) {
-	int pos = 0;
-
 	for (uint i = 0; i < _listIndex.size(); i++) {
 		if (_listIndex[i] == item) {
-			return pos;
-		} else if (_listIndex[i] >= 0) { // skip headers
-			pos++;
+			return i;
 		}
 	}
 
 	return -1;
 }
 
-int GroupedListWidget::getNewSel(int index) {   
-	// If the list is empty, return -1
-	if (_listIndex.size() == 1){
-		return -1;
-	}
+int GroupedListWidget::getNewSel(int index) {
+    if (_listIndex.empty()) {
+        return -1;
+    }
 
-	// Find the index-th item in the list
-	for (uint i = 0; i < _listIndex.size(); i++) {
-		if (index == 0 && _listIndex[i] >= 0) {
-			return _listIndex[i];
-		} else if (_listIndex[i] >= 0) {
-			index--;
-		}
-	}
+    if (index < 0) {
+        return -1;
+    }
+    if (index >= (int)_listIndex.size()) {
+        index = _listIndex.size() - 1;
+    }
 
-	// If we are at the end of the list, return the last item.
-	if (index == 0) {
-		return _listIndex[_listIndex.size() - 1];
-	} else {
-		return -1;
-	}
+    // First try the next selectable visible item
+    int selectable = findSelectableItem(index, +1);
+
+    // If there is none below, try the previous selectable one
+    if (selectable == -1) {
+        selectable = findSelectableItem(index - 1, -1);
+    }
+
+    if (selectable == -1) {
+        return -1;
+    }
+
+    return _listIndex[selectable];
 }
 
 void GroupedListWidget::toggleGroup(int groupID) {

--- a/gui/widgets/groupedlist.h
+++ b/gui/widgets/groupedlist.h
@@ -56,7 +56,6 @@ public:
 	void saveClosedGroups(const Common::U32String &groupName);
 
 	int getSelected() const { return (_selectedItem == -1) ? _selectedItem : _listIndex[_selectedItem]; }
-
 	void setFilter(const Common::U32String &filter, bool redraw = true);
 
 	void handleMouseDown(int x, int y, int button, int clickCount) override;


### PR DESCRIPTION
GUI: Fix cursor jump in GroupedList after game removal

This PR addresses the issue where the cursor would jump to a random 
position when removing a game while grouping is enabled in the 
launcher.

The root cause was a mismatch between visual row indices and actual 
data IDs. The launcher was passing the visual index to the removal 
logic, leading to incorrect deletions and UI state.

Changes:
- Update LauncherDialog::confirmRemoveGames to use getSelected() to 
  retrieve the actual data ID.
- Implement GroupedListWidget::setSelected() to correctly map data IDs 
  to visual positions.
- Ensure the UI highlight is enforced using markSelectedItem() and 
  consistent scrolling with scrollTo().

Tested across multiple engines with single and mass removals. 
Resolves ticket #1221894055059785092.