### PR TITLE
DIRECTOR: DT: Fix crash when opening Cast Details in the ImGui debugger

### DIFF
--- a/engines/director/debugger/debugtools.cpp
+++ b/engines/director/debugger/debugtools.cpp
@@ -421,9 +421,13 @@ ImGuiImage getTextID(CastMember *castMember) {
 	// Make a temporary channel to blit the shape from
 	Channel *channel = new Channel(nullptr, sprite);
 
-	Graphics::MacText *widget = (Graphics::MacText *)castMember->createWidget(bbox, channel, kTextSprite);
+	Graphics::MacWidget *widget = castMember->createWidget(bbox, channel, kTextSprite);
 	Graphics::Surface surface;
-	surface.copyFrom(*widget->getRawSurface());
+
+	if (!widget || !widget->getSurface() || !widget->getSurface()->getPixels())
+      return {};
+
+	surface.copyFrom(*widget->getSurface());
 
 	if (debugChannelSet(8, kDebugImages)) {
 		Common::String prepend = "text";


### PR DESCRIPTION
- Fix crash when opening Cast Details in the ImGui debugger 
- `getTextID()` was casting `MacWidget*` (returned by `RichTextCastMember::createWidget`) to `Graphics::MacText*` and calling `getRawSurface()`, accessing deallocated memory
 - Fixed by using `MacWidget::getSurface()` directly and adding a null guard

