### PR TITLE
TETRAEDGE: disable copy/move in C++11 style for PathNode

### DIFF
--- a/engines/tetraedge/te/micropather.h
+++ b/engines/tetraedge/te/micropather.h
@@ -151,6 +151,12 @@ namespace micropather
 	class PathNode
 	{
 	public:
+		PathNode() = default;
+		PathNode(const PathNode &) = delete;
+		PathNode(PathNode &&) = delete;
+		PathNode &operator=(const PathNode &) = delete;
+		PathNode &operator=(PathNode &&) = delete;
+
 		void Init(	unsigned _frame,
 					void* _state,
 					float _costFromStart,
@@ -209,10 +215,6 @@ namespace micropather
 			else
 				totalCost = FLT_MAX;
 		}
-
-	private:
-
-		void operator=( const PathNode& );
 	};
 
 


### PR DESCRIPTION
Clang believes that an unimplemented private copy assignment operator (C++03 style) makes the class non-trivially copyable.
To squash a compiler warning, the class is modernized to C++11 style explicitly deleted copy and move operations.

```
engines/tetraedge/te/micropather.cpp:500:10: warning: first argument in call to 'memset' is a pointer to non-trivially copyable type 'Tetraedge::micropather::PathNode'
      [-Wnontrivial-memcall]
  500 |         memset( this, 0, sizeof( PathNode ) );
      |                 ^
```