### PR TITLE
SDL: Fix bug 16666

### DIFF
--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -440,8 +440,6 @@ void OpenGLSdlGraphicsManager::notifyResize(const int width, const int height) {
 		// Check if the ScummVM window is maximized and store the current
 		// window dimensions.
 		if (SDL_GetWindowFlags(_window->getSDLWindow()) & SDL_WINDOW_MAXIMIZED) {
-			ConfMan.setInt("window_maximized_width", currentWidth, Common::ConfigManager::kApplicationDomain);
-			ConfMan.setInt("window_maximized_height", currentHeight, Common::ConfigManager::kApplicationDomain);
 			ConfMan.setBool("window_maximized", true, Common::ConfigManager::kApplicationDomain);
 		} else {
 			ConfMan.setInt("last_window_width", currentWidth, Common::ConfigManager::kApplicationDomain);
@@ -478,15 +476,8 @@ bool OpenGLSdlGraphicsManager::loadVideoMode(uint requestedWidth, uint requested
 	Common::Rect desktopRes = _window->getDesktopResolution();
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	bool isMaximized = ConfMan.getBool("window_maximized", Common::ConfigManager::kApplicationDomain);
 	if (!_wantsFullScreen) {
-		if (isMaximized && ConfMan.hasKey("window_maximized_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("window_maximized_height", Common::ConfigManager::kApplicationDomain)) {
-			// Set the window size to the values stored when the window was maximized
-			// for the last time.
-			requestedWidth  = ConfMan.getInt("window_maximized_width", Common::ConfigManager::kApplicationDomain);
-			requestedHeight = ConfMan.getInt("window_maximized_height", Common::ConfigManager::kApplicationDomain);
-
-		} else if (!isMaximized && ConfMan.hasKey("last_window_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("last_window_height", Common::ConfigManager::kApplicationDomain)) {
+		if (ConfMan.hasKey("last_window_width", Common::ConfigManager::kApplicationDomain) && ConfMan.hasKey("last_window_height", Common::ConfigManager::kApplicationDomain)) {
 			// Load previously stored window dimensions.
 			requestedWidth  = ConfMan.getInt("last_window_width", Common::ConfigManager::kApplicationDomain);
 			requestedHeight = ConfMan.getInt("last_window_height", Common::ConfigManager::kApplicationDomain);

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -71,7 +71,7 @@ static void getMouseState(int *x, int *y) {
 SdlGraphicsManager::SdlGraphicsManager(SdlEventSource *source, SdlWindow *window)
 	: _eventSource(source), _window(window), _hwScreen(nullptr)
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-	, _allowWindowSizeReset(false), _hintedWidth(0), _hintedHeight(0), _lastFlags(0)
+	, _allowWindowSizeReset(false), _hintedWidth(0), _hintedHeight(0)
 #endif
 {
 	ConfMan.registerDefault("fullscreen_res", "desktop");
@@ -346,7 +346,7 @@ bool SdlGraphicsManager::createOrUpdateWindow(int width, int height, const Uint3
 	// size or pixel format of the internal game surface (since a user may have
 	// resized the game window), or when the launcher is visible (since a user
 	// may change the scaler, which should reset the window size)
-	if (!_window->getSDLWindow() || _lastFlags != flags || _overlayVisible || _allowWindowSizeReset) {
+	if (!_window->getSDLWindow() || _window->getWindowFlags() != flags || _overlayVisible || _allowWindowSizeReset) {
 #if SDL_VERSION_ATLEAST(3, 0, 0)
 		const bool fullscreen = (flags & (SDL_WINDOW_FULLSCREEN)) != 0;
 #else
@@ -374,7 +374,6 @@ bool SdlGraphicsManager::createOrUpdateWindow(int width, int height, const Uint3
 		}
 #endif
 
-		_lastFlags = flags;
 		_allowWindowSizeReset = false;
 	}
 

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -202,7 +202,6 @@ public:
 	virtual void destroyingWindow() {}
 
 protected:
-	Uint32 _lastFlags;
 	bool _allowWindowSizeReset;
 	int _hintedWidth, _hintedHeight;
 

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -2879,7 +2879,7 @@ void SurfaceSdlGraphicsManager::handleScalerHotkeys(uint mode, int factor) {
 	if (sizeChanged) {
 		// Forcibly resizing the window here since a user switching scaler
 		// size will not normally cause the window to update
-		_window->createOrUpdateWindow(_hwScreen->w, _hwScreen->h, _lastFlags);
+		_window->createOrUpdateWindow(_hwScreen->w, _hwScreen->h, _window->getWindowFlags());
 	}
 #endif
 

--- a/backends/platform/sdl/sdl-window.cpp
+++ b/backends/platform/sdl/sdl-window.cpp
@@ -539,7 +539,11 @@ bool SdlWindow::createOrUpdateWindow(int width, int height, uint32 flags) {
 			SDL_SetWindowFullscreen(_window, fullscreenFlags);
 		} else {
 			SDL_SetWindowFullscreen(_window, fullscreenFlags);
-			SDL_SetWindowSize(_window, width, height);
+			if ((SDL_GetWindowFlags(_window) & SDL_WINDOW_MAXIMIZED) == 0) {
+				// Don't resize the window if we already are maximized
+				// This matches what SDL3 does
+				SDL_SetWindowSize(_window, width, height);
+			}
 			if (flags & SDL_WINDOW_MAXIMIZED) {
 				SDL_MaximizeWindow(_window);
 			} else {

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -185,6 +185,11 @@ public:
 	 */
 	void destroyWindow();
 
+	/**
+	 * @return The last window flags set
+	 */
+	uint32 getWindowFlags() const { return _lastFlags; }
+
 protected:
 	SDL_Window *_window;
 


### PR DESCRIPTION
This PR fixes the bug [#16666](https://bugs.scummvm.org/ticket/16666).

I can't find why we need to store the window maximized size, so I removed it and it makes it work.

In addition, I sneak another small change that I had for some time: instead of having the flags stored duplicated between SdlGraphicsManager and SdlWindow.