### PR TITLE
SCUMM: Fix imuse command assertion

### DIFF
--- a/engines/scumm/imuse/imuse.cpp
+++ b/engines/scumm/imuse/imuse.cpp
@@ -902,7 +902,7 @@ int32 IMuseInternal::doCommand_internal(int numargs, int a[]) {
 			if (!player)
 				return -1;
 			if (_newSystem && cmd == 5) {
-				assert(a[3] >= 0 && a[3] <= 15);
+				assert(a[2] >= 0 && a[2] <= 15);
 				part = player->getPart(a[2]);
 				if (!part)
 					return -1;


### PR DESCRIPTION
This will fix a crash in Sam & Max at the Savage Jungle Inn lobby when the currently unused third imuse argument fails an assertion.