### PR TITLE
CHAMBER: Move splash screen hardcoded filenames to detection flags

### DIFF
--- a/engines/chamber/chamber.cpp
+++ b/engines/chamber/chamber.cpp
@@ -58,6 +58,8 @@ ChamberEngine::ChamberEngine(OSystem *syst, const ADGameDescription *desc)
 	_renderMode = Common::parseRenderMode(ConfMan.get("render_mode"));
 	if (_renderMode == Common::kRenderEGA || _renderMode == Common::kRenderHercG || _renderMode == Common::kRenderHercA)
 		_videoMode = _renderMode;
+	else if (_renderMode == Common::kRenderDefault && Common::checkGameGUIOption(GUIO_RENDEREGA, Common::parseGameGUIOptions(ConfMan.get("guioptions"))))
+		_videoMode = Common::kRenderEGA;
 	else
 		_videoMode = Common::kRenderCGA;
 

--- a/engines/chamber/chamber.h
+++ b/engines/chamber/chamber.h
@@ -27,15 +27,15 @@
 #include "common/serializer.h"
 #include "common/rendermode.h"
 #include "engines/engine.h"
+#include "engines/advancedDetector.h"
 #include "gui/debugger.h"
 #include "chamber/renderer.h"
+#include "chamber/detection.h"
 
 namespace Audio {
 class SoundHandle;
 class PCSpeaker;
 }
-
-struct ADGameDescription;
 
 namespace Chamber {
 

--- a/engines/chamber/chamber.h
+++ b/engines/chamber/chamber.h
@@ -27,10 +27,9 @@
 #include "common/serializer.h"
 #include "common/rendermode.h"
 #include "engines/engine.h"
-#include "engines/advancedDetector.h"
-#include "gui/debugger.h"
 #include "chamber/renderer.h"
-#include "chamber/detection.h"
+
+struct ADGameDescription;
 
 namespace Audio {
 class SoundHandle;

--- a/engines/chamber/detection.cpp
+++ b/engines/chamber/detection.cpp
@@ -21,6 +21,7 @@
 
 #include "base/plugins.h"
 #include "engines/advancedDetector.h"
+#include "chamber/detection.h"
 
 namespace Chamber {
 static const PlainGameDescriptor ChamberGames[] = {
@@ -36,7 +37,7 @@ static const ADGameDescription gameDescriptions[] = {
 		AD_ENTRY1s("ere.pxi", "5aa5bd2d79eefde70675b0b6734944f2", 134358),
 		Common::UNK_LANG, // EN/FR/DE
 		Common::kPlatformDOS,
-		ADGF_UNSTABLE,
+		ADGF_UNSTABLE | GF_SPLASH_PRES | GF_SPLASH_DRAP,
 		GUIO3(GUIO_RENDERHERCGREEN, GUIO_RENDERHERCAMBER, GUIO_RENDERCGA)
 	},
 
@@ -46,9 +47,20 @@ static const ADGameDescription gameDescriptions[] = {
 		AD_ENTRY1s("kult1.pxi", "fc0bd31a3c380338f76ff53e421e47b6", 140537),
 		Common::EN_USA,
 		Common::kPlatformDOS,
-		ADGF_UNSTABLE,
+		ADGF_UNSTABLE | GF_SPLASH_PRESCGA,
 		GUIO3(GUIO_RENDERHERCGREEN, GUIO_RENDERHERCAMBER, GUIO_RENDERCGA)
 	},
+
+	// TODO: add EGA variant once Kult2.pxi MD5 is verified
+	// {
+	// 	"chamber",
+	// 	"EGA",
+	// 	AD_ENTRY1s("Kult2.pxi", "<md5>", <size>),
+	// 	Common::EN_USA,
+	// 	Common::kPlatformDOS,
+	// 	ADGF_UNSTABLE | GF_SPLASH_PRESEGA,
+	// 	GUIO1(GUIO_RENDEREGA)
+	// },
 
 	AD_TABLE_END_MARKER
 };

--- a/engines/chamber/detection.cpp
+++ b/engines/chamber/detection.cpp
@@ -62,7 +62,7 @@ static const ADGameDescription gameDescriptions[] = {
 	// 	Common::EN_USA,
 	// 	Common::kPlatformDOS,
 	// 	ADGF_UNSTABLE | GF_SPLASH_PRESEGA,
-	// 	GUIO1(GUIO_RENDEREGA)
+	// 	GUIO4(GUIO_RENDERHERCGREEN, GUIO_RENDERHERCAMBER, GUIO_RENDERCGA, GUIO_RENDEREGA)
 	// },
 
 	AD_TABLE_END_MARKER

--- a/engines/chamber/detection.cpp
+++ b/engines/chamber/detection.cpp
@@ -35,10 +35,10 @@ static const ADGameDescription gameDescriptions[] = {
 		"chamber",
 		"",
 		AD_ENTRY2s("ere.pxi",  "5aa5bd2d79eefde70675b0b6734944f2", 134358,
-		           "PRES.BIN", nullptr,                              0),
+		           "PRES.BIN", "b8376a81d9ef6d9c5f783c64f718a782",   8005),
 		Common::UNK_LANG, // EN/FR/DE
 		Common::kPlatformDOS,
-		ADGF_UNSTABLE | GF_SPLASH_PRES | GF_SPLASH_DRAP,
+		ADGF_UNSTABLE | GF_SPLASH_PRES | GF_SPLASH2_DRAP,
 		GUIO3(GUIO_RENDERHERCGREEN, GUIO_RENDERHERCAMBER, GUIO_RENDERCGA)
 	},
 
@@ -46,7 +46,7 @@ static const ADGameDescription gameDescriptions[] = {
 		"chamber",
 		"",
 		AD_ENTRY2s("kult1.pxi",   "fc0bd31a3c380338f76ff53e421e47b6", 140537,
-		           "PRESCGA.BIN", nullptr,                              0),
+		           "PRESCGA.BIN", "664a75a95340bde200a2752f54ba7aa7",   5105),
 		Common::EN_USA,
 		Common::kPlatformDOS,
 		ADGF_UNSTABLE | GF_SPLASH_PRESCGA,

--- a/engines/chamber/detection.cpp
+++ b/engines/chamber/detection.cpp
@@ -34,7 +34,8 @@ static const ADGameDescription gameDescriptions[] = {
 	{
 		"chamber",
 		"",
-		AD_ENTRY1s("ere.pxi", "5aa5bd2d79eefde70675b0b6734944f2", 134358),
+		AD_ENTRY2s("ere.pxi",  "5aa5bd2d79eefde70675b0b6734944f2", 134358,
+		           "PRES.BIN", nullptr,                              0),
 		Common::UNK_LANG, // EN/FR/DE
 		Common::kPlatformDOS,
 		ADGF_UNSTABLE | GF_SPLASH_PRES | GF_SPLASH_DRAP,
@@ -44,18 +45,20 @@ static const ADGameDescription gameDescriptions[] = {
 	{
 		"chamber",
 		"",
-		AD_ENTRY1s("kult1.pxi", "fc0bd31a3c380338f76ff53e421e47b6", 140537),
+		AD_ENTRY2s("kult1.pxi",   "fc0bd31a3c380338f76ff53e421e47b6", 140537,
+		           "PRESCGA.BIN", nullptr,                              0),
 		Common::EN_USA,
 		Common::kPlatformDOS,
 		ADGF_UNSTABLE | GF_SPLASH_PRESCGA,
 		GUIO3(GUIO_RENDERHERCGREEN, GUIO_RENDERHERCAMBER, GUIO_RENDERCGA)
 	},
 
-	// TODO: add EGA variant once Kult2.pxi MD5 is verified
+	// TODO: add EGA variant once Kult2.pxi and PRESEGA.EGA MD5s are verified
 	// {
 	// 	"chamber",
 	// 	"EGA",
-	// 	AD_ENTRY1s("Kult2.pxi", "<md5>", <size>),
+	// 	AD_ENTRY2s("Kult2.pxi",   "<md5>", <size>,
+	// 	           "PRESEGA.EGA", "<md5>", <size>),
 	// 	Common::EN_USA,
 	// 	Common::kPlatformDOS,
 	// 	ADGF_UNSTABLE | GF_SPLASH_PRESEGA,

--- a/engines/chamber/detection.cpp
+++ b/engines/chamber/detection.cpp
@@ -53,17 +53,16 @@ static const ADGameDescription gameDescriptions[] = {
 		GUIO3(GUIO_RENDERHERCGREEN, GUIO_RENDERHERCAMBER, GUIO_RENDERCGA)
 	},
 
-	// TODO: add EGA variant once Kult2.pxi and PRESEGA.EGA MD5s are verified
-	// {
-	// 	"chamber",
-	// 	"EGA",
-	// 	AD_ENTRY2s("Kult2.pxi",   "<md5>", <size>,
-	// 	           "PRESEGA.EGA", "<md5>", <size>),
-	// 	Common::EN_USA,
-	// 	Common::kPlatformDOS,
-	// 	ADGF_UNSTABLE | GF_SPLASH_PRESEGA,
-	// 	GUIO4(GUIO_RENDERHERCGREEN, GUIO_RENDERHERCAMBER, GUIO_RENDERCGA, GUIO_RENDEREGA)
-	// },
+	{
+		"chamber",
+		"EGA",
+		AD_ENTRY2s("Kult2.pxi",   "2f5cea29072e8c16bf4724a0d0a2201d", 142658,
+		           "PRESEGA.EGA", "b0a6474fa95276255f8eb85c12aab031",  32000),
+		Common::EN_USA,
+		Common::kPlatformDOS,
+		ADGF_UNSTABLE | GF_SPLASH_PRESEGA,
+		GUIO4(GUIO_RENDERHERCGREEN, GUIO_RENDERHERCAMBER, GUIO_RENDERCGA, GUIO_RENDEREGA)
+	},
 
 	AD_TABLE_END_MARKER
 };

--- a/engines/chamber/detection.h
+++ b/engines/chamber/detection.h
@@ -29,7 +29,7 @@ enum ChamberGameFlags {
 	GF_SPLASH_PRESCGA = (1 << 0), ///< Title screen is PRESCGA.BIN (EN_USA CGA)
 	GF_SPLASH_PRES    = (1 << 1), ///< Title screen is PRES.BIN (multilingual CGA)
 	GF_SPLASH_PRESEGA = (1 << 2), ///< Title screen is PRESEGA.EGA (EGA)
-	GF_SPLASH_DRAP    = (1 << 3), ///< Has DRAP.BIN language selection screen
+	GF_SPLASH2_DRAP   = (1 << 3), ///< Has DRAP.BIN language selection screen
 };
 
 } // End of namespace Chamber

--- a/engines/chamber/detection.h
+++ b/engines/chamber/detection.h
@@ -1,0 +1,37 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CHAMBER_DETECTION_H
+#define CHAMBER_DETECTION_H
+
+namespace Chamber {
+
+// Bits 0-14 are free for engine use; ADGF_* flags occupy bits 15-31.
+enum ChamberGameFlags {
+	GF_SPLASH_PRESCGA = (1 << 0), ///< Title screen is PRESCGA.BIN (EN_USA CGA)
+	GF_SPLASH_PRES    = (1 << 1), ///< Title screen is PRES.BIN (multilingual CGA)
+	GF_SPLASH_PRESEGA = (1 << 2), ///< Title screen is PRESEGA.EGA (EGA)
+	GF_SPLASH_DRAP    = (1 << 3), ///< Has DRAP.BIN language selection screen
+};
+
+} // End of namespace Chamber
+
+#endif // CHAMBER_DETECTION_H

--- a/engines/chamber/kult.cpp
+++ b/engines/chamber/kult.cpp
@@ -280,31 +280,48 @@ Common::Error ChamberEngine::init() {
 
 	Graphics::Surface *splash = nullptr;
 
-	if (g_vm->_videoMode == Common::RenderMode::kRenderEGA) {
-		/* EGA title screen — load planar EGA splash (same format as FOND.EGA) */
+	if (_gameDescription->flags & GF_SPLASH_PRESEGA) {
+		/* EGA title screen */
 		splash = ega_loadFond("PRESEGA.EGA");
+		if (!splash) {
+			_shouldQuit = true;
+			return Common::kNoError;
+		}
 		g_vm->_renderer->colorSelect(0x30);
-		if (splash)
-			g_vm->_renderer->backBufferToRealFull();
-	} else {
-		if (g_vm->getLanguage() == Common::EN_USA) {
-			/* Load title screen */
-			splash = loadSplash("PRESCGA.BIN");
-			if (!splash)
-				exitGame();
+		g_vm->_renderer->backBufferToRealFull();
+	} else if (_gameDescription->flags & GF_SPLASH_PRESCGA) {
+		/* EN_USA CGA title screen */
+		splash = loadSplash("PRESCGA.BIN");
+		if (!splash) {
+			_shouldQuit = true;
+			return Common::kNoError;
+		}
 
-			if (ifgm_loaded) {
-				/*TODO*/
-			}
-		} else {
-			/* Load title screen */
-			splash = loadSplash("PRES.BIN");
-			if (!splash)
-				exitGame();
+		if (ifgm_loaded) {
+			/*TODO*/
 		}
 
 		if (!isCustomHerc) {
-			/* Select intense cyan-mageta palette */
+			g_vm->_renderer->colorSelect(0x30);
+			g_vm->_renderer->backBufferToRealFull();
+		} else {
+			if (_renderMode == Common::kRenderHercG)
+				g_system->getPaletteManager()->setPalette(Graphics::HGC_G_PALETTE, 0, 2);
+			else
+				g_system->getPaletteManager()->setPalette(Graphics::HGC_A_PALETTE, 0, 2);
+
+			g_vm->_renderer->backBufferToRealFull();
+		}
+	} else {
+		/* Multilingual CGA title screen */
+		splash = loadSplash("PRES.BIN");
+		if (!splash) {
+			_shouldQuit = true;
+			return Common::kNoError;
+		}
+
+		if (!isCustomHerc) {
+			/* Select intense cyan-magenta palette */
 			g_vm->_renderer->colorSelect(0x30);
 			g_vm->_renderer->backBufferToRealFull();
 		} else {
@@ -328,17 +345,19 @@ Common::Error ChamberEngine::init() {
 	readKeyboardChar();
 
 
-	if (g_vm->getLanguage() == Common::EN_USA) {
+	if (!(_gameDescription->flags & GF_SPLASH_DRAP)) {
 		if (ifgm_loaded) {
 			/*TODO*/
 		}
 
-		/* Force English language */
+		/* Single-language variant — force English */
 		c = 'E';
 	} else {
 		/* Load language selection screen */
-		if (!loadSplash("DRAP.BIN"))
-			exitGame();
+		if (!loadSplash("DRAP.BIN")) {
+			_shouldQuit = true;
+			return Common::kNoError;
+		}
 
 		/* Wait for a keypress and show the language selection screen */
 		clearKeyboard();

--- a/engines/chamber/kult.cpp
+++ b/engines/chamber/kult.cpp
@@ -21,9 +21,11 @@
 
 #include "common/error.h"
 #include "common/system.h"
+#include "engines/advancedDetector.h"
 #include "engines/util.h"
 
 #include "chamber/chamber.h"
+#include "chamber/detection.h"
 #include "chamber/common.h"
 #include "chamber/decompr.h"
 #include "chamber/cga.h"
@@ -345,7 +347,7 @@ Common::Error ChamberEngine::init() {
 	readKeyboardChar();
 
 
-	if (!(_gameDescription->flags & GF_SPLASH_DRAP)) {
+	if (!(_gameDescription->flags & GF_SPLASH2_DRAP)) {
 		if (ifgm_loaded) {
 			/*TODO*/
 		}


### PR DESCRIPTION
  Replace hardcoded splash screen filenames in kult.cpp with game flags defined 
  in detection.h. Each entry in the detection table now declares which splash
  files it uses via GF_SPLASH_PRESCGA, GF_SPLASH_PRES, GF_SPLASH_PRESEGA, and   
  GF_SPLASH_DRAP flags combine with OR into the existing ADGameDescription.flags field.

  Also fixes a bug where a missing splash file would cause exitGame() to        
  silently fall through, leaving the screen black and the engine stuck waiting
  for a keypress. The fix replaces those calls with _shouldQuit = true; return  
  Common::kNoError;


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
