### PR TITLE
AGOS: Fix window height for Amiga PN intro

### DIFF
--- a/engines/agos/pn.cpp
+++ b/engines/agos/pn.cpp
@@ -171,6 +171,9 @@ void AGOSEngine_PN::demoSeq() {
 }
 
 void AGOSEngine_PN::introSeq() {
+	if (isPnAmiga())
+		_videoWindows[15] = 200;
+
 	loadZone(25); // Zone 'I'
 	setWindowImage(3, 0);
 
@@ -191,6 +194,9 @@ void AGOSEngine_PN::introSeq() {
 		processSpecialKeys();
 		delay(1);
 	}
+
+	if (isPnAmiga())
+		_videoWindows[15] = 240;
 }
 
 void AGOSEngine_PN::setupBoxes() {


### PR DESCRIPTION
This PR fixes an issue introduced by the recent change to the rendering for the Amiga version of PN. It now forces the window height to 200 for the intro, then restores to 240 afterwards.

Screenshot before:
<img width="828" height="621" alt="Screenshot 2026-04-17 at 23 46 20" src="https://github.com/user-attachments/assets/0137f0b6-72e4-42e1-b250-798fe54b8c13" />

Screenshot after:
<img width="828" height="621" alt="Screenshot 2026-04-17 at 23 44 51" src="https://github.com/user-attachments/assets/c361f2ae-3e9d-4290-8cf1-af01632fe41f" />
