### PR TITLE
SCUMM: MONKEY1: Workaround for issue giving room notes to Herman

### DIFF
--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -1188,25 +1188,8 @@ void ScummEngine::checkAndRunSentenceScript() {
 	_sentenceNum--;
 	SentenceTab &st = _sentence[_sentenceNum];
 
-	// WORKAROUND: Monkey Island 1 note/Herman bug #12010.
-	//
-	// This workaround fixes an issue where the scripts would get stuck in a loop
-	// if you tried to give a note to Herman while the note was still in the room
-	// and not in the inventory.
-	// This intercepts the specific note objects that appear in rooms where Herman
-	// can be present, consumes the invalid give, and queues a pickup instead.
-	if ((_game.id == GID_MONKEY || _game.id == GID_MONKEY_EGA || _game.id == GID_MONKEY_VGA) &&
-		enhancementEnabled(kEnhMinorBugFixes) &&
-		// Give(EGA 3, VGA 4)
-		st.verb == (_game.id == GID_MONKEY_EGA ? 3 : 4) &&
-		st.objectB == 7 && // Herman
-		getOwner(st.objectA) == OF_OWNER_ROOM && // Object in room, not inventory
-		// note (volcano beach VGA), note (dry pond VGA), note (volcano beach EGA), note (dry pond EGA)
-		(st.objectA == 27 || st.objectA == 545 || st.objectA == 296 || st.objectA == 297)) {
-		// Pick up(EGA 11, VGA 9)
-		doSentence(_game.id == GID_MONKEY_EGA ? 11 : 9, st.objectA, 0); // Pick up
+	if (monkey1HermanNoteWorkaround(st))
 		return;
-	}
 
 	if (_game.version < 7)
 		if (st.preposition && st.objectB == st.objectA)
@@ -1279,6 +1262,30 @@ void ScummEngine_v0::walkToActorOrObject(int object) {
 		a->stopActorMoving();
 		a->_newWalkBoxEntered = false;
 	}
+}
+
+bool ScummEngine::monkey1HermanNoteWorkaround(const SentenceTab &st) {
+	// WORKAROUND: Monkey Island 1 note/Herman bug #12010.
+	//
+	// This workaround fixes an issue where the scripts would get stuck in a loop
+	// if you tried to give a note to Herman while the note was still in the room
+	// and not in the inventory.
+	// This intercepts the specific note objects that appear in rooms where Herman
+	// can be present, consumes the invalid give, and queues a pickup instead.
+	if ((_game.id == GID_MONKEY || _game.id == GID_MONKEY_EGA || _game.id == GID_MONKEY_VGA) &&
+		enhancementEnabled(kEnhMinorBugFixes) &&
+		// Give(EGA 3, VGA 4)
+		st.verb == (_game.id == GID_MONKEY_EGA ? 3 : 4) &&
+		st.objectB == 7 && // Herman
+		getOwner(st.objectA) == OF_OWNER_ROOM && // Object in room, not inventory
+		// note (volcano beach VGA), note (dry pond VGA), note (volcano beach EGA), note (dry pond EGA)
+		(st.objectA == 27 || st.objectA == 545 || st.objectA == 296 || st.objectA == 297)) {
+		// Pick up(EGA 11, VGA 9)
+		doSentence(_game.id == GID_MONKEY_EGA ? 11 : 9, st.objectA, 0);
+		return true;
+	}
+
+	return false;
 }
 
 bool ScummEngine_v0::checkPendingWalkAction() {

--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -1195,16 +1195,16 @@ void ScummEngine::checkAndRunSentenceScript() {
 	// and not in the inventory.
 	// This intercepts the specific note objects that appear in rooms where Herman
 	// can be present, consumes the invalid give, and queues a pickup instead.
-
-	if (_game.id == GID_MONKEY &&
+	if ((_game.id == GID_MONKEY || _game.id == GID_MONKEY_EGA || _game.id == GID_MONKEY_VGA) &&
 		enhancementEnabled(kEnhMinorBugFixes) &&
-		st.verb == 4 && // Give
+		// Give(EGA 3, VGA 4)
+		st.verb == (_game.id == GID_MONKEY_EGA ? 3 : 4) &&
 		st.objectB == 7 && // Herman
-		getOwner(st.objectA) == OF_OWNER_ROOM && (
-		st.objectA == 27 || // note (volcano beach)
-		st.objectA == 545))  // note (dry pond)
-	{
-		doSentence(9, st.objectA, 0);
+		getOwner(st.objectA) == OF_OWNER_ROOM && // Object in room, not inventory
+		// note (volcano beach VGA), note (dry pond VGA), note (volcano beach EGA), note (dry pond EGA)
+		(st.objectA == 27 || st.objectA == 545 || st.objectA == 296 || st.objectA == 297)) {
+		// Pick up(EGA 11, VGA 9)
+		doSentence(_game.id == GID_MONKEY_EGA ? 11 : 9, st.objectA, 0); // Pick up
 		return;
 	}
 

--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -1197,7 +1197,6 @@ void ScummEngine::checkAndRunSentenceScript() {
 	// can be present, consumes the invalid give, and queues a pickup instead.
 
 	if (_game.id == GID_MONKEY &&
-		_game.version == 5 &&
 		enhancementEnabled(kEnhMinorBugFixes) &&
 		st.verb == 4 && // Give
 		st.objectB == 7 && // Herman

--- a/engines/scumm/script.cpp
+++ b/engines/scumm/script.cpp
@@ -1188,6 +1188,27 @@ void ScummEngine::checkAndRunSentenceScript() {
 	_sentenceNum--;
 	SentenceTab &st = _sentence[_sentenceNum];
 
+	// WORKAROUND: Monkey Island 1 note/Herman bug #12010.
+	//
+	// This workaround fixes an issue where the scripts would get stuck in a loop
+	// if you tried to give a note to Herman while the note was still in the room
+	// and not in the inventory.
+	// This intercepts the specific note objects that appear in rooms where Herman
+	// can be present, consumes the invalid give, and queues a pickup instead.
+
+	if (_game.id == GID_MONKEY &&
+		_game.version == 5 &&
+		enhancementEnabled(kEnhMinorBugFixes) &&
+		st.verb == 4 && // Give
+		st.objectB == 7 && // Herman
+		getOwner(st.objectA) == OF_OWNER_ROOM && (
+		st.objectA == 27 || // note (volcano beach)
+		st.objectA == 545))  // note (dry pond)
+	{
+		doSentence(9, st.objectA, 0);
+		return;
+	}
+
 	if (_game.version < 7)
 		if (st.preposition && st.objectB == st.objectA)
 			return;

--- a/engines/scumm/scumm.h
+++ b/engines/scumm/scumm.h
@@ -1074,6 +1074,7 @@ protected:
 	virtual void runInventoryScript(int i);
 	virtual void runInventoryScriptEx(int i);
 	virtual void checkAndRunSentenceScript();
+	bool monkey1HermanNoteWorkaround(const SentenceTab &st);
 	void runExitScript();
 	void runEntryScript();
 	void runQuitScript();


### PR DESCRIPTION
This PR adds a workaround for an original MI1 script bug:
https://bugs.scummvm.org/ticket/12010

The bug occurs when the player tries to give a note to Herman while it is still on the ground. Script 2 incorrectly executes both the original Give and a pickup, causing the invalid Give to persist and repeatedly re-enter the memo stack scripts.

This results in an infinite loop of Guybrush reading notes, leaving the player unable to easily regain control.

The fix catches the sentence in checkAndRunSentenceScript(), consumes the invalid Give, and replaces it with a Pickup. This prevents the loop while preserving the intended behavior (picking up and reading the note first).

The workaround is gated behind kEnhMinorBugFixes and limited to MI1.
I've tested this in all the problematic rooms and it appears to work without breaking any other functionality.

**REPRO STEPS**(Taken from the original bug report)**:**

1. Start ScummVM/Monkey 1 with the bootparam 9432.
2. Reach the fort.
3. Push the cannon.
4. Pick the scope.
5. Talk with Herman Toothrot, be nice and don't rush.
6. Go out of the fort and enter back: talk again with HT, be nice and don't rush.
7. Go out of the fort, reach the closest beach.
8. Go by the water edge, talk with HT when he appears and again be nice and don't rush, so HT will stay by the beach a few seconds.
9. As soon as you stop talking to HT, "Give" the notes on the beach to HT.