### PR TITLE
BOLT: Add detection entries for additional Funhouse games

### DIFF
--- a/engines/bolt/detection.h
+++ b/engines/bolt/detection.h
@@ -44,11 +44,11 @@ public:
 	}
 
 	const char *getEngineName() const override {
-		return "Cartoon Carnival";
+		return "BOLT";
 	}
 
 	const char *getOriginalCopyright() const override {
-		return "Hanna-Barbera's Cartoon Carnival (C) 1993-1995 Funhouse Design";
+		return "(C) 1993-1995 Philips Interactive Media";
 	}
 };
 

--- a/engines/bolt/detection_tables.h
+++ b/engines/bolt/detection_tables.h
@@ -23,6 +23,8 @@ namespace Bolt {
 
 const PlainGameDescriptor boltGames[] = {
 	{ "carnival", "Cartoon Carnival" },
+	{ "crete", "Labyrinth of Crete" },
+	{ "merlin", "Merlin's Apprentice" },
 	{ 0, 0 }
 };
 
@@ -65,6 +67,30 @@ const ADGameDescription gameDescriptions[] = {
 		Common::kPlatformWindows,
 		ADGF_UNSTABLE | ADGF_DEMO,
 		GUIO1(GAMEOPTION_EXTEND_SCREEN)
+	},
+	
+	{
+		"crete",
+		 nullptr,
+		 AD_ENTRY1s("BOLTLIB.BLT", "65ca78c913539abe0db5c3e255c6727c", 11724174),
+		 Common::EN_ANY,
+		 // Games were released for Win and Mac on the same CD-ROM. There are no
+		 // notable differences between the Win and Mac versions.
+		 Common::kPlatformWindows,
+		 ADGF_UNSTABLE,
+		 GUIO0()
+	},
+
+	{
+		"merlin",
+		 nullptr,
+		 // FIXME: ScummVM will not detect BOLTLIB.BLT until you uncheck its
+		 // "Hidden" property with Explorer.
+		 AD_ENTRY1s("BOLTLIB.BLT", "58ef3e35e1f6369056272a30c67bb94d", 10452486),
+		 Common::EN_ANY,
+		 Common::kPlatformWindows,
+		 ADGF_UNSTABLE,
+		 GUIO0()
 	},
 
 	AD_TABLE_END_MARKER


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->

This PR begins porting my old scummvm-funhouse work to the newer BOLT engine. Detection entries for Merlin's Apprentice and Labyrinth of Crete are added.

Merlin's Apprentice and Labyrinth of Crete are currently unplayable.

As discussed on Discord, the Funhouse game Cartoon Carnival uses a similar codebase to Merlin's Apprentice and Labyrinth of Crete.

My old scummvm-funhouse project can be found at:
Branch `scummvm-funhouse-old-260415` at https://github.com/beholdnec/scummvm-funhouse
It is mostly complete but lacks testing and polish.