### PR TITLE
NANCY: Fix ConversationSound reading for Nancy 10+

### DIFF
--- a/engines/nancy/action/conversation.cpp
+++ b/engines/nancy/action/conversation.cpp
@@ -116,6 +116,12 @@ void ConversationSound::readData(Common::SeekableReadStream &stream) {
 		flagsStruct.flagToSet.flag.label = stream.readSint16LE();
 		flagsStruct.flagToSet.flag.flag = stream.readByte();
 	}
+	// Read additional array for Nancy 10+
+	if (g_nancy->getGameType() >= kGameTypeNancy10) {
+		uint16 numAdditionalEntries = stream.readUint16LE();
+		// Skip the additional entries - they are not used in this implementation
+		stream.skip(numAdditionalEntries * 6);
+	}
 }
 
 void ConversationSound::readTerseData(Common::SeekableReadStream &stream) {
@@ -163,6 +169,13 @@ void ConversationSound::readTerseData(Common::SeekableReadStream &stream) {
 		flagsStruct.flagToSet.type = stream.readByte();
 		flagsStruct.flagToSet.flag.label = stream.readSint16LE();
 		flagsStruct.flagToSet.flag.flag = stream.readByte();
+	}
+
+	// Read additional array for Nancy 10+
+	if (g_nancy->getGameType() >= kGameTypeNancy10) {
+		uint16 numAdditionalEntries = stream.readUint16LE();
+		// Skip the additional entries - they are not used in this implementation
+		stream.skip(numAdditionalEntries * 6);
 	}
 }
 


### PR DESCRIPTION
Nancy 10 added an additional array at the end of ConversationSound data (both regular and terse variants) that was not being read.

The array consists of a uint16 count followed by count * 6 bytes per entry. Not reading it caused incorrect byte alignment, resulting in:

- Incorrect read size warnings for ConversationCelTerse records
- Unimplemented dependency type errors from misaligned dependency data
- Broken dialogue sequencing

The format was reverse engineered from extracted Nancy 10 scene files [(with thanks to mmoga's CIFTREE tools)](https://forums.scummvm.org/viewtopic.php?p=101726#p101726). This pattern was verified across multiple records.

The array entries are currently skipped as currently to me the purpose of them is unknown, making this WIP as if the meaning of these entries is documented this fix should be revisited to handle them properly.

Tested with Secret of Shadow Ranch (nancy10).