### PR TITLE
MM: MM1: resolve global constructors

### DIFF
--- a/engines/mm/mm1/data/character.h
+++ b/engines/mm/mm1/data/character.h
@@ -603,6 +603,12 @@ struct Character : public PrimaryAttributes {
 	}
 };
 
+struct SuggestedName {
+	CharacterClass _class;
+	Sex _sex;
+	Common::String _name;
+};
+
 } // namespace MM1
 } // namespace MM
 

--- a/engines/mm/mm1/globals.cpp
+++ b/engines/mm/mm1/globals.cpp
@@ -40,6 +40,7 @@ Globals::Globals() {
 
 Globals::~Globals() {
 	delete _monsters;
+	delete _suggestedNames;
 	g_globals = nullptr;
 }
 

--- a/engines/mm/mm1/globals.h
+++ b/engines/mm/mm1/globals.h
@@ -60,6 +60,7 @@ public:
 	byte _delay = 5;
 	int _nonCombatEffectCtr = 0, _combatEffectCtr = 0;
 	bool _minimapOn = false;
+	Common::Array<SuggestedName> *_suggestedNames = nullptr;
 
 	// Console flags
 	bool _intangible = false;

--- a/engines/mm/mm1/views/title.cpp
+++ b/engines/mm/mm1/views/title.cpp
@@ -36,8 +36,8 @@ namespace Views {
 #define SCENE_SECONDS 5
 #define TEXT_SCENE_SECONDS 12
 
-static const Common::Rect START_GAME_BOUNDS(23, 164, 157, 173);
-static const Common::Rect SCENES_BOUNDS(162, 164, 292, 173);
+static constexpr Common::Rect START_GAME_BOUNDS(Common::Point(23, 164), 157 - 23, 173 - 164);
+static constexpr Common::Rect SCENES_BOUNDS(Common::Point(162, 164), 292 - 162, 173 - 164);
 
 Title::Title() : UIElement("Title", g_engine) {
 	_bounds = Common::Rect(0, 0, SCREEN_W, SCREEN_H);

--- a/engines/mm/mm1/views_enh/create_characters.cpp
+++ b/engines/mm/mm1/views_enh/create_characters.cpp
@@ -39,15 +39,6 @@ namespace ViewsEnh {
 #define NAME_CANCEL_X 51
 #define NAME_CONFIRM_Y 15
 
-struct SuggestedName {
-	CharacterClass _class;
-	Sex _sex;
-	Common::String _name;
-};
-
-static Common::Array<SuggestedName> g_suggestedNames;
-static bool g_suggestedNamesLoaded = false;
-
 static bool openSuggestedNamesFile(Common::File &f, Common::Path &filename) {
 	filename = Common::Path(NAMES_FILENAME);
 	if (f.open(filename))
@@ -67,21 +58,21 @@ static void addSuggestedName(CharacterClass classId, Sex sexId,
 	entry._class = classId;
 	entry._sex = sexId;
 	entry._name = name;
-	g_suggestedNames.push_back(entry);
+	g_globals->_suggestedNames->push_back(entry);
 }
 
 static void loadSuggestedNames() {
-	if (g_suggestedNamesLoaded)
+	if (g_globals->_suggestedNames)
 		return;
+
+	g_globals->_suggestedNames = new Common::Array<SuggestedName>();
 
 	Common::File f;
 	Common::Path filename;
 	if (!openSuggestedNamesFile(f, filename)) {
 		warning("MM1: Could not open suggested names file");
-		g_suggestedNamesLoaded = true;
 		return;
 	}
-	g_suggestedNamesLoaded = true;
 
 	int invalidLines = 0;
 	while (!f.eos()) {
@@ -733,20 +724,21 @@ void CreateCharacters::enterFunc(const Common::String &name) {
 
 Common::String CreateCharacters::getSuggestedName() {
 	loadSuggestedNames();
-	if (g_suggestedNames.empty()) {
+	const auto &suggestedNames = *g_globals->_suggestedNames;
+	if (suggestedNames.empty()) {
 		return "";
 	}
 
 	Common::Array<uint> matches;
-	for (uint i = 0; i < g_suggestedNames.size(); ++i) {
-		if (g_suggestedNames[i]._class == _newChar._class &&
-				g_suggestedNames[i]._sex == _newChar._sex)
+	for (uint i = 0; i < suggestedNames.size(); ++i) {
+		if (suggestedNames[i]._class == _newChar._class &&
+				suggestedNames[i]._sex == _newChar._sex)
 			matches.push_back(i);
 	}
 
 	if (matches.empty()) {
-		for (uint i = 0; i < g_suggestedNames.size(); ++i) {
-			if (g_suggestedNames[i]._class == _newChar._class)
+		for (uint i = 0; i < suggestedNames.size(); ++i) {
+			if (suggestedNames[i]._class == _newChar._class)
 				matches.push_back(i);
 		}
 	}
@@ -756,7 +748,7 @@ Common::String CreateCharacters::getSuggestedName() {
 	}
 
 	uint idx = matches.size() == 1 ? matches[0] : matches[g_engine->getRandomNumber(matches.size()) - 1];
-	return g_suggestedNames[idx]._name;
+	return suggestedNames[idx]._name;
 }
 
 void CreateCharacters::acceptName() {


### PR DESCRIPTION
Resolve some global constructors in MM1 introduced in PR #7482:

- `Common::Rect` constants are replaced with `constexpr` equivalents
- The list of suggested names for character creation is moved to `g_globals`