### PR TITLE
GRIM: Clear controls state after resuming from paused state

### DIFF
--- a/engines/grim/grim.cpp
+++ b/engines/grim/grim.cpp
@@ -1679,6 +1679,13 @@ void GrimEngine::pauseEngineIntern(bool pause) {
 		_pauseStartTime = _system->getMillis();
 	} else {
 		_frameStart += _system->getMillis() - _pauseStartTime;
+
+		// This "clear event queue" call is added to clear any keys registered as pressed
+		// when the pause occured and their KEYUP event was not handled by the engine
+		// (because it was paused) but it was consumed externally and is no longer pending in the event queue.
+		// The call also clears any pending (at the time of the pause) keyboard or mouse events.
+		// It addresses bug #16667.
+		clearEventQueue();
 	}
 }
 


### PR DESCRIPTION
This is a proposed fix for bug #16667

A Ctrl+F5 combo to bring up the GMM (and pause the engine) would result in Ctrl being "stuck" as pressed as far as the engine is concerned. This fix will unset the modifier key (eg. Ctrl) from the pressed state for the engine after resuming, but might be an overkill, so it has to be reviewed by someone more familiar with the engine.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
