### PR TITLE
AUDIO: do not use memset in constructor, disable copy and move

### DIFF
--- a/audio/softsynth/fmtowns_pc98/towns_pc98_fmsynth.cpp
+++ b/audio/softsynth/fmtowns_pc98/towns_pc98_fmsynth.cpp
@@ -1827,10 +1827,6 @@ const uint8 TownsPC98_FmSynth::_percussionData[] = {
 };
 #endif // DISABLE_PC98_RHYTHM_CHANNEL
 
-TownsPC98_FmSynth::ChanInternal::ChanInternal() {
-	memset(this, 0, sizeof(ChanInternal));
-}
-
 TownsPC98_FmSynth::ChanInternal::~ChanInternal() {
 	for (uint i = 0; i < ARRAYSIZE(opr); ++i)
 		delete opr[i];

--- a/audio/softsynth/fmtowns_pc98/towns_pc98_fmsynth.h
+++ b/audio/softsynth/fmtowns_pc98/towns_pc98_fmsynth.h
@@ -125,7 +125,11 @@ private:
 #endif
 
 	struct ChanInternal {
-		ChanInternal();
+		ChanInternal() = default;
+		ChanInternal(const ChanInternal &) = delete;
+		ChanInternal(ChanInternal &&) = delete;
+		ChanInternal &operator=(const ChanInternal &) = delete;
+		ChanInternal &operator=(ChanInternal &&) = delete;
 		~ChanInternal();
 
 		void ampModSensitivity(uint32 value) {
@@ -138,16 +142,16 @@ private:
 			feedbuf[0] = feedbuf[1] = feedbuf[2] = 0;
 		}
 
-		bool enableLeft;
-		bool enableRight;
-		bool updateEnvelopeParameters;
-		int32 feedbuf[3];
-		uint8 algorithm;
+		bool enableLeft = false;
+		bool enableRight = false;
+		bool updateEnvelopeParameters = false;
+		int32 feedbuf[3] = {};
+		uint8 algorithm = 0u;
 
-		uint32 ampModSvty;
-		uint32 frqModSvty;
+		uint32 ampModSvty = 0u;
+		uint32 frqModSvty = 0u;
 
-		TownsPC98_FmSynthOperator *opr[4];
+		TownsPC98_FmSynthOperator *opr[4] = {};
 	};
 
 	TownsPC98_FmSynthSquareWaveSource *_ssg;


### PR DESCRIPTION
In a case similar to PR #7388, using `memset` in a constructor makes the constructor non-trivial and the struct non-trivially copyable. This triggers a Clang warning about unsafe `memset` usage.
To squash this warning, the `memset`-based constructor is replaced with member initializers.
Furthermore, the struct in question has a non-trivial destructor, so copying and moving are disabled.

```
audio/softsynth/fmtowns_pc98/towns_pc98_fmsynth.cpp:1831:9: warning: first argument in call to 'memset' is a pointer to non-trivially copyable type 'TownsPC98_FmSynth::ChanInternal'
      [-Wnontrivial-memcall]
 1831 |         memset(this, 0, sizeof(ChanInternal));
      |                ^
```