### PR TITLE
GUI: Make OptionsContainerWidget inherit its clipping rectangle

### DIFF
--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -1111,6 +1111,12 @@ void OptionsContainerWidget::reflowLayout() {
 	_h = maxY - minY;
 }
 
+Common::Rect OptionsContainerWidget::getClipRect() const {
+	// Use boss clipping rectangle to avoid drawing issues on checkboxes
+	// which stick out of their rectangle due to their bevel.
+	return _boss->getClipRect();
+}
+
 bool OptionsContainerWidget::containsWidget(Widget *widget) const {
 	return containsWidgetInChain(_firstWidget, widget);
 }

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -570,6 +570,7 @@ public:
 protected:
 	// Widget API
 	void reflowLayout() override;
+	Common::Rect getClipRect() const override;
 	void drawWidget() override {}
 	bool containsWidget(Widget *widget) const override;
 	Widget *findWidget(int x, int y) override;


### PR DESCRIPTION
The OptionsContainerWidget is a bare container without any graphical existence. By making it inheriting the clipping rectangle from its boss, this avoids clipping issues on checkboxes which slightly stick out from their expected size.

Before:
<img width="958" height="623" alt="before" src="https://github.com/user-attachments/assets/4c2e861d-317c-457e-b0f0-9951cd442944" />

After:
<img width="958" height="623" alt="after" src="https://github.com/user-attachments/assets/a16dc580-dc98-4af9-a8bf-62135346e58c" />

This only happens on the last checkbox because, as an optimization, we don't take clipping into account if the widget rectangle is included in the clipping rectangle.
But the check box draws outside its widget rectangle and the clipping is visible only when a checkbox is partially show on screen.
Disabling the optimization makes the problem apparent on every check boxes included in an OptionContainerWidget:
<img width="958" height="623" alt="extreme" src="https://github.com/user-attachments/assets/7aff93fb-d6c3-4366-83d8-9735e21f9361" />
