### PR TITLE
GUI: Add new engine GUI option for speech with optional subtitles

### DIFF
--- a/common/gui_options.cpp
+++ b/common/gui_options.cpp
@@ -44,6 +44,8 @@ const struct GameOpt {
 
 	{ GUIO_NOLANG,        "noLang"},
 
+	{ GUIO_SPEECHOPTSUBS, "sndSpeechWithOptSubs"},
+
 	{ GUIO_NOLAUNCHLOAD, "launchNoLoad" },
 
 	{ GUIO_MIDIPCSPK,    "midiPCSpk" },

--- a/common/gui_options.h
+++ b/common/gui_options.h
@@ -52,6 +52,11 @@
 #define GUIO_NOSPEECHVOLUME  "\x0a"
 
 #define GUIO_NOLANG          "\x0b"
+// GUIO_SPEECHOPTSUBS means speech cannot be toggled off
+// but subtitles are optional (can be toggled on/off),
+// so for "text and speech" the options should be "speech" or "both".
+#define GUIO_SPEECHOPTSUBS   "\x0c"
+
 
 // GUIO flags in range "\x80" - "\xbf" are reserved for prefixed lists of options
 

--- a/engines/myst3/detection.cpp
+++ b/engines/myst3/detection.cpp
@@ -247,7 +247,7 @@ static const Myst3GameDescription gameDescriptions[] = {
 class Myst3MetaEngineDetection : public AdvancedMetaEngineDetection<Myst3GameDescription> {
 public:
 	Myst3MetaEngineDetection() : AdvancedMetaEngineDetection(gameDescriptions, myst3Games) {
-		_guiOptions = GUIO5(GUIO_NOMIDI, GUIO_NOSFX, GUIO_NOSPEECH, GUIO_NOSUBTITLES, GAMEOPTION_WIDESCREEN_MOD);
+		_guiOptions = GUIO6(GUIO_NOMIDI, GUIO_NOSFX, GUIO_NOSPEECH, GUIO_NOSUBTITLES, GUIO_SPEECHOPTSUBS, GAMEOPTION_WIDESCREEN_MOD);
 		_maxScanDepth = 3;
 		_directoryGlobs = directoryGlobs;
 	}

--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -253,7 +253,8 @@ void OptionsDialog::init() {
 	_speechVolumeLabel = nullptr;
 	_muteCheckbox = nullptr;
 	_enableSubtitleSettings = false;
-	_enableSubtitleToggle = false;
+	_enableSubtitleThreeStateToggle = false;
+	_enableSubtitleOnOffWithSpeechToggle = false;
 	_subToggleDesc = nullptr;
 	_subToggleGroup = nullptr;
 	_subToggleSubOnly = nullptr;
@@ -1076,7 +1077,7 @@ void OptionsDialog::apply() {
 	// Subtitle options
 	if (_subToggleGroup) {
 		if (_enableSubtitleSettings) {
-			if (_enableSubtitleToggle) {
+			if (_enableSubtitleThreeStateToggle) {
 				bool subtitles, speech_mute;
 				switch (_subToggleGroup->getValue()) {
 				case kSubtitlesSpeech:
@@ -1097,6 +1098,15 @@ void OptionsDialog::apply() {
 					_subToggleDesc->setFontColor(ThemeEngine::FontColor::kFontColorNormal);
 				}
 				ConfMan.setBool("speech_mute", speech_mute, _domain);
+			} else if (_enableSubtitleOnOffWithSpeechToggle) {
+				bool subtitles = _subToggleGroup->getValue() != kSubtitlesSpeech;
+
+				if (subtitles != ConfMan.getBool("subtitles", _domain)) {
+					ConfMan.setBool("subtitles", subtitles, _domain);
+					_subToggleDesc->setFontColor(ThemeEngine::FontColor::kFontColorNormal);
+				}
+
+				ConfMan.removeKey("speech_mute", _domain);
 			} else if (!_domain.empty()) {
 				ConfMan.removeKey("subtitles", _domain);
 				_subToggleDesc->setFontColor(ThemeEngine::FontColor::kFontColorNormal);
@@ -1418,13 +1428,22 @@ void OptionsDialog::setSubtitleSettingsState(bool enabled) {
 	bool ena;
 	_enableSubtitleSettings = enabled;
 
-	ena = enabled;
-	if ((_guioptions.contains(GUIO_NOSUBTITLES)) || (_guioptions.contains(GUIO_NOSPEECH)))
-		ena = false;
+	if (_guioptions.contains(GUIO_SPEECHOPTSUBS)) {
+		_enableSubtitleOnOffWithSpeechToggle = enabled;
+		_subToggleGroup->setEnabled(enabled);
+		_subToggleSubOnly->setEnabled(false);
+		_subToggleSubOnly->setVisible(false);
+		_subToggleDesc->setEnabled(enabled);
+	} else {
+		ena = enabled;
+		if ((_guioptions.contains(GUIO_NOSUBTITLES)) || (_guioptions.contains(GUIO_NOSPEECH)))
+			ena = false;
 
-	_enableSubtitleToggle = ena;
-	_subToggleGroup->setEnabled(ena);
-	_subToggleDesc->setEnabled(ena);
+		_enableSubtitleThreeStateToggle = ena;
+
+		_subToggleGroup->setEnabled(ena);
+		_subToggleDesc->setEnabled(ena);
+	}
 
 	ena = enabled;
 	if (_guioptions.contains(GUIO_NOSUBTITLES))
@@ -1942,7 +1961,7 @@ void OptionsDialog::addSubtitleControls(GuiObject *boss, const Common::String &p
 	_subSpeedLabel->setFlags(WIDGET_CLEARBG);
 
 	_enableSubtitleSettings = true;
-	_enableSubtitleToggle = true;
+	_enableSubtitleThreeStateToggle = true;
 }
 
 void OptionsDialog::addVolumeControls(GuiObject *boss, const Common::String &prefix) {
@@ -2033,10 +2052,16 @@ void OptionsDialog::saveMusicDeviceSetting(PopUpWidget *popup, Common::String se
 }
 
 int OptionsDialog::getSubtitleMode(bool subtitles, bool speech_mute) {
-	if (_guioptions.contains(GUIO_NOSUBTITLES))
-		return kSubtitlesSpeech; // Speech only
-	if (_guioptions.contains(GUIO_NOSPEECH))
-		return kSubtitlesSubs; // Subtitles only
+	// Option GUIO_SPEECHOPTSUBS means speech cannot be turned off,
+	// but subtitles are optional (can be turned on and off).
+	if (!_guioptions.contains(GUIO_SPEECHOPTSUBS)) {
+		if (_guioptions.contains(GUIO_NOSUBTITLES))
+			return kSubtitlesSpeech; // Speech only
+		if (_guioptions.contains(GUIO_NOSPEECH))
+			return kSubtitlesSubs; // Subtitles only
+	} else {
+		speech_mute = false; // Speech cannot be muted
+	}
 
 	if (!subtitles && !speech_mute) // Speech only
 		return kSubtitlesSpeech;

--- a/gui/options.h
+++ b/gui/options.h
@@ -208,7 +208,8 @@ private:
 	//
 	int getSubtitleMode(bool subtitles, bool speech_mute);
 	bool _enableSubtitleSettings;
-	bool _enableSubtitleToggle;
+	bool _enableSubtitleThreeStateToggle;
+	bool _enableSubtitleOnOffWithSpeechToggle;
 	StaticTextWidget *_subToggleDesc;
 	RadiobuttonGroup *_subToggleGroup;
 	RadiobuttonWidget *_subToggleSubOnly;


### PR DESCRIPTION
The new option GUIO_SPEECHOPTSUBS replaces the three choices for Text and Speech with two

This is a proposed fix for #16720. In order for the fix to be complete, the myst3 engine also has to declare the new option in its detection.cpp, which will be done in a follow up separate commit.

Some engines with voiced dialogue and optional subtitles do not support disabling Speech, so they cannot have "text" only mode.
One such engine is Myst3 which also declares "GUIO_NOSPEECH" and "GUIO_NOSUBTITLES" because it doesn't want (most of) the options for speech or subtitles exposed to the ScummVM GUI. Yet, it does make use of the "subtitles" configuration key. Previously this key would be removed upon any change on the game domain options for Myst 3 due to code in OptionsDialog::apply() of gui/options.cpp. The new option can work on top of "GUIO_NOSPEECH" and "GUIO_NOSUBTITLES", exposing the two supported choices for Text and Speech (which would be Speech or Both) and allowing checking for and handling this special case in OptionsDialog::apply() instead of resulting to removing the "subtitles" key.

Intuitively, I think other engines might be in the same situation as Myst 3,, and thus could benefit from supporting this option, but I haven't checked for that as of yet. 

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
