### PR TITLE
AUDIO: Introduce DISABLE_MAME_OPL

### DIFF
--- a/audio/fmopl.cpp
+++ b/audio/fmopl.cpp
@@ -81,7 +81,9 @@ OPL::OPL() {
 const Config::EmulatorDescription Config::_drivers[] = {
 	{ "auto", "<default>", kAuto, kFlagOpl2 | kFlagDualOpl2 | kFlagOpl3 },
 	{ "null", _s("None"), kNull, kFlagOpl2 | kFlagDualOpl2 | kFlagOpl3 },
+#ifndef DISABLE_MAME_OPL
 	{ "mame", _s("MAME OPL emulator"), kMame, kFlagOpl2 },
+#endif
 #ifndef DISABLE_DOSBOX_OPL
 	{ "db", _s("DOSBox OPL emulator"), kDOSBox, kFlagOpl2 | kFlagDualOpl2 | kFlagOpl3 },
 #endif
@@ -201,12 +203,14 @@ OPL *Config::create(DriverId driver, OplType type) {
 	}
 
 	switch (driver) {
+#ifndef DISABLE_MAME_OPL
 	case kMame:
 		if (type == kOpl2)
 			return new MAME::OPL();
 		else
 			warning("MAME OPL emulator only supports OPL2 emulation");
 		return nullptr;
+#endif
 
 #ifndef DISABLE_DOSBOX_OPL
 	case kDOSBox:

--- a/audio/softsynth/opl/mame.cpp
+++ b/audio/softsynth/opl/mame.cpp
@@ -22,6 +22,8 @@
  *
  */
 
+#ifndef DISABLE_MAME_OPL
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1253,3 +1255,5 @@ FM_OPL *makeAdLibOPL(int rate) {
 
 } // End of namespace MAME
 } // End of namespace OPL
+
+#endif // !DISABLE_MAME_OPL

--- a/audio/softsynth/opl/mame.h
+++ b/audio/softsynth/opl/mame.h
@@ -26,6 +26,8 @@
 #ifndef AUDIO_SOFTSYNTH_OPL_MAME_H
 #define AUDIO_SOFTSYNTH_OPL_MAME_H
 
+#ifndef DISABLE_MAME_OPL
+
 #include "common/scummsys.h"
 #include "common/random.h"
 
@@ -195,5 +197,7 @@ protected:
 
 } // End of namespace MAME
 } // End of namespace OPL
+
+#endif // !DISABLE_MAME_OPL
 
 #endif

--- a/backends/platform/atari/build-release030.sh
+++ b/backends/platform/atari/build-release030.sh
@@ -9,7 +9,7 @@ cd build-release030
 PLATFORM=m68k-atari-mintelf
 FASTCALL=false
 export ASFLAGS="-m68030"
-export CXXFLAGS="-m68030 -DDISABLE_FANCY_THEMES -DDISABLE_DOSBOX_OPL"
+export CXXFLAGS="-m68030 -DDISABLE_FANCY_THEMES -DDISABLE_DOSBOX_OPL -DDISABLE_MAME_OPL"
 export LDFLAGS="-m68030"
 
 export PKG_CONFIG_LIBDIR="$(${PLATFORM}-gcc -print-sysroot)/usr/lib/m68020-60/pkgconfig"

--- a/backends/platform/atari/readme.txt
+++ b/backends/platform/atari/readme.txt
@@ -105,7 +105,7 @@ executable size.
 - "null" music driver is automatically enabled (i.e. OPL emulation is never
   used but still allows playing speech/sfx samples and/or CD audio).
 
-- DOSBox OPL emulator is disabled => smaller executable size.
+- DOSBox and MAME OPL emulator is disabled => smaller executable size.
 
 FireBee package
 ~~~~~~~~~~~~~~~

--- a/backends/platform/atari/readme.txt.in
+++ b/backends/platform/atari/readme.txt.in
@@ -105,7 +105,7 @@ executable size.
 - "null" music driver is automatically enabled (i.e. OPL emulation is never
   used but still allows playing speech/sfx samples and/or CD audio).
 
-- DOSBox OPL emulator is disabled => smaller executable size.
+- DOSBox and MAME OPL emulator is disabled => smaller executable size.
 
 FireBee package
 ~~~~~~~~~~~~~~~

--- a/base/commandLine.cpp
+++ b/base/commandLine.cpp
@@ -180,7 +180,13 @@ static const char HELP_STRING4[] =
 	"  --enable-gs              Enable Roland GS mode for MIDI playback\n"
 	"  --output-channels=CHANNELS Select output channel count (e.g. 2 for stereo)\n"
 	"  --output-rate=RATE       Select output sample rate in Hz (e.g. 22050)\n"
-	"  --opl-driver=DRIVER      Select AdLib (OPL) emulator (db, mame"
+	"  --opl-driver=DRIVER      Select AdLib (OPL) emulator ("
+#ifndef DISABLE_MAME_OPL
+																	 "mame"
+#endif
+#ifndef DISABLE_DOSBOX_OPL
+																	 ", db"
+#endif
 #ifndef DISABLE_NUKED_OPL
 																	 ", nuked"
 #endif

--- a/configure
+++ b/configure
@@ -4230,7 +4230,6 @@ case $_backend in
 	atari)
 		define_in_config_if_yes yes "ATARI"
 		append_var DEFINES "-DDISABLE_NES_APU"
-		#append_var DEFINES "-DDISABLE_DOSBOX_OPL"
 		append_var LIBS "-lgem"
 		_ogg=no
 		_vorbis=no


### PR DESCRIPTION
Similar to DISABLE_DOSBOX_OPL and DISABLE_NUKED_OPL. Now with the null driver available, weaker backends can be completely OPL emulation free.