### PR TITLE
DIRECTOR: Fix ImGui cast viewer crash and filmloop animation regression

### DIFF
--- a/engines/director/castmember/filmloop.cpp
+++ b/engines/director/castmember/filmloop.cpp
@@ -138,6 +138,9 @@ Common::Array<Channel> *FilmLoopCastMember::getSubChannels(Common::Rect &bbox, u
 		if (src._castId.isNull())
 			continue;
 
+		if (src._cast == nullptr && _cast != nullptr)
+			src._cast = _cast->getCastMember(src._castId.member, true);
+
 		debugCN(5, kDebugImages, "FilmLoopCastMember::getSubChannels(): sprite: %d - cast: %s, orig: %d,%d %dx%d",
 				iter, src._castId.asString().c_str(),
 				src._startPoint.x, src._startPoint.y, src._width, src._height);

--- a/engines/director/castmember/filmloop.cpp
+++ b/engines/director/castmember/filmloop.cpp
@@ -109,8 +109,8 @@ Common::Array<Channel> *FilmLoopCastMember::getSubChannels(Common::Rect &bbox, u
 
 	// get the list of sprite IDs for this frame
 	Common::Array<int> spriteIds;
-	for (uint i = 0; i < _score->_channels.size(); ++i) {
-		if (_score->_channels[i]->_sprite && !_score->_channels[i]->_sprite->_castId.isNull())
+	for (uint i = 0; i < _score->_scoreCache[frame]->_sprites.size(); ++i) {
+		if (_score->_scoreCache[frame]->_sprites[i] && !_score->_scoreCache[frame]->_sprites[i]->_castId.isNull())
 			spriteIds.push_back(i);
 	}
 
@@ -134,7 +134,7 @@ Common::Array<Channel> *FilmLoopCastMember::getSubChannels(Common::Rect &bbox, u
 
 	// copy the sprites in order to the list
 	for (auto &iter : spriteIds) {
-		Sprite src = *_score->_channels[iter]->_sprite;
+		Sprite src = *_score->_scoreCache[frame]->_sprites[iter];
 		if (src._castId.isNull())
 			continue;
 

--- a/engines/director/debugger/debugtools.cpp
+++ b/engines/director/debugger/debugtools.cpp
@@ -421,9 +421,13 @@ ImGuiImage getTextID(CastMember *castMember) {
 	// Make a temporary channel to blit the shape from
 	Channel *channel = new Channel(nullptr, sprite);
 
-	Graphics::MacText *widget = (Graphics::MacText *)castMember->createWidget(bbox, channel, kTextSprite);
+	Graphics::MacWidget *widget = castMember->createWidget(bbox, channel, kTextSprite);
 	Graphics::Surface surface;
-	surface.copyFrom(*widget->getRawSurface());
+
+	if (!widget || !widget->getSurface() || !widget->getSurface()->getPixels())
+      return {};
+
+	surface.copyFrom(*widget->getSurface());
 
 	if (debugChannelSet(8, kDebugImages)) {
 		Common::String prepend = "text";

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -930,21 +930,14 @@ void Score::incrementFilmLoops() {
 		if (it->_sprite->_cast && (it->_sprite->_cast->_type == kCastFilmLoop || it->_sprite->_cast->_type == kCastMovie)) {
 			FilmLoopCastMember *fl = ((FilmLoopCastMember *)it->_sprite->_cast);
 			if (!fl->_score->_scoreCache.empty()) {
-				// increment the film loop counter
 				if (fl->_looping) {
-					if (fl->_score->_curFrameNumber + 1 > fl->_score->getFramesNum())
-						fl->_score->setCurrentFrame(1);
-
-					fl->_score->step();
-				} else {
-					if (fl->_score->_curFrameNumber < fl->_score->getFramesNum() - 1)
-						fl->_score->step();
-					else
-						fl->_score->stopPlay();
+					it->_filmLoopFrame += 1;
+					it->_filmLoopFrame %= fl->_score->_scoreCache.size();
+				} else if (it->_filmLoopFrame < (fl->_score->_scoreCache.size() - 1)) {
+					it->_filmLoopFrame += 1;
 				}
-
 			} else {
-				warning("Score::updateFilmLoops(): invalid film loop in castId %s", it->_sprite->_castId.asString().c_str());
+				warning("Score::incrementFilmLoops(): invalid film loop in castId %s", it->_sprite->_castId.asString().c_str());
 			}
 		}
 	}


### PR DESCRIPTION
Fix 2 bugs:
- Fix crash when opening Cast window in the ImGui debugger.
    - getTextID() was incorrectly casting the MacWidget* returned by
      createWidget() to Graphics::MacText* and calling getRawSurface(),
      which is invalid when the widget is not a MacText.
    - Fixed by using MacWidget::getSurface() directly and adding a null guard.

- Fix filmloop animation regression from e720eaf7550.
    - getSubChannels() was reading sprites from _score->_channels, whose _cast pointers were null because castLib=-1 references couldn't be resolved at runtime. 
     - Switch back to reading from _scoreCache and resolve castLib=-1 sprites against the filmloop's own _cast, which is the enclosing movie's cast library.
    - incrementFilmLoops() was calling score->step() which is gated by _nextFrameTime and has unsafe side effects (accessing the game's movie stack, resetting video playback). Replace with a direct _filmLoopFrame increment instead.