### PR TITLE
DIRECTOR: LINGO: Skip D6 mixed compare guard for location lookups

### DIFF
--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -1343,8 +1343,10 @@ Datum LC::compareArrays(Datum (*compareFunc)(Datum, Datum), Datum d1, Datum d2, 
 	// At least one of d1 and d2 must be an array
 	bool d1isArr = d1.isArray() || d1.type == PARRAY;
 	bool d2isArr = d2.isArray() || d2.type == PARRAY;
-	// As far as I can tell, D6 no longer does partial array or element-to-array comparison
-	if ((g_director->getVersion() >= 600) && (!(d1isArr && d2isArr))) {
+	// In D6 and higher, direct relational comparison no longer does partial array or
+	// element-to-array coercion. However, location mode still needs
+	// scalar-to-element checks while scanning array entries.
+	if ((g_director->getVersion() >= 600) && !location && (!(d1isArr && d2isArr))) {
 		return Datum(0);
 	}
 


### PR DESCRIPTION
_WARNING: AI assisted, needs review by a DIRECTOR expert!_

Commit 6292b5d822b9280030bd0b32c02780bd1957fafe introduced a regression for "Masters of the Elements" where in-game sound was not played properly in any except of the very first movie. I found the commit by bisecting.

It seems that the guard introduced here was too strict, and some lookups _still_ need the "old" comparison.

I gave GPT access to the ScummVM sources, and the decompiled Lingo scripts for "melements". During this debugging session, (temporary) debugging messages revealed sound loading has the following conditions:

- location=1
- d1=PARRAY with sound-name keys
- d2=STRING like "bal01"
- frame contexts in preloadDsSound and setLoopDsSound

Excluding `location` from this check fixes the sound issues in `melements`.

@moralrecordings Can you please check if this breaks "Professor Finkle's Math Mania"?