### PR TITLE
PS3: Add support for launching engines as separate modules

### DIFF
--- a/backends/platform/sdl/ps3/ps3.cpp
+++ b/backends/platform/sdl/ps3/ps3.cpp
@@ -35,6 +35,7 @@
 
 #include <dirent.h>
 #include <sys/stat.h>
+#include <sys/process.h>
 
 static const Common::HardwareInputTableEntry playstationJoystickButtons[] = {
 	// I18N: Hardware key on controller
@@ -142,4 +143,8 @@ bool OSystem_PS3::hasFeature(Feature f) {
 	}
 
 	return OSystem_SDL::hasFeature(f);
+}
+
+void OSystem_PS3::spawnProcess(const char *path, const char **argv) {
+	sysProcessExitSpawn2(path, argv, nullptr, nullptr, 0, 1000, SYS_PROCESS_SPAWN_STACK_SIZE_256K);
 }

--- a/backends/platform/sdl/ps3/ps3.h
+++ b/backends/platform/sdl/ps3/ps3.h
@@ -30,6 +30,7 @@ public:
 	void initBackend() override;
 	bool hasFeature(Feature f) override;
 	Common::HardwareInputSet *getHardwareInputSet() override;
+	static void spawnProcess(const char *path, const char **argv);
 
 protected:
 	Common::Path getDefaultConfigFileName() override;

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -94,6 +94,10 @@
 #include "backends/fs/android/android-fs-factory.h"
 #endif
 
+#ifdef PLAYSTATION3
+#include "backends/platform/sdl/ps3/ps3.h"
+#endif
+
 #include "gui/dump-all-dialogs.h"
 
 static bool launcherDialog() {
@@ -776,6 +780,10 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 			// Then, get the relevant Engine plugin from MetaEngine.
 			enginePlugin = PluginMan.findEnginePlugin(engineId);
 			if (enginePlugin == nullptr) {
+#ifdef PLAYSTATION3
+				Common::FSNode node((Common::String(PLUGIN_DIRECTORY "/") + engineId + ".self").c_str());
+				if (!node.exists())
+#endif
 				result = Common::kEnginePluginNotFound;
 			}
 		}
@@ -814,6 +822,20 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 			if (ttsMan != nullptr) {
 				ttsMan->pushState();
 			}
+
+#ifdef PLAYSTATION3
+			// For launcher instance, the process was called without additional params
+			// Launching an engine flow will spawn new process with <target-id> param
+			// New process path will be "<plugin-dir>/<engine-id>.self"
+			if (argc == 1) {
+				const char *spawnArgv[2]{};
+				Common::String enginePath = Common::String(PLUGIN_DIRECTORY "/") + plugin->getName() + ".self";
+				spawnArgv[0] = ConfMan.getActiveDomainName().c_str();
+				system.destroy();
+				OSystem_PS3::spawnProcess(enginePath.c_str(), spawnArgv);
+			}
+#endif
+
 			// Try to run the game
 			result = runGame(enginePlugin, system, game, meDescriptor);
 			if (ttsMan != nullptr) {
@@ -899,6 +921,14 @@ extern "C" int scummvm_main(int argc, const char * const argv[]) {
 		// reset the graphics to default
 		setupGraphics(system);
 		if (nullptr == ConfMan.getActiveDomain()) {
+#ifdef PLAYSTATION3
+			// For engine instance, process was called with <target-id> param
+			// Return to launcher flow spawn new launcher process without params
+			if (argc > 1) {
+				system.destroy();
+				OSystem_PS3::spawnProcess(PREFIX "/scummvm.self", nullptr);
+			}
+#endif
 			launcherDialog();
 		}
 	}

--- a/configure
+++ b/configure
@@ -7857,6 +7857,11 @@ case $_host_os in
 			append_var LDFLAGS "-Wl,--gc-sections"
 		fi
 		;;
+	ps3)
+		# Print enabled engines to 'configure.engines' file.
+		# It will help external build script to handle multiple builds per engine
+		awk -f "$_srcdir/engines.awk" -v _print_enabled_engines=yes < /dev/null
+		;;
 esac
 
 # Promote any warning to an error, only if explicitly asked

--- a/engines.awk
+++ b/engines.awk
@@ -325,7 +325,9 @@ BEGIN {
 	config_mk = "config.mk.engines"
 	config_h = "config.h.engines"
 
-	if (_pass == "pass1")
+	if (_print_enabled_engines == "yes")
+		print_enabled_engines = 1
+	else if (_pass == "pass1")
 		pass = 1
 	else
 		pass = 2
@@ -436,6 +438,27 @@ END {
 			_tainted_build = "yes"
 			break
 		}
+	}
+
+	# Print enabled engines to 'configure.engines' file
+	# It will help external build script to handle multiple builds per engine
+	if (print_enabled_engines) {
+		printf("") > "configure.engines"
+		for (e = 1; e <= engine_count; e++) {
+			engine = sorted_engines[e]
+			if (get_engine_build(engine) != "no" && get_engine_sub(engine) == "no") {
+				line = engine
+				subeng_count = get_engine_subengines(engine, subengines)
+				for (s = 1; s <= subeng_count; s++) {
+					subeng = subengines[s]
+					if (get_engine_build(subeng) != "no") {
+						line = line "," subeng
+					}
+				}
+				print(line) >> "configure.engines"
+			}
+		}
+		exit 0
 	}
 
 	#


### PR DESCRIPTION
This adds PS3-specific support for running ScummVM engines as separate modules/executables and chaining execution between the launcher and engine processes:

Launcher (`EBOOT.BIN` from the XMB UI) -> Engine (`.self`) -> Launcher (`.self`)

## Why?

The PS3 port has limited available memory, around 209 MB.

The current executable size is about 119 MB, and at runtime the launcher uses around 127 MB of memory. This grows with every engine added to ScummVM.

Small games and engines work fine, but larger ones have difficulty working properly, or may not start at all.

## Why this approach?

There is currently no support for building dynamic modules, such as `(S)PRX`, with the homebrew PS3 SDK.

Even if such support existed, it would still not work well for this use case, because binding is limited to predefined imports and exports. ScummVM does not have predefined exports for its common code.

In theory, it would be possible to implement a custom library loader together with a post-build tool, but that is outside the scope of the ScummVM codebase.

## Additional changes for configure

Generate a configure.engines file for PS3 builds, listing enabled engines and sub-engines. This allows external build scripts to split enabled engines into separate build modules.
