### PR TITLE
NANCY: Improve MultiBuildPuzzle sounds

### DIFF
--- a/engines/nancy/action/puzzle/multibuildpuzzle.cpp
+++ b/engines/nancy/action/puzzle/multibuildpuzzle.cpp
@@ -141,9 +141,9 @@ void MultiBuildPuzzle::readData(Common::SeekableReadStream &stream) {
 	}
 
 	// 0x59b: three SoundDescriptions (0x31 bytes each)
-	_sounds[0].readNormal(stream);
-	_sounds[1].readNormal(stream);
-	_sounds[2].readNormal(stream);
+	_rotationSound.readNormal(stream);
+	_pickupSound.readNormal(stream);
+	_dropSound.readNormal(stream);
 
 	// 0x62e: 6 unknown bytes
 	stream.skip(6);
@@ -178,9 +178,9 @@ void MultiBuildPuzzle::execute() {
 	case kBegin:
 		init();
 		registerGraphics();
-		g_nancy->_sound->loadSound(_sounds[0]);
-		g_nancy->_sound->loadSound(_sounds[1]);
-		g_nancy->_sound->loadSound(_sounds[2]);
+		g_nancy->_sound->loadSound(_rotationSound);
+		g_nancy->_sound->loadSound(_pickupSound);
+		g_nancy->_sound->loadSound(_dropSound);
 		g_nancy->_sound->loadSound(_solveSound);
 		_state = kRun;
 		// fall through
@@ -218,9 +218,9 @@ void MultiBuildPuzzle::execute() {
 		break;
 
 	case kActionTrigger:
-		g_nancy->_sound->stopSound(_sounds[0]);
-		g_nancy->_sound->stopSound(_sounds[1]);
-		g_nancy->_sound->stopSound(_sounds[2]);
+		g_nancy->_sound->stopSound(_rotationSound);
+		g_nancy->_sound->stopSound(_pickupSound);
+		g_nancy->_sound->stopSound(_dropSound);
 		g_nancy->_sound->stopSound(_solveSound);
 		if (_isCancelled) {
 			// Change to cancel scene unconditionally, but only set the cancel flag if
@@ -276,7 +276,7 @@ void MultiBuildPuzzle::handleInput(NancyInput &input) {
 			pp.curRotation = (pp.curRotation + 1) % 4;
 			_pickedUpWidth  = pp.rotateSurfaces[pp.curRotation].w;
 			_pickedUpHeight = pp.rotateSurfaces[pp.curRotation].h;
-			g_nancy->_sound->playSound(_sounds[0]);
+			g_nancy->_sound->playSound(_rotationSound);
 			updatePieceRender(_pickedUpPiece);
 			return;
 		}
@@ -319,7 +319,7 @@ void MultiBuildPuzzle::handleInput(NancyInput &input) {
 
 			if (validDrop) {
 				pp.isPlaced = true;
-				g_nancy->_sound->playSound(_sounds[1]);
+				g_nancy->_sound->playSound(_dropSound);
 			} else {
 				// Return piece to its shelf position
 				pp.gameRect = pp.homeRect;
@@ -355,6 +355,7 @@ void MultiBuildPuzzle::handleInput(NancyInput &input) {
 			pp.gameRect = Common::Rect(newLeft, newTop,
 			                          newLeft + _pickedUpWidth, newTop + _pickedUpHeight);
 			updatePieceRender(sel);
+			g_nancy->_sound->playSound(_pickupSound);
 		}
 		return;
 	}
@@ -378,7 +379,6 @@ void MultiBuildPuzzle::handleInput(NancyInput &input) {
 			pp.curRotation = 0;
 			pp.setZ((uint16)(_z + (int)_pieces.size() * 2));
 			pp.registerGraphics();
-			g_nancy->_sound->playSound(_sounds[0]);
 
 			if (_hasCloseupImage && !pp.cuSrcRect.isEmpty()) {
 				// First click shows close-up view, centered in the viewport.
@@ -394,6 +394,7 @@ void MultiBuildPuzzle::handleInput(NancyInput &input) {
 				_pickedUpPiece = topmost;
 				_pickedUpWidth  = pp.rotateSurfaces[0].w;
 				_pickedUpHeight = pp.rotateSurfaces[0].h;
+				g_nancy->_sound->playSound(_pickupSound);
 			}
 			updatePieceRender(topmost);
 		}

--- a/engines/nancy/action/puzzle/multibuildpuzzle.h
+++ b/engines/nancy/action/puzzle/multibuildpuzzle.h
@@ -96,7 +96,9 @@ protected:
 	// so the shelf always shows the source ingredient regardless of where the active piece is.
 	Common::Array<Piece> _shelfSlots;
 
-	SoundDescription _sounds[3];  // [0]=pickup/move, [1]=placement, [2]=extra
+	SoundDescription _rotationSound;
+	SoundDescription _pickupSound;
+	SoundDescription _dropSound;
 
 	SceneChangeWithFlag _solveScene;
 	SoundDescription _solveSound;


### PR DESCRIPTION
Sometimes pickup was drop, or drop was rotation, etc. (And for sandwich, the sound happened at not quite the right moment - it should be when grabbing the closeup, not the shelf item)

I don't actually know about the name "_rotationSound" because I can't find a MultiBuildPuzzle with rotation; I'm trusting the current puzzle implementation where the sound is used under "`// Right click: rotate the carried piece`".


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
