### PR TITLE
DIRECTOR: Fix FilmLoop registration offset and minor DT changes

### DIFF
--- a/engines/director/castmember/filmloop.cpp
+++ b/engines/director/castmember/filmloop.cpp
@@ -254,11 +254,15 @@ void FilmLoopCastMember::unload() {
 }
 
 Common::Point FilmLoopCastMember::getRegistrationOffset() {
-	return Common::Point(_initialRect.width() / 2, _initialRect.height() / 2);
+	if (_center)
+		return Common::Point(_initialRect.width() / 2, _initialRect.height() / 2);
+	return Common::Point(0, 0);
 }
 
 Common::Point FilmLoopCastMember::getRegistrationOffset(int16 currentWidth, int16 currentHeight) {
-	return Common::Point(currentWidth / 2, currentHeight / 2);
+	if(_center)
+		return Common::Point(currentWidth / 2, currentHeight / 2);
+	return Common::Point(0, 0);
 }
 
 uint32 FilmLoopCastMember::getCastDataSize() {

--- a/engines/director/debugger/dt-score.cpp
+++ b/engines/director/debugger/dt-score.cpp
@@ -1295,6 +1295,7 @@ void showChannels() {
 					ImGui::PopID();
 				}
 
+				// Channel number
 				ImGui::TableNextColumn();
 
 				bool isSelected = (_state->_selectedChannel == i + 1);
@@ -1310,6 +1311,7 @@ void showChannels() {
 					_state->_windowToRedraw = selectedWindow;
 				}
 
+				// Cast ID
 				ImGui::TableNextColumn();
 
 				if (sprite._castId.member) {
@@ -1318,37 +1320,62 @@ void showChannels() {
 
 					Common::Point position = channel.getPosition();
 					ImGui::Text("%s", sprite._castId.asString().c_str());
+
+					// visibility
 					ImGui::TableNextColumn();
 					colN = "##vis" + chNum;
 					if (ImGui::Checkbox(colN.c_str(), &channel._visible)) {
 						_state->_windowToRedraw = selectedWindow;
 					}
+
+					// inkData
 					ImGui::TableNextColumn();
 					ImGui::Text("0x%02x", sprite._inkData);
+
+					// ink
 					ImGui::TableNextColumn();
 					ImGui::Text("%d (%s)", sprite._ink, inkType2str(sprite._ink));
+
+					// trails
 					ImGui::TableNextColumn();
 					colN = "##trails" + chNum;
 					ImGui::Checkbox(colN.c_str(), &sprite._trails);
+
+					// stretch
 					ImGui::TableNextColumn();
 					colN = "##stretch" + chNum;
 					ImGui::Checkbox(colN.c_str(), &sprite._stretch);
+
+					// line
 					ImGui::TableNextColumn();
 					ImGui::Text("%d", sprite._thickness);
+
+					// dims
 					ImGui::TableNextColumn();
 					ImGui::Text("%dx%d@%d,%d", channel.getWidth(), channel.getHeight(), position.x, position.y);
+
+					// type
 					ImGui::TableNextColumn();
-					ImGui::Text("%d (%s)", sprite._spriteType, spriteType2str(sprite._spriteType));
+					if (sprite._spriteType == kCastMemberSprite && sprite._cast)
+						ImGui::Text("%d (%s)", sprite._spriteType, castType2str(sprite._cast->_type));
+					else
+						ImGui::Text("%d (%s)", sprite._spriteType, spriteType2str(sprite._spriteType));
+
+					// fq
 					ImGui::TableNextColumn();
 					ImGui::PushID(i + 1);
 					ImGui::Text("%3d", sprite._foreColor); ImGui::SameLine();
 					ImGui::ColorButton("foreColor", convertColor(sprite._foreColor));
 					ImGui::PopID();
+
+					// bq
 					ImGui::TableNextColumn();
 					ImGui::PushID(i + 1);
 					ImGui::Text("%3d", sprite._backColor); ImGui::SameLine();
 					ImGui::ColorButton("backColor", convertColor(sprite._backColor));
 					ImGui::PopID();
+
+					// script
 					ImGui::TableNextColumn();
 
 					if (score->_version >= kFileVer600) {
@@ -1391,31 +1418,47 @@ void showChannels() {
 						}
 					}
 
+					// colorcode
 					ImGui::TableNextColumn();
 					ImGui::Text("0x%x", sprite._colorcode);
+
+					// blend amount
 					ImGui::TableNextColumn();
 					ImGui::Text("0x%x", sprite._blendAmount);
+
+					// unk3
 					ImGui::TableNextColumn();
 					ImGui::Text("0x%x", sprite._unk3);
+
+					// constraint
 					ImGui::TableNextColumn();
 					ImGui::Text("%d", channel._constraint);
+
+					// puppet
 					ImGui::TableNextColumn();
 					colN = "##puppet" + chNum;
 					ImGui::Checkbox(colN.c_str(), &sprite._puppet);
+
+					// moveable
 					ImGui::TableNextColumn();
 					colN = "##moveable" + chNum;
 					ImGui::Checkbox(colN.c_str(), &sprite._moveable);
+
+					// movieRate
 					ImGui::TableNextColumn();
 					if (channel._movieRate)
 						ImGui::Text("%f", channel._movieRate);
 					else
 						ImGui::Text("0");
+
+					// movieTime
 					ImGui::TableNextColumn();
 					if (channel._movieRate)
 						ImGui::Text("%d (%f)", channel._movieTime, (float)(channel._movieTime/60.0f));
 					else
 						ImGui::Text("0");
 				} else {
+					// invalid castID
 					ImGui::Text("000");
 				}
 			}

--- a/engines/director/debugger/dt-scripts.cpp
+++ b/engines/director/debugger/dt-scripts.cpp
@@ -548,7 +548,7 @@ void showExecutionContext() {
 	Window *currentWindow = g_director->getCurrentWindow();
 	bool scriptsRendered = false;
 
-	if (ImGui::Begin("Execution Context", &_state->_w.executionContext, ImGuiWindowFlags_AlwaysAutoResize)) {
+	if (ImGui::Begin("Execution Context", &_state->_w.executionContext)) {
 		Window *stage = g_director->getStage();
 		g_director->setCurrentWindow(stage);
 		g_lingo->switchStateFromWindow();
@@ -557,7 +557,7 @@ void showExecutionContext() {
 		ImGui::PushID(windowID);
 		ImGui::PushStyleColor(ImGuiCol_ChildBg, ImGui::GetStyleColorVec4(ImGuiCol_FrameBg));
 
-		ImGui::BeginChild("Window##", ImVec2(500.0f, 700.0f));
+		ImGui::BeginChild("Window##", ImGui::GetContentRegionAvail());
 		ImGui::Text("%s", stage->asString().c_str());
 		ImGui::Text("%s", stage->getCurrentMovie()->getMacName().c_str());
 


### PR DESCRIPTION
- Fix filmloops shifting when rendering in shotgal.dir (guscan-win)
    - `FilmLoopCastMember::getRegistrationOffset()` always returned the center `(width/2, height/2)`, ignoring the `_center` flag.
    - Fix by returning `(0, 0)` when `_center` is false, and center only when `_center` is true.

Debug Tools:
- The channels window now updates the cast member type if it changes (`kCastMemberSprites`).
- Execution context window can now be resized.