### PR TITLE
ENGINES: Ensure that in-game cursors are scaled on high DPI displays

### DIFF
--- a/engines/bagel/spacebar/baglib/cursor.cpp
+++ b/engines/bagel/spacebar/baglib/cursor.cpp
@@ -133,7 +133,7 @@ void CSystemCursor::setCurrent() {
 
 	Graphics::PixelFormat format = Graphics::PixelFormat::createFormatCLUT8();
 	CursorMan.replaceCursorPalette(CURSOR_PALETTE, 0, ARRAYSIZE(CURSOR_PALETTE) / 3);
-	CursorMan.replaceCursor(ARROW_CURSOR, CURSOR_W, CURSOR_H, 0, 0, 0, true, &format);
+	CursorMan.replaceCursor(ARROW_CURSOR, CURSOR_W, CURSOR_H, 0, 0, 0, false, &format);
 }
 
 } // namespace SpaceBar

--- a/engines/glk/events.cpp
+++ b/engines/glk/events.cpp
@@ -410,7 +410,7 @@ void Events::setCursor(CursorId cursorId) {
 			const Surface &s = _cursors[cursorId];
 			const int TRANSPARENT = s.format.RGBToColor(TRANSPARENT_RGB, TRANSPARENT_RGB, TRANSPARENT_RGB);
 
-			CursorMan.replaceCursor(s, s._hotspot.x, s._hotspot.y, TRANSPARENT, true);
+			CursorMan.replaceCursor(s, s._hotspot.x, s._hotspot.y, TRANSPARENT);
 		}
 
 		_cursorId = cursorId;

--- a/engines/made/screen.cpp
+++ b/engines/made/screen.cpp
@@ -980,6 +980,9 @@ void Screen::clearSpriteList() {
 }
 
 void Screen::setMouseCursor(const Graphics::Cursor *cursor) {
+	// The original Windows version of Rodney's Funscreen upscales the
+	// main screen, but displays the cursor at native resolution.
+	// FIXME: This is likely too small on high DPI displays.
 	CursorMan.replaceCursor(cursor, true);
 }
 

--- a/engines/scumm/cursor.cpp
+++ b/engines/scumm/cursor.cpp
@@ -428,6 +428,7 @@ void ScummEngine::updateCursor() {
 	if (_macScreen && _game.version == 6 && _game.heversion == 0)
 		mac_scaleCursor(cursor, hotspotX, hotspotY, width, height);
 
+	// FIXME: This is likely too small on high DPI displays with HE 70 games.
 #ifdef USE_RGB_COLOR
 	Graphics::PixelFormat format = _system->getScreenFormat();
 	CursorMan.replaceCursor(cursor, width, height,

--- a/engines/tony/game.cpp
+++ b/engines/tony/game.cpp
@@ -1572,7 +1572,7 @@ void RMPointer::updateCursor() {
 
 	// Get the raw pixel data and set the cursor to it
 	Graphics::PixelFormat pixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0);
-	CursorMan.replaceCursor(cursorData, 64, 64, _cursorHotspot._x, _cursorHotspot._y, 0, 1, &pixelFormat);
+	CursorMan.replaceCursor(cursorData, 64, 64, _cursorHotspot._x, _cursorHotspot._y, 0, false, &pixelFormat);
 }
 
 /**

--- a/graphics/cursorman.cpp
+++ b/graphics/cursorman.cpp
@@ -338,10 +338,10 @@ void CursorManager::setDefaultArrowCursor(bool push) {
 
 	if (push) {
 		pushCursorPalette(CURSOR_PALETTE, 0, ARRAYSIZE(CURSOR_PALETTE) / 3);
-		pushCursor(ARROW_CURSOR, CURSOR_W, CURSOR_H, 0, 0, 0, true, &format);
+		pushCursor(ARROW_CURSOR, CURSOR_W, CURSOR_H, 0, 0, 0, false, &format);
 	} else {
 		replaceCursorPalette(CURSOR_PALETTE, 0, ARRAYSIZE(CURSOR_PALETTE) / 3);
-		replaceCursor(ARROW_CURSOR, CURSOR_W, CURSOR_H, 0, 0, 0, true, &format);
+		replaceCursor(ARROW_CURSOR, CURSOR_W, CURSOR_H, 0, 0, 0, false, &format);
 	}
 }
 

--- a/graphics/mfc/gfx/cursor.cpp
+++ b/graphics/mfc/gfx/cursor.cpp
@@ -171,7 +171,7 @@ void Cursor::showCursor() {
 		CursorMan.replaceCursor(cursor);
 	} else {
 		CursorMan.replaceCursor(_surface.getPixels(),
-			_surface.w, _surface.h, 0, 0, 0, true, &format);
+			_surface.w, _surface.h, 0, 0, 0, false, &format);
 	}
 
 	CursorMan.showMouse(true);


### PR DESCRIPTION
The `dontScale` parameter intended for use in the GUI, which is high DPI aware, but engines generally aren't, so the cursor ends up being way too small on high DPI displays.

The comment added to the MADE engine is based on the discussion in PR #6935. It will be addressed in a follow-up PR.