### PR TITLE
Update handling of SDL_MouseWheelEvent

### DIFF
--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -227,6 +227,18 @@ protected:
 	 */
 	Common::Event _fakeKeyUp;
 
+	/**
+	 * Whether and how many times _fakeMouseScroll contains an event we need to send .
+	 */
+	int _queuedFakeMouseScroll;
+
+	/**
+	 * A fake mouse scroll event sent when the graphics manager is told to warp
+	 * the mouse but the system mouse is unable to be warped (e.g. because the
+	 * window is not focused).
+	 */
+	Common::Event _fakeMouseScroll;
+
 	enum {
 		MAX_NUM_FINGERS = 3, // number of fingers to track per panel
 		MAX_TAP_TIME = 250, // taps longer than this will not result in mouse click events

--- a/backends/events/sdl/sdl2-events.cpp
+++ b/backends/events/sdl/sdl2-events.cpp
@@ -717,11 +717,16 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 	case SDL_MOUSEWHEEL: {
 		Sint32 yDir = ev.wheel.y;
 		// We want the mouse coordinates supplied with a mouse wheel event.
-		// However, SDL2 does not supply these, thus we use whatever we got
-		// last time.
+		// However, SDL2 only supplies these since v2.26.0. For older versions
+		// we use whatever we got last time.
+#if SDL_VERSION_ATLEAST(2, 26, 0)
+		if (!processMouseEvent(event, ev.wheel.mouseX, ev.wheel.mouseY)) {
+#else
 		if (!processMouseEvent(event, _mouseX, _mouseY)) {
+#endif
 			return false;
 		}
+
 		if (yDir < 0) {
 			event.type = Common::EVENT_WHEELDOWN;
 			return true;

--- a/backends/events/sdl/sdl2-events.cpp
+++ b/backends/events/sdl/sdl2-events.cpp
@@ -75,7 +75,7 @@ void SdlEventSource::loadGameControllerMappingFile() {
 SdlEventSource::SdlEventSource()
 	: EventSource(), _scrollLock(false), _joystick(nullptr), _lastScreenID(0), _graphicsManager(nullptr), _queuedFakeMouseMove(false),
 	  _lastHatPosition(SDL_HAT_CENTERED), _mouseX(0), _mouseY(0), _engineRunning(false)
-	  , _queuedFakeKeyUp(false), _fakeKeyUp(), _controller(nullptr)
+	  , _queuedFakeKeyUp(false), _fakeKeyUp(), _queuedFakeMouseScroll(0), _fakeMouseScroll(), _controller(nullptr)
 	  {
 	int joystick_num = ConfMan.getInt("joystick_num");
 	if (joystick_num >= 0) {
@@ -640,6 +640,13 @@ bool SdlEventSource::pollEvent(Common::Event &event) {
 		return true;
 	}
 
+	// In we still need to send scroll events for an event with a scroll amount > 1
+	if (_queuedFakeMouseScroll) {
+		event = _fakeMouseScroll;
+		--_queuedFakeMouseScroll;
+		return true;
+	}
+
 	// If the screen changed, send an Common::EVENT_SCREEN_CHANGED
 	int screenID = g_system->getScreenChangeID();
 	if (screenID != _lastScreenID) {
@@ -729,9 +736,13 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 
 		if (yDir < 0) {
 			event.type = Common::EVENT_WHEELDOWN;
+			_fakeMouseScroll = event;
+			_queuedFakeMouseScroll = -yDir - 1;
 			return true;
 		} else if (yDir > 0) {
 			event.type = Common::EVENT_WHEELUP;
+			_fakeMouseScroll = event;
+			_queuedFakeMouseScroll = yDir - 1;
 			return true;
 		} else {
 			return false;

--- a/backends/events/sdl/sdl3-events.cpp
+++ b/backends/events/sdl/sdl3-events.cpp
@@ -695,7 +695,13 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 		return handleMouseButtonUp(ev, event);
 
 	case SDL_EVENT_MOUSE_WHEEL: {
+#if SDL_VERSION_ATLEAST(3, 2, 12)
+		Sint32 yDir = ev.wheel.integer_y;
+#else
+		// We only have the precise y available. Ir would be better to accumulate it
+		// until we get at least -1 or +1 so that we can handle slow scrolling with abs values < 1.
 		Sint32 yDir = ev.wheel.y;
+#endif
 		if (!processMouseEvent(event, ev.wheel.mouse_x, ev.wheel.mouse_y)) {
 			return false;
 		}

--- a/backends/events/sdl/sdl3-events.cpp
+++ b/backends/events/sdl/sdl3-events.cpp
@@ -75,7 +75,7 @@ void SdlEventSource::loadGameControllerMappingFile() {
 SdlEventSource::SdlEventSource()
 	: EventSource(), _scrollLock(false), _joystick(nullptr), _lastScreenID(0), _graphicsManager(nullptr), _queuedFakeMouseMove(false),
 	  _lastHatPosition(SDL_HAT_CENTERED), _mouseX(0), _mouseY(0), _engineRunning(false)
-	  , _queuedFakeKeyUp(false), _fakeKeyUp(), _controller(nullptr) {
+	  , _queuedFakeKeyUp(false), _fakeKeyUp(), _queuedFakeMouseScroll(0), _fakeMouseScroll(), _controller(nullptr) {
 	int joystick_num = ConfMan.getInt("joystick_num");
 	if (joystick_num >= 0) {
 		// Initialize SDL joystick subsystem
@@ -624,6 +624,13 @@ bool SdlEventSource::pollEvent(Common::Event &event) {
 		return true;
 	}
 
+	// In we still need to send scroll events for an event with a scroll amount > 1
+	if (_queuedFakeMouseScroll) {
+		event = _fakeMouseScroll;
+		--_queuedFakeMouseScroll;
+		return true;
+	}
+
 	// If the screen changed, send an Common::EVENT_SCREEN_CHANGED
 	int screenID = g_system->getScreenChangeID();
 	if (screenID != _lastScreenID) {
@@ -707,9 +714,13 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 		}
 		if (yDir < 0) {
 			event.type = Common::EVENT_WHEELDOWN;
+			_fakeMouseScroll = event;
+			_queuedFakeMouseScroll = -yDir - 1;
 			return true;
 		} else if (yDir > 0) {
 			event.type = Common::EVENT_WHEELUP;
+			_fakeMouseScroll = event;
+			_queuedFakeMouseScroll = yDir - 1;
 			return true;
 		} else {
 			return false;

--- a/backends/events/sdl/sdl3-events.cpp
+++ b/backends/events/sdl/sdl3-events.cpp
@@ -696,10 +696,7 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 
 	case SDL_EVENT_MOUSE_WHEEL: {
 		Sint32 yDir = ev.wheel.y;
-		// We want the mouse coordinates supplied with a mouse wheel event.
-		// However, SDL2 does not supply these, thus we use whatever we got
-		// last time.
-		if (!processMouseEvent(event, _mouseX, _mouseY)) {
+		if (!processMouseEvent(event, ev.wheel.mouse_x, ev.wheel.mouse_y)) {
 			return false;
 		}
 		if (yDir < 0) {


### PR DESCRIPTION
This pull request proposes three changes related to the mouse wheel events in the SDL backend:

1. Use the mouse location from the `SDL_MouseWheelEvent`  if available.
Since  SDL v2.26.0[^1] the `SDL_MouseWheelEvent` contains the mouse location. Which means we can use it instead of using the previous mouse location.

2. Use accumulated scroll amount instead of precise scroll amount in SDL 3 if available.
For SDL3, the `SDL_MouseWheelEvent.y` is now the precise scroll amount (as a floating point). The accumulated amount over a whole tick was initially removed before being added back in SDL 3.2.12[^2]. That means we were silently casting the precise scroll amount to an integer, probably doing no scroll for slow scrolls. This pull request proposes to use the accumulated scroll amount (as we did with SDL2) if available. It doesn't change the code for SDL3 < 3.2.12, the idea being that I am not sure it is worth adding custom code to accumulate the value ourselves for a short SDL version span.

3. Do not ignore the scroll amount.
This is actually the reason why I started looking at this code. On macOS at least when scrolling with a trackpad trying to scroll fast was not scrolling faster as beyond a certain speed we don't receive more `SDL_MouseWheelEvent` but instead receive the same number of `SDL_MouseWheelEvent` with a higher scroll amounts. So we ended up scrolling less (same speed over a shorter time). This results in a strange scroll behaviour.

The introduction of the `FluidScroller` makes this last point a bit more difficult to notice as it bounds the velocity. But if you change the `else if (dt < 20) effectiveDt = 20;` (which is too slow for my taste) into `else if (dt < 5) effectiveDt = 5;` then this becomes more visible.

I had two possible approaches to handle this scroll amount: either add the scroll amount to the `Common::Event` or send as many events as the amount. I chose the second option as it was just a local change in `SdlEventSource` and with the first approach I would have needed to check all the places that generate or use a wheel event. But it would maybe work a little bit better with the `FluidScroller` as we could pass the amount to `FluidScroller::handleMouseWheel` as a multiplier instead of calling it more often with a multiplier of 1. But in the end it should have the same effect.

**Note:** The SDL3 changes were done purely based on the documentation. I did not try to compile or test them as I don' have SDL3 locally.

[^1]: https://wiki.libsdl.org/SDL2/SDL_MouseWheelEvent
[^2]: https://wiki.libsdl.org/SDL3/SDL_MouseWheelEvent