### PR TITLE
WII: Fully implement conversion for unsupported pixel formats

### DIFF
--- a/backends/platform/wii/osystem.cpp
+++ b/backends/platform/wii/osystem.cpp
@@ -69,11 +69,9 @@ OSystem_Wii::OSystem_Wii() :
 	_bilinearFilter(false),
 	_pfRGB565(Graphics::PixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0)),
 	_pfRGB3444(Graphics::PixelFormat(2, 4, 4, 4, 3, 8, 4, 0, 12)),
-#ifdef USE_RGB_COLOR
 	_pfGame(Graphics::PixelFormat::createFormatCLUT8()),
 	_pfGameTexture(Graphics::PixelFormat::createFormatCLUT8()),
 	_pfCursor(Graphics::PixelFormat::createFormatCLUT8()),
-#endif
 
 	_optionsDlgActive(false),
 	_consoleVisible(false),

--- a/backends/platform/wii/osystem.cpp
+++ b/backends/platform/wii/osystem.cpp
@@ -49,6 +49,7 @@ OSystem_Wii::OSystem_Wii() :
 	_gameWidth(0),
 	_gameHeight(0),
 	_gamePixels(NULL),
+	_gamePixelsTexture(NULL),
 	_gameDirty(false),
 
 	_overlayVisible(true),
@@ -58,6 +59,7 @@ OSystem_Wii::OSystem_Wii() :
 	_overlayPixels(NULL),
 	_overlayDirty(false),
 
+	_blitFunc(NULL),
 	_lastScreenUpdate(0),
 	_currentWidth(0),
 	_currentHeight(0),

--- a/backends/platform/wii/osystem.h
+++ b/backends/platform/wii/osystem.h
@@ -86,11 +86,9 @@ private:
 	bool _bilinearFilter;
 	const Graphics::PixelFormat _pfRGB565;
 	const Graphics::PixelFormat _pfRGB3444;
-#ifdef USE_RGB_COLOR
 	Graphics::PixelFormat _pfGame;
 	Graphics::PixelFormat _pfGameTexture;
 	Graphics::PixelFormat _pfCursor;
-#endif
 
 	bool _consoleVisible;
 	bool _optionsDlgActive;

--- a/backends/platform/wii/osystem.h
+++ b/backends/platform/wii/osystem.h
@@ -32,6 +32,7 @@
 #include "common/rect.h"
 #include "common/events.h"
 #include "backends/base-backend.h"
+#include "graphics/blit.h"
 #include "graphics/paletteman.h"
 #include "graphics/surface.h"
 #include "audio/mixer_intern.h"
@@ -62,7 +63,7 @@ private:
 
 	bool _gameRunning;
 	u16 _gameWidth, _gameHeight;
-	u8 *_gamePixels;
+	u8 *_gamePixels, *_gamePixelsTexture;
 	Graphics::Surface _surface;
 	gfx_screen_coords_t _coordsGame;
 	gfx_tex_t _texGame;
@@ -77,6 +78,7 @@ private:
 	bool _overlayDirty;
 	bool _overlayInGUI;
 
+	Graphics::FastBlitFunc _blitFunc;
 	u32 _lastScreenUpdate;
 	u16 _currentWidth, _currentHeight;
 	f32 _currentXScale, _currentYScale;

--- a/backends/platform/wii/osystem_gfx.cpp
+++ b/backends/platform/wii/osystem_gfx.cpp
@@ -111,6 +111,9 @@ void OSystem_Wii::deinitGfx() {
 	free(_gamePixels);
 	_gamePixels = NULL;
 
+	free(_gamePixelsTexture);
+	_gamePixelsTexture = NULL;
+
 	free(_overlayPixels);
 	_overlayPixels = NULL;
 }
@@ -235,9 +238,6 @@ void OSystem_Wii::initSize(uint width, uint height,
 	else
 		newFormat = Graphics::PixelFormat::createFormatCLUT8();
 
-	if (newFormat.bytesPerPixel > 2)
-		newFormat = Graphics::PixelFormat::createFormatCLUT8();
-
 	if (_pfGame != newFormat) {
 		_pfGame = newFormat;
 		update = true;
@@ -254,6 +254,7 @@ void OSystem_Wii::initSize(uint width, uint height,
 	}
 
 	if (_gameWidth != newWidth || _gameHeight != newHeight) {
+		// TODO: Return an error code in endGFXTransaction()
 		assert((newWidth <= 640) && (newHeight <= 480));
 
 		if (width != newWidth || height != newHeight)
@@ -275,25 +276,39 @@ void OSystem_Wii::initSize(uint width, uint height,
 	}
 
 	if (update) {
-		free(_gamePixels);
+		if (_gamePixels != _gamePixelsTexture)
+			free(_gamePixels);
+		free(_gamePixelsTexture);
 
 		tex_format = GFX_TF_PALETTE_RGB565;
 
 		if (_pfGame.bytesPerPixel > 1) {
+			// TODO: Support other texture formats?
 			tex_format = GFX_TF_RGB565;
 			_pfGameTexture = _pfRGB565;
 		}
 
-		printf("initSize %u*%u*%u (%u%u%u -> %u%u%u match: %d)\n",
-				_gameWidth, _gameHeight, _pfGame.bytesPerPixel * 8,
-				8 - _pfGame.rLoss, 8 - _pfGame.gLoss, 8 - _pfGame.bLoss,
-				8 - _pfGameTexture.rLoss, 8 - _pfGameTexture.gLoss,
-				8 - _pfGameTexture.bLoss, _pfGame == _pfGameTexture);
+		printf("initSize %u*%u*%u (%s -> %s match: %d)\n",
+				_gameWidth, _gameHeight, _pfGame.bytesPerPixel,
+				_pfGame.toString().c_str(),
+				_pfGameTexture.toString().c_str(),
+				_pfGame == _pfGameTexture);
 
 		_gamePixels = (u8 *) memalign(32, _gameWidth * _gameHeight *
 										_pfGame.bytesPerPixel);
 		memset(_gamePixels, 0, _gameWidth * _gameHeight *
 				_pfGame.bytesPerPixel);
+
+		if (_pfGame != _pfGameTexture) {
+			_gamePixelsTexture = (u8 *) memalign(32, _gameWidth * _gameHeight *
+											_pfGameTexture.bytesPerPixel);
+			memset(_gamePixelsTexture, 0, _gameWidth * _gameHeight *
+					_pfGameTexture.bytesPerPixel);
+		} else {
+			_gamePixelsTexture = _gamePixels;
+		}
+
+		_blitFunc = Graphics::getFastBlitFunc(_pfGameTexture, _pfGame);
 
 		if (!gfx_tex_init(&_texGame, tex_format, TLUT_GAME,
 					_gameWidth, _gameHeight)) {
@@ -405,27 +420,11 @@ void OSystem_Wii::copyRectToScreen(const void *buf, int pitch, int x, int y,
 	assert(w > 0 && x + w <= _gameWidth);
 	assert(h > 0 && y + h <= _gameHeight);
 
-	if (_pfGame.bytesPerPixel > 1) {
-		if (!Graphics::crossBlit(_gamePixels +
-									y * _gameWidth * _pfGame.bytesPerPixel +
-									x * _pfGame.bytesPerPixel,
-									(const byte *)buf, _gameWidth * _pfGame.bytesPerPixel,
-									pitch, w, h, _pfGameTexture, _pfGame)) {
-			printf("crossBlit failed\n");
-			::abort();
-		}
-	} else {
-		byte *dst = _gamePixels + y * _gameWidth + x;
-		if (_gameWidth == pitch && pitch == w) {
-			memcpy(dst, buf, h * w);
-		} else {
-			const byte *src = (const byte *)buf;
-			do {
-				memcpy(dst, src, w);
-				src += pitch;
-				dst += _gameWidth;
-			} while (--h);
-		}
+	Graphics::copyBlit(_gamePixels +
+	                   y * _gameWidth * _pfGame.bytesPerPixel +
+	                   x * _pfGame.bytesPerPixel,
+	                   (const byte *)buf, _gameWidth * _pfGame.bytesPerPixel,
+	                   pitch, w, h, _pfGame.bytesPerPixel);
 
 	_gameDirty = true;
 }
@@ -471,7 +470,22 @@ void OSystem_Wii::updateScreen() {
 
 	if (_gameRunning) {
 		if (_gameDirty) {
-			gfx_tex_convert(&_texGame, _gamePixels);
+			if (_gamePixels != _gamePixelsTexture) {
+				// TODO: Track dirty regions of the screen?
+				if (_blitFunc) {
+					_blitFunc(_gamePixelsTexture, _gamePixels,
+					          _gameWidth * _pfGameTexture.bytesPerPixel,
+					          _gameWidth * _pfGame.bytesPerPixel,
+					          _gameWidth, _gameHeight);
+				} else {
+					Graphics::crossBlit(_gamePixelsTexture, _gamePixels,
+					                    _gameWidth * _pfGameTexture.bytesPerPixel,
+					                    _gameWidth * _pfGame.bytesPerPixel,
+					                    _gameWidth, _gameHeight, _pfGameTexture, _pfGame);
+				}
+
+			}
+			gfx_tex_convert(&_texGame, _gamePixelsTexture);
 			_gameDirty = false;
 		}
 

--- a/backends/platform/wii/osystem_gfx.cpp
+++ b/backends/platform/wii/osystem_gfx.cpp
@@ -228,7 +228,6 @@ void OSystem_Wii::initSize(uint width, uint height,
 	bool update = false;
 	gfx_tex_format_t tex_format;
 
-#ifdef USE_RGB_COLOR
 	Graphics::PixelFormat newFormat;
 
 	if (format)
@@ -243,21 +242,16 @@ void OSystem_Wii::initSize(uint width, uint height,
 		_pfGame = newFormat;
 		update = true;
 	}
-#endif
 
 	uint newWidth, newHeight;
 
-#ifdef USE_RGB_COLOR
 	if (_pfGame.bytesPerPixel > 1) {
 		newWidth = ROUNDUP(width, 4);
 		newHeight = ROUNDUP(height, 4);
 	} else {
-#endif
 		newWidth = ROUNDUP(width, 8);
 		newHeight = ROUNDUP(height, 4);
-#ifdef USE_RGB_COLOR
 	}
-#endif
 
 	if (_gameWidth != newWidth || _gameHeight != newHeight) {
 		assert((newWidth <= 640) && (newHeight <= 480));
@@ -285,7 +279,6 @@ void OSystem_Wii::initSize(uint width, uint height,
 
 		tex_format = GFX_TF_PALETTE_RGB565;
 
-#ifdef USE_RGB_COLOR
 		if (_pfGame.bytesPerPixel > 1) {
 			tex_format = GFX_TF_RGB565;
 			_pfGameTexture = _pfRGB565;
@@ -301,12 +294,6 @@ void OSystem_Wii::initSize(uint width, uint height,
 										_pfGame.bytesPerPixel);
 		memset(_gamePixels, 0, _gameWidth * _gameHeight *
 				_pfGame.bytesPerPixel);
-#else
-		printf("initSize %u*%u\n", _gameWidth, _gameHeight);
-
-		_gamePixels = (u8 *) memalign(32, _gameWidth * _gameHeight);
-		memset(_gamePixels, 0, _gameWidth * _gameHeight);
-#endif
 
 		if (!gfx_tex_init(&_texGame, tex_format, TLUT_GAME,
 					_gameWidth, _gameHeight)) {
@@ -337,12 +324,10 @@ void OSystem_Wii::updateMousePalette() {
 	if (_texMouse.palette) {
 		if (!_cursorPaletteDisabled) {
 			memcpy(_texMouse.palette, _cursorPalette, 256 * 2);
-#ifdef USE_RGB_COLOR
 		} else if (_pfGame.bytesPerPixel != 1) {
 			// When restoring the palette, there may be cases where game doesn't have any palette
 			// In this case, clear the palette
 			memset(_texMouse.palette, 0, 256 * 2);
-#endif
 		} else {
 			memcpy(_texMouse.palette, _texGame.palette, 256 * 2);
 		}
@@ -356,9 +341,7 @@ void OSystem_Wii::setPalette(const byte *colors, uint start, uint num) {
 	printf("%s(%p, %d, %d) _cursorPaletteDisabled:%d\n", __func__, colors, start, num, _cursorPaletteDisabled);
 #endif
 
-#ifdef USE_RGB_COLOR
 	assert(_pfGame.bytesPerPixel == 1);
-#endif
 
 	const byte *s = colors;
 	u16 *d = _texGame.palette;
@@ -372,9 +355,7 @@ void OSystem_Wii::setPalette(const byte *colors, uint start, uint num) {
 }
 
 void OSystem_Wii::grabPalette(byte *colors, uint start, uint num) const {
-#ifdef USE_RGB_COLOR
 	assert(_pfGame.bytesPerPixel == 1);
-#endif
 
 	u16 *s = _texGame.palette;
 	byte *d = colors;
@@ -424,7 +405,6 @@ void OSystem_Wii::copyRectToScreen(const void *buf, int pitch, int x, int y,
 	assert(w > 0 && x + w <= _gameWidth);
 	assert(h > 0 && y + h <= _gameHeight);
 
-#ifdef USE_RGB_COLOR
 	if (_pfGame.bytesPerPixel > 1) {
 		if (!Graphics::crossBlit(_gamePixels +
 									y * _gameWidth * _pfGame.bytesPerPixel +
@@ -435,7 +415,6 @@ void OSystem_Wii::copyRectToScreen(const void *buf, int pitch, int x, int y,
 			::abort();
 		}
 	} else {
-#endif
 		byte *dst = _gamePixels + y * _gameWidth + x;
 		if (_gameWidth == pitch && pitch == w) {
 			memcpy(dst, buf, h * w);
@@ -447,9 +426,6 @@ void OSystem_Wii::copyRectToScreen(const void *buf, int pitch, int x, int y,
 				dst += _gameWidth;
 			} while (--h);
 		}
-#ifdef USE_RGB_COLOR
-	}
-#endif
 
 	_gameDirty = true;
 }
@@ -555,11 +531,7 @@ void OSystem_Wii::updateScreen() {
 
 Graphics::Surface *OSystem_Wii::lockScreen() {
 	_surface.init(_gameWidth, _gameHeight,
-#ifdef USE_RGB_COLOR
 	              _gameWidth * _pfGame.bytesPerPixel, _gamePixels, _pfGame
-#else
-	              _gameWidth, _gamePixels, Graphics::PixelFormat::createFormatCLUT8()
-#endif
 	             );
 
 	return &_surface;
@@ -696,7 +668,6 @@ void OSystem_Wii::setMouseCursor(const void *buf, uint w, uint h, int hotspotX,
 	uint tw, th;
 	uint32 oldKeycolor = _mouseKeyColor;
 
-#ifdef USE_RGB_COLOR
 	if (!format)
 		_pfCursor = Graphics::PixelFormat::createFormatCLUT8();
 	else
@@ -709,14 +680,11 @@ void OSystem_Wii::setMouseCursor(const void *buf, uint w, uint h, int hotspotX,
 		th = ROUNDUP(h, 4);
 
 	} else {
-#endif
 		_mouseKeyColor = keycolor & 0xff;
 		tw = ROUNDUP(w, 8);
 		th = ROUNDUP(h, 4);
 
-#ifdef USE_RGB_COLOR
 	}
-#endif
 
 	if (!gfx_tex_init(&_texMouse, tex_format, TLUT_MOUSE, tw, th)) {
 		printf("could not init the mouse texture\n");
@@ -738,7 +706,6 @@ void OSystem_Wii::setMouseCursor(const void *buf, uint w, uint h, int hotspotX,
 	else
 		memset(tmp, _mouseKeyColor, tw * th);
 
-#ifdef USE_RGB_COLOR
 	if (bpp > 1) {
 
 		if (!Graphics::crossBlit(tmp, (const byte *)buf,
@@ -763,7 +730,6 @@ void OSystem_Wii::setMouseCursor(const void *buf, uint w, uint h, int hotspotX,
 			d += tw - w;
 		}
 	} else {
-#endif
 		const byte *s = (const byte *)buf;
 		byte *d = (byte *) tmp;
 		for (u16 y = 0; y < h; ++y) {
@@ -773,9 +739,7 @@ void OSystem_Wii::setMouseCursor(const void *buf, uint w, uint h, int hotspotX,
 			d += tw - w;
 		}
 
-#ifdef USE_RGB_COLOR
 	}
-#endif
 
 	gfx_tex_convert(&_texMouse, tmp);
 	free(tmp);


### PR DESCRIPTION
This was partially implemented previously, but didn't properly support `lockScreen()` or 32-bit pixel formats.

This has only been tested with Dolphin, and will need testing on actual hardware.