### PR TITLE
NANCY: Add detection for Wii version of nancy16

### DIFF
--- a/engines/nancy/detection_tables.h
+++ b/engines/nancy/detection_tables.h
@@ -814,6 +814,17 @@ static const NancyGameDescription gameDescriptions[] = {
 		},
 		kGameTypeNancy16
 	},
+	{ // MD5 by eientei95
+		{
+			"nancy16", nullptr,
+			AD_ENTRY1s("ciftree.dat", "dcc8ab339061dbd855ff158548543dcc", 1257169),
+			Common::EN_ANY,
+			Common::kPlatformWii,
+			ADGF_UNSUPPORTED | ADGF_DROPPLATFORM,
+			NANCY8_GUIOPTIONS
+		},
+		kGameTypeNancy16
+	},
 	{ // MD5 by bluegr
 		{
 			"nancy17", nullptr,


### PR DESCRIPTION
Here's the contents of the `Common` folder, including ciftree.dat and the plaintext scripts/XML-based files
[Common.zip](https://github.com/user-attachments/files/27381845/Common.zip)