### PR TITLE
TEST: Make cxxtest main and various printers not depend on std

### DIFF
--- a/test/cxxtest/cxxtest/ErrorFormatter.h
+++ b/test/cxxtest/cxxtest/ErrorFormatter.h
@@ -20,6 +20,7 @@
 // analogout to std::ostream.
 //
 
+#include <cxxtest/OutputStream.h>
 #include <cxxtest/TestRunner.h>
 #include <cxxtest/TestListener.h>
 #include <cxxtest/TestTracker.h>
@@ -28,20 +29,6 @@
 
 namespace CxxTest
 {
-class OutputStream
-{
-public:
-    virtual ~OutputStream() {}
-    virtual void flush() {}
-    virtual OutputStream &operator<<(unsigned /*number*/) { return *this; }
-    virtual OutputStream &operator<<(const char * /*string*/) { return *this; }
-
-    typedef void (*Manipulator)(OutputStream &);
-
-    virtual OutputStream &operator<<(Manipulator m) { m(*this); return *this; }
-    static void endl(OutputStream &o) { (o << "\n").flush(); }
-};
-
 class ErrorFormatter : public TestListener
 {
 public:
@@ -325,11 +312,6 @@ private:
             (*_o) << "... ";
         }
         (*_o) << "}" << endl;
-    }
-
-    static void endl(OutputStream &o)
-    {
-        OutputStream::endl(o);
     }
 
     bool _dotting;

--- a/test/cxxtest/cxxtest/ErrorPrinter.h
+++ b/test/cxxtest/cxxtest/ErrorPrinter.h
@@ -16,38 +16,29 @@
 // The ErrorPrinter is a simple TestListener that
 // just prints "OK" if everything goes well, otherwise
 // reports the error in the format of compiler messages.
-// The ErrorPrinter uses stdout
+// The ErrorPrinter uses std::cout or stdout
 //
 
 #include <cxxtest/ErrorFormatter.h>
-#include <stdio.h>
 
 namespace CxxTest
 {
 class ErrorPrinter : public ErrorFormatter
 {
 public:
+#ifdef _CXXTEST_HAVE_STD
+    ErrorPrinter(CXXTEST_STD(ostream) &o = CXXTEST_STD(cout), const char *preLine = ":", const char *postLine = "",
+                 const char *errorString = "Error",
+                 const char *warningString = "Warning") :
+        ErrorFormatter(new StdOStreamAdapter(o), preLine, postLine, errorString, warningString) {}
+#else
     ErrorPrinter(FILE *o = stdout, const char *preLine = ":", const char *postLine = "",
                  const char *errorString = "Error",
                  const char *warningString = "Warning") :
-        ErrorFormatter(new Adapter(o), preLine, postLine, errorString, warningString) {}
+        ErrorFormatter(new StdioFileAdapter(o), preLine, postLine, errorString, warningString) {}
+#endif // _CXXTEST_HAVE_STD
+
     virtual ~ErrorPrinter() { delete outputStream(); }
-
-private:
-    class Adapter : public OutputStream
-    {
-        Adapter(const Adapter &);
-        Adapter &operator=(const Adapter &);
-
-        FILE *_o;
-
-    public:
-        Adapter(FILE *o) : _o(o) {}
-        void flush() { fflush(_o); }
-        OutputStream &operator<<(unsigned i) { fprintf(_o, "%u", i); return *this; }
-        OutputStream &operator<<(const char *s) { fputs(s, _o); return *this; }
-        OutputStream &operator<<(Manipulator m) { return OutputStream::operator<<(m); }
-    };
 };
 }
 

--- a/test/cxxtest/cxxtest/MSVCErrorPrinter.h
+++ b/test/cxxtest/cxxtest/MSVCErrorPrinter.h
@@ -32,8 +32,13 @@ namespace CxxTest
 class MSVCErrorPrinter : public ErrorPrinter
 {
 public:
+#ifdef _CXXTEST_HAVE_STD
+    MSVCErrorPrinter(CXXTEST_STD(ostream) &o = CXXTEST_STD(cout))
+        : ErrorPrinter(o, "(", ") ", "error C2999", "warning C4999") {}
+#else
     MSVCErrorPrinter(FILE *o = stdout)
         : ErrorPrinter(o, "(", ") ", "error C2999", "warning C4999") {}
+#endif // _CXXTEST_HAVE_STD
 };
 }
 

--- a/test/cxxtest/cxxtest/OutputStream.h
+++ b/test/cxxtest/cxxtest/OutputStream.h
@@ -1,0 +1,94 @@
+/*
+-------------------------------------------------------------------------
+ CxxTest: A lightweight C++ unit testing library.
+ Copyright (c) 2008 Sandia Corporation.
+ This software is distributed under the LGPL License v3
+ For more information, see the COPYING file in the top CxxTest directory.
+ Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+ the U.S. Government retains certain rights in this software.
+-------------------------------------------------------------------------
+*/
+
+#ifndef __cxxtest__OutputStream_h__
+#define __cxxtest__OutputStream_h__
+
+//
+//  Since we cannot rely on the standard
+// iostreams, this header defines a base class
+// analogout to std::ostream.
+//
+
+#ifdef _CXXTEST_HAVE_STD
+
+#include <sstream>
+#ifdef _CXXTEST_OLD_STD
+#   include <iostream.h>
+#else // !_CXXTEST_OLD_STD
+#   include <iostream>
+#endif // _CXXTEST_OLD_STD
+
+#endif // _CXXTEST_HAVE_STD
+
+#include <stdio.h>
+
+namespace CxxTest
+{
+class OutputStream
+{
+public:
+    virtual ~OutputStream() {}
+    virtual void flush() {}
+    virtual OutputStream &operator<<(unsigned /*number*/) { return *this; }
+    virtual OutputStream &operator<<(const char * /*string*/) { return *this; }
+
+    typedef void (*Manipulator)(OutputStream &);
+
+    virtual OutputStream &operator<<(Manipulator m) { m(*this); return *this; }
+    static void endl(OutputStream &o) { (o << "\n").flush(); }
+};
+
+// Support use in CxxTest namespace
+void endl(OutputStream &o)
+{
+    OutputStream::endl(o);
+}
+
+#ifdef _CXXTEST_HAVE_STD
+
+class StdOStreamAdapter : public OutputStream
+{
+    CXXTEST_STD(ostream) &_o;
+public:
+    StdOStreamAdapter(CXXTEST_STD(ostream) &o) : _o(o) {}
+    void flush() { _o.flush(); }
+    OutputStream &operator<<(const char *s) { _o << s; return *this; }
+    OutputStream &operator<<(Manipulator m) { return OutputStream::operator<<(m); }
+    OutputStream &operator<<(unsigned i)
+    {
+        char s[1 + 3 * sizeof(unsigned)];
+        numberToString(i, s);
+        _o << s;
+        return *this;
+    }
+};
+
+#endif // _CXXTEST_HAVE_STD
+
+class StdioFileAdapter : public OutputStream
+{
+    StdioFileAdapter(const StdioFileAdapter &);
+    StdioFileAdapter &operator=(const StdioFileAdapter &);
+
+    FILE *_o;
+
+public:
+    StdioFileAdapter(FILE *o) : _o(o) {}
+    void flush() { fflush(_o); }
+    OutputStream &operator<<(unsigned i) { fprintf(_o, "%u", i); return *this; }
+    OutputStream &operator<<(const char *s) { fputs(s, _o); return *this; }
+    OutputStream &operator<<(Manipulator m) { return OutputStream::operator<<(m); }
+};
+
+}
+
+#endif // __cxxtest__OutputStream_h__

--- a/test/cxxtest/cxxtest/ParenPrinter.h
+++ b/test/cxxtest/cxxtest/ParenPrinter.h
@@ -25,7 +25,11 @@ namespace CxxTest
 class ParenPrinter : public ErrorPrinter
 {
 public:
+#ifdef _CXXTEST_HAVE_STD
+    ParenPrinter(CXXTEST_STD(ostream) &o = CXXTEST_STD(cout)) : ErrorPrinter(o, "(", ")") {}
+#else
     ParenPrinter(FILE *o = stdout) : ErrorPrinter(o, "(", ")") {}
+#endif // _CXXTEST_HAVE_STD
 };
 }
 

--- a/test/cxxtest/cxxtest/StdioFilePrinter.h
+++ b/test/cxxtest/cxxtest/StdioFilePrinter.h
@@ -28,24 +28,8 @@ class StdioFilePrinter : public ErrorFormatter
 {
 public:
     StdioFilePrinter(FILE *o, const char *preLine = ":", const char *postLine = "") :
-        ErrorFormatter(new Adapter(o), preLine, postLine) {}
+        ErrorFormatter(new StdioFileAdapter(o), preLine, postLine) {}
     virtual ~StdioFilePrinter() { delete outputStream(); }
-
-private:
-    class Adapter : public OutputStream
-    {
-        Adapter(const Adapter &);
-        Adapter &operator=(const Adapter &);
-
-        FILE *_o;
-
-    public:
-        Adapter(FILE *o) : _o(o) {}
-        void flush() { fflush(_o); }
-        OutputStream &operator<<(unsigned i) { fprintf(_o, "%u", i); return *this; }
-        OutputStream &operator<<(const char *s) { fputs(s, _o); return *this; }
-        OutputStream &operator<<(Manipulator m) { return OutputStream::operator<<(m); }
-    };
 };
 }
 

--- a/test/cxxtest/cxxtest/TestMain.h
+++ b/test/cxxtest/cxxtest/TestMain.h
@@ -15,31 +15,20 @@
 #include <cxxtest/TestTracker.h>
 #include <cxxtest/Flags.h>
 #include <cxxtest/StdValueTraits.h>
-
-#if defined(_CXXTEST_HAVE_STD)
-#ifdef _CXXTEST_OLD_STD
-#   include <iostream.h>
-#   include <string.h>
-#else // !_CXXTEST_OLD_STD
-#   include <iostream>
-#   include <cstring>
-#endif // _CXXTEST_OLD_STD
-#endif
+#include <cxxtest/OutputStream.h>
 
 namespace CxxTest
 {
 
-#if defined(_CXXTEST_HAVE_STD)
-inline void print_help(const char* name)
+inline void print_help(OutputStream &os, const char* name)
 {
-    CXXTEST_STD(cerr) << name << " <suitename>" << CXXTEST_STD(endl);
-    CXXTEST_STD(cerr) << name << " <suitename> <testname>" << CXXTEST_STD(endl);
-    CXXTEST_STD(cerr) << name << " -h" << CXXTEST_STD(endl);
-    CXXTEST_STD(cerr) << name << " --help" << CXXTEST_STD(endl);
-    CXXTEST_STD(cerr) << name << " --help-tests" << CXXTEST_STD(endl);
-    CXXTEST_STD(cerr) << name << " -v             Enable tracing output." << CXXTEST_STD(endl);
+    os << name << " <suitename>" << endl;
+    os << name << " <suitename> <testname>" << endl;
+    os << name << " -h" << endl;
+    os << name << " --help" << endl;
+    os << name << " --help-tests" << endl;
+    os << name << " -v             Enable tracing output." << endl;
 }
-#endif
 
 
 template <class TesterT>
@@ -53,6 +42,12 @@ int Main(TesterT& tmp, int argc, char* argv[])
 //
 
 #if defined(_CXXTEST_HAVE_STD)
+    StdOStreamAdapter out(CXXTEST_STD(cout));
+    StdOStreamAdapter err(CXXTEST_STD(cerr));
+#else
+    StdioFileAdapter out(stdout);
+    StdioFileAdapter err(stderr);
+#endif // _CXXTEST_HAVE_STD
 //
 // Print command-line syntax
 //
@@ -60,17 +55,17 @@ int Main(TesterT& tmp, int argc, char* argv[])
     {
         if ((CXXTEST_STD(strcmp)(argv[i], "-h") == 0) || (CXXTEST_STD(strcmp)(argv[i], "--help") == 0))
         {
-            print_help(argv[0]);
+            print_help(err, argv[0]);
             return 0;
         }
         else if ((CXXTEST_STD(strcmp)(argv[1], "--help-tests") == 0))
         {
-            CXXTEST_STD(cout) << "Suite/Test Names" << CXXTEST_STD(endl);
-            CXXTEST_STD(cout) << "---------------------------------------------------------------------------" << CXXTEST_STD(endl);
+            out << "Suite/Test Names" << endl;
+            out << "---------------------------------------------------------------------------" << endl;
             for (SuiteDescription *sd = RealWorldDescription().firstSuite(); sd; sd = sd->next())
                 for (TestDescription *td = sd->firstTest(); td; td = td->next())
                 {
-                    CXXTEST_STD(cout) << td->suiteName() << " " << td->testName() << CXXTEST_STD(endl);
+                    out << td->suiteName() << " " << td->testName() << endl;
                 }
             return 0;
         }
@@ -87,7 +82,7 @@ int Main(TesterT& tmp, int argc, char* argv[])
         }
         else
         {
-            CXXTEST_STD(cerr) << "ERROR: unknown option '" << argv[1] << "'" << CXXTEST_STD(endl);
+            err << "ERROR: unknown option '" << argv[1] << "'" << endl;
             return -1;
         }
         for (int i = 1; i < (argc - 1); i++)
@@ -106,7 +101,7 @@ int Main(TesterT& tmp, int argc, char* argv[])
         status = leaveOnly(argv[1]);
         if (!status)
         {
-            CXXTEST_STD(cerr) << "ERROR: unknown suite '" << argv[1] << "'" << CXXTEST_STD(endl);
+            err << "ERROR: unknown suite '" << argv[1] << "'" << endl;
             return -1;
         }
     }
@@ -115,11 +110,10 @@ int Main(TesterT& tmp, int argc, char* argv[])
         status = leaveOnly(argv[1], argv[2]);
         if (!status)
         {
-            CXXTEST_STD(cerr) << "ERROR: unknown test '" << argv[1] << "::" << argv[2] << "'" << CXXTEST_STD(endl);
+            err << "ERROR: unknown test '" << argv[1] << "::" << argv[2] << "'" << endl;
             return -1;
         }
     }
-#endif
 
     tmp.process_commandline(argc, argv);
     return tmp.run();

--- a/test/cxxtest/cxxtest/XmlFormatter.h
+++ b/test/cxxtest/cxxtest/XmlFormatter.h
@@ -647,11 +647,6 @@ private:
     }
 #endif
 
-    static void endl(OutputStream &o)
-    {
-        OutputStream::endl(o);
-    }
-
     OutputStream *_o;
     OutputStream *_ostr;
     std::ostringstream *_os;

--- a/test/cxxtest/cxxtest/XmlPrinter.h
+++ b/test/cxxtest/cxxtest/XmlPrinter.h
@@ -21,7 +21,7 @@
 #include <cxxtest/Flags.h>
 
 #ifndef _CXXTEST_HAVE_STD
-#   define _CXXTEST_HAVE_STD
+#   error "XmlPrinter can't be used without std"
 #endif // _CXXTEST_HAVE_STD
 
 #include <cxxtest/XmlFormatter.h>
@@ -40,7 +40,7 @@ class XmlPrinter : public XmlFormatter
 {
 public:
     XmlPrinter(CXXTEST_STD(ostream) &o = CXXTEST_STD(cout), const char* /*preLine*/ = ":", const char* /*postLine*/ = "") :
-        XmlFormatter(new Adapter(o), new Adapter(ostr), &ostr) {}
+        XmlFormatter(new StdOStreamAdapter(o), new StdOStreamAdapter(ostr), &ostr) {}
 
     virtual ~XmlPrinter()
     {
@@ -51,23 +51,6 @@ public:
 private:
 
     std::ostringstream ostr;
-
-    class Adapter : public OutputStream
-    {
-        CXXTEST_STD(ostream) &_o;
-    public:
-        Adapter(CXXTEST_STD(ostream) &o) : _o(o) {}
-        void flush() { _o.flush(); }
-        OutputStream &operator<<(const char *s) { _o << s; return *this; }
-        OutputStream &operator<<(Manipulator m) { return OutputStream::operator<<(m); }
-        OutputStream &operator<<(unsigned i)
-        {
-            char s[1 + 3 * sizeof(unsigned)];
-            numberToString(i, s);
-            _o << s;
-            return *this;
-        }
-    };
 };
 }
 

--- a/test/cxxtest/cxxtest/unix.h
+++ b/test/cxxtest/cxxtest/unix.h
@@ -13,7 +13,7 @@
 #define UNIX_ERROR_PRINTER_H_N4C6JUX4
 
 #ifndef _CXXTEST_HAVE_STD
-#   define _CXXTEST_HAVE_STD
+#   error "UNIXErrorFormatter can't be used without std"
 #endif // _CXXTEST_HAVE_STD
 
 #include <cxxtest/Flags.h>
@@ -22,7 +22,7 @@
 #include <cxxtest/TestTracker.h>
 #include <cxxtest/ValueTraits.h>
 #include <cxxtest/StdValueTraits.h>
-#include <cxxtest/ErrorFormatter.h> // CxxTest::OutputStream
+#include <cxxtest/OutputStream.h>
 
 namespace CxxTest
 {
@@ -262,11 +262,6 @@ private:
         (*_o) << "}" << endl;
     }
 
-    static void endl(OutputStream &o)
-    {
-        OutputStream::endl(o);
-    }
-
     bool _reported;
     OutputStream *_o;
     const char *_preLine;
@@ -281,26 +276,8 @@ class unix : public UNIXErrorFormatter
 {
 public:
     unix(CXXTEST_STD(ostream) &o = CXXTEST_STD(cerr), const char *preLine = ":", const char *postLine = "") :
-        UNIXErrorFormatter(new Adapter(o), preLine, postLine) {}
+        UNIXErrorFormatter(new StdOStreamAdapter(o), preLine, postLine) {}
     virtual ~unix() { delete outputStream(); }
-
-private:
-    class Adapter : public OutputStream
-    {
-        CXXTEST_STD(ostream) &_o;
-    public:
-        Adapter(CXXTEST_STD(ostream) &o) : _o(o) {}
-        void flush() { _o.flush(); }
-        OutputStream &operator<<(const char *s) { _o << s; return *this; }
-        OutputStream &operator<<(Manipulator m) { return OutputStream::operator<<(m); }
-        OutputStream &operator<<(unsigned i)
-        {
-            char s[1 + 3 * sizeof(unsigned)];
-            numberToString(i, s);
-            _o << s;
-            return *this;
-        }
-    };
 };
 }
 


### PR DESCRIPTION
OutputStream and derivatives also moved to a separate header
Alternate proposal to #7516 

The update to CxxTest::Main allow use to process the command line args, which was my desire for the upgrade to CxxTest 4.x. This means I can list the tests and run them individually, which I hope will allow for better IDE integrations