### PR TITLE
GUI: Don't close GridItemTray too hastily if mouse is outside of it

### DIFF
--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -312,7 +312,7 @@ void GridItemWidget::handleMouseUp(int x, int y, int button, int clickCount) {
 #pragma mark -
 
 GridItemTray::GridItemTray(GuiObject *boss, int x, int y, int w, int h, int entryID, GridWidget *grid)
-	: Dialog(x, y, w, h), CommandSender(boss) {
+	: Dialog(x, y, w, h), CommandSender(boss), _mouseOutside(false) {
 
 	_entryID = entryID;
 	_boss = boss;
@@ -388,12 +388,23 @@ void GridItemTray::handleMouseWheel(int x, int y, int direction) {
 	close();
 }
 
+void GridItemTray::receivedFocus(int x, int y) {
+	// Don't call our handleMouseMoved when receiving focus
+	// to avoid spurious closing if the cursor is outside of the tray
+	if (x >= 0 && y >= 0) {
+		Dialog::handleMouseMoved(x, y, 0);
+		_mouseOutside = ((x < 0 || x > _w) || (y > _h || y < -(_grid->_gridItemHeight)));
+	}
+}
+
 void GridItemTray::handleMouseMoved(int x, int y, int button) {
 	Dialog::handleMouseMoved(x, y, button);
-	if ((x < 0 || x > _w) || (y > _h || y < -(_grid->_gridItemHeight))) {
+	bool mouseOutside = (x < 0 || x > _w) || (y > _h || y < -(_grid->_gridItemHeight));
+	if (mouseOutside && !_mouseOutside) {
 		// Close on going outside
 		close();
 	}
+	_mouseOutside = mouseOutside;
 }
 
 #pragma mark -

--- a/gui/widgets/grid.h
+++ b/gui/widgets/grid.h
@@ -85,12 +85,15 @@ class GridItemTray: public Dialog, public CommandSender {
 	PicButtonWidget	*_playButton;
 	PicButtonWidget	*_loadButton;
 	PicButtonWidget	*_editButton;
+
+	bool _mouseOutside;
 public:
 	GridItemTray(GuiObject *boss, int x, int y, int w, int h, int entryID, GridWidget *grid);
 	void enableLoadButton(bool canLoad) { _loadButton->setEnabled(canLoad); }
 
 	void reflowLayout() override;
 
+	void receivedFocus(int x = -1, int y = -1) override;
 	void handleCommand(CommandSender *sender, uint32 cmd, uint32 data) override;
 	void handleMouseDown(int x, int y, int button, int clickCount) override;
 	void handleMouseUp(int x, int y, int button, int clickCount) override;


### PR DESCRIPTION
The mouse can end up outside of the tray when scrolling and the just clicked game has a short name.
Instead, register the case and close the tray only when mouse ended up in it and left again.

Fix #16688.