### PR TITLE
AGOS: Fix Elvira 2 Atari ST colours

### DIFF
--- a/engines/agos/agos.h
+++ b/engines/agos/agos.h
@@ -1237,7 +1237,7 @@ protected:
 	void drawVertImage(VC10_state *state);
 	void drawVertImageCompressed(VC10_state *state);
 	void drawVertImageUncompressed(VC10_state *state);
-
+	void remapElvira2AtariSTUIRegions(Graphics::Surface *screen);
 	void setMoveRect(uint16 x, uint16 y, uint16 width, uint16 height);
 
 	void horizontalScroll(VC10_state *state);

--- a/engines/agos/charset-fontdata.cpp
+++ b/engines/agos/charset-fontdata.cpp
@@ -3005,6 +3005,9 @@ void AGOSEngine::windowDrawChar(WindowBlock *window, uint x, uint y, byte chr) {
 	color = window->textColor;
 	if (getGameType() == GType_ELVIRA2 || getGameType() == GType_WW)
 		color += dst[0] & 0xF0;
+	if (getGameType() == GType_ELVIRA2 && getPlatform() == Common::kPlatformAtariST &&
+			y < 136 && (_windowNum == 1 || _windowNum == 2 || y >= 132))
+		color = (color & 0x0F) | 208;
 
 	do {
 		int8 b = *src++;

--- a/engines/agos/cursor.cpp
+++ b/engines/agos/cursor.cpp
@@ -128,6 +128,11 @@ static const uint16 _common_moveLeft[32] = {
 	0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000
 };
 
+static const byte elvira2AtariSTCursorPalette[] = {
+	0x00, 0x00, 0x00,
+	0xE0, 0xA0, 0x00
+};
+
 static const byte _amiga_mousePalettePN[] = {
 	0x00, 0x00, 0x00,
 	0xDE, 0x20, 0x21,
@@ -941,6 +946,9 @@ void AGOSEngine::drawMousePointer() {
 			}
 			src += 2;
 		}
+
+		if (getGameType() == GType_ELVIRA2 && getPlatform() == Common::kPlatformAtariST)
+			CursorMan.replaceCursorPalette(elvira2AtariSTCursorPalette, 0, ARRAYSIZE(elvira2AtariSTCursorPalette) / 3);
 
 		if (getGameId() == GID_ELVIRA1 && getPlatform() == Common::kPlatformPC98) {
 			// Simple 2x upscaling for the cursor in dual layer hi-res mode.

--- a/engines/agos/draw.cpp
+++ b/engines/agos/draw.cpp
@@ -950,6 +950,9 @@ void AGOSEngine::displayScreen() {
 			_moveYMin = 0xFFFF;
 			_moveXMax = 0;
 			_moveYMax = 0;
+
+			if (getGameType() == GType_ELVIRA2 && getPlatform() == Common::kPlatformAtariST)
+				remapElvira2AtariSTUIRegions(screen);
 		}
 
 		if (_window6Flag == 2) {

--- a/engines/agos/gfx.cpp
+++ b/engines/agos/gfx.cpp
@@ -32,6 +32,29 @@
 
 namespace AGOS {
 
+static void remapElvira2AtariSTUIPaletteRect(Graphics::Surface *screen, uint16 x, uint16 y, uint16 w, uint16 h) {
+	byte *dst = (byte *)screen->getBasePtr(x, y);
+	while (h--) {
+		for (uint16 i = 0; i < w; i++)
+			dst[i] = (dst[i] & 0x0F) | 0xD0;
+		dst += screen->pitch;
+	}
+}
+
+static inline uint8 atariSTColorNibbleToComponent(uint8 v) {
+	v &= 0x07;
+	return v * 32;
+}
+
+void AGOSEngine::remapElvira2AtariSTUIRegions(Graphics::Surface *screen) {
+	if (getGameType() != GType_ELVIRA2 || getPlatform() != Common::kPlatformAtariST)
+		return;
+
+	remapElvira2AtariSTUIPaletteRect(screen, 0, 0, 48, 136);
+	remapElvira2AtariSTUIPaletteRect(screen, 272, 0, 48, 136);
+	remapElvira2AtariSTUIPaletteRect(screen, 0, 132, 320, 68);
+}
+
 byte *vc10_depackColumn(VC10_state * vs) {
 	int8 a = vs->depack_cont;
 	const byte *src = vs->srcPtr;
@@ -952,13 +975,43 @@ void AGOSEngine::drawImage(VC10_state *state) {
 	if (getGameType() == GType_ELVIRA2 || getGameType() == GType_WW)
 		state->palette = state->surf_addr[0] & 0xF0;
 
-	if (getGameType() == GType_ELVIRA2 && getPlatform() == Common::kPlatformAtariST && yoffs > 133)
+	if (getGameType() == GType_ELVIRA2 && getPlatform() == Common::kPlatformAtariST && _windowNum == 4) {
+		_displayPalette[0 * 3 + 0] = atariSTColorNibbleToComponent(0x0);
+		_displayPalette[0 * 3 + 1] = atariSTColorNibbleToComponent(0x0);
+		_displayPalette[0 * 3 + 2] = atariSTColorNibbleToComponent(0x0);
+		_displayPalette[1 * 3 + 0] = atariSTColorNibbleToComponent(0x7);
+		_displayPalette[1 * 3 + 1] = atariSTColorNibbleToComponent(0x7);
+		_displayPalette[1 * 3 + 2] = atariSTColorNibbleToComponent(0x5);
+		_displayPalette[2 * 3 + 0] = atariSTColorNibbleToComponent(0x5);
+		_displayPalette[2 * 3 + 1] = atariSTColorNibbleToComponent(0x0);
+		_displayPalette[2 * 3 + 2] = atariSTColorNibbleToComponent(0x0);
+		_displayPalette[15 * 3 + 0] = atariSTColorNibbleToComponent(0x7);
+		_displayPalette[15 * 3 + 1] = atariSTColorNibbleToComponent(0x5);
+		_displayPalette[15 * 3 + 2] = atariSTColorNibbleToComponent(0x0);
+		_paletteFlag = 1;
+	}
+	if (getGameType() == GType_ELVIRA2 && getPlatform() == Common::kPlatformAtariST &&
+			_windowNum == 3 && yoffs < 136 && xoffs < 48 && xmax > 48) {
+		state->palette = 0;
+		state->paletteMod = 0;
+	}
+
+	if (getGameType() == GType_ELVIRA2 && getPlatform() == Common::kPlatformAtariST &&
+			((yoffs >= 132 && _windowNum != 3) || ((_windowNum == 1 || _windowNum == 2) && yoffs < 136))) {
 		state->palette = 208;
+		if (_backFlag || (state->flags & kDFNonTrans))
+			state->paletteMod = 208;
+	}
 
 	if (_backFlag) {
 		drawBackGroundImage(state);
 	} else {
 		drawVertImage(state);
+	}
+
+	if (getGameType() == GType_ELVIRA2 && getPlatform() == Common::kPlatformAtariST) {
+		if (_windowNum == 1 || _windowNum == 2)
+			remapElvira2AtariSTUIRegions(screen);
 	}
 
 	Common::Rect dirtyRect(xoffs, yoffs, xmax, ymax);

--- a/engines/agos/verb.cpp
+++ b/engines/agos/verb.cpp
@@ -1004,9 +1004,16 @@ void AGOSEngine::invertBox(HitArea *ha, byte a, byte b, byte c, byte d) {
 					src[i] = color;
 				}
 			} else if (getGameType() == GType_ELVIRA2) {
-				if (!(color & 1)) {
-					color ^= 2;
-					src[i] = color;
+				if (getPlatform() == Common::kPlatformAtariST && ha->y < 136) {
+					if ((color & 0x0F) == 1)
+						src[i] = (color & 0xF0) | 15;
+					else if ((color & 0x0F) == 12 || (color & 0x0F) == 15)
+						src[i] = (color & 0xF0) | 1;
+				} else {
+					if (!(color & 1)) {
+						color ^= 2;
+						src[i] = color;
+					}
 				}
 			} else if (getGameType() == GType_ELVIRA1) {
 				if (color & 1) {

--- a/engines/agos/vga.cpp
+++ b/engines/agos/vga.cpp
@@ -935,6 +935,11 @@ static const uint8 iconPalette[64] = {
 	0x77, 0x55, 0x00,
 };
 
+static inline uint8 atariSTColorNibbleToComponent(uint8 v) {
+	v &= 0x07;
+	return v * 32;
+}
+
 void AGOSEngine::vc22_setPalette() {
 	byte *offs, *palptr, *src;
 	uint16 b, num;
@@ -983,9 +988,9 @@ void AGOSEngine::vc22_setPalette() {
 		// Custom palette used for icon area
 		palptr = &_displayPalette[13 * 3 * 16];
 		for (uint8 c = 0; c < 16; c++) {
-			palptr[0] = iconPalette[c * 3 + 0] * 2;
-			palptr[1] = iconPalette[c * 3 + 1] * 2;
-			palptr[2] = iconPalette[c * 3 + 2] * 2;
+			palptr[0] = atariSTColorNibbleToComponent(iconPalette[c * 3 + 0] >> 4);
+			palptr[1] = atariSTColorNibbleToComponent(iconPalette[c * 3 + 1] >> 4);
+			palptr[2] = atariSTColorNibbleToComponent(iconPalette[c * 3 + 2] >> 4);
 
 			palptr += 3;
 		};
@@ -997,9 +1002,15 @@ void AGOSEngine::vc22_setPalette() {
 
 	do {
 		uint16 color = READ_BE_UINT16(src);
-		palptr[0] = ((color & 0xf00) >> 8) * 32;
-		palptr[1] = ((color & 0x0f0) >> 4) * 32;
-		palptr[2] = ((color & 0x00f) >> 0) * 32;
+		if (getGameType() == GType_ELVIRA2 && getPlatform() == Common::kPlatformAtariST) {
+			palptr[0] = atariSTColorNibbleToComponent((color & 0xf00) >> 8);
+			palptr[1] = atariSTColorNibbleToComponent((color & 0x0f0) >> 4);
+			palptr[2] = atariSTColorNibbleToComponent((color & 0x00f) >> 0);
+		} else {
+			palptr[0] = ((color & 0xf00) >> 8) * 32;
+			palptr[1] = ((color & 0x0f0) >> 4) * 32;
+			palptr[2] = ((color & 0x00f) >> 0) * 32;
+		}
 
 		palptr += 3;
 		src += 2;
@@ -1351,9 +1362,15 @@ void AGOSEngine::vc37_pokePalette() {
 		return;
 
 	byte *palptr = _displayPalette + offs * 3;
-	palptr[0] = ((color & 0xf00) >> 8) * 32;
-	palptr[1] = ((color & 0x0f0) >> 4) * 32;
-	palptr[2] = ((color & 0x00f) >> 0) * 32;
+	if (getGameType() == GType_ELVIRA2 && getPlatform() == Common::kPlatformAtariST) {
+		palptr[0] = atariSTColorNibbleToComponent((color & 0xf00) >> 8);
+		palptr[1] = atariSTColorNibbleToComponent((color & 0x0f0) >> 4);
+		palptr[2] = atariSTColorNibbleToComponent((color & 0x00f) >> 0);
+	} else {
+		palptr[0] = ((color & 0xf00) >> 8) * 32;
+		palptr[1] = ((color & 0x0f0) >> 4) * 32;
+		palptr[2] = ((color & 0x00f) >> 0) * 32;
+	}
 
 	if (!(_videoLockOut & 0x20)) {
 		_paletteFlag = 1;

--- a/engines/agos/vga_e2.cpp
+++ b/engines/agos/vga_e2.cpp
@@ -34,6 +34,24 @@
 
 namespace AGOS {
 
+static inline uint8 atariSTColorNibbleToComponent(uint8 v) {
+	v &= 0x07;
+	return v * 32;
+}
+
+static inline void writeElvira2AtariSTPaletteColor(byte *dst, uint16 color) {
+	dst[0] = atariSTColorNibbleToComponent((color >> 8) & 0x0F);
+	dst[1] = atariSTColorNibbleToComponent((color >> 4) & 0x0F);
+	dst[2] = atariSTColorNibbleToComponent((color >> 0) & 0x0F);
+}
+
+static inline void applyElvira2AtariSTScenePaletteOverride(byte *paletteBase) {
+	writeElvira2AtariSTPaletteColor(paletteBase + 0 * 3, 0x000);
+	writeElvira2AtariSTPaletteColor(paletteBase + 1 * 3, 0x775);
+	writeElvira2AtariSTPaletteColor(paletteBase + 2 * 3, 0x500);
+	writeElvira2AtariSTPaletteColor(paletteBase + 15 * 3, 0x750);
+}
+
 void AGOSEngine_Elvira2::setupVideoOpcodes(VgaOpcodeProc *op) {
 	AGOSEngine::setupVideoOpcodes(op);
 
@@ -70,6 +88,9 @@ void AGOSEngine::vc44_ifBitClear() {
 void AGOSEngine::vc45_setWindowPalette() {
 	uint16 num = vcReadNextWord();
 	uint16 color = vcReadNextWord();
+
+	if (getGameType() == GType_ELVIRA2 && getPlatform() == Common::kPlatformAtariST && (num == 1 || num == 2))
+		color = 13;
 
 	const uint16 *vlut = &_videoWindows[num * 4];
 	uint8 width = vlut[2] * 8;
@@ -111,23 +132,32 @@ void AGOSEngine::vc45_setWindowPalette() {
 }
 
 void AGOSEngine::setPaletteSlot(uint16 srcOffs, uint8 dstOffs) {
-	byte *offs, *palptr, *src;
+	byte *offs, *palptr, *src, *paletteBase;
 	uint16 num;
 
-	palptr = _displayPalette + dstOffs * 3 * 16;
+	paletteBase = palptr = _displayPalette + dstOffs * 3 * 16;
 	offs = _curVgaFile1 + READ_BE_UINT16(_curVgaFile1 + 6);
 	src = offs + srcOffs * 32;
 	num = 16;
 
 	do {
 		uint16 color = READ_BE_UINT16(src);
-		palptr[0] = ((color & 0xf00) >> 8) * 32;
-		palptr[1] = ((color & 0x0f0) >> 4) * 32;
-		palptr[2] = ((color & 0x00f) >> 0) * 32;
+		if (getGameType() == GType_ELVIRA2 && getPlatform() == Common::kPlatformAtariST) {
+			palptr[0] = atariSTColorNibbleToComponent((color & 0xf00) >> 8);
+			palptr[1] = atariSTColorNibbleToComponent((color & 0x0f0) >> 4);
+			palptr[2] = atariSTColorNibbleToComponent((color & 0x00f) >> 0);
+		} else {
+			palptr[0] = ((color & 0xf00) >> 8) * 32;
+			palptr[1] = ((color & 0x0f0) >> 4) * 32;
+			palptr[2] = ((color & 0x00f) >> 0) * 32;
+		}
 
 		palptr += 3;
 		src += 2;
 	} while (--num);
+
+	if (getGameType() == GType_ELVIRA2 && getPlatform() == Common::kPlatformAtariST)
+		applyElvira2AtariSTScenePaletteOverride(paletteBase);
 
 	_paletteFlag = 2;
 }

--- a/engines/agos/window.cpp
+++ b/engines/agos/window.cpp
@@ -177,6 +177,9 @@ void AGOSEngine::colorBlock(WindowBlock *window, uint16 x, uint16 y, uint16 w, u
 	uint8 color = window->fillColor;
 	if (getGameType() == GType_ELVIRA2 || getGameType() == GType_WW)
 		color += dst[0] & 0xF0;
+	if (getGameType() == GType_ELVIRA2 && getPlatform() == Common::kPlatformAtariST &&
+			y < 136 && (_windowNum == 1 || _windowNum == 2 || y >= 132))
+		color = (color & 0x0F) | 208;
 	uint16 h2 = h;
 
 	do {


### PR DESCRIPTION
This PR fixes colours in Elvira II for Atari ST.

The original Atari ST version has palette changes/remapping for different screen regions: the room art, side UI panels, bottom UI area, and cursor are not all drawn using one flat palette. ScummVM was drawing the room art and UI with the wrong colours in places, especially around the left/right UI edges. Some work was already done here for the lower inventory area, but the top area was not matching the original.

**ScummVM Before:**

<p align="left">
  <img src="https://github.com/user-attachments/assets/b5b9ad93-247e-41ec-8e43-57cdf6b2dbf4" width="250" />
  <img src="https://github.com/user-attachments/assets/68ae5597-521a-4370-9199-2837d44227df" width="250" />
  <img src="https://github.com/user-attachments/assets/14b9251d-bfea-44d2-ac9f-43f35b142bc9" width="250" />
  <img src="https://github.com/user-attachments/assets/30c0d9f8-56be-4786-80ae-abe96ab6e26b" width="250" />
  <img src="https://github.com/user-attachments/assets/a255e391-a72b-41a6-a5a1-17fdfdd733cb" width="250" />
</p>

**Emulator:**

<p align="left">
  <img src="https://github.com/user-attachments/assets/77eb1160-873e-4934-a98a-350d757d97f3" width="250" />
  <img src="https://github.com/user-attachments/assets/58c11597-304e-4c7f-81a3-bc23406fb743" width="250" />
  <img src="https://github.com/user-attachments/assets/656bc198-3fa5-453e-8569-b2ecc444abe9" width="250" />
  <img src="https://github.com/user-attachments/assets/512274c1-ef37-488f-86fd-e91c1d2b67ae" width="250" />
  <img src="https://github.com/user-attachments/assets/226e9014-90e4-40a9-8bd8-88bd71d6bb88" width="250" />
</p>

**ScummVM After:**

<p align="left">
  <img src="https://github.com/user-attachments/assets/da6031be-0a5a-419e-925e-e94f9ca7f90b" width="250" />
  <img src="https://github.com/user-attachments/assets/16fe22cb-fd46-430a-8221-bc8570a73a01" width="250" />
  <img src="https://github.com/user-attachments/assets/664b8667-cf7a-4821-bb2d-b045447e0a98" width="250" />
  <img src="https://github.com/user-attachments/assets/982b80bc-31c8-454d-8069-020155cfac37" width="250" />
  <img src="https://github.com/user-attachments/assets/fa9086db-343f-4227-971c-6a70bbe4659b" width="250" />
</p>