### PR TITLE
GRAPHICS: MACGUI: Support rendering with any 8/16/32bpp pixel format

### DIFF
--- a/engines/colony/colony.cpp
+++ b/engines/colony/colony.cpp
@@ -566,7 +566,7 @@ void ColonyEngine::initMacMenus() {
 	Graphics::PixelFormat rgba(4, 8, 8, 8, 8, 24, 16, 8, 0);
 	_menuSurface = new Graphics::ManagedSurface(_width, _height, rgba);
 
-	_wm = new Graphics::MacWindowManager(Graphics::kWMModeNoDesktop | Graphics::kWMNoScummVMWallpaper | Graphics::kWMMode32bpp | Graphics::kWMModeNoSystemRedraw);
+	_wm = new Graphics::MacWindowManager(Graphics::kWMModeNoDesktop | Graphics::kWMNoScummVMWallpaper | Graphics::kWMModeNoSystemRedraw, nullptr, Common::UNK_LANG, rgba);
 
 	// Override WM color values for 32bpp RGBA rendering.
 	// The defaults are palette indices (0-6) which are meaningless in 32bpp mode.

--- a/engines/director/castmember/text.cpp
+++ b/engines/director/castmember/text.cpp
@@ -251,6 +251,12 @@ void TextCastMember::setForeColor(uint32 fgCol) {
 void TextCastMember::setForeColor(uint32 fgCol, int start, int end) {
 	Graphics::MacText *target = getWidget();
 	if (target) {
+		if (target->_wm->_pixelformat.isCLUT8()) {
+			byte r, g, b;
+			target->_wm->getPaletteEntry(fgCol, r, g, b);
+			fgCol = target->_wm->findBestColor(r, g, b);
+		}
+
 		return target->setTextColor(fgCol, start, end);
 	}
 	_modified = true;

--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -276,8 +276,12 @@ Common::Error DirectorEngine::run() {
 
 #ifdef USE_RGB_COLOR
 	if (ConfMan.getBool("true_color") || (getGameFlags() & GF_32BPP) || debugChannelSet(-1, kDebug32bpp))
-		_wmMode |= Graphics::kWMMode32bpp;
+		_pixelformat = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
+	else
 #endif
+		_pixelformat = Graphics::PixelFormat::createFormatCLUT8();
+
+	debugC(1, kDebugImages, "Director pixelformat is: %s", _pixelformat.toString().c_str());
 
 	if (getGameFlags() & GF_DESKTOP)
 		_wmMode &= ~Graphics::kWMModeNoDesktop;
@@ -287,7 +291,7 @@ Common::Error DirectorEngine::run() {
 		_wmHeight = 480;
 	}
 
-	_wm = new Graphics::MacWindowManager(_wmMode, &_director3QuickDrawPatterns, getLanguage());
+	_wm = new Graphics::MacWindowManager(_wmMode, &_director3QuickDrawPatterns, getLanguage(), _pixelformat);
 	_wm->setEngine(this);
 
 	gameQuirks(_gameDescription->desc.gameId, _gameDescription->desc.platform);
@@ -298,10 +302,6 @@ Common::Error DirectorEngine::run() {
 	_wm->setDesktopMode(_wmMode);
 
 	_wm->printWMMode();
-
-	_pixelformat = _wm->_pixelformat;
-
-	debugC(1, kDebugImages, "Director pixelformat is: %s", _pixelformat.toString().c_str());
 
 	_stage = new Window(_wm->getNextId(), false, false, false, _wm, this, true);
 	_stage->incRefCount();

--- a/engines/director/graphics.cpp
+++ b/engines/director/graphics.cpp
@@ -289,6 +289,14 @@ class InkPrimitives final : public Graphics::Primitives {
 public:
 	constexpr InkPrimitives() {}
 	void drawPoint(int x, int y, uint32 src, void *data) override;
+private:
+	inline void decomposeColor(Graphics::MacWindowManager *wm, uint32 color, byte &r, byte &g, byte &b) {
+		if (sizeof(T) == sizeof(byte)) {
+			wm->getPaletteEntry(color, r, g, b);
+		} else {
+			wm->_pixelformat.colorToRGB(color, r, g, b);
+		}
+	}
 };
 
 template <typename T>
@@ -344,8 +352,8 @@ void InkPrimitives<T>::drawPoint(int x, int y, uint32 src, void *data) {
 		byte rSrc, gSrc, bSrc;
 		byte rDst, gDst, bDst;
 
-		wm->decomposeColor<T>(src, rSrc, gSrc, bSrc);
-		wm->decomposeColor<T>(*dst, rDst, gDst, bDst);
+		decomposeColor(wm, src, rSrc, gSrc, bSrc);
+		decomposeColor(wm, *dst, rDst, gDst, bDst);
 
 		rDst = lerpByte(rSrc, rDst, p->alpha, 255);
 		gDst = lerpByte(gSrc, gDst, p->alpha, 255);
@@ -396,7 +404,7 @@ void InkPrimitives<T>::drawPoint(int x, int y, uint32 src, void *data) {
 		} else {
 			// Find the inverse of the colour and match it back to the palette if required
 			byte rSrc, gSrc, bSrc;
-			wm->decomposeColor<T>(src, rSrc, gSrc, bSrc);
+			decomposeColor(wm, src, rSrc, gSrc, bSrc);
 
 			*dst = wm->findBestColor(~rSrc, ~gSrc, ~bSrc);
 		}
@@ -484,8 +492,8 @@ void InkPrimitives<T>::drawPoint(int x, int y, uint32 src, void *data) {
 		byte rSrc, gSrc, bSrc;
 		byte rDst, gDst, bDst;
 
-		wm->decomposeColor<T>(src, rSrc, gSrc, bSrc);
-		wm->decomposeColor<T>(*dst, rDst, gDst, bDst);
+		decomposeColor(wm, src, rSrc, gSrc, bSrc);
+		decomposeColor(wm, *dst, rDst, gDst, bDst);
 
 		switch (p->ink) {
 		case kInkTypeAddPin:

--- a/graphics/macgui/macmenu.cpp
+++ b/graphics/macgui/macmenu.cpp
@@ -1113,6 +1113,8 @@ bool MacMenu::draw(ManagedSurface *g, bool forceRedraw) {
 		if (!it->enabled) {
 			if (_wm->_pixelformat.bytesPerPixel == 1) {
 				drawMenuPattern<byte>(_tempSurface, _screen, _wm->getBuiltinPatterns()[kPatternCheckers2 - 1], x, y, it->bbox.width(), _wm->_colorGreen);
+			} else if (_wm->_pixelformat.bytesPerPixel == 2) {
+				drawMenuPattern<uint16>(_tempSurface, _screen, _wm->getBuiltinPatterns()[kPatternCheckers2 - 1], x, y, it->bbox.width(), _wm->_colorGreen);
 			} else {
 				drawMenuPattern<uint32>(_tempSurface, _screen, _wm->getBuiltinPatterns()[kPatternCheckers2 - 1], x, y, it->bbox.width(), _wm->_colorGreen);
 			}
@@ -1254,6 +1256,8 @@ void MacMenu::renderSubmenu(MacMenuSubMenu *menu, bool recursive) {
 			if (!topMenuEnabled || !menu->items[i]->enabled) {
 				if (_wm->_pixelformat.bytesPerPixel == 1) {
 					drawMenuPattern<byte>(_tempSurface, _screen, _wm->getBuiltinPatterns()[kPatternCheckers2 - 1], x, y, r->width(), _wm->_colorGreen);
+				} else if (_wm->_pixelformat.bytesPerPixel == 2) {
+					drawMenuPattern<uint16>(_tempSurface, _screen, _wm->getBuiltinPatterns()[kPatternCheckers2 - 1], x, y, r->width(), _wm->_colorGreen);
 				} else {
 					drawMenuPattern<uint32>(_tempSurface, _screen, _wm->getBuiltinPatterns()[kPatternCheckers2 - 1], x, y, r->width(), _wm->_colorGreen);
 				}
@@ -1262,6 +1266,8 @@ void MacMenu::renderSubmenu(MacMenuSubMenu *menu, bool recursive) {
 		} else { // Delimiter
 			if (_wm->_pixelformat.bytesPerPixel == 1) {
 				drawMenuDelimiter<byte>(_screen, r, y + _menuDropdownItemHeight / 2, _wm->_colorBlack, _wm->_colorWhite);
+			} else if (_wm->_pixelformat.bytesPerPixel == 2) {
+				drawMenuDelimiter<uint16>(_screen, r, y + _menuDropdownItemHeight / 2, _wm->_colorBlack, _wm->_colorWhite);
 			} else {
 				drawMenuDelimiter<uint32>(_screen, r, y + _menuDropdownItemHeight / 2, _wm->_colorBlack, _wm->_colorWhite);
 			}

--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -136,10 +136,10 @@ MacText::MacText(MacWidget *parent, int x, int y, int w, int h, MacWindowManager
 		_defaultFormatting = MacFontRun(_wm);
 		_defaultFormatting.font = wm->_fontMan->getFont(*macFont);
 		byte r, g, b;
-		if (_wm->_pixelformat.bytesPerPixel == 4) {
-			_wm->decomposeColor<uint32>(fgcolor, r, g, b);
+		if (_wm->_pixelformat.isCLUT8()) {
+			_wm->getPaletteEntry(fgcolor, r, g, b);
 		} else {
-			_wm->decomposeColor<byte>(fgcolor, r, g, b);
+			_wm->_pixelformat.colorToRGB(fgcolor, r, g, b);
 		}
 		_defaultFormatting.setValues(_wm, macFont->getId(), macFont->getSlant(), macFont->getSize(), r, g, b);
 	} else {
@@ -166,7 +166,11 @@ MacText::MacText(const Common::U32String &s, MacWindowManager *wm, const MacFont
 		_defaultFormatting = MacFontRun(_wm, macFont->getId(), macFont->getSlant(), macFont->getSize(), 0, 0, 0);
 		_defaultFormatting.font = wm->_fontMan->getFont(*macFont);
 		byte r, g, b;
-		_wm->_pixelformat.colorToRGB(fgcolor, r, g, b);
+		if (_wm->_pixelformat.isCLUT8()) {
+			_wm->getPaletteEntry(fgcolor, r, g, b);
+		} else {
+			_wm->_pixelformat.colorToRGB(fgcolor, r, g, b);
+		}
 		_defaultFormatting.setValues(_wm, macFont->getId(), macFont->getSlant(), macFont->getSize(), r, g, b);
 	} else {
 		_defaultFormatting.font = NULL;
@@ -341,7 +345,7 @@ void MacText::setScrollBar(bool enable) {
 void MacText::resizeScrollBar(int w, int h) {
 	_borderSurface.free();
 	_borderSurface.create(w, h, _wm->_pixelformat);
-	if (_wm->_pixelformat.bytesPerPixel == 1) {
+	if (_wm->_pixelformat.isCLUT8()) {
 		_borderSurface.clear(_wm->_colorGreen);
 	}
 	_scrollBorder.blitBorderInto(_borderSurface, kWindowBorderScrollbar | kWindowBorderActive);
@@ -472,9 +476,8 @@ void MacText::setTextColor(uint32 color, uint32 line) {
 		return;
 	}
 
-	uint32 fgcol = _wm->findBestColor(color);
 	for (uint j = 0; j < _canvas._text[line].chunks.size(); j++) {
-		_canvas._text[line].chunks[j].fgcolor = fgcol;
+		_canvas._text[line].chunks[j].fgcolor = color;
 	}
 
 	// if we are calling this func separately, then here need a refresh
@@ -506,8 +509,7 @@ void setTextColorCallback(MacFontRun &macFontRun, int color) {
 }
 
 void MacText::setTextColor(uint32 color, uint32 start, uint32 end) {
-	uint32 col = _wm->findBestColor(color);
-	setTextChunks(start, end, col, setTextColorCallback);
+	setTextChunks(start, end, color, setTextColorCallback);
 }
 
 void setTextSizeCallback(MacFontRun &macFontRun, int textSize) {
@@ -939,7 +941,7 @@ void MacText::draw(ManagedSurface *g, int x, int y, int w, int h, int xoff, int 
 
 	render();
 
-	drawStep(g, _canvas._surface, &_borderSurface, x, y, w, h, xoff, yoff, _canvas._tbgcolor, (_wm->_pixelformat.bytesPerPixel == 1) ? _wm->_colorGreen : 0);
+	drawStep(g, _canvas._surface, &_borderSurface, x, y, w, h, xoff, yoff, _canvas._tbgcolor, _wm->_pixelformat.isCLUT8() ? _wm->_colorGreen : 0);
 
 	drawStep(_glyphMaskSurface, _canvas._glyphMask, &_borderMaskSurface, x, y, w, h, xoff, yoff, 0, 0);
 	drawStep(_charBoxMaskSurface, _canvas._charBoxMask, &_borderMaskSurface, x, y, w, h, xoff, yoff, 0, 0);

--- a/graphics/macgui/mactextwindow.cpp
+++ b/graphics/macgui/mactextwindow.cpp
@@ -277,7 +277,7 @@ bool MacTextWindow::draw(ManagedSurface *g, bool forceRedraw) {
 		return false;
 
 	g->blitFrom(*_composeSurface, Common::Rect(0, 0, _composeSurface->w, _composeSurface->h), Common::Point(_innerDims.left, _innerDims.top));
-	uint32 transcolor = (_wm->_pixelformat.bytesPerPixel == 1) ? _wm->_colorGreen : 0;
+	uint32 transcolor = _wm->_pixelformat.isCLUT8() ? _wm->_colorGreen : 0;
 	g->transBlitFrom(_borderSurface, Common::Rect(0, 0, _borderSurface.w, _borderSurface.h), Common::Point(_dims.left, _dims.top), transcolor);
 
 	return true;

--- a/graphics/macgui/macwindow.cpp
+++ b/graphics/macgui/macwindow.cpp
@@ -230,7 +230,7 @@ bool MacWindow::draw(ManagedSurface *g, bool forceRedraw) {
 
 	g->blitFrom(*_composeSurface, Common::Rect(0, 0, _composeSurface->w, _composeSurface->h), Common::Point(_innerDims.left, _innerDims.top));
 
-	uint32 transcolor = (_wm->_pixelformat.bytesPerPixel == 1) ? _wm->_colorGreen : 0;
+	uint32 transcolor = _wm->_pixelformat.isCLUT8() ? _wm->_colorGreen : 0;
 
 	g->transBlitFrom(_borderSurface, Common::Rect(0, 0, _borderSurface.w, _borderSurface.h), Common::Point(_dims.left, _dims.top), transcolor);
 
@@ -239,7 +239,7 @@ bool MacWindow::draw(ManagedSurface *g, bool forceRedraw) {
 
 void MacWindow::blit(ManagedSurface *g, Common::Rect &dest) {
 	// Only the inner surface is blitted here
-	uint32 transcolor = (_wm->_pixelformat.bytesPerPixel == 1) ? _wm->_colorGreen2 : 0;
+	uint32 transcolor = _wm->_pixelformat.isCLUT8() ? _wm->_colorGreen2 : 0;
 
 	g->transBlitFrom(*_composeSurface, _composeSurface->getBounds(), dest, transcolor);
 }
@@ -337,7 +337,7 @@ void MacWindow::drawBorder() {
 }
 
 void MacWindow::drawBorderFromSurface(ManagedSurface *g, uint32 flags) {
-	if (_wm->_pixelformat.bytesPerPixel == 1) {
+	if (_wm->_pixelformat.isCLUT8()) {
 		g->clear(_wm->_colorGreen);
 	}
 
@@ -376,19 +376,10 @@ void MacWindow::drawPattern() {
 	const byte *pat = _wm->getPatterns()[_pattern - 1];
 	for (int y = 0; y < _composeSurface->h; y++) {
 		for (int x = 0; x < _composeSurface->w; x++) {
-			if (_wm->_pixelformat.bytesPerPixel == 1) {
-				byte *dst = (byte *)_composeSurface->getBasePtr(x, y);
-				if (pat[y % 8] & (1 << (7 - (x % 8))))
-					*dst = _wm->_colorBlack;
-				else
-					*dst = _wm->_colorWhite;
-			} else {
-				uint32 *dst = (uint32 *)_composeSurface->getBasePtr(x, y);
-				if (pat[y % 8] & (1 << (7 - (x % 8))))
-					*dst = _wm->_colorBlack;
-				else
-					*dst = _wm->_colorWhite;
-			}
+			if (pat[y % 8] & (1 << (7 - (x % 8))))
+				_composeSurface->setPixel(x, y, _wm->_colorBlack);
+			else
+				_composeSurface->setPixel(x, y, _wm->_colorWhite);
 		}
 	}
 }

--- a/graphics/macgui/macwindowborder.cpp
+++ b/graphics/macgui/macwindowborder.cpp
@@ -258,8 +258,10 @@ void MacWindowBorder::loadBorder(Common::SeekableReadStream &file, uint32 flags,
 		if (i < palette.size())
 			surface->setTransparentColor(i);
 	} else {
-		const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 24, 16, 8, 0);
-		surface->convertToInPlace(requiredFormat_4byte);
+		if (_window->_wm->_pixelformat.isCLUT8())
+			surface->convertToInPlace(Graphics::PixelFormat::createFormatRGBA32());
+		else
+			surface->convertToInPlace(_window->_wm->_pixelformat);
 		surface->setTransparentColor(surface->format.RGBToColor(255, 0, 255));
 	}
 

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -186,7 +186,7 @@ public:
 	void drawPoint(int x, int y, uint32 color, void *data) override;
 };
 
-MacWindowManager::MacWindowManager(uint32 mode, MacPatterns *patterns, Common::Language language) {
+MacWindowManager::MacWindowManager(uint32 mode, MacPatterns *patterns, Common::Language language, const Graphics::PixelFormat &pixelformat) {
 	_screen = nullptr;
 	_screenCopy = nullptr;
 	_desktopBmp = nullptr;
@@ -228,15 +228,23 @@ MacWindowManager::MacWindowManager(uint32 mode, MacPatterns *patterns, Common::L
 
 	_hilitingWidget = false;
 
-	if (mode & kWMMode32bpp) {
-		_pixelformat = Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0);
-		_macDrawPrimitives = new MacDrawPrimitives<uint32>();
+	_pixelformat = pixelformat;
+
+	if (_pixelformat.isCLUT8()) {
+		_macDrawPrimitives = new MacDrawPrimitives<byte>();
+		_macDrawInvertPrimitives = new MacDrawInvertPrimitives<byte>();
+	} else if (_pixelformat.bytesPerPixel == 1) {
+		_macDrawPrimitives = new MacDrawPrimitives<byte>();
+		// No implementation yet
+		_macDrawInvertPrimitives = nullptr;
+	} else if (_pixelformat.bytesPerPixel == 2) {
+		_macDrawPrimitives = new MacDrawPrimitives<uint16>();
 		// No implementation yet
 		_macDrawInvertPrimitives = nullptr;
 	} else {
-		_pixelformat = PixelFormat::createFormatCLUT8();
-		_macDrawPrimitives = new MacDrawPrimitives<byte>();
-		_macDrawInvertPrimitives = new MacDrawInvertPrimitives<byte>();
+		_macDrawPrimitives = new MacDrawPrimitives<uint32>();
+		// No implementation yet
+		_macDrawInvertPrimitives = nullptr;
 	}
 
 	if (patterns) {
@@ -891,8 +899,11 @@ void MacWindowManager::loadDesktop() {
 	Image::BitmapDecoder bmpDecoder;
 	bmpDecoder.loadStream(*file);
 
-	const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 24, 16, 8, 0);
-	_desktopBmp = bmpDecoder.getSurface()->convertTo(requiredFormat_4byte, bmpDecoder.getPalette().data(), bmpDecoder.getPalette().size());
+	if (_pixelformat.isCLUT8()) {
+		_desktopBmp = bmpDecoder.getSurface()->convertTo(Graphics::PixelFormat::createFormatRGBA32(), bmpDecoder.getPalette().data(), bmpDecoder.getPalette().size());
+	} else {
+		_desktopBmp = bmpDecoder.getSurface()->convertTo(_pixelformat, bmpDecoder.getPalette().data(), bmpDecoder.getPalette().size());
+	}
 
 	delete file;
 }
@@ -900,27 +911,32 @@ void MacWindowManager::loadDesktop() {
 void MacWindowManager::setDesktopColor(byte r, byte g, byte b) {
 	cleanupDesktopBmp();
 
-	const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 24, 16, 8, 0);
-	uint32 color = requiredFormat_4byte.RGBToColor(r, g, b);
-
 	_desktopBmp = new Graphics::Surface();
-	_desktopBmp->create(10, 10, requiredFormat_4byte);
-	_desktopBmp->fillRect(Common::Rect(10, 10), color);
+	if (_pixelformat.isCLUT8()) {
+		_desktopBmp->create(10, 10, Graphics::PixelFormat::createFormatRGBA32());
+	} else {
+		_desktopBmp->create(10, 10, _pixelformat);
+	}
+	_desktopBmp->fillRect(Common::Rect(10, 10), findBestColor(r, g, b));
 }
 
 void MacWindowManager::drawDesktop() {
 	if (_desktopBmp) {
-		for (int i = 0; i < _desktop->w; ++i) {
-			for (int j = 0; j < _desktop->h; ++j) {
-				uint32 color = *(uint32 *)_desktopBmp->getBasePtr(i % _desktopBmp->w, j % _desktopBmp->h);
-				if (_pixelformat.bytesPerPixel == 1) {
+		if (_pixelformat.isCLUT8()) {
+			for (int i = 0; i < _desktop->w; ++i) {
+				for (int j = 0; j < _desktop->h; ++j) {
+					uint32 color = *(uint32 *)_desktopBmp->getBasePtr(i % _desktopBmp->w, j % _desktopBmp->h);
 					byte r, g, b;
 					_desktopBmp->format.colorToRGB(color, r, g, b);
 					if (color > 0) {
 						*((byte *)_desktop->getBasePtr(i, j)) = findBestColor(r, g, b);
 					}
-				} else {
-					*((uint32 *)_desktop->getBasePtr(i, j)) = color;
+				}
+			}
+		} else {
+			for (int i = 0; i < _desktop->w; i += _desktopBmp->w) {
+				for (int j = 0; j < _desktop->h; j += _desktopBmp->h) {
+					_desktop->simpleBlitFrom(*_desktopBmp, Common::Point(i, j));
 				}
 			}
 		}
@@ -1002,7 +1018,7 @@ void MacWindowManager::draw() {
 
 					adjustDimensions(clip, outerDims, adjWidth, adjHeight);
 
-					if (_pixelformat.bytesPerPixel == 1) {
+					if (_pixelformat.isCLUT8()) {
 						Surface *surface = g_system->lockScreen();
 						ManagedSurface *border = w->getBorderSurface();
 
@@ -1488,47 +1504,33 @@ void MacWindowManager::passPalette(const byte *pal, uint size) {
 }
 
 uint32 MacWindowManager::findBestColor(byte cr, byte cg, byte cb) {
-	if (_pixelformat.bytesPerPixel == 4)
+	if (!_pixelformat.isCLUT8())
 		return _pixelformat.RGBToColor(cr, cg, cb);
 
 	return _paletteLookup.findBestColor(cr, cg, cb);
 }
 
-template <>
-void MacWindowManager::decomposeColor<uint32>(uint32 color, byte &r, byte &g, byte &b) {
-	_pixelformat.colorToRGB(color, r, g, b);
-}
-
-template <>
-void MacWindowManager::decomposeColor<byte>(uint32 color, byte& r, byte& g, byte& b) {
+void MacWindowManager::getPaletteEntry(uint32 color, byte& r, byte& g, byte& b) {
 	r = *(_palette + 3 * (byte)color + 0);
 	g = *(_palette + 3 * (byte)color + 1);
 	b = *(_palette + 3 * (byte)color + 2);
-}
-
-uint32 MacWindowManager::findBestColor(uint32 color) {
-	if (_pixelformat.bytesPerPixel == 4)
-		return color;
-
-	byte r, g, b;
-	decomposeColor<byte>(color, r, g, b);
-	return _paletteLookup.findBestColor(r, g, b);
 }
 
 byte MacWindowManager::inverter(byte src) {
 	if (_invertColorHash.contains(src))
 		return _invertColorHash[src];
 
-	if (_pixelformat.bytesPerPixel == 1) {
+	if (_pixelformat.isCLUT8()) {
 		byte r, g, b;
-		decomposeColor<byte>(src, r, g, b);
+		getPaletteEntry(src, r, g, b);
 		r = ~r;
 		g = ~g;
 		b = ~b;
 		_invertColorHash[src] = findBestColor(r, g, b);
 	} else {
-		uint32 alpha = _pixelformat.ARGBToColor(255, 0, 0, 0);
-		_invertColorHash[src] = ~(src & ~alpha) | alpha;
+		uint32 rgbMask = _pixelformat.ARGBToColor(0, 255, 255, 255);
+		uint32 aMask = _pixelformat.ARGBToColor(255, 0, 0, 0);
+		_invertColorHash[src] = (~src & rgbMask) | aMask;
 	}
 	return _invertColorHash[src];
 }
@@ -1581,11 +1583,6 @@ void MacWindowManager::printWMMode(int debuglevel) {
 
 	if (_mode & kWMModeButtonDialogStyle)
 		out += " kWMModeButtonDialogStyle";
-
-	if (_mode & kWMMode32bpp)
-		out += " kWMMode32bpp";
-	else
-		out += " !kWMMode32bpp";
 
 	if (_mode & kWMNoScummVMWallpaper)
 		out += " kWMNoScummVMWallpaper";

--- a/graphics/macgui/macwindowmanager.h
+++ b/graphics/macgui/macwindowmanager.h
@@ -87,14 +87,13 @@ enum {
 	kWMModeManualDrawWidgets	= (1 << 5),
 	kWMModeFullscreen			= (1 << 6),
 	kWMModeButtonDialogStyle	= (1 << 7),
-	kWMMode32bpp				= (1 << 8),
-	kWMNoScummVMWallpaper		= (1 << 9),
-	kWMModeWin95				= (1 << 10),
-	kWMModeForceMacFontsInWin95 = (1 << 11), // Enforce Mac font for languages which don't have glyphs in ms_sans_serif.ttf
-	kWMModeNoCursorOverride     = (1 << 12),
-	kWMModeForceMacBorder       = (1 << 13),
-	kWMModeForceMacFonts        = (1 << 14), // Enforce Mac fonts even when there are viable TTF substitutions
-	kWMModeNoSystemRedraw       = (1 << 15), // Skip g_system->copyRectToScreen (for 3D game backends)
+	kWMNoScummVMWallpaper		= (1 << 8),
+	kWMModeWin95				= (1 << 9),
+	kWMModeForceMacFontsInWin95 = (1 << 10), // Enforce Mac font for languages which don't have glyphs in ms_sans_serif.ttf
+	kWMModeNoCursorOverride     = (1 << 11),
+	kWMModeForceMacBorder       = (1 << 12),
+	kWMModeForceMacFonts        = (1 << 13), // Enforce Mac fonts even when there are viable TTF substitutions
+	kWMModeNoSystemRedraw       = (1 << 14), // Skip g_system->copyRectToScreen (for 3D game backends)
 };
 
 }
@@ -147,7 +146,8 @@ struct ZoomBox {
  */
 class MacWindowManager {
 public:
-	MacWindowManager(uint32 mode = 0, MacPatterns *patterns = nullptr, Common::Language language = Common::UNK_LANG);
+	MacWindowManager(uint32 mode = 0, MacPatterns *patterns = nullptr, Common::Language language = Common::UNK_LANG,
+	                 const Graphics::PixelFormat &pixelFormat = Graphics::PixelFormat::createFormatCLUT8());
 	~MacWindowManager();
 
 	Primitives &getDrawPrimitives() const { return *_macDrawPrimitives; }
@@ -353,9 +353,8 @@ public:
 	void setEngineActivateMenuCallback(void *engine, void (*redrawCallback)(void *engine));
 
 	void passPalette(const byte *palette, uint size);
-	template <typename T> void decomposeColor(uint32 color, byte &r, byte &g, byte &b);
+	void getPaletteEntry(uint32 color, byte &r, byte &g, byte &b);
 	uint32 findBestColor(byte cr, byte cg, byte cb);
-	uint32 findBestColor(uint32 color);
 	void setDesktopColor(byte, byte, byte);
 
 	byte inverter(byte src);

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -971,9 +971,9 @@ Graphics::MacWindowManager *GuiManager::getWM() {
 		SearchMan.addDirectory(dir);
 	}
 
-	uint32 wmMode = Graphics::kWMModeNoDesktop | Graphics::kWMMode32bpp | Graphics::kWMModeNoCursorOverride;
+	uint32 wmMode = Graphics::kWMModeNoDesktop | Graphics::kWMModeNoCursorOverride;
 
-	_wm = new Graphics::MacWindowManager(wmMode);
+	_wm = new Graphics::MacWindowManager(wmMode, nullptr, Common::UNK_LANG, theme()->getPixelFormat());
 
 	return _wm;
 }


### PR DESCRIPTION
The Help Dialog has been adapted to use this, which avoids needing to convert the surface from RGBA8888 to the platform-specific overlay each time the screen is redrawn.