### PR TITLE
VIDEO: Global SRT support [RFC]

### DIFF
--- a/engines/agos/animation.cpp
+++ b/engines/agos/animation.cpp
@@ -260,6 +260,10 @@ bool MoviePlayerDXA::load() {
 	debug(0, "Playing video %s", videoName.toString(Common::Path::kNativeSeparator).c_str());
 
 	CursorMan.showMouse(false);
+
+	Common::String subtitlesName = Common::String::format("%s.srt", baseName);
+	loadSubtitles(subtitlesName.c_str());
+
 	return true;
 }
 
@@ -430,6 +434,9 @@ bool MoviePlayerSMK::load() {
 	debug(0, "Playing video %s", videoName.toString(Common::Path::kNativeSeparator).c_str());
 
 	CursorMan.showMouse(false);
+
+	Common::String subtitlesName = Common::String::format("%s.srt", baseName);
+	loadSubtitles(subtitlesName.c_str());
 
 	return true;
 }

--- a/engines/agos/animation.cpp
+++ b/engines/agos/animation.cpp
@@ -416,12 +416,6 @@ MoviePlayerSMK::MoviePlayerSMK(AGOSEngine_Feeble *vm, const char *name)
 
 	memset(baseName, 0, sizeof(baseName));
 	memcpy(baseName, name, strlen(name));
-
-	int16 h = g_system->getOverlayHeight();
-
-	_subtitles.setBBox(Common::Rect(20, h - 120, g_system->getOverlayWidth() - 20, h - 20));
-	_subtitles.setColor(0xff, 0xff, 0xff);
-	_subtitles.setFont("LiberationSans-Regular.ttf");
 }
 
 bool MoviePlayerSMK::load() {
@@ -436,9 +430,6 @@ bool MoviePlayerSMK::load() {
 	debug(0, "Playing video %s", videoName.toString(Common::Path::kNativeSeparator).c_str());
 
 	CursorMan.showMouse(false);
-
-	Common::String subtitlesName = Common::String::format("%s.srt", baseName);
-	_subtitles.loadSRTFile(subtitlesName.c_str());
 
 	return true;
 }
@@ -466,19 +457,12 @@ void MoviePlayerSMK::copyFrameToBuffer(byte *dst, uint x, uint y, uint pitch) {
 }
 
 void MoviePlayerSMK::playVideo() {
-	if (_subtitles.isLoaded()) {
-		g_system->clearOverlay();
-		g_system->showOverlay(false);
-	}
 	while (!endOfVideo() && !_skipMovie && !_vm->shouldQuit()) {
 		handleNextFrame();
 	}
 }
 
 void MoviePlayerSMK::stopVideo() {
-	if (_subtitles.isLoaded()) {
-		g_system->hideOverlay();
-	}
 	close();
 }
 
@@ -521,8 +505,6 @@ bool MoviePlayerSMK::processFrame() {
 		warning("dropped frame %i", getCurFrame());
 		return false;
 	}
-
-	_subtitles.drawSubtitle(getTime(), false);
 
 	_vm->_system->updateScreen();
 

--- a/engines/kingdom/kingdom.cpp
+++ b/engines/kingdom/kingdom.cpp
@@ -504,6 +504,9 @@ void KingdomGame::playMovie(int movieNum) {
 		decoder->setAudioTrack(_sound);
 		decoder->start();
 
+		Common::String subtitlePath = Common::String::format("%s.srt", path.toString().c_str());
+		decoder->loadSubtitles(subtitlePath.c_str());
+
 		if (_frameStop) {
 			decoder->setEndFrame(_frameStop);
 		}

--- a/engines/phoenixvr/phoenixvr.cpp
+++ b/engines/phoenixvr/phoenixvr.cpp
@@ -544,6 +544,9 @@ void PhoenixVREngine::playMovie(const Common::String &movie) {
 		return;
 	}
 
+	Common::String subtitles = Common::String::format("%s.srt", movie.c_str());
+	dec->loadSubtitles(_currentScriptPath.append(subtitles));
+
 	_mixer->pauseAll(true);
 	_system->lockMouse(false);
 	dec->start();

--- a/engines/sci/engine/kvideo.cpp
+++ b/engines/sci/engine/kvideo.cpp
@@ -197,6 +197,8 @@ reg_t kShowMovie(EngineState *s, int argc, reg_t *argv) {
 				warning("Failed to open movie file %s", filename.c_str());
 				videoDecoder.reset();
 			}
+			Common::String subtitlesName = Common::String::format("%s.srt", filename.c_str());
+			videoDecoder->loadSubtitles(subtitlesName.c_str());
 			syncLastFrame = false;
 			retval = TRUE_REG;
 			break;

--- a/video/subtitles.cpp
+++ b/video/subtitles.cpp
@@ -474,7 +474,7 @@ bool Subtitles::drawSubtitle(uint32 timestamp, bool force, bool showSFX) const {
 }
 
 void Subtitles::clearSubtitle() const {
-	if (!_loaded)
+	if (!_loaded && !_subtitleDev)
 		return;
 
 	g_system->hideOverlay();
@@ -483,7 +483,7 @@ void Subtitles::clearSubtitle() const {
 }
 
 void Subtitles::updateSubtitleOverlay() const {
-	if (!_loaded)
+	if (!_loaded && !_subtitleDev)
 		return;
 
 	if (!shouldShowSubtitle()) {

--- a/video/video_decoder.cpp
+++ b/video/video_decoder.cpp
@@ -56,6 +56,10 @@ VideoDecoder::VideoDecoder() {
 	_subtitles.setFont("LiberationSans-Regular.ttf");
 }
 
+void VideoDecoder::loadSubtitles(const Common::Path &filename) {
+	_subtitles.loadSRTFile(filename);
+}
+
 void VideoDecoder::close() {
 	if (isPlaying())
 		stop();
@@ -93,9 +97,6 @@ bool VideoDecoder::loadFile(const Common::Path &filename) {
 	bool result = loadStream(file);
 	if (!result)
 		delete file;
-
-	Common::String subtitlesName = Common::String::format("%s.srt", filename.toString().c_str());
-	_subtitles.loadSRTFile(subtitlesName.c_str());
 
 	return result;
 }

--- a/video/video_decoder.cpp
+++ b/video/video_decoder.cpp
@@ -48,6 +48,12 @@ VideoDecoder::VideoDecoder() {
 	_canSetDither = true;
 	_canSetDefaultFormat = true;
 	_videoCodecAccuracy = Image::CodecAccuracy::Default;
+
+	int16 h = g_system->getOverlayHeight();
+
+	_subtitles.setBBox(Common::Rect(20, h - 120, g_system->getOverlayWidth() - 20, h - 20));
+	_subtitles.setColor(0xff, 0xff, 0xff);
+	_subtitles.setFont("LiberationSans-Regular.ttf");
 }
 
 void VideoDecoder::close() {
@@ -87,6 +93,10 @@ bool VideoDecoder::loadFile(const Common::Path &filename) {
 	bool result = loadStream(file);
 	if (!result)
 		delete file;
+
+	Common::String subtitlesName = Common::String::format("%s.srt", filename.toString().c_str());
+	_subtitles.loadSRTFile(subtitlesName.c_str());
+
 	return result;
 }
 
@@ -225,6 +235,7 @@ const Graphics::Surface *VideoDecoder::decodeNextFrame() {
 		_palette = _nextVideoTrack->getPalette();
 		_dirtyPalette = true;
 	}
+	_subtitles.drawSubtitle(getTime());
 
 	// Look for the next video track here for the next decode.
 	findNextVideoTrack();
@@ -453,6 +464,7 @@ void VideoDecoder::start() {
 }
 
 void VideoDecoder::stop() {
+	_subtitles.clearSubtitle();
 	if (!isPlaying())
 		return;
 

--- a/video/video_decoder.h
+++ b/video/video_decoder.h
@@ -504,6 +504,10 @@ public:
 	 */
 	uint getAudioTrackCount() const;
 
+	void loadSubtitles(const Common::Path &filename);
+
+	Subtitles &getSubtitles() { return _subtitles; }
+
 protected:
 	/**
 	 * An abstract representation of a track in a movie. Since tracks here are designed

--- a/video/video_decoder.h
+++ b/video/video_decoder.h
@@ -30,6 +30,7 @@
 #include "common/str.h"
 #include "graphics/pixelformat.h"
 #include "image/codec-options.h"
+#include "video/subtitles.h"
 
 namespace Audio {
 class AudioStream;
@@ -1044,6 +1045,8 @@ protected:
 	VideoTrack *_nextVideoTrack;
 
 	Image::CodecAccuracy _videoCodecAccuracy;
+
+	Subtitles _subtitles;
 
 private:
 	uint32 _pauseLevel;


### PR DESCRIPTION
This adds support for SRT subtitles for all shared video formats in `video/`

I have tested this on:
Toonstruck (uses SMK) (NOTE: has better subtitles already, which appears alongside if both them and SRT available)
The Feeble Files (uses DXA)*
King's Quest 6 (Windows, uses AVI)

This change might affect many games, if either subtitles_dev is configured or the game actually have SRT files already
(this is why it is RFC)

*The custom support for The Feeble Files in AGOS engine had to be removed to allow this due to name conflicts, though the end result is functionally equivalent

Special thanks for @sev- @Die4Ever @lephilousophe and @bluegr who made this possible