### PR TITLE
AGOS: SIMON2: Correctly detect Mac/Amiga Simon2. Fixes bug #16705

### DIFF
--- a/engines/agos/agos.cpp
+++ b/engines/agos/agos.cpp
@@ -644,8 +644,8 @@ Common::Error AGOSEngine::init() {
 
 	_midi = new MidiPlayer(this);
 
-	if ((getGameType() == GType_SIMON2 && getPlatform() == Common::kPlatformWindows) || 
-			(getGameType() == GType_SIMON2 && getPlatform() == Common::kPlatformAmiga) ||
+	if ((getGameType() == GType_SIMON2 && getPlatform() == Common::kPlatformWindows) ||
+			(getGameType() == GType_SIMON2 && (getPlatform() == Common::kPlatformAmiga || isSimon2MacAmiga())) ||
 			(getGameType() == GType_SIMON1 && getPlatform() == Common::kPlatformWindows) ||
 			((getFeatures() & GF_TALKIE) && getPlatform() == Common::kPlatformAcorn) ||
 			(getPlatform() == Common::kPlatformDOS && getGameType() != GType_PN && getGameType() != GType_FF) ||

--- a/engines/agos/agos.h
+++ b/engines/agos/agos.h
@@ -288,6 +288,7 @@ public:
 	int getGameType() const;
 	uint32 getFeatures() const;
 	const char *getExtra() const;
+	bool isSimon2MacAmiga() const;
 	Common::Language getLanguage() const;
 	Common::Platform getPlatform() const;
 	const char *getFileName(int type) const;

--- a/engines/agos/detection_tables.h
+++ b/engines/agos/detection_tables.h
@@ -3054,11 +3054,12 @@ static const AGOSGameDescription gameDescriptions[] = {
 		GF_TALKIE
 	},
 
-	// Simon the Sorcerer 2 - Amiga CD (Update 5)
+	// Simon the Sorcerer 2 - Mac/Amiga CD (Update 5)
+	// kPlatformUnknown because Mac/Amiga(update 5) are identical.
 	{
 		{
 			"simon2",
-			"Amiga CD - Update 5",
+			"Mac/Amiga(Update 5)",
 
 			{
 				{ "gsptr30",		GAME_BASEFILE,	"608e277904d87dd28725fa08eacc2c0d", 58652},
@@ -3070,7 +3071,7 @@ static const AGOSGameDescription gameDescriptions[] = {
 				AD_LISTEND
 			},
 			Common::EN_ANY,
-			Common::kPlatformAmiga,
+			Common::kPlatformUnknown,
 			ADGF_CD,
 			GUIO1(GAMEOPTION_DISABLE_FADE_EFFECTS)
 		},

--- a/engines/agos/metaengine.cpp
+++ b/engines/agos/metaengine.cpp
@@ -373,6 +373,14 @@ const char *AGOSEngine::getExtra() const {
 	return _gameDescription->desc.extra;
 }
 
+//The Mac release of Simon 2 uses identical data to the Amiga release with update 5
+//It is still distinct from the Original Amiga release(simon2.german is different)
+bool AGOSEngine::isSimon2MacAmiga() const {
+	return getGameType() == GType_SIMON2 &&
+		getPlatform() == Common::kPlatformUnknown &&
+		!strcmp(getExtra(), "Mac/Amiga(Update 5)");
+}
+
 Common::Language AGOSEngine::getLanguage() const {
 	return _gameDescription->desc.language;
 }

--- a/engines/agos/metaengine.cpp
+++ b/engines/agos/metaengine.cpp
@@ -377,8 +377,7 @@ const char *AGOSEngine::getExtra() const {
 // It is still distinct from the Original Amiga release (simon2.german is different)
 bool AGOSEngine::isSimon2MacAmiga() const {
 	return getGameType() == GType_SIMON2 &&
-		getPlatform() == Common::kPlatformUnknown &&
-		!strcmp(getExtra(), "Mac/Amiga(Update 5)");
+		getPlatform() == Common::kPlatformUnknown;
 }
 
 Common::Language AGOSEngine::getLanguage() const {

--- a/engines/agos/metaengine.cpp
+++ b/engines/agos/metaengine.cpp
@@ -373,8 +373,8 @@ const char *AGOSEngine::getExtra() const {
 	return _gameDescription->desc.extra;
 }
 
-//The Mac release of Simon 2 uses identical data to the Amiga release with update 5
-//It is still distinct from the Original Amiga release(simon2.german is different)
+// The Mac release of Simon 2 uses identical data to the Amiga release with update 5.
+// It is still distinct from the Original Amiga release (simon2.german is different)
 bool AGOSEngine::isSimon2MacAmiga() const {
 	return getGameType() == GType_SIMON2 &&
 		getPlatform() == Common::kPlatformUnknown &&


### PR DESCRIPTION
This PR addresses bug report [16705](https://bugs.scummvm.org/ticket/16705#comment:2).

It uses kPlatformUnknown for the detection entry of the Mac/Amiga(Update 5) release of Simon 2, these two releases have identical file sets.

This solution was proposed by Sev here: https://discord.com/channels/581224060529148060/711242520415174666/1497607927303901205