### PR TITLE
AGOS: Fix issue with detection order for Simon 2. Fixes bug #16803

### DIFF
--- a/engines/agos/detection.cpp
+++ b/engines/agos/detection.cpp
@@ -159,13 +159,15 @@ public:
 		const bool hadLanguage = ConfMan.hasKey("language");
 		const Common::String originalLanguage = hadLanguage ? ConfMan.get("language") : Common::String();
 
-		if (isSimon2Target && hadLanguage)
-			ConfMan.set("language", Common::getLanguageCode(Common::EN_ANY));
-
 		Common::Error err = AdvancedMetaEngineDetection::identifyGame(game, descriptor);
 
-		if (isSimon2Target && hadLanguage)
+		if (err.getCode() != Common::kNoError && isSimon2Target && hadLanguage) {
+			ConfMan.set("language", Common::getLanguageCode(Common::EN_ANY));
+
+			err = AdvancedMetaEngineDetection::identifyGame(game, descriptor);
+
 			ConfMan.set("language", originalLanguage);
+		}
 
 		if (err.getCode() == Common::kNoError && game.gameId == "simon2" && ConfMan.hasKey("path")) {
 			Common::FSNode gameDir(ConfMan.getPath("path"));


### PR DESCRIPTION
This PR fixes bug #16803.

It now ensures that detection runs before the Amiga/Mac language fallback.