### PR TITLE
CONFIGURE: MACOS: Fix TTS & SDK feature checks for Tiger/Leopard

### DIFF
--- a/configure
+++ b/configure
@@ -435,6 +435,18 @@ cc_check() {
 	return "$TMPR"
 }
 
+cc_objc_check() {
+	prevcxx=$CXX
+	# `-ObjC++` flag doesn't always exist; `-x` flag is more portable, but
+	# should appear before any input file.
+	CXX="$CXX -x objective-c++ -lobjc"
+	cc_check_no_clean "$@"
+	TMPR="$?"
+	cc_check_clean
+	CXX=$prevcxx
+	return "$TMPR"
+}
+
 cc_check_define() {
 cat > $TMPC << EOF
 int main(void) {
@@ -5441,7 +5453,7 @@ EOF
 @end
 int main(void) { return 0; }
 EOF
-				cc_check -ObjC++ -lobjc && _tts=yes
+				cc_objc_check && _tts=yes
 			else
 				# Check the newer AVSpeechSynthesizer API is available
 				cat > $TMPC << EOF
@@ -5451,7 +5463,7 @@ EOF
 @end
 int main(void) { return 0; }
 EOF
-				cc_check -ObjC++ -lobjc && _tts=yes
+				cc_objc_check && _tts=yes
 			fi
 			;;
 		iphoneos)
@@ -5462,7 +5474,7 @@ EOF
 @end
 int main(void) { return 0; }
 EOF
-			cc_check -ObjC++ -lobjc && _tts=yes
+			cc_objc_check && _tts=yes
 			;;
 		emscripten)
 			# Emscripten has the "Web Speech API" available
@@ -5996,7 +6008,7 @@ case $_host_os in
 #include <Sparkle/Sparkle.h>
 int main(void) { SPUStandardUpdaterController *updater = [[SPUStandardUpdaterController alloc] initWithUpdaterDelegate:nil userDriverDelegate:nil]; return 0; }
 EOF
-				cc_check $SPARKLE_CFLAGS $SPARKLE_LIBS -framework Sparkle -ObjC++ -lobjc && _sparkle=yes
+				cc_objc_check $SPARKLE_CFLAGS $SPARKLE_LIBS -framework Sparkle && _sparkle=yes
 			fi
 			if test "$_sparkle" = yes ; then
 				append_var LIBS "$SPARKLE_LIBS -framework Sparkle"
@@ -6315,8 +6327,9 @@ case $_host_os in
 @interface ScummVMDockTilePlugIn : NSObject <NSDockTilePlugIn> {
 }
 @end
+int main(void) { return 0; }
 EOF
-			cc_check -c -ObjC++ && _osxdockplugin=yes
+			cc_objc_check && _osxdockplugin=yes
 		fi
 		define_in_config_if_yes "$_osxdockplugin" 'USE_DOCKTILEPLUGIN'
 		echo "$_osxdockplugin"

--- a/configure
+++ b/configure
@@ -5447,11 +5447,19 @@ EOF
 			if test "$_osx_tts_backend" = "NSSpeechSynthesizer" ; then
 				# Check older NSSpeechSynthesizer API.
 				cat > $TMPC << EOF
+#include <AvailabilityMacros.h>
 #include <AppKit/NSSpeechSynthesizer.h>
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1050
+#error Not enough NSSpeechSynthesizerDelegate features available
+#endif
+#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060
+@interface SpeechDelegate : NSObject {
+#else
 @interface SpeechDelegate : NSObject<NSSpeechSynthesizerDelegate> {
+#endif
 }
 @end
-int main(void) { return 0; }
+int main(void) { return NSSpeechImmediateBoundary; }
 EOF
 				cc_objc_check && _tts=yes
 			else


### PR DESCRIPTION
## Context

On macOS, the Cocoa feature tests use the `-ObjC++` compiler flag (to force an Objective-C++ build test), but it's not portable:

* it exists in Clang,
* and in Apple's (old) versions of GCC,
* but it's _not_ in upstream GCC (e.g. through MacPorts.)

The latter is what the OSXPPC toolchain uses. So all Cocoa feature checks would fail there.

It wasn't much of a problem until now, because none of these feature were compatible with Tiger/Leopard anyway. But recently, I've made small changes to `macosx-text-to-speech.mm` to make it compatible with Leopard, so it's time to fix the uses of the `-ObjC++` flag.

## Change

Replacing `-ObjC++` with `-x objective-c++` is more portable, but this one needs to be put *at the start* of the compiler flag list, not at the end.

`cc_check` always does so, though. As I'd rather not cause any behavior change in it, I'm introducing `cc_objc_check` instead; it injects the flag at the right place, and is used *only* by the Cocoa tests.

The `NSSpeechImmediateBoundary` symbol is tested as well, because on Leopard you can't test `NSSpeechSynthesizerDelegate` (you just have `NSObject`, which is not relevant).

## End results

With this change, the TTS feature is now available when targeting Leopard (but not when targeting Tiger though, as it's missing many `NSSpeechSynthesizerDelegate` features we need.)