### PR TITLE
GUI: Fix ScrollContainerWidget clicks after scrolling

### DIFF
--- a/gui/widgets/scrollcontainer.cpp
+++ b/gui/widgets/scrollcontainer.cpp
@@ -65,8 +65,8 @@ void ScrollContainerWidget::handleMouseDown(int x, int y, int button, int clickC
 	_fluidScroller->stopAnimation();
 	Widget *child = _childUnderMouse;
 	if (child) {
-		int childX = (x + _scrolledX) - (child->getAbsX() - getAbsX());
-		int childY = (y + _scrolledY) - (child->getAbsY() - getAbsY());
+		int childX = x - (child->getAbsX() - getAbsX());
+		int childY = y - (child->getAbsY() - getAbsY());
 		child->handleMouseDown(childX, childY, button, clickCount);
 
 		if (child->getFlags() & WIDGET_IGNORE_DRAG) {
@@ -125,8 +125,8 @@ void ScrollContainerWidget::handleMouseUp(int x, int y, int button, int clickCou
 	_childUnderMouse = nullptr;
 
 	if (!isDragging && child) {
-		int childX = (x + _scrolledX) - (child->getAbsX() - getAbsX());
-		int childY = (y + _scrolledY) - (child->getAbsY() - getAbsY());
+		int childX = x - (child->getAbsX() - getAbsX());
+		int childY = y - (child->getAbsY() - getAbsY());
 		child->handleMouseUp(childX, childY, button, clickCount);
 	}
 }


### PR DESCRIPTION
ScrollContainerWidget already have child absolute positions with the current scroll offset applied through getChildX() and getChildY(). Do not add scroll offset again when converting mouse down/up events to child-local coordinates, as in other case after scroll in scrollable containers (like long keymapper lists) mouse click will fail.
