### PR TITLE
AGOS: Implement day/night palette fading for PN Amiga/Atari ST

### DIFF
--- a/engines/agos/agos.cpp
+++ b/engines/agos/agos.cpp
@@ -517,11 +517,9 @@ AGOSEngine::AGOSEngine(OSystem *system, const AGOSGameDescription *gd)
 	memset(_displayPalette, 0, sizeof(_displayPalette));
 	memset(_pnPaletteBanks, 0, sizeof(_pnPaletteBanks));
 	memset(_pnFadeCurrent, 0, sizeof(_pnFadeCurrent));
-	memset(_pnFadeTarget, 0, sizeof(_pnFadeTarget));
 	memset(_pnHavePaletteBank, 0, sizeof(_pnHavePaletteBank));
-	_pnDesiredPaletteBank = 0;
-	_pnDayNightControllerLastStage = 0xFF;
 	_pnDayNightControllerSelectorMask = 0xFFFF;
+	_pnDayNightControllerLastStage = 0xFF;
 	_pnLastClockMinutes = -1;
 	_pnDayNightControllerTickCounter = 0x00C8;
 

--- a/engines/agos/agos.cpp
+++ b/engines/agos/agos.cpp
@@ -523,7 +523,6 @@ AGOSEngine::AGOSEngine(OSystem *system, const AGOSGameDescription *gd)
 	_pnDayNightControllerLastStage = 0xFF;
 	_pnDayNightControllerSelectorMask = 0xFFFF;
 	_pnLastClockMinutes = -1;
-	_pnDayNightControllerActive = false;
 	_pnDayNightControllerTickCounter = 0x00C8;
 
 	memset(_videoBuf1, 0, sizeof(_videoBuf1));

--- a/engines/agos/agos.cpp
+++ b/engines/agos/agos.cpp
@@ -516,22 +516,14 @@ AGOSEngine::AGOSEngine(OSystem *system, const AGOSGameDescription *gd)
 	memset(_currentPalette, 0, sizeof(_currentPalette));
 	memset(_displayPalette, 0, sizeof(_displayPalette));
 	memset(_pnPaletteBanks, 0, sizeof(_pnPaletteBanks));
-	memset(_pnFadeSource, 0, sizeof(_pnFadeSource));
 	memset(_pnFadeCurrent, 0, sizeof(_pnFadeCurrent));
 	memset(_pnFadeTarget, 0, sizeof(_pnFadeTarget));
 	memset(_pnHavePaletteBank, 0, sizeof(_pnHavePaletteBank));
-	_pnPendingPaletteBank = 0;
 	_pnDesiredPaletteBank = 0;
-	_pnFadeTickDelay = 1;
-	_pnFadeTickCounter = 0;
-	_pnFadeStage = 0;
 	_pnDayNightControllerLastStage = 0xFF;
 	_pnDayNightControllerSelectorMask = 0xFFFF;
-	_pnFadeAdvancePending = false;
 	_pnLastClockMinutes = -1;
-	_pnFadeActive = false;
 	_pnDayNightControllerActive = false;
-	_pnDayNightControllerTickDelay = 0x00C8;
 	_pnDayNightControllerTickCounter = 0x00C8;
 
 	memset(_videoBuf1, 0, sizeof(_videoBuf1));

--- a/engines/agos/agos.cpp
+++ b/engines/agos/agos.cpp
@@ -520,7 +520,6 @@ AGOSEngine::AGOSEngine(OSystem *system, const AGOSGameDescription *gd)
 	memset(_pnFadeCurrent, 0, sizeof(_pnFadeCurrent));
 	memset(_pnFadeTarget, 0, sizeof(_pnFadeTarget));
 	memset(_pnHavePaletteBank, 0, sizeof(_pnHavePaletteBank));
-	_pnActivePaletteBank = 0;
 	_pnPendingPaletteBank = 0;
 	_pnDesiredPaletteBank = 0;
 	_pnFadeTickDelay = 1;

--- a/engines/agos/agos.cpp
+++ b/engines/agos/agos.cpp
@@ -515,6 +515,25 @@ AGOSEngine::AGOSEngine(OSystem *system, const AGOSGameDescription *gd)
 
 	memset(_currentPalette, 0, sizeof(_currentPalette));
 	memset(_displayPalette, 0, sizeof(_displayPalette));
+	memset(_pnPaletteBanks, 0, sizeof(_pnPaletteBanks));
+	memset(_pnFadeSource, 0, sizeof(_pnFadeSource));
+	memset(_pnFadeCurrent, 0, sizeof(_pnFadeCurrent));
+	memset(_pnFadeTarget, 0, sizeof(_pnFadeTarget));
+	memset(_pnHavePaletteBank, 0, sizeof(_pnHavePaletteBank));
+	_pnActivePaletteBank = 0;
+	_pnPendingPaletteBank = 0;
+	_pnDesiredPaletteBank = 0;
+	_pnFadeTickDelay = 1;
+	_pnFadeTickCounter = 0;
+	_pnFadeStage = 0;
+	_pnDayNightControllerLastStage = 0xFF;
+	_pnDayNightControllerSelectorMask = 0xFFFF;
+	_pnFadeAdvancePending = false;
+	_pnLastClockMinutes = -1;
+	_pnFadeActive = false;
+	_pnDayNightControllerActive = false;
+	_pnDayNightControllerTickDelay = 0x00C8;
+	_pnDayNightControllerTickCounter = 0x00C8;
 
 	memset(_videoBuf1, 0, sizeof(_videoBuf1));
 	memset(_videoWindows, 0, sizeof(_videoWindows));

--- a/engines/agos/agos.h
+++ b/engines/agos/agos.h
@@ -629,7 +629,6 @@ protected:
 	uint16 _pnFadeSource[16];
 	uint16 _pnFadeCurrent[16];
 	uint16 _pnFadeTarget[16];
-	uint8 _pnActivePaletteBank;
 	uint8 _pnPendingPaletteBank;
 	uint8 _pnDesiredPaletteBank;
 	uint8 _pnFadeTickDelay;

--- a/engines/agos/agos.h
+++ b/engines/agos/agos.h
@@ -634,7 +634,6 @@ protected:
 	uint16 _pnDayNightControllerSelectorMask;
 	int16 _pnLastClockMinutes;
 	bool _pnHavePaletteBank[2];
-	bool _pnDayNightControllerActive;
 	uint16 _pnDayNightControllerTickCounter;
 	byte *_planarBuf;
 	byte _videoBuf1[32000];

--- a/engines/agos/agos.h
+++ b/engines/agos/agos.h
@@ -628,10 +628,8 @@ protected:
 
 	uint16 _pnPaletteBanks[2][16];
 	uint16 _pnFadeCurrent[16];
-	uint16 _pnFadeTarget[16];
-	uint8 _pnDesiredPaletteBank;
-	uint8 _pnDayNightControllerLastStage;
 	uint16 _pnDayNightControllerSelectorMask;
+	uint8 _pnDayNightControllerLastStage;
 	int16 _pnLastClockMinutes;
 	bool _pnHavePaletteBank[2];
 	uint16 _pnDayNightControllerTickCounter;
@@ -1315,15 +1313,14 @@ protected:
 	void setPaletteSlot(uint16 srcOffs, uint8 dstOffs);
 	bool isPNDayNightPaletteMode() const;
 	uint8 getPNDesiredPaletteBank() const;
-	void syncPNDesiredPaletteBank();
 	void notePNClockValueChange();
 	void resetPNRoomPaletteState();
 	void buildPNPaletteTarget(uint16 selectorMask, uint16 *target) const;
 	uint16 blendPNPaletteColor(uint16 source, uint16 target, uint8 steps) const;
 	uint8 getPNDayNightControllerStage() const;
 	void startPNDayNightController(uint16 selectorMask);
-	void updatePNDayNightController();
-	void applyPNDayNightPalette(const uint16 *palette, bool updateBackend);
+	void updatePNDayNightController(uint16 selectorMask);
+	void applyPNDayNightPalette(const uint16 *palette);
 	void checkOnStopTable();
 	void checkWaitEndTable();
 

--- a/engines/agos/agos.h
+++ b/engines/agos/agos.h
@@ -625,6 +625,25 @@ protected:
 	uint8 _simon2LanguageFlagTimer;
 	bool _simon2LanguageFlagClearPending;
 
+	uint16 _pnPaletteBanks[2][16];
+	uint16 _pnFadeSource[16];
+	uint16 _pnFadeCurrent[16];
+	uint16 _pnFadeTarget[16];
+	uint8 _pnActivePaletteBank;
+	uint8 _pnPendingPaletteBank;
+	uint8 _pnDesiredPaletteBank;
+	uint8 _pnFadeTickDelay;
+	uint8 _pnFadeTickCounter;
+	uint8 _pnFadeStage;
+	uint8 _pnDayNightControllerLastStage;
+	uint16 _pnDayNightControllerSelectorMask;
+	bool _pnFadeAdvancePending;
+	int16 _pnLastClockMinutes;
+	bool _pnHavePaletteBank[2];
+	bool _pnFadeActive;
+	bool _pnDayNightControllerActive;
+	uint16 _pnDayNightControllerTickDelay;
+	uint16 _pnDayNightControllerTickCounter;
 	byte *_planarBuf;
 	byte _videoBuf1[32000];
 	uint16 _videoWindows[128];
@@ -1303,6 +1322,18 @@ protected:
 	void clearVideoBackGround(uint16 windowNum, uint16 color);
 
 	void setPaletteSlot(uint16 srcOffs, uint8 dstOffs);
+	bool isPNDayNightPaletteMode() const;
+	uint8 getPNDesiredPaletteBank() const;
+	void syncPNDesiredPaletteBank();
+	void notePNClockValueChange();
+	void resetPNRoomPaletteState();
+	void buildPNPaletteTarget(uint16 selectorMask, uint16 *target) const;
+	uint16 blendPNPaletteColor(uint16 source, uint16 target, uint8 steps) const;
+	uint8 getPNDayNightControllerStage() const;
+	void updatePNDayNightController();
+	void applyPNDayNightPalette(const uint16 *palette, bool updateBackend);
+	void startPNPaletteFade(uint16 selectorMask, int16 fadeMode, bool animate);
+	void stepPNPaletteFade();
 	void checkOnStopTable();
 	void checkWaitEndTable();
 
@@ -1677,6 +1708,9 @@ protected:
 	void addChar(uint8 chr);
 	void clearCursor(WindowBlock *window);
 	void clearInputLine();
+	bool tryHandleDebugTimeCommand();
+	bool tryParseDebugTimeCommand(const char *typed, uint16 &hour, uint16 &minute) const;
+	void setDebugTime(uint16 hour, uint16 minute);
 	void handleKeyboard();
 	void handleMouseMoved() override;
 	void interact(char *buffer, uint8 size);

--- a/engines/agos/agos.h
+++ b/engines/agos/agos.h
@@ -220,7 +220,8 @@ enum EventType {
 	ANIMATE_EVENT = 1 << 2,
 	SCROLL_EVENT  = 1 << 3,
 	PLAYER_DAMAGE_EVENT = 1 << 4,
-	MONSTER_DAMAGE_EVENT = 1 << 5
+	MONSTER_DAMAGE_EVENT = 1 << 5,
+	PN_FADE_EVENT = 1 << 6
 };
 
 struct GameSpecificSettings;
@@ -1346,6 +1347,8 @@ protected:
 	void addVgaEvent(uint16 num, uint8 type, const byte *codePtr, uint16 curSprite, uint16 curZoneNum);
 	void deleteVgaEvent(VgaTimerEntry * vte);
 	void processVgaEvents();
+	void schedulePNFadeEvent();
+	void removePNFadeEvent();
 	void animateEvent(const byte *codePtr, uint16 curZoneNum, uint16 curSprite);
 	void scrollEvent();
 	void drawStuff(const byte *src, uint offs);

--- a/engines/agos/agos.h
+++ b/engines/agos/agos.h
@@ -627,22 +627,14 @@ protected:
 	bool _simon2LanguageFlagClearPending;
 
 	uint16 _pnPaletteBanks[2][16];
-	uint16 _pnFadeSource[16];
 	uint16 _pnFadeCurrent[16];
 	uint16 _pnFadeTarget[16];
-	uint8 _pnPendingPaletteBank;
 	uint8 _pnDesiredPaletteBank;
-	uint8 _pnFadeTickDelay;
-	uint8 _pnFadeTickCounter;
-	uint8 _pnFadeStage;
 	uint8 _pnDayNightControllerLastStage;
 	uint16 _pnDayNightControllerSelectorMask;
-	bool _pnFadeAdvancePending;
 	int16 _pnLastClockMinutes;
 	bool _pnHavePaletteBank[2];
-	bool _pnFadeActive;
 	bool _pnDayNightControllerActive;
-	uint16 _pnDayNightControllerTickDelay;
 	uint16 _pnDayNightControllerTickCounter;
 	byte *_planarBuf;
 	byte _videoBuf1[32000];
@@ -1330,10 +1322,9 @@ protected:
 	void buildPNPaletteTarget(uint16 selectorMask, uint16 *target) const;
 	uint16 blendPNPaletteColor(uint16 source, uint16 target, uint8 steps) const;
 	uint8 getPNDayNightControllerStage() const;
+	void startPNDayNightController(uint16 selectorMask);
 	void updatePNDayNightController();
 	void applyPNDayNightPalette(const uint16 *palette, bool updateBackend);
-	void startPNPaletteFade(uint16 selectorMask, int16 fadeMode, bool animate);
-	void stepPNPaletteFade();
 	void checkOnStopTable();
 	void checkWaitEndTable();
 

--- a/engines/agos/debugger.cpp
+++ b/engines/agos/debugger.cpp
@@ -45,6 +45,15 @@ Debugger::Debugger(AGOSEngine *vm)
 	registerCmd("dumpimage",      WRAP_METHOD(Debugger, Cmd_dumpImage));
 	registerCmd("dumpscript",     WRAP_METHOD(Debugger, Cmd_dumpScript));
 
+	if (_vm->getGameType() == GType_PN) {
+		registerCmd("gettime",      WRAP_METHOD(Debugger, Cmd_GetTime));
+
+		if (_vm->getPlatform() == Common::kPlatformAmiga || _vm->getPlatform() == Common::kPlatformAtariST) {
+			registerCmd("startday",   WRAP_METHOD(Debugger, Cmd_StartDay));
+			registerCmd("startnight", WRAP_METHOD(Debugger, Cmd_StartNight));
+		}
+	}
+
 }
 
 bool Debugger::Cmd_PlayMusic(int argc, const char **argv) {
@@ -263,6 +272,27 @@ bool Debugger::Cmd_dumpScript(int argc, const char **argv) {
 		debugPrintf("Syntax: dumpscript <zonenum>\n");
 
 	return true;
+}
+
+
+bool Debugger::setPNDebugTime(uint16 hour, uint16 minute) {
+	_vm->writeVariable(84, hour);
+	_vm->writeVariable(85, minute);
+	debugPrintf("Set time to %02u:%02u\n", hour, minute);
+	return true;
+}
+
+bool Debugger::Cmd_GetTime(int argc, const char **argv) {
+	debugPrintf("Time is %02u:%02u\n", (uint)_vm->readVariable(84), (uint)_vm->readVariable(85));
+	return true;
+}
+
+bool Debugger::Cmd_StartDay(int argc, const char **argv) {
+	return setPNDebugTime(6, 58);
+}
+
+bool Debugger::Cmd_StartNight(int argc, const char **argv) {
+	return setPNDebugTime(17, 58);
 }
 
 } // End of namespace AGOS

--- a/engines/agos/debugger.h
+++ b/engines/agos/debugger.h
@@ -46,6 +46,10 @@ private:
 	bool Cmd_StartSubroutine(int argc, const char **argv);
 	bool Cmd_dumpImage(int argc, const char **argv);
 	bool Cmd_dumpScript(int argc, const char **argv);
+	bool Cmd_GetTime(int argc, const char **argv);
+	bool Cmd_StartDay(int argc, const char **argv);
+	bool Cmd_StartNight(int argc, const char **argv);
+	bool setPNDebugTime(uint16 hour, uint16 minute);
 };
 
 } // End of namespace AGOS

--- a/engines/agos/event.cpp
+++ b/engines/agos/event.cpp
@@ -267,7 +267,7 @@ void AGOSEngine::processVgaEvents() {
 			case ANIMATE_INT:
 				vte->delay = (getGameType() == GType_SIMON2) ? 5 : _frameCount;
 				animateSprites();
-				if (_pnDayNightControllerActive)
+				if (isPNDayNightPaletteMode())
 					schedulePNFadeEvent();
 				vte++;
 				break;
@@ -292,7 +292,7 @@ void AGOSEngine::processVgaEvents() {
 				vte = _nextVgaTimerToProcess;
 				break;
 			case PN_FADE_EVENT:
-				if (_pnDayNightControllerActive) {
+				if (isPNDayNightPaletteMode()) {
 					if (_pnDayNightControllerTickCounter > _vgaBaseDelay) {
 						_pnDayNightControllerTickCounter -= _vgaBaseDelay;
 					} else {

--- a/engines/agos/event.cpp
+++ b/engines/agos/event.cpp
@@ -246,6 +246,17 @@ void AGOSEngine::processVgaEvents() {
 			case ANIMATE_INT:
 				vte->delay = (getGameType() == GType_SIMON2) ? 5 : _frameCount;
 				animateSprites();
+				if (isPNDayNightPaletteMode()) {
+					stepPNPaletteFade();
+					if (_pnDayNightControllerActive) {
+						if (_pnDayNightControllerTickCounter > _vgaBaseDelay) {
+							_pnDayNightControllerTickCounter -= _vgaBaseDelay;
+						} else {
+							_pnDayNightControllerTickCounter = _pnDayNightControllerTickDelay;
+							updatePNDayNightController();
+						}
+					}
+				}
 				vte++;
 				break;
 			case ANIMATE_EVENT:

--- a/engines/agos/event.cpp
+++ b/engines/agos/event.cpp
@@ -297,7 +297,7 @@ void AGOSEngine::processVgaEvents() {
 						_pnDayNightControllerTickCounter -= _vgaBaseDelay;
 					} else {
 						_pnDayNightControllerTickCounter = 0x00C8;
-						updatePNDayNightController();
+						updatePNDayNightController(_pnDayNightControllerSelectorMask);
 					}
 				}
 

--- a/engines/agos/event.cpp
+++ b/engines/agos/event.cpp
@@ -239,7 +239,7 @@ void AGOSEngine::schedulePNFadeEvent() {
 			return;
 	}
 
-	addVgaEvent(_frameCount, PN_FADE_EVENT, nullptr, 0, 0);
+	addVgaEvent(_vgaBaseDelay, PN_FADE_EVENT, nullptr, 0, 0);
 }
 
 void AGOSEngine::removePNFadeEvent() {
@@ -267,6 +267,8 @@ void AGOSEngine::processVgaEvents() {
 			case ANIMATE_INT:
 				vte->delay = (getGameType() == GType_SIMON2) ? 5 : _frameCount;
 				animateSprites();
+				if (_pnDayNightControllerActive)
+					schedulePNFadeEvent();
 				vte++;
 				break;
 			case ANIMATE_EVENT:
@@ -290,26 +292,18 @@ void AGOSEngine::processVgaEvents() {
 				vte = _nextVgaTimerToProcess;
 				break;
 			case PN_FADE_EVENT:
-				if (_pnFadeActive)
-					stepPNPaletteFade();
-
 				if (_pnDayNightControllerActive) {
 					if (_pnDayNightControllerTickCounter > _vgaBaseDelay) {
 						_pnDayNightControllerTickCounter -= _vgaBaseDelay;
 					} else {
-						_pnDayNightControllerTickCounter = _pnDayNightControllerTickDelay;
+						_pnDayNightControllerTickCounter = 0x00C8;
 						updatePNDayNightController();
 					}
 				}
 
-				if (_pnFadeActive || _pnDayNightControllerActive) {
-					vte->delay = _frameCount;
-					vte++;
-				} else {
-					_nextVgaTimerToProcess = vte + 1;
-					deleteVgaEvent(vte);
-					vte = _nextVgaTimerToProcess;
-				}
+				_nextVgaTimerToProcess = vte + 1;
+				deleteVgaEvent(vte);
+				vte = _nextVgaTimerToProcess;
 				break;
 			default:
 				error("processVgaEvents: Unknown event type %d", vte->type);

--- a/engines/agos/event.cpp
+++ b/engines/agos/event.cpp
@@ -230,6 +230,27 @@ void AGOSEngine::deleteVgaEvent(VgaTimerEntry * vte) {
 	_videoLockOut &= ~1;
 }
 
+void AGOSEngine::schedulePNFadeEvent() {
+	if (!isPNDayNightPaletteMode())
+		return;
+
+	for (VgaTimerEntry *vte = _vgaTimerList; vte->delay; ++vte) {
+		if (vte->type == PN_FADE_EVENT)
+			return;
+	}
+
+	addVgaEvent(_frameCount, PN_FADE_EVENT, nullptr, 0, 0);
+}
+
+void AGOSEngine::removePNFadeEvent() {
+	for (VgaTimerEntry *vte = _vgaTimerList; vte->delay; ++vte) {
+		if (vte->type == PN_FADE_EVENT) {
+			deleteVgaEvent(vte);
+			return;
+		}
+	}
+}
+
 void AGOSEngine::processVgaEvents() {
 	VgaTimerEntry *vte = _vgaTimerList;
 
@@ -246,17 +267,6 @@ void AGOSEngine::processVgaEvents() {
 			case ANIMATE_INT:
 				vte->delay = (getGameType() == GType_SIMON2) ? 5 : _frameCount;
 				animateSprites();
-				if (isPNDayNightPaletteMode()) {
-					stepPNPaletteFade();
-					if (_pnDayNightControllerActive) {
-						if (_pnDayNightControllerTickCounter > _vgaBaseDelay) {
-							_pnDayNightControllerTickCounter -= _vgaBaseDelay;
-						} else {
-							_pnDayNightControllerTickCounter = _pnDayNightControllerTickDelay;
-							updatePNDayNightController();
-						}
-					}
-				}
 				vte++;
 				break;
 			case ANIMATE_EVENT:
@@ -278,6 +288,28 @@ void AGOSEngine::processVgaEvents() {
 			case MONSTER_DAMAGE_EVENT:
 				monsterDamageEvent(vte, curZoneNum);
 				vte = _nextVgaTimerToProcess;
+				break;
+			case PN_FADE_EVENT:
+				if (_pnFadeActive)
+					stepPNPaletteFade();
+
+				if (_pnDayNightControllerActive) {
+					if (_pnDayNightControllerTickCounter > _vgaBaseDelay) {
+						_pnDayNightControllerTickCounter -= _vgaBaseDelay;
+					} else {
+						_pnDayNightControllerTickCounter = _pnDayNightControllerTickDelay;
+						updatePNDayNightController();
+					}
+				}
+
+				if (_pnFadeActive || _pnDayNightControllerActive) {
+					vte->delay = _frameCount;
+					vte++;
+				} else {
+					_nextVgaTimerToProcess = vte + 1;
+					deleteVgaEvent(vte);
+					vte = _nextVgaTimerToProcess;
+				}
 				break;
 			default:
 				error("processVgaEvents: Unknown event type %d", vte->type);

--- a/engines/agos/items.cpp
+++ b/engines/agos/items.cpp
@@ -72,8 +72,6 @@ uint AGOSEngine::itemGetIconNumber(Item *item) {
 
 void AGOSEngine::setItemState(Item *item, int value) {
 	item->state = value;
-	if (isPNDayNightPaletteMode())
-		syncPNDesiredPaletteBank();
 }
 
 void AGOSEngine::createPlayer() {

--- a/engines/agos/items.cpp
+++ b/engines/agos/items.cpp
@@ -72,6 +72,8 @@ uint AGOSEngine::itemGetIconNumber(Item *item) {
 
 void AGOSEngine::setItemState(Item *item, int value) {
 	item->state = value;
+	if (isPNDayNightPaletteMode())
+		syncPNDesiredPaletteBank();
 }
 
 void AGOSEngine::createPlayer() {

--- a/engines/agos/script.cpp
+++ b/engines/agos/script.cpp
@@ -970,10 +970,21 @@ void AGOSEngine::writeVariable(uint16 variable, uint16 contents) {
 	if (variable >= _numVars)
 		error("writeVariable: Variable %d out of range", variable);
 
+	const bool pnDayNightMode = getGameType() == GType_PN &&
+		!(getFeatures() & GF_EGA) &&
+		(getPlatform() == Common::kPlatformAtariST || getPlatform() == Common::kPlatformAmiga);
+	const uint16 oldValue = _variableArray[variable];
+	const bool pnDayNightVar = pnDayNightMode && variable == 249 && oldValue != contents;
+
 	if (getGameType() == GType_FF && getBitFlag(83))
 		_variableArray2[variable] = contents;
 	else
 		_variableArray[variable] = contents;
+
+	if (pnDayNightVar) {
+		const uint16 selectorMask = (contents == 2) ? 0xFFFF : 0x0000;
+		startPNPaletteFade(selectorMask, -1, true);
+	}
 }
 
 int AGOSEngine::runScript() {

--- a/engines/agos/script.cpp
+++ b/engines/agos/script.cpp
@@ -970,9 +970,7 @@ void AGOSEngine::writeVariable(uint16 variable, uint16 contents) {
 	if (variable >= _numVars)
 		error("writeVariable: Variable %d out of range", variable);
 
-	const bool pnDayNightMode = getGameType() == GType_PN &&
-		!(getFeatures() & GF_EGA) &&
-		(getPlatform() == Common::kPlatformAtariST || getPlatform() == Common::kPlatformAmiga);
+	const bool pnDayNightMode = isPNDayNightPaletteMode();
 	const uint16 oldValue = _variableArray[variable];
 	const bool pnDayNightVar = pnDayNightMode && variable == 249 && oldValue != contents;
 
@@ -983,7 +981,7 @@ void AGOSEngine::writeVariable(uint16 variable, uint16 contents) {
 
 	if (pnDayNightVar) {
 		const uint16 selectorMask = (contents == 2) ? 0xFFFF : 0x0000;
-		startPNPaletteFade(selectorMask, -1, true);
+		startPNDayNightController(selectorMask);
 	}
 }
 

--- a/engines/agos/vga.cpp
+++ b/engines/agos/vga.cpp
@@ -477,6 +477,7 @@ void AGOSEngine::resetPNRoomPaletteState() {
 	_pnFadeActive = false;
 	_pnFadeStage = 0;
 	_pnFadeAdvancePending = false;
+	removePNFadeEvent();
 }
 
 void AGOSEngine::buildPNPaletteTarget(uint16 selectorMask, uint16 *target) const {
@@ -590,6 +591,7 @@ void AGOSEngine::startPNPaletteFade(uint16 selectorMask, int16 fadeMode, bool an
 	_pnFadeStage = 0;
 	_pnFadeAdvancePending = false;
 	_pnFadeActive = true;
+	schedulePNFadeEvent();
 }
 
 void AGOSEngine::stepPNPaletteFade() {
@@ -706,6 +708,7 @@ void AGOSEngine::vc4_fadeIn() {
 		_pnDayNightControllerLastStage = 0xFF;
 		_pnDayNightControllerTickCounter = _pnDayNightControllerTickDelay;
 		updatePNDayNightController();
+		schedulePNFadeEvent();
 		return;
 	}
 

--- a/engines/agos/vga.cpp
+++ b/engines/agos/vga.cpp
@@ -421,14 +421,7 @@ uint8 AGOSEngine::getPNDesiredPaletteBank() const {
 			return 0;
 	}
 
-	return (_pnDesiredPaletteBank == 1) ? 1 : 0;
-}
-
-void AGOSEngine::syncPNDesiredPaletteBank() {
-	if (!isPNDayNightPaletteMode())
-		return;
-
-	_pnDesiredPaletteBank = getPNDesiredPaletteBank();
+	return 0;
 }
 
 void AGOSEngine::notePNClockValueChange() {
@@ -455,14 +448,11 @@ void AGOSEngine::notePNClockValueChange() {
 	const int16 clockMinutes = hour * 60 + minute;
 	if (_pnLastClockMinutes == -1) {
 		_pnLastClockMinutes = clockMinutes;
-		syncPNDesiredPaletteBank();
 		return;
 	}
 
 	if (clockMinutes != _pnLastClockMinutes)
 		_pnLastClockMinutes = clockMinutes;
-
-	syncPNDesiredPaletteBank();
 }
 
 void AGOSEngine::resetPNRoomPaletteState() {
@@ -470,8 +460,8 @@ void AGOSEngine::resetPNRoomPaletteState() {
 		return;
 
 	memset(_pnHavePaletteBank, 0, sizeof(_pnHavePaletteBank));
-	_pnDayNightControllerLastStage = 0xFF;
 	_pnDayNightControllerSelectorMask = 0xFFFF;
+	_pnDayNightControllerLastStage = 0xFF;
 	_pnDayNightControllerTickCounter = 0x00C8;
 	removePNFadeEvent();
 }
@@ -534,11 +524,11 @@ void AGOSEngine::startPNDayNightController(uint16 selectorMask) {
 	_pnDayNightControllerSelectorMask = selectorMask;
 	_pnDayNightControllerLastStage = 0xFF;
 	_pnDayNightControllerTickCounter = 0x00C8;
-	updatePNDayNightController();
+	updatePNDayNightController(selectorMask);
 	schedulePNFadeEvent();
 }
 
-void AGOSEngine::updatePNDayNightController() {
+void AGOSEngine::updatePNDayNightController(uint16 selectorMask) {
 	if (!isPNDayNightPaletteMode())
 		return;
 	if (!_pnHavePaletteBank[0] || !_pnHavePaletteBank[1])
@@ -548,15 +538,16 @@ void AGOSEngine::updatePNDayNightController() {
 	if (stage == _pnDayNightControllerLastStage)
 		return;
 
-	buildPNPaletteTarget(_pnDayNightControllerSelectorMask, _pnFadeTarget);
+	uint16 fadeTarget[16];
+	buildPNPaletteTarget(selectorMask, fadeTarget);
 	for (int i = 0; i < 16; ++i)
-		_pnFadeCurrent[i] = blendPNPaletteColor(_pnPaletteBanks[0][i], _pnFadeTarget[i], stage);
+		_pnFadeCurrent[i] = blendPNPaletteColor(_pnPaletteBanks[0][i], fadeTarget[i], stage);
 
 	_pnDayNightControllerLastStage = stage;
-	applyPNDayNightPalette(_pnFadeCurrent, true);
+	applyPNDayNightPalette(_pnFadeCurrent);
 }
 
-void AGOSEngine::applyPNDayNightPalette(const uint16 *palette, bool updateBackend) {
+void AGOSEngine::applyPNDayNightPalette(const uint16 *palette) {
 	for (int i = 0; i < 16; ++i) {
 		const uint16 color = palette[i];
 		_displayPalette[i * 3 + 0] = ((color & 0x0f00) >> 8) * 32;
@@ -566,7 +557,7 @@ void AGOSEngine::applyPNDayNightPalette(const uint16 *palette, bool updateBacken
 
 	memcpy(_currentPalette, _displayPalette, sizeof(_displayPalette));
 
-	const bool canPushImmediately = updateBackend && isPNDayNightPaletteMode() && _pnHavePaletteBank[0] && _pnHavePaletteBank[1] && _system->getPaletteManager();
+	const bool canPushImmediately = isPNDayNightPaletteMode() && _pnHavePaletteBank[0] && _pnHavePaletteBank[1] && _system->getPaletteManager();
 	if (canPushImmediately) {
 		_system->getPaletteManager()->setPalette(_displayPalette, 0, 16);
 		_paletteFlag = 0;
@@ -639,8 +630,6 @@ void AGOSEngine::vc4_fadeIn() {
 	vcReadNextWord();
 	const int16 fadeMode = (int16)vcReadNextWord();
 
-	syncPNDesiredPaletteBank();
-
 	const bool hasAlternateBank = _pnHavePaletteBank[1];
 	const bool isDayPalette = selectorMask == 0;
 
@@ -651,7 +640,7 @@ void AGOSEngine::vc4_fadeIn() {
 		return;
 	}
 
-	const bool shouldApply = (_pnDesiredPaletteBank == 0) ? isDayPalette : !isDayPalette;
+	const bool shouldApply = (getPNDesiredPaletteBank() == 0) ? isDayPalette : !isDayPalette;
 
 	if (fadeMode == -1) {
 		startPNDayNightController(selectorMask);
@@ -661,9 +650,10 @@ void AGOSEngine::vc4_fadeIn() {
 	if (!shouldApply)
 		return;
 
-	buildPNPaletteTarget(selectorMask, _pnFadeTarget);
-	memcpy(_pnFadeCurrent, _pnFadeTarget, sizeof(_pnFadeCurrent));
-	applyPNDayNightPalette(_pnFadeCurrent, true);
+	uint16 fadeTarget[16];
+	buildPNPaletteTarget(selectorMask, fadeTarget);
+	memcpy(_pnFadeCurrent, fadeTarget, sizeof(_pnFadeCurrent));
+	applyPNDayNightPalette(_pnFadeCurrent);
 }
 
 void AGOSEngine::vc5_ifEqual() {

--- a/engines/agos/vga.cpp
+++ b/engines/agos/vga.cpp
@@ -289,6 +289,9 @@ uint AGOSEngine::vcReadVar(uint var) {
 void AGOSEngine::vcWriteVar(uint var, int16 value) {
 	assert(var < _numVars);
 	_variableArrayPtr[var] = value;
+
+	if (isPNDayNightPaletteMode() && (var == 84 || var == 85))
+		notePNClockValueChange();
 }
 
 void AGOSEngine::vcSkipNextInstruction() {
@@ -388,6 +391,244 @@ void AGOSEngine::vcSkipNextInstruction() {
 	debugCN(kDebugVGAOpcode, "; skipped\n");
 }
 
+bool AGOSEngine::isPNDayNightPaletteMode() const {
+	return getGameType() == GType_PN && !(getFeatures() & GF_EGA) &&
+		(getPlatform() == Common::kPlatformAtariST || getPlatform() == Common::kPlatformAmiga);
+}
+
+uint8 AGOSEngine::getPNDesiredPaletteBank() const {
+	if (!isPNDayNightPaletteMode())
+		return 0;
+
+	if (_variableArray != nullptr && _numVars > 85) {
+		const int16 hour = _variableArray[84];
+		const int16 minute = _variableArray[85];
+		if (hour >= 0 && hour < 24 && minute >= 0 && minute < 60) {
+			if (!(_pnLastClockMinutes == -1 && hour == 0 && minute == 0))
+				return (hour >= 23 || hour < 7) ? 1 : 0;
+		}
+	}
+
+	if (_itemArrayPtr != nullptr && _itemArraySize > 289) {
+		const Item *item196 = _itemArrayPtr[196];
+		const Item *item289 = _itemArrayPtr[289];
+		const bool nightState = (item196 && item196->state == 7) || (item289 && item289->state == 7);
+		const bool dayState = (item196 && item196->state == 27) || (item289 && item289->state == 27);
+
+		if (nightState && !dayState)
+			return 1;
+		if (dayState && !nightState)
+			return 0;
+	}
+
+	return (_pnDesiredPaletteBank == 1) ? 1 : 0;
+}
+
+void AGOSEngine::syncPNDesiredPaletteBank() {
+	if (!isPNDayNightPaletteMode())
+		return;
+
+	_pnDesiredPaletteBank = getPNDesiredPaletteBank();
+}
+
+void AGOSEngine::notePNClockValueChange() {
+	if (!isPNDayNightPaletteMode() || _variableArray == nullptr || _numVars <= 85)
+		return;
+
+	int16 hour = _variableArray[84];
+	int16 minute = _variableArray[85];
+	if (hour < 0 || minute < 0)
+		return;
+
+	if (minute >= 60) {
+		hour += minute / 60;
+		minute %= 60;
+		_variableArray[84] = hour;
+		_variableArray[85] = minute;
+	}
+
+	if (hour >= 24) {
+		hour %= 24;
+		_variableArray[84] = hour;
+	}
+
+	const int16 clockMinutes = hour * 60 + minute;
+	if (_pnLastClockMinutes == -1) {
+		_pnLastClockMinutes = clockMinutes;
+		syncPNDesiredPaletteBank();
+		return;
+	}
+
+	if (clockMinutes != _pnLastClockMinutes)
+		_pnLastClockMinutes = clockMinutes;
+
+	syncPNDesiredPaletteBank();
+}
+
+void AGOSEngine::resetPNRoomPaletteState() {
+	if (!isPNDayNightPaletteMode())
+		return;
+
+	memset(_pnHavePaletteBank, 0, sizeof(_pnHavePaletteBank));
+	_pnDayNightControllerActive = false;
+	_pnDayNightControllerLastStage = 0xFF;
+	_pnDayNightControllerSelectorMask = 0xFFFF;
+	_pnDayNightControllerTickCounter = _pnDayNightControllerTickDelay;
+	_pnFadeActive = false;
+	_pnFadeStage = 0;
+	_pnFadeAdvancePending = false;
+}
+
+void AGOSEngine::buildPNPaletteTarget(uint16 selectorMask, uint16 *target) const {
+	for (int i = 0; i < 16; ++i) {
+		const bool useBank1 = (selectorMask & (0x8000 >> i)) != 0;
+		if (useBank1 && _pnHavePaletteBank[1]) {
+			target[i] = _pnPaletteBanks[1][i];
+		} else if (_pnHavePaletteBank[0]) {
+			target[i] = _pnPaletteBanks[0][i];
+		} else if (_pnHavePaletteBank[1]) {
+			target[i] = _pnPaletteBanks[1][i];
+		} else {
+			target[i] = _pnFadeCurrent[i];
+		}
+	}
+}
+
+uint16 AGOSEngine::blendPNPaletteColor(uint16 source, uint16 target, uint8 steps) const {
+	uint16 current = source;
+
+	for (uint8 step = 0; step < steps; ++step) {
+		const uint16 currentRed = current & 0x0f00;
+		const uint16 targetRed = target & 0x0f00;
+		if (currentRed < targetRed)
+			current += 0x0100;
+		else if (currentRed > targetRed)
+			current -= 0x0100;
+
+		const uint16 currentGreen = current & 0x00f0;
+		const uint16 targetGreen = target & 0x00f0;
+		if (currentGreen < targetGreen)
+			current += 0x0010;
+		else if (currentGreen > targetGreen)
+			current -= 0x0010;
+
+		const uint16 currentBlue = current & 0x000f;
+		const uint16 targetBlue = target & 0x000f;
+		if (currentBlue < targetBlue)
+			current += 0x0001;
+		else if (currentBlue > targetBlue)
+			current -= 0x0001;
+	}
+
+	return current;
+}
+
+uint8 AGOSEngine::getPNDayNightControllerStage() const {
+	if (!isPNDayNightPaletteMode() || _variableArray == nullptr || _numVars <= 212)
+		return 0;
+
+	return (uint8)(_variableArray[212] & 7);
+}
+
+void AGOSEngine::updatePNDayNightController() {
+	if (!isPNDayNightPaletteMode())
+		return;
+	if (!_pnDayNightControllerActive)
+		return;
+	if (!_pnHavePaletteBank[0] || !_pnHavePaletteBank[1])
+		return;
+
+	const uint8 stage = getPNDayNightControllerStage();
+	if (stage == _pnDayNightControllerLastStage)
+		return;
+
+	buildPNPaletteTarget(_pnDayNightControllerSelectorMask, _pnFadeTarget);
+	for (int i = 0; i < 16; ++i)
+		_pnFadeCurrent[i] = blendPNPaletteColor(_pnPaletteBanks[0][i], _pnFadeTarget[i], stage);
+
+	if (stage == 0)
+		_pnActivePaletteBank = 0;
+	else if (stage >= 7)
+		_pnActivePaletteBank = 1;
+
+	_pnDayNightControllerLastStage = stage;
+	applyPNDayNightPalette(_pnFadeCurrent, true);
+}
+
+void AGOSEngine::applyPNDayNightPalette(const uint16 *palette, bool updateBackend) {
+	for (int i = 0; i < 16; ++i) {
+		const uint16 color = palette[i];
+		_displayPalette[i * 3 + 0] = ((color & 0x0f00) >> 8) * 32;
+		_displayPalette[i * 3 + 1] = ((color & 0x00f0) >> 4) * 32;
+		_displayPalette[i * 3 + 2] = ((color & 0x000f) >> 0) * 32;
+	}
+
+	memcpy(_currentPalette, _displayPalette, sizeof(_displayPalette));
+
+	const bool canPushImmediately = updateBackend && (_pnFadeActive || _pnDayNightControllerActive) && _pnHavePaletteBank[0] && _pnHavePaletteBank[1] && _system->getPaletteManager();
+	if (canPushImmediately) {
+		_system->getPaletteManager()->setPalette(_displayPalette, 0, 16);
+		_paletteFlag = 0;
+	} else {
+		_paletteFlag = 1;
+	}
+}
+
+void AGOSEngine::startPNPaletteFade(uint16 selectorMask, int16 fadeMode, bool animate) {
+	if (!isPNDayNightPaletteMode())
+		return;
+
+	buildPNPaletteTarget(selectorMask, _pnFadeTarget);
+	_pnPendingPaletteBank = _pnDesiredPaletteBank;
+
+	if (!animate) {
+		memcpy(_pnFadeCurrent, _pnFadeTarget, sizeof(_pnFadeCurrent));
+		_pnActivePaletteBank = _pnPendingPaletteBank;
+		_pnFadeActive = false;
+		_pnFadeStage = 0;
+		applyPNDayNightPalette(_pnFadeCurrent, true);
+		return;
+	}
+
+	memcpy(_pnFadeSource, _pnFadeCurrent, sizeof(_pnFadeSource));
+	_pnFadeTickDelay = (fadeMode > 0) ? (uint8)fadeMode : 1;
+	_pnFadeTickCounter = _pnFadeTickDelay;
+	_pnFadeStage = 0;
+	_pnFadeAdvancePending = false;
+	_pnFadeActive = true;
+}
+
+void AGOSEngine::stepPNPaletteFade() {
+	if (!_pnFadeActive)
+		return;
+
+	if (!_pnFadeAdvancePending)
+		return;
+	_pnFadeAdvancePending = false;
+
+	if (_pnFadeTickCounter > 1) {
+		_pnFadeTickCounter--;
+		return;
+	}
+
+	_pnFadeTickCounter = _pnFadeTickDelay;
+
+	if (_pnFadeStage >= 7) {
+		memcpy(_pnFadeCurrent, _pnFadeTarget, sizeof(_pnFadeCurrent));
+		_pnActivePaletteBank = _pnPendingPaletteBank;
+		_pnFadeActive = false;
+		_pnFadeAdvancePending = false;
+		applyPNDayNightPalette(_pnFadeCurrent, true);
+		return;
+	}
+
+	for (int i = 0; i < 16; ++i)
+		_pnFadeCurrent[i] = blendPNPaletteColor(_pnFadeSource[i], _pnFadeTarget[i], _pnFadeStage);
+
+	applyPNDayNightPalette(_pnFadeCurrent, true);
+	_pnFadeStage++;
+}
+
 // VGA Script commands
 void AGOSEngine::vc1_fadeOut() {
 	/* dummy opcode */
@@ -443,8 +684,43 @@ void AGOSEngine::vc3_loadSprite() {
 }
 
 void AGOSEngine::vc4_fadeIn() {
-	/* dummy opcode */
-	_vcPtr += 6;
+	if (!isPNDayNightPaletteMode()) {
+		_vcPtr += 6;
+		return;
+	}
+
+	const uint16 selectorMask = vcReadNextWord();
+	vcReadNextWord();
+	const int16 fadeMode = (int16)vcReadNextWord();
+
+	syncPNDesiredPaletteBank();
+
+	const bool hasAlternateBank = _pnHavePaletteBank[1];
+	const bool isDayPalette = selectorMask == 0;
+
+	if (!hasAlternateBank) {
+		if (_pnHavePaletteBank[0]) {
+			memcpy(_pnFadeCurrent, _pnPaletteBanks[0], sizeof(_pnFadeCurrent));
+			_pnActivePaletteBank = 0;
+		}
+		return;
+	}
+
+	const bool shouldApply = (_pnDesiredPaletteBank == 0) ? isDayPalette : !isDayPalette;
+
+	if (fadeMode == -1) {
+		_pnDayNightControllerSelectorMask = selectorMask;
+		_pnDayNightControllerActive = true;
+		_pnDayNightControllerLastStage = 0xFF;
+		_pnDayNightControllerTickCounter = _pnDayNightControllerTickDelay;
+		updatePNDayNightController();
+		return;
+	}
+
+	if (!shouldApply)
+		return;
+
+	startPNPaletteFade(selectorMask, fadeMode, false);
 }
 
 void AGOSEngine::vc5_ifEqual() {
@@ -944,6 +1220,8 @@ void AGOSEngine::vc22_setPalette() {
 	byte *offs, *palptr, *src;
 	uint16 b, num;
 	const uint16 origB = b = vcReadNextWord();
+	uint16 pnPalette[16];
+	const bool pnDayNightPaletteMode = isPNDayNightPaletteMode();
 
 	// PC EGA version of Personal Nightmare uses standard EGA palette
 	if (getGameType() == GType_PN && (getFeatures() & GF_EGA))
@@ -954,10 +1232,14 @@ void AGOSEngine::vc22_setPalette() {
 	palptr = _displayPalette;
 	_bottomPalette = 1;
 
+	uint8 pnBank = 0;
 	if (getGameType() == GType_PN) {
+		if (origB > 128)
+			pnBank = 1;
 		if (b > 128) {
 			b -= 128;
-			palptr = _displayPalette + 3 * 16;
+			if (!pnDayNightPaletteMode)
+				palptr = _displayPalette + 3 * 16;
 		}
 	} else if (getGameType() == GType_ELVIRA1) {
 		if (b >= 1000) {
@@ -1000,21 +1282,42 @@ void AGOSEngine::vc22_setPalette() {
 	offs = _curVgaFile1 + READ_BE_UINT16(_curVgaFile1 + 6);
 	src = offs + b * 32;
 
+	uint pnPaletteIndex = 0;
 	do {
 		uint16 color = READ_BE_UINT16(src);
-		if (getGameType() == GType_ELVIRA2 && getPlatform() == Common::kPlatformAtariST) {
-			palptr[0] = atariSTColorNibbleToComponent((color & 0xf00) >> 8);
-			palptr[1] = atariSTColorNibbleToComponent((color & 0x0f0) >> 4);
-			palptr[2] = atariSTColorNibbleToComponent((color & 0x00f) >> 0);
-		} else {
-			palptr[0] = ((color & 0xf00) >> 8) * 32;
-			palptr[1] = ((color & 0x0f0) >> 4) * 32;
-			palptr[2] = ((color & 0x00f) >> 0) * 32;
+		if (pnDayNightPaletteMode)
+			pnPalette[pnPaletteIndex] = color;
+
+		if (!pnDayNightPaletteMode || pnBank == 0) {
+			if (getGameType() == GType_ELVIRA2 && getPlatform() == Common::kPlatformAtariST) {
+				palptr[0] = atariSTColorNibbleToComponent((color & 0xf00) >> 8);
+				palptr[1] = atariSTColorNibbleToComponent((color & 0x0f0) >> 4);
+				palptr[2] = atariSTColorNibbleToComponent((color & 0x00f) >> 0);
+			} else {
+				palptr[0] = ((color & 0xf00) >> 8) * 32;
+				palptr[1] = ((color & 0x0f0) >> 4) * 32;
+				palptr[2] = ((color & 0x00f) >> 0) * 32;
+			}
+			palptr += 3;
 		}
 
-		palptr += 3;
 		src += 2;
+		pnPaletteIndex++;
 	} while (--num);
+
+	if (pnDayNightPaletteMode) {
+		while (pnPaletteIndex < 16)
+			pnPalette[pnPaletteIndex++] = 0;
+
+		memcpy(_pnPaletteBanks[pnBank], pnPalette, sizeof(pnPalette));
+		_pnHavePaletteBank[pnBank] = true;
+
+		if (pnBank == 0) {
+			memcpy(_pnFadeCurrent, _pnPaletteBanks[0], sizeof(_pnFadeCurrent));
+			_pnActivePaletteBank = 0;
+		}
+
+	}
 
 	if (getGameType() == GType_PN && origB == 9 &&
 			(getPlatform() == Common::kPlatformAtariST || getPlatform() == Common::kPlatformAmiga)) {

--- a/engines/agos/vga.cpp
+++ b/engines/agos/vga.cpp
@@ -470,7 +470,6 @@ void AGOSEngine::resetPNRoomPaletteState() {
 		return;
 
 	memset(_pnHavePaletteBank, 0, sizeof(_pnHavePaletteBank));
-	_pnDayNightControllerActive = false;
 	_pnDayNightControllerLastStage = 0xFF;
 	_pnDayNightControllerSelectorMask = 0xFFFF;
 	_pnDayNightControllerTickCounter = 0x00C8;
@@ -533,7 +532,6 @@ void AGOSEngine::startPNDayNightController(uint16 selectorMask) {
 		return;
 
 	_pnDayNightControllerSelectorMask = selectorMask;
-	_pnDayNightControllerActive = true;
 	_pnDayNightControllerLastStage = 0xFF;
 	_pnDayNightControllerTickCounter = 0x00C8;
 	updatePNDayNightController();
@@ -542,8 +540,6 @@ void AGOSEngine::startPNDayNightController(uint16 selectorMask) {
 
 void AGOSEngine::updatePNDayNightController() {
 	if (!isPNDayNightPaletteMode())
-		return;
-	if (!_pnDayNightControllerActive)
 		return;
 	if (!_pnHavePaletteBank[0] || !_pnHavePaletteBank[1])
 		return;
@@ -570,7 +566,7 @@ void AGOSEngine::applyPNDayNightPalette(const uint16 *palette, bool updateBacken
 
 	memcpy(_currentPalette, _displayPalette, sizeof(_displayPalette));
 
-	const bool canPushImmediately = updateBackend && _pnDayNightControllerActive && _pnHavePaletteBank[0] && _pnHavePaletteBank[1] && _system->getPaletteManager();
+	const bool canPushImmediately = updateBackend && isPNDayNightPaletteMode() && _pnHavePaletteBank[0] && _pnHavePaletteBank[1] && _system->getPaletteManager();
 	if (canPushImmediately) {
 		_system->getPaletteManager()->setPalette(_displayPalette, 0, 16);
 		_paletteFlag = 0;

--- a/engines/agos/vga.cpp
+++ b/engines/agos/vga.cpp
@@ -546,11 +546,6 @@ void AGOSEngine::updatePNDayNightController() {
 	for (int i = 0; i < 16; ++i)
 		_pnFadeCurrent[i] = blendPNPaletteColor(_pnPaletteBanks[0][i], _pnFadeTarget[i], stage);
 
-	if (stage == 0)
-		_pnActivePaletteBank = 0;
-	else if (stage >= 7)
-		_pnActivePaletteBank = 1;
-
 	_pnDayNightControllerLastStage = stage;
 	applyPNDayNightPalette(_pnFadeCurrent, true);
 }
@@ -583,7 +578,6 @@ void AGOSEngine::startPNPaletteFade(uint16 selectorMask, int16 fadeMode, bool an
 
 	if (!animate) {
 		memcpy(_pnFadeCurrent, _pnFadeTarget, sizeof(_pnFadeCurrent));
-		_pnActivePaletteBank = _pnPendingPaletteBank;
 		_pnFadeActive = false;
 		_pnFadeStage = 0;
 		applyPNDayNightPalette(_pnFadeCurrent, true);
@@ -615,7 +609,6 @@ void AGOSEngine::stepPNPaletteFade() {
 
 	if (_pnFadeStage >= 7) {
 		memcpy(_pnFadeCurrent, _pnFadeTarget, sizeof(_pnFadeCurrent));
-		_pnActivePaletteBank = _pnPendingPaletteBank;
 		_pnFadeActive = false;
 		_pnFadeAdvancePending = false;
 		applyPNDayNightPalette(_pnFadeCurrent, true);
@@ -701,7 +694,6 @@ void AGOSEngine::vc4_fadeIn() {
 	if (!hasAlternateBank) {
 		if (_pnHavePaletteBank[0]) {
 			memcpy(_pnFadeCurrent, _pnPaletteBanks[0], sizeof(_pnFadeCurrent));
-			_pnActivePaletteBank = 0;
 		}
 		return;
 	}
@@ -1314,7 +1306,6 @@ void AGOSEngine::vc22_setPalette() {
 
 		if (pnBank == 0) {
 			memcpy(_pnFadeCurrent, _pnPaletteBanks[0], sizeof(_pnFadeCurrent));
-			_pnActivePaletteBank = 0;
 		}
 
 	}

--- a/engines/agos/vga.cpp
+++ b/engines/agos/vga.cpp
@@ -473,10 +473,7 @@ void AGOSEngine::resetPNRoomPaletteState() {
 	_pnDayNightControllerActive = false;
 	_pnDayNightControllerLastStage = 0xFF;
 	_pnDayNightControllerSelectorMask = 0xFFFF;
-	_pnDayNightControllerTickCounter = _pnDayNightControllerTickDelay;
-	_pnFadeActive = false;
-	_pnFadeStage = 0;
-	_pnFadeAdvancePending = false;
+	_pnDayNightControllerTickCounter = 0x00C8;
 	removePNFadeEvent();
 }
 
@@ -531,6 +528,18 @@ uint8 AGOSEngine::getPNDayNightControllerStage() const {
 	return (uint8)(_variableArray[212] & 7);
 }
 
+void AGOSEngine::startPNDayNightController(uint16 selectorMask) {
+	if (!isPNDayNightPaletteMode())
+		return;
+
+	_pnDayNightControllerSelectorMask = selectorMask;
+	_pnDayNightControllerActive = true;
+	_pnDayNightControllerLastStage = 0xFF;
+	_pnDayNightControllerTickCounter = 0x00C8;
+	updatePNDayNightController();
+	schedulePNFadeEvent();
+}
+
 void AGOSEngine::updatePNDayNightController() {
 	if (!isPNDayNightPaletteMode())
 		return;
@@ -561,67 +570,13 @@ void AGOSEngine::applyPNDayNightPalette(const uint16 *palette, bool updateBacken
 
 	memcpy(_currentPalette, _displayPalette, sizeof(_displayPalette));
 
-	const bool canPushImmediately = updateBackend && (_pnFadeActive || _pnDayNightControllerActive) && _pnHavePaletteBank[0] && _pnHavePaletteBank[1] && _system->getPaletteManager();
+	const bool canPushImmediately = updateBackend && _pnDayNightControllerActive && _pnHavePaletteBank[0] && _pnHavePaletteBank[1] && _system->getPaletteManager();
 	if (canPushImmediately) {
 		_system->getPaletteManager()->setPalette(_displayPalette, 0, 16);
 		_paletteFlag = 0;
 	} else {
 		_paletteFlag = 1;
 	}
-}
-
-void AGOSEngine::startPNPaletteFade(uint16 selectorMask, int16 fadeMode, bool animate) {
-	if (!isPNDayNightPaletteMode())
-		return;
-
-	buildPNPaletteTarget(selectorMask, _pnFadeTarget);
-	_pnPendingPaletteBank = _pnDesiredPaletteBank;
-
-	if (!animate) {
-		memcpy(_pnFadeCurrent, _pnFadeTarget, sizeof(_pnFadeCurrent));
-		_pnFadeActive = false;
-		_pnFadeStage = 0;
-		applyPNDayNightPalette(_pnFadeCurrent, true);
-		return;
-	}
-
-	memcpy(_pnFadeSource, _pnFadeCurrent, sizeof(_pnFadeSource));
-	_pnFadeTickDelay = (fadeMode > 0) ? (uint8)fadeMode : 1;
-	_pnFadeTickCounter = _pnFadeTickDelay;
-	_pnFadeStage = 0;
-	_pnFadeAdvancePending = false;
-	_pnFadeActive = true;
-	schedulePNFadeEvent();
-}
-
-void AGOSEngine::stepPNPaletteFade() {
-	if (!_pnFadeActive)
-		return;
-
-	if (!_pnFadeAdvancePending)
-		return;
-	_pnFadeAdvancePending = false;
-
-	if (_pnFadeTickCounter > 1) {
-		_pnFadeTickCounter--;
-		return;
-	}
-
-	_pnFadeTickCounter = _pnFadeTickDelay;
-
-	if (_pnFadeStage >= 7) {
-		memcpy(_pnFadeCurrent, _pnFadeTarget, sizeof(_pnFadeCurrent));
-		_pnFadeActive = false;
-		_pnFadeAdvancePending = false;
-		applyPNDayNightPalette(_pnFadeCurrent, true);
-		return;
-	}
-
-	for (int i = 0; i < 16; ++i)
-		_pnFadeCurrent[i] = blendPNPaletteColor(_pnFadeSource[i], _pnFadeTarget[i], _pnFadeStage);
-
-	applyPNDayNightPalette(_pnFadeCurrent, true);
-	_pnFadeStage++;
 }
 
 // VGA Script commands
@@ -703,19 +658,16 @@ void AGOSEngine::vc4_fadeIn() {
 	const bool shouldApply = (_pnDesiredPaletteBank == 0) ? isDayPalette : !isDayPalette;
 
 	if (fadeMode == -1) {
-		_pnDayNightControllerSelectorMask = selectorMask;
-		_pnDayNightControllerActive = true;
-		_pnDayNightControllerLastStage = 0xFF;
-		_pnDayNightControllerTickCounter = _pnDayNightControllerTickDelay;
-		updatePNDayNightController();
-		schedulePNFadeEvent();
+		startPNDayNightController(selectorMask);
 		return;
 	}
 
 	if (!shouldApply)
 		return;
 
-	startPNPaletteFade(selectorMask, fadeMode, false);
+	buildPNPaletteTarget(selectorMask, _pnFadeTarget);
+	memcpy(_pnFadeCurrent, _pnFadeTarget, sizeof(_pnFadeCurrent));
+	applyPNDayNightPalette(_pnFadeCurrent, true);
 }
 
 void AGOSEngine::vc5_ifEqual() {


### PR DESCRIPTION
This PR adds the day/night palette cycle for the Amiga and Atari ST versions of Personal Nightmare.

The AGOS engine implementation appears to have been based on the DOS version, which does not use this feature, so the ST/Amiga palette behavior was never implemented.

The game keeps the clock in vars 84(H) and 85(M), and the current palette fade stage in var 212. The fade stage is controlled by game script rather than advancing continuously. The fade has 8 stages over one in game hour and the clock advances in 2 minute steps, the palette changes every 8 in game minutes once the correct time has been reached.

**Testing:**

Fast-forward(Ctrl+F) is useful for testing, but it has to be enabled from the title screen because the parser consumes the keypress for F.(Perhaps we need to fix this, I'm open to suggestions.)

The easiest place to test is the evening transition. The game starts at 16:40, and the night fade down starts at 18:00. Start the game, step outside the pub onto the street, then let time pass.

The morning fade up starts at 07:00, but this is harder to test because it requires surviving the full night.

For easier testing, this PR adds debug console commands that will only appear for PN Amiga/Atari ST:

- `gettime`: prints the current in-game time.
- `startnight`: sets the clock to 17:58, just before the night transition.
- `startday`: sets the clock to 06:58, just before the day transition.

We could remove `startnight` and `startday` once the PR has been tested, since they force an abnormal game state.

When using the debug commands, the palette may initially jump to the correct starting state. That is expected because it needs to start the fade from the correct point. After that, the transition proceeds normally.

**Palette Stages:**

Night to day:

- 07:00: stage 7, full darkness
- 07:08: stage 6
- 07:16: stage 5
- ...
- 07:56: stage 0, full brightness

Day to night:

- 18:00: stage 0, full brightness
- 18:08: stage 1
- 18:16: stage 2
- ...
- 18:56: stage 7, full darkness

Video showing night transition(using fast mode):

https://github.com/user-attachments/assets/5a66f8c9-ecf7-4b9a-badc-5625bd4823ba

