### PR TITLE
AGOS: Fix subtitle rendering for Simon II Amiga

### DIFF
--- a/engines/agos/string.cpp
+++ b/engines/agos/string.cpp
@@ -552,7 +552,7 @@ void AGOSEngine::printScreenText(uint vgaSpriteId, uint color, const char *strin
 		stopAnimate(vgaSpriteId + 199);
 	else
 		stopAnimateSimon2(2, vgaSpriteId);
-
+	// Simon II Amiga is built upon the Windows release so should draw subtitles the same way.
 	if (getPlatform() == Common::kPlatformAmiga  && getGameType() != GType_SIMON2) {
 		color = color * 3 + 1;
 		renderStringAmiga(vgaSpriteId, color, width, height, convertedString);

--- a/engines/agos/string.cpp
+++ b/engines/agos/string.cpp
@@ -553,7 +553,7 @@ void AGOSEngine::printScreenText(uint vgaSpriteId, uint color, const char *strin
 	else
 		stopAnimateSimon2(2, vgaSpriteId);
 
-	if (getPlatform() == Common::kPlatformAmiga) {
+	if (getPlatform() == Common::kPlatformAmiga  && getGameType() != GType_SIMON2) {
 		color = color * 3 + 1;
 		renderStringAmiga(vgaSpriteId, color, width, height, convertedString);
 	} else {


### PR DESCRIPTION
This PR fixes subtitle rendering for Simon II Amiga.

The Amiga version of Simon II is built upon the Window release, however my recent PR to add language support for the game caused issues with the subtitles. This was because I had added detection entries for the Amiga version of the game, previously it was detected as the Windows release.

This is a simple change to ensure that the Amiga version of Simon II renders its subtitles the same way it did when it was being detected as the Windows version previously.

Before:
<img width="752" height="620" alt="Screenshot 2026-04-13 at 16 40 04" src="https://github.com/user-attachments/assets/210fe064-e468-42f0-85ad-1929d2081e87" />

After:
<img width="752" height="620" alt="Screenshot 2026-04-13 at 18 38 26" src="https://github.com/user-attachments/assets/093dd05a-9e6a-4455-af1b-e1004e26c5b1" />
