### PR TITLE
MYST3: Fix switching between window configurations

### DIFF
--- a/engines/myst3/gfx.cpp
+++ b/engines/myst3/gfx.cpp
@@ -205,11 +205,20 @@ Renderer *createRenderer(OSystem *system) {
 
 	uint width;
 	uint height = Renderer::kOriginalHeight;
-	if (ConfMan.getBool("widescreen_mod")) {
-		width = Renderer::kOriginalWidth * Renderer::kOriginalHeight / Renderer::kFrameHeight;
-	} else {
-		width = Renderer::kOriginalWidth;
+	// Scale dimensions to properly resize the preferred window configuration
+	if (ConfMan.hasKey("last_window_height", Common::ConfigManager::kApplicationDomain)) {
+		height = MAX<uint>(ConfMan.getInt("last_window_height", Common::ConfigManager::kApplicationDomain), height);
 	}
+	if (ConfMan.getBool("widescreen_mod")) {
+		width = Renderer::kOriginalWidth * (int)height / Renderer::kFrameHeight;
+	} else {
+		width = Renderer::kOriginalWidth * (int)height / Renderer::kOriginalHeight;
+	}
+
+	// Save dimensions to config file to set up preferred window configuration
+	ConfMan.setInt("last_window_width", width, Common::ConfigManager::kApplicationDomain);
+	ConfMan.setInt("last_window_height", height, Common::ConfigManager::kApplicationDomain);
+	ConfMan.flushToDisk();
 
 	if (isAccelerated) {
 		initGraphics3d(width, height);


### PR DESCRIPTION
In windowed mode, Myst 3 is expected to create a widescreen 16:9 window (min 853x480) when the Widescreen Mod is enabled, and a standard 4:3 window (min 640x480) when it's disabled.

Currently, a window is created using whatever dimensions were previously stored in the Config File (even if the requested size is larger), which may or may not match the requested window type.

To clarify, this isn't a graphics issue. It's a case of the engine not implementing the switch between window types properly.

The backend is dependent on the dimensions stored in the Config File to determine which type of window to create.

To effect the switch (4:3 <--> 16:9), the engine needs to set up the Config File with the preferred window configuration, prior to initiating the window request. 

We fix this issue by enabling the engine to calculate its preferred window size dynamically (based on the stored last_window_height value), then save these dimensions to the Config File, before proceeding with the window request.

Note: The game's current window type will persist when returning to the Launcher (potentially changing the Launcher's width). If required, the Launcher can be reconfigured by changing the game's Widescreen Mod status, relaunching the game to effect the change, then quitting back to the Launcher.