### PR TITLE
NANCY: Sync JournalData Entry sceneID

### DIFF
--- a/engines/nancy/puzzledata.cpp
+++ b/engines/nancy/puzzledata.cpp
@@ -149,6 +149,8 @@ void JournalData::synchronize(Common::Serializer &ser) {
 				entry.push_back(Entry());
 				ser.syncString(entry.back().stringID);
 				ser.syncAsUint16LE(entry.back().mark);
+				if (g_nancy->getGameType() >= kGameTypeNancy9)
+					ser.syncAsUint16LE(entry.back().sceneID);
 			}
 		}
 	} else {
@@ -160,6 +162,8 @@ void JournalData::synchronize(Common::Serializer &ser) {
 			for (uint i = 0; i < numStrings; ++i) {
 				ser.syncString(a._value[i].stringID);
 				ser.syncAsUint16LE(a._value[i].mark);
+				if (g_nancy->getGameType() >= kGameTypeNancy9)
+					ser.syncAsUint16LE(a._value[i].sceneID);
 			}
 		}
 	}


### PR DESCRIPTION
Fixup b2231ac3cdfbb59c8de9953dcd929c5666eb085d (Autotext with hotspots)

Fix [#16776](https://bugs.scummvm.org/ticket/16776): hotspot entries losing their hotspot on save+load, e.g. search items / URLs on laptop in nancy9.

This makes existing nancy9 testing saves incompatible. (They superficially appear to load fine but it is kind of like undefined behaviour, reading various garbage entries.) The game is in testing so this should be fine per [wiki Release_Testing](https://wiki.scummvm.org/index.php?title=Release_Testing). I am happy to replace saves on bug tickets I've opened so far.

Edit: Ugh, I've de-emphasized breaking saves, and wish I never emphasized it.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
