### PR TITLE
BACKENDS: Remove EventsBaseBackend

### DIFF
--- a/backends/base-backend.cpp
+++ b/backends/base-backend.cpp
@@ -23,10 +23,6 @@
 
 #include "graphics/scalerplugin.h"
 
-#ifndef DISABLE_DEFAULT_EVENT_MANAGER
-#include "backends/events/default/default-events.h"
-#endif
-
 #ifndef DISABLE_DEFAULT_AUDIOCD_MANAGER
 #include "backends/audiocd/default/default-audiocd.h"
 #endif
@@ -84,14 +80,4 @@ void BaseBackend::fillScreen(const Common::Rect &r, uint32 col) {
 	if (screen)
 		screen->fillRect(r, col);
 	unlockScreen();
-}
-
-void EventsBaseBackend::initBackend() {
-	// Init Event manager
-#ifndef DISABLE_DEFAULT_EVENT_MANAGER
-	if (!_eventManager)
-		_eventManager = new DefaultEventManager(this);
-#endif
-
-	BaseBackend::initBackend();
 }

--- a/backends/base-backend.h
+++ b/backends/base-backend.h
@@ -23,7 +23,6 @@
 #define BACKENDS_BASE_BACKEND_H
 
 #include "common/system.h"
-#include "common/events.h"
 
 /**
  * Subclass of OSystem that contains default implementations of functions that would
@@ -40,11 +39,5 @@ public:
 	void fillScreen(uint32 col) override;
 	void fillScreen(const Common::Rect &r, uint32 col) override;
 };
-
-class EventsBaseBackend : virtual public BaseBackend, Common::EventSource {
-public:
-	virtual void initBackend();
-};
-
 
 #endif

--- a/backends/platform/3ds/osystem.cpp
+++ b/backends/platform/3ds/osystem.cpp
@@ -151,12 +151,13 @@ void OSystem_3DS::initBackend() {
 		ConfMan.set("vkeybd_pack_name", "vkeybd_small");
 	}
 
+	_eventManager = new DefaultEventManager(this);
 	_timerManager = new DefaultTimerManager();
 	_savefileManager = new DefaultSaveFileManager("sdmc:/3ds/scummvm/saves/");
 
 	init3DSGraphics();
 	initAudio();
-	EventsBaseBackend::initBackend();
+	BaseBackend::initBackend();
 	initEvents();
 }
 

--- a/backends/platform/3ds/osystem.h
+++ b/backends/platform/3ds/osystem.h
@@ -100,7 +100,7 @@ struct GfxState {
 };
 
 
-class OSystem_3DS : public EventsBaseBackend, public PaletteManager, public Common::EventObserver {
+class OSystem_3DS : virtual public BaseBackend, public Common::EventSource, public PaletteManager, public Common::EventObserver {
 public:
 	OSystem_3DS();
 	virtual ~OSystem_3DS();

--- a/backends/platform/dc/dc.h
+++ b/backends/platform/dc/dc.h
@@ -68,7 +68,7 @@ public:
 	void stop() override;
 };
 
-class OSystem_Dreamcast : private DCHardware, public EventsBaseBackend, public PaletteManager, public FilesystemFactory
+class OSystem_Dreamcast : virtual public BaseBackend, public Common::EventSource, private DCHardware, public PaletteManager, public FilesystemFactory
 #ifdef DYNAMIC_MODULES
   , public FilePluginProvider
 #endif

--- a/backends/platform/dc/dcmain.cpp
+++ b/backends/platform/dc/dcmain.cpp
@@ -29,6 +29,7 @@
 #include "dcutils.h"
 #include "icon.h"
 #include "DCLauncherDialog.h"
+#include "backends/events/default/default-events.h"
 #include "backends/mutex/null/null-mutex.h"
 #include <common/config-manager.h>
 #include <common/memstream.h>
@@ -56,6 +57,7 @@ OSystem_Dreamcast::OSystem_Dreamcast()
 void OSystem_Dreamcast::initBackend()
 {
   ConfMan.setInt("autosave_period", 0);
+  _eventManager = new DefaultEventManager(this);
   _savefileManager = createSavefileManager();
   _timerManager = new DefaultTimerManager();
 
@@ -65,7 +67,7 @@ void OSystem_Dreamcast::initBackend()
 
   _audiocdManager = new DCCDManager();
 
-  EventsBaseBackend::initBackend();
+  BaseBackend::initBackend();
 }
 
 

--- a/backends/platform/libretro/include/libretro-os.h
+++ b/backends/platform/libretro/include/libretro-os.h
@@ -51,7 +51,7 @@ public:
 	};
 };
 
-class OSystem_libretro : public EventsBaseBackend, public ModularGraphicsBackend {
+class OSystem_libretro : virtual public BaseBackend, public Common::EventSource, public ModularGraphicsBackend {
 private:
 	int _relMouseX;
 	int _relMouseY;

--- a/backends/platform/libretro/src/libretro-os-base.cpp
+++ b/backends/platform/libretro/src/libretro-os-base.cpp
@@ -30,6 +30,7 @@
 #include "common/system.h"
 #include "graphics/surface.h"
 
+#include "backends/events/default/default-events.h"
 #include "backends/saves/default/default-saves.h"
 #include "backends/platform/libretro/include/libretro-defs.h"
 #include "backends/platform/libretro/include/libretro-core.h"
@@ -70,6 +71,7 @@ void OSystem_libretro::initBackend() {
 	if (! ConfMan.hasKey("libretro_hooks_clear"))
 		ConfMan.set("libretro_hooks_clear", 0);
 
+	_eventManager = new DefaultEventManager(this);
 	_savefileManager = new DefaultSaveFileManager();
 
 	_mixer = new Audio::MixerImpl(retro_setting_get_sample_rate(), true, retro_setting_get_audio_samples_buffer_size());
@@ -81,7 +83,7 @@ void OSystem_libretro::initBackend() {
 
 	resetGraphicsManager();
 
-	EventsBaseBackend::initBackend();
+	BaseBackend::initBackend();
 	refreshRetroSettings();
 }
 

--- a/backends/platform/n64/osys_n64.h
+++ b/backends/platform/n64/osys_n64.h
@@ -69,7 +69,7 @@ enum GraphicModeID {
 	OVERS_MPAL_340X240
 };
 
-class OSystem_N64 : public EventsBaseBackend, public PaletteManager {
+class OSystem_N64 : virtual public BaseBackend, public Common::EventSource, public PaletteManager {
 protected:
 	Audio::MixerImpl *_mixer;
 

--- a/backends/platform/n64/osys_n64_base.cpp
+++ b/backends/platform/n64/osys_n64_base.cpp
@@ -28,6 +28,7 @@
 #include "osys_n64.h"
 #include "pakfs_save_manager.h"
 #include "framfs_save_manager.h"
+#include "backends/events/default/default-events.h"
 #include "backends/fs/n64/n64-fs-factory.h"
 #include "backends/mutex/null/null-mutex.h"
 #include "backends/saves/default/default-saves.h"
@@ -188,13 +189,14 @@ void OSystem_N64::initBackend() {
 		_savefileManager = new PAKSaveManager();
 	}
 
+	_eventManager = new DefaultEventManager(this);
 	_timerManager = new DefaultTimerManager();
 
 	setTimerCallback(&timer_handler, 10);
 
 	setupMixer();
 
-	EventsBaseBackend::initBackend();
+	BaseBackend::initBackend();
 }
 
 bool OSystem_N64::hasFeature(Feature f) {

--- a/backends/platform/psp/osys_psp.cpp
+++ b/backends/platform/psp/osys_psp.cpp
@@ -37,6 +37,7 @@
 #include "backends/platform/psp/powerman.h"
 #include "backends/platform/psp/rtc.h"
 
+#include "backends/events/default/default-events.h"
 #include "backends/saves/default/default-saves.h"
 #include "backends/timer/psp/timer.h"
 #include "graphics/surface.h"
@@ -88,6 +89,7 @@ void OSystem_PSP::initBackend() {
 	_imageViewer.setInputHandler(&_inputHandler);
 	_imageViewer.setDisplayManager(&_displayManager);
 
+	_eventManager = new DefaultEventManager(this);
 	_savefileManager = new DefaultSaveFileManager(PSP_DEFAULT_SAVE_PATH);
 
 	_timerManager = new PspTimerManager();
@@ -97,7 +99,7 @@ void OSystem_PSP::initBackend() {
 
 	setupMixer();
 
-	EventsBaseBackend::initBackend();
+	BaseBackend::initBackend();
 }
 
 // Let's us know an engine

--- a/backends/platform/psp/osys_psp.h
+++ b/backends/platform/psp/osys_psp.h
@@ -39,7 +39,7 @@
 #include "backends/platform/psp/audio.h"
 #include "backends/platform/psp/thread.h"
 
-class OSystem_PSP : public EventsBaseBackend, public PaletteManager {
+class OSystem_PSP : virtual public BaseBackend, public Common::EventSource, public PaletteManager {
 private:
 
 	Audio::MixerImpl *_mixer;

--- a/backends/platform/wii/osystem.cpp
+++ b/backends/platform/wii/osystem.cpp
@@ -28,6 +28,7 @@
 
 #include "common/config-manager.h"
 #include "common/textconsole.h"
+#include "backends/events/default/default-events.h"
 #include "backends/fs/wii/wii-fs-factory.h"
 #include "backends/mutex/wii/wii-mutex.h"
 #include "backends/saves/default/default-saves.h"
@@ -134,6 +135,7 @@ void OSystem_Wii::initBackend() {
 	if (!getcwd(buf, MAXPATHLEN))
 		Common::strcpy_s(buf, "/");
 
+	_eventManager = new DefaultEventManager(this);
 	_savefileManager = new DefaultSaveFileManager(buf);
 	_timerManager = new DefaultTimerManager();
 
@@ -141,7 +143,7 @@ void OSystem_Wii::initBackend() {
 	initSfx();
 	initEvents();
 
-	EventsBaseBackend::initBackend();
+	BaseBackend::initBackend();
 }
 
 void OSystem_Wii::quit() {
@@ -343,7 +345,7 @@ Common::String OSystem_Wii::getSystemLanguage() const {
 	} else {
 		// This will only happen when new languages are added to the API.
 		warning("WII: Unknown system language: %d", langID);
-		return EventsBaseBackend::getSystemLanguage();
+		return BaseBackend::getSystemLanguage();
 	}
 }
 #endif // !GAMECUBE

--- a/backends/platform/wii/osystem.h
+++ b/backends/platform/wii/osystem.h
@@ -51,7 +51,7 @@ extern void wii_memstats(void);
 }
 #endif
 
-class OSystem_Wii final : public EventsBaseBackend, public PaletteManager {
+class OSystem_Wii final : virtual public BaseBackend, public Common::EventSource, public PaletteManager {
 private:
 	s64 _startup_time;
 

--- a/common/system.h
+++ b/common/system.h
@@ -199,8 +199,6 @@ protected:
 
 	/**
 	 * No default value is provided for _eventManager by OSystem.
-	 * However, EventsBaseBackend::initBackend() does set a default value
-	 * if none has been set before.
 	 *
 	 * @note _eventManager is deleted by the OSystem destructor.
 	 */

--- a/test/system/null_osystem.cpp
+++ b/test/system/null_osystem.cpp
@@ -47,7 +47,3 @@ void BaseBackend::fillScreen(uint32 col) {
 
 void BaseBackend::fillScreen(const Common::Rect &r, uint32 col) {
 }
-
-void EventsBaseBackend::initBackend() {
-	BaseBackend::initBackend();
-}


### PR DESCRIPTION
It's simpler and more flexible for each backend to create the default event manager manually.