### PR TITLE
GUI: Possible fix for bug #16698, where launcher searches looked like they were empty

### DIFF
--- a/gui/widgets/groupedlist.cpp
+++ b/gui/widgets/groupedlist.cpp
@@ -572,6 +572,7 @@ void GroupedListWidget::setFilter(const Common::U32String &filter, bool redraw) 
 	}
 
 	_currentPos = 0;
+	_scrollPos = 0.0f;
 	_selectedItem = -1;
 	// Try to preserve the previous selection
 	if (selectedItem != -1)

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -1126,6 +1126,7 @@ void ListWidget::setFilter(const Common::U32String &filter, bool redraw) {
 	}
 
 	_currentPos = 0;
+	_scrollPos = 0.0f;
 	_selectedItem = -1;
 
 	if (redraw) {


### PR DESCRIPTION
This may be a regression from the recent scroll changes: https://bugs.scummvm.org/ticket/16698

To reproduce, use the launcher in list (i.e. not icons) mode. Make sure you have more games than will fit at once added to it, then scroll down a bit. If you now search for a game, the result may look empty because the list is scrolled down.

The change I've made is that when `_currentPos` is set to 0, now `_scrollPos` is also set to 0. I don't know if that's the correct fix. I know it isn't ideal, because if a game was selected before the search it will restore that selection afterwards. It would be nice if that game would then be in view, but that's not guaranteed. But I don't know how to fix that right now.
