### PR TITLE
NANCY: Fix inventory check in early games

### DIFF
--- a/engines/nancy/action/actionmanager.cpp
+++ b/engines/nancy/action/actionmanager.cpp
@@ -338,12 +338,7 @@ void ActionManager::processDependency(DependencyRecord &dep, ActionRecord &recor
 			dep.satisfied = true;
 			break;
 		case DependencyType::kInventory:
-			if (dep.condition == g_nancy->_false) {
-				// Item not in possession or held
-				dep.satisfied = !NancySceneState.hasItem(dep.label);
-			} else {
-				dep.satisfied = NancySceneState.hasItem(dep.label);
-			}
+			dep.satisfied = NancySceneState.hasItem(dep.label) == dep.condition;
 
 			break;
 		case DependencyType::kEvent:


### PR DESCRIPTION
hasItem() returns Nancy engine's _true and _false, which might not be `true` and `false`.

Fix [16761](https://bugs.scummvm.org/ticket/16761)

**draft** because I want to more comprehensively check at least one of the newest games i.e. make sure i'm not merely moving the problem elsewhere; nancy1,2,3 ok


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
