### PR TITLE
COMMON: Remove implicit comparison between String and U32String

### DIFF
--- a/common/dbcs-str.cpp
+++ b/common/dbcs-str.cpp
@@ -105,22 +105,6 @@ DBCSString &DBCSString::operator+=(value_type c) {
 	return *this;
 }
 
-bool DBCSString::operator==(const String &x) const {
-	return equalsC(x.c_str());
-}
-
-bool DBCSString::operator==(const char *x) const {
-	return equalsC(x);
-}
-
-bool DBCSString::operator!=(const String &x) const {
-	return !equalsC(x.c_str());
-}
-
-bool DBCSString::operator!=(const char *x) const {
-	return !equalsC(x);
-}
-
 DBCSString operator+(const DBCSString &x, const DBCSString &y) {
 	DBCSString temp(x);
 	temp += y;

--- a/common/dbcs-str.h
+++ b/common/dbcs-str.h
@@ -105,21 +105,6 @@ public:
 	/** @overload */
 	DBCSString &operator+=(value_type c);
 
-	using BaseString<value_type>::operator==;
-	using BaseString<value_type>::operator!=;
-
-	/** Check whether this string is identical to string @p x. */
-	bool operator==(const String &x) const;
-
-	/** @overload */
-	bool operator==(const char *x) const;
-
-	/** Check whether this string is different than string @p x. */
-	bool operator!=(const String &x) const;
-
-	/** @overload */
-	bool operator!=(const char *x) const;
-
 	/** Convert the string to the standard String represantation. */
 	String convertToString() const;
 

--- a/common/formats/winexe_pe.cpp
+++ b/common/formats/winexe_pe.cpp
@@ -297,7 +297,7 @@ WinResources::VersionInfo *PEResources::parseVersionInfo(SeekableReadStream *res
 
 			info->hash.setVal(key.encode(), value);
 		} else {
-			if (key == "VS_VERSION_INFO") {
+			if (key == U"VS_VERSION_INFO") {
 				if (!info->readVSVersionInfo(res))
 					return info;
 			}

--- a/common/str-base.cpp
+++ b/common/str-base.cpp
@@ -321,21 +321,6 @@ TEMPLATE bool BASESTRING::equals(const value_type *ptr) const {
 	return false;
 }
 
-TEMPLATE bool BASESTRING::equalsC(const char *ptr) const {
-	uint i = 0;
-
-	for (; i < _size && *ptr; i++, ptr++) {
-		if (_str[i] != (T)*ptr)
-			return false;
-	}
-
-	if (i == _size && *ptr == 0) {
-		return true;
-	}
-
-	return false;
-}
-
 TEMPLATE bool BASESTRING::operator==(const BaseString &x) const {
 	return equals(x);
 }
@@ -370,23 +355,6 @@ TEMPLATE int BASESTRING::compareTo(const BaseString &x) const {
 }
 
 TEMPLATE int BASESTRING::compareTo(const value_type *ptr) const {
-	uint32 i = 0;
-	for (; i < _size && *ptr; ++i, ptr++) {
-		uint32 sc = _str[i];
-		uint32 xc = *ptr;
-		if (sc < xc)
-			return -1;
-		else if (sc > xc)
-			return +1;
-	}
-	if (i == _size && *ptr == 0)
-		return 0;
-	if (*ptr == 0)
-		return +1;
-	return -1;
-}
-
-TEMPLATE int BASESTRING::compareToC(const char *ptr) const {
 	uint32 i = 0;
 	for (; i < _size && *ptr; ++i, ptr++) {
 		uint32 sc = _str[i];

--- a/common/str-base.h
+++ b/common/str-base.h
@@ -125,10 +125,8 @@ public:
 	 */
 	bool equals(const BaseString &x) const;
 	bool equals(const value_type *x) const;
-	bool equalsC(const char *x) const;
 	int compareTo(const BaseString &x) const;           // strcmp clone
 	int compareTo(const value_type *x) const;             // strcmp clone
-	int compareToC(const char *x) const;             // strcmp clone
 
 	/** Set character c at position p, replacing the previous character there. */
 	void setChar(value_type c, uint32 p);

--- a/common/ustr.cpp
+++ b/common/ustr.cpp
@@ -95,22 +95,6 @@ U32String &U32String::operator+=(value_type c) {
 	return *this;
 }
 
-bool U32String::operator==(const String &x) const {
-	return equalsC(x.c_str());
-}
-
-bool U32String::operator==(const char *x) const {
-	return equalsC(x);
-}
-
-bool U32String::operator!=(const String &x) const {
-	return !equalsC(x.c_str());
-}
-
-bool U32String::operator!=(const char *x) const {
-	return !equalsC(x);
-}
-
 U32String operator+(const U32String &x, const U32String &y) {
 	U32String temp(x);
 	temp += y;

--- a/common/ustr.h
+++ b/common/ustr.h
@@ -121,21 +121,6 @@ public:
 	/** @overload */
 	U32String &operator+=(value_type c);
 
-	using BaseString<value_type>::operator==;
-	using BaseString<value_type>::operator!=;
-
-	/** Check whether this string is identical to string @p x. */
-	bool operator==(const String &x) const;
-
-	/** @overload */
-	bool operator==(const char *x) const;
-
-	/** Check whether this string is different than string @p x. */
-	bool operator!=(const String &x) const;
-
-	/** @overload */
-	bool operator!=(const char *x) const;
-
 	/** Convert the string to the given @p page encoding and return the result as a new String. */
 	String encode(CodePage page = kUtf8) const;
 

--- a/engines/bladerunner/bladerunner.cpp
+++ b/engines/bladerunner/bladerunner.cpp
@@ -406,9 +406,9 @@ Common::Error BladeRunnerEngine::run() {
 				getEventManager()->getKeymapper()->getKeymap(BladeRunnerEngine::kGameplayKeymapId)->setEnabled(true);
 				const Common::Keymap::ActionArray karr = getEventManager()->getKeymapper()->getKeymap(BladeRunnerEngine::kGameplayKeymapId)->getActions();
 				for (uint8 i = 0; i < karr.size(); ++i) {
-					if (karr[i]->description == "COMBAT"
-					    || karr[i]->description == "SKIPDLG"
-					    || karr[i]->description == "KIADB") {
+					if (karr[i]->description == U"COMBAT"
+					    || karr[i]->description == U"SKIPDLG"
+					    || karr[i]->description == U"KIADB") {
 						getEventManager()->getKeymapper()->getKeymap(BladeRunnerEngine::kGameplayKeymapId)->unregisterMapping(karr[i]);
 					}
 				}

--- a/engines/dgds/sound.cpp
+++ b/engines/dgds/sound.cpp
@@ -430,7 +430,7 @@ void Sound::loadSNGSoundData(const Common::String &filename, Common::Array<Sound
 
 void Sound::patchSoundData(const Common::String& filename, uint16 soundNumber, byte* data, uint32 size) {
 	// TODO Can we check here if the game that's currently playing is Heart of China?
-	if (filename.equalsC("SOUNDS1.SNG") && soundNumber == 59) {
+	if (filename == "SOUNDS1.SNG" && soundNumber == 59) {
 		// Heart of China running water sound effect. This is broken on MT-32.
 		// This is an original game bug.
 		//

--- a/engines/director/lingo/xlibs/e/ednox.cpp
+++ b/engines/director/lingo/xlibs/e/ednox.cpp
@@ -124,8 +124,8 @@ XOBJSTUBNR(Ednox::m_dispose)
 
 void Ednox::m_getpathx(int nargs) {
 	/* int mMacMode = */ g_lingo->pop().asInt();
-	Common::U32String hStrIn = g_lingo->pop().asString();
-	/* Common::U32String hSection = */ g_lingo->pop().asString();
+	Common::String hStrIn = g_lingo->pop().asString();
+	/* Common::String hSection = */ g_lingo->pop().asString();
 	hStrIn.toLowercase();
 	if (hStrIn == "cdpath"){
 		g_lingo->push(Datum("d:\\"));
@@ -135,8 +135,8 @@ void Ednox::m_getpathx(int nargs) {
 }
 
 void Ednox::m_iscdx(int nargs) {
-	/* Common::U32String hStrIn = */ g_lingo->pop().asString();
-	Common::U32String hDrive = g_lingo->pop().asString();
+	/* Common::String hStrIn = */ g_lingo->pop().asString();
+	Common::String hDrive = g_lingo->pop().asString();
 	// g_lingo->printSTUBWithArglist("Ednox::m_iscdx", nargs);
 	if (hDrive == "d:\\"){
 		g_lingo->push(Datum("0"));
@@ -146,7 +146,7 @@ void Ednox::m_iscdx(int nargs) {
 }
 
 void Ednox::m_setdrivex(int nargs) {
-	// Common::U32String hStrIn = g_lingo->pop().asString();
+	// Common::String hStrIn = g_lingo->pop().asString();
 	g_lingo->printSTUBWithArglist("Ednox::m_setdrivex", nargs);
 	g_lingo->dropStack(nargs);
 	g_lingo->push(Datum("1"));
@@ -156,8 +156,8 @@ XOBJSTUB(Ednox::m_checksoundx, "")
 XOBJSTUB(Ednox::m_clearsoundx, "")
 
 void Ednox::m_deletedocumentfile(int nargs) {
-	// Common::U32String hFile = g_lingo->pop().asString();
-	// Common::U32String hDir = g_lingo->pop().asString();
+	// Common::String hFile = g_lingo->pop().asString();
+	// Common::String hDir = g_lingo->pop().asString();
 	g_lingo->printSTUBWithArglist("Ednox::m_deletedocumentfile", nargs);
 	g_lingo->dropStack(nargs);
 }
@@ -166,7 +166,7 @@ XOBJSTUB(Ednox::m_enabletaskswitch, "")
 XOBJSTUB(Ednox::m_disabletaskswitch, "")
 
 void Ednox::m_drawbkgndx(int nargs) {
-	// Common::U32String hBkgnd = g_lingo->pop().asString();
+	// Common::String hBkgnd = g_lingo->pop().asString();
 	g_lingo->printSTUBWithArglist("Ednox::m_drawbkgndx", nargs);
 }
 
@@ -253,7 +253,7 @@ XOBJSTUB(Ednox::m_playsoundx, "")
 XOBJSTUB(Ednox::m_restorex, "")
 
 void Ednox::m_savex(int nargs) {
-	// Common::U32String hStrIn = g_lingo->pop().asString();
+	// Common::String hStrIn = g_lingo->pop().asString();
 	g_lingo->printSTUBWithArglist("Ednox::m_savex", nargs);
 	g_lingo->dropStack(nargs);
 }

--- a/engines/glk/scott/load_game.cpp
+++ b/engines/glk/scott/load_game.cpp
@@ -96,7 +96,7 @@ void loadGameFile(Common::SeekableReadStream *f) {
 		const GlkDetectionEntry *p = SCOTT_GAMES;
 
 		while (p->_md5) {
-			if (md5.equalsC(p->_md5)) {
+			if (md5 == p->_md5) {
 				if (!scumm_stricmp(p->_extra, "")) {
 					_G(_fallbackGame)._gameID = SCOTTFREE;
 					break;

--- a/engines/glk/zcode/processor_text.cpp
+++ b/engines/glk/zcode/processor_text.cpp
@@ -568,14 +568,14 @@ void Processor::handleAbbreviations() {
 	Common::U32String word((const char32_t *)_decoded, wordSize);
 
 	// Check for standard abbreviations
-	if (word == "g")
-		word = "again";
-	else if (word == "o")
-		word = "oops";
-	else if (word == "x")
-		word = "examine";
-	else if (word == "z")
-		word = "wait";
+	if (word == Common::U32String('g'))
+		word = U"again";
+	else if (word == Common::U32String('o'))
+		word = U"oops";
+	else if (word == Common::U32String('x'))
+		word = U"examine";
+	else if (word == Common::U32String('z'))
+		word = U"wait";
 	else
 		return;
 

--- a/engines/hadesch/rooms/options.cpp
+++ b/engines/hadesch/rooms/options.cpp
@@ -515,8 +515,8 @@ private:
 		bool selectedIsShown = false;
 		for (int i = 0; i < 6 && _showPos + i < (int) _userNames.size(); i++) {
 			Common::U32String name = _userNames[_showPos + i];
-			if (name == "")
-				name = "No name";
+			if (name.empty())
+				name = U"No name";
 			room->renderString("largeascii", name,
 					   Common::Point(150, 134 + 36 * i), 4000, 0,
 					   Common::String::format("username%d", i));

--- a/engines/ultima/nuvie/keybinding/keys.cpp
+++ b/engines/ultima/nuvie/keybinding/keys.cpp
@@ -501,8 +501,8 @@ Common::Array<Common::U32String> KeyBinder::buildKeyHelp() const {
 			if (inputs.size() > 0) {
 				Common::U32String desc;
 				// The * can't be bolded easily in markdown..
-				if (inputs[0].description == "*")
-					desc = "*";
+				if (inputs[0].description == Common::U32String('*'))
+					desc = Common::U32String('*');
 				else
 					desc = Common::U32String("**") + inputs[0].description + Common::U32String("**");
 				desc += Common::U32String(" - ") + action->description;

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -3699,7 +3699,7 @@ void GlobalOptionsDialog::setupCloudTab() {
 	if (_storageLastSyncDesc) _storageLastSyncDesc->setVisible(shownConnectedInfo);
 	if (_storageLastSync) {
 		Common::U32String sync = CloudMan.getStorageLastSync(_selectedStorageIndex);
-		if (sync == "") {
+		if (sync.empty()) {
 			if (_selectedStorageIndex == CloudMan.getStorageIndex() && CloudMan.isSyncing())
 				sync = _("<right now>");
 			else

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -270,12 +270,12 @@ void GridWidget::loadClosedGroups(const Common::U32String &groupName) {
 	// Recalls what groups were closed from the config
 	if (ConfMan.hasKey("group_" + groupName, ConfMan.kApplicationDomain)) {
 		const Common::String &val = ConfMan.get("group_" + groupName, ConfMan.kApplicationDomain);
-		Common::StringTokenizer hiddenGroups(val);
+		Common::U32StringTokenizer hiddenGroups(val.decode());
 
-		for (Common::String tok = hiddenGroups.nextToken(); tok.size(); tok = hiddenGroups.nextToken()) {
+		for (Common::U32String tok = hiddenGroups.nextToken(); tok.size(); tok = hiddenGroups.nextToken()) {
 			// See if the hidden group is in our group headers still, if so, hide it
 			for (Common::U32StringArray::size_type i = 0; i < _groupHeaders.size(); ++i) {
-				if (_groupHeaders[i] == tok || (tok == "unnamed" && _groupHeaders[i].size() == 0)) {
+				if (_groupHeaders[i] == tok || (tok == U"unnamed" && _groupHeaders[i].size() == 0)) {
 					uint groupID = _groupValueIndex[_groupHeaders[i]];
 					_groupExpanded[groupID] = false;
 					break;

--- a/gui/widgets/groupedlist.cpp
+++ b/gui/widgets/groupedlist.cpp
@@ -165,12 +165,12 @@ void GroupedListWidget::loadClosedGroups(const Common::U32String &groupName) {
 	// Recalls what groups were closed from the config
 	if (ConfMan.hasKey("group_" + groupName, ConfMan.kApplicationDomain)) {
 		const Common::String &val = ConfMan.get("group_" + groupName, ConfMan.kApplicationDomain);
-		Common::StringTokenizer hiddenGroups(val);
+		Common::U32StringTokenizer hiddenGroups(val.decode());
 
-		for (Common::String tok = hiddenGroups.nextToken(); tok.size(); tok = hiddenGroups.nextToken()) {
+		for (Common::U32String tok = hiddenGroups.nextToken(); tok.size(); tok = hiddenGroups.nextToken()) {
 			// See if the hidden group is in our group headers still, if so, hide it
 			for (Common::U32StringArray::size_type i = 0; i < _groupHeaders.size(); ++i) {
-				if (_groupHeaders[i] == tok || (tok == "unnamed" && _groupHeaders[i].size() == 0)) {
+				if (_groupHeaders[i] == tok || (tok == U"unnamed" && _groupHeaders[i].size() == 0)) {
 					uint groupID = _groupValueIndex[_groupHeaders[i]];
 					_groupExpanded[groupID] = false;
 					break;

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -1171,10 +1171,10 @@ Common::U32String ListWidget::getThemeColor(ThemeEngine::FontColor color) {
 }
 
 ThemeEngine::FontColor ListWidget::getThemeColor(const Common::U32String &color) {
-	if (color == "normal")
+	if (color == U"normal")
 		return ThemeEngine::kFontColorNormal;
 
-	if (color == "alternate")
+	if (color == U"alternate")
 		return ThemeEngine::kFontColorAlternate;
 
 	warning("ListWidget::getThemeColor(): Malformed color (\"%s\")", color.encode().c_str());

--- a/test/common/str.h
+++ b/test/common/str.h
@@ -666,18 +666,18 @@ class StringTestSuite : public CxxTest::TestSuite
 		// Makes a deep copy without changing the length of the original
 		Common::U32String s1 = Common::U32String("TestTestTestTestTestTestTestTestTestTestTest");
 		Common::U32String s2(s1);
-		TS_ASSERT_EQUALS(s1, "TestTestTestTestTestTestTestTestTestTestTest");
-		TS_ASSERT_EQUALS(s2, "TestTestTestTestTestTestTestTestTestTestTest");
+		TS_ASSERT_EQUALS(s1, U"TestTestTestTestTestTestTestTestTestTestTest");
+		TS_ASSERT_EQUALS(s2, U"TestTestTestTestTestTestTestTestTestTestTest");
 		s1.replace(0, 4, Common::U32String("TEST"));
-		TS_ASSERT_EQUALS(s1, "TESTTestTestTestTestTestTestTestTestTestTest");
-		TS_ASSERT_EQUALS(s2, "TestTestTestTestTestTestTestTestTestTestTest");
+		TS_ASSERT_EQUALS(s1, U"TESTTestTestTestTestTestTestTestTestTestTest");
+		TS_ASSERT_EQUALS(s2, U"TestTestTestTestTestTestTestTestTestTestTest");
 
 		// Makes a deep copy when we shorten the string
 		Common::U32String s3 = Common::U32String("TestTestTestTestTestTestTestTestTestTestTest");
 		Common::U32String s4(s3);
 		s3.replace(0, 32, Common::U32String());
-		TS_ASSERT_EQUALS(s3, "TestTestTest");
-		TS_ASSERT_EQUALS(s4, "TestTestTestTestTestTestTestTestTestTestTest");
+		TS_ASSERT_EQUALS(s3, U"TestTestTest");
+		TS_ASSERT_EQUALS(s4, U"TestTestTestTestTestTestTestTestTestTestTest");
 	}
 
 	void test_find() {


### PR DESCRIPTION
Comparison between `String`s and `U32String`s was done by comparing each index directly, which is inconsistent with the constructors and assignment operators which convert to/from UTF-8 first. Removing it helps to reduce some of the intermediate conversion back and forth between 8-bit and 32-bit.