### PR TITLE
BACKENDS: Allow cursors to be scaled relative to the game screen

### DIFF
--- a/backends/graphics/atari/atari-graphics.cpp
+++ b/backends/graphics/atari/atari-graphics.cpp
@@ -966,7 +966,7 @@ void AtariGraphicsManager::warpMouse(int x, int y) {
 }
 
 void AtariGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor,
-										  bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
+										  const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) {
 	//debug("setMouseCursor: %d, %d, %d, %d, %d, %d; ignored: %d",
 	//	w, h, hotspotX, hotspotY, keycolor, format ? format->bytesPerPixel : 1, _ignoreCursorChanges);
 

--- a/backends/graphics/atari/atari-graphics.h
+++ b/backends/graphics/atari/atari-graphics.h
@@ -93,7 +93,7 @@ public:
 	bool showMouse(bool visible) override;
 	void warpMouse(int x, int y) override;
 	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor,
-						bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override;
+						const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) override;
 	void setCursorPalette(const byte *colors, uint start, uint num) override;
 
 	Common::Point getMousePosition() const {

--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -116,7 +116,7 @@ public:
 
 	virtual bool showMouse(bool visible) = 0;
 	virtual void warpMouse(int x, int y) = 0;
-	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = nullptr, const byte *mask = nullptr) = 0;
+	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) = 0;
 	virtual void setCursorPalette(const byte *colors, uint start, uint num) = 0;
 
 	virtual void displayMessageOnOSD(const Common::U32String &msg) {}

--- a/backends/graphics/null/null-graphics.h
+++ b/backends/graphics/null/null-graphics.h
@@ -86,7 +86,7 @@ public:
 
 	bool showMouse(bool visible) override { return !visible; }
 	void warpMouse(int x, int y) override {}
-	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override {}
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) override {}
 	void setCursorPalette(const byte *colors, uint start, uint num) override {}
 
 private:

--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -78,9 +78,9 @@ OpenGLGraphicsManager::OpenGLGraphicsManager()
 	  _defaultFormat(), _defaultFormatAlpha(), _targetBuffer(nullptr),
 	  _gameScreen(nullptr), _overlay(nullptr),
 	  _cursor(nullptr), _cursorMask(nullptr),
-	  _cursorHotspotX(0), _cursorHotspotY(0),
+	  _cursorHotspotX(0), _cursorHotspotY(0), _cursorScaleX(0), _cursorScaleY(0),
 	  _cursorHotspotXScaled(0), _cursorHotspotYScaled(0), _cursorWidthScaled(0), _cursorHeightScaled(0),
-	  _cursorKeyColor(0), _cursorUseKey(true), _cursorDontScale(false), _cursorPaletteEnabled(false), _shakeOffsetScaled()
+	  _cursorKeyColor(0), _cursorUseKey(true), _cursorPaletteEnabled(false), _shakeOffsetScaled()
 #if !USE_FORCED_GLES
 	  , _libretroPipeline(nullptr)
 #endif
@@ -1080,14 +1080,15 @@ void multiplyColorWithAlpha(const byte *src, byte *dst, const uint w, const uint
 } // End of anonymous namespace
 
 
-void OpenGLGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
+void OpenGLGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) {
 	_cursorUseKey = (mask == nullptr);
 	if (_cursorUseKey)
 		_cursorKeyColor = keycolor;
 
 	_cursorHotspotX = hotspotX;
 	_cursorHotspotY = hotspotY;
-	_cursorDontScale = dontScale;
+	_cursorScaleX = fracToDouble(scaleX);
+	_cursorScaleY = fracToDouble(scaleY);
 
 	if (!w || !h) {
 		delete _cursor;
@@ -1105,6 +1106,7 @@ void OpenGLGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int 
 		inputFormat = Graphics::PixelFormat::createFormatCLUT8();
 	}
 
+	bool dontScale = (scaleX == 0 && scaleY == 0);
 #ifdef USE_SCALERS
 	bool wantScaler = (_currentState.scaleFactor > 1) && !dontScale && _scalerPlugins[_currentState.scalerIndex]->get<ScalerPluginObject>().canDrawCursor();
 #else
@@ -1170,7 +1172,7 @@ void OpenGLGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int 
 	// If the cursor is scalable, add a 1-texel transparent border.
 	// This ensures that linear filtering falloff from the edge pixels has room to completely fade out instead of
 	// being cut off at half-way.  Could use border clamp too, but GLES2 doesn't support that.
-	if (!_cursorDontScale) {
+	if (!dontScale) {
 		topLeftCoord = Common::Point(1, 1);
 		cursorSurfaceSize += Common::Point(2, 2);
 	}
@@ -1185,7 +1187,7 @@ void OpenGLGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int 
 	if (inputFormat.bytesPerPixel == 1) {
 		// For CLUT8 cursors we can simply copy the input data into the
 		// texture.
-		if (!_cursorDontScale)
+		if (!dontScale)
 			_cursor->fill(keycolor);
 		_cursor->copyRectToTexture(topLeftCoord.x, topLeftCoord.y, w, h, buf, w * inputFormat.bytesPerPixel);
 
@@ -1220,7 +1222,7 @@ void OpenGLGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int 
 		// The pre-multiplication allows using a blend mode that prevents
 		// color fringes due to filtering.
 
-		if (!_cursorDontScale)
+		if (!dontScale)
 			_cursor->fill(0);
 
 		byte *topLeftPixelPtr = static_cast<byte *>(dst->getBasePtr(topLeftCoord.x, topLeftCoord.y));
@@ -1941,21 +1943,24 @@ void OpenGLGraphicsManager::recalculateCursorScaling() {
 	// In case scaling is actually enabled we will scale the cursor according
 	// to the game screen.
 	// In 3D mode, there is no scaling
-	if (!_cursorDontScale && _gameScreen) {
+	if (!(_cursorScaleX == 0 && _cursorScaleY == 0) && _gameScreen) {
 		int rotatedWidth = _gameDrawRect.width();
 		int rotatedHeight = _gameDrawRect.height();
 		if (_rotationMode == Common::kRotation90 || _rotationMode == Common::kRotation270) {
 			SWAP(rotatedWidth, rotatedHeight);
 		}
 
-		const frac_t screenScaleFactorX = intToFrac(rotatedWidth) / _gameScreen->getWidth();
-		const frac_t screenScaleFactorY = intToFrac(rotatedHeight) / _gameScreen->getHeight();
+		const float screenScaleFactorX = rotatedWidth / _gameScreen->getWidth();
+		const float screenScaleFactorY = rotatedHeight / _gameScreen->getHeight();
 
-		_cursorHotspotXScaled = fracToInt(_cursorHotspotXScaled * screenScaleFactorX);
-		_cursorWidthScaled    = fracToDouble(cursorWidth        * screenScaleFactorX);
+		const float cursorScaleFactorX = screenScaleFactorX * _cursorScaleX;
+		const float cursorScaleFactorY = screenScaleFactorY * _cursorScaleY;
 
-		_cursorHotspotYScaled = fracToInt(_cursorHotspotYScaled * screenScaleFactorY);
-		_cursorHeightScaled   = fracToDouble(cursorHeight       * screenScaleFactorY);
+		_cursorHotspotXScaled = _cursorHotspotXScaled * cursorScaleFactorX;
+		_cursorWidthScaled    =  cursorWidth          * cursorScaleFactorX;
+
+		_cursorHotspotYScaled = _cursorHotspotYScaled * cursorScaleFactorY;
+		_cursorHeightScaled   =  cursorHeight         * cursorScaleFactorY;
 	}
 
 	switch (_rotationMode) {

--- a/backends/graphics/opengl/opengl-graphics.h
+++ b/backends/graphics/opengl/opengl-graphics.h
@@ -128,7 +128,7 @@ public:
 	void clearOverlay() override;
 	void grabOverlay(Graphics::Surface &surface) const override;
 
-	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) override;
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) override;
 	void setCursorPalette(const byte *colors, uint start, uint num) override;
 
 	void displayMessageOnOSD(const Common::U32String &msg) override;
@@ -450,9 +450,14 @@ protected:
 	bool _cursorUseKey;
 
 	/**
-	 * Whether no cursor scaling should be applied.
+	 * The X scaling factor for the cursor.
 	 */
-	bool _cursorDontScale;
+	float _cursorScaleX;
+
+	/**
+	 * The Y scaling factor for the cursor.
+	 */
+	float _cursorScaleY;
 
 	/**
 	 * Whether the special cursor palette is enabled.

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -181,7 +181,8 @@ SurfaceSdlGraphicsManager::SurfaceSdlGraphicsManager(SdlEventSource *sdlEventSou
 	_overlayscreen(nullptr), _tmpscreen2(nullptr),
 	_screenChangeCount(0),
 	_mouseSurface(nullptr), _mouseScaler(nullptr),
-	_mouseOrigSurface(nullptr), _cursorDontScale(false), _cursorPaletteDisabled(true),
+	_mouseOrigSurface(nullptr), _cursorPaletteDisabled(true),
+	_cursorScaleX(0), _cursorScaleY(0),
 	_currentShakeXOffset(0), _currentShakeYOffset(0),
 	_paletteDirtyStart(0), _paletteDirtyEnd(0),
 	_screenIsLocked(false),
@@ -2115,7 +2116,7 @@ void SurfaceSdlGraphicsManager::copyRectToOverlay(const void *buf, int pitch, in
 #pragma mark --- Mouse ---
 #pragma mark -
 
-void SurfaceSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keyColor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask, bool disableKeyColor) {
+void SurfaceSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keyColor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY, bool disableKeyColor) {
 
 	if (mask && (!format || format->bytesPerPixel == 1)) {
 		// 8-bit masked cursor, SurfaceSdl has no alpha mask support so we must convert this to color key
@@ -2155,7 +2156,7 @@ void SurfaceSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, 
 				maskedImage[i] = static_cast<byte>(bestKey);
 		}
 
-		setMouseCursor(&maskedImage[0], w, h, hotspotX, hotspotY, bestKey, dontScale, format, nullptr, disableKeyColor);
+		setMouseCursor(&maskedImage[0], w, h, hotspotX, hotspotY, bestKey, format, nullptr, scaleX, scaleY, disableKeyColor);
 		return;
 	}
 
@@ -2206,7 +2207,7 @@ void SurfaceSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, 
 		}
 
 		// Disable the key color because SDL_SetColorKey ignores the alpha channel, which would make 0xFF000000 transparent
-		setMouseCursor(&maskedImage[0], w, h, hotspotX, hotspotY, 0, dontScale, &formatWithAlpha, nullptr, true);
+		setMouseCursor(&maskedImage[0], w, h, hotspotX, hotspotY, 0, &formatWithAlpha, nullptr, scaleX, scaleY, true);
 		return;
 	}
 
@@ -2241,7 +2242,8 @@ void SurfaceSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, 
 		keycolorChanged = true;
 	}
 
-	_cursorDontScale = dontScale;
+	_cursorScaleX = scaleX;
+	_cursorScaleY = scaleY;
 
 	if (_mouseCurState.w != (int)w || _mouseCurState.h != (int)h || formatChanged || !_mouseOrigSurface) {
 		_mouseCurState.w = w;
@@ -2346,8 +2348,8 @@ void SurfaceSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, 
 	blitCursor();
 }
 
-void SurfaceSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keyColor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
-	setMouseCursor(buf, w, h, hotspotX, hotspotY, keyColor, dontScale, format, mask, false);
+void SurfaceSdlGraphicsManager::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keyColor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) {
+	setMouseCursor(buf, w, h, hotspotX, hotspotY, keyColor, format, mask, scaleX, scaleY, false);
 }
 
 void SurfaceSdlGraphicsManager::blitCursor() {
@@ -2360,20 +2362,14 @@ void SurfaceSdlGraphicsManager::blitCursor() {
 
 	_cursorNeedsRedraw = true;
 
-	int cursorScale;
-	if (_cursorDontScale) {
-		// Don't scale the cursor at all if the user requests this behavior.
-		cursorScale = 1;
-	} else {
-		// Scale the cursor with the game screen scale factor.
-		cursorScale = _videoMode.scaleFactor;
-	}
+	frac_t cursorScaleX = _cursorScaleX == 0 ? FRAC_ONE : _videoMode.scaleFactor * _cursorScaleX;
+	frac_t cursorScaleY = _cursorScaleY == 0 ? FRAC_ONE : _videoMode.scaleFactor * _cursorScaleY;
 
 	// Adapt the real hotspot according to the scale factor.
-	int rW = w * cursorScale;
-	int rH = h * cursorScale;
-	_mouseCurState.rHotX = _mouseCurState.hotX * cursorScale;
-	_mouseCurState.rHotY = _mouseCurState.hotY * cursorScale;
+	int rW = fracToInt(w * cursorScaleX);
+	int rH = fracToInt(h * cursorScaleY);
+	_mouseCurState.rHotX = fracToInt(_mouseCurState.hotX * cursorScaleX);
+	_mouseCurState.rHotY = fracToInt(_mouseCurState.hotY * cursorScaleY);
 
 	// The virtual dimensions will be the same as the original.
 
@@ -2387,7 +2383,7 @@ void SurfaceSdlGraphicsManager::blitCursor() {
 	const int rH1 = rH;
 #endif
 
-	if (!_cursorDontScale && _videoMode.aspectRatioCorrection) {
+	if (!(_cursorScaleX == 0 && _cursorScaleY == 0) && _videoMode.aspectRatioCorrection) {
 		rH = real2Aspect(rH - 1) + 1;
 		_mouseCurState.rHotY = real2Aspect(_mouseCurState.rHotY);
 	}
@@ -2447,12 +2443,13 @@ void SurfaceSdlGraphicsManager::blitCursor() {
 	// If possible, use the same scaler for the cursor as for the rest of
 	// the game. This only works well with the non-blurring scalers so we
 	// otherwise use the Normal scaler
-	if (!_cursorDontScale) {
+	if (!(_cursorScaleX == 0 && _cursorScaleY == 0)) {
 #ifdef USE_SCALERS
 		// HACK: AdvMame4x requires a height of at least 4 pixels, so we
 		// fall back on the Normal scaler when a smaller cursor is supplied.
-		if (_mouseScaler && _scalerPlugin->canDrawCursor() && (uint)_mouseCurState.h >= _extraPixels) {
-			_mouseScaler->setFactor(_videoMode.scaleFactor);
+		if (_mouseScaler && _scalerPlugin->canDrawCursor() && (uint)_mouseCurState.h >= _extraPixels && cursorScaleX == cursorScaleY &&
+		    !((cursorScaleX | cursorScaleY) & FRAC_HALF) && _scalerPlugins[_videoMode.scalerIndex]->get<ScalerPluginObject>().hasFactor(fracToInt(cursorScaleX))) {
+			_mouseScaler->setFactor(fracToInt(cursorScaleX));
 #if SDL_VERSION_ATLEAST(3, 0, 0)
 			const SDL_PixelFormatDetails *pixelFormatDetails = SDL_GetPixelFormatDetails(_mouseOrigSurface->format);
 			if (pixelFormatDetails == nullptr)
@@ -2476,12 +2473,12 @@ void SurfaceSdlGraphicsManager::blitCursor() {
 				error("getting pixel format details failed");
 			Graphics::scaleBlit((byte *)_mouseSurface->pixels, (const byte *)_mouseOrigSurface->pixels + _mouseOrigSurface->pitch * _maxExtraPixels + _maxExtraPixels * pixelFormatDetails->bytes_per_pixel,
 			                    _mouseSurface->pitch, _mouseOrigSurface->pitch,
-				                _mouseCurState.w * _videoMode.scaleFactor, _mouseCurState.h * _videoMode.scaleFactor,
+			                    _mouseCurState.rW, _mouseCurState.rH,
 			                    _mouseCurState.w, _mouseCurState.h, convertSDLPixelFormat(_mouseSurface->format));
 #else
 			Graphics::scaleBlit((byte *)_mouseSurface->pixels, (const byte *)_mouseOrigSurface->pixels + _mouseOrigSurface->pitch * _maxExtraPixels + _maxExtraPixels * _mouseOrigSurface->format->BytesPerPixel,
 			                    _mouseSurface->pitch, _mouseOrigSurface->pitch,
-				                _mouseCurState.w * _videoMode.scaleFactor, _mouseCurState.h * _videoMode.scaleFactor,
+			                    _mouseCurState.rW, _mouseCurState.rH,
 			                    _mouseCurState.w, _mouseCurState.h, convertSDLPixelFormat(_mouseSurface->format));
 #endif
 
@@ -2505,7 +2502,7 @@ void SurfaceSdlGraphicsManager::blitCursor() {
 	}
 
 #ifdef USE_ASPECT
-	if (!_cursorDontScale && _videoMode.aspectRatioCorrection)
+	if (!(_cursorScaleX == 0 && _cursorScaleY == 0) && _videoMode.aspectRatioCorrection)
 		stretch200To240Nearest((uint8 *)_mouseSurface->pixels, _mouseSurface->pitch, rW, rH1, 0, 0, 0, convertSDLPixelFormat(_mouseSurface->format));
 #endif
 
@@ -2524,17 +2521,10 @@ void SurfaceSdlGraphicsManager::undrawMouse() {
 	_mouseNextRect.x = virtualCursor.x + _gameScreenShakeXOffset;
 	_mouseNextRect.y = virtualCursor.y + _gameScreenShakeYOffset;
 
-	if (!_overlayInGUI) {
-		_mouseNextRect.w = _mouseCurState.vW;
-		_mouseNextRect.h = _mouseCurState.vH;
-		_mouseNextRect.x -= _mouseCurState.vHotX;
-		_mouseNextRect.y -= _mouseCurState.vHotY;
-	} else {
-		_mouseNextRect.w = _mouseCurState.rW;
-		_mouseNextRect.h = _mouseCurState.rH;
-		_mouseNextRect.x -= _mouseCurState.rHotX;
-		_mouseNextRect.y -= _mouseCurState.rHotY;
-	}
+	_mouseNextRect.w = _mouseCurState.rW;
+	_mouseNextRect.h = _mouseCurState.rH;
+	_mouseNextRect.x -= _mouseCurState.rHotX;
+	_mouseNextRect.y -= _mouseCurState.rHotY;
 
 	if (!_cursorVisible || !_mouseSurface) {
 		_mouseNextRect.x = _mouseNextRect.y = _mouseNextRect.w = _mouseNextRect.h = 0;
@@ -2545,14 +2535,14 @@ void SurfaceSdlGraphicsManager::undrawMouse() {
 	// alpha-blended cursors will happily blend into themselves if the surface
 	// under the cursor is not reset first
 	//
-	// The mouse is undrawn using virtual coordinates, i.e. they may be
-	// scaled and aspect-ratio corrected.
+	// The mouse is undrawn using real coordinates, i.e. they have already
+	// been scaled and aspect-ratio corrected.
 
 	if (_mouseLastRect.w != 0 && _mouseLastRect.h != 0)
-		addDirtyRect(_mouseLastRect.x, _mouseLastRect.y, _mouseLastRect.w, _mouseLastRect.h, _overlayInGUI);
+		addDirtyRect(_mouseLastRect.x, _mouseLastRect.y, _mouseLastRect.w, _mouseLastRect.h, true);
 
 	if (_mouseNextRect.w != 0 && _mouseNextRect.h != 0)
-		addDirtyRect(_mouseNextRect.x, _mouseNextRect.y, _mouseNextRect.w, _mouseNextRect.h, _overlayInGUI);
+		addDirtyRect(_mouseNextRect.x, _mouseNextRect.y, _mouseNextRect.w, _mouseNextRect.h, true);
 }
 
 void SurfaceSdlGraphicsManager::drawMouse() {

--- a/backends/graphics/surfacesdl/surfacesdl-graphics.h
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.h
@@ -117,8 +117,8 @@ public:
 	int16 getOverlayHeight() const override { return _videoMode.overlayHeight; }
 	int16 getOverlayWidth() const override { return _videoMode.overlayWidth; }
 
-	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override;
-	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask, bool disableKeyColor);
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) override;
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY, bool disableKeyColor);
 	void setCursorPalette(const byte *colors, uint start, uint num) override;
 
 #ifdef USE_OSD
@@ -384,7 +384,8 @@ protected:
 	uint32 _mouseKeyColor;
 	bool _disableMouseKeyColor;
 	byte _mappedMouseKeyColor;
-	bool _cursorDontScale;
+	frac_t _cursorScaleX;
+	frac_t _cursorScaleY;
 	bool _cursorPaletteDisabled;
 	SDL_Surface *_mouseOrigSurface;
 	SDL_Surface *_mouseSurface;

--- a/backends/modular-backend.cpp
+++ b/backends/modular-backend.cpp
@@ -283,8 +283,8 @@ void ModularGraphicsBackend::warpMouse(int x, int y) {
 	_graphicsManager->warpMouse(x, y);
 }
 
-void ModularGraphicsBackend::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
-	_graphicsManager->setMouseCursor(buf, w, h, hotspotX, hotspotY, keycolor, dontScale, format, mask);
+void ModularGraphicsBackend::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) {
+	_graphicsManager->setMouseCursor(buf, w, h, hotspotX, hotspotY, keycolor, format, mask, scaleX, scaleY);
 }
 
 void ModularGraphicsBackend::setCursorPalette(const byte *colors, uint start, uint num) {

--- a/backends/modular-backend.h
+++ b/backends/modular-backend.h
@@ -124,7 +124,7 @@ public:
 
 	bool showMouse(bool visible) override final;
 	void warpMouse(int x, int y) override final;
-	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = NULL) override final;
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) override final;
 	void setCursorPalette(const byte *colors, uint start, uint num) override final;
 	bool lockMouse(bool lock) override final;
 

--- a/backends/platform/3ds/osystem-graphics.cpp
+++ b/backends/platform/3ds/osystem-graphics.cpp
@@ -775,7 +775,6 @@ void OSystem_3DS::warpMouse(int x, int y) {
 		_cursorOverlayY = y;
 	}
 
-	// TODO: adjust for _cursorScalable ?
 	x -= _cursorHotspotX;
 	y -= _cursorHotspotY;
 
@@ -796,9 +795,9 @@ void OSystem_3DS::setCursorDelta(float deltaX, float deltaY) {
 
 void OSystem_3DS::setMouseCursor(const void *buf, uint w, uint h,
 								 int hotspotX, int hotspotY,
-								 uint32 keycolor, bool dontScale,
-								 const Graphics::PixelFormat *format, const byte *mask) {
-	_cursorScalable = !dontScale;
+								 uint32 keycolor,
+								 const Graphics::PixelFormat *format, const byte *mask,
+								 frac_t scaleX, frac_t scaleY) {
 	_cursorHotspotX = hotspotX;
 	_cursorHotspotY = hotspotY;
 	_cursorKeyColor = keycolor;

--- a/backends/platform/3ds/osystem.cpp
+++ b/backends/platform/3ds/osystem.cpp
@@ -60,7 +60,6 @@ OSystem_3DS::OSystem_3DS():
 	_focusClearTime(0),
 	_cursorPaletteEnabled(false),
 	_cursorVisible(false),
-	_cursorScalable(false),
 	_cursorScreenX(0),
 	_cursorScreenY(0),
 	_cursorOverlayX(0),

--- a/backends/platform/3ds/osystem.h
+++ b/backends/platform/3ds/osystem.h
@@ -184,8 +184,9 @@ public:
 	bool showMouse(bool visible);
 	void warpMouse(int x, int y);
 	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX,
-	                    int hotspotY, uint32 keycolor, bool dontScale = false,
-	                    const Graphics::PixelFormat *format = NULL, const byte *mask = NULL);
+	                    int hotspotY, uint32 keycolor,
+	                    const Graphics::PixelFormat *format, const byte *mask
+	                    frac_t scaleX, frac_t scaleY);
 	void setCursorPalette(const byte *colors, uint start, uint num);
 
 	// Transform point from touchscreen coords into gamescreen coords
@@ -292,7 +293,6 @@ private:
 	Sprite _cursorTexture;
 	bool _cursorPaletteEnabled;
 	bool _cursorVisible;
-	bool _cursorScalable;
 	float _cursorScreenX, _cursorScreenY;
 	float _cursorOverlayX, _cursorOverlayY;
 	float _cursorDeltaX, _cursorDeltaY;

--- a/backends/platform/dc/dc.h
+++ b/backends/platform/dc/dc.h
@@ -127,7 +127,7 @@ public:
   void warpMouse(int x, int y);
 
   // Set the bitmap that's used when drawing the cursor.
-  void setMouseCursor(const void *buf, uint w, uint h, int hotspot_x, int hotspot_y, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask);
+  void setMouseCursor(const void *buf, uint w, uint h, int hotspot_x, int hotspot_y, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY);
 
   // Replace the specified range of cursor the palette with new colors.
   void setCursorPalette(const byte *colors, uint start, uint num);

--- a/backends/platform/dc/display.cpp
+++ b/backends/platform/dc/display.cpp
@@ -295,7 +295,7 @@ void OSystem_Dreamcast::warpMouse(int x, int y)
 
 void OSystem_Dreamcast::setMouseCursor(const void *buf, uint w, uint h,
 				       int hotspot_x, int hotspot_y,
-				       uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
+				       uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) {
 	if (mask)
 		warning("OSystem_Dreamcast::setMouseCursor: Masks are not supported");
 

--- a/backends/platform/ds/ds-graphics.cpp
+++ b/backends/platform/ds/ds-graphics.cpp
@@ -625,7 +625,7 @@ void OSystem_DS::warpMouse(int x, int y) {
 		_cursorPos = _screen->scaledToReal(x, y);
 }
 
-void OSystem_DS::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, u32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
+void OSystem_DS::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, u32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) {
 	if (!buf || w == 0 || h == 0)
 		return;
 

--- a/backends/platform/ds/osystem_ds.h
+++ b/backends/platform/ds/osystem_ds.h
@@ -171,7 +171,7 @@ public:
 	virtual bool showMouse(bool visible);
 
 	virtual void warpMouse(int x, int y);
-	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, u32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask);
+	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, u32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY);
 
 	virtual void addSysArchivesToSearchSet(Common::SearchSet &s, int priority);
 

--- a/backends/platform/libretro/include/libretro-graphics-opengl.h
+++ b/backends/platform/libretro/include/libretro-graphics-opengl.h
@@ -33,7 +33,7 @@ public:
 	}
 	void refreshScreen() override;
 	void setSystemMousePosition(const int x, const int y) override {};
-	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) override;
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) override;
 	void initSize(uint width, uint height, const Graphics::PixelFormat *format) override;
 	void setMousePosition(int x, int y);
 	void resetContext(OpenGL::ContextType contextType);

--- a/backends/platform/libretro/include/libretro-graphics-surface.h
+++ b/backends/platform/libretro/include/libretro-graphics-surface.h
@@ -33,7 +33,8 @@ public:
 	Graphics::Palette _gamePalette;
 
 private:
-	bool _cursorDontScale;
+	float _cursorScaleX;
+	float _cursorScaleY;
 	bool _cursorPaletteEnabled;
 	bool _screenUpdatePending;
 	int _cursorHotspotX;
@@ -64,7 +65,7 @@ public:
 	Graphics::PixelFormat getOverlayFormat() const override;
 	const Graphics::ManagedSurface *getScreen(void);
 	void warpMouse(int x, int y) override;
-	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor = 255, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = nullptr) override;
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) override;
 	void setCursorPalette(const byte *colors, uint start, uint num) override;
 	bool isOverlayInGUI(void);
 

--- a/backends/platform/libretro/src/libretro-graphics-opengl.cpp
+++ b/backends/platform/libretro/src/libretro-graphics-opengl.cpp
@@ -38,14 +38,14 @@ void LibretroOpenGLGraphics::setMousePosition(int x, int y) {
 	OpenGL::OpenGLGraphicsManager::setMousePosition(x, y);
 }
 
-void LibretroOpenGLGraphics::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
+void LibretroOpenGLGraphics::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) {
 	/* Workaround to fix a cursor glitch (e.g. GUI with Classic theme) occurring when any overlay is activated from retroarch (e.g. keyboard overlay).
 	   Currently no feedback is available from frontend to detect if overlays are toggled to delete _cursor only if needed.
 	   @TODO: root cause to be investigated. */
 	delete _cursor;
 	_cursor = nullptr;
 
-	OpenGL::OpenGLGraphicsManager::setMouseCursor(buf, w, h, hotspotX, hotspotY, keycolor, dontScale, format, mask);
+	OpenGL::OpenGLGraphicsManager::setMouseCursor(buf, w, h, hotspotX, hotspotY, keycolor, format, mask, scaleX, scaleY);
 
 	overrideCursorScaling();
 
@@ -55,13 +55,17 @@ void LibretroOpenGLGraphics::overrideCursorScaling() {
 	OpenGL::OpenGLGraphicsManager::recalculateCursorScaling();
 
 	if (_cursor) {
-		const frac_t screenScaleFactor = (_cursorDontScale || ! _overlayVisible) ? intToFrac(1) : intToFrac(getWindowHeight()) / 200; /* hard coded as base resolution 320x200 is hard coded upstream */
+		const float screenScaleFactorX = (_cursorScaleX == 0 || ! _overlayVisible) ? 1.0f : (float)getWindowHeight() / 200; /* hard coded as base resolution 320x200 is hard coded upstream */
+		const float screenScaleFactorY = (_cursorScaleY == 0 || ! _overlayVisible) ? 1.0f : (float)getWindowHeight() / 200; /* hard coded as base resolution 320x200 is hard coded upstream */
 
-		_cursorHotspotXScaled = fracToInt(_cursorHotspotX * screenScaleFactor);
-		_cursorWidthScaled    = fracToDouble(_cursor->getWidth() * screenScaleFactor);
+		const float cursorScaleFactorX = screenScaleFactorX * _cursorScaleX;
+		const float cursorScaleFactorY = screenScaleFactorY * _cursorScaleY;
 
-		_cursorHotspotYScaled = fracToInt(_cursorHotspotY * screenScaleFactor);
-		_cursorHeightScaled   = fracToDouble(_cursor->getHeight() * screenScaleFactor);
+		_cursorHotspotXScaled = _cursorHotspotX * cursorScaleFactorX;
+		_cursorWidthScaled    = _cursor->getWidth() * cursorScaleFactorX;
+
+		_cursorHotspotYScaled = _cursorHotspotY * cursorScaleFactorY;
+		_cursorHeightScaled   = _cursor->getHeight() * cursorScaleFactorY;
 	}
 }
 

--- a/backends/platform/libretro/src/libretro-graphics-surface.cpp
+++ b/backends/platform/libretro/src/libretro-graphics-surface.cpp
@@ -30,7 +30,8 @@
 
 LibretroGraphics::LibretroGraphics() : _cursorPaletteEnabled(false),
 	_cursorKeyColor(0),
-	_cursorDontScale(false),
+	_cursorScaleX(0),
+	_cursorScaleY(0),
 	_screenUpdatePending(false),
 	_gamePalette(256),
 	_cursorPalette(256),
@@ -168,16 +169,20 @@ void LibretroGraphics::warpMouse(int x, int y) {
 }
 
 void LibretroGraphics::overrideCursorScaling() {
-	const frac_t screenScaleFactor = (_cursorDontScale || ! _overlayVisible) ? intToFrac(1) : intToFrac(getWindowHeight()) / 200; /* hard coded as base resolution 320x200 is hard coded upstream */
+	const float screenScaleFactorX = (_cursorScaleX == 0 || ! _overlayVisible) ? 1.0f : (float)getWindowHeight() / 200; /* hard coded as base resolution 320x200 is hard coded upstream */
+	const float screenScaleFactorY = (_cursorScaleY == 0 || ! _overlayVisible) ? 1.0f : (float)getWindowHeight() / 200; /* hard coded as base resolution 320x200 is hard coded upstream */
 
-	_cursorHotspotXScaled = fracToInt(_cursorHotspotX * screenScaleFactor);
-	_cursorWidthScaled    = fracToDouble(_cursor.w * screenScaleFactor);
+	const float cursorScaleFactorX = screenScaleFactorX * _cursorScaleX;
+	const float cursorScaleFactorY = screenScaleFactorY * _cursorScaleY;
 
-	_cursorHotspotYScaled = fracToInt(_cursorHotspotY * screenScaleFactor);
-	_cursorHeightScaled   = fracToDouble(_cursor.h * screenScaleFactor);
+	_cursorHotspotXScaled = fracToInt(_cursorHotspotX * cursorScaleFactorX);
+	_cursorWidthScaled    = fracToDouble(_cursor.w * cursorScaleFactorX);
+
+	_cursorHotspotYScaled = fracToInt(_cursorHotspotY * cursorScaleFactorY);
+	_cursorHeightScaled   = fracToDouble(_cursor.h * cursorScaleFactorY);
 }
 
-void LibretroGraphics::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
+void LibretroGraphics::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) {
 	if (!buf || !w || !h)
 		return;
 
@@ -191,7 +196,8 @@ void LibretroGraphics::setMouseCursor(const void *buf, uint w, uint h, int hotsp
 	_cursorHotspotX = hotspotX;
 	_cursorHotspotY = hotspotY;
 	_cursorKeyColor = keycolor;
-	_cursorDontScale = dontScale;
+	_cursorScaleX = fracToDouble(scaleX);
+	_cursorScaleY = fracToDouble(scaleY);
 
 	overrideCursorScaling();
 }

--- a/backends/platform/n64/osys_n64.h
+++ b/backends/platform/n64/osys_n64.h
@@ -180,7 +180,7 @@ public:
 	virtual bool showMouse(bool visible);
 
 	virtual void warpMouse(int x, int y);
-	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask);
+	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY);
 	virtual void setCursorPalette(const byte *colors, uint start, uint num);
 
 	virtual bool pollEvent(Common::Event &event);

--- a/backends/platform/n64/osys_n64_base.cpp
+++ b/backends/platform/n64/osys_n64_base.cpp
@@ -768,7 +768,7 @@ void OSystem_N64::warpMouse(int x, int y) {
 	_dirtyOffscreen = true;
 }
 
-void OSystem_N64::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
+void OSystem_N64::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) {
 	if (!w || !h) return;
 
 	if (mask)

--- a/backends/platform/psp/osys_psp.cpp
+++ b/backends/platform/psp/osys_psp.cpp
@@ -307,7 +307,7 @@ void OSystem_PSP::warpMouse(int x, int y) {
 	_cursor.setXY(x, y);
 }
 
-void OSystem_PSP::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
+void OSystem_PSP::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) {
 	DEBUG_ENTER_FUNC();
 
 	if (mask)
@@ -316,7 +316,7 @@ void OSystem_PSP::setMouseCursor(const void *buf, uint w, uint h, int hotspotX, 
 	_displayManager.waitUntilRenderFinished();
 	_pendingUpdate = false;
 
-	PSP_DEBUG_PRINT("pbuf[%p], w[%u], h[%u], hotspot:X[%d], Y[%d], keycolor[%d], scale[%d], pformat[%p]\n", buf, w, h, hotspotX, hotspotY, keycolor, !dontScale, format);
+	PSP_DEBUG_PRINT("pbuf[%p], w[%u], h[%u], hotspot:X[%d], Y[%d], keycolor[%d], pformat[%p], scaleX[%f], scaleY[%f]\n", buf, w, h, hotspotX, hotspotY, keycolor, format, fracToDouble(scaleX), fracToDouble(scaleY));
 	if (format) {
 		PSP_DEBUG_PRINT("format: bpp[%d], rLoss[%d], gLoss[%d], bLoss[%d], aLoss[%d], rShift[%d], gShift[%d], bShift[%d], aShift[%d]\n", format->bytesPerPixel, format->rLoss, format->gLoss, format->bLoss, format->aLoss, format->rShift, format->gShift, format->bShift, format->aShift);
 	}

--- a/backends/platform/psp/osys_psp.h
+++ b/backends/platform/psp/osys_psp.h
@@ -114,7 +114,7 @@ public:
 	// Mouse related
 	bool showMouse(bool visible);
 	void warpMouse(int x, int y);
-	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask);
+	void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY);
 
 	// Events and input
 	bool pollEvent(Common::Event &event);

--- a/backends/platform/wii/osystem.cpp
+++ b/backends/platform/wii/osystem.cpp
@@ -41,7 +41,8 @@ OSystem_Wii::OSystem_Wii() :
 	_startup_time(0),
 
 	_overlayInGUI(false),
-	_cursorDontScale(true),
+	_cursorScaleX(0),
+	_cursorScaleY(0),
 	_cursorPaletteDisabled(true),
 	_cursorPalette(NULL),
 	_cursorPaletteDirty(false),

--- a/backends/platform/wii/osystem.h
+++ b/backends/platform/wii/osystem.h
@@ -55,7 +55,8 @@ class OSystem_Wii final : virtual public BaseBackend, public Common::EventSource
 private:
 	s64 _startup_time;
 
-	bool _cursorDontScale;
+	float _cursorScaleX;
+	float _cursorScaleY;
 	bool _cursorPaletteDisabled;
 	u16 *_cursorPalette;
 	bool _cursorPaletteDirty;
@@ -191,8 +192,8 @@ public:
 	void warpMouse(int x, int y) override;
 	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX,
 								int hotspotY, uint32 keycolor,
-								bool dontScale,
-								const Graphics::PixelFormat *format, const byte *mask) override;
+								const Graphics::PixelFormat *format, const byte *mask,
+								frac_t scaleX, frac_t scaleY) override;
 
 	bool pollEvent(Common::Event &event) override;
 	uint32 getMillis(bool skipRecord = false) override;

--- a/backends/platform/wii/osystem_gfx.cpp
+++ b/backends/platform/wii/osystem_gfx.cpp
@@ -473,7 +473,6 @@ bool OSystem_Wii::needsScreenUpdate() {
 void OSystem_Wii::updateScreen() {
 	static f32 ar;
 	static gfx_screen_coords_t cc;
-	static f32 csx, csy;
 
 	u32 now = getMillis();
 	if (now - _lastScreenUpdate < 1000 / MAX_FPS)
@@ -518,13 +517,8 @@ void OSystem_Wii::updateScreen() {
 	}
 
 	if (_mouseVisible) {
-		if (_cursorDontScale) {
-			csx = 1.0f / _currentXScale;
-			csy = 1.0f / _currentYScale;
-		} else {
-			csx = 1.0f;
-			csy = 1.0f;
-		}
+		f32 csx = _cursorScaleX ? _cursorScaleX : 1.0f;
+		f32 csy = _cursorScaleY ? _cursorScaleY : 1.0f;
 
 		cc.x = f32(_mouseX - csx * _mouseHotspotX) * _currentXScale;
 		cc.y = f32(_mouseY - csy * _mouseHotspotY) * _currentYScale;
@@ -683,10 +677,10 @@ void OSystem_Wii::warpMouse(int x, int y) {
 
 void OSystem_Wii::setMouseCursor(const void *buf, uint w, uint h, int hotspotX,
 									int hotspotY, uint32 keycolor,
-									bool dontScale,
-									const Graphics::PixelFormat *format, const byte *mask) {
+									const Graphics::PixelFormat *format, const byte *mask,
+									frac_t scaleX, frac_t scaleY) {
 #ifdef PLATFORM_WII_OSYSTEM_GFX_DEBUG
-	printf("%s(%p, w:%u, h:%u, hsX:%d, hsY:%d, kc:%u, dontScale:%d, %p, %p)\n", __func__, buf, w, h, hotspotX, hotspotY, keycolor, dontScale, format, mask);
+	printf("%s(%p, w:%u, h:%u, hsX:%d, hsY:%d, kc:%u, scaleX:%f, scaleY:%f, %p, %p)\n", __func__, buf, w, h, hotspotX, hotspotY, keycolor, fracToDouble(scaleX), fracToDouble(scaleY), format, mask);
 #endif
 
 	if (mask)
@@ -782,7 +776,8 @@ void OSystem_Wii::setMouseCursor(const void *buf, uint w, uint h, int hotspotX,
 
 	_mouseHotspotX = hotspotX;
 	_mouseHotspotY = hotspotY;
-	_cursorDontScale = dontScale;
+	_cursorScaleX = fracToDouble(scaleX);
+	_cursorScaleY = fracToDouble(scaleY);
 
 	if (_pfCursor.bytesPerPixel == 1 && oldKeycolor != _mouseKeyColor)
 		updateMousePalette();

--- a/common/system.h
+++ b/common/system.h
@@ -31,6 +31,7 @@
 #include "common/hash-str.h" // For OSystem::updateStartSettings()
 #include "common/path.h"
 #include "common/log.h"
+#include "common/frac.h"
 #include "graphics/pixelformat.h"
 #include "graphics/mode.h"
 #include "graphics/opengl/context.h"
@@ -1510,12 +1511,14 @@ protected:
 	 *                  In case it does, the behavior is undefined. The backend might just error out or simply ignore the
 	 *                  value. (The SDL backend will just assert to prevent abuse of this).
 	 *                  This parameter does nothing if a mask is provided.
-	 * @param dontScale Whether the cursor should never be scaled. An exception is high ppi displays, where the cursor
-	 *                  might be too small to notice otherwise, these are allowed to scale the cursor anyway.
 	 * @param format    Pointer to the pixel format that the cursor graphic uses (0 means CLUT8).
 	 * @param mask      A mask containing values from the CursorMaskValue enum for each cursor pixel.
+	 * @param scaleX    Horizontal scaling factor for the cursor relative to the
+	 *                  game screen scale. A value of 0 means that the cursor should not be scaled.
+	 * @param scaleY    Vertical scaling factor for the cursor relative to the
+	 *                  game screen scale. A value of 0 means that the cursor should not be scaled.
 	 */
-	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = nullptr, const byte *mask = nullptr) = 0;
+	virtual void setMouseCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) = 0;
 
 	/**
 	 * Replace the specified range of cursor palette with new colors.

--- a/engines/avalanche/graphics.cpp
+++ b/engines/avalanche/graphics.cpp
@@ -164,7 +164,7 @@ void GraphicManager::loadMouse(byte which) {
 	mask.free();
 	f.close();
 
-	CursorMan.replaceCursor(cursor, kMouseHotSpots[which]._horizontal, kMouseHotSpots[which]._vertical * 2, 255, false);
+	CursorMan.replaceCursor(cursor, kMouseHotSpots[which]._horizontal, kMouseHotSpots[which]._vertical * 2, 255);
 	cursor.free();
 }
 

--- a/engines/bagel/spacebar/baglib/cursor.cpp
+++ b/engines/bagel/spacebar/baglib/cursor.cpp
@@ -133,7 +133,7 @@ void CSystemCursor::setCurrent() {
 
 	Graphics::PixelFormat format = Graphics::PixelFormat::createFormatCLUT8();
 	CursorMan.replaceCursorPalette(CURSOR_PALETTE, 0, ARRAYSIZE(CURSOR_PALETTE) / 3);
-	CursorMan.replaceCursor(ARROW_CURSOR, CURSOR_W, CURSOR_H, 0, 0, 0, false, &format);
+	CursorMan.replaceCursor(ARROW_CURSOR, CURSOR_W, CURSOR_H, 0, 0, 0, &format);
 }
 
 } // namespace SpaceBar

--- a/engines/freescape/games/castle/castle.cpp
+++ b/engines/freescape/games/castle/castle.cpp
@@ -924,7 +924,7 @@ void CastleEngine::setAmigaCursor(bool crosshair) {
 			scaledCursor[y * sw + x] = srcData[(y / scale) * _cursorW + (x / scale)];
 
 	Graphics::PixelFormat cursorFormat = Graphics::PixelFormat::createFormatCLUT8();
-	CursorMan.replaceCursor(scaledCursor, sw, sh, hotX, hotY, 0, false, &cursorFormat);
+	CursorMan.replaceCursor(scaledCursor, sw, sh, hotX, hotY, 0, &cursorFormat);
 	CursorMan.replaceCursorPalette(cursorPalette, 0, 16);
 	delete[] scaledCursor;
 }

--- a/engines/gob/draw_v1.cpp
+++ b/engines/gob/draw_v1.cpp
@@ -128,7 +128,7 @@ void Draw_v1::animateCursor(int16 cursor) {
 				(cursorIndex + 1) * _cursorWidth - 1,
 				_cursorHeight - 1, 0, 0);
 		CursorMan.replaceCursor(_scummvmCursor->getData(),
-				_cursorWidth, _cursorHeight, hotspotX, hotspotY, 0, false, &_vm->getPixelFormat());
+				_cursorWidth, _cursorHeight, hotspotX, hotspotY, 0, &_vm->getPixelFormat());
 
 		if (_frontSurface != _backSurface) {
 			_showCursor = 3;

--- a/engines/gob/draw_v2.cpp
+++ b/engines/gob/draw_v2.cpp
@@ -162,7 +162,7 @@ void Draw_v2::animateCursor(int16 cursor) {
 				_cursorHeight - 1, 0, 0);
 
 		CursorMan.replaceCursor(_scummvmCursor->getData(),
-				_cursorWidth, _cursorHeight, hotspotX, hotspotY, 0, false, &_vm->getPixelFormat());
+				_cursorWidth, _cursorHeight, hotspotX, hotspotY, 0, &_vm->getPixelFormat());
 		CursorMan.disableCursorPalette(true);
 
 		if (_frontSurface != _backSurface) {

--- a/engines/gob/draw_v7.cpp
+++ b/engines/gob/draw_v7.cpp
@@ -338,7 +338,7 @@ void Draw_v7::animateCursor(int16 cursor) {
 								 _cursorHeight - 1, 0, 0);
 
 			CursorMan.replaceCursor(_scummvmCursor->getData(),
-									_cursorWidth, _cursorHeight, hotspotX, hotspotY, 0, false, &_vm->getPixelFormat());
+									_cursorWidth, _cursorHeight, hotspotX, hotspotY, 0, &_vm->getPixelFormat());
 			CursorMan.disableCursorPalette(true);
 		}
 

--- a/engines/groovie/cursor.cpp
+++ b/engines/groovie/cursor.cpp
@@ -388,7 +388,7 @@ void Cursor_v2::showFrame(uint16 frame) {
 	int offset = _width * _height * frame * 4;
 	// SDL uses keycolor even though we're using ABGR8888, so just set it to a pink color that isn't used
 	uint32 keycolor = _format.ARGBToColor(0, 255, 128, 255);
-	CursorMan.replaceCursor((const byte *)(_img + offset), _width, _height, _hotspotX, _hotspotY, keycolor, false, &_format);
+	CursorMan.replaceCursor((const byte *)(_img + offset), _width, _height, _hotspotX, _hotspotY, keycolor, &_format);
 }
 
 void blendCursorPixel(uint32 &d, uint32 &s) {
@@ -446,7 +446,7 @@ void Cursor_v2::show2Cursors(Cursor_v2 *c1, uint16 frame1, Cursor_v2 *c2, uint16
 	uint32 keycolor = format.ARGBToColor(0, 255, 128, 255);
 
 	// replaceCursor copies the buffer, so we're ok to delete it
-	CursorMan.replaceCursor((const byte *)img, width, height, c1->_hotspotX, c1->_hotspotY, keycolor, false, &c1->_format);
+	CursorMan.replaceCursor((const byte *)img, width, height, c1->_hotspotX, c1->_hotspotY, keycolor, &c1->_format);
 	delete[] img;
 }
 

--- a/engines/hopkins/events.cpp
+++ b/engines/hopkins/events.cpp
@@ -532,7 +532,7 @@ void EventsManager::updateCursor() {
 	// Set the ScummVM cursor from the surface
 	CursorMan.replaceCursorPalette(cursorPalette, 0, PALETTE_SIZE - 1);
 	CursorMan.replaceCursor(cursorSurface, _vm->_objectsMan->getObjectWidth(), _vm->_objectsMan->getObjectHeight(),
-		xOffset, 0, 0, false);
+		xOffset, 0, 0);
 
 	// Delete the cursor surface and palette
 	delete[] cursorPalette;

--- a/engines/hypno/cursors.cpp
+++ b/engines/hypno/cursors.cpp
@@ -175,7 +175,7 @@ void HypnoEngine::changeCursor(const Common::String &cursor, uint32 n, bool cent
 	Graphics::Surface *entry = _cursorCache->getCursor(cursor, n, &palette);
 	uint32 hotspotX = centerCursor ? entry->w / 2 : 0;
 	uint32 hotspotY = centerCursor ? entry->h / 2 : 0;
-	CursorMan.replaceCursor(*entry, hotspotX, hotspotY, 0, false);
+	CursorMan.replaceCursor(*entry, hotspotX, hotspotY, 0);
 	CursorMan.replaceCursorPalette(palette, 0, 256);
 	CursorMan.showMouse(true);
 }
@@ -183,7 +183,7 @@ void HypnoEngine::changeCursor(const Common::String &cursor, uint32 n, bool cent
 void HypnoEngine::changeCursor(const Graphics::Surface &entry, byte *palette, bool centerCursor) {
 	uint32 hotspotX = centerCursor ? entry.w / 2 : 0;
 	uint32 hotspotY = centerCursor ? entry.h / 2 : 0;
-	CursorMan.replaceCursor(entry, hotspotX, hotspotY, 0, false);
+	CursorMan.replaceCursor(entry, hotspotX, hotspotY, 0);
 	CursorMan.replaceCursorPalette(palette, 0, 256);
 	CursorMan.showMouse(true);
 }

--- a/engines/kyra/graphics/screen_eob.cpp
+++ b/engines/kyra/graphics/screen_eob.cpp
@@ -292,7 +292,7 @@ void Screen_EoB::setMouseCursor(int x, int y, const byte *shape, const uint8 *ov
 	colorKey = _16bitConversionPalette ? _16bitConversionPalette[colorKey] : colorKey;
 	Graphics::PixelFormat pixelFormat = _system->getScreenFormat();
 
-	CursorMan.replaceCursor(cursor, mouseW * scaleFactor, mouseH * scaleFactor, x * scaleFactor, y * scaleFactor, colorKey, false, &pixelFormat);
+	CursorMan.replaceCursor(cursor, mouseW * scaleFactor, mouseH * scaleFactor, x * scaleFactor, y * scaleFactor, colorKey, &pixelFormat);
 	if (isMouseVisible())
 		CursorMan.showMouse(true);
 	delete[] cursor;

--- a/engines/made/screen.cpp
+++ b/engines/made/screen.cpp
@@ -981,9 +981,10 @@ void Screen::clearSpriteList() {
 
 void Screen::setMouseCursor(const Graphics::Cursor *cursor) {
 	// The original Windows version of Rodney's Funscreen upscales the
-	// main screen, but displays the cursor at native resolution.
-	// FIXME: This is likely too small on high DPI displays.
-	CursorMan.replaceCursor(cursor, true);
+	// main screen to the native resolution, but leaves the cursor
+	// unscaled. For simplicity, we hardcode the cursor scale to
+	// 0.5x, which matches the original when running in 640x400.
+	CursorMan.replaceCursor(cursor, FRAC_HALF, FRAC_HALF);
 }
 
 void Screen::setDefaultMouseCursor() {

--- a/engines/mohawk/cursors.cpp
+++ b/engines/mohawk/cursors.cpp
@@ -130,7 +130,7 @@ void MystCursorManager::setCursor(uint16 id) {
 			CursorMan.replaceCursorPalette(mhkSurface->getPalette(), 0, 256);
 	} else {
 		Graphics::PixelFormat pixelFormat = g_system->getScreenFormat();
-		CursorMan.replaceCursor(*surface, hotspotX, hotspotY, pixelFormat.RGBToColor(255, 255, 255), false);
+		CursorMan.replaceCursor(*surface, hotspotX, hotspotY, pixelFormat.RGBToColor(255, 255, 255));
 	}
 }
 

--- a/engines/nancy/cursor.cpp
+++ b/engines/nancy/cursor.cpp
@@ -292,7 +292,7 @@ void CursorManager::applyCursor() {
 
 		Graphics::ManagedSurface temp(*surf, bounds);
 
-		CursorMan.replaceCursor(temp, hotspot.x, hotspot.y, g_nancy->_graphics->getTransColor(), false);
+		CursorMan.replaceCursor(temp, hotspot.x, hotspot.y, g_nancy->_graphics->getTransColor());
 		if (g_nancy->getGameType() == kGameTypeVampire) {
 			byte palette[3 * 256];
 			surf->grabPalette(palette, 0, 256);

--- a/engines/pegasus/cursor.cpp
+++ b/engines/pegasus/cursor.cpp
@@ -86,7 +86,7 @@ void Cursor::setCurrentFrameIndex(int32 index) {
 				CursorMan.replaceCursorPalette(_info[index].palette, 0, _info[index].colorCount);
 				CursorMan.replaceCursor(*_info[index].surface, _info[index].hotspot.x, _info[index].hotspot.y, 0);
 			} else {
-				CursorMan.replaceCursor(*_info[index].surface, _info[index].hotspot.x, _info[index].hotspot.y, _info[index].surface->format.RGBToColor(0xFF, 0xFF, 0xFF), false);
+				CursorMan.replaceCursor(*_info[index].surface, _info[index].hotspot.x, _info[index].hotspot.y, _info[index].surface->format.RGBToColor(0xFF, 0xFF, 0xFF));
 			}
 		}
 	}

--- a/engines/prince/cursor.cpp
+++ b/engines/prince/cursor.cpp
@@ -91,7 +91,7 @@ void PrinceEngine::changeCursor(uint16 curId) {
 		curSurface->getBasePtr(0, 0),
 		curSurface->w, curSurface->h,
 		0, 0,
-		255, false,
+		255,
 		&curSurface->format
 	);
 	CursorMan.showMouse(true);

--- a/engines/scumm/cursor.cpp
+++ b/engines/scumm/cursor.cpp
@@ -418,30 +418,29 @@ void ScummEngine_v6::setCursorTransparency(int a) {
 }
 
 void ScummEngine::updateCursor() {
-	int transColor = (_game.heversion >= 80) ? 5 : 255;
 	byte *cursor = _grabbedCursor;
 	int width = _cursor.width;
 	int height = _cursor.height;
 	int hotspotX = _cursor.hotspotX;
 	int hotspotY = _cursor.hotspotY;
+	int transColor = (_game.heversion >= 80) ? 5 : (_game.platform == Common::kPlatformNES ? cursor[63] : 255);
 
 	if (_macScreen && _game.version == 6 && _game.heversion == 0)
 		mac_scaleCursor(cursor, hotspotX, hotspotY, width, height);
 
-	// FIXME: This is likely too small on high DPI displays with HE 70 games.
-#ifdef USE_RGB_COLOR
 	Graphics::PixelFormat format = _system->getScreenFormat();
-	CursorMan.replaceCursor(cursor, width, height,
-							hotspotX, hotspotY,
-							(_game.platform == Common::kPlatformNES ? cursor[63] : transColor),
-							(_game.heversion == 70 ? true : false),
-							&format);
-#else
-	CursorMan.replaceCursor(cursor, width, height,
-							hotspotX, hotspotY,
-							(_game.platform == Common::kPlatformNES ? cursor[63] : transColor),
-							(_game.heversion == 70 ? true : false));
-#endif
+	if (_game.heversion == 70) {
+		// Windows HE 70 games render the game scaled to 640x400, but
+		// leave the cursor unscaled.
+		CursorMan.replaceCursor(cursor, width, height,
+								hotspotX, hotspotY,
+								transColor, &format, nullptr,
+								FRAC_HALF, FRAC_HALF);
+	} else {
+		CursorMan.replaceCursor(cursor, width, height,
+								hotspotX, hotspotY,
+								transColor, &format);
+	}
 }
 
 void ScummEngine_v6::grabCursor(int x, int y, int w, int h) {
@@ -571,19 +570,11 @@ void ScummEngine_v7::updateCursor() {
 	if (_macScreen)
 		mac_scaleCursor(cursor, hotspotX, hotspotY, width, height);
 
-#ifdef USE_RGB_COLOR
 	Graphics::PixelFormat format = _system->getScreenFormat();
 	CursorMan.replaceCursor(cursor, width, height,
 							hotspotX, hotspotY,
 							transColor,
-							false,
 							&format);
-#else
-	CursorMan.replaceCursor(cursor, width, height,
-							hotspotX, hotspotY,
-							transColor,
-							false);
-#endif
 }
 #endif
 

--- a/engines/sherlock/events.cpp
+++ b/engines/sherlock/events.cpp
@@ -98,7 +98,7 @@ void Events::setCursor(const Graphics::Surface &src, int hotspotX, int hotspotY)
 		// PC 8-bit palettized
 		CursorMan.replaceCursor(src, hotspotX, hotspotY, 0xff);
 	} else if (!_vm->_isScreenDoubled) {
-		CursorMan.replaceCursor(src, hotspotX, hotspotY, 0x0000, false);
+		CursorMan.replaceCursor(src, hotspotX, hotspotY, 0x0000);
 	} else {
 		Graphics::Surface tempSurface;
 		tempSurface.create(2 * src.w, 2 * src.h, src.format);
@@ -115,7 +115,7 @@ void Events::setCursor(const Graphics::Surface &src, int hotspotX, int hotspotY)
 		}
 
 		// 3DO RGB565
-		CursorMan.replaceCursor(tempSurface, 2 * hotspotX, 2 * hotspotY, 0x0000, false);
+		CursorMan.replaceCursor(tempSurface, 2 * hotspotX, 2 * hotspotY, 0x0000);
 
 		tempSurface.free();
 	}

--- a/engines/testbed/graphics.cpp
+++ b/engines/testbed/graphics.cpp
@@ -142,26 +142,8 @@ void GFXtests::initMouseCursor() {
 	CursorMan.replaceCursor(MOUSECURSOR_SCI, 11, 16, 0, 0, 0);
 }
 
-Common::Rect GFXtests::computeSize(const Common::Rect &cursorRect, int scalingFactor, int cursorTargetScale) {
-	if (cursorTargetScale == 1 || scalingFactor == 1) {
-		// Game data and cursor would be scaled equally.
-		// so dimensions would be same.
-		return Common::Rect(cursorRect.width(), cursorRect.height());
-	}
-
-	if (scalingFactor == 2) {
-		// Game data is scaled by 2, cursor is said to be scaled by 2 or 3. so it wud not be scaled any further
-		// So a w/2 x h/2 rectangle when scaled would match the cursor
-		return Common::Rect(cursorRect.width() / 2, cursorRect.height() / 2);
-	}
-
-	if (scalingFactor == 3) {
-		// Cursor traget scale is 2 or 3.
-		return Common::Rect((cursorRect.width() / cursorTargetScale), (cursorRect.height() / cursorTargetScale));
-	} else {
-		Testsuite::logPrintf("Unsupported scaler %dx\n", scalingFactor);
-		return Common::Rect();
-	}
+Common::Rect GFXtests::computeSize(const Common::Rect &cursorRect, frac_t cursorTargetScaleX, frac_t cursorTargetScaleY) {
+	return Common::Rect(fracToInt(cursorTargetScaleX * cursorRect.width()), fracToInt(cursorTargetScaleY * cursorRect.height()));
 }
 
 void GFXtests::HSVtoRGB(int &rComp, int &gComp, int &bComp, int hue, int sat, int val) {
@@ -226,7 +208,7 @@ void GFXtests::HSVtoRGB(int &rComp, int &gComp, int &bComp, int hue, int sat, in
 	bComp = (int)(b * 255);
 }
 
-Common::Rect GFXtests::drawCursor(bool cursorPaletteDisabled, int cursorTargetScale) {
+Common::Rect GFXtests::drawCursor(bool cursorPaletteDisabled, frac_t cursorTargetScaleX, frac_t cursorTargetScaleY) {
 	// Buffer initialized with yellow color
 	byte buffer[500];
 	memset(buffer, 2, sizeof(buffer));
@@ -248,8 +230,8 @@ Common::Rect GFXtests::drawCursor(bool cursorPaletteDisabled, int cursorTargetSc
 	*/
 
 	// Uncommenting the next line and commenting the line after that would reproduce the crash
-	// CursorMan.replaceCursor(buffer, 11, 11, 0, 0, 255, cursorTargetScale);
-	CursorMan.replaceCursor(buffer, 12, 12, 0, 0, 255, cursorTargetScale);
+	// CursorMan.replaceCursor(buffer, 11, 11, 0, 0, 255, nullptr, nullptr, cursorTargetScaleX, cursorTargetScaleY);
+	CursorMan.replaceCursor(buffer, 12, 12, 0, 0, 255, nullptr, nullptr, cursorTargetScaleX, cursorTargetScaleY);
 	CursorMan.showMouse(true);
 
 	if (cursorPaletteDisabled) {
@@ -282,14 +264,14 @@ void rotatePalette(byte *palette, int size) {
 /**
  * Sets up mouse loop, exits when user clicks any of the mouse button
  */
-void GFXtests::setupMouseLoop(bool disableCursorPalette, const char *gfxModeName, int cursorTargetScale) {
+void GFXtests::setupMouseLoop(bool disableCursorPalette, const char *gfxModeName, frac_t cursorTargetScaleX, frac_t cursorTargetScaleY) {
 	bool isFeaturePresent;
 	isFeaturePresent = g_system->hasFeature(OSystem::kFeatureCursorPalette);
 	Common::Rect cursorRect;
 
 	if (isFeaturePresent) {
 
-		cursorRect = GFXtests::drawCursor(disableCursorPalette, cursorTargetScale);
+		cursorRect = GFXtests::drawCursor(disableCursorPalette, cursorTargetScaleX, cursorTargetScaleY);
 
 		Common::EventManager *eventMan = g_system->getEventManager();
 		Common::Event event;
@@ -311,29 +293,17 @@ void GFXtests::setupMouseLoop(bool disableCursorPalette, const char *gfxModeName
 
 		Testsuite::writeOnScreen(info, pt);
 
-		info = "GFX Mode";
+		info = "GFX Mode: ";
 		info += gfxModeName;
-		info += " ";
+		info += ", ";
 
-		char cScale = cursorTargetScale + '0';
-		info += "Cursor scale: ";
-		info += cScale;
+		info += Common::String::format("Cursor scale: %.1f x %.1f", fracToDouble(cursorTargetScaleX), fracToDouble(cursorTargetScaleY));
 
 		Common::Rect estimatedCursorRect;
 
 		if (!gfxScalarMode.equals("")) {
 
-			if (gfxScalarMode.contains("1x")) {
-				estimatedCursorRect = computeSize(cursorRect, 1, cursorTargetScale);
-			} else if (gfxScalarMode.contains("2x")) {
-				estimatedCursorRect = computeSize(cursorRect, 2, cursorTargetScale);
-			} else if (gfxScalarMode.contains("3x")) {
-				estimatedCursorRect = computeSize(cursorRect, 3, cursorTargetScale);
-			} else {
-				// If unable to detect scaler, default to 2
-				Testsuite::writeOnScreen("Unable to detect scaling factor, assuming 2x", Common::Point(0, 5));
-				estimatedCursorRect = computeSize(cursorRect, 2, cursorTargetScale);
-			}
+			estimatedCursorRect = computeSize(cursorRect, cursorTargetScaleX, cursorTargetScaleY);
 			Testsuite::writeOnScreen(info, Common::Point(0, 120));
 
 			// Move cursor to (20, 20)
@@ -762,7 +732,7 @@ TestExitStatus GFXtests::alphaCursors() {
 		};
 
 		Graphics::PixelFormat format(4, 8, 8, 8, 8, 24, 16, 8, 0);
-		CursorMan.replaceCursor(cursorData, 7, 7, 3, 3, 0, false, &format);
+		CursorMan.replaceCursor(cursorData, 7, 7, 3, 3, 0, &format);
 		CursorMan.showMouse(true);
 
 		bool waitingForClick = true;
@@ -920,7 +890,7 @@ TestExitStatus GFXtests::maskedCursors() {
 		if (haveCursorPalettes)
 			CursorMan.replaceCursorPalette(newPalette, 0, 4);
 
-		CursorMan.replaceCursor(cursorData, 16, 16, 1, 1, 0, false, nullptr, maskData);
+		CursorMan.replaceCursor(cursorData, 16, 16, 1, 1, 0, nullptr, maskData);
 		CursorMan.showMouse(true);
 
 		bool waitingForClick = true;
@@ -976,7 +946,7 @@ TestExitStatus GFXtests::maskedCursors() {
 					rgbaCursorData[i] = rgbaFormat.ARGBToColor(255, r, g, b);
 				}
 
-				CursorMan.replaceCursor(rgbaCursorData, 16, 16, 1, 1, 0, false, &rgbaFormat, maskData);
+				CursorMan.replaceCursor(rgbaCursorData, 16, 16, 1, 1, 0, &rgbaFormat, maskData);
 
 				waitingForClick = true;
 				while (waitingForClick) {
@@ -1192,7 +1162,7 @@ TestExitStatus GFXtests::scaledCursors() {
 	Common::String info = "Testing : Scaled cursors\n"
 		"Here every graphics mode is tried with a cursorTargetScale of 1, 2 and 3.\n"
 		"The expected cursor size is drawn as a rectangle.\n The cursor should approximately match that rectangle.\n"
-		"This may take time, You may skip the later scalers and just examine the first three i.e 1x, 2x and 3x";
+		"This may take time, You may skip the later scalers and just examine the first four i.e 0.5x, 1x, 2x and 3x";
 
 	bool isAspectRatioCorrected = g_system->getFeatureState(OSystem::kFeatureAspectRatioCorrection);
 
@@ -1206,7 +1176,7 @@ TestExitStatus GFXtests::scaledCursors() {
 	}
 
 	int maxLimit = 1000;
-	if (!Testsuite::handleInteractiveInput("Do You want to restrict scalers to 1x, 2x and 3x only?", "Yes", "No", kOptionRight)) {
+	if (!Testsuite::handleInteractiveInput("Do You want to restrict scalers to 0.5x, 1x, 2x and 3x only?", "Yes", "No", kOptionRight)) {
 		maxLimit = 3;
 	}
 
@@ -1246,13 +1216,19 @@ TestExitStatus GFXtests::scaledCursors() {
 		OSystem::TransactionError gfxError = g_system->endGFXTransaction();
 
 		if (gfxError == OSystem::kTransactionSuccess && isGFXModeSet) {
-			setupMouseLoop(false, gfxMode->name, 1);
+			setupMouseLoop(false, gfxMode->name, FRAC_HALF, FRAC_HALF);
 			Testsuite::clearScreen();
 
-			setupMouseLoop(false, gfxMode->name, 2);
+			setupMouseLoop(false, gfxMode->name, FRAC_ONE, FRAC_ONE);
 			Testsuite::clearScreen();
 
-			setupMouseLoop(false, gfxMode->name, 3);
+			setupMouseLoop(false, gfxMode->name, FRAC_ONE, FRAC_ONE * 2);
+			Testsuite::clearScreen();
+
+			setupMouseLoop(false, gfxMode->name, FRAC_ONE * 2, FRAC_ONE);
+			Testsuite::clearScreen();
+
+			setupMouseLoop(false, gfxMode->name, FRAC_ONE * 2, FRAC_ONE * 2);
 			Testsuite::clearScreen();
 		} else {
 			Testsuite::logDetailedPrintf("Switching to graphics mode %s failed\n", gfxMode->name);

--- a/engines/testbed/graphics.h
+++ b/engines/testbed/graphics.h
@@ -30,12 +30,12 @@ namespace GFXtests {
 
 // Helper functions for GFX tests
 void drawEllipse(int x, int y, int a, int b);
-void setupMouseLoop(bool disableCursorPalette = false, const char *gfxModeName = "", int cursorTargetScale = 1);
+void setupMouseLoop(bool disableCursorPalette = false, const char *gfxModeName = "", frac_t cursorTargetScaleX = FRAC_ONE, frac_t cursorTargetScaleY = FRAC_ONE);
 void initMousePalette();
 void initMouseCursor();
-Common::Rect computeSize(const Common::Rect &cursorRect, int scalingFactor, int cursorTargetScale);
+Common::Rect computeSize(const Common::Rect &cursorRect, frac_t cursorTargetScaleX, frac_t cursorTargetScaleY);
 void HSVtoRGB(int &rComp, int &gComp, int &bComp, int hue, int sat, int val);
-Common::Rect drawCursor(bool cursorPaletteDisabled = false, int cursorTargetScale = 1);
+Common::Rect drawCursor(bool cursorPaletteDisabled, frac_t cursorTargetScaleX, frac_t cursorTargetScaleY);
 TestExitStatus pixelFormats(Common::List<Graphics::PixelFormat> &pfList);
 void showPixelFormat(const Graphics::PixelFormat &pf, uint aLoss);
 

--- a/engines/titanic/support/mouse_cursor.cpp
+++ b/engines/titanic/support/mouse_cursor.cpp
@@ -151,7 +151,7 @@ void CMouseCursor::setCursor(CursorId cursorId) {
 		_cursorId = cursorId;
 
 		// Set the cursor
-		CursorMan.replaceCursor(*ce._surface, ce._centroid.x, ce._centroid.y, 0, false);
+		CursorMan.replaceCursor(*ce._surface, ce._centroid.x, ce._centroid.y, 0);
 	}
 }
 

--- a/engines/tony/game.cpp
+++ b/engines/tony/game.cpp
@@ -1572,7 +1572,7 @@ void RMPointer::updateCursor() {
 
 	// Get the raw pixel data and set the cursor to it
 	Graphics::PixelFormat pixelFormat(2, 5, 6, 5, 0, 11, 5, 0, 0);
-	CursorMan.replaceCursor(cursorData, 64, 64, _cursorHotspot._x, _cursorHotspot._y, 0, false, &pixelFormat);
+	CursorMan.replaceCursor(cursorData, 64, 64, _cursorHotspot._x, _cursorHotspot._y, 0, &pixelFormat);
 }
 
 /**

--- a/engines/trecision/graphics.cpp
+++ b/engines/trecision/graphics.cpp
@@ -736,7 +736,7 @@ void GraphicsManager::initCursor() {
 		cursor[cx + cw * i] = cursorColor; // vertical
 	}
 
-	CursorMan.pushCursor(cursor, cw, ch, cx, cy, 0, false, &_screenFormat);
+	CursorMan.pushCursor(cursor, cw, ch, cx, cy, 0, &_screenFormat);
 }
 
 void GraphicsManager::showCursor() {

--- a/engines/ultima/ultima4/gfx/screen.cpp
+++ b/engines/ultima/ultima4/gfx/screen.cpp
@@ -157,7 +157,7 @@ void Screen::loadMouseCursors() {
 		// Set the default initial cursor
 		const uint TRANSPARENT = format.RGBToColor(0x80, 0x80, 0x80);
 		MouseCursorSurface *c = _mouseCursors[MC_DEFAULT];
-		CursorMan.pushCursor(*c, c->_hotspot.x, c->_hotspot.y, TRANSPARENT, false);
+		CursorMan.pushCursor(*c, c->_hotspot.x, c->_hotspot.y, TRANSPARENT);
 		CursorMan.showMouse(true);
 
 	} else {
@@ -176,7 +176,7 @@ void Screen::setMouseCursor(MouseCursor cursor) {
 		_currentMouseCursor = cursor;
 
 		const uint TRANSPARENT = format.RGBToColor(0x80, 0x80, 0x80);
-		CursorMan.replaceCursor(*c, c->_hotspot.x, c->_hotspot.y, TRANSPARENT, false);
+		CursorMan.replaceCursor(*c, c->_hotspot.x, c->_hotspot.y, TRANSPARENT);
 	}
 }
 

--- a/engines/zvision/graphics/cursors/cursor_manager.cpp
+++ b/engines/zvision/graphics/cursors/cursor_manager.cpp
@@ -106,7 +106,7 @@ void CursorManager::initialize() {
 }
 
 void CursorManager::changeCursor(const ZorkCursor &cursor) {
-	CursorMan.replaceCursor(cursor.getSurface(), cursor.getWidth(), cursor.getHeight(), cursor.getHotspotX(), cursor.getHotspotY(), cursor.getKeyColor(), false, &_pixelFormat);
+	CursorMan.replaceCursor(cursor.getSurface(), cursor.getWidth(), cursor.getHeight(), cursor.getHotspotX(), cursor.getHotspotY(), cursor.getKeyColor(), &_pixelFormat);
 }
 
 void CursorManager::cursorDown(bool pushed) {

--- a/graphics/cursorman.cpp
+++ b/graphics/cursorman.cpp
@@ -117,7 +117,7 @@ bool CursorManager::systemSupportsCursorMask(const byte *mask, uint width, uint 
 	return true;
 }
 
-void CursorManager::pushCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
+void CursorManager::pushCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) {
 	PixelFormat pixelFormat;
 	if (format)
 		pixelFormat = *format;
@@ -128,19 +128,19 @@ void CursorManager::pushCursor(const void *buf, uint w, uint h, int hotspotX, in
 	// we won't touch 'buf' ...
 	surf.init(w, h, w * pixelFormat.bytesPerPixel, const_cast<void *>(buf), pixelFormat);
 
-	pushCursor(surf, hotspotX, hotspotY, keycolor, dontScale, mask);
+	pushCursor(surf, hotspotX, hotspotY, keycolor, mask, scaleX, scaleY);
 }
 
-void CursorManager::pushCursor(const Surface &surf, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const byte *mask) {
+void CursorManager::pushCursor(const Surface &surf, int hotspotX, int hotspotY, uint32 keycolor, const byte *mask, frac_t scaleX, frac_t scaleY) {
 	if (!systemSupportsCursorMask(mask, surf.w, surf.h))
 		mask = nullptr;
 
-	Cursor *cur = new Cursor(surf, hotspotX, hotspotY, keycolor, dontScale, mask);
+	Cursor *cur = new Cursor(surf, hotspotX, hotspotY, keycolor, mask, scaleX, scaleY);
 
 	cur->_visible = isVisible();
 	_cursorStack.push(cur);
 
-	g_system->setMouseCursor(cur->_surf.getPixels(), cur->_surf.w, cur->_surf.h, hotspotX, hotspotY, keycolor, dontScale, &cur->_surf.format, mask);
+	g_system->setMouseCursor(cur->_surf.getPixels(), cur->_surf.w, cur->_surf.h, hotspotX, hotspotY, keycolor, &cur->_surf.format, mask, scaleX, scaleY);
 }
 
 void CursorManager::popCursor() {
@@ -152,9 +152,9 @@ void CursorManager::popCursor() {
 
 	if (!_cursorStack.empty()) {
 		cur = _cursorStack.top();
-		g_system->setMouseCursor(cur->_surf.getPixels(), cur->_surf.w, cur->_surf.h, cur->_hotspotX, cur->_hotspotY, cur->_keycolor, cur->_dontScale, &cur->_surf.format, cur->_mask);
+		g_system->setMouseCursor(cur->_surf.getPixels(), cur->_surf.w, cur->_surf.h, cur->_hotspotX, cur->_hotspotY, cur->_keycolor, &cur->_surf.format, cur->_mask, cur->_scaleX, cur->_scaleY);
 	} else {
-		g_system->setMouseCursor(nullptr, 0, 0, 0, 0, 0);
+		g_system->setMouseCursor(nullptr, 0, 0, 0, 0, 0, nullptr, nullptr, 0, 0);
 	}
 
 	g_system->showMouse(isVisible());
@@ -174,11 +174,11 @@ void CursorManager::popAllCursors() {
 		}
 	}
 
-	g_system->setMouseCursor(nullptr, 0, 0, 0, 0, 0);
+	g_system->setMouseCursor(nullptr, 0, 0, 0, 0, 0, nullptr, nullptr, 0, 0);
 	g_system->showMouse(isVisible());
 }
 
-void CursorManager::replaceCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const Graphics::PixelFormat *format, const byte *mask) {
+void CursorManager::replaceCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format, const byte *mask, frac_t scaleX, frac_t scaleY) {
 	PixelFormat pixelFormat;
 	if (format)
 		pixelFormat = *format;
@@ -189,15 +189,15 @@ void CursorManager::replaceCursor(const void *buf, uint w, uint h, int hotspotX,
 	// we won't touch 'buf' ...
 	surf.init(w, h, w * pixelFormat.bytesPerPixel, const_cast<void *>(buf), pixelFormat);
 
-	replaceCursor(surf, hotspotX, hotspotY, keycolor, dontScale, mask);
+	replaceCursor(surf, hotspotX, hotspotY, keycolor, mask, scaleX, scaleY);
 }
 
-void CursorManager::replaceCursor(const Surface &surf, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const byte *mask) {
+void CursorManager::replaceCursor(const Surface &surf, int hotspotX, int hotspotY, uint32 keycolor, const byte *mask, frac_t scaleX, frac_t scaleY) {
 	if (!systemSupportsCursorMask(mask, surf.w, surf.h))
 		mask = nullptr;
 
 	if (_cursorStack.empty()) {
-		pushCursor(surf, hotspotX, hotspotY, keycolor, dontScale, mask);
+		pushCursor(surf, hotspotX, hotspotY, keycolor, mask, scaleX, scaleY);
 		return;
 	}
 
@@ -233,14 +233,15 @@ void CursorManager::replaceCursor(const Surface &surf, int hotspotX, int hotspot
 	cur->_hotspotX = hotspotX;
 	cur->_hotspotY = hotspotY;
 	cur->_keycolor = keycolor;
-	cur->_dontScale = dontScale;
+	cur->_scaleX = scaleX;
+	cur->_scaleY = scaleY;
 
-	g_system->setMouseCursor(cur->_surf.getPixels(), surf.w, surf.h, hotspotX, hotspotY, keycolor, dontScale, &cur->_surf.format, mask);
+	g_system->setMouseCursor(cur->_surf.getPixels(), surf.w, surf.h, hotspotX, hotspotY, keycolor, &cur->_surf.format, mask, scaleX, scaleY);
 }
 
-void CursorManager::replaceCursor(const Graphics::Cursor *cursor, bool dontScale) {
+void CursorManager::replaceCursor(const Graphics::Cursor *cursor, frac_t scaleX, frac_t scaleY) {
 	replaceCursor(cursor->getSurface(), cursor->getWidth(), cursor->getHeight(), cursor->getHotspotX(),
-				  cursor->getHotspotY(), cursor->getKeyColor(), dontScale, nullptr, cursor->getMask());
+				  cursor->getHotspotY(), cursor->getKeyColor(), nullptr, cursor->getMask(), scaleX, scaleY);
 
 	if (cursor->getPalette())
 		replaceCursorPalette(cursor->getPalette(), cursor->getPaletteStartIndex(), cursor->getPaletteCount());
@@ -338,14 +339,14 @@ void CursorManager::setDefaultArrowCursor(bool push) {
 
 	if (push) {
 		pushCursorPalette(CURSOR_PALETTE, 0, ARRAYSIZE(CURSOR_PALETTE) / 3);
-		pushCursor(ARROW_CURSOR, CURSOR_W, CURSOR_H, 0, 0, 0, false, &format);
+		pushCursor(ARROW_CURSOR, CURSOR_W, CURSOR_H, 0, 0, 0, &format);
 	} else {
 		replaceCursorPalette(CURSOR_PALETTE, 0, ARRAYSIZE(CURSOR_PALETTE) / 3);
-		replaceCursor(ARROW_CURSOR, CURSOR_W, CURSOR_H, 0, 0, 0, false, &format);
+		replaceCursor(ARROW_CURSOR, CURSOR_W, CURSOR_H, 0, 0, 0, &format);
 	}
 }
 
-CursorManager::Cursor::Cursor(const Surface &surf, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const byte *mask) {
+CursorManager::Cursor::Cursor(const Surface &surf, int hotspotX, int hotspotY, uint32 keycolor, const byte *mask, frac_t scaleX, frac_t scaleY) {
 	const uint32 keycolor_mask = (((uint32) -1) >> (sizeof(uint32) * 8 - surf.format.bytesPerPixel * 8));
 	_keycolor = keycolor & keycolor_mask;
 	_size = surf.w * surf.h * surf.format.bytesPerPixel;
@@ -364,7 +365,8 @@ CursorManager::Cursor::Cursor(const Surface &surf, int hotspotX, int hotspotY, u
 
 	_hotspotX = hotspotX;
 	_hotspotY = hotspotY;
-	_dontScale = dontScale;
+	_scaleX = scaleX;
+	_scaleY = scaleY;
 	_visible = false;
 }
 

--- a/graphics/cursorman.h
+++ b/graphics/cursorman.h
@@ -25,6 +25,7 @@
 #include "common/scummsys.h"
 #include "common/stack.h"
 #include "common/singleton.h"
+#include "common/frac.h"
 #include "graphics/cursor.h"
 #include "graphics/surface.h"
 
@@ -75,17 +76,19 @@ public:
 	 * @param keycolor	Color value for the transparent color. This cannot exceed
 	 *                  the maximum color value as defined by format.
 	 *                  Does nothing if mask is set.
-	 * @param dontScale	Whether the cursor should never be scaled. An exception are high PPI displays, where the cursor
-	 *                  would be too small to notice otherwise. These are allowed to scale the cursor anyway.
 	 * @param format	Pointer to the pixel format that the cursor graphic uses.
 	 *					CLUT8 will be used if this is null or not specified.
 	 * @param mask      Optional pointer to cursor mask containing values from the CursorMaskValue enum.
+	 * @param scaleX    Horizontal scaling factor for the cursor relative to the
+	 *                  game screen scale. A value of 0 means that the cursor should not be scaled.
+	 * @param scaleY    Vertical scaling factor for the cursor relative to the
+	 *                  game screen scale. A value of 0 means that the cursor should not be scaled.
 	 *
 	 * @note It is acceptable for the buffer to be a null pointer. It is sometimes
 	 *       useful to push a "dummy" cursor and modify it later. The
 	 *       cursor will be added to the stack, but not to the backend.
 	 */
-	void pushCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = NULL, const byte *mask = nullptr);
+	void pushCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format = NULL, const byte *mask = nullptr, frac_t scaleX = FRAC_ONE, frac_t scaleY = FRAC_ONE);
 
 	/**
 	 * Push a new cursor onto the stack, and set it in the backend.
@@ -99,15 +102,17 @@ public:
 	 * @param keycolor	Color value for the transparent color. This cannot exceed
 	 *                  the maximum color value as defined by format.
 	 *                  Does nothing if mask is set.
-	 * @param dontScale	Whether the cursor should never be scaled. An exception are high PPI displays, where the cursor
-	 *                  would be too small to notice otherwise. These are allowed to scale the cursor anyway.
 	 * @param mask      Optional pointer to cursor mask containing values from the CursorMaskValue enum.
+	 * @param scaleX    Horizontal scaling factor for the cursor relative to the
+	 *                  game screen scale. A value of 0 means that the cursor should not be scaled.
+	 * @param scaleY    Vertical scaling factor for the cursor relative to the
+	 *                  game screen scale. A value of 0 means that the cursor should not be scaled.
 	 *
 	 * @note It is acceptable for the surface to be empty. It is sometimes
 	 *       useful to push a "dummy" cursor and modify it later. The
 	 *       cursor will be added to the stack, but not to the backend.
 	 */
-	void pushCursor(const Surface &surf, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const byte *mask = nullptr);
+	void pushCursor(const Surface &surf, int hotspotX, int hotspotY, uint32 keycolor, const byte *mask = nullptr, frac_t scaleX = FRAC_ONE, frac_t scaleY = FRAC_ONE);
 
 	/**
 	 * Pop a cursor from the stack, and restore the previous one to the
@@ -132,13 +137,15 @@ public:
 	 * @param keycolor	Color value for the transparent color. This cannot exceed
 	 *                  the maximum color value as defined by format.
 	 *                  Does nothing if mask is set.
-	 * @param dontScale	Whether the cursor should never be scaled. An exception are high PPI displays, where the cursor
-	 *                  would be too small to notice otherwise. These are allowed to scale the cursor anyway.
 	 * @param format	Pointer to the pixel format that the cursor graphic uses,
 	 *					CLUT8 will be used if this is null or not specified.
 	 * @param mask      Optional pointer to cursor mask containing values from the CursorMaskValue enum.
+	 * @param scaleX    Horizontal scaling factor for the cursor relative to the
+	 *                  game screen scale. A value of 0 means that the cursor should not be scaled.
+	 * @param scaleY    Vertical scaling factor for the cursor relative to the
+	 *                  game screen scale. A value of 0 means that the cursor should not be scaled.
 	 */
-	void replaceCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const Graphics::PixelFormat *format = nullptr, const byte *mask = nullptr);
+	void replaceCursor(const void *buf, uint w, uint h, int hotspotX, int hotspotY, uint32 keycolor, const Graphics::PixelFormat *format = nullptr, const byte *mask = nullptr, frac_t scaleX = FRAC_ONE, frac_t scaleY = FRAC_ONE);
 
 	/**
 	 * Replace the current cursor on the stack.
@@ -153,11 +160,13 @@ public:
 	 * @param keycolor	Color value for the transparent color. This cannot exceed
 	 *                  the maximum color value as defined by format.
 	 *                  Does nothing if mask is set.
-	 * @param dontScale	Whether the cursor should never be scaled. An exception are high PPI displays, where the cursor
-	 *                  would be too small to notice otherwise. These are allowed to scale the cursor anyway.
 	 * @param mask      Optional pointer to cursor mask containing values from the CursorMaskValue enum.
+	 * @param scaleX    Horizontal scaling factor for the cursor relative to the
+	 *                  game screen scale. A value of 0 means that the cursor should not be scaled.
+	 * @param scaleY    Vertical scaling factor for the cursor relative to the
+	 *                  game screen scale. A value of 0 means that the cursor should not be scaled.
 	 */
-	void replaceCursor(const Surface &surf, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale = false, const byte *mask = nullptr);
+	void replaceCursor(const Surface &surf, int hotspotX, int hotspotY, uint32 keycolor, const byte *mask = nullptr, frac_t scaleX = FRAC_ONE, frac_t scaleY = FRAC_ONE);
 
 	/**
 	 * Replace the current cursor on the stack.
@@ -166,10 +175,12 @@ public:
 	 * more optimized way of popping the old cursor before pushing the new one.
 	 *
 	 * @param cursor	New cursor.
-	 * @param dontScale	Whether the cursor should never be scaled. An exception are high PPI displays, where the cursor
-	 *                  would be too small to notice otherwise. These are allowed to scale the cursor anyway.
+	 * @param scaleX    Horizontal scaling factor for the cursor relative to the
+	 *                  game screen scale. A value of 0 means that the cursor should not be scaled.
+	 * @param scaleY    Vertical scaling factor for the cursor relative to the
+	 *                  game screen scale. A value of 0 means that the cursor should not be scaled.
 	 */
-	void replaceCursor(const Graphics::Cursor *cursor, bool dontScale = false);
+	void replaceCursor(const Graphics::Cursor *cursor, frac_t scaleX = FRAC_ONE, frac_t scaleY = FRAC_ONE);
 
 	/**
 	 * Pop all cursors and cursor palettes from their respective stacks.
@@ -275,14 +286,15 @@ private:
 		int _hotspotX;
 		int _hotspotY;
 		uint32 _keycolor;
-		bool _dontScale;
+		frac_t _scaleX;
+		frac_t _scaleY;
 
 		uint _size;
 
 		// _surf set to default by Graphics::Surface default constructor
-		Cursor() : _mask(0), _visible(false), _hotspotX(0), _hotspotY(0), _keycolor(0), _dontScale(false), _size(0) {}
+		Cursor() : _mask(0), _visible(false), _hotspotX(0), _hotspotY(0), _keycolor(0), _scaleX(FRAC_ONE), _scaleY(FRAC_ONE), _size(0) {}
 
-		Cursor(const Surface &surf, int hotspotX, int hotspotY, uint32 keycolor, bool dontScale, const byte *mask);
+		Cursor(const Surface &surf, int hotspotX, int hotspotY, uint32 keycolor, const byte *mask, frac_t scaleX, frac_t scaleY);
 		~Cursor();
 	};
 

--- a/graphics/macgui/macwindowmanager.cpp
+++ b/graphics/macgui/macwindowmanager.cpp
@@ -1311,7 +1311,7 @@ void MacWindowManager::pushCursor(MacCursorType type, Cursor *cursor) {
 		break;
 	case kMacCursorBeam:
 		if (g_system->getFeatureState(OSystem::kFeatureCursorMaskInvert))
-			CursorMan.replaceCursor(macCursorBeam, 11, 16, 3, 8, 3, false, NULL, macCursorBeamMask);
+			CursorMan.replaceCursor(macCursorBeam, 11, 16, 3, 8, 3, NULL, macCursorBeamMask);
 		else
 			CursorMan.replaceCursor(macCursorBeam, 11, 16, 3, 8, 3);
 		CursorMan.pushCursorPalette(cursorPalette, 0, 2);
@@ -1352,7 +1352,7 @@ void MacWindowManager::replaceCursor(MacCursorType type, Cursor *cursor) {
 		break;
 	case kMacCursorBeam:
 		if (g_system->getFeatureState(OSystem::kFeatureCursorMaskInvert))
-			CursorMan.replaceCursor(macCursorBeam, 11, 16, 3, 8, 3, false, NULL, macCursorBeamMask);
+			CursorMan.replaceCursor(macCursorBeam, 11, 16, 3, 8, 3, NULL, macCursorBeamMask);
 		else
 			CursorMan.replaceCursor(macCursorBeam, 11, 16, 3, 8, 3);
 		CursorMan.replaceCursorPalette(cursorPalette, 0, 2);

--- a/graphics/mfc/gfx/cursor.cpp
+++ b/graphics/mfc/gfx/cursor.cpp
@@ -171,7 +171,7 @@ void Cursor::showCursor() {
 		CursorMan.replaceCursor(cursor);
 	} else {
 		CursorMan.replaceCursor(_surface.getPixels(),
-			_surface.w, _surface.h, 0, 0, 0, false, &format);
+			_surface.w, _surface.h, 0, 0, 0, &format);
 	}
 
 	CursorMan.showMouse(true);

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -389,7 +389,7 @@ void ThemeEngine::refresh() {
 				CursorMan.replaceCursorPalette(pal->data(), 0, pal->size());
 			}
 			CursorMan.replaceCursor(cur.surface->rawSurface(), cur.hotspotX, cur.hotspotY,
-			                        cur.surface->getTransparentColor(), true);
+			                        cur.surface->getTransparentColor(), nullptr, 0, 0);
 		}
 	}
 }
@@ -1688,7 +1688,7 @@ void ThemeEngine::setActiveCursor(CursorType type) {
             CursorMan.replaceCursorPalette(pal->data(), 0, pal->size());
         }
         CursorMan.replaceCursor(cur.surface->rawSurface(), cur.hotspotX, cur.hotspotY,
-                                cur.surface->getTransparentColor(), true);
+                                cur.surface->getTransparentColor(), nullptr, 0, 0);
     }
 }
 
@@ -2263,7 +2263,7 @@ void ThemeEngine::showCursor() {
     }
 
     CursorMan.pushCursor(cur.surface->rawSurface(), cur.hotspotX, cur.hotspotY,
-                         cur.surface->getTransparentColor(), true);
+                         cur.surface->getTransparentColor(), nullptr, 0, 0);
     CursorMan.showMouse(true);
 }
 


### PR DESCRIPTION
Some engines (namely SCUMM and MADE) require the cursor to be at a smaller scale than the game screen, however the `dontScale` parameter doesn't account for the DPI factor, resulting in game cursors being tiny when it's used. This PR resolves that by replacing it with fixed point scale factors (with separate X and Y factors for use with RISC OS cursors) that are taken into account when rendering.

| Before | After |
|--------|-------|
|  <img width="2560" height="1714" alt="scummvm-puttmoon-win-00001" src="https://github.com/user-attachments/assets/2a0ef60d-18ac-4b59-a70a-f622bed76a68" /> | <img width="2560" height="1714" alt="scummvm-puttmoon-win-00000" src="https://github.com/user-attachments/assets/15dbf540-2822-4d4a-9976-8c182e2caf35" /> |

The LibRetro changes have not been tested. Not all backends implement cursor scaling yet, but should continue to behave the same as before.

I'm also not able to test the changes to the MADE engine - @greg-kennedy, are you able to confirm that the changes from PR #6935 still work as expected with this PR?