### PR TITLE
AGOS: ELVIRA1: Add detection/PRG name for FR Atari ST version.

### DIFF
--- a/engines/agos/detection_tables.h
+++ b/engines/agos/detection_tables.h
@@ -246,6 +246,30 @@ static const AGOSGameDescription gameDescriptions[] = {
 		GF_OLD_BUNDLE | GF_CRUNCHED | GF_PLANAR
 	},
 
+	// Elvira 1 - French Atari ST Floppy
+	// Suppliedd by Parotaku in bug report #16707
+	{
+		{
+			"elvira1",
+			"Floppy",
+
+			{
+				{"gamest", 		GAME_BASEFILE, 	"39bb4399d1b79a9c9d60279237a856f9", 120990},
+				{"icon.dat", 	GAME_ICONFILE, 	"2db931e84f1ca01f0816dddfae3f49e1", 36573},
+				{"tbllist", 	GAME_TBLFILE, 	"5b6ff494bf7e24213758598ef4ac0a8b", 476},
+				AD_LISTEND
+			},
+			Common::FR_FRA,
+			Common::kPlatformAtariST,
+			ADGF_NO_FLAGS,
+			GUIO2(GUIO_NOSPEECH, GUIO_NOMIDI)
+		},
+
+		GType_ELVIRA1,
+		GID_ELVIRA1,
+		GF_OLD_BUNDLE | GF_CRUNCHED | GF_PLANAR
+	},
+
 	// Elvira 1 - German Atari ST Floppy
 	{
 		{

--- a/engines/agos/res_snd.cpp
+++ b/engines/agos/res_snd.cpp
@@ -187,6 +187,7 @@ static Common::SeekableReadStream *openElvira1AtariSTPrg() {
 		"ELVIRA.PRG",
 		"ELVIRA+.PRG",
 		"RUNENG.PRG",
+		"RUNFRNCH.PRG",
 		"AUTO/RUNENG.PRG",
 		"AUTO/ADEMO.PRG",
 		"ADEMO.PRG"


### PR DESCRIPTION
This PR adds a detection entry and the PRG name for French Atari ST Elvira I.

This fixes [bug report #16707](https://bugs.scummvm.org/ticket/16707)