### PR TITLE
DISTS: Update Sparkle manifest to fix WinSparkle release notes

### DIFF
--- a/dists/macosx/scummvm_appcast.xml
+++ b/dists/macosx/scummvm_appcast.xml
@@ -8,7 +8,7 @@
 		<item>
 			<title>Version 2026.2.0</title>
 			<sparkle:releaseNotesLink>
-				https://www.scummvm.org/frs/scummvm/2026.2.0/ReleaseNotes.html
+				https://downloads.scummvm.org/frs/scummvm/2026.2.0/ReleaseNotes.html
 			</sparkle:releaseNotesLink>
 			<pubDate>Sat, 28 Mar 2026 18:00:00 +0000</pubDate>
 			<enclosure url="https://downloads.scummvm.org/frs/scummvm/2026.2.0/scummvm-2026.2.0-macosx.dmg"


### PR DESCRIPTION
WinSparkle is not displaying ScummVM's release notes in its dialog. Instead it leaves the Release Notes section blank and opens the ScummVM release notes URL in an external web browser, potentially stealing focus and interrupting the update experience.

To reproduce, download our [previous Windows release](https://downloads.scummvm.org/frs/scummvm/2026.1.0/scummvm-2026.1.0-win32.exe), install, and click Check Now.

This bug was introduced in ScummVM 2.9.1 when we upgraded WinSparkle from 0.6.0 (2018) to 0.9.0 (2025), but it didn't become apparent until our 2026.1.0 release.

I believe this is due to a collision between a 2023 WinSparkle change and our release notes URL returning a HTTP 302 redirect. I am hoping that switching to our underlying release notes URL will work around this, but I am not set up to test the latest WinSparkle code or the Mac Sparkle code. The new URL is also more consistent with the download URLs in the manifest.

In 2023, WinSparkle added code that detects when links are clicked in the Release Notes html so that it can open them in an external web browser. This was meant to prevent the links opening in the webview within the WinSparkle dialog: https://github.com/vslavik/winsparkle/commit/ec271892eaefd48edffd9ec2123fd9f9f09f5113

The WinSparkle code works by handling the `wxEVT_WEBVIEW_NAVIGATING` event, and I suspect that our HTTP 302 is triggering that event, which would explain the blank area from the initial HTTP request and the external browser launch.

It should be easy to test this before merging. We just need to patch https://www.scummvm.org/appcasts/macosx/release.xml on our server and see if the 2026.1.0 Windows release displays the update dialog correctly. If it works, then it should fix 2.9.1 as well.