### PR TITLE
NANCY: Fix TBOX reader for Nancy 10+ conversation font IDs

### DIFF
--- a/engines/nancy/enginedata.cpp
+++ b/engines/nancy/enginedata.cpp
@@ -277,7 +277,11 @@ TBOX::TBOX(Common::SeekableReadStream *chunkStream) : EngineData(chunkStream) {
 	defaultFontID = chunkStream->readUint16LE();
 	defaultTextColor = chunkStream->readUint16LE();
 
-	if (g_nancy->getGameType() >= kGameTypeNancy2) {
+	if (g_nancy->getGameType() >= kGameTypeNancy10) {
+		// Nancy 10+ moved the conversation font IDs to a later position;
+		// the 4 bytes here are unrelated, so skip them.
+		chunkStream->skip(4);
+	} else if (g_nancy->getGameType() >= kGameTypeNancy2) {
 		conversationFontID = chunkStream->readUint16LE();
 		highlightConversationFontID = chunkStream->readUint16LE();
 	} else {
@@ -288,8 +292,11 @@ TBOX::TBOX(Common::SeekableReadStream *chunkStream) : EngineData(chunkStream) {
 	tabWidth = chunkStream->readUint16LE();
 	pageScrollPercent = chunkStream->readUint16LE(); // Not implemented yet
 
-	if (g_nancy->getGameType() >= kGameTypeNancy10)
-		chunkStream->skip(8);	// TODO: 4 new uint16 fields (values: 8, 9, 4, 75 in Nancy10)
+	if (g_nancy->getGameType() >= kGameTypeNancy10) {
+		conversationFontID = chunkStream->readUint16LE();
+		highlightConversationFontID = chunkStream->readUint16LE();
+		chunkStream->skip(4); // 2 unknown uint16 fields (values: 4, 75 in nancy10)
+	}
 
 	Graphics::PixelFormat format = g_nancy->_graphics->getInputPixelFormat();
 	if (g_nancy->getGameType() >= kGameTypeNancy2) {


### PR DESCRIPTION
The TBOX chunk layout changed in Nancy 10+. The original reader reads
conversationFontID and highlightConversationFontID at the same position
as Nancy 2-9, which in Nancy 10 lands in the middle of unrelated data
and returns garbage values.

The Nancy 10+ block already has maxScrollWidth, firstLineY, and the
content dimension fields correctly mapped. Working from those known
boundaries, the font IDs sit after tabWidth and pageScrollPercent rather
than immediately after defaultTextColor. Verified in game,
conversationFontID=8 and highlightConversationFontID=9 for Nancy 10
produces the correct font colors.

Two unknown uint16 fields that follow the font IDs in the Nancy 10+
layout are skipped for now.