### PR TITLE
DIRECTOR: Process timeout events independently of frame cycle

### DIFF
--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -652,6 +652,14 @@ void Score::update() {
 		_activeFade = _soundManager->fadeChannels();
 	}
 
+	// Process timeout events independently of the frame delay
+	if (_haveInteractivity && !_vm->_playbackPaused) {
+		if (_vm->getMacTicks() - _movie->_lastTimeOut >= _movie->_timeOutLength) {
+			_movie->processEvent(kEventTimeout);
+			_movie->_lastTimeOut = _vm->getMacTicks();
+		}
+	}
+
 	if (!debugChannelSet(-1, kDebugFast)) {
 		// end update cycle if we're still waiting for the next frame
 		if (isWaitingForNextFrame()) {
@@ -664,17 +672,6 @@ void Score::update() {
 			// like "go to frame", or open a new movie.
 			if (!_nextFrame && _window->_nextMovie.movie.empty()) {
 				processFrozenScripts();
-			}
-
-			// In the original Director runtime, timeout events fire based on
-			// elapsed time since the last user interaction, independently of
-			// the frame cycle. Process them here so they are not blocked by
-			// frame-rate limiting.
-			if (_haveInteractivity && !_vm->_playbackPaused) {
-				if (_vm->getMacTicks() - _movie->_lastTimeOut >= _movie->_timeOutLength) {
-					_movie->processEvent(kEventTimeout);
-					_movie->_lastTimeOut = _vm->getMacTicks();
-				}
 			}
 			return;
 		}
@@ -703,15 +700,6 @@ void Score::update() {
 		// like "go to frame", or open a new movie.
 		if ((!_nextFrame && _window->_nextMovie.movie.empty()) || _nextFrame == _curFrameNumber) {
 			processFrozenScripts();
-		}
-
-		// Process timeout events independently of the frame delay,
-		// matching original Director runtime behavior.
-		if (_haveInteractivity && !_vm->_playbackPaused) {
-			if (_vm->getMacTicks() - _movie->_lastTimeOut >= _movie->_timeOutLength) {
-				_movie->processEvent(kEventTimeout);
-				_movie->_lastTimeOut = _vm->getMacTicks();
-			}
 		}
 
 		return;
@@ -872,13 +860,6 @@ void Score::update() {
 	}
 
 	// TODO Director 6 - another order
-
-	// TODO: Figure out when exactly timeout events are processed
-	if (_vm->getMacTicks() - _movie->_lastTimeOut >= _movie->_timeOutLength) {
-		_movie->processEvent(kEventTimeout);
-		_movie->_lastTimeOut = _vm->getMacTicks();
-	}
-
 }
 
 void Score::renderFrame(uint16 frameId, RenderMode mode, bool sound1Changed, bool sound2Changed) {

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -665,6 +665,17 @@ void Score::update() {
 			if (!_nextFrame && _window->_nextMovie.movie.empty()) {
 				processFrozenScripts();
 			}
+
+			// In the original Director runtime, timeout events fire based on
+			// elapsed time since the last user interaction, independently of
+			// the frame cycle. Process them here so they are not blocked by
+			// frame-rate limiting.
+			if (_haveInteractivity && !_vm->_playbackPaused) {
+				if (_vm->getMacTicks() - _movie->_lastTimeOut >= _movie->_timeOutLength) {
+					_movie->processEvent(kEventTimeout);
+					_movie->_lastTimeOut = _vm->getMacTicks();
+				}
+			}
 			return;
 		}
 	}
@@ -692,6 +703,15 @@ void Score::update() {
 		// like "go to frame", or open a new movie.
 		if ((!_nextFrame && _window->_nextMovie.movie.empty()) || _nextFrame == _curFrameNumber) {
 			processFrozenScripts();
+		}
+
+		// Process timeout events independently of the frame delay,
+		// matching original Director runtime behavior.
+		if (_haveInteractivity && !_vm->_playbackPaused) {
+			if (_vm->getMacTicks() - _movie->_lastTimeOut >= _movie->_timeOutLength) {
+				_movie->processEvent(kEventTimeout);
+				_movie->_lastTimeOut = _vm->getMacTicks();
+			}
 		}
 
 		return;


### PR DESCRIPTION
In the Director 6 game "Masters of the Elements" (yes, the game I have a slight obsession with), I noticed some weird behavior: Whenever the mouse button was _not_ pressed, the game ran at like 5 FPS. However, if I held and pressed the mouse button, the game ran perfectly fine.

This game does _lots_ of stuff in the background, e.g. it hase a time-tracking feature that's currently nicely visible in the debugger output thanks to some unimplemented code. I observed that the Lingo execution seemingly "stopped" whenever the mouse button was pressed, so my initial assumption was that we had a "bottleneck" in our Lingo execution.

I tried to figure it out every know and then for the last couple of months, but never got really lucky.

Well. Today, I passed the problem to Claude Opus. I gave it the ScummVM code, the dumped Lingo code, and a problem description. After two iteration rounds, it came up with a solution.

I verified that the code works, and at least for this game, it doesn't break anything else. @sev- gave it an initial first look and figured that the explaination is correct.

However, _if_ something breaks unexpectedly, blame me, not the faceless AI, it is just a tool I decided to chose. For the commit message, I followed the `Assisted-by:` guidelines proposed in https://github.com/torvalds/linux/blob/master/Documentation/process/coding-assistants.rst.