### PR TITLE
AD: Skip detection for engines with no matching filenames

### DIFF
--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -718,6 +718,20 @@ ADDetectedGames AdvancedMetaEngineDetectionBase::detectGame(const Common::FSNode
 
 	preprocessDescriptions();
 
+	// Early rejection: if none of the file names referenced by this engine's
+	// detection entries exist in the game folder, there is no chance of a match.
+	bool anyFileFound = false;
+	for (auto it = allFiles.begin(); it != allFiles.end(); ++it) {
+		if (_fileNamesMap.contains(it->_key)) {
+			anyFileFound = true;
+			break;
+		}
+	}
+	if (!anyFileFound) {
+		debugC(3, kDebugGlobalDetection, "Skipping engine '%s': no matching file names in directory", getName());
+		return matched;
+	}
+
 	// Check which files are included in some ADGameDescription *and* whether
 	// they are present. Compute MD5s and file sizes for the available files.
 	for (descPtr = _gameDescriptors; ((const ADGameDescription *)descPtr)->gameId != nullptr; descPtr += _descItemSize) {
@@ -1003,6 +1017,27 @@ void AdvancedMetaEngineDetectionBase::preprocessDescriptions() {
 	// Now scan all detection entries
 	for (const byte *descPtr = _gameDescriptors; ((const ADGameDescription *)descPtr)->gameId != nullptr; descPtr += _descItemSize) {
 		const ADGameDescription *g = (const ADGameDescription *)descPtr;
+
+		// Collect all unique file names for early rejection
+		for (const ADGameFileDescription *fileDesc = g->filesDescriptions; fileDesc->fileName; fileDesc++) {
+			Common::String fname = fileDesc->fileName;
+
+			// For archive entries, extract the archive name
+			if (gameFileToMD5Props(fileDesc, g->flags) & kMD5Archive) {
+				Common::StringTokenizer tok(fname, ":");
+				tok.nextToken(); // skip archive type
+				fname = tok.nextToken(); // archive name
+			}
+
+			// For paths with directory components, extract the leaf filename
+			// unless kADFlagMatchFullPaths is set
+			if (!(_flags & kADFlagMatchFullPaths) && fname.contains('/')) {
+				fname = Common::Path(fname).baseName();
+			}
+
+			_fileNamesMap.setVal(Common::Path(fname, fname.contains('/')
+				? '/' : Common::Path::kNoSeparator), true);
+		}
 
 		// Scan for potential directory globs
 		for (const ADGameFileDescription *fileDesc = g->filesDescriptions; fileDesc->fileName; fileDesc++) {

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -554,6 +554,7 @@ private:
 private:
 	Common::HashMap<Common::String, bool, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> _grayListMap;
 	Common::HashMap<Common::String, bool, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> _globsMap;
+	Common::HashMap<Common::Path, bool, Common::Path::IgnoreCase_Hash, Common::Path::IgnoreCase_EqualTo> _fileNamesMap;
 	bool _hashMapsInited;
 
 protected:


### PR DESCRIPTION
When adding a game, every engine's detection table is traversed twice (once for MD5 pre-computation, once for matching) even if the game folder contains none of the files that engine cares about.

Build a set of all unique filenames referenced by each engine's detection entries during preprocessDescriptions() (called once and cached). Before entering the expensive detection loops, check if any file in the game folder exists in this set. If not, skip the engine entirely.

On the Atari backend with ~60 statically linked engines, this reduces the "Add game" time by about 30-40%.
