### PR TITLE
GUI: Make Help dialog optional

### DIFF
--- a/backends/platform/atari/atari.mk
+++ b/backends/platform/atari/atari.mk
@@ -35,7 +35,6 @@ atarilitedist: $(EXECUTABLE)
 	$(CP) $(DIST_FILES_ENGINEDATA) $(DIST_FILES_ENGINEDATA_BIG) ${LITE_DATA}
 
 	# remove unused files
-	$(RM) ${LITE_DATA}/helpdialog.zip
 	$(RM) $(addsuffix .dat, $(addprefix ${LITE_DATA}/, achievements classicmacfonts encoding macgui))
 
 	# rename remaining files still not fitting into the 8+3 limit (this has to be supported by the backend, too)
@@ -66,7 +65,6 @@ atarifulldist: $(EXECUTABLE)
 	$(CP) $(DIST_FILES_ENGINEDATA) $(DIST_FILES_ENGINEDATA_BIG) ${FULL_DATA}
 
 	# remove unused files
-	$(RM) ${FULL_DATA}/helpdialog.zip
 	$(RM) $(addsuffix .dat, $(addprefix ${FULL_DATA}/, achievements classicmacfonts encoding hadesch_translations macgui prince_translation))
 
 	# rename remaining files still not fitting into the 8+3 limit (this has to be supported by the backend, too)
@@ -111,7 +109,6 @@ fbdist: $(EXECUTABLE)
 	$(CP) $(DIST_FILES_ENGINEDATA) $(DIST_FILES_ENGINEDATA_BIG) ${FB_DATA}
 
 	# remove unused files
-	$(RM) ${FB_DATA}/helpdialog.zip
 	$(RM) $(addsuffix .dat, $(addprefix ${FB_DATA}/, achievements classicmacfonts encoding hadesch_translations macgui prince_translation))
 
 	$(MKDIR) ${FB_THEMES}

--- a/configure
+++ b/configure
@@ -217,6 +217,7 @@ _enable_asan=no
 _enable_tsan=no
 _enable_ubsan=no
 _bink=yes
+_helpdialog=yes
 _cloud=auto
 _dlc=no
 _scummvmdlc=no
@@ -320,6 +321,7 @@ add_feature 16bit "16bit color" "_16bit"
 add_feature 3d "3D rendering" "_3d"
 add_feature bink "Bink" "_bink"
 add_feature cloud "cloud" "_cloud"
+add_feature helpdialog "Help dialog" "_helpdialog"
 add_feature faad "libfaad" "_faad"
 add_feature flac "FLAC" "_flac"
 add_feature fribidi "FriBidi" "_fribidi"
@@ -1358,6 +1360,8 @@ for ac_option in $@; do
 	--disable-enet)               _enet=no               ;;
 	--enable-cloud)               _cloud=yes             ;;
 	--disable-cloud)              _cloud=no              ;;
+	--enable-helpdialog)          _helpdialog=yes        ;;
+	--disable-helpdialog)         _helpdialog=no         ;;
 	--enable-dlc)                 _dlc=yes               ;;
 	--disable-dlc)                _dlc=no                ;;
 	--enable-scummvmdlc)          _scummvmdlc=yes        ;;
@@ -7393,6 +7397,8 @@ else
 	echo "no"
 fi
 define_in_config_if_yes $_cloud 'USE_CLOUD'
+
+define_in_config_if_yes $_helpdialog 'USE_HELPDIALOG'
 
 echo_n "Building local web server... "
 echo "$_sdlnet"

--- a/configure
+++ b/configure
@@ -4251,6 +4251,7 @@ case $_backend in
 		_libmpcdec=no
 		_build_scalers=no
 		_build_aspect=no
+		_helpdialog=no
 		;;
 	dc)
 		append_var INCLUDES '-I$(srcdir)/backends/platform/dc'

--- a/devtools/create_project/create_project.cpp
+++ b/devtools/create_project/create_project.cpp
@@ -1225,6 +1225,7 @@ const Feature s_features[] = {
 	{               "http",                      "USE_HTTP", false, true,  "HTTP client support" },
 	{          "basic-net",                 "USE_BASIC_NET", false, true,  "Basic network support" },
 	{              "cloud",                     "USE_CLOUD", false, true,  "Cloud integration support" },
+	{         "helpdialog",                "USE_HELPDIALOG", false, true,  "Help dialog support" },
 	{               "enet",                      "USE_ENET", false, true,  "ENet networking support" },
 	{        "translation",               "USE_TRANSLATION", false, true,  "Translation support" },
 	{             "vkeybd",                 "ENABLE_VKEYBD", false, false, "Virtual keyboard support"},

--- a/dists/engine-data/engine_data_core.mk
+++ b/dists/engine-data/engine_data_core.mk
@@ -1,5 +1,7 @@
 DIST_FILES_LIST += dists/engine-data/achievements.dat
 DIST_FILES_LIST += dists/engine-data/classicmacfonts.dat
 DIST_FILES_LIST += dists/engine-data/encoding.dat
+ifdef USE_HELPDIALOG
 DIST_FILES_LIST += dists/engine-data/helpdialog.zip
+endif
 DIST_FILES_LIST += dists/engine-data/macgui.dat

--- a/engines/dialogs.cpp
+++ b/engines/dialogs.cpp
@@ -29,7 +29,9 @@
 
 #include "gui/about.h"
 #include "gui/gui-manager.h"
+#ifdef USE_HELPDIALOG
 #include "gui/helpdialog.h"
+#endif
 #include "gui/message.h"
 #include "gui/options.h"
 #include "gui/saveload.h"
@@ -80,7 +82,9 @@ MainMenuDialog::MainMenuDialog(Engine *engine)
 	_helpButton->setVisible(_engine->hasFeature(Engine::kSupportsHelp));
 	_helpButton->setEnabled(_engine->hasFeature(Engine::kSupportsHelp));
 
+#ifdef USE_HELPDIALOG
 	new GUI::ButtonWidget(this, "GlobalMenu.MainHelp", _("~H~elp"), Common::U32String(), kMainHelpCmd);
+#endif
 
 	new GUI::ButtonWidget(this, "GlobalMenu.About", _("~A~bout"), Common::U32String(), kAboutCmd);
 
@@ -131,11 +135,13 @@ void MainMenuDialog::handleCommand(GUI::CommandSender *sender, uint32 cmd, uint3
 		dialog.runModal();
 		}
 		break;
+#ifdef USE_HELPDIALOG
 	case kMainHelpCmd: {
 		GUI::HelpDialog dlg;
 		dlg.runModal();
 		}
 		break;
+#endif
 	case kLauncherCmd: {
 		Common::Event eventReturnToLauncher;
 		eventReturnToLauncher.type = Common::EVENT_RETURN_TO_LAUNCHER;

--- a/gui/browser.cpp
+++ b/gui/browser.cpp
@@ -20,7 +20,9 @@
  */
 
 #include "gui/browser.h"
+#ifdef USE_HELPDIALOG
 #include "gui/helpdialog.h"
+#endif
 #include "gui/gui-manager.h"
 #include "gui/widgets/edittext.h"
 #include "gui/widgets/list.h"
@@ -61,7 +63,9 @@ BrowserDialog::BrowserDialog(const Common::U32String &title, bool dirBrowser)
 
 	// Headline - TODO: should be customizable during creation time
 	new StaticTextWidget(this, "Browser.Headline", title);
+#ifdef USE_HELPDIALOG
 	new ButtonWidget(this, "Browser.Help", _("Help"), Common::U32String(), kHelpCmd);
+#endif
 
 	// Current path - TODO: handle long paths ?
 	_currentPath = new EditTextWidget(this, "Browser.Path", Common::U32String(), Common::U32String(), 0, kPathEditedCmd);
@@ -125,11 +129,13 @@ void BrowserDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 data
 		_node = Common::FSNode(Common::Path(Common::convertFromU32String(_currentPath->getEditString()), Common::Path::kNativeSeparator));
 		updateListing();
 		break;
+#ifdef USE_HELPDIALOG
 	case kHelpCmd: {
 		GUI::HelpDialog dlg;
 		dlg.runModal();
 		}
 		break;
+#endif
 	//Search by text input
 	case kChooseCmd:
 		if (_isDirBrowser) {

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -37,7 +37,9 @@
 #include "gui/widget.h"
 
 #include "graphics/cursorman.h"
+#ifdef USE_HELPDIALOG
 #include "graphics/macgui/macwindowmanager.h"
+#endif
 
 namespace Common {
 DECLARE_SINGLETON(GUI::GuiManager);
@@ -102,7 +104,9 @@ GuiManager::GuiManager() : CommandSender(nullptr), _redrawStatus(kRedrawDisabled
 
 GuiManager::~GuiManager() {
 	delete _theme;
+#ifdef USE_HELPDIALOG
 	delete _wm;
+#endif
 }
 
 void GuiManager::initIconsSet() {
@@ -962,6 +966,7 @@ void GuiManager::initTextToSpeech() {
 	ttsMan->setVoice(voice);
 }
 
+#ifdef USE_HELPDIALOG
 Graphics::MacWindowManager *GuiManager::getWM() {
 	if (_wm)
 		return _wm;
@@ -977,6 +982,7 @@ Graphics::MacWindowManager *GuiManager::getWM() {
 
 	return _wm;
 }
+#endif
 
 void GuiManager::emptyTrash(Dialog *const activeDialog) {
 	Common::List<GuiObjectTrashItem>::iterator it = _guiObjectTrash.begin();

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -37,7 +37,9 @@ class OSystem;
 
 namespace Graphics {
 class Font;
+#ifdef USE_HELPDIALOG
 class MacWindowManager;
+#endif
 }
 
 namespace Common {
@@ -154,7 +156,9 @@ public:
 
 	void displayTopDialogOnly(bool mode);
 
+#ifdef USE_HELPDIALOG
 	Graphics::MacWindowManager *getWM();
+#endif
 
 	// Defined in printing-dialog.cpp
 	void printImage(const Graphics::ManagedSurface &surf, bool defaultFitToPage, bool defaultCenter, PageOrientation defaultOrientation);
@@ -192,7 +196,9 @@ protected:
 	Common::SearchSet _iconsSet;
 	bool _iconsSetChanged;
 
+#ifdef USE_HELPDIALOG
 	Graphics::MacWindowManager *_wm = nullptr;
+#endif
 
 	// position and time of last mouse click (used to detect double clicks)
 	struct MousePos {

--- a/gui/launcher.cpp
+++ b/gui/launcher.cpp
@@ -33,7 +33,9 @@
 #include "gui/chooser.h"
 #include "gui/dlcsdialog.h"
 #include "gui/editgamedialog.h"
+#ifdef USE_HELPDIALOG
 #include "gui/helpdialog.h"
+#endif
 #include "gui/launcher.h"
 #include "gui/massadd.h"
 #include "gui/message.h"
@@ -262,7 +264,9 @@ void LauncherDialog::build() {
 #endif
 		new StaticTextWidget(this, _title + ".Version", Common::U32String(gScummVMFullVersion));
 
+#ifdef USE_HELPDIALOG
 	new ButtonWidget(this, _title + ".HelpButton", Common::U32String("?"), _("Click here to see Help"), kHelpCmd);
+#endif
 
 	if (!g_system->hasFeature(OSystem::kFeatureNoQuit)) {
 		// I18N: Button Quit ScummVM program. Q is the shortcut, Ctrl+Q, put it in parens for non-latin (~Q~)
@@ -272,9 +276,11 @@ void LauncherDialog::build() {
 	// I18N: Button About ScummVM program. b is the shortcut, Ctrl+b, put it in parens for non-latin (~b~)
 	new ButtonWidget(this, _title + ".AboutButton", _("A~b~out"), _("About ScummVM"), kAboutCmd);
 
+#ifdef USE_HELPDIALOG
 	_mainHelpButton = nullptr;
 	if (g_gui.xmlEval()->getVar("Globals.Launcher.ShowMainHelp") == 1)
 		_mainHelpButton = new ButtonWidget(this, _title + ".MainHelpButton", _("Help"), _("General help"), kHelpCmd);
+#endif
 
 	// I18N: Button caption. O is the shortcut, Ctrl+O, put it in parens for non-latin (~O~)
 	new ButtonWidget(this, _title + ".OptionsButton", _("Global ~O~ptions..."), _("Change global ScummVM options"), kOptionsCmd, 0, _c("Global ~O~pts...", "lowres"));
@@ -855,11 +861,13 @@ void LauncherDialog::handleCommand(CommandSender *sender, uint32 cmd, uint32 dat
 		setResult(-1);
 		close();
 		break;
+#ifdef USE_HELPDIALOG
 	case kHelpCmd: {
 		HelpDialog dlg;
 		dlg.runModal();
 		}
 		break;
+#endif
 #ifndef DISABLE_LAUNCHERDISPLAY_GRID
 	case kGridSwitchCmd:
 		setResult(kSwitchLauncherDialog);
@@ -954,6 +962,7 @@ void LauncherDialog::reflowLayout() {
 	_searchClearButton = addClearButton(this, _title + ".SearchClearButton", kSearchClearCmd);
 #endif
 
+#ifdef USE_HELPDIALOG
 	if (g_gui.xmlEval()->getVar("Globals.Launcher.ShowMainHelp") == 1) {
 		if (!_mainHelpButton)
 			_mainHelpButton = new ButtonWidget(this, _title + ".MainHelpButton", _("Help"), _("General help"), kHelpCmd);
@@ -964,6 +973,7 @@ void LauncherDialog::reflowLayout() {
 			_mainHelpButton = nullptr;
 		}
 	}
+#endif
 
 #ifndef DISABLE_LAUNCHERDISPLAY_GRID
 	addLayoutChooserButtons();

--- a/gui/launcher.h
+++ b/gui/launcher.h
@@ -137,7 +137,9 @@ protected:
 	Widget			*_startButton;
 	ButtonWidget	*_loadButton;
 	Widget			*_editButton;
+#ifdef USE_HELPDIALOG
 	Widget			*_mainHelpButton;
+#endif
 	Common::StringArray		_domains;
 	BrowserDialog	*_browser;
 	SaveLoadChooser	*_loadDialog;

--- a/gui/module.mk
+++ b/gui/module.mk
@@ -13,7 +13,6 @@ MODULE_OBJS := \
 	EventRecorder.o \
 	filebrowser-dialog.o \
 	gui-manager.o \
-	helpdialog.o \
 	imagealbum-dialog.o \
 	launcher.o \
 	massadd.o \
@@ -44,10 +43,15 @@ MODULE_OBJS := \
 	widgets/groupedlist.o \
 	widgets/list.o \
 	widgets/popup.o \
-	widgets/richtext.o \
 	widgets/scrollbar.o \
 	widgets/scrollcontainer.o \
 	widgets/tab.o
+
+ifdef USE_HELPDIALOG
+MODULE_OBJS += \
+	helpdialog.o \
+	widgets/richtext.o
+endif
 
 ifdef USE_CLOUD
 MODULE_OBJS += \

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -76,7 +76,9 @@ enum {
 	kGraphicsWidget		= 'GFXW',
 	kContainerWidget	= 'CTNR',
 	kScrollContainerWidget = 'SCTR',
+#ifdef USE_HELPDIALOG
 	kRichTextWidget		= 'RTXT',
+#endif
 	kEEWidget			= 'EEGG',
 };
 


### PR DESCRIPTION
On Atari, there is only the General tab and even that is empty, perhaps due to missing freetype library. So this change makes it less confusing for the users.

Ideally if there was a mechanism to create not only features/components but also users of such features/components. So I'd take a few files and an `ifdef`, label them as a module which depends on e.g. `_16bit _freetype2`, that would be really great. Until then, I hope this is acceptable, too.