### PR TITLE
ALL: Add global force pause via Ctrl+P/PAUSE key

### DIFF
--- a/backends/events/default/default-events.cpp
+++ b/backends/events/default/default-events.cpp
@@ -203,6 +203,15 @@ bool DefaultEventManager::pollEvent(Common::Event &event) {
 			g_engine->flipMute();
 		break;
 
+	case Common::EVENT_SCREEN_PAUSE:
+		if (g_engine) {
+			if (_screenPauseToken.isActive())
+				_screenPauseToken.clear();
+			else
+				_screenPauseToken = g_engine->pauseEngine();
+		}
+		break;
+
 	case Common::EVENT_QUIT:
 		if (g_engine && !g_engine->hasFeature(Engine::kSupportsQuitDialogOverride) && ConfMan.getBool("confirm_exit")) {
 			if (_confirmExitDialogActive) {
@@ -352,6 +361,12 @@ Common::Keymap *DefaultEventManager::getGlobalKeymap() {
 	act = new Action("MUTE", _("Toggle mute"));
 	act->addDefaultInputMapping("C+u");
 	act->setEvent(EVENT_MUTE);
+	globalKeymap->addAction(act);
+
+	act = new Action("SPAUSE", _("Pause (no dialog)"));
+	act->addDefaultInputMapping("PAUSE");
+	act->addDefaultInputMapping("C+p");
+	act->setEvent(EVENT_SCREEN_PAUSE);
 	globalKeymap->addAction(act);
 
 	if (!g_system->hasFeature(OSystem::kFeatureNoQuit)) {

--- a/backends/events/default/default-events.h
+++ b/backends/events/default/default-events.h
@@ -24,6 +24,7 @@
 
 #include "common/events.h"
 #include "common/queue.h"
+#include "engines/engine.h"
 
 namespace Common {
 class Keymapper;
@@ -57,6 +58,7 @@ class DefaultEventManager : public Common::EventManager, Common::EventObserver {
 	bool _shouldQuit;
 	bool _shouldReturnToLauncher;
 	bool _confirmExitDialogActive;
+	PauseToken _screenPauseToken;
 
 public:
 	DefaultEventManager(Common::EventSource *boss);

--- a/common/events.h
+++ b/common/events.h
@@ -117,6 +117,8 @@ enum EventType {
 	EVENT_FOCUS_GAINED = 36,
 	EVENT_FOCUS_LOST = 37,
 
+	EVENT_SCREEN_PAUSE = 38,
+
 	/**
 	 * We reserve some event ids for custom events.
 	 * 

--- a/doc/docportal/settings/keymaps.rst
+++ b/doc/docportal/settings/keymaps.rst
@@ -68,6 +68,11 @@ Quit
 Open Debugger
 	*keymap_global_DEBUGGER*
 
+.. _keymap_spause:
+
+Pause (no dialog)
+	*keymap_global_SPAUSE*
+
 .. _vmouseup:
 
 Virtual mouse up

--- a/doc/docportal/use_scummvm/keyboard_shortcuts.rst
+++ b/doc/docportal/use_scummvm/keyboard_shortcuts.rst
@@ -30,3 +30,4 @@ Default shortcuts are shown in the table.
         :kbd:`Alt+s` ,Takes a :ref:`screenshot <screenshotpath>`
         :kbd:`Ctrl+F7`,"Opens virtual keyboard (if enabled). This can also be opened with a long press of the middle mouse button or wheel."
 		:kbd:`Ctrl+Alt+d`,"Opens the ScummVM debugger"
+		:kbd:`Ctrl+p` or :kbd:`Pause`,"Pauses the engine without a dialog"


### PR DESCRIPTION
## Summary      

Add a global force pause feature that pauses the engine via `Ctrl+P` or the `Pause` key, regardless of whether the running game has its own in-game pause.

The shortcut is registered as a global keymap action (`SPAUSE`) in the default event manager and uses the engine's `pauseEngine()` mechanism, so it works across all engines.

## Motivation                                                                                                         

Many ScummVM-supported games provide their own in-game pause, but some do not. Players who find the dialogue or pacing too fast have no way to pause those games.                                                                                

There is long-standing user demand for this — see the forum thread for examples of users struggling with this issue: https://forums.scummvm.org/viewtopic.php?t=14813

## Changes

- `common/events.h`: Add `EVENT_SCREEN_PAUSE` event type
- `backends/events/default/default-events.{h,cpp}`: Handle `EVENT_SCREEN_PAUSE` and register the global `SPAUSE` keymap action bound to `Ctrl+P` and `PAUSE`
- `doc/docportal/`: Document the new shortcut and keymap