### PR TITLE
GUI: Fix bugs introduced by FluidScroll

### DIFF
--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -1514,6 +1514,7 @@ void ThemeEngine::drawFoldIndicator(const Common::Rect &r, bool expanded) {
 	else
 		orient = Graphics::VectorRenderer::kTriangleRight;
 
+	_vectorRenderer->setClippingRect(_clip);
 	_vectorRenderer->setFillMode(Graphics::VectorRenderer::kFillForeground);
 	_vectorRenderer->setFgColor(_textColors[kTextColorNormal]->r, _textColors[kTextColorNormal]->g, _textColors[kTextColorNormal]->b);
 	_vectorRenderer->drawTriangle(r.left + r.width() / 4, r.top + r.height() / 4, r.width() / 2, r.height() / 2, orient);

--- a/gui/animation/FluidScroll.cpp
+++ b/gui/animation/FluidScroll.cpp
@@ -168,6 +168,13 @@ void FluidScroller::feedWheel(uint32 time, float deltaY) {
 		effectiveDt = 20;
 
 	float velocity = deltaY / (float)effectiveDt;
+	if (_mode == kModeFling) {
+		float elapsed = (float)(time - _startTime);
+		float coefficient = powf(kDecelerationRate, elapsed);
+		float currentVelocity = _initialVelocity * coefficient;
+
+		velocity += currentVelocity * 0.2f;
+	}
 	startFling(velocity);
 }
 
@@ -176,7 +183,6 @@ void FluidScroller::handleMouseWheel(int direction, float multiplier) {
 	if (stepping == 0.0f)
 		return;
 
-	stopAnimation();
 	feedWheel(g_system->getMillis(), stepping);
 }
 

--- a/gui/dialog.cpp
+++ b/gui/dialog.cpp
@@ -119,7 +119,10 @@ void Dialog::reflowLayout() {
 }
 
 void Dialog::lostFocus() {
-	_dragWidget = nullptr;
+	if (_dragWidget) {
+		_dragWidget->lostFocus();
+		_dragWidget = nullptr;
+	}
 
 	if (_tickleWidget) {
 		_tickleWidget->lostFocus();

--- a/gui/dialog.cpp
+++ b/gui/dialog.cpp
@@ -268,8 +268,21 @@ void Dialog::handleMouseWheel(int x, int y, int direction) {
 	Widget *w = findWidget(x, y);
 	if (!w)
 		w = _focusedWidget;
-	if (w)
+	if (w) {
 		w->handleMouseWheel(x - (w->getAbsX() - _x), y - (w->getAbsY() - _y), direction);
+		// Find the scrollable ancestor to set as the tickle target
+		Widget *scrollable = w;
+		while (scrollable) {
+			if (scrollable->hasVisibleScrollBar()) {
+				setTickleWidget(scrollable);
+				break;
+			}
+			if (scrollable->_boss == this)		
+				break;
+
+			scrollable = static_cast<Widget *>(scrollable->_boss);
+		}
+	}
 
 	_handlingMouseWheel = false;
 }

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -186,6 +186,16 @@ Widget *Widget::findWidgetInChain(Widget *w, uint32 type) {
 	return nullptr;
 }
 
+bool Widget::hasVisibleScrollBar() const {
+	Widget *w = _firstWidget;
+	while (w) {
+		if (w->getType() == kScrollBarWidget && w->isVisible())
+			return true;
+		w = w->_next;
+	}
+	return false;
+}
+
 bool Widget::containsWidgetInChain(Widget *w, Widget *search) {
 	while (w) {
 		if (w == search || w->containsWidget(search))

--- a/gui/widget.h
+++ b/gui/widget.h
@@ -162,6 +162,8 @@ public:
 
 	uint32 getType() const { return _type; }
 
+	// Check if the widget or its children contain a visible scrollbar
+	virtual bool hasVisibleScrollBar() const;
 	void setFlags(int flags);
 	void clearFlags(int flags);
 	int getFlags() const		{ return _flags; }

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -1103,6 +1103,11 @@ bool GridWidget::handleKeyUp(Common::KeyState state) {
 	return false;
 }
 
+void GridWidget::lostFocusWidget() {
+	_isMouseDown = _isDragging = false;
+	_dragStartY = _dragLastY = 0;
+}
+
 void GridWidget::handleCommand(CommandSender *sender, uint32 cmd, uint32 data) {
 	// Work in progress
 	switch (cmd) {

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -1023,6 +1023,9 @@ void GridWidget::selectVisualRange(int startPos, int endPos) {
 }
 
 void GridWidget::handleMouseWheel(int x, int y, int direction) {
+	if (!_scrollBar->isVisible())
+		return;
+
 	_fluidScroller->handleMouseWheel(direction);
 }
 
@@ -1058,7 +1061,7 @@ void GridWidget::handleMouseUp(int x, int y, int button, int clickCount) {
 }
 
 void GridWidget::handleMouseMoved(int x, int y, int button) {
-	if (!_isMouseDown)
+	if (!_isMouseDown || !_scrollBar->isVisible())
 		return;
 
 	if (!_isDragging && ABS(y - _dragStartY) > kDragThreshold) {

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -1087,6 +1087,7 @@ void GridWidget::applyScrollPos() {
 
 	assignEntriesToItems();
 	scrollBarRecalc();	
+	markAsDirty();
 	g_gui.scheduleTopDialogRedraw();
 }
 

--- a/gui/widgets/grid.cpp
+++ b/gui/widgets/grid.cpp
@@ -195,6 +195,7 @@ void GridItemWidget::handleMouseWheel(int x, int y, int direction) {
 void GridItemWidget::handleMouseEntered(int button) {
 	if (!_isHighlighted) {
 		_isHighlighted = true;
+		_grid->_highlightedItem = this;
 		markAsDirty();
 	}
 }
@@ -202,6 +203,8 @@ void GridItemWidget::handleMouseEntered(int button) {
 void GridItemWidget::handleMouseLeft(int button) {
 	if (_isHighlighted) {
 		_isHighlighted = false;
+		if (_grid->_highlightedItem == this)
+			_grid->_highlightedItem = nullptr;
 		markAsDirty();
 	}
 }
@@ -1088,6 +1091,8 @@ void GridWidget::applyScrollPos() {
 	assignEntriesToItems();
 	scrollBarRecalc();	
 	markAsDirty();
+	if (_highlightedItem)
+		_highlightedItem->handleMouseLeft(0);
 	g_gui.scheduleTopDialogRedraw();
 }
 

--- a/gui/widgets/grid.h
+++ b/gui/widgets/grid.h
@@ -180,6 +180,7 @@ protected:
 	static const int kDragThreshold = 5;
 
 	FluidScroller *_fluidScroller;
+	GridItemWidget *_highlightedItem = nullptr;
 
 public:
 	int				_gridItemHeight;

--- a/gui/widgets/grid.h
+++ b/gui/widgets/grid.h
@@ -252,6 +252,7 @@ public:
 
 	bool wantsFocus() override { return true; }
 
+	void lostFocusWidget() override;
 	bool handleKeyDown(Common::KeyState state) override;
 	bool handleKeyUp(Common::KeyState state) override;
 	void openTrayAtSelected();

--- a/gui/widgets/groupedlist.cpp
+++ b/gui/widgets/groupedlist.cpp
@@ -356,6 +356,9 @@ void GroupedListWidget::handleMouseUp(int x, int y, int button, int clickCount) 
 }
 
 void GroupedListWidget::handleMouseWheel(int x, int y, int direction) {
+	if (!_scrollBar->isVisible())
+		return;
+
 	_fluidScroller->handleMouseWheel(direction);
 }
 

--- a/gui/widgets/groupedlist.cpp
+++ b/gui/widgets/groupedlist.cpp
@@ -146,7 +146,9 @@ void GroupedListWidget::sortGroups() {
 	checkBounds();
 	scrollBarRecalc();
 
-	_scrollBar->_currentPos = _currentPos;
+	_scrollPos = (float)_currentPos * (kLineHeight + _itemSpacing);
+	_scrollBar->_currentPos = (int)_scrollPos;
+	_fluidScroller->setPosition(_scrollPos, false);
 	_scrollBar->recalc();
 	// FIXME: Temporary solution to clear/display the background ofthe scrollbar when list
 	// grows too small or large during group toggle. We shouldn't have to redraw the top dialog,
@@ -247,11 +249,9 @@ void GroupedListWidget::loadSelection(const Common::Array<bool> &savedSelection)
 	}
 
 	checkBounds();
+	_scrollPos = (float)_currentPos * (kLineHeight + _itemSpacing);
+	_fluidScroller->setPosition(_scrollPos, false);
 	scrollBarRecalc();
-
-	_scrollBar->_currentPos = _currentPos;
-	_scrollBar->recalc();
-
 	markAsDirty();
 }
 
@@ -362,8 +362,8 @@ void GroupedListWidget::handleMouseWheel(int x, int y, int direction) {
 void GroupedListWidget::handleCommand(CommandSender *sender, uint32 cmd, uint32 data) {
 	switch (cmd) {
 	case kSetPositionCmd:
-		if (_currentPos != (int)data) {
-			_scrollPos = (float)data * (kLineHeight + _itemSpacing);
+		if ((int)_scrollPos != (int)data) {
+			_scrollPos = (float)data;
 			_fluidScroller->stopAnimation();
 			_scrollPos = _fluidScroller->setPosition(_scrollPos, false);
 			applyScrollPos();

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -460,11 +460,14 @@ void ListWidget::handleMouseUp(int x, int y, int button, int clickCount) {
 }
 
 void ListWidget::handleMouseWheel(int x, int y, int direction) {
+	if (!_scrollBar->isVisible())
+		return;
+
 	_fluidScroller->handleMouseWheel(direction);
 }
 
 void ListWidget::handleMouseMoved(int x, int y, int button) {
-	if (!isEnabled())
+	if (!isEnabled() || !_scrollBar->isVisible())
 		return;
 
 	if (_isMouseDown && _dragLastY != 0) {

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -290,6 +290,8 @@ void ListWidget::setList(const Common::U32StringArray &list) {
 		_currentPos = size - 1;
 	if (_currentPos < 0)
 		_currentPos = 0;
+	_scrollPos = (float)_currentPos * (kLineHeight + _itemSpacing);
+	_fluidScroller->setPosition(_scrollPos, false);
 	_selectedItem = -1;
 	// Resize and clear bool array
 	_selectedItems.clear();
@@ -347,15 +349,14 @@ void ListWidget::scrollTo(int item) {
 
 void ListWidget::scrollBarRecalc() {
 	const int lineHeight = kLineHeight + _itemSpacing;
-	_scrollBar->_numEntries = _list.size();
-	_scrollBar->_entriesPerPage = _entriesPerPage;
-	int maxIndex = MAX(0, (int)_list.size() - _entriesPerPage);
-	_scrollBar->_currentPos = CLIP<int>(_currentPos, 0, maxIndex);
+	const int visibleHeight = _h - _topPadding - _bottomPadding;
+	_scrollBar->_numEntries = _list.size() * lineHeight;
+	_scrollBar->_entriesPerPage = visibleHeight;
+	int maxScroll = MAX(0, _scrollBar->_numEntries - _scrollBar->_entriesPerPage);
+	_scrollBar->_currentPos = CLIP<int>((int)_scrollPos, 0, maxScroll);
 	_scrollBar->_singleStep = lineHeight;
 	_scrollBar->recalc();
-
-	int maxScroll = MAX(0, (int)(_scrollBar->_numEntries - _scrollBar->_entriesPerPage) * lineHeight);
-	_fluidScroller->setBounds((float)maxScroll, _h - _topPadding - _bottomPadding, (float)_scrollBar->_singleStep);
+	_fluidScroller->setBounds((float)maxScroll, (float)visibleHeight, (float)_scrollBar->_singleStep);
 }
 
 void ListWidget::handleTickle() {
@@ -838,8 +839,8 @@ void ListWidget::lostFocusWidget() {
 void ListWidget::handleCommand(CommandSender *sender, uint32 cmd, uint32 data) {
 	switch (cmd) {
 	case kSetPositionCmd:
-		if (_currentPos != (int)data) {
-			_scrollPos = (float)data * (kLineHeight + _itemSpacing);
+		if ((int)_scrollPos != (int)data) {
+			_scrollPos = (float)data;
 			_fluidScroller->stopAnimation();
 			_scrollPos = _fluidScroller->setPosition(_scrollPos, false);
 			applyScrollPos();
@@ -992,19 +993,16 @@ void ListWidget::scrollToCurrent() {
 
 	checkBounds();
 	_scrollPos = (float)_currentPos * (kLineHeight + _itemSpacing);
-	_scrollBar->_currentPos = _currentPos;
+	_scrollBar->_currentPos = (int)_scrollPos;
 	_scrollBar->recalc();
 	_fluidScroller->setPosition(_scrollPos, false);
 }
 
 void ListWidget::scrollToEnd() {
-	if (_currentPos + _entriesPerPage < (int)_list.size()) {
-		_currentPos = _list.size() - _entriesPerPage;
-	} else {
-		return;
-	}
-
-	_scrollBar->_currentPos = _currentPos;
+	_currentPos = MAX(0, (int)_list.size() - _entriesPerPage);
+	_scrollPos = (float)_currentPos * (kLineHeight + _itemSpacing);
+	_scrollBar->_currentPos = (int)_scrollPos;
+	_fluidScroller->setPosition(_scrollPos, false);
 	_scrollBar->recalc();
 	_scrollBar->markAsDirty();
 }

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -831,6 +831,8 @@ void ListWidget::receivedFocusWidget() {
 
 void ListWidget::lostFocusWidget() {
 	_inversion = ThemeEngine::kTextInversion;
+	_isMouseDown = _isDragging = false;
+	_dragStartY = _dragLastY = 0;
 
 	// If we lose focus, we simply forget the user changes
 	_editMode = false;

--- a/gui/widgets/richtext.cpp
+++ b/gui/widgets/richtext.cpp
@@ -103,6 +103,8 @@ RichTextWidget::~RichTextWidget() {
 }
 
 void RichTextWidget::handleMouseWheel(int x, int y, int direction) {
+	if (!_verticalScroll->isVisible())
+		return;
 	_fluidScroller->handleMouseWheel(direction);
 	applyScrollPos();
 }
@@ -146,7 +148,7 @@ void RichTextWidget::handleMouseMoved(int x, int y, int button) {
 			g_gui.theme()->setActiveCursor(GUI::ThemeEngine::kCursorNormal);
 	}
 
-	if (_mouseDownStartY == 0 || _mouseDownY == y || !_txtWnd)
+	if (_mouseDownStartY == 0 || _mouseDownY == y || !_txtWnd || !_verticalScroll->isVisible())
 		return;
 
 	int deltaY = _mouseDownY - y;

--- a/gui/widgets/richtext.cpp
+++ b/gui/widgets/richtext.cpp
@@ -392,6 +392,11 @@ void RichTextWidget::markAsDirty() {
 	}
 }
 
+void RichTextWidget::lostFocusWidget() {
+	_mouseDownY = _mouseDownStartY = 0;
+	_isDragging = false;
+}
+
 bool RichTextWidget::containsWidget(Widget *w) const {
 	if (w == _verticalScroll || _verticalScroll->containsWidget(w))
 		return true;

--- a/gui/widgets/richtext.h
+++ b/gui/widgets/richtext.h
@@ -74,6 +74,7 @@ public:
 	void handleMouseDown(int x, int y, int button, int clickCount) override;
 	void handleMouseUp(int x, int y, int button, int clickCount) override;
 	void handleMouseMoved(int x, int y, int button) override;
+	void lostFocusWidget() override;
 	void handleTickle() override;
 	void handleTooltipUpdate(int x, int y) override;
 

--- a/gui/widgets/scrollcontainer.cpp
+++ b/gui/widgets/scrollcontainer.cpp
@@ -53,7 +53,7 @@ void ScrollContainerWidget::init() {
 }
 
 void ScrollContainerWidget::handleMouseWheel(int x, int y, int direction) {
-	if (!isEnabled())
+	if (!isEnabled() || !_verticalScroll->isVisible())
 		return;
 
 	_fluidScroller->handleMouseWheel(direction);
@@ -77,7 +77,7 @@ void ScrollContainerWidget::handleMouseDown(int x, int y, int button, int clickC
 }
 
 void ScrollContainerWidget::handleMouseMoved(int x, int y, int button) {
-	if (!_isMouseDown || _mouseDownY == y)
+	if (!_isMouseDown || _mouseDownY == y || !_verticalScroll->isVisible())
 		return;
 
 	if (!_isDragging && ABS(y - _mouseDownStartY) > kDragThreshold)

--- a/gui/widgets/scrollcontainer.cpp
+++ b/gui/widgets/scrollcontainer.cpp
@@ -248,6 +248,11 @@ void ScrollContainerWidget::markAsDirty() {
 	}
 }
 
+void ScrollContainerWidget::lostFocusWidget() {
+	_isMouseDown = _isDragging = false;
+	_mouseDownY = _mouseDownStartY = 0;
+}
+
 bool ScrollContainerWidget::containsWidget(Widget *w) const {
 	if (w == _verticalScroll || _verticalScroll->containsWidget(w))
 		return true;

--- a/gui/widgets/scrollcontainer.h
+++ b/gui/widgets/scrollcontainer.h
@@ -66,6 +66,7 @@ public:
 	void handleMouseDown(int x, int y, int button, int clickCount) override;
 	void handleMouseUp(int x, int y, int button, int clickCount) override;
 	void handleMouseMoved(int x, int y, int button) override;
+	void lostFocusWidget() override;
 	void handleTickle() override;
 
 	// We overload getChildY to make sure child widgets are positioned correctly.


### PR DESCRIPTION
**Fixes:**
- [#16700](https://bugs.scummvm.org/ticket/16700)
- [#16718](https://bugs.scummvm.org/ticket/16718)
- [#16762](https://bugs.scummvm.org/ticket/16762)
- [#16780](https://bugs.scummvm.org/ticket/16780)

- Fixed a scenario where widgets required a click to shift focus before scrolling, even though the mouse was hovering over the widget.
- Fixed unnecessary scrolling and dragging when no scrollbar was present, i.e. all content already fit on screen.
- Fixed GridWidget hover highlights not clearing properly during scrolling, causing items moving away from the cursor to remain highlighted.

**Improvement:** 
- Improved mouse wheel fluid scrolling by building on previous velocity
