### PR TITLE
GLK: Fix saved font selection handling

### DIFF
--- a/engines/glk/dialogs.cpp
+++ b/engines/glk/dialogs.cpp
@@ -572,12 +572,8 @@ void GlkOptionsWidget::load() {
 		{ _gfontPopUps[0], g_conf->_gStyles, "gfont" }
 	};
 
-	for (auto &opt : fontOptions) {
-		if (g_conf)
-			setFontPopUp(opt.popup, true, opt.styles[style_Normal].font, nullptr, _domain);
-		else
-			setFontPopUp(opt.popup, false, (FACES)0, opt.confKeyPrefix, _domain);
-	}
+	for (auto &opt : fontOptions)
+		setFontPopUp(opt.popup, true, opt.styles[style_Normal].font, nullptr, _domain);
 
 	for (auto &opt : colorOptions) {
 		if (g_conf) {
@@ -892,7 +888,7 @@ static void saveFontPopUp(GUI::PopUpWidget *popup, WindowStyle *styles, const ch
 	FACES selectedFont = (FACES)popup->getSelectedTag();
 	for (int i = 0; i < style_NUMSTYLES; ++i) {
 		styles[i].font = selectedFont;
-		Common::String key = Common::String::format("%s%d", confKeyPrefix, i);
+		Common::String key = Common::String::format("%s_%d", confKeyPrefix, i);
 		ConfMan.set(key, Screen::getFontName(selectedFont), domain);
 	}
 }

--- a/engines/glk/glk_api.cpp
+++ b/engines/glk/glk_api.cpp
@@ -480,7 +480,7 @@ void GlkAPI::glk_stylehint_set(uint wintype, uint style, uint hint, int val) {
 		break;
 
 	case stylehint_Proportional:
-		if (wintype == wintype_TextBuffer) {
+		if (wintype == wintype_TextBuffer && !ConfMan.hasKey(Common::String::format("tfont_%u", style))) {
 			p = val > 0;
 			b = styles[style].isBold();
 			i = styles[style].isItalic();


### PR DESCRIPTION
The GLK options dialog saved text and grid font choices using tfont_N and gfont_N keys, but the loader and style hint code did not consistently honor those saved per-style keys. As a result, choosing a monospaced text font in the launcher could appear to succeed in the dialog while the game still rendered with the proportional font selected by style hints.

Load the dialog font popups from the already synchronized Conf styles, save font choices with the same tfont_N/gfont_N key format used by Conf::synchronize(), and avoid applying text-buffer proportional style hints over an explicit saved text font. This keeps user-selected monospaced fonts effective after saving options and starting the game.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
