### PR TITLE
VIDEO: Check validity of granulepos in TheoraVideoTrack::decodePacket

### DIFF
--- a/video/theora_decoder.cpp
+++ b/video/theora_decoder.cpp
@@ -316,19 +316,16 @@ bool TheoraDecoder::TheoraVideoTrack::decodePacket(ogg_packet &oggPacket) {
 			translateYUVtoRGBA(yuv);
 		}
 
-		// We set the current frame counter, delegating the calculation to libtheora 
-		_curFrame = (int) th_granule_frame(_theoraDecode, oggPacket.granulepos);
-
-		double time = th_granule_time(_theoraDecode, oggPacket.granulepos);
-
-		// We need to calculate when the next frame should be shown
-		// This is all in floating point because that's what the Ogg code gives us
-		// Ogg is a lossy container format, so it doesn't always list the time to the
-		// next frame. In such cases, we need to calculate it ourselves.
-		if (time == -1.0)
+		// If we have a valid granule position for this packet, use it to calculate the next
+		// frame information. If we don't have a valid granule position, we need to do our
+		// calculation for the frame number and timing.
+		if (oggPacket.granulepos >= 0) {
+			_curFrame = (int)th_granule_frame(_theoraDecode, oggPacket.granulepos);
+			_nextFrameStartTime = th_granule_time(_theoraDecode, oggPacket.granulepos);
+		} else {
+			_curFrame++;
 			_nextFrameStartTime += _frameRate.getInverse().toDouble();
-		else
-			_nextFrameStartTime = time;
+		}
 
 		return true;
 	}


### PR DESCRIPTION
A fix was introduced in 43c5d3e7c9933fdb8da19491f0b7a69d6b688390, which adds handling for dropped frames in theora decoding. However, this didn't handle the case where the granule position for the current packet is invalid.

These changes introduce a check on the granule position of the current packet. If the granule position is valid, proceed to properly calculate the frame number and the next frame start time from the granule position. If the granule position is not valid, use best estimation of for these values.

These changes also refactor to combine the checks for the two cases where the granule position is passed to theora functions. The documentation for both of these functions states that they will return -1 in the case that the provided granule position is negative.

## Background

I was trying to play Syberia on ScummVM v2026.2.0, and found it unplayable due to the choppy video playback in the main menu and intro video, which also seemingly affects the UI in the game with high latency.

I found v2026.1.0 worked OK, so did a git bisect to locate the commit which introduced the problem for me as 43c5d3e7c9933fdb8da19491f0b7a69d6b688390.

Through some debugging I could see that `oggPacket.granulepos` was often `-1`, which led to `_curFrame` being reset to `-1` frequently throughout video playback. It seems that the code below for calculating `_nextFrameStartTime` was handling this case, so I applied a similar fix to calling `th_granule_frame`, but switching the condition to be on `oggPacket.granulepos` rather than calling the function and checking if the result is invalid. I think this is a reasonable change, having read the documentation for `th_granule_frame` and `th_granule_time`, but I can change the approach to check the result of the function call rather than its input if that is preferable.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
