### PR TITLE
COLONY: Use a more universally supported OpenGL texture format

### DIFF
--- a/engines/colony/animation.cpp
+++ b/engines/colony/animation.cpp
@@ -747,7 +747,7 @@ void ColonyEngine::drawAnimation() {
 
 	if (!_animPatternSurface) {
 		_animPatternSurface = new Graphics::Surface();
-		_animPatternSurface->create(416, 264, Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
+		_animPatternSurface->create(416, 264, _gfx->getPixelFormat());
 	}
 
 	if (keyChanged) {
@@ -863,7 +863,7 @@ void ColonyEngine::drawAnimationImage(Image *img, Image *mask, int x, int y, uin
 
 	// Pixels written into the alpha-keyed RGBA cache. mask=0 → alpha 0
 	// (transparent), so drawSurface's alpha-blend skips them naturally.
-	const Graphics::PixelFormat fmt(4, 8, 8, 8, 8, 24, 16, 8, 0);
+	const Graphics::PixelFormat fmt = _gfx->getPixelFormat();
 	const uint32 black = fmt.ARGBToColor(255, 0, 0, 0);
 	const uint32 white = fmt.ARGBToColor(255, 255, 255, 255);
 	const uint32 transparent = 0;

--- a/engines/colony/colony.cpp
+++ b/engines/colony/colony.cpp
@@ -588,7 +588,7 @@ void ColonyEngine::initMacMenus() {
 	}
 
 	// Create RGBA surface for the MacWindowManager to render into.
-	Graphics::PixelFormat rgba(4, 8, 8, 8, 8, 24, 16, 8, 0);
+	Graphics::PixelFormat rgba = _gfx->getPixelFormat();
 	_menuSurface = new Graphics::ManagedSurface(_width, _height, rgba);
 
 	_wm = new Graphics::MacWindowManager(Graphics::kWMModeNoDesktop | Graphics::kWMNoScummVMWallpaper | Graphics::kWMModeNoSystemRedraw, nullptr, Common::UNK_LANG, rgba);

--- a/engines/colony/renderer.h
+++ b/engines/colony/renderer.h
@@ -75,6 +75,7 @@ public:
 	// Overlay a RGBA software surface onto the GL framebuffer (for Mac menu bar).
 	virtual void drawSurface(const Graphics::Surface *surf, int x, int y) {}
 	virtual Graphics::Surface *getScreenshot() { return nullptr; }
+	virtual Graphics::PixelFormat getPixelFormat() = 0;
 
 	// Convenience color accessors
 	uint32 white() const { return 255; }

--- a/engines/colony/renderer_opengl.cpp
+++ b/engines/colony/renderer_opengl.cpp
@@ -96,6 +96,9 @@ public:
 	void computeScreenViewport() override;
 	void drawSurface(const Graphics::Surface *surf, int x, int y) override;
 	Graphics::Surface *getScreenshot() override;
+	Graphics::PixelFormat getPixelFormat() override {
+		return Graphics::PixelFormat::createFormatRGBA32();
+	}
 
 private:
 	void useColor(uint32 color);
@@ -747,11 +750,8 @@ void OpenGLRenderer::drawSurface(const Graphics::Surface *surf, int x, int y) {
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-	// The surface uses PixelFormat(4,8,8,8,8,24,16,8,0) = R at bit 24, A at bit 0.
-	// GL_UNSIGNED_INT_8_8_8_8 reads a uint32 and maps bits 24..31→R, 16..23→G,
-	// 8..15→B, 0..7→A, matching our pixel layout regardless of endianness.
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, surf->w, surf->h, 0,
-		GL_RGBA, GL_UNSIGNED_INT_8_8_8_8, surf->getPixels());
+		GL_RGBA, GL_UNSIGNED_BYTE, surf->getPixels());
 
 	// Draw textured quad covering the specified region
 	float dx = x * scaleX;

--- a/engines/colony/renderer_opengl_shaders.cpp
+++ b/engines/colony/renderer_opengl_shaders.cpp
@@ -86,6 +86,9 @@ public:
 
 	void drawSurface(const Graphics::Surface *surf, int x, int y) override;
 	Graphics::Surface *getScreenshot() override;
+	Graphics::PixelFormat getPixelFormat() override {
+		return Graphics::PixelFormat::createFormatRGBA32();
+	}
 
 private:
 	void resolveColor(uint32 color, float rgba[4]) const;
@@ -572,12 +575,8 @@ void OpenGLShaderRenderer::drawSurface(const Graphics::Surface *surf, int x, int
 	// Texture params are set once at construction; just bind here.
 	glBindTexture(GL_TEXTURE_2D, _bitmapTexture);
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
-	// The engine's surface format is PixelFormat(4,8,8,8,8,24,16,8,0) —
-	// R at bit 24, A at bit 0 — so GL_RGBA + GL_UNSIGNED_INT_8_8_8_8 reads
-	// each uint32 with the high byte mapping to R, matching the fixed-
-	// function path's drawSurface upload (renderer_opengl.cpp:725).
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, surf->w, surf->h, 0,
-		GL_RGBA, GL_UNSIGNED_INT_8_8_8_8, surf->getPixels());
+		GL_RGBA, GL_UNSIGNED_BYTE, surf->getPixels());
 
 	glEnable(GL_BLEND);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/engines/colony/ui.cpp
+++ b/engines/colony/ui.cpp
@@ -201,7 +201,7 @@ Graphics::Surface *ColonyEngine::loadPictSurface(int resID) {
 			}
 
 			result = new Graphics::Surface();
-			result->create(src->w, src->h, Graphics::PixelFormat(4, 8, 8, 8, 8, 24, 16, 8, 0));
+			result->create(src->w, src->h, _gfx->getPixelFormat());
 			for (int y = 0; y < src->h; y++) {
 				for (int x = 0; x < src->w; x++) {
 					byte r, g, b;


### PR DESCRIPTION
`GL_UNSIGNED_INT_8_8_8_8` is not supported by OpenGL ES, or by very early versions of desktop GL. Now that PR #7412 has been merged, `GL_UNSIGNED_BYTE` can be used instead.

This has not been tested.