### PR TITLE
DIRECTOR: Make Elroy Hits the Pavement fully playable

### DIFF
--- a/engines/director/castmember/castmember.cpp
+++ b/engines/director/castmember/castmember.cpp
@@ -26,6 +26,7 @@
 #include "director/cast.h"
 #include "director/movie.h"
 #include "director/castmember/castmember.h"
+#include "director/castmember/script.h"
 #include "director/lingo/lingo-the.h"
 #include "director/util.h"
 
@@ -321,7 +322,12 @@ void CastMember::setField(int field, const Datum &d) {
 			warning("CastMember::setField(): CastMember info for %d not found", _castId);
 			return;
 		}
-		_cast->_lingoArchive->replaceCode(*d.u.s, kCastScript, _castId);
+		{
+			ScriptType scriptType = kCastScript;
+			if (_type == kCastLingoScript)
+				scriptType = static_cast<ScriptCastMember *>(this)->_scriptType;
+			_cast->_lingoArchive->replaceCode(*d.u.s, scriptType, _castId);
+		}
 		castInfo->script = d.asString();
 		return;
 	case kTheWidth:

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -103,6 +103,7 @@
 #include "director/lingo/xlibs/m/msfile.h"
 #include "director/lingo/xlibs/m/mystisle.h"
 #include "director/lingo/xlibs/m/mazexobj.h"
+#include "director/lingo/xlibs/m/myfolder.h"
 #include "director/lingo/xlibs/o/openbleedwindowxcmd.h"
 #include "director/lingo/xlibs/o/orthoplayxobj.h"
 #include "director/lingo/xlibs/p/paco.h"
@@ -329,6 +330,7 @@ static const struct XLibProto {
 	XLIBDEF(MovUtilsXObj,		kXObj,			400),	// D4
 	XLIBDEF(MSFile,             kXObj,          400),   // D4
 	XLIBDEF(MuiXtra,			kXtraObj,					500),	// D5
+	XLIBDEF(MyFolderXObj,			kXObj,					400),	// D4
 	XLIBDEF(MystIsleXObj,		kXObj,			400),	// D4
 	XLIBDEF(OSCheckXtra,		kXtraObj,		400),	// D4
 	XLIBDEF(OpenBleedWindowXCMD,kXObj,			300),	// D3

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -77,6 +77,7 @@
 #include "director/lingo/xlibs/g/getscreensizexfcn.h"
 #include "director/lingo/xlibs/g/getsoundinlevel.h"
 #include "director/lingo/xlibs/g/gpid.h"
+#include "director/lingo/xlibs/g/getuinfo.h"
 #include "director/lingo/xlibs/h/henry.h"
 #include "director/lingo/xlibs/h/hitmap.h"
 #include "director/lingo/xlibs/i/inixobj.h"
@@ -301,6 +302,7 @@ static const struct XLibProto {
 	XLIBDEF(GetScreenRectsXFCN,	kXObj,			300),	// D3
 	XLIBDEF(GetScreenSizeXFCN,	kXObj,			300),	// D3
 	XLIBDEF(GetSoundInLevelXObj,kXObj,			400),	// D4
+	XLIBDEF(GetUInfoXObj,			kXObj,					400),	// D4
 	XLIBDEF(GpidXObj,			kXObj,			400),	// D4
 	XLIBDEF(HenryXObj,			kXObj,			400),	// D4
 	XLIBDEF(HitMap,				kXObj,			400),	// D4

--- a/engines/director/lingo/lingo-patcher.cpp
+++ b/engines/director/lingo/lingo-patcher.cpp
@@ -397,14 +397,6 @@ on GetCDLetter tagFile, discNumber\r\
 end \r\
 ";
 
-/* Elroy Hits the Pavement has a missing mouseUp script for clicking on the map when
- * you game over in the gangster's hideout. */
-const char *const elroypaveMapFix = " \
-on mouseUp\r\
-  handleMapClick()\r\
-end \r\
-";
-
 /* Frankenstein: Through The Eyes Of The Monster uses a projector FRANKIE.EXE, which calls an
  * identically-named submovie FRANKIE.DIR. For now we can work around this mess by referring to
  * the full "path" of the embedded submovie so path detection doesn't collide with FRANKIE.EXE.
@@ -561,10 +553,6 @@ struct ScriptHandlerPatch {
 	{"kyoto", nullptr, kPlatformWindows, "ck_data\\opening\\shared.dxr", kMovieScript, 802, DEFAULT_CAST_LIB, &kyotoTextEntryFix},
 	{"kyoto", nullptr, kPlatformWindows, "ck_data\\rajoumon\\shared.dxr", kMovieScript, 840, DEFAULT_CAST_LIB, &kyotoTextEntryFix},
 	{"kyoto", nullptr, kPlatformWindows, "ck_data\\rokudou\\shared.dxr", kMovieScript, 846, DEFAULT_CAST_LIB, &kyotoTextEntryFix},
-	{"elroypave", nullptr, kPlatformWindows, "P04\\P04HAZ\\ENDING.DXR", kScoreScript, 27, DEFAULT_CAST_LIB, &elroypaveMapFix},
-	{"elroypave", nullptr, kPlatformWindows, "P04\\P04HAZ\\ENDING.DXR", kScoreScript, 29, DEFAULT_CAST_LIB, &elroypaveMapFix},
-	{"elroypave", nullptr, kPlatformMacintosh, "P04:p04Haz:ending.Dxr", kScoreScript, 27, DEFAULT_CAST_LIB, &elroypaveMapFix},
-	{"elroypave", nullptr, kPlatformMacintosh, "P04:p04Haz:ending.Dxr", kScoreScript, 29, DEFAULT_CAST_LIB, &elroypaveMapFix},
 	{"vnc", nullptr, kPlatformWindows, "VNC\\VNC.EXE", kMovieScript, 57, DEFAULT_CAST_LIB, &vncSkipDetection},
 	{"vnc", nullptr, kPlatformWindows, "VNC2\\SHARED.DXR", kMovieScript, 1248, DEFAULT_CAST_LIB, &vncEnableCheats},
 	{"vnc", nullptr, kPlatformWindows, "VNC\\Shared.DXR", kMovieScript, 1562, DEFAULT_CAST_LIB, &vncFixIntro},

--- a/engines/director/lingo/xlibs/g/getuinfo.cpp
+++ b/engines/director/lingo/xlibs/g/getuinfo.cpp
@@ -1,0 +1,120 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/system.h"
+
+#include "director/director.h"
+#include "director/movie.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/xlibs/g/getuinfo.h"
+
+/**************************************************
+ *
+ * USED IN:
+ * Elroy Hits the Pavement
+ *
+ **************************************************/
+
+/*
+-- Penworks XObject Utilities
+--GetUInfo
+I      mNew                -- Creates a new instance of the XObject
+X      mDispose            -- Disposes of XObject instance
+I      mLButtonDown        -- Returns TRUE if LEFT mouse button is down
+I      mRButtonDown        -- Returns TRUE if RIGHT mouse button is down
+I      mKeyPressed         -- Returns the virtual keycode if a key is pressed
+ */
+
+namespace Director {
+
+const char *GetUInfoXObj::xlibName = "GetUInfo";
+const XlibFileDesc GetUInfoXObj::fileNames[] = {
+	{ "GETUINFO",   nullptr },
+	{ nullptr,        nullptr },
+};
+
+static MethodProto xlibMethods[] = {
+	{ "new",				GetUInfoXObj::m_new,		 0, 0,	400 },
+	{ "dispose",				GetUInfoXObj::m_dispose,		 0, 0,	400 },
+	{ "lButtonDown",				GetUInfoXObj::m_lButtonDown,		 0, 0,	400 },
+	{ "rButtonDown",				GetUInfoXObj::m_rButtonDown,		 0, 0,	400 },
+	{ "keyPressed",				GetUInfoXObj::m_keyPressed,		 0, 0,	400 },
+
+	{ nullptr, nullptr, 0, 0, 0 }
+};
+
+static BuiltinProto xlibBuiltins[] = {
+
+	{ nullptr, nullptr, 0, 0, 0, VOIDSYM }
+};
+
+GetUInfoXObject::GetUInfoXObject(ObjectType ObjectType) :Object<GetUInfoXObject>("GetUInfo") {
+	_objType = ObjectType;
+}
+
+void GetUInfoXObj::open(ObjectType type, const Common::Path &path) {
+    GetUInfoXObject::initMethods(xlibMethods);
+    GetUInfoXObject *xobj = new GetUInfoXObject(type);
+    if (type == kXtraObj) {
+        g_lingo->_openXtras.push_back(xlibName);
+		g_lingo->_openXtraObjects.push_back(xobj);
+	}
+    g_lingo->exposeXObject(xlibName, xobj);
+    g_lingo->initBuiltIns(xlibBuiltins);
+}
+
+void GetUInfoXObj::close(ObjectType type) {
+    GetUInfoXObject::cleanupMethods();
+    g_lingo->_globalvars[xlibName] = Datum();
+
+}
+
+void GetUInfoXObj::m_new(int nargs) {
+	g_lingo->printSTUBWithArglist("GetUInfoXObj::m_new", nargs);
+	g_lingo->dropStack(nargs);
+	g_lingo->push(g_lingo->_state->me);
+}
+
+void GetUInfoXObj::m_dispose(int nargs) {
+	g_lingo->_state->me.u.obj->dispose();
+	g_lingo->push(g_lingo->_state->me);
+}
+
+void GetUInfoXObj::m_lButtonDown(int nargs) {
+	g_lingo->dropStack(nargs);
+	int state = g_system->getEventManager()->getButtonState() & (1 << Common::MOUSE_BUTTON_LEFT) ? 1 : 0;
+	g_lingo->push(Datum(state));
+}
+
+void GetUInfoXObj::m_rButtonDown(int nargs) {
+	g_lingo->dropStack(nargs);
+	int state = g_system->getEventManager()->getButtonState() & (1 << Common::MOUSE_BUTTON_RIGHT) ? 1 : 0;
+	g_lingo->push(Datum(state));
+}
+
+void GetUInfoXObj::m_keyPressed(int nargs) {
+	g_lingo->dropStack(nargs);
+	Movie *movie = g_director->getCurrentMovie();
+	g_lingo->push(Datum(movie ? movie->_keyCode : 0));
+}
+
+}

--- a/engines/director/lingo/xlibs/g/getuinfo.h
+++ b/engines/director/lingo/xlibs/g/getuinfo.h
@@ -1,0 +1,50 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XLIBS_G_GETUINFO_H
+#define DIRECTOR_LINGO_XLIBS_G_GETUINFO_H
+
+namespace Director {
+
+class GetUInfoXObject : public Object<GetUInfoXObject> {
+public:
+	GetUInfoXObject(ObjectType objType);
+};
+
+namespace GetUInfoXObj {
+
+extern const char *xlibName;
+extern const XlibFileDesc fileNames[];
+
+void open(ObjectType type, const Common::Path &path);
+void close(ObjectType type);
+
+void m_new(int nargs);
+void m_dispose(int nargs);
+void m_lButtonDown(int nargs);
+void m_rButtonDown(int nargs);
+void m_keyPressed(int nargs);
+
+} // End of namespace GetUInfoXObj
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/lingo/xlibs/m/myfolder.cpp
+++ b/engines/director/lingo/xlibs/m/myfolder.cpp
@@ -1,0 +1,107 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/system.h"
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/lingo-utils.h"
+#include "director/lingo/xlibs/m/myfolder.h"
+
+/**************************************************
+ *
+ * USED IN:
+ * dimensionq
+ *
+ **************************************************/
+
+/*
+-- MyFolder XObject. Windows version. (c) 1995 Mark Carolan
+--MyFolder
+I      mNew                --Creates a new instance of the XObject
+X      mDispose            --Disposes of XObject instance
+SS     mDo, folderName     --Returns pathname as a string
+-- If folderName is empty string, returns path to preferences directory.
+-- If folderName is supplied, folder folderName is created in preferences.
+-- If folder folderName already exists in preferences, full pathname is returned.
+-- Check for errors by looking for non-string return value or string starting with: <Error
+-- Shareware. $US15 per title gets you Mac & Win version plus a good night's sleep.
+-- Free use for demos. Contact Mark_Carolan@aapda.com.au Compuserve 100242,1154
+ */
+
+namespace Director {
+
+const char *MyFolderXObj::xlibName = "MyFolder";
+const XlibFileDesc MyFolderXObj::fileNames[] = {
+	{ "MYFOLDER",   nullptr },
+	{ nullptr,        nullptr },
+};
+
+static MethodProto xlibMethods[] = {
+	{ "new",				MyFolderXObj::m_new,		 0, 0,	400 },
+	{ "dispose",				MyFolderXObj::m_dispose,		 0, 0,	400 },
+	{ "do",				MyFolderXObj::m_do,		 1, 1,	400 },
+
+	{ nullptr, nullptr, 0, 0, 0 }
+};
+
+static BuiltinProto xlibBuiltins[] = {
+	{ "MyFolder", MyFolderXObj::m_myFolder, 1, 1, 400, HBLTIN },
+	{ nullptr, nullptr, 0, 0, 0, VOIDSYM }
+};
+
+MyFolderXObject::MyFolderXObject(ObjectType ObjectType) :Object<MyFolderXObject>("MyFolder") {
+	_objType = ObjectType;
+}
+
+void MyFolderXObj::open(ObjectType type, const Common::Path &path) {
+    MyFolderXObject::initMethods(xlibMethods);
+    MyFolderXObject *xobj = new MyFolderXObject(type);
+    if (type == kXtraObj) {
+        g_lingo->_openXtras.push_back(xlibName);
+		g_lingo->_openXtraObjects.push_back(xobj);
+	}
+    g_lingo->exposeXObject(xlibName, xobj);
+    g_lingo->initBuiltIns(xlibBuiltins);
+}
+
+void MyFolderXObj::close(ObjectType type) {
+    MyFolderXObject::cleanupMethods();
+    g_lingo->_globalvars[xlibName] = Datum();
+
+}
+
+void MyFolderXObj::m_new(int nargs) {
+	g_lingo->printSTUBWithArglist("MyFolderXObj::m_new", nargs);
+	g_lingo->dropStack(nargs);
+	g_lingo->push(g_lingo->_state->me);
+}
+
+void MyFolderXObj::m_myFolder(int nargs) {
+	g_lingo->dropStack(nargs);
+	g_lingo->push(Datum(""));
+}
+
+XOBJSTUBNR(MyFolderXObj::m_dispose)
+XOBJSTUB(MyFolderXObj::m_do, "")
+
+}

--- a/engines/director/lingo/xlibs/m/myfolder.cpp
+++ b/engines/director/lingo/xlibs/m/myfolder.cpp
@@ -101,7 +101,10 @@ void MyFolderXObj::m_myFolder(int nargs) {
 	g_lingo->push(Datum(""));
 }
 
-XOBJSTUBNR(MyFolderXObj::m_dispose)
+void MyFolderXObj::m_dispose(int nargs) {
+	g_lingo->_state->me.u.obj->dispose();
+	g_lingo->push(g_lingo->_state->me);
+}
 XOBJSTUB(MyFolderXObj::m_do, "")
 
 }

--- a/engines/director/lingo/xlibs/m/myfolder.h
+++ b/engines/director/lingo/xlibs/m/myfolder.h
@@ -1,0 +1,49 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XLIBS_M_MYFOLDER_H
+#define DIRECTOR_LINGO_XLIBS_M_MYFOLDER_H
+
+namespace Director {
+
+class MyFolderXObject : public Object<MyFolderXObject> {
+public:
+	MyFolderXObject(ObjectType objType);
+};
+
+namespace MyFolderXObj {
+
+extern const char *xlibName;
+extern const XlibFileDesc fileNames[];
+
+void open(ObjectType type, const Common::Path &path);
+void close(ObjectType type);
+
+void m_new(int nargs);
+void m_dispose(int nargs);
+void m_do(int nargs);
+void m_myFolder(int nargs);
+
+} // End of namespace MyFolderXObj
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -135,6 +135,7 @@ MODULE_OBJS = \
 	lingo/xlibs/m/mystisle.o \
 	lingo/xlibs/b/blockthedrawingxobj.o \
 	lingo/xlibs/m/mazexobj.o \
+	lingo/xlibs/m/myfolder.o \
 	lingo/xlibs/o/openbleedwindowxcmd.o \
  	lingo/xlibs/p/playsoundmoviexobj.o \
  	lingo/xlibs/s/savenrestorexobj.o \

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -136,6 +136,7 @@ MODULE_OBJS = \
 	lingo/xlibs/b/blockthedrawingxobj.o \
 	lingo/xlibs/m/mazexobj.o \
 	lingo/xlibs/m/myfolder.o \
+	lingo/xlibs/g/getuinfo.o \
 	lingo/xlibs/o/openbleedwindowxcmd.o \
  	lingo/xlibs/p/playsoundmoviexobj.o \
  	lingo/xlibs/s/savenrestorexobj.o \


### PR DESCRIPTION
To make Elroy Hits the Pavement fully playable, this PR includes:

- **Add MyFolder xlib** — stub implementation sufficient for the game
- **Add GetUInfo xlib** — implements mLButtonDown, mRButtonDown, mKeyPressed, and mDispose using ScummVM's event manager and movie keyCode state
- **Fix map navigation from game-over screen** — patches ScoreScripts 27 and 29 in ENDING.DXR (the gangster's hideout game-over) to call handleMapClick(), which the original DXR left empty
- **Fix set scriptText updating wrong script type slot** — root cause fix: `set the scriptText of cast X` was calling replaceCode with kCastScript, but sprite event dispatch looks up kScoreScript. For behavior cast members, this meant dynamic script injection (used by setMap() in every chapter's SHARED.DXR to wire up the map panel's mouseUp handler at runtime) was writing to the wrong slot and had no effect. Fixed by using the cast member's actual _scriptType when replacing.