### PR TITLE
BACKENDS: Restrict direct access to OSystem mouse functions

### DIFF
--- a/common/system.h
+++ b/common/system.h
@@ -40,6 +40,7 @@ class Mixer;
 }
 
 namespace Graphics {
+class CursorManager;
 struct Surface;
 }
 
@@ -162,6 +163,8 @@ typedef struct ImGuiCallbacks {
  * - Sound output
  */
 class OSystem : Common::NonCopyable {
+	friend class Graphics::CursorManager;
+
 protected:
 	OSystem();
 	virtual ~OSystem();
@@ -1480,7 +1483,7 @@ public:
 	 * class instead of using this directly.
 	 */
 
-
+protected:
 	/**
 	 * Show or hide the mouse cursor.
 	 *
@@ -1494,21 +1497,6 @@ public:
 	 * @see Graphics::CursorManager::showMouse
 	 */
 	virtual bool showMouse(bool visible) = 0;
-
-	/**
-	 * Lock or unlock the mouse cursor within the window.
-	 *
-	 */
-	virtual bool lockMouse(bool lock) { return false; }
-
-	/**
-	 * Move ("warp") the mouse cursor to the specified position in virtual
-	 * screen coordinates.
-	 *
-	 * @param x		New x position of the mouse.
-	 * @param y		New y position of the mouse.
-	 */
-	virtual void warpMouse(int x, int y) = 0;
 
 	/**
 	 * Set the bitmap used for drawing the cursor.
@@ -1542,7 +1530,21 @@ public:
 	 */
 	virtual void setCursorPalette(const byte *colors, uint start, uint num) {}
 
+public:
+	/**
+	 * Lock or unlock the mouse cursor within the window.
+	 *
+	 */
+	virtual bool lockMouse(bool lock) { return false; }
 
+	/**
+	 * Move ("warp") the mouse cursor to the specified position in virtual
+	 * screen coordinates.
+	 *
+	 * @param x		New x position of the mouse.
+	 * @param y		New y position of the mouse.
+	 */
+	virtual void warpMouse(int x, int y) = 0;
 
 	/**
 	 * Get the system-configured double-click time interval.

--- a/engines/agi/op_cmd.cpp
+++ b/engines/agi/op_cmd.cpp
@@ -35,6 +35,8 @@
 #include "common/system.h"
 #include "common/textconsole.h"
 
+#include "graphics/cursorman.h"
+
 namespace Agi {
 
 void cmdIncrement(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
@@ -996,7 +998,7 @@ void cmdShowMouse(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
 	if (state->mouseEnabled) {
 		state->mouseHidden = false;
 
-		vm->_system->showMouse(true);
+		CursorMan.showMouse(true);
 	}
 }
 
@@ -1019,7 +1021,7 @@ void cmdHideMouse(AgiGame *state, AgiEngine *vm, uint8 *parameter) {
 	if (state->mouseEnabled) {
 		state->mouseHidden = true;
 
-		vm->_system->showMouse(false);
+		CursorMan.showMouse(false);
 	}
 }
 

--- a/engines/ags/engine/platform/base/sys_main.cpp
+++ b/engines/ags/engine/platform/base/sys_main.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "common/system.h"
+#include "graphics/cursorman.h"
 #include "ags/engine/platform/base/sys_main.h"
 #include "ags/shared/util/geometry.h"
 #include "ags/shared/util/string.h"
@@ -213,7 +214,7 @@ void sys_window_set_style(WindowMode mode, int /*ex_flags*/) {
 }
 
 void sys_window_show_cursor(bool on) {
-	g_system->showMouse(on);
+	CursorMan.showMouse(on);
 }
 
 bool sys_window_lock_mouse(bool on) {

--- a/engines/alcachofa/alcachofa.cpp
+++ b/engines/alcachofa/alcachofa.cpp
@@ -25,6 +25,7 @@
 #include "common/savefile.h"
 #include "common/system.h"
 #include "engines/util.h"
+#include "graphics/cursorman.h"
 #include "graphics/paletteman.h"
 #include "graphics/framelimiter.h"
 #include "graphics/thumbnail.h"
@@ -76,7 +77,7 @@ Common::String AlcachofaEngine::getGameId() const {
 }
 
 Common::Error AlcachofaEngine::run() {
-	g_system->showMouse(false);
+	CursorMan.showMouse(false);
 	setDebugger(_console);
 	_game.reset(Game::create());
 	Config::registerDefaults();

--- a/engines/bladerunner/bladerunner.cpp
+++ b/engines/bladerunner/bladerunner.cpp
@@ -94,6 +94,7 @@
 #include "engines/util.h"
 #include "engines/advancedDetector.h"
 
+#include "graphics/cursorman.h"
 #include "graphics/thumbnail.h"
 
 namespace BladeRunner {
@@ -386,7 +387,7 @@ Common::Error BladeRunnerEngine::run() {
 	_screenPixelFormat = g_system->getScreenFormat();
 	debug("Using pixel format: %s", _screenPixelFormat.toString().c_str());
 
-	_system->showMouse(_isNonInteractiveDemo ? false : true);
+	CursorMan.showMouse(_isNonInteractiveDemo ? false : true);
 
 	bool hasSavegames = !SaveFileManager::list(getMetaEngine(), _targetName).empty();
 

--- a/engines/chamber/cga.cpp
+++ b/engines/chamber/cga.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "common/system.h"
+#include "graphics/cursorman.h"
 #include "graphics/paletteman.h"
 #include "graphics/surface.h"
 
@@ -148,12 +149,13 @@ void waitVBlank(void) {
 }
 
 void CGARenderer::colorSelect(byte csel) {
+	// TODO: Replace use of cursor palettes
 	if (g_vm->_renderMode == Common::kRenderHercG) {
 		g_system->getPaletteManager()->setPalette(Graphics::HGC_G_PALETTE, 0, 2);
-		g_system->setCursorPalette(Graphics::HGC_G_PALETTE, 0, 2);
+		CursorMan.replaceCursorPalette(Graphics::HGC_G_PALETTE, 0, 2);
 	} else if (g_vm->_renderMode == Common::kRenderHercA) {
 		g_system->getPaletteManager()->setPalette(Graphics::HGC_A_PALETTE, 0, 2);
-		g_system->setCursorPalette(Graphics::HGC_A_PALETTE, 0, 2);
+		CursorMan.replaceCursorPalette(Graphics::HGC_A_PALETTE, 0, 2);
 	} else {
 		const byte *pal;
 		if (csel & 0x10)
@@ -162,7 +164,7 @@ void CGARenderer::colorSelect(byte csel) {
 			pal = PALETTE_CGA2;
 
 		g_system->getPaletteManager()->setPalette(pal, 0, 4);
-		g_system->setCursorPalette(pal, 0, 4);
+		CursorMan.replaceCursorPalette(pal, 0, 4);
 	}
 }
 

--- a/engines/chamber/cursor.cpp
+++ b/engines/chamber/cursor.cpp
@@ -28,6 +28,7 @@
 #include "chamber/cga.h"
 #include "chamber/ega.h"
 #include "chamber/renderer.h"
+#include "graphics/cursorman.h"
 #include "graphics/palette.h"
 
 
@@ -94,8 +95,8 @@ void CGARenderer::selectCursor(uint16 num) {
 		}
 	}
 
-	g_system->setMouseCursor(cursorImage, CURSOR_WIDTH, CURSOR_HEIGHT, cursor_x_shift, cursor_y_shift, 255);
-	g_system->showMouse(true);
+	CursorMan.replaceCursor(cursorImage, CURSOR_WIDTH, CURSOR_HEIGHT, cursor_x_shift, cursor_y_shift, 255);
+	CursorMan.showMouse(true);
 }
 
 void EGARenderer::selectCursor(uint16 num) {
@@ -127,9 +128,10 @@ void EGARenderer::selectCursor(uint16 num) {
 		}
 	}
 
-	g_system->setMouseCursor(cursorImage, CURSOR_WIDTH, CURSOR_HEIGHT, cursor_x_shift, cursor_y_shift, 255);
-	g_system->setCursorPalette(Graphics::Palette::createEGAPalette().data(), 0, 16);
-	g_system->showMouse(true);
+	CursorMan.replaceCursor(cursorImage, CURSOR_WIDTH, CURSOR_HEIGHT, cursor_x_shift, cursor_y_shift, 255);
+	// TODO: Replace use of cursor palettes
+	CursorMan.replaceCursorPalette(Graphics::Palette::createEGAPalette().data(), 0, 16);
+	CursorMan.showMouse(true);
 }
 
 /*

--- a/engines/colony/animation.cpp
+++ b/engines/colony/animation.cpp
@@ -396,7 +396,6 @@ void ColonyEngine::playAnimation() {
 
 	_animationRunning = true;
 	_system->lockMouse(false);
-	_system->showMouse(true);
 	warpMouseLogical(_centerX, _centerY);
 	const char *cursorName = "default arrow cursor";
 	if (_renderMode == Common::kRenderMacintosh && _macArrowCursor) {
@@ -649,7 +648,6 @@ void ColonyEngine::playAnimation() {
 	}
 
 	_system->lockMouse(true);
-	_system->showMouse(false);
 	CursorMan.showMouse(false);
 	CursorMan.popAllCursors();
 

--- a/engines/colony/colony.cpp
+++ b/engines/colony/colony.cpp
@@ -480,7 +480,7 @@ void ColonyEngine::syncMacMenuChecks() {
 
 void ColonyEngine::updateMouseCapture(bool recenter) {
 	_system->lockMouse(_mouseLocked);
-	_system->showMouse(!_mouseLocked);
+	CursorMan.showMouse(!_mouseLocked);
 
 	int cursorMode = 0;
 
@@ -538,7 +538,6 @@ void ColonyEngine::handleMenuAction(int action) {
 		break;
 	case kMenuActionOpen:
 		_system->lockMouse(false);
-		_system->showMouse(true);
 		CursorMan.setDefaultArrowCursor();
 		CursorMan.showMouse(true);
 		loadGameDialog();
@@ -547,7 +546,6 @@ void ColonyEngine::handleMenuAction(int action) {
 	case kMenuActionSave:
 	case kMenuActionSaveAs:
 		_system->lockMouse(false);
-		_system->showMouse(true);
 		CursorMan.setDefaultArrowCursor();
 		CursorMan.showMouse(true);
 		saveGameDialog();
@@ -923,7 +921,6 @@ Common::Error ColonyEngine::run() {
 					// WM consumed the event (menu interaction)
 					if (!wasMenuActive && _wm->isMenuActive()) {
 						_system->lockMouse(false);
-						_system->showMouse(true);
 						CursorMan.setDefaultArrowCursor();
 						CursorMan.showMouse(true);
 					}
@@ -1007,7 +1004,6 @@ Common::Error ColonyEngine::run() {
 					break;
 				case kActionEscape:
 					_system->lockMouse(false);
-					_system->showMouse(true);
 					CursorMan.setDefaultArrowCursor();
 					CursorMan.showMouse(true);
 					openMainMenuDialog();

--- a/engines/colony/intro.cpp
+++ b/engines/colony/intro.cpp
@@ -62,7 +62,6 @@ public:
 		_tempSurface->copyRectToSurface(_screen->getBasePtr(_bbox.left, _bbox.top), _screen->pitch,
 			0, 0, _bbox.width() + 1, _bbox.height() + 1);
 		_wm->pushCursor(Graphics::kMacCursorArrow, nullptr);
-		g_system->showMouse(true);
 		CursorMan.showMouse(true);
 
 		while (!shouldQuit) {
@@ -1173,7 +1172,6 @@ void ColonyEngine::terminateGame(bool blowup) {
 	_animationRunning = false;
 	_mouseLocked = false;
 	_system->lockMouse(false);
-	_system->showMouse(true);
 	CursorMan.setDefaultArrowCursor(true);
 	CursorMan.showMouse(true);
 
@@ -1323,7 +1321,6 @@ void ColonyEngine::gameOver(bool kill) {
 
 	_mouseLocked = false;
 	_system->lockMouse(false);
-	_system->showMouse(true);
 	CursorMan.setDefaultArrowCursor(true);
 	CursorMan.showMouse(true);
 

--- a/engines/freescape/freescape.cpp
+++ b/engines/freescape/freescape.cpp
@@ -869,7 +869,7 @@ Common::Error FreescapeEngine::run() {
 	loadAssets();
 	loadColorPalette();
 
-	g_system->showMouse(false);
+	CursorMan.showMouse(false);
 	g_system->lockMouse(true);
 
 	// Simple main event loop
@@ -886,7 +886,7 @@ Common::Error FreescapeEngine::run() {
 		loadGameState(saveSlot);
 	}
 
-	g_system->showMouse(false);
+	CursorMan.showMouse(false);
 	g_system->lockMouse(true);
 	resetInput();
 
@@ -938,7 +938,7 @@ Common::Error FreescapeEngine::run() {
 	}
 
 	_eventManager->clearExitEvents();
-	g_system->showMouse(true);
+	CursorMan.showMouse(true);
 	g_system->lockMouse(false);
 	return Common::kNoError;
 }

--- a/engines/freescape/games/castle/castle.cpp
+++ b/engines/freescape/games/castle/castle.cpp
@@ -1148,7 +1148,7 @@ void CastleEngine::drawInfoMenu() {
 					_eventManager->purgeMouseEvents();
 					if (isDOS() || isAmiga() || isAtariST()) {
 						g_system->lockMouse(false);
-						g_system->showMouse(true);
+						CursorMan.showMouse(true);
 					}
 
 					_gfx->setViewport(_viewArea);
@@ -1161,7 +1161,7 @@ void CastleEngine::drawInfoMenu() {
 					_eventManager->purgeMouseEvents();
 					if (isDOS() || isAmiga() || isAtariST()) {
 						g_system->lockMouse(false);
-						g_system->showMouse(true);
+						CursorMan.showMouse(true);
 					}
 
 					_gfx->setViewport(_viewArea);
@@ -1208,7 +1208,7 @@ void CastleEngine::drawInfoMenu() {
 					_eventManager->purgeKeyboardEvents();
 					loadGameDialog();
 					g_system->lockMouse(false);
-					g_system->showMouse(true);
+					CursorMan.showMouse(true);
 
 					_gfx->setViewport(_viewArea);
 				} else if (saveGameRect.contains(mousePos)) {
@@ -1216,7 +1216,7 @@ void CastleEngine::drawInfoMenu() {
 					_eventManager->purgeKeyboardEvents();
 					saveGameDialog();
 					g_system->lockMouse(false);
-					g_system->showMouse(true);
+					CursorMan.showMouse(true);
 
 					_gfx->setViewport(_viewArea);
 				} else if (toggleSoundRect.contains(mousePos)) {
@@ -2121,10 +2121,9 @@ void CastleEngine::selectCharacterScreen() {
 
 	if (isTouchscreenActive()) {
 		CursorMan.setDefaultArrowCursor();
-		CursorMan.showMouse(true);
 	}
 	_system->lockMouse(false);
-	_system->showMouse(true);
+	CursorMan.showMouse(true);
 
 	// Calculate tap/click rectangles from actual rendered text positions.
 	// lines[5] = prince, lines[6] = princess for ZX/CPC.
@@ -2218,7 +2217,6 @@ void CastleEngine::selectCharacterScreen() {
 		g_system->delayMillis(15); // try to target ~60 FPS
 	}
 	_system->lockMouse(true);
-	_system->showMouse(false);
 	CursorMan.showMouse(false);
 	_gfx->clear(0, 0, 0, true);
 

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -25,6 +25,7 @@
 
 #if defined(USE_OPENGL_GAME)
 
+#include "graphics/cursorman.h"
 #include "graphics/surface.h"
 
 #include "math/glmath.h"
@@ -125,7 +126,7 @@ void GfxOpenGL::setupScreen(int screenW, int screenH) {
 	_useDepthShader = false;
 	_useDimShader = false;
 
-	g_system->showMouse(false);
+	CursorMan.showMouse(false);
 
 	int screenSize = _screenWidth * _screenHeight * 4;
 	_storedDisplay = new byte[screenSize]();

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -43,6 +43,7 @@
 
 #if defined(USE_OPENGL_SHADERS)
 
+#include "graphics/cursorman.h"
 #include "graphics/surface.h"
 #include "graphics/opengl/context.h"
 
@@ -403,7 +404,7 @@ void GfxOpenGLS::setupScreen(int screenW, int screenH) {
 	_scaleW = _screenWidth / (float)_gameWidth;
 	_scaleH = _screenHeight / (float)_gameHeight;
 
-	g_system->showMouse(false);
+	CursorMan.showMouse(false);
 
 	setupZBuffer();
 	setupShaders();

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -23,6 +23,7 @@
 #include "common/endian.h"
 #include "common/system.h"
 
+#include "graphics/cursorman.h"
 #include "graphics/surface.h"
 
 #include "math/glmath.h"
@@ -81,7 +82,7 @@ void GfxTinyGL::setupScreen(int screenW, int screenH) {
 	_scaleW = _screenWidth / (float)_gameWidth;
 	_scaleH = _screenHeight / (float)_gameHeight;
 
-	g_system->showMouse(false);
+	CursorMan.showMouse(false);
 
 	_pixelFormat = g_system->getScreenFormat();
 	debug(2, "INFO: TinyGL front buffer pixel format: %s", _pixelFormat.toString().c_str());

--- a/engines/hpl1/engine/impl/LowLevelGraphicsSDL.cpp
+++ b/engines/hpl1/engine/impl/LowLevelGraphicsSDL.cpp
@@ -40,6 +40,7 @@
 #include "common/config-manager.h"
 #include "common/system.h"
 #include "engines/util.h"
+#include "graphics/cursorman.h"
 #include "hpl1/debug.h"
 #include "hpl1/engine/impl/OcclusionQueryOGL.h"
 #include "hpl1/graphics.h"
@@ -263,7 +264,7 @@ int cLowLevelGraphicsSDL::GetCaps(eGraphicCaps type) const {
 //-----------------------------------------------------------------------
 
 void cLowLevelGraphicsSDL::ShowCursor(bool toggle) {
-	g_system->showMouse(toggle);
+	CursorMan.showMouse(toggle);
 }
 
 //-----------------------------------------------------------------------

--- a/engines/hpl1/engine/impl/low_level_graphics_tgl.cpp
+++ b/engines/hpl1/engine/impl/low_level_graphics_tgl.cpp
@@ -31,6 +31,7 @@
 #include "common/algorithm.h"
 #include "common/system.h"
 #include "engines/util.h"
+#include "graphics/cursorman.h"
 #include "graphics/tinygl/tinygl.h"
 #include "hpl1/debug.h"
 #include "hpl1/graphics.h"
@@ -459,7 +460,7 @@ int LowLevelGraphicsTGL::GetCaps(eGraphicCaps type) const {
 //-----------------------------------------------------------------------
 
 void LowLevelGraphicsTGL::ShowCursor(bool toggle) {
-	g_system->showMouse(toggle);
+	CursorMan.showMouse(toggle);
 }
 
 //-----------------------------------------------------------------------

--- a/engines/made/scriptfuncs.cpp
+++ b/engines/made/scriptfuncs.cpp
@@ -389,12 +389,12 @@ int16 ScriptFunctions::sfStopTele(int16 argc, int16 *argv) {
 }
 
 int16 ScriptFunctions::sfHideMouseCursor(int16 argc, int16 *argv) {
-	_vm->_system->showMouse(false);
+	CursorMan.showMouse(false);
 	return 0;
 }
 
 int16 ScriptFunctions::sfShowMouseCursor(int16 argc, int16 *argv) {
-	_vm->_system->showMouse(true);
+	CursorMan.showMouse(true);
 	return 0;
 }
 
@@ -834,9 +834,9 @@ int16 ScriptFunctions::sfGetTextWidth(int16 argc, int16 *argv) {
 
 int16 ScriptFunctions::sfPlayMovie(int16 argc, int16 *argv) {
 	const char *movieName = _vm->_dat->getObjectString(argv[1]);
-	_vm->_system->showMouse(false);
+	CursorMan.showMouse(false);
 	bool completed = _vm->_pmvPlayer->play(movieName);
-	_vm->_system->showMouse(true);
+	CursorMan.showMouse(true);
 	// Return true/false according to if the movie was canceled or not
 	return completed ? -1 : 0;
 }

--- a/engines/mortevielle/utils.cpp
+++ b/engines/mortevielle/utils.cpp
@@ -226,7 +226,7 @@ void MortevielleEngine::setMousePos(const Common::Point &pt) {
 void MortevielleEngine::delay(int amount) {
 	uint32 endTime = g_system->getMillis() + amount;
 
-	g_system->showMouse(false);
+	CursorMan.showMouse(false);
 	while (g_system->getMillis() < endTime) {
 		if (g_system->getMillis() > (_lastGameFrame + GAME_FRAME_DELAY)) {
 			_lastGameFrame = g_system->getMillis();
@@ -235,7 +235,7 @@ void MortevielleEngine::delay(int amount) {
 
 		g_system->delayMillis(10);
 	}
-	g_system->showMouse(true);
+	CursorMan.showMouse(true);
 }
 
 /**

--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -53,6 +53,7 @@
 
 #include "image/jpeg.h"
 
+#include "graphics/cursorman.h"
 #include "graphics/renderer.h"
 #include "graphics/yuv_to_rgb.h"
 #include "graphics/framelimiter.h"
@@ -178,7 +179,7 @@ Common::Error Myst3Engine::run() {
 	}
 	_archiveNode = new Archive();
 
-	_system->showMouse(false);
+	CursorMan.showMouse(false);
 
 	settingsInitDefaults();
 	syncSoundSettings();

--- a/engines/parallaction/gui_br.cpp
+++ b/engines/parallaction/gui_br.cpp
@@ -22,6 +22,8 @@
 #include "common/system.h"
 #include "common/textconsole.h"
 
+#include "graphics/cursorman.h"
+
 #include "parallaction/gui.h"
 #include "parallaction/input.h"
 #include "parallaction/parallaction.h"
@@ -232,7 +234,7 @@ public:
 
 		}
 
-		_vm->_system->showMouse(false);
+		CursorMan.showMouse(false);
 		cleanup();
 
 		return nullptr;

--- a/engines/sci/graphics/cursor32.cpp
+++ b/engines/sci/graphics/cursor32.cpp
@@ -61,7 +61,7 @@ void GfxCursor32::hide() {
 		return;
 	}
 
-	g_system->showMouse(false);
+	CursorMan.showMouse(false);
 	if (!_cursorBack.rect.isEmpty()) {
 		drawToScreen(_cursorBack);
 	}
@@ -140,14 +140,14 @@ void GfxCursor32::unhide() {
 		return;
 	}
 
-	g_system->showMouse(true);
+	CursorMan.showMouse(true);
 	_cursor.rect.moveTo(_position.x - _hotSpot.x, _position.y - _hotSpot.y);
 	revealCursor();
 }
 
 void GfxCursor32::show() {
 	if (_hideCount) {
-		g_system->showMouse(true);
+		CursorMan.showMouse(true);
 		_hideCount = 0;
 		_cursor.rect.moveTo(_position.x - _hotSpot.x, _position.y - _hotSpot.y);
 		revealCursor();

--- a/engines/teenagent/teenagent.cpp
+++ b/engines/teenagent/teenagent.cpp
@@ -731,7 +731,7 @@ Common::Error TeenAgentEngine::run() {
 			}
 			_sceneBusy = b;
 		}
-		_system->showMouse(scene->getMessage().empty() && !_sceneBusy);
+		CursorMan.showMouse(scene->getMessage().empty() && !_sceneBusy);
 
 		bool busy = inventory->active() || _sceneBusy;
 

--- a/engines/testbed/graphics.cpp
+++ b/engines/testbed/graphics.cpp
@@ -918,7 +918,7 @@ TestExitStatus GFXtests::maskedCursors() {
 		g_system->getPaletteManager()->setPalette(newPalette, 0, 4);
 
 		if (haveCursorPalettes)
-			g_system->setCursorPalette(newPalette, 0, 4);
+			CursorMan.replaceCursorPalette(newPalette, 0, 4);
 
 		CursorMan.replaceCursor(cursorData, 16, 16, 1, 1, 0, false, nullptr, maskData);
 		CursorMan.showMouse(true);

--- a/engines/tetraedge/game/application.cpp
+++ b/engines/tetraedge/game/application.cpp
@@ -25,6 +25,7 @@
 #include "common/util.h"
 #include "common/events.h"
 
+#include "graphics/cursorman.h"
 #include "graphics/scaler.h"
 
 #include "tetraedge/tetraedge.h"
@@ -267,7 +268,7 @@ void Application::create() {
 	_mouseCursorLayout.setName("mouseCursor");
 
 	// Not needed in scummvm:
-	g_system->showMouse(false);
+	CursorMan.showMouse(false);
 	//mainWindow->setNativeCursorVisible(false);
 
 	_mouseCursorLayout.load(_defaultCursor);

--- a/engines/toltecs/saveload.cpp
+++ b/engines/toltecs/saveload.cpp
@@ -21,6 +21,7 @@
 
 #include "common/savefile.h"
 
+#include "graphics/cursorman.h"
 #include "graphics/thumbnail.h"
 
 #include "toltecs/toltecs.h"
@@ -179,7 +180,7 @@ void ToltecsEngine::loadgame(const char *filename) {
 	_mouseDisabled = in->readUint16LE();
 
 	_system->warpMouse(_mouseX, _mouseY);
-	_system->showMouse(_mouseDisabled == 0);
+	CursorMan.showMouse(_mouseDisabled == 0);
 
 	_palette->loadState(in);
 	_script->loadState(in);

--- a/engines/twp/twp.cpp
+++ b/engines/twp/twp.cpp
@@ -1028,7 +1028,7 @@ Common::Error TwpEngine::run() {
 	// Set the engine's debugger console
 	setDebugger(new Console());
 
-	g_system->showMouse(false);
+	CursorMan.showMouse(false);
 	g_system->lockMouse(true);
 
 	_gfx.init();
@@ -1343,7 +1343,7 @@ Common::Error TwpEngine::run() {
 	_system->setImGuiCallbacks(ImGuiCallbacks());
 #endif
 
-	g_system->showMouse(true);
+	CursorMan.showMouse(true);
 	g_system->lockMouse(false);
 
 	return Common::kNoError;
@@ -2133,7 +2133,7 @@ void TwpEngine::capture(Graphics::Surface &surface, int width, int height) {
 HSQUIRRELVM TwpEngine::getVm() { return _vm->get(); }
 
 int TwpEngine::runDialog(GUI::Dialog &dialog) {
-	g_system->showMouse(true);
+	CursorMan.showMouse(true);
 	g_system->lockMouse(false);
 
 	int result = Engine::runDialog(dialog);

--- a/engines/ultima/nuvie/core/game.cpp
+++ b/engines/ultima/nuvie/core/game.cpp
@@ -66,6 +66,7 @@
 #include "ultima/nuvie/nuvie.h"
 
 #include "common/system.h"
+#include "graphics/cursorman.h"
 
 namespace Ultima {
 namespace Nuvie {
@@ -437,7 +438,7 @@ void Game::init_cursor() {
 		cursor = new Cursor();
 
 	if (cursor->init(config, screen, game_type))
-		g_system->showMouse(false); // won't need the system default
+		CursorMan.showMouse(false); // won't need the system default
 	else {
 		delete cursor;
 		cursor = nullptr; // no game cursor

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d.cpp
@@ -32,6 +32,7 @@
 #include "engines/wintermute/base/gfx/3dlight.h"
 #include "engines/wintermute/platform_osystem.h"
 
+#include "graphics/cursorman.h"
 #include "graphics/opengl/system_headers.h"
 
 #include "common/config-manager.h"
@@ -108,7 +109,7 @@ bool BaseRenderOpenGL3D::initRenderer(int width, int height, bool windowed) {
 	_width = width;
 	_height = height;
 
-	g_system->showMouse(false);
+	CursorMan.showMouse(false);
 
 	setViewport(0, 0, width, height);
 

--- a/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
+++ b/engines/wintermute/base/gfx/opengl/base_render_opengl3d_shader.cpp
@@ -32,6 +32,7 @@
 #include "engines/wintermute/base/gfx/3dlight.h"
 #include "engines/wintermute/platform_osystem.h"
 
+#include "graphics/cursorman.h"
 #include "graphics/opengl/system_headers.h"
 
 #include "common/config-manager.h"
@@ -195,7 +196,7 @@ bool BaseRenderOpenGL3DShader::initRenderer(int width, int height, bool windowed
 	_width = width;
 	_height = height;
 
-	g_system->showMouse(false);
+	CursorMan.showMouse(false);
 
 	setViewport(0, 0, width, height);
 

--- a/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
+++ b/engines/wintermute/base/gfx/osystem/base_render_osystem.cpp
@@ -39,6 +39,8 @@
 #include "common/queue.h"
 #include "common/config-manager.h"
 
+#include "graphics/cursorman.h"
+
 #define DIRTY_RECT_LIMIT 800
 
 namespace Wintermute {
@@ -121,7 +123,7 @@ bool BaseRenderOSystem::initRenderer(int width, int height, bool windowed) {
 		return STATUS_FAILED;
 	}
 
-	g_system->showMouse(false);
+	CursorMan.showMouse(false);
 
 	_renderSurface->create(g_system->getWidth(), g_system->getHeight(), g_system->getScreenFormat());
 	_active = true;

--- a/engines/wintermute/base/gfx/tinygl/base_render_tinygl.cpp
+++ b/engines/wintermute/base/gfx/tinygl/base_render_tinygl.cpp
@@ -34,6 +34,8 @@
 
 #include "common/config-manager.h"
 
+#include "graphics/cursorman.h"
+
 #include "engines/util.h"
 
 #if defined(USE_TINYGL)
@@ -117,7 +119,7 @@ bool BaseRenderTinyGL::initRenderer(int width, int height, bool windowed) {
 	_width = width;
 	_height = height;
 
-	g_system->showMouse(false);
+	CursorMan.showMouse(false);
 
 	setViewport(0, 0, width, height);
 

--- a/graphics/mfc/wingdi.cpp
+++ b/graphics/mfc/wingdi.cpp
@@ -21,6 +21,7 @@
 
 #include "common/system.h"
 #include "common/textconsole.h"
+#include "graphics/cursorman.h"
 #include "graphics/mfc/wingdi.h"
 #include "graphics/mfc/global_functions.h"
 #include "graphics/mfc/afxwin.h"
@@ -350,7 +351,7 @@ HCURSOR SetCursor(HCURSOR hCursor) {
 }
 
 int ShowCursor(bool bShow) {
-	g_system->showMouse(bShow);
+	CursorMan.showMouse(bShow);
 	return 0;
 }
 


### PR DESCRIPTION
Calling the OSystem functions directly instead of using CursorMan prevents the GUI from keeping track of the status when opening and closing the GMM or console.