### PR TITLE
GOB: Fix memory leak in Inter_v7::o7_checkData

### DIFF
--- a/engines/gob/inter_v7.cpp
+++ b/engines/gob/inter_v7.cpp
@@ -1901,6 +1901,7 @@ void Inter_v7::o7_checkData(OpFuncParams &params) {
 						break;
 					}
 				}
+				delete stream;
 			}
 		} else if (indexAppli >= 0 && (size_t) indexAppli <= installedApplications.size()) {
 			// Already installed appli, find its directory and set it as "current CD" path


### PR DESCRIPTION
 In the indexAppli <= 0 branch of o7_checkData(), a SeekableReadStream is opened for each CD.INF file found by
  SearchMan.listMatchingMembers() but was never deleted, leaking memory on every iteration.

  This fix adds delete stream; after the inner while loop, once the stream is no longer needed.

  Note: this is a split-out fix extracted from PR #7510 at reviewer request.