### PR TITLE
MTROPOLIS: ignore COPYING.MPL from source tree in main segment search

### DIFF
--- a/engines/mtropolis/boot.cpp
+++ b/engines/mtropolis/boot.cpp
@@ -2657,14 +2657,21 @@ void findWindowsMainSegment(Common::Archive &fs, const BootScriptContext &bootSc
 	if (bootScriptContext.getMainSegmentFileOverride().empty()) {
 		fs.listMembers(allFiles);
 
+		const Common::Path copyingPath("workspace/LICENSES/COPYING.MPL");
+
 		for (const Common::ArchiveMemberPtr &archiveMember : allFiles) {
 			Common::String fileName = archiveMember->getFileName();
 
 			for (const char *suffix : mainSegmentSuffixes) {
 				if (fileName.hasSuffixIgnoreCase(suffix)) {
-					filteredFiles.push_back(archiveMember);
-					debug(4, "Identified possible main segment file %s", archiveMember->getPathInArchive().toString(fs.getPathSeparator()).c_str());
-					break;
+					// Ignore LICENSES/COPYING.MPL from the ScummVM source tree
+					if (archiveMember->getPathInArchive() != copyingPath) {
+						filteredFiles.push_back(archiveMember);
+						debug(4, "Identified possible main segment file %s", archiveMember->getPathInArchive().toString(fs.getPathSeparator()).c_str());
+						break;
+					} else {
+						debug(4, "Ignoring unlikely main segment file %s", archiveMember->getPathInArchive().toString(fs.getPathSeparator()).c_str());
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When building ScummVM directly from the Makefile and running ScummVM directly from the source tree root, mTropolis developers face the slightly silly problem that `LICENSES/COPYING.MPL` from the source tree is considered a main segment file for mTropolis, sharing the MPL file extension with that engine. The engine implementation is very strict and aborts the boot procedure if multiple such main segment files are found.

As a workaround, the file is given a hardcoded skip in the search.
Considering that we have now documented most known mTropolis titles with detection entries, it can be observed that this does not cause a collision with known titles.