### PR TITLE
NANCY: Fix crash on missing FR0 chunk in Nancy 10+

### DIFF
--- a/engines/nancy/state/scene.cpp
+++ b/engines/nancy/state/scene.cpp
@@ -1262,8 +1262,9 @@ void Scene::initStaticData() {
 
 	if (g_nancy->getGameType() <= kGameTypeNancy9) {
 		const ImageChunk *fr0 = (const ImageChunk *)g_nancy->getEngineData("FR0");
-		assert(fr0);
-		imageName = fr0->imageName;
+		if (fr0) {
+			imageName = fr0->imageName;
+		}
 	}
 
 	auto *mapData = GetEngineData(MAP);


### PR DESCRIPTION
In Nancy 10+, the FR0 chunk was removed from boot.cif. The existing code asserts FR0's existence unconditionally, causing a crash when starting a new game in Nancy 10 (Secret of Shadow Ranch).

Wrap the FR0 usage in a null check, allowing Nancy 10+ to continue without the chunk while preserving existing behavior for Nancy 9 and earlier.

Tested with Secret of Shadow Ranch (nancy10).