### PR TITLE
AGOS: SIMON2: Fix Amiga/Mac sounds. Fixes bug #16712

### DIFF
--- a/engines/agos/sound.cpp
+++ b/engines/agos/sound.cpp
@@ -462,7 +462,8 @@ void Sound::loadSfxTable(const char *gameFilename, uint32 base) {
 
 	delete _effects;
 	const bool dataIsUnsigned = true;
-	if (_vm->getPlatform() == Common::kPlatformWindows || (_vm->getFeatures() & GF_WAVSFX))
+	if (_vm->getPlatform() == Common::kPlatformWindows || _vm->getPlatform() == Common::kPlatformAmiga ||
+			_vm->isSimon2MacAmiga() || (_vm->getFeatures() & GF_WAVSFX))
 		_effects = new WavSound(_mixer, gameFilename, base);
 	else
 		_effects = new VocSound(_mixer, gameFilename, dataIsUnsigned, base, false);


### PR DESCRIPTION
This PR fixes bug [#16712](https://bugs.scummvm.org/ticket/16712#no1)

This change is required as the game was previously detected as the Windows version, after adding detection entries for Amiga and Mac, this is required to prevent a crash by ensuring the audio is routed the correct way.