### PR TITLE
AGOS: SIMON1: Remap Amiga CD32 and AGA displayBoxStars color.

### DIFF
--- a/engines/agos/draw.cpp
+++ b/engines/agos/draw.cpp
@@ -525,7 +525,12 @@ void AGOSEngine::displayBoxStars() {
 
 	if (getGameType() == GType_SIMON2)
 		color = 236;
-	else
+	else if (getGameType() == GType_SIMON1 &&
+		getPlatform() == Common::kPlatformAmiga &&
+		// Original Amiga AGA/CD32 code remaps Simon 1 star color, OCS does not.
+		!(getFeatures() & GF_32COLOR)) {
+			color = 241;
+	} else
 		color = 225;
 
 	uint curHeight = (getGameType() == GType_SIMON2) ? _boxStarHeight : 134;


### PR DESCRIPTION
This PR fixes bug [#15413](https://bugs.scummvm.org/ticket/15413) by remapping the displayBoxStars color like the original does for the Amiga AGA and CD32 versions.

The CD32 and AGA executables have an explicit check and remap, this does not happen for the OCS version: 
```
cmp.b		#$E1, d4   ; 225
bne			$A3D8
move.bne	#$F1, d4   ; 241
```