### PR TITLE
GOB: Fix addon loading issue in Adibou 2

### DIFF
--- a/engines/gob/inter_v7.cpp
+++ b/engines/gob/inter_v7.cpp
@@ -1808,6 +1808,14 @@ bool Inter_v7::setCurrentCDPath(const Common::String &newDirName) {
 	if (newDirName.equalsIgnoreCase("applis") || newDirName.equalsIgnoreCase("envir"))
 		return false;
 
+	// Reject absolute paths: SearchMan also registers the root game directory itself, whose
+	// arcName comes back as a full absolute path (e.g. "/home/user/game/adibou2").  Only
+	// simple relative subdirectory names (e.g. "ReadCount67") represent valid addon dirs.
+	if (newDirName.contains('/') || newDirName.contains('\\')) {
+		debugC(5, kDebugFileIO, "setCurrentCDPath: rejected \"%s\" (absolute path, not an addon subdirectory)", newDirName.c_str());
+		return false;
+	}
+
 	if (!_currentCDPath.empty())
 		SearchMan.setPriority(_currentCDPath.toString(), 0);
 
@@ -1901,6 +1909,7 @@ void Inter_v7::o7_checkData(OpFuncParams &params) {
 						break;
 					}
 				}
+				delete stream;
 			}
 		} else if (indexAppli >= 0 && (size_t) indexAppli <= installedApplications.size()) {
 			// Already installed appli, find its directory and set it as "current CD" path


### PR DESCRIPTION
**Fix bug when using multiple addon for adibou2 at the same time.**

**How to reproduce the bug : When using multiple addon at the same time only one is visible and launchable from the loading screen inside the game.**

**Explaination :** 
When switching to an addon, o7_setActiveCD() called setCurrentCDPath() with the first SearchMan candidate matching the addon's marker VMD file. Because APPLI_XX.VMD files are copied into the root game directory, the root dir always appeared as candidate[0] — with its arcName as a full absolute path — ahead of the actual addon subdirectory. setCurrentCDPath() only rejected "applis" and "envir", so the root dir was unconditionally accepted and the correct addon subdirectory was never reached.

**The Fix:** 
reject any arcName containing a path separator. Valid addon subdirectory names are always plain relative names ("ReadCount67"); the root game directory always has an absolute path.

**Additionnal fix :**
Also fix a memory leak in o7_checkData(): the SeekableReadStream opened for each CD.INF file in the indexAppli<=0 branch was allocated but never deleted.
